### PR TITLE
fix: add loading indicator in table views during data fetch

### DIFF
--- a/packages/twenty-front/src/modules/object-record/record-table/components/RecordTable.tsx
+++ b/packages/twenty-front/src/modules/object-record/record-table/components/RecordTable.tsx
@@ -1,7 +1,6 @@
 import { isNonEmptyString } from '@sniptt/guards';
 import { useRef } from 'react';
 import { styled } from '@linaria/react';
-import { keyframes } from '@linaria/core';
 
 import { useObjectPermissionsForObject } from '@/object-record/hooks/useObjectPermissionsForObject';
 import { hasRecordGroupsComponentSelector } from '@/object-record/record-group/states/selectors/hasRecordGroupsComponentSelector';
@@ -21,18 +20,6 @@ import { useAtomComponentStateValue } from '@/ui/utilities/state/jotai/hooks/use
 import isEmpty from 'lodash.isempty';
 import { themeCssVariables } from 'twenty-ui/theme-constants';
 
-const loadingSlide = keyframes`
-  0% {
-    transform: translateX(-100%);
-  }
-  60% {
-    transform: translateX(0%);
-  }
-  100% {
-    transform: translateX(100%);
-  }
-`;
-
 const StyledLoadingBarWrapper = styled.div`
   height: 2px;
   left: 0;
@@ -44,7 +31,7 @@ const StyledLoadingBarWrapper = styled.div`
 `;
 
 const StyledLoadingBar = styled.div`
