### PR TITLE
fix: allow rich text side panel content to scroll

### DIFF
--- a/packages/twenty-front/src/modules/side-panel/components/SidePanelContainer.tsx
+++ b/packages/twenty-front/src/modules/side-panel/components/SidePanelContainer.tsx
@@ -22,6 +22,7 @@ const StyledSidePanelContainer = styled.div<{ isMobile: boolean }>`
 
     return `calc(100% - ${mobileOffset})`;
   }};
+  min-height: 0;
 `;
 
 type SidePanelContainerProps = {

--- a/packages/twenty-front/src/modules/side-panel/components/SidePanelRouter.tsx
+++ b/packages/twenty-front/src/modules/side-panel/components/SidePanelRouter.tsx
@@ -15,6 +15,7 @@ import { ThemeContext } from 'twenty-ui/theme-constants';
 
 const StyledSidePanelContent = styled.div`
   flex: 1;
+  min-height: 0;
   overflow-y: auto;
 `;
 

--- a/packages/twenty-front/src/modules/side-panel/pages/rich-text-page/components/SidePanelEditRichTextPage.tsx
+++ b/packages/twenty-front/src/modules/side-panel/pages/rich-text-page/components/SidePanelEditRichTextPage.tsx
@@ -22,8 +22,18 @@ const RichTextFieldEditor = lazy(() =>
 );
 
 const StyledContainer = styled.div`
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  min-height: 0;
+`;
+
+const StyledContent = styled.div`
   box-sizing: border-box;
+  flex: 1;
   margin: ${themeCssVariables.spacing[4]} -8px;
+  min-height: 0;
+  overflow-y: auto;
   padding-inline: 44px 0px;
   width: 100%;
 `;
@@ -56,20 +66,22 @@ export const SidePanelEditRichTextPage = () => {
 
   return (
     <StyledContainer>
-      <Suspense fallback={<LoadingSkeleton />}>
-        {isActivityObject(objectNameSingular) ? (
-          <ActivityRichTextEditor
-            activityId={recordId}
-            activityObjectNameSingular={objectNameSingular}
-          />
-        ) : (
-          <RichTextFieldEditor
-            recordId={recordId}
-            objectNameSingular={objectNameSingular}
-            fieldName={fieldName}
-          />
-        )}
-      </Suspense>
+      <StyledContent>
+        <Suspense fallback={<LoadingSkeleton />}>
+          {isActivityObject(objectNameSingular) ? (
+            <ActivityRichTextEditor
+              activityId={recordId}
+              activityObjectNameSingular={objectNameSingular}
+            />
+          ) : (
+            <RichTextFieldEditor
+              recordId={recordId}
+              objectNameSingular={objectNameSingular}
+              fieldName={fieldName}
+            />
+          )}
+        </Suspense>
+      </StyledContent>
     </StyledContainer>
   );
 };


### PR DESCRIPTION
## Summary
Closes #20309

Allow long `RICH_TEXT` field content to scroll inside the expanded side panel. The rich text page previously used a single unconstrained container, so long BlockNote content could expand beyond the panel and become inaccessible.

## Changes
- Add a full-height flex wrapper to `SidePanelEditRichTextPage`.
- Add an inner scrollable content area with `flex: 1` and `overflow-y: auto`.
- Preserve the existing rich text spacing and editor rendering.

## Test plan
- Open a record with a long `RICH_TEXT` field.
- Expand the rich text field into the side panel.
- Verify vertical scrolling works.
- Verify the full rich text content is accessible.


