### PR TITLE
Fix silent failures in logic function route trigger execution

### DIFF
--- a/packages/twenty-server/src/engine/core-modules/logic-function/logic-function-drivers/drivers/lambda.driver.ts
+++ b/packages/twenty-server/src/engine/core-modules/logic-function/logic-function-drivers/drivers/lambda.driver.ts
@@ -65,7 +65,7 @@ const YARN_INSTALL_LAMBDA_MEMORY_MB = 1024;
 const COMMON_LAYER_NAME_PREFIX = 'twenty-common-layer';
 const BUILDER_LAMBDA_TIMEOUT_SECONDS = 60;
 const BUILDER_LAMBDA_MEMORY_MB = 512;
-const LAMBDA_EPHEMERAL_STORAGE_MB = 2048;
+const LAMBDA_EPHEMERAL_STORAGE_MB = 4096;
 const YARN_INSTALL_HANDLER_PATH = resolve(
   __dirname,
   join(
@@ -930,12 +930,6 @@ export class LambdaDriver implements LogicFunctionDriver {
     flatApplication: FlatApplication;
     applicationUniversalIdentifier: string;
   }) {
-    this.logger.log(
-      `buildLambdaExecutor: functionId=${flatLogicFunction.id}, ` +
-        `appId=${flatApplication.id}, ` +
-        `appUniversalId=${applicationUniversalIdentifier}`,
-    );
-
     const buildArgs = {
       flatLogicFunction,
       flatApplication,
@@ -945,16 +939,8 @@ export class LambdaDriver implements LogicFunctionDriver {
     const { canSkip } = await this.checkLambdaExecutorBuildStatus(buildArgs);
 
     if (canSkip) {
-      this.logger.log(
-        `buildLambdaExecutor: skipping build for ${flatLogicFunction.id} (already up to date)`,
-      );
-
       return;
     }
-
-    this.logger.log(
-      `buildLambdaExecutor: acquiring lock for ${flatLogicFunction.id}`,
-    );
 
     const buildLockTtlMs = 120_000;
     const buildLockRetryMs = 500;
@@ -967,22 +953,10 @@ export class LambdaDriver implements LogicFunctionDriver {
           await this.checkLambdaExecutorBuildStatus(buildArgs);
 
         if (canSkip) {
-          this.logger.log(
-            `buildLambdaExecutor: skipping build inside lock for ${flatLogicFunction.id}`,
-          );
-
           return;
         }
 
-        this.logger.log(
-          `buildLambdaExecutor: lock acquired, calling ensureLambdaExecutor for ${flatLogicFunction.id}`,
-        );
-
         await this.ensureLambdaExecutor({ ...buildArgs, lambdaExecutor });
-
-        this.logger.log(
-          `buildLambdaExecutor: ensureLambdaExecutor completed for ${flatLogicFunction.id}`,
-        );
       },
       `lambda-build:${flatLogicFunction.id}`,
       {
@@ -1030,34 +1004,35 @@ export class LambdaDriver implements LogicFunctionDriver {
     applicationUniversalIdentifier: string;
     lambdaExecutor: GetFunctionCommandOutput | undefined;
   }) {
-    this.logger.log(
-      `ensureLambdaExecutor: getting deps layer for app ${flatApplication.id}, ` +
-        `yarnLockChecksum=${flatApplication.yarnLockChecksum}`,
-    );
+    let depsLayerArn: string;
 
-    const depsLayerArn = await this.getLayerArn({
-      flatApplication,
-      applicationUniversalIdentifier,
-    });
+    try {
+      depsLayerArn = await this.getLayerArn({
+        flatApplication,
+        applicationUniversalIdentifier,
+      });
+    } catch (error) {
+      this.logger.error(
+        `Failed to get dependency layer for function ${flatLogicFunction.id}: ${error}`,
+      );
+      throw error;
+    }
 
-    this.logger.log(
-      `ensureLambdaExecutor: depsLayerArn=${depsLayerArn}`,
-    );
+    let sdkLayerArn: string;
 
-    const sdkLayerArn = await this.ensureSdkLayer({
-      flatApplication,
-      applicationUniversalIdentifier,
-    });
-
-    this.logger.log(
-      `ensureLambdaExecutor: sdkLayerArn=${sdkLayerArn}`,
-    );
+    try {
+      sdkLayerArn = await this.ensureSdkLayer({
+        flatApplication,
+        applicationUniversalIdentifier,
+      });
+    } catch (error) {
+      this.logger.error(
+        `Failed to get SDK layer for function ${flatLogicFunction.id}: ${error}`,
+      );
+      throw error;
+    }
 
     if (!isDefined(lambdaExecutor)) {
-      this.logger.log(
-        `ensureLambdaExecutor: creating new lambda for ${flatLogicFunction.id}`,
-      );
-
       await this.createLambdaExecutor({
         flatLogicFunction,
         depsLayerArn,
@@ -1065,16 +1040,8 @@ export class LambdaDriver implements LogicFunctionDriver {
       });
       await this.waitFunctionActive(flatLogicFunction.id);
 
-      this.logger.log(
-        `ensureLambdaExecutor: lambda ${flatLogicFunction.id} created and active`,
-      );
-
       return;
     }
-
-    this.logger.log(
-      `ensureLambdaExecutor: updating lambda configuration for ${flatLogicFunction.id}`,
-    );
 
     await this.updateLambdaExecutorConfiguration({
       flatLogicFunction,
@@ -1082,10 +1049,6 @@ export class LambdaDriver implements LogicFunctionDriver {
       sdkLayerArn,
     });
     await this.waitFunctionUpdated(flatLogicFunction.id);
-
-    this.logger.log(
-      `ensureLambdaExecutor: lambda ${flatLogicFunction.id} updated`,
-    );
   }
 
   private async createLambdaExecutor({
@@ -1153,21 +1116,11 @@ export class LambdaDriver implements LogicFunctionDriver {
     env,
     timeoutMs = 900_000,
   }: LogicFunctionExecuteParams): Promise<LogicFunctionExecuteResult> {
-    this.logger.log(
-      `execute: starting for function=${flatLogicFunction.id}, ` +
-        `app=${applicationUniversalIdentifier}, ` +
-        `timeoutMs=${timeoutMs}`,
-    );
-
     await this.buildLambdaExecutor({
       flatLogicFunction,
       flatApplication,
       applicationUniversalIdentifier,
     });
-
-    this.logger.log(
-      `execute: buildLambdaExecutor completed for ${flatLogicFunction.id}`,
-    );
 
     const startTime = Date.now();
 
@@ -1176,10 +1129,6 @@ export class LambdaDriver implements LogicFunctionDriver {
       applicationUniversalIdentifier,
       builtHandlerPath: flatLogicFunction.builtHandlerPath,
     });
-
-    this.logger.log(
-      `execute: built code loaded (${compiledCode.length} chars) for ${flatLogicFunction.id}`,
-    );
 
     const executorPayload: LambdaDriverExecutorPayload = {
       params: payload,
@@ -1195,10 +1144,6 @@ export class LambdaDriver implements LogicFunctionDriver {
     };
 
     const command = new InvokeCommand(params);
-
-    this.logger.log(
-      `execute: invoking lambda ${flatLogicFunction.id} with timeoutMs=${timeoutMs}`,
-    );
 
     try {
       const lambdaClient = await this.getLambdaClient();
@@ -1217,10 +1162,6 @@ export class LambdaDriver implements LogicFunctionDriver {
       const duration = Date.now() - startTime;
 
       if (result.FunctionError) {
-        this.logger.error(
-          `execute: lambda ${flatLogicFunction.id} returned FunctionError: ${JSON.stringify(parsedResult)}`,
-        );
-
         return {
           data: null,
           duration,
@@ -1230,10 +1171,6 @@ export class LambdaDriver implements LogicFunctionDriver {
         };
       }
 
-      this.logger.log(
-        `execute: lambda ${flatLogicFunction.id} completed successfully in ${duration}ms`,
-      );
-
       return {
         data: parsedResult,
         logs,
@@ -1242,7 +1179,7 @@ export class LambdaDriver implements LogicFunctionDriver {
       };
     } catch (error) {
       this.logger.error(
-        `execute: lambda ${flatLogicFunction.id} invoke failed: ${error}`,
+        `Lambda invocation failed for function ${flatLogicFunction.id}: ${error}`,
       );
 
       if (error instanceof ResourceNotFoundException) {

--- a/packages/twenty-server/src/engine/core-modules/logic-function/logic-function-drivers/drivers/lambda.driver.ts
+++ b/packages/twenty-server/src/engine/core-modules/logic-function/logic-function-drivers/drivers/lambda.driver.ts
@@ -25,6 +25,7 @@ import {
 import { PutObjectCommand, S3Client } from '@aws-sdk/client-s3';
 import { AssumeRoleCommand, STSClient } from '@aws-sdk/client-sts';
 import { getSignedUrl } from '@aws-sdk/s3-request-presigner';
+import { Logger } from '@nestjs/common';
 import { isDefined } from 'twenty-shared/utils';
 
 import {
@@ -122,6 +123,7 @@ export interface LambdaDriverOptions extends LambdaClientConfig {
 }
 
 export class LambdaDriver implements LogicFunctionDriver {
+  private readonly logger = new Logger(LambdaDriver.name);
   private lambdaClient: Lambda | undefined;
   private assumeRoleCredentials:
     | { accessKeyId: string; secretAccessKey: string; sessionToken: string }
@@ -928,6 +930,12 @@ export class LambdaDriver implements LogicFunctionDriver {
     flatApplication: FlatApplication;
     applicationUniversalIdentifier: string;
   }) {
+    this.logger.log(
+      `buildLambdaExecutor: functionId=${flatLogicFunction.id}, ` +
+        `appId=${flatApplication.id}, ` +
+        `appUniversalId=${applicationUniversalIdentifier}`,
+    );
+
     const buildArgs = {
       flatLogicFunction,
       flatApplication,
@@ -937,8 +945,16 @@ export class LambdaDriver implements LogicFunctionDriver {
     const { canSkip } = await this.checkLambdaExecutorBuildStatus(buildArgs);
 
     if (canSkip) {
+      this.logger.log(
+        `buildLambdaExecutor: skipping build for ${flatLogicFunction.id} (already up to date)`,
+      );
+
       return;
     }
+
+    this.logger.log(
+      `buildLambdaExecutor: acquiring lock for ${flatLogicFunction.id}`,
+    );
 
     const buildLockTtlMs = 120_000;
     const buildLockRetryMs = 500;
@@ -951,10 +967,22 @@ export class LambdaDriver implements LogicFunctionDriver {
           await this.checkLambdaExecutorBuildStatus(buildArgs);
 
         if (canSkip) {
+          this.logger.log(
+            `buildLambdaExecutor: skipping build inside lock for ${flatLogicFunction.id}`,
+          );
+
           return;
         }
 
+        this.logger.log(
+          `buildLambdaExecutor: lock acquired, calling ensureLambdaExecutor for ${flatLogicFunction.id}`,
+        );
+
         await this.ensureLambdaExecutor({ ...buildArgs, lambdaExecutor });
+
+        this.logger.log(
+          `buildLambdaExecutor: ensureLambdaExecutor completed for ${flatLogicFunction.id}`,
+        );
       },
       `lambda-build:${flatLogicFunction.id}`,
       {
@@ -1002,17 +1030,34 @@ export class LambdaDriver implements LogicFunctionDriver {
     applicationUniversalIdentifier: string;
     lambdaExecutor: GetFunctionCommandOutput | undefined;
   }) {
+    this.logger.log(
+      `ensureLambdaExecutor: getting deps layer for app ${flatApplication.id}, ` +
+        `yarnLockChecksum=${flatApplication.yarnLockChecksum}`,
+    );
+
     const depsLayerArn = await this.getLayerArn({
       flatApplication,
       applicationUniversalIdentifier,
     });
+
+    this.logger.log(
+      `ensureLambdaExecutor: depsLayerArn=${depsLayerArn}`,
+    );
 
     const sdkLayerArn = await this.ensureSdkLayer({
       flatApplication,
       applicationUniversalIdentifier,
     });
 
+    this.logger.log(
+      `ensureLambdaExecutor: sdkLayerArn=${sdkLayerArn}`,
+    );
+
     if (!isDefined(lambdaExecutor)) {
+      this.logger.log(
+        `ensureLambdaExecutor: creating new lambda for ${flatLogicFunction.id}`,
+      );
+
       await this.createLambdaExecutor({
         flatLogicFunction,
         depsLayerArn,
@@ -1020,8 +1065,16 @@ export class LambdaDriver implements LogicFunctionDriver {
       });
       await this.waitFunctionActive(flatLogicFunction.id);
 
+      this.logger.log(
+        `ensureLambdaExecutor: lambda ${flatLogicFunction.id} created and active`,
+      );
+
       return;
     }
+
+    this.logger.log(
+      `ensureLambdaExecutor: updating lambda configuration for ${flatLogicFunction.id}`,
+    );
 
     await this.updateLambdaExecutorConfiguration({
       flatLogicFunction,
@@ -1029,6 +1082,10 @@ export class LambdaDriver implements LogicFunctionDriver {
       sdkLayerArn,
     });
     await this.waitFunctionUpdated(flatLogicFunction.id);
+
+    this.logger.log(
+      `ensureLambdaExecutor: lambda ${flatLogicFunction.id} updated`,
+    );
   }
 
   private async createLambdaExecutor({
@@ -1096,11 +1153,21 @@ export class LambdaDriver implements LogicFunctionDriver {
     env,
     timeoutMs = 900_000,
   }: LogicFunctionExecuteParams): Promise<LogicFunctionExecuteResult> {
+    this.logger.log(
+      `execute: starting for function=${flatLogicFunction.id}, ` +
+        `app=${applicationUniversalIdentifier}, ` +
+        `timeoutMs=${timeoutMs}`,
+    );
+
     await this.buildLambdaExecutor({
       flatLogicFunction,
       flatApplication,
       applicationUniversalIdentifier,
     });
+
+    this.logger.log(
+      `execute: buildLambdaExecutor completed for ${flatLogicFunction.id}`,
+    );
 
     const startTime = Date.now();
 
@@ -1109,6 +1176,10 @@ export class LambdaDriver implements LogicFunctionDriver {
       applicationUniversalIdentifier,
       builtHandlerPath: flatLogicFunction.builtHandlerPath,
     });
+
+    this.logger.log(
+      `execute: built code loaded (${compiledCode.length} chars) for ${flatLogicFunction.id}`,
+    );
 
     const executorPayload: LambdaDriverExecutorPayload = {
       params: payload,
@@ -1124,6 +1195,10 @@ export class LambdaDriver implements LogicFunctionDriver {
     };
 
     const command = new InvokeCommand(params);
+
+    this.logger.log(
+      `execute: invoking lambda ${flatLogicFunction.id} with timeoutMs=${timeoutMs}`,
+    );
 
     try {
       const lambdaClient = await this.getLambdaClient();
@@ -1142,6 +1217,10 @@ export class LambdaDriver implements LogicFunctionDriver {
       const duration = Date.now() - startTime;
 
       if (result.FunctionError) {
+        this.logger.error(
+          `execute: lambda ${flatLogicFunction.id} returned FunctionError: ${JSON.stringify(parsedResult)}`,
+        );
+
         return {
           data: null,
           duration,
@@ -1151,6 +1230,10 @@ export class LambdaDriver implements LogicFunctionDriver {
         };
       }
 
+      this.logger.log(
+        `execute: lambda ${flatLogicFunction.id} completed successfully in ${duration}ms`,
+      );
+
       return {
         data: parsedResult,
         logs,
@@ -1158,6 +1241,10 @@ export class LambdaDriver implements LogicFunctionDriver {
         status: LogicFunctionExecutionStatus.SUCCESS,
       };
     } catch (error) {
+      this.logger.error(
+        `execute: lambda ${flatLogicFunction.id} invoke failed: ${error}`,
+      );
+
       if (error instanceof ResourceNotFoundException) {
         throw new LogicFunctionException(
           `Function '${flatLogicFunction.id}' does not exist`,

--- a/packages/twenty-server/src/engine/core-modules/logic-function/logic-function-drivers/drivers/lambda.driver.ts
+++ b/packages/twenty-server/src/engine/core-modules/logic-function/logic-function-drivers/drivers/lambda.driver.ts
@@ -1015,7 +1015,10 @@ export class LambdaDriver implements LogicFunctionDriver {
       this.logger.error(
         `Failed to get dependency layer for function ${flatLogicFunction.id}: ${error}`,
       );
-      throw error;
+      throw new LogicFunctionException(
+        `Failed to get dependency layer for function '${flatLogicFunction.id}': ${error instanceof Error ? error.message : 'Unknown error'}`,
+        LogicFunctionExceptionCode.LOGIC_FUNCTION_LAYER_BUILD_FAILED,
+      );
     }
 
     let sdkLayerArn: string;
@@ -1029,7 +1032,10 @@ export class LambdaDriver implements LogicFunctionDriver {
       this.logger.error(
         `Failed to get SDK layer for function ${flatLogicFunction.id}: ${error}`,
       );
-      throw error;
+      throw new LogicFunctionException(
+        `Failed to get SDK layer for function '${flatLogicFunction.id}': ${error instanceof Error ? error.message : 'Unknown error'}`,
+        LogicFunctionExceptionCode.LOGIC_FUNCTION_LAYER_BUILD_FAILED,
+      );
     }
 
     if (!isDefined(lambdaExecutor)) {
@@ -1188,7 +1194,15 @@ export class LambdaDriver implements LogicFunctionDriver {
           LogicFunctionExceptionCode.LOGIC_FUNCTION_NOT_FOUND,
         );
       }
-      throw error;
+
+      if (error instanceof LogicFunctionException) {
+        throw error;
+      }
+
+      throw new LogicFunctionException(
+        `Lambda invocation failed for function '${flatLogicFunction.id}': ${error instanceof Error ? error.message : 'Unknown error'}`,
+        LogicFunctionExceptionCode.LOGIC_FUNCTION_EXECUTION_FAILED,
+      );
     }
   }
 }

--- a/packages/twenty-server/src/engine/core-modules/logic-function/logic-function-drivers/drivers/lambda.driver.ts
+++ b/packages/twenty-server/src/engine/core-modules/logic-function/logic-function-drivers/drivers/lambda.driver.ts
@@ -1013,7 +1013,8 @@ export class LambdaDriver implements LogicFunctionDriver {
       });
     } catch (error) {
       this.logger.error(
-        `Failed to get dependency layer for function ${flatLogicFunction.id}: ${error}`,
+        `Failed to get dependency layer for function ${flatLogicFunction.id}: ${error instanceof Error ? error.message : String(error)}`,
+        error instanceof Error ? error.stack : undefined,
       );
       throw new LogicFunctionException(
         `Failed to get dependency layer for function '${flatLogicFunction.id}': ${error instanceof Error ? error.message : 'Unknown error'}`,
@@ -1030,7 +1031,8 @@ export class LambdaDriver implements LogicFunctionDriver {
       });
     } catch (error) {
       this.logger.error(
-        `Failed to get SDK layer for function ${flatLogicFunction.id}: ${error}`,
+        `Failed to get SDK layer for function ${flatLogicFunction.id}: ${error instanceof Error ? error.message : String(error)}`,
+        error instanceof Error ? error.stack : undefined,
       );
       throw new LogicFunctionException(
         `Failed to get SDK layer for function '${flatLogicFunction.id}': ${error instanceof Error ? error.message : 'Unknown error'}`,
@@ -1185,7 +1187,8 @@ export class LambdaDriver implements LogicFunctionDriver {
       };
     } catch (error) {
       this.logger.error(
-        `Lambda invocation failed for function ${flatLogicFunction.id}: ${error}`,
+        `Lambda invocation failed for function ${flatLogicFunction.id}: ${error instanceof Error ? error.message : String(error)}`,
+        error instanceof Error ? error.stack : undefined,
       );
 
       if (error instanceof ResourceNotFoundException) {

--- a/packages/twenty-server/src/engine/core-modules/logic-function/logic-function-executor/logic-function-executor.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/logic-function/logic-function-executor/logic-function-executor.service.ts
@@ -105,7 +105,9 @@ export class LogicFunctionExecutorService {
         `Logic function execution failed: ` +
           `functionId=${logicFunctionId}, ` +
           `workspaceId=${workspaceId}, ` +
-          `driver=${driver.constructor.name}: ${error}`,
+          `driver=${driver.constructor.name}: ` +
+          `${error instanceof Error ? error.message : String(error)}`,
+        error instanceof Error ? error.stack : undefined,
       );
       throw error;
     }

--- a/packages/twenty-server/src/engine/core-modules/logic-function/logic-function-executor/logic-function-executor.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/logic-function/logic-function-executor/logic-function-executor.service.ts
@@ -1,4 +1,4 @@
-import { Injectable } from '@nestjs/common';
+import { Injectable, Logger } from '@nestjs/common';
 
 import {
   DEFAULT_API_KEY_NAME,
@@ -50,6 +50,8 @@ export enum LogicFunctionExecutionExceptionCode {
 
 @Injectable()
 export class LogicFunctionExecutorService {
+  private readonly logger = new Logger(LogicFunctionExecutorService.name);
+
   constructor(
     private readonly logicFunctionDriverFactory: LogicFunctionDriverFactory,
     private readonly throttlerService: ThrottlerService,
@@ -71,7 +73,12 @@ export class LogicFunctionExecutorService {
     workspaceId: string;
     payload: object;
   }): Promise<LogicFunctionExecuteResult> {
+    this.logger.log(
+      `Starting execution: logicFunctionId=${logicFunctionId}, workspaceId=${workspaceId}`,
+    );
+
     await this.throttleExecution(workspaceId);
+    this.logger.log(`Throttle passed for workspace ${workspaceId}`);
 
     const { flatApplication, flatLogicFunction, flatApplicationVariables } =
       await this.getFlatEntitiesOrThrow({
@@ -79,13 +86,24 @@ export class LogicFunctionExecutorService {
         logicFunctionId,
       });
 
+    this.logger.log(
+      `Flat entities resolved: logicFunction=${flatLogicFunction.id} (name=${flatLogicFunction.name}), ` +
+        `application=${flatApplication.id} (universalId=${flatApplication.universalIdentifier}), ` +
+        `isBuildUpToDate=${flatLogicFunction.isBuildUpToDate}, ` +
+        `timeoutSeconds=${flatLogicFunction.timeoutSeconds}`,
+    );
+
     const envVariables = await this.getExecutionEnvVariables({
       workspaceId,
       flatApplication,
       flatApplicationVariables,
     });
 
+    this.logger.log(`Env variables built, calling driver.execute()`);
+
     const driver = this.logicFunctionDriverFactory.getCurrentDriver();
+
+    this.logger.log(`Driver type: ${driver.constructor.name}`);
 
     const resultLogicFunction = await driver.execute({
       flatLogicFunction,
@@ -95,6 +113,11 @@ export class LogicFunctionExecutorService {
       env: envVariables,
       timeoutMs: flatLogicFunction.timeoutSeconds * 1_000,
     });
+
+    this.logger.log(
+      `Driver execution complete: status=${resultLogicFunction.status}, ` +
+        `duration=${resultLogicFunction.duration}ms`,
+    );
 
     await this.handleExecutionResult({
       result: resultLogicFunction,

--- a/packages/twenty-server/src/engine/core-modules/logic-function/logic-function-executor/logic-function-executor.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/logic-function/logic-function-executor/logic-function-executor.service.ts
@@ -73,12 +73,7 @@ export class LogicFunctionExecutorService {
     workspaceId: string;
     payload: object;
   }): Promise<LogicFunctionExecuteResult> {
-    this.logger.log(
-      `Starting execution: logicFunctionId=${logicFunctionId}, workspaceId=${workspaceId}`,
-    );
-
     await this.throttleExecution(workspaceId);
-    this.logger.log(`Throttle passed for workspace ${workspaceId}`);
 
     const { flatApplication, flatLogicFunction, flatApplicationVariables } =
       await this.getFlatEntitiesOrThrow({
@@ -86,38 +81,34 @@ export class LogicFunctionExecutorService {
         logicFunctionId,
       });
 
-    this.logger.log(
-      `Flat entities resolved: logicFunction=${flatLogicFunction.id} (name=${flatLogicFunction.name}), ` +
-        `application=${flatApplication.id} (universalId=${flatApplication.universalIdentifier}), ` +
-        `isBuildUpToDate=${flatLogicFunction.isBuildUpToDate}, ` +
-        `timeoutSeconds=${flatLogicFunction.timeoutSeconds}`,
-    );
-
     const envVariables = await this.getExecutionEnvVariables({
       workspaceId,
       flatApplication,
       flatApplicationVariables,
     });
 
-    this.logger.log(`Env variables built, calling driver.execute()`);
-
     const driver = this.logicFunctionDriverFactory.getCurrentDriver();
 
-    this.logger.log(`Driver type: ${driver.constructor.name}`);
+    let resultLogicFunction: LogicFunctionExecuteResult;
 
-    const resultLogicFunction = await driver.execute({
-      flatLogicFunction,
-      flatApplication,
-      applicationUniversalIdentifier: flatApplication.universalIdentifier,
-      payload,
-      env: envVariables,
-      timeoutMs: flatLogicFunction.timeoutSeconds * 1_000,
-    });
-
-    this.logger.log(
-      `Driver execution complete: status=${resultLogicFunction.status}, ` +
-        `duration=${resultLogicFunction.duration}ms`,
-    );
+    try {
+      resultLogicFunction = await driver.execute({
+        flatLogicFunction,
+        flatApplication,
+        applicationUniversalIdentifier: flatApplication.universalIdentifier,
+        payload,
+        env: envVariables,
+        timeoutMs: flatLogicFunction.timeoutSeconds * 1_000,
+      });
+    } catch (error) {
+      this.logger.error(
+        `Logic function execution failed: ` +
+          `functionId=${logicFunctionId}, ` +
+          `workspaceId=${workspaceId}, ` +
+          `driver=${driver.constructor.name}: ${error}`,
+      );
+      throw error;
+    }
 
     await this.handleExecutionResult({
       result: resultLogicFunction,

--- a/packages/twenty-server/src/engine/core-modules/logic-function/logic-function-trigger/triggers/route/exceptions/route-trigger-rest-api-exception-filter.ts
+++ b/packages/twenty-server/src/engine/core-modules/logic-function/logic-function-trigger/triggers/route/exceptions/route-trigger-rest-api-exception-filter.ts
@@ -39,6 +39,12 @@ export class RouteTriggerRestApiExceptionFilter implements ExceptionFilter {
           response,
           403,
         );
+      case RouteTriggerExceptionCode.RATE_LIMIT_EXCEEDED:
+        return this.httpExceptionHandlerService.handleError(
+          exception as CustomException,
+          response,
+          429,
+        );
       case RouteTriggerExceptionCode.LOGIC_FUNCTION_EXECUTION_ERROR:
         return this.httpExceptionHandlerService.handleError(
           exception as CustomException,

--- a/packages/twenty-server/src/engine/core-modules/logic-function/logic-function-trigger/triggers/route/exceptions/route-trigger.exception.ts
+++ b/packages/twenty-server/src/engine/core-modules/logic-function/logic-function-trigger/triggers/route/exceptions/route-trigger.exception.ts
@@ -13,6 +13,7 @@ export enum RouteTriggerExceptionCode {
   ROUTE_PATH_ALREADY_EXIST = 'ROUTE_PATH_ALREADY_EXIST',
   FORBIDDEN_EXCEPTION = 'FORBIDDEN_EXCEPTION',
   LOGIC_FUNCTION_EXECUTION_ERROR = 'LOGIC_FUNCTION_EXECUTION_ERROR',
+  RATE_LIMIT_EXCEEDED = 'RATE_LIMIT_EXCEEDED',
 }
 
 const getRouteTriggerExceptionUserFriendlyMessage = (
@@ -35,6 +36,8 @@ const getRouteTriggerExceptionUserFriendlyMessage = (
       return msg`You do not have permission to perform this action.`;
     case RouteTriggerExceptionCode.LOGIC_FUNCTION_EXECUTION_ERROR:
       return msg`Logic function execution failed.`;
+    case RouteTriggerExceptionCode.RATE_LIMIT_EXCEEDED:
+      return msg`Too many requests. Please try again later.`;
     default:
       assertUnreachable(code);
   }

--- a/packages/twenty-server/src/engine/core-modules/logic-function/logic-function-trigger/triggers/route/route-trigger.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/logic-function/logic-function-trigger/triggers/route/route-trigger.service.ts
@@ -41,10 +41,6 @@ export class RouteTriggerService {
   }> {
     const host = `${request.protocol}://${request.get('host')}`;
 
-    this.logger.log(
-      `Resolving workspace for host=${host}, path=${request.path}, method=${httpMethod}`,
-    );
-
     const workspace =
       await this.workspaceDomainsService.getWorkspaceByOriginOrDefaultWorkspace(
         host,
@@ -58,8 +54,6 @@ export class RouteTriggerService {
       ),
     );
 
-    this.logger.log(`Workspace resolved: id=${workspace.id}`);
-
     const logicFunctionsWithHttpRouteTrigger =
       await this.logicFunctionRepository.find({
         where: {
@@ -68,20 +62,10 @@ export class RouteTriggerService {
         },
       });
 
-    this.logger.log(
-      `Found ${logicFunctionsWithHttpRouteTrigger.length} logic function(s) with HTTP route triggers for workspace ${workspace.id}`,
-    );
-
     const requestPath = request.path.replace(/^\/s\//, '/');
 
     for (const logicFunction of logicFunctionsWithHttpRouteTrigger) {
       const httpRouteSettings = logicFunction.httpRouteTriggerSettings;
-
-      this.logger.log(
-        `Checking logic function ${logicFunction.id} (name=${logicFunction.name}): ` +
-          `route=${httpRouteSettings?.path}, method=${httpRouteSettings?.httpMethod}, ` +
-          `requestPath=${requestPath}, requestMethod=${httpMethod}`,
-      );
 
       if (
         !isDefined(httpRouteSettings) ||
@@ -96,20 +80,12 @@ export class RouteTriggerService {
       const routeMatched = routeMatcher(requestPath);
 
       if (routeMatched) {
-        this.logger.log(
-          `Route matched: logicFunction=${logicFunction.id}, params=${JSON.stringify(routeMatched.params)}`,
-        );
-
         return {
           logicFunction,
           pathParams: routeMatched.params,
         };
       }
     }
-
-    this.logger.warn(
-      `No route trigger matched for path=${requestPath}, method=${httpMethod}`,
-    );
 
     throw new RouteTriggerException(
       'No Route trigger found',
@@ -151,8 +127,6 @@ export class RouteTriggerService {
     request: Request;
     httpMethod: HTTPMethod;
   }) {
-    this.logger.log(`Handling route trigger: ${httpMethod} ${request.path}`);
-
     const { logicFunction, pathParams } =
       await this.getLogicFunctionWithPathParamsOrFail({
         request,
@@ -162,9 +136,6 @@ export class RouteTriggerService {
     const httpRouteSettings = logicFunction.httpRouteTriggerSettings;
 
     if (httpRouteSettings?.isAuthRequired) {
-      this.logger.log(
-        `Auth required for logic function ${logicFunction.id}, validating...`,
-      );
       await this.validateWorkspaceFromRequest({
         request,
         workspaceId: logicFunction.workspaceId,
@@ -177,29 +148,34 @@ export class RouteTriggerService {
       forwardedRequestHeaders: httpRouteSettings?.forwardedRequestHeaders ?? [],
     });
 
-    this.logger.log(
-      `Executing logic function ${logicFunction.id} for workspace ${logicFunction.workspaceId}`,
-    );
+    let result;
 
-    const result = await this.logicFunctionExecutorService.execute({
-      logicFunctionId: logicFunction.id,
-      workspaceId: logicFunction.workspaceId,
-      payload: event,
-    });
+    try {
+      result = await this.logicFunctionExecutorService.execute({
+        logicFunctionId: logicFunction.id,
+        workspaceId: logicFunction.workspaceId,
+        payload: event,
+      });
+    } catch (error) {
+      if (error instanceof RouteTriggerException) {
+        throw error;
+      }
 
-    this.logger.log(
-      `Execution complete for logic function ${logicFunction.id}: status=${result?.status}`,
-    );
+      this.logger.error(
+        `Unexpected error executing logic function ${logicFunction.id}: ${error}`,
+      );
+
+      throw new RouteTriggerException(
+        `Logic function execution failed: ${error instanceof Error ? error.message : 'Unknown error'}`,
+        RouteTriggerExceptionCode.LOGIC_FUNCTION_EXECUTION_ERROR,
+      );
+    }
 
     if (!isDefined(result)) {
       return result;
     }
 
     if (result.error) {
-      this.logger.error(
-        `Logic function ${logicFunction.id} returned error: ${result.error.errorMessage}`,
-      );
-
       throw new RouteTriggerException(
         result.error.errorMessage,
         RouteTriggerExceptionCode.LOGIC_FUNCTION_EXECUTION_ERROR,

--- a/packages/twenty-server/src/engine/core-modules/logic-function/logic-function-trigger/triggers/route/route-trigger.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/logic-function/logic-function-trigger/triggers/route/route-trigger.service.ts
@@ -129,7 +129,9 @@ export class RouteTriggerService {
     return authContext;
   }
 
-  private mapErrorToRouteTriggerCode(error: unknown): RouteTriggerExceptionCode {
+  private mapErrorToRouteTriggerCode(
+    error: unknown,
+  ): RouteTriggerExceptionCode {
     if (error instanceof LogicFunctionExecutionException) {
       switch (error.code) {
         case LogicFunctionExecutionExceptionCode.LOGIC_FUNCTION_NOT_FOUND:

--- a/packages/twenty-server/src/engine/core-modules/logic-function/logic-function-trigger/triggers/route/route-trigger.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/logic-function/logic-function-trigger/triggers/route/route-trigger.service.ts
@@ -1,4 +1,4 @@
-import { Injectable } from '@nestjs/common';
+import { Injectable, Logger } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 
 import { Request } from 'express';
@@ -19,6 +19,8 @@ import { LogicFunctionExecutorService } from 'src/engine/core-modules/logic-func
 
 @Injectable()
 export class RouteTriggerService {
+  private readonly logger = new Logger(RouteTriggerService.name);
+
   constructor(
     private readonly accessTokenService: AccessTokenService,
     private readonly logicFunctionExecutorService: LogicFunctionExecutorService,
@@ -39,6 +41,10 @@ export class RouteTriggerService {
   }> {
     const host = `${request.protocol}://${request.get('host')}`;
 
+    this.logger.log(
+      `Resolving workspace for host=${host}, path=${request.path}, method=${httpMethod}`,
+    );
+
     const workspace =
       await this.workspaceDomainsService.getWorkspaceByOriginOrDefaultWorkspace(
         host,
@@ -52,6 +58,8 @@ export class RouteTriggerService {
       ),
     );
 
+    this.logger.log(`Workspace resolved: id=${workspace.id}`);
+
     const logicFunctionsWithHttpRouteTrigger =
       await this.logicFunctionRepository.find({
         where: {
@@ -60,10 +68,20 @@ export class RouteTriggerService {
         },
       });
 
+    this.logger.log(
+      `Found ${logicFunctionsWithHttpRouteTrigger.length} logic function(s) with HTTP route triggers for workspace ${workspace.id}`,
+    );
+
     const requestPath = request.path.replace(/^\/s\//, '/');
 
     for (const logicFunction of logicFunctionsWithHttpRouteTrigger) {
       const httpRouteSettings = logicFunction.httpRouteTriggerSettings;
+
+      this.logger.log(
+        `Checking logic function ${logicFunction.id} (name=${logicFunction.name}): ` +
+          `route=${httpRouteSettings?.path}, method=${httpRouteSettings?.httpMethod}, ` +
+          `requestPath=${requestPath}, requestMethod=${httpMethod}`,
+      );
 
       if (
         !isDefined(httpRouteSettings) ||
@@ -78,12 +96,20 @@ export class RouteTriggerService {
       const routeMatched = routeMatcher(requestPath);
 
       if (routeMatched) {
+        this.logger.log(
+          `Route matched: logicFunction=${logicFunction.id}, params=${JSON.stringify(routeMatched.params)}`,
+        );
+
         return {
           logicFunction,
           pathParams: routeMatched.params,
         };
       }
     }
+
+    this.logger.warn(
+      `No route trigger matched for path=${requestPath}, method=${httpMethod}`,
+    );
 
     throw new RouteTriggerException(
       'No Route trigger found',
@@ -125,6 +151,8 @@ export class RouteTriggerService {
     request: Request;
     httpMethod: HTTPMethod;
   }) {
+    this.logger.log(`Handling route trigger: ${httpMethod} ${request.path}`);
+
     const { logicFunction, pathParams } =
       await this.getLogicFunctionWithPathParamsOrFail({
         request,
@@ -134,6 +162,9 @@ export class RouteTriggerService {
     const httpRouteSettings = logicFunction.httpRouteTriggerSettings;
 
     if (httpRouteSettings?.isAuthRequired) {
+      this.logger.log(
+        `Auth required for logic function ${logicFunction.id}, validating...`,
+      );
       await this.validateWorkspaceFromRequest({
         request,
         workspaceId: logicFunction.workspaceId,
@@ -146,17 +177,29 @@ export class RouteTriggerService {
       forwardedRequestHeaders: httpRouteSettings?.forwardedRequestHeaders ?? [],
     });
 
+    this.logger.log(
+      `Executing logic function ${logicFunction.id} for workspace ${logicFunction.workspaceId}`,
+    );
+
     const result = await this.logicFunctionExecutorService.execute({
       logicFunctionId: logicFunction.id,
       workspaceId: logicFunction.workspaceId,
       payload: event,
     });
 
+    this.logger.log(
+      `Execution complete for logic function ${logicFunction.id}: status=${result?.status}`,
+    );
+
     if (!isDefined(result)) {
       return result;
     }
 
     if (result.error) {
+      this.logger.error(
+        `Logic function ${logicFunction.id} returned error: ${result.error.errorMessage}`,
+      );
+
       throw new RouteTriggerException(
         result.error.errorMessage,
         RouteTriggerExceptionCode.LOGIC_FUNCTION_EXECUTION_ERROR,

--- a/packages/twenty-server/src/engine/core-modules/logic-function/logic-function-trigger/triggers/route/route-trigger.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/logic-function/logic-function-trigger/triggers/route/route-trigger.service.ts
@@ -16,6 +16,7 @@ import {
 import { buildLogicFunctionEvent } from 'src/engine/core-modules/logic-function/logic-function-trigger/triggers/route/utils/build-logic-function-event.util';
 import { LogicFunctionEntity } from 'src/engine/metadata-modules/logic-function/logic-function.entity';
 import { LogicFunctionExecutorService } from 'src/engine/core-modules/logic-function/logic-function-executor/logic-function-executor.service';
+import { CustomException } from 'src/utils/custom-exception';
 
 @Injectable()
 export class RouteTriggerService {
@@ -168,6 +169,12 @@ export class RouteTriggerService {
       throw new RouteTriggerException(
         `Logic function execution failed: ${error instanceof Error ? error.message : 'Unknown error'}`,
         RouteTriggerExceptionCode.LOGIC_FUNCTION_EXECUTION_ERROR,
+        {
+          userFriendlyMessage:
+            error instanceof CustomException
+              ? error.userFriendlyMessage
+              : undefined,
+        },
       );
     }
 

--- a/packages/twenty-server/src/engine/core-modules/logic-function/logic-function-trigger/triggers/route/route-trigger.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/logic-function/logic-function-trigger/triggers/route/route-trigger.service.ts
@@ -14,8 +14,16 @@ import {
   RouteTriggerExceptionCode,
 } from 'src/engine/core-modules/logic-function/logic-function-trigger/triggers/route/exceptions/route-trigger.exception';
 import { buildLogicFunctionEvent } from 'src/engine/core-modules/logic-function/logic-function-trigger/triggers/route/utils/build-logic-function-event.util';
+import {
+  LogicFunctionException,
+  LogicFunctionExceptionCode,
+} from 'src/engine/metadata-modules/logic-function/logic-function.exception';
 import { LogicFunctionEntity } from 'src/engine/metadata-modules/logic-function/logic-function.entity';
-import { LogicFunctionExecutorService } from 'src/engine/core-modules/logic-function/logic-function-executor/logic-function-executor.service';
+import {
+  LogicFunctionExecutionException,
+  LogicFunctionExecutionExceptionCode,
+  LogicFunctionExecutorService,
+} from 'src/engine/core-modules/logic-function/logic-function-executor/logic-function-executor.service';
 import { CustomException } from 'src/utils/custom-exception';
 
 @Injectable()
@@ -121,6 +129,26 @@ export class RouteTriggerService {
     return authContext;
   }
 
+  private mapErrorToRouteTriggerCode(error: unknown): RouteTriggerExceptionCode {
+    if (error instanceof LogicFunctionExecutionException) {
+      switch (error.code) {
+        case LogicFunctionExecutionExceptionCode.LOGIC_FUNCTION_NOT_FOUND:
+          return RouteTriggerExceptionCode.LOGIC_FUNCTION_NOT_FOUND;
+        case LogicFunctionExecutionExceptionCode.RATE_LIMIT_EXCEEDED:
+          return RouteTriggerExceptionCode.RATE_LIMIT_EXCEEDED;
+      }
+    }
+
+    if (
+      error instanceof LogicFunctionException &&
+      error.code === LogicFunctionExceptionCode.LOGIC_FUNCTION_NOT_FOUND
+    ) {
+      return RouteTriggerExceptionCode.LOGIC_FUNCTION_NOT_FOUND;
+    }
+
+    return RouteTriggerExceptionCode.LOGIC_FUNCTION_EXECUTION_ERROR;
+  }
+
   async handle({
     request,
     httpMethod,
@@ -163,12 +191,15 @@ export class RouteTriggerService {
       }
 
       this.logger.error(
-        `Unexpected error executing logic function ${logicFunction.id}: ${error}`,
+        `Unexpected error executing logic function ${logicFunction.id}: ${error instanceof Error ? error.message : String(error)}`,
+        error instanceof Error ? error.stack : undefined,
       );
 
+      const code = this.mapErrorToRouteTriggerCode(error);
+
       throw new RouteTriggerException(
-        `Logic function execution failed: ${error instanceof Error ? error.message : 'Unknown error'}`,
-        RouteTriggerExceptionCode.LOGIC_FUNCTION_EXECUTION_ERROR,
+        `Logic function execution failed for ${logicFunction.id}`,
+        code,
         {
           userFriendlyMessage:
             error instanceof CustomException

--- a/packages/twenty-server/src/engine/metadata-modules/logic-function/logic-function.exception.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/logic-function/logic-function.exception.ts
@@ -14,6 +14,8 @@ export enum LogicFunctionExceptionCode {
   LOGIC_FUNCTION_CREATE_FAILED = 'LOGIC_FUNCTION_CREATE_FAILED',
   LOGIC_FUNCTION_COMPILATION_FAILED = 'LOGIC_FUNCTION_COMPILATION_FAILED',
   LOGIC_FUNCTION_EXECUTION_TIMEOUT = 'LOGIC_FUNCTION_EXECUTION_TIMEOUT',
+  LOGIC_FUNCTION_EXECUTION_FAILED = 'LOGIC_FUNCTION_EXECUTION_FAILED',
+  LOGIC_FUNCTION_LAYER_BUILD_FAILED = 'LOGIC_FUNCTION_LAYER_BUILD_FAILED',
   LOGIC_FUNCTION_DISABLED = 'LOGIC_FUNCTION_DISABLED',
   LOGIC_FUNCTION_INVALID_SEED_PROJECT = 'LOGIC_FUNCTION_INVALID_SEED_PROJECT',
 }
@@ -40,6 +42,10 @@ const getLogicFunctionExceptionUserFriendlyMessage = (
       return msg`Function code failed to compile.`;
     case LogicFunctionExceptionCode.LOGIC_FUNCTION_EXECUTION_TIMEOUT:
       return msg`Function execution timed out.`;
+    case LogicFunctionExceptionCode.LOGIC_FUNCTION_EXECUTION_FAILED:
+      return msg`Function execution failed.`;
+    case LogicFunctionExceptionCode.LOGIC_FUNCTION_LAYER_BUILD_FAILED:
+      return msg`Failed to build function dependencies.`;
     case LogicFunctionExceptionCode.LOGIC_FUNCTION_DISABLED:
       return msg`Logic function execution is disabled.`;
     case LogicFunctionExceptionCode.LOGIC_FUNCTION_INVALID_SEED_PROJECT:

--- a/packages/twenty-server/src/engine/metadata-modules/logic-function/utils/logic-function-graphql-api-exception-handler.utils.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/logic-function/utils/logic-function-graphql-api-exception-handler.utils.ts
@@ -29,6 +29,8 @@ export const logicFunctionGraphQLApiExceptionHandler = (error: any) => {
       case LogicFunctionExceptionCode.LOGIC_FUNCTION_CODE_UNCHANGED:
       case LogicFunctionExceptionCode.LOGIC_FUNCTION_CREATE_FAILED:
       case LogicFunctionExceptionCode.LOGIC_FUNCTION_INVALID_SEED_PROJECT:
+      case LogicFunctionExceptionCode.LOGIC_FUNCTION_EXECUTION_FAILED:
+      case LogicFunctionExceptionCode.LOGIC_FUNCTION_LAYER_BUILD_FAILED:
         throw error;
       case LogicFunctionExceptionCode.LOGIC_FUNCTION_COMPILATION_FAILED:
         throw new UserInputError(error);

--- a/packages/twenty-server/src/engine/metadata-modules/route-trigger/route-trigger.controller.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/route-trigger/route-trigger.controller.ts
@@ -2,6 +2,7 @@ import {
   Controller,
   Delete,
   Get,
+  Logger,
   Patch,
   Post,
   Put,
@@ -22,10 +23,16 @@ import { RouteTriggerService } from 'src/engine/core-modules/logic-function/logi
 @UseGuards(PublicEndpointGuard, NoPermissionGuard)
 @UseFilters(RouteTriggerRestApiExceptionFilter)
 export class RouteTriggerController {
+  private readonly logger = new Logger(RouteTriggerController.name);
+
   constructor(private readonly routeTriggerService: RouteTriggerService) {}
 
   @Get('*path')
   async get(@Req() request: Request) {
+    this.logger.log(
+      `Incoming GET ${request.path} from ${request.get('host')}`,
+    );
+
     return await this.routeTriggerService.handle({
       request,
       httpMethod: HTTPMethod.GET,
@@ -34,6 +41,10 @@ export class RouteTriggerController {
 
   @Post('*path')
   async post(@Req() request: Request) {
+    this.logger.log(
+      `Incoming POST ${request.path} from ${request.get('host')}`,
+    );
+
     return await this.routeTriggerService.handle({
       request,
       httpMethod: HTTPMethod.POST,
@@ -42,6 +53,10 @@ export class RouteTriggerController {
 
   @Put('*path')
   async put(@Req() request: Request) {
+    this.logger.log(
+      `Incoming PUT ${request.path} from ${request.get('host')}`,
+    );
+
     return await this.routeTriggerService.handle({
       request,
       httpMethod: HTTPMethod.PUT,
@@ -50,6 +65,10 @@ export class RouteTriggerController {
 
   @Patch('*path')
   async patch(@Req() request: Request) {
+    this.logger.log(
+      `Incoming PATCH ${request.path} from ${request.get('host')}`,
+    );
+
     return await this.routeTriggerService.handle({
       request,
       httpMethod: HTTPMethod.PATCH,
@@ -58,6 +77,10 @@ export class RouteTriggerController {
 
   @Delete('*path')
   async delete(@Req() request: Request) {
+    this.logger.log(
+      `Incoming DELETE ${request.path} from ${request.get('host')}`,
+    );
+
     return await this.routeTriggerService.handle({
       request,
       httpMethod: HTTPMethod.DELETE,

--- a/packages/twenty-server/src/engine/metadata-modules/route-trigger/route-trigger.controller.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/route-trigger/route-trigger.controller.ts
@@ -2,7 +2,6 @@ import {
   Controller,
   Delete,
   Get,
-  Logger,
   Patch,
   Post,
   Put,
@@ -23,16 +22,10 @@ import { RouteTriggerService } from 'src/engine/core-modules/logic-function/logi
 @UseGuards(PublicEndpointGuard, NoPermissionGuard)
 @UseFilters(RouteTriggerRestApiExceptionFilter)
 export class RouteTriggerController {
-  private readonly logger = new Logger(RouteTriggerController.name);
-
   constructor(private readonly routeTriggerService: RouteTriggerService) {}
 
   @Get('*path')
   async get(@Req() request: Request) {
-    this.logger.log(
-      `Incoming GET ${request.path} from ${request.get('host')}`,
-    );
-
     return await this.routeTriggerService.handle({
       request,
       httpMethod: HTTPMethod.GET,
@@ -41,10 +34,6 @@ export class RouteTriggerController {
 
   @Post('*path')
   async post(@Req() request: Request) {
-    this.logger.log(
-      `Incoming POST ${request.path} from ${request.get('host')}`,
-    );
-
     return await this.routeTriggerService.handle({
       request,
       httpMethod: HTTPMethod.POST,
@@ -53,10 +42,6 @@ export class RouteTriggerController {
 
   @Put('*path')
   async put(@Req() request: Request) {
-    this.logger.log(
-      `Incoming PUT ${request.path} from ${request.get('host')}`,
-    );
-
     return await this.routeTriggerService.handle({
       request,
       httpMethod: HTTPMethod.PUT,
@@ -65,10 +50,6 @@ export class RouteTriggerController {
 
   @Patch('*path')
   async patch(@Req() request: Request) {
-    this.logger.log(
-      `Incoming PATCH ${request.path} from ${request.get('host')}`,
-    );
-
     return await this.routeTriggerService.handle({
       request,
       httpMethod: HTTPMethod.PATCH,
@@ -77,10 +58,6 @@ export class RouteTriggerController {
 
   @Delete('*path')
   async delete(@Req() request: Request) {
-    this.logger.log(
-      `Incoming DELETE ${request.path} from ${request.get('host')}`,
-    );
-
     return await this.routeTriggerService.handle({
       request,
       httpMethod: HTTPMethod.DELETE,


### PR DESCRIPTION
## Summary

Route-triggered logic functions were returning empty 500 responses with zero server-side logging when the Lambda build chain failed. This PR makes those failures observable and returns meaningful HTTP responses to API clients.

- **Observability** — Log errors (with stack traces) at each layer of the execution chain: `LambdaDriver` (deps-layer fetch, SDK-layer fetch, invocation), `LogicFunctionExecutorService`, and `RouteTriggerService`.
- **Typed exceptions** — Replace raw `throw error` sites with `LogicFunctionException` carrying an appropriate code and `userFriendlyMessage` (new codes: `LOGIC_FUNCTION_EXECUTION_FAILED`, `LOGIC_FUNCTION_LAYER_BUILD_FAILED`).
- **Correct HTTP semantics** — `RouteTriggerService` maps inner exception codes to the right `RouteTriggerExceptionCode` so `LOGIC_FUNCTION_NOT_FOUND` returns 404 and `RATE_LIMIT_EXCEEDED` returns 429 (new code + filter case) instead of a generic 500.
- **User-facing messages** — Forward the inner `CustomException.userFriendlyMessage` when wrapping into `RouteTriggerException`, without leaking raw internal error text into the public exception message.
- **Infra** — Bump Lambda ephemeral storage from 2048 to 4096 MB to prevent `ENOSPC` errors during yarn install layer builds (root cause of the original silent failures).
