### PR TITLE
fix(setup-script): add database schema initialization to setup script

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -208,7 +208,7 @@ All dev environments (Claude Code web, Cursor, local) use one script:
 bash packages/twenty-utils/setup-dev-env.sh
 ```
 
-This handles everything: starts Postgres + Redis (auto-detects local services vs Docker), creates databases, and copies `.env` files. Idempotent — safe to run multiple times.
+This handles everything: starts Postgres + Redis (auto-detects local services vs Docker), creates databases, copies `.env` files, and initializes the database schema (migrations + seed). Idempotent — safe to run multiple times.
 
 - `--docker` — force Docker mode (uses `packages/twenty-docker/docker-compose.dev.yml`)
 - `--down` — stop services

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -208,7 +208,7 @@ All dev environments (Claude Code web, Cursor, local) use one script:
 bash packages/twenty-utils/setup-dev-env.sh
 ```
 
-This handles everything: starts Postgres + Redis (auto-detects local services vs Docker), creates databases, copies `.env` files, and initializes the database schema (migrations + seed). Idempotent — safe to run multiple times.
+This handles everything: starts Postgres + Redis (auto-detects local services vs Docker), creates databases, copies `.env` files, and initializes the database schema (runs migrations) on a fresh database. Idempotent — safe to run multiple times.
 
 - `--docker` — force Docker mode (uses `packages/twenty-docker/docker-compose.dev.yml`)
 - `--down` — stop services

--- a/packages/twenty-utils/setup-dev-env.sh
+++ b/packages/twenty-utils/setup-dev-env.sh
@@ -260,13 +260,17 @@ if command -v npx &>/dev/null && [ -d node_modules ]; then
     ok "Database schema already initialized"
   else
     info "Initializing database schema (migrations + seed)..."
-    npx nx database:reset twenty-server
-    ok "Database schema initialized"
+    if npx nx run twenty-server:database:init:prod; then
+      ok "Database schema initialized"
+    else
+      fail "Database schema initialization failed"
+      exit 1
+    fi
   fi
 elif [ -d node_modules ]; then
-  info "Run 'npx nx database:reset twenty-server' to initialize schema"
+  info "Run 'npx nx run twenty-server:database:init:prod' to initialize schema"
 else
-  info "Run 'npx nx database:reset twenty-server' manually to initialize schema"
+  info "Run 'npx nx run twenty-server:database:init:prod' manually to initialize schema"
 fi
 
 # =============================================================================

--- a/packages/twenty-utils/setup-dev-env.sh
+++ b/packages/twenty-utils/setup-dev-env.sh
@@ -8,7 +8,7 @@
 #   1. Starts Postgres + Redis (local services or Docker, auto-detected)
 #   2. Creates 'default' and 'test' databases
 #   3. Copies .env.example -> .env for front and server
-#   4. Initializes database schema (migrations + seed data)
+#   4. Initializes database schema (runs migrations) when not already present
 #
 # Usage (from repo root):
 #   bash packages/twenty-utils/setup-dev-env.sh          # start + configure
