### PR TITLE
fix: surface API failures as error snackbars in UI

### DIFF
--- a/packages/twenty-front/src/modules/workflow/workflow-steps/hooks/useCreateWorkflowVersionEdge.ts
+++ b/packages/twenty-front/src/modules/workflow/workflow-steps/hooks/useCreateWorkflowVersionEdge.ts
@@ -1,5 +1,7 @@
 import { useApolloCoreClient } from '@/object-metadata/hooks/useApolloCoreClient';
+import { useSnackBar } from '@/ui/feedback/snack-bar-manager/hooks/useSnackBar';
 import { useMutation } from '@apollo/client/react';
+import { t } from '@lingui/core/macro';
 import {
   type CreateWorkflowVersionEdgeMutation,
   type CreateWorkflowVersionEdgeMutationVariables,
@@ -12,6 +14,7 @@ export const useCreateWorkflowVersionEdge = () => {
   const apolloCoreClient = useApolloCoreClient();
 
   const { updateWorkflowVersionCache } = useUpdateWorkflowVersionCache();
+  const { enqueueErrorSnackBar } = useSnackBar();
 
   const [mutate] = useMutation<
     CreateWorkflowVersionEdgeMutation,
@@ -21,7 +24,15 @@ export const useCreateWorkflowVersionEdge = () => {
   const createWorkflowVersionEdge = async (
     input: CreateWorkflowVersionEdgeInput,
   ) => {
-    const result = await mutate({ variables: { input } });
+    const result = await mutate({
+      variables: { input },
+      onError: (error) => {
+        enqueueErrorSnackBar({
+          apolloError: error,
+          message: t`Failed to create workflow edge`,
+        });
+      },
+    });
 
     const workflowVersionStepChanges = result?.data?.createWorkflowVersionEdge;
 

--- a/packages/twenty-front/src/modules/workflow/workflow-steps/hooks/useCreateWorkflowVersionStep.ts
+++ b/packages/twenty-front/src/modules/workflow/workflow-steps/hooks/useCreateWorkflowVersionStep.ts
@@ -1,6 +1,8 @@
 import { useApolloCoreClient } from '@/object-metadata/hooks/useApolloCoreClient';
 import { CREATE_WORKFLOW_VERSION_STEP } from '@/workflow/graphql/mutations/createWorkflowVersionStep';
+import { useSnackBar } from '@/ui/feedback/snack-bar-manager/hooks/useSnackBar';
 import { useMutation } from '@apollo/client/react';
+import { t } from '@lingui/core/macro';
 import {
   type CreateWorkflowVersionStepInput,
   type CreateWorkflowVersionStepMutation,
@@ -17,6 +19,7 @@ export const useCreateWorkflowVersionStep = () => {
   const { updateWorkflowVersionCache } = useUpdateWorkflowVersionCache();
 
   const setFlow = useSetAtomComponentState(flowComponentState);
+  const { enqueueErrorSnackBar } = useSnackBar();
 
   const [mutate] = useMutation<
     CreateWorkflowVersionStepMutation,
@@ -30,6 +33,12 @@ export const useCreateWorkflowVersionStep = () => {
   ) => {
     const result = await mutate({
       variables: { input },
+      onError: (error) => {
+        enqueueErrorSnackBar({
+          apolloError: error,
+          message: t`Failed to create workflow step`,
+        });
+      },
     });
 
     const workflowVersionStepChanges = result?.data?.createWorkflowVersionStep;

--- a/packages/twenty-front/src/modules/workflow/workflow-steps/hooks/useDeleteWorkflowVersionStep.ts
+++ b/packages/twenty-front/src/modules/workflow/workflow-steps/hooks/useDeleteWorkflowVersionStep.ts
@@ -3,7 +3,9 @@ import { CoreObjectNameSingular } from 'twenty-shared/types';
 import { useFindOneRecordQuery } from '@/object-record/hooks/useFindOneRecordQuery';
 import { DELETE_WORKFLOW_VERSION_STEP } from '@/workflow/graphql/mutations/deleteWorkflowVersionStep';
 import { useUpdateWorkflowVersionCache } from '@/workflow/workflow-steps/hooks/useUpdateWorkflowVersionCache';
+import { useSnackBar } from '@/ui/feedback/snack-bar-manager/hooks/useSnackBar';
 import { useMutation } from '@apollo/client/react';
+import { t } from '@lingui/core/macro';
 import {
   type DeleteWorkflowVersionStepInput,
   type DeleteWorkflowVersionStepMutation,
@@ -14,6 +16,7 @@ export const useDeleteWorkflowVersionStep = () => {
   const apolloCoreClient = useApolloCoreClient();
 
   const { updateWorkflowVersionCache } = useUpdateWorkflowVersionCache();
+  const { enqueueErrorSnackBar } = useSnackBar();
 
   const { findOneRecordQuery: findOneWorkflowVersionQuery } =
     useFindOneRecordQuery({
@@ -39,6 +42,12 @@ export const useDeleteWorkflowVersionStep = () => {
           variables: { objectRecordId: input.workflowVersionId },
         },
       ],
+      onError: (error) => {
+        enqueueErrorSnackBar({
+          apolloError: error,
+          message: t`Failed to delete workflow step`,
+        });
+      },
     });
 
     const workflowVersionStepChanges = result?.data?.deleteWorkflowVersionStep;

--- a/packages/twenty-front/src/modules/workflow/workflow-steps/hooks/useDuplicateWorkflowVersionStep.ts
+++ b/packages/twenty-front/src/modules/workflow/workflow-steps/hooks/useDuplicateWorkflowVersionStep.ts
@@ -3,7 +3,9 @@ import { useSetAtomComponentState } from '@/ui/utilities/state/jotai/hooks/useSe
 import { DUPLICATE_WORKFLOW_VERSION_STEP } from '@/workflow/graphql/mutations/duplicateWorkflowVersionStep';
 import { flowComponentState } from '@/workflow/states/flowComponentState';
 import { useUpdateWorkflowVersionCache } from '@/workflow/workflow-steps/hooks/useUpdateWorkflowVersionCache';
+import { useSnackBar } from '@/ui/feedback/snack-bar-manager/hooks/useSnackBar';
 import { useMutation } from '@apollo/client/react';
+import { t } from '@lingui/core/macro';
 import { isDefined } from 'twenty-shared/utils';
 import {
   type DuplicateWorkflowVersionStepInput,
@@ -17,6 +19,7 @@ export const useDuplicateWorkflowVersionStep = () => {
   const { updateWorkflowVersionCache } = useUpdateWorkflowVersionCache();
 
   const setFlow = useSetAtomComponentState(flowComponentState);
+  const { enqueueErrorSnackBar } = useSnackBar();
 
   const [mutate] = useMutation<
     DuplicateWorkflowVersionStepMutation,
@@ -30,6 +33,12 @@ export const useDuplicateWorkflowVersionStep = () => {
   ) => {
     const result = await mutate({
       variables: { input },
+      onError: (error) => {
+        enqueueErrorSnackBar({
+          apolloError: error,
+          message: t`Failed to duplicate workflow step`,
+        });
+      },
     });
 
     const workflowVersionStepChanges =

--- a/packages/twenty-front/src/modules/workflow/workflow-steps/hooks/useUpdateWorkflowRunStep.ts
+++ b/packages/twenty-front/src/modules/workflow/workflow-steps/hooks/useUpdateWorkflowRunStep.ts
@@ -7,7 +7,9 @@ import { updateRecordFromCache } from '@/object-record/cache/utils/updateRecordF
 import { useObjectPermissions } from '@/object-record/hooks/useObjectPermissions';
 import { UPDATE_WORKFLOW_RUN_STEP } from '@/workflow/graphql/mutations/updateWorkflowRunStep';
 import { type WorkflowStep, type WorkflowRun } from '@/workflow/types/Workflow';
+import { useSnackBar } from '@/ui/feedback/snack-bar-manager/hooks/useSnackBar';
 import { useMutation } from '@apollo/client/react';
+import { t } from '@lingui/core/macro';
 import { isDefined } from 'twenty-shared/utils';
 import {
   type UpdateWorkflowRunStepInput,
@@ -32,11 +34,18 @@ export const useUpdateWorkflowRunStep = () => {
   const getRecordFromCache = useGetRecordFromCache({
     objectNameSingular: CoreObjectNameSingular.WorkflowRun,
   });
+  const { enqueueErrorSnackBar } = useSnackBar();
 
   const updateWorkflowRunStep = async (input: UpdateWorkflowRunStepInput) => {
     const result = await mutate({
       variables: {
         input: { workflowRunId: input.workflowRunId, step: input.step },
+      },
+      onError: (error) => {
+        enqueueErrorSnackBar({
+          apolloError: error,
+          message: t`Failed to update workflow run step`,
+        });
       },
     });
     const updatedStep = result?.data?.updateWorkflowRunStep;

--- a/packages/twenty-front/src/modules/workflow/workflow-steps/hooks/useUpdateWorkflowVersionStep.ts
+++ b/packages/twenty-front/src/modules/workflow/workflow-steps/hooks/useUpdateWorkflowVersionStep.ts
@@ -10,7 +10,9 @@ import {
   type WorkflowVersion,
   type WorkflowStep,
 } from '@/workflow/types/Workflow';
+import { useSnackBar } from '@/ui/feedback/snack-bar-manager/hooks/useSnackBar';
 import { useMutation } from '@apollo/client/react';
+import { t } from '@lingui/core/macro';
 import { isDefined } from 'twenty-shared/utils';
 import {
   type UpdateWorkflowVersionStepInput,
@@ -22,6 +24,7 @@ export const useUpdateWorkflowVersionStep = () => {
   const apolloCoreClient = useApolloCoreClient();
   const { objectMetadataItems } = useObjectMetadataItems();
   const { objectPermissionsByObjectMetadataId } = useObjectPermissions();
+  const { enqueueErrorSnackBar } = useSnackBar();
 
   const { objectMetadataItem } = useObjectMetadataItem({
     objectNameSingular: CoreObjectNameSingular.WorkflowVersion,
@@ -39,7 +42,15 @@ export const useUpdateWorkflowVersionStep = () => {
   const updateWorkflowVersionStep = async (
     input: UpdateWorkflowVersionStepInput,
   ) => {
-    const result = await mutate({ variables: { input } });
+    const result = await mutate({
+      variables: { input },
+      onError: (error) => {
+        enqueueErrorSnackBar({
+          apolloError: error,
+          message: t`Failed to update workflow step`,
+        });
+      },
+    });
     const updatedStep = result?.data?.updateWorkflowVersionStep;
     if (!isDefined(updatedStep)) {
       return;

--- a/packages/twenty-front/src/modules/workspace-invitation/hooks/useCreateWorkspaceInvitation.ts
+++ b/packages/twenty-front/src/modules/workspace-invitation/hooks/useCreateWorkspaceInvitation.ts
@@ -1,15 +1,18 @@
 import { useMutation } from '@apollo/client/react';
+import { t } from '@lingui/core/macro';
 import {
   type SendInvitationsMutationVariables,
   SendInvitationsDocument,
 } from '~/generated-metadata/graphql';
 import { workspaceInvitationsState } from '@/workspace-invitation/states/workspaceInvitationsStates';
 import { useSetAtomState } from '@/ui/utilities/state/jotai/hooks/useSetAtomState';
+import { useSnackBar } from '@/ui/feedback/snack-bar-manager/hooks/useSnackBar';
 
 export const useCreateWorkspaceInvitation = () => {
   const [sendInvitationsMutation] = useMutation(SendInvitationsDocument);
 
   const setWorkspaceInvitations = useSetAtomState(workspaceInvitationsState);
+  const { enqueueErrorSnackBar } = useSnackBar();
 
   const sendInvitation = async (
     variables: SendInvitationsMutationVariables,
@@ -21,6 +24,12 @@ export const useCreateWorkspaceInvitation = () => {
           ...workspaceInvitations,
           ...data.sendInvitations.result,
         ]);
+      },
+      onError: (error) => {
+        enqueueErrorSnackBar({
+          apolloError: error,
+          message: t`Failed to send invitation`,
+        });
       },
     });
   };

--- a/packages/twenty-front/src/modules/workspace-invitation/hooks/useDeleteWorkspaceInvitation.ts
+++ b/packages/twenty-front/src/modules/workspace-invitation/hooks/useDeleteWorkspaceInvitation.ts
@@ -1,10 +1,12 @@
 import { useMutation } from '@apollo/client/react';
+import { t } from '@lingui/core/macro';
 import {
   type DeleteWorkspaceInvitationMutationVariables,
   DeleteWorkspaceInvitationDocument,
 } from '~/generated-metadata/graphql';
 import { workspaceInvitationsState } from '@/workspace-invitation/states/workspaceInvitationsStates';
 import { useSetAtomState } from '@/ui/utilities/state/jotai/hooks/useSetAtomState';
+import { useSnackBar } from '@/ui/feedback/snack-bar-manager/hooks/useSnackBar';
 
 export const useDeleteWorkspaceInvitation = () => {
   const [deleteWorkspaceInvitationMutation] = useMutation(
@@ -12,6 +14,7 @@ export const useDeleteWorkspaceInvitation = () => {
   );
 
   const setWorkspaceInvitations = useSetAtomState(workspaceInvitationsState);
+  const { enqueueErrorSnackBar } = useSnackBar();
 
   const deleteWorkspaceInvitation = async ({
     appTokenId,
@@ -26,6 +29,12 @@ export const useDeleteWorkspaceInvitation = () => {
             (workspaceInvitation) => workspaceInvitation.id !== appTokenId,
           ),
         );
+      },
+      onError: (error) => {
+        enqueueErrorSnackBar({
+          apolloError: error,
+          message: t`Failed to delete invitation`,
+        });
       },
     });
   };

--- a/packages/twenty-front/src/modules/workspace-invitation/hooks/useResendWorkspaceInvitation.ts
+++ b/packages/twenty-front/src/modules/workspace-invitation/hooks/useResendWorkspaceInvitation.ts
@@ -1,10 +1,12 @@
 import { useMutation } from '@apollo/client/react';
+import { t } from '@lingui/core/macro';
 import {
   type ResendWorkspaceInvitationMutationVariables,
   ResendWorkspaceInvitationDocument,
 } from '~/generated-metadata/graphql';
 import { workspaceInvitationsState } from '@/workspace-invitation/states/workspaceInvitationsStates';
 import { useSetAtomState } from '@/ui/utilities/state/jotai/hooks/useSetAtomState';
+import { useSnackBar } from '@/ui/feedback/snack-bar-manager/hooks/useSnackBar';
 
 export const useResendWorkspaceInvitation = () => {
   const [resendWorkspaceInvitationMutation] = useMutation(
@@ -12,6 +14,7 @@ export const useResendWorkspaceInvitation = () => {
   );
 
   const setWorkspaceInvitations = useSetAtomState(workspaceInvitationsState);
+  const { enqueueErrorSnackBar } = useSnackBar();
 
   const resendInvitation = async ({
     appTokenId,
@@ -27,6 +30,12 @@ export const useResendWorkspaceInvitation = () => {
             (workspaceInvitation) => workspaceInvitation.id !== appTokenId,
           ),
         ]);
+      },
+      onError: (error) => {
+        enqueueErrorSnackBar({
+          apolloError: error,
+          message: t`Failed to resend invitation`,
+        });
       },
     });
   };


### PR DESCRIPTION
Add onError callbacks with enqueueErrorSnackBar to mutations in workspace invitation hooks (send, delete, resend) and workflow version step hooks (create, update, delete, edge, duplicate, run step) so that API failures are clearly surfaced to users instead of failing silently.

Closes #20212