### PR TITLE
[codex] fix MCP streamable-http method handling

### DIFF
--- a/packages/twenty-server/src/engine/api/mcp/constants/mcp-protocol-version.const.ts
+++ b/packages/twenty-server/src/engine/api/mcp/constants/mcp-protocol-version.const.ts
@@ -1,1 +1,1 @@
-export const MCP_PROTOCOL_VERSION = '2024-11-05';
+export const MCP_PROTOCOL_VERSION = '2025-03-26';

--- a/packages/twenty-server/src/engine/api/mcp/controllers/__tests__/mcp-core.controller.spec.ts
+++ b/packages/twenty-server/src/engine/api/mcp/controllers/__tests__/mcp-core.controller.spec.ts
@@ -68,6 +68,24 @@ describe('McpCoreController', () => {
     expect(controller).toBeDefined();
   });
 
+  describe('unsupported methods', () => {
+    it('should return 405 payload for GET /mcp', () => {
+      expect(controller.handleUnsupportedGet()).toEqual({
+        error: 'Method Not Allowed',
+        message:
+          'This MCP endpoint supports JSON-RPC over POST only. SSE streaming is not supported on GET /mcp.',
+      });
+    });
+
+    it('should return 405 payload for DELETE /mcp', () => {
+      expect(controller.handleUnsupportedDelete()).toEqual({
+        error: 'Method Not Allowed',
+        message:
+          'This MCP endpoint does not support session termination over DELETE /mcp',
+      });
+    });
+  });
+
   describe('handleMcpCore', () => {
     const mockWorkspace = { id: 'workspace-1' } as WorkspaceEntity;
     const mockUser = { id: 'user-1' } as UserEntity;

--- a/packages/twenty-server/src/engine/api/mcp/controllers/mcp-core.controller.ts
+++ b/packages/twenty-server/src/engine/api/mcp/controllers/mcp-core.controller.ts
@@ -1,6 +1,9 @@
 import {
   Body,
   Controller,
+  Delete,
+  Get,
+  Header,
   HttpCode,
   HttpStatus,
   Post,
@@ -29,11 +32,33 @@ import { NoPermissionGuard } from 'src/engine/guards/no-permission.guard';
 import { WorkspaceAuthGuard } from 'src/engine/guards/workspace-auth.guard';
 
 @Controller('mcp')
-@UseGuards(McpAuthGuard, WorkspaceAuthGuard, NoPermissionGuard)
 @UseFilters(RestApiExceptionFilter)
 export class McpCoreController {
   constructor(private readonly mcpProtocolService: McpProtocolService) {}
 
+  @Get()
+  @Header('Allow', 'POST')
+  @HttpCode(HttpStatus.METHOD_NOT_ALLOWED)
+  handleUnsupportedGet() {
+    return {
+      error: 'Method Not Allowed',
+      message:
+        'This MCP endpoint supports JSON-RPC over POST only. SSE streaming is not supported on GET /mcp.',
+    };
+  }
+
+  @Delete()
+  @Header('Allow', 'POST')
+  @HttpCode(HttpStatus.METHOD_NOT_ALLOWED)
+  handleUnsupportedDelete() {
+    return {
+      error: 'Method Not Allowed',
+      message:
+        'This MCP endpoint does not support session termination over DELETE /mcp',
+    };
+  }
+
+  @UseGuards(McpAuthGuard, WorkspaceAuthGuard, NoPermissionGuard)
   @Post()
   @HttpCode(HttpStatus.OK)
   @UsePipes(

--- a/packages/twenty-server/test/integration/ai/suites/mcp.controller.integration-spec.ts
+++ b/packages/twenty-server/test/integration/ai/suites/mcp.controller.integration-spec.ts
@@ -19,6 +19,24 @@ describe('MCP Controller (integration)', () => {
       .send(JSON.stringify(body));
   };
 
+  it('should return 405 for GET /mcp', async () => {
+    await request(baseUrl)
+      .get(endpoint)
+      .expect(405)
+      .expect((res) => {
+        expect(res.headers.allow).toBe('POST');
+      });
+  });
+
+  it('should return 405 for DELETE /mcp', async () => {
+    await request(baseUrl)
+      .delete(endpoint)
+      .expect(405)
+      .expect((res) => {
+        expect(res.headers.allow).toBe('POST');
+      });
+  });
+
   it('should respond to ping with a JSON-RPC result envelope', async () => {
     await postMcp({ jsonrpc: '2.0', method: 'ping', id: '1' })
       .expect(200)
@@ -39,7 +57,7 @@ describe('MCP Controller (integration)', () => {
         expect(res.body.id).toBe(123);
         expect(res.body.jsonrpc).toBe('2.0');
         expect(res.body.result).toBeDefined();
-        expect(res.body.result.protocolVersion).toBe('2024-11-05');
+        expect(res.body.result.protocolVersion).toBe('2025-03-26');
         expect(res.body.result.capabilities).toBeDefined();
         expect(res.body.result.serverInfo).toBeDefined();
         expect(res.body.result.serverInfo.name).toBe('Twenty MCP Server');


### PR DESCRIPTION
## What changed

This updates the MCP endpoint to behave correctly for `streamable-http` clients that probe `/mcp` with methods other than `POST`.

- add explicit `GET /mcp` and `DELETE /mcp` handlers that return `405 Method Not Allowed`
- move MCP auth guards from the controller class onto the `POST /mcp` handler so the `405` handlers can execute
- add `Allow: POST` to the unsupported-method responses
- update the advertised MCP protocol version to `2025-03-26`
- add controller unit coverage and integration coverage for the new method behavior

## Why

The frontend advertises the Twenty MCP server as `streamable-http`, but the backend only exposed `POST /mcp`.

In practice that meant:

- `GET /mcp` could fail before reaching an explicit handler
- `DELETE /mcp` could fail before reaching an explicit handler
- some MCP clients probing the endpoint during connection setup could see invalid transport behavior and abort

By making unsupported methods explicit and leaving auth protection on `POST`, the endpoint now tells clients that `/mcp` exists while still protecting actual JSON-RPC operations.

## Impact

- MCP clients probing `GET /mcp` and `DELETE /mcp` now receive `405` instead of falling through to other behavior
- unauthenticated `POST /mcp` remains protected and still returns `401`
- the initialize response now reports a protocol version aligned with the documented `streamable-http` configuration

## Validation

- verified live backend behavior locally with curl:
  - `GET /mcp` -> `405`
  - `DELETE /mcp` -> `405`
  - unauthenticated `POST /mcp` -> `401`
- passed controller unit tests:
  - `src/engine/api/mcp/controllers/__tests__/mcp-core.controller.spec.ts`
- attempted targeted integration test run, but local test bootstrap was blocked by database connectivity in the integration environment
