### PR TITLE
Fix docs apps navigation

### DIFF
--- a/packages/twenty-docs/docs.json
+++ b/packages/twenty-docs/docs.json
@@ -374,15 +374,65 @@
               {
                 "group": "Apps",
                 "pages": [
-                  "developers/extend/apps/getting-started",
-                  "developers/extend/apps/building",
-                  "developers/extend/apps/data-model",
-                  "developers/extend/apps/logic-functions",
-                  "developers/extend/apps/front-components",
-                  "developers/extend/apps/layout",
-                  "developers/extend/apps/skills-and-agents",
-                  "developers/extend/apps/cli-and-testing",
-                  "developers/extend/apps/publishing"
+                  {
+                    "group": "Getting Started",
+                    "pages": [
+                      "developers/extend/apps/getting-started/quick-start",
+                      "developers/extend/apps/getting-started/concepts",
+                      "developers/extend/apps/getting-started/project-structure",
+                      "developers/extend/apps/getting-started/local-server",
+                      "developers/extend/apps/getting-started/scaffolding",
+                      "developers/extend/apps/getting-started/troubleshooting"
+                    ]
+                  },
+                  {
+                    "group": "Config",
+                    "pages": [
+                      "developers/extend/apps/config/overview",
+                      "developers/extend/apps/config/application",
+                      "developers/extend/apps/config/roles",
+                      "developers/extend/apps/config/install-hooks",
+                      "developers/extend/apps/config/public-assets"
+                    ]
+                  },
+                  {
+                    "group": "Data",
+                    "pages": [
+                      "developers/extend/apps/data/overview",
+                      "developers/extend/apps/data/objects",
+                      "developers/extend/apps/data/extending-objects",
+                      "developers/extend/apps/data/relations"
+                    ]
+                  },
+                  {
+                    "group": "Logic",
+                    "pages": [
+                      "developers/extend/apps/logic/overview",
+                      "developers/extend/apps/logic/logic-functions",
+                      "developers/extend/apps/logic/skills-and-agents",
+                      "developers/extend/apps/logic/connections"
+                    ]
+                  },
+                  {
+                    "group": "Layout",
+                    "pages": [
+                      "developers/extend/apps/layout/overview",
+                      "developers/extend/apps/layout/views",
+                      "developers/extend/apps/layout/navigation-menu-items",
+                      "developers/extend/apps/layout/page-layouts",
+                      "developers/extend/apps/layout/front-components",
+                      "developers/extend/apps/layout/command-menu-items"
+                    ]
+                  },
+                  {
+                    "group": "Operations",
+                    "pages": [
+                      "developers/extend/apps/operations/overview",
+                      "developers/extend/apps/operations/cli",
+                      "developers/extend/apps/operations/testing",
+                      "developers/extend/apps/operations/publishing"
+                    ]
+                  }
                 ]
               },
               {
@@ -424,22 +474,22 @@
               {
                 "group": "Welcome",
                 "pages": [
-                  "l/fr/getting-started/introduction",
-                  "l/fr/getting-started/key-features",
-                  "l/fr/getting-started/quickstart"
+                  "getting-started/introduction",
+                  "getting-started/key-features",
+                  "getting-started/quickstart"
                 ]
               },
               {
                 "group": "Core Concepts",
                 "pages": [
-                  "l/fr/getting-started/core-concepts/data-model",
-                  "l/fr/getting-started/core-concepts/layout",
-                  "l/fr/getting-started/core-concepts/workflows",
-                  "l/fr/getting-started/core-concepts/calendar-and-email",
-                  "l/fr/getting-started/core-concepts/ai",
-                  "l/fr/getting-started/core-concepts/apps",
-                  "l/fr/getting-started/core-concepts/dashboards",
-                  "l/fr/getting-started/core-concepts/glossary"
+                  "getting-started/core-concepts/data-model",
+                  "getting-started/core-concepts/layout",
+                  "getting-started/core-concepts/workflows",
+                  "getting-started/core-concepts/calendar-and-email",
+                  "getting-started/core-concepts/ai",
+                  "getting-started/core-concepts/apps",
+                  "getting-started/core-concepts/dashboards",
+                  "getting-started/core-concepts/glossary"
                 ]
               }
             ]
@@ -568,7 +618,7 @@
                           "l/fr/user-guide/workflows/how-tos/crm-automations/display-related-record-data",
                           "l/fr/user-guide/workflows/how-tos/crm-automations/closed-won-automations",
                           "l/fr/user-guide/workflows/how-tos/crm-automations/detect-stale-opportunities",
