### PR TITLE
feat(front-component-renderer): forward file input metadata

### DIFF
--- a/packages/twenty-front-component-renderer/scripts/front-component-stories/build-source-examples.ts
+++ b/packages/twenty-front-component-renderer/scripts/front-component-stories/build-source-examples.ts
@@ -87,6 +87,7 @@ const STORY_COMPONENTS = [
   'keyboard-events.front-component',
   'host-api-calls.front-component',
   'caret-preservation.front-component',
+  'file-input.front-component',
 ];
 
 const resolveEntryPoints = (): Record<string, string> => {

--- a/packages/twenty-front-component-renderer/src/__stories__/EventForwarding.stories.tsx
+++ b/packages/twenty-front-component-renderer/src/__stories__/EventForwarding.stories.tsx
@@ -418,6 +418,73 @@ export const TextareaCaretPreservedMidString: Story = createComponentStory(
   },
 );
 
+export const FileInputSingle: Story = createComponentStory('file-input', {
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    await canvas.findByTestId(
+      'file-input-component',
+      {},
+      { timeout: MOUNT_TIMEOUT },
+    );
+
+    const input = (await canvas.findByTestId(
+      'single-file-input',
+    )) as HTMLInputElement;
+
+    const file = new File(['hello world'], 'hello.txt', {
+      type: 'text/plain',
+      lastModified: 1700000000000,
+    });
+
+    await userEvent.upload(input, file);
+
+    await waitFor(
+      () => {
+        expect(canvas.getByTestId('single-file-count').textContent).toBe('1');
+        expect(canvas.getByTestId('single-file-name').textContent).toContain(
+          'hello.txt',
+        );
+        expect(canvas.getByTestId('single-file-name').textContent).toContain(
+          'text/plain',
+        );
+      },
+      { timeout: INTERACTION_TIMEOUT },
+    );
+  },
+});
+
+export const FileInputMultiple: Story = createComponentStory('file-input', {
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    await canvas.findByTestId(
+      'file-input-component',
+      {},
+      { timeout: MOUNT_TIMEOUT },
+    );
+
+    const input = (await canvas.findByTestId(
+      'multi-file-input',
+    )) as HTMLInputElement;
+
+    const first = new File(['a'], 'one.png', { type: 'image/png' });
+    const second = new File(['bb'], 'two.png', { type: 'image/png' });
+
+    await userEvent.upload(input, [first, second]);
+
+    await waitFor(
+      () => {
+        expect(canvas.getByTestId('multi-file-count').textContent).toBe('2');
+        const list = canvas.getByTestId('multi-file-list');
+        expect(list.textContent).toContain('one.png');
+        expect(list.textContent).toContain('two.png');
+      },
+      { timeout: INTERACTION_TIMEOUT },
+    );
+  },
+});
+
 export const HostApiClosePanel: Story = createHostApiStory(
   async ({ canvasElement, args }) => {
     const canvas = within(canvasElement);

--- a/packages/twenty-front-component-renderer/src/__stories__/example-sources/file-input.front-component.tsx
+++ b/packages/twenty-front-component-renderer/src/__stories__/example-sources/file-input.front-component.tsx
@@ -1,0 +1,120 @@
+import { defineFrontComponent } from 'twenty-sdk/define';
+import { type ChangeEvent, useState } from 'react';
+
+type SelectedFile = {
+  name: string;
+  size: number;
+  type: string;
+  lastModified: number;
+};
+
+const CARD_STYLE = {
+  padding: 24,
+  backgroundColor: '#fef3c7',
+  border: '2px solid #f59e0b',
+  borderRadius: 12,
+  fontFamily: 'system-ui, sans-serif',
+  display: 'flex',
+  flexDirection: 'column' as const,
+  gap: 16,
+  maxWidth: 480,
+};
+
+const HEADING_STYLE = {
+  color: '#92400e',
+  fontWeight: 700,
+  fontSize: 18,
+  margin: 0,
+};
+
+const LABEL_STYLE = {
+  fontSize: 13,
+  fontWeight: 600,
+  color: '#374151',
+};
+
+const HINT_STYLE = {
+  fontSize: 13,
+  color: '#6b7280',
+  fontFamily: 'monospace',
+};
+
+const LIST_STYLE = {
+  margin: 0,
+  paddingLeft: 16,
+  fontSize: 13,
+  fontFamily: 'monospace',
+  color: '#374151',
+  display: 'flex',
+  flexDirection: 'column' as const,
+  gap: 4,
+};
+
+const FileInputComponent = () => {
+  const [singleFile, setSingleFile] = useState<SelectedFile | null>(null);
+  const [multiFiles, setMultiFiles] = useState<SelectedFile[]>([]);
+
+  return (
+    <div data-testid="file-input-component" style={CARD_STYLE}>
+      <h2 style={HEADING_STYLE}>File Input</h2>
+
+      <div style={{ display: 'flex', flexDirection: 'column', gap: 4 }}>
+        <label style={LABEL_STYLE}>Single file</label>
+        <input
+          data-testid="single-file-input"
+          type="file"
+          onChange={(event: ChangeEvent<HTMLInputElement>) => {
+            const detail = (
+              event as unknown as { detail: { files?: SelectedFile[] } }
+            ).detail;
+            setSingleFile(detail?.files?.[0] ?? null);
+          }}
+        />
+        <span data-testid="single-file-count" style={HINT_STYLE}>
+          {singleFile === null ? 'none' : '1'}
+        </span>
+        {singleFile !== null && (
+          <span data-testid="single-file-name" style={HINT_STYLE}>
+            {singleFile.name} ({singleFile.size}B, {singleFile.type})
+          </span>
+        )}
+      </div>
+
+      <div style={{ display: 'flex', flexDirection: 'column', gap: 4 }}>
+        <label style={LABEL_STYLE}>Multiple files (image/*)</label>
+        <input
+          data-testid="multi-file-input"
+          type="file"
+          multiple
+          accept="image/*"
+          onChange={(event: ChangeEvent<HTMLInputElement>) => {
+            const detail = (
+              event as unknown as { detail: { files?: SelectedFile[] } }
+            ).detail;
+            setMultiFiles(detail?.files ?? []);
+          }}
+        />
+        <span data-testid="multi-file-count" style={HINT_STYLE}>
+          {multiFiles.length}
+        </span>
+        {multiFiles.length > 0 && (
+          <ul data-testid="multi-file-list" style={LIST_STYLE}>
+            {multiFiles.map((file) => (
+              <li key={`${file.name}-${file.lastModified}`}>
+                {file.name} ({file.size}B)
+              </li>
+            ))}
+          </ul>
+        )}
+      </div>
+    </div>
+  );
+};
+
+export default defineFrontComponent({
+  universalIdentifier: 'test-file-00000000-0000-0000-0000-000000000022',
+  name: 'file-input-component',
+  description:
+    'Component verifying file input metadata is forwarded from host to worker',
+  component: FileInputComponent,
+});

--- a/packages/twenty-front-component-renderer/src/constants/AllowedHtmlElements.ts
+++ b/packages/twenty-front-component-renderer/src/constants/AllowedHtmlElements.ts
@@ -80,6 +80,9 @@ export const ALLOWED_HTML_ELEMENTS: AllowedHtmlElement[] = [
       disabled: { type: 'boolean', optional: true },
       checked: { type: 'boolean', optional: true },
       readOnly: { type: 'boolean', optional: true },
+      accept: { type: 'string', optional: true },
+      multiple: { type: 'boolean', optional: true },
+      capture: { type: 'string', optional: true },
     },
   },
   {

--- a/packages/twenty-front-component-renderer/src/constants/SerializedEventData.ts
+++ b/packages/twenty-front-component-renderer/src/constants/SerializedEventData.ts
@@ -1,3 +1,10 @@
+export type SerializedFileData = {
+  name: string;
+  size: number;
+  type: string;
+  lastModified: number;
+};
+
 export type SerializedEventData = {
   type: string;
   altKey?: boolean;
@@ -34,4 +41,5 @@ export type SerializedEventData = {
   volume?: number;
   muted?: boolean;
   playbackRate?: number;
+  files?: SerializedFileData[];
 };

--- a/packages/twenty-front-component-renderer/src/host/utils/createHtmlHostWrapper.ts
+++ b/packages/twenty-front-component-renderer/src/host/utils/createHtmlHostWrapper.ts
@@ -72,7 +72,9 @@ const parseCssString = (
   return style;
 };
 
-const serializeFileList = (files: unknown): SerializedFileData[] | undefined => {
+const serializeFileList = (
+  files: unknown,
+): SerializedFileData[] | undefined => {
   if (!isObject(files)) return undefined;
   const fileListLike = files as { length?: unknown } & Record<number, unknown>;
   if (!isNumber(fileListLike.length)) return undefined;

--- a/packages/twenty-front-component-renderer/src/host/utils/createHtmlHostWrapper.ts
+++ b/packages/twenty-front-component-renderer/src/host/utils/createHtmlHostWrapper.ts
@@ -53,7 +53,9 @@ const parseCssString = (
 
   for (const declaration of declarations) {
     const colonIndex = declaration.indexOf(':');
-    if (colonIndex === -1) continue;
+    if (colonIndex === -1) {
+      continue;
+    }
 
     const property = declaration.slice(0, colonIndex).trim();
     const value = declaration.slice(colonIndex + 1).trim();
@@ -75,14 +77,20 @@ const parseCssString = (
 const serializeFileList = (
   files: unknown,
 ): SerializedFileData[] | undefined => {
-  if (!isObject(files)) return undefined;
+  if (!isObject(files)) {
+    return undefined;
+  }
   const fileListLike = files as { length?: unknown } & Record<number, unknown>;
-  if (!isNumber(fileListLike.length)) return undefined;
+  if (!isNumber(fileListLike.length)) {
+    return undefined;
+  }
 
   const serialized: SerializedFileData[] = [];
   for (let index = 0; index < fileListLike.length; index++) {
     const file = fileListLike[index];
-    if (!isObject(file)) continue;
+    if (!isObject(file)) {
+      continue;
+    }
     const fileRecord = file as Record<string, unknown>;
     if (
       !isString(fileRecord.name) ||
@@ -113,56 +121,120 @@ const serializeEvent = (event: unknown): SerializedEventData => {
     type: isString(domEvent.type) ? domEvent.type : 'unknown',
   };
 
-  if (isBoolean(domEvent.altKey)) serialized.altKey = domEvent.altKey;
-  if (isBoolean(domEvent.ctrlKey)) serialized.ctrlKey = domEvent.ctrlKey;
-  if (isBoolean(domEvent.metaKey)) serialized.metaKey = domEvent.metaKey;
-  if (isBoolean(domEvent.shiftKey)) serialized.shiftKey = domEvent.shiftKey;
+  if (isBoolean(domEvent.altKey)) {
+    serialized.altKey = domEvent.altKey;
+  }
+  if (isBoolean(domEvent.ctrlKey)) {
+    serialized.ctrlKey = domEvent.ctrlKey;
+  }
+  if (isBoolean(domEvent.metaKey)) {
+    serialized.metaKey = domEvent.metaKey;
+  }
+  if (isBoolean(domEvent.shiftKey)) {
+    serialized.shiftKey = domEvent.shiftKey;
+  }
 
-  if (isNumber(domEvent.clientX)) serialized.clientX = domEvent.clientX;
-  if (isNumber(domEvent.clientY)) serialized.clientY = domEvent.clientY;
-  if (isNumber(domEvent.pageX)) serialized.pageX = domEvent.pageX;
-  if (isNumber(domEvent.pageY)) serialized.pageY = domEvent.pageY;
-  if (isNumber(domEvent.screenX)) serialized.screenX = domEvent.screenX;
-  if (isNumber(domEvent.screenY)) serialized.screenY = domEvent.screenY;
-  if (isNumber(domEvent.offsetX)) serialized.offsetX = domEvent.offsetX;
-  if (isNumber(domEvent.offsetY)) serialized.offsetY = domEvent.offsetY;
-  if (isNumber(domEvent.movementX)) serialized.movementX = domEvent.movementX;
-  if (isNumber(domEvent.movementY)) serialized.movementY = domEvent.movementY;
-  if (isNumber(domEvent.button)) serialized.button = domEvent.button;
-  if (isNumber(domEvent.buttons)) serialized.buttons = domEvent.buttons;
+  if (isNumber(domEvent.clientX)) {
+    serialized.clientX = domEvent.clientX;
+  }
+  if (isNumber(domEvent.clientY)) {
+    serialized.clientY = domEvent.clientY;
+  }
+  if (isNumber(domEvent.pageX)) {
+    serialized.pageX = domEvent.pageX;
+  }
+  if (isNumber(domEvent.pageY)) {
+    serialized.pageY = domEvent.pageY;
+  }
+  if (isNumber(domEvent.screenX)) {
+    serialized.screenX = domEvent.screenX;
+  }
+  if (isNumber(domEvent.screenY)) {
+    serialized.screenY = domEvent.screenY;
+  }
+  if (isNumber(domEvent.offsetX)) {
+    serialized.offsetX = domEvent.offsetX;
+  }
+  if (isNumber(domEvent.offsetY)) {
+    serialized.offsetY = domEvent.offsetY;
+  }
+  if (isNumber(domEvent.movementX)) {
+    serialized.movementX = domEvent.movementX;
+  }
+  if (isNumber(domEvent.movementY)) {
+    serialized.movementY = domEvent.movementY;
+  }
+  if (isNumber(domEvent.button)) {
+    serialized.button = domEvent.button;
+  }
+  if (isNumber(domEvent.buttons)) {
+    serialized.buttons = domEvent.buttons;
+  }
 
-  if (isString(domEvent.key)) serialized.key = domEvent.key;
-  if (isString(domEvent.code)) serialized.code = domEvent.code;
-  if (isBoolean(domEvent.repeat)) serialized.repeat = domEvent.repeat;
+  if (isString(domEvent.key)) {
+    serialized.key = domEvent.key;
+  }
+  if (isString(domEvent.code)) {
+    serialized.code = domEvent.code;
+  }
+  if (isBoolean(domEvent.repeat)) {
+    serialized.repeat = domEvent.repeat;
+  }
 
-  if (isNumber(domEvent.deltaX)) serialized.deltaX = domEvent.deltaX;
-  if (isNumber(domEvent.deltaY)) serialized.deltaY = domEvent.deltaY;
-  if (isNumber(domEvent.deltaZ)) serialized.deltaZ = domEvent.deltaZ;
-  if (isNumber(domEvent.deltaMode)) serialized.deltaMode = domEvent.deltaMode;
+  if (isNumber(domEvent.deltaX)) {
+    serialized.deltaX = domEvent.deltaX;
+  }
+  if (isNumber(domEvent.deltaY)) {
+    serialized.deltaY = domEvent.deltaY;
+  }
+  if (isNumber(domEvent.deltaZ)) {
+    serialized.deltaZ = domEvent.deltaZ;
+  }
+  if (isNumber(domEvent.deltaMode)) {
+    serialized.deltaMode = domEvent.deltaMode;
+  }
 
   const target = domEvent.target;
   if (isObject(target)) {
     const targetRecord = target as Record<string, unknown>;
-    if (isString(targetRecord.value)) serialized.value = targetRecord.value;
-    if (isBoolean(targetRecord.checked))
+    if (isString(targetRecord.value)) {
+      serialized.value = targetRecord.value;
+    }
+    if (isBoolean(targetRecord.checked)) {
       serialized.checked = targetRecord.checked;
-    if (isNumber(targetRecord.scrollTop))
+    }
+    if (isNumber(targetRecord.scrollTop)) {
       serialized.scrollTop = targetRecord.scrollTop;
-    if (isNumber(targetRecord.scrollLeft))
+    }
+    if (isNumber(targetRecord.scrollLeft)) {
       serialized.scrollLeft = targetRecord.scrollLeft;
-    if (isNumber(targetRecord.currentTime))
+    }
+    if (isNumber(targetRecord.currentTime)) {
       serialized.currentTime = targetRecord.currentTime;
-    if (isNumber(targetRecord.duration))
+    }
+    if (isNumber(targetRecord.duration)) {
       serialized.duration = targetRecord.duration;
-    if (isBoolean(targetRecord.paused)) serialized.paused = targetRecord.paused;
-    if (isBoolean(targetRecord.ended)) serialized.ended = targetRecord.ended;
-    if (isNumber(targetRecord.volume)) serialized.volume = targetRecord.volume;
-    if (isBoolean(targetRecord.muted)) serialized.muted = targetRecord.muted;
-    if (isNumber(targetRecord.playbackRate))
+    }
+    if (isBoolean(targetRecord.paused)) {
+      serialized.paused = targetRecord.paused;
+    }
+    if (isBoolean(targetRecord.ended)) {
+      serialized.ended = targetRecord.ended;
+    }
+    if (isNumber(targetRecord.volume)) {
+      serialized.volume = targetRecord.volume;
+    }
+    if (isBoolean(targetRecord.muted)) {
+      serialized.muted = targetRecord.muted;
+    }
+    if (isNumber(targetRecord.playbackRate)) {
       serialized.playbackRate = targetRecord.playbackRate;
+    }
 
     const files = serializeFileList(targetRecord.files);
-    if (isDefined(files)) serialized.files = files;
+    if (isDefined(files)) {
+      serialized.files = files;
+    }
   }
 
   return serialized;
@@ -178,7 +250,9 @@ const filterProps = <T extends object>(props: T): T => {
   const filtered: Record<string, unknown> = {};
 
   for (const [key, value] of Object.entries(props)) {
-    if (INTERNAL_PROPS.has(key) || isUndefined(value)) continue;
+    if (INTERNAL_PROPS.has(key) || isUndefined(value)) {
+      continue;
+    }
 
     if (key === 'style') {
       filtered.style = parseCssString(value as string | undefined);
@@ -226,7 +300,9 @@ const syncValuePreservingCaret = (
   element: CaretPreservingElement,
   nextValue: string,
 ): void => {
-  if (element.value === nextValue) return;
+  if (element.value === nextValue) {
+    return;
+  }
 
   const isFocused = document.activeElement === element;
   const start = isFocused ? element.selectionStart : null;
@@ -258,7 +334,9 @@ const createCaretPreservingElement = (
     ...forcedProps,
     defaultValue: initialValue,
     ref: (node: CaretPreservingElement | null) => {
-      if (!isDefined(node)) return;
+      if (!isDefined(node)) {
+        return;
+      }
       if (isNonEmptyString(value)) {
         syncValuePreservingCaret(node, value);
       }

--- a/packages/twenty-front-component-renderer/src/host/utils/createHtmlHostWrapper.ts
+++ b/packages/twenty-front-component-renderer/src/host/utils/createHtmlHostWrapper.ts
@@ -11,7 +11,10 @@ import React from 'react';
 import { isDefined } from 'twenty-shared/utils';
 
 import { EVENT_TO_REACT } from '@/constants/EventToReact';
-import { type SerializedEventData } from '@/constants/SerializedEventData';
+import {
+  type SerializedEventData,
+  type SerializedFileData,
+} from '@/constants/SerializedEventData';
 
 const INTERNAL_PROPS = new Set(['element', 'receiver', 'components']);
 
@@ -67,6 +70,35 @@ const parseCssString = (
   }
 
   return style;
+};
+
+const serializeFileList = (files: unknown): SerializedFileData[] | undefined => {
+  if (!isObject(files)) return undefined;
+  const fileListLike = files as { length?: unknown } & Record<number, unknown>;
+  if (!isNumber(fileListLike.length)) return undefined;
+
+  const serialized: SerializedFileData[] = [];
+  for (let index = 0; index < fileListLike.length; index++) {
+    const file = fileListLike[index];
+    if (!isObject(file)) continue;
+    const fileRecord = file as Record<string, unknown>;
+    if (
+      !isString(fileRecord.name) ||
+      !isNumber(fileRecord.size) ||
+      !isString(fileRecord.type) ||
+      !isNumber(fileRecord.lastModified)
+    ) {
+      continue;
+    }
+    serialized.push({
+      name: fileRecord.name,
+      size: fileRecord.size,
+      type: fileRecord.type,
+      lastModified: fileRecord.lastModified,
+    });
+  }
+
+  return serialized;
 };
 
 const serializeEvent = (event: unknown): SerializedEventData => {
@@ -126,6 +158,9 @@ const serializeEvent = (event: unknown): SerializedEventData => {
     if (isBoolean(targetRecord.muted)) serialized.muted = targetRecord.muted;
     if (isNumber(targetRecord.playbackRate))
       serialized.playbackRate = targetRecord.playbackRate;
+
+    const files = serializeFileList(targetRecord.files);
+    if (isDefined(files)) serialized.files = files;
   }
 
   return serialized;

--- a/packages/twenty-front-component-renderer/src/remote/generated/remote-elements.ts
+++ b/packages/twenty-front-component-renderer/src/remote/generated/remote-elements.ts
@@ -387,6 +387,9 @@ export type HtmlInputProperties = HtmlCommonProperties & {
   disabled?: boolean;
   checked?: boolean;
   readOnly?: boolean;
+  accept?: string;
+  multiple?: boolean;
+  capture?: string;
 };
 
 export const HtmlInputElement = createRemoteElement<
@@ -404,6 +407,9 @@ export const HtmlInputElement = createRemoteElement<
     disabled: { type: Boolean },
     checked: { type: Boolean },
     readOnly: { type: Boolean },
+    accept: { type: String },
+    multiple: { type: Boolean },
+    capture: { type: String },
   },
   events: [...HTML_COMMON_EVENTS_ARRAY],
 });


### PR DESCRIPTION
## Summary

`<input type=\"file\">` inside front-components was silently non-functional:
- The host-side `serializeEvent` did not read `target.files`, so the worker received an empty `onChange` detail.
- `SerializedEventData` had no `files` field.
- The `html-input` schema in `AllowedHtmlElements` exposed neither `accept`, `multiple`, nor `capture` — the worker could not even configure the picker.

This PR forwards file metadata (`name`, `size`, `type`, `lastModified`) through the existing serialized event detail and accepts the missing attributes on the `html-input` remote element. A new Storybook play test guards the regression by uploading single and multiple files via `userEvent.upload`.

Reading file contents inside the worker is intentionally out of scope here and will need a separate host API bridge (the host has the `File` objects on the real input element; passing bytes through `postMessage` is a bigger design call).

