### PR TITLE
Add twenty-managed Docker target with AWS CLI for EKS deployments

### DIFF
--- a/packages/twenty-docker/twenty/Dockerfile
+++ b/packages/twenty-docker/twenty/Dockerfile
@@ -126,6 +126,18 @@ ENTRYPOINT ["/app/entrypoint.sh"]
 
 
 # ===========================================================================
+# Target: twenty-managed (managed infra with AWS CLI)
+#   docker build --target twenty-managed -f packages/twenty-docker/twenty/Dockerfile .
+# ===========================================================================
+
+FROM twenty AS twenty-managed
+
+USER root
+RUN apk add --no-cache aws-cli
+USER 1000
+
+
+# ===========================================================================
 # Target: twenty-app-dev (all-in-one with Postgres + Redis)
 #   docker build --target twenty-app-dev -f packages/twenty-docker/twenty/Dockerfile .
 # ===========================================================================

--- a/packages/twenty-docker/twenty/Dockerfile
+++ b/packages/twenty-docker/twenty/Dockerfile
@@ -126,11 +126,11 @@ ENTRYPOINT ["/app/entrypoint.sh"]
 
 
 # ===========================================================================
-# Target: twenty-managed (managed infra with AWS CLI)
-#   docker build --target twenty-managed -f packages/twenty-docker/twenty/Dockerfile .
+# Target: twenty-aws
+# docker build --target twenty-aws -f packages/twenty-docker/twenty/Dockerfile .
 # ===========================================================================
 
-FROM twenty AS twenty-managed
+FROM twenty AS twenty-aws
 
 USER root
 RUN apk add --no-cache aws-cli


### PR DESCRIPTION
Separate build target so self-hosters have slimmer image but managed infra gets aws cli for automation