### PR TITLE
fix(server): scope workspace findOne in ApplicationService

### DIFF
--- a/packages/twenty-server/src/engine/core-modules/application/application.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/application/application.service.ts
@@ -82,6 +82,7 @@ export class ApplicationService {
     const workspace = isDefined(workspaceInput)
       ? workspaceInput
       : await this.workspaceRepository.findOne({
+          select: ['id', 'workspaceCustomApplicationId'],
           where: {
             id: workspaceId,
           },


### PR DESCRIPTION
## Summary

Cross-version upgrade still fails after #20581:

```
column WorkspaceEntity.isInternalMessagesImportEnabled does not exist
  at ApplicationService.findWorkspaceTwentyStandardAndCustomApplicationOrThrow (application.service.ts:84)
  at UpdateGlobalObjectContextCommandMenuItemsCommand.runOnWorkspace (1-23-…)
  at BackfillRecordPageLayoutsCommand.runOnWorkspace (1-23-…)
```

(see https://github.com/twentyhq/twenty-infra/actions/runs/25861366732/job/75993012161)

### Root cause

Same class of bug as #20581, different location. `ApplicationService.findWorkspaceTwentyStandardAndCustomApplicationOrThrow` does:

```ts
await this.workspaceRepository.findOne({
  where: { id: workspaceId },
  withDeleted: true,
});
```

No `select`, so TypeORM emits a SELECT for every column declared on `WorkspaceEntity`. PR #20457 added `isInternalMessagesImportEnabled` to the entity; its DB column is only created by the 2-5 fast instance command `1778525104406-add-is-internal-messages-import-enabled`. Many workspace commands across versions 1-21 → 2-3 call this service (notably the 1-23 commands shown in the stack), and they all run before the 2-5 instance command — so the bare findOne hits a column that doesn't exist yet and the upgrade aborts.

### Fix

The function only reads `workspace.id` (passed to cache) and `workspace.workspaceCustomApplicationId`. Narrow the select to just those.

The `workspace: WorkspaceEntity` input variant of the function is unchanged — only the path where we fetch the workspace ourselves is narrowed. Callers don't see the workspace entity (the function only returns `{ twentyStandardFlatApplication, workspaceCustomFlatApplication }`).

### Why not edit the committed 1-23 workspace commands

Same reasoning as #20581: the fix lives in the service that does the read, so future column additions to `WorkspaceEntity` don't risk re-breaking every caller. Per `CLAUDE.md`, instance command `up`/`down` is immutable; this isn't an instance command.

## Test plan

- [ ] Re-run the failing cross-version-upgrade job and confirm it gets past 1-23
- [ ] Verify the function still resolves the standard + custom applications correctly for a workspace (no behavior change in returned shape)