### PR TITLE
Move page layout backfill command out of 1-21 release

### DIFF
--- a/packages/twenty-server/src/database/commands/upgrade-version-command/1-21/1-21-upgrade-version-command.module.ts
+++ b/packages/twenty-server/src/database/commands/upgrade-version-command/1-21/1-21-upgrade-version-command.module.ts
@@ -7,7 +7,6 @@ import { AddComposeEmailCommandMenuItemCommand } from 'src/database/commands/upg
 import { AddGlobalKeyValuePairUniqueIndexCommand } from 'src/database/commands/upgrade-version-command/1-21/1-21-workspace-command-1775500002000-add-global-key-value-pair-unique-index.command';
 import { BackfillDatasourceToWorkspaceCommand } from 'src/database/commands/upgrade-version-command/1-21/1-21-workspace-command-1775500003000-backfill-datasource-to-workspace.command';
 import { BackfillMessageThreadSubjectCommand } from 'src/database/commands/upgrade-version-command/1-21/1-21-workspace-command-1775500004000-backfill-message-thread-subject.command';
-import { BackfillPageLayoutsAndFieldsWidgetViewFieldsCommand } from 'src/database/commands/upgrade-version-command/1-21/1-21-workspace-command-1775500005000-backfill-page-layouts-and-fields-widget-view-fields.command';
 import { DeduplicateEngineCommandsCommand } from 'src/database/commands/upgrade-version-command/1-21/1-21-workspace-command-1775500006000-deduplicate-engine-commands.command';
 import { FixSelectAllCommandMenuItemsCommand } from 'src/database/commands/upgrade-version-command/1-21/1-21-workspace-command-1775500007000-fix-select-all-command-menu-items.command';
 import { MigrateAiAgentTextToJsonResponseFormatCommand } from 'src/database/commands/upgrade-version-command/1-21/1-21-workspace-command-1775500008000-migrate-ai-agent-text-to-json-response-format.command';
@@ -57,7 +56,6 @@ import { WorkspaceMigrationModule } from 'src/engine/workspace-manager/workspace
     AddGlobalKeyValuePairUniqueIndexCommand,
     BackfillDatasourceToWorkspaceCommand,
     BackfillMessageThreadSubjectCommand,
-    BackfillPageLayoutsAndFieldsWidgetViewFieldsCommand,
     DeduplicateEngineCommandsCommand,
     FixSelectAllCommandMenuItemsCommand,
     MigrateAiAgentTextToJsonResponseFormatCommand,

--- a/packages/twenty-server/src/database/commands/upgrade-version-command/1-22/1-22-upgrade-version-command.module.ts
+++ b/packages/twenty-server/src/database/commands/upgrade-version-command/1-22/1-22-upgrade-version-command.module.ts
@@ -1,0 +1,20 @@
+import { Module } from '@nestjs/common';
+
+import { WorkspaceIteratorModule } from 'src/database/commands/command-runners/workspace-iterator.module';
+import { BackfillPageLayoutsAndFieldsWidgetViewFieldsCommand } from 'src/database/commands/upgrade-version-command/1-22/1-22-workspace-command-1780000001000-backfill-page-layouts-and-fields-widget-view-fields.command';
+import { ApplicationModule } from 'src/engine/core-modules/application/application.module';
+import { FeatureFlagModule } from 'src/engine/core-modules/feature-flag/feature-flag.module';
+import { WorkspaceCacheModule } from 'src/engine/workspace-cache/workspace-cache.module';
+import { WorkspaceMigrationModule } from 'src/engine/workspace-manager/workspace-migration/workspace-migration.module';
+
+@Module({
+  imports: [
+    ApplicationModule,
+    FeatureFlagModule,
+    WorkspaceCacheModule,
+    WorkspaceIteratorModule,
+    WorkspaceMigrationModule,
+  ],
+  providers: [BackfillPageLayoutsAndFieldsWidgetViewFieldsCommand],
+})
+export class V1_22_UpgradeVersionCommandModule {}

--- a/packages/twenty-server/src/database/commands/upgrade-version-command/1-22/1-22-workspace-command-1780000001000-backfill-page-layouts-and-fields-widget-view-fields.command.ts
+++ b/packages/twenty-server/src/database/commands/upgrade-version-command/1-22/1-22-workspace-command-1780000001000-backfill-page-layouts-and-fields-widget-view-fields.command.ts
@@ -82,9 +82,9 @@ const isRelationTargetAvailable = (
   return true;
 };
 
-@RegisteredWorkspaceCommand('1.21.0', 1775500005000)
+@RegisteredWorkspaceCommand('1.22.0', 1780000001000)
 @Command({
-  name: 'upgrade:1-21:backfill-page-layouts-and-fields-widget-view-fields',
+  name: 'upgrade:1-22:backfill-page-layouts-and-fields-widget-view-fields',
   description:
     'Backfill RECORD_PAGE page layouts, sync FIELDS_WIDGET view fields, create FIELD widgets, and enable IS_RECORD_PAGE_LAYOUT_EDITING_ENABLED',
 })

--- a/packages/twenty-server/src/database/commands/upgrade-version-command/upgrade-version-command.module.ts
+++ b/packages/twenty-server/src/database/commands/upgrade-version-command/upgrade-version-command.module.ts
@@ -2,6 +2,7 @@ import { Module } from '@nestjs/common';
 
 import { WorkspaceIteratorModule } from 'src/database/commands/command-runners/workspace-iterator.module';
 import { V1_21_UpgradeVersionCommandModule } from 'src/database/commands/upgrade-version-command/1-21/1-21-upgrade-version-command.module';
+import { V1_22_UpgradeVersionCommandModule } from 'src/database/commands/upgrade-version-command/1-22/1-22-upgrade-version-command.module';
 import { UpgradeCommand } from 'src/database/commands/upgrade-version-command/upgrade.command';
 import { CoreEngineVersionModule } from 'src/engine/core-engine-version/core-engine-version.module';
 import { UpgradeModule } from 'src/engine/core-modules/upgrade/upgrade.module';
@@ -11,6 +12,7 @@ import { WorkspaceVersionModule } from 'src/engine/workspace-manager/workspace-v
 @Module({
   imports: [
     V1_21_UpgradeVersionCommandModule,
+    V1_22_UpgradeVersionCommandModule,
     DataSourceModule,
     CoreEngineVersionModule,
     UpgradeModule,

--- a/packages/twenty-server/src/engine/constants/upgrade-command-supported-versions.constant.ts
+++ b/packages/twenty-server/src/engine/constants/upgrade-command-supported-versions.constant.ts
@@ -2,7 +2,11 @@
 // getPreviousVersion() looks up the entry just below the current version
 // to determine the minimum workspace version eligible for upgrade.
 // Removing the previous version would cause the upgrade command to fail.
-export const UPGRADE_COMMAND_SUPPORTED_VERSIONS = ['1.20.0', '1.21.0'] as const;
+export const UPGRADE_COMMAND_SUPPORTED_VERSIONS = [
+  '1.20.0',
+  '1.21.0',
+  '1.22.0',
+] as const;
 
 export type UpgradeCommandVersion =
   (typeof UPGRADE_COMMAND_SUPPORTED_VERSIONS)[number];


### PR DESCRIPTION
Note: The next tag might be 2.0 and this can be changed later, the point here is to move the command out of 1-21