### PR TITLE
Fix plan-required modal issue

### DIFF
--- a/packages/twenty-front/src/modules/metadata-store/components/MinimalMetadataGater.tsx
+++ b/packages/twenty-front/src/modules/metadata-store/components/MinimalMetadataGater.tsx
@@ -21,7 +21,9 @@ export const MinimalMetadataGater = ({ children }: React.PropsWithChildren) => {
     isMatchingLocation(location, AppPath.SignInUp) ||
     isMatchingLocation(location, AppPath.Invite) ||
     isMatchingLocation(location, AppPath.ResetPassword) ||
-    isMatchingLocation(location, AppPath.CreateWorkspace);
+    isMatchingLocation(location, AppPath.CreateWorkspace) ||
+    isMatchingLocation(location, AppPath.PlanRequired) ||
+    isMatchingLocation(location, AppPath.PlanRequiredSuccess);
 
   const shouldShowLoader = !isMinimalMetadataReady && !isOnExcludedPath;
 


### PR DESCRIPTION
Commit ee6c0ef904 (Replace sign-in mocked metadata with hardcoded BackgroundMock) removed the mocked metadata loading path in MinimalMetadataLoadEffect. Before this change, users with an access token but an inactive workspace (plan-required state) would get mocked metadata loaded, which satisfied IsMinimalMetadataReadyEffect's areObjectsLoaded check. After the change, shouldLoadRealMetadata = hasAccessTokenPair && isActiveWorkspace is false for plan-required users, so nothing is loaded, isMinimalMetadataReady stays false, and MinimalMetadataGater renders the loading skeleton forever instead of the actual auth modal content.

Fix: Add AppPath.PlanRequired and AppPath.PlanRequiredSuccess to isOnExcludedPath in MinimalMetadataGater, mirroring how AppPath.Invite is already excluded — both are pages where the user may have a token but the workspace isn't fully active, so they don't need metadata to render.