### PR TITLE
fix(server): correct OpenAPI schema for phones.additionalPhones

### DIFF
--- a/packages/twenty-server/src/engine/core-modules/open-api/utils/__tests__/components.utils.spec.ts
+++ b/packages/twenty-server/src/engine/core-modules/open-api/utils/__tests__/components.utils.spec.ts
@@ -259,7 +259,18 @@ describe('computeSchemaComponents', () => {
         "properties": {
           "additionalPhones": {
             "items": {
-              "type": "string",
+              "properties": {
+                "callingCode": {
+                  "type": "string",
+                },
+                "countryCode": {
+                  "type": "string",
+                },
+                "number": {
+                  "type": "string",
+                },
+              },
+              "type": "object",
             },
             "type": "array",
           },
@@ -491,7 +502,18 @@ describe('computeSchemaComponents', () => {
         "properties": {
           "additionalPhones": {
             "items": {
-              "type": "string",
+              "properties": {
+                "callingCode": {
+                  "type": "string",
+                },
+                "countryCode": {
+                  "type": "string",
+                },
+                "number": {
+                  "type": "string",
+                },
+              },
+              "type": "object",
             },
             "type": "array",
           },
@@ -752,7 +774,18 @@ describe('computeSchemaComponents', () => {
         "properties": {
           "additionalPhones": {
             "items": {
-              "type": "string",
+              "properties": {
+                "callingCode": {
+                  "type": "string",
+                },
+                "countryCode": {
+                  "type": "string",
+                },
+                "number": {
+                  "type": "string",
+                },
+              },
+              "type": "object",
             },
             "type": "array",
           },

--- a/packages/twenty-server/src/engine/utils/convert-object-metadata-to-schema-properties.util.ts
+++ b/packages/twenty-server/src/engine/utils/convert-object-metadata-to-schema-properties.util.ts
@@ -308,7 +308,18 @@ export const convertObjectMetadataToSchemaProperties = ({
             additionalPhones: {
               type: 'array',
               items: {
-                type: 'string',
+                type: 'object',
+                properties: {
+                  number: {
+                    type: 'string',
+                  },
+                  countryCode: {
+                    type: 'string',
+                  },
+                  callingCode: {
+                    type: 'string',
+                  },
+                },
               },
             },
             primaryPhoneCountryCode: {


### PR DESCRIPTION
Fixes #20629

Problem

The OpenAPI schema for PHONES composite fields documented additionalPhones as string[], but the actual runtime type (defined in phones.composite-type.ts) is Array<{ number: string, countryCode: string, callingCode: string }>. This caused generated SDK types and API docs for create/update payloads to be incorrect.

Root cause

A hardcoded mistake in convert-object-metadata-to-schema-properties.util.ts — the FieldMetadataType.PHONES branch set additionalPhones.items to { type: 'string' } instead of an object schema.

Changes

packages/twenty-server/src/engine/utils/convert-object-metadata-to-schema-properties.util.ts
  - Changed additionalPhones.items from { type: 'string' } to { type: 'object', properties: { number, countryCode, callingCode } }, matching AdditionalPhoneMetadata.

packages/twenty-server/src/engine/core-modules/open-api/utils/__tests__/components.utils.spec.ts
  - Updated all three inline snapshot occurrences (for ObjectName, ObjectNameForResponse, ObjectNameForUpdate) to expect the correct object shape instead of string.