### PR TITLE
fix(gmail): recursive body-part search, skip attachments

### DIFF
--- a/packages/twenty-server/src/modules/messaging/message-import-manager/drivers/gmail/utils/get-body-data.util.ts
+++ b/packages/twenty-server/src/modules/messaging/message-import-manager/drivers/gmail/utils/get-body-data.util.ts
@@ -1,12 +1,47 @@
 import { type gmail_v1 as gmailV1 } from 'googleapis';
 
-export const getBodyData = (message: gmailV1.Schema$Message) => {
-  const firstPart = message.payload?.parts?.[0];
+export const getBodyData = (
+  message: gmailV1.Schema$Message,
+  mimeType: string = 'text/plain',
+): string | undefined => {
+  const parts = message.payload?.parts || [];
 
-  if (firstPart?.mimeType === 'text/plain') {
-    return firstPart?.body?.data;
+  // Helper function to recursively search for the desired mimeType
+  const findPartByMimeType = (
+    partList: gmailV1.Schema$MessagePart[] | undefined,
+  ): string | undefined => {
+    if (!partList) return undefined;
+
+    for (const part of partList) {
+      // Skip attachments
+      if (part.filename) continue;
+
+      if (part.mimeType === mimeType && part.body?.data) {
+        return part.body.data;
+      }
+
+      // Recursively search in nested parts
+      if (part.parts) {
+        const result = findPartByMimeType(part.parts);
+        if (result) return result;
+      }
+    }
+
+    return undefined;
+  };
+
+  // Try the first part directly
+  const firstPart = parts[0];
+  if (firstPart) {
+    // If the first part itself matches the desired mimeType and has data, return it
+    if (!firstPart.filename && firstPart.mimeType === mimeType && firstPart.body?.data) {
+      return firstPart.body.data;
+    }
+
+    // Otherwise search recursively through all parts
+    const result = findPartByMimeType(parts);
+    if (result) return result;
   }
 
-  return firstPart?.parts?.find((part) => part.mimeType === 'text/plain')?.body
-    ?.data;
+  return undefined;
 };


### PR DESCRIPTION
## Summary

Fixes the getBodyData function to recursively search nested MIME parts for the desired content type, and skip attachments to avoid false matches.

## Problem

1. **Original bug** (#19879): Gmail body comes empty when importing emails from non-Gmail servers (Yandex SES Android). These servers send multipart/alternative where the first part is the wrapper, not the body itself.

2. **cubic-dev-ai concern**: Recursive selection could match text attachments.

3. **Sentry concern (HIGH)**: Fallback to 	ext/html without caller handling would cause raw HTML in DB.

## Solution

This fix:
- Recursively searches nested parts for the target mimeType (default: 	ext/plain)
- Skips parts with ilename (attachments)
- Does NOT add 	ext/html fallback - only fixes the recursive search for 	ext/plain
- Returns undefined if no matching part is found (original behavior)

## Changes

- getBodyData(message, mimeType = 'text/plain') - added mimeType parameter for flexibility
- Recursive helper indPartByMimeType handles nested part traversal
- Attachment filtering prevents false matches on text attachments

## Testing

CI green on existing tests. The fix addresses the root cause of the nested MIME structure issue.

---
*Closes #19879* (via recursive part search, no HTML fallback)