### PR TITLE
Avoid reporting recoverable SSE token expiry reconnects

### DIFF
--- a/packages/twenty-front/src/modules/sse-db-event/hooks/__tests__/useTriggerEventStreamCreation.test.tsx
+++ b/packages/twenty-front/src/modules/sse-db-event/hooks/__tests__/useTriggerEventStreamCreation.test.tsx
@@ -1,0 +1,143 @@
+import { renderHook } from '@testing-library/react';
+
+import { captureException } from '@sentry/react';
+import { useStore } from 'jotai';
+
+import { useDispatchMetadataEventsFromSseToBrowserEvents } from '@/sse-db-event/hooks/useDispatchMetadataEventsFromSseToBrowserEvents';
+import { useDispatchObjectRecordEventsFromSseToBrowserEvents } from '@/sse-db-event/hooks/useDispatchObjectRecordEventsFromSseToBrowserEvents';
+import { useTriggerEventStreamCreation } from '@/sse-db-event/hooks/useTriggerEventStreamCreation';
+import { useTriggerOptimisticEffectFromSseEvents } from '@/sse-db-event/hooks/useTriggerOptimisticEffectFromSseEvents';
+import { isCreatingSseEventStreamState } from '@/sse-db-event/states/isCreatingSseEventStreamState';
+import { isDestroyingEventStreamState } from '@/sse-db-event/states/isDestroyingEventStreamState';
+import { shouldDestroyEventStreamState } from '@/sse-db-event/states/shouldDestroyEventStreamState';
+import { sseClientState } from '@/sse-db-event/states/sseClientState';
+import { sseEventStreamIdState } from '@/sse-db-event/states/sseEventStreamIdState';
+import { useSetAtomState } from '@/ui/utilities/state/jotai/hooks/useSetAtomState';
+
+jest.mock('@sentry/react', () => ({
+  captureException: jest.fn(),
+}));
+
+jest.mock('jotai', () => {
+  const actual = jest.requireActual('jotai');
+
+  return {
+    ...actual,
+    useStore: jest.fn(),
+  };
+});
+
+jest.mock('@/ui/utilities/state/jotai/hooks/useSetAtomState', () => ({
+  useSetAtomState: jest.fn(),
+}));
+
+jest.mock(
+  '@/sse-db-event/hooks/useDispatchMetadataEventsFromSseToBrowserEvents',
+  () => ({
+    useDispatchMetadataEventsFromSseToBrowserEvents: jest.fn(),
+  }),
+);
+
+jest.mock(
+  '@/sse-db-event/hooks/useDispatchObjectRecordEventsFromSseToBrowserEvents',
+  () => ({
+    useDispatchObjectRecordEventsFromSseToBrowserEvents: jest.fn(),
+  }),
+);
+
+jest.mock(
+  '@/sse-db-event/hooks/useTriggerOptimisticEffectFromSseEvents',
+  () => ({
+    useTriggerOptimisticEffectFromSseEvents: jest.fn(),
+  }),
+);
+
+jest.mock('uuid', () => ({
+  v4: jest.fn(() => 'stream-id-123'),
+}));
+
+describe('useTriggerEventStreamCreation', () => {
+  const mockSet = jest.fn();
+  const mockGet = jest.fn();
+  const mockSubscribe = jest.fn();
+  const mockSetIsCreating = jest.fn();
+  let subscriptionHandlers: Record<string, any> | undefined;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    subscriptionHandlers = undefined;
+
+    mockGet.mockImplementation((atom) => {
+      switch (atom) {
+        case sseClientState.atom:
+          return { subscribe: mockSubscribe };
+        case isCreatingSseEventStreamState.atom:
+          return false;
+        case isDestroyingEventStreamState.atom:
+          return false;
+        case sseEventStreamIdState.atom:
+          return null;
+        default:
+          return undefined;
+      }
+    });
+
+    mockSubscribe.mockImplementation((_payload, _handlers, observer) => {
+      subscriptionHandlers = observer;
+
+      return jest.fn();
+    });
+
+    (useStore as jest.Mock).mockReturnValue({
+      get: mockGet,
+      set: mockSet,
+    });
+
+    (useSetAtomState as jest.Mock).mockReturnValue(mockSetIsCreating);
+
+    (
+      useDispatchMetadataEventsFromSseToBrowserEvents as jest.Mock
+    ).mockReturnValue({
+      dispatchMetadataEventsFromSseToBrowserEvents: jest.fn(),
+    });
+
+    (
+      useDispatchObjectRecordEventsFromSseToBrowserEvents as jest.Mock
+    ).mockReturnValue({
+      dispatchObjectRecordEventsFromSseToBrowserEvents: jest.fn(),
+    });
+
+    (useTriggerOptimisticEffectFromSseEvents as jest.Mock).mockReturnValue({
+      triggerOptimisticEffectFromSseEvents: jest.fn(),
+    });
+  });
+
+  it('should not capture recoverable unauthenticated SSE reconnect errors', () => {
+    const { result } = renderHook(() => useTriggerEventStreamCreation());
+
+    result.current.triggerEventStreamCreation();
+
+    expect(subscriptionHandlers).toBeDefined();
+
+    subscriptionHandlers?.message({
+      event: 'next',
+      data: {
+        errors: [
+          {
+            message: 'Authentication token expired',
+            extensions: {
+              code: 'UNAUTHENTICATED',
+            },
+          },
+        ],
+      },
+    });
+
+    expect(captureException).not.toHaveBeenCalled();
+    expect(mockSet).toHaveBeenCalledWith(
+      shouldDestroyEventStreamState.atom,
+      true,
+    );
+  });
+});

