### PR TITLE
Refactor SAML relayState structure

### DIFF
--- a/packages/twenty-server/src/engine/core-modules/auth/strategies/saml.auth.strategy.spec.ts
+++ b/packages/twenty-server/src/engine/core-modules/auth/strategies/saml.auth.strategy.spec.ts
@@ -1,0 +1,143 @@
+import { type Request } from 'express';
+
+import {
+  AuthException,
+  AuthExceptionCode,
+} from 'src/engine/core-modules/auth/auth.exception';
+import { type SSOService } from 'src/engine/core-modules/sso/services/sso.service';
+
+import { SamlAuthStrategy } from './saml.auth.strategy';
+
+const IDP_A = 'idp-a-uuid';
+const IDP_B = 'idp-b-uuid';
+const VALID_EMAIL = 'alice@example.com';
+
+const buildRequest = ({
+  paramsIdpId,
+  relayStateIdpId,
+  workspaceInviteHash,
+  omitRelayState,
+}: {
+  paramsIdpId: string;
+  relayStateIdpId?: string;
+  workspaceInviteHash?: string;
+  omitRelayState?: boolean;
+}) =>
+  ({
+    params: { identityProviderId: paramsIdpId },
+    body: omitRelayState
+      ? {}
+      : {
+          RelayState: JSON.stringify({
+            identityProviderId: relayStateIdpId,
+            ...(workspaceInviteHash ? { workspaceInviteHash } : {}),
+          }),
+        },
+  }) as unknown as Request;
+
+const buildProfile = (email = VALID_EMAIL) =>
+  ({
+    email,
+    nameID: email,
+    issuer: 'irrelevant',
+  }) as unknown as Parameters<SamlAuthStrategy['validate']>[1];
+
+describe('SamlAuthStrategy.validate', () => {
+  let strategy: SamlAuthStrategy;
+
+  beforeEach(() => {
+    const ssoService = {
+      findSSOIdentityProviderById: jest.fn(),
+      isSAMLIdentityProvider: jest.fn(),
+      buildIssuerURL: jest.fn(),
+      buildCallbackUrl: jest.fn(),
+    } as unknown as SSOService;
+
+    strategy = new SamlAuthStrategy(ssoService);
+  });
+
+  it('rejects auth when RelayState.identityProviderId disagrees with the path param (workspace-confusion attempt)', async () => {
+    const request = buildRequest({
+      paramsIdpId: IDP_A,
+      relayStateIdpId: IDP_B,
+    });
+    const done = jest.fn();
+
+    await strategy.validate(request, buildProfile(), done);
+
+    expect(done).toHaveBeenCalledTimes(1);
+    const err = done.mock.calls[0][0];
+
+    expect(err).toBeInstanceOf(AuthException);
+    expect(err.code).toBe(AuthExceptionCode.INVALID_INPUT);
+    expect(err.message).toMatch(/identity provider mismatch/i);
+    expect(done.mock.calls[0][1]).toBeUndefined();
+  });
+
+  it('binds req.user.identityProviderId to the path param (verified IdP), not RelayState, on the happy path', async () => {
+    const request = buildRequest({
+      paramsIdpId: IDP_A,
+      relayStateIdpId: IDP_A,
+      workspaceInviteHash: 'invite-hash-123',
+    });
+    const done = jest.fn();
+
+    await strategy.validate(request, buildProfile(), done);
+
+    expect(done).toHaveBeenCalledTimes(1);
+    expect(done.mock.calls[0][0]).toBeNull();
+    expect(done.mock.calls[0][1]).toEqual({
+      identityProviderId: IDP_A,
+      workspaceInviteHash: 'invite-hash-123',
+      email: VALID_EMAIL,
+    });
+  });
+
+  it('rejects auth when RelayState is missing entirely', async () => {
+    const request = buildRequest({
+      paramsIdpId: IDP_A,
+      omitRelayState: true,
+    });
+    const done = jest.fn();
+
+    await strategy.validate(request, buildProfile(), done);
+
+    expect(done).toHaveBeenCalledTimes(1);
+    const err = done.mock.calls[0][0];
+
+    expect(err).toBeInstanceOf(AuthException);
+    expect(err.code).toBe(AuthExceptionCode.INVALID_INPUT);
+  });
+
+  it('rejects auth when the email claim is invalid', async () => {
+    const request = buildRequest({
+      paramsIdpId: IDP_A,
+      relayStateIdpId: IDP_A,
+    });
+    const done = jest.fn();
+
+    await strategy.validate(request, buildProfile('not-an-email'), done);
+
+    expect(done).toHaveBeenCalledTimes(1);
+    expect(done.mock.calls[0][0]).toBeInstanceOf(Error);
+    expect(done.mock.calls[0][0].message).toBe('Invalid email');
+  });
+
+  it('rejects auth when the profile is missing', async () => {
+    const request = buildRequest({
+      paramsIdpId: IDP_A,
+      relayStateIdpId: IDP_A,
+    });
+    const done = jest.fn();
+
+    await strategy.validate(
+      request,
+      undefined as unknown as Parameters<SamlAuthStrategy['validate']>[1],
+      done,
+    );
+
+    expect(done).toHaveBeenCalledTimes(1);
+    expect(done.mock.calls[0][0]).toBeInstanceOf(Error);
+    expect(done.mock.calls[0][0].message).toBe('Profile is must be provided');
+  });
+});

