### PR TITLE
docs: fix audit module README title

### DIFF
--- a/packages/twenty-server/src/engine/core-modules/audit/README.md
+++ b/packages/twenty-server/src/engine/core-modules/audit/README.md
@@ -1,6 +1,6 @@
-# Analytics Module
+# Audit Module
 
-This module provides analytics tracking functionality for the Twenty application.
+This module provides audit/analytics tracking functionality for the Twenty application.
 
 ## Usage
 


### PR DESCRIPTION
## Summary

The README in `packages/twenty-server/src/engine/core-modules/audit/` was titled "Analytics Module" but the file lives under `audit/` and the body documents `AuditService`. Renames the title to match.

## Test plan

- [x] No code changes — docs only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)