### PR TITLE
fix: restore Try Twenty button text visibility on docs navbar

### DIFF
--- a/packages/twenty-docs/custom.css
+++ b/packages/twenty-docs/custom.css
@@ -12,7 +12,8 @@
   opacity: 0.85 !important;
 }
 
-:is(.dark, [data-theme="dark"]) #topbar-cta-button a {
+:is(.dark, [data-theme="dark"]) #topbar-cta-button a,
+:is(.dark, [data-theme="dark"]) #topbar-cta-button a span {
   background-color: #ffffff !important;
   color: #141414 !important;
 }


### PR DESCRIPTION
# [Docs]: Fix blank Try Twenty button text in dark mode

## 🐛 Problem
The "Try Twenty" CTA button in the docs navbar appears blank/invisible when users enable dark mode, making it impossible to click through to the sign-up page.

**Issue:** #19965

##  Root Cause
CSS specificity conflict in `packages/twenty-docs/custom.css`:
- The dark mode CSS rule targets only the `<a>` element
- Mintlify renders button text in a nested `<span>` with class `text-white` (white color)
- The `text-white` Tailwind utility directly applies `color: rgb(255 255 255)` to the span
- This overrides the inherited dark color from the parent `<a>` element
- **Result:** White text on white background = invisible button

##  Solution
Update the CSS selector in `packages/twenty-docs/custom.css` to target both the `<a>` element AND the nested `<span>`:

**Before:**
```css
:is(.dark, [data-theme="dark"]) #topbar-cta-button a {
  background-color: #ffffff !important;
  color: #141414 !important;
}