### PR TITLE
fix(front): apply object type translations to details panel widget titles

### DIFF
--- a/packages/twenty-front/src/modules/page-layout/widgets/components/RecordPageWidgetRenderer.tsx
+++ b/packages/twenty-front/src/modules/page-layout/widgets/components/RecordPageWidgetRenderer.tsx
@@ -1,6 +1,7 @@
 import { type PageLayoutWidget } from '@/page-layout/types/PageLayoutWidget';
 import { WidgetCardShell } from '@/page-layout/widgets/components/WidgetCardShell';
 import { useWidgetActions } from '@/page-layout/widgets/hooks/useWidgetActions';
+import { useWidgetDerivedTitle } from '@/page-layout/widgets/hooks/useWidgetDerivedTitle';
 import { useWidgetRendererState } from '@/page-layout/widgets/hooks/useWidgetRendererState';
 import { useIsFeatureEnabled } from '@/workspace/hooks/useIsFeatureEnabled';
 import { styled } from '@linaria/react';
@@ -48,6 +49,8 @@ export const RecordPageWidgetRenderer = ({
 
   const actions = useWidgetActions({ widget });
 
+  const derivedTitle = useWidgetDerivedTitle(widget);
+
   // TODO: remove once all record page layouts widgets use the editable contain in edit mode
   const shouldWrapWithEditingWrapper =
     isWidgetEditable &&
@@ -59,6 +62,7 @@ export const RecordPageWidgetRenderer = ({
   const shell = (
     <WidgetCardShell
       widget={widget}
+      title={derivedTitle}
       variant={state.variant}
       isEditable={isWidgetEditable}
       isEditing={state.isEditing}

--- a/packages/twenty-front/src/modules/page-layout/widgets/components/WidgetCardShell.tsx
+++ b/packages/twenty-front/src/modules/page-layout/widgets/components/WidgetCardShell.tsx
@@ -24,6 +24,7 @@ const StyledNoAccessContainer = styled.div`
 
 type WidgetCardShellProps = {
   widget: PageLayoutWidget;
+  title?: string;
   variant: WidgetCardVariant;
   isEditable: boolean;
   isEditing: boolean;
@@ -46,6 +47,7 @@ type WidgetCardShellProps = {
 
 export const WidgetCardShell = ({
   widget,
+  title,
   variant,
   isEditable,
   isEditing,
@@ -95,7 +97,7 @@ export const WidgetCardShell = ({
             isResizing={isResizing}
             isReorderEnabled={isReorderEnabled}
             isDeletingWidgetEnabled={isDeletingWidgetEnabled}
-            title={widget.title}
+            title={title ?? widget.title}
             onRemove={onRemove}
             actions={actions}
             forbiddenDisplay={

--- a/packages/twenty-front/src/modules/page-layout/widgets/hooks/useWidgetDerivedTitle.ts
+++ b/packages/twenty-front/src/modules/page-layout/widgets/hooks/useWidgetDerivedTitle.ts
@@ -1,0 +1,49 @@
+import { useFieldMetadataItemById } from '@/object-metadata/hooks/useFieldMetadataItemById';
+import { useObjectMetadataItems } from '@/object-metadata/hooks/useObjectMetadataItems';
+import { useResolveFieldMetadataIdFromNameOrId } from '@/page-layout/hooks/useResolveFieldMetadataIdFromNameOrId';
+import { type PageLayoutWidget } from '@/page-layout/types/PageLayoutWidget';
+import { isFieldWidget } from '@/page-layout/widgets/field/utils/isFieldWidget';
+import { isDefined } from 'twenty-shared/utils';
+import { RelationType } from '~/generated-metadata/graphql';
+
+// Relation-field widget headers must follow the target object's current
+// labelPlural / labelSingular so renames (e.g. Company -> Org) propagate to
+// the details panel (issue #19790).
+export const useWidgetDerivedTitle = (widget: PageLayoutWidget): string => {
+  const fallbackTitle = widget.title ?? '';
+
+  const fieldMetadataIdOrName = isFieldWidget(widget)
+    ? widget.configuration.fieldMetadataId
+    : '';
+
+  const resolvedFieldMetadataId = useResolveFieldMetadataIdFromNameOrId(
+    fieldMetadataIdOrName,
+  );
+
+  const { fieldMetadataItem } = useFieldMetadataItemById(
+    resolvedFieldMetadataId ?? '',
+  );
+
+  const { objectMetadataItems } = useObjectMetadataItems();
+
+  if (!isFieldWidget(widget) || !isDefined(fieldMetadataItem?.relation)) {
+    return fallbackTitle;
+  }
+
+  const targetObjectMetadataItem = objectMetadataItems.find(
+    (objectMetadataItem) =>
+      objectMetadataItem.id ===
+      fieldMetadataItem.relation?.targetObjectMetadata.id,
+  );
+
+  if (!isDefined(targetObjectMetadataItem)) {
+    return fallbackTitle;
+  }
+
+  const isToManyRelation =
+    fieldMetadataItem.relation.type === RelationType.ONE_TO_MANY;
+
+  return isToManyRelation
+    ? targetObjectMetadataItem.labelPlural
+    : targetObjectMetadataItem.labelSingular;
+};

--- a/packages/twenty-front/src/modules/page-layout/widgets/hooks/useWidgetDerivedTitle.ts
+++ b/packages/twenty-front/src/modules/page-layout/widgets/hooks/useWidgetDerivedTitle.ts
@@ -1,17 +1,15 @@
-import { useFieldMetadataItemById } from '@/object-metadata/hooks/useFieldMetadataItemById';
 import { useObjectMetadataItems } from '@/object-metadata/hooks/useObjectMetadataItems';
 import { useResolveFieldMetadataIdFromNameOrId } from '@/page-layout/hooks/useResolveFieldMetadataIdFromNameOrId';
 import { type PageLayoutWidget } from '@/page-layout/types/PageLayoutWidget';
 import { isFieldWidget } from '@/page-layout/widgets/field/utils/isFieldWidget';
+import { useMemo } from 'react';
 import { isDefined } from 'twenty-shared/utils';
 import { RelationType } from '~/generated-metadata/graphql';
 
 // Relation-field widget headers must follow the target object's current
-// labelPlural / labelSingular so renames (e.g. Company -> Org) propagate to
-// the details panel (issue #19790).
+// labelPlural / labelSingular so renames (e.g. Company -> Org) and locale
+// switches propagate to the details panel (issue #19790).
 export const useWidgetDerivedTitle = (widget: PageLayoutWidget): string => {
-  const fallbackTitle = widget.title ?? '';
-
   const fieldMetadataIdOrName = isFieldWidget(widget)
     ? widget.configuration.fieldMetadataId
     : '';
@@ -20,14 +18,28 @@ export const useWidgetDerivedTitle = (widget: PageLayoutWidget): string => {
     fieldMetadataIdOrName,
   );
 
-  const { fieldMetadataItem } = useFieldMetadataItemById(
-    resolvedFieldMetadataId ?? '',
-  );
-
   const { objectMetadataItems } = useObjectMetadataItems();
 
-  if (!isFieldWidget(widget) || !isDefined(fieldMetadataItem?.relation)) {
-    return fallbackTitle;
+  const fieldMetadataItem = useMemo(() => {
+    if (!isDefined(resolvedFieldMetadataId)) {
+      return undefined;
+    }
+
+    for (const objectMetadataItem of objectMetadataItems) {
+      const field = objectMetadataItem.fields.find(
+        ({ id }) => id === resolvedFieldMetadataId,
+      );
+
+      if (isDefined(field)) {
+        return field;
+      }
+    }
+
+    return undefined;
+  }, [objectMetadataItems, resolvedFieldMetadataId]);
+
+  if (!isDefined(fieldMetadataItem?.relation)) {
+    return widget.title;
   }
 
   const targetObjectMetadataItem = objectMetadataItems.find(
@@ -37,7 +49,7 @@ export const useWidgetDerivedTitle = (widget: PageLayoutWidget): string => {
   );
 
   if (!isDefined(targetObjectMetadataItem)) {
-    return fallbackTitle;
+    return widget.title;
   }
 
   const isToManyRelation =


### PR DESCRIPTION
Closes #19790

## What
Object type translations and custom labels (renames) were not applied to
widget titles in the record details side panel (e.g. "People", "Opportunities",
"Company"), causing a mismatch with the rest of the app.

## Why
Standard page-layout widgets store their title as a static string seeded from
`standard-*-page-layout.config.ts` into `core.pageLayoutWidget.title`. That
value is fixed at seed time, so it doesn't follow subsequent object renames
or locale changes.

## How
- Added `useWidgetDerivedTitle` hook at
  `packages/twenty-front/src/modules/page-layout/widgets/hooks/useWidgetDerivedTitle.ts`.
  For a `FIELD` widget backed by a relation field, it resolves the target
  object from `objectMetadataItems` and returns its current `labelPlural`
  (ONE_TO_MANY) or `labelSingular` (MANY_TO_ONE). Non-relation widgets fall
  back to the stored `widget.title`.
- Wired the hook into `RecordPageWidgetRenderer` and passed the derived
  title to `WidgetCardShell` as an optional `title` prop, which overrides
  `widget.title` when present.
- Non-record-page widgets (dashboards etc.) are unaffected.

Translations work for free: the server's `MinimalMetadataService` already
applies Lingui translations to `labelPlural` / `labelSingular` before
returning them, so locale switches propagate without additional code.

## Testing
- Renamed Company → "Org" in Settings → Data model → reopened a Person
  record; the side-panel widget formerly titled "Company" now reads "Org".
- Renamed Person plural → "Humans" → reopened a Company record; the
  "People" widget now reads "Humans".
- Switched app locale; relation widget titles switched with it.
- Verified non-relation widgets (timeline, tasks, notes, system fields)
  are unchanged.

## Screenshot
<img width="1470" height="956" alt="image" src="https://github.com/user-attachments/assets/15ba8096-acb3-4aab-b96b-7210f757f8d7" />

Testing : 
<img width="1470" height="956" alt="image" src="https://github.com/user-attachments/assets/328fe71f-8761-4409-bd2d-a246eac629a7" />


