### PR TITLE
Skip email/calendar tab creation for custom object record page layouts

### DIFF
--- a/packages/twenty-server/src/engine/metadata-modules/object-metadata/utils/compute-flat-default-record-page-layout-to-create.util.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/object-metadata/utils/compute-flat-default-record-page-layout-to-create.util.ts
@@ -38,8 +38,6 @@ export const computeFlatDefaultRecordPageLayoutToCreate = ({
     { key: 'tasks' as const, widgetKey: 'tasks' as const },
     { key: 'notes' as const, widgetKey: 'notes' as const },
     { key: 'files' as const, widgetKey: 'files' as const },
-    { key: 'emails' as const, widgetKey: 'emails' as const },
-    { key: 'calendar' as const, widgetKey: 'calendar' as const },
   ];
 
   const pageLayoutTabs: FlatPageLayoutTab[] = [];


### PR DESCRIPTION
## Context
Emails and calendars can only be associated with specific objects (companies, people...) and we were adding those tabs for all custom objects. I'm removing these from the default config