### PR TITLE
Rename standard and custom apps

### DIFF
--- a/.cursor/rules/creating-syncable-entity.mdc
+++ b/.cursor/rules/creating-syncable-entity.mdc
@@ -22,7 +22,7 @@ This main guide provides a high-level overview and navigation hub.
 
 A syncable entity is a metadata entity that:
 - Has a **`universalIdentifier`**: A unique identifier used for syncing entities across workspaces/applications
-- Has an **`applicationId`**: Links the entity to an application (Twenty Standard or Custom applications)
+- Has an **`applicationId`**: Links the entity to an application (Standard or Custom applications)
 - Participates in the **workspace migration system**: Can be created, updated, and deleted through the migration pipeline
 - Is **cached as a flat entity**: Denormalized representation for efficient validation and change detection
 

--- a/packages/twenty-front/src/modules/views/hooks/useCreateDefaultViewForObject.ts
+++ b/packages/twenty-front/src/modules/views/hooks/useCreateDefaultViewForObject.ts
@@ -11,7 +11,7 @@ const DEFAULT_VIEW_FIELD_SIZE = 180;
 const pendingViewCreations = new Set<string>();
 
 // TODO: This runtime fallback logic is temporary
-// System views will later be created declaratively in the database during twenty standard app installation.
+// System views will later be created declaratively in the database during Standard app installation.
 export const useCreateDefaultViewForObject = () => {
   const { performViewAPICreate } = usePerformViewAPIPersist();
   const { performViewFieldAPICreate } = usePerformViewFieldAPIPersist();

--- a/packages/twenty-server/src/engine/core-modules/application/application.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/application/application.service.ts
@@ -294,11 +294,9 @@ export class ApplicationService {
     {
       workspaceId,
       applicationId,
-      workspaceDisplayName,
     }: {
       workspaceId: string;
       applicationId: string;
-      workspaceDisplayName?: string;
     },
     queryRunner?: QueryRunner,
   ) {
@@ -307,9 +305,9 @@ export class ApplicationService {
     const workspaceCustomApplication = await this.create(
       {
         description: 'Workspace custom application',
-        name: `${isDefined(workspaceDisplayName) ? workspaceDisplayName : 'Workspace'}'s custom application`,
+        name: 'Custom',
         sourcePath: 'workspace-custom',
-        version: '1.0.0',
+        version: '1.0.1',
         universalIdentifier: applicationId,
         workspaceId,
         id: applicationId,

--- a/packages/twenty-server/src/engine/core-modules/application/application.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/application/application.service.ts
@@ -88,7 +88,7 @@ export class ApplicationService {
 
     if (!isDefined(twentyStandardApplicationId)) {
       throw new ApplicationException(
-        `Could not find workspace twenty standard applicationId in cache ${workspaceId}`,
+        `Could not find workspace Standard applicationId in cache ${workspaceId}`,
         ApplicationExceptionCode.APPLICATION_NOT_FOUND,
       );
     }
@@ -241,7 +241,7 @@ export class ApplicationService {
 
     if (!isDefined(application)) {
       throw new ApplicationException(
-        `Twenty standard application not found for workspace ${workspace.id}`,
+        `Standard application not found for workspace ${workspace.id}`,
         ApplicationExceptionCode.APPLICATION_NOT_FOUND,
       );
     }

--- a/packages/twenty-server/src/engine/metadata-modules/flat-object-metadata/utils/__tests__/are-flat-object-metadata-names-synced-with-labels.util.spec.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/flat-object-metadata/utils/__tests__/are-flat-object-metadata-names-synced-with-labels.util.spec.ts
@@ -85,7 +85,7 @@ describe('areFlatObjectMetadataNamesSyncedWithLabels', () => {
     expect(result).toBe(false);
   });
 
-  it('should not apply custom suffix for reserved words when caller is the Twenty Standard app', () => {
+  it('should not apply custom suffix for reserved words when caller is the Standard app', () => {
     const result = areFlatObjectMetadataNamesSyncedWithLabels({
       flatObjectMetadata: {
         nameSingular: 'event',

--- a/packages/twenty-server/src/engine/workspace-manager/dev-seeder/services/dev-seeder.service.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/dev-seeder/services/dev-seeder.service.ts
@@ -226,7 +226,6 @@ export class DevSeederService {
         {
           workspaceId,
           applicationId: workspaceCustomApplicationId,
-          workspaceDisplayName: createWorkspaceStaticInput.displayName,
         },
         queryRunner,
       );

--- a/packages/twenty-server/src/engine/workspace-manager/twenty-standard-application/constants/twenty-standard-applications.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/twenty-standard-application/constants/twenty-standard-applications.ts
@@ -3,10 +3,10 @@ import { type ApplicationEntity } from 'src/engine/core-modules/application/appl
 
 export const TWENTY_STANDARD_APPLICATION = {
   universalIdentifier: '20202020-64aa-4b6f-b003-9c74b97cee20',
-  name: 'Twenty Standard',
+  name: 'Standard',
   description:
     'Twenty is an open-source CRM that allows you to manage your sales and customer relationships',
-  version: '1.0.0',
+  version: '1.0.1',
   sourcePath: 'cli-sync',
   sourceType: ApplicationRegistrationSourceType.LOCAL,
 } as const satisfies Pick<

--- a/packages/twenty-server/test/integration/metadata/suites/application/application-token-schema-filtering.integration-spec.ts
+++ b/packages/twenty-server/test/integration/metadata/suites/application/application-token-schema-filtering.integration-spec.ts
@@ -17,7 +17,7 @@ const INTROSPECTION_QUERY = `
 `;
 
 // Custom objects seeded in the dev workspace that should NOT appear
-// in a schema scoped to the Twenty Standard Application
+// in a schema scoped to the Standard Application
 const CUSTOM_OBJECT_TYPE_NAMES = [
   'Rocket',
   'Pet',


### PR DESCRIPTION
as title
no migration for existing apps, changes only apply on new workspaces