### PR TITLE
Improve upgrade registry logging for pre-release bundles

### DIFF
--- a/packages/twenty-server/src/engine/core-modules/upgrade/services/upgrade-command-registry.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/upgrade/services/upgrade-command-registry.service.ts
@@ -169,8 +169,14 @@ export class UpgradeCommandRegistryService implements OnModuleInit {
         bundle.workspaceCommands.length;
 
       if (totalCount > 0) {
+        const crossUpgradeLabel = (
+          TWENTY_CROSS_UPGRADE_SUPPORTED_VERSIONS as readonly string[]
+        ).includes(version)
+          ? 'cross-upgrade supported'
+          : 'pre-release';
+
         this.logger.log(
-          `Registered ${bundle.fastInstanceCommands.length} fast instance, ${bundle.slowInstanceCommands.length} slow instance, and ${bundle.workspaceCommands.length} workspace command(s) for ${version}`,
+          `Registered ${bundle.fastInstanceCommands.length} fast instance, ${bundle.slowInstanceCommands.length} slow instance, and ${bundle.workspaceCommands.length} workspace command(s) for ${version} (${crossUpgradeLabel})`,
         );
       }
     }


### PR DESCRIPTION
```ts
Registered 3 fast instance command(s), 0 slow instance command(s), and 14 workspace command(s) for 1.21.0
Registered 5 fast instance command(s), 1 slow instance command(s), and 3 workspace command(s) for 1.22.0
Registered 1 fast instance command(s), 0 slow instance command(s), and 1 workspace command(s) for 1.23.0 (pre-release)
```