### PR TITLE
fix: show empty cell instead of 'Not shared' for soft-deleted related records

### DIFF
--- a/packages/twenty-front/src/modules/object-record/record-field/ui/meta-types/display/components/RelationFromManyFieldDisplay.tsx
+++ b/packages/twenty-front/src/modules/object-record/record-field/ui/meta-types/display/components/RelationFromManyFieldDisplay.tsx
@@ -4,16 +4,15 @@ import { useActivityTargetObjectRecords } from '@/activities/hooks/useActivityTa
 import { type NoteTarget } from '@/activities/types/NoteTarget';
 import { type TaskTarget } from '@/activities/types/TaskTarget';
 import { useObjectMetadataItems } from '@/object-metadata/hooks/useObjectMetadataItems';
-import { CoreObjectNameSingular } from 'twenty-shared/types';
 import { RecordChip } from '@/object-record/components/RecordChip';
 import { isActivityTargetField } from '@/object-record/record-field-list/utils/categorizeRelationFields';
 import { FieldContext } from '@/object-record/record-field/ui/contexts/FieldContext';
 import { useFieldFocus } from '@/object-record/record-field/ui/hooks/useFieldFocus';
 import { useRelationFromManyFieldDisplay } from '@/object-record/record-field/ui/meta-types/hooks/useRelationFromManyFieldDisplay';
-import { ForbiddenFieldDisplay } from '@/object-record/record-field/ui/meta-types/display/components/ForbiddenFieldDisplay';
 import { extractTargetRecordsFromJunction } from '@/object-record/record-field/ui/utils/junction/extractTargetRecordsFromJunction';
 import { getJunctionConfig } from '@/object-record/record-field/ui/utils/junction/getJunctionConfig';
 import { hasJunctionConfig } from '@/object-record/record-field/ui/utils/junction/hasJunctionConfig';
+import { CoreObjectNameSingular } from 'twenty-shared/types';
 
 import { ExpandableList } from '@/ui/layout/expandable-list/components/ExpandableList';
 import { styled } from '@linaria/react';
@@ -146,8 +145,11 @@ export const RelationFromManyFieldDisplay = () => {
       })
       .filter(isDefined);
 
+    // Return null instead of ForbiddenFieldDisplay when we have junction records but can't extract target records
+    // This handles the case where related records are soft deleted (junction records exist but target records are not available)
+    // Previously showed "Not shared" which was misleading for soft-deleted records
     if (fieldValue.some(isDefined) && targetRecordsWithMetadata.length === 0) {
-      return <ForbiddenFieldDisplay />;
+      return null;
     }
 
     return (

--- a/packages/twenty-front/src/modules/object-record/record-field/ui/meta-types/display/components/RelationToOneFieldDisplay.tsx
+++ b/packages/twenty-front/src/modules/object-record/record-field/ui/meta-types/display/components/RelationToOneFieldDisplay.tsx
@@ -1,9 +1,8 @@
-import { CoreObjectNameSingular } from 'twenty-shared/types';
 import { RecordChip } from '@/object-record/components/RecordChip';
 import { FieldContext } from '@/object-record/record-field/ui/contexts/FieldContext';
-import { ForbiddenFieldDisplay } from '@/object-record/record-field/ui/meta-types/display/components/ForbiddenFieldDisplay';
 import { useRelationToOneFieldDisplay } from '@/object-record/record-field/ui/meta-types/hooks/useRelationToOneFieldDisplay';
 import { useContext } from 'react';
+import { CoreObjectNameSingular } from 'twenty-shared/types';
 import { isDefined } from 'twenty-shared/utils';
 
 export const RelationToOneFieldDisplay = () => {
@@ -16,8 +15,11 @@ export const RelationToOneFieldDisplay = () => {
 
   const { disableChipClick, triggerEvent } = useContext(FieldContext);
 
+  // Return null instead of ForbiddenFieldDisplay when we have a foreign key but no record data
+  // This handles the case where a related record is soft deleted (foreign key exists but record is not available)
+  // Previously showed "Not shared" which was misleading for soft-deleted records
   if (!isDefined(fieldValue) && isDefined(foreignKeyFieldValue)) {
-    return <ForbiddenFieldDisplay />;
+    return null;
   }
 
   if (


### PR DESCRIPTION

## Summary

Close#20076

### Problem
When a related record is soft deleted, cells were showing "Not shared" (with lock icon) which is misleading. "Not shared" implies a permission issue, not a deleted record.

### Solution
Changed `RelationToOneFieldDisplay` and `RelationFromManyFieldDisplay` to return `null` instead of `<ForbiddenFieldDisplay />` when:
1. We have a foreign key but no record data (`RelationToOneFieldDisplay`)
2. We have junction records but can't extract target records (`RelationFromManyFieldDisplay`)

This shows empty cells instead of "Not shared" for soft-deleted related records.

### Changes
- `packages/twenty-front/src/modules/object-record/record-field/ui/meta-types/display/components/RelationToOneFieldDisplay.tsx`
- `packages/twenty-front/src/modules/object-record/record-field/ui/meta-types/display/components/RelationFromManyFieldDisplay.tsx`

### Testing
- Manual testing: Create a relation, link records, soft delete related record, verify cell shows empty instead of "Not shared"
- No existing tests broken (no tests were testing this specific behavior)
