### PR TITLE
Fix phone unique constraints

### DIFF
--- a/packages/twenty-front/src/modules/settings/data-model/constants/SettingsCompositeFieldTypeConfigs.ts
+++ b/packages/twenty-front/src/modules/settings/data-model/constants/SettingsCompositeFieldTypeConfigs.ts
@@ -209,7 +209,7 @@ export const SETTINGS_COMPOSITE_FIELD_TYPE_CONFIGS = {
             .primaryPhoneCallingCode,
         isImportable: true,
         isFilterable: true,
-        isIncludedInUniqueConstraint: false,
+        isIncludedInUniqueConstraint: true,
       },
       {
         subFieldName:

--- a/packages/twenty-server/src/engine/api/common/common-query-runners/common-create-many-query-runner/utils/__tests__/get-conflicting-fields.util.spec.ts
+++ b/packages/twenty-server/src/engine/api/common/common-query-runners/common-create-many-query-runner/utils/__tests__/get-conflicting-fields.util.spec.ts
@@ -54,6 +54,13 @@ describe('getConflictingFields', () => {
     isUnique: true,
   });
 
+  const phonesUniqueField = createMockField({
+    id: 'phones-unique-id',
+    name: 'phonesField',
+    type: FieldMetadataType.PHONES,
+    isUnique: true,
+  });
+
   const phonesNotUniqueField = createMockField({
     id: 'phones-not-unique-id',
     name: 'phonesField',
@@ -155,6 +162,31 @@ describe('getConflictingFields', () => {
         },
       ]),
     );
+  });
+
+  it('returns every included unique property for phone composite fields', () => {
+    const fields = [idField, phonesUniqueField];
+    const flatObjectMetadata = buildFlatObjectMetadata(fields);
+    const flatFieldMetadataMaps = buildFlatFieldMetadataMaps(fields);
+
+    const result = getConflictingFields(
+      flatObjectMetadata,
+      flatFieldMetadataMaps,
+    );
+
+    expect(result).toEqual([
+      { baseField: 'id', fullPath: 'id', column: 'id' },
+      {
+        baseField: 'phonesField',
+        fullPath: 'phonesField.primaryPhoneNumber',
+        column: 'phonesFieldPrimaryPhoneNumber',
+      },
+      {
+        baseField: 'phonesField',
+        fullPath: 'phonesField.primaryPhoneCallingCode',
+        column: 'phonesFieldPrimaryPhoneCallingCode',
+      },
+    ]);
   });
 
   it('does not include composite fields without included unique property', () => {

--- a/packages/twenty-server/src/engine/api/common/common-query-runners/common-create-many-query-runner/utils/__tests__/get-matching-record-id.util.spec.ts
+++ b/packages/twenty-server/src/engine/api/common/common-query-runners/common-create-many-query-runner/utils/__tests__/get-matching-record-id.util.spec.ts
@@ -68,6 +68,90 @@ describe('getMatchingRecordId', () => {
     expect(id).toBe('recordId2');
   });
 
+  it('matches an existing record when all composite unique subfields are undefined on both sides', () => {
+    const recordsWithoutCallingCode: PartialObjectRecordWithId[] = [
+      {
+        id: 'recordIdWithoutCallingCode',
+        phonesField: {
+          primaryPhoneNumber: '555000111',
+        },
+      },
+    ];
+
+    const record = {
+      phonesField: {
+        primaryPhoneNumber: '555000111',
+      },
+    };
+
+    const conflictingFields = [
+      {
+        baseField: 'phonesField',
+        fullPath: 'phonesField.primaryPhoneNumber',
+        column: 'phonesFieldPrimaryPhoneNumber',
+      },
+      {
+        baseField: 'phonesField',
+        fullPath: 'phonesField.primaryPhoneCallingCode',
+        column: 'phonesFieldPrimaryPhoneCallingCode',
+      },
+    ];
+
+    const id = getMatchingRecordId(
+      record,
+      conflictingFields,
+      recordsWithoutCallingCode,
+    );
+
+    expect(id).toBe('recordIdWithoutCallingCode');
+  });
+
+  it('does not match when one side has a calling code and the other does not', () => {
+    const record = {
+      phonesField: {
+        primaryPhoneNumber: '123456789',
+      },
+    };
+
+    const conflictingFields = [
+      {
+        baseField: 'phonesField',
+        fullPath: 'phonesField.primaryPhoneNumber',
+        column: 'phonesFieldPrimaryPhoneNumber',
+      },
+      {
+        baseField: 'phonesField',
+        fullPath: 'phonesField.primaryPhoneCallingCode',
+        column: 'phonesFieldPrimaryPhoneCallingCode',
+      },
+    ];
+
+    const id = getMatchingRecordId(record, conflictingFields, existingRecords);
+
+    expect(id).toBeUndefined();
+  });
+
+  it('skips composite dedup when the request supplies no values for the base field', () => {
+    const record = {};
+
+    const conflictingFields = [
+      {
+        baseField: 'phonesField',
+        fullPath: 'phonesField.primaryPhoneNumber',
+        column: 'phonesFieldPrimaryPhoneNumber',
+      },
+      {
+        baseField: 'phonesField',
+        fullPath: 'phonesField.primaryPhoneCallingCode',
+        column: 'phonesFieldPrimaryPhoneCallingCode',
+      },
+    ];
+
+    const id = getMatchingRecordId(record, conflictingFields, existingRecords);
+
+    expect(id).toBeUndefined();
+  });
+
   it('returns undefined when only part of a composite unique field matches', () => {
     const record = {
       phonesField: {

--- a/packages/twenty-server/src/engine/api/common/common-query-runners/common-create-many-query-runner/utils/__tests__/get-matching-record-id.util.spec.ts
+++ b/packages/twenty-server/src/engine/api/common/common-query-runners/common-create-many-query-runner/utils/__tests__/get-matching-record-id.util.spec.ts
@@ -8,11 +8,19 @@ describe('getMatchingRecordId', () => {
       id: 'recordId1',
       uniqueText: 'alpha',
       emailsField: { primaryEmail: 'alpha@example.com' },
+      phonesField: {
+        primaryPhoneNumber: '123456789',
+        primaryPhoneCallingCode: '+1',
+      },
     },
     {
       id: 'recordId2',
       uniqueText: 'beta',
       emailsField: { primaryEmail: 'beta@example.com' },
+      phonesField: {
+        primaryPhoneNumber: '123456789',
+        primaryPhoneCallingCode: '+32',
+      },
     },
   ];
 
@@ -32,6 +40,58 @@ describe('getMatchingRecordId', () => {
     const id = getMatchingRecordId(record, conflictingFields, existingRecords);
 
     expect(id).toBe('recordId1');
+  });
+
+  it('returns the matching record id when every composite unique field matches the same existing record', () => {
+    const record = {
+      phonesField: {
+        primaryPhoneNumber: '123456789',
+        primaryPhoneCallingCode: '+32',
+      },
+    };
+
+    const conflictingFields = [
+      {
+        baseField: 'phonesField',
+        fullPath: 'phonesField.primaryPhoneNumber',
+        column: 'phonesFieldPrimaryPhoneNumber',
+      },
+      {
+        baseField: 'phonesField',
+        fullPath: 'phonesField.primaryPhoneCallingCode',
+        column: 'phonesFieldPrimaryPhoneCallingCode',
+      },
+    ];
+
+    const id = getMatchingRecordId(record, conflictingFields, existingRecords);
+
+    expect(id).toBe('recordId2');
+  });
+
+  it('returns undefined when only part of a composite unique field matches', () => {
+    const record = {
+      phonesField: {
+        primaryPhoneNumber: '123456789',
+        primaryPhoneCallingCode: '+33',
+      },
+    };
+
+    const conflictingFields = [
+      {
+        baseField: 'phonesField',
+        fullPath: 'phonesField.primaryPhoneNumber',
+        column: 'phonesFieldPrimaryPhoneNumber',
+      },
+      {
+        baseField: 'phonesField',
+        fullPath: 'phonesField.primaryPhoneCallingCode',
+        column: 'phonesFieldPrimaryPhoneCallingCode',
+      },
+    ];
+
+    const id = getMatchingRecordId(record, conflictingFields, existingRecords);
+
+    expect(id).toBeUndefined();
   });
 
   it('returns undefined when no existing record matches any conflicting field', () => {

--- a/packages/twenty-server/src/engine/api/common/common-query-runners/common-create-many-query-runner/utils/get-conflicting-fields.util.ts
+++ b/packages/twenty-server/src/engine/api/common/common-query-runners/common-create-many-query-runner/utils/get-conflicting-fields.util.ts
@@ -32,18 +32,14 @@ export const getConflictingFields = (
         ];
       }
 
-      const property = compositeType.properties.find(
+      const properties = compositeType.properties.filter(
         (prop) => prop.isIncludedInUniqueConstraint,
       );
 
-      return property
-        ? [
-            {
-              baseField: field.name,
-              fullPath: `${field.name}.${property.name}`,
-              column: `${field.name}${capitalize(property.name)}`,
-            },
-          ]
-        : [];
+      return properties.map((property) => ({
+        baseField: field.name,
+        fullPath: `${field.name}.${property.name}`,
+        column: `${field.name}${capitalize(property.name)}`,
+      }));
     });
 };

--- a/packages/twenty-server/src/engine/api/common/common-query-runners/common-create-many-query-runner/utils/get-matching-record-id.util.ts
+++ b/packages/twenty-server/src/engine/api/common/common-query-runners/common-create-many-query-runner/utils/get-matching-record-id.util.ts
@@ -18,20 +18,37 @@ export const getMatchingRecordId = (
   }[],
   existingRecords: PartialObjectRecordWithId[],
 ): string | undefined => {
-  const matchingRecordIds = conflictingFields.reduce<string[]>((acc, field) => {
-    const requestFieldValue = getValueFromPath(record, field.fullPath);
+  const conflictingFieldsByBaseField = conflictingFields.reduce(
+    (acc, field) => {
+      acc[field.baseField] = [...(acc[field.baseField] ?? []), field];
 
-    const matchingRecord = existingRecords.find((existingRecord) => {
-      const existingFieldValue = getValueFromPath(
-        existingRecord,
-        field.fullPath,
-      );
+      return acc;
+    },
+    {} as Record<string, typeof conflictingFields>,
+  );
 
-      return (
-        isDefined(existingFieldValue) &&
-        existingFieldValue === requestFieldValue
-      );
-    });
+  const matchingRecordIds = Object.values(conflictingFieldsByBaseField).reduce<
+    string[]
+  >((acc, fields) => {
+    const requestFieldValues = fields.map((field) => ({
+      field,
+      value: getValueFromPath(record, field.fullPath),
+    }));
+
+    if (requestFieldValues.some(({ value }) => !isDefined(value))) {
+      return acc;
+    }
+
+    const matchingRecord = existingRecords.find((existingRecord) =>
+      requestFieldValues.every(({ field, value }) => {
+        const existingFieldValue = getValueFromPath(
+          existingRecord,
+          field.fullPath,
+        );
+
+        return isDefined(existingFieldValue) && existingFieldValue === value;
+      }),
+    );
 
     if (isDefined(matchingRecord)) {
       acc.push(matchingRecord.id);

--- a/packages/twenty-server/src/engine/api/common/common-query-runners/common-create-many-query-runner/utils/get-matching-record-id.util.ts
+++ b/packages/twenty-server/src/engine/api/common/common-query-runners/common-create-many-query-runner/utils/get-matching-record-id.util.ts
@@ -35,7 +35,7 @@ export const getMatchingRecordId = (
       value: getValueFromPath(record, field.fullPath),
     }));
 
-    if (requestFieldValues.some(({ value }) => !isDefined(value))) {
+    if (requestFieldValues.every(({ value }) => !isDefined(value))) {
       return acc;
     }
 
@@ -45,6 +45,13 @@ export const getMatchingRecordId = (
           existingRecord,
           field.fullPath,
         );
+
+        // Treat both-undefined as equal so optional composite subfields
+        // (e.g. phone calling code) still trigger a duplicate match when
+        // the same null shape is repeated across records.
+        if (!isDefined(value) && !isDefined(existingFieldValue)) {
+          return true;
+        }
 
         return isDefined(existingFieldValue) && existingFieldValue === value;
       }),

--- a/packages/twenty-server/src/engine/workspace-manager/workspace-migration/workspace-migration-runner/action-handlers/index/utils/__tests__/index-action-handler.utils.spec.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/workspace-migration/workspace-migration-runner/action-handlers/index/utils/__tests__/index-action-handler.utils.spec.ts
@@ -1,0 +1,41 @@
+import { FieldMetadataType } from 'twenty-shared/types';
+
+import { type MetadataFlatEntityMaps } from 'src/engine/metadata-modules/flat-entity/types/metadata-flat-entity-maps.type';
+import { type FlatFieldMetadata } from 'src/engine/metadata-modules/flat-field-metadata/types/flat-field-metadata.type';
+import { type FlatIndexFieldMetadata } from 'src/engine/metadata-modules/flat-index-metadata/types/flat-index-metadata.type';
+import { computeFlatIndexFieldColumnNames } from 'src/engine/workspace-manager/workspace-migration/workspace-migration-runner/action-handlers/index/utils/index-action-handler.utils';
+
+describe('computeFlatIndexFieldColumnNames', () => {
+  const phoneFieldMetadataId = 'phone-field-metadata-id';
+  const phoneFieldUniversalIdentifier = 'phone-field-universal-identifier';
+
+  const flatFieldMetadataMaps = {
+    byUniversalIdentifier: {
+      [phoneFieldUniversalIdentifier]: {
+        id: phoneFieldMetadataId,
+        universalIdentifier: phoneFieldUniversalIdentifier,
+        name: 'phone',
+        type: FieldMetadataType.PHONES,
+      } as FlatFieldMetadata,
+    },
+    universalIdentifierById: {
+      [phoneFieldMetadataId]: phoneFieldUniversalIdentifier,
+    },
+    universalIdentifiersByApplicationId: {},
+  } as MetadataFlatEntityMaps<'fieldMetadata'>;
+
+  it('returns every unique subfield column for phone composite fields', () => {
+    const flatIndexFieldMetadatas = [
+      {
+        fieldMetadataId: phoneFieldMetadataId,
+      } as FlatIndexFieldMetadata,
+    ];
+
+    expect(
+      computeFlatIndexFieldColumnNames({
+        flatIndexFieldMetadatas,
+        flatFieldMetadataMaps,
+      }),
+    ).toEqual(['phonePrimaryPhoneNumber', 'phonePrimaryPhoneCallingCode']);
+  });
+});

--- a/packages/twenty-shared/src/types/composite-types/phones.composite-type.ts
+++ b/packages/twenty-shared/src/types/composite-types/phones.composite-type.ts
@@ -23,6 +23,7 @@ export const phonesCompositeType: CompositeType = {
       type: FieldMetadataType.TEXT,
       hidden: false,
       isRequired: false,
+      isIncludedInUniqueConstraint: true,
     },
     {
       name: 'additionalPhones',


### PR DESCRIPTION
## Summary

Closes #20195

Fix phone field unique constraints so phone numbers are considered unique by both `primaryPhoneNumber` and `primaryPhoneCallingCode`. Previously, two records with the same number but different international codes (e.g. `+1 123456789` and `+32 123456789`) were incorrectly flagged as duplicates.

## Changes

- Mark `primaryPhoneCallingCode` as part of the phone composite unique constraint (`twenty-shared` metadata + frontend settings config).
- Return **all** included unique subfields from `getConflictingFields` (not just the first match).
- Match composite unique fields **as a group** in `getMatchingRecordId` so every subfield must match the same existing record.
- Treat `undefined === undefined` as a match for optional subfields, so two phone entries with the same number and no calling code still deduplicate (prevents NULL bypass).
- Skip composite dedup only when the request supplies **no values** for the base field.

## Root Cause

Phone composite metadata only marked `primaryPhoneNumber` as part of the unique constraint, so different international numbers sharing the same national digits collided. The dedup utility also only looked at a single composite property at a time.

## Test Plan

- [x] Added unit tests for `getConflictingFields` covering the multi-property phone case.
- [x] Added unit tests for `getMatchingRecordId` covering:
  - all composite subfields match the same record
  - partial subfield mismatch returns `undefined`
  - both-undefined subfields match (NULL-bypass fix)
  - one-side-undefined does not match
  - empty record skips dedup
- [x] Added unit test for `computeFlatIndexFieldColumnNames` returning every unique subfield column for phone composite fields.
- [ ] Manual verification: create two People with same number and different calling codes — both should save without a unique-constraint error.
- [ ] Manual verification: create two People with same number and **no** calling code — second should be flagged as duplicate.
