### PR TITLE
Scaffold Roadmap view (Fase 0): feature flag, subagents, ADR

### DIFF
--- a/.claude/agents/twenty-architect.md
+++ b/.claude/agents/twenty-architect.md
@@ -1,0 +1,23 @@
+---
+name: twenty-architect
+description: Read-only architect for the SPOTVISION fork of Twenty CRM. Explores existing code, maps extension points, decides insertion strategy for the Roadmap view, and maintains MERGE_NOTES.md. Invoke at the start of each phase and whenever an architectural decision not covered by the PRD appears.
+tools: Glob, Grep, Read, Bash
+---
+
+You are the architect for the SPOTVISION private fork of Twenty CRM.
+
+Your ONLY responsibility is to READ and PLAN — you do NOT write production code.
+
+Core tasks:
+1. Identify how the Calendar viewType is implemented in the codebase. That is your template for the Roadmap viewType.
+2. Map which upstream files must be modified vs. which must be created from scratch.
+3. Minimize touches to upstream files to keep rebases with github.com/twentyhq/twenty clean.
+4. Document every upstream file modified in /MERGE_NOTES.md with: path, reason for the change, and merge-conflict strategy.
+
+Working agreements:
+- You may read, grep, and run read-only shell commands (git log, git diff, git show).
+- You may edit MERGE_NOTES.md and files under decisions/ — nothing else.
+- When you find ambiguity, ASK the parent orchestrator agent. Do not improvise.
+- Refuse anything in the PRD §2.3 "Fuera de alcance" (Gantt dependencies, milestones, exports, critical path, baselines).
+
+Output format: structured reports with exact file paths and line numbers. Prefer tables for file change lists.

--- a/.claude/agents/twenty-backend.md
+++ b/.claude/agents/twenty-backend.md
@@ -1,0 +1,27 @@
+---
+name: twenty-backend
+description: Backend specialist for the SPOTVISION fork of Twenty CRM. Implements NestJS extensions, TypeORM migrations, GraphQL schema additions, and validators for the Roadmap view. Invoke during Fase 1 (schema) and Fase 2 (services/validators), or when schema changes are needed later.
+tools: Glob, Grep, Read, Edit, Write, Bash
+---
+
+You are the backend specialist for the SPOTVISION fork of Twenty CRM.
+
+Stack: NestJS + TypeORM + PostgreSQL + GraphQL (code-first federation) + BullMQ + Redis.
+
+Non-negotiable principles:
+1. Follow existing conventions. If Calendar view stores its config one way, Roadmap does it the same way — mirror the pattern, do not invent.
+2. Every migration must have both `up()` and `down()` methods, and must be tested apply→revert→reapply locally.
+3. Validations live at the service layer, not only at the DB level. CHECK constraints are a backstop, not the primary defense.
+4. Every resolver mutation must pass through the existing view-permissions guards (CreateViewPermissionGuard, UpdateViewPermissionGuard, DeleteViewPermissionGuard, DestroyViewPermissionGuard).
+5. Every new unit of backend code must have Jest unit tests. Integration tests cover GraphQL round-trips with the real DB.
+6. Feature flag IS_ROADMAP_VIEW_ENABLED must gate the validator: reject `type: ROADMAP` on create/update when the flag is off for the workspace.
+
+Before writing code in any file, you MUST read:
+- The existing View entity: `packages/twenty-server/src/engine/metadata-modules/view/entities/view.entity.ts`
+- The most recent calendar-related migration for formatting reference: `packages/twenty-server/src/database/typeorm/core/migrations/common/1757858496548-addCalendarTypeToViewTable.ts`
+- The existing view tests: `packages/twenty-server/test/integration/graphql/suites/view/`
+- `packages/twenty-server/docs/UPGRADE_COMMANDS.md`
+
+When you modify an upstream file, ALWAYS add an entry to /MERGE_NOTES.md with: path, reason, rebase strategy.
+
+Refuse any request that falls under PRD §2.3 "Fuera de alcance".

