### PR TITLE
Flush Redis between server runs in breaking changes CI

### DIFF
--- a/.github/workflows/ci-breaking-changes.yaml
+++ b/.github/workflows/ci-breaking-changes.yaml
@@ -251,6 +251,14 @@ jobs:
             rm -f /tmp/current-server.pid
           fi
 
+      - name: Flush Redis between server runs
+        run: |
+          # Clear all Redis caches to prevent stale data from the current branch
+          # server contaminating the main branch server. Both servers share the
+          # same Redis instance, and CoreEntityCacheService/WorkspaceCacheService
+          # persist cached entities across process restarts.
+          redis-cli -h localhost -p 6379 FLUSHALL || echo "::warning::Failed to flush Redis"
+
       - name: Checkout main branch
         run: |
           git stash


### PR DESCRIPTION
## Summary
Added a Redis cache flush step in the breaking changes CI workflow to prevent stale data contamination between consecutive server runs.

## Key Changes
- Added a new workflow step that executes `redis-cli FLUSHALL` between the current branch server run and the main branch server run
- Includes error handling to log a warning if the Redis flush fails, without blocking the workflow
- Added explanatory comments documenting why this step is necessary

## Implementation Details
The Redis flush is necessary because both the current branch and main branch servers share the same Redis instance during CI testing. The `CoreEntityCacheService` and `WorkspaceCacheService` persist cached entities across process restarts, which can cause stale data from the current branch server to contaminate the main branch server comparison. This step ensures a clean cache state before switching branches.

https://claude.ai/code/session_01BVMacfAXDMNx5WAFtP7GgW