### PR TITLE
Remove orphaned workspaceId column from BillingSubscriptionItemEntity

### DIFF
--- a/packages/twenty-server/src/engine/core-modules/billing/entities/billing-subscription-item.entity.ts
+++ b/packages/twenty-server/src/engine/core-modules/billing/entities/billing-subscription-item.entity.ts
@@ -5,7 +5,6 @@ import {
   Column,
   CreateDateColumn,
   Entity,
-  Index,
   JoinColumn,
   ManyToOne,
   PrimaryGeneratedColumn,
@@ -17,7 +16,6 @@ import {
 import { BillingProductEntity } from 'src/engine/core-modules/billing/entities/billing-product.entity';
 import { BillingSubscriptionEntity } from 'src/engine/core-modules/billing/entities/billing-subscription.entity';
 import { BillingSubscriptionItemMetadata } from 'src/engine/core-modules/billing/types/billing-subscription-item-metadata.type';
-import type { WorkspaceEntity } from 'src/engine/core-modules/workspace/workspace.entity';
 @Entity({ name: 'billingSubscriptionItem', schema: 'core' })
 @Unique(
   'IDX_BILLING_SUBSCRIPTION_ITEM_BILLING_SUBSCRIPTION_ID_STRIPE_PRODUCT_ID_UNIQUE',
@@ -26,14 +24,6 @@ import type { WorkspaceEntity } from 'src/engine/core-modules/workspace/workspac
 export class BillingSubscriptionItemEntity {
   @PrimaryGeneratedColumn('uuid')
   id: string;
-
-  @Column({ nullable: false, type: 'uuid' })
-  @Index()
-  workspaceId: string;
-
-  @ManyToOne('WorkspaceEntity', { onDelete: 'CASCADE' })
-  @JoinColumn({ name: 'workspaceId' })
-  workspace: Relation<WorkspaceEntity>;
 
   @Column({ nullable: true, type: 'timestamptz' })
   deletedAt?: Date;


### PR DESCRIPTION
## Summary
- Removes the `workspaceId` column, `@Index()`, and `@ManyToOne` workspace relation from `BillingSubscriptionItemEntity`
- The entity defined these fields but they don't exist in the actual database table, causing `column X.workspaceId does not exist` errors at runtime
- The workspace relationship is already accessible through the parent `BillingSubscriptionEntity`

