### PR TITLE
fix: skip STATUS call on \Noselect IMAP folders (#19090)

### DIFF
--- a/packages/twenty-server/src/modules/messaging/message-folder-manager/drivers/imap/services/imap-get-all-folders.service.ts
+++ b/packages/twenty-server/src/modules/messaging/message-folder-manager/drivers/imap/services/imap-get-all-folders.service.ts
@@ -166,6 +166,10 @@ export class ImapGetAllFoldersService implements MessageFolderDriver {
     client: ImapFlow,
     mailbox: ListResponse,
   ): Promise<bigint | null> {
+    if (!this.isMailboxSelectable(mailbox)) {
+      return null;
+    }
+
     if (mailbox.status?.uidValidity) {
       return mailbox.status.uidValidity;
     }

--- a/packages/twenty-server/src/modules/messaging/message-import-manager/drivers/imap/utils/get-sent-folder-candidates-by-regex.util.ts
+++ b/packages/twenty-server/src/modules/messaging/message-import-manager/drivers/imap/utils/get-sent-folder-candidates-by-regex.util.ts
@@ -9,6 +9,10 @@ export function getImapSentFolderCandidatesByRegex(
   const regexCandidateFolders: string[] = [];
 
   for (const folder of list) {
+    if (folder.flags?.has('\\Noselect')) {
+      continue;
+    }
+
     const standardFolder = getStandardFolderByRegex(folder.name);
 
     if (standardFolder === StandardFolder.SENT) {


### PR DESCRIPTION
## Description

Fixes #19090

IMAP folder sync was calling `STATUS` on folders with the `\Noselect` flag (pure container/hierarchy folders without actual mailbox storage), causing "Mailbox doesn't exist" errors.

### Root Cause

When Dovecot (and other IMAP servers) create folder hierarchies, parent folders that only serve as containers get the `\Noselect` flag in the `LIST` response. These folders cannot be opened or queried with `STATUS`, but Twenty's IMAP sync was attempting `STATUS` commands on them to retrieve `uidValidity`.

### Changes

1. **`imap-get-all-folders.service.ts`** — Added `isMailboxSelectable()` guard in `getUidValidity()` to return `null` early for `\Noselect` folders, preventing the invalid `STATUS` call. The existing `isValidMailbox()` check in the main loop already filters `\Noselect` folders, but `getUidValidity()` now has its own defensive check as a safety net.

2. **`get-sent-folder-candidates-by-regex.util.ts`** — Added `\Noselect` filter in `getImapSentFolderCandidatesByRegex()` to prevent matching container folders as sent folder candidates.

### Testing

The existing test suite covers this scenario — see `Noselect folder handling` tests in `imap-get-all-folders.service.spec.ts`:
- `should not issue STATUS against a \Noselect folder`
- `should preserve parent references for children of \Noselect folders`  
- `should exclude \Noselect sent folder from results and skip STATUS`
