### PR TITLE
ci(preview-env): drop yarn `--` separator so `--light` reaches the seed command

### DIFF
--- a/.github/workflows/preview-env-keepalive.yaml
+++ b/.github/workflows/preview-env-keepalive.yaml
@@ -144,7 +144,7 @@ jobs:
         run: |
           cd packages/twenty-docker/
           echo "Seeding light dev workspace (Apple only)..."
-          if ! docker compose exec -T server yarn command:prod -- workspace:seed:dev --light; then
+          if ! docker compose exec -T server yarn command:prod workspace:seed:dev --light; then
             echo "❌ Seeding light dev workspace failed. Dumping server logs..."
             docker compose logs server
             exit 1


### PR DESCRIPTION
## Summary

Follow-up to #20464. That PR added `--light` to the preview env seed command but left the `--` between `yarn command:prod` and the script args. After yarn strips its own `--`, nest-commander still sees `argv: [..., '--', 'workspace:seed:dev', '--light']`. Commander.js treats `--` as the end-of-options marker, so `--light` is parsed as a positional arg and silently ignored — the seed runs in full mode (Apple + YCombinator + Empty3 + Empty4) and Empty4 still ends up as the default workspace.

## Evidence

In the preview run on `f706cc052b` (which had #20464's `--light` flag), the seed step took only ~40s but the `GqlTypeGenerator` log emits four regenerations across two workspaces with custom objects:

- 28 standard → 28 + 5 custom (`rocket, surveyResult, employmentHistory, petCareAgreement, pet`) — matches Apple
- 28 standard → 28 + 1 custom (`surveyResult`) — matches YCombinator

With `--light` actually applied, `getLightConfig` returns `{ objects: [], fields: [] }` so no custom objects should be generated.

The working `twenty-app-dev` invocation in `packages/twenty-docker/twenty-app-dev/rootfs/etc/s6-overlay/scripts/init-db.sh:66` is `yarn command:prod workspace:seed:dev --light` — no `--`. Matching that fixes it.

## Test plan

- [ ] Trigger the preview-app label on a PR, confirm only the Apple workspace is created and `tim@apple.dev` signs in there
- [ ] Confirm the seed step still passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)