### PR TITLE
Fix address autocomplete street formatting

### DIFF
--- a/packages/twenty-front/src/modules/geo-map/graphql-query/__tests__/geo-map-appolo.api.test.ts
+++ b/packages/twenty-front/src/modules/geo-map/graphql-query/__tests__/geo-map-appolo.api.test.ts
@@ -133,17 +133,19 @@ describe('geo-map GraphQL queries', () => {
       const fields = selectionSet.selections.map((s: any) => s.name.value);
 
       expect(fields).toContain('state');
+      expect(fields).toContain('street');
       expect(fields).toContain('postcode');
       expect(fields).toContain('city');
       expect(fields).toContain('country');
       expect(fields).toContain('location');
-      expect(fields).toHaveLength(5);
+      expect(fields).toHaveLength(6);
     });
 
     it('should match the expected query string', () => {
       const expectedQuery = gql`
         query GetAddressDetails($placeId: String!, $token: String!) {
           getAddressDetails(placeId: $placeId, token: $token) {
+            street
             state
             postcode
             city

--- a/packages/twenty-front/src/modules/geo-map/graphql-query/geo-map-appolo.api.ts
+++ b/packages/twenty-front/src/modules/geo-map/graphql-query/geo-map-appolo.api.ts
@@ -22,6 +22,7 @@ export const GET_AUTOCOMPLETE_QUERY = gql`
 export const GET_PLACE_DETAILS_QUERY = gql`
   query GetAddressDetails($placeId: String!, $token: String!) {
     getAddressDetails(placeId: $placeId, token: $token) {
+      street
       state
       postcode
       city

--- a/packages/twenty-front/src/modules/geo-map/types/__tests__/placeApi.test.ts
+++ b/packages/twenty-front/src/modules/geo-map/types/__tests__/placeApi.test.ts
@@ -122,12 +122,14 @@ describe('placeApi types', () => {
   describe('PlaceDetailsResult', () => {
     it('should have correct structure with all fields', () => {
       const result: PlaceDetailsResult = {
+        street: '987 Rodeo Dr',
         state: 'California',
         postcode: '90210',
         city: 'Beverly Hills',
         country: 'United States',
       };
 
+      expect(result.street).toBe('987 Rodeo Dr');
       expect(result.state).toBe('California');
       expect(result.postcode).toBe('90210');
       expect(result.city).toBe('Beverly Hills');
@@ -144,16 +146,19 @@ describe('placeApi types', () => {
       expect(resultWithMissingFields.country).toBe('France');
       expect(resultWithMissingFields.state).toBeUndefined();
       expect(resultWithMissingFields.postcode).toBeUndefined();
+      expect(resultWithMissingFields.street).toBeUndefined();
     });
 
     it('should handle undefined values', () => {
       const result: PlaceDetailsResult = {
+        street: undefined,
         state: undefined,
         postcode: undefined,
         city: 'London',
         country: 'United Kingdom',
       };
 
+      expect(result.street).toBeUndefined();
       expect(result.state).toBeUndefined();
       expect(result.postcode).toBeUndefined();
       expect(result.city).toBe('London');
@@ -162,12 +167,14 @@ describe('placeApi types', () => {
 
     it('should handle all undefined values', () => {
       const result: PlaceDetailsResult = {
+        street: undefined,
         state: undefined,
         postcode: undefined,
         city: undefined,
         country: undefined,
       };
 
+      expect(result.street).toBeUndefined();
       expect(result.state).toBeUndefined();
       expect(result.postcode).toBeUndefined();
       expect(result.city).toBeUndefined();
@@ -176,12 +183,16 @@ describe('placeApi types', () => {
 
     it('should enforce string or undefined types', () => {
       const result: PlaceDetailsResult = {
+        street: '5th Avenue',
         state: 'New York',
         postcode: '10001',
         city: 'New York City',
         country: 'United States',
       };
 
+      expect(
+        typeof result.street === 'string' || result.street === undefined,
+      ).toBe(true);
       expect(
         typeof result.state === 'string' || result.state === undefined,
       ).toBe(true);
@@ -198,6 +209,7 @@ describe('placeApi types', () => {
 
     it('should handle international addresses', () => {
       const japaneseResult: PlaceDetailsResult = {
+        street: '千代田1-1',
         state: '東京都',
         postcode: '100-0001',
         city: '東京',
@@ -205,6 +217,7 @@ describe('placeApi types', () => {
       };
 
       const frenchResult: PlaceDetailsResult = {
+        street: '10 Rue de Rivoli',
         state: 'Île-de-France',
         postcode: '75001',
         city: 'Paris',

--- a/packages/twenty-front/src/modules/geo-map/types/placeApi.ts
+++ b/packages/twenty-front/src/modules/geo-map/types/placeApi.ts
@@ -13,6 +13,7 @@ export type PlaceAutocompleteResult = {
 };
 
 export type PlaceDetailsResult = {
+  street?: string;
   state?: string;
   postcode?: string;
   city?: string;

--- a/packages/twenty-front/src/modules/ui/field/input/hooks/__tests__/useAddressAutocomplete.test.tsx
+++ b/packages/twenty-front/src/modules/ui/field/input/hooks/__tests__/useAddressAutocomplete.test.tsx
@@ -140,6 +140,42 @@ describe('useAddressAutocomplete', () => {
     });
   });
 
+  it('should prefer the parsed street over the raw autocomplete text', async () => {
+    const mockOnChange = jest.fn();
+    const mockPlaceData = {
+      street: '123 Main St',
+      city: 'New York',
+      state: 'NY',
+      country: 'US',
+      postcode: '10001',
+      location: { lat: 40.7128, lng: -74.006 },
+    };
+
+    mockGetPlaceDetailsData.mockResolvedValue(mockPlaceData);
+    mockFindCountryNameByCountryCode.mockReturnValue('United States');
+
+    const { result } = renderHook(() => useAddressAutocomplete(mockOnChange));
+
+    await act(async () => {
+      await result.current.autoFillInputsFromPlaceDetails(
+        'place123',
+        'token123',
+        '123 Main St, New York, NY 10001, USA',
+      );
+    });
+
+    expect(mockOnChange).toHaveBeenCalledWith({
+      addressStreet1: '123 Main St',
+      addressStreet2: null,
+      addressCity: 'New York',
+      addressState: 'NY',
+      addressCountry: 'United States',
+      addressPostcode: '10001',
+      addressLat: 40.7128,
+      addressLng: -74.006,
+    });
+  });
+
   it('should preserve existing values when place data is missing', async () => {
     const mockOnChange = jest.fn();
     const mockPlaceData = {

--- a/packages/twenty-front/src/modules/ui/field/input/hooks/useAddressAutocomplete.ts
+++ b/packages/twenty-front/src/modules/ui/field/input/hooks/useAddressAutocomplete.ts
@@ -80,7 +80,10 @@ export const useAddressAutocomplete = (
       const countryName = findCountryNameByCountryCode(placeData?.country);
 
       const updatedAddress = {
-        addressStreet1: addressStreet1 || (internalValue?.addressStreet1 ?? ''),
+        addressStreet1:
+          placeData?.street ||
+          addressStreet1 ||
+          (internalValue?.addressStreet1 ?? ''),
         addressStreet2: internalValue?.addressStreet2 ?? null,
         addressCity: placeData?.city || (internalValue?.addressCity ?? null),
         addressState: placeData?.state || (internalValue?.addressState ?? null),

--- a/packages/twenty-server/src/engine/core-modules/geo-map/dtos/place-details-result.dto.ts
+++ b/packages/twenty-server/src/engine/core-modules/geo-map/dtos/place-details-result.dto.ts
@@ -12,6 +12,9 @@ export class LocationDTO {
 @ObjectType('PlaceDetailsResult')
 export class PlaceDetailsResultDTO {
   @Field({ nullable: true })
+  street?: string;
+
+  @Field({ nullable: true })
   state?: string;
 
   @Field({ nullable: true })

--- a/packages/twenty-server/src/engine/core-modules/geo-map/utils/sanitize-place-details-results.util.spec.ts
+++ b/packages/twenty-server/src/engine/core-modules/geo-map/utils/sanitize-place-details-results.util.spec.ts
@@ -1,0 +1,68 @@
+import { sanitizePlaceDetailsResults } from './sanitize-place-details-results.util';
+
+describe('sanitizePlaceDetailsResults', () => {
+  it('should extract street details from address components', () => {
+    const result = sanitizePlaceDetailsResults(
+      [
+        {
+          long_name: '123',
+          short_name: '123',
+          types: ['street_number'],
+        },
+        {
+          long_name: 'Main St',
+          short_name: 'Main St',
+          types: ['route'],
+        },
+        {
+          long_name: 'Springfield',
+          short_name: 'Springfield',
+          types: ['locality'],
+        },
+        {
+          long_name: 'Illinois',
+          short_name: 'IL',
+          types: ['administrative_area_level_1'],
+        },
+        {
+          long_name: '62704',
+          short_name: '62704',
+          types: ['postal_code'],
+        },
+        {
+          long_name: 'United States',
+          short_name: 'US',
+          types: ['country'],
+        },
+      ],
+      { lat: 39.7817, lng: -89.6501 },
+    );
+
+    expect(result).toEqual({
+      street: '123 Main St',
+      city: 'Springfield',
+      state: 'Illinois',
+      postcode: '62704',
+      country: 'US',
+      location: { lat: 39.7817, lng: -89.6501 },
+    });
+  });
+
+  it('should handle a route without a street number', () => {
+    const result = sanitizePlaceDetailsResults([
+      {
+        long_name: 'Broadway',
+        short_name: 'Broadway',
+        types: ['route'],
+      },
+      {
+        long_name: 'New York',
+        short_name: 'New York',
+        types: ['locality'],
+      },
+    ]);
+
+    expect(result.street).toBe('Broadway');
+    expect(result.city).toBe('New York');
+  });
+});

--- a/packages/twenty-server/src/engine/core-modules/geo-map/utils/sanitize-place-details-results.util.ts
+++ b/packages/twenty-server/src/engine/core-modules/geo-map/utils/sanitize-place-details-results.util.ts
@@ -4,6 +4,7 @@ export type AddressComponent = {
   types: string[];
 };
 export type AddressFields = {
+  street?: string;
   state?: string;
   postcode?: string;
   city?: string;
@@ -21,10 +22,22 @@ export const sanitizePlaceDetailsResults = (
   if (!AddressComponents || AddressComponents.length === 0) return {};
 
   const address: AddressFields = {};
+  let streetNumber: string | undefined;
+  let route: string | undefined;
 
   for (const AddressComponent of AddressComponents) {
     for (const type of AddressComponent.types) {
       switch (type) {
+        case 'street_number': {
+          streetNumber = AddressComponent.long_name;
+          break;
+        }
+
+        case 'route': {
+          route = AddressComponent.long_name;
+          break;
+        }
+
         case 'postal_code': {
           address.postcode =
             AddressComponent.long_name + (address.postcode ?? '');
@@ -72,6 +85,8 @@ export const sanitizePlaceDetailsResults = (
       }
     }
   }
+
+  address.street = [streetNumber, route].filter(Boolean).join(' ') || undefined;
   address.location = location;
 
   return address;


### PR DESCRIPTION
## Summary
- extract the street portion from place details and expose it in the address details payload
- prefer the parsed street value when autofilling Address 1 instead of the full autocomplete label
- add frontend and backend regression tests for the new street parsing flow

Fixes #18860

## Validation
- corepack yarn exec jest --config packages/twenty-front/jest.config.mjs packages/twenty-front/src/modules/ui/field/input/hooks/__tests__/useAddressAutocomplete.test.tsx packages/twenty-front/src/modules/geo-map/types/__tests__/placeApi.test.ts packages/twenty-front/src/modules/geo-map/graphql-query/__tests__/geo-map-appolo.api.test.ts --runInBand
- corepack yarn exec jest --config packages/twenty-server/jest.config.mjs packages/twenty-server/src/engine/core-modules/geo-map/utils/sanitize-place-details-results.util.spec.ts --runInBand
- corepack yarn prettier --check packages/twenty-front/src/modules/ui/field/input/hooks/__tests__/useAddressAutocomplete.test.tsx packages/twenty-front/src/modules/geo-map/types/__tests__/placeApi.test.ts packages/twenty-front/src/modules/geo-map/graphql-query/__tests__/geo-map-appolo.api.test.ts packages/twenty-front/src/modules/geo-map/graphql-query/geo-map-appolo.api.ts packages/twenty-front/src/modules/geo-map/types/placeApi.ts packages/twenty-front/src/modules/ui/field/input/hooks/useAddressAutocomplete.ts packages/twenty-server/src/engine/core-modules/geo-map/utils/sanitize-place-details-results.util.ts packages/twenty-server/src/engine/core-modules/geo-map/utils/sanitize-place-details-results.util.spec.ts packages/twenty-server/src/engine/core-modules/geo-map/dtos/place-details-result.dto.ts

## Notes
- The repo currently enforces Node ^24.5.0; this environment is on 24.1.0, so I ran the commands with YARN_IGNORE_NODE=1 to get targeted validation running.
- oxlint was not available as a callable binary in this environment, so I wasn't able to run the targeted lint pass here.
