### PR TITLE
Fix VariablePicker and Fullscreen Icon overlap in FormAdvancedTextFieldInput

### DIFF
--- a/packages/twenty-front/src/modules/object-record/record-field/ui/form-types/components/FormAdvancedTextFieldInput.tsx
+++ b/packages/twenty-front/src/modules/object-record/record-field/ui/form-types/components/FormAdvancedTextFieldInput.tsx
@@ -46,10 +46,15 @@ const StyledAdvancedTextFieldInnerContainer = styled.div`
   width: 100%;
 `;
 
-const StyledEditorActionButtonContainer = styled.div`
+const StyledEditorActionButtonContainer = styled.div<{
+  hasVariablePicker?: boolean;
+}>`
   margin-top: ${themeCssVariables.spacing[1]};
   position: absolute;
-  right: ${themeCssVariables.spacing[1]};
+  right: ${({ hasVariablePicker }) =>
+    hasVariablePicker
+      ? `calc(${themeCssVariables.spacing[7]} + ${themeCssVariables.spacing[2]})`
+      : themeCssVariables.spacing[1]};
   top: ${themeCssVariables.spacing[0]};
   z-index: 1;
 `;
@@ -214,7 +219,9 @@ export const FormAdvancedTextFieldInput = ({
               )}
 
               {enableFullScreen && (
-                <StyledEditorActionButtonContainer>
+                <StyledEditorActionButtonContainer
+                  hasVariablePicker={isDefined(VariablePicker)}
+                >
                   {!readonly && !isFullScreen && (
                     <LightIconButton
                       Icon={IconMaximize}

--- a/packages/twenty-front/src/modules/object-record/record-field/ui/form-types/components/FormAdvancedTextFieldInput.tsx
+++ b/packages/twenty-front/src/modules/object-record/record-field/ui/form-types/components/FormAdvancedTextFieldInput.tsx
@@ -220,7 +220,7 @@ export const FormAdvancedTextFieldInput = ({
 
               {enableFullScreen && (
                 <StyledEditorActionButtonContainer
-                  hasVariablePicker={isDefined(VariablePicker)}
+                  hasVariablePicker={isDefined(VariablePicker) && !readonly}
                 >
                   {!readonly && !isFullScreen && (
                     <LightIconButton


### PR DESCRIPTION
fixes 

<img width="659" height="386" alt="image" src="https://github.com/user-attachments/assets/c9755574-6830-464d-8abf-7741188f84dd" />
