### PR TITLE
fix compute folders to update util

### DIFF
--- a/packages/twenty-server/src/modules/messaging/message-folder-manager/services/sync-message-folders.service.spec.ts
+++ b/packages/twenty-server/src/modules/messaging/message-folder-manager/services/sync-message-folders.service.spec.ts
@@ -370,6 +370,7 @@ describe('SyncMessageFoldersService', () => {
           id: 'folder-1',
           externalId: 'inbox-ext',
           name: 'INBOX',
+          isSynced: true,
           isSentFolder: false,
           parentFolderId: null,
         });
@@ -377,6 +378,7 @@ describe('SyncMessageFoldersService', () => {
           createMockDiscoveredFolder({
             externalId: 'inbox-ext',
             name: 'INBOX',
+            isSynced: true,
             isSentFolder: false,
             parentFolderId: null,
           }),
@@ -474,6 +476,7 @@ describe('SyncMessageFoldersService', () => {
           createMockDiscoveredFolder({
             externalId: 'unchanged-ext',
             name: 'Unchanged',
+            isSynced: true,
           }),
           createMockDiscoveredFolder({
             externalId: 'new-ext',
@@ -534,6 +537,7 @@ describe('SyncMessageFoldersService', () => {
           createMockDiscoveredFolder({
             externalId: 'inbox-ext',
             name: 'INBOX',
+            isSynced: true,
           }),
         ];
         const messageChannel = createMockMessageChannel({

--- a/packages/twenty-server/src/modules/messaging/message-folder-manager/utils/__tests__/compute-folders-to-update.util.spec.ts
+++ b/packages/twenty-server/src/modules/messaging/message-folder-manager/utils/__tests__/compute-folders-to-update.util.spec.ts
@@ -93,6 +93,72 @@ describe('computeFoldersToUpdate', () => {
     expect(result.size).toBe(0);
   });
 
+  it('should detect isSynced change from false to true', () => {
+    const discoveredFolders = [
+      {
+        name: 'Inbox',
+        externalId: 'INBOX',
+        isSynced: true,
+        isSentFolder: false,
+        parentFolderId: null,
+      },
+    ];
+
+    const existingFolders = [
+      {
+        id: 'folder-id',
+        name: 'Inbox',
+        externalId: 'INBOX',
+        isSynced: false,
+        isSentFolder: false,
+        parentFolderId: null,
+        syncCursor: 'cursor',
+        pendingSyncAction: MessageFolderPendingSyncAction.NONE,
+      },
+    ];
+
+    const result = computeFoldersToUpdate({
+      discoveredFolders,
+      existingFolders,
+    });
+
+    expect(result.size).toBe(1);
+    expect(result.get('folder-id')?.isSynced).toBe(true);
+  });
+
+  it('should detect isSynced change from true to false', () => {
+    const discoveredFolders = [
+      {
+        name: 'Promotions',
+        externalId: 'promo-1',
+        isSynced: false,
+        isSentFolder: false,
+        parentFolderId: null,
+      },
+    ];
+
+    const existingFolders = [
+      {
+        id: 'folder-id',
+        name: 'Promotions',
+        externalId: 'promo-1',
+        isSynced: true,
+        isSentFolder: false,
+        parentFolderId: null,
+        syncCursor: 'cursor',
+        pendingSyncAction: MessageFolderPendingSyncAction.NONE,
+      },
+    ];
+
+    const result = computeFoldersToUpdate({
+      discoveredFolders,
+      existingFolders,
+    });
+
+    expect(result.size).toBe(1);
+    expect(result.get('folder-id')?.isSynced).toBe(false);
+  });
+
   it('should treat empty string parentFolderId same as null', () => {
     const discoveredFolders = [
       {

--- a/packages/twenty-server/src/modules/messaging/message-folder-manager/utils/compute-folders-to-update.util.ts
+++ b/packages/twenty-server/src/modules/messaging/message-folder-manager/utils/compute-folders-to-update.util.ts
@@ -14,12 +14,18 @@ export const computeFoldersToUpdate = ({
 }: {
   discoveredFolders: DiscoveredMessageFolder[];
   existingFolders: MessageFolder[];
-}): Map<string, Partial<MessageFolderEntity>> => {
+}): Map<
+  string,
+  Pick<MessageFolderEntity, 'name' | 'isSynced' | 'isSentFolder' | 'parentFolderId'>
+> => {
   const existingFoldersByExternalId = new Map(
     existingFolders.map((folder) => [folder.externalId, folder]),
   );
 
-  const foldersToUpdate = new Map<string, Partial<MessageFolderEntity>>();
+  const foldersToUpdate = new Map<
+    string,
+    Pick<MessageFolderEntity, 'name' | 'isSynced' | 'isSentFolder' | 'parentFolderId'>
+  >();
 
   for (const discoveredFolder of discoveredFolders) {
     const existingFolder = existingFoldersByExternalId.get(
@@ -36,12 +42,14 @@ export const computeFoldersToUpdate = ({
 
     const discoveredFolderData = {
       name: discoveredFolder.name,
+      isSynced: discoveredFolder.isSynced,
       isSentFolder: discoveredFolder.isSentFolder,
       parentFolderId,
     };
 
     const existingFolderData = {
       name: existingFolder.name,
+      isSynced: existingFolder.isSynced,
       isSentFolder: existingFolder.isSentFolder,
       parentFolderId: isNonEmptyString(existingFolder.parentFolderId)
         ? existingFolder.parentFolderId

--- a/packages/twenty-server/src/modules/messaging/message-folder-manager/utils/compute-folders-to-update.util.ts
+++ b/packages/twenty-server/src/modules/messaging/message-folder-manager/utils/compute-folders-to-update.util.ts
@@ -16,7 +16,10 @@ export const computeFoldersToUpdate = ({
   existingFolders: MessageFolder[];
 }): Map<
   string,
-  Pick<MessageFolderEntity, 'name' | 'isSynced' | 'isSentFolder' | 'parentFolderId'>
+  Pick<
+    MessageFolderEntity,
+    'name' | 'isSynced' | 'isSentFolder' | 'parentFolderId'
+  >
 > => {
   const existingFoldersByExternalId = new Map(
     existingFolders.map((folder) => [folder.externalId, folder]),
@@ -24,7 +27,10 @@ export const computeFoldersToUpdate = ({
 
   const foldersToUpdate = new Map<
     string,
-    Pick<MessageFolderEntity, 'name' | 'isSynced' | 'isSentFolder' | 'parentFolderId'>
+    Pick<
+      MessageFolderEntity,
+      'name' | 'isSynced' | 'isSentFolder' | 'parentFolderId'
+    >
   >();
 
   for (const discoveredFolder of discoveredFolders) {


### PR DESCRIPTION
This regressed with the migration work

Type checker should've caught it, but didn't because of `Partial` changed it to `Pick` instead to avoid future cases

/closes https://github.com/twentyhq/twenty/issues/19745
