### PR TITLE
Refactor sanitize file strips images exif metadata

### DIFF
--- a/packages/twenty-server/src/engine/core-modules/application/application-install/application-install.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/application/application-install/application-install.service.ts
@@ -497,7 +497,11 @@ export class ApplicationInstallService {
         file: content,
         filename: relativePath,
       });
-      const sanitizedContent = sanitizeFile({ file: content, ext, mimeType });
+      const sanitizedContent = await sanitizeFile({
+        file: content,
+        ext,
+        mimeType,
+      });
 
       await this.fileStorageService.writeFile({
         sourceFile: sanitizedContent,

--- a/packages/twenty-server/src/engine/core-modules/file-storage/interfaces/file-storage-exception.ts
+++ b/packages/twenty-server/src/engine/core-modules/file-storage/interfaces/file-storage-exception.ts
@@ -8,6 +8,7 @@ export enum FileStorageExceptionCode {
   FILE_NOT_FOUND = 'FILE_NOT_FOUND',
   ACCESS_DENIED = 'ACCESS_DENIED',
   INVALID_EXTENSION = 'INVALID_EXTENSION',
+  SANITIZATION_FAILED = 'SANITIZATION_FAILED',
 }
 
 const getFileStorageExceptionUserFriendlyMessage = (
@@ -20,6 +21,8 @@ const getFileStorageExceptionUserFriendlyMessage = (
       return msg`File not found.`;
     case FileStorageExceptionCode.ACCESS_DENIED:
       return msg`Access denied.`;
+    case FileStorageExceptionCode.SANITIZATION_FAILED:
+      return msg`The image file could not be processed. It may be corrupted or in an unsupported format.`;
     default:
       assertUnreachable(code);
   }

--- a/packages/twenty-server/src/engine/core-modules/file/file-ai-chat/services/file-ai-chat.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/file/file-ai-chat/services/file-ai-chat.service.ts
@@ -32,7 +32,7 @@ export class FileAiChatService {
       filename,
     });
 
-    const sanitizedFile = sanitizeFile({ file, ext, mimeType });
+    const sanitizedFile = await sanitizeFile({ file, ext, mimeType });
 
     const fileId = v4();
     const name = `${fileId}${isNonEmptyString(ext) ? `.${ext}` : ''}`;

--- a/packages/twenty-server/src/engine/core-modules/file/file-core-picture/services/file-core-picture.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/file/file-core-picture/services/file-core-picture.service.ts
@@ -73,7 +73,7 @@ export class FileCorePictureService {
     queryRunner?: QueryRunner;
   }): Promise<FileEntity> {
     const { mimeType, ext } = await extractFileInfo({ file, filename });
-    const sanitizedFile = sanitizeFile({ file, ext, mimeType });
+    const sanitizedFile = await sanitizeFile({ file, ext, mimeType });
 
     const fileId = v4();
     const finalName = `${fileId}${isNonEmptyString(ext) ? `.${ext}` : ''}`;

--- a/packages/twenty-server/src/engine/core-modules/file/file-email-attachment/services/file-email-attachment.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/file/file-email-attachment/services/file-email-attachment.service.ts
@@ -35,7 +35,7 @@ export class FileEmailAttachmentService {
       filename,
     });
 
-    const sanitizedFile = sanitizeFile({ file, ext, mimeType });
+    const sanitizedFile = await sanitizeFile({ file, ext, mimeType });
 
     const fileId = v4();
     const name = `${fileId}${isNonEmptyString(ext) ? `.${ext}` : ''}`;

--- a/packages/twenty-server/src/engine/core-modules/file/file-workflow/services/file-workflow.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/file/file-workflow/services/file-workflow.service.ts
@@ -33,7 +33,7 @@ export class FileWorkflowService {
       filename,
     });
 
-    const sanitizedFile = sanitizeFile({ file, ext, mimeType });
+    const sanitizedFile = await sanitizeFile({ file, ext, mimeType });
 
     const fileId = v4();
     const name = `${fileId}${isNonEmptyString(ext) ? `.${ext}` : ''}`;

