### PR TITLE
Export field settings types from SDK public API

### DIFF
--- a/packages/create-twenty-app/package.json
+++ b/packages/create-twenty-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-twenty-app",
-  "version": "1.22.0-canary.5",
+  "version": "1.22.0-canary.6",
   "description": "Command-line interface to create Twenty application",
   "main": "dist/cli.cjs",
   "bin": "dist/cli.cjs",

--- a/packages/twenty-client-sdk/package.json
+++ b/packages/twenty-client-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "twenty-client-sdk",
-  "version": "1.22.0-canary.5",
+  "version": "1.22.0-canary.6",
   "sideEffects": false,
   "license": "AGPL-3.0",
   "scripts": {

--- a/packages/twenty-sdk/package.json
+++ b/packages/twenty-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "twenty-sdk",
-  "version": "1.22.0-canary.5",
+  "version": "1.22.0-canary.6",
   "main": "dist/index.cjs",
   "module": "dist/index.mjs",
   "types": "dist/sdk/index.d.ts",

--- a/packages/twenty-sdk/src/sdk/index.ts
+++ b/packages/twenty-sdk/src/sdk/index.ts
@@ -1,7 +1,10 @@
 export {
   AggregateOperations,
+  DateDisplayFormat,
+  FieldMetadataSettingsOnClickAction,
   HTTPMethod,
   NavigationMenuItemType,
+  NumberDataType,
   ObjectRecordGroupByDateGranularity,
   PageLayoutTabLayoutMode,
   ViewFilterGroupLogicalOperator,


### PR DESCRIPTION
## Summary

- Follows up on #19610 which exported view/page-layout types but missed field settings types
- Adds re-exports for `DateDisplayFormat`, `NumberDataType`, and `FieldMetadataSettingsOnClickAction` from the SDK public API
- These enums are referenced in the return type of `defineObject` (via field settings types like `FieldMetadataSettingsDate`, `FieldMetadataSettingsNumber`, `FieldMetadataSettingsMultiItem`) but were not publicly exported
- This causes TS4082 ("private name") errors for SDK consumers that have `declaration: true` in their tsconfig, specifically when using `defineObject` with fields that have settings (e.g. SELECT, DATE, NUMBER fields)
