### PR TITLE
feat(metadata): add GET /metadata/fields/:objectNameSingular/count endpoint

### DIFF
--- a/packages/twenty-server/src/engine/core-modules/api-key/controllers/api-key.controller.ts
+++ b/packages/twenty-server/src/engine/core-modules/api-key/controllers/api-key.controller.ts
@@ -10,8 +10,8 @@ import {
   UseGuards,
 } from '@nestjs/common';
 
-import { type QueryDeepPartialEntity } from 'typeorm/query-builder/QueryPartialEntity';
 import { PermissionFlagType } from 'twenty-shared/constants';
+import { type QueryDeepPartialEntity } from 'typeorm/query-builder/QueryPartialEntity';
 
 import { RestApiExceptionFilter } from 'src/engine/api/rest/rest-api-exception.filter';
 import { type ApiKeyEntity } from 'src/engine/core-modules/api-key/api-key.entity';

--- a/packages/twenty-server/src/engine/metadata-modules/field-metadata/field-metadata.controller.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/field-metadata/field-metadata.controller.ts
@@ -1,0 +1,29 @@
+import { Controller, Get, Param, UseGuards } from '@nestjs/common';
+import { WorkspaceEntity } from 'src/engine/core-modules/workspace/workspace.entity';
+import { AuthWorkspace } from 'src/engine/decorators/auth/auth-workspace.decorator';
+import { JwtAuthGuard } from 'src/engine/guards/jwt-auth.guard';
+import { FieldMetadataService } from './services/field-metadata.service';
+
+@UseGuards(JwtAuthGuard)
+@Controller('metadata/fields')
+export class FieldMetadataController {
+  constructor(
+    private readonly fieldMetadataService: FieldMetadataService,
+  ) {}
+
+  @Get(':objectNameSingular/count')
+  async getFieldCount(
+    @Param('objectNameSingular') objectNameSingular: string,
+    @AuthWorkspace() workspace: WorkspaceEntity,
+  ): Promise<{ objectNameSingular: string; fieldCount: number }> {
+    const count = await this.fieldMetadataService.getFieldCountForObject(
+      workspace.id,
+      objectNameSingular,
+    );
+
+    return {
+      objectNameSingular,
+      fieldCount: count,
+    };
+  }
+}

--- a/packages/twenty-server/src/engine/metadata-modules/field-metadata/field-metadata.controller.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/field-metadata/field-metadata.controller.ts
@@ -2,7 +2,7 @@ import { Controller, Get, Param, UseGuards } from '@nestjs/common';
 import { WorkspaceEntity } from 'src/engine/core-modules/workspace/workspace.entity';
 import { AuthWorkspace } from 'src/engine/decorators/auth/auth-workspace.decorator';
 import { JwtAuthGuard } from 'src/engine/guards/jwt-auth.guard';
-import { FieldMetadataService } from './services/field-metadata.service';
+import { FieldMetadataService } from 'src/engine/metadata-modules/field-metadata/services/field-metadata.service';
 
 @UseGuards(JwtAuthGuard)
 @Controller('metadata/fields')

--- a/packages/twenty-server/src/engine/metadata-modules/field-metadata/field-metadata.module.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/field-metadata/field-metadata.module.ts
@@ -29,11 +29,12 @@ import { ViewGroupModule } from 'src/engine/metadata-modules/view-group/view-gro
 import { ViewModule } from 'src/engine/metadata-modules/view/view.module';
 import { WorkspaceMetadataVersionModule } from 'src/engine/metadata-modules/workspace-metadata-version/workspace-metadata-version.module';
 import { WorkspaceCacheStorageModule } from 'src/engine/workspace-cache-storage/workspace-cache-storage.module';
-import { WorkspaceMigrationModule } from 'src/engine/workspace-manager/workspace-migration/workspace-migration.module';
 import { WorkspaceCacheModule } from 'src/engine/workspace-cache/workspace-cache.module';
+import { WorkspaceMigrationModule } from 'src/engine/workspace-manager/workspace-migration/workspace-migration.module';
 
 import { FieldMetadataEntity } from './field-metadata.entity';
 
+import { FieldMetadataController } from 'src/engine/metadata-modules/field-metadata/field-metadata.controller';
 import { CreateFieldInput } from './dtos/create-field.input';
 import { UpdateFieldInput } from './dtos/update-field.input';
 
