### PR TITLE
Re-export missing types from SDK public API

### DIFF
--- a/packages/create-twenty-app/package.json
+++ b/packages/create-twenty-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-twenty-app",
-  "version": "1.22.0-canary.4",
+  "version": "1.22.0-canary.5",
   "description": "Command-line interface to create Twenty application",
   "main": "dist/cli.cjs",
   "bin": "dist/cli.cjs",

--- a/packages/twenty-client-sdk/package.json
+++ b/packages/twenty-client-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "twenty-client-sdk",
-  "version": "1.22.0-canary.4",
+  "version": "1.22.0-canary.5",
   "sideEffects": false,
   "license": "AGPL-3.0",
   "scripts": {

--- a/packages/twenty-sdk/package.json
+++ b/packages/twenty-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "twenty-sdk",
-  "version": "1.22.0-canary.4",
+  "version": "1.22.0-canary.5",
   "main": "dist/index.cjs",
   "module": "dist/index.mjs",
   "types": "dist/sdk/index.d.ts",

--- a/packages/twenty-sdk/src/sdk/index.ts
+++ b/packages/twenty-sdk/src/sdk/index.ts
@@ -1,10 +1,20 @@
 export {
   AggregateOperations,
+  HTTPMethod,
   NavigationMenuItemType,
   ObjectRecordGroupByDateGranularity,
   PageLayoutTabLayoutMode,
+  ViewFilterGroupLogicalOperator,
+  ViewFilterOperand,
+  ViewOpenRecordIn,
+  ViewType,
+  ViewVisibility,
 } from 'twenty-shared/types';
-export type { PageLayoutWidgetUniversalConfiguration } from 'twenty-shared/types';
+export type {
+  GridPosition,
+  PageLayoutWidgetConditionalDisplay,
+  PageLayoutWidgetUniversalConfiguration,
+} from 'twenty-shared/types';
 export type { ApplicationConfig } from './application/application-config';
 export { defineApplication } from './application/define-application';
 export type {
@@ -47,6 +57,7 @@ export type {
   LogicFunctionConfig,
   LogicFunctionHandler,
 } from './logic-functions/logic-function-config';
+export type { InputJsonSchema } from 'twenty-shared/logic-function';
 export type { CronPayload } from './logic-functions/triggers/cron-payload-type';
 export type {
   DatabaseEventPayload,


### PR DESCRIPTION
## Summary

- Fixes TS4082 errors for SDK consumers with `declaration: true` in their tsconfig
- The `define*` functions (e.g. `defineView`, `definePageLayout`, `defineLogicFunction`) return `ValidationResult<T>` where `T` references types from `twenty-shared` that were not re-exported from the SDK's public barrel
- TypeScript cannot generate `.d.ts` files when the return type references "private names" — types that exist in the package but aren't publicly exported

### Added re-exports

**Enums** (used in `ViewManifest`, `HttpRouteTriggerSettings`):
- `ViewType`, `ViewFilterOperand`, `ViewFilterGroupLogicalOperator`, `ViewOpenRecordIn`, `ViewVisibility`
- `HTTPMethod`

**Types** (used in `PageLayoutWidgetManifest`, `LogicFunctionConfig`):
- `GridPosition`, `PageLayoutWidgetConditionalDisplay`
- `InputJsonSchema`
