### PR TITLE
Fix apps capability docs redirect

### DIFF
--- a/packages/twenty-docs/docs.json
+++ b/packages/twenty-docs/docs.json
@@ -6170,7 +6170,7 @@
     },
     {
       "source": "/developers/extend/capabilities/apps",
-      "destination": "/developers/extend/apps/getting-started"
+      "destination": "/developers/extend/apps/getting-started/quick-start"
     },
     {
       "source": "/developers/extend/mcp",


### PR DESCRIPTION
## Scope & Context

Closes #20370.

The legacy `/developers/extend/capabilities/apps` redirect pointed to `/developers/extend/apps/getting-started`, which is no longer an actual MDX page and is itself another redirect source.

## Technical inputs

- Point `/developers/extend/capabilities/apps` directly to the canonical Apps quick-start page: `/developers/extend/apps/getting-started/quick-start`.

## Validation

- Parsed `packages/twenty-docs/docs.json` as valid JSON.
- Checked every internal redirect destination against existing MDX pages: `bad internal redirect destinations 0`.