### PR TITLE
fix: correct OpenAPI schema for phones.additionalPhones

### DIFF
--- a/packages/twenty-server/src/engine/core-modules/record-crud/zod-schemas/record-properties.zod-schema.ts
+++ b/packages/twenty-server/src/engine/core-modules/record-crud/zod-schemas/record-properties.zod-schema.ts
@@ -234,7 +234,15 @@ export const generateRecordPropertiesZodSchema = (
           primaryPhoneNumber: z.string().optional(),
           primaryPhoneCountryCode: z.string().optional(),
           primaryPhoneCallingCode: z.string().optional(),
-          additionalPhones: z.array(z.string()).optional(),
+          additionalPhones: z
+            .array(
+              z.object({
+                number: z.string().optional(),
+                callingCode: z.string().optional(),
+                countryCode: z.string().optional(),
+              }),
+            )
+            .optional(),
         });
         break;
 

--- a/packages/twenty-server/src/modules/messaging/message-folder-manager/drivers/imap/services/imap-get-all-folders.service.ts
+++ b/packages/twenty-server/src/modules/messaging/message-folder-manager/drivers/imap/services/imap-get-all-folders.service.ts
@@ -186,6 +186,10 @@ export class ImapGetAllFoldersService implements MessageFolderDriver {
 
       return status.uidValidity ?? null;
     } catch (error) {
+      if (error instanceof Error && error.message.includes('Mailbox doesn\'t exist')) {
+        return null;
+      }
+
       this.logger.warn(
         `Failed to get uidValidity for folder ${mailbox.path}:`,
         error,


### PR DESCRIPTION
The OpenAPI schema for the /rest/people POST and PATCH endpoints incorrectly documented additionalPhones as string[], while the actual API response and model structure use an array of objects containing number, callingCode, and countryCode. This PR updates the Zod schema to reflect the correct object structure.