### PR TITLE
Bump twenty-sdk, twenty-client-sdk, create-twenty-app to 1.23.0-canary.1

### DIFF
--- a/packages/create-twenty-app/package.json
+++ b/packages/create-twenty-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-twenty-app",
-  "version": "1.22.0",
+  "version": "1.23.0-canary.1",
   "description": "Command-line interface to create Twenty application",
   "main": "dist/cli.cjs",
   "bin": "dist/cli.cjs",

--- a/packages/twenty-client-sdk/package.json
+++ b/packages/twenty-client-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "twenty-client-sdk",
-  "version": "1.22.0",
+  "version": "1.23.0-canary.1",
   "sideEffects": false,
   "license": "AGPL-3.0",
   "scripts": {

--- a/packages/twenty-sdk/package.json
+++ b/packages/twenty-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "twenty-sdk",
-  "version": "1.22.0",
+  "version": "1.23.0-canary.1",
   "sideEffects": false,
   "bin": {
     "twenty": "dist/cli.cjs"


### PR DESCRIPTION
## Summary
- Bumps `twenty-sdk`, `twenty-client-sdk`, and `create-twenty-app` from `1.22.0` to `1.23.0-canary.1`.

## Test plan
- [ ] CI green

Made with [Cursor](https://cursor.com)