### PR TITLE
Fix: aggregate Calculate not updating in dashboard Table widgets

### DIFF
--- a/packages/twenty-front/src/modules/object-record/record-table-widget/components/RecordTableWidget.tsx
+++ b/packages/twenty-front/src/modules/object-record/record-table-widget/components/RecordTableWidget.tsx
@@ -1,3 +1,4 @@
+import { RecordIndexTableContainerEffect } from '@/object-record/record-index/components/RecordIndexTableContainerEffect';
 import { useRecordIndexContextOrThrow } from '@/object-record/record-index/contexts/RecordIndexContext';
 import { RecordTableWidgetSetReadOnlyColumnHeadersEffect } from '@/object-record/record-table-widget/components/RecordTableWidgetSetReadOnlyColumnHeadersEffect';
 import { RecordTableWithWrappers } from '@/object-record/record-table/components/RecordTableWithWrappers';
@@ -19,6 +20,7 @@ export const RecordTableWidget = () => {
       <RecordTableWidgetSetReadOnlyColumnHeadersEffect
         recordTableId={recordIndexId}
       />
+      <RecordIndexTableContainerEffect />
       <StyledTableContainer>
         <RecordTableWithWrappers
           recordTableId={recordIndexId}


### PR DESCRIPTION
## Context
Picking an aggregate option (Count, Sum, Percentage Not Empty, etc.) in a dashboard Table widget footer did nothing visually — the value never appeared or updated

## Fix
RecordTableWidget was missing RecordIndexTableContainerEffect, which reactively syncs currentView.viewFields[].aggregateOperation from the Apollo cache into the viewFieldAggregateOperationState jotai atom that the footer reads

<img width="612" height="261" alt="Screenshot 2026-04-17 at 14 17 47" src="https://github.com/user-attachments/assets/b4409b0e-82a6-4614-bc09-653be738134a" />
