### PR TITLE
Fix(twenty-front): Color of title of side panel with multi records info following the theme correctly

### DIFF
--- a/packages/twenty-front/src/modules/side-panel/components/SidePanelPageInfoLayout.tsx
+++ b/packages/twenty-front/src/modules/side-panel/components/SidePanelPageInfoLayout.tsx
@@ -29,7 +29,7 @@ export const StyledPageInfoTextContainer = styled.div`
 `;
 
 export const StyledPageInfoTitleContainer = styled.div`
-  color: ${themeCssVariables.font.color.tertiary};
+  color: ${themeCssVariables.font.color.secondary};
   font-size: ${themeCssVariables.font.size.md};
   font-weight: ${themeCssVariables.font.weight.semiBold};
   max-width: 150px;

--- a/packages/twenty-front/src/modules/side-panel/components/SidePanelPageInfoLayout.tsx
+++ b/packages/twenty-front/src/modules/side-panel/components/SidePanelPageInfoLayout.tsx
@@ -29,6 +29,7 @@ export const StyledPageInfoTextContainer = styled.div`
 `;
 
 export const StyledPageInfoTitleContainer = styled.div`
+  color: ${themeCssVariables.font.color.tertiary};
   font-size: ${themeCssVariables.font.size.md};
   font-weight: ${themeCssVariables.font.weight.semiBold};
   max-width: 150px;


### PR DESCRIPTION
Fixes #20627 

Screenshot:

<img width="469" height="1019" alt="Screenshot 2026-05-17 at 1 07 34 AM" src="https://github.com/user-attachments/assets/e602f756-c739-4164-ae65-e82e39bbc2b6" />
