### PR TITLE
fix(imap): use full IMAP path for Gmail sent folder (#20469)

### DIFF
--- a/packages/twenty-server/src/modules/messaging/message-folder-manager/drivers/imap/services/imap-get-all-folders.service.ts
+++ b/packages/twenty-server/src/modules/messaging/message-folder-manager/drivers/imap/services/imap-get-all-folders.service.ts
@@ -86,7 +86,7 @@ export class ImapGetAllFoldersService implements MessageFolderDriver {
 
       folders.push({
         externalId,
-        name: sentFolder.name,
+        name: sentFolder.path,
         isSynced: true,
         isSentFolder: true,
         parentFolderId: sentMailbox?.parentPath || null,
@@ -120,7 +120,7 @@ export class ImapGetAllFoldersService implements MessageFolderDriver {
 
       folders.push({
         externalId,
-        name: mailbox.name,
+        name: mailbox.path,
         isSynced,
         isSentFolder: false,
         parentFolderId: mailbox.parentPath || null,

--- a/packages/twenty-server/src/modules/messaging/message-outbound-manager/resolvers/send-email.resolver.ts
+++ b/packages/twenty-server/src/modules/messaging/message-outbound-manager/resolvers/send-email.resolver.ts
@@ -107,7 +107,21 @@ export class SendEmailResolver {
         throw error;
       }
 
-      this.logger.error(`Failed to send email: ${error}`);
+      const errorResponse =
+        error instanceof Error && 'response' in error
+          ? String((error as Error & { response?: unknown }).response)
+          : undefined;
+      const errorResponseStatus =
+        error instanceof Error && 'responseStatus' in error
+          ? String((error as Error & { responseStatus?: unknown }).responseStatus)
+          : undefined;
+
+      this.logger.error(
+        `Failed to send email: ${error}${
+          errorResponse ? `, response=${errorResponse}` : ''
+        }${errorResponseStatus ? `, responseStatus=${errorResponseStatus}` : ''}`,
+        error instanceof Error ? error.stack : undefined,
+      );
 
       return {
         success: false,


### PR DESCRIPTION
## Summary

Fixes outbound email send failure for Gmail IMAP accounts.

**Root cause**: `ImapGetAllFoldersService` stored `mailbox.name` (leaf name, e.g. `Sent Mail`) in `messageFolder.name` instead of `mailbox.path` (full hierarchy, e.g. `[Gmail]/Sent Mail`). For Gmail special folders, protocol operations must use the full IMAP path.

## Changes

1. In `ImapGetAllFoldersService.filterAndMapFolders`, store `sentFolder.path` and `mailbox.path` in `name` instead of the leaf names.
2. In `SendEmailResolver`, log `error.response` and `error.responseStatus` when available to make future IMAP failures easier to diagnose.

Closes #20469

---
Work submitted for Algora bounty.
