### PR TITLE
Nest command unhandled error process exit 1

### DIFF
--- a/packages/twenty-docker/twenty-app-dev/rootfs/etc/s6-overlay/scripts/init-db.sh
+++ b/packages/twenty-docker/twenty-app-dev/rootfs/etc/s6-overlay/scripts/init-db.sh
@@ -34,25 +34,27 @@ has_schema=$(PGPASSWORD=twenty psql -h localhost -U twenty -d default -tAc \
   "SELECT EXISTS (SELECT 1 FROM information_schema.schemata WHERE schema_name = 'core')")
 
 if [ "$has_schema" = "f" ]; then
-  step_start "Running initial database setup"
-  NODE_OPTIONS="--max-old-space-size=1500" node ./dist/database/scripts/setup-db.js
+  step_start "Running initial database setup and migrations"
+  yarn database:init:prod
   step_done
 fi
 
-step_start "Running migrations"
-yarn database:migrate:prod --force
-step_done
-
 step_start "Flushing cache"
-yarn command:prod cache:flush
+if ! yarn command:prod cache:flush; then
+  echo "Warning: Failed to flush cache before upgrade, but continuing startup..."
+fi
 step_done
 
 step_start "Running upgrade"
-yarn command:prod upgrade
+if ! yarn command:prod upgrade; then
+  echo "Warning: Upgrade completed with errors. Some workspaces may not be fully migrated. Check logs for details."
+fi
 step_done
 
 step_start "Flushing cache"
-yarn command:prod cache:flush
+if ! yarn command:prod cache:flush; then
+  echo "Warning: Failed to flush cache after upgrade, but continuing startup..."
+fi
 step_done
 
 # Only seed on first boot — check if the dev workspace already exists

--- a/packages/twenty-docker/twenty/entrypoint.sh
+++ b/packages/twenty-docker/twenty/entrypoint.sh
@@ -16,9 +16,17 @@ setup_and_migrate_db() {
         yarn database:init:prod
     fi
 
-    yarn command:prod cache:flush
-    yarn command:prod upgrade
-    yarn command:prod cache:flush
+    if ! yarn command:prod cache:flush; then
+        echo "Warning: Failed to flush cache before upgrade, but continuing startup..."
+    fi
+
+    if ! yarn command:prod upgrade; then
+        echo "Warning: Upgrade completed with errors. Some workspaces may not be fully migrated. Check logs for details."
+    fi
+
+    if ! yarn command:prod cache:flush; then
+        echo "Warning: Failed to flush cache after upgrade, but continuing startup..."
+    fi
 
     echo "Successfully migrated DB!"
 }

--- a/packages/twenty-server/src/command/command.ts
+++ b/packages/twenty-server/src/command/command.ts
@@ -13,6 +13,8 @@ async function bootstrap() {
     if (shouldCaptureException(err)) {
       exceptionHandlerService.captureExceptions([err]);
     }
+
+    process.exitCode = 1;
   };
 
   const app = await CommandFactory.createWithoutRunning(CommandModule, {


### PR DESCRIPTION
# Introduction
When running the `run-instance-commands` on a migration failure the process wouldn't throw at all
Leading to conditional flow to keep going whereas it should have stopped
This update is very invasive and impacts all the nest commander registered commands
We should keep in mind that it impacts the way we create and init database and so on

But I think that's for the best, as cli that never exit 1 is counterintuitive