### PR TITLE
refactor: scope ApplicationRegistrationService findOneById to tenant rows

### DIFF
--- a/packages/twenty-server/src/engine/core-modules/application/application-registration/application-registration.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/application/application-registration/application-registration.service.ts
@@ -6,7 +6,7 @@ import crypto from 'crypto';
 import * as bcrypt from 'bcrypt';
 import { type Manifest } from 'twenty-shared/application';
 import { isDefined } from 'twenty-shared/utils';
-import { IsNull, type Repository } from 'typeorm';
+import { type Repository } from 'typeorm';
 import { v4 } from 'uuid';
 
 import { ALL_OAUTH_SCOPES } from 'src/engine/core-modules/application/application-oauth/constants/oauth-scopes';
@@ -56,15 +56,16 @@ export class ApplicationRegistrationService {
     });
   }
 
+  // Tenant-scoped lookup. Only returns registrations the caller's workspace
+  // owns. System-level rows (ownerWorkspaceId IS NULL — DCR clients, marketplace
+  // catalog entries, the Twenty CLI registration) are intentionally excluded
+  // here. Admin paths must use findOneByIdGlobal instead.
   async findOneById(
     id: string,
     ownerWorkspaceId: string,
   ): Promise<ApplicationRegistrationEntity> {
     const registration = await this.applicationRegistrationRepository.findOne({
-      where: [
-        { id, ownerWorkspaceId },
-        { id, ownerWorkspaceId: IsNull() },
-      ],
+      where: { id, ownerWorkspaceId },
     });
 
     if (!registration) {

--- a/packages/twenty-server/src/engine/core-modules/application/application-registration/application-registration.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/application/application-registration/application-registration.service.ts
@@ -56,10 +56,6 @@ export class ApplicationRegistrationService {
     });
   }
 
-  // Tenant-scoped lookup. Only returns registrations the caller's workspace
-  // owns. System-level rows (ownerWorkspaceId IS NULL — DCR clients, marketplace
-  // catalog entries, the Twenty CLI registration) are intentionally excluded
-  // here. Admin paths must use findOneByIdGlobal instead.
   async findOneById(
     id: string,
     ownerWorkspaceId: string,


### PR DESCRIPTION
## Summary

- `findOneById` is the lookup used by tenant-scoped operations (`update`, `delete`, `rotateClientSecret`, `getStats`, `transferOwnership`). It currently also matches `ownerWorkspaceId IS NULL` rows, which was a leftover from when `ownerWorkspaceId` was made nullable to support catalog-synced apps.
- System-level rows (marketplace catalog entries, the Twenty CLI registration, dynamic OAuth client registrations) are already managed through dedicated admin paths — `findAll()` and `findOneByIdGlobal()` behind `AdminPanelGuard` — so the `IS NULL` fallback in `findOneById` is unused by any real caller.
- Dropping it tightens the contract: tenant-scoped helpers operate on tenant rows, global helpers operate on the global view. No behavior change for any current legitimate flow.

## Test plan

- [ ] Existing application-registration GraphQL queries/mutations (`findOneApplicationRegistration`, `updateApplicationRegistration`, `deleteApplicationRegistration`, `rotateApplicationRegistrationClientSecret`, `findApplicationRegistrationStats`, `transferApplicationRegistrationOwnership`) continue to work for a workspace's own registrations.
- [ ] Admin Panel "Apps" tab continues to list and view all registrations (uses `findAllApplicationRegistrations` / `findOneAdminApplicationRegistration`, unaffected).
- [ ] Marketplace catalog sync still upserts catalog rows (uses `findOneByUniversalIdentifier`, unaffected).
- [ ] Twenty CLI registration bootstrap still works (uses `findOneByUniversalIdentifier`, unaffected).

🤖 Generated with [Claude Code](https://claude.com/claude-code)