### PR TITLE
feat(messaging): add OAuth2 support (XOAUTH2) for IMAP and SMTP

### DIFF
--- a/packages/twenty-server/src/engine/core-modules/imap-smtp-caldav-connection/dtos/imap-smtp-caldav-connection.dto.ts
+++ b/packages/twenty-server/src/engine/core-modules/imap-smtp-caldav-connection/dtos/imap-smtp-caldav-connection.dto.ts
@@ -22,8 +22,8 @@ export class ConnectionParameters {
    * While encrypting it could provide an extra layer of defense, we have decided not to,
    * as database access implies a broader compromise. For context, see discussion in PR #12576.
    */
-  @Field(() => String)
-  password: string;
+  @Field(() => String, { nullable: true })
+  password?: string;
 
   @Field(() => Boolean, { nullable: true })
   secure?: boolean;
@@ -52,8 +52,8 @@ export class ConnectionParametersDTO {
   @Field(() => String, { nullable: true })
   username?: string;
 
-  @Field(() => String)
-  password: string;
+  @Field(() => String, { nullable: true })
+  password?: string;
 
   @Field(() => Boolean, { nullable: true })
   secure?: boolean;

--- a/packages/twenty-server/src/engine/core-modules/imap-smtp-caldav-connection/types/imap-smtp-caldav-connection.type.ts
+++ b/packages/twenty-server/src/engine/core-modules/imap-smtp-caldav-connection/types/imap-smtp-caldav-connection.type.ts
@@ -2,7 +2,7 @@ export type ConnectionParameters = {
   host: string;
   port: number;
   username?: string;
-  password: string;
+  password?: string;
   secure?: boolean;
 };
 

--- a/packages/twenty-server/src/modules/messaging/message-import-manager/drivers/imap/providers/imap-client.provider.ts
+++ b/packages/twenty-server/src/modules/messaging/message-import-manager/drivers/imap/providers/imap-client.provider.ts
@@ -12,7 +12,7 @@ import { parseImapAuthenticationError } from 'src/modules/messaging/message-impo
 
 type ConnectedAccountIdentifier = Pick<
   ConnectedAccountEntity,
-  'id' | 'provider' | 'connectionParameters' | 'handle'
+  'id' | 'provider' | 'connectionParameters' | 'handle' | 'accessToken'
 >;
 
 @Injectable()
@@ -76,16 +76,26 @@ export class ImapClientProvider {
         connectionParameters.IMAP?.host || '',
       );
 
+    const auth: any = {
+      user: isDefined(connectionParameters.IMAP?.username)
+        ? connectionParameters.IMAP?.username
+        : connectedAccount.handle,
+    };
+
+    if (
+      connectedAccount.provider === ConnectedAccountProvider.GOOGLE ||
+      connectedAccount.provider === ConnectedAccountProvider.MICROSOFT
+    ) {
+      auth.accessToken = connectedAccount.accessToken;
+    } else {
+      auth.pass = connectionParameters.IMAP?.password || '';
+    }
+
     const client = new ImapFlow({
       host: validatedImapHost,
       port: connectionParameters.IMAP?.port || 993,
       secure: connectionParameters.IMAP?.secure,
-      auth: {
-        user: isDefined(connectionParameters.IMAP?.username)
-          ? connectionParameters.IMAP?.username
-          : connectedAccount.handle,
-        pass: connectionParameters.IMAP?.password || '',
-      },
+      auth,
       logger: false,
       tls: {
         rejectUnauthorized: false,

--- a/packages/twenty-server/src/modules/messaging/message-import-manager/drivers/imap/services/imap-get-messages.service.ts
+++ b/packages/twenty-server/src/modules/messaging/message-import-manager/drivers/imap/services/imap-get-messages.service.ts
@@ -18,7 +18,7 @@ import { sanitizeString } from 'src/modules/messaging/message-import-manager/uti
 
 type ConnectedAccount = Pick<
   ConnectedAccountEntity,
-  'id' | 'provider' | 'handle' | 'handleAliases' | 'connectionParameters'
+  'id' | 'provider' | 'handle' | 'handleAliases' | 'connectionParameters' | 'accessToken'
 >;
 
 @Injectable()

--- a/packages/twenty-server/src/modules/messaging/message-import-manager/drivers/smtp/providers/smtp-client.provider.ts
+++ b/packages/twenty-server/src/modules/messaging/message-import-manager/drivers/smtp/providers/smtp-client.provider.ts
@@ -6,6 +6,7 @@ import { isDefined } from 'twenty-shared/utils';
 import type SMTPConnection from 'nodemailer/lib/smtp-connection';
 
 import { SecureHttpClientService } from 'src/engine/core-modules/secure-http-client/secure-http-client.service';
+import { ConnectedAccountProvider } from 'twenty-shared/types';
 import { type ConnectedAccountEntity } from 'src/engine/metadata-modules/connected-account/entities/connected-account.entity';
 
 @Injectable()
@@ -17,7 +18,7 @@ export class SmtpClientProvider {
   public async getSmtpClient(
     connectedAccount: Pick<
       ConnectedAccountEntity,
-      'connectionParameters' | 'handle'
+      'connectionParameters' | 'handle' | 'provider' | 'accessToken'
     >,
   ): Promise<Transporter> {
     const smtpParams = connectedAccount.connectionParameters?.SMTP;
@@ -29,13 +30,24 @@ export class SmtpClientProvider {
     const validatedSmtpHost =
       await this.secureHttpClientService.getValidatedHost(smtpParams.host);
 
+    const auth: any = {
+      user: smtpParams.username ?? connectedAccount.handle ?? '',
+    };
+
+    if (
+      connectedAccount.provider === ConnectedAccountProvider.GOOGLE ||
+      connectedAccount.provider === ConnectedAccountProvider.MICROSOFT
+    ) {
+      auth.type = 'OAuth2';
+      auth.accessToken = connectedAccount.accessToken;
+    } else {
+      auth.pass = smtpParams.password;
+    }
+
     const options: SMTPConnection.Options = {
       host: validatedSmtpHost,
       port: smtpParams.port,
-      auth: {
-        user: smtpParams.username ?? connectedAccount.handle ?? '',
-        pass: smtpParams.password,
-      },
+      auth,
       tls: {
         rejectUnauthorized: false,
       },


### PR DESCRIPTION
This PR implements OAuth2 (XOAUTH2/Bearer) support for IMAP and SMTP drivers.

/attempt #19273