### PR TITLE
fix(front): display all fitting relation items in record table cells

### DIFF
--- a/packages/twenty-front/src/modules/object-record/record-field/ui/meta-types/display/components/RelationFromManyFieldDisplay.tsx
+++ b/packages/twenty-front/src/modules/object-record/record-field/ui/meta-types/display/components/RelationFromManyFieldDisplay.tsx
@@ -15,20 +15,8 @@ import { getJunctionConfig } from '@/object-record/record-field/ui/utils/junctio
 import { hasJunctionConfig } from '@/object-record/record-field/ui/utils/junction/hasJunctionConfig';
 
 import { ExpandableList } from '@/ui/layout/expandable-list/components/ExpandableList';
-import { styled } from '@linaria/react';
 import { isArray } from '@sniptt/guards';
 import { isDefined } from 'twenty-shared/utils';
-import { themeCssVariables } from 'twenty-ui/theme-constants';
-
-const StyledContainer = styled.div`
-  align-items: center;
-  display: flex;
-  gap: ${themeCssVariables.spacing[1]};
-  justify-content: flex-start;
-  max-width: 100%;
-  overflow: hidden;
-  width: 100%;
-`;
 
 export const RelationFromManyFieldDisplay = () => {
   const { fieldValue, fieldDefinition, generateRecordChipData } =
@@ -108,15 +96,9 @@ export const RelationFromManyFieldDisplay = () => {
       })
       .filter(isDefined);
 
-    if (isFocused) {
-      return (
-        <ExpandableList isChipCountDisplayed={isFocused}>
-          {chips}
-        </ExpandableList>
-      );
-    }
-
-    return <StyledContainer>{chips}</StyledContainer>;
+    return (
+      <ExpandableList isChipCountDisplayed={isFocused}>{chips}</ExpandableList>
+    );
   }
 
   if (isJunctionRelation && isDefined(junctionConfig)) {


### PR DESCRIPTION
## Summary
- Always use `ExpandableList` for relation from-many field display, even when the cell is not focused
- Previously, unfocused cells rendered chips in a plain container with `overflow: hidden`, which only showed ~3 items regardless of available space
- Now the dynamic overflow detection in `ExpandableList` ensures as many chips as fit are visible, with a `+N` count shown on hover

## Test plan
- [ ] Open a record table with a relation field that has more than 3 linked records
- [ ] Verify that the cell displays as many chips as fit in its width
- [ ] Verify that hovering shows the `+N` chip count for hidden items
- [ ] Resize the column wider and verify more items become visible

Fixes #12039