### PR TITLE
`[run-instance-commands]` Preserve `fast` `slow` sequentiality

### DIFF
--- a/packages/twenty-server/src/database/commands/run-instance-commands.command.ts
+++ b/packages/twenty-server/src/database/commands/run-instance-commands.command.ts
@@ -68,12 +68,8 @@ export class RunInstanceCommandsCommand extends CommandRunner {
         await this.workspaceVersionService.getActiveOrSuspendedWorkspaceIds();
 
       const sequence = this.upgradeSequenceReaderService.getUpgradeSequence();
-      const startIndex =
-        await this.findInstanceCommandIndexToStartFrom(sequence);
 
-      for (let index = startIndex; index < sequence.length; index++) {
-        const step = sequence[index];
-
+      for (const step of sequence) {
         if (step.kind === 'fast-instance') {
           const result =
             await this.instanceUpgradeService.runFastInstanceCommand({
@@ -153,33 +149,6 @@ export class RunInstanceCommandsCommand extends CommandRunner {
           'Use --force to bypass this check (not recommended).',
       );
     }
-  }
-
-  private async findInstanceCommandIndexToStartFrom(
-    sequence: ReturnType<UpgradeSequenceReaderService['getUpgradeSequence']>,
-  ): Promise<number> {
-    const lastAttempted =
-      await this.upgradeMigrationService.getLastAttemptedInstanceCommand();
-
-    if (!lastAttempted) {
-      return 0;
-    }
-
-    const cursorIndex = sequence.findIndex(
-      (step) => step.name === lastAttempted.name,
-    );
-
-    if (cursorIndex === -1) {
-      throw new Error(
-        `Last attempted instance command "${lastAttempted.name}" not found in upgrade sequence`,
-      );
-    }
-
-    if (lastAttempted.status === 'failed') {
-      return cursorIndex;
-    }
-
-    return cursorIndex + 1;
   }
 
   private async runLegacyPendingTypeOrmMigrations(): Promise<void> {

--- a/packages/twenty-server/src/database/commands/run-instance-commands.command.ts
+++ b/packages/twenty-server/src/database/commands/run-instance-commands.command.ts
@@ -9,6 +9,7 @@ import { TWENTY_PREVIOUS_VERSIONS } from 'src/engine/core-modules/upgrade/consta
 import { InstanceCommandRunnerService } from 'src/engine/core-modules/upgrade/services/instance-command-runner.service';
 import { UpgradeCommandRegistryService } from 'src/engine/core-modules/upgrade/services/upgrade-command-registry.service';
 import { UpgradeMigrationService } from 'src/engine/core-modules/upgrade/services/upgrade-migration.service';
+import { UpgradeSequenceReaderService } from 'src/engine/core-modules/upgrade/services/upgrade-sequence-reader.service';
 import { WorkspaceVersionService } from 'src/engine/workspace-manager/workspace-version/services/workspace-version.service';
 
 type RunInstanceCommandsOptions = {
@@ -30,6 +31,7 @@ export class RunInstanceCommandsCommand extends CommandRunner {
     private readonly dataSource: DataSource,
     private readonly workspaceVersionService: WorkspaceVersionService,
     private readonly upgradeCommandRegistryService: UpgradeCommandRegistryService,
+    private readonly upgradeSequenceReaderService: UpgradeSequenceReaderService,
     private readonly instanceUpgradeService: InstanceCommandRunnerService,
     private readonly upgradeMigrationService: UpgradeMigrationService,
   ) {
@@ -65,31 +67,30 @@ export class RunInstanceCommandsCommand extends CommandRunner {
       const activeOrSuspendedWorkspaceIds =
         await this.workspaceVersionService.getActiveOrSuspendedWorkspaceIds();
 
-      for (const {
-        command,
-        name,
-      } of this.upgradeCommandRegistryService.getCrossUpgradeSupportedFastInstanceCommands()) {
-        const result = await this.instanceUpgradeService.runFastInstanceCommand(
-          {
-            command,
-            name,
-          },
-        );
+      const sequence = this.upgradeSequenceReaderService.getUpgradeSequence();
+      const startIndex =
+        await this.findInstanceCommandIndexToStartFrom(sequence);
 
-        if (result.status === 'failed') {
-          throw result.error;
+      for (let index = startIndex; index < sequence.length; index++) {
+        const step = sequence[index];
+
+        if (step.kind === 'fast-instance') {
+          const result =
+            await this.instanceUpgradeService.runFastInstanceCommand({
+              command: step.command,
+              name: step.name,
+            });
+
+          if (result.status === 'failed') {
+            throw result.error;
+          }
         }
-      }
 
-      if (options.includeSlow) {
-        for (const {
-          command,
-          name,
-        } of this.upgradeCommandRegistryService.getCrossUpgradeSupportedSlowInstanceCommands()) {
+        if (step.kind === 'slow-instance' && options.includeSlow) {
           const result =
             await this.instanceUpgradeService.runSlowInstanceCommand({
-              command,
-              name,
+              command: step.command,
+              name: step.name,
               skipDataMigration: activeOrSuspendedWorkspaceIds.length === 0,
             });
 
@@ -152,6 +153,33 @@ export class RunInstanceCommandsCommand extends CommandRunner {
           'Use --force to bypass this check (not recommended).',
       );
     }
+  }
+
+  private async findInstanceCommandIndexToStartFrom(
+    sequence: ReturnType<UpgradeSequenceReaderService['getUpgradeSequence']>,
+  ): Promise<number> {
+    const lastAttempted =
+      await this.upgradeMigrationService.getLastAttemptedInstanceCommand();
+
+    if (!lastAttempted) {
+      return 0;
+    }
+
+    const cursorIndex = sequence.findIndex(
+      (step) => step.name === lastAttempted.name,
+    );
+
+    if (cursorIndex === -1) {
+      throw new Error(
+        `Last attempted instance command "${lastAttempted.name}" not found in upgrade sequence`,
+      );
+    }
+
+    if (lastAttempted.status === 'failed') {
+      return cursorIndex;
+    }
+
+    return cursorIndex + 1;
   }
 
   private async runLegacyPendingTypeOrmMigrations(): Promise<void> {

--- a/packages/twenty-server/src/engine/core-modules/upgrade/services/upgrade-migration.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/upgrade/services/upgrade-migration.service.ts
@@ -283,10 +283,10 @@ export class UpgradeMigrationService {
     return completedCount === workspaceIds.length;
   }
 
-  async getLastAttemptedInstanceCommandOrThrow(): Promise<{
+  async getLastAttemptedInstanceCommand(): Promise<{
     name: string;
     status: UpgradeMigrationStatus;
-  }> {
+  } | null> {
     const migration = await this.upgradeMigrationRepository
       .createQueryBuilder('migration')
       .select(['migration.name', 'migration.status'])
@@ -304,11 +304,24 @@ export class UpgradeMigrationService {
       .getOne();
 
     if (!migration) {
+      return null;
+    }
+
+    return { name: migration.name, status: migration.status };
+  }
+
+  async getLastAttemptedInstanceCommandOrThrow(): Promise<{
+    name: string;
+    status: UpgradeMigrationStatus;
+  }> {
+    const result = await this.getLastAttemptedInstanceCommand();
+
+    if (!result) {
       throw new Error(
         'No instance command found — the database may not have been initialized',
       );
     }
 
-    return { name: migration.name, status: migration.status };
+    return result;
   }
 }


### PR DESCRIPTION
# Introduction
The command was wrongly running all fast and then all slow ignoring instance commands segment
Leading to 
```ts
1.23.0_AddGlobalObjectContextToCommandMenuItemAvailabilityTypeFastInstanceCommand_1776090711153 executed successfully
[Nest] 32679  - 04/16/2026, 1:21:07 PM     LOG [InstanceCommandRunnerService] 1.23.0_DropWorkspaceVersionColumnFastInstanceCommand_1785000000000 executed successfully
[Nest] 32679  - 04/16/2026, 1:21:07 PM     LOG [InstanceCommandRunnerService] 1.22.0_BackfillWorkspaceIdOnIndirectEntitiesSlowInstanceCommand_1775758621018 executed successfully
[Nest] 32679  - 04/16/2026, 1:21:07 PM     LOG [RunInstanceCommandsCommand] Instance commands completed
```

No prod/self host impact as 1.23 hasn't been released yet