### PR TITLE
Fix Gmail folder backfill when enabling sync

### DIFF
--- a/packages/twenty-server/src/engine/metadata-modules/message-folder/message-folder-metadata.service.spec.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/message-folder/message-folder-metadata.service.spec.ts
@@ -1,0 +1,216 @@
+import { Test, type TestingModule } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+
+import {
+  ConnectedAccountProvider,
+  MessageChannelSyncStage,
+  MessageFolderPendingSyncAction,
+} from 'twenty-shared/types';
+import { In } from 'typeorm';
+
+import { ConnectedAccountMetadataService } from 'src/engine/metadata-modules/connected-account/connected-account-metadata.service';
+import { MessageChannelMetadataService } from 'src/engine/metadata-modules/message-channel/message-channel-metadata.service';
+import { MessageFolderEntity } from 'src/engine/metadata-modules/message-folder/entities/message-folder.entity';
+import { MessageFolderMetadataService } from 'src/engine/metadata-modules/message-folder/message-folder-metadata.service';
+
+describe('MessageFolderMetadataService', () => {
+  let service: MessageFolderMetadataService;
+  let messageFolderRepository: {
+    find: jest.Mock;
+    findOne: jest.Mock;
+    findOneOrFail: jest.Mock;
+    update: jest.Mock;
+  };
+  let messageChannelMetadataService: {
+    findById: jest.Mock;
+    update: jest.Mock;
+  };
+  let connectedAccountMetadataService: {
+    findById: jest.Mock;
+    getUserConnectedAccountIds: jest.Mock;
+  };
+
+  beforeEach(async () => {
+    messageFolderRepository = {
+      find: jest.fn(),
+      findOne: jest.fn(),
+      findOneOrFail: jest.fn(),
+      update: jest.fn().mockResolvedValue(undefined),
+    };
+    messageChannelMetadataService = {
+      findById: jest.fn(),
+      update: jest.fn().mockResolvedValue(undefined),
+    };
+    connectedAccountMetadataService = {
+      findById: jest.fn(),
+      getUserConnectedAccountIds: jest.fn(),
+    };
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        MessageFolderMetadataService,
+        {
+          provide: getRepositoryToken(MessageFolderEntity),
+          useValue: messageFolderRepository,
+        },
+        {
+          provide: MessageChannelMetadataService,
+          useValue: messageChannelMetadataService,
+        },
+        {
+          provide: ConnectedAccountMetadataService,
+          useValue: connectedAccountMetadataService,
+        },
+      ],
+    }).compile();
+
+    service = module.get<MessageFolderMetadataService>(
+      MessageFolderMetadataService,
+    );
+  });
+
+  it('resets the Google channel cursor when disabled folders are enabled in bulk', async () => {
+    messageFolderRepository.find
+      .mockResolvedValueOnce([
+        {
+          id: 'folder-1',
+          messageChannelId: 'google-channel',
+        },
+        {
+          id: 'folder-2',
+          messageChannelId: 'imap-channel',
+        },
+      ])
+      .mockResolvedValueOnce([
+        {
+          id: 'folder-1',
+          isSynced: true,
+        },
+        {
+          id: 'folder-2',
+          isSynced: true,
+        },
+      ]);
+
+    messageChannelMetadataService.findById.mockImplementation(({ id }) => {
+      if (id === 'google-channel') {
+        return Promise.resolve({
+          id,
+          connectedAccountId: 'google-account',
+        });
+      }
+
+      return Promise.resolve({
+        id,
+        connectedAccountId: 'imap-account',
+      });
+    });
+
+    connectedAccountMetadataService.findById.mockImplementation(({ id }) => {
+      if (id === 'google-account') {
+        return Promise.resolve({
+          id,
+          provider: ConnectedAccountProvider.GOOGLE,
+        });
+      }
+
+      return Promise.resolve({
+        id,
+        provider: ConnectedAccountProvider.IMAP_SMTP_CALDAV,
+      });
+    });
+
+    await service.updateMany({
+      ids: ['folder-1', 'folder-2'],
+      workspaceId: 'workspace-id',
+      data: { isSynced: true },
+    });
+
+    expect(messageFolderRepository.find).toHaveBeenNthCalledWith(1, {
+      where: {
+        id: In(['folder-1', 'folder-2']),
+        workspaceId: 'workspace-id',
+        isSynced: false,
+      },
+      select: ['id', 'messageChannelId'],
+    });
+    expect(messageChannelMetadataService.update).toHaveBeenCalledTimes(1);
+    expect(messageChannelMetadataService.update).toHaveBeenCalledWith({
+      id: 'google-channel',
+      workspaceId: 'workspace-id',
+      data: {
+        syncCursor: '',
+        syncStage: MessageChannelSyncStage.MESSAGE_LIST_FETCH_PENDING,
+        syncStageStartedAt: null,
+      },
+    });
+    expect(messageFolderRepository.update).toHaveBeenCalledWith(
+      { id: In(['folder-1', 'folder-2']), workspaceId: 'workspace-id' },
+      { isSynced: true },
+    );
+  });
+
+  it('does not reset channel cursors when folders are disabled', async () => {
+    messageFolderRepository.find.mockResolvedValueOnce([
+      {
+        id: 'folder-1',
+        isSynced: false,
+      },
+    ]);
+
+    await service.updateMany({
+      ids: ['folder-1'],
+      workspaceId: 'workspace-id',
+      data: { isSynced: false },
+    });
+
+    expect(messageChannelMetadataService.findById).not.toHaveBeenCalled();
+    expect(messageChannelMetadataService.update).not.toHaveBeenCalled();
+    expect(messageFolderRepository.update).toHaveBeenCalledWith(
+      { id: In(['folder-1']), workspaceId: 'workspace-id' },
+      { isSynced: false },
+    );
+  });
+
+  it('resets the Google channel cursor when one disabled folder is enabled', async () => {
+    messageFolderRepository.find.mockResolvedValueOnce([
+      {
+        id: 'folder-1',
+        messageChannelId: 'google-channel',
+      },
+    ]);
+    messageFolderRepository.findOneOrFail.mockResolvedValueOnce({
+      id: 'folder-1',
+      isSynced: true,
+      pendingSyncAction: MessageFolderPendingSyncAction.NONE,
+    });
+    messageChannelMetadataService.findById.mockResolvedValueOnce({
+      id: 'google-channel',
+      connectedAccountId: 'google-account',
+    });
+    connectedAccountMetadataService.findById.mockResolvedValueOnce({
+      id: 'google-account',
+      provider: ConnectedAccountProvider.GOOGLE,
+    });
+
+    await service.update({
+      id: 'folder-1',
+      workspaceId: 'workspace-id',
+      data: { isSynced: true },
+    });
+
+    expect(messageChannelMetadataService.update).toHaveBeenCalledWith({
+      id: 'google-channel',
+      workspaceId: 'workspace-id',
+      data: {
+        syncCursor: '',
+        syncStage: MessageChannelSyncStage.MESSAGE_LIST_FETCH_PENDING,
+        syncStageStartedAt: null,
+      },
+    });
+    expect(messageFolderRepository.update).toHaveBeenCalledWith(
+      { id: 'folder-1', workspaceId: 'workspace-id' },
+      { isSynced: true },
+    );
+  });
+});

