### PR TITLE
fix(imap): per-folder error isolation, graceful UID validity resync, and required-field validation

### DIFF
--- a/packages/twenty-server/src/modules/messaging/message-import-manager/drivers/imap/providers/imap-client.provider.ts
+++ b/packages/twenty-server/src/modules/messaging/message-import-manager/drivers/imap/providers/imap-client.provider.ts
@@ -71,20 +71,30 @@ export class ImapClientProvider {
       );
     }
 
+    const imapParams = connectionParameters.IMAP;
+
+    if (!isDefined(imapParams?.password)) {
+      throw new CustomError(
+        'IMAP password is required',
+        MessageImportDriverExceptionCode.CHANNEL_MISCONFIGURED,
+      );
+    }
+
     const validatedImapHost =
       await this.secureHttpClientService.getValidatedHost(
-        connectionParameters.IMAP?.host || '',
+        imapParams?.host || '',
       );
 
     const client = new ImapFlow({
       host: validatedImapHost,
-      port: connectionParameters.IMAP?.port || 993,
-      secure: connectionParameters.IMAP?.secure,
+      port: imapParams?.port || 993,
+      // Default to true so connections are secure unless the user explicitly opts out
+      secure: imapParams?.secure ?? true,
       auth: {
-        user: isDefined(connectionParameters.IMAP?.username)
-          ? connectionParameters.IMAP?.username
+        user: isDefined(imapParams?.username)
+          ? imapParams?.username
           : connectedAccount.handle,
-        pass: connectionParameters.IMAP?.password || '',
+        pass: imapParams.password,
       },
       logger: false,
       tls: {

--- a/packages/twenty-server/src/modules/messaging/message-import-manager/drivers/imap/services/imap-get-message-list.service.spec.ts
+++ b/packages/twenty-server/src/modules/messaging/message-import-manager/drivers/imap/services/imap-get-message-list.service.spec.ts
@@ -27,6 +27,7 @@ const createMockFolder = (
 });
 
 describe('ImapGetMessageListService', () => {
+  let module: TestingModule;
   let service: ImapGetMessageListService;
   let imapClientProvider: ImapClientProvider;
 
@@ -63,7 +64,7 @@ describe('ImapGetMessageListService', () => {
   };
 
   beforeEach(async () => {
-    const module: TestingModule = await Test.createTestingModule({
+    module = await Test.createTestingModule({
       providers: [
         ImapGetMessageListService,
         {
@@ -76,7 +77,10 @@ describe('ImapGetMessageListService', () => {
         {
           provide: ImapSyncService,
           useValue: {
-            syncFolder: jest.fn().mockResolvedValue({ messageUids: [1, 2, 3] }),
+            syncFolder: jest.fn().mockResolvedValue({
+              messageUids: [1, 2, 3],
+              requiresFullResync: false,
+            }),
           },
         },
         {
@@ -224,6 +228,121 @@ describe('ImapGetMessageListService', () => {
       });
 
       expect(imapClientProvider.closeClient).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('per-folder error isolation', () => {
+    it('should continue processing remaining folders when one folder fails', async () => {
+      const goodFolder1 = createMockFolder({
+        name: 'INBOX',
+        externalId: 'INBOX:1',
+        isSynced: true,
+      });
+
+      const badFolder = createMockFolder({
+        name: 'Broken',
+        externalId: 'Broken:1',
+        isSynced: true,
+      });
+
+      const goodFolder2 = createMockFolder({
+        name: 'Sent',
+        externalId: 'Sent:1',
+        isSynced: true,
+      });
+
+      const imapSyncService = module.get<ImapSyncService>(ImapSyncService);
+      let callCount = 0;
+
+      jest.spyOn(imapSyncService, 'syncFolder').mockImplementation(async () => {
+        callCount++;
+        if (callCount === 2) {
+          throw new Error('IMAP connection reset');
+        }
+
+        return { messageUids: [1, 2, 3], requiresFullResync: false };
+      });
+
+      const result = await service.getMessageLists({
+        connectedAccount: mockConnectedAccount,
+        messageChannel: {
+          syncCursor: '',
+          id: 'channel-1',
+          messageFolderImportPolicy: MessageFolderImportPolicy.ALL_FOLDERS,
+        },
+        messageFolders: [goodFolder1, badFolder, goodFolder2],
+      });
+
+      // Only the two good folders contribute results
+      expect(result).toHaveLength(2);
+      expect(result.map((r) => r.folderId)).toEqual([
+        goodFolder1.id,
+        goodFolder2.id,
+      ]);
+    });
+
+    it('should still close the IMAP client when a folder throws', async () => {
+      const folder = createMockFolder({
+        name: 'INBOX',
+        externalId: 'INBOX:1',
+        isSynced: true,
+      });
+
+      const imapSyncService = module.get<ImapSyncService>(ImapSyncService);
+
+      jest
+        .spyOn(imapSyncService, 'syncFolder')
+        .mockRejectedValue(new Error('Network error'));
+
+      await service.getMessageLists({
+        connectedAccount: mockConnectedAccount,
+        messageChannel: {
+          syncCursor: '',
+          id: 'channel-1',
+          messageFolderImportPolicy: MessageFolderImportPolicy.ALL_FOLDERS,
+        },
+        messageFolders: [folder],
+      });
+
+      expect(imapClientProvider.closeClient).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('requiresFullResync handling', () => {
+    it('should return a valid response when syncFolder signals requiresFullResync', async () => {
+      const folder = createMockFolder({
+        name: 'INBOX',
+        externalId: 'INBOX:1',
+        isSynced: true,
+        syncCursor: JSON.stringify({
+          highestUid: 50,
+          uidValidity: 99999,
+          modSeq: '500',
+        }),
+      });
+
+      const imapSyncService = module.get<ImapSyncService>(ImapSyncService);
+
+      jest.spyOn(imapSyncService, 'syncFolder').mockResolvedValue({
+        messageUids: [1, 2, 3, 4, 5],
+        requiresFullResync: true,
+      });
+
+      const result = await service.getMessageLists({
+        connectedAccount: mockConnectedAccount,
+        messageChannel: {
+          syncCursor: '',
+          id: 'channel-1',
+          messageFolderImportPolicy: MessageFolderImportPolicy.ALL_FOLDERS,
+        },
+        messageFolders: [folder],
+      });
+
+      expect(result).toHaveLength(1);
+      // Should have message external IDs for all 5 fetched UIDs
+      expect(result[0].messageExternalIds).toHaveLength(5);
+      // nextSyncCursor must be set (non-empty) so the next sync has a baseline
+      expect(result[0].nextSyncCursor).toBeTruthy();
     });
   });
 });

--- a/packages/twenty-server/src/modules/messaging/message-import-manager/drivers/imap/services/imap-get-message-list.service.ts
+++ b/packages/twenty-server/src/modules/messaging/message-import-manager/drivers/imap/services/imap-get-message-list.service.ts
@@ -58,18 +58,18 @@ export class ImapGetMessageListService {
       const results: GetMessageListsResponse = [];
 
       for (const folder of foldersToProcess) {
-        const response = await this.getMessageList(client, folder);
+        try {
+          const response = await this.getMessageList(client, folder);
 
-        results.push({ ...response, folderId: folder.id });
+          results.push({ ...response, folderId: folder.id });
+        } catch (error) {
+          this.logger.error(
+            `Connected account ${connectedAccount.id}: Skipping folder ${folder.name} after error: ${error.message}`,
+          );
+        }
       }
 
       return results;
-    } catch (error) {
-      this.logger.error(
-        `Connected account ${connectedAccount.id}: Error fetching message list: ${error.message}`,
-      );
-      this.errorHandler.handleError(error);
-      throw error;
     } finally {
       await this.imapClientProvider.closeClient(client);
     }
@@ -118,16 +118,17 @@ export class ImapGetMessageListService {
 
       const mailboxState = extractMailboxState(mailbox);
 
-      const { messageUids } = await this.imapSyncService.syncFolder(
-        client,
-        folderPath,
-        previousCursor,
-        mailboxState,
-      );
+      const { messageUids, requiresFullResync } =
+        await this.imapSyncService.syncFolder(
+          client,
+          folderPath,
+          previousCursor,
+          mailboxState,
+        );
 
       const nextCursor = createSyncCursor(
         messageUids,
-        previousCursor,
+        requiresFullResync ? null : previousCursor,
         mailboxState,
       );
 

--- a/packages/twenty-server/src/modules/messaging/message-import-manager/drivers/imap/services/imap-sync.service.ts
+++ b/packages/twenty-server/src/modules/messaging/message-import-manager/drivers/imap/services/imap-sync.service.ts
@@ -2,16 +2,16 @@ import { Injectable, Logger } from '@nestjs/common';
 
 import { type ImapFlow } from 'imapflow';
 
-import {
-  MessageImportDriverException,
-  MessageImportDriverExceptionCode,
-} from 'src/modules/messaging/message-import-manager/drivers/exceptions/message-import-driver.exception';
 import { canUseQresync } from 'src/modules/messaging/message-import-manager/drivers/imap/utils/can-use-qresync.util';
 import { type MailboxState } from 'src/modules/messaging/message-import-manager/drivers/imap/utils/extract-mailbox-state.util';
 import { type ImapSyncCursor } from 'src/modules/messaging/message-import-manager/drivers/imap/utils/parse-sync-cursor.util';
 
 type SyncResult = {
   messageUids: number[];
+  // True when the server's UID validity has changed and all previously stored
+  // message UIDs for this folder are now invalid. The caller must clear the
+  // folder's sync cursor and re-import all messages from scratch.
+  requiresFullResync: boolean;
 };
 
 @Injectable()
@@ -24,7 +24,18 @@ export class ImapSyncService {
     previousCursor: ImapSyncCursor | null,
     mailboxState: MailboxState,
   ): Promise<SyncResult> {
-    this.validateUidValidity(previousCursor, mailboxState, folderPath);
+    if (this.hasUidValidityChanged(previousCursor, mailboxState, folderPath)) {
+      // UID validity changing means every stored UID is stale. Fetch all
+      // messages from scratch by treating this as a first-time sync.
+      const messageUids = await this.fetchNewMessageUids(
+        client,
+        null,
+        mailboxState,
+        folderPath,
+      );
+
+      return { messageUids, requiresFullResync: true };
+    }
 
     const messageUids = await this.fetchNewMessageUids(
       client,
@@ -33,27 +44,28 @@ export class ImapSyncService {
       folderPath,
     );
 
-    return { messageUids };
+    return { messageUids, requiresFullResync: false };
   }
 
-  private validateUidValidity(
+  // Returns true when the server reports a different UID validity than the one
+  // stored in our cursor, indicating a full folder resync is required.
+  private hasUidValidityChanged(
     previousCursor: ImapSyncCursor | null,
     mailboxState: MailboxState,
     folderPath: string,
-  ): void {
+  ): boolean {
     const previousUidValidity = previousCursor?.uidValidity ?? 0;
     const { uidValidity } = mailboxState;
 
     if (previousUidValidity !== 0 && previousUidValidity !== uidValidity) {
       this.logger.warn(
-        `UID validity changed from ${previousUidValidity} to ${uidValidity} in ${folderPath}. Full resync required.`,
+        `UID validity changed from ${previousUidValidity} to ${uidValidity} in ${folderPath}. Performing full resync.`,
       );
 
-      throw new MessageImportDriverException(
-        `IMAP UID validity changed for folder ${folderPath}`,
-        MessageImportDriverExceptionCode.SYNC_CURSOR_ERROR,
-      );
+      return true;
     }
+
+    return false;
   }
 
   private async fetchNewMessageUids(


### PR DESCRIPTION
## Summary

Fixes three reliability issues in the IMAP sync layer that cause account-wide failures for common server-side events.

### Fix 1 — `ImapClientProvider`: validate IMAP password + default `secure: true`

Previously:
- Missing password produced an empty-string `pass`, connecting with no credentials and failing with a confusing auth error
- `secure` had no default — falsy when omitted, silently downgrading to an unencrypted connection

After:
- Throws `CHANNEL_MISCONFIGURED` immediately when password is absent, surfacing the error at configuration time
- `secure` defaults to `true`; users must explicitly set `secure: false` to opt out of TLS

### Fix 2 — `ImapSyncService`: UID validity change treated as recoverable full-resync

Previously: `syncFolder` threw `SYNC_CURSOR_ERROR` when the server's UID validity differed from the stored cursor. This propagated up and marked the **entire connected account** as broken, requiring manual intervention.

After:
- `hasUidValidityChanged()` returns a boolean instead of throwing
- When validity changes, `syncFolder` fetches all messages from scratch (passing `null` cursor) and returns `{ messageUids, requiresFullResync: true }`
- The account keeps syncing normally; the affected folder re-imports cleanly on the next run

### Fix 3 — `ImapGetMessageListService`: per-folder error isolation + cursor reset on full-resync

Previously: a single folder error inside `getMessageLists` re-threw after the outer catch, aborting all subsequent folders in the same sync run. Any transient IMAP error on folder N meant folders N+1…N+K were silently skipped.

After:
- Each folder is wrapped in its own `try/catch`; errors are logged and the loop continues
- `requiresFullResync: true` is forwarded to `createSyncCursor` (passing `null` as `previousCursor`) so the new cursor is anchored to the current UID validity rather than the stale one

## Test coverage

Updated `imap-get-message-list.service.spec.ts`:
- Existing folder-policy tests updated to expect `{ messageUids, requiresFullResync }` return shape
- **New**: per-folder isolation — second of three folders throws, first and third still appear in results
- **New**: `closeClient` is still called when a folder throws (finally block)
- **New**: `requiresFullResync: true` produces a valid response with message external IDs and a non-empty `nextSyncCursor`

/claim #460