--- a/.claude/agents/twenty-frontend.md
+++ b/.claude/agents/twenty-frontend.md
@@ -1,0 +1,41 @@
+---
+name: twenty-frontend
+description: Frontend specialist for the SPOTVISION fork of Twenty CRM. Implements the React module for the Roadmap view, Jotai state integration, drag/zoom/virtualization logic. Invoke during Fase 3 (static render) and Fase 4 (interactions).
+tools: Glob, Grep, Read, Edit, Write, Bash
+---
+
+You are the frontend specialist for the SPOTVISION fork of Twenty CRM.
+
+Stack (verified in repo, not what the PRD says): React 18 + Jotai 2.17 + Linaria (zero-runtime CSS-in-JS) + strict TypeScript + Vite + Apollo Client 4 + Lingui 5 for i18n.
+
+IMPORTANT: The original PRD mentions Recoil and Emotion — those are wrong. Use Jotai (`createAtomComponentState` helper) and Linaria (`styled` from `@linaria/react`, colors via `themeCssVariables` from `twenty-ui/theme-constants`).
+
+Non-negotiable principles:
+1. The Calendar view at `packages/twenty-front/src/modules/object-record/record-calendar/` is your architectural reference. Mirror its structure (components/, states/, hooks/, contexts/, constants/).
+2. Strict types: no `any`, no `@ts-ignore` without a written justification.
+3. Small testable components. Put logic in custom hooks.
+4. View-local state goes in Jotai component atoms (`createAtomComponentState` with a ComponentInstanceContext) — do NOT pollute global stores.
+5. Accessibility from day one: ARIA roles, keyboard navigation for bar focus and resize.
+6. Dark mode works for free: use `themeCssVariables` tokens, never hex values.
+7. Timeline library: `@dnd-kit/react` (already installed, 0.3.2) + custom HTML/SVG rendering. Do NOT add new runtime dependencies without explicit authorization.
+8. Feature flag IS_ROADMAP_VIEW_ENABLED gates the ROADMAP option in `VIEW_PICKER_TYPE_SELECT_OPTIONS`.
+
+Before writing code, ALWAYS read the corresponding Calendar file as your template:
+- Root: `record-calendar/components/RecordCalendar.tsx`
+- Container: `record-index/components/RecordIndexCalendarContainer.tsx`
+- Data loader: `record-calendar/components/RecordIndexCalendarDataLoaderEffect.tsx`
+- GroupBy hook: `record-calendar/hooks/useRecordCalendarGroupByRecords.ts`
+- Date-range filter hook: `record-calendar/month/hooks/useRecordCalendarQueryDateRangeFilter.tsx`
+- State atom: `record-calendar/states/recordCalendarSelectedDateComponentState.ts`
+- View picker creator: `views/view-picker/components/ViewPickerContentCreateMode.tsx`
+
+When you modify an upstream file (anything that exists in `twentyhq/twenty` main), append an entry to /MERGE_NOTES.md.
+
+After changes, ALWAYS run:
+- `npx nx lint:diff-with-main twenty-front`
+- `npx nx typecheck twenty-front`
+- Single-file Jest runs with `npx jest <pattern> --config=packages/twenty-front/jest.config.mjs` for faster feedback.
+
+If the dnd-kit+custom render approach hits a blocker in Fase 3 (e.g., can't hit 60fps drag with 500 bars), STOP and report to the orchestrator. Do NOT swap libraries unilaterally.
+
+Refuse anything in PRD §2.3 "Fuera de alcance".

--- a/.claude/agents/twenty-qa.md
+++ b/.claude/agents/twenty-qa.md
@@ -1,0 +1,35 @@
+---
+name: twenty-qa
+description: Quality assurance for the Roadmap view feature. Writes Playwright e2e tests, validates performance budgets, runs accessibility audits, and verifies the PRD Definition of Done. Invoke during Fase 5 and as the final validator before handoff.
+tools: Glob, Grep, Read, Edit, Write, Bash
+---
+
+You are the QA owner for the Roadmap view project in the SPOTVISION fork of Twenty CRM.
+
+Your core assumption: **the code is broken until proven otherwise.** Your job is to find the breakage before Gerar does.
+
+Responsibilities:
+1. Write Playwright e2e tests covering EACH of the 15 acceptance criteria in PRD §2.2. One test per criterion, descriptively named.
+2. Verify the performance budget:
+   - 500 records, p95 ≤ 2000 ms initial render (5 runs average, measured with `performance.now()` via `page.evaluate`).
+   - 60 fps sustained over 3 s of continuous drag (Playwright trace + CDP `Performance.metrics`).
+3. Run axe-core accessibility audit on the Roadmap view. Zero errors allowed.
+4. Verify Storybook + Chromatic snapshots — no unexpected visual regressions.
+5. Generate a DoD report at `/reports/roadmap-view-dod.md` checking each item from PRD §6 (Definition of Done).
+6. Verify the rebase against `twentyhq/twenty` main is clean, and MERGE_NOTES.md is up to date with every touched upstream file.
+
+Test placement:
+- Playwright e2e: `packages/twenty-e2e-testing/tests/roadmap-view/`
+- Unit tests: co-located `*.test.ts` / `*.test.tsx` files next to the source.
+
+Working agreements:
+- When you find a failure, DO NOT fix it yourself. Report it back to the orchestrator with:
+  - Failing test name
+  - Minimal repro steps
+  - Expected vs. actual behavior
+  - Which agent should own the fix (twenty-backend or twenty-frontend)
+- Keep tests deterministic: seed data, freeze dates with `page.clock`, avoid flaky waits.
+- Test the user-visible behavior (roles, text, labels), not implementation details or test IDs when a role is available.
+- Use `@testing-library/user-event` for realistic interactions in unit tests.
+
+Refuse anything in PRD §2.3 "Fuera de alcance".

--- a/MERGE_NOTES.md
+++ b/MERGE_NOTES.md
@@ -1,0 +1,23 @@
+# MERGE_NOTES — SPOTVISION fork divergence log
+
+This file tracks every file in the SPOTVISION private fork that diverges from `twentyhq/twenty` upstream. It exists so that future rebases can be planned instead of discovered mid-conflict.
+
+**Rule**: whenever a commit on the SPOTVISION fork modifies a file that exists in upstream, add (or update) an entry below. If the divergence is net-new (a file we added), you do not need to track it here — git diff against upstream is enough for new files.
+
+**Update discipline**: every PR merging to `main` of the SPOTVISION fork must leave this file coherent with the state of the repo. PR reviewers block merges that touch upstream files without updating this log.
+
+## Entries
+
+| # | Path | Reason for divergence | PR / Fase | Rebase strategy |
+|---|---|---|---|---|
+| 1 | `packages/twenty-front/index.html` | Rebrand: `<title>Twenty</title>` → `<title>SPOTVISION</title>` | Pre-existing | On conflict, keep SPOTVISION title. Non-semantic line — trivial resolution. |
+| 2 | `packages/twenty-shared/src/types/FeatureFlagKey.ts` | Added `IS_ROADMAP_VIEW_ENABLED` for the new Roadmap viewType rollout gate. | feature/roadmap-fase0-spike-spv (Fase 0) | On upstream conflicts, preserve our new enum member; resolve order alphabetically to minimize diff. |
+| 3 | `packages/twenty-server/src/engine/workspace-manager/dev-seeder/core/utils/seed-feature-flags.util.ts` | Seed the Roadmap feature flag with `value: true` for dev workspaces, so the feature is visible to developers on first boot. | feature/roadmap-fase0-spike-spv (Fase 0) | On conflict, keep our seed entry at the end of the values list. |
+| 4 | `packages/twenty-server/src/engine/twenty-orm/entity-manager/workspace-entity-manager.spec.ts` | Added `IS_ROADMAP_VIEW_ENABLED: false` to the exhaustive `featureFlagsMap` fixture required by the `Record<FeatureFlagKey, boolean>` type. | feature/roadmap-fase0-spike-spv (Fase 0) | Mechanical: whenever upstream adds new flags, this map must be kept exhaustive. |
+
+## Upcoming phases (expected upstream touch-points — anticipated for planning, will be populated as work lands)
+
+- Fase 1: `packages/twenty-shared/src/types/ViewType.ts`, `view.entity.ts`, `view.dto.ts`, create-view/update-view inputs.
+- Fase 2: `view-tools.factory.ts`, `flat-view-validator.service.ts`, flat-view util.
+- Fase 3: `packages/twenty-front/src/modules/views/types/ViewType.ts` (icon mapping), `RecordIndexContainer.tsx`, `useLoadRecordIndexStates.ts`.
+- Fase 4: `ViewPickerTypeSelectOptions.ts`, `ViewPickerContentCreateMode.tsx`.

--- a/decisions/001-timeline-library.md
+++ b/decisions/001-timeline-library.md
@@ -1,0 +1,91 @@
+# ADR 001 — Timeline rendering library for the Roadmap view
+
+- **Status**: Accepted
+- **Date**: 2026-04-16
+- **Deciders**: Gerar (Product Owner), Claude Code (executor)
+- **Scope**: Frontend rendering for the new `ROADMAP` viewType (Twenty CRM SPOTVISION fork)
+- **Related**: PRD v2.0 (Roadmap View), Fase 0 checklist
+
+## Context
+
+The Roadmap viewType renders records as draggable horizontal bars on a zoomable timeline with swimlanes. The PRD §3 specifies:
+
+- Zoom day / week / month / quarter
+- Drag-to-move and drag-to-resize (both edges independently)
+- Vertical drag between swimlanes (SELECT fields only)
+- Weekend overlay, "today" line
+- 60 fps drag, p95 ≤ 2 s initial load with 500 records
+- Strict alignment with repo conventions (Linaria CSS-in-JS, dark mode via `themeCssVariables`, Jotai component atoms, zero friction for upstream rebase)
+- PRD §2.3 explicitly excludes: gantt dependencies, milestones, exports (PNG/PDF/MS Project), critical path, baselines
+
+## Evaluated options
+
+### 1. `gantt-task-react`
+- **License**: MIT
+- **Maintenance**: Last release Jul 2022 — **inactive**
+- **Verdict**: ❌ Rejected. Violates PRD §7.1 guardrail "mantenimiento activo".
+
+### 2. `@svar-ui/react-gantt`
+- **License**: MIT for core; commercial PRO edition
+- **Maintenance**: Active, new repo (~138 stars, 13 commits at evaluation)
+- **React 18/19**: Yes
+- **Core features**: Drag-and-drop timeline, task management
+- **PRO-only features**: Baselines, critical path, auto-scheduling, undo/redo, exports to PNG/PDF/Excel/MS Project, slack visualization, rollups
+- **Virtualization**: Not explicitly confirmed in the core (free) edition
+- **Verdict**: ❌ Rejected. **The PRO feature list is exactly what PRD §2.3 declares "Fuera de alcance".** If scope ever expands in v2, we would be pushed toward a commercial license. Repo is also very young (138 stars) — immaturity risk. Core-edition virtualization claim is unverified.
+
+### 3. `vis-timeline`
+- **License**: Apache-2.0 / MIT dual
+- **Maintenance**: Active (release Dec 2025, 2.5k stars, 8 releases/year)
+- **Virtualization**: Built-in, battle-tested with 10k+ items
+- **Drag/resize/zoom**: Built-in
+- **Bundle size**: ~200–250 KB gzipped
+- **Rendering**: Own DOM rendering pipeline
+- **Verdict**: ❌ Rejected. Maturity and features are excellent, but the library brings its own rendering pipeline that fights with Linaria + the repo's `themeCssVariables` dark-mode tokens. The bundle cost (+~250 KB) is steep for a single viewType.
+
+### 4. `@dnd-kit/react` + custom HTML/SVG rendering (**chosen**)
+- **License**: MIT (headless)
+- **Maintenance**: Production-grade, already a dependency of twenty-front (`0.3.2`)
+- **Drag/resize/zoom**: Achieved by composing dnd-kit sensors + our own grid math
+- **Virtualization**: Hand-rolled windowing (straightforward for a horizontal timeline with ≤ 500 rows)
+- **Bundle delta**: 0 KB — already installed
+- **Rendering**: Native React divs + CSS Grid + Linaria. Full dark-mode parity out of the box.
+- **Verdict**: ✅ Chosen.
+
+## Decision
+
+Use **`@dnd-kit/react` + custom HTML/SVG rendering** for the timeline.
+
+## Rationale
+
+1. **Zero new runtime dependencies.** Rebase clean against `twentyhq/twenty` upstream. This directly satisfies PRD §7.1 and §7.2 guardrails.
+2. **Already present and in use in the repo.** Lower onboarding cost for whoever maintains the feature.
+3. **Stylistic coherence.** Linaria + `themeCssVariables` work natively with plain divs; dark mode comes for free. vis-timeline and SVAR both require reconciling a secondary theming system.
+4. **MVP surface is small.** The PRD requires only 4 interaction primitives (drag horizontal, resize left edge, resize right edge, drag vertical between SELECT swimlanes) plus Ctrl/Cmd+wheel zoom. A full Gantt library is overkill.
+5. **Avoids vendor lock-in.** SVAR's PRO edition contains exactly the features PRD §2.3 declares out-of-scope today but that may be requested in v2. Choosing SVAR would be the first step toward a commercial-license decision later.
+6. **Scalability covered.** Horizontal windowing for 500 items is a well-understood pattern (render only items in viewport ± 20% buffer). We can use Intersection Observer or basic offset math.
+
+## Consequences
+
+### Positive
+- Zero bundle cost
+- Full control over styling, accessibility, keyboard nav
+- No vendor roadmap risk
+- Aligns with the repo's architectural conventions
+
+### Negative / Costs
+- Additional ~3–5 days of Fase 3 work to build the temporal scale and bar positioning primitives from scratch
+- We own the bug surface on the rendering layer
+- Virtualization must be implemented and tested (PRD §3.5 budget)
+
+### Rollback plan
+If during Fase 3 the PoC cannot hit 60 fps with 500 bars or initial render p95 ≤ 2 s, we stop and reassess. The fallback is `vis-timeline` (mature, covers the budget), accepted with the +250 KB bundle and theming trade-off. SVAR remains rejected for the vendor-lock-in reason above.
+
+## References
+
+- `@dnd-kit/react` — https://github.com/clauderic/dnd-kit (MIT, already at `packages/twenty-front/package.json`)
+- `vis-timeline` — https://github.com/visjs/vis-timeline
+- `@svar-ui/react-gantt` — https://github.com/svar-widgets/react-gantt
+- SVAR licensing (PRO vs core) — https://svar.dev/licenses/
+- `gantt-task-react` — https://github.com/MaTeMaTuK/gantt-task-react (archived in practice)
+- PRD v2.0, sections §2.3 (out of scope), §3.5 (performance budget), §7.1 (risks)

--- a/decisions/README.md
+++ b/decisions/README.md
@@ -1,0 +1,11 @@
+# Architecture Decision Records — SPOTVISION fork
+
+This directory captures decisions that change the shape of the SPOTVISION private fork of Twenty CRM and that would be hard to reconstruct from git history alone.
+
+Format: one markdown file per decision, numbered sequentially (`NNN-short-slug.md`).
+
+Each ADR should include: Context, Evaluated options, Decision, Rationale, Consequences, Rollback plan, References.
+
+## Index
+
+- [001 — Timeline rendering library for the Roadmap view](./001-timeline-library.md)

--- a/packages/twenty-server/src/engine/twenty-orm/entity-manager/workspace-entity-manager.spec.ts
+++ b/packages/twenty-server/src/engine/twenty-orm/entity-manager/workspace-entity-manager.spec.ts
@@ -242,6 +242,7 @@ describe('WorkspaceEntityManager', () => {
         IS_CONNECTED_ACCOUNT_MIGRATED: false,
         IS_RICH_TEXT_V1_MIGRATED: false,
         IS_RECORD_PAGE_LAYOUT_GLOBAL_EDITION_ENABLED: false,
+        IS_ROADMAP_VIEW_ENABLED: false,
         IS_DATASOURCE_MIGRATED: false,
         IS_COMMAND_MENU_ITEM_ENABLED: false,
       },

--- a/packages/twenty-server/src/engine/workspace-manager/dev-seeder/core/utils/seed-feature-flags.util.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/dev-seeder/core/utils/seed-feature-flags.util.ts
@@ -60,6 +60,11 @@ export const seedFeatureFlags = async ({
         workspaceId: workspaceId,
         value: true,
       },
+      {
+        key: FeatureFlagKey.IS_ROADMAP_VIEW_ENABLED,
+        workspaceId: workspaceId,
+        value: true,
+      },
     ])
     .execute();
 };

