### PR TITLE
External contributor auto-draft and dispatch pr-review event type

### DIFF
--- a/.github/workflows/external-contributor-pr-auto-draft.yaml
+++ b/.github/workflows/external-contributor-pr-auto-draft.yaml
@@ -1,0 +1,37 @@
+name: Auto-Draft External PRs
+
+on:
+  pull_request_target:
+    types: [opened]
+
+jobs:
+  convert-to-draft:
+    if: |
+      github.event.pull_request.draft == false &&
+      github.event.pull_request.author_association != 'MEMBER' &&
+      github.event.pull_request.author_association != 'OWNER' &&
+      github.event.pull_request.author_association != 'COLLABORATOR'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Convert to draft
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh api graphql -f query='
+            mutation {
+              convertPullRequestToDraft(input: {pullRequestId: "${{ github.event.pull_request.node_id }}"}) {
+                pullRequest { isDraft }
+              }
+            }
+          '
+
+      - name: Welcome comment
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh pr comment ${{ github.event.pull_request.number }} --repo ${{ github.repository }} --body "👋 Thanks for contributing to Twenty!
+
+          Your PR has been set to draft while you work on it. Once you're done, mark it as **Ready for review** and our automated checks will run.
+
+          Looking forward to your contribution!"

--- a/.github/workflows/external-contributor-pr-auto-draft.yaml
+++ b/.github/workflows/external-contributor-pr-auto-draft.yaml
@@ -4,6 +4,9 @@ on:
   pull_request_target:
     types: [opened]
 
+permissions:
+  pull-requests: write
+
 jobs:
   convert-to-draft:
     if: |
@@ -17,20 +20,22 @@ jobs:
       - name: Convert to draft
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NODE_ID: ${{ github.event.pull_request.node_id }}
         run: |
-          gh api graphql -f query='
+          gh api graphql -f query="
             mutation {
-              convertPullRequestToDraft(input: {pullRequestId: "${{ github.event.pull_request.node_id }}"}) {
+              convertPullRequestToDraft(input: {pullRequestId: \"$PR_NODE_ID\"}) {
                 pullRequest { isDraft }
               }
             }
-          '
+          "
 
       - name: Welcome comment
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
         run: |
-          gh pr comment ${{ github.event.pull_request.number }} --repo ${{ github.repository }} --body "👋 Thanks for contributing to Twenty!
+          gh pr comment "$PR_NUMBER" --repo ${{ github.repository }} --body "👋 Thanks for contributing to Twenty!
 
           Your PR has been set to draft while you work on it. Once you're done, mark it as **Ready for review** and our automated checks will run.
 

--- a/.github/workflows/pr-auto-review-dispatch.yaml
+++ b/.github/workflows/pr-auto-review-dispatch.yaml
@@ -1,0 +1,30 @@
+name: PR Review Dispatch
+
+on:
+  pull_request_target:
+    types: [ready_for_review, synchronize]
+
+concurrency:
+  group: pr-review-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  dispatch:
+    # Remove prastoin condition when tested and working
+    if: |
+      github.event.pull_request.draft == false &&
+      github.event.pull_request.user.login == 'prastoin'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Dispatch to ci-privileged
+        env:
+          GH_TOKEN: ${{ secrets.CI_PRIVILEGED_DISPATCH_TOKEN }}
+        run: |
+          gh api repos/twentyhq/ci-privileged/dispatches \
+            -f event_type=pr-review \
+            -f 'client_payload[pr_number]=${{ github.event.pull_request.number }}' \
+            -f 'client_payload[pr_head_sha]=${{ github.event.pull_request.head.sha }}' \
+            -f 'client_payload[pr_author]=${{ github.event.pull_request.user.login }}' \
+            -f 'client_payload[pr_author_association]=${{ github.event.pull_request.author_association }}' \
+            -f 'client_payload[repo]=${{ github.repository }}'

--- a/.github/workflows/pr-auto-review-dispatch.yaml
+++ b/.github/workflows/pr-auto-review-dispatch.yaml
@@ -12,10 +12,7 @@ concurrency:
 
 jobs:
   dispatch:
-    # Remove prastoin condition when tested and working
-    if: |
-      github.event.pull_request.draft == false &&
-      github.event.pull_request.user.login == 'prastoin'
+    if: github.event.pull_request.draft == false
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:

--- a/.github/workflows/pr-auto-review-dispatch.yaml
+++ b/.github/workflows/pr-auto-review-dispatch.yaml
@@ -4,6 +4,8 @@ on:
   pull_request_target:
     types: [ready_for_review, synchronize]
 
+permissions: {}
+
 concurrency:
   group: pr-review-${{ github.event.pull_request.number }}
   cancel-in-progress: true
@@ -20,11 +22,16 @@ jobs:
       - name: Dispatch to ci-privileged
         env:
           GH_TOKEN: ${{ secrets.CI_PRIVILEGED_DISPATCH_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          PR_AUTHOR: ${{ github.event.pull_request.user.login }}
+          PR_AUTHOR_ASSOCIATION: ${{ github.event.pull_request.author_association }}
+          REPO: ${{ github.repository }}
         run: |
           gh api repos/twentyhq/ci-privileged/dispatches \
             -f event_type=pr-review \
-            -f 'client_payload[pr_number]=${{ github.event.pull_request.number }}' \
-            -f 'client_payload[pr_head_sha]=${{ github.event.pull_request.head.sha }}' \
-            -f 'client_payload[pr_author]=${{ github.event.pull_request.user.login }}' \
-            -f 'client_payload[pr_author_association]=${{ github.event.pull_request.author_association }}' \
-            -f 'client_payload[repo]=${{ github.repository }}'
+            -f "client_payload[pr_number]=$PR_NUMBER" \
+            -f "client_payload[pr_head_sha]=$PR_HEAD_SHA" \
+            -f "client_payload[pr_author]=$PR_AUTHOR" \
+            -f "client_payload[pr_author_association]=$PR_AUTHOR_ASSOCIATION" \
+            -f "client_payload[repo]=$REPO"


### PR DESCRIPTION
# Introduction

## Auto draft
On external contributor PR creation auto draft it and comment stating that it needs to be marked as ready for review when it is

## Caveats / future improvement
Lets iterate first but we can imagine future pain points such as:
- Cubic only runs on ready for review PRs
- Expected green ci before turning ready to be review ? ( we could invoke cubic ourselves )\
- Auto close external contributors draft PR after x duration

## Auto review
Once a PR started to be review or is being synchronized then auto dispatch auto review