### PR TITLE
feat: expose upgrade status as Prometheus gauge metrics

### DIFF
--- a/packages/twenty-server/src/engine/core-modules/upgrade/upgrade-gauge.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/upgrade/upgrade-gauge.service.ts
@@ -1,0 +1,98 @@
+import { Injectable, Logger, OnModuleInit } from '@nestjs/common';
+
+import { UpgradeHealthEnum } from 'twenty-shared/types';
+
+import { MetricsService } from 'src/engine/core-modules/metrics/metrics.service';
+import { UpgradeStatusService } from 'src/engine/core-modules/upgrade/services/upgrade-status.service';
+
+const HEALTH_TO_GAUGE_VALUE: Record<UpgradeHealthEnum, number> = {
+  [UpgradeHealthEnum.UP_TO_DATE]: 1,
+  [UpgradeHealthEnum.BEHIND]: 0,
+  [UpgradeHealthEnum.FAILED]: -1,
+};
+
+@Injectable()
+export class UpgradeGaugeService implements OnModuleInit {
+  private readonly logger = new Logger(UpgradeGaugeService.name);
+
+  constructor(
+    private readonly metricsService: MetricsService,
+    private readonly upgradeStatusService: UpgradeStatusService,
+  ) {}
+
+  onModuleInit() {
+    this.metricsService.createObservableGauge({
+      metricName: 'twenty_upgrade_instance_health',
+      options: {
+        description:
+          'Instance upgrade health (1 = up-to-date, 0 = behind, -1 = failed)',
+      },
+      callback: async () => {
+        return this.getInstanceHealthGauge();
+      },
+      cacheValue: true,
+    });
+
+    this.metricsService.createObservableGauge({
+      metricName: 'twenty_upgrade_workspaces_behind_total',
+      options: {
+        description: 'Number of workspaces behind on upgrade commands',
+      },
+      callback: async () => {
+        return this.getWorkspacesBehindCount();
+      },
+      cacheValue: true,
+    });
+
+    this.metricsService.createObservableGauge({
+      metricName: 'twenty_upgrade_workspaces_failed_total',
+      options: {
+        description:
+          'Number of workspaces with a failed upgrade command',
+      },
+      callback: async () => {
+        return this.getWorkspacesFailedCount();
+      },
+      cacheValue: true,
+    });
+  }
+
+  private async getInstanceHealthGauge(): Promise<number> {
+    try {
+      const status =
+        await this.upgradeStatusService.getInstanceAndAllWorkspacesStatus();
+
+      return HEALTH_TO_GAUGE_VALUE[status.instanceUpgradeStatus.health] ?? 0;
+    } catch (error) {
+      this.logger.error('Failed to get instance upgrade health', error);
+
+      return 0;
+    }
+  }
+
+  private async getWorkspacesBehindCount(): Promise<number> {
+    try {
+      const status =
+        await this.upgradeStatusService.getInstanceAndAllWorkspacesStatus();
+
+      return status.workspacesBehind.length;
+    } catch (error) {
+      this.logger.error('Failed to count workspaces behind', error);
+
+      return 0;
+    }
+  }
+
+  private async getWorkspacesFailedCount(): Promise<number> {
+    try {
+      const status =
+        await this.upgradeStatusService.getInstanceAndAllWorkspacesStatus();
+
+      return status.workspacesFailed.length;
+    } catch (error) {
+      this.logger.error('Failed to count workspaces failed', error);
+
+      return 0;
+    }
+  }
+}

