### PR TITLE
docs: document rawBody on RoutePayload

### DIFF
--- a/packages/twenty-docs/developers/extend/apps/logic-functions.mdx
+++ b/packages/twenty-docs/developers/extend/apps/logic-functions.mdx
@@ -101,6 +101,7 @@ The `RoutePayload` type has the following structure:
   | `queryStringParameters` | `Record<string, string \| undefined>` | Query string parameters (multiple values joined with commas)  | `/users?ids=1&ids=2&ids=3&name=Alice` -> `{ ids: '1,2,3', name: 'Alice' }`|
   | `pathParameters` | `Record<string, string \| undefined>` | Path parameters extracted from the route pattern | `/users/:id`, `/users/123` -> `{ id: '123' }` |
   | `body` | `object \| null` | Parsed request body (JSON) | `{ id: 1 }` -> `{ id: 1 }` |
+  | `rawBody` | `string \| undefined` | Original UTF-8 request body, before JSON parsing. Useful for verifying HMAC-style webhook signatures (e.g. GitHub's `X-Hub-Signature-256`, Stripe). `undefined` when the runtime did not preserve it. | |
   | `isBase64Encoded` | `boolean` | Whether the body is base64 encoded | |
   | `requestContext.http.method` | `string` | HTTP method (GET, POST, PUT, PATCH, DELETE) | |
   | `requestContext.http.path` | `string` | Raw request path | |


### PR DESCRIPTION
## Summary

Follow-up to #20061, which added `rawBody?: string` to `LogicFunctionEvent` / `RoutePayload` so logic functions can verify HMAC-style webhook signatures (GitHub's `X-Hub-Signature-256`, Stripe, …) against the exact bytes that were received.

That PR did not update the public SDK docs, so the new field is effectively invisible to developers consuming `RoutePayload` from `twenty-sdk`. This PR adds a single row to the `RoutePayload` structure table in `logic-functions.mdx` so the field is discoverable.

Addresses the review feedback on https://github.com/twentyhq/twenty/pull/20061#discussion_r3147065014.

