### PR TITLE
test(upgrade): assert sequence-runner error structurally instead of snapshot

### DIFF
--- a/packages/twenty-server/test/integration/upgrade/suites/sequence-runner/__snapshots__/failing-sequence-runner.integration-spec.ts.snap
+++ b/packages/twenty-server/test/integration/upgrade/suites/sequence-runner/__snapshots__/failing-sequence-runner.integration-spec.ts.snap
@@ -1,3 +1,0 @@
-// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
-
-exports[`UpgradeSequenceRunnerService — failing sequence (integration) should throw when cursor command is not found in the sequence 1`] = `"Step "RemovedCommand" not found in upgrade sequence. The sequence only covers versions [1.21.0, 1.22.0, 1.23.0, 2.0.0, 2.1.0, 2.2.0]. Please upgrade to 1.21.0 first."`;

--- a/packages/twenty-server/test/integration/upgrade/suites/sequence-runner/failing-sequence-runner.integration-spec.ts
+++ b/packages/twenty-server/test/integration/upgrade/suites/sequence-runner/failing-sequence-runner.integration-spec.ts
@@ -106,7 +106,7 @@ describe('UpgradeSequenceRunnerService — failing sequence (integration)', () =
         sequence,
         options: DEFAULT_OPTIONS,
       }),
-    ).rejects.toThrowErrorMatchingSnapshot();
+    ).rejects.toThrow(/Step "RemovedCommand" not found in upgrade sequence/);
   });
 
   it('should throw when workspace cursors are outside the current slice', async () => {


### PR DESCRIPTION
## Summary

The integration test `should throw when cursor command is not found in the sequence` in `failing-sequence-runner.integration-spec.ts` used `toThrowErrorMatchingSnapshot()`. The captured snapshot included the literal `TWENTY_CROSS_UPGRADE_SUPPORTED_VERSIONS` list from `upgrade-sequence-reader.service.ts`, which grows by one entry on every Twenty release. As a result, the snapshot drifted and broke whenever a new instance command landed (noticed during PR #20181), creating recurring "snapshot needs updating" churn with no real signal value.

This PR replaces the snapshot assertion with a regex match on the structural part of the error message:

```ts
).rejects.toThrow(/Step "RemovedCommand" not found in upgrade sequence/);
```

The regex still catches the same class of regressions (the runner failing to surface a missing-step error) without pinning the version list. The now-empty snap file is removed (it had only this one entry).

## Test plan

- [ ] CI integration tests pass on this branch
- [ ] No remaining references to the deleted snapshot

🤖 Generated with [Claude Code](https://claude.com/claude-code)