### PR TITLE
Add APPLICATION_LOG_DRIVER=CONSOLE to twenty-app-dev container

### DIFF
--- a/packages/twenty-docker/twenty/Dockerfile
+++ b/packages/twenty-docker/twenty/Dockerfile
@@ -215,7 +215,8 @@ ENV PG_DATABASE_URL=postgres://twenty:twenty@localhost:5432/default \
     DISABLE_DB_MIGRATIONS=true \
     DISABLE_CRON_JOBS_REGISTRATION=true \
     IS_BILLING_ENABLED=false \
-    SIGN_IN_PREFILLED=true
+    SIGN_IN_PREFILLED=true \
+    APPLICATION_LOG_DRIVER=CONSOLE
 
 EXPOSE 2020
 VOLUME ["/data/postgres", "/app/packages/twenty-server/.local-storage"]

--- a/packages/twenty-server/.env.example
+++ b/packages/twenty-server/.env.example
@@ -48,6 +48,7 @@ FRONTEND_URL=http://localhost:3001
 # SENTRY_ENVIRONMENT=main
 # SENTRY_DSN=https://xxx@xxx.ingest.sentry.io/xxx
 # SENTRY_FRONT_DSN=https://xxx@xxx.ingest.sentry.io/xxx
+# APPLICATION_LOG_DRIVER=CONSOLE
 # LOG_LEVELS=error,warn
 # SERVER_URL=http://localhost:3000
 # WORKSPACE_INACTIVE_DAYS_BEFORE_NOTIFICATION=7

--- a/packages/twenty-server/src/engine/core-modules/application-logs/application-logs.module-factory.ts
+++ b/packages/twenty-server/src/engine/core-modules/application-logs/application-logs.module-factory.ts
@@ -1,14 +1,14 @@
 import { type TwentyConfigService } from 'src/engine/core-modules/twenty-config/twenty-config.service';
 
 import { type OPTIONS_TYPE } from 'src/engine/core-modules/application-logs/application-logs.module-definition';
-import { ApplicationLogDriverType } from 'src/engine/core-modules/application-logs/interfaces/application-log-driver-type.enum';
+import { ApplicationLogDriver } from 'src/engine/core-modules/application-logs/interfaces/application-log-driver.enum';
 
 export const applicationLogsModuleFactory = async (
   twentyConfigService: TwentyConfigService,
 ): Promise<typeof OPTIONS_TYPE> => {
-  const driverType = twentyConfigService.get('APPLICATION_LOG_DRIVER_TYPE');
+  const driverType = twentyConfigService.get('APPLICATION_LOG_DRIVER');
 
   return {
-    type: driverType as ApplicationLogDriverType,
+    type: driverType as ApplicationLogDriver,
   };
 };

--- a/packages/twenty-server/src/engine/core-modules/application-logs/application-logs.module.ts
+++ b/packages/twenty-server/src/engine/core-modules/application-logs/application-logs.module.ts
@@ -12,7 +12,7 @@ import { ApplicationLogsService } from 'src/engine/core-modules/application-logs
 import { ClickHouseApplicationLogDriver } from 'src/engine/core-modules/application-logs/drivers/clickhouse.driver';
 import { ConsoleApplicationLogDriver } from 'src/engine/core-modules/application-logs/drivers/console.driver';
 import { DisabledApplicationLogDriver } from 'src/engine/core-modules/application-logs/drivers/disabled.driver';
