### PR TITLE
feat: move admin panel to dedicated /admin-panel GraphQL endpoint

### DIFF
--- a/.github/workflows/ci-server.yaml
+++ b/.github/workflows/ci-server.yaml
@@ -25,6 +25,7 @@ jobs:
         packages/twenty-server/**
         packages/twenty-front/src/generated/**
         packages/twenty-front/src/generated-metadata/**
+        packages/twenty-front/src/generated-admin/**
         packages/twenty-client-sdk/**
         packages/twenty-emails/**
         packages/twenty-shared/**

--- a/.github/workflows/ci-server.yaml
+++ b/.github/workflows/ci-server.yaml
@@ -165,13 +165,14 @@ jobs:
 
           npx nx run twenty-front:graphql:generate
           npx nx run twenty-front:graphql:generate --configuration=metadata
+          npx nx run twenty-front:graphql:generate --configuration=admin
 
-          if ! git diff --quiet -- packages/twenty-front/src/generated packages/twenty-front/src/generated-metadata; then
-            echo "::error::GraphQL schema changes detected. Please run 'npx nx run twenty-front:graphql:generate' and 'npx nx run twenty-front:graphql:generate --configuration=metadata' and commit the changes."
+          if ! git diff --quiet -- packages/twenty-front/src/generated packages/twenty-front/src/generated-metadata packages/twenty-front/src/generated-admin; then
+            echo "::error::GraphQL schema changes detected. Please run the three graphql:generate configurations ('data', 'metadata', 'admin') and commit the changes."
             echo ""
             echo "The following GraphQL schema changes were detected:"
             echo "==================================================="
-            git diff -- packages/twenty-front/src/generated packages/twenty-front/src/generated-metadata
+            git diff -- packages/twenty-front/src/generated packages/twenty-front/src/generated-metadata packages/twenty-front/src/generated-admin
             echo "==================================================="
             echo ""
             HAS_ERRORS=true

--- a/packages/twenty-client-sdk/src/metadata/generated/schema.graphql
+++ b/packages/twenty-client-sdk/src/metadata/generated/schema.graphql
@@ -1607,84 +1607,6 @@ type WorkspaceUrls {
   subdomainUrl: String!
 }
 
-type UserInfo {
-  id: UUID!
-  email: String!
-  firstName: String
-  lastName: String
-  createdAt: DateTime!
-}
-
-type WorkspaceInfo {
-  id: UUID!
-  name: String!
-  allowImpersonation: Boolean!
-  logo: String
-  totalUsers: Float!
-  activationStatus: WorkspaceActivationStatus!
-  createdAt: DateTime!
-  workspaceUrls: WorkspaceUrls!
-  users: [UserInfo!]!
-  featureFlags: [FeatureFlag!]!
-}
-
-type UserLookup {
-  user: UserInfo!
-  workspaces: [WorkspaceInfo!]!
-}
-
-type AdminPanelRecentUser {
-  id: UUID!
-  email: String!
-  firstName: String
-  lastName: String
-  createdAt: DateTime!
-  workspaceName: String
-  workspaceId: UUID
-}
-
-type AdminPanelTopWorkspace {
-  id: UUID!
-  name: String!
-  totalUsers: Int!
-  subdomain: String!
-}
-
-type AdminWorkspaceChatThread {
-  id: UUID!
-  title: String
-  totalInputTokens: Int!
-  totalOutputTokens: Int!
-  conversationSize: Int!
-  createdAt: DateTime!
-  updatedAt: DateTime!
-}
-
-type AdminChatMessagePart {
-  type: String!
-  textContent: String
-  toolName: String
-}
-
-type AdminChatMessage {
-  id: UUID!
-  role: AgentMessageRole!
-  parts: [AdminChatMessagePart!]!
-  createdAt: DateTime!
-}
-
-"""Role of a message in a chat thread"""
-enum AgentMessageRole {
-  SYSTEM
-  USER
-  ASSISTANT
-}
-
-type AdminChatThreadMessages {
-  thread: AdminWorkspaceChatThread!
-  messages: [AdminChatMessage!]!
-}
-
 type BillingTrialPeriod {
   duration: Float!
   isCreditCardRequired: Boolean!
@@ -1767,32 +1689,6 @@ enum ModelFamily {
   GEMINI
   MISTRAL
   GROK
-}
-
-type AdminAiModelConfig {
-  modelId: String!
-  label: String!
-  modelFamily: ModelFamily
-  modelFamilyLabel: String
-  sdkPackage: String
-  isAvailable: Boolean!
-  isAdminEnabled: Boolean!
-  isDeprecated: Boolean
-  isRecommended: Boolean
-  contextWindowTokens: Float
-  maxOutputTokens: Float
-  inputCostPerMillionTokens: Float
-  outputCostPerMillionTokens: Float
-  providerName: String
-  providerLabel: String
-  name: String
-  dataResidency: String
-}
-
-type AdminAiModels {
-  models: [AdminAiModelConfig!]!
-  defaultSmartModelId: String
-  defaultFastModelId: String
 }
 
 type Billing {
@@ -1884,228 +1780,6 @@ type UsageBreakdownItem {
   key: String!
   label: String
   creditsUsed: Float!
-}
-
-type ConfigVariable {
-  name: String!
-  description: String!
-  value: JSON
-  isSensitive: Boolean!
-  source: ConfigSource!
-  isEnvOnly: Boolean!
-  type: ConfigVariableType!
-  options: JSON
-}
-
-enum ConfigSource {
-  ENVIRONMENT
-  DATABASE
-  DEFAULT
-}
-
-enum ConfigVariableType {
-  BOOLEAN
-  NUMBER
-  ARRAY
-  STRING
-  ENUM
-  JSON
-}
-
-type ConfigVariablesGroupData {
-  variables: [ConfigVariable!]!
-  name: ConfigVariablesGroup!
-  description: String!
-  isHiddenOnLoad: Boolean!
-}
-
-enum ConfigVariablesGroup {
-  SERVER_CONFIG
-  RATE_LIMITING
-  STORAGE_CONFIG
-  GOOGLE_AUTH
-  MICROSOFT_AUTH
-  EMAIL_SETTINGS
-  LOGGING
-  ADVANCED_SETTINGS
-  BILLING_CONFIG
-  CAPTCHA_CONFIG
-  CLOUDFLARE_CONFIG
-  LLM
-  LOGIC_FUNCTION_CONFIG
-  CODE_INTERPRETER_CONFIG
-  SSL
-  SUPPORT_CHAT_CONFIG
-  ANALYTICS_CONFIG
-  TOKENS_DURATION
-  AWS_SES_SETTINGS
-}
-
-type ConfigVariables {
-  groups: [ConfigVariablesGroupData!]!
-}
-
-type JobOperationResult {
-  jobId: String!
-  success: Boolean!
-  error: String
-}
-
-type DeleteJobsResponse {
-  deletedCount: Int!
-  results: [JobOperationResult!]!
-}
-
-type QueueJob {
-  id: String!
-  name: String!
-  data: JSON
-  state: JobState!
-  timestamp: Float
-  failedReason: String
-  processedOn: Float
-  finishedOn: Float
-  attemptsMade: Float!
-  returnValue: JSON
-  logs: [String!]
-  stackTrace: [String!]
-}
-
-"""Job state in the queue"""
-enum JobState {
-  COMPLETED
-  FAILED
-  ACTIVE
-  WAITING
-  DELAYED
-  PRIORITIZED
-  WAITING_CHILDREN
-}
-
-type QueueRetentionConfig {
-  completedMaxAge: Float!
-  completedMaxCount: Float!
-  failedMaxAge: Float!
-  failedMaxCount: Float!
-}
-
-type QueueJobsResponse {
-  jobs: [QueueJob!]!
-  count: Float!
-  totalCount: Float!
-  hasMore: Boolean!
-  retentionConfig: QueueRetentionConfig!
-}
-
-type RetryJobsResponse {
-  retriedCount: Int!
-  results: [JobOperationResult!]!
-}
-
-type SystemHealthService {
-  id: HealthIndicatorId!
-  label: String!
-  status: AdminPanelHealthServiceStatus!
-}
-
-enum HealthIndicatorId {
-  database
-  redis
-  worker
-  connectedAccount
-  app
-}
-
-enum AdminPanelHealthServiceStatus {
-  OPERATIONAL
-  OUTAGE
-}
-
-type SystemHealth {
-  services: [SystemHealthService!]!
-}
-
-type VersionInfo {
-  currentVersion: String
-  latestVersion: String!
-}
-
-type AdminPanelWorkerQueueHealth {
-  id: String!
-  queueName: String!
-  status: AdminPanelHealthServiceStatus!
-}
-
-type AdminPanelHealthServiceData {
-  id: HealthIndicatorId!
-  label: String!
-  description: String!
-  status: AdminPanelHealthServiceStatus!
-  errorMessage: String
-  details: String
-  queues: [AdminPanelWorkerQueueHealth!]
-}
-
-type MaintenanceMode {
-  startAt: DateTime!
-  endAt: DateTime!
-  link: String
-}
-
-type ModelsDevModelSuggestion {
-  modelId: String!
-  name: String!
-  inputCostPerMillionTokens: Float!
-  outputCostPerMillionTokens: Float!
-  cachedInputCostPerMillionTokens: Float
-  cacheCreationCostPerMillionTokens: Float
-  contextWindowTokens: Float!
-  maxOutputTokens: Float!
-  modalities: [String!]!
-  supportsReasoning: Boolean!
-}
-
-type ModelsDevProviderSuggestion {
-  id: String!
-  modelCount: Float!
-  npm: String!
-}
-
-type QueueMetricsDataPoint {
-  x: Float!
-  y: Float!
-}
-
-type QueueMetricsSeries {
-  id: String!
-  data: [QueueMetricsDataPoint!]!
-}
-
-type WorkerQueueMetrics {
-  failed: Float!
-  completed: Float!
-  waiting: Float!
-  active: Float!
-  delayed: Float!
-  failureRate: Float!
-  failedData: [Float!]
-  completedData: [Float!]
-}
-
-type QueueMetricsData {
-  queueName: String!
-  workers: Float!
-  timeRange: QueueMetricsTimeRange!
-  details: WorkerQueueMetrics
-  data: [QueueMetricsSeries!]!
-}
-
-enum QueueMetricsTimeRange {
-  SevenDays
-  OneDay
-  TwelveHours
-  FourHours
-  OneHour
 }
 
 type VersionDistributionEntry {
@@ -3356,27 +3030,6 @@ type Query {
   getConnectedImapSmtpCaldavAccount(id: UUID!): ConnectedImapSmtpCaldavAccount!
   getAutoCompleteAddress(address: String!, token: String!, country: String, isFieldCity: Boolean): [AutocompleteResult!]!
   getAddressDetails(placeId: String!, token: String!): PlaceDetailsResult!
-  userLookupAdminPanel(userIdentifier: String!): UserLookup!
-  adminPanelRecentUsers(searchTerm: String = ""): [AdminPanelRecentUser!]!
-  adminPanelTopWorkspaces(searchTerm: String = ""): [AdminPanelTopWorkspace!]!
-  getConfigVariablesGrouped: ConfigVariables!
-  getSystemHealthStatus: SystemHealth!
-  getIndicatorHealthStatus(indicatorId: HealthIndicatorId!): AdminPanelHealthServiceData!
-  getQueueMetrics(queueName: String!, timeRange: QueueMetricsTimeRange = OneHour): QueueMetricsData!
-  versionInfo: VersionInfo!
-  getAdminAiModels: AdminAiModels!
-  getDatabaseConfigVariable(key: String!): ConfigVariable!
-  getQueueJobs(queueName: String!, state: JobState!, limit: Int = 50, offset: Int = 0): QueueJobsResponse!
-  findAllApplicationRegistrations: [ApplicationRegistration!]!
-  getAiProviders: JSON!
-  getModelsDevProviders: [ModelsDevProviderSuggestion!]!
-  getModelsDevSuggestions(providerType: String!): [ModelsDevModelSuggestion!]!
-  getAdminAiUsageByWorkspace(periodStart: DateTime, periodEnd: DateTime): [UsageBreakdownItem!]!
-  getMaintenanceMode: MaintenanceMode
-  workspaceLookupAdminPanel(workspaceId: UUID!): UserLookup!
-  getAdminWorkspaceChatThreads(workspaceId: UUID!): [AdminWorkspaceChatThread!]!
-  getAdminChatThreadMessages(threadId: UUID!): AdminChatThreadMessages!
-  findOneAdminApplicationRegistration(id: String!): ApplicationRegistration!
   getUsageAnalytics(input: UsageAnalyticsInput): UsageAnalytics!
   getPostgresCredentials: PostgresCredentials
   findManyPublicDomains: [PublicDomain!]!
@@ -3691,23 +3344,6 @@ type Mutation {
   startChannelSync(connectedAccountId: UUID!): ChannelSyncSuccess!
   saveImapSmtpCaldavAccount(accountOwnerId: UUID!, handle: String!, connectionParameters: EmailAccountConnectionParameters!, id: UUID): ImapSmtpCaldavConnectionSuccess!
   updateLabPublicFeatureFlag(input: UpdateLabPublicFeatureFlagInput!): FeatureFlag!
-  updateWorkspaceFeatureFlag(workspaceId: UUID!, featureFlag: String!, value: Boolean!): Boolean!
-  setAdminAiModelEnabled(modelId: String!, enabled: Boolean!): Boolean!
-  setAdminAiModelsEnabled(modelIds: [String!]!, enabled: Boolean!): Boolean!
-  setAdminAiModelRecommended(modelId: String!, recommended: Boolean!): Boolean!
-  setAdminAiModelsRecommended(modelIds: [String!]!, recommended: Boolean!): Boolean!
-  setAdminDefaultAiModel(role: AiModelRole!, modelId: String!): Boolean!
-  createDatabaseConfigVariable(key: String!, value: JSON!): Boolean!
-  updateDatabaseConfigVariable(key: String!, value: JSON!): Boolean!
-  deleteDatabaseConfigVariable(key: String!): Boolean!
-  retryJobs(queueName: String!, jobIds: [String!]!): RetryJobsResponse!
-  deleteJobs(queueName: String!, jobIds: [String!]!): DeleteJobsResponse!
-  addAiProvider(providerName: String!, providerConfig: JSON!): Boolean!
-  removeAiProvider(providerName: String!): Boolean!
-  addModelToProvider(providerName: String!, modelConfig: JSON!): Boolean!
-  removeModelFromProvider(providerName: String!, modelName: String!): Boolean!
-  setMaintenanceMode(startAt: DateTime!, endAt: DateTime!, link: String): Boolean!
-  clearMaintenanceMode: Boolean!
   enablePostgresProxy: PostgresCredentials!
   disablePostgresProxy: PostgresCredentials!
   createPublicDomain(domain: String!): PublicDomain!
@@ -4706,11 +4342,6 @@ input ConnectionParameters {
 input UpdateLabPublicFeatureFlagInput {
   publicFeatureFlag: String!
   value: Boolean!
-}
-
-enum AiModelRole {
-  FAST
-  SMART
 }
 
 input CreateOneAppTokenInput {

--- a/packages/twenty-client-sdk/src/metadata/generated/schema.ts
+++ b/packages/twenty-client-sdk/src/metadata/generated/schema.ts
@@ -1302,90 +1302,6 @@ export interface WorkspaceUrls {
     __typename: 'WorkspaceUrls'
 }
 
-export interface UserInfo {
-    id: Scalars['UUID']
-    email: Scalars['String']
-    firstName?: Scalars['String']
-    lastName?: Scalars['String']
-    createdAt: Scalars['DateTime']
-    __typename: 'UserInfo'
-}
-
-export interface WorkspaceInfo {
-    id: Scalars['UUID']
-    name: Scalars['String']
-    allowImpersonation: Scalars['Boolean']
-    logo?: Scalars['String']
-    totalUsers: Scalars['Float']
-    activationStatus: WorkspaceActivationStatus
-    createdAt: Scalars['DateTime']
-    workspaceUrls: WorkspaceUrls
-    users: UserInfo[]
-    featureFlags: FeatureFlag[]
-    __typename: 'WorkspaceInfo'
-}
-
-export interface UserLookup {
-    user: UserInfo
-    workspaces: WorkspaceInfo[]
-    __typename: 'UserLookup'
-}
-
-export interface AdminPanelRecentUser {
-    id: Scalars['UUID']
-    email: Scalars['String']
-    firstName?: Scalars['String']
-    lastName?: Scalars['String']
-    createdAt: Scalars['DateTime']
-    workspaceName?: Scalars['String']
-    workspaceId?: Scalars['UUID']
-    __typename: 'AdminPanelRecentUser'
-}
-
-export interface AdminPanelTopWorkspace {
-    id: Scalars['UUID']
-    name: Scalars['String']
-    totalUsers: Scalars['Int']
-    subdomain: Scalars['String']
-    __typename: 'AdminPanelTopWorkspace'
-}
-
-export interface AdminWorkspaceChatThread {
-    id: Scalars['UUID']
-    title?: Scalars['String']
-    totalInputTokens: Scalars['Int']
-    totalOutputTokens: Scalars['Int']
-    conversationSize: Scalars['Int']
-    createdAt: Scalars['DateTime']
-    updatedAt: Scalars['DateTime']
-    __typename: 'AdminWorkspaceChatThread'
-}
-
-export interface AdminChatMessagePart {
-    type: Scalars['String']
-    textContent?: Scalars['String']
-    toolName?: Scalars['String']
-    __typename: 'AdminChatMessagePart'
-}
-
-export interface AdminChatMessage {
-    id: Scalars['UUID']
-    role: AgentMessageRole
-    parts: AdminChatMessagePart[]
-    createdAt: Scalars['DateTime']
-    __typename: 'AdminChatMessage'
-}
-
-
-/** Role of a message in a chat thread */
-export type AgentMessageRole = 'SYSTEM' | 'USER' | 'ASSISTANT'
-
-export interface AdminChatThreadMessages {
-    thread: AdminWorkspaceChatThread
-    messages: AdminChatMessage[]
-    __typename: 'AdminChatThreadMessages'
-}
-
 export interface BillingTrialPeriod {
     duration: Scalars['Float']
     isCreditCardRequired: Scalars['Boolean']
@@ -1464,34 +1380,6 @@ export interface ClientAiModelConfig {
 }
 
 export type ModelFamily = 'GPT' | 'CLAUDE' | 'GEMINI' | 'MISTRAL' | 'GROK'
-
-export interface AdminAiModelConfig {
-    modelId: Scalars['String']
-    label: Scalars['String']
-    modelFamily?: ModelFamily
-    modelFamilyLabel?: Scalars['String']
-    sdkPackage?: Scalars['String']
-    isAvailable: Scalars['Boolean']
-    isAdminEnabled: Scalars['Boolean']
-    isDeprecated?: Scalars['Boolean']
-    isRecommended?: Scalars['Boolean']
-    contextWindowTokens?: Scalars['Float']
-    maxOutputTokens?: Scalars['Float']
-    inputCostPerMillionTokens?: Scalars['Float']
-    outputCostPerMillionTokens?: Scalars['Float']
-    providerName?: Scalars['String']
-    providerLabel?: Scalars['String']
-    name?: Scalars['String']
-    dataResidency?: Scalars['String']
-    __typename: 'AdminAiModelConfig'
-}
-
-export interface AdminAiModels {
-    models: AdminAiModelConfig[]
-    defaultSmartModelId?: Scalars['String']
-    defaultFastModelId?: Scalars['String']
-    __typename: 'AdminAiModels'
-}
 
 export interface Billing {
     isBillingEnabled: Scalars['Boolean']
@@ -1587,196 +1475,6 @@ export interface UsageBreakdownItem {
     creditsUsed: Scalars['Float']
     __typename: 'UsageBreakdownItem'
 }
-
-export interface ConfigVariable {
-    name: Scalars['String']
-    description: Scalars['String']
-    value?: Scalars['JSON']
-    isSensitive: Scalars['Boolean']
-    source: ConfigSource
-    isEnvOnly: Scalars['Boolean']
-    type: ConfigVariableType
-    options?: Scalars['JSON']
-    __typename: 'ConfigVariable'
-}
-
-export type ConfigSource = 'ENVIRONMENT' | 'DATABASE' | 'DEFAULT'
-
-export type ConfigVariableType = 'BOOLEAN' | 'NUMBER' | 'ARRAY' | 'STRING' | 'ENUM' | 'JSON'
-
-export interface ConfigVariablesGroupData {
-    variables: ConfigVariable[]
-    name: ConfigVariablesGroup
-    description: Scalars['String']
-    isHiddenOnLoad: Scalars['Boolean']
-    __typename: 'ConfigVariablesGroupData'
-}
-
-export type ConfigVariablesGroup = 'SERVER_CONFIG' | 'RATE_LIMITING' | 'STORAGE_CONFIG' | 'GOOGLE_AUTH' | 'MICROSOFT_AUTH' | 'EMAIL_SETTINGS' | 'LOGGING' | 'ADVANCED_SETTINGS' | 'BILLING_CONFIG' | 'CAPTCHA_CONFIG' | 'CLOUDFLARE_CONFIG' | 'LLM' | 'LOGIC_FUNCTION_CONFIG' | 'CODE_INTERPRETER_CONFIG' | 'SSL' | 'SUPPORT_CHAT_CONFIG' | 'ANALYTICS_CONFIG' | 'TOKENS_DURATION' | 'AWS_SES_SETTINGS'
-
-export interface ConfigVariables {
-    groups: ConfigVariablesGroupData[]
-    __typename: 'ConfigVariables'
-}
-
-export interface JobOperationResult {
-    jobId: Scalars['String']
-    success: Scalars['Boolean']
-    error?: Scalars['String']
-    __typename: 'JobOperationResult'
-}
-
-export interface DeleteJobsResponse {
-    deletedCount: Scalars['Int']
-    results: JobOperationResult[]
-    __typename: 'DeleteJobsResponse'
-}
-
-export interface QueueJob {
-    id: Scalars['String']
-    name: Scalars['String']
-    data?: Scalars['JSON']
-    state: JobState
-    timestamp?: Scalars['Float']
-    failedReason?: Scalars['String']
-    processedOn?: Scalars['Float']
-    finishedOn?: Scalars['Float']
-    attemptsMade: Scalars['Float']
-    returnValue?: Scalars['JSON']
-    logs?: Scalars['String'][]
-    stackTrace?: Scalars['String'][]
-    __typename: 'QueueJob'
-}
-
-
-/** Job state in the queue */
-export type JobState = 'COMPLETED' | 'FAILED' | 'ACTIVE' | 'WAITING' | 'DELAYED' | 'PRIORITIZED' | 'WAITING_CHILDREN'
-
-export interface QueueRetentionConfig {
-    completedMaxAge: Scalars['Float']
-    completedMaxCount: Scalars['Float']
-    failedMaxAge: Scalars['Float']
-    failedMaxCount: Scalars['Float']
-    __typename: 'QueueRetentionConfig'
-}
-
-export interface QueueJobsResponse {
-    jobs: QueueJob[]
-    count: Scalars['Float']
-    totalCount: Scalars['Float']
-    hasMore: Scalars['Boolean']
-    retentionConfig: QueueRetentionConfig
-    __typename: 'QueueJobsResponse'
-}
-
-export interface RetryJobsResponse {
-    retriedCount: Scalars['Int']
-    results: JobOperationResult[]
-    __typename: 'RetryJobsResponse'
-}
-
-export interface SystemHealthService {
-    id: HealthIndicatorId
-    label: Scalars['String']
-    status: AdminPanelHealthServiceStatus
-    __typename: 'SystemHealthService'
-}
-
-export type HealthIndicatorId = 'database' | 'redis' | 'worker' | 'connectedAccount' | 'app'
-
-export type AdminPanelHealthServiceStatus = 'OPERATIONAL' | 'OUTAGE'
-
-export interface SystemHealth {
-    services: SystemHealthService[]
-    __typename: 'SystemHealth'
-}
-
-export interface VersionInfo {
-    currentVersion?: Scalars['String']
-    latestVersion: Scalars['String']
-    __typename: 'VersionInfo'
-}
-
-export interface AdminPanelWorkerQueueHealth {
-    id: Scalars['String']
-    queueName: Scalars['String']
-    status: AdminPanelHealthServiceStatus
-    __typename: 'AdminPanelWorkerQueueHealth'
-}
-
-export interface AdminPanelHealthServiceData {
-    id: HealthIndicatorId
-    label: Scalars['String']
-    description: Scalars['String']
-    status: AdminPanelHealthServiceStatus
-    errorMessage?: Scalars['String']
-    details?: Scalars['String']
-    queues?: AdminPanelWorkerQueueHealth[]
-    __typename: 'AdminPanelHealthServiceData'
-}
-
-export interface MaintenanceMode {
-    startAt: Scalars['DateTime']
-    endAt: Scalars['DateTime']
-    link?: Scalars['String']
-    __typename: 'MaintenanceMode'
-}
-
-export interface ModelsDevModelSuggestion {
-    modelId: Scalars['String']
-    name: Scalars['String']
-    inputCostPerMillionTokens: Scalars['Float']
-    outputCostPerMillionTokens: Scalars['Float']
-    cachedInputCostPerMillionTokens?: Scalars['Float']
-    cacheCreationCostPerMillionTokens?: Scalars['Float']
-    contextWindowTokens: Scalars['Float']
-    maxOutputTokens: Scalars['Float']
-    modalities: Scalars['String'][]
-    supportsReasoning: Scalars['Boolean']
-    __typename: 'ModelsDevModelSuggestion'
-}
-
-export interface ModelsDevProviderSuggestion {
-    id: Scalars['String']
-    modelCount: Scalars['Float']
-    npm: Scalars['String']
-    __typename: 'ModelsDevProviderSuggestion'
-}
-
-export interface QueueMetricsDataPoint {
-    x: Scalars['Float']
-    y: Scalars['Float']
-    __typename: 'QueueMetricsDataPoint'
-}
-
-export interface QueueMetricsSeries {
-    id: Scalars['String']
-    data: QueueMetricsDataPoint[]
-    __typename: 'QueueMetricsSeries'
-}
-
-export interface WorkerQueueMetrics {
-    failed: Scalars['Float']
-    completed: Scalars['Float']
-    waiting: Scalars['Float']
-    active: Scalars['Float']
-    delayed: Scalars['Float']
-    failureRate: Scalars['Float']
-    failedData?: Scalars['Float'][]
-    completedData?: Scalars['Float'][]
-    __typename: 'WorkerQueueMetrics'
-}
-
-export interface QueueMetricsData {
-    queueName: Scalars['String']
-    workers: Scalars['Float']
-    timeRange: QueueMetricsTimeRange
-    details?: WorkerQueueMetrics
-    data: QueueMetricsSeries[]
-    __typename: 'QueueMetricsData'
-}
-
-export type QueueMetricsTimeRange = 'SevenDays' | 'OneDay' | 'TwelveHours' | 'FourHours' | 'OneHour'
 
 export interface VersionDistributionEntry {
     version: Scalars['String']
@@ -2919,27 +2617,6 @@ export interface Query {
     getConnectedImapSmtpCaldavAccount: ConnectedImapSmtpCaldavAccount
     getAutoCompleteAddress: AutocompleteResult[]
     getAddressDetails: PlaceDetailsResult
-    userLookupAdminPanel: UserLookup
-    adminPanelRecentUsers: AdminPanelRecentUser[]
-    adminPanelTopWorkspaces: AdminPanelTopWorkspace[]
-    getConfigVariablesGrouped: ConfigVariables
-    getSystemHealthStatus: SystemHealth
-    getIndicatorHealthStatus: AdminPanelHealthServiceData
-    getQueueMetrics: QueueMetricsData
-    versionInfo: VersionInfo
-    getAdminAiModels: AdminAiModels
-    getDatabaseConfigVariable: ConfigVariable
-    getQueueJobs: QueueJobsResponse
-    findAllApplicationRegistrations: ApplicationRegistration[]
-    getAiProviders: Scalars['JSON']
-    getModelsDevProviders: ModelsDevProviderSuggestion[]
-    getModelsDevSuggestions: ModelsDevModelSuggestion[]
-    getAdminAiUsageByWorkspace: UsageBreakdownItem[]
-    getMaintenanceMode?: MaintenanceMode
-    workspaceLookupAdminPanel: UserLookup
-    getAdminWorkspaceChatThreads: AdminWorkspaceChatThread[]
-    getAdminChatThreadMessages: AdminChatThreadMessages
-    findOneAdminApplicationRegistration: ApplicationRegistration
     getUsageAnalytics: UsageAnalytics
     getPostgresCredentials?: PostgresCredentials
     findManyPublicDomains: PublicDomain[]
@@ -3147,23 +2824,6 @@ export interface Mutation {
     startChannelSync: ChannelSyncSuccess
     saveImapSmtpCaldavAccount: ImapSmtpCaldavConnectionSuccess
     updateLabPublicFeatureFlag: FeatureFlag
-    updateWorkspaceFeatureFlag: Scalars['Boolean']
-    setAdminAiModelEnabled: Scalars['Boolean']
-    setAdminAiModelsEnabled: Scalars['Boolean']
-    setAdminAiModelRecommended: Scalars['Boolean']
-    setAdminAiModelsRecommended: Scalars['Boolean']
-    setAdminDefaultAiModel: Scalars['Boolean']
-    createDatabaseConfigVariable: Scalars['Boolean']
-    updateDatabaseConfigVariable: Scalars['Boolean']
-    deleteDatabaseConfigVariable: Scalars['Boolean']
-    retryJobs: RetryJobsResponse
-    deleteJobs: DeleteJobsResponse
-    addAiProvider: Scalars['Boolean']
-    removeAiProvider: Scalars['Boolean']
-    addModelToProvider: Scalars['Boolean']
-    removeModelFromProvider: Scalars['Boolean']
-    setMaintenanceMode: Scalars['Boolean']
-    clearMaintenanceMode: Scalars['Boolean']
     enablePostgresProxy: PostgresCredentials
     disablePostgresProxy: PostgresCredentials
     createPublicDomain: PublicDomain
@@ -3189,8 +2849,6 @@ export interface Mutation {
 }
 
 export type AnalyticsType = 'PAGEVIEW' | 'TRACK'
-
-export type AiModelRole = 'FAST' | 'SMART'
 
 export type WorkspaceMigrationActionType = 'delete' | 'create' | 'update'
 
@@ -4556,95 +4214,6 @@ export interface WorkspaceUrlsGenqlSelection{
     __scalar?: boolean | number
 }
 
-export interface UserInfoGenqlSelection{
-    id?: boolean | number
-    email?: boolean | number
-    firstName?: boolean | number
-    lastName?: boolean | number
-    createdAt?: boolean | number
-    __typename?: boolean | number
-    __scalar?: boolean | number
-}
-
-export interface WorkspaceInfoGenqlSelection{
-    id?: boolean | number
-    name?: boolean | number
-    allowImpersonation?: boolean | number
-    logo?: boolean | number
-    totalUsers?: boolean | number
-    activationStatus?: boolean | number
-    createdAt?: boolean | number
-    workspaceUrls?: WorkspaceUrlsGenqlSelection
-    users?: UserInfoGenqlSelection
-    featureFlags?: FeatureFlagGenqlSelection
-    __typename?: boolean | number
-    __scalar?: boolean | number
-}
-
-export interface UserLookupGenqlSelection{
-    user?: UserInfoGenqlSelection
-    workspaces?: WorkspaceInfoGenqlSelection
-    __typename?: boolean | number
-    __scalar?: boolean | number
-}
-
-export interface AdminPanelRecentUserGenqlSelection{
-    id?: boolean | number
-    email?: boolean | number
-    firstName?: boolean | number
-    lastName?: boolean | number
-    createdAt?: boolean | number
-    workspaceName?: boolean | number
-    workspaceId?: boolean | number
-    __typename?: boolean | number
-    __scalar?: boolean | number
-}
-
-export interface AdminPanelTopWorkspaceGenqlSelection{
-    id?: boolean | number
-    name?: boolean | number
-    totalUsers?: boolean | number
-    subdomain?: boolean | number
-    __typename?: boolean | number
-    __scalar?: boolean | number
-}
-
-export interface AdminWorkspaceChatThreadGenqlSelection{
-    id?: boolean | number
-    title?: boolean | number
-    totalInputTokens?: boolean | number
-    totalOutputTokens?: boolean | number
-    conversationSize?: boolean | number
-    createdAt?: boolean | number
-    updatedAt?: boolean | number
-    __typename?: boolean | number
-    __scalar?: boolean | number
-}
-
-export interface AdminChatMessagePartGenqlSelection{
-    type?: boolean | number
-    textContent?: boolean | number
-    toolName?: boolean | number
-    __typename?: boolean | number
-    __scalar?: boolean | number
-}
-
-export interface AdminChatMessageGenqlSelection{
-    id?: boolean | number
-    role?: boolean | number
-    parts?: AdminChatMessagePartGenqlSelection
-    createdAt?: boolean | number
-    __typename?: boolean | number
-    __scalar?: boolean | number
-}
-
-export interface AdminChatThreadMessagesGenqlSelection{
-    thread?: AdminWorkspaceChatThreadGenqlSelection
-    messages?: AdminChatMessageGenqlSelection
-    __typename?: boolean | number
-    __scalar?: boolean | number
-}
-
 export interface BillingTrialPeriodGenqlSelection{
     duration?: boolean | number
     isCreditCardRequired?: boolean | number
@@ -4722,36 +4291,6 @@ export interface ClientAiModelConfigGenqlSelection{
     contextWindowTokens?: boolean | number
     maxOutputTokens?: boolean | number
     dataResidency?: boolean | number
-    __typename?: boolean | number
-    __scalar?: boolean | number
-}
-
-export interface AdminAiModelConfigGenqlSelection{
-    modelId?: boolean | number
-    label?: boolean | number
-    modelFamily?: boolean | number
-    modelFamilyLabel?: boolean | number
-    sdkPackage?: boolean | number
-    isAvailable?: boolean | number
-    isAdminEnabled?: boolean | number
-    isDeprecated?: boolean | number
-    isRecommended?: boolean | number
-    contextWindowTokens?: boolean | number
-    maxOutputTokens?: boolean | number
-    inputCostPerMillionTokens?: boolean | number
-    outputCostPerMillionTokens?: boolean | number
-    providerName?: boolean | number
-    providerLabel?: boolean | number
-    name?: boolean | number
-    dataResidency?: boolean | number
-    __typename?: boolean | number
-    __scalar?: boolean | number
-}
-
-export interface AdminAiModelsGenqlSelection{
-    models?: AdminAiModelConfigGenqlSelection
-    defaultSmartModelId?: boolean | number
-    defaultFastModelId?: boolean | number
     __typename?: boolean | number
     __scalar?: boolean | number
 }
@@ -4853,201 +4392,6 @@ export interface UsageBreakdownItemGenqlSelection{
     key?: boolean | number
     label?: boolean | number
     creditsUsed?: boolean | number
-    __typename?: boolean | number
-    __scalar?: boolean | number
-}
-
-export interface ConfigVariableGenqlSelection{
-    name?: boolean | number
-    description?: boolean | number
-    value?: boolean | number
-    isSensitive?: boolean | number
-    source?: boolean | number
-    isEnvOnly?: boolean | number
-    type?: boolean | number
-    options?: boolean | number
-    __typename?: boolean | number
-    __scalar?: boolean | number
-}
-
-export interface ConfigVariablesGroupDataGenqlSelection{
-    variables?: ConfigVariableGenqlSelection
-    name?: boolean | number
-    description?: boolean | number
-    isHiddenOnLoad?: boolean | number
-    __typename?: boolean | number
-    __scalar?: boolean | number
-}
-
-export interface ConfigVariablesGenqlSelection{
-    groups?: ConfigVariablesGroupDataGenqlSelection
-    __typename?: boolean | number
-    __scalar?: boolean | number
-}
-
-export interface JobOperationResultGenqlSelection{
-    jobId?: boolean | number
-    success?: boolean | number
-    error?: boolean | number
-    __typename?: boolean | number
-    __scalar?: boolean | number
-}
-
-export interface DeleteJobsResponseGenqlSelection{
-    deletedCount?: boolean | number
-    results?: JobOperationResultGenqlSelection
-    __typename?: boolean | number
-    __scalar?: boolean | number
-}
-
-export interface QueueJobGenqlSelection{
-    id?: boolean | number
-    name?: boolean | number
-    data?: boolean | number
-    state?: boolean | number
-    timestamp?: boolean | number
-    failedReason?: boolean | number
-    processedOn?: boolean | number
-    finishedOn?: boolean | number
-    attemptsMade?: boolean | number
-    returnValue?: boolean | number
-    logs?: boolean | number
-    stackTrace?: boolean | number
-    __typename?: boolean | number
-    __scalar?: boolean | number
-}
-
-export interface QueueRetentionConfigGenqlSelection{
-    completedMaxAge?: boolean | number
-    completedMaxCount?: boolean | number
-    failedMaxAge?: boolean | number
-    failedMaxCount?: boolean | number
-    __typename?: boolean | number
-    __scalar?: boolean | number
-}
-
-export interface QueueJobsResponseGenqlSelection{
-    jobs?: QueueJobGenqlSelection
-    count?: boolean | number
-    totalCount?: boolean | number
-    hasMore?: boolean | number
-    retentionConfig?: QueueRetentionConfigGenqlSelection
-    __typename?: boolean | number
-    __scalar?: boolean | number
-}
-
-export interface RetryJobsResponseGenqlSelection{
-    retriedCount?: boolean | number
-    results?: JobOperationResultGenqlSelection
-    __typename?: boolean | number
-    __scalar?: boolean | number
-}
-
-export interface SystemHealthServiceGenqlSelection{
-    id?: boolean | number
-    label?: boolean | number
-    status?: boolean | number
-    __typename?: boolean | number
-    __scalar?: boolean | number
-}
-
-export interface SystemHealthGenqlSelection{
-    services?: SystemHealthServiceGenqlSelection
-    __typename?: boolean | number
-    __scalar?: boolean | number
-}
-
-export interface VersionInfoGenqlSelection{
-    currentVersion?: boolean | number
-    latestVersion?: boolean | number
-    __typename?: boolean | number
-    __scalar?: boolean | number
-}
-
-export interface AdminPanelWorkerQueueHealthGenqlSelection{
-    id?: boolean | number
-    queueName?: boolean | number
-    status?: boolean | number
-    __typename?: boolean | number
-    __scalar?: boolean | number
-}
-
-export interface AdminPanelHealthServiceDataGenqlSelection{
-    id?: boolean | number
-    label?: boolean | number
-    description?: boolean | number
-    status?: boolean | number
-    errorMessage?: boolean | number
-    details?: boolean | number
-    queues?: AdminPanelWorkerQueueHealthGenqlSelection
-    __typename?: boolean | number
-    __scalar?: boolean | number
-}
-
-export interface MaintenanceModeGenqlSelection{
-    startAt?: boolean | number
-    endAt?: boolean | number
-    link?: boolean | number
-    __typename?: boolean | number
-    __scalar?: boolean | number
-}
-
-export interface ModelsDevModelSuggestionGenqlSelection{
-    modelId?: boolean | number
-    name?: boolean | number
-    inputCostPerMillionTokens?: boolean | number
-    outputCostPerMillionTokens?: boolean | number
-    cachedInputCostPerMillionTokens?: boolean | number
-    cacheCreationCostPerMillionTokens?: boolean | number
-    contextWindowTokens?: boolean | number
-    maxOutputTokens?: boolean | number
-    modalities?: boolean | number
-    supportsReasoning?: boolean | number
-    __typename?: boolean | number
-    __scalar?: boolean | number
-}
-
-export interface ModelsDevProviderSuggestionGenqlSelection{
-    id?: boolean | number
-    modelCount?: boolean | number
-    npm?: boolean | number
-    __typename?: boolean | number
-    __scalar?: boolean | number
-}
-
-export interface QueueMetricsDataPointGenqlSelection{
-    x?: boolean | number
-    y?: boolean | number
-    __typename?: boolean | number
-    __scalar?: boolean | number
-}
-
-export interface QueueMetricsSeriesGenqlSelection{
-    id?: boolean | number
-    data?: QueueMetricsDataPointGenqlSelection
-    __typename?: boolean | number
-    __scalar?: boolean | number
-}
-
-export interface WorkerQueueMetricsGenqlSelection{
-    failed?: boolean | number
-    completed?: boolean | number
-    waiting?: boolean | number
-    active?: boolean | number
-    delayed?: boolean | number
-    failureRate?: boolean | number
-    failedData?: boolean | number
-    completedData?: boolean | number
-    __typename?: boolean | number
-    __scalar?: boolean | number
-}
-
-export interface QueueMetricsDataGenqlSelection{
-    queueName?: boolean | number
-    workers?: boolean | number
-    timeRange?: boolean | number
-    details?: WorkerQueueMetricsGenqlSelection
-    data?: QueueMetricsSeriesGenqlSelection
     __typename?: boolean | number
     __scalar?: boolean | number
 }
@@ -6299,27 +5643,6 @@ export interface QueryGenqlSelection{
     getConnectedImapSmtpCaldavAccount?: (ConnectedImapSmtpCaldavAccountGenqlSelection & { __args: {id: Scalars['UUID']} })
     getAutoCompleteAddress?: (AutocompleteResultGenqlSelection & { __args: {address: Scalars['String'], token: Scalars['String'], country?: (Scalars['String'] | null), isFieldCity?: (Scalars['Boolean'] | null)} })
     getAddressDetails?: (PlaceDetailsResultGenqlSelection & { __args: {placeId: Scalars['String'], token: Scalars['String']} })
-    userLookupAdminPanel?: (UserLookupGenqlSelection & { __args: {userIdentifier: Scalars['String']} })
-    adminPanelRecentUsers?: (AdminPanelRecentUserGenqlSelection & { __args?: {searchTerm?: (Scalars['String'] | null)} })
-    adminPanelTopWorkspaces?: (AdminPanelTopWorkspaceGenqlSelection & { __args?: {searchTerm?: (Scalars['String'] | null)} })
-    getConfigVariablesGrouped?: ConfigVariablesGenqlSelection
-    getSystemHealthStatus?: SystemHealthGenqlSelection
-    getIndicatorHealthStatus?: (AdminPanelHealthServiceDataGenqlSelection & { __args: {indicatorId: HealthIndicatorId} })
-    getQueueMetrics?: (QueueMetricsDataGenqlSelection & { __args: {queueName: Scalars['String'], timeRange?: (QueueMetricsTimeRange | null)} })
-    versionInfo?: VersionInfoGenqlSelection
-    getAdminAiModels?: AdminAiModelsGenqlSelection
-    getDatabaseConfigVariable?: (ConfigVariableGenqlSelection & { __args: {key: Scalars['String']} })
-    getQueueJobs?: (QueueJobsResponseGenqlSelection & { __args: {queueName: Scalars['String'], state: JobState, limit?: (Scalars['Int'] | null), offset?: (Scalars['Int'] | null)} })
-    findAllApplicationRegistrations?: ApplicationRegistrationGenqlSelection
-    getAiProviders?: boolean | number
-    getModelsDevProviders?: ModelsDevProviderSuggestionGenqlSelection
-    getModelsDevSuggestions?: (ModelsDevModelSuggestionGenqlSelection & { __args: {providerType: Scalars['String']} })
-    getAdminAiUsageByWorkspace?: (UsageBreakdownItemGenqlSelection & { __args?: {periodStart?: (Scalars['DateTime'] | null), periodEnd?: (Scalars['DateTime'] | null)} })
-    getMaintenanceMode?: MaintenanceModeGenqlSelection
-    workspaceLookupAdminPanel?: (UserLookupGenqlSelection & { __args: {workspaceId: Scalars['UUID']} })
-    getAdminWorkspaceChatThreads?: (AdminWorkspaceChatThreadGenqlSelection & { __args: {workspaceId: Scalars['UUID']} })
-    getAdminChatThreadMessages?: (AdminChatThreadMessagesGenqlSelection & { __args: {threadId: Scalars['UUID']} })
-    findOneAdminApplicationRegistration?: (ApplicationRegistrationGenqlSelection & { __args: {id: Scalars['String']} })
     getUsageAnalytics?: (UsageAnalyticsGenqlSelection & { __args?: {input?: (UsageAnalyticsInput | null)} })
     getPostgresCredentials?: PostgresCredentialsGenqlSelection
     findManyPublicDomains?: PublicDomainGenqlSelection
@@ -6546,23 +5869,6 @@ export interface MutationGenqlSelection{
     startChannelSync?: (ChannelSyncSuccessGenqlSelection & { __args: {connectedAccountId: Scalars['UUID']} })
     saveImapSmtpCaldavAccount?: (ImapSmtpCaldavConnectionSuccessGenqlSelection & { __args: {accountOwnerId: Scalars['UUID'], handle: Scalars['String'], connectionParameters: EmailAccountConnectionParameters, id?: (Scalars['UUID'] | null)} })
     updateLabPublicFeatureFlag?: (FeatureFlagGenqlSelection & { __args: {input: UpdateLabPublicFeatureFlagInput} })
-    updateWorkspaceFeatureFlag?: { __args: {workspaceId: Scalars['UUID'], featureFlag: Scalars['String'], value: Scalars['Boolean']} }
-    setAdminAiModelEnabled?: { __args: {modelId: Scalars['String'], enabled: Scalars['Boolean']} }
-    setAdminAiModelsEnabled?: { __args: {modelIds: Scalars['String'][], enabled: Scalars['Boolean']} }
-    setAdminAiModelRecommended?: { __args: {modelId: Scalars['String'], recommended: Scalars['Boolean']} }
-    setAdminAiModelsRecommended?: { __args: {modelIds: Scalars['String'][], recommended: Scalars['Boolean']} }
-    setAdminDefaultAiModel?: { __args: {role: AiModelRole, modelId: Scalars['String']} }
-    createDatabaseConfigVariable?: { __args: {key: Scalars['String'], value: Scalars['JSON']} }
-    updateDatabaseConfigVariable?: { __args: {key: Scalars['String'], value: Scalars['JSON']} }
-    deleteDatabaseConfigVariable?: { __args: {key: Scalars['String']} }
-    retryJobs?: (RetryJobsResponseGenqlSelection & { __args: {queueName: Scalars['String'], jobIds: Scalars['String'][]} })
-    deleteJobs?: (DeleteJobsResponseGenqlSelection & { __args: {queueName: Scalars['String'], jobIds: Scalars['String'][]} })
-    addAiProvider?: { __args: {providerName: Scalars['String'], providerConfig: Scalars['JSON']} }
-    removeAiProvider?: { __args: {providerName: Scalars['String']} }
-    addModelToProvider?: { __args: {providerName: Scalars['String'], modelConfig: Scalars['JSON']} }
-    removeModelFromProvider?: { __args: {providerName: Scalars['String'], modelName: Scalars['String']} }
-    setMaintenanceMode?: { __args: {startAt: Scalars['DateTime'], endAt: Scalars['DateTime'], link?: (Scalars['String'] | null)} }
-    clearMaintenanceMode?: boolean | number
     enablePostgresProxy?: PostgresCredentialsGenqlSelection
     disablePostgresProxy?: PostgresCredentialsGenqlSelection
     createPublicDomain?: (PublicDomainGenqlSelection & { __args: {domain: Scalars['String']} })
@@ -7759,78 +7065,6 @@ export interface LogicFunctionLogsInput {applicationId?: (Scalars['UUID'] | null
     
 
 
-    const UserInfo_possibleTypes: string[] = ['UserInfo']
-    export const isUserInfo = (obj?: { __typename?: any } | null): obj is UserInfo => {
-      if (!obj?.__typename) throw new Error('__typename is missing in "isUserInfo"')
-      return UserInfo_possibleTypes.includes(obj.__typename)
-    }
-    
-
-
-    const WorkspaceInfo_possibleTypes: string[] = ['WorkspaceInfo']
-    export const isWorkspaceInfo = (obj?: { __typename?: any } | null): obj is WorkspaceInfo => {
-      if (!obj?.__typename) throw new Error('__typename is missing in "isWorkspaceInfo"')
-      return WorkspaceInfo_possibleTypes.includes(obj.__typename)
-    }
-    
-
-
-    const UserLookup_possibleTypes: string[] = ['UserLookup']
-    export const isUserLookup = (obj?: { __typename?: any } | null): obj is UserLookup => {
-      if (!obj?.__typename) throw new Error('__typename is missing in "isUserLookup"')
-      return UserLookup_possibleTypes.includes(obj.__typename)
-    }
-    
-
-
-    const AdminPanelRecentUser_possibleTypes: string[] = ['AdminPanelRecentUser']
-    export const isAdminPanelRecentUser = (obj?: { __typename?: any } | null): obj is AdminPanelRecentUser => {
-      if (!obj?.__typename) throw new Error('__typename is missing in "isAdminPanelRecentUser"')
-      return AdminPanelRecentUser_possibleTypes.includes(obj.__typename)
-    }
-    
-
-
-    const AdminPanelTopWorkspace_possibleTypes: string[] = ['AdminPanelTopWorkspace']
-    export const isAdminPanelTopWorkspace = (obj?: { __typename?: any } | null): obj is AdminPanelTopWorkspace => {
-      if (!obj?.__typename) throw new Error('__typename is missing in "isAdminPanelTopWorkspace"')
-      return AdminPanelTopWorkspace_possibleTypes.includes(obj.__typename)
-    }
-    
-
-
-    const AdminWorkspaceChatThread_possibleTypes: string[] = ['AdminWorkspaceChatThread']
-    export const isAdminWorkspaceChatThread = (obj?: { __typename?: any } | null): obj is AdminWorkspaceChatThread => {
-      if (!obj?.__typename) throw new Error('__typename is missing in "isAdminWorkspaceChatThread"')
-      return AdminWorkspaceChatThread_possibleTypes.includes(obj.__typename)
-    }
-    
-
-
-    const AdminChatMessagePart_possibleTypes: string[] = ['AdminChatMessagePart']
-    export const isAdminChatMessagePart = (obj?: { __typename?: any } | null): obj is AdminChatMessagePart => {
-      if (!obj?.__typename) throw new Error('__typename is missing in "isAdminChatMessagePart"')
-      return AdminChatMessagePart_possibleTypes.includes(obj.__typename)
-    }
-    
-
-
-    const AdminChatMessage_possibleTypes: string[] = ['AdminChatMessage']
-    export const isAdminChatMessage = (obj?: { __typename?: any } | null): obj is AdminChatMessage => {
-      if (!obj?.__typename) throw new Error('__typename is missing in "isAdminChatMessage"')
-      return AdminChatMessage_possibleTypes.includes(obj.__typename)
-    }
-    
-
-
-    const AdminChatThreadMessages_possibleTypes: string[] = ['AdminChatThreadMessages']
-    export const isAdminChatThreadMessages = (obj?: { __typename?: any } | null): obj is AdminChatThreadMessages => {
-      if (!obj?.__typename) throw new Error('__typename is missing in "isAdminChatThreadMessages"')
-      return AdminChatThreadMessages_possibleTypes.includes(obj.__typename)
-    }
-    
-
-
     const BillingTrialPeriod_possibleTypes: string[] = ['BillingTrialPeriod']
     export const isBillingTrialPeriod = (obj?: { __typename?: any } | null): obj is BillingTrialPeriod => {
       if (!obj?.__typename) throw new Error('__typename is missing in "isBillingTrialPeriod"')
@@ -7891,22 +7125,6 @@ export interface LogicFunctionLogsInput {applicationId?: (Scalars['UUID'] | null
     export const isClientAiModelConfig = (obj?: { __typename?: any } | null): obj is ClientAiModelConfig => {
       if (!obj?.__typename) throw new Error('__typename is missing in "isClientAiModelConfig"')
       return ClientAiModelConfig_possibleTypes.includes(obj.__typename)
-    }
-    
-
-
-    const AdminAiModelConfig_possibleTypes: string[] = ['AdminAiModelConfig']
-    export const isAdminAiModelConfig = (obj?: { __typename?: any } | null): obj is AdminAiModelConfig => {
-      if (!obj?.__typename) throw new Error('__typename is missing in "isAdminAiModelConfig"')
-      return AdminAiModelConfig_possibleTypes.includes(obj.__typename)
-    }
-    
-
-
-    const AdminAiModels_possibleTypes: string[] = ['AdminAiModels']
-    export const isAdminAiModels = (obj?: { __typename?: any } | null): obj is AdminAiModels => {
-      if (!obj?.__typename) throw new Error('__typename is missing in "isAdminAiModels"')
-      return AdminAiModels_possibleTypes.includes(obj.__typename)
     }
     
 
@@ -7987,174 +7205,6 @@ export interface LogicFunctionLogsInput {applicationId?: (Scalars['UUID'] | null
     export const isUsageBreakdownItem = (obj?: { __typename?: any } | null): obj is UsageBreakdownItem => {
       if (!obj?.__typename) throw new Error('__typename is missing in "isUsageBreakdownItem"')
       return UsageBreakdownItem_possibleTypes.includes(obj.__typename)
-    }
-    
-
-
-    const ConfigVariable_possibleTypes: string[] = ['ConfigVariable']
-    export const isConfigVariable = (obj?: { __typename?: any } | null): obj is ConfigVariable => {
-      if (!obj?.__typename) throw new Error('__typename is missing in "isConfigVariable"')
-      return ConfigVariable_possibleTypes.includes(obj.__typename)
-    }
-    
-
-
-    const ConfigVariablesGroupData_possibleTypes: string[] = ['ConfigVariablesGroupData']
-    export const isConfigVariablesGroupData = (obj?: { __typename?: any } | null): obj is ConfigVariablesGroupData => {
-      if (!obj?.__typename) throw new Error('__typename is missing in "isConfigVariablesGroupData"')
-      return ConfigVariablesGroupData_possibleTypes.includes(obj.__typename)
-    }
-    
-
-
-    const ConfigVariables_possibleTypes: string[] = ['ConfigVariables']
-    export const isConfigVariables = (obj?: { __typename?: any } | null): obj is ConfigVariables => {
-      if (!obj?.__typename) throw new Error('__typename is missing in "isConfigVariables"')
-      return ConfigVariables_possibleTypes.includes(obj.__typename)
-    }
-    
-
-
-    const JobOperationResult_possibleTypes: string[] = ['JobOperationResult']
-    export const isJobOperationResult = (obj?: { __typename?: any } | null): obj is JobOperationResult => {
-      if (!obj?.__typename) throw new Error('__typename is missing in "isJobOperationResult"')
-      return JobOperationResult_possibleTypes.includes(obj.__typename)
-    }
-    
-
-
-    const DeleteJobsResponse_possibleTypes: string[] = ['DeleteJobsResponse']
-    export const isDeleteJobsResponse = (obj?: { __typename?: any } | null): obj is DeleteJobsResponse => {
-      if (!obj?.__typename) throw new Error('__typename is missing in "isDeleteJobsResponse"')
-      return DeleteJobsResponse_possibleTypes.includes(obj.__typename)
-    }
-    
-
-
-    const QueueJob_possibleTypes: string[] = ['QueueJob']
-    export const isQueueJob = (obj?: { __typename?: any } | null): obj is QueueJob => {
-      if (!obj?.__typename) throw new Error('__typename is missing in "isQueueJob"')
-      return QueueJob_possibleTypes.includes(obj.__typename)
-    }
-    
-
-
-    const QueueRetentionConfig_possibleTypes: string[] = ['QueueRetentionConfig']
-    export const isQueueRetentionConfig = (obj?: { __typename?: any } | null): obj is QueueRetentionConfig => {
-      if (!obj?.__typename) throw new Error('__typename is missing in "isQueueRetentionConfig"')
-      return QueueRetentionConfig_possibleTypes.includes(obj.__typename)
-    }
-    
-
-
-    const QueueJobsResponse_possibleTypes: string[] = ['QueueJobsResponse']
-    export const isQueueJobsResponse = (obj?: { __typename?: any } | null): obj is QueueJobsResponse => {
-      if (!obj?.__typename) throw new Error('__typename is missing in "isQueueJobsResponse"')
-      return QueueJobsResponse_possibleTypes.includes(obj.__typename)
-    }
-    
-
-
-    const RetryJobsResponse_possibleTypes: string[] = ['RetryJobsResponse']
-    export const isRetryJobsResponse = (obj?: { __typename?: any } | null): obj is RetryJobsResponse => {
-      if (!obj?.__typename) throw new Error('__typename is missing in "isRetryJobsResponse"')
-      return RetryJobsResponse_possibleTypes.includes(obj.__typename)
-    }
-    
-
-
-    const SystemHealthService_possibleTypes: string[] = ['SystemHealthService']
-    export const isSystemHealthService = (obj?: { __typename?: any } | null): obj is SystemHealthService => {
-      if (!obj?.__typename) throw new Error('__typename is missing in "isSystemHealthService"')
-      return SystemHealthService_possibleTypes.includes(obj.__typename)
-    }
-    
-
-
-    const SystemHealth_possibleTypes: string[] = ['SystemHealth']
-    export const isSystemHealth = (obj?: { __typename?: any } | null): obj is SystemHealth => {
-      if (!obj?.__typename) throw new Error('__typename is missing in "isSystemHealth"')
-      return SystemHealth_possibleTypes.includes(obj.__typename)
-    }
-    
-
-
-    const VersionInfo_possibleTypes: string[] = ['VersionInfo']
-    export const isVersionInfo = (obj?: { __typename?: any } | null): obj is VersionInfo => {
-      if (!obj?.__typename) throw new Error('__typename is missing in "isVersionInfo"')
-      return VersionInfo_possibleTypes.includes(obj.__typename)
-    }
-    
-
-
-    const AdminPanelWorkerQueueHealth_possibleTypes: string[] = ['AdminPanelWorkerQueueHealth']
-    export const isAdminPanelWorkerQueueHealth = (obj?: { __typename?: any } | null): obj is AdminPanelWorkerQueueHealth => {
-      if (!obj?.__typename) throw new Error('__typename is missing in "isAdminPanelWorkerQueueHealth"')
-      return AdminPanelWorkerQueueHealth_possibleTypes.includes(obj.__typename)
-    }
-    
-
-
-    const AdminPanelHealthServiceData_possibleTypes: string[] = ['AdminPanelHealthServiceData']
-    export const isAdminPanelHealthServiceData = (obj?: { __typename?: any } | null): obj is AdminPanelHealthServiceData => {
-      if (!obj?.__typename) throw new Error('__typename is missing in "isAdminPanelHealthServiceData"')
-      return AdminPanelHealthServiceData_possibleTypes.includes(obj.__typename)
-    }
-    
-
-
-    const MaintenanceMode_possibleTypes: string[] = ['MaintenanceMode']
-    export const isMaintenanceMode = (obj?: { __typename?: any } | null): obj is MaintenanceMode => {
-      if (!obj?.__typename) throw new Error('__typename is missing in "isMaintenanceMode"')
-      return MaintenanceMode_possibleTypes.includes(obj.__typename)
-    }
-    
-
-
-    const ModelsDevModelSuggestion_possibleTypes: string[] = ['ModelsDevModelSuggestion']
-    export const isModelsDevModelSuggestion = (obj?: { __typename?: any } | null): obj is ModelsDevModelSuggestion => {
-      if (!obj?.__typename) throw new Error('__typename is missing in "isModelsDevModelSuggestion"')
-      return ModelsDevModelSuggestion_possibleTypes.includes(obj.__typename)
-    }
-    
-
-
-    const ModelsDevProviderSuggestion_possibleTypes: string[] = ['ModelsDevProviderSuggestion']
-    export const isModelsDevProviderSuggestion = (obj?: { __typename?: any } | null): obj is ModelsDevProviderSuggestion => {
-      if (!obj?.__typename) throw new Error('__typename is missing in "isModelsDevProviderSuggestion"')
-      return ModelsDevProviderSuggestion_possibleTypes.includes(obj.__typename)
-    }
-    
-
-
-    const QueueMetricsDataPoint_possibleTypes: string[] = ['QueueMetricsDataPoint']
-    export const isQueueMetricsDataPoint = (obj?: { __typename?: any } | null): obj is QueueMetricsDataPoint => {
-      if (!obj?.__typename) throw new Error('__typename is missing in "isQueueMetricsDataPoint"')
-      return QueueMetricsDataPoint_possibleTypes.includes(obj.__typename)
-    }
-    
-
-
-    const QueueMetricsSeries_possibleTypes: string[] = ['QueueMetricsSeries']
-    export const isQueueMetricsSeries = (obj?: { __typename?: any } | null): obj is QueueMetricsSeries => {
-      if (!obj?.__typename) throw new Error('__typename is missing in "isQueueMetricsSeries"')
-      return QueueMetricsSeries_possibleTypes.includes(obj.__typename)
-    }
-    
-
-
-    const WorkerQueueMetrics_possibleTypes: string[] = ['WorkerQueueMetrics']
-    export const isWorkerQueueMetrics = (obj?: { __typename?: any } | null): obj is WorkerQueueMetrics => {
-      if (!obj?.__typename) throw new Error('__typename is missing in "isWorkerQueueMetrics"')
-      return WorkerQueueMetrics_possibleTypes.includes(obj.__typename)
-    }
-    
-
-
-    const QueueMetricsData_possibleTypes: string[] = ['QueueMetricsData']
-    export const isQueueMetricsData = (obj?: { __typename?: any } | null): obj is QueueMetricsData => {
-      if (!obj?.__typename) throw new Error('__typename is missing in "isQueueMetricsData"')
-      return QueueMetricsData_possibleTypes.includes(obj.__typename)
     }
     
 
@@ -9522,12 +8572,6 @@ export const enumFeatureFlagKey = {
    IS_DATASOURCE_MIGRATED: 'IS_DATASOURCE_MIGRATED' as const
 }
 
-export const enumAgentMessageRole = {
-   SYSTEM: 'SYSTEM' as const,
-   USER: 'USER' as const,
-   ASSISTANT: 'ASSISTANT' as const
-}
-
 export const enumIdentityProviderType = {
    OIDC: 'OIDC' as const,
    SAML: 'SAML' as const
@@ -9555,74 +8599,6 @@ export const enumSupportDriver = {
 export const enumCaptchaDriverType = {
    GOOGLE_RECAPTCHA: 'GOOGLE_RECAPTCHA' as const,
    TURNSTILE: 'TURNSTILE' as const
-}
-
-export const enumConfigSource = {
-   ENVIRONMENT: 'ENVIRONMENT' as const,
-   DATABASE: 'DATABASE' as const,
-   DEFAULT: 'DEFAULT' as const
-}
-
-export const enumConfigVariableType = {
-   BOOLEAN: 'BOOLEAN' as const,
-   NUMBER: 'NUMBER' as const,
-   ARRAY: 'ARRAY' as const,
-   STRING: 'STRING' as const,
-   ENUM: 'ENUM' as const,
-   JSON: 'JSON' as const
-}
-
-export const enumConfigVariablesGroup = {
-   SERVER_CONFIG: 'SERVER_CONFIG' as const,
-   RATE_LIMITING: 'RATE_LIMITING' as const,
-   STORAGE_CONFIG: 'STORAGE_CONFIG' as const,
-   GOOGLE_AUTH: 'GOOGLE_AUTH' as const,
-   MICROSOFT_AUTH: 'MICROSOFT_AUTH' as const,
-   EMAIL_SETTINGS: 'EMAIL_SETTINGS' as const,
-   LOGGING: 'LOGGING' as const,
-   ADVANCED_SETTINGS: 'ADVANCED_SETTINGS' as const,
-   BILLING_CONFIG: 'BILLING_CONFIG' as const,
-   CAPTCHA_CONFIG: 'CAPTCHA_CONFIG' as const,
-   CLOUDFLARE_CONFIG: 'CLOUDFLARE_CONFIG' as const,
-   LLM: 'LLM' as const,
-   LOGIC_FUNCTION_CONFIG: 'LOGIC_FUNCTION_CONFIG' as const,
-   CODE_INTERPRETER_CONFIG: 'CODE_INTERPRETER_CONFIG' as const,
-   SSL: 'SSL' as const,
-   SUPPORT_CHAT_CONFIG: 'SUPPORT_CHAT_CONFIG' as const,
-   ANALYTICS_CONFIG: 'ANALYTICS_CONFIG' as const,
-   TOKENS_DURATION: 'TOKENS_DURATION' as const,
-   AWS_SES_SETTINGS: 'AWS_SES_SETTINGS' as const
-}
-
-export const enumJobState = {
-   COMPLETED: 'COMPLETED' as const,
-   FAILED: 'FAILED' as const,
-   ACTIVE: 'ACTIVE' as const,
-   WAITING: 'WAITING' as const,
-   DELAYED: 'DELAYED' as const,
-   PRIORITIZED: 'PRIORITIZED' as const,
-   WAITING_CHILDREN: 'WAITING_CHILDREN' as const
-}
-
-export const enumHealthIndicatorId = {
-   database: 'database' as const,
-   redis: 'redis' as const,
-   worker: 'worker' as const,
-   connectedAccount: 'connectedAccount' as const,
-   app: 'app' as const
-}
-
-export const enumAdminPanelHealthServiceStatus = {
-   OPERATIONAL: 'OPERATIONAL' as const,
-   OUTAGE: 'OUTAGE' as const
-}
-
-export const enumQueueMetricsTimeRange = {
-   SevenDays: 'SevenDays' as const,
-   OneDay: 'OneDay' as const,
-   TwelveHours: 'TwelveHours' as const,
-   FourHours: 'FourHours' as const,
-   OneHour: 'OneHour' as const
 }
 
 export const enumRelationType = {
@@ -9871,11 +8847,6 @@ export const enumUsageOperationType = {
 export const enumAnalyticsType = {
    PAGEVIEW: 'PAGEVIEW' as const,
    TRACK: 'TRACK' as const
-}
-
-export const enumAiModelRole = {
-   FAST: 'FAST' as const,
-   SMART: 'SMART' as const
 }
 
 export const enumWorkspaceMigrationActionType = {

--- a/packages/twenty-client-sdk/src/metadata/generated/types.ts
+++ b/packages/twenty-client-sdk/src/metadata/generated/types.ts
@@ -49,49 +49,40 @@ export default {
         152,
         156,
         158,
-        168,
-        172,
+        162,
+        163,
+        170,
         173,
-        180,
-        185,
-        188,
-        196,
-        197,
+        176,
         199,
-        204,
-        209,
-        210,
-        222,
-        239,
+        214,
+        253,
         254,
-        293,
-        294,
+        264,
+        265,
+        301,
+        302,
+        303,
         304,
-        305,
+        306,
+        307,
+        308,
+        309,
+        310,
+        311,
+        312,
+        314,
+        316,
+        324,
+        330,
+        331,
+        332,
+        334,
         341,
-        342,
-        343,
-        344,
-        346,
-        347,
         348,
-        349,
-        350,
-        351,
-        352,
-        354,
-        356,
-        364,
-        370,
-        371,
-        372,
-        374,
-        381,
-        388,
-        419,
-        501,
-        506,
-        507
+        379,
+        465,
+        466
     ],
     "types": {
         "BillingProductDTO": {
@@ -789,10 +780,10 @@ export default {
                 3
             ],
             "relation": [
-                238
+                198
             ],
             "morphRelations": [
-                238
+                198
             ],
             "object": [
                 46
@@ -851,7 +842,7 @@ export default {
                 36
             ],
             "objectMetadata": [
-                246,
+                206,
                 {
                     "paging": [
                         39,
@@ -864,7 +855,7 @@ export default {
                 }
             ],
             "indexFieldMetadatas": [
-                244,
+                204,
                 {
                     "paging": [
                         39,
@@ -1109,7 +1100,7 @@ export default {
                 37
             ],
             "fields": [
-                251,
+                211,
                 {
                     "paging": [
                         39,
@@ -1122,7 +1113,7 @@ export default {
                 }
             ],
             "indexMetadatas": [
-                249,
+                209,
                 {
                     "paging": [
                         39,
@@ -1706,7 +1697,7 @@ export default {
                 135
             ],
             "billingEntitlements": [
-                253
+                213
             ],
             "hasValidEnterpriseKey": [
                 6
@@ -1810,7 +1801,7 @@ export default {
                 20
             ],
             "deletedWorkspaceMembers": [
-                237
+                197
             ],
             "hasPassword": [
                 6
@@ -1822,7 +1813,7 @@ export default {
                 17
             ],
             "availableWorkspaces": [
-                236
+                196
             ],
             "__typename": [
                 1
@@ -3213,184 +3204,6 @@ export default {
                 1
             ]
         },
-        "UserInfo": {
-            "id": [
-                3
-            ],
-            "email": [
-                1
-            ],
-            "firstName": [
-                1
-            ],
-            "lastName": [
-                1
-            ],
-            "createdAt": [
-                4
-            ],
-            "__typename": [
-                1
-            ]
-        },
-        "WorkspaceInfo": {
-            "id": [
-                3
-            ],
-            "name": [
-                1
-            ],
-            "allowImpersonation": [
-                6
-            ],
-            "logo": [
-                1
-            ],
-            "totalUsers": [
-                11
-            ],
-            "activationStatus": [
-                67
-            ],
-            "createdAt": [
-                4
-            ],
-            "workspaceUrls": [
-                159
-            ],
-            "users": [
-                160
-            ],
-            "featureFlags": [
-                157
-            ],
-            "__typename": [
-                1
-            ]
-        },
-        "UserLookup": {
-            "user": [
-                160
-            ],
-            "workspaces": [
-                161
-            ],
-            "__typename": [
-                1
-            ]
-        },
-        "AdminPanelRecentUser": {
-            "id": [
-                3
-            ],
-            "email": [
-                1
-            ],
-            "firstName": [
-                1
-            ],
-            "lastName": [
-                1
-            ],
-            "createdAt": [
-                4
-            ],
-            "workspaceName": [
-                1
-            ],
-            "workspaceId": [
-                3
-            ],
-            "__typename": [
-                1
-            ]
-        },
-        "AdminPanelTopWorkspace": {
-            "id": [
-                3
-            ],
-            "name": [
-                1
-            ],
-            "totalUsers": [
-                21
-            ],
-            "subdomain": [
-                1
-            ],
-            "__typename": [
-                1
-            ]
-        },
-        "AdminWorkspaceChatThread": {
-            "id": [
-                3
-            ],
-            "title": [
-                1
-            ],
-            "totalInputTokens": [
-                21
-            ],
-            "totalOutputTokens": [
-                21
-            ],
-            "conversationSize": [
-                21
-            ],
-            "createdAt": [
-                4
-            ],
-            "updatedAt": [
-                4
-            ],
-            "__typename": [
-                1
-            ]
-        },
-        "AdminChatMessagePart": {
-            "type": [
-                1
-            ],
-            "textContent": [
-                1
-            ],
-            "toolName": [
-                1
-            ],
-            "__typename": [
-                1
-            ]
-        },
-        "AdminChatMessage": {
-            "id": [
-                3
-            ],
-            "role": [
-                168
-            ],
-            "parts": [
-                166
-            ],
-            "createdAt": [
-                4
-            ],
-            "__typename": [
-                1
-            ]
-        },
-        "AgentMessageRole": {},
-        "AdminChatThreadMessages": {
-            "thread": [
-                165
-            ],
-            "messages": [
-                167
-            ],
-            "__typename": [
-                1
-            ]
-        },
         "BillingTrialPeriod": {
             "duration": [
                 11
@@ -3410,10 +3223,10 @@ export default {
                 1
             ],
             "type": [
-                172
+                162
             ],
             "status": [
-                173
+                163
             ],
             "issuer": [
                 1
@@ -3426,7 +3239,7 @@ export default {
         "SSOIdentityProviderStatus": {},
         "AuthProviders": {
             "sso": [
-                171
+                161
             ],
             "google": [
                 6
@@ -3463,10 +3276,10 @@ export default {
                 3
             ],
             "authProviders": [
-                174
+                164
             ],
             "authBypassProviders": [
-                175
+                165
             ],
             "logo": [
                 1
@@ -3514,7 +3327,7 @@ export default {
                 1
             ],
             "modelFamily": [
-                180
+                170
             ],
             "modelFamilyLabel": [
                 1
@@ -3529,7 +3342,7 @@ export default {
                 11
             ],
             "nativeCapabilities": [
-                178
+                168
             ],
             "isDeprecated": [
                 6
@@ -3557,76 +3370,6 @@ export default {
             ]
         },
         "ModelFamily": {},
-        "AdminAiModelConfig": {
-            "modelId": [
-                1
-            ],
-            "label": [
-                1
-            ],
-            "modelFamily": [
-                180
-            ],
-            "modelFamilyLabel": [
-                1
-            ],
-            "sdkPackage": [
-                1
-            ],
-            "isAvailable": [
-                6
-            ],
-            "isAdminEnabled": [
-                6
-            ],
-            "isDeprecated": [
-                6
-            ],
-            "isRecommended": [
-                6
-            ],
-            "contextWindowTokens": [
-                11
-            ],
-            "maxOutputTokens": [
-                11
-            ],
-            "inputCostPerMillionTokens": [
-                11
-            ],
-            "outputCostPerMillionTokens": [
-                11
-            ],
-            "providerName": [
-                1
-            ],
-            "providerLabel": [
-                1
-            ],
-            "name": [
-                1
-            ],
-            "dataResidency": [
-                1
-            ],
-            "__typename": [
-                1
-            ]
-        },
-        "AdminAiModels": {
-            "models": [
-                181
-            ],
-            "defaultSmartModelId": [
-                1
-            ],
-            "defaultFastModelId": [
-                1
-            ],
-            "__typename": [
-                1
-            ]
-        },
         "Billing": {
             "isBillingEnabled": [
                 6
@@ -3635,7 +3378,7 @@ export default {
                 1
             ],
             "trialPeriods": [
-                170
+                160
             ],
             "__typename": [
                 1
@@ -3643,7 +3386,7 @@ export default {
         },
         "Support": {
             "supportDriver": [
-                185
+                173
             ],
             "supportFrontChatId": [
                 1
@@ -3669,7 +3412,7 @@ export default {
         },
         "Captcha": {
             "provider": [
-                188
+                176
             ],
             "siteKey": [
                 1
@@ -3706,7 +3449,7 @@ export default {
                 158
             ],
             "metadata": [
-                190
+                178
             ],
             "__typename": [
                 1
@@ -3731,13 +3474,13 @@ export default {
                 1
             ],
             "authProviders": [
-                174
+                164
             ],
             "billing": [
-                183
+                171
             ],
             "aiModels": [
-                179
+                169
             ],
             "signInPrefilled": [
                 6
@@ -3758,25 +3501,25 @@ export default {
                 6
             ],
             "support": [
-                184
+                172
             ],
             "isAttachmentPreviewEnabled": [
                 6
             ],
             "sentry": [
-                186
+                174
             ],
             "captcha": [
-                187
+                175
             ],
             "api": [
-                189
+                177
             ],
             "canManageFeatureFlags": [
                 6
             ],
             "publicFeatureFlags": [
-                191
+                179
             ],
             "isMicrosoftMessagingEnabled": [
                 6
@@ -3812,7 +3555,7 @@ export default {
                 6
             ],
             "maintenance": [
-                192
+                180
             ],
             "__typename": [
                 1
@@ -3832,388 +3575,6 @@ export default {
                 1
             ]
         },
-        "ConfigVariable": {
-            "name": [
-                1
-            ],
-            "description": [
-                1
-            ],
-            "value": [
-                15
-            ],
-            "isSensitive": [
-                6
-            ],
-            "source": [
-                196
-            ],
-            "isEnvOnly": [
-                6
-            ],
-            "type": [
-                197
-            ],
-            "options": [
-                15
-            ],
-            "__typename": [
-                1
-            ]
-        },
-        "ConfigSource": {},
-        "ConfigVariableType": {},
-        "ConfigVariablesGroupData": {
-            "variables": [
-                195
-            ],
-            "name": [
-                199
-            ],
-            "description": [
-                1
-            ],
-            "isHiddenOnLoad": [
-                6
-            ],
-            "__typename": [
-                1
-            ]
-        },
-        "ConfigVariablesGroup": {},
-        "ConfigVariables": {
-            "groups": [
-                198
-            ],
-            "__typename": [
-                1
-            ]
-        },
-        "JobOperationResult": {
-            "jobId": [
-                1
-            ],
-            "success": [
-                6
-            ],
-            "error": [
-                1
-            ],
-            "__typename": [
-                1
-            ]
-        },
-        "DeleteJobsResponse": {
-            "deletedCount": [
-                21
-            ],
-            "results": [
-                201
-            ],
-            "__typename": [
-                1
-            ]
-        },
-        "QueueJob": {
-            "id": [
-                1
-            ],
-            "name": [
-                1
-            ],
-            "data": [
-                15
-            ],
-            "state": [
-                204
-            ],
-            "timestamp": [
-                11
-            ],
-            "failedReason": [
-                1
-            ],
-            "processedOn": [
-                11
-            ],
-            "finishedOn": [
-                11
-            ],
-            "attemptsMade": [
-                11
-            ],
-            "returnValue": [
-                15
-            ],
-            "logs": [
-                1
-            ],
-            "stackTrace": [
-                1
-            ],
-            "__typename": [
-                1
-            ]
-        },
-        "JobState": {},
-        "QueueRetentionConfig": {
-            "completedMaxAge": [
-                11
-            ],
-            "completedMaxCount": [
-                11
-            ],
-            "failedMaxAge": [
-                11
-            ],
-            "failedMaxCount": [
-                11
-            ],
-            "__typename": [
-                1
-            ]
-        },
-        "QueueJobsResponse": {
-            "jobs": [
-                203
-            ],
-            "count": [
-                11
-            ],
-            "totalCount": [
-                11
-            ],
-            "hasMore": [
-                6
-            ],
-            "retentionConfig": [
-                205
-            ],
-            "__typename": [
-                1
-            ]
-        },
-        "RetryJobsResponse": {
-            "retriedCount": [
-                21
-            ],
-            "results": [
-                201
-            ],
-            "__typename": [
-                1
-            ]
-        },
-        "SystemHealthService": {
-            "id": [
-                209
-            ],
-            "label": [
-                1
-            ],
-            "status": [
-                210
-            ],
-            "__typename": [
-                1
-            ]
-        },
-        "HealthIndicatorId": {},
-        "AdminPanelHealthServiceStatus": {},
-        "SystemHealth": {
-            "services": [
-                208
-            ],
-            "__typename": [
-                1
-            ]
-        },
-        "VersionInfo": {
-            "currentVersion": [
-                1
-            ],
-            "latestVersion": [
-                1
-            ],
-            "__typename": [
-                1
-            ]
-        },
-        "AdminPanelWorkerQueueHealth": {
-            "id": [
-                1
-            ],
-            "queueName": [
-                1
-            ],
-            "status": [
-                210
-            ],
-            "__typename": [
-                1
-            ]
-        },
-        "AdminPanelHealthServiceData": {
-            "id": [
-                209
-            ],
-            "label": [
-                1
-            ],
-            "description": [
-                1
-            ],
-            "status": [
-                210
-            ],
-            "errorMessage": [
-                1
-            ],
-            "details": [
-                1
-            ],
-            "queues": [
-                213
-            ],
-            "__typename": [
-                1
-            ]
-        },
-        "MaintenanceMode": {
-            "startAt": [
-                4
-            ],
-            "endAt": [
-                4
-            ],
-            "link": [
-                1
-            ],
-            "__typename": [
-                1
-            ]
-        },
-        "ModelsDevModelSuggestion": {
-            "modelId": [
-                1
-            ],
-            "name": [
-                1
-            ],
-            "inputCostPerMillionTokens": [
-                11
-            ],
-            "outputCostPerMillionTokens": [
-                11
-            ],
-            "cachedInputCostPerMillionTokens": [
-                11
-            ],
-            "cacheCreationCostPerMillionTokens": [
-                11
-            ],
-            "contextWindowTokens": [
-                11
-            ],
-            "maxOutputTokens": [
-                11
-            ],
-            "modalities": [
-                1
-            ],
-            "supportsReasoning": [
-                6
-            ],
-            "__typename": [
-                1
-            ]
-        },
-        "ModelsDevProviderSuggestion": {
-            "id": [
-                1
-            ],
-            "modelCount": [
-                11
-            ],
-            "npm": [
-                1
-            ],
-            "__typename": [
-                1
-            ]
-        },
-        "QueueMetricsDataPoint": {
-            "x": [
-                11
-            ],
-            "y": [
-                11
-            ],
-            "__typename": [
-                1
-            ]
-        },
-        "QueueMetricsSeries": {
-            "id": [
-                1
-            ],
-            "data": [
-                218
-            ],
-            "__typename": [
-                1
-            ]
-        },
-        "WorkerQueueMetrics": {
-            "failed": [
-                11
-            ],
-            "completed": [
-                11
-            ],
-            "waiting": [
-                11
-            ],
-            "active": [
-                11
-            ],
-            "delayed": [
-                11
-            ],
-            "failureRate": [
-                11
-            ],
-            "failedData": [
-                11
-            ],
-            "completedData": [
-                11
-            ],
-            "__typename": [
-                1
-            ]
-        },
-        "QueueMetricsData": {
-            "queueName": [
-                1
-            ],
-            "workers": [
-                11
-            ],
-            "timeRange": [
-                222
-            ],
-            "details": [
-                220
-            ],
-            "data": [
-                219
-            ],
-            "__typename": [
-                1
-            ]
-        },
-        "QueueMetricsTimeRange": {},
         "VersionDistributionEntry": {
             "version": [
                 1
@@ -4233,7 +3594,7 @@ export default {
                 1
             ],
             "versionDistribution": [
-                223
+                183
             ],
             "__typename": [
                 1
@@ -4299,7 +3660,7 @@ export default {
                 3
             ],
             "type": [
-                172
+                162
             ],
             "issuer": [
                 1
@@ -4308,7 +3669,7 @@ export default {
                 1
             ],
             "status": [
-                173
+                163
             ],
             "__typename": [
                 1
@@ -4327,7 +3688,7 @@ export default {
         },
         "FindAvailableSSOIDP": {
             "type": [
-                172
+                162
             ],
             "id": [
                 3
@@ -4339,10 +3700,10 @@ export default {
                 1
             ],
             "status": [
-                173
+                163
             ],
             "workspace": [
-                231
+                191
             ],
             "__typename": [
                 1
@@ -4353,7 +3714,7 @@ export default {
                 3
             ],
             "type": [
-                172
+                162
             ],
             "issuer": [
                 1
@@ -4362,7 +3723,7 @@ export default {
                 1
             ],
             "status": [
-                173
+                163
             ],
             "__typename": [
                 1
@@ -4370,7 +3731,7 @@ export default {
         },
         "SSOConnection": {
             "type": [
-                172
+                162
             ],
             "id": [
                 3
@@ -4382,7 +3743,7 @@ export default {
                 1
             ],
             "status": [
-                173
+                163
             ],
             "__typename": [
                 1
@@ -4411,7 +3772,7 @@ export default {
                 1
             ],
             "sso": [
-                234
+                194
             ],
             "__typename": [
                 1
@@ -4419,10 +3780,10 @@ export default {
         },
         "AvailableWorkspaces": {
             "availableWorkspacesForSignIn": [
-                235
+                195
             ],
             "availableWorkspacesForSignUp": [
-                235
+                195
             ],
             "__typename": [
                 1
@@ -4450,7 +3811,7 @@ export default {
         },
         "Relation": {
             "type": [
-                239
+                199
             ],
             "sourceObjectMetadata": [
                 46
@@ -4499,10 +3860,10 @@ export default {
         },
         "IndexConnection": {
             "pageInfo": [
-                241
+                201
             ],
             "edges": [
-                240
+                200
             ],
             "__typename": [
                 1
@@ -4521,10 +3882,10 @@ export default {
         },
         "IndexIndexFieldMetadatasConnection": {
             "pageInfo": [
-                241
+                201
             ],
             "edges": [
-                243
+                203
             ],
             "__typename": [
                 1
@@ -4543,10 +3904,10 @@ export default {
         },
         "IndexObjectMetadataConnection": {
             "pageInfo": [
-                241
+                201
             ],
             "edges": [
-                245
+                205
             ],
             "__typename": [
                 1
@@ -4565,10 +3926,10 @@ export default {
         },
         "ObjectConnection": {
             "pageInfo": [
-                241
+                201
             ],
             "edges": [
-                245
+                205
             ],
             "__typename": [
                 1
@@ -4576,10 +3937,10 @@ export default {
         },
         "ObjectIndexMetadatasConnection": {
             "pageInfo": [
-                241
+                201
             ],
             "edges": [
-                240
+                200
             ],
             "__typename": [
                 1
@@ -4598,10 +3959,10 @@ export default {
         },
         "ObjectFieldsConnection": {
             "pageInfo": [
-                241
+                201
             ],
             "edges": [
-                250
+                210
             ],
             "__typename": [
                 1
@@ -4609,10 +3970,10 @@ export default {
         },
         "FieldConnection": {
             "pageInfo": [
-                241
+                201
             ],
             "edges": [
-                250
+                210
             ],
             "__typename": [
                 1
@@ -4620,7 +3981,7 @@ export default {
         },
         "BillingEntitlement": {
             "key": [
-                254
+                214
             ],
             "value": [
                 6
@@ -4658,7 +4019,7 @@ export default {
                 1
             ],
             "records": [
-                255
+                215
             ],
             "__typename": [
                 1
@@ -4688,10 +4049,10 @@ export default {
         },
         "ApplicationTokenPair": {
             "applicationAccessToken": [
-                258
+                218
             ],
             "applicationRefreshToken": [
-                258
+                218
             ],
             "__typename": [
                 1
@@ -4738,7 +4099,7 @@ export default {
                 6
             ],
             "applicationTokenPair": [
-                259
+                219
             ],
             "__typename": [
                 1
@@ -4786,10 +4147,10 @@ export default {
         },
         "AuthTokenPair": {
             "accessOrWorkspaceAgnosticToken": [
-                258
+                218
             ],
             "refreshToken": [
-                258
+                218
             ],
             "__typename": [
                 1
@@ -4797,10 +4158,10 @@ export default {
         },
         "AvailableWorkspacesAndAccessTokens": {
             "tokens": [
-                266
+                226
             ],
             "availableWorkspaces": [
-                236
+                196
             ],
             "__typename": [
                 1
@@ -4849,10 +4210,10 @@ export default {
         },
         "SignUp": {
             "loginToken": [
-                258
+                218
             ],
             "workspace": [
-                271
+                231
             ],
             "__typename": [
                 1
@@ -4860,7 +4221,7 @@ export default {
         },
         "TransientToken": {
             "transientToken": [
-                258
+                218
             ],
             "__typename": [
                 1
@@ -4882,7 +4243,7 @@ export default {
         },
         "VerifyEmailAndGetLoginToken": {
             "loginToken": [
-                258
+                218
             ],
             "workspaceUrls": [
                 159
@@ -4901,7 +4262,7 @@ export default {
         },
         "AuthTokens": {
             "tokens": [
-                266
+                226
             ],
             "__typename": [
                 1
@@ -4909,7 +4270,7 @@ export default {
         },
         "LoginToken": {
             "loginToken": [
-                258
+                218
             ],
             "__typename": [
                 1
@@ -4939,10 +4300,10 @@ export default {
         },
         "Impersonate": {
             "loginToken": [
-                258
+                218
             ],
             "workspace": [
-                271
+                231
             ],
             "__typename": [
                 1
@@ -4964,7 +4325,7 @@ export default {
                 1
             ],
             "dailyUsage": [
-                282
+                242
             ],
             "__typename": [
                 1
@@ -4972,16 +4333,16 @@ export default {
         },
         "UsageAnalytics": {
             "usageByUser": [
-                194
+                182
             ],
             "usageByOperationType": [
-                194
+                182
             ],
             "usageByModel": [
-                194
+                182
             ],
             "timeSeries": [
-                282
+                242
             ],
             "periodStart": [
                 4
@@ -4990,7 +4351,7 @@ export default {
                 4
             ],
             "userDailyUsage": [
-                283
+                243
             ],
             "__typename": [
                 1
@@ -5147,13 +4508,13 @@ export default {
                 1
             ],
             "driver": [
-                293
+                253
             ],
             "status": [
-                294
+                254
             ],
             "verificationRecords": [
-                291
+                251
             ],
             "verifiedAt": [
                 4
@@ -5203,7 +4564,7 @@ export default {
                 1
             ],
             "location": [
-                296
+                256
             ],
             "__typename": [
                 1
@@ -5231,13 +4592,13 @@ export default {
         },
         "ImapSmtpCaldavConnectionParameters": {
             "IMAP": [
-                298
+                258
             ],
             "SMTP": [
-                298
+                258
             ],
             "CALDAV": [
-                298
+                258
             ],
             "__typename": [
                 1
@@ -5257,7 +4618,7 @@ export default {
                 3
             ],
             "connectionParameters": [
-                299
+                259
             ],
             "__typename": [
                 1
@@ -5302,10 +4663,10 @@ export default {
                 3
             ],
             "frontComponent": [
-                260
+                220
             ],
             "engineComponentKey": [
-                304
+                264
             ],
             "label": [
                 1
@@ -5323,10 +4684,10 @@ export default {
                 6
             ],
             "availabilityType": [
-                305
+                265
             ],
             "payload": [
-                306
+                266
             ],
             "hotKeys": [
                 1
@@ -5357,10 +4718,10 @@ export default {
         "CommandMenuItemAvailabilityType": {},
         "CommandMenuItemPayload": {
             "on_PathCommandMenuItemPayload": [
-                307
+                267
             ],
             "on_ObjectMetadataCommandMenuItemPayload": [
-                308
+                268
             ],
             "__typename": [
                 1
@@ -5518,7 +4879,7 @@ export default {
                 1
             ],
             "series": [
-                312
+                272
             ],
             "xAxisLabel": [
                 1
@@ -5567,7 +4928,7 @@ export default {
                 1
             ],
             "data": [
-                314
+                274
             ],
             "__typename": [
                 1
@@ -5575,7 +4936,7 @@ export default {
         },
         "LineChartData": {
             "series": [
-                315
+                275
             ],
             "xAxisLabel": [
                 1
@@ -5612,7 +4973,7 @@ export default {
         },
         "PieChartData": {
             "data": [
-                317
+                277
             ],
             "showLegend": [
                 6
@@ -5679,7 +5040,7 @@ export default {
                 1
             ],
             "connectionParameters": [
-                299
+                259
             ],
             "lastSignedInAt": [
                 4
@@ -5716,13 +5077,13 @@ export default {
         },
         "PublicImapSmtpCaldavConnectionParameters": {
             "IMAP": [
-                321
+                281
             ],
             "SMTP": [
-                321
+                281
             ],
             "CALDAV": [
-                321
+                281
             ],
             "__typename": [
                 1
@@ -5763,7 +5124,7 @@ export default {
                 4
             ],
             "connectionParameters": [
-                322
+                282
             ],
             "__typename": [
                 1
@@ -5819,13 +5180,13 @@ export default {
         },
         "EventLogQueryResult": {
             "records": [
-                325
+                285
             ],
             "totalCount": [
                 21
             ],
             "pageInfo": [
-                326
+                286
             ],
             "__typename": [
                 1
@@ -5924,7 +5285,7 @@ export default {
                 1
             ],
             "parts": [
-                310
+                270
             ],
             "processedAt": [
                 4
@@ -5952,7 +5313,7 @@ export default {
         },
         "AiSystemPromptPreview": {
             "sections": [
-                331
+                291
             ],
             "estimatedTokenCount": [
                 21
@@ -5999,7 +5360,7 @@ export default {
         },
         "AgentChatThreadEdge": {
             "node": [
-                329
+                289
             ],
             "cursor": [
                 40
@@ -6010,10 +5371,10 @@ export default {
         },
         "AgentChatThreadConnection": {
             "pageInfo": [
-                241
+                201
             ],
             "edges": [
-                336
+                296
             ],
             "__typename": [
                 1
@@ -6050,10 +5411,10 @@ export default {
                 3
             ],
             "evaluations": [
-                338
+                298
             ],
             "messages": [
-                330
+                290
             ],
             "createdAt": [
                 4
@@ -6070,19 +5431,19 @@ export default {
                 1
             ],
             "syncStatus": [
-                341
+                301
             ],
             "syncStage": [
-                342
+                302
             ],
             "visibility": [
-                343
+                303
             ],
             "isContactAutoCreationEnabled": [
                 6
             ],
             "contactAutoCreationPolicy": [
-                344
+                304
             ],
             "isSyncEnabled": [
                 6
@@ -6118,22 +5479,22 @@ export default {
                 3
             ],
             "visibility": [
-                346
+                306
             ],
             "handle": [
                 1
             ],
             "type": [
-                347
+                307
             ],
             "isContactAutoCreationEnabled": [
                 6
             ],
             "contactAutoCreationPolicy": [
-                348
+                308
             ],
             "messageFolderImportPolicy": [
-                349
+                309
             ],
             "excludeNonProfessionalEmails": [
                 6
@@ -6142,7 +5503,7 @@ export default {
                 6
             ],
             "pendingGroupEmailsAction": [
-                350
+                310
             ],
             "isSyncEnabled": [
                 6
@@ -6151,10 +5512,10 @@ export default {
                 4
             ],
             "syncStatus": [
-                351
+                311
             ],
             "syncStage": [
-                352
+                312
             ],
             "syncStageStartedAt": [
                 4
@@ -6205,7 +5566,7 @@ export default {
                 1
             ],
             "pendingSyncAction": [
-                354
+                314
             ],
             "messageChannelId": [
                 3
@@ -6223,7 +5584,7 @@ export default {
         "MessageFolderPendingSyncAction": {},
         "CollectionHash": {
             "collectionName": [
-                356
+                316
             ],
             "hash": [
                 1
@@ -6290,13 +5651,13 @@ export default {
         },
         "MinimalMetadata": {
             "objectMetadataItems": [
-                357
+                317
             ],
             "views": [
-                358
+                318
             ],
             "collectionHashes": [
-                355
+                315
             ],
             "__typename": [
                 1
@@ -6462,7 +5823,7 @@ export default {
                 2,
                 {
                     "input": [
-                        362,
+                        322,
                         "GetApiKeyInput!"
                     ]
                 }
@@ -6566,7 +5927,7 @@ export default {
                 32,
                 {
                     "input": [
-                        363,
+                        323,
                         "LogicFunctionIdInput!"
                     ]
                 }
@@ -6578,7 +5939,7 @@ export default {
                 15,
                 {
                     "input": [
-                        363,
+                        323,
                         "LogicFunctionIdInput!"
                     ]
                 }
@@ -6587,16 +5948,16 @@ export default {
                 1,
                 {
                     "input": [
-                        363,
+                        323,
                         "LogicFunctionIdInput!"
                     ]
                 }
             ],
             "commandMenuItems": [
-                303
+                263
             ],
             "commandMenuItem": [
-                303,
+                263,
                 {
                     "id": [
                         3,
@@ -6605,10 +5966,10 @@ export default {
                 }
             ],
             "frontComponents": [
-                260
+                220
             ],
             "frontComponent": [
-                260,
+                220,
                 {
                     "id": [
                         3,
@@ -6617,7 +5978,7 @@ export default {
                 }
             ],
             "objectRecordCounts": [
-                247
+                207
             ],
             "object": [
                 46,
@@ -6629,7 +5990,7 @@ export default {
                 }
             ],
             "objects": [
-                248,
+                208,
                 {
                     "paging": [
                         39,
@@ -6651,7 +6012,7 @@ export default {
                 }
             ],
             "indexMetadatas": [
-                242,
+                202,
                 {
                     "paging": [
                         39,
@@ -6670,7 +6031,7 @@ export default {
                 25,
                 {
                     "input": [
-                        365,
+                        325,
                         "AgentIdInput!"
                     ]
                 }
@@ -6679,7 +6040,7 @@ export default {
                 29
             ],
             "getToolIndex": [
-                309
+                269
             ],
             "getToolInputSchema": [
                 15,
@@ -6700,7 +6061,7 @@ export default {
                 }
             ],
             "fields": [
-                252,
+                212,
                 {
                     "paging": [
                         39,
@@ -6730,7 +6091,7 @@ export default {
                 }
             ],
             "myMessageFolders": [
-                353,
+                313,
                 {
                     "messageChannelId": [
                         3
@@ -6738,7 +6099,7 @@ export default {
                 }
             ],
             "myMessageChannels": [
-                345,
+                305,
                 {
                     "connectedAccountId": [
                         3
@@ -6746,10 +6107,10 @@ export default {
                 }
             ],
             "myConnectedAccounts": [
-                320
+                280
             ],
             "connectedAccountById": [
-                323,
+                283,
                 {
                     "id": [
                         3,
@@ -6758,10 +6119,10 @@ export default {
                 }
             ],
             "connectedAccounts": [
-                320
+                280
             ],
             "myCalendarChannels": [
-                340,
+                300,
                 {
                     "connectedAccountId": [
                         3
@@ -6769,10 +6130,10 @@ export default {
                 }
             ],
             "webhooks": [
-                360
+                320
             ],
             "webhook": [
-                360,
+                320,
                 {
                     "id": [
                         3,
@@ -6781,10 +6142,10 @@ export default {
                 }
             ],
             "minimalMetadata": [
-                359
+                319
             ],
             "chatThread": [
-                329,
+                289,
                 {
                     "id": [
                         3,
@@ -6793,7 +6154,7 @@ export default {
                 }
             ],
             "chatMessages": [
-                330,
+                290,
                 {
                     "threadId": [
                         3,
@@ -6802,7 +6163,7 @@ export default {
                 }
             ],
             "chatStreamCatchupChunks": [
-                333,
+                293,
                 {
                     "threadId": [
                         3,
@@ -6811,13 +6172,13 @@ export default {
                 }
             ],
             "getAiSystemPromptPreview": [
-                332
+                292
             ],
             "skills": [
-                328
+                288
             ],
             "skill": [
-                328,
+                288,
                 {
                     "id": [
                         3,
@@ -6826,24 +6187,24 @@ export default {
                 }
             ],
             "chatThreads": [
-                337,
+                297,
                 {
                     "paging": [
                         39,
                         "CursorPaging!"
                     ],
                     "filter": [
-                        366,
+                        326,
                         "AgentChatThreadFilter!"
                     ],
                     "sorting": [
-                        369,
+                        329,
                         "[AgentChatThreadSort!]!"
                     ]
                 }
             ],
             "agentTurns": [
-                339,
+                299,
                 {
                     "agentId": [
                         3,
@@ -6852,43 +6213,43 @@ export default {
                 }
             ],
             "eventLogs": [
-                327,
+                287,
                 {
                     "input": [
-                        373,
+                        333,
                         "EventLogQueryInput!"
                     ]
                 }
             ],
             "pieChartData": [
-                318,
+                278,
                 {
                     "input": [
-                        377,
+                        337,
                         "PieChartDataInput!"
                     ]
                 }
             ],
             "lineChartData": [
-                316,
+                276,
                 {
                     "input": [
-                        378,
+                        338,
                         "LineChartDataInput!"
                     ]
                 }
             ],
             "barChartData": [
-                313,
+                273,
                 {
                     "input": [
-                        379,
+                        339,
                         "BarChartDataInput!"
                     ]
                 }
             ],
             "checkUserExists": [
-                279,
+                239,
                 {
                     "email": [
                         1,
@@ -6900,7 +6261,7 @@ export default {
                 }
             ],
             "checkWorkspaceInviteHashIsValid": [
-                280,
+                240,
                 {
                     "inviteHash": [
                         1,
@@ -6918,7 +6279,7 @@ export default {
                 }
             ],
             "validatePasswordResetToken": [
-                274,
+                234,
                 {
                     "passwordResetToken": [
                         1,
@@ -6927,7 +6288,7 @@ export default {
                 }
             ],
             "findApplicationRegistrationByClientId": [
-                226,
+                186,
                 {
                     "clientId": [
                         1,
@@ -6957,7 +6318,7 @@ export default {
                 }
             ],
             "findApplicationRegistrationStats": [
-                224,
+                184,
                 {
                     "id": [
                         1,
@@ -6990,7 +6351,7 @@ export default {
                 66
             ],
             "getPublicWorkspaceDataByDomain": [
-                176,
+                166,
                 {
                     "origin": [
                         1
@@ -6998,7 +6359,7 @@ export default {
                 }
             ],
             "getPublicWorkspaceDataById": [
-                177,
+                167,
                 {
                     "id": [
                         3,
@@ -7007,10 +6368,10 @@ export default {
                 }
             ],
             "getSSOIdentityProviders": [
-                232
+                192
             ],
             "getConnectedImapSmtpCaldavAccount": [
-                300,
+                260,
                 {
                     "id": [
                         3,
@@ -7019,7 +6380,7 @@ export default {
                 }
             ],
             "getAutoCompleteAddress": [
-                295,
+                255,
                 {
                     "address": [
                         1,
@@ -7038,7 +6399,7 @@ export default {
                 }
             ],
             "getAddressDetails": [
-                297,
+                257,
                 {
                     "placeId": [
                         1,
@@ -7050,182 +6411,28 @@ export default {
                     ]
                 }
             ],
-            "userLookupAdminPanel": [
-                162,
-                {
-                    "userIdentifier": [
-                        1,
-                        "String!"
-                    ]
-                }
-            ],
-            "adminPanelRecentUsers": [
-                163,
-                {
-                    "searchTerm": [
-                        1
-                    ]
-                }
-            ],
-            "adminPanelTopWorkspaces": [
-                164,
-                {
-                    "searchTerm": [
-                        1
-                    ]
-                }
-            ],
-            "getConfigVariablesGrouped": [
-                200
-            ],
-            "getSystemHealthStatus": [
-                211
-            ],
-            "getIndicatorHealthStatus": [
-                214,
-                {
-                    "indicatorId": [
-                        209,
-                        "HealthIndicatorId!"
-                    ]
-                }
-            ],
-            "getQueueMetrics": [
-                221,
-                {
-                    "queueName": [
-                        1,
-                        "String!"
-                    ],
-                    "timeRange": [
-                        222
-                    ]
-                }
-            ],
-            "versionInfo": [
-                212
-            ],
-            "getAdminAiModels": [
-                182
-            ],
-            "getDatabaseConfigVariable": [
-                195,
-                {
-                    "key": [
-                        1,
-                        "String!"
-                    ]
-                }
-            ],
-            "getQueueJobs": [
-                206,
-                {
-                    "queueName": [
-                        1,
-                        "String!"
-                    ],
-                    "state": [
-                        204,
-                        "JobState!"
-                    ],
-                    "limit": [
-                        21
-                    ],
-                    "offset": [
-                        21
-                    ]
-                }
-            ],
-            "findAllApplicationRegistrations": [
-                7
-            ],
-            "getAiProviders": [
-                15
-            ],
-            "getModelsDevProviders": [
-                217
-            ],
-            "getModelsDevSuggestions": [
-                216,
-                {
-                    "providerType": [
-                        1,
-                        "String!"
-                    ]
-                }
-            ],
-            "getAdminAiUsageByWorkspace": [
-                194,
-                {
-                    "periodStart": [
-                        4
-                    ],
-                    "periodEnd": [
-                        4
-                    ]
-                }
-            ],
-            "getMaintenanceMode": [
-                215
-            ],
-            "workspaceLookupAdminPanel": [
-                162,
-                {
-                    "workspaceId": [
-                        3,
-                        "UUID!"
-                    ]
-                }
-            ],
-            "getAdminWorkspaceChatThreads": [
-                165,
-                {
-                    "workspaceId": [
-                        3,
-                        "UUID!"
-                    ]
-                }
-            ],
-            "getAdminChatThreadMessages": [
-                169,
-                {
-                    "threadId": [
-                        3,
-                        "UUID!"
-                    ]
-                }
-            ],
-            "findOneAdminApplicationRegistration": [
-                7,
-                {
-                    "id": [
-                        1,
-                        "String!"
-                    ]
-                }
-            ],
             "getUsageAnalytics": [
-                284,
+                244,
                 {
                     "input": [
-                        380
+                        340
                     ]
                 }
             ],
             "getPostgresCredentials": [
-                302
+                262
             ],
             "findManyPublicDomains": [
-                290
+                250
             ],
             "getEmailingDomains": [
-                292
+                252
             ],
             "findManyMarketplaceApps": [
-                288
+                248
             ],
             "findMarketplaceAppDetail": [
-                289,
+                249,
                 {
                     "universalIdentifier": [
                         1,
@@ -7261,7 +6468,7 @@ export default {
         },
         "LogicFunctionIdInput": {
             "id": [
-                364
+                324
             ],
             "__typename": [
                 1
@@ -7278,16 +6485,16 @@ export default {
         },
         "AgentChatThreadFilter": {
             "and": [
-                366
+                326
             ],
             "or": [
-                366
+                326
             ],
             "id": [
                 42
             ],
             "updatedAt": [
-                367
+                327
             ],
             "__typename": [
                 1
@@ -7325,10 +6532,10 @@ export default {
                 4
             ],
             "between": [
-                368
+                328
             ],
             "notBetween": [
-                368
+                328
             ],
             "__typename": [
                 1
@@ -7347,13 +6554,13 @@ export default {
         },
         "AgentChatThreadSort": {
             "field": [
-                370
+                330
             ],
             "direction": [
-                371
+                331
             ],
             "nulls": [
-                372
+                332
             ],
             "__typename": [
                 1
@@ -7364,10 +6571,10 @@ export default {
         "SortNulls": {},
         "EventLogQueryInput": {
             "table": [
-                374
+                334
             ],
             "filters": [
-                375
+                335
             ],
             "first": [
                 21
@@ -7388,7 +6595,7 @@ export default {
                 1
             ],
             "dateRange": [
-                376
+                336
             ],
             "recordId": [
                 1
@@ -7455,7 +6662,7 @@ export default {
                 1
             ],
             "operationTypes": [
-                381
+                341
             ],
             "__typename": [
                 1
@@ -7467,7 +6674,7 @@ export default {
                 6,
                 {
                     "input": [
-                        383,
+                        343,
                         "AddQuerySubscriptionInput!"
                     ]
                 }
@@ -7476,7 +6683,7 @@ export default {
                 6,
                 {
                     "input": [
-                        384,
+                        344,
                         "RemoveQueryFromEventStreamInput!"
                     ]
                 }
@@ -7485,7 +6692,7 @@ export default {
                 146,
                 {
                     "inputs": [
-                        385,
+                        345,
                         "[CreateNavigationMenuItemInput!]!"
                     ]
                 }
@@ -7494,7 +6701,7 @@ export default {
                 146,
                 {
                     "input": [
-                        385,
+                        345,
                         "CreateNavigationMenuItemInput!"
                     ]
                 }
@@ -7503,7 +6710,7 @@ export default {
                 146,
                 {
                     "inputs": [
-                        386,
+                        346,
                         "[UpdateOneNavigationMenuItemInput!]!"
                     ]
                 }
@@ -7512,7 +6719,7 @@ export default {
                 146,
                 {
                     "input": [
-                        386,
+                        346,
                         "UpdateOneNavigationMenuItemInput!"
                     ]
                 }
@@ -7539,7 +6746,7 @@ export default {
                 118,
                 {
                     "file": [
-                        388,
+                        348,
                         "Upload!"
                     ]
                 }
@@ -7548,7 +6755,7 @@ export default {
                 118,
                 {
                     "file": [
-                        388,
+                        348,
                         "Upload!"
                     ]
                 }
@@ -7557,7 +6764,7 @@ export default {
                 118,
                 {
                     "file": [
-                        388,
+                        348,
                         "Upload!"
                     ]
                 }
@@ -7566,7 +6773,7 @@ export default {
                 118,
                 {
                     "file": [
-                        388,
+                        348,
                         "Upload!"
                     ]
                 }
@@ -7575,7 +6782,7 @@ export default {
                 118,
                 {
                     "file": [
-                        388,
+                        348,
                         "Upload!"
                     ]
                 }
@@ -7584,7 +6791,7 @@ export default {
                 118,
                 {
                     "file": [
-                        388,
+                        348,
                         "Upload!"
                     ],
                     "fieldMetadataId": [
@@ -7597,7 +6804,7 @@ export default {
                 118,
                 {
                     "file": [
-                        388,
+                        348,
                         "Upload!"
                     ],
                     "fieldMetadataUniversalIdentifier": [
@@ -7610,7 +6817,7 @@ export default {
                 52,
                 {
                     "input": [
-                        389,
+                        349,
                         "CreateViewFilterGroupInput!"
                     ]
                 }
@@ -7623,7 +6830,7 @@ export default {
                         "String!"
                     ],
                     "input": [
-                        390,
+                        350,
                         "UpdateViewFilterGroupInput!"
                     ]
                 }
@@ -7650,7 +6857,7 @@ export default {
                 54,
                 {
                     "input": [
-                        391,
+                        351,
                         "CreateViewFilterInput!"
                     ]
                 }
@@ -7659,7 +6866,7 @@ export default {
                 54,
                 {
                     "input": [
-                        392,
+                        352,
                         "UpdateViewFilterInput!"
                     ]
                 }
@@ -7668,7 +6875,7 @@ export default {
                 54,
                 {
                     "input": [
-                        394,
+                        354,
                         "DeleteViewFilterInput!"
                     ]
                 }
@@ -7677,7 +6884,7 @@ export default {
                 54,
                 {
                     "input": [
-                        395,
+                        355,
                         "DestroyViewFilterInput!"
                     ]
                 }
@@ -7686,7 +6893,7 @@ export default {
                 60,
                 {
                     "input": [
-                        396,
+                        356,
                         "CreateViewInput!"
                     ]
                 }
@@ -7699,7 +6906,7 @@ export default {
                         "String!"
                     ],
                     "input": [
-                        397,
+                        357,
                         "UpdateViewInput!"
                     ]
                 }
@@ -7726,7 +6933,7 @@ export default {
                 57,
                 {
                     "input": [
-                        398,
+                        358,
                         "CreateViewSortInput!"
                     ]
                 }
@@ -7735,7 +6942,7 @@ export default {
                 57,
                 {
                     "input": [
-                        399,
+                        359,
                         "UpdateViewSortInput!"
                     ]
                 }
@@ -7744,7 +6951,7 @@ export default {
                 6,
                 {
                     "input": [
-                        401,
+                        361,
                         "DeleteViewSortInput!"
                     ]
                 }
@@ -7753,7 +6960,7 @@ export default {
                 6,
                 {
                     "input": [
-                        402,
+                        362,
                         "DestroyViewSortInput!"
                     ]
                 }
@@ -7762,7 +6969,7 @@ export default {
                 50,
                 {
                     "input": [
-                        403,
+                        363,
                         "UpdateViewFieldInput!"
                     ]
                 }
@@ -7771,7 +6978,7 @@ export default {
                 50,
                 {
                     "input": [
-                        405,
+                        365,
                         "CreateViewFieldInput!"
                     ]
                 }
@@ -7780,7 +6987,7 @@ export default {
                 50,
                 {
                     "inputs": [
-                        405,
+                        365,
                         "[CreateViewFieldInput!]!"
                     ]
                 }
@@ -7789,7 +6996,7 @@ export default {
                 50,
                 {
                     "input": [
-                        406,
+                        366,
                         "DeleteViewFieldInput!"
                     ]
                 }
@@ -7798,7 +7005,7 @@ export default {
                 50,
                 {
                     "input": [
-                        407,
+                        367,
                         "DestroyViewFieldInput!"
                     ]
                 }
@@ -7807,7 +7014,7 @@ export default {
                 59,
                 {
                     "input": [
-                        408,
+                        368,
                         "UpdateViewFieldGroupInput!"
                     ]
                 }
@@ -7816,7 +7023,7 @@ export default {
                 59,
                 {
                     "input": [
-                        410,
+                        370,
                         "CreateViewFieldGroupInput!"
                     ]
                 }
@@ -7825,7 +7032,7 @@ export default {
                 59,
                 {
                     "inputs": [
-                        410,
+                        370,
                         "[CreateViewFieldGroupInput!]!"
                     ]
                 }
@@ -7834,7 +7041,7 @@ export default {
                 59,
                 {
                     "input": [
-                        411,
+                        371,
                         "DeleteViewFieldGroupInput!"
                     ]
                 }
@@ -7843,7 +7050,7 @@ export default {
                 59,
                 {
                     "input": [
-                        412,
+                        372,
                         "DestroyViewFieldGroupInput!"
                     ]
                 }
@@ -7852,7 +7059,7 @@ export default {
                 60,
                 {
                     "input": [
-                        413,
+                        373,
                         "UpsertFieldsWidgetInput!"
                     ]
                 }
@@ -7861,7 +7068,7 @@ export default {
                 2,
                 {
                     "input": [
-                        416,
+                        376,
                         "CreateApiKeyInput!"
                     ]
                 }
@@ -7870,7 +7077,7 @@ export default {
                 2,
                 {
                     "input": [
-                        417,
+                        377,
                         "UpdateApiKeyInput!"
                     ]
                 }
@@ -7879,7 +7086,7 @@ export default {
                 2,
                 {
                     "input": [
-                        418,
+                        378,
                         "RevokeApiKeyInput!"
                     ]
                 }
@@ -7921,7 +7128,7 @@ export default {
                 116,
                 {
                     "type": [
-                        419,
+                        379,
                         "AnalyticsType!"
                     ],
                     "name": [
@@ -8034,7 +7241,7 @@ export default {
                 117,
                 {
                     "input": [
-                        420,
+                        380,
                         "CreateApprovedAccessDomainInput!"
                     ]
                 }
@@ -8043,7 +7250,7 @@ export default {
                 6,
                 {
                     "input": [
-                        421,
+                        381,
                         "DeleteApprovedAccessDomainInput!"
                     ]
                 }
@@ -8052,7 +7259,7 @@ export default {
                 117,
                 {
                     "input": [
-                        422,
+                        382,
                         "ValidateApprovedAccessDomainInput!"
                     ]
                 }
@@ -8061,7 +7268,7 @@ export default {
                 113,
                 {
                     "input": [
-                        423,
+                        383,
                         "CreatePageLayoutTabInput!"
                     ]
                 }
@@ -8074,7 +7281,7 @@ export default {
                         "String!"
                     ],
                     "input": [
-                        424,
+                        384,
                         "UpdatePageLayoutTabInput!"
                     ]
                 }
@@ -8092,7 +7299,7 @@ export default {
                 114,
                 {
                     "input": [
-                        425,
+                        385,
                         "CreatePageLayoutInput!"
                     ]
                 }
@@ -8105,7 +7312,7 @@ export default {
                         "String!"
                     ],
                     "input": [
-                        426,
+                        386,
                         "UpdatePageLayoutInput!"
                     ]
                 }
@@ -8127,7 +7334,7 @@ export default {
                         "String!"
                     ],
                     "input": [
-                        427,
+                        387,
                         "UpdatePageLayoutWithTabsInput!"
                     ]
                 }
@@ -8163,7 +7370,7 @@ export default {
                 75,
                 {
                     "input": [
-                        431,
+                        391,
                         "CreatePageLayoutWidgetInput!"
                     ]
                 }
@@ -8176,7 +7383,7 @@ export default {
                         "String!"
                     ],
                     "input": [
-                        432,
+                        392,
                         "UpdatePageLayoutWidgetInput!"
                     ]
                 }
@@ -8194,7 +7401,7 @@ export default {
                 32,
                 {
                     "input": [
-                        363,
+                        323,
                         "LogicFunctionIdInput!"
                     ]
                 }
@@ -8203,7 +7410,7 @@ export default {
                 32,
                 {
                     "input": [
-                        433,
+                        393,
                         "CreateLogicFunctionFromSourceInput!"
                     ]
                 }
@@ -8212,7 +7419,7 @@ export default {
                 155,
                 {
                     "input": [
-                        434,
+                        394,
                         "ExecuteOneLogicFunctionInput!"
                     ]
                 }
@@ -8221,31 +7428,31 @@ export default {
                 6,
                 {
                     "input": [
-                        435,
+                        395,
                         "UpdateLogicFunctionFromSourceInput!"
                     ]
                 }
             ],
             "createCommandMenuItem": [
-                303,
+                263,
                 {
                     "input": [
-                        437,
+                        397,
                         "CreateCommandMenuItemInput!"
                     ]
                 }
             ],
             "updateCommandMenuItem": [
-                303,
+                263,
                 {
                     "input": [
-                        438,
+                        398,
                         "UpdateCommandMenuItemInput!"
                     ]
                 }
             ],
             "deleteCommandMenuItem": [
-                303,
+                263,
                 {
                     "id": [
                         3,
@@ -8254,25 +7461,25 @@ export default {
                 }
             ],
             "createFrontComponent": [
-                260,
+                220,
                 {
                     "input": [
-                        439,
+                        399,
                         "CreateFrontComponentInput!"
                     ]
                 }
             ],
             "updateFrontComponent": [
-                260,
+                220,
                 {
                     "input": [
-                        440,
+                        400,
                         "UpdateFrontComponentInput!"
                     ]
                 }
             ],
             "deleteFrontComponent": [
-                260,
+                220,
                 {
                     "id": [
                         3,
@@ -8284,7 +7491,7 @@ export default {
                 46,
                 {
                     "input": [
-                        442,
+                        402,
                         "CreateOneObjectInput!"
                     ]
                 }
@@ -8293,7 +7500,7 @@ export default {
                 46,
                 {
                     "input": [
-                        444,
+                        404,
                         "DeleteOneObjectInput!"
                     ]
                 }
@@ -8302,7 +7509,7 @@ export default {
                 46,
                 {
                     "input": [
-                        445,
+                        405,
                         "UpdateOneObjectInput!"
                     ]
                 }
@@ -8311,7 +7518,7 @@ export default {
                 25,
                 {
                     "input": [
-                        447,
+                        407,
                         "CreateAgentInput!"
                     ]
                 }
@@ -8320,7 +7527,7 @@ export default {
                 25,
                 {
                     "input": [
-                        448,
+                        408,
                         "UpdateAgentInput!"
                     ]
                 }
@@ -8329,7 +7536,7 @@ export default {
                 25,
                 {
                     "input": [
-                        365,
+                        325,
                         "AgentIdInput!"
                     ]
                 }
@@ -8351,7 +7558,7 @@ export default {
                 29,
                 {
                     "createRoleInput": [
-                        449,
+                        409,
                         "CreateRoleInput!"
                     ]
                 }
@@ -8360,7 +7567,7 @@ export default {
                 29,
                 {
                     "updateRoleInput": [
-                        450,
+                        410,
                         "UpdateRoleInput!"
                     ]
                 }
@@ -8378,7 +7585,7 @@ export default {
                 16,
                 {
                     "upsertObjectPermissionsInput": [
-                        452,
+                        412,
                         "UpsertObjectPermissionsInput!"
                     ]
                 }
@@ -8387,7 +7594,7 @@ export default {
                 27,
                 {
                     "upsertPermissionFlagsInput": [
-                        454,
+                        414,
                         "UpsertPermissionFlagsInput!"
                     ]
                 }
@@ -8396,16 +7603,16 @@ export default {
                 26,
                 {
                     "upsertFieldPermissionsInput": [
-                        455,
+                        415,
                         "UpsertFieldPermissionsInput!"
                     ]
                 }
             ],
             "upsertRowLevelPermissionPredicates": [
-                257,
+                217,
                 {
                     "input": [
-                        457,
+                        417,
                         "UpsertRowLevelPermissionPredicatesInput!"
                     ]
                 }
@@ -8436,7 +7643,7 @@ export default {
                 34,
                 {
                     "input": [
-                        460,
+                        420,
                         "CreateOneFieldMetadataInput!"
                     ]
                 }
@@ -8445,7 +7652,7 @@ export default {
                 34,
                 {
                     "input": [
-                        462,
+                        422,
                         "UpdateOneFieldMetadataInput!"
                     ]
                 }
@@ -8454,7 +7661,7 @@ export default {
                 34,
                 {
                     "input": [
-                        464,
+                        424,
                         "DeleteOneFieldInput!"
                     ]
                 }
@@ -8463,7 +7670,7 @@ export default {
                 56,
                 {
                     "input": [
-                        465,
+                        425,
                         "CreateViewGroupInput!"
                     ]
                 }
@@ -8472,7 +7679,7 @@ export default {
                 56,
                 {
                     "inputs": [
-                        465,
+                        425,
                         "[CreateViewGroupInput!]!"
                     ]
                 }
@@ -8481,7 +7688,7 @@ export default {
                 56,
                 {
                     "input": [
-                        466,
+                        426,
                         "UpdateViewGroupInput!"
                     ]
                 }
@@ -8490,7 +7697,7 @@ export default {
                 56,
                 {
                     "inputs": [
-                        466,
+                        426,
                         "[UpdateViewGroupInput!]!"
                     ]
                 }
@@ -8499,7 +7706,7 @@ export default {
                 56,
                 {
                     "input": [
-                        468,
+                        428,
                         "DeleteViewGroupInput!"
                     ]
                 }
@@ -8508,40 +7715,40 @@ export default {
                 56,
                 {
                     "input": [
-                        469,
+                        429,
                         "DestroyViewGroupInput!"
                     ]
                 }
             ],
             "updateMessageFolder": [
-                353,
+                313,
                 {
                     "input": [
-                        470,
+                        430,
                         "UpdateMessageFolderInput!"
                     ]
                 }
             ],
             "updateMessageFolders": [
-                353,
+                313,
                 {
                     "input": [
-                        472,
+                        432,
                         "UpdateMessageFoldersInput!"
                     ]
                 }
             ],
             "updateMessageChannel": [
-                345,
+                305,
                 {
                     "input": [
-                        473,
+                        433,
                         "UpdateMessageChannelInput!"
                     ]
                 }
             ],
             "deleteConnectedAccount": [
-                320,
+                280,
                 {
                     "id": [
                         3,
@@ -8550,34 +7757,34 @@ export default {
                 }
             ],
             "updateCalendarChannel": [
-                340,
+                300,
                 {
                     "input": [
-                        475,
+                        435,
                         "UpdateCalendarChannelInput!"
                     ]
                 }
             ],
             "createWebhook": [
-                360,
+                320,
                 {
                     "input": [
-                        477,
+                        437,
                         "CreateWebhookInput!"
                     ]
                 }
             ],
             "updateWebhook": [
-                360,
+                320,
                 {
                     "input": [
-                        478,
+                        438,
                         "UpdateWebhookInput!"
                     ]
                 }
             ],
             "deleteWebhook": [
-                360,
+                320,
                 {
                     "id": [
                         3,
@@ -8586,10 +7793,10 @@ export default {
                 }
             ],
             "createChatThread": [
-                329
+                289
             ],
             "sendChatMessage": [
-                334,
+                294,
                 {
                     "threadId": [
                         3,
@@ -8634,25 +7841,25 @@ export default {
                 }
             ],
             "createSkill": [
-                328,
+                288,
                 {
                     "input": [
-                        480,
+                        440,
                         "CreateSkillInput!"
                     ]
                 }
             ],
             "updateSkill": [
-                328,
+                288,
                 {
                     "input": [
-                        481,
+                        441,
                         "UpdateSkillInput!"
                     ]
                 }
             ],
             "deleteSkill": [
-                328,
+                288,
                 {
                     "id": [
                         3,
@@ -8661,7 +7868,7 @@ export default {
                 }
             ],
             "activateSkill": [
-                328,
+                288,
                 {
                     "id": [
                         3,
@@ -8670,7 +7877,7 @@ export default {
                 }
             ],
             "deactivateSkill": [
-                328,
+                288,
                 {
                     "id": [
                         3,
@@ -8679,7 +7886,7 @@ export default {
                 }
             ],
             "evaluateAgentTurn": [
-                338,
+                298,
                 {
                     "turnId": [
                         3,
@@ -8688,7 +7895,7 @@ export default {
                 }
             ],
             "runEvaluationInput": [
-                339,
+                299,
                 {
                     "agentId": [
                         3,
@@ -8701,7 +7908,7 @@ export default {
                 }
             ],
             "duplicateDashboard": [
-                319,
+                279,
                 {
                     "id": [
                         3,
@@ -8710,16 +7917,16 @@ export default {
                 }
             ],
             "getAuthorizationUrlForSSO": [
-                269,
+                229,
                 {
                     "input": [
-                        482,
+                        442,
                         "GetAuthorizationUrlForSSOInput!"
                     ]
                 }
             ],
             "getLoginTokenFromCredentials": [
-                278,
+                238,
                 {
                     "email": [
                         1,
@@ -8745,7 +7952,7 @@ export default {
                 }
             ],
             "signIn": [
-                267,
+                227,
                 {
                     "email": [
                         1,
@@ -8767,7 +7974,7 @@ export default {
                 }
             ],
             "verifyEmailAndGetLoginToken": [
-                275,
+                235,
                 {
                     "emailVerificationToken": [
                         1,
@@ -8787,7 +7994,7 @@ export default {
                 }
             ],
             "verifyEmailAndGetWorkspaceAgnosticToken": [
-                267,
+                227,
                 {
                     "emailVerificationToken": [
                         1,
@@ -8803,7 +8010,7 @@ export default {
                 }
             ],
             "getAuthTokensFromOTP": [
-                277,
+                237,
                 {
                     "otp": [
                         1,
@@ -8823,7 +8030,7 @@ export default {
                 }
             ],
             "signUp": [
-                267,
+                227,
                 {
                     "email": [
                         1,
@@ -8845,7 +8052,7 @@ export default {
                 }
             ],
             "signUpInWorkspace": [
-                272,
+                232,
                 {
                     "email": [
                         1,
@@ -8876,13 +8083,13 @@ export default {
                 }
             ],
             "signUpInNewWorkspace": [
-                272
+                232
             ],
             "generateTransientToken": [
-                273
+                233
             ],
             "getAuthTokensFromLoginToken": [
-                277,
+                237,
                 {
                     "loginToken": [
                         1,
@@ -8895,7 +8102,7 @@ export default {
                 }
             ],
             "authorizeApp": [
-                265,
+                225,
                 {
                     "clientId": [
                         1,
@@ -8917,7 +8124,7 @@ export default {
                 }
             ],
             "renewToken": [
-                277,
+                237,
                 {
                     "appToken": [
                         1,
@@ -8926,7 +8133,7 @@ export default {
                 }
             ],
             "generateApiKeyToken": [
-                276,
+                236,
                 {
                     "apiKeyId": [
                         3,
@@ -8939,7 +8146,7 @@ export default {
                 }
             ],
             "emailPasswordResetLink": [
-                268,
+                228,
                 {
                     "email": [
                         1,
@@ -8951,7 +8158,7 @@ export default {
                 }
             ],
             "updatePasswordViaResetToken": [
-                270,
+                230,
                 {
                     "passwordResetToken": [
                         1,
@@ -8964,10 +8171,10 @@ export default {
                 }
             ],
             "createApplicationRegistration": [
-                225,
+                185,
                 {
                     "input": [
-                        483,
+                        443,
                         "CreateApplicationRegistrationInput!"
                     ]
                 }
@@ -8976,7 +8183,7 @@ export default {
                 7,
                 {
                     "input": [
-                        484,
+                        444,
                         "UpdateApplicationRegistrationInput!"
                     ]
                 }
@@ -8991,7 +8198,7 @@ export default {
                 }
             ],
             "rotateApplicationRegistrationClientSecret": [
-                227,
+                187,
                 {
                     "id": [
                         1,
@@ -9003,7 +8210,7 @@ export default {
                 5,
                 {
                     "input": [
-                        486,
+                        446,
                         "CreateApplicationRegistrationVariableInput!"
                     ]
                 }
@@ -9012,7 +8219,7 @@ export default {
                 5,
                 {
                     "input": [
-                        487,
+                        447,
                         "UpdateApplicationRegistrationVariableInput!"
                     ]
                 }
@@ -9030,7 +8237,7 @@ export default {
                 7,
                 {
                     "file": [
-                        388,
+                        348,
                         "Upload!"
                     ],
                     "universalIdentifier": [
@@ -9052,7 +8259,7 @@ export default {
                 }
             ],
             "initiateOTPProvisioning": [
-                263,
+                223,
                 {
                     "loginToken": [
                         1,
@@ -9065,10 +8272,10 @@ export default {
                 }
             ],
             "initiateOTPProvisioningForAuthenticatedUser": [
-                263
+                223
             ],
             "deleteTwoFactorAuthenticationMethod": [
-                262,
+                222,
                 {
                     "twoFactorAuthenticationMethodId": [
                         3,
@@ -9077,7 +8284,7 @@ export default {
                 }
             ],
             "verifyTwoFactorAuthenticationMethodForAuthenticatedUser": [
-                264,
+                224,
                 {
                     "otp": [
                         1,
@@ -9101,7 +8308,7 @@ export default {
                 6,
                 {
                     "input": [
-                        489,
+                        449,
                         "UpdateWorkspaceMemberSettingsInput!"
                     ]
                 }
@@ -9119,7 +8326,7 @@ export default {
                 }
             ],
             "resendEmailVerificationToken": [
-                228,
+                188,
                 {
                     "email": [
                         1,
@@ -9135,7 +8342,7 @@ export default {
                 66,
                 {
                     "data": [
-                        490,
+                        450,
                         "ActivateWorkspaceInput!"
                     ]
                 }
@@ -9144,7 +8351,7 @@ export default {
                 66,
                 {
                     "data": [
-                        491,
+                        451,
                         "UpdateWorkspaceInput!"
                     ]
                 }
@@ -9153,46 +8360,46 @@ export default {
                 66
             ],
             "checkCustomDomainValidRecords": [
-                256
+                216
             ],
             "createOIDCIdentityProvider": [
-                233,
+                193,
                 {
                     "input": [
-                        492,
+                        452,
                         "SetupOIDCSsoInput!"
                     ]
                 }
             ],
             "createSAMLIdentityProvider": [
-                233,
+                193,
                 {
                     "input": [
-                        493,
+                        453,
                         "SetupSAMLSsoInput!"
                     ]
                 }
             ],
             "deleteSSOIdentityProvider": [
-                229,
+                189,
                 {
                     "input": [
-                        494,
+                        454,
                         "DeleteSsoInput!"
                     ]
                 }
             ],
             "editSSOIdentityProvider": [
-                230,
+                190,
                 {
                     "input": [
-                        495,
+                        455,
                         "EditSsoInput!"
                     ]
                 }
             ],
             "impersonate": [
-                281,
+                241,
                 {
                     "userId": [
                         3,
@@ -9205,16 +8412,16 @@ export default {
                 }
             ],
             "sendEmail": [
-                324,
+                284,
                 {
                     "input": [
-                        496,
+                        456,
                         "SendEmailInput!"
                     ]
                 }
             ],
             "startChannelSync": [
-                311,
+                271,
                 {
                     "connectedAccountId": [
                         3,
@@ -9223,7 +8430,7 @@ export default {
                 }
             ],
             "saveImapSmtpCaldavAccount": [
-                301,
+                261,
                 {
                     "accountOwnerId": [
                         3,
@@ -9234,7 +8441,7 @@ export default {
                         "String!"
                     ],
                     "connectionParameters": [
-                        498,
+                        458,
                         "EmailAccountConnectionParameters!"
                     ],
                     "id": [
@@ -9246,229 +8453,19 @@ export default {
                 157,
                 {
                     "input": [
-                        500,
+                        460,
                         "UpdateLabPublicFeatureFlagInput!"
                     ]
                 }
             ],
-            "updateWorkspaceFeatureFlag": [
-                6,
-                {
-                    "workspaceId": [
-                        3,
-                        "UUID!"
-                    ],
-                    "featureFlag": [
-                        1,
-                        "String!"
-                    ],
-                    "value": [
-                        6,
-                        "Boolean!"
-                    ]
-                }
-            ],
-            "setAdminAiModelEnabled": [
-                6,
-                {
-                    "modelId": [
-                        1,
-                        "String!"
-                    ],
-                    "enabled": [
-                        6,
-                        "Boolean!"
-                    ]
-                }
-            ],
-            "setAdminAiModelsEnabled": [
-                6,
-                {
-                    "modelIds": [
-                        1,
-                        "[String!]!"
-                    ],
-                    "enabled": [
-                        6,
-                        "Boolean!"
-                    ]
-                }
-            ],
-            "setAdminAiModelRecommended": [
-                6,
-                {
-                    "modelId": [
-                        1,
-                        "String!"
-                    ],
-                    "recommended": [
-                        6,
-                        "Boolean!"
-                    ]
-                }
-            ],
-            "setAdminAiModelsRecommended": [
-                6,
-                {
-                    "modelIds": [
-                        1,
-                        "[String!]!"
-                    ],
-                    "recommended": [
-                        6,
-                        "Boolean!"
-                    ]
-                }
-            ],
-            "setAdminDefaultAiModel": [
-                6,
-                {
-                    "role": [
-                        501,
-                        "AiModelRole!"
-                    ],
-                    "modelId": [
-                        1,
-                        "String!"
-                    ]
-                }
-            ],
-            "createDatabaseConfigVariable": [
-                6,
-                {
-                    "key": [
-                        1,
-                        "String!"
-                    ],
-                    "value": [
-                        15,
-                        "JSON!"
-                    ]
-                }
-            ],
-            "updateDatabaseConfigVariable": [
-                6,
-                {
-                    "key": [
-                        1,
-                        "String!"
-                    ],
-                    "value": [
-                        15,
-                        "JSON!"
-                    ]
-                }
-            ],
-            "deleteDatabaseConfigVariable": [
-                6,
-                {
-                    "key": [
-                        1,
-                        "String!"
-                    ]
-                }
-            ],
-            "retryJobs": [
-                207,
-                {
-                    "queueName": [
-                        1,
-                        "String!"
-                    ],
-                    "jobIds": [
-                        1,
-                        "[String!]!"
-                    ]
-                }
-            ],
-            "deleteJobs": [
-                202,
-                {
-                    "queueName": [
-                        1,
-                        "String!"
-                    ],
-                    "jobIds": [
-                        1,
-                        "[String!]!"
-                    ]
-                }
-            ],
-            "addAiProvider": [
-                6,
-                {
-                    "providerName": [
-                        1,
-                        "String!"
-                    ],
-                    "providerConfig": [
-                        15,
-                        "JSON!"
-                    ]
-                }
-            ],
-            "removeAiProvider": [
-                6,
-                {
-                    "providerName": [
-                        1,
-                        "String!"
-                    ]
-                }
-            ],
-            "addModelToProvider": [
-                6,
-                {
-                    "providerName": [
-                        1,
-                        "String!"
-                    ],
-                    "modelConfig": [
-                        15,
-                        "JSON!"
-                    ]
-                }
-            ],
-            "removeModelFromProvider": [
-                6,
-                {
-                    "providerName": [
-                        1,
-                        "String!"
-                    ],
-                    "modelName": [
-                        1,
-                        "String!"
-                    ]
-                }
-            ],
-            "setMaintenanceMode": [
-                6,
-                {
-                    "startAt": [
-                        4,
-                        "DateTime!"
-                    ],
-                    "endAt": [
-                        4,
-                        "DateTime!"
-                    ],
-                    "link": [
-                        1
-                    ]
-                }
-            ],
-            "clearMaintenanceMode": [
-                6
-            ],
             "enablePostgresProxy": [
-                302
+                262
             ],
             "disablePostgresProxy": [
-                302
+                262
             ],
             "createPublicDomain": [
-                290,
+                250,
                 {
                     "domain": [
                         1,
@@ -9486,7 +8483,7 @@ export default {
                 }
             ],
             "checkPublicDomainValidRecords": [
-                256,
+                216,
                 {
                     "domain": [
                         1,
@@ -9495,14 +8492,14 @@ export default {
                 }
             ],
             "createEmailingDomain": [
-                292,
+                252,
                 {
                     "domain": [
                         1,
                         "String!"
                     ],
                     "driver": [
-                        293,
+                        253,
                         "EmailingDomainDriver!"
                     ]
                 }
@@ -9517,7 +8514,7 @@ export default {
                 }
             ],
             "verifyEmailingDomain": [
-                292,
+                252,
                 {
                     "id": [
                         1,
@@ -9529,7 +8526,7 @@ export default {
                 68,
                 {
                     "input": [
-                        502,
+                        461,
                         "CreateOneAppTokenInput!"
                     ]
                 }
@@ -9565,7 +8562,7 @@ export default {
                 6,
                 {
                     "workspaceMigration": [
-                        504,
+                        463,
                         "WorkspaceMigrationInput!"
                     ]
                 }
@@ -9597,7 +8594,7 @@ export default {
                 }
             ],
             "createDevelopmentApplication": [
-                285,
+                245,
                 {
                     "universalIdentifier": [
                         1,
@@ -9610,7 +8607,7 @@ export default {
                 }
             ],
             "generateApplicationToken": [
-                259,
+                219,
                 {
                     "applicationId": [
                         3,
@@ -9619,7 +8616,7 @@ export default {
                 }
             ],
             "syncApplication": [
-                286,
+                246,
                 {
                     "manifest": [
                         15,
@@ -9628,10 +8625,10 @@ export default {
                 }
             ],
             "uploadApplicationFile": [
-                287,
+                247,
                 {
                     "file": [
-                        388,
+                        348,
                         "Upload!"
                     ],
                     "applicationUniversalIdentifier": [
@@ -9639,7 +8636,7 @@ export default {
                         "String!"
                     ],
                     "fileFolder": [
-                        507,
+                        466,
                         "FileFolder!"
                     ],
                     "filePath": [
@@ -9662,7 +8659,7 @@ export default {
                 }
             ],
             "renewApplicationToken": [
-                259,
+                219,
                 {
                     "applicationRefreshToken": [
                         1,
@@ -9748,7 +8745,7 @@ export default {
                 3
             ],
             "update": [
-                387
+                347
             ],
             "__typename": [
                 1
@@ -9855,7 +8852,7 @@ export default {
                 3
             ],
             "update": [
-                393
+                353
             ],
             "__typename": [
                 1
@@ -10028,7 +9025,7 @@ export default {
                 3
             ],
             "update": [
-                400
+                360
             ],
             "__typename": [
                 1
@@ -10063,7 +9060,7 @@ export default {
                 3
             ],
             "update": [
-                404
+                364
             ],
             "__typename": [
                 1
@@ -10139,7 +9136,7 @@ export default {
                 3
             ],
             "update": [
-                409
+                369
             ],
             "__typename": [
                 1
@@ -10203,10 +9200,10 @@ export default {
                 3
             ],
             "groups": [
-                414
+                374
             ],
             "fields": [
-                415
+                375
             ],
             "__typename": [
                 1
@@ -10226,7 +9223,7 @@ export default {
                 6
             ],
             "fields": [
-                415
+                375
             ],
             "__typename": [
                 1
@@ -10395,7 +9392,7 @@ export default {
                 3
             ],
             "tabs": [
-                428
+                388
             ],
             "__typename": [
                 1
@@ -10418,7 +9415,7 @@ export default {
                 79
             ],
             "widgets": [
-                429
+                389
             ],
             "__typename": [
                 1
@@ -10441,7 +9438,7 @@ export default {
                 3
             ],
             "gridPosition": [
-                430
+                390
             ],
             "position": [
                 15
@@ -10490,7 +9487,7 @@ export default {
                 3
             ],
             "gridPosition": [
-                430
+                390
             ],
             "position": [
                 15
@@ -10516,7 +9513,7 @@ export default {
                 3
             ],
             "gridPosition": [
-                430
+                390
             ],
             "position": [
                 15
@@ -10588,7 +9585,7 @@ export default {
                 3
             ],
             "update": [
-                436
+                396
             ],
             "__typename": [
                 1
@@ -10640,7 +9637,7 @@ export default {
                 3
             ],
             "engineComponentKey": [
-                304
+                264
             ],
             "label": [
                 1
@@ -10658,7 +9655,7 @@ export default {
                 6
             ],
             "availabilityType": [
-                305
+                265
             ],
             "hotKeys": [
                 1
@@ -10699,13 +9696,13 @@ export default {
                 6
             ],
             "availabilityType": [
-                305
+                265
             ],
             "availabilityObjectMetadataId": [
                 3
             ],
             "engineComponentKey": [
-                304
+                264
             ],
             "hotKeys": [
                 1
@@ -10748,7 +9745,7 @@ export default {
                 3
             ],
             "update": [
-                441
+                401
             ],
             "__typename": [
                 1
@@ -10767,7 +9764,7 @@ export default {
         },
         "CreateOneObjectInput": {
             "object": [
-                443
+                403
             ],
             "__typename": [
                 1
@@ -10827,7 +9824,7 @@ export default {
         },
         "UpdateOneObjectInput": {
             "update": [
-                446
+                406
             ],
             "id": [
                 3
@@ -10999,7 +9996,7 @@ export default {
         },
         "UpdateRoleInput": {
             "update": [
-                451
+                411
             ],
             "id": [
                 3
@@ -11054,7 +10051,7 @@ export default {
                 3
             ],
             "objectPermissions": [
-                453
+                413
             ],
             "__typename": [
                 1
@@ -11096,7 +10093,7 @@ export default {
                 3
             ],
             "fieldPermissions": [
-                456
+                416
             ],
             "__typename": [
                 1
@@ -11127,10 +10124,10 @@ export default {
                 3
             ],
             "predicates": [
-                458
+                418
             ],
             "predicateGroups": [
-                459
+                419
             ],
             "__typename": [
                 1
@@ -11190,7 +10187,7 @@ export default {
         },
         "CreateOneFieldMetadataInput": {
             "field": [
-                461
+                421
             ],
             "__typename": [
                 1
@@ -11263,7 +10260,7 @@ export default {
                 3
             ],
             "update": [
-                463
+                423
             ],
             "__typename": [
                 1
@@ -11355,7 +10352,7 @@ export default {
                 3
             ],
             "update": [
-                467
+                427
             ],
             "__typename": [
                 1
@@ -11399,7 +10396,7 @@ export default {
                 3
             ],
             "update": [
-                471
+                431
             ],
             "__typename": [
                 1
@@ -11418,7 +10415,7 @@ export default {
                 3
             ],
             "update": [
-                471
+                431
             ],
             "__typename": [
                 1
@@ -11429,7 +10426,7 @@ export default {
                 3
             ],
             "update": [
-                474
+                434
             ],
             "__typename": [
                 1
@@ -11437,16 +10434,16 @@ export default {
         },
         "UpdateMessageChannelInputUpdates": {
             "visibility": [
-                346
+                306
             ],
             "isContactAutoCreationEnabled": [
                 6
             ],
             "contactAutoCreationPolicy": [
-                348
+                308
             ],
             "messageFolderImportPolicy": [
-                349
+                309
             ],
             "isSyncEnabled": [
                 6
@@ -11466,7 +10463,7 @@ export default {
                 3
             ],
             "update": [
-                476
+                436
             ],
             "__typename": [
                 1
@@ -11474,13 +10471,13 @@ export default {
         },
         "UpdateCalendarChannelInputUpdates": {
             "visibility": [
-                343
+                303
             ],
             "isContactAutoCreationEnabled": [
                 6
             ],
             "contactAutoCreationPolicy": [
-                344
+                304
             ],
             "isSyncEnabled": [
                 6
@@ -11514,7 +10511,7 @@ export default {
                 3
             ],
             "update": [
-                479
+                439
             ],
             "__typename": [
                 1
@@ -11619,7 +10616,7 @@ export default {
                 1
             ],
             "update": [
-                485
+                445
             ],
             "__typename": [
                 1
@@ -11667,7 +10664,7 @@ export default {
                 1
             ],
             "update": [
-                488
+                448
             ],
             "__typename": [
                 1
@@ -11833,7 +10830,7 @@ export default {
                 3
             ],
             "status": [
-                173
+                163
             ],
             "__typename": [
                 1
@@ -11862,7 +10859,7 @@ export default {
                 1
             ],
             "files": [
-                497
+                457
             ],
             "__typename": [
                 1
@@ -11881,13 +10878,13 @@ export default {
         },
         "EmailAccountConnectionParameters": {
             "IMAP": [
-                499
+                459
             ],
             "SMTP": [
-                499
+                459
             ],
             "CALDAV": [
-                499
+                459
             ],
             "__typename": [
                 1
@@ -11924,10 +10921,9 @@ export default {
                 1
             ]
         },
-        "AiModelRole": {},
         "CreateOneAppTokenInput": {
             "appToken": [
-                503
+                462
             ],
             "__typename": [
                 1
@@ -11943,7 +10939,7 @@ export default {
         },
         "WorkspaceMigrationInput": {
             "actions": [
-                505
+                464
             ],
             "__typename": [
                 1
@@ -11951,10 +10947,10 @@ export default {
         },
         "WorkspaceMigrationDeleteActionInput": {
             "type": [
-                506
+                465
             ],
             "metadataName": [
-                356
+                316
             ],
             "universalIdentifier": [
                 1
@@ -11976,16 +10972,16 @@ export default {
                 }
             ],
             "logicFunctionLogs": [
-                261,
+                221,
                 {
                     "input": [
-                        509,
+                        468,
                         "LogicFunctionLogsInput!"
                     ]
                 }
             ],
             "onAgentChatEvent": [
-                335,
+                295,
                 {
                     "threadId": [
                         3,

--- a/packages/twenty-front/.oxlintrc.json
+++ b/packages/twenty-front/.oxlintrc.json
@@ -9,6 +9,7 @@
     "node_modules",
     "src/generated",
     "src/generated-metadata",
+    "src/generated-admin",
     "src/locales/generated",
     "src/testing/mock-data",
     "**/__mocks__/**",

--- a/packages/twenty-front/.prettierignore
+++ b/packages/twenty-front/.prettierignore
@@ -1,4 +1,5 @@
 src/generated
 src/generated-metadata
+src/generated-admin
 src/locales/generated
 src/testing/mock-data/generated

--- a/packages/twenty-front/codegen-admin.cjs
+++ b/packages/twenty-front/codegen-admin.cjs
@@ -1,5 +1,3 @@
-process.env.NODE_TLS_REJECT_UNAUTHORIZED = '0';
-
 module.exports = {
   schema:
     (process.env.REACT_APP_SERVER_BASE_URL ?? 'http://localhost:3000') +

--- a/packages/twenty-front/codegen-admin.cjs
+++ b/packages/twenty-front/codegen-admin.cjs
@@ -1,0 +1,29 @@
+process.env.NODE_TLS_REJECT_UNAUTHORIZED = '0';
+
+module.exports = {
+  schema:
+    (process.env.REACT_APP_SERVER_BASE_URL ?? 'http://localhost:3000') +
+    '/admin-panel',
+  documents: [
+    './src/modules/settings/admin-panel/**/graphql/**/*.{ts,tsx}',
+    './src/modules/settings/application-registrations/graphql/fragments/*.{ts,tsx}',
+
+    '!./src/**/*.test.{ts,tsx}',
+    '!./src/**/*.stories.{ts,tsx}',
+    '!./src/**/__mocks__/*.ts',
+  ],
+  overwrite: true,
+  generates: {
+    './src/generated-admin/graphql.ts': {
+      plugins: ['typescript', 'typescript-operations', 'typed-document-node'],
+      config: {
+        skipTypename: false,
+        scalars: {
+          DateTime: 'string',
+          UUID: 'string',
+        },
+        namingConvention: { enumValues: 'keep' },
+      },
+    },
+  },
+};

--- a/packages/twenty-front/codegen-metadata.cjs
+++ b/packages/twenty-front/codegen-metadata.cjs
@@ -16,6 +16,7 @@ module.exports = {
     './src/modules/workspace-invitation/graphql/**/*.{ts,tsx}',
 
     './src/modules/settings/**/graphql/**/*.{ts,tsx}',
+    '!./src/modules/settings/admin-panel/**/graphql/**/*.{ts,tsx}',
     './src/modules/logic-functions/graphql/**/*.{ts,tsx}',
 
     './src/modules/databases/graphql/**/*.{ts,tsx}',

--- a/packages/twenty-front/project.json
+++ b/packages/twenty-front/project.json
@@ -275,6 +275,9 @@
         },
         "metadata": {
           "config": "codegen-metadata.cjs"
+        },
+        "admin": {
+          "config": "codegen-admin.cjs"
         }
       }
     },

--- a/packages/twenty-front/src/generated-admin/graphql.ts
+++ b/packages/twenty-front/src/generated-admin/graphql.ts
@@ -1,0 +1,983 @@
+import { TypedDocumentNode as DocumentNode } from '@graphql-typed-document-node/core';
+export type Maybe<T> = T | null;
+export type InputMaybe<T> = Maybe<T>;
+export type Exact<T extends { [key: string]: unknown }> = { [K in keyof T]: T[K] };
+export type MakeOptional<T, K extends keyof T> = Omit<T, K> & { [SubKey in K]?: Maybe<T[SubKey]> };
+export type MakeMaybe<T, K extends keyof T> = Omit<T, K> & { [SubKey in K]: Maybe<T[SubKey]> };
+/** All built-in and custom scalars, mapped to their actual values */
+export type Scalars = {
+  ID: string;
+  String: string;
+  Boolean: boolean;
+  Int: number;
+  Float: number;
+  DateTime: string;
+  JSON: any;
+  UUID: string;
+};
+
+export type AdminAiModelConfig = {
+  __typename?: 'AdminAiModelConfig';
+  contextWindowTokens?: Maybe<Scalars['Float']>;
+  dataResidency?: Maybe<Scalars['String']>;
+  inputCostPerMillionTokens?: Maybe<Scalars['Float']>;
+  isAdminEnabled: Scalars['Boolean'];
+  isAvailable: Scalars['Boolean'];
+  isDeprecated?: Maybe<Scalars['Boolean']>;
+  isRecommended?: Maybe<Scalars['Boolean']>;
+  label: Scalars['String'];
+  maxOutputTokens?: Maybe<Scalars['Float']>;
+  modelFamily?: Maybe<ModelFamily>;
+  modelFamilyLabel?: Maybe<Scalars['String']>;
+  modelId: Scalars['String'];
+  name?: Maybe<Scalars['String']>;
+  outputCostPerMillionTokens?: Maybe<Scalars['Float']>;
+  providerLabel?: Maybe<Scalars['String']>;
+  providerName?: Maybe<Scalars['String']>;
+  sdkPackage?: Maybe<Scalars['String']>;
+};
+
+export type AdminAiModels = {
+  __typename?: 'AdminAiModels';
+  defaultFastModelId?: Maybe<Scalars['String']>;
+  defaultSmartModelId?: Maybe<Scalars['String']>;
+  models: Array<AdminAiModelConfig>;
+};
+
+export type AdminChatMessage = {
+  __typename?: 'AdminChatMessage';
+  createdAt: Scalars['DateTime'];
+  id: Scalars['UUID'];
+  parts: Array<AdminChatMessagePart>;
+  role: AgentMessageRole;
+};
+
+export type AdminChatMessagePart = {
+  __typename?: 'AdminChatMessagePart';
+  textContent?: Maybe<Scalars['String']>;
+  toolName?: Maybe<Scalars['String']>;
+  type: Scalars['String'];
+};
+
+export type AdminChatThreadMessages = {
+  __typename?: 'AdminChatThreadMessages';
+  messages: Array<AdminChatMessage>;
+  thread: AdminWorkspaceChatThread;
+};
+
+export type AdminPanelHealthServiceData = {
+  __typename?: 'AdminPanelHealthServiceData';
+  description: Scalars['String'];
+  details?: Maybe<Scalars['String']>;
+  errorMessage?: Maybe<Scalars['String']>;
+  id: HealthIndicatorId;
+  label: Scalars['String'];
+  queues?: Maybe<Array<AdminPanelWorkerQueueHealth>>;
+  status: AdminPanelHealthServiceStatus;
+};
+
+export enum AdminPanelHealthServiceStatus {
+  OPERATIONAL = 'OPERATIONAL',
+  OUTAGE = 'OUTAGE'
+}
+
+export type AdminPanelRecentUser = {
+  __typename?: 'AdminPanelRecentUser';
+  createdAt: Scalars['DateTime'];
+  email: Scalars['String'];
+  firstName?: Maybe<Scalars['String']>;
+  id: Scalars['UUID'];
+  lastName?: Maybe<Scalars['String']>;
+  workspaceId?: Maybe<Scalars['UUID']>;
+  workspaceName?: Maybe<Scalars['String']>;
+};
+
+export type AdminPanelTopWorkspace = {
+  __typename?: 'AdminPanelTopWorkspace';
+  id: Scalars['UUID'];
+  name: Scalars['String'];
+  subdomain: Scalars['String'];
+  totalUsers: Scalars['Int'];
+};
+
+export type AdminPanelWorkerQueueHealth = {
+  __typename?: 'AdminPanelWorkerQueueHealth';
+  id: Scalars['String'];
+  queueName: Scalars['String'];
+  status: AdminPanelHealthServiceStatus;
+};
+
+export type AdminWorkspaceChatThread = {
+  __typename?: 'AdminWorkspaceChatThread';
+  conversationSize: Scalars['Int'];
+  createdAt: Scalars['DateTime'];
+  id: Scalars['UUID'];
+  title?: Maybe<Scalars['String']>;
+  totalInputTokens: Scalars['Int'];
+  totalOutputTokens: Scalars['Int'];
+  updatedAt: Scalars['DateTime'];
+};
+
+/** Role of a message in a chat thread */
+export enum AgentMessageRole {
+  ASSISTANT = 'ASSISTANT',
+  SYSTEM = 'SYSTEM',
+  USER = 'USER'
+}
+
+export enum AiModelRole {
+  FAST = 'FAST',
+  SMART = 'SMART'
+}
+
+export type ApplicationRegistration = {
+  __typename?: 'ApplicationRegistration';
+  createdAt: Scalars['DateTime'];
+  id: Scalars['UUID'];
+  isFeatured: Scalars['Boolean'];
+  isListed: Scalars['Boolean'];
+  latestAvailableVersion?: Maybe<Scalars['String']>;
+  logoUrl?: Maybe<Scalars['String']>;
+  name: Scalars['String'];
+  oAuthClientId: Scalars['String'];
+  oAuthRedirectUris: Array<Scalars['String']>;
+  oAuthScopes: Array<Scalars['String']>;
+  ownerWorkspaceId?: Maybe<Scalars['UUID']>;
+  sourcePackage?: Maybe<Scalars['String']>;
+  sourceType: ApplicationRegistrationSourceType;
+  universalIdentifier: Scalars['String'];
+  updatedAt: Scalars['DateTime'];
+};
+
+export enum ApplicationRegistrationSourceType {
+  LOCAL = 'LOCAL',
+  NPM = 'NPM',
+  OAUTH_ONLY = 'OAUTH_ONLY',
+  TARBALL = 'TARBALL'
+}
+
+export enum ConfigSource {
+  DATABASE = 'DATABASE',
+  DEFAULT = 'DEFAULT',
+  ENVIRONMENT = 'ENVIRONMENT'
+}
+
+export type ConfigVariable = {
+  __typename?: 'ConfigVariable';
+  description: Scalars['String'];
+  isEnvOnly: Scalars['Boolean'];
+  isSensitive: Scalars['Boolean'];
+  name: Scalars['String'];
+  options?: Maybe<Scalars['JSON']>;
+  source: ConfigSource;
+  type: ConfigVariableType;
+  value?: Maybe<Scalars['JSON']>;
+};
+
+export enum ConfigVariableType {
+  ARRAY = 'ARRAY',
+  BOOLEAN = 'BOOLEAN',
+  ENUM = 'ENUM',
+  JSON = 'JSON',
+  NUMBER = 'NUMBER',
+  STRING = 'STRING'
+}
+
+export type ConfigVariables = {
+  __typename?: 'ConfigVariables';
+  groups: Array<ConfigVariablesGroupData>;
+};
+
+export enum ConfigVariablesGroup {
+  ADVANCED_SETTINGS = 'ADVANCED_SETTINGS',
+  ANALYTICS_CONFIG = 'ANALYTICS_CONFIG',
+  AWS_SES_SETTINGS = 'AWS_SES_SETTINGS',
+  BILLING_CONFIG = 'BILLING_CONFIG',
+  CAPTCHA_CONFIG = 'CAPTCHA_CONFIG',
+  CLOUDFLARE_CONFIG = 'CLOUDFLARE_CONFIG',
+  CODE_INTERPRETER_CONFIG = 'CODE_INTERPRETER_CONFIG',
+  EMAIL_SETTINGS = 'EMAIL_SETTINGS',
+  GOOGLE_AUTH = 'GOOGLE_AUTH',
+  LLM = 'LLM',
+  LOGGING = 'LOGGING',
+  LOGIC_FUNCTION_CONFIG = 'LOGIC_FUNCTION_CONFIG',
+  MICROSOFT_AUTH = 'MICROSOFT_AUTH',
+  RATE_LIMITING = 'RATE_LIMITING',
+  SERVER_CONFIG = 'SERVER_CONFIG',
+  SSL = 'SSL',
+  STORAGE_CONFIG = 'STORAGE_CONFIG',
+  SUPPORT_CHAT_CONFIG = 'SUPPORT_CHAT_CONFIG',
+  TOKENS_DURATION = 'TOKENS_DURATION'
+}
+
+export type ConfigVariablesGroupData = {
+  __typename?: 'ConfigVariablesGroupData';
+  description: Scalars['String'];
+  isHiddenOnLoad: Scalars['Boolean'];
+  name: ConfigVariablesGroup;
+  variables: Array<ConfigVariable>;
+};
+
+export type DeleteJobsResponse = {
+  __typename?: 'DeleteJobsResponse';
+  deletedCount: Scalars['Int'];
+  results: Array<JobOperationResult>;
+};
+
+export type FeatureFlag = {
+  __typename?: 'FeatureFlag';
+  key: FeatureFlagKey;
+  value: Scalars['Boolean'];
+};
+
+export enum FeatureFlagKey {
+  IS_AI_ENABLED = 'IS_AI_ENABLED',
+  IS_COMMAND_MENU_ITEM_ENABLED = 'IS_COMMAND_MENU_ITEM_ENABLED',
+  IS_CONNECTED_ACCOUNT_MIGRATED = 'IS_CONNECTED_ACCOUNT_MIGRATED',
+  IS_DATASOURCE_MIGRATED = 'IS_DATASOURCE_MIGRATED',
+  IS_EMAILING_DOMAIN_ENABLED = 'IS_EMAILING_DOMAIN_ENABLED',
+  IS_JSON_FILTER_ENABLED = 'IS_JSON_FILTER_ENABLED',
+  IS_JUNCTION_RELATIONS_ENABLED = 'IS_JUNCTION_RELATIONS_ENABLED',
+  IS_MARKETPLACE_SETTING_TAB_VISIBLE = 'IS_MARKETPLACE_SETTING_TAB_VISIBLE',
+  IS_PUBLIC_DOMAIN_ENABLED = 'IS_PUBLIC_DOMAIN_ENABLED',
+  IS_RECORD_PAGE_LAYOUT_EDITING_ENABLED = 'IS_RECORD_PAGE_LAYOUT_EDITING_ENABLED',
+  IS_RECORD_PAGE_LAYOUT_GLOBAL_EDITION_ENABLED = 'IS_RECORD_PAGE_LAYOUT_GLOBAL_EDITION_ENABLED',
+  IS_RICH_TEXT_V1_MIGRATED = 'IS_RICH_TEXT_V1_MIGRATED',
+  IS_UNIQUE_INDEXES_ENABLED = 'IS_UNIQUE_INDEXES_ENABLED'
+}
+
+export enum HealthIndicatorId {
+  app = 'app',
+  connectedAccount = 'connectedAccount',
+  database = 'database',
+  redis = 'redis',
+  worker = 'worker'
+}
+
+export type JobOperationResult = {
+  __typename?: 'JobOperationResult';
+  error?: Maybe<Scalars['String']>;
+  jobId: Scalars['String'];
+  success: Scalars['Boolean'];
+};
+
+/** Job state in the queue */
+export enum JobState {
+  ACTIVE = 'ACTIVE',
+  COMPLETED = 'COMPLETED',
+  DELAYED = 'DELAYED',
+  FAILED = 'FAILED',
+  PRIORITIZED = 'PRIORITIZED',
+  WAITING = 'WAITING',
+  WAITING_CHILDREN = 'WAITING_CHILDREN'
+}
+
+export type MaintenanceMode = {
+  __typename?: 'MaintenanceMode';
+  endAt: Scalars['DateTime'];
+  link?: Maybe<Scalars['String']>;
+  startAt: Scalars['DateTime'];
+};
+
+export enum ModelFamily {
+  CLAUDE = 'CLAUDE',
+  GEMINI = 'GEMINI',
+  GPT = 'GPT',
+  GROK = 'GROK',
+  MISTRAL = 'MISTRAL'
+}
+
+export type ModelsDevModelSuggestion = {
+  __typename?: 'ModelsDevModelSuggestion';
+  cacheCreationCostPerMillionTokens?: Maybe<Scalars['Float']>;
+  cachedInputCostPerMillionTokens?: Maybe<Scalars['Float']>;
+  contextWindowTokens: Scalars['Float'];
+  inputCostPerMillionTokens: Scalars['Float'];
+  maxOutputTokens: Scalars['Float'];
+  modalities: Array<Scalars['String']>;
+  modelId: Scalars['String'];
+  name: Scalars['String'];
+  outputCostPerMillionTokens: Scalars['Float'];
+  supportsReasoning: Scalars['Boolean'];
+};
+
+export type ModelsDevProviderSuggestion = {
+  __typename?: 'ModelsDevProviderSuggestion';
+  id: Scalars['String'];
+  modelCount: Scalars['Float'];
+  npm: Scalars['String'];
+};
+
+export type Mutation = {
+  __typename?: 'Mutation';
+  addAiProvider: Scalars['Boolean'];
+  addModelToProvider: Scalars['Boolean'];
+  clearMaintenanceMode: Scalars['Boolean'];
+  createDatabaseConfigVariable: Scalars['Boolean'];
+  deleteDatabaseConfigVariable: Scalars['Boolean'];
+  deleteJobs: DeleteJobsResponse;
+  removeAiProvider: Scalars['Boolean'];
+  removeModelFromProvider: Scalars['Boolean'];
+  retryJobs: RetryJobsResponse;
+  setAdminAiModelEnabled: Scalars['Boolean'];
+  setAdminAiModelRecommended: Scalars['Boolean'];
+  setAdminAiModelsEnabled: Scalars['Boolean'];
+  setAdminAiModelsRecommended: Scalars['Boolean'];
+  setAdminDefaultAiModel: Scalars['Boolean'];
+  setMaintenanceMode: Scalars['Boolean'];
+  updateDatabaseConfigVariable: Scalars['Boolean'];
+  updateWorkspaceFeatureFlag: Scalars['Boolean'];
+};
+
+
+export type MutationAddAiProviderArgs = {
+  providerConfig: Scalars['JSON'];
+  providerName: Scalars['String'];
+};
+
+
+export type MutationAddModelToProviderArgs = {
+  modelConfig: Scalars['JSON'];
+  providerName: Scalars['String'];
+};
+
+
+export type MutationCreateDatabaseConfigVariableArgs = {
+  key: Scalars['String'];
+  value: Scalars['JSON'];
+};
+
+
+export type MutationDeleteDatabaseConfigVariableArgs = {
+  key: Scalars['String'];
+};
+
+
+export type MutationDeleteJobsArgs = {
+  jobIds: Array<Scalars['String']>;
+  queueName: Scalars['String'];
+};
+
+
+export type MutationRemoveAiProviderArgs = {
+  providerName: Scalars['String'];
+};
+
+
+export type MutationRemoveModelFromProviderArgs = {
+  modelName: Scalars['String'];
+  providerName: Scalars['String'];
+};
+
+
+export type MutationRetryJobsArgs = {
+  jobIds: Array<Scalars['String']>;
+  queueName: Scalars['String'];
+};
+
+
+export type MutationSetAdminAiModelEnabledArgs = {
+  enabled: Scalars['Boolean'];
+  modelId: Scalars['String'];
+};
+
+
+export type MutationSetAdminAiModelRecommendedArgs = {
+  modelId: Scalars['String'];
+  recommended: Scalars['Boolean'];
+};
+
+
+export type MutationSetAdminAiModelsEnabledArgs = {
+  enabled: Scalars['Boolean'];
+  modelIds: Array<Scalars['String']>;
+};
+
+
+export type MutationSetAdminAiModelsRecommendedArgs = {
+  modelIds: Array<Scalars['String']>;
+  recommended: Scalars['Boolean'];
+};
+
+
+export type MutationSetAdminDefaultAiModelArgs = {
+  modelId: Scalars['String'];
+  role: AiModelRole;
+};
+
+
+export type MutationSetMaintenanceModeArgs = {
+  endAt: Scalars['DateTime'];
+  link?: InputMaybe<Scalars['String']>;
+  startAt: Scalars['DateTime'];
+};
+
+
+export type MutationUpdateDatabaseConfigVariableArgs = {
+  key: Scalars['String'];
+  value: Scalars['JSON'];
+};
+
+
+export type MutationUpdateWorkspaceFeatureFlagArgs = {
+  featureFlag: Scalars['String'];
+  value: Scalars['Boolean'];
+  workspaceId: Scalars['UUID'];
+};
+
+export type Query = {
+  __typename?: 'Query';
+  adminPanelRecentUsers: Array<AdminPanelRecentUser>;
+  adminPanelTopWorkspaces: Array<AdminPanelTopWorkspace>;
+  findAllApplicationRegistrations: Array<ApplicationRegistration>;
+  findOneAdminApplicationRegistration: ApplicationRegistration;
+  getAdminAiModels: AdminAiModels;
+  getAdminAiUsageByWorkspace: Array<UsageBreakdownItem>;
+  getAdminChatThreadMessages: AdminChatThreadMessages;
+  getAdminWorkspaceChatThreads: Array<AdminWorkspaceChatThread>;
+  getAiProviders: Scalars['JSON'];
+  getConfigVariablesGrouped: ConfigVariables;
+  getDatabaseConfigVariable: ConfigVariable;
+  getIndicatorHealthStatus: AdminPanelHealthServiceData;
+  getMaintenanceMode?: Maybe<MaintenanceMode>;
+  getModelsDevProviders: Array<ModelsDevProviderSuggestion>;
+  getModelsDevSuggestions: Array<ModelsDevModelSuggestion>;
+  getQueueJobs: QueueJobsResponse;
+  getQueueMetrics: QueueMetricsData;
+  getSystemHealthStatus: SystemHealth;
+  userLookupAdminPanel: UserLookup;
+  versionInfo: VersionInfo;
+  workspaceLookupAdminPanel: UserLookup;
+};
+
+
+export type QueryAdminPanelRecentUsersArgs = {
+  searchTerm?: InputMaybe<Scalars['String']>;
+};
+
+
+export type QueryAdminPanelTopWorkspacesArgs = {
+  searchTerm?: InputMaybe<Scalars['String']>;
+};
+
+
+export type QueryFindOneAdminApplicationRegistrationArgs = {
+  id: Scalars['String'];
+};
+
+
+export type QueryGetAdminAiUsageByWorkspaceArgs = {
+  periodEnd?: InputMaybe<Scalars['DateTime']>;
+  periodStart?: InputMaybe<Scalars['DateTime']>;
+};
+
+
+export type QueryGetAdminChatThreadMessagesArgs = {
+  threadId: Scalars['UUID'];
+};
+
+
+export type QueryGetAdminWorkspaceChatThreadsArgs = {
+  workspaceId: Scalars['UUID'];
+};
+
+
+export type QueryGetDatabaseConfigVariableArgs = {
+  key: Scalars['String'];
+};
+
+
+export type QueryGetIndicatorHealthStatusArgs = {
+  indicatorId: HealthIndicatorId;
+};
+
+
+export type QueryGetModelsDevSuggestionsArgs = {
+  providerType: Scalars['String'];
+};
+
+
+export type QueryGetQueueJobsArgs = {
+  limit?: InputMaybe<Scalars['Int']>;
+  offset?: InputMaybe<Scalars['Int']>;
+  queueName: Scalars['String'];
+  state: JobState;
+};
+
+
+export type QueryGetQueueMetricsArgs = {
+  queueName: Scalars['String'];
+  timeRange?: InputMaybe<QueueMetricsTimeRange>;
+};
+
+
+export type QueryUserLookupAdminPanelArgs = {
+  userIdentifier: Scalars['String'];
+};
+
+
+export type QueryWorkspaceLookupAdminPanelArgs = {
+  workspaceId: Scalars['UUID'];
+};
+
+export type QueueJob = {
+  __typename?: 'QueueJob';
+  attemptsMade: Scalars['Float'];
+  data?: Maybe<Scalars['JSON']>;
+  failedReason?: Maybe<Scalars['String']>;
+  finishedOn?: Maybe<Scalars['Float']>;
+  id: Scalars['String'];
+  logs?: Maybe<Array<Scalars['String']>>;
+  name: Scalars['String'];
+  processedOn?: Maybe<Scalars['Float']>;
+  returnValue?: Maybe<Scalars['JSON']>;
+  stackTrace?: Maybe<Array<Scalars['String']>>;
+  state: JobState;
+  timestamp?: Maybe<Scalars['Float']>;
+};
+
+export type QueueJobsResponse = {
+  __typename?: 'QueueJobsResponse';
+  count: Scalars['Float'];
+  hasMore: Scalars['Boolean'];
+  jobs: Array<QueueJob>;
+  retentionConfig: QueueRetentionConfig;
+  totalCount: Scalars['Float'];
+};
+
+export type QueueMetricsData = {
+  __typename?: 'QueueMetricsData';
+  data: Array<QueueMetricsSeries>;
+  details?: Maybe<WorkerQueueMetrics>;
+  queueName: Scalars['String'];
+  timeRange: QueueMetricsTimeRange;
+  workers: Scalars['Float'];
+};
+
+export type QueueMetricsDataPoint = {
+  __typename?: 'QueueMetricsDataPoint';
+  x: Scalars['Float'];
+  y: Scalars['Float'];
+};
+
+export type QueueMetricsSeries = {
+  __typename?: 'QueueMetricsSeries';
+  data: Array<QueueMetricsDataPoint>;
+  id: Scalars['String'];
+};
+
+export enum QueueMetricsTimeRange {
+  FourHours = 'FourHours',
+  OneDay = 'OneDay',
+  OneHour = 'OneHour',
+  SevenDays = 'SevenDays',
+  TwelveHours = 'TwelveHours'
+}
+
+export type QueueRetentionConfig = {
+  __typename?: 'QueueRetentionConfig';
+  completedMaxAge: Scalars['Float'];
+  completedMaxCount: Scalars['Float'];
+  failedMaxAge: Scalars['Float'];
+  failedMaxCount: Scalars['Float'];
+};
+
+export type RetryJobsResponse = {
+  __typename?: 'RetryJobsResponse';
+  results: Array<JobOperationResult>;
+  retriedCount: Scalars['Int'];
+};
+
+export type SystemHealth = {
+  __typename?: 'SystemHealth';
+  services: Array<SystemHealthService>;
+};
+
+export type SystemHealthService = {
+  __typename?: 'SystemHealthService';
+  id: HealthIndicatorId;
+  label: Scalars['String'];
+  status: AdminPanelHealthServiceStatus;
+};
+
+export type UsageBreakdownItem = {
+  __typename?: 'UsageBreakdownItem';
+  creditsUsed: Scalars['Float'];
+  key: Scalars['String'];
+  label?: Maybe<Scalars['String']>;
+};
+
+export type UserInfo = {
+  __typename?: 'UserInfo';
+  createdAt: Scalars['DateTime'];
+  email: Scalars['String'];
+  firstName?: Maybe<Scalars['String']>;
+  id: Scalars['UUID'];
+  lastName?: Maybe<Scalars['String']>;
+};
+
+export type UserLookup = {
+  __typename?: 'UserLookup';
+  user: UserInfo;
+  workspaces: Array<WorkspaceInfo>;
+};
+
+export type VersionInfo = {
+  __typename?: 'VersionInfo';
+  currentVersion?: Maybe<Scalars['String']>;
+  latestVersion: Scalars['String'];
+};
+
+export type WorkerQueueMetrics = {
+  __typename?: 'WorkerQueueMetrics';
+  active: Scalars['Float'];
+  completed: Scalars['Float'];
+  completedData?: Maybe<Array<Scalars['Float']>>;
+  delayed: Scalars['Float'];
+  failed: Scalars['Float'];
+  failedData?: Maybe<Array<Scalars['Float']>>;
+  failureRate: Scalars['Float'];
+  waiting: Scalars['Float'];
+};
+
+export enum WorkspaceActivationStatus {
+  ACTIVE = 'ACTIVE',
+  INACTIVE = 'INACTIVE',
+  ONGOING_CREATION = 'ONGOING_CREATION',
+  PENDING_CREATION = 'PENDING_CREATION',
+  SUSPENDED = 'SUSPENDED'
+}
+
+export type WorkspaceInfo = {
+  __typename?: 'WorkspaceInfo';
+  activationStatus: WorkspaceActivationStatus;
+  allowImpersonation: Scalars['Boolean'];
+  createdAt: Scalars['DateTime'];
+  featureFlags: Array<FeatureFlag>;
+  id: Scalars['UUID'];
+  logo?: Maybe<Scalars['String']>;
+  name: Scalars['String'];
+  totalUsers: Scalars['Float'];
+  users: Array<UserInfo>;
+  workspaceUrls: WorkspaceUrls;
+};
+
+export type WorkspaceUrls = {
+  __typename?: 'WorkspaceUrls';
+  customUrl?: Maybe<Scalars['String']>;
+  subdomainUrl: Scalars['String'];
+};
+
+export type AddAiProviderMutationVariables = Exact<{
+  providerName: Scalars['String'];
+  providerConfig: Scalars['JSON'];
+}>;
+
+
+export type AddAiProviderMutation = { __typename?: 'Mutation', addAiProvider: boolean };
+
+export type AddModelToProviderMutationVariables = Exact<{
+  providerName: Scalars['String'];
+  modelConfig: Scalars['JSON'];
+}>;
+
+
+export type AddModelToProviderMutation = { __typename?: 'Mutation', addModelToProvider: boolean };
+
+export type RemoveAiProviderMutationVariables = Exact<{
+  providerName: Scalars['String'];
+}>;
+
+
+export type RemoveAiProviderMutation = { __typename?: 'Mutation', removeAiProvider: boolean };
+
+export type RemoveModelFromProviderMutationVariables = Exact<{
+  providerName: Scalars['String'];
+  modelName: Scalars['String'];
+}>;
+
+
+export type RemoveModelFromProviderMutation = { __typename?: 'Mutation', removeModelFromProvider: boolean };
+
+export type SetAdminAiModelEnabledMutationVariables = Exact<{
+  modelId: Scalars['String'];
+  enabled: Scalars['Boolean'];
+}>;
+
+
+export type SetAdminAiModelEnabledMutation = { __typename?: 'Mutation', setAdminAiModelEnabled: boolean };
+
+export type SetAdminAiModelRecommendedMutationVariables = Exact<{
+  modelId: Scalars['String'];
+  recommended: Scalars['Boolean'];
+}>;
+
+
+export type SetAdminAiModelRecommendedMutation = { __typename?: 'Mutation', setAdminAiModelRecommended: boolean };
+
+export type SetAdminAiModelsEnabledMutationVariables = Exact<{
+  modelIds: Array<Scalars['String']> | Scalars['String'];
+  enabled: Scalars['Boolean'];
+}>;
+
+
+export type SetAdminAiModelsEnabledMutation = { __typename?: 'Mutation', setAdminAiModelsEnabled: boolean };
+
+export type SetAdminAiModelsRecommendedMutationVariables = Exact<{
+  modelIds: Array<Scalars['String']> | Scalars['String'];
+  recommended: Scalars['Boolean'];
+}>;
+
+
+export type SetAdminAiModelsRecommendedMutation = { __typename?: 'Mutation', setAdminAiModelsRecommended: boolean };
+
+export type SetAdminDefaultAiModelMutationVariables = Exact<{
+  role: AiModelRole;
+  modelId: Scalars['String'];
+}>;
+
+
+export type SetAdminDefaultAiModelMutation = { __typename?: 'Mutation', setAdminDefaultAiModel: boolean };
+
+export type GetAdminAiModelsQueryVariables = Exact<{ [key: string]: never; }>;
+
+
+export type GetAdminAiModelsQuery = { __typename?: 'Query', getAdminAiModels: { __typename?: 'AdminAiModels', defaultSmartModelId?: string | null, defaultFastModelId?: string | null, models: Array<{ __typename?: 'AdminAiModelConfig', modelId: string, label: string, modelFamily?: ModelFamily | null, sdkPackage?: string | null, isAvailable: boolean, isAdminEnabled: boolean, isDeprecated?: boolean | null, isRecommended?: boolean | null, contextWindowTokens?: number | null, maxOutputTokens?: number | null, inputCostPerMillionTokens?: number | null, outputCostPerMillionTokens?: number | null, providerName?: string | null, providerLabel?: string | null, name?: string | null, dataResidency?: string | null }> } };
+
+export type GetAdminAiUsageByWorkspaceQueryVariables = Exact<{
+  periodStart?: InputMaybe<Scalars['DateTime']>;
+  periodEnd?: InputMaybe<Scalars['DateTime']>;
+}>;
+
+
+export type GetAdminAiUsageByWorkspaceQuery = { __typename?: 'Query', getAdminAiUsageByWorkspace: Array<{ __typename?: 'UsageBreakdownItem', key: string, label?: string | null, creditsUsed: number }> };
+
+export type GetAiProvidersQueryVariables = Exact<{ [key: string]: never; }>;
+
+
+export type GetAiProvidersQuery = { __typename?: 'Query', getAiProviders: any };
+
+export type GetModelsDevProvidersQueryVariables = Exact<{ [key: string]: never; }>;
+
+
+export type GetModelsDevProvidersQuery = { __typename?: 'Query', getModelsDevProviders: Array<{ __typename?: 'ModelsDevProviderSuggestion', id: string, modelCount: number, npm: string }> };
+
+export type GetModelsDevSuggestionsQueryVariables = Exact<{
+  providerType: Scalars['String'];
+}>;
+
+
+export type GetModelsDevSuggestionsQuery = { __typename?: 'Query', getModelsDevSuggestions: Array<{ __typename?: 'ModelsDevModelSuggestion', modelId: string, name: string, inputCostPerMillionTokens: number, outputCostPerMillionTokens: number, cachedInputCostPerMillionTokens?: number | null, cacheCreationCostPerMillionTokens?: number | null, contextWindowTokens: number, maxOutputTokens: number, modalities: Array<string>, supportsReasoning: boolean }> };
+
+export type FindAllApplicationRegistrationsQueryVariables = Exact<{ [key: string]: never; }>;
+
+
+export type FindAllApplicationRegistrationsQuery = { __typename?: 'Query', findAllApplicationRegistrations: Array<{ __typename?: 'ApplicationRegistration', id: string, universalIdentifier: string, name: string, oAuthClientId: string, oAuthRedirectUris: Array<string>, oAuthScopes: Array<string>, sourceType: ApplicationRegistrationSourceType, sourcePackage?: string | null, latestAvailableVersion?: string | null, isListed: boolean, isFeatured: boolean, ownerWorkspaceId?: string | null, createdAt: string, updatedAt: string }> };
+
+export type CreateDatabaseConfigVariableMutationVariables = Exact<{
+  key: Scalars['String'];
+  value: Scalars['JSON'];
+}>;
+
+
+export type CreateDatabaseConfigVariableMutation = { __typename?: 'Mutation', createDatabaseConfigVariable: boolean };
+
+export type DeleteDatabaseConfigVariableMutationVariables = Exact<{
+  key: Scalars['String'];
+}>;
+
+
+export type DeleteDatabaseConfigVariableMutation = { __typename?: 'Mutation', deleteDatabaseConfigVariable: boolean };
+
+export type UpdateDatabaseConfigVariableMutationVariables = Exact<{
+  key: Scalars['String'];
+  value: Scalars['JSON'];
+}>;
+
+
+export type UpdateDatabaseConfigVariableMutation = { __typename?: 'Mutation', updateDatabaseConfigVariable: boolean };
+
+export type GetConfigVariablesGroupedQueryVariables = Exact<{ [key: string]: never; }>;
+
+
+export type GetConfigVariablesGroupedQuery = { __typename?: 'Query', getConfigVariablesGrouped: { __typename?: 'ConfigVariables', groups: Array<{ __typename?: 'ConfigVariablesGroupData', name: ConfigVariablesGroup, description: string, isHiddenOnLoad: boolean, variables: Array<{ __typename?: 'ConfigVariable', name: string, description: string, value?: any | null, isSensitive: boolean, isEnvOnly: boolean, type: ConfigVariableType, options?: any | null, source: ConfigSource }> }> } };
+
+export type GetDatabaseConfigVariableQueryVariables = Exact<{
+  key: Scalars['String'];
+}>;
+
+
+export type GetDatabaseConfigVariableQuery = { __typename?: 'Query', getDatabaseConfigVariable: { __typename?: 'ConfigVariable', name: string, description: string, value?: any | null, isSensitive: boolean, isEnvOnly: boolean, type: ConfigVariableType, options?: any | null, source: ConfigSource } };
+
+export type UserInfoFragmentFragment = { __typename?: 'UserInfo', id: string, email: string, firstName?: string | null, lastName?: string | null, createdAt: string };
+
+export type UpdateWorkspaceFeatureFlagMutationVariables = Exact<{
+  workspaceId: Scalars['UUID'];
+  featureFlag: Scalars['String'];
+  value: Scalars['Boolean'];
+}>;
+
+
+export type UpdateWorkspaceFeatureFlagMutation = { __typename?: 'Mutation', updateWorkspaceFeatureFlag: boolean };
+
+export type AdminPanelRecentUsersQueryVariables = Exact<{
+  searchTerm?: InputMaybe<Scalars['String']>;
+}>;
+
+
+export type AdminPanelRecentUsersQuery = { __typename?: 'Query', adminPanelRecentUsers: Array<{ __typename?: 'AdminPanelRecentUser', id: string, email: string, firstName?: string | null, lastName?: string | null, createdAt: string, workspaceName?: string | null, workspaceId?: string | null }> };
+
+export type AdminPanelTopWorkspacesQueryVariables = Exact<{
+  searchTerm?: InputMaybe<Scalars['String']>;
+}>;
+
+
+export type AdminPanelTopWorkspacesQuery = { __typename?: 'Query', adminPanelTopWorkspaces: Array<{ __typename?: 'AdminPanelTopWorkspace', id: string, name: string, totalUsers: number, subdomain: string }> };
+
+export type FindOneAdminApplicationRegistrationQueryVariables = Exact<{
+  id: Scalars['String'];
+}>;
+
+
+export type FindOneAdminApplicationRegistrationQuery = { __typename?: 'Query', findOneAdminApplicationRegistration: { __typename?: 'ApplicationRegistration', id: string, universalIdentifier: string, name: string, oAuthClientId: string, oAuthRedirectUris: Array<string>, oAuthScopes: Array<string>, sourceType: ApplicationRegistrationSourceType, sourcePackage?: string | null, latestAvailableVersion?: string | null, isListed: boolean, isFeatured: boolean, ownerWorkspaceId?: string | null, createdAt: string, updatedAt: string } };
+
+export type GetAdminChatThreadMessagesQueryVariables = Exact<{
+  threadId: Scalars['UUID'];
+}>;
+
+
+export type GetAdminChatThreadMessagesQuery = { __typename?: 'Query', getAdminChatThreadMessages: { __typename?: 'AdminChatThreadMessages', thread: { __typename?: 'AdminWorkspaceChatThread', id: string, title?: string | null, totalInputTokens: number, totalOutputTokens: number, conversationSize: number, createdAt: string, updatedAt: string }, messages: Array<{ __typename?: 'AdminChatMessage', id: string, role: AgentMessageRole, createdAt: string, parts: Array<{ __typename?: 'AdminChatMessagePart', type: string, textContent?: string | null, toolName?: string | null }> }> } };
+
+export type GetAdminWorkspaceChatThreadsQueryVariables = Exact<{
+  workspaceId: Scalars['UUID'];
+}>;
+
+
+export type GetAdminWorkspaceChatThreadsQuery = { __typename?: 'Query', getAdminWorkspaceChatThreads: Array<{ __typename?: 'AdminWorkspaceChatThread', id: string, title?: string | null, totalInputTokens: number, totalOutputTokens: number, conversationSize: number, createdAt: string, updatedAt: string }> };
+
+export type GetVersionInfoQueryVariables = Exact<{ [key: string]: never; }>;
+
+
+export type GetVersionInfoQuery = { __typename?: 'Query', versionInfo: { __typename?: 'VersionInfo', currentVersion?: string | null, latestVersion: string } };
+
+export type UserLookupAdminPanelQueryVariables = Exact<{
+  userIdentifier: Scalars['String'];
+}>;
+
+
+export type UserLookupAdminPanelQuery = { __typename?: 'Query', userLookupAdminPanel: { __typename?: 'UserLookup', user: { __typename?: 'UserInfo', id: string, email: string, firstName?: string | null, lastName?: string | null, createdAt: string }, workspaces: Array<{ __typename?: 'WorkspaceInfo', id: string, name: string, logo?: string | null, totalUsers: number, activationStatus: WorkspaceActivationStatus, createdAt: string, allowImpersonation: boolean, workspaceUrls: { __typename?: 'WorkspaceUrls', customUrl?: string | null, subdomainUrl: string }, users: Array<{ __typename?: 'UserInfo', id: string, email: string, firstName?: string | null, lastName?: string | null }>, featureFlags: Array<{ __typename?: 'FeatureFlag', key: FeatureFlagKey, value: boolean }> }> } };
+
+export type WorkspaceLookupAdminPanelQueryVariables = Exact<{
+  workspaceId: Scalars['UUID'];
+}>;
+
+
+export type WorkspaceLookupAdminPanelQuery = { __typename?: 'Query', workspaceLookupAdminPanel: { __typename?: 'UserLookup', user: { __typename?: 'UserInfo', id: string, email: string, firstName?: string | null, lastName?: string | null, createdAt: string }, workspaces: Array<{ __typename?: 'WorkspaceInfo', id: string, name: string, allowImpersonation: boolean, logo?: string | null, totalUsers: number, activationStatus: WorkspaceActivationStatus, createdAt: string, workspaceUrls: { __typename?: 'WorkspaceUrls', customUrl?: string | null, subdomainUrl: string }, users: Array<{ __typename?: 'UserInfo', id: string, email: string, firstName?: string | null, lastName?: string | null }>, featureFlags: Array<{ __typename?: 'FeatureFlag', key: FeatureFlagKey, value: boolean }> }> } };
+
+export type DeleteJobsMutationVariables = Exact<{
+  queueName: Scalars['String'];
+  jobIds: Array<Scalars['String']> | Scalars['String'];
+}>;
+
+
+export type DeleteJobsMutation = { __typename?: 'Mutation', deleteJobs: { __typename?: 'DeleteJobsResponse', deletedCount: number, results: Array<{ __typename?: 'JobOperationResult', jobId: string, success: boolean, error?: string | null }> } };
+
+export type RetryJobsMutationVariables = Exact<{
+  queueName: Scalars['String'];
+  jobIds: Array<Scalars['String']> | Scalars['String'];
+}>;
+
+
+export type RetryJobsMutation = { __typename?: 'Mutation', retryJobs: { __typename?: 'RetryJobsResponse', retriedCount: number, results: Array<{ __typename?: 'JobOperationResult', jobId: string, success: boolean, error?: string | null }> } };
+
+export type GetIndicatorHealthStatusQueryVariables = Exact<{
+  indicatorId: HealthIndicatorId;
+}>;
+
+
+export type GetIndicatorHealthStatusQuery = { __typename?: 'Query', getIndicatorHealthStatus: { __typename?: 'AdminPanelHealthServiceData', id: HealthIndicatorId, label: string, description: string, status: AdminPanelHealthServiceStatus, errorMessage?: string | null, details?: string | null, queues?: Array<{ __typename?: 'AdminPanelWorkerQueueHealth', id: string, queueName: string, status: AdminPanelHealthServiceStatus }> | null } };
+
+export type GetQueueJobsQueryVariables = Exact<{
+  queueName: Scalars['String'];
+  state: JobState;
+  limit?: InputMaybe<Scalars['Int']>;
+  offset?: InputMaybe<Scalars['Int']>;
+}>;
+
+
+export type GetQueueJobsQuery = { __typename?: 'Query', getQueueJobs: { __typename?: 'QueueJobsResponse', count: number, totalCount: number, hasMore: boolean, jobs: Array<{ __typename?: 'QueueJob', id: string, name: string, data?: any | null, state: JobState, timestamp?: number | null, failedReason?: string | null, processedOn?: number | null, finishedOn?: number | null, attemptsMade: number, returnValue?: any | null, logs?: Array<string> | null, stackTrace?: Array<string> | null }>, retentionConfig: { __typename?: 'QueueRetentionConfig', completedMaxAge: number, completedMaxCount: number, failedMaxAge: number, failedMaxCount: number } } };
+
+export type GetQueueMetricsQueryVariables = Exact<{
+  queueName: Scalars['String'];
+  timeRange?: InputMaybe<QueueMetricsTimeRange>;
+}>;
+
+
+export type GetQueueMetricsQuery = { __typename?: 'Query', getQueueMetrics: { __typename?: 'QueueMetricsData', queueName: string, timeRange: QueueMetricsTimeRange, workers: number, details?: { __typename?: 'WorkerQueueMetrics', failed: number, completed: number, waiting: number, active: number, delayed: number, failureRate: number } | null, data: Array<{ __typename?: 'QueueMetricsSeries', id: string, data: Array<{ __typename?: 'QueueMetricsDataPoint', x: number, y: number }> }> } };
+
+export type GetSystemHealthStatusQueryVariables = Exact<{ [key: string]: never; }>;
+
+
+export type GetSystemHealthStatusQuery = { __typename?: 'Query', getSystemHealthStatus: { __typename?: 'SystemHealth', services: Array<{ __typename?: 'SystemHealthService', id: HealthIndicatorId, label: string, status: AdminPanelHealthServiceStatus }> } };
+
+export type ClearMaintenanceModeMutationVariables = Exact<{ [key: string]: never; }>;
+
+
+export type ClearMaintenanceModeMutation = { __typename?: 'Mutation', clearMaintenanceMode: boolean };
+
+export type SetMaintenanceModeMutationVariables = Exact<{
+  startAt: Scalars['DateTime'];
+  endAt: Scalars['DateTime'];
+  link?: InputMaybe<Scalars['String']>;
+}>;
+
+
+export type SetMaintenanceModeMutation = { __typename?: 'Mutation', setMaintenanceMode: boolean };
+
+export type GetMaintenanceModeQueryVariables = Exact<{ [key: string]: never; }>;
+
+
+export type GetMaintenanceModeQuery = { __typename?: 'Query', getMaintenanceMode?: { __typename?: 'MaintenanceMode', startAt: string, endAt: string, link?: string | null } | null };
+
+export type ApplicationRegistrationFragmentFragment = { __typename?: 'ApplicationRegistration', id: string, universalIdentifier: string, name: string, oAuthClientId: string, oAuthRedirectUris: Array<string>, oAuthScopes: Array<string>, sourceType: ApplicationRegistrationSourceType, sourcePackage?: string | null, latestAvailableVersion?: string | null, isListed: boolean, isFeatured: boolean, ownerWorkspaceId?: string | null, createdAt: string, updatedAt: string };
+
+export const UserInfoFragmentFragmentDoc = {"kind":"Document","definitions":[{"kind":"FragmentDefinition","name":{"kind":"Name","value":"UserInfoFragment"},"typeCondition":{"kind":"NamedType","name":{"kind":"Name","value":"UserInfo"}},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"id"}},{"kind":"Field","name":{"kind":"Name","value":"email"}},{"kind":"Field","name":{"kind":"Name","value":"firstName"}},{"kind":"Field","name":{"kind":"Name","value":"lastName"}},{"kind":"Field","name":{"kind":"Name","value":"createdAt"}}]}}]} as unknown as DocumentNode<UserInfoFragmentFragment, unknown>;
+export const ApplicationRegistrationFragmentFragmentDoc = {"kind":"Document","definitions":[{"kind":"FragmentDefinition","name":{"kind":"Name","value":"ApplicationRegistrationFragment"},"typeCondition":{"kind":"NamedType","name":{"kind":"Name","value":"ApplicationRegistration"}},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"id"}},{"kind":"Field","name":{"kind":"Name","value":"universalIdentifier"}},{"kind":"Field","name":{"kind":"Name","value":"name"}},{"kind":"Field","name":{"kind":"Name","value":"oAuthClientId"}},{"kind":"Field","name":{"kind":"Name","value":"oAuthRedirectUris"}},{"kind":"Field","name":{"kind":"Name","value":"oAuthScopes"}},{"kind":"Field","name":{"kind":"Name","value":"sourceType"}},{"kind":"Field","name":{"kind":"Name","value":"sourcePackage"}},{"kind":"Field","name":{"kind":"Name","value":"latestAvailableVersion"}},{"kind":"Field","name":{"kind":"Name","value":"isListed"}},{"kind":"Field","name":{"kind":"Name","value":"isFeatured"}},{"kind":"Field","name":{"kind":"Name","value":"ownerWorkspaceId"}},{"kind":"Field","name":{"kind":"Name","value":"createdAt"}},{"kind":"Field","name":{"kind":"Name","value":"updatedAt"}}]}}]} as unknown as DocumentNode<ApplicationRegistrationFragmentFragment, unknown>;
+export const AddAiProviderDocument = {"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"mutation","name":{"kind":"Name","value":"AddAiProvider"},"variableDefinitions":[{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"providerName"}},"type":{"kind":"NonNullType","type":{"kind":"NamedType","name":{"kind":"Name","value":"String"}}}},{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"providerConfig"}},"type":{"kind":"NonNullType","type":{"kind":"NamedType","name":{"kind":"Name","value":"JSON"}}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"addAiProvider"},"arguments":[{"kind":"Argument","name":{"kind":"Name","value":"providerName"},"value":{"kind":"Variable","name":{"kind":"Name","value":"providerName"}}},{"kind":"Argument","name":{"kind":"Name","value":"providerConfig"},"value":{"kind":"Variable","name":{"kind":"Name","value":"providerConfig"}}}]}]}}]} as unknown as DocumentNode<AddAiProviderMutation, AddAiProviderMutationVariables>;
+export const AddModelToProviderDocument = {"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"mutation","name":{"kind":"Name","value":"AddModelToProvider"},"variableDefinitions":[{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"providerName"}},"type":{"kind":"NonNullType","type":{"kind":"NamedType","name":{"kind":"Name","value":"String"}}}},{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"modelConfig"}},"type":{"kind":"NonNullType","type":{"kind":"NamedType","name":{"kind":"Name","value":"JSON"}}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"addModelToProvider"},"arguments":[{"kind":"Argument","name":{"kind":"Name","value":"providerName"},"value":{"kind":"Variable","name":{"kind":"Name","value":"providerName"}}},{"kind":"Argument","name":{"kind":"Name","value":"modelConfig"},"value":{"kind":"Variable","name":{"kind":"Name","value":"modelConfig"}}}]}]}}]} as unknown as DocumentNode<AddModelToProviderMutation, AddModelToProviderMutationVariables>;
+export const RemoveAiProviderDocument = {"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"mutation","name":{"kind":"Name","value":"RemoveAiProvider"},"variableDefinitions":[{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"providerName"}},"type":{"kind":"NonNullType","type":{"kind":"NamedType","name":{"kind":"Name","value":"String"}}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"removeAiProvider"},"arguments":[{"kind":"Argument","name":{"kind":"Name","value":"providerName"},"value":{"kind":"Variable","name":{"kind":"Name","value":"providerName"}}}]}]}}]} as unknown as DocumentNode<RemoveAiProviderMutation, RemoveAiProviderMutationVariables>;
+export const RemoveModelFromProviderDocument = {"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"mutation","name":{"kind":"Name","value":"RemoveModelFromProvider"},"variableDefinitions":[{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"providerName"}},"type":{"kind":"NonNullType","type":{"kind":"NamedType","name":{"kind":"Name","value":"String"}}}},{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"modelName"}},"type":{"kind":"NonNullType","type":{"kind":"NamedType","name":{"kind":"Name","value":"String"}}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"removeModelFromProvider"},"arguments":[{"kind":"Argument","name":{"kind":"Name","value":"providerName"},"value":{"kind":"Variable","name":{"kind":"Name","value":"providerName"}}},{"kind":"Argument","name":{"kind":"Name","value":"modelName"},"value":{"kind":"Variable","name":{"kind":"Name","value":"modelName"}}}]}]}}]} as unknown as DocumentNode<RemoveModelFromProviderMutation, RemoveModelFromProviderMutationVariables>;
+export const SetAdminAiModelEnabledDocument = {"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"mutation","name":{"kind":"Name","value":"SetAdminAiModelEnabled"},"variableDefinitions":[{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"modelId"}},"type":{"kind":"NonNullType","type":{"kind":"NamedType","name":{"kind":"Name","value":"String"}}}},{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"enabled"}},"type":{"kind":"NonNullType","type":{"kind":"NamedType","name":{"kind":"Name","value":"Boolean"}}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"setAdminAiModelEnabled"},"arguments":[{"kind":"Argument","name":{"kind":"Name","value":"modelId"},"value":{"kind":"Variable","name":{"kind":"Name","value":"modelId"}}},{"kind":"Argument","name":{"kind":"Name","value":"enabled"},"value":{"kind":"Variable","name":{"kind":"Name","value":"enabled"}}}]}]}}]} as unknown as DocumentNode<SetAdminAiModelEnabledMutation, SetAdminAiModelEnabledMutationVariables>;
+export const SetAdminAiModelRecommendedDocument = {"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"mutation","name":{"kind":"Name","value":"SetAdminAiModelRecommended"},"variableDefinitions":[{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"modelId"}},"type":{"kind":"NonNullType","type":{"kind":"NamedType","name":{"kind":"Name","value":"String"}}}},{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"recommended"}},"type":{"kind":"NonNullType","type":{"kind":"NamedType","name":{"kind":"Name","value":"Boolean"}}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"setAdminAiModelRecommended"},"arguments":[{"kind":"Argument","name":{"kind":"Name","value":"modelId"},"value":{"kind":"Variable","name":{"kind":"Name","value":"modelId"}}},{"kind":"Argument","name":{"kind":"Name","value":"recommended"},"value":{"kind":"Variable","name":{"kind":"Name","value":"recommended"}}}]}]}}]} as unknown as DocumentNode<SetAdminAiModelRecommendedMutation, SetAdminAiModelRecommendedMutationVariables>;
+export const SetAdminAiModelsEnabledDocument = {"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"mutation","name":{"kind":"Name","value":"SetAdminAiModelsEnabled"},"variableDefinitions":[{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"modelIds"}},"type":{"kind":"NonNullType","type":{"kind":"ListType","type":{"kind":"NonNullType","type":{"kind":"NamedType","name":{"kind":"Name","value":"String"}}}}}},{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"enabled"}},"type":{"kind":"NonNullType","type":{"kind":"NamedType","name":{"kind":"Name","value":"Boolean"}}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"setAdminAiModelsEnabled"},"arguments":[{"kind":"Argument","name":{"kind":"Name","value":"modelIds"},"value":{"kind":"Variable","name":{"kind":"Name","value":"modelIds"}}},{"kind":"Argument","name":{"kind":"Name","value":"enabled"},"value":{"kind":"Variable","name":{"kind":"Name","value":"enabled"}}}]}]}}]} as unknown as DocumentNode<SetAdminAiModelsEnabledMutation, SetAdminAiModelsEnabledMutationVariables>;
+export const SetAdminAiModelsRecommendedDocument = {"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"mutation","name":{"kind":"Name","value":"SetAdminAiModelsRecommended"},"variableDefinitions":[{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"modelIds"}},"type":{"kind":"NonNullType","type":{"kind":"ListType","type":{"kind":"NonNullType","type":{"kind":"NamedType","name":{"kind":"Name","value":"String"}}}}}},{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"recommended"}},"type":{"kind":"NonNullType","type":{"kind":"NamedType","name":{"kind":"Name","value":"Boolean"}}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"setAdminAiModelsRecommended"},"arguments":[{"kind":"Argument","name":{"kind":"Name","value":"modelIds"},"value":{"kind":"Variable","name":{"kind":"Name","value":"modelIds"}}},{"kind":"Argument","name":{"kind":"Name","value":"recommended"},"value":{"kind":"Variable","name":{"kind":"Name","value":"recommended"}}}]}]}}]} as unknown as DocumentNode<SetAdminAiModelsRecommendedMutation, SetAdminAiModelsRecommendedMutationVariables>;
+export const SetAdminDefaultAiModelDocument = {"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"mutation","name":{"kind":"Name","value":"SetAdminDefaultAiModel"},"variableDefinitions":[{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"role"}},"type":{"kind":"NonNullType","type":{"kind":"NamedType","name":{"kind":"Name","value":"AiModelRole"}}}},{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"modelId"}},"type":{"kind":"NonNullType","type":{"kind":"NamedType","name":{"kind":"Name","value":"String"}}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"setAdminDefaultAiModel"},"arguments":[{"kind":"Argument","name":{"kind":"Name","value":"role"},"value":{"kind":"Variable","name":{"kind":"Name","value":"role"}}},{"kind":"Argument","name":{"kind":"Name","value":"modelId"},"value":{"kind":"Variable","name":{"kind":"Name","value":"modelId"}}}]}]}}]} as unknown as DocumentNode<SetAdminDefaultAiModelMutation, SetAdminDefaultAiModelMutationVariables>;
+export const GetAdminAiModelsDocument = {"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"query","name":{"kind":"Name","value":"GetAdminAiModels"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"getAdminAiModels"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"defaultSmartModelId"}},{"kind":"Field","name":{"kind":"Name","value":"defaultFastModelId"}},{"kind":"Field","name":{"kind":"Name","value":"models"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"modelId"}},{"kind":"Field","name":{"kind":"Name","value":"label"}},{"kind":"Field","name":{"kind":"Name","value":"modelFamily"}},{"kind":"Field","name":{"kind":"Name","value":"sdkPackage"}},{"kind":"Field","name":{"kind":"Name","value":"isAvailable"}},{"kind":"Field","name":{"kind":"Name","value":"isAdminEnabled"}},{"kind":"Field","name":{"kind":"Name","value":"isDeprecated"}},{"kind":"Field","name":{"kind":"Name","value":"isRecommended"}},{"kind":"Field","name":{"kind":"Name","value":"contextWindowTokens"}},{"kind":"Field","name":{"kind":"Name","value":"maxOutputTokens"}},{"kind":"Field","name":{"kind":"Name","value":"inputCostPerMillionTokens"}},{"kind":"Field","name":{"kind":"Name","value":"outputCostPerMillionTokens"}},{"kind":"Field","name":{"kind":"Name","value":"providerName"}},{"kind":"Field","name":{"kind":"Name","value":"providerLabel"}},{"kind":"Field","name":{"kind":"Name","value":"name"}},{"kind":"Field","name":{"kind":"Name","value":"dataResidency"}}]}}]}}]}}]} as unknown as DocumentNode<GetAdminAiModelsQuery, GetAdminAiModelsQueryVariables>;
+export const GetAdminAiUsageByWorkspaceDocument = {"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"query","name":{"kind":"Name","value":"GetAdminAiUsageByWorkspace"},"variableDefinitions":[{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"periodStart"}},"type":{"kind":"NamedType","name":{"kind":"Name","value":"DateTime"}}},{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"periodEnd"}},"type":{"kind":"NamedType","name":{"kind":"Name","value":"DateTime"}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"getAdminAiUsageByWorkspace"},"arguments":[{"kind":"Argument","name":{"kind":"Name","value":"periodStart"},"value":{"kind":"Variable","name":{"kind":"Name","value":"periodStart"}}},{"kind":"Argument","name":{"kind":"Name","value":"periodEnd"},"value":{"kind":"Variable","name":{"kind":"Name","value":"periodEnd"}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"key"}},{"kind":"Field","name":{"kind":"Name","value":"label"}},{"kind":"Field","name":{"kind":"Name","value":"creditsUsed"}}]}}]}}]} as unknown as DocumentNode<GetAdminAiUsageByWorkspaceQuery, GetAdminAiUsageByWorkspaceQueryVariables>;
+export const GetAiProvidersDocument = {"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"query","name":{"kind":"Name","value":"GetAiProviders"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"getAiProviders"}}]}}]} as unknown as DocumentNode<GetAiProvidersQuery, GetAiProvidersQueryVariables>;
+export const GetModelsDevProvidersDocument = {"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"query","name":{"kind":"Name","value":"GetModelsDevProviders"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"getModelsDevProviders"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"id"}},{"kind":"Field","name":{"kind":"Name","value":"modelCount"}},{"kind":"Field","name":{"kind":"Name","value":"npm"}}]}}]}}]} as unknown as DocumentNode<GetModelsDevProvidersQuery, GetModelsDevProvidersQueryVariables>;
+export const GetModelsDevSuggestionsDocument = {"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"query","name":{"kind":"Name","value":"GetModelsDevSuggestions"},"variableDefinitions":[{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"providerType"}},"type":{"kind":"NonNullType","type":{"kind":"NamedType","name":{"kind":"Name","value":"String"}}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"getModelsDevSuggestions"},"arguments":[{"kind":"Argument","name":{"kind":"Name","value":"providerType"},"value":{"kind":"Variable","name":{"kind":"Name","value":"providerType"}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"modelId"}},{"kind":"Field","name":{"kind":"Name","value":"name"}},{"kind":"Field","name":{"kind":"Name","value":"inputCostPerMillionTokens"}},{"kind":"Field","name":{"kind":"Name","value":"outputCostPerMillionTokens"}},{"kind":"Field","name":{"kind":"Name","value":"cachedInputCostPerMillionTokens"}},{"kind":"Field","name":{"kind":"Name","value":"cacheCreationCostPerMillionTokens"}},{"kind":"Field","name":{"kind":"Name","value":"contextWindowTokens"}},{"kind":"Field","name":{"kind":"Name","value":"maxOutputTokens"}},{"kind":"Field","name":{"kind":"Name","value":"modalities"}},{"kind":"Field","name":{"kind":"Name","value":"supportsReasoning"}}]}}]}}]} as unknown as DocumentNode<GetModelsDevSuggestionsQuery, GetModelsDevSuggestionsQueryVariables>;
+export const FindAllApplicationRegistrationsDocument = {"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"query","name":{"kind":"Name","value":"FindAllApplicationRegistrations"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"findAllApplicationRegistrations"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"FragmentSpread","name":{"kind":"Name","value":"ApplicationRegistrationFragment"}}]}}]}},{"kind":"FragmentDefinition","name":{"kind":"Name","value":"ApplicationRegistrationFragment"},"typeCondition":{"kind":"NamedType","name":{"kind":"Name","value":"ApplicationRegistration"}},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"id"}},{"kind":"Field","name":{"kind":"Name","value":"universalIdentifier"}},{"kind":"Field","name":{"kind":"Name","value":"name"}},{"kind":"Field","name":{"kind":"Name","value":"oAuthClientId"}},{"kind":"Field","name":{"kind":"Name","value":"oAuthRedirectUris"}},{"kind":"Field","name":{"kind":"Name","value":"oAuthScopes"}},{"kind":"Field","name":{"kind":"Name","value":"sourceType"}},{"kind":"Field","name":{"kind":"Name","value":"sourcePackage"}},{"kind":"Field","name":{"kind":"Name","value":"latestAvailableVersion"}},{"kind":"Field","name":{"kind":"Name","value":"isListed"}},{"kind":"Field","name":{"kind":"Name","value":"isFeatured"}},{"kind":"Field","name":{"kind":"Name","value":"ownerWorkspaceId"}},{"kind":"Field","name":{"kind":"Name","value":"createdAt"}},{"kind":"Field","name":{"kind":"Name","value":"updatedAt"}}]}}]} as unknown as DocumentNode<FindAllApplicationRegistrationsQuery, FindAllApplicationRegistrationsQueryVariables>;
+export const CreateDatabaseConfigVariableDocument = {"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"mutation","name":{"kind":"Name","value":"CreateDatabaseConfigVariable"},"variableDefinitions":[{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"key"}},"type":{"kind":"NonNullType","type":{"kind":"NamedType","name":{"kind":"Name","value":"String"}}}},{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"value"}},"type":{"kind":"NonNullType","type":{"kind":"NamedType","name":{"kind":"Name","value":"JSON"}}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"createDatabaseConfigVariable"},"arguments":[{"kind":"Argument","name":{"kind":"Name","value":"key"},"value":{"kind":"Variable","name":{"kind":"Name","value":"key"}}},{"kind":"Argument","name":{"kind":"Name","value":"value"},"value":{"kind":"Variable","name":{"kind":"Name","value":"value"}}}]}]}}]} as unknown as DocumentNode<CreateDatabaseConfigVariableMutation, CreateDatabaseConfigVariableMutationVariables>;
+export const DeleteDatabaseConfigVariableDocument = {"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"mutation","name":{"kind":"Name","value":"DeleteDatabaseConfigVariable"},"variableDefinitions":[{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"key"}},"type":{"kind":"NonNullType","type":{"kind":"NamedType","name":{"kind":"Name","value":"String"}}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"deleteDatabaseConfigVariable"},"arguments":[{"kind":"Argument","name":{"kind":"Name","value":"key"},"value":{"kind":"Variable","name":{"kind":"Name","value":"key"}}}]}]}}]} as unknown as DocumentNode<DeleteDatabaseConfigVariableMutation, DeleteDatabaseConfigVariableMutationVariables>;
+export const UpdateDatabaseConfigVariableDocument = {"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"mutation","name":{"kind":"Name","value":"UpdateDatabaseConfigVariable"},"variableDefinitions":[{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"key"}},"type":{"kind":"NonNullType","type":{"kind":"NamedType","name":{"kind":"Name","value":"String"}}}},{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"value"}},"type":{"kind":"NonNullType","type":{"kind":"NamedType","name":{"kind":"Name","value":"JSON"}}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"updateDatabaseConfigVariable"},"arguments":[{"kind":"Argument","name":{"kind":"Name","value":"key"},"value":{"kind":"Variable","name":{"kind":"Name","value":"key"}}},{"kind":"Argument","name":{"kind":"Name","value":"value"},"value":{"kind":"Variable","name":{"kind":"Name","value":"value"}}}]}]}}]} as unknown as DocumentNode<UpdateDatabaseConfigVariableMutation, UpdateDatabaseConfigVariableMutationVariables>;
+export const GetConfigVariablesGroupedDocument = {"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"query","name":{"kind":"Name","value":"GetConfigVariablesGrouped"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"getConfigVariablesGrouped"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"groups"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"name"}},{"kind":"Field","name":{"kind":"Name","value":"description"}},{"kind":"Field","name":{"kind":"Name","value":"isHiddenOnLoad"}},{"kind":"Field","name":{"kind":"Name","value":"variables"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"name"}},{"kind":"Field","name":{"kind":"Name","value":"description"}},{"kind":"Field","name":{"kind":"Name","value":"value"}},{"kind":"Field","name":{"kind":"Name","value":"isSensitive"}},{"kind":"Field","name":{"kind":"Name","value":"isEnvOnly"}},{"kind":"Field","name":{"kind":"Name","value":"type"}},{"kind":"Field","name":{"kind":"Name","value":"options"}},{"kind":"Field","name":{"kind":"Name","value":"source"}}]}}]}}]}}]}}]} as unknown as DocumentNode<GetConfigVariablesGroupedQuery, GetConfigVariablesGroupedQueryVariables>;
+export const GetDatabaseConfigVariableDocument = {"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"query","name":{"kind":"Name","value":"GetDatabaseConfigVariable"},"variableDefinitions":[{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"key"}},"type":{"kind":"NonNullType","type":{"kind":"NamedType","name":{"kind":"Name","value":"String"}}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"getDatabaseConfigVariable"},"arguments":[{"kind":"Argument","name":{"kind":"Name","value":"key"},"value":{"kind":"Variable","name":{"kind":"Name","value":"key"}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"name"}},{"kind":"Field","name":{"kind":"Name","value":"description"}},{"kind":"Field","name":{"kind":"Name","value":"value"}},{"kind":"Field","name":{"kind":"Name","value":"isSensitive"}},{"kind":"Field","name":{"kind":"Name","value":"isEnvOnly"}},{"kind":"Field","name":{"kind":"Name","value":"type"}},{"kind":"Field","name":{"kind":"Name","value":"options"}},{"kind":"Field","name":{"kind":"Name","value":"source"}}]}}]}}]} as unknown as DocumentNode<GetDatabaseConfigVariableQuery, GetDatabaseConfigVariableQueryVariables>;
+export const UpdateWorkspaceFeatureFlagDocument = {"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"mutation","name":{"kind":"Name","value":"UpdateWorkspaceFeatureFlag"},"variableDefinitions":[{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"workspaceId"}},"type":{"kind":"NonNullType","type":{"kind":"NamedType","name":{"kind":"Name","value":"UUID"}}}},{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"featureFlag"}},"type":{"kind":"NonNullType","type":{"kind":"NamedType","name":{"kind":"Name","value":"String"}}}},{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"value"}},"type":{"kind":"NonNullType","type":{"kind":"NamedType","name":{"kind":"Name","value":"Boolean"}}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"updateWorkspaceFeatureFlag"},"arguments":[{"kind":"Argument","name":{"kind":"Name","value":"workspaceId"},"value":{"kind":"Variable","name":{"kind":"Name","value":"workspaceId"}}},{"kind":"Argument","name":{"kind":"Name","value":"featureFlag"},"value":{"kind":"Variable","name":{"kind":"Name","value":"featureFlag"}}},{"kind":"Argument","name":{"kind":"Name","value":"value"},"value":{"kind":"Variable","name":{"kind":"Name","value":"value"}}}]}]}}]} as unknown as DocumentNode<UpdateWorkspaceFeatureFlagMutation, UpdateWorkspaceFeatureFlagMutationVariables>;
+export const AdminPanelRecentUsersDocument = {"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"query","name":{"kind":"Name","value":"AdminPanelRecentUsers"},"variableDefinitions":[{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"searchTerm"}},"type":{"kind":"NamedType","name":{"kind":"Name","value":"String"}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"adminPanelRecentUsers"},"arguments":[{"kind":"Argument","name":{"kind":"Name","value":"searchTerm"},"value":{"kind":"Variable","name":{"kind":"Name","value":"searchTerm"}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"id"}},{"kind":"Field","name":{"kind":"Name","value":"email"}},{"kind":"Field","name":{"kind":"Name","value":"firstName"}},{"kind":"Field","name":{"kind":"Name","value":"lastName"}},{"kind":"Field","name":{"kind":"Name","value":"createdAt"}},{"kind":"Field","name":{"kind":"Name","value":"workspaceName"}},{"kind":"Field","name":{"kind":"Name","value":"workspaceId"}}]}}]}}]} as unknown as DocumentNode<AdminPanelRecentUsersQuery, AdminPanelRecentUsersQueryVariables>;
+export const AdminPanelTopWorkspacesDocument = {"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"query","name":{"kind":"Name","value":"AdminPanelTopWorkspaces"},"variableDefinitions":[{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"searchTerm"}},"type":{"kind":"NamedType","name":{"kind":"Name","value":"String"}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"adminPanelTopWorkspaces"},"arguments":[{"kind":"Argument","name":{"kind":"Name","value":"searchTerm"},"value":{"kind":"Variable","name":{"kind":"Name","value":"searchTerm"}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"id"}},{"kind":"Field","name":{"kind":"Name","value":"name"}},{"kind":"Field","name":{"kind":"Name","value":"totalUsers"}},{"kind":"Field","name":{"kind":"Name","value":"subdomain"}}]}}]}}]} as unknown as DocumentNode<AdminPanelTopWorkspacesQuery, AdminPanelTopWorkspacesQueryVariables>;
+export const FindOneAdminApplicationRegistrationDocument = {"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"query","name":{"kind":"Name","value":"FindOneAdminApplicationRegistration"},"variableDefinitions":[{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"id"}},"type":{"kind":"NonNullType","type":{"kind":"NamedType","name":{"kind":"Name","value":"String"}}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"findOneAdminApplicationRegistration"},"arguments":[{"kind":"Argument","name":{"kind":"Name","value":"id"},"value":{"kind":"Variable","name":{"kind":"Name","value":"id"}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"FragmentSpread","name":{"kind":"Name","value":"ApplicationRegistrationFragment"}}]}}]}},{"kind":"FragmentDefinition","name":{"kind":"Name","value":"ApplicationRegistrationFragment"},"typeCondition":{"kind":"NamedType","name":{"kind":"Name","value":"ApplicationRegistration"}},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"id"}},{"kind":"Field","name":{"kind":"Name","value":"universalIdentifier"}},{"kind":"Field","name":{"kind":"Name","value":"name"}},{"kind":"Field","name":{"kind":"Name","value":"oAuthClientId"}},{"kind":"Field","name":{"kind":"Name","value":"oAuthRedirectUris"}},{"kind":"Field","name":{"kind":"Name","value":"oAuthScopes"}},{"kind":"Field","name":{"kind":"Name","value":"sourceType"}},{"kind":"Field","name":{"kind":"Name","value":"sourcePackage"}},{"kind":"Field","name":{"kind":"Name","value":"latestAvailableVersion"}},{"kind":"Field","name":{"kind":"Name","value":"isListed"}},{"kind":"Field","name":{"kind":"Name","value":"isFeatured"}},{"kind":"Field","name":{"kind":"Name","value":"ownerWorkspaceId"}},{"kind":"Field","name":{"kind":"Name","value":"createdAt"}},{"kind":"Field","name":{"kind":"Name","value":"updatedAt"}}]}}]} as unknown as DocumentNode<FindOneAdminApplicationRegistrationQuery, FindOneAdminApplicationRegistrationQueryVariables>;
+export const GetAdminChatThreadMessagesDocument = {"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"query","name":{"kind":"Name","value":"GetAdminChatThreadMessages"},"variableDefinitions":[{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"threadId"}},"type":{"kind":"NonNullType","type":{"kind":"NamedType","name":{"kind":"Name","value":"UUID"}}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"getAdminChatThreadMessages"},"arguments":[{"kind":"Argument","name":{"kind":"Name","value":"threadId"},"value":{"kind":"Variable","name":{"kind":"Name","value":"threadId"}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"thread"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"id"}},{"kind":"Field","name":{"kind":"Name","value":"title"}},{"kind":"Field","name":{"kind":"Name","value":"totalInputTokens"}},{"kind":"Field","name":{"kind":"Name","value":"totalOutputTokens"}},{"kind":"Field","name":{"kind":"Name","value":"conversationSize"}},{"kind":"Field","name":{"kind":"Name","value":"createdAt"}},{"kind":"Field","name":{"kind":"Name","value":"updatedAt"}}]}},{"kind":"Field","name":{"kind":"Name","value":"messages"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"id"}},{"kind":"Field","name":{"kind":"Name","value":"role"}},{"kind":"Field","name":{"kind":"Name","value":"parts"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"type"}},{"kind":"Field","name":{"kind":"Name","value":"textContent"}},{"kind":"Field","name":{"kind":"Name","value":"toolName"}}]}},{"kind":"Field","name":{"kind":"Name","value":"createdAt"}}]}}]}}]}}]} as unknown as DocumentNode<GetAdminChatThreadMessagesQuery, GetAdminChatThreadMessagesQueryVariables>;
+export const GetAdminWorkspaceChatThreadsDocument = {"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"query","name":{"kind":"Name","value":"GetAdminWorkspaceChatThreads"},"variableDefinitions":[{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"workspaceId"}},"type":{"kind":"NonNullType","type":{"kind":"NamedType","name":{"kind":"Name","value":"UUID"}}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"getAdminWorkspaceChatThreads"},"arguments":[{"kind":"Argument","name":{"kind":"Name","value":"workspaceId"},"value":{"kind":"Variable","name":{"kind":"Name","value":"workspaceId"}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"id"}},{"kind":"Field","name":{"kind":"Name","value":"title"}},{"kind":"Field","name":{"kind":"Name","value":"totalInputTokens"}},{"kind":"Field","name":{"kind":"Name","value":"totalOutputTokens"}},{"kind":"Field","name":{"kind":"Name","value":"conversationSize"}},{"kind":"Field","name":{"kind":"Name","value":"createdAt"}},{"kind":"Field","name":{"kind":"Name","value":"updatedAt"}}]}}]}}]} as unknown as DocumentNode<GetAdminWorkspaceChatThreadsQuery, GetAdminWorkspaceChatThreadsQueryVariables>;
+export const GetVersionInfoDocument = {"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"query","name":{"kind":"Name","value":"GetVersionInfo"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"versionInfo"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"currentVersion"}},{"kind":"Field","name":{"kind":"Name","value":"latestVersion"}}]}}]}}]} as unknown as DocumentNode<GetVersionInfoQuery, GetVersionInfoQueryVariables>;
+export const UserLookupAdminPanelDocument = {"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"query","name":{"kind":"Name","value":"UserLookupAdminPanel"},"variableDefinitions":[{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"userIdentifier"}},"type":{"kind":"NonNullType","type":{"kind":"NamedType","name":{"kind":"Name","value":"String"}}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"userLookupAdminPanel"},"arguments":[{"kind":"Argument","name":{"kind":"Name","value":"userIdentifier"},"value":{"kind":"Variable","name":{"kind":"Name","value":"userIdentifier"}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"user"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"FragmentSpread","name":{"kind":"Name","value":"UserInfoFragment"}}]}},{"kind":"Field","name":{"kind":"Name","value":"workspaces"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"id"}},{"kind":"Field","name":{"kind":"Name","value":"name"}},{"kind":"Field","name":{"kind":"Name","value":"logo"}},{"kind":"Field","name":{"kind":"Name","value":"totalUsers"}},{"kind":"Field","name":{"kind":"Name","value":"activationStatus"}},{"kind":"Field","name":{"kind":"Name","value":"createdAt"}},{"kind":"Field","name":{"kind":"Name","value":"allowImpersonation"}},{"kind":"Field","name":{"kind":"Name","value":"workspaceUrls"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"customUrl"}},{"kind":"Field","name":{"kind":"Name","value":"subdomainUrl"}}]}},{"kind":"Field","name":{"kind":"Name","value":"users"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"id"}},{"kind":"Field","name":{"kind":"Name","value":"email"}},{"kind":"Field","name":{"kind":"Name","value":"firstName"}},{"kind":"Field","name":{"kind":"Name","value":"lastName"}}]}},{"kind":"Field","name":{"kind":"Name","value":"featureFlags"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"key"}},{"kind":"Field","name":{"kind":"Name","value":"value"}}]}}]}}]}}]}},{"kind":"FragmentDefinition","name":{"kind":"Name","value":"UserInfoFragment"},"typeCondition":{"kind":"NamedType","name":{"kind":"Name","value":"UserInfo"}},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"id"}},{"kind":"Field","name":{"kind":"Name","value":"email"}},{"kind":"Field","name":{"kind":"Name","value":"firstName"}},{"kind":"Field","name":{"kind":"Name","value":"lastName"}},{"kind":"Field","name":{"kind":"Name","value":"createdAt"}}]}}]} as unknown as DocumentNode<UserLookupAdminPanelQuery, UserLookupAdminPanelQueryVariables>;
+export const WorkspaceLookupAdminPanelDocument = {"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"query","name":{"kind":"Name","value":"WorkspaceLookupAdminPanel"},"variableDefinitions":[{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"workspaceId"}},"type":{"kind":"NonNullType","type":{"kind":"NamedType","name":{"kind":"Name","value":"UUID"}}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"workspaceLookupAdminPanel"},"arguments":[{"kind":"Argument","name":{"kind":"Name","value":"workspaceId"},"value":{"kind":"Variable","name":{"kind":"Name","value":"workspaceId"}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"user"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"FragmentSpread","name":{"kind":"Name","value":"UserInfoFragment"}}]}},{"kind":"Field","name":{"kind":"Name","value":"workspaces"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"id"}},{"kind":"Field","name":{"kind":"Name","value":"name"}},{"kind":"Field","name":{"kind":"Name","value":"allowImpersonation"}},{"kind":"Field","name":{"kind":"Name","value":"logo"}},{"kind":"Field","name":{"kind":"Name","value":"totalUsers"}},{"kind":"Field","name":{"kind":"Name","value":"activationStatus"}},{"kind":"Field","name":{"kind":"Name","value":"createdAt"}},{"kind":"Field","name":{"kind":"Name","value":"workspaceUrls"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"customUrl"}},{"kind":"Field","name":{"kind":"Name","value":"subdomainUrl"}}]}},{"kind":"Field","name":{"kind":"Name","value":"users"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"id"}},{"kind":"Field","name":{"kind":"Name","value":"email"}},{"kind":"Field","name":{"kind":"Name","value":"firstName"}},{"kind":"Field","name":{"kind":"Name","value":"lastName"}}]}},{"kind":"Field","name":{"kind":"Name","value":"featureFlags"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"key"}},{"kind":"Field","name":{"kind":"Name","value":"value"}}]}}]}}]}}]}},{"kind":"FragmentDefinition","name":{"kind":"Name","value":"UserInfoFragment"},"typeCondition":{"kind":"NamedType","name":{"kind":"Name","value":"UserInfo"}},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"id"}},{"kind":"Field","name":{"kind":"Name","value":"email"}},{"kind":"Field","name":{"kind":"Name","value":"firstName"}},{"kind":"Field","name":{"kind":"Name","value":"lastName"}},{"kind":"Field","name":{"kind":"Name","value":"createdAt"}}]}}]} as unknown as DocumentNode<WorkspaceLookupAdminPanelQuery, WorkspaceLookupAdminPanelQueryVariables>;
+export const DeleteJobsDocument = {"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"mutation","name":{"kind":"Name","value":"DeleteJobs"},"variableDefinitions":[{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"queueName"}},"type":{"kind":"NonNullType","type":{"kind":"NamedType","name":{"kind":"Name","value":"String"}}}},{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"jobIds"}},"type":{"kind":"NonNullType","type":{"kind":"ListType","type":{"kind":"NonNullType","type":{"kind":"NamedType","name":{"kind":"Name","value":"String"}}}}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"deleteJobs"},"arguments":[{"kind":"Argument","name":{"kind":"Name","value":"queueName"},"value":{"kind":"Variable","name":{"kind":"Name","value":"queueName"}}},{"kind":"Argument","name":{"kind":"Name","value":"jobIds"},"value":{"kind":"Variable","name":{"kind":"Name","value":"jobIds"}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"deletedCount"}},{"kind":"Field","name":{"kind":"Name","value":"results"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"jobId"}},{"kind":"Field","name":{"kind":"Name","value":"success"}},{"kind":"Field","name":{"kind":"Name","value":"error"}}]}}]}}]}}]} as unknown as DocumentNode<DeleteJobsMutation, DeleteJobsMutationVariables>;
+export const RetryJobsDocument = {"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"mutation","name":{"kind":"Name","value":"RetryJobs"},"variableDefinitions":[{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"queueName"}},"type":{"kind":"NonNullType","type":{"kind":"NamedType","name":{"kind":"Name","value":"String"}}}},{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"jobIds"}},"type":{"kind":"NonNullType","type":{"kind":"ListType","type":{"kind":"NonNullType","type":{"kind":"NamedType","name":{"kind":"Name","value":"String"}}}}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"retryJobs"},"arguments":[{"kind":"Argument","name":{"kind":"Name","value":"queueName"},"value":{"kind":"Variable","name":{"kind":"Name","value":"queueName"}}},{"kind":"Argument","name":{"kind":"Name","value":"jobIds"},"value":{"kind":"Variable","name":{"kind":"Name","value":"jobIds"}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"retriedCount"}},{"kind":"Field","name":{"kind":"Name","value":"results"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"jobId"}},{"kind":"Field","name":{"kind":"Name","value":"success"}},{"kind":"Field","name":{"kind":"Name","value":"error"}}]}}]}}]}}]} as unknown as DocumentNode<RetryJobsMutation, RetryJobsMutationVariables>;
+export const GetIndicatorHealthStatusDocument = {"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"query","name":{"kind":"Name","value":"GetIndicatorHealthStatus"},"variableDefinitions":[{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"indicatorId"}},"type":{"kind":"NonNullType","type":{"kind":"NamedType","name":{"kind":"Name","value":"HealthIndicatorId"}}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"getIndicatorHealthStatus"},"arguments":[{"kind":"Argument","name":{"kind":"Name","value":"indicatorId"},"value":{"kind":"Variable","name":{"kind":"Name","value":"indicatorId"}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"id"}},{"kind":"Field","name":{"kind":"Name","value":"label"}},{"kind":"Field","name":{"kind":"Name","value":"description"}},{"kind":"Field","name":{"kind":"Name","value":"status"}},{"kind":"Field","name":{"kind":"Name","value":"errorMessage"}},{"kind":"Field","name":{"kind":"Name","value":"details"}},{"kind":"Field","name":{"kind":"Name","value":"queues"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"id"}},{"kind":"Field","name":{"kind":"Name","value":"queueName"}},{"kind":"Field","name":{"kind":"Name","value":"status"}}]}}]}}]}}]} as unknown as DocumentNode<GetIndicatorHealthStatusQuery, GetIndicatorHealthStatusQueryVariables>;
+export const GetQueueJobsDocument = {"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"query","name":{"kind":"Name","value":"GetQueueJobs"},"variableDefinitions":[{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"queueName"}},"type":{"kind":"NonNullType","type":{"kind":"NamedType","name":{"kind":"Name","value":"String"}}}},{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"state"}},"type":{"kind":"NonNullType","type":{"kind":"NamedType","name":{"kind":"Name","value":"JobState"}}}},{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"limit"}},"type":{"kind":"NamedType","name":{"kind":"Name","value":"Int"}}},{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"offset"}},"type":{"kind":"NamedType","name":{"kind":"Name","value":"Int"}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"getQueueJobs"},"arguments":[{"kind":"Argument","name":{"kind":"Name","value":"queueName"},"value":{"kind":"Variable","name":{"kind":"Name","value":"queueName"}}},{"kind":"Argument","name":{"kind":"Name","value":"state"},"value":{"kind":"Variable","name":{"kind":"Name","value":"state"}}},{"kind":"Argument","name":{"kind":"Name","value":"limit"},"value":{"kind":"Variable","name":{"kind":"Name","value":"limit"}}},{"kind":"Argument","name":{"kind":"Name","value":"offset"},"value":{"kind":"Variable","name":{"kind":"Name","value":"offset"}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"jobs"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"id"}},{"kind":"Field","name":{"kind":"Name","value":"name"}},{"kind":"Field","name":{"kind":"Name","value":"data"}},{"kind":"Field","name":{"kind":"Name","value":"state"}},{"kind":"Field","name":{"kind":"Name","value":"timestamp"}},{"kind":"Field","name":{"kind":"Name","value":"failedReason"}},{"kind":"Field","name":{"kind":"Name","value":"processedOn"}},{"kind":"Field","name":{"kind":"Name","value":"finishedOn"}},{"kind":"Field","name":{"kind":"Name","value":"attemptsMade"}},{"kind":"Field","name":{"kind":"Name","value":"returnValue"}},{"kind":"Field","name":{"kind":"Name","value":"logs"}},{"kind":"Field","name":{"kind":"Name","value":"stackTrace"}}]}},{"kind":"Field","name":{"kind":"Name","value":"count"}},{"kind":"Field","name":{"kind":"Name","value":"totalCount"}},{"kind":"Field","name":{"kind":"Name","value":"hasMore"}},{"kind":"Field","name":{"kind":"Name","value":"retentionConfig"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"completedMaxAge"}},{"kind":"Field","name":{"kind":"Name","value":"completedMaxCount"}},{"kind":"Field","name":{"kind":"Name","value":"failedMaxAge"}},{"kind":"Field","name":{"kind":"Name","value":"failedMaxCount"}}]}}]}}]}}]} as unknown as DocumentNode<GetQueueJobsQuery, GetQueueJobsQueryVariables>;
+export const GetQueueMetricsDocument = {"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"query","name":{"kind":"Name","value":"GetQueueMetrics"},"variableDefinitions":[{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"queueName"}},"type":{"kind":"NonNullType","type":{"kind":"NamedType","name":{"kind":"Name","value":"String"}}}},{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"timeRange"}},"type":{"kind":"NamedType","name":{"kind":"Name","value":"QueueMetricsTimeRange"}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"getQueueMetrics"},"arguments":[{"kind":"Argument","name":{"kind":"Name","value":"queueName"},"value":{"kind":"Variable","name":{"kind":"Name","value":"queueName"}}},{"kind":"Argument","name":{"kind":"Name","value":"timeRange"},"value":{"kind":"Variable","name":{"kind":"Name","value":"timeRange"}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"queueName"}},{"kind":"Field","name":{"kind":"Name","value":"timeRange"}},{"kind":"Field","name":{"kind":"Name","value":"workers"}},{"kind":"Field","name":{"kind":"Name","value":"details"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"failed"}},{"kind":"Field","name":{"kind":"Name","value":"completed"}},{"kind":"Field","name":{"kind":"Name","value":"waiting"}},{"kind":"Field","name":{"kind":"Name","value":"active"}},{"kind":"Field","name":{"kind":"Name","value":"delayed"}},{"kind":"Field","name":{"kind":"Name","value":"failureRate"}}]}},{"kind":"Field","name":{"kind":"Name","value":"data"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"id"}},{"kind":"Field","name":{"kind":"Name","value":"data"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"x"}},{"kind":"Field","name":{"kind":"Name","value":"y"}}]}}]}}]}}]}}]} as unknown as DocumentNode<GetQueueMetricsQuery, GetQueueMetricsQueryVariables>;
+export const GetSystemHealthStatusDocument = {"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"query","name":{"kind":"Name","value":"GetSystemHealthStatus"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"getSystemHealthStatus"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"services"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"id"}},{"kind":"Field","name":{"kind":"Name","value":"label"}},{"kind":"Field","name":{"kind":"Name","value":"status"}}]}}]}}]}}]} as unknown as DocumentNode<GetSystemHealthStatusQuery, GetSystemHealthStatusQueryVariables>;
+export const ClearMaintenanceModeDocument = {"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"mutation","name":{"kind":"Name","value":"ClearMaintenanceMode"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"clearMaintenanceMode"}}]}}]} as unknown as DocumentNode<ClearMaintenanceModeMutation, ClearMaintenanceModeMutationVariables>;
+export const SetMaintenanceModeDocument = {"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"mutation","name":{"kind":"Name","value":"SetMaintenanceMode"},"variableDefinitions":[{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"startAt"}},"type":{"kind":"NonNullType","type":{"kind":"NamedType","name":{"kind":"Name","value":"DateTime"}}}},{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"endAt"}},"type":{"kind":"NonNullType","type":{"kind":"NamedType","name":{"kind":"Name","value":"DateTime"}}}},{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"link"}},"type":{"kind":"NamedType","name":{"kind":"Name","value":"String"}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"setMaintenanceMode"},"arguments":[{"kind":"Argument","name":{"kind":"Name","value":"startAt"},"value":{"kind":"Variable","name":{"kind":"Name","value":"startAt"}}},{"kind":"Argument","name":{"kind":"Name","value":"endAt"},"value":{"kind":"Variable","name":{"kind":"Name","value":"endAt"}}},{"kind":"Argument","name":{"kind":"Name","value":"link"},"value":{"kind":"Variable","name":{"kind":"Name","value":"link"}}}]}]}}]} as unknown as DocumentNode<SetMaintenanceModeMutation, SetMaintenanceModeMutationVariables>;
+export const GetMaintenanceModeDocument = {"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"query","name":{"kind":"Name","value":"GetMaintenanceMode"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"getMaintenanceMode"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"startAt"}},{"kind":"Field","name":{"kind":"Name","value":"endAt"}},{"kind":"Field","name":{"kind":"Name","value":"link"}}]}}]}}]} as unknown as DocumentNode<GetMaintenanceModeQuery, GetMaintenanceModeQueryVariables>;

--- a/packages/twenty-front/src/generated-metadata/graphql.ts
+++ b/packages/twenty-front/src/generated-metadata/graphql.ts
@@ -29,108 +29,6 @@ export type AddQuerySubscriptionInput = {
   queryId: Scalars['String'];
 };
 
-export type AdminAiModelConfig = {
-  __typename?: 'AdminAiModelConfig';
-  contextWindowTokens?: Maybe<Scalars['Float']>;
-  dataResidency?: Maybe<Scalars['String']>;
-  inputCostPerMillionTokens?: Maybe<Scalars['Float']>;
-  isAdminEnabled: Scalars['Boolean'];
-  isAvailable: Scalars['Boolean'];
-  isDeprecated?: Maybe<Scalars['Boolean']>;
-  isRecommended?: Maybe<Scalars['Boolean']>;
-  label: Scalars['String'];
-  maxOutputTokens?: Maybe<Scalars['Float']>;
-  modelFamily?: Maybe<ModelFamily>;
-  modelFamilyLabel?: Maybe<Scalars['String']>;
-  modelId: Scalars['String'];
-  name?: Maybe<Scalars['String']>;
-  outputCostPerMillionTokens?: Maybe<Scalars['Float']>;
-  providerLabel?: Maybe<Scalars['String']>;
-  providerName?: Maybe<Scalars['String']>;
-  sdkPackage?: Maybe<Scalars['String']>;
-};
-
-export type AdminAiModels = {
-  __typename?: 'AdminAiModels';
-  defaultFastModelId?: Maybe<Scalars['String']>;
-  defaultSmartModelId?: Maybe<Scalars['String']>;
-  models: Array<AdminAiModelConfig>;
-};
-
-export type AdminChatMessage = {
-  __typename?: 'AdminChatMessage';
-  createdAt: Scalars['DateTime'];
-  id: Scalars['UUID'];
-  parts: Array<AdminChatMessagePart>;
-  role: AgentMessageRole;
-};
-
-export type AdminChatMessagePart = {
-  __typename?: 'AdminChatMessagePart';
-  textContent?: Maybe<Scalars['String']>;
-  toolName?: Maybe<Scalars['String']>;
-  type: Scalars['String'];
-};
-
-export type AdminChatThreadMessages = {
-  __typename?: 'AdminChatThreadMessages';
-  messages: Array<AdminChatMessage>;
-  thread: AdminWorkspaceChatThread;
-};
-
-export type AdminPanelHealthServiceData = {
-  __typename?: 'AdminPanelHealthServiceData';
-  description: Scalars['String'];
-  details?: Maybe<Scalars['String']>;
-  errorMessage?: Maybe<Scalars['String']>;
-  id: HealthIndicatorId;
-  label: Scalars['String'];
-  queues?: Maybe<Array<AdminPanelWorkerQueueHealth>>;
-  status: AdminPanelHealthServiceStatus;
-};
-
-export enum AdminPanelHealthServiceStatus {
-  OPERATIONAL = 'OPERATIONAL',
-  OUTAGE = 'OUTAGE'
-}
-
-export type AdminPanelRecentUser = {
-  __typename?: 'AdminPanelRecentUser';
-  createdAt: Scalars['DateTime'];
-  email: Scalars['String'];
-  firstName?: Maybe<Scalars['String']>;
-  id: Scalars['UUID'];
-  lastName?: Maybe<Scalars['String']>;
-  workspaceId?: Maybe<Scalars['UUID']>;
-  workspaceName?: Maybe<Scalars['String']>;
-};
-
-export type AdminPanelTopWorkspace = {
-  __typename?: 'AdminPanelTopWorkspace';
-  id: Scalars['UUID'];
-  name: Scalars['String'];
-  subdomain: Scalars['String'];
-  totalUsers: Scalars['Int'];
-};
-
-export type AdminPanelWorkerQueueHealth = {
-  __typename?: 'AdminPanelWorkerQueueHealth';
-  id: Scalars['String'];
-  queueName: Scalars['String'];
-  status: AdminPanelHealthServiceStatus;
-};
-
-export type AdminWorkspaceChatThread = {
-  __typename?: 'AdminWorkspaceChatThread';
-  conversationSize: Scalars['Int'];
-  createdAt: Scalars['DateTime'];
-  id: Scalars['UUID'];
-  title?: Maybe<Scalars['String']>;
-  totalInputTokens: Scalars['Int'];
-  totalOutputTokens: Scalars['Int'];
-  updatedAt: Scalars['DateTime'];
-};
-
 export type Agent = {
   __typename?: 'Agent';
   applicationId?: Maybe<Scalars['UUID']>;
@@ -252,13 +150,6 @@ export type AgentMessagePart = {
   type: Scalars['String'];
 };
 
-/** Role of a message in a chat thread */
-export enum AgentMessageRole {
-  ASSISTANT = 'ASSISTANT',
-  SYSTEM = 'SYSTEM',
-  USER = 'USER'
-}
-
 export type AgentTurn = {
   __typename?: 'AgentTurn';
   agentId?: Maybe<Scalars['UUID']>;
@@ -308,11 +199,6 @@ export enum AggregateOperations {
   PERCENTAGE_EMPTY = 'PERCENTAGE_EMPTY',
   PERCENTAGE_NOT_EMPTY = 'PERCENTAGE_NOT_EMPTY',
   SUM = 'SUM'
-}
-
-export enum AiModelRole {
-  FAST = 'FAST',
-  SMART = 'SMART'
 }
 
 export type AiSystemPromptPreview = {
@@ -1020,68 +906,6 @@ export enum CommandMenuItemAvailabilityType {
 
 export type CommandMenuItemPayload = ObjectMetadataCommandMenuItemPayload | PathCommandMenuItemPayload;
 
-export enum ConfigSource {
-  DATABASE = 'DATABASE',
-  DEFAULT = 'DEFAULT',
-  ENVIRONMENT = 'ENVIRONMENT'
-}
-
-export type ConfigVariable = {
-  __typename?: 'ConfigVariable';
-  description: Scalars['String'];
-  isEnvOnly: Scalars['Boolean'];
-  isSensitive: Scalars['Boolean'];
-  name: Scalars['String'];
-  options?: Maybe<Scalars['JSON']>;
-  source: ConfigSource;
-  type: ConfigVariableType;
-  value?: Maybe<Scalars['JSON']>;
-};
-
-export enum ConfigVariableType {
-  ARRAY = 'ARRAY',
-  BOOLEAN = 'BOOLEAN',
-  ENUM = 'ENUM',
-  JSON = 'JSON',
-  NUMBER = 'NUMBER',
-  STRING = 'STRING'
-}
-
-export type ConfigVariables = {
-  __typename?: 'ConfigVariables';
-  groups: Array<ConfigVariablesGroupData>;
-};
-
-export enum ConfigVariablesGroup {
-  ADVANCED_SETTINGS = 'ADVANCED_SETTINGS',
-  ANALYTICS_CONFIG = 'ANALYTICS_CONFIG',
-  AWS_SES_SETTINGS = 'AWS_SES_SETTINGS',
-  BILLING_CONFIG = 'BILLING_CONFIG',
-  CAPTCHA_CONFIG = 'CAPTCHA_CONFIG',
-  CLOUDFLARE_CONFIG = 'CLOUDFLARE_CONFIG',
-  CODE_INTERPRETER_CONFIG = 'CODE_INTERPRETER_CONFIG',
-  EMAIL_SETTINGS = 'EMAIL_SETTINGS',
-  GOOGLE_AUTH = 'GOOGLE_AUTH',
-  LLM = 'LLM',
-  LOGGING = 'LOGGING',
-  LOGIC_FUNCTION_CONFIG = 'LOGIC_FUNCTION_CONFIG',
-  MICROSOFT_AUTH = 'MICROSOFT_AUTH',
-  RATE_LIMITING = 'RATE_LIMITING',
-  SERVER_CONFIG = 'SERVER_CONFIG',
-  SSL = 'SSL',
-  STORAGE_CONFIG = 'STORAGE_CONFIG',
-  SUPPORT_CHAT_CONFIG = 'SUPPORT_CHAT_CONFIG',
-  TOKENS_DURATION = 'TOKENS_DURATION'
-}
-
-export type ConfigVariablesGroupData = {
-  __typename?: 'ConfigVariablesGroupData';
-  description: Scalars['String'];
-  isHiddenOnLoad: Scalars['Boolean'];
-  name: ConfigVariablesGroup;
-  variables: Array<ConfigVariable>;
-};
-
 export type ConnectedAccountDto = {
   __typename?: 'ConnectedAccountDTO';
   authFailedAt?: Maybe<Scalars['DateTime']>;
@@ -1472,12 +1296,6 @@ export type DateFieldComparisonBetween = {
 
 export type DeleteApprovedAccessDomainInput = {
   id: Scalars['UUID'];
-};
-
-export type DeleteJobsResponse = {
-  __typename?: 'DeleteJobsResponse';
-  deletedCount: Scalars['Int'];
-  results: Array<JobOperationResult>;
 };
 
 export type DeleteOneFieldInput = {
@@ -2098,14 +1916,6 @@ export type GridPositionInput = {
   rowSpan: Scalars['Float'];
 };
 
-export enum HealthIndicatorId {
-  app = 'app',
-  connectedAccount = 'connectedAccount',
-  database = 'database',
-  redis = 'redis',
-  worker = 'worker'
-}
-
 export enum IdentityProviderType {
   OIDC = 'OIDC',
   SAML = 'SAML'
@@ -2243,24 +2053,6 @@ export type InvalidatePassword = {
   success: Scalars['Boolean'];
 };
 
-export type JobOperationResult = {
-  __typename?: 'JobOperationResult';
-  error?: Maybe<Scalars['String']>;
-  jobId: Scalars['String'];
-  success: Scalars['Boolean'];
-};
-
-/** Job state in the queue */
-export enum JobState {
-  ACTIVE = 'ACTIVE',
-  COMPLETED = 'COMPLETED',
-  DELAYED = 'DELAYED',
-  FAILED = 'FAILED',
-  PRIORITIZED = 'PRIORITIZED',
-  WAITING = 'WAITING',
-  WAITING_CHILDREN = 'WAITING_CHILDREN'
-}
-
 export type LineChartConfiguration = {
   __typename?: 'LineChartConfiguration';
   aggregateFieldMetadataId: Scalars['UUID'];
@@ -2390,13 +2182,6 @@ export type LogicFunctionLogsInput = {
 export type LoginToken = {
   __typename?: 'LoginToken';
   loginToken: AuthToken;
-};
-
-export type MaintenanceMode = {
-  __typename?: 'MaintenanceMode';
-  endAt: Scalars['DateTime'];
-  link?: Maybe<Scalars['String']>;
-  startAt: Scalars['DateTime'];
 };
 
 export type MarketplaceApp = {
@@ -2569,33 +2354,10 @@ export enum ModelFamily {
   MISTRAL = 'MISTRAL'
 }
 
-export type ModelsDevModelSuggestion = {
-  __typename?: 'ModelsDevModelSuggestion';
-  cacheCreationCostPerMillionTokens?: Maybe<Scalars['Float']>;
-  cachedInputCostPerMillionTokens?: Maybe<Scalars['Float']>;
-  contextWindowTokens: Scalars['Float'];
-  inputCostPerMillionTokens: Scalars['Float'];
-  maxOutputTokens: Scalars['Float'];
-  modalities: Array<Scalars['String']>;
-  modelId: Scalars['String'];
-  name: Scalars['String'];
-  outputCostPerMillionTokens: Scalars['Float'];
-  supportsReasoning: Scalars['Boolean'];
-};
-
-export type ModelsDevProviderSuggestion = {
-  __typename?: 'ModelsDevProviderSuggestion';
-  id: Scalars['String'];
-  modelCount: Scalars['Float'];
-  npm: Scalars['String'];
-};
-
 export type Mutation = {
   __typename?: 'Mutation';
   activateSkill: Skill;
   activateWorkspace: Workspace;
-  addAiProvider: Scalars['Boolean'];
-  addModelToProvider: Scalars['Boolean'];
   addQueryToEventStream: Scalars['Boolean'];
   assignRoleToAgent: Scalars['Boolean'];
   assignRoleToApiKey: Scalars['Boolean'];
@@ -2606,14 +2368,12 @@ export type Mutation = {
   checkCustomDomainValidRecords?: Maybe<DomainValidRecords>;
   checkPublicDomainValidRecords?: Maybe<DomainValidRecords>;
   checkoutSession: BillingSession;
-  clearMaintenanceMode: Scalars['Boolean'];
   createApiKey: ApiKey;
   createApplicationRegistration: CreateApplicationRegistration;
   createApplicationRegistrationVariable: ApplicationRegistrationVariable;
   createApprovedAccessDomain: ApprovedAccessDomain;
   createChatThread: AgentChatThread;
   createCommandMenuItem: CommandMenuItem;
-  createDatabaseConfigVariable: Scalars['Boolean'];
   createDevelopmentApplication: DevelopmentApplication;
   createEmailingDomain: EmailingDomain;
   createFrontComponent: FrontComponent;
@@ -2651,10 +2411,8 @@ export type Mutation = {
   deleteCommandMenuItem: CommandMenuItem;
   deleteConnectedAccount: ConnectedAccountDto;
   deleteCurrentWorkspace: Workspace;
-  deleteDatabaseConfigVariable: Scalars['Boolean'];
   deleteEmailingDomain: Scalars['Boolean'];
   deleteFrontComponent: FrontComponent;
-  deleteJobs: DeleteJobsResponse;
   deleteManyNavigationMenuItems: Array<NavigationMenuItem>;
   deleteNavigationMenuItem: NavigationMenuItem;
   deleteOneAgent: Agent;
@@ -2709,8 +2467,6 @@ export type Mutation = {
   installApplication: Scalars['Boolean'];
   installMarketplaceApp: Scalars['Boolean'];
   refreshEnterpriseValidityToken: Scalars['Boolean'];
-  removeAiProvider: Scalars['Boolean'];
-  removeModelFromProvider: Scalars['Boolean'];
   removeQueryFromEventStream: Scalars['Boolean'];
   removeRoleFromAgent: Scalars['Boolean'];
   renewApplicationToken: ApplicationTokenPair;
@@ -2720,7 +2476,6 @@ export type Mutation = {
   resetPageLayoutTabToDefault: PageLayoutTab;
   resetPageLayoutToDefault: PageLayout;
   resetPageLayoutWidgetToDefault: PageLayoutWidget;
-  retryJobs: RetryJobsResponse;
   revokeApiKey?: Maybe<ApiKey>;
   rotateApplicationRegistrationClientSecret: RotateClientSecret;
   runEvaluationInput: AgentTurn;
@@ -2729,13 +2484,7 @@ export type Mutation = {
   sendChatMessage: SendChatMessageResult;
   sendEmail: SendEmailOutput;
   sendInvitations: SendInvitations;
-  setAdminAiModelEnabled: Scalars['Boolean'];
-  setAdminAiModelRecommended: Scalars['Boolean'];
-  setAdminAiModelsEnabled: Scalars['Boolean'];
-  setAdminAiModelsRecommended: Scalars['Boolean'];
-  setAdminDefaultAiModel: Scalars['Boolean'];
   setEnterpriseKey: EnterpriseLicenseInfoDto;
-  setMaintenanceMode: Scalars['Boolean'];
   setMeteredSubscriptionPrice: BillingUpdate;
   signIn: AvailableWorkspacesAndAccessTokens;
   signUp: AvailableWorkspacesAndAccessTokens;
@@ -2757,7 +2506,6 @@ export type Mutation = {
   updateApplicationRegistrationVariable: ApplicationRegistrationVariable;
   updateCalendarChannel: CalendarChannel;
   updateCommandMenuItem: CommandMenuItem;
-  updateDatabaseConfigVariable: Scalars['Boolean'];
   updateFrontComponent: FrontComponent;
   updateLabPublicFeatureFlag: FeatureFlag;
   updateManyNavigationMenuItems: Array<NavigationMenuItem>;
@@ -2788,7 +2536,6 @@ export type Mutation = {
   updateViewSort: ViewSort;
   updateWebhook: Webhook;
   updateWorkspace: Workspace;
-  updateWorkspaceFeatureFlag: Scalars['Boolean'];
   updateWorkspaceMemberRole: WorkspaceMember;
   updateWorkspaceMemberSettings: Scalars['Boolean'];
   upgradeApplication: Scalars['Boolean'];
@@ -2821,18 +2568,6 @@ export type MutationActivateSkillArgs = {
 
 export type MutationActivateWorkspaceArgs = {
   data: ActivateWorkspaceInput;
-};
-
-
-export type MutationAddAiProviderArgs = {
-  providerConfig: Scalars['JSON'];
-  providerName: Scalars['String'];
-};
-
-
-export type MutationAddModelToProviderArgs = {
-  modelConfig: Scalars['JSON'];
-  providerName: Scalars['String'];
 };
 
 
@@ -2897,12 +2632,6 @@ export type MutationCreateApprovedAccessDomainArgs = {
 
 export type MutationCreateCommandMenuItemArgs = {
   input: CreateCommandMenuItemInput;
-};
-
-
-export type MutationCreateDatabaseConfigVariableArgs = {
-  key: Scalars['String'];
-  value: Scalars['JSON'];
 };
 
 
@@ -3091,11 +2820,6 @@ export type MutationDeleteConnectedAccountArgs = {
 };
 
 
-export type MutationDeleteDatabaseConfigVariableArgs = {
-  key: Scalars['String'];
-};
-
-
 export type MutationDeleteEmailingDomainArgs = {
   id: Scalars['String'];
 };
@@ -3103,12 +2827,6 @@ export type MutationDeleteEmailingDomainArgs = {
 
 export type MutationDeleteFrontComponentArgs = {
   id: Scalars['UUID'];
-};
-
-
-export type MutationDeleteJobsArgs = {
-  jobIds: Array<Scalars['String']>;
-  queueName: Scalars['String'];
 };
 
 
@@ -3362,17 +3080,6 @@ export type MutationInstallMarketplaceAppArgs = {
 };
 
 
-export type MutationRemoveAiProviderArgs = {
-  providerName: Scalars['String'];
-};
-
-
-export type MutationRemoveModelFromProviderArgs = {
-  modelName: Scalars['String'];
-  providerName: Scalars['String'];
-};
-
-
 export type MutationRemoveQueryFromEventStreamArgs = {
   input: RemoveQueryFromEventStreamInput;
 };
@@ -3416,12 +3123,6 @@ export type MutationResetPageLayoutToDefaultArgs = {
 
 export type MutationResetPageLayoutWidgetToDefaultArgs = {
   id: Scalars['String'];
-};
-
-
-export type MutationRetryJobsArgs = {
-  jobIds: Array<Scalars['String']>;
-  queueName: Scalars['String'];
 };
 
 
@@ -3475,45 +3176,8 @@ export type MutationSendInvitationsArgs = {
 };
 
 
-export type MutationSetAdminAiModelEnabledArgs = {
-  enabled: Scalars['Boolean'];
-  modelId: Scalars['String'];
-};
-
-
-export type MutationSetAdminAiModelRecommendedArgs = {
-  modelId: Scalars['String'];
-  recommended: Scalars['Boolean'];
-};
-
-
-export type MutationSetAdminAiModelsEnabledArgs = {
-  enabled: Scalars['Boolean'];
-  modelIds: Array<Scalars['String']>;
-};
-
-
-export type MutationSetAdminAiModelsRecommendedArgs = {
-  modelIds: Array<Scalars['String']>;
-  recommended: Scalars['Boolean'];
-};
-
-
-export type MutationSetAdminDefaultAiModelArgs = {
-  modelId: Scalars['String'];
-  role: AiModelRole;
-};
-
-
 export type MutationSetEnterpriseKeyArgs = {
   enterpriseKey: Scalars['String'];
-};
-
-
-export type MutationSetMaintenanceModeArgs = {
-  endAt: Scalars['DateTime'];
-  link?: InputMaybe<Scalars['String']>;
-  startAt: Scalars['DateTime'];
 };
 
 
@@ -3608,12 +3272,6 @@ export type MutationUpdateCalendarChannelArgs = {
 
 export type MutationUpdateCommandMenuItemArgs = {
   input: UpdateCommandMenuItemInput;
-};
-
-
-export type MutationUpdateDatabaseConfigVariableArgs = {
-  key: Scalars['String'];
-  value: Scalars['JSON'];
 };
 
 
@@ -3774,13 +3432,6 @@ export type MutationUpdateWebhookArgs = {
 
 export type MutationUpdateWorkspaceArgs = {
   data: UpdateWorkspaceInput;
-};
-
-
-export type MutationUpdateWorkspaceFeatureFlagArgs = {
-  featureFlag: Scalars['String'];
-  value: Scalars['Boolean'];
-  workspaceId: Scalars['UUID'];
 };
 
 
@@ -4394,8 +4045,6 @@ export type PublicWorkspaceDataSummary = {
 
 export type Query = {
   __typename?: 'Query';
-  adminPanelRecentUsers: Array<AdminPanelRecentUser>;
-  adminPanelTopWorkspaces: Array<AdminPanelTopWorkspace>;
   agentTurns: Array<AgentTurn>;
   apiKey?: Maybe<ApiKey>;
   apiKeys: Array<ApiKey>;
@@ -4420,7 +4069,6 @@ export type Query = {
   eventLogs: EventLogQueryResult;
   field: Field;
   fields: FieldConnection;
-  findAllApplicationRegistrations: Array<ApplicationRegistration>;
   findApplicationRegistrationByClientId?: Maybe<PublicApplicationRegistration>;
   findApplicationRegistrationByUniversalIdentifier?: Maybe<ApplicationRegistration>;
   findApplicationRegistrationStats: ApplicationRegistrationStats;
@@ -4432,7 +4080,6 @@ export type Query = {
   findManyMarketplaceApps: Array<MarketplaceApp>;
   findManyPublicDomains: Array<PublicDomain>;
   findMarketplaceAppDetail: MarketplaceAppDetail;
-  findOneAdminApplicationRegistration: ApplicationRegistration;
   findOneAgent: Agent;
   findOneApplication: Application;
   findOneApplicationRegistration: ApplicationRegistration;
@@ -4442,25 +4089,14 @@ export type Query = {
   frontComponent?: Maybe<FrontComponent>;
   frontComponents: Array<FrontComponent>;
   getAddressDetails: PlaceDetailsResult;
-  getAdminAiModels: AdminAiModels;
-  getAdminAiUsageByWorkspace: Array<UsageBreakdownItem>;
-  getAdminChatThreadMessages: AdminChatThreadMessages;
-  getAdminWorkspaceChatThreads: Array<AdminWorkspaceChatThread>;
-  getAiProviders: Scalars['JSON'];
   getAiSystemPromptPreview: AiSystemPromptPreview;
   getApprovedAccessDomains: Array<ApprovedAccessDomain>;
   getAutoCompleteAddress: Array<AutocompleteResult>;
   getAvailablePackages: Scalars['JSON'];
-  getConfigVariablesGrouped: ConfigVariables;
   getConnectedImapSmtpCaldavAccount: ConnectedImapSmtpCaldavAccount;
-  getDatabaseConfigVariable: ConfigVariable;
   getEmailingDomains: Array<EmailingDomain>;
-  getIndicatorHealthStatus: AdminPanelHealthServiceData;
   getLogicFunctionSourceCode?: Maybe<Scalars['String']>;
-  getMaintenanceMode?: Maybe<MaintenanceMode>;
   getMeteredProductsUsage: Array<BillingMeteredProductUsage>;
-  getModelsDevProviders: Array<ModelsDevProviderSuggestion>;
-  getModelsDevSuggestions: Array<ModelsDevModelSuggestion>;
   getPageLayout?: Maybe<PageLayout>;
   getPageLayoutTab: PageLayoutTab;
   getPageLayoutTabs: Array<PageLayoutTab>;
@@ -4470,11 +4106,8 @@ export type Query = {
   getPostgresCredentials?: Maybe<PostgresCredentials>;
   getPublicWorkspaceDataByDomain: PublicWorkspaceData;
   getPublicWorkspaceDataById: PublicWorkspaceDataSummary;
-  getQueueJobs: QueueJobsResponse;
-  getQueueMetrics: QueueMetricsData;
   getRoles: Array<Role>;
   getSSOIdentityProviders: Array<FindAvailableSsoidp>;
-  getSystemHealthStatus: SystemHealth;
   getToolIndex: Array<ToolIndexEntry>;
   getToolInputSchema?: Maybe<Scalars['JSON']>;
   getUsageAnalytics: UsageAnalytics;
@@ -4509,22 +4142,9 @@ export type Query = {
   pieChartData: PieChartData;
   skill?: Maybe<Skill>;
   skills: Array<Skill>;
-  userLookupAdminPanel: UserLookup;
   validatePasswordResetToken: ValidatePasswordResetToken;
-  versionInfo: VersionInfo;
   webhook?: Maybe<Webhook>;
   webhooks: Array<Webhook>;
-  workspaceLookupAdminPanel: UserLookup;
-};
-
-
-export type QueryAdminPanelRecentUsersArgs = {
-  searchTerm?: InputMaybe<Scalars['String']>;
-};
-
-
-export type QueryAdminPanelTopWorkspacesArgs = {
-  searchTerm?: InputMaybe<Scalars['String']>;
 };
 
 
@@ -4647,11 +4267,6 @@ export type QueryFindMarketplaceAppDetailArgs = {
 };
 
 
-export type QueryFindOneAdminApplicationRegistrationArgs = {
-  id: Scalars['String'];
-};
-
-
 export type QueryFindOneAgentArgs = {
   input: AgentIdInput;
 };
@@ -4689,22 +4304,6 @@ export type QueryGetAddressDetailsArgs = {
 };
 
 
-export type QueryGetAdminAiUsageByWorkspaceArgs = {
-  periodEnd?: InputMaybe<Scalars['DateTime']>;
-  periodStart?: InputMaybe<Scalars['DateTime']>;
-};
-
-
-export type QueryGetAdminChatThreadMessagesArgs = {
-  threadId: Scalars['UUID'];
-};
-
-
-export type QueryGetAdminWorkspaceChatThreadsArgs = {
-  workspaceId: Scalars['UUID'];
-};
-
-
 export type QueryGetAutoCompleteAddressArgs = {
   address: Scalars['String'];
   country?: InputMaybe<Scalars['String']>;
@@ -4723,23 +4322,8 @@ export type QueryGetConnectedImapSmtpCaldavAccountArgs = {
 };
 
 
-export type QueryGetDatabaseConfigVariableArgs = {
-  key: Scalars['String'];
-};
-
-
-export type QueryGetIndicatorHealthStatusArgs = {
-  indicatorId: HealthIndicatorId;
-};
-
-
 export type QueryGetLogicFunctionSourceCodeArgs = {
   input: LogicFunctionIdInput;
-};
-
-
-export type QueryGetModelsDevSuggestionsArgs = {
-  providerType: Scalars['String'];
 };
 
 
@@ -4781,20 +4365,6 @@ export type QueryGetPublicWorkspaceDataByDomainArgs = {
 
 export type QueryGetPublicWorkspaceDataByIdArgs = {
   id: Scalars['UUID'];
-};
-
-
-export type QueryGetQueueJobsArgs = {
-  limit?: InputMaybe<Scalars['Int']>;
-  offset?: InputMaybe<Scalars['Int']>;
-  queueName: Scalars['String'];
-  state: JobState;
-};
-
-
-export type QueryGetQueueMetricsArgs = {
-  queueName: Scalars['String'];
-  timeRange?: InputMaybe<QueueMetricsTimeRange>;
 };
 
 
@@ -4936,11 +4506,6 @@ export type QuerySkillArgs = {
 };
 
 
-export type QueryUserLookupAdminPanelArgs = {
-  userIdentifier: Scalars['String'];
-};
-
-
 export type QueryValidatePasswordResetTokenArgs = {
   passwordResetToken: Scalars['String'];
 };
@@ -4948,73 +4513,6 @@ export type QueryValidatePasswordResetTokenArgs = {
 
 export type QueryWebhookArgs = {
   id: Scalars['UUID'];
-};
-
-
-export type QueryWorkspaceLookupAdminPanelArgs = {
-  workspaceId: Scalars['UUID'];
-};
-
-export type QueueJob = {
-  __typename?: 'QueueJob';
-  attemptsMade: Scalars['Float'];
-  data?: Maybe<Scalars['JSON']>;
-  failedReason?: Maybe<Scalars['String']>;
-  finishedOn?: Maybe<Scalars['Float']>;
-  id: Scalars['String'];
-  logs?: Maybe<Array<Scalars['String']>>;
-  name: Scalars['String'];
-  processedOn?: Maybe<Scalars['Float']>;
-  returnValue?: Maybe<Scalars['JSON']>;
-  stackTrace?: Maybe<Array<Scalars['String']>>;
-  state: JobState;
-  timestamp?: Maybe<Scalars['Float']>;
-};
-
-export type QueueJobsResponse = {
-  __typename?: 'QueueJobsResponse';
-  count: Scalars['Float'];
-  hasMore: Scalars['Boolean'];
-  jobs: Array<QueueJob>;
-  retentionConfig: QueueRetentionConfig;
-  totalCount: Scalars['Float'];
-};
-
-export type QueueMetricsData = {
-  __typename?: 'QueueMetricsData';
-  data: Array<QueueMetricsSeries>;
-  details?: Maybe<WorkerQueueMetrics>;
-  queueName: Scalars['String'];
-  timeRange: QueueMetricsTimeRange;
-  workers: Scalars['Float'];
-};
-
-export type QueueMetricsDataPoint = {
-  __typename?: 'QueueMetricsDataPoint';
-  x: Scalars['Float'];
-  y: Scalars['Float'];
-};
-
-export type QueueMetricsSeries = {
-  __typename?: 'QueueMetricsSeries';
-  data: Array<QueueMetricsDataPoint>;
-  id: Scalars['String'];
-};
-
-export enum QueueMetricsTimeRange {
-  FourHours = 'FourHours',
-  OneDay = 'OneDay',
-  OneHour = 'OneHour',
-  SevenDays = 'SevenDays',
-  TwelveHours = 'TwelveHours'
-}
-
-export type QueueRetentionConfig = {
-  __typename?: 'QueueRetentionConfig';
-  completedMaxAge: Scalars['Float'];
-  completedMaxCount: Scalars['Float'];
-  failedMaxAge: Scalars['Float'];
-  failedMaxCount: Scalars['Float'];
 };
 
 export type RatioAggregateConfig = {
@@ -5059,12 +4557,6 @@ export type RemoveQueryFromEventStreamInput = {
 export type ResendEmailVerificationToken = {
   __typename?: 'ResendEmailVerificationToken';
   success: Scalars['Boolean'];
-};
-
-export type RetryJobsResponse = {
-  __typename?: 'RetryJobsResponse';
-  results: Array<JobOperationResult>;
-  retriedCount: Scalars['Int'];
 };
 
 export type RevokeApiKeyInput = {
@@ -5366,18 +4858,6 @@ export enum SupportDriver {
   FRONT = 'FRONT',
   NONE = 'NONE'
 }
-
-export type SystemHealth = {
-  __typename?: 'SystemHealth';
-  services: Array<SystemHealthService>;
-};
-
-export type SystemHealthService = {
-  __typename?: 'SystemHealthService';
-  id: HealthIndicatorId;
-  label: Scalars['String'];
-  status: AdminPanelHealthServiceStatus;
-};
 
 export type TasksConfiguration = {
   __typename?: 'TasksConfiguration';
@@ -5984,21 +5464,6 @@ export type User = {
   workspaces: Array<UserWorkspace>;
 };
 
-export type UserInfo = {
-  __typename?: 'UserInfo';
-  createdAt: Scalars['DateTime'];
-  email: Scalars['String'];
-  firstName?: Maybe<Scalars['String']>;
-  id: Scalars['UUID'];
-  lastName?: Maybe<Scalars['String']>;
-};
-
-export type UserLookup = {
-  __typename?: 'UserLookup';
-  user: UserInfo;
-  workspaces: Array<WorkspaceInfo>;
-};
-
 export type UserWorkspace = {
   __typename?: 'UserWorkspace';
   createdAt: Scalars['DateTime'];
@@ -6049,12 +5514,6 @@ export type VersionDistributionEntry = {
   __typename?: 'VersionDistributionEntry';
   count: Scalars['Int'];
   version: Scalars['String'];
-};
-
-export type VersionInfo = {
-  __typename?: 'VersionInfo';
-  currentVersion?: Maybe<Scalars['String']>;
-  latestVersion: Scalars['String'];
 };
 
 export type View = {
@@ -6306,18 +5765,6 @@ export enum WidgetType {
   WORKFLOW_VERSION = 'WORKFLOW_VERSION'
 }
 
-export type WorkerQueueMetrics = {
-  __typename?: 'WorkerQueueMetrics';
-  active: Scalars['Float'];
-  completed: Scalars['Float'];
-  completedData?: Maybe<Array<Scalars['Float']>>;
-  delayed: Scalars['Float'];
-  failed: Scalars['Float'];
-  failedData?: Maybe<Array<Scalars['Float']>>;
-  failureRate: Scalars['Float'];
-  waiting: Scalars['Float'];
-};
-
 export type WorkflowConfiguration = {
   __typename?: 'WorkflowConfiguration';
   configurationType: WidgetConfigurationType;
@@ -6394,20 +5841,6 @@ export enum WorkspaceActivationStatus {
   PENDING_CREATION = 'PENDING_CREATION',
   SUSPENDED = 'SUSPENDED'
 }
-
-export type WorkspaceInfo = {
-  __typename?: 'WorkspaceInfo';
-  activationStatus: WorkspaceActivationStatus;
-  allowImpersonation: Scalars['Boolean'];
-  createdAt: Scalars['DateTime'];
-  featureFlags: Array<FeatureFlag>;
-  id: Scalars['UUID'];
-  logo?: Maybe<Scalars['String']>;
-  name: Scalars['String'];
-  totalUsers: Scalars['Float'];
-  users: Array<UserInfo>;
-  workspaceUrls: WorkspaceUrls;
-};
 
 export type WorkspaceInvitation = {
   __typename?: 'WorkspaceInvitation';
@@ -7388,277 +6821,6 @@ export type MyMessageFoldersQueryVariables = Exact<{
 
 export type MyMessageFoldersQuery = { __typename?: 'Query', myMessageFolders: Array<{ __typename?: 'MessageFolder', id: string, name?: string | null, isSynced: boolean, isSentFolder: boolean, parentFolderId?: string | null, externalId?: string | null, messageChannelId: string, createdAt: string, updatedAt: string }> };
 
-export type AddAiProviderMutationVariables = Exact<{
-  providerName: Scalars['String'];
-  providerConfig: Scalars['JSON'];
-}>;
-
-
-export type AddAiProviderMutation = { __typename?: 'Mutation', addAiProvider: boolean };
-
-export type AddModelToProviderMutationVariables = Exact<{
-  providerName: Scalars['String'];
-  modelConfig: Scalars['JSON'];
-}>;
-
-
-export type AddModelToProviderMutation = { __typename?: 'Mutation', addModelToProvider: boolean };
-
-export type RemoveAiProviderMutationVariables = Exact<{
-  providerName: Scalars['String'];
-}>;
-
-
-export type RemoveAiProviderMutation = { __typename?: 'Mutation', removeAiProvider: boolean };
-
-export type RemoveModelFromProviderMutationVariables = Exact<{
-  providerName: Scalars['String'];
-  modelName: Scalars['String'];
-}>;
-
-
-export type RemoveModelFromProviderMutation = { __typename?: 'Mutation', removeModelFromProvider: boolean };
-
-export type SetAdminAiModelEnabledMutationVariables = Exact<{
-  modelId: Scalars['String'];
-  enabled: Scalars['Boolean'];
-}>;
-
-
-export type SetAdminAiModelEnabledMutation = { __typename?: 'Mutation', setAdminAiModelEnabled: boolean };
-
-export type SetAdminAiModelRecommendedMutationVariables = Exact<{
-  modelId: Scalars['String'];
-  recommended: Scalars['Boolean'];
-}>;
-
-
-export type SetAdminAiModelRecommendedMutation = { __typename?: 'Mutation', setAdminAiModelRecommended: boolean };
-
-export type SetAdminAiModelsEnabledMutationVariables = Exact<{
-  modelIds: Array<Scalars['String']> | Scalars['String'];
-  enabled: Scalars['Boolean'];
-}>;
-
-
-export type SetAdminAiModelsEnabledMutation = { __typename?: 'Mutation', setAdminAiModelsEnabled: boolean };
-
-export type SetAdminAiModelsRecommendedMutationVariables = Exact<{
-  modelIds: Array<Scalars['String']> | Scalars['String'];
-  recommended: Scalars['Boolean'];
-}>;
-
-
-export type SetAdminAiModelsRecommendedMutation = { __typename?: 'Mutation', setAdminAiModelsRecommended: boolean };
-
-export type SetAdminDefaultAiModelMutationVariables = Exact<{
-  role: AiModelRole;
-  modelId: Scalars['String'];
-}>;
-
-
-export type SetAdminDefaultAiModelMutation = { __typename?: 'Mutation', setAdminDefaultAiModel: boolean };
-
-export type GetAdminAiModelsQueryVariables = Exact<{ [key: string]: never; }>;
-
-
-export type GetAdminAiModelsQuery = { __typename?: 'Query', getAdminAiModels: { __typename?: 'AdminAiModels', defaultSmartModelId?: string | null, defaultFastModelId?: string | null, models: Array<{ __typename?: 'AdminAiModelConfig', modelId: string, label: string, modelFamily?: ModelFamily | null, sdkPackage?: string | null, isAvailable: boolean, isAdminEnabled: boolean, isDeprecated?: boolean | null, isRecommended?: boolean | null, contextWindowTokens?: number | null, maxOutputTokens?: number | null, inputCostPerMillionTokens?: number | null, outputCostPerMillionTokens?: number | null, providerName?: string | null, providerLabel?: string | null, name?: string | null, dataResidency?: string | null }> } };
-
-export type GetAdminAiUsageByWorkspaceQueryVariables = Exact<{
-  periodStart?: InputMaybe<Scalars['DateTime']>;
-  periodEnd?: InputMaybe<Scalars['DateTime']>;
-}>;
-
-
-export type GetAdminAiUsageByWorkspaceQuery = { __typename?: 'Query', getAdminAiUsageByWorkspace: Array<{ __typename?: 'UsageBreakdownItem', key: string, label?: string | null, creditsUsed: number }> };
-
-export type GetAiProvidersQueryVariables = Exact<{ [key: string]: never; }>;
-
-
-export type GetAiProvidersQuery = { __typename?: 'Query', getAiProviders: any };
-
-export type GetModelsDevProvidersQueryVariables = Exact<{ [key: string]: never; }>;
-
-
-export type GetModelsDevProvidersQuery = { __typename?: 'Query', getModelsDevProviders: Array<{ __typename?: 'ModelsDevProviderSuggestion', id: string, modelCount: number, npm: string }> };
-
-export type GetModelsDevSuggestionsQueryVariables = Exact<{
-  providerType: Scalars['String'];
-}>;
-
-
-export type GetModelsDevSuggestionsQuery = { __typename?: 'Query', getModelsDevSuggestions: Array<{ __typename?: 'ModelsDevModelSuggestion', modelId: string, name: string, inputCostPerMillionTokens: number, outputCostPerMillionTokens: number, cachedInputCostPerMillionTokens?: number | null, cacheCreationCostPerMillionTokens?: number | null, contextWindowTokens: number, maxOutputTokens: number, modalities: Array<string>, supportsReasoning: boolean }> };
-
-export type FindAllApplicationRegistrationsQueryVariables = Exact<{ [key: string]: never; }>;
-
-
-export type FindAllApplicationRegistrationsQuery = { __typename?: 'Query', findAllApplicationRegistrations: Array<{ __typename?: 'ApplicationRegistration', id: string, universalIdentifier: string, name: string, oAuthClientId: string, oAuthRedirectUris: Array<string>, oAuthScopes: Array<string>, sourceType: ApplicationRegistrationSourceType, sourcePackage?: string | null, latestAvailableVersion?: string | null, isListed: boolean, isFeatured: boolean, ownerWorkspaceId?: string | null, createdAt: string, updatedAt: string }> };
-
-export type CreateDatabaseConfigVariableMutationVariables = Exact<{
-  key: Scalars['String'];
-  value: Scalars['JSON'];
-}>;
-
-
-export type CreateDatabaseConfigVariableMutation = { __typename?: 'Mutation', createDatabaseConfigVariable: boolean };
-
-export type DeleteDatabaseConfigVariableMutationVariables = Exact<{
-  key: Scalars['String'];
-}>;
-
-
-export type DeleteDatabaseConfigVariableMutation = { __typename?: 'Mutation', deleteDatabaseConfigVariable: boolean };
-
-export type UpdateDatabaseConfigVariableMutationVariables = Exact<{
-  key: Scalars['String'];
-  value: Scalars['JSON'];
-}>;
-
-
-export type UpdateDatabaseConfigVariableMutation = { __typename?: 'Mutation', updateDatabaseConfigVariable: boolean };
-
-export type GetConfigVariablesGroupedQueryVariables = Exact<{ [key: string]: never; }>;
-
-
-export type GetConfigVariablesGroupedQuery = { __typename?: 'Query', getConfigVariablesGrouped: { __typename?: 'ConfigVariables', groups: Array<{ __typename?: 'ConfigVariablesGroupData', name: ConfigVariablesGroup, description: string, isHiddenOnLoad: boolean, variables: Array<{ __typename?: 'ConfigVariable', name: string, description: string, value?: any | null, isSensitive: boolean, isEnvOnly: boolean, type: ConfigVariableType, options?: any | null, source: ConfigSource }> }> } };
-
-export type GetDatabaseConfigVariableQueryVariables = Exact<{
-  key: Scalars['String'];
-}>;
-
-
-export type GetDatabaseConfigVariableQuery = { __typename?: 'Query', getDatabaseConfigVariable: { __typename?: 'ConfigVariable', name: string, description: string, value?: any | null, isSensitive: boolean, isEnvOnly: boolean, type: ConfigVariableType, options?: any | null, source: ConfigSource } };
-
-export type UserInfoFragmentFragment = { __typename?: 'UserInfo', id: string, email: string, firstName?: string | null, lastName?: string | null, createdAt: string };
-
-export type UpdateWorkspaceFeatureFlagMutationVariables = Exact<{
-  workspaceId: Scalars['UUID'];
-  featureFlag: Scalars['String'];
-  value: Scalars['Boolean'];
-}>;
-
-
-export type UpdateWorkspaceFeatureFlagMutation = { __typename?: 'Mutation', updateWorkspaceFeatureFlag: boolean };
-
-export type AdminPanelRecentUsersQueryVariables = Exact<{
-  searchTerm?: InputMaybe<Scalars['String']>;
-}>;
-
-
-export type AdminPanelRecentUsersQuery = { __typename?: 'Query', adminPanelRecentUsers: Array<{ __typename?: 'AdminPanelRecentUser', id: string, email: string, firstName?: string | null, lastName?: string | null, createdAt: string, workspaceName?: string | null, workspaceId?: string | null }> };
-
-export type AdminPanelTopWorkspacesQueryVariables = Exact<{
-  searchTerm?: InputMaybe<Scalars['String']>;
-}>;
-
-
-export type AdminPanelTopWorkspacesQuery = { __typename?: 'Query', adminPanelTopWorkspaces: Array<{ __typename?: 'AdminPanelTopWorkspace', id: string, name: string, totalUsers: number, subdomain: string }> };
-
-export type FindOneAdminApplicationRegistrationQueryVariables = Exact<{
-  id: Scalars['String'];
-}>;
-
-
-export type FindOneAdminApplicationRegistrationQuery = { __typename?: 'Query', findOneAdminApplicationRegistration: { __typename?: 'ApplicationRegistration', id: string, universalIdentifier: string, name: string, oAuthClientId: string, oAuthRedirectUris: Array<string>, oAuthScopes: Array<string>, sourceType: ApplicationRegistrationSourceType, sourcePackage?: string | null, latestAvailableVersion?: string | null, isListed: boolean, isFeatured: boolean, ownerWorkspaceId?: string | null, createdAt: string, updatedAt: string } };
-
-export type GetAdminChatThreadMessagesQueryVariables = Exact<{
-  threadId: Scalars['UUID'];
-}>;
-
-
-export type GetAdminChatThreadMessagesQuery = { __typename?: 'Query', getAdminChatThreadMessages: { __typename?: 'AdminChatThreadMessages', thread: { __typename?: 'AdminWorkspaceChatThread', id: string, title?: string | null, totalInputTokens: number, totalOutputTokens: number, conversationSize: number, createdAt: string, updatedAt: string }, messages: Array<{ __typename?: 'AdminChatMessage', id: string, role: AgentMessageRole, createdAt: string, parts: Array<{ __typename?: 'AdminChatMessagePart', type: string, textContent?: string | null, toolName?: string | null }> }> } };
-
-export type GetAdminWorkspaceChatThreadsQueryVariables = Exact<{
-  workspaceId: Scalars['UUID'];
-}>;
-
-
-export type GetAdminWorkspaceChatThreadsQuery = { __typename?: 'Query', getAdminWorkspaceChatThreads: Array<{ __typename?: 'AdminWorkspaceChatThread', id: string, title?: string | null, totalInputTokens: number, totalOutputTokens: number, conversationSize: number, createdAt: string, updatedAt: string }> };
-
-export type GetVersionInfoQueryVariables = Exact<{ [key: string]: never; }>;
-
-
-export type GetVersionInfoQuery = { __typename?: 'Query', versionInfo: { __typename?: 'VersionInfo', currentVersion?: string | null, latestVersion: string } };
-
-export type UserLookupAdminPanelQueryVariables = Exact<{
-  userIdentifier: Scalars['String'];
-}>;
-
-
-export type UserLookupAdminPanelQuery = { __typename?: 'Query', userLookupAdminPanel: { __typename?: 'UserLookup', user: { __typename?: 'UserInfo', id: string, email: string, firstName?: string | null, lastName?: string | null, createdAt: string }, workspaces: Array<{ __typename?: 'WorkspaceInfo', id: string, name: string, logo?: string | null, totalUsers: number, activationStatus: WorkspaceActivationStatus, createdAt: string, allowImpersonation: boolean, workspaceUrls: { __typename?: 'WorkspaceUrls', customUrl?: string | null, subdomainUrl: string }, users: Array<{ __typename?: 'UserInfo', id: string, email: string, firstName?: string | null, lastName?: string | null }>, featureFlags: Array<{ __typename?: 'FeatureFlag', key: FeatureFlagKey, value: boolean }> }> } };
-
-export type WorkspaceLookupAdminPanelQueryVariables = Exact<{
-  workspaceId: Scalars['UUID'];
-}>;
-
-
-export type WorkspaceLookupAdminPanelQuery = { __typename?: 'Query', workspaceLookupAdminPanel: { __typename?: 'UserLookup', user: { __typename?: 'UserInfo', id: string, email: string, firstName?: string | null, lastName?: string | null, createdAt: string }, workspaces: Array<{ __typename?: 'WorkspaceInfo', id: string, name: string, allowImpersonation: boolean, logo?: string | null, totalUsers: number, activationStatus: WorkspaceActivationStatus, createdAt: string, workspaceUrls: { __typename?: 'WorkspaceUrls', customUrl?: string | null, subdomainUrl: string }, users: Array<{ __typename?: 'UserInfo', id: string, email: string, firstName?: string | null, lastName?: string | null }>, featureFlags: Array<{ __typename?: 'FeatureFlag', key: FeatureFlagKey, value: boolean }> }> } };
-
-export type DeleteJobsMutationVariables = Exact<{
-  queueName: Scalars['String'];
-  jobIds: Array<Scalars['String']> | Scalars['String'];
-}>;
-
-
-export type DeleteJobsMutation = { __typename?: 'Mutation', deleteJobs: { __typename?: 'DeleteJobsResponse', deletedCount: number, results: Array<{ __typename?: 'JobOperationResult', jobId: string, success: boolean, error?: string | null }> } };
-
-export type RetryJobsMutationVariables = Exact<{
-  queueName: Scalars['String'];
-  jobIds: Array<Scalars['String']> | Scalars['String'];
-}>;
-
-
-export type RetryJobsMutation = { __typename?: 'Mutation', retryJobs: { __typename?: 'RetryJobsResponse', retriedCount: number, results: Array<{ __typename?: 'JobOperationResult', jobId: string, success: boolean, error?: string | null }> } };
-
-export type GetIndicatorHealthStatusQueryVariables = Exact<{
-  indicatorId: HealthIndicatorId;
-}>;
-
-
-export type GetIndicatorHealthStatusQuery = { __typename?: 'Query', getIndicatorHealthStatus: { __typename?: 'AdminPanelHealthServiceData', id: HealthIndicatorId, label: string, description: string, status: AdminPanelHealthServiceStatus, errorMessage?: string | null, details?: string | null, queues?: Array<{ __typename?: 'AdminPanelWorkerQueueHealth', id: string, queueName: string, status: AdminPanelHealthServiceStatus }> | null } };
-
-export type GetQueueJobsQueryVariables = Exact<{
-  queueName: Scalars['String'];
-  state: JobState;
-  limit?: InputMaybe<Scalars['Int']>;
-  offset?: InputMaybe<Scalars['Int']>;
-}>;
-
-
-export type GetQueueJobsQuery = { __typename?: 'Query', getQueueJobs: { __typename?: 'QueueJobsResponse', count: number, totalCount: number, hasMore: boolean, jobs: Array<{ __typename?: 'QueueJob', id: string, name: string, data?: any | null, state: JobState, timestamp?: number | null, failedReason?: string | null, processedOn?: number | null, finishedOn?: number | null, attemptsMade: number, returnValue?: any | null, logs?: Array<string> | null, stackTrace?: Array<string> | null }>, retentionConfig: { __typename?: 'QueueRetentionConfig', completedMaxAge: number, completedMaxCount: number, failedMaxAge: number, failedMaxCount: number } } };
-
-export type GetQueueMetricsQueryVariables = Exact<{
-  queueName: Scalars['String'];
-  timeRange?: InputMaybe<QueueMetricsTimeRange>;
-}>;
-
-
-export type GetQueueMetricsQuery = { __typename?: 'Query', getQueueMetrics: { __typename?: 'QueueMetricsData', queueName: string, timeRange: QueueMetricsTimeRange, workers: number, details?: { __typename?: 'WorkerQueueMetrics', failed: number, completed: number, waiting: number, active: number, delayed: number, failureRate: number } | null, data: Array<{ __typename?: 'QueueMetricsSeries', id: string, data: Array<{ __typename?: 'QueueMetricsDataPoint', x: number, y: number }> }> } };
-
-export type GetSystemHealthStatusQueryVariables = Exact<{ [key: string]: never; }>;
-
-
-export type GetSystemHealthStatusQuery = { __typename?: 'Query', getSystemHealthStatus: { __typename?: 'SystemHealth', services: Array<{ __typename?: 'SystemHealthService', id: HealthIndicatorId, label: string, status: AdminPanelHealthServiceStatus }> } };
-
-export type ClearMaintenanceModeMutationVariables = Exact<{ [key: string]: never; }>;
-
-
-export type ClearMaintenanceModeMutation = { __typename?: 'Mutation', clearMaintenanceMode: boolean };
-
-export type SetMaintenanceModeMutationVariables = Exact<{
-  startAt: Scalars['DateTime'];
-  endAt: Scalars['DateTime'];
-  link?: InputMaybe<Scalars['String']>;
-}>;
-
-
-export type SetMaintenanceModeMutation = { __typename?: 'Mutation', setMaintenanceMode: boolean };
-
-export type GetMaintenanceModeQueryVariables = Exact<{ [key: string]: never; }>;
-
-
-export type GetMaintenanceModeQuery = { __typename?: 'Query', getMaintenanceMode?: { __typename?: 'MaintenanceMode', startAt: string, endAt: string, link?: string | null } | null };
-
 export type ApplicationRegistrationFragmentFragment = { __typename?: 'ApplicationRegistration', id: string, universalIdentifier: string, name: string, oAuthClientId: string, oAuthRedirectUris: Array<string>, oAuthScopes: Array<string>, sourceType: ApplicationRegistrationSourceType, sourcePackage?: string | null, latestAvailableVersion?: string | null, isListed: boolean, isFeatured: boolean, ownerWorkspaceId?: string | null, createdAt: string, updatedAt: string };
 
 export type DeleteApplicationRegistrationMutationVariables = Exact<{
@@ -8622,7 +7784,6 @@ export const MarketplaceAppFieldsFragmentDoc = {"kind":"Document","definitions":
 export const NavigationMenuItemFieldsFragmentDoc = {"kind":"Document","definitions":[{"kind":"FragmentDefinition","name":{"kind":"Name","value":"NavigationMenuItemFields"},"typeCondition":{"kind":"NamedType","name":{"kind":"Name","value":"NavigationMenuItem"}},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"id"}},{"kind":"Field","name":{"kind":"Name","value":"type"}},{"kind":"Field","name":{"kind":"Name","value":"userWorkspaceId"}},{"kind":"Field","name":{"kind":"Name","value":"targetRecordId"}},{"kind":"Field","name":{"kind":"Name","value":"targetObjectMetadataId"}},{"kind":"Field","name":{"kind":"Name","value":"viewId"}},{"kind":"Field","name":{"kind":"Name","value":"folderId"}},{"kind":"Field","name":{"kind":"Name","value":"name"}},{"kind":"Field","name":{"kind":"Name","value":"link"}},{"kind":"Field","name":{"kind":"Name","value":"icon"}},{"kind":"Field","name":{"kind":"Name","value":"color"}},{"kind":"Field","name":{"kind":"Name","value":"pageLayoutId"}},{"kind":"Field","name":{"kind":"Name","value":"position"}},{"kind":"Field","name":{"kind":"Name","value":"applicationId"}},{"kind":"Field","name":{"kind":"Name","value":"createdAt"}},{"kind":"Field","name":{"kind":"Name","value":"updatedAt"}}]}}]} as unknown as DocumentNode<NavigationMenuItemFieldsFragment, unknown>;
 export const NavigationMenuItemQueryFieldsFragmentDoc = {"kind":"Document","definitions":[{"kind":"FragmentDefinition","name":{"kind":"Name","value":"NavigationMenuItemQueryFields"},"typeCondition":{"kind":"NamedType","name":{"kind":"Name","value":"NavigationMenuItem"}},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"FragmentSpread","name":{"kind":"Name","value":"NavigationMenuItemFields"}},{"kind":"Field","name":{"kind":"Name","value":"targetRecordIdentifier"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"id"}},{"kind":"Field","name":{"kind":"Name","value":"labelIdentifier"}},{"kind":"Field","name":{"kind":"Name","value":"imageIdentifier"}}]}}]}},{"kind":"FragmentDefinition","name":{"kind":"Name","value":"NavigationMenuItemFields"},"typeCondition":{"kind":"NamedType","name":{"kind":"Name","value":"NavigationMenuItem"}},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"id"}},{"kind":"Field","name":{"kind":"Name","value":"type"}},{"kind":"Field","name":{"kind":"Name","value":"userWorkspaceId"}},{"kind":"Field","name":{"kind":"Name","value":"targetRecordId"}},{"kind":"Field","name":{"kind":"Name","value":"targetObjectMetadataId"}},{"kind":"Field","name":{"kind":"Name","value":"viewId"}},{"kind":"Field","name":{"kind":"Name","value":"folderId"}},{"kind":"Field","name":{"kind":"Name","value":"name"}},{"kind":"Field","name":{"kind":"Name","value":"link"}},{"kind":"Field","name":{"kind":"Name","value":"icon"}},{"kind":"Field","name":{"kind":"Name","value":"color"}},{"kind":"Field","name":{"kind":"Name","value":"pageLayoutId"}},{"kind":"Field","name":{"kind":"Name","value":"position"}},{"kind":"Field","name":{"kind":"Name","value":"applicationId"}},{"kind":"Field","name":{"kind":"Name","value":"createdAt"}},{"kind":"Field","name":{"kind":"Name","value":"updatedAt"}}]}}]} as unknown as DocumentNode<NavigationMenuItemQueryFieldsFragment, unknown>;
 export const PublicConnectionParamsFragmentDoc = {"kind":"Document","definitions":[{"kind":"FragmentDefinition","name":{"kind":"Name","value":"PublicConnectionParams"},"typeCondition":{"kind":"NamedType","name":{"kind":"Name","value":"PublicConnectionParametersOutput"}},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"host"}},{"kind":"Field","name":{"kind":"Name","value":"port"}},{"kind":"Field","name":{"kind":"Name","value":"secure"}},{"kind":"Field","name":{"kind":"Name","value":"username"}}]}}]} as unknown as DocumentNode<PublicConnectionParamsFragment, unknown>;
-export const UserInfoFragmentFragmentDoc = {"kind":"Document","definitions":[{"kind":"FragmentDefinition","name":{"kind":"Name","value":"UserInfoFragment"},"typeCondition":{"kind":"NamedType","name":{"kind":"Name","value":"UserInfo"}},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"id"}},{"kind":"Field","name":{"kind":"Name","value":"email"}},{"kind":"Field","name":{"kind":"Name","value":"firstName"}},{"kind":"Field","name":{"kind":"Name","value":"lastName"}},{"kind":"Field","name":{"kind":"Name","value":"createdAt"}}]}}]} as unknown as DocumentNode<UserInfoFragmentFragment, unknown>;
 export const ApplicationRegistrationFragmentFragmentDoc = {"kind":"Document","definitions":[{"kind":"FragmentDefinition","name":{"kind":"Name","value":"ApplicationRegistrationFragment"},"typeCondition":{"kind":"NamedType","name":{"kind":"Name","value":"ApplicationRegistration"}},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"id"}},{"kind":"Field","name":{"kind":"Name","value":"universalIdentifier"}},{"kind":"Field","name":{"kind":"Name","value":"name"}},{"kind":"Field","name":{"kind":"Name","value":"oAuthClientId"}},{"kind":"Field","name":{"kind":"Name","value":"oAuthRedirectUris"}},{"kind":"Field","name":{"kind":"Name","value":"oAuthScopes"}},{"kind":"Field","name":{"kind":"Name","value":"sourceType"}},{"kind":"Field","name":{"kind":"Name","value":"sourcePackage"}},{"kind":"Field","name":{"kind":"Name","value":"latestAvailableVersion"}},{"kind":"Field","name":{"kind":"Name","value":"isListed"}},{"kind":"Field","name":{"kind":"Name","value":"isFeatured"}},{"kind":"Field","name":{"kind":"Name","value":"ownerWorkspaceId"}},{"kind":"Field","name":{"kind":"Name","value":"createdAt"}},{"kind":"Field","name":{"kind":"Name","value":"updatedAt"}}]}}]} as unknown as DocumentNode<ApplicationRegistrationFragmentFragment, unknown>;
 export const BillingPriceLicensedFragmentFragmentDoc = {"kind":"Document","definitions":[{"kind":"FragmentDefinition","name":{"kind":"Name","value":"BillingPriceLicensedFragment"},"typeCondition":{"kind":"NamedType","name":{"kind":"Name","value":"BillingPriceLicensed"}},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"stripePriceId"}},{"kind":"Field","name":{"kind":"Name","value":"unitAmount"}},{"kind":"Field","name":{"kind":"Name","value":"recurringInterval"}},{"kind":"Field","name":{"kind":"Name","value":"priceUsageType"}}]}}]} as unknown as DocumentNode<BillingPriceLicensedFragmentFragment, unknown>;
 export const BillingPriceMeteredFragmentFragmentDoc = {"kind":"Document","definitions":[{"kind":"FragmentDefinition","name":{"kind":"Name","value":"BillingPriceMeteredFragment"},"typeCondition":{"kind":"NamedType","name":{"kind":"Name","value":"BillingPriceMetered"}},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"priceUsageType"}},{"kind":"Field","name":{"kind":"Name","value":"recurringInterval"}},{"kind":"Field","name":{"kind":"Name","value":"stripePriceId"}},{"kind":"Field","name":{"kind":"Name","value":"tiers"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"flatAmount"}},{"kind":"Field","name":{"kind":"Name","value":"unitAmount"}},{"kind":"Field","name":{"kind":"Name","value":"upTo"}}]}}]}}]} as unknown as DocumentNode<BillingPriceMeteredFragmentFragment, unknown>;
@@ -8772,44 +7933,6 @@ export const MyCalendarChannelsDocument = {"kind":"Document","definitions":[{"ki
 export const MyConnectedAccountsDocument = {"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"query","name":{"kind":"Name","value":"MyConnectedAccounts"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"myConnectedAccounts"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"id"}},{"kind":"Field","name":{"kind":"Name","value":"handle"}},{"kind":"Field","name":{"kind":"Name","value":"provider"}},{"kind":"Field","name":{"kind":"Name","value":"authFailedAt"}},{"kind":"Field","name":{"kind":"Name","value":"scopes"}},{"kind":"Field","name":{"kind":"Name","value":"handleAliases"}},{"kind":"Field","name":{"kind":"Name","value":"lastSignedInAt"}},{"kind":"Field","name":{"kind":"Name","value":"userWorkspaceId"}},{"kind":"Field","name":{"kind":"Name","value":"connectionParameters"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"IMAP"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"host"}},{"kind":"Field","name":{"kind":"Name","value":"port"}},{"kind":"Field","name":{"kind":"Name","value":"secure"}},{"kind":"Field","name":{"kind":"Name","value":"username"}},{"kind":"Field","name":{"kind":"Name","value":"password"}}]}},{"kind":"Field","name":{"kind":"Name","value":"SMTP"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"host"}},{"kind":"Field","name":{"kind":"Name","value":"port"}},{"kind":"Field","name":{"kind":"Name","value":"secure"}},{"kind":"Field","name":{"kind":"Name","value":"username"}},{"kind":"Field","name":{"kind":"Name","value":"password"}}]}},{"kind":"Field","name":{"kind":"Name","value":"CALDAV"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"host"}},{"kind":"Field","name":{"kind":"Name","value":"username"}},{"kind":"Field","name":{"kind":"Name","value":"password"}}]}}]}},{"kind":"Field","name":{"kind":"Name","value":"createdAt"}},{"kind":"Field","name":{"kind":"Name","value":"updatedAt"}}]}}]}}]} as unknown as DocumentNode<MyConnectedAccountsQuery, MyConnectedAccountsQueryVariables>;
 export const MyMessageChannelsDocument = {"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"query","name":{"kind":"Name","value":"MyMessageChannels"},"variableDefinitions":[{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"connectedAccountId"}},"type":{"kind":"NamedType","name":{"kind":"Name","value":"UUID"}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"myMessageChannels"},"arguments":[{"kind":"Argument","name":{"kind":"Name","value":"connectedAccountId"},"value":{"kind":"Variable","name":{"kind":"Name","value":"connectedAccountId"}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"id"}},{"kind":"Field","name":{"kind":"Name","value":"handle"}},{"kind":"Field","name":{"kind":"Name","value":"visibility"}},{"kind":"Field","name":{"kind":"Name","value":"type"}},{"kind":"Field","name":{"kind":"Name","value":"isContactAutoCreationEnabled"}},{"kind":"Field","name":{"kind":"Name","value":"contactAutoCreationPolicy"}},{"kind":"Field","name":{"kind":"Name","value":"messageFolderImportPolicy"}},{"kind":"Field","name":{"kind":"Name","value":"excludeNonProfessionalEmails"}},{"kind":"Field","name":{"kind":"Name","value":"excludeGroupEmails"}},{"kind":"Field","name":{"kind":"Name","value":"isSyncEnabled"}},{"kind":"Field","name":{"kind":"Name","value":"syncStatus"}},{"kind":"Field","name":{"kind":"Name","value":"syncStage"}},{"kind":"Field","name":{"kind":"Name","value":"syncStageStartedAt"}},{"kind":"Field","name":{"kind":"Name","value":"connectedAccountId"}},{"kind":"Field","name":{"kind":"Name","value":"createdAt"}},{"kind":"Field","name":{"kind":"Name","value":"updatedAt"}}]}}]}}]} as unknown as DocumentNode<MyMessageChannelsQuery, MyMessageChannelsQueryVariables>;
 export const MyMessageFoldersDocument = {"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"query","name":{"kind":"Name","value":"MyMessageFolders"},"variableDefinitions":[{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"messageChannelId"}},"type":{"kind":"NamedType","name":{"kind":"Name","value":"UUID"}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"myMessageFolders"},"arguments":[{"kind":"Argument","name":{"kind":"Name","value":"messageChannelId"},"value":{"kind":"Variable","name":{"kind":"Name","value":"messageChannelId"}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"id"}},{"kind":"Field","name":{"kind":"Name","value":"name"}},{"kind":"Field","name":{"kind":"Name","value":"isSynced"}},{"kind":"Field","name":{"kind":"Name","value":"isSentFolder"}},{"kind":"Field","name":{"kind":"Name","value":"parentFolderId"}},{"kind":"Field","name":{"kind":"Name","value":"externalId"}},{"kind":"Field","name":{"kind":"Name","value":"messageChannelId"}},{"kind":"Field","name":{"kind":"Name","value":"createdAt"}},{"kind":"Field","name":{"kind":"Name","value":"updatedAt"}}]}}]}}]} as unknown as DocumentNode<MyMessageFoldersQuery, MyMessageFoldersQueryVariables>;
-export const AddAiProviderDocument = {"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"mutation","name":{"kind":"Name","value":"AddAiProvider"},"variableDefinitions":[{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"providerName"}},"type":{"kind":"NonNullType","type":{"kind":"NamedType","name":{"kind":"Name","value":"String"}}}},{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"providerConfig"}},"type":{"kind":"NonNullType","type":{"kind":"NamedType","name":{"kind":"Name","value":"JSON"}}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"addAiProvider"},"arguments":[{"kind":"Argument","name":{"kind":"Name","value":"providerName"},"value":{"kind":"Variable","name":{"kind":"Name","value":"providerName"}}},{"kind":"Argument","name":{"kind":"Name","value":"providerConfig"},"value":{"kind":"Variable","name":{"kind":"Name","value":"providerConfig"}}}]}]}}]} as unknown as DocumentNode<AddAiProviderMutation, AddAiProviderMutationVariables>;
-export const AddModelToProviderDocument = {"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"mutation","name":{"kind":"Name","value":"AddModelToProvider"},"variableDefinitions":[{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"providerName"}},"type":{"kind":"NonNullType","type":{"kind":"NamedType","name":{"kind":"Name","value":"String"}}}},{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"modelConfig"}},"type":{"kind":"NonNullType","type":{"kind":"NamedType","name":{"kind":"Name","value":"JSON"}}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"addModelToProvider"},"arguments":[{"kind":"Argument","name":{"kind":"Name","value":"providerName"},"value":{"kind":"Variable","name":{"kind":"Name","value":"providerName"}}},{"kind":"Argument","name":{"kind":"Name","value":"modelConfig"},"value":{"kind":"Variable","name":{"kind":"Name","value":"modelConfig"}}}]}]}}]} as unknown as DocumentNode<AddModelToProviderMutation, AddModelToProviderMutationVariables>;
-export const RemoveAiProviderDocument = {"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"mutation","name":{"kind":"Name","value":"RemoveAiProvider"},"variableDefinitions":[{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"providerName"}},"type":{"kind":"NonNullType","type":{"kind":"NamedType","name":{"kind":"Name","value":"String"}}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"removeAiProvider"},"arguments":[{"kind":"Argument","name":{"kind":"Name","value":"providerName"},"value":{"kind":"Variable","name":{"kind":"Name","value":"providerName"}}}]}]}}]} as unknown as DocumentNode<RemoveAiProviderMutation, RemoveAiProviderMutationVariables>;
-export const RemoveModelFromProviderDocument = {"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"mutation","name":{"kind":"Name","value":"RemoveModelFromProvider"},"variableDefinitions":[{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"providerName"}},"type":{"kind":"NonNullType","type":{"kind":"NamedType","name":{"kind":"Name","value":"String"}}}},{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"modelName"}},"type":{"kind":"NonNullType","type":{"kind":"NamedType","name":{"kind":"Name","value":"String"}}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"removeModelFromProvider"},"arguments":[{"kind":"Argument","name":{"kind":"Name","value":"providerName"},"value":{"kind":"Variable","name":{"kind":"Name","value":"providerName"}}},{"kind":"Argument","name":{"kind":"Name","value":"modelName"},"value":{"kind":"Variable","name":{"kind":"Name","value":"modelName"}}}]}]}}]} as unknown as DocumentNode<RemoveModelFromProviderMutation, RemoveModelFromProviderMutationVariables>;
-export const SetAdminAiModelEnabledDocument = {"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"mutation","name":{"kind":"Name","value":"SetAdminAiModelEnabled"},"variableDefinitions":[{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"modelId"}},"type":{"kind":"NonNullType","type":{"kind":"NamedType","name":{"kind":"Name","value":"String"}}}},{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"enabled"}},"type":{"kind":"NonNullType","type":{"kind":"NamedType","name":{"kind":"Name","value":"Boolean"}}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"setAdminAiModelEnabled"},"arguments":[{"kind":"Argument","name":{"kind":"Name","value":"modelId"},"value":{"kind":"Variable","name":{"kind":"Name","value":"modelId"}}},{"kind":"Argument","name":{"kind":"Name","value":"enabled"},"value":{"kind":"Variable","name":{"kind":"Name","value":"enabled"}}}]}]}}]} as unknown as DocumentNode<SetAdminAiModelEnabledMutation, SetAdminAiModelEnabledMutationVariables>;
-export const SetAdminAiModelRecommendedDocument = {"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"mutation","name":{"kind":"Name","value":"SetAdminAiModelRecommended"},"variableDefinitions":[{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"modelId"}},"type":{"kind":"NonNullType","type":{"kind":"NamedType","name":{"kind":"Name","value":"String"}}}},{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"recommended"}},"type":{"kind":"NonNullType","type":{"kind":"NamedType","name":{"kind":"Name","value":"Boolean"}}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"setAdminAiModelRecommended"},"arguments":[{"kind":"Argument","name":{"kind":"Name","value":"modelId"},"value":{"kind":"Variable","name":{"kind":"Name","value":"modelId"}}},{"kind":"Argument","name":{"kind":"Name","value":"recommended"},"value":{"kind":"Variable","name":{"kind":"Name","value":"recommended"}}}]}]}}]} as unknown as DocumentNode<SetAdminAiModelRecommendedMutation, SetAdminAiModelRecommendedMutationVariables>;
-export const SetAdminAiModelsEnabledDocument = {"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"mutation","name":{"kind":"Name","value":"SetAdminAiModelsEnabled"},"variableDefinitions":[{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"modelIds"}},"type":{"kind":"NonNullType","type":{"kind":"ListType","type":{"kind":"NonNullType","type":{"kind":"NamedType","name":{"kind":"Name","value":"String"}}}}}},{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"enabled"}},"type":{"kind":"NonNullType","type":{"kind":"NamedType","name":{"kind":"Name","value":"Boolean"}}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"setAdminAiModelsEnabled"},"arguments":[{"kind":"Argument","name":{"kind":"Name","value":"modelIds"},"value":{"kind":"Variable","name":{"kind":"Name","value":"modelIds"}}},{"kind":"Argument","name":{"kind":"Name","value":"enabled"},"value":{"kind":"Variable","name":{"kind":"Name","value":"enabled"}}}]}]}}]} as unknown as DocumentNode<SetAdminAiModelsEnabledMutation, SetAdminAiModelsEnabledMutationVariables>;
-export const SetAdminAiModelsRecommendedDocument = {"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"mutation","name":{"kind":"Name","value":"SetAdminAiModelsRecommended"},"variableDefinitions":[{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"modelIds"}},"type":{"kind":"NonNullType","type":{"kind":"ListType","type":{"kind":"NonNullType","type":{"kind":"NamedType","name":{"kind":"Name","value":"String"}}}}}},{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"recommended"}},"type":{"kind":"NonNullType","type":{"kind":"NamedType","name":{"kind":"Name","value":"Boolean"}}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"setAdminAiModelsRecommended"},"arguments":[{"kind":"Argument","name":{"kind":"Name","value":"modelIds"},"value":{"kind":"Variable","name":{"kind":"Name","value":"modelIds"}}},{"kind":"Argument","name":{"kind":"Name","value":"recommended"},"value":{"kind":"Variable","name":{"kind":"Name","value":"recommended"}}}]}]}}]} as unknown as DocumentNode<SetAdminAiModelsRecommendedMutation, SetAdminAiModelsRecommendedMutationVariables>;
-export const SetAdminDefaultAiModelDocument = {"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"mutation","name":{"kind":"Name","value":"SetAdminDefaultAiModel"},"variableDefinitions":[{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"role"}},"type":{"kind":"NonNullType","type":{"kind":"NamedType","name":{"kind":"Name","value":"AiModelRole"}}}},{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"modelId"}},"type":{"kind":"NonNullType","type":{"kind":"NamedType","name":{"kind":"Name","value":"String"}}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"setAdminDefaultAiModel"},"arguments":[{"kind":"Argument","name":{"kind":"Name","value":"role"},"value":{"kind":"Variable","name":{"kind":"Name","value":"role"}}},{"kind":"Argument","name":{"kind":"Name","value":"modelId"},"value":{"kind":"Variable","name":{"kind":"Name","value":"modelId"}}}]}]}}]} as unknown as DocumentNode<SetAdminDefaultAiModelMutation, SetAdminDefaultAiModelMutationVariables>;
-export const GetAdminAiModelsDocument = {"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"query","name":{"kind":"Name","value":"GetAdminAiModels"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"getAdminAiModels"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"defaultSmartModelId"}},{"kind":"Field","name":{"kind":"Name","value":"defaultFastModelId"}},{"kind":"Field","name":{"kind":"Name","value":"models"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"modelId"}},{"kind":"Field","name":{"kind":"Name","value":"label"}},{"kind":"Field","name":{"kind":"Name","value":"modelFamily"}},{"kind":"Field","name":{"kind":"Name","value":"sdkPackage"}},{"kind":"Field","name":{"kind":"Name","value":"isAvailable"}},{"kind":"Field","name":{"kind":"Name","value":"isAdminEnabled"}},{"kind":"Field","name":{"kind":"Name","value":"isDeprecated"}},{"kind":"Field","name":{"kind":"Name","value":"isRecommended"}},{"kind":"Field","name":{"kind":"Name","value":"contextWindowTokens"}},{"kind":"Field","name":{"kind":"Name","value":"maxOutputTokens"}},{"kind":"Field","name":{"kind":"Name","value":"inputCostPerMillionTokens"}},{"kind":"Field","name":{"kind":"Name","value":"outputCostPerMillionTokens"}},{"kind":"Field","name":{"kind":"Name","value":"providerName"}},{"kind":"Field","name":{"kind":"Name","value":"providerLabel"}},{"kind":"Field","name":{"kind":"Name","value":"name"}},{"kind":"Field","name":{"kind":"Name","value":"dataResidency"}}]}}]}}]}}]} as unknown as DocumentNode<GetAdminAiModelsQuery, GetAdminAiModelsQueryVariables>;
-export const GetAdminAiUsageByWorkspaceDocument = {"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"query","name":{"kind":"Name","value":"GetAdminAiUsageByWorkspace"},"variableDefinitions":[{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"periodStart"}},"type":{"kind":"NamedType","name":{"kind":"Name","value":"DateTime"}}},{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"periodEnd"}},"type":{"kind":"NamedType","name":{"kind":"Name","value":"DateTime"}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"getAdminAiUsageByWorkspace"},"arguments":[{"kind":"Argument","name":{"kind":"Name","value":"periodStart"},"value":{"kind":"Variable","name":{"kind":"Name","value":"periodStart"}}},{"kind":"Argument","name":{"kind":"Name","value":"periodEnd"},"value":{"kind":"Variable","name":{"kind":"Name","value":"periodEnd"}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"key"}},{"kind":"Field","name":{"kind":"Name","value":"label"}},{"kind":"Field","name":{"kind":"Name","value":"creditsUsed"}}]}}]}}]} as unknown as DocumentNode<GetAdminAiUsageByWorkspaceQuery, GetAdminAiUsageByWorkspaceQueryVariables>;
-export const GetAiProvidersDocument = {"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"query","name":{"kind":"Name","value":"GetAiProviders"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"getAiProviders"}}]}}]} as unknown as DocumentNode<GetAiProvidersQuery, GetAiProvidersQueryVariables>;
-export const GetModelsDevProvidersDocument = {"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"query","name":{"kind":"Name","value":"GetModelsDevProviders"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"getModelsDevProviders"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"id"}},{"kind":"Field","name":{"kind":"Name","value":"modelCount"}},{"kind":"Field","name":{"kind":"Name","value":"npm"}}]}}]}}]} as unknown as DocumentNode<GetModelsDevProvidersQuery, GetModelsDevProvidersQueryVariables>;
-export const GetModelsDevSuggestionsDocument = {"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"query","name":{"kind":"Name","value":"GetModelsDevSuggestions"},"variableDefinitions":[{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"providerType"}},"type":{"kind":"NonNullType","type":{"kind":"NamedType","name":{"kind":"Name","value":"String"}}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"getModelsDevSuggestions"},"arguments":[{"kind":"Argument","name":{"kind":"Name","value":"providerType"},"value":{"kind":"Variable","name":{"kind":"Name","value":"providerType"}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"modelId"}},{"kind":"Field","name":{"kind":"Name","value":"name"}},{"kind":"Field","name":{"kind":"Name","value":"inputCostPerMillionTokens"}},{"kind":"Field","name":{"kind":"Name","value":"outputCostPerMillionTokens"}},{"kind":"Field","name":{"kind":"Name","value":"cachedInputCostPerMillionTokens"}},{"kind":"Field","name":{"kind":"Name","value":"cacheCreationCostPerMillionTokens"}},{"kind":"Field","name":{"kind":"Name","value":"contextWindowTokens"}},{"kind":"Field","name":{"kind":"Name","value":"maxOutputTokens"}},{"kind":"Field","name":{"kind":"Name","value":"modalities"}},{"kind":"Field","name":{"kind":"Name","value":"supportsReasoning"}}]}}]}}]} as unknown as DocumentNode<GetModelsDevSuggestionsQuery, GetModelsDevSuggestionsQueryVariables>;
-export const FindAllApplicationRegistrationsDocument = {"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"query","name":{"kind":"Name","value":"FindAllApplicationRegistrations"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"findAllApplicationRegistrations"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"FragmentSpread","name":{"kind":"Name","value":"ApplicationRegistrationFragment"}}]}}]}},{"kind":"FragmentDefinition","name":{"kind":"Name","value":"ApplicationRegistrationFragment"},"typeCondition":{"kind":"NamedType","name":{"kind":"Name","value":"ApplicationRegistration"}},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"id"}},{"kind":"Field","name":{"kind":"Name","value":"universalIdentifier"}},{"kind":"Field","name":{"kind":"Name","value":"name"}},{"kind":"Field","name":{"kind":"Name","value":"oAuthClientId"}},{"kind":"Field","name":{"kind":"Name","value":"oAuthRedirectUris"}},{"kind":"Field","name":{"kind":"Name","value":"oAuthScopes"}},{"kind":"Field","name":{"kind":"Name","value":"sourceType"}},{"kind":"Field","name":{"kind":"Name","value":"sourcePackage"}},{"kind":"Field","name":{"kind":"Name","value":"latestAvailableVersion"}},{"kind":"Field","name":{"kind":"Name","value":"isListed"}},{"kind":"Field","name":{"kind":"Name","value":"isFeatured"}},{"kind":"Field","name":{"kind":"Name","value":"ownerWorkspaceId"}},{"kind":"Field","name":{"kind":"Name","value":"createdAt"}},{"kind":"Field","name":{"kind":"Name","value":"updatedAt"}}]}}]} as unknown as DocumentNode<FindAllApplicationRegistrationsQuery, FindAllApplicationRegistrationsQueryVariables>;
-export const CreateDatabaseConfigVariableDocument = {"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"mutation","name":{"kind":"Name","value":"CreateDatabaseConfigVariable"},"variableDefinitions":[{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"key"}},"type":{"kind":"NonNullType","type":{"kind":"NamedType","name":{"kind":"Name","value":"String"}}}},{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"value"}},"type":{"kind":"NonNullType","type":{"kind":"NamedType","name":{"kind":"Name","value":"JSON"}}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"createDatabaseConfigVariable"},"arguments":[{"kind":"Argument","name":{"kind":"Name","value":"key"},"value":{"kind":"Variable","name":{"kind":"Name","value":"key"}}},{"kind":"Argument","name":{"kind":"Name","value":"value"},"value":{"kind":"Variable","name":{"kind":"Name","value":"value"}}}]}]}}]} as unknown as DocumentNode<CreateDatabaseConfigVariableMutation, CreateDatabaseConfigVariableMutationVariables>;
-export const DeleteDatabaseConfigVariableDocument = {"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"mutation","name":{"kind":"Name","value":"DeleteDatabaseConfigVariable"},"variableDefinitions":[{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"key"}},"type":{"kind":"NonNullType","type":{"kind":"NamedType","name":{"kind":"Name","value":"String"}}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"deleteDatabaseConfigVariable"},"arguments":[{"kind":"Argument","name":{"kind":"Name","value":"key"},"value":{"kind":"Variable","name":{"kind":"Name","value":"key"}}}]}]}}]} as unknown as DocumentNode<DeleteDatabaseConfigVariableMutation, DeleteDatabaseConfigVariableMutationVariables>;
-export const UpdateDatabaseConfigVariableDocument = {"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"mutation","name":{"kind":"Name","value":"UpdateDatabaseConfigVariable"},"variableDefinitions":[{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"key"}},"type":{"kind":"NonNullType","type":{"kind":"NamedType","name":{"kind":"Name","value":"String"}}}},{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"value"}},"type":{"kind":"NonNullType","type":{"kind":"NamedType","name":{"kind":"Name","value":"JSON"}}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"updateDatabaseConfigVariable"},"arguments":[{"kind":"Argument","name":{"kind":"Name","value":"key"},"value":{"kind":"Variable","name":{"kind":"Name","value":"key"}}},{"kind":"Argument","name":{"kind":"Name","value":"value"},"value":{"kind":"Variable","name":{"kind":"Name","value":"value"}}}]}]}}]} as unknown as DocumentNode<UpdateDatabaseConfigVariableMutation, UpdateDatabaseConfigVariableMutationVariables>;
-export const GetConfigVariablesGroupedDocument = {"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"query","name":{"kind":"Name","value":"GetConfigVariablesGrouped"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"getConfigVariablesGrouped"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"groups"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"name"}},{"kind":"Field","name":{"kind":"Name","value":"description"}},{"kind":"Field","name":{"kind":"Name","value":"isHiddenOnLoad"}},{"kind":"Field","name":{"kind":"Name","value":"variables"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"name"}},{"kind":"Field","name":{"kind":"Name","value":"description"}},{"kind":"Field","name":{"kind":"Name","value":"value"}},{"kind":"Field","name":{"kind":"Name","value":"isSensitive"}},{"kind":"Field","name":{"kind":"Name","value":"isEnvOnly"}},{"kind":"Field","name":{"kind":"Name","value":"type"}},{"kind":"Field","name":{"kind":"Name","value":"options"}},{"kind":"Field","name":{"kind":"Name","value":"source"}}]}}]}}]}}]}}]} as unknown as DocumentNode<GetConfigVariablesGroupedQuery, GetConfigVariablesGroupedQueryVariables>;
-export const GetDatabaseConfigVariableDocument = {"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"query","name":{"kind":"Name","value":"GetDatabaseConfigVariable"},"variableDefinitions":[{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"key"}},"type":{"kind":"NonNullType","type":{"kind":"NamedType","name":{"kind":"Name","value":"String"}}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"getDatabaseConfigVariable"},"arguments":[{"kind":"Argument","name":{"kind":"Name","value":"key"},"value":{"kind":"Variable","name":{"kind":"Name","value":"key"}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"name"}},{"kind":"Field","name":{"kind":"Name","value":"description"}},{"kind":"Field","name":{"kind":"Name","value":"value"}},{"kind":"Field","name":{"kind":"Name","value":"isSensitive"}},{"kind":"Field","name":{"kind":"Name","value":"isEnvOnly"}},{"kind":"Field","name":{"kind":"Name","value":"type"}},{"kind":"Field","name":{"kind":"Name","value":"options"}},{"kind":"Field","name":{"kind":"Name","value":"source"}}]}}]}}]} as unknown as DocumentNode<GetDatabaseConfigVariableQuery, GetDatabaseConfigVariableQueryVariables>;
-export const UpdateWorkspaceFeatureFlagDocument = {"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"mutation","name":{"kind":"Name","value":"UpdateWorkspaceFeatureFlag"},"variableDefinitions":[{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"workspaceId"}},"type":{"kind":"NonNullType","type":{"kind":"NamedType","name":{"kind":"Name","value":"UUID"}}}},{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"featureFlag"}},"type":{"kind":"NonNullType","type":{"kind":"NamedType","name":{"kind":"Name","value":"String"}}}},{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"value"}},"type":{"kind":"NonNullType","type":{"kind":"NamedType","name":{"kind":"Name","value":"Boolean"}}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"updateWorkspaceFeatureFlag"},"arguments":[{"kind":"Argument","name":{"kind":"Name","value":"workspaceId"},"value":{"kind":"Variable","name":{"kind":"Name","value":"workspaceId"}}},{"kind":"Argument","name":{"kind":"Name","value":"featureFlag"},"value":{"kind":"Variable","name":{"kind":"Name","value":"featureFlag"}}},{"kind":"Argument","name":{"kind":"Name","value":"value"},"value":{"kind":"Variable","name":{"kind":"Name","value":"value"}}}]}]}}]} as unknown as DocumentNode<UpdateWorkspaceFeatureFlagMutation, UpdateWorkspaceFeatureFlagMutationVariables>;
-export const AdminPanelRecentUsersDocument = {"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"query","name":{"kind":"Name","value":"AdminPanelRecentUsers"},"variableDefinitions":[{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"searchTerm"}},"type":{"kind":"NamedType","name":{"kind":"Name","value":"String"}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"adminPanelRecentUsers"},"arguments":[{"kind":"Argument","name":{"kind":"Name","value":"searchTerm"},"value":{"kind":"Variable","name":{"kind":"Name","value":"searchTerm"}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"id"}},{"kind":"Field","name":{"kind":"Name","value":"email"}},{"kind":"Field","name":{"kind":"Name","value":"firstName"}},{"kind":"Field","name":{"kind":"Name","value":"lastName"}},{"kind":"Field","name":{"kind":"Name","value":"createdAt"}},{"kind":"Field","name":{"kind":"Name","value":"workspaceName"}},{"kind":"Field","name":{"kind":"Name","value":"workspaceId"}}]}}]}}]} as unknown as DocumentNode<AdminPanelRecentUsersQuery, AdminPanelRecentUsersQueryVariables>;
-export const AdminPanelTopWorkspacesDocument = {"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"query","name":{"kind":"Name","value":"AdminPanelTopWorkspaces"},"variableDefinitions":[{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"searchTerm"}},"type":{"kind":"NamedType","name":{"kind":"Name","value":"String"}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"adminPanelTopWorkspaces"},"arguments":[{"kind":"Argument","name":{"kind":"Name","value":"searchTerm"},"value":{"kind":"Variable","name":{"kind":"Name","value":"searchTerm"}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"id"}},{"kind":"Field","name":{"kind":"Name","value":"name"}},{"kind":"Field","name":{"kind":"Name","value":"totalUsers"}},{"kind":"Field","name":{"kind":"Name","value":"subdomain"}}]}}]}}]} as unknown as DocumentNode<AdminPanelTopWorkspacesQuery, AdminPanelTopWorkspacesQueryVariables>;
-export const FindOneAdminApplicationRegistrationDocument = {"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"query","name":{"kind":"Name","value":"FindOneAdminApplicationRegistration"},"variableDefinitions":[{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"id"}},"type":{"kind":"NonNullType","type":{"kind":"NamedType","name":{"kind":"Name","value":"String"}}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"findOneAdminApplicationRegistration"},"arguments":[{"kind":"Argument","name":{"kind":"Name","value":"id"},"value":{"kind":"Variable","name":{"kind":"Name","value":"id"}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"FragmentSpread","name":{"kind":"Name","value":"ApplicationRegistrationFragment"}}]}}]}},{"kind":"FragmentDefinition","name":{"kind":"Name","value":"ApplicationRegistrationFragment"},"typeCondition":{"kind":"NamedType","name":{"kind":"Name","value":"ApplicationRegistration"}},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"id"}},{"kind":"Field","name":{"kind":"Name","value":"universalIdentifier"}},{"kind":"Field","name":{"kind":"Name","value":"name"}},{"kind":"Field","name":{"kind":"Name","value":"oAuthClientId"}},{"kind":"Field","name":{"kind":"Name","value":"oAuthRedirectUris"}},{"kind":"Field","name":{"kind":"Name","value":"oAuthScopes"}},{"kind":"Field","name":{"kind":"Name","value":"sourceType"}},{"kind":"Field","name":{"kind":"Name","value":"sourcePackage"}},{"kind":"Field","name":{"kind":"Name","value":"latestAvailableVersion"}},{"kind":"Field","name":{"kind":"Name","value":"isListed"}},{"kind":"Field","name":{"kind":"Name","value":"isFeatured"}},{"kind":"Field","name":{"kind":"Name","value":"ownerWorkspaceId"}},{"kind":"Field","name":{"kind":"Name","value":"createdAt"}},{"kind":"Field","name":{"kind":"Name","value":"updatedAt"}}]}}]} as unknown as DocumentNode<FindOneAdminApplicationRegistrationQuery, FindOneAdminApplicationRegistrationQueryVariables>;
-export const GetAdminChatThreadMessagesDocument = {"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"query","name":{"kind":"Name","value":"GetAdminChatThreadMessages"},"variableDefinitions":[{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"threadId"}},"type":{"kind":"NonNullType","type":{"kind":"NamedType","name":{"kind":"Name","value":"UUID"}}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"getAdminChatThreadMessages"},"arguments":[{"kind":"Argument","name":{"kind":"Name","value":"threadId"},"value":{"kind":"Variable","name":{"kind":"Name","value":"threadId"}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"thread"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"id"}},{"kind":"Field","name":{"kind":"Name","value":"title"}},{"kind":"Field","name":{"kind":"Name","value":"totalInputTokens"}},{"kind":"Field","name":{"kind":"Name","value":"totalOutputTokens"}},{"kind":"Field","name":{"kind":"Name","value":"conversationSize"}},{"kind":"Field","name":{"kind":"Name","value":"createdAt"}},{"kind":"Field","name":{"kind":"Name","value":"updatedAt"}}]}},{"kind":"Field","name":{"kind":"Name","value":"messages"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"id"}},{"kind":"Field","name":{"kind":"Name","value":"role"}},{"kind":"Field","name":{"kind":"Name","value":"parts"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"type"}},{"kind":"Field","name":{"kind":"Name","value":"textContent"}},{"kind":"Field","name":{"kind":"Name","value":"toolName"}}]}},{"kind":"Field","name":{"kind":"Name","value":"createdAt"}}]}}]}}]}}]} as unknown as DocumentNode<GetAdminChatThreadMessagesQuery, GetAdminChatThreadMessagesQueryVariables>;
-export const GetAdminWorkspaceChatThreadsDocument = {"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"query","name":{"kind":"Name","value":"GetAdminWorkspaceChatThreads"},"variableDefinitions":[{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"workspaceId"}},"type":{"kind":"NonNullType","type":{"kind":"NamedType","name":{"kind":"Name","value":"UUID"}}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"getAdminWorkspaceChatThreads"},"arguments":[{"kind":"Argument","name":{"kind":"Name","value":"workspaceId"},"value":{"kind":"Variable","name":{"kind":"Name","value":"workspaceId"}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"id"}},{"kind":"Field","name":{"kind":"Name","value":"title"}},{"kind":"Field","name":{"kind":"Name","value":"totalInputTokens"}},{"kind":"Field","name":{"kind":"Name","value":"totalOutputTokens"}},{"kind":"Field","name":{"kind":"Name","value":"conversationSize"}},{"kind":"Field","name":{"kind":"Name","value":"createdAt"}},{"kind":"Field","name":{"kind":"Name","value":"updatedAt"}}]}}]}}]} as unknown as DocumentNode<GetAdminWorkspaceChatThreadsQuery, GetAdminWorkspaceChatThreadsQueryVariables>;
-export const GetVersionInfoDocument = {"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"query","name":{"kind":"Name","value":"GetVersionInfo"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"versionInfo"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"currentVersion"}},{"kind":"Field","name":{"kind":"Name","value":"latestVersion"}}]}}]}}]} as unknown as DocumentNode<GetVersionInfoQuery, GetVersionInfoQueryVariables>;
-export const UserLookupAdminPanelDocument = {"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"query","name":{"kind":"Name","value":"UserLookupAdminPanel"},"variableDefinitions":[{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"userIdentifier"}},"type":{"kind":"NonNullType","type":{"kind":"NamedType","name":{"kind":"Name","value":"String"}}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"userLookupAdminPanel"},"arguments":[{"kind":"Argument","name":{"kind":"Name","value":"userIdentifier"},"value":{"kind":"Variable","name":{"kind":"Name","value":"userIdentifier"}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"user"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"FragmentSpread","name":{"kind":"Name","value":"UserInfoFragment"}}]}},{"kind":"Field","name":{"kind":"Name","value":"workspaces"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"id"}},{"kind":"Field","name":{"kind":"Name","value":"name"}},{"kind":"Field","name":{"kind":"Name","value":"logo"}},{"kind":"Field","name":{"kind":"Name","value":"totalUsers"}},{"kind":"Field","name":{"kind":"Name","value":"activationStatus"}},{"kind":"Field","name":{"kind":"Name","value":"createdAt"}},{"kind":"Field","name":{"kind":"Name","value":"allowImpersonation"}},{"kind":"Field","name":{"kind":"Name","value":"workspaceUrls"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"customUrl"}},{"kind":"Field","name":{"kind":"Name","value":"subdomainUrl"}}]}},{"kind":"Field","name":{"kind":"Name","value":"users"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"id"}},{"kind":"Field","name":{"kind":"Name","value":"email"}},{"kind":"Field","name":{"kind":"Name","value":"firstName"}},{"kind":"Field","name":{"kind":"Name","value":"lastName"}}]}},{"kind":"Field","name":{"kind":"Name","value":"featureFlags"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"key"}},{"kind":"Field","name":{"kind":"Name","value":"value"}}]}}]}}]}}]}},{"kind":"FragmentDefinition","name":{"kind":"Name","value":"UserInfoFragment"},"typeCondition":{"kind":"NamedType","name":{"kind":"Name","value":"UserInfo"}},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"id"}},{"kind":"Field","name":{"kind":"Name","value":"email"}},{"kind":"Field","name":{"kind":"Name","value":"firstName"}},{"kind":"Field","name":{"kind":"Name","value":"lastName"}},{"kind":"Field","name":{"kind":"Name","value":"createdAt"}}]}}]} as unknown as DocumentNode<UserLookupAdminPanelQuery, UserLookupAdminPanelQueryVariables>;
-export const WorkspaceLookupAdminPanelDocument = {"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"query","name":{"kind":"Name","value":"WorkspaceLookupAdminPanel"},"variableDefinitions":[{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"workspaceId"}},"type":{"kind":"NonNullType","type":{"kind":"NamedType","name":{"kind":"Name","value":"UUID"}}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"workspaceLookupAdminPanel"},"arguments":[{"kind":"Argument","name":{"kind":"Name","value":"workspaceId"},"value":{"kind":"Variable","name":{"kind":"Name","value":"workspaceId"}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"user"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"FragmentSpread","name":{"kind":"Name","value":"UserInfoFragment"}}]}},{"kind":"Field","name":{"kind":"Name","value":"workspaces"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"id"}},{"kind":"Field","name":{"kind":"Name","value":"name"}},{"kind":"Field","name":{"kind":"Name","value":"allowImpersonation"}},{"kind":"Field","name":{"kind":"Name","value":"logo"}},{"kind":"Field","name":{"kind":"Name","value":"totalUsers"}},{"kind":"Field","name":{"kind":"Name","value":"activationStatus"}},{"kind":"Field","name":{"kind":"Name","value":"createdAt"}},{"kind":"Field","name":{"kind":"Name","value":"workspaceUrls"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"customUrl"}},{"kind":"Field","name":{"kind":"Name","value":"subdomainUrl"}}]}},{"kind":"Field","name":{"kind":"Name","value":"users"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"id"}},{"kind":"Field","name":{"kind":"Name","value":"email"}},{"kind":"Field","name":{"kind":"Name","value":"firstName"}},{"kind":"Field","name":{"kind":"Name","value":"lastName"}}]}},{"kind":"Field","name":{"kind":"Name","value":"featureFlags"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"key"}},{"kind":"Field","name":{"kind":"Name","value":"value"}}]}}]}}]}}]}},{"kind":"FragmentDefinition","name":{"kind":"Name","value":"UserInfoFragment"},"typeCondition":{"kind":"NamedType","name":{"kind":"Name","value":"UserInfo"}},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"id"}},{"kind":"Field","name":{"kind":"Name","value":"email"}},{"kind":"Field","name":{"kind":"Name","value":"firstName"}},{"kind":"Field","name":{"kind":"Name","value":"lastName"}},{"kind":"Field","name":{"kind":"Name","value":"createdAt"}}]}}]} as unknown as DocumentNode<WorkspaceLookupAdminPanelQuery, WorkspaceLookupAdminPanelQueryVariables>;
-export const DeleteJobsDocument = {"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"mutation","name":{"kind":"Name","value":"DeleteJobs"},"variableDefinitions":[{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"queueName"}},"type":{"kind":"NonNullType","type":{"kind":"NamedType","name":{"kind":"Name","value":"String"}}}},{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"jobIds"}},"type":{"kind":"NonNullType","type":{"kind":"ListType","type":{"kind":"NonNullType","type":{"kind":"NamedType","name":{"kind":"Name","value":"String"}}}}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"deleteJobs"},"arguments":[{"kind":"Argument","name":{"kind":"Name","value":"queueName"},"value":{"kind":"Variable","name":{"kind":"Name","value":"queueName"}}},{"kind":"Argument","name":{"kind":"Name","value":"jobIds"},"value":{"kind":"Variable","name":{"kind":"Name","value":"jobIds"}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"deletedCount"}},{"kind":"Field","name":{"kind":"Name","value":"results"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"jobId"}},{"kind":"Field","name":{"kind":"Name","value":"success"}},{"kind":"Field","name":{"kind":"Name","value":"error"}}]}}]}}]}}]} as unknown as DocumentNode<DeleteJobsMutation, DeleteJobsMutationVariables>;
-export const RetryJobsDocument = {"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"mutation","name":{"kind":"Name","value":"RetryJobs"},"variableDefinitions":[{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"queueName"}},"type":{"kind":"NonNullType","type":{"kind":"NamedType","name":{"kind":"Name","value":"String"}}}},{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"jobIds"}},"type":{"kind":"NonNullType","type":{"kind":"ListType","type":{"kind":"NonNullType","type":{"kind":"NamedType","name":{"kind":"Name","value":"String"}}}}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"retryJobs"},"arguments":[{"kind":"Argument","name":{"kind":"Name","value":"queueName"},"value":{"kind":"Variable","name":{"kind":"Name","value":"queueName"}}},{"kind":"Argument","name":{"kind":"Name","value":"jobIds"},"value":{"kind":"Variable","name":{"kind":"Name","value":"jobIds"}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"retriedCount"}},{"kind":"Field","name":{"kind":"Name","value":"results"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"jobId"}},{"kind":"Field","name":{"kind":"Name","value":"success"}},{"kind":"Field","name":{"kind":"Name","value":"error"}}]}}]}}]}}]} as unknown as DocumentNode<RetryJobsMutation, RetryJobsMutationVariables>;
-export const GetIndicatorHealthStatusDocument = {"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"query","name":{"kind":"Name","value":"GetIndicatorHealthStatus"},"variableDefinitions":[{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"indicatorId"}},"type":{"kind":"NonNullType","type":{"kind":"NamedType","name":{"kind":"Name","value":"HealthIndicatorId"}}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"getIndicatorHealthStatus"},"arguments":[{"kind":"Argument","name":{"kind":"Name","value":"indicatorId"},"value":{"kind":"Variable","name":{"kind":"Name","value":"indicatorId"}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"id"}},{"kind":"Field","name":{"kind":"Name","value":"label"}},{"kind":"Field","name":{"kind":"Name","value":"description"}},{"kind":"Field","name":{"kind":"Name","value":"status"}},{"kind":"Field","name":{"kind":"Name","value":"errorMessage"}},{"kind":"Field","name":{"kind":"Name","value":"details"}},{"kind":"Field","name":{"kind":"Name","value":"queues"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"id"}},{"kind":"Field","name":{"kind":"Name","value":"queueName"}},{"kind":"Field","name":{"kind":"Name","value":"status"}}]}}]}}]}}]} as unknown as DocumentNode<GetIndicatorHealthStatusQuery, GetIndicatorHealthStatusQueryVariables>;
-export const GetQueueJobsDocument = {"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"query","name":{"kind":"Name","value":"GetQueueJobs"},"variableDefinitions":[{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"queueName"}},"type":{"kind":"NonNullType","type":{"kind":"NamedType","name":{"kind":"Name","value":"String"}}}},{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"state"}},"type":{"kind":"NonNullType","type":{"kind":"NamedType","name":{"kind":"Name","value":"JobState"}}}},{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"limit"}},"type":{"kind":"NamedType","name":{"kind":"Name","value":"Int"}}},{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"offset"}},"type":{"kind":"NamedType","name":{"kind":"Name","value":"Int"}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"getQueueJobs"},"arguments":[{"kind":"Argument","name":{"kind":"Name","value":"queueName"},"value":{"kind":"Variable","name":{"kind":"Name","value":"queueName"}}},{"kind":"Argument","name":{"kind":"Name","value":"state"},"value":{"kind":"Variable","name":{"kind":"Name","value":"state"}}},{"kind":"Argument","name":{"kind":"Name","value":"limit"},"value":{"kind":"Variable","name":{"kind":"Name","value":"limit"}}},{"kind":"Argument","name":{"kind":"Name","value":"offset"},"value":{"kind":"Variable","name":{"kind":"Name","value":"offset"}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"jobs"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"id"}},{"kind":"Field","name":{"kind":"Name","value":"name"}},{"kind":"Field","name":{"kind":"Name","value":"data"}},{"kind":"Field","name":{"kind":"Name","value":"state"}},{"kind":"Field","name":{"kind":"Name","value":"timestamp"}},{"kind":"Field","name":{"kind":"Name","value":"failedReason"}},{"kind":"Field","name":{"kind":"Name","value":"processedOn"}},{"kind":"Field","name":{"kind":"Name","value":"finishedOn"}},{"kind":"Field","name":{"kind":"Name","value":"attemptsMade"}},{"kind":"Field","name":{"kind":"Name","value":"returnValue"}},{"kind":"Field","name":{"kind":"Name","value":"logs"}},{"kind":"Field","name":{"kind":"Name","value":"stackTrace"}}]}},{"kind":"Field","name":{"kind":"Name","value":"count"}},{"kind":"Field","name":{"kind":"Name","value":"totalCount"}},{"kind":"Field","name":{"kind":"Name","value":"hasMore"}},{"kind":"Field","name":{"kind":"Name","value":"retentionConfig"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"completedMaxAge"}},{"kind":"Field","name":{"kind":"Name","value":"completedMaxCount"}},{"kind":"Field","name":{"kind":"Name","value":"failedMaxAge"}},{"kind":"Field","name":{"kind":"Name","value":"failedMaxCount"}}]}}]}}]}}]} as unknown as DocumentNode<GetQueueJobsQuery, GetQueueJobsQueryVariables>;
-export const GetQueueMetricsDocument = {"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"query","name":{"kind":"Name","value":"GetQueueMetrics"},"variableDefinitions":[{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"queueName"}},"type":{"kind":"NonNullType","type":{"kind":"NamedType","name":{"kind":"Name","value":"String"}}}},{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"timeRange"}},"type":{"kind":"NamedType","name":{"kind":"Name","value":"QueueMetricsTimeRange"}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"getQueueMetrics"},"arguments":[{"kind":"Argument","name":{"kind":"Name","value":"queueName"},"value":{"kind":"Variable","name":{"kind":"Name","value":"queueName"}}},{"kind":"Argument","name":{"kind":"Name","value":"timeRange"},"value":{"kind":"Variable","name":{"kind":"Name","value":"timeRange"}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"queueName"}},{"kind":"Field","name":{"kind":"Name","value":"timeRange"}},{"kind":"Field","name":{"kind":"Name","value":"workers"}},{"kind":"Field","name":{"kind":"Name","value":"details"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"failed"}},{"kind":"Field","name":{"kind":"Name","value":"completed"}},{"kind":"Field","name":{"kind":"Name","value":"waiting"}},{"kind":"Field","name":{"kind":"Name","value":"active"}},{"kind":"Field","name":{"kind":"Name","value":"delayed"}},{"kind":"Field","name":{"kind":"Name","value":"failureRate"}}]}},{"kind":"Field","name":{"kind":"Name","value":"data"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"id"}},{"kind":"Field","name":{"kind":"Name","value":"data"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"x"}},{"kind":"Field","name":{"kind":"Name","value":"y"}}]}}]}}]}}]}}]} as unknown as DocumentNode<GetQueueMetricsQuery, GetQueueMetricsQueryVariables>;
-export const GetSystemHealthStatusDocument = {"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"query","name":{"kind":"Name","value":"GetSystemHealthStatus"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"getSystemHealthStatus"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"services"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"id"}},{"kind":"Field","name":{"kind":"Name","value":"label"}},{"kind":"Field","name":{"kind":"Name","value":"status"}}]}}]}}]}}]} as unknown as DocumentNode<GetSystemHealthStatusQuery, GetSystemHealthStatusQueryVariables>;
-export const ClearMaintenanceModeDocument = {"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"mutation","name":{"kind":"Name","value":"ClearMaintenanceMode"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"clearMaintenanceMode"}}]}}]} as unknown as DocumentNode<ClearMaintenanceModeMutation, ClearMaintenanceModeMutationVariables>;
-export const SetMaintenanceModeDocument = {"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"mutation","name":{"kind":"Name","value":"SetMaintenanceMode"},"variableDefinitions":[{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"startAt"}},"type":{"kind":"NonNullType","type":{"kind":"NamedType","name":{"kind":"Name","value":"DateTime"}}}},{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"endAt"}},"type":{"kind":"NonNullType","type":{"kind":"NamedType","name":{"kind":"Name","value":"DateTime"}}}},{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"link"}},"type":{"kind":"NamedType","name":{"kind":"Name","value":"String"}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"setMaintenanceMode"},"arguments":[{"kind":"Argument","name":{"kind":"Name","value":"startAt"},"value":{"kind":"Variable","name":{"kind":"Name","value":"startAt"}}},{"kind":"Argument","name":{"kind":"Name","value":"endAt"},"value":{"kind":"Variable","name":{"kind":"Name","value":"endAt"}}},{"kind":"Argument","name":{"kind":"Name","value":"link"},"value":{"kind":"Variable","name":{"kind":"Name","value":"link"}}}]}]}}]} as unknown as DocumentNode<SetMaintenanceModeMutation, SetMaintenanceModeMutationVariables>;
-export const GetMaintenanceModeDocument = {"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"query","name":{"kind":"Name","value":"GetMaintenanceMode"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"getMaintenanceMode"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"startAt"}},{"kind":"Field","name":{"kind":"Name","value":"endAt"}},{"kind":"Field","name":{"kind":"Name","value":"link"}}]}}]}}]} as unknown as DocumentNode<GetMaintenanceModeQuery, GetMaintenanceModeQueryVariables>;
 export const DeleteApplicationRegistrationDocument = {"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"mutation","name":{"kind":"Name","value":"DeleteApplicationRegistration"},"variableDefinitions":[{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"id"}},"type":{"kind":"NonNullType","type":{"kind":"NamedType","name":{"kind":"Name","value":"String"}}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"deleteApplicationRegistration"},"arguments":[{"kind":"Argument","name":{"kind":"Name","value":"id"},"value":{"kind":"Variable","name":{"kind":"Name","value":"id"}}}]}]}}]} as unknown as DocumentNode<DeleteApplicationRegistrationMutation, DeleteApplicationRegistrationMutationVariables>;
 export const RotateApplicationRegistrationClientSecretDocument = {"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"mutation","name":{"kind":"Name","value":"RotateApplicationRegistrationClientSecret"},"variableDefinitions":[{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"id"}},"type":{"kind":"NonNullType","type":{"kind":"NamedType","name":{"kind":"Name","value":"String"}}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"rotateApplicationRegistrationClientSecret"},"arguments":[{"kind":"Argument","name":{"kind":"Name","value":"id"},"value":{"kind":"Variable","name":{"kind":"Name","value":"id"}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"clientSecret"}}]}}]}}]} as unknown as DocumentNode<RotateApplicationRegistrationClientSecretMutation, RotateApplicationRegistrationClientSecretMutationVariables>;
 export const TransferApplicationRegistrationOwnershipDocument = {"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"mutation","name":{"kind":"Name","value":"TransferApplicationRegistrationOwnership"},"variableDefinitions":[{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"applicationRegistrationId"}},"type":{"kind":"NonNullType","type":{"kind":"NamedType","name":{"kind":"Name","value":"String"}}}},{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"targetWorkspaceSubdomain"}},"type":{"kind":"NonNullType","type":{"kind":"NamedType","name":{"kind":"Name","value":"String"}}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"transferApplicationRegistrationOwnership"},"arguments":[{"kind":"Argument","name":{"kind":"Name","value":"applicationRegistrationId"},"value":{"kind":"Variable","name":{"kind":"Name","value":"applicationRegistrationId"}}},{"kind":"Argument","name":{"kind":"Name","value":"targetWorkspaceSubdomain"},"value":{"kind":"Variable","name":{"kind":"Name","value":"targetWorkspaceSubdomain"}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"id"}},{"kind":"Field","name":{"kind":"Name","value":"name"}}]}}]}}]} as unknown as DocumentNode<TransferApplicationRegistrationOwnershipMutation, TransferApplicationRegistrationOwnershipMutationVariables>;

--- a/packages/twenty-front/src/modules/app/components/AppRouterProviders.tsx
+++ b/packages/twenty-front/src/modules/app/components/AppRouterProviders.tsx
@@ -18,6 +18,7 @@ import { MinimalMetadataLoadEffect } from '@/metadata-store/effect-components/Mi
 import { UserMetadataProviderInitialEffect } from '@/metadata-store/effect-components/UserMetadataProviderInitialEffect';
 import { ApolloCoreProvider } from '@/object-metadata/components/ApolloCoreProvider';
 import { PreComputedChipGeneratorsProvider } from '@/object-metadata/components/PreComputedChipGeneratorsProvider';
+import { ApolloAdminProvider } from '@/settings/admin-panel/apollo/components/ApolloAdminProvider';
 
 import { CommandRunner } from '@/command-menu-item/engine-command/components/CommandRunner';
 import { SSEProvider } from '@/sse-db-event/components/SSEProvider';
@@ -52,36 +53,38 @@ export const AppRouterProviders = () => {
             <MinimalMetadataGater>
               <AuthProvider>
                 <ApolloCoreProvider>
-                  <SSEProvider>
-                    <PreComputedChipGeneratorsProvider>
-                      <UserThemeProviderEffect />
-                      <SnackBarProvider>
-                        <ErrorMessageEffect />
-                        <AgentChatProvider>
-                          <DialogComponentInstanceContext.Provider
-                            value={{ instanceId: 'dialog-manager' }}
-                          >
-                            <DialogManager>
-                              <StrictMode>
-                                <PromiseRejectionEffect />
-                                <GotoHotkeysEffectsProvider />
-                                <PageTitle title={pageTitle} />
-                                <PageFavicon />
-                                <Outlet />
-                                <GlobalFilePreviewModal />
-                                <CommandMenuConfirmationModalManager />
-                                <CommandRunner />
-                              </StrictMode>
-                            </DialogManager>
-                          </DialogComponentInstanceContext.Provider>
-                        </AgentChatProvider>
-                      </SnackBarProvider>
-                      <MainContextStoreProvider />
-                      <SupportChatEffect />
-                      <PageChangeEffect />
-                      <SignOutOnOtherTabSignOutEffect />
-                    </PreComputedChipGeneratorsProvider>
-                  </SSEProvider>
+                  <ApolloAdminProvider>
+                    <SSEProvider>
+                      <PreComputedChipGeneratorsProvider>
+                        <UserThemeProviderEffect />
+                        <SnackBarProvider>
+                          <ErrorMessageEffect />
+                          <AgentChatProvider>
+                            <DialogComponentInstanceContext.Provider
+                              value={{ instanceId: 'dialog-manager' }}
+                            >
+                              <DialogManager>
+                                <StrictMode>
+                                  <PromiseRejectionEffect />
+                                  <GotoHotkeysEffectsProvider />
+                                  <PageTitle title={pageTitle} />
+                                  <PageFavicon />
+                                  <Outlet />
+                                  <GlobalFilePreviewModal />
+                                  <CommandMenuConfirmationModalManager />
+                                  <CommandRunner />
+                                </StrictMode>
+                              </DialogManager>
+                            </DialogComponentInstanceContext.Provider>
+                          </AgentChatProvider>
+                        </SnackBarProvider>
+                        <MainContextStoreProvider />
+                        <SupportChatEffect />
+                        <PageChangeEffect />
+                        <SignOutOnOtherTabSignOutEffect />
+                      </PreComputedChipGeneratorsProvider>
+                    </SSEProvider>
+                  </ApolloAdminProvider>
                 </ApolloCoreProvider>
               </AuthProvider>
             </MinimalMetadataGater>

--- a/packages/twenty-front/src/modules/settings/admin-panel/ai/components/SettingsAdminAI.tsx
+++ b/packages/twenty-front/src/modules/settings/admin-panel/ai/components/SettingsAdminAI.tsx
@@ -13,6 +13,7 @@ import { currentWorkspaceState } from '@/auth/states/currentWorkspaceState';
 import { billingState } from '@/client-config/states/billingState';
 import { useClientConfig } from '@/client-config/hooks/useClientConfig';
 import { SettingsAiModelsTable } from '@/settings/ai/components/SettingsAiModelsTable';
+import { useApolloAdminClient } from '@/settings/admin-panel/apollo/hooks/useApolloAdminClient';
 import { SettingsAdminAiProviderListCard } from '@/settings/admin-panel/ai/components/SettingsAdminAiProviderListCard';
 import { AI_PROVIDER_SOURCE } from '@/settings/admin-panel/ai/constants/AiProviderSource';
 import { SET_ADMIN_AI_MODEL_RECOMMENDED } from '@/settings/admin-panel/ai/graphql/mutations/setAdminAiModelRecommended';
@@ -42,7 +43,7 @@ import { GenericDropdownContentWidth } from '@/ui/layout/dropdown/constants/Gene
 import {
   AiModelRole,
   type AdminAiModelConfig,
-} from '~/generated-metadata/graphql';
+} from '~/generated-admin/graphql';
 
 const USAGE_TABLE_GRID_TEMPLATE_COLUMNS = '1fr 120px';
 
@@ -53,6 +54,7 @@ type UsageBreakdownItem = {
 };
 
 export const SettingsAdminAI = () => {
+  const apolloAdminClient = useApolloAdminClient();
   const { enqueueErrorSnackBar } = useSnackBar();
   const { refetch: refetchClientConfig } = useClientConfig();
   const { formatUsageValue } = useUsageValueFormatter();
@@ -75,18 +77,27 @@ export const SettingsAdminAI = () => {
       defaultFastModelId?: string | null;
       models: AdminAiModelConfig[];
     };
-  }>(GET_ADMIN_AI_MODELS);
+  }>(GET_ADMIN_AI_MODELS, { client: apolloAdminClient });
 
-  const [setModelRecommended] = useMutation(SET_ADMIN_AI_MODEL_RECOMMENDED);
-  const [setModelsRecommended] = useMutation(SET_ADMIN_AI_MODELS_RECOMMENDED);
-  const [setDefaultModel] = useMutation(SET_ADMIN_DEFAULT_AI_MODEL);
+  const [setModelRecommended] = useMutation(SET_ADMIN_AI_MODEL_RECOMMENDED, {
+    client: apolloAdminClient,
+  });
+  const [setModelsRecommended] = useMutation(SET_ADMIN_AI_MODELS_RECOMMENDED, {
+    client: apolloAdminClient,
+  });
+  const [setDefaultModel] = useMutation(SET_ADMIN_DEFAULT_AI_MODEL, {
+    client: apolloAdminClient,
+  });
 
   const { data: providersData, loading: isLoadingProviders } =
-    useQuery<GetAiProvidersResult>(GET_AI_PROVIDERS);
+    useQuery<GetAiProvidersResult>(GET_AI_PROVIDERS, {
+      client: apolloAdminClient,
+    });
 
   const { data: usageData, previousData: previousUsageData } = useQuery<{
     getAdminAiUsageByWorkspace: UsageBreakdownItem[];
   }>(GET_ADMIN_AI_USAGE_BY_WORKSPACE, {
+    client: apolloAdminClient,
     variables: {
       periodStart: usageDates.periodStart,
       periodEnd: usageDates.periodEnd,

--- a/packages/twenty-front/src/modules/settings/admin-panel/ai/constants/ModelIconConfig.ts
+++ b/packages/twenty-front/src/modules/settings/admin-panel/ai/constants/ModelIconConfig.ts
@@ -8,7 +8,7 @@ import {
   type IconComponent,
 } from 'twenty-ui/display';
 
-import { ModelFamily } from '~/generated-metadata/graphql';
+import { ModelFamily } from '~/generated-admin/graphql';
 
 export type ModelIconConfigKey = ModelFamily | 'FALLBACK';
 

--- a/packages/twenty-front/src/modules/settings/admin-panel/apollo/components/ApolloAdminProvider.tsx
+++ b/packages/twenty-front/src/modules/settings/admin-panel/apollo/components/ApolloAdminProvider.tsx
@@ -1,0 +1,19 @@
+import { useApolloFactory } from '@/apollo/hooks/useApolloFactory';
+import { ApolloAdminClientContext } from '@/settings/admin-panel/apollo/contexts/ApolloAdminClientContext';
+import { REACT_APP_SERVER_BASE_URL } from '~/config';
+
+export const ApolloAdminProvider = ({
+  children,
+}: {
+  children: React.ReactNode;
+}) => {
+  const apolloAdminClient = useApolloFactory({
+    uri: `${REACT_APP_SERVER_BASE_URL}/admin-panel`,
+  });
+
+  return (
+    <ApolloAdminClientContext.Provider value={apolloAdminClient}>
+      {children}
+    </ApolloAdminClientContext.Provider>
+  );
+};

--- a/packages/twenty-front/src/modules/settings/admin-panel/apollo/contexts/ApolloAdminClientContext.ts
+++ b/packages/twenty-front/src/modules/settings/admin-panel/apollo/contexts/ApolloAdminClientContext.ts
@@ -1,0 +1,6 @@
+import { type ApolloClient } from '@apollo/client';
+import { createContext } from 'react';
+
+export const ApolloAdminClientContext = createContext<ApolloClient | null>(
+  null,
+);

--- a/packages/twenty-front/src/modules/settings/admin-panel/apollo/hooks/useApolloAdminClient.ts
+++ b/packages/twenty-front/src/modules/settings/admin-panel/apollo/hooks/useApolloAdminClient.ts
@@ -1,0 +1,19 @@
+import { useApolloClient } from '@apollo/client/react';
+import { useContext } from 'react';
+
+import { ApolloAdminClientContext } from '@/settings/admin-panel/apollo/contexts/ApolloAdminClientContext';
+
+export const useApolloAdminClient = () => {
+  const apolloAdminClient = useContext(ApolloAdminClientContext);
+  const apolloClient = useApolloClient();
+
+  if (process.env.NODE_ENV === 'test') {
+    return apolloClient;
+  }
+
+  if (!apolloAdminClient) {
+    throw new Error('ApolloAdminClient not found');
+  }
+
+  return apolloAdminClient;
+};

--- a/packages/twenty-front/src/modules/settings/admin-panel/apps/components/SettingsAdminApps.tsx
+++ b/packages/twenty-front/src/modules/settings/admin-panel/apps/components/SettingsAdminApps.tsx
@@ -1,3 +1,4 @@
+import { useApolloAdminClient } from '@/settings/admin-panel/apollo/hooks/useApolloAdminClient';
 import { Table } from '@/ui/layout/table/components/Table';
 import { TableBody } from '@/ui/layout/table/components/TableBody';
 import { TableCell } from '@/ui/layout/table/components/TableCell';
@@ -21,7 +22,7 @@ import {
   type ApplicationRegistrationFragmentFragment,
   ApplicationRegistrationSourceType,
   FindAllApplicationRegistrationsDocument,
-} from '~/generated-metadata/graphql';
+} from '~/generated-admin/graphql';
 
 const StyledTableContainer = styled.div`
   border-bottom: 1px solid ${themeCssVariables.border.color.light};
@@ -32,10 +33,13 @@ const TABLE_GRID = '1fr 100px 100px 40px';
 const TABLE_GRID_MOBILE = '3fr 3fr 1fr 40px';
 
 export const SettingsAdminApps = () => {
+  const apolloAdminClient = useApolloAdminClient();
   const [searchQuery, setSearchQuery] = useState('');
   const { theme } = useContext(ThemeContext);
 
-  const { data } = useQuery(FindAllApplicationRegistrationsDocument);
+  const { data } = useQuery(FindAllApplicationRegistrationsDocument, {
+    client: apolloAdminClient,
+  });
 
   const registrations: ApplicationRegistrationFragmentFragment[] =
     data?.findAllApplicationRegistrations ?? [];

--- a/packages/twenty-front/src/modules/settings/admin-panel/components/SettingsAdminChatThreadMessageList.tsx
+++ b/packages/twenty-front/src/modules/settings/admin-panel/components/SettingsAdminChatThreadMessageList.tsx
@@ -9,7 +9,7 @@ import { themeCssVariables } from 'twenty-ui/theme-constants';
 import {
   AgentMessageRole,
   type GetAdminChatThreadMessagesQuery,
-} from '~/generated-metadata/graphql';
+} from '~/generated-admin/graphql';
 
 type ChatMessage = NonNullable<
   GetAdminChatThreadMessagesQuery['getAdminChatThreadMessages']

--- a/packages/twenty-front/src/modules/settings/admin-panel/components/SettingsAdminGeneral.tsx
+++ b/packages/twenty-front/src/modules/settings/admin-panel/components/SettingsAdminGeneral.tsx
@@ -1,4 +1,5 @@
 import { canManageFeatureFlagsState } from '@/client-config/states/canManageFeatureFlagsState';
+import { useApolloAdminClient } from '@/settings/admin-panel/apollo/hooks/useApolloAdminClient';
 import { SettingsAdminVersionContainer } from '@/settings/admin-panel/components/SettingsAdminVersionContainer';
 import { ADMIN_PANEL_RECENT_USERS } from '@/settings/admin-panel/graphql/queries/adminPanelRecentUsers';
 import { ADMIN_PANEL_TOP_WORKSPACES } from '@/settings/admin-panel/graphql/queries/adminPanelTopWorkspaces';
@@ -29,6 +30,7 @@ const StyledEmptyState = styled.div`
 `;
 
 export const SettingsAdminGeneral = () => {
+  const apolloAdminClient = useApolloAdminClient();
   const [userSearchTerm, setUserSearchTerm] = useState('');
   const [debouncedUserSearchTerm] = useDebounce(userSearchTerm, 300);
 
@@ -51,6 +53,7 @@ export const SettingsAdminGeneral = () => {
       workspaceId?: string | null;
     }[];
   }>(ADMIN_PANEL_RECENT_USERS, {
+    client: apolloAdminClient,
     variables: { searchTerm: debouncedUserSearchTerm },
     skip: !canImpersonate,
   });
@@ -63,6 +66,7 @@ export const SettingsAdminGeneral = () => {
       subdomain: string;
     }[];
   }>(ADMIN_PANEL_TOP_WORKSPACES, {
+    client: apolloAdminClient,
     variables: { searchTerm: debouncedWorkspaceSearchTerm },
     skip: !canImpersonate,
   });

--- a/packages/twenty-front/src/modules/settings/admin-panel/components/SettingsAdminVersionContainer.tsx
+++ b/packages/twenty-front/src/modules/settings/admin-panel/components/SettingsAdminVersionContainer.tsx
@@ -1,12 +1,16 @@
 import { SettingsTableCard } from '@/settings/components/SettingsTableCard';
+import { useApolloAdminClient } from '@/settings/admin-panel/apollo/hooks/useApolloAdminClient';
 import { SettingsAdminVersionDisplay } from '@/settings/admin-panel/components/SettingsAdminVersionDisplay';
 import { t } from '@lingui/core/macro';
 import { IconCircleDot, IconStatusChange } from 'twenty-ui/display';
 import { useQuery } from '@apollo/client/react';
-import { GetVersionInfoDocument } from '~/generated-metadata/graphql';
+import { GetVersionInfoDocument } from '~/generated-admin/graphql';
 
 export const SettingsAdminVersionContainer = () => {
-  const { data, loading } = useQuery(GetVersionInfoDocument);
+  const apolloAdminClient = useApolloAdminClient();
+  const { data, loading } = useQuery(GetVersionInfoDocument, {
+    client: apolloAdminClient,
+  });
   const { currentVersion, latestVersion } = data?.versionInfo ?? {};
 
   const versionItems = [

--- a/packages/twenty-front/src/modules/settings/admin-panel/config-variables/components/ConfigVariableDatabaseInput.tsx
+++ b/packages/twenty-front/src/modules/settings/admin-panel/config-variables/components/ConfigVariableDatabaseInput.tsx
@@ -12,7 +12,7 @@ import { CustomError } from 'twenty-shared/utils';
 import { CodeEditor } from 'twenty-ui/input';
 import { MenuItemMultiSelect } from 'twenty-ui/navigation';
 import { themeCssVariables } from 'twenty-ui/theme-constants';
-import { ConfigVariableType } from '~/generated-metadata/graphql';
+import { ConfigVariableType } from '~/generated-admin/graphql';
 import { type ConfigVariableOptions } from '@/settings/admin-panel/config-variables/types/ConfigVariableOptions';
 
 const StyledJsonEditorContainer = styled.div`

--- a/packages/twenty-front/src/modules/settings/admin-panel/config-variables/components/ConfigVariableHelpText.tsx
+++ b/packages/twenty-front/src/modules/settings/admin-panel/config-variables/components/ConfigVariableHelpText.tsx
@@ -4,10 +4,7 @@ import { useLingui } from '@lingui/react/macro';
 import { isConfigVariablesInDbEnabledState } from '@/client-config/states/isConfigVariablesInDbEnabledState';
 import { useAtomStateValue } from '@/ui/utilities/state/jotai/hooks/useAtomStateValue';
 import { themeCssVariables } from 'twenty-ui/theme-constants';
-import {
-  ConfigSource,
-  type ConfigVariable,
-} from '~/generated-metadata/graphql';
+import { ConfigSource, type ConfigVariable } from '~/generated-admin/graphql';
 
 const StyledHelpText = styled.div<{ color?: string }>`
   color: ${themeCssVariables.font.color.tertiary};

--- a/packages/twenty-front/src/modules/settings/admin-panel/config-variables/components/ConfigVariableValueInput.tsx
+++ b/packages/twenty-front/src/modules/settings/admin-panel/config-variables/components/ConfigVariableValueInput.tsx
@@ -5,7 +5,7 @@ import { TextInput } from '@/ui/input/components/TextInput';
 import { styled } from '@linaria/react';
 import { useAtomStateValue } from '@/ui/utilities/state/jotai/hooks/useAtomStateValue';
 import { type ConfigVariableValue } from 'twenty-shared/types';
-import { type ConfigVariable } from '~/generated-metadata/graphql';
+import { type ConfigVariable } from '~/generated-admin/graphql';
 import { ConfigVariableDatabaseInput } from './ConfigVariableDatabaseInput';
 
 type ConfigVariableValueInputProps = {

--- a/packages/twenty-front/src/modules/settings/admin-panel/config-variables/components/SettingsAdminConfigVariables.tsx
+++ b/packages/twenty-front/src/modules/settings/admin-panel/config-variables/components/SettingsAdminConfigVariables.tsx
@@ -1,4 +1,5 @@
 import { SettingsAdminTabSkeletonLoader } from '@/settings/admin-panel/components/SettingsAdminTabSkeletonLoader';
+import { useApolloAdminClient } from '@/settings/admin-panel/apollo/hooks/useApolloAdminClient';
 import { ConfigVariableFilterContainer } from '@/settings/admin-panel/config-variables/components/ConfigVariableFilterContainer';
 import { ConfigVariableFilterDropdown } from '@/settings/admin-panel/config-variables/components/ConfigVariableFilterDropdown';
 import { SettingsAdminConfigVariablesTable } from '@/settings/admin-panel/config-variables/components/SettingsAdminConfigVariablesTable';
@@ -15,7 +16,7 @@ import { useQuery } from '@apollo/client/react';
 import {
   ConfigSource,
   GetConfigVariablesGroupedDocument,
-} from '~/generated-metadata/graphql';
+} from '~/generated-admin/graphql';
 import { normalizeSearchText } from '~/utils/normalizeSearchText';
 import { ConfigVariableSearchInput } from './ConfigVariableSearchInput';
 import { useAtomState } from '@/ui/utilities/state/jotai/hooks/useAtomState';
@@ -31,9 +32,11 @@ const StyledTableContainer = styled.div`
 `;
 
 export const SettingsAdminConfigVariables = () => {
+  const apolloAdminClient = useApolloAdminClient();
   const { data: configVariables, loading: configVariablesLoading } = useQuery(
     GetConfigVariablesGroupedDocument,
     {
+      client: apolloAdminClient,
       fetchPolicy: 'network-only',
     },
   );

--- a/packages/twenty-front/src/modules/settings/admin-panel/config-variables/components/SettingsAdminConfigVariablesTable.tsx
+++ b/packages/twenty-front/src/modules/settings/admin-panel/config-variables/components/SettingsAdminConfigVariablesTable.tsx
@@ -1,4 +1,4 @@
-import { type ConfigVariable } from '~/generated-metadata/graphql';
+import { type ConfigVariable } from '~/generated-admin/graphql';
 import { ConfigVariableTable } from '@/settings/config-variables/components/ConfigVariableTable';
 import { getSettingsPath } from 'twenty-shared/utils';
 import { SettingsPath } from 'twenty-shared/types';

--- a/packages/twenty-front/src/modules/settings/admin-panel/config-variables/hooks/useConfigVariableActions.ts
+++ b/packages/twenty-front/src/modules/settings/admin-panel/config-variables/hooks/useConfigVariableActions.ts
@@ -1,4 +1,5 @@
 import { useClientConfig } from '@/client-config/hooks/useClientConfig';
+import { useApolloAdminClient } from '@/settings/admin-panel/apollo/hooks/useApolloAdminClient';
 import { GET_DATABASE_CONFIG_VARIABLE } from '@/settings/admin-panel/config-variables/graphql/queries/getDatabaseConfigVariable';
 import { type ConfigVariableValue } from 'twenty-shared/types';
 import { isDefined } from 'twenty-shared/utils';
@@ -7,19 +8,23 @@ import {
   CreateDatabaseConfigVariableDocument,
   DeleteDatabaseConfigVariableDocument,
   UpdateDatabaseConfigVariableDocument,
-} from '~/generated-metadata/graphql';
+} from '~/generated-admin/graphql';
 
 export const useConfigVariableActions = (variableName: string) => {
+  const apolloAdminClient = useApolloAdminClient();
   const { refetch: refetchClientConfig } = useClientConfig();
 
   const [updateDatabaseConfigVariable] = useMutation(
     UpdateDatabaseConfigVariableDocument,
+    { client: apolloAdminClient },
   );
   const [createDatabaseConfigVariable] = useMutation(
     CreateDatabaseConfigVariableDocument,
+    { client: apolloAdminClient },
   );
   const [deleteDatabaseConfigVariable] = useMutation(
     DeleteDatabaseConfigVariableDocument,
+    { client: apolloAdminClient },
   );
 
   const handleUpdateVariable = async (

--- a/packages/twenty-front/src/modules/settings/admin-panel/config-variables/utils/useSourceContent.ts
+++ b/packages/twenty-front/src/modules/settings/admin-panel/config-variables/utils/useSourceContent.ts
@@ -3,7 +3,7 @@ import { useContext } from 'react';
 import { CustomError } from 'twenty-shared/utils';
 import { ThemeContext } from 'twenty-ui/theme-constants';
 
-import { ConfigSource } from '~/generated-metadata/graphql';
+import { ConfigSource } from '~/generated-admin/graphql';
 
 export const useSourceContent = (source: ConfigSource) => {
   const { theme } = useContext(ThemeContext);

--- a/packages/twenty-front/src/modules/settings/admin-panel/health-status/components/SettingsAdminConnectedAccountHealthStatus.tsx
+++ b/packages/twenty-front/src/modules/settings/admin-panel/health-status/components/SettingsAdminConnectedAccountHealthStatus.tsx
@@ -4,7 +4,7 @@ import { styled } from '@linaria/react';
 import { t } from '@lingui/core/macro';
 import { useContext } from 'react';
 import { themeCssVariables } from 'twenty-ui/theme-constants';
-import { AdminPanelHealthServiceStatus } from '~/generated-metadata/graphql';
+import { AdminPanelHealthServiceStatus } from '~/generated-admin/graphql';
 
 const StyledErrorMessage = styled.div`
   color: ${themeCssVariables.color.red};

--- a/packages/twenty-front/src/modules/settings/admin-panel/health-status/components/SettingsAdminHealthStatus.tsx
+++ b/packages/twenty-front/src/modules/settings/admin-panel/health-status/components/SettingsAdminHealthStatus.tsx
@@ -1,3 +1,4 @@
+import { useApolloAdminClient } from '@/settings/admin-panel/apollo/hooks/useApolloAdminClient';
 import { SettingsAdminTabSkeletonLoader } from '@/settings/admin-panel/components/SettingsAdminTabSkeletonLoader';
 import { SettingsAdminHealthStatusListCard } from '@/settings/admin-panel/health-status/components/SettingsAdminHealthStatusListCard';
 import { SettingsAdminMaintenanceModeFetchEffect } from '@/settings/admin-panel/health-status/maintenance-mode/components/SettingsAdminMaintenanceModeFetchEffect';
@@ -6,12 +7,14 @@ import { t } from '@lingui/core/macro';
 import { H2Title } from 'twenty-ui/display';
 import { Section } from 'twenty-ui/layout';
 import { useQuery } from '@apollo/client/react';
-import { GetSystemHealthStatusDocument } from '~/generated-metadata/graphql';
+import { GetSystemHealthStatusDocument } from '~/generated-admin/graphql';
 
 export const SettingsAdminHealthStatus = () => {
+  const apolloAdminClient = useApolloAdminClient();
   const { data, loading: loadingHealthStatus } = useQuery(
     GetSystemHealthStatusDocument,
     {
+      client: apolloAdminClient,
       fetchPolicy: 'network-only',
     },
   );

--- a/packages/twenty-front/src/modules/settings/admin-panel/health-status/components/SettingsAdminHealthStatusListCard.tsx
+++ b/packages/twenty-front/src/modules/settings/admin-panel/health-status/components/SettingsAdminHealthStatusListCard.tsx
@@ -14,7 +14,7 @@ import { ThemeContext } from 'twenty-ui/theme-constants';
 import {
   HealthIndicatorId,
   type SystemHealthService,
-} from '~/generated-metadata/graphql';
+} from '~/generated-admin/graphql';
 
 import { SettingsAdminHealthStatusRightContainer } from './SettingsAdminHealthStatusRightContainer';
 

--- a/packages/twenty-front/src/modules/settings/admin-panel/health-status/components/SettingsAdminHealthStatusRightContainer.tsx
+++ b/packages/twenty-front/src/modules/settings/admin-panel/health-status/components/SettingsAdminHealthStatusRightContainer.tsx
@@ -1,6 +1,6 @@
 import { t } from '@lingui/core/macro';
 import { Status } from 'twenty-ui/display';
-import { AdminPanelHealthServiceStatus } from '~/generated-metadata/graphql';
+import { AdminPanelHealthServiceStatus } from '~/generated-admin/graphql';
 
 export const SettingsAdminHealthStatusRightContainer = ({
   status,

--- a/packages/twenty-front/src/modules/settings/admin-panel/health-status/components/SettingsAdminIndicatorHealthStatusContent.tsx
+++ b/packages/twenty-front/src/modules/settings/admin-panel/health-status/components/SettingsAdminIndicatorHealthStatusContent.tsx
@@ -2,7 +2,7 @@ import { SettingsAdminConnectedAccountHealthStatus } from '@/settings/admin-pane
 import { SettingsAdminJsonDataIndicatorHealthStatus } from '@/settings/admin-panel/health-status/components/SettingsAdminJsonDataIndicatorHealthStatus';
 import { SettingsAdminWorkerHealthStatus } from '@/settings/admin-panel/health-status/components/SettingsAdminWorkerHealthStatus';
 import { useParams } from 'react-router-dom';
-import { HealthIndicatorId } from '~/generated-metadata/graphql';
+import { HealthIndicatorId } from '~/generated-admin/graphql';
 
 export const SettingsAdminIndicatorHealthStatusContent = () => {
   const { indicatorId } = useParams();

--- a/packages/twenty-front/src/modules/settings/admin-panel/health-status/components/SettingsAdminJobDetailsExpandable.tsx
+++ b/packages/twenty-front/src/modules/settings/admin-panel/health-status/components/SettingsAdminJobDetailsExpandable.tsx
@@ -3,7 +3,7 @@ import { t } from '@lingui/core/macro';
 import { JsonTree } from 'twenty-ui/json-visualizer';
 import { AnimatedExpandableContainer } from 'twenty-ui/layout';
 import { themeCssVariables } from 'twenty-ui/theme-constants';
-import { type QueueJob } from '~/generated-metadata/graphql';
+import { type QueueJob } from '~/generated-admin/graphql';
 import { useCopyToClipboard } from '~/hooks/useCopyToClipboard';
 
 type SettingsAdminJobDetailsExpandableProps = {

--- a/packages/twenty-front/src/modules/settings/admin-panel/health-status/components/SettingsAdminJobStateBadge.tsx
+++ b/packages/twenty-front/src/modules/settings/admin-panel/health-status/components/SettingsAdminJobStateBadge.tsx
@@ -1,7 +1,7 @@
 import { styled } from '@linaria/react';
 import { Tag, type TagColor } from 'twenty-ui/components';
 import { themeCssVariables } from 'twenty-ui/theme-constants';
-import { JobState } from '~/generated-metadata/graphql';
+import { JobState } from '~/generated-admin/graphql';
 
 type SettingsAdminJobStateBadgeProps = {
   state: JobState;

--- a/packages/twenty-front/src/modules/settings/admin-panel/health-status/components/SettingsAdminJsonDataIndicatorHealthStatus.tsx
+++ b/packages/twenty-front/src/modules/settings/admin-panel/health-status/components/SettingsAdminJsonDataIndicatorHealthStatus.tsx
@@ -5,7 +5,7 @@ import { useContext } from 'react';
 import { JsonTree } from 'twenty-ui/json-visualizer';
 import { Section } from 'twenty-ui/layout';
 import { themeCssVariables } from 'twenty-ui/theme-constants';
-import { AdminPanelHealthServiceStatus } from '~/generated-metadata/graphql';
+import { AdminPanelHealthServiceStatus } from '~/generated-admin/graphql';
 import { useCopyToClipboard } from '~/hooks/useCopyToClipboard';
 
 const StyledDetailsContainer = styled.div`

--- a/packages/twenty-front/src/modules/settings/admin-panel/health-status/components/SettingsAdminQueueJobRowDropdownMenu.tsx
+++ b/packages/twenty-front/src/modules/settings/admin-panel/health-status/components/SettingsAdminQueueJobRowDropdownMenu.tsx
@@ -6,7 +6,7 @@ import { t } from '@lingui/core/macro';
 import { IconDotsVertical, IconRefresh, IconTrash } from 'twenty-ui/display';
 import { LightIconButton } from 'twenty-ui/input';
 import { MenuItem } from 'twenty-ui/navigation';
-import { JobState } from '~/generated-metadata/graphql';
+import { JobState } from '~/generated-admin/graphql';
 
 type SettingsAdminQueueJobRowDropdownMenuProps = {
   jobId: string;

--- a/packages/twenty-front/src/modules/settings/admin-panel/health-status/components/SettingsAdminQueueJobsTable.tsx
+++ b/packages/twenty-front/src/modules/settings/admin-panel/health-status/components/SettingsAdminQueueJobsTable.tsx
@@ -4,6 +4,7 @@ import { SettingsAdminJobDetailsExpandable } from '@/settings/admin-panel/health
 import { SettingsAdminJobStateBadge } from '@/settings/admin-panel/health-status/components/SettingsAdminJobStateBadge';
 import { SettingsAdminQueueJobRowDropdownMenu } from '@/settings/admin-panel/health-status/components/SettingsAdminQueueJobRowDropdownMenu';
 import { SettingsAdminRetryJobsConfirmationModal } from '@/settings/admin-panel/health-status/components/SettingsAdminRetryJobsConfirmationModal';
+import { useApolloAdminClient } from '@/settings/admin-panel/apollo/hooks/useApolloAdminClient';
 import { useDeleteJobs } from '@/settings/admin-panel/health-status/hooks/useDeleteJobs';
 import { useRetryJobs } from '@/settings/admin-panel/health-status/hooks/useRetryJobs';
 import { Select } from '@/ui/input/components/Select';
@@ -24,7 +25,7 @@ import {
   JobState,
   type QueueJob,
   GetQueueJobsDocument,
-} from '~/generated-metadata/graphql';
+} from '~/generated-admin/graphql';
 import { beautifyPastDateRelativeToNow } from '~/utils/date-utils';
 
 type SettingsAdminQueueJobsTableProps = {
@@ -74,6 +75,7 @@ export const SettingsAdminQueueJobsTable = ({
   queueName,
   onRetentionConfigLoaded,
 }: SettingsAdminQueueJobsTableProps) => {
+  const apolloAdminClient = useApolloAdminClient();
   const [page, setPage] = useState(0);
   const [stateFilter, setStateFilter] = useState<JobState>(JobState.COMPLETED);
   const [expandedJobId, setExpandedJobId] = useState<string | null>(null);
@@ -93,6 +95,7 @@ export const SettingsAdminQueueJobsTable = ({
   const offset = page * LIMIT;
 
   const { data, loading, refetch } = useQuery(GetQueueJobsDocument, {
+    client: apolloAdminClient,
     variables: {
       queueName,
       state: stateFilter,

--- a/packages/twenty-front/src/modules/settings/admin-panel/health-status/components/SettingsAdminWorkerHealthStatus.tsx
+++ b/packages/twenty-front/src/modules/settings/admin-panel/health-status/components/SettingsAdminWorkerHealthStatus.tsx
@@ -2,7 +2,7 @@ import { SettingsAdminWorkerQueueMetricsSection } from '@/settings/admin-panel/h
 import { styled } from '@linaria/react';
 import { t } from '@lingui/core/macro';
 import { useContext } from 'react';
-import { AdminPanelHealthServiceStatus } from '~/generated-metadata/graphql';
+import { AdminPanelHealthServiceStatus } from '~/generated-admin/graphql';
 import { SettingsAdminIndicatorHealthContext } from '@/settings/admin-panel/health-status/contexts/SettingsAdminIndicatorHealthContext';
 import { themeCssVariables } from 'twenty-ui/theme-constants';
 

--- a/packages/twenty-front/src/modules/settings/admin-panel/health-status/components/SettingsAdminWorkerMetricsGraph.tsx
+++ b/packages/twenty-front/src/modules/settings/admin-panel/health-status/components/SettingsAdminWorkerMetricsGraph.tsx
@@ -1,5 +1,6 @@
 import { isDefined } from 'twenty-shared/utils';
 import { SettingsTableCard } from '@/settings/components/SettingsTableCard';
+import { useApolloAdminClient } from '@/settings/admin-panel/apollo/hooks/useApolloAdminClient';
 import { SettingsAdminWorkerMetricsTooltip } from '@/settings/admin-panel/health-status/components/SettingsAdminWorkerMetricsTooltip';
 import { useSnackBarOnQueryError } from '@/apollo/hooks/useSnackBarOnQueryError';
 import { styled } from '@linaria/react';
@@ -11,7 +12,7 @@ import { useQuery } from '@apollo/client/react';
 import {
   QueueMetricsTimeRange,
   GetQueueMetricsDocument,
-} from '~/generated-metadata/graphql';
+} from '~/generated-admin/graphql';
 
 const StyledGraphContainer = styled.div`
   background-color: ${themeCssVariables.background.secondary};
@@ -48,9 +49,11 @@ export const SettingsAdminWorkerMetricsGraph = ({
   queueName,
   timeRange,
 }: SettingsAdminWorkerMetricsGraphProps) => {
+  const apolloAdminClient = useApolloAdminClient();
   const { theme } = useContext(ThemeContext);
 
   const { loading, data, error } = useQuery(GetQueueMetricsDocument, {
+    client: apolloAdminClient,
     variables: {
       queueName,
       timeRange,

--- a/packages/twenty-front/src/modules/settings/admin-panel/health-status/components/SettingsAdminWorkerQueueMetricsSection.tsx
+++ b/packages/twenty-front/src/modules/settings/admin-panel/health-status/components/SettingsAdminWorkerQueueMetricsSection.tsx
@@ -13,7 +13,7 @@ import { themeCssVariables } from 'twenty-ui/theme-constants';
 import {
   type AdminPanelWorkerQueueHealth,
   QueueMetricsTimeRange,
-} from '~/generated-metadata/graphql';
+} from '~/generated-admin/graphql';
 
 const SettingsAdminWorkerMetricsGraph = lazy(() =>
   import('./SettingsAdminWorkerMetricsGraph').then((module) => ({

--- a/packages/twenty-front/src/modules/settings/admin-panel/health-status/constants/WorkerQueueMetricsSelectOptions.ts
+++ b/packages/twenty-front/src/modules/settings/admin-panel/health-status/constants/WorkerQueueMetricsSelectOptions.ts
@@ -1,5 +1,5 @@
 import { msg } from '@lingui/core/macro';
-import { QueueMetricsTimeRange } from '~/generated-metadata/graphql';
+import { QueueMetricsTimeRange } from '~/generated-admin/graphql';
 
 export const WORKER_QUEUE_METRICS_SELECT_OPTIONS = [
   { value: QueueMetricsTimeRange.SevenDays, label: msg`This week` },

--- a/packages/twenty-front/src/modules/settings/admin-panel/health-status/contexts/SettingsAdminIndicatorHealthContext.tsx
+++ b/packages/twenty-front/src/modules/settings/admin-panel/health-status/contexts/SettingsAdminIndicatorHealthContext.tsx
@@ -3,7 +3,7 @@ import {
   AdminPanelHealthServiceStatus,
   HealthIndicatorId,
   type AdminPanelHealthServiceData,
-} from '~/generated-metadata/graphql';
+} from '~/generated-admin/graphql';
 
 type SettingsAdminIndicatorHealthContextType = {
   indicatorHealth: AdminPanelHealthServiceData;

--- a/packages/twenty-front/src/modules/settings/admin-panel/health-status/hooks/useDeleteJobs.ts
+++ b/packages/twenty-front/src/modules/settings/admin-panel/health-status/hooks/useDeleteJobs.ts
@@ -1,16 +1,20 @@
+import { useApolloAdminClient } from '@/settings/admin-panel/apollo/hooks/useApolloAdminClient';
 import { useSnackBar } from '@/ui/feedback/snack-bar-manager/hooks/useSnackBar';
 import { CombinedGraphQLErrors } from '@apollo/client/errors';
 import { plural, t } from '@lingui/core/macro';
 import { useState } from 'react';
 import { isDefined } from 'twenty-shared/utils';
 import { useMutation } from '@apollo/client/react';
-import { DeleteJobsDocument } from '~/generated-metadata/graphql';
+import { DeleteJobsDocument } from '~/generated-admin/graphql';
 import { getErrorMessageFromApolloError } from '~/utils/get-error-message-from-apollo-error.util';
 
 export const useDeleteJobs = (queueName: string, onSuccess?: () => void) => {
+  const apolloAdminClient = useApolloAdminClient();
   const { enqueueSuccessSnackBar, enqueueErrorSnackBar } = useSnackBar();
   const [isDeleting, setIsDeleting] = useState(false);
-  const [deleteJobsMutation] = useMutation(DeleteJobsDocument);
+  const [deleteJobsMutation] = useMutation(DeleteJobsDocument, {
+    client: apolloAdminClient,
+  });
 
   const deleteJobs = async (jobIds: string[]) => {
     setIsDeleting(true);

--- a/packages/twenty-front/src/modules/settings/admin-panel/health-status/hooks/useRetryJobs.ts
+++ b/packages/twenty-front/src/modules/settings/admin-panel/health-status/hooks/useRetryJobs.ts
@@ -1,16 +1,20 @@
+import { useApolloAdminClient } from '@/settings/admin-panel/apollo/hooks/useApolloAdminClient';
 import { useSnackBar } from '@/ui/feedback/snack-bar-manager/hooks/useSnackBar';
 import { CombinedGraphQLErrors } from '@apollo/client/errors';
 import { plural, t } from '@lingui/core/macro';
 import { useState } from 'react';
 import { isDefined } from 'twenty-shared/utils';
 import { useMutation } from '@apollo/client/react';
-import { RetryJobsDocument } from '~/generated-metadata/graphql';
+import { RetryJobsDocument } from '~/generated-admin/graphql';
 import { getErrorMessageFromApolloError } from '~/utils/get-error-message-from-apollo-error.util';
 
 export const useRetryJobs = (queueName: string, onSuccess?: () => void) => {
+  const apolloAdminClient = useApolloAdminClient();
   const { enqueueSuccessSnackBar, enqueueErrorSnackBar } = useSnackBar();
   const [isRetrying, setIsRetrying] = useState(false);
-  const [retryJobsMutation] = useMutation(RetryJobsDocument);
+  const [retryJobsMutation] = useMutation(RetryJobsDocument, {
+    client: apolloAdminClient,
+  });
 
   const retryJobs = async (jobIds: string[]) => {
     setIsRetrying(true);

--- a/packages/twenty-front/src/modules/settings/admin-panel/health-status/maintenance-mode/components/SettingsAdminMaintenanceMode.tsx
+++ b/packages/twenty-front/src/modules/settings/admin-panel/health-status/maintenance-mode/components/SettingsAdminMaintenanceMode.tsx
@@ -9,6 +9,7 @@ import { Card, CardContent, Section } from 'twenty-ui/layout';
 import { themeCssVariables } from 'twenty-ui/theme-constants';
 
 import { maintenanceModeState } from '@/client-config/states/maintenanceModeState';
+import { useApolloAdminClient } from '@/settings/admin-panel/apollo/hooks/useApolloAdminClient';
 import { CLEAR_MAINTENANCE_MODE } from '@/settings/admin-panel/health-status/maintenance-mode/graphql/mutations/clearMaintenanceMode';
 import { SET_MAINTENANCE_MODE } from '@/settings/admin-panel/health-status/maintenance-mode/graphql/mutations/setMaintenanceMode';
 import { adminPanelMaintenanceModeState } from '@/settings/admin-panel/health-status/maintenance-mode/states/adminPanelMaintenanceModeState';
@@ -34,6 +35,7 @@ const StyledStatusRow = styled.div`
 `;
 
 export const SettingsAdminMaintenanceMode = () => {
+  const apolloAdminClient = useApolloAdminClient();
   const [adminPanelMaintenanceMode, setAdminPanelMaintenanceMode] =
     useAtomState(adminPanelMaintenanceModeState);
 
@@ -43,8 +45,12 @@ export const SettingsAdminMaintenanceMode = () => {
   const { userTimezone } = useUserTimezone();
   const { enqueueErrorSnackBar } = useSnackBar();
 
-  const [setMaintenanceModeMutation] = useMutation(SET_MAINTENANCE_MODE);
-  const [clearMaintenanceModeMutation] = useMutation(CLEAR_MAINTENANCE_MODE);
+  const [setMaintenanceModeMutation] = useMutation(SET_MAINTENANCE_MODE, {
+    client: apolloAdminClient,
+  });
+  const [clearMaintenanceModeMutation] = useMutation(CLEAR_MAINTENANCE_MODE, {
+    client: apolloAdminClient,
+  });
 
   const isEnabled = isDefined(adminPanelMaintenanceMode);
 

--- a/packages/twenty-front/src/modules/settings/admin-panel/health-status/maintenance-mode/components/SettingsAdminMaintenanceModeFetchEffect.tsx
+++ b/packages/twenty-front/src/modules/settings/admin-panel/health-status/maintenance-mode/components/SettingsAdminMaintenanceModeFetchEffect.tsx
@@ -2,13 +2,16 @@ import { useQuery } from '@apollo/client/react';
 import { useEffect } from 'react';
 import { isDefined } from 'twenty-shared/utils';
 
+import { useApolloAdminClient } from '@/settings/admin-panel/apollo/hooks/useApolloAdminClient';
 import { GET_MAINTENANCE_MODE } from '@/settings/admin-panel/health-status/maintenance-mode/graphql/queries/getMaintenanceMode';
 import { adminPanelMaintenanceModeState } from '@/settings/admin-panel/health-status/maintenance-mode/states/adminPanelMaintenanceModeState';
 import { useSetAtomState } from '@/ui/utilities/state/jotai/hooks/useSetAtomState';
-import { type GetMaintenanceModeQuery } from '~/generated-metadata/graphql';
+import { type GetMaintenanceModeQuery } from '~/generated-admin/graphql';
 
 export const SettingsAdminMaintenanceModeFetchEffect = () => {
+  const apolloAdminClient = useApolloAdminClient();
   const { data } = useQuery<GetMaintenanceModeQuery>(GET_MAINTENANCE_MODE, {
+    client: apolloAdminClient,
     fetchPolicy: 'network-only',
   });
 

--- a/packages/twenty-front/src/modules/settings/admin-panel/hooks/useFeatureFlagState.ts
+++ b/packages/twenty-front/src/modules/settings/admin-panel/hooks/useFeatureFlagState.ts
@@ -1,7 +1,7 @@
 import { currentWorkspaceState } from '@/auth/states/currentWorkspaceState';
 import { useAtomState } from '@/ui/utilities/state/jotai/hooks/useAtomState';
 import { isDefined } from 'twenty-shared/utils';
-import { type FeatureFlagKey } from '~/generated-metadata/graphql';
+import { type FeatureFlagKey } from '~/generated-admin/graphql';
 
 export const useFeatureFlagState = () => {
   const [currentWorkspace, setCurrentWorkspace] = useAtomState(

--- a/packages/twenty-front/src/modules/settings/admin-panel/types/WorkspaceInfo.ts
+++ b/packages/twenty-front/src/modules/settings/admin-panel/types/WorkspaceInfo.ts
@@ -1,4 +1,4 @@
-import { type WorkspaceLookupAdminPanelQuery } from '~/generated-metadata/graphql';
+import { type WorkspaceLookupAdminPanelQuery } from '~/generated-admin/graphql';
 
 export type WorkspaceInfo =
   WorkspaceLookupAdminPanelQuery['workspaceLookupAdminPanel']['workspaces'][number];

--- a/packages/twenty-front/src/pages/settings/admin-panel/SettingsAdminAiProviderDetail.tsx
+++ b/packages/twenty-front/src/pages/settings/admin-panel/SettingsAdminAiProviderDetail.tsx
@@ -25,6 +25,7 @@ import { Section } from 'twenty-ui/layout';
 import { RoundedLink, UndecoratedLink } from 'twenty-ui/navigation';
 
 import { useClientConfig } from '@/client-config/hooks/useClientConfig';
+import { useApolloAdminClient } from '@/settings/admin-panel/apollo/hooks/useApolloAdminClient';
 import { SettingsSkeletonLoader } from '@/settings/components/SettingsSkeletonLoader';
 import { SettingsAiModelsTable } from '@/settings/ai/components/SettingsAiModelsTable';
 import { REMOVE_AI_PROVIDER } from '@/settings/admin-panel/ai/graphql/mutations/removeAiProvider';
@@ -43,13 +44,14 @@ import { SubMenuTopBarContainer } from '@/ui/layout/page/components/SubMenuTopBa
 import {
   type AdminAiModelConfig,
   SetAdminAiModelEnabledDocument,
-} from '~/generated-metadata/graphql';
+} from '~/generated-admin/graphql';
 
 const REMOVE_PROVIDER_MODAL_ID = 'settings-ai-provider-remove';
 const REMOVE_MODEL_MODAL_ID = 'settings-ai-model-remove';
 
 export const SettingsAdminAiProviderDetail = () => {
   const { providerName } = useParams<{ providerName: string }>();
+  const apolloAdminClient = useApolloAdminClient();
   const navigate = useNavigate();
   const { enqueueErrorSnackBar, enqueueSuccessSnackBar } = useSnackBar();
   const { refetch: refetchClientConfig } = useClientConfig();
@@ -62,7 +64,9 @@ export const SettingsAdminAiProviderDetail = () => {
   } | null>(null);
 
   const { data: providersData, loading: isLoadingProviders } =
-    useQuery<GetAiProvidersResult>(GET_AI_PROVIDERS);
+    useQuery<GetAiProvidersResult>(GET_AI_PROVIDERS, {
+      client: apolloAdminClient,
+    });
 
   const {
     data: modelsData,
@@ -72,12 +76,20 @@ export const SettingsAdminAiProviderDetail = () => {
     getAdminAiModels: {
       models: AdminAiModelConfig[];
     };
-  }>(GET_ADMIN_AI_MODELS);
+  }>(GET_ADMIN_AI_MODELS, { client: apolloAdminClient });
 
-  const [setModelEnabled] = useMutation(SetAdminAiModelEnabledDocument);
-  const [setModelsEnabled] = useMutation(SET_ADMIN_AI_MODELS_ENABLED);
-  const [removeAiProvider] = useMutation(REMOVE_AI_PROVIDER);
-  const [removeModelFromProvider] = useMutation(REMOVE_MODEL_FROM_PROVIDER);
+  const [setModelEnabled] = useMutation(SetAdminAiModelEnabledDocument, {
+    client: apolloAdminClient,
+  });
+  const [setModelsEnabled] = useMutation(SET_ADMIN_AI_MODELS_ENABLED, {
+    client: apolloAdminClient,
+  });
+  const [removeAiProvider] = useMutation(REMOVE_AI_PROVIDER, {
+    client: apolloAdminClient,
+  });
+  const [removeModelFromProvider] = useMutation(REMOVE_MODEL_FROM_PROVIDER, {
+    client: apolloAdminClient,
+  });
 
   const handleRemoveProvider = async () => {
     if (!providerName) {

--- a/packages/twenty-front/src/pages/settings/admin-panel/SettingsAdminApplicationRegistrationDetail.tsx
+++ b/packages/twenty-front/src/pages/settings/admin-panel/SettingsAdminApplicationRegistrationDetail.tsx
@@ -1,10 +1,11 @@
 import { useParams } from 'react-router-dom';
 import { useQuery } from '@apollo/client/react';
-import { FindOneAdminApplicationRegistrationDocument } from '~/generated-metadata/graphql';
+import { FindOneAdminApplicationRegistrationDocument } from '~/generated-admin/graphql';
 import { getSettingsPath, isDefined } from 'twenty-shared/utils';
 import { SettingsPath } from 'twenty-shared/types';
 import { useLingui } from '@lingui/react/macro';
 import { SubMenuTopBarContainer } from '@/ui/layout/page/components/SubMenuTopBarContainer';
+import { useApolloAdminClient } from '@/settings/admin-panel/apollo/hooks/useApolloAdminClient';
 import { APPLICATION_REGISTRATION_ADMIN_PATH } from '@/settings/admin-panel/apps/constants/ApplicationRegistrationAdminPath';
 import { SettingsPageContainer } from '@/settings/components/SettingsPageContainer';
 import {
@@ -26,6 +27,7 @@ const REGISTRATION_DETAIL_TAB_LIST_ID =
 
 export const SettingsAdminApplicationRegistrationDetail = () => {
   const { t } = useLingui();
+  const apolloAdminClient = useApolloAdminClient();
 
   const activeTabId = useAtomComponentStateValue(
     activeTabIdComponentState,
@@ -39,6 +41,7 @@ export const SettingsAdminApplicationRegistrationDetail = () => {
   const { data, loading } = useQuery(
     FindOneAdminApplicationRegistrationDocument,
     {
+      client: apolloAdminClient,
       variables: { id: applicationRegistrationId },
       skip: !applicationRegistrationId,
     },

--- a/packages/twenty-front/src/pages/settings/admin-panel/SettingsAdminConfigVariableDetails.tsx
+++ b/packages/twenty-front/src/pages/settings/admin-panel/SettingsAdminConfigVariableDetails.tsx
@@ -3,6 +3,7 @@ import { useState } from 'react';
 import { useParams } from 'react-router-dom';
 
 import { isConfigVariablesInDbEnabledState } from '@/client-config/states/isConfigVariablesInDbEnabledState';
+import { useApolloAdminClient } from '@/settings/admin-panel/apollo/hooks/useApolloAdminClient';
 import { ConfigVariableHelpText } from '@/settings/admin-panel/config-variables/components/ConfigVariableHelpText';
 import { ConfigVariableValueInput } from '@/settings/admin-panel/config-variables/components/ConfigVariableValueInput';
 import { useConfigVariableActions } from '@/settings/admin-panel/config-variables/hooks/useConfigVariableActions';
@@ -16,7 +17,7 @@ import { useQuery } from '@apollo/client/react';
 import {
   ConfigSource,
   GetDatabaseConfigVariableDocument,
-} from '~/generated-metadata/graphql';
+} from '~/generated-admin/graphql';
 
 const hasMeaningfulValue = (value: ConfigVariableValue): boolean => {
   if (value === null || value === undefined) {
@@ -33,6 +34,7 @@ const hasMeaningfulValue = (value: ConfigVariableValue): boolean => {
 
 export const SettingsAdminConfigVariableDetails = () => {
   const { variableName } = useParams();
+  const apolloAdminClient = useApolloAdminClient();
 
   const { t } = useLingui();
 
@@ -45,6 +47,7 @@ export const SettingsAdminConfigVariableDetails = () => {
   const { data: configVariableData, loading } = useQuery(
     GetDatabaseConfigVariableDocument,
     {
+      client: apolloAdminClient,
       variables: { key: variableName ?? '' },
       fetchPolicy: 'network-only',
     },

--- a/packages/twenty-front/src/pages/settings/admin-panel/SettingsAdminIndicatorHealthStatus.tsx
+++ b/packages/twenty-front/src/pages/settings/admin-panel/SettingsAdminIndicatorHealthStatus.tsx
@@ -1,3 +1,4 @@
+import { useApolloAdminClient } from '@/settings/admin-panel/apollo/hooks/useApolloAdminClient';
 import { SettingsAdminHealthStatusRightContainer } from '@/settings/admin-panel/health-status/components/SettingsAdminHealthStatusRightContainer';
 import { SettingsAdminIndicatorHealthStatusContent } from '@/settings/admin-panel/health-status/components/SettingsAdminIndicatorHealthStatusContent';
 import { SettingsAdminIndicatorHealthContext } from '@/settings/admin-panel/health-status/contexts/SettingsAdminIndicatorHealthContext';
@@ -17,7 +18,7 @@ import {
   AdminPanelHealthServiceStatus,
   HealthIndicatorId,
   GetIndicatorHealthStatusDocument,
-} from '~/generated-metadata/graphql';
+} from '~/generated-admin/graphql';
 
 const StyledTitleContainer = styled.div`
   align-items: center;
@@ -29,9 +30,11 @@ const StyledTitleContainer = styled.div`
 export const SettingsAdminIndicatorHealthStatus = () => {
   const { t } = useLingui();
   const { indicatorId } = useParams();
+  const apolloAdminClient = useApolloAdminClient();
   const { data, loading: loadingIndicatorHealthStatus } = useQuery(
     GetIndicatorHealthStatusDocument,
     {
+      client: apolloAdminClient,
       variables: {
         indicatorId: indicatorId as HealthIndicatorId,
       },

--- a/packages/twenty-front/src/pages/settings/admin-panel/SettingsAdminNewAiModel.tsx
+++ b/packages/twenty-front/src/pages/settings/admin-panel/SettingsAdminNewAiModel.tsx
@@ -12,6 +12,7 @@ import { H2Title, IconPlus } from 'twenty-ui/display';
 import { Section } from 'twenty-ui/layout';
 import { themeCssVariables } from 'twenty-ui/theme-constants';
 
+import { useApolloAdminClient } from '@/settings/admin-panel/apollo/hooks/useApolloAdminClient';
 import { ADD_MODEL_TO_PROVIDER } from '@/settings/admin-panel/ai/graphql/mutations/addModelToProvider';
 import { GET_ADMIN_AI_MODELS } from '@/settings/admin-panel/ai/graphql/queries/getAdminAiModels';
 import { GET_AI_PROVIDERS } from '@/settings/admin-panel/ai/graphql/queries/getAiProviders';
@@ -79,14 +80,19 @@ type FormValues = {
 
 export const SettingsAdminNewAiModel = () => {
   const { providerName } = useParams<{ providerName: string }>();
+  const apolloAdminClient = useApolloAdminClient();
   const navigate = useNavigate();
   const { t } = useLingui();
   const { enqueueSuccessSnackBar, enqueueErrorSnackBar } = useSnackBar();
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [isCustomModelId, setIsCustomModelId] = useState(false);
 
-  const { data: providersData } =
-    useQuery<GetAiProvidersResult>(GET_AI_PROVIDERS);
+  const { data: providersData } = useQuery<GetAiProvidersResult>(
+    GET_AI_PROVIDERS,
+    {
+      client: apolloAdminClient,
+    },
+  );
 
   const provider =
     providerName && providersData?.getAiProviders
@@ -98,6 +104,7 @@ export const SettingsAdminNewAiModel = () => {
   const { data: suggestionsData } = useQuery<{
     getModelsDevSuggestions: ModelSuggestion[];
   }>(GET_MODELS_DEV_SUGGESTIONS, {
+    client: apolloAdminClient,
     variables: { providerType: modelsDevName ?? '' },
     skip: !modelsDevName,
   });
@@ -122,7 +129,9 @@ export const SettingsAdminNewAiModel = () => {
     label: `${suggestion.name} (${suggestion.modelId})`,
   }));
 
-  const [addModelToProvider] = useMutation(ADD_MODEL_TO_PROVIDER);
+  const [addModelToProvider] = useMutation(ADD_MODEL_TO_PROVIDER, {
+    client: apolloAdminClient,
+  });
 
   const form = useForm<FormValues>({
     mode: 'onSubmit',

--- a/packages/twenty-front/src/pages/settings/admin-panel/SettingsAdminNewAiProvider.tsx
+++ b/packages/twenty-front/src/pages/settings/admin-panel/SettingsAdminNewAiProvider.tsx
@@ -12,6 +12,7 @@ import { Section } from 'twenty-ui/layout';
 
 import { AI_ADMIN_PATH } from '@/settings/admin-panel/ai/constants/AiAdminPath';
 import { DATA_RESIDENCY_OPTIONS } from '@/settings/admin-panel/ai/constants/DataResidencyOptions';
+import { useApolloAdminClient } from '@/settings/admin-panel/apollo/hooks/useApolloAdminClient';
 import { ADD_AI_PROVIDER } from '@/settings/admin-panel/ai/graphql/mutations/addAiProvider';
 import { GET_ADMIN_AI_MODELS } from '@/settings/admin-panel/ai/graphql/queries/getAdminAiModels';
 import { GET_AI_PROVIDERS } from '@/settings/admin-panel/ai/graphql/queries/getAiProviders';
@@ -40,6 +41,7 @@ type FormValues = {
 };
 
 export const SettingsAdminNewAiProvider = () => {
+  const apolloAdminClient = useApolloAdminClient();
   const navigate = useNavigate();
   const { t } = useLingui();
   const { enqueueSuccessSnackBar, enqueueErrorSnackBar } = useSnackBar();
@@ -49,11 +51,13 @@ export const SettingsAdminNewAiProvider = () => {
   );
   const [isCustomMode, setIsCustomMode] = useState(false);
 
-  const [addAiProvider] = useMutation(ADD_AI_PROVIDER);
+  const [addAiProvider] = useMutation(ADD_AI_PROVIDER, {
+    client: apolloAdminClient,
+  });
 
   const { data: modelsDevData } = useQuery<{
     getModelsDevProviders: ModelsDevProvider[];
-  }>(GET_MODELS_DEV_PROVIDERS);
+  }>(GET_MODELS_DEV_PROVIDERS, { client: apolloAdminClient });
 
   const modelsDevProviders = useMemo(
     () => modelsDevData?.getModelsDevProviders ?? [],

--- a/packages/twenty-front/src/pages/settings/admin-panel/SettingsAdminUserDetail.tsx
+++ b/packages/twenty-front/src/pages/settings/admin-panel/SettingsAdminUserDetail.tsx
@@ -8,6 +8,7 @@ import { SettingsPath } from 'twenty-shared/types';
 import { getImageAbsoluteURI, getSettingsPath } from 'twenty-shared/utils';
 
 import { currentUserState } from '@/auth/states/currentUserState';
+import { useApolloAdminClient } from '@/settings/admin-panel/apollo/hooks/useApolloAdminClient';
 import { SettingsAdminWorkspaceContent } from '@/settings/admin-panel/components/SettingsAdminWorkspaceContent';
 import { SETTINGS_ADMIN_USER_LOOKUP_WORKSPACE_TABS_ID } from '@/settings/admin-panel/constants/SettingsAdminUserLookupWorkspaceTabsId';
 import { useHandleImpersonate } from '@/settings/admin-panel/hooks/useHandleImpersonate';
@@ -35,7 +36,7 @@ import { REACT_APP_SERVER_BASE_URL } from '~/config';
 import {
   type UserLookupAdminPanelQuery,
   UserLookupAdminPanelDocument,
-} from '~/generated-metadata/graphql';
+} from '~/generated-admin/graphql';
 
 const StyledButtonContainer = styled.div`
   margin-top: ${themeCssVariables.spacing[3]};
@@ -43,6 +44,7 @@ const StyledButtonContainer = styled.div`
 
 export const SettingsAdminUserDetail = () => {
   const { userId } = useParams<{ userId: string }>();
+  const apolloAdminClient = useApolloAdminClient();
 
   const activeTabId = useAtomComponentStateValue(
     activeTabIdComponentState,
@@ -51,6 +53,7 @@ export const SettingsAdminUserDetail = () => {
 
   const { data: userLookupData, loading: isLoading } =
     useQuery<UserLookupAdminPanelQuery>(UserLookupAdminPanelDocument, {
+      client: apolloAdminClient,
       variables: { userIdentifier: userId },
       skip: !userId,
     });

--- a/packages/twenty-front/src/pages/settings/admin-panel/SettingsAdminWorkspaceChatThread.tsx
+++ b/packages/twenty-front/src/pages/settings/admin-panel/SettingsAdminWorkspaceChatThread.tsx
@@ -6,6 +6,7 @@ import { SettingsPath } from 'twenty-shared/types';
 import { getSettingsPath } from 'twenty-shared/utils';
 
 import { AI_ADMIN_PATH } from '@/settings/admin-panel/ai/constants/AiAdminPath';
+import { useApolloAdminClient } from '@/settings/admin-panel/apollo/hooks/useApolloAdminClient';
 import { SettingsAdminChatThreadMessageList } from '@/settings/admin-panel/components/SettingsAdminChatThreadMessageList';
 import { GET_ADMIN_CHAT_THREAD_MESSAGES } from '@/settings/admin-panel/graphql/queries/getAdminChatThreadMessages';
 import { SettingsPageContainer } from '@/settings/components/SettingsPageContainer';
@@ -13,16 +14,18 @@ import { SettingsSkeletonLoader } from '@/settings/components/SettingsSkeletonLo
 import { SubMenuTopBarContainer } from '@/ui/layout/page/components/SubMenuTopBarContainer';
 import { H2Title } from 'twenty-ui/display';
 import { Section } from 'twenty-ui/layout';
-import { type GetAdminChatThreadMessagesQuery } from '~/generated-metadata/graphql';
+import { type GetAdminChatThreadMessagesQuery } from '~/generated-admin/graphql';
 
 export const SettingsAdminWorkspaceChatThread = () => {
   const { workspaceId, threadId } = useParams<{
     workspaceId: string;
     threadId: string;
   }>();
+  const apolloAdminClient = useApolloAdminClient();
 
   const { data, loading: isLoading } =
     useQuery<GetAdminChatThreadMessagesQuery>(GET_ADMIN_CHAT_THREAD_MESSAGES, {
+      client: apolloAdminClient,
       variables: { threadId },
       skip: !threadId,
     });

--- a/packages/twenty-front/src/pages/settings/admin-panel/SettingsAdminWorkspaceDetail.tsx
+++ b/packages/twenty-front/src/pages/settings/admin-panel/SettingsAdminWorkspaceDetail.tsx
@@ -8,6 +8,7 @@ import { getSettingsPath, isDefined } from 'twenty-shared/utils';
 import { currentUserState } from '@/auth/states/currentUserState';
 import { canManageFeatureFlagsState } from '@/client-config/states/canManageFeatureFlagsState';
 import { AI_ADMIN_PATH } from '@/settings/admin-panel/ai/constants/AiAdminPath';
+import { useApolloAdminClient } from '@/settings/admin-panel/apollo/hooks/useApolloAdminClient';
 import { SettingsAdminWorkspaceContent } from '@/settings/admin-panel/components/SettingsAdminWorkspaceContent';
 import { GET_ADMIN_WORKSPACE_CHAT_THREADS } from '@/settings/admin-panel/graphql/queries/getAdminWorkspaceChatThreads';
 import { WORKSPACE_LOOKUP_ADMIN_PANEL } from '@/settings/admin-panel/graphql/queries/workspaceLookupAdminPanel';
@@ -42,7 +43,7 @@ import {
   type GetAdminWorkspaceChatThreadsQuery,
   type WorkspaceLookupAdminPanelQuery,
   UpdateWorkspaceFeatureFlagDocument,
-} from '~/generated-metadata/graphql';
+} from '~/generated-admin/graphql';
 
 const WORKSPACE_DETAIL_TABS_ID = 'settings-admin-workspace-detail-tabs';
 
@@ -55,6 +56,7 @@ const WORKSPACE_DETAIL_TAB_IDS = {
 
 export const SettingsAdminWorkspaceDetail = () => {
   const { workspaceId } = useParams<{ workspaceId: string }>();
+  const apolloAdminClient = useApolloAdminClient();
 
   const activeTabId = useAtomComponentStateValue(
     activeTabIdComponentState,
@@ -66,10 +68,13 @@ export const SettingsAdminWorkspaceDetail = () => {
   const { enqueueErrorSnackBar } = useSnackBar();
   const { updateFeatureFlagState } = useFeatureFlagState();
   const { handleImpersonate, impersonatingUserId } = useHandleImpersonate();
-  const [updateFeatureFlag] = useMutation(UpdateWorkspaceFeatureFlagDocument);
+  const [updateFeatureFlag] = useMutation(UpdateWorkspaceFeatureFlagDocument, {
+    client: apolloAdminClient,
+  });
 
   const { data: workspaceData, loading: isLoadingWorkspace } =
     useQuery<WorkspaceLookupAdminPanelQuery>(WORKSPACE_LOOKUP_ADMIN_PANEL, {
+      client: apolloAdminClient,
       variables: { workspaceId },
       skip: !workspaceId,
     });
@@ -82,6 +87,7 @@ export const SettingsAdminWorkspaceDetail = () => {
     useQuery<GetAdminWorkspaceChatThreadsQuery>(
       GET_ADMIN_WORKSPACE_CHAT_THREADS,
       {
+        client: apolloAdminClient,
         variables: { workspaceId },
         skip:
           !workspaceId ||

--- a/packages/twenty-front/vite.config.ts
+++ b/packages/twenty-front/vite.config.ts
@@ -88,6 +88,7 @@ export default defineConfig(({ mode }) => {
           include: [path.resolve(__dirname, 'src') + '/**/*.{ts,tsx}'],
           exclude: [
             '**/generated-metadata/**',
+            '**/generated-admin/**',
             '**/testing/mock-data/**',
             '**/testing/jest/**',
             '**/testing/hooks/**',

--- a/packages/twenty-server/patches/@nestjs+graphql+12.1.1.patch
+++ b/packages/twenty-server/patches/@nestjs+graphql+12.1.1.patch
@@ -9,7 +9,7 @@ index 72bab49dcc2b411408c75adf64c3f250cdeaa195..068dc04966e3f7ac7c7093f9ed8f29f2
 +    /**
 +     * When set, only resolvers decorated with a matching scope will be included in this schema.
 +     */
-+    resolverSchemaScope?: 'core' | 'metadata';
++    resolverSchemaScope?: 'core' | 'metadata' | 'admin';
  }
  export interface GqlOptionsFactory<T extends Record<string, any> = GqlModuleOptions> {
      createGqlOptions(): Promise<Omit<T, 'driver'>> | Omit<T, 'driver'>;

--- a/packages/twenty-server/src/app.module.ts
+++ b/packages/twenty-server/src/app.module.ts
@@ -13,6 +13,7 @@ import { join } from 'path';
 import { YogaDriver, type YogaDriverConfig } from '@graphql-yoga/nestjs';
 import { SentryModule } from '@sentry/nestjs/setup';
 
+import { AdminPanelGraphQLApiModule } from 'src/engine/api/graphql/admin-panel-graphql-api.module';
 import { CoreGraphQLApiModule } from 'src/engine/api/graphql/core-graphql-api.module';
 import { GraphQLConfigModule } from 'src/engine/api/graphql/graphql-config/graphql-config.module';
 import { GraphQLConfigService } from 'src/engine/api/graphql/graphql-config/graphql-config.service';
@@ -65,6 +66,7 @@ const MIGRATED_REST_METHODS = [
     // Api modules
     CoreGraphQLApiModule,
     MetadataGraphQLApiModule,
+    AdminPanelGraphQLApiModule,
     RestApiModule,
     McpModule,
     MiddlewareModule,
@@ -123,6 +125,13 @@ export class AppModule {
         WorkspaceAuthContextMiddleware,
       )
       .forRoutes({ path: 'metadata', method: RequestMethod.ALL });
+
+    consumer
+      .apply(
+        GraphQLHydrateRequestFromTokenMiddleware,
+        WorkspaceAuthContextMiddleware,
+      )
+      .forRoutes({ path: 'admin-panel', method: RequestMethod.ALL });
 
     consumer
       .apply(McpMethodGuardMiddleware)

--- a/packages/twenty-server/src/engine/api/graphql/admin-panel-graphql-api.module.ts
+++ b/packages/twenty-server/src/engine/api/graphql/admin-panel-graphql-api.module.ts
@@ -1,0 +1,40 @@
+import { Module } from '@nestjs/common';
+import { GraphQLModule } from '@nestjs/graphql';
+
+import { YogaDriver, type YogaDriverConfig } from '@graphql-yoga/nestjs';
+
+import { adminPanelModuleFactory } from 'src/engine/api/graphql/admin-panel.module-factory';
+import { GraphQLConfigModule } from 'src/engine/api/graphql/graphql-config/graphql-config.module';
+import { AdminPanelModule } from 'src/engine/core-modules/admin-panel/admin-panel.module';
+import { ExceptionHandlerService } from 'src/engine/core-modules/exception-handler/exception-handler.service';
+import { I18nModule } from 'src/engine/core-modules/i18n/i18n.module';
+import { I18nService } from 'src/engine/core-modules/i18n/i18n.service';
+import { MetricsModule } from 'src/engine/core-modules/metrics/metrics.module';
+import { MetricsService } from 'src/engine/core-modules/metrics/metrics.service';
+import { TwentyConfigService } from 'src/engine/core-modules/twenty-config/twenty-config.service';
+import { DataloaderModule } from 'src/engine/dataloaders/dataloader.module';
+import { DataloaderService } from 'src/engine/dataloaders/dataloader.service';
+
+@Module({
+  imports: [
+    GraphQLModule.forRootAsync<YogaDriverConfig>({
+      driver: YogaDriver,
+      useFactory: adminPanelModuleFactory,
+      imports: [
+        GraphQLConfigModule,
+        DataloaderModule,
+        MetricsModule,
+        I18nModule,
+      ],
+      inject: [
+        TwentyConfigService,
+        ExceptionHandlerService,
+        DataloaderService,
+        MetricsService,
+        I18nService,
+      ],
+    }),
+    AdminPanelModule,
+  ],
+})
+export class AdminPanelGraphQLApiModule {}

--- a/packages/twenty-server/src/engine/api/graphql/admin-panel.module-factory.ts
+++ b/packages/twenty-server/src/engine/api/graphql/admin-panel.module-factory.ts
@@ -1,0 +1,66 @@
+import { type YogaDriverConfig } from '@graphql-yoga/nestjs';
+import * as Sentry from '@sentry/node';
+import GraphQLJSON from 'graphql-type-json';
+
+import { NodeEnvironment } from 'src/engine/core-modules/twenty-config/interfaces/node-environment.interface';
+
+import { AdminPanelGraphQLApiModule } from 'src/engine/api/graphql/admin-panel-graphql-api.module';
+import { type ExceptionHandlerService } from 'src/engine/core-modules/exception-handler/exception-handler.service';
+import { useSentryTracing } from 'src/engine/core-modules/exception-handler/hooks/use-sentry-tracing';
+import { useDisableIntrospectionAndSuggestionsForUnauthenticatedUsers } from 'src/engine/core-modules/graphql/hooks/use-disable-introspection-and-suggestions-for-unauthenticated-users.hook';
+import { useGraphQLErrorHandlerHook } from 'src/engine/core-modules/graphql/hooks/use-graphql-error-handler.hook';
+import { useValidateGraphqlQueryComplexity } from 'src/engine/core-modules/graphql/hooks/use-validate-graphql-query-complexity.hook';
+import { type I18nService } from 'src/engine/core-modules/i18n/i18n.service';
+import { type MetricsService } from 'src/engine/core-modules/metrics/metrics.service';
+import { type TwentyConfigService } from 'src/engine/core-modules/twenty-config/twenty-config.service';
+import { type DataloaderService } from 'src/engine/dataloaders/dataloader.service';
+import { renderApolloPlayground } from 'src/engine/utils/render-apollo-playground.util';
+
+export const adminPanelModuleFactory = async (
+  twentyConfigService: TwentyConfigService,
+  exceptionHandlerService: ExceptionHandlerService,
+  dataloaderService: DataloaderService,
+  metricsService: MetricsService,
+  i18nService: I18nService,
+): Promise<YogaDriverConfig> => {
+  const config: YogaDriverConfig = {
+    autoSchemaFile: true,
+    include: [AdminPanelGraphQLApiModule],
+    resolverSchemaScope: 'admin',
+    buildSchemaOptions: {},
+    renderGraphiQL() {
+      return renderApolloPlayground({ path: 'admin-panel' });
+    },
+    resolvers: { JSON: GraphQLJSON },
+    plugins: [
+      ...(Sentry.isInitialized() ? [useSentryTracing()] : []),
+      useGraphQLErrorHandlerHook({
+        metricsService: metricsService,
+        exceptionHandlerService,
+        i18nService,
+        twentyConfigService,
+      }),
+      useDisableIntrospectionAndSuggestionsForUnauthenticatedUsers(
+        twentyConfigService.get('NODE_ENV') === NodeEnvironment.PRODUCTION,
+      ),
+      useValidateGraphqlQueryComplexity({
+        maximumAllowedFields: twentyConfigService.get('GRAPHQL_MAX_FIELDS'),
+        maximumAllowedRootResolvers: 10,
+        maximumAllowedNestedFields: 10,
+        checkDuplicateRootResolvers: true,
+      }),
+    ],
+    path: '/admin-panel',
+    context: () => ({
+      loaders: dataloaderService.createLoaders(),
+    }),
+  };
+
+  if (twentyConfigService.get('NODE_ENV') === NodeEnvironment.DEVELOPMENT) {
+    config.renderGraphiQL = () => {
+      return renderApolloPlayground({ path: 'admin-panel' });
+    };
+  }
+
+  return config;
+};

--- a/packages/twenty-server/src/engine/api/graphql/graphql-config/decorators/admin-resolver.decorator.ts
+++ b/packages/twenty-server/src/engine/api/graphql/graphql-config/decorators/admin-resolver.decorator.ts
@@ -1,0 +1,11 @@
+import { applyDecorators, SetMetadata } from '@nestjs/common';
+import { Resolver } from '@nestjs/graphql';
+
+import { RESOLVER_SCHEMA_SCOPE_KEY } from 'src/engine/api/graphql/graphql-config/constants/resolver-schema-scope-key.constant';
+import { type ResolverSchemaScope } from 'src/engine/api/graphql/graphql-config/types/resolver-schema-scope.type';
+
+export const AdminResolver = (typeFunc?: () => unknown) =>
+  applyDecorators(
+    typeFunc ? Resolver(typeFunc) : Resolver(),
+    SetMetadata(RESOLVER_SCHEMA_SCOPE_KEY, 'admin' as ResolverSchemaScope),
+  );

--- a/packages/twenty-server/src/engine/api/graphql/graphql-config/types/resolver-schema-scope.type.ts
+++ b/packages/twenty-server/src/engine/api/graphql/graphql-config/types/resolver-schema-scope.type.ts
@@ -1,1 +1,1 @@
-export type ResolverSchemaScope = 'core' | 'metadata';
+export type ResolverSchemaScope = 'core' | 'metadata' | 'admin';

--- a/packages/twenty-server/src/engine/core-modules/admin-panel/admin-panel.resolver.ts
+++ b/packages/twenty-server/src/engine/core-modules/admin-panel/admin-panel.resolver.ts
@@ -58,7 +58,7 @@ import { type AiProviderModelConfig } from 'src/engine/metadata-modules/ai/ai-mo
 import { extractConfigVariableName } from 'src/engine/metadata-modules/ai/ai-models/utils/extract-config-variable-name.util';
 import { loadDefaultAiProviders } from 'src/engine/metadata-modules/ai/ai-models/utils/load-default-ai-providers.util';
 import { WorkspaceEntity } from 'src/engine/core-modules/workspace/workspace.entity';
-import { MetadataResolver } from 'src/engine/api/graphql/graphql-config/decorators/metadata-resolver.decorator';
+import { AdminResolver } from 'src/engine/api/graphql/graphql-config/decorators/admin-resolver.decorator';
 import { AdminPanelGuard } from 'src/engine/guards/admin-panel-guard';
 import { ServerLevelImpersonateGuard } from 'src/engine/guards/server-level-impersonate.guard';
 import { SettingsPermissionGuard } from 'src/engine/guards/settings-permission.guard';
@@ -74,7 +74,7 @@ import { SetMaintenanceModeInput } from './dtos/set-maintenance-mode.input';
 import { AuthWorkspace } from 'src/engine/decorators/auth/auth-workspace.decorator';
 
 @UsePipes(ResolverValidationPipe)
-@MetadataResolver()
+@AdminResolver()
 @UseFilters(
   AuthGraphqlApiExceptionFilter,
   PreventNestToAutoLogGraphqlErrorsFilter,

--- a/packages/twenty-server/test/integration/metadata/suites/utils/update-feature-flag.util.ts
+++ b/packages/twenty-server/test/integration/metadata/suites/utils/update-feature-flag.util.ts
@@ -1,4 +1,4 @@
-import { makeMetadataAPIRequest } from 'test/integration/metadata/suites/utils/make-metadata-api-request.util';
+import { makeAdminPanelAPIRequest } from 'test/integration/twenty-config/utils/make-admin-panel-api-request.util';
 import { updateFeatureFlagFactory } from 'test/integration/graphql/utils/update-feature-flag-factory.util';
 import { warnIfErrorButNotExpectedToFail } from 'test/integration/metadata/utils/warn-if-error-but-not-expected-to-fail.util';
 import { warnIfNoErrorButExpectedToFail } from 'test/integration/metadata/utils/warn-if-no-error-but-expected-to-fail.util';
@@ -23,7 +23,7 @@ export const updateFeatureFlag = async ({
     value,
   );
 
-  const response = await makeMetadataAPIRequest(enablePermissionsQuery);
+  const response = await makeAdminPanelAPIRequest(enablePermissionsQuery);
 
   if (expectToFail === false) {
     warnIfErrorButNotExpectedToFail({

--- a/packages/twenty-server/test/integration/twenty-config/utils/make-admin-panel-api-request.util.ts
+++ b/packages/twenty-server/test/integration/twenty-config/utils/make-admin-panel-api-request.util.ts
@@ -14,7 +14,7 @@ export const makeAdminPanelAPIRequest = (
   const client = request(`http://localhost:${APP_PORT}`);
 
   return client
-    .post('/metadata')
+    .post('/admin-panel')
     .set('Authorization', `Bearer ${APPLE_JANE_ADMIN_ACCESS_TOKEN}`)
     .send({
       query: print(graphqlOperation.query),

--- a/packages/twenty-server/test/integration/twenty-config/utils/make-unauthenticated-api-request.util.ts
+++ b/packages/twenty-server/test/integration/twenty-config/utils/make-unauthenticated-api-request.util.ts
@@ -4,7 +4,7 @@ export const makeUnauthenticatedAPIRequest = async (query: string) => {
   const client = request(`http://localhost:${APP_PORT}`);
 
   return client
-    .post('/metadata')
+    .post('/admin-panel')
     .send({
       query,
     })

--- a/yarn.lock
+++ b/yarn.lock
@@ -12866,7 +12866,7 @@ __metadata:
 
 "@nestjs/graphql@patch:@nestjs/graphql@12.1.1#./patches/@nestjs+graphql+12.1.1.patch::locator=twenty-server%40workspace%3Apackages%2Ftwenty-server":
   version: 12.1.1
-  resolution: "@nestjs/graphql@patch:@nestjs/graphql@npm%3A12.1.1#./patches/@nestjs+graphql+12.1.1.patch::version=12.1.1&hash=c6f13a&locator=twenty-server%40workspace%3Apackages%2Ftwenty-server"
+  resolution: "@nestjs/graphql@patch:@nestjs/graphql@npm%3A12.1.1#./patches/@nestjs+graphql+12.1.1.patch::version=12.1.1&hash=eaf96d&locator=twenty-server%40workspace%3Apackages%2Ftwenty-server"
   dependencies:
     "@graphql-tools/merge": "npm:9.0.1"
     "@graphql-tools/schema": "npm:10.0.2"
@@ -12900,7 +12900,7 @@ __metadata:
       optional: true
     ts-morph:
       optional: true
-  checksum: 10c0/807541d7f7d8a3261787c04bd9456ad1a3198645b967ad68371406f5038ec5e5f3dd26912a914cce25465b828e7d1b037558c79461adb93efbc78382424444c2
+  checksum: 10c0/0d13646d982c3d18de9a5d4989edf2e8d1ef15974d41795f8b220819a8b27c4d4cb9c71bd73524978fe12457e1e955b86f47efa3a4621a571b139d1918702125
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary

Splits admin-panel resolvers off the shared `/metadata` GraphQL endpoint onto a dedicated `/admin-panel` endpoint. The backend plumbing mirrors the existing `metadata` / `core` pattern (new scope, decorator, module, factory), and admin types now live in their own `generated-admin/graphql.ts` on the frontend — dropping 877 lines of admin noise from `generated-metadata`.

## Why

- **Smaller attack surface on `/metadata`** — every authenticated user hits that endpoint; admin ops don't belong there.
- **Independent complexity limits and monitoring** per endpoint.
- **Cleaner module boundaries** — admin is a cross-cutting concern that doesn't match the "shared-schema configuration" meaning of `/metadata`.
- **Deploy / blast-radius isolation** — a broken admin query can't affect `/metadata`.

Runtime behavior, auth, and authorization are unchanged — this is a relocation, not a re-permissioning. All existing guards (`WorkspaceAuthGuard`, `UserAuthGuard`, `SettingsPermissionGuard(SECURITY)` at class level; `AdminPanelGuard` / `ServerLevelImpersonateGuard` at method level) remain on `AdminPanelResolver`.

## What changed

### Backend
- `@AdminResolver()` decorator with scope `'admin'`, naming parallels `CoreResolver` / `MetadataResolver`.
- `AdminPanelGraphQLApiModule` + `adminPanelModuleFactory` registered at `/admin-panel`, same Yoga hook set as the metadata factory (Sentry tracing, error handler, introspection-disabling in prod, complexity validation).
- Middleware chain on `/admin-panel` is identical to `/metadata`.
- `@nestjs/graphql` patch extended: `resolverSchemaScope?: 'core' | 'metadata' | 'admin'`.
- `AdminPanelResolver` class decorator swapped from `@MetadataResolver()` to `@AdminResolver()` — no other changes.

### Frontend
- `codegen-admin.cjs` → `src/generated-admin/graphql.ts` (982 lines).
- `codegen-metadata.cjs` excludes admin paths; metadata file shrinks by 877 lines.
- `ApolloAdminProvider` / `useApolloAdminClient` follow the existing `ApolloCoreProvider` / `useApolloCoreClient` pattern, wired inside `AppRouterProviders` alongside the core provider.
- 37 admin consumer files migrated: imports switched to `~/generated-admin/graphql` and `client: useApolloAdminClient()` is passed to `useQuery` / `useMutation`.
- Three files intentionally kept on `generated-metadata` because they consume non-admin Documents: `useHandleImpersonate.ts`, `SettingsAdminApplicationRegistrationDangerZone.tsx`, `SettingsAdminApplicationRegistrationGeneralToggles.tsx`.

### CI
- `ci-server.yaml` runs all three `graphql:generate` configurations and diff-checks all three generated dirs.

## Authorization (unchanged, but audited while reviewing)

Every one of the 38 methods on `AdminPanelResolver` has a method-level guard:
- `AdminPanelGuard` (32 methods) — requires `canAccessFullAdminPanel === true`
- `ServerLevelImpersonateGuard` (6 methods: user/workspace lookup + chat thread views) — requires `canImpersonate === true`

On top of the class-level guards above. No resolver method is accessible without these flags + `SECURITY` permission in the workspace.

## Test plan

- [ ] Dev server boots; `/graphql`, `/metadata`, `/admin-panel` all mapped as separate GraphQL routes (confirmed locally during development).
- [ ] `nx typecheck twenty-server` passes.
- [ ] `nx typecheck twenty-front` passes.
- [ ] `nx lint:diff-with-main twenty-server` and `twenty-front` both clean.
- [ ] Manual smoke test: log in with a user who has `canAccessFullAdminPanel=true`, open the admin panel at `/settings/admin-panel`, verify each tab loads (General, Health, Config variables, AI, Apps, Workspace details, User details, chat threads).
- [ ] Manual smoke test: log in with a user who has `canImpersonate=false` and `canAccessFullAdminPanel=false`, hit `/admin-panel` directly with a raw GraphQL request, confirm permission error on every operation.
- [ ] Production deploy note: reverse proxy / ingress must route the new `/admin-panel` path to the Nest server. If the proxy has an explicit allowlist, infra change required before cutover.

## Follow-ups (out of scope here)

- Consider cutting over the three `SettingsAdminApplicationRegistration*` components to admin-scope versions of the app-registration operations so the admin page is fully on the admin endpoint.
- The `renderGraphiQL` double-assignment in `admin-panel.module-factory.ts` is copied from `metadata.module-factory.ts` — worth cleaning up in both.