### PR TITLE
fix(server): make `workspace:seed:dev --light` actually seed only one workspace

### DIFF
--- a/packages/twenty-server/src/database/commands/data-seed-dev-workspace.command.ts
+++ b/packages/twenty-server/src/database/commands/data-seed-dev-workspace.command.ts
@@ -31,7 +31,7 @@ export class DataSeedWorkspaceCommand extends CommandRunner {
   @Option({
     flags: '--light',
     description:
-      'Light seed: skip demo custom objects (Pet, Survey, etc.) and limit records to 5 per object',
+      'Light seed: only seed the Apple workspace (skip YCombinator and the Empty3/Empty4 fixtures used by integration tests), skip demo custom objects (Pet, Survey, etc.) and limit records to 5 per object',
   })
   parseLight(): boolean {
     return true;
@@ -41,14 +41,17 @@ export class DataSeedWorkspaceCommand extends CommandRunner {
     _passedParams: string[],
     options: DataSeedWorkspaceOptions,
   ): Promise<void> {
+    // --light seeds a single workspace (Apple) for thin dev containers like
+    // twenty-app-dev. The default (no flag) seeds all four workspaces — Apple,
+    // YCombinator and the Empty3/Empty4 fixtures consumed by upgrade-sequence
+    // integration tests.
     const workspaceIds: SeededWorkspacesIds[] = options.light
       ? [SEED_APPLE_WORKSPACE_ID]
       : [SEED_APPLE_WORKSPACE_ID, SEED_YCOMBINATOR_WORKSPACE_ID];
 
-    const emptyWorkspaceIds: SeededEmptyWorkspacesIds[] = [
-      SEED_EMPTY_WORKSPACE_3_ID,
-      SEED_EMPTY_WORKSPACE_4_ID,
-    ];
+    const emptyWorkspaceIds: SeededEmptyWorkspacesIds[] = options.light
+      ? []
+      : [SEED_EMPTY_WORKSPACE_3_ID, SEED_EMPTY_WORKSPACE_4_ID];
 
     try {
       for (const workspaceId of workspaceIds) {


### PR DESCRIPTION
## Summary

The `--light` flag of `workspace:seed:dev` was supposed to seed a single workspace for thin dev containers, but it was only filtering the rich workspaces (Apple, YCombinator) — the `Empty3`/`Empty4` fixtures introduced in #19559 for upgrade-sequence integration tests were always seeded.

So `--light` actually produced **3** workspaces:
- Apple
- Empty3
- Empty4

In single-workspace mode (`IS_MULTIWORKSPACE_ENABLED=false`, the default for the `twenty-app-dev` container), [`WorkspaceDomainsService.getDefaultWorkspace`](https://github.com/twentyhq/twenty/blob/main/packages/twenty-server/src/engine/core-modules/domain/workspace-domains/services/workspace-domains.service.ts) returns the most recently created workspace — Empty4 — which has no users. The prefilled `tim@apple.dev` therefore cannot sign in, which breaks flows that depend on the default workspace such as `yarn twenty remote add --local`'s OAuth handshake against the dev container.

This PR makes `--light` actually skip the empty fixtures so the dev container ends up with a single workspace (Apple). The default (no flag) invocation, used by `database:reset` for integration tests, still seeds all four workspaces, so `upgrade-sequence-runner-integration-test.util.ts` keeps working unchanged.
