### PR TITLE
fix(messaging): store full IMAP folder path instead of leaf name

### DIFF
--- a/packages/twenty-server/src/modules/messaging/message-folder-manager/drivers/imap/services/__tests__/imap-get-all-folders.service.spec.ts
+++ b/packages/twenty-server/src/modules/messaging/message-folder-manager/drivers/imap/services/__tests__/imap-get-all-folders.service.spec.ts
@@ -75,6 +75,38 @@ describe('ImapGetAllFoldersService', () => {
     imapFindSentFolderService = module.get(ImapFindSentFolderService);
   });
 
+  describe('Gmail folder path handling', () => {
+    it('should persist the full IMAP path for Gmail special folders', async () => {
+      const mailboxList = [
+        createMockMailbox({
+          path: '[Gmail]/Sent Mail',
+          name: 'Sent Mail',
+          delimiter: '/',
+          parentPath: '[Gmail]',
+        }),
+      ];
+
+      mockImapClient.list.mockResolvedValue(mailboxList);
+      mockImapClient.status.mockResolvedValue({ uidValidity: BigInt(42) } as any);
+      imapFindSentFolderService.findSentFolder.mockResolvedValue({
+        path: '[Gmail]/Sent Mail',
+        name: 'Sent Mail',
+      });
+
+      const result = await service.getAllMessageFolders(
+        CONNECTED_ACCOUNT,
+        MESSAGE_CHANNEL,
+      );
+
+      expect(result).toHaveLength(1);
+      expect(result[0]).toMatchObject({
+        externalId: '[Gmail]/Sent Mail:42',
+        name: '[Gmail]/Sent Mail',
+        isSentFolder: true,
+      });
+    });
+  });
+
   describe('Noselect folder handling', () => {
     it('should not issue STATUS against a \\Noselect folder', async () => {
       const mailboxList = [

--- a/packages/twenty-server/src/modules/messaging/message-folder-manager/drivers/imap/services/imap-get-all-folders.service.ts
+++ b/packages/twenty-server/src/modules/messaging/message-folder-manager/drivers/imap/services/imap-get-all-folders.service.ts
@@ -86,7 +86,7 @@ export class ImapGetAllFoldersService implements MessageFolderDriver {
 
       folders.push({
         externalId,
-        name: sentFolder.name,
+        name: sentFolder.path,
         isSynced: true,
         isSentFolder: true,
         parentFolderId: sentMailbox?.parentPath || null,
@@ -120,7 +120,7 @@ export class ImapGetAllFoldersService implements MessageFolderDriver {
 
       folders.push({
         externalId,
-        name: mailbox.name,
+        name: mailbox.path,
         isSynced,
         isSentFolder: false,
         parentFolderId: mailbox.parentPath || null,


### PR DESCRIPTION
## Summary

Fixes Gmail IMAP send failures where Twenty stores only the mailbox leaf name (`Sent Mail`) instead of the full IMAP hierarchy path (`[Gmail]/Sent Mail`).

For Gmail / Google Workspace, special folders live under the `[Gmail]/` namespace. Persisting only the leaf name causes outbound send to later issue `APPEND "Sent Mail"`, which Gmail rejects with `NO [TRYCREATE]` because the mailbox does not exist at the root.

## Related issue

Fixes #20469

## Changes

- Persist `sentFolder.path` instead of `sentFolder.name` for the sent folder
- Persist `mailbox.path` instead of `mailbox.name` for discovered IMAP folders
- Add a unit test covering Gmail's `[Gmail]/Sent Mail` path behavior

## Why this is safe

`externalId` already uses `mailbox.path`, and outbound send relies on `messageFolder.name` as the IMAP append target. Storing the full path keeps the displayed/stored target aligned with the actual IMAP mailbox path.

## Testing

- Added unit test verifying Gmail sent folder is stored as `[Gmail]/Sent Mail`, not `Sent Mail`
- Manual verification against the issue root cause: `APPEND "[Gmail]/Sent Mail"` targets the real Gmail special folder path, while `APPEND "Sent Mail"` fails.
