### PR TITLE
Flatten AI tool call output structure

### DIFF
--- a/packages/twenty-front/src/modules/ai/hooks/useProcessUIToolCallMessage.ts
+++ b/packages/twenty-front/src/modules/ai/hooks/useProcessUIToolCallMessage.ts
@@ -42,7 +42,7 @@ export const useProcessUIToolCallMessage = () => {
         continue;
       }
 
-      if (toolExecutionPart.output.result.success !== true) {
+      if (toolExecutionPart.output.success !== true) {
         continue;
       }
 
@@ -51,7 +51,11 @@ export const useProcessUIToolCallMessage = () => {
         toolExecutionPart.toolCallId,
       ]);
 
-      const navigateAppOutput = toolExecutionPart.output.result.result;
+      const navigateAppOutput = toolExecutionPart.output.result;
+
+      if (!isDefined(navigateAppOutput)) {
+        continue;
+      }
 
       switch (navigateAppOutput.action) {
         case 'navigateToObject': {

--- a/packages/twenty-front/src/modules/ai/types/AgentChatMessageUIToolCallPart.ts
+++ b/packages/twenty-front/src/modules/ai/types/AgentChatMessageUIToolCallPart.ts
@@ -5,11 +5,9 @@ export type AgentChatMessageUIToolCallPart = {
   toolCallId: string;
   state: string;
   output: {
-    toolName: string;
-    result: {
-      message: string;
-      result: NavigateAppToolOutput;
-      success: boolean;
-    };
+    success: boolean;
+    message: string;
+    error?: string;
+    result?: NavigateAppToolOutput;
   };
 };


### PR DESCRIPTION
## Summary
Refactored the `AgentChatMessageUIToolCallPart` output structure to flatten the nested result object, simplifying the data model and improving code clarity.

## Key Changes
- **Flattened output structure**: Moved `success`, `message`, and `result` fields from `output.result` directly to `output`, eliminating unnecessary nesting
- **Removed `toolName` field**: Deleted the unused `toolName` property from the output object
- **Made fields optional**: Changed `error` and `result` to optional fields to better represent cases where they may not be present
- **Updated hook logic**: Modified `useProcessUIToolCallMessage` to access the flattened structure:
  - Changed `toolExecutionPart.output.result.success` to `toolExecutionPart.output.success`
  - Changed `toolExecutionPart.output.result.result` to `toolExecutionPart.output.result`
  - Added null check for `navigateAppOutput` to handle cases where result is undefined

## Implementation Details
The refactoring maintains backward compatibility in functionality while simplifying the data structure. The optional `result` field now properly reflects that navigation output may not always be present, with an explicit guard clause added to handle this case gracefully.

https://claude.ai/code/session_01EnYKwVaCJyhgNPsi7p3YSq