-                          "l/fr/user-guide/workflows/how-tos/crm-automations/auto-reply-to-inbound-emails"
+                          "user-guide/workflows/how-tos/crm-automations/auto-reply-to-inbound-emails"
                         ]
                       },
                       {
@@ -624,11 +674,11 @@
                 "group": "Layout",
                 "icon": "table-columns",
                 "pages": [
-                  "l/fr/user-guide/layout/overview",
+                  "user-guide/layout/overview",
                   {
                     "group": "Reference",
                     "pages": [
-                      "l/fr/user-guide/layout/capabilities/navigation",
+                      "user-guide/layout/capabilities/navigation",
                       {
                         "group": "Views",
                         "pages": [
@@ -640,7 +690,7 @@
                           "l/fr/user-guide/views-pipelines/capabilities/view-settings"
                         ]
                       },
-                      "l/fr/user-guide/layout/capabilities/record-pages"
+                      "user-guide/layout/capabilities/record-pages"
                     ]
                   },
                   {
@@ -757,23 +807,73 @@
               {
                 "group": "Apps",
                 "pages": [
-                  "l/fr/developers/extend/apps/getting-started",
-                  "l/fr/developers/extend/apps/building",
-                  "l/fr/developers/extend/apps/data-model",
-                  "l/fr/developers/extend/apps/logic-functions",
-                  "l/fr/developers/extend/apps/front-components",
-                  "l/fr/developers/extend/apps/layout",
-                  "l/fr/developers/extend/apps/skills-and-agents",
-                  "l/fr/developers/extend/apps/cli-and-testing",
-                  "l/fr/developers/extend/apps/publishing"
+                  {
+                    "group": "Getting Started",
+                    "pages": [
+                      "developers/extend/apps/getting-started/quick-start",
+                      "developers/extend/apps/getting-started/concepts",
+                      "developers/extend/apps/getting-started/project-structure",
+                      "developers/extend/apps/getting-started/local-server",
+                      "developers/extend/apps/getting-started/scaffolding",
+                      "developers/extend/apps/getting-started/troubleshooting"
+                    ]
+                  },
+                  {
+                    "group": "Config",
+                    "pages": [
+                      "developers/extend/apps/config/overview",
+                      "developers/extend/apps/config/application",
+                      "developers/extend/apps/config/roles",
+                      "developers/extend/apps/config/install-hooks",
+                      "developers/extend/apps/config/public-assets"
+                    ]
+                  },
+                  {
+                    "group": "Data",
+                    "pages": [
+                      "developers/extend/apps/data/overview",
+                      "developers/extend/apps/data/objects",
+                      "developers/extend/apps/data/extending-objects",
+                      "developers/extend/apps/data/relations"
+                    ]
+                  },
+                  {
+                    "group": "Logic",
+                    "pages": [
+                      "developers/extend/apps/logic/overview",
+                      "developers/extend/apps/logic/logic-functions",
+                      "developers/extend/apps/logic/skills-and-agents",
+                      "developers/extend/apps/logic/connections"
+                    ]
+                  },
+                  {
+                    "group": "Layout",
+                    "pages": [
+                      "developers/extend/apps/layout/overview",
+                      "developers/extend/apps/layout/views",
+                      "developers/extend/apps/layout/navigation-menu-items",
+                      "developers/extend/apps/layout/page-layouts",
+                      "developers/extend/apps/layout/front-components",
+                      "developers/extend/apps/layout/command-menu-items"
+                    ]
+                  },
+                  {
+                    "group": "Operations",
+                    "pages": [
+                      "developers/extend/apps/operations/overview",
+                      "developers/extend/apps/operations/cli",
+                      "developers/extend/apps/operations/testing",
+                      "developers/extend/apps/operations/publishing"
+                    ]
+                  }
                 ]
               },
               {
                 "group": "API",
                 "pages": [
-                  "l/fr/developers/extend/api",
-                  "l/fr/developers/extend/webhooks",
-                  "l/fr/developers/extend/oauth"
+                  "developers/extend/api",
+                  "developers/extend/webhooks",
+                  "developers/extend/oauth"
                 ]
               },
               {
@@ -790,8 +890,8 @@
                 "group": "Contribuer",
                 "pages": [
                   "l/fr/developers/contribute/capabilities/local-setup",
-                  "l/fr/developers/contribute/commands",
-                  "l/fr/developers/contribute/style-guide"
+                  "developers/contribute/commands",
+                  "developers/contribute/style-guide"
                 ]
               }
             ]
@@ -807,22 +907,22 @@
               {
                 "group": "مرحبًا",
                 "pages": [
-                  "l/ar/getting-started/introduction",
-                  "l/ar/getting-started/key-features",
-                  "l/ar/getting-started/quickstart"
+                  "getting-started/introduction",
+                  "getting-started/key-features",
+                  "getting-started/quickstart"
                 ]
               },
               {
                 "group": "المفاهيم الأساسية",
                 "pages": [
-                  "l/ar/getting-started/core-concepts/data-model",
-                  "l/ar/getting-started/core-concepts/layout",
-                  "l/ar/getting-started/core-concepts/workflows",
-                  "l/ar/getting-started/core-concepts/calendar-and-email",
-                  "l/ar/getting-started/core-concepts/ai",
-                  "l/ar/getting-started/core-concepts/apps",
-                  "l/ar/getting-started/core-concepts/dashboards",
-                  "l/ar/getting-started/core-concepts/glossary"
+                  "getting-started/core-concepts/data-model",
+                  "getting-started/core-concepts/layout",
+                  "getting-started/core-concepts/workflows",
+                  "getting-started/core-concepts/calendar-and-email",
+                  "getting-started/core-concepts/ai",
+                  "getting-started/core-concepts/apps",
+                  "getting-started/core-concepts/dashboards",
+                  "getting-started/core-concepts/glossary"
                 ]
               }
             ]
@@ -1140,15 +1240,65 @@
               {
                 "group": "التطبيقات",
                 "pages": [
-                  "l/ar/developers/extend/apps/getting-started",
-                  "l/ar/developers/extend/apps/building",
-                  "l/ar/developers/extend/apps/data-model",
-                  "l/ar/developers/extend/apps/logic-functions",
-                  "l/ar/developers/extend/apps/front-components",
-                  "l/ar/developers/extend/apps/layout",
-                  "l/ar/developers/extend/apps/skills-and-agents",
-                  "l/ar/developers/extend/apps/cli-and-testing",
-                  "l/ar/developers/extend/apps/publishing"
+                  {
+                    "group": "Getting Started",
+                    "pages": [
+                      "developers/extend/apps/getting-started/quick-start",
+                      "developers/extend/apps/getting-started/concepts",
+                      "developers/extend/apps/getting-started/project-structure",
+                      "developers/extend/apps/getting-started/local-server",
+                      "developers/extend/apps/getting-started/scaffolding",
+                      "developers/extend/apps/getting-started/troubleshooting"
+                    ]
+                  },
+                  {
+                    "group": "Config",
+                    "pages": [
+                      "developers/extend/apps/config/overview",
+                      "developers/extend/apps/config/application",
+                      "developers/extend/apps/config/roles",
+                      "developers/extend/apps/config/install-hooks",
+                      "developers/extend/apps/config/public-assets"
+                    ]
+                  },
+                  {
+                    "group": "Data",
+                    "pages": [
+                      "developers/extend/apps/data/overview",
+                      "developers/extend/apps/data/objects",
+                      "developers/extend/apps/data/extending-objects",
+                      "developers/extend/apps/data/relations"
+                    ]
+                  },
+                  {
+                    "group": "Logic",
+                    "pages": [
+                      "developers/extend/apps/logic/overview",
+                      "developers/extend/apps/logic/logic-functions",
+                      "developers/extend/apps/logic/skills-and-agents",
+                      "developers/extend/apps/logic/connections"
+                    ]
+                  },
+                  {
+                    "group": "Layout",
+                    "pages": [
+                      "developers/extend/apps/layout/overview",
+                      "developers/extend/apps/layout/views",
+                      "developers/extend/apps/layout/navigation-menu-items",
+                      "developers/extend/apps/layout/page-layouts",
+                      "developers/extend/apps/layout/front-components",
+                      "developers/extend/apps/layout/command-menu-items"
+                    ]
+                  },
+                  {
+                    "group": "Operations",
+                    "pages": [
+                      "developers/extend/apps/operations/overview",
+                      "developers/extend/apps/operations/cli",
+                      "developers/extend/apps/operations/testing",
+                      "developers/extend/apps/operations/publishing"
+                    ]
+                  }
                 ]
               },
               {
@@ -1190,22 +1340,22 @@
               {
                 "group": "Vítejte",
                 "pages": [
-                  "l/cs/getting-started/introduction",
-                  "l/cs/getting-started/key-features",
-                  "l/cs/getting-started/quickstart"
+                  "getting-started/introduction",
+                  "getting-started/key-features",
+                  "getting-started/quickstart"
                 ]
               },
               {
                 "group": "Základní pojmy",
                 "pages": [
-                  "l/cs/getting-started/core-concepts/data-model",
-                  "l/cs/getting-started/core-concepts/layout",
-                  "l/cs/getting-started/core-concepts/workflows",
-                  "l/cs/getting-started/core-concepts/calendar-and-email",
-                  "l/cs/getting-started/core-concepts/ai",
-                  "l/cs/getting-started/core-concepts/apps",
-                  "l/cs/getting-started/core-concepts/dashboards",
-                  "l/cs/getting-started/core-concepts/glossary"
+                  "getting-started/core-concepts/data-model",
+                  "getting-started/core-concepts/layout",
+                  "getting-started/core-concepts/workflows",
+                  "getting-started/core-concepts/calendar-and-email",
+                  "getting-started/core-concepts/ai",
+                  "getting-started/core-concepts/apps",
+                  "getting-started/core-concepts/dashboards",
+                  "getting-started/core-concepts/glossary"
                 ]
               }
             ]
@@ -1523,15 +1673,65 @@
               {
                 "group": "Aplikace",
                 "pages": [
-                  "l/cs/developers/extend/apps/getting-started",
-                  "l/cs/developers/extend/apps/building",
-                  "l/cs/developers/extend/apps/data-model",
-                  "l/cs/developers/extend/apps/logic-functions",
-                  "l/cs/developers/extend/apps/front-components",
-                  "l/cs/developers/extend/apps/layout",
-                  "l/cs/developers/extend/apps/skills-and-agents",
-                  "l/cs/developers/extend/apps/cli-and-testing",
-                  "l/cs/developers/extend/apps/publishing"
+                  {
+                    "group": "Getting Started",
+                    "pages": [
+                      "developers/extend/apps/getting-started/quick-start",
+                      "developers/extend/apps/getting-started/concepts",
+                      "developers/extend/apps/getting-started/project-structure",
+                      "developers/extend/apps/getting-started/local-server",
+                      "developers/extend/apps/getting-started/scaffolding",
+                      "developers/extend/apps/getting-started/troubleshooting"
+                    ]
+                  },
+                  {
+                    "group": "Config",
+                    "pages": [
+                      "developers/extend/apps/config/overview",
+                      "developers/extend/apps/config/application",
+                      "developers/extend/apps/config/roles",
+                      "developers/extend/apps/config/install-hooks",
+                      "developers/extend/apps/config/public-assets"
+                    ]
+                  },
+                  {
+                    "group": "Data",
+                    "pages": [
+                      "developers/extend/apps/data/overview",
+                      "developers/extend/apps/data/objects",
+                      "developers/extend/apps/data/extending-objects",
+                      "developers/extend/apps/data/relations"
+                    ]
+                  },
+                  {
+                    "group": "Logic",
+                    "pages": [
+                      "developers/extend/apps/logic/overview",
+                      "developers/extend/apps/logic/logic-functions",
+                      "developers/extend/apps/logic/skills-and-agents",
+                      "developers/extend/apps/logic/connections"
+                    ]
+                  },
+                  {
+                    "group": "Layout",
+                    "pages": [
+                      "developers/extend/apps/layout/overview",
+                      "developers/extend/apps/layout/views",
+                      "developers/extend/apps/layout/navigation-menu-items",
+                      "developers/extend/apps/layout/page-layouts",
+                      "developers/extend/apps/layout/front-components",
+                      "developers/extend/apps/layout/command-menu-items"
+                    ]
+                  },
+                  {
+                    "group": "Operations",
+                    "pages": [
+                      "developers/extend/apps/operations/overview",
+                      "developers/extend/apps/operations/cli",
+                      "developers/extend/apps/operations/testing",
+                      "developers/extend/apps/operations/publishing"
+                    ]
+                  }
                 ]
               },
               {
@@ -1573,22 +1773,22 @@
               {
                 "group": "Willkommen",
                 "pages": [
-                  "l/de/getting-started/introduction",
-                  "l/de/getting-started/key-features",
-                  "l/de/getting-started/quickstart"
+                  "getting-started/introduction",
+                  "getting-started/key-features",
+                  "getting-started/quickstart"
                 ]
               },
               {
                 "group": "Kernkonzepte",
                 "pages": [
-                  "l/de/getting-started/core-concepts/data-model",
-                  "l/de/getting-started/core-concepts/layout",
-                  "l/de/getting-started/core-concepts/workflows",
-                  "l/de/getting-started/core-concepts/calendar-and-email",
-                  "l/de/getting-started/core-concepts/ai",
-                  "l/de/getting-started/core-concepts/apps",
-                  "l/de/getting-started/core-concepts/dashboards",
-                  "l/de/getting-started/core-concepts/glossary"
+                  "getting-started/core-concepts/data-model",
+                  "getting-started/core-concepts/layout",
+                  "getting-started/core-concepts/workflows",
+                  "getting-started/core-concepts/calendar-and-email",
+                  "getting-started/core-concepts/ai",
+                  "getting-started/core-concepts/apps",
+                  "getting-started/core-concepts/dashboards",
+                  "getting-started/core-concepts/glossary"
                 ]
               }
             ]
@@ -1906,15 +2106,65 @@
               {
                 "group": "Apps",
                 "pages": [
-                  "l/de/developers/extend/apps/getting-started",
-                  "l/de/developers/extend/apps/building",
-                  "l/de/developers/extend/apps/data-model",
-                  "l/de/developers/extend/apps/logic-functions",
-                  "l/de/developers/extend/apps/front-components",
-                  "l/de/developers/extend/apps/layout",
-                  "l/de/developers/extend/apps/skills-and-agents",
-                  "l/de/developers/extend/apps/cli-and-testing",
-                  "l/de/developers/extend/apps/publishing"
+                  {
+                    "group": "Getting Started",
+                    "pages": [
+                      "l/de/developers/extend/apps/getting-started/quick-start",
+                      "l/de/developers/extend/apps/getting-started/concepts",
+                      "l/de/developers/extend/apps/getting-started/project-structure",
+                      "l/de/developers/extend/apps/getting-started/local-server",
+                      "l/de/developers/extend/apps/getting-started/scaffolding",
+                      "l/de/developers/extend/apps/getting-started/troubleshooting"
+                    ]
+                  },
+                  {
+                    "group": "Config",
+                    "pages": [
+                      "l/de/developers/extend/apps/config/overview",
+                      "l/de/developers/extend/apps/config/application",
+                      "l/de/developers/extend/apps/config/roles",
+                      "l/de/developers/extend/apps/config/install-hooks",
+                      "l/de/developers/extend/apps/config/public-assets"
+                    ]
+                  },
+                  {
+                    "group": "Data",
+                    "pages": [
+                      "l/de/developers/extend/apps/data/overview",
+                      "l/de/developers/extend/apps/data/objects",
+                      "l/de/developers/extend/apps/data/extending-objects",
+                      "l/de/developers/extend/apps/data/relations"
+                    ]
+                  },
+                  {
+                    "group": "Logic",
+                    "pages": [
+                      "l/de/developers/extend/apps/logic/overview",
+                      "l/de/developers/extend/apps/logic/logic-functions",
+                      "l/de/developers/extend/apps/logic/skills-and-agents",
+                      "l/de/developers/extend/apps/logic/connections"
+                    ]
+                  },
+                  {
+                    "group": "Layout",
+                    "pages": [
+                      "l/de/developers/extend/apps/layout/overview",
+                      "l/de/developers/extend/apps/layout/views",
+                      "l/de/developers/extend/apps/layout/navigation-menu-items",
+                      "l/de/developers/extend/apps/layout/page-layouts",
+                      "l/de/developers/extend/apps/layout/front-components",
+                      "l/de/developers/extend/apps/layout/command-menu-items"
+                    ]
+                  },
+                  {
+                    "group": "Operations",
+                    "pages": [
+                      "l/de/developers/extend/apps/operations/overview",
+                      "l/de/developers/extend/apps/operations/cli",
+                      "l/de/developers/extend/apps/operations/testing",
+                      "l/de/developers/extend/apps/operations/publishing"
+                    ]
+                  }
                 ]
               },
               {
@@ -1956,22 +2206,22 @@
               {
                 "group": "Welcome",
                 "pages": [
-                  "l/es/getting-started/introduction",
-                  "l/es/getting-started/key-features",
-                  "l/es/getting-started/quickstart"
+                  "getting-started/introduction",
+                  "getting-started/key-features",
+                  "getting-started/quickstart"
                 ]
               },
               {
                 "group": "Core Concepts",
                 "pages": [
-                  "l/es/getting-started/core-concepts/data-model",
-                  "l/es/getting-started/core-concepts/layout",
-                  "l/es/getting-started/core-concepts/workflows",
-                  "l/es/getting-started/core-concepts/calendar-and-email",
-                  "l/es/getting-started/core-concepts/ai",
-                  "l/es/getting-started/core-concepts/apps",
-                  "l/es/getting-started/core-concepts/dashboards",
-                  "l/es/getting-started/core-concepts/glossary"
+                  "getting-started/core-concepts/data-model",
+                  "getting-started/core-concepts/layout",
+                  "getting-started/core-concepts/workflows",
+                  "getting-started/core-concepts/calendar-and-email",
+                  "getting-started/core-concepts/ai",
+                  "getting-started/core-concepts/apps",
+                  "getting-started/core-concepts/dashboards",
+                  "getting-started/core-concepts/glossary"
                 ]
               }
             ]
@@ -2100,7 +2350,7 @@
                           "l/es/user-guide/workflows/how-tos/crm-automations/display-related-record-data",
                           "l/es/user-guide/workflows/how-tos/crm-automations/closed-won-automations",
                           "l/es/user-guide/workflows/how-tos/crm-automations/detect-stale-opportunities",
-                          "l/es/user-guide/workflows/how-tos/crm-automations/auto-reply-to-inbound-emails"
+                          "user-guide/workflows/how-tos/crm-automations/auto-reply-to-inbound-emails"
                         ]
                       },
                       {
@@ -2156,11 +2406,11 @@
                 "group": "Layout",
                 "icon": "table-columns",
                 "pages": [
-                  "l/es/user-guide/layout/overview",
+                  "user-guide/layout/overview",
                   {
                     "group": "Reference",
                     "pages": [
-                      "l/es/user-guide/layout/capabilities/navigation",
+                      "user-guide/layout/capabilities/navigation",
                       {
                         "group": "Views",
                         "pages": [
@@ -2172,7 +2422,7 @@
                           "l/es/user-guide/views-pipelines/capabilities/view-settings"
                         ]
                       },
-                      "l/es/user-guide/layout/capabilities/record-pages"
+                      "user-guide/layout/capabilities/record-pages"
                     ]
                   },
                   {
@@ -2289,23 +2539,73 @@
               {
                 "group": "Apps",
                 "pages": [
-                  "l/es/developers/extend/apps/getting-started",
-                  "l/es/developers/extend/apps/building",
-                  "l/es/developers/extend/apps/data-model",
-                  "l/es/developers/extend/apps/logic-functions",
-                  "l/es/developers/extend/apps/front-components",
-                  "l/es/developers/extend/apps/layout",
-                  "l/es/developers/extend/apps/skills-and-agents",
-                  "l/es/developers/extend/apps/cli-and-testing",
-                  "l/es/developers/extend/apps/publishing"
+                  {
+                    "group": "Getting Started",
+                    "pages": [
+                      "developers/extend/apps/getting-started/quick-start",
+                      "developers/extend/apps/getting-started/concepts",
+                      "developers/extend/apps/getting-started/project-structure",
+                      "developers/extend/apps/getting-started/local-server",
+                      "developers/extend/apps/getting-started/scaffolding",
+                      "developers/extend/apps/getting-started/troubleshooting"
+                    ]
+                  },
+                  {
+                    "group": "Config",
+                    "pages": [
+                      "developers/extend/apps/config/overview",
+                      "developers/extend/apps/config/application",
+                      "developers/extend/apps/config/roles",
+                      "developers/extend/apps/config/install-hooks",
+                      "developers/extend/apps/config/public-assets"
+                    ]
+                  },
+                  {
+                    "group": "Data",
+                    "pages": [
+                      "developers/extend/apps/data/overview",
+                      "developers/extend/apps/data/objects",
+                      "developers/extend/apps/data/extending-objects",
+                      "developers/extend/apps/data/relations"
+                    ]
+                  },
+                  {
+                    "group": "Logic",
+                    "pages": [
+                      "developers/extend/apps/logic/overview",
+                      "developers/extend/apps/logic/logic-functions",
+                      "developers/extend/apps/logic/skills-and-agents",
+                      "developers/extend/apps/logic/connections"
+                    ]
+                  },
+                  {
+                    "group": "Layout",
+                    "pages": [
+                      "developers/extend/apps/layout/overview",
+                      "developers/extend/apps/layout/views",
+                      "developers/extend/apps/layout/navigation-menu-items",
+                      "developers/extend/apps/layout/page-layouts",
+                      "developers/extend/apps/layout/front-components",
+                      "developers/extend/apps/layout/command-menu-items"
+                    ]
+                  },
+                  {
+                    "group": "Operations",
+                    "pages": [
+                      "developers/extend/apps/operations/overview",
+                      "developers/extend/apps/operations/cli",
+                      "developers/extend/apps/operations/testing",
+                      "developers/extend/apps/operations/publishing"
+                    ]
+                  }
                 ]
               },
               {
                 "group": "API",
                 "pages": [
-                  "l/es/developers/extend/api",
-                  "l/es/developers/extend/webhooks",
-                  "l/es/developers/extend/oauth"
+                  "developers/extend/api",
+                  "developers/extend/webhooks",
+                  "developers/extend/oauth"
                 ]
               },
               {
@@ -2322,8 +2622,8 @@
                 "group": "Contribuir",
                 "pages": [
                   "l/es/developers/contribute/capabilities/local-setup",
-                  "l/es/developers/contribute/commands",
-                  "l/es/developers/contribute/style-guide"
+                  "developers/contribute/commands",
+                  "developers/contribute/style-guide"
                 ]
               }
             ]
@@ -2339,22 +2639,22 @@
               {
                 "group": "Benvenuto",
                 "pages": [
-                  "l/it/getting-started/introduction",
-                  "l/it/getting-started/key-features",
-                  "l/it/getting-started/quickstart"
+                  "getting-started/introduction",
+                  "getting-started/key-features",
+                  "getting-started/quickstart"
                 ]
               },
               {
                 "group": "Concetti chiave",
                 "pages": [
-                  "l/it/getting-started/core-concepts/data-model",
-                  "l/it/getting-started/core-concepts/layout",
-                  "l/it/getting-started/core-concepts/workflows",
-                  "l/it/getting-started/core-concepts/calendar-and-email",
-                  "l/it/getting-started/core-concepts/ai",
-                  "l/it/getting-started/core-concepts/apps",
-                  "l/it/getting-started/core-concepts/dashboards",
-                  "l/it/getting-started/core-concepts/glossary"
+                  "getting-started/core-concepts/data-model",
+                  "getting-started/core-concepts/layout",
+                  "getting-started/core-concepts/workflows",
+                  "getting-started/core-concepts/calendar-and-email",
+                  "getting-started/core-concepts/ai",
+                  "getting-started/core-concepts/apps",
+                  "getting-started/core-concepts/dashboards",
+                  "getting-started/core-concepts/glossary"
                 ]
               }
             ]
@@ -2672,15 +2972,65 @@
               {
                 "group": "App",
                 "pages": [
-                  "l/it/developers/extend/apps/getting-started",
-                  "l/it/developers/extend/apps/building",
-                  "l/it/developers/extend/apps/data-model",
-                  "l/it/developers/extend/apps/logic-functions",
-                  "l/it/developers/extend/apps/front-components",
-                  "l/it/developers/extend/apps/layout",
-                  "l/it/developers/extend/apps/skills-and-agents",
-                  "l/it/developers/extend/apps/cli-and-testing",
-                  "l/it/developers/extend/apps/publishing"
+                  {
+                    "group": "Getting Started",
+                    "pages": [
+                      "developers/extend/apps/getting-started/quick-start",
+                      "developers/extend/apps/getting-started/concepts",
+                      "developers/extend/apps/getting-started/project-structure",
+                      "developers/extend/apps/getting-started/local-server",
+                      "developers/extend/apps/getting-started/scaffolding",
+                      "developers/extend/apps/getting-started/troubleshooting"
+                    ]
+                  },
+                  {
+                    "group": "Config",
+                    "pages": [
+                      "developers/extend/apps/config/overview",
+                      "developers/extend/apps/config/application",
+                      "developers/extend/apps/config/roles",
+                      "developers/extend/apps/config/install-hooks",
+                      "developers/extend/apps/config/public-assets"
+                    ]
+                  },
+                  {
+                    "group": "Data",
+                    "pages": [
+                      "developers/extend/apps/data/overview",
+                      "developers/extend/apps/data/objects",
+                      "developers/extend/apps/data/extending-objects",
+                      "developers/extend/apps/data/relations"
+                    ]
+                  },
+                  {
+                    "group": "Logic",
+                    "pages": [
+                      "developers/extend/apps/logic/overview",
+                      "developers/extend/apps/logic/logic-functions",
+                      "developers/extend/apps/logic/skills-and-agents",
+                      "developers/extend/apps/logic/connections"
+                    ]
+                  },
+                  {
+                    "group": "Layout",
+                    "pages": [
+                      "developers/extend/apps/layout/overview",
+                      "developers/extend/apps/layout/views",
+                      "developers/extend/apps/layout/navigation-menu-items",
+                      "developers/extend/apps/layout/page-layouts",
+                      "developers/extend/apps/layout/front-components",
+                      "developers/extend/apps/layout/command-menu-items"
+                    ]
+                  },
+                  {
+                    "group": "Operations",
+                    "pages": [
+                      "developers/extend/apps/operations/overview",
+                      "developers/extend/apps/operations/cli",
+                      "developers/extend/apps/operations/testing",
+                      "developers/extend/apps/operations/publishing"
+                    ]
+                  }
                 ]
               },
               {
@@ -2722,22 +3072,22 @@
               {
                 "group": "Welcome",
                 "pages": [
-                  "l/ja/getting-started/introduction",
-                  "l/ja/getting-started/key-features",
-                  "l/ja/getting-started/quickstart"
+                  "getting-started/introduction",
+                  "getting-started/key-features",
+                  "getting-started/quickstart"
                 ]
               },
               {
                 "group": "Core Concepts",
                 "pages": [
-                  "l/ja/getting-started/core-concepts/data-model",
-                  "l/ja/getting-started/core-concepts/layout",
-                  "l/ja/getting-started/core-concepts/workflows",
-                  "l/ja/getting-started/core-concepts/calendar-and-email",
-                  "l/ja/getting-started/core-concepts/ai",
-                  "l/ja/getting-started/core-concepts/apps",
-                  "l/ja/getting-started/core-concepts/dashboards",
-                  "l/ja/getting-started/core-concepts/glossary"
+                  "getting-started/core-concepts/data-model",
+                  "getting-started/core-concepts/layout",
+                  "getting-started/core-concepts/workflows",
+                  "getting-started/core-concepts/calendar-and-email",
+                  "getting-started/core-concepts/ai",
+                  "getting-started/core-concepts/apps",
+                  "getting-started/core-concepts/dashboards",
+                  "getting-started/core-concepts/glossary"
                 ]
               }
             ]
@@ -2866,7 +3216,7 @@
                           "l/ja/user-guide/workflows/how-tos/crm-automations/display-related-record-data",
                           "l/ja/user-guide/workflows/how-tos/crm-automations/closed-won-automations",
                           "l/ja/user-guide/workflows/how-tos/crm-automations/detect-stale-opportunities",
-                          "l/ja/user-guide/workflows/how-tos/crm-automations/auto-reply-to-inbound-emails"
+                          "user-guide/workflows/how-tos/crm-automations/auto-reply-to-inbound-emails"
                         ]
                       },
                       {
@@ -2922,11 +3272,11 @@
                 "group": "Layout",
                 "icon": "table-columns",
                 "pages": [
-                  "l/ja/user-guide/layout/overview",
+                  "user-guide/layout/overview",
                   {
                     "group": "Reference",
                     "pages": [
-                      "l/ja/user-guide/layout/capabilities/navigation",
+                      "user-guide/layout/capabilities/navigation",
                       {
                         "group": "Views",
                         "pages": [
@@ -2938,7 +3288,7 @@
                           "l/ja/user-guide/views-pipelines/capabilities/view-settings"
                         ]
                       },
-                      "l/ja/user-guide/layout/capabilities/record-pages"
+                      "user-guide/layout/capabilities/record-pages"
                     ]
                   },
                   {
@@ -3055,23 +3405,73 @@
               {
                 "group": "Apps",
                 "pages": [
-                  "l/ja/developers/extend/apps/getting-started",
-                  "l/ja/developers/extend/apps/building",
-                  "l/ja/developers/extend/apps/data-model",
-                  "l/ja/developers/extend/apps/logic-functions",
-                  "l/ja/developers/extend/apps/front-components",
-                  "l/ja/developers/extend/apps/layout",
-                  "l/ja/developers/extend/apps/skills-and-agents",
-                  "l/ja/developers/extend/apps/cli-and-testing",
-                  "l/ja/developers/extend/apps/publishing"
+                  {
+                    "group": "Getting Started",
+                    "pages": [
+                      "developers/extend/apps/getting-started/quick-start",
+                      "developers/extend/apps/getting-started/concepts",
+                      "developers/extend/apps/getting-started/project-structure",
+                      "developers/extend/apps/getting-started/local-server",
+                      "developers/extend/apps/getting-started/scaffolding",
+                      "developers/extend/apps/getting-started/troubleshooting"
+                    ]
+                  },
+                  {
+                    "group": "Config",
+                    "pages": [
+                      "developers/extend/apps/config/overview",
+                      "developers/extend/apps/config/application",
+                      "developers/extend/apps/config/roles",
+                      "developers/extend/apps/config/install-hooks",
+                      "developers/extend/apps/config/public-assets"
+                    ]
+                  },
+                  {
+                    "group": "Data",
+                    "pages": [
+                      "developers/extend/apps/data/overview",
+                      "developers/extend/apps/data/objects",
+                      "developers/extend/apps/data/extending-objects",
+                      "developers/extend/apps/data/relations"
+                    ]
+                  },
+                  {
+                    "group": "Logic",
+                    "pages": [
+                      "developers/extend/apps/logic/overview",
+                      "developers/extend/apps/logic/logic-functions",
+                      "developers/extend/apps/logic/skills-and-agents",
+                      "developers/extend/apps/logic/connections"
+                    ]
+                  },
+                  {
+                    "group": "Layout",
+                    "pages": [
+                      "developers/extend/apps/layout/overview",
+                      "developers/extend/apps/layout/views",
+                      "developers/extend/apps/layout/navigation-menu-items",
+                      "developers/extend/apps/layout/page-layouts",
+                      "developers/extend/apps/layout/front-components",
+                      "developers/extend/apps/layout/command-menu-items"
+                    ]
+                  },
+                  {
+                    "group": "Operations",
+                    "pages": [
+                      "developers/extend/apps/operations/overview",
+                      "developers/extend/apps/operations/cli",
+                      "developers/extend/apps/operations/testing",
+                      "developers/extend/apps/operations/publishing"
+                    ]
+                  }
                 ]
               },
               {
                 "group": "API",
                 "pages": [
-                  "l/ja/developers/extend/api",
-                  "l/ja/developers/extend/webhooks",
-                  "l/ja/developers/extend/oauth"
+                  "developers/extend/api",
+                  "developers/extend/webhooks",
+                  "developers/extend/oauth"
                 ]
               },
               {
@@ -3088,8 +3488,8 @@
                 "group": "貢献",
                 "pages": [
                   "l/ja/developers/contribute/capabilities/local-setup",
-                  "l/ja/developers/contribute/commands",
-                  "l/ja/developers/contribute/style-guide"
+                  "developers/contribute/commands",
+                  "developers/contribute/style-guide"
                 ]
               }
             ]
@@ -3105,22 +3505,22 @@
               {
                 "group": "Welcome",
                 "pages": [
-                  "l/ko/getting-started/introduction",
-                  "l/ko/getting-started/key-features",
-                  "l/ko/getting-started/quickstart"
+                  "getting-started/introduction",
+                  "getting-started/key-features",
+                  "getting-started/quickstart"
                 ]
               },
               {
                 "group": "Core Concepts",
                 "pages": [
-                  "l/ko/getting-started/core-concepts/data-model",
-                  "l/ko/getting-started/core-concepts/layout",
-                  "l/ko/getting-started/core-concepts/workflows",
-                  "l/ko/getting-started/core-concepts/calendar-and-email",
-                  "l/ko/getting-started/core-concepts/ai",
-                  "l/ko/getting-started/core-concepts/apps",
-                  "l/ko/getting-started/core-concepts/dashboards",
-                  "l/ko/getting-started/core-concepts/glossary"
+                  "getting-started/core-concepts/data-model",
+                  "getting-started/core-concepts/layout",
+                  "getting-started/core-concepts/workflows",
+                  "getting-started/core-concepts/calendar-and-email",
+                  "getting-started/core-concepts/ai",
+                  "getting-started/core-concepts/apps",
+                  "getting-started/core-concepts/dashboards",
+                  "getting-started/core-concepts/glossary"
                 ]
               }
             ]
@@ -3249,7 +3649,7 @@
                           "l/ko/user-guide/workflows/how-tos/crm-automations/display-related-record-data",
                           "l/ko/user-guide/workflows/how-tos/crm-automations/closed-won-automations",
                           "l/ko/user-guide/workflows/how-tos/crm-automations/detect-stale-opportunities",
-                          "l/ko/user-guide/workflows/how-tos/crm-automations/auto-reply-to-inbound-emails"
+                          "user-guide/workflows/how-tos/crm-automations/auto-reply-to-inbound-emails"
                         ]
                       },
                       {
@@ -3305,11 +3705,11 @@
                 "group": "Layout",
                 "icon": "table-columns",
                 "pages": [
-                  "l/ko/user-guide/layout/overview",
+                  "user-guide/layout/overview",
                   {
                     "group": "Reference",
                     "pages": [
-                      "l/ko/user-guide/layout/capabilities/navigation",
+                      "user-guide/layout/capabilities/navigation",
                       {
                         "group": "Views",
                         "pages": [
@@ -3321,7 +3721,7 @@
                           "l/ko/user-guide/views-pipelines/capabilities/view-settings"
                         ]
                       },
-                      "l/ko/user-guide/layout/capabilities/record-pages"
+                      "user-guide/layout/capabilities/record-pages"
                     ]
                   },
                   {
@@ -3438,23 +3838,73 @@
               {
                 "group": "Apps",
                 "pages": [
-                  "l/ko/developers/extend/apps/getting-started",
-                  "l/ko/developers/extend/apps/building",
-                  "l/ko/developers/extend/apps/data-model",
-                  "l/ko/developers/extend/apps/logic-functions",
-                  "l/ko/developers/extend/apps/front-components",
-                  "l/ko/developers/extend/apps/layout",
-                  "l/ko/developers/extend/apps/skills-and-agents",
-                  "l/ko/developers/extend/apps/cli-and-testing",
-                  "l/ko/developers/extend/apps/publishing"
+                  {
+                    "group": "Getting Started",
+                    "pages": [
+                      "developers/extend/apps/getting-started/quick-start",
+                      "developers/extend/apps/getting-started/concepts",
+                      "developers/extend/apps/getting-started/project-structure",
+                      "developers/extend/apps/getting-started/local-server",
+                      "developers/extend/apps/getting-started/scaffolding",
+                      "developers/extend/apps/getting-started/troubleshooting"
+                    ]
+                  },
+                  {
+                    "group": "Config",
+                    "pages": [
+                      "developers/extend/apps/config/overview",
+                      "developers/extend/apps/config/application",
+                      "developers/extend/apps/config/roles",
+                      "developers/extend/apps/config/install-hooks",
+                      "developers/extend/apps/config/public-assets"
+                    ]
+                  },
+                  {
+                    "group": "Data",
+                    "pages": [
+                      "developers/extend/apps/data/overview",
+                      "developers/extend/apps/data/objects",
+                      "developers/extend/apps/data/extending-objects",
+                      "developers/extend/apps/data/relations"
+                    ]
+                  },
+                  {
+                    "group": "Logic",
+                    "pages": [
+                      "developers/extend/apps/logic/overview",
+                      "developers/extend/apps/logic/logic-functions",
+                      "developers/extend/apps/logic/skills-and-agents",
+                      "developers/extend/apps/logic/connections"
+                    ]
+                  },
+                  {
+                    "group": "Layout",
+                    "pages": [
+                      "developers/extend/apps/layout/overview",
+                      "developers/extend/apps/layout/views",
+                      "developers/extend/apps/layout/navigation-menu-items",
+                      "developers/extend/apps/layout/page-layouts",
+                      "developers/extend/apps/layout/front-components",
+                      "developers/extend/apps/layout/command-menu-items"
+                    ]
+                  },
+                  {
+                    "group": "Operations",
+                    "pages": [
+                      "developers/extend/apps/operations/overview",
+                      "developers/extend/apps/operations/cli",
+                      "developers/extend/apps/operations/testing",
+                      "developers/extend/apps/operations/publishing"
+                    ]
+                  }
                 ]
               },
               {
                 "group": "API",
                 "pages": [
-                  "l/ko/developers/extend/api",
-                  "l/ko/developers/extend/webhooks",
-                  "l/ko/developers/extend/oauth"
+                  "developers/extend/api",
+                  "developers/extend/webhooks",
+                  "developers/extend/oauth"
                 ]
               },
               {
@@ -3471,8 +3921,8 @@
                 "group": "기여",
                 "pages": [
                   "l/ko/developers/contribute/capabilities/local-setup",
-                  "l/ko/developers/contribute/commands",
-                  "l/ko/developers/contribute/style-guide"
+                  "developers/contribute/commands",
+                  "developers/contribute/style-guide"
                 ]
               }
             ]
@@ -3488,22 +3938,22 @@
               {
                 "group": "Boas-vindas",
                 "pages": [
-                  "l/pt/getting-started/introduction",
-                  "l/pt/getting-started/key-features",
-                  "l/pt/getting-started/quickstart"
+                  "getting-started/introduction",
+                  "getting-started/key-features",
+                  "getting-started/quickstart"
                 ]
               },
               {
                 "group": "Conceitos essenciais",
                 "pages": [
-                  "l/pt/getting-started/core-concepts/data-model",
-                  "l/pt/getting-started/core-concepts/layout",
-                  "l/pt/getting-started/core-concepts/workflows",
-                  "l/pt/getting-started/core-concepts/calendar-and-email",
-                  "l/pt/getting-started/core-concepts/ai",
-                  "l/pt/getting-started/core-concepts/apps",
-                  "l/pt/getting-started/core-concepts/dashboards",
-                  "l/pt/getting-started/core-concepts/glossary"
+                  "getting-started/core-concepts/data-model",
+                  "getting-started/core-concepts/layout",
+                  "getting-started/core-concepts/workflows",
+                  "getting-started/core-concepts/calendar-and-email",
+                  "getting-started/core-concepts/ai",
+                  "getting-started/core-concepts/apps",
+                  "getting-started/core-concepts/dashboards",
+                  "getting-started/core-concepts/glossary"
                 ]
               }
             ]
@@ -3821,15 +4271,65 @@
               {
                 "group": "Aplicativos",
                 "pages": [
-                  "l/pt/developers/extend/apps/getting-started",
-                  "l/pt/developers/extend/apps/building",
-                  "l/pt/developers/extend/apps/data-model",
-                  "l/pt/developers/extend/apps/logic-functions",
-                  "l/pt/developers/extend/apps/front-components",
-                  "l/pt/developers/extend/apps/layout",
-                  "l/pt/developers/extend/apps/skills-and-agents",
-                  "l/pt/developers/extend/apps/cli-and-testing",
-                  "l/pt/developers/extend/apps/publishing"
+                  {
+                    "group": "Getting Started",
+                    "pages": [
+                      "l/pt/developers/extend/apps/getting-started/quick-start",
+                      "l/pt/developers/extend/apps/getting-started/concepts",
+                      "l/pt/developers/extend/apps/getting-started/project-structure",
+                      "l/pt/developers/extend/apps/getting-started/local-server",
+                      "l/pt/developers/extend/apps/getting-started/scaffolding",
+                      "l/pt/developers/extend/apps/getting-started/troubleshooting"
+                    ]
+                  },
+                  {
+                    "group": "Config",
+                    "pages": [
+                      "l/pt/developers/extend/apps/config/overview",
+                      "l/pt/developers/extend/apps/config/application",
+                      "l/pt/developers/extend/apps/config/roles",
+                      "l/pt/developers/extend/apps/config/install-hooks",
+                      "l/pt/developers/extend/apps/config/public-assets"
+                    ]
+                  },
+                  {
+                    "group": "Data",
+                    "pages": [
+                      "l/pt/developers/extend/apps/data/overview",
+                      "l/pt/developers/extend/apps/data/objects",
+                      "l/pt/developers/extend/apps/data/extending-objects",
+                      "l/pt/developers/extend/apps/data/relations"
+                    ]
+                  },
+                  {
+                    "group": "Logic",
+                    "pages": [
+                      "l/pt/developers/extend/apps/logic/overview",
+                      "l/pt/developers/extend/apps/logic/logic-functions",
+                      "l/pt/developers/extend/apps/logic/skills-and-agents",
+                      "l/pt/developers/extend/apps/logic/connections"
+                    ]
+                  },
+                  {
+                    "group": "Layout",
+                    "pages": [
+                      "l/pt/developers/extend/apps/layout/overview",
+                      "l/pt/developers/extend/apps/layout/views",
+                      "l/pt/developers/extend/apps/layout/navigation-menu-items",
+                      "l/pt/developers/extend/apps/layout/page-layouts",
+                      "l/pt/developers/extend/apps/layout/front-components",
+                      "l/pt/developers/extend/apps/layout/command-menu-items"
+                    ]
+                  },
+                  {
+                    "group": "Operations",
+                    "pages": [
+                      "l/pt/developers/extend/apps/operations/overview",
+                      "l/pt/developers/extend/apps/operations/cli",
+                      "l/pt/developers/extend/apps/operations/testing",
+                      "l/pt/developers/extend/apps/operations/publishing"
+                    ]
+                  }
                 ]
               },
               {
@@ -3871,22 +4371,22 @@
               {
                 "group": "Bun venit",
                 "pages": [
-                  "l/ro/getting-started/introduction",
-                  "l/ro/getting-started/key-features",
-                  "l/ro/getting-started/quickstart"
+                  "getting-started/introduction",
+                  "getting-started/key-features",
+                  "getting-started/quickstart"
                 ]
               },
               {
                 "group": "Concepte cheie",
                 "pages": [
-                  "l/ro/getting-started/core-concepts/data-model",
-                  "l/ro/getting-started/core-concepts/layout",
-                  "l/ro/getting-started/core-concepts/workflows",
-                  "l/ro/getting-started/core-concepts/calendar-and-email",
-                  "l/ro/getting-started/core-concepts/ai",
-                  "l/ro/getting-started/core-concepts/apps",
-                  "l/ro/getting-started/core-concepts/dashboards",
-                  "l/ro/getting-started/core-concepts/glossary"
+                  "getting-started/core-concepts/data-model",
+                  "getting-started/core-concepts/layout",
+                  "getting-started/core-concepts/workflows",
+                  "getting-started/core-concepts/calendar-and-email",
+                  "getting-started/core-concepts/ai",
+                  "getting-started/core-concepts/apps",
+                  "getting-started/core-concepts/dashboards",
+                  "getting-started/core-concepts/glossary"
                 ]
               }
             ]
@@ -4204,15 +4704,65 @@
               {
                 "group": "Aplicații",
                 "pages": [
-                  "l/ro/developers/extend/apps/getting-started",
-                  "l/ro/developers/extend/apps/building",
-                  "l/ro/developers/extend/apps/data-model",
-                  "l/ro/developers/extend/apps/logic-functions",
-                  "l/ro/developers/extend/apps/front-components",
-                  "l/ro/developers/extend/apps/layout",
-                  "l/ro/developers/extend/apps/skills-and-agents",
-                  "l/ro/developers/extend/apps/cli-and-testing",
-                  "l/ro/developers/extend/apps/publishing"
+                  {
+                    "group": "Getting Started",
+                    "pages": [
+                      "l/ro/developers/extend/apps/getting-started/quick-start",
+                      "l/ro/developers/extend/apps/getting-started/concepts",
+                      "l/ro/developers/extend/apps/getting-started/project-structure",
+                      "l/ro/developers/extend/apps/getting-started/local-server",
+                      "l/ro/developers/extend/apps/getting-started/scaffolding",
+                      "l/ro/developers/extend/apps/getting-started/troubleshooting"
+                    ]
+                  },
+                  {
+                    "group": "Config",
+                    "pages": [
+                      "l/ro/developers/extend/apps/config/overview",
+                      "l/ro/developers/extend/apps/config/application",
+                      "l/ro/developers/extend/apps/config/roles",
+                      "l/ro/developers/extend/apps/config/install-hooks",
+                      "l/ro/developers/extend/apps/config/public-assets"
+                    ]
+                  },
+                  {
+                    "group": "Data",
+                    "pages": [
+                      "l/ro/developers/extend/apps/data/overview",
+                      "l/ro/developers/extend/apps/data/objects",
+                      "l/ro/developers/extend/apps/data/extending-objects",
+                      "l/ro/developers/extend/apps/data/relations"
+                    ]
+                  },
+                  {
+                    "group": "Logic",
+                    "pages": [
+                      "l/ro/developers/extend/apps/logic/overview",
+                      "l/ro/developers/extend/apps/logic/logic-functions",
+                      "l/ro/developers/extend/apps/logic/skills-and-agents",
+                      "l/ro/developers/extend/apps/logic/connections"
+                    ]
+                  },
+                  {
+                    "group": "Layout",
+                    "pages": [
+                      "l/ro/developers/extend/apps/layout/overview",
+                      "l/ro/developers/extend/apps/layout/views",
+                      "l/ro/developers/extend/apps/layout/navigation-menu-items",
+                      "l/ro/developers/extend/apps/layout/page-layouts",
+                      "l/ro/developers/extend/apps/layout/front-components",
+                      "l/ro/developers/extend/apps/layout/command-menu-items"
+                    ]
+                  },
+                  {
+                    "group": "Operations",
+                    "pages": [
+                      "l/ro/developers/extend/apps/operations/overview",
+                      "l/ro/developers/extend/apps/operations/cli",
+                      "l/ro/developers/extend/apps/operations/testing",
+                      "l/ro/developers/extend/apps/operations/publishing"
+                    ]
+                  }
                 ]
               },
               {
@@ -4254,22 +4804,22 @@
               {
                 "group": "Добро пожаловать",
                 "pages": [
-                  "l/ru/getting-started/introduction",
-                  "l/ru/getting-started/key-features",
-                  "l/ru/getting-started/quickstart"
+                  "getting-started/introduction",
+                  "getting-started/key-features",
+                  "getting-started/quickstart"
                 ]
               },
               {
                 "group": "Основные понятия",
                 "pages": [
-                  "l/ru/getting-started/core-concepts/data-model",
-                  "l/ru/getting-started/core-concepts/layout",
-                  "l/ru/getting-started/core-concepts/workflows",
-                  "l/ru/getting-started/core-concepts/calendar-and-email",
-                  "l/ru/getting-started/core-concepts/ai",
-                  "l/ru/getting-started/core-concepts/apps",
-                  "l/ru/getting-started/core-concepts/dashboards",
-                  "l/ru/getting-started/core-concepts/glossary"
+                  "getting-started/core-concepts/data-model",
+                  "getting-started/core-concepts/layout",
+                  "getting-started/core-concepts/workflows",
+                  "getting-started/core-concepts/calendar-and-email",
+                  "getting-started/core-concepts/ai",
+                  "getting-started/core-concepts/apps",
+                  "getting-started/core-concepts/dashboards",
+                  "getting-started/core-concepts/glossary"
                 ]
               }
             ]
@@ -4587,15 +5137,65 @@
               {
                 "group": "Приложения",
                 "pages": [
-                  "l/ru/developers/extend/apps/getting-started",
-                  "l/ru/developers/extend/apps/building",
-                  "l/ru/developers/extend/apps/data-model",
-                  "l/ru/developers/extend/apps/logic-functions",
-                  "l/ru/developers/extend/apps/front-components",
-                  "l/ru/developers/extend/apps/layout",
-                  "l/ru/developers/extend/apps/skills-and-agents",
-                  "l/ru/developers/extend/apps/cli-and-testing",
-                  "l/ru/developers/extend/apps/publishing"
+                  {
+                    "group": "Getting Started",
+                    "pages": [
+                      "l/ru/developers/extend/apps/getting-started/quick-start",
+                      "l/ru/developers/extend/apps/getting-started/concepts",
+                      "l/ru/developers/extend/apps/getting-started/project-structure",
+                      "l/ru/developers/extend/apps/getting-started/local-server",
+                      "l/ru/developers/extend/apps/getting-started/scaffolding",
+                      "l/ru/developers/extend/apps/getting-started/troubleshooting"
+                    ]
+                  },
+                  {
+                    "group": "Config",
+                    "pages": [
+                      "l/ru/developers/extend/apps/config/overview",
+                      "l/ru/developers/extend/apps/config/application",
+                      "l/ru/developers/extend/apps/config/roles",
+                      "l/ru/developers/extend/apps/config/install-hooks",
+                      "l/ru/developers/extend/apps/config/public-assets"
+                    ]
+                  },
+                  {
+                    "group": "Data",
+                    "pages": [
+                      "l/ru/developers/extend/apps/data/overview",
+                      "l/ru/developers/extend/apps/data/objects",
+                      "l/ru/developers/extend/apps/data/extending-objects",
+                      "l/ru/developers/extend/apps/data/relations"
+                    ]
+                  },
+                  {
+                    "group": "Logic",
+                    "pages": [
+                      "l/ru/developers/extend/apps/logic/overview",
+                      "l/ru/developers/extend/apps/logic/logic-functions",
+                      "l/ru/developers/extend/apps/logic/skills-and-agents",
+                      "l/ru/developers/extend/apps/logic/connections"
+                    ]
+                  },
+                  {
+                    "group": "Layout",
+                    "pages": [
+                      "l/ru/developers/extend/apps/layout/overview",
+                      "l/ru/developers/extend/apps/layout/views",
+                      "l/ru/developers/extend/apps/layout/navigation-menu-items",
+                      "l/ru/developers/extend/apps/layout/page-layouts",
+                      "l/ru/developers/extend/apps/layout/front-components",
+                      "l/ru/developers/extend/apps/layout/command-menu-items"
+                    ]
+                  },
+                  {
+                    "group": "Operations",
+                    "pages": [
+                      "l/ru/developers/extend/apps/operations/overview",
+                      "l/ru/developers/extend/apps/operations/cli",
+                      "l/ru/developers/extend/apps/operations/testing",
+                      "l/ru/developers/extend/apps/operations/publishing"
+                    ]
+                  }
                 ]
               },
               {
@@ -4637,22 +5237,22 @@
               {
                 "group": "Hoş geldiniz",
                 "pages": [
-                  "l/tr/getting-started/introduction",
-                  "l/tr/getting-started/key-features",
-                  "l/tr/getting-started/quickstart"
+                  "getting-started/introduction",
+                  "getting-started/key-features",
+                  "getting-started/quickstart"
                 ]
               },
               {
                 "group": "Temel Kavramlar",
                 "pages": [
-                  "l/tr/getting-started/core-concepts/data-model",
-                  "l/tr/getting-started/core-concepts/layout",
-                  "l/tr/getting-started/core-concepts/workflows",
-                  "l/tr/getting-started/core-concepts/calendar-and-email",
-                  "l/tr/getting-started/core-concepts/ai",
-                  "l/tr/getting-started/core-concepts/apps",
-                  "l/tr/getting-started/core-concepts/dashboards",
-                  "l/tr/getting-started/core-concepts/glossary"
+                  "getting-started/core-concepts/data-model",
+                  "getting-started/core-concepts/layout",
+                  "getting-started/core-concepts/workflows",
+                  "getting-started/core-concepts/calendar-and-email",
+                  "getting-started/core-concepts/ai",
+                  "getting-started/core-concepts/apps",
+                  "getting-started/core-concepts/dashboards",
+                  "getting-started/core-concepts/glossary"
                 ]
               }
             ]
@@ -4970,15 +5570,65 @@
               {
                 "group": "Uygulamalar",
                 "pages": [
-                  "l/tr/developers/extend/apps/getting-started",
-                  "l/tr/developers/extend/apps/building",
-                  "l/tr/developers/extend/apps/data-model",
-                  "l/tr/developers/extend/apps/logic-functions",
-                  "l/tr/developers/extend/apps/front-components",
-                  "l/tr/developers/extend/apps/layout",
-                  "l/tr/developers/extend/apps/skills-and-agents",
-                  "l/tr/developers/extend/apps/cli-and-testing",
-                  "l/tr/developers/extend/apps/publishing"
+                  {
+                    "group": "Getting Started",
+                    "pages": [
+                      "l/tr/developers/extend/apps/getting-started/quick-start",
+                      "l/tr/developers/extend/apps/getting-started/concepts",
+                      "l/tr/developers/extend/apps/getting-started/project-structure",
+                      "l/tr/developers/extend/apps/getting-started/local-server",
+                      "l/tr/developers/extend/apps/getting-started/scaffolding",
+                      "l/tr/developers/extend/apps/getting-started/troubleshooting"
+                    ]
+                  },
+                  {
+                    "group": "Config",
+                    "pages": [
+                      "l/tr/developers/extend/apps/config/overview",
+                      "l/tr/developers/extend/apps/config/application",
+                      "l/tr/developers/extend/apps/config/roles",
+                      "l/tr/developers/extend/apps/config/install-hooks",
+                      "l/tr/developers/extend/apps/config/public-assets"
+                    ]
+                  },
+                  {
+                    "group": "Data",
+                    "pages": [
+                      "l/tr/developers/extend/apps/data/overview",
+                      "l/tr/developers/extend/apps/data/objects",
+                      "l/tr/developers/extend/apps/data/extending-objects",
+                      "l/tr/developers/extend/apps/data/relations"
+                    ]
+                  },
+                  {
+                    "group": "Logic",
+                    "pages": [
+                      "l/tr/developers/extend/apps/logic/overview",
+                      "l/tr/developers/extend/apps/logic/logic-functions",
+                      "l/tr/developers/extend/apps/logic/skills-and-agents",
+                      "l/tr/developers/extend/apps/logic/connections"
+                    ]
+                  },
+                  {
+                    "group": "Layout",
+                    "pages": [
+                      "l/tr/developers/extend/apps/layout/overview",
+                      "l/tr/developers/extend/apps/layout/views",
+                      "l/tr/developers/extend/apps/layout/navigation-menu-items",
+                      "l/tr/developers/extend/apps/layout/page-layouts",
+                      "l/tr/developers/extend/apps/layout/front-components",
+                      "l/tr/developers/extend/apps/layout/command-menu-items"
+                    ]
+                  },
+                  {
+                    "group": "Operations",
+                    "pages": [
+                      "l/tr/developers/extend/apps/operations/overview",
+                      "l/tr/developers/extend/apps/operations/cli",
+                      "l/tr/developers/extend/apps/operations/testing",
+                      "l/tr/developers/extend/apps/operations/publishing"
+                    ]
+                  }
                 ]
               },
               {
@@ -5020,22 +5670,22 @@
               {
                 "group": "欢迎",
                 "pages": [
-                  "l/zh/getting-started/introduction",
-                  "l/zh/getting-started/key-features",
-                  "l/zh/getting-started/quickstart"
+                  "getting-started/introduction",
+                  "getting-started/key-features",
+                  "getting-started/quickstart"
                 ]
               },
               {
                 "group": "核心概念",
                 "pages": [
-                  "l/zh/getting-started/core-concepts/data-model",
-                  "l/zh/getting-started/core-concepts/layout",
-                  "l/zh/getting-started/core-concepts/workflows",
-                  "l/zh/getting-started/core-concepts/calendar-and-email",
-                  "l/zh/getting-started/core-concepts/ai",
-                  "l/zh/getting-started/core-concepts/apps",
-                  "l/zh/getting-started/core-concepts/dashboards",
-                  "l/zh/getting-started/core-concepts/glossary"
+                  "getting-started/core-concepts/data-model",
+                  "getting-started/core-concepts/layout",
+                  "getting-started/core-concepts/workflows",
+                  "getting-started/core-concepts/calendar-and-email",
+                  "getting-started/core-concepts/ai",
+                  "getting-started/core-concepts/apps",
+                  "getting-started/core-concepts/dashboards",
+                  "getting-started/core-concepts/glossary"
                 ]
               }
             ]
@@ -5353,15 +6003,65 @@
               {
                 "group": "应用",
                 "pages": [
-                  "l/zh/developers/extend/apps/getting-started",
-                  "l/zh/developers/extend/apps/building",
-                  "l/zh/developers/extend/apps/data-model",
-                  "l/zh/developers/extend/apps/logic-functions",
-                  "l/zh/developers/extend/apps/front-components",
-                  "l/zh/developers/extend/apps/layout",
-                  "l/zh/developers/extend/apps/skills-and-agents",
-                  "l/zh/developers/extend/apps/cli-and-testing",
-                  "l/zh/developers/extend/apps/publishing"
+                  {
+                    "group": "Getting Started",
+                    "pages": [
+                      "l/zh/developers/extend/apps/getting-started/quick-start",
+                      "l/zh/developers/extend/apps/getting-started/concepts",
+                      "l/zh/developers/extend/apps/getting-started/project-structure",
+                      "l/zh/developers/extend/apps/getting-started/local-server",
+                      "l/zh/developers/extend/apps/getting-started/scaffolding",
+                      "l/zh/developers/extend/apps/getting-started/troubleshooting"
+                    ]
+                  },
+                  {
+                    "group": "Config",
+                    "pages": [
+                      "l/zh/developers/extend/apps/config/overview",
+                      "l/zh/developers/extend/apps/config/application",
+                      "l/zh/developers/extend/apps/config/roles",
+                      "l/zh/developers/extend/apps/config/install-hooks",
+                      "l/zh/developers/extend/apps/config/public-assets"
+                    ]
+                  },
+                  {
+                    "group": "Data",
+                    "pages": [
+                      "l/zh/developers/extend/apps/data/overview",
+                      "l/zh/developers/extend/apps/data/objects",
+                      "l/zh/developers/extend/apps/data/extending-objects",
+                      "l/zh/developers/extend/apps/data/relations"
+                    ]
+                  },
+                  {
+                    "group": "Logic",
+                    "pages": [
+                      "l/zh/developers/extend/apps/logic/overview",
+                      "l/zh/developers/extend/apps/logic/logic-functions",
+                      "l/zh/developers/extend/apps/logic/skills-and-agents",
+                      "l/zh/developers/extend/apps/logic/connections"
+                    ]
+                  },
+                  {
+                    "group": "Layout",
+                    "pages": [
+                      "l/zh/developers/extend/apps/layout/overview",
+                      "l/zh/developers/extend/apps/layout/views",
+                      "l/zh/developers/extend/apps/layout/navigation-menu-items",
+                      "l/zh/developers/extend/apps/layout/page-layouts",
+                      "l/zh/developers/extend/apps/layout/front-components",
+                      "l/zh/developers/extend/apps/layout/command-menu-items"
+                    ]
+                  },
+                  {
+                    "group": "Operations",
+                    "pages": [
+                      "l/zh/developers/extend/apps/operations/overview",
+                      "l/zh/developers/extend/apps/operations/cli",
+                      "l/zh/developers/extend/apps/operations/testing",
+                      "l/zh/developers/extend/apps/operations/publishing"
+                    ]
+                  }
                 ]
               },
               {

--- a/packages/twenty-docs/navigation/base-structure.json
+++ b/packages/twenty-docs/navigation/base-structure.json
@@ -382,15 +382,71 @@
           "key": "apps",
           "label": "Apps",
           "pages": [
-            "developers/extend/apps/getting-started",
-            "developers/extend/apps/building",
-            "developers/extend/apps/data-model",
-            "developers/extend/apps/logic-functions",
-            "developers/extend/apps/front-components",
-            "developers/extend/apps/layout",
-            "developers/extend/apps/skills-and-agents",
-            "developers/extend/apps/cli-and-testing",
-            "developers/extend/apps/publishing"
+            {
+              "key": "appsGettingStarted",
+              "label": "Getting Started",
+              "pages": [
+                "developers/extend/apps/getting-started/quick-start",
+                "developers/extend/apps/getting-started/concepts",
+                "developers/extend/apps/getting-started/project-structure",
+                "developers/extend/apps/getting-started/local-server",
+                "developers/extend/apps/getting-started/scaffolding",
+                "developers/extend/apps/getting-started/troubleshooting"
+              ]
+            },
+            {
+              "key": "appsConfig",
+              "label": "Config",
+              "pages": [
+                "developers/extend/apps/config/overview",
+                "developers/extend/apps/config/application",
+                "developers/extend/apps/config/roles",
+                "developers/extend/apps/config/install-hooks",
+                "developers/extend/apps/config/public-assets"
+              ]
+            },
+            {
+              "key": "appsData",
+              "label": "Data",
+              "pages": [
+                "developers/extend/apps/data/overview",
+                "developers/extend/apps/data/objects",
+                "developers/extend/apps/data/extending-objects",
+                "developers/extend/apps/data/relations"
+              ]
+            },
+            {
+              "key": "appsLogic",
+              "label": "Logic",
+              "pages": [
+                "developers/extend/apps/logic/overview",
+                "developers/extend/apps/logic/logic-functions",
+                "developers/extend/apps/logic/skills-and-agents",
+                "developers/extend/apps/logic/connections"
+              ]
+            },
+            {
+              "key": "appsLayout",
+              "label": "Layout",
+              "pages": [
+                "developers/extend/apps/layout/overview",
+                "developers/extend/apps/layout/views",
+                "developers/extend/apps/layout/navigation-menu-items",
+                "developers/extend/apps/layout/page-layouts",
+                "developers/extend/apps/layout/front-components",
+                "developers/extend/apps/layout/command-menu-items"
+              ]
+            },
+            {
+              "key": "appsOperations",
+              "label": "Operations",
+              "pages": [
+                "developers/extend/apps/operations/overview",
+                "developers/extend/apps/operations/cli",
+                "developers/extend/apps/operations/testing",
+                "developers/extend/apps/operations/publishing"
+              ]
+            }
           ]
         },
         {

--- a/packages/twenty-docs/navigation/navigation.template.json
+++ b/packages/twenty-docs/navigation/navigation.template.json
@@ -155,7 +155,27 @@
           "label": "Overview"
         },
         "apps": {
-          "label": "Apps"
+          "label": "Apps",
+          "groups": {
+            "appsGettingStarted": {
+              "label": "Getting Started"
+            },
+            "appsConfig": {
+              "label": "Config"
+            },
+            "appsData": {
+              "label": "Data"
+            },
+            "appsLogic": {
+              "label": "Logic"
+            },
+            "appsLayout": {
+              "label": "Layout"
+            },
+            "appsOperations": {
+              "label": "Operations"
+            }
+          }
         },
         "api": {
           "label": "API"

--- a/packages/twenty-docs/scripts/generate-docs-json.ts
+++ b/packages/twenty-docs/scripts/generate-docs-json.ts
@@ -142,8 +142,15 @@ const buildGroup = (
   ),
 });
 
