### PR TITLE
docs: align example name to my-twenty-app across quickstarts

### DIFF
--- a/packages/twenty-docs/getting-started/core-concepts/apps.mdx
+++ b/packages/twenty-docs/getting-started/core-concepts/apps.mdx
@@ -36,8 +36,8 @@ Everything is detected via AST analysis at build time — no config files, no re
 ## The developer experience
 
 ```bash
-npx create-twenty-app@latest my-app
-cd my-app
+npx create-twenty-app@latest my-twenty-app
+cd my-twenty-app
 yarn twenty dev
 ```
 

--- a/packages/twenty-sdk/README.md
+++ b/packages/twenty-sdk/README.md
@@ -19,8 +19,8 @@ A CLI and SDK to develop, build, and publish applications that extend [Twenty CR
 The recommended way to start is with [create-twenty-app](https://www.npmjs.com/package/create-twenty-app):
 
 ```bash
-npx create-twenty-app@latest my-app
-cd my-app
+npx create-twenty-app@latest my-twenty-app
+cd my-twenty-app
 yarn twenty dev
 ```
 


### PR DESCRIPTION
## Summary

The example directory name in our scaffolding instructions was inconsistent across docs:

| Source | Name used |
|--------|-----------|
| `create-twenty-app` README | `my-twenty-app` |
| Getting Started (developer docs) | `my-twenty-app` |
| Core Concepts → Apps (intro doc) | `my-app` ⚠️ |
| `twenty-sdk` README | `my-app` ⚠️ |

This means a user reading the high-level Apps intro sees `my-app`, then the official Getting Started guide and the scaffold use `my-twenty-app`. Small but eroding for confidence on the very first command.

This PR aligns the two outliers to `my-twenty-app`. The `twenty-my-app` example in `publishing.mdx` is left alone — that's an npm package name example, not a directory name (different concept).

## Test plan
- [x] `grep -rn "my-app\b"` over source docs returns no other directory-name occurrences
- [ ] Verify rendered docs after merge