### PR TITLE
fix(ai-agent-node) - agent node execution error

### DIFF
--- a/packages/twenty-server/src/modules/workflow/workflow-executor/workflow-actions/ai-agent/ai-agent.workflow-action.ts
+++ b/packages/twenty-server/src/modules/workflow/workflow-executor/workflow-actions/ai-agent/ai-agent.workflow-action.ts
@@ -48,7 +48,7 @@ export class AiAgentWorkflowAction implements WorkflowAction {
     }
 
     const { agentId, prompt } = step.settings.input;
-    const workspaceId = context.workspaceId as string;
+    const workspaceId = runInfo.workspaceId;
 
     let agent: AgentEntity | null = null;
 


### PR DESCRIPTION
**Root cause:** getWorkflowRunContext(stepInfos) builds a Record<string, unknown> from the previous steps' results. There is no workspaceId key in it, so context.workspaceId as string silently evaluated to undefined. That undefined was then passed all the way down to WorkspaceCacheService.getOrRecompute, **which correctly throws** when workspaceId is not a valid UUID.

Before : 
<img width="525" height="130" alt="Screenshot 2026-05-13 at 14 58 54" src="https://github.com/user-attachments/assets/0549b4dc-7063-44e5-95a1-00a460a6d7f1" />

Introduced with billing v2 yesterday, since then, workspaceId is needed to bill credit usage

