### PR TITLE
Fix standalone page migration failing on navigationMenuItem enum type change

### DIFF
--- a/packages/twenty-server/src/database/commands/upgrade-version-command/1-23/1-23-instance-command-fast-1775752781995-add-standalone-page.ts
+++ b/packages/twenty-server/src/database/commands/upgrade-version-command/1-23/1-23-instance-command-fast-1775752781995-add-standalone-page.ts
@@ -37,7 +37,13 @@ export class AddStandalonePageFastInstanceCommand
       "CREATE TYPE \"core\".\"navigationMenuItem_type_enum\" AS ENUM('VIEW', 'FOLDER', 'LINK', 'OBJECT', 'RECORD', 'PAGE_LAYOUT')",
     );
     await queryRunner.query(
+      'ALTER TABLE "core"."navigationMenuItem" ALTER COLUMN "type" DROP DEFAULT',
+    );
+    await queryRunner.query(
       'ALTER TABLE "core"."navigationMenuItem" ALTER COLUMN "type" TYPE "core"."navigationMenuItem_type_enum" USING "type"::"text"::"core"."navigationMenuItem_type_enum"',
+    );
+    await queryRunner.query(
+      'ALTER TABLE "core"."navigationMenuItem" ALTER COLUMN "type" SET DEFAULT \'VIEW\'',
     );
     await queryRunner.query(
       'DROP TYPE "core"."navigationMenuItem_type_enum_old"',
@@ -70,7 +76,13 @@ export class AddStandalonePageFastInstanceCommand
       "CREATE TYPE \"core\".\"navigationMenuItem_type_enum_old\" AS ENUM('FOLDER', 'LINK', 'OBJECT', 'RECORD', 'VIEW')",
     );
     await queryRunner.query(
+      'ALTER TABLE "core"."navigationMenuItem" ALTER COLUMN "type" DROP DEFAULT',
+    );
+    await queryRunner.query(
       'ALTER TABLE "core"."navigationMenuItem" ALTER COLUMN "type" TYPE "core"."navigationMenuItem_type_enum_old" USING "type"::"text"::"core"."navigationMenuItem_type_enum_old"',
+    );
+    await queryRunner.query(
+      'ALTER TABLE "core"."navigationMenuItem" ALTER COLUMN "type" SET DEFAULT \'VIEW\'',
     );
     await queryRunner.query('DROP TYPE "core"."navigationMenuItem_type_enum"');
     await queryRunner.query(

--- a/packages/twenty-server/src/database/commands/upgrade-version-command/1-23/1-23-instance-command-fast-1775752781995-add-standalone-page.ts
+++ b/packages/twenty-server/src/database/commands/upgrade-version-command/1-23/1-23-instance-command-fast-1775752781995-add-standalone-page.ts
@@ -43,9 +43,6 @@ export class AddStandalonePageFastInstanceCommand
       'ALTER TABLE "core"."navigationMenuItem" ALTER COLUMN "type" TYPE "core"."navigationMenuItem_type_enum" USING "type"::"text"::"core"."navigationMenuItem_type_enum"',
     );
     await queryRunner.query(
-      'ALTER TABLE "core"."navigationMenuItem" ALTER COLUMN "type" SET DEFAULT \'VIEW\'',
-    );
-    await queryRunner.query(
       'DROP TYPE "core"."navigationMenuItem_type_enum_old"',
     );
     await queryRunner.query(


### PR DESCRIPTION
## Summary
- The `AddStandalonePageFastInstanceCommand` migration was failing with: `default for column "type" cannot be cast automatically to type core."navigationMenuItem_type_enum"`
- The migration was missing `DROP DEFAULT` / `SET DEFAULT` around the `ALTER COLUMN TYPE` for `navigationMenuItem.type`. PostgreSQL cannot automatically cast the existing default (`'VIEW'::old_enum`) to the new enum type.
- The same 3-step pattern (DROP DEFAULT → ALTER TYPE → SET DEFAULT) was already correctly applied for `pageLayout.type` in the same migration — this fix brings `navigationMenuItem.type` in line.

