### PR TITLE
docs: use twenty-sdk/define subpath in docs and website demo

### DIFF
--- a/packages/twenty-docs/developers/extend/apps/building.mdx
+++ b/packages/twenty-docs/developers/extend/apps/building.mdx
@@ -28,7 +28,7 @@ import {
   defineRole,
   PermissionFlag,
   STANDARD_OBJECT_UNIVERSAL_IDENTIFIERS,
-} from 'twenty-sdk';
+} from 'twenty-sdk/define';
 
 export default defineRole({
   universalIdentifier: '2c80f640-2083-4803-bb49-003e38279de6',
@@ -77,7 +77,7 @@ Every app must have exactly one `defineApplication` call that describes:
 - **(Optional) Pre-install / post-install functions**: logic functions that run before or after installation.
 
 ```ts src/application-config.ts
-import { defineApplication } from 'twenty-sdk';
+import { defineApplication } from 'twenty-sdk/define';
 import { DEFAULT_ROLE_UNIVERSAL_IDENTIFIER } from 'src/roles/default-role';
 
 export default defineApplication({
@@ -132,7 +132,7 @@ The `defaultRoleUniversalIdentifier` in `application-config.ts` designates the d
 When you scaffold a new app, the CLI creates a default role file:
 
 ```ts src/roles/default-role.ts
-import { defineRole, PermissionFlag } from 'twenty-sdk';
+import { defineRole, PermissionFlag } from 'twenty-sdk/define';
 
 export const DEFAULT_ROLE_UNIVERSAL_IDENTIFIER =
   'b648f87b-1d26-4961-b974-0908fd991061';
@@ -172,7 +172,7 @@ Notes:
 Custom objects describe both schema and behavior for records in your workspace. Use `defineObject()` to define objects with built-in validation:
 
 ```ts postCard.object.ts
-import { defineObject, FieldType } from 'twenty-sdk';
+import { defineObject, FieldType } from 'twenty-sdk/define';
 
 enum PostCardStatus {
   DRAFT = 'DRAFT',
@@ -261,7 +261,7 @@ Key points:
 Use `defineField()` to add fields to objects you don't own — such as standard Twenty objects (Person, Company, etc.) or objects from other apps. Unlike inline fields in `defineObject()`, standalone fields require an `objectUniversalIdentifier` to specify which object they extend:
 
 ```ts src/fields/company-loyalty-tier.field.ts
-import { defineField, FieldType } from 'twenty-sdk';
+import { defineField, FieldType } from 'twenty-sdk/define';
 
 export default defineField({
   universalIdentifier: 'f2a1b3c4-d5e6-7890-abcd-ef1234567890',
@@ -311,7 +311,7 @@ Suppose a `PostCard` can be sent to many `PostCardRecipient` records. Each recip
 **Step 1: Define the ONE_TO_MANY side on PostCard** (the "one" side):
 
 ```ts src/fields/post-card-recipients-on-post-card.field.ts
-import { defineField, FieldType, RelationType } from 'twenty-sdk';
+import { defineField, FieldType, RelationType } from 'twenty-sdk/define';
 import { POST_CARD_UNIVERSAL_IDENTIFIER } from '../objects/post-card.object';
 import { POST_CARD_RECIPIENT_UNIVERSAL_IDENTIFIER } from '../objects/post-card-recipient.object';
 
@@ -338,7 +338,7 @@ export default defineField({
 **Step 2: Define the MANY_TO_ONE side on PostCardRecipient** (the "many" side — holds the foreign key):
 
 ```ts src/fields/post-card-on-post-card-recipient.field.ts
-import { defineField, FieldType, RelationType, OnDeleteAction } from 'twenty-sdk';
+import { defineField, FieldType, RelationType, OnDeleteAction } from 'twenty-sdk/define';
 import { POST_CARD_UNIVERSAL_IDENTIFIER } from '../objects/post-card.object';
 import { POST_CARD_RECIPIENT_UNIVERSAL_IDENTIFIER } from '../objects/post-card-recipient.object';
 
@@ -379,7 +379,7 @@ import {
   RelationType,
   OnDeleteAction,
   STANDARD_OBJECT_UNIVERSAL_IDENTIFIERS,
-} from 'twenty-sdk';
+} from 'twenty-sdk/define';
 import { SELF_HOSTING_USER_UNIVERSAL_IDENTIFIER } from '../objects/self-hosting-user.object';
 
 export const PERSON_FIELD_ID = 'c3333333-3333-3333-3333-333333333333';
@@ -448,8 +448,8 @@ export default defineObject({
 Each function file uses `defineLogicFunction()` to export a configuration with a handler and optional triggers.
 
 ```ts src/logic-functions/createPostCard.logic-function.ts
-import { defineLogicFunction } from 'twenty-sdk';
-import type { DatabaseEventPayload, ObjectRecordCreateEvent, CronPayload, RoutePayload } from 'twenty-sdk';
+import { defineLogicFunction } from 'twenty-sdk/define';
+import type { DatabaseEventPayload, ObjectRecordCreateEvent, CronPayload, RoutePayload } from 'twenty-sdk/define';
 import { CoreApiClient, type Person } from 'twenty-client-sdk/core';
 
 const handler = async (params: RoutePayload) => {
@@ -519,7 +519,7 @@ When a route trigger invokes your logic function, it receives a `RoutePayload` o
 Import the `RoutePayload` type from `twenty-sdk`:
 
 ```ts
-import { defineLogicFunction, type RoutePayload } from 'twenty-sdk';
+import { defineLogicFunction, type RoutePayload } from 'twenty-sdk/define';
 
 const handler = async (event: RoutePayload) => {
   const { headers, queryStringParameters, pathParameters, body } = event;
@@ -584,7 +584,7 @@ Logic functions can be exposed as **tools** for AI agents and workflows. When ma
 To mark a logic function as a tool, set `isTool: true`:
 
 ```ts src/logic-functions/enrich-company.logic-function.ts
-import { defineLogicFunction } from 'twenty-sdk';
+import { defineLogicFunction } from 'twenty-sdk/define';
 import { CoreApiClient } from 'twenty-client-sdk/core';
 
 const handler = async (params: { companyName: string; domain?: string }) => {
@@ -650,7 +650,7 @@ export default defineLogicFunction({
 A post-install function is a logic function that runs automatically once your app has finished installing on a workspace. The server executes it **after** the app's metadata has been synchronized and the SDK client has been generated, so the workspace is fully ready to use and the new schema is in place. Typical use cases include seeding default data, creating initial records, configuring workspace settings, or provisioning resources on third-party services.
 
 ```ts src/logic-functions/post-install.ts
-import { definePostInstallLogicFunction, type InstallPayload } from 'twenty-sdk';
+import { definePostInstallLogicFunction, type InstallPayload } from 'twenty-sdk/define';
 
 const handler = async (payload: InstallPayload): Promise<void> => {
   console.log('Post install logic function executed successfully!', payload.previousVersion);
@@ -693,7 +693,7 @@ Key points:
 A pre-install function is a logic function that runs automatically during installation, **before the workspace metadata migration is applied**. It shares the same payload shape as post-install (`InstallPayload`), but it is positioned earlier in the install flow so it can prepare state that the upcoming migration depends on — typical uses include backing up data, validating compatibility with the new schema, or archiving records that are about to be restructured or dropped.
 
 ```ts src/logic-functions/pre-install.ts
-import { definePreInstallLogicFunction, type InstallPayload } from 'twenty-sdk';
+import { definePreInstallLogicFunction, type InstallPayload } from 'twenty-sdk/define';
 
 const handler = async (payload: InstallPayload): Promise<void> => {
   console.log('Pre install logic function executed successfully!', payload.previousVersion);
@@ -751,7 +751,7 @@ Pre-install is always **synchronous** (it blocks the install and can abort it). 
 Example — seed a default `PostCard` record after install:
 
 ```ts src/logic-functions/post-install.ts
-import { definePostInstallLogicFunction, type InstallPayload } from 'twenty-sdk';
+import { definePostInstallLogicFunction, type InstallPayload } from 'twenty-sdk/define';
 import { createClient } from './generated/client';
 
 const handler = async ({ previousVersion }: InstallPayload): Promise<void> => {
@@ -783,7 +783,7 @@ export default definePostInstallLogicFunction({
 Example — archive records before a destructive migration:
 
 ```ts src/logic-functions/pre-install.ts
-import { definePreInstallLogicFunction, type InstallPayload } from 'twenty-sdk';
+import { definePreInstallLogicFunction, type InstallPayload } from 'twenty-sdk/define';
 import { createClient } from './generated/client';
 
 const handler = async ({ previousVersion, newVersion }: InstallPayload): Promise<void> => {
@@ -855,7 +855,7 @@ Front components can render in two locations within Twenty:
 The quickest way to see a front component in action is to register it as a **command**. Adding a `command` field with `isPinned: true` makes it appear as a quick-action button in the top-right corner of the page — no page layout needed:
 
 ```tsx src/front-components/hello-world.tsx
-import { defineFrontComponent } from 'twenty-sdk';
+import { defineFrontComponent } from 'twenty-sdk/define';
 
 const HelloWorld = () => {
   return (
@@ -916,7 +916,8 @@ Front components come in two rendering modes controlled by the `isHeadless` opti
 **Headless (`isHeadless: true`)** — The component mounts invisibly in the background. It does not open the side panel. Headless components are designed for actions that execute logic and then unmount themselves — for example, running an async task, navigating to a page, or showing a confirmation modal. They pair naturally with the SDK Command components described below.
 
 ```tsx src/front-components/sync-tracker.tsx
-import { defineFrontComponent, useRecordId, enqueueSnackbar } from 'twenty-sdk';
+import { defineFrontComponent } from 'twenty-sdk/define';
+import { useRecordId, enqueueSnackbar } from 'twenty-sdk/front-component';
 import { useEffect } from 'react';
 
 const SyncTracker = () => {
@@ -954,7 +955,7 @@ Import them from `twenty-sdk/command`:
 Here is a full example of a headless front component using `Command` to run an action from the command menu:
 
 ```tsx src/front-components/run-action.tsx
-import { defineFrontComponent } from 'twenty-sdk';
+import { defineFrontComponent } from 'twenty-sdk/define';
 import { Command } from 'twenty-sdk/command';
 import { CoreApiClient } from 'twenty-sdk/clients';
 
@@ -990,7 +991,7 @@ export default defineFrontComponent({
 And an example using `CommandModal` to ask for confirmation before executing:
 
 ```tsx src/front-components/delete-draft.tsx
-import { defineFrontComponent } from 'twenty-sdk';
+import { defineFrontComponent } from 'twenty-sdk/define';
 import { CommandModal } from 'twenty-sdk/command';
 
 const DeleteDraft = () => {
@@ -1028,12 +1029,12 @@ export default defineFrontComponent({
 Inside your component, use SDK hooks to access the current user, record, and component instance:
 
 ```tsx src/front-components/record-info.tsx
+import { defineFrontComponent } from 'twenty-sdk/define';
 import {
-  defineFrontComponent,
   useUserId,
   useRecordId,
   useFrontComponentId,
-} from 'twenty-sdk';
+} from 'twenty-sdk/front-component';
 
 const RecordInfo = () => {
   const userId = useUserId();
@@ -1082,8 +1083,9 @@ Front components can trigger navigation, modals, and notifications using functio
 Here is an example that uses the host API to show a snackbar and close the side panel after an action completes:
 
 ```tsx src/front-components/archive-record.tsx
-import { defineFrontComponent, useRecordId } from 'twenty-sdk';
-import { enqueueSnackbar, closeSidePanel } from 'twenty-sdk';
+import { defineFrontComponent } from 'twenty-sdk/define';
+import { useRecordId } from 'twenty-sdk/front-component';
+import { enqueueSnackbar, closeSidePanel } from 'twenty-sdk/front-component';
 import { CoreApiClient } from 'twenty-sdk/clients';
 
 const ArchiveRecord = () => {
@@ -1143,14 +1145,14 @@ Adding a `command` field to `defineFrontComponent` registers the component in th
 The `conditionalAvailabilityExpression` field lets you control when a command is visible based on the current page context. Import typed variables and operators from `twenty-sdk` to build expressions:
 
 ```tsx
+import { defineFrontComponent } from 'twenty-sdk/define';
 import {
-  defineFrontComponent,
   pageType,
   numberOfSelectedRecords,
   objectPermissions,
   everyEquals,
   isDefined,
-} from 'twenty-sdk';
+} from 'twenty-sdk/front-component';
 
 export default defineFrontComponent({
   universalIdentifier: '...',
@@ -1210,7 +1212,7 @@ export default defineFrontComponent({
 Front components can access files from the app's `public/` directory using `getPublicAssetUrl`:
 
 ```tsx
-import { defineFrontComponent, getPublicAssetUrl } from 'twenty-sdk';
+import { defineFrontComponent, getPublicAssetUrl } from 'twenty-sdk/define';
 
 const Logo = () => <img src={getPublicAssetUrl('logo.png')} alt="Logo" />;
 
@@ -1235,7 +1237,7 @@ Front components support multiple styling approaches. You can use:
 - **Any CSS-in-JS library** compatible with React
 
 ```tsx
-import { defineFrontComponent } from 'twenty-sdk';
+import { defineFrontComponent } from 'twenty-sdk/define';
 import { Button, Tag, Status } from 'twenty-sdk/ui';
 
 const StyledWidget = () => {
@@ -1262,7 +1264,7 @@ export default defineFrontComponent({
 Skills define reusable instructions and capabilities that AI agents can use within your workspace. Use `defineSkill()` to define skills with built-in validation:
 
 ```ts src/skills/example-skill.ts
-import { defineSkill } from 'twenty-sdk';
+import { defineSkill } from 'twenty-sdk/define';
 
 export default defineSkill({
   universalIdentifier: 'a1b2c3d4-e5f6-7890-abcd-ef1234567890',
@@ -1291,7 +1293,7 @@ Key points:
 Agents are AI assistants that live inside your workspace. Use `defineAgent()` to create agents with a custom system prompt:
 
 ```ts src/agents/example-agent.ts
-import { defineAgent } from 'twenty-sdk';
+import { defineAgent } from 'twenty-sdk/define';
 
 export default defineAgent({
   universalIdentifier: 'b3c4d5e6-f7a8-9012-bcde-f34567890123',
@@ -1317,7 +1319,7 @@ Key points:
 Views are saved configurations for how records of an object are displayed — including which fields are visible, their order, and any filters or groups applied. Use `defineView()` to ship pre-configured views with your app:
 
 ```ts src/views/example-view.ts
-import { defineView, ViewKey } from 'twenty-sdk';
+import { defineView, ViewKey } from 'twenty-sdk/define';
 import { EXAMPLE_OBJECT_UNIVERSAL_IDENTIFIER } from '../objects/example-object';
 import { NAME_FIELD_UNIVERSAL_IDENTIFIER } from '../objects/example-object';
 
@@ -1353,7 +1355,7 @@ Key points:
 Navigation menu items add custom entries to the workspace sidebar. Use `defineNavigationMenuItem()` to link to views, external URLs, or objects:
 
 ```ts src/navigation-menu-items/example-navigation-menu-item.ts
-import { defineNavigationMenuItem, NavigationMenuItemType } from 'twenty-sdk';
+import { defineNavigationMenuItem, NavigationMenuItemType } from 'twenty-sdk/define';
 import { EXAMPLE_VIEW_UNIVERSAL_IDENTIFIER } from '../views/example-view';
 
 export default defineNavigationMenuItem({
@@ -1379,7 +1381,7 @@ Key points:
 Page layouts let you customize how a record detail page looks — which tabs appear, what widgets are inside each tab, and how they are arranged. Use `definePageLayout()` to ship custom layouts with your app:
 
 ```ts src/page-layouts/example-record-page-layout.ts
-import { definePageLayout, PageLayoutTabLayoutMode } from 'twenty-sdk';
+import { definePageLayout, PageLayoutTabLayoutMode } from 'twenty-sdk/define';
 import { EXAMPLE_OBJECT_UNIVERSAL_IDENTIFIER } from '../objects/example-object';
 import { HELLO_WORLD_FRONT_COMPONENT_UNIVERSAL_IDENTIFIER } from '../front-components/hello-world';
 
@@ -1442,7 +1444,7 @@ Use the `getPublicAssetUrl` helper from `twenty-sdk` to get the full URL of a fi
 **In a logic function:**
 
 ```ts src/logic-functions/send-invoice.ts
-import { defineLogicFunction, getPublicAssetUrl } from 'twenty-sdk';
+import { defineLogicFunction, getPublicAssetUrl } from 'twenty-sdk/define';
 
 const handler = async (): Promise<any> => {
   const logoUrl = getPublicAssetUrl('logo.png');
@@ -1467,7 +1469,7 @@ export default defineLogicFunction({
 **In a front component:**
 
 ```tsx src/front-components/company-card.tsx
-import { defineFrontComponent, getPublicAssetUrl } from 'twenty-sdk';
+import { defineFrontComponent, getPublicAssetUrl } from 'twenty-sdk/define';
 
 export default defineFrontComponent(() => {
   const logoUrl = getPublicAssetUrl('logo.png');
@@ -1491,7 +1493,7 @@ yarn add axios
 Then import it in your code:
 
 ```ts src/logic-functions/fetch-data.ts
-import { defineLogicFunction } from 'twenty-sdk';
+import { defineLogicFunction } from 'twenty-sdk/define';
 import axios from 'axios';
 
 const handler = async (): Promise<any> => {
@@ -1512,7 +1514,7 @@ export default defineLogicFunction({
 The same works for front components:
 
 ```tsx src/front-components/chart.tsx
-import { defineFrontComponent } from 'twenty-sdk';
+import { defineFrontComponent } from 'twenty-sdk/define';
 import { format } from 'date-fns';
 
 const DateWidget = () => {

--- a/packages/twenty-website-new/src/sections/Hero/components/HomeVisual/DraggableTerminal/TerminalEditor/editorData.ts
+++ b/packages/twenty-website-new/src/sections/Hero/components/HomeVisual/DraggableTerminal/TerminalEditor/editorData.ts
@@ -128,7 +128,7 @@ const schemaIdentifiersSource = `export const SCHEMA_IDS = {
 } as const;
 `;
 
-const rocketObjectSource = `import { defineObject, FieldType, RelationType } from 'twenty-sdk';
+const rocketObjectSource = `import { defineObject, FieldType, RelationType } from 'twenty-sdk/define';
 
 import { SCHEMA_IDS } from 'src/constants/schema-identifiers';
 
@@ -206,7 +206,7 @@ const launchObjectSource = `import {
   FieldType,
   OnDeleteAction,
   RelationType,
-} from 'twenty-sdk';
+} from 'twenty-sdk/define';
 
 import { SCHEMA_IDS } from 'src/constants/schema-identifiers';
 
@@ -309,7 +309,7 @@ const payloadObjectSource = `import {
   OnDeleteAction,
   RelationType,
   STANDARD_OBJECT,
-} from 'twenty-sdk';
+} from 'twenty-sdk/define';
 
 import { SCHEMA_IDS } from 'src/constants/schema-identifiers';
 
@@ -397,7 +397,7 @@ export default defineObject({
 });
 `;
 
-const launchSiteObjectSource = `import { defineObject, FieldType, RelationType } from 'twenty-sdk';
+const launchSiteObjectSource = `import { defineObject, FieldType, RelationType } from 'twenty-sdk/define';
 
 import { SCHEMA_IDS } from 'src/constants/schema-identifiers';
 
@@ -451,7 +451,7 @@ export default defineObject({
 });
 `;
 
-const launchesViewSource = `import { defineView, ViewKey } from 'twenty-sdk';
+const launchesViewSource = `import { defineView, ViewKey } from 'twenty-sdk/define';
 
 import { SCHEMA_IDS } from 'src/constants/schema-identifiers';
 
@@ -495,7 +495,7 @@ const upcomingLaunchesViewSource = `import {
   defineView,
   ViewFilterOperand,
   ViewType,
-} from 'twenty-sdk';
+} from 'twenty-sdk/define';
 
 import { SCHEMA_IDS } from 'src/constants/schema-identifiers';
 
@@ -519,7 +519,7 @@ export default defineView({
 const launchesNavItemSource = `import {
   defineNavigationMenuItem,
   NavigationMenuItemType,
-} from 'twenty-sdk';
+} from 'twenty-sdk/define';
 
 import { SCHEMA_IDS } from 'src/constants/schema-identifiers';
 
@@ -537,7 +537,7 @@ export default defineNavigationMenuItem({
 const upcomingLaunchesNavItemSource = `import {
   defineNavigationMenuItem,
   NavigationMenuItemType,
-} from 'twenty-sdk';
+} from 'twenty-sdk/define';
 
 import { SCHEMA_IDS } from 'src/constants/schema-identifiers';
 
@@ -555,7 +555,7 @@ export default defineNavigationMenuItem({
 const pastLaunchesNavItemSource = `import {
   defineNavigationMenuItem,
   NavigationMenuItemType,
-} from 'twenty-sdk';
+} from 'twenty-sdk/define';
 
 import { SCHEMA_IDS } from 'src/constants/schema-identifiers';
 
@@ -573,7 +573,7 @@ export default defineNavigationMenuItem({
 const rocketsNavItemSource = `import {
   defineNavigationMenuItem,
   NavigationMenuItemType,
-} from 'twenty-sdk';
+} from 'twenty-sdk/define';
 
 import { SCHEMA_IDS } from 'src/constants/schema-identifiers';
 
@@ -591,7 +591,7 @@ export default defineNavigationMenuItem({
 const payloadsNavItemSource = `import {
   defineNavigationMenuItem,
   NavigationMenuItemType,
-} from 'twenty-sdk';
+} from 'twenty-sdk/define';
 
 import { SCHEMA_IDS } from 'src/constants/schema-identifiers';
 
@@ -609,7 +609,7 @@ export default defineNavigationMenuItem({
 const launchSitesNavItemSource = `import {
   defineNavigationMenuItem,
   NavigationMenuItemType,
-} from 'twenty-sdk';
+} from 'twenty-sdk/define';
 
 import { SCHEMA_IDS } from 'src/constants/schema-identifiers';
 
@@ -624,7 +624,7 @@ export default defineNavigationMenuItem({
 });
 `;
 
-const rocketsViewSource = `import { defineView, ViewKey } from 'twenty-sdk';
+const rocketsViewSource = `import { defineView, ViewKey } from 'twenty-sdk/define';
 
 import { SCHEMA_IDS } from 'src/constants/schema-identifiers';
 
@@ -658,7 +658,7 @@ export default defineView({
 });
 `;
 
-const payloadsViewSource = `import { defineView, ViewKey } from 'twenty-sdk';
+const payloadsViewSource = `import { defineView, ViewKey } from 'twenty-sdk/define';
 
 import { SCHEMA_IDS } from 'src/constants/schema-identifiers';
 
@@ -704,7 +704,7 @@ export default defineView({
 });
 `;
 
-const launchSitesViewSource = `import { defineView, ViewKey } from 'twenty-sdk';
+const launchSitesViewSource = `import { defineView, ViewKey } from 'twenty-sdk/define';
 
 import { SCHEMA_IDS } from 'src/constants/schema-identifiers';
 
@@ -742,7 +742,7 @@ const pastLaunchesViewSource = `import {
   defineView,
   ViewFilterOperand,
   ViewType,
-} from 'twenty-sdk';
+} from 'twenty-sdk/define';
 
 import { SCHEMA_IDS } from 'src/constants/schema-identifiers';
 
@@ -767,7 +767,7 @@ const flyAgainCommandMenuItemSource = `import {
   CommandMenuItemAvailabilityType,
   CommandMenuItemActionType,
   defineCommandMenuItem,
-} from 'twenty-sdk';
+} from 'twenty-sdk/define';
 
 import { SCHEMA_IDS } from 'src/constants/schema-identifiers';
 
@@ -794,7 +794,7 @@ const scheduleLaunchFromRocketCommandMenuItemSource = `import {
   CommandMenuItemAvailabilityType,
   CommandMenuItemActionType,
   defineCommandMenuItem,
-} from 'twenty-sdk';
+} from 'twenty-sdk/define';
 
 import { SCHEMA_IDS } from 'src/constants/schema-identifiers';
 
@@ -819,7 +819,7 @@ const retireRocketCommandMenuItemSource = `import {
   CommandMenuItemAvailabilityType,
   CommandMenuItemActionType,
   defineCommandMenuItem,
-} from 'twenty-sdk';
+} from 'twenty-sdk/define';
 
 import { SCHEMA_IDS } from 'src/constants/schema-identifiers';
 
@@ -844,7 +844,7 @@ const rescheduleLaunchCommandMenuItemSource = `import {
   CommandMenuItemAvailabilityType,
   CommandMenuItemActionType,
   defineCommandMenuItem,
-} from 'twenty-sdk';
+} from 'twenty-sdk/define';
 
 import { SCHEMA_IDS } from 'src/constants/schema-identifiers';
 
@@ -867,7 +867,7 @@ const addPayloadCommandMenuItemSource = `import {
   CommandMenuItemAvailabilityType,
   CommandMenuItemActionType,
   defineCommandMenuItem,
-} from 'twenty-sdk';
+} from 'twenty-sdk/define';
 
 import { SCHEMA_IDS } from 'src/constants/schema-identifiers';
 
@@ -892,7 +892,7 @@ const upcomingLaunchesCommandMenuItemSource = `import {
   CommandMenuItemAvailabilityType,
   CommandMenuItemActionType,
   defineCommandMenuItem,
-} from 'twenty-sdk';
+} from 'twenty-sdk/define';
 
 import { SCHEMA_IDS } from 'src/constants/schema-identifiers';
 
@@ -916,7 +916,7 @@ const bookSlotCommandMenuItemSource = `import {
   CommandMenuItemActionType,
   defineCommandMenuItem,
   STANDARD_OBJECT,
-} from 'twenty-sdk';
+} from 'twenty-sdk/define';
 
 import { SCHEMA_IDS } from 'src/constants/schema-identifiers';
 
@@ -944,7 +944,7 @@ const setPayloadStatusCommandMenuItemSource = `import {
   CommandMenuItemAvailabilityType,
   CommandMenuItemActionType,
   defineCommandMenuItem,
-} from 'twenty-sdk';
+} from 'twenty-sdk/define';
 
 import { SCHEMA_IDS } from 'src/constants/schema-identifiers';
 
@@ -968,7 +968,7 @@ const setCustomerStatusCommandMenuItemSource = `import {
   CommandMenuItemActionType,
   defineCommandMenuItem,
   STANDARD_OBJECT,
-} from 'twenty-sdk';
+} from 'twenty-sdk/define';
 
 import { SCHEMA_IDS } from 'src/constants/schema-identifiers';
 
@@ -993,7 +993,7 @@ const setSiteStatusCommandMenuItemSource = `import {
   CommandMenuItemAvailabilityType,
   CommandMenuItemActionType,
   defineCommandMenuItem,
-} from 'twenty-sdk';
+} from 'twenty-sdk/define';
 
 import { SCHEMA_IDS } from 'src/constants/schema-identifiers';
 
@@ -1017,7 +1017,7 @@ const bookWindowCommandMenuItemSource = `import {
   CommandMenuItemAvailabilityType,
   CommandMenuItemActionType,
   defineCommandMenuItem,
-} from 'twenty-sdk';
+} from 'twenty-sdk/define';
 
 import { SCHEMA_IDS } from 'src/constants/schema-identifiers';
 
@@ -1044,7 +1044,7 @@ const launchesFromSiteCommandMenuItemSource = `import {
   CommandMenuItemAvailabilityType,
   CommandMenuItemActionType,
   defineCommandMenuItem,
-} from 'twenty-sdk';
+} from 'twenty-sdk/define';
 
 import { SCHEMA_IDS } from 'src/constants/schema-identifiers';
 
@@ -1064,7 +1064,7 @@ export default defineCommandMenuItem({
 });
 `;
 
-const applicationConfigSource = `import { defineApplication } from 'twenty-sdk';
+const applicationConfigSource = `import { defineApplication } from 'twenty-sdk/define';
 
 import {
   APP_DESCRIPTION,


### PR DESCRIPTION
## Summary

Following the recent move of `defineXXX` exports (e.g. `defineLogicFunction`, `defineObject`, `defineFrontComponent`, …) from the `twenty-sdk` root entry to the `twenty-sdk/define` subpath, this PR aligns the documentation and the marketing site so users see the correct import paths.

- `packages/twenty-docs/developers/extend/apps/building.mdx`: every code snippet now imports `defineXXX` and related types/enums (`FieldType`, `RelationType`, `OnDeleteAction`, `STANDARD_OBJECT_UNIVERSAL_IDENTIFIERS`, `PermissionFlag`, `ViewKey`, `NavigationMenuItemType`, `PageLayoutTabLayoutMode`, `getPublicAssetUrl`, `DatabaseEventPayload`, `RoutePayload`, `InstallPayload`, …) from `twenty-sdk/define`. Mixed imports were split so that hooks and host-API helpers (`useRecordId`, `useUserId`, `useFrontComponentId`, `enqueueSnackbar`, `closeSidePanel`, `pageType`, `numberOfSelectedRecords`, `objectPermissions`, `everyEquals`, `isDefined`) come from `twenty-sdk/front-component`.
- `packages/twenty-website-new/.../DraggableTerminal/TerminalEditor/editorData.ts`: the 29 demo source strings shown in the homepage's draggable terminal now import from `twenty-sdk/define`.

Example apps under `packages/twenty-apps/{examples,internal,fixtures}` were already using the right subpaths, so no code changes were needed there.

Translations under `packages/twenty-docs/l/` are intentionally left untouched — they will be refreshed via Crowdin from the English source.

## Test plan

- [ ] Skim the rendered `building.mdx` on Mintlify preview to confirm code snippets look right.
- [ ] Visual check on the website's draggable terminal demo.


Made with [Cursor](https://cursor.com)