### PR TITLE
fix: allow email change verification on self-hosted instances

### DIFF
--- a/packages/twenty-server/src/engine/core-modules/user/services/user.service.spec.ts
+++ b/packages/twenty-server/src/engine/core-modules/user/services/user.service.spec.ts
@@ -10,6 +10,7 @@ import { type AuthContextUser } from 'src/engine/core-modules/auth/types/auth-co
 import { WorkspaceDomainsService } from 'src/engine/core-modules/domain/workspace-domains/services/workspace-domains.service';
 import { EmailVerificationService } from 'src/engine/core-modules/email-verification/services/email-verification.service';
 import { MessageQueue } from 'src/engine/core-modules/message-queue/message-queue.constants';
+import { TwentyConfigService } from 'src/engine/core-modules/twenty-config/twenty-config.service';
 import { type UserWorkspaceEntity } from 'src/engine/core-modules/user-workspace/user-workspace.entity';
 import { UserWorkspaceService } from 'src/engine/core-modules/user-workspace/user-workspace.service';
 import { UserService } from 'src/engine/core-modules/user/services/user.service';
@@ -111,6 +112,12 @@ describe('UserService', () => {
           provide: WorkspaceMemberTranspiler,
           useValue: {
             generateSignedAvatarUrl: jest.fn().mockReturnValue(''),
+          },
+        },
+        {
+          provide: TwentyConfigService,
+          useValue: {
+            get: jest.fn().mockReturnValue(false),
           },
         },
       ],

--- a/packages/twenty-server/src/engine/core-modules/user/services/user.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/user/services/user.service.ts
@@ -19,6 +19,7 @@ import { type AuthContextUser } from 'src/engine/core-modules/auth/types/auth-co
 import { WorkspaceDomainsService } from 'src/engine/core-modules/domain/workspace-domains/services/workspace-domains.service';
 import { EmailVerificationTrigger } from 'src/engine/core-modules/email-verification/email-verification.constants';
 import { EmailVerificationService } from 'src/engine/core-modules/email-verification/services/email-verification.service';
+import { TwentyConfigService } from 'src/engine/core-modules/twenty-config/twenty-config.service';
 import { UserInputError } from 'src/engine/core-modules/graphql/utils/graphql-errors.util';
 import { InjectMessageQueue } from 'src/engine/core-modules/message-queue/decorators/message-queue.decorator';
 import { MessageQueue } from 'src/engine/core-modules/message-queue/message-queue.constants';
@@ -60,6 +61,7 @@ export class UserService extends TypeOrmQueryService<UserEntity> {
     private readonly workspaceQueueService: MessageQueueService,
     private readonly coreEntityCacheService: CoreEntityCacheService,
     private readonly workspaceMemberTranspiler: WorkspaceMemberTranspiler,
+    private readonly twentyConfigService: TwentyConfigService,
   ) {
     super(userRepository);
   }
@@ -510,6 +512,12 @@ export class UserService extends TypeOrmQueryService<UserEntity> {
         subCode: UserExceptionCode.EMAIL_ALREADY_IN_USE,
         userFriendlyMessage: msg`Email already in use`,
       });
+    }
+
+    if (!this.twentyConfigService.get('IS_EMAIL_VERIFICATION_REQUIRED')) {
+      await this.updateEmailFromVerificationToken(user.id, normalizedEmail);
+
+      return;
     }
 
     const workspaceDomainConfig =

--- a/packages/twenty-server/test/integration/graphql/suites/settings-permissions/update-workspace-member-settings-onboarding.integration-spec.ts
+++ b/packages/twenty-server/test/integration/graphql/suites/settings-permissions/update-workspace-member-settings-onboarding.integration-spec.ts
@@ -1,16 +1,12 @@
 import { randomUUID } from 'crypto';
 
 import gql from 'graphql-tag';
-import request from 'supertest';
-import { getAuthTokensFromLoginToken } from 'test/integration/graphql/utils/get-auth-tokens-from-login-token.util';
 import { deleteUser } from 'test/integration/graphql/utils/delete-user.util';
 import { makeGraphqlAPIRequest } from 'test/integration/graphql/utils/make-graphql-api-request.util';
