### PR TITLE
fix(infra): copy nx.json and tsconfig.base.json into website-new image

### DIFF
--- a/packages/twenty-docker/twenty-website-new/Dockerfile
+++ b/packages/twenty-docker/twenty-website-new/Dockerfile
@@ -6,6 +6,8 @@ WORKDIR /app
 COPY ./package.json .
 COPY ./yarn.lock .
 COPY ./.yarnrc.yml .
+COPY ./tsconfig.base.json .
+COPY ./nx.json .
 COPY ./.yarn/releases /app/.yarn/releases
 COPY ./.yarn/patches /app/.yarn/patches
 COPY ./packages/twenty-oxlint-rules /app/packages/twenty-oxlint-rules


### PR DESCRIPTION
## Summary

Fix the website-new Docker build which currently fails with:

\`\`\`
NX   \"production\" is an invalid fileset.
All filesets have to start with either {workspaceRoot} or {projectRoot}.
\`\`\`

\`packages/twenty-website-new/project.json\` declares \`\"inputs\": [\"production\", \"^production\"]\` — a named input defined in the root \`nx.json\`. Without copying \`nx.json\` into the image, nx can't resolve it and the build fails.

Mirrors what the main twenty Dockerfile already does (line 9 of \`packages/twenty-docker/twenty/Dockerfile\` copies both \`tsconfig.base.json\` and \`nx.json\`).

## Test plan

- [ ] Re-run twenty-infra's \`Deploy Website New\` workflow (dev) — build step should now pass

Made with [Cursor](https://cursor.com)