### PR TITLE
chore(members): rename "Access" tab to "Invite" + fix e2e

### DIFF
--- a/packages/twenty-docs/user-guide/settings/capabilities/domains-settings.mdx
+++ b/packages/twenty-docs/user-guide/settings/capabilities/domains-settings.mdx
@@ -20,7 +20,7 @@ For custom domains, you'll need to configure DNS settings with your domain provi
 
 ## Approved Domains
 
-Configure under **Settings → Members → Access**.
+Configure under **Settings → Members → Invite**.
 
 Anyone with an email address at these domains is allowed to sign up for this workspace automatically.
 

--- a/packages/twenty-docs/user-guide/settings/capabilities/member-management.mdx
+++ b/packages/twenty-docs/user-guide/settings/capabilities/member-management.mdx
@@ -67,7 +67,7 @@ Manage invitations that haven't been accepted:
 
 Allow team members to join automatically based on their email domain:
 
-1. Go to **Settings → Members → Access**
+1. Go to **Settings → Members → Invite**
 2. Add your company domain (e.g., `yourcompany.com`)
 3. Anyone with that email domain can join without an invitation
 

--- a/packages/twenty-docs/user-guide/settings/how-tos/settings-faq.mdx
+++ b/packages/twenty-docs/user-guide/settings/how-tos/settings-faq.mdx
@@ -146,7 +146,7 @@ A subdomain is quick to set up, while a custom domain provides a fully branded e
 </Accordion>
 
 <Accordion title="How do approved access domains work?">
-You can configure approved access domains so team members with company email addresses can automatically join your workspace. Go to **Settings → Members → Access** and add your company domain (e.g., `yourcompany.com`).
+You can configure approved access domains so team members with company email addresses can automatically join your workspace. Go to **Settings → Members → Invite** and add your company domain (e.g., `yourcompany.com`).
 </Accordion>
 </AccordionGroup>
 

