### PR TITLE
fix(server): batch upgrade migration inserts to stay under PG param limit

### DIFF
--- a/packages/twenty-server/src/engine/core-modules/upgrade/services/upgrade-migration.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/upgrade/services/upgrade-migration.service.ts
@@ -21,10 +21,6 @@ export type WorkspaceLastAttemptedCommand = {
   isInitial: boolean;
 };
 
-// Postgres caps a single statement at 65,535 bind parameters (16-bit count in
-// the wire protocol). `UpgradeMigrationEntity` has 6 user-provided columns
-// per row, so a multi-row INSERT overflows at ~10,920 rows. Cap the per-batch
-// row count well below that so we stay safe even if columns are added later.
 const UPGRADE_MIGRATION_SAVE_BATCH_SIZE = 1000;
 
 @Injectable()

--- a/packages/twenty-server/src/engine/core-modules/upgrade/services/upgrade-migration.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/upgrade/services/upgrade-migration.service.ts
@@ -21,12 +21,29 @@ export type WorkspaceLastAttemptedCommand = {
   isInitial: boolean;
 };
 
+// Postgres caps a single statement at 65,535 bind parameters (16-bit count in
+// the wire protocol). `UpgradeMigrationEntity` has 6 user-provided columns
+// per row, so a multi-row INSERT overflows at ~10,920 rows. Cap the per-batch
+// row count well below that so we stay safe even if columns are added later.
+const UPGRADE_MIGRATION_SAVE_BATCH_SIZE = 1000;
+
 @Injectable()
 export class UpgradeMigrationService {
   constructor(
     @InjectRepository(UpgradeMigrationEntity)
     private readonly upgradeMigrationRepository: Repository<UpgradeMigrationEntity>,
   ) {}
+
+  private async saveInChunks(
+    repository: Repository<UpgradeMigrationEntity>,
+    rows: Array<Partial<UpgradeMigrationEntity>>,
+  ): Promise<void> {
+    for (let cursor = 0; cursor < rows.length; cursor += UPGRADE_MIGRATION_SAVE_BATCH_SIZE) {
+      await repository.save(
+        rows.slice(cursor, cursor + UPGRADE_MIGRATION_SAVE_BATCH_SIZE),
+      );
+    }
+  }
 
   async getInferredVersion(commandName?: string): Promise<string | null> {
     if (isDefined(commandName)) {
@@ -95,7 +112,7 @@ export class UpgradeMigrationService {
         where: { name, workspaceId: IsNull() },
       });
 
-      await repository.save([
+      await this.saveInChunks(repository, [
         {
           name,
           status,
@@ -134,7 +151,7 @@ export class UpgradeMigrationService {
       });
     }
 
-    await repository.save(rows);
+    await this.saveInChunks(repository, rows);
   }
 
   async markAsWorkspaceInitial({

--- a/packages/twenty-server/src/engine/core-modules/upgrade/services/upgrade-migration.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/upgrade/services/upgrade-migration.service.ts
@@ -1,6 +1,7 @@
 import { Injectable } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 
+import chunk from 'lodash.chunk';
 import { isDefined } from 'twenty-shared/utils';
 import { In, IsNull, type QueryRunner, Repository } from 'typeorm';
 
@@ -29,21 +30,6 @@ export class UpgradeMigrationService {
     @InjectRepository(UpgradeMigrationEntity)
     private readonly upgradeMigrationRepository: Repository<UpgradeMigrationEntity>,
   ) {}
-
-  private async saveInChunks(
-    repository: Repository<UpgradeMigrationEntity>,
-    rows: Array<Partial<UpgradeMigrationEntity>>,
-  ): Promise<void> {
-    for (
-      let cursor = 0;
-      cursor < rows.length;
-      cursor += UPGRADE_MIGRATION_SAVE_BATCH_SIZE
-    ) {
-      await repository.save(
-        rows.slice(cursor, cursor + UPGRADE_MIGRATION_SAVE_BATCH_SIZE),
-      );
-    }
-  }
 
   async getInferredVersion(commandName?: string): Promise<string | null> {
     if (isDefined(commandName)) {
@@ -112,7 +98,7 @@ export class UpgradeMigrationService {
         where: { name, workspaceId: IsNull() },
       });
 
-      await this.saveInChunks(repository, [
+      const instanceRows = [
         {
           name,
           status,
@@ -129,7 +115,14 @@ export class UpgradeMigrationService {
           workspaceId,
           errorMessage,
         })),
-      ]);
+      ];
+
+      for (const batch of chunk(
+        instanceRows,
+        UPGRADE_MIGRATION_SAVE_BATCH_SIZE,
+      )) {
+        await repository.save(batch);
+      }
 
       return;
     }
@@ -151,7 +144,9 @@ export class UpgradeMigrationService {
       });
     }
 
-    await this.saveInChunks(repository, rows);
+    for (const batch of chunk(rows, UPGRADE_MIGRATION_SAVE_BATCH_SIZE)) {
+      await repository.save(batch);
+    }
   }
 
   async markAsWorkspaceInitial({

--- a/packages/twenty-server/src/engine/core-modules/upgrade/services/upgrade-migration.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/upgrade/services/upgrade-migration.service.ts
@@ -34,7 +34,11 @@ export class UpgradeMigrationService {
     repository: Repository<UpgradeMigrationEntity>,
     rows: Array<Partial<UpgradeMigrationEntity>>,
   ): Promise<void> {
-    for (let cursor = 0; cursor < rows.length; cursor += UPGRADE_MIGRATION_SAVE_BATCH_SIZE) {
+    for (
+      let cursor = 0;
+      cursor < rows.length;
+      cursor += UPGRADE_MIGRATION_SAVE_BATCH_SIZE
+    ) {
       await repository.save(
         rows.slice(cursor, cursor + UPGRADE_MIGRATION_SAVE_BATCH_SIZE),
       );


### PR DESCRIPTION
## Summary

Prod deploy of v2.5.0 fails with a query failure inserting into `core.upgradeMigration`:

```
query failed: INSERT INTO "core"."upgradeMigration" ("id", "name", "status", "attempt", "executedByVersion", "errorMessage", "isInitial", "workspaceId", "createdAt")
VALUES (DEFAULT, $1, $2, $3, $4, $5, DEFAULT, $6, DEFAULT),
       (DEFAULT, $7, $8, $9, $10, $11, DEFAULT, $12, DEFAULT),
       ... (continues past $2515) ...
```

### Root cause

`UpgradeMigrationService.recordUpgradeMigration` writes one row per workspace via a single `repository.save([...rows])` call. `UpgradeMigrationEntity` has **6 user-provided columns** per row (`name`, `status`, `attempt`, `executedByVersion`, `errorMessage`, `workspaceId`), so the multi-row INSERT binds `6 * (1 + N_workspaces)` parameters.

Postgres' wire protocol caps a single statement at **65,535 bind parameters** (16-bit count). That gives a hard ceiling of ~10,920 rows per call. Production has enough workspaces to overflow.
