### PR TITLE
shouldIncludeRecordPageLayouts deprecation

### DIFF
--- a/packages/twenty-e2e-testing/tests/create-record.spec.ts
+++ b/packages/twenty-e2e-testing/tests/create-record.spec.ts
@@ -64,7 +64,7 @@ test('Create and update record', async ({ page }) => {
     await lastNameInput.press('Enter');
 
     // Focus on recordFieldList
-    const recordFieldList = page.getByTestId('person-widget-fields');
+    const recordFieldList = page.getByTestId('record-fields-widget');
     await expect(recordFieldList).toBeVisible();
     await recordFieldList.getByText('Emails').first().click();
 

--- a/packages/twenty-front/src/modules/page-layout/widgets/components/WidgetCardShell.tsx
+++ b/packages/twenty-front/src/modules/page-layout/widgets/components/WidgetCardShell.tsx
@@ -67,6 +67,9 @@ export const WidgetCardShell = ({
 }: WidgetCardShellProps) => {
   const { theme } = useContext(ThemeContext);
 
+  const dataTestId =
+    widget.type === WidgetType.FIELDS ? 'record-fields-widget' : widget.id;
+
   return (
     <WidgetComponentInstanceContext.Provider value={{ instanceId: widget.id }}>
       <WidgetCard
@@ -81,7 +84,7 @@ export const WidgetCardShell = ({
         onMouseEnter={onMouseEnter}
         onMouseLeave={onMouseLeave}
         data-widget-id={widget.id}
-        data-testid={widget.id}
+        data-testid={dataTestId}
         className="widget"
       >
         {showHeader && (

--- a/packages/twenty-server/src/database/commands/upgrade-version-command/1-21/1-21-workspace-command-1775500001000-add-compose-email-command-menu-item.command.ts
+++ b/packages/twenty-server/src/database/commands/upgrade-version-command/1-21/1-21-workspace-command-1775500001000-add-compose-email-command-menu-item.command.ts
@@ -65,7 +65,6 @@ export class AddComposeEmailCommandMenuItemCommand extends ActiveOrSuspendedWork
 
     const { allFlatEntityMaps: standardAllFlatEntityMaps } =
       computeTwentyStandardApplicationAllFlatEntityMaps({
-        shouldIncludeRecordPageLayouts: true,
         now: new Date().toISOString(),
         workspaceId,
         twentyStandardApplicationId: twentyStandardFlatApplication.id,

--- a/packages/twenty-server/src/database/commands/upgrade-version-command/1-21/1-21-workspace-command-1775500006000-deduplicate-engine-commands.command.ts
+++ b/packages/twenty-server/src/database/commands/upgrade-version-command/1-21/1-21-workspace-command-1775500006000-deduplicate-engine-commands.command.ts
@@ -76,7 +76,6 @@ export class DeduplicateEngineCommandsCommand extends ActiveOrSuspendedWorkspace
 
     const { allFlatEntityMaps: standardAllFlatEntityMaps } =
       computeTwentyStandardApplicationAllFlatEntityMaps({
-        shouldIncludeRecordPageLayouts: true,
         now: new Date().toISOString(),
         workspaceId,
         twentyStandardApplicationId: twentyStandardFlatApplication.id,

--- a/packages/twenty-server/src/database/commands/upgrade-version-command/1-21/1-21-workspace-command-1775500007000-fix-select-all-command-menu-items.command.ts
+++ b/packages/twenty-server/src/database/commands/upgrade-version-command/1-21/1-21-workspace-command-1775500007000-fix-select-all-command-menu-items.command.ts
@@ -55,7 +55,6 @@ export class FixSelectAllCommandMenuItemsCommand extends ActiveOrSuspendedWorksp
 
     const { allFlatEntityMaps: standardAllFlatEntityMaps } =
       computeTwentyStandardApplicationAllFlatEntityMaps({
-        shouldIncludeRecordPageLayouts: true,
         now: new Date().toISOString(),
         workspaceId,
         twentyStandardApplicationId: twentyStandardFlatApplication.id,

--- a/packages/twenty-server/src/database/commands/upgrade-version-command/1-22/1-22-workspace-command-1775500016000-add-send-email-record-selection-command-menu-items.command.ts
+++ b/packages/twenty-server/src/database/commands/upgrade-version-command/1-22/1-22-workspace-command-1775500016000-add-send-email-record-selection-command-menu-items.command.ts
@@ -73,7 +73,6 @@ export class AddSendEmailRecordSelectionCommandMenuItemsCommand extends ActiveOr
 
     const { allFlatEntityMaps: standardAllFlatEntityMaps } =
       computeTwentyStandardApplicationAllFlatEntityMaps({
-        shouldIncludeRecordPageLayouts: true,
         now: new Date().toISOString(),
         workspaceId,
         twentyStandardApplicationId: twentyStandardFlatApplication.id,

--- a/packages/twenty-server/src/database/commands/upgrade-version-command/1-22/1-22-workspace-command-1780000002000-backfill-standard-skills.command.ts
+++ b/packages/twenty-server/src/database/commands/upgrade-version-command/1-22/1-22-workspace-command-1780000002000-backfill-standard-skills.command.ts
@@ -48,7 +48,6 @@ export class BackfillStandardSkillsCommand extends ActiveOrSuspendedWorkspaceCom
 
     const { allFlatEntityMaps: standardAllFlatEntityMaps } =
       computeTwentyStandardApplicationAllFlatEntityMaps({
-        shouldIncludeRecordPageLayouts: true,
         now: new Date().toISOString(),
         workspaceId,
         twentyStandardApplicationId: twentyStandardFlatApplication.id,

--- a/packages/twenty-server/src/database/commands/upgrade-version-command/1-22/1-22-workspace-command-1780000003000-fix-merge-command-select-all.command.ts
+++ b/packages/twenty-server/src/database/commands/upgrade-version-command/1-22/1-22-workspace-command-1780000003000-fix-merge-command-select-all.command.ts
@@ -53,7 +53,6 @@ export class FixMergeCommandSelectAllCommand extends ActiveOrSuspendedWorkspaceC
 
     const { allFlatEntityMaps: standardAllFlatEntityMaps } =
       computeTwentyStandardApplicationAllFlatEntityMaps({
-        shouldIncludeRecordPageLayouts: true,
         now: new Date().toISOString(),
         workspaceId,
         twentyStandardApplicationId: twentyStandardFlatApplication.id,

--- a/packages/twenty-server/src/database/commands/upgrade-version-command/1-23/1-23-workspace-command-1780000001500-backfill-record-page-layouts.command.ts
+++ b/packages/twenty-server/src/database/commands/upgrade-version-command/1-23/1-23-workspace-command-1780000001500-backfill-record-page-layouts.command.ts
@@ -240,7 +240,6 @@ export class BackfillRecordPageLayoutsCommand extends ActiveOrSuspendedWorkspace
   }): Promise<void> {
     const { allFlatEntityMaps: standardMaps } =
       computeTwentyStandardApplicationAllFlatEntityMaps({
-        shouldIncludeRecordPageLayouts: true,
         now: new Date().toISOString(),
         workspaceId,
         twentyStandardApplicationId: twentyStandardFlatApplication.id,

--- a/packages/twenty-server/src/database/commands/upgrade-version-command/1-23/1-23-workspace-command-1780000005000-update-global-object-context-command-menu-items.command.ts
+++ b/packages/twenty-server/src/database/commands/upgrade-version-command/1-23/1-23-workspace-command-1780000005000-update-global-object-context-command-menu-items.command.ts
@@ -58,7 +58,6 @@ export class UpdateGlobalObjectContextCommandMenuItemsCommand extends ActiveOrSu
 
     const { allFlatEntityMaps: standardAllFlatEntityMaps } =
       computeTwentyStandardApplicationAllFlatEntityMaps({
-        shouldIncludeRecordPageLayouts: true,
         now: new Date().toISOString(),
         workspaceId,
         twentyStandardApplicationId: twentyStandardFlatApplication.id,

--- a/packages/twenty-server/src/engine/core-modules/twenty-config/config-variables.ts
+++ b/packages/twenty-server/src/engine/core-modules/twenty-config/config-variables.ts
@@ -235,8 +235,7 @@ export class ConfigVariables {
    */
   @ConfigVariablesMetadata({
     group: ConfigVariablesGroup.ADVANCED_SETTINGS,
-    description:
-      'Deprecated - record page layouts are now always seeded (GA)',
+    description: 'Deprecated - record page layouts are now always seeded (GA)',
     type: ConfigVariableType.BOOLEAN,
   })
   @IsOptional()

--- a/packages/twenty-server/src/engine/core-modules/twenty-config/config-variables.ts
+++ b/packages/twenty-server/src/engine/core-modules/twenty-config/config-variables.ts
@@ -230,14 +230,17 @@ export class ConfigVariables {
   @ValidateIf((env) => env.AUTH_MICROSOFT_ENABLED)
   AUTH_MICROSOFT_APIS_CALLBACK_URL: string;
 
+  /**
+   * @deprecated Use is now GA - record page layouts are always seeded
+   */
   @ConfigVariablesMetadata({
     group: ConfigVariablesGroup.ADVANCED_SETTINGS,
     description:
-      'Enable or disable the seeding of standard record page layouts',
+      'Deprecated - record page layouts are now always seeded (GA)',
     type: ConfigVariableType.BOOLEAN,
   })
   @IsOptional()
-  SHOULD_SEED_STANDARD_RECORD_PAGE_LAYOUTS = false;
+  SHOULD_SEED_STANDARD_RECORD_PAGE_LAYOUTS = true;
 
   @ConfigVariablesMetadata({
     group: ConfigVariablesGroup.MICROSOFT_AUTH,

--- a/packages/twenty-server/src/engine/workspace-manager/twenty-standard-application/services/twenty-standard-application.service.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/twenty-standard-application/services/twenty-standard-application.service.ts
@@ -1,7 +1,6 @@
 import { Injectable } from '@nestjs/common';
 
 import { ApplicationService } from 'src/engine/core-modules/application/application.service';
-import { TwentyConfigService } from 'src/engine/core-modules/twenty-config/twenty-config.service';
 import { MetadataFlatEntity } from 'src/engine/metadata-modules/flat-entity/types/metadata-flat-entity.type';
 import { getMetadataFlatEntityMapsKey } from 'src/engine/metadata-modules/flat-entity/utils/get-metadata-flat-entity-maps-key.util';
 import { getSubFlatEntityMapsByApplicationIdsOrThrow } from 'src/engine/metadata-modules/flat-entity/utils/get-sub-flat-entity-maps-by-application-ids-or-throw.util';
@@ -18,7 +17,6 @@ import { FromToAllUniversalFlatEntityMaps } from 'src/engine/workspace-manager/w
 export class TwentyStandardApplicationService {
   constructor(
     private readonly applicationService: ApplicationService,
-    private readonly twentyConfigService: TwentyConfigService,
     private readonly workspaceMigrationValidateBuildAndRunService: WorkspaceMigrationValidateBuildAndRunService,
     private readonly workspaceCacheService: WorkspaceCacheService,
     private readonly globalWorkspaceOrmManager: GlobalWorkspaceOrmManager,
@@ -41,10 +39,6 @@ export class TwentyStandardApplicationService {
         'featureFlagsMap',
       ]);
 
-    const shouldIncludeRecordPageLayouts = this.twentyConfigService.get(
-      'SHOULD_SEED_STANDARD_RECORD_PAGE_LAYOUTS',
-    );
-
     const {
       allFlatEntityMaps: toTwentyStandardAllFlatEntityMaps,
       idByUniversalIdentifierByMetadataName,
@@ -52,7 +46,6 @@ export class TwentyStandardApplicationService {
       now: new Date().toISOString(),
       workspaceId,
       twentyStandardApplicationId: twentyStandardFlatApplication.id,
-      shouldIncludeRecordPageLayouts,
     });
 
     const fromToAllFlatEntityMaps: FromToAllUniversalFlatEntityMaps = {};

--- a/packages/twenty-server/src/engine/workspace-manager/twenty-standard-application/utils/page-layout-tab/build-standard-flat-page-layout-tab-metadata-maps.util.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/twenty-standard-application/utils/page-layout-tab/build-standard-flat-page-layout-tab-metadata-maps.util.ts
@@ -2,10 +2,7 @@ import { createEmptyFlatEntityMaps } from 'src/engine/metadata-modules/flat-enti
 import { type FlatEntityMaps } from 'src/engine/metadata-modules/flat-entity/types/flat-entity-maps.type';
 import { addFlatEntityToFlatEntityMapsOrThrow } from 'src/engine/metadata-modules/flat-entity/utils/add-flat-entity-to-flat-entity-maps-or-throw.util';
 import { type FlatPageLayoutTab } from 'src/engine/metadata-modules/flat-page-layout-tab/types/flat-page-layout-tab.type';
-import {
-  STANDARD_PAGE_LAYOUTS,
-  STANDARD_RECORD_PAGE_LAYOUTS,
-} from 'src/engine/workspace-manager/twenty-standard-application/constants/standard-page-layout.constant';
+import { STANDARD_PAGE_LAYOUTS } from 'src/engine/workspace-manager/twenty-standard-application/constants/standard-page-layout.constant';
 import { type StandardPageLayoutTabConfig } from 'src/engine/workspace-manager/twenty-standard-application/utils/page-layout-config/standard-page-layout-config.type';
 import {
   type CreateStandardPageLayoutTabArgs,
@@ -15,28 +12,17 @@ import {
 export type BuildStandardFlatPageLayoutTabMetadataMapsArgs = Omit<
   CreateStandardPageLayoutTabArgs,
   'context'
-> & {
-  shouldIncludeRecordPageLayouts?: boolean;
-};
+>;
 
 export const buildStandardFlatPageLayoutTabMetadataMaps = ({
   now,
   workspaceId,
   twentyStandardApplicationId,
   standardPageLayoutMetadataRelatedEntityIds,
-  shouldIncludeRecordPageLayouts,
 }: BuildStandardFlatPageLayoutTabMetadataMapsArgs): FlatEntityMaps<FlatPageLayoutTab> => {
   const allPageLayoutTabMetadatas: FlatPageLayoutTab[] = [];
-  const recordPageLayoutNames = Object.keys(STANDARD_RECORD_PAGE_LAYOUTS);
 
   for (const layoutName of Object.keys(STANDARD_PAGE_LAYOUTS)) {
-    if (
-      !shouldIncludeRecordPageLayouts &&
-      recordPageLayoutNames.includes(layoutName)
-    ) {
-      continue;
-    }
-
     const layout = STANDARD_PAGE_LAYOUTS[
       layoutName as keyof typeof STANDARD_PAGE_LAYOUTS
     ] as { tabs: Record<string, StandardPageLayoutTabConfig> };

--- a/packages/twenty-server/src/engine/workspace-manager/twenty-standard-application/utils/page-layout-widget/build-standard-flat-page-layout-widget-metadata-maps.util.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/twenty-standard-application/utils/page-layout-widget/build-standard-flat-page-layout-widget-metadata-maps.util.ts
@@ -23,9 +23,7 @@ import { findObjectNameByUniversalIdentifier } from 'src/engine/workspace-manage
 export type BuildStandardFlatPageLayoutWidgetMetadataMapsArgs = Omit<
   CreateStandardPageLayoutWidgetArgs,
   'context'
-> & {
-  shouldIncludeRecordPageLayouts?: boolean;
-};
+>;
 
 const RECORD_PAGE_LAYOUT_WIDGET_TYPES = [
   WidgetType.FIELDS,
@@ -336,9 +334,7 @@ export const buildStandardFlatPageLayoutWidgetMetadataMaps = (
 ): FlatEntityMaps<FlatPageLayoutWidget> => {
   const allWidgetMetadatas: FlatPageLayoutWidget[] = [
     ...computeMyFirstDashboardWidgets(args),
-    ...(args.shouldIncludeRecordPageLayouts
-      ? computeRecordPageWidgets(args)
-      : []),
+    ...computeRecordPageWidgets(args),
   ];
 
   let flatPageLayoutWidgetMaps = createEmptyFlatEntityMaps();

--- a/packages/twenty-server/src/engine/workspace-manager/twenty-standard-application/utils/page-layout/build-standard-flat-page-layout-metadata-maps.util.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/twenty-standard-application/utils/page-layout/build-standard-flat-page-layout-metadata-maps.util.ts
@@ -2,33 +2,20 @@ import { createEmptyFlatEntityMaps } from 'src/engine/metadata-modules/flat-enti
 import { type FlatEntityMaps } from 'src/engine/metadata-modules/flat-entity/types/flat-entity-maps.type';
 import { addFlatEntityToFlatEntityMapsOrThrow } from 'src/engine/metadata-modules/flat-entity/utils/add-flat-entity-to-flat-entity-maps-or-throw.util';
 import { type FlatPageLayout } from 'src/engine/metadata-modules/flat-page-layout/types/flat-page-layout.type';
-import { STANDARD_RECORD_PAGE_LAYOUTS } from 'src/engine/workspace-manager/twenty-standard-application/constants/standard-page-layout.constant';
 import { type CreateStandardPageLayoutArgs } from 'src/engine/workspace-manager/twenty-standard-application/utils/page-layout/create-standard-page-layout-flat-metadata.util';
 import { STANDARD_FLAT_PAGE_LAYOUT_BUILDERS_BY_LAYOUT_NAME } from 'src/engine/workspace-manager/twenty-standard-application/utils/page-layout/standard-flat-page-layout-builders.constant';
 
 export type BuildStandardFlatPageLayoutMetadataMapsArgs = Omit<
   CreateStandardPageLayoutArgs,
   'context'
-> & {
-  shouldIncludeRecordPageLayouts?: boolean;
-};
+>;
 
 export const buildStandardFlatPageLayoutMetadataMaps = (
   args: BuildStandardFlatPageLayoutMetadataMapsArgs,
 ): FlatEntityMaps<FlatPageLayout> => {
-  const recordPageLayoutNames = Object.keys(STANDARD_RECORD_PAGE_LAYOUTS);
-
-  const layoutEntries = Object.entries(
+  const allPageLayoutMetadatas: FlatPageLayout[] = Object.values(
     STANDARD_FLAT_PAGE_LAYOUT_BUILDERS_BY_LAYOUT_NAME,
-  ).filter(
-    ([layoutName]) =>
-      args.shouldIncludeRecordPageLayouts ||
-      !recordPageLayoutNames.includes(layoutName),
-  );
-
-  const allPageLayoutMetadatas: FlatPageLayout[] = layoutEntries.map(
-    ([, builder]) => builder(args),
-  );
+  ).map((builder) => builder(args));
 
   let flatPageLayoutMaps = createEmptyFlatEntityMaps();
 

--- a/packages/twenty-server/src/engine/workspace-manager/twenty-standard-application/utils/twenty-standard-application-all-flat-entity-maps.constant.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/twenty-standard-application/utils/twenty-standard-application-all-flat-entity-maps.constant.ts
@@ -28,14 +28,12 @@ export type ComputeTwentyStandardApplicationAllFlatEntityMapsArgs = {
   now: string;
   workspaceId: string;
   twentyStandardApplicationId: string;
-  shouldIncludeRecordPageLayouts?: boolean;
 };
 
 export const computeTwentyStandardApplicationAllFlatEntityMaps = ({
   now,
   workspaceId,
   twentyStandardApplicationId,
-  shouldIncludeRecordPageLayouts,
 }: ComputeTwentyStandardApplicationAllFlatEntityMapsArgs): {
   allFlatEntityMaps: TwentyStandardAllFlatEntityMaps;
   // TODO remove once all metadatas has fully been universal migrated
@@ -84,7 +82,6 @@ export const computeTwentyStandardApplicationAllFlatEntityMaps = ({
     standardObjectMetadataRelatedEntityIds,
     twentyStandardApplicationId,
     workspaceId,
-    shouldIncludeRecordPageLayouts,
   });
 
   const flatViewGroupMaps = buildStandardFlatViewGroupMetadataMaps({
@@ -108,7 +105,6 @@ export const computeTwentyStandardApplicationAllFlatEntityMaps = ({
     standardObjectMetadataRelatedEntityIds,
     twentyStandardApplicationId,
     workspaceId,
-    shouldIncludeRecordPageLayouts,
   });
 
   const flatViewFilterMaps = buildStandardFlatViewFilterMetadataMaps({
@@ -134,7 +130,6 @@ export const computeTwentyStandardApplicationAllFlatEntityMaps = ({
     standardObjectMetadataRelatedEntityIds,
     twentyStandardApplicationId,
     workspaceId,
-    shouldIncludeRecordPageLayouts,
   });
 
   const flatRoleMaps = buildStandardFlatRoleMetadataMaps({
@@ -172,7 +167,6 @@ export const computeTwentyStandardApplicationAllFlatEntityMaps = ({
     twentyStandardApplicationId,
     standardObjectMetadataRelatedEntityIds,
     standardPageLayoutMetadataRelatedEntityIds,
-    shouldIncludeRecordPageLayouts,
   });
 
   const flatPageLayoutTabMaps = buildStandardFlatPageLayoutTabMetadataMaps({
@@ -180,7 +174,6 @@ export const computeTwentyStandardApplicationAllFlatEntityMaps = ({
     workspaceId,
     twentyStandardApplicationId,
     standardPageLayoutMetadataRelatedEntityIds,
-    shouldIncludeRecordPageLayouts,
   });
 
   const flatPageLayoutWidgetMaps =
@@ -190,7 +183,6 @@ export const computeTwentyStandardApplicationAllFlatEntityMaps = ({
       twentyStandardApplicationId,
       standardObjectMetadataRelatedEntityIds,
       standardPageLayoutMetadataRelatedEntityIds,
-      shouldIncludeRecordPageLayouts,
     });
 
   const flatNavigationMenuItemMaps = buildStandardFlatNavigationMenuItemMaps({

--- a/packages/twenty-server/src/engine/workspace-manager/twenty-standard-application/utils/view-field-group/build-standard-flat-view-field-group-metadata-maps.util.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/twenty-standard-application/utils/view-field-group/build-standard-flat-view-field-group-metadata-maps.util.ts
@@ -58,18 +58,11 @@ const STANDARD_FLAT_VIEW_FIELD_GROUP_METADATA_BUILDERS_BY_OBJECT_NAME = {
 export type BuildStandardFlatViewFieldGroupMetadataMapsArgs = Omit<
   CreateStandardViewFieldGroupArgs,
   'context' | 'objectName'
-> & {
-  shouldIncludeRecordPageLayouts?: boolean;
-};
+>;
 
-export const buildStandardFlatViewFieldGroupMetadataMaps = ({
-  shouldIncludeRecordPageLayouts,
-  ...args
-}: BuildStandardFlatViewFieldGroupMetadataMapsArgs): FlatEntityMaps<FlatViewFieldGroup> => {
-  if (!shouldIncludeRecordPageLayouts) {
-    return createEmptyFlatEntityMaps();
-  }
-
+export const buildStandardFlatViewFieldGroupMetadataMaps = (
+  args: BuildStandardFlatViewFieldGroupMetadataMapsArgs,
+): FlatEntityMaps<FlatViewFieldGroup> => {
   const allViewFieldGroupMetadatas: FlatViewFieldGroup[] = (
     Object.keys(
       STANDARD_FLAT_VIEW_FIELD_GROUP_METADATA_BUILDERS_BY_OBJECT_NAME,

--- a/packages/twenty-server/src/engine/workspace-manager/twenty-standard-application/utils/view-field/build-standard-flat-view-field-metadata-maps.util.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/twenty-standard-application/utils/view-field/build-standard-flat-view-field-metadata-maps.util.ts
@@ -1,4 +1,3 @@
-import { isDefined } from 'twenty-shared/utils';
 
 import { createEmptyFlatEntityMaps } from 'src/engine/metadata-modules/flat-entity/constant/create-empty-flat-entity-maps.constant';
 import { type FlatEntityMaps } from 'src/engine/metadata-modules/flat-entity/types/flat-entity-maps.type';
@@ -78,14 +77,11 @@ const STANDARD_FLAT_VIEW_FIELD_METADATA_BUILDERS_BY_OBJECT_NAME = {
 export type BuildStandardFlatViewFieldMetadataMapsArgs = Omit<
   CreateStandardViewFieldArgs,
   'context' | 'objectName'
-> & {
-  shouldIncludeRecordPageLayouts?: boolean;
-};
+>;
 
-export const buildStandardFlatViewFieldMetadataMaps = ({
-  shouldIncludeRecordPageLayouts,
-  ...args
-}: BuildStandardFlatViewFieldMetadataMapsArgs): FlatEntityMaps<FlatViewField> => {
+export const buildStandardFlatViewFieldMetadataMaps = (
+  args: BuildStandardFlatViewFieldMetadataMapsArgs,
+): FlatEntityMaps<FlatViewField> => {
   const allViewFieldMetadatas: FlatViewField[] = (
     Object.keys(
       STANDARD_FLAT_VIEW_FIELD_METADATA_BUILDERS_BY_OBJECT_NAME,
@@ -99,15 +95,7 @@ export const buildStandardFlatViewFieldMetadataMaps = ({
       objectName,
     });
 
-    return Object.values(result).filter(
-      (viewField) =>
-        shouldIncludeRecordPageLayouts ||
-        isDefined(
-          args.dependencyFlatEntityMaps.flatViewMaps.byUniversalIdentifier[
-            viewField.viewUniversalIdentifier
-          ],
-        ),
-    );
+    return Object.values(result);
   });
 
   let flatViewFieldMaps = createEmptyFlatEntityMaps();

--- a/packages/twenty-server/src/engine/workspace-manager/twenty-standard-application/utils/view-field/build-standard-flat-view-field-metadata-maps.util.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/twenty-standard-application/utils/view-field/build-standard-flat-view-field-metadata-maps.util.ts
@@ -1,4 +1,3 @@
-
 import { createEmptyFlatEntityMaps } from 'src/engine/metadata-modules/flat-entity/constant/create-empty-flat-entity-maps.constant';
 import { type FlatEntityMaps } from 'src/engine/metadata-modules/flat-entity/types/flat-entity-maps.type';
 import { addFlatEntityToFlatEntityMapsOrThrow } from 'src/engine/metadata-modules/flat-entity/utils/add-flat-entity-to-flat-entity-maps-or-throw.util';

--- a/packages/twenty-server/src/engine/workspace-manager/twenty-standard-application/utils/view/build-standard-flat-view-metadata-maps.util.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/twenty-standard-application/utils/view/build-standard-flat-view-metadata-maps.util.ts
@@ -1,4 +1,3 @@
-import { ViewType } from 'twenty-shared/types';
 
 import { createEmptyFlatEntityMaps } from 'src/engine/metadata-modules/flat-entity/constant/create-empty-flat-entity-maps.constant';
 import { type FlatEntityMaps } from 'src/engine/metadata-modules/flat-entity/types/flat-entity-maps.type';
@@ -78,14 +77,11 @@ const STANDARD_FLAT_VIEW_METADATA_BUILDERS_BY_OBJECT_NAME = {
 export type BuildStandardFlatViewMetadataMapsArgs = Omit<
   CreateStandardViewArgs,
   'context' | 'objectName'
-> & {
-  shouldIncludeRecordPageLayouts?: boolean;
-};
+>;
 
-export const buildStandardFlatViewMetadataMaps = ({
-  shouldIncludeRecordPageLayouts,
-  ...args
-}: BuildStandardFlatViewMetadataMapsArgs): FlatEntityMaps<FlatView> => {
+export const buildStandardFlatViewMetadataMaps = (
+  args: BuildStandardFlatViewMetadataMapsArgs,
+): FlatEntityMaps<FlatView> => {
   const allViewMetadatas: FlatView[] = (
     Object.keys(
       STANDARD_FLAT_VIEW_METADATA_BUILDERS_BY_OBJECT_NAME,
@@ -99,10 +95,7 @@ export const buildStandardFlatViewMetadataMaps = ({
       objectName,
     });
 
-    return Object.values(result).filter(
-      (view) =>
-        shouldIncludeRecordPageLayouts || view.type !== ViewType.FIELDS_WIDGET,
-    );
+    return Object.values(result);
   });
 
   let flatViewMaps = createEmptyFlatEntityMaps();

--- a/packages/twenty-server/src/engine/workspace-manager/twenty-standard-application/utils/view/build-standard-flat-view-metadata-maps.util.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/twenty-standard-application/utils/view/build-standard-flat-view-metadata-maps.util.ts
@@ -1,4 +1,3 @@
-
 import { createEmptyFlatEntityMaps } from 'src/engine/metadata-modules/flat-entity/constant/create-empty-flat-entity-maps.constant';
 import { type FlatEntityMaps } from 'src/engine/metadata-modules/flat-entity/types/flat-entity-maps.type';
 import { addFlatEntityToFlatEntityMapsOrThrow } from 'src/engine/metadata-modules/flat-entity/utils/add-flat-entity-to-flat-entity-maps-or-throw.util';


### PR DESCRIPTION
## Context
Deprecating shouldIncludeRecordPageLayouts in preparation for page layout release.

See new workspace with standard page layout from standard app
<img width="570" height="682" alt="Screenshot 2026-04-16 at 18 35 23" src="https://github.com/user-attachments/assets/bf7fa621-d40d-4c29-8d96-537c58b3eb40" />
