### PR TITLE
security: harden CI against supply-chain attacks

### DIFF
--- a/.cursor/rules/github-actions-security.mdc
+++ b/.cursor/rules/github-actions-security.mdc
@@ -1,0 +1,36 @@
+---
+description: GitHub Actions security guidelines for supply chain protection
+globs: **/.github/**/*.yml, **/.github/**/*.yaml
+alwaysApply: false
+---
+
+# GitHub Actions Security
+
+## Pin Third-Party Actions to Commit SHAs
+
+Always reference external actions and reusable workflows by their full commit SHA, never by a mutable tag or branch. Tags can be force-pushed by a compromised maintainer account.
+
+```yaml
+# ❌ Mutable tag — vulnerable to supply chain attacks
+uses: actions/checkout@v4
+uses: actions/setup-node@v4
+uses: peter-evans/repository-dispatch@v2
+
+# ✅ Pinned to commit SHA with tag comment for readability
+uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+uses: actions/setup-node@60edb5dd545a775178f52524783378180af0d1f8 # v4.0.2
+uses: peter-evans/repository-dispatch@ff45666b9427631e3450c54a1bcbee4d9ff4d7c0 # v3.0.0
+```
+
+## Minimal Permissions
+
+Always declare explicit `permissions` at the job level with the least privilege required. Never rely on the default `GITHUB_TOKEN` permissions.
+
+```yaml
+# ✅ Explicit minimal permissions
+permissions:
+  contents: read
+
+# ❌ Overly broad or implicit permissions
+permissions: write-all
+```

--- a/.cursor/rules/github-actions-security.mdc
+++ b/.cursor/rules/github-actions-security.mdc
@@ -14,12 +14,32 @@ Always reference external actions and reusable workflows by their full commit SH
 # ❌ Mutable tag — vulnerable to supply chain attacks
 uses: actions/checkout@v4
 uses: actions/setup-node@v4
-uses: peter-evans/repository-dispatch@v2
 
 # ✅ Pinned to commit SHA with tag comment for readability
 uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
 uses: actions/setup-node@60edb5dd545a775178f52524783378180af0d1f8 # v4.0.2
-uses: peter-evans/repository-dispatch@ff45666b9427631e3450c54a1bcbee4d9ff4d7c0 # v3.0.0
+```
+
+## Prefer `gh api` Over Third-Party Dispatch Actions
+
+For repository dispatch calls, use `gh api` directly instead of third-party actions like `peter-evans/repository-dispatch`. This eliminates a supply-chain dependency entirely.
+
+```yaml
+# ✅ Direct gh api call — no third-party action needed
+- name: Dispatch to target repo
+  env:
+    GH_TOKEN: ${{ secrets.DISPATCH_TOKEN }}
+  run: |
+    gh api repos/org/repo/dispatches \
+      --raw-field event_type=my-event \
+      --raw-field 'client_payload={"key": "value"}'
+
+# ❌ Third-party action dependency
+- uses: peter-evans/repository-dispatch@v2
+  with:
+    token: ${{ secrets.DISPATCH_TOKEN }}
+    repository: org/repo
+    event-type: my-event
 ```
 
 ## Minimal Permissions

--- a/.cursor/rules/github-actions-security.mdc
+++ b/.cursor/rules/github-actions-security.mdc
@@ -16,8 +16,8 @@ uses: actions/checkout@v4
 uses: actions/setup-node@v4
 
 # ✅ Pinned to commit SHA with tag comment for readability
-uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
-uses: actions/setup-node@60edb5dd545a775178f52524783378180af0d1f8 # v4.0.2
+uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
 ```
 
 ## Prefer `gh api` Over Third-Party Dispatch Actions

--- a/.cursor/rules/github-actions-security.mdc
+++ b/.cursor/rules/github-actions-security.mdc
@@ -25,14 +25,24 @@ uses: actions/setup-node@60edb5dd545a775178f52524783378180af0d1f8 # v4.0.2
 For repository dispatch calls, use `gh api` directly instead of third-party actions like `peter-evans/repository-dispatch`. This eliminates a supply-chain dependency entirely.
 
 ```yaml
-# ✅ Direct gh api call — no third-party action needed
+# ✅ Use env vars + bracket notation to prevent injection
 - name: Dispatch to target repo
   env:
     GH_TOKEN: ${{ secrets.DISPATCH_TOKEN }}
+    PR_NUMBER: ${{ github.event.pull_request.number }}
+    BRANCH: ${{ github.event.workflow_run.head_branch }}
   run: |
     gh api repos/org/repo/dispatches \
-      --raw-field event_type=my-event \
-      --raw-field 'client_payload={"key": "value"}'
+      -f event_type=my-event \
+      -f "client_payload[pr_number]=$PR_NUMBER" \
+      -f "client_payload[branch]=$BRANCH"
+
+# ✅ Simple dispatch without payload
+- name: Trigger workflow
+  env:
+    GH_TOKEN: ${{ secrets.DISPATCH_TOKEN }}
+  run: |
+    gh api repos/org/repo/dispatches -f event_type=my-event
 
 # ❌ Third-party action dependency
 - uses: peter-evans/repository-dispatch@v2
@@ -40,6 +50,12 @@ For repository dispatch calls, use `gh api` directly instead of third-party acti
     token: ${{ secrets.DISPATCH_TOKEN }}
     repository: org/repo
     event-type: my-event
+
+# ❌ Inline ${{ }} in shell — vulnerable to injection
+- run: |
+    gh api repos/org/repo/dispatches --input - <<EOF
+    {"event_type": "x", "client_payload": {"branch": "${{ github.head_ref }}"}}
+    EOF
 ```
 
 ## Minimal Permissions

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,6 +1,6 @@
-/.github/                                @prastoin @charlesBochet @FelixMalfait
-/.github/CODEOWNERS                       @prastoin @charlesBochet @FelixMalfait
-/.github/workflows/                       @prastoin @charlesBochet @FelixMalfait
-/.github/actions/                         @prastoin @charlesBochet @FelixMalfait
-/.github/dependabot.yml                   @prastoin @charlesBochet @FelixMalfait
-/.yarnrc.yml                              @prastoin @charlesBochet @FelixMalfait
+/.github/              @charlesBochet @FelixMalfait @Weiko @prastoin @bosiraphael @etiennejouan @ijreilly @martmull @thomtrp
+/.github/CODEOWNERS    @charlesBochet @FelixMalfait @Weiko @prastoin @bosiraphael @etiennejouan @ijreilly @martmull @thomtrp
+/.github/workflows/    @charlesBochet @FelixMalfait @Weiko @prastoin @bosiraphael @etiennejouan @ijreilly @martmull @thomtrp
+/.github/actions/      @charlesBochet @FelixMalfait @Weiko @prastoin @bosiraphael @etiennejouan @ijreilly @martmull @thomtrp
+/.github/dependabot.yml @charlesBochet @FelixMalfait @Weiko @prastoin @bosiraphael @etiennejouan @ijreilly @martmull @thomtrp
+/.yarnrc.yml           @charlesBochet @FelixMalfait @Weiko @prastoin @bosiraphael @etiennejouan @ijreilly @martmull @thomtrp

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,6 @@
+/.github/                                @prastoin @charlesBochet @FelixMalfait
+/.github/CODEOWNERS                       @prastoin @charlesBochet @FelixMalfait
+/.github/workflows/                       @prastoin @charlesBochet @FelixMalfait
+/.github/actions/                         @prastoin @charlesBochet @FelixMalfait
+/.github/dependabot.yml                   @prastoin @charlesBochet @FelixMalfait
+/.yarnrc.yml                              @prastoin @charlesBochet @FelixMalfait

--- a/.github/actions/deploy-twenty-app/action.yml
+++ b/.github/actions/deploy-twenty-app/action.yml
@@ -21,7 +21,7 @@ runs:
       run: corepack enable
 
     - name: Setup Node.js
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
       with:
         node-version-file: '${{ inputs.app-path }}/.nvmrc'
         cache: yarn

--- a/.github/actions/install-twenty-app/action.yml
+++ b/.github/actions/install-twenty-app/action.yml
@@ -21,7 +21,7 @@ runs:
       run: corepack enable
 
     - name: Setup Node.js
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
       with:
         node-version-file: '${{ inputs.app-path }}/.nvmrc'
         cache: yarn

--- a/.github/actions/nx-affected/action.yaml
+++ b/.github/actions/nx-affected/action.yaml
@@ -20,7 +20,7 @@ runs:
       run: git fetch origin main --depth=1
     - name: Get last successful commit
       if: env.NX_BASE == ''
-      uses: nrwl/nx-set-shas@v4
+      uses: nrwl/nx-set-shas@3e9ad7370203c1e93d109be57f3b72eb0eb511b1 # v4
     - name: Fallback to origin/main if no base found
       if: env.NX_BASE == ''
       shell: bash

--- a/.github/actions/restore-cache/action.yaml
+++ b/.github/actions/restore-cache/action.yaml
@@ -25,7 +25,7 @@ runs:
       run: |
         echo "CACHE_PRIMARY_KEY_PREFIX=v4-${CACHE_KEY}-${REF_NAME}" >> "${GITHUB_OUTPUT}"
     - name: Restore cache
-      uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.2.0 (restore)
+      uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0 (restore)
       id: restore-cache
       with:
         key: ${{ steps.cache-primary-key-builder.outputs.CACHE_PRIMARY_KEY_PREFIX }}-${{ github.sha }}

--- a/.github/actions/restore-cache/action.yaml
+++ b/.github/actions/restore-cache/action.yaml
@@ -25,7 +25,7 @@ runs:
       run: |
         echo "CACHE_PRIMARY_KEY_PREFIX=v4-${CACHE_KEY}-${REF_NAME}" >> "${GITHUB_OUTPUT}"
     - name: Restore cache
-      uses: actions/cache/restore@v4
+      uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.2.0 (restore)
       id: restore-cache
       with:
         key: ${{ steps.cache-primary-key-builder.outputs.CACHE_PRIMARY_KEY_PREFIX }}-${{ github.sha }}

--- a/.github/actions/save-cache/action.yaml
+++ b/.github/actions/save-cache/action.yaml
@@ -13,7 +13,7 @@ runs:
     # The fork guard is defense-in-depth for pull_request_target, which does have write access.
     - name: Save cache
       if: ${{ format('{0}', github.event.pull_request.head.repo.fork) != 'true' }}
-      uses: actions/cache/save@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.2.0 (save)
+      uses: actions/cache/save@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0 (save)
       with:
         key: ${{ inputs.key }}
         path: |

--- a/.github/actions/save-cache/action.yaml
+++ b/.github/actions/save-cache/action.yaml
@@ -9,6 +9,8 @@ inputs:
 runs:
   using: "composite"
   steps:
+    # Fork PRs on pull_request already can't write to the base repo's cache (GitHub built-in).
+    # The fork guard is defense-in-depth for pull_request_target, which does have write access.
     - name: Save cache
       if: ${{ format('{0}', github.event.pull_request.head.repo.fork) != 'true' }}
       uses: actions/cache/save@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.2.0 (save)

--- a/.github/actions/save-cache/action.yaml
+++ b/.github/actions/save-cache/action.yaml
@@ -10,7 +10,7 @@ runs:
   using: "composite"
   steps:
     - name: Save cache
-      if: ${{ github.event.pull_request.head.repo.fork != true }}
+      if: ${{ format('{0}', github.event.pull_request.head.repo.fork) != 'true' }}
       uses: actions/cache/save@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.2.0 (save)
       with:
         key: ${{ inputs.key }}

--- a/.github/actions/save-cache/action.yaml
+++ b/.github/actions/save-cache/action.yaml
@@ -10,7 +10,7 @@ runs:
   using: "composite"
   steps:
     - name: Save cache
-      uses: actions/cache/save@v4
+      uses: actions/cache/save@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.2.0 (save)
       with:
         key: ${{ inputs.key }}
         path: |

--- a/.github/actions/save-cache/action.yaml
+++ b/.github/actions/save-cache/action.yaml
@@ -10,6 +10,7 @@ runs:
   using: "composite"
   steps:
     - name: Save cache
+      if: ${{ github.event.pull_request.head.repo.fork != true }}
       uses: actions/cache/save@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.2.0 (save)
       with:
         key: ${{ inputs.key }}

--- a/.github/actions/spawn-twenty-docker-image/action.yaml
+++ b/.github/actions/spawn-twenty-docker-image/action.yaml
@@ -48,7 +48,7 @@ runs:
         fi
 
     - name: Checkout docker compose files
-      uses: actions/checkout@v4
+      uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.0
       with:
         repository: ${{ inputs.twenty-repository }}
         ref: ${{ steps.resolve.outputs.git-ref }}

--- a/.github/actions/spawn-twenty-docker-image/action.yaml
+++ b/.github/actions/spawn-twenty-docker-image/action.yaml
@@ -48,7 +48,7 @@ runs:
         fi
 
     - name: Checkout docker compose files
-      uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.0
+      uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
       with:
         repository: ${{ inputs.twenty-repository }}
         ref: ${{ steps.resolve.outputs.git-ref }}

--- a/.github/actions/yarn-install/action.yaml
+++ b/.github/actions/yarn-install/action.yaml
@@ -46,6 +46,8 @@ runs:
         yarn config set enableHardenedMode true
         yarn config set enableScripts false
         yarn --immutable --check-cache
+    # Fork PRs on pull_request already can't write to the base repo's cache (GitHub built-in).
+    # The fork guard is defense-in-depth for pull_request_target, which does have write access.
     - name: Save cache
       if: ${{ steps.cache-node-modules.outputs.cache-hit != 'true' && steps.cache-node-modules.outputs.cache-matched-key == '' && format('{0}', github.event.pull_request.head.repo.fork) != 'true' }}
       uses: actions/cache/save@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.2.0 (save)

--- a/.github/actions/yarn-install/action.yaml
+++ b/.github/actions/yarn-install/action.yaml
@@ -3,6 +3,10 @@ inputs:
   node-version:
     required: false
     default: '24'
+  ignore-scripts:
+    description: 'Disable lifecycle scripts during install. Set true for fork-PR contexts where package.json is attacker-controllable.'
+    required: false
+    default: 'false'
 
 runs:
   using: 'composite'
@@ -29,12 +33,12 @@ runs:
         echo "packages/*/node_modules" >> $GITHUB_OUTPUT
         echo 'EOF' >> $GITHUB_OUTPUT
     - name: Setup Node.js and get yarn cache
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
       with:
         node-version: ${{ inputs.node-version }}
     - name: Restore node_modules
       id: cache-node-modules
-      uses: actions/cache/restore@v4
+      uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.2.0 (restore)
       with:
         key: v4-${{ steps.globals.outputs.CACHE_KEY_PREFIX }}-${{github.sha}}
         restore-keys: v4-${{ steps.globals.outputs.CACHE_KEY_PREFIX }}-
@@ -42,12 +46,17 @@ runs:
     - name: Install Dependencies
       if: ${{ steps.cache-node-modules.outputs.cache-hit != 'true' && steps.cache-node-modules.outputs.cache-matched-key == '' }}
       shell: ${{ steps.globals.outputs.ACTION_SHELL }}
+      env:
+        IGNORE_SCRIPTS: ${{ inputs.ignore-scripts }}
       run: |
         yarn config set enableHardenedMode true
+        if [ "${IGNORE_SCRIPTS}" = "true" ]; then
+          yarn config set enableScripts false
+        fi
         yarn --immutable --check-cache
     - name: Save cache
       if: ${{ steps.cache-node-modules.outputs.cache-hit != 'true' && steps.cache-node-modules.outputs.cache-matched-key == '' }}
