### PR TITLE
Finalize Twenty stage and filter semantics

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,3 +53,5 @@ mcp.json
 TRANSLATION_QA_REPORT.md
 .playwright-mcp/
 .playwright-cli/
+packages/twenty-front/tmp*
+.auth-state*

--- a/packages/twenty-front/src/modules/activities/notes/components/NotesCard.tsx
+++ b/packages/twenty-front/src/modules/activities/notes/components/NotesCard.tsx
@@ -7,6 +7,7 @@ import { useObjectMetadataItem } from '@/object-metadata/hooks/useObjectMetadata
 import { CoreObjectNameSingular } from 'twenty-shared/types';
 import { useObjectPermissionsForObject } from '@/object-record/hooks/useObjectPermissionsForObject';
 import { useTargetRecord } from '@/ui/layout/contexts/useTargetRecord';
+import { useAICElement } from '@aicorg/sdk-react';
 import { styled } from '@linaria/react';
 import { t } from '@lingui/core/macro';
 import { IconPlus } from 'twenty-ui/display';
@@ -55,6 +56,23 @@ export const NotesCard = () => {
 
   const hasObjectUpdatePermissions = objectPermissions.canUpdateObjectRecords;
 
+  const noteActionId = `${targetRecord.targetObjectNameSingular}.note.add.${targetRecord.id}`;
+  const noteActionLabel = `Add note to ${targetRecord.targetObjectNameSingular}`;
+  const noteWorkflowStep = `${targetRecord.targetObjectNameSingular}.add_note`;
+  const noteAction = useAICElement({
+    agentId: noteActionId,
+    agentAction: 'open',
+    agentDescription:
+      'Open the note creation flow for the current record without changing the destructive-action state.',
+    agentEntityId: targetRecord.id,
+    agentEntityLabel: `${targetRecord.targetObjectNameSingular} ${targetRecord.id}`,
+    agentEntityType: targetRecord.targetObjectNameSingular,
+    agentExamples: ['Requested security review before proposal.'],
+    agentLabel: noteActionLabel,
+    agentRisk: 'medium',
+    agentWorkflowStep: noteWorkflowStep,
+  });
+
   if (loading && isNotesEmpty) {
     return <SkeletonLoader />;
   }
@@ -75,16 +93,18 @@ export const NotesCard = () => {
           </AnimatedPlaceholderEmptySubTitle>
         </AnimatedPlaceholderEmptyTextContainer>
         {hasObjectUpdatePermissions && (
-          <Button
-            Icon={IconPlus}
-            title={t`New note`}
-            variant="secondary"
-            onClick={() =>
-              openCreateActivity({
-                targetableObjects: [targetRecord],
-              })
-            }
-          />
+          <div {...noteAction.attributes}>
+            <Button
+              Icon={IconPlus}
+              title={t`New note`}
+              variant="secondary"
+              onClick={() =>
+                openCreateActivity({
+                  targetableObjects: [targetRecord],
+                })
+              }
+            />
+          </div>
         )}
       </AnimatedPlaceholderEmptyContainer>
     );
@@ -98,17 +118,19 @@ export const NotesCard = () => {
         totalCount={totalCountNotes}
         button={
           hasObjectUpdatePermissions && (
-            <Button
-              Icon={IconPlus}
-              size="small"
-              variant="secondary"
-              title={t`Add note`}
-              onClick={() =>
-                openCreateActivity({
-                  targetableObjects: [targetRecord],
-                })
-              }
-            />
+            <div {...noteAction.attributes}>
+              <Button
+                Icon={IconPlus}
+                size="small"
+                variant="secondary"
+                title={t`Add note`}
+                onClick={() =>
+                  openCreateActivity({
+                    targetableObjects: [targetRecord],
+                  })
+                }
+              />
+            </div>
           )
         }
       />

--- a/packages/twenty-front/src/modules/activities/tasks/components/AddTaskButton.tsx
+++ b/packages/twenty-front/src/modules/activities/tasks/components/AddTaskButton.tsx
@@ -3,6 +3,7 @@ import { type ActivityTargetableObject } from '@/activities/types/ActivityTarget
 import { useObjectMetadataItem } from '@/object-metadata/hooks/useObjectMetadataItem';
 import { CoreObjectNameSingular } from 'twenty-shared/types';
 import { useObjectPermissionsForObject } from '@/object-record/hooks/useObjectPermissionsForObject';
+import { useAICElement } from '@aicorg/sdk-react';
 import { t } from '@lingui/core/macro';
 import { IconPlus } from 'twenty-ui/display';
 import { Button } from 'twenty-ui/input';
@@ -30,17 +31,33 @@ export const AddTaskButton = ({
     return null;
   }
 
+  const taskAction = useAICElement({
+    agentId: `${activityTargetableObject.targetObjectNameSingular}.task.add.list.${activityTargetableObject.id}`,
+    agentAction: 'open',
+    agentDescription:
+      'Open the task creation flow for the current record without leaving the current record page.',
+    agentEntityId: activityTargetableObject.id,
+    agentEntityLabel: `${activityTargetableObject.targetObjectNameSingular} ${activityTargetableObject.id}`,
+    agentEntityType: activityTargetableObject.targetObjectNameSingular,
+    agentExamples: ['Follow up with Google procurement before proposal review.'],
+    agentLabel: `Add task to ${activityTargetableObject.targetObjectNameSingular}`,
+    agentRisk: 'medium',
+    agentWorkflowStep: `${activityTargetableObject.targetObjectNameSingular}.add_task`,
+  });
+
   return (
-    <Button
-      Icon={IconPlus}
-      size="small"
-      variant="secondary"
-      title={t`Add task`}
-      onClick={() =>
-        openCreateActivity({
-          targetableObjects: [activityTargetableObject],
-        })
-      }
-    />
+    <div {...taskAction.attributes}>
+      <Button
+        Icon={IconPlus}
+        size="small"
+        variant="secondary"
+        title={t`Add task`}
+        onClick={() =>
+          openCreateActivity({
+            targetableObjects: [activityTargetableObject],
+          })
+        }
+      />
+    </div>
   );
 };

--- a/packages/twenty-front/src/modules/activities/tasks/components/TaskGroups.tsx
+++ b/packages/twenty-front/src/modules/activities/tasks/components/TaskGroups.tsx
@@ -7,6 +7,7 @@ import { type ActivityTargetableObject } from '@/activities/types/ActivityTarget
 import { type Task } from '@/activities/types/Task';
 import { useObjectMetadataItem } from '@/object-metadata/hooks/useObjectMetadataItem';
 import { useObjectPermissionsForObject } from '@/object-record/hooks/useObjectPermissionsForObject';
+import { useAICElement } from '@aicorg/sdk-react';
 import { activeTabIdComponentState } from '@/ui/layout/tab-list/states/activeTabIdComponentState';
 import { useAtomComponentStateValue } from '@/ui/utilities/state/jotai/hooks/useAtomComponentStateValue';
 import { t } from '@lingui/core/macro';
@@ -65,6 +66,20 @@ export const TaskGroups = ({ targetableObject }: TaskGroupsProps) => {
     (activeTabId !== 'done' && tasks?.length === 0) ||
     (activeTabId === 'done' && tasks?.length === 0);
 
+  const emptyStateTaskAction = useAICElement({
+    agentId: `${targetableObject.targetObjectNameSingular}.task.add.empty_state.${targetableObject.id}`,
+    agentAction: 'open',
+    agentDescription:
+      'Open the task creation flow for the current record from the empty-state tasks view.',
+    agentEntityId: targetableObject.id,
+    agentEntityLabel: `${targetableObject.targetObjectNameSingular} ${targetableObject.id}`,
+    agentEntityType: targetableObject.targetObjectNameSingular,
+    agentExamples: ['Follow up with Google procurement before proposal review.'],
+    agentLabel: `Add task to ${targetableObject.targetObjectNameSingular}`,
+    agentRisk: 'medium',
+    agentWorkflowStep: `${targetableObject.targetObjectNameSingular}.add_task`,
+  });
+
   if (isLoading && isTasksEmpty) {
     return <SkeletonLoader />;
   }
@@ -85,16 +100,18 @@ export const TaskGroups = ({ targetableObject }: TaskGroupsProps) => {
           </AnimatedPlaceholderEmptySubTitle>
         </AnimatedPlaceholderEmptyTextContainer>
         {hasObjectUpdatePermissions && (
-          <Button
-            Icon={IconPlus}
-            title={t`New task`}
-            variant="secondary"
-            onClick={() =>
-              openCreateActivity({
-                targetableObjects: [targetableObject],
-              })
-            }
-          />
+          <div {...emptyStateTaskAction.attributes}>
+            <Button
+              Icon={IconPlus}
+              title={t`New task`}
+              variant="secondary"
+              onClick={() =>
+                openCreateActivity({
+                  targetableObjects: [targetableObject],
+                })
+              }
+            />
+          </div>
         )}
       </AnimatedPlaceholderEmptyContainer>
     );

--- a/packages/twenty-front/src/modules/app/components/AppRouterProviders.tsx
+++ b/packages/twenty-front/src/modules/app/components/AppRouterProviders.tsx
@@ -31,6 +31,7 @@ import { UserThemeProviderEffect } from '@/ui/theme/components/UserThemeProvider
 import { PageFavicon } from '@/ui/utilities/page-favicon/components/PageFavicon';
 import { PageTitle } from '@/ui/utilities/page-title/components/PageTitle';
 import { WorkspaceProviderEffect } from '@/workspace/components/WorkspaceProviderEffect';
+import { AICProvider } from '@aicorg/sdk-react';
 import { StrictMode } from 'react';
 import { Outlet, useLocation } from 'react-router-dom';
 import { getPageTitleFromPath } from '~/utils/title-utils';
@@ -40,54 +41,56 @@ export const AppRouterProviders = () => {
   const pageTitle = getPageTitleFromPath(pathname);
 
   return (
-    <ApolloProvider>
-      <BaseThemeProvider>
-        <ClientConfigProviderEffect />
-        <UserMetadataProviderInitialEffect />
-        <MinimalMetadataLoadEffect />
-        <IsMinimalMetadataReadyEffect />
-        <WorkspaceProviderEffect />
-        <ClientConfigProvider>
-          <CaptchaProvider>
-            <MinimalMetadataGater>
-              <AuthProvider>
-                <ApolloCoreProvider>
-                  <SSEProvider>
-                    <PreComputedChipGeneratorsProvider>
-                      <UserThemeProviderEffect />
-                      <SnackBarProvider>
-                        <ErrorMessageEffect />
-                        <AgentChatProvider>
-                          <DialogComponentInstanceContext.Provider
-                            value={{ instanceId: 'dialog-manager' }}
-                          >
-                            <DialogManager>
-                              <StrictMode>
-                                <PromiseRejectionEffect />
-                                <GotoHotkeysEffectsProvider />
-                                <PageTitle title={pageTitle} />
-                                <PageFavicon />
-                                <Outlet />
-                                <GlobalFilePreviewModal />
-                                <CommandMenuConfirmationModalManager />
-                                <CommandRunner />
-                              </StrictMode>
-                            </DialogManager>
-                          </DialogComponentInstanceContext.Provider>
-                        </AgentChatProvider>
-                      </SnackBarProvider>
-                      <MainContextStoreProvider />
-                      <SupportChatEffect />
-                      <PageChangeEffect />
-                      <SignOutOnOtherTabSignOutEffect />
-                    </PreComputedChipGeneratorsProvider>
-                  </SSEProvider>
-                </ApolloCoreProvider>
-              </AuthProvider>
-            </MinimalMetadataGater>
-          </CaptchaProvider>
-        </ClientConfigProvider>
-      </BaseThemeProvider>
-    </ApolloProvider>
+    <AICProvider>
+      <ApolloProvider>
+        <BaseThemeProvider>
+          <ClientConfigProviderEffect />
+          <UserMetadataProviderInitialEffect />
+          <MinimalMetadataLoadEffect />
+          <IsMinimalMetadataReadyEffect />
+          <WorkspaceProviderEffect />
+          <ClientConfigProvider>
+            <CaptchaProvider>
+              <MinimalMetadataGater>
+                <AuthProvider>
+                  <ApolloCoreProvider>
+                    <SSEProvider>
+                      <PreComputedChipGeneratorsProvider>
+                        <UserThemeProviderEffect />
+                        <SnackBarProvider>
+                          <ErrorMessageEffect />
+                          <AgentChatProvider>
+                            <DialogComponentInstanceContext.Provider
+                              value={{ instanceId: 'dialog-manager' }}
+                            >
+                              <DialogManager>
+                                <StrictMode>
+                                  <PromiseRejectionEffect />
+                                  <GotoHotkeysEffectsProvider />
+                                  <PageTitle title={pageTitle} />
+                                  <PageFavicon />
+                                  <Outlet />
+                                  <GlobalFilePreviewModal />
+                                  <CommandMenuConfirmationModalManager />
+                                  <CommandRunner />
+                                </StrictMode>
+                              </DialogManager>
+                            </DialogComponentInstanceContext.Provider>
+                          </AgentChatProvider>
+                        </SnackBarProvider>
+                        <MainContextStoreProvider />
+                        <SupportChatEffect />
+                        <PageChangeEffect />
+                        <SignOutOnOtherTabSignOutEffect />
+                      </PreComputedChipGeneratorsProvider>
+                    </SSEProvider>
+                  </ApolloCoreProvider>
+                </AuthProvider>
+              </MinimalMetadataGater>
+            </CaptchaProvider>
+          </ClientConfigProvider>
+        </BaseThemeProvider>
+      </ApolloProvider>
+    </AICProvider>
   );
 };

--- a/packages/twenty-front/src/modules/command-menu-item/confirmation-modal/components/CommandMenuConfirmationModalManager.tsx
+++ b/packages/twenty-front/src/modules/command-menu-item/confirmation-modal/components/CommandMenuConfirmationModalManager.tsx
@@ -10,6 +10,7 @@ import { isModalOpenedComponentState } from '@/ui/layout/modal/states/isModalOpe
 import { useAtomComponentStateValue } from '@/ui/utilities/state/jotai/hooks/useAtomComponentStateValue';
 import { useAtomStateValue } from '@/ui/utilities/state/jotai/hooks/useAtomStateValue';
 import { useSetAtomState } from '@/ui/utilities/state/jotai/hooks/useSetAtomState';
+import { useAICElement } from '@aicorg/sdk-react';
 import { isDefined } from 'twenty-shared/utils';
 
 export const CommandMenuConfirmationModalManager = () => {
@@ -48,23 +49,42 @@ export const CommandMenuConfirmationModalManager = () => {
     setCommandMenuItemConfirmationModalConfig(null);
   };
 
+  const { attributes } = useAICElement({
+    agentId: 'record.destroy.confirmation_modal',
+    agentAction: 'confirm',
+    agentConfirmation: {
+      prompt_template:
+        'Review the destructive action summary, then cancel unless explicit approval to confirm was given.',
+      summary_fields: ['title', 'subtitle'],
+      type: 'human_review',
+    },
+    agentDescription:
+      'Confirmation dialog for destructive record commands. Cancel by default unless explicit approval to confirm is present.',
+    agentLabel: 'Destructive action confirmation modal',
+    agentRequiresConfirmation: true,
+    agentRisk: 'critical',
+    agentWorkflowStep: 'record.confirm_destructive_action',
+  });
+
   if (!commandMenuItemConfirmationModalConfig || !isModalOpened) {
     return null;
   }
 
   return (
-    <ConfirmationModal
-      modalInstanceId={COMMAND_MENU_CONFIRMATION_MODAL_INSTANCE_ID}
-      title={commandMenuItemConfirmationModalConfig.title}
-      subtitle={commandMenuItemConfirmationModalConfig.subtitle}
-      onConfirmClick={() => emitConfirmationResult('confirm')}
-      onClose={() => emitConfirmationResult('cancel')}
-      confirmButtonText={
-        commandMenuItemConfirmationModalConfig.confirmButtonText
-      }
-      confirmButtonAccent={
-        commandMenuItemConfirmationModalConfig.confirmButtonAccent
-      }
-    />
+    <div {...attributes}>
+      <ConfirmationModal
+        modalInstanceId={COMMAND_MENU_CONFIRMATION_MODAL_INSTANCE_ID}
+        title={commandMenuItemConfirmationModalConfig.title}
+        subtitle={commandMenuItemConfirmationModalConfig.subtitle}
+        onConfirmClick={() => emitConfirmationResult('confirm')}
+        onClose={() => emitConfirmationResult('cancel')}
+        confirmButtonText={
+          commandMenuItemConfirmationModalConfig.confirmButtonText
+        }
+        confirmButtonAccent={
+          commandMenuItemConfirmationModalConfig.confirmButtonAccent
+        }
+      />
+    </div>
   );
 };

--- a/packages/twenty-front/src/modules/command-menu-item/display/components/HeadlessCommandMenuItem.tsx
+++ b/packages/twenty-front/src/modules/command-menu-item/display/components/HeadlessCommandMenuItem.tsx
@@ -1,7 +1,9 @@
-import { useContext } from 'react';
+import { type ReactNode, useContext, useId } from 'react';
 
+import { getCommandMenuItemLabel } from '@/command-menu-item/utils/getCommandMenuItemLabel';
 import { CommandConfigContext } from '@/command-menu-item/contexts/CommandConfigContext';
 import { useMountCommand } from '@/command-menu-item/engine-command/hooks/useMountCommand';
+import { useCommandMenuContextApi } from '@/command-menu-item/server-items/common/hooks/useCommandMenuContextApi';
 import { isEngineCommandMountedFamilySelector } from '@/command-menu-item/engine-command/selectors/isEngineCommandMountedFamilySelector';
 import { useCloseCommandMenu } from '@/command-menu-item/hooks/useCloseCommandMenu';
 import { commandMenuItemProgressFamilyState } from '@/command-menu-item/states/commandMenuItemProgressFamilyState';
@@ -9,8 +11,12 @@ import { ContextStoreComponentInstanceContext } from '@/context-store/states/con
 import { useAvailableComponentInstanceIdOrThrow } from '@/ui/utilities/state/component-state/hooks/useAvailableComponentInstanceIdOrThrow';
 import { useAtomFamilySelectorValue } from '@/ui/utilities/state/jotai/hooks/useAtomFamilySelectorValue';
 import { useAtomFamilyStateValue } from '@/ui/utilities/state/jotai/hooks/useAtomFamilyStateValue';
+import { useAICElement } from '@aicorg/sdk-react';
 import { isDefined } from 'twenty-shared/utils';
-import { type CommandMenuItemFieldsFragment } from '~/generated-metadata/graphql';
+import {
+  EngineComponentKey,
+  type CommandMenuItemFieldsFragment,
+} from '~/generated-metadata/graphql';
 
 import { CommandMenuItemDisplay } from './CommandMenuItemDisplay';
 
@@ -64,11 +70,146 @@ export const HeadlessCommandMenuItem = ({
   };
 
   return (
-    <CommandMenuItemDisplay
-      onClick={handleClick}
-      disabled={isMounted}
-      progress={commandMenuItemProgress}
-      showDisabledLoader={isMounted}
-    />
+    <AICCommandMenuItemWrapper item={item}>
+      <CommandMenuItemDisplay
+        onClick={handleClick}
+        disabled={isMounted}
+        progress={commandMenuItemProgress}
+        showDisabledLoader={isMounted}
+      />
+    </AICCommandMenuItemWrapper>
   );
 };
+
+const AICCommandMenuItemWrapper = ({
+  item,
+  children,
+}: {
+  item: CommandMenuItemFieldsFragment;
+  children: ReactNode;
+}) => {
+  const action = useContext(CommandConfigContext);
+  const commandMenuContextApi = useCommandMenuContextApi();
+  const instanceKey = normalizeAgentKeyFragment(useId());
+
+  if (!isDefined(action)) {
+    return children;
+  }
+
+  const metadata = buildCommandMenuAICMetadata(
+    item,
+    action,
+    commandMenuContextApi,
+    instanceKey,
+  );
+
+  if (!metadata) {
+    return children;
+  }
+
+  const { attributes } = useAICElement(metadata, {
+    defaultAction: 'click',
+    role: 'menuitem',
+  });
+
+  return <div {...attributes}>{children}</div>;
+};
+
+function buildCommandMenuAICMetadata(
+  item: CommandMenuItemFieldsFragment,
+  action: { key?: unknown; label: unknown; description?: unknown },
+  commandMenuContextApi: ReturnType<typeof useCommandMenuContextApi>,
+  instanceKey: string,
+) {
+  const label = getCommandMenuItemLabel(action.label);
+  const description = getCommandMenuItemLabel(action.description);
+  const actionKey = normalizeAgentKeyFragment(action.key);
+  const selectedRecord = commandMenuContextApi.selectedRecords.at(0);
+  const objectMetadataItem = commandMenuContextApi.objectMetadataItem;
+  const objectNameSingular = objectMetadataItem.nameSingular ?? 'record';
+  const objectLabelSingular = objectMetadataItem.labelSingular ?? 'record';
+  const objectLabelPlural = objectMetadataItem.labelPlural ?? 'records';
+  const isSingleRecord = commandMenuContextApi.numberOfSelectedRecords === 1;
+  const entityId =
+    selectedRecord?.id ??
+    (isSingleRecord ? 'selected_record' : 'record_selection');
+  const entityLabel =
+    selectedRecord?.name ??
+    (isSingleRecord ? objectLabelSingular : objectLabelPlural);
+
+  switch (item.engineComponentKey) {
+    case EngineComponentKey.DELETE_RECORDS:
+    case EngineComponentKey.DELETE_SINGLE_RECORD:
+    case EngineComponentKey.DELETE_MULTIPLE_RECORDS:
+      return {
+        agentAction: 'click' as const,
+        agentDescription:
+          description ||
+          'Soft delete the selected record and expose restore and permanent-destroy follow-up actions. This step is reversible.',
+        agentEntityId: entityId,
+        agentEntityLabel: entityLabel,
+        agentEntityType: objectNameSingular,
+        agentExecution: {
+          settled_when: [
+            'Deleted record banner is visible and restore or destroy follow-up actions are available.',
+          ],
+        },
+        agentId: `command_menu.record.soft_delete.${item.id}.${actionKey}.${instanceKey}`,
+        agentLabel: label || 'Delete record',
+        agentRecovery: {
+          partial_state_changed: true,
+          recovery:
+            'Use the restore action to recover the soft-deleted record.',
+          retryable: false,
+        },
+        agentRisk: 'high' as const,
+        agentWorkflowStep: 'record.soft_delete',
+      };
+    case EngineComponentKey.DESTROY_RECORDS:
+    case EngineComponentKey.DESTROY_SINGLE_RECORD:
+    case EngineComponentKey.DESTROY_MULTIPLE_RECORDS:
+      return {
+        agentAction: 'click' as const,
+        agentConfirmation: {
+          prompt_template:
+            'Open the irreversible destroy confirmation dialog for the selected record. Do not confirm unless explicit approval was given.',
+          summary_fields: ['entity_label', 'entity_id'],
+          type: 'inline_modal' as const,
+        },
+        agentDescription:
+          description ||
+          'Open the irreversible destroy action for the current record. This leads to a critical confirmation boundary.',
+        agentEntityId: entityId,
+        agentEntityLabel: entityLabel,
+        agentEntityType: objectNameSingular,
+        agentId: `command_menu.record.destroy.${item.id}.${actionKey}.${instanceKey}`,
+        agentLabel: label || 'Permanently destroy record',
+        agentRequiresConfirmation: true,
+        agentRisk: 'critical' as const,
+        agentWorkflowStep: 'record.open_destroy_confirmation',
+      };
+    case EngineComponentKey.RESTORE_RECORDS:
+    case EngineComponentKey.RESTORE_SINGLE_RECORD:
+    case EngineComponentKey.RESTORE_MULTIPLE_RECORDS:
+      return {
+        agentAction: 'click' as const,
+        agentDescription:
+          description || 'Restore the selected soft-deleted record to the active state.',
+        agentEntityId: entityId,
+        agentEntityLabel: entityLabel,
+        agentEntityType: objectNameSingular,
+        agentId: `command_menu.record.restore.${item.id}.${actionKey}.${instanceKey}`,
+        agentLabel: label || 'Restore record',
+        agentRisk: 'low' as const,
+        agentWorkflowStep: 'record.restore',
+      };
+    default:
+      return null;
+  }
+}
+
+function normalizeAgentKeyFragment(value: unknown) {
+  return String(value ?? 'command')
+    .trim()
+    .replace(/[^a-zA-Z0-9._-]+/g, '_');
+}

--- a/packages/twenty-front/src/modules/command-menu-item/engine-command/record/components/DeleteRecordsCommand.tsx
+++ b/packages/twenty-front/src/modules/command-menu-item/engine-command/record/components/DeleteRecordsCommand.tsx
@@ -6,6 +6,7 @@ import { DEFAULT_QUERY_PAGE_SIZE } from '@/object-record/constants/DefaultQueryP
 import { useIncrementalDeleteManyRecords } from '@/object-record/hooks/useIncrementalDeleteManyRecords';
 import { useRemoveSelectedRecordsFromRecordBoard } from '@/object-record/record-board/hooks/useRemoveSelectedRecordsFromRecordBoard';
 import { useResetTableRowSelection } from '@/object-record/record-table/hooks/internal/useResetTableRowSelection';
+import { useAICElement } from '@aicorg/sdk-react';
 import { type RecordGqlOperationFilter } from 'twenty-shared/types';
 import { isDefined } from 'twenty-shared/utils';
 
@@ -41,6 +42,35 @@ export const DeleteRecordsCommand = () => {
   const { removeNavigationMenuItemsByTargetRecordIds } =
     useRemoveNavigationMenuItemByTargetRecordId();
 
+  const isSingleRecord = selectedRecords.length === 1;
+  const selectedRecord = selectedRecords.at(0);
+  const objectLabel = isSingleRecord
+    ? objectMetadataItem.labelSingular
+    : objectMetadataItem.labelPlural;
+
+  const { attributes } = useAICElement({
+    agentAction: 'click',
+    agentDescription:
+      'Soft delete the selected record. This is reversible through the restore action.',
+    agentEntityId: selectedRecord?.id ?? 'selection',
+    agentEntityLabel: selectedRecord?.name ?? objectLabel,
+    agentEntityType: objectMetadataItem.nameSingular,
+    agentExecution: {
+      settled_when: [
+        'Deleted record banner is visible or the record disappears from the current active list view.',
+      ],
+    },
+    agentId: `${objectMetadataItem.nameSingular}.soft_delete.${selectedRecord?.id ?? 'selection'}`,
+    agentLabel: `Delete ${objectLabel}`,
+    agentRecovery: {
+      partial_state_changed: true,
+      recovery: 'Use the restore action to recover the deleted record.',
+      retryable: false,
+    },
+    agentRisk: 'high',
+    agentWorkflowStep: `${objectMetadataItem.nameSingular}.soft_delete`,
+  });
+
   const handleExecute = async () => {
     removeSelectedRecordsFromRecordBoard();
     resetTableRowSelection();
@@ -63,5 +93,10 @@ export const DeleteRecordsCommand = () => {
     await incrementalDeleteManyRecords();
   };
 
-  return <HeadlessEngineCommandWrapperEffect execute={handleExecute} />;
+  return (
+    <>
+      <span hidden {...attributes} />
+      <HeadlessEngineCommandWrapperEffect execute={handleExecute} />
+    </>
+  );
 };

--- a/packages/twenty-front/src/modules/command-menu-item/engine-command/record/components/DestroyRecordsCommand.tsx
+++ b/packages/twenty-front/src/modules/command-menu-item/engine-command/record/components/DestroyRecordsCommand.tsx
@@ -4,6 +4,7 @@ import { DEFAULT_QUERY_PAGE_SIZE } from '@/object-record/constants/DefaultQueryP
 import { useIncrementalDestroyManyRecords } from '@/object-record/hooks/useIncrementalDestroyManyRecords';
 import { useRemoveSelectedRecordsFromRecordBoard } from '@/object-record/record-board/hooks/useRemoveSelectedRecordsFromRecordBoard';
 import { useResetTableRowSelection } from '@/object-record/record-table/hooks/internal/useResetTableRowSelection';
+import { useAICElement } from '@aicorg/sdk-react';
 import { t } from '@lingui/core/macro';
 import { AppPath, type RecordGqlOperationFilter } from 'twenty-shared/types';
 import { isDefined } from 'twenty-shared/utils';
@@ -71,13 +72,35 @@ export const DestroyRecordsCommand = () => {
     ? t`Are you sure you want to destroy this ${objectMetadataItem.labelSingular}? It cannot be recovered anymore.`
     : t`Are you sure you want to destroy these ${objectMetadataItem.labelPlural}? They won't be recoverable anymore.`;
   const confirmButtonText = `${t`Permanently Destroy`} ${objectLabel}`;
+  const selectedRecord = selectedRecords.at(0);
+  const { attributes } = useAICElement({
+    agentId: `${objectMetadataItem.nameSingular}.destroy.${selectedRecord?.id ?? 'selection'}`,
+    agentAction: 'delete',
+    agentConfirmation: {
+      prompt_template: `Permanently destroy the selected ${objectLabel}. This cannot be undone.`,
+      summary_fields: ['entity_label', 'entity_id'],
+      type: 'human_review',
+    },
+    agentDescription:
+      'Permanently destroy the selected record after explicit confirmation.',
+    agentEntityId: selectedRecord?.id ?? 'selection',
+    agentEntityLabel: selectedRecord?.name ?? objectLabel,
+    agentEntityType: objectMetadataItem.nameSingular,
+    agentLabel: `Destroy ${objectLabel}`,
+    agentRequiresConfirmation: true,
+    agentRisk: 'critical',
+    agentWorkflowStep: `${objectMetadataItem.nameSingular}.confirm_destroy`,
+  });
 
   return (
-    <HeadlessConfirmationModalEngineCommandEffect
-      title={title}
-      subtitle={subtitle}
-      confirmButtonText={confirmButtonText}
-      execute={handleExecute}
-    />
+    <>
+      <span hidden {...attributes} />
+      <HeadlessConfirmationModalEngineCommandEffect
+        title={title}
+        subtitle={subtitle}
+        confirmButtonText={confirmButtonText}
+        execute={handleExecute}
+      />
+    </>
   );
 };

--- a/packages/twenty-front/src/modules/command-menu-item/engine-command/record/components/RestoreRecordsCommand.tsx
+++ b/packages/twenty-front/src/modules/command-menu-item/engine-command/record/components/RestoreRecordsCommand.tsx
@@ -5,6 +5,7 @@ import { useLazyFetchAllRecords } from '@/object-record/hooks/useLazyFetchAllRec
 import { useRestoreManyRecords } from '@/object-record/hooks/useRestoreManyRecords';
 import { useRemoveSelectedRecordsFromRecordBoard } from '@/object-record/record-board/hooks/useRemoveSelectedRecordsFromRecordBoard';
 import { useResetTableRowSelection } from '@/object-record/record-table/hooks/internal/useResetTableRowSelection';
+import { useAICElement } from '@aicorg/sdk-react';
 import { t } from '@lingui/core/macro';
 import { type RecordGqlOperationFilter } from 'twenty-shared/types';
 import { isDefined } from 'twenty-shared/utils';
@@ -67,19 +68,39 @@ export const RestoreRecordsCommand = () => {
   const objectLabel = isSingleRecord
     ? objectMetadataItem.labelSingular
     : objectMetadataItem.labelPlural;
+  const selectedRecord = selectedRecords.at(0);
 
   const title = t`Restore ${objectLabel}`;
   const subtitle = isSingleRecord
     ? t`Are you sure you want to restore this ${objectMetadataItem.labelSingular}?`
     : t`Are you sure you want to restore these ${objectMetadataItem.labelPlural}?`;
 
+  const { attributes } = useAICElement({
+    agentAction: 'click',
+    agentDescription:
+      'Restore the selected soft-deleted record to the active state.',
+    agentEntityId: selectedRecord?.id ?? 'selection',
+    agentEntityLabel: selectedRecord?.name ?? objectLabel,
+    agentEntityType: objectMetadataItem.nameSingular,
+    agentExecution: {
+      settled_when: ['Deleted record banner disappears or active record view is shown again.'],
+    },
+    agentId: `${objectMetadataItem.nameSingular}.restore.${selectedRecord?.id ?? 'selection'}`,
+    agentLabel: `Restore ${objectLabel}`,
+    agentRisk: 'low',
+    agentWorkflowStep: `${objectMetadataItem.nameSingular}.restore`,
+  });
+
   return (
-    <HeadlessConfirmationModalEngineCommandEffect
-      title={title}
-      subtitle={subtitle}
-      confirmButtonText={title}
-      confirmButtonAccent="default"
-      execute={handleExecute}
-    />
+    <>
+      <span hidden {...attributes} />
+      <HeadlessConfirmationModalEngineCommandEffect
+        title={title}
+        subtitle={subtitle}
+        confirmButtonText={title}
+        confirmButtonAccent="default"
+        execute={handleExecute}
+      />
+    </>
   );
 };

--- a/packages/twenty-front/src/modules/command-menu-item/server-items/display/components/CommandMenuItemMoreActionsButton.tsx
+++ b/packages/twenty-front/src/modules/command-menu-item/server-items/display/components/CommandMenuItemMoreActionsButton.tsx
@@ -2,6 +2,7 @@ import { useSidePanelMenu } from '@/side-panel/hooks/useSidePanelMenu';
 import { isSidePanelOpenedState } from '@/side-panel/states/isSidePanelOpenedState';
 import { PAGE_HEADER_SIDE_PANEL_BUTTON_CLICK_OUTSIDE_ID } from '@/ui/layout/page-header/constants/PageHeaderSidePanelButtonClickOutsideId';
 import { useAtomStateValue } from '@/ui/utilities/state/jotai/hooks/useAtomStateValue';
+import { useAICElement } from '@aicorg/sdk-react';
 import { styled } from '@linaria/react';
 import { t } from '@lingui/core/macro';
 import {
@@ -29,8 +30,18 @@ export const CommandMenuItemMoreActionsButton = () => {
     ? t`Close side panel`
     : t`Open side panel`;
 
+  const { attributes } = useAICElement({
+    agentId: 'record.more_actions.toggle',
+    agentAction: isSidePanelOpened ? 'close' : 'open',
+    agentDescription:
+      'Toggle the record more-actions side panel to expose record-scoped commands.',
+    agentLabel: 'Toggle record more actions',
+    agentRisk: 'low',
+    agentWorkflowStep: 'record.open_more_actions',
+  });
+
   return (
-    <div id="toggle-side-panel-button">
+    <div id="toggle-side-panel-button" {...attributes}>
       <AnimatedButton
         animatedSvg={
           <AnimatedIconCrossfade

--- a/packages/twenty-front/src/modules/object-record/components/RecordChip.tsx
+++ b/packages/twenty-front/src/modules/object-record/components/RecordChip.tsx
@@ -8,7 +8,7 @@ import { canOpenObjectInSidePanel } from '@/object-record/utils/canOpenObjectInS
 import { useAtomStateValue } from '@/ui/utilities/state/jotai/hooks/useAtomStateValue';
 import { ViewOpenRecordIn } from '~/generated-metadata/graphql';
 import { t } from '@lingui/core/macro';
-import { type MouseEvent } from 'react';
+import { type AnchorHTMLAttributes, type MouseEvent } from 'react';
 import { isDefined } from 'twenty-shared/utils';
 import {
   AvatarOrIcon,
@@ -33,6 +33,10 @@ export type RecordChipProps = {
   isIconHidden?: boolean;
   triggerEvent?: TriggerEventType;
   onClick?: (event: MouseEvent) => void;
+  linkAttributes?: Omit<
+    AnchorHTMLAttributes<HTMLAnchorElement>,
+    'className' | 'href' | 'onClick' | 'onMouseDown' | 'target'
+  >;
 };
 
 export const RecordChip = ({
@@ -49,6 +53,7 @@ export const RecordChip = ({
   isIconHidden = false,
   triggerEvent = 'MOUSE_DOWN',
   onClick,
+  linkAttributes,
 }: RecordChipProps) => {
   const { recordChipData } = useRecordChipData({
     objectNameSingular,
@@ -132,6 +137,7 @@ export const RecordChip = ({
       to={to ?? getLinkToShowPage(objectNameSingular, record)}
       onClick={handleCustomClick}
       triggerEvent={triggerEvent}
+      {...linkAttributes}
     />
   );
 };

--- a/packages/twenty-front/src/modules/object-record/object-filter-dropdown/components/ObjectFilterDropdownOptionSelect.tsx
+++ b/packages/twenty-front/src/modules/object-record/object-filter-dropdown/components/ObjectFilterDropdownOptionSelect.tsx
@@ -19,6 +19,7 @@ import { useHotkeysOnFocusedElement } from '@/ui/utilities/hotkey/hooks/useHotke
 import { useAvailableComponentInstanceIdOrThrow } from '@/ui/utilities/state/component-state/hooks/useAvailableComponentInstanceIdOrThrow';
 import { useAtomComponentSelectorValue } from '@/ui/utilities/state/jotai/hooks/useAtomComponentSelectorValue';
 import { useAtomComponentStateValue } from '@/ui/utilities/state/jotai/hooks/useAtomComponentStateValue';
+import { useAICElement } from '@aicorg/sdk-react';
 import { t } from '@lingui/core/macro';
 import { isNonEmptyString } from '@sniptt/guards';
 import { MAX_OPTIONS_TO_DISPLAY } from 'twenty-shared/constants';
@@ -30,6 +31,46 @@ export const EMPTY_FILTER_VALUE = '';
 
 type SelectOptionForFilter = FieldMetadataItemOption & {
   isSelected: boolean;
+};
+
+const FilterOptionMenuItem = ({
+  option,
+  selected,
+  isKeySelected,
+  onSelectChange,
+  fieldName,
+  fieldLabel,
+}: {
+  option: SelectOptionForFilter;
+  selected: boolean;
+  isKeySelected?: boolean;
+  onSelectChange: (selected: boolean) => void;
+  fieldName: string;
+  fieldLabel: string;
+}) => {
+  const { attributes } = useAICElement({
+    agentId: `opportunity.view.filter.option.${fieldName}.${option.value}`,
+    agentAction: 'select',
+    agentDescription: `Apply the ${option.label} option for the ${fieldLabel} filter on the current opportunities view.`,
+    agentEntityId: option.id,
+    agentEntityLabel: option.label,
+    agentEntityType: 'opportunity_filter_option',
+    agentLabel: `Filter opportunities where ${fieldLabel} includes ${option.label}`,
+    agentRisk: 'low',
+    agentWorkflowStep: 'opportunity.view.select_filter_value',
+  });
+
+  return (
+    <MenuItemMultiSelect
+      selected={selected}
+      isKeySelected={isKeySelected}
+      onSelectChange={onSelectChange}
+      text={option.label}
+      color={option.color}
+      className=""
+      {...attributes}
+    />
+  );
 };
 
 export const ObjectFilterDropdownOptionSelect = ({
@@ -77,6 +118,8 @@ export const ObjectFilterDropdownOptionSelect = ({
   );
 
   const fieldMetaDataId = fieldMetadataItemUsedInDropdown?.id ?? '';
+  const fieldName = fieldMetadataItemUsedInDropdown?.name ?? 'field';
+  const fieldLabel = fieldMetadataItemUsedInDropdown?.label ?? 'field';
 
   const { selectOptions } = useOptionsForSelect(fieldMetaDataId);
 
@@ -163,16 +206,16 @@ export const ObjectFilterDropdownOptionSelect = ({
           <MenuItem text={t`No results`} />
         ) : (
           optionsInDropdown?.map((option) => (
-            <MenuItemMultiSelect
+            <FilterOptionMenuItem
               key={option.id}
+              option={option}
               selected={option.isSelected}
               isKeySelected={option.id === selectedItemId}
               onSelectChange={(selected) =>
                 handleMultipleOptionSelectChange(option, selected)
               }
-              text={option.label}
-              color={option.color}
-              className=""
+              fieldName={fieldName}
+              fieldLabel={fieldLabel}
             />
           ))
         )}

--- a/packages/twenty-front/src/modules/object-record/object-sort-dropdown/components/ObjectSortDropdownButton.tsx
+++ b/packages/twenty-front/src/modules/object-record/object-sort-dropdown/components/ObjectSortDropdownButton.tsx
@@ -30,12 +30,57 @@ import { useAtomComponentState } from '@/ui/utilities/state/jotai/hooks/useAtomC
 import { useAtomComponentStateValue } from '@/ui/utilities/state/jotai/hooks/useAtomComponentStateValue';
 import { useSetAtomComponentState } from '@/ui/utilities/state/jotai/hooks/useSetAtomComponentState';
 import { useAtomFamilySelectorValue } from '@/ui/utilities/state/jotai/hooks/useAtomFamilySelectorValue';
+import { useAICElement } from '@aicorg/sdk-react';
 import { Trans, useLingui } from '@lingui/react/macro';
+import { type ComponentType } from 'react';
 import { findByProperty } from 'twenty-shared/utils';
 import { IconX, useIcons } from 'twenty-ui/display';
 import { MenuItem } from 'twenty-ui/navigation';
 import { v4 } from 'uuid';
 import { ViewSortDirection } from '~/generated-metadata/graphql';
+
+type SortFieldMenuItemProps = {
+  fieldMetadataItem: FieldMetadataItem;
+  focused: boolean;
+  onClick: () => void;
+  testId: string;
+  objectNameSingular: string;
+  objectLabelPlural: string;
+  LeftIcon: ComponentType<any>;
+};
+
+const SortFieldMenuItem = ({
+  fieldMetadataItem,
+  focused,
+  onClick,
+  testId,
+  objectNameSingular,
+  objectLabelPlural,
+  LeftIcon,
+}: SortFieldMenuItemProps) => {
+  const { attributes } = useAICElement({
+    agentId: `${objectNameSingular}.view.sort.field.${fieldMetadataItem.name}`,
+    agentAction: 'select',
+    agentDescription: `Apply a sort on the ${fieldMetadataItem.label} field for the current ${objectLabelPlural} view.`,
+    agentEntityId: fieldMetadataItem.id,
+    agentEntityLabel: fieldMetadataItem.label,
+    agentEntityType: `${objectNameSingular}_field`,
+    agentLabel: `Sort ${objectLabelPlural} by ${fieldMetadataItem.label}`,
+    agentRisk: 'low',
+    agentWorkflowStep: `${objectNameSingular}.view.select_sort_field`,
+  });
+
+  return (
+    <MenuItem
+      focused={focused}
+      testId={testId}
+      onClick={onClick}
+      LeftIcon={LeftIcon}
+      text={fieldMetadataItem.label}
+      {...attributes}
+    />
+  );
+};
 
 export const ObjectSortDropdownButton = () => {
   const { resetRecordSortDropdownSearchInput } =
@@ -164,12 +209,25 @@ export const ObjectSortDropdownButton = () => {
 
   const shouldShowHiddenFields = hiddenFieldMetadataItemsSorted.length > 0;
   const shouldShowVisibleFields = visibleFieldMetadataItems.length > 0;
+  const sortAction = useAICElement({
+    agentId: `${objectMetadataItem.nameSingular}.view.sort.open`,
+    agentAction: 'open',
+    agentDescription:
+      'Open the current record list sort controls for this object view.',
+    agentEntityId: objectMetadataItem.id,
+    agentEntityLabel: objectMetadataItem.labelPlural,
+    agentEntityType: `${objectMetadataItem.nameSingular}_view`,
+    agentLabel: `Open ${objectMetadataItem.labelPlural} sort controls`,
+    agentRisk: 'low',
+    agentWorkflowStep: `${objectMetadataItem.nameSingular}.view.open_sort`,
+  });
 
   return (
     <Dropdown
       dropdownId={OBJECT_SORT_DROPDOWN_ID}
       dropdownOffset={{ y: 8 }}
       onOpen={handleDropdownOpen}
+      clickableComponentProps={sortAction.attributes}
       clickableComponent={
         <StyledHeaderDropdownButton isUnfolded={isDropdownOpen}>
           <Trans>Sort</Trans>
@@ -235,7 +293,8 @@ export const ObjectSortDropdownButton = () => {
                         itemId={visibleFieldMetadataItem.id}
                         onEnter={() => handleAddSort(visibleFieldMetadataItem)}
                       >
-                        <MenuItem
+                        <SortFieldMenuItem
+                          fieldMetadataItem={visibleFieldMetadataItem}
                           focused={
                             selectedItemId === visibleFieldMetadataItem.id
                           }
@@ -244,7 +303,8 @@ export const ObjectSortDropdownButton = () => {
                             handleAddSort(visibleFieldMetadataItem)
                           }
                           LeftIcon={getIcon(visibleFieldMetadataItem.icon)}
-                          text={visibleFieldMetadataItem.label}
+                          objectNameSingular={objectMetadataItem.nameSingular}
+                          objectLabelPlural={objectMetadataItem.labelPlural}
                         />
                       </SelectableListItem>
                     ),
@@ -264,14 +324,16 @@ export const ObjectSortDropdownButton = () => {
                         itemId={hiddenFieldMetadataItem.id}
                         onEnter={() => handleAddSort(hiddenFieldMetadataItem)}
                       >
-                        <MenuItem
+                        <SortFieldMenuItem
+                          fieldMetadataItem={hiddenFieldMetadataItem}
                           focused={
                             selectedItemId === hiddenFieldMetadataItem.id
                           }
                           testId={`hidden-select-sort-${index}`}
                           onClick={() => handleAddSort(hiddenFieldMetadataItem)}
                           LeftIcon={getIcon(hiddenFieldMetadataItem.icon)}
-                          text={hiddenFieldMetadataItem.label}
+                          objectNameSingular={objectMetadataItem.nameSingular}
+                          objectLabelPlural={objectMetadataItem.labelPlural}
                         />
                       </SelectableListItem>
                     ),

--- a/packages/twenty-front/src/modules/object-record/record-field/ui/contexts/FieldContext.ts
+++ b/packages/twenty-front/src/modules/object-record/record-field/ui/contexts/FieldContext.ts
@@ -1,4 +1,4 @@
-import { createContext, type MouseEvent } from 'react';
+import { createContext, type AnchorHTMLAttributes, type MouseEvent } from 'react';
 
 import { type TriggerEventType } from 'twenty-ui/utilities';
 import { type FieldDefinition } from '@/object-record/record-field/ui/types/FieldDefinition';
@@ -36,6 +36,10 @@ export type GenericFieldContextType = {
   isRecordFieldReadOnly: boolean;
   disableChipClick?: boolean;
   onRecordChipClick?: (event: MouseEvent) => void;
+  recordChipLinkAttributes?: Omit<
+    AnchorHTMLAttributes<HTMLAnchorElement>,
+    'className' | 'href' | 'onClick' | 'onMouseDown' | 'target'
+  >;
   onOpenEditMode?: () => void;
   onCloseEditMode?: () => void;
   onMouseEnter?: () => void;

--- a/packages/twenty-front/src/modules/object-record/record-field/ui/meta-types/display/components/ChipFieldDisplay.tsx
+++ b/packages/twenty-front/src/modules/object-record/record-field/ui/meta-types/display/components/ChipFieldDisplay.tsx
@@ -12,6 +12,7 @@ export const ChipFieldDisplay = () => {
     maxWidth,
     triggerEvent,
     onRecordChipClick,
+    recordChipLinkAttributes,
     isLabelIdentifierCompact,
   } = useChipFieldDisplay();
 
@@ -30,6 +31,7 @@ export const ChipFieldDisplay = () => {
       forceDisableClick={disableChipClick}
       triggerEvent={triggerEvent}
       onClick={onRecordChipClick}
+      linkAttributes={recordChipLinkAttributes}
     />
   );
 };

--- a/packages/twenty-front/src/modules/object-record/record-field/ui/meta-types/display/components/SelectFieldDisplay.tsx
+++ b/packages/twenty-front/src/modules/object-record/record-field/ui/meta-types/display/components/SelectFieldDisplay.tsx
@@ -13,7 +13,5 @@ export const SelectFieldDisplay = () => {
     return <></>;
   }
 
-  return (
-    <SelectDisplay color={selectedOption.color} label={selectedOption.label} />
-  );
+  return <SelectDisplay color={selectedOption.color} label={selectedOption.label} />;
 };

--- a/packages/twenty-front/src/modules/object-record/record-field/ui/meta-types/hooks/useChipFieldDisplay.ts
+++ b/packages/twenty-front/src/modules/object-record/record-field/ui/meta-types/hooks/useChipFieldDisplay.ts
@@ -22,6 +22,7 @@ export const useChipFieldDisplay = () => {
     maxWidth,
     triggerEvent,
     onRecordChipClick,
+    recordChipLinkAttributes,
     isLabelIdentifierCompact,
   } = useContext(FieldContext);
 
@@ -65,6 +66,7 @@ export const useChipFieldDisplay = () => {
     maxWidth,
     triggerEvent,
     onRecordChipClick,
+    recordChipLinkAttributes,
     isLabelIdentifierCompact,
   };
 };

--- a/packages/twenty-front/src/modules/object-record/record-field/ui/meta-types/input/components/RichTextFieldEditor.tsx
+++ b/packages/twenty-front/src/modules/object-record/record-field/ui/meta-types/input/components/RichTextFieldEditor.tsx
@@ -28,6 +28,7 @@ import '@blocknote/core/fonts/inter.css';
 import '@blocknote/mantine/style.css';
 import { useCreateBlockNote } from '@blocknote/react';
 import '@blocknote/react/style.css';
+import { useAICElement } from '@aicorg/sdk-react';
 import { Key } from 'ts-key-enum';
 import { isDefined } from 'twenty-shared/utils';
 import { useDebouncedCallback } from 'use-debounce';
@@ -267,13 +268,89 @@ export const RichTextFieldEditor = ({
     removeFocusItemFromFocusStackById({ focusId });
   }, [focusId, removeFocusItemFromFocusStackById, onBlurOverride]);
 
-  return (
-    <BlockEditor
-      onFocus={handleBlockEditorFocus}
-      onBlur={handleBlockEditorBlur}
-      onChange={handleEditorChange}
-      editor={editor}
-      readonly={isRecordFieldReadOnly}
-    />
+  const editorAIC = buildRichTextEditorAICMetadata(
+    objectNameSingular,
+    fieldName,
+    recordId,
   );
+
+  return (
+    <RichTextEditorAICWrapper metadata={editorAIC}>
+      <BlockEditor
+        onFocus={handleBlockEditorFocus}
+        onBlur={handleBlockEditorBlur}
+        onChange={handleEditorChange}
+        editor={editor}
+        readonly={isRecordFieldReadOnly}
+      />
+    </RichTextEditorAICWrapper>
+  );
+};
+
+const RichTextEditorAICWrapper = ({
+  metadata,
+  children,
+}: {
+  metadata: ReturnType<typeof buildRichTextEditorAICMetadata>;
+  children: React.ReactNode;
+}) => {
+  if (!metadata) {
+    return children;
+  }
+
+  const { attributes } = useAICElement(metadata, {
+    defaultAction: 'edit',
+    role: 'textbox',
+  });
+
+  return <div {...attributes}>{children}</div>;
+};
+
+const buildRichTextEditorAICMetadata = (
+  objectNameSingular: string,
+  fieldName: string,
+  recordId: string,
+) => {
+  if (
+    fieldName !== 'bodyV2' ||
+    (objectNameSingular !== CoreObjectNameSingular.Note &&
+      objectNameSingular !== CoreObjectNameSingular.Task)
+  ) {
+    return null;
+  }
+
+  return {
+    agentId: `${objectNameSingular}.body.edit.${recordId}`,
+    agentAction: 'edit' as const,
+    agentDescription:
+      objectNameSingular === CoreObjectNameSingular.Note
+        ? 'Edit the note body for the current note. Changes autosave after typing settles.'
+        : 'Edit the task description for the current task. Changes autosave after typing settles.',
+    agentEntityId: recordId,
+    agentEntityLabel:
+      objectNameSingular === CoreObjectNameSingular.Note
+        ? `Note ${recordId}`
+        : `Task ${recordId}`,
+    agentEntityType: objectNameSingular,
+    agentExecution: {
+      settled_when: [
+        'Typed rich text remains visible after focus leaves the editor and the side panel stays open.',
+      ],
+    },
+    agentLabel:
+      objectNameSingular === CoreObjectNameSingular.Note
+        ? 'Edit note body'
+        : 'Edit task description',
+    agentRecovery: {
+      partial_state_changed: true,
+      recovery:
+        'If the content does not persist, reopen the same record and verify the body before retrying.',
+      retryable: true,
+    },
+    agentRisk: 'medium' as const,
+    agentWorkflowStep:
+      objectNameSingular === CoreObjectNameSingular.Note
+        ? 'note.edit_body'
+        : 'task.edit_body',
+  };
 };

--- a/packages/twenty-front/src/modules/object-record/record-field/ui/meta-types/input/components/SelectFieldInput.tsx
+++ b/packages/twenty-front/src/modules/object-record/record-field/ui/meta-types/input/components/SelectFieldInput.tsx
@@ -1,3 +1,4 @@
+import { useAICElement } from '@aicorg/sdk-react';
 import { t } from '@lingui/core/macro';
 import { FieldInputEventContext } from '@/object-record/record-field/ui/contexts/FieldInputEventContext';
 import { useClearField } from '@/object-record/record-field/ui/hooks/useClearField';
@@ -11,13 +12,14 @@ import { SelectInput } from '@/ui/field/input/components/SelectInput';
 import { useSelectableList } from '@/ui/layout/selectable-list/hooks/useSelectableList';
 import { useHotkeysOnFocusedElement } from '@/ui/utilities/hotkey/hooks/useHotkeysOnFocusedElement';
 import { useAvailableComponentInstanceIdOrThrow } from '@/ui/utilities/state/component-state/hooks/useAvailableComponentInstanceIdOrThrow';
+import { type HTMLAttributes } from 'react';
 import { useContext, useState } from 'react';
 import { Key } from 'ts-key-enum';
 import { isDefined } from 'twenty-shared/utils';
 import { type SelectOption } from 'twenty-ui/input';
 
 export const SelectFieldInput = () => {
-  const { fieldDefinition, fieldValue } = useSelectField();
+  const { fieldDefinition, fieldValue, recordId } = useSelectField();
   const { addSelectOption } = useAddSelectOption(
     fieldDefinition?.metadata?.fieldName,
   );
@@ -84,33 +86,156 @@ export const SelectFieldInput = () => {
     ...filteredOptions.map((option) => option.value),
   ];
 
+  const editorMetadata = buildOpportunityStageSelectAICMetadata({
+    recordId,
+    fieldName: fieldDefinition.metadata.fieldName,
+    objectNameSingular: fieldDefinition.metadata.objectMetadataNameSingular,
+    fieldLabel,
+    options: fieldDefinition.metadata.options,
+  });
+
+  const optionMetadataByValue = new Map(
+    buildOpportunityStageOptionAICMetadata({
+      recordId,
+      fieldName: fieldDefinition.metadata.fieldName,
+      objectNameSingular: fieldDefinition.metadata.objectMetadataNameSingular,
+      fieldLabel,
+      options: fieldDefinition.metadata.options,
+    }).map((metadata) => [metadata.optionValue, metadata]),
+  );
+
   return (
-    <SelectInput
-      selectableListComponentInstanceId={
-        SELECT_FIELD_INPUT_SELECTABLE_LIST_COMPONENT_INSTANCE_ID
-      }
-      selectableItemIdArray={optionIds}
-      focusId={instanceId}
-      onEnter={(itemId) => {
-        const option = filteredOptions.find(
-          (option) => option.value === itemId,
-        );
-        if (isDefined(option)) {
-          handleSubmit(option);
+    <SelectFieldInputAICWrapper metadata={editorMetadata}>
+      <SelectInput
+        selectableListComponentInstanceId={
+          SELECT_FIELD_INPUT_SELECTABLE_LIST_COMPONENT_INSTANCE_ID
         }
-      }}
-      onOptionSelected={handleSubmit}
-      options={selectOptions}
-      onCancel={onCancel}
-      defaultOption={selectedOption}
-      onFilterChange={setFilteredOptions}
-      onClear={
-        fieldDefinition.metadata.isNullable && canSelectEmpty
-          ? handleClearField
-          : undefined
-      }
-      clearLabel={fieldDefinition.label}
-      onAddSelectOption={handleAddSelectOption}
-    />
+        selectableItemIdArray={optionIds}
+        focusId={instanceId}
+        onEnter={(itemId) => {
+          const option = filteredOptions.find(
+            (option) => option.value === itemId,
+          );
+          if (isDefined(option)) {
+            handleSubmit(option);
+          }
+        }}
+        onOptionSelected={handleSubmit}
+        options={selectOptions}
+        onCancel={onCancel}
+        defaultOption={selectedOption}
+        onFilterChange={setFilteredOptions}
+        onClear={
+          fieldDefinition.metadata.isNullable && canSelectEmpty
+            ? handleClearField
+            : undefined
+        }
+        clearLabel={fieldDefinition.label}
+        onAddSelectOption={handleAddSelectOption}
+        getOptionContainerProps={(option) => {
+          const metadata = optionMetadataByValue.get(option.value);
+          return metadata?.attributes;
+        }}
+      />
+    </SelectFieldInputAICWrapper>
+  );
+};
+
+const SelectFieldInputAICWrapper = ({
+  metadata,
+  children,
+}: {
+  metadata: ReturnType<typeof buildOpportunityStageSelectAICMetadata>;
+  children: React.ReactNode;
+}) => {
+  if (!metadata) {
+    return children;
+  }
+
+  const { attributes } = useAICElement(metadata, {
+    defaultAction: 'edit',
+    role: 'listbox',
+  });
+
+  return <div {...attributes}>{children}</div>;
+};
+
+const buildOpportunityStageSelectAICMetadata = ({
+  recordId,
+  fieldName,
+  objectNameSingular,
+  fieldLabel,
+  options,
+}: {
+  recordId: string;
+  fieldName: string;
+  objectNameSingular: string;
+  fieldLabel: string;
+  options?: Array<{ label: string; value: string }>;
+}) => {
+  if (objectNameSingular !== 'opportunity' || fieldName !== 'stage') {
+    return null;
+  }
+
+  const optionLabels = options?.map((option) => option.label).filter(Boolean);
+
+  return {
+    agentId: `opportunity.stage.select.${recordId}`,
+    agentAction: 'edit' as const,
+    agentDescription: optionLabels?.length
+      ? `Choose a new stage for this exact opportunity. Available labels include: ${optionLabels.join(', ')}.`
+      : 'Choose a new stage for this exact opportunity.',
+    agentEntityId: recordId,
+    agentEntityLabel: `Opportunity ${recordId}`,
+    agentEntityType: 'opportunity',
+    agentExecution: {
+      settled_when: [
+        'The updated stage label is visible on the opportunity record after the selector closes.',
+      ],
+    },
+    agentLabel: fieldLabel,
+    agentRecovery: {
+      partial_state_changed: true,
+      recovery:
+        'If the new stage does not remain visible after the selector closes, reopen the same opportunity and verify the stage before retrying.',
+      retryable: true,
+    },
+    agentRisk: 'medium' as const,
+    agentWorkflowStep: 'opportunity.stage.select_value',
+  };
+};
+
+const buildOpportunityStageOptionAICMetadata = ({
+  recordId,
+  fieldName,
+  objectNameSingular,
+  fieldLabel,
+  options,
+}: {
+  recordId: string;
+  fieldName: string;
+  objectNameSingular: string;
+  fieldLabel: string;
+  options?: Array<{ label: string; value: string }>;
+}) => {
+  if (objectNameSingular !== 'opportunity' || fieldName !== 'stage') {
+    return [];
+  }
+
+  return (
+    options?.map((option) => ({
+      optionValue: option.value,
+      attributes: {
+        'data-agent-id': `opportunity.stage.option.${recordId}.${option.value}`,
+        'data-agent-action': 'edit',
+        'data-agent-description': `Select the ${option.label} stage for this exact opportunity.`,
+        'data-agent-entity-id': recordId,
+        'data-agent-entity-label': `Opportunity ${recordId}`,
+        'data-agent-entity-type': 'opportunity',
+        'data-agent-label': `${fieldLabel} ${option.label}`,
+        'data-agent-risk': 'medium',
+        'data-agent-workflow': 'opportunity.stage.select_value',
+      } satisfies HTMLAttributes<HTMLDivElement>,
+    })) ?? []
   );
 };

--- a/packages/twenty-front/src/modules/object-record/record-inline-cell/components/RecordInlineCell.tsx
+++ b/packages/twenty-front/src/modules/object-record/record-inline-cell/components/RecordInlineCell.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useContext } from 'react';
+import { useCallback, useContext, useState } from 'react';
 
 import { FieldDisplay } from '@/object-record/record-field/ui/components/FieldDisplay';
 import { FieldInput } from '@/object-record/record-field/ui/components/FieldInput';
@@ -47,19 +47,23 @@ export const RecordInlineCell = ({
   } = useContext(FieldContext);
   const { scopeInstanceId } = useRecordFieldsScopeContextOrThrow();
   const store = useStore();
+  const [isEditModeOpen, setIsEditModeOpen] = useState(false);
 
   const { openFieldInput, closeFieldInput } = useOpenFieldInputEditMode();
 
   const onOpenEditMode = onOpenEditModeFromContext
     ? onOpenEditModeFromContext
-    : () =>
+    : () => {
+        setIsEditModeOpen(true);
         openFieldInput({
           fieldDefinition,
           recordId,
           prefix: instanceIdPrefix,
         });
+      };
 
   const onCloseEditMode = useCallback(() => {
+    setIsEditModeOpen(false);
     onCloseEditModeFromContext
       ? onCloseEditModeFromContext()
       : closeFieldInput({
@@ -189,6 +193,7 @@ export const RecordInlineCell = ({
     isDisplayModeFixHeight: isDisplayModeFixHeight,
     editModeContentOnly: isFieldInputOnly,
     loading: loading,
+    isEditModeOpen,
     onOpenEditMode,
     onCloseEditMode,
   };

--- a/packages/twenty-front/src/modules/object-record/record-inline-cell/components/RecordInlineCellAnchoredPortalContext.tsx
+++ b/packages/twenty-front/src/modules/object-record/record-inline-cell/components/RecordInlineCellAnchoredPortalContext.tsx
@@ -6,6 +6,7 @@ import { useIsFieldInputOnly } from '@/object-record/record-field/ui/hooks/useIs
 import {
   RecordInlineCellContext,
   type RecordInlineCellContextProps,
+  useRecordInlineCellContext,
 } from '@/object-record/record-inline-cell/components/RecordInlineCellContext';
 import { useContext, type ReactNode } from 'react';
 import { useIcons } from 'twenty-ui/display';
@@ -17,6 +18,7 @@ type RecordInlineCellAnchoredPortalContextProps = {
 export const RecordInlineCellAnchoredPortalContext = ({
   children,
 }: RecordInlineCellAnchoredPortalContextProps) => {
+  const parentInlineCellContext = useRecordInlineCellContext();
   const {
     isRecordFieldReadOnly,
     fieldDefinition,
@@ -44,6 +46,7 @@ export const RecordInlineCellAnchoredPortalContext = ({
     isDisplayModeFixHeight: isDisplayModeFixHeight,
     editModeContentOnly: isFieldInputOnly,
     loading: false,
+    isEditModeOpen: parentInlineCellContext.isEditModeOpen,
     onOpenEditMode,
     onCloseEditMode,
   };

--- a/packages/twenty-front/src/modules/object-record/record-inline-cell/components/RecordInlineCellContainer.tsx
+++ b/packages/twenty-front/src/modules/object-record/record-inline-cell/components/RecordInlineCellContainer.tsx
@@ -1,5 +1,6 @@
+import { useAICElement } from '@aicorg/sdk-react';
 import { styled } from '@linaria/react';
-import { useContext } from 'react';
+import { type HTMLAttributes, useContext } from 'react';
 import { ThemeContext, themeCssVariables } from 'twenty-ui/theme-constants';
 
 import { FieldContext } from '@/object-record/record-field/ui/contexts/FieldContext';
@@ -70,7 +71,7 @@ export const StyledSkeletonDiv = styled.div`
 `;
 
 export const RecordInlineCellContainer = () => {
-  const { readonly, IconLabel, label, labelWidth, showLabel } =
+  const { readonly, IconLabel, label, labelWidth, showLabel, isEditModeOpen } =
     useRecordInlineCellContext();
   const { theme } = useContext(ThemeContext);
 
@@ -101,6 +102,14 @@ export const RecordInlineCellContainer = () => {
     recordId,
     fieldName: fieldDefinition?.metadata?.fieldName,
   })}`;
+
+  const fieldEntryMetadata = buildOpportunityStageEntryAICMetadata({
+    isEditModeOpen,
+    recordId,
+    fieldName: fieldDefinition?.metadata?.fieldName,
+    objectNameSingular: fieldDefinition?.metadata?.objectMetadataNameSingular,
+    fieldLabel: fieldDefinition?.label,
+  });
 
   return (
     <StyledInlineCellBaseContainer
@@ -135,8 +144,70 @@ export const RecordInlineCellContainer = () => {
         </StyledLabelAndIconContainer>
       )}
       <StyledValueContainer readonly={readonly ?? false} id={anchorId}>
-        <RecordInlineCellValue />
+        <RecordInlineCellAICBridge metadata={fieldEntryMetadata}>
+          {(containerAttributes) => (
+            <RecordInlineCellValue containerAttributes={containerAttributes} />
+          )}
+        </RecordInlineCellAICBridge>
       </StyledValueContainer>
     </StyledInlineCellBaseContainer>
   );
+};
+
+const RecordInlineCellAICBridge = ({
+  metadata,
+  children,
+}: {
+  metadata: ReturnType<typeof buildOpportunityStageEntryAICMetadata>;
+  children: (
+    containerAttributes?: HTMLAttributes<HTMLDivElement>,
+  ) => React.ReactNode;
+}) => {
+  if (!metadata) {
+    return children();
+  }
+
+  const { attributes } = useAICElement(metadata, {
+    defaultAction: 'click',
+  });
+
+  return children(attributes as HTMLAttributes<HTMLDivElement>);
+};
+
+const buildOpportunityStageEntryAICMetadata = ({
+  isEditModeOpen,
+  recordId,
+  fieldName,
+  objectNameSingular,
+  fieldLabel,
+}: {
+  isEditModeOpen?: boolean;
+  recordId: string;
+  fieldName?: string;
+  objectNameSingular?: string;
+  fieldLabel?: string;
+}) => {
+  if (objectNameSingular !== 'opportunity' || fieldName !== 'stage') {
+    return null;
+  }
+
+  return {
+    agentId: isEditModeOpen
+      ? `opportunity.stage.select_trigger.${recordId}`
+      : `opportunity.stage.open_editor.${recordId}`,
+    agentAction: 'click' as const,
+    agentDescription: isEditModeOpen
+      ? 'Open the stage option list for this exact opportunity from the active inline editor.'
+      : 'Open the opportunity stage editor for this exact record before choosing a new stage.',
+    agentEntityId: recordId,
+    agentEntityLabel: `Opportunity ${recordId}`,
+    agentEntityType: 'opportunity',
+    agentLabel: isEditModeOpen
+      ? `${fieldLabel ?? 'Stage'} current value`
+      : fieldLabel ?? 'Stage',
+    agentRisk: 'medium' as const,
+    agentWorkflowStep: isEditModeOpen
+      ? 'opportunity.stage.open_selector'
+      : 'opportunity.stage.open_editor',
+  };
 };

--- a/packages/twenty-front/src/modules/object-record/record-inline-cell/components/RecordInlineCellContext.tsx
+++ b/packages/twenty-front/src/modules/object-record/record-inline-cell/components/RecordInlineCellContext.tsx
@@ -15,6 +15,7 @@ export type RecordInlineCellContextProps = {
   disableHoverEffect?: boolean;
   loading?: boolean;
   isCentered?: boolean;
+  isEditModeOpen?: boolean;
   onOpenEditMode?: () => void;
   onCloseEditMode?: () => void;
 };
@@ -33,6 +34,7 @@ const defaultRecordInlineCellContextProp: RecordInlineCellContextProps = {
   disableHoverEffect: false,
   loading: false,
   isCentered: false,
+  isEditModeOpen: false,
   onOpenEditMode: undefined,
   onCloseEditMode: undefined,
 };

--- a/packages/twenty-front/src/modules/object-record/record-inline-cell/components/RecordInlineCellDisplayMode.tsx
+++ b/packages/twenty-front/src/modules/object-record/record-inline-cell/components/RecordInlineCellDisplayMode.tsx
@@ -3,20 +3,28 @@ import { styled } from '@linaria/react';
 import { FieldContext } from '@/object-record/record-field/ui/contexts/FieldContext';
 import { useIsFieldEmpty } from '@/object-record/record-field/ui/hooks/useIsFieldEmpty';
 import { useIsFieldInputOnly } from '@/object-record/record-field/ui/hooks/useIsFieldInputOnly';
+import { RecordFieldComponentInstanceContext } from '@/object-record/record-field/ui/states/contexts/RecordFieldComponentInstanceContext';
 import {
   useRecordInlineCellContext,
   type RecordInlineCellContextProps,
 } from '@/object-record/record-inline-cell/components/RecordInlineCellContext';
 import { RecordInlineCellButton } from '@/object-record/record-inline-cell/components/RecordInlineCellEditButton';
+import { focusStackState } from '@/ui/utilities/focus/states/focusStackState';
+import { useAvailableComponentInstanceIdOrThrow } from '@/ui/utilities/state/component-state/hooks/useAvailableComponentInstanceIdOrThrow';
+import { useAtomStateValue } from '@/ui/utilities/state/jotai/hooks/useAtomStateValue';
 import { useLingui } from '@lingui/react/macro';
-import { useContext } from 'react';
+import { type HTMLAttributes, useContext } from 'react';
 import { themeCssVariables } from 'twenty-ui/theme-constants';
 
 const StyledRecordInlineCellNormalModeOuterContainer = styled.div<
   Pick<
     RecordInlineCellContextProps,
     'isDisplayModeFixHeight' | 'disableHoverEffect' | 'readonly'
-  > & { isHovered?: boolean }
+  > & {
+    isHovered?: boolean;
+    disablePointerEvents?: boolean;
+    promoteAboveOverlays?: boolean;
+  }
 >`
   align-items: center;
   background-color: ${({ isHovered, readonly, disableHoverEffect }) =>
@@ -38,6 +46,14 @@ const StyledRecordInlineCellNormalModeOuterContainer = styled.div<
   overflow: hidden;
   padding-left: ${themeCssVariables.spacing[1]};
   padding-right: ${themeCssVariables.spacing[1]};
+  pointer-events: ${({ disablePointerEvents }) =>
+    disablePointerEvents ? 'none' : 'auto'};
+  position: relative;
+  z-index: ${({ promoteAboveOverlays }) => (promoteAboveOverlays ? 1 : 'auto')};
+
+  * {
+    pointer-events: none;
+  }
 `;
 
 const StyledRecordInlineCellNormalModeInnerContainer = styled.div`
@@ -49,7 +65,6 @@ const StyledRecordInlineCellNormalModeInnerContainer = styled.div`
   overflow: hidden;
   padding-bottom: 2px;
   padding-top: 2px;
-
   text-overflow: ellipsis;
   white-space: nowrap;
 `;
@@ -65,16 +80,26 @@ export const RecordInlineCellDisplayMode = ({
   children,
   onClick,
   isHovered,
+  containerAttributes,
 }: React.PropsWithChildren<{
   isHovered: boolean;
   onClick?: () => void;
+  containerAttributes?: HTMLAttributes<HTMLDivElement>;
 }>) => {
   const { t } = useLingui();
+  const recordFieldInstanceId = useAvailableComponentInstanceIdOrThrow(
+    RecordFieldComponentInstanceContext,
+  );
+  const focusStack = useAtomStateValue(focusStackState);
 
-  const { editModeContentOnly, label, buttonIcon, readonly } =
+  const { editModeContentOnly, label, buttonIcon, readonly, isEditModeOpen } =
     useRecordInlineCellContext();
 
-  const { isForbidden } = useContext(FieldContext);
+  const { isForbidden, recordId, fieldDefinition } = useContext(FieldContext);
+  const isCurrentFieldEditing = focusStack.some(
+    (item) =>
+      item.componentInstance.componentInstanceId === recordFieldInstanceId,
+  );
 
   const isFieldEmpty = useIsFieldEmpty();
   const showEditButton =
@@ -92,12 +117,47 @@ export const RecordInlineCellDisplayMode = ({
 
   const shouldShowEmptyPlaceholder = isFieldEmpty && !isForbidden;
 
+  const handleKeyDown = (event: React.KeyboardEvent<HTMLDivElement>) => {
+    if (!onClick || readonly) {
+      return;
+    }
+
+    if (event.key === 'Enter' || event.key === ' ') {
+      event.preventDefault();
+      onClick();
+    }
+  };
+
+  const stageAttributes = buildOpportunityStageDisplayAICAttributes({
+    recordId,
+    fieldLabel: label,
+    fieldName: fieldDefinition.metadata.fieldName,
+    isEditModeOpen,
+    isCurrentFieldEditing,
+    objectNameSingular: fieldDefinition.metadata.objectMetadataNameSingular,
+  });
+  const shouldDisableStagePointerEvents =
+    fieldDefinition.metadata.objectMetadataNameSingular === 'opportunity' &&
+    fieldDefinition.metadata.fieldName === 'stage' &&
+    isCurrentFieldEditing &&
+    !isEditModeOpen;
+  const shouldPromoteStageSelectorEntry =
+    stageAttributes?.['data-agent-id']?.includes('.select_trigger.') ?? false;
+
   return (
     <>
       <StyledRecordInlineCellNormalModeOuterContainer
+        disablePointerEvents={shouldDisableStagePointerEvents}
         isHovered={isHovered}
+        promoteAboveOverlays={shouldPromoteStageSelectorEntry}
         readonly={readonly}
         onClick={onClick}
+        onKeyDown={handleKeyDown}
+        data-inline-editable={onClick ? '1' : '0'}
+        role={readonly ? undefined : 'button'}
+        tabIndex={readonly ? -1 : 0}
+        {...containerAttributes}
+        {...stageAttributes}
       >
         <StyledRecordInlineCellNormalModeInnerContainer>
           {shouldShowValue ? (
@@ -112,4 +172,46 @@ export const RecordInlineCellDisplayMode = ({
       )}
     </>
   );
+};
+
+const buildOpportunityStageDisplayAICAttributes = ({
+  recordId,
+  fieldLabel,
+  fieldName,
+  isEditModeOpen,
+  isCurrentFieldEditing,
+  objectNameSingular,
+}: {
+  recordId: string;
+  fieldLabel?: string;
+  fieldName?: string;
+  isEditModeOpen?: boolean;
+  isCurrentFieldEditing?: boolean;
+  objectNameSingular?: string;
+}): HTMLAttributes<HTMLDivElement> | undefined => {
+  if (objectNameSingular !== 'opportunity' || fieldName !== 'stage') {
+    return undefined;
+  }
+
+  const isSelectorEntryActive = isEditModeOpen || isCurrentFieldEditing;
+
+  return {
+    'data-agent-id': isSelectorEntryActive
+      ? `opportunity.stage.select_trigger.${recordId}`
+      : `opportunity.stage.open_editor.${recordId}`,
+    'data-agent-action': 'click',
+    'data-agent-description': isSelectorEntryActive
+      ? 'Open the stage option list for this exact opportunity from the active inline editor.'
+      : 'Open the opportunity stage editor for this exact record before choosing a new stage.',
+    'data-agent-entity-id': recordId,
+    'data-agent-entity-label': `Opportunity ${recordId}`,
+    'data-agent-entity-type': 'opportunity',
+    'data-agent-label': isSelectorEntryActive
+      ? `${fieldLabel ?? 'Stage'} current value`
+      : fieldLabel ?? 'Stage',
+    'data-agent-risk': 'medium',
+    'data-agent-workflow': isSelectorEntryActive
+      ? 'opportunity.stage.open_selector'
+      : 'opportunity.stage.open_editor',
+  } satisfies HTMLAttributes<HTMLDivElement>;
 };

--- a/packages/twenty-front/src/modules/object-record/record-inline-cell/components/RecordInlineCellEditMode.tsx
+++ b/packages/twenty-front/src/modules/object-record/record-inline-cell/components/RecordInlineCellEditMode.tsx
@@ -15,7 +15,7 @@ import {
   useFloating,
   type MiddlewareState,
 } from '@floating-ui/react';
-import { useContext } from 'react';
+import { type HTMLAttributes, useContext } from 'react';
 import { createPortal } from 'react-dom';
 
 const StyledInlineCellEditModeContainer = styled.div`
@@ -37,6 +37,7 @@ export const RecordInlineCellEditMode = ({
   children,
 }: RecordInlineCellEditModeProps) => {
   const { isCentered } = useContext(RecordInlineCellContext);
+  const { recordId, fieldDefinition } = useContext(FieldContext);
 
   const recordFieldComponentInstanceId = useAvailableComponentInstanceIdOrThrow(
     RecordFieldComponentInstanceContext,

--- a/packages/twenty-front/src/modules/object-record/record-inline-cell/components/RecordInlineCellHoveredPortal.tsx
+++ b/packages/twenty-front/src/modules/object-record/record-inline-cell/components/RecordInlineCellHoveredPortal.tsx
@@ -3,6 +3,7 @@ import { styled } from '@linaria/react';
 const StyledRecordTableCellHoveredPortal = styled.div`
   height: 100%;
   left: 0;
+  pointer-events: none;
   position: absolute;
   top: 0;
   width: 100%;

--- a/packages/twenty-front/src/modules/object-record/record-inline-cell/components/RecordInlineCellHoveredPortalContent.tsx
+++ b/packages/twenty-front/src/modules/object-record/record-inline-cell/components/RecordInlineCellHoveredPortalContent.tsx
@@ -5,12 +5,14 @@ import { themeCssVariables } from 'twenty-ui/theme-constants';
 const StyledRecordTableCellHoveredPortalContent = styled.div<{
   readonly?: boolean;
   isCentered?: boolean;
+  isDisabled?: boolean;
 }>`
   align-items: center;
   display: flex;
   gap: ${themeCssVariables.spacing[1]};
   justify-content: ${({ isCentered }) =>
     isCentered === true ? 'center' : 'normal'};
+  pointer-events: ${({ isDisabled }) => (isDisabled ? 'none' : 'auto')};
 
   width: 100%;
 `;
@@ -29,12 +31,14 @@ type RecordInlineCellHoveredPortalContentProps = {
   children: React.ReactNode;
   readonly: boolean;
   isCentered?: boolean;
+  isDisabled?: boolean;
   onMouseLeave?: () => void;
 };
 
 export const RecordInlineCellHoveredPortalContent = ({
   children,
   isCentered,
+  isDisabled,
   readonly,
   onMouseLeave,
 }: RecordInlineCellHoveredPortalContentProps) => {
@@ -46,6 +50,7 @@ export const RecordInlineCellHoveredPortalContent = ({
       >
         <StyledRecordTableCellHoveredPortalContent
           isCentered={isCentered}
+          isDisabled={isDisabled}
           readonly={readonly}
         >
           {children}

--- a/packages/twenty-front/src/modules/object-record/record-inline-cell/components/RecordInlineCellValue.tsx
+++ b/packages/twenty-front/src/modules/object-record/record-inline-cell/components/RecordInlineCellValue.tsx
@@ -1,4 +1,5 @@
 import { styled } from '@linaria/react';
+import { type HTMLAttributes } from 'react';
 
 import { FieldDisplay } from '@/object-record/record-field/ui/components/FieldDisplay';
 import { useFieldFocus } from '@/object-record/record-field/ui/hooks/useFieldFocus';
@@ -21,7 +22,11 @@ const StyledClickableContainer = styled.div<{
   width: 100%;
 `;
 
-export const RecordInlineCellValue = () => {
+export const RecordInlineCellValue = ({
+  containerAttributes,
+}: {
+  containerAttributes?: HTMLAttributes<HTMLDivElement>;
+}) => {
   const { readonly, loading, isCentered, onOpenEditMode } =
     useRecordInlineCellContext();
   const { isFocused } = useFieldFocus();
@@ -35,6 +40,7 @@ export const RecordInlineCellValue = () => {
       <RecordInlineCellDisplayMode
         isHovered={isFocused}
         onClick={onOpenEditMode}
+        containerAttributes={containerAttributes}
       >
         <FieldDisplay />
       </RecordInlineCellDisplayMode>

--- a/packages/twenty-front/src/modules/object-record/record-table/record-table-cell/components/RecordTableCellFieldContextLabelIdentifier.tsx
+++ b/packages/twenty-front/src/modules/object-record/record-table/record-table-cell/components/RecordTableCellFieldContextLabelIdentifier.tsx
@@ -9,14 +9,17 @@ import { useRecordTableRowContextOrThrow } from '@/object-record/record-table/co
 import { RecordTableUpdateContext } from '@/object-record/record-table/contexts/RecordTableUpdateContext';
 import { isRecordTableCellsNonEditableComponentState } from '@/object-record/record-table/states/isRecordTableCellsNonEditableComponentState';
 import { useAtomComponentStateValue } from '@/ui/utilities/state/jotai/hooks/useAtomComponentStateValue';
-import { useContext, type ReactNode } from 'react';
+import { useAICElement } from '@aicorg/sdk-react';
+import { useContext, useId, type ReactNode } from 'react';
 
 type RecordTableCellFieldContextLabelIdentifierProps = {
   children: ReactNode;
+  aicSurface?: 'table' | 'portal';
 };
 
 export const RecordTableCellFieldContextLabelIdentifier = ({
   children,
+  aicSurface = 'table',
 }: RecordTableCellFieldContextLabelIdentifierProps) => {
   const {
     objectPermissionsByObjectMetadataId,
@@ -48,6 +51,22 @@ export const RecordTableCellFieldContextLabelIdentifier = ({
 
   const fieldDefinition =
     fieldDefinitionByFieldMetadataItemId[recordField.fieldMetadataItemId];
+  const portalInstanceId = useId().replace(/:/g, '');
+
+  const { attributes } = useAICElement({
+    agentId:
+      aicSurface === 'table'
+        ? `${objectMetadataItem.nameSingular}.row.open_identifier.${recordId}`
+        : `${objectMetadataItem.nameSingular}.row.open_identifier.portal.${recordId}.${portalInstanceId}`,
+    agentAction: 'navigate',
+    agentDescription: `Open the ${objectMetadataItem.labelSingular} record details from the list identifier.`,
+    agentEntityId: recordId,
+    agentEntityLabel: `${objectMetadataItem.labelSingular} ${recordId}`,
+    agentEntityType: objectMetadataItem.nameSingular,
+    agentLabel: `Open ${objectMetadataItem.labelSingular} from list`,
+    agentRisk: 'low',
+    agentWorkflowStep: `${objectMetadataItem.nameSingular}.locate_record`,
+  });
 
   const handleChipClick = () => {
     onRecordIdentifierClick?.(rowIndex, recordId);
@@ -77,7 +96,8 @@ export const RecordTableCellFieldContextLabelIdentifier = ({
         maxWidth: recordField.size,
         onRecordChipClick: handleChipClick,
         isForbidden: !hasObjectReadPermissions,
-        triggerEvent,
+        triggerEvent: aicSurface === 'table' ? 'CLICK' : triggerEvent,
+        recordChipLinkAttributes: attributes,
       }}
     >
       {children}

--- a/packages/twenty-front/src/modules/object-record/record-table/record-table-cell/components/RecordTableCellFieldContextWrapper.tsx
+++ b/packages/twenty-front/src/modules/object-record/record-table/record-table-cell/components/RecordTableCellFieldContextWrapper.tsx
@@ -11,11 +11,13 @@ import { type ReactNode } from 'react';
 type RecordTableCellFieldContextWrapperProps = {
   children: ReactNode;
   recordField: RecordField;
+  aicSurface?: 'table' | 'portal';
 };
 
 export const RecordTableCellFieldContextWrapper = ({
   recordField,
   children,
+  aicSurface = 'table',
 }: RecordTableCellFieldContextWrapperProps) => {
   const { recordId } = useRecordTableRowContextOrThrow();
 
@@ -39,7 +41,10 @@ export const RecordTableCellFieldContextWrapper = ({
   return (
     <RecordFieldComponentInstanceContext.Provider value={{ instanceId }}>
       {isLabelIdentifier ? (
-        <RecordTableCellFieldContextLabelIdentifier key={instanceId}>
+        <RecordTableCellFieldContextLabelIdentifier
+          key={instanceId}
+          aicSurface={aicSurface}
+        >
           {children}
         </RecordTableCellFieldContextLabelIdentifier>
       ) : (

--- a/packages/twenty-front/src/modules/object-record/record-table/record-table-cell/components/RecordTableCellPortalContexts.tsx
+++ b/packages/twenty-front/src/modules/object-record/record-table/record-table-cell/components/RecordTableCellPortalContexts.tsx
@@ -64,7 +64,10 @@ export const RecordTableCellPortalContexts = ({
           cellPosition: position,
         }}
       >
-        <RecordTableCellFieldContextWrapper recordField={recordField}>
+        <RecordTableCellFieldContextWrapper
+          recordField={recordField}
+          aicSurface="portal"
+        >
           {children}
         </RecordTableCellFieldContextWrapper>
       </RecordTableCellContext.Provider>

--- a/packages/twenty-front/src/modules/object-record/record-table/record-table-cell/components/RecordTableCellWrapper.tsx
+++ b/packages/twenty-front/src/modules/object-record/record-table/record-table-cell/components/RecordTableCellWrapper.tsx
@@ -32,7 +32,10 @@ export const RecordTableCellWrapper = ({
       }}
       key={recordField.fieldMetadataItemId}
     >
-      <RecordTableCellFieldContextWrapper recordField={recordField}>
+      <RecordTableCellFieldContextWrapper
+        recordField={recordField}
+        aicSurface="table"
+      >
         {children}
       </RecordTableCellFieldContextWrapper>
     </RecordTableCellContext.Provider>

--- a/packages/twenty-front/src/modules/object-record/record-table/record-table-row/components/RecordTableTr.tsx
+++ b/packages/twenty-front/src/modules/object-record/record-table/record-table-row/components/RecordTableTr.tsx
@@ -10,6 +10,7 @@ import { isRecordTableRowFocusedComponentFamilyState } from '@/object-record/rec
 
 import { useAtomComponentFamilyStateValue } from '@/ui/utilities/state/jotai/hooks/useAtomComponentFamilyStateValue';
 import { useAtomComponentStateValue } from '@/ui/utilities/state/jotai/hooks/useAtomComponentStateValue';
+import { useAICElement } from '@aicorg/sdk-react';
 import { forwardRef, type ReactNode } from 'react';
 
 type RecordTableTrProps = {
@@ -50,6 +51,18 @@ export const RecordTableTr = forwardRef<HTMLDivElement, RecordTableTrProps>(
       objectMetadataId: objectMetadataItem.id,
     });
 
+    const { attributes } = useAICElement({
+      agentId: `${objectMetadataItem.nameSingular}.row.open.${recordId}`,
+      agentAction: 'navigate',
+      agentDescription: `Open the ${objectMetadataItem.labelSingular} record details.`,
+      agentEntityId: recordId,
+      agentEntityLabel: `${objectMetadataItem.labelSingular} ${recordId}`,
+      agentEntityType: objectMetadataItem.nameSingular,
+      agentLabel: `Open ${objectMetadataItem.labelSingular}`,
+      agentRisk: 'low',
+      agentWorkflowStep: `${objectMetadataItem.nameSingular}.locate_record`,
+    });
+
     return (
       <RecordTableRowContextProvider
         value={{
@@ -74,6 +87,7 @@ export const RecordTableTr = forwardRef<HTMLDivElement, RecordTableTrProps>(
             isRecordTableRowFocused &&
             !isRecordTableRowActive
           }
+          {...attributes}
           // oxlint-disable-next-line react/jsx-props-no-spreading
           {...props}
         >

--- a/packages/twenty-front/src/modules/page-layout/widgets/field/components/FieldWidgetCellEditModePortal.tsx
+++ b/packages/twenty-front/src/modules/page-layout/widgets/field/components/FieldWidgetCellEditModePortal.tsx
@@ -5,9 +5,13 @@ import { RecordInlineCellAnchoredPortal } from '@/object-record/record-inline-ce
 import { RecordInlineCellEditMode } from '@/object-record/record-inline-cell/components/RecordInlineCellEditMode';
 import { FieldWidgetInputContextProvider } from '@/page-layout/widgets/field/components/FieldWidgetInputContextProvider';
 import { useIsFieldWidgetEditing } from '@/page-layout/widgets/field/hooks/useIsFieldWidgetEditing';
+import { getRecordFieldInputInstanceId } from '@/object-record/utils/getRecordFieldInputId';
+import { getDropdownFocusIdForRecordField } from '@/object-record/utils/getDropdownFocusIdForRecordField';
 import { useOpenFieldWidgetFieldInputEditMode } from '@/page-layout/widgets/field/hooks/useOpenFieldWidgetFieldInputEditMode';
 import { fieldWidgetHoverComponentState } from '@/page-layout/widgets/field/states/fieldWidgetHoverComponentState';
 import { useSetAtomComponentState } from '@/ui/utilities/state/jotai/hooks/useSetAtomComponentState';
+import { activeDropdownFocusIdState } from '@/ui/layout/dropdown/states/activeDropdownFocusIdState';
+import { useAtomStateValue } from '@/ui/utilities/state/jotai/hooks/useAtomStateValue';
 
 type FieldWidgetCellEditModePortalProps = {
   objectMetadataItem: EnrichedObjectMetadataItem;
@@ -22,7 +26,21 @@ export const FieldWidgetCellEditModePortal = ({
   recordId,
   instanceId,
 }: FieldWidgetCellEditModePortalProps) => {
-  const { isEditing } = useIsFieldWidgetEditing();
+  const fieldInstanceId = getRecordFieldInputInstanceId({
+    recordId,
+    fieldName: fieldMetadataItem.name,
+    prefix: instanceId,
+  });
+
+  const { isEditing } = useIsFieldWidgetEditing(fieldInstanceId);
+  const activeDropdownFocusId = useAtomStateValue(activeDropdownFocusIdState);
+  const expectedDropdownFocusId = getDropdownFocusIdForRecordField({
+    recordId,
+    fieldMetadataId: fieldMetadataItem.id,
+    componentType: 'inline-cell',
+    instanceId,
+  });
+  const isDropdownFocused = activeDropdownFocusId === expectedDropdownFocusId;
 
   const setFieldWidgetHover = useSetAtomComponentState(
     fieldWidgetHoverComponentState,
@@ -36,7 +54,7 @@ export const FieldWidgetCellEditModePortal = ({
     closeFieldInput();
   };
 
-  if (!isEditing) {
+  if (!isEditing && !isDropdownFocused) {
     return null;
   }
 

--- a/packages/twenty-front/src/modules/page-layout/widgets/field/components/FieldWidgetCellHoveredContent.tsx
+++ b/packages/twenty-front/src/modules/page-layout/widgets/field/components/FieldWidgetCellHoveredContent.tsx
@@ -6,8 +6,11 @@ import { RecordInlineCellDisplayMode } from '@/object-record/record-inline-cell/
 import { RecordInlineCellHoveredPortalContent } from '@/object-record/record-inline-cell/components/RecordInlineCellHoveredPortalContent';
 import { useInlineCell } from '@/object-record/record-inline-cell/hooks/useInlineCell';
 import { FieldWidgetInputContextProvider } from '@/page-layout/widgets/field/components/FieldWidgetInputContextProvider';
+import { useIsFieldWidgetEditing } from '@/page-layout/widgets/field/hooks/useIsFieldWidgetEditing';
 import { useOpenFieldWidgetFieldInputEditMode } from '@/page-layout/widgets/field/hooks/useOpenFieldWidgetFieldInputEditMode';
-import { useContext } from 'react';
+import { fieldWidgetHoverComponentState } from '@/page-layout/widgets/field/states/fieldWidgetHoverComponentState';
+import { useSetAtomComponentState } from '@/ui/utilities/state/jotai/hooks/useSetAtomComponentState';
+import { useContext, useState } from 'react';
 
 type FieldWidgetCellHoveredContentProps = {
   onMouseLeave: () => void;
@@ -22,12 +25,23 @@ export const FieldWidgetCellHoveredContent = ({
 
   const { openInlineCell } = useInlineCell();
   const { openFieldInput } = useOpenFieldWidgetFieldInputEditMode();
+  const { isEditing } = useIsFieldWidgetEditing();
+  const setFieldWidgetHover = useSetAtomComponentState(
+    fieldWidgetHoverComponentState,
+  );
+  const [isActivating, setIsActivating] = useState(false);
 
   const shouldContainerBeClickable =
     !isRecordFieldReadOnly && !editModeContentOnly;
 
+  if (isActivating) {
+    return null;
+  }
+
   const handleClick = () => {
     if (shouldContainerBeClickable) {
+      setIsActivating(true);
+      setFieldWidgetHover(false);
       openInlineCell();
       openFieldInput({
         fieldDefinition,
@@ -38,6 +52,7 @@ export const FieldWidgetCellHoveredContent = ({
 
   return (
     <RecordInlineCellHoveredPortalContent
+      isDisabled={isActivating || isEditing}
       readonly={isRecordFieldReadOnly}
       isCentered={isCentered}
       onMouseLeave={onMouseLeave}

--- a/packages/twenty-front/src/modules/page-layout/widgets/field/components/FieldWidgetInlineCell.tsx
+++ b/packages/twenty-front/src/modules/page-layout/widgets/field/components/FieldWidgetInlineCell.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useContext } from 'react';
+import { useCallback, useContext, useState } from 'react';
 
 import { FieldDisplay } from '@/object-record/record-field/ui/components/FieldDisplay';
 import { FieldInput } from '@/object-record/record-field/ui/components/FieldInput';
@@ -7,14 +7,13 @@ import { FieldFocusContextProvider } from '@/object-record/record-field/ui/conte
 import { useGetButtonIcon } from '@/object-record/record-field/ui/hooks/useGetButtonIcon';
 
 import { useIsFieldInputOnly } from '@/object-record/record-field/ui/hooks/useIsFieldInputOnly';
-import { useOpenFieldInputEditMode } from '@/object-record/record-field/ui/hooks/useOpenFieldInputEditMode';
-
 import { useRecordFieldsScopeContextOrThrow } from '@/object-record/record-field-list/contexts/RecordFieldsScopeContext';
 import {
   FieldInputEventContext,
   type FieldInputClickOutsideEvent,
   type FieldInputEvent,
 } from '@/object-record/record-field/ui/contexts/FieldInputEventContext';
+import { useInitDraftValue } from '@/object-record/record-field/ui/hooks/useInitDraftValue';
 import { usePersistFieldFromFieldInputContext } from '@/object-record/record-field/ui/hooks/usePersistFieldFromFieldInputContext';
 import {
   RecordInlineCellContext,
@@ -22,8 +21,12 @@ import {
 } from '@/object-record/record-inline-cell/components/RecordInlineCellContext';
 import { getDropdownFocusIdForRecordField } from '@/object-record/utils/getDropdownFocusIdForRecordField';
 import { FieldWidgetInlineCellContainer } from '@/page-layout/widgets/field/components/FieldWidgetInlineCellContainer';
+import { useOpenFieldWidgetFieldInputEditMode } from '@/page-layout/widgets/field/hooks/useOpenFieldWidgetFieldInputEditMode';
+import { fieldWidgetHoverComponentState } from '@/page-layout/widgets/field/states/fieldWidgetHoverComponentState';
 import { useGoBackToPreviousDropdownFocusId } from '@/ui/layout/dropdown/hooks/useGoBackToPreviousDropdownFocusId';
+import { useSetActiveDropdownFocusIdAndMemorizePrevious } from '@/ui/layout/dropdown/hooks/useSetFocusedDropdownIdAndMemorizePrevious';
 import { activeDropdownFocusIdState } from '@/ui/layout/dropdown/states/activeDropdownFocusIdState';
+import { useSetAtomComponentState } from '@/ui/utilities/state/jotai/hooks/useSetAtomComponentState';
 import { useStore } from 'jotai';
 
 type FieldWidgetInlineCellProps = {
@@ -33,10 +36,11 @@ type FieldWidgetInlineCellProps = {
 
 export const FieldWidgetInlineCell = ({
   loading,
-  instanceIdPrefix,
+  instanceIdPrefix: _instanceIdPrefix,
 }: FieldWidgetInlineCellProps) => {
   const { scopeInstanceId } = useRecordFieldsScopeContextOrThrow();
   const store = useStore();
+  const [isEditModeOpen, setIsEditModeOpen] = useState(false);
   const {
     fieldDefinition,
     recordId,
@@ -47,31 +51,43 @@ export const FieldWidgetInlineCell = ({
     isRecordFieldReadOnly: isReadOnly,
   } = useContext(FieldContext);
 
-  const { openFieldInput, closeFieldInput } = useOpenFieldInputEditMode();
+  const { openFieldInput, closeFieldInput } =
+    useOpenFieldWidgetFieldInputEditMode();
+  const initFieldInputDraftValue = useInitDraftValue();
+  const { setActiveDropdownFocusIdAndMemorizePrevious } =
+    useSetActiveDropdownFocusIdAndMemorizePrevious();
+  const setFieldWidgetHover = useSetAtomComponentState(
+    fieldWidgetHoverComponentState,
+  );
 
   const onOpenEditMode = onOpenEditModeFromContext
     ? onOpenEditModeFromContext
-    : () =>
+    : () => {
+        setFieldWidgetHover(false);
+        setIsEditModeOpen(true);
+        initFieldInputDraftValue({
+          recordId,
+          fieldDefinition,
+        });
+        const dropdownId = getDropdownFocusIdForRecordField({
+          recordId,
+          fieldMetadataId: fieldDefinition.fieldMetadataId,
+          componentType: 'inline-cell',
+          instanceId: scopeInstanceId,
+        });
+        setActiveDropdownFocusIdAndMemorizePrevious(dropdownId);
         openFieldInput({
           fieldDefinition,
           recordId,
-          prefix: instanceIdPrefix,
         });
+      };
 
   const onCloseEditMode = useCallback(() => {
-    onCloseEditModeFromContext
-      ? onCloseEditModeFromContext()
-      : closeFieldInput({
-          fieldDefinition,
-          recordId,
-          prefix: instanceIdPrefix,
-        });
+    setIsEditModeOpen(false);
+    onCloseEditModeFromContext ? onCloseEditModeFromContext() : closeFieldInput();
   }, [
     onCloseEditModeFromContext,
     closeFieldInput,
-    fieldDefinition,
-    recordId,
-    instanceIdPrefix,
   ]);
 
   const buttonIcon = useGetButtonIcon();
@@ -182,6 +198,7 @@ export const FieldWidgetInlineCell = ({
     editModeContentOnly: isFieldInputOnly,
     loading: loading,
     isCentered,
+    isEditModeOpen,
     onOpenEditMode,
     onCloseEditMode,
   };

--- a/packages/twenty-front/src/modules/page-layout/widgets/field/hooks/useIsFieldWidgetEditing.ts
+++ b/packages/twenty-front/src/modules/page-layout/widgets/field/hooks/useIsFieldWidgetEditing.ts
@@ -3,9 +3,12 @@ import { focusStackState } from '@/ui/utilities/focus/states/focusStackState';
 import { useAvailableComponentInstanceIdOrThrow } from '@/ui/utilities/state/component-state/hooks/useAvailableComponentInstanceIdOrThrow';
 import { useAtomStateValue } from '@/ui/utilities/state/jotai/hooks/useAtomStateValue';
 
-export const useIsFieldWidgetEditing = () => {
+export const useIsFieldWidgetEditing = (
+  recordFieldInstanceIdFromProps?: string,
+) => {
   const recordFieldInstanceId = useAvailableComponentInstanceIdOrThrow(
     RecordFieldComponentInstanceContext,
+    recordFieldInstanceIdFromProps,
   );
 
   const focusStack = useAtomStateValue(focusStackState);

--- a/packages/twenty-front/src/modules/ui/field/input/components/SelectInput.tsx
+++ b/packages/twenty-front/src/modules/ui/field/input/components/SelectInput.tsx
@@ -1,3 +1,4 @@
+import { type HTMLAttributes } from 'react';
 import { SelectInput as SelectBaseInput } from '@/ui/input/components/SelectInput';
 import { SelectableList } from '@/ui/layout/selectable-list/components/SelectableList';
 import { type SelectOption } from 'twenty-ui/input';
@@ -15,6 +16,9 @@ type SelectInputProps = {
   onClear?: (() => void) | undefined;
   clearLabel?: string;
   onAddSelectOption?: (optionName: string) => void;
+  getOptionContainerProps?: (
+    option: SelectOption,
+  ) => HTMLAttributes<HTMLDivElement> | undefined;
 };
 
 export const SelectInput = ({
@@ -29,6 +33,7 @@ export const SelectInput = ({
   onClear,
   clearLabel,
   onAddSelectOption,
+  getOptionContainerProps,
 }: SelectInputProps) => {
   return (
     <SelectableList
@@ -46,6 +51,7 @@ export const SelectInput = ({
         clearLabel={clearLabel}
         focusId={focusId}
         onAddSelectOption={onAddSelectOption}
+        getOptionContainerProps={getOptionContainerProps}
       />
     </SelectableList>
   );

--- a/packages/twenty-front/src/modules/ui/input/components/SelectControl.tsx
+++ b/packages/twenty-front/src/modules/ui/input/components/SelectControl.tsx
@@ -1,6 +1,6 @@
 import { type SelectSizeVariant } from '@/ui/input/components/Select';
 import { styled } from '@linaria/react';
-import { useContext } from 'react';
+import { type HTMLAttributes, useContext } from 'react';
 import { isDefined } from 'twenty-shared/utils';
 import { IconChevronDown, OverflowingTextWithTooltip } from 'twenty-ui/display';
 import { type SelectOption } from 'twenty-ui/input';
@@ -68,6 +68,7 @@ export type SelectControlProps = {
   selectSizeVariant?: SelectSizeVariant;
   textAccent?: SelectControlTextAccent;
   hasRightElement?: boolean;
+  containerProps?: HTMLAttributes<HTMLDivElement>;
 };
 
 export const SelectControl = ({
@@ -76,6 +77,7 @@ export const SelectControl = ({
   selectSizeVariant,
   textAccent = 'default',
   hasRightElement,
+  containerProps,
 }: SelectControlProps) => {
   const { theme } = useContext(ThemeContext);
   return (
@@ -86,6 +88,7 @@ export const SelectControl = ({
       textAccent={textAccent}
       hasRightElement={hasRightElement}
       title={selectedOption.fullLabel}
+      {...containerProps}
     >
       {isDefined(selectedOption?.Icon) ? (
         <selectedOption.Icon

--- a/packages/twenty-front/src/modules/ui/input/components/SelectInput.tsx
+++ b/packages/twenty-front/src/modules/ui/input/components/SelectInput.tsx
@@ -9,7 +9,7 @@ import { selectedItemIdComponentState } from '@/ui/layout/selectable-list/states
 import { useListenClickOutside } from '@/ui/utilities/pointer-event/hooks/useListenClickOutside';
 import { useAvailableComponentInstanceIdOrThrow } from '@/ui/utilities/state/component-state/hooks/useAvailableComponentInstanceIdOrThrow';
 import { useAtomComponentStateValue } from '@/ui/utilities/state/jotai/hooks/useAtomComponentStateValue';
-import { useEffect, useMemo, useRef, useState } from 'react';
+import { type HTMLAttributes, useEffect, useMemo, useRef, useState } from 'react';
 import { t } from '@lingui/core/macro';
 import { isDefined } from 'twenty-shared/utils';
 import { type TagColor } from 'twenty-ui/components';
@@ -27,6 +27,12 @@ interface SelectInputProps {
   clearLabel?: string;
   focusId: string;
   onAddSelectOption?: (optionName: string) => void;
+  getControlContainerProps?: (
+    selectedOption: SelectOption | undefined,
+  ) => HTMLAttributes<HTMLDivElement> | undefined;
+  getOptionContainerProps?: (
+    option: SelectOption,
+  ) => HTMLAttributes<HTMLDivElement> | undefined;
 }
 
 export const SelectInput = ({
@@ -38,6 +44,8 @@ export const SelectInput = ({
   defaultOption,
   onFilterChange,
   onAddSelectOption,
+  getControlContainerProps,
+  getOptionContainerProps,
 }: SelectInputProps) => {
   const containerRef = useRef<HTMLDivElement>(null);
 
@@ -132,6 +140,7 @@ export const SelectInput = ({
               key={option.value}
               itemId={option.value}
               onEnter={() => handleOptionChange(option)}
+              containerProps={getOptionContainerProps?.(option)}
             >
               <MenuItemSelectTag
                 key={option.value}

--- a/packages/twenty-front/src/modules/ui/layout/dropdown/components/Dropdown.tsx
+++ b/packages/twenty-front/src/modules/ui/layout/dropdown/components/Dropdown.tsx
@@ -24,7 +24,12 @@ import {
   useFloating,
 } from '@floating-ui/react';
 import { styled } from '@linaria/react';
-import { type MouseEvent, type ReactNode, useCallback } from 'react';
+import {
+  type HTMLAttributes,
+  type MouseEvent,
+  type ReactNode,
+  useCallback,
+} from 'react';
 import { flushSync } from 'react-dom';
 import { type Keys } from 'react-hotkeys-hook';
 import { isDefined } from 'twenty-shared/utils';
@@ -46,6 +51,7 @@ const StyledClickableComponent = styled.div<{
 
 export type DropdownProps = {
   clickableComponent?: ReactNode;
+  clickableComponentProps?: HTMLAttributes<HTMLDivElement>;
   clickableComponentWidth?: Width;
   dropdownComponents: ReactNode;
   hotkey?: {
@@ -72,6 +78,7 @@ export type DropdownProps = {
 
 export const Dropdown = ({
   clickableComponent,
+  clickableComponentProps,
   dropdownComponents,
   hotkey,
   dropdownId,
@@ -204,6 +211,7 @@ export const Dropdown = ({
           aria-haspopup={true}
           role="button"
           width={clickableComponentWidth}
+          {...clickableComponentProps}
         >
           {clickableComponent}
         </StyledClickableComponent>

--- a/packages/twenty-front/src/modules/ui/layout/selectable-list/components/SelectableListItem.tsx
+++ b/packages/twenty-front/src/modules/ui/layout/selectable-list/components/SelectableListItem.tsx
@@ -1,4 +1,4 @@
-import { type ReactNode, useEffect, useRef } from 'react';
+import { type HTMLAttributes, type ReactNode, useEffect, useRef } from 'react';
 
 import { SelectableListItemHotkeyEffect } from '@/ui/layout/selectable-list/components/SelectableListItemHotkeyEffect';
 import { isSelectedItemIdComponentFamilyState } from '@/ui/layout/selectable-list/states/isSelectedItemIdComponentFamilyState';
@@ -19,6 +19,7 @@ export type SelectableListItemProps = {
   children: ReactNode;
   onEnter?: () => void;
   className?: string;
+  containerProps?: HTMLAttributes<HTMLDivElement>;
 };
 
 export const SelectableListItem = ({
@@ -26,6 +27,7 @@ export const SelectableListItem = ({
   children,
   onEnter,
   className,
+  containerProps,
 }: SelectableListItemProps) => {
   const isSelectedItemId = useAtomComponentFamilyStateValue(
     isSelectedItemIdComponentFamilyState,
@@ -58,7 +60,11 @@ export const SelectableListItem = ({
       {isSelectedItemId && isDefined(onEnter) && (
         <SelectableListItemHotkeyEffect itemId={itemId} onEnter={onEnter} />
       )}
-      <StyledListItemContainer ref={listItemRef} className={className}>
+      <StyledListItemContainer
+        ref={listItemRef}
+        className={className}
+        {...containerProps}
+      >
         {children}
       </StyledListItemContainer>
     </>

--- a/packages/twenty-front/src/modules/views/components/SortOrFilterChip.tsx
+++ b/packages/twenty-front/src/modules/views/components/SortOrFilterChip.tsx
@@ -111,6 +111,7 @@ type SortOrFilterChipProps = {
   Icon?: IconComponent;
   onRemove: () => void;
   onClick?: () => void;
+  removeButtonProps?: React.ButtonHTMLAttributes<HTMLButtonElement>;
   testId?: string;
   type: SortOrFilterChipType;
 };
@@ -123,6 +124,7 @@ export const SortOrFilterChip = ({
   onRemove,
   testId,
   onClick,
+  removeButtonProps,
   type,
 }: SortOrFilterChipProps) => {
   const { theme } = useContext(ThemeContext);
@@ -151,6 +153,7 @@ export const SortOrFilterChip = ({
         variant={variant}
         onClick={handleDeleteClick}
         data-testid={'remove-icon-' + testId}
+        {...removeButtonProps}
       >
         <IconX size={theme.icon.size.sm} stroke={theme.icon.stroke.sm} />
       </StyledDelete>

--- a/packages/twenty-front/src/modules/views/components/ViewBarFilterDropdown.tsx
+++ b/packages/twenty-front/src/modules/views/components/ViewBarFilterDropdown.tsx
@@ -1,4 +1,5 @@
 import { useResetFilterDropdown } from '@/object-record/object-filter-dropdown/hooks/useResetFilterDropdown';
+import { useRecordIndexContextOrThrow } from '@/object-record/record-index/contexts/RecordIndexContext';
 import { Dropdown } from '@/ui/layout/dropdown/components/Dropdown';
 import { ViewBarFilterDropdownIds } from '@/views/constants/ViewBarFilterDropdownIds';
 
@@ -7,10 +8,12 @@ import { useRemoveRecordFilter } from '@/object-record/record-filter/hooks/useRe
 import { isRecordFilterConsideredEmpty } from '@/object-record/record-filter/utils/isRecordFilterConsideredEmpty';
 import { useAtomComponentStateValue } from '@/ui/utilities/state/jotai/hooks/useAtomComponentStateValue';
 import { ViewBarFilterDropdownContent } from '@/views/components/ViewBarFilterDropdownContent';
+import { useAICElement } from '@aicorg/sdk-react';
 import { isDefined } from 'twenty-shared/utils';
 import { ViewBarFilterButton } from './ViewBarFilterButton';
 
 export const ViewBarFilterDropdown = () => {
+  const { objectMetadataItem } = useRecordIndexContextOrThrow();
   const { resetFilterDropdown } = useResetFilterDropdown();
   const { removeRecordFilter } = useRemoveRecordFilter();
 
@@ -38,12 +41,26 @@ export const ViewBarFilterDropdown = () => {
     resetFilterDropdown();
   };
 
+  const filterAction = useAICElement({
+    agentId: `${objectMetadataItem.nameSingular}.view.filter.open`,
+    agentAction: 'open',
+    agentDescription:
+      'Open the current record list filter controls for this object view.',
+    agentEntityId: objectMetadataItem.id,
+    agentEntityLabel: objectMetadataItem.labelPlural,
+    agentEntityType: `${objectMetadataItem.nameSingular}_view`,
+    agentLabel: `Open ${objectMetadataItem.labelPlural} filter controls`,
+    agentRisk: 'low',
+    agentWorkflowStep: `${objectMetadataItem.nameSingular}.view.open_filter`,
+  });
+
   return (
     <Dropdown
       dropdownId={ViewBarFilterDropdownIds.MAIN}
       onClose={handleDropdownClose}
       onOpen={handleDropdownOpen}
       clickableComponent={<ViewBarFilterButton />}
+      clickableComponentProps={filterAction.attributes}
       dropdownComponents={<ViewBarFilterDropdownContent />}
       dropdownOffset={{ y: 8 }}
       onClickOutside={handleDropdownClickOutside}

--- a/packages/twenty-front/src/modules/views/components/ViewBarFilterDropdownFieldSelectMenuItem.tsx
+++ b/packages/twenty-front/src/modules/views/components/ViewBarFilterDropdownFieldSelectMenuItem.tsx
@@ -1,10 +1,12 @@
 import { type FieldMetadataItem } from '@/object-metadata/types/FieldMetadataItem';
 import { FILTER_FIELD_LIST_ID } from '@/object-record/object-filter-dropdown/constants/FilterFieldListId';
+import { useRecordIndexContextOrThrow } from '@/object-record/record-index/contexts/RecordIndexContext';
 import { SelectableListItem } from '@/ui/layout/selectable-list/components/SelectableListItem';
 import { useSelectableList } from '@/ui/layout/selectable-list/hooks/useSelectableList';
 import { isSelectedItemIdComponentFamilyState } from '@/ui/layout/selectable-list/states/isSelectedItemIdComponentFamilyState';
 import { useAtomComponentFamilyStateValue } from '@/ui/utilities/state/jotai/hooks/useAtomComponentFamilyStateValue';
 import { useInitializeFilterOnFieldMetadataItemFromViewBarFilterDropdown } from '@/views/hooks/useInitializeFilterOnFieldMetadataItemFromViewBarFilterDropdown';
+import { useAICElement } from '@aicorg/sdk-react';
 import { useIcons } from 'twenty-ui/display';
 import { MenuItem } from 'twenty-ui/navigation';
 
@@ -15,6 +17,7 @@ export type ViewBarFilterDropdownFieldSelectMenuItemProps = {
 export const ViewBarFilterDropdownFieldSelectMenuItem = ({
   fieldMetadataItemToSelect,
 }: ViewBarFilterDropdownFieldSelectMenuItemProps) => {
+  const { objectMetadataItem } = useRecordIndexContextOrThrow();
   const { resetSelectedItem } = useSelectableList(FILTER_FIELD_LIST_ID);
 
   const isSelectedItemId = useAtomComponentFamilyStateValue(
@@ -28,6 +31,17 @@ export const ViewBarFilterDropdownFieldSelectMenuItem = ({
   const { getIcon } = useIcons();
 
   const Icon = getIcon(fieldMetadataItemToSelect.icon);
+  const { attributes } = useAICElement({
+    agentId: `${objectMetadataItem.nameSingular}.view.filter.field.${fieldMetadataItemToSelect.name}`,
+    agentAction: 'select',
+    agentDescription: `Initialize a list filter on the ${fieldMetadataItemToSelect.label} field for the current ${objectMetadataItem.labelPlural} view.`,
+    agentEntityId: fieldMetadataItemToSelect.id,
+    agentEntityLabel: fieldMetadataItemToSelect.label,
+    agentEntityType: `${objectMetadataItem.nameSingular}_field`,
+    agentLabel: `Filter ${objectMetadataItem.labelPlural} by ${fieldMetadataItemToSelect.label}`,
+    agentRisk: 'low',
+    agentWorkflowStep: `${objectMetadataItem.nameSingular}.view.select_filter_field`,
+  });
 
   const handleClick = () => {
     resetSelectedItem();
@@ -47,6 +61,7 @@ export const ViewBarFilterDropdownFieldSelectMenuItem = ({
         onClick={handleClick}
         LeftIcon={Icon}
         text={fieldMetadataItemToSelect.label}
+        {...attributes}
       />
     </SelectableListItem>
   );

--- a/packages/twenty-front/src/modules/views/editable-chip/components/EditableFilterChip.tsx
+++ b/packages/twenty-front/src/modules/views/editable-chip/components/EditableFilterChip.tsx
@@ -6,6 +6,7 @@ import { isValidSubFieldName } from '@/settings/data-model/utils/isValidSubField
 import { SortOrFilterChip } from '@/views/components/SortOrFilterChip';
 import { useGetRecordFilterChipLabelValue } from '@/views/hooks/useGetRecordFilterChipLabelValue';
 
+import { useAICElement } from '@aicorg/sdk-react';
 import { isNonEmptyString } from '@sniptt/guards';
 import { useIcons } from 'twenty-ui/display';
 import { FieldMetadataType } from '~/generated-metadata/graphql';
@@ -52,17 +53,43 @@ export const EditableFilterChip = ({
   const labelValue = getRecordFilterChipLabelValue({
     recordFilter,
   });
+  const { attributes } = useAICElement({
+    agentId: `opportunity.view.filter.active.${fieldMetadataItem.name}.${recordFilter.id}`,
+    agentAction: 'open',
+    agentDescription: `Inspect or edit the active ${fieldMetadataItem.label} filter on the current opportunities view.`,
+    agentEntityId: recordFilter.id,
+    agentEntityLabel: fieldMetadataItem.label,
+    agentEntityType: 'opportunity_filter',
+    agentLabel: `Active opportunity filter for ${fieldMetadataItem.label}`,
+    agentRisk: 'low',
+    agentWorkflowStep: 'opportunity.view.inspect_active_filter',
+  });
+
+  const removeAttributes = {
+    'data-agent-id': `opportunity.view.filter.remove.${fieldMetadataItem.name}.${recordFilter.id}`,
+    'data-agent-action': 'click',
+    'data-agent-description': `Remove the active ${fieldMetadataItem.label} filter from the current opportunities view.`,
+    'data-agent-entity-id': recordFilter.id,
+    'data-agent-entity-label': fieldMetadataItem.label,
+    'data-agent-entity-type': 'opportunity_filter',
+    'data-agent-label': `Remove active opportunity filter for ${fieldMetadataItem.label}`,
+    'data-agent-risk': 'low',
+    'data-agent-workflow': 'opportunity.view.clear_active_filter',
+  };
 
   return (
-    <SortOrFilterChip
-      key={recordFilter.id}
-      testId={recordFilter.id}
-      labelKey={labelKey}
-      labelValue={labelValue}
-      Icon={FieldMetadataItemIcon}
-      onRemove={onRemove}
-      onClick={onClick}
-      type="filter"
-    />
+    <div {...attributes}>
+      <SortOrFilterChip
+        key={recordFilter.id}
+        testId={recordFilter.id}
+        labelKey={labelKey}
+        labelValue={labelValue}
+        Icon={FieldMetadataItemIcon}
+        onRemove={onRemove}
+        onClick={onClick}
+        removeButtonProps={removeAttributes}
+        type="filter"
+      />
+    </div>
   );
 };

--- a/packages/twenty-front/src/modules/views/editable-chip/components/EditableRelationFilterChip.tsx
+++ b/packages/twenty-front/src/modules/views/editable-chip/components/EditableRelationFilterChip.tsx
@@ -2,6 +2,7 @@ import { useFieldMetadataItemByIdOrThrow } from '@/object-metadata/hooks/useFiel
 import { type RecordFilter } from '@/object-record/record-filter/types/RecordFilter';
 import { SortOrFilterChip } from '@/views/components/SortOrFilterChip';
 import { useComputeRecordRelationFilterLabelValue } from '@/views/hooks/useComputeRecordRelationFilterLabelValue';
+import { useAICElement } from '@aicorg/sdk-react';
 import { useIcons } from 'twenty-ui/display';
 
 type EditableRelationFilterChipProps = {
@@ -26,17 +27,43 @@ export const EditableRelationFilterChip = ({
   const { labelValue } = useComputeRecordRelationFilterLabelValue({
     recordFilter,
   });
+  const { attributes } = useAICElement({
+    agentId: `opportunity.view.filter.active.${fieldMetadataItem.name}.${recordFilter.id}`,
+    agentAction: 'open',
+    agentDescription: `Inspect or edit the active ${fieldMetadataItem.label} relation filter on the current opportunities view.`,
+    agentEntityId: recordFilter.id,
+    agentEntityLabel: fieldMetadataItem.label,
+    agentEntityType: 'opportunity_filter',
+    agentLabel: `Active opportunity relation filter for ${fieldMetadataItem.label}`,
+    agentRisk: 'low',
+    agentWorkflowStep: 'opportunity.view.inspect_active_filter',
+  });
+
+  const removeAttributes = {
+    'data-agent-id': `opportunity.view.filter.remove.${fieldMetadataItem.name}.${recordFilter.id}`,
+    'data-agent-action': 'click',
+    'data-agent-description': `Remove the active ${fieldMetadataItem.label} relation filter from the current opportunities view.`,
+    'data-agent-entity-id': recordFilter.id,
+    'data-agent-entity-label': fieldMetadataItem.label,
+    'data-agent-entity-type': 'opportunity_filter',
+    'data-agent-label': `Remove active opportunity relation filter for ${fieldMetadataItem.label}`,
+    'data-agent-risk': 'low',
+    'data-agent-workflow': 'opportunity.view.clear_active_filter',
+  };
 
   return (
-    <SortOrFilterChip
-      key={recordFilter.id}
-      testId={recordFilter.id}
-      labelKey={fieldMetadataItem.label}
-      labelValue={labelValue}
-      Icon={FieldMetadataItemIcon}
-      onRemove={onRemove}
-      onClick={onClick}
-      type="filter"
-    />
+    <div {...attributes}>
+      <SortOrFilterChip
+        key={recordFilter.id}
+        testId={recordFilter.id}
+        labelKey={fieldMetadataItem.label}
+        labelValue={labelValue}
+        Icon={FieldMetadataItemIcon}
+        onRemove={onRemove}
+        onClick={onClick}
+        removeButtonProps={removeAttributes}
+        type="filter"
+      />
+    </div>
   );
 };

--- a/packages/twenty-front/tsconfig.json
+++ b/packages/twenty-front/tsconfig.json
@@ -21,6 +21,9 @@
     "forceConsistentCasingInFileNames": true,
     "outDir": "../../.cache/tsc",
     "paths": {
+      "@aicorg/runtime": ["/mnt/c/users/vatsa/agentinteractioncontrol/packages/runtime/src/index.ts"],
+      "@aicorg/sdk-react": ["/mnt/c/users/vatsa/agentinteractioncontrol/packages/sdk-react/src/index.tsx"],
+      "@aicorg/spec": ["/mnt/c/users/vatsa/agentinteractioncontrol/packages/spec/src/index.ts"],
       "@/*": ["./src/modules/*"],
       "~/*": ["./src/*"]
     },

--- a/packages/twenty-front/vite.config.ts
+++ b/packages/twenty-front/vite.config.ts
@@ -18,6 +18,7 @@ import { createWywProfilingPlugin } from 'twenty-shared/vite';
 
 export default defineConfig(({ mode }) => {
   const env = loadEnv(mode, __dirname, '');
+  const aicRepoRoot = '/mnt/c/users/vatsa/agentinteractioncontrol';
 
   const {
     REACT_APP_SERVER_BASE_URL,
@@ -65,6 +66,7 @@ export default defineConfig(({ mode }) => {
           }),
       fs: {
         allow: [
+          aicRepoRoot,
           searchForWorkspaceRoot(process.cwd()),
           '**/@blocknote/core/src/fonts/**',
         ],
@@ -247,6 +249,18 @@ export default defineConfig(({ mode }) => {
     },
     resolve: {
       alias: {
+        '@aicorg/runtime': path.resolve(
+          aicRepoRoot,
+          'packages/runtime/src/index.ts',
+        ),
+        '@aicorg/sdk-react': path.resolve(
+          aicRepoRoot,
+          'packages/sdk-react/src/index.tsx',
+        ),
+        '@aicorg/spec': path.resolve(
+          aicRepoRoot,
+          'packages/spec/src/index.ts',
+        ),
         path: 'rollup-plugin-node-polyfills/polyfills/path',
       },
     },

--- a/packages/twenty-ui/src/components/chip/LinkChip.tsx
+++ b/packages/twenty-ui/src/components/chip/LinkChip.tsx
@@ -8,7 +8,7 @@ import {
 } from '@ui/components/chip/Chip';
 import { LINK_CHIP_CLICK_OUTSIDE_ID } from '@ui/components/chip/constants/LinkChipClickOutsideId';
 import { type TriggerEventType, useMouseDownNavigation } from '@ui/utilities';
-import { type MouseEvent } from 'react';
+import { type AnchorHTMLAttributes, type MouseEvent } from 'react';
 import { Link } from 'react-router-dom';
 
 export type LinkChipProps = Omit<
@@ -20,7 +20,10 @@ export type LinkChipProps = Omit<
   onMouseDown?: (event: MouseEvent<HTMLElement>) => void;
   triggerEvent?: TriggerEventType;
   target?: '_blank' | '_self';
-};
+} & Omit<
+    AnchorHTMLAttributes<HTMLAnchorElement>,
+    'className' | 'href' | 'onClick' | 'onMouseDown' | 'target'
+  >;
 
 const StyledLinkContainer = styled.span`
   display: inline-flex;
@@ -49,6 +52,7 @@ export const LinkChip = ({
   triggerEvent,
   target,
   emptyLabel,
+  ...linkProps
 }: LinkChipProps) => {
   const { onClick: onClickHandler, onMouseDown: onMouseDownHandler } =
     useMouseDownNavigation({
@@ -69,6 +73,7 @@ export const LinkChip = ({
         data-click-outside-id={LINK_CHIP_CLICK_OUTSIDE_ID}
         target={target}
         rel={target === '_blank' ? 'noopener noreferrer' : undefined}
+        {...linkProps}
       >
         <Chip
           size={size}

--- a/packages/twenty-ui/src/navigation/menu/menu-item/components/MenuItem.tsx
+++ b/packages/twenty-ui/src/navigation/menu/menu-item/components/MenuItem.tsx
@@ -2,6 +2,7 @@ import { IconChevronRight, type IconComponent } from '@ui/display';
 import { type LightIconButtonProps } from '@ui/input/button/components/LightIconButton';
 import { LightIconButtonGroup } from '@ui/input/button/components/LightIconButtonGroup';
 import {
+  type HTMLAttributes,
   type FunctionComponent,
   type MouseEvent,
   type ReactElement,
@@ -30,7 +31,7 @@ export type MenuItemIconButton = {
   dataTestId?: string;
 };
 
-export type MenuItemProps = {
+export type MenuItemProps = HTMLAttributes<HTMLDivElement> & {
   accent?: MenuItemAccent;
   className?: string;
   withIconContainer?: boolean;
@@ -87,6 +88,7 @@ export const MenuItem = ({
   selected = false,
   hotKeys,
   isSubMenuOpened = false,
+  ...rest
 }: MenuItemProps) => {
   const { theme } = useContext(ThemeContext);
   const showIconButtons = Array.isArray(iconButtons) && iconButtons.length > 0;
@@ -110,6 +112,7 @@ export const MenuItem = ({
       onMouseEnter={onMouseEnter}
       onMouseLeave={onMouseLeave}
       focused={focused || selected}
+      {...rest}
     >
       <MenuItemLeftContent
         LeftIcon={LeftIcon ?? undefined}

--- a/packages/twenty-ui/src/navigation/menu/menu-item/components/MenuItemMultiSelect.tsx
+++ b/packages/twenty-ui/src/navigation/menu/menu-item/components/MenuItemMultiSelect.tsx
@@ -1,4 +1,5 @@
 import { styled } from '@linaria/react';
+import { type HTMLAttributes } from 'react';
 
 import { Tag } from '@ui/components';
 import { type IconComponent } from '@ui/display';
@@ -17,7 +18,7 @@ const StyledLeftContentWithCheckboxContainer = styled.div`
   overflow: hidden;
 `;
 
-type MenuItemMultiSelectProps = {
+type MenuItemMultiSelectProps = HTMLAttributes<HTMLDivElement> & {
   color?: ThemeColor;
   LeftIcon?: IconComponent;
   selected: boolean;
@@ -37,6 +38,7 @@ export const MenuItemMultiSelect = ({
   isKeySelected,
   className,
   onSelectChange,
+  ...rest
 }: MenuItemMultiSelectProps) => {
   const handleOnClick = () => {
     onSelectChange?.(!selected);
@@ -47,6 +49,7 @@ export const MenuItemMultiSelect = ({
       isKeySelected={isKeySelected}
       className={className}
       onClick={handleOnClick}
+      {...rest}
     >
       <StyledLeftContentWithCheckboxContainer>
         <Checkbox checked={selected} />


### PR DESCRIPTION
This carries the local AIC instrumentation work for stage mutation and filter semantics, including active filter clear semantics and the supporting widget/list semantic surfaces used by the benchmark.