### PR TITLE
fix: update broken AI documentation link

### DIFF
--- a/packages/twenty-front/src/modules/ai/components/AiChatApiKeyNotConfiguredMessage.tsx
+++ b/packages/twenty-front/src/modules/ai/components/AiChatApiKeyNotConfiguredMessage.tsx
@@ -3,8 +3,7 @@ import { t } from '@lingui/core/macro';
 import { IconExternalLink } from 'twenty-ui/display';
 
 const DOCS_URL =
-  'https://twenty.com/developers/section/self-hosting/self-hosting-var#ai-features';
-
+  'https://twenty.com/developers/section/self-hosting/docker-compose';
 export const AiChatApiKeyNotConfiguredMessage = () => {
   const handleDocsClick = () => {
     window.open(DOCS_URL, '_blank', 'noopener,noreferrer');

--- a/packages/twenty-front/src/modules/ai/components/AiChatApiKeyNotConfiguredMessage.tsx
+++ b/packages/twenty-front/src/modules/ai/components/AiChatApiKeyNotConfiguredMessage.tsx
@@ -1,12 +1,20 @@
 import { AiChatBanner } from '@/ai/components/AiChatBanner';
+import { currentWorkspaceMemberState } from '@/auth/states/currentWorkspaceMemberState';
+import { getDocumentationUrl } from '@/support/utils/getDocumentationUrl';
+import { useAtomStateValue } from '@/ui/utilities/state/jotai/hooks/useAtomStateValue';
 import { t } from '@lingui/core/macro';
+import { DOCUMENTATION_PATHS } from 'twenty-shared/constants';
 import { IconExternalLink } from 'twenty-ui/display';
 
-const DOCS_URL =
-  'https://twenty.com/developers/section/self-hosting/docker-compose';
 export const AiChatApiKeyNotConfiguredMessage = () => {
+  const currentWorkspaceMember = useAtomStateValue(currentWorkspaceMemberState);
+
   const handleDocsClick = () => {
-    window.open(DOCS_URL, '_blank', 'noopener,noreferrer');
+    const docsUrl = getDocumentationUrl({
+      locale: currentWorkspaceMember?.locale,
+      path: DOCUMENTATION_PATHS.DEVELOPERS_SELF_HOST_CAPABILITIES_SETUP,
+    });
+    window.open(docsUrl, '_blank', 'noopener,noreferrer');
   };
 
   return (


### PR DESCRIPTION
## Summary

Updated the broken AI documentation link in `AiChatApiKeyNotConfiguredMessage.tsx`.

## Changes

* Replaced outdated self-hosting AI docs URL
* Updated link to a valid self-hosting documentation page

Fixes #20071