-const formatPageSlug = (slug: string, language: string): string =>
-  language === DEFAULT_LANGUAGE ? slug : `l/${language}/${slug}`;
+const formatPageSlug = (slug: string, language: string): string => {
+  if (language === DEFAULT_LANGUAGE) {
+    return slug;
+  }
+
+  const localizedPagePath = path.join(localesRoot, language, `${slug}.mdx`);
+
+  return fs.existsSync(localizedPagePath) ? `l/${language}/${slug}` : slug;
+};
 
 const hasLocaleContent = (language: string): boolean => {
   if (language === DEFAULT_LANGUAGE) {
@@ -165,4 +172,3 @@ if (!docsConfig.navigation) {
 docsConfig.navigation.languages = languages;
 
 fs.writeFileSync(docsPath, `${JSON.stringify(docsConfig, null, 2)}\n`);
-


### PR DESCRIPTION
## Scope & Context

Closes #20358.

The Apps docs were restructured into nested pages, but the generated docs navigation source still pointed to the old flat Apps page slugs. This made Developers > Apps navigation entries point to removed English docs pages.

## Technical inputs

- Update `packages/twenty-docs/navigation/base-structure.json` to use the current nested Apps docs structure.
- Regenerate `packages/twenty-docs/docs.json` and `packages/twenty-docs/navigation/navigation.template.json` from the updated structure.
- Update `generate-docs-json.ts` so localized navigation falls back to the English slug when the localized `.mdx` file does not exist yet, avoiding generated 404 links while translations catch up.

## Validation

- Parsed `docs.json`, `base-structure.json`, and `navigation.template.json` as valid JSON.
- Checked all generated navigation page slugs against existing `.mdx` files: `missing nav mdx 0`.
- Checked Apps navigation specifically: `missing apps nav mdx 0`.

`yarn docs:generate` could not be run in this local environment because Yarn/Corepack is not installed here, so I regenerated the JSON files with the same generator logic via Node.