### PR TITLE
Fix: currency icon and amount text misalignment

### DIFF
--- a/packages/twenty-front/src/modules/ui/field/display/components/CurrencyDisplay.tsx
+++ b/packages/twenty-front/src/modules/ui/field/display/components/CurrencyDisplay.tsx
@@ -14,11 +14,17 @@ import { isDefined, formatToShortNumber } from 'twenty-shared/utils';
 import { DEFAULT_DECIMAL_VALUE } from '~/utils/format/formatNumber';
 import { isUndefinedOrNull } from '~/utils/isUndefinedOrNull';
 import { ThemeContext } from 'twenty-ui/theme-constants';
+import { styled } from '@linaria/react';
 
 type CurrencyDisplayProps = {
   currencyValue: FieldCurrencyValue | null | undefined;
   fieldDefinition: FieldDefinition<FieldCurrencyMetadata>;
 };
+
+const StyledOuterSpan = styled.div`
+  display: flex;
+  align-items: center;
+`;
 
 export const CurrencyDisplay = ({
   currencyValue,
@@ -57,7 +63,7 @@ export const CurrencyDisplay = ({
       <EllipsisDisplay>
         {shouldShowCurrencyTooltip && (
           <>
-            <span
+            <StyledOuterSpan 
               id={tooltipAnchorId}
               onMouseEnter={() => setShouldRenderTooltip(true)}
               onMouseLeave={() => setShouldRenderTooltip(false)}
@@ -67,7 +73,7 @@ export const CurrencyDisplay = ({
                 size={theme.icon.size.md}
                 stroke={theme.icon.stroke.sm}
               />
-            </span>{' '}
+            </StyledOuterSpan>{' '}
           </>
         )}
         {amountToDisplay !== null


### PR DESCRIPTION
Fixes #20640 

Screenshots:

<img width="552" height="100" alt="image" src="https://github.com/user-attachments/assets/716e1c88-0998-43de-aa86-b1a1fecff37b" />

<img width="143" height="76" alt="image" src="https://github.com/user-attachments/assets/36041a96-e661-4701-84a8-3b6e96f36659" />