-  animation: ${loadingSlide} 1.4s ease-in-out infinite;
+  animation: loading-slide 1.4s ease-in-out infinite;
   background: linear-gradient(
     90deg,
     transparent 0%,
@@ -54,6 +41,18 @@ const StyledLoadingBar = styled.div`
   );
   height: 100%;
   width: 60%;
+
+  @keyframes loading-slide {
+    0% {
+      transform: translateX(-100%);
+    }
+    60% {
+      transform: translateX(0%);
+    }
+    100% {
+      transform: translateX(100%);
+    }
+  }
 `;
 
 const StyledTableWrapper = styled.div`

--- a/packages/twenty-front/src/modules/object-record/record-table/components/RecordTable.tsx
+++ b/packages/twenty-front/src/modules/object-record/record-table/components/RecordTable.tsx
@@ -19,6 +19,7 @@ import { useClickOutsideListener } from '@/ui/utilities/pointer-event/hooks/useC
 import { useAtomComponentSelectorValue } from '@/ui/utilities/state/jotai/hooks/useAtomComponentSelectorValue';
 import { useAtomComponentStateValue } from '@/ui/utilities/state/jotai/hooks/useAtomComponentStateValue';
 import isEmpty from 'lodash.isempty';
+import { themeCssVariables } from 'twenty-ui/theme-constants';
 
 const loadingSlide = keyframes`
   0% {
@@ -47,8 +48,8 @@ const StyledLoadingBar = styled.div`
   background: linear-gradient(
     90deg,
     transparent 0%,
-    #4f46e5 40%,
-    #818cf8 60%,
+    ${themeCssVariables.color.blue} 40%,
+    ${themeCssVariables.color.blue3} 60%,
     transparent 100%
   );
   height: 100%;
@@ -56,8 +57,8 @@ const StyledLoadingBar = styled.div`
 `;
 
 const StyledTableWrapper = styled.div`
-  position: relative;
   height: 100%;
+  position: relative;
   width: 100%;
 `;
 

--- a/packages/twenty-front/src/modules/object-record/record-table/components/RecordTable.tsx
+++ b/packages/twenty-front/src/modules/object-record/record-table/components/RecordTable.tsx
@@ -1,5 +1,7 @@
 import { isNonEmptyString } from '@sniptt/guards';
 import { useRef } from 'react';
+import { styled } from '@linaria/react';
+import { keyframes } from '@linaria/core';
 
 import { useObjectPermissionsForObject } from '@/object-record/hooks/useObjectPermissionsForObject';
 import { hasRecordGroupsComponentSelector } from '@/object-record/record-group/states/selectors/hasRecordGroupsComponentSelector';
@@ -17,6 +19,47 @@ import { useClickOutsideListener } from '@/ui/utilities/pointer-event/hooks/useC
 import { useAtomComponentSelectorValue } from '@/ui/utilities/state/jotai/hooks/useAtomComponentSelectorValue';
 import { useAtomComponentStateValue } from '@/ui/utilities/state/jotai/hooks/useAtomComponentStateValue';
 import isEmpty from 'lodash.isempty';
+
+const loadingSlide = keyframes`
+  0% {
+    transform: translateX(-100%);
+  }
+  60% {
+    transform: translateX(0%);
+  }
+  100% {
+    transform: translateX(100%);
+  }
+`;
+
+const StyledLoadingBarWrapper = styled.div`
+  height: 2px;
+  left: 0;
+  overflow: hidden;
+  position: absolute;
+  right: 0;
+  top: 0;
+  z-index: 10;
+`;
+
+const StyledLoadingBar = styled.div`
+  animation: ${loadingSlide} 1.4s ease-in-out infinite;
+  background: linear-gradient(
+    90deg,
+    transparent 0%,
+    #4f46e5 40%,
+    #818cf8 60%,
+    transparent 100%
+  );
+  height: 100%;
+  width: 60%;
+`;
+
+const StyledTableWrapper = styled.div`
+  position: relative;
+  height: 100%;
+  width: 100%;
+`;
 
 export const RecordTable = () => {
   const {
@@ -69,6 +112,8 @@ export const RecordTable = () => {
     toggleClickOutside(true);
   };
 
+  const isRefetching = isRecordTableInitialLoading && recordTableHasRecords;
+
   return (
     <>
       {objectPermissions.canReadObjectRecords && (
@@ -86,13 +131,20 @@ export const RecordTable = () => {
         !hasRecordGroups ? (
         <RecordTableEmpty tableBodyRef={tableBodyRef} />
       ) : (
-        <RecordTableContent
-          tableBodyRef={tableBodyRef}
-          handleDragSelectionStart={handleDragSelectionStart}
-          handleDragSelectionEnd={handleDragSelectionEnd}
-          hasRecordGroups={hasRecordGroups}
-          recordTableId={recordTableId}
-        />
+        <StyledTableWrapper>
+          {isRefetching && (
+            <StyledLoadingBarWrapper>
+              <StyledLoadingBar />
+            </StyledLoadingBarWrapper>
+          )}
+          <RecordTableContent
+            tableBodyRef={tableBodyRef}
+            handleDragSelectionStart={handleDragSelectionStart}
+            handleDragSelectionEnd={handleDragSelectionEnd}
+            hasRecordGroups={hasRecordGroups}
+            recordTableId={recordTableId}
+          />
+        </StyledTableWrapper>
       )}
     </>
   );

--- a/packages/twenty-front/src/modules/object-record/record-table/record-table-body/components/RecordTableBodyLoading.tsx
+++ b/packages/twenty-front/src/modules/object-record/record-table/record-table-body/components/RecordTableBodyLoading.tsx
@@ -25,7 +25,7 @@ export const RecordTableBodyLoading = () => {
 
   return (
     <RecordTableBody>
-      {Array.from({ length: 80 }).map((_, rowIndex) => (
+      {Array.from({ length: 8 }).map((_, rowIndex) => (
         <RecordTableRowContextProvider
           key={rowIndex}
           value={{


### PR DESCRIPTION
Fixes #20211

When navigating to or refreshing a table view, there was no visible 
feedback while data was being fetched — the table appeared blank or 
static.

- **Re-fetch scenario** (records already cached): Added a thin animated 
  indigo progress bar at the top of the table that slides while new data 
  loads — users can still see existing data.
- **Initial load** (no cached records): The existing skeleton row loader 
  was already present, but rendered 80 rows unnecessarily. Reduced to 8 
  rows for better performance.

## Changes
- `RecordTable.tsx` — Added animated loading bar overlay for re-fetch state
- `RecordTableBodyLoading.tsx` — Reduced skeleton rows from 80 → 8

## Testing
- Navigate to any table view → skeleton rows shown on first load
- Navigate away and back → thin loading bar at top during re-fetch
- Empty table state unaffected
- Kanban and Calendar views unaffected
