### PR TITLE
[COMMAND MENU ITEMS] Remove object metadata name from search commands

### DIFF
--- a/packages/twenty-server/src/database/commands/upgrade-version-command/1-21/1-21-upgrade-version-command.module.ts
+++ b/packages/twenty-server/src/database/commands/upgrade-version-command/1-21/1-21-upgrade-version-command.module.ts
@@ -16,6 +16,7 @@ import { DropWorkspaceMessagingFksCommand } from 'src/database/commands/upgrade-
 import { MigrateMessageFolderParentIdToExternalIdCommand } from 'src/database/commands/upgrade-version-command/1-21/1-21-workspace-command-1775500011000-migrate-message-folder-parent-id-to-external-id.command';
 import { MigrateMessagingInfrastructureToMetadataCommand } from 'src/database/commands/upgrade-version-command/1-21/1-21-workspace-command-1775500012000-migrate-messaging-infrastructure-to-metadata.command';
 import { FixMessageThreadViewAndLabelIdentifierCommand } from 'src/database/commands/upgrade-version-command/1-21/1-21-workspace-command-1775500014000-fix-message-thread-view-and-label-identifier.command';
+import { UpdateSearchCommandMenuItemLabelsCommand } from 'src/database/commands/upgrade-version-command/1-21/1-21-workspace-command-1775500015000-update-search-command-menu-item-labels.command';
 import { ApplicationModule } from 'src/engine/core-modules/application/application.module';
 import { FeatureFlagModule } from 'src/engine/core-modules/feature-flag/feature-flag.module';
 import { UserWorkspaceEntity } from 'src/engine/core-modules/user-workspace/user-workspace.entity';
@@ -66,6 +67,7 @@ import { WorkspaceMigrationModule } from 'src/engine/workspace-manager/workspace
     MigrateMessageFolderParentIdToExternalIdCommand,
     MigrateMessagingInfrastructureToMetadataCommand,
     FixMessageThreadViewAndLabelIdentifierCommand,
+    UpdateSearchCommandMenuItemLabelsCommand,
   ],
 })
 export class V1_21_UpgradeVersionCommandModule {}

