### PR TITLE
fix: include shared workspace in website image

### DIFF
--- a/packages/twenty-docker/twenty-website-new/Dockerfile
+++ b/packages/twenty-docker/twenty-website-new/Dockerfile
@@ -11,10 +11,12 @@ COPY ./nx.json .
 COPY ./.yarn/releases /app/.yarn/releases
 COPY ./.yarn/patches /app/.yarn/patches
 COPY ./packages/twenty-oxlint-rules /app/packages/twenty-oxlint-rules
+COPY ./packages/twenty-shared/package.json /app/packages/twenty-shared/package.json
 COPY ./packages/twenty-website-new/package.json /app/packages/twenty-website-new/package.json
 
 RUN yarn
 
+COPY ./packages/twenty-shared /app/packages/twenty-shared
 COPY ./packages/twenty-website-new /app/packages/twenty-website-new
 RUN npx nx build twenty-website-new
 


### PR DESCRIPTION
Workflow failing: https://github.com/twentyhq/twenty-infra/actions/runs/25066332458/job/73434373104.

Assuming this is the right fix for the reported error since twenty Dockerfile does the same. If this is the wrong fix, please help in fixing the issue.