### PR TITLE
chore: revert app CI workflows to use spawn-twenty-docker-image

### DIFF
--- a/packages/create-twenty-app/src/constants/template/github/workflows/ci.yml
+++ b/packages/create-twenty-app/src/constants/template/github/workflows/ci.yml
@@ -6,15 +6,8 @@ on:
       - main
   pull_request: {}
 
-permissions:
-  contents: read
-
 env:
   TWENTY_VERSION: latest
-
-concurrency:
-  group: ci-${{ github.ref }}
-  cancel-in-progress: true
 
 jobs:
   test:
@@ -23,11 +16,12 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Spawn Twenty test instance
+      - name: Spawn Twenty instance
         id: twenty
-        uses: twentyhq/twenty/.github/actions/spawn-twenty-app-dev-test@feature/sdk-config-file-source-of-truth
+        uses: twentyhq/twenty/.github/actions/spawn-twenty-docker-image@main
         with:
           twenty-version: ${{ env.TWENTY_VERSION }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Enable Corepack
         run: corepack enable
@@ -36,7 +30,7 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version-file: '.nvmrc'
-          cache: yarn
+          cache: 'yarn'
 
       - name: Install dependencies
         run: yarn install --immutable
@@ -45,4 +39,4 @@ jobs:
         run: yarn test
         env:
           TWENTY_API_URL: ${{ steps.twenty.outputs.server-url }}
-          TWENTY_API_KEY: ${{ steps.twenty.outputs.api-key }}
+          TWENTY_API_KEY: ${{ steps.twenty.outputs.access-token }}

--- a/packages/twenty-apps/examples/hello-world/.github/workflows/ci.yml
+++ b/packages/twenty-apps/examples/hello-world/.github/workflows/ci.yml
@@ -6,15 +6,8 @@ on:
       - main
   pull_request: {}
 
-permissions:
-  contents: read
-
 env:
   TWENTY_VERSION: latest
-
-concurrency:
-  group: ci-${{ github.ref }}
-  cancel-in-progress: true
 
 jobs:
   test:
@@ -23,11 +16,12 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Spawn Twenty test instance
+      - name: Spawn Twenty instance
         id: twenty
-        uses: twentyhq/twenty/.github/actions/spawn-twenty-app-dev-test@feature/sdk-config-file-source-of-truth
+        uses: twentyhq/twenty/.github/actions/spawn-twenty-docker-image@main
         with:
           twenty-version: ${{ env.TWENTY_VERSION }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Enable Corepack
         run: corepack enable
@@ -36,7 +30,7 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version-file: '.nvmrc'
-          cache: yarn
+          cache: 'yarn'
 
       - name: Install dependencies
         run: yarn install --immutable
@@ -45,4 +39,4 @@ jobs:
         run: yarn test
         env:
           TWENTY_API_URL: ${{ steps.twenty.outputs.server-url }}
-          TWENTY_API_KEY: ${{ steps.twenty.outputs.api-key }}
+          TWENTY_API_KEY: ${{ steps.twenty.outputs.access-token }}

--- a/packages/twenty-apps/examples/postcard/.github/workflows/ci.yml
+++ b/packages/twenty-apps/examples/postcard/.github/workflows/ci.yml
@@ -6,15 +6,8 @@ on:
       - main
   pull_request: {}
 
-permissions:
-  contents: read
-
 env:
   TWENTY_VERSION: latest
-
-concurrency:
-  group: ci-${{ github.ref }}
-  cancel-in-progress: true
 
 jobs:
   test:
@@ -23,11 +16,12 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Spawn Twenty test instance
+      - name: Spawn Twenty instance
         id: twenty
-        uses: twentyhq/twenty/.github/actions/spawn-twenty-app-dev-test@feature/sdk-config-file-source-of-truth
+        uses: twentyhq/twenty/.github/actions/spawn-twenty-docker-image@main
         with:
           twenty-version: ${{ env.TWENTY_VERSION }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Enable Corepack
         run: corepack enable
@@ -36,7 +30,7 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version-file: '.nvmrc'
-          cache: yarn
+          cache: 'yarn'
 
       - name: Install dependencies
         run: yarn install --immutable
@@ -45,4 +39,4 @@ jobs:
         run: yarn test
         env:
           TWENTY_API_URL: ${{ steps.twenty.outputs.server-url }}
-          TWENTY_API_KEY: ${{ steps.twenty.outputs.api-key }}
+          TWENTY_API_KEY: ${{ steps.twenty.outputs.access-token }}


### PR DESCRIPTION
## Summary

- Reverts CI workflows in `create-twenty-app` template, `hello-world`, and `postcard` examples back to using `spawn-twenty-docker-image@main` instead of `spawn-twenty-app-dev-test@feature/sdk-config-file-source-of-truth`
- Restores `github-token` input and `access-token` output mapping
- Removes `permissions` and `concurrency` blocks that were added alongside the action change


Made with [Cursor](https://cursor.com)