### PR TITLE
fix(messaging): add null guards for connected account in IMAP sync

### DIFF
--- a/packages/twenty-server/src/modules/messaging/message-import-manager/jobs/messaging-message-list-fetch.job.ts
+++ b/packages/twenty-server/src/modules/messaging/message-import-manager/jobs/messaging-message-list-fetch.job.ts
@@ -67,6 +67,16 @@ export class MessagingMessageListFetchJob {
         return;
       }
 
+      if (!messageChannel.connectedAccount) {
+        await this.messagingMonitoringService.track({
+          eventName: 'message_list_fetch_job.error.connected_account_not_found',
+          messageChannelId,
+          workspaceId,
+        });
+
+        return;
+      }
+
       if (
         messageChannel.syncStage !==
         MessageChannelSyncStage.MESSAGE_LIST_FETCH_SCHEDULED

--- a/packages/twenty-server/src/modules/messaging/message-import-manager/services/__tests__/messaging-message-list-fetch.service.spec.ts
+++ b/packages/twenty-server/src/modules/messaging/message-import-manager/services/__tests__/messaging-message-list-fetch.service.spec.ts
@@ -18,6 +18,7 @@ import { MessagingGetMessageListService } from 'src/modules/messaging/message-im
 import { MessageImportExceptionHandlerService } from 'src/modules/messaging/message-import-manager/services/messaging-import-exception-handler.service';
 import { MessagingMessageListFetchService } from 'src/modules/messaging/message-import-manager/services/messaging-message-list-fetch.service';
 import { MessagingMessagesImportService } from 'src/modules/messaging/message-import-manager/services/messaging-messages-import.service';
+import { MessagingMonitoringService } from 'src/modules/messaging/monitoring/services/messaging-monitoring.service';
 import { MessagingProcessFolderActionsService } from 'src/modules/messaging/message-import-manager/services/messaging-process-folder-actions.service';
 import { MessagingProcessGroupEmailActionsService } from 'src/modules/messaging/message-import-manager/services/messaging-process-group-email-actions.service';
 import { MessageChannelEntity } from 'src/engine/metadata-modules/message-channel/entities/message-channel.entity';
@@ -283,6 +284,12 @@ describe('MessagingMessageListFetchService', () => {
           provide: MessagingProcessFolderActionsService,
           useValue: {
             processFolderActions: jest.fn().mockResolvedValue(undefined),
+          },
+        },
+        {
+          provide: MessagingMonitoringService,
+          useValue: {
+            track: jest.fn().mockResolvedValue(undefined),
           },
         },
       ],

--- a/packages/twenty-server/src/modules/messaging/message-import-manager/services/messaging-message-list-fetch.service.ts
+++ b/packages/twenty-server/src/modules/messaging/message-import-manager/services/messaging-message-list-fetch.service.ts
@@ -28,6 +28,7 @@ import {
   MessageImportSyncStep,
 } from 'src/modules/messaging/message-import-manager/services/messaging-import-exception-handler.service';
 import { MessagingMessagesImportService } from 'src/modules/messaging/message-import-manager/services/messaging-messages-import.service';
+import { MessagingMonitoringService } from 'src/modules/messaging/monitoring/services/messaging-monitoring.service';
 import { MessagingProcessFolderActionsService } from 'src/modules/messaging/message-import-manager/services/messaging-process-folder-actions.service';
 import { MessagingProcessGroupEmailActionsService } from 'src/modules/messaging/message-import-manager/services/messaging-process-group-email-actions.service';
 import { MessageChannelEntity } from 'src/engine/metadata-modules/message-channel/entities/message-channel.entity';
@@ -53,6 +54,7 @@ export class MessagingMessageListFetchService {
     private readonly syncMessageFoldersService: SyncMessageFoldersService,
     private readonly messagingProcessGroupEmailActionsService: MessagingProcessGroupEmailActionsService,
     private readonly messagingProcessFolderActionsService: MessagingProcessFolderActionsService,
+    private readonly messagingMonitoringService: MessagingMonitoringService,
   ) {}
 
   public async processMessageListFetch(
@@ -96,6 +98,16 @@ export class MessagingMessageListFetchService {
           this.logger.error(
             `WorkspaceId: ${workspaceId}, MessageChannelId: ${messageChannel.id} - Message channel not found`,
           );
+
+          return;
+        }
+
+        if (!isDefined(freshMessageChannel.connectedAccount)) {
+          await this.messagingMonitoringService.track({
+            eventName: 'message_list_fetch.error.connected_account_not_found',
+            workspaceId,
+            messageChannelId: freshMessageChannel.id,
+          });
 
           return;
         }


### PR DESCRIPTION
This PR resolves the IMAP sync crash reported in #19494 by adding null guards for `connectedAccount` in the messaging fetch pipeline.

### Root Cause
A recent schema migration (1.20) resulted in some `messageChannel` records being created without a corresponding `connectedAccount` in the core schema. When the sync job attempts to access `messageChannel.connectedAccount.id`, it throws a null pointer exception, crashing the background worker.

### Changes
- Added null check in `MessagingMessageListFetchJob` before accessing `connectedAccount`.
- Added null check in `MessagingMessageListFetchService` and injected `MessagingMonitoringService` to properly track the error via the existing monitoring infrastructure.

These guards prevent the worker from crashing while ensuring the 'connected account not found' event is logged for operational monitoring.

Fixes #19494