### PR TITLE
fix(docs): replace removed Mintlify build command

### DIFF
--- a/packages/twenty-docs/README.md
+++ b/packages/twenty-docs/README.md
@@ -72,11 +72,11 @@ Your content here...
 - `package.json` - Package dependencies and scripts (`docs:generate`, `docs:generate-navigation-template`, …).
 - `project.json` - Nx workspace configuration
 
-## 📦 Build validation
+## 📦 Validation
 
 ```bash
 # Validate the documentation build
-npx nx run twenty-docs:build
+npx nx run twenty-docs:validate
 ```
 
 ## 🔗 Links

--- a/packages/twenty-docs/README.md
+++ b/packages/twenty-docs/README.md
@@ -72,10 +72,10 @@ Your content here...
 - `package.json` - Package dependencies and scripts (`docs:generate`, `docs:generate-navigation-template`, …).
 - `project.json` - Nx workspace configuration
 
-## 📦 Building
+## 📦 Build validation
 
 ```bash
-# Build the documentation
+# Validate the documentation build
 npx nx run twenty-docs:build
 ```
 
@@ -97,4 +97,3 @@ To contribute to the documentation:
 ## 📄 License
 
 This documentation is part of the Twenty project and is licensed under [AGPL-3.0](../../LICENSE).
-

--- a/packages/twenty-docs/package.json
+++ b/packages/twenty-docs/package.json
@@ -6,7 +6,7 @@
   "license": "AGPL-3.0",
   "scripts": {
     "dev": "mintlify dev",
-    "build": "mintlify build",
+    "build": "mintlify validate",
     "fix-links": "bash scripts/fix-translated-links.sh",
     "lint": "npx oxlint -c .oxlintrc.json ."
   },

--- a/packages/twenty-docs/package.json
+++ b/packages/twenty-docs/package.json
@@ -6,7 +6,7 @@
   "license": "AGPL-3.0",
   "scripts": {
     "dev": "mintlify dev",
-    "build": "mintlify validate",
+    "validate": "mintlify validate",
     "fix-links": "bash scripts/fix-translated-links.sh",
     "lint": "npx oxlint -c .oxlintrc.json ."
   },

--- a/packages/twenty-docs/project.json
+++ b/packages/twenty-docs/project.json
@@ -12,7 +12,7 @@
         "command": "mintlify dev"
       }
     },
-    "build": {
+    "validate": {
       "executor": "nx:run-commands",
       "options": {
         "cwd": "{projectRoot}",

--- a/packages/twenty-docs/project.json
+++ b/packages/twenty-docs/project.json
@@ -14,10 +14,9 @@
     },
     "build": {
       "executor": "nx:run-commands",
-      "outputs": ["{projectRoot}/.mintlify"],
       "options": {
         "cwd": "{projectRoot}",
-        "command": "mintlify build"
+        "command": "mintlify validate"
       }
     },
     "lint": {},


### PR DESCRIPTION
## Summary
Closes #20565.

The Twenty docs package still pointed contributors at the removed `mintlify build` command. This switches the docs workflow to a `validate` command, which matches the supported Mintlify CLI command for validating the documentation build, and updates the README wording to match.

## Changes
- Replaced the `twenty-docs` package `build` script with a `validate` script.
- Renamed the Nx docs target from `build` to `validate` and kept it wired to `mintlify validate`.
- Updated the README validation command to `npx nx run twenty-docs:validate`.

## Verification
```bash
$ npx -y mintlify validate --help
usage: mintlify validate [options]

Options:
  -t, --telemetry        Enable or disable anonymous usage telemetry   [boolean]
      --groups           Mock user groups for validation                 [array]
      --disable-openapi  Disable OpenAPI file generation
                                                      [boolean] [default: false]
  -h, --help             Show help                                     [boolean]
  -v, --version          Show version number                           [boolean]

Examples:
  mintlify validate  validate the build
```

```bash
$ npx -y mintlify build
Unknown command: build
```

I also started `npx -y mintlify validate --disable-openapi`; the CLI recognized the command and began validating, but this Windows environment could not finish Mintlify framework extraction because it hit an EPERM symlink error inside the local `.mintlify` cache.
