### PR TITLE
fix(front): prevent standalone page layout crash from useTargetRecord

### DIFF
--- a/packages/twenty-front/src/modules/page-layout/components/PageLayoutTabsRenderer.tsx
+++ b/packages/twenty-front/src/modules/page-layout/components/PageLayoutTabsRenderer.tsx
@@ -76,8 +76,6 @@ export const PageLayoutTabsRenderer = () => {
 
   const { objectMetadataItems } = useObjectMetadataItems();
 
-  // Standalone (dashboard) page layouts have no target record, so there are
-  // no relation fields to filter against.
   const inactiveRelationFieldNames = useMemo(() => {
     if (!isDefined(targetRecordIdentifier)) {
       return new Set<string>();

--- a/packages/twenty-front/src/modules/page-layout/components/PageLayoutTabsRenderer.tsx
+++ b/packages/twenty-front/src/modules/page-layout/components/PageLayoutTabsRenderer.tsx
@@ -1,6 +1,6 @@
 import { metadataStoreState } from '@/metadata-store/states/metadataStoreState';
 import { type FlatObjectMetadataItem } from '@/metadata-store/types/FlatObjectMetadataItem';
-import { useObjectMetadataItem } from '@/object-metadata/hooks/useObjectMetadataItem';
+import { useObjectMetadataItems } from '@/object-metadata/hooks/useObjectMetadataItems';
 import { PageLayoutLeftPanel } from '@/page-layout/components/PageLayoutLeftPanel';
 import { PageLayoutTabList } from '@/page-layout/components/PageLayoutTabList';
 import { PageLayoutTabListEffect } from '@/page-layout/components/PageLayoutTabListEffect';
@@ -19,7 +19,6 @@ import { getTabsWithVisibleWidgets } from '@/page-layout/utils/getTabsWithVisibl
 import { shouldEnableTabEditingFeatures } from '@/page-layout/utils/shouldEnableTabEditingFeatures';
 import { sortTabsByPosition } from '@/page-layout/utils/sortTabsByPosition';
 import { useLayoutRenderingContext } from '@/ui/layout/contexts/LayoutRenderingContext';
-import { useTargetRecord } from '@/ui/layout/contexts/useTargetRecord';
 import { activeTabIdComponentState } from '@/ui/layout/tab-list/states/activeTabIdComponentState';
 import { ScrollWrapper } from '@/ui/utilities/scroll/components/ScrollWrapper';
 import { useAtomComponentStateValue } from '@/ui/utilities/state/jotai/hooks/useAtomComponentStateValue';
@@ -75,16 +74,24 @@ export const PageLayoutTabsRenderer = () => {
     currentPageLayout.id,
   );
 
-  const targetRecord = useTargetRecord();
+  const { objectMetadataItems } = useObjectMetadataItems();
 
-  const { objectMetadataItem } = useObjectMetadataItem({
-    objectNameSingular: targetRecord.targetObjectNameSingular,
-  });
-
+  // Standalone (dashboard) page layouts have no target record, so there are
+  // no relation fields to filter against.
   const inactiveRelationFieldNames = useMemo(() => {
+    if (!isDefined(targetRecordIdentifier)) {
+      return new Set<string>();
+    }
+
+    const objectMetadataItem = objectMetadataItems.find(
+      (item) =>
+        item.nameSingular === targetRecordIdentifier.targetObjectNameSingular,
+    );
+
     if (!isDefined(objectMetadataItem)) {
       return new Set<string>();
     }
+
     return new Set(
       objectMetadataItem.fields
         .filter(
@@ -95,7 +102,7 @@ export const PageLayoutTabsRenderer = () => {
         )
         .map((field) => field.name),
     );
-  }, [objectMetadataItem]);
+  }, [objectMetadataItems, targetRecordIdentifier]);
 
   const isMobile = useIsMobile();
 


### PR DESCRIPTION
## Context

Reported in production on `engineering.twenty.com` — standalone page layouts (e.g. "Release overview") crash with the React error boundary fallback ("Sorry, something went wrong"). The console shows:

```
Error: useTargetRecord must be used within a record page context (targetRecordIdentifier is required)
```

The minified stack trace points at `SidePanelToggleButto…`, but that's just the bundle chunk name — the actual call site is `PageLayoutTabsRenderer`.

## Root cause

#19296 added an unconditional `useTargetRecord()` call inside `PageLayoutTabsRenderer` so it could read the target object's metadata and hide tabs whose widgets reference deactivated relations:

```ts
const targetRecord = useTargetRecord();

const { objectMetadataItem } = useObjectMetadataItem({
  objectNameSingular: targetRecord.targetObjectNameSingular,
});
```

But `PageLayoutTabsRenderer` runs on **both** record pages and standalone pages. On standalone pages, `StandalonePageLayoutPage` intentionally sets `targetRecordIdentifier: undefined` in `LayoutRenderingProvider`, which makes `useTargetRecord()` throw — and the follow-up `useObjectMetadataItem()` would also throw on miss.

