### PR TITLE
fix(front): use theme-aware color for side panel title

### DIFF
--- a/packages/twenty-front/src/modules/side-panel/components/SidePanelPageInfoLayout.tsx
+++ b/packages/twenty-front/src/modules/side-panel/components/SidePanelPageInfoLayout.tsx
@@ -29,6 +29,7 @@ export const StyledPageInfoTextContainer = styled.div`
 `;
 
 export const StyledPageInfoTitleContainer = styled.div`
+  color: ${themeCssVariables.font.color.primary};
   font-size: ${themeCssVariables.font.size.md};
   font-weight: ${themeCssVariables.font.weight.semiBold};
   max-width: 150px;


### PR DESCRIPTION
## Summary
- Added `color: ${themeCssVariables.font.color.primary}` to `StyledPageInfoTitleContainer` in `SidePanelPageInfoLayout.tsx`
- The "Update records" title had no explicit color, so it didn't adapt to dark mode and was nearly invisible against the dark background
- Now correctly uses the theme-aware primary font color

## Changes
- `packages/twenty-front/src/modules/side-panel/components/SidePanelPageInfoLayout.tsx`

Fixes #20627