### PR TITLE
Twenty crashes after format settings changed when a user picture is present

### DIFF
--- a/packages/twenty-server/src/modules/workspace-member/listeners/workspace-member-avatar-file-deletion.listener.ts
+++ b/packages/twenty-server/src/modules/workspace-member/listeners/workspace-member-avatar-file-deletion.listener.ts
@@ -29,7 +29,7 @@ export class WorkspaceMemberAvatarFileDeletionListener {
   ) {
     const fileIdsToDelete = this.getFileIdsToDeleteFromUpdateEvent(payload);
 
-    this.deleteCorePictures(fileIdsToDelete, payload.workspaceId);
+    await this.deleteCorePictures(fileIdsToDelete, payload.workspaceId);
   }
 
   @OnDatabaseBatchEvent('workspaceMember', DatabaseEventAction.DESTROYED)
@@ -80,7 +80,9 @@ export class WorkspaceMemberAvatarFileDeletionListener {
           FileFolder.CorePicture,
         );
 
-        return beforeFileId !== afterFileId ? beforeFileId : undefined;
+        return beforeFileId !== afterFileId && isDefined(afterFileId)
+          ? beforeFileId
+          : undefined;
       })
       .filter(isDefined);
   }


### PR DESCRIPTION
# Description

> The patch in this PR was drafted with the help of AI while I was debugging the issue. Putting it up as a starting point for someone with deeper context.

Hit this on production first on v2.0.3 (migrated from v1.18 by the guide), then reproduced locally on a fresh instance. If a user picture is present, changing any format settings in Experience section will remove the user picture from the local storage then crash the server.

Environment variables I use for testing with a local instance:
```
TAG=v2.0.3
SERVER_URL=http://localhost:3000
DISABLE_DB_MIGRATIONS=false
DISABLE_CRON_JOBS_REGISTRATION=false
MESSAGING_PROVIDER_GMAIL_ENABLED=false
CALENDAR_PROVIDER_GOOGLE_ENABLED=false
STORAGE_TYPE=local
APP_SECRET=REDACTED
```

# Reproduction

1. Go to `/settings/general` and upload a user picture
2. Go to `/settings/experience` and change a couple of format options to arbitrary values
3. The server will crash and you expect to see similar logs:

```
/app/node_modules/typeorm/entity-manager/EntityManager.js:652
                return Promise.reject(new EntityNotFoundError_1.EntityNotFoundError(entityClass, options));
                                      ^

EntityNotFoundError: Could not find any entity of type "FileEntity" matching: {
    "where": {
        "id": "5f12293f-2522-4ffe-b859-cdae3cd09199",
        "path": {
            "_type": "like",
            "_value": "core-picture/%",
            "_useParameter": true,
            "_multipleParameters": false
        },
        "workspaceId": "aba7b173-add4-40a6-9c01-5947d57ff7e6"
    }
}
    at /app/node_modules/typeorm/entity-manager/EntityManager.js:652:39
    at process.processTicksAndRejections (node:internal/process/task_queues:104:5)
    at async FileCorePictureService.deleteCorePicture (/app/packages/twenty-server/dist/engine/core-modules/file/file-core-picture/services/file-core-picture.service.js:134:22)
    at async WorkspaceMemberAvatarFileDeletionListener.deleteCorePictures (/app/packages/twenty-server/dist/modules/workspace-member/listeners/workspace-member-avatar-file-deletion.listener.js:39:13) {
  entityClass: [class FileEntity extends WorkspaceRelatedEntity],
  criteria: {
    where: {
      id: '5f12293f-2522-4ffe-b859-cdae3cd09199',
      path: FindOperator {
        '@instanceof': Symbol(FindOperator),
        _type: 'like',
        _value: 'core-picture/%',
        _useParameter: true,
        _multipleParameters: false,
        _getSql: undefined,
        _objectLiteralParameters: undefined
      },
      workspaceId: 'aba7b173-add4-40a6-9c01-5947d57ff7e6'
    }
  }
}
```