### PR TITLE
fix(ai-chat): preload web_search action tool when driver is enabled

### DIFF
--- a/packages/twenty-server/src/database/commands/upgrade-version-command/1-21/1-21-workspace-command-1775500014000-fix-message-thread-view-and-label-identifier.command.ts
+++ b/packages/twenty-server/src/database/commands/upgrade-version-command/1-21/1-21-workspace-command-1775500014000-fix-message-thread-view-and-label-identifier.command.ts
@@ -155,6 +155,7 @@ export class FixMessageThreadViewAndLabelIdentifierCommand extends ActiveOrSuspe
           workspaceId,
           applicationUniversalIdentifier:
             twentyStandardFlatApplication.universalIdentifier,
+          isSystemBuild: true,
         },
       );
 

--- a/packages/twenty-server/src/engine/metadata-modules/ai/ai-chat/services/chat-execution.service.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/ai/ai-chat/services/chat-execution.service.ts
@@ -142,8 +142,15 @@ export class ChatExecutionService {
       `Built tool catalog with ${toolCatalog.length} tools, ${skillCatalog.length} skills available`,
     );
 
+    const useNativeSearch = this.webSearchService.shouldUseNativeSearch();
+
+    const toolNamesToPreload = [
+      ...COMMON_PRELOAD_TOOLS,
+      ...(useNativeSearch ? [] : ['web_search']),
+    ];
+
     const preloadedTools = await this.toolRegistry.getToolsByName(
-      COMMON_PRELOAD_TOOLS,
+      toolNamesToPreload,
       toolContext,
     );
 
@@ -162,8 +169,6 @@ export class ChatExecutionService {
     const modelConfig = this.aiModelRegistryService.getEffectiveModelConfig(
       registeredModel.modelId,
     );
-
-    const useNativeSearch = this.webSearchService.shouldUseNativeSearch();
 
     const { tools: nativeSearchTools, callableToolNames: searchToolNames } =
       useNativeSearch


### PR DESCRIPTION
## Summary
- When `WEB_SEARCH_DRIVER` is set to a non-native driver (e.g. `EXA`), the `web_search` action tool was only listed in the tool catalog and had to be discovered via `learn_tools` before use. Worse, `system-prompt-builder` explicitly instructed the model **not** to call `web_search` whenever it wasn't in the preloaded set, so even setting `EXA_API_KEY` correctly resulted in the model never calling Exa.
- Fix: preload `web_search` from the registry alongside the other action tools when `shouldUseNativeSearch()` is false, mirroring how native provider search is already injected into `directTools`. The system prompt builder picks this up automatically and advertises `web_search` as a ready-to-use tool.
- Unrelated: pass `isSystemBuild: true` to the messageThread upgrade command's migration build.

## Test plan
- [ ] With `WEB_SEARCH_DRIVER=EXA` and `EXA_API_KEY` set, ask the chat agent for current/news information and verify it calls `web_search` directly (not via `learn_tools` / `execute_tool`) and that Exa is hit.
- [ ] With `WEB_SEARCH_PREFER_NATIVE=true`, verify native provider search is still used and the action tool is not preloaded.
- [ ] With `WEB_SEARCH_DRIVER=DISABLED`, verify behavior is unchanged (`shouldUseNativeSearch()` returns true → no Exa preload).
- [ ] Run the 1-21 fix-message-thread-view-and-label-identifier upgrade command on a workspace and confirm the migration builds/runs as a system build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)