### PR TITLE
perf(server): reuse ESM module cache across warm Lambda invocations of logic functions

### DIFF
--- a/packages/twenty-server/src/engine/core-modules/logic-function/logic-function-drivers/constants/executor/index.mjs
+++ b/packages/twenty-server/src/engine/core-modules/logic-function/logic-function-drivers/constants/executor/index.mjs
@@ -2,7 +2,6 @@ import { promises as fs } from 'fs';
 import { createHash } from 'crypto';
 
 export const handler = async (event) => {
-  const handlerStartMs = Date.now();
   const { code, params, env, handlerName } = event;
 
   // Use a content-hash filename so identical code is written once per
@@ -10,55 +9,43 @@ export const handler = async (event) => {
   // `import(mainPath)` calls. With random names, every warm invocation
   // re-parsed and re-evaluated the entire user bundle (~hundreds of ms
   // for typical apps, dominating Lambda warm-start latency).
-  const codeHash = createHash('sha1').update(code).digest('hex').slice(0, 16);
+  //
+  // Implication: any module-scoped state and side-effects in the user
+  // bundle (e.g. in-memory caches) are now intentionally shared across
+  // invocations of the same container. Logic functions are expected to
+  // treat module scope as a per-container cache, not as per-call isolation.
+  //
+  // Disk usage tradeoff: when a logic function's compiled bundle changes
+  // (e.g. on app deploy), a new file is written and the previous one stays
+  // until the container is recycled. This is bounded by the number of
+  // distinct bundle hashes a single container sees during its lifetime,
+  // which is small in practice; Lambda wipes /tmp on container recycle.
+  const codeHash = createHash('sha256').update(code).digest('hex');
   const mainPath = `/tmp/${codeHash}.mjs`;
 
   // oxlint-disable-next-line no-undef
   const oldProcessEnv = { ...process.env };
 
   try {
-    const codeBytes =
-      typeof code === 'string' ? Buffer.byteLength(code, 'utf8') : 0;
-
-    const beforeWriteMs = Date.now();
-    let wrote = 0;
     try {
       await fs.access(mainPath);
     } catch {
       await fs.writeFile(mainPath, code, 'utf8');
-      wrote = 1;
     }
-    const writeMs = Date.now() - beforeWriteMs;
 
     // oxlint-disable-next-line no-undef
     process.env = { ...process.env, ...(env ?? {}) };
 
-    const beforeImportMs = Date.now();
     const mainFile = await import(mainPath);
-    const importMs = Date.now() - beforeImportMs;
 
     const handlerFn = handlerName
       .split('.')
       .reduce((obj, key) => obj[key], mainFile);
 
-    const beforeUserHandlerMs = Date.now();
-    // Goes to CloudWatch — used to monitor that warm invocations actually
-    // hit the cache (`wrote=0 importMs=0`) after the executor cache fix.
-    // oxlint-disable-next-line no-console
-    console.log(
-      `[executor-timing] codeBytes=${codeBytes} wrote=${wrote} writeMs=${writeMs} importMs=${importMs} preHandlerMs=${beforeUserHandlerMs - handlerStartMs}`,
-    );
-    const result = await handlerFn(params);
-    // oxlint-disable-next-line no-console
-    console.log(
-      `[executor-timing] handlerMs=${Date.now() - beforeUserHandlerMs} totalMs=${Date.now() - handlerStartMs}`,
-    );
-
-    return result;
+    return await handlerFn(params);
   } finally {
-    // Intentionally NOT removing `mainPath` here: we want the file (and the
-    // associated ESM cache entry) to survive across warm invocations.
-    // /tmp is wiped automatically when the container is recycled.
+    // Intentionally NOT removing `mainPath` here so subsequent warm
+    // invocations hit Node's ESM cache (see comment above).
 
     // oxlint-disable-next-line no-undef
     process.env = oldProcessEnv;

--- a/packages/twenty-server/src/engine/core-modules/logic-function/logic-function-drivers/constants/executor/index.mjs
+++ b/packages/twenty-server/src/engine/core-modules/logic-function/logic-function-drivers/constants/executor/index.mjs
@@ -1,31 +1,65 @@
 import { promises as fs } from 'fs';
-import { randomBytes } from 'crypto';
+import { createHash } from 'crypto';
 
 export const handler = async (event) => {
-  const randomId = randomBytes(16).toString('hex');
+  const handlerStartMs = Date.now();
+  const { code, params, env, handlerName } = event;
 
-  const mainPath = `/tmp/${randomId}.mjs`;
+  // Use a content-hash filename so identical code is written once per
+  // warm container and Node's ESM module cache can short-circuit subsequent
+  // `import(mainPath)` calls. With random names, every warm invocation
+  // re-parsed and re-evaluated the entire user bundle (~hundreds of ms
+  // for typical apps, dominating Lambda warm-start latency).
+  const codeHash = createHash('sha1').update(code).digest('hex').slice(0, 16);
+  const mainPath = `/tmp/${codeHash}.mjs`;
 
   // oxlint-disable-next-line no-undef
   const oldProcessEnv = { ...process.env };
 
   try {
-    const { code, params, env, handlerName } = event;
+    const codeBytes =
+      typeof code === 'string' ? Buffer.byteLength(code, 'utf8') : 0;
 
-    await fs.writeFile(mainPath, code, 'utf8');
+    const beforeWriteMs = Date.now();
+    let wrote = 0;
+    try {
+      await fs.access(mainPath);
+    } catch {
+      await fs.writeFile(mainPath, code, 'utf8');
+      wrote = 1;
+    }
+    const writeMs = Date.now() - beforeWriteMs;
 
     // oxlint-disable-next-line no-undef
     process.env = { ...process.env, ...(env ?? {}) };
 
+    const beforeImportMs = Date.now();
     const mainFile = await import(mainPath);
+    const importMs = Date.now() - beforeImportMs;
 
     const handlerFn = handlerName
       .split('.')
       .reduce((obj, key) => obj[key], mainFile);
 
-    return await handlerFn(params);
+    const beforeUserHandlerMs = Date.now();
+    // Goes to CloudWatch — used to monitor that warm invocations actually
+    // hit the cache (`wrote=0 importMs=0`) after the executor cache fix.
+    // oxlint-disable-next-line no-console
+    console.log(
+      `[executor-timing] codeBytes=${codeBytes} wrote=${wrote} writeMs=${writeMs} importMs=${importMs} preHandlerMs=${beforeUserHandlerMs - handlerStartMs}`,
+    );
+    const result = await handlerFn(params);
+    // oxlint-disable-next-line no-console
+    console.log(
+      `[executor-timing] handlerMs=${Date.now() - beforeUserHandlerMs} totalMs=${Date.now() - handlerStartMs}`,
+    );
+
+    return result;
   } finally {
-    await fs.rm(mainPath, { force: true });
+    // Intentionally NOT removing `mainPath` here: we want the file (and the
+    // associated ESM cache entry) to survive across warm invocations.
+    // /tmp is wiped automatically when the container is recycled.
+
     // oxlint-disable-next-line no-undef
     process.env = oldProcessEnv;
   }

--- a/packages/twenty-server/src/engine/core-modules/logic-function/logic-function-drivers/drivers/lambda.driver.ts
+++ b/packages/twenty-server/src/engine/core-modules/logic-function/logic-function-drivers/drivers/lambda.driver.ts
@@ -1127,11 +1127,14 @@ export class LambdaDriver implements LogicFunctionDriver {
     env,
     timeoutMs = 900_000,
   }: LogicFunctionExecuteParams): Promise<LogicFunctionExecuteResult> {
+    const buildStart = Date.now();
+
     await this.buildLambdaExecutor({
       flatLogicFunction,
       flatApplication,
       applicationUniversalIdentifier,
     });
+    const buildExecutorMs = Date.now() - buildStart;
 
     const startTime = Date.now();
 
@@ -1140,6 +1143,7 @@ export class LambdaDriver implements LogicFunctionDriver {
       applicationUniversalIdentifier,
       builtHandlerPath: flatLogicFunction.builtHandlerPath,
     });
+    const getBuiltCodeMs = Date.now() - startTime;
 
     const executorPayload: LambdaDriverExecutorPayload = {
       params: payload,
@@ -1148,9 +1152,10 @@ export class LambdaDriver implements LogicFunctionDriver {
       handlerName: flatLogicFunction.handlerName,
     };
 
+    const payloadString = JSON.stringify(executorPayload);
     const params: InvokeCommandInput = {
       FunctionName: flatLogicFunction.id,
-      Payload: JSON.stringify(executorPayload),
+      Payload: payloadString,
       LogType: LogType.Tail,
     };
 
@@ -1159,18 +1164,33 @@ export class LambdaDriver implements LogicFunctionDriver {
     try {
       const lambdaClient = await this.getLambdaClient();
 
+      const invokeStart = Date.now();
       const result = await callWithTimeout({
         callback: () => lambdaClient.send(command),
         timeoutMs,
       });
+      const invokeSendMs = Date.now() - invokeStart;
 
       const parsedResult = result.Payload
         ? JSON.parse(result.Payload.transformToString())
         : {};
 
+      const rawLogs = result.LogResult
+        ? Buffer.from(result.LogResult, 'base64').toString('utf8')
+        : '';
+      const initMatch = rawLogs.match(/Init Duration:\s*([\d.]+)\s*ms/i);
+      const billedMatch = rawLogs.match(/Billed Duration:\s*([\d.]+)\s*ms/i);
+      const reportMatch = rawLogs.match(/\bDuration:\s*([\d.]+)\s*ms/i);
+
       const logs = result.LogResult ? this.extractLogs(result.LogResult) : '';
 
       const duration = Date.now() - startTime;
+
+      // Structured timing log so we can monitor warm/cold-start behaviour
+      // of logic-function lambdas in production (CloudWatch / log aggregator).
+      this.logger.log(
+        `[lambda-timing] fnId=${flatLogicFunction.id} totalMs=${duration} buildExecutorMs=${buildExecutorMs} getBuiltCodeMs=${getBuiltCodeMs} payloadBytes=${Buffer.byteLength(payloadString, 'utf8')} invokeSendMs=${invokeSendMs} reportDurationMs=${reportMatch?.[1] ?? 'n/a'} billedMs=${billedMatch?.[1] ?? 'n/a'} initDurationMs=${initMatch?.[1] ?? 'n/a'} coldStart=${initMatch !== null}`,
+      );
 
       if (result.FunctionError) {
         return {

--- a/packages/twenty-server/src/engine/core-modules/logic-function/logic-function-drivers/drivers/lambda.driver.ts
+++ b/packages/twenty-server/src/engine/core-modules/logic-function/logic-function-drivers/drivers/lambda.driver.ts
@@ -1185,10 +1185,8 @@ export class LambdaDriver implements LogicFunctionDriver {
 
       const duration = Date.now() - startTime;
 
-      // Structured timing log so we can monitor warm/cold-start behaviour
-      // of logic-function lambdas in production (CloudWatch / log aggregator).
       this.logger.log(
-        `[lambda-timing] fnId=${flatLogicFunction.id} totalMs=${duration} buildExecutorMs=${buildExecutorMs} getBuiltCodeMs=${getBuiltCodeMs} payloadBytes=${Buffer.byteLength(payloadString, 'utf8')} invokeSendMs=${invokeSendMs} reportDurationMs=${reportMatch?.[1] ?? 'n/a'} billedMs=${billedMatch?.[1] ?? 'n/a'} initDurationMs=${initMatch?.[1] ?? 'n/a'} coldStart=${initMatch !== null}`,
+        `[lambda-timing] fnId=${flatLogicFunction.id} totalMs=${Date.now() - buildStart} buildExecutorMs=${buildExecutorMs} getBuiltCodeMs=${getBuiltCodeMs} payloadBytes=${Buffer.byteLength(payloadString, 'utf8')} invokeSendMs=${invokeSendMs} reportDurationMs=${reportMatch?.[1] ?? 'n/a'} billedMs=${billedMatch?.[1] ?? 'n/a'} initDurationMs=${initMatch?.[1] ?? 'n/a'} coldStart=${initMatch !== null}`,
       );
 
       if (result.FunctionError) {

--- a/packages/twenty-server/src/engine/core-modules/logic-function/logic-function-drivers/drivers/lambda.driver.ts
+++ b/packages/twenty-server/src/engine/core-modules/logic-function/logic-function-drivers/drivers/lambda.driver.ts
@@ -1104,13 +1104,10 @@ export class LambdaDriver implements LogicFunctionDriver {
     }
   }
 
-  private extractLogs(logString: string): string {
-    const formattedLogString = Buffer.from(logString, 'base64')
-      .toString('utf8')
+  private extractLogs(decodedLogs: string): string {
+    return decodedLogs
       .split('\t')
-      .join(' ');
-
-    return formattedLogString
+      .join(' ')
       .replace(/^(START|END|REPORT).*\n?/gm, '')
       .replace(
         /^(\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z) [a-f0-9-]+ INFO /gm,
@@ -1175,14 +1172,16 @@ export class LambdaDriver implements LogicFunctionDriver {
         ? JSON.parse(result.Payload.transformToString())
         : {};
 
-      const rawLogs = result.LogResult
+      const decodedLogs = result.LogResult
         ? Buffer.from(result.LogResult, 'base64').toString('utf8')
         : '';
-      const initMatch = rawLogs.match(/Init Duration:\s*([\d.]+)\s*ms/i);
-      const billedMatch = rawLogs.match(/Billed Duration:\s*([\d.]+)\s*ms/i);
-      const reportMatch = rawLogs.match(/\bDuration:\s*([\d.]+)\s*ms/i);
+      const initMatch = decodedLogs.match(/Init Duration:\s*([\d.]+)\s*ms/i);
+      const billedMatch = decodedLogs.match(
+        /Billed Duration:\s*([\d.]+)\s*ms/i,
+      );
+      const reportMatch = decodedLogs.match(/\bDuration:\s*([\d.]+)\s*ms/i);
 
-      const logs = result.LogResult ? this.extractLogs(result.LogResult) : '';
+      const logs = decodedLogs ? this.extractLogs(decodedLogs) : '';
 
       const duration = Date.now() - startTime;
 

--- a/packages/twenty-server/src/engine/core-modules/logic-function/logic-function-drivers/drivers/lambda.driver.ts
+++ b/packages/twenty-server/src/engine/core-modules/logic-function/logic-function-drivers/drivers/lambda.driver.ts
@@ -1205,8 +1205,13 @@ export class LambdaDriver implements LogicFunctionDriver {
         ? JSON.parse(result.Payload.transformToString())
         : {};
 
-      const { logs, initDurationMs, billedDurationMs, reportDurationMs, coldStart } =
-        this.parseLambdaLogResult(result.LogResult);
+      const {
+        logs,
+        initDurationMs,
+        billedDurationMs,
+        reportDurationMs,
+        coldStart,
+      } = this.parseLambdaLogResult(result.LogResult);
 
       const duration = Date.now() - startTime;
 

--- a/packages/twenty-server/src/engine/core-modules/logic-function/logic-function-drivers/drivers/lambda.driver.ts
+++ b/packages/twenty-server/src/engine/core-modules/logic-function/logic-function-drivers/drivers/lambda.driver.ts
@@ -1104,8 +1104,33 @@ export class LambdaDriver implements LogicFunctionDriver {
     }
   }
 
-  private extractLogs(decodedLogs: string): string {
-    return decodedLogs
+  private parseLambdaLogResult(logResult: string | undefined): {
+    logs: string;
+    initDurationMs: string | null;
+    billedDurationMs: string | null;
+    reportDurationMs: string | null;
+    coldStart: boolean;
+  } {
+    if (!logResult) {
+      return {
+        logs: '',
+        initDurationMs: null,
+        billedDurationMs: null,
+        reportDurationMs: null,
+        coldStart: false,
+      };
+    }
+
+    const decoded = Buffer.from(logResult, 'base64').toString('utf8');
+
+    const initDurationMs =
+      decoded.match(/Init Duration:\s*([\d.]+)\s*ms/i)?.[1] ?? null;
+    const billedDurationMs =
+      decoded.match(/Billed Duration:\s*([\d.]+)\s*ms/i)?.[1] ?? null;
+    const reportDurationMs =
+      decoded.match(/\bDuration:\s*([\d.]+)\s*ms/i)?.[1] ?? null;
+
+    const logs = decoded
       .split('\t')
       .join(' ')
       .replace(/^(START|END|REPORT).*\n?/gm, '')
@@ -1114,6 +1139,14 @@ export class LambdaDriver implements LogicFunctionDriver {
         '$1 INFO ',
       )
       .trim();
+
+    return {
+      logs,
+      initDurationMs,
+      billedDurationMs,
+      reportDurationMs,
+      coldStart: initDurationMs !== null,
+    };
   }
 
   async execute({
@@ -1172,21 +1205,13 @@ export class LambdaDriver implements LogicFunctionDriver {
         ? JSON.parse(result.Payload.transformToString())
         : {};
 
-      const decodedLogs = result.LogResult
-        ? Buffer.from(result.LogResult, 'base64').toString('utf8')
-        : '';
-      const initMatch = decodedLogs.match(/Init Duration:\s*([\d.]+)\s*ms/i);
-      const billedMatch = decodedLogs.match(
-        /Billed Duration:\s*([\d.]+)\s*ms/i,
-      );
-      const reportMatch = decodedLogs.match(/\bDuration:\s*([\d.]+)\s*ms/i);
-
-      const logs = decodedLogs ? this.extractLogs(decodedLogs) : '';
+      const { logs, initDurationMs, billedDurationMs, reportDurationMs, coldStart } =
+        this.parseLambdaLogResult(result.LogResult);
 
       const duration = Date.now() - startTime;
 
       this.logger.log(
-        `[lambda-timing] fnId=${flatLogicFunction.id} totalMs=${Date.now() - buildStart} buildExecutorMs=${buildExecutorMs} getBuiltCodeMs=${getBuiltCodeMs} payloadBytes=${Buffer.byteLength(payloadString, 'utf8')} invokeSendMs=${invokeSendMs} reportDurationMs=${reportMatch?.[1] ?? 'n/a'} billedMs=${billedMatch?.[1] ?? 'n/a'} initDurationMs=${initMatch?.[1] ?? 'n/a'} coldStart=${initMatch !== null}`,
+        `[lambda-timing] fnId=${flatLogicFunction.id} totalMs=${Date.now() - buildStart} buildExecutorMs=${buildExecutorMs} getBuiltCodeMs=${getBuiltCodeMs} payloadBytes=${Buffer.byteLength(payloadString, 'utf8')} invokeSendMs=${invokeSendMs} reportDurationMs=${reportDurationMs ?? 'n/a'} billedMs=${billedDurationMs ?? 'n/a'} initDurationMs=${initDurationMs ?? 'n/a'} coldStart=${coldStart}`,
       );
 
       if (result.FunctionError) {


### PR DESCRIPTION
## Summary

Lambda warm-invocations of logic functions were spending **~440 ms** re-parsing and re-evaluating the user bundle on every call. The executor wrote the user code to a **randomly-named** temp file and `import()`-ed it, so each warm call resolved to a new URL and Node's ESM cache could never reuse the previous module record.

This PR makes the executor write to a **content-hash filename**, skip the write when the file already exists, and stop deleting it. Identical code now reuses the same module record across warm calls in the same container, dropping warm-invocation overhead by **~30–40%**.

## What changed

- `executor/index.mjs`: temp filename derived from `sha256(code)`, write skipped when file exists, no `fs.rm` on cleanup.
- `lambda.driver.ts`: single structured `[lambda-timing]` log per invocation with `totalMs / buildExecutorMs / getBuiltCodeMs / payloadBytes / invokeSendMs / reportDurationMs / billedMs / initDurationMs / coldStart`. Goes through the standard NestJS `Logger`.

No behavioural change for callers: same input → same output, same error semantics.

### Caveat: module-scope state now persists across warm calls

With a stable filename, the user bundle is evaluated **once per warm container**. Any module-scoped state or top-level side-effects in user code are now shared across invocations of the same container, instead of re-running on every call. This is documented in the executor and is the intended trade-off — module scope should be treated as a per-container cache, not as per-call isolation.

## Findings — measured impact

Same logic function (`fetch-prs`, ~12k PRs to page through), same workspace, same Lambda config (eu-west-3, 512 MB), token cache primed.

### Warm invocations

| Phase                                  | Before fix    | After fix      | Δ            |
| -------------------------------------- | ------------- | -------------- | ------------ |
| Executor `import(userBundle)`          | ~440 ms       | **~0 ms**      | **-440 ms**  |
| Lambda billed duration                 | ~1.5–1.7 s    | **~1.0–1.1 s** | **~30–40%**  |
| Server-perceived round-trip            | ~1.7–2.0 s    | **~1.0–1.2 s** | **~30–40%**  |

### Cold starts

Unchanged — the cache helps subsequent warm calls in the same container, not the first one. Init Duration stays ~130–170 ms; total cold call ~2.5–3.0 s.

### Stress

Could not reproduce the previously-reported \"every ~10th call times out\" behaviour after the fix:

- 30 sequential calls: max 1.7 s, median ~1.1 s, 0 timeouts
- 50 concurrent calls: max 9.4 s (clear cold-start cluster), median ~1.5 s, 0 timeouts

Hypothesis: the warm-import overhead was eating into the headroom against the function timeout under bursty load; removing it pushed everything well below the limit.

## Observability

One structured log line per invocation, sent through the standard NestJS logger:

\`\`\`
[lambda-timing] fnId=abc123 totalMs=1187 buildExecutorMs=2 getBuiltCodeMs=3 payloadBytes=1466321 invokeSendMs=1180 reportDurationMs=992 billedMs=1000 initDurationMs=n/a coldStart=false
\`\`\`

\`coldStart=true\` whenever Lambda spun up a fresh container; on warm calls \`buildExecutorMs\` and \`getBuiltCodeMs\` collapse to single-digit ms, confirming the cache fix is working.

## Test plan

- [ ] CI green.
- [ ] Deploy to a Lambda-backed env, trigger a logic function several times in a row.
- [ ] Confirm \`[lambda-timing]\` warm invocations show \`totalMs\` ~30–40% lower than before, and \`coldStart=false\` after the first call in a container.
- [ ] Push a new version of an app; confirm the next call shows higher \`buildExecutorMs\` (new hash, new file written) followed by warm calls again.
- [ ] Smoke test: errors thrown by the user handler are still surfaced correctly.

Made with [Cursor](https://cursor.com)