--- a/packages/twenty-server/src/engine/core-modules/upgrade/upgrade-gauge.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/upgrade/upgrade-gauge.service.ts
@@ -47,8 +47,7 @@ export class UpgradeGaugeService implements OnModuleInit {
     this.metricsService.createObservableGauge({
       metricName: 'twenty_upgrade_workspaces_failed_total',
       options: {
-        description:
-          'Number of workspaces with a failed upgrade command',
+        description: 'Number of workspaces with a failed upgrade command',
       },
       callback: async () => {
         return this.getWorkspacesFailedCount();

--- a/packages/twenty-server/src/engine/core-modules/upgrade/upgrade-gauge.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/upgrade/upgrade-gauge.service.ts
@@ -15,15 +15,16 @@ const HEALTH_TO_GAUGE_VALUE: Record<UpgradeHealthEnum, number> = {
 };
 
 const HEALTH_UNKNOWN = -2;
-const SNAPSHOT_TTL_MS = 60_000;
+const UPGRADE_STATUS_TTL_MS = 60_000;
 
 @Injectable()
 export class UpgradeGaugeService implements OnModuleInit {
   private readonly logger = new Logger(UpgradeGaugeService.name);
 
-  private cachedSnapshot: InstanceAndAllWorkspacesUpgradeStatus | null = null;
-  private cachedSnapshotExpiresAt = 0;
-  private inflightPromise: Promise<InstanceAndAllWorkspacesUpgradeStatus> | null =
+  private cachedUpgradeStatus: InstanceAndAllWorkspacesUpgradeStatus | null =
+    null;
+  private cachedUpgradeStatusExpiresAt = 0;
+  private inflightUpgradeStatusPromise: Promise<InstanceAndAllWorkspacesUpgradeStatus> | null =
     null;
 
   constructor(
@@ -39,14 +40,14 @@ export class UpgradeGaugeService implements OnModuleInit {
           'Instance upgrade health (1 = up-to-date, 0 = behind, -1 = failed, -2 = unknown)',
       },
       callback: async () => {
-        const snapshot = await this.getSnapshot();
+        const upgradeStatus = await this.getCachedUpgradeStatus();
 
-        if (!snapshot) {
+        if (!upgradeStatus) {
           return HEALTH_UNKNOWN;
         }
 
         return (
-          HEALTH_TO_GAUGE_VALUE[snapshot.instanceUpgradeStatus.health] ??
+          HEALTH_TO_GAUGE_VALUE[upgradeStatus.instanceUpgradeStatus.health] ??
           HEALTH_UNKNOWN
         );
       },
@@ -59,9 +60,9 @@ export class UpgradeGaugeService implements OnModuleInit {
         description: 'Number of workspaces behind on upgrade commands',
       },
       callback: async () => {
-        const snapshot = await this.getSnapshot();
+        const upgradeStatus = await this.getCachedUpgradeStatus();
 
-        return snapshot?.workspacesBehind.length ?? 0;
+        return upgradeStatus?.workspacesBehind.length ?? 0;
       },
       cacheValue: true,
     });
@@ -72,39 +73,40 @@ export class UpgradeGaugeService implements OnModuleInit {
         description: 'Number of workspaces with a failed upgrade command',
       },
       callback: async () => {
-        const snapshot = await this.getSnapshot();
+        const upgradeStatus = await this.getCachedUpgradeStatus();
 
-        return snapshot?.workspacesFailed.length ?? 0;
+        return upgradeStatus?.workspacesFailed.length ?? 0;
       },
       cacheValue: true,
     });
   }
 
-  // Deduplicates concurrent calls and memoizes for SNAPSHOT_TTL_MS
-  // so all 3 gauges share a single fetch per scrape cycle.
-  private async getSnapshot(): Promise<InstanceAndAllWorkspacesUpgradeStatus | null> {
-    if (this.cachedSnapshot && Date.now() < this.cachedSnapshotExpiresAt) {
-      return this.cachedSnapshot;
+  private async getCachedUpgradeStatus(): Promise<InstanceAndAllWorkspacesUpgradeStatus | null> {
+    if (
+      this.cachedUpgradeStatus &&
+      Date.now() < this.cachedUpgradeStatusExpiresAt
+    ) {
+      return this.cachedUpgradeStatus;
     }
 
-    if (this.inflightPromise) {
-      return this.inflightPromise;
+    if (this.inflightUpgradeStatusPromise) {
+      return this.inflightUpgradeStatusPromise;
     }
 
-    this.inflightPromise =
+    this.inflightUpgradeStatusPromise =
       this.upgradeStatusService.getInstanceAndAllWorkspacesStatus();
 
     try {
-      this.cachedSnapshot = await this.inflightPromise;
-      this.cachedSnapshotExpiresAt = Date.now() + SNAPSHOT_TTL_MS;
+      this.cachedUpgradeStatus = await this.inflightUpgradeStatusPromise;
+      this.cachedUpgradeStatusExpiresAt = Date.now() + UPGRADE_STATUS_TTL_MS;
 
-      return this.cachedSnapshot;
+      return this.cachedUpgradeStatus;
     } catch (error) {
-      this.logger.error('Failed to fetch upgrade status snapshot', error);
+      this.logger.error('Failed to fetch upgrade status for gauges', error);
 
       return null;
     } finally {
-      this.inflightPromise = null;
+      this.inflightUpgradeStatusPromise = null;
     }
   }
 }

--- a/packages/twenty-server/src/engine/core-modules/upgrade/upgrade-gauge.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/upgrade/upgrade-gauge.service.ts
@@ -3,7 +3,10 @@ import { Injectable, Logger, OnModuleInit } from '@nestjs/common';
 import { UpgradeHealthEnum } from 'twenty-shared/types';
 
 import { MetricsService } from 'src/engine/core-modules/metrics/metrics.service';
-import { UpgradeStatusService } from 'src/engine/core-modules/upgrade/services/upgrade-status.service';
+import {
+  type InstanceAndAllWorkspacesUpgradeStatus,
+  UpgradeStatusService,
+} from 'src/engine/core-modules/upgrade/services/upgrade-status.service';
 
 const HEALTH_TO_GAUGE_VALUE: Record<UpgradeHealthEnum, number> = {
   [UpgradeHealthEnum.UP_TO_DATE]: 1,
@@ -11,9 +14,17 @@ const HEALTH_TO_GAUGE_VALUE: Record<UpgradeHealthEnum, number> = {
   [UpgradeHealthEnum.FAILED]: -1,
 };
 
+const HEALTH_UNKNOWN = -2;
+const SNAPSHOT_TTL_MS = 60_000;
+
 @Injectable()
 export class UpgradeGaugeService implements OnModuleInit {
   private readonly logger = new Logger(UpgradeGaugeService.name);
+
+  private cachedSnapshot: InstanceAndAllWorkspacesUpgradeStatus | null = null;
+  private cachedSnapshotExpiresAt = 0;
+  private inflightPromise: Promise<InstanceAndAllWorkspacesUpgradeStatus> | null =
+    null;
 
   constructor(
     private readonly metricsService: MetricsService,
@@ -25,10 +36,19 @@ export class UpgradeGaugeService implements OnModuleInit {
       metricName: 'twenty_upgrade_instance_health',
       options: {
         description:
-          'Instance upgrade health (1 = up-to-date, 0 = behind, -1 = failed)',
+          'Instance upgrade health (1 = up-to-date, 0 = behind, -1 = failed, -2 = unknown)',
       },
       callback: async () => {
-        return this.getInstanceHealthGauge();
+        const snapshot = await this.getSnapshot();
+
+        if (!snapshot) {
+          return HEALTH_UNKNOWN;
+        }
+
+        return (
+          HEALTH_TO_GAUGE_VALUE[snapshot.instanceUpgradeStatus.health] ??
+          HEALTH_UNKNOWN
+        );
       },
       cacheValue: true,
     });
@@ -39,7 +59,9 @@ export class UpgradeGaugeService implements OnModuleInit {
         description: 'Number of workspaces behind on upgrade commands',
       },
       callback: async () => {
-        return this.getWorkspacesBehindCount();
+        const snapshot = await this.getSnapshot();
+
+        return snapshot?.workspacesBehind.length ?? 0;
       },
       cacheValue: true,
     });
@@ -50,48 +72,39 @@ export class UpgradeGaugeService implements OnModuleInit {
         description: 'Number of workspaces with a failed upgrade command',
       },
       callback: async () => {
-        return this.getWorkspacesFailedCount();
+        const snapshot = await this.getSnapshot();
+
+        return snapshot?.workspacesFailed.length ?? 0;
       },
       cacheValue: true,
     });
   }
 
-  private async getInstanceHealthGauge(): Promise<number> {
-    try {
-      const status =
-        await this.upgradeStatusService.getInstanceAndAllWorkspacesStatus();
-
-      return HEALTH_TO_GAUGE_VALUE[status.instanceUpgradeStatus.health] ?? 0;
-    } catch (error) {
-      this.logger.error('Failed to get instance upgrade health', error);
-
-      return 0;
+  // Deduplicates concurrent calls and memoizes for SNAPSHOT_TTL_MS
+  // so all 3 gauges share a single fetch per scrape cycle.
+  private async getSnapshot(): Promise<InstanceAndAllWorkspacesUpgradeStatus | null> {
+    if (this.cachedSnapshot && Date.now() < this.cachedSnapshotExpiresAt) {
+      return this.cachedSnapshot;
     }
-  }
 
-  private async getWorkspacesBehindCount(): Promise<number> {
-    try {
-      const status =
-        await this.upgradeStatusService.getInstanceAndAllWorkspacesStatus();
-
-      return status.workspacesBehind.length;
-    } catch (error) {
-      this.logger.error('Failed to count workspaces behind', error);
-
-      return 0;
+    if (this.inflightPromise) {
+      return this.inflightPromise;
     }
-  }
 
-  private async getWorkspacesFailedCount(): Promise<number> {
+    this.inflightPromise =
+      this.upgradeStatusService.getInstanceAndAllWorkspacesStatus();
+
     try {
-      const status =
-        await this.upgradeStatusService.getInstanceAndAllWorkspacesStatus();
+      this.cachedSnapshot = await this.inflightPromise;
+      this.cachedSnapshotExpiresAt = Date.now() + SNAPSHOT_TTL_MS;
 
-      return status.workspacesFailed.length;
+      return this.cachedSnapshot;
     } catch (error) {
-      this.logger.error('Failed to count workspaces failed', error);
+      this.logger.error('Failed to fetch upgrade status snapshot', error);
 
-      return 0;
+      return null;
+    } finally {
+      this.inflightPromise = null;
     }
   }
 }

--- a/packages/twenty-server/src/engine/core-modules/upgrade/upgrade-gauge.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/upgrade/upgrade-gauge.service.ts
@@ -90,7 +90,7 @@ export class UpgradeGaugeService implements OnModuleInit {
     }
 
     if (this.inflightUpgradeStatusPromise) {
-      return this.inflightUpgradeStatusPromise;
+      return this.inflightUpgradeStatusPromise.catch(() => null);
     }
 
     this.inflightUpgradeStatusPromise =

--- a/packages/twenty-server/src/engine/core-modules/upgrade/upgrade.module.ts
+++ b/packages/twenty-server/src/engine/core-modules/upgrade/upgrade.module.ts
@@ -6,6 +6,7 @@ import { WorkspaceIteratorModule } from 'src/database/commands/command-runners/w
 import { InstanceCommandProviderModule } from 'src/database/commands/upgrade-version-command/instance-command-provider.module';
 import { WorkspaceCommandProviderModule } from 'src/database/commands/upgrade-version-command/workspace-command-provider.module';
 import { CoreEntityCacheModule } from 'src/engine/core-entity-cache/core-entity-cache.module';
+import { MetricsModule } from 'src/engine/core-modules/metrics/metrics.module';
 import { InstanceCommandRunnerService } from 'src/engine/core-modules/upgrade/services/instance-command-runner.service';
 import { UpgradeCommandRegistryService } from 'src/engine/core-modules/upgrade/services/upgrade-command-registry.service';
 import { UpgradeMigrationService } from 'src/engine/core-modules/upgrade/services/upgrade-migration.service';
@@ -14,6 +15,7 @@ import { UpgradeSequenceRunnerService } from 'src/engine/core-modules/upgrade/se
 import { UpgradeStatusCacheService } from 'src/engine/core-modules/upgrade/services/upgrade-status-cache.service';
 import { UpgradeStatusService } from 'src/engine/core-modules/upgrade/services/upgrade-status.service';
 import { WorkspaceCommandRunnerService } from 'src/engine/core-modules/upgrade/services/workspace-command-runner.service';
+import { UpgradeGaugeService } from 'src/engine/core-modules/upgrade/upgrade-gauge.service';
 import { UpgradeMigrationEntity } from 'src/engine/core-modules/upgrade/upgrade-migration.entity';
 import { WorkspaceEntity } from 'src/engine/core-modules/workspace/workspace.entity';
 import { WorkspaceVersionModule } from 'src/engine/workspace-manager/workspace-version/workspace-version.module';
@@ -23,6 +25,7 @@ import { WorkspaceVersionModule } from 'src/engine/workspace-manager/workspace-v
     CoreEntityCacheModule,
     DiscoveryModule,
     InstanceCommandProviderModule,
+    MetricsModule,
     WorkspaceCommandProviderModule,
     WorkspaceIteratorModule,
     WorkspaceVersionModule,
@@ -37,6 +40,7 @@ import { WorkspaceVersionModule } from 'src/engine/workspace-manager/workspace-v
     UpgradeSequenceRunnerService,
     UpgradeStatusService,
     UpgradeStatusCacheService,
+    UpgradeGaugeService,
   ],
   exports: [
     UpgradeMigrationService,


### PR DESCRIPTION
## Summary

- Adds `UpgradeGaugeService` that exposes three observable Prometheus gauges based on the recently merged upgrade status service:
  - `twenty_upgrade_instance_health` — 1 (up-to-date), 0 (behind), -1 (failed)
  - `twenty_upgrade_workspaces_behind_total` — count of workspaces with pending upgrade commands
  - `twenty_upgrade_workspaces_failed_total` — count of workspaces with a failed upgrade command
- Follows the existing gauge pattern (`WorkspaceGaugeService`, `BillingGaugeService`, `DatabaseGaugeService`)

### Caching & QPS design

Prometheus scrapes every **15s** via `ServiceMonitor`. Each gauge uses the `MetricsService.createObservableGauge({ cacheValue: true })` pattern which caches the value in Redis for **60 seconds**. Under that, `UpgradeStatusService.getInstanceAndAllWorkspacesStatus()` uses `UpgradeStatusCacheService` with a **1-hour TTL** in Redis.

Result: at most 1 DB query per hour regardless of scrape frequency.