--- a/packages/twenty-e2e-testing/lib/pom/settings/membersSection.ts
+++ b/packages/twenty-e2e-testing/lib/pom/settings/membersSection.ts
@@ -1,12 +1,14 @@
 import { Locator, Page } from '@playwright/test';
 
 export class MembersSection {
+  private readonly inviteTab: Locator;
   private readonly inviteMembersField: Locator;
   private readonly inviteMembersButton: Locator;
   private readonly inviteLinkButton: Locator;
 
   constructor(public readonly page: Page) {
     this.page = page;
+    this.inviteTab = page.getByTestId('tab-invite');
     this.inviteMembersField = page.getByPlaceholder(
       'tim@apple.com, jony.ive@apple',
     );
@@ -14,11 +16,17 @@ export class MembersSection {
     this.inviteLinkButton = page.getByRole('button', { name: 'Copy link' });
   }
 
+  async goToInviteTab() {
+    await this.inviteTab.click();
+  }
+
   async copyInviteLink() {
+    await this.goToInviteTab();
     await this.inviteLinkButton.click();
   }
 
   async sendInviteEmail(email: string) {
+    await this.goToInviteTab();
     await this.inviteMembersField.click();
     await this.inviteMembersField.fill(email);
     await this.inviteMembersButton.click();

--- a/packages/twenty-front/src/pages/settings/members/SettingsWorkspaceMembers.tsx
+++ b/packages/twenty-front/src/pages/settings/members/SettingsWorkspaceMembers.tsx
@@ -1,7 +1,7 @@
 import { Trans, useLingui } from '@lingui/react/macro';
 import { SettingsPath } from 'twenty-shared/types';
 import { getSettingsPath } from 'twenty-shared/utils';
-import { IconKey, IconLock, IconUsers } from 'twenty-ui/display';
+import { IconLock, IconUserPlus, IconUsers } from 'twenty-ui/display';
 
 import { useHasPermissionFlag } from '@/settings/roles/hooks/useHasPermissionFlag';
 import { SettingsPageContainer } from '@/settings/components/SettingsPageContainer';
@@ -10,14 +10,14 @@ import { TabList } from '@/ui/layout/tab-list/components/TabList';
 import { activeTabIdComponentState } from '@/ui/layout/tab-list/states/activeTabIdComponentState';
 import { useAtomComponentStateValue } from '@/ui/utilities/state/jotai/hooks/useAtomComponentStateValue';
 import { PermissionFlagType } from '~/generated-metadata/graphql';
-import { SettingsWorkspaceMembersAccessTab } from '~/pages/settings/members/tabs/SettingsWorkspaceMembersAccessTab';
+import { SettingsWorkspaceMembersInviteTab } from '~/pages/settings/members/tabs/SettingsWorkspaceMembersInviteTab';
 import { SettingsWorkspaceMembersRolesTab } from '~/pages/settings/members/tabs/SettingsWorkspaceMembersRolesTab';
 import { SettingsWorkspaceMembersTeamTab } from '~/pages/settings/members/tabs/SettingsWorkspaceMembersTeamTab';
 
 const MEMBERS_TAB_LIST_ID = 'members-tab-list';
 
 const MEMBERS_TAB_TEAM_ID = 'team';
-const MEMBERS_TAB_ACCESS_ID = 'access';
+const MEMBERS_TAB_INVITE_ID = 'invite';
 const MEMBERS_TAB_ROLES_ID = 'roles';
 
 export const SettingsWorkspaceMembers = () => {
@@ -32,7 +32,7 @@ export const SettingsWorkspaceMembers = () => {
 
   const tabs = [
     { id: MEMBERS_TAB_TEAM_ID, title: t`Team`, Icon: IconUsers },
-    { id: MEMBERS_TAB_ACCESS_ID, title: t`Access`, Icon: IconKey },
+    { id: MEMBERS_TAB_INVITE_ID, title: t`Invite`, Icon: IconUserPlus },
     ...(hasRolesPermission
       ? [{ id: MEMBERS_TAB_ROLES_ID, title: t`Roles`, Icon: IconLock }]
       : []),
@@ -40,8 +40,8 @@ export const SettingsWorkspaceMembers = () => {
 
   const renderActiveTabContent = () => {
     switch (activeTabId) {
-      case MEMBERS_TAB_ACCESS_ID:
-        return <SettingsWorkspaceMembersAccessTab />;
+      case MEMBERS_TAB_INVITE_ID:
+        return <SettingsWorkspaceMembersInviteTab />;
       case MEMBERS_TAB_ROLES_ID:
         return hasRolesPermission ? (
           <SettingsWorkspaceMembersRolesTab />

--- a/packages/twenty-front/src/pages/settings/members/tabs/SettingsWorkspaceMembersInviteTab.tsx
+++ b/packages/twenty-front/src/pages/settings/members/tabs/SettingsWorkspaceMembersInviteTab.tsx
@@ -71,7 +71,7 @@ const StyledTableRows = styled.div`
   padding-top: ${themeCssVariables.spacing[2]};
 `;
 
-export const SettingsWorkspaceMembersAccessTab = () => {
+export const SettingsWorkspaceMembersInviteTab = () => {
   const { theme } = useContext(ThemeContext);
   const { t } = useLingui();
   const { enqueueErrorSnackBar } = useSnackBar();


### PR DESCRIPTION
## Summary

Two things, both fallout from #20360:

1. Rename the `Members → Access` tab to `Members → Invite`. The previous label leaned security-flavored; "Invite" reads as the verb users come here to do.
2. Fix the `signup_invite_email` Playwright test (failing on main, e.g. https://github.com/twentyhq/twenty/actions/runs/25671161586/job/75356474079). The invite-link button moved off the default Team tab when the Members page got tabbed; the test was looking for it on the wrong tab.

## Rename details

- File: `SettingsWorkspaceMembersAccessTab.tsx` → `SettingsWorkspaceMembersInviteTab.tsx` (single git rename, ~99% similarity)
- Exported component: `SettingsWorkspaceMembersAccessTab` → `SettingsWorkspaceMembersInviteTab`
- Tab id (and URL hash): `access` → `invite`
- Tab title: `Access` → `Invite`
- Icon: `IconKey` → `IconUserPlus`
- Doc breadcrumbs (3 files): `Members → Access` → `Members → Invite`

## E2E fix

`MembersSection` (Page Object Model) now has an `inviteTab` locator (via `getByTestId('tab-invite')`) and a `goToInviteTab()` helper. Both `copyInviteLink` and `sendInviteEmail` click the Invite tab first, so they work regardless of which tab the page lands on initially. Idempotent if already there.

## Test plan

- [x] CI green (e2e test + lint + typecheck + format)
- Lingui `.po` files will pick up the new source paths on the next translation pass — not touched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)