### PR TITLE
fix(logic-function): serialize LocalDriver layer builds with cache lock

### DIFF
--- a/packages/twenty-server/src/engine/core-modules/logic-function/logic-function-drivers/drivers/local.driver.ts
+++ b/packages/twenty-server/src/engine/core-modules/logic-function/logic-function-drivers/drivers/local.driver.ts
@@ -24,15 +24,10 @@ import { copyYarnEngineAndBuildDependencies } from 'src/engine/core-modules/appl
 import type { LogicFunctionResourceService } from 'src/engine/core-modules/logic-function/logic-function-resource/logic-function-resource.service';
 import type { SdkClientArchiveService } from 'src/engine/core-modules/sdk-client/sdk-client-archive.service';
 
-// Concurrent execute() calls for the same application would otherwise race
-// in `createLayerIfNotExist` / `ensureSdkLayer`: both would observe the layer
-// as missing, both would `fs.rm` and repopulate the same directory, and yarn
-// install running in one call would see its cwd wiped by the other. Use the
-// shared cache-backed lock (same mechanism Lambda driver uses) to serialize
-// layer builds across processes.
 const LAYER_BUILD_LOCK_TTL_MS = 120_000;
 const LAYER_BUILD_LOCK_RETRY_MS = 500;
 const LAYER_BUILD_LOCK_MAX_RETRIES = 240;
