### PR TITLE
feat: add inline creation and editing for relational objects in Recor…

### DIFF
--- a/packages/twenty-front/src/modules/object-record/record-field-list/record-detail-section/relation/components/RecordDetailInlineRelationCreateForm.tsx
+++ b/packages/twenty-front/src/modules/object-record/record-field-list/record-detail-section/relation/components/RecordDetailInlineRelationCreateForm.tsx
@@ -1,0 +1,90 @@
+import { styled } from '@linaria/react';
+
+import { RecordFieldList } from '@/object-record/record-field-list/components/RecordFieldList';
+import { RecordDetailRecordsListItemContainer } from '@/object-record/record-field-list/record-detail-section/components/RecordDetailRecordsListItemContainer';
+import { RecordChip } from '@/object-record/components/RecordChip';
+import { useDeleteOneRecord } from '@/object-record/hooks/useDeleteOneRecord';
+import { type FieldMetadataItem } from '@/object-metadata/types/FieldMetadataItem';
+import { type EnrichedObjectMetadataItem } from '@/object-metadata/types/EnrichedObjectMetadataItem';
+import { t } from '@lingui/core/macro';
+import { themeCssVariables } from 'twenty-ui/theme-constants';
+import { Button } from 'twenty-ui/input';
+
+const StyledInlineCreateWrapper = styled.div`
+  background-color: ${themeCssVariables.background.secondary};
+  border-radius: ${themeCssVariables.border.radius.sm};
+  margin-bottom: ${themeCssVariables.spacing[1]};
+`;
+
+const StyledFormActions = styled.div`
+  border-top: 1px solid ${themeCssVariables.border.color.light};
+  display: flex;
+  gap: ${themeCssVariables.spacing[2]};
+  justify-content: flex-end;
+  padding: ${themeCssVariables.spacing[1]} ${themeCssVariables.spacing[2]};
+`;
+
+type RecordDetailInlineRelationCreateFormProps = {
+  newRecordId: string;
+  relationObjectMetadataItem: EnrichedObjectMetadataItem;
+  relationFieldMetadataItem: FieldMetadataItem;
+  scopeInstanceId: string;
+  onDone: () => void;
+  onCancel: (newRecordId: string) => void;
+};
+
+export const RecordDetailInlineRelationCreateForm = ({
+  newRecordId,
+  relationObjectMetadataItem,
+  relationFieldMetadataItem,
+  scopeInstanceId,
+  onDone,
+  onCancel,
+}: RecordDetailInlineRelationCreateFormProps) => {
+  const { deleteOneRecord } = useDeleteOneRecord({
+    objectNameSingular: relationObjectMetadataItem.nameSingular,
+  });
+
+  const handleCancel = async () => {
+    await deleteOneRecord(newRecordId);
+    onCancel(newRecordId);
+  };
+
+  return (
+    <StyledInlineCreateWrapper>
+      <RecordDetailRecordsListItemContainer>
+        <RecordChip
+          record={{
+            id: newRecordId,
+            __typename: relationObjectMetadataItem.nameSingular,
+          }}
+          objectNameSingular={relationObjectMetadataItem.nameSingular}
+          forceDisableClick={true}
+        />
+      </RecordDetailRecordsListItemContainer>
+      <RecordFieldList
+        instanceId={`${scopeInstanceId}-inline-create-${newRecordId}`}
+        objectNameSingular={relationObjectMetadataItem.nameSingular}
+        objectRecordId={newRecordId}
+        showDuplicatesSection={false}
+        showRelationSections={false}
+        excludeCreatedAtAndUpdatedAt={true}
+        excludeFieldMetadataIds={[relationFieldMetadataItem.id]}
+      />
+      <StyledFormActions>
+        <Button
+          title={t`Discard`}
+          variant="secondary"
+          size="small"
+          onClick={handleCancel}
+        />
+        <Button
+          title={t`Done`}
+          variant="primary"
+          size="small"
+          onClick={onDone}
+        />
+      </StyledFormActions>
+    </StyledInlineCreateWrapper>
+  );
+};

