### PR TITLE
fix(website-new): pre-resolve wyw-in-js babel presets to absolute paths

### DIFF
--- a/packages/twenty-website-new/wyw-in-js.config.cjs
+++ b/packages/twenty-website-new/wyw-in-js.config.cjs
@@ -2,7 +2,17 @@ module.exports = {
   // Prevent Babel from emitting the 500KB "deoptimised the styling" notice for
   // large vendor ESM files such as Three.js while Linaria evaluates imports.
   babelOptions: {
-    presets: ['next/babel', '@wyw-in-js'],
+    // Pre-resolve presets to absolute paths so they work regardless of how
+    // yarn berry hoists `next` and `@wyw-in-js/babel-preset` in the workspace.
+    // `babel-merge` calls `@babel/core`'s `resolvePreset` without a dirname,
+    // which makes Babel resolve from `@babel/core`'s own location rather than
+    // from this config file — breaking when those packages are nested in
+    // `packages/twenty-website-new/node_modules` instead of hoisted to the
+    // workspace root (e.g. in single-workspace Docker builds).
+    presets: [
+      require.resolve('next/babel'),
+      require.resolve('@wyw-in-js/babel-preset'),
+    ],
     compact: true,
   },
 };


### PR DESCRIPTION
## Problem

Building `twenty-website-new` in any environment that does **not** also include `twenty-website` (e.g. the Docker image used by the deployment workflow) fails with:

```
Error: Turbopack build failed with 99 errors:
Error evaluating Node.js code
Error: Cannot find module 'next/babel'
Require stack:
- /app/node_modules/@babel/core/lib/config/files/plugins.js
- ...
- /app/node_modules/babel-merge/src/index.js
- /app/packages/twenty-website-new/node_modules/@wyw-in-js/transform/lib/plugins/babel-transform.js
- /app/packages/twenty-website-new/node_modules/next-with-linaria/lib/loaders/turbopack-transform-loader.js
```

## Root cause

`packages/twenty-website-new/wyw-in-js.config.cjs` references presets by bare name:

```js
presets: ['next/babel', '@wyw-in-js'],
```

These options flow through [`babel-merge`](https://github.com/cellog/babel-merge/blob/master/src/index.js#L11), which calls `@babel/core`'s `resolvePreset(name)` **without** a `dirname` argument. With no `dirname`, `@babel/core` falls back to `require.resolve(id)` from its own file location — so resolution starts at `node_modules/@babel/core/...` and only walks parent `node_modules` directories from there, never down into individual workspace packages.

In a normal local install both presets happen to be hoisted to the workspace root (because `twenty-website` pins `next@^14` and wins the hoist), so resolution succeeds by accident. In the single-workspace Docker build only `twenty-website-new` is present, so `next` (16.1.7) and `@wyw-in-js/babel-preset` are nested in `packages/twenty-website-new/node_modules` and Babel cannot reach them — hence the failure.

## Fix

Pre-resolve both presets with `require.resolve(...)` in the wyw-in-js config so Babel receives absolute paths and resolution becomes independent of hoisting layout.

## Verification

- `yarn nx build twenty-website-new` — passes locally with the full workspace
- Reproduced the original failure with a simulated single-workspace install (only `twenty-website-new` and `twenty-oxlint-rules` present), confirmed it fails on `main` and passes with this patch
- This unblocks the `twenty-infra` `Deploy Website New` workflow ([related infra PR](https://github.com/twentyhq/twenty-infra/pull/586))


Made with [Cursor](https://cursor.com)