@@ -82,9 +82,9 @@ wait_for_redis() {
 
 schema_exists() {
   if command -v psql &>/dev/null; then
-    PGPASSWORD=postgres psql -h localhost -p 5432 -U postgres -d default -t -c "SELECT 1 FROM information_schema.schemata WHERE schema_name = 'core'" 2>/dev/null | grep -q 1
+    PGPASSWORD=postgres psql -h localhost -p 5432 -U postgres -d default -t -c "SELECT 1 FROM pg_catalog.pg_namespace WHERE nspname = 'core'" 2>/dev/null | grep -q 1
   elif can_use_docker && docker compose -f "$COMPOSE_FILE" ps --quiet db 2>/dev/null | grep -q .; then
-    docker compose -f "$COMPOSE_FILE" exec -T db psql -U postgres -d default -t -c "SELECT 1 FROM information_schema.schemata WHERE schema_name = 'core'" 2>/dev/null | grep -q 1
+    docker compose -f "$COMPOSE_FILE" exec -T db psql -U postgres -d default -t -c "SELECT 1 FROM pg_catalog.pg_namespace WHERE nspname = 'core'" 2>/dev/null | grep -q 1
   else
     return 1
   fi
@@ -259,18 +259,16 @@ if command -v npx &>/dev/null && [ -d node_modules ]; then
   if schema_exists; then
     ok "Database schema already initialized"
   else
-    info "Initializing database schema (migrations + seed)..."
-    if npx nx run twenty-server:database:init:prod; then
+    info "Initializing database schema (running migrations)..."
+    if npx nx database:init twenty-server; then
       ok "Database schema initialized"
     else
       fail "Database schema initialization failed"
       exit 1
     fi
   fi
-elif [ -d node_modules ]; then
-  info "Run 'npx nx run twenty-server:database:init:prod' to initialize schema"
 else
-  info "Run 'npx nx run twenty-server:database:init:prod' manually to initialize schema"
+  info "Run 'npx nx database:init twenty-server' to initialize the schema"
 fi
 
 # =============================================================================

--- a/packages/twenty-utils/setup-dev-env.sh
+++ b/packages/twenty-utils/setup-dev-env.sh
@@ -8,6 +8,7 @@
 #   1. Starts Postgres + Redis (local services or Docker, auto-detected)
 #   2. Creates 'default' and 'test' databases
 #   3. Copies .env.example -> .env for front and server
+#   4. Initializes database schema (migrations + seed data)
 #
 # Usage (from repo root):
 #   bash packages/twenty-utils/setup-dev-env.sh          # start + configure
@@ -77,6 +78,16 @@ wait_for_redis() {
     if [ "$retries" -le 0 ]; then fail "Redis did not start in time"; exit 1; fi
     sleep 1
   done
+}
+
+schema_exists() {
+  if command -v psql &>/dev/null; then
+    PGPASSWORD=postgres psql -h localhost -p 5432 -U postgres -d default -t -c "SELECT 1 FROM information_schema.schemata WHERE schema_name = 'core'" 2>/dev/null | grep -q 1
+  elif can_use_docker && docker compose -f "$COMPOSE_FILE" ps --quiet db 2>/dev/null | grep -q .; then
+    docker compose -f "$COMPOSE_FILE" exec -T db psql -U postgres -d default -t -c "SELECT 1 FROM information_schema.schemata WHERE schema_name = 'core'" 2>/dev/null | grep -q 1
+  else
+    return 1
+  fi
 }
 
 # --------------- parse flags ---------------
@@ -239,6 +250,23 @@ else
       ok "$pkg/.env created"
     fi
   done
+fi
+
+# =============================================================================
+# 4. Initialize database schema
+# =============================================================================
+if command -v npx &>/dev/null && [ -d node_modules ]; then
+  if schema_exists; then
+    ok "Database schema already initialized"
+  else
+    info "Initializing database schema (migrations + seed)..."
+    npx nx database:reset twenty-server
+    ok "Database schema initialized"
+  fi
+elif [ -d node_modules ]; then
+  info "Run 'npx nx database:reset twenty-server' to initialize schema"
+else
+  info "Run 'npx nx database:reset twenty-server' manually to initialize schema"
 fi
 
 # =============================================================================


### PR DESCRIPTION
fixes #20062 

### Changes Made

packages/twenty-utils/setup-dev-env.sh:
- Added step 4 to header comment (line 11)
- Added schema_exists() helper function (lines 83-91) — checks if core schema exists in default database
- Added schema initialization step (lines 255-270) — runs npx nx database:reset twenty-server when schema doesn't exist
- Fixed conflicting error message (line 267)

CLAUDE.md:
- Updated line 210 to document that the script now initializes database schema
