### PR TITLE
refactor(filters): make dispatcher pure; hydrate filters at the platform edge

### DIFF
--- a/packages/twenty-front/src/modules/command-menu-item/engine-command/utils/buildHeadlessCommandContextApi.ts
+++ b/packages/twenty-front/src/modules/command-menu-item/engine-command/utils/buildHeadlessCommandContextApi.ts
@@ -100,7 +100,7 @@ export const buildHeadlessCommandContextApi = ({
         contextStoreFilters: filters,
         contextStoreFilterGroups: filterGroups,
         objectMetadataItem,
-        findFieldMetadataItemById: (id) => fieldMetadataItemByIdMap.get(id),
+        fieldMetadataItemByIdMap,
         filterValueDependencies: {
           currentWorkspaceMemberId: currentWorkspaceMember?.id,
           timeZone: userTimezone,

--- a/packages/twenty-front/src/modules/context-store/hooks/useFindManyRecordsSelectedInContextStore.ts
+++ b/packages/twenty-front/src/modules/context-store/hooks/useFindManyRecordsSelectedInContextStore.ts
@@ -65,7 +65,7 @@ export const useFindManyRecordsSelectedInContextStore = ({
     contextStoreFilters,
     contextStoreFilterGroups,
     objectMetadataItem,
-    findFieldMetadataItemById: (id) => fieldMetadataItemByIdMap.get(id),
+    fieldMetadataItemByIdMap,
     filterValueDependencies,
     contextStoreAnyFieldFilterValue,
   });

--- a/packages/twenty-front/src/modules/context-store/utils/__tests__/computeContextStoreFilters.test.ts
+++ b/packages/twenty-front/src/modules/context-store/utils/__tests__/computeContextStoreFilters.test.ts
@@ -29,8 +29,9 @@ describe('computeContextStoreFilters', () => {
       contextStoreFilters: [],
       contextStoreFilterGroups: [],
       objectMetadataItem: personObjectMetadataItem,
-      findFieldMetadataItemById: (id) =>
-        personObjectMetadataItem.fields.find((field) => field.id === id),
+      fieldMetadataItemByIdMap: new Map(
+        personObjectMetadataItem.fields.map((field) => [field.id, field]),
+      ),
       filterValueDependencies: mockFilterValueDependencies,
       contextStoreAnyFieldFilterValue: '',
     });
@@ -75,8 +76,9 @@ describe('computeContextStoreFilters', () => {
       contextStoreFilters,
       contextStoreFilterGroups: [],
       objectMetadataItem: personObjectMetadataItem,
-      findFieldMetadataItemById: (id) =>
-        personObjectMetadataItem.fields.find((field) => field.id === id),
+      fieldMetadataItemByIdMap: new Map(
+        personObjectMetadataItem.fields.map((field) => [field.id, field]),
+      ),
       filterValueDependencies: mockFilterValueDependencies,
       contextStoreAnyFieldFilterValue: '',
     });

--- a/packages/twenty-front/src/modules/context-store/utils/computeContextStoreFilters.ts
+++ b/packages/twenty-front/src/modules/context-store/utils/computeContextStoreFilters.ts
@@ -1,5 +1,6 @@
 import { type ContextStoreTargetedRecordsRule } from '@/context-store/states/contextStoreTargetedRecordsRuleComponentState';
 import { type EnrichedObjectMetadataItem } from '@/object-metadata/types/EnrichedObjectMetadataItem';
+import { type FieldMetadataItem } from '@/object-metadata/types/FieldMetadataItem';
 import { type RecordFilterGroup } from '@/object-record/record-filter-group/types/RecordFilterGroup';
 import { type RecordFilter } from '@/object-record/record-filter/types/RecordFilter';
 import { makeAndFilterVariables } from '@/object-record/utils/makeAndFilterVariables';
@@ -9,7 +10,7 @@ import {
 } from 'twenty-shared/types';
 import {
   computeRecordGqlOperationFilter,
-  type FindFieldMetadataItemById,
+  hydrateRecordFilters,
   turnAnyFieldFilterIntoRecordGqlFilter,
 } from 'twenty-shared/utils';
 
@@ -18,7 +19,7 @@ type ComputeContextStoreFiltersProps = {
   contextStoreFilters: RecordFilter[];
   contextStoreFilterGroups: RecordFilterGroup[];
   objectMetadataItem: EnrichedObjectMetadataItem;
-  findFieldMetadataItemById: FindFieldMetadataItemById;
+  fieldMetadataItemByIdMap: ReadonlyMap<string, FieldMetadataItem>;
   filterValueDependencies: RecordFilterValueDependencies;
   contextStoreAnyFieldFilterValue: string;
 };
@@ -28,7 +29,7 @@ export const computeContextStoreFilters = ({
   contextStoreFilters,
   contextStoreFilterGroups,
   objectMetadataItem,
-  findFieldMetadataItemById,
+  fieldMetadataItemByIdMap,
   filterValueDependencies,
   contextStoreAnyFieldFilterValue,
 }: ComputeContextStoreFiltersProps) => {
@@ -40,13 +41,17 @@ export const computeContextStoreFilters = ({
       fields: objectMetadataItem.fields,
     });
 
+  const hydratedContextStoreFilters = hydrateRecordFilters(
+    contextStoreFilters,
+    (id) => fieldMetadataItemByIdMap.get(id),
+  );
+
   if (contextStoreTargetedRecordsRule.mode === 'exclusion') {
     queryFilter = makeAndFilterVariables([
       recordGqlFilterForAnyFieldFilter,
       computeRecordGqlOperationFilter({
         filterValueDependencies,
-        findFieldMetadataItemById,
-        recordFilters: contextStoreFilters,
+        recordFilters: hydratedContextStoreFilters,
         recordFilterGroups: contextStoreFilterGroups,
       }),
       contextStoreTargetedRecordsRule.excludedRecordIds.length > 0
@@ -74,8 +79,7 @@ export const computeContextStoreFilters = ({
       },
       computeRecordGqlOperationFilter({
         filterValueDependencies,
-        findFieldMetadataItemById,
-        recordFilters: contextStoreFilters,
+        recordFilters: hydratedContextStoreFilters,
         recordFilterGroups: contextStoreFilterGroups,
       }),
     ]);

--- a/packages/twenty-front/src/modules/object-record/record-calendar/month/hooks/useRecordCalendarQueryDateRangeFilter.tsx
+++ b/packages/twenty-front/src/modules/object-record/record-calendar/month/hooks/useRecordCalendarQueryDateRangeFilter.tsx
@@ -16,6 +16,7 @@ import { type Temporal } from 'temporal-polyfill';
 import {
   combineFilters,
   computeRecordGqlOperationFilter,
+  hydrateRecordFilters,
   isDefined,
   turnAnyFieldFilterIntoRecordGqlFilter,
   turnPlainDateIntoUserTimeZoneInstantString,
@@ -108,9 +109,10 @@ export const useRecordCalendarQueryDateRangeFilter = (
 
   const dateRangeFilter = computeRecordGqlOperationFilter({
     filterValueDependencies,
-    recordFilters: calendarRecordFilters,
+    recordFilters: hydrateRecordFilters(calendarRecordFilters, (id) =>
+      fieldMetadataItemByIdMap.get(id),
+    ),
     recordFilterGroups: currentRecordFilterGroups,
-    findFieldMetadataItemById: (id) => fieldMetadataItemByIdMap.get(id),
   });
 
   const { recordGqlOperationFilter: anyFieldFilter } =

--- a/packages/twenty-front/src/modules/object-record/record-filter/utils/__tests__/computeViewRecordGqlOperationFilter.test.ts
+++ b/packages/twenty-front/src/modules/object-record/record-filter/utils/__tests__/computeViewRecordGqlOperationFilter.test.ts
@@ -7,6 +7,7 @@ import {
 } from 'twenty-shared/types';
 import {
   computeRecordGqlOperationFilter,
+  hydrateRecordFilters,
   isDefined,
 } from 'twenty-shared/utils';
 import { FieldMetadataType } from '~/generated-metadata/graphql';
@@ -61,9 +62,8 @@ describe('computeViewRecordGqlOperationFilter', () => {
 
     const result = computeRecordGqlOperationFilter({
       filterValueDependencies: mockFilterValueDependencies,
-      recordFilters: [nameFilter],
+      recordFilters: hydrateRecordFilters([nameFilter], findCompanyFieldById),
       recordFilterGroups: [],
-      findFieldMetadataItemById: findCompanyFieldById,
     });
 
     expect(result).toEqual({
@@ -114,9 +114,11 @@ describe('computeViewRecordGqlOperationFilter', () => {
 
     const result = computeRecordGqlOperationFilter({
       filterValueDependencies: mockFilterValueDependencies,
-      recordFilters: [nameFilter, employeesFilter],
+      recordFilters: hydrateRecordFilters(
+        [nameFilter, employeesFilter],
+        findCompanyFieldById,
+      ),
       recordFilterGroups: [],
-      findFieldMetadataItemById: findCompanyFieldById,
     });
 
     expect(result).toEqual({
@@ -189,14 +191,16 @@ describe('should work as expected for the different field types', () => {
 
     const result = computeRecordGqlOperationFilter({
       filterValueDependencies: mockFilterValueDependencies,
-      recordFilters: [
-        addressFilterContains,
-        addressFilterDoesNotContain,
-        addressFilterIsEmpty,
-        addressFilterIsNotEmpty,
-      ],
+      recordFilters: hydrateRecordFilters(
+        [
+          addressFilterContains,
+          addressFilterDoesNotContain,
+          addressFilterIsEmpty,
+          addressFilterIsNotEmpty,
+        ],
+        findCompanyFieldById,
+      ),
       recordFilterGroups: [],
-      findFieldMetadataItemById: findCompanyFieldById,
     });
 
     expect(result).toEqual({
@@ -653,14 +657,16 @@ describe('should work as expected for the different field types', () => {
 
     const result = computeRecordGqlOperationFilter({
       filterValueDependencies: mockFilterValueDependencies,
-      recordFilters: [
-        phonesFilterContains,
-        phonesFilterDoesNotContain,
-        phonesFilterIsEmpty,
-        phonesFilterIsNotEmpty,
-      ],
+      recordFilters: hydrateRecordFilters(
+        [
+          phonesFilterContains,
+          phonesFilterDoesNotContain,
+          phonesFilterIsEmpty,
+          phonesFilterIsNotEmpty,
+        ],
+        findPersonFieldById,
+      ),
       recordFilterGroups: [],
-      findFieldMetadataItemById: findPersonFieldById,
     });
 
     expect(result).toEqual({
@@ -850,14 +856,16 @@ describe('should work as expected for the different field types', () => {
 
     const result = computeRecordGqlOperationFilter({
       filterValueDependencies: mockFilterValueDependencies,
-      recordFilters: [
-        emailsFilterContains,
-        emailsFilterDoesNotContain,
-        emailsFilterIsEmpty,
-        emailsFilterIsNotEmpty,
-      ],
+      recordFilters: hydrateRecordFilters(
+        [
+          emailsFilterContains,
+          emailsFilterDoesNotContain,
+          emailsFilterIsEmpty,
+          emailsFilterIsNotEmpty,
+        ],
+        findPersonFieldById,
+      ),
       recordFilterGroups: [],
-      findFieldMetadataItemById: findPersonFieldById,
     });
 
     expect(result).toEqual({
@@ -1061,15 +1069,17 @@ describe('should work as expected for the different field types', () => {
 
     const result = computeRecordGqlOperationFilter({
       filterValueDependencies: mockFilterValueDependencies,
-      recordFilters: [
-        dateFilterIsAfter,
-        dateFilterIsBefore,
-        dateFilterIs,
-        dateFilterIsEmpty,
-        dateFilterIsNotEmpty,
-      ],
+      recordFilters: hydrateRecordFilters(
+        [
+          dateFilterIsAfter,
+          dateFilterIsBefore,
+          dateFilterIs,
+          dateFilterIsEmpty,
+          dateFilterIsNotEmpty,
+        ],
+        findCompanyFieldById,
+      ),
       recordFilterGroups: [],
-      findFieldMetadataItemById: findCompanyFieldById,
     });
 
     expect(result).toEqual({
@@ -1164,14 +1174,16 @@ describe('should work as expected for the different field types', () => {
 
     const result = computeRecordGqlOperationFilter({
       filterValueDependencies: mockFilterValueDependencies,
-      recordFilters: [
-        employeesFilterIsGreaterThan,
-        employeesFilterIsLessThan,
-        employeesFilterIsEmpty,
-        employeesFilterIsNotEmpty,
-      ],
+      recordFilters: hydrateRecordFilters(
+        [
+          employeesFilterIsGreaterThan,
+          employeesFilterIsLessThan,
+          employeesFilterIsEmpty,
+          employeesFilterIsNotEmpty,
+        ],
+        findCompanyFieldById,
+      ),
       recordFilterGroups: [],
-      findFieldMetadataItemById: findCompanyFieldById,
     });
 
     expect(result).toEqual({
@@ -1266,14 +1278,16 @@ describe('should work as expected for the different field types', () => {
 
     const result = computeRecordGqlOperationFilter({
       filterValueDependencies: mockFilterValueDependencies,
-      recordFilters: [
-        ARRFilterIsGreaterThan,
-        ARRFilterIsLessThan,
-        ARRFilterIs,
-        ARRFilterIsNot,
-      ],
+      recordFilters: hydrateRecordFilters(
+        [
+          ARRFilterIsGreaterThan,
+          ARRFilterIsLessThan,
+          ARRFilterIs,
+          ARRFilterIsNot,
+        ],
+        findCompanyFieldById,
+      ),
       recordFilterGroups: [],
-      findFieldMetadataItemById: findCompanyFieldById,
     });
 
     expect(result).toEqual({
@@ -1348,9 +1362,11 @@ describe('should work as expected for the different field types', () => {
 
     const result = computeRecordGqlOperationFilter({
       filterValueDependencies: mockFilterValueDependencies,
-      recordFilters: [ARRFilterIn, ARRFilterNotIn],
+      recordFilters: hydrateRecordFilters(
+        [ARRFilterIn, ARRFilterNotIn],
+        findCompanyFieldById,
+      ),
       recordFilterGroups: [],
-      findFieldMetadataItemById: findCompanyFieldById,
     });
 
     expect(result).toEqual({
@@ -1408,9 +1424,11 @@ describe('should work as expected for the different field types', () => {
 
     const result = computeRecordGqlOperationFilter({
       filterValueDependencies: mockFilterValueDependencies,
-      recordFilters: [selectFilterIs, selectFilterIsNot],
+      recordFilters: hydrateRecordFilters(
+        [selectFilterIs, selectFilterIsNot],
+        findPetFieldById,
+      ),
       recordFilterGroups: [],
-      findFieldMetadataItemById: findPetFieldById,
     });
 
     expect(result).toEqual({
@@ -1478,12 +1496,11 @@ describe('should work as expected for the different field types', () => {
 
     const result = computeRecordGqlOperationFilter({
       filterValueDependencies: mockFilterValueDependencies,
-      recordFilters: [
-        multiSelectFilterContains,
-        multiSelectFilterDoesNotContain,
-      ],
+      recordFilters: hydrateRecordFilters(
+        [multiSelectFilterContains, multiSelectFilterDoesNotContain],
+        findCompanyFieldById,
+      ),
       recordFilterGroups: [],
-      findFieldMetadataItemById: findCompanyFieldById,
     });
 
     expect(result).toEqual({

--- a/packages/twenty-front/src/modules/object-record/record-index/components/RecordIndexContainerContextStoreNumberOfSelectedRecordsEffect.tsx
+++ b/packages/twenty-front/src/modules/object-record/record-index/components/RecordIndexContainerContextStoreNumberOfSelectedRecordsEffect.tsx
@@ -63,7 +63,7 @@ export const RecordIndexContainerContextStoreNumberOfSelectedRecordsEffect =
       contextStoreFilters,
       contextStoreFilterGroups,
       objectMetadataItem,
-      findFieldMetadataItemById: (id) => fieldMetadataItemByIdMap.get(id),
+      fieldMetadataItemByIdMap,
       filterValueDependencies,
       contextStoreAnyFieldFilterValue,
     });

--- a/packages/twenty-front/src/modules/object-record/record-index/export/hooks/useRecordIndexLazyFetchRecords.ts
+++ b/packages/twenty-front/src/modules/object-record/record-index/export/hooks/useRecordIndexLazyFetchRecords.ts
@@ -107,7 +107,7 @@ export const useRecordIndexLazyFetchRecords = ({
     contextStoreFilters,
     contextStoreFilterGroups,
     objectMetadataItem,
-    findFieldMetadataItemById: (id) => fieldMetadataItemByIdMap.get(id),
+    fieldMetadataItemByIdMap,
     filterValueDependencies,
     contextStoreAnyFieldFilterValue,
   });

--- a/packages/twenty-front/src/modules/object-record/record-index/hooks/useFindManyRecordIndexTableParams.ts
+++ b/packages/twenty-front/src/modules/object-record/record-index/hooks/useFindManyRecordIndexTableParams.ts
@@ -14,6 +14,7 @@ import { useAtomStateValue } from '@/ui/utilities/state/jotai/hooks/useAtomState
 import {
   combineFilters,
   computeRecordGqlOperationFilter,
+  hydrateRecordFilters,
   turnAnyFieldFilterIntoRecordGqlFilter,
 } from 'twenty-shared/utils';
 
@@ -54,9 +55,10 @@ export const useFindManyRecordIndexTableParams = (
   );
 
   const currentFilters = computeRecordGqlOperationFilter({
-    findFieldMetadataItemById: (id) => fieldMetadataItemByIdMap.get(id),
     recordFilterGroups: currentRecordFilterGroups,
-    recordFilters: currentRecordFilters,
+    recordFilters: hydrateRecordFilters(currentRecordFilters, (id) =>
+      fieldMetadataItemByIdMap.get(id),
+    ),
     filterValueDependencies,
   });
 

--- a/packages/twenty-front/src/modules/object-record/record-index/hooks/useRecordIndexGroupCommonQueryVariables.ts
+++ b/packages/twenty-front/src/modules/object-record/record-index/hooks/useRecordIndexGroupCommonQueryVariables.ts
@@ -17,6 +17,7 @@ import { useAtomStateValue } from '@/ui/utilities/state/jotai/hooks/useAtomState
 import {
   combineFilters,
   computeRecordGqlOperationFilter,
+  hydrateRecordFilters,
   turnAnyFieldFilterIntoRecordGqlFilter,
 } from 'twenty-shared/utils';
 
@@ -44,9 +45,10 @@ export const useRecordIndexGroupCommonQueryVariables = () => {
 
   const requestFilters = computeRecordGqlOperationFilter({
     filterValueDependencies,
-    recordFilters: currentRecordFilters,
+    recordFilters: hydrateRecordFilters(currentRecordFilters, (id) =>
+      fieldMetadataItemByIdMap.get(id),
+    ),
     recordFilterGroups: currentRecordFilterGroups,
-    findFieldMetadataItemById: (id) => fieldMetadataItemByIdMap.get(id),
   });
 
   const anyFieldFilterValue = useAtomComponentStateValue(

--- a/packages/twenty-front/src/modules/object-record/record-index/hooks/useRecordIndexGroupsAggregatesGroupBy.ts
+++ b/packages/twenty-front/src/modules/object-record/record-index/hooks/useRecordIndexGroupsAggregatesGroupBy.ts
@@ -19,6 +19,7 @@ import { useMemo } from 'react';
 import { type Nullable } from 'twenty-shared/types';
 import {
   computeRecordGqlOperationFilter,
+  hydrateRecordFilters,
   isDefined,
   turnAnyFieldFilterIntoRecordGqlFilter,
 } from 'twenty-shared/utils';
@@ -54,9 +55,10 @@ export const useRecordIndexGroupsAggregatesGroupBy = ({
 
   const requestFilters = computeRecordGqlOperationFilter({
     filterValueDependencies,
-    recordFilters: currentRecordFilters,
+    recordFilters: hydrateRecordFilters(currentRecordFilters, (id) =>
+      fieldMetadataItemByIdMap.get(id),
+    ),
     recordFilterGroups: currentRecordFilterGroups,
-    findFieldMetadataItemById: (id) => fieldMetadataItemByIdMap.get(id),
   });
 
   const { recordAggregateGqlField } =

--- a/packages/twenty-front/src/modules/object-record/record-table/components/RecordTableEmptyHasNewRecordEffect.tsx
+++ b/packages/twenty-front/src/modules/object-record/record-table/components/RecordTableEmptyHasNewRecordEffect.tsx
@@ -18,7 +18,10 @@ import { useAtomStateValue } from '@/ui/utilities/state/jotai/hooks/useAtomState
 
 import { useStore } from 'jotai';
 import { useCallback, useMemo } from 'react';
-import { computeRecordGqlOperationFilter } from 'twenty-shared/utils';
+import {
+  computeRecordGqlOperationFilter,
+  hydrateRecordFilters,
+} from 'twenty-shared/utils';
 
 export const RecordTableEmptyHasNewRecordEffect = () => {
   const { objectMetadataItem } = useRecordIndexContextOrThrow();
@@ -63,8 +66,9 @@ export const RecordTableEmptyHasNewRecordEffect = () => {
       objectNameSingular: objectMetadataItem.nameSingular,
       variables: {
         filter: computeRecordGqlOperationFilter({
-          findFieldMetadataItemById: (id) => fieldMetadataItemByIdMap.get(id),
-          recordFilters: currentRecordFilters,
+          recordFilters: hydrateRecordFilters(currentRecordFilters, (id) =>
+            fieldMetadataItemByIdMap.get(id),
+          ),
           recordFilterGroups: currentRecordFilterGroups,
           filterValueDependencies,
         }),

--- a/packages/twenty-front/src/modules/object-record/record-table/record-table-footer/hooks/useAggregateRecordsForRecordTableColumnFooter.tsx
+++ b/packages/twenty-front/src/modules/object-record/record-table/record-table-footer/hooks/useAggregateRecordsForRecordTableColumnFooter.tsx
@@ -23,6 +23,7 @@ import { useContext } from 'react';
 import { FIELD_FOR_TOTAL_COUNT_AGGREGATE_OPERATION } from 'twenty-shared/constants';
 import {
   computeRecordGqlOperationFilter,
+  hydrateRecordFilters,
   findById,
   isDefined,
   isFieldMetadataDateKind,
@@ -53,10 +54,11 @@ export const useAggregateRecordsForRecordTableColumnFooter = (
   const { filterValueDependencies } = useFilterValueDependencies();
 
   const requestFilters = computeRecordGqlOperationFilter({
-    findFieldMetadataItemById: (id) => fieldMetadataItemByIdMap.get(id),
     filterValueDependencies,
     recordFilterGroups: currentRecordFilterGroups,
-    recordFilters: currentRecordFilters,
+    recordFilters: hydrateRecordFilters(currentRecordFilters, (id) =>
+      fieldMetadataItemByIdMap.get(id),
+    ),
   });
 
   const { viewFieldId } = useContext(

--- a/packages/twenty-front/src/modules/object-record/record-table/virtualization/components/RecordTableVirtualizedSSESubscribeEffect.tsx
+++ b/packages/twenty-front/src/modules/object-record/record-table/virtualization/components/RecordTableVirtualizedSSESubscribeEffect.tsx
@@ -10,7 +10,10 @@ import { currentRecordSortsComponentState } from '@/object-record/record-sort/st
 import { useListenToEventsForQuery } from '@/sse-db-event/hooks/useListenToEventsForQuery';
 import { useAtomComponentStateValue } from '@/ui/utilities/state/jotai/hooks/useAtomComponentStateValue';
 import { useAtomStateValue } from '@/ui/utilities/state/jotai/hooks/useAtomStateValue';
-import { computeRecordGqlOperationFilter } from 'twenty-shared/utils';
+import {
+  computeRecordGqlOperationFilter,
+  hydrateRecordFilters,
+} from 'twenty-shared/utils';
 
 export const RecordTableVirtualizedSSESubscribeEffect = () => {
   const { objectMetadataItem } = useRecordIndexContextOrThrow();
@@ -39,8 +42,9 @@ export const RecordTableVirtualizedSSESubscribeEffect = () => {
       objectNameSingular: objectMetadataItem.nameSingular,
       variables: {
         filter: computeRecordGqlOperationFilter({
-          findFieldMetadataItemById: (id) => fieldMetadataItemByIdMap.get(id),
-          recordFilters: currentRecordFilters,
+          recordFilters: hydrateRecordFilters(currentRecordFilters, (id) =>
+            fieldMetadataItemByIdMap.get(id),
+          ),
           recordFilterGroups: currentRecordFilterGroups,
           filterValueDependencies,
         }),

--- a/packages/twenty-front/src/modules/object-record/record-update-multiple/hooks/useUpdateMultipleRecordsActions.ts
+++ b/packages/twenty-front/src/modules/object-record/record-update-multiple/hooks/useUpdateMultipleRecordsActions.ts
@@ -54,7 +54,7 @@ export const useUpdateMultipleRecordsActions = ({
     contextStoreFilters,
     contextStoreFilterGroups,
     objectMetadataItem,
-    findFieldMetadataItemById: (id) => fieldMetadataItemByIdMap.get(id),
+    fieldMetadataItemByIdMap,
     filterValueDependencies,
     contextStoreAnyFieldFilterValue,
   });

--- a/packages/twenty-front/src/modules/page-layout/widgets/graph/hooks/useGraphWidgetQueryCommon.ts
+++ b/packages/twenty-front/src/modules/page-layout/widgets/graph/hooks/useGraphWidgetQueryCommon.ts
@@ -4,7 +4,9 @@ import { useFilterValueDependencies } from '@/object-record/record-filter/hooks/
 import { useAtomStateValue } from '@/ui/utilities/state/jotai/hooks/useAtomStateValue';
 import {
   computeRecordGqlOperationFilter,
+  hydrateRecordFilters,
   isDefined,
+  type RecordFilter,
 } from 'twenty-shared/utils';
 import {
   type AggregateChartConfiguration,
@@ -47,9 +49,11 @@ export const useGraphWidgetQueryCommon = ({
   const widgetRecordFilters = configuration.filter?.recordFilters ?? [];
 
   const gqlOperationFilter = computeRecordGqlOperationFilter({
-    findFieldMetadataItemById: (id) => fieldMetadataItemByIdMap.get(id),
     filterValueDependencies,
-    recordFilters: widgetRecordFilters,
+    recordFilters: hydrateRecordFilters(
+      widgetRecordFilters as RecordFilter[],
+      (id) => fieldMetadataItemByIdMap.get(id),
+    ),
     recordFilterGroups: configuration.filter?.recordFilterGroups ?? [],
   });
 

--- a/packages/twenty-front/src/modules/views/hooks/internal/useGetRecordIndexTotalCount.ts
+++ b/packages/twenty-front/src/modules/views/hooks/internal/useGetRecordIndexTotalCount.ts
@@ -11,6 +11,7 @@ import { useAtomStateValue } from '@/ui/utilities/state/jotai/hooks/useAtomState
 import { useGetViewGroupsFilters } from '@/views/hooks/useGetViewGroupsFilters';
 import {
   computeRecordGqlOperationFilter,
+  hydrateRecordFilters,
   turnAnyFieldFilterIntoRecordGqlFilter,
 } from 'twenty-shared/utils';
 
@@ -35,9 +36,11 @@ export const useGetRecordIndexTotalCount = () => {
 
   const filter = computeRecordGqlOperationFilter({
     filterValueDependencies,
-    recordFilters: [...currentRecordFilters, ...recordGroupsVisibilityFilter],
+    recordFilters: hydrateRecordFilters(
+      [...currentRecordFilters, ...recordGroupsVisibilityFilter],
+      (id) => fieldMetadataItemByIdMap.get(id),
+    ),
     recordFilterGroups: currentRecordFilterGroups,
-    findFieldMetadataItemById: (id) => fieldMetadataItemByIdMap.get(id),
   });
 
   const anyFieldFilterValue = useAtomComponentStateValue(

--- a/packages/twenty-front/src/modules/views/hooks/useQueryVariablesFromParentView.ts
+++ b/packages/twenty-front/src/modules/views/hooks/useQueryVariablesFromParentView.ts
@@ -33,7 +33,7 @@ export const useQueryVariablesFromParentView = ({
     recordSorts: contextStoreRecordShowParentView?.parentViewSorts ?? [],
     objectMetadataItem,
     objectMetadataItems,
-    findFieldMetadataItemById: (id) => fieldMetadataItemByIdMap.get(id),
+    fieldMetadataItemByIdMap,
     filterValueDependencies,
   });
 

--- a/packages/twenty-front/src/modules/views/utils/getQueryVariablesFromFiltersAndSorts.ts
+++ b/packages/twenty-front/src/modules/views/utils/getQueryVariablesFromFiltersAndSorts.ts
@@ -1,4 +1,5 @@
 import { type EnrichedObjectMetadataItem } from '@/object-metadata/types/EnrichedObjectMetadataItem';
+import { type FieldMetadataItem } from '@/object-metadata/types/FieldMetadataItem';
 import { turnSortsIntoOrderBy } from '@/object-record/object-sort-dropdown/utils/turnSortsIntoOrderBy';
 import { type RecordFilterGroup } from '@/object-record/record-filter-group/types/RecordFilterGroup';
 import { type RecordFilter } from '@/object-record/record-filter/types/RecordFilter';
@@ -6,7 +7,7 @@ import { type RecordSort } from '@/object-record/record-sort/types/RecordSort';
 import { type RecordFilterValueDependencies } from 'twenty-shared/types';
 import {
   computeRecordGqlOperationFilter,
-  type FindFieldMetadataItemById,
+  hydrateRecordFilters,
 } from 'twenty-shared/utils';
 
 export const getQueryVariablesFromFiltersAndSorts = ({
@@ -15,7 +16,7 @@ export const getQueryVariablesFromFiltersAndSorts = ({
   recordSorts,
   objectMetadataItem,
   objectMetadataItems = [],
-  findFieldMetadataItemById,
+  fieldMetadataItemByIdMap,
   filterValueDependencies,
 }: {
   recordFilterGroups: RecordFilterGroup[];
@@ -23,14 +24,15 @@ export const getQueryVariablesFromFiltersAndSorts = ({
   recordSorts: RecordSort[];
   objectMetadataItem: EnrichedObjectMetadataItem;
   objectMetadataItems?: EnrichedObjectMetadataItem[];
-  findFieldMetadataItemById: FindFieldMetadataItemById;
+  fieldMetadataItemByIdMap: ReadonlyMap<string, FieldMetadataItem>;
   filterValueDependencies: RecordFilterValueDependencies;
 }) => {
   const filter = computeRecordGqlOperationFilter({
-    findFieldMetadataItemById,
     filterValueDependencies,
     recordFilterGroups,
-    recordFilters,
+    recordFilters: hydrateRecordFilters(recordFilters, (id) =>
+      fieldMetadataItemByIdMap.get(id),
+    ),
   });
 
   const orderBy = turnSortsIntoOrderBy(

--- a/packages/twenty-server/src/engine/api/common/common-query-runners/common-group-by-query-runner.service.ts
+++ b/packages/twenty-server/src/engine/api/common/common-query-runners/common-group-by-query-runner.service.ts
@@ -11,6 +11,7 @@ import {
   computeRecordGqlOperationFilter,
   convertViewFilterValueToString,
   getFilterTypeFromFieldType,
+  hydrateRecordFilters,
   isDefined,
   turnAnyFieldFilterIntoRecordGqlFilter,
 } from 'twenty-shared/utils';
@@ -257,13 +258,13 @@ export class CommonGroupByQueryRunnerService extends CommonBaseQueryRunnerServic
     }));
 
     const filtersFromView = computeRecordGqlOperationFilter({
-      recordFilters,
-      recordFilterGroups: recordFilterGroups,
-      findFieldMetadataItemById: (id) =>
+      recordFilters: hydrateRecordFilters(recordFilters, (id) =>
         findFlatEntityByIdInFlatEntityMaps({
           flatEntityId: id,
           flatEntityMaps: flatFieldMetadataMaps,
         }),
+      ),
+      recordFilterGroups: recordFilterGroups,
       filterValueDependencies: {
         timeZone: 'UTC', // TODO: see if we use workspace member timezone here
       },

--- a/packages/twenty-server/src/engine/metadata-modules/view/services/view-query-params.service.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/view/services/view-query-params.service.ts
@@ -10,6 +10,7 @@ import {
 } from 'twenty-shared/types';
 import {
   computeRecordGqlOperationFilter,
+  hydrateRecordFilters,
   isDefined,
   type RecordFilter,
   type RecordFilterGroup,
@@ -108,12 +109,12 @@ export class ViewQueryParamsService {
     }));
 
     const filter = computeRecordGqlOperationFilter({
-      findFieldMetadataItemById: (id) =>
+      recordFilters: hydrateRecordFilters(recordFilters, (id) =>
         findFlatEntityByIdInFlatEntityMaps({
           flatEntityId: id,
           flatEntityMaps: flatFieldMetadataMaps,
         }),
-      recordFilters,
+      ),
       recordFilterGroups,
       filterValueDependencies: { currentWorkspaceMemberId, timeZone },
     });

--- a/packages/twenty-server/src/engine/twenty-orm/utils/build-row-level-permission-record-filter.util.ts
+++ b/packages/twenty-server/src/engine/twenty-orm/utils/build-row-level-permission-record-filter.util.ts
@@ -12,6 +12,7 @@ import {
   computeRecordGqlOperationFilter,
   convertViewFilterValueToString,
   getFilterTypeFromFieldType,
+  hydrateRecordFilters,
   isDefined,
   type RecordFilter,
   type RecordFilterGroup,
@@ -216,13 +217,13 @@ export const buildRowLevelPermissionRecordFilter = ({
     }));
 
   return computeRecordGqlOperationFilter({
-    recordFilters,
-    recordFilterGroups,
-    findFieldMetadataItemById: (id) =>
+    recordFilters: hydrateRecordFilters(recordFilters, (id) =>
       findFlatEntityByIdInFlatEntityMaps({
         flatEntityId: id,
         flatEntityMaps: flatFieldMetadataMaps,
       }),
+    ),
+    recordFilterGroups,
     filterValueDependencies: {
       currentWorkspaceMemberId: workspaceMember?.id,
     },

--- a/packages/twenty-server/src/modules/dashboard/chart-data/utils/convert-chart-filter-to-gql-operation-filter.util.ts
+++ b/packages/twenty-server/src/modules/dashboard/chart-data/utils/convert-chart-filter-to-gql-operation-filter.util.ts
@@ -7,6 +7,7 @@ import {
 } from 'twenty-shared/types';
 import {
   computeRecordGqlOperationFilter,
+  hydrateRecordFilters,
   isDefined,
   type RecordFilter,
   type RecordFilterGroup,
@@ -74,12 +75,14 @@ export const convertChartFilterToGqlOperationFilter = ({
     }));
 
   return computeRecordGqlOperationFilter({
-    findFieldMetadataItemById: (id) =>
-      findFlatEntityByIdInFlatEntityMaps({
-        flatEntityId: id,
-        flatEntityMaps: flatFieldMetadataMaps,
-      }),
-    recordFilters: convertedRecordFilters,
+    recordFilters: hydrateRecordFilters(
+      convertedRecordFilters as RecordFilter[],
+      (id) =>
+        findFlatEntityByIdInFlatEntityMaps({
+          flatEntityId: id,
+          flatEntityMaps: flatFieldMetadataMaps,
+        }),
+    ),
     recordFilterGroups: convertedRecordFilterGroups,
     filterValueDependencies: {
       timeZone: userTimezone,

--- a/packages/twenty-server/src/modules/workflow/workflow-executor/workflow-actions/record-crud/find-records.workflow-action.ts
+++ b/packages/twenty-server/src/modules/workflow/workflow-executor/workflow-actions/record-crud/find-records.workflow-action.ts
@@ -2,6 +2,7 @@ import { Injectable } from '@nestjs/common';
 
 import {
   computeRecordGqlOperationFilter,
+  hydrateRecordFilters,
   isRecordFilterValueValid,
   resolveInput,
 } from 'twenty-shared/utils';
@@ -79,12 +80,14 @@ export class FindRecordsWorkflowAction implements WorkflowAction {
       workflowActionInput.filter?.recordFilters &&
       workflowActionInput.filter?.recordFilterGroups
         ? computeRecordGqlOperationFilter({
-            findFieldMetadataItemById: (id) =>
-              findFlatEntityByIdInFlatEntityMaps({
-                flatEntityId: id,
-                flatEntityMaps: flatFieldMetadataMaps,
-              }),
-            recordFilters: workflowActionInput.filter.recordFilters,
+            recordFilters: hydrateRecordFilters(
+              workflowActionInput.filter.recordFilters,
+              (id) =>
+                findFlatEntityByIdInFlatEntityMaps({
+                  flatEntityId: id,
+                  flatEntityMaps: flatFieldMetadataMaps,
+                }),
+            ),
             recordFilterGroups: workflowActionInput.filter.recordFilterGroups,
             filterValueDependencies: {
               timeZone: 'UTC',

--- a/packages/twenty-shared/src/utils/filter/HydratedRecordFilter.ts
+++ b/packages/twenty-shared/src/utils/filter/HydratedRecordFilter.ts
@@ -1,0 +1,27 @@
+import {
+  type CompositeFieldSubFieldName,
+  type FilterableAndTSVectorFieldType,
+  type PartialFieldMetadataItem,
+  type ViewFilterOperand,
+} from '@/types';
+
+// Minimal field shape the GraphQL dispatcher needs. Defined as a Pick so any
+// field-like object (FieldMetadataItem on the frontend, FlatFieldMetadata on
+// the server) satisfies it structurally without callers having to remap.
+export type HydratedFilterField = Pick<
+  PartialFieldMetadataItem,
+  'id' | 'name' | 'type' | 'label'
+>;
+
+// Resolved counterpart of RecordFilter: `field` and `targetField` carry the
+// looked-up field metadata so the dispatcher can do pure data transformation.
+export type HydratedRecordFilter = {
+  id?: string;
+  field: HydratedFilterField;
+  targetField?: HydratedFilterField;
+  value: string;
+  type: FilterableAndTSVectorFieldType;
+  recordFilterGroupId?: string | null;
+  operand: ViewFilterOperand;
+  subFieldName?: CompositeFieldSubFieldName | null | undefined;
+};

--- a/packages/twenty-shared/src/utils/filter/__tests__/computeRecordGqlOperationFilter.test.ts
+++ b/packages/twenty-shared/src/utils/filter/__tests__/computeRecordGqlOperationFilter.test.ts
@@ -1,5 +1,5 @@
 import { computeRecordGqlOperationFilter } from '../computeRecordGqlOperationFilter';
-import type { RecordFilter } from '../turnRecordFilterGroupIntoGqlOperationFilter';
+import { type HydratedRecordFilter } from '../HydratedRecordFilter';
 
 import { FieldMetadataType } from '@/types/FieldMetadataType';
 import type { PartialFieldMetadataItem } from '@/types/PartialFieldMetadataItem';
@@ -16,10 +16,10 @@ describe('computeRecordGqlOperationFilter', () => {
 
     const uuidValue = '4f83d5c0-7c7a-4f67-9f29-0a6aad1f4eb1';
 
-    const recordFilters: RecordFilter[] = [
+    const recordFilters: HydratedRecordFilter[] = [
       {
         id: 'uuid-filter',
-        fieldMetadataId: companyIdField.id,
+        field: companyIdField,
         value: uuidValue,
         type: 'UUID',
         operand: ViewFilterOperand.IS,
@@ -27,8 +27,6 @@ describe('computeRecordGqlOperationFilter', () => {
     ];
 
     const filter = computeRecordGqlOperationFilter({
-      findFieldMetadataItemById: (id) =>
-        id === companyIdField.id ? companyIdField : undefined,
       recordFilters,
       recordFilterGroups: [],
       filterValueDependencies: {

--- a/packages/twenty-shared/src/utils/filter/__tests__/turnRecordFilterGroupIntoGqlOperationFilter.test.ts
+++ b/packages/twenty-shared/src/utils/filter/__tests__/turnRecordFilterGroupIntoGqlOperationFilter.test.ts
@@ -3,32 +3,31 @@ import {
   RecordFilterGroupLogicalOperator,
   ViewFilterOperand,
 } from '@/types';
+import { type HydratedRecordFilter } from '@/utils/filter/HydratedRecordFilter';
 import { turnRecordFilterGroupsIntoGqlOperationFilter } from '@/utils/filter/turnRecordFilterGroupIntoGqlOperationFilter';
 
 describe('turnRecordFilterGroupsIntoGqlOperationFilter', () => {
-  const fields = [
-    {
-      id: 'f1',
-      name: 'name',
-      type: FieldMetadataType.TEXT,
-      label: 'Name',
-    },
-    {
-      id: 'f2',
-      name: 'age',
-      type: FieldMetadataType.NUMBER,
-      label: 'Age',
-    },
-  ];
+  const nameField = {
+    id: 'f1',
+    name: 'name',
+    type: FieldMetadataType.TEXT,
+    label: 'Name',
+  };
 
-  const fieldById = new Map(fields.map((field) => [field.id, field]));
-  const findFieldMetadataItemById = (id: string) => fieldById.get(id);
+  const filterInGroup = (
+    recordFilterGroupId: string,
+  ): HydratedRecordFilter => ({
+    field: nameField,
+    value: 'test',
+    type: 'TEXT',
+    operand: ViewFilterOperand.CONTAINS,
+    recordFilterGroupId,
+  });
 
   it('should return undefined when group is not found', () => {
     const result = turnRecordFilterGroupsIntoGqlOperationFilter({
       filterValueDependencies: {},
       filters: [],
-      findFieldMetadataItemById,
       recordFilterGroups: [],
       currentRecordFilterGroupId: 'nonexistent',
     });
@@ -39,16 +38,7 @@ describe('turnRecordFilterGroupsIntoGqlOperationFilter', () => {
   it('should return AND filter for AND logical operator', () => {
     const result = turnRecordFilterGroupsIntoGqlOperationFilter({
       filterValueDependencies: {},
-      filters: [
-        {
-          fieldMetadataId: 'f1',
-          value: 'test',
-          type: 'TEXT',
-          operand: ViewFilterOperand.CONTAINS,
-          recordFilterGroupId: 'group1',
-        },
-      ],
-      findFieldMetadataItemById,
+      filters: [filterInGroup('group1')],
       recordFilterGroups: [
         {
           id: 'group1',
@@ -64,16 +54,7 @@ describe('turnRecordFilterGroupsIntoGqlOperationFilter', () => {
   it('should return OR filter for OR logical operator', () => {
     const result = turnRecordFilterGroupsIntoGqlOperationFilter({
       filterValueDependencies: {},
-      filters: [
-        {
-          fieldMetadataId: 'f1',
-          value: 'test',
-          type: 'TEXT',
-          operand: ViewFilterOperand.CONTAINS,
-          recordFilterGroupId: 'group1',
-        },
-      ],
-      findFieldMetadataItemById,
+      filters: [filterInGroup('group1')],
       recordFilterGroups: [
         {
           id: 'group1',
@@ -89,16 +70,7 @@ describe('turnRecordFilterGroupsIntoGqlOperationFilter', () => {
   it('should handle nested groups', () => {
     const result = turnRecordFilterGroupsIntoGqlOperationFilter({
       filterValueDependencies: {},
-      filters: [
-        {
-          fieldMetadataId: 'f1',
-          value: 'test',
-          type: 'TEXT',
-          operand: ViewFilterOperand.CONTAINS,
-          recordFilterGroupId: 'subgroup1',
-        },
-      ],
-      findFieldMetadataItemById,
+      filters: [filterInGroup('subgroup1')],
       recordFilterGroups: [
         {
           id: 'group1',
@@ -114,7 +86,7 @@ describe('turnRecordFilterGroupsIntoGqlOperationFilter', () => {
     });
 
     expect(result).toHaveProperty('and');
-    const andFilters = (result as any).and;
+    const andFilters = (result as { and: unknown[] }).and;
 
     expect(andFilters.length).toBeGreaterThan(0);
   });

--- a/packages/twenty-shared/src/utils/filter/__tests__/turnRecordFilterIntoGqlOperationFilter.test.ts
+++ b/packages/twenty-shared/src/utils/filter/__tests__/turnRecordFilterIntoGqlOperationFilter.test.ts
@@ -2,7 +2,7 @@ import {
   FieldMetadataType,
   ViewFilterOperand as RecordFilterOperand,
 } from '@/types';
-import { type RecordFilter } from '@/utils';
+import { type HydratedRecordFilter } from '@/utils/filter/HydratedRecordFilter';
 import { turnRecordFilterIntoRecordGqlOperationFilter } from '@/utils/filter/turnRecordFilterIntoGqlOperationFilter';
 
 const fields = [
@@ -132,44 +132,33 @@ const fields = [
 const filterValueDependencies = { timeZone: 'UTC' };
 
 const fieldById = new Map(fields.map((field) => [field.id, field]));
-const findFieldMetadataItemById = (id: string) => fieldById.get(id);
 
 const makeFilter = (
-  fieldMetadataId: string,
+  fieldId: string,
   operand: RecordFilterOperand,
   value: string,
   type: string = 'TEXT',
   subFieldName?: string,
-) =>
-  ({
+): HydratedRecordFilter => {
+  const field = fieldById.get(fieldId);
+
+  if (!field) throw new Error(`Field ${fieldId} missing from test fixtures`);
+
+  return {
     id: 'test-filter',
-    fieldMetadataId,
+    field,
     value,
-    type: type as any,
+    type: type as HydratedRecordFilter['type'],
     operand,
-    subFieldName,
-  }) as RecordFilter;
+    subFieldName: subFieldName as HydratedRecordFilter['subFieldName'],
+  };
+};
 
 describe('turnRecordFilterIntoRecordGqlOperationFilter', () => {
-  it('should return undefined when field metadata is not found', () => {
-    const result = turnRecordFilterIntoRecordGqlOperationFilter({
-      filterValueDependencies,
-      recordFilter: makeFilter(
-        'nonexistent',
-        RecordFilterOperand.CONTAINS,
-        'x',
-      ),
-      findFieldMetadataItemById,
-    });
-
-    expect(result).toBeUndefined();
-  });
-
   it('should return undefined when value is empty for non-emptiness operand', () => {
     const result = turnRecordFilterIntoRecordGqlOperationFilter({
       filterValueDependencies,
       recordFilter: makeFilter('f-text', RecordFilterOperand.CONTAINS, ''),
-      findFieldMetadataItemById,
     });
 
     expect(result).toBeUndefined();
@@ -184,7 +173,6 @@ describe('turnRecordFilterIntoRecordGqlOperationFilter', () => {
           RecordFilterOperand.CONTAINS,
           'test',
         ),
-        findFieldMetadataItemById,
       });
 
       expect(result).toEqual({ name: { ilike: '%test%' } });
@@ -198,7 +186,6 @@ describe('turnRecordFilterIntoRecordGqlOperationFilter', () => {
           RecordFilterOperand.DOES_NOT_CONTAIN,
           'test',
         ),
-        findFieldMetadataItemById,
       });
 
       expect(result).toEqual({ not: { name: { ilike: '%test%' } } });
@@ -210,7 +197,6 @@ describe('turnRecordFilterIntoRecordGqlOperationFilter', () => {
       const result = turnRecordFilterIntoRecordGqlOperationFilter({
         filterValueDependencies,
         recordFilter: makeFilter('f-number', RecordFilterOperand.IS, '42'),
-        findFieldMetadataItemById,
       });
 
       expect(result).toEqual({ amount: { eq: 42 } });
@@ -220,7 +206,6 @@ describe('turnRecordFilterIntoRecordGqlOperationFilter', () => {
       const result = turnRecordFilterIntoRecordGqlOperationFilter({
         filterValueDependencies,
         recordFilter: makeFilter('f-number', RecordFilterOperand.IS_NOT, '42'),
-        findFieldMetadataItemById,
       });
 
       expect(result).toEqual({ not: { amount: { eq: 42 } } });
@@ -234,7 +219,6 @@ describe('turnRecordFilterIntoRecordGqlOperationFilter', () => {
           RecordFilterOperand.GREATER_THAN_OR_EQUAL,
           '10',
         ),
-        findFieldMetadataItemById,
       });
 
       expect(result).toEqual({ amount: { gte: 10 } });
@@ -248,7 +232,6 @@ describe('turnRecordFilterIntoRecordGqlOperationFilter', () => {
           RecordFilterOperand.LESS_THAN_OR_EQUAL,
           '100',
         ),
-        findFieldMetadataItemById,
       });
 
       expect(result).toEqual({ amount: { lte: 100 } });
@@ -264,7 +247,6 @@ describe('turnRecordFilterIntoRecordGqlOperationFilter', () => {
           RecordFilterOperand.IS_AFTER,
           '2024-03-15',
         ),
-        findFieldMetadataItemById,
       });
 
       expect(result).toEqual({ createdAt: { gte: '2024-03-15' } });
@@ -278,7 +260,6 @@ describe('turnRecordFilterIntoRecordGqlOperationFilter', () => {
           RecordFilterOperand.IS_BEFORE,
           '2024-03-15',
         ),
-        findFieldMetadataItemById,
       });
 
       expect(result).toEqual({ createdAt: { lt: '2024-03-15' } });
@@ -292,7 +273,6 @@ describe('turnRecordFilterIntoRecordGqlOperationFilter', () => {
           RecordFilterOperand.IS,
           '2024-03-15',
         ),
-        findFieldMetadataItemById,
       });
 
       expect(result).toEqual({ createdAt: { eq: '2024-03-15' } });
@@ -302,7 +282,6 @@ describe('turnRecordFilterIntoRecordGqlOperationFilter', () => {
       const result = turnRecordFilterIntoRecordGqlOperationFilter({
         filterValueDependencies,
         recordFilter: makeFilter('f-date', RecordFilterOperand.IS_IN_PAST, ''),
-        findFieldMetadataItemById,
       });
 
       expect(result).toHaveProperty('createdAt.lt');
@@ -316,7 +295,6 @@ describe('turnRecordFilterIntoRecordGqlOperationFilter', () => {
           RecordFilterOperand.IS_IN_FUTURE,
           '',
         ),
-        findFieldMetadataItemById,
       });
 
       expect(result).toHaveProperty('createdAt.gte');
@@ -326,7 +304,6 @@ describe('turnRecordFilterIntoRecordGqlOperationFilter', () => {
       const result = turnRecordFilterIntoRecordGqlOperationFilter({
         filterValueDependencies,
         recordFilter: makeFilter('f-date', RecordFilterOperand.IS_TODAY, ''),
-        findFieldMetadataItemById,
       });
 
       expect(result).toHaveProperty('createdAt.eq');
@@ -340,7 +317,6 @@ describe('turnRecordFilterIntoRecordGqlOperationFilter', () => {
           RecordFilterOperand.IS_RELATIVE,
           'PAST_7_DAY',
         ),
-        findFieldMetadataItemById,
       });
 
       expect(result).toHaveProperty('and');
@@ -356,7 +332,6 @@ describe('turnRecordFilterIntoRecordGqlOperationFilter', () => {
           RecordFilterOperand.IS_AFTER,
           '2024-03-15T10:00:00Z',
         ),
-        findFieldMetadataItemById,
       });
 
       expect(result).toHaveProperty('updatedAt.gte');
@@ -370,7 +345,6 @@ describe('turnRecordFilterIntoRecordGqlOperationFilter', () => {
           RecordFilterOperand.IS_BEFORE,
           '2024-03-15T10:00:00Z',
         ),
-        findFieldMetadataItemById,
       });
 
       expect(result).toHaveProperty('updatedAt.lt');
@@ -384,7 +358,6 @@ describe('turnRecordFilterIntoRecordGqlOperationFilter', () => {
           RecordFilterOperand.IS,
           '2024-03-15T10:00:00Z',
         ),
-        findFieldMetadataItemById,
       });
 
       expect(result).toHaveProperty('and');
@@ -398,7 +371,6 @@ describe('turnRecordFilterIntoRecordGqlOperationFilter', () => {
           RecordFilterOperand.IS_IN_PAST,
           '',
         ),
-        findFieldMetadataItemById,
       });
 
       expect(result).toHaveProperty('updatedAt.lt');
@@ -412,7 +384,6 @@ describe('turnRecordFilterIntoRecordGqlOperationFilter', () => {
           RecordFilterOperand.IS_IN_FUTURE,
           '',
         ),
-        findFieldMetadataItemById,
       });
 
       expect(result).toHaveProperty('updatedAt.gt');
@@ -426,7 +397,6 @@ describe('turnRecordFilterIntoRecordGqlOperationFilter', () => {
           RecordFilterOperand.IS_TODAY,
           '',
         ),
-        findFieldMetadataItemById,
       });
 
       expect(result).toHaveProperty('and');
@@ -440,7 +410,6 @@ describe('turnRecordFilterIntoRecordGqlOperationFilter', () => {
           RecordFilterOperand.IS_RELATIVE,
           `PAST_7_DAY;;UTC;;`,
         ),
-        findFieldMetadataItemById,
       });
 
       expect(result).toHaveProperty('and');
@@ -452,7 +421,6 @@ describe('turnRecordFilterIntoRecordGqlOperationFilter', () => {
       const result = turnRecordFilterIntoRecordGqlOperationFilter({
         filterValueDependencies,
         recordFilter: makeFilter('f-rating', RecordFilterOperand.IS, '3'),
-        findFieldMetadataItemById,
       });
 
       expect(result).toHaveProperty('rating.eq');
@@ -466,7 +434,6 @@ describe('turnRecordFilterIntoRecordGqlOperationFilter', () => {
           RecordFilterOperand.GREATER_THAN_OR_EQUAL,
           '3',
         ),
-        findFieldMetadataItemById,
       });
 
       expect(result).toHaveProperty('rating.in');
@@ -480,7 +447,6 @@ describe('turnRecordFilterIntoRecordGqlOperationFilter', () => {
           RecordFilterOperand.LESS_THAN_OR_EQUAL,
           '3',
         ),
-        findFieldMetadataItemById,
       });
 
       expect(result).toHaveProperty('rating.in');
@@ -492,7 +458,6 @@ describe('turnRecordFilterIntoRecordGqlOperationFilter', () => {
       const result = turnRecordFilterIntoRecordGqlOperationFilter({
         filterValueDependencies,
         recordFilter: makeFilter('f-bool', RecordFilterOperand.IS, 'true'),
-        findFieldMetadataItemById,
       });
 
       expect(result).toEqual({ isActive: { eq: true } });
@@ -502,7 +467,6 @@ describe('turnRecordFilterIntoRecordGqlOperationFilter', () => {
       const result = turnRecordFilterIntoRecordGqlOperationFilter({
         filterValueDependencies,
         recordFilter: makeFilter('f-bool', RecordFilterOperand.IS, 'false'),
-        findFieldMetadataItemById,
       });
 
       expect(result).toEqual({ isActive: { eq: false } });
@@ -518,7 +482,6 @@ describe('turnRecordFilterIntoRecordGqlOperationFilter', () => {
           RecordFilterOperand.IS,
           '["ACTIVE","PENDING"]',
         ),
-        findFieldMetadataItemById,
       });
 
       expect(result).toHaveProperty('status.in');
@@ -532,7 +495,6 @@ describe('turnRecordFilterIntoRecordGqlOperationFilter', () => {
           RecordFilterOperand.IS_NOT,
           '["ACTIVE"]',
         ),
-        findFieldMetadataItemById,
       });
 
       expect(result).toHaveProperty('not');
@@ -548,7 +510,6 @@ describe('turnRecordFilterIntoRecordGqlOperationFilter', () => {
           RecordFilterOperand.CONTAINS,
           '["TAG1","TAG2"]',
         ),
-        findFieldMetadataItemById,
       });
 
       expect(result).toHaveProperty('tags.containsAny');
@@ -562,7 +523,6 @@ describe('turnRecordFilterIntoRecordGqlOperationFilter', () => {
           RecordFilterOperand.DOES_NOT_CONTAIN,
           '["TAG1"]',
         ),
-        findFieldMetadataItemById,
       });
 
       expect(result).toHaveProperty('or');
@@ -578,7 +538,6 @@ describe('turnRecordFilterIntoRecordGqlOperationFilter', () => {
           RecordFilterOperand.IS,
           '["550e8400-e29b-41d4-a716-446655440000"]',
         ),
-        findFieldMetadataItemById,
       });
 
       expect(result).toHaveProperty('companyId.in');
@@ -592,7 +551,6 @@ describe('turnRecordFilterIntoRecordGqlOperationFilter', () => {
           RecordFilterOperand.IS_NOT,
           '["550e8400-e29b-41d4-a716-446655440000"]',
         ),
-        findFieldMetadataItemById,
       });
 
       expect(result).toHaveProperty('or');
@@ -608,7 +566,6 @@ describe('turnRecordFilterIntoRecordGqlOperationFilter', () => {
           RecordFilterOperand.CONTAINS,
           'test',
         ),
-        findFieldMetadataItemById,
       });
 
       expect(result).toEqual({ metadata: { like: '%test%' } });
@@ -622,7 +579,6 @@ describe('turnRecordFilterIntoRecordGqlOperationFilter', () => {
           RecordFilterOperand.DOES_NOT_CONTAIN,
           'test',
         ),
-        findFieldMetadataItemById,
       });
 
       expect(result).toEqual({ not: { metadata: { like: '%test%' } } });
@@ -638,7 +594,6 @@ describe('turnRecordFilterIntoRecordGqlOperationFilter', () => {
           RecordFilterOperand.CONTAINS,
           'doc',
         ),
-        findFieldMetadataItemById,
       });
 
       expect(result).toEqual({ attachments: { like: '%doc%' } });
@@ -654,7 +609,6 @@ describe('turnRecordFilterIntoRecordGqlOperationFilter', () => {
           RecordFilterOperand.VECTOR_SEARCH,
           'hello world',
         ),
-        findFieldMetadataItemById,
       });
 
       expect(result).toEqual({ search: { search: 'hello world' } });
@@ -672,7 +626,6 @@ describe('turnRecordFilterIntoRecordGqlOperationFilter', () => {
           'CURRENCY',
           'amountMicros',
         ),
-        findFieldMetadataItemById,
       });
 
       expect(result).toHaveProperty('revenue');
@@ -688,7 +641,6 @@ describe('turnRecordFilterIntoRecordGqlOperationFilter', () => {
           RecordFilterOperand.CONTAINS,
           'John',
         ),
-        findFieldMetadataItemById,
       });
 
       expect(result).toHaveProperty('or');
@@ -704,7 +656,6 @@ describe('turnRecordFilterIntoRecordGqlOperationFilter', () => {
           RecordFilterOperand.CONTAINS,
           'Paris',
         ),
-        findFieldMetadataItemById,
       });
 
       expect(result).toHaveProperty('or');
@@ -720,7 +671,6 @@ describe('turnRecordFilterIntoRecordGqlOperationFilter', () => {
           RecordFilterOperand.CONTAINS,
           'api',
         ),
-        findFieldMetadataItemById,
       });
 
       expect(result).toEqual({
@@ -747,7 +697,6 @@ describe('turnRecordFilterIntoRecordGqlOperationFilter', () => {
           RecordFilterOperand.CONTAINS,
           'xyz123',
         ),
-        findFieldMetadataItemById,
       });
 
       expect(result).toEqual({
@@ -772,7 +721,6 @@ describe('turnRecordFilterIntoRecordGqlOperationFilter', () => {
           RecordFilterOperand.DOES_NOT_CONTAIN,
           'api',
         ),
-        findFieldMetadataItemById,
       });
 
       expect(result).toEqual({
@@ -803,7 +751,6 @@ describe('turnRecordFilterIntoRecordGqlOperationFilter', () => {
           RecordFilterOperand.DOES_NOT_CONTAIN,
           'xyz123',
         ),
-        findFieldMetadataItemById,
       });
 
       expect(result).toEqual({
@@ -834,7 +781,6 @@ describe('turnRecordFilterIntoRecordGqlOperationFilter', () => {
           'PHONES',
           'primaryPhoneNumber',
         ),
-        findFieldMetadataItemById,
       });
 
       expect(result).toBeDefined();
@@ -852,7 +798,6 @@ describe('turnRecordFilterIntoRecordGqlOperationFilter', () => {
           'EMAILS',
           'primaryEmail',
         ),
-        findFieldMetadataItemById,
       });
 
       expect(result).toBeDefined();
@@ -870,7 +815,6 @@ describe('turnRecordFilterIntoRecordGqlOperationFilter', () => {
           'LINKS',
           'primaryLinkUrl',
         ),
-        findFieldMetadataItemById,
       });
 
       expect(result).toBeDefined();
@@ -886,7 +830,6 @@ describe('turnRecordFilterIntoRecordGqlOperationFilter', () => {
           RecordFilterOperand.CONTAINS,
           '["item1"]',
         ),
-        findFieldMetadataItemById,
       });
 
       expect(result).toBeDefined();
@@ -900,7 +843,6 @@ describe('turnRecordFilterIntoRecordGqlOperationFilter', () => {
           RecordFilterOperand.DOES_NOT_CONTAIN,
           '["item1"]',
         ),
-        findFieldMetadataItemById,
       });
 
       expect(result).toHaveProperty('not');
@@ -916,7 +858,6 @@ describe('turnRecordFilterIntoRecordGqlOperationFilter', () => {
           RecordFilterOperand.IS,
           '["550e8400-e29b-41d4-a716-446655440000"]',
         ),
-        findFieldMetadataItemById,
       });
 
       expect(result).toHaveProperty('recordId.in');
@@ -924,37 +865,31 @@ describe('turnRecordFilterIntoRecordGqlOperationFilter', () => {
   });
 
   describe('relation traversal', () => {
+    const withTarget = (
+      filter: HydratedRecordFilter,
+      targetFieldId: string,
+    ): HydratedRecordFilter => {
+      const targetField = fieldById.get(targetFieldId);
+
+      if (!targetField)
+        throw new Error(`Field ${targetFieldId} missing from test fixtures`);
+
+      return { ...filter, targetField };
+    };
+
     // The dispatcher should wrap the inner filter under the relation source
     // field's GraphQL key and build it against the target field's type
     // (not the relation FK's type).
     it('should nest filter under source field name when target field is set', () => {
       const result = turnRecordFilterIntoRecordGqlOperationFilter({
         filterValueDependencies,
-        recordFilter: {
-          ...makeFilter('f-relation', RecordFilterOperand.CONTAINS, 'Acme'),
-          relationTargetFieldMetadataId: 'f-text',
-        } as RecordFilter,
-        findFieldMetadataItemById,
+        recordFilter: withTarget(
+          makeFilter('f-relation', RecordFilterOperand.CONTAINS, 'Acme'),
+          'f-text',
+        ),
       });
 
       expect(result).toEqual({ company: { name: { ilike: '%Acme%' } } });
-    });
-
-    // If the target field is no longer resolvable (e.g. it was
-    // deleted from the workspace), dropping the filter is the safe path —
-    // the alternative would silently interpret the text value as a UUID
-    // list against the relation FK.
-    it('should return undefined when target field is not found', () => {
-      const result = turnRecordFilterIntoRecordGqlOperationFilter({
-        filterValueDependencies,
-        recordFilter: {
-          ...makeFilter('f-relation', RecordFilterOperand.CONTAINS, 'Acme'),
-          relationTargetFieldMetadataId: 'nonexistent-target',
-        } as RecordFilter,
-        findFieldMetadataItemById,
-      });
-
-      expect(result).toBeUndefined();
     });
 
     // Emptiness operands must check the target column on the related
@@ -962,11 +897,10 @@ describe('turnRecordFilterIntoRecordGqlOperationFilter', () => {
     it('should apply IS_EMPTY against the target field, not the relation FK', () => {
       const result = turnRecordFilterIntoRecordGqlOperationFilter({
         filterValueDependencies,
-        recordFilter: {
-          ...makeFilter('f-relation', RecordFilterOperand.IS_EMPTY, ''),
-          relationTargetFieldMetadataId: 'f-text',
-        } as RecordFilter,
-        findFieldMetadataItemById,
+        recordFilter: withTarget(
+          makeFilter('f-relation', RecordFilterOperand.IS_EMPTY, ''),
+          'f-text',
+        ),
       });
 
       // Without traversal, the RELATION case would have produced a filter
@@ -983,19 +917,18 @@ describe('turnRecordFilterIntoRecordGqlOperationFilter', () => {
     it('should dispatch to target type switch (SELECT target)', () => {
       const result = turnRecordFilterIntoRecordGqlOperationFilter({
         filterValueDependencies,
-        recordFilter: {
-          ...makeFilter('f-relation', RecordFilterOperand.IS, '["ACTIVE"]'),
-          relationTargetFieldMetadataId: 'f-select',
-        } as RecordFilter,
-        findFieldMetadataItemById,
+        recordFilter: withTarget(
+          makeFilter('f-relation', RecordFilterOperand.IS, '["ACTIVE"]'),
+          'f-select',
+        ),
       });
 
       expect(result).toEqual({ company: { status: { in: ['ACTIVE'] } } });
     });
 
-    // Without a relationTargetFieldMetadataId the dispatcher must fall
-    // through to the direct builder — preserving the filter-by-record-id
-    // behaviour on the relation FK.
+    // Without a target field the dispatcher must fall through to the
+    // direct builder — preserving the filter-by-record-id behaviour on the
+    // relation FK.
     it('should keep relation filter-by-id behaviour when no target field is set', () => {
       const result = turnRecordFilterIntoRecordGqlOperationFilter({
         filterValueDependencies,
@@ -1004,7 +937,6 @@ describe('turnRecordFilterIntoRecordGqlOperationFilter', () => {
           RecordFilterOperand.IS,
           '["550e8400-e29b-41d4-a716-446655440000"]',
         ),
-        findFieldMetadataItemById,
       });
 
       expect(result).toHaveProperty('companyId.in');

--- a/packages/twenty-shared/src/utils/filter/compute-record-gql-operation-filter/for-composite-field/computeGqlOperationFilterForEmails.ts
+++ b/packages/twenty-shared/src/utils/filter/compute-record-gql-operation-filter/for-composite-field/computeGqlOperationFilterForEmails.ts
@@ -15,7 +15,7 @@ export const computeGqlOperationFilterForEmails = ({
   correspondingFieldMetadataItem,
   subFieldName,
 }: {
-  recordFilter: Omit<RecordFilter, 'id'>;
+  recordFilter: Pick<RecordFilter, 'operand' | 'value' | 'subFieldName'>;
   correspondingFieldMetadataItem: Pick<
     PartialFieldMetadataItem,
     'name' | 'type'

--- a/packages/twenty-shared/src/utils/filter/compute-record-gql-operation-filter/for-composite-field/computeGqlOperationFilterForLinks.ts
+++ b/packages/twenty-shared/src/utils/filter/compute-record-gql-operation-filter/for-composite-field/computeGqlOperationFilterForLinks.ts
@@ -13,7 +13,7 @@ export const computeGqlOperationFilterForLinks = ({
   correspondingFieldMetadataItem,
   subFieldName,
 }: {
-  recordFilter: Omit<RecordFilter, 'id'>;
+  recordFilter: Pick<RecordFilter, 'operand' | 'value' | 'subFieldName'>;
   correspondingFieldMetadataItem: Pick<
     PartialFieldMetadataItem,
     'name' | 'type'

--- a/packages/twenty-shared/src/utils/filter/computeEmptyGqlOperationFilterForEmails.ts
+++ b/packages/twenty-shared/src/utils/filter/computeEmptyGqlOperationFilterForEmails.ts
@@ -12,7 +12,7 @@ export const computeEmptyGqlOperationFilterForEmails = ({
   recordFilter,
   correspondingFieldMetadataItem,
 }: {
-  recordFilter: Omit<RecordFilter, 'id'>;
+  recordFilter: Pick<RecordFilter, 'subFieldName'>;
   correspondingFieldMetadataItem: Pick<
     PartialFieldMetadataItem,
     'name' | 'type'

--- a/packages/twenty-shared/src/utils/filter/computeEmptyGqlOperationFilterForLinks.ts
+++ b/packages/twenty-shared/src/utils/filter/computeEmptyGqlOperationFilterForLinks.ts
@@ -12,7 +12,7 @@ export const computeEmptyGqlOperationFilterForLinks = ({
   recordFilter,
   correspondingFieldMetadataItem,
 }: {
-  recordFilter: Omit<RecordFilter, 'id'>;
+  recordFilter: Pick<RecordFilter, 'subFieldName'>;
   correspondingFieldMetadataItem: Pick<PartialFieldMetadataItem, 'name'>;
 }): RecordGqlOperationFilter => {
   const subFieldName = recordFilter.subFieldName;

--- a/packages/twenty-shared/src/utils/filter/computeRecordGqlOperationFilter.ts
+++ b/packages/twenty-shared/src/utils/filter/computeRecordGqlOperationFilter.ts
@@ -2,38 +2,32 @@ import {
   type RecordFilterValueDependencies,
   type RecordGqlOperationFilter,
 } from '@/types';
+import { type HydratedRecordFilter } from '@/utils/filter/HydratedRecordFilter';
 import {
   turnRecordFilterGroupsIntoGqlOperationFilter,
-  type RecordFilter,
   type RecordFilterGroup,
 } from '@/utils/filter/turnRecordFilterGroupIntoGqlOperationFilter';
-import {
-  type FindFieldMetadataItemById,
-  turnRecordFilterIntoRecordGqlOperationFilter,
-} from '@/utils/filter/turnRecordFilterIntoGqlOperationFilter';
+import { turnRecordFilterIntoRecordGqlOperationFilter } from '@/utils/filter/turnRecordFilterIntoGqlOperationFilter';
 import { isDefined } from '@/utils/validation/isDefined';
 
 export const computeRecordGqlOperationFilter = ({
-  findFieldMetadataItemById,
   recordFilters,
   recordFilterGroups,
   filterValueDependencies,
 }: {
-  recordFilters: Omit<RecordFilter, 'id'>[];
-  findFieldMetadataItemById: FindFieldMetadataItemById;
+  recordFilters: HydratedRecordFilter[];
   recordFilterGroups: RecordFilterGroup[];
   filterValueDependencies: RecordFilterValueDependencies;
 }): RecordGqlOperationFilter => {
   const regularRecordGqlOperationFilter: RecordGqlOperationFilter[] =
     recordFilters
       .filter((filter) => !isDefined(filter.recordFilterGroupId))
-      .map((regularFilter) => {
-        return turnRecordFilterIntoRecordGqlOperationFilter({
+      .map((regularFilter) =>
+        turnRecordFilterIntoRecordGqlOperationFilter({
           recordFilter: regularFilter,
-          findFieldMetadataItemById,
           filterValueDependencies,
-        });
-      })
+        }),
+      )
       .filter(isDefined);
 
   const outermostFilterGroupId = recordFilterGroups.find(
@@ -44,7 +38,6 @@ export const computeRecordGqlOperationFilter = ({
     turnRecordFilterGroupsIntoGqlOperationFilter({
       filterValueDependencies,
       filters: recordFilters,
-      findFieldMetadataItemById,
       recordFilterGroups,
       currentRecordFilterGroupId: outermostFilterGroupId,
     });

--- a/packages/twenty-shared/src/utils/filter/hydrateRecordFilter.ts
+++ b/packages/twenty-shared/src/utils/filter/hydrateRecordFilter.ts
@@ -1,0 +1,37 @@
+import {
+  type HydratedFilterField,
+  type HydratedRecordFilter,
+} from '@/utils/filter/HydratedRecordFilter';
+import { type RecordFilter } from '@/utils/filter/turnRecordFilterGroupIntoGqlOperationFilter';
+import { isDefined } from '@/utils/validation/isDefined';
+
+export type ResolveField = (id: string) => HydratedFilterField | undefined;
+
+export const hydrateRecordFilter = (
+  recordFilter: RecordFilter,
+  resolveField: ResolveField,
+): HydratedRecordFilter | null => {
+  const field = resolveField(recordFilter.fieldMetadataId);
+
+  if (!isDefined(field)) {
+    return null;
+  }
+
+  let targetField: HydratedFilterField | undefined;
+
+  if (isDefined(recordFilter.relationTargetFieldMetadataId)) {
+    targetField = resolveField(recordFilter.relationTargetFieldMetadataId);
+
+    if (!isDefined(targetField)) {
+      return null;
+    }
+  }
+
+  const {
+    fieldMetadataId: _fieldMetadataId,
+    relationTargetFieldMetadataId: _relationTargetFieldMetadataId,
+    ...rest
+  } = recordFilter;
+
+  return { ...rest, field, targetField };
+};

--- a/packages/twenty-shared/src/utils/filter/hydrateRecordFilters.ts
+++ b/packages/twenty-shared/src/utils/filter/hydrateRecordFilters.ts
@@ -1,0 +1,15 @@
+import { type HydratedRecordFilter } from '@/utils/filter/HydratedRecordFilter';
+import {
+  hydrateRecordFilter,
+  type ResolveField,
+} from '@/utils/filter/hydrateRecordFilter';
+import { type RecordFilter } from '@/utils/filter/turnRecordFilterGroupIntoGqlOperationFilter';
+import { isDefined } from '@/utils/validation/isDefined';
+
+export const hydrateRecordFilters = (
+  recordFilters: RecordFilter[],
+  resolveField: ResolveField,
+): HydratedRecordFilter[] =>
+  recordFilters
+    .map((recordFilter) => hydrateRecordFilter(recordFilter, resolveField))
+    .filter(isDefined);

--- a/packages/twenty-shared/src/utils/filter/index.ts
+++ b/packages/twenty-shared/src/utils/filter/index.ts
@@ -5,6 +5,9 @@ export * from './compute-record-gql-operation-filter/for-composite-field/compute
 export * from './computeEmptyGqlOperationFilterForEmails';
 export * from './computeEmptyGqlOperationFilterForLinks';
 export * from './computeRecordGqlOperationFilter';
+export * from './HydratedRecordFilter';
+export * from './hydrateRecordFilter';
+export * from './hydrateRecordFilters';
 export * from './isEmptinessOperand';
 export * from './isRecordFilterOperandExpectingValue';
 export * from './isRecordFilterValueValid';

--- a/packages/twenty-shared/src/utils/filter/turnAnyFieldFilterIntoRecordGqlFilter.ts
+++ b/packages/twenty-shared/src/utils/filter/turnAnyFieldFilterIntoRecordGqlFilter.ts
@@ -224,13 +224,19 @@ export const turnAnyFieldFilterIntoRecordGqlFilter = ({
   const fieldById = new Map(fields.map((field) => [field.id, field]));
 
   const baseRecordGqlOperationFilters = anyFieldRecordFilters
-    .map((recordFilter) =>
-      turnRecordFilterIntoRecordGqlOperationFilter({
+    .map((recordFilter) => {
+      const field = fieldById.get(recordFilter.fieldMetadataId);
+
+      if (!isDefined(field)) return undefined;
+
+      return turnRecordFilterIntoRecordGqlOperationFilter({
         filterValueDependencies: {},
-        findFieldMetadataItemById: (id) => fieldById.get(id),
-        recordFilter,
-      }),
-    )
+        recordFilter: {
+          ...recordFilter,
+          field,
+        },
+      });
+    })
     .filter(isDefined);
 
   const recordGqlOperationFilter: RecordGqlOperationFilter = {

--- a/packages/twenty-shared/src/utils/filter/turnRecordFilterGroupIntoGqlOperationFilter.ts
+++ b/packages/twenty-shared/src/utils/filter/turnRecordFilterGroupIntoGqlOperationFilter.ts
@@ -8,10 +8,8 @@ import {
 } from '@/types';
 
 import { isDefined } from '@/utils';
-import {
-  type FindFieldMetadataItemById,
-  turnRecordFilterIntoRecordGqlOperationFilter,
-} from '@/utils/filter/turnRecordFilterIntoGqlOperationFilter';
+import { type HydratedRecordFilter } from '@/utils/filter/HydratedRecordFilter';
+import { turnRecordFilterIntoRecordGqlOperationFilter } from '@/utils/filter/turnRecordFilterIntoGqlOperationFilter';
 
 export type RecordFilter = {
   id: string;
@@ -33,13 +31,11 @@ export type RecordFilterGroup = {
 export const turnRecordFilterGroupsIntoGqlOperationFilter = ({
   filterValueDependencies,
   filters,
-  findFieldMetadataItemById,
   recordFilterGroups,
   currentRecordFilterGroupId,
 }: {
   filterValueDependencies: RecordFilterValueDependencies;
-  filters: Omit<RecordFilter, 'id'>[];
-  findFieldMetadataItemById: FindFieldMetadataItemById;
+  filters: HydratedRecordFilter[];
   recordFilterGroups: RecordFilterGroup[];
   currentRecordFilterGroupId?: string;
 }): RecordGqlOperationFilter | undefined => {
@@ -59,8 +55,7 @@ export const turnRecordFilterGroupsIntoGqlOperationFilter = ({
     .map((recordFilter) =>
       turnRecordFilterIntoRecordGqlOperationFilter({
         filterValueDependencies,
-        recordFilter: recordFilter,
-        findFieldMetadataItemById,
+        recordFilter,
       }),
     )
     .filter(isDefined);
@@ -75,7 +70,6 @@ export const turnRecordFilterGroupsIntoGqlOperationFilter = ({
       turnRecordFilterGroupsIntoGqlOperationFilter({
         filterValueDependencies,
         filters,
-        findFieldMetadataItemById,
         recordFilterGroups,
         currentRecordFilterGroupId: subRecordFilterGroup.id,
       }),

--- a/packages/twenty-shared/src/utils/filter/turnRecordFilterIntoGqlOperationFilter.ts
+++ b/packages/twenty-shared/src/utils/filter/turnRecordFilterIntoGqlOperationFilter.ts
@@ -38,6 +38,7 @@ import {
 } from '@/utils/filter';
 
 import { type DateTimeFilter } from '@/types/RecordGqlOperationFilter';
+import { type HydratedRecordFilter } from '@/utils/filter/HydratedRecordFilter';
 import {
   checkIfShouldComputeEmptinessFilter,
   CustomError,
@@ -49,65 +50,38 @@ import {
   resolveDateFilter,
   resolveDateTimeFilter,
   resolveRelativeDateFilterStringified,
-  type RecordFilter,
 } from '@/utils';
 import { arrayOfStringsOrVariablesSchema } from '@/utils/filter/utils/validation-schemas/arrayOfStringsOrVariablesSchema';
 import { arrayOfUuidOrVariableSchema } from '@/utils/filter/utils/validation-schemas/arrayOfUuidsOrVariablesSchema';
 import { jsonRelationFilterValueSchema } from '@/utils/filter/utils/validation-schemas/jsonRelationFilterValueSchema';
 
-type FieldShared = {
-  id: string;
-  name: string;
-  type: FieldMetadataType;
-  label: string;
-};
-
-export type FindFieldMetadataItemById = (id: string) => FieldShared | undefined;
-
 type TurnRecordFilterIntoRecordGqlOperationFilterParams = {
   filterValueDependencies: RecordFilterValueDependencies;
-  recordFilter: Omit<RecordFilter, 'id'>;
-  findFieldMetadataItemById: FindFieldMetadataItemById;
+  recordFilter: HydratedRecordFilter;
 };
 
 export const turnRecordFilterIntoRecordGqlOperationFilter = ({
   recordFilter,
-  findFieldMetadataItemById,
   filterValueDependencies,
 }: TurnRecordFilterIntoRecordGqlOperationFilterParams):
   | RecordGqlOperationFilter
   | undefined => {
-  const sourceFieldMetadataItem = findFieldMetadataItemById(
-    recordFilter.fieldMetadataId,
-  );
-
-  if (!isDefined(sourceFieldMetadataItem)) {
-    return;
-  }
-
   if (!isRecordFilterValueValid(recordFilter)) {
     return;
   }
 
+  const sourceFieldMetadataItem = recordFilter.field;
+
   if (
     sourceFieldMetadataItem.type === FieldMetadataType.RELATION &&
-    isDefined(recordFilter.relationTargetFieldMetadataId)
+    isDefined(recordFilter.targetField)
   ) {
-    const targetFieldMetadataItem = findFieldMetadataItemById(
-      recordFilter.relationTargetFieldMetadataId,
-    );
-
-    if (!isDefined(targetFieldMetadataItem)) {
-      return;
-    }
-
     const innerFilter = buildDirectFieldGqlOperationFilter({
       recordFilter: {
         ...recordFilter,
-        fieldMetadataId: targetFieldMetadataItem.id,
-        relationTargetFieldMetadataId: null,
+        field: recordFilter.targetField,
+        targetField: undefined,
       },
-      fieldMetadataItem: targetFieldMetadataItem,
       filterValueDependencies,
     });
 
@@ -122,24 +96,22 @@ export const turnRecordFilterIntoRecordGqlOperationFilter = ({
 
   return buildDirectFieldGqlOperationFilter({
     recordFilter,
-    fieldMetadataItem: sourceFieldMetadataItem,
     filterValueDependencies,
   });
 };
 
 type BuildDirectFieldGqlOperationFilterParams = {
   filterValueDependencies: RecordFilterValueDependencies;
-  recordFilter: Omit<RecordFilter, 'id'>;
-  fieldMetadataItem: FieldShared;
+  recordFilter: HydratedRecordFilter;
 };
 
 const buildDirectFieldGqlOperationFilter = ({
   recordFilter,
-  fieldMetadataItem,
   filterValueDependencies,
 }: BuildDirectFieldGqlOperationFilterParams):
   | RecordGqlOperationFilter
   | undefined => {
+  const fieldMetadataItem = recordFilter.field;
   const shouldComputeEmptinessFilter = checkIfShouldComputeEmptinessFilter({
     recordFilterOperand: recordFilter.operand,
     correspondingFieldMetadataItem: fieldMetadataItem,

--- a/packages/twenty-shared/src/utils/filter/utils/getEmptyRecordGqlOperationFilter.ts
+++ b/packages/twenty-shared/src/utils/filter/utils/getEmptyRecordGqlOperationFilter.ts
@@ -27,7 +27,7 @@ import { isNonEmptyString } from '@sniptt/guards';
 type GetEmptyRecordGqlOperationFilterParams = {
   operand: ViewFilterOperand;
   correspondingField: Pick<PartialFieldMetadataItem, 'id' | 'name' | 'type'>;
-  recordFilter: Omit<RecordFilter, 'id'>;
+  recordFilter: Pick<RecordFilter, 'operand' | 'value' | 'subFieldName'>;
 };
 
 export const getEmptyRecordGqlOperationFilter = ({

--- a/packages/twenty-shared/src/utils/index.ts
+++ b/packages/twenty-shared/src/utils/index.ts
@@ -95,6 +95,13 @@ export { resolveRelativeDateTimeFilterStringified } from './filter/dates/utils/r
 export { subUnitFromDateTime } from './filter/dates/utils/subUnitFromDateTime';
 export { subUnitFromZonedDateTime } from './filter/dates/utils/subUnitFromZonedDateTime';
 export { filterOutInvalidRecordFilters } from './filter/filterOutInvalidRecordFilters';
+export type {
+  HydratedFilterField,
+  HydratedRecordFilter,
+} from './filter/HydratedRecordFilter';
+export type { ResolveField } from './filter/hydrateRecordFilter';
+export { hydrateRecordFilter } from './filter/hydrateRecordFilter';
+export { hydrateRecordFilters } from './filter/hydrateRecordFilters';
 export { isEmptinessOperand } from './filter/isEmptinessOperand';
 export { isRecordFilterOperandExpectingValue } from './filter/isRecordFilterOperandExpectingValue';
 export { isRecordFilterValueValid } from './filter/isRecordFilterValueValid';
@@ -104,7 +111,6 @@ export type {
   RecordFilterGroup,
 } from './filter/turnRecordFilterGroupIntoGqlOperationFilter';
 export { turnRecordFilterGroupsIntoGqlOperationFilter } from './filter/turnRecordFilterGroupIntoGqlOperationFilter';
-export type { FindFieldMetadataItemById } from './filter/turnRecordFilterIntoGqlOperationFilter';
 export { turnRecordFilterIntoRecordGqlOperationFilter } from './filter/turnRecordFilterIntoGqlOperationFilter';
 export { combineFilters } from './filter/utils/combineFilters';
 export { convertViewFilterOperandToCoreOperand } from './filter/utils/convert-view-filter-operand-to-core-operand.util';


### PR DESCRIPTION
## Summary

Follow-up to #20670 (now merged). Takes the dispatcher API one step further: the dispatcher becomes a pure data → data function, with field resolution moved to a separate "hydration" step at each platform edge.

## What changed

**`HydratedRecordFilter` (new type)** — the resolved counterpart of `RecordFilter`. Carries `field: PartialFieldMetadataItem` and optional `targetField` instead of the bare ids `fieldMetadataId` / `relationTargetFieldMetadataId`.

**`hydrateRecordFilter(s)` (new utility)** — takes raw `RecordFilter[]` + a `resolveField: (id) => Field | undefined` callback, returns `HydratedRecordFilter[]`. Filters that can't be hydrated (field or relation-target missing) are dropped explicitly.

**Dispatcher (`computeRecordGqlOperationFilter` + friends)** — now takes `recordFilters: HydratedRecordFilter[]`. No more `findFieldMetadataItemById` callback, no more "field not found → silently drop" branch inside the compute logic. The dispatcher is pure: input data → output data.

**Frontend** — each hook that calls the dispatcher (or a utility wrapping it) now hydrates inline:
```ts
recordFilters: hydrateRecordFilters(rawFilters, (id) => fieldMetadataItemByIdMap.get(id))
```
Pure utilities (`computeContextStoreFilters`, `getQueryVariablesFromFiltersAndSorts`) take the Map directly and hydrate internally.

**Server** — each caller passes a wrapper over `findFlatEntityByIdInFlatEntityMaps`. Native to the server's id→entity lookup; no Map materialization.

## Why

#20670 fixed the original silently-dropped-relation-traversal-filter bug structurally by making the dispatcher own field resolution via a callback. That works but mixed concerns: the dispatcher had to know about lookups, callers had to provide them, and the failure mode (filter dropped) lived inside the compute logic.

Pulling resolution out of the dispatcher entirely:
- **Dispatcher is trivially testable** — no callbacks to mock, no lookup setup.
- **Failure mode is explicit and at the boundary** — `hydrateRecordFilter` returns `null` if a field can't be resolved. Dropped filters are visible at the hydration step, not buried inside compute.
- **No more "what shape should the dispatcher API be" debate** — Map vs callback vs array. The dispatcher takes data; each platform shapes its hydration step however is natural for its data layer.
- **Each platform owns its edge** — frontend uses Jotai map, server uses `flatFieldMetadataMaps`. Neither pollutes `twenty-shared`.

## Code shape

Net diff: **261 insertions, 323 deletions** (~60 lines net removed). 38 files changed.

## Test plan
- [ ] All shared filter unit tests pass (1,215 tests)
- [ ] Frontend filter/context-store/total-count tests pass (13 tests)
- [ ] Integration tests on #20670 still pass — workflow find-records + chart-data with relation-traversal filter both verified through hydration step
- [ ] No behavior change end-to-end; this is a pure refactor on top of the bug fixes in #20670
