### PR TITLE
fix(server): normalize empty composite phone sub-fields to NULL

### DIFF
--- a/packages/twenty-server/src/engine/core-modules/record-transformer/utils/__tests__/transform-phones-value.util.spec.ts
+++ b/packages/twenty-server/src/engine/core-modules/record-transformer/utils/__tests__/transform-phones-value.util.spec.ts
@@ -1,0 +1,118 @@
+import { transformPhonesValue } from 'src/engine/core-modules/record-transformer/utils/transform-phones-value.util';
+
+describe('transformPhonesValue', () => {
+  describe('null/undefined passthrough', () => {
+    it('should return null when input is null', () => {
+      const result = transformPhonesValue({ input: null });
+
+      expect(result).toBeNull();
+    });
+
+    it('should return undefined when input is undefined', () => {
+      const result = transformPhonesValue({ input: undefined });
+
+      expect(result).toBeUndefined();
+    });
+  });
+
+  describe('null-equivalent normalization for unique-constraint safety', () => {
+    // Regression for issue #19740:
+    // Storing '' in a UNIQUE indexed column causes PostgreSQL to treat two
+    // blank rows as duplicates (NULL would be treated as distinct).
+    it('should normalize empty primaryPhoneNumber to null', () => {
+      const result = transformPhonesValue({
+        input: { primaryPhoneNumber: '' },
+      });
+
+      expect(result).toEqual({
+        additionalPhones: null,
+        primaryPhoneNumber: null,
+      });
+    });
+
+    it('should normalize empty primaryPhoneCallingCode to null', () => {
+      const result = transformPhonesValue({
+        input: { primaryPhoneCallingCode: '' },
+      });
+
+      expect(result).toEqual({
+        additionalPhones: null,
+        primaryPhoneCallingCode: null,
+      });
+    });
+
+    it('should normalize empty primaryPhoneCountryCode to null', () => {
+      const result = transformPhonesValue({
+        input: { primaryPhoneCountryCode: '' },
+      });
+
+      expect(result).toEqual({
+        additionalPhones: null,
+        primaryPhoneCountryCode: null,
+      });
+    });
+
+    it('should normalize all empty primary fields to null when submitted together', () => {
+      const result = transformPhonesValue({
+        input: {
+          primaryPhoneNumber: '',
+          primaryPhoneCallingCode: '',
+          primaryPhoneCountryCode: '',
+        },
+      });
+
+      expect(result).toEqual({
+        additionalPhones: null,
+        primaryPhoneNumber: null,
+        primaryPhoneCallingCode: null,
+        primaryPhoneCountryCode: null,
+      });
+    });
+
+    it('should normalize empty number inside an additionalPhones entry to null and drop unsupplied sub-fields', () => {
+      const result = transformPhonesValue({
+        input: {
+          primaryPhoneNumber: '',
+          additionalPhones: JSON.stringify([{ number: '' }]),
+        },
+      });
+
+      // Only the number was supplied (as empty). callingCode/countryCode were
+      // not provided, so they should be absent from the serialized entry rather
+      // than forced to null (preserves partial-update semantics).
+      expect(result?.additionalPhones).toBe(JSON.stringify([{ number: null }]));
+    });
+  });
+
+  describe('valid phone input', () => {
+    it('should parse a valid international phone number into its canonical parts', () => {
+      const result = transformPhonesValue({
+        input: { primaryPhoneNumber: '+14155552671' },
+      });
+
+      expect(result).toEqual({
+        additionalPhones: null,
+        primaryPhoneNumber: '4155552671',
+        primaryPhoneCallingCode: '+1',
+        primaryPhoneCountryCode: 'US',
+      });
+    });
+
+    it('should preserve a valid calling code and country code supplied with a local number', () => {
+      const result = transformPhonesValue({
+        input: {
+          primaryPhoneNumber: '4155552671',
+          primaryPhoneCallingCode: '+1',
+          primaryPhoneCountryCode: 'US',
+        },
+      });
+
+      expect(result).toEqual({
+        additionalPhones: null,
+        primaryPhoneNumber: '4155552671',
+        primaryPhoneCallingCode: '+1',
+        primaryPhoneCountryCode: 'US',
+      });
+    });
+  });
+});

