### PR TITLE
fix(twenty-front): anchor body text color to theme var

### DIFF
--- a/packages/twenty-front/src/index.css
+++ b/packages/twenty-front/src/index.css
@@ -4,6 +4,7 @@ body {
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
   background: var(--t-background-tertiary);
+  color: var(--t-font-color-primary);
 }
 
 html {


### PR DESCRIPTION
Fixes #20607.
also fixes https://github.com/twentyhq/twenty/issues/20627


Front Components rendered via Remote DOM produced black-on-dark text in dark mode for any unstyled element. `body` already anchored `background` to a theme var; the matching `color` rule was missing, so unstyled subtrees fell through to browser default `#000`.

before - 

<img width="850" height="526" alt="CleanShot 2026-05-16 at 16 31 49@2x" src="https://github.com/user-attachments/assets/ca21359c-d1d1-4367-831e-f694673757e5" />

<img width="840" height="1694" alt="CleanShot 2026-05-16 at 16 32 02@2x" src="https://github.com/user-attachments/assets/ed0891b5-1b97-4499-bb52-9e31c4cabf11" />

after - 

<img width="828" height="514" alt="CleanShot 2026-05-16 at 16 30 50@2x" src="https://github.com/user-attachments/assets/a22d1f1b-a79b-454c-8c05-5c7c00157b2c" />

<img width="852" height="1674" alt="CleanShot 2026-05-16 at 16 31 07@2x" src="https://github.com/user-attachments/assets/9b1dc19e-ccc5-472b-9184-59fa9b8832f8" />

