### PR TITLE
[Docs]: fix 404 on language switch on docs page

### DIFF
--- a/packages/twenty-docs/docs.json
+++ b/packages/twenty-docs/docs.json
@@ -424,22 +424,22 @@
               {
                 "group": "Welcome",
                 "pages": [
-                  "l/fr/getting-started/introduction",
-                  "l/fr/getting-started/key-features",
-                  "l/fr/getting-started/quickstart"
+                  "getting-started/introduction",
+                  "getting-started/key-features",
+                  "getting-started/quickstart"
                 ]
               },
               {
                 "group": "Core Concepts",
                 "pages": [
-                  "l/fr/getting-started/core-concepts/data-model",
-                  "l/fr/getting-started/core-concepts/layout",
-                  "l/fr/getting-started/core-concepts/workflows",
-                  "l/fr/getting-started/core-concepts/calendar-and-email",
-                  "l/fr/getting-started/core-concepts/ai",
-                  "l/fr/getting-started/core-concepts/apps",
-                  "l/fr/getting-started/core-concepts/dashboards",
-                  "l/fr/getting-started/core-concepts/glossary"
+                  "getting-started/core-concepts/data-model",
+                  "getting-started/core-concepts/layout",
+                  "getting-started/core-concepts/workflows",
+                  "getting-started/core-concepts/calendar-and-email",
+                  "getting-started/core-concepts/ai",
+                  "getting-started/core-concepts/apps",
+                  "getting-started/core-concepts/dashboards",
+                  "getting-started/core-concepts/glossary"
                 ]
               }
             ]
@@ -807,22 +807,22 @@
               {
                 "group": "مرحبًا",
                 "pages": [
-                  "l/ar/getting-started/introduction",
-                  "l/ar/getting-started/key-features",
-                  "l/ar/getting-started/quickstart"
+                  "getting-started/introduction",
+                  "getting-started/key-features",
+                  "getting-started/quickstart"
                 ]
               },
               {
                 "group": "المفاهيم الأساسية",
                 "pages": [
-                  "l/ar/getting-started/core-concepts/data-model",
-                  "l/ar/getting-started/core-concepts/layout",
-                  "l/ar/getting-started/core-concepts/workflows",
-                  "l/ar/getting-started/core-concepts/calendar-and-email",
-                  "l/ar/getting-started/core-concepts/ai",
-                  "l/ar/getting-started/core-concepts/apps",
-                  "l/ar/getting-started/core-concepts/dashboards",
-                  "l/ar/getting-started/core-concepts/glossary"
+                  "getting-started/core-concepts/data-model",
+                  "getting-started/core-concepts/layout",
+                  "getting-started/core-concepts/workflows",
+                  "getting-started/core-concepts/calendar-and-email",
+                  "getting-started/core-concepts/ai",
+                  "getting-started/core-concepts/apps",
+                  "getting-started/core-concepts/dashboards",
+                  "getting-started/core-concepts/glossary"
                 ]
               }
             ]


### PR DESCRIPTION
## Summary
Switching the Mintlify docs site (docs.twenty.com) to **French (fr)** or **Arabic (ar)** currently redirects to a 404. This happens because the `packages/twenty-docs/docs.json` navigation references `l/fr/getting-started/...` and `l/ar/getting-started/...` pages that do not exist yet.

This PR updates the **Getting Started** tab for **fr** and **ar** to temporarily point to the existing English pages under `getting-started/...`, so switching to these languages no longer results in a broken landing page.

## What changed
- **File:** `packages/twenty-docs/docs.json`
- **French (`fr`)**: Replaced `l/fr/getting-started/...` with `getting-started/...` **only** inside the **Getting Started** tab.
- **Arabic (`ar`)**: Replaced `l/ar/getting-started/...` with `getting-started/...` **only** inside the **Getting Started** tab.
- Left other translated paths untouched (e.g. `l/fr/user-guide/...`, `l/ar/user-guide/...`, `l/<lang>/developers/...`), including `l/<lang>/developers/extend/apps/getting-started` which is a different page and remains valid.

## Why
Mintlify loads the first page of the selected language’s navigation when switching languages. Since `l/fr/getting-started/introduction` and `l/ar/getting-started/introduction` (and the rest of that section) aren’t present, users hit a 404. Showing the Getting Started section in English is preferable to a broken docs experience until translations are available.

## User impact
- Users can switch to **French** or **Arabic** without landing on a 404.
- The **Getting Started** section will appear in English for **fr** and **ar** until translated files are added.

## Testing
- Switched language to **fr** and **ar** and verified the docs no longer redirect to a 404.
- Verified other translated sections continue to resolve correctly.

## Follow-up
- Once translated `l/fr/getting-started/**` and `l/ar/getting-started/**` content is created by the translation pipeline, update `docs.json` to point back to the translated paths.

## Related
Fixes #19971