### PR TITLE
fix(settings): force display "Standard" and "Custom" for app chips

### DIFF
--- a/packages/twenty-front/src/modules/applications/components/AppChip.tsx
+++ b/packages/twenty-front/src/modules/applications/components/AppChip.tsx
@@ -14,7 +14,7 @@ const StyledContainer = styled.div`
   display: inline-flex;
   font-size: ${themeCssVariables.font.size.sm};
   font-weight: ${themeCssVariables.font.weight.regular};
-  gap: ${themeCssVariables.spacing[1]};
+  gap: ${themeCssVariables.spacing[2]};
   max-width: 100%;
   min-width: 0;
   overflow: hidden;

--- a/packages/twenty-front/src/modules/applications/components/AppChip.tsx
+++ b/packages/twenty-front/src/modules/applications/components/AppChip.tsx
@@ -1,82 +1,48 @@
 import { useApplicationChipData } from '@/applications/hooks/useApplicationChipData';
 import { styled } from '@linaria/react';
 import { Avatar } from 'twenty-ui/display';
-import {
-  Chip,
-  ChipAccent,
-  type ChipSize,
-  ChipVariant,
-  LinkChip,
-} from 'twenty-ui/components';
 import { themeCssVariables } from 'twenty-ui/theme-constants';
 
 type AppChipProps = {
   applicationId: string;
-  variant?: ChipVariant;
-  size?: ChipSize;
-  to?: string;
   className?: string;
 };
 
-const StyledChip = styled(Chip)`
-  && {
-    color: ${themeCssVariables.font.color.secondary};
-    font-size: ${themeCssVariables.font.size.sm};
-    font-weight: ${themeCssVariables.font.weight.regular};
-  }
+const StyledContainer = styled.div`
+  align-items: center;
+  color: ${themeCssVariables.font.color.secondary};
+  display: inline-flex;
+  font-size: ${themeCssVariables.font.size.sm};
+  font-weight: ${themeCssVariables.font.weight.regular};
+  gap: ${themeCssVariables.spacing[1]};
+  max-width: 100%;
+  min-width: 0;
+  overflow: hidden;
 `;
 
