### PR TITLE
`[Headless Front component]` Support multiple selected record 

### DIFF
--- a/packages/twenty-apps/examples/postcard/src/components/card.front-component.tsx
+++ b/packages/twenty-apps/examples/postcard/src/components/card.front-component.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useState } from 'react';
 import { defineFrontComponent } from 'twenty-sdk/define';
-import { useRecordIds } from 'twenty-sdk/front-component';
+import { useSelectedRecordIds } from 'twenty-sdk/front-component';
 import { CoreApiClient } from 'twenty-client-sdk/core';
 import { isDefined } from 'twenty-shared/utils';
 
@@ -72,8 +72,8 @@ const CardDisplay = ({
 };
 
 const PostCardPreview = () => {
-  const recordIds = useRecordIds();
-  const recordId = recordIds.length === 1 ? recordIds[0] : null;
+  const selectedRecordIds = useSelectedRecordIds();
+  const recordId = selectedRecordIds.length === 1 ? selectedRecordIds[0] : null;
   const [postCard, setPostCard] = useState<PostCardRecord | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);

--- a/packages/twenty-apps/examples/postcard/src/components/card.front-component.tsx
+++ b/packages/twenty-apps/examples/postcard/src/components/card.front-component.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useState } from 'react';
 import { defineFrontComponent } from 'twenty-sdk/define';
-import { useRecordId } from 'twenty-sdk/front-component';
+import { useRecordIds } from 'twenty-sdk/front-component';
 import { CoreApiClient } from 'twenty-client-sdk/core';
 import { isDefined } from 'twenty-shared/utils';
 
