### PR TITLE
Fix: Staled data on record table after merging records

### DIFF
--- a/packages/twenty-front/src/modules/object-record/record-table/virtualization/components/RecordTableVirtualizedInitialDataLoadEffect.tsx
+++ b/packages/twenty-front/src/modules/object-record/record-table/virtualization/components/RecordTableVirtualizedInitialDataLoadEffect.tsx
@@ -14,7 +14,7 @@ import { useAtomComponentState } from '@/ui/utilities/state/jotai/hooks/useAtomC
 import { useAtomFamilyStateValue } from '@/ui/utilities/state/jotai/hooks/useAtomFamilyStateValue';
 import { useGetCurrentViewOnly } from '@/views/hooks/useGetCurrentViewOnly';
 import isEmpty from 'lodash.isempty';
-import { useEffect } from 'react';
+import { useEffect, useState } from 'react';
 
 // TODO: see if we can merge the initial and load more processes, to have only one load at scroll index effect
 export const RecordTableVirtualizedInitialDataLoadEffect = () => {
@@ -24,6 +24,8 @@ export const RecordTableVirtualizedInitialDataLoadEffect = () => {
 
   const [lastRecordTableQueryIdentifier, setLastRecordTableQueryIdentifier] =
     useAtomComponentState(lastRecordTableQueryIdentifierComponentState);
+
+  const [isInitializedOnMount, setIsInitializedOnMount] = useState(false);
 
   const visibleRecordFields = useAtomComponentSelectorValue(
     visibleRecordFieldsComponentSelector,
@@ -105,6 +107,9 @@ export const RecordTableVirtualizedInitialDataLoadEffect = () => {
             shouldScrollToStart: isEmpty(lastFields),
           });
         }
+      } else if (!isInitializedOnMount) {
+        setIsInitializedOnMount(true);
+        await triggerInitialRecordTableDataLoad();
       }
     })();
   }, [
@@ -122,6 +127,8 @@ export const RecordTableVirtualizedInitialDataLoadEffect = () => {
     lastContextStoreVirtualizedVisibleRecordFields,
     setLastContextStoreVirtualizedVisibleRecordFields,
     visibleRecordFields,
+    isInitializedOnMount,
+    setIsInitializedOnMount,
   ]);
 
   return <></>;


### PR DESCRIPTION
Fix record table not refreshing after merging records

The record table's virtualization state persists across navigations, so when the table remounts after a merge redirect, none of the existing reload conditions were satisfied and the table rendered stale data.

Add an isInitializedOnMount local state to RecordTableVirtualizedInitialDataLoadEffect that guarantees a fresh triggerInitialRecordTableDataLoad on every mount, acting as a fallback when no other reload condition matches.