### PR TITLE
fix(server): handle network errors in RestApiService catch block

### DIFF
--- a/packages/twenty-server/src/engine/api/rest/rest-api.service.ts
+++ b/packages/twenty-server/src/engine/api/rest/rest-api.service.ts
@@ -1,4 +1,4 @@
-import { Injectable, InternalServerErrorException } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
 
 import { type AxiosResponse } from 'axios';
 
@@ -46,9 +46,7 @@ export class RestApiService {
         throw new RestApiException(err.response.data.errors);
       }
 
-      throw new InternalServerErrorException(
-        err.message ?? 'Internal server error',
-      );
+      throw err;
     }
 
     if (isDefined(response.data.errors) && response.data.errors.length > 0) {

--- a/packages/twenty-server/src/engine/api/rest/rest-api.service.ts
+++ b/packages/twenty-server/src/engine/api/rest/rest-api.service.ts
@@ -41,7 +41,13 @@ export class RestApiService {
         },
       });
     } catch (err) {
-      throw new RestApiException(err.response.data.errors);
+      if (err.response?.data?.errors) {
+        throw new RestApiException(err.response.data.errors);
+      }
+
+      throw new RestApiException([
+        { message: err.message ?? 'Internal server error' },
+      ]);
     }
 
     if (response.data.errors?.length) {

--- a/packages/twenty-server/src/engine/api/rest/rest-api.service.ts
+++ b/packages/twenty-server/src/engine/api/rest/rest-api.service.ts
@@ -6,6 +6,7 @@ import { type Query } from 'src/engine/api/rest/core/types/query.type';
 import { RestApiException } from 'src/engine/api/rest/errors/RestApiException';
 import { type RequestContext } from 'src/engine/api/rest/types/RequestContext';
 import { SecureHttpClientService } from 'src/engine/core-modules/secure-http-client/secure-http-client.service';
+import { isDefined } from 'twenty-shared/utils';
 
 export enum GraphqlApiType {
   CORE = 'core',
@@ -41,7 +42,7 @@ export class RestApiService {
         },
       });
     } catch (err) {
-      if (err.response?.data?.errors) {
+      if (isDefined(err.response?.data?.errors)) {
         throw new RestApiException(err.response.data.errors);
       }
 
@@ -50,7 +51,7 @@ export class RestApiService {
       );
     }
 
-    if (response.data.errors?.length) {
+    if (isDefined(response.data.errors) && response.data.errors.length > 0) {
       throw new RestApiException(response.data.errors);
     }
 

--- a/packages/twenty-server/src/engine/api/rest/rest-api.service.ts
+++ b/packages/twenty-server/src/engine/api/rest/rest-api.service.ts
@@ -1,4 +1,4 @@
-import { Injectable } from '@nestjs/common';
+import { Injectable, InternalServerErrorException } from '@nestjs/common';
 
 import { type AxiosResponse } from 'axios';
 
@@ -45,9 +45,9 @@ export class RestApiService {
         throw new RestApiException(err.response.data.errors);
       }
 
-      throw new RestApiException([
-        { message: err.message ?? 'Internal server error' },
-      ]);
+      throw new InternalServerErrorException(
+        err.message ?? 'Internal server error',
+      );
     }
 
     if (response.data.errors?.length) {

--- a/packages/twenty-server/src/filters/unhandled-exception.filter.ts
+++ b/packages/twenty-server/src/filters/unhandled-exception.filter.ts
@@ -35,6 +35,6 @@ export class UnhandledExceptionFilter implements ExceptionFilter {
     const status =
       exception instanceof HttpException ? exception.getStatus() : 500;
 
-    response.status(status).json(exception.response);
+    response.status(status).json(exception.response ?? exception.message);
   }
 }


### PR DESCRIPTION
## Summary
- Added safe null check for `err.response?.data?.errors` in `RestApiService.call()` catch block
- When the internal HTTP client fails with a network-level error (ECONNREFUSED, timeout), `err.response` is `undefined` — accessing `.data.errors` on it throws a `TypeError` which gets silently swallowed, returning an empty 500
- Now falls back to throwing the raw error message for network failures instead of crashing

## Changes
- `packages/twenty-server/src/engine/api/rest/rest-api.service.ts`

Fixes #20136