### PR TITLE
fix: avoid reporting recoverable SSE token expiry to Sentry

### DIFF
--- a/packages/twenty-front/src/modules/sse-db-event/hooks/__tests__/useTriggerEventStreamCreation.test.tsx
+++ b/packages/twenty-front/src/modules/sse-db-event/hooks/__tests__/useTriggerEventStreamCreation.test.tsx
@@ -1,0 +1,153 @@
+import { act, renderHook } from '@testing-library/react';
+
+import { useTriggerEventStreamCreation } from '@/sse-db-event/hooks/useTriggerEventStreamCreation';
+import { shouldDestroyEventStreamState } from '@/sse-db-event/states/shouldDestroyEventStreamState';
+import { isCreatingSseEventStreamState } from '@/sse-db-event/states/isCreatingSseEventStreamState';
+import { sseClientState } from '@/sse-db-event/states/sseClientState';
+import { sseEventStreamIdState } from '@/sse-db-event/states/sseEventStreamIdState';
+import { isDestroyingEventStreamState } from '@/sse-db-event/states/isDestroyingEventStreamState';
+import { disposeFunctionForEventStreamState } from '@/sse-db-event/states/disposeFunctionByEventStreamMapState';
+import { getJestMetadataAndApolloMocksWrapper } from '~/testing/jest/getJestMetadataAndApolloMocksWrapper';
+
+import type { Store } from 'jotai/vanilla/store';
+
+jest.mock('@sentry/react', () => ({
+  captureException: jest.fn(),
+}));
+
+import { captureException } from '@sentry/react';
+
+const mockCaptureException = captureException as jest.MockedFunction<
+  typeof captureException
+>;
+
+describe('useTriggerEventStreamCreation', () => {
+  let messageHandler:
+    | ((params: { data: unknown; event: string }) => void)
+    | null;
+  let capturedStore: Store | null = null;
+
+  const createWrapper = () =>
+    getJestMetadataAndApolloMocksWrapper({
+      apolloMocks: [],
+      onInitializeJotaiStore: (store: Store) => {
+        capturedStore = store;
+
+        messageHandler = null;
+
+        const mockSubscribe = jest.fn(
+          (_query: any, _observers: any, options: any) => {
+            if (options?.message) {
+              messageHandler = options.message;
+            }
+            return { unsubscribe: jest.fn() };
+          },
+        );
+
+        store.set(sseClientState.atom, {
+          subscribe: mockSubscribe,
+          dispose: jest.fn(),
+        } as any);
+        store.set(sseEventStreamIdState.atom, null);
+        store.set(isCreatingSseEventStreamState.atom, false);
+        store.set(isDestroyingEventStreamState.atom, false);
+        store.set(shouldDestroyEventStreamState.atom, false);
+        store.set(disposeFunctionForEventStreamState.atom, {
+          dispose: jest.fn(),
+        });
+      },
+    });
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    messageHandler = null;
+    capturedStore = null;
+  });
+
+  it('marks stream for destruction without reporting UNAUTHENTICATED subCode to Sentry', async () => {
+    const Wrapper = createWrapper();
+    const {
+      result: { current },
+    } = renderHook(() => useTriggerEventStreamCreation(), { wrapper: Wrapper });
+
+    current.triggerEventStreamCreation();
+
+    await act(async () => {
+      messageHandler!({
+        data: {
+          errors: [
+            {
+              message: 'Unauthorized',
+              extensions: {
+                code: 'UNAUTHENTICATED',
+                subCode: 'UNAUTHENTICATED',
+              },
+            },
+          ],
+        },
+        event: 'next',
+      });
+    });
+
+    expect(capturedStore!.get(shouldDestroyEventStreamState.atom)).toBe(true);
+    expect(mockCaptureException).not.toHaveBeenCalled();
+  });
+
+  it('marks stream for destruction without reporting FORBIDDEN subCode to Sentry', async () => {
+    const Wrapper = createWrapper();
+    const {
+      result: { current },
+    } = renderHook(() => useTriggerEventStreamCreation(), { wrapper: Wrapper });
+
+    current.triggerEventStreamCreation();
+
+    await act(async () => {
+      messageHandler!({
+        data: {
+          errors: [
+            {
+              message: 'Forbidden',
+              extensions: {
+                code: 'FORBIDDEN',
+                subCode: 'FORBIDDEN',
+              },
+            },
+          ],
+        },
+        event: 'next',
+      });
+    });
+
+    expect(capturedStore!.get(shouldDestroyEventStreamState.atom)).toBe(true);
+    expect(mockCaptureException).not.toHaveBeenCalled();
+  });
+
+  it('reports unexpected error subCodes to Sentry', async () => {
+    const Wrapper = createWrapper();
+    const {
+      result: { current },
+    } = renderHook(() => useTriggerEventStreamCreation(), { wrapper: Wrapper });
+
+    current.triggerEventStreamCreation();
+
+    await act(async () => {
+      messageHandler!({
+        data: {
+          errors: [
+            {
+              message: 'Something went wrong',
+              extensions: {
+                code: 'INTERNAL_SERVER_ERROR',
+                subCode: 'UNKNOWN_ERROR',
+              },
+            },
+          ],
+        },
+        event: 'next',
+      });
+    });
+
+    expect(mockCaptureException).toHaveBeenCalledTimes(1);
+    expect(capturedStore!.get(shouldDestroyEventStreamState.atom)).toBe(true);
+  });
+});

--- a/packages/twenty-front/src/modules/sse-db-event/hooks/useTriggerEventStreamCreation.ts
+++ b/packages/twenty-front/src/modules/sse-db-event/hooks/useTriggerEventStreamCreation.ts
@@ -131,7 +131,9 @@ export const useTriggerEventStreamCreation = () => {
                 const subCode = result.errors[0]?.extensions?.subCode;
 
                 switch (subCode) {
-                  case 'EVENT_STREAM_ALREADY_EXISTS': {
+                  case 'EVENT_STREAM_ALREADY_EXISTS':
+                  case 'UNAUTHENTICATED':
+                  case 'FORBIDDEN': {
                     store.set(shouldDestroyEventStreamState.atom, true);
                     break;
                   }


### PR DESCRIPTION
## Problem

When a user session stays idle long enough for the token to expire, the SSE event stream creation path reports the resulting `UNAUTHENTICATED` and `FORBIDDEN` errors to Sentry. These are expected, recoverable reconnect cases — not bugs. ([Issue #18077](https://github.com/twentyhq/twenty/issues/18077))

## Solution

In the `message` handler of `useTriggerEventStreamCreation`, the switch on `subCode` only handled `EVENT_STREAM_ALREADY_EXISTS`. Added `UNAUTHENTICATED` and `FORBIDDEN` as additional recoverable cases, so they destroy the stream for clean recreation instead of being reported to Sentry.

This follows the same pattern already used in `SSEQuerySubscribeEffect.tsx` (lines 82-93), where these same subCodes are treated as recoverable in the subscription update path.

## Changes

- 1 file changed: `packages/twenty-front/src/modules/sse-db-event/hooks/useTriggerEventStreamCreation.ts`
- Added `UNAUTHENTICATED` and `FORBIDDEN` to the existing `switch(subCode)` recoverable cases
- The `store.set(shouldDestroyEventStreamState.atom, true)` on line 148 still runs unconditionally after the switch, so stream cleanup is preserved for all error paths

Fixes #18077