### PR TITLE
fix(front): use custom object labels for relation fields in details panel

### DIFF
--- a/packages/twenty-front/src/modules/object-record/record-field-list/record-detail-section/relation/components/RecordDetailRelationSection.tsx
+++ b/packages/twenty-front/src/modules/object-record/record-field-list/record-detail-section/relation/components/RecordDetailRelationSection.tsx
@@ -189,7 +189,13 @@ export const RecordDetailRelationSection = ({
     >
       <RecordDetailSectionContainer
         dataTestId={`${fieldDefinition.label.toLowerCase().replace(' ', '-')}-relation`}
-        title={fieldDefinition.label}
+        title={
+          isToManyObjects
+            ? relationObjectMetadataItem.labelPlural
+            : isToOneObject
+              ? relationObjectMetadataItem.labelSingular
+              : fieldDefinition.label
+        }
         link={
           isToManyObjects
             ? {


### PR DESCRIPTION
## Summary
- Uses the related object's `labelPlural` (for to-many) or `labelSingular` (for to-one) as the section title in the record details panel instead of the static `fieldDefinition.label`
- This ensures that when users customize or translate object type names, those custom labels are reflected in relation field sections

## Test plan
- [ ] Rename an object type (e.g., "Companies" → "Unternehmen") in Settings
- [ ] Open a record's details panel that has a relation to that object
- [ ] Verify the relation section title shows the custom name instead of the default

Fixes #19790