### PR TITLE
fix: address review feedback on relation traversal filter (stacked on #20533)

### DIFF
--- a/packages/twenty-front/src/modules/object-record/advanced-filter/components/AdvancedFilterSubFieldSelectMenu.tsx
+++ b/packages/twenty-front/src/modules/object-record/advanced-filter/components/AdvancedFilterSubFieldSelectMenu.tsx
@@ -135,7 +135,7 @@ export const AdvancedFilterSubFieldSelectMenu = ({
     );
 
   const selectableItemIdArray = isRelationSubMenu
-    ? ['-1', ...relationTargetFields.map((field) => field.id)]
+    ? relationTargetFields.map((field) => field.id)
     : ['-1', ...subFieldNames.map((subFieldName) => subFieldName)];
 
   const fieldLabel = fieldMetadataItemUsedInDropdown?.label;

--- a/packages/twenty-server/src/engine/api/common/common-args-processors/filter-arg-processor/filter-arg-processor.service.ts
+++ b/packages/twenty-server/src/engine/api/common/common-args-processors/filter-arg-processor/filter-arg-processor.service.ts
@@ -41,6 +41,30 @@ function throwUseJoinColumnInstead(key: string): never {
   );
 }
 
+// GraphQL leaf-operator names. A filter whose keys are exclusively these is
+// never a relation traversal — even if a custom field happens to share one of
+// these names. This prevents `{ eq: "uuid" }` from being misclassified as a
+// traversal when someone creates a field called "eq".
+const GRAPHQL_LEAF_OPERATORS = new Set([
+  'eq',
+  'neq',
+  'in',
+  'is',
+  'like',
+  'ilike',
+  'gt',
+  'gte',
+  'lt',
+  'lte',
+  'startsWith',
+  'endsWith',
+  'regex',
+  'search',
+  'containsAny',
+  'isEmptyArray',
+  'containsIlike',
+]);
+
 // A relation filter is treated as a traversal (`{ name: { eq: "X" } }`) when
 // at least one top-level key matches a field on the target object or is a
 // logical operator (`and`/`or`/`not`). Otherwise the value looks like a leaf
@@ -69,8 +93,9 @@ const isRelationTraversalShape = ({
       k === 'and' ||
       k === 'or' ||
       k === 'not' ||
-      isDefined(targetFieldIdByName[k]) ||
-      isDefined(targetFieldIdByJoinColumnName[k]),
+      (!GRAPHQL_LEAF_OPERATORS.has(k) &&
+        (isDefined(targetFieldIdByName[k]) ||
+          isDefined(targetFieldIdByJoinColumnName[k]))),
   );
 };
 

--- a/packages/twenty-shared/src/utils/filter/turnRecordFilterIntoGqlOperationFilter.ts
+++ b/packages/twenty-shared/src/utils/filter/turnRecordFilterIntoGqlOperationFilter.ts
@@ -87,10 +87,22 @@ export const turnRecordFilterIntoRecordGqlOperationFilter = ({
     return;
   }
 
-  const shouldComputeEmptinessFilter = checkIfShouldComputeEmptinessFilter({
-    recordFilterOperand: recordFilter.operand,
-    correspondingFieldMetadataItem,
-  });
+  const subFieldName = recordFilter.subFieldName;
+
+  const isSubFieldFilter = isNonEmptyString(subFieldName);
+
+  // For relation traversals IS_EMPTY / IS_NOT_EMPTY apply to the target field,
+  // not the FK column — the traversal branch below recurses and handles them.
+  const isRelationTraversal =
+    correspondingFieldMetadataItem.type === FieldMetadataType.RELATION &&
+    isSubFieldFilter;
+
+  const shouldComputeEmptinessFilter =
+    !isRelationTraversal &&
+    checkIfShouldComputeEmptinessFilter({
+      recordFilterOperand: recordFilter.operand,
+      correspondingFieldMetadataItem,
+    });
 
   if (shouldComputeEmptinessFilter) {
     const emptinessFilter = getEmptyRecordGqlOperationFilter({
@@ -102,20 +114,13 @@ export const turnRecordFilterIntoRecordGqlOperationFilter = ({
     return emptinessFilter;
   }
 
-  const subFieldName = recordFilter.subFieldName;
-
-  const isSubFieldFilter = isNonEmptyString(subFieldName);
-
   // Relation traversal: the record filter targets a field on the related
   // object (e.g. `company.name`). The frontend already stored the target
   // field's type on `recordFilter.type`, so we synthesize a field metadata
   // for the target, recurse to build the inner filter, then wrap the result
   // under the relation field's name to produce
   // `{ relationName: { targetFieldName: { operator: value } } }`.
-  if (
-    correspondingFieldMetadataItem.type === FieldMetadataType.RELATION &&
-    isSubFieldFilter
-  ) {
+  if (isRelationTraversal) {
     const syntheticTargetFieldId = `__relation-traversal-target__${correspondingFieldMetadataItem.id}`;
 
     const syntheticTargetField: FieldShared = {


### PR DESCRIPTION
Stacked on #20533 — three issues flagged in the review.

## Changes

**1. IS_EMPTY / IS_NOT_EMPTY on relation sub-fields returned wrong filter**

Picking `Company → Name → is empty` was hitting the emptiness short-circuit before the traversal branch ran, producing `{ companyId: { is: NULL } }` instead of `{ company: { name: { is: NULL } } }`. Fixed by resolving `subFieldName` before the emptiness guard and skipping the guard for relation traversals.

**2. Ghost `-1` entry broke keyboard navigation in the relation sub-menu**

`selectableItemIdArray` included `'-1'` (the "Any field" composite item) in the relation branch even though it's never rendered there. First arrow-down was wasted on the invisible item. Removed it.

**3. `isRelationTraversalShape` could misclassify filters on fields named after GraphQL operators**

If a workspace had a custom field named `eq`, `in`, `like`, etc., a plain scalar filter `{ eq: "value" }` would be treated as a relation traversal and fail with a confusing error. Added `GRAPHQL_LEAF_OPERATORS` set; those keys are now excluded from the field-name check.

## Test plan

- [ ] `Company → Name → is empty` filter returns people with no company name, not people with no company
- [ ] Arrow-down in the relation sub-menu lands on the first field immediately
- [ ] Creating a custom field named `eq` and filtering by it does not throw a traversal error

Made with [Cursor](https://cursor.com)