### PR TITLE
fix(imap): suppress 'Mailbox doesn't exist' warning for non-selectable folders

### DIFF
--- a/packages/twenty-server/src/modules/messaging/message-folder-manager/drivers/imap/services/imap-get-all-folders.service.ts
+++ b/packages/twenty-server/src/modules/messaging/message-folder-manager/drivers/imap/services/imap-get-all-folders.service.ts
@@ -186,6 +186,10 @@ export class ImapGetAllFoldersService implements MessageFolderDriver {
 
       return status.uidValidity ?? null;
     } catch (error) {
+      if (error instanceof Error && error.message.includes('Mailbox doesn\'t exist')) {
+        return null;
+      }
+
       this.logger.warn(
         `Failed to get uidValidity for folder ${mailbox.path}:`,
         error,


### PR DESCRIPTION
This PR suppresses the 'Mailbox doesn't exist' warning in ImapGetAllFoldersService when attempting to get uidValidity for non-selectable (container) folders. This resolves the log spam reported in issue #19090 while maintaining the current behavior of falling back to the folder path as the external ID.