### PR TITLE
fix: distinguish soft-deleted relations from RLS-restricted ones

### DIFF
--- a/packages/twenty-front/src/modules/object-record/record-field/ui/meta-types/display/components/RelationFromManyFieldDisplay.tsx
+++ b/packages/twenty-front/src/modules/object-record/record-field/ui/meta-types/display/components/RelationFromManyFieldDisplay.tsx
@@ -3,9 +3,11 @@ import { useContext } from 'react';
 import { useActivityTargetObjectRecords } from '@/activities/hooks/useActivityTargetObjectRecords';
 import { type NoteTarget } from '@/activities/types/NoteTarget';
 import { type TaskTarget } from '@/activities/types/TaskTarget';
+import { getObjectPermissionsForObject } from '@/object-metadata/utils/getObjectPermissionsForObject';
 import { useObjectMetadataItems } from '@/object-metadata/hooks/useObjectMetadataItems';
 import { CoreObjectNameSingular } from 'twenty-shared/types';
 import { RecordChip } from '@/object-record/components/RecordChip';
+import { useObjectPermissions } from '@/object-record/hooks/useObjectPermissions';
 import { isActivityTargetField } from '@/object-record/record-field-list/utils/categorizeRelationFields';
 import { FieldContext } from '@/object-record/record-field/ui/contexts/FieldContext';
 import { useFieldFocus } from '@/object-record/record-field/ui/hooks/useFieldFocus';
@@ -13,6 +15,7 @@ import { useRelationFromManyFieldDisplay } from '@/object-record/record-field/ui
 import { ForbiddenFieldDisplay } from '@/object-record/record-field/ui/meta-types/display/components/ForbiddenFieldDisplay';
 import { extractTargetRecordsFromJunction } from '@/object-record/record-field/ui/utils/junction/extractTargetRecordsFromJunction';
 import { getJunctionConfig } from '@/object-record/record-field/ui/utils/junction/getJunctionConfig';
+import { getTargetObjectMetadataIdsFromField } from '@/object-record/record-field/ui/utils/junction/getTargetObjectMetadataIdsFromField';
 import { hasJunctionConfig } from '@/object-record/record-field/ui/utils/junction/hasJunctionConfig';
 
 import { ExpandableList } from '@/ui/layout/expandable-list/components/ExpandableList';
@@ -37,6 +40,7 @@ export const RelationFromManyFieldDisplay = () => {
   const { isFocused } = useFieldFocus();
   const { disableChipClick, triggerEvent } = useContext(FieldContext);
   const { objectMetadataItems } = useObjectMetadataItems();
+  const { objectPermissionsByObjectMetadataId } = useObjectPermissions();
 
   const { fieldName, objectMetadataNameSingular } = fieldDefinition.metadata;
 
@@ -147,7 +151,23 @@ export const RelationFromManyFieldDisplay = () => {
       .filter(isDefined);
 
     if (fieldValue.some(isDefined) && targetRecordsWithMetadata.length === 0) {
-      return <ForbiddenFieldDisplay />;
+      const targetObjectMetadataIds = junctionConfig.targetFields.flatMap(
+        getTargetObjectMetadataIdsFromField,
+      );
+
+      const hasRowLevelRestrictions = targetObjectMetadataIds.some(
+        (targetId) =>
+          getObjectPermissionsForObject(
+            objectPermissionsByObjectMetadataId,
+            targetId,
+          ).rowLevelPermissionPredicates.length > 0,
+      );
+
+      if (hasRowLevelRestrictions) {
+        return <ForbiddenFieldDisplay />;
+      }
+
+      return null;
     }
 
     return (

--- a/packages/twenty-front/src/modules/object-record/record-field/ui/meta-types/display/components/RelationToOneFieldDisplay.tsx
+++ b/packages/twenty-front/src/modules/object-record/record-field/ui/meta-types/display/components/RelationToOneFieldDisplay.tsx
@@ -1,5 +1,6 @@
 import { CoreObjectNameSingular } from 'twenty-shared/types';
 import { RecordChip } from '@/object-record/components/RecordChip';
+import { useObjectPermissionsForObject } from '@/object-record/hooks/useObjectPermissionsForObject';
 import { FieldContext } from '@/object-record/record-field/ui/contexts/FieldContext';
 import { ForbiddenFieldDisplay } from '@/object-record/record-field/ui/meta-types/display/components/ForbiddenFieldDisplay';
 import { useRelationToOneFieldDisplay } from '@/object-record/record-field/ui/meta-types/hooks/useRelationToOneFieldDisplay';
@@ -16,8 +17,19 @@ export const RelationToOneFieldDisplay = () => {
 
   const { disableChipClick, triggerEvent } = useContext(FieldContext);
 
+  const targetObjectPermissions = useObjectPermissionsForObject(
+    fieldDefinition.metadata.relationObjectMetadataId,
+  );
+
   if (!isDefined(fieldValue) && isDefined(foreignKeyFieldValue)) {
-    return <ForbiddenFieldDisplay />;
+    const hasRowLevelRestrictions =
+      targetObjectPermissions.rowLevelPermissionPredicates.length > 0;
+
+    if (hasRowLevelRestrictions) {
+      return <ForbiddenFieldDisplay />;
+    }
+
+    return null;
   }
 
   if (


### PR DESCRIPTION
## Summary

Fixes #20076

When a relation foreign key exists but the target record can't be loaded, the UI previously always showed "Not shared" (`ForbiddenFieldDisplay`). This was misleading because it couldn't distinguish between:
- **Soft-deleted records** (the target was deleted, FK is stale) → should show empty
- **RLS-restricted records** (the target exists but the user lacks row-level access) → should show "Not shared"

**Approach:** The frontend already knows whether row-level permission predicates are configured on each object (via `ObjectPermissions.rowLevelPermissionPredicates`). When the relation display encounters a non-null FK with a missing record:
- If the target object has **no RLS predicates** → the record must be soft-deleted → render empty
- If the target object **has RLS predicates** → the record may be access-restricted → render `ForbiddenFieldDisplay`

This is a minimal, frontend-only fix (2 files changed) with no backend changes needed.

## Changes
- `RelationToOneFieldDisplay.tsx` — uses `useObjectPermissionsForObject` to check target object's RLS predicates
- `RelationFromManyFieldDisplay.tsx` — same logic for junction relations using `getObjectPermissionsForObject`

## Test plan
- [ ] Soft-delete a company, verify that relation fields pointing to it show empty (not "Not shared")
- [ ] Configure RLS predicates on an object, verify that restricted records still show "Not shared"
- [ ] Verify no regression for normal relation display (non-deleted, accessible records)
- [ ] Verify object-level permission denial still shows "Not shared" at the `FieldDisplay` level (unchanged behavior)


Made with [Cursor](https://cursor.com)