### PR TITLE
fix(twenty-front): prevent connected account row overflow on long status label

### DIFF
--- a/packages/twenty-front/src/modules/settings/accounts/components/SettingsAccountsConnectedAccountsRowRightContainer.tsx
+++ b/packages/twenty-front/src/modules/settings/accounts/components/SettingsAccountsConnectedAccountsRowRightContainer.tsx
@@ -11,6 +11,19 @@ const StyledRowRightContainer = styled.div`
   align-items: center;
   display: flex;
   gap: ${themeCssVariables.spacing[4]};
+  min-width: 0;
+  overflow: hidden;
+`;
+
+const StyledStatusWrapper = styled.div`
+  display: flex;
+  min-width: 0;
+  overflow: hidden;
+`;
+
+const StyledDropdownMenuWrapper = styled.div`
+  display: flex;
+  flex-shrink: 0;
 `;
 
 export const SettingsAccountsConnectedAccountsRowRightContainer = ({
@@ -25,27 +38,31 @@ export const SettingsAccountsConnectedAccountsRowRightContainer = ({
 
   return (
     <StyledRowRightContainer>
-      {status === SyncStatus.FAILED && (
-        <Status color="red" text={t`Sync failed`} weight="medium" />
-      )}
-      {status === SyncStatus.SYNCED && (
-        <Status color="green" text={t`Synced`} weight="medium" />
-      )}
-      {status === SyncStatus.NOT_SYNCED && (
-        <Status color="orange" text={t`Not synced`} weight="medium" />
-      )}
-      {status === SyncStatus.IMPORTING && (
-        <Status
-          color="turquoise"
-          text={t`Importing`}
-          weight="medium"
-          isLoaderVisible
-        />
-      )}
-      {status === SyncStatus.PENDING_CONFIGURATION && (
-        <Status color="orange" text={t`Setup incomplete`} weight="medium" />
-      )}
-      <SettingsAccountsRowDropdownMenu account={account} />
+      <StyledStatusWrapper>
+        {status === SyncStatus.FAILED && (
+          <Status color="red" text={t`Sync failed`} weight="medium" />
+        )}
+        {status === SyncStatus.SYNCED && (
+          <Status color="green" text={t`Synced`} weight="medium" />
+        )}
+        {status === SyncStatus.NOT_SYNCED && (
+          <Status color="orange" text={t`Not synced`} weight="medium" />
+        )}
+        {status === SyncStatus.IMPORTING && (
+          <Status
+            color="turquoise"
+            text={t`Importing`}
+            weight="medium"
+            isLoaderVisible
+          />
+        )}
+        {status === SyncStatus.PENDING_CONFIGURATION && (
+          <Status color="orange" text={t`Setup incomplete`} weight="medium" />
+        )}
+      </StyledStatusWrapper>
+      <StyledDropdownMenuWrapper>
+        <SettingsAccountsRowDropdownMenu account={account} />
+      </StyledDropdownMenuWrapper>
     </StyledRowRightContainer>
   );
 };

--- a/packages/twenty-front/src/modules/settings/accounts/components/SettingsAccountsConnectedAccountsRowRightContainer.tsx
+++ b/packages/twenty-front/src/modules/settings/accounts/components/SettingsAccountsConnectedAccountsRowRightContainer.tsx
@@ -11,19 +11,6 @@ const StyledRowRightContainer = styled.div`
   align-items: center;
   display: flex;
   gap: ${themeCssVariables.spacing[4]};
-  min-width: 0;
-  overflow: hidden;
-`;
-
-const StyledStatusWrapper = styled.div`
-  display: flex;
-  min-width: 0;
-  overflow: hidden;
-`;
-
-const StyledDropdownMenuWrapper = styled.div`
-  display: flex;
-  flex-shrink: 0;
 `;
 
 export const SettingsAccountsConnectedAccountsRowRightContainer = ({
@@ -38,31 +25,27 @@ export const SettingsAccountsConnectedAccountsRowRightContainer = ({
 
   return (
     <StyledRowRightContainer>
-      <StyledStatusWrapper>
-        {status === SyncStatus.FAILED && (
-          <Status color="red" text={t`Sync failed`} weight="medium" />
-        )}
-        {status === SyncStatus.SYNCED && (
-          <Status color="green" text={t`Synced`} weight="medium" />
-        )}
-        {status === SyncStatus.NOT_SYNCED && (
-          <Status color="orange" text={t`Not synced`} weight="medium" />
-        )}
-        {status === SyncStatus.IMPORTING && (
-          <Status
-            color="turquoise"
-            text={t`Importing`}
-            weight="medium"
-            isLoaderVisible
-          />
-        )}
-        {status === SyncStatus.PENDING_CONFIGURATION && (
-          <Status color="orange" text={t`Setup incomplete`} weight="medium" />
-        )}
-      </StyledStatusWrapper>
-      <StyledDropdownMenuWrapper>
-        <SettingsAccountsRowDropdownMenu account={account} />
-      </StyledDropdownMenuWrapper>
+      {status === SyncStatus.FAILED && (
+        <Status color="red" text={t`Sync failed`} weight="medium" />
+      )}
+      {status === SyncStatus.SYNCED && (
+        <Status color="green" text={t`Synced`} weight="medium" />
+      )}
+      {status === SyncStatus.NOT_SYNCED && (
+        <Status color="orange" text={t`Not synced`} weight="medium" />
+      )}
+      {status === SyncStatus.IMPORTING && (
+        <Status
+          color="turquoise"
+          text={t`Importing`}
+          weight="medium"
+          isLoaderVisible
+        />
+      )}
+      {status === SyncStatus.PENDING_CONFIGURATION && (
+        <Status color="orange" text={t`Setup incomplete`} weight="medium" />
+      )}
+      <SettingsAccountsRowDropdownMenu account={account} />
     </StyledRowRightContainer>
   );
 };

--- a/packages/twenty-front/src/modules/settings/components/SettingsConnectedAccountsTableRow.tsx
+++ b/packages/twenty-front/src/modules/settings/components/SettingsConnectedAccountsTableRow.tsx
@@ -35,8 +35,11 @@ export const SettingsConnectedAccountsTableRow = ({
 
   return (
     <StyledTableRowContainer>
-      <TableRow key={account.id} gridAutoColumns="332px 1fr">
-        <TableCell>
+      <TableRow
+        key={account.id}
+        gridTemplateColumns="minmax(0, 1fr) auto"
+      >
+        <TableCell overflow="hidden">
           <StyledNameCell>
             <IconComponent
               size={theme.icon.size.md}
@@ -45,7 +48,7 @@ export const SettingsConnectedAccountsTableRow = ({
             {account.handle}
           </StyledNameCell>
         </TableCell>
-        <TableCell align="right">
+        <TableCell align="right" minWidth="0" overflow="hidden">
           <SettingsAccountsConnectedAccountsRowRightContainer
             account={account}
           />

--- a/packages/twenty-front/src/modules/settings/components/SettingsConnectedAccountsTableRow.tsx
+++ b/packages/twenty-front/src/modules/settings/components/SettingsConnectedAccountsTableRow.tsx
@@ -35,11 +35,8 @@ export const SettingsConnectedAccountsTableRow = ({
 
   return (
     <StyledTableRowContainer>
-      <TableRow
-        key={account.id}
-        gridTemplateColumns="minmax(0, 1fr) auto"
-      >
-        <TableCell overflow="hidden">
+      <TableRow key={account.id} gridTemplateColumns="minmax(0, 1fr) auto">
+        <TableCell>
           <StyledNameCell>
             <IconComponent
               size={theme.icon.size.md}
@@ -48,7 +45,7 @@ export const SettingsConnectedAccountsTableRow = ({
             {account.handle}
           </StyledNameCell>
         </TableCell>
-        <TableCell align="right" minWidth="0" overflow="hidden">
+        <TableCell align="right">
           <SettingsAccountsConnectedAccountsRowRightContainer
             account={account}
           />


### PR DESCRIPTION
Reproducible on German language

Before

<img width="638" height="262" alt="SCR-20260519-ofhi" src="https://github.com/user-attachments/assets/633ddd9a-203d-472a-bf29-379d6f088e80" />


After

<img width="806" height="434" alt="SCR-20260519-oesa" src="https://github.com/user-attachments/assets/ca37c06b-e439-4156-8447-0e75a5f3fe9c" />


/closes #20594