### PR TITLE
fix: extract street from Place Details so Address 1 shows only street after auto-fill

### DIFF
--- a/packages/twenty-front/src/modules/geo-map/types/placeApi.ts
+++ b/packages/twenty-front/src/modules/geo-map/types/placeApi.ts
@@ -13,6 +13,7 @@ export type PlaceAutocompleteResult = {
 };
 
 export type PlaceDetailsResult = {
+  street?: string;
   state?: string;
   postcode?: string;
   city?: string;

--- a/packages/twenty-front/src/modules/ui/field/input/hooks/useAddressAutocomplete.ts
+++ b/packages/twenty-front/src/modules/ui/field/input/hooks/useAddressAutocomplete.ts
@@ -80,7 +80,8 @@ export const useAddressAutocomplete = (
       const countryName = findCountryNameByCountryCode(placeData?.country);
 
       const updatedAddress = {
-        addressStreet1: addressStreet1 || (internalValue?.addressStreet1 ?? ''),
+        addressStreet1:
+          placeData?.street || addressStreet1 || (internalValue?.addressStreet1 ?? ''),
         addressStreet2: internalValue?.addressStreet2 ?? null,
         addressCity: placeData?.city || (internalValue?.addressCity ?? null),
         addressState: placeData?.state || (internalValue?.addressState ?? null),

--- a/packages/twenty-server/src/engine/core-modules/geo-map/dtos/place-details-result.dto.ts
+++ b/packages/twenty-server/src/engine/core-modules/geo-map/dtos/place-details-result.dto.ts
@@ -12,6 +12,9 @@ export class LocationDTO {
 @ObjectType('PlaceDetailsResult')
 export class PlaceDetailsResultDTO {
   @Field({ nullable: true })
+  street?: string;
+
+  @Field({ nullable: true })
   state?: string;
 
   @Field({ nullable: true })

--- a/packages/twenty-server/src/engine/core-modules/geo-map/utils/sanitize-place-details-results.util.ts
+++ b/packages/twenty-server/src/engine/core-modules/geo-map/utils/sanitize-place-details-results.util.ts
@@ -4,6 +4,7 @@ export type AddressComponent = {
   types: string[];
 };
 export type AddressFields = {
+  street?: string;
   state?: string;
   postcode?: string;
   city?: string;
@@ -21,10 +22,20 @@ export const sanitizePlaceDetailsResults = (
   if (!AddressComponents || AddressComponents.length === 0) return {};
 
   const address: AddressFields = {};
+  let streetNumber = '';
+  let route = '';
 
   for (const AddressComponent of AddressComponents) {
     for (const type of AddressComponent.types) {
       switch (type) {
+        case 'street_number':
+          streetNumber = AddressComponent.long_name;
+          break;
+
+        case 'route':
+          route = AddressComponent.long_name;
+          break;
+
         case 'postal_code': {
           address.postcode =
             AddressComponent.long_name + (address.postcode ?? '');
@@ -72,6 +83,11 @@ export const sanitizePlaceDetailsResults = (
       }
     }
   }
+  const streetParts = [streetNumber, route].filter(Boolean).join(' ');
+  if (streetParts) {
+    address.street = streetParts;
+  }
+
   address.location = location;
 
   return address;


### PR DESCRIPTION
Fixes #18860.

When a user selects an address from the autocomplete suggestions, city/state/zip/country get correctly populated in their subfields, but Address 1 keeps the full address string (including the parts that are now in subfields). This is because the Place Details API returns structured `address_components` including `street_number` and `route`, but `sanitizePlaceDetailsResults` was only extracting city/state/country/postcode and ignoring the street components.

4 files changed:

- `sanitize-place-details-results.util.ts` — extract `street_number` + `route` from address_components, combine into a new `street` field
- `place-details-result.dto.ts` — expose `street` in the GraphQL DTO
- `placeApi.ts` (frontend type) — add `street` to `PlaceDetailsResult`
- `useAddressAutocomplete.ts` — prefer `placeData.street` over the raw autocomplete text for `addressStreet1`

Now when a user selects "123 Main St, New York, NY 10001", Address 1 shows "123 Main St" and the subfields show the rest.