### PR TITLE
Fix default workspace resolution in single-workspace mode

### DIFF
--- a/packages/twenty-server/src/engine/core-modules/domain/workspace-domains/services/__test__/workspace-domains.service.spec.ts
+++ b/packages/twenty-server/src/engine/core-modules/domain/workspace-domains/services/__test__/workspace-domains.service.spec.ts
@@ -213,7 +213,7 @@ describe('WorkspaceDomainsService', () => {
       expect(result?.id).toEqual('workspace-id');
     });
 
-    it('should return 1st workspace if multiple workspaces when IS_MULTIWORKSPACE_ENABLED=false', async () => {
+    it('should return first workspace if multiple workspaces exist when IS_MULTIWORKSPACE_ENABLED=false', async () => {
       jest
         .spyOn(twentyConfigService, 'get')
         .mockImplementation((key: string) => {

--- a/packages/twenty-server/src/engine/core-modules/domain/workspace-domains/services/workspace-domains.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/domain/workspace-domains/services/workspace-domains.service.ts
@@ -66,14 +66,14 @@ export class WorkspaceDomainsService {
 
     const workspaces = await this.workspaceRepository.find({
       order: {
-        createdAt: 'DESC',
+        createdAt: 'ASC',
       },
       relations: ['workspaceSSOIdentityProviders'],
     });
 
     if (workspaces.length > 1) {
       Logger.warn(
-        ` ${workspaces.length} workspaces found in database. In single-workspace mode, there should be only one workspace. Apple seed workspace will be used as fallback if it found.`,
+        ` ${workspaces.length} workspaces found in database. In single-workspace mode, there should be only one workspace. The oldest workspace will be used as fallback.`,
       );
     }
 


### PR DESCRIPTION
## Summary

In single-workspace mode, `getDefaultWorkspace()` sorted workspaces by `createdAt DESC` and picked the first result. After a full dev seed (which creates 4 workspaces), this resolved to Empty4 — the most recently created workspace. The default login user `tim@apple.dev` is only a member of Apple and YCombinator, so login failed with "User is not a member of the workspace."

## Fix

Changed the sort order from `createdAt DESC` to `createdAt ASC` so the oldest workspace (Apple, seeded first) is selected as the default. Updated the warning message to reflect the actual fallback behavior.

## Testing

- Updated existing test for multiple workspace fallback behavior
- All 11 tests pass
