### PR TITLE
Move view field label identifier deletion validation into the cross entity validation

### DIFF
--- a/packages/twenty-server/src/engine/metadata-modules/flat-view-field/validators/utils/validate-view-field-label-identifier-cross-entity.util.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/flat-view-field/validators/utils/validate-view-field-label-identifier-cross-entity.util.ts
@@ -13,11 +13,6 @@ import { type UniversalFlatEntityMaps } from 'src/engine/workspace-manager/works
 import { type UniversalFlatViewField } from 'src/engine/workspace-manager/workspace-migration/universal-flat-entity/types/universal-flat-view-field.type';
 import { getEmptyFlatEntityValidationError } from 'src/engine/workspace-manager/workspace-migration/workspace-migration-builder/builders/utils/get-flat-entity-validation-error.util';
 
-// After all entity builders have run, verify that deleting view fields did not
-// remove the last view field pointing to the label identifier from any
-// non-FIELDS_WIDGET view. This replaces the former atomic check in the view
-// field deletion validator, which could not account for the label identifier
-// being repointed or the view field being recreated in the same batch.
 export const validateViewFieldLabelIdentifierCrossEntity = ({
   optimisticUniversalFlatMaps,
   orchestratorActionsReport,
@@ -34,8 +29,7 @@ export const validateViewFieldLabelIdentifierCrossEntity = ({
     viewField: [],
   };
 
-  const deletedViewFieldActions =
-    orchestratorActionsReport.viewField.delete;
+  const deletedViewFieldActions = orchestratorActionsReport.viewField.delete;
 
   if (deletedViewFieldActions.length === 0) {
     return validationErrors;

--- a/packages/twenty-server/src/engine/metadata-modules/flat-view-field/validators/utils/validate-view-field-label-identifier-cross-entity.util.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/flat-view-field/validators/utils/validate-view-field-label-identifier-cross-entity.util.ts
@@ -47,21 +47,23 @@ export const validateViewFieldLabelIdentifierCrossEntity = ({
       continue;
     }
 
-    alreadyCheckedViewUniversalIdentifiers.add(viewUniversalIdentifier);
-
-    const view = findFlatEntityByUniversalIdentifierOrThrow({
+    const view = findFlatEntityByUniversalIdentifier({
       universalIdentifier: viewUniversalIdentifier,
       flatEntityMaps: optimisticUniversalFlatMaps.flatViewMaps,
     });
 
-    if (view.type === ViewType.FIELDS_WIDGET) {
+    if (!isDefined(view) || view.type === ViewType.FIELDS_WIDGET) {
       continue;
     }
 
-    const objectMetadata = findFlatEntityByUniversalIdentifierOrThrow({
+    const objectMetadata = findFlatEntityByUniversalIdentifier({
       universalIdentifier: view.objectMetadataUniversalIdentifier,
       flatEntityMaps: optimisticUniversalFlatMaps.flatObjectMetadataMaps,
     });
+
+    if (!isDefined(objectMetadata)) {
+      continue;
+    }
 
     const { labelIdentifierFieldMetadataUniversalIdentifier } = objectMetadata;
 
@@ -75,6 +77,8 @@ export const validateViewFieldLabelIdentifierCrossEntity = ({
     ) {
       continue;
     }
+
+    alreadyCheckedViewUniversalIdentifiers.add(viewUniversalIdentifier);
 
     const viewFieldUniversalIdentifiers =
       view.viewFieldUniversalIdentifiers ?? [];

--- a/packages/twenty-server/src/engine/metadata-modules/flat-view-field/validators/utils/validate-view-field-label-identifier-cross-entity.util.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/flat-view-field/validators/utils/validate-view-field-label-identifier-cross-entity.util.ts
@@ -1,0 +1,134 @@
+import { msg, t } from '@lingui/core/macro';
+import { ViewType } from 'twenty-shared/types';
+import { isDefined } from 'twenty-shared/utils';
+
+import { findFlatEntityByUniversalIdentifier } from 'src/engine/metadata-modules/flat-entity/utils/find-flat-entity-by-universal-identifier.util';
+import { ViewExceptionCode } from 'src/engine/metadata-modules/view/exceptions/view.exception';
+import {
+  type OrchestratorActionsReport,
+  type OrchestratorFailureReport,
+} from 'src/engine/workspace-manager/workspace-migration/types/workspace-migration-orchestrator.type';
+import { type AllUniversalFlatEntityMaps } from 'src/engine/workspace-manager/workspace-migration/universal-flat-entity/types/all-universal-flat-entity-maps.type';
+import { type UniversalFlatEntityMaps } from 'src/engine/workspace-manager/workspace-migration/universal-flat-entity/types/universal-flat-entity-maps.type';
+import { type UniversalFlatViewField } from 'src/engine/workspace-manager/workspace-migration/universal-flat-entity/types/universal-flat-view-field.type';
+import { getEmptyFlatEntityValidationError } from 'src/engine/workspace-manager/workspace-migration/workspace-migration-builder/builders/utils/get-flat-entity-validation-error.util';
+
+// After all entity builders have run, verify that deleting view fields did not
+// remove the last view field pointing to the label identifier from any
+// non-FIELDS_WIDGET view. This replaces the former atomic check in the view
+// field deletion validator, which could not account for the label identifier
+// being repointed or the view field being recreated in the same batch.
+export const validateViewFieldLabelIdentifierCrossEntity = ({
+  optimisticUniversalFlatMaps,
+  orchestratorActionsReport,
+  preDeletionFlatViewFieldMaps,
+}: {
+  optimisticUniversalFlatMaps: Pick<
+    AllUniversalFlatEntityMaps,
+    'flatObjectMetadataMaps' | 'flatViewMaps' | 'flatViewFieldMaps'
+  >;
+  orchestratorActionsReport: Pick<OrchestratorActionsReport, 'viewField'>;
+  preDeletionFlatViewFieldMaps: UniversalFlatEntityMaps<UniversalFlatViewField>;
+}): Pick<OrchestratorFailureReport, 'viewField'> => {
+  const validationErrors: Pick<OrchestratorFailureReport, 'viewField'> = {
+    viewField: [],
+  };
+
+  const deletedViewFieldActions =
+    orchestratorActionsReport.viewField.delete;
+
+  if (deletedViewFieldActions.length === 0) {
+    return validationErrors;
+  }
+
+  const alreadyCheckedViewUniversalIdentifiers = new Set<string>();
+
+  for (const deleteAction of deletedViewFieldActions) {
+    const deletedViewField = findFlatEntityByUniversalIdentifier({
+      universalIdentifier: deleteAction.universalIdentifier,
+      flatEntityMaps: preDeletionFlatViewFieldMaps,
+    });
+
+    if (!isDefined(deletedViewField)) {
+      continue;
+    }
+
+    const { viewUniversalIdentifier, fieldMetadataUniversalIdentifier } =
+      deletedViewField;
+
+    if (alreadyCheckedViewUniversalIdentifiers.has(viewUniversalIdentifier)) {
+      continue;
+    }
+
+    alreadyCheckedViewUniversalIdentifiers.add(viewUniversalIdentifier);
+
+    const view = findFlatEntityByUniversalIdentifier({
+      universalIdentifier: viewUniversalIdentifier,
+      flatEntityMaps: optimisticUniversalFlatMaps.flatViewMaps,
+    });
+
+    if (!isDefined(view) || view.type === ViewType.FIELDS_WIDGET) {
+      continue;
+    }
+
+    const objectMetadata = findFlatEntityByUniversalIdentifier({
+      universalIdentifier: view.objectMetadataUniversalIdentifier,
+      flatEntityMaps: optimisticUniversalFlatMaps.flatObjectMetadataMaps,
+    });
+
+    if (!isDefined(objectMetadata)) {
+      continue;
+    }
+
+    const { labelIdentifierFieldMetadataUniversalIdentifier } = objectMetadata;
+
+    if (!isDefined(labelIdentifierFieldMetadataUniversalIdentifier)) {
+      continue;
+    }
+
+    if (
+      fieldMetadataUniversalIdentifier !==
+      labelIdentifierFieldMetadataUniversalIdentifier
+    ) {
+      continue;
+    }
+
+    const viewFieldUniversalIdentifiers =
+      view.viewFieldUniversalIdentifiers ?? [];
+
+    const hasLabelIdentifierViewField = viewFieldUniversalIdentifiers.some(
+      (viewFieldUniversalIdentifier) => {
+        const viewField = findFlatEntityByUniversalIdentifier({
+          universalIdentifier: viewFieldUniversalIdentifier,
+          flatEntityMaps: optimisticUniversalFlatMaps.flatViewFieldMaps,
+        });
+
+        return (
+          isDefined(viewField) &&
+          viewField.fieldMetadataUniversalIdentifier ===
+            labelIdentifierFieldMetadataUniversalIdentifier
+        );
+      },
+    );
+
+    if (!hasLabelIdentifierViewField) {
+      const failedValidation = getEmptyFlatEntityValidationError({
+        flatEntityMinimalInformation: {
+          universalIdentifier: deleteAction.universalIdentifier,
+        },
+        metadataName: 'viewField',
+        type: 'delete',
+      });
+
+      failedValidation.errors.push({
+        code: ViewExceptionCode.INVALID_VIEW_DATA,
+        message: t`Label identifier view field cannot be deleted`,
+        userFriendlyMessage: msg`Label identifier view field cannot be deleted`,
+      });
+
+      validationErrors.viewField.push(failedValidation);
+    }
+  }
+
+  return validationErrors;
+};

--- a/packages/twenty-server/src/engine/metadata-modules/flat-view-field/validators/utils/validate-view-field-label-identifier-cross-entity.util.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/flat-view-field/validators/utils/validate-view-field-label-identifier-cross-entity.util.ts
@@ -3,33 +3,30 @@ import { ViewType } from 'twenty-shared/types';
 import { isDefined } from 'twenty-shared/utils';
 
 import { findFlatEntityByUniversalIdentifier } from 'src/engine/metadata-modules/flat-entity/utils/find-flat-entity-by-universal-identifier.util';
+import { findFlatEntityByUniversalIdentifierOrThrow } from 'src/engine/metadata-modules/flat-entity/utils/find-flat-entity-by-universal-identifier-or-throw.util';
 import { ViewExceptionCode } from 'src/engine/metadata-modules/view/exceptions/view.exception';
-import {
-  type OrchestratorActionsReport,
-  type OrchestratorFailureReport,
-} from 'src/engine/workspace-manager/workspace-migration/types/workspace-migration-orchestrator.type';
+import { type OrchestratorFailureReport } from 'src/engine/workspace-manager/workspace-migration/types/workspace-migration-orchestrator.type';
 import { type AllUniversalFlatEntityMaps } from 'src/engine/workspace-manager/workspace-migration/universal-flat-entity/types/all-universal-flat-entity-maps.type';
 import { type UniversalFlatEntityMaps } from 'src/engine/workspace-manager/workspace-migration/universal-flat-entity/types/universal-flat-entity-maps.type';
 import { type UniversalFlatViewField } from 'src/engine/workspace-manager/workspace-migration/universal-flat-entity/types/universal-flat-view-field.type';
+import { type UniversalDeleteViewFieldAction } from 'src/engine/workspace-manager/workspace-migration/workspace-migration-builder/builders/view-field/types/workspace-migration-view-field-action.type';
 import { getEmptyFlatEntityValidationError } from 'src/engine/workspace-manager/workspace-migration/workspace-migration-builder/builders/utils/get-flat-entity-validation-error.util';
 
 export const validateViewFieldLabelIdentifierCrossEntity = ({
   optimisticUniversalFlatMaps,
-  orchestratorActionsReport,
+  deletedViewFieldActions,
   preDeletionFlatViewFieldMaps,
 }: {
   optimisticUniversalFlatMaps: Pick<
     AllUniversalFlatEntityMaps,
     'flatObjectMetadataMaps' | 'flatViewMaps' | 'flatViewFieldMaps'
   >;
-  orchestratorActionsReport: Pick<OrchestratorActionsReport, 'viewField'>;
+  deletedViewFieldActions: UniversalDeleteViewFieldAction[];
   preDeletionFlatViewFieldMaps: UniversalFlatEntityMaps<UniversalFlatViewField>;
 }): Pick<OrchestratorFailureReport, 'viewField'> => {
   const validationErrors: Pick<OrchestratorFailureReport, 'viewField'> = {
     viewField: [],
   };
-
-  const deletedViewFieldActions = orchestratorActionsReport.viewField.delete;
 
   if (deletedViewFieldActions.length === 0) {
     return validationErrors;
@@ -38,14 +35,10 @@ export const validateViewFieldLabelIdentifierCrossEntity = ({
   const alreadyCheckedViewUniversalIdentifiers = new Set<string>();
 
   for (const deleteAction of deletedViewFieldActions) {
-    const deletedViewField = findFlatEntityByUniversalIdentifier({
+    const deletedViewField = findFlatEntityByUniversalIdentifierOrThrow({
       universalIdentifier: deleteAction.universalIdentifier,
       flatEntityMaps: preDeletionFlatViewFieldMaps,
     });
-
-    if (!isDefined(deletedViewField)) {
-      continue;
-    }
 
     const { viewUniversalIdentifier, fieldMetadataUniversalIdentifier } =
       deletedViewField;
@@ -56,23 +49,19 @@ export const validateViewFieldLabelIdentifierCrossEntity = ({
 
     alreadyCheckedViewUniversalIdentifiers.add(viewUniversalIdentifier);
 
-    const view = findFlatEntityByUniversalIdentifier({
+    const view = findFlatEntityByUniversalIdentifierOrThrow({
       universalIdentifier: viewUniversalIdentifier,
       flatEntityMaps: optimisticUniversalFlatMaps.flatViewMaps,
     });
 
-    if (!isDefined(view) || view.type === ViewType.FIELDS_WIDGET) {
+    if (view.type === ViewType.FIELDS_WIDGET) {
       continue;
     }
 
-    const objectMetadata = findFlatEntityByUniversalIdentifier({
+    const objectMetadata = findFlatEntityByUniversalIdentifierOrThrow({
       universalIdentifier: view.objectMetadataUniversalIdentifier,
       flatEntityMaps: optimisticUniversalFlatMaps.flatObjectMetadataMaps,
     });
-
-    if (!isDefined(objectMetadata)) {
-      continue;
-    }
 
     const { labelIdentifierFieldMetadataUniversalIdentifier } = objectMetadata;
 

--- a/packages/twenty-server/src/engine/metadata-modules/flat-view-field/validators/utils/validate-view-field-label-identifier-cross-entity.util.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/flat-view-field/validators/utils/validate-view-field-label-identifier-cross-entity.util.ts
@@ -109,6 +109,8 @@ export const validateViewFieldLabelIdentifierCrossEntity = ({
       const failedValidation = getEmptyFlatEntityValidationError({
         flatEntityMinimalInformation: {
           universalIdentifier: deleteAction.universalIdentifier,
+          viewUniversalIdentifier,
+          fieldMetadataUniversalIdentifier,
         },
         metadataName: 'viewField',
         type: 'delete',

--- a/packages/twenty-server/src/engine/workspace-manager/workspace-migration/services/workspace-migration-build-orchestrator.service.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/workspace-migration/services/workspace-migration-build-orchestrator.service.ts
@@ -131,6 +131,10 @@ export class WorkspaceMigrationBuildOrchestratorService {
       dependencyAllFlatEntityMaps,
     });
 
+    const preDeletionFlatViewFieldMaps = structuredClone(
+      optimisticAllFlatEntityMaps.flatViewFieldMaps,
+    );
+
     const {
       flatObjectMetadataMaps,
       flatViewFieldMaps,
@@ -818,12 +822,14 @@ export class WorkspaceMigrationBuildOrchestratorService {
       }
     }
 
-    const { objectMetadata } = crossEntityTransversalValidation({
+    const { objectMetadata, viewField } = crossEntityTransversalValidation({
       optimisticUniversalFlatMaps: optimisticAllFlatEntityMaps,
       orchestratorActionsReport,
+      preDeletionFlatViewFieldMaps,
     });
 
     orchestratorFailureReport.objectMetadata.push(...objectMetadata);
+    orchestratorFailureReport.viewField.push(...viewField);
 
     const allErrors = Object.values(orchestratorFailureReport);
 

--- a/packages/twenty-server/src/engine/workspace-manager/workspace-migration/utils/cross-entity-transversal-validation.util.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/workspace-migration/utils/cross-entity-transversal-validation.util.ts
@@ -1,21 +1,32 @@
 import { validateObjectMetadataCrossEntity } from 'src/engine/metadata-modules/flat-object-metadata/validators/utils/validate-object-metadata-cross-entity.util';
+import { validateViewFieldLabelIdentifierCrossEntity } from 'src/engine/metadata-modules/flat-view-field/validators/utils/validate-view-field-label-identifier-cross-entity.util';
 import {
   type OrchestratorActionsReport,
   type OrchestratorFailureReport,
 } from 'src/engine/workspace-manager/workspace-migration/types/workspace-migration-orchestrator.type';
 import { type AllUniversalFlatEntityMaps } from 'src/engine/workspace-manager/workspace-migration/universal-flat-entity/types/all-universal-flat-entity-maps.type';
+import { type UniversalFlatEntityMaps } from 'src/engine/workspace-manager/workspace-migration/universal-flat-entity/types/universal-flat-entity-maps.type';
+import { type UniversalFlatViewField } from 'src/engine/workspace-manager/workspace-migration/universal-flat-entity/types/universal-flat-view-field.type';
 
 export const crossEntityTransversalValidation = ({
   optimisticUniversalFlatMaps,
   orchestratorActionsReport,
+  preDeletionFlatViewFieldMaps,
 }: {
   optimisticUniversalFlatMaps: AllUniversalFlatEntityMaps;
   orchestratorActionsReport: OrchestratorActionsReport;
-}): Pick<OrchestratorFailureReport, 'objectMetadata'> => {
+  preDeletionFlatViewFieldMaps: UniversalFlatEntityMaps<UniversalFlatViewField>;
+}): Pick<OrchestratorFailureReport, 'objectMetadata' | 'viewField'> => {
   const { objectMetadata } = validateObjectMetadataCrossEntity({
     optimisticUniversalFlatMaps,
     orchestratorActionsReport,
   });
 
-  return { objectMetadata };
+  const { viewField } = validateViewFieldLabelIdentifierCrossEntity({
+    optimisticUniversalFlatMaps,
+    orchestratorActionsReport,
+    preDeletionFlatViewFieldMaps,
+  });
+
+  return { objectMetadata, viewField };
 };

--- a/packages/twenty-server/src/engine/workspace-manager/workspace-migration/utils/cross-entity-transversal-validation.util.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/workspace-migration/utils/cross-entity-transversal-validation.util.ts
@@ -24,7 +24,7 @@ export const crossEntityTransversalValidation = ({
 
   const { viewField } = validateViewFieldLabelIdentifierCrossEntity({
     optimisticUniversalFlatMaps,
-    orchestratorActionsReport,
+    deletedViewFieldActions: orchestratorActionsReport.viewField.delete,
     preDeletionFlatViewFieldMaps,
   });
 

--- a/packages/twenty-server/src/engine/workspace-manager/workspace-migration/workspace-migration-builder/validators/services/flat-view-field-validator.service.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/workspace-migration/workspace-migration-builder/validators/services/flat-view-field-validator.service.ts
@@ -127,9 +127,6 @@ export class FlatViewFieldValidatorService {
     flatEntityToValidate: { universalIdentifier },
     optimisticFlatEntityMapsAndRelatedFlatEntityMaps: {
       flatViewFieldMaps: optimisticFlatViewFieldMaps,
-      flatFieldMetadataMaps,
-      flatObjectMetadataMaps,
-      flatViewMaps,
     },
   }: UniversalFlatEntityValidationArgs<
     typeof ALL_METADATA_NAME.viewField
@@ -155,43 +152,6 @@ export class FlatViewFieldValidatorService {
       });
 
       return validationResult;
-    }
-
-    const flatFieldMetadata = findFlatEntityByUniversalIdentifier({
-      universalIdentifier:
-        existingFlatViewField.fieldMetadataUniversalIdentifier,
-      flatEntityMaps: flatFieldMetadataMaps,
-    });
-
-    if (!isDefined(flatFieldMetadata)) {
-      return validationResult;
-    }
-
-    const flatObjectMetadata = findFlatEntityByUniversalIdentifier({
-      universalIdentifier: flatFieldMetadata.objectMetadataUniversalIdentifier,
-      flatEntityMaps: flatObjectMetadataMaps,
-    });
-
-    if (!isDefined(flatObjectMetadata)) {
-      return validationResult;
-    }
-
-    if (
-      flatObjectMetadata.labelIdentifierFieldMetadataUniversalIdentifier ===
-      existingFlatViewField.fieldMetadataUniversalIdentifier
-    ) {
-      const flatView = findFlatEntityByUniversalIdentifier({
-        universalIdentifier: existingFlatViewField.viewUniversalIdentifier,
-        flatEntityMaps: flatViewMaps,
-      });
-
-      if (!isDefined(flatView) || flatView.type !== ViewType.FIELDS_WIDGET) {
-        validationResult.errors.push({
-          code: ViewExceptionCode.INVALID_VIEW_DATA,
-          message: t`Label identifier view field cannot be deleted`,
-          userFriendlyMessage: msg`Label identifier view field cannot be deleted`,
-        });
-      }
     }
 
     return validationResult;

--- a/packages/twenty-server/test/integration/graphql/suites/view/view-field/__snapshots__/object-identifier-update-side-effect-on-view-field.integration-spec.ts.snap
+++ b/packages/twenty-server/test/integration/graphql/suites/view/view-field/__snapshots__/object-identifier-update-side-effect-on-view-field.integration-spec.ts.snap
@@ -92,7 +92,6 @@ exports[`View Field Resolver - Successful object metadata identifier update side
             "universalIdentifier": Any<String>,
           },
           "metadataName": "viewField",
-          "status": "fail",
           "type": "delete",
         },
       ],

--- a/packages/twenty-server/test/integration/graphql/suites/view/view-field/__snapshots__/object-identifier-update-side-effect-on-view-field.integration-spec.ts.snap
+++ b/packages/twenty-server/test/integration/graphql/suites/view/view-field/__snapshots__/object-identifier-update-side-effect-on-view-field.integration-spec.ts.snap
@@ -89,7 +89,9 @@ exports[`View Field Resolver - Successful object metadata identifier update side
             },
           ],
           "flatEntityMinimalInformation": {
+            "fieldMetadataUniversalIdentifier": Any<String>,
             "universalIdentifier": Any<String>,
+            "viewUniversalIdentifier": Any<String>,
           },
           "metadataName": "viewField",
           "type": "delete",


### PR DESCRIPTION
## Introduction
In the same validate build and run we should be able to delete a view field targetting a label identifier and at the same create one that repoints to it again without failing any validation

Leading for this valdiation rule to be moved in the cross entity validation steps