### PR TITLE
fix(imap): log full error detail on send failure and add Gmail namespace folder test

### DIFF
--- a/packages/twenty-server/src/modules/messaging/message-folder-manager/drivers/imap/services/__tests__/imap-get-all-folders.service.spec.ts
+++ b/packages/twenty-server/src/modules/messaging/message-folder-manager/drivers/imap/services/__tests__/imap-get-all-folders.service.spec.ts
@@ -160,7 +160,47 @@ describe('ImapGetAllFoldersService', () => {
       }
     });
 
-    it('should exclude \\Noselect sent folder from results and skip STATUS', async () => {
+    it('should store the full IMAP path (e.g. [Gmail]/Sent Mail) as externalId for namespaced sent folders', async () => {
+      // Gmail-style: special folders live under [Gmail]/ namespace
+      // mailbox.name === 'Sent Mail', mailbox.path === '[Gmail]/Sent Mail'
+      // The APPEND command needs the path, not the leaf name, or it gets TRYCREATE
+      const mailboxList = [
+        createMockMailbox({ path: 'INBOX' }),
+        createMockMailbox({
+          path: '[Gmail]/Sent Mail',
+          name: 'Sent Mail',
+          parentPath: '[Gmail]',
+        }),
+      ];
+
+      mockImapClient.list.mockResolvedValue(mailboxList);
+      mockImapClient.status.mockImplementation(async (path: string) => {
+        const uidMap: Record<string, bigint> = {
+          INBOX: BigInt(1),
+          '[Gmail]/Sent Mail': BigInt(2),
+        };
+
+        return { uidValidity: uidMap[path] } as any;
+      });
+
+      imapFindSentFolderService.findSentFolder.mockResolvedValue({
+        path: '[Gmail]/Sent Mail',
+        name: 'Sent Mail',
+      });
+
+      const result = await service.getAllMessageFolders(
+        CONNECTED_ACCOUNT,
+        MESSAGE_CHANNEL,
+      );
+
+      const sentFolder = result.find((f) => f.isSentFolder);
+
+      expect(sentFolder).toBeDefined();
+      // externalId should encode the full path so getImapFolderPath() returns '[Gmail]/Sent Mail'
+      expect(sentFolder?.externalId).toMatch(/^\[Gmail\]\/Sent Mail/);
+    });
+
+    it('should exclude \\\\Noselect sent folder from results and skip STATUS', async () => {
       const mailboxList = [
         createMockMailbox({ path: 'INBOX' }),
         createMockMailbox({

--- a/packages/twenty-server/src/modules/messaging/message-outbound-manager/resolvers/send-email.resolver.ts
+++ b/packages/twenty-server/src/modules/messaging/message-outbound-manager/resolvers/send-email.resolver.ts
@@ -107,7 +107,11 @@ export class SendEmailResolver {
         throw error;
       }
 
-      this.logger.error(`Failed to send email: ${error}`);
+      this.logger.error(`Failed to send email: ${error}`, {
+        stack: error instanceof Error ? error.stack : undefined,
+        response: (error as any)?.response,
+        responseStatus: (error as any)?.responseStatus,
+      });
 
       return {
         success: false,


### PR DESCRIPTION
Fixes #20469

Two small but impactful changes to the Gmail IMAP send path:

**Better error visibility**

The catch block in `SendEmailResolver.sendEmail` was doing:
```ts
this.logger.error(`Failed to send email: ${error}`);
```
This discards the imapflow-specific `response` and `responseStatus` fields that tell you *why* an APPEND failed (e.g. `NO [TRYCREATE]` when the folder path is wrong). Now the full context is included in the log, making future debugging much faster.

**Regression test for Gmail-style namespaced folders**

Gmail puts its special folders under `[Gmail]/` — so the IMAP LIST returns `path: '[Gmail]/Sent Mail'`, `name: 'Sent Mail'`. If anything ever stores the leaf name and tries to APPEND to it, Gmail returns `NO [TRYCREATE]` and the send appears to fail even though the message was delivered.

The new test asserts that `externalId` encodes the full path (`[Gmail]/Sent Mail:uidValidity`) so that `getImapFolderPath()` always resolves to the correct IMAP APPEND target — not the bare leaf name.

No behaviour changes beyond improved logging. Existing tests still pass.