### PR TITLE
Invert pinned and dots icon buttons in command menu items edit mode

### DIFF
--- a/packages/twenty-front/src/modules/command-menu-item/edit/components/SidePanelCommandMenuItemEditPage.tsx
+++ b/packages/twenty-front/src/modules/command-menu-item/edit/components/SidePanelCommandMenuItemEditPage.tsx
@@ -273,16 +273,16 @@ export const SidePanelCommandMenuItemEditPage = () => {
                           isIconDisplayedOnHoverOnly={false}
                           iconButtons={[
                             {
+                              Icon: IconDotsVertical,
+                              Wrapper: makeOptionsDropdownWrapper(item),
+                              onClick: () => {},
+                            },
+                            {
                               Icon: IconPinnedOff,
                               onClick: (event) => {
                                 event.stopPropagation();
                                 handleTogglePin(item.id, true);
                               },
-                            },
-                            {
-                              Icon: IconDotsVertical,
-                              Wrapper: makeOptionsDropdownWrapper(item),
-                              onClick: () => {},
                             },
                           ]}
                         />


### PR DESCRIPTION
## Before
<img width="804" height="158" alt="CleanShot 2026-04-15 at 14 22 22@2x" src="https://github.com/user-attachments/assets/65c4d4f1-6f17-47e2-b964-f3b7132d2f18" />

## After
<img width="804" height="168" alt="CleanShot 2026-04-15 at 14 21 38@2x" src="https://github.com/user-attachments/assets/2f1d4fff-5f07-4df0-833e-129ad85391a9" />
