### PR TITLE
feat(infra): add Dockerfile for twenty-website-new

### DIFF
--- a/packages/twenty-docker/twenty-website-new/Dockerfile
+++ b/packages/twenty-docker/twenty-website-new/Dockerfile
@@ -1,0 +1,37 @@
+FROM node:24-alpine AS twenty-website-new-build
+
+
+WORKDIR /app
+
+COPY ./package.json .
+COPY ./yarn.lock .
+COPY ./.yarnrc.yml .
+COPY ./.yarn/releases /app/.yarn/releases
+COPY ./.yarn/patches /app/.yarn/patches
+COPY ./packages/twenty-oxlint-rules /app/packages/twenty-oxlint-rules
+COPY ./packages/twenty-ui/package.json /app/packages/twenty-ui/
+COPY ./packages/twenty-shared/package.json /app/packages/twenty-shared/
+COPY ./packages/twenty-website-new/package.json /app/packages/twenty-website-new/package.json
+
+RUN yarn
+
+COPY ./packages/twenty-website-new /app/packages/twenty-website-new
+RUN npx nx build twenty-website-new
+
+FROM node:24-alpine AS twenty-website-new
+
+WORKDIR /app/packages/twenty-website-new
+
+COPY --from=twenty-website-new-build /app /app
+
+WORKDIR /app/packages/twenty-website-new
+
+LABEL org.opencontainers.image.source=https://github.com/twentyhq/twenty
+LABEL org.opencontainers.image.description="This image provides a consistent and reproducible environment for the new marketing website."
+
+RUN chown -R 1000 /app
+
+# Use non root user with uid 1000
+USER 1000
+
+CMD ["/bin/sh", "-c", "npx nx start twenty-website-new"]

--- a/packages/twenty-docker/twenty-website-new/Dockerfile
+++ b/packages/twenty-docker/twenty-website-new/Dockerfile
@@ -9,8 +9,6 @@ COPY ./.yarnrc.yml .
 COPY ./.yarn/releases /app/.yarn/releases
 COPY ./.yarn/patches /app/.yarn/patches
 COPY ./packages/twenty-oxlint-rules /app/packages/twenty-oxlint-rules
-COPY ./packages/twenty-ui/package.json /app/packages/twenty-ui/
-COPY ./packages/twenty-shared/package.json /app/packages/twenty-shared/
 COPY ./packages/twenty-website-new/package.json /app/packages/twenty-website-new/package.json
 
 RUN yarn


### PR DESCRIPTION
## Summary

Adds the Docker build for the new marketing website at `packages/twenty-website-new`, mirroring the existing `packages/twenty-docker/twenty-website/Dockerfile`.

Differences from the existing `twenty-website` Dockerfile:

- Uses `nx build twenty-website-new` / `nx start twenty-website-new`
- Drops the `KEYSTATIC_*` build-time fake env (the new website doesn't use Keystatic)
- Doesn't copy `twenty-ui` source (the new website has no workspace dependency on it)

The image will be built by the new `deploy-website-new.yaml` workflow in [`twentyhq/twenty-infra`](https://github.com/twentyhq/twenty-infra) and pushed to ECR repos `dev-website-new` / `staging-website-new`.

Companion PRs:
- twentyhq/twenty-infra: Helm chart + ArgoCD app + deploy workflow
- twentyhq/twenty-infra-releases: bootstrap tags.yaml

## Test plan

- [ ] Local build: \`docker build -f packages/twenty-docker/twenty-website-new/Dockerfile .\`
- [ ] First run of \`Deploy Website New\` workflow on dev succeeds (build + push to ECR)
- [ ] ArgoCD \`website-new\` application becomes Healthy on dev
- [ ] https://website-new.twenty-main.com serves the new website

Made with [Cursor](https://cursor.com)