### PR TITLE
fix: don't mark IMAP channel as failed on transient server errors

### DIFF
--- a/packages/twenty-server/src/modules/messaging/message-import-manager/drivers/imap/utils/parse-imap-authentication-error.util.ts
+++ b/packages/twenty-server/src/modules/messaging/message-import-manager/drivers/imap/utils/parse-imap-authentication-error.util.ts
@@ -11,7 +11,7 @@ const TRANSIENT_IMAP_RESPONSE_CODES = new Set([
   'UNAVAILABLE',
   'INUSE',
   'SERVERBUG',
-  'SERVERBUG'
+  'SERVERBUG',
 ]);
 
 export const parseImapAuthenticationError = (

--- a/packages/twenty-server/src/modules/messaging/message-import-manager/drivers/imap/utils/parse-imap-authentication-error.util.ts
+++ b/packages/twenty-server/src/modules/messaging/message-import-manager/drivers/imap/utils/parse-imap-authentication-error.util.ts
@@ -11,7 +11,6 @@ const TRANSIENT_IMAP_RESPONSE_CODES = new Set([
   'UNAVAILABLE',
   'INUSE',
   'SERVERBUG',
-  'SERVERBUG',
 ]);
 
 export const parseImapAuthenticationError = (

--- a/packages/twenty-server/src/modules/messaging/message-import-manager/drivers/imap/utils/parse-imap-authentication-error.util.ts
+++ b/packages/twenty-server/src/modules/messaging/message-import-manager/drivers/imap/utils/parse-imap-authentication-error.util.ts
@@ -1,3 +1,5 @@
+import { isDefined } from 'twenty-shared/utils';
+
 import {
   MessageImportDriverException,
   MessageImportDriverExceptionCode,
@@ -5,12 +7,30 @@ import {
 import { type ImapFlowError } from 'src/modules/messaging/message-import-manager/drivers/imap/types/imap-error.type';
 import { isImapNetworkError } from 'src/modules/messaging/message-import-manager/drivers/imap/utils/is-imap-network-error.util';
 
+const TRANSIENT_IMAP_RESPONSE_CODES = new Set([
+  'UNAVAILABLE',
+  'INUSE',
+  'SERVERBUG',
+  'SERVERBUG'
+]);
+
 export const parseImapAuthenticationError = (
   error: ImapFlowError,
 ): MessageImportDriverException => {
   if (isImapNetworkError(error)) {
     return new MessageImportDriverException(
       `IMAP network error: ${error.message}`,
+      MessageImportDriverExceptionCode.TEMPORARY_ERROR,
+      { cause: error },
+    );
+  }
+
+  if (
+    isDefined(error.serverResponseCode) &&
+    TRANSIENT_IMAP_RESPONSE_CODES.has(error.serverResponseCode)
+  ) {
+    return new MessageImportDriverException(
+      `IMAP transient error [${error.serverResponseCode}]: ${error.responseText ?? error.message}`,
       MessageImportDriverExceptionCode.TEMPORARY_ERROR,
       { cause: error },
     );


### PR DESCRIPTION
Map RFC 5530 codes to `TEMPORARY_ERROR` so sync retries instead of terminally flagging `FAILED_INSUFFICIENT_PERMISSIONS` when the server is briefly unavailable.

prod Logs

```
	2026-05-05 03:53:42.129	
    authenticationFailed: true
	2026-05-05 03:53:42.129	
    serverResponseCode: 'UNAVAILABLE',
	2026-05-05 03:53:42.129	
    responseText: 'Account is temporarily unavailable.',
	2026-05-05 03:53:42.129	
	2026-05-05 03:53:42.129	
    response: '2 NO [UNAVAILABLE] Account is temporarily unavailable.',
	2026-05-05 03:53:42.129	
  cause: Error: Command failed
	2026-05-05 03:53:42.129	
  code: 'INSUFFICIENT_PERMISSIONS',
Caused by: Error: Command failed

[Nest] 35  - 05/04/2026, 10:23:42 PM   ERROR [ImapGetAllFoldersService] MessageImportDriverException: IMAP authentication error: Command failed
```