### PR TITLE
Oxlint ignore twenty-version constant

### DIFF
--- a/packages/twenty-server/.oxlintrc.json
+++ b/packages/twenty-server/.oxlintrc.json
@@ -14,7 +14,10 @@
     "src/utils/email-providers.ts",
     "src/engine/core-modules/i18n/locales/generated/**",
     "src/engine/core-modules/logic-function/logic-function-resource/constants/seed-project/src/index.ts",
-    "src/engine/metadata-modules/front-component/constants/seed-project/**"
+    "src/engine/metadata-modules/front-component/constants/seed-project/**",
+    "src/engine/core-modules/upgrade/constants/twenty-current-version.constant.ts",
+    "src/engine/core-modules/upgrade/constants/twenty-previous-versions.constant.ts",
+    "src/engine/core-modules/upgrade/constants/twenty-next-versions.constant.ts"
   ],
   "rules": {
     "func-style": ["error", "declaration", { "allowArrowFunctions": true }],


### PR DESCRIPTION
# Introduction
We could handle that by installing prettier on the package.json root and running it over the twenty versions files inside the ci.
But to be honest it seems redundant, and would bloat the ci in the end. Lets just not care about lint in these codegen files

Related https://github.com/twentyhq/twenty/pull/20345