### PR TITLE
fix(website-new): inherit test target so twenty-shared builds in CI

### DIFF
--- a/packages/twenty-website-new/project.json
+++ b/packages/twenty-website-new/project.json
@@ -87,29 +87,7 @@
       ]
     },
     "typecheck": {},
-    "test": {
-      "executor": "@nx/jest:jest",
-      "outputs": ["{projectRoot}/coverage"],
-      "options": {
-        "jestConfig": "{projectRoot}/jest.config.mjs",
-        "silent": true,
-        "coverage": true,
-        "coverageReporters": ["text-summary"],
-        "cacheDirectory": "../../.cache/jest/{projectRoot}"
-      },
-      "configurations": {
-        "ci": {
-          "ci": true,
-          "maxWorkers": 1
-        },
-        "coverage": {
-          "coverageReporters": ["lcov", "text"]
-        },
-        "watch": {
-          "watch": true
-        }
-      }
-    },
+    "test": {},
     "fmt": {
       "options": {
         "files": "."


### PR DESCRIPTION
## Summary
The new `CI Website` workflow added in #20281 fails on the `test` matrix job because tests cannot resolve `twenty-shared/translations` — a subpath that requires `twenty-shared` to be built first.

Root cause: `packages/twenty-website-new/project.json` fully overrides the `test` target, duplicating the executor/options/configurations from `nx.json` `targetDefaults` but **losing `dependsOn: ["^build"]`** (and `inputs` / `cache`). As a result, `nx affected -t test` for `twenty-website-new` does not build `twenty-shared` first.

`twenty-front` works because its `project.json` declares `"test": {}` and inherits the full default. This PR does the same for `twenty-website-new`.

Verified the diagnosis from the failing run — `front-task (test)` logs show `nx run twenty-shared:build` is invoked transitively, while `website-task (test)` logs do not, leading to the missing-module error.
