### PR TITLE
fix: validate enum values before opening transaction in alterEnumValues

### DIFF
--- a/packages/twenty-server/src/engine/twenty-orm/workspace-schema-manager/services/workspace-schema-enum-manager.service.ts
+++ b/packages/twenty-server/src/engine/twenty-orm/workspace-schema-manager/services/workspace-schema-enum-manager.service.ts
@@ -129,12 +129,6 @@ export class WorkspaceSchemaEnumManagerService {
     enumValues: string[];
     oldToNewEnumOptionMap: Record<string, string>;
   }): Promise<void> {
-    const isTransactionAlreadyActive = queryRunner.isTransactionActive;
-
-    if (!isTransactionAlreadyActive) {
-      await queryRunner.startTransaction();
-    }
-
     if (!enumValues || enumValues.length === 0) {
       throw new WorkspaceSchemaManagerException(
         `Cannot alter enum values for column ${columnDefinition.name} because it has no enum values`,

--- a/packages/twenty-server/src/engine/twenty-orm/workspace-schema-manager/services/workspace-schema-enum-manager.service.ts
+++ b/packages/twenty-server/src/engine/twenty-orm/workspace-schema-manager/services/workspace-schema-enum-manager.service.ts
@@ -142,6 +142,12 @@ export class WorkspaceSchemaEnumManagerService {
       );
     }
 
+    const isTransactionAlreadyActive = queryRunner.isTransactionActive;
+
+    if (!isTransactionAlreadyActive) {
+      await queryRunner.startTransaction();
+    }
+
     try {
       const columnName = columnDefinition.name;
 


### PR DESCRIPTION
## Context
The validation throws after startTransaction() and outside the surrounding try. 
If the empty-enum branch ever fires, a BEGIN is left open on the borrowed QueryRunner and never rolled back by this method the caller has no way of knowing it now owes a ROLLBACK. Whatever the caller does next on that QueryRunner runs inside the leftover transaction, and if its lifecycle ends with a release() instead of a rollbackTransaction(), the connection goes back to the pool with state still pending.