--- a/packages/twenty-server/src/engine/metadata-modules/message-folder/message-folder-metadata.service.spec.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/message-folder/message-folder-metadata.service.spec.ts
@@ -9,6 +9,7 @@ import {
 import { In } from 'typeorm';
 
 import { ConnectedAccountMetadataService } from 'src/engine/metadata-modules/connected-account/connected-account-metadata.service';
+import { MessageChannelEntity } from 'src/engine/metadata-modules/message-channel/entities/message-channel.entity';
 import { MessageChannelMetadataService } from 'src/engine/metadata-modules/message-channel/message-channel-metadata.service';
 import { MessageFolderEntity } from 'src/engine/metadata-modules/message-folder/entities/message-folder.entity';
 import { MessageFolderMetadataService } from 'src/engine/metadata-modules/message-folder/message-folder-metadata.service';
@@ -19,6 +20,12 @@ describe('MessageFolderMetadataService', () => {
     find: jest.Mock;
     findOne: jest.Mock;
     findOneOrFail: jest.Mock;
+    manager: {
+      transaction: jest.Mock;
+    };
+    update: jest.Mock;
+  };
+  let transactionManager: {
     update: jest.Mock;
   };
   let messageChannelMetadataService: {
@@ -31,10 +38,16 @@ describe('MessageFolderMetadataService', () => {
   };
 
   beforeEach(async () => {
+    transactionManager = {
+      update: jest.fn().mockResolvedValue(undefined),
+    };
     messageFolderRepository = {
       find: jest.fn(),
       findOne: jest.fn(),
       findOneOrFail: jest.fn(),
+      manager: {
+        transaction: jest.fn((callback) => callback(transactionManager)),
+      },
       update: jest.fn().mockResolvedValue(undefined),
     };
     messageChannelMetadataService = {
@@ -134,20 +147,23 @@ describe('MessageFolderMetadataService', () => {
       },
       select: ['id', 'messageChannelId'],
     });
-    expect(messageChannelMetadataService.update).toHaveBeenCalledTimes(1);
-    expect(messageChannelMetadataService.update).toHaveBeenCalledWith({
-      id: 'google-channel',
-      workspaceId: 'workspace-id',
-      data: {
+    expect(transactionManager.update).toHaveBeenNthCalledWith(
+      1,
+      MessageFolderEntity,
+      { id: In(['folder-1', 'folder-2']), workspaceId: 'workspace-id' },
+      { isSynced: true },
+    );
+    expect(transactionManager.update).toHaveBeenNthCalledWith(
+      2,
+      MessageChannelEntity,
+      { id: In(['google-channel']), workspaceId: 'workspace-id' },
+      {
         syncCursor: '',
         syncStage: MessageChannelSyncStage.MESSAGE_LIST_FETCH_PENDING,
         syncStageStartedAt: null,
       },
-    });
-    expect(messageFolderRepository.update).toHaveBeenCalledWith(
-      { id: In(['folder-1', 'folder-2']), workspaceId: 'workspace-id' },
-      { isSynced: true },
     );
+    expect(messageChannelMetadataService.update).not.toHaveBeenCalled();
   });
 
   it('does not reset channel cursors when folders are disabled', async () => {
@@ -166,7 +182,9 @@ describe('MessageFolderMetadataService', () => {
 
     expect(messageChannelMetadataService.findById).not.toHaveBeenCalled();
     expect(messageChannelMetadataService.update).not.toHaveBeenCalled();
-    expect(messageFolderRepository.update).toHaveBeenCalledWith(
+    expect(transactionManager.update).toHaveBeenCalledTimes(1);
+    expect(transactionManager.update).toHaveBeenCalledWith(
+      MessageFolderEntity,
       { id: In(['folder-1']), workspaceId: 'workspace-id' },
       { isSynced: false },
     );
@@ -199,18 +217,22 @@ describe('MessageFolderMetadataService', () => {
       data: { isSynced: true },
     });
 
-    expect(messageChannelMetadataService.update).toHaveBeenCalledWith({
-      id: 'google-channel',
-      workspaceId: 'workspace-id',
-      data: {
+    expect(transactionManager.update).toHaveBeenNthCalledWith(
+      1,
+      MessageFolderEntity,
+      { id: 'folder-1', workspaceId: 'workspace-id' },
+      { isSynced: true },
+    );
+    expect(transactionManager.update).toHaveBeenNthCalledWith(
+      2,
+      MessageChannelEntity,
+      { id: In(['google-channel']), workspaceId: 'workspace-id' },
+      {
         syncCursor: '',
         syncStage: MessageChannelSyncStage.MESSAGE_LIST_FETCH_PENDING,
         syncStageStartedAt: null,
       },
-    });
-    expect(messageFolderRepository.update).toHaveBeenCalledWith(
-      { id: 'folder-1', workspaceId: 'workspace-id' },
-      { isSynced: true },
     );
+    expect(messageChannelMetadataService.update).not.toHaveBeenCalled();
   });
 });

--- a/packages/twenty-server/src/engine/metadata-modules/message-folder/message-folder-metadata.service.spec.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/message-folder/message-folder-metadata.service.spec.ts
@@ -155,10 +155,15 @@ describe('MessageFolderMetadataService', () => {
     );
     expect(transactionManager.update).toHaveBeenNthCalledWith(
       2,
+      MessageFolderEntity,
+      { id: In(['folder-1']), workspaceId: 'workspace-id' },
+      { syncCursor: '' },
+    );
+    expect(transactionManager.update).toHaveBeenNthCalledWith(
+      3,
       MessageChannelEntity,
       { id: In(['google-channel']), workspaceId: 'workspace-id' },
       {
-        syncCursor: '',
         syncStage: MessageChannelSyncStage.MESSAGE_LIST_FETCH_PENDING,
         syncStageStartedAt: null,
       },
@@ -225,10 +230,15 @@ describe('MessageFolderMetadataService', () => {
     );
     expect(transactionManager.update).toHaveBeenNthCalledWith(
       2,
+      MessageFolderEntity,
+      { id: In(['folder-1']), workspaceId: 'workspace-id' },
+      { syncCursor: '' },
+    );
+    expect(transactionManager.update).toHaveBeenNthCalledWith(
+      3,
       MessageChannelEntity,
       { id: In(['google-channel']), workspaceId: 'workspace-id' },
       {
-        syncCursor: '',
         syncStage: MessageChannelSyncStage.MESSAGE_LIST_FETCH_PENDING,
         syncStageStartedAt: null,
       },

--- a/packages/twenty-server/src/engine/metadata-modules/message-folder/message-folder-metadata.service.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/message-folder/message-folder-metadata.service.ts
@@ -1,7 +1,7 @@
 import { Injectable } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 
-import { In, Repository } from 'typeorm';
+import { EntityManager, In, Repository } from 'typeorm';
 
 import {
   ConnectedAccountProvider,
@@ -10,6 +10,7 @@ import {
 } from 'twenty-shared/types';
 
 import { ConnectedAccountMetadataService } from 'src/engine/metadata-modules/connected-account/connected-account-metadata.service';
+import { MessageChannelEntity } from 'src/engine/metadata-modules/message-channel/entities/message-channel.entity';
 import { MessageFolderDTO } from 'src/engine/metadata-modules/message-folder/dtos/message-folder.dto';
 import { MessageFolderEntity } from 'src/engine/metadata-modules/message-folder/entities/message-folder.entity';
 import {
@@ -186,13 +187,20 @@ export class MessageFolderMetadataService {
         data,
       });
 
-    await this.repository.update(
-      { id, workspaceId },
-      data as Record<string, unknown>,
-    );
+    await this.repository.manager.transaction(async (transactionManager) => {
+      await transactionManager.update(
+        MessageFolderEntity,
+        { id, workspaceId },
+        data as Record<string, unknown>,
+      );
 
-    await this.resetGoogleMessageChannelCursor(googleMessageChannelIdsToReset, {
-      workspaceId,
+      await this.resetGoogleMessageChannelCursor(
+        transactionManager,
+        googleMessageChannelIdsToReset,
+        {
+          workspaceId,
+        },
+      );
     });
 
     return this.repository.findOneOrFail({ where: { id, workspaceId } });
@@ -214,13 +222,20 @@ export class MessageFolderMetadataService {
         data,
       });
 
-    await this.repository.update(
-      { id: In(ids), workspaceId },
-      data as Record<string, unknown>,
-    );
+    await this.repository.manager.transaction(async (transactionManager) => {
+      await transactionManager.update(
+        MessageFolderEntity,
+        { id: In(ids), workspaceId },
+        data as Record<string, unknown>,
+      );
 
-    await this.resetGoogleMessageChannelCursor(googleMessageChannelIdsToReset, {
-      workspaceId,
+      await this.resetGoogleMessageChannelCursor(
+        transactionManager,
+        googleMessageChannelIdsToReset,
+        {
+          workspaceId,
+        },
+      );
     });
 
     return this.repository.find({ where: { id: In(ids), workspaceId } });
@@ -276,21 +291,22 @@ export class MessageFolderMetadataService {
   }
 
   private async resetGoogleMessageChannelCursor(
+    transactionManager: EntityManager,
     messageChannelIds: string[],
     { workspaceId }: { workspaceId: string },
   ): Promise<void> {
-    await Promise.all(
-      messageChannelIds.map((messageChannelId) =>
-        this.messageChannelMetadataService.update({
-          id: messageChannelId,
-          workspaceId,
-          data: {
-            syncCursor: '',
-            syncStage: MessageChannelSyncStage.MESSAGE_LIST_FETCH_PENDING,
-            syncStageStartedAt: null,
-          },
-        }),
-      ),
+    if (messageChannelIds.length === 0) {
+      return;
+    }
+
+    await transactionManager.update(
+      MessageChannelEntity,
+      { id: In(messageChannelIds), workspaceId },
+      {
+        syncCursor: '',
+        syncStage: MessageChannelSyncStage.MESSAGE_LIST_FETCH_PENDING,
+        syncStageStartedAt: null,
+      },
     );
   }
 

--- a/packages/twenty-server/src/engine/metadata-modules/message-folder/message-folder-metadata.service.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/message-folder/message-folder-metadata.service.ts
@@ -3,7 +3,11 @@ import { InjectRepository } from '@nestjs/typeorm';
 
 import { In, Repository } from 'typeorm';
 
-import { MessageFolderPendingSyncAction } from 'twenty-shared/types';
+import {
+  ConnectedAccountProvider,
+  MessageChannelSyncStage,
+  MessageFolderPendingSyncAction,
+} from 'twenty-shared/types';
 
 import { ConnectedAccountMetadataService } from 'src/engine/metadata-modules/connected-account/connected-account-metadata.service';
 import { MessageFolderDTO } from 'src/engine/metadata-modules/message-folder/dtos/message-folder.dto';
@@ -175,10 +179,21 @@ export class MessageFolderMetadataService {
     workspaceId: string;
     data: Partial<MessageFolderEntity>;
   }): Promise<MessageFolderDTO> {
+    const googleMessageChannelIdsToReset =
+      await this.findGoogleMessageChannelIdsForEnabledFolders({
+        ids: [id],
+        workspaceId,
+        data,
+      });
+
     await this.repository.update(
       { id, workspaceId },
       data as Record<string, unknown>,
     );
+
+    await this.resetGoogleMessageChannelCursor(googleMessageChannelIdsToReset, {
+      workspaceId,
+    });
 
     return this.repository.findOneOrFail({ where: { id, workspaceId } });
   }
@@ -192,12 +207,91 @@ export class MessageFolderMetadataService {
     workspaceId: string;
     data: Partial<MessageFolderEntity>;
   }): Promise<MessageFolderDTO[]> {
+    const googleMessageChannelIdsToReset =
+      await this.findGoogleMessageChannelIdsForEnabledFolders({
+        ids,
+        workspaceId,
+        data,
+      });
+
     await this.repository.update(
       { id: In(ids), workspaceId },
       data as Record<string, unknown>,
     );
 
+    await this.resetGoogleMessageChannelCursor(googleMessageChannelIdsToReset, {
+      workspaceId,
+    });
+
     return this.repository.find({ where: { id: In(ids), workspaceId } });
+  }
+
+  private async findGoogleMessageChannelIdsForEnabledFolders({
+    ids,
+    workspaceId,
+    data,
+  }: {
+    ids: string[];
+    workspaceId: string;
+    data: Partial<MessageFolderEntity>;
+  }): Promise<string[]> {
+    if (data.isSynced !== true || ids.length === 0) {
+      return [];
+    }
+
+    const newlyEnabledFolders = await this.repository.find({
+      where: { id: In(ids), workspaceId, isSynced: false },
+      select: ['id', 'messageChannelId'],
+    });
+
+    const messageChannelIds = [
+      ...new Set(newlyEnabledFolders.map((folder) => folder.messageChannelId)),
+    ];
+
+    const googleMessageChannelIds = await Promise.all(
+      messageChannelIds.map(async (messageChannelId) => {
+        const messageChannel =
+          await this.messageChannelMetadataService.findById({
+            id: messageChannelId,
+            workspaceId,
+          });
+
+        if (!messageChannel) {
+          return null;
+        }
+
+        const connectedAccount =
+          await this.connectedAccountMetadataService.findById({
+            id: messageChannel.connectedAccountId,
+            workspaceId,
+          });
+
+        return connectedAccount?.provider === ConnectedAccountProvider.GOOGLE
+          ? messageChannel.id
+          : null;
+      }),
+    );
+
+    return googleMessageChannelIds.filter((id) => id !== null);
+  }
+
+  private async resetGoogleMessageChannelCursor(
+    messageChannelIds: string[],
+    { workspaceId }: { workspaceId: string },
+  ): Promise<void> {
+    await Promise.all(
+      messageChannelIds.map((messageChannelId) =>
+        this.messageChannelMetadataService.update({
+          id: messageChannelId,
+          workspaceId,
+          data: {
+            syncCursor: '',
+            syncStage: MessageChannelSyncStage.MESSAGE_LIST_FETCH_PENDING,
+            syncStageStartedAt: null,
+          },
+        }),
+      ),
+    );
   }
 
   async delete({

--- a/packages/twenty-server/src/engine/metadata-modules/message-folder/message-folder-metadata.service.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/message-folder/message-folder-metadata.service.ts
@@ -180,8 +180,8 @@ export class MessageFolderMetadataService {
     workspaceId: string;
     data: Partial<MessageFolderEntity>;
   }): Promise<MessageFolderDTO> {
-    const googleMessageChannelIdsToReset =
-      await this.findGoogleMessageChannelIdsForEnabledFolders({
+    const googleFolderBackfillTargets =
+      await this.findGoogleFolderBackfillTargetsForEnabledFolders({
         ids: [id],
         workspaceId,
         data,
@@ -194,9 +194,9 @@ export class MessageFolderMetadataService {
         data as Record<string, unknown>,
       );
 
-      await this.resetGoogleMessageChannelCursor(
+      await this.markGoogleFolderBackfillPending(
         transactionManager,
-        googleMessageChannelIdsToReset,
+        googleFolderBackfillTargets,
         {
           workspaceId,
         },
@@ -215,8 +215,8 @@ export class MessageFolderMetadataService {
     workspaceId: string;
     data: Partial<MessageFolderEntity>;
   }): Promise<MessageFolderDTO[]> {
-    const googleMessageChannelIdsToReset =
-      await this.findGoogleMessageChannelIdsForEnabledFolders({
+    const googleFolderBackfillTargets =
+      await this.findGoogleFolderBackfillTargetsForEnabledFolders({
         ids,
         workspaceId,
         data,
@@ -229,9 +229,9 @@ export class MessageFolderMetadataService {
         data as Record<string, unknown>,
       );
 
-      await this.resetGoogleMessageChannelCursor(
+      await this.markGoogleFolderBackfillPending(
         transactionManager,
-        googleMessageChannelIdsToReset,
+        googleFolderBackfillTargets,
         {
           workspaceId,
         },
@@ -241,7 +241,7 @@ export class MessageFolderMetadataService {
     return this.repository.find({ where: { id: In(ids), workspaceId } });
   }
 
-  private async findGoogleMessageChannelIdsForEnabledFolders({
+  private async findGoogleFolderBackfillTargetsForEnabledFolders({
     ids,
     workspaceId,
     data,
@@ -249,9 +249,12 @@ export class MessageFolderMetadataService {
     ids: string[];
     workspaceId: string;
     data: Partial<MessageFolderEntity>;
-  }): Promise<string[]> {
+  }): Promise<{
+    messageChannelIds: string[];
+    messageFolderIds: string[];
+  }> {
     if (data.isSynced !== true || ids.length === 0) {
-      return [];
+      return { messageChannelIds: [], messageFolderIds: [] };
     }
 
     const newlyEnabledFolders = await this.repository.find({
@@ -263,7 +266,7 @@ export class MessageFolderMetadataService {
       ...new Set(newlyEnabledFolders.map((folder) => folder.messageChannelId)),
     ];
 
-    const googleMessageChannelIds = await Promise.all(
+    const googleTargets = await Promise.all(
       messageChannelIds.map(async (messageChannelId) => {
         const messageChannel =
           await this.messageChannelMetadataService.findById({
@@ -272,7 +275,7 @@ export class MessageFolderMetadataService {
           });
 
         if (!messageChannel) {
-          return null;
+          return { messageChannelId: null, messageFolderIds: [] };
         }
 
         const connectedAccount =
@@ -281,29 +284,54 @@ export class MessageFolderMetadataService {
             workspaceId,
           });
 
-        return connectedAccount?.provider === ConnectedAccountProvider.GOOGLE
-          ? messageChannel.id
-          : null;
+        if (connectedAccount?.provider !== ConnectedAccountProvider.GOOGLE) {
+          return { messageChannelId: null, messageFolderIds: [] };
+        }
+
+        return {
+          messageChannelId: messageChannel.id,
+          messageFolderIds: newlyEnabledFolders
+            .filter((folder) => folder.messageChannelId === messageChannel.id)
+            .map((folder) => folder.id),
+        };
       }),
     );
 
-    return googleMessageChannelIds.filter((id) => id !== null);
+    return {
+      messageChannelIds: googleTargets
+        .map((target) => target.messageChannelId)
+        .filter((id) => id !== null),
+      messageFolderIds: googleTargets.flatMap(
+        (target) => target.messageFolderIds,
+      ),
+    };
   }
 
-  private async resetGoogleMessageChannelCursor(
+  private async markGoogleFolderBackfillPending(
     transactionManager: EntityManager,
-    messageChannelIds: string[],
+    {
+      messageChannelIds,
+      messageFolderIds,
+    }: {
+      messageChannelIds: string[];
+      messageFolderIds: string[];
+    },
     { workspaceId }: { workspaceId: string },
   ): Promise<void> {
-    if (messageChannelIds.length === 0) {
+    if (messageChannelIds.length === 0 || messageFolderIds.length === 0) {
       return;
     }
+
+    await transactionManager.update(
+      MessageFolderEntity,
+      { id: In(messageFolderIds), workspaceId },
+      { syncCursor: '' },
+    );
 
     await transactionManager.update(
       MessageChannelEntity,
       { id: In(messageChannelIds), workspaceId },
       {
-        syncCursor: '',
         syncStage: MessageChannelSyncStage.MESSAGE_LIST_FETCH_PENDING,
         syncStageStartedAt: null,
       },

--- a/packages/twenty-server/src/modules/messaging/message-import-manager/drivers/gmail/services/gmail-get-message-list.service.spec.ts
+++ b/packages/twenty-server/src/modules/messaging/message-import-manager/drivers/gmail/services/gmail-get-message-list.service.spec.ts
@@ -31,6 +31,7 @@ const createMockFolder = (
 describe('GmailGetMessageListService', () => {
   let service: GmailGetMessageListService;
   let oAuth2ClientManagerService: OAuth2ClientManagerService;
+  let gmailGetHistoryService: GmailGetHistoryService;
 
   const mockConnectedAccount: Pick<
     ConnectedAccountEntity,
@@ -82,6 +83,9 @@ describe('GmailGetMessageListService', () => {
     );
     oAuth2ClientManagerService = module.get<OAuth2ClientManagerService>(
       OAuth2ClientManagerService,
+    );
+    gmailGetHistoryService = module.get<GmailGetHistoryService>(
+      GmailGetHistoryService,
     );
   });
 
@@ -338,6 +342,153 @@ describe('GmailGetMessageListService', () => {
 
       expect(result).toEqual([]);
       expect(mockGmailClient.users.messages.list).not.toHaveBeenCalled();
+    });
+
+    it('should run a targeted folder backfill without clearing the channel cursor', async () => {
+      const mockGmailClient = {
+        users: {
+          messages: {
+            list: jest.fn().mockResolvedValue({
+              data: {
+                messages: [{ id: 'backfill-message' }],
+                nextPageToken: undefined,
+              },
+            }),
+            get: jest.fn().mockResolvedValue({
+              data: {
+                historyId: 'folder-history-id',
+              },
+            }),
+          },
+        },
+      };
+
+      jest.spyOn(google, 'gmail').mockReturnValue(mockGmailClient as never);
+      (
+        oAuth2ClientManagerService.getGoogleOAuth2Client as jest.Mock
+      ).mockResolvedValue({});
+      (gmailGetHistoryService.getHistory as jest.Mock).mockResolvedValue({
+        history: [{ id: 'history-entry' }],
+        historyId: 'channel-history-id',
+      });
+      (
+        gmailGetHistoryService.getMessageIdsFromHistory as jest.Mock
+      ).mockResolvedValue({
+        messagesAdded: ['incremental-message'],
+        messagesDeleted: [],
+      });
+
+      const result = await service.getMessageLists({
+        messageChannel: {
+          syncCursor: 'existing-channel-history-id',
+          id: 'channel-1',
+          messageFolderImportPolicy: MessageFolderImportPolicy.SELECTED_FOLDERS,
+        },
+        connectedAccount: mockConnectedAccount,
+        messageFolders: [
+          createMockFolder({
+            id: 'folder-inbox',
+            name: 'INBOX',
+            externalId: 'INBOX',
+            isSynced: true,
+            syncCursor: 'already-backfilled',
+          }),
+          createMockFolder({
+            id: 'folder-work',
+            name: 'Work',
+            externalId: 'Label_work',
+            isSynced: true,
+            syncCursor: '',
+          }),
+        ],
+      });
+
+      expect(result).toEqual([
+        {
+          messageExternalIds: ['backfill-message'],
+          messageExternalIdsToDelete: [],
+          previousSyncCursor: '',
+          nextSyncCursor: 'folder-history-id',
+          folderId: 'folder-work',
+        },
+        {
+          messageExternalIds: ['incremental-message'],
+          messageExternalIdsToDelete: [],
+          previousSyncCursor: 'existing-channel-history-id',
+          nextSyncCursor: 'channel-history-id',
+          folderId: undefined,
+        },
+      ]);
+      expect(mockGmailClient.users.messages.list).toHaveBeenCalledWith(
+        expect.objectContaining({
+          q: expect.stringContaining('label:work'),
+        }),
+      );
+      expect(mockGmailClient.users.messages.list).not.toHaveBeenCalledWith(
+        expect.objectContaining({
+          q: expect.stringContaining('label:inbox'),
+        }),
+      );
+      expect(gmailGetHistoryService.getHistory).toHaveBeenCalledWith(
+        mockGmailClient,
+        'existing-channel-history-id',
+      );
+    });
+
+    it('should mark an empty targeted folder backfill with the existing channel cursor', async () => {
+      const mockGmailClient = {
+        users: {
+          messages: {
+            list: jest.fn().mockResolvedValue({
+              data: {
+                messages: [],
+                nextPageToken: undefined,
+              },
+            }),
+          },
+        },
+      };
+
+      jest.spyOn(google, 'gmail').mockReturnValue(mockGmailClient as never);
+      (
+        oAuth2ClientManagerService.getGoogleOAuth2Client as jest.Mock
+      ).mockResolvedValue({});
+      (gmailGetHistoryService.getHistory as jest.Mock).mockResolvedValue({
+        history: [],
+        historyId: 'channel-history-id',
+      });
+      (
+        gmailGetHistoryService.getMessageIdsFromHistory as jest.Mock
+      ).mockResolvedValue({
+        messagesAdded: [],
+        messagesDeleted: [],
+      });
+
+      const result = await service.getMessageLists({
+        messageChannel: {
+          syncCursor: 'existing-channel-history-id',
+          id: 'channel-1',
+          messageFolderImportPolicy: MessageFolderImportPolicy.SELECTED_FOLDERS,
+        },
+        connectedAccount: mockConnectedAccount,
+        messageFolders: [
+          createMockFolder({
+            id: 'folder-work',
+            name: 'Work',
+            externalId: 'Label_work',
+            isSynced: true,
+            syncCursor: '',
+          }),
+        ],
+      });
+
+      expect(result[0]).toEqual({
+        messageExternalIds: [],
+        messageExternalIdsToDelete: [],
+        previousSyncCursor: '',
+        nextSyncCursor: 'existing-channel-history-id',
+        folderId: 'folder-work',
+      });
     });
   });
 

--- a/packages/twenty-server/src/modules/messaging/message-import-manager/drivers/gmail/services/gmail-get-message-list.service.ts
+++ b/packages/twenty-server/src/modules/messaging/message-import-manager/drivers/gmail/services/gmail-get-message-list.service.ts
@@ -1,7 +1,7 @@
 import { Injectable, Logger } from '@nestjs/common';
 
 import { isNonEmptyString } from '@sniptt/guards';
-import { google } from 'googleapis';
+import { type gmail_v1, google } from 'googleapis';
 
 import { MessageFolderImportPolicy } from 'twenty-shared/types';
 import { MessageChannelEntity } from 'src/engine/metadata-modules/message-channel/entities/message-channel.entity';
@@ -29,6 +29,7 @@ export class GmailGetMessageListService {
   ) {}
 
   private async getMessageListWithoutCursor(
+    gmailClient: gmail_v1.Gmail,
     connectedAccount: Pick<
       ConnectedAccountEntity,
       | 'provider'
@@ -42,17 +43,12 @@ export class GmailGetMessageListService {
       MessageFolderEntity,
       'name' | 'externalId' | 'isSynced' | 'parentFolderId'
     >[],
-    messageChannel: Pick<MessageChannelEntity, 'messageFolderImportPolicy'>,
+    messageChannel: Pick<
+      MessageChannelEntity,
+      'messageFolderImportPolicy' | 'syncCursor'
+    >,
+    folderId?: string,
   ): Promise<GetMessageListsResponse> {
-    const oAuth2Client =
-      await this.oAuth2ClientManagerService.getGoogleOAuth2Client(
-        connectedAccount,
-      );
-    const gmailClient = google.gmail({
-      version: 'v1',
-      auth: oAuth2Client,
-    });
-
     let pageToken: string | undefined;
     let hasMoreMessages = true;
 
@@ -107,10 +103,10 @@ export class GmailGetMessageListService {
       return [
         {
           messageExternalIds,
-          nextSyncCursor: '',
+          nextSyncCursor: folderId ? (messageChannel.syncCursor ?? '') : '',
           previousSyncCursor: '',
           messageExternalIdsToDelete: [],
-          folderId: undefined,
+          folderId,
         },
       ];
     }
@@ -140,7 +136,7 @@ export class GmailGetMessageListService {
         nextSyncCursor,
         previousSyncCursor: '',
         messageExternalIdsToDelete: [],
-        folderId: undefined,
+        folderId,
       },
     ];
   }
@@ -174,8 +170,33 @@ export class GmailGetMessageListService {
       auth: oAuth2Client,
     });
 
+    const folderBackfillsToRun =
+      messageChannel.messageFolderImportPolicy ===
+        MessageFolderImportPolicy.SELECTED_FOLDERS &&
+      isNonEmptyString(messageChannel.syncCursor)
+        ? messageFolders.filter(
+            (folder) => folder.isSynced && folder.syncCursor === '',
+          )
+        : [];
+
+    const folderBackfillMessageLists = await Promise.all(
+      folderBackfillsToRun.map((folder) =>
+        this.getMessageListWithoutCursor(
+          gmailClient,
+          connectedAccount,
+          messageFolders.map((messageFolder) => ({
+            ...messageFolder,
+            isSynced: messageFolder.id === folder.id,
+          })),
+          messageChannel,
+          folder.id,
+        ),
+      ),
+    );
+
     if (!isNonEmptyString(messageChannel.syncCursor)) {
       return this.getMessageListWithoutCursor(
+        gmailClient,
         connectedAccount,
         messageFolders,
         messageChannel,
@@ -199,6 +220,7 @@ export class GmailGetMessageListService {
     }
 
     return [
+      ...folderBackfillMessageLists.flat(),
       {
         messageExternalIds: messagesAdded,
         messageExternalIdsToDelete: messagesDeleted,


### PR DESCRIPTION
## What changed

Fixes #17095.

When a Gmail folder is toggled from unsynced to synced, the service now marks only that folder for a one-time backfill by clearing the folder-level `syncCursor` and moving its Google message channel back to `MESSAGE_LIST_FETCH_PENDING` in the same transaction.

On the next Gmail list fetch, folders with `syncCursor === ''` are queried with a targeted Gmail label search. The existing channel-level history cursor is preserved, so normal incremental history sync continues from the previous cursor instead of triggering a broad full-channel rescan.

## Notes

- Scoped to Google channels only. IMAP/Microsoft are left unchanged because their folder-level cursor behavior already differs.
- No backfill marker is written when folders are disabled or when the folder was already synced.
- The folder update, folder backfill marker, and channel scheduling update are persisted in one transaction.

## Verification

- `PATH=/tmp/node24/bin:$PATH ../../node_modules/.bin/jest --config ./jest.config.mjs --runInBand --runTestsByPath src/engine/metadata-modules/message-folder/message-folder-metadata.service.spec.ts src/modules/messaging/message-import-manager/drivers/gmail/services/gmail-get-message-list.service.spec.ts`
- `PATH=/tmp/node24/bin:$PATH npx oxlint --type-aware -c .oxlintrc.json src/engine/metadata-modules/message-folder/message-folder-metadata.service.ts src/engine/metadata-modules/message-folder/message-folder-metadata.service.spec.ts src/modules/messaging/message-import-manager/drivers/gmail/services/gmail-get-message-list.service.ts src/modules/messaging/message-import-manager/drivers/gmail/services/gmail-get-message-list.service.spec.ts`
- `PATH=/tmp/node24/bin:$PATH npx tsgo -p tsconfig.json --noEmit`
- `PATH=/tmp/node24/bin:$PATH ./node_modules/.bin/prettier --check packages/twenty-server/src/engine/metadata-modules/message-folder/message-folder-metadata.service.ts packages/twenty-server/src/engine/metadata-modules/message-folder/message-folder-metadata.service.spec.ts packages/twenty-server/src/modules/messaging/message-import-manager/drivers/gmail/services/gmail-get-message-list.service.ts packages/twenty-server/src/modules/messaging/message-import-manager/drivers/gmail/services/gmail-get-message-list.service.spec.ts`
- `git diff --check`