### PR TITLE
fix(imap): log imapflow response detail on send failure and add Gmail namespace regression test

### DIFF
--- a/packages/twenty-server/src/modules/messaging/message-folder-manager/drivers/imap/services/__tests__/imap-get-all-folders.service.spec.ts
+++ b/packages/twenty-server/src/modules/messaging/message-folder-manager/drivers/imap/services/__tests__/imap-get-all-folders.service.spec.ts
@@ -160,7 +160,47 @@ describe('ImapGetAllFoldersService', () => {
       }
     });
 
-    it('should exclude \\Noselect sent folder from results and skip STATUS', async () => {
+    it('should store the full IMAP path (e.g. [Gmail]/Sent Mail) as externalId for namespaced sent folders', async () => {
+      // Gmail-style: special folders live under [Gmail]/ namespace
+      // mailbox.name === 'Sent Mail', mailbox.path === '[Gmail]/Sent Mail'
+      // The APPEND command needs the path, not the leaf name, or it gets TRYCREATE
+      const mailboxList = [
+        createMockMailbox({ path: 'INBOX' }),
+        createMockMailbox({
+          path: '[Gmail]/Sent Mail',
+          name: 'Sent Mail',
+          parentPath: '[Gmail]',
+        }),
+      ];
+
+      mockImapClient.list.mockResolvedValue(mailboxList);
+      mockImapClient.status.mockImplementation(async (path: string) => {
+        const uidMap: Record<string, bigint> = {
+          INBOX: BigInt(1),
+          '[Gmail]/Sent Mail': BigInt(2),
+        };
+
+        return { uidValidity: uidMap[path] } as any;
+      });
+
+      imapFindSentFolderService.findSentFolder.mockResolvedValue({
+        path: '[Gmail]/Sent Mail',
+        name: 'Sent Mail',
+      });
+
+      const result = await service.getAllMessageFolders(
+        CONNECTED_ACCOUNT,
+        MESSAGE_CHANNEL,
+      );
+
+      const sentFolder = result.find((f) => f.isSentFolder);
+
+      expect(sentFolder).toBeDefined();
+      // externalId should encode the full path so getImapFolderPath() returns '[Gmail]/Sent Mail'
+      expect(sentFolder?.externalId).toMatch(/^\[Gmail\]\/Sent Mail/);
+    });
+
+    it('should exclude \\\\Noselect sent folder from results and skip STATUS', async () => {
       const mailboxList = [
         createMockMailbox({ path: 'INBOX' }),
         createMockMailbox({

--- a/packages/twenty-server/src/modules/messaging/message-outbound-manager/resolvers/send-email.resolver.ts
+++ b/packages/twenty-server/src/modules/messaging/message-outbound-manager/resolvers/send-email.resolver.ts
@@ -107,7 +107,11 @@ export class SendEmailResolver {
         throw error;
       }
 
-      this.logger.error(`Failed to send email: ${error}`);
+      this.logger.error(`Failed to send email: ${error}`, {
+        stack: error instanceof Error ? error.stack : undefined,
+        response: (error as any)?.response,
+        responseStatus: (error as any)?.responseStatus,
+      });
 
       return {
         success: false,


### PR DESCRIPTION
Closes #20469

When appending to a Gmail sent folder fails with TRYCREATE, the catch block in `SendEmailResolver` was logging only the stringified error message — swallowing the `response` and `responseStatus` fields that imapflow attaches to the thrown Error. This makes the failure completely opaque in production logs.

This PR updates the logger call to include both fields so the actual IMAP server response (e.g. `NO [TRYCREATE] Unknown Mailbox: Sent Mail`) is visible when troubleshooting.

It also adds a regression test for `ImapGetAllFoldersService` that covers the Gmail namespace case: when imapflow returns a mailbox with `path: '[Gmail]/Sent Mail'` and `name: 'Sent Mail'`, the service should encode the **full path** into `externalId` (which it does — `externalId` is `[Gmail]/Sent Mail:uid`), so that `getImapFolderPath()` resolves to `[Gmail]/Sent Mail` for the IMAP APPEND call rather than the leaf name `Sent Mail` that Gmail rejects.

The test catches any future regression where someone might accidentally switch back to `mailbox.name` for the externalId.

/claim #20469