-      uses: actions/cache/save@v4
+      uses: actions/cache/save@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.2.0 (save)
       with:
         key: ${{ steps.cache-node-modules.outputs.cache-primary-key }}
         path: ${{ steps.globals.outputs.PATH_TO_CACHE }}

--- a/.github/actions/yarn-install/action.yaml
+++ b/.github/actions/yarn-install/action.yaml
@@ -47,7 +47,7 @@ runs:
         yarn config set enableScripts false
         yarn --immutable --check-cache
     - name: Save cache
-      if: ${{ steps.cache-node-modules.outputs.cache-hit != 'true' && steps.cache-node-modules.outputs.cache-matched-key == '' && github.event.pull_request.head.repo.fork != true }}
+      if: ${{ steps.cache-node-modules.outputs.cache-hit != 'true' && steps.cache-node-modules.outputs.cache-matched-key == '' && format('{0}', github.event.pull_request.head.repo.fork) != 'true' }}
       uses: actions/cache/save@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.2.0 (save)
       with:
         key: ${{ steps.cache-node-modules.outputs.cache-primary-key }}

--- a/.github/actions/yarn-install/action.yaml
+++ b/.github/actions/yarn-install/action.yaml
@@ -3,10 +3,6 @@ inputs:
   node-version:
     required: false
     default: '24'
-  ignore-scripts:
-    description: 'Disable lifecycle scripts during install. Set true for fork-PR contexts where package.json is attacker-controllable.'
-    required: false
-    default: 'false'
 
 runs:
   using: 'composite'
@@ -46,16 +42,12 @@ runs:
     - name: Install Dependencies
       if: ${{ steps.cache-node-modules.outputs.cache-hit != 'true' && steps.cache-node-modules.outputs.cache-matched-key == '' }}
       shell: ${{ steps.globals.outputs.ACTION_SHELL }}
-      env:
-        IGNORE_SCRIPTS: ${{ inputs.ignore-scripts }}
       run: |
         yarn config set enableHardenedMode true
-        if [ "${IGNORE_SCRIPTS}" = "true" ]; then
-          yarn config set enableScripts false
-        fi
+        yarn config set enableScripts false
         yarn --immutable --check-cache
     - name: Save cache
-      if: ${{ steps.cache-node-modules.outputs.cache-hit != 'true' && steps.cache-node-modules.outputs.cache-matched-key == '' }}
+      if: ${{ steps.cache-node-modules.outputs.cache-hit != 'true' && steps.cache-node-modules.outputs.cache-matched-key == '' && github.event.pull_request.head.repo.fork != true }}
       uses: actions/cache/save@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.2.0 (save)
       with:
         key: ${{ steps.cache-node-modules.outputs.cache-primary-key }}

--- a/.github/actions/yarn-install/action.yaml
+++ b/.github/actions/yarn-install/action.yaml
@@ -34,7 +34,7 @@ runs:
         node-version: ${{ inputs.node-version }}
     - name: Restore node_modules
       id: cache-node-modules
-      uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.2.0 (restore)
+      uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0 (restore)
       with:
         key: v4-${{ steps.globals.outputs.CACHE_KEY_PREFIX }}-${{github.sha}}
         restore-keys: v4-${{ steps.globals.outputs.CACHE_KEY_PREFIX }}-
@@ -50,7 +50,7 @@ runs:
     # The fork guard is defense-in-depth for pull_request_target, which does have write access.
     - name: Save cache
       if: ${{ steps.cache-node-modules.outputs.cache-hit != 'true' && steps.cache-node-modules.outputs.cache-matched-key == '' && format('{0}', github.event.pull_request.head.repo.fork) != 'true' }}
-      uses: actions/cache/save@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.2.0 (save)
+      uses: actions/cache/save@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0 (save)
       with:
         key: ${{ steps.cache-node-modules.outputs.cache-primary-key }}
         path: ${{ steps.globals.outputs.PATH_TO_CACHE }}

--- a/.github/workflows/cd-deploy-main.yaml
+++ b/.github/workflows/cd-deploy-main.yaml
@@ -14,9 +14,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Repository Dispatch
-        uses: peter-evans/repository-dispatch@bf47d102fdb849e755b0b0023ea3e81a44b6f570 # v2
-        with:
-          token: ${{ secrets.TWENTY_INFRA_TOKEN }}
-          repository: twentyhq/twenty-infra
-          event-type: auto-deploy-main
-          client-payload: '{"github": {"sha": ${{ toJSON(github.sha) }}, "ref": ${{ toJSON(github.ref) }}, "actor": ${{ toJSON(github.actor) }}, "run_id": ${{ toJSON(github.run_id) }}, "repository": ${{ toJSON(github.repository) }}}}'
+        env:
+          GH_TOKEN: ${{ secrets.TWENTY_INFRA_TOKEN }}
+        run: |
+          gh api repos/twentyhq/twenty-infra/dispatches \
+            --raw-field event_type=auto-deploy-main \
+            --raw-field 'client_payload={"github": {"sha": "${{ github.sha }}", "ref": "${{ github.ref }}", "actor": "${{ github.actor }}", "run_id": "${{ github.run_id }}", "repository": "${{ github.repository }}"}}'

--- a/.github/workflows/cd-deploy-main.yaml
+++ b/.github/workflows/cd-deploy-main.yaml
@@ -16,16 +16,6 @@ jobs:
       - name: Repository Dispatch
         env:
           GH_TOKEN: ${{ secrets.TWENTY_INFRA_TOKEN }}
-          SHA: ${{ github.sha }}
-          REF: ${{ github.ref }}
-          ACTOR: ${{ github.actor }}
-          RUN_ID: ${{ github.run_id }}
-          REPOSITORY: ${{ github.repository }}
         run: |
           gh api repos/twentyhq/twenty-infra/dispatches \
-            -f event_type=auto-deploy-main \
-            -f "client_payload[github][sha]=$SHA" \
-            -f "client_payload[github][ref]=$REF" \
-            -f "client_payload[github][actor]=$ACTOR" \
-            -f "client_payload[github][run_id]=$RUN_ID" \
-            -f "client_payload[github][repository]=$REPOSITORY"
+            -f event_type=auto-deploy-main

--- a/.github/workflows/cd-deploy-main.yaml
+++ b/.github/workflows/cd-deploy-main.yaml
@@ -19,4 +19,4 @@ jobs:
           token: ${{ secrets.TWENTY_INFRA_TOKEN }}
           repository: twentyhq/twenty-infra
           event-type: auto-deploy-main
-          client-payload: '{"sha": ${{ toJSON(github.sha) }}, "ref": ${{ toJSON(github.ref) }}, "actor": ${{ toJSON(github.actor) }}, "run_id": ${{ toJSON(github.run_id) }}, "repository": ${{ toJSON(github.repository) }}}'
+          client-payload: '{"github": {"sha": ${{ toJSON(github.sha) }}, "ref": ${{ toJSON(github.ref) }}, "actor": ${{ toJSON(github.actor) }}, "run_id": ${{ toJSON(github.run_id) }}, "repository": ${{ toJSON(github.repository) }}}}'

--- a/.github/workflows/cd-deploy-main.yaml
+++ b/.github/workflows/cd-deploy-main.yaml
@@ -14,9 +14,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Repository Dispatch
-        uses: peter-evans/repository-dispatch@v2
+        uses: peter-evans/repository-dispatch@bf47d102fdb849e755b0b0023ea3e81a44b6f570 # v2
         with:
           token: ${{ secrets.TWENTY_INFRA_TOKEN }}
           repository: twentyhq/twenty-infra
           event-type: auto-deploy-main
-          client-payload: '{"github": ${{ toJson(github) }}}' # Passes the entire github context to the downstream workflow
+          client-payload: '{"sha": ${{ toJSON(github.sha) }}, "ref": ${{ toJSON(github.ref) }}, "actor": ${{ toJSON(github.actor) }}, "run_id": ${{ toJSON(github.run_id) }}, "repository": ${{ toJSON(github.repository) }}}'

--- a/.github/workflows/cd-deploy-main.yaml
+++ b/.github/workflows/cd-deploy-main.yaml
@@ -16,7 +16,16 @@ jobs:
       - name: Repository Dispatch
         env:
           GH_TOKEN: ${{ secrets.TWENTY_INFRA_TOKEN }}
+          SHA: ${{ github.sha }}
+          REF: ${{ github.ref }}
+          ACTOR: ${{ github.actor }}
+          RUN_ID: ${{ github.run_id }}
+          REPOSITORY: ${{ github.repository }}
         run: |
           gh api repos/twentyhq/twenty-infra/dispatches \
-            --raw-field event_type=auto-deploy-main \
-            --raw-field 'client_payload={"github": {"sha": "${{ github.sha }}", "ref": "${{ github.ref }}", "actor": "${{ github.actor }}", "run_id": "${{ github.run_id }}", "repository": "${{ github.repository }}"}}'
+            -f event_type=auto-deploy-main \
+            -f "client_payload[github][sha]=$SHA" \
+            -f "client_payload[github][ref]=$REF" \
+            -f "client_payload[github][actor]=$ACTOR" \
+            -f "client_payload[github][run_id]=$RUN_ID" \
+            -f "client_payload[github][repository]=$REPOSITORY"

--- a/.github/workflows/cd-deploy-tag.yaml
+++ b/.github/workflows/cd-deploy-tag.yaml
@@ -16,7 +16,18 @@ jobs:
       - name: Repository Dispatch
         env:
           GH_TOKEN: ${{ secrets.TWENTY_INFRA_TOKEN }}
+          SHA: ${{ github.sha }}
+          REF: ${{ github.ref }}
+          REF_NAME: ${{ github.ref_name }}
+          ACTOR: ${{ github.actor }}
+          RUN_ID: ${{ github.run_id }}
+          REPOSITORY: ${{ github.repository }}
         run: |
           gh api repos/twentyhq/twenty-infra/dispatches \
-            --raw-field event_type=auto-deploy-tag \
-            --raw-field 'client_payload={"github": {"sha": "${{ github.sha }}", "ref": "${{ github.ref }}", "ref_name": "${{ github.ref_name }}", "actor": "${{ github.actor }}", "run_id": "${{ github.run_id }}", "repository": "${{ github.repository }}"}}'
+            -f event_type=auto-deploy-tag \
+            -f "client_payload[github][sha]=$SHA" \
+            -f "client_payload[github][ref]=$REF" \
+            -f "client_payload[github][ref_name]=$REF_NAME" \
+            -f "client_payload[github][actor]=$ACTOR" \
+            -f "client_payload[github][run_id]=$RUN_ID" \
+            -f "client_payload[github][repository]=$REPOSITORY"

--- a/.github/workflows/cd-deploy-tag.yaml
+++ b/.github/workflows/cd-deploy-tag.yaml
@@ -14,9 +14,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Repository Dispatch
-        uses: peter-evans/repository-dispatch@bf47d102fdb849e755b0b0023ea3e81a44b6f570 # v2
-        with:
-          token: ${{ secrets.TWENTY_INFRA_TOKEN }}
-          repository: twentyhq/twenty-infra
-          event-type: auto-deploy-tag
-          client-payload: '{"github": {"sha": ${{ toJSON(github.sha) }}, "ref": ${{ toJSON(github.ref) }}, "ref_name": ${{ toJSON(github.ref_name) }}, "actor": ${{ toJSON(github.actor) }}, "run_id": ${{ toJSON(github.run_id) }}, "repository": ${{ toJSON(github.repository) }}}}'
+        env:
+          GH_TOKEN: ${{ secrets.TWENTY_INFRA_TOKEN }}
+        run: |
+          gh api repos/twentyhq/twenty-infra/dispatches \
+            --raw-field event_type=auto-deploy-tag \
+            --raw-field 'client_payload={"github": {"sha": "${{ github.sha }}", "ref": "${{ github.ref }}", "ref_name": "${{ github.ref_name }}", "actor": "${{ github.actor }}", "run_id": "${{ github.run_id }}", "repository": "${{ github.repository }}"}}'

--- a/.github/workflows/cd-deploy-tag.yaml
+++ b/.github/workflows/cd-deploy-tag.yaml
@@ -14,9 +14,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Repository Dispatch
-        uses: peter-evans/repository-dispatch@v2
+        uses: peter-evans/repository-dispatch@bf47d102fdb849e755b0b0023ea3e81a44b6f570 # v2
         with:
           token: ${{ secrets.TWENTY_INFRA_TOKEN }}
           repository: twentyhq/twenty-infra
           event-type: auto-deploy-tag
-          client-payload: '{"github": ${{ toJson(github) }}}' # Passes the entire github context to the downstream workflow
+          client-payload: '{"sha": ${{ toJSON(github.sha) }}, "ref": ${{ toJSON(github.ref) }}, "ref_name": ${{ toJSON(github.ref_name) }}, "actor": ${{ toJSON(github.actor) }}, "run_id": ${{ toJSON(github.run_id) }}, "repository": ${{ toJSON(github.repository) }}}'

--- a/.github/workflows/cd-deploy-tag.yaml
+++ b/.github/workflows/cd-deploy-tag.yaml
@@ -19,4 +19,4 @@ jobs:
           token: ${{ secrets.TWENTY_INFRA_TOKEN }}
           repository: twentyhq/twenty-infra
           event-type: auto-deploy-tag
-          client-payload: '{"sha": ${{ toJSON(github.sha) }}, "ref": ${{ toJSON(github.ref) }}, "ref_name": ${{ toJSON(github.ref_name) }}, "actor": ${{ toJSON(github.actor) }}, "run_id": ${{ toJSON(github.run_id) }}, "repository": ${{ toJSON(github.repository) }}}'
+          client-payload: '{"github": {"sha": ${{ toJSON(github.sha) }}, "ref": ${{ toJSON(github.ref) }}, "ref_name": ${{ toJSON(github.ref_name) }}, "actor": ${{ toJSON(github.actor) }}, "run_id": ${{ toJSON(github.run_id) }}, "repository": ${{ toJSON(github.repository) }}}}'

--- a/.github/workflows/cd-deploy-tag.yaml
+++ b/.github/workflows/cd-deploy-tag.yaml
@@ -16,18 +16,8 @@ jobs:
       - name: Repository Dispatch
         env:
           GH_TOKEN: ${{ secrets.TWENTY_INFRA_TOKEN }}
-          SHA: ${{ github.sha }}
-          REF: ${{ github.ref }}
           REF_NAME: ${{ github.ref_name }}
-          ACTOR: ${{ github.actor }}
-          RUN_ID: ${{ github.run_id }}
-          REPOSITORY: ${{ github.repository }}
         run: |
           gh api repos/twentyhq/twenty-infra/dispatches \
             -f event_type=auto-deploy-tag \
-            -f "client_payload[github][sha]=$SHA" \
-            -f "client_payload[github][ref]=$REF" \
-            -f "client_payload[github][ref_name]=$REF_NAME" \
-            -f "client_payload[github][actor]=$ACTOR" \
-            -f "client_payload[github][run_id]=$RUN_ID" \
-            -f "client_payload[github][repository]=$REPOSITORY"
+            -f "client_payload[github][ref_name]=$REF_NAME"

--- a/.github/workflows/changed-files.yaml
+++ b/.github/workflows/changed-files.yaml
@@ -21,11 +21,11 @@ jobs:
       any_changed: ${{ steps.changed-files.outputs.any_changed }}
     steps:
       - name: Fetch custom Github Actions and base branch history
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.0
         with:
           fetch-depth: 10
       - name: Check for changed files
         id: changed-files
