### PR TITLE
fix(ai): clear error state when switching to new AI chat

### DIFF
--- a/packages/twenty-front/src/modules/ai/components/AIChatEmptyState.tsx
+++ b/packages/twenty-front/src/modules/ai/components/AIChatEmptyState.tsx
@@ -37,6 +37,7 @@ export const AIChatEmptyState = ({ editor }: AIChatEmptyStateProps) => {
     skipMessagesSkeletonUntilLoadedState,
   );
   const currentAIChatThread = useAtomStateValue(currentAIChatThreadState);
+  const currentThreadError = agentChatError[currentAIChatThread ?? ''] ?? null;
 
   const hasMessages = useAtomComponentSelectorValue(
     agentChatHasMessageComponentSelector,
@@ -48,7 +49,7 @@ export const AIChatEmptyState = ({ editor }: AIChatEmptyStateProps) => {
     (agentChatThreadsLoading && isOnNewChatSlot) ||
     (agentChatMessagesLoading && !skipMessagesSkeletonUntilLoaded);
   const shouldRender =
-    !hasMessages && !isDefined(agentChatError) && !skeletonShowing;
+    !hasMessages && !isDefined(currentThreadError) && !skeletonShowing;
 
   if (!shouldRender) {
     return null;

--- a/packages/twenty-front/src/modules/ai/components/AIChatErrorUnderMessageList.tsx
+++ b/packages/twenty-front/src/modules/ai/components/AIChatErrorUnderMessageList.tsx
@@ -4,6 +4,7 @@ import { agentChatErrorState } from '@/ai/states/agentChatErrorState';
 import { agentChatIsStreamingState } from '@/ai/states/agentChatIsStreamingState';
 import { agentChatMessageComponentFamilySelector } from '@/ai/states/agentChatMessageComponentFamilySelector';
 import { agentChatMessageIdsComponentSelector } from '@/ai/states/agentChatMessageIdsComponentSelector';
+import { currentAIChatThreadState } from '@/ai/states/currentAIChatThreadState';
 import { useAtomComponentFamilySelectorValue } from '@/ui/utilities/state/jotai/hooks/useAtomComponentFamilySelectorValue';
 import { useAtomComponentSelectorValue } from '@/ui/utilities/state/jotai/hooks/useAtomComponentSelectorValue';
 import { useAtomStateValue } from '@/ui/utilities/state/jotai/hooks/useAtomStateValue';
@@ -16,6 +17,8 @@ const StyledErrorWrapper = styled.div`
 
 export const AIChatErrorUnderMessageList = () => {
   const agentChatError = useAtomStateValue(agentChatErrorState);
+  const currentAIChatThread = useAtomStateValue(currentAIChatThreadState);
+  const currentThreadError = agentChatError[currentAIChatThread ?? ''] ?? null;
   const agentChatIsStreaming = useAtomStateValue(agentChatIsStreamingState);
 
   const agentChatMessageIds = useAtomComponentSelectorValue(
@@ -29,7 +32,7 @@ export const AIChatErrorUnderMessageList = () => {
   );
 
   const showError =
-    agentChatError &&
+    currentThreadError &&
     !agentChatIsStreaming &&
     agentChatMessage?.role === AgentMessageRole.USER;
 
@@ -39,7 +42,7 @@ export const AIChatErrorUnderMessageList = () => {
 
   return (
     <StyledErrorWrapper>
-      <AIChatErrorRenderer error={agentChatError} />
+      <AIChatErrorRenderer error={currentThreadError} />
     </StyledErrorWrapper>
   );
 };

--- a/packages/twenty-front/src/modules/ai/components/AIChatLastMessageWithStreamingState.tsx
+++ b/packages/twenty-front/src/modules/ai/components/AIChatLastMessageWithStreamingState.tsx
@@ -2,6 +2,7 @@ import { AIChatMessage } from '@/ai/components/AIChatMessage';
 import { agentChatErrorState } from '@/ai/states/agentChatErrorState';
 import { agentChatIsStreamingState } from '@/ai/states/agentChatIsStreamingState';
 import { agentChatLastMessageIdComponentSelector } from '@/ai/states/agentChatLastMessageIdComponentSelector';
+import { currentAIChatThreadState } from '@/ai/states/currentAIChatThreadState';
 import { useAtomComponentSelectorValue } from '@/ui/utilities/state/jotai/hooks/useAtomComponentSelectorValue';
 import { useAtomStateValue } from '@/ui/utilities/state/jotai/hooks/useAtomStateValue';
 import { isDefined } from 'twenty-shared/utils';
@@ -13,6 +14,8 @@ export const AIChatLastMessageWithStreamingState = () => {
 
   const agentChatIsStreaming = useAtomStateValue(agentChatIsStreamingState);
   const agentChatError = useAtomStateValue(agentChatErrorState);
+  const currentAIChatThread = useAtomStateValue(currentAIChatThreadState);
+  const currentThreadError = agentChatError[currentAIChatThread ?? ''] ?? null;
 
   if (!isDefined(lastMessageId)) {
     return null;
@@ -22,7 +25,7 @@ export const AIChatLastMessageWithStreamingState = () => {
     <AIChatMessage
       messageId={lastMessageId}
       isLastMessageStreaming={agentChatIsStreaming}
-      error={agentChatError ?? undefined}
+      error={currentThreadError ?? undefined}
     />
   );
 };

--- a/packages/twenty-front/src/modules/ai/components/AIChatStandaloneError.tsx
+++ b/packages/twenty-front/src/modules/ai/components/AIChatStandaloneError.tsx
@@ -4,6 +4,7 @@ import { AIChatErrorRenderer } from '@/ai/components/AIChatErrorRenderer';
 import { agentChatErrorState } from '@/ai/states/agentChatErrorState';
 import { agentChatHasMessageComponentSelector } from '@/ai/states/agentChatHasMessageComponentSelector';
 import { agentChatIsLoadingState } from '@/ai/states/agentChatIsLoadingState';
+import { currentAIChatThreadState } from '@/ai/states/currentAIChatThreadState';
 import { useAtomComponentSelectorValue } from '@/ui/utilities/state/jotai/hooks/useAtomComponentSelectorValue';
 import { useAtomStateValue } from '@/ui/utilities/state/jotai/hooks/useAtomStateValue';
 import { isDefined } from 'twenty-shared/utils';
@@ -19,13 +20,15 @@ export const AIChatStandaloneError = () => {
   const agentChatIsLoading = useAtomStateValue(agentChatIsLoadingState);
 
   const agentChatError = useAtomStateValue(agentChatErrorState);
+  const currentAIChatThread = useAtomStateValue(currentAIChatThreadState);
+  const currentThreadError = agentChatError[currentAIChatThread ?? ''] ?? null;
 
   const hasMessages = useAtomComponentSelectorValue(
     agentChatHasMessageComponentSelector,
   );
 
   const shouldRender =
-    !hasMessages && isDefined(agentChatError) && !agentChatIsLoading;
+    !hasMessages && isDefined(currentThreadError) && !agentChatIsLoading;
 
   if (!shouldRender) {
     return null;
@@ -33,7 +36,7 @@ export const AIChatStandaloneError = () => {
 
   return (
     <StyledErrorContainer>
-      <AIChatErrorRenderer error={agentChatError} />
+      <AIChatErrorRenderer error={currentThreadError} />
     </StyledErrorContainer>
   );
 };

--- a/packages/twenty-front/src/modules/ai/hooks/useAgentChat.ts
+++ b/packages/twenty-front/src/modules/ai/hooks/useAgentChat.ts
@@ -15,6 +15,7 @@ import {
   AGENT_CHAT_NEW_THREAD_DRAFT_KEY,
   agentChatDraftsByThreadIdState,
 } from '@/ai/states/agentChatDraftsByThreadIdState';
+import { agentChatErrorState } from '@/ai/states/agentChatErrorState';
 import { agentChatInputState } from '@/ai/states/agentChatInputState';
 import { agentChatSelectedFilesState } from '@/ai/states/agentChatSelectedFilesState';
 import { agentChatUploadedFilesState } from '@/ai/states/agentChatUploadedFilesState';
@@ -82,6 +83,11 @@ export const useAgentChat = (
     if (draftKey === AGENT_CHAT_NEW_THREAD_DRAFT_KEY) {
       setPendingThreadIdAfterFirstSend(threadId);
     }
+
+    store.set(agentChatErrorState.atom, (prev) => ({
+      ...prev,
+      [threadId]: null,
+    }));
 
     setAgentChatInput('');
     setAgentChatDraftsByThreadId((prev) => ({

--- a/packages/twenty-front/src/modules/ai/hooks/useAgentChatSubscription.ts
+++ b/packages/twenty-front/src/modules/ai/hooks/useAgentChatSubscription.ts
@@ -288,7 +288,10 @@ export const useAgentChatSubscription = (threadId: string | null) => {
           };
 
           streamError.code = event.code;
-          store.set(agentChatErrorState.atom, streamError);
+          store.set(agentChatErrorState.atom, (prev) => ({
+            ...prev,
+            [threadId]: streamError,
+          }));
 
           closeWriter();
           store.set(agentChatIsStreamingState.atom, false);

--- a/packages/twenty-front/src/modules/ai/hooks/useSwitchToNewAIChat.ts
+++ b/packages/twenty-front/src/modules/ai/hooks/useSwitchToNewAIChat.ts
@@ -4,6 +4,7 @@ import {
   AGENT_CHAT_NEW_THREAD_DRAFT_KEY,
   agentChatDraftsByThreadIdState,
 } from '@/ai/states/agentChatDraftsByThreadIdState';
+import { agentChatErrorState } from '@/ai/states/agentChatErrorState';
 import { agentChatInputState } from '@/ai/states/agentChatInputState';
 import { agentChatUsageState } from '@/ai/states/agentChatUsageState';
 import { currentAIChatThreadState } from '@/ai/states/currentAIChatThreadState';
@@ -50,6 +51,7 @@ export const useSwitchToNewAIChat = () => {
     setAgentChatInput(newChatDraft);
     setCurrentAIChatThreadTitle(null);
     setAgentChatUsage(null);
+    store.set(agentChatErrorState.atom, null);
     openAskAIPage();
     store.set(shouldFocusChatEditorState.atom, true);
   };

--- a/packages/twenty-front/src/modules/ai/hooks/useSwitchToNewAIChat.ts
+++ b/packages/twenty-front/src/modules/ai/hooks/useSwitchToNewAIChat.ts
@@ -4,7 +4,6 @@ import {
   AGENT_CHAT_NEW_THREAD_DRAFT_KEY,
   agentChatDraftsByThreadIdState,
 } from '@/ai/states/agentChatDraftsByThreadIdState';
-import { agentChatErrorState } from '@/ai/states/agentChatErrorState';
 import { agentChatInputState } from '@/ai/states/agentChatInputState';
 import { agentChatUsageState } from '@/ai/states/agentChatUsageState';
 import { currentAIChatThreadState } from '@/ai/states/currentAIChatThreadState';
@@ -51,7 +50,6 @@ export const useSwitchToNewAIChat = () => {
     setAgentChatInput(newChatDraft);
     setCurrentAIChatThreadTitle(null);
     setAgentChatUsage(null);
-    store.set(agentChatErrorState.atom, null);
     openAskAIPage();
     store.set(shouldFocusChatEditorState.atom, true);
   };

--- a/packages/twenty-front/src/modules/ai/states/agentChatErrorState.ts
+++ b/packages/twenty-front/src/modules/ai/states/agentChatErrorState.ts
@@ -1,6 +1,8 @@
 import { createAtomState } from '@/ui/utilities/state/jotai/utils/createAtomState';
 
-export const agentChatErrorState = createAtomState<Error | undefined | null>({
+export const agentChatErrorState = createAtomState<
+  Record<string, Error | null>
+>({
   key: 'agentChatErrorState',
-  defaultValue: null,
+  defaultValue: {},
 });


### PR DESCRIPTION
Summary:                                                                                                                                      
  - When an AI chat session encounters an error (e.g. "Failed to get response"), the error banner persists even after clicking "New Chat"
  - reset agentChatErrorState in useSwitchToNewAIChat so errors are cleared alongside other state (input, usage, title) during thread switch

**Reproduction: set an invalid api key and then chat with ai**

## before

https://github.com/user-attachments/assets/f05a0394-64e5-4379-bed3-583cdf4531f6

## after

https://github.com/user-attachments/assets/2adcd978-22c0-45a5-865b-69d9ee589432

