### PR TITLE
Fix layout edition mode dark mode text color - 2

### DIFF
--- a/packages/twenty-front/src/modules/layout-customization/components/LayoutCustomizationBar.tsx
+++ b/packages/twenty-front/src/modules/layout-customization/components/LayoutCustomizationBar.tsx
@@ -36,6 +36,10 @@ const StyledContainer = styled.div`
     color: ${GRAY_SCALE_LIGHT.gray1};
   }
 
+  button {
+    --tw-button-color: ${GRAY_SCALE_LIGHT.gray1};
+  }
+
   button[type='submit']:not(:disabled):not(:focus) {
     border-color: color(display-p3 1 1 1 / 0.5);
   }

--- a/packages/twenty-front/src/modules/layout-customization/components/LayoutCustomizationBar.tsx
+++ b/packages/twenty-front/src/modules/layout-customization/components/LayoutCustomizationBar.tsx
@@ -37,7 +37,7 @@ const StyledContainer = styled.div`
   }
 
   button {
-    --tw-button-color: ${GRAY_SCALE_LIGHT.gray1};
+    --tw-button-color: ${GRAY_SCALE_LIGHT.gray1} !important;
   }
 
   button[type='submit']:not(:disabled):not(:focus) {


### PR DESCRIPTION
Followup https://github.com/twentyhq/twenty/pull/19992

Added button { --tw-button-color: ${GRAY_SCALE_LIGHT.gray1}; } to StyledContainer,
mirroring the existing color override. This forces the loader's color (which reads
var(--tw-button-color) in Loader.tsx) to stay white on the blue bar regardless of theme —
in dark mode, the button's inline --tw-button-color previously resolved to a dark
font.color.inverted, making the spinner nearly invisible.

## Before
<img width="137" height="37" alt="Screenshot 2026-04-24 at 11 01 51" src="https://github.com/user-attachments/assets/a870f1a3-83bd-4094-bc78-f9416fce1e0e" />

## After
<img width="139" height="31" alt="Screenshot 2026-04-24 at 11 00 14" src="https://github.com/user-attachments/assets/1bff4411-aee2-4ad4-bae3-8118fa117368" />