--- a/packages/twenty-front/src/modules/object-record/record-field-list/record-detail-section/relation/components/RecordDetailRelationRecordsList.tsx
+++ b/packages/twenty-front/src/modules/object-record/record-field-list/record-detail-section/relation/components/RecordDetailRelationRecordsList.tsx
@@ -1,28 +1,64 @@
 import { Fragment, useState } from 'react';
 
+import { type FieldMetadataItem } from '@/object-metadata/types/FieldMetadataItem';
+import { type EnrichedObjectMetadataItem } from '@/object-metadata/types/EnrichedObjectMetadataItem';
 import { RecordDetailRecordsListContainer } from '@/object-record/record-field-list/record-detail-section/components/RecordDetailRecordsListContainer';
+import { RecordDetailInlineRelationCreateForm } from '@/object-record/record-field-list/record-detail-section/relation/components/RecordDetailInlineRelationCreateForm';
 import { RecordDetailRelationRecordsListItem } from '@/object-record/record-field-list/record-detail-section/relation/components/RecordDetailRelationRecordsListItem';
 import { RecordDetailRelationRecordsListItemEffect } from '@/object-record/record-field-list/record-detail-section/relation/components/RecordDetailRelationRecordsListItemEffect';
+import { useRecordFieldsScopeContextOrThrow } from '@/object-record/record-field-list/contexts/RecordFieldsScopeContext';
 import { type ObjectRecord } from '@/object-record/types/ObjectRecord';
+import { isDefined } from 'twenty-shared/utils';
 
