### PR TITLE
ci(preview-env): use --light seed so Apple is the default workspace

### DIFF
--- a/.github/workflows/preview-env-keepalive.yaml
+++ b/.github/workflows/preview-env-keepalive.yaml
@@ -143,9 +143,9 @@ jobs:
       - name: Seed Dev Workspace
         run: |
           cd packages/twenty-docker/
-          echo "Seeding full dev workspace..."
-          if ! docker compose exec -T server yarn command:prod -- workspace:seed:dev; then
-            echo "❌ Seeding full dev workspace failed. Dumping server logs..."
+          echo "Seeding light dev workspace (Apple only)..."
+          if ! docker compose exec -T server yarn command:prod -- workspace:seed:dev --light; then
+            echo "❌ Seeding light dev workspace failed. Dumping server logs..."
             docker compose logs server
             exit 1
           fi


### PR DESCRIPTION
## Summary

- Pass `--light` to `workspace:seed:dev` in the preview env keepalive workflow so only the Apple workspace is created
- Avoids `Empty4` being picked as the default workspace at sign-in (which has no users), making the prefilled `tim@apple.dev` credentials land on a useful workspace

## Why

`workspace:seed:dev` (no flag) seeds Apple + YCombinator + Empty3 + Empty4. Preview envs run in single-workspace mode (`IS_MULTIWORKSPACE_ENABLED=false`), so [`WorkspaceDomainsService.getDefaultWorkspace`](https://github.com/twentyhq/twenty/blob/main/packages/twenty-server/src/engine/core-modules/domain/workspace-domains/services/workspace-domains.service.ts) returns the most recently created workspace — Empty4 — which has no users. Users hitting the preview URL therefore see "Welcome, Empty4." and can't sign in. Same failure mode #19822 fixed for `twenty-app-dev`.

## Test plan

- [ ] Trigger the `preview-app` label on a PR and confirm the preview URL signs in to the Apple workspace, not Empty4
- [ ] Confirm the seed step still passes (no `Empty3`/`Empty4` references break it)

🤖 Generated with [Claude Code](https://claude.com/claude-code)