### PR TITLE
fix: allow overriding REACT_APP_SERVER_BASE_URL independently of SERVER_URL

### DIFF
--- a/packages/twenty-server/src/utils/generate-front-config.ts
+++ b/packages/twenty-server/src/utils/generate-front-config.ts
@@ -11,7 +11,8 @@ export function generateFrontConfig(): void {
   const configObject = {
     window: {
       _env_: {
-        REACT_APP_SERVER_BASE_URL: process.env.SERVER_URL,
+        REACT_APP_SERVER_BASE_URL:
+          process.env.REACT_APP_SERVER_BASE_URL ?? process.env.SERVER_URL,
       },
     },
   };


### PR DESCRIPTION
## Summary

- Allow `REACT_APP_SERVER_BASE_URL` to be set as an independent env var, overriding what gets injected into the frontend config
- Falls back to `SERVER_URL` when unset (preserving current behavior)

## Problem

When self-hosting Twenty behind a reverse proxy, VPN, or on platforms where the access hostname differs from the configured `SERVER_URL`, the frontend cannot reach the backend; `generateFrontConfig()` always injects `SERVER_URL` as `REACT_APP_SERVER_BASE_URL` into the frontend HTML. The browser then makes API calls to that hardcoded URL. If the user accesses Twenty via a different hostname the API calls fail with "Unable to Reach Back-end."

The frontend already has auto-detection logic that derives the backend URL from `window.location.origin` when `REACT_APP_SERVER_BASE_URL` is empty but there's currently no way to trigger it, since `SERVER_URL` is always injected and cannot be set to empty (validation requires a valid URL).

## Use Cases

This benefits any self-hosted deployment where the access hostname isn't known at config time:

- **VPN access** (Tailscale, WireGuard) — hostname differs from LAN
- **Reverse proxy** (Nginx, Caddy, Traefik) — custom domain fronting the app
- **Tunnel services** (Cloudflare Tunnel, ngrok) — dynamic hostnames
- **Home server platforms** (Umbrel, CasaOS, Unraid) — accessed via mDNS, IP, or VPN interchangeably

## Test Plan

- [x] Verify existing behavior: without REACT_APP_SERVER_BASE_URL set, frontend still uses SERVER_URL as before
- [x] Set REACT_APP_SERVER_BASE_URL="" frontend auto-detects backend URL from browser location
- [x] Set REACT_APP_SERVER_BASE_URL=http://custom-domain:3000 frontend uses the custom URL