-        uses: tj-actions/changed-files@v45
+        uses: tj-actions/changed-files@48d8f15b2aaa3d255ca5af3eba4870f807ce6b3c # v45.0.9
         with:
           files: ${{ inputs.files }}

--- a/.github/workflows/changed-files.yaml
+++ b/.github/workflows/changed-files.yaml
@@ -21,7 +21,7 @@ jobs:
       any_changed: ${{ steps.changed-files.outputs.any_changed }}
     steps:
       - name: Fetch custom Github Actions and base branch history
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.0
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           fetch-depth: 10
       - name: Check for changed files

--- a/.github/workflows/ci-ai-catalog-sync.yaml
+++ b/.github/workflows/ci-ai-catalog-sync.yaml
@@ -17,7 +17,7 @@ jobs:
       NODE_OPTIONS: '--max-old-space-size=4096'
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.0
         with:
           ref: main
 
@@ -41,7 +41,7 @@ jobs:
 
       - name: Create pull request
         if: steps.changes.outputs.changed == 'true'
-        uses: peter-evans/create-pull-request@v7
+        uses: peter-evans/create-pull-request@22a9089034f40e5a961c8808d113e2c98fb63676 # v7.0.6
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           commit-message: 'chore: sync AI model catalog from models.dev'
@@ -61,7 +61,7 @@ jobs:
 
       - name: Trigger automerge
         if: steps.changes.outputs.changed == 'true'
-        uses: peter-evans/repository-dispatch@v2
+        uses: peter-evans/repository-dispatch@bf47d102fdb849e755b0b0023ea3e81a44b6f570 # v2
         with:
           token: ${{ secrets.TWENTY_INFRA_TOKEN }}
           repository: twentyhq/twenty-infra

--- a/.github/workflows/ci-ai-catalog-sync.yaml
+++ b/.github/workflows/ci-ai-catalog-sync.yaml
@@ -61,8 +61,9 @@ jobs:
 
       - name: Trigger automerge
         if: steps.changes.outputs.changed == 'true'
-        uses: peter-evans/repository-dispatch@bf47d102fdb849e755b0b0023ea3e81a44b6f570 # v2
-        with:
-          token: ${{ secrets.TWENTY_INFRA_TOKEN }}
-          repository: twentyhq/twenty-infra
-          event-type: automated-pr-ready
+        env:
+          GH_TOKEN: ${{ secrets.TWENTY_INFRA_TOKEN }}
+        run: |
+          gh api repos/twentyhq/twenty-infra/dispatches \
+            --raw-field event_type=automated-pr-ready \
+            --raw-field 'client_payload={}'

--- a/.github/workflows/ci-ai-catalog-sync.yaml
+++ b/.github/workflows/ci-ai-catalog-sync.yaml
@@ -17,7 +17,7 @@ jobs:
       NODE_OPTIONS: '--max-old-space-size=4096'
     steps:
       - name: Checkout
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.0
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           ref: main
 

--- a/.github/workflows/ci-ai-catalog-sync.yaml
+++ b/.github/workflows/ci-ai-catalog-sync.yaml
@@ -64,6 +64,4 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.TWENTY_INFRA_TOKEN }}
         run: |
-          gh api repos/twentyhq/twenty-infra/dispatches \
-            --raw-field event_type=automated-pr-ready \
-            --raw-field 'client_payload={}'
+          gh api repos/twentyhq/twenty-infra/dispatches -f event_type=automated-pr-ready

--- a/.github/workflows/ci-breaking-changes.yaml
+++ b/.github/workflows/ci-breaking-changes.yaml
@@ -66,7 +66,7 @@ jobs:
 
     steps:
       - name: Checkout current branch
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.0
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           fetch-depth: 10
 

--- a/.github/workflows/ci-breaking-changes.yaml
+++ b/.github/workflows/ci-breaking-changes.yaml
@@ -66,7 +66,7 @@ jobs:
 
     steps:
       - name: Checkout current branch
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.0
         with:
           fetch-depth: 10
 
@@ -634,7 +634,7 @@ jobs:
 
       - name: Upload breaking changes report
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: breaking-changes-report
           path: |

--- a/.github/workflows/ci-create-app-e2e-hello-world.yaml
+++ b/.github/workflows/ci-create-app-e2e-hello-world.yaml
@@ -57,7 +57,7 @@ jobs:
       TWENTY_API_KEY: eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIyMDIwMjAyMC1lNmI1LTQ2ODAtOGEzMi1iODIwOTczNzE1NmIiLCJ1c2VySWQiOiIyMDIwMjAyMC1lNmI1LTQ2ODAtOGEzMi1iODIwOTczNzE1NmIiLCJ3b3Jrc3BhY2VJZCI6IjIwMjAyMDIwLTFjMjUtNGQwMi1iZjI1LTZhZWNjZjdlYTQxOSIsIndvcmtzcGFjZU1lbWJlcklkIjoiMjAyMDIwMjAtNDYzZi00MzViLTgyOGMtMTA3ZTAwN2EyNzExIiwidXNlcldvcmtzcGFjZUlkIjoiMjAyMDIwMjAtMWU3Yy00M2Q5LWE1ZGItNjg1YjUwNjlkODE2IiwidHlwZSI6IkFDQ0VTUyIsImF1dGhQcm92aWRlciI6InBhc3N3b3JkIiwiaWF0IjoxNzUxMjgxNzA0LCJleHAiOjIwNjY4NTc3MDR9.HMGqCsVlOAPVUBhKSGlD1X86VoHKt4LIUtET3CGIdik
     steps:
       - name: Fetch custom Github Actions and base branch history
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.0
         with:
           fetch-depth: 10
 

--- a/.github/workflows/ci-create-app-e2e-hello-world.yaml
+++ b/.github/workflows/ci-create-app-e2e-hello-world.yaml
@@ -57,7 +57,7 @@ jobs:
       TWENTY_API_KEY: eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIyMDIwMjAyMC1lNmI1LTQ2ODAtOGEzMi1iODIwOTczNzE1NmIiLCJ1c2VySWQiOiIyMDIwMjAyMC1lNmI1LTQ2ODAtOGEzMi1iODIwOTczNzE1NmIiLCJ3b3Jrc3BhY2VJZCI6IjIwMjAyMDIwLTFjMjUtNGQwMi1iZjI1LTZhZWNjZjdlYTQxOSIsIndvcmtzcGFjZU1lbWJlcklkIjoiMjAyMDIwMjAtNDYzZi00MzViLTgyOGMtMTA3ZTAwN2EyNzExIiwidXNlcldvcmtzcGFjZUlkIjoiMjAyMDIwMjAtMWU3Yy00M2Q5LWE1ZGItNjg1YjUwNjlkODE2IiwidHlwZSI6IkFDQ0VTUyIsImF1dGhQcm92aWRlciI6InBhc3N3b3JkIiwiaWF0IjoxNzUxMjgxNzA0LCJleHAiOjIwNjY4NTc3MDR9.HMGqCsVlOAPVUBhKSGlD1X86VoHKt4LIUtET3CGIdik
     steps:
       - name: Fetch custom Github Actions and base branch history
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.0
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           fetch-depth: 10
 

--- a/.github/workflows/ci-create-app-e2e-minimal.yaml
+++ b/.github/workflows/ci-create-app-e2e-minimal.yaml
@@ -55,7 +55,7 @@ jobs:
       TWENTY_API_KEY: eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIyMDIwMjAyMC1lNmI1LTQ2ODAtOGEzMi1iODIwOTczNzE1NmIiLCJ1c2VySWQiOiIyMDIwMjAyMC1lNmI1LTQ2ODAtOGEzMi1iODIwOTczNzE1NmIiLCJ3b3Jrc3BhY2VJZCI6IjIwMjAyMDIwLTFjMjUtNGQwMi1iZjI1LTZhZWNjZjdlYTQxOSIsIndvcmtzcGFjZU1lbWJlcklkIjoiMjAyMDIwMjAtNDYzZi00MzViLTgyOGMtMTA3ZTAwN2EyNzExIiwidXNlcldvcmtzcGFjZUlkIjoiMjAyMDIwMjAtMWU3Yy00M2Q5LWE1ZGItNjg1YjUwNjlkODE2IiwidHlwZSI6IkFDQ0VTUyIsImF1dGhQcm92aWRlciI6InBhc3N3b3JkIiwiaWF0IjoxNzUxMjgxNzA0LCJleHAiOjIwNjY4NTc3MDR9.HMGqCsVlOAPVUBhKSGlD1X86VoHKt4LIUtET3CGIdik
     steps:
       - name: Fetch custom Github Actions and base branch history
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.0
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           fetch-depth: 10
 

--- a/.github/workflows/ci-create-app-e2e-minimal.yaml
+++ b/.github/workflows/ci-create-app-e2e-minimal.yaml
@@ -55,7 +55,7 @@ jobs:
       TWENTY_API_KEY: eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIyMDIwMjAyMC1lNmI1LTQ2ODAtOGEzMi1iODIwOTczNzE1NmIiLCJ1c2VySWQiOiIyMDIwMjAyMC1lNmI1LTQ2ODAtOGEzMi1iODIwOTczNzE1NmIiLCJ3b3Jrc3BhY2VJZCI6IjIwMjAyMDIwLTFjMjUtNGQwMi1iZjI1LTZhZWNjZjdlYTQxOSIsIndvcmtzcGFjZU1lbWJlcklkIjoiMjAyMDIwMjAtNDYzZi00MzViLTgyOGMtMTA3ZTAwN2EyNzExIiwidXNlcldvcmtzcGFjZUlkIjoiMjAyMDIwMjAtMWU3Yy00M2Q5LWE1ZGItNjg1YjUwNjlkODE2IiwidHlwZSI6IkFDQ0VTUyIsImF1dGhQcm92aWRlciI6InBhc3N3b3JkIiwiaWF0IjoxNzUxMjgxNzA0LCJleHAiOjIwNjY4NTc3MDR9.HMGqCsVlOAPVUBhKSGlD1X86VoHKt4LIUtET3CGIdik
     steps:
       - name: Fetch custom Github Actions and base branch history
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.0
         with:
           fetch-depth: 10
 

--- a/.github/workflows/ci-create-app-e2e-postcard.yaml
+++ b/.github/workflows/ci-create-app-e2e-postcard.yaml
@@ -57,7 +57,7 @@ jobs:
       TWENTY_API_KEY: eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIyMDIwMjAyMC1lNmI1LTQ2ODAtOGEzMi1iODIwOTczNzE1NmIiLCJ1c2VySWQiOiIyMDIwMjAyMC1lNmI1LTQ2ODAtOGEzMi1iODIwOTczNzE1NmIiLCJ3b3Jrc3BhY2VJZCI6IjIwMjAyMDIwLTFjMjUtNGQwMi1iZjI1LTZhZWNjZjdlYTQxOSIsIndvcmtzcGFjZU1lbWJlcklkIjoiMjAyMDIwMjAtNDYzZi00MzViLTgyOGMtMTA3ZTAwN2EyNzExIiwidXNlcldvcmtzcGFjZUlkIjoiMjAyMDIwMjAtMWU3Yy00M2Q5LWE1ZGItNjg1YjUwNjlkODE2IiwidHlwZSI6IkFDQ0VTUyIsImF1dGhQcm92aWRlciI6InBhc3N3b3JkIiwiaWF0IjoxNzUxMjgxNzA0LCJleHAiOjIwNjY4NTc3MDR9.HMGqCsVlOAPVUBhKSGlD1X86VoHKt4LIUtET3CGIdik
     steps:
       - name: Fetch custom Github Actions and base branch history
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.0
         with:
           fetch-depth: 10
 

--- a/.github/workflows/ci-create-app-e2e-postcard.yaml
+++ b/.github/workflows/ci-create-app-e2e-postcard.yaml
@@ -57,7 +57,7 @@ jobs:
       TWENTY_API_KEY: eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIyMDIwMjAyMC1lNmI1LTQ2ODAtOGEzMi1iODIwOTczNzE1NmIiLCJ1c2VySWQiOiIyMDIwMjAyMC1lNmI1LTQ2ODAtOGEzMi1iODIwOTczNzE1NmIiLCJ3b3Jrc3BhY2VJZCI6IjIwMjAyMDIwLTFjMjUtNGQwMi1iZjI1LTZhZWNjZjdlYTQxOSIsIndvcmtzcGFjZU1lbWJlcklkIjoiMjAyMDIwMjAtNDYzZi00MzViLTgyOGMtMTA3ZTAwN2EyNzExIiwidXNlcldvcmtzcGFjZUlkIjoiMjAyMDIwMjAtMWU3Yy00M2Q5LWE1ZGItNjg1YjUwNjlkODE2IiwidHlwZSI6IkFDQ0VTUyIsImF1dGhQcm92aWRlciI6InBhc3N3b3JkIiwiaWF0IjoxNzUxMjgxNzA0LCJleHAiOjIwNjY4NTc3MDR9.HMGqCsVlOAPVUBhKSGlD1X86VoHKt4LIUtET3CGIdik
     steps:
       - name: Fetch custom Github Actions and base branch history
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.0
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           fetch-depth: 10
 

--- a/.github/workflows/ci-create-app.yaml
+++ b/.github/workflows/ci-create-app.yaml
@@ -31,11 +31,11 @@ jobs:
         task: [lint, typecheck, test]
     steps:
       - name: Cancel Previous Runs
-        uses: styfle/cancel-workflow-action@0.11.0
+        uses: styfle/cancel-workflow-action@b173b6ec0100793626c2d9e6b90435061f4fc3e5 # 0.11.0
         with:
           access_token: ${{ github.token }}
       - name: Fetch custom Github Actions and base branch history
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.0
         with:
           fetch-depth: 10
       - name: Install dependencies

--- a/.github/workflows/ci-create-app.yaml
+++ b/.github/workflows/ci-create-app.yaml
@@ -30,10 +30,6 @@ jobs:
       matrix:
         task: [lint, typecheck, test]
     steps:
-      - name: Cancel Previous Runs
-        uses: styfle/cancel-workflow-action@b173b6ec0100793626c2d9e6b90435061f4fc3e5 # 0.11.0
-        with:
-          access_token: ${{ github.token }}
       - name: Fetch custom Github Actions and base branch history
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.0
         with:

--- a/.github/workflows/ci-create-app.yaml
+++ b/.github/workflows/ci-create-app.yaml
@@ -31,7 +31,7 @@ jobs:
         task: [lint, typecheck, test]
     steps:
       - name: Fetch custom Github Actions and base branch history
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.0
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           fetch-depth: 10
       - name: Install dependencies

--- a/.github/workflows/ci-docs.yaml
+++ b/.github/workflows/ci-docs.yaml
@@ -28,11 +28,6 @@ jobs:
     timeout-minutes: 10
     runs-on: ubuntu-latest
     steps:
-      - name: Cancel Previous Runs
-        uses: styfle/cancel-workflow-action@b173b6ec0100793626c2d9e6b90435061f4fc3e5 # 0.11.0
-        with:
-          access_token: ${{ github.token }}
-
       - name: Fetch local actions
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.0
         with:

--- a/.github/workflows/ci-docs.yaml
+++ b/.github/workflows/ci-docs.yaml
@@ -29,12 +29,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Cancel Previous Runs
-        uses: styfle/cancel-workflow-action@0.11.0
+        uses: styfle/cancel-workflow-action@b173b6ec0100793626c2d9e6b90435061f4fc3e5 # 0.11.0
         with:
           access_token: ${{ github.token }}
 
       - name: Fetch local actions
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.0
         with:
           fetch-depth: 10
 

