### PR TITLE
Stop rejecting application token on calendar and message events requests

### DIFF
--- a/packages/twenty-server/src/engine/twenty-orm/repository/permissions.utils.ts
+++ b/packages/twenty-server/src/engine/twenty-orm/repository/permissions.utils.ts
@@ -119,7 +119,6 @@ export const validateOperationIsPermittedOrThrow = ({
     WORKSPACE_MEMBER_OBJECT_UNIVERSAL_IDENTIFIER;
 
   // TODO: this should be improved, we may have more complex permission configuration for is system objects
-  // see https://discord.com/channels/1130383047699738754/1503320724704854036 for context
   if (objectMetadataIsSystem && !isWorkspaceMemberObject) {
     return;
   }

--- a/packages/twenty-server/src/engine/twenty-orm/repository/permissions.utils.ts
+++ b/packages/twenty-server/src/engine/twenty-orm/repository/permissions.utils.ts
@@ -118,6 +118,8 @@ export const validateOperationIsPermittedOrThrow = ({
     objectMetadata.universalIdentifier ===
     WORKSPACE_MEMBER_OBJECT_UNIVERSAL_IDENTIFIER;
 
+  // TODO: this should be improved, we may have more complex permission configuration for is system objects
+  // see https://discord.com/channels/1130383047699738754/1503320724704854036 for context
   if (objectMetadataIsSystem && !isWorkspaceMemberObject) {
     return;
   }

--- a/packages/twenty-server/src/modules/calendar/common/query-hooks/calendar-event/calendar-event-find-many.post-query.hook.ts
+++ b/packages/twenty-server/src/modules/calendar/common/query-hooks/calendar-event/calendar-event-find-many.post-query.hook.ts
@@ -7,6 +7,8 @@ import { type WorkspaceAuthContext } from 'src/engine/core-modules/auth/types/wo
 import { ForbiddenError } from 'src/engine/core-modules/graphql/utils/graphql-errors.util';
 import { ApplyCalendarEventsVisibilityRestrictionsService } from 'src/modules/calendar/common/query-hooks/calendar-event/services/apply-calendar-events-visibility-restrictions.service';
 import { type CalendarEventWorkspaceEntity } from 'src/modules/calendar/common/standard-objects/calendar-event.workspace-entity';
+import { isApiKeyAuthContext } from 'src/engine/core-modules/auth/guards/is-api-key-auth-context.guard';
+import { isApplicationAuthContext } from 'src/engine/core-modules/auth/guards/is-application-auth-context.guard';
 
 @WorkspaceQueryHook({
   key: `calendarEvent.findMany`,
@@ -29,11 +31,13 @@ export class CalendarEventFindManyPostQueryHook
 
     // TODO: this check should be removed, see https://discord.com/channels/1130383047699738754/1503320724704854036 for context
     if (
-      authContext.type !== 'user' &&
-      authContext.type !== 'apiKey' &&
-      authContext.type !== 'application'
+      !isUserAuthContext(authContext) &&
+      !isApiKeyAuthContext(authContext) &&
+      !isApplicationAuthContext(authContext)
     ) {
-      throw new ForbiddenError('Authentication should be user scoped');
+      throw new ForbiddenError(
+        'Authentication error, auth context should be user, apiKey or application',
+      );
     }
 
     const workspace = authContext.workspace;

--- a/packages/twenty-server/src/modules/calendar/common/query-hooks/calendar-event/calendar-event-find-many.post-query.hook.ts
+++ b/packages/twenty-server/src/modules/calendar/common/query-hooks/calendar-event/calendar-event-find-many.post-query.hook.ts
@@ -29,7 +29,7 @@ export class CalendarEventFindManyPostQueryHook
     const isUserContext = isUserAuthContext(authContext);
     const userId = isUserContext ? authContext.user.id : undefined;
 
-    // TODO: this check should be removed, see https://discord.com/channels/1130383047699738754/1503320724704854036 for context
+    // TODO: this check should be removed
     if (
       !isUserAuthContext(authContext) &&
       !isApiKeyAuthContext(authContext) &&

--- a/packages/twenty-server/src/modules/calendar/common/query-hooks/calendar-event/calendar-event-find-many.post-query.hook.ts
+++ b/packages/twenty-server/src/modules/calendar/common/query-hooks/calendar-event/calendar-event-find-many.post-query.hook.ts
@@ -5,7 +5,6 @@ import { WorkspaceQueryHookType } from 'src/engine/api/graphql/workspace-query-r
 import { isUserAuthContext } from 'src/engine/core-modules/auth/guards/is-user-auth-context.guard';
 import { type WorkspaceAuthContext } from 'src/engine/core-modules/auth/types/workspace-auth-context.type';
 import { ForbiddenError } from 'src/engine/core-modules/graphql/utils/graphql-errors.util';
-import { TWENTY_STANDARD_APPLICATION } from 'src/engine/workspace-manager/twenty-standard-application/constants/twenty-standard-applications';
 import { ApplyCalendarEventsVisibilityRestrictionsService } from 'src/modules/calendar/common/query-hooks/calendar-event/services/apply-calendar-events-visibility-restrictions.service';
 import { type CalendarEventWorkspaceEntity } from 'src/modules/calendar/common/standard-objects/calendar-event.workspace-entity';
 
@@ -28,17 +27,13 @@ export class CalendarEventFindManyPostQueryHook
     const isUserContext = isUserAuthContext(authContext);
     const userId = isUserContext ? authContext.user.id : undefined;
 
-    const isTwentyStandardApplication =
-      authContext.type === 'application' &&
-      authContext.application.universalIdentifier ===
-        TWENTY_STANDARD_APPLICATION.universalIdentifier;
-
+    // TODO: this check should be removed, see https://discord.com/channels/1130383047699738754/1503320724704854036 for context
     if (
-      !isUserContext &&
+      authContext.type !== 'user' &&
       authContext.type !== 'apiKey' &&
-      !isTwentyStandardApplication
+      authContext.type !== 'application'
     ) {
-      throw new ForbiddenError('Authentication is required');
+      throw new ForbiddenError('Authentication should be user scoped');
     }
 
     const workspace = authContext.workspace;

--- a/packages/twenty-server/src/modules/calendar/common/query-hooks/calendar-event/calendar-event-find-one.post-query.hook.ts
+++ b/packages/twenty-server/src/modules/calendar/common/query-hooks/calendar-event/calendar-event-find-one.post-query.hook.ts
@@ -5,7 +5,6 @@ import { WorkspaceQueryHookType } from 'src/engine/api/graphql/workspace-query-r
 import { isUserAuthContext } from 'src/engine/core-modules/auth/guards/is-user-auth-context.guard';
 import { type WorkspaceAuthContext } from 'src/engine/core-modules/auth/types/workspace-auth-context.type';
 import { ForbiddenError } from 'src/engine/core-modules/graphql/utils/graphql-errors.util';
-import { TWENTY_STANDARD_APPLICATION } from 'src/engine/workspace-manager/twenty-standard-application/constants/twenty-standard-applications';
 import { ApplyCalendarEventsVisibilityRestrictionsService } from 'src/modules/calendar/common/query-hooks/calendar-event/services/apply-calendar-events-visibility-restrictions.service';
 import { type CalendarEventWorkspaceEntity } from 'src/modules/calendar/common/standard-objects/calendar-event.workspace-entity';
 
@@ -28,17 +27,13 @@ export class CalendarEventFindOnePostQueryHook
     const isUserContext = isUserAuthContext(authContext);
     const userId = isUserContext ? authContext.user.id : undefined;
 
-    const isTwentyStandardApplication =
-      authContext.type === 'application' &&
-      authContext.application.universalIdentifier ===
-        TWENTY_STANDARD_APPLICATION.universalIdentifier;
-
+    // TODO: this check should be removed, see https://discord.com/channels/1130383047699738754/1503320724704854036 for context
     if (
-      !isUserContext &&
+      authContext.type !== 'user' &&
       authContext.type !== 'apiKey' &&
-      !isTwentyStandardApplication
+      authContext.type !== 'application'
     ) {
-      throw new ForbiddenError('Authentication is required');
+      throw new ForbiddenError('Authentication should be user scoped');
     }
 
     const workspace = authContext.workspace;

--- a/packages/twenty-server/src/modules/calendar/common/query-hooks/calendar-event/calendar-event-find-one.post-query.hook.ts
+++ b/packages/twenty-server/src/modules/calendar/common/query-hooks/calendar-event/calendar-event-find-one.post-query.hook.ts
@@ -7,6 +7,8 @@ import { type WorkspaceAuthContext } from 'src/engine/core-modules/auth/types/wo
 import { ForbiddenError } from 'src/engine/core-modules/graphql/utils/graphql-errors.util';
 import { ApplyCalendarEventsVisibilityRestrictionsService } from 'src/modules/calendar/common/query-hooks/calendar-event/services/apply-calendar-events-visibility-restrictions.service';
 import { type CalendarEventWorkspaceEntity } from 'src/modules/calendar/common/standard-objects/calendar-event.workspace-entity';
+import { isApiKeyAuthContext } from 'src/engine/core-modules/auth/guards/is-api-key-auth-context.guard';
+import { isApplicationAuthContext } from 'src/engine/core-modules/auth/guards/is-application-auth-context.guard';
 
 @WorkspaceQueryHook({
   key: `calendarEvent.findOne`,
@@ -29,11 +31,13 @@ export class CalendarEventFindOnePostQueryHook
 
     // TODO: this check should be removed, see https://discord.com/channels/1130383047699738754/1503320724704854036 for context
     if (
-      authContext.type !== 'user' &&
-      authContext.type !== 'apiKey' &&
-      authContext.type !== 'application'
+      !isUserAuthContext(authContext) &&
+      !isApiKeyAuthContext(authContext) &&
+      !isApplicationAuthContext(authContext)
     ) {
-      throw new ForbiddenError('Authentication should be user scoped');
+      throw new ForbiddenError(
+        'Authentication error, auth context should be user, apiKey or application',
+      );
     }
 
     const workspace = authContext.workspace;

--- a/packages/twenty-server/src/modules/calendar/common/query-hooks/calendar-event/calendar-event-find-one.post-query.hook.ts
+++ b/packages/twenty-server/src/modules/calendar/common/query-hooks/calendar-event/calendar-event-find-one.post-query.hook.ts
@@ -29,7 +29,7 @@ export class CalendarEventFindOnePostQueryHook
     const isUserContext = isUserAuthContext(authContext);
     const userId = isUserContext ? authContext.user.id : undefined;
 
-    // TODO: this check should be removed, see https://discord.com/channels/1130383047699738754/1503320724704854036 for context
+    // TODO: this check should be removed
     if (
       !isUserAuthContext(authContext) &&
       !isApiKeyAuthContext(authContext) &&

--- a/packages/twenty-server/src/modules/messaging/common/query-hooks/message/message-find-many.post-query.hook.ts
+++ b/packages/twenty-server/src/modules/messaging/common/query-hooks/message/message-find-many.post-query.hook.ts
@@ -5,7 +5,6 @@ import { WorkspaceQueryHookType } from 'src/engine/api/graphql/workspace-query-r
 import { isUserAuthContext } from 'src/engine/core-modules/auth/guards/is-user-auth-context.guard';
 import { type WorkspaceAuthContext } from 'src/engine/core-modules/auth/types/workspace-auth-context.type';
 import { ForbiddenError } from 'src/engine/core-modules/graphql/utils/graphql-errors.util';
-import { TWENTY_STANDARD_APPLICATION } from 'src/engine/workspace-manager/twenty-standard-application/constants/twenty-standard-applications';
 import { ApplyMessagesVisibilityRestrictionsService } from 'src/modules/messaging/common/query-hooks/message/apply-messages-visibility-restrictions.service';
 import { type MessageWorkspaceEntity } from 'src/modules/messaging/common/standard-objects/message.workspace-entity';
 
@@ -25,17 +24,13 @@ export class MessageFindManyPostQueryHook
     _objectName: string,
     payload: MessageWorkspaceEntity[],
   ): Promise<void> {
-    const isTwentyStandardApplication =
-      authContext.type === 'application' &&
-      authContext.application.universalIdentifier ===
-        TWENTY_STANDARD_APPLICATION.universalIdentifier;
-
+    // TODO: this check should be removed, see https://discord.com/channels/1130383047699738754/1503320724704854036 for context
     if (
       authContext.type !== 'user' &&
       authContext.type !== 'apiKey' &&
-      !isTwentyStandardApplication
+      authContext.type !== 'application'
     ) {
-      throw new ForbiddenError('Authentication is required');
+      throw new ForbiddenError('Authentication should be user scoped');
     }
 
     const workspace = authContext.workspace;

--- a/packages/twenty-server/src/modules/messaging/common/query-hooks/message/message-find-many.post-query.hook.ts
+++ b/packages/twenty-server/src/modules/messaging/common/query-hooks/message/message-find-many.post-query.hook.ts
@@ -7,6 +7,8 @@ import { type WorkspaceAuthContext } from 'src/engine/core-modules/auth/types/wo
 import { ForbiddenError } from 'src/engine/core-modules/graphql/utils/graphql-errors.util';
 import { ApplyMessagesVisibilityRestrictionsService } from 'src/modules/messaging/common/query-hooks/message/apply-messages-visibility-restrictions.service';
 import { type MessageWorkspaceEntity } from 'src/modules/messaging/common/standard-objects/message.workspace-entity';
+import { isApiKeyAuthContext } from 'src/engine/core-modules/auth/guards/is-api-key-auth-context.guard';
+import { isApplicationAuthContext } from 'src/engine/core-modules/auth/guards/is-application-auth-context.guard';
 
 @WorkspaceQueryHook({
   key: `message.findMany`,
@@ -26,11 +28,13 @@ export class MessageFindManyPostQueryHook
   ): Promise<void> {
     // TODO: this check should be removed, see https://discord.com/channels/1130383047699738754/1503320724704854036 for context
     if (
-      authContext.type !== 'user' &&
-      authContext.type !== 'apiKey' &&
-      authContext.type !== 'application'
+      !isUserAuthContext(authContext) &&
+      !isApiKeyAuthContext(authContext) &&
+      !isApplicationAuthContext(authContext)
     ) {
-      throw new ForbiddenError('Authentication should be user scoped');
+      throw new ForbiddenError(
+        'Authentication error, auth context should be user, apiKey or application',
+      );
     }
 
     const workspace = authContext.workspace;

--- a/packages/twenty-server/src/modules/messaging/common/query-hooks/message/message-find-many.post-query.hook.ts
+++ b/packages/twenty-server/src/modules/messaging/common/query-hooks/message/message-find-many.post-query.hook.ts
@@ -26,7 +26,7 @@ export class MessageFindManyPostQueryHook
     _objectName: string,
     payload: MessageWorkspaceEntity[],
   ): Promise<void> {
-    // TODO: this check should be removed, see https://discord.com/channels/1130383047699738754/1503320724704854036 for context
+    // TODO: this check should be removed
     if (
       !isUserAuthContext(authContext) &&
       !isApiKeyAuthContext(authContext) &&

--- a/packages/twenty-server/src/modules/messaging/common/query-hooks/message/message-find-one.post-query.hook.ts
+++ b/packages/twenty-server/src/modules/messaging/common/query-hooks/message/message-find-one.post-query.hook.ts
@@ -2,12 +2,9 @@ import { type WorkspacePostQueryHookInstance } from 'src/engine/api/graphql/work
 
 import { WorkspaceQueryHook } from 'src/engine/api/graphql/workspace-query-runner/workspace-query-hook/decorators/workspace-query-hook.decorator';
 import { WorkspaceQueryHookType } from 'src/engine/api/graphql/workspace-query-runner/workspace-query-hook/types/workspace-query-hook.type';
-import { isApiKeyAuthContext } from 'src/engine/core-modules/auth/guards/is-api-key-auth-context.guard';
-import { isApplicationAuthContext } from 'src/engine/core-modules/auth/guards/is-application-auth-context.guard';
 import { isUserAuthContext } from 'src/engine/core-modules/auth/guards/is-user-auth-context.guard';
 import { type WorkspaceAuthContext } from 'src/engine/core-modules/auth/types/workspace-auth-context.type';
 import { ForbiddenError } from 'src/engine/core-modules/graphql/utils/graphql-errors.util';
-import { TWENTY_STANDARD_APPLICATION } from 'src/engine/workspace-manager/twenty-standard-application/constants/twenty-standard-applications';
 import { ApplyMessagesVisibilityRestrictionsService } from 'src/modules/messaging/common/query-hooks/message/apply-messages-visibility-restrictions.service';
 import { type MessageWorkspaceEntity } from 'src/modules/messaging/common/standard-objects/message.workspace-entity';
 
@@ -27,17 +24,13 @@ export class MessageFindOnePostQueryHook
     _objectName: string,
     payload: MessageWorkspaceEntity[],
   ): Promise<void> {
-    const isTwentyStandardApplication =
-      isApplicationAuthContext(authContext) &&
-      authContext.application.universalIdentifier ===
-        TWENTY_STANDARD_APPLICATION.universalIdentifier;
-
+    // TODO: this check should be removed, see https://discord.com/channels/1130383047699738754/1503320724704854036 for context
     if (
-      !isUserAuthContext(authContext) &&
-      !isApiKeyAuthContext(authContext) &&
-      !isTwentyStandardApplication
+      authContext.type !== 'user' &&
+      authContext.type !== 'apiKey' &&
+      authContext.type !== 'application'
     ) {
-      throw new ForbiddenError('Authentication is required');
+      throw new ForbiddenError('Authentication should be user scoped');
     }
 
     const workspace = authContext.workspace;

--- a/packages/twenty-server/src/modules/messaging/common/query-hooks/message/message-find-one.post-query.hook.ts
+++ b/packages/twenty-server/src/modules/messaging/common/query-hooks/message/message-find-one.post-query.hook.ts
@@ -26,7 +26,7 @@ export class MessageFindOnePostQueryHook
     _objectName: string,
     payload: MessageWorkspaceEntity[],
   ): Promise<void> {
-    // TODO: this check should be removed, see https://discord.com/channels/1130383047699738754/1503320724704854036 for context
+    // TODO: this check should be removed
     if (
       !isUserAuthContext(authContext) &&
       !isApiKeyAuthContext(authContext) &&

--- a/packages/twenty-server/src/modules/messaging/common/query-hooks/message/message-find-one.post-query.hook.ts
+++ b/packages/twenty-server/src/modules/messaging/common/query-hooks/message/message-find-one.post-query.hook.ts
@@ -1,12 +1,22 @@
-import { type WorkspacePostQueryHookInstance } from 'src/engine/api/graphql/workspace-query-runner/workspace-query-hook/interfaces/workspace-query-hook.interface';
+import {
+  type WorkspacePostQueryHookInstance
+} from 'src/engine/api/graphql/workspace-query-runner/workspace-query-hook/interfaces/workspace-query-hook.interface';
 
-import { WorkspaceQueryHook } from 'src/engine/api/graphql/workspace-query-runner/workspace-query-hook/decorators/workspace-query-hook.decorator';
-import { WorkspaceQueryHookType } from 'src/engine/api/graphql/workspace-query-runner/workspace-query-hook/types/workspace-query-hook.type';
+import {
+  WorkspaceQueryHook
+} from 'src/engine/api/graphql/workspace-query-runner/workspace-query-hook/decorators/workspace-query-hook.decorator';
+import {
+  WorkspaceQueryHookType
+} from 'src/engine/api/graphql/workspace-query-runner/workspace-query-hook/types/workspace-query-hook.type';
 import { isUserAuthContext } from 'src/engine/core-modules/auth/guards/is-user-auth-context.guard';
 import { type WorkspaceAuthContext } from 'src/engine/core-modules/auth/types/workspace-auth-context.type';
 import { ForbiddenError } from 'src/engine/core-modules/graphql/utils/graphql-errors.util';
-import { ApplyMessagesVisibilityRestrictionsService } from 'src/modules/messaging/common/query-hooks/message/apply-messages-visibility-restrictions.service';
+import {
+  ApplyMessagesVisibilityRestrictionsService
+} from 'src/modules/messaging/common/query-hooks/message/apply-messages-visibility-restrictions.service';
 import { type MessageWorkspaceEntity } from 'src/modules/messaging/common/standard-objects/message.workspace-entity';
+import { isApiKeyAuthContext } from 'src/engine/core-modules/auth/guards/is-api-key-auth-context.guard';
+import { isApplicationAuthContext } from 'src/engine/core-modules/auth/guards/is-application-auth-context.guard';
 
 @WorkspaceQueryHook({
   key: `message.findOne`,
@@ -26,11 +36,13 @@ export class MessageFindOnePostQueryHook
   ): Promise<void> {
     // TODO: this check should be removed, see https://discord.com/channels/1130383047699738754/1503320724704854036 for context
     if (
-      authContext.type !== 'user' &&
-      authContext.type !== 'apiKey' &&
-      authContext.type !== 'application'
+      !isUserAuthContext(authContext) &&
+      !isApiKeyAuthContext(authContext) &&
+      !isApplicationAuthContext(authContext)
     ) {
-      throw new ForbiddenError('Authentication should be user scoped');
+      throw new ForbiddenError(
+        'Authentication error, auth context should be user, apiKey or application',
+      );
     }
 
     const workspace = authContext.workspace;

--- a/packages/twenty-server/src/modules/messaging/common/query-hooks/message/message-find-one.post-query.hook.ts
+++ b/packages/twenty-server/src/modules/messaging/common/query-hooks/message/message-find-one.post-query.hook.ts
@@ -1,19 +1,11 @@
-import {
-  type WorkspacePostQueryHookInstance
-} from 'src/engine/api/graphql/workspace-query-runner/workspace-query-hook/interfaces/workspace-query-hook.interface';
+import { type WorkspacePostQueryHookInstance } from 'src/engine/api/graphql/workspace-query-runner/workspace-query-hook/interfaces/workspace-query-hook.interface';
 
-import {
-  WorkspaceQueryHook
-} from 'src/engine/api/graphql/workspace-query-runner/workspace-query-hook/decorators/workspace-query-hook.decorator';
-import {
-  WorkspaceQueryHookType
-} from 'src/engine/api/graphql/workspace-query-runner/workspace-query-hook/types/workspace-query-hook.type';
+import { WorkspaceQueryHook } from 'src/engine/api/graphql/workspace-query-runner/workspace-query-hook/decorators/workspace-query-hook.decorator';
+import { WorkspaceQueryHookType } from 'src/engine/api/graphql/workspace-query-runner/workspace-query-hook/types/workspace-query-hook.type';
 import { isUserAuthContext } from 'src/engine/core-modules/auth/guards/is-user-auth-context.guard';
 import { type WorkspaceAuthContext } from 'src/engine/core-modules/auth/types/workspace-auth-context.type';
 import { ForbiddenError } from 'src/engine/core-modules/graphql/utils/graphql-errors.util';
-import {
-  ApplyMessagesVisibilityRestrictionsService
-} from 'src/modules/messaging/common/query-hooks/message/apply-messages-visibility-restrictions.service';
+import { ApplyMessagesVisibilityRestrictionsService } from 'src/modules/messaging/common/query-hooks/message/apply-messages-visibility-restrictions.service';
 import { type MessageWorkspaceEntity } from 'src/modules/messaging/common/standard-objects/message.workspace-entity';
 import { isApiKeyAuthContext } from 'src/engine/core-modules/auth/guards/is-api-key-auth-context.guard';
 import { isApplicationAuthContext } from 'src/engine/core-modules/auth/guards/is-application-auth-context.guard';


### PR DESCRIPTION
fixes https://github.com/twentyhq/twenty/issues/20423 by authorizing application token to perform calendarEvents and message queries