### PR TITLE
Fix `AddPermissionFlagRoleIdIndexFastInstanceCommand`

### DIFF
--- a/packages/twenty-server/src/database/commands/upgrade-version-command/1-22/1-22-instance-command-fast-1775749486425-add-permission-flag-role-id-index.ts
+++ b/packages/twenty-server/src/database/commands/upgrade-version-command/1-22/1-22-instance-command-fast-1775749486425-add-permission-flag-role-id-index.ts
@@ -9,11 +9,13 @@ export class AddPermissionFlagRoleIdIndexFastInstanceCommand
 {
   public async up(queryRunner: QueryRunner): Promise<void> {
     await queryRunner.query(
-      'CREATE INDEX "IDX_PERMISSION_FLAG_ROLE_ID" ON "core"."permissionFlag" ("roleId") ',
+      'CREATE INDEX IF NOT EXISTS "IDX_PERMISSION_FLAG_ROLE_ID" ON "core"."permissionFlag" ("roleId") ',
     );
   }
 
   public async down(queryRunner: QueryRunner): Promise<void> {
-    await queryRunner.query('DROP INDEX "core"."IDX_PERMISSION_FLAG_ROLE_ID"');
+    await queryRunner.query(
+      'DROP INDEX IF EXISTS "core"."IDX_PERMISSION_FLAG_ROLE_ID"',
+    );
   }
 }


### PR DESCRIPTION
# Introduction
Index seemed to be missing in production only, as it's blocking the whole migration release on other env that already implements the index