### PR TITLE
Add isUnique update in query + invalidate cache on rollback

### DIFF
--- a/packages/twenty-front/src/modules/object-metadata/hooks/useUpdateOneFieldMetadataItem.ts
+++ b/packages/twenty-front/src/modules/object-metadata/hooks/useUpdateOneFieldMetadataItem.ts
@@ -43,10 +43,12 @@ export const useUpdateOneFieldMetadataItem = () => {
       | 'description'
       | 'icon'
       | 'isActive'
+      | 'isUnique'
       | 'label'
       | 'name'
       | 'defaultValue'
       | 'options'
+      | 'settings'
       | 'isLabelSyncedWithName'
     >;
   }): Promise<

--- a/packages/twenty-server/src/engine/workspace-manager/workspace-migration/workspace-migration-runner/services/workspace-migration-runner.service.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/workspace-migration/workspace-migration-runner/services/workspace-migration-runner.service.ts
@@ -288,6 +288,18 @@ export class WorkspaceMigrationRunnerService {
         );
       }
 
+      try {
+        await this.invalidateCache({
+          allFlatEntityMapsKeys,
+          workspaceId,
+        });
+      } catch (cacheError) {
+        this.logger.error(
+          `Cache invalidation failed after rollback: ${cacheError}`,
+          'Runner',
+        );
+      }
+
       if (error instanceof WorkspaceMigrationRunnerException) {
         throw error;
       }


### PR DESCRIPTION
Fix isUnique not sent in field update mutation: Added isUnique and settings to the Pick type in useUpdateOneFieldMetadataItem, which previously silently dropped these properties from the GraphQL payload.

Invalidate cache on failed migration rollback: Added invalidateCache() call in the migration runner's catch block so that a failed migration (e.g., unique index creation failing due to duplicate data) regenerates the Redis hash, preventing stale metadata from persisting in frontend localStorage indefinitely. Was 