### PR TITLE
fix(messaging): prevent IMAP socket timeout from crashing twenty-server

### DIFF
--- a/packages/twenty-server/src/modules/messaging/message-import-manager/drivers/imap/providers/imap-client.provider.spec.ts
+++ b/packages/twenty-server/src/modules/messaging/message-import-manager/drivers/imap/providers/imap-client.provider.spec.ts
@@ -1,0 +1,53 @@
+import { ConnectedAccountProvider } from 'twenty-shared/types';
+
+import { SecureHttpClientService } from 'src/engine/core-modules/secure-http-client/secure-http-client.service';
+import { ImapClientProvider } from 'src/modules/messaging/message-import-manager/drivers/imap/providers/imap-client.provider';
+
+const mockConnect = jest.fn();
+const mockLogout = jest.fn();
+const mockOn = jest.fn();
+
+jest.mock('imapflow', () => ({
+  ImapFlow: jest.fn().mockImplementation(() => ({
+    connect: mockConnect,
+    logout: mockLogout,
+    on: mockOn,
+  })),
+}));
+
+describe('ImapClientProvider', () => {
+  let provider: ImapClientProvider;
+
+  const secureHttpClientService = {
+    getValidatedHost: jest.fn().mockResolvedValue('imap.example.com'),
+  } as unknown as SecureHttpClientService;
+
+  const connectedAccount = {
+    id: 'connected-account-id',
+    provider: ConnectedAccountProvider.IMAP_SMTP_CALDAV,
+    handle: 'test@example.com',
+    connectionParameters: {
+      IMAP: {
+        host: 'imap.example.com',
+        port: 993,
+        secure: true,
+        password: 'password',
+      },
+    },
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockConnect.mockResolvedValue(undefined);
+    mockLogout.mockResolvedValue(undefined);
+
+    provider = new ImapClientProvider(secureHttpClientService);
+  });
+
+  it('attaches an error listener before connecting the IMAP client', async () => {
+    await provider.getClient(connectedAccount);
+
+    expect(mockOn).toHaveBeenCalledWith('error', expect.any(Function));
+    expect(mockOn).toHaveBeenCalledBefore(mockConnect);
+  });
+});

--- a/packages/twenty-server/src/modules/messaging/message-import-manager/drivers/imap/providers/imap-client.provider.ts
+++ b/packages/twenty-server/src/modules/messaging/message-import-manager/drivers/imap/providers/imap-client.provider.ts
@@ -94,6 +94,13 @@ export class ImapClientProvider {
       greetingTimeout: ImapClientProvider.GREETING_TIMEOUT_MS,
     });
 
+    client.on('error', (error) => {
+      this.logger.warn(
+        `IMAP client error for ${connectedAccount.handle}: ${error.message}`,
+        error.stack,
+      );
+    });
+
     try {
       await client.connect();
 


### PR DESCRIPTION
## Summary

Fixes an IMAP crash path where `ImapFlow` can emit an `error` event (for example socket timeout) without a registered listener, causing Node.js to treat it as an uncaught exception and exit `twenty-server`.

This PR attaches a permanent `error` listener immediately after creating the IMAP client and before `connect()`, so transient IMAP socket errors are logged instead of crashing the process.

## Related issue

Fixes #20509

## Changes

- Add an `error` listener to `ImapFlow` clients created by `ImapClientProvider`
- Log IMAP client errors with account context
- Add a unit test that verifies the listener is registered before connecting

## Testing

- Added provider-level unit test for listener registration ordering
- Manual code inspection against Node.js EventEmitter semantics: an `error` event without a listener throws; with the listener attached, it is handled/logged.

Note: I started a full repository dependency install locally to run the target test suite; the repo install is still running due to the size of the monorepo. The fix itself is intentionally minimal and scoped to the crash root cause.
