### PR TITLE
fix(front): resolve reply account from message channel

### DIFF
--- a/packages/twenty-front/src/modules/activities/emails/hooks/__tests__/useEmailThread.test.ts
+++ b/packages/twenty-front/src/modules/activities/emails/hooks/__tests__/useEmailThread.test.ts
@@ -1,0 +1,173 @@
+import { useQuery } from '@apollo/client/react';
+import { renderHook, waitFor } from '@testing-library/react';
+
+import { useEmailThread } from '@/activities/emails/hooks/useEmailThread';
+import { GET_MY_CONNECTED_ACCOUNTS } from '@/settings/accounts/graphql/queries/getMyConnectedAccounts';
+import { GET_MY_MESSAGE_CHANNELS } from '@/settings/accounts/graphql/queries/getMyMessageChannels';
+import {
+  ConnectedAccountProvider,
+  CoreObjectNameSingular,
+  MessageParticipantRole,
+} from 'twenty-shared/types';
+
+const mockUseFindOneRecord = jest.fn();
+const mockUseFindManyRecords = jest.fn();
+const mockUpsertRecordsInStore = jest.fn();
+
+jest.mock('@apollo/client/react', () => ({
+  useQuery: jest.fn(),
+}));
+
+jest.mock('@/object-record/hooks/useFindOneRecord', () => ({
+  useFindOneRecord: (args: unknown) => mockUseFindOneRecord(args),
+}));
+
+jest.mock('@/object-record/hooks/useFindManyRecords', () => ({
+  useFindManyRecords: (args: unknown) => mockUseFindManyRecords(args),
+}));
+
+jest.mock('@/object-record/record-store/hooks/useUpsertRecordsInStore', () => ({
+  useUpsertRecordsInStore: () => ({
+    upsertRecordsInStore: mockUpsertRecordsInStore,
+  }),
+}));
+
+describe('useEmailThread', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    mockUseFindOneRecord.mockReturnValue({
+      record: { id: 'thread-id' },
+      loading: false,
+    });
+
+    mockUseFindManyRecords.mockImplementation(
+      (args: { objectNameSingular: string; skip?: boolean }) => {
+        if (
+          args.objectNameSingular === CoreObjectNameSingular.MessageThread ||
+          args.objectNameSingular === CoreObjectNameSingular.Message
+        ) {
+          return {
+            records: [
+              {
+                id: 'message-1',
+                subject: 'Thread',
+                headerMessageId: 'header-1',
+              },
+              {
+                id: 'message-2',
+                subject: 'Thread',
+                headerMessageId: 'header-2',
+              },
+            ],
+            loading: false,
+            fetchMoreRecords: jest.fn(),
+            hasNextPage: false,
+          };
+        }
+
+        if (
+          args.objectNameSingular === CoreObjectNameSingular.MessageParticipant
+        ) {
+          return {
+            records: [
+              {
+                id: 'sender-1',
+                messageId: 'message-1',
+                role: MessageParticipantRole.FROM,
+                handle: 'first@example.com',
+              },
+              {
+                id: 'sender-2',
+                messageId: 'message-2',
+                role: MessageParticipantRole.FROM,
+                handle: 'second@example.com',
+              },
+            ],
+            loading: false,
+          };
+        }
+
+        if (
+          args.objectNameSingular ===
+          CoreObjectNameSingular.MessageChannelMessageAssociation
+        ) {
+          return {
+            records: args.skip
+              ? []
+              : [
+                  {
+                    id: 'association-id',
+                    messageId: 'message-2',
+                    messageChannelId: 'channel-2',
+                    messageThreadExternalId: 'thread-external-id',
+                    messageExternalId: 'message-external-id',
+                  },
+                ],
+            loading: false,
+          };
+        }
+
+        return {
+          records: [],
+          loading: false,
+        };
+      },
+    );
+
+    (useQuery as unknown as jest.Mock).mockImplementation((query) => {
+      if (query === GET_MY_CONNECTED_ACCOUNTS) {
+        return {
+          data: {
+            myConnectedAccounts: [
+              {
+                id: 'wrong-account-id',
+                handle: 'wrong@example.com',
+                provider: ConnectedAccountProvider.GOOGLE,
+              },
+              {
+                id: 'thread-account-id',
+                handle: 'thread@example.com',
+                provider: ConnectedAccountProvider.IMAP_SMTP_CALDAV,
+              },
+            ],
+          },
+          loading: false,
+        };
+      }
+
+      if (query === GET_MY_MESSAGE_CHANNELS) {
+        return {
+          data: {
+            myMessageChannels: [
+              {
+                id: 'channel-1',
+                connectedAccountId: 'wrong-account-id',
+              },
+              {
+                id: 'channel-2',
+                connectedAccountId: 'thread-account-id',
+              },
+            ],
+          },
+          loading: false,
+        };
+      }
+
+      return { data: undefined, loading: false };
+    });
+  });
+
+  it('resolves the connected account from the thread message channel', async () => {
+    const { result } = renderHook(() => useEmailThread('thread-id'));
+
+    await waitFor(() => {
+      expect(result.current.connectedAccountId).toBe('thread-account-id');
+    });
+
+    expect(result.current.connectedAccountHandle).toBe('thread@example.com');
+    expect(result.current.connectedAccountProvider).toBe(
+      ConnectedAccountProvider.IMAP_SMTP_CALDAV,
+    );
+  });
+});

