### PR TITLE
chore(.vscode): add remaining packages to VSCode workspace

### DIFF
--- a/.vscode/twenty.code-workspace
+++ b/.vscode/twenty.code-workspace
@@ -43,6 +43,46 @@
     {
       "name": "packages/twenty-e2e-testing",
       "path": "../packages/twenty-e2e-testing"
+    },
+    {
+      "name": "packages/twenty-docs",
+      "path": "../packages/twenty-docs"
+    },
+    {
+      "name": "packages/create-twenty-app",
+      "path": "../packages/create-twenty-app"
+    },
+    {
+      "name": "packages/twenty-apps",
+      "path": "../packages/twenty-apps"
+    },
+    {
+      "name": "packages/twenty-claude-skills",
+      "path": "../packages/twenty-claude-skills"
+    },
+    {
+      "name": "packages/twenty-cli",
+      "path": "../packages/twenty-cli"
+    },
+    {
+      "name": "packages/twenty-client-sdk",
+      "path": "../packages/twenty-client-sdk"
+    },
+    {
+      "name": "packages/twenty-companion",
+      "path": "../packages/twenty-companion"
+    },
+    {
+      "name": "packages/twenty-front-component-renderer",
+      "path": "../packages/twenty-front-component-renderer"
+    },
+    {
+      "name": "packages/twenty-sdk",
+      "path": "../packages/twenty-sdk"
+    },
+    {
+      "name": "packages/twenty-website-new",
+      "path": "../packages/twenty-website-new"
     }
   ],
   "settings": {


### PR DESCRIPTION
## Context
This PR extends the multi-root VSCode workspace configuration introduced in #2937  by adding the remaining packages from the `packages/*` directories to the `twenty.code-workspace` folders array.

## Problem
Previously, some packages were not added to the multi-root workspace configuration. As a result, when opening the repository as a vscode workspace, those packages were hidden from the VSCode Explorer because they were not part of the configured workspace folders.

## Benefits

- Prevents packages from being hidden when the repository is opened as a vscode workspace.
- Improves consistency and navigation across the monorepo workspace experience.

## Related PR
- #2937 