### PR TITLE
fix(front): remove non-existent icon/universalIdentifier fields from FindManyMarketplaceAppsForToolTable query

### DIFF
--- a/packages/twenty-front/src/pages/settings/ai/components/SettingsToolIcon.tsx
+++ b/packages/twenty-front/src/pages/settings/ai/components/SettingsToolIcon.tsx
@@ -7,6 +7,7 @@ import { isDefined } from 'twenty-shared/utils';
 import {
   Avatar,
   getIconTileColorShades,
+  IconApps,
   IconCode,
   IconEdit,
   IconPlus,
@@ -22,7 +23,6 @@ type ApplicationInfo = {
 };
 
 type MarketplaceAppInfo = {
-  icon: string;
   logo?: string | null;
 };
 
@@ -110,8 +110,7 @@ export const SettingsToolIcon = ({
   }
 
   if (isDefined(marketplaceApp)) {
-    const MarketplaceIcon = getIcon(marketplaceApp.icon);
-    return <MarketplaceIcon size={16} />;
+    return <IconApps size={16} />;
   }
 
   if (isDefined(application)) {

--- a/packages/twenty-front/src/pages/settings/ai/components/SettingsToolsTable.tsx
+++ b/packages/twenty-front/src/pages/settings/ai/components/SettingsToolsTable.tsx
@@ -63,8 +63,6 @@ const FIND_MANY_MARKETPLACE_APPS_FOR_TOOL_TABLE = gql`
   query FindManyMarketplaceAppsForToolTable {
     findManyMarketplaceApps {
       id
-      universalIdentifier
-      icon
       logo
     }
   }
@@ -98,8 +96,6 @@ export const SettingsToolsTable = () => {
   const { data: marketplaceAppsData } = useQuery<{
     findManyMarketplaceApps: Array<{
       id: string;
-      universalIdentifier: string;
-      icon: string;
       logo?: string | null;
     }>;
   }>(FIND_MANY_MARKETPLACE_APPS_FOR_TOOL_TABLE);
@@ -166,9 +162,11 @@ export const SettingsToolsTable = () => {
       application,
     ]),
   );
+  // MarketplaceApp.id === Application.universalIdentifier
+  // (set in marketplace-query.service.ts: `id: registration.universalIdentifier`)
   const marketplaceAppByUniversalIdentifier = new Map(
     (marketplaceAppsData?.findManyMarketplaceApps ?? []).map(
-      (marketplaceApp) => [marketplaceApp.universalIdentifier, marketplaceApp],
+      (marketplaceApp) => [marketplaceApp.id, marketplaceApp],
     ),
   );
 


### PR DESCRIPTION
## Fixes #20485

## Bug

`/settings/ai` throws GraphQL validation errors on every load:

```
Cannot query field "icon" on type "MarketplaceApp".
Cannot query field "universalIdentifier" on type "MarketplaceApp".
```

The inline query `FIND_MANY_MARKETPLACE_APPS_FOR_TOOL_TABLE` in `SettingsToolsTable.tsx` requests `universalIdentifier` and `icon` on `MarketplaceApp`, but neither field is exposed on `MarketplaceAppDTO`:

- `icon` was removed in #20142 (commit `bddd23fd`).
- `universalIdentifier` is only an `@Args` parameter on `findOneMarketplaceApp`, not a `@Field` on the type.

The shared `MARKETPLACE_APP_FRAGMENT` was updated by #20142, but this separate inline query was missed.

## Fix

**`SettingsToolsTable.tsx`**

Drop `universalIdentifier` and `icon` from the query. Key the lookup map by `id` instead — `MarketplaceApp.id` is set to `registration.universalIdentifier` in `marketplace-query.service.ts`, so `application.universalIdentifier` remains the correct lookup key, just resolving against `id` on the returned objects.

**`SettingsToolIcon.tsx`**

`marketplaceApp.icon` is no longer queryable. The `getIcon(marketplaceApp.icon)` call would have received `undefined` at runtime even if the GraphQL validation didn't fail. Replace the branch with a static `IconApps` fallback — matches the previous server-side default (`icon: app?.icon ?? 'IconApps'` removed in #20142).

## Behavior after fix

| Input                                       | Before #20142 | v2.2.0 (broken)         | This PR             |
| ------------------------------------------- | ------------- | ----------------------- | ------------------- |
| `application` + `marketplaceApp.logo`       | Logo Avatar   | GraphQL error (no data) | Logo Avatar         |
| `application` + `marketplaceApp`, no `logo` | Manifest icon | GraphQL error (no data) | `IconApps` fallback |
| `application` alone                         | Name Avatar   | Name Avatar             | Name Avatar         |
| System tool                                 | Composite     | Composite               | Composite           |

## Verification

- Reproduced on fresh `twentycrm/twenty:v2.2.0` Docker image at `/settings/ai` with marketplace apps present.
- After patch: page loads clean, no GraphQL errors in console / Apollo link.
- Single caller of `<SettingsToolIcon />` confirmed via code search.
- No other inline queries reference the removed fields; shared fragment was already field-clean.