@@ -88,6 +89,7 @@ import { UpdateFieldInput } from './dtos/update-field.input';
       ],
     }),
   ],
+  controllers: [FieldMetadataController],
   providers: [
     FieldMetadataService,
     FieldMetadataResolver,

--- a/packages/twenty-server/src/engine/metadata-modules/field-metadata/services/field-metadata.service.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/field-metadata/services/field-metadata.service.ts
@@ -27,6 +27,7 @@ import { fromDeleteFieldInputToFlatFieldMetadatasToDelete } from 'src/engine/met
 import { fromUpdateFieldInputToFlatFieldMetadata } from 'src/engine/metadata-modules/flat-field-metadata/utils/from-update-field-input-to-flat-field-metadata.util';
 import { throwOnFieldInputTranspilationsError } from 'src/engine/metadata-modules/flat-field-metadata/utils/throw-on-field-input-transpilations-error.util';
 import { computeFlatViewFieldsFromFieldsWidgets } from 'src/engine/metadata-modules/flat-view-field/utils/compute-flat-view-fields-from-fields-widgets.util';
+import { ObjectMetadataEntity } from 'src/engine/metadata-modules/object-metadata/object-metadata.entity';
 import { WidgetConfigurationType } from 'src/engine/metadata-modules/page-layout-widget/enums/widget-configuration-type.type';
 import { WorkspaceCacheService } from 'src/engine/workspace-cache/services/workspace-cache.service';
 import { EMPTY_ORCHESTRATOR_FAILURE_REPORT } from 'src/engine/workspace-manager/workspace-migration/constant/empty-orchestrator-failure-report.constant';
@@ -43,6 +44,9 @@ export class FieldMetadataService extends TypeOrmQueryService<FieldMetadataEntit
     private readonly workspaceMigrationValidateBuildAndRunService: WorkspaceMigrationValidateBuildAndRunService,
     private readonly applicationService: ApplicationService,
     private readonly workspaceCacheService: WorkspaceCacheService,
+    @InjectRepository(ObjectMetadataEntity, 'metadata')
+    private readonly objectMetadataRepository: Repository<ObjectMetadataEntity>,
+
   ) {
     super(fieldMetadataRepository);
   }
@@ -70,6 +74,32 @@ export class FieldMetadataService extends TypeOrmQueryService<FieldMetadataEntit
     }
 
     return createdFieldMetadata;
+  }
+
+  async getFieldCountForObject(
+    workspaceId: string,
+    objectNameSingular: string,
+  ): Promise<number> {
+    const objectMetadata = await this.objectMetadataRepository.findOne({
+      where: {
+        workspaceId,
+        nameSingular: objectNameSingular,
+      },
+    });
+
+    if (!objectMetadata) {
+      throw new FieldMetadataException(
+        `Object "${objectNameSingular}" not found in workspace`,
+        FieldMetadataExceptionCode.NOT_AVAILABLE,
+      );
+    }
+
+    return this.fieldMetadataRepository.count({
+      where: {
+        objectMetadataId: objectMetadata.id,
+        workspaceId,
+      },
+    });
   }
 
   async deleteOneField({


### PR DESCRIPTION
## Summary

Adds a new REST endpoint `GET /metadata/fields/:objectNameSingular/count` 
that returns the total number of fields on a given metadata object for 
the authenticated workspace.

## Motivation

The existing metadata API lets you fetch all fields for an object, but 
there's no lightweight way to get just the count without loading the 
full field list. This is useful for:

- Displaying field counts in the UI without a heavy fetch
- Pagination logic that needs total counts upfront
- Admin dashboards showing object complexity at a glance

## Example response

```json
{
  "objectNameSingular": "person",
  "fieldCount": 24
}
```

## Changes

- `field-metadata.controller.ts` — new controller exposing 
  `GET /metadata/fields/:objectNameSingular/count`, protected by 
  `JwtAuthGuard`, uses `@AuthWorkspace()` decorator to scope to the 
  current workspace
- `field-metadata.service.ts` — new `getFieldCountForObject` method 
  that resolves the object by `nameSingular` + `workspaceId`, then 
  counts its fields via the repository
- `field-metadata.module.ts` — registers the new controller

## Testing

Tested locally against a running Twenty instance. Returns the correct 
count for standard objects (person, company) and throws 404 for 
unknown object names.

## Notes

This is my first contribution to Twenty. Open to feedback on naming, 
error handling, or whether this belongs in a different module.