--- a/packages/twenty-front/src/modules/activities/emails/hooks/useEmailThread.ts
+++ b/packages/twenty-front/src/modules/activities/emails/hooks/useEmailThread.ts
@@ -11,6 +11,7 @@ import { useFindManyRecords } from '@/object-record/hooks/useFindManyRecords';
 import { useFindOneRecord } from '@/object-record/hooks/useFindOneRecord';
 import { useUpsertRecordsInStore } from '@/object-record/record-store/hooks/useUpsertRecordsInStore';
 import { GET_MY_CONNECTED_ACCOUNTS } from '@/settings/accounts/graphql/queries/getMyConnectedAccounts';
+import { GET_MY_MESSAGE_CHANNELS } from '@/settings/accounts/graphql/queries/getMyMessageChannels';
 import {
   type ConnectedAccountProvider,
   CoreObjectNameSingular,
@@ -104,24 +105,25 @@ export const useEmailThread = (threadId: string | null) => {
       skip: messages.length === 0,
     });
 
-  const { records: messageChannelMessageAssociationData } =
-    useFindManyRecords<MessageChannelMessageAssociation>({
-      filter: {
-        messageId: {
-          eq: lastMessageId ?? '',
-        },
+  const {
+    records: messageChannelMessageAssociationData,
+    loading: messageChannelMessageAssociationLoading,
+  } = useFindManyRecords<MessageChannelMessageAssociation>({
+    filter: {
+      messageId: {
+        eq: lastMessageId ?? '',
       },
-      objectNameSingular:
-        CoreObjectNameSingular.MessageChannelMessageAssociation,
-      recordGqlFields: {
-        id: true,
-        messageId: true,
-        messageChannelId: true,
-        messageThreadExternalId: true,
-        messageExternalId: true,
-      },
-      skip: !lastMessageId || !isMessagesFetchComplete,
-    });
+    },
+    objectNameSingular: CoreObjectNameSingular.MessageChannelMessageAssociation,
+    recordGqlFields: {
+      id: true,
+      messageId: true,
+      messageChannelId: true,
+      messageThreadExternalId: true,
+      messageExternalId: true,
+    },
+    skip: !lastMessageId || !isMessagesFetchComplete,
+  });
 
   const messageThreadExternalId =
     messageChannelMessageAssociationData.length > 0
@@ -130,6 +132,10 @@ export const useEmailThread = (threadId: string | null) => {
   const lastMessageExternalId =
     messageChannelMessageAssociationData.length > 0
       ? messageChannelMessageAssociationData[0].messageExternalId
+      : null;
+  const lastMessageChannelId =
+    messageChannelMessageAssociationData.length > 0
+      ? messageChannelMessageAssociationData[0].messageChannelId
       : null;
 
   const messagesWithSender: EmailThreadMessageWithSender[] = messages
@@ -149,10 +155,7 @@ export const useEmailThread = (threadId: string | null) => {
     })
     .filter(isDefined);
 
-  // connectedAccount and messageChannel live in the core schema,
-  // so we resolve the account from the core myConnectedAccounts query
-  // rather than the workspace-level messageChannel records.
-  const { data: myConnectedAccountsData, loading: messageChannelLoading } =
+  const { data: myConnectedAccountsData, loading: myConnectedAccountsLoading } =
     useQuery<{
       myConnectedAccounts: {
         id: string;
@@ -161,8 +164,30 @@ export const useEmailThread = (threadId: string | null) => {
       }[];
     }>(GET_MY_CONNECTED_ACCOUNTS);
 
+  const { data: myMessageChannelsData, loading: myMessageChannelsLoading } =
+    useQuery<{
+      myMessageChannels: {
+        id: string;
+        connectedAccountId: string;
+      }[];
+    }>(GET_MY_MESSAGE_CHANNELS, {
+      skip: !lastMessageChannelId,
+    });
+
+  const messageChannelLoading =
+    messageChannelMessageAssociationLoading ||
+    myConnectedAccountsLoading ||
+    myMessageChannelsLoading;
+
+  const resolvedMessageChannel = myMessageChannelsData?.myMessageChannels.find(
+    (messageChannel) => messageChannel.id === lastMessageChannelId,
+  );
+
   const resolvedConnectedAccount =
-    myConnectedAccountsData?.myConnectedAccounts[0] ?? null;
+    myConnectedAccountsData?.myConnectedAccounts.find(
+      (connectedAccount) =>
+        connectedAccount.id === resolvedMessageChannel?.connectedAccountId,
+    ) ?? null;
 
   const connectedAccountId = resolvedConnectedAccount?.id ?? null;
   const connectedAccountHandle = resolvedConnectedAccount?.handle ?? null;


### PR DESCRIPTION
## Summary

- resolve reply connected account from the email thread's message channel instead of `myConnectedAccounts[0]`
- keep reply context loading until the message-channel association and account/channel queries resolve
- add a regression test covering a thread whose channel maps to the second connected account

## Test plan

- `node_modules\\.bin\\jest.cmd --config packages/twenty-front/jest.config.mjs packages/twenty-front/src/modules/activities/emails/hooks/__tests__/useEmailThread.test.ts --runInBand`
- `node_modules\\.bin\\prettier.cmd --check packages/twenty-front/src/modules/activities/emails/hooks/useEmailThread.ts packages/twenty-front/src/modules/activities/emails/hooks/__tests__/useEmailThread.test.ts`
- `node_modules\\.bin\\oxlint.cmd -c packages/twenty-front/.oxlintrc.json packages/twenty-front/src/modules/activities/emails/hooks/useEmailThread.ts packages/twenty-front/src/modules/activities/emails/hooks/__tests__/useEmailThread.test.ts`

Note: `nx test twenty-front` is currently blocked by an unrelated existing TypeScript error in `packages/twenty-front-component-renderer/src/remote/worker/utils/createCommandConfirmationModalBridge.ts`.

Fixes #20658
/claim #20658