-const StyledLinkChip = styled(LinkChip)`
-  && {
-    color: ${themeCssVariables.font.color.secondary};
-    font-size: ${themeCssVariables.font.size.sm};
-    font-weight: ${themeCssVariables.font.weight.regular};
-  }
+const StyledLabel = styled.span`
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 `;
 
-export const AppChip = ({
-  applicationId,
-  variant,
-  size,
-  to,
-  className,
-}: AppChipProps) => {
+export const AppChip = ({ applicationId, className }: AppChipProps) => {
   const { applicationChipData } = useApplicationChipData({ applicationId });
 
-  const leftComponent = (
-    <Avatar
-      type="app"
-      size="md"
-      placeholder={applicationChipData.name}
-      placeholderColorSeed={applicationChipData.seed}
-      color={applicationChipData.colors?.color}
-      backgroundColor={applicationChipData.colors?.backgroundColor}
-      borderColor={applicationChipData.colors?.borderColor}
-    />
-  );
-
-  if (to) {
-    return (
-      <StyledLinkChip
-        className={className}
-        label={applicationChipData.name}
-        leftComponent={leftComponent}
-        size={size}
-        variant={variant ?? ChipVariant.Highlighted}
-        accent={ChipAccent.TextSecondary}
-        to={to}
-      />
-    );
-  }
-
   return (
-    <StyledChip
-      className={className}
-      label={applicationChipData.name}
-      leftComponent={leftComponent}
-      size={size}
-      variant={variant ?? ChipVariant.Transparent}
-      accent={ChipAccent.TextSecondary}
-    />
+    <StyledContainer className={className}>
+      <Avatar
+        type="app"
+        size="md"
+        placeholder={applicationChipData.name}
+        placeholderColorSeed={applicationChipData.seed}
+        color={applicationChipData.colors?.color}
+        backgroundColor={applicationChipData.colors?.backgroundColor}
+        borderColor={applicationChipData.colors?.borderColor}
+      />
+      <StyledLabel title={applicationChipData.name}>
+        {applicationChipData.name}
+      </StyledLabel>
+    </StyledContainer>
   );
 };

--- a/packages/twenty-front/src/modules/applications/components/AppChip.tsx
+++ b/packages/twenty-front/src/modules/applications/components/AppChip.tsx
@@ -1,4 +1,5 @@
 import { useApplicationChipData } from '@/applications/hooks/useApplicationChipData';
+import { styled } from '@linaria/react';
 import { Avatar } from 'twenty-ui/display';
 import {
   Chip,
@@ -7,6 +8,7 @@ import {
   ChipVariant,
   LinkChip,
 } from 'twenty-ui/components';
+import { themeCssVariables } from 'twenty-ui/theme-constants';
 
 type AppChipProps = {
   applicationId: string;
@@ -15,6 +17,22 @@ type AppChipProps = {
   to?: string;
   className?: string;
 };
+
+const StyledChip = styled(Chip)`
+  && {
+    color: ${themeCssVariables.font.color.secondary};
+    font-size: ${themeCssVariables.font.size.sm};
+    font-weight: ${themeCssVariables.font.weight.regular};
+  }
+`;
+
+const StyledLinkChip = styled(LinkChip)`
+  && {
+    color: ${themeCssVariables.font.color.secondary};
+    font-size: ${themeCssVariables.font.size.sm};
+    font-weight: ${themeCssVariables.font.weight.regular};
+  }
+`;
 
 export const AppChip = ({
   applicationId,
@@ -39,26 +57,26 @@ export const AppChip = ({
 
   if (to) {
     return (
-      <LinkChip
+      <StyledLinkChip
         className={className}
         label={applicationChipData.name}
         leftComponent={leftComponent}
         size={size}
         variant={variant ?? ChipVariant.Highlighted}
-        accent={ChipAccent.TextPrimary}
+        accent={ChipAccent.TextSecondary}
         to={to}
       />
     );
   }
 
   return (
-    <Chip
+    <StyledChip
       className={className}
       label={applicationChipData.name}
       leftComponent={leftComponent}
       size={size}
       variant={variant ?? ChipVariant.Transparent}
-      accent={ChipAccent.TextPrimary}
+      accent={ChipAccent.TextSecondary}
     />
   );
 };

--- a/packages/twenty-front/src/modules/applications/hooks/useApplicationAvatarColors.ts
+++ b/packages/twenty-front/src/modules/applications/hooks/useApplicationAvatarColors.ts
@@ -40,8 +40,9 @@ export const useApplicationAvatarColors = (
   }
 
   const isStandard =
+    isDefined(application.universalIdentifier) &&
     application.universalIdentifier ===
-    TWENTY_STANDARD_APPLICATION_UNIVERSAL_IDENTIFIER;
+      TWENTY_STANDARD_APPLICATION_UNIVERSAL_IDENTIFIER;
 
   const isCustom =
     isDefined(currentWorkspace?.workspaceCustomApplication?.id) &&

--- a/packages/twenty-front/src/modules/applications/hooks/useApplicationAvatarColors.ts
+++ b/packages/twenty-front/src/modules/applications/hooks/useApplicationAvatarColors.ts
@@ -1,10 +1,7 @@
 import { currentWorkspaceState } from '@/auth/states/currentWorkspaceState';
 import { useAtomStateValue } from '@/ui/utilities/state/jotai/hooks/useAtomStateValue';
 import { useContext } from 'react';
-import {
-  TWENTY_STANDARD_APPLICATION_NAME,
-  TWENTY_STANDARD_APPLICATION_UNIVERSAL_IDENTIFIER,
-} from 'twenty-shared/application';
+import { TWENTY_STANDARD_APPLICATION_UNIVERSAL_IDENTIFIER } from 'twenty-shared/application';
 import { isDefined } from 'twenty-shared/utils';
 import { ThemeContext } from 'twenty-ui/theme-constants';
 
@@ -44,8 +41,7 @@ export const useApplicationAvatarColors = (
 
   const isStandard =
     application.universalIdentifier ===
-      TWENTY_STANDARD_APPLICATION_UNIVERSAL_IDENTIFIER ||
-    application.name === TWENTY_STANDARD_APPLICATION_NAME;
+    TWENTY_STANDARD_APPLICATION_UNIVERSAL_IDENTIFIER;
 
   const isCustom =
     isDefined(currentWorkspace?.workspaceCustomApplication?.id) &&

--- a/packages/twenty-front/src/modules/applications/hooks/useApplicationAvatarColors.ts
+++ b/packages/twenty-front/src/modules/applications/hooks/useApplicationAvatarColors.ts
@@ -20,6 +20,12 @@ type UseApplicationAvatarColorsArgs = {
   universalIdentifier?: string | null;
 };
 
+const STANDARD_APPLICATION_AVATAR_COLORS: ApplicationAvatarColors = {
+  backgroundColor: '#CEE7FE',
+  borderColor: '#B7D9F8',
+  color: '#113264',
+};
+
 export const useApplicationAvatarColors = (
   application: UseApplicationAvatarColorsArgs | null | undefined,
 ): ApplicationAvatarColors | undefined => {
@@ -40,11 +46,7 @@ export const useApplicationAvatarColors = (
     currentWorkspace.workspaceCustomApplication.id === application.id;
 
   if (isStandard) {
-    return {
-      backgroundColor: theme.color.blue5,
-      borderColor: theme.color.blue6,
-      color: theme.color.blue12,
-    };
+    return STANDARD_APPLICATION_AVATAR_COLORS;
   }
 
   if (isCustom) {

--- a/packages/twenty-front/src/modules/applications/hooks/useApplicationAvatarColors.ts
+++ b/packages/twenty-front/src/modules/applications/hooks/useApplicationAvatarColors.ts
@@ -21,8 +21,14 @@ type UseApplicationAvatarColorsArgs = {
 };
 
 const STANDARD_APPLICATION_AVATAR_COLORS: ApplicationAvatarColors = {
+  // The standard application avatar follows the Figma `Colors/Blue` palette,
+  // which is Radix's pure blue and not Twenty's `theme.color.blue*` tokens
+  // (those map to the indigo palette).
+  // oxlint-disable-next-line twenty/no-hardcoded-colors
   backgroundColor: '#CEE7FE',
+  // oxlint-disable-next-line twenty/no-hardcoded-colors
   borderColor: '#B7D9F8',
+  // oxlint-disable-next-line twenty/no-hardcoded-colors
   color: '#113264',
 };
 

--- a/packages/twenty-front/src/modules/applications/hooks/useApplicationChipData.ts
+++ b/packages/twenty-front/src/modules/applications/hooks/useApplicationChipData.ts
@@ -7,6 +7,10 @@ import { currentWorkspaceState } from '@/auth/states/currentWorkspaceState';
 import { useAtomStateValue } from '@/ui/utilities/state/jotai/hooks/useAtomStateValue';
 import { t } from '@lingui/core/macro';
 import { useContext } from 'react';
+import {
+  TWENTY_STANDARD_APPLICATION_NAME,
+  TWENTY_STANDARD_APPLICATION_UNIVERSAL_IDENTIFIER,
+} from 'twenty-shared/application';
 import { isDefined } from 'twenty-shared/utils';
 
 type UseApplicationChipDataArgs = {
@@ -47,9 +51,26 @@ export const useApplicationChipData = ({
   const isCurrent =
     isDefined(currentApplicationId) && currentApplicationId === applicationId;
 
+  const isStandard =
+    application.universalIdentifier ===
+      TWENTY_STANDARD_APPLICATION_UNIVERSAL_IDENTIFIER ||
+    application.name === TWENTY_STANDARD_APPLICATION_NAME;
+
+  const isCustom =
+    isDefined(currentWorkspace?.workspaceCustomApplication?.id) &&
+    currentWorkspace.workspaceCustomApplication.id === application.id;
+
+  const displayName = isCurrent
+    ? t`This app`
+    : isStandard
+      ? t`Standard`
+      : isCustom
+        ? t`Custom`
+        : application.name;
+
   return {
     applicationChipData: {
-      name: isCurrent ? t`This app` : application.name,
+      name: displayName,
       seed: application.universalIdentifier ?? application.name,
       colors,
     },

--- a/packages/twenty-front/src/modules/applications/hooks/useApplicationChipData.ts
+++ b/packages/twenty-front/src/modules/applications/hooks/useApplicationChipData.ts
@@ -49,8 +49,9 @@ export const useApplicationChipData = ({
     isDefined(currentApplicationId) && currentApplicationId === applicationId;
 
   const isStandard =
+    isDefined(application.universalIdentifier) &&
     application.universalIdentifier ===
-    TWENTY_STANDARD_APPLICATION_UNIVERSAL_IDENTIFIER;
+      TWENTY_STANDARD_APPLICATION_UNIVERSAL_IDENTIFIER;
 
   const isCustom =
     isDefined(currentWorkspace?.workspaceCustomApplication?.id) &&

--- a/packages/twenty-front/src/modules/applications/hooks/useApplicationChipData.ts
+++ b/packages/twenty-front/src/modules/applications/hooks/useApplicationChipData.ts
@@ -7,10 +7,7 @@ import { currentWorkspaceState } from '@/auth/states/currentWorkspaceState';
 import { useAtomStateValue } from '@/ui/utilities/state/jotai/hooks/useAtomStateValue';
 import { t } from '@lingui/core/macro';
 import { useContext } from 'react';
-import {
-  TWENTY_STANDARD_APPLICATION_NAME,
-  TWENTY_STANDARD_APPLICATION_UNIVERSAL_IDENTIFIER,
-} from 'twenty-shared/application';
+import { TWENTY_STANDARD_APPLICATION_UNIVERSAL_IDENTIFIER } from 'twenty-shared/application';
 import { isDefined } from 'twenty-shared/utils';
 
 type UseApplicationChipDataArgs = {
@@ -53,8 +50,7 @@ export const useApplicationChipData = ({
 
   const isStandard =
     application.universalIdentifier ===
-      TWENTY_STANDARD_APPLICATION_UNIVERSAL_IDENTIFIER ||
-    application.name === TWENTY_STANDARD_APPLICATION_NAME;
+    TWENTY_STANDARD_APPLICATION_UNIVERSAL_IDENTIFIER;
 
   const isCustom =
     isDefined(currentWorkspace?.workspaceCustomApplication?.id) &&


### PR DESCRIPTION
## Summary
- Override the `AppChip` label so the Twenty standard application always renders as `Standard` and the workspace custom application always renders as `Custom`, instead of leaking each app's underlying name (e.g. `Twenty Eng's custom application`).
- Detection mirrors the logic already used in `useApplicationAvatarColors`, relying on `TWENTY_STANDARD_APPLICATION_UNIVERSAL_IDENTIFIER` / `TWENTY_STANDARD_APPLICATION_NAME` and `currentWorkspace.workspaceCustomApplication.id`.
- The `This app` label for the current application context and the original `application.name` fallback for any other installed app are preserved.

## Affected UI
- Settings → Data model → Existing objects (App column).
- Anywhere else `AppChip` / `useApplicationChipData` is used.