+import { signUpInWorkspaceAndGetAccessToken } from 'test/integration/graphql/utils/sign-up-in-workspace-and-get-access-token.util';
 import { makeMetadataAPIRequest } from 'test/integration/metadata/suites/utils/make-metadata-api-request.util';
 
 import { OnboardingStatus } from 'src/engine/core-modules/onboarding/enums/onboarding-status.enum';
-import { SEED_APPLE_WORKSPACE_ID } from 'src/engine/workspace-manager/dev-seeder/core/constants/seeder-workspaces.constant';
-
-const APPLE_WORKSPACE_INVITE_HASH = 'apple.dev-invite-hash';
 
 describe('updateWorkspaceMemberSettings and profile onboarding', () => {
   let newUserAccessToken: string | undefined;
@@ -76,99 +72,10 @@ describe('updateWorkspaceMemberSettings and profile onboarding', () => {
   });
 
   it('should clear PROFILE_CREATION onboarding after saving first and last name via updateWorkspaceMemberSettings', async () => {
-    const client = request(`http://localhost:${APP_PORT}`);
-
-    const enablePublicInviteLinkMutation = {
-      query: `
-        mutation UpdateWorkspace {
-          updateWorkspace(data: { isPublicInviteLinkEnabled: true }) {
-            id
-            isPublicInviteLinkEnabled
-          }
-        }
-      `,
-    };
-
-    await client
-      .post('/metadata')
-      .set('Authorization', `Bearer ${APPLE_JANE_ADMIN_ACCESS_TOKEN}`)
-      .send(enablePublicInviteLinkMutation)
-      .expect(200)
-      .expect((response) => {
-        expect(response.body.errors).toBeUndefined();
-        expect(
-          response.body.data.updateWorkspace.isPublicInviteLinkEnabled,
-        ).toBe(true);
-      });
-
     const uniqueEmail = `profile-onboarding-${randomUUID()}@example.com`;
-    const password = 'Password123!';
-
-    const signUpInWorkspaceMutation = gql`
-      mutation SignUpInWorkspace(
-        $email: String!
-        $password: String!
-        $workspaceInviteHash: String
-        $workspaceId: UUID
-      ) {
-        signUpInWorkspace(
-          email: $email
-          password: $password
-          workspaceInviteHash: $workspaceInviteHash
-          workspaceId: $workspaceId
-        ) {
-          loginToken {
-            token
-          }
-          workspace {
-            id
-            workspaceUrls {
-              subdomainUrl
-            }
-          }
-        }
-      }
-    `;
-
-    const signUpResponse = await makeMetadataAPIRequest(
-      {
-        query: signUpInWorkspaceMutation,
-        variables: {
-          email: uniqueEmail,
-          password,
-          workspaceInviteHash: APPLE_WORKSPACE_INVITE_HASH,
-          workspaceId: SEED_APPLE_WORKSPACE_ID,
-        },
-      },
-      undefined,
-    );
-
-    expect(signUpResponse.status).toBe(200);
-    expect(signUpResponse.body.errors).toBeUndefined();
-
-    const signUpPayload = signUpResponse.body.data.signUpInWorkspace;
-
-    expect(signUpPayload.loginToken.token).toBeDefined();
-
-    await testDataSource.query(
-      'UPDATE core."user" SET "isEmailVerified" = true WHERE email = $1',
-      [uniqueEmail],
-    );
-
-    const origin =
-      signUpPayload.workspace.workspaceUrls?.subdomainUrl ??
-      'http://localhost:3001';
-
-    const {
-      data: { getAuthTokensFromLoginToken: authTokensData },
-    } = await getAuthTokensFromLoginToken({
-      loginToken: signUpPayload.loginToken.token,
-      origin,
-      expectToFail: false,
-    });
 
     newUserAccessToken =
-      authTokensData.tokens.accessOrWorkspaceAgnosticToken.token;
+      await signUpInWorkspaceAndGetAccessToken(uniqueEmail);
 
     const currentUserWithOnboardingQuery = gql`
       query CurrentUserWithOnboarding {

--- a/packages/twenty-server/test/integration/graphql/suites/user.integration-spec.ts
+++ b/packages/twenty-server/test/integration/graphql/suites/user.integration-spec.ts
@@ -2,103 +2,18 @@ import { randomUUID } from 'crypto';
 
 import gql from 'graphql-tag';
 import request from 'supertest';
-import { getAuthTokensFromLoginToken } from 'test/integration/graphql/utils/get-auth-tokens-from-login-token.util';
 import { getCurrentUser } from 'test/integration/graphql/utils/get-current-user.util';
 import { signUpOperationFactory } from 'test/integration/graphql/utils/sign-up-operation-factory.util';
+import { signUpInWorkspaceAndGetAccessToken } from 'test/integration/graphql/utils/sign-up-in-workspace-and-get-access-token.util';
 import { deleteUser } from 'test/integration/graphql/utils/delete-user.util';
 import { makeMetadataAPIRequest } from 'test/integration/metadata/suites/utils/make-metadata-api-request.util';
 import { updateConfigVariable } from 'test/integration/twenty-config/utils/update-config-variable.util';
 
 import { ErrorCode } from 'src/engine/core-modules/graphql/utils/graphql-errors.util';
 import { PermissionsExceptionMessage } from 'src/engine/metadata-modules/permissions/permissions.exception';
-import { SEED_APPLE_WORKSPACE_ID } from 'src/engine/workspace-manager/dev-seeder/core/constants/seeder-workspaces.constant';
 import { WORKSPACE_MEMBER_DATA_SEED_IDS } from 'src/engine/workspace-manager/dev-seeder/data/constants/workspace-member-data-seeds.constant';
 
 const client = request(`http://localhost:${APP_PORT}`);
-
-const APPLE_WORKSPACE_INVITE_HASH = 'apple.dev-invite-hash';
-
-const signUpAndGetAccessToken = async (email: string) => {
-  const enablePublicInviteLinkMutation = {
-    query: `
-      mutation updateWorkspace {
-        updateWorkspace(data: { isPublicInviteLinkEnabled: true }) {
-          id
-          isPublicInviteLinkEnabled
-        }
-      }
-    `,
-  };
-
-  await client
-    .post('/metadata')
-    .set('Authorization', `Bearer ${APPLE_JANE_ADMIN_ACCESS_TOKEN}`)
-    .send(enablePublicInviteLinkMutation)
-    .expect(200);
-
-  const signUpInWorkspaceMutation = gql`
-    mutation SignUpInWorkspace(
-      $email: String!
-      $password: String!
-      $workspaceInviteHash: String
-      $workspaceId: UUID
-    ) {
-      signUpInWorkspace(
-        email: $email
-        password: $password
-        workspaceInviteHash: $workspaceInviteHash
-        workspaceId: $workspaceId
-      ) {
-        loginToken {
-          token
-        }
-        workspace {
-          id
-          workspaceUrls {
-            subdomainUrl
-          }
-        }
-      }
-    }
-  `;
-
-  const signUpResponse = await makeMetadataAPIRequest(
-    {
-      query: signUpInWorkspaceMutation,
-      variables: {
-        email,
-        password: 'Password123!',
-        workspaceInviteHash: APPLE_WORKSPACE_INVITE_HASH,
-        workspaceId: SEED_APPLE_WORKSPACE_ID,
-      },
-    },
-    undefined,
-  );
-
-  expect(signUpResponse.status).toBe(200);
-  expect(signUpResponse.body.errors).toBeUndefined();
-
-  const signUpPayload = signUpResponse.body.data.signUpInWorkspace;
-
-  await testDataSource.query(
-    'UPDATE core."user" SET "isEmailVerified" = true WHERE email = $1',
-    [email],
-  );
-
-  const origin =
-    signUpPayload.workspace.workspaceUrls?.subdomainUrl ??
-    'http://localhost:3001';
-
-  const {
-    data: { getAuthTokensFromLoginToken: authTokensData },
-  } = await getAuthTokensFromLoginToken({
-    loginToken: signUpPayload.loginToken.token,
-    origin,
-    expectToFail: false,
-  });
-
-  return authTokensData.tokens.accessOrWorkspaceAgnosticToken.token;
-};
 
 describe('deleteUser', () => {
   it('should not allow to delete user if they are the unique admin of a workspace', async () => {
@@ -298,7 +213,8 @@ describe('updateUserEmail', () => {
     const originalEmail = `update-email-no-verif-${randomUUID()}@example.com`;
     const updatedEmail = `updated-${randomUUID()}@example.com`;
 
-    newUserAccessToken = await signUpAndGetAccessToken(originalEmail);
+    newUserAccessToken =
+      await signUpInWorkspaceAndGetAccessToken(originalEmail);
 
     const updateEmailMutation = gql`
       mutation UpdateUserEmail($newEmail: String!) {
@@ -330,7 +246,8 @@ describe('updateUserEmail', () => {
     const originalEmail = `update-email-with-verif-${randomUUID()}@example.com`;
     const updatedEmail = `updated-verif-${randomUUID()}@example.com`;
 
-    newUserAccessToken = await signUpAndGetAccessToken(originalEmail);
+    newUserAccessToken =
+      await signUpInWorkspaceAndGetAccessToken(originalEmail);
 
     await updateConfigVariable({
       input: {

--- a/packages/twenty-server/test/integration/graphql/suites/user.integration-spec.ts
+++ b/packages/twenty-server/test/integration/graphql/suites/user.integration-spec.ts
@@ -1,11 +1,104 @@
+import { randomUUID } from 'crypto';
+
+import gql from 'graphql-tag';
 import request from 'supertest';
+import { getAuthTokensFromLoginToken } from 'test/integration/graphql/utils/get-auth-tokens-from-login-token.util';
+import { getCurrentUser } from 'test/integration/graphql/utils/get-current-user.util';
 import { signUpOperationFactory } from 'test/integration/graphql/utils/sign-up-operation-factory.util';
+import { deleteUser } from 'test/integration/graphql/utils/delete-user.util';
+import { makeMetadataAPIRequest } from 'test/integration/metadata/suites/utils/make-metadata-api-request.util';
+import { updateConfigVariable } from 'test/integration/twenty-config/utils/update-config-variable.util';
 
 import { ErrorCode } from 'src/engine/core-modules/graphql/utils/graphql-errors.util';
 import { PermissionsExceptionMessage } from 'src/engine/metadata-modules/permissions/permissions.exception';
+import { SEED_APPLE_WORKSPACE_ID } from 'src/engine/workspace-manager/dev-seeder/core/constants/seeder-workspaces.constant';
 import { WORKSPACE_MEMBER_DATA_SEED_IDS } from 'src/engine/workspace-manager/dev-seeder/data/constants/workspace-member-data-seeds.constant';
 
 const client = request(`http://localhost:${APP_PORT}`);
+
+const APPLE_WORKSPACE_INVITE_HASH = 'apple.dev-invite-hash';
+
+const signUpAndGetAccessToken = async (email: string) => {
+  const enablePublicInviteLinkMutation = {
+    query: `
+      mutation updateWorkspace {
+        updateWorkspace(data: { isPublicInviteLinkEnabled: true }) {
+          id
+          isPublicInviteLinkEnabled
+        }
+      }
+    `,
+  };
+
+  await client
+    .post('/metadata')
+    .set('Authorization', `Bearer ${APPLE_JANE_ADMIN_ACCESS_TOKEN}`)
+    .send(enablePublicInviteLinkMutation)
+    .expect(200);
+
+  const signUpInWorkspaceMutation = gql`
+    mutation SignUpInWorkspace(
+      $email: String!
+      $password: String!
+      $workspaceInviteHash: String
+      $workspaceId: UUID
+    ) {
+      signUpInWorkspace(
+        email: $email
+        password: $password
+        workspaceInviteHash: $workspaceInviteHash
+        workspaceId: $workspaceId
+      ) {
+        loginToken {
+          token
+        }
+        workspace {
+          id
+          workspaceUrls {
+            subdomainUrl
+          }
+        }
+      }
+    }
+  `;
+
+  const signUpResponse = await makeMetadataAPIRequest(
+    {
+      query: signUpInWorkspaceMutation,
+      variables: {
+        email,
+        password: 'Password123!',
+        workspaceInviteHash: APPLE_WORKSPACE_INVITE_HASH,
+        workspaceId: SEED_APPLE_WORKSPACE_ID,
+      },
+    },
+    undefined,
+  );
+
+  expect(signUpResponse.status).toBe(200);
+  expect(signUpResponse.body.errors).toBeUndefined();
+
+  const signUpPayload = signUpResponse.body.data.signUpInWorkspace;
+
+  await testDataSource.query(
+    'UPDATE core."user" SET "isEmailVerified" = true WHERE email = $1',
+    [email],
+  );
+
+  const origin =
+    signUpPayload.workspace.workspaceUrls?.subdomainUrl ??
+    'http://localhost:3001';
+
+  const {
+    data: { getAuthTokensFromLoginToken: authTokensData },
+  } = await getAuthTokensFromLoginToken({
+    loginToken: signUpPayload.loginToken.token,
+    origin,
+    expectToFail: false,
+  });
+
+  return authTokensData.tokens.accessOrWorkspaceAgnosticToken.token;
+};
 
 describe('deleteUser', () => {
   it('should not allow to delete user if they are the unique admin of a workspace', async () => {
@@ -184,6 +277,101 @@ describe('deleteUser', () => {
       expect(
         role.workspaceMembers.find((wm) => wm.id === createdWorkspaceMemberId),
       ).toBeUndefined();
+    }
+  });
+});
+
+describe('updateUserEmail', () => {
+  let newUserAccessToken: string | undefined;
+
+  afterEach(async () => {
+    if (newUserAccessToken) {
+      await deleteUser({
+        accessToken: newUserAccessToken,
+        expectToFail: false,
+      });
+      newUserAccessToken = undefined;
+    }
+  });
+
+  it('should update email directly when IS_EMAIL_VERIFICATION_REQUIRED is false', async () => {
+    const originalEmail = `update-email-no-verif-${randomUUID()}@example.com`;
+    const updatedEmail = `updated-${randomUUID()}@example.com`;
+
+    newUserAccessToken = await signUpAndGetAccessToken(originalEmail);
+
+    const updateEmailMutation = gql`
+      mutation UpdateUserEmail($newEmail: String!) {
+        updateUserEmail(newEmail: $newEmail)
+      }
+    `;
+
+    const updateResponse = await makeMetadataAPIRequest(
+      {
+        query: updateEmailMutation,
+        variables: { newEmail: updatedEmail },
+      },
+      newUserAccessToken,
+    );
+
+    expect(updateResponse.status).toBe(200);
+    expect(updateResponse.body.errors).toBeUndefined();
+    expect(updateResponse.body.data.updateUserEmail).toBe(true);
+
+    const { data } = await getCurrentUser({
+      accessToken: newUserAccessToken,
+      expectToFail: false,
+    });
+
+    expect(data.currentUser.email).toBe(updatedEmail);
+  });
+
+  it('should not update email immediately when IS_EMAIL_VERIFICATION_REQUIRED is true', async () => {
+    const originalEmail = `update-email-with-verif-${randomUUID()}@example.com`;
+    const updatedEmail = `updated-verif-${randomUUID()}@example.com`;
+
+    newUserAccessToken = await signUpAndGetAccessToken(originalEmail);
+
+    await updateConfigVariable({
+      input: {
+        key: 'IS_EMAIL_VERIFICATION_REQUIRED',
+        value: true,
+      },
+    });
+
+    try {
+      const updateEmailMutation = gql`
+        mutation UpdateUserEmail($newEmail: String!) {
+          updateUserEmail(newEmail: $newEmail)
+        }
+      `;
+
+      const updateResponse = await makeMetadataAPIRequest(
+        {
+          query: updateEmailMutation,
+          variables: { newEmail: updatedEmail },
+        },
+        newUserAccessToken,
+      );
+
+      expect(updateResponse.status).toBe(200);
+      expect(updateResponse.body.errors).toBeUndefined();
+      expect(updateResponse.body.data.updateUserEmail).toBe(true);
+
+      // Email should remain unchanged — verification email was sent but not confirmed
+      const { data } = await getCurrentUser({
+        accessToken: newUserAccessToken,
+        expectToFail: false,
+      });
+
+      expect(data.currentUser.email).toBe(originalEmail);
+    } finally {
+      await updateConfigVariable({
+        input: {
+          key: 'IS_EMAIL_VERIFICATION_REQUIRED',
+          value: false,
+        },
+      });
     }
   });
 });

--- a/packages/twenty-server/test/integration/graphql/utils/sign-up-in-workspace-and-get-access-token.util.ts
+++ b/packages/twenty-server/test/integration/graphql/utils/sign-up-in-workspace-and-get-access-token.util.ts
@@ -1,0 +1,99 @@
+import gql from 'graphql-tag';
+import request from 'supertest';
+import { getAuthTokensFromLoginToken } from 'test/integration/graphql/utils/get-auth-tokens-from-login-token.util';
+import { makeMetadataAPIRequest } from 'test/integration/metadata/suites/utils/make-metadata-api-request.util';
+
+import { SEED_APPLE_WORKSPACE_ID } from 'src/engine/workspace-manager/dev-seeder/core/constants/seeder-workspaces.constant';
+
+const APPLE_WORKSPACE_INVITE_HASH = 'apple.dev-invite-hash';
+
+// Signs up a user in the Apple workspace, marks their email as verified,
+// and returns a valid access token for that user.
+export const signUpInWorkspaceAndGetAccessToken = async (
+  email: string,
+  password = 'Password123!',
+): Promise<string> => {
+  const client = request(`http://localhost:${APP_PORT}`);
+
+  const enablePublicInviteLinkMutation = {
+    query: `
+      mutation updateWorkspace {
+        updateWorkspace(data: { isPublicInviteLinkEnabled: true }) {
+          id
+          isPublicInviteLinkEnabled
+        }
+      }
+    `,
+  };
+
+  await client
+    .post('/metadata')
+    .set('Authorization', `Bearer ${APPLE_JANE_ADMIN_ACCESS_TOKEN}`)
+    .send(enablePublicInviteLinkMutation)
+    .expect(200);
+
+  const signUpInWorkspaceMutation = gql`
+    mutation SignUpInWorkspace(
+      $email: String!
+      $password: String!
+      $workspaceInviteHash: String
+      $workspaceId: UUID
+    ) {
+      signUpInWorkspace(
+        email: $email
+        password: $password
+        workspaceInviteHash: $workspaceInviteHash
+        workspaceId: $workspaceId
+      ) {
+        loginToken {
+          token
+        }
+        workspace {
+          id
+          workspaceUrls {
+            subdomainUrl
+          }
+        }
+      }
+    }
+  `;
+
+  const signUpResponse = await makeMetadataAPIRequest(
+    {
+      query: signUpInWorkspaceMutation,
+      variables: {
+        email,
+        password,
+        workspaceInviteHash: APPLE_WORKSPACE_INVITE_HASH,
+        workspaceId: SEED_APPLE_WORKSPACE_ID,
+      },
+    },
+    undefined,
+  );
+
+  expect(signUpResponse.status).toBe(200);
+  expect(signUpResponse.body.errors).toBeUndefined();
+
+  const signUpPayload = signUpResponse.body.data.signUpInWorkspace;
+
+  expect(signUpPayload.loginToken.token).toBeDefined();
+
+  await testDataSource.query(
+    'UPDATE core."user" SET "isEmailVerified" = true WHERE email = $1',
+    [email],
+  );
+
+  const origin =
+    signUpPayload.workspace.workspaceUrls?.subdomainUrl ??
+    'http://localhost:3001';
+
+  const {
+    data: { getAuthTokensFromLoginToken: authTokensData },
+  } = await getAuthTokensFromLoginToken({
+    loginToken: signUpPayload.loginToken.token,
+    origin,
+    expectToFail: false,
+  });
+
+  return authTokensData.tokens.accessOrWorkspaceAgnosticToken.token;
+};


### PR DESCRIPTION
fixes #20117 

## Technical Details
Flow after fix:
1. User submits email change request
2. user.service.ts:517-524 calls sendVerificationEmail() with verificationTrigger: EMAIL_UPDATE
3. Guard checks: verificationTrigger === SIGN_UP → false → guard skipped
4. Verification token generated, email rendered and sent via emailService.send()
5. User receives confirmation email at new address
6. User clicks confirmation link → email update completes
---
Impact
- Minimal change: Only 3 lines modified in a single file
- No breaking changes: Sign-up verification behavior unchanged
- Security preserved: Email changes always require verification (correct security behavior)
- Self-hosted friendly: Instance admins can disable sign-up verification while keeping email change verification active