--- a/packages/twenty-server/src/engine/core-modules/auth/strategies/saml.auth.strategy.spec.ts
+++ b/packages/twenty-server/src/engine/core-modules/auth/strategies/saml.auth.strategy.spec.ts
@@ -1,9 +1,5 @@
 import { type Request } from 'express';
 
-import {
-  AuthException,
-  AuthExceptionCode,
-} from 'src/engine/core-modules/auth/auth.exception';
 import { type SSOService } from 'src/engine/core-modules/sso/services/sso.service';
 
 import { SamlAuthStrategy } from './saml.auth.strategy';
@@ -12,30 +8,33 @@ const IDP_A = 'idp-a-uuid';
 const IDP_B = 'idp-b-uuid';
 const VALID_EMAIL = 'alice@example.com';
 
+type RelayStateInput =
+  | { kind: 'absent' }
+  | { kind: 'raw'; value: string }
+  | { kind: 'json'; value: Record<string, unknown> };
+
 const buildRequest = ({
   paramsIdpId,
-  relayStateIdpId,
-  workspaceInviteHash,
-  omitRelayState,
+  relayState = { kind: 'absent' },
 }: {
   paramsIdpId: string;
-  relayStateIdpId?: string;
-  workspaceInviteHash?: string;
-  omitRelayState?: boolean;
-}) =>
-  ({
-    params: { identityProviderId: paramsIdpId },
-    body: omitRelayState
-      ? {}
-      : {
-          RelayState: JSON.stringify({
-            identityProviderId: relayStateIdpId,
-            ...(workspaceInviteHash ? { workspaceInviteHash } : {}),
-          }),
-        },
-  }) as unknown as Request;
+  relayState?: RelayStateInput;
+}) => {
+  let body: Record<string, unknown> = {};
 
-const buildProfile = (email = VALID_EMAIL) =>
+  if (relayState.kind === 'raw') {
+    body = { RelayState: relayState.value };
+  } else if (relayState.kind === 'json') {
+    body = { RelayState: JSON.stringify(relayState.value) };
+  }
+
+  return {
+    params: { identityProviderId: paramsIdpId },
+    body,
+  } as unknown as Request;
+};
+
+const buildProfile = (email: string = VALID_EMAIL) =>
   ({
     email,
     nameID: email,
@@ -56,29 +55,49 @@ describe('SamlAuthStrategy.validate', () => {
     strategy = new SamlAuthStrategy(ssoService);
   });
 
-  it('rejects auth when RelayState.identityProviderId disagrees with the path param (workspace-confusion attempt)', async () => {
+  // Regression test for the workspace-confusion finding. An attacker-controlled
+  // RelayState that claims a different identity-provider id than the one whose
+  // cert verified the assertion must have zero influence on the resolved IdP.
+  it('ignores RelayState.identityProviderId and sources it exclusively from the URL path', async () => {
     const request = buildRequest({
       paramsIdpId: IDP_A,
-      relayStateIdpId: IDP_B,
+      relayState: { kind: 'json', value: { identityProviderId: IDP_B } },
     });
     const done = jest.fn();
 
     await strategy.validate(request, buildProfile(), done);
 
     expect(done).toHaveBeenCalledTimes(1);
-    const err = done.mock.calls[0][0];
-
-    expect(err).toBeInstanceOf(AuthException);
-    expect(err.code).toBe(AuthExceptionCode.INVALID_INPUT);
-    expect(err.message).toMatch(/identity provider mismatch/i);
-    expect(done.mock.calls[0][1]).toBeUndefined();
+    expect(done.mock.calls[0][0]).toBeNull();
+    expect(done.mock.calls[0][1]).toEqual({
+      identityProviderId: IDP_A,
+      workspaceInviteHash: undefined,
+      email: VALID_EMAIL,
+    });
   });
 
-  it('binds req.user.identityProviderId to the path param (verified IdP), not RelayState, on the happy path', async () => {
+  it('accepts a request with no RelayState at all (no workspaceInviteHash threaded through)', async () => {
+    const request = buildRequest({ paramsIdpId: IDP_A });
+    const done = jest.fn();
+
+    await strategy.validate(request, buildProfile(), done);
+
+    expect(done).toHaveBeenCalledTimes(1);
+    expect(done.mock.calls[0][0]).toBeNull();
+    expect(done.mock.calls[0][1]).toEqual({
+      identityProviderId: IDP_A,
+      workspaceInviteHash: undefined,
+      email: VALID_EMAIL,
+    });
+  });
+
+  it('threads workspaceInviteHash from RelayState through to req.user', async () => {
     const request = buildRequest({
       paramsIdpId: IDP_A,
-      relayStateIdpId: IDP_A,
-      workspaceInviteHash: 'invite-hash-123',
+      relayState: {
+        kind: 'json',
+        value: { workspaceInviteHash: 'invite-hash-123' },
+      },
     });
     const done = jest.fn();
 
@@ -93,27 +112,71 @@ describe('SamlAuthStrategy.validate', () => {
     });
   });
 
-  it('rejects auth when RelayState is missing entirely', async () => {
+  it('still resolves identityProviderId from the URL path when RelayState mixes a malicious id with a real invite hash', async () => {
     const request = buildRequest({
       paramsIdpId: IDP_A,
-      omitRelayState: true,
+      relayState: {
+        kind: 'json',
+        value: {
+          identityProviderId: IDP_B,
+          workspaceInviteHash: 'invite-hash-123',
+        },
+      },
     });
     const done = jest.fn();
 
     await strategy.validate(request, buildProfile(), done);
 
     expect(done).toHaveBeenCalledTimes(1);
-    const err = done.mock.calls[0][0];
+    expect(done.mock.calls[0][0]).toBeNull();
+    expect(done.mock.calls[0][1]).toEqual({
+      identityProviderId: IDP_A,
+      workspaceInviteHash: 'invite-hash-123',
+      email: VALID_EMAIL,
+    });
+  });
 
-    expect(err).toBeInstanceOf(AuthException);
-    expect(err.code).toBe(AuthExceptionCode.INVALID_INPUT);
+  it('tolerates malformed RelayState JSON without throwing (no invite hash extracted)', async () => {
+    const request = buildRequest({
+      paramsIdpId: IDP_A,
+      relayState: { kind: 'raw', value: 'not-json{' },
+    });
+    const done = jest.fn();
+
+    await strategy.validate(request, buildProfile(), done);
+
+    expect(done).toHaveBeenCalledTimes(1);
+    expect(done.mock.calls[0][0]).toBeNull();
+    expect(done.mock.calls[0][1]).toEqual({
+      identityProviderId: IDP_A,
+      workspaceInviteHash: undefined,
+      email: VALID_EMAIL,
+    });
+  });
+
+  it('ignores non-string workspaceInviteHash payloads in RelayState', async () => {
+    const request = buildRequest({
+      paramsIdpId: IDP_A,
+      relayState: {
+        kind: 'json',
+        value: { workspaceInviteHash: { nested: 'object' } },
+      },
+    });
+    const done = jest.fn();
+
+    await strategy.validate(request, buildProfile(), done);
+
+    expect(done).toHaveBeenCalledTimes(1);
+    expect(done.mock.calls[0][0]).toBeNull();
+    expect(done.mock.calls[0][1]).toEqual({
+      identityProviderId: IDP_A,
+      workspaceInviteHash: undefined,
+      email: VALID_EMAIL,
+    });
   });
 
   it('rejects auth when the email claim is invalid', async () => {
-    const request = buildRequest({
-      paramsIdpId: IDP_A,
-      relayStateIdpId: IDP_A,
-    });
+    const request = buildRequest({ paramsIdpId: IDP_A });
     const done = jest.fn();
 
     await strategy.validate(request, buildProfile('not-an-email'), done);
@@ -124,10 +187,7 @@ describe('SamlAuthStrategy.validate', () => {
   });
 
   it('rejects auth when the profile is missing', async () => {
-    const request = buildRequest({
-      paramsIdpId: IDP_A,
-      relayStateIdpId: IDP_A,
-    });
+    const request = buildRequest({ paramsIdpId: IDP_A });
     const done = jest.fn();
 
     await strategy.validate(

--- a/packages/twenty-server/src/engine/core-modules/auth/strategies/saml.auth.strategy.spec.ts
+++ b/packages/twenty-server/src/engine/core-modules/auth/strategies/saml.auth.strategy.spec.ts
@@ -1,3 +1,5 @@
+/* @license Enterprise */
+
 import { type Request } from 'express';
 
 import { type SSOService } from 'src/engine/core-modules/sso/services/sso.service';
@@ -198,6 +200,6 @@ describe('SamlAuthStrategy.validate', () => {
 
     expect(done).toHaveBeenCalledTimes(1);
     expect(done.mock.calls[0][0]).toBeInstanceOf(Error);
-    expect(done.mock.calls[0][0].message).toBe('Profile is must be provided');
+    expect(done.mock.calls[0][0].message).toBe('Profile must be provided');
   });
 });

--- a/packages/twenty-server/src/engine/core-modules/auth/strategies/saml.auth.strategy.ts
+++ b/packages/twenty-server/src/engine/core-modules/auth/strategies/saml.auth.strategy.ts
@@ -14,10 +14,6 @@ import { type AuthenticateOptions } from '@node-saml/passport-saml/lib/types';
 import { isEmail } from 'class-validator';
 import { type Request } from 'express';
 
-import {
-  AuthException,
-  AuthExceptionCode,
-} from 'src/engine/core-modules/auth/auth.exception';
 import { SSOService } from 'src/engine/core-modules/sso/services/sso.service';
 
 export type SAMLRequest = Omit<
@@ -83,36 +79,49 @@ export class SamlAuthStrategy extends PassportStrategy(
   }
 
   authenticate(req: Request, options: AuthenticateOptions) {
+    const workspaceInviteHash = req.query.workspaceInviteHash;
+
     super.authenticate(req, {
       ...options,
-      additionalParams: {
-        RelayState: JSON.stringify({
-          identityProviderId: req.params.identityProviderId,
-          ...(req.query.workspaceInviteHash
-            ? { workspaceInviteHash: req.query.workspaceInviteHash }
-            : {}),
-        }),
-      },
+      ...(typeof workspaceInviteHash === 'string'
+        ? {
+            additionalParams: {
+              RelayState: JSON.stringify({ workspaceInviteHash }),
+            },
+          }
+        : {}),
     });
   }
 
-  private extractState(req: Request): {
-    identityProviderId: string;
-    workspaceInviteHash?: string;
-  } {
-    try {
-      if ('RelayState' in req.body && typeof req.body.RelayState === 'string') {
-        const RelayState = JSON.parse(req.body.RelayState);
+  // RelayState is an unsigned, attacker-shapeable form field. It must never
+  // carry the identity-provider id (that lives in the ACS URL path and is what
+  // selects the cert that verifies the SAML signature). The only legitimate
+  // payload here is `workspaceInviteHash`, which is an SP-side query param
+  // that has no other way to survive the IdP round-trip.
+  private extractWorkspaceInviteHash(req: Request): string | undefined {
+    if (
+      !('RelayState' in req.body) ||
+      typeof req.body.RelayState !== 'string'
+    ) {
+      return undefined;
+    }
 
-        return {
-          identityProviderId: RelayState.identityProviderId,
-          workspaceInviteHash: RelayState.workspaceInviteHash,
-        };
+    try {
+      const parsed: unknown = JSON.parse(req.body.RelayState);
+
+      if (
+        typeof parsed === 'object' &&
+        parsed !== null &&
+        'workspaceInviteHash' in parsed &&
+        typeof (parsed as { workspaceInviteHash: unknown })
+          .workspaceInviteHash === 'string'
+      ) {
+        return (parsed as { workspaceInviteHash: string }).workspaceInviteHash;
       }
 
-      throw new Error();
+      return undefined;
     } catch {
-      throw new AuthException('Invalid state', AuthExceptionCode.INVALID_INPUT);
+      return undefined;
     }
   }
 
@@ -127,27 +136,15 @@ export class SamlAuthStrategy extends PassportStrategy(
       if (!isEmail(email)) {
         return done(new Error('Invalid email'));
       }
-      const state = this.extractState(request);
-      const verifiedIdentityProviderId = request.params.identityProviderId;
 
-      // The IdP cert that just verified this SAML assertion was selected from
-      // `req.params.identityProviderId` in `getSamlOptions`. RelayState, in
-      // contrast, is part of the attacker-controllable ACS POST body. If the
-      // two disagree we must refuse the auth: otherwise an assertion signed by
-      // IdP A could be attached to a session that the controller then resolves
-      // against IdP B's workspace.
-      if (state.identityProviderId !== verifiedIdentityProviderId) {
-        return done(
-          new AuthException(
-            'SAML RelayState identity provider mismatch',
-            AuthExceptionCode.INVALID_INPUT,
-          ),
-        );
-      }
-
+      // `identityProviderId` is sourced exclusively from the URL path. That
+      // value is what `getSamlOptions` used to pick the IdP cert that just
+      // verified this assertion, so it is the only identifier cryptographically
+      // bound to the signed payload. Reading it from RelayState would let an
+      // attacker route an assertion signed by IdP A into IdP B's workspace.
       done(null, {
-        identityProviderId: verifiedIdentityProviderId,
-        workspaceInviteHash: state.workspaceInviteHash,
+        identityProviderId: request.params.identityProviderId,
+        workspaceInviteHash: this.extractWorkspaceInviteHash(request),
         email,
       });
     } catch (err) {

--- a/packages/twenty-server/src/engine/core-modules/auth/strategies/saml.auth.strategy.ts
+++ b/packages/twenty-server/src/engine/core-modules/auth/strategies/saml.auth.strategy.ts
@@ -17,11 +17,7 @@ import { z } from 'zod';
 
 import { SSOService } from 'src/engine/core-modules/sso/services/sso.service';
 
-const RELAY_STATE_PAYLOAD_SCHEMA = z.object({
-  workspaceInviteHash: z.string().optional(),
-});
-
-const SAML_LOGIN_QUERY_SCHEMA = z.object({
+const WORKSPACE_INVITE_HASH_PAYLOAD_SCHEMA = z.object({
   workspaceInviteHash: z.string().optional(),
 });
 
@@ -40,7 +36,7 @@ const RELAY_STATE_BODY_SCHEMA = z.object({
         return z.NEVER;
       }
     })
-    .pipe(RELAY_STATE_PAYLOAD_SCHEMA),
+    .pipe(WORKSPACE_INVITE_HASH_PAYLOAD_SCHEMA),
 });
 
 export type SAMLRequest = Omit<
@@ -106,7 +102,9 @@ export class SamlAuthStrategy extends PassportStrategy(
   }
 
   authenticate(req: Request, options: AuthenticateOptions) {
-    const queryParseResult = SAML_LOGIN_QUERY_SCHEMA.safeParse(req.query);
+    const queryParseResult = WORKSPACE_INVITE_HASH_PAYLOAD_SCHEMA.safeParse(
+      req.query,
+    );
     const workspaceInviteHash = queryParseResult.success
       ? queryParseResult.data.workspaceInviteHash
       : undefined;

--- a/packages/twenty-server/src/engine/core-modules/auth/strategies/saml.auth.strategy.ts
+++ b/packages/twenty-server/src/engine/core-modules/auth/strategies/saml.auth.strategy.ts
@@ -13,8 +13,31 @@ import {
 import { type AuthenticateOptions } from '@node-saml/passport-saml/lib/types';
 import { isEmail } from 'class-validator';
 import { type Request } from 'express';
+import { z } from 'zod';
 
 import { SSOService } from 'src/engine/core-modules/sso/services/sso.service';
+
+const WORKSPACE_INVITE_HASH_SCHEMA = z.object({
+  workspaceInviteHash: z.string().optional(),
+});
+
+const RELAY_STATE_BODY_SCHEMA = z.object({
+  RelayState: z
+    .string()
+    .transform((raw, ctx) => {
+      try {
+        return JSON.parse(raw) as unknown;
+      } catch {
+        ctx.addIssue({
+          code: 'custom',
+          message: 'RelayState is not valid JSON',
+        });
+
+        return z.NEVER;
+      }
+    })
+    .pipe(WORKSPACE_INVITE_HASH_SCHEMA),
+});
 
 export type SAMLRequest = Omit<
   Request,
@@ -79,11 +102,14 @@ export class SamlAuthStrategy extends PassportStrategy(
   }
 
   authenticate(req: Request, options: AuthenticateOptions) {
-    const workspaceInviteHash = req.query.workspaceInviteHash;
+    const queryParseResult = WORKSPACE_INVITE_HASH_SCHEMA.safeParse(req.query);
+    const workspaceInviteHash = queryParseResult.success
+      ? queryParseResult.data.workspaceInviteHash
+      : undefined;
 
     super.authenticate(req, {
       ...options,
-      ...(typeof workspaceInviteHash === 'string'
+      ...(workspaceInviteHash !== undefined
         ? {
             additionalParams: {
               RelayState: JSON.stringify({ workspaceInviteHash }),
@@ -93,36 +119,12 @@ export class SamlAuthStrategy extends PassportStrategy(
     });
   }
 
-  // RelayState is an unsigned, attacker-shapeable form field. It must never
-  // carry the identity-provider id (that lives in the ACS URL path and is what
-  // selects the cert that verifies the SAML signature). The only legitimate
-  // payload here is `workspaceInviteHash`, which is an SP-side query param
-  // that has no other way to survive the IdP round-trip.
   private extractWorkspaceInviteHash(req: Request): string | undefined {
-    if (
-      !('RelayState' in req.body) ||
-      typeof req.body.RelayState !== 'string'
-    ) {
-      return undefined;
-    }
+    const result = RELAY_STATE_BODY_SCHEMA.safeParse(req.body);
 
-    try {
-      const parsed: unknown = JSON.parse(req.body.RelayState);
-
-      if (
-        typeof parsed === 'object' &&
-        parsed !== null &&
-        'workspaceInviteHash' in parsed &&
-        typeof (parsed as { workspaceInviteHash: unknown })
-          .workspaceInviteHash === 'string'
-      ) {
-        return (parsed as { workspaceInviteHash: string }).workspaceInviteHash;
-      }
-
-      return undefined;
-    } catch {
-      return undefined;
-    }
+    return result.success
+      ? result.data.RelayState.workspaceInviteHash
+      : undefined;
   }
 
   validate: VerifyWithRequest = async (request, profile, done) => {
@@ -137,11 +139,6 @@ export class SamlAuthStrategy extends PassportStrategy(
         return done(new Error('Invalid email'));
       }
 
-      // `identityProviderId` is sourced exclusively from the URL path. That
-      // value is what `getSamlOptions` used to pick the IdP cert that just
-      // verified this assertion, so it is the only identifier cryptographically
-      // bound to the signed payload. Reading it from RelayState would let an
-      // attacker route an assertion signed by IdP A into IdP B's workspace.
       done(null, {
         identityProviderId: request.params.identityProviderId,
         workspaceInviteHash: this.extractWorkspaceInviteHash(request),

--- a/packages/twenty-server/src/engine/core-modules/auth/strategies/saml.auth.strategy.ts
+++ b/packages/twenty-server/src/engine/core-modules/auth/strategies/saml.auth.strategy.ts
@@ -17,7 +17,11 @@ import { z } from 'zod';
 
 import { SSOService } from 'src/engine/core-modules/sso/services/sso.service';
 
-const WORKSPACE_INVITE_HASH_SCHEMA = z.object({
+const RELAY_STATE_PAYLOAD_SCHEMA = z.object({
+  workspaceInviteHash: z.string().optional(),
+});
+
+const SAML_LOGIN_QUERY_SCHEMA = z.object({
   workspaceInviteHash: z.string().optional(),
 });
 
@@ -36,7 +40,7 @@ const RELAY_STATE_BODY_SCHEMA = z.object({
         return z.NEVER;
       }
     })
-    .pipe(WORKSPACE_INVITE_HASH_SCHEMA),
+    .pipe(RELAY_STATE_PAYLOAD_SCHEMA),
 });
 
 export type SAMLRequest = Omit<
@@ -102,7 +106,7 @@ export class SamlAuthStrategy extends PassportStrategy(
   }
 
   authenticate(req: Request, options: AuthenticateOptions) {
-    const queryParseResult = WORKSPACE_INVITE_HASH_SCHEMA.safeParse(req.query);
+    const queryParseResult = SAML_LOGIN_QUERY_SCHEMA.safeParse(req.query);
     const workspaceInviteHash = queryParseResult.success
       ? queryParseResult.data.workspaceInviteHash
       : undefined;
@@ -130,7 +134,7 @@ export class SamlAuthStrategy extends PassportStrategy(
   validate: VerifyWithRequest = async (request, profile, done) => {
     try {
       if (!profile) {
-        return done(new Error('Profile is must be provided'));
+        return done(new Error('Profile must be provided'));
       }
 
       const email = profile.email ?? profile.mail ?? profile.nameID;

--- a/packages/twenty-server/src/engine/core-modules/auth/strategies/saml.auth.strategy.ts
+++ b/packages/twenty-server/src/engine/core-modules/auth/strategies/saml.auth.strategy.ts
@@ -128,8 +128,28 @@ export class SamlAuthStrategy extends PassportStrategy(
         return done(new Error('Invalid email'));
       }
       const state = this.extractState(request);
+      const verifiedIdentityProviderId = request.params.identityProviderId;
 
-      done(null, { ...state, email });
+      // The IdP cert that just verified this SAML assertion was selected from
+      // `req.params.identityProviderId` in `getSamlOptions`. RelayState, in
+      // contrast, is part of the attacker-controllable ACS POST body. If the
+      // two disagree we must refuse the auth: otherwise an assertion signed by
+      // IdP A could be attached to a session that the controller then resolves
+      // against IdP B's workspace.
+      if (state.identityProviderId !== verifiedIdentityProviderId) {
+        return done(
+          new AuthException(
+            'SAML RelayState identity provider mismatch',
+            AuthExceptionCode.INVALID_INPUT,
+          ),
+        );
+      }
+
+      done(null, {
+        identityProviderId: verifiedIdentityProviderId,
+        workspaceInviteHash: state.workspaceInviteHash,
+        email,
+      });
     } catch (err) {
       done(err);
     }


### PR DESCRIPTION
# Introduction
Restructure the RelayState and avoid asserting the idp identifier from this opaque blob
Inferring the id from the secured validated and signed request params