### PR TITLE
Fix:19331 :  It's not possible to change the stage of an opportunity by moving it in the Kanban view

### DIFF
--- a/packages/twenty-front/src/modules/object-record/record-board/hooks/__tests__/useGetShouldInitializeRecordBoardForUpdateInputs.test.tsx
+++ b/packages/twenty-front/src/modules/object-record/record-board/hooks/__tests__/useGetShouldInitializeRecordBoardForUpdateInputs.test.tsx
@@ -1,0 +1,80 @@
+import { renderHook } from '@testing-library/react';
+
+import { useActiveFieldMetadataItems } from '@/object-metadata/hooks/useActiveFieldMetadataItems';
+import { type FieldMetadataItem } from '@/object-metadata/types/FieldMetadataItem';
+import { currentRecordFiltersComponentState } from '@/object-record/record-filter/states/currentRecordFiltersComponentState';
+import { useRecordIndexContextOrThrow } from '@/object-record/record-index/contexts/RecordIndexContext';
+import { useGetShouldInitializeRecordBoardForUpdateInputs } from '@/object-record/record-board/hooks/useGetShouldInitializeRecordBoardForUpdateInputs';
+import { recordIndexGroupFieldMetadataItemComponentState } from '@/object-record/record-index/states/recordIndexGroupFieldMetadataComponentState';
+import { currentRecordSortsComponentState } from '@/object-record/record-sort/states/currentRecordSortsComponentState';
+import { useAtomComponentStateValue } from '@/ui/utilities/state/jotai/hooks/useAtomComponentStateValue';
+import { FieldMetadataType } from 'twenty-shared/types';
+
+jest.mock('@/object-metadata/hooks/useActiveFieldMetadataItems');
+jest.mock('@/object-record/record-index/contexts/RecordIndexContext');
+jest.mock('@/ui/utilities/state/jotai/hooks/useAtomComponentStateValue');
+
+const mockUseActiveFieldMetadataItems = jest.mocked(
+  useActiveFieldMetadataItems,
+);
+const mockUseRecordIndexContextOrThrow = jest.mocked(
+  useRecordIndexContextOrThrow,
+);
+const mockUseAtomComponentStateValue = jest.mocked(useAtomComponentStateValue);
+
+describe('useGetShouldInitializeRecordBoardForUpdateInputs', () => {
+  beforeEach(() => {
+    mockUseRecordIndexContextOrThrow.mockReturnValue({
+      objectMetadataItem: {
+        id: 'opportunity-object-id',
+      },
+    } as never);
+
+    mockUseActiveFieldMetadataItems.mockReturnValue({
+      activeFieldMetadataItems: [
+        {
+          id: 'stage-field-id',
+          name: 'stage',
+          type: FieldMetadataType.SELECT,
+        },
+      ] as FieldMetadataItem[],
+    });
+
+    mockUseAtomComponentStateValue.mockImplementation((state) => {
+      if (state === currentRecordSortsComponentState) {
+        return [];
+      }
+
+      if (state === currentRecordFiltersComponentState) {
+        return [];
+      }
+
+      if (state === recordIndexGroupFieldMetadataItemComponentState) {
+        return {
+          id: 'stage-field-id',
+        };
+      }
+
+      return undefined;
+    });
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should reinitialize the board for a kanban drop style stage and position update', () => {
+    const { result } = renderHook(() =>
+      useGetShouldInitializeRecordBoardForUpdateInputs(),
+    );
+
+    expect(
+      result.current.getShouldInitializeRecordBoardForUpdateInputs([
+        {
+          recordId: 'opportunity-id',
+          updatedFields: [{ stage: 'SCREENING' }, { position: 1 }],
+        },
+      ]),
+    ).toBe(true);
+  });
+});

--- a/packages/twenty-front/src/modules/object-record/record-board/hooks/useGetShouldInitializeRecordBoardForUpdateInputs.ts
+++ b/packages/twenty-front/src/modules/object-record/record-board/hooks/useGetShouldInitializeRecordBoardForUpdateInputs.ts
@@ -2,11 +2,10 @@ import { useActiveFieldMetadataItems } from '@/object-metadata/hooks/useActiveFi
 import { currentRecordFiltersComponentState } from '@/object-record/record-filter/states/currentRecordFiltersComponentState';
 import { useRecordIndexContextOrThrow } from '@/object-record/record-index/contexts/RecordIndexContext';
 import { recordIndexGroupFieldMetadataItemComponentState } from '@/object-record/record-index/states/recordIndexGroupFieldMetadataComponentState';