--- a/.github/workflows/ci-docs.yaml
+++ b/.github/workflows/ci-docs.yaml
@@ -29,7 +29,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Fetch local actions
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.0
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           fetch-depth: 10
 

--- a/.github/workflows/ci-emails.yaml
+++ b/.github/workflows/ci-emails.yaml
@@ -28,7 +28,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Fetch custom Github Actions and base branch history
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.0
         with:
           fetch-depth: 10
       - name: Install dependencies

--- a/.github/workflows/ci-emails.yaml
+++ b/.github/workflows/ci-emails.yaml
@@ -28,7 +28,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Fetch custom Github Actions and base branch history
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.0
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           fetch-depth: 10
       - name: Install dependencies

--- a/.github/workflows/ci-example-app-hello-world.yaml
+++ b/.github/workflows/ci-example-app-hello-world.yaml
@@ -54,7 +54,7 @@ jobs:
       TWENTY_API_KEY: eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIyMDIwMjAyMC1lNmI1LTQ2ODAtOGEzMi1iODIwOTczNzE1NmIiLCJ1c2VySWQiOiIyMDIwMjAyMC1lNmI1LTQ2ODAtOGEzMi1iODIwOTczNzE1NmIiLCJ3b3Jrc3BhY2VJZCI6IjIwMjAyMDIwLTFjMjUtNGQwMi1iZjI1LTZhZWNjZjdlYTQxOSIsIndvcmtzcGFjZU1lbWJlcklkIjoiMjAyMDIwMjAtNDYzZi00MzViLTgyOGMtMTA3ZTAwN2EyNzExIiwidXNlcldvcmtzcGFjZUlkIjoiMjAyMDIwMjAtMWU3Yy00M2Q5LWE1ZGItNjg1YjUwNjlkODE2IiwidHlwZSI6IkFDQ0VTUyIsImF1dGhQcm92aWRlciI6InBhc3N3b3JkIiwiaWF0IjoxNzUxMjgxNzA0LCJleHAiOjIwNjY4NTc3MDR9.HMGqCsVlOAPVUBhKSGlD1X86VoHKt4LIUtET3CGIdik
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.0
 
       - name: Install dependencies
         uses: ./.github/actions/yarn-install

--- a/.github/workflows/ci-example-app-hello-world.yaml
+++ b/.github/workflows/ci-example-app-hello-world.yaml
@@ -54,7 +54,7 @@ jobs:
       TWENTY_API_KEY: eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIyMDIwMjAyMC1lNmI1LTQ2ODAtOGEzMi1iODIwOTczNzE1NmIiLCJ1c2VySWQiOiIyMDIwMjAyMC1lNmI1LTQ2ODAtOGEzMi1iODIwOTczNzE1NmIiLCJ3b3Jrc3BhY2VJZCI6IjIwMjAyMDIwLTFjMjUtNGQwMi1iZjI1LTZhZWNjZjdlYTQxOSIsIndvcmtzcGFjZU1lbWJlcklkIjoiMjAyMDIwMjAtNDYzZi00MzViLTgyOGMtMTA3ZTAwN2EyNzExIiwidXNlcldvcmtzcGFjZUlkIjoiMjAyMDIwMjAtMWU3Yy00M2Q5LWE1ZGItNjg1YjUwNjlkODE2IiwidHlwZSI6IkFDQ0VTUyIsImF1dGhQcm92aWRlciI6InBhc3N3b3JkIiwiaWF0IjoxNzUxMjgxNzA0LCJleHAiOjIwNjY4NTc3MDR9.HMGqCsVlOAPVUBhKSGlD1X86VoHKt4LIUtET3CGIdik
     steps:
       - name: Checkout
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.0
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
       - name: Install dependencies
         uses: ./.github/actions/yarn-install

--- a/.github/workflows/ci-example-app-postcard.yaml
+++ b/.github/workflows/ci-example-app-postcard.yaml
@@ -54,7 +54,7 @@ jobs:
       TWENTY_API_KEY: eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIyMDIwMjAyMC1lNmI1LTQ2ODAtOGEzMi1iODIwOTczNzE1NmIiLCJ1c2VySWQiOiIyMDIwMjAyMC1lNmI1LTQ2ODAtOGEzMi1iODIwOTczNzE1NmIiLCJ3b3Jrc3BhY2VJZCI6IjIwMjAyMDIwLTFjMjUtNGQwMi1iZjI1LTZhZWNjZjdlYTQxOSIsIndvcmtzcGFjZU1lbWJlcklkIjoiMjAyMDIwMjAtNDYzZi00MzViLTgyOGMtMTA3ZTAwN2EyNzExIiwidXNlcldvcmtzcGFjZUlkIjoiMjAyMDIwMjAtMWU3Yy00M2Q5LWE1ZGItNjg1YjUwNjlkODE2IiwidHlwZSI6IkFDQ0VTUyIsImF1dGhQcm92aWRlciI6InBhc3N3b3JkIiwiaWF0IjoxNzUxMjgxNzA0LCJleHAiOjIwNjY4NTc3MDR9.HMGqCsVlOAPVUBhKSGlD1X86VoHKt4LIUtET3CGIdik
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.0
 
       - name: Install dependencies
         uses: ./.github/actions/yarn-install

--- a/.github/workflows/ci-example-app-postcard.yaml
+++ b/.github/workflows/ci-example-app-postcard.yaml
@@ -54,7 +54,7 @@ jobs:
       TWENTY_API_KEY: eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIyMDIwMjAyMC1lNmI1LTQ2ODAtOGEzMi1iODIwOTczNzE1NmIiLCJ1c2VySWQiOiIyMDIwMjAyMC1lNmI1LTQ2ODAtOGEzMi1iODIwOTczNzE1NmIiLCJ3b3Jrc3BhY2VJZCI6IjIwMjAyMDIwLTFjMjUtNGQwMi1iZjI1LTZhZWNjZjdlYTQxOSIsIndvcmtzcGFjZU1lbWJlcklkIjoiMjAyMDIwMjAtNDYzZi00MzViLTgyOGMtMTA3ZTAwN2EyNzExIiwidXNlcldvcmtzcGFjZUlkIjoiMjAyMDIwMjAtMWU3Yy00M2Q5LWE1ZGItNjg1YjUwNjlkODE2IiwidHlwZSI6IkFDQ0VTUyIsImF1dGhQcm92aWRlciI6InBhc3N3b3JkIiwiaWF0IjoxNzUxMjgxNzA0LCJleHAiOjIwNjY4NTc3MDR9.HMGqCsVlOAPVUBhKSGlD1X86VoHKt4LIUtET3CGIdik
     steps:
       - name: Checkout
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.0
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
       - name: Install dependencies
         uses: ./.github/actions/yarn-install

--- a/.github/workflows/ci-front-component-renderer.yaml
+++ b/.github/workflows/ci-front-component-renderer.yaml
@@ -33,7 +33,7 @@ jobs:
         task: [build, typecheck, lint]
     steps:
       - name: Fetch custom Github Actions and base branch history
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.0
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           fetch-depth: 10
       - name: Install dependencies
@@ -47,7 +47,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Fetch custom Github Actions and base branch history
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.0
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           fetch-depth: 10
       - name: Install dependencies
@@ -68,7 +68,7 @@ jobs:
       STORYBOOK_URL: http://localhost:6008
     steps:
       - name: Fetch custom Github Actions and base branch history
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.0
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           fetch-depth: 10
       - name: Install dependencies

--- a/.github/workflows/ci-front-component-renderer.yaml
+++ b/.github/workflows/ci-front-component-renderer.yaml
@@ -33,11 +33,11 @@ jobs:
         task: [build, typecheck, lint]
     steps:
       - name: Cancel Previous Runs
-        uses: styfle/cancel-workflow-action@0.11.0
+        uses: styfle/cancel-workflow-action@b173b6ec0100793626c2d9e6b90435061f4fc3e5 # 0.11.0
         with:
           access_token: ${{ github.token }}
       - name: Fetch custom Github Actions and base branch history
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.0
         with:
           fetch-depth: 10
       - name: Install dependencies
@@ -51,11 +51,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Cancel Previous Runs
-        uses: styfle/cancel-workflow-action@0.11.0
+        uses: styfle/cancel-workflow-action@b173b6ec0100793626c2d9e6b90435061f4fc3e5 # 0.11.0
         with:
           access_token: ${{ github.token }}
       - name: Fetch custom Github Actions and base branch history
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.0
         with:
           fetch-depth: 10
       - name: Install dependencies
@@ -63,7 +63,7 @@ jobs:
       - name: Build storybook
         run: npx nx storybook:build twenty-front-component-renderer
       - name: Upload storybook build
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: storybook-twenty-front-component-renderer
           path: packages/twenty-front-component-renderer/storybook-static
@@ -76,7 +76,7 @@ jobs:
       STORYBOOK_URL: http://localhost:6008
     steps:
       - name: Fetch custom Github Actions and base branch history
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.0
         with:
           fetch-depth: 10
       - name: Install dependencies
@@ -84,7 +84,7 @@ jobs:
       - name: Build dependencies
         run: npx nx build twenty-sdk
       - name: Download storybook build
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
           name: storybook-twenty-front-component-renderer
           path: packages/twenty-front-component-renderer/storybook-static

--- a/.github/workflows/ci-front-component-renderer.yaml
+++ b/.github/workflows/ci-front-component-renderer.yaml
@@ -32,10 +32,6 @@ jobs:
       matrix:
         task: [build, typecheck, lint]
     steps:
-      - name: Cancel Previous Runs
-        uses: styfle/cancel-workflow-action@b173b6ec0100793626c2d9e6b90435061f4fc3e5 # 0.11.0
-        with:
-          access_token: ${{ github.token }}
       - name: Fetch custom Github Actions and base branch history
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.0
         with:
@@ -50,10 +46,6 @@ jobs:
     timeout-minutes: 30
     runs-on: ubuntu-latest
     steps:
-      - name: Cancel Previous Runs
-        uses: styfle/cancel-workflow-action@b173b6ec0100793626c2d9e6b90435061f4fc3e5 # 0.11.0
-        with:
-          access_token: ${{ github.token }}
       - name: Fetch custom Github Actions and base branch history
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.0
         with:

--- a/.github/workflows/ci-front.yaml
+++ b/.github/workflows/ci-front.yaml
@@ -38,10 +38,6 @@ jobs:
     env:
       REACT_APP_SERVER_BASE_URL: http://localhost:3000
     steps:
-      - name: Cancel Previous Runs
-        uses: styfle/cancel-workflow-action@b173b6ec0100793626c2d9e6b90435061f4fc3e5 # 0.11.0
-        with:
-          access_token: ${{ github.token }}
       - name: Fetch local actions
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.0
         with:
@@ -164,10 +160,6 @@ jobs:
       matrix:
         task: [lint, typecheck, test]
     steps:
-      - name: Cancel Previous Runs
-        uses: styfle/cancel-workflow-action@b173b6ec0100793626c2d9e6b90435061f4fc3e5 # 0.11.0
-        with:
-          access_token: ${{ github.token }}
       - name: Fetch custom Github Actions and base branch history
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.0
         with:
@@ -203,10 +195,6 @@ jobs:
       NODE_OPTIONS: "--max-old-space-size=10240"
       ANALYZE: "true"
     steps:
-      - name: Cancel Previous Runs
-        uses: styfle/cancel-workflow-action@b173b6ec0100793626c2d9e6b90435061f4fc3e5 # 0.11.0
-        with:
-          access_token: ${{ github.token }}
       - name: Fetch custom Github Actions and base branch history
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.0
         with:

--- a/.github/workflows/ci-front.yaml
+++ b/.github/workflows/ci-front.yaml
@@ -39,11 +39,11 @@ jobs:
       REACT_APP_SERVER_BASE_URL: http://localhost:3000
     steps:
       - name: Cancel Previous Runs
-        uses: styfle/cancel-workflow-action@0.11.0
+        uses: styfle/cancel-workflow-action@b173b6ec0100793626c2d9e6b90435061f4fc3e5 # 0.11.0
         with:
           access_token: ${{ github.token }}
       - name: Fetch local actions
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.0
         with:
           fetch-depth: 10
       - name: Install dependencies
@@ -55,7 +55,7 @@ jobs:
       - name: Front / Build storybook
         run: npx nx storybook:build twenty-front
       - name: Upload storybook build
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: storybook-static
           path: packages/twenty-front/storybook-static
@@ -79,7 +79,7 @@ jobs:
       STORYBOOK_URL: http://localhost:6006
     steps:
       - name: Fetch local actions
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.0
         with:
           fetch-depth: 10
       - name: Install dependencies
@@ -96,7 +96,7 @@ jobs:
           npx nx build twenty-ui
           npx nx build twenty-front-component-renderer
       - name: Download storybook build
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
           name: storybook-static
           path: packages/twenty-front/storybook-static
@@ -121,7 +121,7 @@ jobs:
       #       exit 1
       #     fi
       # - name: Upload coverage artifact
-      #   uses: actions/upload-artifact@v4
+      #   uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
       #   with:
       #     retention-days: 1
       #     name: coverage-artifacts-${{ matrix.storybook_scope }}-${{ github.run_id }}-${{ matrix.shard }}
@@ -136,12 +136,12 @@ jobs:
   #     matrix:
   #       storybook_scope: [modules, pages, performance]
   #   steps:
-  #     - uses: actions/checkout@v4
+  #     - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.0
   #       with:
   #         fetch-depth: 10
   #     - name: Install dependencies
   #       uses: ./.github/actions/yarn-install
-  #     - uses: actions/download-artifact@v4
+  #     - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
   #       with:
   #         pattern: coverage-artifacts-${{ matrix.storybook_scope }}-${{ github.run_id }}-*
   #         merge-multiple: true
@@ -165,11 +165,11 @@ jobs:
         task: [lint, typecheck, test]
     steps:
       - name: Cancel Previous Runs
-        uses: styfle/cancel-workflow-action@0.11.0
+        uses: styfle/cancel-workflow-action@b173b6ec0100793626c2d9e6b90435061f4fc3e5 # 0.11.0
         with:
           access_token: ${{ github.token }}
       - name: Fetch custom Github Actions and base branch history
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.0
         with:
           fetch-depth: 10
       - name: Install dependencies
@@ -204,11 +204,11 @@ jobs:
       ANALYZE: "true"
     steps:
       - name: Cancel Previous Runs
-        uses: styfle/cancel-workflow-action@0.11.0
+        uses: styfle/cancel-workflow-action@b173b6ec0100793626c2d9e6b90435061f4fc3e5 # 0.11.0
         with:
           access_token: ${{ github.token }}
       - name: Fetch custom Github Actions and base branch history
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.0
         with:
           fetch-depth: 10
       - name: Install dependencies
@@ -218,7 +218,7 @@ jobs:
       - name: Build frontend
         run: npx nx build twenty-front
       # - name: Upload frontend build artifact
-      #   uses: actions/upload-artifact@v4
+      #   uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
       #   with:
       #     name: frontend-build
       #     path: packages/twenty-front/build

--- a/.github/workflows/ci-front.yaml
+++ b/.github/workflows/ci-front.yaml
@@ -39,7 +39,7 @@ jobs:
       REACT_APP_SERVER_BASE_URL: http://localhost:3000
     steps:
       - name: Fetch local actions
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.0
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           fetch-depth: 10
       - name: Install dependencies
