### PR TITLE
Slow instance commands

### DIFF
--- a/packages/twenty-server/src/database/commands/__tests__/__snapshots__/instance-command-generation.service.spec.ts.snap
+++ b/packages/twenty-server/src/database/commands/__tests__/__snapshots__/instance-command-generation.service.spec.ts.snap
@@ -4,12 +4,13 @@ exports[`InstanceCommandGenerationService should encode version correctly in fil
 {
   "className": "TestCommand",
   "fileName": "1-20-instance-command-fast-1775000000000-test.ts",
-  "fileTemplate": "import { MigrationInterface, QueryRunner } from 'typeorm';
+  "fileTemplate": "import { QueryRunner } from 'typeorm';
 
 import { RegisteredInstanceCommand } from 'src/engine/core-modules/upgrade/decorators/registered-instance-command.decorator';
+import { FastInstanceCommand } from 'src/engine/core-modules/upgrade/interfaces/fast-instance-command.interface';
 
 @RegisteredInstanceCommand('1.20.0', 1775000000000)
-export class TestCommand implements MigrationInterface {
+export class TestCommand implements FastInstanceCommand {
   public async up(queryRunner: QueryRunner): Promise<void> {
     await queryRunner.query('SELECT 1');
   }
@@ -26,12 +27,13 @@ exports[`InstanceCommandGenerationService should escape backslashes in SQL queri
 {
   "className": "UpdatePathCommand",
   "fileName": "1-21-instance-command-fast-1775000000000-update-path.ts",
-  "fileTemplate": "import { MigrationInterface, QueryRunner } from 'typeorm';
+  "fileTemplate": "import { QueryRunner } from 'typeorm';
 
 import { RegisteredInstanceCommand } from 'src/engine/core-modules/upgrade/decorators/registered-instance-command.decorator';
+import { FastInstanceCommand } from 'src/engine/core-modules/upgrade/interfaces/fast-instance-command.interface';
 
 @RegisteredInstanceCommand('1.21.0', 1775000000000)
-export class UpdatePathCommand implements MigrationInterface {
+export class UpdatePathCommand implements FastInstanceCommand {
   public async up(queryRunner: QueryRunner): Promise<void> {
     await queryRunner.query('UPDATE "core"."config" SET "value" = E\\'path\\\\\\\\to\\\\\\\\file\\'');
   }
@@ -48,12 +50,13 @@ exports[`InstanceCommandGenerationService should escape single quotes in SQL que
 {
   "className": "UpdateConfigCommand",
   "fileName": "1-21-instance-command-fast-1775000000000-update-config.ts",
-  "fileTemplate": "import { MigrationInterface, QueryRunner } from 'typeorm';
+  "fileTemplate": "import { QueryRunner } from 'typeorm';
 
 import { RegisteredInstanceCommand } from 'src/engine/core-modules/upgrade/decorators/registered-instance-command.decorator';
+import { FastInstanceCommand } from 'src/engine/core-modules/upgrade/interfaces/fast-instance-command.interface';
 
 @RegisteredInstanceCommand('1.21.0', 1775000000000)
-export class UpdateConfigCommand implements MigrationInterface {
+export class UpdateConfigCommand implements FastInstanceCommand {
   public async up(queryRunner: QueryRunner): Promise<void> {
     await queryRunner.query('UPDATE "core"."config" SET "value" = \\'it\\'\\'s done\\'');
   }
@@ -70,12 +73,13 @@ exports[`InstanceCommandGenerationService should generate a migration with a sin
 {
   "className": "AddFooColumnCommand",
   "fileName": "1-21-instance-command-fast-1775000000000-add-foo-column.ts",
-  "fileTemplate": "import { MigrationInterface, QueryRunner } from 'typeorm';
+  "fileTemplate": "import { QueryRunner } from 'typeorm';
 
 import { RegisteredInstanceCommand } from 'src/engine/core-modules/upgrade/decorators/registered-instance-command.decorator';
+import { FastInstanceCommand } from 'src/engine/core-modules/upgrade/interfaces/fast-instance-command.interface';
 
 @RegisteredInstanceCommand('1.21.0', 1775000000000)
-export class AddFooColumnCommand implements MigrationInterface {
+export class AddFooColumnCommand implements FastInstanceCommand {
   public async up(queryRunner: QueryRunner): Promise<void> {
     await queryRunner.query('ALTER TABLE "core"."user" ADD "foo" varchar');
   }
@@ -92,12 +96,13 @@ exports[`InstanceCommandGenerationService should generate a migration with multi
 {
   "className": "CreateTaskTableCommand",
   "fileName": "1-21-instance-command-fast-1775000000000-create-task-table.ts",
-  "fileTemplate": "import { MigrationInterface, QueryRunner } from 'typeorm';
+  "fileTemplate": "import { QueryRunner } from 'typeorm';
 
 import { RegisteredInstanceCommand } from 'src/engine/core-modules/upgrade/decorators/registered-instance-command.decorator';
+import { FastInstanceCommand } from 'src/engine/core-modules/upgrade/interfaces/fast-instance-command.interface';
 
 @RegisteredInstanceCommand('1.21.0', 1775000000000)
-export class CreateTaskTableCommand implements MigrationInterface {
+export class CreateTaskTableCommand implements FastInstanceCommand {
   public async up(queryRunner: QueryRunner): Promise<void> {
     await queryRunner.query('CREATE TABLE "core"."task" ("id" uuid NOT NULL DEFAULT uuid_generate_v4(), "name" varchar NOT NULL)');
     await queryRunner.query('ALTER TABLE "core"."task" ADD CONSTRAINT "PK_task" PRIMARY KEY ("id")');
@@ -116,12 +121,13 @@ exports[`InstanceCommandGenerationService should generate a migration with query
 {
   "className": "SeedSettingCommand",
   "fileName": "1-21-instance-command-fast-1775000000000-seed-setting.ts",
-  "fileTemplate": "import { MigrationInterface, QueryRunner } from 'typeorm';
+  "fileTemplate": "import { QueryRunner } from 'typeorm';
 
 import { RegisteredInstanceCommand } from 'src/engine/core-modules/upgrade/decorators/registered-instance-command.decorator';
+import { FastInstanceCommand } from 'src/engine/core-modules/upgrade/interfaces/fast-instance-command.interface';
 
 @RegisteredInstanceCommand('1.21.0', 1775000000000)
-export class SeedSettingCommand implements MigrationInterface {
+export class SeedSettingCommand implements FastInstanceCommand {
   public async up(queryRunner: QueryRunner): Promise<void> {
     await queryRunner.query('INSERT INTO "core"."setting" ("key", "value") VALUES ($1, $2)', ["theme","dark"]);
   }
@@ -134,16 +140,51 @@ export class SeedSettingCommand implements MigrationInterface {
 }
 `;
 
+exports[`InstanceCommandGenerationService should generate a slow instance command template 1`] = `
+{
+  "className": "MakeColumnNotNullableCommand",
+  "fileName": "1-21-instance-command-slow-1775000000000-make-column-not-nullable.ts",
+  "fileTemplate": "import { InjectDataSource } from '@nestjs/typeorm';
+
+import { DataSource, QueryRunner } from 'typeorm';
+
+import { RegisteredInstanceCommand } from 'src/engine/core-modules/upgrade/decorators/registered-instance-command.decorator';
+import { SlowInstanceCommand } from 'src/engine/core-modules/upgrade/interfaces/slow-instance-command.interface';
+
+@RegisteredInstanceCommand('1.21.0', 1775000000000, { type: 'slow' })
+export class MakeColumnNotNullableCommand implements SlowInstanceCommand {
+  constructor(
+    @InjectDataSource()
+    private readonly dataSource: DataSource,
+  ) {}
+
+  async runDataMigration(): Promise<void> {
+    // TODO: implement data backfill before the DDL migration
+  }
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    // TODO: implement DDL migration (runs after data migration)
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    // TODO: implement rollback
+  }
+}
+",
+}
+`;
+
 exports[`InstanceCommandGenerationService should use default migration name in class and file names 1`] = `
 {
   "className": "AutoGeneratedCommand",
   "fileName": "1-21-instance-command-fast-1775000000000-auto-generated.ts",
-  "fileTemplate": "import { MigrationInterface, QueryRunner } from 'typeorm';
+  "fileTemplate": "import { QueryRunner } from 'typeorm';
 
 import { RegisteredInstanceCommand } from 'src/engine/core-modules/upgrade/decorators/registered-instance-command.decorator';
+import { FastInstanceCommand } from 'src/engine/core-modules/upgrade/interfaces/fast-instance-command.interface';
 
 @RegisteredInstanceCommand('1.21.0', 1775000000000)
-export class AutoGeneratedCommand implements MigrationInterface {
+export class AutoGeneratedCommand implements FastInstanceCommand {
   public async up(queryRunner: QueryRunner): Promise<void> {
     await queryRunner.query('ALTER TABLE "core"."user" ADD "bar" integer');
   }

--- a/packages/twenty-server/src/database/commands/__tests__/__snapshots__/instance-command-generation.service.spec.ts.snap
+++ b/packages/twenty-server/src/database/commands/__tests__/__snapshots__/instance-command-generation.service.spec.ts.snap
@@ -2,7 +2,7 @@
 
 exports[`InstanceCommandGenerationService should encode version correctly in file and class names 1`] = `
 {
-  "className": "TestCommand",
+  "className": "TestFastInstanceCommand",
   "fileName": "1-20-instance-command-fast-1775000000000-test.ts",
   "fileTemplate": "import { QueryRunner } from 'typeorm';
 
@@ -10,7 +10,7 @@ import { RegisteredInstanceCommand } from 'src/engine/core-modules/upgrade/decor
 import { FastInstanceCommand } from 'src/engine/core-modules/upgrade/interfaces/fast-instance-command.interface';
 
 @RegisteredInstanceCommand('1.20.0', 1775000000000)
-export class TestCommand implements FastInstanceCommand {
+export class TestFastInstanceCommand implements FastInstanceCommand {
   public async up(queryRunner: QueryRunner): Promise<void> {
     await queryRunner.query('SELECT 1');
   }
@@ -25,7 +25,7 @@ export class TestCommand implements FastInstanceCommand {
 
 exports[`InstanceCommandGenerationService should escape backslashes in SQL queries 1`] = `
 {
-  "className": "UpdatePathCommand",
+  "className": "UpdatePathFastInstanceCommand",
   "fileName": "1-21-instance-command-fast-1775000000000-update-path.ts",
   "fileTemplate": "import { QueryRunner } from 'typeorm';
 
@@ -33,7 +33,7 @@ import { RegisteredInstanceCommand } from 'src/engine/core-modules/upgrade/decor
 import { FastInstanceCommand } from 'src/engine/core-modules/upgrade/interfaces/fast-instance-command.interface';
 
 @RegisteredInstanceCommand('1.21.0', 1775000000000)
-export class UpdatePathCommand implements FastInstanceCommand {
+export class UpdatePathFastInstanceCommand implements FastInstanceCommand {
   public async up(queryRunner: QueryRunner): Promise<void> {
     await queryRunner.query('UPDATE "core"."config" SET "value" = E\\'path\\\\\\\\to\\\\\\\\file\\'');
   }
@@ -48,7 +48,7 @@ export class UpdatePathCommand implements FastInstanceCommand {
 
 exports[`InstanceCommandGenerationService should escape single quotes in SQL queries 1`] = `
 {
-  "className": "UpdateConfigCommand",
+  "className": "UpdateConfigFastInstanceCommand",
   "fileName": "1-21-instance-command-fast-1775000000000-update-config.ts",
   "fileTemplate": "import { QueryRunner } from 'typeorm';
 
@@ -56,7 +56,7 @@ import { RegisteredInstanceCommand } from 'src/engine/core-modules/upgrade/decor
 import { FastInstanceCommand } from 'src/engine/core-modules/upgrade/interfaces/fast-instance-command.interface';
 
 @RegisteredInstanceCommand('1.21.0', 1775000000000)
-export class UpdateConfigCommand implements FastInstanceCommand {
+export class UpdateConfigFastInstanceCommand implements FastInstanceCommand {
   public async up(queryRunner: QueryRunner): Promise<void> {
     await queryRunner.query('UPDATE "core"."config" SET "value" = \\'it\\'\\'s done\\'');
   }
@@ -71,7 +71,7 @@ export class UpdateConfigCommand implements FastInstanceCommand {
 
 exports[`InstanceCommandGenerationService should generate a migration with a single up/down query 1`] = `
 {
-  "className": "AddFooColumnCommand",
+  "className": "AddFooColumnFastInstanceCommand",
   "fileName": "1-21-instance-command-fast-1775000000000-add-foo-column.ts",
   "fileTemplate": "import { QueryRunner } from 'typeorm';
 
@@ -79,7 +79,7 @@ import { RegisteredInstanceCommand } from 'src/engine/core-modules/upgrade/decor
 import { FastInstanceCommand } from 'src/engine/core-modules/upgrade/interfaces/fast-instance-command.interface';
 
 @RegisteredInstanceCommand('1.21.0', 1775000000000)
-export class AddFooColumnCommand implements FastInstanceCommand {
+export class AddFooColumnFastInstanceCommand implements FastInstanceCommand {
   public async up(queryRunner: QueryRunner): Promise<void> {
     await queryRunner.query('ALTER TABLE "core"."user" ADD "foo" varchar');
   }
@@ -94,7 +94,7 @@ export class AddFooColumnCommand implements FastInstanceCommand {
 
 exports[`InstanceCommandGenerationService should generate a migration with multiple queries 1`] = `
 {
-  "className": "CreateTaskTableCommand",
+  "className": "CreateTaskTableFastInstanceCommand",
   "fileName": "1-21-instance-command-fast-1775000000000-create-task-table.ts",
   "fileTemplate": "import { QueryRunner } from 'typeorm';
 
@@ -102,7 +102,7 @@ import { RegisteredInstanceCommand } from 'src/engine/core-modules/upgrade/decor
 import { FastInstanceCommand } from 'src/engine/core-modules/upgrade/interfaces/fast-instance-command.interface';
 
 @RegisteredInstanceCommand('1.21.0', 1775000000000)
-export class CreateTaskTableCommand implements FastInstanceCommand {
+export class CreateTaskTableFastInstanceCommand implements FastInstanceCommand {
   public async up(queryRunner: QueryRunner): Promise<void> {
     await queryRunner.query('CREATE TABLE "core"."task" ("id" uuid NOT NULL DEFAULT uuid_generate_v4(), "name" varchar NOT NULL)');
     await queryRunner.query('ALTER TABLE "core"."task" ADD CONSTRAINT "PK_task" PRIMARY KEY ("id")');
@@ -119,7 +119,7 @@ export class CreateTaskTableCommand implements FastInstanceCommand {
 
 exports[`InstanceCommandGenerationService should generate a migration with query parameters 1`] = `
 {
-  "className": "SeedSettingCommand",
+  "className": "SeedSettingFastInstanceCommand",
   "fileName": "1-21-instance-command-fast-1775000000000-seed-setting.ts",
   "fileTemplate": "import { QueryRunner } from 'typeorm';
 
@@ -127,7 +127,7 @@ import { RegisteredInstanceCommand } from 'src/engine/core-modules/upgrade/decor
 import { FastInstanceCommand } from 'src/engine/core-modules/upgrade/interfaces/fast-instance-command.interface';
 
 @RegisteredInstanceCommand('1.21.0', 1775000000000)
-export class SeedSettingCommand implements FastInstanceCommand {
+export class SeedSettingFastInstanceCommand implements FastInstanceCommand {
   public async up(queryRunner: QueryRunner): Promise<void> {
     await queryRunner.query('INSERT INTO "core"."setting" ("key", "value") VALUES ($1, $2)', ["theme","dark"]);
   }
@@ -140,9 +140,9 @@ export class SeedSettingCommand implements FastInstanceCommand {
 }
 `;
 
-exports[`InstanceCommandGenerationService should generate a slow instance command template 1`] = `
+exports[`InstanceCommandGenerationService should generate a slow instance command with populated up/down 1`] = `
 {
-  "className": "MakeColumnNotNullableCommand",
+  "className": "MakeColumnNotNullableSlowInstanceCommand",
   "fileName": "1-21-instance-command-slow-1775000000000-make-column-not-nullable.ts",
   "fileTemplate": "import { InjectDataSource } from '@nestjs/typeorm';
 
@@ -152,7 +152,7 @@ import { RegisteredInstanceCommand } from 'src/engine/core-modules/upgrade/decor
 import { SlowInstanceCommand } from 'src/engine/core-modules/upgrade/interfaces/slow-instance-command.interface';
 
 @RegisteredInstanceCommand('1.21.0', 1775000000000, { type: 'slow' })
-export class MakeColumnNotNullableCommand implements SlowInstanceCommand {
+export class MakeColumnNotNullableSlowInstanceCommand implements SlowInstanceCommand {
   constructor(
     @InjectDataSource()
     private readonly dataSource: DataSource,
@@ -163,11 +163,11 @@ export class MakeColumnNotNullableCommand implements SlowInstanceCommand {
   }
 
   public async up(queryRunner: QueryRunner): Promise<void> {
-    // TODO: implement DDL migration (runs after data migration)
+    await queryRunner.query('ALTER TABLE "core"."user" ALTER COLUMN "email" SET NOT NULL');
   }
 
   public async down(queryRunner: QueryRunner): Promise<void> {
-    // TODO: implement rollback
+    await queryRunner.query('ALTER TABLE "core"."user" ALTER COLUMN "email" DROP NOT NULL');
   }
 }
 ",
@@ -176,7 +176,7 @@ export class MakeColumnNotNullableCommand implements SlowInstanceCommand {
 
 exports[`InstanceCommandGenerationService should use default migration name in class and file names 1`] = `
 {
-  "className": "AutoGeneratedCommand",
+  "className": "AutoGeneratedFastInstanceCommand",
   "fileName": "1-21-instance-command-fast-1775000000000-auto-generated.ts",
   "fileTemplate": "import { QueryRunner } from 'typeorm';
 
@@ -184,7 +184,7 @@ import { RegisteredInstanceCommand } from 'src/engine/core-modules/upgrade/decor
 import { FastInstanceCommand } from 'src/engine/core-modules/upgrade/interfaces/fast-instance-command.interface';
 
 @RegisteredInstanceCommand('1.21.0', 1775000000000)
-export class AutoGeneratedCommand implements FastInstanceCommand {
+export class AutoGeneratedFastInstanceCommand implements FastInstanceCommand {
   public async up(queryRunner: QueryRunner): Promise<void> {
     await queryRunner.query('ALTER TABLE "core"."user" ADD "bar" integer');
   }

--- a/packages/twenty-server/src/database/commands/__tests__/__snapshots__/instance-command-generation.service.spec.ts.snap
+++ b/packages/twenty-server/src/database/commands/__tests__/__snapshots__/instance-command-generation.service.spec.ts.snap
@@ -144,21 +144,14 @@ exports[`InstanceCommandGenerationService should generate a slow instance comman
 {
   "className": "MakeColumnNotNullableSlowInstanceCommand",
   "fileName": "1-21-instance-command-slow-1775000000000-make-column-not-nullable.ts",
-  "fileTemplate": "import { InjectDataSource } from '@nestjs/typeorm';
-
-import { DataSource, QueryRunner } from 'typeorm';
+  "fileTemplate": "import { DataSource, QueryRunner } from 'typeorm';
 
 import { RegisteredInstanceCommand } from 'src/engine/core-modules/upgrade/decorators/registered-instance-command.decorator';
 import { SlowInstanceCommand } from 'src/engine/core-modules/upgrade/interfaces/slow-instance-command.interface';
 
 @RegisteredInstanceCommand('1.21.0', 1775000000000, { type: 'slow' })
 export class MakeColumnNotNullableSlowInstanceCommand implements SlowInstanceCommand {
-  constructor(
-    @InjectDataSource()
-    private readonly dataSource: DataSource,
-  ) {}
-
-  async runDataMigration(): Promise<void> {
+  async runDataMigration(dataSource: DataSource): Promise<void> {
     // TODO: implement data backfill before the DDL migration
   }
 

--- a/packages/twenty-server/src/database/commands/__tests__/instance-command-generation.service.spec.ts
+++ b/packages/twenty-server/src/database/commands/__tests__/instance-command-generation.service.spec.ts
@@ -177,4 +177,31 @@ describe('InstanceCommandGenerationService', () => {
 
     expect(result).toMatchSnapshot();
   });
+
+  it('should generate a slow instance command template', async () => {
+    const service = await buildService();
+
+    const result = service.generateSlow({
+      migrationName: 'make-column-not-nullable',
+      version: '1.21.0',
+      timestamp: FIXED_TIMESTAMP,
+    });
+
+    expect(result).toMatchSnapshot();
+  });
+
+  it('should use correct file naming for slow instance commands', async () => {
+    const service = await buildService();
+
+    const result = service.generateSlow({
+      migrationName: 'backfill-data',
+      version: '1.20.0',
+      timestamp: FIXED_TIMESTAMP,
+    });
+
+    expect(result.fileName).toBe(
+      '1-20-instance-command-slow-1775000000000-backfill-data.ts',
+    );
+    expect(result.className).toBe('BackfillDataCommand');
+  });
 });

--- a/packages/twenty-server/src/database/commands/__tests__/instance-command-generation.service.spec.ts
+++ b/packages/twenty-server/src/database/commands/__tests__/instance-command-generation.service.spec.ts
@@ -37,7 +37,7 @@ describe('InstanceCommandGenerationService', () => {
   it('should return null when no schema changes are detected', async () => {
     const service = await buildService();
 
-    const result = await service.generate({
+    const result = await service.generateInstanceCommand({
       migrationName: 'no-changes',
       version: '1.21.0',
       timestamp: FIXED_TIMESTAMP,
@@ -52,7 +52,7 @@ describe('InstanceCommandGenerationService', () => {
       [{ query: 'ALTER TABLE "core"."user" DROP COLUMN "foo"' }],
     );
 
-    const result = await service.generate({
+    const result = await service.generateInstanceCommand({
       migrationName: 'add-foo-column',
       version: '1.21.0',
       timestamp: FIXED_TIMESTAMP,
@@ -79,7 +79,7 @@ describe('InstanceCommandGenerationService', () => {
       ],
     );
 
-    const result = await service.generate({
+    const result = await service.generateInstanceCommand({
       migrationName: 'create-task-table',
       version: '1.21.0',
       timestamp: FIXED_TIMESTAMP,
@@ -105,7 +105,7 @@ describe('InstanceCommandGenerationService', () => {
       ],
     );
 
-    const result = await service.generate({
+    const result = await service.generateInstanceCommand({
       migrationName: 'seed-setting',
       version: '1.21.0',
       timestamp: FIXED_TIMESTAMP,
@@ -120,7 +120,7 @@ describe('InstanceCommandGenerationService', () => {
       [{ query: 'UPDATE "core"."config" SET "value" = \'original\'' }],
     );
 
-    const result = await service.generate({
+    const result = await service.generateInstanceCommand({
       migrationName: 'update-config',
       version: '1.21.0',
       timestamp: FIXED_TIMESTAMP,
@@ -139,7 +139,7 @@ describe('InstanceCommandGenerationService', () => {
       [{ query: 'UPDATE "core"."config" SET "value" = NULL' }],
     );
 
-    const result = await service.generate({
+    const result = await service.generateInstanceCommand({
       migrationName: 'update-path',
       version: '1.21.0',
       timestamp: FIXED_TIMESTAMP,
@@ -154,7 +154,7 @@ describe('InstanceCommandGenerationService', () => {
       [{ query: 'ALTER TABLE "core"."user" DROP COLUMN "bar"' }],
     );
 
-    const result = await service.generate({
+    const result = await service.generateInstanceCommand({
       migrationName: 'auto-generated',
       version: '1.21.0',
       timestamp: FIXED_TIMESTAMP,
@@ -169,7 +169,7 @@ describe('InstanceCommandGenerationService', () => {
       [{ query: 'SELECT 1' }],
     );
 
-    const result = await service.generate({
+    const result = await service.generateInstanceCommand({
       migrationName: 'test',
       version: '1.20.0',
       timestamp: FIXED_TIMESTAMP,
@@ -178,30 +178,51 @@ describe('InstanceCommandGenerationService', () => {
     expect(result).toMatchSnapshot();
   });
 
-  it('should generate a slow instance command template', async () => {
+  it('should return null for slow type when no schema changes are detected', async () => {
     const service = await buildService();
 
-    const result = service.generateSlow({
+    const result = await service.generateInstanceCommand({
+      migrationName: 'no-changes',
+      version: '1.21.0',
+      timestamp: FIXED_TIMESTAMP,
+      type: 'slow',
+    });
+
+    expect(result).toBeNull();
+  });
+
+  it('should generate a slow instance command with populated up/down', async () => {
+    const service = await buildService(
+      [{ query: 'ALTER TABLE "core"."user" ALTER COLUMN "email" SET NOT NULL' }],
+      [{ query: 'ALTER TABLE "core"."user" ALTER COLUMN "email" DROP NOT NULL' }],
+    );
+
+    const result = await service.generateInstanceCommand({
       migrationName: 'make-column-not-nullable',
       version: '1.21.0',
       timestamp: FIXED_TIMESTAMP,
+      type: 'slow',
     });
 
     expect(result).toMatchSnapshot();
   });
 
   it('should use correct file naming for slow instance commands', async () => {
-    const service = await buildService();
+    const service = await buildService(
+      [{ query: 'SELECT 1' }],
+      [{ query: 'SELECT 1' }],
+    );
 
-    const result = service.generateSlow({
+    const result = await service.generateInstanceCommand({
       migrationName: 'backfill-data',
       version: '1.20.0',
       timestamp: FIXED_TIMESTAMP,
+      type: 'slow',
     });
 
-    expect(result.fileName).toBe(
+    expect(result?.fileName).toBe(
       '1-20-instance-command-slow-1775000000000-backfill-data.ts',
     );
-    expect(result.className).toBe('BackfillDataCommand');
+    expect(result?.className).toBe('BackfillDataSlowInstanceCommand');
   });
 });

--- a/packages/twenty-server/src/database/commands/__tests__/instance-command-generation.service.spec.ts
+++ b/packages/twenty-server/src/database/commands/__tests__/instance-command-generation.service.spec.ts
@@ -193,8 +193,16 @@ describe('InstanceCommandGenerationService', () => {
 
   it('should generate a slow instance command with populated up/down', async () => {
     const service = await buildService(
-      [{ query: 'ALTER TABLE "core"."user" ALTER COLUMN "email" SET NOT NULL' }],
-      [{ query: 'ALTER TABLE "core"."user" ALTER COLUMN "email" DROP NOT NULL' }],
+      [
+        {
+          query: 'ALTER TABLE "core"."user" ALTER COLUMN "email" SET NOT NULL',
+        },
+      ],
+      [
+        {
+          query: 'ALTER TABLE "core"."user" ALTER COLUMN "email" DROP NOT NULL',
+        },
+      ],
     );
 
     const result = await service.generateInstanceCommand({

--- a/packages/twenty-server/src/database/commands/generate-instance-command.command.ts
+++ b/packages/twenty-server/src/database/commands/generate-instance-command.command.ts
@@ -7,6 +7,7 @@ import { Command, CommandRunner, Option } from 'nest-commander';
 
 import { InstanceCommandGenerationService } from 'src/database/commands/instance-command-generation.service';
 import { UPGRADE_COMMAND_SUPPORTED_VERSIONS } from 'src/engine/constants/upgrade-command-supported-versions.constant';
+import { type InstanceCommandType } from 'src/engine/core-modules/upgrade/decorators/registered-instance-command.decorator';
 
 const UPGRADE_VERSION_COMMAND_DIR = path.resolve(
   process.cwd(),
@@ -15,6 +16,7 @@ const UPGRADE_VERSION_COMMAND_DIR = path.resolve(
 
 type GenerateInstanceCommandOptions = {
   name: string;
+  type: InstanceCommandType;
 };
 
 @Command({
@@ -40,6 +42,19 @@ export class GenerateInstanceCommandCommand extends CommandRunner {
     return value;
   }
 
+  @Option({
+    flags: '-t, --type <type>',
+    description: 'Command type: fast (schema diff) or slow (data migration + DDL)',
+    defaultValue: 'fast',
+  })
+  parseType(value: string): InstanceCommandType {
+    if (value !== 'fast' && value !== 'slow') {
+      throw new Error(`Invalid type "${value}". Must be "fast" or "slow".`);
+    }
+
+    return value;
+  }
+
   async run(
     _passedParams: string[],
     options: GenerateInstanceCommandOptions,
@@ -52,10 +67,37 @@ export class GenerateInstanceCommandCommand extends CommandRunner {
       throw new Error('No supported versions found');
     }
 
-    this.logger.log(`Generating versioned migration for version ${version}...`);
+    const commandType = options.type;
+
+    this.logger.log(
+      `Generating ${commandType} instance command for version ${version}...`,
+    );
 
     const versionDir = this.getVersionDir(version);
     const timestamp = Date.now();
+
+    if (commandType === 'slow') {
+      const result = this.instanceMigrationGenerationService.generateSlow({
+        migrationName,
+        version,
+        timestamp,
+      });
+
+      const filePath = path.join(versionDir, result.fileName);
+
+      fs.writeFileSync(filePath, result.fileTemplate);
+
+      this.logger.log(`Slow command generated successfully: ${filePath}`);
+      this.logger.log(`  Class: ${result.className}`);
+      this.logger.log(`  Version: ${version}`);
+
+      const versionSlug = version.split('.').slice(0, 2).join('-');
+      const newImportPath = `src/database/commands/upgrade-version-command/${versionSlug}/${result.fileName.replace('.ts', '')}`;
+
+      this.appendToInstanceCommandsConstant(result.className, newImportPath);
+
+      return;
+    }
 
     const result = await this.instanceMigrationGenerationService.generate({
       migrationName,

--- a/packages/twenty-server/src/database/commands/generate-instance-command.command.ts
+++ b/packages/twenty-server/src/database/commands/generate-instance-command.command.ts
@@ -76,34 +76,13 @@ export class GenerateInstanceCommandCommand extends CommandRunner {
     const versionDir = this.getVersionDir(version);
     const timestamp = Date.now();
 
-    if (commandType === 'slow') {
-      const result = this.instanceMigrationGenerationService.generateSlow({
+    const result =
+      await this.instanceMigrationGenerationService.generateInstanceCommand({
         migrationName,
         version,
         timestamp,
+        type: commandType,
       });
-
-      const filePath = path.join(versionDir, result.fileName);
-
-      fs.writeFileSync(filePath, result.fileTemplate);
-
-      this.logger.log(`Slow command generated successfully: ${filePath}`);
-      this.logger.log(`  Class: ${result.className}`);
-      this.logger.log(`  Version: ${version}`);
-
-      const versionSlug = version.split('.').slice(0, 2).join('-');
-      const newImportPath = `src/database/commands/upgrade-version-command/${versionSlug}/${result.fileName.replace('.ts', '')}`;
-
-      this.appendToInstanceCommandsConstant(result.className, newImportPath);
-
-      return;
-    }
-
-    const result = await this.instanceMigrationGenerationService.generate({
-      migrationName,
-      version,
-      timestamp,
-    });
 
     if (!result) {
       this.logger.warn(
@@ -113,11 +92,13 @@ export class GenerateInstanceCommandCommand extends CommandRunner {
       return;
     }
 
-    const migrationFilePath = path.join(versionDir, result.fileName);
+    const filePath = path.join(versionDir, result.fileName);
 
-    fs.writeFileSync(migrationFilePath, result.fileTemplate);
+    fs.writeFileSync(filePath, result.fileTemplate);
 
-    this.logger.log(`Migration generated successfully: ${migrationFilePath}`);
+    this.logger.log(
+      `${commandType} instance command generated successfully: ${filePath}`,
+    );
     this.logger.log(`  Class: ${result.className}`);
     this.logger.log(`  Version: ${version}`);
 

--- a/packages/twenty-server/src/database/commands/generate-instance-command.command.ts
+++ b/packages/twenty-server/src/database/commands/generate-instance-command.command.ts
@@ -44,7 +44,8 @@ export class GenerateInstanceCommandCommand extends CommandRunner {
 
   @Option({
     flags: '-t, --type <type>',
-    description: 'Command type: fast (schema diff) or slow (data migration + DDL)',
+    description:
+      'Command type: fast (schema diff) or slow (data migration + DDL)',
     defaultValue: 'fast',
   })
   parseType(value: string): InstanceCommandType {

--- a/packages/twenty-server/src/database/commands/instance-command-generation.service.ts
+++ b/packages/twenty-server/src/database/commands/instance-command-generation.service.ts
@@ -52,7 +52,7 @@ export class InstanceCommandGenerationService {
           `    await queryRunner.query('${this.escapeForSingleQuotedString(query)}'${this.formatQueryParams(parameters)});`,
       );
 
-    const fileTemplate = this.buildMigrationFileContent({
+    const fileTemplate = this.buildFastMigrationFileContent({
       className,
       version,
       timestamp,
@@ -62,6 +62,24 @@ export class InstanceCommandGenerationService {
 
     const versionSlug = version.split('.').slice(0, 2).join('-');
     const fileName = `${versionSlug}-instance-command-fast-${timestamp}-${migrationName}.ts`;
+
+    return { fileName, fileTemplate, className };
+  }
+
+  generateSlow({
+    migrationName,
+    version,
+    timestamp,
+  }: GenerateMigrationArgs): GeneratedMigrationResult {
+    const className = this.buildClassName(migrationName);
+    const versionSlug = version.split('.').slice(0, 2).join('-');
+    const fileName = `${versionSlug}-instance-command-slow-${timestamp}-${migrationName}.ts`;
+
+    const fileTemplate = this.buildSlowMigrationFileContent({
+      className,
+      version,
+      timestamp,
+    });
 
     return { fileName, fileTemplate, className };
   }
@@ -82,7 +100,7 @@ export class InstanceCommandGenerationService {
     return query.replace(/\\/g, '\\\\').replace(/'/g, "\\'");
   }
 
-  private buildMigrationFileContent({
+  private buildFastMigrationFileContent({
     className,
     version,
     timestamp,
@@ -95,18 +113,57 @@ export class InstanceCommandGenerationService {
     upStatements: string[];
     downStatements: string[];
   }): string {
-    return `import { MigrationInterface, QueryRunner } from 'typeorm';
+    return `import { QueryRunner } from 'typeorm';
 
 import { RegisteredInstanceCommand } from 'src/engine/core-modules/upgrade/decorators/registered-instance-command.decorator';
+import { FastInstanceCommand } from 'src/engine/core-modules/upgrade/interfaces/fast-instance-command.interface';
 
 @RegisteredInstanceCommand('${version}', ${timestamp})
-export class ${className} implements MigrationInterface {
+export class ${className} implements FastInstanceCommand {
   public async up(queryRunner: QueryRunner): Promise<void> {
 ${upStatements.join('\n')}
   }
 
   public async down(queryRunner: QueryRunner): Promise<void> {
 ${downStatements.join('\n')}
+  }
+}
+`;
+  }
+
+  private buildSlowMigrationFileContent({
+    className,
+    version,
+    timestamp,
+  }: {
+    className: string;
+    version: string;
+    timestamp: number;
+  }): string {
+    return `import { InjectDataSource } from '@nestjs/typeorm';
+
+import { DataSource, QueryRunner } from 'typeorm';
+
+import { RegisteredInstanceCommand } from 'src/engine/core-modules/upgrade/decorators/registered-instance-command.decorator';
+import { SlowInstanceCommand } from 'src/engine/core-modules/upgrade/interfaces/slow-instance-command.interface';
+
+@RegisteredInstanceCommand('${version}', ${timestamp}, { type: 'slow' })
+export class ${className} implements SlowInstanceCommand {
+  constructor(
+    @InjectDataSource()
+    private readonly dataSource: DataSource,
+  ) {}
+
+  async runDataMigration(): Promise<void> {
+    // TODO: implement data backfill before the DDL migration
+  }
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    // TODO: implement DDL migration (runs after data migration)
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    // TODO: implement rollback
   }
 }
 `;

--- a/packages/twenty-server/src/database/commands/instance-command-generation.service.ts
+++ b/packages/twenty-server/src/database/commands/instance-command-generation.service.ts
@@ -5,11 +5,13 @@ import { pascalCase } from 'twenty-shared/utils';
 import { DataSource } from 'typeorm';
 
 import { type UpgradeCommandVersion } from 'src/engine/constants/upgrade-command-supported-versions.constant';
+import { type InstanceCommandType } from 'src/engine/core-modules/upgrade/decorators/registered-instance-command.decorator';
 
-type GenerateMigrationArgs = {
+type GenerateInstanceCommandArgs = {
   migrationName: string;
   version: UpgradeCommandVersion;
   timestamp: number;
+  type?: InstanceCommandType;
 };
 
 export type GeneratedMigrationResult = {
@@ -25,11 +27,12 @@ export class InstanceCommandGenerationService {
     private readonly dataSource: DataSource,
   ) {}
 
-  async generate({
+  async generateInstanceCommand({
     migrationName,
     version,
     timestamp,
-  }: GenerateMigrationArgs): Promise<GeneratedMigrationResult | null> {
+    type = 'fast',
+  }: GenerateInstanceCommandArgs): Promise<GeneratedMigrationResult | null> {
     const sqlInMemory = await this.dataSource.driver
       .createSchemaBuilder()
       .log();
@@ -38,7 +41,7 @@ export class InstanceCommandGenerationService {
       return null;
     }
 
-    const className = this.buildClassName(migrationName);
+    const className = this.buildClassName({ name: migrationName, type });
 
     const upStatements = sqlInMemory.upQueries.map(
       ({ query, parameters }) =>
@@ -52,40 +55,37 @@ export class InstanceCommandGenerationService {
           `    await queryRunner.query('${this.escapeForSingleQuotedString(query)}'${this.formatQueryParams(parameters)});`,
       );
 
-    const fileTemplate = this.buildFastMigrationFileContent({
-      className,
-      version,
-      timestamp,
-      upStatements,
-      downStatements,
-    });
+    const fileTemplate =
+      type === 'slow'
+        ? this.buildSlowMigrationFileContent({
+            className,
+            version,
+            timestamp,
+            upStatements,
+            downStatements,
+          })
+        : this.buildFastMigrationFileContent({
+            className,
+            version,
+            timestamp,
+            upStatements,
+            downStatements,
+          });
 
     const versionSlug = version.split('.').slice(0, 2).join('-');
-    const fileName = `${versionSlug}-instance-command-fast-${timestamp}-${migrationName}.ts`;
+    const fileName = `${versionSlug}-instance-command-${type}-${timestamp}-${migrationName}.ts`;
 
     return { fileName, fileTemplate, className };
   }
 
-  generateSlow({
-    migrationName,
-    version,
-    timestamp,
-  }: GenerateMigrationArgs): GeneratedMigrationResult {
-    const className = this.buildClassName(migrationName);
-    const versionSlug = version.split('.').slice(0, 2).join('-');
-    const fileName = `${versionSlug}-instance-command-slow-${timestamp}-${migrationName}.ts`;
-
-    const fileTemplate = this.buildSlowMigrationFileContent({
-      className,
-      version,
-      timestamp,
-    });
-
-    return { fileName, fileTemplate, className };
-  }
-
-  private buildClassName(name: string): string {
-    return `${pascalCase(name)}Command`;
+  private buildClassName({
+    name,
+    type,
+  }: {
+    name: string;
+    type: InstanceCommandType;
+  }): string {
+    return `${pascalCase(name)}${pascalCase(type)}InstanceCommand`;
   }
 
   private formatQueryParams(parameters: unknown[] | undefined): string {
@@ -135,10 +135,14 @@ ${downStatements.join('\n')}
     className,
     version,
     timestamp,
+    upStatements,
+    downStatements,
   }: {
     className: string;
     version: string;
     timestamp: number;
+    upStatements: string[];
+    downStatements: string[];
   }): string {
     return `import { InjectDataSource } from '@nestjs/typeorm';
 
@@ -159,11 +163,11 @@ export class ${className} implements SlowInstanceCommand {
   }
 
   public async up(queryRunner: QueryRunner): Promise<void> {
-    // TODO: implement DDL migration (runs after data migration)
+${upStatements.join('\n')}
   }
 
   public async down(queryRunner: QueryRunner): Promise<void> {
-    // TODO: implement rollback
+${downStatements.join('\n')}
   }
 }
 `;

--- a/packages/twenty-server/src/database/commands/instance-command-generation.service.ts
+++ b/packages/twenty-server/src/database/commands/instance-command-generation.service.ts
@@ -144,21 +144,14 @@ ${downStatements.join('\n')}
     upStatements: string[];
     downStatements: string[];
   }): string {
-    return `import { InjectDataSource } from '@nestjs/typeorm';
-
-import { DataSource, QueryRunner } from 'typeorm';
+    return `import { DataSource, QueryRunner } from 'typeorm';
 
 import { RegisteredInstanceCommand } from 'src/engine/core-modules/upgrade/decorators/registered-instance-command.decorator';
 import { SlowInstanceCommand } from 'src/engine/core-modules/upgrade/interfaces/slow-instance-command.interface';
 
 @RegisteredInstanceCommand('${version}', ${timestamp}, { type: 'slow' })
 export class ${className} implements SlowInstanceCommand {
-  constructor(
-    @InjectDataSource()
-    private readonly dataSource: DataSource,
-  ) {}
-
-  async runDataMigration(): Promise<void> {
+  async runDataMigration(dataSource: DataSource): Promise<void> {
     // TODO: implement data backfill before the DDL migration
   }
 

--- a/packages/twenty-server/src/database/commands/run-instance-commands.command.ts
+++ b/packages/twenty-server/src/database/commands/run-instance-commands.command.ts
@@ -3,7 +3,6 @@ import { InjectDataSource } from '@nestjs/typeorm';
 
 import chalk from 'chalk';
 import { Command, CommandRunner, Option } from 'nest-commander';
-import { isDefined } from 'twenty-shared/utils';
 import { DataSource } from 'typeorm';
 
 import { CoreEngineVersionService } from 'src/engine/core-engine-version/services/core-engine-version.service';
@@ -60,15 +59,31 @@ export class RunInstanceCommandsCommand extends CommandRunner {
     try {
       await this.checkWorkspaceVersionSafety(options);
       await this.runLegacyPendingTypeOrmMigrations();
-      await this.runAllFastInstanceCommands();
+
+      for (const { migration } of this.upgradeCommandRegistryService.getAllFastInstanceCommands()) {
+        const result =
+          await this.instanceUpgradeService.runFastInstanceCommand(migration);
+
+        if (result.status === 'failed') {
+          throw result.error;
+        }
+      }
 
       if (options.includeSlow) {
         const hasWorkspaces =
           await this.workspaceVersionService.hasActiveOrSuspendedWorkspaces();
 
-        await this.runAllSlowInstanceCommands({
-          skipDataMigration: !hasWorkspaces,
-        });
+        for (const { migration } of this.upgradeCommandRegistryService.getAllSlowInstanceCommands()) {
+          const result =
+            await this.instanceUpgradeService.runSlowInstanceCommand(
+              migration,
+              { skipDataMigration: !hasWorkspaces },
+            );
+
+          if (result.status === 'failed') {
+            throw result.error;
+          }
+        }
       }
 
       this.logger.log(chalk.green('Instance commands completed'));
@@ -93,120 +108,6 @@ export class RunInstanceCommandsCommand extends CommandRunner {
       this.logger.log(
         `Executed ${migrations.length} legacy migration(s): ${migrations.map((migration) => migration.name).join(', ')}`,
       );
-    }
-  }
-
-  private async runAllFastInstanceCommands(): Promise<void> {
-    const allFastInstanceCommands =
-      this.upgradeCommandRegistryService.getAllFastInstanceCommands();
-
-    if (allFastInstanceCommands.length === 0) {
-      this.logger.log('No registered fast instance commands');
-
-      return;
-    }
-
-    this.logger.log(
-      `Running ${allFastInstanceCommands.length} fast instance command(s) across all versions...`,
-    );
-
-    for (const { version, migration } of allFastInstanceCommands) {
-      const migrationName = migration.constructor.name;
-      const result =
-        await this.instanceUpgradeService.runFastInstanceCommand(migration);
-
-      switch (result.status) {
-        case 'already-executed': {
-          this.logger.log(
-            `Instance command ${migrationName} (${version}) already executed, skipping`,
-          );
-
-          break;
-        }
-        case 'failed': {
-          this.logger.error(
-            `Instance command ${migrationName} (${version}) failed`,
-          );
-
-          if (isDefined(result.error)) {
-            this.logger.error(
-              result.error instanceof Error
-                ? (result.error.stack ?? result.error.message)
-                : String(result.error),
-            );
-          }
-
-          throw new Error(
-            `Instance command ${migrationName} (${version}) failed`,
-          );
-        }
-        case 'success': {
-          this.logger.log(
-            `Instance command ${migrationName} (${version}) executed successfully`,
-          );
-
-          break;
-        }
-      }
-    }
-  }
-
-  private async runAllSlowInstanceCommands(options: {
-    skipDataMigration: boolean;
-  }): Promise<void> {
-    const allSlowInstanceCommands =
-      this.upgradeCommandRegistryService.getAllSlowInstanceCommands();
-
-    if (allSlowInstanceCommands.length === 0) {
-      this.logger.log('No registered slow instance commands');
-
-      return;
-    }
-
-    this.logger.log(
-      `Running ${allSlowInstanceCommands.length} slow instance command(s) across all versions...`,
-    );
-
-    for (const { version, migration } of allSlowInstanceCommands) {
-      const migrationName = migration.constructor.name;
-      const result = await this.instanceUpgradeService.runSlowInstanceCommand(
-        migration,
-        { skipDataMigration: options.skipDataMigration },
-      );
-
-      switch (result.status) {
-        case 'already-executed': {
-          this.logger.log(
-            `Slow instance command ${migrationName} (${version}) already executed, skipping`,
-          );
-
-          break;
-        }
-        case 'failed': {
-          this.logger.error(
-            `Slow instance command ${migrationName} (${version}) failed`,
-          );
-
-          if (isDefined(result.error)) {
-            this.logger.error(
-              result.error instanceof Error
-                ? (result.error.stack ?? result.error.message)
-                : String(result.error),
-            );
-          }
-
-          throw new Error(
-            `Slow instance command ${migrationName} (${version}) failed`,
-          );
-        }
-        case 'success': {
-          this.logger.log(
-            `Slow instance command ${migrationName} (${version}) executed successfully`,
-          );
-
-          break;
-        }
-      }
     }
   }
 

--- a/packages/twenty-server/src/database/commands/run-instance-commands.command.ts
+++ b/packages/twenty-server/src/database/commands/run-instance-commands.command.ts
@@ -61,10 +61,14 @@ export class RunInstanceCommandsCommand extends CommandRunner {
       await this.runLegacyPendingTypeOrmMigrations();
 
       for (const {
-        migration,
+        command,
+        name,
       } of this.upgradeCommandRegistryService.getAllFastInstanceCommands()) {
         const result =
-          await this.instanceUpgradeService.runFastInstanceCommand(migration);
+          await this.instanceUpgradeService.runFastInstanceCommand({
+            command,
+            name,
+          });
 
         if (result.status === 'failed') {
           throw result.error;
@@ -76,13 +80,15 @@ export class RunInstanceCommandsCommand extends CommandRunner {
           await this.workspaceVersionService.hasActiveOrSuspendedWorkspaces();
 
         for (const {
-          migration,
+          command,
+          name,
         } of this.upgradeCommandRegistryService.getAllSlowInstanceCommands()) {
           const result =
-            await this.instanceUpgradeService.runSlowInstanceCommand(
-              migration,
-              { skipDataMigration: !hasWorkspaces },
-            );
+            await this.instanceUpgradeService.runSlowInstanceCommand({
+              command,
+              name,
+              skipDataMigration: !hasWorkspaces,
+            });
 
           if (result.status === 'failed') {
             throw result.error;

--- a/packages/twenty-server/src/database/commands/run-instance-commands.command.ts
+++ b/packages/twenty-server/src/database/commands/run-instance-commands.command.ts
@@ -60,7 +60,9 @@ export class RunInstanceCommandsCommand extends CommandRunner {
       await this.checkWorkspaceVersionSafety(options);
       await this.runLegacyPendingTypeOrmMigrations();
 
-      for (const { migration } of this.upgradeCommandRegistryService.getAllFastInstanceCommands()) {
+      for (const {
+        migration,
+      } of this.upgradeCommandRegistryService.getAllFastInstanceCommands()) {
         const result =
           await this.instanceUpgradeService.runFastInstanceCommand(migration);
 
@@ -73,7 +75,9 @@ export class RunInstanceCommandsCommand extends CommandRunner {
         const hasWorkspaces =
           await this.workspaceVersionService.hasActiveOrSuspendedWorkspaces();
 
-        for (const { migration } of this.upgradeCommandRegistryService.getAllSlowInstanceCommands()) {
+        for (const {
+          migration,
+        } of this.upgradeCommandRegistryService.getAllSlowInstanceCommands()) {
           const result =
             await this.instanceUpgradeService.runSlowInstanceCommand(
               migration,

--- a/packages/twenty-server/src/database/commands/run-instance-commands.command.ts
+++ b/packages/twenty-server/src/database/commands/run-instance-commands.command.ts
@@ -13,6 +13,7 @@ import { WorkspaceVersionService } from 'src/engine/workspace-manager/workspace-
 
 type RunInstanceCommandsOptions = {
   force?: boolean;
+  includeSlow?: boolean;
 };
 
 @Command({
@@ -43,6 +44,15 @@ export class RunInstanceCommandsCommand extends CommandRunner {
     return true;
   }
 
+  @Option({
+    flags: '--include-slow',
+    description: 'Also run slow instance commands (data migration + DDL)',
+    required: false,
+  })
+  parseIncludeSlow(): boolean {
+    return true;
+  }
+
   async run(
     _passedParams: string[],
     options: RunInstanceCommandsOptions,
@@ -50,7 +60,16 @@ export class RunInstanceCommandsCommand extends CommandRunner {
     try {
       await this.checkWorkspaceVersionSafety(options);
       await this.runLegacyPendingTypeOrmMigrations();
-      await this.runAllInstanceCommands();
+      await this.runAllFastInstanceCommands();
+
+      if (options.includeSlow) {
+        const hasWorkspaces =
+          await this.workspaceVersionService.hasActiveOrSuspendedWorkspaces();
+
+        await this.runAllSlowInstanceCommands({
+          skipDataMigration: !hasWorkspaces,
+        });
+      }
 
       this.logger.log(chalk.green('Instance commands completed'));
     } catch (error) {
@@ -77,24 +96,24 @@ export class RunInstanceCommandsCommand extends CommandRunner {
     }
   }
 
-  private async runAllInstanceCommands(): Promise<void> {
-    const allInstanceCommands =
-      this.upgradeCommandRegistryService.getAllInstanceCommands();
+  private async runAllFastInstanceCommands(): Promise<void> {
+    const allFastInstanceCommands =
+      this.upgradeCommandRegistryService.getAllFastInstanceCommands();
 
-    if (allInstanceCommands.length === 0) {
-      this.logger.log('No registered instance commands');
+    if (allFastInstanceCommands.length === 0) {
+      this.logger.log('No registered fast instance commands');
 
       return;
     }
 
     this.logger.log(
-      `Running ${allInstanceCommands.length} instance command(s) across all versions...`,
+      `Running ${allFastInstanceCommands.length} fast instance command(s) across all versions...`,
     );
 
-    for (const { version, migration } of allInstanceCommands) {
+    for (const { version, migration } of allFastInstanceCommands) {
       const migrationName = migration.constructor.name;
       const result =
-        await this.instanceUpgradeService.runSingleMigration(migration);
+        await this.instanceUpgradeService.runFastInstanceCommand(migration);
 
       switch (result.status) {
         case 'already-executed': {
@@ -124,6 +143,65 @@ export class RunInstanceCommandsCommand extends CommandRunner {
         case 'success': {
           this.logger.log(
             `Instance command ${migrationName} (${version}) executed successfully`,
+          );
+
+          break;
+        }
+      }
+    }
+  }
+
+  private async runAllSlowInstanceCommands(options: {
+    skipDataMigration: boolean;
+  }): Promise<void> {
+    const allSlowInstanceCommands =
+      this.upgradeCommandRegistryService.getAllSlowInstanceCommands();
+
+    if (allSlowInstanceCommands.length === 0) {
+      this.logger.log('No registered slow instance commands');
+
+      return;
+    }
+
+    this.logger.log(
+      `Running ${allSlowInstanceCommands.length} slow instance command(s) across all versions...`,
+    );
+
+    for (const { version, migration } of allSlowInstanceCommands) {
+      const migrationName = migration.constructor.name;
+      const result = await this.instanceUpgradeService.runSlowInstanceCommand(
+        migration,
+        { skipDataMigration: options.skipDataMigration },
+      );
+
+      switch (result.status) {
+        case 'already-executed': {
+          this.logger.log(
+            `Slow instance command ${migrationName} (${version}) already executed, skipping`,
+          );
+
+          break;
+        }
+        case 'failed': {
+          this.logger.error(
+            `Slow instance command ${migrationName} (${version}) failed`,
+          );
+
+          if (isDefined(result.error)) {
+            this.logger.error(
+              result.error instanceof Error
+                ? (result.error.stack ?? result.error.message)
+                : String(result.error),
+            );
+          }
+
+          throw new Error(
+            `Slow instance command ${migrationName} (${version}) failed`,
+          );
+        }
+        case 'success': {
+          this.logger.log(
+            `Slow instance command ${migrationName} (${version}) executed successfully`,
           );
 
           break;

--- a/packages/twenty-server/src/database/commands/run-instance-commands.command.ts
+++ b/packages/twenty-server/src/database/commands/run-instance-commands.command.ts
@@ -64,11 +64,12 @@ export class RunInstanceCommandsCommand extends CommandRunner {
         command,
         name,
       } of this.upgradeCommandRegistryService.getAllFastInstanceCommands()) {
-        const result =
-          await this.instanceUpgradeService.runFastInstanceCommand({
+        const result = await this.instanceUpgradeService.runFastInstanceCommand(
+          {
             command,
             name,
-          });
+          },
+        );
 
         if (result.status === 'failed') {
           throw result.error;

--- a/packages/twenty-server/src/database/commands/upgrade-version-command/__tests__/upgrade.command.spec.ts
+++ b/packages/twenty-server/src/database/commands/upgrade-version-command/__tests__/upgrade.command.spec.ts
@@ -405,9 +405,9 @@ describe('UpgradeCommandRunner', () => {
 
     await upgradeCommandRunner.run([], {});
 
-    expect(
-      instanceUpgradeService.runFastInstanceCommand,
-    ).toHaveBeenCalledTimes(2);
+    expect(instanceUpgradeService.runFastInstanceCommand).toHaveBeenCalledTimes(
+      2,
+    );
     expect(
       instanceUpgradeService.runFastInstanceCommand,
     ).toHaveBeenNthCalledWith(1, addIndex);
@@ -436,9 +436,7 @@ describe('UpgradeCommandRunner', () => {
       error: new Error('SQL error'),
     });
 
-    await expect(upgradeCommandRunner.run([], {})).rejects.toThrow(
-      'SQL error',
-    );
+    await expect(upgradeCommandRunner.run([], {})).rejects.toThrow('SQL error');
   });
 
   describe('Workspace upgrade should fail', () => {
@@ -526,12 +524,13 @@ describe('UpgradeCommandRunner', () => {
 
     await upgradeCommandRunner.run([], {});
 
-    expect(
-      instanceUpgradeService.runSlowInstanceCommand,
-    ).toHaveBeenCalledTimes(1);
-    expect(
-      instanceUpgradeService.runSlowInstanceCommand,
-    ).toHaveBeenCalledWith(slowMigration, { skipDataMigration: false });
+    expect(instanceUpgradeService.runSlowInstanceCommand).toHaveBeenCalledTimes(
+      1,
+    );
+    expect(instanceUpgradeService.runSlowInstanceCommand).toHaveBeenCalledWith(
+      slowMigration,
+      { skipDataMigration: false },
+    );
   });
 
   it('should run slow commands after fast commands but before workspace commands', async () => {
@@ -611,11 +610,12 @@ describe('UpgradeCommandRunner', () => {
 
     await upgradeCommandRunner.run([], {});
 
-    expect(
-      instanceUpgradeService.runSlowInstanceCommand,
-    ).toHaveBeenCalledWith(expect.any(SlowMigrationFreshInstall), {
-      skipDataMigration: true,
-    });
+    expect(instanceUpgradeService.runSlowInstanceCommand).toHaveBeenCalledWith(
+      expect.any(SlowMigrationFreshInstall),
+      {
+        skipDataMigration: true,
+      },
+    );
   });
 
   it('should propagate errors from runSlowInstanceCommand', async () => {

--- a/packages/twenty-server/src/database/commands/upgrade-version-command/__tests__/upgrade.command.spec.ts
+++ b/packages/twenty-server/src/database/commands/upgrade-version-command/__tests__/upgrade.command.spec.ts
@@ -410,10 +410,16 @@ describe('UpgradeCommandRunner', () => {
     );
     expect(
       instanceUpgradeService.runFastInstanceCommand,
-    ).toHaveBeenNthCalledWith(1, addIndex);
+    ).toHaveBeenNthCalledWith(1, {
+      command: addIndex,
+      name: `${CURRENT_VERSION}_AddIndexToUsers1770000000000_1770000000000`,
+    });
     expect(
       instanceUpgradeService.runFastInstanceCommand,
-    ).toHaveBeenNthCalledWith(2, addColumn);
+    ).toHaveBeenNthCalledWith(2, {
+      command: addColumn,
+      name: `${CURRENT_VERSION}_AddColumnToAccounts1771000000000_1771000000000`,
+    });
   });
 
   it('should propagate errors from runFastInstanceCommand', async () => {
@@ -527,10 +533,11 @@ describe('UpgradeCommandRunner', () => {
     expect(instanceUpgradeService.runSlowInstanceCommand).toHaveBeenCalledTimes(
       1,
     );
-    expect(instanceUpgradeService.runSlowInstanceCommand).toHaveBeenCalledWith(
-      slowMigration,
-      { skipDataMigration: false },
-    );
+    expect(instanceUpgradeService.runSlowInstanceCommand).toHaveBeenCalledWith({
+      command: slowMigration,
+      name: `${CURRENT_VERSION}_SlowMigration1780000000000_1780000000000`,
+      skipDataMigration: false,
+    });
   });
 
   it('should run slow commands after fast commands but before workspace commands', async () => {
@@ -610,12 +617,11 @@ describe('UpgradeCommandRunner', () => {
 
     await upgradeCommandRunner.run([], {});
 
-    expect(instanceUpgradeService.runSlowInstanceCommand).toHaveBeenCalledWith(
-      expect.any(SlowMigrationFreshInstall),
-      {
-        skipDataMigration: true,
-      },
-    );
+    expect(instanceUpgradeService.runSlowInstanceCommand).toHaveBeenCalledWith({
+      command: expect.any(SlowMigrationFreshInstall),
+      name: `${CURRENT_VERSION}_SlowMigrationFreshInstall_1780000000000`,
+      skipDataMigration: true,
+    });
   });
 
   it('should propagate errors from runSlowInstanceCommand', async () => {

--- a/packages/twenty-server/src/database/commands/upgrade-version-command/__tests__/upgrade.command.spec.ts
+++ b/packages/twenty-server/src/database/commands/upgrade-version-command/__tests__/upgrade.command.spec.ts
@@ -3,11 +3,10 @@ import {
   eachTestingContextFilter,
   type EachTestingContext,
 } from 'twenty-shared/testing';
-import {
-  type DataSource,
-  type MigrationInterface,
-  type QueryRunner,
-} from 'typeorm';
+import { type DataSource, type QueryRunner } from 'typeorm';
+
+import { type FastInstanceCommand } from 'src/engine/core-modules/upgrade/interfaces/fast-instance-command.interface';
+import { type SlowInstanceCommand } from 'src/engine/core-modules/upgrade/interfaces/slow-instance-command.interface';
 
 import { getDataSourceToken } from '@nestjs/typeorm';
 
@@ -61,7 +60,7 @@ type BuildUpgradeCommandModuleArgs = {
   workspaces: WorkspaceEntity[];
   appVersion: string | null;
   commandRunner: CommandRunnerValues;
-  migrations?: MigrationInterface[];
+  migrations?: FastInstanceCommand[];
 };
 const buildUpgradeCommandModule = async ({
   workspaces,
@@ -92,7 +91,8 @@ const buildUpgradeCommandModule = async ({
     : {
         provide: UpgradeCommandRegistryService,
         useValue: {
-          getInstanceCommandsForVersion: jest.fn().mockReturnValue([]),
+          getFastInstanceCommandsForVersion: jest.fn().mockReturnValue([]),
+          getSlowInstanceCommandsForVersion: jest.fn().mockReturnValue([]),
           getWorkspaceCommandsForVersion: jest.fn().mockReturnValue([]),
         },
       };
@@ -184,7 +184,10 @@ const buildUpgradeCommandModule = async ({
       {
         provide: InstanceUpgradeService,
         useValue: {
-          runSingleMigration: jest
+          runFastInstanceCommand: jest
+            .fn()
+            .mockResolvedValue({ status: 'success' }),
+          runSlowInstanceCommand: jest
             .fn()
             .mockResolvedValue({ status: 'success' }),
         },
@@ -242,7 +245,7 @@ describe('UpgradeCommandRunner', () => {
     workspaces?: WorkspaceEntity[];
     appVersion?: string | null;
     commandRunner?: CommandRunnerValues;
-    migrations?: MigrationInterface[];
+    migrations?: FastInstanceCommand[];
   };
   const buildModuleAndSetupSpies = async ({
     numberOfWorkspace = 1,
@@ -365,26 +368,26 @@ describe('UpgradeCommandRunner', () => {
     );
   });
 
-  it('should call runSingleMigration for each current-version instance command', async () => {
+  it('should call runFastInstanceCommand for each current-version instance command', async () => {
     @RegisteredInstanceCommand(CURRENT_VERSION, 1770000000000)
-    class AddIndexToUsers1770000000000 implements MigrationInterface {
+    class AddIndexToUsers1770000000000 implements FastInstanceCommand {
       async up(_queryRunner: QueryRunner) {}
       async down(_queryRunner: QueryRunner) {}
     }
 
     @RegisteredInstanceCommand(CURRENT_VERSION, 1771000000000)
-    class AddColumnToAccounts1771000000000 implements MigrationInterface {
+    class AddColumnToAccounts1771000000000 implements FastInstanceCommand {
       async up(_queryRunner: QueryRunner) {}
       async down(_queryRunner: QueryRunner) {}
     }
 
     @RegisteredInstanceCommand(PREVIOUS_VERSION, 1769000000000)
-    class DropLegacyTable1769000000000 implements MigrationInterface {
+    class DropLegacyTable1769000000000 implements FastInstanceCommand {
       async up(_queryRunner: QueryRunner) {}
       async down(_queryRunner: QueryRunner) {}
     }
 
-    class UndecoratedMigration1768000000000 implements MigrationInterface {
+    class UndecoratedMigration1768000000000 implements FastInstanceCommand {
       async up(_queryRunner: QueryRunner) {}
       async down(_queryRunner: QueryRunner) {}
     }
@@ -405,12 +408,12 @@ describe('UpgradeCommandRunner', () => {
 
     await upgradeCommandRunner.run(passedParams, options);
 
-    expect(instanceUpgradeService.runSingleMigration).toHaveBeenCalledTimes(2);
-    expect(instanceUpgradeService.runSingleMigration).toHaveBeenNthCalledWith(
+    expect(instanceUpgradeService.runFastInstanceCommand).toHaveBeenCalledTimes(2);
+    expect(instanceUpgradeService.runFastInstanceCommand).toHaveBeenNthCalledWith(
       1,
       addIndex,
     );
-    expect(instanceUpgradeService.runSingleMigration).toHaveBeenNthCalledWith(
+    expect(instanceUpgradeService.runFastInstanceCommand).toHaveBeenNthCalledWith(
       2,
       addColumn,
     );
@@ -418,7 +421,7 @@ describe('UpgradeCommandRunner', () => {
 
   it('should skip already-executed instance commands', async () => {
     @RegisteredInstanceCommand(CURRENT_VERSION, 1770000000000)
-    class AlreadyRunMigration1770000000000 implements MigrationInterface {
+    class AlreadyRunMigration1770000000000 implements FastInstanceCommand {
       async up(_queryRunner: QueryRunner) {}
       async down(_queryRunner: QueryRunner) {}
     }
@@ -431,7 +434,7 @@ describe('UpgradeCommandRunner', () => {
 
     const instanceUpgradeService = module.get(InstanceUpgradeService);
 
-    (instanceUpgradeService.runSingleMigration as jest.Mock).mockResolvedValue({
+    (instanceUpgradeService.runFastInstanceCommand as jest.Mock).mockResolvedValue({
       status: 'already-executed',
     });
 
@@ -447,7 +450,7 @@ describe('UpgradeCommandRunner', () => {
 
   it('should throw when a migration fails', async () => {
     @RegisteredInstanceCommand(CURRENT_VERSION, 1770000000000)
-    class FailingMigration1770000000000 implements MigrationInterface {
+    class FailingMigration1770000000000 implements FastInstanceCommand {
       async up(_queryRunner: QueryRunner) {}
       async down(_queryRunner: QueryRunner) {}
     }
@@ -460,7 +463,7 @@ describe('UpgradeCommandRunner', () => {
 
     const instanceUpgradeService = module.get(InstanceUpgradeService);
 
-    (instanceUpgradeService.runSingleMigration as jest.Mock).mockResolvedValue({
+    (instanceUpgradeService.runFastInstanceCommand as jest.Mock).mockResolvedValue({
       status: 'failed',
       error: new Error('SQL error'),
     });
@@ -475,7 +478,7 @@ describe('UpgradeCommandRunner', () => {
 
   it('should log success when a migration succeeds', async () => {
     @RegisteredInstanceCommand(CURRENT_VERSION, 1770000000000)
-    class SuccessMigration1770000000000 implements MigrationInterface {
+    class SuccessMigration1770000000000 implements FastInstanceCommand {
       async up(_queryRunner: QueryRunner) {}
       async down(_queryRunner: QueryRunner) {}
     }
@@ -493,7 +496,7 @@ describe('UpgradeCommandRunner', () => {
 
     await upgradeCommandRunner.run(passedParams, options);
 
-    expect(instanceUpgradeService.runSingleMigration).toHaveBeenCalledWith(
+    expect(instanceUpgradeService.runFastInstanceCommand).toHaveBeenCalledWith(
       success,
     );
     expect(upgradeCommandRunner['logger'].log).toHaveBeenCalledWith(
@@ -563,6 +566,169 @@ describe('UpgradeCommandRunner', () => {
           upgradeCommandRunner.run(passedParams, options),
         ).rejects.toThrow(expectedErrorMessage);
       },
+    );
+  });
+
+  it('should call runSlowInstanceCommand for slow instance commands', async () => {
+    @RegisteredInstanceCommand(CURRENT_VERSION, 1780000000000, {
+      type: 'slow',
+    })
+    class SlowMigration1780000000000 implements SlowInstanceCommand {
+      async runDataMigration(_dataSource: DataSource): Promise<void> {}
+      async up(_queryRunner: QueryRunner) {}
+      async down(_queryRunner: QueryRunner) {}
+    }
+
+    const slowMigration = new SlowMigration1780000000000();
+
+    const module = await buildModuleAndSetupSpies({
+      migrations: [slowMigration],
+    });
+
+    const instanceUpgradeService = module.get(InstanceUpgradeService);
+
+    await upgradeCommandRunner.run([], {});
+
+    expect(instanceUpgradeService.runSlowInstanceCommand).toHaveBeenCalledTimes(1);
+    expect(instanceUpgradeService.runSlowInstanceCommand).toHaveBeenCalledWith(
+      slowMigration,
+      { skipDataMigration: false },
+    );
+  });
+
+  it('should run slow commands after fast commands but before workspace commands', async () => {
+    const executionOrder: string[] = [];
+
+    @RegisteredInstanceCommand(CURRENT_VERSION, 1770000000000)
+    class FastMigration1770000000000 implements FastInstanceCommand {
+      async up(_queryRunner: QueryRunner) {}
+      async down(_queryRunner: QueryRunner) {}
+    }
+
+    @RegisteredInstanceCommand(CURRENT_VERSION, 1780000000000, {
+      type: 'slow',
+    })
+    class SlowMigration1780000000000 implements SlowInstanceCommand {
+      async runDataMigration(_dataSource: DataSource): Promise<void> {}
+      async up(_queryRunner: QueryRunner) {}
+      async down(_queryRunner: QueryRunner) {}
+    }
+
+    const module = await buildModuleAndSetupSpies({
+      migrations: [
+        new FastMigration1770000000000(),
+        new SlowMigration1780000000000(),
+      ],
+    });
+
+    const instanceUpgradeService = module.get(InstanceUpgradeService);
+
+    (instanceUpgradeService.runFastInstanceCommand as jest.Mock).mockImplementation(
+      async () => {
+        executionOrder.push('fast');
+
+        return { status: 'success' };
+      },
+    );
+
+    (instanceUpgradeService.runSlowInstanceCommand as jest.Mock).mockImplementation(
+      async () => {
+        executionOrder.push('slow');
+
+        return { status: 'success' };
+      },
+    );
+
+    const workspaceIteratorService = module.get(WorkspaceIteratorService);
+
+    (workspaceIteratorService.iterate as jest.Mock).mockImplementation(
+      async () => {
+        executionOrder.push('workspace');
+
+        return { success: [], fail: [] };
+      },
+    );
+
+    await upgradeCommandRunner.run([], {});
+
+    expect(executionOrder).toStrictEqual(['fast', 'slow', 'workspace']);
+  });
+
+  it('should skip already-executed slow instance commands', async () => {
+    @RegisteredInstanceCommand(CURRENT_VERSION, 1780000000000, {
+      type: 'slow',
+    })
+    class AlreadyRunSlowMigration implements SlowInstanceCommand {
+      async runDataMigration(_dataSource: DataSource): Promise<void> {}
+      async up(_queryRunner: QueryRunner) {}
+      async down(_queryRunner: QueryRunner) {}
+    }
+
+    const module = await buildModuleAndSetupSpies({
+      migrations: [new AlreadyRunSlowMigration()],
+    });
+
+    const instanceUpgradeService = module.get(InstanceUpgradeService);
+
+    (instanceUpgradeService.runSlowInstanceCommand as jest.Mock).mockResolvedValue({
+      status: 'already-executed',
+    });
+
+    await upgradeCommandRunner.run([], {});
+
+    expect(upgradeCommandRunner['logger'].warn).toHaveBeenCalledWith(
+      expect.stringContaining('already executed'),
+    );
+  });
+
+  it('should pass skipDataMigration: true on fresh install (no workspaces)', async () => {
+    @RegisteredInstanceCommand(CURRENT_VERSION, 1780000000000, {
+      type: 'slow',
+    })
+    class SlowMigrationFreshInstall implements SlowInstanceCommand {
+      async runDataMigration(_dataSource: DataSource): Promise<void> {}
+      async up(_queryRunner: QueryRunner) {}
+      async down(_queryRunner: QueryRunner) {}
+    }
+
+    const module = await buildModuleAndSetupSpies({
+      numberOfWorkspace: 0,
+      migrations: [new SlowMigrationFreshInstall()],
+    });
+
+    const instanceUpgradeService = module.get(InstanceUpgradeService);
+
+    await upgradeCommandRunner.run([], {});
+
+    expect(instanceUpgradeService.runSlowInstanceCommand).toHaveBeenCalledWith(
+      expect.any(SlowMigrationFreshInstall),
+      { skipDataMigration: true },
+    );
+  });
+
+  it('should throw when a slow migration fails', async () => {
+    @RegisteredInstanceCommand(CURRENT_VERSION, 1780000000000, {
+      type: 'slow',
+    })
+    class FailingSlowMigration implements SlowInstanceCommand {
+      async runDataMigration(_dataSource: DataSource): Promise<void> {}
+      async up(_queryRunner: QueryRunner) {}
+      async down(_queryRunner: QueryRunner) {}
+    }
+
+    const module = await buildModuleAndSetupSpies({
+      migrations: [new FailingSlowMigration()],
+    });
+
+    const instanceUpgradeService = module.get(InstanceUpgradeService);
+
+    (instanceUpgradeService.runSlowInstanceCommand as jest.Mock).mockResolvedValue({
+      status: 'failed',
+      error: new Error('Data migration error'),
+    });
+
+    await expect(upgradeCommandRunner.run([], {})).rejects.toThrow(
+      'Slow migration FailingSlowMigration failed',
     );
   });
 });

--- a/packages/twenty-server/src/database/commands/upgrade-version-command/__tests__/upgrade.command.spec.ts
+++ b/packages/twenty-server/src/database/commands/upgrade-version-command/__tests__/upgrade.command.spec.ts
@@ -91,9 +91,11 @@ const buildUpgradeCommandModule = async ({
     : {
         provide: UpgradeCommandRegistryService,
         useValue: {
-          getFastInstanceCommandsForVersion: jest.fn().mockReturnValue([]),
-          getSlowInstanceCommandsForVersion: jest.fn().mockReturnValue([]),
-          getWorkspaceCommandsForVersion: jest.fn().mockReturnValue([]),
+          getBucketForVersion: jest.fn().mockReturnValue({
+            fastInstanceCommands: [],
+            slowInstanceCommands: [],
+            workspaceCommands: [],
+          }),
         },
       };
 

--- a/packages/twenty-server/src/database/commands/upgrade-version-command/__tests__/upgrade.command.spec.ts
+++ b/packages/twenty-server/src/database/commands/upgrade-version-command/__tests__/upgrade.command.spec.ts
@@ -403,104 +403,41 @@ describe('UpgradeCommandRunner', () => {
 
     const instanceUpgradeService = module.get(InstanceUpgradeService);
 
-    const passedParams: string[] = [];
-    const options: UpgradeCommandOptions = {};
+    await upgradeCommandRunner.run([], {});
 
-    await upgradeCommandRunner.run(passedParams, options);
-
-    expect(instanceUpgradeService.runFastInstanceCommand).toHaveBeenCalledTimes(2);
-    expect(instanceUpgradeService.runFastInstanceCommand).toHaveBeenNthCalledWith(
-      1,
-      addIndex,
-    );
-    expect(instanceUpgradeService.runFastInstanceCommand).toHaveBeenNthCalledWith(
-      2,
-      addColumn,
-    );
+    expect(
+      instanceUpgradeService.runFastInstanceCommand,
+    ).toHaveBeenCalledTimes(2);
+    expect(
+      instanceUpgradeService.runFastInstanceCommand,
+    ).toHaveBeenNthCalledWith(1, addIndex);
+    expect(
+      instanceUpgradeService.runFastInstanceCommand,
+    ).toHaveBeenNthCalledWith(2, addColumn);
   });
 
-  it('should skip already-executed instance commands', async () => {
-    @RegisteredInstanceCommand(CURRENT_VERSION, 1770000000000)
-    class AlreadyRunMigration1770000000000 implements FastInstanceCommand {
-      async up(_queryRunner: QueryRunner) {}
-      async down(_queryRunner: QueryRunner) {}
-    }
-
-    const alreadyRun = new AlreadyRunMigration1770000000000();
-
-    const module = await buildModuleAndSetupSpies({
-      migrations: [alreadyRun],
-    });
-
-    const instanceUpgradeService = module.get(InstanceUpgradeService);
-
-    (instanceUpgradeService.runFastInstanceCommand as jest.Mock).mockResolvedValue({
-      status: 'already-executed',
-    });
-
-    const passedParams: string[] = [];
-    const options: UpgradeCommandOptions = {};
-
-    await upgradeCommandRunner.run(passedParams, options);
-
-    expect(upgradeCommandRunner['logger'].warn).toHaveBeenCalledWith(
-      expect.stringContaining('already executed'),
-    );
-  });
-
-  it('should throw when a migration fails', async () => {
+  it('should propagate errors from runFastInstanceCommand', async () => {
     @RegisteredInstanceCommand(CURRENT_VERSION, 1770000000000)
     class FailingMigration1770000000000 implements FastInstanceCommand {
       async up(_queryRunner: QueryRunner) {}
       async down(_queryRunner: QueryRunner) {}
     }
 
-    const failing = new FailingMigration1770000000000();
-
     const module = await buildModuleAndSetupSpies({
-      migrations: [failing],
+      migrations: [new FailingMigration1770000000000()],
     });
 
     const instanceUpgradeService = module.get(InstanceUpgradeService);
 
-    (instanceUpgradeService.runFastInstanceCommand as jest.Mock).mockResolvedValue({
+    (
+      instanceUpgradeService.runFastInstanceCommand as jest.Mock
+    ).mockResolvedValue({
       status: 'failed',
       error: new Error('SQL error'),
     });
 
-    const passedParams: string[] = [];
-    const options: UpgradeCommandOptions = {};
-
-    await expect(
-      upgradeCommandRunner.run(passedParams, options),
-    ).rejects.toThrow('Core migration FailingMigration1770000000000 failed');
-  });
-
-  it('should log success when a migration succeeds', async () => {
-    @RegisteredInstanceCommand(CURRENT_VERSION, 1770000000000)
-    class SuccessMigration1770000000000 implements FastInstanceCommand {
-      async up(_queryRunner: QueryRunner) {}
-      async down(_queryRunner: QueryRunner) {}
-    }
-
-    const success = new SuccessMigration1770000000000();
-
-    const module = await buildModuleAndSetupSpies({
-      migrations: [success],
-    });
-
-    const instanceUpgradeService = module.get(InstanceUpgradeService);
-
-    const passedParams: string[] = [];
-    const options: UpgradeCommandOptions = {};
-
-    await upgradeCommandRunner.run(passedParams, options);
-
-    expect(instanceUpgradeService.runFastInstanceCommand).toHaveBeenCalledWith(
-      success,
-    );
-    expect(upgradeCommandRunner['logger'].log).toHaveBeenCalledWith(
-      expect.stringContaining('executed successfully'),
+    await expect(upgradeCommandRunner.run([], {})).rejects.toThrow(
+      'SQL error',
     );
   });
 
@@ -569,7 +506,7 @@ describe('UpgradeCommandRunner', () => {
     );
   });
 
-  it('should call runSlowInstanceCommand for slow instance commands', async () => {
+  it('should call runSlowInstanceCommand for each current-version slow command', async () => {
     @RegisteredInstanceCommand(CURRENT_VERSION, 1780000000000, {
       type: 'slow',
     })
@@ -589,11 +526,12 @@ describe('UpgradeCommandRunner', () => {
 
     await upgradeCommandRunner.run([], {});
 
-    expect(instanceUpgradeService.runSlowInstanceCommand).toHaveBeenCalledTimes(1);
-    expect(instanceUpgradeService.runSlowInstanceCommand).toHaveBeenCalledWith(
-      slowMigration,
-      { skipDataMigration: false },
-    );
+    expect(
+      instanceUpgradeService.runSlowInstanceCommand,
+    ).toHaveBeenCalledTimes(1);
+    expect(
+      instanceUpgradeService.runSlowInstanceCommand,
+    ).toHaveBeenCalledWith(slowMigration, { skipDataMigration: false });
   });
 
   it('should run slow commands after fast commands but before workspace commands', async () => {
@@ -623,21 +561,21 @@ describe('UpgradeCommandRunner', () => {
 
     const instanceUpgradeService = module.get(InstanceUpgradeService);
 
-    (instanceUpgradeService.runFastInstanceCommand as jest.Mock).mockImplementation(
-      async () => {
-        executionOrder.push('fast');
+    (
+      instanceUpgradeService.runFastInstanceCommand as jest.Mock
+    ).mockImplementation(async () => {
+      executionOrder.push('fast');
 
-        return { status: 'success' };
-      },
-    );
+      return { status: 'success' };
+    });
 
-    (instanceUpgradeService.runSlowInstanceCommand as jest.Mock).mockImplementation(
-      async () => {
-        executionOrder.push('slow');
+    (
+      instanceUpgradeService.runSlowInstanceCommand as jest.Mock
+    ).mockImplementation(async () => {
+      executionOrder.push('slow');
 
-        return { status: 'success' };
-      },
-    );
+      return { status: 'success' };
+    });
 
     const workspaceIteratorService = module.get(WorkspaceIteratorService);
 
@@ -652,33 +590,6 @@ describe('UpgradeCommandRunner', () => {
     await upgradeCommandRunner.run([], {});
 
     expect(executionOrder).toStrictEqual(['fast', 'slow', 'workspace']);
-  });
-
-  it('should skip already-executed slow instance commands', async () => {
-    @RegisteredInstanceCommand(CURRENT_VERSION, 1780000000000, {
-      type: 'slow',
-    })
-    class AlreadyRunSlowMigration implements SlowInstanceCommand {
-      async runDataMigration(_dataSource: DataSource): Promise<void> {}
-      async up(_queryRunner: QueryRunner) {}
-      async down(_queryRunner: QueryRunner) {}
-    }
-
-    const module = await buildModuleAndSetupSpies({
-      migrations: [new AlreadyRunSlowMigration()],
-    });
-
-    const instanceUpgradeService = module.get(InstanceUpgradeService);
-
-    (instanceUpgradeService.runSlowInstanceCommand as jest.Mock).mockResolvedValue({
-      status: 'already-executed',
-    });
-
-    await upgradeCommandRunner.run([], {});
-
-    expect(upgradeCommandRunner['logger'].warn).toHaveBeenCalledWith(
-      expect.stringContaining('already executed'),
-    );
   });
 
   it('should pass skipDataMigration: true on fresh install (no workspaces)', async () => {
@@ -700,13 +611,14 @@ describe('UpgradeCommandRunner', () => {
 
     await upgradeCommandRunner.run([], {});
 
-    expect(instanceUpgradeService.runSlowInstanceCommand).toHaveBeenCalledWith(
-      expect.any(SlowMigrationFreshInstall),
-      { skipDataMigration: true },
-    );
+    expect(
+      instanceUpgradeService.runSlowInstanceCommand,
+    ).toHaveBeenCalledWith(expect.any(SlowMigrationFreshInstall), {
+      skipDataMigration: true,
+    });
   });
 
-  it('should throw when a slow migration fails', async () => {
+  it('should propagate errors from runSlowInstanceCommand', async () => {
     @RegisteredInstanceCommand(CURRENT_VERSION, 1780000000000, {
       type: 'slow',
     })
@@ -722,13 +634,15 @@ describe('UpgradeCommandRunner', () => {
 
     const instanceUpgradeService = module.get(InstanceUpgradeService);
 
-    (instanceUpgradeService.runSlowInstanceCommand as jest.Mock).mockResolvedValue({
+    (
+      instanceUpgradeService.runSlowInstanceCommand as jest.Mock
+    ).mockResolvedValue({
       status: 'failed',
       error: new Error('Data migration error'),
     });
 
     await expect(upgradeCommandRunner.run([], {})).rejects.toThrow(
-      'Slow migration FailingSlowMigration failed',
+      'Data migration error',
     );
   });
 });

--- a/packages/twenty-server/src/database/commands/upgrade-version-command/__tests__/upgrade.command.spec.ts
+++ b/packages/twenty-server/src/database/commands/upgrade-version-command/__tests__/upgrade.command.spec.ts
@@ -91,7 +91,7 @@ const buildUpgradeCommandModule = async ({
     : {
         provide: UpgradeCommandRegistryService,
         useValue: {
-          getBucketForVersion: jest.fn().mockReturnValue({
+          getBundleForVersion: jest.fn().mockReturnValue({
             fastInstanceCommands: [],
             slowInstanceCommands: [],
             workspaceCommands: [],

--- a/packages/twenty-server/src/database/commands/upgrade-version-command/upgrade.command.ts
+++ b/packages/twenty-server/src/database/commands/upgrade-version-command/upgrade.command.ts
@@ -13,10 +13,8 @@ import { type UpgradeCommandVersion } from 'src/engine/constants/upgrade-command
 import { CoreEngineVersionService } from 'src/engine/core-engine-version/services/core-engine-version.service';
 import { InstanceUpgradeService } from 'src/engine/core-modules/upgrade/services/instance-upgrade.service';
 import {
-  type RegisteredFastInstanceCommand,
-  type RegisteredSlowInstanceCommand,
-  type RegisteredWorkspaceCommand,
   UpgradeCommandRegistryService,
+  type VersionBucket,
 } from 'src/engine/core-modules/upgrade/services/upgrade-command-registry.service';
 import { WorkspaceUpgradeService } from 'src/engine/core-modules/upgrade/services/workspace-upgrade.service';
 import { WorkspaceVersionService } from 'src/engine/workspace-manager/workspace-version/services/workspace-version.service';
@@ -34,13 +32,10 @@ export type UpgradeCommandOptions = {
   verbose?: boolean;
 };
 
-type VersionContext = {
+type VersionContext = VersionBucket & {
   fromWorkspaceVersion: SemVer;
   currentAppVersion: SemVer;
   currentVersionMajorMinor: UpgradeCommandVersion;
-  fastInstanceCommands: RegisteredFastInstanceCommand[];
-  slowInstanceCommands: RegisteredSlowInstanceCommand[];
-  workspaceCommands: RegisteredWorkspaceCommand[];
 };
 
 @Command({
@@ -260,18 +255,8 @@ Please roll back to that version and run the upgrade command again.`,
     const fromWorkspaceVersion =
       this.coreEngineVersionService.getPreviousVersion();
 
-    const fastInstanceCommands =
-      this.upgradeCommandRegistryService.getFastInstanceCommandsForVersion(
-        currentVersionMajorMinor,
-      );
-
-    const slowInstanceCommands =
-      this.upgradeCommandRegistryService.getSlowInstanceCommandsForVersion(
-        currentVersionMajorMinor,
-      );
-
-    const workspaceCommands =
-      this.upgradeCommandRegistryService.getWorkspaceCommandsForVersion(
+    const { fastInstanceCommands, slowInstanceCommands, workspaceCommands } =
+      this.upgradeCommandRegistryService.getBucketForVersion(
         currentVersionMajorMinor,
       );
 
@@ -279,9 +264,9 @@ Please roll back to that version and run the upgrade command again.`,
       fromWorkspaceVersion,
       currentAppVersion,
       currentVersionMajorMinor,
-      workspaceCommands,
       fastInstanceCommands,
       slowInstanceCommands,
+      workspaceCommands,
     };
   }
 

--- a/packages/twenty-server/src/database/commands/upgrade-version-command/upgrade.command.ts
+++ b/packages/twenty-server/src/database/commands/upgrade-version-command/upgrade.command.ts
@@ -3,7 +3,6 @@ import { InjectDataSource } from '@nestjs/typeorm';
 import chalk from 'chalk';
 import { Command, CommandRunner, Option } from 'nest-commander';
 import { SemVer } from 'semver';
-import { assertUnreachable, isDefined } from 'twenty-shared/utils';
 import { DataSource } from 'typeorm';
 
 import { ActiveOrSuspendedWorkspaceCommandRunner } from 'src/database/commands/command-runners/active-or-suspended-workspace.command-runner';
@@ -171,14 +170,29 @@ Please roll back to that version and run the upgrade command again.`,
       }
 
       await this.runLegacyPendingTypeOrmMigrations();
-      await this.runFastInstanceCommandsOrThrow(versionContext);
+
+      for (const command of versionContext.fastInstanceCommands) {
+        const result =
+          await this.instanceUpgradeService.runFastInstanceCommand(command);
+
+        if (result.status === 'failed') {
+          throw result.error;
+        }
+      }
 
       const hasWorkspaces =
         await this.workspaceVersionService.hasActiveOrSuspendedWorkspaces();
 
-      await this.runSlowInstanceCommandsOrThrow(versionContext, {
-        skipDataMigration: !hasWorkspaces,
-      });
+      for (const command of versionContext.slowInstanceCommands) {
+        const result =
+          await this.instanceUpgradeService.runSlowInstanceCommand(command, {
+            skipDataMigration: !hasWorkspaces,
+          });
+
+        if (result.status === 'failed') {
+          throw result.error;
+        }
+      }
 
       if (!hasWorkspaces) {
         this.logger.log(
@@ -225,95 +239,6 @@ Please roll back to that version and run the upgrade command again.`,
       this.logger.log(
         `Executed ${migrations.length} legacy migration(s): ${migrations.map((migration) => migration.name).join(', ')}`,
       );
-    }
-  }
-
-  private async runFastInstanceCommandsOrThrow(
-    versionContext: VersionContext,
-  ): Promise<void> {
-    for (const instanceCommand of versionContext.fastInstanceCommands) {
-      const migrationName = instanceCommand.constructor.name;
-      const result =
-        await this.instanceUpgradeService.runFastInstanceCommand(instanceCommand);
-
-      switch (result.status) {
-        case 'already-executed': {
-          this.logger.warn(
-            `Core migration ${migrationName} already executed, skipping`,
-          );
-
-          break;
-        }
-        case 'failed': {
-          this.logger.error(`Core migration ${migrationName} failed`);
-
-          if (isDefined(result.error)) {
-            this.logger.error(
-              result.error instanceof Error
-                ? (result.error.stack ?? result.error.message)
-                : String(result.error),
-            );
-          }
-
-          throw new Error(`Core migration ${migrationName} failed`);
-        }
-        case 'success': {
-          this.logger.log(
-            `Core migration ${migrationName} executed successfully`,
-          );
-
-          break;
-        }
-        default: {
-          assertUnreachable(result);
-        }
-      }
-    }
-  }
-
-  private async runSlowInstanceCommandsOrThrow(
-    versionContext: VersionContext,
-    options: { skipDataMigration: boolean },
-  ): Promise<void> {
-    for (const slowCommand of versionContext.slowInstanceCommands) {
-      const migrationName = slowCommand.constructor.name;
-      const result = await this.instanceUpgradeService.runSlowInstanceCommand(
-        slowCommand,
-        { skipDataMigration: options.skipDataMigration },
-      );
-
-      switch (result.status) {
-        case 'already-executed': {
-          this.logger.warn(
-            `Slow migration ${migrationName} already executed, skipping`,
-          );
-
-          break;
-        }
-        case 'failed': {
-          this.logger.error(`Slow migration ${migrationName} failed`);
-
-          if (isDefined(result.error)) {
-            this.logger.error(
-              result.error instanceof Error
-                ? (result.error.stack ?? result.error.message)
-                : String(result.error),
-            );
-          }
-
-          throw new Error(`Slow migration ${migrationName} failed`);
-        }
-        case 'success': {
-          this.logger.log(
-            `Slow migration ${migrationName} executed successfully`,
-          );
-
-          break;
-        }
-        default: {
-          assertUnreachable(result);
-        }
-      }
     }
   }
 

--- a/packages/twenty-server/src/database/commands/upgrade-version-command/upgrade.command.ts
+++ b/packages/twenty-server/src/database/commands/upgrade-version-command/upgrade.command.ts
@@ -11,10 +11,13 @@ import { WorkspaceCommandRunner } from 'src/database/commands/command-runners/wo
 import { CommandLogger } from 'src/database/commands/logger';
 import { type UpgradeCommandVersion } from 'src/engine/constants/upgrade-command-supported-versions.constant';
 import { CoreEngineVersionService } from 'src/engine/core-engine-version/services/core-engine-version.service';
-import { type FastInstanceCommand } from 'src/engine/core-modules/upgrade/interfaces/fast-instance-command.interface';
-import { type SlowInstanceCommand } from 'src/engine/core-modules/upgrade/interfaces/slow-instance-command.interface';
 import { InstanceUpgradeService } from 'src/engine/core-modules/upgrade/services/instance-upgrade.service';
-import { UpgradeCommandRegistryService } from 'src/engine/core-modules/upgrade/services/upgrade-command-registry.service';
+import {
+  type RegisteredFastInstanceCommand,
+  type RegisteredSlowInstanceCommand,
+  type RegisteredWorkspaceCommand,
+  UpgradeCommandRegistryService,
+} from 'src/engine/core-modules/upgrade/services/upgrade-command-registry.service';
 import { WorkspaceUpgradeService } from 'src/engine/core-modules/upgrade/services/workspace-upgrade.service';
 import { WorkspaceVersionService } from 'src/engine/workspace-manager/workspace-version/services/workspace-version.service';
 
@@ -35,9 +38,9 @@ type VersionContext = {
   fromWorkspaceVersion: SemVer;
   currentAppVersion: SemVer;
   currentVersionMajorMinor: UpgradeCommandVersion;
-  fastInstanceCommands: FastInstanceCommand[];
-  slowInstanceCommands: SlowInstanceCommand[];
-  workspaceCommands: VersionCommands;
+  fastInstanceCommands: RegisteredFastInstanceCommand[];
+  slowInstanceCommands: RegisteredSlowInstanceCommand[];
+  workspaceCommands: RegisteredWorkspaceCommand[];
 };
 
 @Command({
@@ -171,9 +174,13 @@ Please roll back to that version and run the upgrade command again.`,
 
       await this.runLegacyPendingTypeOrmMigrations();
 
-      for (const command of versionContext.fastInstanceCommands) {
-        const result =
-          await this.instanceUpgradeService.runFastInstanceCommand(command);
+      for (const { command, name } of versionContext.fastInstanceCommands) {
+        const result = await this.instanceUpgradeService.runFastInstanceCommand(
+          {
+            command,
+            name,
+          },
+        );
 
         if (result.status === 'failed') {
           throw result.error;
@@ -183,10 +190,11 @@ Please roll back to that version and run the upgrade command again.`,
       const hasWorkspaces =
         await this.workspaceVersionService.hasActiveOrSuspendedWorkspaces();
 
-      for (const command of versionContext.slowInstanceCommands) {
+      for (const { command, name } of versionContext.slowInstanceCommands) {
         const result = await this.instanceUpgradeService.runSlowInstanceCommand(
-          command,
           {
+            command,
+            name,
             skipDataMigration: !hasWorkspaces,
           },
         );
@@ -249,11 +257,6 @@ Please roll back to that version and run the upgrade command again.`,
     const currentVersionMajorMinor =
       `${currentAppVersion.major}.${currentAppVersion.minor}.0` as UpgradeCommandVersion;
 
-    const workspaceCommands =
-      this.upgradeCommandRegistryService.getWorkspaceCommandsForVersion(
-        currentVersionMajorMinor,
-      );
-
     const fromWorkspaceVersion =
       this.coreEngineVersionService.getPreviousVersion();
 
@@ -264,6 +267,11 @@ Please roll back to that version and run the upgrade command again.`,
 
     const slowInstanceCommands =
       this.upgradeCommandRegistryService.getSlowInstanceCommandsForVersion(
+        currentVersionMajorMinor,
+      );
+
+    const workspaceCommands =
+      this.upgradeCommandRegistryService.getWorkspaceCommandsForVersion(
         currentVersionMajorMinor,
       );
 
@@ -295,7 +303,9 @@ Please roll back to that version and run the upgrade command again.`,
           options,
           fromWorkspaceVersion: versionContext.fromWorkspaceVersion,
           currentAppVersion: versionContext.currentAppVersion,
-          workspaceCommands: versionContext.workspaceCommands,
+          workspaceCommands: versionContext.workspaceCommands.map(
+            (entry) => entry.command,
+          ),
         });
       },
     });

--- a/packages/twenty-server/src/database/commands/upgrade-version-command/upgrade.command.ts
+++ b/packages/twenty-server/src/database/commands/upgrade-version-command/upgrade.command.ts
@@ -184,10 +184,12 @@ Please roll back to that version and run the upgrade command again.`,
         await this.workspaceVersionService.hasActiveOrSuspendedWorkspaces();
 
       for (const command of versionContext.slowInstanceCommands) {
-        const result =
-          await this.instanceUpgradeService.runSlowInstanceCommand(command, {
+        const result = await this.instanceUpgradeService.runSlowInstanceCommand(
+          command,
+          {
             skipDataMigration: !hasWorkspaces,
-          });
+          },
+        );
 
         if (result.status === 'failed') {
           throw result.error;

--- a/packages/twenty-server/src/database/commands/upgrade-version-command/upgrade.command.ts
+++ b/packages/twenty-server/src/database/commands/upgrade-version-command/upgrade.command.ts
@@ -4,7 +4,7 @@ import chalk from 'chalk';
 import { Command, CommandRunner, Option } from 'nest-commander';
 import { SemVer } from 'semver';
 import { assertUnreachable, isDefined } from 'twenty-shared/utils';
-import { DataSource, MigrationInterface } from 'typeorm';
+import { DataSource } from 'typeorm';
 
 import { ActiveOrSuspendedWorkspaceCommandRunner } from 'src/database/commands/command-runners/active-or-suspended-workspace.command-runner';
 import { WorkspaceIteratorService } from 'src/database/commands/command-runners/workspace-iterator.service';
@@ -12,6 +12,8 @@ import { WorkspaceCommandRunner } from 'src/database/commands/command-runners/wo
 import { CommandLogger } from 'src/database/commands/logger';
 import { type UpgradeCommandVersion } from 'src/engine/constants/upgrade-command-supported-versions.constant';
 import { CoreEngineVersionService } from 'src/engine/core-engine-version/services/core-engine-version.service';
+import { type FastInstanceCommand } from 'src/engine/core-modules/upgrade/interfaces/fast-instance-command.interface';
+import { type SlowInstanceCommand } from 'src/engine/core-modules/upgrade/interfaces/slow-instance-command.interface';
 import { InstanceUpgradeService } from 'src/engine/core-modules/upgrade/services/instance-upgrade.service';
 import { UpgradeCommandRegistryService } from 'src/engine/core-modules/upgrade/services/upgrade-command-registry.service';
 import { WorkspaceUpgradeService } from 'src/engine/core-modules/upgrade/services/workspace-upgrade.service';
@@ -34,7 +36,8 @@ type VersionContext = {
   fromWorkspaceVersion: SemVer;
   currentAppVersion: SemVer;
   currentVersionMajorMinor: UpgradeCommandVersion;
-  instanceCommands: MigrationInterface[];
+  fastInstanceCommands: FastInstanceCommand[];
+  slowInstanceCommands: SlowInstanceCommand[];
   workspaceCommands: VersionCommands;
 };
 
@@ -143,7 +146,8 @@ export class UpgradeCommand extends CommandRunner {
             'Initialized upgrade context with:',
             `- currentVersion (migrating to): ${versionContext.currentAppVersion}`,
             `- fromWorkspaceVersion: ${versionContext.fromWorkspaceVersion}`,
-            `- ${versionContext.instanceCommands.length} instance commands (from registry)`,
+            `- ${versionContext.fastInstanceCommands.length} fast instance commands (from registry)`,
+            `- ${versionContext.slowInstanceCommands.length} slow instance commands (from registry)`,
             `- ${versionContext.workspaceCommands.length} workspace commands`,
           ].join('\n   '),
         ),
@@ -167,10 +171,14 @@ Please roll back to that version and run the upgrade command again.`,
       }
 
       await this.runLegacyPendingTypeOrmMigrations();
-      await this.runInstanceCommandsOrThrow(versionContext);
+      await this.runFastInstanceCommandsOrThrow(versionContext);
 
       const hasWorkspaces =
         await this.workspaceVersionService.hasActiveOrSuspendedWorkspaces();
+
+      await this.runSlowInstanceCommandsOrThrow(versionContext, {
+        skipDataMigration: !hasWorkspaces,
+      });
 
       if (!hasWorkspaces) {
         this.logger.log(
@@ -220,13 +228,13 @@ Please roll back to that version and run the upgrade command again.`,
     }
   }
 
-  private async runInstanceCommandsOrThrow(
+  private async runFastInstanceCommandsOrThrow(
     versionContext: VersionContext,
   ): Promise<void> {
-    for (const instanceCommand of versionContext.instanceCommands) {
+    for (const instanceCommand of versionContext.fastInstanceCommands) {
       const migrationName = instanceCommand.constructor.name;
       const result =
-        await this.instanceUpgradeService.runSingleMigration(instanceCommand);
+        await this.instanceUpgradeService.runFastInstanceCommand(instanceCommand);
 
       switch (result.status) {
         case 'already-executed': {
@@ -263,6 +271,52 @@ Please roll back to that version and run the upgrade command again.`,
     }
   }
 
+  private async runSlowInstanceCommandsOrThrow(
+    versionContext: VersionContext,
+    options: { skipDataMigration: boolean },
+  ): Promise<void> {
+    for (const slowCommand of versionContext.slowInstanceCommands) {
+      const migrationName = slowCommand.constructor.name;
+      const result = await this.instanceUpgradeService.runSlowInstanceCommand(
+        slowCommand,
+        { skipDataMigration: options.skipDataMigration },
+      );
+
+      switch (result.status) {
+        case 'already-executed': {
+          this.logger.warn(
+            `Slow migration ${migrationName} already executed, skipping`,
+          );
+
+          break;
+        }
+        case 'failed': {
+          this.logger.error(`Slow migration ${migrationName} failed`);
+
+          if (isDefined(result.error)) {
+            this.logger.error(
+              result.error instanceof Error
+                ? (result.error.stack ?? result.error.message)
+                : String(result.error),
+            );
+          }
+
+          throw new Error(`Slow migration ${migrationName} failed`);
+        }
+        case 'success': {
+          this.logger.log(
+            `Slow migration ${migrationName} executed successfully`,
+          );
+
+          break;
+        }
+        default: {
+          assertUnreachable(result);
+        }
+      }
+    }
+  }
+
   private resolveVersionContext(): VersionContext {
     const currentAppVersion = this.coreEngineVersionService.getCurrentVersion();
     const currentVersionMajorMinor =
@@ -276,8 +330,13 @@ Please roll back to that version and run the upgrade command again.`,
     const fromWorkspaceVersion =
       this.coreEngineVersionService.getPreviousVersion();
 
-    const instanceCommands =
-      this.upgradeCommandRegistryService.getInstanceCommandsForVersion(
+    const fastInstanceCommands =
+      this.upgradeCommandRegistryService.getFastInstanceCommandsForVersion(
+        currentVersionMajorMinor,
+      );
+
+    const slowInstanceCommands =
+      this.upgradeCommandRegistryService.getSlowInstanceCommandsForVersion(
         currentVersionMajorMinor,
       );
 
@@ -286,7 +345,8 @@ Please roll back to that version and run the upgrade command again.`,
       currentAppVersion,
       currentVersionMajorMinor,
       workspaceCommands,
-      instanceCommands,
+      fastInstanceCommands,
+      slowInstanceCommands,
     };
   }
 

--- a/packages/twenty-server/src/database/commands/upgrade-version-command/upgrade.command.ts
+++ b/packages/twenty-server/src/database/commands/upgrade-version-command/upgrade.command.ts
@@ -14,7 +14,7 @@ import { CoreEngineVersionService } from 'src/engine/core-engine-version/service
 import { InstanceUpgradeService } from 'src/engine/core-modules/upgrade/services/instance-upgrade.service';
 import {
   UpgradeCommandRegistryService,
-  type VersionBucket,
+  type VersionBundle,
 } from 'src/engine/core-modules/upgrade/services/upgrade-command-registry.service';
 import { WorkspaceUpgradeService } from 'src/engine/core-modules/upgrade/services/workspace-upgrade.service';
 import { WorkspaceVersionService } from 'src/engine/workspace-manager/workspace-version/services/workspace-version.service';
@@ -32,7 +32,7 @@ export type UpgradeCommandOptions = {
   verbose?: boolean;
 };
 
-type VersionContext = VersionBucket & {
+type VersionContext = VersionBundle & {
   fromWorkspaceVersion: SemVer;
   currentAppVersion: SemVer;
   currentVersionMajorMinor: UpgradeCommandVersion;
@@ -256,7 +256,7 @@ Please roll back to that version and run the upgrade command again.`,
       this.coreEngineVersionService.getPreviousVersion();
 
     const { fastInstanceCommands, slowInstanceCommands, workspaceCommands } =
-      this.upgradeCommandRegistryService.getBucketForVersion(
+      this.upgradeCommandRegistryService.getBundleForVersion(
         currentVersionMajorMinor,
       );
 

--- a/packages/twenty-server/src/engine/core-modules/upgrade/decorators/registered-instance-command.decorator.ts
+++ b/packages/twenty-server/src/engine/core-modules/upgrade/decorators/registered-instance-command.decorator.ts
@@ -4,9 +4,12 @@ import { Injectable } from '@nestjs/common';
 
 import { type UpgradeCommandVersion } from 'src/engine/constants/upgrade-command-supported-versions.constant';
 
+export type InstanceCommandType = 'fast' | 'slow';
+
 export type RegisteredInstanceCommandMetadata = {
   version: UpgradeCommandVersion;
   timestamp: number;
+  type: InstanceCommandType;
 };
 
 const REGISTERED_INSTANCE_COMMAND_KEY = 'REGISTERED_INSTANCE_COMMAND';
@@ -15,12 +18,16 @@ const REGISTERED_INSTANCE_COMMAND_KEY = 'REGISTERED_INSTANCE_COMMAND';
 // remove the @RegisteredInstanceCommand decorator from its associated
 // command files.
 export const RegisteredInstanceCommand =
-  (version: UpgradeCommandVersion, timestamp: number): ClassDecorator =>
+  (
+    version: UpgradeCommandVersion,
+    timestamp: number,
+    options?: { type: 'slow' },
+  ): ClassDecorator =>
   (target) => {
     Injectable()(target);
     Reflect.defineMetadata(
       REGISTERED_INSTANCE_COMMAND_KEY,
-      { version, timestamp },
+      { version, timestamp, type: options?.type ?? 'fast' },
       target,
     );
   };

--- a/packages/twenty-server/src/engine/core-modules/upgrade/interfaces/fast-instance-command.interface.ts
+++ b/packages/twenty-server/src/engine/core-modules/upgrade/interfaces/fast-instance-command.interface.ts
@@ -1,0 +1,6 @@
+import { type QueryRunner } from 'typeorm';
+
+export interface FastInstanceCommand {
+  up(queryRunner: QueryRunner): Promise<void>;
+  down(queryRunner: QueryRunner): Promise<void>;
+}

--- a/packages/twenty-server/src/engine/core-modules/upgrade/interfaces/slow-instance-command.interface.ts
+++ b/packages/twenty-server/src/engine/core-modules/upgrade/interfaces/slow-instance-command.interface.ts
@@ -1,0 +1,7 @@
+import { type DataSource } from 'typeorm';
+
+import { type FastInstanceCommand } from 'src/engine/core-modules/upgrade/interfaces/fast-instance-command.interface';
+
+export interface SlowInstanceCommand extends FastInstanceCommand {
+  runDataMigration(dataSource: DataSource): Promise<void>;
+}

--- a/packages/twenty-server/src/engine/core-modules/upgrade/services/__tests__/upgrade-command-registry.service.spec.ts
+++ b/packages/twenty-server/src/engine/core-modules/upgrade/services/__tests__/upgrade-command-registry.service.spec.ts
@@ -97,8 +97,8 @@ describe('UpgradeCommandRegistryService', () => {
       new MigrationC1772000000000(),
     ]);
 
-    const v120 = service.getBucketForVersion('1.20.0');
-    const v121 = service.getBucketForVersion('1.21.0');
+    const v120 = service.getBundleForVersion('1.20.0');
+    const v121 = service.getBundleForVersion('1.21.0');
 
     expect(
       v120.fastInstanceCommands.map(
@@ -125,7 +125,7 @@ describe('UpgradeCommandRegistryService', () => {
     ]);
 
     const names = service
-      .getBucketForVersion('1.21.0')
+      .getBundleForVersion('1.21.0')
       .fastInstanceCommands.map((entry) => entry.command.constructor.name);
 
     expect(names).toStrictEqual([
@@ -141,7 +141,7 @@ describe('UpgradeCommandRegistryService', () => {
       new MigrationA1770000000000(),
     ]);
 
-    const v121 = service.getBucketForVersion('1.21.0');
+    const v121 = service.getBundleForVersion('1.21.0');
 
     expect(v121.fastInstanceCommands).toHaveLength(1);
     expect(v121.fastInstanceCommands[0].command.constructor.name).toBe(
@@ -152,8 +152,8 @@ describe('UpgradeCommandRegistryService', () => {
   it('should return empty array for version with no commands', async () => {
     const service = await buildRegistryService([]);
 
-    const v120 = service.getBucketForVersion('1.20.0');
-    const v121 = service.getBucketForVersion('1.21.0');
+    const v120 = service.getBundleForVersion('1.20.0');
+    const v121 = service.getBundleForVersion('1.21.0');
 
     expect(v120.fastInstanceCommands).toStrictEqual([]);
     expect(v121.fastInstanceCommands).toStrictEqual([]);
@@ -165,7 +165,7 @@ describe('UpgradeCommandRegistryService', () => {
     const service = await buildRegistryService([]);
 
     expect(
-      service.getBucketForVersion('99.0.0' as unknown as '1.21.0')
+      service.getBundleForVersion('99.0.0' as unknown as '1.21.0')
         .fastInstanceCommands,
     ).toStrictEqual([]);
   });
@@ -176,7 +176,7 @@ describe('UpgradeCommandRegistryService', () => {
       new WorkspaceCommandA(),
     ]);
 
-    const { workspaceCommands } = service.getBucketForVersion('1.21.0');
+    const { workspaceCommands } = service.getBundleForVersion('1.21.0');
 
     expect(
       workspaceCommands.map((entry) => entry.command.constructor.name),
@@ -191,7 +191,7 @@ describe('UpgradeCommandRegistryService', () => {
       new WorkspaceCommandB(),
     ]);
 
-    const bucket = service.getBucketForVersion('1.21.0');
+    const bucket = service.getBundleForVersion('1.21.0');
 
     expect(bucket.fastInstanceCommands).toHaveLength(2);
     expect(bucket.workspaceCommands).toHaveLength(2);
@@ -208,7 +208,7 @@ describe('UpgradeCommandRegistryService', () => {
       new WorkspaceCommandSameTimestamp(),
     ]);
 
-    const bucket = service.getBucketForVersion('1.21.0');
+    const bucket = service.getBundleForVersion('1.21.0');
 
     expect(bucket.fastInstanceCommands).toHaveLength(1);
     expect(bucket.workspaceCommands).toHaveLength(1);
@@ -292,7 +292,7 @@ describe('UpgradeCommandRegistryService', () => {
       new MigrationA1770000000000_WS(),
     ]);
 
-    const bucket = service.getBucketForVersion('1.21.0');
+    const bucket = service.getBundleForVersion('1.21.0');
 
     expect(bucket.fastInstanceCommands).toHaveLength(1);
     expect(bucket.workspaceCommands).toHaveLength(1);
@@ -322,7 +322,7 @@ describe('UpgradeCommandRegistryService', () => {
       new SlowMigrationA1779000000000(),
     ]);
 
-    const { slowInstanceCommands } = service.getBucketForVersion('1.21.0');
+    const { slowInstanceCommands } = service.getBundleForVersion('1.21.0');
 
     expect(
       slowInstanceCommands.map((entry) => entry.command.constructor.name),
@@ -347,7 +347,7 @@ describe('UpgradeCommandRegistryService', () => {
       new SlowMigration1780000000000(),
     ]);
 
-    const bucket = service.getBucketForVersion('1.21.0');
+    const bucket = service.getBundleForVersion('1.21.0');
 
     expect(bucket.fastInstanceCommands).toHaveLength(1);
     expect(bucket.slowInstanceCommands).toHaveLength(1);
@@ -397,7 +397,7 @@ describe('UpgradeCommandRegistryService', () => {
       new SlowMigrationSameTimestamp(),
     ]);
 
-    const bucket = service.getBucketForVersion('1.21.0');
+    const bucket = service.getBundleForVersion('1.21.0');
 
     expect(bucket.fastInstanceCommands).toHaveLength(1);
     expect(bucket.slowInstanceCommands).toHaveLength(1);

--- a/packages/twenty-server/src/engine/core-modules/upgrade/services/__tests__/upgrade-command-registry.service.spec.ts
+++ b/packages/twenty-server/src/engine/core-modules/upgrade/services/__tests__/upgrade-command-registry.service.spec.ts
@@ -101,15 +101,11 @@ describe('UpgradeCommandRegistryService', () => {
     const v121 = service.getBundleForVersion('1.21.0');
 
     expect(
-      v120.fastInstanceCommands.map(
-        (entry) => entry.command.constructor.name,
-      ),
+      v120.fastInstanceCommands.map((entry) => entry.command.constructor.name),
     ).toStrictEqual(['MigrationD1769000000000']);
 
     expect(
-      v121.fastInstanceCommands.map(
-        (entry) => entry.command.constructor.name,
-      ),
+      v121.fastInstanceCommands.map((entry) => entry.command.constructor.name),
     ).toStrictEqual([
       'MigrationA1770000000000',
       'MigrationB1771000000000',

--- a/packages/twenty-server/src/engine/core-modules/upgrade/services/__tests__/upgrade-command-registry.service.spec.ts
+++ b/packages/twenty-server/src/engine/core-modules/upgrade/services/__tests__/upgrade-command-registry.service.spec.ts
@@ -97,14 +97,20 @@ describe('UpgradeCommandRegistryService', () => {
       new MigrationC1772000000000(),
     ]);
 
-    const v120 = service.getFastInstanceCommandsForVersion('1.20.0');
-    const v121 = service.getFastInstanceCommandsForVersion('1.21.0');
+    const v120 = service.getBucketForVersion('1.20.0');
+    const v121 = service.getBucketForVersion('1.21.0');
 
-    expect(v120.map((entry) => entry.command.constructor.name)).toStrictEqual([
-      'MigrationD1769000000000',
-    ]);
+    expect(
+      v120.fastInstanceCommands.map(
+        (entry) => entry.command.constructor.name,
+      ),
+    ).toStrictEqual(['MigrationD1769000000000']);
 
-    expect(v121.map((entry) => entry.command.constructor.name)).toStrictEqual([
+    expect(
+      v121.fastInstanceCommands.map(
+        (entry) => entry.command.constructor.name,
+      ),
+    ).toStrictEqual([
       'MigrationA1770000000000',
       'MigrationB1771000000000',
       'MigrationC1772000000000',
@@ -119,8 +125,8 @@ describe('UpgradeCommandRegistryService', () => {
     ]);
 
     const names = service
-      .getFastInstanceCommandsForVersion('1.21.0')
-      .map((entry) => entry.command.constructor.name);
+      .getBucketForVersion('1.21.0')
+      .fastInstanceCommands.map((entry) => entry.command.constructor.name);
 
     expect(names).toStrictEqual([
       'MigrationA1770000000000',
@@ -135,32 +141,32 @@ describe('UpgradeCommandRegistryService', () => {
       new MigrationA1770000000000(),
     ]);
 
-    const v121 = service.getFastInstanceCommandsForVersion('1.21.0');
+    const v121 = service.getBucketForVersion('1.21.0');
 
-    expect(v121).toHaveLength(1);
-    expect(v121[0].command.constructor.name).toBe('MigrationA1770000000000');
+    expect(v121.fastInstanceCommands).toHaveLength(1);
+    expect(v121.fastInstanceCommands[0].command.constructor.name).toBe(
+      'MigrationA1770000000000',
+    );
   });
 
   it('should return empty array for version with no commands', async () => {
     const service = await buildRegistryService([]);
 
-    expect(service.getFastInstanceCommandsForVersion('1.20.0')).toStrictEqual(
-      [],
-    );
-    expect(service.getFastInstanceCommandsForVersion('1.21.0')).toStrictEqual(
-      [],
-    );
-    expect(service.getWorkspaceCommandsForVersion('1.20.0')).toStrictEqual([]);
-    expect(service.getWorkspaceCommandsForVersion('1.21.0')).toStrictEqual([]);
+    const v120 = service.getBucketForVersion('1.20.0');
+    const v121 = service.getBucketForVersion('1.21.0');
+
+    expect(v120.fastInstanceCommands).toStrictEqual([]);
+    expect(v121.fastInstanceCommands).toStrictEqual([]);
+    expect(v120.workspaceCommands).toStrictEqual([]);
+    expect(v121.workspaceCommands).toStrictEqual([]);
   });
 
   it('should return empty array for unsupported version', async () => {
     const service = await buildRegistryService([]);
 
     expect(
-      service.getFastInstanceCommandsForVersion(
-        '99.0.0' as unknown as '1.21.0',
-      ),
+      service.getBucketForVersion('99.0.0' as unknown as '1.21.0')
+        .fastInstanceCommands,
     ).toStrictEqual([]);
   });
 
@@ -170,10 +176,10 @@ describe('UpgradeCommandRegistryService', () => {
       new WorkspaceCommandA(),
     ]);
 
-    const commands = service.getWorkspaceCommandsForVersion('1.21.0');
+    const { workspaceCommands } = service.getBucketForVersion('1.21.0');
 
     expect(
-      commands.map((entry) => entry.command.constructor.name),
+      workspaceCommands.map((entry) => entry.command.constructor.name),
     ).toStrictEqual(['WorkspaceCommandA', 'WorkspaceCommandB']);
   });
 
@@ -185,12 +191,10 @@ describe('UpgradeCommandRegistryService', () => {
       new WorkspaceCommandB(),
     ]);
 
-    const instanceCommands =
-      service.getFastInstanceCommandsForVersion('1.21.0');
-    const workspaceCommands = service.getWorkspaceCommandsForVersion('1.21.0');
+    const bucket = service.getBucketForVersion('1.21.0');
 
-    expect(instanceCommands).toHaveLength(2);
-    expect(workspaceCommands).toHaveLength(2);
+    expect(bucket.fastInstanceCommands).toHaveLength(2);
+    expect(bucket.workspaceCommands).toHaveLength(2);
   });
 
   it('should allow same timestamp across different kinds', async () => {
@@ -204,8 +208,10 @@ describe('UpgradeCommandRegistryService', () => {
       new WorkspaceCommandSameTimestamp(),
     ]);
 
-    expect(service.getFastInstanceCommandsForVersion('1.21.0')).toHaveLength(1);
-    expect(service.getWorkspaceCommandsForVersion('1.21.0')).toHaveLength(1);
+    const bucket = service.getBucketForVersion('1.21.0');
+
+    expect(bucket.fastInstanceCommands).toHaveLength(1);
+    expect(bucket.workspaceCommands).toHaveLength(1);
   });
 
   it('should throw on duplicate timestamps within the same kind', async () => {
@@ -286,8 +292,10 @@ describe('UpgradeCommandRegistryService', () => {
       new MigrationA1770000000000_WS(),
     ]);
 
-    expect(service.getFastInstanceCommandsForVersion('1.21.0')).toHaveLength(1);
-    expect(service.getWorkspaceCommandsForVersion('1.21.0')).toHaveLength(1);
+    const bucket = service.getBucketForVersion('1.21.0');
+
+    expect(bucket.fastInstanceCommands).toHaveLength(1);
+    expect(bucket.workspaceCommands).toHaveLength(1);
   });
 
   it('should discover slow instance commands and sort by timestamp', async () => {
@@ -314,10 +322,10 @@ describe('UpgradeCommandRegistryService', () => {
       new SlowMigrationA1779000000000(),
     ]);
 
-    const slowCommands = service.getSlowInstanceCommandsForVersion('1.21.0');
+    const { slowInstanceCommands } = service.getBucketForVersion('1.21.0');
 
     expect(
-      slowCommands.map((entry) => entry.command.constructor.name),
+      slowInstanceCommands.map((entry) => entry.command.constructor.name),
     ).toStrictEqual([
       'SlowMigrationA1779000000000',
       'SlowMigrationB1780000000000',
@@ -339,8 +347,10 @@ describe('UpgradeCommandRegistryService', () => {
       new SlowMigration1780000000000(),
     ]);
 
-    expect(service.getFastInstanceCommandsForVersion('1.21.0')).toHaveLength(1);
-    expect(service.getSlowInstanceCommandsForVersion('1.21.0')).toHaveLength(1);
+    const bucket = service.getBucketForVersion('1.21.0');
+
+    expect(bucket.fastInstanceCommands).toHaveLength(1);
+    expect(bucket.slowInstanceCommands).toHaveLength(1);
   });
 
   it('should throw on duplicate timestamps within slow instance commands', async () => {
@@ -387,8 +397,10 @@ describe('UpgradeCommandRegistryService', () => {
       new SlowMigrationSameTimestamp(),
     ]);
 
-    expect(service.getFastInstanceCommandsForVersion('1.21.0')).toHaveLength(1);
-    expect(service.getSlowInstanceCommandsForVersion('1.21.0')).toHaveLength(1);
+    const bucket = service.getBucketForVersion('1.21.0');
+
+    expect(bucket.fastInstanceCommands).toHaveLength(1);
+    expect(bucket.slowInstanceCommands).toHaveLength(1);
   });
 
   it('should return all slow instance commands across versions', async () => {

--- a/packages/twenty-server/src/engine/core-modules/upgrade/services/__tests__/upgrade-command-registry.service.spec.ts
+++ b/packages/twenty-server/src/engine/core-modules/upgrade/services/__tests__/upgrade-command-registry.service.spec.ts
@@ -144,8 +144,12 @@ describe('UpgradeCommandRegistryService', () => {
   it('should return empty array for version with no commands', async () => {
     const service = await buildRegistryService([]);
 
-    expect(service.getFastInstanceCommandsForVersion('1.20.0')).toStrictEqual([]);
-    expect(service.getFastInstanceCommandsForVersion('1.21.0')).toStrictEqual([]);
+    expect(service.getFastInstanceCommandsForVersion('1.20.0')).toStrictEqual(
+      [],
+    );
+    expect(service.getFastInstanceCommandsForVersion('1.21.0')).toStrictEqual(
+      [],
+    );
     expect(service.getWorkspaceCommandsForVersion('1.20.0')).toStrictEqual([]);
     expect(service.getWorkspaceCommandsForVersion('1.21.0')).toStrictEqual([]);
   });
@@ -154,7 +158,9 @@ describe('UpgradeCommandRegistryService', () => {
     const service = await buildRegistryService([]);
 
     expect(
-      service.getFastInstanceCommandsForVersion('99.0.0' as unknown as '1.21.0'),
+      service.getFastInstanceCommandsForVersion(
+        '99.0.0' as unknown as '1.21.0',
+      ),
     ).toStrictEqual([]);
   });
 
@@ -180,7 +186,8 @@ describe('UpgradeCommandRegistryService', () => {
       new WorkspaceCommandB(),
     ]);
 
-    const instanceCommands = service.getFastInstanceCommandsForVersion('1.21.0');
+    const instanceCommands =
+      service.getFastInstanceCommandsForVersion('1.21.0');
     const workspaceCommands = service.getWorkspaceCommandsForVersion('1.21.0');
 
     expect(instanceCommands).toHaveLength(2);
@@ -216,7 +223,9 @@ describe('UpgradeCommandRegistryService', () => {
         new MigrationA1770000000000(),
         new DuplicateInstanceTimestamp(),
       ]),
-    ).rejects.toThrow('Duplicate fast-instance command timestamp 1770000000000');
+    ).rejects.toThrow(
+      'Duplicate fast-instance command timestamp 1770000000000',
+    );
   });
 
   it('should throw on duplicate computed names across kinds', async () => {
@@ -343,12 +352,8 @@ describe('UpgradeCommandRegistryService', () => {
       new SlowMigration1780000000000(),
     ]);
 
-    expect(
-      service.getFastInstanceCommandsForVersion('1.21.0'),
-    ).toHaveLength(1);
-    expect(
-      service.getSlowInstanceCommandsForVersion('1.21.0'),
-    ).toHaveLength(1);
+    expect(service.getFastInstanceCommandsForVersion('1.21.0')).toHaveLength(1);
+    expect(service.getSlowInstanceCommandsForVersion('1.21.0')).toHaveLength(1);
   });
 
   it('should throw on duplicate timestamps within slow instance commands', async () => {
@@ -375,7 +380,9 @@ describe('UpgradeCommandRegistryService', () => {
         new SlowMigrationA1780000000000(),
         new SlowMigrationB1780000000000(),
       ]),
-    ).rejects.toThrow('Duplicate slow-instance command timestamp 1780000000000');
+    ).rejects.toThrow(
+      'Duplicate slow-instance command timestamp 1780000000000',
+    );
   });
 
   it('should allow same timestamp across fast and slow instance commands', async () => {
@@ -393,12 +400,8 @@ describe('UpgradeCommandRegistryService', () => {
       new SlowMigrationSameTimestamp(),
     ]);
 
-    expect(
-      service.getFastInstanceCommandsForVersion('1.21.0'),
-    ).toHaveLength(1);
-    expect(
-      service.getSlowInstanceCommandsForVersion('1.21.0'),
-    ).toHaveLength(1);
+    expect(service.getFastInstanceCommandsForVersion('1.21.0')).toHaveLength(1);
+    expect(service.getSlowInstanceCommandsForVersion('1.21.0')).toHaveLength(1);
   });
 
   it('should return all slow instance commands across versions', async () => {

--- a/packages/twenty-server/src/engine/core-modules/upgrade/services/__tests__/upgrade-command-registry.service.spec.ts
+++ b/packages/twenty-server/src/engine/core-modules/upgrade/services/__tests__/upgrade-command-registry.service.spec.ts
@@ -3,14 +3,17 @@ import 'reflect-metadata';
 import { Test } from '@nestjs/testing';
 import { DiscoveryService } from '@nestjs/core';
 
-import { type MigrationInterface } from 'typeorm';
+import { type DataSource } from 'typeorm';
+
+import { type FastInstanceCommand } from 'src/engine/core-modules/upgrade/interfaces/fast-instance-command.interface';
 
 import { UpgradeCommandRegistryService } from 'src/engine/core-modules/upgrade/services/upgrade-command-registry.service';
 import { RegisteredInstanceCommand } from 'src/engine/core-modules/upgrade/decorators/registered-instance-command.decorator';
 import { RegisteredWorkspaceCommand } from 'src/engine/core-modules/upgrade/decorators/registered-workspace-command.decorator';
+import { type SlowInstanceCommand } from 'src/engine/core-modules/upgrade/interfaces/slow-instance-command.interface';
 
 @RegisteredInstanceCommand('1.21.0', 1770000000000)
-class MigrationA1770000000000 implements MigrationInterface {
+class MigrationA1770000000000 implements FastInstanceCommand {
   name = 'MigrationA1770000000000';
 
   async up(): Promise<void> {}
@@ -18,7 +21,7 @@ class MigrationA1770000000000 implements MigrationInterface {
 }
 
 @RegisteredInstanceCommand('1.21.0', 1771000000000)
-class MigrationB1771000000000 implements MigrationInterface {
+class MigrationB1771000000000 implements FastInstanceCommand {
   name = 'MigrationB1771000000000';
 
   async up(): Promise<void> {}
@@ -26,7 +29,7 @@ class MigrationB1771000000000 implements MigrationInterface {
 }
 
 @RegisteredInstanceCommand('1.21.0', 1772000000000)
-class MigrationC1772000000000 implements MigrationInterface {
+class MigrationC1772000000000 implements FastInstanceCommand {
   name = 'MigrationC1772000000000';
 
   async up(): Promise<void> {}
@@ -34,14 +37,14 @@ class MigrationC1772000000000 implements MigrationInterface {
 }
 
 @RegisteredInstanceCommand('1.20.0', 1769000000000)
-class MigrationD1769000000000 implements MigrationInterface {
+class MigrationD1769000000000 implements FastInstanceCommand {
   name = 'MigrationD1769000000000';
 
   async up(): Promise<void> {}
   async down(): Promise<void> {}
 }
 
-class UndecoratedMigration1768000000000 implements MigrationInterface {
+class UndecoratedMigration1768000000000 implements FastInstanceCommand {
   name = 'UndecoratedMigration1768000000000';
 
   async up(): Promise<void> {}
@@ -94,8 +97,8 @@ describe('UpgradeCommandRegistryService', () => {
       new MigrationC1772000000000(),
     ]);
 
-    const v120 = service.getInstanceCommandsForVersion('1.20.0');
-    const v121 = service.getInstanceCommandsForVersion('1.21.0');
+    const v120 = service.getFastInstanceCommandsForVersion('1.20.0');
+    const v121 = service.getFastInstanceCommandsForVersion('1.21.0');
 
     expect(v120.map((migration) => migration.constructor.name)).toStrictEqual([
       'MigrationD1769000000000',
@@ -116,7 +119,7 @@ describe('UpgradeCommandRegistryService', () => {
     ]);
 
     const names = service
-      .getInstanceCommandsForVersion('1.21.0')
+      .getFastInstanceCommandsForVersion('1.21.0')
       .map((migration) => migration.constructor.name);
 
     expect(names).toStrictEqual([
@@ -132,7 +135,7 @@ describe('UpgradeCommandRegistryService', () => {
       new MigrationA1770000000000(),
     ]);
 
-    const v121 = service.getInstanceCommandsForVersion('1.21.0');
+    const v121 = service.getFastInstanceCommandsForVersion('1.21.0');
 
     expect(v121).toHaveLength(1);
     expect(v121[0].constructor.name).toBe('MigrationA1770000000000');
@@ -141,8 +144,8 @@ describe('UpgradeCommandRegistryService', () => {
   it('should return empty array for version with no commands', async () => {
     const service = await buildRegistryService([]);
 
-    expect(service.getInstanceCommandsForVersion('1.20.0')).toStrictEqual([]);
-    expect(service.getInstanceCommandsForVersion('1.21.0')).toStrictEqual([]);
+    expect(service.getFastInstanceCommandsForVersion('1.20.0')).toStrictEqual([]);
+    expect(service.getFastInstanceCommandsForVersion('1.21.0')).toStrictEqual([]);
     expect(service.getWorkspaceCommandsForVersion('1.20.0')).toStrictEqual([]);
     expect(service.getWorkspaceCommandsForVersion('1.21.0')).toStrictEqual([]);
   });
@@ -151,7 +154,7 @@ describe('UpgradeCommandRegistryService', () => {
     const service = await buildRegistryService([]);
 
     expect(
-      service.getInstanceCommandsForVersion('99.0.0' as unknown as '1.21.0'),
+      service.getFastInstanceCommandsForVersion('99.0.0' as unknown as '1.21.0'),
     ).toStrictEqual([]);
   });
 
@@ -177,7 +180,7 @@ describe('UpgradeCommandRegistryService', () => {
       new WorkspaceCommandB(),
     ]);
 
-    const instanceCommands = service.getInstanceCommandsForVersion('1.21.0');
+    const instanceCommands = service.getFastInstanceCommandsForVersion('1.21.0');
     const workspaceCommands = service.getWorkspaceCommandsForVersion('1.21.0');
 
     expect(instanceCommands).toHaveLength(2);
@@ -195,13 +198,13 @@ describe('UpgradeCommandRegistryService', () => {
       new WorkspaceCommandSameTimestamp(),
     ]);
 
-    expect(service.getInstanceCommandsForVersion('1.21.0')).toHaveLength(1);
+    expect(service.getFastInstanceCommandsForVersion('1.21.0')).toHaveLength(1);
     expect(service.getWorkspaceCommandsForVersion('1.21.0')).toHaveLength(1);
   });
 
   it('should throw on duplicate timestamps within the same kind', async () => {
     @RegisteredInstanceCommand('1.21.0', 1770000000000)
-    class DuplicateInstanceTimestamp implements MigrationInterface {
+    class DuplicateInstanceTimestamp implements FastInstanceCommand {
       name = 'DuplicateInstanceTimestamp';
 
       async up(): Promise<void> {}
@@ -213,7 +216,7 @@ describe('UpgradeCommandRegistryService', () => {
         new MigrationA1770000000000(),
         new DuplicateInstanceTimestamp(),
       ]),
-    ).rejects.toThrow('Duplicate instance command timestamp 1770000000000');
+    ).rejects.toThrow('Duplicate fast-instance command timestamp 1770000000000');
   });
 
   it('should throw on duplicate computed names across kinds', async () => {
@@ -244,7 +247,7 @@ describe('UpgradeCommandRegistryService', () => {
       new MigrationB1771000000000(),
     ]);
 
-    const allCommands = service.getAllInstanceCommands();
+    const allCommands = service.getAllFastInstanceCommands();
 
     expect(allCommands).toStrictEqual([
       {
@@ -266,10 +269,10 @@ describe('UpgradeCommandRegistryService', () => {
     ]);
   });
 
-  it('should return empty array from getAllInstanceCommands when no commands registered', async () => {
+  it('should return empty array from getAllFastInstanceCommands when no commands registered', async () => {
     const service = await buildRegistryService([]);
 
-    expect(service.getAllInstanceCommands()).toStrictEqual([]);
+    expect(service.getAllFastInstanceCommands()).toStrictEqual([]);
   });
 
   it('should allow same class name with different timestamps across kinds', async () => {
@@ -287,7 +290,156 @@ describe('UpgradeCommandRegistryService', () => {
       new MigrationA1770000000000_WS(),
     ]);
 
-    expect(service.getInstanceCommandsForVersion('1.21.0')).toHaveLength(1);
+    expect(service.getFastInstanceCommandsForVersion('1.21.0')).toHaveLength(1);
     expect(service.getWorkspaceCommandsForVersion('1.21.0')).toHaveLength(1);
+  });
+
+  it('should discover slow instance commands and sort by timestamp', async () => {
+    @RegisteredInstanceCommand('1.21.0', 1780000000000, { type: 'slow' })
+    class SlowMigrationB1780000000000 implements SlowInstanceCommand {
+      name = 'SlowMigrationB1780000000000';
+
+      async runDataMigration(_dataSource: DataSource): Promise<void> {}
+      async up(): Promise<void> {}
+      async down(): Promise<void> {}
+    }
+
+    @RegisteredInstanceCommand('1.21.0', 1779000000000, { type: 'slow' })
+    class SlowMigrationA1779000000000 implements SlowInstanceCommand {
+      name = 'SlowMigrationA1779000000000';
+
+      async runDataMigration(_dataSource: DataSource): Promise<void> {}
+      async up(): Promise<void> {}
+      async down(): Promise<void> {}
+    }
+
+    const service = await buildRegistryService([
+      new SlowMigrationB1780000000000(),
+      new SlowMigrationA1779000000000(),
+    ]);
+
+    const slowCommands = service.getSlowInstanceCommandsForVersion('1.21.0');
+
+    expect(
+      slowCommands.map((command) => command.constructor.name),
+    ).toStrictEqual([
+      'SlowMigrationA1779000000000',
+      'SlowMigrationB1780000000000',
+    ]);
+  });
+
+  it('should separate fast and slow instance commands in the same version', async () => {
+    @RegisteredInstanceCommand('1.21.0', 1780000000000, { type: 'slow' })
+    class SlowMigration1780000000000 implements SlowInstanceCommand {
+      name = 'SlowMigration1780000000000';
+
+      async runDataMigration(_dataSource: DataSource): Promise<void> {}
+      async up(): Promise<void> {}
+      async down(): Promise<void> {}
+    }
+
+    const service = await buildRegistryService([
+      new MigrationA1770000000000(),
+      new SlowMigration1780000000000(),
+    ]);
+
+    expect(
+      service.getFastInstanceCommandsForVersion('1.21.0'),
+    ).toHaveLength(1);
+    expect(
+      service.getSlowInstanceCommandsForVersion('1.21.0'),
+    ).toHaveLength(1);
+  });
+
+  it('should throw on duplicate timestamps within slow instance commands', async () => {
+    @RegisteredInstanceCommand('1.21.0', 1780000000000, { type: 'slow' })
+    class SlowMigrationA1780000000000 implements SlowInstanceCommand {
+      name = 'SlowMigrationA1780000000000';
+
+      async runDataMigration(_dataSource: DataSource): Promise<void> {}
+      async up(): Promise<void> {}
+      async down(): Promise<void> {}
+    }
+
+    @RegisteredInstanceCommand('1.21.0', 1780000000000, { type: 'slow' })
+    class SlowMigrationB1780000000000 implements SlowInstanceCommand {
+      name = 'SlowMigrationB1780000000000';
+
+      async runDataMigration(_dataSource: DataSource): Promise<void> {}
+      async up(): Promise<void> {}
+      async down(): Promise<void> {}
+    }
+
+    await expect(
+      buildRegistryService([
+        new SlowMigrationA1780000000000(),
+        new SlowMigrationB1780000000000(),
+      ]),
+    ).rejects.toThrow('Duplicate slow-instance command timestamp 1780000000000');
+  });
+
+  it('should allow same timestamp across fast and slow instance commands', async () => {
+    @RegisteredInstanceCommand('1.21.0', 1770000000000, { type: 'slow' })
+    class SlowMigrationSameTimestamp implements SlowInstanceCommand {
+      name = 'SlowMigrationSameTimestamp';
+
+      async runDataMigration(_dataSource: DataSource): Promise<void> {}
+      async up(): Promise<void> {}
+      async down(): Promise<void> {}
+    }
+
+    const service = await buildRegistryService([
+      new MigrationA1770000000000(),
+      new SlowMigrationSameTimestamp(),
+    ]);
+
+    expect(
+      service.getFastInstanceCommandsForVersion('1.21.0'),
+    ).toHaveLength(1);
+    expect(
+      service.getSlowInstanceCommandsForVersion('1.21.0'),
+    ).toHaveLength(1);
+  });
+
+  it('should return all slow instance commands across versions', async () => {
+    @RegisteredInstanceCommand('1.21.0', 1780000000000, { type: 'slow' })
+    class SlowMigration1780000000000 implements SlowInstanceCommand {
+      name = 'SlowMigration1780000000000';
+
+      async runDataMigration(_dataSource: DataSource): Promise<void> {}
+      async up(): Promise<void> {}
+      async down(): Promise<void> {}
+    }
+
+    @RegisteredInstanceCommand('1.20.0', 1768000000000, { type: 'slow' })
+    class SlowMigration1768000000000 implements SlowInstanceCommand {
+      name = 'SlowMigration1768000000000';
+
+      async runDataMigration(_dataSource: DataSource): Promise<void> {}
+      async up(): Promise<void> {}
+      async down(): Promise<void> {}
+    }
+
+    const service = await buildRegistryService([
+      new SlowMigration1780000000000(),
+      new SlowMigration1768000000000(),
+    ]);
+
+    const allSlowCommands = service.getAllSlowInstanceCommands();
+
+    expect(allSlowCommands).toStrictEqual([
+      {
+        version: '1.20.0',
+        migration: expect.objectContaining({
+          name: 'SlowMigration1768000000000',
+        }),
+      },
+      {
+        version: '1.21.0',
+        migration: expect.objectContaining({
+          name: 'SlowMigration1780000000000',
+        }),
+      },
+    ]);
   });
 });

--- a/packages/twenty-server/src/engine/core-modules/upgrade/services/__tests__/upgrade-command-registry.service.spec.ts
+++ b/packages/twenty-server/src/engine/core-modules/upgrade/services/__tests__/upgrade-command-registry.service.spec.ts
@@ -100,11 +100,11 @@ describe('UpgradeCommandRegistryService', () => {
     const v120 = service.getFastInstanceCommandsForVersion('1.20.0');
     const v121 = service.getFastInstanceCommandsForVersion('1.21.0');
 
-    expect(v120.map((migration) => migration.constructor.name)).toStrictEqual([
+    expect(v120.map((entry) => entry.command.constructor.name)).toStrictEqual([
       'MigrationD1769000000000',
     ]);
 
-    expect(v121.map((migration) => migration.constructor.name)).toStrictEqual([
+    expect(v121.map((entry) => entry.command.constructor.name)).toStrictEqual([
       'MigrationA1770000000000',
       'MigrationB1771000000000',
       'MigrationC1772000000000',
@@ -120,7 +120,7 @@ describe('UpgradeCommandRegistryService', () => {
 
     const names = service
       .getFastInstanceCommandsForVersion('1.21.0')
-      .map((migration) => migration.constructor.name);
+      .map((entry) => entry.command.constructor.name);
 
     expect(names).toStrictEqual([
       'MigrationA1770000000000',
@@ -138,7 +138,7 @@ describe('UpgradeCommandRegistryService', () => {
     const v121 = service.getFastInstanceCommandsForVersion('1.21.0');
 
     expect(v121).toHaveLength(1);
-    expect(v121[0].constructor.name).toBe('MigrationA1770000000000');
+    expect(v121[0].command.constructor.name).toBe('MigrationA1770000000000');
   });
 
   it('should return empty array for version with no commands', async () => {
@@ -172,10 +172,9 @@ describe('UpgradeCommandRegistryService', () => {
 
     const commands = service.getWorkspaceCommandsForVersion('1.21.0');
 
-    expect(commands.map((command) => command.constructor.name)).toStrictEqual([
-      'WorkspaceCommandA',
-      'WorkspaceCommandB',
-    ]);
+    expect(
+      commands.map((entry) => entry.command.constructor.name),
+    ).toStrictEqual(['WorkspaceCommandA', 'WorkspaceCommandB']);
   });
 
   it('should discover both instance and workspace commands for the same version', async () => {
@@ -258,23 +257,11 @@ describe('UpgradeCommandRegistryService', () => {
 
     const allCommands = service.getAllFastInstanceCommands();
 
-    expect(allCommands).toStrictEqual([
-      {
-        version: '1.20.0',
-        migration: expect.objectContaining({ name: 'MigrationD1769000000000' }),
-      },
-      {
-        version: '1.21.0',
-        migration: expect.objectContaining({ name: 'MigrationA1770000000000' }),
-      },
-      {
-        version: '1.21.0',
-        migration: expect.objectContaining({ name: 'MigrationB1771000000000' }),
-      },
-      {
-        version: '1.21.0',
-        migration: expect.objectContaining({ name: 'MigrationC1772000000000' }),
-      },
+    expect(allCommands.map((entry) => entry.name)).toStrictEqual([
+      '1.20.0_MigrationD1769000000000_1769000000000',
+      '1.21.0_MigrationA1770000000000_1770000000000',
+      '1.21.0_MigrationB1771000000000_1771000000000',
+      '1.21.0_MigrationC1772000000000_1772000000000',
     ]);
   });
 
@@ -330,7 +317,7 @@ describe('UpgradeCommandRegistryService', () => {
     const slowCommands = service.getSlowInstanceCommandsForVersion('1.21.0');
 
     expect(
-      slowCommands.map((command) => command.constructor.name),
+      slowCommands.map((entry) => entry.command.constructor.name),
     ).toStrictEqual([
       'SlowMigrationA1779000000000',
       'SlowMigrationB1780000000000',
@@ -430,19 +417,9 @@ describe('UpgradeCommandRegistryService', () => {
 
     const allSlowCommands = service.getAllSlowInstanceCommands();
 
-    expect(allSlowCommands).toStrictEqual([
-      {
-        version: '1.20.0',
-        migration: expect.objectContaining({
-          name: 'SlowMigration1768000000000',
-        }),
-      },
-      {
-        version: '1.21.0',
-        migration: expect.objectContaining({
-          name: 'SlowMigration1780000000000',
-        }),
-      },
+    expect(allSlowCommands.map((entry) => entry.name)).toStrictEqual([
+      '1.20.0_SlowMigration1768000000000_1768000000000',
+      '1.21.0_SlowMigration1780000000000_1780000000000',
     ]);
   });
 });

--- a/packages/twenty-server/src/engine/core-modules/upgrade/services/instance-upgrade.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/upgrade/services/instance-upgrade.service.ts
@@ -31,18 +31,17 @@ export class InstanceUpgradeService {
     command: FastInstanceCommand;
     name: string;
   }): Promise<RunSingleMigrationResult> {
-    const migrationName = name;
     const executedByVersion =
       this.twentyConfigService.get('APP_VERSION') ?? 'unknown';
 
     const isAlreadyCompleted =
       await this.upgradeMigrationService.isLastAttemptCompleted({
-        name: migrationName,
+        name,
         workspaceId: null,
       });
 
     if (isAlreadyCompleted) {
-      this.logger.log(`${migrationName} already executed, skipping`);
+      this.logger.log(`${name} already executed, skipping`);
 
       return { status: 'already-executed' };
     }
@@ -56,7 +55,7 @@ export class InstanceUpgradeService {
       await command.up(queryRunner);
 
       await this.upgradeMigrationService.markAsCompleted({
-        name: migrationName,
+        name,
         workspaceId: null,
         executedByVersion,
         queryRunner,
@@ -69,13 +68,13 @@ export class InstanceUpgradeService {
       }
 
       await this.upgradeMigrationService.markAsFailed({
-        name: migrationName,
+        name,
         workspaceId: null,
         executedByVersion,
       });
 
       this.logger.error(
-        `${migrationName} failed`,
+        `${name} failed`,
         error instanceof Error ? error.stack : String(error),
       );
 
@@ -84,7 +83,7 @@ export class InstanceUpgradeService {
       await queryRunner.release();
     }
 
-    this.logger.log(`${migrationName} executed successfully`);
+    this.logger.log(`${name} executed successfully`);
 
     return { status: 'success' };
   }
@@ -98,8 +97,19 @@ export class InstanceUpgradeService {
     name: string;
     skipDataMigration?: boolean;
   }): Promise<RunSingleMigrationResult> {
+    const isAlreadyCompleted =
+      await this.upgradeMigrationService.isLastAttemptCompleted({
+        name,
+        workspaceId: null,
+      });
+
+    if (isAlreadyCompleted) {
+      this.logger.log(`${name} already executed, skipping`);
+
+      return { status: 'already-executed' };
+    }
+
     if (!skipDataMigration) {
-      const migrationName = name;
       const executedByVersion =
         this.twentyConfigService.get('APP_VERSION') ?? 'unknown';
 
@@ -107,13 +117,13 @@ export class InstanceUpgradeService {
         await command.runDataMigration(this.dataSource);
       } catch (error) {
         await this.upgradeMigrationService.markAsFailed({
-          name: migrationName,
+          name,
           workspaceId: null,
           executedByVersion,
         });
 
         this.logger.error(
-          `${migrationName} data migration failed`,
+          `${name} data migration failed`,
           error instanceof Error ? error.stack : String(error),
         );
 

--- a/packages/twenty-server/src/engine/core-modules/upgrade/services/instance-upgrade.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/upgrade/services/instance-upgrade.service.ts
@@ -1,9 +1,11 @@
 import { Injectable } from '@nestjs/common';
 import { InjectDataSource } from '@nestjs/typeorm';
 
-import { DataSource, MigrationInterface } from 'typeorm';
+import { DataSource } from 'typeorm';
 
 import { TwentyConfigService } from 'src/engine/core-modules/twenty-config/twenty-config.service';
+import { type FastInstanceCommand } from 'src/engine/core-modules/upgrade/interfaces/fast-instance-command.interface';
+import { type SlowInstanceCommand } from 'src/engine/core-modules/upgrade/interfaces/slow-instance-command.interface';
 import { UpgradeMigrationService } from 'src/engine/core-modules/upgrade/services/upgrade-migration.service';
 
 export type RunSingleMigrationResult =
@@ -20,8 +22,8 @@ export class InstanceUpgradeService {
     private readonly upgradeMigrationService: UpgradeMigrationService,
   ) {}
 
-  async runSingleMigration(
-    migration: MigrationInterface,
+  async runFastInstanceCommand(
+    migration: FastInstanceCommand,
   ): Promise<RunSingleMigrationResult> {
     const migrationName = migration.constructor.name;
     const executedByVersion =
@@ -70,5 +72,30 @@ export class InstanceUpgradeService {
     }
 
     return { status: 'success' };
+  }
+
+  async runSlowInstanceCommand(
+    migration: SlowInstanceCommand,
+    options?: { skipDataMigration?: boolean },
+  ): Promise<RunSingleMigrationResult> {
+    if (!options?.skipDataMigration) {
+      const migrationName = migration.constructor.name;
+      const executedByVersion =
+        this.twentyConfigService.get('APP_VERSION') ?? 'unknown';
+
+      try {
+        await migration.runDataMigration(this.dataSource);
+      } catch (error) {
+        await this.upgradeMigrationService.markAsFailed({
+          name: migrationName,
+          workspaceId: null,
+          executedByVersion,
+        });
+
+        return { status: 'failed', error };
+      }
+    }
+
+    return this.runFastInstanceCommand(migration);
   }
 }

--- a/packages/twenty-server/src/engine/core-modules/upgrade/services/instance-upgrade.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/upgrade/services/instance-upgrade.service.ts
@@ -24,10 +24,14 @@ export class InstanceUpgradeService {
     private readonly upgradeMigrationService: UpgradeMigrationService,
   ) {}
 
-  async runFastInstanceCommand(
-    migration: FastInstanceCommand,
-  ): Promise<RunSingleMigrationResult> {
-    const migrationName = migration.constructor.name;
+  async runFastInstanceCommand({
+    command,
+    name,
+  }: {
+    command: FastInstanceCommand;
+    name: string;
+  }): Promise<RunSingleMigrationResult> {
+    const migrationName = name;
     const executedByVersion =
       this.twentyConfigService.get('APP_VERSION') ?? 'unknown';
 
@@ -49,7 +53,7 @@ export class InstanceUpgradeService {
       await queryRunner.connect();
       await queryRunner.startTransaction();
 
-      await migration.up(queryRunner);
+      await command.up(queryRunner);
 
       await this.upgradeMigrationService.markAsCompleted({
         name: migrationName,
@@ -85,17 +89,22 @@ export class InstanceUpgradeService {
     return { status: 'success' };
   }
 
-  async runSlowInstanceCommand(
-    migration: SlowInstanceCommand,
-    options?: { skipDataMigration?: boolean },
-  ): Promise<RunSingleMigrationResult> {
-    if (!options?.skipDataMigration) {
-      const migrationName = migration.constructor.name;
+  async runSlowInstanceCommand({
+    command,
+    name,
+    skipDataMigration,
+  }: {
+    command: SlowInstanceCommand;
+    name: string;
+    skipDataMigration?: boolean;
+  }): Promise<RunSingleMigrationResult> {
+    if (!skipDataMigration) {
+      const migrationName = name;
       const executedByVersion =
         this.twentyConfigService.get('APP_VERSION') ?? 'unknown';
 
       try {
-        await migration.runDataMigration(this.dataSource);
+        await command.runDataMigration(this.dataSource);
       } catch (error) {
         await this.upgradeMigrationService.markAsFailed({
           name: migrationName,
@@ -112,6 +121,6 @@ export class InstanceUpgradeService {
       }
     }
 
-    return this.runFastInstanceCommand(migration);
+    return this.runFastInstanceCommand({ command, name });
   }
 }

--- a/packages/twenty-server/src/engine/core-modules/upgrade/services/instance-upgrade.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/upgrade/services/instance-upgrade.service.ts
@@ -1,4 +1,4 @@
-import { Injectable } from '@nestjs/common';
+import { Injectable, Logger } from '@nestjs/common';
 import { InjectDataSource } from '@nestjs/typeorm';
 
 import { DataSource } from 'typeorm';
@@ -8,13 +8,15 @@ import { type FastInstanceCommand } from 'src/engine/core-modules/upgrade/interf
 import { type SlowInstanceCommand } from 'src/engine/core-modules/upgrade/interfaces/slow-instance-command.interface';
 import { UpgradeMigrationService } from 'src/engine/core-modules/upgrade/services/upgrade-migration.service';
 
-export type RunSingleMigrationResult =
+type RunSingleMigrationResult =
   | { status: 'success' }
   | { status: 'already-executed' }
   | { status: 'failed'; error: unknown };
 
 @Injectable()
 export class InstanceUpgradeService {
+  private readonly logger = new Logger(InstanceUpgradeService.name);
+
   constructor(
     @InjectDataSource()
     private readonly dataSource: DataSource,
@@ -36,6 +38,8 @@ export class InstanceUpgradeService {
       });
 
     if (isAlreadyCompleted) {
+      this.logger.log(`${migrationName} already executed, skipping`);
+
       return { status: 'already-executed' };
     }
 
@@ -66,10 +70,17 @@ export class InstanceUpgradeService {
         executedByVersion,
       });
 
+      this.logger.error(
+        `${migrationName} failed`,
+        error instanceof Error ? error.stack : String(error),
+      );
+
       return { status: 'failed', error };
     } finally {
       await queryRunner.release();
     }
+
+    this.logger.log(`${migrationName} executed successfully`);
 
     return { status: 'success' };
   }
@@ -91,6 +102,11 @@ export class InstanceUpgradeService {
           workspaceId: null,
           executedByVersion,
         });
+
+        this.logger.error(
+          `${migrationName} data migration failed`,
+          error instanceof Error ? error.stack : String(error),
+        );
 
         return { status: 'failed', error };
       }

--- a/packages/twenty-server/src/engine/core-modules/upgrade/services/upgrade-command-registry.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/upgrade/services/upgrade-command-registry.service.ts
@@ -41,6 +41,12 @@ export type VersionBundle = {
   workspaceCommands: RegisteredWorkspaceCommand[];
 };
 
+const buildEmptyVersionBundle = (): VersionBundle => ({
+  fastInstanceCommands: [],
+  slowInstanceCommands: [],
+  workspaceCommands: [],
+});
+
 @Injectable()
 export class UpgradeCommandRegistryService implements OnModuleInit {
   private readonly logger = new Logger(UpgradeCommandRegistryService.name);
@@ -154,17 +160,8 @@ export class UpgradeCommandRegistryService implements OnModuleInit {
     }
   }
 
-  private static readonly EMPTY_BUNDLE: VersionBundle = {
-    fastInstanceCommands: [],
-    slowInstanceCommands: [],
-    workspaceCommands: [],
-  };
-
   getBundleForVersion(version: UpgradeCommandVersion): VersionBundle {
-    return (
-      this.bundlesByVersion.get(version) ??
-      UpgradeCommandRegistryService.EMPTY_BUNDLE
-    );
+    return this.bundlesByVersion.get(version) ?? buildEmptyVersionBundle();
   }
 
   getAllFastInstanceCommands(): RegisteredFastInstanceCommand[] {

--- a/packages/twenty-server/src/engine/core-modules/upgrade/services/upgrade-command-registry.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/upgrade/services/upgrade-command-registry.service.ts
@@ -1,12 +1,12 @@
 import { Injectable, Logger, type OnModuleInit } from '@nestjs/common';
 import { DiscoveryService } from '@nestjs/core';
 
-import { type MigrationInterface } from 'typeorm';
-
 import { type ActiveOrSuspendedWorkspaceCommandRunner } from 'src/database/commands/command-runners/active-or-suspended-workspace.command-runner';
 import { type WorkspaceCommandRunner } from 'src/database/commands/command-runners/workspace.command-runner';
-import { getRegisteredWorkspaceCommandMetadata } from 'src/engine/core-modules/upgrade/decorators/registered-workspace-command.decorator';
 import { getRegisteredInstanceCommandMetadata } from 'src/engine/core-modules/upgrade/decorators/registered-instance-command.decorator';
+import { getRegisteredWorkspaceCommandMetadata } from 'src/engine/core-modules/upgrade/decorators/registered-workspace-command.decorator';
+import { type FastInstanceCommand } from 'src/engine/core-modules/upgrade/interfaces/fast-instance-command.interface';
+import { type SlowInstanceCommand } from 'src/engine/core-modules/upgrade/interfaces/slow-instance-command.interface';
 import {
   UPGRADE_COMMAND_SUPPORTED_VERSIONS,
   type UpgradeCommandVersion,
@@ -17,9 +17,15 @@ type WorkspaceCommand =
   | WorkspaceCommandRunner
   | ActiveOrSuspendedWorkspaceCommandRunner;
 
-type RegisteredInstanceCommand = {
+type RegisteredFastInstanceCommand = {
   name: string;
-  command: MigrationInterface;
+  command: FastInstanceCommand;
+  timestamp: number;
+};
+
+type RegisteredSlowInstanceCommand = {
+  name: string;
+  command: SlowInstanceCommand;
   timestamp: number;
 };
 
@@ -30,7 +36,8 @@ type RegisteredWorkspaceCommand = {
 };
 
 type VersionBucket = {
-  instanceCommands: RegisteredInstanceCommand[];
+  fastInstanceCommands: RegisteredFastInstanceCommand[];
+  slowInstanceCommands: RegisteredSlowInstanceCommand[];
   workspaceCommands: RegisteredWorkspaceCommand[];
 };
 
@@ -48,7 +55,8 @@ export class UpgradeCommandRegistryService implements OnModuleInit {
   onModuleInit(): void {
     for (const version of UPGRADE_COMMAND_SUPPORTED_VERSIONS) {
       this.bucketsByVersion.set(version, {
-        instanceCommands: [],
+        fastInstanceCommands: [],
+        slowInstanceCommands: [],
         workspaceCommands: [],
       });
     }
@@ -71,15 +79,26 @@ export class UpgradeCommandRegistryService implements OnModuleInit {
         );
 
         if (isDefined(bucket)) {
-          bucket.instanceCommands.push({
+          const entry = {
             name: this.computeCommandName(
               instanceCommandMetadata.version,
-              (instance as MigrationInterface).constructor.name,
+              (instance as FastInstanceCommand).constructor.name,
               instanceCommandMetadata.timestamp,
             ),
-            command: instance as MigrationInterface,
             timestamp: instanceCommandMetadata.timestamp,
-          });
+          };
+
+          if (instanceCommandMetadata.type === 'slow') {
+            bucket.slowInstanceCommands.push({
+              ...entry,
+              command: instance as SlowInstanceCommand,
+            });
+          } else {
+            bucket.fastInstanceCommands.push({
+              ...entry,
+              command: instance as FastInstanceCommand,
+            });
+          }
         }
 
         continue;
@@ -108,7 +127,10 @@ export class UpgradeCommandRegistryService implements OnModuleInit {
     }
 
     for (const [, bucket] of this.bucketsByVersion) {
-      bucket.instanceCommands.sort(
+      bucket.fastInstanceCommands.sort(
+        (entryA, entryB) => entryA.timestamp - entryB.timestamp,
+      );
+      bucket.slowInstanceCommands.sort(
         (entryA, entryB) => entryA.timestamp - entryB.timestamp,
       );
       bucket.workspaceCommands.sort(
@@ -120,23 +142,35 @@ export class UpgradeCommandRegistryService implements OnModuleInit {
 
     for (const [version, bucket] of this.bucketsByVersion) {
       const totalCount =
-        bucket.instanceCommands.length + bucket.workspaceCommands.length;
+        bucket.fastInstanceCommands.length +
+        bucket.slowInstanceCommands.length +
+        bucket.workspaceCommands.length;
 
       if (totalCount > 0) {
         this.logger.log(
-          `Registered ${bucket.instanceCommands.length} instance command(s) and ${bucket.workspaceCommands.length} workspace command(s) for ${version}`,
+          `Registered ${bucket.fastInstanceCommands.length} fast instance, ${bucket.slowInstanceCommands.length} slow instance, and ${bucket.workspaceCommands.length} workspace command(s) for ${version}`,
         );
       }
     }
   }
 
-  getInstanceCommandsForVersion(
+  getFastInstanceCommandsForVersion(
     version: UpgradeCommandVersion,
-  ): MigrationInterface[] {
+  ): FastInstanceCommand[] {
     return (
       this.bucketsByVersion
         .get(version)
-        ?.instanceCommands.map((entry) => entry.command) ?? []
+        ?.fastInstanceCommands.map((entry) => entry.command) ?? []
+    );
+  }
+
+  getSlowInstanceCommandsForVersion(
+    version: UpgradeCommandVersion,
+  ): SlowInstanceCommand[] {
+    return (
+      this.bucketsByVersion
+        .get(version)
+        ?.slowInstanceCommands.map((entry) => entry.command) ?? []
     );
   }
 
@@ -150,17 +184,35 @@ export class UpgradeCommandRegistryService implements OnModuleInit {
     );
   }
 
-  getAllInstanceCommands(): {
+  getAllFastInstanceCommands(): {
     version: UpgradeCommandVersion;
-    migration: MigrationInterface;
+    migration: FastInstanceCommand;
   }[] {
     const result: {
       version: UpgradeCommandVersion;
-      migration: MigrationInterface;
+      migration: FastInstanceCommand;
     }[] = [];
 
     for (const version of UPGRADE_COMMAND_SUPPORTED_VERSIONS) {
-      for (const command of this.getInstanceCommandsForVersion(version)) {
+      for (const command of this.getFastInstanceCommandsForVersion(version)) {
+        result.push({ version, migration: command });
+      }
+    }
+
+    return result;
+  }
+
+  getAllSlowInstanceCommands(): {
+    version: UpgradeCommandVersion;
+    migration: SlowInstanceCommand;
+  }[] {
+    const result: {
+      version: UpgradeCommandVersion;
+      migration: SlowInstanceCommand;
+    }[] = [];
+
+    for (const version of UPGRADE_COMMAND_SUPPORTED_VERSIONS) {
+      for (const command of this.getSlowInstanceCommandsForVersion(version)) {
         result.push({ version, migration: command });
       }
     }
@@ -180,8 +232,13 @@ export class UpgradeCommandRegistryService implements OnModuleInit {
     for (const [version, bucket] of this.bucketsByVersion) {
       this.validateNoTimestampDuplicatesWithinKind(
         version,
-        'instance',
-        bucket.instanceCommands,
+        'fast-instance',
+        bucket.fastInstanceCommands,
+      );
+      this.validateNoTimestampDuplicatesWithinKind(
+        version,
+        'slow-instance',
+        bucket.slowInstanceCommands,
       );
       this.validateNoTimestampDuplicatesWithinKind(
         version,
@@ -192,7 +249,8 @@ export class UpgradeCommandRegistryService implements OnModuleInit {
       const seenNames = new Set<string>();
 
       const allNames = [
-        ...bucket.instanceCommands.map((entry) => entry.name),
+        ...bucket.fastInstanceCommands.map((entry) => entry.name),
+        ...bucket.slowInstanceCommands.map((entry) => entry.name),
         ...bucket.workspaceCommands.map((entry) => entry.name),
       ];
 
@@ -210,8 +268,11 @@ export class UpgradeCommandRegistryService implements OnModuleInit {
 
   private validateNoTimestampDuplicatesWithinKind(
     version: UpgradeCommandVersion,
-    kind: 'instance' | 'workspace',
-    entries: RegisteredInstanceCommand[] | RegisteredWorkspaceCommand[],
+    kind: 'fast-instance' | 'slow-instance' | 'workspace',
+    entries:
+      | RegisteredFastInstanceCommand[]
+      | RegisteredSlowInstanceCommand[]
+      | RegisteredWorkspaceCommand[],
   ): void {
     const seenTimestamps = new Set<number>();
 

--- a/packages/twenty-server/src/engine/core-modules/upgrade/services/upgrade-command-registry.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/upgrade/services/upgrade-command-registry.service.ts
@@ -35,7 +35,7 @@ export type RegisteredWorkspaceCommand = {
   timestamp: number;
 };
 
-export type VersionBucket = {
+export type VersionBundle = {
   fastInstanceCommands: RegisteredFastInstanceCommand[];
   slowInstanceCommands: RegisteredSlowInstanceCommand[];
   workspaceCommands: RegisteredWorkspaceCommand[];
@@ -45,16 +45,16 @@ export type VersionBucket = {
 export class UpgradeCommandRegistryService implements OnModuleInit {
   private readonly logger = new Logger(UpgradeCommandRegistryService.name);
 
-  private readonly bucketsByVersion = new Map<
+  private readonly bundlesByVersion = new Map<
     UpgradeCommandVersion,
-    VersionBucket
+    VersionBundle
   >();
 
   constructor(private readonly discoveryService: DiscoveryService) {}
 
   onModuleInit(): void {
     for (const version of UPGRADE_COMMAND_SUPPORTED_VERSIONS) {
-      this.bucketsByVersion.set(version, {
+      this.bundlesByVersion.set(version, {
         fastInstanceCommands: [],
         slowInstanceCommands: [],
         workspaceCommands: [],
@@ -74,7 +74,7 @@ export class UpgradeCommandRegistryService implements OnModuleInit {
         getRegisteredInstanceCommandMetadata(metatype);
 
       if (isDefined(instanceCommandMetadata)) {
-        const bucket = this.bucketsByVersion.get(
+        const bucket = this.bundlesByVersion.get(
           instanceCommandMetadata.version,
         );
 
@@ -108,7 +108,7 @@ export class UpgradeCommandRegistryService implements OnModuleInit {
         getRegisteredWorkspaceCommandMetadata(metatype);
 
       if (isDefined(workspaceCommandMetadata)) {
-        const bucket = this.bucketsByVersion.get(
+        const bucket = this.bundlesByVersion.get(
           workspaceCommandMetadata.version,
         );
 
@@ -126,7 +126,7 @@ export class UpgradeCommandRegistryService implements OnModuleInit {
       }
     }
 
-    for (const [, bucket] of this.bucketsByVersion) {
+    for (const [, bucket] of this.bundlesByVersion) {
       bucket.fastInstanceCommands.sort(
         (entryA, entryB) => entryA.timestamp - entryB.timestamp,
       );
@@ -140,7 +140,7 @@ export class UpgradeCommandRegistryService implements OnModuleInit {
 
     this.validateNoDuplicates();
 
-    for (const [version, bucket] of this.bucketsByVersion) {
+    for (const [version, bucket] of this.bundlesByVersion) {
       const totalCount =
         bucket.fastInstanceCommands.length +
         bucket.slowInstanceCommands.length +
@@ -154,25 +154,25 @@ export class UpgradeCommandRegistryService implements OnModuleInit {
     }
   }
 
-  private static readonly EMPTY_BUCKET: VersionBucket = {
+  private static readonly EMPTY_BUNDLE: VersionBundle = {
     fastInstanceCommands: [],
     slowInstanceCommands: [],
     workspaceCommands: [],
   };
 
-  getBucketForVersion(version: UpgradeCommandVersion): VersionBucket {
-    return this.bucketsByVersion.get(version) ?? UpgradeCommandRegistryService.EMPTY_BUCKET;
+  getBundleForVersion(version: UpgradeCommandVersion): VersionBundle {
+    return this.bundlesByVersion.get(version) ?? UpgradeCommandRegistryService.EMPTY_BUNDLE;
   }
 
   getAllFastInstanceCommands(): RegisteredFastInstanceCommand[] {
     return UPGRADE_COMMAND_SUPPORTED_VERSIONS.flatMap(
-      (version) => this.getBucketForVersion(version).fastInstanceCommands,
+      (version) => this.getBundleForVersion(version).fastInstanceCommands,
     );
   }
 
   getAllSlowInstanceCommands(): RegisteredSlowInstanceCommand[] {
     return UPGRADE_COMMAND_SUPPORTED_VERSIONS.flatMap(
-      (version) => this.getBucketForVersion(version).slowInstanceCommands,
+      (version) => this.getBundleForVersion(version).slowInstanceCommands,
     );
   }
 
@@ -185,7 +185,7 @@ export class UpgradeCommandRegistryService implements OnModuleInit {
   }
 
   private validateNoDuplicates(): void {
-    for (const [version, bucket] of this.bucketsByVersion) {
+    for (const [version, bucket] of this.bundlesByVersion) {
       this.validateNoTimestampDuplicatesWithinKind(
         version,
         'fast-instance',

--- a/packages/twenty-server/src/engine/core-modules/upgrade/services/upgrade-command-registry.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/upgrade/services/upgrade-command-registry.service.ts
@@ -161,7 +161,10 @@ export class UpgradeCommandRegistryService implements OnModuleInit {
   };
 
   getBundleForVersion(version: UpgradeCommandVersion): VersionBundle {
-    return this.bundlesByVersion.get(version) ?? UpgradeCommandRegistryService.EMPTY_BUNDLE;
+    return (
+      this.bundlesByVersion.get(version) ??
+      UpgradeCommandRegistryService.EMPTY_BUNDLE
+    );
   }
 
   getAllFastInstanceCommands(): RegisteredFastInstanceCommand[] {

--- a/packages/twenty-server/src/engine/core-modules/upgrade/services/upgrade-command-registry.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/upgrade/services/upgrade-command-registry.service.ts
@@ -80,11 +80,11 @@ export class UpgradeCommandRegistryService implements OnModuleInit {
         getRegisteredInstanceCommandMetadata(metatype);
 
       if (isDefined(instanceCommandMetadata)) {
-        const bucket = this.bundlesByVersion.get(
+        const bundle = this.bundlesByVersion.get(
           instanceCommandMetadata.version,
         );
 
-        if (isDefined(bucket)) {
+        if (isDefined(bundle)) {
           const entry = {
             name: this.computeCommandName(
               instanceCommandMetadata.version,
@@ -95,12 +95,12 @@ export class UpgradeCommandRegistryService implements OnModuleInit {
           };
 
           if (instanceCommandMetadata.type === 'slow') {
-            bucket.slowInstanceCommands.push({
+            bundle.slowInstanceCommands.push({
               ...entry,
               command: instance as SlowInstanceCommand,
             });
           } else {
-            bucket.fastInstanceCommands.push({
+            bundle.fastInstanceCommands.push({
               ...entry,
               command: instance as FastInstanceCommand,
             });
@@ -114,12 +114,12 @@ export class UpgradeCommandRegistryService implements OnModuleInit {
         getRegisteredWorkspaceCommandMetadata(metatype);
 
       if (isDefined(workspaceCommandMetadata)) {
-        const bucket = this.bundlesByVersion.get(
+        const bundle = this.bundlesByVersion.get(
           workspaceCommandMetadata.version,
         );
 
-        if (isDefined(bucket)) {
-          bucket.workspaceCommands.push({
+        if (isDefined(bundle)) {
+          bundle.workspaceCommands.push({
             name: this.computeCommandName(
               workspaceCommandMetadata.version,
               (instance as WorkspaceCommand).constructor.name,
@@ -132,29 +132,29 @@ export class UpgradeCommandRegistryService implements OnModuleInit {
       }
     }
 
-    for (const [, bucket] of this.bundlesByVersion) {
-      bucket.fastInstanceCommands.sort(
+    for (const [, bundle] of this.bundlesByVersion) {
+      bundle.fastInstanceCommands.sort(
         (entryA, entryB) => entryA.timestamp - entryB.timestamp,
       );
-      bucket.slowInstanceCommands.sort(
+      bundle.slowInstanceCommands.sort(
         (entryA, entryB) => entryA.timestamp - entryB.timestamp,
       );
-      bucket.workspaceCommands.sort(
+      bundle.workspaceCommands.sort(
         (entryA, entryB) => entryA.timestamp - entryB.timestamp,
       );
     }
 
     this.validateNoDuplicates();
 
-    for (const [version, bucket] of this.bundlesByVersion) {
+    for (const [version, bundle] of this.bundlesByVersion) {
       const totalCount =
-        bucket.fastInstanceCommands.length +
-        bucket.slowInstanceCommands.length +
-        bucket.workspaceCommands.length;
+        bundle.fastInstanceCommands.length +
+        bundle.slowInstanceCommands.length +
+        bundle.workspaceCommands.length;
 
       if (totalCount > 0) {
         this.logger.log(
-          `Registered ${bucket.fastInstanceCommands.length} fast instance, ${bucket.slowInstanceCommands.length} slow instance, and ${bucket.workspaceCommands.length} workspace command(s) for ${version}`,
+          `Registered ${bundle.fastInstanceCommands.length} fast instance, ${bundle.slowInstanceCommands.length} slow instance, and ${bundle.workspaceCommands.length} workspace command(s) for ${version}`,
         );
       }
     }
@@ -185,29 +185,29 @@ export class UpgradeCommandRegistryService implements OnModuleInit {
   }
 
   private validateNoDuplicates(): void {
-    for (const [version, bucket] of this.bundlesByVersion) {
+    for (const [version, bundle] of this.bundlesByVersion) {
       this.validateNoTimestampDuplicatesWithinKind(
         version,
         'fast-instance',
-        bucket.fastInstanceCommands,
+        bundle.fastInstanceCommands,
       );
       this.validateNoTimestampDuplicatesWithinKind(
         version,
         'slow-instance',
-        bucket.slowInstanceCommands,
+        bundle.slowInstanceCommands,
       );
       this.validateNoTimestampDuplicatesWithinKind(
         version,
         'workspace',
-        bucket.workspaceCommands,
+        bundle.workspaceCommands,
       );
 
       const seenNames = new Set<string>();
 
       const allNames = [
-        ...bucket.fastInstanceCommands.map((entry) => entry.name),
-        ...bucket.slowInstanceCommands.map((entry) => entry.name),
-        ...bucket.workspaceCommands.map((entry) => entry.name),
+        ...bundle.fastInstanceCommands.map((entry) => entry.name),
+        ...bundle.slowInstanceCommands.map((entry) => entry.name),
+        ...bundle.workspaceCommands.map((entry) => entry.name),
       ];
 
       for (const name of allNames) {

--- a/packages/twenty-server/src/engine/core-modules/upgrade/services/upgrade-command-registry.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/upgrade/services/upgrade-command-registry.service.ts
@@ -17,19 +17,19 @@ type WorkspaceCommand =
   | WorkspaceCommandRunner
   | ActiveOrSuspendedWorkspaceCommandRunner;
 
-type RegisteredFastInstanceCommand = {
+export type RegisteredFastInstanceCommand = {
   name: string;
   command: FastInstanceCommand;
   timestamp: number;
 };
 
-type RegisteredSlowInstanceCommand = {
+export type RegisteredSlowInstanceCommand = {
   name: string;
   command: SlowInstanceCommand;
   timestamp: number;
 };
 
-type RegisteredWorkspaceCommand = {
+export type RegisteredWorkspaceCommand = {
   name: string;
   command: WorkspaceCommand;
   timestamp: number;
@@ -156,65 +156,37 @@ export class UpgradeCommandRegistryService implements OnModuleInit {
 
   getFastInstanceCommandsForVersion(
     version: UpgradeCommandVersion,
-  ): FastInstanceCommand[] {
-    return (
-      this.bucketsByVersion
-        .get(version)
-        ?.fastInstanceCommands.map((entry) => entry.command) ?? []
-    );
+  ): RegisteredFastInstanceCommand[] {
+    return this.bucketsByVersion.get(version)?.fastInstanceCommands ?? [];
   }
 
   getSlowInstanceCommandsForVersion(
     version: UpgradeCommandVersion,
-  ): SlowInstanceCommand[] {
-    return (
-      this.bucketsByVersion
-        .get(version)
-        ?.slowInstanceCommands.map((entry) => entry.command) ?? []
-    );
+  ): RegisteredSlowInstanceCommand[] {
+    return this.bucketsByVersion.get(version)?.slowInstanceCommands ?? [];
   }
 
   getWorkspaceCommandsForVersion(
     version: UpgradeCommandVersion,
-  ): WorkspaceCommand[] {
-    return (
-      this.bucketsByVersion
-        .get(version)
-        ?.workspaceCommands.map((entry) => entry.command) ?? []
-    );
+  ): RegisteredWorkspaceCommand[] {
+    return this.bucketsByVersion.get(version)?.workspaceCommands ?? [];
   }
 
-  getAllFastInstanceCommands(): {
-    version: UpgradeCommandVersion;
-    migration: FastInstanceCommand;
-  }[] {
-    const result: {
-      version: UpgradeCommandVersion;
-      migration: FastInstanceCommand;
-    }[] = [];
+  getAllFastInstanceCommands(): RegisteredFastInstanceCommand[] {
+    const result: RegisteredFastInstanceCommand[] = [];
 
     for (const version of UPGRADE_COMMAND_SUPPORTED_VERSIONS) {
-      for (const command of this.getFastInstanceCommandsForVersion(version)) {
-        result.push({ version, migration: command });
-      }
+      result.push(...this.getFastInstanceCommandsForVersion(version));
     }
 
     return result;
   }
 
-  getAllSlowInstanceCommands(): {
-    version: UpgradeCommandVersion;
-    migration: SlowInstanceCommand;
-  }[] {
-    const result: {
-      version: UpgradeCommandVersion;
-      migration: SlowInstanceCommand;
-    }[] = [];
+  getAllSlowInstanceCommands(): RegisteredSlowInstanceCommand[] {
+    const result: RegisteredSlowInstanceCommand[] = [];
 
     for (const version of UPGRADE_COMMAND_SUPPORTED_VERSIONS) {
-      for (const command of this.getSlowInstanceCommandsForVersion(version)) {
-        result.push({ version, migration: command });
-      }
+      result.push(...this.getSlowInstanceCommandsForVersion(version));
     }
 
     return result;

--- a/packages/twenty-server/src/engine/core-modules/upgrade/services/upgrade-command-registry.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/upgrade/services/upgrade-command-registry.service.ts
@@ -35,7 +35,7 @@ export type RegisteredWorkspaceCommand = {
   timestamp: number;
 };
 
-type VersionBucket = {
+export type VersionBucket = {
   fastInstanceCommands: RegisteredFastInstanceCommand[];
   slowInstanceCommands: RegisteredSlowInstanceCommand[];
   workspaceCommands: RegisteredWorkspaceCommand[];
@@ -154,42 +154,26 @@ export class UpgradeCommandRegistryService implements OnModuleInit {
     }
   }
 
-  getFastInstanceCommandsForVersion(
-    version: UpgradeCommandVersion,
-  ): RegisteredFastInstanceCommand[] {
-    return this.bucketsByVersion.get(version)?.fastInstanceCommands ?? [];
-  }
+  private static readonly EMPTY_BUCKET: VersionBucket = {
+    fastInstanceCommands: [],
+    slowInstanceCommands: [],
+    workspaceCommands: [],
+  };
 
-  getSlowInstanceCommandsForVersion(
-    version: UpgradeCommandVersion,
-  ): RegisteredSlowInstanceCommand[] {
-    return this.bucketsByVersion.get(version)?.slowInstanceCommands ?? [];
-  }
-
-  getWorkspaceCommandsForVersion(
-    version: UpgradeCommandVersion,
-  ): RegisteredWorkspaceCommand[] {
-    return this.bucketsByVersion.get(version)?.workspaceCommands ?? [];
+  getBucketForVersion(version: UpgradeCommandVersion): VersionBucket {
+    return this.bucketsByVersion.get(version) ?? UpgradeCommandRegistryService.EMPTY_BUCKET;
   }
 
   getAllFastInstanceCommands(): RegisteredFastInstanceCommand[] {
-    const result: RegisteredFastInstanceCommand[] = [];
-
-    for (const version of UPGRADE_COMMAND_SUPPORTED_VERSIONS) {
-      result.push(...this.getFastInstanceCommandsForVersion(version));
-    }
-
-    return result;
+    return UPGRADE_COMMAND_SUPPORTED_VERSIONS.flatMap(
+      (version) => this.getBucketForVersion(version).fastInstanceCommands,
+    );
   }
 
   getAllSlowInstanceCommands(): RegisteredSlowInstanceCommand[] {
-    const result: RegisteredSlowInstanceCommand[] = [];
-
-    for (const version of UPGRADE_COMMAND_SUPPORTED_VERSIONS) {
-      result.push(...this.getSlowInstanceCommandsForVersion(version));
-    }
-
-    return result;
+    return UPGRADE_COMMAND_SUPPORTED_VERSIONS.flatMap(
+      (version) => this.getBucketForVersion(version).slowInstanceCommands,
+    );
   }
 
   private computeCommandName(


### PR DESCRIPTION
# Introduction
This PR introduces the slow instance commands pattern, that allow migrating data in prior of the schema migration, that would fail if not.

Slow instance commands runs after the fast instance commands and before the workspace commands.
On twenty instance that do not has any active or suspended workspace the data migration part is skipped but the migration still runs, especially for fresh installs

We were previously hacking through typeorm transaction system to gain such granularity using save points:
```ts
export class AddPayloadToCommandMenuItem1775129635528
  implements MigrationInterface
{
  name = 'AddPayloadToCommandMenuItem1775129635528';

  public async up(queryRunner: QueryRunner): Promise<void> {
    await queryRunner.query(
      `ALTER TABLE "core"."commandMenuItem" ADD "payload" jsonb`,
    );

    const savepointName =
      'sp_add_payload_check_constraint_to_command_menu_item';

    try {
      await queryRunner.query(`SAVEPOINT ${savepointName}`);

      await addPayloadCheckConstraintToCommandMenuItem(queryRunner);

      await queryRunner.query(`RELEASE SAVEPOINT ${savepointName}`);
    } catch (e) {
      try {
        await queryRunner.query(`ROLLBACK TO SAVEPOINT ${savepointName}`);
        await queryRunner.query(`RELEASE SAVEPOINT ${savepointName}`);
      } catch (rollbackError) {
        // oxlint-disable-next-line no-console
        console.error(
          'Failed to rollback to savepoint in AddPayloadToCommandMenuItem1775129635528',
          rollbackError,
        );
        throw rollbackError;
      }

      // oxlint-disable-next-line no-console
      console.error(
        'Swallowing AddPayloadToCommandMenuItem1775129635528 error',
        e,
      );
    }
  }
```

It was afterwards re-applied within an workspace commands, it was hacky and missleading for the self host having false positive in logs

## New pattern

Generate the slow instance command
```
npx nx database:migrate:generate twenty-server -- --name add-foo-bar-columns --type slow
```

```ts
import { DataSource, QueryRunner } from 'typeorm';

import { RegisteredInstanceCommand } from 'src/engine/core-modules/upgrade/decorators/registered-instance-command.decorator';
import { SlowInstanceCommand } from 'src/engine/core-modules/upgrade/interfaces/slow-instance-command.interface';

@RegisteredInstanceCommand('1.21.0', 1775640902366, { type: 'slow' })
export class AddPrastoinColToWorkspaceSlowInstanceCommand implements SlowInstanceCommand {
  async runDataMigration(dataSource: DataSource): Promise<void> {
    // TODO: implement data backfill before the DDL migration
  }

  public async up(queryRunner: QueryRunner): Promise<void> {
    await queryRunner.query('ALTER TABLE "core"."workspace" ADD "prastoin" character varying');
  }

  public async down(queryRunner: QueryRunner): Promise<void> {
    await queryRunner.query('ALTER TABLE "core"."workspace" DROP COLUMN "prastoin"');
  }
}
```

### Why `run-instance-commands` and `upgrade` remain separate commands

These two commands serve fundamentally different purposes with incompatible scoping semantics:
The run-instance-commands iterates over all the legacy typeorm and the instance commands of all versions, used for database init and so on. we could be centralizing both but the readability tradeoff isn't worth it

In the future thanks to the cross-version pattern we will be able to centralize them but not right now

Please note that by default the `run-instance-commands` only run the fast instance commands which is expected for our cloud prod CD