### PR TITLE
fix(messaging): store mailbox.path as name in IMAP folder discovery (Gmail sent folder)

### DIFF
--- a/packages/twenty-server/src/modules/messaging/message-folder-manager/drivers/imap/services/__tests__/imap-get-all-folders.service.spec.ts
+++ b/packages/twenty-server/src/modules/messaging/message-folder-manager/drivers/imap/services/__tests__/imap-get-all-folders.service.spec.ts
@@ -232,4 +232,56 @@ describe('ImapGetAllFoldersService', () => {
       },
     );
   });
+
+  describe('Gmail namespace handling', () => {
+    it('should store the full hierarchical path as name, not the leaf name', async () => {
+      const mailboxList = [
+        createMockMailbox({
+          path: 'INBOX',
+          name: 'INBOX',
+        }),
+        createMockMailbox({
+          path: '[Gmail]/Sent Mail',
+          name: 'Sent Mail',
+        }),
+        createMockMailbox({
+          path: '[Gmail]/All Mail',
+          name: 'All Mail',
+        }),
+      ];
+
+      mockImapClient.list.mockResolvedValue(mailboxList);
+      mockImapClient.status.mockImplementation(async (path: string) => {
+        const uidMap: Record<string, bigint> = {
+          INBOX: BigInt(1),
+          '[Gmail]/Sent Mail': BigInt(2),
+          '[Gmail]/All Mail': BigInt(3),
+        };
+
+        return { uidValidity: uidMap[path] } as any;
+      });
+
+      imapFindSentFolderService.findSentFolder.mockResolvedValue({
+        path: '[Gmail]/Sent Mail',
+        name: 'Sent Mail',
+      });
+
+      const result = await service.getAllMessageFolders(
+        CONNECTED_ACCOUNT,
+        MESSAGE_CHANNEL,
+      );
+
+      const sentFolder = result.find((f) => f.isSentFolder);
+
+      expect(sentFolder).toBeDefined();
+      expect(sentFolder?.name).toBe('[Gmail]/Sent Mail');
+      expect(sentFolder?.externalId).toBe('[Gmail]/Sent Mail:2');
+
+      const allMailFolder = result.find(
+        (f) => !f.isSentFolder && f.externalId?.includes('All Mail'),
+      );
+
+      expect(allMailFolder?.name).toBe('[Gmail]/All Mail');
+    });
+  });
 });

--- a/packages/twenty-server/src/modules/messaging/message-folder-manager/drivers/imap/services/imap-get-all-folders.service.ts
+++ b/packages/twenty-server/src/modules/messaging/message-folder-manager/drivers/imap/services/imap-get-all-folders.service.ts
@@ -86,7 +86,7 @@ export class ImapGetAllFoldersService implements MessageFolderDriver {
 
       folders.push({
         externalId,
-        name: sentFolder.name,
+        name: sentFolder.path,
         isSynced: true,
         isSentFolder: true,
         parentFolderId: sentMailbox?.parentPath || null,
@@ -120,7 +120,7 @@ export class ImapGetAllFoldersService implements MessageFolderDriver {
 
       folders.push({
         externalId,
-        name: mailbox.name,
+        name: mailbox.path,
         isSynced,
         isSentFolder: false,
         parentFolderId: mailbox.parentPath || null,


### PR DESCRIPTION
## Summary

Fixes #20469.

**Problem**: Gmail IMAP accounts fail to sync outbound emails because the sent folder name is stored incorrectly in .

**Root cause**:  stored  (the leaf name, e.g., ) in the folder's  field, instead of  (the full IMAP path, e.g., ).

Gmail uses the  namespace for special-use folders. When the outbound sync service tries to APPEND to , Gmail's IMAP server responds with , because  alone is not a valid mailbox path — only  is.

**Fix**: Changed two lines in  to store  as  instead of :

```diff
- name: sentFolder.name,
+ name: sentFolder.path,
```

(also applied to the regular mailbox loop for consistency)

**New test added**:  in  — verifies that folders like  and  store the full path as .

**Testing**:
1. Connect a Gmail IMAP account in Twenty
2. Trigger folder sync: Settings → Accounts → IMAP/SMTP → Sync folders
3. Query `core.messageFolder` —  should be , not 
4. Send an email — it should appear in  without a NO TRYCREATE error

---
/claim #20469
