### PR TITLE
feat(upgrade): emit structured logfmt logs for upgrade flow

### DIFF
--- a/packages/twenty-server/src/database/commands/upgrade-version-command/upgrade.command.ts
+++ b/packages/twenty-server/src/database/commands/upgrade-version-command/upgrade.command.ts
@@ -122,6 +122,9 @@ export class UpgradeCommand extends CommandRunner {
       );
     }
 
+    let totalSuccesses = 0;
+    let totalFailures = 0;
+
     try {
       const sequence = this.upgradeSequenceReaderService.getUpgradeSequence();
 
@@ -151,16 +154,17 @@ export class UpgradeCommand extends CommandRunner {
         );
       }
 
-      const { totalSuccesses, totalFailures } =
-        await this.upgradeSequenceRunnerService.run({
-          sequence,
-          options: {
-            ...options,
-            workspaceIds: isDefined(options.workspaceId)
-              ? Array.from(options.workspaceId)
-              : undefined,
-          },
-        });
+      const report = await this.upgradeSequenceRunnerService.run({
+        sequence,
+        options: {
+          ...options,
+          workspaceIds: isDefined(options.workspaceId)
+            ? Array.from(options.workspaceId)
+            : undefined,
+        },
+      });
+      totalSuccesses = report.totalSuccesses;
+      totalFailures = report.totalFailures;
 
       this.logger.log(
         formatUpgradeLog({
@@ -173,12 +177,6 @@ export class UpgradeCommand extends CommandRunner {
           },
         }),
       );
-
-      if (totalFailures > 0) {
-        throw new Error(
-          `Upgrade completed with ${totalFailures} workspace failure(s)`,
-        );
-      }
     } catch (error) {
       const errorMessage =
         error instanceof Error ? error.message : String(error);
@@ -191,6 +189,12 @@ export class UpgradeCommand extends CommandRunner {
         }),
       );
       throw error;
+    }
+
+    if (totalFailures > 0) {
+      throw new Error(
+        `Upgrade completed with ${totalFailures} workspace failure(s)`,
+      );
     }
   }
 }

