### PR TITLE
Bump twenty-sdk, twenty-client-sdk, create-twenty-app to 2.5.0

### DIFF
--- a/packages/create-twenty-app/package.json
+++ b/packages/create-twenty-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-twenty-app",
-  "version": "2.4.2",
+  "version": "2.5.0",
   "description": "Command-line interface to create Twenty application",
   "main": "dist/cli.cjs",
   "bin": "dist/cli.cjs",

--- a/packages/twenty-client-sdk/package.json
+++ b/packages/twenty-client-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "twenty-client-sdk",
-  "version": "2.4.2",
+  "version": "2.5.0",
   "sideEffects": false,
   "license": "AGPL-3.0",
   "scripts": {

--- a/packages/twenty-sdk/package.json
+++ b/packages/twenty-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "twenty-sdk",
-  "version": "2.4.2",
+  "version": "2.5.0",
   "sideEffects": false,
   "bin": {
     "twenty": "dist/cli.cjs"


### PR DESCRIPTION
## Summary

- Bumps `twenty-sdk` from `2.4.2` to `2.5.0`.
- Bumps `twenty-client-sdk` from `2.4.2` to `2.5.0`.
- Bumps `create-twenty-app` from `2.4.2` to `2.5.0`.