### PR TITLE
Add logs before and after instance slow data migration

### DIFF
--- a/packages/twenty-server/src/engine/core-modules/upgrade/services/instance-command-runner.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/upgrade/services/instance-command-runner.service.ts
@@ -129,7 +129,9 @@ export class InstanceCommandRunnerService {
         this.twentyConfigService.get('APP_VERSION') ?? 'unknown';
 
       try {
+        this.logger.log(`${name} starting data migration...`);
         await command.runDataMigration(this.dataSource);
+        this.logger.log(`${name} data migration completed`);
       } catch (error) {
         const workspaceIds =
           await this.workspaceVersionService.getActiveOrSuspendedWorkspaceIds();


### PR DESCRIPTION
As it can take sometime, would result in not seeing any logs until