### PR TITLE
fix: include calling code in phone field unique constraint

### DIFF
--- a/packages/twenty-front/src/modules/settings/data-model/constants/SettingsCompositeFieldTypeConfigs.ts
+++ b/packages/twenty-front/src/modules/settings/data-model/constants/SettingsCompositeFieldTypeConfigs.ts
@@ -1,30 +1,30 @@
 import {
-  type FieldActorValue,
-  type FieldAddressValue,
-  type FieldCurrencyValue,
-  type FieldEmailsValue,
-  type FieldFullNameValue,
-  type FieldLinksValue,
-  type FieldPhonesValue,
-  type FieldRichTextValue,
+    type FieldActorValue,
+    type FieldAddressValue,
+    type FieldCurrencyValue,
+    type FieldEmailsValue,
+    type FieldFullNameValue,
+    type FieldLinksValue,
+    type FieldPhonesValue,
+    type FieldRichTextValue,
 } from '@/object-record/record-field/ui/types/FieldMetadata';
 import { COMPOSITE_FIELD_SUB_FIELD_LABELS } from '@/settings/data-model/constants/CompositeFieldSubFieldLabel';
 import { type SettingsFieldTypeConfig } from '@/settings/data-model/constants/SettingsNonCompositeFieldTypeConfigs';
 import { type CompositeFieldType } from '@/settings/data-model/types/CompositeFieldType';
 import {
-  COMPOSITE_FIELD_TYPE_SUB_FIELDS_NAMES,
-  CurrencyCode,
+    COMPOSITE_FIELD_TYPE_SUB_FIELDS_NAMES,
+    CurrencyCode,
 } from 'twenty-shared/constants';
 import { ConnectedAccountProvider } from 'twenty-shared/types';
 import {
-  IllustrationIconCurrency,
-  IllustrationIconLink,
-  IllustrationIconMail,
-  IllustrationIconMap,
-  IllustrationIconPhone,
-  IllustrationIconSetting,
-  IllustrationIconText,
-  IllustrationIconUser,
+    IllustrationIconCurrency,
+    IllustrationIconLink,
+    IllustrationIconMail,
+    IllustrationIconMap,
+    IllustrationIconPhone,
+    IllustrationIconSetting,
+    IllustrationIconText,
+    IllustrationIconUser,
 } from 'twenty-ui/display';
 import { FieldMetadataType } from '~/generated-metadata/graphql';
 
@@ -209,7 +209,7 @@ export const SETTINGS_COMPOSITE_FIELD_TYPE_CONFIGS = {
             .primaryPhoneCallingCode,
         isImportable: true,
         isFilterable: true,
-        isIncludedInUniqueConstraint: false,
+        isIncludedInUniqueConstraint: true,
       },
       {
         subFieldName:

--- a/packages/twenty-shared/src/types/composite-types/phones.composite-type.ts
+++ b/packages/twenty-shared/src/types/composite-types/phones.composite-type.ts
@@ -23,6 +23,7 @@ export const phonesCompositeType: CompositeType = {
       type: FieldMetadataType.TEXT,
       hidden: false,
       isRequired: false,
+      isIncludedInUniqueConstraint: true,
     },
     {
       name: 'additionalPhones',


### PR DESCRIPTION
## Summary

Fixes #20195
Related #20261
### Problem
When a unique constraint is enabled on a PHONES field, the unique index only covers the `primaryPhoneNumber` sub-column, ignoring `primaryPhoneCallingCode`. This causes false duplicate errors when two records have the same national number but different country calling codes (e.g., +1 123456789 vs +32 123456789).

### Solution
Added `isIncludedInUniqueConstraint: true` to `primaryPhoneCallingCode` in the phones composite type definition. This ensures unique indexes for phone fields include both the phone number AND the calling code.

### Changes
1. **`packages/twenty-shared/src/types/composite-types/phones.composite-type.ts`**:
   - Added `isIncludedInUniqueConstraint: true` to `primaryPhoneCallingCode` property
   
2. **`packages/twenty-front/src/modules/settings/data-model/constants/SettingsCompositeFieldTypeConfigs.ts`**:
   - Updated frontend configuration to reflect that `primaryPhoneCallingCode` is included in unique constraints

### Technical Details
- Phone fields are "composite fields" consisting of multiple sub-fields
- The `isIncludedInUniqueConstraint` flag determines which sub-fields are included in database unique indexes
- Previously only `primaryPhoneNumber` was included, now both `primaryPhoneNumber` AND `primaryPhoneCallingCode` are included
- This creates a compound unique index: `(primaryPhoneNumber, primaryPhoneCallingCode)`

### Impact
- ✅ Phone number uniqueness now properly considers both number and calling code
- ✅ International phone numbers with same digits but different country codes are no longer incorrectly flagged as duplicates
- ✅ Example: `+1 123456789` (USA) and `+32 123456789` (Belgium) are now correctly treated as different numbers
- ✅ Database unique indexes will be compound indexes on both fields
- ✅ Minimal code changes - leverages existing architecture

### Testing
- Test with `+1 123456789` and `+32 123456789` (should NOT be duplicates)
- Test with `+1 123456789` and `+1 123456789` (SHOULD be duplicates)
- Test with null/empty calling codes
- Existing tests for phone field uniqueness should be updated to verify both fields

### Notes
- This fix requires database migration for existing unique indexes on phone fields
- The `primaryPhoneCountryCode` field is not included in uniqueness as `primaryPhoneCallingCode` is sufficient for distinguishing international numbers
- The `additionalPhones` JSON array is not affected by this change (handled separately if at all)
