### PR TITLE
fix: prevent server crash on IMAP socket timeout

### DIFF
--- a/packages/twenty-server/src/engine/core-modules/imap-smtp-caldav-connection/services/imap-smtp-caldav-connection.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/imap-smtp-caldav-connection/services/imap-smtp-caldav-connection.service.ts
@@ -54,7 +54,10 @@ export class ImapSmtpCaldavService {
     });
 
     client.on('error', (error) => {
-      this.logger.error(`IMAP client error for ${handle}: ${error.message}`, error.stack);
+      this.logger.error(
+        `IMAP client error for ${handle}: ${error.message}`,
+        error.stack,
+      );
     });
 
     try {

--- a/packages/twenty-server/src/engine/core-modules/imap-smtp-caldav-connection/services/imap-smtp-caldav-connection.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/imap-smtp-caldav-connection/services/imap-smtp-caldav-connection.service.ts
@@ -53,6 +53,10 @@ export class ImapSmtpCaldavService {
       },
     });
 
+    client.on('error', (error) => {
+      this.logger.error(`IMAP client error for ${handle}: ${error.message}`, error.stack);
+    });
+
     try {
       await client.connect();
 

--- a/packages/twenty-server/src/engine/core-modules/imap-smtp-caldav-connection/services/imap-smtp-caldav-connection.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/imap-smtp-caldav-connection/services/imap-smtp-caldav-connection.service.ts
@@ -51,6 +51,8 @@ export class ImapSmtpCaldavService {
       tls: {
         rejectUnauthorized: false,
       },
+      connectionTimeout: 30000,
+      greetingTimeout: 16000,
     });
 
     client.on('error', (error) => {

--- a/packages/twenty-server/src/modules/messaging/message-import-manager/drivers/imap/providers/imap-client.provider.ts
+++ b/packages/twenty-server/src/modules/messaging/message-import-manager/drivers/imap/providers/imap-client.provider.ts
@@ -94,6 +94,13 @@ export class ImapClientProvider {
       greetingTimeout: ImapClientProvider.GREETING_TIMEOUT_MS,
     });
 
+    client.on('error', (error) => {
+      this.logger.error(
+        `IMAP client error for ${connectedAccount.handle}: ${error.message}`,
+        error.stack,
+      );
+    });
+
     try {
       await client.connect();
 


### PR DESCRIPTION
## Description\nThis PR fixes a critical issue where the server would crash with an unhandled exception when an IMAP socket encountered a timeout or connection reset after the initial connection was established.\n\n### Changes\n- Added .on('error', ...) listeners to ImapFlow instances in ImapClientProvider and ImapSmtpCaldavService.\n- Ensures that asynchronous socket errors are caught and logged instead of bubbling up to the process level.\n\n### Impact\nThis prevents uncaughtException crashes in production environments with unstable IMAP connections, significantly improving the stability of the messaging module. Closes #20509