### PR TITLE
fix(front): show "No results" in slash menu when no commands match

### DIFF
--- a/packages/twenty-front/src/modules/blocknote-editor/components/CustomSlashMenu.tsx
+++ b/packages/twenty-front/src/modules/blocknote-editor/components/CustomSlashMenu.tsx
@@ -16,6 +16,8 @@ import { DropdownContent } from '@/ui/layout/dropdown/components/DropdownContent
 import { DropdownMenuItemsContainer } from '@/ui/layout/dropdown/components/DropdownMenuItemsContainer';
 import { OverlayContainer } from '@/ui/layout/overlay/components/OverlayContainer';
 import { SelectableList } from '@/ui/layout/selectable-list/components/SelectableList';
+import { MenuItem } from 'twenty-ui/navigation';
+import { t } from '@lingui/core/macro';
 
 export type { SuggestionItem };
 
@@ -76,15 +78,19 @@ export const CustomSlashMenu = ({
             >
               <DropdownContent>
                 <DropdownMenuItemsContainer hasMaxHeight>
-                  <SelectableList
-                    focusId={SLASH_MENU_DROPDOWN_CLICK_OUTSIDE_ID}
-                    selectableListInstanceId={SLASH_MENU_LIST_ID}
-                    selectableItemIdArray={items.map((item) => item.title)}
-                  >
-                    {items.map((item) => (
-                      <CustomSlashMenuListItem key={item.title} item={item} />
-                    ))}
-                  </SelectableList>
+                  {items.length === 0 ? (
+                    <MenuItem text={t`No results`} />
+                  ) : (
+                    <SelectableList
+                      focusId={SLASH_MENU_DROPDOWN_CLICK_OUTSIDE_ID}
+                      selectableListInstanceId={SLASH_MENU_LIST_ID}
+                      selectableItemIdArray={items.map((item) => item.title)}
+                    >
+                      {items.map((item) => (
+                        <CustomSlashMenuListItem key={item.title} item={item} />
+                      ))}
+                    </SelectableList>
+                  )}
                 </DropdownMenuItemsContainer>
               </DropdownContent>
             </OverlayContainer>


### PR DESCRIPTION
## Summary
- When typing a slash command with no matching items, the dropdown rendered an empty container that looked like a visual glitch
- Now displays a "No results" message using the same `MenuItem` pattern used across other dropdowns in the codebase

## Test plan
- [ ] Open a rich text editor (e.g., a Note)
- [ ] Type `/` to open the slash menu
- [ ] Type a random string that matches no commands (e.g., `/xyzabc`)
- [ ] Verify a "No results" message is displayed instead of an empty bubble

Fixes #20625