--- a/packages/twenty-server/src/database/commands/upgrade-version-command/1-21/1-21-workspace-command-1775500015000-update-search-command-menu-item-labels.command.ts
+++ b/packages/twenty-server/src/database/commands/upgrade-version-command/1-21/1-21-workspace-command-1775500015000-update-search-command-menu-item-labels.command.ts
@@ -1,0 +1,139 @@
+import { Command } from 'nest-commander';
+import { isDefined } from 'twenty-shared/utils';
+
+import { ActiveOrSuspendedWorkspaceCommandRunner } from 'src/database/commands/command-runners/active-or-suspended-workspace.command-runner';
+import { WorkspaceIteratorService } from 'src/database/commands/command-runners/workspace-iterator.service';
+import { type RunOnWorkspaceArgs } from 'src/database/commands/command-runners/workspace.command-runner';
+import { ApplicationService } from 'src/engine/core-modules/application/application.service';
+import { RegisteredWorkspaceCommand } from 'src/engine/core-modules/upgrade/decorators/registered-workspace-command.decorator';
+import { WorkspaceCacheService } from 'src/engine/workspace-cache/services/workspace-cache.service';
+import { STANDARD_COMMAND_MENU_ITEMS } from 'src/engine/workspace-manager/twenty-standard-application/constants/standard-command-menu-item.constant';
+import { computeTwentyStandardApplicationAllFlatEntityMaps } from 'src/engine/workspace-manager/twenty-standard-application/utils/twenty-standard-application-all-flat-entity-maps.constant';
+import { WorkspaceMigrationValidateBuildAndRunService } from 'src/engine/workspace-manager/workspace-migration/services/workspace-migration-validate-build-and-run-service';
+
+const UNIVERSAL_IDENTIFIERS_TO_FIX = new Set<string>([
+  STANDARD_COMMAND_MENU_ITEMS.searchRecords.universalIdentifier,
+  STANDARD_COMMAND_MENU_ITEMS.searchRecordsFallback.universalIdentifier,
+]);
+
+@RegisteredWorkspaceCommand('1.21.0', 1775500015000)
+@Command({
+  name: 'upgrade:1-21:update-search-command-menu-item-labels',
+  description:
+    'Update search command menu item labels to remove objectMetadata name',
+})
+export class UpdateSearchCommandMenuItemLabelsCommand extends ActiveOrSuspendedWorkspaceCommandRunner {
+  constructor(
+    protected readonly workspaceIteratorService: WorkspaceIteratorService,
+    private readonly applicationService: ApplicationService,
+    private readonly workspaceMigrationValidateBuildAndRunService: WorkspaceMigrationValidateBuildAndRunService,
+    private readonly workspaceCacheService: WorkspaceCacheService,
+  ) {
+    super(workspaceIteratorService);
+  }
+
+  override async runOnWorkspace({
+    workspaceId,
+    options,
+  }: RunOnWorkspaceArgs): Promise<void> {
+    const isDryRun = options.dryRun ?? false;
+
+    this.logger.log(
+      `${isDryRun ? '[DRY RUN] ' : ''}Starting search label update for workspace ${workspaceId}`,
+    );
+
+    const { twentyStandardFlatApplication } =
+      await this.applicationService.findWorkspaceTwentyStandardAndCustomApplicationOrThrow(
+        { workspaceId },
+      );
+
+    const { flatCommandMenuItemMaps: existingFlatCommandMenuItemMaps } =
+      await this.workspaceCacheService.getOrRecompute(workspaceId, [
+        'flatCommandMenuItemMaps',
+      ]);
+
+    const { allFlatEntityMaps: standardAllFlatEntityMaps } =
+      computeTwentyStandardApplicationAllFlatEntityMaps({
+        now: new Date().toISOString(),
+        workspaceId,
+        twentyStandardApplicationId: twentyStandardFlatApplication.id,
+      });
+
+    const itemsToUpdate = [...UNIVERSAL_IDENTIFIERS_TO_FIX]
+      .map((universalIdentifier) => {
+        const standardItem =
+          standardAllFlatEntityMaps.flatCommandMenuItemMaps
+            .byUniversalIdentifier[universalIdentifier];
+
+        const existingItem =
+          existingFlatCommandMenuItemMaps.byUniversalIdentifier[
+            universalIdentifier
+          ];
+
+        if (
+          !isDefined(standardItem) ||
+          !isDefined(existingItem) ||
+          existingItem.label === standardItem.label
+        ) {
+          return undefined;
+        }
+
+        return {
+          ...existingItem,
+          label: standardItem.label,
+          updatedAt: new Date().toISOString(),
+        };
+      })
+      .filter(isDefined);
+
+    if (itemsToUpdate.length === 0) {
+      this.logger.log(
+        `Search command menu item labels already up to date for workspace ${workspaceId}`,
+      );
+
+      return;
+    }
+
+    this.logger.log(
+      `Found ${itemsToUpdate.length} search command menu item(s) to update for workspace ${workspaceId}`,
+    );
+
+    if (isDryRun) {
+      this.logger.log(
+        `[DRY RUN] Would update ${itemsToUpdate.length} search command menu item label(s) for workspace ${workspaceId}`,
+      );
+
+      return;
+    }
+
+    const validateAndBuildResult =
+      await this.workspaceMigrationValidateBuildAndRunService.validateBuildAndRunWorkspaceMigration(
+        {
+          allFlatEntityOperationByMetadataName: {
+            commandMenuItem: {
+              flatEntityToCreate: [],
+              flatEntityToDelete: [],
+              flatEntityToUpdate: itemsToUpdate,
+            },
+          },
+          workspaceId,
+          applicationUniversalIdentifier:
+            twentyStandardFlatApplication.universalIdentifier,
+        },
+      );
+
+    if (validateAndBuildResult.status === 'fail') {
+      this.logger.error(
+        `Failed to update search labels:\n${JSON.stringify(validateAndBuildResult, null, 2)}`,
+      );
+
+      throw new Error(
+        `Failed to update search command menu item labels for workspace ${workspaceId}`,
+      );
+    }
+
+    this.logger.log(
+      `Successfully updated ${itemsToUpdate.length} search command menu item label(s) for workspace ${workspaceId}`,
+    );
+  }
+}

--- a/packages/twenty-server/src/engine/workspace-manager/twenty-standard-application/constants/standard-command-menu-item.constant.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/twenty-standard-application/constants/standard-command-menu-item.constant.ts
@@ -605,7 +605,7 @@ export const STANDARD_COMMAND_MENU_ITEMS = {
   },
   searchRecords: {
     universalIdentifier: 'fa24e25e-68f8-4548-82ff-c7b5168b7c7d',
-    label: 'Search ${capitalize(objectMetadataItem.labelPlural)}',
+    label: 'Search',
     icon: 'IconSearch',
     isPinned: false,
     position: 40,
@@ -619,7 +619,7 @@ export const STANDARD_COMMAND_MENU_ITEMS = {
   },
   searchRecordsFallback: {
     universalIdentifier: 'c659890c-7266-46c9-bfe1-75cefff8b6d0',
-    label: 'Search ${capitalize(objectMetadataItem.labelPlural)}',
+    label: 'Search',
     icon: 'IconSearch',
     isPinned: false,
     position: 41,


### PR DESCRIPTION
Command menu items label become "Search" instead of "Search companies" or "Search people" since the search is made across all objects.