### PR TITLE
Fix system objects not appearing in sidebar View picker due to filtering mismatch

### DIFF
--- a/packages/twenty-front/src/modules/navigation-menu-item/edit/side-panel/components/SidePanelNewSidebarItemViewSystemPickerSubPage.tsx
+++ b/packages/twenty-front/src/modules/navigation-menu-item/edit/side-panel/components/SidePanelNewSidebarItemViewSystemPickerSubPage.tsx
@@ -1,16 +1,15 @@
 import { useDraftNavigationMenuItems } from '@/navigation-menu-item/edit/hooks/useDraftNavigationMenuItems';
 import { useNavigationMenuObjectMetadataFromDraft } from '@/navigation-menu-item/edit/hooks/useNavigationMenuObjectMetadataFromDraft';
+import { SidePanelNewSidebarItemViewSystemSubView } from '@/navigation-menu-item/edit/side-panel/components/SidePanelNewSidebarItemViewSystemSubView';
+import { getAvailableObjectMetadataForNewSidebarItem } from '@/navigation-menu-item/edit/side-panel/utils/getAvailableObjectMetadataForNewSidebarItem';
+import { isViewDisplayableInNavigationMenu } from '@/navigation-menu-item/edit/side-panel/utils/isViewDisplayableInNavigationMenu';
 import { useFilteredObjectMetadataItems } from '@/object-metadata/hooks/useFilteredObjectMetadataItems';
 import { useObjectMetadataItems } from '@/object-metadata/hooks/useObjectMetadataItems';
 import { type EnrichedObjectMetadataItem } from '@/object-metadata/types/EnrichedObjectMetadataItem';
 import { useSidePanelSubPageHistory } from '@/side-panel/hooks/useSidePanelSubPageHistory';
-import { SidePanelNewSidebarItemViewSystemSubView } from '@/navigation-menu-item/edit/side-panel/components/SidePanelNewSidebarItemViewSystemSubView';
-import { getAvailableObjectMetadataForNewSidebarItem } from '@/navigation-menu-item/edit/side-panel/utils/getAvailableObjectMetadataForNewSidebarItem';
 import { selectedObjectMetadataIdForViewFlowState } from '@/side-panel/states/selectedObjectMetadataIdForViewFlowState';
 import { SidePanelSubPages } from '@/side-panel/types/SidePanelSubPages';
 import { useSetAtomComponentState } from '@/ui/utilities/state/jotai/hooks/useSetAtomComponentState';
-import { ViewKey } from '@/views/types/ViewKey';
-import { ViewType } from '@/views/types/ViewType';
 import { useState } from 'react';
 
 export const SidePanelNewSidebarItemViewSystemPickerSubPage = () => {
@@ -24,14 +23,15 @@ export const SidePanelNewSidebarItemViewSystemPickerSubPage = () => {
   const { objectMetadataItems } = useObjectMetadataItems();
   const { activeNonSystemObjectMetadataItems } =
     useFilteredObjectMetadataItems();
-  const { views, objectMetadataIdsWithIndexView } =
+  const { views, objectMetadataIdsWithIndexView, viewIdsInWorkspace } =
     useNavigationMenuObjectMetadataFromDraft(currentDraft);
 
   const objectMetadataIdsWithDisplayableViews = new Set(
     views
       .filter(
         (view) =>
-          view.key !== ViewKey.INDEX && view.type !== ViewType.FIELDS_WIDGET,
+          isViewDisplayableInNavigationMenu(view) &&
+          !viewIdsInWorkspace.has(view.id),
       )
       .map((view) => view.objectMetadataId),
   );


### PR DESCRIPTION
## Summary
- System objects with valid views were incorrectly hidden in the View > System objects picker
- The system picker page used a different filter (`view.key !== ViewKey.INDEX`) than the parent page (`isViewDisplayableInNavigationMenu`), causing a mismatch where the "System objects" link was visible but clicking it showed an empty list
- Aligned filtering in `SidePanelNewSidebarItemViewSystemPickerSubPage` to use `isViewDisplayableInNavigationMenu` and exclude views already in the workspace, consistent with the non-system picker page