--- a/packages/twenty-server/src/engine/core-modules/file/files-field/services/files-field.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/file/files-field/services/files-field.service.ts
@@ -58,7 +58,7 @@ export class FilesFieldService {
       filename,
     });
 
-    const sanitizedFile = sanitizeFile({ file, ext, mimeType });
+    const sanitizedFile = await sanitizeFile({ file, ext, mimeType });
 
     const fileId = v4();
     const name = `${fileId}${isNonEmptyString(ext) ? `.${ext}` : ''}`;

--- a/packages/twenty-server/src/engine/core-modules/file/utils/__tests__/sanitize-file.utils.spec.ts
+++ b/packages/twenty-server/src/engine/core-modules/file/utils/__tests__/sanitize-file.utils.spec.ts
@@ -4,7 +4,7 @@ import { FileStorageException } from 'src/engine/core-modules/file-storage/inter
 
 import { sanitizeFile } from '../sanitize-file.utils';
 
-// Minimal valid 1x1 JPEG with an EXIF block containing a UserComment tag
+// Minimal valid 1x1 JPEG with an EXIF block containing an ImageDescription tag
 const createJpegWithExif = async (): Promise<Buffer> => {
   return sharp({
     create: { width: 1, height: 1, channels: 3, background: '#ff0000' },
@@ -62,6 +62,46 @@ describe('sanitizeFile', () => {
 
       const sanitizedMetadata = await sharp(sanitized as Buffer).metadata();
 
+      expect(sanitizedMetadata.exif).toBeUndefined();
+    });
+
+    it('should strip EXIF metadata when file is a Uint8Array', async () => {
+      const jpegWithExif = await createJpegWithExif();
+      const uint8Array = new Uint8Array(jpegWithExif);
+
+      const sanitized = await sanitizeFile({
+        file: uint8Array,
+        ext: 'jpg',
+        mimeType: 'image/jpeg',
+      });
+
+      expect(Buffer.isBuffer(sanitized)).toBe(true);
+
+      const sanitizedMetadata = await sharp(sanitized as Buffer).metadata();
+
+      expect(sanitizedMetadata.exif).toBeUndefined();
+    });
+
+    it('should apply EXIF orientation before stripping metadata', async () => {
+      // Create a 2x1 image then tag it with orientation 6 (90° CW rotation)
+      const landscape = await sharp({
+        create: { width: 2, height: 1, channels: 3, background: '#0000ff' },
+      })
+        .jpeg()
+        .withMetadata({ orientation: 6 })
+        .toBuffer();
+
+      const sanitized = await sanitizeFile({
+        file: landscape,
+        ext: 'jpg',
+        mimeType: 'image/jpeg',
+      });
+
+      const sanitizedMetadata = await sharp(sanitized as Buffer).metadata();
+
+      // After applying orientation 6 (90° CW), a 2x1 image becomes 1x2
+      expect(sanitizedMetadata.width).toBe(1);
+      expect(sanitizedMetadata.height).toBe(2);
       expect(sanitizedMetadata.exif).toBeUndefined();
     });
 

--- a/packages/twenty-server/src/engine/core-modules/file/utils/__tests__/sanitize-file.utils.spec.ts
+++ b/packages/twenty-server/src/engine/core-modules/file/utils/__tests__/sanitize-file.utils.spec.ts
@@ -1,0 +1,148 @@
+import sharp from 'sharp';
+
+import { sanitizeFile } from '../sanitize-file.utils';
+
+// Minimal valid 1x1 JPEG with an EXIF block containing a UserComment tag
+const createJpegWithExif = async (): Promise<Buffer> => {
+  return sharp({
+    create: { width: 1, height: 1, channels: 3, background: '#ff0000' },
+  })
+    .jpeg()
+    .withMetadata({
+      exif: {
+        IFD0: { ImageDescription: 'sensitive-location-data' },
+      },
+    })
+    .toBuffer();
+};
+
+describe('sanitizeFile', () => {
+  describe('raster image EXIF stripping', () => {
+    it('should strip EXIF metadata from JPEG files', async () => {
+      const jpegWithExif = await createJpegWithExif();
+
+      const originalMetadata = await sharp(jpegWithExif).metadata();
+
+      expect(originalMetadata.exif).toBeDefined();
+
+      const sanitized = await sanitizeFile({
+        file: jpegWithExif,
+        ext: 'jpg',
+        mimeType: 'image/jpeg',
+      });
+
+      expect(Buffer.isBuffer(sanitized)).toBe(true);
+
+      const sanitizedMetadata = await sharp(sanitized as Buffer).metadata();
+
+      expect(sanitizedMetadata.exif).toBeUndefined();
+    });
+
+    it('should strip EXIF metadata from PNG files', async () => {
+      const pngWithExif = await sharp({
+        create: { width: 1, height: 1, channels: 3, background: '#00ff00' },
+      })
+        .png()
+        .withMetadata({
+          exif: {
+            IFD0: { ImageDescription: 'test-metadata' },
+          },
+        })
+        .toBuffer();
+
+      const sanitized = await sanitizeFile({
+        file: pngWithExif,
+        ext: 'png',
+        mimeType: 'image/png',
+      });
+
+      expect(Buffer.isBuffer(sanitized)).toBe(true);
+
+      const sanitizedMetadata = await sharp(sanitized as Buffer).metadata();
+
+      expect(sanitizedMetadata.exif).toBeUndefined();
+    });
+
+    it('should return original file when sharp processing fails', async () => {
+      const corruptedBuffer = Buffer.from('not-a-real-image');
+
+      const result = await sanitizeFile({
+        file: corruptedBuffer,
+        ext: 'jpg',
+        mimeType: 'image/jpeg',
+      });
+
+      expect(result).toBe(corruptedBuffer);
+    });
+  });
+
+  describe('SVG sanitization', () => {
+    it('should sanitize SVG files with DOMPurify', async () => {
+      const maliciousSvg =
+        '<svg><script>alert("xss")</script><circle r="10"/></svg>';
+
+      const result = await sanitizeFile({
+        file: maliciousSvg,
+        ext: 'svg',
+        mimeType: 'image/svg+xml',
+      });
+
+      expect(typeof result).toBe('string');
+      expect(result).not.toContain('<script>');
+      expect(result).toContain('<circle');
+    });
+
+    it('should handle SVG passed as Buffer', async () => {
+      const svgBuffer = Buffer.from(
+        '<svg><script>alert("xss")</script><rect/></svg>',
+      );
+
+      const result = await sanitizeFile({
+        file: svgBuffer,
+        ext: 'svg',
+        mimeType: 'image/svg+xml',
+      });
+
+      expect(typeof result).toBe('string');
+      expect(result).not.toContain('<script>');
+    });
+  });
+
+  describe('non-image files', () => {
+    it('should pass through non-image files unmodified', async () => {
+      const textContent = Buffer.from('plain text content');
+
+      const result = await sanitizeFile({
+        file: textContent,
+        ext: 'txt',
+        mimeType: 'text/plain',
+      });
+
+      expect(result).toBe(textContent);
+    });
+
+    it('should pass through PDF files unmodified', async () => {
+      const pdfContent = Buffer.from('%PDF-1.4 fake pdf content');
+
+      const result = await sanitizeFile({
+        file: pdfContent,
+        ext: 'pdf',
+        mimeType: 'application/pdf',
+      });
+
+      expect(result).toBe(pdfContent);
+    });
+
+    it('should pass through files with undefined mime type', async () => {
+      const unknownContent = Buffer.from('unknown content');
+
+      const result = await sanitizeFile({
+        file: unknownContent,
+        ext: 'bin',
+        mimeType: undefined,
+      });
+
+      expect(result).toBe(unknownContent);
+    });
+  });
+});

--- a/packages/twenty-server/src/engine/core-modules/file/utils/__tests__/sanitize-file.utils.spec.ts
+++ b/packages/twenty-server/src/engine/core-modules/file/utils/__tests__/sanitize-file.utils.spec.ts
@@ -1,5 +1,7 @@
 import sharp from 'sharp';
 
+import { FileStorageException } from 'src/engine/core-modules/file-storage/interfaces/file-storage-exception';
+
 import { sanitizeFile } from '../sanitize-file.utils';
 
 // Minimal valid 1x1 JPEG with an EXIF block containing a UserComment tag
@@ -63,16 +65,16 @@ describe('sanitizeFile', () => {
       expect(sanitizedMetadata.exif).toBeUndefined();
     });
 
-    it('should return original file when sharp processing fails', async () => {
+    it('should throw a FileStorageException when sharp cannot process a corrupted image', async () => {
       const corruptedBuffer = Buffer.from('not-a-real-image');
 
-      const result = await sanitizeFile({
-        file: corruptedBuffer,
-        ext: 'jpg',
-        mimeType: 'image/jpeg',
-      });
-
-      expect(result).toBe(corruptedBuffer);
+      await expect(
+        sanitizeFile({
+          file: corruptedBuffer,
+          ext: 'jpg',
+          mimeType: 'image/jpeg',
+        }),
+      ).rejects.toThrow(FileStorageException);
     });
   });
 

--- a/packages/twenty-server/src/engine/core-modules/file/utils/sanitize-file.utils.ts
+++ b/packages/twenty-server/src/engine/core-modules/file/utils/sanitize-file.utils.ts
@@ -16,6 +16,10 @@ const SHARP_SUPPORTED_MIME_TYPES = new Set([
   'image/avif',
 ]);
 
+const isBufferLike = (
+  file: Buffer | Uint8Array | string,
+): file is Buffer | Uint8Array => typeof file !== 'string';
+
 export const sanitizeFile = async ({
   file,
   ext,
@@ -42,13 +46,9 @@ export const sanitizeFile = async ({
     return purify.sanitize(fileString);
   }
 
-  if (mimeType && SHARP_SUPPORTED_MIME_TYPES.has(mimeType)) {
+  if (mimeType && SHARP_SUPPORTED_MIME_TYPES.has(mimeType) && isBufferLike(file)) {
     try {
-      const inputBuffer = Buffer.isBuffer(file)
-        ? file
-        : typeof file === 'string'
-          ? Buffer.from(file, 'binary')
-          : Buffer.from(file);
+      const inputBuffer = Buffer.isBuffer(file) ? file : Buffer.from(file);
 
       // rotate() applies EXIF orientation before metadata is stripped
       return await sharp(inputBuffer).rotate().toBuffer();

--- a/packages/twenty-server/src/engine/core-modules/file/utils/sanitize-file.utils.ts
+++ b/packages/twenty-server/src/engine/core-modules/file/utils/sanitize-file.utils.ts
@@ -1,7 +1,16 @@
 import DOMPurify from 'dompurify';
 import { JSDOM } from 'jsdom';
+import sharp from 'sharp';
 
-export const sanitizeFile = ({
+const SHARP_SUPPORTED_MIME_TYPES = new Set([
+  'image/jpeg',
+  'image/png',
+  'image/webp',
+  'image/tiff',
+  'image/avif',
+]);
+
+export const sanitizeFile = async ({
   file,
   ext,
   mimeType,
@@ -9,7 +18,7 @@ export const sanitizeFile = ({
   file: Buffer | Uint8Array | string;
   ext: string;
   mimeType: string | undefined;
-}): Buffer | Uint8Array | string => {
+}): Promise<Buffer | Uint8Array | string> => {
   if (ext === 'svg' || mimeType === 'image/svg+xml') {
     const window = new JSDOM('').window;
     const purify = DOMPurify(window);
@@ -25,6 +34,21 @@ export const sanitizeFile = ({
     }
 
     return purify.sanitize(fileString);
+  }
+
+  if (mimeType && SHARP_SUPPORTED_MIME_TYPES.has(mimeType)) {
+    try {
+      const inputBuffer = Buffer.isBuffer(file)
+        ? file
+        : typeof file === 'string'
+          ? Buffer.from(file, 'binary')
+          : Buffer.from(file);
+
+      // rotate() applies EXIF orientation before metadata is stripped
+      return await sharp(inputBuffer).rotate().toBuffer();
+    } catch {
+      return file;
+    }
   }
 
   return file;

--- a/packages/twenty-server/src/engine/core-modules/file/utils/sanitize-file.utils.ts
+++ b/packages/twenty-server/src/engine/core-modules/file/utils/sanitize-file.utils.ts
@@ -46,7 +46,11 @@ export const sanitizeFile = async ({
     return purify.sanitize(fileString);
   }
 
-  if (mimeType && SHARP_SUPPORTED_MIME_TYPES.has(mimeType) && isBufferLike(file)) {
+  if (
+    mimeType &&
+    SHARP_SUPPORTED_MIME_TYPES.has(mimeType) &&
+    isBufferLike(file)
+  ) {
     try {
       const inputBuffer = Buffer.isBuffer(file) ? file : Buffer.from(file);
 

--- a/packages/twenty-server/src/engine/core-modules/file/utils/sanitize-file.utils.ts
+++ b/packages/twenty-server/src/engine/core-modules/file/utils/sanitize-file.utils.ts
@@ -1,4 +1,3 @@
-import { msg } from '@lingui/core/macro';
 import DOMPurify from 'dompurify';
 import { JSDOM } from 'jsdom';
 import sharp from 'sharp';
@@ -14,6 +13,8 @@ const SHARP_SUPPORTED_MIME_TYPES = new Set([
   'image/webp',
   'image/tiff',
   'image/avif',
+  'image/heif',
+  'image/heic',
 ]);
 
 const isBufferLike = (
@@ -60,9 +61,6 @@ export const sanitizeFile = async ({
       throw new FileStorageException(
         `Failed to sanitize image metadata: ${error instanceof Error ? error.message : String(error)}`,
         FileStorageExceptionCode.SANITIZATION_FAILED,
-        {
-          userFriendlyMessage: msg`The image file could not be processed. It may be corrupted or in an unsupported format.`,
-        },
       );
     }
   }

--- a/packages/twenty-server/src/engine/core-modules/file/utils/sanitize-file.utils.ts
+++ b/packages/twenty-server/src/engine/core-modules/file/utils/sanitize-file.utils.ts
@@ -1,6 +1,12 @@
+import { msg } from '@lingui/core/macro';
 import DOMPurify from 'dompurify';
 import { JSDOM } from 'jsdom';
 import sharp from 'sharp';
+
+import {
+  FileStorageException,
+  FileStorageExceptionCode,
+} from 'src/engine/core-modules/file-storage/interfaces/file-storage-exception';
 
 const SHARP_SUPPORTED_MIME_TYPES = new Set([
   'image/jpeg',
@@ -46,8 +52,14 @@ export const sanitizeFile = async ({
 
       // rotate() applies EXIF orientation before metadata is stripped
       return await sharp(inputBuffer).rotate().toBuffer();
-    } catch {
-      return file;
+    } catch (error) {
+      throw new FileStorageException(
+        `Failed to sanitize image metadata: ${error instanceof Error ? error.message : String(error)}`,
+        FileStorageExceptionCode.SANITIZATION_FAILED,
+        {
+          userFriendlyMessage: msg`The image file could not be processed. It may be corrupted or in an unsupported format.`,
+        },
+      );
     }
   }
 


### PR DESCRIPTION
# Introduction
Sharp natively removes the metadata after processing a file, we're applying any exif metadata orientation before then stripping them

closes https://github.com/twentyhq/twenty/issues/20477

## Backfill
Regarding the low/med privacy severity we won't backfill the existing files images