### PR TITLE
:bug: Serialise first-login user provisioning behind an advisory lock

### DIFF
--- a/packages/twenty-docker/twenty-app-dev/rootfs/etc/s6-overlay/scripts/init-db.sh
+++ b/packages/twenty-docker/twenty-app-dev/rootfs/etc/s6-overlay/scripts/init-db.sh
@@ -30,7 +30,19 @@ su-exec postgres psql -h localhost -tc \
 # Run Twenty database setup and migrations
 cd /app/packages/twenty-server
 
-has_schema=$(PGPASSWORD=twenty psql -h localhost -U twenty -d default -tAc \
+# When PG_DATABASE_URL is set (external postgres mode) target it directly;
+# otherwise fall back to the embedded postgres + default db.
+# Wrapped in a function (not a string) so the URL stays one argument and
+# can't be word-split if it ever contains spaces or shell metacharacters.
+psql_target() {
+  if [ -n "$PG_DATABASE_URL" ]; then
+    psql "$PG_DATABASE_URL" "$@"
+  else
+    PGPASSWORD=twenty psql -h localhost -U twenty -d default "$@"
+  fi
+}
+
+has_schema=$(psql_target -tAc \
   "SELECT EXISTS (SELECT 1 FROM information_schema.schemata WHERE schema_name = 'core')")
 
 if [ "$has_schema" = "f" ]; then
@@ -55,8 +67,12 @@ step_start "Flushing cache"
 yarn command:prod cache:flush
 step_done
 
-# Only seed on first boot — check if the dev workspace already exists
-has_workspace=$(PGPASSWORD=twenty psql -h localhost -U twenty -d default -tAc \
+# Only seed on first boot — check if the dev workspace already exists.
+# UUID is SEED_APPLE_WORKSPACE_ID from
+# packages/twenty-server/src/engine/workspace-manager/dev-seeder/core/constants/seeder-workspaces.constant.ts
+# (the constant file repurposes this slot for SMB deployments via SMB_NAME
+# but keeps the same UUID, so the existence check is correct in both modes).
+has_workspace=$(psql_target -tAc \
   "SELECT EXISTS (SELECT 1 FROM core.workspace WHERE id = '20202020-1c25-4d02-bf25-6aeccf7ea419')")
 
 if [ "$has_workspace" = "f" ]; then

--- a/packages/twenty-front/scripts/inject-runtime-env.sh
+++ b/packages/twenty-front/scripts/inject-runtime-env.sh
@@ -5,12 +5,37 @@ if [ -z "$REACT_APP_SERVER_BASE_URL" ]; then
   exit 1
 fi
 
+if [ "$AUTH_TYPE" = "SSO" ] && [ -z "$SMB_NAME" ]; then
+  # SMB_NAME is required when AUTH_TYPE=SSO. No default — fail loudly so
+  # the SPA never silently rewrites the logout host to the wrong domain.
+  # Same env name across every devstack app — see sso-rules RULES.md.
+  echo "Error: SMB_NAME is required when AUTH_TYPE=SSO." >&2
+  echo "       Set it to the portal hostname prefix (e.g. 'moneta')." >&2
+  exit 1
+fi
+
+# Reject characters that would break out of the JSON string and corrupt
+# the generated <script> block (or, worst case, inject script content).
+# These values come from compose env (not user-controlled today), but the
+# script is also reused outside the bundled build, so harden the boundary.
+for value in "$REACT_APP_SERVER_BASE_URL" "$AUTH_TYPE" "$SMB_NAME"; do
+  case "$value" in
+    *'"'* | *'<'* | *'>'* | *\\* | *'	'* | *'
+'*)
+      echo "Error: env values must not contain quotes, angle brackets, backslashes, tabs, or newlines." >&2
+      exit 1
+      ;;
+  esac
+done
+
 echo "Injecting runtime environment variables into index.html..."
 
 CONFIG_BLOCK=$(cat << EOF
     <script id="twenty-env-config">
       window._env_ = {
-        REACT_APP_SERVER_BASE_URL: "$REACT_APP_SERVER_BASE_URL"
+        REACT_APP_SERVER_BASE_URL: "$REACT_APP_SERVER_BASE_URL",
+        AUTH_TYPE: "$AUTH_TYPE",
+        SMB_NAME: "$SMB_NAME"
       };
     </script>
     <!-- END: Twenty Config -->

--- a/packages/twenty-front/src/modules/auth/hooks/__tests__/useIsSsoEnabled.test.ts
+++ b/packages/twenty-front/src/modules/auth/hooks/__tests__/useIsSsoEnabled.test.ts
@@ -1,0 +1,49 @@
+import { renderHook } from '@testing-library/react';
+
+import { useIsSsoEnabled } from '@/auth/hooks/useIsSsoEnabled';
+
+describe('useIsSsoEnabled', () => {
+  // Seed window._env_ so jest.replaceProperty has a property to replace.
+  // The shape doesn't matter — every test overwrites it.
+  beforeAll(() => {
+    if (!Object.prototype.hasOwnProperty.call(window, '_env_')) {
+      Object.defineProperty(window, '_env_', {
+        value: {},
+        writable: true,
+        configurable: true,
+      });
+    }
+  });
+
+  it('returns true when AUTH_TYPE is "SSO"', () => {
+    jest.replaceProperty(window, '_env_', { AUTH_TYPE: 'SSO' });
+
+    const { result } = renderHook(() => useIsSsoEnabled());
+
+    expect(result.current).toBe(true);
+  });
+
+  it('returns false when AUTH_TYPE is some other value', () => {
+    jest.replaceProperty(window, '_env_', { AUTH_TYPE: 'PASSWORD' });
+
+    const { result } = renderHook(() => useIsSsoEnabled());
+
+    expect(result.current).toBe(false);
+  });
+
+  it('returns false when AUTH_TYPE is missing', () => {
+    jest.replaceProperty(window, '_env_', {});
+
+    const { result } = renderHook(() => useIsSsoEnabled());
+
+    expect(result.current).toBe(false);
+  });
+
+  it('returns false when window._env_ is undefined', () => {
+    jest.replaceProperty(window, '_env_', undefined);
+
+    const { result } = renderHook(() => useIsSsoEnabled());
+
+    expect(result.current).toBe(false);
+  });
+});

--- a/packages/twenty-front/src/modules/auth/hooks/useAuth.ts
+++ b/packages/twenty-front/src/modules/auth/hooks/useAuth.ts
@@ -17,7 +17,9 @@ import {
   VerifyEmailAndGetWorkspaceAgnosticTokenDocument,
 } from '~/generated-metadata/graphql';
 
+import { useIsSsoEnabled } from '@/auth/hooks/useIsSsoEnabled';
 import { tokenPairState } from '@/auth/states/tokenPairState';
+import { buildPortalUrl } from '@/auth/utils/buildPortalUrl';
 import { clearSessionLocalStorageKeys } from '@/auth/utils/clearSessionLocalStorageKeys';
 import { broadcastSignOutToOtherTabs } from '@/auth/utils/crossTabSignOut';
 import { useAtomStateValue } from '@/ui/utilities/state/jotai/hooks/useAtomStateValue';
@@ -53,6 +55,7 @@ import { useStore } from 'jotai';
 
 export const useAuth = () => {
   const store = useStore();
+  const isSsoEnabled = useIsSsoEnabled();
   const setTokenPair = useSetAtomState(tokenPairState);
   const setLoginToken = useSetAtomState(loginTokenState);
   const setIsAppEffectRedirectEnabled = useSetAtomState(
@@ -408,8 +411,32 @@ export const useAuth = () => {
 
   const handleSignOut = useCallback(() => {
     broadcastSignOutToOtherTabs();
+
+    if (isSsoEnabled) {
+      // 1-layer logout: clear local session and navigate to the portal host.
+      // Matches the shape every other app in the foss-server-bundle-devstack
+      // (Plane / Outline / Penpot / SurfSense) settled on — rewrite
+      // "<prefix>-<app>.<domain>" → "<prefix>.<domain>" by capturing the
+      // prefix and dropping the -<app> segment. The oauth2-proxy /sign_out
+      // hop was dropped on 2026-04-17 because Cognito hosted /logout isn't
+      // available on this app client.
+      // We replicate clearSession's cleanup inline (skipping its terminal
+      // window.location.assign(AppPath.SignInUp)) so we can navigate to the
+      // portal host instead.
+      sessionStorage.clear();
+      clearSessionLocalStorageKeys();
+      store.set(tokenPairState.atom, null);
+      setLastAuthenticateWorkspaceDomain(null);
+
+      window.location.href = buildPortalUrl(
+        window.location.hostname,
+        window.location.protocol,
+      );
+      return;
+    }
+
     clearSession();
-  }, [clearSession]);
+  }, [clearSession, isSsoEnabled, store, setLastAuthenticateWorkspaceDomain]);
 
   const handleCredentialsSignUpInWorkspace = useCallback(
     async ({

--- a/packages/twenty-front/src/modules/auth/hooks/useAuth.ts
+++ b/packages/twenty-front/src/modules/auth/hooks/useAuth.ts
@@ -429,7 +429,7 @@ export const useAuth = () => {
       setLastAuthenticateWorkspaceDomain(null);
 
       window.location.href = buildPortalUrl(
-        window.location.hostname,
+        window.location.host,
         window.location.protocol,
       );
       return;

--- a/packages/twenty-front/src/modules/auth/hooks/useIsSsoEnabled.ts
+++ b/packages/twenty-front/src/modules/auth/hooks/useIsSsoEnabled.ts
@@ -1,0 +1,3 @@
+export const useIsSsoEnabled = (): boolean => {
+  return window._env_?.AUTH_TYPE === 'SSO';
+};

--- a/packages/twenty-front/src/modules/auth/utils/__tests__/buildPortalUrl.test.ts
+++ b/packages/twenty-front/src/modules/auth/utils/__tests__/buildPortalUrl.test.ts
@@ -1,0 +1,31 @@
+import { buildPortalUrl } from '@/auth/utils/buildPortalUrl';
+
+describe('buildPortalUrl', () => {
+  it('rewrites <prefix>-<app>.<domain> to <prefix>.<domain>', () => {
+    expect(buildPortalUrl('foss-twenty.local.moneta.dev', 'https:')).toBe(
+      'https://foss.local.moneta.dev/',
+    );
+  });
+
+  it('preserves the same scheme for http://', () => {
+    expect(buildPortalUrl('foss-pm.local.moneta.dev', 'http:')).toBe(
+      'http://foss.local.moneta.dev/',
+    );
+  });
+
+  it('no-ops on `localhost` (no hyphen segment, no first-label rewrite)', () => {
+    expect(buildPortalUrl('localhost', 'http:')).toBe('http://localhost/');
+  });
+
+  it('no-ops on hosts without a hyphen segment', () => {
+    expect(buildPortalUrl('foo.example.com', 'https:')).toBe(
+      'https://foo.example.com/',
+    );
+  });
+
+  it('only rewrites the first label, leaves deeper subdomains alone', () => {
+    expect(buildPortalUrl('foss-twenty.staging.moneta.dev', 'https:')).toBe(
+      'https://foss.staging.moneta.dev/',
+    );
+  });
+});

--- a/packages/twenty-front/src/modules/auth/utils/__tests__/buildPortalUrl.test.ts
+++ b/packages/twenty-front/src/modules/auth/utils/__tests__/buildPortalUrl.test.ts
@@ -28,4 +28,10 @@ describe('buildPortalUrl', () => {
       'https://foss.staging.moneta.dev/',
     );
   });
+
+  it('preserves port when present', () => {
+    expect(
+      buildPortalUrl('foss-twenty.local.moneta.dev:8080', 'http:'),
+    ).toBe('http://foss.local.moneta.dev:8080/');
+  });
 });

--- a/packages/twenty-front/src/modules/auth/utils/buildPortalUrl.ts
+++ b/packages/twenty-front/src/modules/auth/utils/buildPortalUrl.ts
@@ -3,8 +3,8 @@
 // target in useAuth: `foss-twenty.local.moneta.dev` -> `foss.local.moneta.dev`.
 // The regex requires a hyphen segment so non-`<prefix>-<app>` hosts
 // (`localhost`, `foo.example.com`) no-op safely.
-export const buildPortalUrl = (hostname: string, protocol: string) => {
-  const portalHost = hostname.replace(/^([^-]+)-[^.]+\.(.+)/, '$1.$2');
+export const buildPortalUrl = (host: string, protocol: string) => {
+  const portalHost = host.replace(/^([^-]+)-[^.]+\.(.+)/, '$1.$2');
 
   return `${protocol}//${portalHost}/`;
 };

--- a/packages/twenty-front/src/modules/auth/utils/buildPortalUrl.ts
+++ b/packages/twenty-front/src/modules/auth/utils/buildPortalUrl.ts
@@ -1,0 +1,10 @@
+// Rewrite the current host's first label (`<prefix>-<app>`) to just
+// `<prefix>`, then build a same-protocol root URL. Drives the SSO sign-out
+// target in useAuth: `foss-twenty.local.moneta.dev` -> `foss.local.moneta.dev`.
+// The regex requires a hyphen segment so non-`<prefix>-<app>` hosts
+// (`localhost`, `foo.example.com`) no-op safely.
+export const buildPortalUrl = (hostname: string, protocol: string) => {
+  const portalHost = hostname.replace(/^([^-]+)-[^.]+\.(.+)/, '$1.$2');
+
+  return `${protocol}//${portalHost}/`;
+};

--- a/packages/twenty-front/src/modules/auth/utils/buildPortalUrl.ts
+++ b/packages/twenty-front/src/modules/auth/utils/buildPortalUrl.ts
@@ -1,10 +1,15 @@
-// Rewrite the current host's first label (`<prefix>-<app>`) to just
-// `<prefix>`, then build a same-protocol root URL. Drives the SSO sign-out
-// target in useAuth: `foss-twenty.local.moneta.dev` -> `foss.local.moneta.dev`.
-// The regex requires a hyphen segment so non-`<prefix>-<app>` hosts
-// (`localhost`, `foo.example.com`) no-op safely.
+// Strip the first subdomain so we land on the portal (outside ForwardAuth)
+// instead of Twenty's own root, which would silently re-auth. Drives the SSO
+// sign-out target in useAuth.
+//
+// Works for the 4-label `<app>.<prefix>.<domain>` deployment shape used in
+// sandbox + prod (`twenty.foss.arbisoft.com` -> `foss.arbisoft.com`).
+//
+// The lookahead requires at least 2 trailing labels with dots, so single-
+// label hosts (`localhost`) and 2-label hosts (`foo.example.com`) no-op
+// safely instead of stripping into nothing.
 export const buildPortalUrl = (host: string, protocol: string) => {
-  const portalHost = host.replace(/^([^-]+)-[^.]+\.(.+)/, '$1.$2');
+  const portalHost = host.replace(/^[^.]+\.(?=[^.]*\.[^.]*\.)/, '');
 
   return `${protocol}//${portalHost}/`;
 };

--- a/packages/twenty-front/src/modules/settings/profile/components/EmailField.tsx
+++ b/packages/twenty-front/src/modules/settings/profile/components/EmailField.tsx
@@ -1,6 +1,7 @@
 import { styled } from '@linaria/react';
 import { useState } from 'react';
 
+import { useIsSsoEnabled } from '@/auth/hooks/useIsSsoEnabled';
 import { currentUserState } from '@/auth/states/currentUserState';
 import { useCanEditProfileField } from '@/settings/profile/hooks/useCanEditProfileField';
 import { useUpdateEmail } from '@/settings/profile/hooks/useUpdateEmail';
@@ -40,7 +41,9 @@ const StyledActionButtonContainer = styled.div`
 
 export const EmailField = () => {
   const currentUser = useAtomStateValue(currentUserState);
-  const { canEdit } = useCanEditProfileField('email');
+  const { canEdit: canEditFromHook } = useCanEditProfileField('email');
+  const isSsoEnabled = useIsSsoEnabled();
+  const canEdit = canEditFromHook && !isSsoEnabled;
   const { updateEmail } = useUpdateEmail();
 
   const [draftEmail, setDraftEmail] = useState('');

--- a/packages/twenty-front/src/modules/settings/profile/hooks/useCanChangePassword.ts
+++ b/packages/twenty-front/src/modules/settings/profile/hooks/useCanChangePassword.ts
@@ -1,3 +1,4 @@
+import { useIsSsoEnabled } from '@/auth/hooks/useIsSsoEnabled';
 import { currentUserWorkspaceState } from '@/auth/states/currentUserWorkspaceState';
 import { currentWorkspaceState } from '@/auth/states/currentWorkspaceState';
 import { PermissionFlagType } from '~/generated-metadata/graphql';
@@ -6,6 +7,11 @@ import { useAtomStateValue } from '@/ui/utilities/state/jotai/hooks/useAtomState
 export const useCanChangePassword = () => {
   const currentWorkspace = useAtomStateValue(currentWorkspaceState);
   const currentUserWorkspace = useAtomStateValue(currentUserWorkspaceState);
+  const isSsoEnabled = useIsSsoEnabled();
+
+  if (isSsoEnabled) {
+    return { canChangePassword: false };
+  }
 
   const isPasswordAuthEnabled =
     currentWorkspace?.isPasswordAuthEnabled === true;

--- a/packages/twenty-front/src/modules/settings/security/components/Toggle2FA.tsx
+++ b/packages/twenty-front/src/modules/settings/security/components/Toggle2FA.tsx
@@ -1,3 +1,4 @@
+import { useIsSsoEnabled } from '@/auth/hooks/useIsSsoEnabled';
 import { currentWorkspaceState } from '@/auth/states/currentWorkspaceState';
 import { useAtomState } from '@/ui/utilities/state/jotai/hooks/useAtomState';
 import { SettingsOptionCardContentToggle } from '@/settings/components/SettingsOptions/SettingsOptionCardContentToggle';
@@ -8,12 +9,25 @@ import { IconLifebuoy } from 'twenty-ui/display';
 import { useMutation } from '@apollo/client/react';
 import { UpdateWorkspaceDocument } from '~/generated-metadata/graphql';
 
+// Under SSO the IdP owns MFA — Twenty's local 2FA enforcement toggle is a
+// dead control. Outer component bails out before any of the inner hooks
+// (useSnackBar, useAtomState, useMutation) run, so neither the workspace
+// state nor the GraphQL client need to be available when SSO is on.
 export const Toggle2FA = () => {
+  const isSsoEnabled = useIsSsoEnabled();
+
+  if (isSsoEnabled) {
+    return null;
+  }
+
+  return <Toggle2FAEnabled />;
+};
+
+const Toggle2FAEnabled = () => {
   const { enqueueErrorSnackBar } = useSnackBar();
   const [currentWorkspace, setCurrentWorkspace] = useAtomState(
     currentWorkspaceState,
   );
-
   const [updateWorkspace] = useMutation(UpdateWorkspaceDocument);
 
   const handleChange = async () => {

--- a/packages/twenty-front/src/modules/settings/security/components/__tests__/Toggle2FA.test.tsx
+++ b/packages/twenty-front/src/modules/settings/security/components/__tests__/Toggle2FA.test.tsx
@@ -1,0 +1,26 @@
+import { render } from '@testing-library/react';
+
+import { Toggle2FA } from '@/settings/security/components/Toggle2FA';
+
+jest.mock('@/auth/hooks/useIsSsoEnabled', () => ({
+  useIsSsoEnabled: jest.fn(),
+}));
+
+const useIsSsoEnabledMock: jest.Mock = jest.requireMock(
+  '@/auth/hooks/useIsSsoEnabled',
+).useIsSsoEnabled;
+
+describe('Toggle2FA', () => {
+  // Under SSO the IdP owns MFA — the outer component returns null before
+  // any inner hook (useSnackBar, useAtomState, useMutation) runs. The
+  // SSO-off path defers to <Toggle2FAEnabled /> which depends on contexts
+  // we don't own — out of scope for this test file.
+  it('returns null when SSO is enabled', () => {
+    useIsSsoEnabledMock.mockReturnValue(true);
+
+    const { container } = render(<Toggle2FA />);
+
+    expect(container.firstChild).toBeNull();
+    expect(useIsSsoEnabledMock).toHaveBeenCalled();
+  });
+});

--- a/packages/twenty-front/src/pages/auth/PasswordReset.tsx
+++ b/packages/twenty-front/src/pages/auth/PasswordReset.tsx
@@ -3,6 +3,7 @@ import { Logo } from '@/auth/components/Logo';
 import { Title } from '@/auth/components/Title';
 import { useAuth } from '@/auth/hooks/useAuth';
 import { useHasAccessTokenPair } from '@/auth/hooks/useHasAccessTokenPair';
+import { useIsSsoEnabled } from '@/auth/hooks/useIsSsoEnabled';
 import { currentUserState } from '@/auth/states/currentUserState';
 import { workspacePublicDataState } from '@/auth/states/workspacePublicDataState';
 import { PASSWORD_REGEX } from '@/auth/utils/passwordRegex';
@@ -90,6 +91,7 @@ export const PasswordReset = () => {
   const { theme } = useContext(ThemeContext);
   const { t } = useLingui();
   const { enqueueErrorSnackBar, enqueueSuccessSnackBar } = useSnackBar();
+  const isSsoEnabled = useIsSsoEnabled();
 
   const workspacePublicData = useAtomStateValue(workspacePublicDataState);
   const setCurrentUser = useSetAtomState(currentUserState);
@@ -217,6 +219,25 @@ export const PasswordReset = () => {
 
   const passwordActionLabel =
     isTargetUserPasswordSet === true ? t`Change Password` : t`Set Password`;
+
+  if (isSsoEnabled) {
+    return (
+      <ModalContent isVerticallyCentered isHorizontallyCentered>
+        <StyledMainContainer>
+          <AnimatedEaseIn>
+            <Logo
+              secondaryLogo={workspacePublicData?.logo}
+              placeholder={workspacePublicData?.displayName}
+            />
+          </AnimatedEaseIn>
+          <Title animate>{t`Password is managed by SSO`}</Title>
+          <StyledContentContainer>
+            {t`Contact your administrator to manage credentials.`}
+          </StyledContentContainer>
+        </StyledMainContainer>
+      </ModalContent>
+    );
+  }
 
   return (
     isTokenValid && (

--- a/packages/twenty-front/src/pages/auth/SignInUp.tsx
+++ b/packages/twenty-front/src/pages/auth/SignInUp.tsx
@@ -1,3 +1,4 @@
+import { useIsSsoEnabled } from '@/auth/hooks/useIsSsoEnabled';
 import { useSignInUp } from '@/auth/sign-in-up/hooks/useSignInUp';
 import { useSignInUpForm } from '@/auth/sign-in-up/hooks/useSignInUpForm';
 import {
@@ -22,13 +23,14 @@ import { isMultiWorkspaceEnabledState } from '@/client-config/states/isMultiWork
 import { useGetPublicWorkspaceDataByDomain } from '@/domain-manager/hooks/useGetPublicWorkspaceDataByDomain';
 import { useIsCurrentLocationOnAWorkspace } from '@/domain-manager/hooks/useIsCurrentLocationOnAWorkspace';
 import { useIsCurrentLocationOnDefaultDomain } from '@/domain-manager/hooks/useIsCurrentLocationOnDefaultDomain';
-import { useMemo } from 'react';
+import { useEffect, useMemo } from 'react';
 
 import { SignInUpGlobalScopeFormEffect } from '@/auth/sign-in-up/components/internal/SignInUpGlobalScopeFormEffect';
 import { SignInUpTwoFactorAuthenticationProvision } from '@/auth/sign-in-up/components/internal/SignInUpTwoFactorAuthenticationProvision';
 import { SignInUpTOTPVerification } from '@/auth/sign-in-up/components/internal/SignInUpTwoFactorAuthenticationVerification';
 import { useWorkspaceFromInviteHash } from '@/auth/sign-in-up/hooks/useWorkspaceFromInviteHash';
 import { clientConfigApiStatusState } from '@/client-config/states/clientConfigApiStatusState';
+import { REACT_APP_SERVER_BASE_URL } from '~/config';
 import { ModalContent } from 'twenty-ui/layout';
 import { useLingui } from '@lingui/react/macro';
 import { useSearchParams } from 'react-router-dom';
@@ -85,6 +87,19 @@ export const SignInUp = () => {
   const { t } = useLingui();
   const setSignInUpStep = useSetAtomState(signInUpStepState);
   const clientConfigApiStatus = useAtomStateValue(clientConfigApiStatusState);
+  const isSsoEnabled = useIsSsoEnabled();
+
+  useEffect(() => {
+    if (isSsoEnabled) {
+      // Use the API origin so the redirect still works when the SPA is
+      // served separately from the backend. In the unified-image setup
+      // both share an origin and the absolute URL collapses to the same
+      // path; in split-deploy mode it correctly hits the API.
+      window.location.replace(
+        `${REACT_APP_SERVER_BASE_URL}/auth/sso/proxy-login`,
+      );
+    }
+  }, [isSsoEnabled]);
 
   const { form } = useSignInUpForm();
   const { signInUpStep } = useSignInUp(form);
@@ -202,6 +217,16 @@ export const SignInUp = () => {
     signInUpStep,
     workspacePublicData,
   ]);
+
+  if (isSsoEnabled) {
+    return (
+      <ModalContent isVerticallyCentered isHorizontallyCentered>
+        <StyledLoaderContainer>
+          <Loader color="gray" />
+        </StyledLoaderContainer>
+      </ModalContent>
+    );
+  }
 
   if (signInUpStep === SignInUpStep.EmailVerification) {
     return (

--- a/packages/twenty-front/src/pages/settings/SettingsTwoFactorAuthenticationMethod.tsx
+++ b/packages/twenty-front/src/pages/settings/SettingsTwoFactorAuthenticationMethod.tsx
@@ -2,7 +2,9 @@ import { styled } from '@linaria/react';
 import { Trans, useLingui } from '@lingui/react/macro';
 import { FormProvider } from 'react-hook-form';
 import QRCode from 'react-qr-code';
+import { Navigate } from 'react-router-dom';
 
+import { useIsSsoEnabled } from '@/auth/hooks/useIsSsoEnabled';
 import { qrCodeState } from '@/auth/states/qrCode';
 import { SaveAndCancelButtons } from '@/settings/components/SaveAndCancelButtons/SaveAndCancelButtons';
 import { SettingsPageContainer } from '@/settings/components/SettingsPageContainer';
@@ -82,7 +84,23 @@ const StyledDivider = styled.div`
   width: 100%;
 `;
 
+// Under SSO the IdP owns MFA — Twenty's local TOTP setup page would mint
+// authenticator entries that never participate in the actual login flow.
+// Outer component bails out with a Navigate before any of the inner hooks
+// (useCopyToClipboard, useAtomStateValue, useCurrentUserWorkspaceTwoFactorAuthentication,
+// useTwoFactorVerificationForSettings) run, so the page can stay
+// uninstantiable for SSO sessions without their contexts being provided.
 export const SettingsTwoFactorAuthenticationMethod = () => {
+  const isSsoEnabled = useIsSsoEnabled();
+
+  if (isSsoEnabled) {
+    return <Navigate to={getSettingsPath(SettingsPath.ProfilePage)} replace />;
+  }
+
+  return <SettingsTwoFactorAuthenticationMethodInner />;
+};
+
+const SettingsTwoFactorAuthenticationMethodInner = () => {
   const { t } = useLingui();
   const { copyToClipboard } = useCopyToClipboard();
   const qrCode = useAtomStateValue(qrCodeState);

--- a/packages/twenty-front/src/pages/settings/__tests__/SettingsTwoFactorAuthenticationMethod.test.tsx
+++ b/packages/twenty-front/src/pages/settings/__tests__/SettingsTwoFactorAuthenticationMethod.test.tsx
@@ -1,0 +1,43 @@
+import { render } from '@testing-library/react';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+
+import { SettingsTwoFactorAuthenticationMethod } from '~/pages/settings/SettingsTwoFactorAuthenticationMethod';
+
+jest.mock('@/auth/hooks/useIsSsoEnabled', () => ({
+  useIsSsoEnabled: jest.fn(),
+}));
+
+const useIsSsoEnabledMock: jest.Mock = jest.requireMock(
+  '@/auth/hooks/useIsSsoEnabled',
+).useIsSsoEnabled;
+
+describe('SettingsTwoFactorAuthenticationMethod', () => {
+  // Under SSO the IdP owns MFA — the outer component returns
+  // <Navigate to=/settings/profile replace /> before any inner hook runs,
+  // so the route is unreachable, not just visually hidden. The SSO-off
+  // path defers to the inner component which depends on contexts we don't
+  // own — out of scope for this test file.
+  it('redirects to /settings/profile when SSO is enabled', () => {
+    useIsSsoEnabledMock.mockReturnValue(true);
+
+    const { container } = render(
+      <MemoryRouter initialEntries={['/settings/profile/two-factor/TOTP']}>
+        <Routes>
+          <Route
+            path="/settings/profile/two-factor/TOTP"
+            element={<SettingsTwoFactorAuthenticationMethod />}
+          />
+          <Route
+            path="/settings/profile"
+            element={<div data-testid="profile-page">profile</div>}
+          />
+        </Routes>
+      </MemoryRouter>,
+    );
+
+    expect(
+      container.querySelector('[data-testid="profile-page"]'),
+    ).not.toBeNull();
+    expect(useIsSsoEnabledMock).toHaveBeenCalled();
+  });
+});

--- a/packages/twenty-server/src/database/commands/bootstrap-sso-admin.command.spec.ts
+++ b/packages/twenty-server/src/database/commands/bootstrap-sso-admin.command.spec.ts
@@ -25,9 +25,11 @@ const buildCommand = (overrides?: {
     ),
   };
   const roleRepository = {
-    findOne: jest.fn().mockResolvedValue(
-      overrides?.adminRole ?? { id: 'admin-role-id', label: 'Admin' },
-    ),
+    findOne: jest
+      .fn()
+      .mockResolvedValue(
+        overrides?.adminRole ?? { id: 'admin-role-id', label: 'Admin' },
+      ),
   };
   const userWorkspaceService = {
     addUserToWorkspaceOrEnsureRole: jest
@@ -78,9 +80,9 @@ describe('BootstrapSsoAdminCommand', () => {
   it('throws when SMB_NAME is not configured', async () => {
     const { command } = buildCommand({ configuredSubdomain: '' });
 
-    await expect(
-      command.run([], { email: 'admin@askii.ai' }),
-    ).rejects.toThrow('SMB_NAME is not configured');
+    await expect(command.run([], { email: 'admin@askii.ai' })).rejects.toThrow(
+      'SMB_NAME is not configured',
+    );
   });
 
   it('throws on email without @-sign', async () => {
@@ -96,9 +98,9 @@ describe('BootstrapSsoAdminCommand', () => {
 
     workspaceRepository.findOne.mockResolvedValueOnce(null);
 
-    await expect(
-      command.run([], { email: 'admin@askii.ai' }),
-    ).rejects.toThrow('Workspace with subdomain="askii" not found');
+    await expect(command.run([], { email: 'admin@askii.ai' })).rejects.toThrow(
+      'Workspace with subdomain="askii" not found',
+    );
   });
 
   it('throws when Admin role is missing in the workspace', async () => {
@@ -106,9 +108,9 @@ describe('BootstrapSsoAdminCommand', () => {
 
     roleRepository.findOne.mockResolvedValueOnce(null);
 
-    await expect(
-      command.run([], { email: 'admin@askii.ai' }),
-    ).rejects.toThrow('Admin role missing in workspace');
+    await expect(command.run([], { email: 'admin@askii.ai' })).rejects.toThrow(
+      'Admin role missing in workspace',
+    );
   });
 
   it('newly provisions Admin user when no userWorkspace exists (cold start)', async () => {

--- a/packages/twenty-server/src/database/commands/bootstrap-sso-admin.command.spec.ts
+++ b/packages/twenty-server/src/database/commands/bootstrap-sso-admin.command.spec.ts
@@ -1,0 +1,168 @@
+import { Logger } from '@nestjs/common';
+
+import { BootstrapSsoAdminCommand } from 'src/database/commands/bootstrap-sso-admin.command';
+
+type ConfigKey = 'SMB_NAME';
+
+const buildCommand = (overrides?: {
+  existingUser?: unknown;
+  workspace?: unknown;
+  adminRole?: unknown;
+  configuredSubdomain?: string;
+  helperResult?: { wasExistingMember: boolean };
+}) => {
+  const userRepository = {
+    findOne: jest.fn().mockResolvedValue(overrides?.existingUser ?? null),
+    create: jest.fn((u) => u),
+    save: jest.fn(async (u) => ({ id: 'user-id-1', ...u })),
+  };
+  const workspaceRepository = {
+    findOne: jest.fn().mockResolvedValue(
+      overrides?.workspace ?? {
+        id: 'workspace-id-1',
+        subdomain: 'askii',
+      },
+    ),
+  };
+  const roleRepository = {
+    findOne: jest.fn().mockResolvedValue(
+      overrides?.adminRole ?? { id: 'admin-role-id', label: 'Admin' },
+    ),
+  };
+  const userWorkspaceService = {
+    addUserToWorkspaceOrEnsureRole: jest
+      .fn()
+      .mockResolvedValue(
+        overrides?.helperResult ?? { wasExistingMember: false },
+      ),
+  };
+  const twentyConfigService = {
+    get: jest.fn((key: ConfigKey) =>
+      key === 'SMB_NAME'
+        ? (overrides?.configuredSubdomain ?? 'askii')
+        : undefined,
+    ),
+  };
+
+  const command = new BootstrapSsoAdminCommand(
+    userRepository as any,
+    workspaceRepository as any,
+    roleRepository as any,
+    userWorkspaceService as any,
+    twentyConfigService as any,
+  );
+
+  return {
+    command,
+    userRepository,
+    workspaceRepository,
+    roleRepository,
+    userWorkspaceService,
+    twentyConfigService,
+  };
+};
+
+describe('BootstrapSsoAdminCommand', () => {
+  let logSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    logSpy = jest
+      .spyOn(Logger.prototype, 'log')
+      .mockImplementation(() => undefined);
+  });
+
+  afterEach(() => {
+    logSpy.mockRestore();
+  });
+
+  it('throws when SMB_NAME is not configured', async () => {
+    const { command } = buildCommand({ configuredSubdomain: '' });
+
+    await expect(
+      command.run([], { email: 'admin@askii.ai' }),
+    ).rejects.toThrow('SMB_NAME is not configured');
+  });
+
+  it('throws on email without @-sign', async () => {
+    const { command } = buildCommand();
+
+    await expect(command.run([], { email: 'plainusername' })).rejects.toThrow(
+      'Invalid email',
+    );
+  });
+
+  it('throws when workspace with subdomain not found', async () => {
+    const { command, workspaceRepository } = buildCommand();
+
+    workspaceRepository.findOne.mockResolvedValueOnce(null);
+
+    await expect(
+      command.run([], { email: 'admin@askii.ai' }),
+    ).rejects.toThrow('Workspace with subdomain="askii" not found');
+  });
+
+  it('throws when Admin role is missing in the workspace', async () => {
+    const { command, roleRepository } = buildCommand();
+
+    roleRepository.findOne.mockResolvedValueOnce(null);
+
+    await expect(
+      command.run([], { email: 'admin@askii.ai' }),
+    ).rejects.toThrow('Admin role missing in workspace');
+  });
+
+  it('newly provisions Admin user when no userWorkspace exists (cold start)', async () => {
+    const { command, userRepository, userWorkspaceService } = buildCommand({
+      helperResult: { wasExistingMember: false },
+    });
+
+    await command.run([], { email: 'ADMIN@Askii.ai' });
+
+    expect(userRepository.findOne).toHaveBeenCalledWith({
+      where: { email: 'admin@askii.ai' },
+    });
+    expect(userRepository.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        email: 'admin@askii.ai',
+        isEmailVerified: true,
+      }),
+    );
+    expect(userRepository.save).toHaveBeenCalled();
+    expect(
+      userWorkspaceService.addUserToWorkspaceOrEnsureRole,
+    ).toHaveBeenCalledWith(
+      expect.objectContaining({ email: 'admin@askii.ai' }),
+      expect.objectContaining({ subdomain: 'askii' }),
+      'admin-role-id',
+    );
+    expect(logSpy).toHaveBeenCalledWith(
+      expect.stringContaining('newly provisioned'),
+    );
+  });
+
+  it('promotes existing Member to Admin (regression case for bug_001)', async () => {
+    const existingUser = {
+      id: 'existing-user-id',
+      email: 'admin@askii.ai',
+    };
+    const { command, userRepository, userWorkspaceService } = buildCommand({
+      existingUser,
+      helperResult: { wasExistingMember: true },
+    });
+
+    await command.run([], { email: 'admin@askii.ai' });
+
+    expect(userRepository.create).not.toHaveBeenCalled();
+    expect(userRepository.save).not.toHaveBeenCalled();
+    expect(
+      userWorkspaceService.addUserToWorkspaceOrEnsureRole,
+    ).toHaveBeenCalledWith(
+      existingUser,
+      expect.objectContaining({ subdomain: 'askii' }),
+      'admin-role-id',
+    );
+    expect(logSpy).toHaveBeenCalledWith(
+      expect.stringContaining('promoted to Admin'),
+    );
+  });
+});

--- a/packages/twenty-server/src/database/commands/bootstrap-sso-admin.command.ts
+++ b/packages/twenty-server/src/database/commands/bootstrap-sso-admin.command.ts
@@ -20,8 +20,9 @@ type BootstrapSsoAdminOptions = {
 
 // Pre-seed one Admin user for the SMB_NAME workspace so SSO sign-in lands a
 // useful role on first hit. Mirrors `provision-plane.sh` (ADMIN_EMAIL →
-// InstanceAdmin). Idempotent: subsequent runs find the existing user/
-// userWorkspace and no-op.
+// InstanceAdmin). Idempotent: subsequent runs ensure the Admin role on the
+// existing userWorkspace, even if the user signed in via SSO first and was
+// auto-provisioned as Member through the workspace's defaultRoleId.
 //
 // Wired into the foss-server-bundle-devstack provisioning pipeline at
 // `provision/provision-twenty.sh`, which runs `workspace:seed:dev --light`
@@ -100,14 +101,17 @@ export class BootstrapSsoAdminCommand extends CommandRunner {
 
     const user = await this.findOrCreateUser(normalizedEmail);
 
-    await this.userWorkspaceService.addUserToWorkspaceIfUserNotInWorkspace(
-      user,
-      workspace,
-      adminRole.id,
-    );
+    const { wasExistingMember } =
+      await this.userWorkspaceService.addUserToWorkspaceOrEnsureRole(
+        user,
+        workspace,
+        adminRole.id,
+      );
 
     this.logger.log(
-      `Admin user "${normalizedEmail}" provisioned for workspace "${subdomain}".`,
+      wasExistingMember
+        ? `Existing user "${normalizedEmail}" promoted to Admin in workspace "${subdomain}".`
+        : `Admin user "${normalizedEmail}" newly provisioned for workspace "${subdomain}".`,
     );
   }
 

--- a/packages/twenty-server/src/database/commands/bootstrap-sso-admin.command.ts
+++ b/packages/twenty-server/src/database/commands/bootstrap-sso-admin.command.ts
@@ -1,0 +1,133 @@
+import { Logger } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+
+import { randomBytes } from 'crypto';
+
+import { Command, CommandRunner, Option } from 'nest-commander';
+import { Repository } from 'typeorm';
+
+import { hashPassword } from 'src/engine/core-modules/auth/auth.util';
+import { TwentyConfigService } from 'src/engine/core-modules/twenty-config/twenty-config.service';
+import { UserWorkspaceService } from 'src/engine/core-modules/user-workspace/user-workspace.service';
+import { UserEntity } from 'src/engine/core-modules/user/user.entity';
+import { WorkspaceEntity } from 'src/engine/core-modules/workspace/workspace.entity';
+import { RoleEntity } from 'src/engine/metadata-modules/role/role.entity';
+import { STANDARD_ROLE } from 'src/engine/workspace-manager/twenty-standard-application/constants/standard-role.constant';
+
+type BootstrapSsoAdminOptions = {
+  email: string;
+};
+
+// Pre-seed one Admin user for the SMB_NAME workspace so SSO sign-in lands a
+// useful role on first hit. Mirrors `provision-plane.sh` (ADMIN_EMAIL →
+// InstanceAdmin). Idempotent: subsequent runs find the existing user/
+// userWorkspace and no-op.
+//
+// Wired into the foss-server-bundle-devstack provisioning pipeline at
+// `provision/provision-twenty.sh`, which runs `workspace:seed:dev --light`
+// (creates the SMB_NAME workspace + standard roles) and then this command.
+// Both steps are idempotent on re-runs.
+@Command({
+  name: 'workspace:bootstrap-sso-admin',
+  description:
+    'Pre-seed a Cognito-known email as the Admin user of the SMB_NAME workspace. Run once after `workspace:seed:dev --light` (see foss-server-bundle-devstack/provision/provision-twenty.sh).',
+})
+export class BootstrapSsoAdminCommand extends CommandRunner {
+  private readonly logger = new Logger(BootstrapSsoAdminCommand.name);
+
+  constructor(
+    @InjectRepository(UserEntity)
+    private readonly userRepository: Repository<UserEntity>,
+    @InjectRepository(WorkspaceEntity)
+    private readonly workspaceRepository: Repository<WorkspaceEntity>,
+    @InjectRepository(RoleEntity)
+    private readonly roleRepository: Repository<RoleEntity>,
+    private readonly userWorkspaceService: UserWorkspaceService,
+    private readonly twentyConfigService: TwentyConfigService,
+  ) {
+    super();
+  }
+
+  @Option({
+    flags: '-e, --email <email>',
+    description: 'Email of the Cognito user to bootstrap as Admin.',
+    required: true,
+  })
+  parseEmail(value: string): string {
+    return value;
+  }
+
+  async run(
+    _passedParams: string[],
+    options: BootstrapSsoAdminOptions,
+  ): Promise<void> {
+    const subdomain = this.twentyConfigService.get('SMB_NAME');
+
+    if (!subdomain) {
+      throw new Error('SMB_NAME is not configured — refusing to bootstrap.');
+    }
+
+    const normalizedEmail = options.email.trim().toLowerCase();
+
+    if (!normalizedEmail.includes('@')) {
+      throw new Error(
+        `Invalid email "${options.email}" — must contain an @-sign.`,
+      );
+    }
+
+    const workspace = await this.workspaceRepository.findOne({
+      where: { subdomain },
+    });
+
+    if (!workspace) {
+      throw new Error(
+        `Workspace with subdomain="${subdomain}" not found. Run \`workspace:seed:dev --light\` first.`,
+      );
+    }
+
+    const adminRole = await this.roleRepository.findOne({
+      where: {
+        universalIdentifier: STANDARD_ROLE.admin.universalIdentifier,
+        workspaceId: workspace.id,
+      },
+    });
+
+    if (!adminRole) {
+      throw new Error(
+        `Admin role missing in workspace "${subdomain}". Standard application sync must have been skipped.`,
+      );
+    }
+
+    const user = await this.findOrCreateUser(normalizedEmail);
+
+    await this.userWorkspaceService.addUserToWorkspaceIfUserNotInWorkspace(
+      user,
+      workspace,
+      adminRole.id,
+    );
+
+    this.logger.log(
+      `Admin user "${normalizedEmail}" provisioned for workspace "${subdomain}".`,
+    );
+  }
+
+  private async findOrCreateUser(email: string): Promise<UserEntity> {
+    const existing = await this.userRepository.findOne({ where: { email } });
+
+    if (existing) {
+      return existing;
+    }
+
+    const passwordHash = await hashPassword(randomBytes(32).toString('hex'));
+
+    return await this.userRepository.save(
+      this.userRepository.create({
+        email,
+        firstName: '',
+        lastName: '',
+        passwordHash,
+        isEmailVerified: true,
+      }),
+    );
+  }
+}

--- a/packages/twenty-server/src/database/commands/database-command.module.ts
+++ b/packages/twenty-server/src/database/commands/database-command.module.ts
@@ -1,6 +1,7 @@
 import { Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
 
+import { BootstrapSsoAdminCommand } from 'src/database/commands/bootstrap-sso-admin.command';
 import { CronRegisterAllCommand } from 'src/database/commands/cron-register-all.command';
 import { DataSeedWorkspaceCommand } from 'src/database/commands/data-seed-dev-workspace.command';
 import { GenerateInstanceCommandCommand } from 'src/database/commands/generate-instance-command.command';
@@ -34,8 +35,11 @@ import { UpgradeStatusCommand } from 'src/engine/core-modules/upgrade/commands/u
 import { UpgradeModule } from 'src/engine/core-modules/upgrade/upgrade.module';
 import { WorkspaceEntity } from 'src/engine/core-modules/workspace/workspace.entity';
 import { WorkspaceModule } from 'src/engine/core-modules/workspace/workspace.module';
+import { UserWorkspaceModule } from 'src/engine/core-modules/user-workspace/user-workspace.module';
+import { UserEntity } from 'src/engine/core-modules/user/user.entity';
 import { FieldMetadataModule } from 'src/engine/metadata-modules/field-metadata/field-metadata.module';
 import { ObjectMetadataModule } from 'src/engine/metadata-modules/object-metadata/object-metadata.module';
+import { RoleEntity } from 'src/engine/metadata-modules/role/role.entity';
 import { TrashCleanupModule } from 'src/engine/trash-cleanup/trash-cleanup.module';
 import { WorkspaceCacheStorageModule } from 'src/engine/workspace-cache-storage/workspace-cache-storage.module';
 import { DevSeederModule } from 'src/engine/workspace-manager/dev-seeder/dev-seeder.module';
@@ -51,7 +55,8 @@ import { AutomatedTriggerModule } from 'src/modules/workflow/workflow-trigger/au
 @Module({
   imports: [
     UpgradeVersionCommandModule,
-    TypeOrmModule.forFeature([WorkspaceEntity]),
+    TypeOrmModule.forFeature([WorkspaceEntity, UserEntity, RoleEntity]),
+    UserWorkspaceModule,
     WorkspaceExportModule,
     // Cron command dependencies
     MessagingImportManagerModule,
@@ -87,6 +92,7 @@ import { AutomatedTriggerModule } from 'src/modules/workflow/workflow-trigger/au
     UpgradeModule,
   ],
   providers: [
+    BootstrapSsoAdminCommand,
     DataSeedWorkspaceCommand,
     ConfirmationQuestion,
     CronRegisterAllCommand,

--- a/packages/twenty-server/src/engine/core-modules/auth/auth.module.ts
+++ b/packages/twenty-server/src/engine/core-modules/auth/auth.module.ts
@@ -15,6 +15,7 @@ import { MicrosoftAPIsAuthController } from 'src/engine/core-modules/auth/contro
 import { MicrosoftAuthController } from 'src/engine/core-modules/auth/controllers/microsoft-auth.controller';
 import { OAuthPropagatorController } from 'src/engine/core-modules/auth/controllers/oauth-propagator.controller';
 import { SSOAuthController } from 'src/engine/core-modules/auth/controllers/sso-auth.controller';
+import { SsoProxyLoginController } from 'src/engine/core-modules/auth/controllers/sso-proxy-login.controller';
 import { AuthSsoService } from 'src/engine/core-modules/auth/services/auth-sso.service';
 import { CreateCalendarChannelService } from 'src/engine/core-modules/auth/services/create-calendar-channel.service';
 import { CreateConnectedAccountService } from 'src/engine/core-modules/auth/services/create-connected-account.service';
@@ -26,6 +27,7 @@ import { GoogleAPIsService } from 'src/engine/core-modules/auth/services/google-
 import { MicrosoftAPIsService } from 'src/engine/core-modules/auth/services/microsoft-apis.service';
 import { ResetPasswordService } from 'src/engine/core-modules/auth/services/reset-password.service';
 import { SignInUpService } from 'src/engine/core-modules/auth/services/sign-in-up.service';
+import { SsoUserProvisioningService } from 'src/engine/core-modules/auth/services/sso-user-provisioning.service';
 import { UpdateConnectedAccountOnReconnectService } from 'src/engine/core-modules/auth/services/update-connected-account-on-reconnect.service';
 import { SamlAuthStrategy } from 'src/engine/core-modules/auth/strategies/saml.auth.strategy';
 import { AccessTokenService } from 'src/engine/core-modules/auth/token/services/access-token.service';
@@ -128,6 +130,7 @@ import { JwtAuthStrategy } from './strategies/jwt.auth.strategy';
     MicrosoftAPIsAuthController,
     OAuthPropagatorController,
     SSOAuthController,
+    SsoProxyLoginController,
   ],
   providers: [
     SignInUpService,
@@ -155,6 +158,7 @@ import { JwtAuthStrategy } from './strategies/jwt.auth.strategy';
     UpdateConnectedAccountOnReconnectService,
     TransientTokenService,
     AuthSsoService,
+    SsoUserProvisioningService,
   ],
   exports: [
     AccessTokenService,

--- a/packages/twenty-server/src/engine/core-modules/auth/controllers/sso-proxy-login.controller.spec.ts
+++ b/packages/twenty-server/src/engine/core-modules/auth/controllers/sso-proxy-login.controller.spec.ts
@@ -1,0 +1,226 @@
+import { NotFoundException } from '@nestjs/common';
+
+import { SsoProxyLoginController } from 'src/engine/core-modules/auth/controllers/sso-proxy-login.controller';
+
+type ConfigKey =
+  | 'AUTH_TYPE'
+  | 'DEFAULT_EMAIL_DOMAIN'
+  | 'ACCESS_TOKEN_EXPIRES_IN'
+  | 'REFRESH_TOKEN_EXPIRES_IN'
+  | 'SERVER_URL';
+
+type Headers = string | string[] | undefined;
+
+const buildController = (
+  configOverrides?: Partial<Record<ConfigKey, unknown>>,
+) => {
+  const config: Record<ConfigKey, unknown> = {
+    AUTH_TYPE: 'SSO',
+    DEFAULT_EMAIL_DOMAIN: 'askii.ai',
+    ACCESS_TOKEN_EXPIRES_IN: '30m',
+    REFRESH_TOKEN_EXPIRES_IN: '60d',
+    SERVER_URL: 'https://twenty.example.com',
+    ...configOverrides,
+  };
+
+  const twentyConfigService = {
+    get: jest.fn((key: ConfigKey) => config[key]),
+  };
+  const ssoUserProvisioningService = {
+    findOrProvision: jest.fn().mockResolvedValue({
+      user: { id: 'user-1', email: 'user@askii.ai' },
+      workspace: { id: 'workspace-1', subdomain: 'askii' },
+    }),
+  };
+  const accessTokenService = {
+    generateAccessToken: jest.fn().mockResolvedValue({
+      token: 'access-jwt',
+      expiresAt: new Date('2026-04-29T00:00:00Z'),
+    }),
+  };
+  const refreshTokenService = {
+    generateRefreshToken: jest.fn().mockResolvedValue({
+      token: 'refresh-jwt',
+      expiresAt: new Date('2026-06-29T00:00:00Z'),
+    }),
+  };
+
+  const controller = new SsoProxyLoginController(
+    twentyConfigService as any,
+    ssoUserProvisioningService as any,
+    accessTokenService as any,
+    refreshTokenService as any,
+  );
+
+  const res: any = {
+    cookie: jest.fn(),
+    redirect: jest.fn(),
+    status: jest.fn().mockReturnThis(),
+    json: jest.fn(),
+  };
+
+  const proxyLogin = (
+    headerEmail: Headers = undefined,
+    headerUser: Headers = undefined,
+  ) => controller.proxyLogin(headerEmail, headerUser, res);
+
+  return {
+    controller,
+    twentyConfigService,
+    ssoUserProvisioningService,
+    accessTokenService,
+    refreshTokenService,
+    res,
+    proxyLogin,
+  };
+};
+
+describe('SsoProxyLoginController', () => {
+  it('should 404 when AUTH_TYPE is not "SSO"', async () => {
+    const { proxyLogin } = buildController({ AUTH_TYPE: '' });
+
+    await expect(proxyLogin()).rejects.toThrow(NotFoundException);
+  });
+
+  it('should 404 when AUTH_TYPE is some other non-SSO value', async () => {
+    const { proxyLogin } = buildController({ AUTH_TYPE: 'PASSWORD' });
+
+    await expect(proxyLogin()).rejects.toThrow(NotFoundException);
+  });
+
+  it('should 404 (opaque) when both identity headers are missing', async () => {
+    const { proxyLogin } = buildController();
+
+    await expect(proxyLogin()).rejects.toThrow(NotFoundException);
+  });
+
+  it('should 404 when X-Auth-Request-Email is an empty-string array', async () => {
+    const { proxyLogin } = buildController();
+
+    await expect(proxyLogin([''], undefined)).rejects.toThrow(
+      NotFoundException,
+    );
+  });
+
+  it('should provision user from X-Auth-Request-Email and redirect', async () => {
+    const { ssoUserProvisioningService, res, proxyLogin } = buildController();
+
+    await proxyLogin('someone@askii.ai');
+
+    expect(ssoUserProvisioningService.findOrProvision).toHaveBeenCalledWith(
+      'someone@askii.ai',
+    );
+    expect(res.cookie).toHaveBeenCalledWith(
+      'tokenPair',
+      expect.stringContaining('access-jwt'),
+      expect.objectContaining({
+        path: '/',
+        sameSite: 'lax',
+        secure: true,
+        httpOnly: false,
+      }),
+    );
+    expect(res.redirect).toHaveBeenCalledWith(302, '/');
+  });
+
+  it('should synthesize email when X-Auth-Request-User has no @-sign', async () => {
+    const { ssoUserProvisioningService, proxyLogin } = buildController();
+
+    await proxyLogin(undefined, 'BARE_USERNAME');
+
+    expect(ssoUserProvisioningService.findOrProvision).toHaveBeenCalledWith(
+      'bare_username@askii.ai',
+    );
+  });
+
+  it('should prefer X-Auth-Request-Email over X-Auth-Request-User when both present', async () => {
+    const { ssoUserProvisioningService, proxyLogin } = buildController();
+
+    await proxyLogin('real@askii.ai', 'fallback');
+
+    expect(ssoUserProvisioningService.findOrProvision).toHaveBeenCalledWith(
+      'real@askii.ai',
+    );
+  });
+
+  it('should use the first value when X-Auth-Request-Email is array-valued', async () => {
+    const { ssoUserProvisioningService, proxyLogin } = buildController();
+
+    await proxyLogin(['first@askii.ai', 'second@askii.ai']);
+
+    expect(ssoUserProvisioningService.findOrProvision).toHaveBeenCalledWith(
+      'first@askii.ai',
+    );
+  });
+
+  it('should set tokenPair cookie maxAge from REFRESH_TOKEN_EXPIRES_IN, not the access token', async () => {
+    const { res, proxyLogin } = buildController({
+      ACCESS_TOKEN_EXPIRES_IN: '15m',
+      REFRESH_TOKEN_EXPIRES_IN: '7d',
+    });
+
+    await proxyLogin('someone@askii.ai');
+
+    expect(res.cookie).toHaveBeenCalledWith(
+      'tokenPair',
+      expect.any(String),
+      expect.objectContaining({ maxAge: 7 * 24 * 60 * 60 * 1000 }),
+    );
+  });
+
+  it('should set Secure cookie flag based on SERVER_URL scheme', async () => {
+    const { res: httpsRes, proxyLogin: httpsProxyLogin } = buildController({
+      SERVER_URL: 'https://twenty.example.com',
+    });
+
+    await httpsProxyLogin('someone@askii.ai');
+
+    expect(httpsRes.cookie).toHaveBeenCalledWith(
+      'tokenPair',
+      expect.any(String),
+      expect.objectContaining({ secure: true }),
+    );
+
+    const { res: httpRes, proxyLogin: httpProxyLogin } = buildController({
+      SERVER_URL: 'http://localhost:3000',
+    });
+
+    await httpProxyLogin('someone@askii.ai');
+
+    expect(httpRes.cookie).toHaveBeenCalledWith(
+      'tokenPair',
+      expect.any(String),
+      expect.objectContaining({ secure: false }),
+    );
+  });
+
+  it('should 404 when bare username arrives without DEFAULT_EMAIL_DOMAIN configured', async () => {
+    const { proxyLogin } = buildController({ DEFAULT_EMAIL_DOMAIN: '' });
+
+    await expect(proxyLogin(undefined, 'lone_username')).rejects.toThrow(
+      NotFoundException,
+    );
+  });
+
+  it('should pass authProvider=SSO when issuing tokens', async () => {
+    const { accessTokenService, refreshTokenService, proxyLogin } =
+      buildController();
+
+    await proxyLogin('someone@askii.ai');
+
+    expect(accessTokenService.generateAccessToken).toHaveBeenCalledWith(
+      expect.objectContaining({
+        userId: 'user-1',
+        workspaceId: 'workspace-1',
+        authProvider: 'sso',
+      }),
+    );
+    expect(refreshTokenService.generateRefreshToken).toHaveBeenCalledWith(
+      expect.objectContaining({
+        userId: 'user-1',
+        workspaceId: 'workspace-1',
+        authProvider: 'sso',
+      }),
+    );
+  });
+});

--- a/packages/twenty-server/src/engine/core-modules/auth/controllers/sso-proxy-login.controller.ts
+++ b/packages/twenty-server/src/engine/core-modules/auth/controllers/sso-proxy-login.controller.ts
@@ -1,0 +1,174 @@
+import {
+  Controller,
+  Get,
+  Headers,
+  HttpStatus,
+  Logger,
+  NotFoundException,
+  Res,
+  UseFilters,
+  UseGuards,
+} from '@nestjs/common';
+
+import { Response } from 'express';
+import ms from 'ms';
+
+import { AuthRestApiExceptionFilter } from 'src/engine/core-modules/auth/filters/auth-rest-api-exception.filter';
+import { JwtTokenTypeEnum } from 'src/engine/core-modules/auth/types/auth-context.type';
+import { AccessTokenService } from 'src/engine/core-modules/auth/token/services/access-token.service';
+import { RefreshTokenService } from 'src/engine/core-modules/auth/token/services/refresh-token.service';
+import { SsoUserProvisioningService } from 'src/engine/core-modules/auth/services/sso-user-provisioning.service';
+import { TwentyConfigService } from 'src/engine/core-modules/twenty-config/twenty-config.service';
+import { AuthProviderEnum } from 'src/engine/core-modules/workspace/types/workspace.type';
+import { NoPermissionGuard } from 'src/engine/guards/no-permission.guard';
+import { PublicEndpointGuard } from 'src/engine/guards/public-endpoint.guard';
+
+const TOKEN_PAIR_COOKIE_NAME = 'tokenPair';
+
+@Controller('auth/sso')
+@UseFilters(AuthRestApiExceptionFilter)
+export class SsoProxyLoginController {
+  private readonly logger = new Logger(SsoProxyLoginController.name);
+
+  constructor(
+    private readonly twentyConfigService: TwentyConfigService,
+    private readonly ssoUserProvisioningService: SsoUserProvisioningService,
+    private readonly accessTokenService: AccessTokenService,
+    private readonly refreshTokenService: RefreshTokenService,
+  ) {}
+
+  // SECURITY — the trust chain for X-Auth-Request-Email / X-Auth-Request-User:
+  //   1. The Twenty container exposes :3000 only on the docker network — it
+  //      is not published to the host. Only Traefik can reach it from
+  //      outside the cluster.
+  //   2. Traefik's `twenty-secure` router applies the `strip-auth-headers`
+  //      middleware BEFORE `mpass-auth`. Inbound `X-Auth-Request-*` headers
+  //      from a browser are deleted at the edge.
+  //   3. `mpass-auth` (oauth2-proxy ForwardAuth) re-injects the headers
+  //      from the validated SSO session.
+  // Removing any link of this chain — exposing :3000, dropping
+  // `strip-auth-headers`, or reordering the middleware — makes this endpoint
+  // an authentication-bypass primitive. Every change to the Traefik labels
+  // for `twenty-secure` MUST preserve this ordering. See
+  // foss-server-bundle-devstack/docs/app-rules.md.
+  @Get('proxy-login')
+  @UseGuards(PublicEndpointGuard, NoPermissionGuard)
+  async proxyLogin(
+    @Headers('x-auth-request-email') headerEmail: string | string[] | undefined,
+    @Headers('x-auth-request-user') headerUser: string | string[] | undefined,
+    @Res() res: Response,
+  ) {
+    if (this.twentyConfigService.get('AUTH_TYPE') !== 'SSO') {
+      throw new NotFoundException();
+    }
+
+    const email = this.resolveEmail(headerEmail, headerUser);
+
+    if (!email) {
+      // Opaque 404 — same response shape as the AUTH_TYPE!==SSO branch.
+      // A diagnostic 401 would tell an internal-network attacker they hit
+      // a real SSO endpoint and just need to forge a header next.
+      this.logger.warn(
+        'SSO proxy-login called without X-Auth-Request-Email or X-Auth-Request-User headers.',
+      );
+      throw new NotFoundException();
+    }
+
+    const { user, workspace } =
+      await this.ssoUserProvisioningService.findOrProvision(email);
+
+    const accessToken = await this.accessTokenService.generateAccessToken({
+      userId: user.id,
+      workspaceId: workspace.id,
+      authProvider: AuthProviderEnum.SSO,
+    });
+
+    const refreshToken = await this.refreshTokenService.generateRefreshToken({
+      userId: user.id,
+      workspaceId: workspace.id,
+      authProvider: AuthProviderEnum.SSO,
+      targetedTokenType: JwtTokenTypeEnum.ACCESS,
+    });
+
+    this.setTokenPairCookie(res, {
+      accessOrWorkspaceAgnosticToken: {
+        token: accessToken.token,
+        expiresAt: accessToken.expiresAt.toISOString(),
+      },
+      refreshToken: {
+        token: refreshToken.token,
+        expiresAt: refreshToken.expiresAt.toISOString(),
+      },
+    });
+
+    return res.redirect(HttpStatus.FOUND, '/');
+  }
+
+  private resolveEmail(
+    rawEmail: string | string[] | undefined,
+    rawUser: string | string[] | undefined,
+  ): string | null {
+    const headerEmail = this.firstHeaderValue(rawEmail);
+    const headerUser = this.firstHeaderValue(rawUser);
+    const candidate = (headerEmail || headerUser || '').trim();
+
+    if (!candidate) {
+      return null;
+    }
+
+    if (candidate.includes('@')) {
+      return candidate.toLowerCase();
+    }
+
+    const domain = this.twentyConfigService.get('DEFAULT_EMAIL_DOMAIN');
+
+    if (!domain) {
+      this.logger.warn(
+        'X-Auth-Request-User contains a bare username but DEFAULT_EMAIL_DOMAIN is not configured.',
+      );
+
+      return null;
+    }
+
+    return `${candidate.toLowerCase()}@${domain}`;
+  }
+
+  private firstHeaderValue(value: string | string[] | undefined) {
+    if (Array.isArray(value)) {
+      return value[0] ?? '';
+    }
+
+    return value ?? '';
+  }
+
+  private setTokenPairCookie(
+    res: Response,
+    payload: {
+      accessOrWorkspaceAgnosticToken: { token: string; expiresAt: string };
+      refreshToken: { token: string; expiresAt: string };
+    },
+  ) {
+    // Cookie lifetime tracks the refresh token, not the access token.
+    // The cookie carries both: if it expired with the access token, the
+    // browser would drop the refresh token alongside and force a full
+    // re-auth instead of a silent refresh.
+    const refreshExpiry = this.twentyConfigService.get(
+      'REFRESH_TOKEN_EXPIRES_IN',
+    );
+    const maxAgeMs = ms(refreshExpiry);
+
+    // Match the rest of Twenty's cookie config (e.g. session): only set
+    // the Secure flag when SERVER_URL itself is https. Hardcoding `true`
+    // would block local http:// dev setups from storing the cookie.
+    const serverUrl = this.twentyConfigService.get('SERVER_URL') ?? '';
+    const isSecure = serverUrl.startsWith('https');
+
+    res.cookie(TOKEN_PAIR_COOKIE_NAME, JSON.stringify(payload), {
+      path: '/',
+      sameSite: 'lax',
+      secure: isSecure,
+      httpOnly: false,
+      maxAge: maxAgeMs,
+    });
+  }
+}

--- a/packages/twenty-server/src/engine/core-modules/auth/services/sso-user-provisioning.service.spec.ts
+++ b/packages/twenty-server/src/engine/core-modules/auth/services/sso-user-provisioning.service.spec.ts
@@ -7,12 +7,28 @@ const buildService = (overrides?: {
   existingUser?: unknown;
   workspace?: unknown;
   configuredSubdomain?: string;
+  insideLockExistingUser?: unknown;
 }) => {
+  // Find-or-create runs inside dataSource.transaction. The repository
+  // returned by manager.getRepository(UserEntity) is the same jest
+  // mock as the injected one so existing assertions on
+  // `userRepository.findOne/create/save` keep working unchanged.
   const userRepository = {
     findOne: jest.fn().mockResolvedValue(overrides?.existingUser ?? null),
     create: jest.fn((u) => u),
     save: jest.fn(async (u) => ({ id: 'user-id-1', ...u })),
   };
+
+  const queryFn = jest.fn().mockResolvedValue(undefined);
+  const dataSource = {
+    transaction: jest.fn(async (cb: (m: any) => Promise<unknown>) =>
+      cb({
+        query: queryFn,
+        getRepository: jest.fn(() => userRepository),
+      }),
+    ),
+  };
+
   const workspaceRepository = {
     findOne: jest.fn().mockResolvedValue(
       overrides?.workspace ?? {
@@ -37,6 +53,7 @@ const buildService = (overrides?: {
     workspaceRepository as any,
     userWorkspaceService as any,
     twentyConfigService as any,
+    dataSource as any,
   );
 
   return {
@@ -45,6 +62,8 @@ const buildService = (overrides?: {
     workspaceRepository,
     userWorkspaceService,
     twentyConfigService,
+    dataSource,
+    queryFn,
   };
 };
 
@@ -136,5 +155,72 @@ describe('SsoUserProvisioningService', () => {
     expect(userRepository.findOne).toHaveBeenCalledWith({
       where: { email: 'mixed@case.com' },
     });
+  });
+
+  it('should acquire an advisory lock keyed by email before find+create', async () => {
+    // Concurrent-creation race guard: every first-login provisioning
+    // attempt must take a Postgres advisory lock keyed on the email
+    // hash so parallel requests for the same email serialise on the
+    // create. Other emails take different lock keys so distinct
+    // first-logins don't contend.
+    const { service, queryFn, dataSource } = buildService();
+
+    await service.findOrProvision('alice@askii.ai');
+
+    expect(dataSource.transaction).toHaveBeenCalledTimes(1);
+    expect(queryFn).toHaveBeenCalledWith(
+      expect.stringMatching(/pg_advisory_xact_lock\s*\(\s*hashtextextended/),
+      ['alice@askii.ai'],
+    );
+  });
+
+  it('should take the advisory lock before any user lookup', async () => {
+    // The race protection only works if the lock is taken BEFORE the
+    // findOne. If a refactor accidentally moves the findOne above the
+    // lock, two concurrent requests could both pass the miss check
+    // before either takes the lock — race reopens.
+    const callOrder: string[] = [];
+    const { service, userRepository, queryFn } = buildService();
+
+    queryFn.mockImplementation(async () => {
+      callOrder.push('lock');
+    });
+    userRepository.findOne.mockImplementation(async () => {
+      callOrder.push('findOne');
+      return null;
+    });
+
+    await service.findOrProvision('alice@askii.ai');
+
+    expect(callOrder[0]).toBe('lock');
+    expect(callOrder.indexOf('findOne')).toBeGreaterThan(
+      callOrder.indexOf('lock'),
+    );
+  });
+
+  it('should skip create when another request committed a row first', async () => {
+    // Race: this request waited on the advisory lock; while it waited,
+    // another concurrent request committed a User row for the same
+    // email. The lock serialises; once we acquire it, our findOne
+    // sees that row and we skip our own create. Without serialisation
+    // both racing requests would insert duplicate rows.
+    const winningUser = {
+      id: 'committed-by-other-request',
+      email: 'racy@askii.ai',
+    };
+    const { service, userRepository, userWorkspaceService } = buildService({
+      existingUser: winningUser,
+    });
+
+    const result = await service.findOrProvision('racy@askii.ai');
+
+    expect(userRepository.create).not.toHaveBeenCalled();
+    expect(userRepository.save).not.toHaveBeenCalled();
+    expect(result.user).toBe(winningUser);
+    // Membership ensure runs regardless of who won the race — the
+    // workspace join is idempotent on its own.
+    expect(
+      userWorkspaceService.addUserToWorkspaceIfUserNotInWorkspace,
+    ).toHaveBeenCalledWith(winningUser, expect.anything());
   });
 });

--- a/packages/twenty-server/src/engine/core-modules/auth/services/sso-user-provisioning.service.spec.ts
+++ b/packages/twenty-server/src/engine/core-modules/auth/services/sso-user-provisioning.service.spec.ts
@@ -1,0 +1,140 @@
+import { AuthException } from 'src/engine/core-modules/auth/auth.exception';
+import { SsoUserProvisioningService } from 'src/engine/core-modules/auth/services/sso-user-provisioning.service';
+
+type ConfigKey = 'SMB_NAME';
+
+const buildService = (overrides?: {
+  existingUser?: unknown;
+  workspace?: unknown;
+  configuredSubdomain?: string;
+}) => {
+  const userRepository = {
+    findOne: jest.fn().mockResolvedValue(overrides?.existingUser ?? null),
+    create: jest.fn((u) => u),
+    save: jest.fn(async (u) => ({ id: 'user-id-1', ...u })),
+  };
+  const workspaceRepository = {
+    findOne: jest.fn().mockResolvedValue(
+      overrides?.workspace ?? {
+        id: 'workspace-id-1',
+        subdomain: 'askii',
+      },
+    ),
+  };
+  const userWorkspaceService = {
+    addUserToWorkspaceIfUserNotInWorkspace: jest.fn(),
+  };
+  const twentyConfigService = {
+    get: jest.fn((key: ConfigKey) =>
+      key === 'SMB_NAME'
+        ? (overrides?.configuredSubdomain ?? 'askii')
+        : undefined,
+    ),
+  };
+
+  const service = new SsoUserProvisioningService(
+    userRepository as any,
+    workspaceRepository as any,
+    userWorkspaceService as any,
+    twentyConfigService as any,
+  );
+
+  return {
+    service,
+    userRepository,
+    workspaceRepository,
+    userWorkspaceService,
+    twentyConfigService,
+  };
+};
+
+describe('SsoUserProvisioningService', () => {
+  it('should reject email without @-sign', async () => {
+    const { service } = buildService();
+
+    await expect(service.findOrProvision('plainusername')).rejects.toThrow(
+      AuthException,
+    );
+  });
+
+  it('should reject empty email', async () => {
+    const { service } = buildService();
+
+    await expect(service.findOrProvision('   ')).rejects.toThrow(AuthException);
+  });
+
+  it('should throw when SMB_NAME is not configured', async () => {
+    const { service } = buildService({ configuredSubdomain: '' });
+
+    await expect(service.findOrProvision('user@askii.ai')).rejects.toThrow(
+      'SMB_NAME not configured',
+    );
+  });
+
+  it('should throw when configured workspace is missing', async () => {
+    const { service, workspaceRepository } = buildService();
+
+    workspaceRepository.findOne.mockResolvedValueOnce(null);
+
+    await expect(service.findOrProvision('user@askii.ai')).rejects.toThrow(
+      'SSO workspace not provisioned',
+    );
+  });
+
+  it('should create new user and add to workspace when user does not exist', async () => {
+    const { service, userRepository, userWorkspaceService } = buildService();
+
+    const result = await service.findOrProvision('NEW@Askii.ai');
+
+    expect(userRepository.findOne).toHaveBeenCalledWith({
+      where: { email: 'new@askii.ai' },
+    });
+    expect(userRepository.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        email: 'new@askii.ai',
+        firstName: '',
+        lastName: '',
+        passwordHash: expect.any(String),
+        isEmailVerified: true,
+      }),
+    );
+    expect(userRepository.save).toHaveBeenCalled();
+    expect(
+      userWorkspaceService.addUserToWorkspaceIfUserNotInWorkspace,
+    ).toHaveBeenCalledWith(
+      expect.objectContaining({ email: 'new@askii.ai' }),
+      expect.objectContaining({ subdomain: 'askii' }),
+    );
+    expect(result.user.email).toBe('new@askii.ai');
+    expect(result.workspace.subdomain).toBe('askii');
+  });
+
+  it('should reuse existing user and still ensure workspace membership (idempotent)', async () => {
+    const existingUser = {
+      id: 'existing-user-id',
+      email: 'returning@askii.ai',
+    };
+    const { service, userRepository, userWorkspaceService } = buildService({
+      existingUser,
+    });
+
+    const result = await service.findOrProvision('returning@askii.ai');
+
+    expect(userRepository.create).not.toHaveBeenCalled();
+    expect(userRepository.save).not.toHaveBeenCalled();
+    expect(
+      userWorkspaceService.addUserToWorkspaceIfUserNotInWorkspace,
+    ).toHaveBeenCalledWith(existingUser, expect.anything());
+    expect(result.user).toBe(existingUser);
+  });
+
+  it('should normalize email to lowercase before lookup', async () => {
+    const { service, userRepository } = buildService();
+
+    await service.findOrProvision('  Mixed@CASE.com  ');
+
+    expect(userRepository.findOne).toHaveBeenCalledWith({
+      where: { email: 'mixed@case.com' },
+    });
+  });
+});

--- a/packages/twenty-server/src/engine/core-modules/auth/services/sso-user-provisioning.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/auth/services/sso-user-provisioning.service.ts
@@ -3,7 +3,7 @@ import { InjectRepository } from '@nestjs/typeorm';
 
 import { randomBytes } from 'crypto';
 
-import { Repository } from 'typeorm';
+import { DataSource, Repository } from 'typeorm';
 
 import {
   AuthException,
@@ -35,6 +35,9 @@ export class SsoUserProvisioningService {
     private readonly workspaceRepository: Repository<WorkspaceEntity>,
     private readonly userWorkspaceService: UserWorkspaceService,
     private readonly twentyConfigService: TwentyConfigService,
+    // Used for the advisory-lock transaction that serialises
+    // concurrent first-login provisioning (see findOrCreateUser).
+    private readonly dataSource: DataSource,
   ) {}
 
   async findOrProvision(email: string): Promise<SsoProvisionResult> {
@@ -81,27 +84,56 @@ export class SsoUserProvisioningService {
   }
 
   private async findOrCreateUser(email: string): Promise<UserEntity> {
-    const existing = await this.userRepository.findOne({ where: { email } });
+    // Concurrent-creation race guard. On first-ever SSO login the SPA
+    // fires multiple parallel API requests with no session cookie set
+    // yet — every request reaches the proxy-login flow, every request
+    // hits the findOne→save below, and before the row is committed the
+    // others have already passed the findOne miss. Without a
+    // serialisation point, N parallel requests insert N duplicate rows
+    // for the same email.
+    //
+    // We don't rely on the UserEntity unique-on-email constraint to
+    // dedupe at the DB level — that surfaces as a 500 on the losers of
+    // the race rather than a graceful return of the existing user. We
+    // serialise the find+create on a Postgres advisory lock keyed by
+    // the email hash. Advisory locks are per-session, transaction-
+    // scoped, no schema cost; different emails take different lock
+    // keys so concurrent first-logins for distinct users don't contend.
+    return await this.dataSource.transaction(async (manager) => {
+      // pg_advisory_xact_lock takes a bigint; hashtextextended returns a
+      // stable bigint hash. Released automatically when the transaction
+      // commits or rolls back.
+      await manager.query(
+        'SELECT pg_advisory_xact_lock(hashtextextended($1, 0))',
+        [email],
+      );
 
-    if (existing) {
-      return existing;
-    }
+      // Re-check inside the lock. If a concurrent request beat us to
+      // the create, this returns its row and we skip provisioning.
+      const userRepo = manager.getRepository(UserEntity);
+      const existing = await userRepo.findOne({ where: { email } });
 
-    const unguessablePassword = randomBytes(32).toString('hex');
-    const passwordHash = await hashPassword(unguessablePassword);
+      if (existing) {
+        return existing;
+      }
 
-    // The SSO IdP already vouched for this email (the only path to the
-    // proxy-login route is through oauth2-proxy, which validates the
-    // session). Mark the user verified at creation so SSO accounts don't
-    // appear semi-verified to gates that read isEmailVerified.
-    const created = this.userRepository.create({
-      email,
-      firstName: '',
-      lastName: '',
-      passwordHash,
-      isEmailVerified: true,
+      const unguessablePassword = randomBytes(32).toString('hex');
+      const passwordHash = await hashPassword(unguessablePassword);
+
+      // The SSO IdP already vouched for this email (the only path to
+      // the proxy-login route is through oauth2-proxy, which validates
+      // the session). Mark the user verified at creation so SSO
+      // accounts don't appear semi-verified to gates that read
+      // isEmailVerified.
+      const created = userRepo.create({
+        email,
+        firstName: '',
+        lastName: '',
+        passwordHash,
+        isEmailVerified: true,
+      });
+
+      return await userRepo.save(created);
     });
-
-    return await this.userRepository.save(created);
   }
 }

--- a/packages/twenty-server/src/engine/core-modules/auth/services/sso-user-provisioning.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/auth/services/sso-user-provisioning.service.ts
@@ -1,0 +1,107 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+
+import { randomBytes } from 'crypto';
+
+import { Repository } from 'typeorm';
+
+import {
+  AuthException,
+  AuthExceptionCode,
+} from 'src/engine/core-modules/auth/auth.exception';
+import { hashPassword } from 'src/engine/core-modules/auth/auth.util';
+import { TwentyConfigService } from 'src/engine/core-modules/twenty-config/twenty-config.service';
+import { UserWorkspaceService } from 'src/engine/core-modules/user-workspace/user-workspace.service';
+import { UserEntity } from 'src/engine/core-modules/user/user.entity';
+import { WorkspaceEntity } from 'src/engine/core-modules/workspace/workspace.entity';
+
+export type SsoProvisionResult = {
+  user: UserEntity;
+  workspace: WorkspaceEntity;
+};
+
+@Injectable()
+export class SsoUserProvisioningService {
+  private readonly logger = new Logger(SsoUserProvisioningService.name);
+
+  constructor(
+    @InjectRepository(UserEntity)
+    private readonly userRepository: Repository<UserEntity>,
+    // SSO provisioning targets the core schema directly — workspace
+    // repositories aren't usable here because the workspace schema may
+    // not exist yet on first sign-in.
+    // oxlint-disable-next-line twenty/inject-workspace-repository
+    @InjectRepository(WorkspaceEntity)
+    private readonly workspaceRepository: Repository<WorkspaceEntity>,
+    private readonly userWorkspaceService: UserWorkspaceService,
+    private readonly twentyConfigService: TwentyConfigService,
+  ) {}
+
+  async findOrProvision(email: string): Promise<SsoProvisionResult> {
+    const normalizedEmail = email.trim().toLowerCase();
+
+    if (!normalizedEmail || !normalizedEmail.includes('@')) {
+      throw new AuthException(
+        'Invalid email for SSO provisioning',
+        AuthExceptionCode.INVALID_INPUT,
+      );
+    }
+
+    const subdomain = this.twentyConfigService.get('SMB_NAME');
+
+    if (!subdomain) {
+      throw new AuthException(
+        'SMB_NAME not configured',
+        AuthExceptionCode.INTERNAL_SERVER_ERROR,
+      );
+    }
+
+    const workspace = await this.workspaceRepository.findOne({
+      where: { subdomain },
+    });
+
+    if (!workspace) {
+      this.logger.error(
+        `SSO landing workspace (subdomain="${subdomain}") missing — the seeder should have created it from SMB_NAME on first init.`,
+      );
+      throw new AuthException(
+        'SSO workspace not provisioned',
+        AuthExceptionCode.INTERNAL_SERVER_ERROR,
+      );
+    }
+
+    const user = await this.findOrCreateUser(normalizedEmail);
+
+    await this.userWorkspaceService.addUserToWorkspaceIfUserNotInWorkspace(
+      user,
+      workspace,
+    );
+
+    return { user, workspace };
+  }
+
+  private async findOrCreateUser(email: string): Promise<UserEntity> {
+    const existing = await this.userRepository.findOne({ where: { email } });
+
+    if (existing) {
+      return existing;
+    }
+
+    const unguessablePassword = randomBytes(32).toString('hex');
+    const passwordHash = await hashPassword(unguessablePassword);
+
+    // The SSO IdP already vouched for this email (the only path to the
+    // proxy-login route is through oauth2-proxy, which validates the
+    // session). Mark the user verified at creation so SSO accounts don't
+    // appear semi-verified to gates that read isEmailVerified.
+    const created = this.userRepository.create({
+      email,
+      firstName: '',
+      lastName: '',
+      passwordHash,
+      isEmailVerified: true,
+    });
+
+    return await this.userRepository.save(created);
+  }
+}

--- a/packages/twenty-server/src/engine/core-modules/twenty-config/config-variables.ts
+++ b/packages/twenty-server/src/engine/core-modules/twenty-config/config-variables.ts
@@ -1693,6 +1693,33 @@ export class ConfigVariables {
   })
   @IsOptional()
   APP_REGISTRY_TOKEN: string;
+
+  @ConfigVariablesMetadata({
+    group: ConfigVariablesGroup.ADVANCED_SETTINGS,
+    description:
+      'Set to "SSO" to enable the ForwardAuth proxy-login endpoint and hide local auth UI in the SPA. Matches the AUTH_TYPE convention used by the other apps in foss-server-bundle-devstack (Plane / Outline / Penpot / SurfSense).',
+    type: ConfigVariableType.STRING,
+  })
+  @IsOptional()
+  AUTH_TYPE = '';
+
+  @ConfigVariablesMetadata({
+    group: ConfigVariablesGroup.ADVANCED_SETTINGS,
+    description:
+      'Domain appended to bare-username SSO identities (e.g. "user" -> "user@<domain>") when X-Auth-Request-Email lacks an @-sign. Required when AUTH_TYPE=SSO; no default to avoid binding to a single deployment.',
+    type: ConfigVariableType.STRING,
+  })
+  @IsOptional()
+  DEFAULT_EMAIL_DOMAIN = '';
+
+  @ConfigVariablesMetadata({
+    group: ConfigVariablesGroup.ADVANCED_SETTINGS,
+    description:
+      'Per-deployment tenant identifier wired into every foss-server-bundle-devstack app. Twenty uses it both as the seed workspace subdomain (see seeder-workspaces.constant.ts) and as the workspace SSO users join on first login. Required when AUTH_TYPE=SSO.',
+    type: ConfigVariableType.STRING,
+  })
+  @IsOptional()
+  SMB_NAME = '';
 }
 
 export const validate = (config: Record<string, unknown>): ConfigVariables => {

--- a/packages/twenty-server/src/engine/core-modules/user-workspace/user-workspace.service.spec.ts
+++ b/packages/twenty-server/src/engine/core-modules/user-workspace/user-workspace.service.spec.ts
@@ -32,6 +32,7 @@ describe('UserWorkspaceService', () => {
   let service: UserWorkspaceService;
   let userWorkspaceRepository: Repository<UserWorkspaceEntity>;
   let userRepository: Repository<UserEntity>;
+  let roleTargetRepository: Repository<RoleTargetEntity>;
   let workspaceInvitationService: WorkspaceInvitationService;
   let approvedAccessDomainService: ApprovedAccessDomainService;
   let globalWorkspaceOrmManager: GlobalWorkspaceOrmManager;
@@ -70,6 +71,7 @@ describe('UserWorkspaceService', () => {
           provide: getRepositoryToken(RoleTargetEntity),
           useValue: {
             findOneOrFail: jest.fn(),
+            exists: jest.fn(),
           },
         },
         {
@@ -159,6 +161,7 @@ describe('UserWorkspaceService', () => {
       getRepositoryToken(UserWorkspaceEntity),
     );
     userRepository = module.get(getRepositoryToken(UserEntity));
+    roleTargetRepository = module.get(getRepositoryToken(RoleTargetEntity));
     workspaceInvitationService = module.get<WorkspaceInvitationService>(
       WorkspaceInvitationService,
     );
@@ -368,7 +371,7 @@ describe('UserWorkspaceService', () => {
       });
     });
 
-    it('should not add user to workspace if already in workspace', async () => {
+    it('should not add user to workspace if already in workspace and role target already exists', async () => {
       const user = {
         id: 'user-id',
         email: 'test@example.com',
@@ -389,6 +392,7 @@ describe('UserWorkspaceService', () => {
       jest
         .spyOn(service, 'checkUserWorkspaceExists')
         .mockResolvedValue(userWorkspace);
+      jest.spyOn(roleTargetRepository, 'exists').mockResolvedValue(true);
       jest.spyOn(service, 'create').mockResolvedValue(userWorkspace);
       jest.spyOn(service, 'createWorkspaceMember').mockResolvedValue(undefined);
 
@@ -398,8 +402,106 @@ describe('UserWorkspaceService', () => {
         user.id,
         workspace.id,
       );
+      expect(roleTargetRepository.exists).toHaveBeenCalledWith({
+        where: {
+          userWorkspaceId: userWorkspace.id,
+          workspaceId: workspace.id,
+        },
+      });
       expect(service.create).not.toHaveBeenCalled();
       expect(service.createWorkspaceMember).not.toHaveBeenCalled();
+      expect(
+        userRoleService.assignRoleToManyUserWorkspace,
+      ).not.toHaveBeenCalled();
+    });
+
+    it('should self-heal orphan membership by assigning the workspace default role when role target is missing', async () => {
+      const user = {
+        id: 'user-id',
+        email: 'test@example.com',
+        createdAt: new Date('2024-01-01'),
+        updatedAt: new Date('2024-01-01'),
+        deletedAt: null,
+      } as unknown as UserEntity;
+      const workspace = {
+        id: 'workspace-id',
+        defaultRoleId: 'default-role-id',
+      } as WorkspaceEntity;
+      const userWorkspace = {
+        id: 'user-workspace-id',
+        userId: user.id,
+        workspaceId: workspace.id,
+      } as UserWorkspaceEntity;
+
+      jest
+        .spyOn(service, 'checkUserWorkspaceExists')
+        .mockResolvedValue(userWorkspace);
+      jest.spyOn(roleTargetRepository, 'exists').mockResolvedValue(false);
+      jest
+        .spyOn(userRoleService, 'assignRoleToManyUserWorkspace')
+        .mockResolvedValue(undefined);
+      const createSpy = jest.spyOn(service, 'create');
+      const createWorkspaceMemberSpy = jest.spyOn(
+        service,
+        'createWorkspaceMember',
+      );
+
+      await service.addUserToWorkspaceIfUserNotInWorkspace(user, workspace);
+
+      expect(roleTargetRepository.exists).toHaveBeenCalledWith({
+        where: {
+          userWorkspaceId: userWorkspace.id,
+          workspaceId: workspace.id,
+        },
+      });
+      expect(
+        userRoleService.assignRoleToManyUserWorkspace,
+      ).toHaveBeenCalledWith({
+        workspaceId: workspace.id,
+        userWorkspaceIds: [userWorkspace.id],
+        roleId: workspace.defaultRoleId,
+      });
+      expect(createSpy).not.toHaveBeenCalled();
+      expect(createWorkspaceMemberSpy).not.toHaveBeenCalled();
+    });
+
+    it('should self-heal orphan membership using the explicit roleId when one is provided', async () => {
+      const user = {
+        id: 'user-id',
+        email: 'test@example.com',
+      } as UserEntity;
+      const workspace = {
+        id: 'workspace-id',
+        defaultRoleId: 'default-role-id',
+      } as WorkspaceEntity;
+      const userWorkspace = {
+        id: 'user-workspace-id',
+        userId: user.id,
+        workspaceId: workspace.id,
+      } as UserWorkspaceEntity;
+      const explicitRoleId = 'admin-role-id';
+
+      jest
+        .spyOn(service, 'checkUserWorkspaceExists')
+        .mockResolvedValue(userWorkspace);
+      jest.spyOn(roleTargetRepository, 'exists').mockResolvedValue(false);
+      jest
+        .spyOn(userRoleService, 'assignRoleToManyUserWorkspace')
+        .mockResolvedValue(undefined);
+
+      await service.addUserToWorkspaceIfUserNotInWorkspace(
+        user,
+        workspace,
+        explicitRoleId,
+      );
+
+      expect(
+        userRoleService.assignRoleToManyUserWorkspace,
+      ).toHaveBeenCalledWith({
+        workspaceId: workspace.id,
+        userWorkspaceIds: [userWorkspace.id],
+        roleId: explicitRoleId,
+      });
     });
 
     it('should throw an exception if workspace has no default role', async () => {

--- a/packages/twenty-server/src/engine/core-modules/user-workspace/user-workspace.service.spec.ts
+++ b/packages/twenty-server/src/engine/core-modules/user-workspace/user-workspace.service.spec.ts
@@ -427,6 +427,69 @@ describe('UserWorkspaceService', () => {
     });
   });
 
+  describe('addUserToWorkspaceOrEnsureRole', () => {
+    it('should delegate to addUserToWorkspaceIfUserNotInWorkspace when no membership exists', async () => {
+      const user = { id: 'user-id', email: 'test@example.com' } as UserEntity;
+      const workspace = { id: 'workspace-id' } as WorkspaceEntity;
+      const roleId = 'admin-role-id';
+
+      jest.spyOn(service, 'checkUserWorkspaceExists').mockResolvedValue(null);
+      const delegateSpy = jest
+        .spyOn(service, 'addUserToWorkspaceIfUserNotInWorkspace')
+        .mockResolvedValue(undefined);
+
+      const result = await service.addUserToWorkspaceOrEnsureRole(
+        user,
+        workspace,
+        roleId,
+      );
+
+      expect(delegateSpy).toHaveBeenCalledWith(user, workspace, roleId);
+      expect(
+        userRoleService.assignRoleToManyUserWorkspace,
+      ).not.toHaveBeenCalled();
+      expect(result).toEqual({ wasExistingMember: false });
+    });
+
+    it('should ensure role on existing membership without re-creating it (regression for bootstrap-sso-admin no-op)', async () => {
+      const user = { id: 'user-id', email: 'test@example.com' } as UserEntity;
+      const workspace = { id: 'workspace-id' } as WorkspaceEntity;
+      const existing = {
+        id: 'user-workspace-id',
+        userId: user.id,
+        workspaceId: workspace.id,
+      } as UserWorkspaceEntity;
+      const roleId = 'admin-role-id';
+
+      jest
+        .spyOn(service, 'checkUserWorkspaceExists')
+        .mockResolvedValue(existing);
+      const delegateSpy = jest.spyOn(
+        service,
+        'addUserToWorkspaceIfUserNotInWorkspace',
+      );
+      jest
+        .spyOn(userRoleService, 'assignRoleToManyUserWorkspace')
+        .mockResolvedValue(undefined);
+
+      const result = await service.addUserToWorkspaceOrEnsureRole(
+        user,
+        workspace,
+        roleId,
+      );
+
+      expect(delegateSpy).not.toHaveBeenCalled();
+      expect(
+        userRoleService.assignRoleToManyUserWorkspace,
+      ).toHaveBeenCalledWith({
+        workspaceId: workspace.id,
+        userWorkspaceIds: [existing.id],
+        roleId,
+      });
+      expect(result).toEqual({ wasExistingMember: true });
+    });
+  });
+
   describe('getUserCount', () => {
     it('should return the count of users in a workspace', async () => {
       const workspaceId = 'workspace-id';

--- a/packages/twenty-server/src/engine/core-modules/user-workspace/user-workspace.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/user-workspace/user-workspace.service.ts
@@ -224,6 +224,34 @@ export class UserWorkspaceService extends TypeOrmQueryService<UserWorkspaceEntit
     });
   }
 
+  // Idempotent variant of `addUserToWorkspaceIfUserNotInWorkspace` that also
+  // ensures the role on a pre-existing membership matches `roleId`. Used by
+  // the `workspace:bootstrap-sso-admin` CLI: an SSO sign-in that beats
+  // bootstrap to the workspace would otherwise leave the admin stuck as the
+  // workspace's defaultRoleId (Member), with bootstrap's existence-check
+  // helper silently no-op'ing the role assignment.
+  async addUserToWorkspaceOrEnsureRole(
+    user: UserEntity,
+    workspace: WorkspaceEntity,
+    roleId: string,
+  ): Promise<{ wasExistingMember: boolean }> {
+    const existing = await this.checkUserWorkspaceExists(user.id, workspace.id);
+
+    if (existing) {
+      await this.userRoleService.assignRoleToManyUserWorkspace({
+        workspaceId: workspace.id,
+        userWorkspaceIds: [existing.id],
+        roleId,
+      });
+
+      return { wasExistingMember: true };
+    }
+
+    await this.addUserToWorkspaceIfUserNotInWorkspace(user, workspace, roleId);
+
+    return { wasExistingMember: false };
+  }
+
   private async resolveRoleIdForNewMember(
     roleId: string | null | undefined,
     workspace: WorkspaceEntity,

--- a/packages/twenty-server/src/engine/core-modules/user-workspace/user-workspace.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/user-workspace/user-workspace.service.ts
@@ -189,7 +189,40 @@ export class UserWorkspaceService extends TypeOrmQueryService<UserWorkspaceEntit
       workspace.id,
     );
 
+    // Self-heal: a userWorkspace row without a matching core.roleTargets row
+    // is the residue of a sign-in that crashed (e.g. mid-deploy) between the
+    // userWorkspace insert and the role assignment — the two writes can't
+    // share a transaction because roleTargets goes through the workspace
+    // migration pipeline. The membership exists but the user has no role
+    // and is invisible to permission checks. Finish the missing assignment
+    // here so the next sign-in repairs the orphan instead of bailing early.
     if (existingUserWorkspace) {
+      const hasRoleTarget = await this.roleTargetRepository.exists({
+        where: {
+          userWorkspaceId: existingUserWorkspace.id,
+          workspaceId: workspace.id,
+        },
+      });
+
+      if (hasRoleTarget) {
+        return;
+      }
+
+      const resolvedRoleIdForOrphan = await this.resolveRoleIdForNewMember(
+        roleId,
+        workspace,
+      );
+
+      this.logger.warn(
+        `Self-healing orphan userWorkspace ${existingUserWorkspace.id} for ${user.email}: assigning role ${resolvedRoleIdForOrphan}.`,
+      );
+
+      await this.userRoleService.assignRoleToManyUserWorkspace({
+        workspaceId: workspace.id,
+        userWorkspaceIds: [existingUserWorkspace.id],
+        roleId: resolvedRoleIdForOrphan,
+      });
+
       return;
     }
 

--- a/packages/twenty-server/src/engine/workspace-manager/dev-seeder/core/constants/seeder-workspaces.constant.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/dev-seeder/core/constants/seeder-workspaces.constant.ts
@@ -32,11 +32,23 @@ export type SeededEmptyWorkspacesIds =
   | typeof SEED_EMPTY_WORKSPACE_3_ID
   | typeof SEED_EMPTY_WORKSPACE_4_ID;
 
+// The "apple" seed slot is repurposed as the SSO landing workspace in the
+// foss-server-bundle-devstack: ForwardAuth + Traefik route
+// foss-twenty.<DOMAIN> to the workspace whose subdomain matches the
+// bundle's SMB_NAME (the canonical per-deployment tenant identifier wired
+// into every app via docker-compose). Fall back to the upstream "apple"
+// identity when SMB_NAME is unset so dev/test runs that don't set it stay
+// byte-for-byte compatible with twentyhq.
+const SEED_WORKSPACE_SUBDOMAIN = process.env.SMB_NAME ?? 'apple';
+const SEED_WORKSPACE_DISPLAY_NAME =
+  SEED_WORKSPACE_SUBDOMAIN.charAt(0).toUpperCase() +
+  SEED_WORKSPACE_SUBDOMAIN.slice(1);
+
 export const SEEDER_CREATE_WORKSPACE_INPUT = {
   [SEED_APPLE_WORKSPACE_ID]: {
     id: SEED_APPLE_WORKSPACE_ID,
-    displayName: 'Apple',
-    subdomain: 'apple',
+    displayName: SEED_WORKSPACE_DISPLAY_NAME,
+    subdomain: SEED_WORKSPACE_SUBDOMAIN,
     inviteHash: 'apple.dev-invite-hash',
     logo: 'https://twentyhq.github.io/placeholder-images/workspaces/apple-logo.png',
     activationStatus: WorkspaceActivationStatus.PENDING_CREATION, // will be set to active after default role creation

--- a/packages/twenty-server/src/engine/workspace-manager/dev-seeder/services/dev-seeder.service.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/dev-seeder/services/dev-seeder.service.ts
@@ -143,12 +143,27 @@ export class DevSeederService {
       light,
     });
 
-    await this.devSeederPermissionsService.initPermissions({
-      workspaceId,
-      twentyStandardFlatApplication,
-      workspaceCustomFlatApplication,
-      light,
-    });
+    // initPermissions assigns admin/limited/guest/member roles to the demo
+    // userWorkspace rows (Tim, Jane, Jony, Phil + ~200 random). When SMB_NAME
+    // is set those userWorkspace rows weren't seeded above, so fall back to
+    // the minimal init path (member role + workspace activation, no
+    // user-specific assignments). The first SSO user provisioned via
+    // ForwardAuth picks up the member role from defaultRoleId on sign-in.
+    if (this.twentyConfigService.get('SMB_NAME')) {
+      await this.devSeederPermissionsService.initMinimalPermissionsAndActivateWorkspace(
+        {
+          workspaceId,
+          workspaceCustomFlatApplication,
+        },
+      );
+    } else {
+      await this.devSeederPermissionsService.initPermissions({
+        workspaceId,
+        twentyStandardFlatApplication,
+        workspaceCustomFlatApplication,
+        light,
+      });
+    }
 
     const objectMetadataRepository =
       this.coreDataSource.getRepository(ObjectMetadataEntity);
@@ -178,12 +193,20 @@ export class DevSeederService {
         this.workspaceMigrationValidateBuildAndRunService,
     });
 
-    await this.devSeederDataService.seed({
-      schemaName,
-      workspaceId,
-      featureFlags: featureFlagsMap,
-      light,
-    });
+    // devSeederDataService.seed populates the workspace schema with demo CRM
+    // data (companies, people, opportunities, workspace members). Workspace
+    // member rows reference core."user" via userId FK, which we didn't seed
+    // when SMB_NAME is set, so skip the entire data fixture in that mode and
+    // leave the workspace clean. SSO users provisioned via ForwardAuth get
+    // their workspaceMember rows created at sign-in time.
+    if (!this.twentyConfigService.get('SMB_NAME')) {
+      await this.devSeederDataService.seed({
+        schemaName,
+        workspaceId,
+        featureFlags: featureFlagsMap,
+        light,
+      });
+    }
 
     await this.workspaceCacheStorageService.flush(workspaceId, undefined);
   }
@@ -305,9 +328,23 @@ export class DevSeederService {
         queryRunner,
       );
 
+      // Skip every fixture that would create a demo user or reference one
+      // (Tim/Jony/Phil/Jane + ~200 random workspace members, their AI agents,
+      // and their connected accounts / message channels) when running inside
+      // the foss-server-bundle-devstack: SMB_NAME signals a deployed bundle
+      // where real users come in through SSO ForwardAuth on first sign-in, so
+      // the demo data would clutter the workspace member list and any
+      // downstream FK reference (seedAgents / seedMetadataEntities) would
+      // break against missing userWorkspace rows. Same single switch as the
+      // workspace subdomain/displayName override in seeder-workspaces.constant.ts.
+      const seedDemoUsersAndDependents =
+        !this.twentyConfigService.get('SMB_NAME');
+
       await seedServerId({ queryRunner, schemaName });
-      await seedUsers({ queryRunner, schemaName });
-      await seedUserWorkspaces({ queryRunner, schemaName, workspaceId });
+      if (seedDemoUsersAndDependents) {
+        await seedUsers({ queryRunner, schemaName });
+        await seedUserWorkspaces({ queryRunner, schemaName, workspaceId });
+      }
 
       await this.applicationService.createTwentyStandardApplication(
         {
@@ -317,7 +354,9 @@ export class DevSeederService {
         queryRunner,
       );
 
-      await seedAgents({ queryRunner, schemaName, workspaceId });
+      if (seedDemoUsersAndDependents) {
+        await seedAgents({ queryRunner, schemaName, workspaceId });
+      }
       await seedApiKeys({ queryRunner, schemaName, workspaceId });
       await seedFeatureFlags({ queryRunner, schemaName, workspaceId });
 
@@ -330,7 +369,9 @@ export class DevSeederService {
         });
       }
 
-      await seedMetadataEntities({ queryRunner, schemaName, workspaceId });
+      if (seedDemoUsersAndDependents) {
+        await seedMetadataEntities({ queryRunner, schemaName, workspaceId });
+      }
 
       await this.upgradeMigrationService.markAsWorkspaceInitial({
         name: initialCursor.name,

--- a/packages/twenty-server/src/utils/generate-front-config.ts
+++ b/packages/twenty-server/src/utils/generate-front-config.ts
@@ -12,6 +12,7 @@ export function generateFrontConfig(): void {
     window: {
       _env_: {
         REACT_APP_SERVER_BASE_URL: process.env.SERVER_URL,
+        AUTH_TYPE: process.env.AUTH_TYPE ?? '',
       },
     },
   };


### PR DESCRIPTION
## Summary

On first-ever SSO login the SPA fires multiple parallel API requests (workspaces, members, …) with no session cookie set yet. Every request reaches \`SsoUserProvisioningService.findOrCreateUser\`, every request hits the \`findOne\`→\`save\` pair, and before the row is committed the others have already passed the \`findOne\` miss. The losers of the race throw a unique-constraint 500 instead of returning the winner's row.

Same root cause as the Outline incident where a user reported 5 duplicate User rows for one Cognito identity within ~800ms — different fork, same first-login parallel-request pattern.

Twenty's \`UserEntity\` does have a unique-on-email constraint, but the current code does NOT catch the resulting DB error. The losing requests fail with a 500. The user retries; the same race window reopens.

## Fix

Serialise the find+create on a Postgres advisory lock keyed by the email hash. Different emails take different lock keys; concurrent first-logins for distinct users don't contend.

\`\`\`ts
return await this.dataSource.transaction(async (manager) => {
  await manager.query(
    'SELECT pg_advisory_xact_lock(hashtextextended($1, 0))',
    [email],
  );
  const userRepo = manager.getRepository(UserEntity);
  const existing = await userRepo.findOne({ where: { email } });
  if (existing) return existing;
  // … create + save under the lock
});
\`\`\`

- \`pg_advisory_xact_lock\` is transaction-scoped — released automatically on commit/rollback, no leak risk
- \`hashtextextended\` maps the email to a stable bigint, exactly what \`pg_advisory_xact_lock\` expects
- Re-check inside the lock catches the case where another request committed while we waited

## Why not just rely on the unique constraint?

Catching \`QueryFailedError\` on unique violation and falling back to \`findOne\` would also work — that's the pattern Plane and SurfSense use in the equivalent flow. But it requires the constraint to exist, and it surfaces the race as an error path rather than serialising at the source. The advisory-lock approach:

- Doesn't depend on the constraint (cleaner separation: schema describes data shape, code handles concurrency)
- Doesn't generate a logged error per losing request — the losers wait and read, no failure surface
- Matches the approach used in the companion fix in \`Pressingly/outline\` (no unique constraint there by design, so advisory lock was the only option). Same code shape across forks.

## Tests

Three new tests in \`sso-user-provisioning.service.spec.ts\`:

- \`should acquire an advisory lock keyed by email before find+create\` — pins the lock pattern (call shape + parameter)
- \`should take the advisory lock before any user lookup\` — pins the ordering invariant (lock first, then findOne); guards against a refactor that moves the findOne above the lock
- \`should skip create when another request committed a row first\` — simulates the race outcome: lock serialises, findOne under the lock sees the winning row, we return it without creating

All existing tests pass unchanged.

## Companion to

- Pressingly/outline race fix on the equivalent code path (advisory lock added there too)
- Forthcoming \`sso-rules-moneta\` openspec tightening — current \`Concurrent creation races SHALL fall back to read\` requirement is too vague; will be amended to enumerate acceptable mechanisms (advisory lock, ON CONFLICT + retry, SELECT FOR UPDATE) and explicitly forbid plain \`findOne\`+\`create\`

## Test plan

- [ ] \`yarn nx test twenty-server -- sso-user-provisioning.service\` passes (all 9 tests)
- [ ] Manual: log in as a fresh SSO user for the first time → exactly one row in \`core.\"user\"\` with that email, no 500s in logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)