### PR TITLE
[COMMAND MENU ITEMS] Disable hide label toggle for items with no short label

### DIFF
--- a/packages/twenty-front/src/modules/command-menu-item/server-items/edit/components/CommandMenuItemOptionsDropdown.tsx
+++ b/packages/twenty-front/src/modules/command-menu-item/server-items/edit/components/CommandMenuItemOptionsDropdown.tsx
@@ -67,7 +67,7 @@ export const CommandMenuItemOptionsDropdown = ({
             <MenuItemToggle
               LeftIcon={IconTag}
               text={t`Hide label`}
-              toggled={isLabelHidden}
+              toggled={isLabelHidden || hasNoShortLabel}
               onToggleChange={handleToggleHideLabel}
               toggleSize="small"
               disabled={hasNoShortLabel}

--- a/packages/twenty-front/src/modules/command-menu-item/server-items/edit/components/CommandMenuItemOptionsDropdown.tsx
+++ b/packages/twenty-front/src/modules/command-menu-item/server-items/edit/components/CommandMenuItemOptionsDropdown.tsx
@@ -37,6 +37,7 @@ export const CommandMenuItemOptionsDropdown = ({
 
   const normalizedServerShortLabel = serverShortLabel ?? null;
   const normalizedShortLabel = shortLabel ?? null;
+  const hasNoShortLabel = normalizedServerShortLabel === null;
   const isLabelHidden =
     normalizedShortLabel === null && isDefined(normalizedServerShortLabel);
   const hasShortLabelOverride =
@@ -69,6 +70,7 @@ export const CommandMenuItemOptionsDropdown = ({
               toggled={isLabelHidden}
               onToggleChange={handleToggleHideLabel}
               toggleSize="small"
+              disabled={hasNoShortLabel}
             />
             <MenuItem
               LeftIcon={IconRefresh}


### PR DESCRIPTION
<img width="824" height="1140" alt="CleanShot 2026-04-08 at 18 08 31@2x" src="https://github.com/user-attachments/assets/67989cd7-ac0f-4c28-b128-6db50abecc88" />
