### PR TITLE
Harden cross-app role ownership validation on role create and update

### DIFF
--- a/packages/twenty-server/src/engine/workspace-manager/workspace-migration/workspace-migration-builder/validators/services/flat-role-validator.service.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/workspace-migration/workspace-migration-builder/validators/services/flat-role-validator.service.ts
@@ -10,6 +10,7 @@ import { type FailedFlatEntityValidation } from 'src/engine/workspace-manager/wo
 import { getEmptyFlatEntityValidationError } from 'src/engine/workspace-manager/workspace-migration/workspace-migration-builder/builders/utils/get-flat-entity-validation-error.util';
 import { type FlatEntityUpdateValidationArgs } from 'src/engine/workspace-manager/workspace-migration/workspace-migration-builder/types/universal-flat-entity-update-validation-args.type';
 import { type UniversalFlatEntityValidationArgs } from 'src/engine/workspace-manager/workspace-migration/workspace-migration-builder/types/universal-flat-entity-validation-args.type';
+import { validateRoleBelongsToCallerApplication } from 'src/engine/workspace-manager/workspace-migration/workspace-migration-builder/validators/utils/validate-role-belongs-to-caller-application.util';
 import { validateRoleIsEditable } from 'src/engine/workspace-manager/workspace-migration/workspace-migration-builder/validators/utils/validate-role-is-editable.util';
 import { validateRoleLabelUniqueness } from 'src/engine/workspace-manager/workspace-migration/workspace-migration-builder/validators/utils/validate-role-label-uniqueness.util';
 import { validateRoleReadWritePermissionsConsistency } from 'src/engine/workspace-manager/workspace-migration/workspace-migration-builder/validators/utils/validate-role-read-write-permissions-consistency.util';
