### PR TITLE
fix(server): skip composite fields with missing columns in NormalizeCompositeFieldDefaultsCommand

### DIFF
--- a/packages/twenty-server/src/database/commands/upgrade-version-command/2-5/2-5-workspace-command-1778000001000-normalize-composite-field-defaults.command.ts
+++ b/packages/twenty-server/src/database/commands/upgrade-version-command/2-5/2-5-workspace-command-1778000001000-normalize-composite-field-defaults.command.ts
@@ -100,11 +100,44 @@ export class NormalizeCompositeFieldDefaultsCommand extends ActiveOrSuspendedWor
       return;
     }
 
+    const fieldsToUpdate = affectedFields.filter((field) => {
+      const compositeType = compositeTypeDefinitions.get(
+        field.type as FieldMetadataType,
+      );
+
+      if (!isDefined(compositeType)) {
+        return false;
+      }
+
+      for (const property of compositeType.properties) {
+        if (
+          !isDefined(field.defaultValue) ||
+          !(property.name in field.defaultValue)
+        ) {
+          this.logger.warn(
+            `Skipping composite field "${field.name}" (${field.id}) for workspace ${workspaceId}: defaultValue is missing key "${property.name}"`,
+          );
+
+          return false;
+        }
+      }
+
+      return true;
+    });
+
+    if (fieldsToUpdate.length === 0) {
+      this.logger.log(
+        `No composite fields to update for workspace ${workspaceId} after defaultValue-shape check, skipping`,
+      );
+
+      return;
+    }
+
     const schemaName = getWorkspaceSchemaName(workspaceId);
     const backfillTargets: Array<{ tableName: string; columnName: string }> =
       [];
 
-    for (const field of affectedFields) {
+    for (const field of fieldsToUpdate) {
       const flatObjectMetadata =
         flatObjectMetadataMaps.byUniversalIdentifier[
           field.objectMetadataUniversalIdentifier
@@ -146,7 +179,7 @@ export class NormalizeCompositeFieldDefaultsCommand extends ActiveOrSuspendedWor
       }
     }
 
-    const fieldsByApplication = affectedFields.reduce<
+    const fieldsByApplication = fieldsToUpdate.reduce<
       Map<string, typeof affectedFields>
     >((acc, field) => {
       const key = field.applicationUniversalIdentifier;


### PR DESCRIPTION
## Summary

The 2.5 workspace command `NormalizeCompositeFieldDefaultsCommand` fails on workspaces created before the `context` sub-property was added to the ACTOR composite type (`actor.composite-type.ts:52-57`). For those workspaces, the field metadata's `defaultValue` for `createdBy` predates `context` — it has shapes like `{ source: 'SYSTEM' }` (3 keys missing) — and the workspace tables are correspondingly missing the `…createdByContext` column.

The `affectedFields` filter picks these fields up because `nullifyEmptyActorDefaultValue` produces a normalized object with all 4 keys, so the property-by-property comparison fires (`null !== undefined` for the missing keys). The field is then scheduled for a metadata UPDATE; the schema migration runner emits:

```sql
ALTER TABLE "workspace_…"."attachment" ALTER COLUMN "createdByContext" SET DEFAULT NULL
```

…which Postgres rejects with:

```
column "createdByContext" of relation "attachment" does not exist
```

## Fix

Filter `affectedFields` to keep only fields whose `defaultValue` already has every sub-property key declared by the composite type. If any key is missing from the metadata's `defaultValue`, the workspace predates that sub-property and its column is not yet provisioned — skip the field with a warning. Derived entirely from the in-memory `flatFieldMetadataMaps`; no `information_schema` query needed.

A field that needs normalizing (e.g. empty-string `name`) **and** is missing a composite key gets skipped too. That's a minor tradeoff vs crashing; the normalize can run on the next upgrade after the column is provisioned.

## Note

Editing a 2.5 file with `TWENTY_CURRENT_VERSION = 2.6.0`, so `ci:allow-previous-version-upgrade-mutation` label is on the PR.

## Test plan

- [ ] Re-run the upgrade against the failing workspace and confirm it gets past `NormalizeCompositeFieldDefaults`
- [ ] Verify the `Skipping composite field … defaultValue is missing key …` warning fires on each pre-context ACTOR field
- [ ] Confirm workspaces whose composite `defaultValue`s have every key still get normalised end-to-end