### PR TITLE
Expend field widget field supported types

### DIFF
--- a/packages/twenty-front/src/modules/page-layout/widgets/field/constants/fieldWidgetSupportedFieldTypes.ts
+++ b/packages/twenty-front/src/modules/page-layout/widgets/field/constants/fieldWidgetSupportedFieldTypes.ts
@@ -1,7 +1,0 @@
-import { type FieldMetadataType } from 'twenty-shared/types';
-
-import { FIELD_WIDGET_CONFIG } from '@/page-layout/widgets/field/constants/fieldWidgetConfig';
-
-export const FIELD_WIDGET_SUPPORTED_FIELD_TYPES = Object.keys(
-  FIELD_WIDGET_CONFIG,
-) as FieldMetadataType[];

--- a/packages/twenty-front/src/modules/page-layout/widgets/field/hooks/useFieldWidgetEligibleFields.ts
+++ b/packages/twenty-front/src/modules/page-layout/widgets/field/hooks/useFieldWidgetEligibleFields.ts
@@ -1,6 +1,5 @@
 import { useFieldListFieldMetadataItems } from '@/object-record/record-field-list/hooks/useFieldListFieldMetadataItems';
 import { isJunctionRelationField } from '@/object-record/record-field/ui/utils/junction/isJunctionRelationField';
-import { FIELD_WIDGET_SUPPORTED_FIELD_TYPES } from '@/page-layout/widgets/field/constants/fieldWidgetSupportedFieldTypes';
 import { useMemo } from 'react';
 
 export const useFieldWidgetEligibleFields = (objectNameSingular: string) => {
@@ -12,9 +11,7 @@ export const useFieldWidgetEligibleFields = (objectNameSingular: string) => {
 
   return useMemo(() => {
     const eligibleInlineFields = inlineFieldMetadataItems.filter(
-      (field) =>
-        FIELD_WIDGET_SUPPORTED_FIELD_TYPES.includes(field.type) &&
-        !isJunctionRelationField(field),
+      (field) => !isJunctionRelationField(field),
     );
 
     return [


### PR DESCRIPTION
## Context
Expending field widget supported types to all field types. They will all by default fallback to "FIELD" displaymode which is the inline display mode (same as the one used in FIELDS widget) and can be extended to other displayMode such as CARD or EDITOR in the future if needed. Most of the work was already done in the previous PR and was unnecessary filter out until this was properly tested

<img width="951" height="757" alt="Screenshot 2026-04-14 at 13 24 24" src="https://github.com/user-attachments/assets/a08a1855-21ea-4e75-8032-4f970b3ff50d" />
<img width="915" height="595" alt="Screenshot 2026-04-14 at 13 23 34" src="https://github.com/user-attachments/assets/8b420c1f-0496-4c1c-91b8-b266c40b3772" />
