### PR TITLE
fix: Filter system object record pages by translated tab titles

### DIFF
--- a/packages/twenty-front/src/modules/page-layout/components/PageLayoutTabsRenderer.tsx
+++ b/packages/twenty-front/src/modules/page-layout/components/PageLayoutTabsRenderer.tsx
@@ -27,7 +27,6 @@ import { useAtomFamilyStateValue } from '@/ui/utilities/state/jotai/hooks/useAto
 import { useIsFeatureEnabled } from '@/workspace/hooks/useIsFeatureEnabled';
 import { styled } from '@linaria/react';
 import { useLingui } from '@lingui/react/macro';
-import { useMemo } from 'react';
 import { isDefined } from 'twenty-shared/utils';
 import { useIsMobile } from 'twenty-ui/utilities';
 import { FeatureFlagKey } from '~/generated-metadata/graphql';
@@ -110,15 +109,10 @@ export const PageLayoutTabsRenderer = () => {
     isEditMode: isPageLayoutInEditMode,
   });
 
-  const systemObjectTabTitles = useMemo(
-    () => getSystemObjectTabTitles(i18n),
-    [i18n],
-  );
-
   const tabsForCurrentObject = getPageLayoutTabsForCurrentObject({
     isSystemObject,
     tabsWithVisibleWidgets,
-    systemObjectTabTitles,
+    systemObjectTabTitles: getSystemObjectTabTitles(i18n),
   });
 
   const { tabsToRenderInTabList, pinnedLeftTab } = getTabsByDisplayMode({

--- a/packages/twenty-front/src/modules/page-layout/components/PageLayoutTabsRenderer.tsx
+++ b/packages/twenty-front/src/modules/page-layout/components/PageLayoutTabsRenderer.tsx
@@ -112,7 +112,7 @@ export const PageLayoutTabsRenderer = () => {
 
   const systemObjectTabTitles = useMemo(
     () => getSystemObjectTabTitles(i18n),
-    [i18n, i18n.locale],
+    [i18n],
   );
 
   const tabsForCurrentObject = getPageLayoutTabsForCurrentObject({

--- a/packages/twenty-front/src/modules/page-layout/components/PageLayoutTabsRenderer.tsx
+++ b/packages/twenty-front/src/modules/page-layout/components/PageLayoutTabsRenderer.tsx
@@ -10,6 +10,10 @@ import { usePageLayoutAddTabStrategy } from '@/page-layout/hooks/usePageLayoutAd
 import { useReorderRecordPageLayoutTabs } from '@/page-layout/hooks/useReorderRecordPageLayoutTabs';
 import { PageLayoutMainContent } from '@/page-layout/PageLayoutMainContent';
 import { getScrollWrapperInstanceIdFromPageLayoutId } from '@/page-layout/utils/getScrollWrapperInstanceIdFromPageLayoutId';
+import {
+  getPageLayoutTabsForCurrentObject,
+  getSystemObjectTabTitles,
+} from '@/page-layout/utils/getPageLayoutTabsForCurrentObject';
 import { getTabListInstanceIdFromPageLayoutAndRecord } from '@/page-layout/utils/getTabListInstanceIdFromPageLayoutAndRecord';
 import { getTabsByDisplayMode } from '@/page-layout/utils/getTabsByDisplayMode';
 import { getTabsWithVisibleWidgets } from '@/page-layout/utils/getTabsWithVisibleWidgets';
@@ -22,6 +26,8 @@ import { useAtomComponentStateValue } from '@/ui/utilities/state/jotai/hooks/use
 import { useAtomFamilyStateValue } from '@/ui/utilities/state/jotai/hooks/useAtomFamilyStateValue';
 import { useIsFeatureEnabled } from '@/workspace/hooks/useIsFeatureEnabled';
 import { styled } from '@linaria/react';
+import { useLingui } from '@lingui/react/macro';
+import { useMemo } from 'react';
 import { isDefined } from 'twenty-shared/utils';
 import { useIsMobile } from 'twenty-ui/utilities';
 import { FeatureFlagKey } from '~/generated-metadata/graphql';
@@ -47,6 +53,8 @@ const StyledScrollWrapperContainer = styled.div`
 `;
 
 export const PageLayoutTabsRenderer = () => {
+  const { i18n } = useLingui();
+
   const { currentPageLayout } = useCurrentPageLayoutOrThrow();
 
   const { isInSidePanel, layoutType, targetRecordIdentifier } =
@@ -102,13 +110,16 @@ export const PageLayoutTabsRenderer = () => {
     isEditMode: isPageLayoutInEditMode,
   });
 
-  const SYSTEM_OBJECT_TABS = ['Home', 'Timeline', 'Overview', 'Flow'];
+  const systemObjectTabTitles = useMemo(
+    () => getSystemObjectTabTitles(i18n),
+    [i18n, i18n.locale],
+  );
 
-  const tabsForCurrentObject = isSystemObject
-    ? tabsWithVisibleWidgets.filter((tab) =>
-        SYSTEM_OBJECT_TABS.includes(tab.title),
-      )
-    : tabsWithVisibleWidgets;
+  const tabsForCurrentObject = getPageLayoutTabsForCurrentObject({
+    isSystemObject,
+    tabsWithVisibleWidgets,
+    systemObjectTabTitles,
+  });
 
   const { tabsToRenderInTabList, pinnedLeftTab } = getTabsByDisplayMode({
     tabs: tabsForCurrentObject,

--- a/packages/twenty-front/src/modules/page-layout/components/__tests__/PageLayoutTabsRenderer.test.tsx
+++ b/packages/twenty-front/src/modules/page-layout/components/__tests__/PageLayoutTabsRenderer.test.tsx
@@ -1,0 +1,63 @@
+import { type I18n } from '@lingui/core';
+
+import { type PageLayoutTab } from '@/page-layout/types/PageLayoutTab';
+import {
+  getPageLayoutTabsForCurrentObject,
+  getSystemObjectTabTitles,
+} from '@/page-layout/utils/getPageLayoutTabsForCurrentObject';
+
+const createMockTab = (id: string, title: string): PageLayoutTab => ({
+  __typename: 'PageLayoutTab',
+  applicationId: '',
+  id,
+  isActive: true,
+  pageLayoutId: 'page-layout-1',
+  title,
+  position: 0,
+  widgets: [],
+  createdAt: '2024-01-01T00:00:00.000Z',
+  updatedAt: '2024-01-01T00:00:00.000Z',
+  deletedAt: null,
+});
+
+describe('PageLayoutTabsRenderer', () => {
+  it('keeps translated system object tabs in non-English locales', () => {
+    const translatedSystemObjectTabTitles = [
+      'ホーム',
+      'タイムライン',
+      '概要',
+      'フロー',
+    ];
+
+    const mockI18n = {
+      _: jest
+        .fn()
+        .mockReturnValueOnce(translatedSystemObjectTabTitles[0])
+        .mockReturnValueOnce(translatedSystemObjectTabTitles[1])
+        .mockReturnValueOnce(translatedSystemObjectTabTitles[2])
+        .mockReturnValueOnce(translatedSystemObjectTabTitles[3]),
+    } as unknown as I18n;
+
+    const systemObjectTabTitles = getSystemObjectTabTitles(mockI18n);
+
+    const tabs = [
+      createMockTab('home', translatedSystemObjectTabTitles[0]),
+      createMockTab('timeline', translatedSystemObjectTabTitles[1]),
+      createMockTab('overview', translatedSystemObjectTabTitles[2]),
+      createMockTab('flow', translatedSystemObjectTabTitles[3]),
+      createMockTab('custom', 'Custom'),
+      createMockTab('english-home', 'Home'),
+    ];
+
+    const result = getPageLayoutTabsForCurrentObject({
+      isSystemObject: true,
+      tabsWithVisibleWidgets: tabs,
+      systemObjectTabTitles,
+    });
+
+    expect(result).toHaveLength(4);
+    expect(result.map((tab) => tab.title)).toEqual(
+      translatedSystemObjectTabTitles,
+    );
+  });
+});

--- a/packages/twenty-front/src/modules/page-layout/components/__tests__/PageLayoutTabsRenderer.test.tsx
+++ b/packages/twenty-front/src/modules/page-layout/components/__tests__/PageLayoutTabsRenderer.test.tsx
@@ -46,7 +46,6 @@ describe('PageLayoutTabsRenderer', () => {
       createMockTab('overview', translatedSystemObjectTabTitles[2]),
       createMockTab('flow', translatedSystemObjectTabTitles[3]),
       createMockTab('custom', 'Custom'),
-      createMockTab('english-home', 'Home'),
     ];
 
     const result = getPageLayoutTabsForCurrentObject({
@@ -59,5 +58,48 @@ describe('PageLayoutTabsRenderer', () => {
     expect(result.map((tab) => tab.title)).toEqual(
       translatedSystemObjectTabTitles,
     );
+  });
+
+  it('keeps translated and source system object tabs in non-English locales', () => {
+    const translatedSystemObjectTabTitles = [
+      'ホーム',
+      'タイムライン',
+      '概要',
+      'フロー',
+    ];
+
+    const mockI18n = {
+      _: jest
+        .fn()
+        .mockReturnValueOnce(translatedSystemObjectTabTitles[0])
+        .mockReturnValueOnce(translatedSystemObjectTabTitles[1])
+        .mockReturnValueOnce(translatedSystemObjectTabTitles[2])
+        .mockReturnValueOnce(translatedSystemObjectTabTitles[3]),
+    } as unknown as I18n;
+
+    const systemObjectTabTitles = getSystemObjectTabTitles(mockI18n);
+
+    const tabs = [
+      createMockTab('home', translatedSystemObjectTabTitles[0]),
+      createMockTab('timeline', 'Timeline'),
+      createMockTab('overview', translatedSystemObjectTabTitles[2]),
+      createMockTab('flow', 'Flow'),
+      createMockTab('custom', 'Custom'),
+      createMockTab('reports', 'Reports'),
+    ];
+
+    const result = getPageLayoutTabsForCurrentObject({
+      isSystemObject: true,
+      tabsWithVisibleWidgets: tabs,
+      systemObjectTabTitles,
+    });
+
+    expect(result).toHaveLength(4);
+    expect(result.map((tab) => tab.title)).toEqual([
+      translatedSystemObjectTabTitles[0],
+      'Timeline',
+      translatedSystemObjectTabTitles[2],
+      'Flow',
+    ]);
   });
 });

--- a/packages/twenty-front/src/modules/page-layout/utils/getPageLayoutTabsForCurrentObject.ts
+++ b/packages/twenty-front/src/modules/page-layout/utils/getPageLayoutTabsForCurrentObject.ts
@@ -3,7 +3,12 @@ import { msg } from '@lingui/core/macro';
 
 import { type PageLayoutTab } from '@/page-layout/types/PageLayoutTab';
 
-const SYSTEM_OBJECT_TAB_SOURCE_TITLES = ['Home', 'Timeline', 'Overview', 'Flow'];
+const SYSTEM_OBJECT_TAB_SOURCE_TITLES = [
+  'Home',
+  'Timeline',
+  'Overview',
+  'Flow',
+];
 
 export const getSystemObjectTabTitles = (i18n: I18n) => {
   const translated = [

--- a/packages/twenty-front/src/modules/page-layout/utils/getPageLayoutTabsForCurrentObject.ts
+++ b/packages/twenty-front/src/modules/page-layout/utils/getPageLayoutTabsForCurrentObject.ts
@@ -3,12 +3,20 @@ import { msg } from '@lingui/core/macro';
 
 import { type PageLayoutTab } from '@/page-layout/types/PageLayoutTab';
 
-export const getSystemObjectTabTitles = (i18n: I18n) => [
-  i18n._(msg`Home`),
-  i18n._(msg`Timeline`),
-  i18n._(msg`Overview`),
-  i18n._(msg`Flow`),
-];
+const SYSTEM_OBJECT_TAB_SOURCE_TITLES = ['Home', 'Timeline', 'Overview', 'Flow'];
+
+export const getSystemObjectTabTitles = (i18n: I18n) => {
+  const translated = [
+    i18n._(msg`Home`),
+    i18n._(msg`Timeline`),
+    i18n._(msg`Overview`),
+    i18n._(msg`Flow`),
+  ];
+
+  return Array.from(
+    new Set([...SYSTEM_OBJECT_TAB_SOURCE_TITLES, ...translated]),
+  );
+};
 
 type GetPageLayoutTabsForCurrentObjectArgs = {
   isSystemObject: boolean;

--- a/packages/twenty-front/src/modules/page-layout/utils/getPageLayoutTabsForCurrentObject.ts
+++ b/packages/twenty-front/src/modules/page-layout/utils/getPageLayoutTabsForCurrentObject.ts
@@ -1,0 +1,29 @@
+import { type I18n } from '@lingui/core';
+import { msg } from '@lingui/core/macro';
+
+import { type PageLayoutTab } from '@/page-layout/types/PageLayoutTab';
+
+export const getSystemObjectTabTitles = (i18n: I18n) => [
+  i18n._(msg`Home`),
+  i18n._(msg`Timeline`),
+  i18n._(msg`Overview`),
+  i18n._(msg`Flow`),
+];
+
+type GetPageLayoutTabsForCurrentObjectArgs = {
+  isSystemObject: boolean;
+  tabsWithVisibleWidgets: PageLayoutTab[];
+  systemObjectTabTitles: string[];
+};
+
+export const getPageLayoutTabsForCurrentObject = ({
+  isSystemObject,
+  tabsWithVisibleWidgets,
+  systemObjectTabTitles,
+}: GetPageLayoutTabsForCurrentObjectArgs) => {
+  return isSystemObject
+    ? tabsWithVisibleWidgets.filter((tab) =>
+        systemObjectTabTitles.includes(tab.title),
+      )
+    : tabsWithVisibleWidgets;
+};


### PR DESCRIPTION
## Summary

System object record pages (`messageThread`, `company`, etc.) render empty for non-English workspace members. The email body, timeline, and other widgets never appear.

## Why this matters

The tab filter at `PageLayoutTabsRenderer.tsx:105` compared against an English-only allow-list, but `tab.title` arrives Lingui-translated for non-English locales. The filter dropped every tab, and `<PageLayoutMainContent />` never mounted.

OP's diagnosis at [#20102](https://github.com/twentyhq/twenty/issues/20102) is correct.

## Changes

Filter against both source-locale and Lingui-translated forms via a small helper. Source forms stay in the allow-list because client-side default page layouts ship hardcoded English titles.

## Testing

Two unit tests: server-translated titles only (the original repro) and a mixed translated/source case (the client-default code path).

`nx lint twenty-front` and `nx typecheck twenty-front` clean.

Fixes #20102

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
