### PR TITLE
Export generateDefaultFieldUniversalIdentifier from SDK

### DIFF
--- a/packages/twenty-sdk/src/cli/utilities/build/manifest/utils/__tests__/get-default-object-fields.spec.ts
+++ b/packages/twenty-sdk/src/cli/utilities/build/manifest/utils/__tests__/get-default-object-fields.spec.ts
@@ -1,6 +1,6 @@
 import { FieldMetadataType } from 'twenty-shared/types';
 import { getDefaultObjectFields } from '@/cli/utilities/build/manifest/utils/get-default-object-fields';
-import { generateDefaultFieldUniversalIdentifier } from '@/cli/utilities/build/manifest/utils/generate-default-field-universal-identifier';
+import { generateDefaultFieldUniversalIdentifier } from '@/sdk/define/objects/generate-default-field-universal-identifier';
 import type { ObjectConfig } from '@/sdk/define/objects/object-config';
 
 const mockObjectConfig: ObjectConfig = {
@@ -14,7 +14,7 @@ const mockObjectConfig: ObjectConfig = {
 
 const expectedUniversalId = (fieldName: string) =>
   generateDefaultFieldUniversalIdentifier({
-    objectConfig: mockObjectConfig,
+    objectUniversalIdentifier: mockObjectConfig.universalIdentifier,
     fieldName,
   });
 

--- a/packages/twenty-sdk/src/cli/utilities/build/manifest/utils/get-default-object-fields.ts
+++ b/packages/twenty-sdk/src/cli/utilities/build/manifest/utils/get-default-object-fields.ts
@@ -1,11 +1,13 @@
 import type { ObjectConfig } from '@/sdk/define/objects/object-config';
 import { FieldMetadataType } from 'twenty-shared/types';
-import { generateDefaultFieldUniversalIdentifier } from '@/cli/utilities/build/manifest/utils/generate-default-field-universal-identifier';
+import { generateDefaultFieldUniversalIdentifier } from '@/sdk/define/objects/generate-default-field-universal-identifier';
 import { type ObjectFieldManifest } from 'twenty-shared/application';
 
 export const getDefaultObjectFields = (
   objectConfig: ObjectConfig,
 ): ObjectFieldManifest[] => {
+  const objectUniversalIdentifier = objectConfig.universalIdentifier;
+
   const idField: ObjectFieldManifest = {
     name: 'id',
     label: 'Id',
@@ -15,7 +17,7 @@ export const getDefaultObjectFields = (
     defaultValue: 'uuid',
     type: FieldMetadataType.UUID as const,
     universalIdentifier: generateDefaultFieldUniversalIdentifier({
-      objectConfig,
+      objectUniversalIdentifier,
       fieldName: 'id',
     }),
   };
@@ -29,7 +31,7 @@ export const getDefaultObjectFields = (
     defaultValue: null,
     type: FieldMetadataType.TEXT as const,
     universalIdentifier: generateDefaultFieldUniversalIdentifier({
-      objectConfig,
+      objectUniversalIdentifier,
       fieldName: 'name',
     }),
   };
@@ -43,7 +45,7 @@ export const getDefaultObjectFields = (
     defaultValue: 'now',
     type: FieldMetadataType.DATE_TIME as const,
     universalIdentifier: generateDefaultFieldUniversalIdentifier({
-      objectConfig,
+      objectUniversalIdentifier,
       fieldName: 'createdAt',
     }),
   };
@@ -57,7 +59,7 @@ export const getDefaultObjectFields = (
     defaultValue: 'now',
     type: FieldMetadataType.DATE_TIME as const,
     universalIdentifier: generateDefaultFieldUniversalIdentifier({
-      objectConfig,
+      objectUniversalIdentifier,
       fieldName: 'updatedAt',
     }),
   };
@@ -71,7 +73,7 @@ export const getDefaultObjectFields = (
     defaultValue: null,
     type: FieldMetadataType.DATE_TIME as const,
     universalIdentifier: generateDefaultFieldUniversalIdentifier({
-      objectConfig,
+      objectUniversalIdentifier,
       fieldName: 'deletedAt',
     }),
   };
@@ -85,7 +87,7 @@ export const getDefaultObjectFields = (
     defaultValue: { name: "''", source: "'MANUAL'" },
     type: FieldMetadataType.ACTOR as const,
     universalIdentifier: generateDefaultFieldUniversalIdentifier({
-      objectConfig,
+      objectUniversalIdentifier,
       fieldName: 'createdBy',
     }),
   };
@@ -99,7 +101,7 @@ export const getDefaultObjectFields = (
     defaultValue: { name: "''", source: "'MANUAL'" },
     type: FieldMetadataType.ACTOR as const,
     universalIdentifier: generateDefaultFieldUniversalIdentifier({
-      objectConfig,
+      objectUniversalIdentifier,
       fieldName: 'updatedBy',
     }),
   };
@@ -113,7 +115,7 @@ export const getDefaultObjectFields = (
     defaultValue: 0,
     type: FieldMetadataType.POSITION,
     universalIdentifier: generateDefaultFieldUniversalIdentifier({
-      objectConfig,
+      objectUniversalIdentifier,
       fieldName: 'position',
     }),
   };
@@ -127,7 +129,7 @@ export const getDefaultObjectFields = (
     defaultValue: null,
     type: FieldMetadataType.TS_VECTOR,
     universalIdentifier: generateDefaultFieldUniversalIdentifier({
-      objectConfig,
+      objectUniversalIdentifier,
       fieldName: 'searchVector',
     }),
   };

--- a/packages/twenty-sdk/src/cli/utilities/build/manifest/utils/get-default-relation-object-fields.ts
+++ b/packages/twenty-sdk/src/cli/utilities/build/manifest/utils/get-default-relation-object-fields.ts
@@ -1,4 +1,4 @@
-import { generateDefaultFieldUniversalIdentifier } from '@/cli/utilities/build/manifest/utils/generate-default-field-universal-identifier';
+import { generateDefaultFieldUniversalIdentifier } from '@/sdk/define/objects/generate-default-field-universal-identifier';
 import { RelationType } from '@/sdk/define';
 import type { ObjectConfig } from '@/sdk/define/objects/object-config';
 import {
@@ -130,13 +130,13 @@ export const getDefaultRelationObjectFields = (
 
     const forwardFieldUniversalIdentifier =
       generateDefaultFieldUniversalIdentifier({
-        objectConfig,
+        objectUniversalIdentifier: objectConfig.universalIdentifier,
         fieldName: config.fieldName,
       });
 
     const reverseFieldUniversalIdentifier =
       generateDefaultFieldUniversalIdentifier({
-        objectConfig,
+        objectUniversalIdentifier: objectConfig.universalIdentifier,
         fieldName: `${config.fieldName}Inverse`,
       });
 

--- a/packages/twenty-sdk/src/sdk/define/index.ts
+++ b/packages/twenty-sdk/src/sdk/define/index.ts
@@ -63,6 +63,7 @@ export type { InputJsonSchema } from 'twenty-shared/logic-function';
 export { defineNavigationMenuItem } from '@/sdk/define/navigation-menu-items/define-navigation-menu-item';
 
 export { defineObject } from '@/sdk/define/objects/define-object';
+export { generateDefaultFieldUniversalIdentifier } from '@/sdk/define/objects/generate-default-field-universal-identifier';
 export {
   STANDARD_OBJECT_UNIVERSAL_IDENTIFIERS as STANDARD_OBJECT,
   STANDARD_OBJECT_UNIVERSAL_IDENTIFIERS,

--- a/packages/twenty-sdk/src/sdk/define/objects/__tests__/generate-default-field-universal-identifier.spec.ts
+++ b/packages/twenty-sdk/src/sdk/define/objects/__tests__/generate-default-field-universal-identifier.spec.ts
@@ -1,23 +1,20 @@
-import { generateDefaultFieldUniversalIdentifier } from '@/cli/utilities/build/manifest/utils/generate-default-field-universal-identifier';
-import { type ObjectConfig } from '@/sdk/define/objects/object-config';
+import { generateDefaultFieldUniversalIdentifier } from '@/sdk/define/objects/generate-default-field-universal-identifier';
 
 describe('generateDefaultFieldUniversalIdentifier', () => {
   it('should generate a unique universal identifier', () => {
-    const objectConfig = {
-      universalIdentifier: '55b79f88-4094-4b3f-a0ac-1a91a55714f2',
-    } as ObjectConfig;
+    const objectUniversalIdentifier = '55b79f88-4094-4b3f-a0ac-1a91a55714f2';
 
     const uId1 = generateDefaultFieldUniversalIdentifier({
-      objectConfig,
+      objectUniversalIdentifier,
       fieldName: 'id',
     });
     const uId2 = generateDefaultFieldUniversalIdentifier({
-      objectConfig,
+      objectUniversalIdentifier,
       fieldName: 'id',
     });
 
     const anotherUId = generateDefaultFieldUniversalIdentifier({
-      objectConfig,
+      objectUniversalIdentifier,
       fieldName: 'name',
     });
 

--- a/packages/twenty-sdk/src/sdk/define/objects/generate-default-field-universal-identifier.ts
+++ b/packages/twenty-sdk/src/sdk/define/objects/generate-default-field-universal-identifier.ts
@@ -1,16 +1,15 @@
-import type { ObjectConfig } from '@/sdk/define/objects/object-config';
 import { v5 } from 'uuid';
 
 const UNIVERSAL_IDENTIFIER_NAMESPACE = '142046f0-4d80-48b5-ad56-26ad410e895c';
 
 export const generateDefaultFieldUniversalIdentifier = ({
-  objectConfig,
+  objectUniversalIdentifier,
   fieldName,
 }: {
-  objectConfig: ObjectConfig;
+  objectUniversalIdentifier: string;
   fieldName: string;
 }) => {
-  const seed = `${objectConfig.universalIdentifier}-${fieldName}`;
+  const seed = `${objectUniversalIdentifier}-${fieldName}`;
 
   return v5(seed, UNIVERSAL_IDENTIFIER_NAMESPACE);
 };


### PR DESCRIPTION
## Context
- Moved generateDefaultFieldUniversalIdentifier from the internal
cli/utilities/build/manifest/utils/ folder to sdk/define/objects/ and re-exported it from
the public twenty-sdk/define entry point, so app authors can compute the deterministic UID
of a default field (id, name, createdAt, …) from their own code.
- Narrowed the signature from { objectConfig: ObjectConfig; fieldName } to {
objectUniversalIdentifier: string; fieldName: string } — the only thing the helper needs,
and what app code has on hand.
- Updated the two internal callers and the spec to the new import path and signature.

```typescript
import {
  defineView,
  generateDefaultFieldUniversalIdentifier,
} from "twenty-sdk/define";

export default defineView({
  universalIdentifier: "70f10d44-144a-4da8-8c6f-3ec2422138c0",
  name: "all-thing",
  objectUniversalIdentifier: "c782b61c-70fd-4c88-9cd6-4e61ab8d7591",
  icon: "IconList",
  position: 0,
  fields: [
    {
      universalIdentifier: "75a90bc4-d901-4df4-85e0-af29db5e0104",
      fieldMetadataUniversalIdentifier: generateDefaultFieldUniversalIdentifier(
        {
          objectUniversalIdentifier: "c782b61c-70fd-4c88-9cd6-4e61ab8d7591",
          fieldName: "createdAt",
        },
      ),
      position: 0,
      isVisible: true,
      size: 200,
    },
    {
      universalIdentifier: "75a90bc5-d901-4df4-85e0-af29db5e0105",
      fieldMetadataUniversalIdentifier: generateDefaultFieldUniversalIdentifier(
        {
          objectUniversalIdentifier: "c782b61c-70fd-4c88-9cd6-4e61ab8d7591",
          fieldName: "createdBy",
        },
      ),
      position: 0,
      isVisible: true,
      size: 200,
    },
  ],
});
```
