### PR TITLE
fix: correct sSOService → ssoService camelCase typo

### DIFF
--- a/packages/twenty-server/src/engine/core-modules/auth/auth.resolver.ts
+++ b/packages/twenty-server/src/engine/core-modules/auth/auth.resolver.ts
@@ -122,7 +122,7 @@ export class AuthResolver {
     private workspaceDomainsService: WorkspaceDomainsService,
     private userWorkspaceService: UserWorkspaceService,
     private emailVerificationTokenService: EmailVerificationTokenService,
-    private sSOService: SSOService,
+    private ssoService: SSOService,
     private readonly auditService: AuditService,
     private readonly permissionsService: PermissionsService,
   ) {}
@@ -142,7 +142,7 @@ export class AuthResolver {
   async getAuthorizationUrlForSSO(
     @Args('input') params: GetAuthorizationUrlForSSOInput,
   ) {
-    return await this.sSOService.getAuthorizationUrlForSSO(
+    return await this.ssoService.getAuthorizationUrlForSSO(
       params.identityProviderId,
       omit(params, ['identityProviderId']),
     );

--- a/packages/twenty-server/src/engine/core-modules/auth/controllers/sso-auth.controller.ts
+++ b/packages/twenty-server/src/engine/core-modules/auth/controllers/sso-auth.controller.ts
@@ -51,7 +51,7 @@ export class SSOAuthController {
     private readonly guardRedirectService: GuardRedirectService,
     private readonly workspaceDomainsService: WorkspaceDomainsService,
     private readonly userService: UserService,
-    private readonly sSOService: SSOService,
+    private readonly ssoService: SSOService,
     @InjectRepository(WorkspaceSSOIdentityProviderEntity)
     private readonly workspaceSSOIdentityProviderRepository: Repository<WorkspaceSSOIdentityProviderEntity>,
   ) {}
@@ -66,11 +66,11 @@ export class SSOAuthController {
   async generateMetadata(@Req() req: any): Promise<string | void> {
     return generateServiceProviderMetadata({
       wantAssertionsSigned: true,
-      issuer: this.sSOService.buildIssuerURL({
+      issuer: this.ssoService.buildIssuerURL({
         id: req.params.identityProviderId,
         type: IdentityProviderType.SAML,
       }),
-      callbackUrl: this.sSOService.buildCallbackUrl({
+      callbackUrl: this.ssoService.buildCallbackUrl({
         id: req.params.identityProviderId,
         type: IdentityProviderType.SAML,
       }),

--- a/packages/twenty-server/src/engine/core-modules/auth/guards/oidc-auth.guard.ts
+++ b/packages/twenty-server/src/engine/core-modules/auth/guards/oidc-auth.guard.ts
@@ -19,7 +19,7 @@ import { type WorkspaceSSOIdentityProviderEntity } from 'src/engine/core-modules
 @Injectable()
 export class OIDCAuthGuard extends AuthGuard('openidconnect') {
   constructor(
-    private readonly sSOService: SSOService,
+    private readonly ssoService: SSOService,
     private readonly guardRedirectService: GuardRedirectService,
     private readonly workspaceDomainsService: WorkspaceDomainsService,
   ) {
@@ -69,7 +69,7 @@ export class OIDCAuthGuard extends AuthGuard('openidconnect') {
         );
       }
 
-      identityProvider = await this.sSOService.findSSOIdentityProviderById(
+      identityProvider = await this.ssoService.findSSOIdentityProviderById(
         state.identityProviderId,
       );
 
@@ -82,7 +82,7 @@ export class OIDCAuthGuard extends AuthGuard('openidconnect') {
       const issuer = await Issuer.discover(identityProvider.issuer);
 
       new OIDCAuthStrategy(
-        this.sSOService.getOIDCClient(identityProvider, issuer),
+        this.ssoService.getOIDCClient(identityProvider, issuer),
         identityProvider.id,
       );
 

--- a/packages/twenty-server/src/engine/core-modules/auth/guards/oidc-auth.spec.ts
+++ b/packages/twenty-server/src/engine/core-modules/auth/guards/oidc-auth.spec.ts
@@ -37,7 +37,7 @@ jest.mock('openid-client', () => ({
 
 describe('OIDCAuthGuard', () => {
   let guard: OIDCAuthGuard;
-  let sSOService: SSOService;
+  let ssoService: SSOService;
   let guardRedirectService: GuardRedirectService;
   let mockExecutionContext: ExecutionContext;
 
@@ -70,7 +70,7 @@ describe('OIDCAuthGuard', () => {
     }).compile();
 
     guard = module.get<OIDCAuthGuard>(OIDCAuthGuard);
-    sSOService = module.get<SSOService>(SSOService);
+    ssoService = module.get<SSOService>(SSOService);
     guardRedirectService =
       module.get<GuardRedirectService>(GuardRedirectService);
 
@@ -88,7 +88,7 @@ describe('OIDCAuthGuard', () => {
 
     mockExecutionContext = createMockExecutionContext(mockedRequest);
 
-    jest.spyOn(sSOService, 'findSSOIdentityProviderById').mockResolvedValue({
+    jest.spyOn(ssoService, 'findSSOIdentityProviderById').mockResolvedValue({
       id: 'test-id',
       issuer: 'https://issuer.example.com',
       workspace: {},
@@ -98,7 +98,7 @@ describe('OIDCAuthGuard', () => {
 
     expect(result).toBe(true);
     expect(guardRedirectService.dispatchErrorFromGuard).not.toHaveBeenCalled();
-    expect(sSOService.findSSOIdentityProviderById).toHaveBeenCalledWith(
+    expect(ssoService.findSSOIdentityProviderById).toHaveBeenCalledWith(
       'test-id',
     );
   });
@@ -111,11 +111,11 @@ describe('OIDCAuthGuard', () => {
     mockExecutionContext = createMockExecutionContext(mockedRequest);
 
     jest
-      .spyOn(sSOService, 'findSSOIdentityProviderById')
+      .spyOn(ssoService, 'findSSOIdentityProviderById')
       .mockResolvedValue(null);
 
     await expect(guard.canActivate(mockExecutionContext)).resolves.toBe(false);
-    expect(sSOService.findSSOIdentityProviderById).toHaveBeenCalledWith(
+    expect(ssoService.findSSOIdentityProviderById).toHaveBeenCalledWith(
       'non-existent-id',
     );
     expect(guardRedirectService.dispatchErrorFromGuard).toHaveBeenCalled();
@@ -129,7 +129,7 @@ describe('OIDCAuthGuard', () => {
     mockExecutionContext = createMockExecutionContext(mockedRequest);
 
     jest
-      .spyOn(sSOService, 'findSSOIdentityProviderById')
+      .spyOn(ssoService, 'findSSOIdentityProviderById')
       .mockResolvedValue(null);
 
     await expect(guard.canActivate(mockExecutionContext)).resolves.toBe(false);

--- a/packages/twenty-server/src/engine/core-modules/auth/guards/saml-auth.guard.ts
+++ b/packages/twenty-server/src/engine/core-modules/auth/guards/saml-auth.guard.ts
@@ -19,7 +19,7 @@ import { type WorkspaceSSOIdentityProviderEntity } from 'src/engine/core-modules
 @Injectable()
 export class SAMLAuthGuard extends AuthGuard('saml') {
   constructor(
-    private readonly sSOService: SSOService,
+    private readonly ssoService: SSOService,
     private readonly guardRedirectService: GuardRedirectService,
     private readonly workspaceDomainsService: WorkspaceDomainsService,
   ) {
@@ -34,7 +34,7 @@ export class SAMLAuthGuard extends AuthGuard('saml') {
       | null = null;
 
     try {
-      identityProvider = await this.sSOService.findSSOIdentityProviderById(
+      identityProvider = await this.ssoService.findSSOIdentityProviderById(
         request.params.identityProviderId,
       );
 
@@ -44,7 +44,7 @@ export class SAMLAuthGuard extends AuthGuard('saml') {
           AuthExceptionCode.INVALID_DATA,
         );
       }
-      new SamlAuthStrategy(this.sSOService);
+      new SamlAuthStrategy(this.ssoService);
 
       return (await super.canActivate(context)) as boolean;
     } catch (err) {

--- a/packages/twenty-server/src/engine/core-modules/auth/strategies/saml.auth.strategy.ts
+++ b/packages/twenty-server/src/engine/core-modules/auth/strategies/saml.auth.strategy.ts
@@ -36,16 +36,16 @@ export class SamlAuthStrategy extends PassportStrategy(
   MultiSamlStrategy,
   'saml',
 ) {
-  constructor(private readonly sSOService: SSOService) {
+  constructor(private readonly ssoService: SSOService) {
     super(
       {
         getSamlOptions: (req, callback) => {
-          this.sSOService
+          this.ssoService
             .findSSOIdentityProviderById(req.params.identityProviderId)
             .then((identityProvider) => {
               if (
                 identityProvider &&
-                this.sSOService.isSAMLIdentityProvider(identityProvider)
+                this.ssoService.isSAMLIdentityProvider(identityProvider)
               ) {
                 // IdP metadata XML typically has whitespace-formatted certificates
                 const sanitizedCertificate =
@@ -53,9 +53,9 @@ export class SamlAuthStrategy extends PassportStrategy(
 
                 const config: SamlConfig = {
                   entryPoint: identityProvider.ssoURL,
-                  issuer: this.sSOService.buildIssuerURL(identityProvider),
+                  issuer: this.ssoService.buildIssuerURL(identityProvider),
                   callbackUrl:
-                    this.sSOService.buildCallbackUrl(identityProvider),
+                    this.ssoService.buildCallbackUrl(identityProvider),
                   idpCert: sanitizedCertificate,
                   wantAssertionsSigned: true,
                   wantAuthnResponseSigned: false,

--- a/packages/twenty-server/src/engine/core-modules/sso/sso.resolver.ts
+++ b/packages/twenty-server/src/engine/core-modules/sso/sso.resolver.ts
@@ -35,7 +35,7 @@ import { PermissionsGraphqlApiExceptionFilter } from 'src/engine/metadata-module
 @UsePipes(ResolverValidationPipe)
 @UseGuards(SettingsPermissionGuard(PermissionFlagType.SECURITY))
 export class SSOResolver {
-  constructor(private readonly sSOService: SSOService) {}
+  constructor(private readonly ssoService: SSOService) {}
 
   @UseGuards(WorkspaceAuthGuard, EnterpriseFeaturesEnabledGuard)
   @Mutation(() => SetupSsoDTO)
@@ -43,7 +43,7 @@ export class SSOResolver {
     @Args('input') setupSsoInput: SetupOIDCSsoInput,
     @AuthWorkspace() { id: workspaceId }: WorkspaceEntity,
   ): Promise<SetupSsoDTO | SSOException> {
-    return this.sSOService.createOIDCIdentityProvider(
+    return this.ssoService.createOIDCIdentityProvider(
       setupSsoInput,
       workspaceId,
     );
@@ -54,7 +54,7 @@ export class SSOResolver {
   async getSSOIdentityProviders(
     @AuthWorkspace() { id: workspaceId }: WorkspaceEntity,
   ) {
-    return this.sSOService.getSSOIdentityProviders(workspaceId);
+    return this.ssoService.getSSOIdentityProviders(workspaceId);
   }
 
   @UseGuards(WorkspaceAuthGuard, EnterpriseFeaturesEnabledGuard)
@@ -63,7 +63,7 @@ export class SSOResolver {
     @Args('input') setupSsoInput: SetupSAMLSsoInput,
     @AuthWorkspace() { id: workspaceId }: WorkspaceEntity,
   ): Promise<SetupSsoDTO | SSOException> {
-    return this.sSOService.createSAMLIdentityProvider(
+    return this.ssoService.createSAMLIdentityProvider(
       setupSsoInput,
       workspaceId,
     );
@@ -75,7 +75,7 @@ export class SSOResolver {
     @Args('input') { identityProviderId }: DeleteSsoInput,
     @AuthWorkspace() { id: workspaceId }: WorkspaceEntity,
   ) {
-    return this.sSOService.deleteSSOIdentityProvider(
+    return this.ssoService.deleteSSOIdentityProvider(
       identityProviderId,
       workspaceId,
     );
@@ -87,6 +87,6 @@ export class SSOResolver {
     @Args('input') input: EditSsoInput,
     @AuthWorkspace() { id: workspaceId }: WorkspaceEntity,
   ) {
-    return this.sSOService.editSSOIdentityProvider(input, workspaceId);
+    return this.ssoService.editSSOIdentityProvider(input, workspaceId);
   }
 }


### PR DESCRIPTION
## Summary

Fixes the pre-existing camelCase typo mentioned in twentyhq/core-team-issues#2419.

The injected `SSOService` property was named `sSOService` instead of the correct camelCase `ssoService` across the auth module. This is a straightforward mechanical rename of the property/variable name — no logic changes.

> **Bonus: pre-existing typo to fix** — `private sSOService: SSOService` — The variable name is a camelCase typo (`sSOService` instead of `ssoService`). — twentyhq/core-team-issues#2419

## Changes

Renamed `sSOService` → `ssoService` in 7 files:
- `auth/guards/oidc-auth.guard.ts`
- `auth/guards/saml-auth.guard.ts`
- `auth/guards/oidc-auth.spec.ts`
- `auth/auth.resolver.ts`
- `auth/controllers/sso-auth.controller.ts`
- `auth/strategies/saml.auth.strategy.ts`
- `sso/sso.resolver.ts`

Note: The type `SSOService` (PascalCase class name) is intentionally left unchanged — it will be addressed in the broader SSO acronym PR from twentyhq/core-team-issues#2419.

## Test plan

- [ ] Verify `typecheck twenty-server` passes
- [ ] Verify existing auth/SSO tests pass