### PR TITLE
fix(server): add Apple seed workspace as fallback for single-workspace mode

### DIFF
--- a/packages/twenty-server/src/engine/core-modules/domain/workspace-domains/services/__test__/workspace-domains.service.spec.ts
+++ b/packages/twenty-server/src/engine/core-modules/domain/workspace-domains/services/__test__/workspace-domains.service.spec.ts
@@ -8,7 +8,6 @@ import { WorkspaceDomainsService } from 'src/engine/core-modules/domain/workspac
 import { PublicDomainEntity } from 'src/engine/core-modules/public-domain/public-domain.entity';
 import { TwentyConfigService } from 'src/engine/core-modules/twenty-config/twenty-config.service';
 import { WorkspaceEntity } from 'src/engine/core-modules/workspace/workspace.entity';
-import { SEED_APPLE_WORKSPACE_ID } from 'src/engine/workspace-manager/dev-seeder/core/constants/seeder-workspaces.constant';
 
 describe('WorkspaceDomainsService', () => {
   let workspaceDomainsService: WorkspaceDomainsService;
@@ -242,36 +241,6 @@ describe('WorkspaceDomainsService', () => {
         );
 
       expect(result?.id).toEqual('workspace-id1');
-    });
-
-    it('should prefer Apple seed workspace as fallback when multiple workspaces exist and IS_MULTIWORKSPACE_ENABLED=false', async () => {
-      jest
-        .spyOn(twentyConfigService, 'get')
-        .mockImplementation((key: string) => {
-          const env = {
-            FRONTEND_URL: 'https://example.com',
-            IS_MULTIWORKSPACE_ENABLED: false,
-          };
-
-          // @ts-expect-error legacy noImplicitAny
-          return env[key];
-        });
-
-      // The repo returns workspaces ordered by createdAt DESC, so Apple is not
-      // first. The service should still prefer the Apple seed workspace.
-      jest.spyOn(workspaceRepository, 'find').mockResolvedValueOnce([
-        { id: 'empty4-id' },
-        { id: 'empty3-id' },
-        { id: 'ycombinator-id' },
-        { id: SEED_APPLE_WORKSPACE_ID },
-      ] as unknown as WorkspaceEntity[]);
-
-      const result =
-        await workspaceDomainsService.getWorkspaceByOriginOrDefaultWorkspace(
-          'https://example.com',
-        );
-
-      expect(result?.id).toEqual(SEED_APPLE_WORKSPACE_ID);
     });
 
     it('should return workspace by subdomain', async () => {

--- a/packages/twenty-server/src/engine/core-modules/domain/workspace-domains/services/__test__/workspace-domains.service.spec.ts
+++ b/packages/twenty-server/src/engine/core-modules/domain/workspace-domains/services/__test__/workspace-domains.service.spec.ts
@@ -8,6 +8,7 @@ import { WorkspaceDomainsService } from 'src/engine/core-modules/domain/workspac
 import { PublicDomainEntity } from 'src/engine/core-modules/public-domain/public-domain.entity';
 import { TwentyConfigService } from 'src/engine/core-modules/twenty-config/twenty-config.service';
 import { WorkspaceEntity } from 'src/engine/core-modules/workspace/workspace.entity';
+import { SEED_APPLE_WORKSPACE_ID } from 'src/engine/workspace-manager/dev-seeder/core/constants/seeder-workspaces.constant';
 
 describe('WorkspaceDomainsService', () => {
   let workspaceDomainsService: WorkspaceDomainsService;
@@ -241,6 +242,36 @@ describe('WorkspaceDomainsService', () => {
         );
 
       expect(result?.id).toEqual('workspace-id1');
+    });
+
+    it('should prefer Apple seed workspace as fallback when multiple workspaces exist and IS_MULTIWORKSPACE_ENABLED=false', async () => {
+      jest
+        .spyOn(twentyConfigService, 'get')
+        .mockImplementation((key: string) => {
+          const env = {
+            FRONTEND_URL: 'https://example.com',
+            IS_MULTIWORKSPACE_ENABLED: false,
+          };
+
+          // @ts-expect-error legacy noImplicitAny
+          return env[key];
+        });
+
+      // The repo returns workspaces ordered by createdAt DESC, so Apple is not
+      // first. The service should still prefer the Apple seed workspace.
+      jest.spyOn(workspaceRepository, 'find').mockResolvedValueOnce([
+        { id: 'empty4-id' },
+        { id: 'empty3-id' },
+        { id: 'ycombinator-id' },
+        { id: SEED_APPLE_WORKSPACE_ID },
+      ] as unknown as WorkspaceEntity[]);
+
+      const result =
+        await workspaceDomainsService.getWorkspaceByOriginOrDefaultWorkspace(
+          'https://example.com',
+        );
+
+      expect(result?.id).toEqual(SEED_APPLE_WORKSPACE_ID);
     });
 
     it('should return workspace by subdomain', async () => {

--- a/packages/twenty-server/src/engine/core-modules/domain/workspace-domains/services/workspace-domains.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/domain/workspace-domains/services/workspace-domains.service.ts
@@ -11,6 +11,7 @@ import { PublicDomainEntity } from 'src/engine/core-modules/public-domain/public
 import { TwentyConfigService } from 'src/engine/core-modules/twenty-config/twenty-config.service';
 import { WorkspaceEntity } from 'src/engine/core-modules/workspace/workspace.entity';
 import { WorkspaceNotFoundDefaultError } from 'src/engine/core-modules/workspace/workspace.exception';
+import { SEED_APPLE_WORKSPACE_ID } from 'src/engine/workspace-manager/dev-seeder/core/constants/seeder-workspaces.constant';
 
 @Injectable()
 export class WorkspaceDomainsService {
@@ -77,7 +78,10 @@ export class WorkspaceDomainsService {
       );
     }
 
-    const foundWorkspace = workspaces[0];
+    // use Apple seed workspace by default if present when there are more than one workspaces.
+    const foundWorkspace =
+      workspaces.find((ws) => ws.id === SEED_APPLE_WORKSPACE_ID) ??
+      workspaces[0];
 
     assertIsDefinedOrThrow(foundWorkspace, WorkspaceNotFoundDefaultError);
 

--- a/packages/twenty-server/src/engine/core-modules/domain/workspace-domains/services/workspace-domains.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/domain/workspace-domains/services/workspace-domains.service.ts
@@ -74,14 +74,18 @@ export class WorkspaceDomainsService {
 
     if (workspaces.length > 1) {
       Logger.warn(
-        ` ${workspaces.length} workspaces found in database. In single-workspace mode, there should be only one workspace. Apple seed workspace will be used as fallback if it found.`,
+        `${workspaces.length} workspaces found in database. In single-workspace mode, there should be only one workspace. The Apple seed workspace will be used as fallback if present.`,
       );
     }
 
-    // use Apple seed workspace by default if present when there are more than one workspaces.
+    // Prefer the Apple seed workspace when multiple workspaces exist (e.g. after a full
+    // dev seed that creates Apple + YCombinator + Empty3 + Empty4) so the default user
+    // `tim@apple.dev` lands on a workspace they belong to. Falls back to the most
+    // recently created workspace otherwise.
     const foundWorkspace =
-      workspaces.find((ws) => ws.id === SEED_APPLE_WORKSPACE_ID) ??
-      workspaces[0];
+      workspaces.find(
+        (workspace) => workspace.id === SEED_APPLE_WORKSPACE_ID,
+      ) ?? workspaces[0];
 
     assertIsDefinedOrThrow(foundWorkspace, WorkspaceNotFoundDefaultError);
 

--- a/packages/twenty-server/src/engine/core-modules/domain/workspace-domains/services/workspace-domains.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/domain/workspace-domains/services/workspace-domains.service.ts
@@ -78,10 +78,6 @@ export class WorkspaceDomainsService {
       );
     }
 
-    // Prefer the Apple seed workspace when multiple workspaces exist (e.g. after a full
-    // dev seed that creates Apple + YCombinator + Empty3 + Empty4) so the default user
-    // `tim@apple.dev` lands on a workspace they belong to. Falls back to the most
-    // recently created workspace otherwise.
     const foundWorkspace =
       workspaces.find(
         (workspace) => workspace.id === SEED_APPLE_WORKSPACE_ID,


### PR DESCRIPTION
## Issue
As per the developer docs, the local setup uses the `npx nx database:reset twenty-server` command, which seeds 4 workspaces. This works correctly for multi-workspace mode (`IS_MULTIWORKSPACE_ENABLED=true`) and integration tests but causes issues in single-workspace mode (`IS_MULTIWORKSPACE_ENABLED=false`) or when switching from multi-workspace mode back to single-workspace mode.

Also, the default mode is single-workspace but 4 workspaces are already seeded in the database. As a result, `WorkspaceDomainsService.getDefaultWorkspace()` selects the newest workspace (Empty4), which is intended only for integration testing and contains no user data. 


There is also an existing warning log mentioning fallback to the Apple seed workspace when multiple workspaces are found in single-workspace mode i.e `IS_MULTIWORKSPACE_ENABLED=true`, but it was never implemented.

```
 if (workspaces.length > 1) {
      Logger.warn(
        ` ${workspaces.length} workspaces found in database. In single-workspace mode, there should be only one workspace. Apple seed workspace will be used as fallback if it found.`,
      );
    }
```

Although we could replace with `"nx command-no-deps -- workspace:seed:dev --light"` in `project.json` for `database:reset`, which will only seed one workspace but it wont resolve issue when switching from multi-workspace mode back to single-workspace mode or for integration test `with-db-reset`.


## Changes

- Implement fallback behavior already hinted by existing warning logs.
- Ensure the Apple seed workspace is used as the fallback in single-workspace mode when multiple workspaces exist.

This improves:
- Local developer onboarding experience.
- Switching between multi-workspace and single-workspace development modes.
- Consistency during local development and integration testing.

## Related PR
- #19822 
- #20464 

These PRs only resolves the issue for docker environments but not for local development setup.

 
 