-import { ApplicationLogDriverType } from 'src/engine/core-modules/application-logs/interfaces/application-log-driver-type.enum';
+import { ApplicationLogDriver } from 'src/engine/core-modules/application-logs/interfaces/application-log-driver.enum';
 
 @Global()
 @Module({
@@ -64,13 +64,13 @@ export class ApplicationLogsModule extends ConfigurableModuleClass {
   }
 
   private static createDriver(
-    type: ApplicationLogDriverType,
+    type: ApplicationLogDriver,
     clickHouseService?: ClickHouseService,
   ) {
     switch (type) {
-      case ApplicationLogDriverType.CONSOLE:
+      case ApplicationLogDriver.CONSOLE:
         return new ConsoleApplicationLogDriver();
-      case ApplicationLogDriverType.CLICKHOUSE:
+      case ApplicationLogDriver.CLICKHOUSE:
         if (!clickHouseService) {
           throw new Error(
             'ClickHouseService is required for the ClickHouse application log driver',
@@ -78,7 +78,7 @@ export class ApplicationLogsModule extends ConfigurableModuleClass {
         }
 
         return new ClickHouseApplicationLogDriver(clickHouseService);
-      case ApplicationLogDriverType.DISABLED:
+      case ApplicationLogDriver.DISABLED:
       default:
         return new DisabledApplicationLogDriver();
     }

--- a/packages/twenty-server/src/engine/core-modules/application-logs/interfaces/application-log-driver.enum.ts
+++ b/packages/twenty-server/src/engine/core-modules/application-logs/interfaces/application-log-driver.enum.ts
@@ -1,4 +1,4 @@
-export enum ApplicationLogDriverType {
+export enum ApplicationLogDriver {
   DISABLED = 'DISABLED',
   CONSOLE = 'CONSOLE',
   CLICKHOUSE = 'CLICKHOUSE',

--- a/packages/twenty-server/src/engine/core-modules/application-logs/interfaces/application-logs-module-options.type.ts
+++ b/packages/twenty-server/src/engine/core-modules/application-logs/interfaces/application-logs-module-options.type.ts
@@ -1,5 +1,5 @@
-import { type ApplicationLogDriverType } from 'src/engine/core-modules/application-logs/interfaces/application-log-driver-type.enum';
+import { type ApplicationLogDriver } from 'src/engine/core-modules/application-logs/interfaces/application-log-driver.enum';
 
 export type ApplicationLogsModuleOptions = {
-  type: ApplicationLogDriverType;
+  type: ApplicationLogDriver;
 };

--- a/packages/twenty-server/src/engine/core-modules/twenty-config/config-variables.ts
+++ b/packages/twenty-server/src/engine/core-modules/twenty-config/config-variables.ts
@@ -17,7 +17,7 @@ import { type AwsRegion } from 'src/engine/core-modules/twenty-config/interfaces
 import { NodeEnvironment } from 'src/engine/core-modules/twenty-config/interfaces/node-environment.interface';
 import { SupportDriver } from 'src/engine/core-modules/twenty-config/interfaces/support.interface';
 
-import { ApplicationLogDriverType } from 'src/engine/core-modules/application-logs/interfaces/application-log-driver-type.enum';
+import { ApplicationLogDriver } from 'src/engine/core-modules/application-logs/interfaces/application-log-driver.enum';
 import { CaptchaDriverType } from 'src/engine/core-modules/captcha/interfaces';
 import { CodeInterpreterDriverType } from 'src/engine/core-modules/code-interpreter/code-interpreter.interface';
 import { WebSearchDriverType } from 'src/engine/core-modules/web-search/web-search.interface';
@@ -932,13 +932,13 @@ export class ConfigVariables {
     description:
       'Driver used for application logs (Disabled, Console, or ClickHouse)',
     type: ConfigVariableType.ENUM,
-    options: Object.values(ApplicationLogDriverType),
+    options: Object.values(ApplicationLogDriver),
     isEnvOnly: true,
   })
   @IsOptional()
   @CastToUpperSnakeCase()
-  APPLICATION_LOG_DRIVER_TYPE: ApplicationLogDriverType =
-    ApplicationLogDriverType.DISABLED;
+  APPLICATION_LOG_DRIVER: ApplicationLogDriver =
+    ApplicationLogDriver.DISABLED;
 
   @ConfigVariablesMetadata({
     group: ConfigVariablesGroup.SUPPORT_CHAT_CONFIG,

--- a/packages/twenty-server/src/engine/core-modules/twenty-config/config-variables.ts
+++ b/packages/twenty-server/src/engine/core-modules/twenty-config/config-variables.ts
@@ -937,8 +937,7 @@ export class ConfigVariables {
   })
   @IsOptional()
   @CastToUpperSnakeCase()
-  APPLICATION_LOG_DRIVER: ApplicationLogDriver =
-    ApplicationLogDriver.DISABLED;
+  APPLICATION_LOG_DRIVER: ApplicationLogDriver = ApplicationLogDriver.DISABLED;
 
   @ConfigVariablesMetadata({
     group: ConfigVariablesGroup.SUPPORT_CHAT_CONFIG,


### PR DESCRIPTION
## Summary
- Enable application log console output in the `twenty-app-dev` Docker image by adding `APPLICATION_LOG_DRIVER=CONSOLE` to the Dockerfile ENV block
- Rename `APPLICATION_LOG_DRIVER_TYPE` to `APPLICATION_LOG_DRIVER` and `ApplicationLogDriverType` to `ApplicationLogDriver` for consistency with all other driver config variables (`EMAIL_DRIVER`, `LOGGER_DRIVER`, `CAPTCHA_DRIVER`, etc.)
- Add `APPLICATION_LOG_DRIVER` to `.env.example`