+import { shouldInitializeRecordBoardFromUpdateInputs } from '@/object-record/record-board/utils/shouldInitializeRecordBoardFromUpdateInputs';
 import { currentRecordSortsComponentState } from '@/object-record/record-sort/states/currentRecordSortsComponentState';
 import { type ObjectRecordOperationUpdateInput } from '@/object-record/types/ObjectRecordOperationUpdateInput';
 import { useAtomComponentStateValue } from '@/ui/utilities/state/jotai/hooks/useAtomComponentStateValue';
-import { FieldMetadataType } from 'twenty-shared/types';
-import { isDefined, mapById } from 'twenty-shared/utils';
 
 export const useGetShouldInitializeRecordBoardForUpdateInputs = () => {
   const { objectMetadataItem } = useRecordIndexContextOrThrow();
@@ -29,70 +28,14 @@ export const useGetShouldInitializeRecordBoardForUpdateInputs = () => {
 
   const getShouldInitializeRecordBoardForUpdateInputs = (
     updateInputs: ObjectRecordOperationUpdateInput[],
-  ) => {
-    const updatedFieldNames = new Set<string>();
-    let thereIsAnUpdateOnAFilteredField = false;
-    let thereIsAnUpdateOnASortedField = false;
-    let thereIsAnUpdateOnAGroupField = false;
-
-    for (const updateInput of updateInputs) {
-      const fieldNamesForUpdateInput = updateInput.updatedFields.flatMap(
-        (updatedField) => Object.keys(updatedField ?? {}),
-      );
-
-      for (const fieldName of fieldNamesForUpdateInput) {
-        updatedFieldNames.add(fieldName);
-      }
-
-      const updatedFieldMetadataItems = activeFieldMetadataItems.filter(
-        (fieldMetadataItemToFilter) =>
-          fieldNamesForUpdateInput.includes(fieldMetadataItemToFilter.name) ||
-          (fieldMetadataItemToFilter.type === FieldMetadataType.RELATION &&
-            fieldNamesForUpdateInput.includes(
-              `${fieldMetadataItemToFilter.name}Id`,
-            )),
-      );
-
-      const updatedFieldMetadataItemIds =
-        updatedFieldMetadataItems.map(mapById);
-
-      const updateOnAFilteredField = currentRecordFilters.some((recordFilter) =>
-        updatedFieldMetadataItemIds.includes(recordFilter.fieldMetadataId),
-      );
-
-      const updateOnASortedField = currentRecordSorts.some((recordSort) =>
-        updatedFieldMetadataItemIds.includes(recordSort.fieldMetadataId),
-      );
-
-      if (isDefined(recordIndexGroupFieldMetadataItem)) {
-        if (
-          updatedFieldMetadataItemIds.includes(
-            recordIndexGroupFieldMetadataItem.id,
-          )
-        ) {
-          thereIsAnUpdateOnAGroupField = true;
-        }
-      }
-
-      if (updateOnAFilteredField) {
-        thereIsAnUpdateOnAFilteredField = true;
-      }
-
-      if (updateOnASortedField) {
-        thereIsAnUpdateOnASortedField = true;
-      }
-    }
-
-    if (updatedFieldNames.has('position')) {
-      return false;
-    }
-
-    return (
-      thereIsAnUpdateOnAFilteredField ||
-      thereIsAnUpdateOnASortedField ||
-      thereIsAnUpdateOnAGroupField
-    );
-  };
+  ) =>
+    shouldInitializeRecordBoardFromUpdateInputs({
+      updateInputs,
+      activeFieldMetadataItems,
+      currentRecordFilters,
+      currentRecordSorts,
+      recordIndexGroupFieldMetadataItem,
+    });
 
   return {
     getShouldInitializeRecordBoardForUpdateInputs,

--- a/packages/twenty-front/src/modules/object-record/record-board/utils/__tests__/shouldInitializeRecordBoardFromUpdateInputs.test.ts
+++ b/packages/twenty-front/src/modules/object-record/record-board/utils/__tests__/shouldInitializeRecordBoardFromUpdateInputs.test.ts
@@ -1,0 +1,132 @@
+import { type FieldMetadataItem } from '@/object-metadata/types/FieldMetadataItem';
+import { type RecordFilter } from '@/object-record/record-filter/types/RecordFilter';
+import { type RecordSort } from '@/object-record/record-sort/types/RecordSort';
+import { shouldInitializeRecordBoardFromUpdateInputs } from '@/object-record/record-board/utils/shouldInitializeRecordBoardFromUpdateInputs';
+import { type ObjectRecordOperationUpdateInput } from '@/object-record/types/ObjectRecordOperationUpdateInput';
+import { FieldMetadataType } from 'twenty-shared/types';
+
+const activeFieldMetadataItems = [
+  {
+    id: 'stage-field-id',
+    name: 'stage',
+    type: FieldMetadataType.SELECT,
+  },
+  {
+    id: 'amount-field-id',
+    name: 'amount',
+    type: FieldMetadataType.CURRENCY,
+  },
+  {
+    id: 'name-field-id',
+    name: 'name',
+    type: FieldMetadataType.TEXT,
+  },
+  {
+    id: 'company-field-id',
+    name: 'company',
+    type: FieldMetadataType.RELATION,
+  },
+] as FieldMetadataItem[];
+
+const currentRecordFilters = [
+  {
+    fieldMetadataId: 'amount-field-id',
+  },
+] as RecordFilter[];
+
+const currentRecordSorts = [
+  {
+    fieldMetadataId: 'amount-field-id',
+  },
+] as RecordSort[];
+
+const recordIndexGroupFieldMetadataItem = {
+  id: 'stage-field-id',
+};
+
+const buildUpdateInput = (
+  updatedFields: Record<string, unknown>[],
+): ObjectRecordOperationUpdateInput => ({
+  recordId: 'record-id',
+  updatedFields,
+});
+
+describe('shouldInitializeRecordBoardFromUpdateInputs', () => {
+  it('should return true for a grouped field update without position', () => {
+    expect(
+      shouldInitializeRecordBoardFromUpdateInputs({
+        updateInputs: [buildUpdateInput([{ stage: 'SCREENING' }])],
+        activeFieldMetadataItems,
+        currentRecordFilters,
+        currentRecordSorts,
+        recordIndexGroupFieldMetadataItem,
+      }),
+    ).toBe(true);
+  });
+
+  it('should return false for a position-only update', () => {
+    expect(
+      shouldInitializeRecordBoardFromUpdateInputs({
+        updateInputs: [buildUpdateInput([{ position: 1 }])],
+        activeFieldMetadataItems,
+        currentRecordFilters,
+        currentRecordSorts,
+        recordIndexGroupFieldMetadataItem,
+      }),
+    ).toBe(false);
+  });
+
+  it('should return true for a grouped field update mixed with position', () => {
+    expect(
+      shouldInitializeRecordBoardFromUpdateInputs({
+        updateInputs: [
+          buildUpdateInput([{ stage: 'SCREENING' }, { position: 1 }]),
+        ],
+        activeFieldMetadataItems,
+        currentRecordFilters,
+        currentRecordSorts,
+        recordIndexGroupFieldMetadataItem,
+      }),
+    ).toBe(true);
+  });
+
+  it('should return true for a sorted field update mixed with position', () => {
+    expect(
+      shouldInitializeRecordBoardFromUpdateInputs({
+        updateInputs: [
+          buildUpdateInput([{ amount: { amountMicros: 1 } }, { position: 1 }]),
+        ],
+        activeFieldMetadataItems,
+        currentRecordFilters: [],
+        currentRecordSorts,
+        recordIndexGroupFieldMetadataItem,
+      }),
+    ).toBe(true);
+  });
+
+  it('should return true for a filtered field update mixed with position', () => {
+    expect(
+      shouldInitializeRecordBoardFromUpdateInputs({
+        updateInputs: [
+          buildUpdateInput([{ amount: { amountMicros: 1 } }, { position: 1 }]),
+        ],
+        activeFieldMetadataItems,
+        currentRecordFilters,
+        currentRecordSorts: [],
+        recordIndexGroupFieldMetadataItem,
+      }),
+    ).toBe(true);
+  });
+
+  it('should return false for an unrelated field update mixed with position', () => {
+    expect(
+      shouldInitializeRecordBoardFromUpdateInputs({
+        updateInputs: [buildUpdateInput([{ name: 'Updated' }, { position: 1 }])],
+        activeFieldMetadataItems,
+        currentRecordFilters,
+        currentRecordSorts,
+        recordIndexGroupFieldMetadataItem,
+      }),
+    ).toBe(false);
+  });
+});

--- a/packages/twenty-front/src/modules/object-record/record-board/utils/shouldInitializeRecordBoardFromUpdateInputs.ts
+++ b/packages/twenty-front/src/modules/object-record/record-board/utils/shouldInitializeRecordBoardFromUpdateInputs.ts
@@ -1,0 +1,61 @@
+import { type FieldMetadataItem } from '@/object-metadata/types/FieldMetadataItem';
+import { type RecordFilter } from '@/object-record/record-filter/types/RecordFilter';
+import { type RecordSort } from '@/object-record/record-sort/types/RecordSort';
+import { type ObjectRecordOperationUpdateInput } from '@/object-record/types/ObjectRecordOperationUpdateInput';
+import { FieldMetadataType } from 'twenty-shared/types';
+import { isDefined, mapById } from 'twenty-shared/utils';
+
+type ShouldInitializeRecordBoardFromUpdateInputsArgs = {
+  updateInputs: ObjectRecordOperationUpdateInput[];
+  activeFieldMetadataItems: FieldMetadataItem[];
+  currentRecordFilters: RecordFilter[];
+  currentRecordSorts: RecordSort[];
+  recordIndexGroupFieldMetadataItem?: Pick<FieldMetadataItem, 'id'> | null;
+};
+
+export const shouldInitializeRecordBoardFromUpdateInputs = ({
+  updateInputs,
+  activeFieldMetadataItems,
+  currentRecordFilters,
+  currentRecordSorts,
+  recordIndexGroupFieldMetadataItem,
+}: ShouldInitializeRecordBoardFromUpdateInputsArgs) => {
+  for (const updateInput of updateInputs) {
+    const fieldNamesForUpdateInput = updateInput.updatedFields.flatMap(
+      (updatedField) => Object.keys(updatedField ?? {}),
+    );
+
+    const updatedFieldMetadataItems = activeFieldMetadataItems.filter(
+      (fieldMetadataItemToFilter) =>
+        fieldNamesForUpdateInput.includes(fieldMetadataItemToFilter.name) ||
+        (fieldMetadataItemToFilter.type === FieldMetadataType.RELATION &&
+          fieldNamesForUpdateInput.includes(
+            `${fieldMetadataItemToFilter.name}Id`,
+          )),
+    );
+
+    const updatedFieldMetadataItemIds = updatedFieldMetadataItems.map(mapById);
+
+    const updateOnAFilteredField = currentRecordFilters.some((recordFilter) =>
+      updatedFieldMetadataItemIds.includes(recordFilter.fieldMetadataId),
+    );
+
+    const updateOnASortedField = currentRecordSorts.some((recordSort) =>
+      updatedFieldMetadataItemIds.includes(recordSort.fieldMetadataId),
+    );
+
+    const updateOnAGroupField =
+      isDefined(recordIndexGroupFieldMetadataItem) &&
+      updatedFieldMetadataItemIds.includes(recordIndexGroupFieldMetadataItem.id);
+
+    if (
+      updateOnAFilteredField ||
+      updateOnASortedField ||
+      updateOnAGroupField
+    ) {
+      return true;
+    }
+  }
+
+  return false;
+};


### PR DESCRIPTION
The change fixes a mismatch between two update paths.

When you edit an opportunity directly, the app sends only stage, so the board knows “this record may belong in a different column” and reloads. But when you drag a card in kanban, the app sends both stage and position. The old logic treated any update containing position as a pure reorder and skipped the board refresh entirely. That meant a cross-column move could be optimistically shown first, then the board state stayed stale and the card appeared to jump back.

What I changed is:

I moved the refresh decision into a pure helper at shouldInitializeRecordBoardFromUpdateInputs.ts.
I updated useGetShouldInitializeRecordBoardForUpdateInputs.ts to use that helper instead of the old if (updatedFieldNames.has('position')) return false rule.
The new behavior is:

position only: no board reinit, because that’s a same-column reorder.
stage only: reinit.
stage + position: reinit.
filtered field + position: reinit.
sorted field + position: reinit.
unrelated field + position: no reinit.
I also added tests:

shouldInitializeRecordBoardFromUpdateInputs.test.ts covers the decision matrix directly.
useGetShouldInitializeRecordBoardForUpdateInputs.test.tsx adds a regression test for the kanban-style stage + position update.
So the intent was to keep fast optimistic drag behavior for real reorders, while making cross-stage kanban moves refresh correctly and stop snapping back.