+const LAYER_BUILD_READY_SENTINEL = '.twenty-layer-ready';
 
 export interface LocalDriverOptions {
   logicFunctionResourceService: LogicFunctionResourceService;
@@ -89,9 +84,12 @@ export class LocalDriver implements LogicFunctionDriver {
     applicationUniversalIdentifier: string;
   }): Promise<void> {
     const depsLayerPath = this.getDepsLayerPath(flatApplication);
-    const depsNodeModulesPath = join(depsLayerPath, 'node_modules');
+    const depsReadySentinelPath = join(
+      depsLayerPath,
+      LAYER_BUILD_READY_SENTINEL,
+    );
 
-    if (await pathExists(depsNodeModulesPath)) {
+    if (await pathExists(depsReadySentinelPath)) {
       return;
     }
 
@@ -99,12 +97,10 @@ export class LocalDriver implements LogicFunctionDriver {
 
     await this.cacheLockService.withLock(
       async () => {
-        // Re-check inside the lock: another caller may have just built it.
-        if (await pathExists(depsNodeModulesPath)) {
+        if (await pathExists(depsReadySentinelPath)) {
           return;
         }
 
-        // Wipe any partial leftovers from a previously failed build
         await fs.rm(depsLayerPath, { recursive: true, force: true });
 
         await this.logicFunctionResourceService.copyDependenciesInMemory({
@@ -113,6 +109,7 @@ export class LocalDriver implements LogicFunctionDriver {
           inMemoryFolderPath: depsLayerPath,
         });
         await copyYarnEngineAndBuildDependencies(depsLayerPath);
+        await fs.writeFile(depsReadySentinelPath, '');
       },
       lockKey,
       {
@@ -135,9 +132,10 @@ export class LocalDriver implements LogicFunctionDriver {
       applicationUniversalIdentifier,
     });
     const sdkNodeModulesPath = join(sdkLayerPath, 'node_modules');
+    const sdkReadySentinelPath = join(sdkLayerPath, LAYER_BUILD_READY_SENTINEL);
 
     if (
-      (await pathExists(sdkNodeModulesPath)) &&
+      (await pathExists(sdkReadySentinelPath)) &&
       !flatApplication.isSdkLayerStale
     ) {
       return;
@@ -147,12 +145,12 @@ export class LocalDriver implements LogicFunctionDriver {
 
     await this.cacheLockService.withLock(
       async () => {
-        // Re-check inside the lock: another caller may have just refreshed it,
-        // and the staleness flag may have flipped in the meantime.
-        if (
-          (await pathExists(sdkNodeModulesPath)) &&
-          !flatApplication.isSdkLayerStale
-        ) {
+        const isStale = await this.sdkClientArchiveService.isSdkLayerStale({
+          applicationId: flatApplication.id,
+          workspaceId: flatApplication.workspaceId,
+        });
+
+        if ((await pathExists(sdkReadySentinelPath)) && !isStale) {
           return;
         }
 
@@ -171,6 +169,8 @@ export class LocalDriver implements LogicFunctionDriver {
           applicationId: flatApplication.id,
           workspaceId: flatApplication.workspaceId,
         });
+
+        await fs.writeFile(sdkReadySentinelPath, '');
       },
       lockKey,
       {

--- a/packages/twenty-server/src/engine/core-modules/logic-function/logic-function-drivers/drivers/local.driver.ts
+++ b/packages/twenty-server/src/engine/core-modules/logic-function/logic-function-drivers/drivers/local.driver.ts
@@ -23,6 +23,7 @@ import { LogicFunctionExecutionStatus } from 'src/engine/metadata-modules/logic-
 import { copyYarnEngineAndBuildDependencies } from 'src/engine/core-modules/application/application-package/utils/copy-yarn-engine-and-build-dependencies';
 import type { LogicFunctionResourceService } from 'src/engine/core-modules/logic-function/logic-function-resource/logic-function-resource.service';
 import type { SdkClientArchiveService } from 'src/engine/core-modules/sdk-client/sdk-client-archive.service';
+import type { WorkspaceCacheService } from 'src/engine/workspace-cache/services/workspace-cache.service';
 
 const LAYER_BUILD_LOCK_TTL_MS = 120_000;
 const LAYER_BUILD_LOCK_RETRY_MS = 500;
@@ -33,6 +34,7 @@ export interface LocalDriverOptions {
   logicFunctionResourceService: LogicFunctionResourceService;
   sdkClientArchiveService: SdkClientArchiveService;
   cacheLockService: CacheLockService;
+  workspaceCacheService: WorkspaceCacheService;
 }
 
 const pathExists = async (targetPath: string): Promise<boolean> => {
@@ -49,11 +51,13 @@ export class LocalDriver implements LogicFunctionDriver {
   private readonly logicFunctionResourceService: LogicFunctionResourceService;
   private readonly sdkClientArchiveService: SdkClientArchiveService;
   private readonly cacheLockService: CacheLockService;
+  private readonly workspaceCacheService: WorkspaceCacheService;
 
   constructor(options: LocalDriverOptions) {
     this.logicFunctionResourceService = options.logicFunctionResourceService;
     this.sdkClientArchiveService = options.sdkClientArchiveService;
     this.cacheLockService = options.cacheLockService;
+    this.workspaceCacheService = options.workspaceCacheService;
   }
 
   private getDepsLayerPath(flatApplication: FlatApplication): string {
@@ -145,10 +149,14 @@ export class LocalDriver implements LogicFunctionDriver {
 
     await this.cacheLockService.withLock(
       async () => {
-        const isStale = await this.sdkClientArchiveService.isSdkLayerStale({
-          applicationId: flatApplication.id,
-          workspaceId: flatApplication.workspaceId,
-        });
+        const { flatApplicationMaps } =
+          await this.workspaceCacheService.getOrRecompute(
+            flatApplication.workspaceId,
+            ['flatApplicationMaps'],
+          );
+        const freshFlatApplication =
+          flatApplicationMaps.byId[flatApplication.id];
+        const isStale = freshFlatApplication?.isSdkLayerStale ?? true;
 
         if ((await pathExists(sdkReadySentinelPath)) && !isStale) {
           return;

--- a/packages/twenty-server/src/engine/core-modules/logic-function/logic-function-drivers/drivers/local.driver.ts
+++ b/packages/twenty-server/src/engine/core-modules/logic-function/logic-function-drivers/drivers/local.driver.ts
@@ -14,6 +14,7 @@ import {
 } from 'src/engine/core-modules/logic-function/logic-function-drivers/interfaces/logic-function-driver.interface';
 
 import { type FlatApplication } from 'src/engine/core-modules/application/types/flat-application.type';
+import { type CacheLockService } from 'src/engine/core-modules/cache-lock/cache-lock.service';
 import { LOGIC_FUNCTION_EXECUTOR_TMPDIR_FOLDER } from 'src/engine/core-modules/logic-function/logic-function-drivers/constants/logic-function-executor-tmpdir-folder';
 import { ConsoleListener } from 'src/engine/core-modules/logic-function/logic-function-drivers/utils/intercept-console';
 import { TemporaryDirManager } from 'src/engine/core-modules/logic-function/logic-function-drivers/utils/temporary-dir-manager';
@@ -23,9 +24,20 @@ import { copyYarnEngineAndBuildDependencies } from 'src/engine/core-modules/appl
 import type { LogicFunctionResourceService } from 'src/engine/core-modules/logic-function/logic-function-resource/logic-function-resource.service';
 import type { SdkClientArchiveService } from 'src/engine/core-modules/sdk-client/sdk-client-archive.service';
 
+// Concurrent execute() calls for the same application would otherwise race
+// in `createLayerIfNotExist` / `ensureSdkLayer`: both would observe the layer
+// as missing, both would `fs.rm` and repopulate the same directory, and yarn
+// install running in one call would see its cwd wiped by the other. Use the
+// shared cache-backed lock (same mechanism Lambda driver uses) to serialize
+// layer builds across processes.
+const LAYER_BUILD_LOCK_TTL_MS = 120_000;
+const LAYER_BUILD_LOCK_RETRY_MS = 500;
+const LAYER_BUILD_LOCK_MAX_RETRIES = 240;
+
 export interface LocalDriverOptions {
   logicFunctionResourceService: LogicFunctionResourceService;
   sdkClientArchiveService: SdkClientArchiveService;
+  cacheLockService: CacheLockService;
 }
 
 const pathExists = async (targetPath: string): Promise<boolean> => {
@@ -41,10 +53,12 @@ const pathExists = async (targetPath: string): Promise<boolean> => {
 export class LocalDriver implements LogicFunctionDriver {
   private readonly logicFunctionResourceService: LogicFunctionResourceService;
   private readonly sdkClientArchiveService: SdkClientArchiveService;
+  private readonly cacheLockService: CacheLockService;
 
   constructor(options: LocalDriverOptions) {
     this.logicFunctionResourceService = options.logicFunctionResourceService;
     this.sdkClientArchiveService = options.sdkClientArchiveService;
+    this.cacheLockService = options.cacheLockService;
   }
 
   private getDepsLayerPath(flatApplication: FlatApplication): string {
@@ -77,21 +91,36 @@ export class LocalDriver implements LogicFunctionDriver {
     const depsLayerPath = this.getDepsLayerPath(flatApplication);
     const depsNodeModulesPath = join(depsLayerPath, 'node_modules');
 
-    const nodeModulesExist = await pathExists(depsNodeModulesPath);
-
-    if (nodeModulesExist) {
+    if (await pathExists(depsNodeModulesPath)) {
       return;
     }
 
-    // Wipe any partial leftovers from a previously failed build
-    await fs.rm(depsLayerPath, { recursive: true, force: true });
+    const lockKey = `local-driver-deps-layer:${flatApplication.yarnLockChecksum ?? 'default'}`;
 
-    await this.logicFunctionResourceService.copyDependenciesInMemory({
-      applicationUniversalIdentifier,
-      workspaceId: flatApplication.workspaceId,
-      inMemoryFolderPath: depsLayerPath,
-    });
-    await copyYarnEngineAndBuildDependencies(depsLayerPath);
+    await this.cacheLockService.withLock(
+      async () => {
+        // Re-check inside the lock: another caller may have just built it.
+        if (await pathExists(depsNodeModulesPath)) {
+          return;
+        }
+
+        // Wipe any partial leftovers from a previously failed build
+        await fs.rm(depsLayerPath, { recursive: true, force: true });
+
+        await this.logicFunctionResourceService.copyDependenciesInMemory({
+          applicationUniversalIdentifier,
+          workspaceId: flatApplication.workspaceId,
+          inMemoryFolderPath: depsLayerPath,
+        });
+        await copyYarnEngineAndBuildDependencies(depsLayerPath);
+      },
+      lockKey,
+      {
+        ttl: LAYER_BUILD_LOCK_TTL_MS,
+        ms: LAYER_BUILD_LOCK_RETRY_MS,
+        maxRetries: LAYER_BUILD_LOCK_MAX_RETRIES,
+      },
+    );
   }
 
   private async ensureSdkLayer({
@@ -107,27 +136,49 @@ export class LocalDriver implements LogicFunctionDriver {
     });
     const sdkNodeModulesPath = join(sdkLayerPath, 'node_modules');
 
-    const nodeModulesExist = await pathExists(sdkNodeModulesPath);
-
-    if (nodeModulesExist && !flatApplication.isSdkLayerStale) {
+    if (
+      (await pathExists(sdkNodeModulesPath)) &&
+      !flatApplication.isSdkLayerStale
+    ) {
       return;
     }
 
-    await fs.rm(sdkLayerPath, { recursive: true, force: true });
+    const lockKey = `local-driver-sdk-layer:${flatApplication.workspaceId}:${applicationUniversalIdentifier}`;
 
-    const sdkPackagePath = join(sdkNodeModulesPath, 'twenty-client-sdk');
+    await this.cacheLockService.withLock(
+      async () => {
+        // Re-check inside the lock: another caller may have just refreshed it,
+        // and the staleness flag may have flipped in the meantime.
+        if (
+          (await pathExists(sdkNodeModulesPath)) &&
+          !flatApplication.isSdkLayerStale
+        ) {
+          return;
+        }
 
-    await this.sdkClientArchiveService.downloadAndExtractToPackage({
-      workspaceId: flatApplication.workspaceId,
-      applicationId: flatApplication.id,
-      applicationUniversalIdentifier,
-      targetPackagePath: sdkPackagePath,
-    });
+        await fs.rm(sdkLayerPath, { recursive: true, force: true });
 
-    await this.sdkClientArchiveService.markSdkLayerFresh({
-      applicationId: flatApplication.id,
-      workspaceId: flatApplication.workspaceId,
-    });
+        const sdkPackagePath = join(sdkNodeModulesPath, 'twenty-client-sdk');
+
+        await this.sdkClientArchiveService.downloadAndExtractToPackage({
+          workspaceId: flatApplication.workspaceId,
+          applicationId: flatApplication.id,
+          applicationUniversalIdentifier,
+          targetPackagePath: sdkPackagePath,
+        });
+
+        await this.sdkClientArchiveService.markSdkLayerFresh({
+          applicationId: flatApplication.id,
+          workspaceId: flatApplication.workspaceId,
+        });
+      },
+      lockKey,
+      {
+        ttl: LAYER_BUILD_LOCK_TTL_MS,
+        ms: LAYER_BUILD_LOCK_RETRY_MS,
+        maxRetries: LAYER_BUILD_LOCK_MAX_RETRIES,
+      },
+    );
   }
 
   async transpile({

--- a/packages/twenty-server/src/engine/core-modules/logic-function/logic-function-drivers/logic-function-driver.factory.ts
+++ b/packages/twenty-server/src/engine/core-modules/logic-function/logic-function-drivers/logic-function-driver.factory.ts
@@ -51,6 +51,7 @@ export class LogicFunctionDriverFactory extends DriverFactoryBase<LogicFunctionD
         return new LocalDriver({
           logicFunctionResourceService: this.logicFunctionResourceService,
           sdkClientArchiveService: this.sdkClientArchiveService,
+          cacheLockService: this.cacheLockService,
         });
 
       case LogicFunctionDriverType.LAMBDA: {

--- a/packages/twenty-server/src/engine/core-modules/logic-function/logic-function-drivers/logic-function-driver.factory.ts
+++ b/packages/twenty-server/src/engine/core-modules/logic-function/logic-function-drivers/logic-function-driver.factory.ts
@@ -17,6 +17,7 @@ import { DriverFactoryBase } from 'src/engine/core-modules/twenty-config/dynamic
 import { ConfigVariablesGroup } from 'src/engine/core-modules/twenty-config/enums/config-variables-group.enum';
 import { ConfigGroupHashService } from 'src/engine/core-modules/twenty-config/services/config-group-hash.service';
 import { TwentyConfigService } from 'src/engine/core-modules/twenty-config/twenty-config.service';
+import { WorkspaceCacheService } from 'src/engine/workspace-cache/services/workspace-cache.service';
 
 @Injectable()
 export class LogicFunctionDriverFactory extends DriverFactoryBase<LogicFunctionDriver> {
@@ -26,6 +27,7 @@ export class LogicFunctionDriverFactory extends DriverFactoryBase<LogicFunctionD
     private readonly logicFunctionResourceService: LogicFunctionResourceService,
     private readonly sdkClientArchiveService: SdkClientArchiveService,
     private readonly cacheLockService: CacheLockService,
+    private readonly workspaceCacheService: WorkspaceCacheService,
   ) {
     super(twentyConfigService, configGroupHashService);
   }
@@ -52,6 +54,7 @@ export class LogicFunctionDriverFactory extends DriverFactoryBase<LogicFunctionD
           logicFunctionResourceService: this.logicFunctionResourceService,
           sdkClientArchiveService: this.sdkClientArchiveService,
           cacheLockService: this.cacheLockService,
+          workspaceCacheService: this.workspaceCacheService,
         });
 
       case LogicFunctionDriverType.LAMBDA: {

--- a/packages/twenty-server/src/engine/core-modules/logic-function/logic-function.module.ts
+++ b/packages/twenty-server/src/engine/core-modules/logic-function/logic-function.module.ts
@@ -7,6 +7,7 @@ import { LogicFunctionTriggerModule } from 'src/engine/core-modules/logic-functi
 import { LogicFunctionExecutorModule } from 'src/engine/core-modules/logic-function/logic-function-executor/logic-function-executor.module';
 import { SdkClientModule } from 'src/engine/core-modules/sdk-client/sdk-client.module';
 import { TwentyConfigModule } from 'src/engine/core-modules/twenty-config/twenty-config.module';
+import { WorkspaceCacheModule } from 'src/engine/workspace-cache/workspace-cache.module';
 
 @Global()
 @Module({})
@@ -21,6 +22,7 @@ export class LogicFunctionModule {
         LogicFunctionTriggerModule,
         LogicFunctionExecutorModule,
         SdkClientModule,
+        WorkspaceCacheModule,
       ],
       providers: [LogicFunctionDriverFactory],
       exports: [

--- a/packages/twenty-server/src/engine/core-modules/sdk-client/sdk-client-archive.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/sdk-client/sdk-client-archive.service.ts
@@ -130,21 +130,6 @@ export class SdkClientArchiveService {
     ]);
   }
 
-  async isSdkLayerStale({
-    applicationId,
-    workspaceId,
-  }: {
-    applicationId: string;
-    workspaceId: string;
-  }): Promise<boolean> {
-    const application = await this.applicationRepository.findOne({
-      where: { id: applicationId, workspaceId },
-      select: ['isSdkLayerStale'],
-    });
-
-    return application?.isSdkLayerStale ?? true;
-  }
-
   private async downloadArchiveBufferOrGenerate({
     workspaceId,
     applicationId,

--- a/packages/twenty-server/src/engine/core-modules/sdk-client/sdk-client-archive.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/sdk-client/sdk-client-archive.service.ts
@@ -130,6 +130,21 @@ export class SdkClientArchiveService {
     ]);
   }
 
+  async isSdkLayerStale({
+    applicationId,
+    workspaceId,
+  }: {
+    applicationId: string;
+    workspaceId: string;
+  }): Promise<boolean> {
+    const application = await this.applicationRepository.findOne({
+      where: { id: applicationId, workspaceId },
+      select: ['isSdkLayerStale'],
+    });
+
+    return application?.isSdkLayerStale ?? true;
+  }
+
   private async downloadArchiveBufferOrGenerate({
     workspaceId,
     applicationId,


### PR DESCRIPTION
## Summary

Fixes a race condition in `LocalDriver` where concurrent `execute()` calls for the same application can trash each other's layer build, causing logic function executions to fail with either:

- `Error: ENOENT: process.cwd failed with error no such file or directory, the current working directory was likely removed without changing the working directory, uv_cwd` (the yarn-install child's `cwd` got wiped mid-run), or
- `ENOENT: no such file or directory, open '…/<pkg>/<file>.js.map'` raised from yarn's berry link step (files under the deps layer vanish while yarn is extracting).

Both are thrown from `…/deps/<checksum>/.yarn/releases/yarn-4.9.2.cjs` — i.e. the yarn process `copyYarnEngineAndBuildDependencies` spawns with `cwd: buildDirectory`.

## Root cause

`LocalDriver.createLayerIfNotExist` (and `ensureSdkLayer`) both follow a check-then-act pattern with no mutual exclusion:

```ts
if (await pathExists(depsNodeModulesPath)) return;
await fs.rm(depsLayerPath, { recursive: true, force: true });
await copyDependenciesInMemory(...);
await copyYarnEngineAndBuildDependencies(depsLayerPath); // spawns yarn with cwd=depsLayerPath
```

The deps layer path is shared across all `execute()` calls that match a given `yarnLockChecksum`. Two concurrent callers (e.g. a webhook invocation + a cron-triggered logic function firing while the first run's layer is still being built) both see no `node_modules`, both `fs.rm` the directory, and one's yarn child ends up with its `cwd` or its extraction target gone.

## Fix

Wrap the critical sections with `CacheLockService.withLock` — the same cache-backed lock the Lambda driver already uses for its layer/executor builds:

- `createLayerIfNotExist` → lock key `local-driver-deps-layer:${yarnLockChecksum ?? 'default'}`
- `ensureSdkLayer` → lock key `local-driver-sdk-layer:${workspaceId}:${applicationUniversalIdentifier}`

A fast-path `pathExists` check is kept outside the lock (so warm executions still skip lock acquisition entirely), and the existence + staleness check is **repeated inside the lock** so followers no-op after the leader finishes.

Lock parameters mirror the Lambda driver's layer-build lock (`ttl=120s`, `retry=500ms`, `maxRetries=240`).

`cacheLockService` is now passed to `LocalDriver` from `LogicFunctionDriverFactory` (it was already injected there for the Lambda driver).