@@ -75,7 +75,7 @@ jobs:
       STORYBOOK_URL: http://localhost:6006
     steps:
       - name: Fetch local actions
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.0
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           fetch-depth: 10
       - name: Install dependencies
@@ -132,7 +132,7 @@ jobs:
   #     matrix:
   #       storybook_scope: [modules, pages, performance]
   #   steps:
-  #     - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.0
+  #     - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
   #       with:
   #         fetch-depth: 10
   #     - name: Install dependencies
@@ -161,7 +161,7 @@ jobs:
         task: [lint, typecheck, test]
     steps:
       - name: Fetch custom Github Actions and base branch history
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.0
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           fetch-depth: 10
       - name: Install dependencies
@@ -196,7 +196,7 @@ jobs:
       ANALYZE: "true"
     steps:
       - name: Fetch custom Github Actions and base branch history
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.0
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           fetch-depth: 10
       - name: Install dependencies

--- a/.github/workflows/ci-merge-queue.yaml
+++ b/.github/workflows/ci-merge-queue.yaml
@@ -41,7 +41,7 @@ jobs:
         ports:
           - 6379:6379
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.0
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           fetch-depth: 10
 
@@ -53,7 +53,7 @@ jobs:
         uses: ./.github/actions/yarn-install
 
       - name: Restore Nx build cache
-        uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.2.0 (restore)
+        uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0 (restore)
         with:
           key: v4-e2e-build-${{ github.ref_name }}-${{ github.sha }}
           restore-keys: |
@@ -83,7 +83,7 @@ jobs:
 
       - name: Save Nx build cache
         if: always()
-        uses: actions/cache/save@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.2.0 (save)
+        uses: actions/cache/save@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0 (save)
         with:
           key: v4-e2e-build-${{ github.ref_name }}-${{ github.sha }}
           path: |

