### PR TITLE
`database:init:prod` triggers instance slow command too

### DIFF
--- a/packages/twenty-server/package.json
+++ b/packages/twenty-server/package.json
@@ -9,7 +9,7 @@
     "start:prod": "node dist/main",
     "command:prod": "node dist/command/command",
     "worker:prod": "node dist/queue-worker/queue-worker",
-    "database:init:prod": "node dist/database/scripts/setup-db.js && yarn database:migrate:prod --force",
+    "database:init:prod": "node dist/database/scripts/setup-db.js && yarn database:migrate:prod --force --include-slow",
     "database:migrate:prod": "node dist/command/command run-instance-commands",
     "clickhouse:migrate:prod": "node dist/database/clickHouse/migrations/run-migrations.js",
     "typeorm": "../../node_modules/typeorm/.bin/typeorm"


### PR DESCRIPTION
When creating a db from scrath we still need to run the slow instance command so the associated queries are still applied to the empty db

Please note that by default if there's no workspace the instance slow runner will skip the runDataMigration part