### PR TITLE
[codex] Add OpenAI Apps domain challenge file

### DIFF
--- a/packages/twenty-website-new/public/.well-known/openai-apps-challenge
+++ b/packages/twenty-website-new/public/.well-known/openai-apps-challenge
@@ -1,0 +1,1 @@
+6-1tez_gHTN3rqJBhwcxsc6k1BM8vwglvmV7ERKHrSk


### PR DESCRIPTION
## Summary
- Add the OpenAI Apps domain verification token as a static well-known file on the Twenty website.

## Why
The OpenAI Apps submission form allows a challenge base URL on the MCP hostname or a parent hostname. Since the MCP hostname is `api.twenty.com`, the parent origin `https://twenty.com` can serve the challenge at `/.well-known/openai-apps-challenge` without adding an API route.

## Validation
- `curl -I -L https://twenty.com/.well-known/openai-apps-challenge` currently returns 404, confirming the file is not already live.
- `git diff --check origin/main...HEAD`
- Verified the PR diff is a single static file: `packages/twenty-website-new/public/.well-known/openai-apps-challenge`.

## Submission setting
Use `https://twenty.com` as the Challenge Base URL after this is deployed.