### PR TITLE
fix(shared): @types/lodash.camelcase for Docker CD

### DIFF
--- a/packages/twenty-shared/package.json
+++ b/packages/twenty-shared/package.json
@@ -24,6 +24,7 @@
     "@types/babel__preset-env": "^7",
     "@types/handlebars": "^4.1.0",
     "@types/jest": "^30.0.0",
+    "@types/lodash.camelcase": "^4.3.7",
     "@types/lodash.escaperegexp": "^4.1.9",
     "@typescript/native-preview": "^7.0.0-dev.20260116.1",
     "babel-plugin-module-resolver": "^5.0.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -58277,6 +58277,7 @@ __metadata:
     "@types/babel__preset-env": "npm:^7"
     "@types/handlebars": "npm:^4.1.0"
     "@types/jest": "npm:^30.0.0"
+    "@types/lodash.camelcase": "npm:^4.3.7"
     "@types/lodash.escaperegexp": "npm:^4.1.9"
     "@typescript/native-preview": "npm:^7.0.0-dev.20260116.1"
     ai: "npm:6.0.97"


### PR DESCRIPTION
Adds `@types/lodash.camelcase` to `twenty-shared`.

**Why:** `lodash.camelcase` has no bundled types. Those types used to come from the root `devDependencies`; after scoped/hoisted deps (#20140), they are no longer guaranteed in the Docker `common-deps` graph, so `twenty-shared:build` (pulled in before server Lingui) fails with TS7016. Declaring the types on the package that imports `lodash.camelcase` fixes CD.