### PR TITLE
fix(server): add missing return in catch blocks of metadata resolvers

### DIFF
--- a/packages/twenty-server/src/engine/metadata-modules/field-metadata/field-metadata.resolver.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/field-metadata/field-metadata.resolver.ts
@@ -122,7 +122,7 @@ export class FieldMetadataResolver {
 
       return fromFlatFieldMetadataToFieldMetadataDto(flatFieldMetadata);
     } catch (error) {
-      fieldMetadataGraphqlApiExceptionHandler(error);
+      return fieldMetadataGraphqlApiExceptionHandler(error);
     }
   }
 
@@ -144,7 +144,7 @@ export class FieldMetadataResolver {
 
       return fromFlatFieldMetadataToFieldMetadataDto(flatFieldMetadata);
     } catch (error) {
-      fieldMetadataGraphqlApiExceptionHandler(error);
+      return fieldMetadataGraphqlApiExceptionHandler(error);
     }
   }
 

--- a/packages/twenty-server/src/engine/metadata-modules/object-metadata/object-metadata.resolver.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/object-metadata/object-metadata.resolver.ts
@@ -147,7 +147,7 @@ export class ObjectMetadataResolver {
 
       return fromFlatObjectMetadataToObjectMetadataDto(flatobjectMetadata);
     } catch (error) {
-      objectMetadataGraphqlApiExceptionHandler(error);
+      return objectMetadataGraphqlApiExceptionHandler(error);
     }
   }
 
@@ -166,7 +166,7 @@ export class ObjectMetadataResolver {
 
       return fromFlatObjectMetadataToObjectMetadataDto(flatobjectMetadata);
     } catch (error) {
-      objectMetadataGraphqlApiExceptionHandler(error);
+      return objectMetadataGraphqlApiExceptionHandler(error);
     }
   }
 
@@ -185,7 +185,7 @@ export class ObjectMetadataResolver {
 
       return fromFlatObjectMetadataToObjectMetadataDto(flatobjectMetadata);
     } catch (error) {
-      objectMetadataGraphqlApiExceptionHandler(error);
+      return objectMetadataGraphqlApiExceptionHandler(error);
     }
   }
 


### PR DESCRIPTION
## Summary
- Added missing `return` before exception handler calls in `updateOneField` and `deleteOneField` (`field-metadata.resolver.ts`)
- Added missing `return` before exception handler calls in `createOneObject`, `deleteOneObject`, and `updateOneObject` (`object-metadata.resolver.ts`)
- Without these, when the handler doesn't throw, the functions silently return `undefined` which GraphQL serializes as `null` with no error surfaced to the client

## Note
- `index-metadata.resolver.ts` (mentioned in the issue) already has `return [];` after the handler call, so no change was needed there
- The pattern is now consistent with `createOneField` which already had `return` correctly

Fixes #20205