### PR TITLE
fix(server): backport relationTargetFieldMetadataId column-add to 2.5.0 fast

### DIFF
--- a/packages/twenty-server/src/database/commands/upgrade-version-command/2-5/2-5-instance-command-fast-1798500001000-add-relation-target-field-metadata-id-to-view-filter.ts
+++ b/packages/twenty-server/src/database/commands/upgrade-version-command/2-5/2-5-instance-command-fast-1798500001000-add-relation-target-field-metadata-id-to-view-filter.ts
@@ -1,0 +1,27 @@
+import { QueryRunner } from 'typeorm';
+
+import { RegisteredInstanceCommand } from 'src/engine/core-modules/upgrade/decorators/registered-instance-command.decorator';
+import { FastInstanceCommand } from 'src/engine/core-modules/upgrade/interfaces/fast-instance-command.interface';
+
+// Backport of the relationTargetFieldMetadataId column-add to 2.5.0 so that
+// the 2.5 workspace command NormalizeCompositeFieldDefaults — which selects
+// this column via WorkspaceFlatViewFilterMapCacheService.computeForCache —
+// can run on v2.3 and v2.4 baselines. The upgrade runner walks forward from
+// `lastAttemptedCommandName`, so the 2.3 backport is skipped for users
+// already past v2.3 and the 2.6 add runs too late.
+@RegisteredInstanceCommand('2.5.0', 1798500001000)
+export class AddRelationTargetFieldMetadataIdToViewFilterFastInstanceCommand2_5
+  implements FastInstanceCommand
+{
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "core"."viewFilter" ADD COLUMN IF NOT EXISTS "relationTargetFieldMetadataId" uuid`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "core"."viewFilter" DROP COLUMN IF EXISTS "relationTargetFieldMetadataId"`,
+    );
+  }
+}

--- a/packages/twenty-server/src/database/commands/upgrade-version-command/instance-commands.constant.ts
+++ b/packages/twenty-server/src/database/commands/upgrade-version-command/instance-commands.constant.ts
@@ -47,6 +47,7 @@ import { EncryptSensitiveConfigStorageSlowInstanceCommand } from 'src/database/c
 import { EncryptTotpSecretsSlowInstanceCommand } from 'src/database/commands/upgrade-version-command/2-5/2-5-instance-command-slow-1798000009000-encrypt-totp-secrets';
 import { AddSubFieldNameToViewSortFastInstanceCommand } from 'src/database/commands/upgrade-version-command/2-5/2-5-instance-command-fast-1778502963794-add-sub-field-name-to-view-sort';
 import { DropPostgresCredentialsTableFastInstanceCommand } from 'src/database/commands/upgrade-version-command/2-5/2-5-instance-command-fast-1798500000000-drop-postgres-credentials-table';
+import { AddRelationTargetFieldMetadataIdToViewFilterFastInstanceCommand2_5 } from 'src/database/commands/upgrade-version-command/2-5/2-5-instance-command-fast-1798500001000-add-relation-target-field-metadata-id-to-view-filter';
 import { AddRelationTargetFieldMetadataIdToViewFilterFastInstanceCommand } from 'src/database/commands/upgrade-version-command/2-6/2-6-instance-command-fast-1798000005000-add-relation-target-field-metadata-id-to-view-filter';
 import { AddChannelSyncStageIndexesFastInstanceCommand } from 'src/database/commands/upgrade-version-command/2-6/2-6-instance-command-fast-1798000010000-add-channel-sync-stage-indexes';
 
@@ -98,6 +99,7 @@ export const INSTANCE_COMMANDS = [
   EncryptTotpSecretsSlowInstanceCommand,
   AddSubFieldNameToViewSortFastInstanceCommand,
   DropPostgresCredentialsTableFastInstanceCommand,
+  AddRelationTargetFieldMetadataIdToViewFilterFastInstanceCommand2_5,
   AddRelationTargetFieldMetadataIdToViewFilterFastInstanceCommand,
   AddChannelSyncStageIndexesFastInstanceCommand,
 ];


### PR DESCRIPTION
## Summary

Cross-version upgrade audit found that two baselines fail when upgrading to v2.6.1:

- `v2.3 -> v2.6.1` fails
- `v2.4 -> v2.6.1` fails

Other baselines (v2.5 -> v2.6.1, v2.6.0 -> v2.6.1) pass. The failing workspace command is the 2.5 `NormalizeCompositeFieldDefaults`:

```
column ViewFilterEntity.relationTargetFieldMetadataId does not exist
  at WorkspaceFlatViewFilterMapCacheService.computeForCache
  during workspace command NormalizeCompositeFieldDefaults 1778000001000 (2.5.0)
```

## Why the existing column-adds don't cover this

The `relationTargetFieldMetadataId` column is added in two existing instance commands:

- `2-3/2-3-instance-command-fast-1747234300000-add-relation-target-field-metadata-id-to-view-filter.ts` (backport from #20664)
- `2-6/2-6-instance-command-fast-1798000005000-add-relation-target-field-metadata-id-to-view-filter.ts`

But the runner's `resolveStartCursor` in `packages/twenty-server/src/engine/core-modules/upgrade/services/upgrade-sequence-runner.service.ts` walks forward from `lastAttemptedCommandName`:

- A workspace already at v2.3+ has a cursor past `1747234300000`, so the 2.3 backport is skipped on subsequent upgrades.
- The 2.6 add at `1798000005000` runs only after all 2.5 commands have completed — too late for the 2.5 workspace command at `1778000001000` that needs the column.

The cursor never walks backward and never re-runs commands inserted behind it, so retroactively patching pre-2.6 versions is impossible. The only viable fix is to insert the column-add at the version where it is first needed: 2.5.0, before the 2.5 workspace commands.

Pre-2.6 instance commands do not have the `@WasIntroducedInUpgrade` decorator tooling, so the backport pattern (a hand-written file with `ADD COLUMN IF NOT EXISTS`) is the only available mechanism.

## What this PR does

- Adds `2-5/2-5-instance-command-fast-1798500001000-add-relation-target-field-metadata-id-to-view-filter.ts` (timestamp one past the last existing 2.5 fast, `1798500000000-drop-postgres-credentials-table`).
- Uses `ADD COLUMN IF NOT EXISTS` for idempotency — runs as a no-op on workspaces already past 2.3 backport or 2.6 add.
- Registers it in `instance-commands.constant.ts`.
- **Keeps** the existing 2.6 `AddRelationTargetFieldMetadataIdToViewFilterFastInstanceCommand` file untouched — removing it would change applied state for already-upgraded v2.6.x users; leaving it in place is safe because it is also idempotent.

## Test plan

- [ ] Re-run cross-version-upgrade CI with `OLDEST_SUPPORTED_VERSION=v2.3` — `v2.3 -> v2.6.1` should now pass `NormalizeCompositeFieldDefaults`.
- [ ] Re-run cross-version-upgrade CI with `OLDEST_SUPPORTED_VERSION=v2.4` — `v2.4 -> v2.6.1` should now pass.
- [ ] Confirm `v2.5 -> v2.6.1` and `v2.6.0 -> v2.6.1` still pass (new command is a no-op on these baselines because the column already exists).