### PR TITLE
Add SVG export and refine halftone studio controls

### DIFF
--- a/packages/twenty-website-new/src/app/(home)/_constants/problem.ts
+++ b/packages/twenty-website-new/src/app/(home)/_constants/problem.ts
@@ -1,7 +1,7 @@
 import type { ProblemDataType } from '@/sections/Problem/types';
 
 export const PROBLEM_DATA: ProblemDataType = {
-  eyebrow: { heading: { text: 'The Problem', fontFamily: 'sans' } },
+  eyebrow: { heading: { text: 'The Problem.', fontFamily: 'sans' } },
   heading: [
     { text: 'A custom CRM gives your org an edge, ', fontFamily: 'serif' },
     { text: 'but building one comes with tradeoffs', fontFamily: 'sans' },

--- a/packages/twenty-website-new/src/app/(home)/_constants/problem.ts
+++ b/packages/twenty-website-new/src/app/(home)/_constants/problem.ts
@@ -1,7 +1,7 @@
 import type { ProblemDataType } from '@/sections/Problem/types';
 
 export const PROBLEM_DATA: ProblemDataType = {
-  eyebrow: { heading: { text: 'The Problem:', fontFamily: 'sans' } },
+  eyebrow: { heading: { text: 'The Problem', fontFamily: 'sans' } },
   heading: [
     { text: 'A custom CRM gives your org an edge, ', fontFamily: 'serif' },
     { text: 'but building one comes with tradeoffs', fontFamily: 'sans' },

--- a/packages/twenty-website-new/src/app/halftone/_components/ControlsPanel.tsx
+++ b/packages/twenty-website-new/src/app/halftone/_components/ControlsPanel.tsx
@@ -28,6 +28,7 @@ type ControlsPanelProps = {
   onCopyShareLink: () => void;
   onDashColorChange: (value: string) => void;
   onHoverDashColorChange: (value: string) => void;
+  onCopyHalftoneImage: (width: number, height: number) => void;
   onExportHalftoneImage: (width: number, height: number) => void;
   onExportBackgroundChange: (value: boolean) => void;
   onExportHtml: () => void;
@@ -133,6 +134,7 @@ export function ControlsPanel({
   onCopyShareLink,
   onDashColorChange,
   onHoverDashColorChange,
+  onCopyHalftoneImage,
   onExportHalftoneImage,
   onExportBackgroundChange,
   onExportHtml,
@@ -236,6 +238,7 @@ export function ControlsPanel({
           exportBackground={exportBackground}
           exportName={exportName}
           imageFileName={imageFileName}
+          onCopyHalftoneImage={onCopyHalftoneImage}
           onExportHalftoneImage={onExportHalftoneImage}
           onExportBackgroundChange={onExportBackgroundChange}
           onExportHtml={onExportHtml}

--- a/packages/twenty-website-new/src/app/halftone/_components/ControlsPanel.tsx
+++ b/packages/twenty-website-new/src/app/halftone/_components/ControlsPanel.tsx
@@ -29,7 +29,9 @@ type ControlsPanelProps = {
   onDashColorChange: (value: string) => void;
   onHoverDashColorChange: (value: string) => void;
   onCopyHalftoneImage: (width: number, height: number) => void;
+  onCopyHalftoneSvg: (width: number, height: number) => void;
   onExportHalftoneImage: (width: number, height: number) => void;
+  onExportHalftoneSvg: (width: number, height: number) => void;
   onExportBackgroundChange: (value: boolean) => void;
   onExportHtml: () => void;
   onExportNameChange: (value: string) => void;
@@ -135,7 +137,9 @@ export function ControlsPanel({
   onDashColorChange,
   onHoverDashColorChange,
   onCopyHalftoneImage,
+  onCopyHalftoneSvg,
   onExportHalftoneImage,
+  onExportHalftoneSvg,
   onExportBackgroundChange,
   onExportHtml,
   onExportNameChange,
@@ -239,7 +243,9 @@ export function ControlsPanel({
           exportName={exportName}
           imageFileName={imageFileName}
           onCopyHalftoneImage={onCopyHalftoneImage}
+          onCopyHalftoneSvg={onCopyHalftoneSvg}
           onExportHalftoneImage={onExportHalftoneImage}
+          onExportHalftoneSvg={onExportHalftoneSvg}
           onExportBackgroundChange={onExportBackgroundChange}
           onExportHtml={onExportHtml}
           onExportNameChange={onExportNameChange}

--- a/packages/twenty-website-new/src/app/halftone/_components/HalftoneCanvas.tsx
+++ b/packages/twenty-website-new/src/app/halftone/_components/HalftoneCanvas.tsx
@@ -470,7 +470,7 @@ function getCanvasCursor(
   isDragging: boolean,
 ) {
   if (settings.sourceMode === 'image') {
-    return 'crosshair';
+    return 'default';
   }
 
   if (settings.animation.followDragEnabled) {

--- a/packages/twenty-website-new/src/app/halftone/_components/HalftoneCanvas.tsx
+++ b/packages/twenty-website-new/src/app/halftone/_components/HalftoneCanvas.tsx
@@ -111,6 +111,7 @@ const halftoneFragmentShader = `
   uniform float tile;
   uniform float s_3;
   uniform float s_4;
+  uniform float applyToDarkAreas;
   uniform vec3 dashColor;
   uniform vec3 hoverDashColor;
   uniform float time;
@@ -229,16 +230,13 @@ const halftoneFragmentShader = `
       hoverLightMask *
       mix(0.78, 1.18, motionBias) *
       0.22;
+    float toneValue =
+      (sceneSample.r + sceneSample.g + sceneSample.b) * (1.0 / 3.0);
+    if (applyToDarkAreas > 0.5) {
+      toneValue = 1.0 - toneValue;
+    }
     float bandRadius = clamp(
-      (
-        (
-          sceneSample.r +
-          sceneSample.g +
-          sceneSample.b +
-          localPower * length(vec2(0.5))
-        ) *
-        (1.0 / 3.0)
-      ) + lightLift,
+      toneValue + localPower * length(vec2(0.5)) + lightLift,
       0.0,
       1.0
     ) * 1.86 * 0.5;
@@ -527,6 +525,8 @@ function updateHalftone(
   resources.halftoneMaterial.uniforms.tile.value = settings.halftone.scale;
   resources.halftoneMaterial.uniforms.s_3.value = settings.halftone.power;
   resources.halftoneMaterial.uniforms.s_4.value = settings.halftone.width;
+  resources.halftoneMaterial.uniforms.applyToDarkAreas.value =
+    settings.halftone.toneTarget === 'dark' ? 1 : 0;
   (resources.halftoneMaterial.uniforms.dashColor.value as THREE.Color).set(
     settings.halftone.dashColor,
   );
@@ -883,6 +883,9 @@ export function HalftoneCanvas({
           tile: { value: initialSettings.halftone.scale },
           s_3: { value: initialSettings.halftone.power },
           s_4: { value: initialSettings.halftone.width },
+          applyToDarkAreas: {
+            value: initialSettings.halftone.toneTarget === 'dark' ? 1 : 0,
+          },
           dashColor: {
             value: new THREE.Color(initialSettings.halftone.dashColor),
           },

--- a/packages/twenty-website-new/src/app/halftone/_components/HalftoneStudio.tsx
+++ b/packages/twenty-website-new/src/app/halftone/_components/HalftoneStudio.tsx
@@ -172,6 +172,14 @@ const HiddenFileInput = styled.input`
 const DEFAULT_PREVIEW_DISTANCE = 6;
 const DEFAULT_IMAGE_ASSET_PATH = '/images/shared/halftone/twenty-logo.svg';
 const DEFAULT_IMAGE_FILENAME = 'twenty-logo.svg';
+const CLIPBOARD_IMAGE_EXTENSION_BY_MIME: Record<string, string> = {
+  'image/bmp': '.bmp',
+  'image/gif': '.gif',
+  'image/jpeg': '.jpg',
+  'image/png': '.png',
+  'image/svg+xml': '.svg',
+  'image/webp': '.webp',
+};
 type PendingFilePicker = {
   resolve: (file: File | null) => void;
 };
@@ -222,6 +230,42 @@ function getAssetFilenameFromUrl(assetUrl: string, fallbackFilename: string) {
   return assetFilename && assetFilename.length > 0
     ? assetFilename
     : fallbackFilename;
+}
+
+function isEditablePasteTarget(target: EventTarget | null) {
+  if (!(target instanceof HTMLElement)) {
+    return false;
+  }
+
+  return (
+    target.isContentEditable ||
+    target instanceof HTMLInputElement ||
+    target instanceof HTMLTextAreaElement ||
+    target.closest('[contenteditable=""], [contenteditable="true"]') !== null
+  );
+}
+
+function createPastedImageFile(file: File) {
+  const hasExtension = /\.[^.]+$/i.test(file.name);
+
+  if (hasExtension) {
+    return file;
+  }
+
+  const extension =
+    CLIPBOARD_IMAGE_EXTENSION_BY_MIME[file.type] ??
+    CLIPBOARD_IMAGE_EXTENSION_BY_MIME['image/png'];
+
+  return new File([file], `pasted-image-${Date.now()}${extension}`, {
+    type: file.type || 'image/png',
+    lastModified: Date.now(),
+  });
+}
+
+function hasTextSelection() {
+  const selection = window.getSelection();
+
+  return selection !== null && selection.toString().trim().length > 0;
 }
 
 function createInitialExportPose(): HalftoneExportPose {
@@ -324,6 +368,7 @@ export function HalftoneStudio() {
   const defaultImageFileReference = useRef<File | null>(null);
   const defaultImageFilePromiseReference = useRef<Promise<File> | null>(null);
   const snapshotReference = useRef<HalftoneSnapshotFn | null>(null);
+  const canvasLayerReference = useRef<HTMLDivElement>(null);
   const fileInputReference = useRef<HTMLInputElement>(null);
   const presetFileInputReference = useRef<HTMLInputElement>(null);
   const pendingFilePickerReference = useRef<PendingFilePicker | null>(null);
@@ -491,6 +536,93 @@ export function HalftoneStudio() {
         });
       });
   }, [exportName, previewDistance, state.settings]);
+
+  const handleCopyHalftoneImage = useCallback(
+    async (width: number, height: number) => {
+      const snapshotFn = snapshotReference.current;
+
+      if (!snapshotFn) {
+        return;
+      }
+
+      if (
+        typeof ClipboardItem === 'undefined' ||
+        typeof navigator.clipboard?.write !== 'function'
+      ) {
+        dispatch({
+          type: 'setStatus',
+          message: 'Image clipboard copy is not supported in this browser.',
+          isError: true,
+        });
+        return;
+      }
+
+      const blob = await snapshotFn(width, height, {
+        backgroundColor: state.settings.background.color,
+        includeBackground: exportBackground,
+      });
+
+      if (!blob) {
+        dispatch({
+          type: 'setStatus',
+          message: 'Could not copy the halftone image.',
+          isError: true,
+        });
+        return;
+      }
+
+      try {
+        await navigator.clipboard.write([
+          new ClipboardItem({
+            [blob.type || 'image/png']: blob,
+          }),
+        ]);
+        dispatch({
+          type: 'setStatus',
+          message: 'Image copied to clipboard.',
+        });
+        window.setTimeout(() => dispatch({ type: 'clearStatus' }), 2000);
+      } catch {
+        dispatch({
+          type: 'setStatus',
+          message: 'Could not copy the halftone image.',
+          isError: true,
+        });
+      }
+    },
+    [exportBackground, state.settings.background.color],
+  );
+
+  useEffect(() => {
+    const handleKeyDown = (event: KeyboardEvent) => {
+      const isCopyShortcut =
+        (event.metaKey || event.ctrlKey) &&
+        !event.shiftKey &&
+        !event.altKey &&
+        event.key.toLowerCase() === 'c';
+
+      if (!isCopyShortcut) {
+        return;
+      }
+
+      if (isEditablePasteTarget(event.target) || hasTextSelection()) {
+        return;
+      }
+
+      const canvasLayer = canvasLayerReference.current;
+      const width = Math.max(canvasLayer?.clientWidth ?? 0, 1);
+      const height = Math.max(canvasLayer?.clientHeight ?? 0, 1);
+
+      event.preventDefault();
+      void handleCopyHalftoneImage(width, height);
+    };
+
+    window.addEventListener('keydown', handleKeyDown);
+
+    return () => {
+      window.removeEventListener('keydown', handleKeyDown);
+    };
+  }, [handleCopyHalftoneImage]);
 
   const openFilePicker = useCallback((accept: string) => {
     return new Promise<File | null>((resolve) => {
@@ -681,6 +813,47 @@ export function HalftoneStudio() {
     },
     [state.settings.halftone, state.settings.sourceMode],
   );
+
+  useEffect(() => {
+    const handlePaste = (event: ClipboardEvent) => {
+      if (isEditablePasteTarget(event.target)) {
+        return;
+      }
+
+      const imageItem = Array.from(event.clipboardData?.items ?? []).find(
+        (item) => item.type.startsWith('image/'),
+      );
+
+      if (!imageItem) {
+        return;
+      }
+
+      const pastedFile = imageItem.getAsFile();
+
+      if (!pastedFile) {
+        dispatch({
+          type: 'setStatus',
+          message: 'Could not read the pasted image.',
+          isError: true,
+        });
+        return;
+      }
+
+      event.preventDefault();
+      activateUploadedImage(createPastedImageFile(pastedFile));
+      dispatch({
+        type: 'setStatus',
+        message: 'Image pasted from clipboard.',
+      });
+      window.setTimeout(() => dispatch({ type: 'clearStatus' }), 2000);
+    };
+
+    window.addEventListener('paste', handlePaste);
+
+    return () => {
+      window.removeEventListener('paste', handlePaste);
+    };
+  }, [activateUploadedImage]);
 
   const handleUploadSource = useCallback(async () => {
     const file = await openFilePicker(
@@ -1166,7 +1339,7 @@ export function HalftoneStudio() {
           {state.statusMessage}
         </Status>
 
-        <CanvasLayer>
+        <CanvasLayer ref={canvasLayerReference}>
           <HalftoneCanvas
             geometry={activeGeometry}
             initialPose={canvasInitialPose}
@@ -1204,6 +1377,9 @@ export function HalftoneStudio() {
                 value: { hoverDashColor: value },
               })
             }
+            onCopyHalftoneImage={(width, height) => {
+              void handleCopyHalftoneImage(width, height);
+            }}
             onExportHalftoneImage={(width, height) => {
               void handleExportHalftoneImage(width, height);
             }}

--- a/packages/twenty-website-new/src/app/halftone/_components/HalftoneStudio.tsx
+++ b/packages/twenty-website-new/src/app/halftone/_components/HalftoneStudio.tsx
@@ -12,6 +12,7 @@ import {
   getGeometryForSpec,
 } from '@/app/halftone/_lib/geometry-registry';
 import { REFERENCE_PREVIEW_DISTANCE } from '@/app/halftone/_lib/footprint';
+import { generateImageHalftoneSvg } from '@/app/halftone/_lib/imageSvgExport';
 import {
   DEFAULT_REACT_EXPORT_SETTINGS,
   deriveExportComponentName,
@@ -1165,6 +1166,124 @@ export function HalftoneStudio() {
     ],
   );
 
+  const buildHalftoneSvg = useCallback(
+    (width: number, height: number) => {
+      if (state.settings.sourceMode !== 'image' || !imageElement) {
+        return null;
+      }
+
+      return generateImageHalftoneSvg({
+        backgroundColor: state.settings.background.color,
+        image: imageElement,
+        includeBackground: exportBackground,
+        previewDistance,
+        settings: state.settings,
+        width,
+        height,
+      });
+    },
+    [
+      exportBackground,
+      imageElement,
+      previewDistance,
+      state.settings,
+    ],
+  );
+
+  const handleExportHalftoneSvg = useCallback(
+    (width: number, height: number) => {
+      const svg = buildHalftoneSvg(width, height);
+
+      if (!svg) {
+        dispatch({
+          type: 'setStatus',
+          message: 'Could not export the halftone SVG.',
+          isError: true,
+        });
+        return;
+      }
+
+      downloadBlob(
+        `${exportArtifactNames.fileBaseName}-${width}x${height}.svg`,
+        new Blob([svg], { type: 'image/svg+xml;charset=utf-8' }),
+      );
+      dispatch({
+        type: 'setStatus',
+        message: 'Halftone SVG downloaded.',
+      });
+      window.setTimeout(() => dispatch({ type: 'clearStatus' }), 2000);
+    },
+    [
+      buildHalftoneSvg,
+      exportArtifactNames.fileBaseName,
+    ],
+  );
+
+  const handleCopyHalftoneSvg = useCallback(
+    async (width: number, height: number) => {
+      const svg = buildHalftoneSvg(width, height);
+
+      if (!svg) {
+        dispatch({
+          type: 'setStatus',
+          message: 'Could not copy the halftone SVG.',
+          isError: true,
+        });
+        return;
+      }
+
+      const svgBlob = new Blob([svg], { type: 'image/svg+xml;charset=utf-8' });
+
+      if (
+        typeof ClipboardItem !== 'undefined' &&
+        typeof navigator.clipboard?.write === 'function'
+      ) {
+        try {
+          await navigator.clipboard.write([
+            new ClipboardItem({
+              'image/svg+xml': svgBlob,
+              'text/plain': new Blob([svg], { type: 'text/plain' }),
+            }),
+          ]);
+          dispatch({
+            type: 'setStatus',
+            message: 'SVG copied to clipboard.',
+          });
+          window.setTimeout(() => dispatch({ type: 'clearStatus' }), 2000);
+          return;
+        } catch {
+          // Fall through to plain-text clipboard copy below.
+        }
+      }
+
+      if (typeof navigator.clipboard?.writeText === 'function') {
+        try {
+          await navigator.clipboard.writeText(svg);
+          dispatch({
+            type: 'setStatus',
+            message: 'SVG markup copied to clipboard as text.',
+          });
+          window.setTimeout(() => dispatch({ type: 'clearStatus' }), 2000);
+          return;
+        } catch {
+          dispatch({
+            type: 'setStatus',
+            message: 'Could not copy the halftone SVG.',
+            isError: true,
+          });
+          return;
+        }
+      }
+
+      dispatch({
+        type: 'setStatus',
+        message: 'SVG clipboard copy is not supported in this browser.',
+        isError: true,
+      });
+    },
+    [buildHalftoneSvg],
+  );
+
   const handleExportHtml = useCallback(async () => {
     const componentName = exportArtifactNames.componentName;
     const kebabName = exportArtifactNames.fileBaseName;
@@ -1382,6 +1501,12 @@ export function HalftoneStudio() {
             }}
             onExportHalftoneImage={(width, height) => {
               void handleExportHalftoneImage(width, height);
+            }}
+            onExportHalftoneSvg={(width, height) => {
+              void handleExportHalftoneSvg(width, height);
+            }}
+            onCopyHalftoneSvg={(width, height) => {
+              void handleCopyHalftoneSvg(width, height);
             }}
             onExportBackgroundChange={setExportBackground}
             onExportHtml={() => {

--- a/packages/twenty-website-new/src/app/halftone/_components/controls/DesignTab.tsx
+++ b/packages/twenty-website-new/src/app/halftone/_components/controls/DesignTab.tsx
@@ -431,6 +431,20 @@ export function DesignTab({
         </SectionToggleHeader>
         {settings.halftone.enabled ? (
           <ControlGrid>
+            <SegmentedControl
+              onChange={(value) =>
+                onHalftoneChange({
+                  toneTarget: value === 'dark' ? 'dark' : 'light',
+                })
+              }
+              options={[
+                { label: 'Light', value: 'light' },
+                { label: 'Dark', value: 'dark' },
+              ]}
+              value={settings.halftone.toneTarget}
+            >
+              Areas
+            </SegmentedControl>
             <SliderControl
               max={72}
               min={8}

--- a/packages/twenty-website-new/src/app/halftone/_components/controls/ExportTab.tsx
+++ b/packages/twenty-website-new/src/app/halftone/_components/controls/ExportTab.tsx
@@ -81,6 +81,7 @@ type ExportTabProps = {
   exportBackground: boolean;
   exportName: string;
   imageFileName: string | null;
+  onCopyHalftoneImage: (width: number, height: number) => void;
   onExportHalftoneImage: (width: number, height: number) => void;
   onExportBackgroundChange: (value: boolean) => void;
   onExportHtml: () => void;
@@ -105,6 +106,7 @@ export function ExportTab({
   exportBackground,
   exportName,
   imageFileName,
+  onCopyHalftoneImage,
   onExportHalftoneImage,
   onExportBackgroundChange,
   onExportHtml,
@@ -137,11 +139,22 @@ export function ExportTab({
     defaultExportName,
   );
 
-  const handleDownloadHalftoneImage = () => {
+  const getSelectedResolution = () => {
     const [widthStr, heightStr] = resolution.split('x');
-    const width = parseInt(widthStr, 10);
-    const height = parseInt(heightStr, 10);
+    const width = parseInt(widthStr ?? '', 10);
+    const height = parseInt(heightStr ?? '', 10);
+
+    return { width, height };
+  };
+
+  const handleDownloadHalftoneImage = () => {
+    const { width, height } = getSelectedResolution();
     onExportHalftoneImage(width, height);
+  };
+
+  const handleCopyHalftoneImage = () => {
+    const { width, height } = getSelectedResolution();
+    onCopyHalftoneImage(width, height);
   };
 
   return (
@@ -176,8 +189,8 @@ export function ExportTab({
       <Section>
         <SectionTitle>
           {sectionLabel(
-            'Download Image',
-            'Downloads a PNG snapshot of the current halftone effect at the selected resolution.',
+            'Image Export',
+            'Downloads a PNG snapshot of the current halftone effect or copies it to the clipboard at the selected resolution.',
           )}
         </SectionTitle>
 
@@ -195,6 +208,9 @@ export function ExportTab({
           type="button"
         >
           Download Halftone Image
+        </ExportButton>
+        <ExportButton onClick={handleCopyHalftoneImage} type="button">
+          Copy Halftone Image
         </ExportButton>
       </Section>
 

--- a/packages/twenty-website-new/src/app/halftone/_components/controls/ExportTab.tsx
+++ b/packages/twenty-website-new/src/app/halftone/_components/controls/ExportTab.tsx
@@ -82,7 +82,9 @@ type ExportTabProps = {
   exportName: string;
   imageFileName: string | null;
   onCopyHalftoneImage: (width: number, height: number) => void;
+  onCopyHalftoneSvg: (width: number, height: number) => void;
   onExportHalftoneImage: (width: number, height: number) => void;
+  onExportHalftoneSvg: (width: number, height: number) => void;
   onExportBackgroundChange: (value: boolean) => void;
   onExportHtml: () => void;
   onExportNameChange: (value: string) => void;
@@ -107,7 +109,9 @@ export function ExportTab({
   exportName,
   imageFileName,
   onCopyHalftoneImage,
+  onCopyHalftoneSvg,
   onExportHalftoneImage,
+  onExportHalftoneSvg,
   onExportBackgroundChange,
   onExportHtml,
   onExportNameChange,
@@ -157,6 +161,16 @@ export function ExportTab({
     onCopyHalftoneImage(width, height);
   };
 
+  const handleDownloadHalftoneSvg = () => {
+    const { width, height } = getSelectedResolution();
+    onExportHalftoneSvg(width, height);
+  };
+
+  const handleCopyHalftoneSvg = () => {
+    const { width, height } = getSelectedResolution();
+    onCopyHalftoneSvg(width, height);
+  };
+
   return (
     <TabContent>
       <Section $first>
@@ -190,7 +204,9 @@ export function ExportTab({
         <SectionTitle>
           {sectionLabel(
             'Image Export',
-            'Downloads a PNG snapshot of the current halftone effect or copies it to the clipboard at the selected resolution.',
+            isImageMode
+              ? 'Downloads either a PNG snapshot or an SVG vector export of the current halftone effect, and can copy either format to the clipboard at the selected resolution.'
+              : 'Downloads a PNG snapshot of the current halftone effect or copies it to the clipboard at the selected resolution.',
           )}
         </SectionTitle>
 
@@ -202,16 +218,49 @@ export function ExportTab({
           Resolution
         </SelectControl>
 
-        <ExportButton
-          onClick={handleDownloadHalftoneImage}
-          style={{ marginTop: 12 }}
-          type="button"
-        >
-          Download Halftone Image
-        </ExportButton>
-        <ExportButton onClick={handleCopyHalftoneImage} type="button">
-          Copy Halftone Image
-        </ExportButton>
+        <div style={{ marginTop: 12 }}>
+          <SectionTitle $preserveCase>Download</SectionTitle>
+          <div style={{ display: 'flex', gap: 8 }}>
+            <ExportButton
+              onClick={handleDownloadHalftoneImage}
+              style={{ flex: 1, marginTop: 0 }}
+              type="button"
+            >
+              PNG
+            </ExportButton>
+            {isImageMode ? (
+              <ExportButton
+                onClick={handleDownloadHalftoneSvg}
+                style={{ flex: 1, marginTop: 0 }}
+                type="button"
+              >
+                SVG
+              </ExportButton>
+            ) : null}
+          </div>
+        </div>
+
+        <div style={{ marginTop: 14 }}>
+          <SectionTitle $preserveCase>Copy</SectionTitle>
+          <div style={{ display: 'flex', gap: 8 }}>
+            <ExportButton
+              onClick={handleCopyHalftoneImage}
+              style={{ flex: 1, marginTop: 0 }}
+              type="button"
+            >
+              PNG
+            </ExportButton>
+            {isImageMode ? (
+              <ExportButton
+                onClick={handleCopyHalftoneSvg}
+                style={{ flex: 1, marginTop: 0 }}
+                type="button"
+              >
+                SVG
+              </ExportButton>
+            ) : null}
+          </div>
+        </div>
       </Section>
 
       <Section>

--- a/packages/twenty-website-new/src/app/halftone/_lib/exporters.test.ts
+++ b/packages/twenty-website-new/src/app/halftone/_lib/exporters.test.ts
@@ -78,6 +78,24 @@ describe('halftone export naming', () => {
     ).toBe(DEFAULT_HALFTONE_SETTINGS.halftone.hoverDashColor);
   });
 
+  it('preserves dark-area halftone presets through export parsing', () => {
+    const output = generateReactComponent(
+      normalizeHalftoneStudioSettings({
+        ...DEFAULT_HALFTONE_SETTINGS,
+        halftone: {
+          ...DEFAULT_HALFTONE_SETTINGS.halftone,
+          toneTarget: 'dark',
+        },
+      }),
+      undefined,
+      'dark tone preset',
+    );
+
+    const parsed = parseExportedPreset(output);
+
+    expect(parsed.settings.halftone.toneTarget).toBe('dark');
+  });
+
   it('uses the initial pose as the export runtime rotation baseline', async () => {
     const reactOutput = generateReactComponent(
       DEFAULT_HALFTONE_SETTINGS,

--- a/packages/twenty-website-new/src/app/halftone/_lib/exporters.ts
+++ b/packages/twenty-website-new/src/app/halftone/_lib/exporters.ts
@@ -130,6 +130,7 @@ const halftoneFragmentShader = `
   uniform float tile;
   uniform float s_3;
   uniform float s_4;
+  uniform float applyToDarkAreas;
   uniform vec3 dashColor;
   uniform vec3 hoverDashColor;
   uniform float time;
@@ -245,16 +246,13 @@ const halftoneFragmentShader = `
     );
     float lightLift =
       hoverLightStrength * hoverLightMask * mix(0.78, 1.18, motionBias) * 0.22;
+    float toneValue =
+      (sceneSample.r + sceneSample.g + sceneSample.b) * (1.0 / 3.0);
+    if (applyToDarkAreas > 0.5) {
+      toneValue = 1.0 - toneValue;
+    }
     float bandRadius = clamp(
-      (
-        (
-          sceneSample.r +
-          sceneSample.g +
-          sceneSample.b +
-          localPower * length(vec2(0.5))
-        ) *
-        (1.0 / 3.0)
-      ) + lightLift,
+      toneValue + localPower * length(vec2(0.5)) + lightLift,
       0.0,
       1.0
     ) * 1.86 * 0.5;
@@ -2233,6 +2231,9 @@ async function mountHalftoneCanvas(options) {
       tile: { value: settings.halftone.scale },
       s_3: { value: settings.halftone.power },
       s_4: { value: settings.halftone.width },
+      applyToDarkAreas: {
+        value: settings.halftone.toneTarget === 'dark' ? 1 : 0,
+      },
       dashColor: { value: new THREE.Color(settings.halftone.dashColor) },
       hoverDashColor: {
         value: new THREE.Color(settings.halftone.hoverDashColor),
@@ -2821,6 +2822,9 @@ async function mountHalftoneCanvas(options) {
       tile: { value: settings.halftone.scale },
       s_3: { value: settings.halftone.power },
       s_4: { value: settings.halftone.width },
+      applyToDarkAreas: {
+        value: settings.halftone.toneTarget === 'dark' ? 1 : 0,
+      },
       dashColor: { value: new THREE.Color(settings.halftone.dashColor) },
       hoverDashColor: {
         value: new THREE.Color(settings.halftone.hoverDashColor),

--- a/packages/twenty-website-new/src/app/halftone/_lib/imageSvgExport.ts
+++ b/packages/twenty-website-new/src/app/halftone/_lib/imageSvgExport.ts
@@ -1,0 +1,296 @@
+import {
+  getContainedImageRect,
+  getImageFootprintScale,
+  getImagePreviewZoom,
+} from '@/app/halftone/_lib/footprint';
+import type { HalftoneStudioSettings } from '@/app/halftone/_lib/state';
+
+type PixelBounds = {
+  maxX: number;
+  maxY: number;
+  minX: number;
+  minY: number;
+};
+
+type PathGroup = {
+  commands: string[];
+  strokeOpacity: string;
+  strokeWidth: string;
+};
+
+type GenerateImageHalftoneSvgOptions = {
+  backgroundColor: string;
+  image: HTMLImageElement;
+  includeBackground: boolean;
+  previewDistance: number;
+  settings: HalftoneStudioSettings;
+  width: number;
+  height: number;
+};
+
+function clamp(value: number, min: number, max: number) {
+  return Math.min(Math.max(value, min), max);
+}
+
+function smoothstep(edge0: number, edge1: number, value: number) {
+  const x = clamp((value - edge0) / Math.max(edge1 - edge0, 0.000001), 0, 1);
+
+  return x * x * (3 - 2 * x);
+}
+
+function formatNumber(value: number) {
+  return Number(value.toFixed(3)).toString();
+}
+
+function escapeAttribute(value: string) {
+  return value
+    .replaceAll('&', '&amp;')
+    .replaceAll('"', '&quot;')
+    .replaceAll('<', '&lt;')
+    .replaceAll('>', '&gt;');
+}
+
+function getHorizontalAlphaSegments(
+  pixels: Uint8ClampedArray,
+  width: number,
+  height: number,
+  y: number,
+  xStart: number,
+  xEnd: number,
+  threshold = 8,
+) {
+  const clampedY = clamp(Math.round(y), 0, height - 1);
+  const minX = clamp(Math.floor(xStart), 0, width - 1);
+  const maxX = clamp(Math.ceil(xEnd) - 1, 0, width - 1);
+
+  if (maxX < minX) {
+    return [];
+  }
+
+  const segments: Array<{ x1: number; x2: number }> = [];
+  let segmentStart: number | null = null;
+
+  for (let x = minX; x <= maxX; x++) {
+    const alpha = pixels[(clampedY * width + x) * 4 + 3];
+    const isOpaque = alpha > threshold;
+
+    if (isOpaque && segmentStart === null) {
+      segmentStart = x;
+      continue;
+    }
+
+    if (!isOpaque && segmentStart !== null) {
+      segments.push({
+        x1: Math.max(xStart, segmentStart),
+        x2: Math.min(xEnd, x),
+      });
+      segmentStart = null;
+    }
+  }
+
+  if (segmentStart !== null) {
+    segments.push({
+      x1: Math.max(xStart, segmentStart),
+      x2: Math.min(xEnd, maxX + 1),
+    });
+  }
+
+  return segments.filter((segment) => segment.x2 > segment.x1);
+}
+
+export function generateImageHalftoneSvg({
+  backgroundColor,
+  image,
+  includeBackground,
+  previewDistance,
+  settings,
+  width,
+  height,
+}: GenerateImageHalftoneSvgOptions) {
+  if (
+    width <= 0 ||
+    height <= 0 ||
+    image.naturalWidth <= 0 ||
+    image.naturalHeight <= 0
+  ) {
+    return null;
+  }
+
+  const imageRect = getContainedImageRect({
+    imageHeight: image.naturalHeight,
+    imageWidth: image.naturalWidth,
+    viewportHeight: height,
+    viewportWidth: width,
+    zoom: getImagePreviewZoom(previewDistance),
+  });
+
+  if (!imageRect) {
+    return null;
+  }
+
+  const sourceCanvas = document.createElement('canvas');
+  sourceCanvas.width = width;
+  sourceCanvas.height = height;
+  const sourceContext = sourceCanvas.getContext('2d');
+
+  if (!sourceContext) {
+    return null;
+  }
+
+  sourceContext.clearRect(0, 0, width, height);
+  sourceContext.drawImage(
+    image,
+    imageRect.x,
+    imageRect.y,
+    imageRect.width,
+    imageRect.height,
+  );
+
+  const pixels = sourceContext.getImageData(0, 0, width, height).data;
+  const footprintScale = getImageFootprintScale({
+    imageHeight: image.naturalHeight,
+    imageWidth: image.naturalWidth,
+    previewDistance,
+    viewportHeight: height,
+    viewportWidth: width,
+  });
+  const halftoneSize = Math.max(
+    settings.halftone.scale * Math.max(footprintScale, 0.001),
+    1,
+  );
+  const localPower = clamp(settings.halftone.power, -1.5, 1.5);
+  const localWidth = clamp(settings.halftone.width, 0.05, 1.4);
+  const toneTargetMultiplier =
+    settings.halftone.toneTarget === 'dark' ? -1 : 1;
+  const lineColor = settings.halftone.dashColor;
+  const columns = Math.ceil(width / halftoneSize);
+  const rows = Math.ceil(height / halftoneSize);
+  const pathGroups = new Map<string, PathGroup>();
+  let lineBounds: PixelBounds | null = null;
+
+  for (let row = 0; row < rows; row++) {
+    for (let column = 0; column < columns; column++) {
+      const sampleX = clamp((column + 0.5) * halftoneSize, 0, width - 1);
+      const sampleY = clamp((row + 0.5) * halftoneSize, 0, height - 1);
+      const sampleIndex =
+        (Math.floor(sampleY) * width + Math.floor(sampleX)) * 4;
+      const alpha = pixels[sampleIndex + 3] / 255;
+      const mask = smoothstep(0.02, 0.08, alpha);
+
+      if (mask <= 0) {
+        continue;
+      }
+
+      const contrast = settings.halftone.imageContrast;
+      const red = clamp(
+        ((pixels[sampleIndex] / 255 - 0.5) * contrast) + 0.5,
+        0,
+        1,
+      );
+      const green = clamp(
+        ((pixels[sampleIndex + 1] / 255 - 0.5) * contrast) + 0.5,
+        0,
+        1,
+      );
+      const blue = clamp(
+        ((pixels[sampleIndex + 2] / 255 - 0.5) * contrast) + 0.5,
+        0,
+        1,
+      );
+      let toneValue = (red + green + blue) / 3;
+
+      if (toneTargetMultiplier < 0) {
+        toneValue = 1 - toneValue;
+      }
+
+      const bandRadius =
+        clamp(toneValue + localPower * Math.SQRT1_2, 0, 1) * 0.93;
+
+      if (bandRadius <= 0.0001) {
+        continue;
+      }
+
+      const strokeWidth = 2 * localWidth * bandRadius * halftoneSize;
+
+      if (strokeWidth <= 0.001) {
+        continue;
+      }
+
+      const centerY = (row + 0.5) * halftoneSize;
+      const startX = (column + 0.5 - bandRadius) * halftoneSize;
+      const endX = (column + 0.5 + bandRadius) * halftoneSize;
+      const halfStroke = strokeWidth * 0.5;
+      const segments = getHorizontalAlphaSegments(
+        pixels,
+        width,
+        height,
+        centerY,
+        startX,
+        endX,
+      );
+      const strokeWidthValue = formatNumber(strokeWidth);
+      const strokeOpacityValue = formatNumber(mask);
+      const styleKey = `${strokeWidthValue}|${strokeOpacityValue}`;
+      let pathGroup = pathGroups.get(styleKey);
+
+      if (!pathGroup) {
+        pathGroup = {
+          commands: [],
+          strokeOpacity: strokeOpacityValue,
+          strokeWidth: strokeWidthValue,
+        };
+        pathGroups.set(styleKey, pathGroup);
+      }
+
+      for (const segment of segments) {
+        const command = `M ${formatNumber(segment.x1)} ${formatNumber(centerY)} H ${formatNumber(segment.x2)}`;
+        const bounds = {
+          minX: Math.floor(segment.x1 - halfStroke),
+          minY: Math.floor(centerY - halfStroke),
+          maxX: Math.ceil(segment.x2 + halfStroke),
+          maxY: Math.ceil(centerY + halfStroke),
+        };
+
+        lineBounds = lineBounds
+          ? {
+              minX: Math.min(lineBounds.minX, bounds.minX),
+              minY: Math.min(lineBounds.minY, bounds.minY),
+              maxX: Math.max(lineBounds.maxX, bounds.maxX),
+              maxY: Math.max(lineBounds.maxY, bounds.maxY),
+            }
+          : bounds;
+
+        pathGroup.commands.push(command);
+      }
+    }
+  }
+
+  const fullBounds = {
+    minX: 0,
+    minY: 0,
+    maxX: width - 1,
+    maxY: height - 1,
+  };
+  const croppedBounds = includeBackground
+    ? fullBounds
+    : (lineBounds ?? fullBounds);
+  const exportWidth = croppedBounds.maxX - croppedBounds.minX + 1;
+  const exportHeight = croppedBounds.maxY - croppedBounds.minY + 1;
+  const paths = Array.from(pathGroups.values()).map(
+    (group) =>
+      `<path d="${group.commands.join(' ')}" fill="none" stroke="${escapeAttribute(lineColor)}" stroke-opacity="${group.strokeOpacity}" stroke-width="${group.strokeWidth}" stroke-linecap="round" />`,
+  );
+
+  return [
+    `<svg xmlns="http://www.w3.org/2000/svg" width="${formatNumber(exportWidth)}" height="${formatNumber(exportHeight)}" viewBox="0 0 ${formatNumber(exportWidth)} ${formatNumber(exportHeight)}" fill="none">`,
+    includeBackground
+      ? `<rect width="${formatNumber(exportWidth)}" height="${formatNumber(exportHeight)}" fill="${escapeAttribute(backgroundColor)}" />`
+      : '',
+    `<g transform="translate(${formatNumber(-croppedBounds.minX)} ${formatNumber(-croppedBounds.minY)})">`,
+    ...paths,
+    '</g>',
+    '</svg>',
+  ]
+    .filter(Boolean)
+    .join('');
+}

--- a/packages/twenty-website-new/src/app/halftone/_lib/state.test.ts
+++ b/packages/twenty-website-new/src/app/halftone/_lib/state.test.ts
@@ -76,5 +76,27 @@ describe('halftone studio state defaults', () => {
     expect(normalized.halftone.hoverDashColor).toBe(
       DEFAULT_HALFTONE_SETTINGS.halftone.hoverDashColor,
     );
+    expect(normalized.halftone.toneTarget).toBe(
+      DEFAULT_HALFTONE_SETTINGS.halftone.toneTarget,
+    );
+  });
+
+  it('preserves a dark-area halftone target from newer presets', () => {
+    const normalized = normalizeHalftoneStudioSettings(
+      JSON.parse(`{
+        "halftone": {
+          "enabled": true,
+          "scale": 24.72,
+          "power": -0.07,
+          "toneTarget": "dark",
+          "width": 0.46,
+          "imageContrast": 1,
+          "dashColor": "#112233",
+          "hoverDashColor": "#445566"
+        }
+      }`) as Partial<HalftoneStudioSettings>,
+    );
+
+    expect(normalized.halftone.toneTarget).toBe('dark');
   });
 });

--- a/packages/twenty-website-new/src/app/halftone/_lib/state.ts
+++ b/packages/twenty-website-new/src/app/halftone/_lib/state.ts
@@ -1,6 +1,7 @@
 export type HalftoneTabId = 'design' | 'animations' | 'export';
 export type HalftoneSourceMode = 'shape' | 'image';
 export type HalftoneMaterialSurface = 'solid' | 'glass';
+export type HalftoneToneTarget = 'light' | 'dark';
 export type HalftoneRotateAxis =
   | 'x'
   | 'y'
@@ -35,6 +36,7 @@ export interface HalftoneEffectSettings {
   enabled: boolean;
   scale: number;
   power: number;
+  toneTarget: HalftoneToneTarget;
   width: number;
   imageContrast: number;
   dashColor: string;
@@ -199,6 +201,7 @@ export const DEFAULT_SHAPE_HALFTONE_SETTINGS: HalftoneEffectSettings = {
   enabled: true,
   scale: 24.72,
   power: -0.07,
+  toneTarget: 'light',
   width: 0.46,
   imageContrast: 1,
   dashColor: '#4A38F5',
@@ -209,6 +212,7 @@ export const DEFAULT_IMAGE_HALFTONE_SETTINGS: HalftoneEffectSettings = {
   enabled: true,
   scale: 24.72,
   power: -0.07,
+  toneTarget: 'light',
   width: 0.46,
   imageContrast: 1,
   dashColor: '#4A38F5',
@@ -407,9 +411,10 @@ export const LEGACY_HALFTONE_SETTING_KEYS = [
 
 export function isRoundedBandHalftoneSettings(value: unknown): value is Omit<
   HalftoneEffectSettings,
-  'hoverDashColor'
+  'hoverDashColor' | 'toneTarget'
 > & {
   hoverDashColor?: string;
+  toneTarget?: HalftoneToneTarget;
 } {
   if (!value || typeof value !== 'object') {
     return false;
@@ -424,6 +429,9 @@ export function isRoundedBandHalftoneSettings(value: unknown): value is Omit<
     typeof candidate.width === 'number' &&
     typeof candidate.imageContrast === 'number' &&
     typeof candidate.dashColor === 'string' &&
+    (candidate.toneTarget === 'light' ||
+      candidate.toneTarget === 'dark' ||
+      typeof candidate.toneTarget === 'undefined') &&
     (typeof candidate.hoverDashColor === 'string' ||
       typeof candidate.hoverDashColor === 'undefined')
   );
@@ -443,6 +451,7 @@ function normalizeHalftoneEffectSettings(
     enabled: settings?.enabled ?? defaults.enabled,
     scale: settings?.scale ?? defaults.scale,
     power: settings?.power ?? defaults.power,
+    toneTarget: settings?.toneTarget ?? defaults.toneTarget,
     width: settings?.width ?? defaults.width,
     imageContrast: settings?.imageContrast ?? defaults.imageContrast,
     dashColor: settings?.dashColor ?? defaults.dashColor,

--- a/packages/twenty-website-new/src/illustrations/Helped/HelpedHalftoneModel.tsx
+++ b/packages/twenty-website-new/src/illustrations/Helped/HelpedHalftoneModel.tsx
@@ -10,6 +10,7 @@ import {
   DEFAULT_SOLID_BACKGROUND_SETTINGS,
   DEFAULT_SOLID_MATERIAL_SETTINGS,
   type HalftoneMaterialSurface,
+  type HalftoneToneTarget,
   type HalftoneStudioSettings,
 } from '@/app/halftone/_lib/state';
 import { styled } from '@linaria/react';
@@ -70,6 +71,7 @@ export type HelpedHalftoneSettings = {
     enabled: boolean;
     scale: number;
     power: number;
+    toneTarget?: HalftoneToneTarget;
     width: number;
     imageContrast?: number;
     dashColor: string;
@@ -167,6 +169,7 @@ const halftoneFragmentShader = /* glsl */ `
   uniform float tile;
   uniform float s_3;
   uniform float s_4;
+  uniform float applyToDarkAreas;
   uniform vec3 dashColor;
   uniform float time;
   uniform float waveAmount;
@@ -259,16 +262,13 @@ const halftoneFragmentShader = /* glsl */ `
     float mask = smoothstep(0.02, 0.08, sceneSample.a);
     float lightLift =
       hoverLightStrength * hoverLightMask * mix(0.78, 1.18, motionBias) * 0.22;
+    float toneValue =
+      (sceneSample.r + sceneSample.g + sceneSample.b) * (1.0 / 3.0);
+    if (applyToDarkAreas > 0.5) {
+      toneValue = 1.0 - toneValue;
+    }
     float bandRadius = clamp(
-      (
-        (
-          sceneSample.r +
-          sceneSample.g +
-          sceneSample.b +
-          s_3 * length(vec2(0.5))
-        ) *
-        (1.0 / 3.0)
-      ) + lightLift,
+      toneValue + s_3 * length(vec2(0.5)) + lightLift,
       0.0,
       1.0
     ) * 1.86 * 0.5;
@@ -782,6 +782,9 @@ function createStudioSettings(
     halftone: {
       ...DEFAULT_SHAPE_HALFTONE_SETTINGS,
       ...settings.halftone,
+      toneTarget:
+        settings.halftone.toneTarget ??
+        DEFAULT_SHAPE_HALFTONE_SETTINGS.toneTarget,
       hoverDashColor:
         settings.halftone.hoverDashColor ?? settings.halftone.dashColor,
       imageContrast:
@@ -922,6 +925,9 @@ function HelpedHalftoneCanvas({
         tile: { value: settings.halftone.scale },
         s_3: { value: settings.halftone.power },
         s_4: { value: settings.halftone.width },
+        applyToDarkAreas: {
+          value: settings.halftone.toneTarget === 'dark' ? 1 : 0,
+        },
         dashColor: { value: new THREE.Color(settings.halftone.dashColor) },
         time: { value: 0 },
         waveAmount: {

--- a/packages/twenty-website-new/src/illustrations/Testimonials/Partner.tsx
+++ b/packages/twenty-website-new/src/illustrations/Testimonials/Partner.tsx
@@ -39,6 +39,7 @@ const PARTNER_QUOTE_SETTINGS: HalftoneStudioSettings = {
     enabled: true,
     scale: 24.72,
     power: -0.07,
+    toneTarget: 'light',
     width: 0.46,
     imageContrast: 1,
     dashColor: '#4A38F5',

--- a/packages/twenty-website-new/src/illustrations/Testimonials/PartnerEffect.tsx
+++ b/packages/twenty-website-new/src/illustrations/Testimonials/PartnerEffect.tsx
@@ -32,6 +32,7 @@ const PARTNER_EFFECT_SETTINGS: HalftoneStudioSettings = {
     enabled: true,
     scale: 8,
     power: -0.07,
+    toneTarget: 'light',
     width: 0.46,
     imageContrast: 1,
     dashColor: '#FFFFFF',

--- a/packages/twenty-website-new/src/sections/ThreeCards/components/FeatureCard/LiveDataHeroTable.tsx
+++ b/packages/twenty-website-new/src/sections/ThreeCards/components/FeatureCard/LiveDataHeroTable.tsx
@@ -1,14 +1,13 @@
 'use client';
 
-import { SHARED_COMPANY_LOGO_URLS } from '@/lib/shared-asset-paths';
 import { theme } from '@/theme';
 import { styled } from '@linaria/react';
 import {
-  IconBuildingSkyscraper,
+  IconAt,
   IconCheckbox,
   IconChevronDown,
-  IconLink,
   IconPlus,
+  IconUser,
 } from '@tabler/icons-react';
 import {
   useEffect,
@@ -32,6 +31,8 @@ const ROW_ENTER_STAGGER_MS = 160;
 const COLORS = {
   accentBorder: VISUAL_TOKENS.border.color.blue,
   accentSurfaceSoft: VISUAL_TOKENS.background.transparent.blue,
+  avatarBackground: '#1f1f1f',
+  avatarText: '#ffffff',
   background: VISUAL_TOKENS.background.primary,
   backgroundSecondary: VISUAL_TOKENS.background.secondary,
   borderLight: VISUAL_TOKENS.border.color.light,
@@ -50,67 +51,67 @@ const COLORS = {
 } as const;
 
 const TABLE_COLUMNS = [
-  { id: 'company', isFirstColumn: true, label: 'Companies', width: 180 },
-  { id: 'type', isFirstColumn: false, label: 'Type', width: 132 },
-  { id: 'url', isFirstColumn: false, label: 'Domain', width: 150 },
+  { id: 'contact', isFirstColumn: true, label: 'Contacts', width: 180 },
+  { id: 'segment', isFirstColumn: false, label: 'Segment', width: 132 },
+  { id: 'email', isFirstColumn: false, label: 'Email', width: 190 },
 ] as const;
 
 type TableRow = {
-  company: string;
-  domain: string;
+  contact: string;
+  email: string;
+  initials: string;
   isNew?: boolean;
-  logoSrc: string;
-  status: string;
+  segment: string;
 };
 
 const BASE_TABLE_ROWS: ReadonlyArray<TableRow> = [
   {
-    company: 'Anthropic',
-    domain: 'anthropic.com',
-    logoSrc: SHARED_COMPANY_LOGO_URLS.anthropic,
-    status: 'Customer',
+    contact: 'Ava Martinez',
+    email: 'ava@resend.com',
+    initials: 'AM',
+    segment: 'VIP',
   },
   {
-    company: 'Slack',
-    domain: 'slack.com',
-    logoSrc: SHARED_COMPANY_LOGO_URLS.slack,
-    status: 'Customer',
+    contact: 'Noah Kim',
+    email: 'noah@resend.com',
+    initials: 'NK',
+    segment: 'Champion',
   },
   {
-    company: 'Notion',
-    domain: 'notion.so',
-    logoSrc: SHARED_COMPANY_LOGO_URLS.notion,
-    status: 'Customer',
+    contact: 'Lena Patel',
+    email: 'lena@resend.com',
+    initials: 'LP',
+    segment: 'Champion',
   },
   {
-    company: 'Sequoia',
-    domain: 'sequoiacap.com',
-    logoSrc: SHARED_COMPANY_LOGO_URLS.sequoia,
-    status: 'Customer',
+    contact: 'Miles Chen',
+    email: 'miles@resend.com',
+    initials: 'MC',
+    segment: 'Warm',
   },
   {
-    company: 'Cursor',
-    domain: 'cursor.com',
-    logoSrc: SHARED_COMPANY_LOGO_URLS.cursor,
-    status: 'Customer',
+    contact: 'Zoe Rivera',
+    email: 'zoe@resend.com',
+    initials: 'ZR',
+    segment: 'Warm',
   },
 ];
 
 const EXPANDED_TABLE_ROWS: ReadonlyArray<TableRow> = [
   ...BASE_TABLE_ROWS,
   {
-    company: 'Twenty',
-    domain: 'twenty.com',
+    contact: 'Eli Brooks',
+    email: 'eli@resend.com',
+    initials: 'EB',
     isNew: true,
-    logoSrc: SHARED_COMPANY_LOGO_URLS.twenty,
-    status: 'Customer',
+    segment: 'Prospect',
   },
   {
-    company: 'Linear',
-    domain: 'linear.app',
+    contact: 'Ivy Foster',
+    email: 'ivy@resend.com',
+    initials: 'IF',
     isNew: true,
-    logoSrc: SHARED_COMPANY_LOGO_URLS.linear,
-    status: 'Customer',
+    segment: 'New',
   },
 ];
 
@@ -332,17 +333,27 @@ const LogoBase = styled.div`
   align-items: center;
   display: inline-flex;
   flex: 0 0 auto;
-  height: 14px;
+  height: 16px;
   justify-content: center;
   overflow: hidden;
-  width: 14px;
+  width: 16px;
 `;
 
-const CompanyLogoImage = styled.img`
-  display: block;
-  height: 100%;
-  object-fit: contain;
-  width: 14px;
+const ContactAvatar = styled.div`
+  align-items: center;
+  background: ${COLORS.avatarBackground};
+  border-radius: 999px;
+  color: ${COLORS.avatarText};
+  display: inline-flex;
+  font-family: ${APP_FONT};
+  font-size: 8px;
+  font-weight: ${theme.font.weight.medium};
+  height: 16px;
+  justify-content: center;
+  letter-spacing: 0.02em;
+  line-height: 1;
+  text-transform: uppercase;
+  width: 16px;
 `;
 
 const StatusChip = styled.div<{ $edited?: boolean; $hoveredByAlice?: boolean }>`
@@ -378,9 +389,9 @@ function HeaderIcon({
 }: {
   columnId: (typeof TABLE_COLUMNS)[number]['id'];
 }) {
-  if (columnId === 'url') {
+  if (columnId === 'email') {
     return (
-      <IconLink
+      <IconAt
         aria-hidden
         color={COLORS.textTertiary}
         size={16}
@@ -389,7 +400,7 @@ function HeaderIcon({
     );
   }
 
-  if (columnId === 'type') {
+  if (columnId === 'segment') {
     return (
       <IconCheckbox
         aria-hidden
@@ -401,7 +412,7 @@ function HeaderIcon({
   }
 
   return (
-    <IconBuildingSkyscraper
+    <IconUser
       aria-hidden
       color={COLORS.textTertiary}
       size={16}
@@ -432,7 +443,7 @@ function PlusMini({ size = 12 }: { size?: number }) {
   );
 }
 
-function CompanyCell({ label, logoSrc }: { label: string; logoSrc: string }) {
+function ContactCell({ initials, label }: { initials: string; label: string }) {
   return (
     <CellHoverAnchor>
       <CheckboxContainer>
@@ -443,12 +454,7 @@ function CompanyCell({ label, logoSrc }: { label: string; logoSrc: string }) {
         label={label}
         leftComponent={
           <LogoBase>
-            <CompanyLogoImage
-              alt=""
-              decoding="async"
-              loading="lazy"
-              src={logoSrc}
-            />
+            <ContactAvatar aria-hidden>{initials}</ContactAvatar>
           </LogoBase>
         }
         variant={ChipVariant.Highlighted}
@@ -584,7 +590,7 @@ export function LiveDataHeroTable({
       <TableViewport
         ref={viewportRef}
         $dragging={dragging}
-        aria-label="Interactive preview of the companies table"
+        aria-label="Interactive preview of the Resend contacts table"
         onPointerCancel={endDragging}
         onPointerDown={handlePointerDown}
         onPointerLeave={endDragging}
@@ -638,7 +644,7 @@ export function LiveDataHeroTable({
 
             return (
               <DataRow
-                key={row.company}
+                key={row.contact}
                 onMouseEnter={() => setHoveredRowIndex(index)}
                 onMouseLeave={() =>
                   setHoveredRowIndex((current) =>
@@ -652,7 +658,7 @@ export function LiveDataHeroTable({
                   $width={TABLE_COLUMNS[0].width}
                 >
                   <RowMotion $delayMs={enterDelayMs} $entering={row.isNew}>
-                    <CompanyCell label={row.company} logoSrc={row.logoSrc} />
+                    <ContactCell initials={row.initials} label={row.contact} />
                   </RowMotion>
                 </TableCell>
                 <TableCell $hovered={hovered} $width={TABLE_COLUMNS[1].width}>
@@ -663,13 +669,13 @@ export function LiveDataHeroTable({
                     >
                       {index === 0 && isFirstTagEdited
                         ? editedStatusLabel
-                        : row.status}
+                        : row.segment}
                     </StatusChip>
                   </RowMotion>
                 </TableCell>
                 <TableCell $hovered={hovered} $width={TABLE_COLUMNS[2].width}>
                   <RowMotion $delayMs={enterDelayMs} $entering={row.isNew}>
-                    <LinkCell label={row.domain} />
+                    <LinkCell label={row.email} />
                   </RowMotion>
                 </TableCell>
                 <EmptyFillCell $hovered={hovered} $width={fillerWidth}>

--- a/packages/twenty-website-new/src/sections/ThreeCards/components/FeatureCard/LiveDataVisual.tsx
+++ b/packages/twenty-website-new/src/sections/ThreeCards/components/FeatureCard/LiveDataVisual.tsx
@@ -3,11 +3,11 @@
 import { theme } from '@/theme';
 import { styled } from '@linaria/react';
 import {
+  IconBuildingSkyscraper,
   IconChevronDown,
-  IconHeartHandshake,
   IconList,
+  IconMail,
   IconPlus,
-  IconUser,
   IconX,
 } from '@tabler/icons-react';
 import { type RefObject, useEffect, useRef, useState } from 'react';
@@ -181,9 +181,7 @@ const TablePanel = styled.div<{ $active?: boolean }>`
   position: absolute;
   right: 0px;
   transform: ${({ $active }) =>
-    `translate3d(0, 0, 0) scale(${
-      $active ? TABLE_PANEL_HOVER_SCALE : 1
-    })`};
+    `translate3d(0, 0, 0) scale(${$active ? TABLE_PANEL_HOVER_SCALE : 1})`};
   transform-origin: bottom right;
   transition:
     box-shadow 260ms cubic-bezier(0.22, 1, 0.36, 1),
@@ -710,8 +708,8 @@ export function LiveDataVisual({
   pointerTargetRef,
 }: LiveDataVisualProps) {
   const rootRef = useRef<HTMLDivElement>(null);
-  const typeFilterRef = useRef<HTMLDivElement>(null);
-  const employeesFilterRef = useRef<HTMLDivElement>(null);
+  const companyFilterRef = useRef<HTMLDivElement>(null);
+  const opensFilterRef = useRef<HTMLDivElement>(null);
   const [isBobHovered, setIsBobHovered] = useState(false);
   const [isTomHovered, setIsTomHovered] = useState(false);
   const [phase, setPhase] = useState<LiveDataPhase>('idle');
@@ -783,23 +781,18 @@ export function LiveDataVisual({
 
   useEffect(() => {
     const measureAddFilterLefts = () => {
-      const typeFilter = typeFilterRef.current;
-      const employeesFilter = employeesFilterRef.current;
+      const companyFilter = companyFilterRef.current;
+      const opensFilter = opensFilterRef.current;
 
-      if (
-        !typeFilter ||
-        !employeesFilter ||
-        employeesFilter.offsetWidth === 0
-      ) {
+      if (!companyFilter || !opensFilter || opensFilter.offsetWidth === 0) {
         return;
       }
 
       const nextLefts = {
-        docked: typeFilter.offsetLeft + typeFilter.offsetWidth + FILTER_ROW_GAP,
+        docked:
+          companyFilter.offsetLeft + companyFilter.offsetWidth + FILTER_ROW_GAP,
         parked:
-          employeesFilter.offsetLeft +
-          employeesFilter.offsetWidth +
-          FILTER_ROW_GAP,
+          opensFilter.offsetLeft + opensFilter.offsetWidth + FILTER_ROW_GAP,
       };
 
       setAddFilterLefts((current) =>
@@ -837,10 +830,10 @@ export function LiveDataVisual({
     phase === 'return-bob' ||
     phase === 'settle';
   const isBobCursorVisible = active;
-  const isEmployeesFilterRemoving = phase === 'remove-filter';
-  const isEmployeesFilterVisible =
+  const isOpensFilterRemoving = phase === 'remove-filter';
+  const isOpensFilterVisible =
     phase !== 'remove-filter' && phase !== 'return-bob' && phase !== 'settle';
-  const hasEmployeesFilterBeenRemoved =
+  const hasOpensFilterBeenRemoved =
     phase === 'remove-filter' || phase === 'return-bob' || phase === 'settle';
   const isFirstTagRenamed =
     phase === 'rename-tag' ||
@@ -857,7 +850,7 @@ export function LiveDataVisual({
   const addFilterLeft = isAddFilterDocked
     ? (addFilterLefts?.docked ?? DEFAULT_ADD_FILTER_LEFTS.docked)
     : (addFilterLefts?.parked ?? DEFAULT_ADD_FILTER_LEFTS.parked);
-  const viewCount = hasEmployeesFilterBeenRemoved ? 11 : 9;
+  const viewCount = hasOpensFilterBeenRemoved ? 11 : 9;
 
   return (
     <VisualRoot aria-hidden ref={rootRef}>
@@ -895,10 +888,7 @@ export function LiveDataVisual({
                 $bottom={bobCursor.bottom}
                 $right={bobCursor.right}
               >
-                <MarkerCursorSlot
-                  $pressed={phase === 'remove-filter'}
-                  $visible
-                >
+                <MarkerCursorSlot $pressed={phase === 'remove-filter'} $visible>
                   <MarkerCursor
                     color={COLORS.bobCursor}
                     rotation={bobCursor.rotation}
@@ -924,7 +914,7 @@ export function LiveDataVisual({
                         stroke={TABLER_STROKE}
                       />
                     </ViewSwitcherIcon>
-                    <ViewLabel>All</ViewLabel>
+                    <ViewLabel>All contacts</ViewLabel>
                     <ViewDot />
                     <ViewCount>{viewCount}</ViewCount>
                   </ViewSwitcherLeft>
@@ -940,19 +930,19 @@ export function LiveDataVisual({
               </ViewRow>
 
               <FilterRow>
-                <FilterChip ref={typeFilterRef}>
+                <FilterChip ref={companyFilterRef}>
                   <FilterChipLabel>
                     <FilterChipIcon>
-                      <IconHeartHandshake
+                      <IconBuildingSkyscraper
                         aria-hidden
                         color={COLORS.blue}
                         size={14}
                         stroke={FILTER_ICON_STROKE}
                       />
                     </FilterChipIcon>
-                    <FilterName>Type</FilterName>
+                    <FilterName>Company</FilterName>
                   </FilterChipLabel>
-                  <FilterValue>is Customer</FilterValue>
+                  <FilterValue>is Resend</FilterValue>
                   <FilterCloseButton type="button">
                     <IconX
                       aria-hidden
@@ -964,26 +954,26 @@ export function LiveDataVisual({
                 </FilterChip>
 
                 <FilterChipMotion
-                  ref={employeesFilterRef}
-                  $removing={isEmployeesFilterRemoving}
-                  $visible={isEmployeesFilterVisible}
+                  ref={opensFilterRef}
+                  $removing={isOpensFilterRemoving}
+                  $visible={isOpensFilterVisible}
                 >
                   <FilterChip
                     $pressed={phase === 'remove-filter'}
-                    $removing={isEmployeesFilterRemoving}
+                    $removing={isOpensFilterRemoving}
                   >
                     <FilterChipLabel>
                       <FilterChipIcon>
-                        <IconUser
+                        <IconMail
                           aria-hidden
                           color={COLORS.blue}
                           size={14}
                           stroke={FILTER_ICON_STROKE}
                         />
                       </FilterChipIcon>
-                      <FilterName>Employees</FilterName>
+                      <FilterName>Opens</FilterName>
                     </FilterChipLabel>
-                    <FilterValue>{'>500'}</FilterValue>
+                    <FilterValue>{'>5'}</FilterValue>
                     <FilterCloseButton
                       $pressed={phase === 'remove-filter'}
                       type="button"
@@ -1020,7 +1010,7 @@ export function LiveDataVisual({
                   editedStatusLabel={isFirstTagRenamed ? typedTagLabel : ''}
                   isFirstTagEdited={isFirstTagEdited}
                   isFirstTagHoveredByAlice={isFirstTagHoveredByAlice}
-                  showExtendedRows={hasEmployeesFilterBeenRemoved}
+                  showExtendedRows={hasOpensFilterBeenRemoved}
                 />
               </TableBodyArea>
             </TablePanel>


### PR DESCRIPTION
## Summary
- Added image-mode SVG export and clipboard copy support for the halftone generator.
- Reworked the export panel UX into separate `Download` and `Copy` sections with format-only buttons.
- Simplified the SVG output to reduce redundant segments while preserving the rendered result.
- Updated related halftone canvas, state, exporter, and illustration code to support the new flow.

## Testing
- `yarn nx typecheck twenty-website-new`
- `yarn nx build twenty-website-new`