### PR TITLE
Fix record table dashboard save

### DIFF
--- a/packages/twenty-front/src/modules/page-layout/hooks/useSaveRecordTableWidgetViews.ts
+++ b/packages/twenty-front/src/modules/page-layout/hooks/useSaveRecordTableWidgetViews.ts
@@ -65,7 +65,6 @@ export const useSaveRecordTableWidgetViews = () => {
             input: {
               widgetId: widget.id,
               viewFields: widgetViewDraft.viewFields.map((field) => ({
-                ...(isDefined(field.id) ? { viewFieldId: field.id } : {}),
                 fieldMetadataId: field.fieldMetadataId,
                 isVisible: field.isVisible,
                 position: field.position,

--- a/packages/twenty-server/src/engine/metadata-modules/view/services/view-widget-upsert.service.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/view/services/view-widget-upsert.service.ts
@@ -383,13 +383,20 @@ export class ViewWidgetUpsertService {
     const fieldsToUpdate: FlatViewField[] = [];
 
     for (const inputField of inputFields) {
-      const existingField = isDefined(inputField.viewFieldId)
+      const existingFieldByViewFieldId = isDefined(inputField.viewFieldId)
         ? existingViewFields.find((f) => f.id === inputField.viewFieldId)
-        : isDefined(inputField.fieldMetadataId)
-          ? existingViewFields.find(
-              (f) => f.fieldMetadataId === inputField.fieldMetadataId,
-            )
-          : undefined;
+        : undefined;
+
+      const existingFieldByFieldMetadataId = isDefined(
+        inputField.fieldMetadataId,
+      )
+        ? existingViewFields.find(
+            (f) => f.fieldMetadataId === inputField.fieldMetadataId,
+          )
+        : undefined;
+
+      const existingField =
+        existingFieldByViewFieldId ?? existingFieldByFieldMetadataId;
 
       if (isDefined(existingField)) {
         const resolvedIsVisible = isDefined(existingField.overrides?.isVisible)


### PR DESCRIPTION
## Summary

Fixes `METADATA_VALIDATION_FAILED` / “view field already exists” when saving dashboard **record table** widgets after the first persist (e.g. several table widgets on one dashboard).

## Problem

Draft view columns used **client-generated** `viewField` ids. After save, the API stored **different** ids. The next upsert still sent the old draft ids as `viewFieldId`. The server only matched on that id, missed every row, and tried to **create** columns that already existed for the same `fieldMetadataId` + view.