### PR TITLE
fix: prevent image upload panel from being clipped in side panel

### DIFF
--- a/packages/twenty-front/src/modules/blocknote-editor/components/BlockEditor.tsx
+++ b/packages/twenty-front/src/modules/blocknote-editor/components/BlockEditor.tsx
@@ -25,7 +25,6 @@ interface BlockEditorProps {
 
 // oxlint-disable-next-line twenty/no-hardcoded-colors
 const StyledEditor = styled.div`
-  container-type: inline-size;
   width: 100%;
 
   & .editor {
@@ -130,6 +129,10 @@ const StyledEditor = styled.div`
     font-family: monospace;
     font-size: 0.9rem;
     padding: 2px 4px;
+  }
+
+  & .bn-mantine {
+    container-type: inline-size;
   }
 
   & .bn-mantine .bn-panel {

--- a/packages/twenty-front/src/modules/blocknote-editor/components/BlockEditor.tsx
+++ b/packages/twenty-front/src/modules/blocknote-editor/components/BlockEditor.tsx
@@ -25,6 +25,7 @@ interface BlockEditorProps {
 
 // oxlint-disable-next-line twenty/no-hardcoded-colors
 const StyledEditor = styled.div`
+  container-type: inline-size;
   width: 100%;
 
   & .editor {
@@ -129,6 +130,10 @@ const StyledEditor = styled.div`
     font-family: monospace;
     font-size: 0.9rem;
     padding: 2px 4px;
+  }
+
+  & .bn-mantine .bn-panel {
+    width: 100cqi;
   }
 `;
 


### PR DESCRIPTION
fixes:   #19571 
## Summary:
  - BlockNote's file upload/embed panel (.bn-panel) has a hardcoded width: 500px that overflows the side panel's overflow: hidden containers, causing the Upload/Embed UI to be cut off
<img width="636" height="364" alt="image" src="https://github.com/user-attachments/assets/4ec501c6-409c-4a86-a5b3-2c5f104c94f1" />

## Before
<img width="464" height="660" alt="image" src="https://github.com/user-attachments/assets/3364e20e-6194-4c5d-b16f-9541cc11bfd7" />

## After
**Same width with "Add Image" button** ( same in the video,audio upload
<img width="444" height="665" alt="image" src="https://github.com/user-attachments/assets/369a6974-a986-44ab-a38a-a717a8f978c0" />
