### PR TITLE
fix(ai-chat): refresh JWT token on SSE reconnect to prevent login re

### DIFF
--- a/packages/twenty-front/src/modules/sse-db-event/hooks/useHandleSseClientConnectionRetry.ts
+++ b/packages/twenty-front/src/modules/sse-db-event/hooks/useHandleSseClientConnectionRetry.ts
@@ -1,17 +1,29 @@
+import { renewToken } from '@/auth/services/AuthService';
 import { tokenPairState } from '@/auth/states/tokenPairState';
 import { SSE_CONNECTION_RETRY_MAX_WAIT_TIME_IN_MS } from '@/sse-db-event/constants/SseConnectionRetryMaxWaitTimeInMs';
 import { SSE_CONNECTION_RETRY_WAIT_TIME_IN_MS_FOR_DEV_MODE } from '@/sse-db-event/constants/SseConnectionRetryWaitTimeInMsForDevMode';
 import { SSE_CONNECTION_RETRY_WAIT_TIME_IN_MS_TO_AVOID_RACE_CONDITIONS } from '@/sse-db-event/constants/SseConnectionRetryWaitTimeInMsToAvoidRaceConditions';
 import { shouldDestroyEventStreamState } from '@/sse-db-event/states/shouldDestroyEventStreamState';
 import { sseClientState } from '@/sse-db-event/states/sseClientState';
-import { useCallback } from 'react';
-import { isDefined } from 'twenty-shared/utils';
-import { getIsDevelopmentEnvironment } from '~/utils/getIsDevelopmentEnvironment';
-import { sleep } from '~/utils/sleep';
+import { CombinedGraphQLErrors } from '@apollo/client/errors';
 import { useStore } from 'jotai';
+import { useCallback, useRef } from 'react';
+import { isDefined } from 'twenty-shared/utils';
+import { REACT_APP_SERVER_BASE_URL } from '~/config';
+import { getIsDevelopmentEnvironment } from '~/utils/getIsDevelopmentEnvironment';
+import { retryWithBackoff } from '~/utils/retryWithBackoff';
+import { sleep } from '~/utils/sleep';
+
+const TOKEN_RENEWAL_MAX_RETRIES = 3;
+const TOKEN_RENEWAL_RETRY_DELAY_MS = 1000;
 
 export const useHandleSseClientConnectionRetry = () => {
   const store = useStore();
+
+  // Shared promise so concurrent retry calls deduplicate into one renewal
+  // request  mirrors the same pattern used in ApolloFactory.
+  const renewalPromiseRef = useRef<Promise<boolean> | null>(null);
+
   const handleSseClientConnectionRetry = useCallback(
     async (retryCount: number) => {
       const sseClient = store.get(sseClientState.atom);
@@ -27,10 +39,50 @@ export const useHandleSseClientConnectionRetry = () => {
       const tokenPair = store.get(tokenPairState.atom);
       const currentAppToken = tokenPair?.accessOrWorkspaceAgnosticToken?.token;
 
-      const shouldResetSseClient =
-        !isDefined(currentAppToken) || retryCount > 10;
+      if (!isDefined(currentAppToken)) {
+        await sleep(
+          SSE_CONNECTION_RETRY_WAIT_TIME_IN_MS_TO_AVOID_RACE_CONDITIONS,
+        );
 
-      if (shouldResetSseClient) {
+        sseClient.dispose();
+        store.set(shouldDestroyEventStreamState.atom, true);
+        store.set(sseClientState.atom, null);
+        return;
+      }
+
+      // Attempt token renewal before each reconnect so the SSE client can
+      // reconnect with a fresh JWT instead of showing the login screen.
+      // We deduplicate concurrent renewal requests through renewalPromiseRef,
+      // exactly like ApolloFactory does for its /graphql and /metadata clients.
+      if (!renewalPromiseRef.current) {
+        const metadataUri = `${REACT_APP_SERVER_BASE_URL}/metadata`;
+
+        renewalPromiseRef.current = retryWithBackoff(
+          () => renewToken(metadataUri, store.get(tokenPairState.atom)),
+          {
+            maxRetries: TOKEN_RENEWAL_MAX_RETRIES,
+            baseDelayMs: TOKEN_RENEWAL_RETRY_DELAY_MS,
+            shouldRetry: (error) =>
+              !CombinedGraphQLErrors.is(error) &&
+              isDefined(store.get(tokenPairState.atom)),
+          },
+        )
+          .then((tokens) => {
+            if (isDefined(tokens)) {
+              store.set(tokenPairState.atom, tokens);
+            }
+
+            return true;
+          })
+          .catch(() => false)
+          .finally(() => {
+            renewalPromiseRef.current = null;
+          });
+      }
+
+      const renewed = await renewalPromiseRef.current;
+
+      if (!renewed || retryCount > 10) {
         await sleep(
           SSE_CONNECTION_RETRY_WAIT_TIME_IN_MS_TO_AVOID_RACE_CONDITIONS,
         );


### PR DESCRIPTION
Closes #18928

When a JWT access token expires while the AI chat is streaming a response,
the SSE connection drops and `graphql-sse` calls the retry callback.
The previous implementation would wait, then destroy the SSE client 
but **never refreshed the token**. On the next connection attempt the
client reused the same expired token, eventually triggering an
`UNAUTHENTICATED` error that redirected the user to the login screen.

## Solution

Attempt a proactive token renewal inside `useHandleSseClientConnectionRetry`
before each reconnect attempt, following the **exact same pattern** already
used in `ApolloFactory` for GraphQL requests:

- Call `renewToken` (via `retryWithBackoff` with 3 retries) against the
  `/metadata` endpoint
- Write the fresh `tokenPair` directly into the Jotai store
- The SSE client's `headers: () => store.get(tokenPairState)` callback
  automatically picks up the new token on reconnect
- Concurrent retry calls share a single `renewalPromiseRef` to avoid
  duplicate renewal requests (same deduplication strategy as Apollo's
  module-level `renewalPromise`)
- If renewal fails (no refresh token, or server error after retries)
  -> fall back to destroying the SSE client as before

## Files changed

- `packages/twenty-front/src/modules/sse-db-event/hooks/useHandleSseClientConnectionRetry.ts`

## How to test

1. Open the AI chat and start a long streaming response
2. In DevTools -> Application -> Cookies, delete or corrupt the access
   token cookie mid-stream (or use a short-lived token in dev)
3. **Before**: login screen appears, stream is lost
4. **After**: stream continues seamlessly after a brief reconnect pause