### PR TITLE
chore(server): bump current version to 2.2.0

### DIFF
--- a/packages/twenty-server/src/database/commands/__tests__/__snapshots__/instance-command-generation.service.spec.ts.snap
+++ b/packages/twenty-server/src/database/commands/__tests__/__snapshots__/instance-command-generation.service.spec.ts.snap
@@ -26,13 +26,13 @@ export class TestFastInstanceCommand implements FastInstanceCommand {
 exports[`InstanceCommandGenerationService should escape backslashes in SQL queries 1`] = `
 {
   "className": "UpdatePathFastInstanceCommand",
-  "fileName": "2-1-instance-command-fast-1775000000000-update-path.ts",
+  "fileName": "2-2-instance-command-fast-1775000000000-update-path.ts",
   "fileTemplate": "import { QueryRunner } from 'typeorm';
 
 import { RegisteredInstanceCommand } from 'src/engine/core-modules/upgrade/decorators/registered-instance-command.decorator';
 import { FastInstanceCommand } from 'src/engine/core-modules/upgrade/interfaces/fast-instance-command.interface';
 
-@RegisteredInstanceCommand('2.1.0', 1775000000000)
+@RegisteredInstanceCommand('2.2.0', 1775000000000)
 export class UpdatePathFastInstanceCommand implements FastInstanceCommand {
   public async up(queryRunner: QueryRunner): Promise<void> {
     await queryRunner.query('UPDATE "core"."config" SET "value" = E\\'path\\\\\\\\to\\\\\\\\file\\'');
@@ -49,13 +49,13 @@ export class UpdatePathFastInstanceCommand implements FastInstanceCommand {
 exports[`InstanceCommandGenerationService should escape single quotes in SQL queries 1`] = `
 {
   "className": "UpdateConfigFastInstanceCommand",
-  "fileName": "2-1-instance-command-fast-1775000000000-update-config.ts",
+  "fileName": "2-2-instance-command-fast-1775000000000-update-config.ts",
   "fileTemplate": "import { QueryRunner } from 'typeorm';
 
 import { RegisteredInstanceCommand } from 'src/engine/core-modules/upgrade/decorators/registered-instance-command.decorator';
 import { FastInstanceCommand } from 'src/engine/core-modules/upgrade/interfaces/fast-instance-command.interface';
 
-@RegisteredInstanceCommand('2.1.0', 1775000000000)
+@RegisteredInstanceCommand('2.2.0', 1775000000000)
 export class UpdateConfigFastInstanceCommand implements FastInstanceCommand {
   public async up(queryRunner: QueryRunner): Promise<void> {
     await queryRunner.query('UPDATE "core"."config" SET "value" = \\'it\\'\\'s done\\'');
@@ -72,13 +72,13 @@ export class UpdateConfigFastInstanceCommand implements FastInstanceCommand {
 exports[`InstanceCommandGenerationService should generate a migration with a single up/down query 1`] = `
 {
   "className": "AddFooColumnFastInstanceCommand",
-  "fileName": "2-1-instance-command-fast-1775000000000-add-foo-column.ts",
+  "fileName": "2-2-instance-command-fast-1775000000000-add-foo-column.ts",
   "fileTemplate": "import { QueryRunner } from 'typeorm';
 
 import { RegisteredInstanceCommand } from 'src/engine/core-modules/upgrade/decorators/registered-instance-command.decorator';
 import { FastInstanceCommand } from 'src/engine/core-modules/upgrade/interfaces/fast-instance-command.interface';
 
-@RegisteredInstanceCommand('2.1.0', 1775000000000)
+@RegisteredInstanceCommand('2.2.0', 1775000000000)
 export class AddFooColumnFastInstanceCommand implements FastInstanceCommand {
   public async up(queryRunner: QueryRunner): Promise<void> {
     await queryRunner.query('ALTER TABLE "core"."user" ADD "foo" varchar');
@@ -95,13 +95,13 @@ export class AddFooColumnFastInstanceCommand implements FastInstanceCommand {
 exports[`InstanceCommandGenerationService should generate a migration with multiple queries 1`] = `
 {
   "className": "CreateTaskTableFastInstanceCommand",
-  "fileName": "2-1-instance-command-fast-1775000000000-create-task-table.ts",
+  "fileName": "2-2-instance-command-fast-1775000000000-create-task-table.ts",
   "fileTemplate": "import { QueryRunner } from 'typeorm';
 
 import { RegisteredInstanceCommand } from 'src/engine/core-modules/upgrade/decorators/registered-instance-command.decorator';
 import { FastInstanceCommand } from 'src/engine/core-modules/upgrade/interfaces/fast-instance-command.interface';
 
-@RegisteredInstanceCommand('2.1.0', 1775000000000)
+@RegisteredInstanceCommand('2.2.0', 1775000000000)
 export class CreateTaskTableFastInstanceCommand implements FastInstanceCommand {
   public async up(queryRunner: QueryRunner): Promise<void> {
     await queryRunner.query('CREATE TABLE "core"."task" ("id" uuid NOT NULL DEFAULT uuid_generate_v4(), "name" varchar NOT NULL)');
@@ -120,13 +120,13 @@ export class CreateTaskTableFastInstanceCommand implements FastInstanceCommand {
 exports[`InstanceCommandGenerationService should generate a migration with query parameters 1`] = `
 {
   "className": "SeedSettingFastInstanceCommand",
-  "fileName": "2-1-instance-command-fast-1775000000000-seed-setting.ts",
+  "fileName": "2-2-instance-command-fast-1775000000000-seed-setting.ts",
   "fileTemplate": "import { QueryRunner } from 'typeorm';
 
 import { RegisteredInstanceCommand } from 'src/engine/core-modules/upgrade/decorators/registered-instance-command.decorator';
 import { FastInstanceCommand } from 'src/engine/core-modules/upgrade/interfaces/fast-instance-command.interface';
 
-@RegisteredInstanceCommand('2.1.0', 1775000000000)
+@RegisteredInstanceCommand('2.2.0', 1775000000000)
 export class SeedSettingFastInstanceCommand implements FastInstanceCommand {
   public async up(queryRunner: QueryRunner): Promise<void> {
     await queryRunner.query('INSERT INTO "core"."setting" ("key", "value") VALUES ($1, $2)', ["theme","dark"]);
@@ -143,13 +143,13 @@ export class SeedSettingFastInstanceCommand implements FastInstanceCommand {
 exports[`InstanceCommandGenerationService should generate a slow instance command with populated up/down 1`] = `
 {
   "className": "MakeColumnNotNullableSlowInstanceCommand",
-  "fileName": "2-1-instance-command-slow-1775000000000-make-column-not-nullable.ts",
+  "fileName": "2-2-instance-command-slow-1775000000000-make-column-not-nullable.ts",
   "fileTemplate": "import { DataSource, QueryRunner } from 'typeorm';
 
 import { RegisteredInstanceCommand } from 'src/engine/core-modules/upgrade/decorators/registered-instance-command.decorator';
 import { SlowInstanceCommand } from 'src/engine/core-modules/upgrade/interfaces/slow-instance-command.interface';
 
-@RegisteredInstanceCommand('2.1.0', 1775000000000, { type: 'slow' })
+@RegisteredInstanceCommand('2.2.0', 1775000000000, { type: 'slow' })
 export class MakeColumnNotNullableSlowInstanceCommand implements SlowInstanceCommand {
   async runDataMigration(dataSource: DataSource): Promise<void> {
     // TODO: implement data backfill before the DDL migration
@@ -170,13 +170,13 @@ export class MakeColumnNotNullableSlowInstanceCommand implements SlowInstanceCom
 exports[`InstanceCommandGenerationService should use default migration name in class and file names 1`] = `
 {
   "className": "AutoGeneratedFastInstanceCommand",
-  "fileName": "2-1-instance-command-fast-1775000000000-auto-generated.ts",
+  "fileName": "2-2-instance-command-fast-1775000000000-auto-generated.ts",
   "fileTemplate": "import { QueryRunner } from 'typeorm';
 
 import { RegisteredInstanceCommand } from 'src/engine/core-modules/upgrade/decorators/registered-instance-command.decorator';
 import { FastInstanceCommand } from 'src/engine/core-modules/upgrade/interfaces/fast-instance-command.interface';
 
-@RegisteredInstanceCommand('2.1.0', 1775000000000)
+@RegisteredInstanceCommand('2.2.0', 1775000000000)
 export class AutoGeneratedFastInstanceCommand implements FastInstanceCommand {
   public async up(queryRunner: QueryRunner): Promise<void> {
     await queryRunner.query('ALTER TABLE "core"."user" ADD "bar" integer');

--- a/packages/twenty-server/src/engine/core-modules/upgrade/constants/twenty-current-version.constant.ts
+++ b/packages/twenty-server/src/engine/core-modules/upgrade/constants/twenty-current-version.constant.ts
@@ -1,1 +1,1 @@
-export const TWENTY_CURRENT_VERSION = '2.1.0' as const;
+export const TWENTY_CURRENT_VERSION = '2.2.0' as const;

--- a/packages/twenty-server/src/engine/core-modules/upgrade/constants/twenty-next-versions.constant.ts
+++ b/packages/twenty-server/src/engine/core-modules/upgrade/constants/twenty-next-versions.constant.ts
@@ -1,1 +1,1 @@
-export const TWENTY_NEXT_VERSIONS = ['2.2.0'] as const;
+export const TWENTY_NEXT_VERSIONS = [] as const;

--- a/packages/twenty-server/src/engine/core-modules/upgrade/constants/twenty-previous-versions.constant.ts
+++ b/packages/twenty-server/src/engine/core-modules/upgrade/constants/twenty-previous-versions.constant.ts
@@ -3,4 +3,5 @@ export const TWENTY_PREVIOUS_VERSIONS = [
   '1.22.0',
   '1.23.0',
   '2.0.0',
+  '2.1.0',
 ] as const;

--- a/packages/twenty-server/test/integration/upgrade/suites/sequence-runner/__snapshots__/failing-sequence-runner.integration-spec.ts.snap
+++ b/packages/twenty-server/test/integration/upgrade/suites/sequence-runner/__snapshots__/failing-sequence-runner.integration-spec.ts.snap
@@ -1,3 +1,3 @@
 // Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
-exports[`UpgradeSequenceRunnerService — failing sequence (integration) should throw when cursor command is not found in the sequence 1`] = `"Step "RemovedCommand" not found in upgrade sequence. The sequence only covers versions [1.21.0, 1.22.0, 1.23.0, 2.0.0, 2.1.0]. Please upgrade to 1.21.0 first."`;
+exports[`UpgradeSequenceRunnerService — failing sequence (integration) should throw when cursor command is not found in the sequence 1`] = `"Step "RemovedCommand" not found in upgrade sequence. The sequence only covers versions [1.21.0, 1.22.0, 1.23.0, 2.0.0, 2.1.0, 2.2.0]. Please upgrade to 1.21.0 first."`;


### PR DESCRIPTION
## Summary

We are releasing Twenty v2.2.0. This PR sets up the upgrade-version-command machinery for the new release line:

- Promote `2.1.0` into `TWENTY_PREVIOUS_VERSIONS` (it just shipped)
- Set `TWENTY_CURRENT_VERSION` to `2.2.0`
- Reset `TWENTY_NEXT_VERSIONS` to `[]`
- Refresh the `InstanceCommandGenerationService` snapshots to reflect the new current version (`2.2.0` / `2-2-` slug)
- Update the failing-sequence-runner snapshot to include `2.2.0` in the covered versions list

The `2-2/` upgrade-version-command module is already in place and wired into `WorkspaceCommandProviderModule`, so future upgrade commands targeting `2.2.0` can land directly under `2-2/` (or be generated against `--version 2.2.0`).
