### PR TITLE
fix(server): allow workspace activation when no instance command has run

### DIFF
--- a/packages/twenty-server/src/engine/core-modules/upgrade/services/__tests__/upgrade-sequence-reader.service.spec.ts
+++ b/packages/twenty-server/src/engine/core-modules/upgrade/services/__tests__/upgrade-sequence-reader.service.spec.ts
@@ -276,6 +276,25 @@ describe('UpgradeSequenceReaderService', () => {
       expect(result).toEqual({ name: 'Ic0', status: 'failed' });
     });
 
+    it('should return the last workspace command as completed when no instance command has been attempted', async () => {
+      // Fresh install: upgradeMigration table has no instance-scoped rows.
+      // A brand-new workspace has nothing pending, so the cursor should land
+      // at the last workspace command of the sequence, marked completed.
+      const sequence = [
+        makeFastInstance('Ic0'),
+        makeWorkspace('Wc0'),
+        makeWorkspace('Wc1'),
+        makeFastInstance('Ic1'),
+        makeWorkspace('Wc2'),
+      ];
+
+      const service = await buildServiceWithMockedSequence(sequence);
+
+      const result = service.getInitialCursorForNewWorkspace(null);
+
+      expect(result).toEqual({ name: 'Wc2', status: 'completed' });
+    });
+
     it('should return the failed mid-segment instance command', async () => {
       // Sequence: Ic0 → Ic1 → Ic2 → Wc0
       // Ic1 failed (Ic0 completed but Ic1 is the last attempted) → cursor at Ic1:failed

--- a/packages/twenty-server/src/engine/core-modules/upgrade/services/upgrade-sequence-reader.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/upgrade/services/upgrade-sequence-reader.service.ts
@@ -162,15 +162,35 @@ export class UpgradeSequenceReaderService {
       : workspaceCommands.slice(cursorIndex);
   }
 
-  getInitialCursorForNewWorkspace(lastAttemptedInstanceCommand: {
-    name: string;
-    status: UpgradeMigrationStatus;
-  }): {
+  getInitialCursorForNewWorkspace(
+    lastAttemptedInstanceCommand: {
+      name: string;
+      status: UpgradeMigrationStatus;
+    } | null,
+  ): {
     name: string;
     status: UpgradeMigrationStatus;
   } {
-    const { name, status } = lastAttemptedInstanceCommand;
     const sequence = this.getUpgradeSequence();
+
+    // No instance command has ever been attempted (fresh install / reset DB).
+    // A brand-new workspace has nothing pending — anchor the cursor at the
+    // last workspace command of the sequence, marked completed.
+    if (lastAttemptedInstanceCommand === null) {
+      const lastWorkspaceStep = [...sequence]
+        .reverse()
+        .find((step): step is WorkspaceUpgradeStep => step.kind === 'workspace');
+
+      if (!isDefined(lastWorkspaceStep)) {
+        throw new Error(
+          'Upgrade sequence contains no workspace command — cannot derive an initial cursor for a new workspace.',
+        );
+      }
+
+      return { name: lastWorkspaceStep.name, status: 'completed' };
+    }
+
+    const { name, status } = lastAttemptedInstanceCommand;
 
     const instanceCursor = this.locateStepInSequenceOrThrow({
       sequence,

--- a/packages/twenty-server/src/engine/core-modules/workspace/services/workspace.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/workspace/services/workspace.service.ts
@@ -387,7 +387,7 @@ export class WorkspaceService extends TypeOrmQueryService<WorkspaceEntity> {
     displayName: string;
   }): Promise<void> {
     const lastAttemptedInstanceCommand =
-      await this.upgradeMigrationService.getLastAttemptedInstanceCommandOrThrow();
+      await this.upgradeMigrationService.getLastAttemptedInstanceCommand();
 
     const initialCursor =
       this.upgradeSequenceReaderService.getInitialCursorForNewWorkspace(

--- a/packages/twenty-server/src/engine/workspace-manager/dev-seeder/services/dev-seeder.service.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/dev-seeder/services/dev-seeder.service.ts
@@ -77,7 +77,7 @@ export class DevSeederService {
     const appVersion = this.twentyConfigService.get('APP_VERSION') ?? 'unknown';
 
     const lastAttemptedInstanceCommand =
-      await this.upgradeMigrationService.getLastAttemptedInstanceCommandOrThrow();
+      await this.upgradeMigrationService.getLastAttemptedInstanceCommand();
     const initialCursor =
       this.upgradeSequenceReaderService.getInitialCursorForNewWorkspace(
         lastAttemptedInstanceCommand,
@@ -193,7 +193,7 @@ export class DevSeederService {
   ): Promise<void> {
     const appVersion = this.twentyConfigService.get('APP_VERSION') ?? 'unknown';
     const lastAttemptedInstanceCommand =
-      await this.upgradeMigrationService.getLastAttemptedInstanceCommandOrThrow();
+      await this.upgradeMigrationService.getLastAttemptedInstanceCommand();
     const initialCursor =
       this.upgradeSequenceReaderService.getInitialCursorForNewWorkspace(
         lastAttemptedInstanceCommand,


### PR DESCRIPTION
activateAndInitializeUpgradeState and the dev seeders were calling getLastAttemptedInstanceCommandOrThrow, which throws when the upgradeMigration table has no instance-scoped rows. That state is the normal initial condition of any fresh install or freshly reset database, so workspace creation blew up unhandled and left the workspace stuck in ONGOING_CREATION.

Switch the three call sites to the non-throwing
getLastAttemptedInstanceCommand and teach
getInitialCursorForNewWorkspace to handle the null case by anchoring the cursor at the last workspace command of the sequence as completed - a brand-new workspace has nothing pending.

Closes #20402