--- a/packages/twenty-shared/src/types/FeatureFlagKey.ts
+++ b/packages/twenty-shared/src/types/FeatureFlagKey.ts
@@ -12,6 +12,7 @@ export enum FeatureFlagKey {
   IS_CONNECTED_ACCOUNT_MIGRATED = 'IS_CONNECTED_ACCOUNT_MIGRATED',
   IS_RICH_TEXT_V1_MIGRATED = 'IS_RICH_TEXT_V1_MIGRATED',
   IS_RECORD_PAGE_LAYOUT_GLOBAL_EDITION_ENABLED = 'IS_RECORD_PAGE_LAYOUT_GLOBAL_EDITION_ENABLED',
+  IS_ROADMAP_VIEW_ENABLED = 'IS_ROADMAP_VIEW_ENABLED',
   // @deprecated - Migration is complete. Kept for backward compatibility
   // until all workspaces have the flag and the flag can be removed entirely.
   IS_DATASOURCE_MIGRATED = 'IS_DATASOURCE_MIGRATED',


### PR DESCRIPTION
Phase 0 of the SPOTVISION Roadmap/Gantt viewType initiative. Lays down the non-code groundwork that every subsequent phase depends on, behind the IS_ROADMAP_VIEW_ENABLED feature flag so later PRs can merge safely without exposing the unfinished feature to end users.

- Add IS_ROADMAP_VIEW_ENABLED to FeatureFlagKey enum and dev seeder.
- Keep the fixture in workspace-entity-manager.spec.ts exhaustive.
- Commit four Claude Code subagent definitions for architect, backend, frontend, and QA so each phase delegates to a role-scoped prompt.
- Open MERGE_NOTES.md to track every upstream file touched by the fork, so future rebases against twentyhq/twenty are planned, not discovered.
- Document the timeline-library decision in ADR 001 (chose dnd-kit + custom render over vis-timeline, SVAR Gantt, and gantt-task-react).