### PR TITLE
fix: prevent admin panel workspace upgrade error from overflowing the table

### DIFF
--- a/packages/twenty-front/src/modules/settings/admin-panel/components/SettingsAdminWorkspaceContent.tsx
+++ b/packages/twenty-front/src/modules/settings/admin-panel/components/SettingsAdminWorkspaceContent.tsx
@@ -211,7 +211,14 @@ export const SettingsAdminWorkspaceContent = ({
                     {
                       Icon: IconStatusChange,
                       label: t`Last error`,
-                      value: workspaceUpgradeStatus.latestCommand.errorMessage,
+                      value: (
+                        <OverflowingTextWithTooltip
+                          text={
+                            workspaceUpgradeStatus.latestCommand.errorMessage
+                          }
+                          isTooltipMultiline
+                        />
+                      ),
                     },
                   ]
                 : []),


### PR DESCRIPTION
## Summary

In the admin panel workspace detail page, the **Upgrade Status > Last error** row was rendering the raw `errorMessage` string directly. Long messages (typically full stack traces) overflowed the table cell and overlapped neighbouring rows, breaking the layout.

The `Last command` row in the same table already uses `OverflowingTextWithTooltip` (the helper used elsewhere in settings tables) to clamp long values to a single line and reveal the full text in a tooltip on hover.

This PR applies the same treatment to the `Last error` row, with `isTooltipMultiline` so newlines in the stack trace are preserved when the tooltip opens.

## Test plan

- [ ] Open Admin Panel > a workspace with a failed upgrade and verify the `Last error` row stays on a single line with an ellipsis
- [ ] Hover the row and verify the full multi-line error is shown in the tooltip
- [ ] Verify other rows (Last command, Last updated, etc.) and the workspace info section are unaffected