### PR TITLE
fix: enable rich text field editing in record table cells

### DIFF
--- a/packages/twenty-front/src/modules/object-record/constants/FieldsNotOverwrittenAtDraft.ts
+++ b/packages/twenty-front/src/modules/object-record/constants/FieldsNotOverwrittenAtDraft.ts
@@ -8,4 +8,5 @@ export const FIELD_NOT_OVERWRITTEN_AT_DRAFT = [
   FieldMetadataType.RATING,
   FieldMetadataType.SELECT,
   FieldMetadataType.FILES,
+  FieldMetadataType.RICH_TEXT,
 ];

--- a/packages/twenty-front/src/modules/object-record/record-field/ui/utils/getFieldButtonIcon.ts
+++ b/packages/twenty-front/src/modules/object-record/record-field/ui/utils/getFieldButtonIcon.ts
@@ -10,6 +10,7 @@ import { isUndefinedOrNull } from '~/utils/isUndefinedOrNull';
 
 import { isFieldArray } from '@/object-record/record-field/ui/types/guards/isFieldArray';
 import { isFieldFiles } from '@/object-record/record-field/ui/types/guards/isFieldFiles';
+import { isFieldRichText } from '@/object-record/record-field/ui/types/guards/isFieldRichText';
 import { IconPencil, type IconComponent } from 'twenty-ui/display';
 
 export const getFieldButtonIcon = (
@@ -30,7 +31,8 @@ export const getFieldButtonIcon = (
     isFieldEmails(fieldDefinition) ||
     isFieldArray(fieldDefinition) ||
     isFieldFiles(fieldDefinition) ||
-    isFieldPhones(fieldDefinition)
+    isFieldPhones(fieldDefinition) ||
+    isFieldRichText(fieldDefinition)
   ) {
     return IconPencil;
   }


### PR DESCRIPTION
## Summary
- Add `RICH_TEXT` to `getFieldButtonIcon` so the pencil edit icon appears on hover for rich text fields in record table cells
- Add `RICH_TEXT` to `FIELD_NOT_OVERWRITTEN_AT_DRAFT` to prevent crashes when keyboard input attempts to overwrite the BlockNote JSON draft value with a plain string

## Test plan
- [ ] Create a RICH_TEXT field on any object (e.g., Person)
- [ ] Verify the pencil edit button appears when hovering the cell
- [ ] Click the cell or pencil icon — the rich text editor should open inline
- [ ] Type in the editor — no crash should occur

Fixes #20288