### PR TITLE
chore(server): bump current version to 2.0.0 and add 2.1.0 as next

### DIFF
--- a/packages/twenty-server/src/database/commands/__tests__/__snapshots__/instance-command-generation.service.spec.ts.snap
+++ b/packages/twenty-server/src/database/commands/__tests__/__snapshots__/instance-command-generation.service.spec.ts.snap
@@ -26,13 +26,13 @@ export class TestFastInstanceCommand implements FastInstanceCommand {
 exports[`InstanceCommandGenerationService should escape backslashes in SQL queries 1`] = `
 {
   "className": "UpdatePathFastInstanceCommand",
-  "fileName": "1-23-instance-command-fast-1775000000000-update-path.ts",
+  "fileName": "2-0-instance-command-fast-1775000000000-update-path.ts",
   "fileTemplate": "import { QueryRunner } from 'typeorm';
 
 import { RegisteredInstanceCommand } from 'src/engine/core-modules/upgrade/decorators/registered-instance-command.decorator';
 import { FastInstanceCommand } from 'src/engine/core-modules/upgrade/interfaces/fast-instance-command.interface';
 
-@RegisteredInstanceCommand('1.23.0', 1775000000000)
+@RegisteredInstanceCommand('2.0.0', 1775000000000)
 export class UpdatePathFastInstanceCommand implements FastInstanceCommand {
   public async up(queryRunner: QueryRunner): Promise<void> {
     await queryRunner.query('UPDATE "core"."config" SET "value" = E\\'path\\\\\\\\to\\\\\\\\file\\'');
@@ -49,13 +49,13 @@ export class UpdatePathFastInstanceCommand implements FastInstanceCommand {
 exports[`InstanceCommandGenerationService should escape single quotes in SQL queries 1`] = `
 {
   "className": "UpdateConfigFastInstanceCommand",
-  "fileName": "1-23-instance-command-fast-1775000000000-update-config.ts",
+  "fileName": "2-0-instance-command-fast-1775000000000-update-config.ts",
   "fileTemplate": "import { QueryRunner } from 'typeorm';
 
 import { RegisteredInstanceCommand } from 'src/engine/core-modules/upgrade/decorators/registered-instance-command.decorator';
 import { FastInstanceCommand } from 'src/engine/core-modules/upgrade/interfaces/fast-instance-command.interface';
 
-@RegisteredInstanceCommand('1.23.0', 1775000000000)
+@RegisteredInstanceCommand('2.0.0', 1775000000000)
 export class UpdateConfigFastInstanceCommand implements FastInstanceCommand {
   public async up(queryRunner: QueryRunner): Promise<void> {
     await queryRunner.query('UPDATE "core"."config" SET "value" = \\'it\\'\\'s done\\'');
@@ -72,13 +72,13 @@ export class UpdateConfigFastInstanceCommand implements FastInstanceCommand {
 exports[`InstanceCommandGenerationService should generate a migration with a single up/down query 1`] = `
 {
   "className": "AddFooColumnFastInstanceCommand",
-  "fileName": "1-23-instance-command-fast-1775000000000-add-foo-column.ts",
+  "fileName": "2-0-instance-command-fast-1775000000000-add-foo-column.ts",
   "fileTemplate": "import { QueryRunner } from 'typeorm';
 
 import { RegisteredInstanceCommand } from 'src/engine/core-modules/upgrade/decorators/registered-instance-command.decorator';
 import { FastInstanceCommand } from 'src/engine/core-modules/upgrade/interfaces/fast-instance-command.interface';
 
-@RegisteredInstanceCommand('1.23.0', 1775000000000)
+@RegisteredInstanceCommand('2.0.0', 1775000000000)
 export class AddFooColumnFastInstanceCommand implements FastInstanceCommand {
   public async up(queryRunner: QueryRunner): Promise<void> {
     await queryRunner.query('ALTER TABLE "core"."user" ADD "foo" varchar');
@@ -95,13 +95,13 @@ export class AddFooColumnFastInstanceCommand implements FastInstanceCommand {
 exports[`InstanceCommandGenerationService should generate a migration with multiple queries 1`] = `
 {
   "className": "CreateTaskTableFastInstanceCommand",
-  "fileName": "1-23-instance-command-fast-1775000000000-create-task-table.ts",
+  "fileName": "2-0-instance-command-fast-1775000000000-create-task-table.ts",
   "fileTemplate": "import { QueryRunner } from 'typeorm';
 
 import { RegisteredInstanceCommand } from 'src/engine/core-modules/upgrade/decorators/registered-instance-command.decorator';
 import { FastInstanceCommand } from 'src/engine/core-modules/upgrade/interfaces/fast-instance-command.interface';
 
-@RegisteredInstanceCommand('1.23.0', 1775000000000)
+@RegisteredInstanceCommand('2.0.0', 1775000000000)
 export class CreateTaskTableFastInstanceCommand implements FastInstanceCommand {
   public async up(queryRunner: QueryRunner): Promise<void> {
     await queryRunner.query('CREATE TABLE "core"."task" ("id" uuid NOT NULL DEFAULT uuid_generate_v4(), "name" varchar NOT NULL)');
@@ -120,13 +120,13 @@ export class CreateTaskTableFastInstanceCommand implements FastInstanceCommand {
 exports[`InstanceCommandGenerationService should generate a migration with query parameters 1`] = `
 {
   "className": "SeedSettingFastInstanceCommand",
-  "fileName": "1-23-instance-command-fast-1775000000000-seed-setting.ts",
+  "fileName": "2-0-instance-command-fast-1775000000000-seed-setting.ts",
   "fileTemplate": "import { QueryRunner } from 'typeorm';
 
 import { RegisteredInstanceCommand } from 'src/engine/core-modules/upgrade/decorators/registered-instance-command.decorator';
 import { FastInstanceCommand } from 'src/engine/core-modules/upgrade/interfaces/fast-instance-command.interface';
 
-@RegisteredInstanceCommand('1.23.0', 1775000000000)
+@RegisteredInstanceCommand('2.0.0', 1775000000000)
 export class SeedSettingFastInstanceCommand implements FastInstanceCommand {
   public async up(queryRunner: QueryRunner): Promise<void> {
     await queryRunner.query('INSERT INTO "core"."setting" ("key", "value") VALUES ($1, $2)', ["theme","dark"]);
@@ -143,13 +143,13 @@ export class SeedSettingFastInstanceCommand implements FastInstanceCommand {
 exports[`InstanceCommandGenerationService should generate a slow instance command with populated up/down 1`] = `
 {
   "className": "MakeColumnNotNullableSlowInstanceCommand",
-  "fileName": "1-23-instance-command-slow-1775000000000-make-column-not-nullable.ts",
+  "fileName": "2-0-instance-command-slow-1775000000000-make-column-not-nullable.ts",
   "fileTemplate": "import { DataSource, QueryRunner } from 'typeorm';
 
 import { RegisteredInstanceCommand } from 'src/engine/core-modules/upgrade/decorators/registered-instance-command.decorator';
 import { SlowInstanceCommand } from 'src/engine/core-modules/upgrade/interfaces/slow-instance-command.interface';
 
-@RegisteredInstanceCommand('1.23.0', 1775000000000, { type: 'slow' })
+@RegisteredInstanceCommand('2.0.0', 1775000000000, { type: 'slow' })
 export class MakeColumnNotNullableSlowInstanceCommand implements SlowInstanceCommand {
   async runDataMigration(dataSource: DataSource): Promise<void> {
     // TODO: implement data backfill before the DDL migration
@@ -170,13 +170,13 @@ export class MakeColumnNotNullableSlowInstanceCommand implements SlowInstanceCom
 exports[`InstanceCommandGenerationService should use default migration name in class and file names 1`] = `
 {
   "className": "AutoGeneratedFastInstanceCommand",
-  "fileName": "1-23-instance-command-fast-1775000000000-auto-generated.ts",
+  "fileName": "2-0-instance-command-fast-1775000000000-auto-generated.ts",
   "fileTemplate": "import { QueryRunner } from 'typeorm';
 
 import { RegisteredInstanceCommand } from 'src/engine/core-modules/upgrade/decorators/registered-instance-command.decorator';
 import { FastInstanceCommand } from 'src/engine/core-modules/upgrade/interfaces/fast-instance-command.interface';
 
-@RegisteredInstanceCommand('1.23.0', 1775000000000)
+@RegisteredInstanceCommand('2.0.0', 1775000000000)
 export class AutoGeneratedFastInstanceCommand implements FastInstanceCommand {
   public async up(queryRunner: QueryRunner): Promise<void> {
     await queryRunner.query('ALTER TABLE "core"."user" ADD "bar" integer');

--- a/packages/twenty-server/src/database/commands/upgrade-version-command/2-0/2-0-upgrade-version-command.module.ts
+++ b/packages/twenty-server/src/database/commands/upgrade-version-command/2-0/2-0-upgrade-version-command.module.ts
@@ -1,0 +1,7 @@
+import { Module } from '@nestjs/common';
+
+@Module({
+  imports: [],
+  providers: [],
+})
+export class V2_0_UpgradeVersionCommandModule {}

--- a/packages/twenty-server/src/database/commands/upgrade-version-command/2-1/2-1-upgrade-version-command.module.ts
+++ b/packages/twenty-server/src/database/commands/upgrade-version-command/2-1/2-1-upgrade-version-command.module.ts
@@ -1,0 +1,7 @@
+import { Module } from '@nestjs/common';
+
+@Module({
+  imports: [],
+  providers: [],
+})
+export class V2_1_UpgradeVersionCommandModule {}

--- a/packages/twenty-server/src/database/commands/upgrade-version-command/workspace-command-provider.module.ts
+++ b/packages/twenty-server/src/database/commands/upgrade-version-command/workspace-command-provider.module.ts
@@ -3,12 +3,16 @@ import { Module } from '@nestjs/common';
 import { V1_21_UpgradeVersionCommandModule } from 'src/database/commands/upgrade-version-command/1-21/1-21-upgrade-version-command.module';
 import { V1_22_UpgradeVersionCommandModule } from 'src/database/commands/upgrade-version-command/1-22/1-22-upgrade-version-command.module';
 import { V1_23_UpgradeVersionCommandModule } from 'src/database/commands/upgrade-version-command/1-23/1-23-upgrade-version-command.module';
+import { V2_0_UpgradeVersionCommandModule } from 'src/database/commands/upgrade-version-command/2-0/2-0-upgrade-version-command.module';
+import { V2_1_UpgradeVersionCommandModule } from 'src/database/commands/upgrade-version-command/2-1/2-1-upgrade-version-command.module';
 
 @Module({
   imports: [
     V1_21_UpgradeVersionCommandModule,
     V1_22_UpgradeVersionCommandModule,
     V1_23_UpgradeVersionCommandModule,
+    V2_0_UpgradeVersionCommandModule,
+    V2_1_UpgradeVersionCommandModule,
   ],
 })
 export class WorkspaceCommandProviderModule {}

--- a/packages/twenty-server/src/engine/core-modules/upgrade/constants/twenty-current-version.constant.ts
+++ b/packages/twenty-server/src/engine/core-modules/upgrade/constants/twenty-current-version.constant.ts
@@ -1,1 +1,1 @@
-export const TWENTY_CURRENT_VERSION = '1.23.0' as const;
+export const TWENTY_CURRENT_VERSION = '2.0.0' as const;

--- a/packages/twenty-server/src/engine/core-modules/upgrade/constants/twenty-next-versions.constant.ts
+++ b/packages/twenty-server/src/engine/core-modules/upgrade/constants/twenty-next-versions.constant.ts
@@ -1,1 +1,1 @@
-export const TWENTY_NEXT_VERSIONS = [] as const;
+export const TWENTY_NEXT_VERSIONS = ['2.1.0'] as const;

--- a/packages/twenty-server/src/engine/core-modules/upgrade/constants/twenty-previous-versions.constant.ts
+++ b/packages/twenty-server/src/engine/core-modules/upgrade/constants/twenty-previous-versions.constant.ts
@@ -1,1 +1,1 @@
-export const TWENTY_PREVIOUS_VERSIONS = ['1.21.0', '1.22.0'] as const;
+export const TWENTY_PREVIOUS_VERSIONS = ['1.21.0', '1.22.0', '1.23.0'] as const;

--- a/packages/twenty-server/test/integration/upgrade/suites/sequence-runner/__snapshots__/failing-sequence-runner.integration-spec.ts.snap
+++ b/packages/twenty-server/test/integration/upgrade/suites/sequence-runner/__snapshots__/failing-sequence-runner.integration-spec.ts.snap
@@ -1,3 +1,3 @@
 // Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
-exports[`UpgradeSequenceRunnerService — failing sequence (integration) should throw when cursor command is not found in the sequence 1`] = `"Step "RemovedCommand" not found in upgrade sequence. The sequence only covers versions [1.21.0, 1.22.0, 1.23.0]. Please upgrade to 1.21.0 first."`;
+exports[`UpgradeSequenceRunnerService — failing sequence (integration) should throw when cursor command is not found in the sequence 1`] = `"Step "RemovedCommand" not found in upgrade sequence. The sequence only covers versions [1.21.0, 1.22.0, 1.23.0, 2.0.0]. Please upgrade to 1.21.0 first."`;


### PR DESCRIPTION
## Summary

We are releasing Twenty v2.0. This PR sets up the upgrade-version-command machinery for the new release line:

- Move `1.23.0` into `TWENTY_PREVIOUS_VERSIONS` (it just shipped)
- Set `TWENTY_CURRENT_VERSION` to `2.0.0` (no specific upgrade commands — this is just the major version cut)
- Set `TWENTY_NEXT_VERSIONS` to `['2.1.0']` so future PRs that previously would have targeted `1.24.0` now target `2.1.0`
- Add empty `V2_0_UpgradeVersionCommandModule` and `V2_1_UpgradeVersionCommandModule` and wire them into `WorkspaceCommandProviderModule`
- Refresh the `InstanceCommandGenerationService` snapshots to reflect the new current version (`2.0.0` / `2-0-` slug)

The `2-0/` directory is intentionally empty — there are no specific upgrade commands for the v2.0 cut. New upgrade commands authored after this merges should land in `2-1/` (or be generated against `--version 2.1.0`).

## Test plan

- [x] `npx jest` on the impacted upgrade test files (`upgrade-sequence-reader`, `upgrade-command-registry`, `instance-command-generation`) passes (41 tests, 8 snapshots)
- [x] `prettier --check` and `oxlint` clean on touched files
- [ ] Manual: open `nx run twenty-server:command -- upgrade --dry-run` against a local stack with workspaces still on `1.23.0` and confirm the sequence is computed without errors

Made with [Cursor](https://cursor.com)