### PR TITLE
refactor(server): drop logo select workaround in flat-application cache

### DIFF
--- a/packages/twenty-server/src/engine/core-modules/application/application.entity.ts
+++ b/packages/twenty-server/src/engine/core-modules/application/application.entity.ts
@@ -19,6 +19,7 @@ import { ApplicationRegistrationEntity } from 'src/engine/core-modules/applicati
 import { ApplicationRegistrationSourceType } from 'src/engine/core-modules/application/application-registration/enums/application-registration-source-type.enum';
 import { FileEntity } from 'src/engine/core-modules/file/entities/file.entity';
 import { ApplicationVariableEntity } from 'src/engine/core-modules/application/application-variable/application-variable.entity';
+import { WasIntroducedInUpgrade } from 'src/engine/core-modules/upgrade/decorators/was-introduced-in-upgrade.decorator';
 import { AgentEntity } from 'src/engine/metadata-modules/ai/ai-agent/entities/agent.entity';
 import { CommandMenuItemEntity } from 'src/engine/metadata-modules/command-menu-item/entities/command-menu-item.entity';
 import { FrontComponentEntity } from 'src/engine/metadata-modules/front-component/entities/front-component.entity';
@@ -52,6 +53,10 @@ export class ApplicationEntity extends WorkspaceRelatedEntity {
   description: string | null;
 
   @Column({ nullable: true, type: 'text' })
+  @WasIntroducedInUpgrade({
+    upgradeCommandName:
+      '2.2.0_AddLogoToApplicationFastInstanceCommand_1777539664664',
+  })
   logo: string | null;
 
   // TODO should not be nullable

--- a/packages/twenty-server/src/engine/core-modules/application/workspace-flat-application-map-cache.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/application/workspace-flat-application-map-cache.service.ts
@@ -1,7 +1,7 @@
 import { Injectable } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 
-import { type FindOptionsSelect, Repository } from 'typeorm';
+import { Repository } from 'typeorm';
 
 import { WorkspaceCacheProvider } from 'src/engine/workspace-cache/interfaces/workspace-cache-provider.service';
 
@@ -27,30 +27,6 @@ export class WorkspaceFlatApplicationMapCacheService extends WorkspaceCacheProvi
       where: {
         workspaceId,
       },
-      select: {
-        id: true,
-        universalIdentifier: true,
-        name: true,
-        description: true,
-        version: true,
-        sourceType: true,
-        sourcePath: true,
-        packageJsonChecksum: true,
-        packageJsonFileId: true,
-        yarnLockChecksum: true,
-        yarnLockFileId: true,
-        availablePackages: true,
-        logicFunctionLayerId: true,
-        defaultRoleId: true,
-        settingsCustomTabFrontComponentId: true,
-        canBeUninstalled: true,
-        isSdkLayerStale: true,
-        applicationRegistrationId: true,
-        workspaceId: true,
-        createdAt: true,
-        updatedAt: true,
-        deletedAt: true,
-      } as unknown as FindOptionsSelect<ApplicationEntity>,
       withDeleted: true,
     });
 


### PR DESCRIPTION
## Summary

Replaces the temporary `select: { ... }` workaround in `WorkspaceFlatApplicationMapCacheService` (introduced by #20159) with a property-level `@WasIntroducedInUpgrade` decorator on `ApplicationEntity.logo`.

#20159's own description called itself out: *"This is a temporary fix for cross-version upgrade process, a better fix would be to expose an hasInstanceCommandBeenRun() util (and later a decorator)"*. The decorator now exists, courtesy of #20686.

## Root cause recap

`ApplicationEntity.logo` is added by `2-2-instance-command-fast-1777539664664-add-logo-to-application.ts`. The column is declared on the entity class, so before that instance command runs (i.e. on a cross-version upgrade from a 2.1 or older baseline), TypeORM's bare `repository.find()` emits `SELECT \"logo\" …` against a table that doesn't have the column yet → upgrade aborts. #20159 worked around this by listing every column **except** `logo` in an explicit `select`, with an `as unknown as FindOptionsSelect<ApplicationEntity>` cast.
