### PR TITLE
docs: remove alpha warning from apps pages except skills & agents

### DIFF
--- a/packages/twenty-docs/developers/extend/apps/building.mdx
+++ b/packages/twenty-docs/developers/extend/apps/building.mdx
@@ -4,10 +4,6 @@ description: How Twenty apps work — sandboxing, lifecycle, and the building bl
 icon: "sitemap"
 ---
 
-<Warning>
-  Apps are currently in alpha. The feature works but is still evolving.
-</Warning>
-
 Twenty apps are TypeScript packages that extend your workspace with custom objects, logic, UI components, and AI capabilities. They run on the Twenty platform with full sandboxing and permission controls.
 
 ## How apps work

--- a/packages/twenty-docs/developers/extend/apps/cli-and-testing.mdx
+++ b/packages/twenty-docs/developers/extend/apps/cli-and-testing.mdx
@@ -4,10 +4,6 @@ description: CLI commands, testing setup, public assets, npm packages, remotes, 
 icon: "terminal"
 ---
 
-<Warning>
-  Apps are currently in alpha. The feature works but is still evolving.
-</Warning>
-
 ## Public assets (`public/` folder)
 
 The `public/` folder at the root of your app holds static files — images, icons, fonts, or any other assets your app needs at runtime. These files are automatically included in builds, synced during dev mode, and uploaded to the server.

--- a/packages/twenty-docs/developers/extend/apps/data-model.mdx
+++ b/packages/twenty-docs/developers/extend/apps/data-model.mdx
@@ -4,10 +4,6 @@ description: Define objects, fields, roles, and application metadata with the Tw
 icon: "database"
 ---
 
-<Warning>
-  Apps are currently in alpha. The feature works but is still evolving.
-</Warning>
-
 The `twenty-sdk` package provides `defineEntity` functions to declare your app's data model. You must use `export default defineEntity({...})` for the SDK to detect your entities. These functions validate your configuration at build time and provide IDE autocompletion and type safety.
 
 <Note>

--- a/packages/twenty-docs/developers/extend/apps/front-components.mdx
+++ b/packages/twenty-docs/developers/extend/apps/front-components.mdx
@@ -4,10 +4,6 @@ description: Build React components that render inside Twenty's UI with sandboxe
 icon: "window-maximize"
 ---
 
-<Warning>
-  Apps are currently in alpha. The feature works but is still evolving.
-</Warning>
-
 Front components are React components that render directly inside Twenty's UI. They run in an **isolated Web Worker** using Remote DOM — your code is sandboxed but renders natively in the page, not in an iframe.
 
 ## Where front components can be used

--- a/packages/twenty-docs/developers/extend/apps/getting-started.mdx
+++ b/packages/twenty-docs/developers/extend/apps/getting-started.mdx
@@ -4,10 +4,6 @@ icon: "rocket"
 description: Create your first Twenty app in minutes.
 ---
 
-<Warning>
-Apps are currently in alpha. The feature works but is still evolving.
-</Warning>
-
 ## What are apps?
 
 Apps let you extend Twenty with custom objects, fields, logic functions, front components, AI skills, and more — all managed as code. Instead of configuring everything through the UI, you define your data model and logic in TypeScript and deploy it to one or more workspaces.

--- a/packages/twenty-docs/developers/extend/apps/layout.mdx
+++ b/packages/twenty-docs/developers/extend/apps/layout.mdx
@@ -4,10 +4,6 @@ description: Define views, navigation menu items, and page layouts to shape how 
 icon: "table-columns"
 ---
 
-<Warning>
-  Apps are currently in alpha. The feature works but is still evolving.
-</Warning>
-
 Layout entities control how your app surfaces inside Twenty's UI — what lives in the sidebar, which saved views ship with the app, and how a record detail page is arranged.
 
 ## Layout concepts

--- a/packages/twenty-docs/developers/extend/apps/logic-functions.mdx
+++ b/packages/twenty-docs/developers/extend/apps/logic-functions.mdx
@@ -4,10 +4,6 @@ description: Define server-side TypeScript functions with HTTP, cron, and databa
 icon: "bolt"
 ---
 
-<Warning>
-  Apps are currently in alpha. The feature works but is still evolving.
-</Warning>
-
 Logic functions are server-side TypeScript functions that run on the Twenty platform. They can be triggered by HTTP requests, cron schedules, or database events — and can also be exposed as tools for AI agents.
 
 <AccordionGroup>

--- a/packages/twenty-docs/developers/extend/apps/publishing.mdx
+++ b/packages/twenty-docs/developers/extend/apps/publishing.mdx
@@ -4,10 +4,6 @@ icon: "upload"
 description: Distribute your Twenty app to the marketplace or deploy it internally.
 ---
 
-<Warning>
-  Apps are currently in alpha. The feature works but is still evolving.
-</Warning>
-
 ## Overview
 
 Once your app is [built and tested locally](/developers/extend/apps/building), you have two paths for distributing it:

--- a/packages/twenty-docs/developers/extend/apps/skills-and-agents.mdx
+++ b/packages/twenty-docs/developers/extend/apps/skills-and-agents.mdx
@@ -5,7 +5,7 @@ icon: "robot"
 ---
 
 <Warning>
-  Apps are currently in alpha. The feature works but is still evolving.
+  Skills and agents are currently in alpha. The feature works but is still evolving.
 </Warning>
 
 Apps can define AI capabilities that live inside the workspace — reusable skill instructions and agents with custom system prompts.


### PR DESCRIPTION
## Summary
- Remove the \"Apps are currently in alpha\" warning from 8 pages under `developers/extend/apps/` (getting-started, architecture/building, data-model, layout, logic-functions, front-components, cli-and-testing, publishing).
- Keep the warning on the Skills & Agents page only, and reword it to scope it to that feature: \"Skills and agents are currently in alpha. The feature works but is still evolving.\"

## Test plan
- [ ] Preview docs build and confirm the warning banner no longer appears on the 8 pages above.
- [ ] Confirm the warning still renders on the Skills & Agents page with the updated wording.

🤖 Generated with [Claude Code](https://claude.com/claude-code)