### PR TITLE
fix: side panel close animation cleanup not firing due to invalid CSS transition

### DIFF
--- a/packages/twenty-front/src/modules/side-panel/components/SidePanelForDesktop.tsx
+++ b/packages/twenty-front/src/modules/side-panel/components/SidePanelForDesktop.tsx
@@ -1,19 +1,19 @@
+import { tableWidthResizeIsActiveState } from '@/object-record/record-table/states/tableWidthResizeIsActivedState';
 import { SidePanelRouter } from '@/side-panel/components/SidePanelRouter';
 import { SidePanelWidthEffect } from '@/side-panel/components/SidePanelWidthEffect';
 import { SIDE_PANEL_CLICK_OUTSIDE_ID } from '@/side-panel/constants/SidePanelClickOutsideId';
-import { useSidePanelMenu } from '@/side-panel/hooks/useSidePanelMenu';
+import { SIDE_PANEL_CONSTRAINTS } from '@/side-panel/constants/SidePanelConstraints';
 import { useSidePanelCloseAnimationCompleteCleanup } from '@/side-panel/hooks/useSidePanelCloseAnimationCompleteCleanup';
+import { useSidePanelMenu } from '@/side-panel/hooks/useSidePanelMenu';
+import { isSidePanelClosingState } from '@/side-panel/states/isSidePanelClosingState';
+import { isSidePanelOpenedState } from '@/side-panel/states/isSidePanelOpenedState';
 import {
   SIDE_PANEL_WIDTH_VAR,
   sidePanelWidthState,
 } from '@/side-panel/states/sidePanelWidthState';
-import { isSidePanelClosingState } from '@/side-panel/states/isSidePanelClosingState';
-import { isSidePanelOpenedState } from '@/side-panel/states/isSidePanelOpenedState';
-import { tableWidthResizeIsActiveState } from '@/object-record/record-table/states/tableWidthResizeIsActivedState';
 import { ModalContainerContext } from '@/ui/layout/modal/contexts/ModalContainerContext';
-import { ParentClickOutsideIdContext } from '@/ui/utilities/pointer-event/contexts/ParentClickOutsideIdContext';
 import { ResizablePanelGap } from '@/ui/layout/resizable-panel/components/ResizablePanelGap';
-import { SIDE_PANEL_CONSTRAINTS } from '@/side-panel/constants/SidePanelConstraints';
+import { ParentClickOutsideIdContext } from '@/ui/utilities/pointer-event/contexts/ParentClickOutsideIdContext';
 import { useAtomState } from '@/ui/utilities/state/jotai/hooks/useAtomState';
 import { useAtomStateValue } from '@/ui/utilities/state/jotai/hooks/useAtomStateValue';
 import { useSetAtomState } from '@/ui/utilities/state/jotai/hooks/useSetAtomState';
@@ -31,7 +31,7 @@ const StyledSidePanelWrapper = styled.div<{
   transition: ${({ isResizing }) =>
     isResizing
       ? 'none'
-      : `width ${themeCssVariables.animation.duration.normal}s`};
+      : `width calc(${themeCssVariables.animation.duration.normal} * 1s)`};
   width: ${({ isOpen }) => (isOpen ? `var(${SIDE_PANEL_WIDTH_VAR})` : '0px')};
 `;
 


### PR DESCRIPTION
## Summary

Fixes the side panel close animation cleanup (`sidePanelCloseAnimationCompleteCleanup`) never running during the close transition.

This eventually fixes the issue where in navbar edit mode, clicking on a nav item sometimes doesn't get selected, the side panel opens but shows `Select a navigation item to edit` instead of the selected item's settings. The root cause was stale `isSidePanelClosing` state from a previous close that wasn't cleaned up, causing the next open to run cleanup synchronously (without emitting the close event), which interfered with the navigation item selection flow.

### Root cause

The CSS `transition` on `StyledSidePanelWrapper` used `${themeCssVariables.animation.duration.normal}s`, which Linaria converts to a CSS custom property value like `width var(--t-animation-duration-normal)s`. After CSS variable substitution, `0.3` and `s` become two separate tokens, not a valid `<time>` dimension (`0.3s`). The browser rejects the entire transition declaration, falls back to `all 0s`, and the width change happens instantly with no `transitionend` event.

### Fix

- Use `calc(var(--t-animation-duration-normal) * 1s)` to properly construct the `<time>` value (consistent with ~30 other usages in the codebase).
- Filter `handleTransitionEnd` to only process `width` transitions on the wrapper element itself, ignoring bubbled child `background-color` transitions.


## Before

https://github.com/user-attachments/assets/496ccbff-dc96-487d-a994-451dbf2a5165




## After

https://github.com/user-attachments/assets/78255240-1d7d-42cd-9b56-25627613883a

