### PR TITLE
Force uuids in AI workflow tools

### DIFF
--- a/packages/twenty-server/src/modules/workflow/workflow-tools/tools/activate-workflow-version.tool.ts
+++ b/packages/twenty-server/src/modules/workflow/workflow-tools/tools/activate-workflow-version.tool.ts
@@ -8,7 +8,8 @@ import {
 const activateWorkflowVersionSchema = z.object({
   workflowVersionId: z
     .string()
-    .describe('The ID of the workflow version to activate'),
+    .uuid()
+    .describe('The UUID of the workflow version to activate'),
 });
 
 type ActivateWorkflowVersionInput = z.infer<

--- a/packages/twenty-server/src/modules/workflow/workflow-tools/tools/compute-step-output-schema.tool.ts
+++ b/packages/twenty-server/src/modules/workflow/workflow-tools/tools/compute-step-output-schema.tool.ts
@@ -15,7 +15,10 @@ const computeStepOutputSchemaSchema = z.object({
   step: z
     .union([workflowTriggerSchema, workflowActionSchema])
     .describe('The workflow step configuration'),
-  workflowVersionId: z.string().describe('The ID of the workflow version'),
+  workflowVersionId: z
+    .string()
+    .uuid()
+    .describe('The UUID of the workflow version'),
 });
 
 export const createComputeStepOutputSchemaTool = (

--- a/packages/twenty-server/src/modules/workflow/workflow-tools/tools/create-draft-from-workflow-version.tool.ts
+++ b/packages/twenty-server/src/modules/workflow/workflow-tools/tools/create-draft-from-workflow-version.tool.ts
@@ -6,10 +6,11 @@ import {
 } from 'src/modules/workflow/workflow-tools/types/workflow-tool-dependencies.type';
 
 const createDraftFromWorkflowVersionSchema = z.object({
-  workflowId: z.string().describe('The ID of the workflow'),
+  workflowId: z.string().uuid().describe('The UUID of the workflow'),
   workflowVersionIdToCopy: z
     .string()
-    .describe('The ID of the workflow version to create a draft from'),
+    .uuid()
+    .describe('The UUID of the workflow version to create a draft from'),
 });
 
 type CreateDraftFromWorkflowVersionInput = z.infer<

--- a/packages/twenty-server/src/modules/workflow/workflow-tools/tools/create-workflow-version-edge.tool.ts
+++ b/packages/twenty-server/src/modules/workflow/workflow-tools/tools/create-workflow-version-edge.tool.ts
@@ -7,9 +7,16 @@ import {
 } from 'src/modules/workflow/workflow-tools/types/workflow-tool-dependencies.type';
 
 const createWorkflowVersionEdgeSchema = z.object({
-  workflowVersionId: z.string().describe('The ID of the workflow version'),
-  source: z.string().describe('The ID of the source step'),
-  target: z.string().describe('The ID of the target step'),
+  workflowVersionId: z
+    .string()
+    .uuid()
+    .describe('The UUID of the workflow version'),
+  source: z
+    .string()
+    .describe(
+      'The ID of the source step (UUID, or "trigger" for the trigger step)',
+    ),
+  target: z.string().uuid().describe('The UUID of the target step'),
   sourceConnectionOptions: z
     .object({
       connectedStepType: z.literal(WorkflowActionType.ITERATOR),

--- a/packages/twenty-server/src/modules/workflow/workflow-tools/tools/create-workflow-version-edge.tool.ts
+++ b/packages/twenty-server/src/modules/workflow/workflow-tools/tools/create-workflow-version-edge.tool.ts
@@ -12,10 +12,8 @@ const createWorkflowVersionEdgeSchema = z.object({
     .uuid()
     .describe('The UUID of the workflow version'),
   source: z
-    .string()
-    .describe(
-      'The ID of the source step (UUID, or "trigger" for the trigger step)',
-    ),
+    .union([z.literal('trigger'), z.string().uuid()])
+    .describe('The source step: "trigger" or a step UUID'),
   target: z.string().uuid().describe('The UUID of the target step'),
   sourceConnectionOptions: z
     .object({

--- a/packages/twenty-server/src/modules/workflow/workflow-tools/tools/create-workflow-version-step.tool.ts
+++ b/packages/twenty-server/src/modules/workflow/workflow-tools/tools/create-workflow-version-step.tool.ts
@@ -13,12 +13,13 @@ import {
 const baseStepFields = {
   workflowVersionId: z
     .string()
-    .describe('The ID of the workflow version to add the step to'),
+    .uuid()
+    .describe('The UUID of the workflow version to add the step to'),
   parentStepId: z
     .string()
     .optional()
     .describe(
-      'Optional ID of the parent step this step should come after. If not provided, the step will be added at the end of the workflow.',
+      'Optional ID of the parent step this step should come after (UUID, or "trigger" for the trigger step). If not provided, the step will be added at the end of the workflow.',
     ),
   parentStepConnectionOptions: z
     .object({

--- a/packages/twenty-server/src/modules/workflow/workflow-tools/tools/deactivate-workflow-version.tool.ts
+++ b/packages/twenty-server/src/modules/workflow/workflow-tools/tools/deactivate-workflow-version.tool.ts
@@ -8,7 +8,8 @@ import {
 const deactivateWorkflowVersionSchema = z.object({
   workflowVersionId: z
     .string()
-    .describe('The ID of the workflow version to deactivate'),
+    .uuid()
+    .describe('The UUID of the workflow version to deactivate'),
 });
 
 type DeactivateWorkflowVersionInput = z.infer<

--- a/packages/twenty-server/src/modules/workflow/workflow-tools/tools/delete-workflow-version-edge.tool.ts
+++ b/packages/twenty-server/src/modules/workflow/workflow-tools/tools/delete-workflow-version-edge.tool.ts
@@ -7,9 +7,16 @@ import {
 } from 'src/modules/workflow/workflow-tools/types/workflow-tool-dependencies.type';
 
 const deleteWorkflowVersionEdgeSchema = z.object({
-  workflowVersionId: z.string().describe('The ID of the workflow version'),
-  source: z.string().describe('The ID of the source step'),
-  target: z.string().describe('The ID of the target step'),
+  workflowVersionId: z
+    .string()
+    .uuid()
+    .describe('The UUID of the workflow version'),
+  source: z
+    .string()
+    .describe(
+      'The ID of the source step (UUID, or "trigger" for the trigger step)',
+    ),
+  target: z.string().uuid().describe('The UUID of the target step'),
   sourceConnectionOptions: z
     .object({
       connectedStepType: z.literal(WorkflowActionType.ITERATOR),

--- a/packages/twenty-server/src/modules/workflow/workflow-tools/tools/delete-workflow-version-edge.tool.ts
+++ b/packages/twenty-server/src/modules/workflow/workflow-tools/tools/delete-workflow-version-edge.tool.ts
@@ -12,10 +12,8 @@ const deleteWorkflowVersionEdgeSchema = z.object({
     .uuid()
     .describe('The UUID of the workflow version'),
   source: z
-    .string()
-    .describe(
-      'The ID of the source step (UUID, or "trigger" for the trigger step)',
-    ),
+    .union([z.literal('trigger'), z.string().uuid()])
+    .describe('The source step: "trigger" or a step UUID'),
   target: z.string().uuid().describe('The UUID of the target step'),
   sourceConnectionOptions: z
     .object({

--- a/packages/twenty-server/src/modules/workflow/workflow-tools/tools/delete-workflow-version-step.tool.ts
+++ b/packages/twenty-server/src/modules/workflow/workflow-tools/tools/delete-workflow-version-step.tool.ts
@@ -8,8 +8,12 @@ import {
 const deleteWorkflowVersionStepSchema = z.object({
   workflowVersionId: z
     .string()
-    .describe('The ID of the workflow version containing the step'),
-  stepId: z.string().describe('The ID of the step to delete'),
+    .uuid()
+    .describe('The UUID of the workflow version containing the step'),
+  stepId: z
+    .string()
+    .uuid()
+    .describe('The UUID of the step to delete'),
 });
 
 type DeleteWorkflowVersionStepInput = z.infer<

--- a/packages/twenty-server/src/modules/workflow/workflow-tools/tools/delete-workflow-version-step.tool.ts
+++ b/packages/twenty-server/src/modules/workflow/workflow-tools/tools/delete-workflow-version-step.tool.ts
@@ -10,10 +10,7 @@ const deleteWorkflowVersionStepSchema = z.object({
     .string()
     .uuid()
     .describe('The UUID of the workflow version containing the step'),
-  stepId: z
-    .string()
-    .uuid()
-    .describe('The UUID of the step to delete'),
+  stepId: z.string().uuid().describe('The UUID of the step to delete'),
 });
 
 type DeleteWorkflowVersionStepInput = z.infer<

--- a/packages/twenty-server/src/modules/workflow/workflow-tools/tools/get-workflow-current-version.tool.ts
+++ b/packages/twenty-server/src/modules/workflow/workflow-tools/tools/get-workflow-current-version.tool.ts
@@ -15,7 +15,8 @@ import {
 const getWorkflowCurrentVersionSchema = z.object({
   workflowId: z
     .string()
-    .describe('The ID of the workflow to get the current version for'),
+    .uuid()
+    .describe('The UUID of the workflow to get the current version for'),
 });
 
 type GetWorkflowCurrentVersionInput = z.infer<

--- a/packages/twenty-server/src/modules/workflow/workflow-tools/tools/update-workflow-version-positions.tool.ts
+++ b/packages/twenty-server/src/modules/workflow/workflow-tools/tools/update-workflow-version-positions.tool.ts
@@ -7,7 +7,10 @@ import {
 } from 'src/modules/workflow/workflow-tools/types/workflow-tool-dependencies.type';
 
 const updateWorkflowVersionPositionsSchema = z.object({
-  workflowVersionId: z.string().describe('The ID of the workflow version'),
+  workflowVersionId: z
+    .string()
+    .uuid()
+    .describe('The UUID of the workflow version'),
   positions: z
     .array(
       z.object({

--- a/packages/twenty-server/src/modules/workflow/workflow-tools/tools/update-workflow-version-step.tool.ts
+++ b/packages/twenty-server/src/modules/workflow/workflow-tools/tools/update-workflow-version-step.tool.ts
@@ -10,7 +10,8 @@ import {
 const updateWorkflowVersionStepSchema = z.object({
   workflowVersionId: z
     .string()
-    .describe('The ID of the workflow version containing the step'),
+    .uuid()
+    .describe('The UUID of the workflow version containing the step'),
   step: z
     .union([workflowActionSchema])
     .describe('The updated step configuration'),

--- a/packages/twenty-server/src/modules/workflow/workflow-tools/tools/update-workflow-version-trigger.tool.ts
+++ b/packages/twenty-server/src/modules/workflow/workflow-tools/tools/update-workflow-version-trigger.tool.ts
@@ -10,7 +10,8 @@ import {
 const updateWorkflowVersionTriggerSchema = z.object({
   workflowVersionId: z
     .string()
-    .describe('The ID of the workflow version containing the trigger'),
+    .uuid()
+    .describe('The UUID of the workflow version containing the trigger'),
   trigger: workflowTriggerSchema.describe('The updated trigger configuration'),
 });
 


### PR DESCRIPTION
- Add .uuid() Zod validation to all AI workflow tool schemas (workflowVersionId, workflowId, stepId, edge target) so the AI model is constrained to use valid UUIDs instead of human-readable strings like step-find-stale-leads
- Fixes Sentry noise from Invalid UUID errors triggered when workflows created with non-UUID step IDs are later edited via GraphQL mutations that enforce UUID scalars

Will fix https://twenty-v7.sentry.io/issues/7240446584/events/05c7782655a34f4a8f5fc889164026ab/?project=4507072499810304&referrer=previous-event