### PR TITLE
fix: force expand navigation drawer in Settings

### DIFF
--- a/packages/twenty-front/src/modules/navigation/components/SettingsNavigationDrawer.tsx
+++ b/packages/twenty-front/src/modules/navigation/components/SettingsNavigationDrawer.tsx
@@ -3,8 +3,11 @@ import { NavigationDrawer } from '@/ui/navigation/navigation-drawer/components/N
 import { NavigationDrawerFixedContent } from '@/ui/navigation/navigation-drawer/components/NavigationDrawerFixedContent';
 import { NavigationDrawerScrollableContent } from '@/ui/navigation/navigation-drawer/components/NavigationDrawerScrollableContent';
 import { isAdvancedModeEnabledState } from '@/ui/navigation/navigation-drawer/states/isAdvancedModeEnabledState';
+import { isNavigationDrawerExpandedState } from '@/ui/navigation/states/isNavigationDrawerExpanded';
 import { useAtomState } from '@/ui/utilities/state/jotai/hooks/useAtomState';
+import { useSetAtomState } from '@/ui/utilities/state/jotai/hooks/useSetAtomState';
 import { useLingui } from '@lingui/react/macro';
+import { useEffect } from 'react';
 import { AdvancedSettingsToggle } from 'twenty-ui/navigation';
 
 export const SettingsNavigationDrawer = ({
@@ -16,6 +19,14 @@ export const SettingsNavigationDrawer = ({
   const [isAdvancedModeEnabled, setIsAdvancedModeEnabled] = useAtomState(
     isAdvancedModeEnabledState,
   );
+  const setIsNavigationDrawerExpanded = useSetAtomState(
+    isNavigationDrawerExpandedState,
+  );
+
+  // Force expand navigation drawer in Settings to prevent collapsed state from main app
+  useEffect(() => {
+    setIsNavigationDrawerExpanded(true);
+  }, [setIsNavigationDrawerExpanded]);
 
   return (
     <NavigationDrawer className={className} title={t`Exit Settings`}>


### PR DESCRIPTION
## Summary
Fixes the issue where collapsing the navigation menu in the main app affects the Settings page layout, causing an ugly collapsed state.

## Changes
- Added `useEffect` in `SettingsNavigationDrawer` to force expand the navigation drawer when Settings mounts
- Imported `isNavigationDrawerExpandedState` and `useSetAtomState` to control the drawer state
- Prevents the collapsed state from persisting across tabs/routes into Settings

## Root Cause
The `isNavigationDrawerExpandedState` uses `localStorage` to persist the collapsed state across tabs. When a user collapses the drawer in the main app, this state carries over to the Settings page, which should always have an expanded drawer for proper layout.

## Solution
Force the drawer to expand when the Settings navigation drawer component mounts, ensuring Settings always displays with the correct layout regardless of the main app state.

Fixes #20502

## Testing
- Manual testing: collapse drawer in main app → navigate to Settings → drawer should be expanded
- Existing tests should pass (no breaking changes to component API)