--- a/.github/workflows/ci-merge-queue.yaml
+++ b/.github/workflows/ci-merge-queue.yaml
@@ -41,11 +41,11 @@ jobs:
         ports:
           - 6379:6379
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.0
         with:
           fetch-depth: 10
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: lts/*
 
@@ -53,7 +53,7 @@ jobs:
         uses: ./.github/actions/yarn-install
 
       - name: Restore Nx build cache
-        uses: actions/cache/restore@v4
+        uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.2.0 (restore)
         with:
           key: v4-e2e-build-${{ github.ref_name }}-${{ github.sha }}
           restore-keys: |
@@ -83,7 +83,7 @@ jobs:
 
       - name: Save Nx build cache
         if: always()
-        uses: actions/cache/save@v4
+        uses: actions/cache/save@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.2.0 (save)
         with:
           key: v4-e2e-build-${{ github.ref_name }}-${{ github.sha }}
           path: |
@@ -119,7 +119,7 @@ jobs:
 
       - name: Upload Playwright results
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: playwright-results
           path: |

--- a/.github/workflows/ci-release-create.yaml
+++ b/.github/workflows/ci-release-create.yaml
@@ -28,7 +28,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.0
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           ref: ${{ github.event.inputs.ref }}
 

--- a/.github/workflows/ci-release-create.yaml
+++ b/.github/workflows/ci-release-create.yaml
@@ -28,7 +28,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.0
         with:
           ref: ${{ github.event.inputs.ref }}
 
@@ -47,7 +47,7 @@ jobs:
           printf '%s\n' "$VERSION" > version.txt
 
       - name: Create Pull Request
-        uses: peter-evans/create-pull-request@v6
+        uses: peter-evans/create-pull-request@c5a7806660adbe173f04e3e038b0ccdcd758773c # v6.1.0
         with:
           branch: release/${{ steps.sanitize.outputs.version }}
           commit-message: "chore: release v${{ steps.sanitize.outputs.version }}"

--- a/.github/workflows/ci-release-merge.yaml
+++ b/.github/workflows/ci-release-merge.yaml
@@ -30,7 +30,7 @@ jobs:
           fi
 
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.0
         with:
           ref: main
 
@@ -55,7 +55,7 @@ jobs:
           git tag "v${{ env.VERSION }}"
           git push origin "v${{ env.VERSION }}"
 
-      - uses: release-drafter/release-drafter@v5
+      - uses: release-drafter/release-drafter@09c613e259eb8d4e7c81c2cb00618eb5fc4575a7 # v5
         if: contains(github.event.pull_request.labels.*.name, 'create_release')
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/ci-release-merge.yaml
+++ b/.github/workflows/ci-release-merge.yaml
@@ -30,7 +30,7 @@ jobs:
           fi
 
       - name: Checkout
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.0
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           ref: main
 

--- a/.github/workflows/ci-sdk.yaml
+++ b/.github/workflows/ci-sdk.yaml
@@ -31,7 +31,7 @@ jobs:
         task: [lint, typecheck, test:unit, test:integration]
     steps:
       - name: Fetch custom Github Actions and base branch history
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.0
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           fetch-depth: 10
       - name: Install dependencies
@@ -70,7 +70,7 @@ jobs:
       TWENTY_API_KEY: eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIyMDIwMjAyMC1lNmI1LTQ2ODAtOGEzMi1iODIwOTczNzE1NmIiLCJ1c2VySWQiOiIyMDIwMjAyMC1lNmI1LTQ2ODAtOGEzMi1iODIwOTczNzE1NmIiLCJ3b3Jrc3BhY2VJZCI6IjIwMjAyMDIwLTFjMjUtNGQwMi1iZjI1LTZhZWNjZjdlYTQxOSIsIndvcmtzcGFjZU1lbWJlcklkIjoiMjAyMDIwMjAtNDYzZi00MzViLTgyOGMtMTA3ZTAwN2EyNzExIiwidXNlcldvcmtzcGFjZUlkIjoiMjAyMDIwMjAtMWU3Yy00M2Q5LWE1ZGItNjg1YjUwNjlkODE2IiwidHlwZSI6IkFDQ0VTUyIsImF1dGhQcm92aWRlciI6InBhc3N3b3JkIiwiaWF0IjoxNzUxMjgxNzA0LCJleHAiOjIwNjY4NTc3MDR9.HMGqCsVlOAPVUBhKSGlD1X86VoHKt4LIUtET3CGIdik
     steps:
       - name: Fetch custom Github Actions and base branch history
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.0
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           fetch-depth: 10
       - name: Install dependencies

--- a/.github/workflows/ci-sdk.yaml
+++ b/.github/workflows/ci-sdk.yaml
@@ -31,11 +31,11 @@ jobs:
         task: [lint, typecheck, test:unit, test:integration]
     steps:
       - name: Cancel Previous Runs
-        uses: styfle/cancel-workflow-action@0.11.0
+        uses: styfle/cancel-workflow-action@b173b6ec0100793626c2d9e6b90435061f4fc3e5 # 0.11.0
         with:
           access_token: ${{ github.token }}
       - name: Fetch custom Github Actions and base branch history
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.0
         with:
           fetch-depth: 10
       - name: Install dependencies
@@ -74,7 +74,7 @@ jobs:
       TWENTY_API_KEY: eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIyMDIwMjAyMC1lNmI1LTQ2ODAtOGEzMi1iODIwOTczNzE1NmIiLCJ1c2VySWQiOiIyMDIwMjAyMC1lNmI1LTQ2ODAtOGEzMi1iODIwOTczNzE1NmIiLCJ3b3Jrc3BhY2VJZCI6IjIwMjAyMDIwLTFjMjUtNGQwMi1iZjI1LTZhZWNjZjdlYTQxOSIsIndvcmtzcGFjZU1lbWJlcklkIjoiMjAyMDIwMjAtNDYzZi00MzViLTgyOGMtMTA3ZTAwN2EyNzExIiwidXNlcldvcmtzcGFjZUlkIjoiMjAyMDIwMjAtMWU3Yy00M2Q5LWE1ZGItNjg1YjUwNjlkODE2IiwidHlwZSI6IkFDQ0VTUyIsImF1dGhQcm92aWRlciI6InBhc3N3b3JkIiwiaWF0IjoxNzUxMjgxNzA0LCJleHAiOjIwNjY4NTc3MDR9.HMGqCsVlOAPVUBhKSGlD1X86VoHKt4LIUtET3CGIdik
     steps:
       - name: Fetch custom Github Actions and base branch history
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.0
         with:
           fetch-depth: 10
       - name: Install dependencies

--- a/.github/workflows/ci-sdk.yaml
+++ b/.github/workflows/ci-sdk.yaml
@@ -30,10 +30,6 @@ jobs:
       matrix:
         task: [lint, typecheck, test:unit, test:integration]
     steps:
-      - name: Cancel Previous Runs
-        uses: styfle/cancel-workflow-action@b173b6ec0100793626c2d9e6b90435061f4fc3e5 # 0.11.0
-        with:
-          access_token: ${{ github.token }}
       - name: Fetch custom Github Actions and base branch history
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.0
         with:

--- a/.github/workflows/ci-server.yaml
+++ b/.github/workflows/ci-server.yaml
@@ -37,7 +37,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Fetch custom Github Actions and base branch history
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.0
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           fetch-depth: 10
       - name: Install dependencies
@@ -65,7 +65,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Fetch custom Github Actions and base branch history
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.0
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           fetch-depth: 10
       - name: Install dependencies
@@ -83,7 +83,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Fetch custom Github Actions and base branch history
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.0
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           fetch-depth: 10
       - name: Get changed upgrade-version-command files
@@ -178,7 +178,7 @@ jobs:
           - 6379:6379
     steps:
       - name: Fetch custom Github Actions and base branch history
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.0
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           fetch-depth: 10
       - name: Install dependencies
@@ -278,7 +278,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Fetch custom Github Actions and base branch history
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.0
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           fetch-depth: 10
       - name: Install dependencies
@@ -341,7 +341,7 @@ jobs:
       SHARD_COUNTER: 10
     steps:
       - name: Fetch custom Github Actions and base branch history
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.0
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           fetch-depth: 10
       - name: Install dependencies

--- a/.github/workflows/ci-server.yaml
+++ b/.github/workflows/ci-server.yaml
@@ -37,7 +37,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Fetch custom Github Actions and base branch history
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.0
         with:
           fetch-depth: 10
       - name: Install dependencies
@@ -65,7 +65,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Fetch custom Github Actions and base branch history
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.0
         with:
           fetch-depth: 10
       - name: Install dependencies
@@ -83,12 +83,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Fetch custom Github Actions and base branch history
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.0
         with:
           fetch-depth: 10
       - name: Get changed upgrade-version-command files
         id: changed-files
-        uses: tj-actions/changed-files@v45
+        uses: tj-actions/changed-files@48d8f15b2aaa3d255ca5af3eba4870f807ce6b3c # v45.0.9
         with:
           files: |
             packages/twenty-server/src/database/commands/upgrade-version-command/**
@@ -178,7 +178,7 @@ jobs:
           - 6379:6379
     steps:
       - name: Fetch custom Github Actions and base branch history
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.0
         with:
           fetch-depth: 10
       - name: Install dependencies
@@ -278,7 +278,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Fetch custom Github Actions and base branch history
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.0
         with:
           fetch-depth: 10
       - name: Install dependencies
@@ -341,7 +341,7 @@ jobs:
       SHARD_COUNTER: 10
     steps:
       - name: Fetch custom Github Actions and base branch history
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.0
         with:
           fetch-depth: 10
       - name: Install dependencies

--- a/.github/workflows/ci-shared.yaml
+++ b/.github/workflows/ci-shared.yaml
@@ -30,11 +30,11 @@ jobs:
         task: [lint, typecheck, test]
     steps:
       - name: Cancel Previous Runs
-        uses: styfle/cancel-workflow-action@0.11.0
+        uses: styfle/cancel-workflow-action@b173b6ec0100793626c2d9e6b90435061f4fc3e5 # 0.11.0
         with:
           access_token: ${{ github.token }}
       - name: Fetch custom Github Actions and base branch history
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.0
         with:
           fetch-depth: 10
       - name: Install dependencies

--- a/.github/workflows/ci-shared.yaml
+++ b/.github/workflows/ci-shared.yaml
@@ -30,7 +30,7 @@ jobs:
         task: [lint, typecheck, test]
     steps:
       - name: Fetch custom Github Actions and base branch history
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.0
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           fetch-depth: 10
       - name: Install dependencies

--- a/.github/workflows/ci-shared.yaml
+++ b/.github/workflows/ci-shared.yaml
@@ -29,10 +29,6 @@ jobs:
       matrix:
         task: [lint, typecheck, test]
     steps:
-      - name: Cancel Previous Runs
-        uses: styfle/cancel-workflow-action@b173b6ec0100793626c2d9e6b90435061f4fc3e5 # 0.11.0
-        with:
-          access_token: ${{ github.token }}
       - name: Fetch custom Github Actions and base branch history
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.0
         with:

--- a/.github/workflows/ci-test-docker-compose.yaml
+++ b/.github/workflows/ci-test-docker-compose.yaml
@@ -26,9 +26,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.0
       - name: Login to Docker Hub
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3.4.0
         with:
           username: ${{ vars.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_PASSWORD }}
@@ -101,9 +101,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.0
       - name: Login to Docker Hub
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3.4.0
         with:
           username: ${{ vars.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_PASSWORD }}

--- a/.github/workflows/ci-test-docker-compose.yaml
+++ b/.github/workflows/ci-test-docker-compose.yaml
@@ -26,9 +26,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.0
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
       - name: Login to Docker Hub
-        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3.4.0
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3.7.0
         with:
           username: ${{ vars.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_PASSWORD }}
@@ -101,9 +101,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.0
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
       - name: Login to Docker Hub
-        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3.4.0
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3.7.0
         with:
           username: ${{ vars.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_PASSWORD }}

--- a/.github/workflows/ci-ui.yaml
+++ b/.github/workflows/ci-ui.yaml
@@ -31,11 +31,11 @@ jobs:
         task: [lint, typecheck, test]
     steps:
       - name: Cancel Previous Runs
-        uses: styfle/cancel-workflow-action@0.11.0
+        uses: styfle/cancel-workflow-action@b173b6ec0100793626c2d9e6b90435061f4fc3e5 # 0.11.0
         with:
           access_token: ${{ github.token }}
       - name: Fetch custom Github Actions and base branch history
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.0
         with:
           fetch-depth: 10
       - name: Install dependencies
@@ -49,11 +49,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Cancel Previous Runs
-        uses: styfle/cancel-workflow-action@0.11.0
+        uses: styfle/cancel-workflow-action@b173b6ec0100793626c2d9e6b90435061f4fc3e5 # 0.11.0
         with:
           access_token: ${{ github.token }}
       - name: Fetch custom Github Actions and base branch history
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.0
         with:
           fetch-depth: 10
       - name: Install dependencies
@@ -61,7 +61,7 @@ jobs:
       - name: Build storybook
         run: npx nx storybook:build twenty-ui
       - name: Upload storybook build
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: storybook-twenty-ui
           path: packages/twenty-ui/storybook-static
@@ -74,7 +74,7 @@ jobs:
       STORYBOOK_URL: http://localhost:6007
     steps:
       - name: Fetch custom Github Actions and base branch history
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.0
         with:
           fetch-depth: 10
       - name: Install dependencies
@@ -82,7 +82,7 @@ jobs:
       - name: Build dependencies
         run: npx nx build twenty-shared
       - name: Download storybook build
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
           name: storybook-twenty-ui
           path: packages/twenty-ui/storybook-static

--- a/.github/workflows/ci-ui.yaml
+++ b/.github/workflows/ci-ui.yaml
@@ -30,10 +30,6 @@ jobs:
       matrix:
         task: [lint, typecheck, test]
     steps:
-      - name: Cancel Previous Runs
-        uses: styfle/cancel-workflow-action@b173b6ec0100793626c2d9e6b90435061f4fc3e5 # 0.11.0
-        with:
-          access_token: ${{ github.token }}
       - name: Fetch custom Github Actions and base branch history
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.0
         with:
@@ -48,10 +44,6 @@ jobs:
     timeout-minutes: 30
     runs-on: ubuntu-latest
     steps:
-      - name: Cancel Previous Runs
-        uses: styfle/cancel-workflow-action@b173b6ec0100793626c2d9e6b90435061f4fc3e5 # 0.11.0
-        with:
-          access_token: ${{ github.token }}
       - name: Fetch custom Github Actions and base branch history
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.0
         with:

--- a/.github/workflows/ci-ui.yaml
+++ b/.github/workflows/ci-ui.yaml
@@ -31,7 +31,7 @@ jobs:
         task: [lint, typecheck, test]
     steps:
       - name: Fetch custom Github Actions and base branch history
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.0
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           fetch-depth: 10
       - name: Install dependencies
@@ -45,7 +45,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Fetch custom Github Actions and base branch history
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.0
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           fetch-depth: 10
       - name: Install dependencies
@@ -66,7 +66,7 @@ jobs:
       STORYBOOK_URL: http://localhost:6007
     steps:
       - name: Fetch custom Github Actions and base branch history
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.0
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           fetch-depth: 10
       - name: Install dependencies

--- a/.github/workflows/ci-utils.yaml
+++ b/.github/workflows/ci-utils.yaml
@@ -25,7 +25,7 @@ jobs:
     runs-on: ubuntu-latest
     if: github.event.action != 'closed'
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.0
       - name: Install dependencies
         uses: ./.github/actions/yarn-install
       - name: Utils / Run Danger.js
@@ -38,7 +38,7 @@ jobs:
     runs-on: ubuntu-latest
     if: github.event.action == 'closed' && github.event.pull_request.merged == true
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.0
       - name: Install dependencies
         uses: ./.github/actions/yarn-install
       - name: Run congratulate-dangerfile.js

--- a/.github/workflows/ci-utils.yaml
+++ b/.github/workflows/ci-utils.yaml
@@ -25,7 +25,7 @@ jobs:
     runs-on: ubuntu-latest
     if: github.event.action != 'closed'
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.0
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
       - name: Install dependencies
         uses: ./.github/actions/yarn-install
       - name: Utils / Run Danger.js
@@ -38,7 +38,7 @@ jobs:
     runs-on: ubuntu-latest
     if: github.event.action == 'closed' && github.event.pull_request.merged == true
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.0
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
       - name: Install dependencies
         uses: ./.github/actions/yarn-install
       - name: Run congratulate-dangerfile.js

--- a/.github/workflows/ci-website.yaml
+++ b/.github/workflows/ci-website.yaml
@@ -33,7 +33,7 @@ jobs:
         task: [lint, typecheck, test]
     steps:
       - name: Fetch custom Github Actions and base branch history
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.0
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           fetch-depth: 10
       - name: Install dependencies

--- a/.github/workflows/ci-website.yaml
+++ b/.github/workflows/ci-website.yaml
@@ -32,10 +32,6 @@ jobs:
       matrix:
         task: [lint, typecheck, test]
     steps:
-      - name: Cancel Previous Runs
-        uses: styfle/cancel-workflow-action@b173b6ec0100793626c2d9e6b90435061f4fc3e5 # 0.11.0
-        with:
-          access_token: ${{ github.token }}
       - name: Fetch custom Github Actions and base branch history
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.0
         with:

--- a/.github/workflows/ci-website.yaml
+++ b/.github/workflows/ci-website.yaml
@@ -33,11 +33,11 @@ jobs:
         task: [lint, typecheck, test]
     steps:
       - name: Cancel Previous Runs
-        uses: styfle/cancel-workflow-action@0.11.0
+        uses: styfle/cancel-workflow-action@b173b6ec0100793626c2d9e6b90435061f4fc3e5 # 0.11.0
         with:
           access_token: ${{ github.token }}
       - name: Fetch custom Github Actions and base branch history
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.0
         with:
           fetch-depth: 10
       - name: Install dependencies

--- a/.github/workflows/ci-zapier.yaml
+++ b/.github/workflows/ci-zapier.yaml
@@ -46,7 +46,7 @@ jobs:
           - 6379:6379
     steps:
       - name: Fetch custom Github Actions and base branch history
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.0
         with:
           fetch-depth: 10
       - name: Install dependencies
@@ -98,11 +98,11 @@ jobs:
         task: [lint, typecheck, validate]
     steps:
       - name: Cancel Previous Runs
-        uses: styfle/cancel-workflow-action@0.11.0
+        uses: styfle/cancel-workflow-action@b173b6ec0100793626c2d9e6b90435061f4fc3e5 # 0.11.0
         with:
           access_token: ${{ github.token }}
       - name: Fetch custom Github Actions and base branch history
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.0
         with:
           fetch-depth: 10
       - name: Install dependencies

--- a/.github/workflows/ci-zapier.yaml
+++ b/.github/workflows/ci-zapier.yaml
@@ -46,7 +46,7 @@ jobs:
           - 6379:6379
     steps:
       - name: Fetch custom Github Actions and base branch history
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.0
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           fetch-depth: 10
       - name: Install dependencies
@@ -98,7 +98,7 @@ jobs:
         task: [lint, typecheck, validate]
     steps:
       - name: Fetch custom Github Actions and base branch history
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.0
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           fetch-depth: 10
       - name: Install dependencies

--- a/.github/workflows/ci-zapier.yaml
+++ b/.github/workflows/ci-zapier.yaml
@@ -97,10 +97,6 @@ jobs:
       matrix:
         task: [lint, typecheck, validate]
     steps:
-      - name: Cancel Previous Runs
-        uses: styfle/cancel-workflow-action@b173b6ec0100793626c2d9e6b90435061f4fc3e5 # 0.11.0
-        with:
-          access_token: ${{ github.token }}
       - name: Fetch custom Github Actions and base branch history
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.0
         with:

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -70,10 +70,6 @@ jobs:
         ports:
           - 6379:6379
     steps:
-      - name: Harden runner
-        uses: step-security/harden-runner@a5ad31d6a139d249332a2605b85202e8c0b78450 # v2.19.1
-        with:
-          egress-policy: audit
       - name: Checkout repository
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
@@ -146,10 +142,6 @@ jobs:
         ports:
           - 6379:6379
     steps:
-      - name: Harden runner
-        uses: step-security/harden-runner@a5ad31d6a139d249332a2605b85202e8c0b78450 # v2.19.1
-        with:
-          egress-policy: audit
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           fetch-depth: 0

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -19,17 +19,35 @@ concurrency:
 jobs:
   claude:
     if: |
-      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude') && github.event.comment.user.type != 'Bot') ||
-      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude') && github.event.comment.user.type != 'Bot') ||
-      (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude') && github.event.review.user.type != 'Bot') ||
-      (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
+      (
+        github.event_name == 'issue_comment' &&
+        contains(github.event.comment.body, '@claude') &&
+        github.event.comment.user.type != 'Bot' &&
+        contains(fromJson('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association)
+      ) ||
+      (
+        github.event_name == 'pull_request_review_comment' &&
+        contains(github.event.comment.body, '@claude') &&
+        github.event.comment.user.type != 'Bot' &&
+        contains(fromJson('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association)
+      ) ||
+      (
+        github.event_name == 'pull_request_review' &&
+        contains(github.event.review.body, '@claude') &&
+        github.event.review.user.type != 'Bot' &&
+        contains(fromJson('["OWNER","MEMBER","COLLABORATOR"]'), github.event.review.author_association)
+      ) ||
+      (
+        github.event_name == 'issues' &&
+        (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')) &&
+        contains(fromJson('["OWNER","MEMBER","COLLABORATOR"]'), github.event.issue.author_association)
+      )
     runs-on: ubuntu-latest
     timeout-minutes: 60
     permissions:
       contents: write
       pull-requests: write
       issues: write
-      id-token: write
     services:
       postgres:
         image: postgres:16
@@ -49,15 +67,19 @@ jobs:
         ports:
           - 6379:6379
     steps:
+      - name: Harden runner
+        uses: step-security/harden-runner@a5ad31d6a139d249332a2605b85202e8c0b78450 # v2
+        with:
+          egress-policy: audit
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.0
         with:
           fetch-depth: 0
       - name: Install dependencies
         uses: ./.github/actions/yarn-install
       - name: Run Claude Code
         id: claude-code
-        uses: anthropics/claude-code-action@v1
+        uses: anthropics/claude-code-action@dde2242db6af13460b916652159b6ba19a598f30 # v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           additional_permissions: |
@@ -102,7 +124,6 @@ jobs:
       contents: write
       pull-requests: write
       issues: write
-      id-token: write
     services:
       postgres:
         image: postgres:16
@@ -122,14 +143,18 @@ jobs:
         ports:
           - 6379:6379
     steps:
-      - uses: actions/checkout@v4
+      - name: Harden runner
+        uses: step-security/harden-runner@a5ad31d6a139d249332a2605b85202e8c0b78450 # v2
+        with:
+          egress-policy: audit
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.0
         with:
           fetch-depth: 0
       - name: Install dependencies
         uses: ./.github/actions/yarn-install
       - name: Build prompt from dispatch payload
         id: prompt
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7.0.1
         with:
           script: |
             const p = context.payload.client_payload;
@@ -144,7 +169,7 @@ jobs:
             core.setOutput('issue_number', p.issue_number);
       - name: Run Claude Code
         id: claude
-        uses: anthropics/claude-code-action@v1
+        uses: anthropics/claude-code-action@dde2242db6af13460b916652159b6ba19a598f30 # v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           prompt: ${{ steps.prompt.outputs.prompt }}
@@ -159,7 +184,7 @@ jobs:
             }
       - name: Dispatch response to ci-privileged
         if: always()
-        uses: peter-evans/repository-dispatch@v2
+        uses: peter-evans/repository-dispatch@bf47d102fdb849e755b0b0023ea3e81a44b6f570 # v2
         with:
           token: ${{ secrets.CI_PRIVILEGED_DISPATCH_TOKEN }}
           repository: twentyhq/ci-privileged

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -8,7 +8,7 @@ on:
   pull_request_review:
     types: [submitted]
   issues:
-    types: [opened, assigned]
+    types: [opened]
   repository_dispatch:
     types: [claude-core-team-issues]
 
@@ -44,11 +44,6 @@ jobs:
         github.event.action == 'opened' &&
         (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')) &&
         contains(fromJson('["OWNER","MEMBER","COLLABORATOR"]'), github.event.issue.author_association)
-      ) ||
-      (
-        github.event_name == 'issues' &&
-        github.event.action == 'assigned' &&
-        (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude'))
       )
     runs-on: ubuntu-latest
     timeout-minutes: 60

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -188,7 +188,14 @@ jobs:
         if: always()
         env:
           GH_TOKEN: ${{ secrets.CI_PRIVILEGED_DISPATCH_TOKEN }}
+          REPO: ${{ steps.prompt.outputs.repo }}
+          ISSUE_NUMBER: ${{ steps.prompt.outputs.issue_number }}
+          RUN_ID: ${{ github.run_id }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
         run: |
           gh api repos/twentyhq/ci-privileged/dispatches \
-            --raw-field event_type=claude-cross-repo-response \
-            --raw-field "client_payload={\"repo\": \"${{ steps.prompt.outputs.repo }}\", \"issue_number\": \"${{ steps.prompt.outputs.issue_number }}\", \"run_id\": \"${{ github.run_id }}\", \"run_url\": \"${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}\"}"
+            -f event_type=claude-cross-repo-response \
+            -f "client_payload[repo]=$REPO" \
+            -f "client_payload[issue_number]=$ISSUE_NUMBER" \
+            -f "client_payload[run_id]=$RUN_ID" \
+            -f "client_payload[run_url]=$RUN_URL"

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -186,9 +186,9 @@ jobs:
             }
       - name: Dispatch response to ci-privileged
         if: always()
-        uses: peter-evans/repository-dispatch@bf47d102fdb849e755b0b0023ea3e81a44b6f570 # v2
-        with:
-          token: ${{ secrets.CI_PRIVILEGED_DISPATCH_TOKEN }}
-          repository: twentyhq/ci-privileged
-          event-type: claude-cross-repo-response
-          client-payload: '{"repo": ${{ toJSON(steps.prompt.outputs.repo) }}, "issue_number": ${{ toJSON(steps.prompt.outputs.issue_number) }}, "run_id": ${{ toJSON(github.run_id) }}, "run_url": "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"}'
+        env:
+          GH_TOKEN: ${{ secrets.CI_PRIVILEGED_DISPATCH_TOKEN }}
+        run: |
+          gh api repos/twentyhq/ci-privileged/dispatches \
+            --raw-field event_type=claude-cross-repo-response \
+            --raw-field "client_payload={\"repo\": \"${{ steps.prompt.outputs.repo }}\", \"issue_number\": \"${{ steps.prompt.outputs.issue_number }}\", \"run_id\": \"${{ github.run_id }}\", \"run_url\": \"${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}\"}"

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -76,11 +76,11 @@ jobs:
           - 6379:6379
     steps:
       - name: Harden runner
-        uses: step-security/harden-runner@a5ad31d6a139d249332a2605b85202e8c0b78450 # v2
+        uses: step-security/harden-runner@a5ad31d6a139d249332a2605b85202e8c0b78450 # v2.19.1
         with:
           egress-policy: audit
       - name: Checkout repository
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.0
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           fetch-depth: 0
       - name: Install dependencies
@@ -152,17 +152,17 @@ jobs:
           - 6379:6379
     steps:
       - name: Harden runner
-        uses: step-security/harden-runner@a5ad31d6a139d249332a2605b85202e8c0b78450 # v2
+        uses: step-security/harden-runner@a5ad31d6a139d249332a2605b85202e8c0b78450 # v2.19.1
         with:
           egress-policy: audit
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.0
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           fetch-depth: 0
       - name: Install dependencies
         uses: ./.github/actions/yarn-install
       - name: Build prompt from dispatch payload
         id: prompt
-        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7.0.1
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7.1.0
         with:
           script: |
             const p = context.payload.client_payload;

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -12,6 +12,8 @@ on:
   repository_dispatch:
     types: [claude-core-team-issues]
 
+permissions: {}
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.issue.number || github.event.pull_request.number || github.event.client_payload.issue_number }}
   cancel-in-progress: false

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -41,8 +41,14 @@ jobs:
       ) ||
       (
         github.event_name == 'issues' &&
+        github.event.action == 'opened' &&
         (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')) &&
         contains(fromJson('["OWNER","MEMBER","COLLABORATOR"]'), github.event.issue.author_association)
+      ) ||
+      (
+        github.event_name == 'issues' &&
+        github.event.action == 'assigned' &&
+        (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude'))
       )
     runs-on: ubuntu-latest
     timeout-minutes: 60

--- a/.github/workflows/docs-i18n-pull.yaml
+++ b/.github/workflows/docs-i18n-pull.yaml
@@ -45,8 +45,6 @@ jobs:
 
       - name: Install dependencies
         uses: ./.github/actions/yarn-install
-        with:
-          ignore-scripts: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository }}
 
       - name: Setup i18n-docs branch
         if: github.event_name != 'pull_request'

--- a/.github/workflows/docs-i18n-pull.yaml
+++ b/.github/workflows/docs-i18n-pull.yaml
@@ -37,7 +37,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.0
         with:
           token: ${{ github.token }}
           repository: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name || github.repository }}
@@ -45,6 +45,8 @@ jobs:
 
       - name: Install dependencies
         uses: ./.github/actions/yarn-install
+        with:
+          ignore-scripts: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository }}
 
       - name: Setup i18n-docs branch
         if: github.event_name != 'pull_request'
@@ -153,7 +155,7 @@ jobs:
 
       - name: Trigger i18n automerge
         if: github.event_name != 'pull_request' && steps.check_changes.outputs.changes_detected == 'true'
-        uses: peter-evans/repository-dispatch@v2
+        uses: peter-evans/repository-dispatch@bf47d102fdb849e755b0b0023ea3e81a44b6f570 # v2
         with:
           token: ${{ secrets.TWENTY_INFRA_TOKEN }}
           repository: twentyhq/twenty-infra

--- a/.github/workflows/docs-i18n-pull.yaml
+++ b/.github/workflows/docs-i18n-pull.yaml
@@ -156,6 +156,4 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.TWENTY_INFRA_TOKEN }}
         run: |
-          gh api repos/twentyhq/twenty-infra/dispatches \
-            --raw-field event_type=i18n-pr-ready \
-            --raw-field 'client_payload={}'
+          gh api repos/twentyhq/twenty-infra/dispatches -f event_type=i18n-pr-ready

--- a/.github/workflows/docs-i18n-pull.yaml
+++ b/.github/workflows/docs-i18n-pull.yaml
@@ -37,7 +37,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.0
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           token: ${{ github.token }}
           repository: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name || github.repository }}

--- a/.github/workflows/docs-i18n-pull.yaml
+++ b/.github/workflows/docs-i18n-pull.yaml
@@ -153,8 +153,9 @@ jobs:
 
       - name: Trigger i18n automerge
         if: github.event_name != 'pull_request' && steps.check_changes.outputs.changes_detected == 'true'
-        uses: peter-evans/repository-dispatch@bf47d102fdb849e755b0b0023ea3e81a44b6f570 # v2
-        with:
-          token: ${{ secrets.TWENTY_INFRA_TOKEN }}
-          repository: twentyhq/twenty-infra
-          event-type: i18n-pr-ready
+        env:
+          GH_TOKEN: ${{ secrets.TWENTY_INFRA_TOKEN }}
+        run: |
+          gh api repos/twentyhq/twenty-infra/dispatches \
+            --raw-field event_type=i18n-pr-ready \
+            --raw-field 'client_payload={}'

--- a/.github/workflows/docs-i18n-push.yaml
+++ b/.github/workflows/docs-i18n-push.yaml
@@ -24,7 +24,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.0
         with:
           token: ${{ github.token }}
           ref: ${{ github.ref }}
@@ -36,7 +36,7 @@ jobs:
         run: yarn docs:generate-navigation-template
 
       - name: Upload docs to Crowdin
-        uses: crowdin/github-action@v2
+        uses: crowdin/github-action@8868a33591d21088edfc398968173a3b98d51706 # v2
         with:
           upload_sources: true
           upload_translations: false

--- a/.github/workflows/docs-i18n-push.yaml
+++ b/.github/workflows/docs-i18n-push.yaml
@@ -24,7 +24,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.0
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           token: ${{ github.token }}
           ref: ${{ github.ref }}

--- a/.github/workflows/i18n-pull.yaml
+++ b/.github/workflows/i18n-pull.yaml
@@ -142,6 +142,4 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.TWENTY_INFRA_TOKEN }}
         run: |
-          gh api repos/twentyhq/twenty-infra/dispatches \
-            --raw-field event_type=i18n-pr-ready \
-            --raw-field 'client_payload={}'
+          gh api repos/twentyhq/twenty-infra/dispatches -f event_type=i18n-pr-ready

--- a/.github/workflows/i18n-pull.yaml
+++ b/.github/workflows/i18n-pull.yaml
@@ -139,8 +139,9 @@ jobs:
 
       - name: Trigger i18n automerge
         if: steps.compile_translations.outputs.changes_detected == 'true'
-        uses: peter-evans/repository-dispatch@bf47d102fdb849e755b0b0023ea3e81a44b6f570 # v2
-        with:
-          token: ${{ secrets.TWENTY_INFRA_TOKEN }}
-          repository: twentyhq/twenty-infra
-          event-type: i18n-pr-ready
+        env:
+          GH_TOKEN: ${{ secrets.TWENTY_INFRA_TOKEN }}
+        run: |
+          gh api repos/twentyhq/twenty-infra/dispatches \
+            --raw-field event_type=i18n-pr-ready \
+            --raw-field 'client_payload={}'

--- a/.github/workflows/i18n-pull.yaml
+++ b/.github/workflows/i18n-pull.yaml
@@ -35,7 +35,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.0
         with:
           token: ${{ github.token }}
           ref: ${{ github.head_ref || github.ref_name }}
@@ -69,7 +69,7 @@ jobs:
 
       - name: Pull translations from Crowdin
         if: inputs.force_pull || steps.compile_translations_strict.outcome == 'failure'
-        uses: crowdin/github-action@v2
+        uses: crowdin/github-action@8868a33591d21088edfc398968173a3b98d51706 # v2
         with:
           upload_sources: false
           upload_translations: false
@@ -139,7 +139,7 @@ jobs:
 
       - name: Trigger i18n automerge
         if: steps.compile_translations.outputs.changes_detected == 'true'
-        uses: peter-evans/repository-dispatch@v2
+        uses: peter-evans/repository-dispatch@bf47d102fdb849e755b0b0023ea3e81a44b6f570 # v2
         with:
           token: ${{ secrets.TWENTY_INFRA_TOKEN }}
           repository: twentyhq/twenty-infra

--- a/.github/workflows/i18n-pull.yaml
+++ b/.github/workflows/i18n-pull.yaml
@@ -35,7 +35,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.0
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           token: ${{ github.token }}
           ref: ${{ github.head_ref || github.ref_name }}

--- a/.github/workflows/i18n-push.yaml
+++ b/.github/workflows/i18n-push.yaml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.0
         with:
           token: ${{ github.token }}
           ref: main
@@ -80,7 +80,7 @@ jobs:
 
       - name: Upload missing translations
         if: steps.check_extract_changes.outputs.changes_detected == 'true'
-        uses: crowdin/github-action@v2
+        uses: crowdin/github-action@8868a33591d21088edfc398968173a3b98d51706 # v2
         with:
           upload_sources: true
           upload_translations: true
@@ -105,7 +105,7 @@ jobs:
 
       - name: Trigger i18n automerge
         if: steps.check_extract_changes.outputs.changes_detected == 'true' || steps.check_compile_changes.outputs.changes_detected == 'true'
-        uses: peter-evans/repository-dispatch@v2
+        uses: peter-evans/repository-dispatch@bf47d102fdb849e755b0b0023ea3e81a44b6f570 # v2
         with:
           token: ${{ secrets.TWENTY_INFRA_TOKEN }}
           repository: twentyhq/twenty-infra

--- a/.github/workflows/i18n-push.yaml
+++ b/.github/workflows/i18n-push.yaml
@@ -108,6 +108,4 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.TWENTY_INFRA_TOKEN }}
         run: |
-          gh api repos/twentyhq/twenty-infra/dispatches \
-            --raw-field event_type=i18n-pr-ready \
-            --raw-field 'client_payload={}'
+          gh api repos/twentyhq/twenty-infra/dispatches -f event_type=i18n-pr-ready

--- a/.github/workflows/i18n-push.yaml
+++ b/.github/workflows/i18n-push.yaml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.0
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           token: ${{ github.token }}
           ref: main

--- a/.github/workflows/i18n-push.yaml
+++ b/.github/workflows/i18n-push.yaml
@@ -105,8 +105,9 @@ jobs:
 
       - name: Trigger i18n automerge
         if: steps.check_extract_changes.outputs.changes_detected == 'true' || steps.check_compile_changes.outputs.changes_detected == 'true'
-        uses: peter-evans/repository-dispatch@bf47d102fdb849e755b0b0023ea3e81a44b6f570 # v2
-        with:
-          token: ${{ secrets.TWENTY_INFRA_TOKEN }}
-          repository: twentyhq/twenty-infra
-          event-type: i18n-pr-ready
+        env:
+          GH_TOKEN: ${{ secrets.TWENTY_INFRA_TOKEN }}
+        run: |
+          gh api repos/twentyhq/twenty-infra/dispatches \
+            --raw-field event_type=i18n-pr-ready \
+            --raw-field 'client_payload={}'

--- a/.github/workflows/post-ci-comments.yaml
+++ b/.github/workflows/post-ci-comments.yaml
@@ -63,9 +63,9 @@ jobs:
 
       - name: Dispatch to ci-privileged
         if: steps.pr-info.outputs.has_pr == 'true'
-        uses: peter-evans/repository-dispatch@bf47d102fdb849e755b0b0023ea3e81a44b6f570 # v2
-        with:
-          token: ${{ secrets.CI_PRIVILEGED_DISPATCH_TOKEN }}
-          repository: twentyhq/ci-privileged
-          event-type: breaking-changes-report
-          client-payload: '{"pr_number": ${{ toJSON(steps.pr-info.outputs.pr_number) }}, "run_id": ${{ toJSON(steps.pr-info.outputs.run_id) }}, "repo": ${{ toJSON(github.repository) }}, "branch_state": ${{ toJSON(github.event.workflow_run.head_branch) }}}'
+        env:
+          GH_TOKEN: ${{ secrets.CI_PRIVILEGED_DISPATCH_TOKEN }}
+        run: |
+          gh api repos/twentyhq/ci-privileged/dispatches \
+            --raw-field event_type=breaking-changes-report \
+            --raw-field 'client_payload={"pr_number": "${{ steps.pr-info.outputs.pr_number }}", "run_id": "${{ steps.pr-info.outputs.run_id }}", "repo": "${{ github.repository }}", "branch_state": "${{ github.event.workflow_run.head_branch }}"}'

--- a/.github/workflows/post-ci-comments.yaml
+++ b/.github/workflows/post-ci-comments.yaml
@@ -65,7 +65,14 @@ jobs:
         if: steps.pr-info.outputs.has_pr == 'true'
         env:
           GH_TOKEN: ${{ secrets.CI_PRIVILEGED_DISPATCH_TOKEN }}
+          PR_NUMBER: ${{ steps.pr-info.outputs.pr_number }}
+          RUN_ID: ${{ steps.pr-info.outputs.run_id }}
+          REPOSITORY: ${{ github.repository }}
+          BRANCH_STATE: ${{ github.event.workflow_run.head_branch }}
         run: |
           gh api repos/twentyhq/ci-privileged/dispatches \
-            --raw-field event_type=breaking-changes-report \
-            --raw-field 'client_payload={"pr_number": "${{ steps.pr-info.outputs.pr_number }}", "run_id": "${{ steps.pr-info.outputs.run_id }}", "repo": "${{ github.repository }}", "branch_state": "${{ github.event.workflow_run.head_branch }}"}'
+            -f event_type=breaking-changes-report \
+            -f "client_payload[pr_number]=$PR_NUMBER" \
+            -f "client_payload[run_id]=$RUN_ID" \
+            -f "client_payload[repo]=$REPOSITORY" \
+            -f "client_payload[branch_state]=$BRANCH_STATE"

--- a/.github/workflows/post-ci-comments.yaml
+++ b/.github/workflows/post-ci-comments.yaml
@@ -16,7 +16,7 @@ jobs:
     steps:
       - name: Get PR number from workflow run
         id: pr-info
-        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7.0.1
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7.1.0
         with:
           script: |
             const runId = context.payload.workflow_run.id;

--- a/.github/workflows/post-ci-comments.yaml
+++ b/.github/workflows/post-ci-comments.yaml
@@ -16,7 +16,7 @@ jobs:
     steps:
       - name: Get PR number from workflow run
         id: pr-info
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7.0.1
         with:
           script: |
             const runId = context.payload.workflow_run.id;
@@ -63,7 +63,7 @@ jobs:
 
       - name: Dispatch to ci-privileged
         if: steps.pr-info.outputs.has_pr == 'true'
-        uses: peter-evans/repository-dispatch@v2
+        uses: peter-evans/repository-dispatch@bf47d102fdb849e755b0b0023ea3e81a44b6f570 # v2
         with:
           token: ${{ secrets.CI_PRIVILEGED_DISPATCH_TOKEN }}
           repository: twentyhq/ci-privileged

--- a/.github/workflows/preview-env-dispatch.yaml
+++ b/.github/workflows/preview-env-dispatch.yaml
@@ -38,15 +38,25 @@ jobs:
       - name: Trigger preview environment workflow
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          REPOSITORY: ${{ github.repository }}
         run: |
-          gh api repos/${{ github.repository }}/dispatches \
-            --raw-field event_type=preview-environment \
-            --raw-field 'client_payload={"pr_number": "${{ github.event.pull_request.number }}", "pr_head_sha": "${{ github.event.pull_request.head.sha }}", "repo_full_name": "${{ github.repository }}"}'
+          gh api repos/"$REPOSITORY"/dispatches \
+            -f event_type=preview-environment \
+            -f "client_payload[pr_number]=$PR_NUMBER" \
+            -f "client_payload[pr_head_sha]=$PR_HEAD_SHA" \
+            -f "client_payload[repo_full_name]=$REPOSITORY"
 
       - name: Dispatch to ci-privileged for PR comment
         env:
           GH_TOKEN: ${{ secrets.CI_PRIVILEGED_DISPATCH_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          KEEPALIVE_DISPATCH_TIME: ${{ github.event.pull_request.updated_at }}
+          REPOSITORY: ${{ github.repository }}
         run: |
           gh api repos/twentyhq/ci-privileged/dispatches \
-            --raw-field event_type=preview-env-url \
-            --raw-field 'client_payload={"pr_number": "${{ github.event.pull_request.number }}", "keepalive_dispatch_time": "${{ github.event.pull_request.updated_at }}", "repo": "${{ github.repository }}"}'
+            -f event_type=preview-env-url \
+            -f "client_payload[pr_number]=$PR_NUMBER" \
+            -f "client_payload[keepalive_dispatch_time]=$KEEPALIVE_DISPATCH_TIME" \
+            -f "client_payload[repo]=$REPOSITORY"

--- a/.github/workflows/preview-env-dispatch.yaml
+++ b/.github/workflows/preview-env-dispatch.yaml
@@ -36,17 +36,17 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Trigger preview environment workflow
-        uses: peter-evans/repository-dispatch@bf47d102fdb849e755b0b0023ea3e81a44b6f570 # v2
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          repository: ${{ github.repository }}
-          event-type: preview-environment
-          client-payload: '{"pr_number": "${{ github.event.pull_request.number }}", "pr_head_sha": "${{ github.event.pull_request.head.sha }}", "repo_full_name": "${{ github.repository }}"}'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh api repos/${{ github.repository }}/dispatches \
+            --raw-field event_type=preview-environment \
+            --raw-field 'client_payload={"pr_number": "${{ github.event.pull_request.number }}", "pr_head_sha": "${{ github.event.pull_request.head.sha }}", "repo_full_name": "${{ github.repository }}"}'
 
       - name: Dispatch to ci-privileged for PR comment
-        uses: peter-evans/repository-dispatch@bf47d102fdb849e755b0b0023ea3e81a44b6f570 # v2
-        with:
-          token: ${{ secrets.CI_PRIVILEGED_DISPATCH_TOKEN }}
-          repository: twentyhq/ci-privileged
-          event-type: preview-env-url
-          client-payload: '{"pr_number": ${{ toJSON(github.event.pull_request.number) }}, "keepalive_dispatch_time": ${{ toJSON(github.event.pull_request.updated_at) }}, "repo": ${{ toJSON(github.repository) }}}'
+        env:
+          GH_TOKEN: ${{ secrets.CI_PRIVILEGED_DISPATCH_TOKEN }}
+        run: |
+          gh api repos/twentyhq/ci-privileged/dispatches \
+            --raw-field event_type=preview-env-url \
+            --raw-field 'client_payload={"pr_number": "${{ github.event.pull_request.number }}", "keepalive_dispatch_time": "${{ github.event.pull_request.updated_at }}", "repo": "${{ github.repository }}"}'

--- a/.github/workflows/preview-env-dispatch.yaml
+++ b/.github/workflows/preview-env-dispatch.yaml
@@ -36,7 +36,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Trigger preview environment workflow
-        uses: peter-evans/repository-dispatch@v2
+        uses: peter-evans/repository-dispatch@bf47d102fdb849e755b0b0023ea3e81a44b6f570 # v2
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           repository: ${{ github.repository }}
@@ -44,7 +44,7 @@ jobs:
           client-payload: '{"pr_number": "${{ github.event.pull_request.number }}", "pr_head_sha": "${{ github.event.pull_request.head.sha }}", "repo_full_name": "${{ github.repository }}"}'
 
       - name: Dispatch to ci-privileged for PR comment
-        uses: peter-evans/repository-dispatch@v2
+        uses: peter-evans/repository-dispatch@bf47d102fdb849e755b0b0023ea3e81a44b6f570 # v2
         with:
           token: ${{ secrets.CI_PRIVILEGED_DISPATCH_TOKEN }}
           repository: twentyhq/ci-privileged

--- a/.github/workflows/preview-env-keepalive.yaml
+++ b/.github/workflows/preview-env-keepalive.yaml
@@ -13,12 +13,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout PR
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.0
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           ref: ${{ github.event.client_payload.pr_head_sha }}
 
       - name: Login to Docker Hub
-        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3.4.0
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3.7.0
         with:
           username: ${{ vars.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_PASSWORD }}

--- a/.github/workflows/preview-env-keepalive.yaml
+++ b/.github/workflows/preview-env-keepalive.yaml
@@ -13,12 +13,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout PR
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.0
         with:
           ref: ${{ github.event.client_payload.pr_head_sha }}
 
       - name: Login to Docker Hub
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3.4.0
         with:
           username: ${{ vars.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_PASSWORD }}
@@ -166,7 +166,7 @@ jobs:
           echo "$TUNNEL_URL" > tunnel-url.txt
 
       - name: Upload tunnel URL artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: tunnel-url
           path: tunnel-url.txt

--- a/.github/workflows/visual-regression-dispatch.yaml
+++ b/.github/workflows/visual-regression-dispatch.yaml
@@ -23,7 +23,7 @@ jobs:
     steps:
       - name: Determine project and artifact name
         id: project
-        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7.0.1
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7.1.0
         with:
           script: |
             const workflowName = context.payload.workflow_run.name;
@@ -43,7 +43,7 @@ jobs:
 
       - name: Check if storybook artifact exists
         id: check-artifact
-        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7.0.1
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7.1.0
         with:
           script: |
             const artifactName = '${{ steps.project.outputs.artifact_name }}';
@@ -65,7 +65,7 @@ jobs:
       - name: Get PR number
         if: steps.check-artifact.outputs.exists == 'true'
         id: pr-info
-        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7.0.1
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7.1.0
         with:
           script: |
             const headBranch = context.payload.workflow_run.head_branch;

--- a/.github/workflows/visual-regression-dispatch.yaml
+++ b/.github/workflows/visual-regression-dispatch.yaml
@@ -128,17 +128,9 @@ jobs:
 
       - name: Dispatch to ci-privileged
         if: steps.check-artifact.outputs.exists == 'true' && steps.pr-info.outputs.has_pr == 'true'
-        uses: peter-evans/repository-dispatch@bf47d102fdb849e755b0b0023ea3e81a44b6f570 # v2
-        with:
-          token: ${{ secrets.CI_PRIVILEGED_DISPATCH_TOKEN }}
-          repository: twentyhq/ci-privileged
-          event-type: visual-regression
-          client-payload: >-
-            {
-              "pr_number": "${{ steps.pr-info.outputs.pr_number }}",
-              "run_id": "${{ github.run_id }}",
-              "repo": "${{ github.repository }}",
-              "project": "${{ steps.project.outputs.project }}",
-              "branch": "${{ github.event.workflow_run.head_branch }}",
-              "commit": "${{ github.event.workflow_run.head_sha }}"
-            }
+        env:
+          GH_TOKEN: ${{ secrets.CI_PRIVILEGED_DISPATCH_TOKEN }}
+        run: |
+          gh api repos/twentyhq/ci-privileged/dispatches \
+            --raw-field event_type=visual-regression \
+            --raw-field 'client_payload={"pr_number": "${{ steps.pr-info.outputs.pr_number }}", "run_id": "${{ github.run_id }}", "repo": "${{ github.repository }}", "project": "${{ steps.project.outputs.project }}", "branch": "${{ github.event.workflow_run.head_branch }}", "commit": "${{ github.event.workflow_run.head_sha }}"}'

--- a/.github/workflows/visual-regression-dispatch.yaml
+++ b/.github/workflows/visual-regression-dispatch.yaml
@@ -130,7 +130,18 @@ jobs:
         if: steps.check-artifact.outputs.exists == 'true' && steps.pr-info.outputs.has_pr == 'true'
         env:
           GH_TOKEN: ${{ secrets.CI_PRIVILEGED_DISPATCH_TOKEN }}
+          PR_NUMBER: ${{ steps.pr-info.outputs.pr_number }}
+          RUN_ID: ${{ github.run_id }}
+          REPOSITORY: ${{ github.repository }}
+          PROJECT: ${{ steps.project.outputs.project }}
+          BRANCH: ${{ github.event.workflow_run.head_branch }}
+          COMMIT: ${{ github.event.workflow_run.head_sha }}
         run: |
           gh api repos/twentyhq/ci-privileged/dispatches \
-            --raw-field event_type=visual-regression \
-            --raw-field 'client_payload={"pr_number": "${{ steps.pr-info.outputs.pr_number }}", "run_id": "${{ github.run_id }}", "repo": "${{ github.repository }}", "project": "${{ steps.project.outputs.project }}", "branch": "${{ github.event.workflow_run.head_branch }}", "commit": "${{ github.event.workflow_run.head_sha }}"}'
+            -f event_type=visual-regression \
+            -f "client_payload[pr_number]=$PR_NUMBER" \
+            -f "client_payload[run_id]=$RUN_ID" \
+            -f "client_payload[repo]=$REPOSITORY" \
+            -f "client_payload[project]=$PROJECT" \
+            -f "client_payload[branch]=$BRANCH" \
+            -f "client_payload[commit]=$COMMIT"

--- a/.github/workflows/visual-regression-dispatch.yaml
+++ b/.github/workflows/visual-regression-dispatch.yaml
@@ -23,7 +23,7 @@ jobs:
     steps:
       - name: Determine project and artifact name
         id: project
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7.0.1
         with:
           script: |
             const workflowName = context.payload.workflow_run.name;
@@ -43,7 +43,7 @@ jobs:
 
       - name: Check if storybook artifact exists
         id: check-artifact
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7.0.1
         with:
           script: |
             const artifactName = '${{ steps.project.outputs.artifact_name }}';
@@ -65,7 +65,7 @@ jobs:
       - name: Get PR number
         if: steps.check-artifact.outputs.exists == 'true'
         id: pr-info
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7.0.1
         with:
           script: |
             const headBranch = context.payload.workflow_run.head_branch;
@@ -107,7 +107,7 @@ jobs:
 
       - name: Download storybook artifact from triggering run
         if: steps.check-artifact.outputs.exists == 'true' && steps.pr-info.outputs.has_pr == 'true'
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
           name: ${{ steps.project.outputs.artifact_name }}
           path: storybook-static
@@ -120,7 +120,7 @@ jobs:
 
       - name: Upload storybook tarball
         if: steps.check-artifact.outputs.exists == 'true' && steps.pr-info.outputs.has_pr == 'true'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: ${{ steps.project.outputs.tarball_name }}
           path: /tmp/${{ steps.project.outputs.tarball_file }}
@@ -128,7 +128,7 @@ jobs:
 
       - name: Dispatch to ci-privileged
         if: steps.check-artifact.outputs.exists == 'true' && steps.pr-info.outputs.has_pr == 'true'
-        uses: peter-evans/repository-dispatch@v2
+        uses: peter-evans/repository-dispatch@bf47d102fdb849e755b0b0023ea3e81a44b6f570 # v2
         with:
           token: ${{ secrets.CI_PRIVILEGED_DISPATCH_TOKEN }}
           repository: twentyhq/ci-privileged

--- a/.github/workflows/website-i18n-pull.yaml
+++ b/.github/workflows/website-i18n-pull.yaml
@@ -128,8 +128,9 @@ jobs:
 
       - name: Trigger i18n automerge
         if: steps.compile_translations.outputs.changes_detected == 'true'
-        uses: peter-evans/repository-dispatch@bf47d102fdb849e755b0b0023ea3e81a44b6f570 # v2
-        with:
-          token: ${{ secrets.TWENTY_INFRA_TOKEN }}
-          repository: twentyhq/twenty-infra
-          event-type: i18n-pr-ready
+        env:
+          GH_TOKEN: ${{ secrets.TWENTY_INFRA_TOKEN }}
+        run: |
+          gh api repos/twentyhq/twenty-infra/dispatches \
+            --raw-field event_type=i18n-pr-ready \
+            --raw-field 'client_payload={}'

--- a/.github/workflows/website-i18n-pull.yaml
+++ b/.github/workflows/website-i18n-pull.yaml
@@ -35,7 +35,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.0
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           token: ${{ github.token }}
           ref: ${{ github.head_ref || github.ref_name }}

--- a/.github/workflows/website-i18n-pull.yaml
+++ b/.github/workflows/website-i18n-pull.yaml
@@ -131,6 +131,4 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.TWENTY_INFRA_TOKEN }}
         run: |
-          gh api repos/twentyhq/twenty-infra/dispatches \
-            --raw-field event_type=i18n-pr-ready \
-            --raw-field 'client_payload={}'
+          gh api repos/twentyhq/twenty-infra/dispatches -f event_type=i18n-pr-ready

--- a/.github/workflows/website-i18n-pull.yaml
+++ b/.github/workflows/website-i18n-pull.yaml
@@ -35,7 +35,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.0
         with:
           token: ${{ github.token }}
           ref: ${{ github.head_ref || github.ref_name }}
@@ -66,7 +66,7 @@ jobs:
 
       - name: Pull website translations from Crowdin
         if: inputs.force_pull || steps.compile_translations_strict.outcome == 'failure'
-        uses: crowdin/github-action@v2
+        uses: crowdin/github-action@8868a33591d21088edfc398968173a3b98d51706 # v2
         with:
           upload_sources: false
           upload_translations: false
@@ -128,7 +128,7 @@ jobs:
 
       - name: Trigger i18n automerge
         if: steps.compile_translations.outputs.changes_detected == 'true'
-        uses: peter-evans/repository-dispatch@v2
+        uses: peter-evans/repository-dispatch@bf47d102fdb849e755b0b0023ea3e81a44b6f570 # v2
         with:
           token: ${{ secrets.TWENTY_INFRA_TOKEN }}
           repository: twentyhq/twenty-infra

--- a/.github/workflows/website-i18n-push.yaml
+++ b/.github/workflows/website-i18n-push.yaml
@@ -107,6 +107,4 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.TWENTY_INFRA_TOKEN }}
         run: |
-          gh api repos/twentyhq/twenty-infra/dispatches \
-            --raw-field event_type=i18n-pr-ready \
-            --raw-field 'client_payload={}'
+          gh api repos/twentyhq/twenty-infra/dispatches -f event_type=i18n-pr-ready

--- a/.github/workflows/website-i18n-push.yaml
+++ b/.github/workflows/website-i18n-push.yaml
@@ -24,7 +24,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.0
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           token: ${{ github.token }}
           ref: main

--- a/.github/workflows/website-i18n-push.yaml
+++ b/.github/workflows/website-i18n-push.yaml
@@ -104,8 +104,9 @@ jobs:
 
       - name: Trigger i18n automerge
         if: steps.check_extract_changes.outputs.changes_detected == 'true' || steps.check_compile_changes.outputs.changes_detected == 'true'
-        uses: peter-evans/repository-dispatch@bf47d102fdb849e755b0b0023ea3e81a44b6f570 # v2
-        with:
-          token: ${{ secrets.TWENTY_INFRA_TOKEN }}
-          repository: twentyhq/twenty-infra
-          event-type: i18n-pr-ready
+        env:
+          GH_TOKEN: ${{ secrets.TWENTY_INFRA_TOKEN }}
+        run: |
+          gh api repos/twentyhq/twenty-infra/dispatches \
+            --raw-field event_type=i18n-pr-ready \
+            --raw-field 'client_payload={}'

--- a/.github/workflows/website-i18n-push.yaml
+++ b/.github/workflows/website-i18n-push.yaml
@@ -24,7 +24,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.0
         with:
           token: ${{ github.token }}
           ref: main
@@ -78,7 +78,7 @@ jobs:
 
       - name: Upload missing website translations
         if: steps.check_extract_changes.outputs.changes_detected == 'true'
-        uses: crowdin/github-action@v2
+        uses: crowdin/github-action@8868a33591d21088edfc398968173a3b98d51706 # v2
         with:
           upload_sources: true
           upload_translations: true
@@ -104,7 +104,7 @@ jobs:
 
       - name: Trigger i18n automerge
         if: steps.check_extract_changes.outputs.changes_detected == 'true' || steps.check_compile_changes.outputs.changes_detected == 'true'
-        uses: peter-evans/repository-dispatch@v2
+        uses: peter-evans/repository-dispatch@bf47d102fdb849e755b0b0023ea3e81a44b6f570 # v2
         with:
           token: ${{ secrets.TWENTY_INFRA_TOKEN }}
           repository: twentyhq/twenty-infra

--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -6,4 +6,6 @@ enableInlineHunks: true
 
 nodeLinker: node-modules
 
+npmMinimalAgeGate: "7d"
+
 yarnPath: .yarn/releases/yarn-4.13.0.cjs

--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -6,6 +6,6 @@ enableInlineHunks: true
 
 nodeLinker: node-modules
 
-npmMinimalAgeGate: "7d"
+npmMinimalAgeGate: "3d"
 
 yarnPath: .yarn/releases/yarn-4.13.0.cjs


### PR DESCRIPTION
- Pin all third-party actions to SHA
- Gate claude.yml triggers to internal authors with Harden-Runner egress audit
- Ignore fork-PR lifecycle scripts
- Narrow cross-repo dispatch payloads
- Add 7d npm release-age gate
- Add CODEOWNERS on .github/** and .yarnrc.yml