### PR TITLE
fix(imap): optimize performance and improve reliability

### DIFF
--- a/packages/twenty-server/src/modules/messaging/message-folder-manager/drivers/imap/services/imap-get-all-folders.service.ts
+++ b/packages/twenty-server/src/modules/messaging/message-folder-manager/drivers/imap/services/imap-get-all-folders.service.ts
@@ -43,8 +43,6 @@ export class ImapGetAllFoldersService implements MessageFolderDriver {
         messageChannel,
       );
 
-      await this.imapClientProvider.closeClient(client);
-
       return folders;
     } catch (error) {
       this.logger.error(
@@ -53,6 +51,8 @@ export class ImapGetAllFoldersService implements MessageFolderDriver {
       );
 
       throw error;
+    } finally {
+      await this.imapClientProvider.closeClient(connectedAccount.id);
     }
   }
 

--- a/packages/twenty-server/src/modules/messaging/message-import-manager/drivers/imap/providers/imap-client.provider.spec.ts
+++ b/packages/twenty-server/src/modules/messaging/message-import-manager/drivers/imap/providers/imap-client.provider.spec.ts
@@ -1,0 +1,133 @@
+import { Test, type TestingModule } from '@nestjs/testing';
+import { ImapClientProvider } from './imap-client.provider';
+import { SecureHttpClientService } from 'src/engine/core-modules/secure-http-client/secure-http-client.service';
+import { ImapFlow } from 'imapflow';
+import { ConnectedAccountProvider } from 'twenty-shared/types';
+
+jest.mock('imapflow');
+
+describe('ImapClientProvider', () => {
+  let provider: ImapClientProvider;
+
+  const mockConnectedAccount = {
+    id: 'account-1',
+    provider: ConnectedAccountProvider.IMAP_SMTP_CALDAV,
+    handle: 'test@example.com',
+    connectionParameters: {
+      IMAP: {
+        host: 'imap.example.com',
+        port: 993,
+        secure: true,
+      },
+    },
+  };
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        ImapClientProvider,
+        {
+          provide: SecureHttpClientService,
+          useValue: {
+            getValidatedHost: jest.fn().mockResolvedValue('imap.example.com'),
+          },
+        },
+      ],
+    }).compile();
+
+    provider = module.get<ImapClientProvider>(ImapClientProvider);
+
+    jest.clearAllMocks();
+  });
+
+  it('should be defined', () => {
+    expect(provider).toBeDefined();
+  });
+
+  describe('getClient', () => {
+    it('should create a new connection if none exists', async () => {
+      const mockConnect = jest.fn().mockResolvedValue(undefined);
+      (ImapFlow as jest.Mock).mockImplementation(() => ({
+        connect: mockConnect,
+        usable: true,
+      }));
+
+      const client = await provider.getClient(mockConnectedAccount as any);
+
+      expect(ImapFlow).toHaveBeenCalled();
+      expect(mockConnect).toHaveBeenCalled();
+      expect(client).toBeDefined();
+    });
+
+    it('should reuse connection if it exists and is usable', async () => {
+      const mockConnect = jest.fn().mockResolvedValue(undefined);
+      const mockClient = {
+        connect: mockConnect,
+        usable: true,
+      };
+      (ImapFlow as jest.Mock).mockImplementation(() => mockClient);
+
+      await provider.getClient(mockConnectedAccount as any);
+      const client2 = await provider.getClient(mockConnectedAccount as any);
+
+      expect(ImapFlow).toHaveBeenCalledTimes(1);
+      expect(client2).toBe(mockClient);
+    });
+
+    it('should create a new connection if cached one is not usable', async () => {
+      const mockConnect = jest.fn().mockResolvedValue(undefined);
+      (ImapFlow as jest.Mock)
+        .mockImplementationOnce(() => ({
+          connect: mockConnect,
+          usable: false,
+          logout: jest.fn(),
+        }))
+        .mockImplementationOnce(() => ({
+          connect: mockConnect,
+          usable: true,
+        }));
+
+      await provider.getClient(mockConnectedAccount as any);
+      await provider.getClient(mockConnectedAccount as any);
+
+      expect(ImapFlow).toHaveBeenCalledTimes(2);
+    });
+
+    it('should retry connection on failure', async () => {
+      const mockConnect = jest
+        .fn()
+        .mockRejectedValueOnce(new Error('Connection failed'))
+        .mockResolvedValueOnce(undefined);
+
+      (ImapFlow as jest.Mock).mockImplementation(() => ({
+        connect: mockConnect,
+        usable: true,
+        logout: jest.fn(),
+      }));
+
+      await provider.getClient(mockConnectedAccount as any);
+
+      expect(mockConnect).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  describe('closeClient', () => {
+    it('should logout and remove client from cache', async () => {
+      const mockLogout = jest.fn().mockResolvedValue(undefined);
+      (ImapFlow as jest.Mock).mockImplementation(() => ({
+        connect: jest.fn().mockResolvedValue(undefined),
+        logout: mockLogout,
+        usable: true,
+      }));
+
+      await provider.getClient(mockConnectedAccount as any);
+      await provider.closeClient(mockConnectedAccount.id);
+
+      expect(mockLogout).toHaveBeenCalled();
+
+      // Verify it's removed from cache by getting it again
+      await provider.getClient(mockConnectedAccount as any);
+      expect(ImapFlow).toHaveBeenCalledTimes(2);
+    });
+  });
+});

--- a/packages/twenty-server/src/modules/messaging/message-import-manager/drivers/imap/providers/imap-client.provider.ts
+++ b/packages/twenty-server/src/modules/messaging/message-import-manager/drivers/imap/providers/imap-client.provider.ts
@@ -21,6 +21,7 @@ export class ImapClientProvider {
 
   private static readonly CONNECTION_TIMEOUT_MS = 30000;
   private static readonly GREETING_TIMEOUT_MS = 16000;
+  private static readonly RESPONSE_TIMEOUT_MS = 30000;
 
   constructor(
     private readonly secureHttpClientService: SecureHttpClientService,
@@ -92,6 +93,7 @@ export class ImapClientProvider {
       },
       connectionTimeout: ImapClientProvider.CONNECTION_TIMEOUT_MS,
       greetingTimeout: ImapClientProvider.GREETING_TIMEOUT_MS,
+      responseTimeout: ImapClientProvider.RESPONSE_TIMEOUT_MS,
     });
 
     try {

--- a/packages/twenty-server/src/modules/messaging/message-import-manager/drivers/imap/providers/imap-client.provider.ts
+++ b/packages/twenty-server/src/modules/messaging/message-import-manager/drivers/imap/providers/imap-client.provider.ts
@@ -22,6 +22,9 @@ export class ImapClientProvider {
   private static readonly CONNECTION_TIMEOUT_MS = 30000;
   private static readonly GREETING_TIMEOUT_MS = 16000;
   private static readonly RESPONSE_TIMEOUT_MS = 30000;
+  private static readonly MAX_RETRIES = 2;
+
+  private readonly clients = new Map<string, ImapFlow>();
 
   constructor(
     private readonly secureHttpClientService: SecureHttpClientService,
@@ -30,8 +33,19 @@ export class ImapClientProvider {
   async getClient(
     connectedAccount: ConnectedAccountIdentifier,
   ): Promise<ImapFlow> {
+    const cachedClient = this.clients.get(connectedAccount.id);
+
+    if (cachedClient && cachedClient.usable) {
+      this.logger.debug(
+        `Reusing cached IMAP client for ${connectedAccount.handle}`,
+      );
+      return cachedClient;
+    }
+
     try {
-      return await this.createConnection(connectedAccount);
+      const client = await this.createConnectionWithRetry(connectedAccount);
+      this.clients.set(connectedAccount.id, client);
+      return client;
     } catch (error) {
       this.logger.error(
         `Failed to establish IMAP connection for ${connectedAccount.handle}: ${error.message}`,
@@ -42,12 +56,46 @@ export class ImapClientProvider {
     }
   }
 
-  async closeClient(client: ImapFlow): Promise<void> {
+  async closeClient(connectedAccountId: string): Promise<void> {
+    const client = this.clients.get(connectedAccountId);
+
+    if (!client) {
+      return;
+    }
+
     try {
       await client.logout();
-      this.logger.log('Closed IMAP client');
+      this.clients.delete(connectedAccountId);
+      this.logger.log(`Closed IMAP client for ${connectedAccountId}`);
     } catch (error) {
       this.logger.error(`Error closing IMAP client: ${error.message}`);
+      this.clients.delete(connectedAccountId);
+    }
+  }
+
+  // Helper for cleanup when we want to force logout a specific client instance
+  async forceLogout(client: ImapFlow): Promise<void> {
+    try {
+      await client.logout();
+    } catch {
+      // Ignore
+    }
+  }
+
+  private async createConnectionWithRetry(
+    connectedAccount: ConnectedAccountIdentifier,
+    retryCount = 0,
+  ): Promise<ImapFlow> {
+    try {
+      return await this.createConnection(connectedAccount);
+    } catch (error) {
+      if (retryCount < ImapClientProvider.MAX_RETRIES) {
+        this.logger.warn(
+          `Connection attempt ${retryCount + 1} failed for ${connectedAccount.handle}, retrying...`,
+        );
+        return this.createConnectionWithRetry(connectedAccount, retryCount + 1);
+      }
+      throw error;
     }
   }
 
@@ -89,11 +137,12 @@ export class ImapClientProvider {
       },
       logger: false,
       tls: {
-        rejectUnauthorized: false,
+        rejectUnauthorized: false, // Potentially unsafe, but often required for IMAP
       },
       connectionTimeout: ImapClientProvider.CONNECTION_TIMEOUT_MS,
       greetingTimeout: ImapClientProvider.GREETING_TIMEOUT_MS,
       responseTimeout: ImapClientProvider.RESPONSE_TIMEOUT_MS,
+      // Default imapflow options usually enable CONDSTORE/QRESYNC if available
     });
 
     try {

--- a/packages/twenty-server/src/modules/messaging/message-import-manager/drivers/imap/services/imap-get-message-list.service.ts
+++ b/packages/twenty-server/src/modules/messaging/message-import-manager/drivers/imap/services/imap-get-message-list.service.ts
@@ -71,7 +71,7 @@ export class ImapGetMessageListService {
       this.errorHandler.handleError(error);
       throw error;
     } finally {
-      await this.imapClientProvider.closeClient(client);
+      await this.imapClientProvider.closeClient(connectedAccount.id);
     }
   }
 
@@ -118,7 +118,7 @@ export class ImapGetMessageListService {
 
       const mailboxState = extractMailboxState(mailbox);
 
-      const { messageUids } = await this.imapSyncService.syncFolder(
+      const { messageUids, isPartial } = await this.imapSyncService.syncFolder(
         client,
         folderPath,
         previousCursor,
@@ -129,6 +129,7 @@ export class ImapGetMessageListService {
         messageUids,
         previousCursor,
         mailboxState,
+        isPartial,
       );
 
       const messageExternalIds = messageUids

--- a/packages/twenty-server/src/modules/messaging/message-import-manager/drivers/imap/services/imap-get-messages.service.ts
+++ b/packages/twenty-server/src/modules/messaging/message-import-manager/drivers/imap/services/imap-get-messages.service.ts
@@ -50,7 +50,7 @@ export class ImapGetMessagesService {
         connectedAccount,
       );
     } finally {
-      await this.imapClientProvider.closeClient(client);
+      await this.imapClientProvider.closeClient(connectedAccount.id);
     }
   }
 

--- a/packages/twenty-server/src/modules/messaging/message-import-manager/drivers/imap/services/imap-message-parser.service.ts
+++ b/packages/twenty-server/src/modules/messaging/message-import-manager/drivers/imap/services/imap-message-parser.service.ts
@@ -1,6 +1,7 @@
 import { Injectable, Logger } from '@nestjs/common';
 
 import { type FetchMessageObject, type ImapFlow } from 'imapflow';
+import { chunk } from 'lodash';
 import PostalMime, { type Email as ParsedEmail } from 'postal-mime';
 
 export type MessageParseResult = {
@@ -17,6 +18,7 @@ export type FolderParseResult = {
 @Injectable()
 export class ImapMessageParserService {
   private readonly logger = new Logger(ImapMessageParserService.name);
+  private readonly BATCH_SIZE = 10;
 
   async parseMessagesFromFolder(
     messageUids: number[],
@@ -35,21 +37,29 @@ export class ImapMessageParserService {
           ? client.mailbox.uidValidity
           : null;
 
-      const uidSet = messageUids.join(',');
       const startTime = Date.now();
-
-      const messages = await client.fetchAll(
-        uidSet,
-        { uid: true, source: true },
-        { uid: true },
-      );
-
-      const fetchedUids = new Set<number>();
       const results: MessageParseResult[] = [];
+      const fetchedUids = new Set<number>();
 
-      for (const message of messages) {
-        fetchedUids.add(message.uid);
-        results.push(await this.parseMessage(message));
+      const batches = chunk(messageUids, this.BATCH_SIZE);
+
+      for (const batch of batches) {
+        const uidSet = batch.join(',');
+
+        this.logger.debug(
+          `Fetching batch of ${batch.length} messages from ${folderPath}`,
+        );
+
+        const messages = await client.fetchAll(
+          uidSet,
+          { uid: true, source: true },
+          { uid: true },
+        );
+
+        for (const message of messages) {
+          fetchedUids.add(message.uid);
+          results.push(await this.parseMessage(message));
+        }
       }
 
       for (const uid of messageUids) {

--- a/packages/twenty-server/src/modules/messaging/message-import-manager/drivers/imap/services/imap-message-parser.service.ts
+++ b/packages/twenty-server/src/modules/messaging/message-import-manager/drivers/imap/services/imap-message-parser.service.ts
@@ -1,7 +1,7 @@
 import { Injectable, Logger } from '@nestjs/common';
 
 import { type FetchMessageObject, type ImapFlow } from 'imapflow';
-import { chunk } from 'lodash';
+import chunk from 'lodash.chunk';
 import PostalMime, { type Email as ParsedEmail } from 'postal-mime';
 
 export type MessageParseResult = {

--- a/packages/twenty-server/src/modules/messaging/message-import-manager/drivers/imap/services/imap-sync.service.spec.ts
+++ b/packages/twenty-server/src/modules/messaging/message-import-manager/drivers/imap/services/imap-sync.service.spec.ts
@@ -1,0 +1,167 @@
+import { Test, type TestingModule } from '@nestjs/testing';
+import { ImapSyncService } from './imap-sync.service';
+import { type ImapFlow } from 'imapflow';
+import { createSyncCursor } from '../utils/create-sync-cursor.util';
+
+describe('ImapSyncService', () => {
+  let service: ImapSyncService;
+
+  const mockImapClient = {
+    capabilities: new Set<string>([]),
+    search: jest.fn(),
+  };
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [ImapSyncService],
+    }).compile();
+
+    service = module.get<ImapSyncService>(ImapSyncService);
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+
+  describe('syncFolder', () => {
+    it('should use UID range when QRESYNC is not available', async () => {
+      const folderPath = 'INBOX';
+      const previousCursor = { highestUid: 100, uidValidity: 12345 };
+      const mailboxState = {
+        maxUid: 500,
+        uidValidity: 12345,
+        highestModSeq: '1000',
+      };
+
+      mockImapClient.search.mockResolvedValue([101, 102, 103]);
+
+      const result = await service.syncFolder(
+        mockImapClient as unknown as ImapFlow,
+        folderPath,
+        previousCursor,
+        mailboxState as any,
+      );
+
+      expect(mockImapClient.search).toHaveBeenCalledWith(
+        { uid: '101:500' },
+        { uid: true },
+      );
+      expect(result.messageUids).toEqual([101, 102, 103]);
+      expect(result.isPartial).toBe(false);
+    });
+
+    it('should chunk the UID range if it exceeds MAX_UID_FETCH_SIZE', async () => {
+      const folderPath = 'INBOX';
+      const previousCursor = { highestUid: 100, uidValidity: 12345 };
+      const mailboxState = {
+        maxUid: 50000,
+        uidValidity: 12345,
+        highestModSeq: '1000',
+      };
+
+      mockImapClient.search.mockResolvedValue([]);
+
+      const result = await service.syncFolder(
+        mockImapClient as unknown as ImapFlow,
+        folderPath,
+        previousCursor,
+        mailboxState as any,
+      );
+
+      expect(mockImapClient.search).toHaveBeenCalledWith(
+        { uid: '101:1100' },
+        { uid: true },
+      );
+      expect(result.isPartial).toBe(true);
+    });
+
+    it('should chunk QRESYNC results if they exceed MAX_UID_FETCH_SIZE', async () => {
+      const folderPath = 'INBOX';
+      const previousCursor = {
+        highestUid: 100,
+        uidValidity: 12345,
+        modSeq: '500',
+      };
+      const mailboxState = {
+        maxUid: 50000,
+        uidValidity: 12345,
+        highestModSeq: '1000',
+      };
+
+      mockImapClient.capabilities.add('QRESYNC');
+
+      const manyUids = Array.from({ length: 1500 }, (_, i) => 101 + i);
+      mockImapClient.search.mockResolvedValue(manyUids);
+
+      const result = await service.syncFolder(
+        mockImapClient as unknown as ImapFlow,
+        folderPath,
+        previousCursor,
+        mailboxState as any,
+      );
+
+      expect(mockImapClient.search).toHaveBeenCalledWith(
+        { modseq: BigInt(501), uid: '101:*' },
+        { uid: true },
+      );
+      expect(result.messageUids.length).toBe(1000);
+      expect(result.isPartial).toBe(true);
+
+      mockImapClient.capabilities.delete('QRESYNC');
+    });
+  });
+
+  describe('createSyncCursor', () => {
+    it('should update modSeq if not partial', () => {
+      const previousCursor = {
+        highestUid: 100,
+        uidValidity: 12345,
+        modSeq: '500',
+      };
+      const mailboxState = {
+        maxUid: 200,
+        uidValidity: 12345,
+        highestModSeq: '1000',
+      };
+      const messageUids = [101, 102];
+
+      const nextCursor = createSyncCursor(
+        messageUids,
+        previousCursor,
+        mailboxState as any,
+        false,
+      );
+
+      expect(nextCursor.modSeq).toBe('1000');
+      expect(nextCursor.highestUid).toBe(102);
+    });
+
+    it('should NOT update modSeq if partial', () => {
+      const previousCursor = {
+        highestUid: 100,
+        uidValidity: 12345,
+        modSeq: '500',
+      };
+      const mailboxState = {
+        maxUid: 50000,
+        uidValidity: 12345,
+        highestModSeq: '1000',
+      };
+      const messageUids = [101, 102]; // Only first 2 of many
+
+      const nextCursor = createSyncCursor(
+        messageUids,
+        previousCursor,
+        mailboxState as any,
+        true,
+      );
+
+      expect(nextCursor.modSeq).toBe('500');
+      expect(nextCursor.highestUid).toBe(102);
+    });
+  });
+});

--- a/packages/twenty-server/src/modules/messaging/message-import-manager/drivers/imap/services/imap-sync.service.ts
+++ b/packages/twenty-server/src/modules/messaging/message-import-manager/drivers/imap/services/imap-sync.service.ts
@@ -12,11 +12,14 @@ import { type ImapSyncCursor } from 'src/modules/messaging/message-import-manage
 
 type SyncResult = {
   messageUids: number[];
+  isPartial: boolean;
 };
 
 @Injectable()
 export class ImapSyncService {
   private readonly logger = new Logger(ImapSyncService.name);
+
+  private static readonly MAX_UID_FETCH_SIZE = 1000;
 
   async syncFolder(
     client: ImapFlow,
@@ -26,14 +29,12 @@ export class ImapSyncService {
   ): Promise<SyncResult> {
     this.validateUidValidity(previousCursor, mailboxState, folderPath);
 
-    const messageUids = await this.fetchNewMessageUids(
+    return await this.fetchNewMessageUids(
       client,
       previousCursor,
       mailboxState,
       folderPath,
     );
-
-    return { messageUids };
   }
 
   private validateUidValidity(
@@ -61,7 +62,7 @@ export class ImapSyncService {
     previousCursor: ImapSyncCursor | null,
     mailboxState: MailboxState,
     folderPath: string,
-  ): Promise<number[]> {
+  ): Promise<SyncResult> {
     const lastSyncedUid = previousCursor?.highestUid ?? 0;
     const { maxUid } = mailboxState;
 
@@ -69,11 +70,13 @@ export class ImapSyncService {
       this.logger.debug(`Using QRESYNC for folder ${folderPath}`);
 
       try {
-        return await this.fetchWithQresync(
+        const result = await this.fetchWithQresync(
           client,
           lastSyncedUid,
           BigInt(previousCursor!.modSeq!),
         );
+
+        return result;
       } catch (error) {
         this.logger.warn(
           `QRESYNC failed for ${folderPath}, falling back to UID range: ${error.message}`,
@@ -90,40 +93,60 @@ export class ImapSyncService {
     client: ImapFlow,
     lastSyncedUid: number,
     highestAvailableUid: number,
-  ): Promise<number[]> {
+  ): Promise<SyncResult> {
     if (lastSyncedUid >= highestAvailableUid) {
-      return [];
+      return { messageUids: [], isPartial: false };
     }
 
-    const uidRange = `${lastSyncedUid + 1}:${highestAvailableUid}`;
+    const nextUid = lastSyncedUid + 1;
+    const endUid = Math.min(
+      nextUid + ImapSyncService.MAX_UID_FETCH_SIZE - 1,
+      highestAvailableUid,
+    );
+
+    const isPartial = endUid < highestAvailableUid;
+    const uidRange = `${nextUid}:${endUid}`;
+
+    this.logger.debug(
+      `Fetching UID range ${uidRange} (max available: ${highestAvailableUid})`,
+    );
+
     const uids = await client.search({ uid: uidRange }, { uid: true });
 
     if (!uids || !Array.isArray(uids)) {
-      return [];
+      return { messageUids: [], isPartial: false };
     }
 
-    return uids;
+    // Cast as number[] because imapflow search with {uid: true} returns numbers
+    return { messageUids: uids as number[], isPartial };
   }
 
   private async fetchWithQresync(
     client: ImapFlow,
     lastSyncedUid: number,
     lastModSeq: bigint,
-  ): Promise<number[]> {
-    const uids = await client.search(
+  ): Promise<SyncResult> {
+    const uids = (await client.search(
       {
         modseq: lastModSeq + BigInt(1),
         uid: `${lastSyncedUid + 1}:*`,
       },
       { uid: true },
-    );
+    )) as number[];
 
     if (!uids || !Array.isArray(uids) || !uids.length) {
-      return [];
+      return { messageUids: [], isPartial: false };
     }
 
-    this.logger.debug(`QRESYNC found ${uids.length} new/modified messages`);
+    const isPartial = uids.length > ImapSyncService.MAX_UID_FETCH_SIZE;
+    const messageUids = isPartial
+      ? uids.slice(0, ImapSyncService.MAX_UID_FETCH_SIZE)
+      : uids;
 
-    return uids;
+    this.logger.debug(
+      `QRESYNC found ${uids.length} new/modified messages${isPartial ? ` (returning first ${ImapSyncService.MAX_UID_FETCH_SIZE})` : ''}`,
+    );
+
+    return { messageUids, isPartial };
   }
 }

--- a/packages/twenty-server/src/modules/messaging/message-import-manager/drivers/imap/utils/create-sync-cursor.util.ts
+++ b/packages/twenty-server/src/modules/messaging/message-import-manager/drivers/imap/utils/create-sync-cursor.util.ts
@@ -5,6 +5,7 @@ export const createSyncCursor = (
   messageUids: number[],
   previousCursor: ImapSyncCursor | null,
   mailboxState: MailboxState,
+  isPartial: boolean,
 ): ImapSyncCursor => {
   const { uidValidity, highestModSeq } = mailboxState;
   const lastSeenUid = previousCursor?.highestUid ?? 0;
@@ -17,9 +18,11 @@ export const createSyncCursor = (
     }
   }
 
+  const modSeq = isPartial ? previousCursor?.modSeq : highestModSeq?.toString();
+
   return {
     highestUid,
     uidValidity,
-    ...(highestModSeq ? { modSeq: highestModSeq.toString() } : {}),
+    ...(modSeq ? { modSeq } : {}),
   };
 };


### PR DESCRIPTION
This PR addresses major IMAP issues by:

1. Implementing batched fetching and parsing to fix high CPU usage (#14520).
2. Adding a 30s responseTimeout to prevent sync hangs (#15842).
3. Chunked syncing with max 1000 messages per turn to handle massive inboxes.
4. Connection reuse and retry logic for improved stability.

Fixes #14520
Fixes #15842
/claim #14520
/claim #15842