### PR TITLE
`[twenty-server]` no-misused-promise lint

### DIFF
--- a/packages/twenty-server/.oxlintrc.json
+++ b/packages/twenty-server/.oxlintrc.json
@@ -57,6 +57,7 @@
     "typescript/no-empty-function": "off",
     "typescript/no-explicit-any": "warn",
     "typescript/no-floating-promises": "error",
+    "typescript/no-misused-promises": "error",
     "typescript/no-unused-vars": ["warn", {
       "vars": "all",
       "varsIgnorePattern": "^_",

--- a/packages/twenty-server/src/engine/core-modules/auth/strategies/oidc.auth.strategy.ts
+++ b/packages/twenty-server/src/engine/core-modules/auth/strategies/oidc.auth.strategy.ts
@@ -47,7 +47,7 @@ export class OIDCAuthStrategy extends PassportStrategy(
   }
 
   // oxlint-disable-next-line @typescripttypescript/no-explicit-any
-  async authenticate(req: Request, options: any) {
+  authenticate(req: Request, options: any) {
     return super.authenticate(req, {
       ...options,
       state: JSON.stringify({

--- a/packages/twenty-server/src/engine/core-modules/cache-storage/services/cache-storage.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/cache-storage/services/cache-storage.service.ts
@@ -134,7 +134,7 @@ export class CacheStorageService {
 
   async countAllSetMembers(cacheKeys: string[]) {
     return (
-      await Promise.all(cacheKeys.map((key) => this.getSetLength(key) || 0))
+      await Promise.all(cacheKeys.map((key) => this.getSetLength(key)))
     ).reduce((acc, setLength) => acc + setLength, 0);
   }
 

--- a/packages/twenty-server/src/engine/core-modules/code-interpreter/drivers/e2b.driver.ts
+++ b/packages/twenty-server/src/engine/core-modules/code-interpreter/drivers/e2b.driver.ts
@@ -96,7 +96,7 @@ export class E2BDriver implements CodeInterpreterDriver {
       const execution = await sbx.runCode(envSetup + code, {
         onStdout: (data) => callbacks?.onStdout?.(data.line),
         onStderr: (data) => callbacks?.onStderr?.(data.line),
-        onResult: (result) => {
+        onResult: async (result) => {
           if (result.png) {
             const outputFile: OutputFile = {
               filename: `chart-${chartCounter++}.png`,
@@ -105,7 +105,7 @@ export class E2BDriver implements CodeInterpreterDriver {
             };
 
             outputFiles.push(outputFile);
-            callbacks?.onResult?.(outputFile);
+            await callbacks?.onResult?.(outputFile);
           }
         },
       });
@@ -126,7 +126,7 @@ export class E2BDriver implements CodeInterpreterDriver {
             };
 
             outputFiles.push(outputFile);
-            callbacks?.onResult?.(outputFile);
+            await callbacks?.onResult?.(outputFile);
           }
         }
       } catch {

--- a/packages/twenty-server/src/engine/core-modules/code-interpreter/drivers/interfaces/code-interpreter-driver.interface.ts
+++ b/packages/twenty-server/src/engine/core-modules/code-interpreter/drivers/interfaces/code-interpreter-driver.interface.ts
@@ -25,7 +25,7 @@ export type ExecutionContext = {
 export type StreamCallbacks = {
   onStdout?: (line: string) => void;
   onStderr?: (line: string) => void;
-  onResult?: (result: OutputFile) => void;
+  onResult?: (result: OutputFile) => Promise<void>;
 };
 
 export interface CodeInterpreterDriver {

--- a/packages/twenty-server/src/engine/core-modules/code-interpreter/drivers/local.driver.ts
+++ b/packages/twenty-server/src/engine/core-modules/code-interpreter/drivers/local.driver.ts
@@ -111,7 +111,7 @@ export class LocalDriver implements CodeInterpreterDriver {
             };
 
             outputFiles.push(outputFile);
-            callbacks?.onResult?.(outputFile);
+            await callbacks?.onResult?.(outputFile);
           }
         }
       } catch {

--- a/packages/twenty-server/src/engine/core-modules/tool/tools/code-interpreter-tool/code-interpreter-tool.ts
+++ b/packages/twenty-server/src/engine/core-modules/tool/tools/code-interpreter-tool/code-interpreter-tool.ts
@@ -32,9 +32,9 @@ import {
   type CodeInterpreterFileInput,
   type CodeInterpreterInput,
 } from 'src/engine/core-modules/tool/tools/code-interpreter-tool/types/code-interpreter-input.type';
+import { type ToolExecutionContext } from 'src/engine/core-modules/tool/types/tool-execution-context.type';
 import { type ToolInput } from 'src/engine/core-modules/tool/types/tool-input.type';
 import { type ToolOutput } from 'src/engine/core-modules/tool/types/tool-output.type';
-import { type ToolExecutionContext } from 'src/engine/core-modules/tool/types/tool-execution-context.type';
 import { type Tool } from 'src/engine/core-modules/tool/types/tool.type';
 import { TwentyConfigService } from 'src/engine/core-modules/twenty-config/twenty-config.service';
 import { AuthProviderEnum } from 'src/engine/core-modules/workspace/types/workspace.type';

--- a/packages/twenty-server/src/engine/subscriptions/utils/wrap-async-iterator-with-lifecycle.ts
+++ b/packages/twenty-server/src/engine/subscriptions/utils/wrap-async-iterator-with-lifecycle.ts
@@ -17,13 +17,11 @@ export function wrapAsyncIteratorWithLifecycle<T>(
 
   const startHeartbeat = () => {
     if (onHeartbeat && heartbeatIntervalMs) {
-      heartbeatInterval = setInterval(async () => {
-        try {
-          await onHeartbeat();
-        } catch {
-          // Heartbeat failure shouldn't crash the stream
-        }
-      }, heartbeatIntervalMs);
+      // Heartbeat failure shouldn't crash the stream
+      heartbeatInterval = setInterval(
+        () => void onHeartbeat().catch(() => {}),
+        heartbeatIntervalMs,
+      );
     }
   };
 

--- a/packages/twenty-server/src/engine/subscriptions/utils/wrap-async-iterator-with-lifecycle.ts
+++ b/packages/twenty-server/src/engine/subscriptions/utils/wrap-async-iterator-with-lifecycle.ts
@@ -17,11 +17,13 @@ export function wrapAsyncIteratorWithLifecycle<T>(
 
   const startHeartbeat = () => {
     if (onHeartbeat && heartbeatIntervalMs) {
-      // Heartbeat failure shouldn't crash the stream
-      heartbeatInterval = setInterval(
-        () => void onHeartbeat().catch(() => {}),
-        heartbeatIntervalMs,
-      );
+      heartbeatInterval = setInterval(() => {
+        try {
+          void onHeartbeat().catch(() => {});
+        } catch {
+          // Heartbeat failure shouldn't crash the stream
+        }
+      }, heartbeatIntervalMs);
     }
   };
 

--- a/packages/twenty-server/src/engine/twenty-orm/entity-manager/workspace-entity-manager.ts
+++ b/packages/twenty-server/src/engine/twenty-orm/entity-manager/workspace-entity-manager.ts
@@ -86,20 +86,6 @@ export class WorkspaceEntityManager extends EntityManager {
     this.repositories = new Map();
   }
 
-  private async executeAndRelease({
-    queryRunner,
-    executor,
-  }: {
-    queryRunner: QueryRunner;
-    executor: EntityPersistExecutor;
-  }): Promise<void> {
-    try {
-      await executor.execute();
-    } finally {
-      await queryRunner.release();
-    }
-  }
-
   private get eventEmitterService(): WorkspaceEventEmitter {
     return this.connection.eventEmitterService;
   }
@@ -1284,25 +1270,24 @@ export class WorkspaceEntityManager extends EntityManager {
         updatedColumns,
       });
 
-      await this.executeAndRelease({
-        queryRunner: queryRunnerForEntityPersistExecutor,
-        executor: new EntityPersistExecutor(
-          this.connection,
-          queryRunnerForEntityPersistExecutor,
-          'save',
-          target,
-          formattedEntityOrEntities as ObjectLiteral[],
-          options as SaveOptions | (SaveOptions & { reload: false }),
-        ),
-      });
+      const result = await new EntityPersistExecutor(
+        this.connection,
+        queryRunnerForEntityPersistExecutor,
+        'save',
+        target,
+        formattedEntityOrEntities as ObjectLiteral[],
+        options as SaveOptions | (SaveOptions & { reload: false }),
+      )
+        .execute()
+        .then(() => formattedEntityOrEntities as Entity[])
+        // oxlint-disable-next-line @typescripttypescript/no-misused-promises
+        .finally(() => queryRunnerForEntityPersistExecutor.release());
 
       if (isDefined(filesFieldFileIds)) {
         await filesFieldSync.updateFileEntityRecords(filesFieldFileIds);
       }
 
-      const resultArray = Array.isArray(formattedEntityOrEntities)
-        ? (formattedEntityOrEntities as Entity[])
-        : [formattedEntityOrEntities as Entity];
+      const resultArray = Array.isArray(result) ? result : [result];
 
       let formattedResult = formatResult<Entity[]>(
         resultArray,
@@ -1506,20 +1491,21 @@ export class WorkspaceEntityManager extends EntityManager {
       this.internalContext.flatFieldMetadataMaps,
     );
 
-    await this.executeAndRelease({
-      queryRunner: queryRunnerForEntityPersistExecutor,
-      executor: new EntityPersistExecutor(
-        this.connection,
-        queryRunnerForEntityPersistExecutor,
-        'remove',
-        target as string | undefined,
-        formattedEntity as ObjectLiteral,
-        options as RemoveOptions,
-      ),
-    });
+    const result = new EntityPersistExecutor(
+      this.connection,
+      queryRunnerForEntityPersistExecutor,
+      'remove',
+      target as string | undefined,
+      formattedEntity as ObjectLiteral,
+      options as RemoveOptions,
+    )
+      .execute()
+      .then(() => formattedEntity as Entity | Entity[])
+      // oxlint-disable-next-line @typescripttypescript/no-misused-promises
+      .finally(() => queryRunnerForEntityPersistExecutor.release());
 
     const formattedResult = formatResult<Entity[]>(
-      formattedEntity,
+      result,
       objectMetadataItem,
       this.internalContext.flatObjectMetadataMaps,
       this.internalContext.flatFieldMetadataMaps,
@@ -1654,20 +1640,21 @@ export class WorkspaceEntityManager extends EntityManager {
       this.internalContext.flatFieldMetadataMaps,
     );
 
-    await this.executeAndRelease({
-      queryRunner: queryRunnerForEntityPersistExecutor,
-      executor: new EntityPersistExecutor(
-        this.connection,
-        queryRunnerForEntityPersistExecutor,
-        'soft-remove',
-        target,
-        formattedEntity as ObjectLiteral,
-        options as SaveOptions,
-      ),
-    });
+    const result = new EntityPersistExecutor(
+      this.connection,
+      queryRunnerForEntityPersistExecutor,
+      'soft-remove',
+      target,
+      formattedEntity as ObjectLiteral,
+      options as SaveOptions,
+    )
+      .execute()
+      .then(() => formattedEntity as Entity)
+      // oxlint-disable-next-line @typescripttypescript/no-misused-promises
+      .finally(() => queryRunnerForEntityPersistExecutor.release());
 
     const formattedResult = formatResult<Entity[]>(
-      formattedEntity,
+      result,
       objectMetadataItem,
       this.internalContext.flatObjectMetadataMaps,
       this.internalContext.flatFieldMetadataMaps,
@@ -1803,20 +1790,21 @@ export class WorkspaceEntityManager extends EntityManager {
       this.internalContext.flatFieldMetadataMaps,
     );
 
-    await this.executeAndRelease({
-      queryRunner: queryRunnerForEntityPersistExecutor,
-      executor: new EntityPersistExecutor(
-        this.connection,
-        queryRunnerForEntityPersistExecutor,
-        'recover',
-        target,
-        formattedEntity as ObjectLiteral,
-        options as SaveOptions,
-      ),
-    });
+    const result = new EntityPersistExecutor(
+      this.connection,
+      queryRunnerForEntityPersistExecutor,
+      'recover',
+      target,
+      formattedEntity as ObjectLiteral,
+      options as SaveOptions,
+    )
+      .execute()
+      .then(() => formattedEntity as Entity)
+      // oxlint-disable-next-line @typescripttypescript/no-misused-promises
+      .finally(() => queryRunnerForEntityPersistExecutor.release());
 
     const formattedResult = formatResult<Entity[]>(
-      formattedEntity,
+      result,
       objectMetadataItem,
       this.internalContext.flatObjectMetadataMaps,
       this.internalContext.flatFieldMetadataMaps,

--- a/packages/twenty-server/src/engine/twenty-orm/entity-manager/workspace-entity-manager.ts
+++ b/packages/twenty-server/src/engine/twenty-orm/entity-manager/workspace-entity-manager.ts
@@ -86,6 +86,20 @@ export class WorkspaceEntityManager extends EntityManager {
     this.repositories = new Map();
   }
 
+  private async executeAndRelease({
+    queryRunner,
+    executor,
+  }: {
+    queryRunner: QueryRunner;
+    executor: EntityPersistExecutor;
+  }): Promise<void> {
+    try {
+      await executor.execute();
+    } finally {
+      await queryRunner.release();
+    }
+  }
+
   private get eventEmitterService(): WorkspaceEventEmitter {
     return this.connection.eventEmitterService;
   }
@@ -1270,28 +1284,25 @@ export class WorkspaceEntityManager extends EntityManager {
         updatedColumns,
       });
 
-      let result: Entity[];
-
-      try {
-        await new EntityPersistExecutor(
+      await this.executeAndRelease({
+        queryRunner: queryRunnerForEntityPersistExecutor,
+        executor: new EntityPersistExecutor(
           this.connection,
           queryRunnerForEntityPersistExecutor,
           'save',
           target,
           formattedEntityOrEntities as ObjectLiteral[],
           options as SaveOptions | (SaveOptions & { reload: false }),
-        ).execute();
-
-        result = formattedEntityOrEntities as Entity[];
-      } finally {
-        await queryRunnerForEntityPersistExecutor.release();
-      }
+        ),
+      });
 
       if (isDefined(filesFieldFileIds)) {
         await filesFieldSync.updateFileEntityRecords(filesFieldFileIds);
       }
 
-      const resultArray = Array.isArray(result) ? result : [result];
+      const resultArray = Array.isArray(formattedEntityOrEntities)
+        ? (formattedEntityOrEntities as Entity[])
+        : [formattedEntityOrEntities as Entity];
 
       let formattedResult = formatResult<Entity[]>(
         resultArray,
@@ -1495,25 +1506,20 @@ export class WorkspaceEntityManager extends EntityManager {
       this.internalContext.flatFieldMetadataMaps,
     );
 
-    let result: Entity | Entity[];
-
-    try {
-      await new EntityPersistExecutor(
+    await this.executeAndRelease({
+      queryRunner: queryRunnerForEntityPersistExecutor,
+      executor: new EntityPersistExecutor(
         this.connection,
         queryRunnerForEntityPersistExecutor,
         'remove',
         target as string | undefined,
         formattedEntity as ObjectLiteral,
         options as RemoveOptions,
-      ).execute();
-
-      result = formattedEntity as Entity | Entity[];
-    } finally {
-      await queryRunnerForEntityPersistExecutor.release();
-    }
+      ),
+    });
 
     const formattedResult = formatResult<Entity[]>(
-      result,
+      formattedEntity,
       objectMetadataItem,
       this.internalContext.flatObjectMetadataMaps,
       this.internalContext.flatFieldMetadataMaps,
@@ -1648,25 +1654,20 @@ export class WorkspaceEntityManager extends EntityManager {
       this.internalContext.flatFieldMetadataMaps,
     );
 
-    let result: Entity;
-
-    try {
-      await new EntityPersistExecutor(
+    await this.executeAndRelease({
+      queryRunner: queryRunnerForEntityPersistExecutor,
+      executor: new EntityPersistExecutor(
         this.connection,
         queryRunnerForEntityPersistExecutor,
         'soft-remove',
         target,
         formattedEntity as ObjectLiteral,
         options as SaveOptions,
-      ).execute();
-
-      result = formattedEntity as Entity;
-    } finally {
-      await queryRunnerForEntityPersistExecutor.release();
-    }
+      ),
+    });
 
     const formattedResult = formatResult<Entity[]>(
-      result,
+      formattedEntity,
       objectMetadataItem,
       this.internalContext.flatObjectMetadataMaps,
       this.internalContext.flatFieldMetadataMaps,
@@ -1802,25 +1803,20 @@ export class WorkspaceEntityManager extends EntityManager {
       this.internalContext.flatFieldMetadataMaps,
     );
 
-    let result: Entity;
-
-    try {
-      await new EntityPersistExecutor(
+    await this.executeAndRelease({
+      queryRunner: queryRunnerForEntityPersistExecutor,
+      executor: new EntityPersistExecutor(
         this.connection,
         queryRunnerForEntityPersistExecutor,
         'recover',
         target,
         formattedEntity as ObjectLiteral,
         options as SaveOptions,
-      ).execute();
-
-      result = formattedEntity as Entity;
-    } finally {
-      await queryRunnerForEntityPersistExecutor.release();
-    }
+      ),
+    });
 
     const formattedResult = formatResult<Entity[]>(
-      result,
+      formattedEntity,
       objectMetadataItem,
       this.internalContext.flatObjectMetadataMaps,
       this.internalContext.flatFieldMetadataMaps,

--- a/packages/twenty-server/src/engine/twenty-orm/entity-manager/workspace-entity-manager.ts
+++ b/packages/twenty-server/src/engine/twenty-orm/entity-manager/workspace-entity-manager.ts
@@ -1270,17 +1270,22 @@ export class WorkspaceEntityManager extends EntityManager {
         updatedColumns,
       });
 
-      const result = await new EntityPersistExecutor(
-        this.connection,
-        queryRunnerForEntityPersistExecutor,
-        'save',
-        target,
-        formattedEntityOrEntities as ObjectLiteral[],
-        options as SaveOptions | (SaveOptions & { reload: false }),
-      )
-        .execute()
-        .then(() => formattedEntityOrEntities as Entity[])
-        .finally(() => queryRunnerForEntityPersistExecutor.release());
+      let result: Entity[];
+
+      try {
+        await new EntityPersistExecutor(
+          this.connection,
+          queryRunnerForEntityPersistExecutor,
+          'save',
+          target,
+          formattedEntityOrEntities as ObjectLiteral[],
+          options as SaveOptions | (SaveOptions & { reload: false }),
+        ).execute();
+
+        result = formattedEntityOrEntities as Entity[];
+      } finally {
+        await queryRunnerForEntityPersistExecutor.release();
+      }
 
       if (isDefined(filesFieldFileIds)) {
         await filesFieldSync.updateFileEntityRecords(filesFieldFileIds);
@@ -1490,17 +1495,22 @@ export class WorkspaceEntityManager extends EntityManager {
       this.internalContext.flatFieldMetadataMaps,
     );
 
-    const result = new EntityPersistExecutor(
-      this.connection,
-      queryRunnerForEntityPersistExecutor,
-      'remove',
-      target as string | undefined,
-      formattedEntity as ObjectLiteral,
-      options as RemoveOptions,
-    )
-      .execute()
-      .then(() => formattedEntity as Entity | Entity[])
-      .finally(() => queryRunnerForEntityPersistExecutor.release());
+    let result: Entity | Entity[];
+
+    try {
+      await new EntityPersistExecutor(
+        this.connection,
+        queryRunnerForEntityPersistExecutor,
+        'remove',
+        target as string | undefined,
+        formattedEntity as ObjectLiteral,
+        options as RemoveOptions,
+      ).execute();
+
+      result = formattedEntity as Entity | Entity[];
+    } finally {
+      await queryRunnerForEntityPersistExecutor.release();
+    }
 
     const formattedResult = formatResult<Entity[]>(
       result,
@@ -1638,17 +1648,22 @@ export class WorkspaceEntityManager extends EntityManager {
       this.internalContext.flatFieldMetadataMaps,
     );
 
-    const result = new EntityPersistExecutor(
-      this.connection,
-      queryRunnerForEntityPersistExecutor,
-      'soft-remove',
-      target,
-      formattedEntity as ObjectLiteral,
-      options as SaveOptions,
-    )
-      .execute()
-      .then(() => formattedEntity as Entity)
-      .finally(() => queryRunnerForEntityPersistExecutor.release());
+    let result: Entity;
+
+    try {
+      await new EntityPersistExecutor(
+        this.connection,
+        queryRunnerForEntityPersistExecutor,
+        'soft-remove',
+        target,
+        formattedEntity as ObjectLiteral,
+        options as SaveOptions,
+      ).execute();
+
+      result = formattedEntity as Entity;
+    } finally {
+      await queryRunnerForEntityPersistExecutor.release();
+    }
 
     const formattedResult = formatResult<Entity[]>(
       result,
@@ -1787,17 +1802,22 @@ export class WorkspaceEntityManager extends EntityManager {
       this.internalContext.flatFieldMetadataMaps,
     );
 
-    const result = new EntityPersistExecutor(
-      this.connection,
-      queryRunnerForEntityPersistExecutor,
-      'recover',
-      target,
-      formattedEntity as ObjectLiteral,
-      options as SaveOptions,
-    )
-      .execute()
-      .then(() => formattedEntity as Entity)
-      .finally(() => queryRunnerForEntityPersistExecutor.release());
+    let result: Entity;
+
+    try {
+      await new EntityPersistExecutor(
+        this.connection,
+        queryRunnerForEntityPersistExecutor,
+        'recover',
+        target,
+        formattedEntity as ObjectLiteral,
+        options as SaveOptions,
+      ).execute();
+
+      result = formattedEntity as Entity;
+    } finally {
+      await queryRunnerForEntityPersistExecutor.release();
+    }
 
     const formattedResult = formatResult<Entity[]>(
       result,


### PR DESCRIPTION
# Introduction
Adding `no-miused-promise` lint rule to the twenty-server
In order to flag such pattern
```ts
// ❌ Flagged — forEach doesn't await the callback
items.forEach(async (item) => {
  await process(item);
});
```

## What happened
- Refactored the code-interpreter driver to have a async onResult ( which is also expected by e2b )
- Workspace manager still dirty solution including force cast
- Basic fixes