### PR TITLE
Fix workspace command name inserted in db

### DIFF
--- a/packages/twenty-server/src/database/commands/upgrade-version-command/upgrade.command.ts
+++ b/packages/twenty-server/src/database/commands/upgrade-version-command/upgrade.command.ts
@@ -268,7 +268,11 @@ Please roll back to that version and run the upgrade command again.`,
 
   private async runWorkspaceCommands(
     options: UpgradeCommandOptions,
-    versionContext: VersionContext,
+    {
+      currentAppVersion,
+      fromWorkspaceVersion,
+      workspaceCommands,
+    }: VersionContext,
   ) {
     return await this.workspaceIteratorService.iterate({
       workspaceIds:
@@ -282,9 +286,9 @@ Please roll back to that version and run the upgrade command again.`,
         await this.workspaceUpgradeService.upgradeWorkspace({
           iteratorContext: context,
           options,
-          fromWorkspaceVersion: versionContext.fromWorkspaceVersion,
-          currentAppVersion: versionContext.currentAppVersion,
-          workspaceCommands: versionContext.workspaceCommands,
+          fromWorkspaceVersion,
+          currentAppVersion,
+          workspaceCommands,
         });
       },
     });

--- a/packages/twenty-server/src/database/commands/upgrade-version-command/upgrade.command.ts
+++ b/packages/twenty-server/src/database/commands/upgrade-version-command/upgrade.command.ts
@@ -5,24 +5,20 @@ import { Command, CommandRunner, Option } from 'nest-commander';
 import { SemVer } from 'semver';
 import { DataSource } from 'typeorm';
 
-import { ActiveOrSuspendedWorkspaceCommandRunner } from 'src/database/commands/command-runners/active-or-suspended-workspace.command-runner';
 import { WorkspaceIteratorService } from 'src/database/commands/command-runners/workspace-iterator.service';
-import { WorkspaceCommandRunner } from 'src/database/commands/command-runners/workspace.command-runner';
 import { CommandLogger } from 'src/database/commands/logger';
 import { type UpgradeCommandVersion } from 'src/engine/constants/upgrade-command-supported-versions.constant';
 import { CoreEngineVersionService } from 'src/engine/core-engine-version/services/core-engine-version.service';
 import { InstanceUpgradeService } from 'src/engine/core-modules/upgrade/services/instance-upgrade.service';
 import {
   UpgradeCommandRegistryService,
+  type RegisteredWorkspaceCommand,
   type VersionBundle,
 } from 'src/engine/core-modules/upgrade/services/upgrade-command-registry.service';
 import { WorkspaceUpgradeService } from 'src/engine/core-modules/upgrade/services/workspace-upgrade.service';
 import { WorkspaceVersionService } from 'src/engine/workspace-manager/workspace-version/services/workspace-version.service';
 
-export type VersionCommands = (
-  | WorkspaceCommandRunner
-  | ActiveOrSuspendedWorkspaceCommandRunner
-)[];
+export type VersionCommands = RegisteredWorkspaceCommand[];
 
 export type UpgradeCommandOptions = {
   workspaceId?: Set<string>;
@@ -288,9 +284,7 @@ Please roll back to that version and run the upgrade command again.`,
           options,
           fromWorkspaceVersion: versionContext.fromWorkspaceVersion,
           currentAppVersion: versionContext.currentAppVersion,
-          workspaceCommands: versionContext.workspaceCommands.map(
-            (entry) => entry.command,
-          ),
+          workspaceCommands: versionContext.workspaceCommands,
         });
       },
     });

--- a/packages/twenty-server/src/engine/core-modules/upgrade/services/workspace-upgrade.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/upgrade/services/workspace-upgrade.service.ts
@@ -11,6 +11,7 @@ import {
   type VersionCommands,
 } from 'src/database/commands/upgrade-version-command/upgrade.command';
 import { TwentyConfigService } from 'src/engine/core-modules/twenty-config/twenty-config.service';
+import { RegisteredWorkspaceCommand } from 'src/engine/core-modules/upgrade/services/upgrade-command-registry.service';
 import { UpgradeMigrationService } from 'src/engine/core-modules/upgrade/services/upgrade-migration.service';
 import { WorkspaceEntity } from 'src/engine/core-modules/workspace/workspace.entity';
 import {
@@ -66,9 +67,9 @@ export class WorkspaceUpgradeService {
         const executedByVersion =
           this.twentyConfigService.get('APP_VERSION') ?? 'unknown';
 
-        for (const workspaceCommand of workspaceCommands) {
+        for (const workspaceCommandEntry of workspaceCommands) {
           await this.runSingleWorkspaceCommandOrThrow({
-            workspaceCommand,
+            workspaceCommandEntry,
             workspaceId,
             executedByVersion,
             options,
@@ -120,29 +121,29 @@ export class WorkspaceUpgradeService {
   }
 
   private async runSingleWorkspaceCommandOrThrow({
-    workspaceCommand,
+    workspaceCommandEntry,
     workspaceId,
     executedByVersion,
     options,
     iteratorContext,
   }: {
-    workspaceCommand: VersionCommands[number];
+    workspaceCommandEntry: RegisteredWorkspaceCommand;
     workspaceId: string;
     executedByVersion: string;
     options: UpgradeCommandOptions;
     iteratorContext: WorkspaceIteratorContext;
   }): Promise<void> {
-    const commandName = workspaceCommand.constructor.name;
+    const { name, command: workspaceCommand } = workspaceCommandEntry;
 
     const isAlreadyCompleted =
       await this.upgradeMigrationService.isLastAttemptCompleted({
-        name: commandName,
+        name,
         workspaceId,
       });
 
     if (isAlreadyCompleted) {
       this.logger.log(
-        `Workspace command ${commandName} already completed for workspace ${workspaceId}, skipping`,
+        `Workspace command ${name} already completed for workspace ${workspaceId}, skipping`,
       );
 
       return;
@@ -159,7 +160,7 @@ export class WorkspaceUpgradeService {
 
       if (!options.dryRun) {
         await this.upgradeMigrationService.markAsCompleted({
-          name: commandName,
+          name,
           workspaceId,
           executedByVersion,
         });
@@ -167,7 +168,7 @@ export class WorkspaceUpgradeService {
     } catch (error) {
       if (!options.dryRun) {
         await this.upgradeMigrationService.markAsFailed({
-          name: commandName,
+          name,
           workspaceId,
           executedByVersion,
           error,


### PR DESCRIPTION
# Introduction
Persist in the db the registry computed name that contains version_classname_timestamp to be consistent with the instance command pattern too