### PR TITLE
Bump twenty-sdk, twenty-client-sdk, create-twenty-app to 1.22.0-canary.1

### DIFF
--- a/packages/create-twenty-app/package.json
+++ b/packages/create-twenty-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-twenty-app",
-  "version": "0.9.0",
+  "version": "1.22.0-canary.1",
   "description": "Command-line interface to create Twenty application",
   "main": "dist/cli.cjs",
   "bin": "dist/cli.cjs",

--- a/packages/twenty-client-sdk/package.json
+++ b/packages/twenty-client-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "twenty-client-sdk",
-  "version": "0.9.0",
+  "version": "1.22.0-canary.1",
   "sideEffects": false,
   "license": "AGPL-3.0",
   "scripts": {

--- a/packages/twenty-sdk/package.json
+++ b/packages/twenty-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "twenty-sdk",
-  "version": "0.9.0",
+  "version": "1.22.0-canary.1",
   "main": "dist/index.cjs",
   "module": "dist/index.mjs",
   "types": "dist/sdk/index.d.ts",


### PR DESCRIPTION
## Summary
- Bumps `twenty-sdk`, `twenty-client-sdk`, and `create-twenty-app` package versions from `0.9.0` to `1.22.0-canary.1` for the 1.22 canary release.