-type RecordDetailRelationRecordsListProps = {
+type RelationRecordWithObjectNameSingular = {
   objectNameSingular: string;
   value: ObjectRecord;
   fieldMetadataId: string;
 };
 
+type RecordDetailRelationRecordsListProps = {
+  recordsWithObjectNameSingular: RelationRecordWithObjectNameSingular[];
+  inlineCreateRecordIds?: string[];
+  relationObjectMetadataItem?: EnrichedObjectMetadataItem;
+  relationFieldMetadataItem?: FieldMetadataItem;
+  onInlineCreateDone?: (recordId: string) => void;
+  onInlineCreateCancel?: (recordId: string) => void;
+};
+
 export const RecordDetailRelationRecordsList = ({
   recordsWithObjectNameSingular,
-}: {
-  recordsWithObjectNameSingular: RecordDetailRelationRecordsListProps[];
-}) => {
+  inlineCreateRecordIds,
+  relationObjectMetadataItem,
+  relationFieldMetadataItem,
+  onInlineCreateDone,
+  onInlineCreateCancel,
+}: RecordDetailRelationRecordsListProps) => {
+  const { scopeInstanceId } = useRecordFieldsScopeContextOrThrow();
   const [expandedItem, setExpandedItem] = useState('');
 
   const handleItemClick = (recordId: string) =>
     setExpandedItem(recordId === expandedItem ? '' : recordId);
 
+  const showInlineCreateForms =
+    isDefined(inlineCreateRecordIds) &&
+    inlineCreateRecordIds.length > 0 &&
+    isDefined(relationObjectMetadataItem) &&
+    isDefined(relationFieldMetadataItem);
+
   return (
     <RecordDetailRecordsListContainer>
+      {showInlineCreateForms &&
+        inlineCreateRecordIds.map((newRecordId) => (
+          <RecordDetailInlineRelationCreateForm
+            key={newRecordId}
+            newRecordId={newRecordId}
+            relationObjectMetadataItem={relationObjectMetadataItem}
+            relationFieldMetadataItem={relationFieldMetadataItem}
+            scopeInstanceId={scopeInstanceId}
+            onDone={() => onInlineCreateDone?.(newRecordId)}
+            onCancel={onInlineCreateCancel ?? (() => {})}
+          />
+        ))}
       {recordsWithObjectNameSingular
         .slice(0, 5)
         .map((recordWithObjectNameSingular) => (

--- a/packages/twenty-front/src/modules/object-record/record-field-list/record-detail-section/relation/components/RecordDetailRelationSection.tsx
+++ b/packages/twenty-front/src/modules/object-record/record-field-list/record-detail-section/relation/components/RecordDetailRelationSection.tsx
@@ -1,4 +1,4 @@
-import { useContext } from 'react';
+import { useCallback, useContext, useState } from 'react';
 
 import { useObjectMetadataItem } from '@/object-metadata/hooks/useObjectMetadataItem';
 import { useObjectMetadataItems } from '@/object-metadata/hooks/useObjectMetadataItems';
@@ -177,9 +177,29 @@ export const RecordDetailRelationSection = ({
     });
   };
 
+  const [inlineCreateRecordIds, setInlineCreateRecordIds] = useState<string[]>(
+    [],
+  );
+
+  const handleInlineCreate = useCallback((newRecordId: string) => {
+    setInlineCreateRecordIds((prev) => [...prev, newRecordId]);
+  }, []);
+
+  const handleInlineCreateDone = useCallback((recordId: string) => {
+    setInlineCreateRecordIds((prev) => prev.filter((id) => id !== recordId));
+  }, []);
+
+  const handleInlineCreateCancel = useCallback((recordId: string) => {
+    setInlineCreateRecordIds((prev) => prev.filter((id) => id !== recordId));
+  }, []);
+
   if (loading) return null;
 
   const relationRecordsCount = relationAggregateResult?.id?.COUNT ?? 0;
+
+  const relationFieldMetadataItemForCreate = relationObjectMetadataItem.fields.find(
+    ({ id }) => id === relationFieldMetadataId,
+  );
 
   return (
     <FieldInputEventContext.Provider
@@ -202,12 +222,18 @@ export const RecordDetailRelationSection = ({
             : undefined
         }
         hideRightAdornmentOnMouseLeave={!isDropdownOpen && !isMobile}
-        areRecordsAvailable={relationRecords.length > 0}
+        areRecordsAvailable={
+          relationRecords.length > 0 || inlineCreateRecordIds.length > 0
+        }
         rightAdornment={
-          <RecordDetailRelationSectionDropdown loading={loading} />
+          <RecordDetailRelationSectionDropdown
+            loading={loading}
+            onInlineCreate={handleInlineCreate}
+          />
         }
       >
-        {relationRecords.length > 0 && (
+        {(relationRecords.length > 0 ||
+          inlineCreateRecordIds.length > 0) && (
           <RecordDetailRelationRecordsList
             recordsWithObjectNameSingular={relationRecords.map(
               (relationRecord) => ({
@@ -216,6 +242,11 @@ export const RecordDetailRelationSection = ({
                 fieldMetadataId: relationFieldMetadataId,
               }),
             )}
+            inlineCreateRecordIds={inlineCreateRecordIds}
+            relationObjectMetadataItem={relationObjectMetadataItem}
+            relationFieldMetadataItem={relationFieldMetadataItemForCreate}
+            onInlineCreateDone={handleInlineCreateDone}
+            onInlineCreateCancel={handleInlineCreateCancel}
           />
         )}
       </RecordDetailSectionContainer>

--- a/packages/twenty-front/src/modules/object-record/record-field-list/record-detail-section/relation/components/RecordDetailRelationSectionDropdown.tsx
+++ b/packages/twenty-front/src/modules/object-record/record-field-list/record-detail-section/relation/components/RecordDetailRelationSectionDropdown.tsx
@@ -11,11 +11,13 @@ import { RelationType } from '~/generated-metadata/graphql';
 type RecordDetailRelationSectionDropdownProps = {
   loading: boolean;
   dropdownTriggerClickableComponent?: ReactNode;
+  onInlineCreate?: (newRecordId: string) => void;
 };
 
 export const RecordDetailRelationSectionDropdown = ({
   loading,
   dropdownTriggerClickableComponent,
+  onInlineCreate,
 }: RecordDetailRelationSectionDropdownProps) => {
   const { fieldDefinition, isRecordFieldReadOnly, recordId } =
     useContext(FieldContext);
@@ -57,12 +59,14 @@ export const RecordDetailRelationSectionDropdown = ({
     return (
       <RecordDetailRelationSectionDropdownToOne
         dropdownTriggerClickableComponent={dropdownTriggerClickableComponent}
+        onInlineCreate={onInlineCreate}
       />
     );
   } else if (isToManyObjects) {
     return (
       <RecordDetailRelationSectionDropdownToMany
         dropdownTriggerClickableComponent={dropdownTriggerClickableComponent}
+        onInlineCreate={onInlineCreate}
       />
     );
   } else {

--- a/packages/twenty-front/src/modules/object-record/record-field-list/record-detail-section/relation/components/RecordDetailRelationSectionDropdownToMany.tsx
+++ b/packages/twenty-front/src/modules/object-record/record-field-list/record-detail-section/relation/components/RecordDetailRelationSectionDropdownToMany.tsx
@@ -10,6 +10,7 @@ import { useRecordFieldsScopeContextOrThrow } from '@/object-record/record-field
 import { FieldContext } from '@/object-record/record-field/ui/contexts/FieldContext';
 import { useUpdateJunctionRelationFromCell } from '@/object-record/record-field/ui/hooks/useUpdateJunctionRelationFromCell';
 import { useAddNewRecordAndOpenSidePanel } from '@/object-record/record-field/ui/meta-types/input/hooks/useAddNewRecordAndOpenSidePanel';
+import { useCreateRelatedRecord } from '@/object-record/record-field/ui/meta-types/input/hooks/useCreateRelatedRecord';
 import { useUpdateRelationOneToManyFieldInput } from '@/object-record/record-field/ui/meta-types/input/hooks/useUpdateRelationOneToManyFieldInput';
 import { type FieldDefinition } from '@/object-record/record-field/ui/types/FieldDefinition';
 import { type FieldRelationMetadata } from '@/object-record/record-field/ui/types/FieldMetadata';
@@ -42,10 +43,12 @@ import { LightIconButton } from 'twenty-ui/input';
 
 type RecordDetailRelationSectionDropdownToManyProps = {
   dropdownTriggerClickableComponent?: ReactNode;
+  onInlineCreate?: (newRecordId: string) => void;
 };
 
 export const RecordDetailRelationSectionDropdownToMany = ({
   dropdownTriggerClickableComponent,
+  onInlineCreate,
 }: RecordDetailRelationSectionDropdownToManyProps) => {
   const store = useStore();
   const { scopeInstanceId } = useRecordFieldsScopeContextOrThrow();
@@ -204,6 +207,15 @@ export const RecordDetailRelationSectionDropdownToMany = ({
     recordId,
   });
 
+  const { createRelatedRecord } = useCreateRelatedRecord({
+    fieldMetadataItem,
+    objectMetadataItem,
+    relationObjectMetadataNameSingular,
+    relationObjectMetadataItem,
+    relationFieldMetadataItem,
+    recordId,
+  });
+
   const { createOneRecord: createTargetRecord } = useCreateOneRecord({
     objectNameSingular:
       junctionTargetObjectMetadata?.nameSingular ??
@@ -335,7 +347,13 @@ export const RecordDetailRelationSectionDropdownToMany = ({
       }
 
       closeDropdown(dropdownId);
-      createNewRecordAndOpenSidePanel?.(searchString);
+
+      if (isDefined(onInlineCreate) && isDefined(createRelatedRecord)) {
+        const newRecordId = await createRelatedRecord(searchString);
+        onInlineCreate(newRecordId);
+      } else {
+        createNewRecordAndOpenSidePanel?.(searchString);
+      }
     },
     [
       closeDropdown,
@@ -351,6 +369,8 @@ export const RecordDetailRelationSectionDropdownToMany = ({
       multipleRecordPickerPickableMorphItemsCallbackState,
       multipleRecordPickerPerformSearch,
       objectMetadataItem,
+      onInlineCreate,
+      createRelatedRecord,
       pickerObjectMetadataItem,
       recordId,
       store,

--- a/packages/twenty-front/src/modules/object-record/record-field-list/record-detail-section/relation/components/RecordDetailRelationSectionDropdownToOne.tsx
+++ b/packages/twenty-front/src/modules/object-record/record-field-list/record-detail-section/relation/components/RecordDetailRelationSectionDropdownToOne.tsx
@@ -6,6 +6,7 @@ import { useRecordFieldsScopeContextOrThrow } from '@/object-record/record-field
 import { FieldContext } from '@/object-record/record-field/ui/contexts/FieldContext';
 import { FieldInputEventContext } from '@/object-record/record-field/ui/contexts/FieldInputEventContext';
 import { useAddNewRecordAndOpenSidePanel } from '@/object-record/record-field/ui/meta-types/input/hooks/useAddNewRecordAndOpenSidePanel';
+import { useCreateRelatedRecord } from '@/object-record/record-field/ui/meta-types/input/hooks/useCreateRelatedRecord';
 import { SingleRecordPicker } from '@/object-record/record-picker/single-record-picker/components/SingleRecordPicker';
 import { useSingleRecordPickerOpen } from '@/object-record/record-picker/single-record-picker/hooks/useSingleRecordPickerOpen';
 import { singleRecordPickerSearchFilterComponentState } from '@/object-record/record-picker/single-record-picker/states/singleRecordPickerSearchFilterComponentState';
@@ -31,10 +32,12 @@ import { LightIconButton } from 'twenty-ui/input';
 
 type RecordDetailRelationSectionDropdownToOneProps = {
   dropdownTriggerClickableComponent?: ReactNode;
+  onInlineCreate?: (newRecordId: string) => void;
 };
 
 export const RecordDetailRelationSectionDropdownToOne = ({
   dropdownTriggerClickableComponent,
+  onInlineCreate,
 }: RecordDetailRelationSectionDropdownToOneProps) => {
   const { scopeInstanceId } = useRecordFieldsScopeContextOrThrow();
   const { recordId, fieldDefinition } = useContext(FieldContext);
@@ -137,6 +140,15 @@ export const RecordDetailRelationSectionDropdownToOne = ({
     recordId,
   });
 
+  const { createRelatedRecord } = useCreateRelatedRecord({
+    fieldMetadataItem,
+    objectMetadataItem,
+    relationObjectMetadataNameSingular,
+    relationObjectMetadataItem,
+    relationFieldMetadataItem,
+    recordId,
+  });
+
   const { openSingleRecordPicker } = useSingleRecordPickerOpen();
 
   const handleOpenRelationPickerDropdown = () => {
@@ -148,11 +160,16 @@ export const RecordDetailRelationSectionDropdownToOne = ({
     }
   };
 
-  const handleCreateNew = (searchString?: string) => {
+  const handleCreateNew = useCallback(async (searchString?: string) => {
     closeDropdown(dropdownId);
 
-    createNewRecordAndOpenSidePanel?.(searchString);
-  };
+    if (isDefined(onInlineCreate) && isDefined(createRelatedRecord)) {
+      const newRecordId = await createRelatedRecord(searchString);
+      onInlineCreate(newRecordId);
+    } else {
+      createNewRecordAndOpenSidePanel?.(searchString);
+    }
+  }, [closeDropdown, createNewRecordAndOpenSidePanel, createRelatedRecord, dropdownId, onInlineCreate]);
 
   const shouldAllowCreateNew =
     relationObjectMetadataNameSingular !==

--- a/packages/twenty-front/src/modules/object-record/record-field/ui/meta-types/input/hooks/useCreateRelatedRecord.ts
+++ b/packages/twenty-front/src/modules/object-record/record-field/ui/meta-types/input/hooks/useCreateRelatedRecord.ts
@@ -1,0 +1,85 @@
+import { v4 } from 'uuid';
+
+import { type FieldMetadataItem } from '@/object-metadata/types/FieldMetadataItem';
+import { type EnrichedObjectMetadataItem } from '@/object-metadata/types/EnrichedObjectMetadataItem';
+import { useCreateOneRecord } from '@/object-record/hooks/useCreateOneRecord';
+import { useUpdateOneRecord } from '@/object-record/hooks/useUpdateOneRecord';
+import { buildRecordLabelPayload } from '@/object-record/utils/buildRecordLabelPayload';
+import { computeMorphRelationFieldName, isDefined } from 'twenty-shared/utils';
+import { FieldMetadataType, RelationType } from '~/generated-metadata/graphql';
+
+type UseCreateRelatedRecordProps = {
+  fieldMetadataItem: FieldMetadataItem;
+  objectMetadataItem: EnrichedObjectMetadataItem;
+  relationObjectMetadataNameSingular: string;
+  relationObjectMetadataItem: EnrichedObjectMetadataItem;
+  relationFieldMetadataItem: FieldMetadataItem;
+  recordId: string;
+};
+
+// Creates a related record and wires up the relation without opening the side panel.
+export const useCreateRelatedRecord = ({
+  fieldMetadataItem,
+  objectMetadataItem,
+  relationObjectMetadataNameSingular,
+  relationObjectMetadataItem,
+  relationFieldMetadataItem,
+  recordId,
+}: UseCreateRelatedRecordProps) => {
+  const { createOneRecord } = useCreateOneRecord({
+    objectNameSingular: relationObjectMetadataNameSingular,
+  });
+
+  const { updateOneRecord } = useUpdateOneRecord();
+
+  if (
+    relationObjectMetadataNameSingular === 'workspaceMember' ||
+    !isDefined(objectMetadataItem.nameSingular)
+  ) {
+    return { createRelatedRecord: undefined };
+  }
+
+  const relationFieldMetadataItemRelationType =
+    relationFieldMetadataItem.settings?.relationType;
+
+  return {
+    createRelatedRecord: async (searchInput?: string): Promise<string> => {
+      const newRecordId = v4();
+
+      const createRecordPayload = buildRecordLabelPayload({
+        id: newRecordId,
+        searchInput,
+        objectMetadataItem: relationObjectMetadataItem,
+      });
+
+      if (relationFieldMetadataItemRelationType === RelationType.MANY_TO_ONE) {
+        const gqlField =
+          relationFieldMetadataItem.type === FieldMetadataType.RELATION
+            ? relationFieldMetadataItem.name
+            : computeMorphRelationFieldName({
+                fieldName: relationFieldMetadataItem.name,
+                relationType: relationFieldMetadataItemRelationType,
+                targetObjectMetadataNameSingular:
+                  objectMetadataItem.nameSingular,
+                targetObjectMetadataNamePlural: objectMetadataItem.namePlural,
+              });
+
+        createRecordPayload[`${gqlField}Id`] = recordId;
+      }
+
+      await createOneRecord(createRecordPayload);
+
+      if (relationFieldMetadataItemRelationType === RelationType.ONE_TO_MANY) {
+        await updateOneRecord({
+          objectNameSingular: objectMetadataItem.nameSingular ?? '',
+          idToUpdate: recordId,
+          updateOneRecordInput: {
+            [`${fieldMetadataItem.name}Id`]: newRecordId,
+          },
+        });
+      }
+
+      return newRecordId;
+    },
+  };
+};


### PR DESCRIPTION
…d Page Layouts

Implements #19900 - when clicking "Add New" in a relation section, instead of routing to the side panel, an accordion-style inline form expands directly within the Record Page Layout widget.

- Add RecordDetailInlineRelationCreateForm: inline form component that renders a RecordFieldList for the new related record and provides Done/Discard actions
- Add useCreateRelatedRecord hook: creates a related record and wires up the relation without opening the side panel
- Modify RecordDetailRelationSection: manages inlineCreateRecordIds state and passes onInlineCreate callback down to the dropdown
- Modify RecordDetailRelationRecordsList: renders inline create forms above the existing relation records list
- Modify RecordDetailRelationSectionDropdownToOne and ToMany: use onInlineCreate when provided, falling back to side panel for junction relations and non-inline contexts