--- a/packages/twenty-server/src/database/commands/upgrade-version-command/upgrade.command.ts
+++ b/packages/twenty-server/src/database/commands/upgrade-version-command/upgrade.command.ts
@@ -126,19 +126,27 @@ export class UpgradeCommand extends CommandRunner {
       const sequence = this.upgradeSequenceReaderService.getUpgradeSequence();
 
       this.logger.log(
-        formatUpgradeLog('sequence.initialized', {
-          stepCount: sequence.length,
-          dryRun: options.dryRun ?? false,
+        formatUpgradeLog({
+          message: `Initialized upgrade sequence: ${sequence.length} step(s)`,
+          event: 'sequence.initialized',
+          fields: {
+            stepCount: sequence.length,
+            dryRun: options.dryRun ?? false,
+          },
         }),
       );
 
       for (const [index, step] of sequence.entries()) {
         this.logger.verbose(
-          formatUpgradeLog('sequence.step', {
-            index,
-            kind: step.kind,
-            name: step.name,
-            version: step.version,
+          formatUpgradeLog({
+            message: `  [${index}] ${step.kind} — ${step.name} (${step.version})`,
+            event: 'sequence.step',
+            fields: {
+              index,
+              kind: step.kind,
+              name: step.name,
+              version: step.version,
+            },
           }),
         );
       }
@@ -155,10 +163,14 @@ export class UpgradeCommand extends CommandRunner {
         });
 
       this.logger.log(
-        formatUpgradeLog('summary', {
-          totalSuccesses,
-          totalFailures,
-          dryRun: options.dryRun ?? false,
+        formatUpgradeLog({
+          message: `Upgrade summary: ${totalSuccesses} workspace(s) succeeded, ${totalFailures} workspace(s) failed`,
+          event: 'summary',
+          fields: {
+            totalSuccesses,
+            totalFailures,
+            dryRun: options.dryRun ?? false,
+          },
         }),
       );
 
@@ -168,9 +180,14 @@ export class UpgradeCommand extends CommandRunner {
         );
       }
     } catch (error) {
+      const errorMessage =
+        error instanceof Error ? error.message : String(error);
+
       this.logger.error(
-        formatUpgradeLog('aborted', {
-          error: error instanceof Error ? error.message : String(error),
+        formatUpgradeLog({
+          message: `Upgrade failed: ${errorMessage}`,
+          event: 'aborted',
+          fields: { error: errorMessage },
         }),
       );
       throw error;

--- a/packages/twenty-server/src/database/commands/upgrade-version-command/upgrade.command.ts
+++ b/packages/twenty-server/src/database/commands/upgrade-version-command/upgrade.command.ts
@@ -122,9 +122,6 @@ export class UpgradeCommand extends CommandRunner {
       );
     }
 
-    let totalSuccesses = 0;
-    let totalFailures = 0;
-
     try {
       const sequence = this.upgradeSequenceReaderService.getUpgradeSequence();
 
@@ -154,17 +151,16 @@ export class UpgradeCommand extends CommandRunner {
         );
       }
 
-      const report = await this.upgradeSequenceRunnerService.run({
-        sequence,
-        options: {
-          ...options,
-          workspaceIds: isDefined(options.workspaceId)
-            ? Array.from(options.workspaceId)
-            : undefined,
-        },
-      });
-      totalSuccesses = report.totalSuccesses;
-      totalFailures = report.totalFailures;
+      const { totalSuccesses, totalFailures } =
+        await this.upgradeSequenceRunnerService.run({
+          sequence,
+          options: {
+            ...options,
+            workspaceIds: isDefined(options.workspaceId)
+              ? Array.from(options.workspaceId)
+              : undefined,
+          },
+        });
 
       this.logger.log(
         formatUpgradeLog({
@@ -177,6 +173,12 @@ export class UpgradeCommand extends CommandRunner {
           },
         }),
       );
+
+      if (totalFailures > 0) {
+        throw new Error(
+          `Upgrade completed with ${totalFailures} workspace failure(s)`,
+        );
+      }
     } catch (error) {
       const errorMessage =
         error instanceof Error ? error.message : String(error);
@@ -189,12 +191,6 @@ export class UpgradeCommand extends CommandRunner {
         }),
       );
       throw error;
-    }
-
-    if (totalFailures > 0) {
-      throw new Error(
-        `Upgrade completed with ${totalFailures} workspace failure(s)`,
-      );
     }
   }
 }

--- a/packages/twenty-server/src/database/commands/upgrade-version-command/upgrade.command.ts
+++ b/packages/twenty-server/src/database/commands/upgrade-version-command/upgrade.command.ts
@@ -127,9 +127,9 @@ export class UpgradeCommand extends CommandRunner {
 
       this.logger.log(
         formatUpgradeLog({
-          message: `Initialized upgrade sequence: ${sequence.length} step(s)`,
+          humanMessage: `Initialized upgrade sequence: ${sequence.length} step(s)`,
           event: 'sequence.initialized',
-          fields: {
+          logFields: {
             stepCount: sequence.length,
             dryRun: options.dryRun ?? false,
           },
@@ -139,9 +139,9 @@ export class UpgradeCommand extends CommandRunner {
       for (const [index, step] of sequence.entries()) {
         this.logger.verbose(
           formatUpgradeLog({
-            message: `  [${index}] ${step.kind} — ${step.name} (${step.version})`,
+            humanMessage: `  [${index}] ${step.kind} — ${step.name} (${step.version})`,
             event: 'sequence.step',
-            fields: {
+            logFields: {
               index,
               kind: step.kind,
               name: step.name,
@@ -164,9 +164,9 @@ export class UpgradeCommand extends CommandRunner {
 
       this.logger.log(
         formatUpgradeLog({
-          message: `Upgrade summary: ${totalSuccesses} workspace(s) succeeded, ${totalFailures} workspace(s) failed`,
+          humanMessage: `Upgrade summary: ${totalSuccesses} workspace(s) succeeded, ${totalFailures} workspace(s) failed`,
           event: 'summary',
-          fields: {
+          logFields: {
             totalSuccesses,
             totalFailures,
             dryRun: options.dryRun ?? false,
@@ -185,9 +185,8 @@ export class UpgradeCommand extends CommandRunner {
 
       this.logger.error(
         formatUpgradeLog({
-          message: `Upgrade failed: ${errorMessage}`,
+          humanMessage: `Upgrade failed: ${errorMessage}`,
           event: 'aborted',
-          fields: { error: errorMessage },
         }),
       );
       throw error;

--- a/packages/twenty-server/src/database/commands/upgrade-version-command/upgrade.command.ts
+++ b/packages/twenty-server/src/database/commands/upgrade-version-command/upgrade.command.ts
@@ -1,10 +1,10 @@
-import chalk from 'chalk';
 import { Command, CommandRunner, Option } from 'nest-commander';
 import { isDefined } from 'twenty-shared/utils';
 
 import { CommandLogger } from 'src/database/commands/logger';
 import { UpgradeSequenceReaderService } from 'src/engine/core-modules/upgrade/services/upgrade-sequence-reader.service';
 import { UpgradeSequenceRunnerService } from 'src/engine/core-modules/upgrade/services/upgrade-sequence-runner.service';
+import { formatUpgradeLog } from 'src/engine/core-modules/upgrade/utils/format-upgrade-log.util';
 
 type RawUpgradeCommandOptions = {
   workspaceId?: Set<string>;
@@ -126,17 +126,22 @@ export class UpgradeCommand extends CommandRunner {
       const sequence = this.upgradeSequenceReaderService.getUpgradeSequence();
 
       this.logger.log(
-        chalk.blue(
-          [
-            'Initialized upgrade sequence:',
-            `- ${sequence.length} step(s)`,
-            ...sequence.map(
-              (step, index) =>
-                `  [${index}] ${step.kind} — ${step.name} (${step.version})`,
-            ),
-          ].join('\n   '),
-        ),
+        formatUpgradeLog('sequence.initialized', {
+          stepCount: sequence.length,
+          dryRun: options.dryRun ?? false,
+        }),
       );
+
+      for (const [index, step] of sequence.entries()) {
+        this.logger.verbose(
+          formatUpgradeLog('sequence.step', {
+            index,
+            kind: step.kind,
+            name: step.name,
+            version: step.version,
+          }),
+        );
+      }
 
       const { totalSuccesses, totalFailures } =
         await this.upgradeSequenceRunnerService.run({
@@ -150,9 +155,11 @@ export class UpgradeCommand extends CommandRunner {
         });
 
       this.logger.log(
-        chalk.blue(
-          `Upgrade summary: ${totalSuccesses} workspace(s) succeeded, ${totalFailures} workspace(s) failed`,
-        ),
+        formatUpgradeLog('summary', {
+          totalSuccesses,
+          totalFailures,
+          dryRun: options.dryRun ?? false,
+        }),
       );
 
       if (totalFailures > 0) {
@@ -161,7 +168,11 @@ export class UpgradeCommand extends CommandRunner {
         );
       }
     } catch (error) {
-      this.logger.error(chalk.red(`Upgrade failed: ${error.message}`));
+      this.logger.error(
+        formatUpgradeLog('aborted', {
+          error: error instanceof Error ? error.message : String(error),
+        }),
+      );
       throw error;
     }
   }

--- a/packages/twenty-server/src/engine/core-modules/upgrade/services/instance-command-runner.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/upgrade/services/instance-command-runner.service.ts
@@ -8,7 +8,6 @@ import { type FastInstanceCommand } from 'src/engine/core-modules/upgrade/interf
 import { type SlowInstanceCommand } from 'src/engine/core-modules/upgrade/interfaces/slow-instance-command.interface';
 import { UpgradeMigrationService } from 'src/engine/core-modules/upgrade/services/upgrade-migration.service';
 import { UpgradeStatusService } from 'src/engine/core-modules/upgrade/services/upgrade-status.service';
-import { formatUpgradeLog } from 'src/engine/core-modules/upgrade/utils/format-upgrade-log.util';
 import { WorkspaceVersionService } from 'src/engine/workspace-manager/workspace-version/services/workspace-version.service';
 
 type RunSingleMigrationResult =
@@ -46,13 +45,7 @@ export class InstanceCommandRunnerService {
       });
 
     if (isAlreadyCompleted) {
-      this.logger.log(
-        formatUpgradeLog({
-          message: `${name} already executed, skipping`,
-          event: 'instance.skipped',
-          fields: { command: name, reason: 'already-executed' },
-        }),
-      );
+      this.logger.log(`${name} already executed, skipping`);
 
       return { status: 'already-executed' };
     }
@@ -81,13 +74,7 @@ export class InstanceCommandRunnerService {
 
       await queryRunner.commitTransaction();
 
-      this.logger.log(
-        formatUpgradeLog({
-          message: `${name} executed successfully`,
-          event: 'instance.success',
-          fields: { command: name, executedByVersion },
-        }),
-      );
+      this.logger.log(`${name} executed successfully`);
 
       return { status: 'success' };
     } catch (error) {
@@ -107,19 +94,8 @@ export class InstanceCommandRunnerService {
         error,
       });
 
-      const errorMessage =
-        error instanceof Error ? error.message : String(error);
-
       this.logger.error(
-        formatUpgradeLog({
-          message: `${name} failed: ${errorMessage}`,
-          event: 'instance.failed',
-          fields: {
-            command: name,
-            executedByVersion,
-            error: errorMessage,
-          },
-        }),
+        `${name} failed`,
         error instanceof Error ? error.stack : String(error),
       );
 
@@ -134,18 +110,10 @@ export class InstanceCommandRunnerService {
     try {
       await this.upgradeStatusService.invalidateInstanceAndAllWorkspacesStatus();
     } catch (error) {
-      const errorMessage =
-        error instanceof Error ? error.message : String(error);
-
       this.logger.warn(
-        formatUpgradeLog({
-          message: `Failed to invalidate upgrade-status cache: ${errorMessage}`,
-          event: 'cache.invalidate.failed',
-          fields: {
-            scope: 'instance-and-all-workspaces',
-            error: errorMessage,
-          },
-        }),
+        `Failed to invalidate upgrade-status cache: ${
+          error instanceof Error ? error.message : String(error)
+        }`,
       );
     }
   }
@@ -166,13 +134,7 @@ export class InstanceCommandRunnerService {
       });
 
     if (isAlreadyCompleted) {
-      this.logger.log(
-        formatUpgradeLog({
-          message: `${name} already executed, skipping`,
-          event: 'instance.skipped',
-          fields: { command: name, reason: 'already-executed' },
-        }),
-      );
+      this.logger.log(`${name} already executed, skipping`);
 
       return { status: 'already-executed' };
     }
@@ -182,21 +144,9 @@ export class InstanceCommandRunnerService {
         this.twentyConfigService.get('APP_VERSION') ?? 'unknown';
 
       try {
-        this.logger.log(
-          formatUpgradeLog({
-            message: `${name} starting data migration...`,
-            event: 'instance.data_migration.start',
-            fields: { command: name },
-          }),
-        );
+        this.logger.log(`${name} starting data migration...`);
         await command.runDataMigration(this.dataSource);
-        this.logger.log(
-          formatUpgradeLog({
-            message: `${name} data migration completed`,
-            event: 'instance.data_migration.success',
-            fields: { command: name },
-          }),
-        );
+        this.logger.log(`${name} data migration completed`);
       } catch (error) {
         const workspaceIds =
           await this.workspaceVersionService.getActiveOrSuspendedWorkspaceIds();
@@ -210,19 +160,8 @@ export class InstanceCommandRunnerService {
           error,
         });
 
-        const errorMessage =
-          error instanceof Error ? error.message : String(error);
-
         this.logger.error(
-          formatUpgradeLog({
-            message: `${name} data migration failed: ${errorMessage}`,
-            event: 'instance.data_migration.failed',
-            fields: {
-              command: name,
-              executedByVersion,
-              error: errorMessage,
-            },
-          }),
+          `${name} data migration failed`,
           error instanceof Error ? error.stack : String(error),
         );
 

--- a/packages/twenty-server/src/engine/core-modules/upgrade/services/instance-command-runner.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/upgrade/services/instance-command-runner.service.ts
@@ -8,6 +8,7 @@ import { type FastInstanceCommand } from 'src/engine/core-modules/upgrade/interf
 import { type SlowInstanceCommand } from 'src/engine/core-modules/upgrade/interfaces/slow-instance-command.interface';
 import { UpgradeMigrationService } from 'src/engine/core-modules/upgrade/services/upgrade-migration.service';
 import { UpgradeStatusService } from 'src/engine/core-modules/upgrade/services/upgrade-status.service';
+import { formatUpgradeLog } from 'src/engine/core-modules/upgrade/utils/format-upgrade-log.util';
 import { WorkspaceVersionService } from 'src/engine/workspace-manager/workspace-version/services/workspace-version.service';
 
 type RunSingleMigrationResult =
@@ -45,7 +46,12 @@ export class InstanceCommandRunnerService {
       });
 
     if (isAlreadyCompleted) {
-      this.logger.log(`${name} already executed, skipping`);
+      this.logger.log(
+        formatUpgradeLog('instance.skipped', {
+          command: name,
+          reason: 'already-executed',
+        }),
+      );
 
       return { status: 'already-executed' };
     }
@@ -74,7 +80,12 @@ export class InstanceCommandRunnerService {
 
       await queryRunner.commitTransaction();
 
-      this.logger.log(`${name} executed successfully`);
+      this.logger.log(
+        formatUpgradeLog('instance.success', {
+          command: name,
+          executedByVersion,
+        }),
+      );
 
       return { status: 'success' };
     } catch (error) {
@@ -95,7 +106,11 @@ export class InstanceCommandRunnerService {
       });
 
       this.logger.error(
-        `${name} failed`,
+        formatUpgradeLog('instance.failed', {
+          command: name,
+          executedByVersion,
+          error: error instanceof Error ? error.message : String(error),
+        }),
         error instanceof Error ? error.stack : String(error),
       );
 
@@ -111,9 +126,10 @@ export class InstanceCommandRunnerService {
       await this.upgradeStatusService.invalidateInstanceAndAllWorkspacesStatus();
     } catch (error) {
       this.logger.warn(
-        `Failed to invalidate upgrade-status cache: ${
-          error instanceof Error ? error.message : String(error)
-        }`,
+        formatUpgradeLog('cache.invalidate.failed', {
+          scope: 'instance-and-all-workspaces',
+          error: error instanceof Error ? error.message : String(error),
+        }),
       );
     }
   }
@@ -134,7 +150,12 @@ export class InstanceCommandRunnerService {
       });
 
     if (isAlreadyCompleted) {
-      this.logger.log(`${name} already executed, skipping`);
+      this.logger.log(
+        formatUpgradeLog('instance.skipped', {
+          command: name,
+          reason: 'already-executed',
+        }),
+      );
 
       return { status: 'already-executed' };
     }
@@ -144,9 +165,15 @@ export class InstanceCommandRunnerService {
         this.twentyConfigService.get('APP_VERSION') ?? 'unknown';
 
       try {
-        this.logger.log(`${name} starting data migration...`);
+        this.logger.log(
+          formatUpgradeLog('instance.data_migration.start', { command: name }),
+        );
         await command.runDataMigration(this.dataSource);
-        this.logger.log(`${name} data migration completed`);
+        this.logger.log(
+          formatUpgradeLog('instance.data_migration.success', {
+            command: name,
+          }),
+        );
       } catch (error) {
         const workspaceIds =
           await this.workspaceVersionService.getActiveOrSuspendedWorkspaceIds();
@@ -161,7 +188,11 @@ export class InstanceCommandRunnerService {
         });
 
         this.logger.error(
-          `${name} data migration failed`,
+          formatUpgradeLog('instance.data_migration.failed', {
+            command: name,
+            executedByVersion,
+            error: error instanceof Error ? error.message : String(error),
+          }),
           error instanceof Error ? error.stack : String(error),
         );
 

--- a/packages/twenty-server/src/engine/core-modules/upgrade/services/instance-command-runner.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/upgrade/services/instance-command-runner.service.ts
@@ -47,9 +47,10 @@ export class InstanceCommandRunnerService {
 
     if (isAlreadyCompleted) {
       this.logger.log(
-        formatUpgradeLog('instance.skipped', {
-          command: name,
-          reason: 'already-executed',
+        formatUpgradeLog({
+          message: `${name} already executed, skipping`,
+          event: 'instance.skipped',
+          fields: { command: name, reason: 'already-executed' },
         }),
       );
 
@@ -81,9 +82,10 @@ export class InstanceCommandRunnerService {
       await queryRunner.commitTransaction();
 
       this.logger.log(
-        formatUpgradeLog('instance.success', {
-          command: name,
-          executedByVersion,
+        formatUpgradeLog({
+          message: `${name} executed successfully`,
+          event: 'instance.success',
+          fields: { command: name, executedByVersion },
         }),
       );
 
@@ -105,11 +107,18 @@ export class InstanceCommandRunnerService {
         error,
       });
 
+      const errorMessage =
+        error instanceof Error ? error.message : String(error);
+
       this.logger.error(
-        formatUpgradeLog('instance.failed', {
-          command: name,
-          executedByVersion,
-          error: error instanceof Error ? error.message : String(error),
+        formatUpgradeLog({
+          message: `${name} failed: ${errorMessage}`,
+          event: 'instance.failed',
+          fields: {
+            command: name,
+            executedByVersion,
+            error: errorMessage,
+          },
         }),
         error instanceof Error ? error.stack : String(error),
       );
@@ -125,10 +134,17 @@ export class InstanceCommandRunnerService {
     try {
       await this.upgradeStatusService.invalidateInstanceAndAllWorkspacesStatus();
     } catch (error) {
+      const errorMessage =
+        error instanceof Error ? error.message : String(error);
+
       this.logger.warn(
-        formatUpgradeLog('cache.invalidate.failed', {
-          scope: 'instance-and-all-workspaces',
-          error: error instanceof Error ? error.message : String(error),
+        formatUpgradeLog({
+          message: `Failed to invalidate upgrade-status cache: ${errorMessage}`,
+          event: 'cache.invalidate.failed',
+          fields: {
+            scope: 'instance-and-all-workspaces',
+            error: errorMessage,
+          },
         }),
       );
     }
@@ -151,9 +167,10 @@ export class InstanceCommandRunnerService {
 
     if (isAlreadyCompleted) {
       this.logger.log(
-        formatUpgradeLog('instance.skipped', {
-          command: name,
-          reason: 'already-executed',
+        formatUpgradeLog({
+          message: `${name} already executed, skipping`,
+          event: 'instance.skipped',
+          fields: { command: name, reason: 'already-executed' },
         }),
       );
 
@@ -166,12 +183,18 @@ export class InstanceCommandRunnerService {
 
       try {
         this.logger.log(
-          formatUpgradeLog('instance.data_migration.start', { command: name }),
+          formatUpgradeLog({
+            message: `${name} starting data migration...`,
+            event: 'instance.data_migration.start',
+            fields: { command: name },
+          }),
         );
         await command.runDataMigration(this.dataSource);
         this.logger.log(
-          formatUpgradeLog('instance.data_migration.success', {
-            command: name,
+          formatUpgradeLog({
+            message: `${name} data migration completed`,
+            event: 'instance.data_migration.success',
+            fields: { command: name },
           }),
         );
       } catch (error) {
@@ -187,11 +210,18 @@ export class InstanceCommandRunnerService {
           error,
         });
 
+        const errorMessage =
+          error instanceof Error ? error.message : String(error);
+
         this.logger.error(
-          formatUpgradeLog('instance.data_migration.failed', {
-            command: name,
-            executedByVersion,
-            error: error instanceof Error ? error.message : String(error),
+          formatUpgradeLog({
+            message: `${name} data migration failed: ${errorMessage}`,
+            event: 'instance.data_migration.failed',
+            fields: {
+              command: name,
+              executedByVersion,
+              error: errorMessage,
+            },
           }),
           error instanceof Error ? error.stack : String(error),
         );

--- a/packages/twenty-server/src/engine/core-modules/upgrade/services/upgrade-sequence-runner.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/upgrade/services/upgrade-sequence-runner.service.ts
@@ -76,9 +76,16 @@ export class UpgradeSequenceRunnerService {
           isDefined(options.workspaceCountLimit)
         ) {
           this.logger.log(
-            formatUpgradeLog('sequence.stopped', {
-              before: step.name,
-              reason: 'workspace-filter-active',
+            formatUpgradeLog({
+              message:
+                `Stopping before instance step "${step.name}": ` +
+                'upgrade was run with a workspace filter (-w, --start-from-workspace-id, or --workspace-count-limit). ' +
+                'Instance commands require all workspaces to be aligned.',
+              event: 'sequence.stopped',
+              fields: {
+                before: step.name,
+                reason: 'workspace-filter-active',
+              },
             }),
           );
 
@@ -122,9 +129,15 @@ export class UpgradeSequenceRunnerService {
 
       if (report.fail.length > 0) {
         this.logger.error(
-          formatUpgradeLog('sequence.aborted', {
-            failures: report.fail.length,
-            reason: 'workspace-failures',
+          formatUpgradeLog({
+            message:
+              `Workspace steps ended with ${report.fail.length} failure(s). ` +
+              'Aborting — cannot proceed to next instance step.',
+            event: 'sequence.aborted',
+            fields: {
+              failures: report.fail.length,
+              reason: 'workspace-failures',
+            },
           }),
         );
 

--- a/packages/twenty-server/src/engine/core-modules/upgrade/services/upgrade-sequence-runner.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/upgrade/services/upgrade-sequence-runner.service.ts
@@ -17,6 +17,7 @@ import {
   UpgradeSequenceReaderService,
 } from 'src/engine/core-modules/upgrade/services/upgrade-sequence-reader.service';
 import { WorkspaceCommandRunnerService } from 'src/engine/core-modules/upgrade/services/workspace-command-runner.service';
+import { formatUpgradeLog } from 'src/engine/core-modules/upgrade/utils/format-upgrade-log.util';
 import { WorkspaceVersionService } from 'src/engine/workspace-manager/workspace-version/services/workspace-version.service';
 import { assertUnreachable, isDefined } from 'twenty-shared/utils';
 
@@ -75,9 +76,10 @@ export class UpgradeSequenceRunnerService {
           isDefined(options.workspaceCountLimit)
         ) {
           this.logger.log(
-            `Stopping before instance step "${step.name}": ` +
-              'upgrade was run with a workspace filter (-w, --start-from-workspace-id, or --workspace-count-limit). ' +
-              'Instance commands require all workspaces to be aligned.',
+            formatUpgradeLog('sequence.stopped', {
+              before: step.name,
+              reason: 'workspace-filter-active',
+            }),
           );
 
           break;
@@ -120,8 +122,10 @@ export class UpgradeSequenceRunnerService {
 
       if (report.fail.length > 0) {
         this.logger.error(
-          `Workspace steps ended with ${report.fail.length} failure(s). ` +
-            'Aborting — cannot proceed to next instance step.',
+          formatUpgradeLog('sequence.aborted', {
+            failures: report.fail.length,
+            reason: 'workspace-failures',
+          }),
         );
 
         return { totalSuccesses, totalFailures };

--- a/packages/twenty-server/src/engine/core-modules/upgrade/services/upgrade-sequence-runner.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/upgrade/services/upgrade-sequence-runner.service.ts
@@ -77,12 +77,12 @@ export class UpgradeSequenceRunnerService {
         ) {
           this.logger.log(
             formatUpgradeLog({
-              message:
+              humanMessage:
                 `Stopping before instance step "${step.name}": ` +
                 'upgrade was run with a workspace filter (-w, --start-from-workspace-id, or --workspace-count-limit). ' +
                 'Instance commands require all workspaces to be aligned.',
               event: 'sequence.stopped',
-              fields: {
+              logFields: {
                 before: step.name,
                 reason: 'workspace-filter-active',
               },
@@ -130,11 +130,11 @@ export class UpgradeSequenceRunnerService {
       if (report.fail.length > 0) {
         this.logger.error(
           formatUpgradeLog({
-            message:
+            humanMessage:
               `Workspace steps ended with ${report.fail.length} failure(s). ` +
               'Aborting — cannot proceed to next instance step.',
             event: 'sequence.aborted',
-            fields: {
+            logFields: {
               failures: report.fail.length,
               reason: 'workspace-failures',
             },

--- a/packages/twenty-server/src/engine/core-modules/upgrade/services/workspace-command-runner.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/upgrade/services/workspace-command-runner.service.ts
@@ -36,12 +36,18 @@ export class WorkspaceCommandRunnerService {
   }: RunWorkspaceCommandsArgs): Promise<void> {
     const { workspaceId, index, total } = iteratorContext;
 
+    const dryRunPrefix = options.dryRun ? '(dry run) ' : '';
+
     this.logger.log(
-      formatUpgradeLog('workspace.start', {
-        workspaceId,
-        index: index + 1,
-        total,
-        dryRun: options.dryRun ?? false,
+      formatUpgradeLog({
+        message: `${dryRunPrefix}Upgrading workspace ${workspaceId} ${index + 1}/${total}`,
+        event: 'workspace.start',
+        fields: {
+          workspaceId,
+          index: index + 1,
+          total,
+          dryRun: options.dryRun ?? false,
+        },
       }),
     );
 
@@ -60,10 +66,14 @@ export class WorkspaceCommandRunnerService {
       }
 
       this.logger.log(
-        formatUpgradeLog('workspace.success', {
-          workspaceId,
-          executedByVersion,
-          dryRun: options.dryRun ?? false,
+        formatUpgradeLog({
+          message: `Upgrade for workspace ${workspaceId} completed.`,
+          event: 'workspace.success',
+          fields: {
+            workspaceId,
+            executedByVersion,
+            dryRun: options.dryRun ?? false,
+          },
         }),
       );
     } finally {
@@ -77,10 +87,14 @@ export class WorkspaceCommandRunnerService {
     try {
       await this.upgradeStatusService.invalidateInstanceAndAllWorkspacesStatus();
     } catch (error) {
+      const errorMessage =
+        error instanceof Error ? error.message : String(error);
+
       this.logger.warn(
-        formatUpgradeLog('cache.invalidate.failed', {
-          workspaceId,
-          error: error instanceof Error ? error.message : String(error),
+        formatUpgradeLog({
+          message: `Failed to invalidate upgrade-status cache for workspace ${workspaceId}: ${errorMessage}`,
+          event: 'cache.invalidate.failed',
+          fields: { workspaceId, error: errorMessage },
         }),
       );
     }
@@ -131,13 +145,20 @@ export class WorkspaceCommandRunnerService {
         });
       }
 
+      const errorMessage =
+        error instanceof Error ? error.message : String(error);
+
       this.logger.error(
-        formatUpgradeLog('workspace.failed', {
-          workspaceId,
-          command: name,
-          executedByVersion,
-          dryRun: options.dryRun ?? false,
-          error: error instanceof Error ? error.message : String(error),
+        formatUpgradeLog({
+          message: `Workspace ${workspaceId} failed on ${name}: ${errorMessage}`,
+          event: 'workspace.failed',
+          fields: {
+            workspaceId,
+            command: name,
+            executedByVersion,
+            dryRun: options.dryRun ?? false,
+            error: errorMessage,
+          },
         }),
         error instanceof Error ? error.stack : undefined,
       );

--- a/packages/twenty-server/src/engine/core-modules/upgrade/services/workspace-command-runner.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/upgrade/services/workspace-command-runner.service.ts
@@ -6,6 +6,7 @@ import { TwentyConfigService } from 'src/engine/core-modules/twenty-config/twent
 import { type RegisteredWorkspaceCommand } from 'src/engine/core-modules/upgrade/services/upgrade-command-registry.service';
 import { UpgradeMigrationService } from 'src/engine/core-modules/upgrade/services/upgrade-migration.service';
 import { UpgradeStatusService } from 'src/engine/core-modules/upgrade/services/upgrade-status.service';
+import { formatUpgradeLog } from 'src/engine/core-modules/upgrade/utils/format-upgrade-log.util';
 
 type WorkspaceCommandEntry = Pick<
   RegisteredWorkspaceCommand,
@@ -36,7 +37,12 @@ export class WorkspaceCommandRunnerService {
     const { workspaceId, index, total } = iteratorContext;
 
     this.logger.log(
-      `${options.dryRun ? '(dry run) ' : ''}Upgrading workspace ${workspaceId} ${index + 1}/${total}`,
+      formatUpgradeLog('workspace.start', {
+        workspaceId,
+        index: index + 1,
+        total,
+        dryRun: options.dryRun ?? false,
+      }),
     );
 
     const executedByVersion =
@@ -53,7 +59,13 @@ export class WorkspaceCommandRunnerService {
         });
       }
 
-      this.logger.log(`Upgrade for workspace ${workspaceId} completed.`);
+      this.logger.log(
+        formatUpgradeLog('workspace.success', {
+          workspaceId,
+          executedByVersion,
+          dryRun: options.dryRun ?? false,
+        }),
+      );
     } finally {
       if (!options.dryRun) {
         await this.safeInvalidateWorkspace(workspaceId);
@@ -66,9 +78,10 @@ export class WorkspaceCommandRunnerService {
       await this.upgradeStatusService.invalidateInstanceAndAllWorkspacesStatus();
     } catch (error) {
       this.logger.warn(
-        `Failed to invalidate upgrade-status cache for workspace ${workspaceId}: ${
-          error instanceof Error ? error.message : String(error)
-        }`,
+        formatUpgradeLog('cache.invalidate.failed', {
+          workspaceId,
+          error: error instanceof Error ? error.message : String(error),
+        }),
       );
     }
   }
@@ -117,6 +130,17 @@ export class WorkspaceCommandRunnerService {
           error,
         });
       }
+
+      this.logger.error(
+        formatUpgradeLog('workspace.failed', {
+          workspaceId,
+          command: name,
+          executedByVersion,
+          dryRun: options.dryRun ?? false,
+          error: error instanceof Error ? error.message : String(error),
+        }),
+        error instanceof Error ? error.stack : undefined,
+      );
 
       throw error;
     }

--- a/packages/twenty-server/src/engine/core-modules/upgrade/services/workspace-command-runner.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/upgrade/services/workspace-command-runner.service.ts
@@ -40,9 +40,9 @@ export class WorkspaceCommandRunnerService {
 
     this.logger.log(
       formatUpgradeLog({
-        message: `${dryRunPrefix}Upgrading workspace ${workspaceId} ${index + 1}/${total}`,
+        humanMessage: `${dryRunPrefix}Upgrading workspace ${workspaceId} ${index + 1}/${total}`,
         event: 'workspace.start',
-        fields: {
+        logFields: {
           workspaceId,
           index: index + 1,
           total,
@@ -67,9 +67,9 @@ export class WorkspaceCommandRunnerService {
 
       this.logger.log(
         formatUpgradeLog({
-          message: `Upgrade for workspace ${workspaceId} completed.`,
+          humanMessage: `Upgrade for workspace ${workspaceId} completed.`,
           event: 'workspace.success',
-          fields: {
+          logFields: {
             workspaceId,
             executedByVersion,
             dryRun: options.dryRun ?? false,
@@ -92,12 +92,11 @@ export class WorkspaceCommandRunnerService {
 
       this.logger.warn(
         formatUpgradeLog({
-          message: `Failed to invalidate upgrade-status cache (triggered by workspace ${workspaceId}): ${errorMessage}`,
+          humanMessage: `Failed to invalidate upgrade-status cache (triggered by workspace ${workspaceId}): ${errorMessage}`,
           event: 'cache.invalidate.failed',
-          fields: {
+          logFields: {
             scope: 'instance-and-all-workspaces',
             triggeredByWorkspaceId: workspaceId,
-            error: errorMessage,
           },
         }),
       );

--- a/packages/twenty-server/src/engine/core-modules/upgrade/services/workspace-command-runner.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/upgrade/services/workspace-command-runner.service.ts
@@ -149,24 +149,6 @@ export class WorkspaceCommandRunnerService {
         });
       }
 
-      const errorMessage =
-        error instanceof Error ? error.message : String(error);
-
-      this.logger.error(
-        formatUpgradeLog({
-          message: `Workspace ${workspaceId} failed on ${name}: ${errorMessage}`,
-          event: 'workspace.failed',
-          fields: {
-            workspaceId,
-            command: name,
-            executedByVersion,
-            dryRun: options.dryRun ?? false,
-            error: errorMessage,
-          },
-        }),
-        error instanceof Error ? error.stack : undefined,
-      );
-
       throw error;
     }
   }

--- a/packages/twenty-server/src/engine/core-modules/upgrade/services/workspace-command-runner.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/upgrade/services/workspace-command-runner.service.ts
@@ -92,9 +92,13 @@ export class WorkspaceCommandRunnerService {
 
       this.logger.warn(
         formatUpgradeLog({
-          message: `Failed to invalidate upgrade-status cache for workspace ${workspaceId}: ${errorMessage}`,
+          message: `Failed to invalidate upgrade-status cache (triggered by workspace ${workspaceId}): ${errorMessage}`,
           event: 'cache.invalidate.failed',
-          fields: { workspaceId, error: errorMessage },
+          fields: {
+            scope: 'instance-and-all-workspaces',
+            triggeredByWorkspaceId: workspaceId,
+            error: errorMessage,
+          },
         }),
       );
     }

--- a/packages/twenty-server/src/engine/core-modules/upgrade/utils/__tests__/format-upgrade-log.util.spec.ts
+++ b/packages/twenty-server/src/engine/core-modules/upgrade/utils/__tests__/format-upgrade-log.util.spec.ts
@@ -1,18 +1,18 @@
 import { formatUpgradeLog } from 'src/engine/core-modules/upgrade/utils/format-upgrade-log.util';
 
 describe('formatUpgradeLog', () => {
-  it('should emit "[upgrade] <message> | event=<event>" with no fields', () => {
+  it('emits "[upgrade] <message> | event=<event>" with no fields', () => {
     expect(
       formatUpgradeLog({
         message: 'Upgrade for workspace abc-123 completed.',
         event: 'workspace.success',
       }),
-    ).toBe(
-      '[upgrade] Upgrade for workspace abc-123 completed. | event=workspace.success',
+    ).toMatchInlineSnapshot(
+      `"[upgrade] Upgrade for workspace abc-123 completed. | event=workspace.success"`,
     );
   });
 
-  it('should serialize numeric, boolean and string fields after the message', () => {
+  it('serializes numeric, boolean and string fields after the message', () => {
     expect(
       formatUpgradeLog({
         message: 'Upgrading workspace abc-123 1/10',
@@ -24,12 +24,12 @@ describe('formatUpgradeLog', () => {
           dryRun: false,
         },
       }),
-    ).toBe(
-      '[upgrade] Upgrading workspace abc-123 1/10 | event=workspace.start workspaceId=abc-123 index=1 total=10 dryRun=false',
+    ).toMatchInlineSnapshot(
+      `"[upgrade] Upgrading workspace abc-123 1/10 | event=workspace.start workspaceId=abc-123 index=1 total=10 dryRun=false"`,
     );
   });
 
-  it('should skip undefined and null fields via isDefined', () => {
+  it('emits null and undefined fields explicitly', () => {
     expect(
       formatUpgradeLog({
         message: 'migration-foo executed successfully',
@@ -40,12 +40,12 @@ describe('formatUpgradeLog', () => {
           executedByVersion: null,
         },
       }),
-    ).toBe(
-      '[upgrade] migration-foo executed successfully | event=instance.success command=migration-foo',
+    ).toMatchInlineSnapshot(
+      `"[upgrade] migration-foo executed successfully | event=instance.success command=migration-foo error=undefined executedByVersion=null"`,
     );
   });
 
-  it('should quote values containing whitespace, quotes or equals signs', () => {
+  it('quotes values containing whitespace, quotes or equals signs', () => {
     expect(
       formatUpgradeLog({
         message: 'Workspace abc failed on migrate-foo',
@@ -55,12 +55,12 @@ describe('formatUpgradeLog', () => {
           error: 'Connection timed out',
         },
       }),
-    ).toBe(
-      '[upgrade] Workspace abc failed on migrate-foo | event=workspace.failed workspaceId=abc error="Connection timed out"',
+    ).toMatchInlineSnapshot(
+      `"[upgrade] Workspace abc failed on migrate-foo | event=workspace.failed workspaceId=abc error="Connection timed out""`,
     );
   });
 
-  it('should escape embedded quotes and backslashes', () => {
+  it('escapes embedded quotes and backslashes', () => {
     expect(
       formatUpgradeLog({
         message: 'Workspace abc failed',
@@ -69,12 +69,12 @@ describe('formatUpgradeLog', () => {
           error: 'bad "quote" and \\ backslash',
         },
       }),
-    ).toBe(
-      '[upgrade] Workspace abc failed | event=workspace.failed error="bad \\"quote\\" and \\\\ backslash"',
+    ).toMatchInlineSnapshot(
+      `"[upgrade] Workspace abc failed | event=workspace.failed error="bad \\"quote\\" and \\\\ backslash""`,
     );
   });
 
-  it('should escape newlines, carriage returns and tabs so a single event stays on one line', () => {
+  it('keeps multi-line values on a single log line via \\n / \\r / \\t escaping', () => {
     expect(
       formatUpgradeLog({
         message: 'Workspace abc failed',
@@ -83,17 +83,54 @@ describe('formatUpgradeLog', () => {
           error: 'line one\nline two\rline three\ttab',
         },
       }),
-    ).toBe(
-      '[upgrade] Workspace abc failed | event=workspace.failed error="line one\\nline two\\rline three\\ttab"',
+    ).toMatchInlineSnapshot(
+      `"[upgrade] Workspace abc failed | event=workspace.failed error="line one\\nline two\\rline three\\ttab""`,
     );
   });
 
-  it('should escape an event name containing whitespace or =', () => {
+  it('escapes an event name containing whitespace or =', () => {
     expect(
       formatUpgradeLog({
         message: 'Something happened',
         event: 'weird event=with-equals',
       }),
-    ).toBe('[upgrade] Something happened | event="weird event=with-equals"');
+    ).toMatchInlineSnapshot(
+      `"[upgrade] Something happened | event="weird event=with-equals""`,
+    );
+  });
+
+  it('handles a realistic multi-line orchestrator validation error', () => {
+    const error = `{
+  "code": "METADATA_VALIDATION_FAILED",
+  "errors": {
+    "fieldMetadata": [
+      {
+        "errors": [
+          { "code": "INVALID_FIELD_INPUT", "message": "Option id is required" },
+          { "code": "INVALID_FIELD_INPUT", "message": "Option id is invalid", "value": null }
+        ],
+        "metadataName": "fieldMetadata",
+        "status": "fail",
+        "type": "update"
+      }
+    ]
+  },
+  "message": "Validation failed for 1 fieldMetadata",
+  "summary": { "fieldMetadata": 1, "totalErrors": 1 }
+}`;
+
+    expect(
+      formatUpgradeLog({
+        message: 'Workspace abc failed on validate-field-metadata',
+        event: 'workspace.failed',
+        fields: {
+          workspaceId: 'abc',
+          command: 'validate-field-metadata',
+          error,
+        },
+      }),
+    ).toMatchInlineSnapshot(
+      `"[upgrade] Workspace abc failed on validate-field-metadata | event=workspace.failed workspaceId=abc command=validate-field-metadata error="{\\n  \\"code\\": \\"METADATA_VALIDATION_FAILED\\",\\n  \\"errors\\": {\\n    \\"fieldMetadata\\": [\\n      {\\n        \\"errors\\": [\\n          { \\"code\\": \\"INVALID_FIELD_INPUT\\", \\"message\\": \\"Option id is required\\" },\\n          { \\"code\\": \\"INVALID_FIELD_INPUT\\", \\"message\\": \\"Option id is invalid\\", \\"value\\": null }\\n        ],\\n        \\"metadataName\\": \\"fieldMetadata\\",\\n        \\"status\\": \\"fail\\",\\n        \\"type\\": \\"update\\"\\n      }\\n    ]\\n  },\\n  \\"message\\": \\"Validation failed for 1 fieldMetadata\\",\\n  \\"summary\\": { \\"fieldMetadata\\": 1, \\"totalErrors\\": 1 }\\n}""`,
+    );
   });
 });

--- a/packages/twenty-server/src/engine/core-modules/upgrade/utils/__tests__/format-upgrade-log.util.spec.ts
+++ b/packages/twenty-server/src/engine/core-modules/upgrade/utils/__tests__/format-upgrade-log.util.spec.ts
@@ -1,53 +1,76 @@
 import { formatUpgradeLog } from 'src/engine/core-modules/upgrade/utils/format-upgrade-log.util';
 
 describe('formatUpgradeLog', () => {
-  it('should emit the [upgrade] prefix and event tag', () => {
-    expect(formatUpgradeLog('workspace.success')).toBe(
-      '[upgrade] event=workspace.success',
-    );
-  });
-
-  it('should serialize numeric, boolean and string fields', () => {
+  it('should emit "[upgrade] <message> | event=<event>" with no fields', () => {
     expect(
-      formatUpgradeLog('workspace.start', {
-        workspaceId: 'abc-123',
-        index: 1,
-        total: 10,
-        dryRun: false,
+      formatUpgradeLog({
+        message: 'Upgrade for workspace abc-123 completed.',
+        event: 'workspace.success',
       }),
     ).toBe(
-      '[upgrade] event=workspace.start workspaceId=abc-123 index=1 total=10 dryRun=false',
+      '[upgrade] Upgrade for workspace abc-123 completed. | event=workspace.success',
     );
   });
 
-  it('should skip undefined and null fields', () => {
+  it('should serialize numeric, boolean and string fields after the message', () => {
     expect(
-      formatUpgradeLog('instance.success', {
-        command: 'foo',
-        error: undefined,
-        executedByVersion: null,
+      formatUpgradeLog({
+        message: 'Upgrading workspace abc-123 1/10',
+        event: 'workspace.start',
+        fields: {
+          workspaceId: 'abc-123',
+          index: 1,
+          total: 10,
+          dryRun: false,
+        },
       }),
-    ).toBe('[upgrade] event=instance.success command=foo');
+    ).toBe(
+      '[upgrade] Upgrading workspace abc-123 1/10 | event=workspace.start workspaceId=abc-123 index=1 total=10 dryRun=false',
+    );
+  });
+
+  it('should skip undefined and null fields via isDefined', () => {
+    expect(
+      formatUpgradeLog({
+        message: 'migration-foo executed successfully',
+        event: 'instance.success',
+        fields: {
+          command: 'migration-foo',
+          error: undefined,
+          executedByVersion: null,
+        },
+      }),
+    ).toBe(
+      '[upgrade] migration-foo executed successfully | event=instance.success command=migration-foo',
+    );
   });
 
   it('should quote values containing whitespace, quotes or equals signs', () => {
     expect(
-      formatUpgradeLog('workspace.failed', {
-        workspaceId: 'abc',
-        error: 'Connection timed out',
+      formatUpgradeLog({
+        message: 'Workspace abc failed on migrate-foo',
+        event: 'workspace.failed',
+        fields: {
+          workspaceId: 'abc',
+          error: 'Connection timed out',
+        },
       }),
     ).toBe(
-      '[upgrade] event=workspace.failed workspaceId=abc error="Connection timed out"',
+      '[upgrade] Workspace abc failed on migrate-foo | event=workspace.failed workspaceId=abc error="Connection timed out"',
     );
   });
 
   it('should escape embedded quotes and backslashes', () => {
     expect(
-      formatUpgradeLog('workspace.failed', {
-        error: 'bad "quote" and \\ backslash',
+      formatUpgradeLog({
+        message: 'Workspace abc failed',
+        event: 'workspace.failed',
+        fields: {
+          error: 'bad "quote" and \\ backslash',
+        },
       }),
     ).toBe(
-      '[upgrade] event=workspace.failed error="bad \\"quote\\" and \\\\ backslash"',
+      '[upgrade] Workspace abc failed | event=workspace.failed error="bad \\"quote\\" and \\\\ backslash"',
     );
   });
 });

--- a/packages/twenty-server/src/engine/core-modules/upgrade/utils/__tests__/format-upgrade-log.util.spec.ts
+++ b/packages/twenty-server/src/engine/core-modules/upgrade/utils/__tests__/format-upgrade-log.util.spec.ts
@@ -1,10 +1,10 @@
 import { formatUpgradeLog } from 'src/engine/core-modules/upgrade/utils/format-upgrade-log.util';
 
 describe('formatUpgradeLog', () => {
-  it('emits "[upgrade] <message> | event=<event>" with no fields', () => {
+  it('emits "[upgrade] <humanMessage> | event=<event>" with no logFields', () => {
     expect(
       formatUpgradeLog({
-        message: 'Upgrade for workspace abc-123 completed.',
+        humanMessage: 'Upgrade for workspace abc-123 completed.',
         event: 'workspace.success',
       }),
     ).toMatchInlineSnapshot(
@@ -12,12 +12,12 @@ describe('formatUpgradeLog', () => {
     );
   });
 
-  it('serializes numeric, boolean and string fields after the message', () => {
+  it('serializes numeric, boolean and string logFields after the humanMessage', () => {
     expect(
       formatUpgradeLog({
-        message: 'Upgrading workspace abc-123 1/10',
+        humanMessage: 'Upgrading workspace abc-123 1/10',
         event: 'workspace.start',
-        fields: {
+        logFields: {
           workspaceId: 'abc-123',
           index: 1,
           total: 10,
@@ -29,12 +29,12 @@ describe('formatUpgradeLog', () => {
     );
   });
 
-  it('emits null and undefined fields explicitly', () => {
+  it('emits null and undefined logFields explicitly', () => {
     expect(
       formatUpgradeLog({
-        message: 'migration-foo executed successfully',
+        humanMessage: 'migration-foo executed successfully',
         event: 'instance.success',
-        fields: {
+        logFields: {
           command: 'migration-foo',
           error: undefined,
           executedByVersion: null,
@@ -48,50 +48,51 @@ describe('formatUpgradeLog', () => {
   it('quotes values containing whitespace, quotes or equals signs', () => {
     expect(
       formatUpgradeLog({
-        message: 'Workspace abc failed on migrate-foo',
+        humanMessage:
+          'Workspace abc failed on migrate-foo: Connection timed out',
         event: 'workspace.failed',
-        fields: {
+        logFields: {
           workspaceId: 'abc',
-          error: 'Connection timed out',
+          command: 'migrate-foo',
         },
       }),
     ).toMatchInlineSnapshot(
-      `"[upgrade] Workspace abc failed on migrate-foo | event=workspace.failed workspaceId=abc error="Connection timed out""`,
+      `"[upgrade] Workspace abc failed on migrate-foo: Connection timed out | event=workspace.failed workspaceId=abc command=migrate-foo"`,
     );
   });
 
-  it('escapes embedded quotes and backslashes', () => {
+  it('escapes embedded quotes and backslashes in logField values', () => {
     expect(
       formatUpgradeLog({
-        message: 'Workspace abc failed',
+        humanMessage: 'Workspace abc failed',
         event: 'workspace.failed',
-        fields: {
-          error: 'bad "quote" and \\ backslash',
+        logFields: {
+          reason: 'bad "quote" and \\ backslash',
         },
       }),
     ).toMatchInlineSnapshot(
-      `"[upgrade] Workspace abc failed | event=workspace.failed error="bad \\"quote\\" and \\\\ backslash""`,
+      `"[upgrade] Workspace abc failed | event=workspace.failed reason="bad \\"quote\\" and \\\\ backslash""`,
     );
   });
 
-  it('keeps multi-line values on a single log line via \\n / \\r / \\t escaping', () => {
+  it('keeps multi-line logField values on a single log line via \\n / \\r / \\t escaping', () => {
     expect(
       formatUpgradeLog({
-        message: 'Workspace abc failed',
+        humanMessage: 'Workspace abc failed',
         event: 'workspace.failed',
-        fields: {
-          error: 'line one\nline two\rline three\ttab',
+        logFields: {
+          reason: 'line one\nline two\rline three\ttab',
         },
       }),
     ).toMatchInlineSnapshot(
-      `"[upgrade] Workspace abc failed | event=workspace.failed error="line one\\nline two\\rline three\\ttab""`,
+      `"[upgrade] Workspace abc failed | event=workspace.failed reason="line one\\nline two\\rline three\\ttab""`,
     );
   });
 
   it('escapes an event name containing whitespace or =', () => {
     expect(
       formatUpgradeLog({
-        message: 'Something happened',
+        humanMessage: 'Something happened',
         event: 'weird event=with-equals',
       }),
     ).toMatchInlineSnapshot(

--- a/packages/twenty-server/src/engine/core-modules/upgrade/utils/__tests__/format-upgrade-log.util.spec.ts
+++ b/packages/twenty-server/src/engine/core-modules/upgrade/utils/__tests__/format-upgrade-log.util.spec.ts
@@ -29,6 +29,23 @@ describe('formatUpgradeLog', () => {
     );
   });
 
+  it('matches the summary call site emitted by UpgradeCommand at the end of a run', () => {
+    expect(
+      formatUpgradeLog({
+        humanMessage:
+          'Upgrade summary: 42 workspace(s) succeeded, 1 workspace(s) failed',
+        event: 'summary',
+        logFields: {
+          totalSuccesses: 42,
+          totalFailures: 1,
+          dryRun: false,
+        },
+      }),
+    ).toMatchInlineSnapshot(
+      `"[upgrade] Upgrade summary: 42 workspace(s) succeeded, 1 workspace(s) failed | event=summary totalSuccesses=42 totalFailures=1 dryRun=false"`,
+    );
+  });
+
   it('emits null and undefined logFields explicitly', () => {
     expect(
       formatUpgradeLog({

--- a/packages/twenty-server/src/engine/core-modules/upgrade/utils/__tests__/format-upgrade-log.util.spec.ts
+++ b/packages/twenty-server/src/engine/core-modules/upgrade/utils/__tests__/format-upgrade-log.util.spec.ts
@@ -1,0 +1,53 @@
+import { formatUpgradeLog } from 'src/engine/core-modules/upgrade/utils/format-upgrade-log.util';
+
+describe('formatUpgradeLog', () => {
+  it('should emit the [upgrade] prefix and event tag', () => {
+    expect(formatUpgradeLog('workspace.success')).toBe(
+      '[upgrade] event=workspace.success',
+    );
+  });
+
+  it('should serialize numeric, boolean and string fields', () => {
+    expect(
+      formatUpgradeLog('workspace.start', {
+        workspaceId: 'abc-123',
+        index: 1,
+        total: 10,
+        dryRun: false,
+      }),
+    ).toBe(
+      '[upgrade] event=workspace.start workspaceId=abc-123 index=1 total=10 dryRun=false',
+    );
+  });
+
+  it('should skip undefined and null fields', () => {
+    expect(
+      formatUpgradeLog('instance.success', {
+        command: 'foo',
+        error: undefined,
+        executedByVersion: null,
+      }),
+    ).toBe('[upgrade] event=instance.success command=foo');
+  });
+
+  it('should quote values containing whitespace, quotes or equals signs', () => {
+    expect(
+      formatUpgradeLog('workspace.failed', {
+        workspaceId: 'abc',
+        error: 'Connection timed out',
+      }),
+    ).toBe(
+      '[upgrade] event=workspace.failed workspaceId=abc error="Connection timed out"',
+    );
+  });
+
+  it('should escape embedded quotes and backslashes', () => {
+    expect(
+      formatUpgradeLog('workspace.failed', {
+        error: 'bad "quote" and \\ backslash',
+      }),
+    ).toBe(
+      '[upgrade] event=workspace.failed error="bad \\"quote\\" and \\\\ backslash"',
+    );
+  });
+});

--- a/packages/twenty-server/src/engine/core-modules/upgrade/utils/__tests__/format-upgrade-log.util.spec.ts
+++ b/packages/twenty-server/src/engine/core-modules/upgrade/utils/__tests__/format-upgrade-log.util.spec.ts
@@ -73,4 +73,27 @@ describe('formatUpgradeLog', () => {
       '[upgrade] Workspace abc failed | event=workspace.failed error="bad \\"quote\\" and \\\\ backslash"',
     );
   });
+
+  it('should escape newlines, carriage returns and tabs so a single event stays on one line', () => {
+    expect(
+      formatUpgradeLog({
+        message: 'Workspace abc failed',
+        event: 'workspace.failed',
+        fields: {
+          error: 'line one\nline two\rline three\ttab',
+        },
+      }),
+    ).toBe(
+      '[upgrade] Workspace abc failed | event=workspace.failed error="line one\\nline two\\rline three\\ttab"',
+    );
+  });
+
+  it('should escape an event name containing whitespace or =', () => {
+    expect(
+      formatUpgradeLog({
+        message: 'Something happened',
+        event: 'weird event=with-equals',
+      }),
+    ).toBe('[upgrade] Something happened | event="weird event=with-equals"');
+  });
 });

--- a/packages/twenty-server/src/engine/core-modules/upgrade/utils/__tests__/format-upgrade-log.util.spec.ts
+++ b/packages/twenty-server/src/engine/core-modules/upgrade/utils/__tests__/format-upgrade-log.util.spec.ts
@@ -1,15 +1,16 @@
 import { formatUpgradeLog } from 'src/engine/core-modules/upgrade/utils/format-upgrade-log.util';
 
 describe('formatUpgradeLog', () => {
-  it('emits "[upgrade] <humanMessage> | event=<event>" with no logFields', () => {
+  it('emits humanMessage on its own lines followed by a single-line "[upgrade] event=<event>" tail', () => {
     expect(
       formatUpgradeLog({
         humanMessage: 'Upgrade for workspace abc-123 completed.',
         event: 'workspace.success',
       }),
-    ).toMatchInlineSnapshot(
-      `"[upgrade] Upgrade for workspace abc-123 completed. | event=workspace.success"`,
-    );
+    ).toMatchInlineSnapshot(`
+"Upgrade for workspace abc-123 completed.
+[upgrade] event=workspace.success"
+`);
   });
 
   it('serializes numeric, boolean and string logFields after the humanMessage', () => {
@@ -24,9 +25,10 @@ describe('formatUpgradeLog', () => {
           dryRun: false,
         },
       }),
-    ).toMatchInlineSnapshot(
-      `"[upgrade] Upgrading workspace abc-123 1/10 | event=workspace.start workspaceId=abc-123 index=1 total=10 dryRun=false"`,
-    );
+    ).toMatchInlineSnapshot(`
+"Upgrading workspace abc-123 1/10
+[upgrade] event=workspace.start workspaceId=abc-123 index=1 total=10 dryRun=false"
+`);
   });
 
   it('matches the summary call site emitted by UpgradeCommand at the end of a run', () => {
@@ -41,12 +43,13 @@ describe('formatUpgradeLog', () => {
           dryRun: false,
         },
       }),
-    ).toMatchInlineSnapshot(
-      `"[upgrade] Upgrade summary: 42 workspace(s) succeeded, 1 workspace(s) failed | event=summary totalSuccesses=42 totalFailures=1 dryRun=false"`,
-    );
+    ).toMatchInlineSnapshot(`
+"Upgrade summary: 42 workspace(s) succeeded, 1 workspace(s) failed
+[upgrade] event=summary totalSuccesses=42 totalFailures=1 dryRun=false"
+`);
   });
 
-  it('collapses a multi-line humanMessage (e.g. an Error with embedded newlines) so the line stays a single Loki event', () => {
+  it('preserves a multi-line humanMessage as-is and keeps the structured tail on its own single line', () => {
     const errorMessage =
       'Workspace migration runner failed:\n  - Option id is required\n  - Option id is invalid';
 
@@ -60,9 +63,12 @@ describe('formatUpgradeLog', () => {
           dryRun: false,
         },
       }),
-    ).toMatchInlineSnapshot(
-      `"[upgrade] Upgrade failed: Workspace migration runner failed:\\n  - Option id is required\\n  - Option id is invalid | event=aborted totalSuccesses=41 totalFailures=2 dryRun=false"`,
-    );
+    ).toMatchInlineSnapshot(`
+"Upgrade failed: Workspace migration runner failed:
+  - Option id is required
+  - Option id is invalid
+[upgrade] event=aborted totalSuccesses=41 totalFailures=2 dryRun=false"
+`);
   });
 
   it('emits null and undefined logFields explicitly', () => {
@@ -76,9 +82,10 @@ describe('formatUpgradeLog', () => {
           executedByVersion: null,
         },
       }),
-    ).toMatchInlineSnapshot(
-      `"[upgrade] migration-foo executed successfully | event=instance.success command=migration-foo error=undefined executedByVersion=null"`,
-    );
+    ).toMatchInlineSnapshot(`
+"migration-foo executed successfully
+[upgrade] event=instance.success command=migration-foo error=undefined executedByVersion=null"
+`);
   });
 
   it('quotes values containing whitespace, quotes or equals signs', () => {
@@ -92,9 +99,10 @@ describe('formatUpgradeLog', () => {
           command: 'migrate-foo',
         },
       }),
-    ).toMatchInlineSnapshot(
-      `"[upgrade] Workspace abc failed on migrate-foo: Connection timed out | event=workspace.failed workspaceId=abc command=migrate-foo"`,
-    );
+    ).toMatchInlineSnapshot(`
+"Workspace abc failed on migrate-foo: Connection timed out
+[upgrade] event=workspace.failed workspaceId=abc command=migrate-foo"
+`);
   });
 
   it('escapes embedded quotes and backslashes in logField values', () => {
@@ -106,9 +114,10 @@ describe('formatUpgradeLog', () => {
           reason: 'bad "quote" and \\ backslash',
         },
       }),
-    ).toMatchInlineSnapshot(
-      `"[upgrade] Workspace abc failed | event=workspace.failed reason="bad \\"quote\\" and \\\\ backslash""`,
-    );
+    ).toMatchInlineSnapshot(`
+"Workspace abc failed
+[upgrade] event=workspace.failed reason="bad \\"quote\\" and \\\\ backslash""
+`);
   });
 
   it('keeps multi-line logField values on a single log line via \\n / \\r / \\t escaping', () => {
@@ -120,9 +129,10 @@ describe('formatUpgradeLog', () => {
           reason: 'line one\nline two\rline three\ttab',
         },
       }),
-    ).toMatchInlineSnapshot(
-      `"[upgrade] Workspace abc failed | event=workspace.failed reason="line one\\nline two\\rline three\\ttab""`,
-    );
+    ).toMatchInlineSnapshot(`
+"Workspace abc failed
+[upgrade] event=workspace.failed reason="line one\\nline two\\rline three\\ttab""
+`);
   });
 
   it('escapes an event name containing whitespace or =', () => {
@@ -131,8 +141,9 @@ describe('formatUpgradeLog', () => {
         humanMessage: 'Something happened',
         event: 'weird event=with-equals',
       }),
-    ).toMatchInlineSnapshot(
-      `"[upgrade] Something happened | event="weird event=with-equals""`,
-    );
+    ).toMatchInlineSnapshot(`
+"Something happened
+[upgrade] event="weird event=with-equals""
+`);
   });
 });

--- a/packages/twenty-server/src/engine/core-modules/upgrade/utils/__tests__/format-upgrade-log.util.spec.ts
+++ b/packages/twenty-server/src/engine/core-modules/upgrade/utils/__tests__/format-upgrade-log.util.spec.ts
@@ -46,6 +46,25 @@ describe('formatUpgradeLog', () => {
     );
   });
 
+  it('collapses a multi-line humanMessage (e.g. an Error with embedded newlines) so the line stays a single Loki event', () => {
+    const errorMessage =
+      'Workspace migration runner failed:\n  - Option id is required\n  - Option id is invalid';
+
+    expect(
+      formatUpgradeLog({
+        humanMessage: `Upgrade failed: ${errorMessage}`,
+        event: 'aborted',
+        logFields: {
+          totalSuccesses: 41,
+          totalFailures: 2,
+          dryRun: false,
+        },
+      }),
+    ).toMatchInlineSnapshot(
+      `"[upgrade] Upgrade failed: Workspace migration runner failed:\\n  - Option id is required\\n  - Option id is invalid | event=aborted totalSuccesses=41 totalFailures=2 dryRun=false"`,
+    );
+  });
+
   it('emits null and undefined logFields explicitly', () => {
     expect(
       formatUpgradeLog({

--- a/packages/twenty-server/src/engine/core-modules/upgrade/utils/__tests__/format-upgrade-log.util.spec.ts
+++ b/packages/twenty-server/src/engine/core-modules/upgrade/utils/__tests__/format-upgrade-log.util.spec.ts
@@ -98,39 +98,4 @@ describe('formatUpgradeLog', () => {
       `"[upgrade] Something happened | event="weird event=with-equals""`,
     );
   });
-
-  it('handles a realistic multi-line orchestrator validation error', () => {
-    const error = `{
-  "code": "METADATA_VALIDATION_FAILED",
-  "errors": {
-    "fieldMetadata": [
-      {
-        "errors": [
-          { "code": "INVALID_FIELD_INPUT", "message": "Option id is required" },
-          { "code": "INVALID_FIELD_INPUT", "message": "Option id is invalid", "value": null }
-        ],
-        "metadataName": "fieldMetadata",
-        "status": "fail",
-        "type": "update"
-      }
-    ]
-  },
-  "message": "Validation failed for 1 fieldMetadata",
-  "summary": { "fieldMetadata": 1, "totalErrors": 1 }
-}`;
-
-    expect(
-      formatUpgradeLog({
-        message: 'Workspace abc failed on validate-field-metadata',
-        event: 'workspace.failed',
-        fields: {
-          workspaceId: 'abc',
-          command: 'validate-field-metadata',
-          error,
-        },
-      }),
-    ).toMatchInlineSnapshot(
-      `"[upgrade] Workspace abc failed on validate-field-metadata | event=workspace.failed workspaceId=abc command=validate-field-metadata error="{\\n  \\"code\\": \\"METADATA_VALIDATION_FAILED\\",\\n  \\"errors\\": {\\n    \\"fieldMetadata\\": [\\n      {\\n        \\"errors\\": [\\n          { \\"code\\": \\"INVALID_FIELD_INPUT\\", \\"message\\": \\"Option id is required\\" },\\n          { \\"code\\": \\"INVALID_FIELD_INPUT\\", \\"message\\": \\"Option id is invalid\\", \\"value\\": null }\\n        ],\\n        \\"metadataName\\": \\"fieldMetadata\\",\\n        \\"status\\": \\"fail\\",\\n        \\"type\\": \\"update\\"\\n      }\\n    ]\\n  },\\n  \\"message\\": \\"Validation failed for 1 fieldMetadata\\",\\n  \\"summary\\": { \\"fieldMetadata\\": 1, \\"totalErrors\\": 1 }\\n}""`,
-    );
-  });
 });

--- a/packages/twenty-server/src/engine/core-modules/upgrade/utils/format-upgrade-log.util.ts
+++ b/packages/twenty-server/src/engine/core-modules/upgrade/utils/format-upgrade-log.util.ts
@@ -45,5 +45,5 @@ export const formatUpgradeLog = ({
     );
   }
 
-  return `${UPGRADE_LOG_PREFIX} ${collapseControlCharacters(humanMessage)} | ${tailParts.join(' ')}`;
+  return `${humanMessage}\n${UPGRADE_LOG_PREFIX} ${tailParts.join(' ')}`;
 };

--- a/packages/twenty-server/src/engine/core-modules/upgrade/utils/format-upgrade-log.util.ts
+++ b/packages/twenty-server/src/engine/core-modules/upgrade/utils/format-upgrade-log.util.ts
@@ -1,36 +1,48 @@
-type UpgradeLogValue = string | number | boolean | null | undefined;
+import { isDefined } from 'twenty-shared/utils';
 
-type UpgradeLogFields = Record<string, UpgradeLogValue>;
+type UpgradeLogScalar = string | number | boolean;
+
+type UpgradeLogFields = Record<string, UpgradeLogScalar | null | undefined>;
+
+type FormatUpgradeLogParams = {
+  message: string;
+  event: string;
+  fields?: UpgradeLogFields;
+};
 
 const UPGRADE_LOG_PREFIX = '[upgrade]';
 
-const formatValue = (value: UpgradeLogValue): string | undefined => {
-  if (value === undefined || value === null) {
-    return undefined;
-  }
-
+const escapeForLogfmt = (value: UpgradeLogScalar): string => {
   const stringified = String(value);
 
-  if (/[\s"=]/.test(stringified)) {
-    return `"${stringified.replace(/\\/g, '\\\\').replace(/"/g, '\\"')}"`;
+  if (!/[\s"=]/.test(stringified)) {
+    return stringified;
   }
 
-  return stringified;
+  return `"${stringified.replace(/\\/g, '\\\\').replace(/"/g, '\\"')}"`;
 };
 
-export const formatUpgradeLog = (
-  event: string,
-  fields: UpgradeLogFields = {},
-): string => {
-  const parts = [`event=${event}`];
+/**
+ * Emits a log line that reads naturally for humans yet is parseable by Loki's
+ * `| logfmt` decoder. The shape is:
+ *
+ *   [upgrade] <message> | event=<event> key=value ...
+ *
+ * The free-text message keeps a `git log`-style narrative for engineers
+ * scrolling pod logs; the structured tail lets the dashboard panel pull out
+ * `event`, `workspaceId`, `command`, `error`, etc.
+ */
+export const formatUpgradeLog = ({
+  message,
+  event,
+  fields = {},
+}: FormatUpgradeLogParams): string => {
+  const tailParts: string[] = [`event=${event}`];
 
   for (const [key, value] of Object.entries(fields)) {
-    const formatted = formatValue(value);
-
-    if (formatted !== undefined) {
-      parts.push(`${key}=${formatted}`);
-    }
+    if (!isDefined(value)) continue;
+    tailParts.push(`${key}=${escapeForLogfmt(value)}`);
   }
 
-  return `${UPGRADE_LOG_PREFIX} ${parts.join(' ')}`;
+  return `${UPGRADE_LOG_PREFIX} ${message} | ${tailParts.join(' ')}`;
 };

--- a/packages/twenty-server/src/engine/core-modules/upgrade/utils/format-upgrade-log.util.ts
+++ b/packages/twenty-server/src/engine/core-modules/upgrade/utils/format-upgrade-log.util.ts
@@ -40,8 +40,9 @@ export const formatUpgradeLog = ({
   const tailParts: string[] = [`event=${escapeLogValue(event)}`];
 
   for (const [key, value] of Object.entries(fields)) {
-    if (!isDefined(value)) continue;
-    tailParts.push(`${key}=${escapeLogValue(value)}`);
+    tailParts.push(
+      `${key}=${isDefined(value) ? escapeLogValue(value) : String(value)}`,
+    );
   }
 
   return `${UPGRADE_LOG_PREFIX} ${message} | ${tailParts.join(' ')}`;

--- a/packages/twenty-server/src/engine/core-modules/upgrade/utils/format-upgrade-log.util.ts
+++ b/packages/twenty-server/src/engine/core-modules/upgrade/utils/format-upgrade-log.util.ts
@@ -15,6 +15,9 @@ const UPGRADE_LOG_PREFIX = '[upgrade]';
 const NEEDS_QUOTING = /[\s"=]/;
 const CONTROL_CHARACTERS = /[\n\r\t]/;
 
+const collapseControlCharacters = (raw: string): string =>
+  raw.replace(/\n/g, '\\n').replace(/\r/g, '\\r').replace(/\t/g, '\\t');
+
 const escapeLogValue = (value: UpgradeLogScalar): string => {
   const raw = String(value);
 
@@ -22,12 +25,9 @@ const escapeLogValue = (value: UpgradeLogScalar): string => {
     return raw;
   }
 
-  const escaped = raw
-    .replace(/\\/g, '\\\\')
-    .replace(/"/g, '\\"')
-    .replace(/\n/g, '\\n')
-    .replace(/\r/g, '\\r')
-    .replace(/\t/g, '\\t');
+  const escaped = collapseControlCharacters(
+    raw.replace(/\\/g, '\\\\').replace(/"/g, '\\"'),
+  );
 
   return `"${escaped}"`;
 };
@@ -45,5 +45,5 @@ export const formatUpgradeLog = ({
     );
   }
 
-  return `${UPGRADE_LOG_PREFIX} ${humanMessage} | ${tailParts.join(' ')}`;
+  return `${UPGRADE_LOG_PREFIX} ${collapseControlCharacters(humanMessage)} | ${tailParts.join(' ')}`;
 };

--- a/packages/twenty-server/src/engine/core-modules/upgrade/utils/format-upgrade-log.util.ts
+++ b/packages/twenty-server/src/engine/core-modules/upgrade/utils/format-upgrade-log.util.ts
@@ -1,0 +1,36 @@
+type UpgradeLogValue = string | number | boolean | null | undefined;
+
+type UpgradeLogFields = Record<string, UpgradeLogValue>;
+
+const UPGRADE_LOG_PREFIX = '[upgrade]';
+
+const formatValue = (value: UpgradeLogValue): string | undefined => {
+  if (value === undefined || value === null) {
+    return undefined;
+  }
+
+  const stringified = String(value);
+
+  if (/[\s"=]/.test(stringified)) {
+    return `"${stringified.replace(/\\/g, '\\\\').replace(/"/g, '\\"')}"`;
+  }
+
+  return stringified;
+};
+
+export const formatUpgradeLog = (
+  event: string,
+  fields: UpgradeLogFields = {},
+): string => {
+  const parts = [`event=${event}`];
+
+  for (const [key, value] of Object.entries(fields)) {
+    const formatted = formatValue(value);
+
+    if (formatted !== undefined) {
+      parts.push(`${key}=${formatted}`);
+    }
+  }
+
+  return `${UPGRADE_LOG_PREFIX} ${parts.join(' ')}`;
+};

--- a/packages/twenty-server/src/engine/core-modules/upgrade/utils/format-upgrade-log.util.ts
+++ b/packages/twenty-server/src/engine/core-modules/upgrade/utils/format-upgrade-log.util.ts
@@ -5,9 +5,9 @@ type UpgradeLogScalar = string | number | boolean;
 type UpgradeLogFields = Record<string, UpgradeLogScalar | null | undefined>;
 
 type FormatUpgradeLogParams = {
-  message: string;
+  humanMessage: string;
   event: string;
-  fields?: UpgradeLogFields;
+  logFields?: UpgradeLogFields;
 };
 
 const UPGRADE_LOG_PREFIX = '[upgrade]';
@@ -33,17 +33,17 @@ const escapeLogValue = (value: UpgradeLogScalar): string => {
 };
 
 export const formatUpgradeLog = ({
-  message,
+  humanMessage,
   event,
-  fields = {},
+  logFields = {},
 }: FormatUpgradeLogParams): string => {
   const tailParts: string[] = [`event=${escapeLogValue(event)}`];
 
-  for (const [key, value] of Object.entries(fields)) {
+  for (const [key, value] of Object.entries(logFields)) {
     tailParts.push(
       `${key}=${isDefined(value) ? escapeLogValue(value) : String(value)}`,
     );
   }
 
-  return `${UPGRADE_LOG_PREFIX} ${message} | ${tailParts.join(' ')}`;
+  return `${UPGRADE_LOG_PREFIX} ${humanMessage} | ${tailParts.join(' ')}`;
 };

--- a/packages/twenty-server/src/engine/core-modules/upgrade/utils/format-upgrade-log.util.ts
+++ b/packages/twenty-server/src/engine/core-modules/upgrade/utils/format-upgrade-log.util.ts
@@ -15,9 +15,6 @@ const UPGRADE_LOG_PREFIX = '[upgrade]';
 const NEEDS_QUOTING = /[\s"=]/;
 const CONTROL_CHARACTERS = /[\n\r\t]/;
 
-const collapseControlCharacters = (raw: string): string =>
-  raw.replace(/\n/g, '\\n').replace(/\r/g, '\\r').replace(/\t/g, '\\t');
-
 const escapeLogValue = (value: UpgradeLogScalar): string => {
   const raw = String(value);
 
@@ -25,9 +22,12 @@ const escapeLogValue = (value: UpgradeLogScalar): string => {
     return raw;
   }
 
-  const escaped = collapseControlCharacters(
-    raw.replace(/\\/g, '\\\\').replace(/"/g, '\\"'),
-  );
+  const escaped = raw
+    .replace(/\\/g, '\\\\')
+    .replace(/"/g, '\\"')
+    .replace(/\n/g, '\\n')
+    .replace(/\r/g, '\\r')
+    .replace(/\t/g, '\\t');
 
   return `"${escaped}"`;
 };

--- a/packages/twenty-server/src/engine/core-modules/upgrade/utils/format-upgrade-log.util.ts
+++ b/packages/twenty-server/src/engine/core-modules/upgrade/utils/format-upgrade-log.util.ts
@@ -12,36 +12,36 @@ type FormatUpgradeLogParams = {
 
 const UPGRADE_LOG_PREFIX = '[upgrade]';
 
-const escapeForLogfmt = (value: UpgradeLogScalar): string => {
-  const stringified = String(value);
+const NEEDS_QUOTING = /[\s"=]/;
+const CONTROL_CHARACTERS = /[\n\r\t]/;
 
-  if (!/[\s"=]/.test(stringified)) {
-    return stringified;
+const escapeLogValue = (value: UpgradeLogScalar): string => {
+  const raw = String(value);
+
+  if (!NEEDS_QUOTING.test(raw) && !CONTROL_CHARACTERS.test(raw)) {
+    return raw;
   }
 
-  return `"${stringified.replace(/\\/g, '\\\\').replace(/"/g, '\\"')}"`;
+  const escaped = raw
+    .replace(/\\/g, '\\\\')
+    .replace(/"/g, '\\"')
+    .replace(/\n/g, '\\n')
+    .replace(/\r/g, '\\r')
+    .replace(/\t/g, '\\t');
+
+  return `"${escaped}"`;
 };
 
-/**
- * Emits a log line that reads naturally for humans yet is parseable by Loki's
- * `| logfmt` decoder. The shape is:
- *
- *   [upgrade] <message> | event=<event> key=value ...
- *
- * The free-text message keeps a `git log`-style narrative for engineers
- * scrolling pod logs; the structured tail lets the dashboard panel pull out
- * `event`, `workspaceId`, `command`, `error`, etc.
- */
 export const formatUpgradeLog = ({
   message,
   event,
   fields = {},
 }: FormatUpgradeLogParams): string => {
-  const tailParts: string[] = [`event=${event}`];
+  const tailParts: string[] = [`event=${escapeLogValue(event)}`];
 
   for (const [key, value] of Object.entries(fields)) {
     if (!isDefined(value)) continue;
-    tailParts.push(`${key}=${escapeForLogfmt(value)}`);
+    tailParts.push(`${key}=${escapeLogValue(value)}`);
   }
 
   return `${UPGRADE_LOG_PREFIX} ${message} | ${tailParts.join(' ')}`;


### PR DESCRIPTION
## Summary

Adds a small helper that lets every log line in the upgrade flow stay human-readable while emitting a structured tail that Loki / the upgrade-status Grafana dashboard can filter on.

Output shape per `logger.log()` call:

```
<humanMessage as-is, may span multiple lines>
[upgrade] event=<event> key=value …    ← always single line
```

Same call produces **one** structured Loki event regardless of how chatty the human-readable part gets — the dashboard's `|= "[upgrade]"` filter only matches the trailing line.

## Helper API

```ts
formatUpgradeLog({
  humanMessage: string,                  // free-form, multi-line OK, for engineers scrolling raw pod logs
  event: string,                         // required anchor for Loki filtering / dashboards
  logFields?: Record<string,             // short structured key=value tail
    string | number | boolean | null | undefined
  >,
});
```

- `humanMessage` is preserved as-is. A thrown `new Error('line one\nline two')` surfacing through `humanMessage` stays human-readable across multiple lines.
- `logFields` values are logfmt-escaped: whitespace / `=` / `"` get quoted, embedded `\` / `"` / `\n` / `\r` / `\t` are escaped, `null` / `undefined` emit literally (`key=null`, `key=undefined`) instead of being silently dropped — caught via `isDefined` from `twenty-shared/utils`.
- `event` itself runs through the same escape so an event name with whitespace or `=` can't break parsing.

## Example output

```
Initialized upgrade sequence: 8 step(s)
[upgrade] event=sequence.initialized stepCount=8 dryRun=false

Upgrading workspace abc-123 1/10
[upgrade] event=workspace.start workspaceId=abc-123 index=1 total=10 dryRun=false

Upgrade for workspace abc-123 completed.
[upgrade] event=workspace.success workspaceId=abc-123 executedByVersion=1.4.0 dryRun=false

Upgrade summary: 42 workspace(s) succeeded, 1 workspace(s) failed
[upgrade] event=summary totalSuccesses=42 totalFailures=1 dryRun=false

Upgrade failed: Workspace migration runner failed:
  - Option id is required
  - Option id is invalid
[upgrade] event=aborted totalSuccesses=41 totalFailures=2 dryRun=false
```

Loki query for the dashboard: `{namespace="twenty"} |= "[upgrade]" | logfmt event, workspaceId, command, executedByVersion`

## Scope

Only the **upgrade-specific** call sites carry the tag:

- `upgrade.command.ts` — `sequence.initialized`, `sequence.step` (verbose), `summary`, `aborted`
- `upgrade-sequence-runner.service.ts` — `sequence.stopped`, `sequence.aborted`
- `workspace-command-runner.service.ts` — `workspace.start`, `workspace.success`, `cache.invalidate.failed`

`instance-command-runner.service.ts` is intentionally **not** tagged — `runFastInstanceCommand` / `runSlowInstanceCommand` are also invoked from `RunInstanceCommandsCommand` (DB init / `run-instance-commands`), so an `[upgrade]` tag there would mislead at init time. Those lines stay plain-text; stacks still flow on their own via NestJS `logger.error(message, error.stack)`.

`chalk` is dropped from `upgrade.command.ts` — ANSI escapes break log parsers and chalk is a no-op without a TTY anyway.

## Tests

9 inline-snapshot tests in `format-upgrade-log.util.spec.ts` surface the actual output of every interesting shape (summary call site, multi-line humanMessage, quoted / escaped / control-character logField values, null/undefined fields, event name escaping). Snapshots double as documentation of what a real upgrade log line looks like.

## Test plan

- [x] Unit tests green (`jest format-upgrade-log`)
- [x] oxlint + prettier clean
- [x] tsgo typecheck clean on the upgrade module
- [x] CI green
- [ ] Smoke test on staging: run `upgrade` command, confirm `[upgrade]` structured lines surface in Loki and `| logfmt` extracts fields