### PR TITLE
fix(front): gate renewToken Apollo logger on IS_DEBUG_MODE

### DIFF
--- a/packages/twenty-front/src/modules/auth/services/AuthService.ts
+++ b/packages/twenty-front/src/modules/auth/services/AuthService.ts
@@ -14,6 +14,8 @@ import {
 } from '~/generated-metadata/graphql';
 import { isUndefinedOrNull } from '~/utils/isUndefinedOrNull';
 
+const isDebugMode = process.env.IS_DEBUG_MODE === 'true';
+
 const logger = loggerLink(() => 'Twenty-Refresh');
 
 const renewTokenMutation = async (
@@ -23,7 +25,7 @@ const renewTokenMutation = async (
   const httpLink = new HttpLink({ uri });
 
   const client = new ApolloClient({
-    link: ApolloLink.from([logger, httpLink]),
+    link: ApolloLink.from([...(isDebugMode ? [logger] : []), httpLink]),
     cache: new InMemoryCache({}),
   });
 


### PR DESCRIPTION
## Summary

The standalone Apollo client used by `AuthService.renewToken` attached `loggerLink` unconditionally, while the main `apollo.factory` client correctly gates it on `isDebugMode`. As a result, **every token refresh in production printed the `renewToken` response — including the new access and refresh JWTs — to the browser console** via the `loggerLink` `RESULT` group.

Reproduced in production: opening devtools shows a `Twenty-Refresh::Generic` collapsed group on every token renewal, containing `HEADERS`, `VARIABLES`, `QUERY` and a `RESULT` payload with the full token strings.

The fix mirrors the gating already used in `apollo.factory.ts` (`...(isDebugMode ? [logger] : [])`), so the logger is only attached when `IS_DEBUG_MODE=true`. Local debug behavior is unchanged.