@@ -22,6 +23,7 @@ export class FlatRoleValidatorService {
     optimisticFlatEntityMapsAndRelatedFlatEntityMaps: {
       flatRoleMaps: optimisticFlatRoleMaps,
     },
+    buildOptions,
   }: UniversalFlatEntityValidationArgs<
     typeof ALL_METADATA_NAME.role
   >): FailedFlatEntityValidation<'role', 'create'> {
@@ -37,6 +39,21 @@ export class FlatRoleValidatorService {
     const existingRoles = Object.values(
       optimisticFlatRoleMaps.byUniversalIdentifier,
     ).filter(isDefined);
+
+    const existingRoleWithSameUniversalIdentifier =
+      findFlatEntityByUniversalIdentifier({
+        universalIdentifier: flatEntityToValidate.universalIdentifier,
+        flatEntityMaps: optimisticFlatRoleMaps,
+      });
+
+    if (isDefined(existingRoleWithSameUniversalIdentifier)) {
+      validationResult.errors.push(
+        ...validateRoleBelongsToCallerApplication({
+          referencedRole: existingRoleWithSameUniversalIdentifier,
+          buildOptions,
+        }),
+      );
+    }
 
     validationResult.errors.push(
       ...validateRoleRequiredPropertiesAreDefined({
@@ -135,6 +152,13 @@ export class FlatRoleValidatorService {
 
       return validationResult;
     }
+
+    validationResult.errors.push(
+      ...validateRoleBelongsToCallerApplication({
+        referencedRole: fromFlatRole,
+        buildOptions,
+      }),
+    );
 
     validationResult.errors.push(
       ...validateRoleIsEditable({

--- a/packages/twenty-server/test/integration/metadata/suites/application/__snapshots__/failing-sync-application-cross-app-permission-on-standard-role.integration-spec.ts.snap
+++ b/packages/twenty-server/test/integration/metadata/suites/application/__snapshots__/failing-sync-application-cross-app-permission-on-standard-role.integration-spec.ts.snap
@@ -54,6 +54,7 @@ exports[`Sync application should fail when creating permissions on a standard ro
             },
           ],
           "flatEntityMinimalInformation": {
+            "label": "Stolen Admin Role",
             "universalIdentifier": Any<String>,
           },
           "metadataName": "role",
@@ -117,6 +118,7 @@ exports[`Sync application should fail when creating permissions on a standard ro
             },
           ],
           "flatEntityMinimalInformation": {
+            "label": "Stolen Admin Role",
             "universalIdentifier": Any<String>,
           },
           "metadataName": "role",
@@ -186,6 +188,7 @@ exports[`Sync application should fail when creating permissions on a standard ro
             },
           ],
           "flatEntityMinimalInformation": {
+            "label": "Stolen Admin Role",
             "universalIdentifier": Any<String>,
           },
           "metadataName": "role",

--- a/packages/twenty-server/test/integration/metadata/suites/application/__snapshots__/failing-sync-application-cross-app-permission-on-standard-role.integration-spec.ts.snap
+++ b/packages/twenty-server/test/integration/metadata/suites/application/__snapshots__/failing-sync-application-cross-app-permission-on-standard-role.integration-spec.ts.snap
@@ -44,6 +44,11 @@ exports[`Sync application should fail when creating permissions on a standard ro
         {
           "errors": [
             {
+              "code": "ROLE_BELONGS_TO_ANOTHER_APPLICATION",
+              "message": "Cannot modify permissions on a role owned by another application",
+              "userFriendlyMessage": "Cannot modify permissions on a role owned by another application.",
+            },
+            {
               "code": "ENTITY_ALREADY_EXISTS",
               "message": "Cannot create role: universalIdentifier "20202020-02c2-43f2-b94d-cab1f2b532eb" already exists in role maps from application "20202020-64aa-4b6f-b003-9c74b97cee20"",
             },
@@ -101,6 +106,11 @@ exports[`Sync application should fail when creating permissions on a standard ro
       "role": [
         {
           "errors": [
+            {
+              "code": "ROLE_BELONGS_TO_ANOTHER_APPLICATION",
+              "message": "Cannot modify permissions on a role owned by another application",
+              "userFriendlyMessage": "Cannot modify permissions on a role owned by another application.",
+            },
             {
               "code": "ENTITY_ALREADY_EXISTS",
               "message": "Cannot create role: universalIdentifier "20202020-02c2-43f2-b94d-cab1f2b532eb" already exists in role maps from application "20202020-64aa-4b6f-b003-9c74b97cee20"",
@@ -165,6 +175,11 @@ exports[`Sync application should fail when creating permissions on a standard ro
       "role": [
         {
           "errors": [
+            {
+              "code": "ROLE_BELONGS_TO_ANOTHER_APPLICATION",
+              "message": "Cannot modify permissions on a role owned by another application",
+              "userFriendlyMessage": "Cannot modify permissions on a role owned by another application.",
+            },
             {
               "code": "ENTITY_ALREADY_EXISTS",
               "message": "Cannot create role: universalIdentifier "20202020-02c2-43f2-b94d-cab1f2b532eb" already exists in role maps from application "20202020-64aa-4b6f-b003-9c74b97cee20"",

--- a/packages/twenty-server/test/integration/metadata/suites/application/__snapshots__/failing-sync-application-universal-identifier-conflict.integration-spec.ts.snap
+++ b/packages/twenty-server/test/integration/metadata/suites/application/__snapshots__/failing-sync-application-universal-identifier-conflict.integration-spec.ts.snap
@@ -19,6 +19,7 @@ exports[`Sync application should fail on universalIdentifier conflicts should fa
             },
           ],
           "flatEntityMinimalInformation": {
+            "label": "Stolen Admin Role",
             "universalIdentifier": Any<String>,
           },
           "metadataName": "role",

--- a/packages/twenty-server/test/integration/metadata/suites/application/__snapshots__/failing-sync-application-universal-identifier-conflict.integration-spec.ts.snap
+++ b/packages/twenty-server/test/integration/metadata/suites/application/__snapshots__/failing-sync-application-universal-identifier-conflict.integration-spec.ts.snap
@@ -9,6 +9,11 @@ exports[`Sync application should fail on universalIdentifier conflicts should fa
         {
           "errors": [
             {
+              "code": "ROLE_BELONGS_TO_ANOTHER_APPLICATION",
+              "message": "Cannot modify permissions on a role owned by another application",
+              "userFriendlyMessage": "Cannot modify permissions on a role owned by another application.",
+            },
+            {
               "code": "ENTITY_ALREADY_EXISTS",
               "message": "Cannot create role: universalIdentifier "20202020-02c2-43f2-b94d-cab1f2b532eb" already exists in role maps from application "20202020-64aa-4b6f-b003-9c74b97cee20"",
             },

--- a/packages/twenty-server/test/integration/metadata/suites/role/__snapshots__/failing-role-update.integration-spec.ts.snap
+++ b/packages/twenty-server/test/integration/metadata/suites/role/__snapshots__/failing-role-update.integration-spec.ts.snap
@@ -56,6 +56,11 @@ exports[`Role update should fail when updating a non-editable system role 1`] = 
         {
           "errors": [
             {
+              "code": "ROLE_BELONGS_TO_ANOTHER_APPLICATION",
+              "message": "Cannot modify permissions on a role owned by another application",
+              "userFriendlyMessage": "Cannot modify permissions on a role owned by another application.",
+            },
+            {
               "code": "ROLE_NOT_EDITABLE",
               "message": "Role is not editable",
               "userFriendlyMessage": "This role cannot be modified because it is a system role. Only custom roles can be edited.",


### PR DESCRIPTION
Follow-up to #19808 / #19807.

## Summary
- add `validateRoleBelongsToCallerApplication` to `validateFlatRoleCreation` so an app sync that re-declares a role whose `universalIdentifier` already belongs to another application fails with `ROLE_BELONGS_TO_ANOTHER_APPLICATION` before the centralized `ENTITY_ALREADY_EXISTS` check and before the optimistic role map is mutated.
- add the same check to `validateFlatRoleUpdate` so any update targeting an existing role owned by another application is rejected before `validateRoleIsEditable` or other update-time rules run.
- update the affected snapshot fixtures: both `failing-sync-application-cross-app-permission-on-standard-role` and `failing-sync-application-universal-identifier-conflict` now surface the new nested error in addition to `ENTITY_ALREADY_EXISTS`.

## Why
PR #19783 closed the cross-app role-retarget path on permission creation. PR #19808 mirrored the same guard on the permission update validators for `permissionFlag`, `objectPermission`, and `fieldPermission`. That leaves one remaining shape: the role entity itself. When an app sync declares a role whose `universalIdentifier` is already owned by another application, the centralized `ENTITY_ALREADY_EXISTS` does fire for collisions that reach the role-type map, but the per-type validator lets the build optimistically continue — and for scenarios where the central check misses the shape (e.g. narrower dependency-loading windows) the hijack can poison the optimistic role map with the caller's `applicationUniversalIdentifier`, silently defeating the downstream permission-update guards.

Running the ownership check at the role-type layer closes the asymmetry: the role CREATE and UPDATE validators now fail fast with a dedicated `ROLE_BELONGS_TO_ANOTHER_APPLICATION` error, matching the behaviour already present on permission-level validators.

## Test plan
- [x] `npx nx lint:diff-with-main twenty-server`
- [x] `npx nx typecheck twenty-server`
- [ ] full `nx run twenty-server:test:integration:with-db-reset`
  - not executed locally (no Postgres/ClickHouse running in this environment); affected suites:
    - `failing-sync-application-cross-app-permission-on-standard-role`
    - `failing-sync-application-universal-identifier-conflict`
    - `failing-role-creation` / `failing-role-update` (unchanged snapshots — same-app scenarios should still pass cleanly because the check only fires on cross-app mismatches)