### PR TITLE
chore: use navigation menu item type into the generated navigation menu layout

### DIFF
--- a/packages/twenty-sdk/src/cli/utilities/entity/__tests__/get-navigation-menu-item-base-file.spec.ts
+++ b/packages/twenty-sdk/src/cli/utilities/entity/__tests__/get-navigation-menu-item-base-file.spec.ts
@@ -8,7 +8,7 @@ describe('getNavigationMenuItemBaseFile', () => {
     });
 
     expect(result).toContain(
-      "import { defineNavigationMenuItem } from 'twenty-sdk/define';",
+      "import { defineNavigationMenuItem, NavigationMenuItemType } from 'twenty-sdk/define';",
     );
     expect(result).toContain('export default defineNavigationMenuItem({');
     expect(result).toContain(
@@ -26,7 +26,7 @@ describe('getNavigationMenuItemBaseFile', () => {
       viewUniversalIdentifier: 'view-uuid-123',
     });
 
-    expect(result).toContain("type: 'VIEW'");
+    expect(result).toContain('type: NavigationMenuItemType.VIEW');
     expect(result).toContain("viewUniversalIdentifier: 'view-uuid-123'");
   });
 
@@ -35,7 +35,7 @@ describe('getNavigationMenuItemBaseFile', () => {
       name: 'unlinked-item',
     });
 
-    expect(result).toContain("type: 'VIEW'");
+    expect(result).toContain('type: NavigationMenuItemType.VIEW');
     expect(result).toContain('// viewUniversalIdentifier:');
   });
 
@@ -46,7 +46,7 @@ describe('getNavigationMenuItemBaseFile', () => {
       targetObjectUniversalIdentifier: 'obj-uuid-123',
     });
 
-    expect(result).toContain("type: 'OBJECT'");
+    expect(result).toContain('type: NavigationMenuItemType.OBJECT');
     expect(result).toContain("targetObjectUniversalIdentifier: 'obj-uuid-123'");
   });
 

--- a/packages/twenty-sdk/src/cli/utilities/entity/entity-navigation-menu-item-template.ts
+++ b/packages/twenty-sdk/src/cli/utilities/entity/entity-navigation-menu-item-template.ts
@@ -19,22 +19,22 @@ export const getNavigationMenuItemBaseFile = ({
   let typeAndConfig: string;
 
   if (type === 'OBJECT' && targetObjectUniversalIdentifier) {
-    typeAndConfig = `  type: 'OBJECT',
+    typeAndConfig = `  type: NavigationMenuItemType.OBJECT,
   targetObjectUniversalIdentifier: '${targetObjectUniversalIdentifier}',`;
   } else if (type === 'VIEW' && viewUniversalIdentifier) {
-    typeAndConfig = `  type: 'VIEW',
+    typeAndConfig = `  type: NavigationMenuItemType.VIEW,
   viewUniversalIdentifier: '${viewUniversalIdentifier}',`;
   } else if (type === 'LINK') {
-    typeAndConfig = `  type: 'LINK',
+    typeAndConfig = `  type: NavigationMenuItemType.LINK,
   link: 'https://example.com',`;
   } else if (type === 'FOLDER') {
-    typeAndConfig = `  type: 'FOLDER',`;
+    typeAndConfig = `  type: NavigationMenuItemType.FOLDER,`;
   } else {
-    typeAndConfig = `  type: 'VIEW',
+    typeAndConfig = `  type: NavigationMenuItemType.VIEW,
   // viewUniversalIdentifier: '...',`;
   }
 
-  return `import { defineNavigationMenuItem } from 'twenty-sdk/define';
+  return `import { defineNavigationMenuItem, NavigationMenuItemType } from 'twenty-sdk/define';
 
 export default defineNavigationMenuItem({
   universalIdentifier: '${universalIdentifier}',


### PR DESCRIPTION
This is a small PR to fix an issue that came up when I created an object with the default navigation menu item.

<img width="811" height="461" alt="image" src="https://github.com/user-attachments/assets/70c7f55d-3d41-48ed-8cf9-5f649ea41f49" />
