### PR TITLE
Fix 1.17 upgrade crash when built-function folder is missing

### DIFF
--- a/packages/twenty-server/src/database/commands/upgrade-version-command/1-17/1-17-migrate-workflow-code-steps.command.ts
+++ b/packages/twenty-server/src/database/commands/upgrade-version-command/1-17/1-17-migrate-workflow-code-steps.command.ts
@@ -2,8 +2,13 @@ import { Logger } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 
 import crypto from 'crypto';
+import { mkdtemp, mkdir, writeFile, readFile, rm } from 'fs/promises';
+import { tmpdir } from 'os';
+import { join } from 'path';
 
+import { build } from 'esbuild';
 import { Command } from 'nest-commander';
+import { NODE_ESM_CJS_BANNER } from 'twenty-shared/application';
 import { FileFolder, type Sources } from 'twenty-shared/types';
 import { isDefined } from 'twenty-shared/utils';
 import { In, Repository } from 'typeorm';
@@ -239,9 +244,17 @@ export class MigrateWorkflowCodeStepsCommand extends ActiveOrSuspendedWorkspaces
   ): Promise<{ builtContent: string; sourceContent: string }> {
     const workspacePrefix = `workspace-${workspaceId}`;
 
-    const builtSources = await this.fileStorageService.readFolderLegacy(
-      `${workspacePrefix}/${OLD_BUILT_FOLDER}/${serverlessFunctionId}/${version}`,
-    );
+    let builtSources: Sources | null = null;
+
+    try {
+      builtSources = await this.fileStorageService.readFolderLegacy(
+        `${workspacePrefix}/${OLD_BUILT_FOLDER}/${serverlessFunctionId}/${version}`,
+      );
+    } catch {
+      this.logger.warn(
+        `Built folder not found for serverless function ${serverlessFunctionId}/${version} in workspace ${workspaceId}, will build from source`,
+      );
+    }
 
     const sourceSources = await this.fileStorageService.readFolderLegacy(
       `${workspacePrefix}/${OLD_SOURCE_FOLDER}/${serverlessFunctionId}/${version}`,
@@ -251,16 +264,52 @@ export class MigrateWorkflowCodeStepsCommand extends ActiveOrSuspendedWorkspaces
     const sourceRoot =
       (sourceSources.src as Sources) ?? (sourceSources as Sources);
 
-    const builtContent = builtSources['index.mjs'] as string;
     const sourceContent = sourceRoot['index.ts'] as string;
 
-    if (!isDefined(builtContent) || !isDefined(sourceContent)) {
+    if (!isDefined(sourceContent)) {
       throw new Error(
-        `Missing index.mjs or index.ts for serverless function ${serverlessFunctionId}/${version} in workspace ${workspaceId}`,
+        `Missing index.ts for serverless function ${serverlessFunctionId}/${version} in workspace ${workspaceId}`,
       );
     }
 
+    let builtContent = builtSources?.['index.mjs'] as string | undefined;
+
+    if (!isDefined(builtContent)) {
+      this.logger.log(
+        `Building serverless function ${serverlessFunctionId}/${version} from source in workspace ${workspaceId}`,
+      );
+      builtContent = await this.buildSourceToMjs(sourceContent);
+    }
+
     return { builtContent, sourceContent };
+  }
+
+  private async buildSourceToMjs(sourceContent: string): Promise<string> {
+    const tempDir = await mkdtemp(join(tmpdir(), 'twenty-migrate-'));
+
+    try {
+      const srcDir = join(tempDir, 'src');
+      const outFile = join(tempDir, 'index.mjs');
+
+      await mkdir(srcDir, { recursive: true });
+      await writeFile(join(srcDir, 'index.ts'), sourceContent);
+
+      await build({
+        entryPoints: [join(srcDir, 'index.ts')],
+        outfile: outFile,
+        platform: 'node',
+        format: 'esm',
+        target: 'es2017',
+        bundle: true,
+        sourcemap: true,
+        packages: 'external',
+        banner: NODE_ESM_CJS_BANNER,
+      });
+
+      return await readFile(outFile, 'utf-8');
+    } finally {
+      await rm(tempDir, { recursive: true, force: true });
+    }
   }
 
   private async uploadFunctionFiles(


### PR DESCRIPTION
## Summary

- Fix the v1.17 upgrade command (`upgrade:1-17:migrate-workflow-code-steps`) crashing when the `built-function/` folder doesn't exist in storage
- When built files are missing, the migration now builds from source using esbuild instead of failing

## Context

Serverless functions created in v1.14 only write **source files** (`serverless-function/{id}/draft/src/index.ts`). The **built files** (`built-function/{id}/draft/index.mjs`) are only created when a function is actually **executed** at runtime.

The v1.17 migration assumed both always exist. Users who created serverless functions but never ran them hit one of two errors depending on their storage driver:
- **Local storage**: `ENOENT: no such file or directory, scandir '.local-storage/.../built-function/{id}/draft'`
- **S3**: `Missing index.mjs or index.ts for serverless function {id}/draft in workspace {workspace-id}`

## Fix

`readOldFunctionFiles()` now:
1. Wraps the `built-function/` read in a try/catch — missing directory is no longer fatal
2. If built files are missing, builds from source using esbuild (same config used by `LogicFunctionResourceService.buildInMemory`)
3. Only throws if the source (`index.ts`) is genuinely missing

## Test plan

- [ ] Create serverless functions in v1.14 without executing them
- [ ] Upgrade through v1.15 → v1.16 → v1.17
- [ ] Verify upgrade completes without error
- [ ] Verify migrated logic functions work correctly after upgrade

🤖 Generated with [Claude Code](https://claude.com/claude-code)