### PR TITLE
Fix root monorepo package json focused installation

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "@nx/web": "22.5.4",
     "@types/react": "^18.2.39",
     "@types/react-dom": "^18.2.15",
+    "@yarnpkg/types": "^4.0.0",
     "concurrently": "^8.2.2",
     "http-server": "^14.1.1",
     "nx": "22.5.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -54951,6 +54951,7 @@ __metadata:
     "@nx/web": "npm:22.5.4"
     "@types/react": "npm:^18.2.39"
     "@types/react-dom": "npm:^18.2.15"
+    "@yarnpkg/types": "npm:^4.0.0"
     concurrently: "npm:^8.2.2"
     http-server: "npm:^14.1.1"
     nx: "npm:22.5.4"


### PR DESCRIPTION
# Introduction
Running `yarn workspace focus twenty`( only installing root package.json dependencies ) would fail because the yarn constraint expect the yarn types to be installed