@@ -72,7 +72,8 @@ const CardDisplay = ({
 };
 
 const PostCardPreview = () => {
-  const recordId = useRecordId();
+  const recordIds = useRecordIds();
+  const recordId = recordIds.length === 1 ? recordIds[0] : null;
   const [postCard, setPostCard] = useState<PostCardRecord | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);

--- a/packages/twenty-apps/examples/postcard/src/components/generate-post-card-component-effect.tsx
+++ b/packages/twenty-apps/examples/postcard/src/components/generate-post-card-component-effect.tsx
@@ -1,8 +1,7 @@
 import { useEffect } from 'react';
 import { defineFrontComponent } from 'twenty-sdk/define';
-import { useRecordId, updateProgress, enqueueSnackbar, unmountFrontComponent } from 'twenty-sdk/front-component';
+import { useRecordIds, updateProgress, enqueueSnackbar, unmountFrontComponent } from 'twenty-sdk/front-component';
 import { CoreApiClient } from 'twenty-client-sdk/core';
-import { isDefined } from 'twenty-shared/utils';
 import { POST_CARD_UNIVERSAL_IDENTIFIER } from '../objects/post-card.object';
 
 const SYSTEM_PROMPT =
@@ -11,12 +10,13 @@ const SYSTEM_PROMPT =
   'text, nothing else — no greeting label, no sign-off label, just the message.';
 
 const GeneratePostCardEffect = () => {
-  const recordId = useRecordId();
+  const recordIds = useRecordIds();
+  const recordId = recordIds.length === 1 ? recordIds[0] : null;
 
   useEffect(() => {
-    if (!isDefined(recordId)) {
+    if (recordId === null) {
       enqueueSnackbar({
-        message: 'No record selected',
+        message: 'Please select exactly one record',
         variant: 'error',
       });
       unmountFrontComponent();

--- a/packages/twenty-apps/examples/postcard/src/components/generate-post-card-component-effect.tsx
+++ b/packages/twenty-apps/examples/postcard/src/components/generate-post-card-component-effect.tsx
@@ -1,6 +1,6 @@
 import { useEffect } from 'react';
 import { defineFrontComponent } from 'twenty-sdk/define';
-import { useRecordIds, updateProgress, enqueueSnackbar, unmountFrontComponent } from 'twenty-sdk/front-component';
+import { useSelectedRecordIds, updateProgress, enqueueSnackbar, unmountFrontComponent } from 'twenty-sdk/front-component';
 import { CoreApiClient } from 'twenty-client-sdk/core';
 import { POST_CARD_UNIVERSAL_IDENTIFIER } from '../objects/post-card.object';
 
@@ -10,8 +10,8 @@ const SYSTEM_PROMPT =
   'text, nothing else — no greeting label, no sign-off label, just the message.';
 
 const GeneratePostCardEffect = () => {
-  const recordIds = useRecordIds();
-  const recordId = recordIds.length === 1 ? recordIds[0] : null;
+  const selectedRecordIds = useSelectedRecordIds();
+  const recordId = selectedRecordIds.length === 1 ? selectedRecordIds[0] : null;
 
   useEffect(() => {
     if (recordId === null) {

--- a/packages/twenty-apps/examples/postcard/src/components/send-post-cards-component-effect.tsx
+++ b/packages/twenty-apps/examples/postcard/src/components/send-post-cards-component-effect.tsx
@@ -10,52 +10,35 @@ const SendPostCardsEffect = () => {
   useEffect(() => {
     const send = async () => {
       try {
-        await updateProgress(0.1);
-        const client = new CoreApiClient();
-
-        let idsToSend: string[] = [];
-
-        if (recordIds.length > 0) {
-          idsToSend = recordIds;
-        } else {
-          const { postCards } = await client.query({
-            postCards: {
-              __args: {
-                filter: { status: { eq: 'DRAFT' } },
-              },
-              edges: { node: { id: true } },
-            },
+        if (recordIds.length === 0) {
+          await enqueueSnackbar({
+            message: 'No postcards selected',
+            variant: 'error',
           });
-
-          idsToSend =
-            postCards?.edges?.map(
-              (edge: { node: { id: string; status: true } }) => edge.node.id,
-            ) ?? [];
-        }
-
-        if (idsToSend.length === 0) {
-          await updateProgress(1);
           await unmountFrontComponent();
           return;
         }
 
+        await updateProgress(0.1);
+        const client = new CoreApiClient();
+
         await updateProgress(0.3);
 
-        for (let i = 0; i < idsToSend.length; i++) {
+        for (let i = 0; i < recordIds.length; i++) {
           await client.mutation({
             updatePostCard: {
               __args: {
-                id: idsToSend[i],
+                id: recordIds[i],
                 data: { status: 'SENT' },
               },
               id: true,
             },
           });
 
-          await updateProgress(0.3 + (0.7 * (i + 1)) / idsToSend.length);
+          await updateProgress(0.3 + (0.7 * (i + 1)) / recordIds.length);
         }
 
-        const count = idsToSend.length;
+        const count = recordIds.length;
 
         await enqueueSnackbar({
           message: `${count} postcard${count > 1 ? 's' : ''} sent`,

--- a/packages/twenty-apps/examples/postcard/src/components/send-post-cards-component-effect.tsx
+++ b/packages/twenty-apps/examples/postcard/src/components/send-post-cards-component-effect.tsx
@@ -1,12 +1,11 @@
 import { useEffect } from 'react';
 import { defineFrontComponent } from 'twenty-sdk/define';
-import { useRecordId, updateProgress, enqueueSnackbar, unmountFrontComponent } from 'twenty-sdk/front-component';
+import { useRecordIds, updateProgress, enqueueSnackbar, unmountFrontComponent } from 'twenty-sdk/front-component';
 import { CoreApiClient } from 'twenty-client-sdk/core';
-import { isDefined } from 'twenty-shared/utils';
 import { POST_CARD_UNIVERSAL_IDENTIFIER } from '../objects/post-card.object';
 
 const SendPostCardsEffect = () => {
-  const recordId = useRecordId();
+  const recordIds = useRecordIds();
 
   useEffect(() => {
     const send = async () => {
@@ -16,8 +15,8 @@ const SendPostCardsEffect = () => {
 
         let idsToSend: string[] = [];
 
-        if (isDefined(recordId)) {
-          idsToSend = [recordId];
+        if (recordIds.length > 0) {
+          idsToSend = recordIds;
         } else {
           const { postCards } = await client.query({
             postCards: {
@@ -74,7 +73,7 @@ const SendPostCardsEffect = () => {
     };
 
     send();
-  }, [recordId]);
+  }, [recordIds]);
 
   return null;
 };

--- a/packages/twenty-apps/examples/postcard/src/components/send-post-cards-component-effect.tsx
+++ b/packages/twenty-apps/examples/postcard/src/components/send-post-cards-component-effect.tsx
@@ -1,16 +1,16 @@
 import { useEffect } from 'react';
 import { defineFrontComponent } from 'twenty-sdk/define';
-import { useRecordIds, updateProgress, enqueueSnackbar, unmountFrontComponent } from 'twenty-sdk/front-component';
+import { useSelectedRecordIds, updateProgress, enqueueSnackbar, unmountFrontComponent } from 'twenty-sdk/front-component';
 import { CoreApiClient } from 'twenty-client-sdk/core';
 import { POST_CARD_UNIVERSAL_IDENTIFIER } from '../objects/post-card.object';
 
 const SendPostCardsEffect = () => {
-  const recordIds = useRecordIds();
+  const selectedRecordIds = useSelectedRecordIds();
 
   useEffect(() => {
     const send = async () => {
       try {
-        if (recordIds.length === 0) {
+        if (selectedRecordIds.length === 0) {
           await enqueueSnackbar({
             message: 'No postcards selected',
             variant: 'error',
@@ -24,21 +24,21 @@ const SendPostCardsEffect = () => {
 
         await updateProgress(0.3);
 
-        for (let i = 0; i < recordIds.length; i++) {
+        for (let i = 0; i < selectedRecordIds.length; i++) {
           await client.mutation({
             updatePostCard: {
               __args: {
-                id: recordIds[i],
+                id: selectedRecordIds[i],
                 data: { status: 'SENT' },
               },
               id: true,
             },
           });
 
-          await updateProgress(0.3 + (0.7 * (i + 1)) / recordIds.length);
+          await updateProgress(0.3 + (0.7 * (i + 1)) / selectedRecordIds.length);
         }
 
-        const count = recordIds.length;
+        const count = selectedRecordIds.length;
 
         await enqueueSnackbar({
           message: `${count} postcard${count > 1 ? 's' : ''} sent`,
@@ -56,7 +56,7 @@ const SendPostCardsEffect = () => {
     };
 
     send();
-  }, [recordIds]);
+  }, [selectedRecordIds]);
 
   return null;
 };

--- a/packages/twenty-docs/developers/extend/apps/front-components.mdx
+++ b/packages/twenty-docs/developers/extend/apps/front-components.mdx
@@ -223,8 +223,8 @@ Available hooks:
 | Hook | Returns | Description |
 |------|---------|-------------|
 | `useUserId()` | `string` or `null` | The current user's ID |
-| `useRecordId()` | `string` or `null` | The selected record ID when exactly one record is selected, otherwise null |
 | `useRecordIds()` | `string[]` | All selected record IDs (empty array if none selected) |
+| `useRecordId()` | `string` or `null` | **Deprecated.** Use `useRecordIds()` instead |
 | `useFrontComponentId()` | `string` | This component instance's ID |
 | `useFrontComponentExecutionContext(selector)` | varies | Access the full execution context with a selector function |
 

--- a/packages/twenty-docs/developers/extend/apps/front-components.mdx
+++ b/packages/twenty-docs/developers/extend/apps/front-components.mdx
@@ -223,7 +223,8 @@ Available hooks:
 | Hook | Returns | Description |
 |------|---------|-------------|
 | `useUserId()` | `string` or `null` | The current user's ID |
-| `useRecordId()` | `string` or `null` | The current record's ID (when placed on a record page) |
+| `useRecordIds()` | `string[]` | All selected record IDs (empty array if none selected) |
+| `useRecordId()` | `string` or `null` | **Deprecated.** Use `useRecordIds()` instead. Returns the first selected record ID or null |
 | `useFrontComponentId()` | `string` | This component instance's ID |
 | `useFrontComponentExecutionContext(selector)` | varies | Access the full execution context with a selector function |
 
@@ -283,6 +284,61 @@ export default defineFrontComponent({
   name: 'archive-record',
   description: 'Archives the current record',
   component: ArchiveRecord,
+});
+```
+
+### Working with multiple records
+
+Use `useRecordIds()` to handle multiple selected records. This is useful for bulk operations:
+
+```tsx src/front-components/bulk-export.tsx
+import { defineFrontComponent } from 'twenty-sdk/define';
+import { useRecordIds, numberOfSelectedRecords } from 'twenty-sdk/front-component';
+import { enqueueSnackbar, closeSidePanel } from 'twenty-sdk/front-component';
+import { CoreApiClient } from 'twenty-sdk/clients';
+
+const BulkExport = () => {
+  const recordIds = useRecordIds();
+
+  const handleExport = async () => {
+    const client = new CoreApiClient();
+
+    for (const recordId of recordIds) {
+      await client.mutation({
+        updateTask: {
+          __args: { id: recordId, data: { exported: true } },
+          id: true,
+        },
+      });
+    }
+
+    await enqueueSnackbar({
+      message: `Exported ${recordIds.length} records`,
+      variant: 'success',
+    });
+
+    await closeSidePanel();
+  };
+
+  return (
+    <div style={{ padding: '20px' }}>
+      <p>Export {recordIds.length} selected record(s)?</p>
+      <button onClick={handleExport}>Export</button>
+    </div>
+  );
+};
+
+export default defineFrontComponent({
+  universalIdentifier: 'd0e1f2a3-b4c5-6789-defa-012345678901',
+  name: 'bulk-export',
+  description: 'Export selected records',
+  component: BulkExport,
+  command: {
+    universalIdentifier: 'd0e1f2a3-b4c5-6789-defa-012345678902',
+    label: 'Bulk Export',
+    availabilityType: 'RECORD_SELECTION',
+    conditionalAvailabilityExpression: numberOfSelectedRecords > 0,
+  },
 });
 ```
 

--- a/packages/twenty-docs/developers/extend/apps/front-components.mdx
+++ b/packages/twenty-docs/developers/extend/apps/front-components.mdx
@@ -223,8 +223,8 @@ Available hooks:
 | Hook | Returns | Description |
 |------|---------|-------------|
 | `useUserId()` | `string` or `null` | The current user's ID |
-| `useRecordIds()` | `string[]` | All selected record IDs (empty array if none selected) |
-| `useRecordId()` | `string` or `null` | **Deprecated.** Use `useRecordIds()` instead |
+| `useSelectedRecordIds()` | `string[]` | All selected record IDs (empty array if none selected) |
+| `useRecordId()` | `string` or `null` | **Deprecated.** Use `useSelectedRecordIds()` instead |
 | `useFrontComponentId()` | `string` | This component instance's ID |
 | `useFrontComponentExecutionContext(selector)` | varies | Access the full execution context with a selector function |
 
@@ -289,21 +289,21 @@ export default defineFrontComponent({
 
 ### Working with multiple records
 
-Use `useRecordIds()` to handle multiple selected records. This is useful for bulk operations:
+Use `useSelectedRecordIds()` to handle multiple selected records. This is useful for bulk operations:
 
 ```tsx src/front-components/bulk-export.tsx
 import { defineFrontComponent } from 'twenty-sdk/define';
-import { useRecordIds, numberOfSelectedRecords } from 'twenty-sdk/front-component';
+import { useSelectedRecordIds, numberOfSelectedRecords } from 'twenty-sdk/front-component';
 import { enqueueSnackbar, closeSidePanel } from 'twenty-sdk/front-component';
 import { CoreApiClient } from 'twenty-sdk/clients';
 
 const BulkExport = () => {
-  const recordIds = useRecordIds();
+  const selectedRecordIds = useSelectedRecordIds();
 
   const handleExport = async () => {
     const client = new CoreApiClient();
 
-    for (const recordId of recordIds) {
+    for (const recordId of selectedRecordIds) {
       await client.mutation({
         updateTask: {
           __args: { id: recordId, data: { exported: true } },
@@ -313,7 +313,7 @@ const BulkExport = () => {
     }
 
     await enqueueSnackbar({
-      message: `Exported ${recordIds.length} records`,
+      message: `Exported ${selectedRecordIds.length} records`,
       variant: 'success',
     });
 
@@ -322,7 +322,7 @@ const BulkExport = () => {
 
   return (
     <div style={{ padding: '20px' }}>
-      <p>Export {recordIds.length} selected record(s)?</p>
+      <p>Export {selectedRecordIds.length} selected record(s)?</p>
       <button onClick={handleExport}>Export</button>
     </div>
   );

--- a/packages/twenty-docs/developers/extend/apps/front-components.mdx
+++ b/packages/twenty-docs/developers/extend/apps/front-components.mdx
@@ -223,8 +223,8 @@ Available hooks:
 | Hook | Returns | Description |
 |------|---------|-------------|
 | `useUserId()` | `string` or `null` | The current user's ID |
+| `useRecordId()` | `string` or `null` | The selected record ID when exactly one record is selected, otherwise null |
 | `useRecordIds()` | `string[]` | All selected record IDs (empty array if none selected) |
-| `useRecordId()` | `string` or `null` | **Deprecated.** Use `useRecordIds()` instead. Returns the first selected record ID or null |
 | `useFrontComponentId()` | `string` | This component instance's ID |
 | `useFrontComponentExecutionContext(selector)` | varies | Access the full execution context with a selector function |
 

--- a/packages/twenty-front-component-renderer/src/__stories__/EventForwarding.stories.tsx
+++ b/packages/twenty-front-component-renderer/src/__stories__/EventForwarding.stories.tsx
@@ -31,7 +31,7 @@ const meta: Meta<typeof FrontComponentRenderer> = {
       frontComponentId: 'storybook-test',
       userId: null,
       recordId: null,
-      recordIds: [],
+      selectedRecordIds: [],
     },
     colorScheme: 'light',
     frontComponentHostCommunicationApi: createHostApiMocks(),

--- a/packages/twenty-front-component-renderer/src/__stories__/EventForwarding.stories.tsx
+++ b/packages/twenty-front-component-renderer/src/__stories__/EventForwarding.stories.tsx
@@ -31,6 +31,7 @@ const meta: Meta<typeof FrontComponentRenderer> = {
       frontComponentId: 'storybook-test',
       userId: null,
       recordId: null,
+      recordIds: [],
     },
     colorScheme: 'light',
     frontComponentHostCommunicationApi: createHostApiMocks(),

--- a/packages/twenty-front-component-renderer/src/__stories__/FrontComponentRenderer.stories.tsx
+++ b/packages/twenty-front-component-renderer/src/__stories__/FrontComponentRenderer.stories.tsx
@@ -20,7 +20,7 @@ const meta: Meta<typeof FrontComponentRenderer> = {
       frontComponentId: 'storybook-test',
       userId: null,
       recordId: null,
-      recordIds: [],
+      selectedRecordIds: [],
     },
   },
   beforeEach: () => {
@@ -123,7 +123,7 @@ export const SdkContext: Story = {
       frontComponentId: 'sdk-context-test',
       userId: 'test-user-abc-123',
       recordId: null,
-      recordIds: [],
+      selectedRecordIds: [],
     },
   },
   play: async ({ canvasElement }) => {

--- a/packages/twenty-front-component-renderer/src/__stories__/FrontComponentRenderer.stories.tsx
+++ b/packages/twenty-front-component-renderer/src/__stories__/FrontComponentRenderer.stories.tsx
@@ -20,6 +20,7 @@ const meta: Meta<typeof FrontComponentRenderer> = {
       frontComponentId: 'storybook-test',
       userId: null,
       recordId: null,
+      recordIds: [],
     },
   },
   beforeEach: () => {
@@ -122,6 +123,7 @@ export const SdkContext: Story = {
       frontComponentId: 'sdk-context-test',
       userId: 'test-user-abc-123',
       recordId: null,
+      recordIds: [],
     },
   },
   play: async ({ canvasElement }) => {

--- a/packages/twenty-front-component-renderer/src/__stories__/UILibraries.stories.tsx
+++ b/packages/twenty-front-component-renderer/src/__stories__/UILibraries.stories.tsx
@@ -20,6 +20,7 @@ const meta: Meta<typeof FrontComponentRenderer> = {
       frontComponentId: 'storybook-test',
       userId: null,
       recordId: null,
+      recordIds: [],
     },
   },
   beforeEach: () => {

--- a/packages/twenty-front-component-renderer/src/__stories__/UILibraries.stories.tsx
+++ b/packages/twenty-front-component-renderer/src/__stories__/UILibraries.stories.tsx
@@ -20,7 +20,7 @@ const meta: Meta<typeof FrontComponentRenderer> = {
       frontComponentId: 'storybook-test',
       userId: null,
       recordId: null,
-      recordIds: [],
+      selectedRecordIds: [],
     },
   },
   beforeEach: () => {

--- a/packages/twenty-front-component-renderer/src/types/FrontComponentExecutionContext.ts
+++ b/packages/twenty-front-component-renderer/src/types/FrontComponentExecutionContext.ts
@@ -2,8 +2,9 @@ export type FrontComponentExecutionContext = {
   frontComponentId: string;
   userId: string | null;
   /**
-   * @deprecated Use `recordIds` instead. Returns first selected record ID or null.
+   * @deprecated Use `recordIds` instead. Derive single record as `recordIds.length === 1 ? recordIds[0] : null`.
    */
   recordId: string | null;
+  /** All selected record IDs */
   recordIds: string[];
 };

--- a/packages/twenty-front-component-renderer/src/types/FrontComponentExecutionContext.ts
+++ b/packages/twenty-front-component-renderer/src/types/FrontComponentExecutionContext.ts
@@ -2,9 +2,9 @@ export type FrontComponentExecutionContext = {
   frontComponentId: string;
   userId: string | null;
   /**
-   * @deprecated Use `recordIds` instead. Derive single record as `recordIds.length === 1 ? recordIds[0] : null`.
+   * @deprecated Use `selectedRecordIds` instead. Derive single record as `selectedRecordIds.length === 1 ? selectedRecordIds[0] : null`.
    */
   recordId: string | null;
   /** All selected record IDs */
-  recordIds: string[];
+  selectedRecordIds: string[];
 };

--- a/packages/twenty-front-component-renderer/src/types/FrontComponentExecutionContext.ts
+++ b/packages/twenty-front-component-renderer/src/types/FrontComponentExecutionContext.ts
@@ -1,5 +1,9 @@
 export type FrontComponentExecutionContext = {
   frontComponentId: string;
   userId: string | null;
+  /**
+   * @deprecated Use `recordIds` instead. Returns first selected record ID or null.
+   */
   recordId: string | null;
+  recordIds: string[];
 };

--- a/packages/twenty-front/src/modules/command-menu-item/engine-command/components/HeadlessFrontComponentRendererEngineCommand.tsx
+++ b/packages/twenty-front/src/modules/command-menu-item/engine-command/components/HeadlessFrontComponentRendererEngineCommand.tsx
@@ -24,17 +24,14 @@ export const HeadlessFrontComponentRendererEngineCommand = () => {
     );
   }
 
-  const recordId =
-    context.selectedRecords.length === 1
-      ? context.selectedRecords[0].id
-      : undefined;
+  const recordIds = context.selectedRecords.map((record) => record.id);
 
   return (
     <Suspense fallback={null}>
       <FrontComponentRenderer
         frontComponentId={context.frontComponentId}
         commandMenuItemId={commandMenuItemId}
-        recordId={recordId}
+        recordIds={recordIds}
       />
     </Suspense>
   );

--- a/packages/twenty-front/src/modules/command-menu-item/engine-command/components/HeadlessFrontComponentRendererEngineCommand.tsx
+++ b/packages/twenty-front/src/modules/command-menu-item/engine-command/components/HeadlessFrontComponentRendererEngineCommand.tsx
@@ -24,14 +24,14 @@ export const HeadlessFrontComponentRendererEngineCommand = () => {
     );
   }
 
-  const recordIds = context.selectedRecords.map((record) => record.id);
+  const selectedRecordIds = context.selectedRecords.map((record) => record.id);
 
   return (
     <Suspense fallback={null}>
       <FrontComponentRenderer
         frontComponentId={context.frontComponentId}
         commandMenuItemId={commandMenuItemId}
-        recordIds={recordIds}
+        selectedRecordIds={selectedRecordIds}
       />
     </Suspense>
   );

--- a/packages/twenty-front/src/modules/front-components/components/FrontComponentRenderer.tsx
+++ b/packages/twenty-front/src/modules/front-components/components/FrontComponentRenderer.tsx
@@ -18,13 +18,13 @@ import { FindOneFrontComponentDocument } from '~/generated-metadata/graphql';
 type FrontComponentRendererProps = {
   frontComponentId: string;
   commandMenuItemId?: string;
-  recordId?: string;
+  recordIds?: string[];
 };
 
 export const FrontComponentRenderer = ({
   frontComponentId,
   commandMenuItemId,
-  recordId,
+  recordIds,
 }: FrontComponentRendererProps) => {
   const { colorScheme } = useContext(ThemeContext);
   const { enqueueErrorSnackBar } = useSnackBar();
@@ -38,7 +38,7 @@ export const FrontComponentRenderer = ({
     useFrontComponentExecutionContext({
       frontComponentId,
       commandMenuItemId,
-      recordId,
+      recordIds,
     });
 
   const handleError = useCallback(

--- a/packages/twenty-front/src/modules/front-components/components/FrontComponentRenderer.tsx
+++ b/packages/twenty-front/src/modules/front-components/components/FrontComponentRenderer.tsx
@@ -18,13 +18,13 @@ import { FindOneFrontComponentDocument } from '~/generated-metadata/graphql';
 type FrontComponentRendererProps = {
   frontComponentId: string;
   commandMenuItemId?: string;
-  recordIds?: string[];
+  selectedRecordIds?: string[];
 };
 
 export const FrontComponentRenderer = ({
   frontComponentId,
   commandMenuItemId,
-  recordIds,
+  selectedRecordIds,
 }: FrontComponentRendererProps) => {
   const { colorScheme } = useContext(ThemeContext);
   const { enqueueErrorSnackBar } = useSnackBar();
@@ -38,7 +38,7 @@ export const FrontComponentRenderer = ({
     useFrontComponentExecutionContext({
       frontComponentId,
       commandMenuItemId,
-      recordIds,
+      selectedRecordIds,
     });
 
   const handleError = useCallback(

--- a/packages/twenty-front/src/modules/front-components/hooks/__tests__/useFrontComponentExecutionContext.test.tsx
+++ b/packages/twenty-front/src/modules/front-components/hooks/__tests__/useFrontComponentExecutionContext.test.tsx
@@ -109,7 +109,7 @@ describe('useFrontComponentExecutionContext', () => {
       });
     });
 
-    it('should return recordId as first element when multiple recordIds provided', () => {
+    it('should return null recordId when multiple recordIds provided', () => {
       const { result } = renderHook(() =>
         useFrontComponentExecutionContext({
           frontComponentId: FRONT_COMPONENT_ID,
@@ -120,7 +120,7 @@ describe('useFrontComponentExecutionContext', () => {
       expect(result.current.executionContext).toEqual({
         frontComponentId: FRONT_COMPONENT_ID,
         userId: 'user-123',
-        recordId: 'record-1',
+        recordId: null,
         recordIds: ['record-1', 'record-2', 'record-3'],
       });
     });

--- a/packages/twenty-front/src/modules/front-components/hooks/__tests__/useFrontComponentExecutionContext.test.tsx
+++ b/packages/twenty-front/src/modules/front-components/hooks/__tests__/useFrontComponentExecutionContext.test.tsx
@@ -93,11 +93,11 @@ describe('useFrontComponentExecutionContext', () => {
   });
 
   describe('executionContext', () => {
-    it('should return frontComponentId, userId, and recordId', () => {
+    it('should return frontComponentId, userId, recordId, and recordIds with single record', () => {
       const { result } = renderHook(() =>
         useFrontComponentExecutionContext({
           frontComponentId: FRONT_COMPONENT_ID,
-          recordId: 'record-456',
+          recordIds: ['record-456'],
         }),
       );
 
@@ -105,6 +105,23 @@ describe('useFrontComponentExecutionContext', () => {
         frontComponentId: FRONT_COMPONENT_ID,
         userId: 'user-123',
         recordId: 'record-456',
+        recordIds: ['record-456'],
+      });
+    });
+
+    it('should return recordId as first element when multiple recordIds provided', () => {
+      const { result } = renderHook(() =>
+        useFrontComponentExecutionContext({
+          frontComponentId: FRONT_COMPONENT_ID,
+          recordIds: ['record-1', 'record-2', 'record-3'],
+        }),
+      );
+
+      expect(result.current.executionContext).toEqual({
+        frontComponentId: FRONT_COMPONENT_ID,
+        userId: 'user-123',
+        recordId: 'record-1',
+        recordIds: ['record-1', 'record-2', 'record-3'],
       });
     });
 
@@ -120,7 +137,7 @@ describe('useFrontComponentExecutionContext', () => {
       expect(result.current.executionContext.userId).toBeNull();
     });
 
-    it('should return null recordId when no recordId provided', () => {
+    it('should return null recordId and empty recordIds when no recordIds provided', () => {
       const { result } = renderHook(() =>
         useFrontComponentExecutionContext({
           frontComponentId: FRONT_COMPONENT_ID,
@@ -128,6 +145,19 @@ describe('useFrontComponentExecutionContext', () => {
       );
 
       expect(result.current.executionContext.recordId).toBeNull();
+      expect(result.current.executionContext.recordIds).toEqual([]);
+    });
+
+    it('should return null recordId and empty recordIds when empty array provided', () => {
+      const { result } = renderHook(() =>
+        useFrontComponentExecutionContext({
+          frontComponentId: FRONT_COMPONENT_ID,
+          recordIds: [],
+        }),
+      );
+
+      expect(result.current.executionContext.recordId).toBeNull();
+      expect(result.current.executionContext.recordIds).toEqual([]);
     });
   });
 

--- a/packages/twenty-front/src/modules/front-components/hooks/__tests__/useFrontComponentExecutionContext.test.tsx
+++ b/packages/twenty-front/src/modules/front-components/hooks/__tests__/useFrontComponentExecutionContext.test.tsx
@@ -93,11 +93,11 @@ describe('useFrontComponentExecutionContext', () => {
   });
 
   describe('executionContext', () => {
-    it('should return frontComponentId, userId, recordId, and recordIds with single record', () => {
+    it('should return frontComponentId, userId, recordId, and selectedRecordIds with single record', () => {
       const { result } = renderHook(() =>
         useFrontComponentExecutionContext({
           frontComponentId: FRONT_COMPONENT_ID,
-          recordIds: ['record-456'],
+          selectedRecordIds: ['record-456'],
         }),
       );
 
@@ -105,15 +105,15 @@ describe('useFrontComponentExecutionContext', () => {
         frontComponentId: FRONT_COMPONENT_ID,
         userId: 'user-123',
         recordId: 'record-456',
-        recordIds: ['record-456'],
+        selectedRecordIds: ['record-456'],
       });
     });
 
-    it('should return null recordId when multiple recordIds provided', () => {
+    it('should return null recordId when multiple selectedRecordIds provided', () => {
       const { result } = renderHook(() =>
         useFrontComponentExecutionContext({
           frontComponentId: FRONT_COMPONENT_ID,
-          recordIds: ['record-1', 'record-2', 'record-3'],
+          selectedRecordIds: ['record-1', 'record-2', 'record-3'],
         }),
       );
 
@@ -121,7 +121,7 @@ describe('useFrontComponentExecutionContext', () => {
         frontComponentId: FRONT_COMPONENT_ID,
         userId: 'user-123',
         recordId: null,
-        recordIds: ['record-1', 'record-2', 'record-3'],
+        selectedRecordIds: ['record-1', 'record-2', 'record-3'],
       });
     });
 
@@ -137,7 +137,7 @@ describe('useFrontComponentExecutionContext', () => {
       expect(result.current.executionContext.userId).toBeNull();
     });
 
-    it('should return null recordId and empty recordIds when no recordIds provided', () => {
+    it('should return null recordId and empty selectedRecordIds when no selectedRecordIds provided', () => {
       const { result } = renderHook(() =>
         useFrontComponentExecutionContext({
           frontComponentId: FRONT_COMPONENT_ID,
@@ -145,19 +145,19 @@ describe('useFrontComponentExecutionContext', () => {
       );
 
       expect(result.current.executionContext.recordId).toBeNull();
-      expect(result.current.executionContext.recordIds).toEqual([]);
+      expect(result.current.executionContext.selectedRecordIds).toEqual([]);
     });
 
-    it('should return null recordId and empty recordIds when empty array provided', () => {
+    it('should return null recordId and empty selectedRecordIds when empty array provided', () => {
       const { result } = renderHook(() =>
         useFrontComponentExecutionContext({
           frontComponentId: FRONT_COMPONENT_ID,
-          recordIds: [],
+          selectedRecordIds: [],
         }),
       );
 
       expect(result.current.executionContext.recordId).toBeNull();
-      expect(result.current.executionContext.recordIds).toEqual([]);
+      expect(result.current.executionContext.selectedRecordIds).toEqual([]);
     });
   });
 

--- a/packages/twenty-front/src/modules/front-components/hooks/useFrontComponentExecutionContext.ts
+++ b/packages/twenty-front/src/modules/front-components/hooks/useFrontComponentExecutionContext.ts
@@ -23,11 +23,11 @@ import { useNavigateApp } from '~/hooks/useNavigateApp';
 export const useFrontComponentExecutionContext = ({
   frontComponentId,
   commandMenuItemId,
-  recordId,
+  recordIds,
 }: {
   frontComponentId: string;
   commandMenuItemId?: string;
-  recordId?: string;
+  recordIds?: string[];
 }): {
   executionContext: FrontComponentExecutionContext;
   frontComponentHostCommunicationApi: FrontComponentHostCommunicationApi;
@@ -127,7 +127,8 @@ export const useFrontComponentExecutionContext = ({
   const executionContext: FrontComponentExecutionContext = {
     frontComponentId,
     userId: currentUser?.id ?? null,
-    recordId: recordId ?? null,
+    recordId: recordIds?.[0] ?? null,
+    recordIds: recordIds ?? [],
   };
 
   const unmountFrontComponent: FrontComponentHostCommunicationApi['unmountFrontComponent'] =

--- a/packages/twenty-front/src/modules/front-components/hooks/useFrontComponentExecutionContext.ts
+++ b/packages/twenty-front/src/modules/front-components/hooks/useFrontComponentExecutionContext.ts
@@ -127,7 +127,7 @@ export const useFrontComponentExecutionContext = ({
   const executionContext: FrontComponentExecutionContext = {
     frontComponentId,
     userId: currentUser?.id ?? null,
-    recordId: recordIds?.[0] ?? null,
+    recordId: recordIds?.length === 1 ? recordIds[0] : null,
     recordIds: recordIds ?? [],
   };
 

--- a/packages/twenty-front/src/modules/front-components/hooks/useFrontComponentExecutionContext.ts
+++ b/packages/twenty-front/src/modules/front-components/hooks/useFrontComponentExecutionContext.ts
@@ -23,11 +23,11 @@ import { useNavigateApp } from '~/hooks/useNavigateApp';
 export const useFrontComponentExecutionContext = ({
   frontComponentId,
   commandMenuItemId,
-  recordIds,
+  selectedRecordIds,
 }: {
   frontComponentId: string;
   commandMenuItemId?: string;
-  recordIds?: string[];
+  selectedRecordIds?: string[];
 }): {
   executionContext: FrontComponentExecutionContext;
   frontComponentHostCommunicationApi: FrontComponentHostCommunicationApi;
@@ -127,8 +127,8 @@ export const useFrontComponentExecutionContext = ({
   const executionContext: FrontComponentExecutionContext = {
     frontComponentId,
     userId: currentUser?.id ?? null,
-    recordId: recordIds?.length === 1 ? recordIds[0] : null,
-    recordIds: recordIds ?? [],
+    recordId: selectedRecordIds?.length === 1 ? selectedRecordIds[0] : null,
+    selectedRecordIds: selectedRecordIds ?? [],
   };
 
   const unmountFrontComponent: FrontComponentHostCommunicationApi['unmountFrontComponent'] =

--- a/packages/twenty-front/src/modules/page-layout/widgets/front-component/components/FrontComponentWidgetRenderer.tsx
+++ b/packages/twenty-front/src/modules/page-layout/widgets/front-component/components/FrontComponentWidgetRenderer.tsx
@@ -42,13 +42,16 @@ export const FrontComponentWidgetRenderer = ({
   }
 
   const frontComponentId = configuration.frontComponentId;
+  const recordIds = isDefined(targetRecordIdentifier?.id)
+    ? [targetRecordIdentifier.id]
+    : undefined;
 
   return (
     <StyledContainer isInEditMode={isPageLayoutInEditMode}>
       <Suspense fallback={null}>
         <FrontComponentRenderer
           frontComponentId={frontComponentId}
-          recordId={targetRecordIdentifier?.id}
+          recordIds={recordIds}
         />
       </Suspense>
     </StyledContainer>

--- a/packages/twenty-front/src/modules/page-layout/widgets/front-component/components/FrontComponentWidgetRenderer.tsx
+++ b/packages/twenty-front/src/modules/page-layout/widgets/front-component/components/FrontComponentWidgetRenderer.tsx
@@ -42,7 +42,7 @@ export const FrontComponentWidgetRenderer = ({
   }
 
   const frontComponentId = configuration.frontComponentId;
-  const recordIds = isDefined(targetRecordIdentifier?.id)
+  const selectedRecordIds = isDefined(targetRecordIdentifier?.id)
     ? [targetRecordIdentifier.id]
     : undefined;
 
@@ -51,7 +51,7 @@ export const FrontComponentWidgetRenderer = ({
       <Suspense fallback={null}>
         <FrontComponentRenderer
           frontComponentId={frontComponentId}
-          recordIds={recordIds}
+          selectedRecordIds={selectedRecordIds}
         />
       </Suspense>
     </StyledContainer>

--- a/packages/twenty-front/src/modules/side-panel/pages/front-component/components/SidePanelFrontComponentPage.tsx
+++ b/packages/twenty-front/src/modules/side-panel/pages/front-component/components/SidePanelFrontComponentPage.tsx
@@ -24,7 +24,7 @@ export const SidePanelFrontComponentPage = () => {
     return null;
   }
 
-  const recordIds = isDefined(viewableFrontComponentRecordContext?.recordId)
+  const selectedRecordIds = isDefined(viewableFrontComponentRecordContext?.recordId)
     ? [viewableFrontComponentRecordContext.recordId]
     : undefined;
 
@@ -32,7 +32,7 @@ export const SidePanelFrontComponentPage = () => {
     <Suspense fallback={null}>
       <FrontComponentRenderer
         frontComponentId={viewableFrontComponentId}
-        recordIds={recordIds}
+        selectedRecordIds={selectedRecordIds}
       />
     </Suspense>
   );

--- a/packages/twenty-front/src/modules/side-panel/pages/front-component/components/SidePanelFrontComponentPage.tsx
+++ b/packages/twenty-front/src/modules/side-panel/pages/front-component/components/SidePanelFrontComponentPage.tsx
@@ -24,7 +24,9 @@ export const SidePanelFrontComponentPage = () => {
     return null;
   }
 
-  const selectedRecordIds = isDefined(viewableFrontComponentRecordContext?.recordId)
+  const selectedRecordIds = isDefined(
+    viewableFrontComponentRecordContext?.recordId,
+  )
     ? [viewableFrontComponentRecordContext.recordId]
     : undefined;
 

--- a/packages/twenty-front/src/modules/side-panel/pages/front-component/components/SidePanelFrontComponentPage.tsx
+++ b/packages/twenty-front/src/modules/side-panel/pages/front-component/components/SidePanelFrontComponentPage.tsx
@@ -24,11 +24,15 @@ export const SidePanelFrontComponentPage = () => {
     return null;
   }
 
+  const recordIds = isDefined(viewableFrontComponentRecordContext?.recordId)
+    ? [viewableFrontComponentRecordContext.recordId]
+    : undefined;
+
   return (
     <Suspense fallback={null}>
       <FrontComponentRenderer
         frontComponentId={viewableFrontComponentId}
-        recordId={viewableFrontComponentRecordContext?.recordId}
+        recordIds={recordIds}
       />
     </Suspense>
   );

--- a/packages/twenty-sdk/src/sdk/front-component/hooks/useRecordId.ts
+++ b/packages/twenty-sdk/src/sdk/front-component/hooks/useRecordId.ts
@@ -5,6 +5,10 @@ const selectRecordId = (
   context: FrontComponentExecutionContext,
 ): string | null => context.recordId;
 
+/**
+ * @deprecated Use `useRecordIds` instead. This hook returns only the first
+ * selected record ID or null when multiple records are selected.
+ */
 export const useRecordId = (): string | null => {
   return useFrontComponentExecutionContext(selectRecordId);
 };

--- a/packages/twenty-sdk/src/sdk/front-component/hooks/useRecordId.ts
+++ b/packages/twenty-sdk/src/sdk/front-component/hooks/useRecordId.ts
@@ -4,11 +4,11 @@ import { useFrontComponentExecutionContext } from './useFrontComponentExecutionC
 const selectRecordId = (
   context: FrontComponentExecutionContext,
 ): string | null =>
-  context.recordIds.length === 1 ? context.recordIds[0] : null;
+  context.selectedRecordIds.length === 1 ? context.selectedRecordIds[0] : null;
 
 /**
- * @deprecated Use `useRecordIds()` instead. For single-record operations,
- * use `recordIds.length === 1 ? recordIds[0] : null`.
+ * @deprecated Use `useSelectedRecordIds()` instead. For single-record operations,
+ * use `selectedRecordIds.length === 1 ? selectedRecordIds[0] : null`.
  */
 export const useRecordId = (): string | null => {
   return useFrontComponentExecutionContext(selectRecordId);

--- a/packages/twenty-sdk/src/sdk/front-component/hooks/useRecordId.ts
+++ b/packages/twenty-sdk/src/sdk/front-component/hooks/useRecordId.ts
@@ -3,11 +3,12 @@ import { useFrontComponentExecutionContext } from './useFrontComponentExecutionC
 
 const selectRecordId = (
   context: FrontComponentExecutionContext,
-): string | null => context.recordId;
+): string | null =>
+  context.recordIds.length === 1 ? context.recordIds[0] : null;
 
 /**
- * @deprecated Use `useRecordIds` instead. This hook returns only the first
- * selected record ID or null when multiple records are selected.
+ * Returns the selected record ID when exactly one record is selected,
+ * otherwise returns null. Use `useRecordIds()` for multi-record operations.
  */
 export const useRecordId = (): string | null => {
   return useFrontComponentExecutionContext(selectRecordId);

--- a/packages/twenty-sdk/src/sdk/front-component/hooks/useRecordId.ts
+++ b/packages/twenty-sdk/src/sdk/front-component/hooks/useRecordId.ts
@@ -7,8 +7,8 @@ const selectRecordId = (
   context.recordIds.length === 1 ? context.recordIds[0] : null;
 
 /**
- * Returns the selected record ID when exactly one record is selected,
- * otherwise returns null. Use `useRecordIds()` for multi-record operations.
+ * @deprecated Use `useRecordIds()` instead. For single-record operations,
+ * use `recordIds.length === 1 ? recordIds[0] : null`.
  */
 export const useRecordId = (): string | null => {
   return useFrontComponentExecutionContext(selectRecordId);

--- a/packages/twenty-sdk/src/sdk/front-component/hooks/useRecordIds.ts
+++ b/packages/twenty-sdk/src/sdk/front-component/hooks/useRecordIds.ts
@@ -1,9 +1,8 @@
 import { type FrontComponentExecutionContext } from '../types/FrontComponentExecutionContext';
 import { useFrontComponentExecutionContext } from './useFrontComponentExecutionContext';
 
-const selectRecordIds = (
-  context: FrontComponentExecutionContext,
-): string[] => context.recordIds;
+const selectRecordIds = (context: FrontComponentExecutionContext): string[] =>
+  context.recordIds;
 
 export const useRecordIds = (): string[] => {
   return useFrontComponentExecutionContext(selectRecordIds);

--- a/packages/twenty-sdk/src/sdk/front-component/hooks/useRecordIds.ts
+++ b/packages/twenty-sdk/src/sdk/front-component/hooks/useRecordIds.ts
@@ -1,0 +1,10 @@
+import { type FrontComponentExecutionContext } from '../types/FrontComponentExecutionContext';
+import { useFrontComponentExecutionContext } from './useFrontComponentExecutionContext';
+
+const selectRecordIds = (
+  context: FrontComponentExecutionContext,
+): string[] => context.recordIds;
+
+export const useRecordIds = (): string[] => {
+  return useFrontComponentExecutionContext(selectRecordIds);
+};

--- a/packages/twenty-sdk/src/sdk/front-component/hooks/useRecordIds.ts
+++ b/packages/twenty-sdk/src/sdk/front-component/hooks/useRecordIds.ts
@@ -1,9 +1,0 @@
-import { type FrontComponentExecutionContext } from '../types/FrontComponentExecutionContext';
-import { useFrontComponentExecutionContext } from './useFrontComponentExecutionContext';
-
-const selectRecordIds = (context: FrontComponentExecutionContext): string[] =>
-  context.recordIds;
-
-export const useRecordIds = (): string[] => {
-  return useFrontComponentExecutionContext(selectRecordIds);
-};

--- a/packages/twenty-sdk/src/sdk/front-component/hooks/useSelectedRecordIds.ts
+++ b/packages/twenty-sdk/src/sdk/front-component/hooks/useSelectedRecordIds.ts
@@ -1,0 +1,10 @@
+import { type FrontComponentExecutionContext } from '../types/FrontComponentExecutionContext';
+import { useFrontComponentExecutionContext } from './useFrontComponentExecutionContext';
+
+const selectSelectedRecordIds = (
+  context: FrontComponentExecutionContext,
+): string[] => context.selectedRecordIds;
+
+export const useSelectedRecordIds = (): string[] => {
+  return useFrontComponentExecutionContext(selectSelectedRecordIds);
+};

--- a/packages/twenty-sdk/src/sdk/front-component/index.ts
+++ b/packages/twenty-sdk/src/sdk/front-component/index.ts
@@ -38,7 +38,7 @@ export { updateProgress } from './functions/updateProgress';
 export { useFrontComponentExecutionContext } from './hooks/useFrontComponentExecutionContext';
 export { useFrontComponentId } from './hooks/useFrontComponentId';
 export { useRecordId } from './hooks/useRecordId';
-export { useRecordIds } from './hooks/useRecordIds';
+export { useSelectedRecordIds } from './hooks/useSelectedRecordIds';
 export { useUserId } from './hooks/useUserId';
 export type { FrontComponentExecutionContext } from './types/FrontComponentExecutionContext';
 export { getFrontComponentCommandErrorDedupeKey } from './utils/getFrontComponentCommandErrorDedupeKey';

--- a/packages/twenty-sdk/src/sdk/front-component/index.ts
+++ b/packages/twenty-sdk/src/sdk/front-component/index.ts
@@ -38,6 +38,7 @@ export { updateProgress } from './functions/updateProgress';
 export { useFrontComponentExecutionContext } from './hooks/useFrontComponentExecutionContext';
 export { useFrontComponentId } from './hooks/useFrontComponentId';
 export { useRecordId } from './hooks/useRecordId';
+export { useRecordIds } from './hooks/useRecordIds';
 export { useUserId } from './hooks/useUserId';
 export type { FrontComponentExecutionContext } from './types/FrontComponentExecutionContext';
 export { getFrontComponentCommandErrorDedupeKey } from './utils/getFrontComponentCommandErrorDedupeKey';

--- a/packages/twenty-sdk/src/sdk/front-component/types/FrontComponentExecutionContext.ts
+++ b/packages/twenty-sdk/src/sdk/front-component/types/FrontComponentExecutionContext.ts
@@ -2,8 +2,9 @@ export type FrontComponentExecutionContext = {
   frontComponentId: string;
   userId: string | null;
   /**
-   * @deprecated Use `recordIds` instead. Returns first selected record ID or null.
+   * @deprecated Use `recordIds` instead. Derive single record as `recordIds.length === 1 ? recordIds[0] : null`.
    */
   recordId: string | null;
+  /** All selected record IDs */
   recordIds: string[];
 };

--- a/packages/twenty-sdk/src/sdk/front-component/types/FrontComponentExecutionContext.ts
+++ b/packages/twenty-sdk/src/sdk/front-component/types/FrontComponentExecutionContext.ts
@@ -2,9 +2,9 @@ export type FrontComponentExecutionContext = {
   frontComponentId: string;
   userId: string | null;
   /**
-   * @deprecated Use `recordIds` instead. Derive single record as `recordIds.length === 1 ? recordIds[0] : null`.
+   * @deprecated Use `selectedRecordIds` instead. Derive single record as `selectedRecordIds.length === 1 ? selectedRecordIds[0] : null`.
    */
   recordId: string | null;
   /** All selected record IDs */
-  recordIds: string[];
+  selectedRecordIds: string[];
 };

--- a/packages/twenty-sdk/src/sdk/front-component/types/FrontComponentExecutionContext.ts
+++ b/packages/twenty-sdk/src/sdk/front-component/types/FrontComponentExecutionContext.ts
@@ -1,5 +1,9 @@
 export type FrontComponentExecutionContext = {
   frontComponentId: string;
   userId: string | null;
+  /**
+   * @deprecated Use `recordIds` instead. Returns first selected record ID or null.
+   */
   recordId: string | null;
+  recordIds: string[];
 };


### PR DESCRIPTION
# Introduction

Support multiple selected record ids for headless front components

### Changes

**Added:**
- `recordIds: string[]` field to `FrontComponentExecutionContext`
- `useRecordIds()` hook to get all selected record IDs

**Deprecated:**
- `recordId` field - use `recordIds` instead
- `useRecordId()` hook - use `useRecordIds()` instead

Backward compatibility is preserved