### PR TITLE
Fix layout edition mode dark mode text color

### DIFF
--- a/packages/twenty-front/src/modules/layout-customization/components/LayoutCustomizationBar.tsx
+++ b/packages/twenty-front/src/modules/layout-customization/components/LayoutCustomizationBar.tsx
@@ -5,6 +5,7 @@ import { useAtomValue } from 'jotai';
 import { useContext } from 'react';
 import { isDefined } from 'twenty-shared/utils';
 import { IconCheck, IconPaint } from 'twenty-ui/display';
+import { GRAY_SCALE_LIGHT } from 'twenty-ui/theme';
 import { ThemeContext, themeCssVariables } from 'twenty-ui/theme-constants';
 
 import { LayoutCustomizationBarMenuDropdown } from '@/layout-customization/components/LayoutCustomizationBarMenuDropdown';
@@ -24,7 +25,7 @@ const StyledContainer = styled.div`
   align-items: center;
   background: ${themeCssVariables.color.blue};
   box-sizing: border-box;
-  color: ${themeCssVariables.font.color.inverted};
+  color: ${GRAY_SCALE_LIGHT.gray1};
   display: flex;
   justify-content: space-between;
   padding: ${themeCssVariables.spacing[2]} ${themeCssVariables.spacing[3]};

--- a/packages/twenty-front/src/modules/layout-customization/components/LayoutCustomizationBar.tsx
+++ b/packages/twenty-front/src/modules/layout-customization/components/LayoutCustomizationBar.tsx
@@ -30,6 +30,15 @@ const StyledContainer = styled.div`
   justify-content: space-between;
   padding: ${themeCssVariables.spacing[2]} ${themeCssVariables.spacing[3]};
   width: 100%;
+
+  button,
+  button * {
+    color: ${GRAY_SCALE_LIGHT.gray1};
+  }
+
+  button[type='submit']:not(:disabled):not(:focus) {
+    border-color: color(display-p3 1 1 1 / 0.5);
+  }
 `;
 
 const StyledLeftSection = styled.div`

--- a/packages/twenty-front/src/modules/layout-customization/components/LayoutCustomizationBarMenuDropdown.tsx
+++ b/packages/twenty-front/src/modules/layout-customization/components/LayoutCustomizationBarMenuDropdown.tsx
@@ -3,6 +3,7 @@ import { useLingui } from '@lingui/react/macro';
 import { IconDotsVertical, IconReload } from 'twenty-ui/display';
 import { LightIconButton } from 'twenty-ui/input';
 import { MenuItem } from 'twenty-ui/navigation';
+import { GRAY_SCALE_LIGHT } from 'twenty-ui/theme';
 import { themeCssVariables } from 'twenty-ui/theme-constants';
 
 import { LAYOUT_CUSTOMIZATION_BAR_DROPDOWN_ID } from '@/layout-customization/constants/LayoutCustomizationBarDropdownId';
@@ -19,7 +20,7 @@ const StyledInvertedIconButtonWrapper = styled.span`
   display: flex;
 
   button {
-    color: ${themeCssVariables.font.color.inverted};
+    color: ${GRAY_SCALE_LIGHT.gray1};
   }
 
   button:hover {


### PR DESCRIPTION
Summary

Fixed the dark-mode regression in the layout customization banner at packages/twenty-front/src/modules/layout-customization/components/LayoutCustomizationBar.tsx:

- The banner's background is themeCssVariables.color.blue (theme-independent), so its text color must be theme-independent too.
- Replaced color: ${themeCssVariables.font.color.inverted} (which resolves to near-black in dark mode) with color: ${GRAY_SCALE_LIGHT.gray1} (always white), matching the convention used
 in AnimatedButton.tsx for text on colored backgrounds.

## Before
<img width="1508" height="185" alt="Screenshot 2026-04-22 at 19 50 03" src="https://github.com/user-attachments/assets/b0a95fc2-05d5-4207-9d72-64a83daf94ae" />

## After
<img width="1511" height="190" alt="Screenshot 2026-04-22 at 19 49 39" src="https://github.com/user-attachments/assets/9ce33353-412f-4db2-9322-a6f293f6f1b4" />
