### PR TITLE
chore: export the enum view calendar layout to avoid typing errors on apps

### DIFF
--- a/packages/twenty-sdk/src/cli/utilities/build/common/plugins/__tests__/__snapshots__/stub-twenty-sdk-define.plugin.spec.ts.snap
+++ b/packages/twenty-sdk/src/cli/utilities/build/common/plugins/__tests__/__snapshots__/stub-twenty-sdk-define.plugin.spec.ts.snap
@@ -17,6 +17,7 @@ exports[`stub-twenty-sdk-define plugin > matches the recorded export partition 1
     "RelationType",
     "STANDARD_OBJECT",
     "STANDARD_OBJECT_UNIVERSAL_IDENTIFIERS",
+    "ViewCalendarLayout",
     "ViewFilterGroupLogicalOperator",
     "ViewFilterOperand",
     "ViewKey",

--- a/packages/twenty-sdk/src/sdk/define/index.ts
+++ b/packages/twenty-sdk/src/sdk/define/index.ts
@@ -108,6 +108,7 @@ export {
   NumberDataType,
   ObjectRecordGroupByDateGranularity,
   PageLayoutTabLayoutMode,
+  ViewCalendarLayout,
   ViewFilterGroupLogicalOperator,
   ViewFilterOperand,
   ViewOpenRecordIn,


### PR DESCRIPTION
This is a small PR to fix an issue that came up when I created an app with a custom object. I think the enum `ViewCalendarLayout` was not caught as part of the exports. 

<img width="1624" height="1114" alt="image" src="https://github.com/user-attachments/assets/7bca3d0d-0e68-48ef-ac5f-6a3375733499" />
