### PR TITLE
fix(server): scope workspace findOne in 1-21 backfill-datasource command

### DIFF
--- a/packages/twenty-server/src/database/commands/upgrade-version-command/1-21/1-21-workspace-command-1775500003000-backfill-datasource-to-workspace.command.ts
+++ b/packages/twenty-server/src/database/commands/upgrade-version-command/1-21/1-21-workspace-command-1775500003000-backfill-datasource-to-workspace.command.ts
@@ -35,11 +35,6 @@ export class BackfillDatasourceToWorkspaceCommand extends ActiveOrSuspendedWorks
   }: RunOnWorkspaceArgs): Promise<void> {
     const isDryRun = options.dryRun ?? false;
 
-    // Explicitly select only the columns this command needs.
-    // A bare findOne emits SELECT on every column declared on WorkspaceEntity,
-    // which breaks cross-version upgrades whenever a newer column has been added
-    // to the entity but its DB column is only created by a later instance command
-    // in the upgrade sequence.
     const workspace = await this.workspaceRepository.findOne({
       select: ['id', 'databaseSchema'],
       where: { id: workspaceId },

--- a/packages/twenty-server/src/database/commands/upgrade-version-command/1-21/1-21-workspace-command-1775500003000-backfill-datasource-to-workspace.command.ts
+++ b/packages/twenty-server/src/database/commands/upgrade-version-command/1-21/1-21-workspace-command-1775500003000-backfill-datasource-to-workspace.command.ts
@@ -35,7 +35,13 @@ export class BackfillDatasourceToWorkspaceCommand extends ActiveOrSuspendedWorks
   }: RunOnWorkspaceArgs): Promise<void> {
     const isDryRun = options.dryRun ?? false;
 
+    // Explicitly select only the columns this command needs.
+    // A bare findOne emits SELECT on every column declared on WorkspaceEntity,
+    // which breaks cross-version upgrades whenever a newer column has been added
+    // to the entity but its DB column is only created by a later instance command
+    // in the upgrade sequence.
     const workspace = await this.workspaceRepository.findOne({
+      select: ['id', 'databaseSchema'],
       where: { id: workspaceId },
     });
 


### PR DESCRIPTION
## Summary

Cross-version upgrades from pre-1-21 instances currently fail with:

```
error: column WorkspaceEntity.isInternalMessagesImportEnabled does not exist
```

(see https://github.com/twentyhq/twenty-infra/actions/runs/25857499266/job/75979993686)

### Root cause

The 1-21 workspace command `backfill-datasource-to-workspace` does:

```ts
const workspace = await this.workspaceRepository.findOne({
  where: { id: workspaceId },
});
```

No `select`, so TypeORM emits a SELECT for every column declared on `WorkspaceEntity`. PR #20457 added `isInternalMessagesImportEnabled` to the entity, but its DB column is only created by the 2-5 fast instance command `1778525104406-add-is-internal-messages-import-enabled`. On a fresh cross-version upgrade, the runner reaches the 1-21 workspace segment before that 2-5 instance command runs, the bare `findOne` issues SELECT on a column that doesn't exist yet, and the upgrade aborts.

### Fix

Narrow the select to just the columns this command actually reads (`id`, `databaseSchema`). The query now ignores entity columns added later in the upgrade sequence.

### Why edit a committed workspace command

Per `CLAUDE.md`, committed *instance* command `up`/`down` logic is immutable. Workspace commands are idempotent backfills — adding a `select` narrows the read but doesn't change behavior, so it's safe.

### Audit

Verified this is the only unguarded `workspaceRepository.find*` across the entire upgrade subtree:
- `WorkspaceIteratorService.iterate` uses `select: ['databaseSchema']`
- `WorkspaceVersionService.getActiveOrSuspendedWorkspaceIds` uses `select: ['id']`
- `UpgradeStatusService.loadActiveOrSuspendedWorkspaces` uses `select: ['id', 'displayName']`

## Test plan

- [ ] Re-run the failing cross-version upgrade job and confirm it gets past 1-21
- [ ] Verify the 1-21 backfill still correctly skips workspaces with a non-empty `databaseSchema` and backfills those without