--- a/packages/twenty-server/src/engine/core-modules/record-transformer/utils/__tests__/transform-phones-value.util.spec.ts
+++ b/packages/twenty-server/src/engine/core-modules/record-transformer/utils/__tests__/transform-phones-value.util.spec.ts
@@ -1,147 +1,83 @@
 import { transformPhonesValue } from 'src/engine/core-modules/record-transformer/utils/transform-phones-value.util';
 
 describe('transformPhonesValue', () => {
-  describe('null/undefined passthrough', () => {
-    it('should return null when input is null', () => {
-      const result = transformPhonesValue({ input: null });
+  it('should return null when input is null', () => {
+    const result = transformPhonesValue({ input: null });
 
-      expect(result).toBeNull();
+    expect(result).toBeNull();
+  });
+
+  it('should normalize all empty primary sub-fields to null', () => {
+    const result = transformPhonesValue({
+      input: {
+        primaryPhoneNumber: '',
+        primaryPhoneCallingCode: '',
+        primaryPhoneCountryCode: '',
+      },
     });
 
-    it('should return undefined when input is undefined', () => {
-      const result = transformPhonesValue({ input: undefined });
-
-      expect(result).toBeUndefined();
+    expect(result).toEqual({
+      additionalPhones: null,
+      primaryPhoneNumber: null,
+      primaryPhoneCallingCode: null,
+      primaryPhoneCountryCode: null,
     });
   });
 
-  describe('null-equivalent normalization for unique-constraint safety', () => {
-    it('should normalize empty primaryPhoneNumber to null', () => {
-      const result = transformPhonesValue({
-        input: { primaryPhoneNumber: '' },
-      });
-
-      expect(result).toEqual({
-        additionalPhones: null,
-        primaryPhoneNumber: null,
-      });
+  it('should normalize empty number inside an additionalPhones entry to null', () => {
+    const result = transformPhonesValue({
+      input: {
+        primaryPhoneNumber: '',
+        additionalPhones: JSON.stringify([{ number: '' }]),
+      },
     });
 
-    it('should normalize empty primaryPhoneCallingCode to null', () => {
-      const result = transformPhonesValue({
-        input: { primaryPhoneCallingCode: '' },
-      });
+    expect(result?.additionalPhones).toBe(JSON.stringify([{ number: null }]));
+  });
 
-      expect(result).toEqual({
-        additionalPhones: null,
-        primaryPhoneCallingCode: null,
-      });
+  it('should parse a valid international phone number into its canonical parts', () => {
+    const result = transformPhonesValue({
+      input: { primaryPhoneNumber: '+14155552671' },
     });
 
-    it('should normalize empty primaryPhoneCountryCode to null', () => {
-      const result = transformPhonesValue({
-        input: { primaryPhoneCountryCode: '' },
-      });
-
-      expect(result).toEqual({
-        additionalPhones: null,
-        primaryPhoneCountryCode: null,
-      });
-    });
-
-    it('should normalize all empty primary fields to null when submitted together', () => {
-      const result = transformPhonesValue({
-        input: {
-          primaryPhoneNumber: '',
-          primaryPhoneCallingCode: '',
-          primaryPhoneCountryCode: '',
-        },
-      });
-
-      expect(result).toEqual({
-        additionalPhones: null,
-        primaryPhoneNumber: null,
-        primaryPhoneCallingCode: null,
-        primaryPhoneCountryCode: null,
-      });
-    });
-
-    it('should normalize empty number inside an additionalPhones entry to null and drop unsupplied sub-fields', () => {
-      const result = transformPhonesValue({
-        input: {
-          primaryPhoneNumber: '',
-          additionalPhones: JSON.stringify([{ number: '' }]),
-        },
-      });
-
-      expect(result?.additionalPhones).toBe(JSON.stringify([{ number: null }]));
+    expect(result).toEqual({
+      additionalPhones: null,
+      primaryPhoneNumber: '4155552671',
+      primaryPhoneCallingCode: '+1',
+      primaryPhoneCountryCode: 'US',
     });
   });
 
-  describe('valid phone input', () => {
-    it('should parse a valid international phone number into its canonical parts', () => {
-      const result = transformPhonesValue({
-        input: { primaryPhoneNumber: '+14155552671' },
-      });
-
-      expect(result).toEqual({
-        additionalPhones: null,
-        primaryPhoneNumber: '4155552671',
-        primaryPhoneCallingCode: '+1',
-        primaryPhoneCountryCode: 'US',
-      });
+  it('should infer callingCode from the number when callingCode is an empty string', () => {
+    const result = transformPhonesValue({
+      input: {
+        primaryPhoneNumber: '+14155552671',
+        primaryPhoneCallingCode: '',
+      },
     });
 
-    it('should preserve a valid calling code and country code supplied with a local number', () => {
-      const result = transformPhonesValue({
-        input: {
-          primaryPhoneNumber: '4155552671',
-          primaryPhoneCallingCode: '+1',
-          primaryPhoneCountryCode: 'US',
-        },
-      });
-
-      expect(result).toEqual({
-        additionalPhones: null,
-        primaryPhoneNumber: '4155552671',
-        primaryPhoneCallingCode: '+1',
-        primaryPhoneCountryCode: 'US',
-      });
-    });
-
-    it('should infer callingCode from the number when callingCode is an empty string', () => {
-      const result = transformPhonesValue({
-        input: {
-          primaryPhoneNumber: '+14155552671',
-          primaryPhoneCallingCode: '',
-        },
-      });
-
-      expect(result).toEqual({
-        additionalPhones: null,
-        primaryPhoneNumber: '4155552671',
-        primaryPhoneCallingCode: '+1',
-        primaryPhoneCountryCode: 'US',
-      });
+    expect(result).toEqual({
+      additionalPhones: null,
+      primaryPhoneNumber: '4155552671',
+      primaryPhoneCallingCode: '+1',
+      primaryPhoneCountryCode: 'US',
     });
   });
 
-  describe('additionalPhones input shapes', () => {
-    it('should accept additionalPhones as an array of phone objects', () => {
-      const result = transformPhonesValue({
-        input: {
-          primaryPhoneNumber: '+14155552671',
-          additionalPhones: [
-            { number: '+442071838750', callingCode: '+44', countryCode: 'GB' },
-          ],
-        },
-      });
-
-      expect(result?.additionalPhones).toBe(
-        JSON.stringify([
-          { countryCode: 'GB', callingCode: '+44', number: '2071838750' },
-        ]),
-      );
+  it('should accept additionalPhones as an array of phone objects', () => {
+    const result = transformPhonesValue({
+      input: {
+        primaryPhoneNumber: '+14155552671',
+        additionalPhones: [
+          { number: '+442071838750', callingCode: '+44', countryCode: 'GB' },
+        ],
+      },
     });
+
+    expect(result?.additionalPhones).toBe(
+      JSON.stringify([
+        { countryCode: 'GB', callingCode: '+44', number: '2071838750' },
+      ]),
+    );
   });
 });

--- a/packages/twenty-server/src/engine/core-modules/record-transformer/utils/__tests__/transform-phones-value.util.spec.ts
+++ b/packages/twenty-server/src/engine/core-modules/record-transformer/utils/__tests__/transform-phones-value.util.spec.ts
@@ -114,5 +114,46 @@ describe('transformPhonesValue', () => {
         primaryPhoneCountryCode: 'US',
       });
     });
+
+    it('should infer callingCode from the number when callingCode is an empty string', () => {
+      // Review follow-up: with a valid number, an empty callingCode used to
+      // short-circuit the `callingCode ?? inferred` fallback because '' is not
+      // nullish, persisting primaryPhoneCallingCode as ''.
+      const result = transformPhonesValue({
+        input: {
+          primaryPhoneNumber: '+14155552671',
+          primaryPhoneCallingCode: '',
+        },
+      });
+
+      expect(result).toEqual({
+        additionalPhones: null,
+        primaryPhoneNumber: '4155552671',
+        primaryPhoneCallingCode: '+1',
+        primaryPhoneCountryCode: 'US',
+      });
+    });
+  });
+
+  describe('additionalPhones input shapes', () => {
+    // Review follow-up: transformPhonesValue explicitly supports arrays via
+    // the isArray branch and integration tests pass arrays. The type must
+    // reflect that.
+    it('should accept additionalPhones as an array of phone objects', () => {
+      const result = transformPhonesValue({
+        input: {
+          primaryPhoneNumber: '+14155552671',
+          additionalPhones: [
+            { number: '+442071838750', callingCode: '+44', countryCode: 'GB' },
+          ],
+        },
+      });
+
+      expect(result?.additionalPhones).toBe(
+        JSON.stringify([
+          { countryCode: 'GB', callingCode: '+44', number: '2071838750' },
+        ]),
+      );
+    });
   });
 });

--- a/packages/twenty-server/src/engine/core-modules/record-transformer/utils/__tests__/transform-phones-value.util.spec.ts
+++ b/packages/twenty-server/src/engine/core-modules/record-transformer/utils/__tests__/transform-phones-value.util.spec.ts
@@ -16,9 +16,6 @@ describe('transformPhonesValue', () => {
   });
 
   describe('null-equivalent normalization for unique-constraint safety', () => {
-    // Regression for issue #19740:
-    // Storing '' in a UNIQUE indexed column causes PostgreSQL to treat two
-    // blank rows as duplicates (NULL would be treated as distinct).
     it('should normalize empty primaryPhoneNumber to null', () => {
       const result = transformPhonesValue({
         input: { primaryPhoneNumber: '' },
@@ -77,9 +74,6 @@ describe('transformPhonesValue', () => {
         },
       });
 
-      // Only the number was supplied (as empty). callingCode/countryCode were
-      // not provided, so they should be absent from the serialized entry rather
-      // than forced to null (preserves partial-update semantics).
       expect(result?.additionalPhones).toBe(JSON.stringify([{ number: null }]));
     });
   });
@@ -116,9 +110,6 @@ describe('transformPhonesValue', () => {
     });
 
     it('should infer callingCode from the number when callingCode is an empty string', () => {
-      // Review follow-up: with a valid number, an empty callingCode used to
-      // short-circuit the `callingCode ?? inferred` fallback because '' is not
-      // nullish, persisting primaryPhoneCallingCode as ''.
       const result = transformPhonesValue({
         input: {
           primaryPhoneNumber: '+14155552671',
@@ -136,9 +127,6 @@ describe('transformPhonesValue', () => {
   });
 
   describe('additionalPhones input shapes', () => {
-    // Review follow-up: transformPhonesValue explicitly supports arrays via
-    // the isArray branch and integration tests pass arrays. The type must
-    // reflect that.
     it('should accept additionalPhones as an array of phone objects', () => {
       const result = transformPhonesValue({
         input: {

--- a/packages/twenty-server/src/engine/core-modules/record-transformer/utils/transform-phones-value.util.ts
+++ b/packages/twenty-server/src/engine/core-modules/record-transformer/utils/transform-phones-value.util.ts
@@ -23,12 +23,14 @@ import {
 // The CountryCode brand is applied later, inside validation. Typing the input
 // as `CountryCode` here would be a type-level lie — the UI can send '' or any
 // string, which is exactly how issue #19740 slipped through.
+// additionalPhones accepts both a JSON string and a pre-parsed array; the
+// isArray branch below is exercised by several integration suites.
 export type PhonesFieldGraphQLInput =
   | {
       primaryPhoneNumber?: string | null;
       primaryPhoneCountryCode?: string | null;
       primaryPhoneCallingCode?: string | null;
-      additionalPhones?: string | null;
+      additionalPhones?: string | Partial<AdditionalPhoneMetadata>[] | null;
     }
   | null
   | undefined;
@@ -189,9 +191,16 @@ const validateAndInferPhoneInput = ({
         ? countryCode
         : undefined;
 
+    // An empty callingCode must be treated as "not provided" so the nullish
+    // coalesce below falls through to the inferred `+countryCallingCode`;
+    // otherwise '' would survive all the way to primaryPhoneCallingCode.
+    const providedCallingCode = isNonEmptyString(callingCode)
+      ? callingCode
+      : undefined;
+
     return validateAndInferMetadataFromPrimaryPhoneNumber({
       number,
-      callingCode: callingCode ?? undefined,
+      callingCode: providedCallingCode,
       countryCode: brandedCountryCode,
     });
   }

--- a/packages/twenty-server/src/engine/core-modules/record-transformer/utils/transform-phones-value.util.ts
+++ b/packages/twenty-server/src/engine/core-modules/record-transformer/utils/transform-phones-value.util.ts
@@ -19,12 +19,6 @@ import {
   RecordTransformerExceptionCode,
 } from 'src/engine/core-modules/record-transformer/record-transformer.exception';
 
-// GraphQL delivers sub-fields as raw strings (or null) at the input boundary.
-// The CountryCode brand is applied later, inside validation. Typing the input
-// as `CountryCode` here would be a type-level lie — the UI can send '' or any
-// string, which is exactly how issue #19740 slipped through.
-// additionalPhones accepts both a JSON string and a pre-parsed array; the
-// isArray branch below is exercised by several integration suites.
 export type PhonesFieldGraphQLInput =
   | {
       primaryPhoneNumber?: string | null;
@@ -35,33 +29,21 @@ export type PhonesFieldGraphQLInput =
   | null
   | undefined;
 
-type RawPhoneInput = {
-  callingCode?: string | null;
-  countryCode?: string | null;
-  number?: string | null;
-};
-
 type AdditionalPhoneMetadataWithNumber = Partial<AdditionalPhoneMetadata> &
   Required<Pick<AdditionalPhoneMetadata, 'number'>>;
 
-// Unique indexes on composite phone sub-columns treat '' as duplicates but
-// NULLs as distinct, so blank inputs must reach the DB as NULL, not ''.
-// `undefined` is preserved so partial updates leave unrelated columns untouched.
-const nullIfEmptyString = <T extends string>(
-  value: T | null | undefined,
-): T | null | undefined => {
-  if (value === undefined) return undefined;
-  if (value === null || value.length === 0) return null;
-
-  return value;
-};
-
 const removePlusFromString = (str: string) => str.replace(/\+/g, '');
+
+const nullIfEmptyString = (value: string | null | undefined) =>
+  value === undefined ? undefined : isNonEmptyString(value) ? value : null;
 
 const validatePrimaryPhoneCountryCodeAndCallingCode = ({
   callingCode,
   countryCode,
-}: Omit<RawPhoneInput, 'number'>) => {
+}: {
+  callingCode?: string | null;
+  countryCode?: string | null;
+}) => {
   if (isNonEmptyString(countryCode) && !isValidCountryCode(countryCode)) {
     throw new RecordTransformerException(
       `Invalid country code ${countryCode}`,
@@ -176,32 +158,21 @@ const validateAndInferPhoneInput = ({
   callingCode,
   countryCode,
   number,
-}: RawPhoneInput) => {
-  validatePrimaryPhoneCountryCodeAndCallingCode({
-    callingCode,
-    countryCode,
-  });
+}: {
+  callingCode?: string | null;
+  countryCode?: string | null;
+  number?: string | null;
+}) => {
+  validatePrimaryPhoneCountryCodeAndCallingCode({ callingCode, countryCode });
 
-  if (isDefined(number) && isNonEmptyString(number)) {
-    // validatePrimaryPhoneCountryCodeAndCallingCode already threw on invalid
-    // countryCode; this narrow re-runs the guard purely to carry the brand
-    // into validateAndInferMetadataFromPrimaryPhoneNumber.
-    const brandedCountryCode =
-      isNonEmptyString(countryCode) && isValidCountryCode(countryCode)
-        ? countryCode
-        : undefined;
-
-    // An empty callingCode must be treated as "not provided" so the nullish
-    // coalesce below falls through to the inferred `+countryCallingCode`;
-    // otherwise '' would survive all the way to primaryPhoneCallingCode.
-    const providedCallingCode = isNonEmptyString(callingCode)
-      ? callingCode
-      : undefined;
-
+  if (isNonEmptyString(number)) {
     return validateAndInferMetadataFromPrimaryPhoneNumber({
       number,
-      callingCode: providedCallingCode,
-      countryCode: brandedCountryCode,
+      callingCode: isNonEmptyString(callingCode) ? callingCode : undefined,
+      countryCode:
+        isNonEmptyString(countryCode) && isValidCountryCode(countryCode)
+          ? countryCode
+          : undefined,
     });
   }
 

--- a/packages/twenty-server/src/engine/core-modules/record-transformer/utils/transform-phones-value.util.ts
+++ b/packages/twenty-server/src/engine/core-modules/record-transformer/utils/transform-phones-value.util.ts
@@ -35,7 +35,7 @@ type AdditionalPhoneMetadataWithNumber = Partial<AdditionalPhoneMetadata> &
 const removePlusFromString = (str: string) => str.replace(/\+/g, '');
 
 const nullIfEmptyString = (value: string | null | undefined) =>
-  value === undefined ? undefined : isNonEmptyString(value) ? value : null;
+  !isDefined(value) ? value : isNonEmptyString(value) ? value : null;
 
 const validatePrimaryPhoneCountryCodeAndCallingCode = ({
   callingCode,

--- a/packages/twenty-server/src/engine/core-modules/record-transformer/utils/transform-phones-value.util.ts
+++ b/packages/twenty-server/src/engine/core-modules/record-transformer/utils/transform-phones-value.util.ts
@@ -5,10 +5,7 @@ import {
   parsePhoneNumberWithError,
 } from 'libphonenumber-js';
 import isEmpty from 'lodash.isempty';
-import {
-  type AdditionalPhoneMetadata,
-  type PhonesMetadata,
-} from 'twenty-shared/types';
+import { type AdditionalPhoneMetadata } from 'twenty-shared/types';
 import {
   getCountryCodesForCallingCode,
   isDefined,
@@ -22,24 +19,47 @@ import {
   RecordTransformerExceptionCode,
 } from 'src/engine/core-modules/record-transformer/record-transformer.exception';
 
+// GraphQL delivers sub-fields as raw strings (or null) at the input boundary.
+// The CountryCode brand is applied later, inside validation. Typing the input
+// as `CountryCode` here would be a type-level lie — the UI can send '' or any
+// string, which is exactly how issue #19740 slipped through.
 export type PhonesFieldGraphQLInput =
-  | Partial<
-      Omit<PhonesMetadata, 'additionalPhones'> & {
-        additionalPhones: string | null;
-      }
-    >
+  | {
+      primaryPhoneNumber?: string | null;
+      primaryPhoneCountryCode?: string | null;
+      primaryPhoneCallingCode?: string | null;
+      additionalPhones?: string | null;
+    }
   | null
   | undefined;
 
+type RawPhoneInput = {
+  callingCode?: string | null;
+  countryCode?: string | null;
+  number?: string | null;
+};
+
 type AdditionalPhoneMetadataWithNumber = Partial<AdditionalPhoneMetadata> &
   Required<Pick<AdditionalPhoneMetadata, 'number'>>;
+
+// Unique indexes on composite phone sub-columns treat '' as duplicates but
+// NULLs as distinct, so blank inputs must reach the DB as NULL, not ''.
+// `undefined` is preserved so partial updates leave unrelated columns untouched.
+const nullIfEmptyString = <T extends string>(
+  value: T | null | undefined,
+): T | null | undefined => {
+  if (value === undefined) return undefined;
+  if (value === null || value.length === 0) return null;
+
+  return value;
+};
 
 const removePlusFromString = (str: string) => str.replace(/\+/g, '');
 
 const validatePrimaryPhoneCountryCodeAndCallingCode = ({
   callingCode,
   countryCode,
-}: Partial<Omit<AdditionalPhoneMetadata, 'number'>>) => {
+}: Omit<RawPhoneInput, 'number'>) => {
   if (isNonEmptyString(countryCode) && !isValidCountryCode(countryCode)) {
     throw new RecordTransformerException(
       `Invalid country code ${countryCode}`,
@@ -154,24 +174,32 @@ const validateAndInferPhoneInput = ({
   callingCode,
   countryCode,
   number,
-}: Partial<AdditionalPhoneMetadata>) => {
+}: RawPhoneInput) => {
   validatePrimaryPhoneCountryCodeAndCallingCode({
     callingCode,
     countryCode,
   });
 
   if (isDefined(number) && isNonEmptyString(number)) {
+    // validatePrimaryPhoneCountryCodeAndCallingCode already threw on invalid
+    // countryCode; this narrow re-runs the guard purely to carry the brand
+    // into validateAndInferMetadataFromPrimaryPhoneNumber.
+    const brandedCountryCode =
+      isNonEmptyString(countryCode) && isValidCountryCode(countryCode)
+        ? countryCode
+        : undefined;
+
     return validateAndInferMetadataFromPrimaryPhoneNumber({
       number,
-      callingCode,
-      countryCode,
+      callingCode: callingCode ?? undefined,
+      countryCode: brandedCountryCode,
     });
   }
 
   return {
-    callingCode,
-    countryCode,
-    number,
+    callingCode: nullIfEmptyString(callingCode),
+    countryCode: nullIfEmptyString(countryCode),
+    number: nullIfEmptyString(number),
   };
 };
 

--- a/packages/twenty-server/test/integration/graphql/suites/object-generated/unique-phones-field-null-equivalence.integration-spec.ts
+++ b/packages/twenty-server/test/integration/graphql/suites/object-generated/unique-phones-field-null-equivalence.integration-spec.ts
@@ -1,0 +1,159 @@
+import { faker } from '@faker-js/faker';
+import { createOneOperation } from 'test/integration/graphql/utils/create-one-operation.util';
+import { createOneFieldMetadata } from 'test/integration/metadata/suites/field-metadata/utils/create-one-field-metadata.util';
+import { createOneObjectMetadata } from 'test/integration/metadata/suites/object-metadata/utils/create-one-object-metadata.util';
+import { deleteOneObjectMetadata } from 'test/integration/metadata/suites/object-metadata/utils/delete-one-object-metadata.util';
+import { updateOneObjectMetadata } from 'test/integration/metadata/suites/object-metadata/utils/update-one-object-metadata.util';
+import { deleteRecordsByIds } from 'test/integration/utils/delete-records-by-ids';
+import { FieldMetadataType } from 'twenty-shared/types';
+
+const OBJECT_SINGULAR = 'uniquePhonesTestObject';
+const OBJECT_PLURAL = 'uniquePhonesTestObjects';
+const FIELD_NAME = 'phone';
+
+describe('unique PHONES field with empty values - regression for #19740', () => {
+  let createdObjectMetadataId: string;
+  let createdRecordIdsForCleaning: string[] = [];
+
+  beforeAll(async () => {
+    const { data } = await createOneObjectMetadata({
+      input: {
+        nameSingular: OBJECT_SINGULAR,
+        namePlural: OBJECT_PLURAL,
+        labelSingular: 'Unique Phones Test Object',
+        labelPlural: 'Unique Phones Test Objects',
+        icon: 'IconPhone',
+        isLabelSyncedWithName: false,
+      },
+    });
+
+    createdObjectMetadataId = data.createOneObject.id;
+
+    await createOneFieldMetadata({
+      input: {
+        name: FIELD_NAME,
+        label: 'Phone',
+        type: FieldMetadataType.PHONES,
+        objectMetadataId: createdObjectMetadataId,
+        isUnique: true,
+        isLabelSyncedWithName: false,
+      },
+      gqlFields: `
+        id
+        name
+        isUnique
+      `,
+    });
+  });
+
+  afterEach(async () => {
+    if (createdRecordIdsForCleaning.length > 0) {
+      await deleteRecordsByIds(OBJECT_SINGULAR, createdRecordIdsForCleaning);
+      createdRecordIdsForCleaning = [];
+    }
+  });
+
+  afterAll(async () => {
+    await updateOneObjectMetadata({
+      expectToFail: false,
+      input: {
+        idToUpdate: createdObjectMetadataId,
+        updatePayload: { isActive: false },
+      },
+    });
+    await deleteOneObjectMetadata({
+      input: { idToDelete: createdObjectMetadataId },
+    });
+  });
+
+  it('should allow creating two records with empty primaryPhoneNumber on a unique PHONES field', async () => {
+    const firstId = faker.string.uuid();
+    const secondId = faker.string.uuid();
+
+    const firstResponse = await createOneOperation({
+      objectMetadataSingularName: OBJECT_SINGULAR,
+      input: {
+        id: firstId,
+        [FIELD_NAME]: { primaryPhoneNumber: '' },
+      },
+      gqlFields: `id`,
+    });
+
+    expect(firstResponse.errors).toBeUndefined();
+    expect(firstResponse.data.createOneResponse.id).toBe(firstId);
+    createdRecordIdsForCleaning.push(firstId);
+
+    const secondResponse = await createOneOperation({
+      objectMetadataSingularName: OBJECT_SINGULAR,
+      input: {
+        id: secondId,
+        [FIELD_NAME]: { primaryPhoneNumber: '' },
+      },
+      gqlFields: `id`,
+    });
+
+    expect(secondResponse.errors).toBeUndefined();
+    expect(secondResponse.data.createOneResponse.id).toBe(secondId);
+    createdRecordIdsForCleaning.push(secondId);
+  });
+
+  it('should allow creating two records with no PHONES payload at all', async () => {
+    const firstId = faker.string.uuid();
+    const secondId = faker.string.uuid();
+
+    const firstResponse = await createOneOperation({
+      objectMetadataSingularName: OBJECT_SINGULAR,
+      input: { id: firstId },
+      gqlFields: `id`,
+    });
+
+    expect(firstResponse.errors).toBeUndefined();
+    createdRecordIdsForCleaning.push(firstId);
+
+    const secondResponse = await createOneOperation({
+      objectMetadataSingularName: OBJECT_SINGULAR,
+      input: { id: secondId },
+      gqlFields: `id`,
+    });
+
+    expect(secondResponse.errors).toBeUndefined();
+    createdRecordIdsForCleaning.push(secondId);
+  });
+
+  it('should still enforce uniqueness when two records share the same non-empty primaryPhoneNumber', async () => {
+    const firstId = faker.string.uuid();
+    const secondId = faker.string.uuid();
+
+    const firstResponse = await createOneOperation({
+      objectMetadataSingularName: OBJECT_SINGULAR,
+      input: {
+        id: firstId,
+        [FIELD_NAME]: {
+          primaryPhoneNumber: '4155552671',
+          primaryPhoneCallingCode: '+1',
+          primaryPhoneCountryCode: 'US',
+        },
+      },
+      gqlFields: `id`,
+    });
+
+    expect(firstResponse.errors).toBeUndefined();
+    createdRecordIdsForCleaning.push(firstId);
+
+    const secondResponse = await createOneOperation({
+      objectMetadataSingularName: OBJECT_SINGULAR,
+      input: {
+        id: secondId,
+        [FIELD_NAME]: {
+          primaryPhoneNumber: '4155552671',
+          primaryPhoneCallingCode: '+1',
+          primaryPhoneCountryCode: 'US',
+        },
+      },
+      gqlFields: `id`,
+      expectToFail: true,
+    });
+
+    expect(secondResponse.errors).toBeDefined();
+  });
+});

--- a/packages/twenty-server/test/integration/graphql/suites/unique-field/unique-phones-field-null-equivalence.integration-spec.ts
+++ b/packages/twenty-server/test/integration/graphql/suites/unique-field/unique-phones-field-null-equivalence.integration-spec.ts
@@ -11,7 +11,7 @@ const OBJECT_SINGULAR = 'uniquePhonesTestObject';
 const OBJECT_PLURAL = 'uniquePhonesTestObjects';
 const FIELD_NAME = 'phone';
 
-describe('unique PHONES field with empty values - regression for #19740', () => {
+describe('unique PHONES field with empty values', () => {
   let createdObjectMetadataId: string;
   let createdRecordIdsForCleaning: string[] = [];
 


### PR DESCRIPTION
Fixed using Opus 4.7, I wanted to test this model out and in this repo I know you guys care about quality, pls let me know if this is good code. It looks good to me

Fixes #19740.

## Summary

PostgreSQL UNIQUE indexes treat two `''` values as duplicates but two `NULL`s as distinct. `validateAndInferPhoneInput` was persisting blank `primaryPhoneNumber` as `''` instead of `NULL`, so a second record with an empty unique phone failed with a constraint violation. The sibling composite transforms (`transformEmailsValue`, `removeEmptyLinks`, `transformTextField`) already canonicalize null-equivalent values; phones was the outlier.

- Empty-string phone sub-fields now normalize to `null`. `undefined` is preserved so partial updates leave columns the user did not touch alone.
- `PhonesFieldGraphQLInput` drops the aspirational `CountryCode` brand on input. GraphQL delivers raw strings at the boundary; branding happens during validation.