--- a/packages/twenty-front/src/modules/sse-db-event/hooks/useTriggerEventStreamCreation.ts
+++ b/packages/twenty-front/src/modules/sse-db-event/hooks/useTriggerEventStreamCreation.ts
@@ -20,6 +20,19 @@ import { isDefined } from 'twenty-shared/utils';
 import { v4 } from 'uuid';
 import { type EventSubscription } from '~/generated-metadata/graphql';
 
+const isRecoverableEventStreamError = ({
+  subCode,
+  code,
+}: {
+  subCode?: string;
+  code?: string;
+}) =>
+  subCode === 'EVENT_STREAM_DOES_NOT_EXIST' ||
+  subCode === 'EVENT_STREAM_ALREADY_EXISTS' ||
+  subCode === 'NOT_AUTHORIZED' ||
+  code === 'UNAUTHENTICATED' ||
+  code === 'FORBIDDEN';
+
 export const useTriggerEventStreamCreation = () => {
   const store = useStore();
   const setIsCreatingSseEventStream = useSetAtomState(
@@ -80,9 +93,17 @@ export const useTriggerEventStreamCreation = () => {
           }>,
         ) => {
           if (isDefined(value?.errors) && Array.isArray(value.errors)) {
-            captureException(
-              new Error(`SSE subscription error: ${value.errors[0]?.message}`),
-            );
+            const subCode = value.errors[0]?.extensions?.subCode;
+            const code = value.errors[0]?.extensions?.code;
+
+            if (!isRecoverableEventStreamError({ subCode, code })) {
+              captureException(
+                new Error(
+                  `SSE subscription error: ${value.errors[0]?.message}`,
+                ),
+              );
+            }
+
             store.set(shouldDestroyEventStreamState.atom, true);
 
             return;
@@ -129,16 +150,11 @@ export const useTriggerEventStreamCreation = () => {
             if (event === 'next') {
               if (isDefined(result?.errors)) {
                 const subCode = result.errors[0]?.extensions?.subCode;
+                const code = result.errors[0]?.extensions?.code;
 
-                switch (subCode) {
-                  case 'EVENT_STREAM_ALREADY_EXISTS': {
-                    store.set(shouldDestroyEventStreamState.atom, true);
-                    break;
-                  }
-                  default: {
-                    for (const error of result.errors) {
-                      captureException(error);
-                    }
+                if (!isRecoverableEventStreamError({ subCode, code })) {
+                  for (const error of result.errors) {
+                    captureException(error);
                   }
                 }
 


### PR DESCRIPTION
## Summary
- treat unauthenticated and authorization-related SSE stream creation errors as recoverable reconnect cases
- avoid reporting those expected reconnect paths to Sentry during normal token expiry handling
- add focused coverage for the UNAUTHENTICATED SSE message path

Fixes #18077

## Validation
- corepack yarn exec jest --config packages/twenty-front/jest.config.mjs packages/twenty-front/src/modules/sse-db-event/hooks/__tests__/useTriggerEventStreamCreation.test.tsx --runInBand
- corepack yarn prettier --check packages/twenty-front/src/modules/sse-db-event/hooks/useTriggerEventStreamCreation.ts packages/twenty-front/src/modules/sse-db-event/hooks/__tests__/useTriggerEventStreamCreation.test.tsx

## Notes
- The repo currently enforces Node ^24.5.0; this environment is on 24.1.0, so I ran the commands with YARN_IGNORE_NODE=1 to get targeted validation running.
