### PR TITLE
Remove broken total count from workflow version

### DIFF
--- a/packages/twenty-front/src/modules/workflow/hooks/useWorkflowVersion.ts
+++ b/packages/twenty-front/src/modules/workflow/hooks/useWorkflowVersion.ts
@@ -1,9 +1,11 @@
 import { useFindOneRecord } from '@/object-record/hooks/useFindOneRecord';
-import { type WorkflowVersion } from '@/workflow/types/Workflow';
+import { type Workflow, type WorkflowVersion } from '@/workflow/types/Workflow';
 import { CoreObjectNameSingular } from 'twenty-shared/types';
 
 export const useWorkflowVersion = (workflowVersionId?: string) => {
-  const { record: workflowVersion } = useFindOneRecord<WorkflowVersion>({
+  const { record: workflowVersion } = useFindOneRecord<
+    WorkflowVersion & { workflow: Pick<Workflow, 'id' | 'name'> }
+  >({
     objectNameSingular: CoreObjectNameSingular.WorkflowVersion,
     objectRecordId: workflowVersionId,
     recordGqlFields: {

--- a/packages/twenty-front/src/modules/workflow/hooks/useWorkflowVersion.ts
+++ b/packages/twenty-front/src/modules/workflow/hooks/useWorkflowVersion.ts
@@ -1,15 +1,9 @@
-import { CoreObjectNameSingular } from 'twenty-shared/types';
 import { useFindOneRecord } from '@/object-record/hooks/useFindOneRecord';
-import { type Workflow, type WorkflowVersion } from '@/workflow/types/Workflow';
+import { type WorkflowVersion } from '@/workflow/types/Workflow';
+import { CoreObjectNameSingular } from 'twenty-shared/types';
 
 export const useWorkflowVersion = (workflowVersionId?: string) => {
-  const { record: workflowVersion } = useFindOneRecord<
-    WorkflowVersion & {
-      workflow: Omit<Workflow, 'versions'> & {
-        versions: Array<{ __typename: string }>;
-      };
-    }
-  >({
+  const { record: workflowVersion } = useFindOneRecord<WorkflowVersion>({
     objectNameSingular: CoreObjectNameSingular.WorkflowVersion,
     objectRecordId: workflowVersionId,
     recordGqlFields: {
@@ -24,10 +18,6 @@ export const useWorkflowVersion = (workflowVersionId?: string) => {
       workflow: {
         id: true,
         name: true,
-        statuses: true,
-        versions: {
-          totalCount: true,
-        },
       },
     },
     skip: !workflowVersionId,

--- a/packages/twenty-front/src/modules/workflow/hooks/useWorkflowWithCurrentVersion.ts
+++ b/packages/twenty-front/src/modules/workflow/hooks/useWorkflowWithCurrentVersion.ts
@@ -1,6 +1,5 @@
 import { useEffect } from 'react';
 
-import { CoreObjectNameSingular } from 'twenty-shared/types';
 import { useFindOneRecord } from '@/object-record/hooks/useFindOneRecord';
 import { useAtomFamilyStateValue } from '@/ui/utilities/state/jotai/hooks/useAtomFamilyStateValue';
 import { useSetAtomFamilyState } from '@/ui/utilities/state/jotai/hooks/useSetAtomFamilyState';
@@ -10,6 +9,7 @@ import {
   type WorkflowVersion,
   type WorkflowWithCurrentVersion,
 } from '@/workflow/types/Workflow';
+import { CoreObjectNameSingular } from 'twenty-shared/types';
 import { isDefined } from 'twenty-shared/utils';
 
 type WorkflowWithAllVersions = Omit<Workflow, 'versions'> & {


### PR DESCRIPTION
## Problem

Opening a workflow run with a form step in the side panel, closing the form and reopening it crashes the app: `<SidePanelWorkflowStepInfo>` blows up on `workflow.versions.find` because `versions` is `null` in the Apollo cache.

## Root cause

`useWorkflowVersion` was selecting:

```ts
workflow: { id, name, statuses, versions: { totalCount: true } }
```
Twenty's GraphQL field generator doesn't support connection-level scalars — { totalCount: true } is interpreted as fields on the inner WorkflowVersion node, gets filtered out, and the query collapses to:
versions { edges { node { __typename } } }
The server returns versions: null for that empty-node selection. 

Why now
The selection has always been wrong, but two recent changes made it consistently surface:

Apollo Client v4 upgrade (#18584): stricter normalized writes, null always wins.
#20242: WorkflowRunSSESubscribeEffect in the form filler keeps SSE flowing, which re-fires useWorkflowVersion more often, making the bad query consistently the last writer.