### PR TITLE
[Website] Hide Product and Articles from navigation and remove language switcher.

### DIFF
--- a/packages/twenty-website-new/src/sections/Footer/components/Bottom.tsx
+++ b/packages/twenty-website-new/src/sections/Footer/components/Bottom.tsx
@@ -2,7 +2,6 @@ import { ArrowRightUpIcon, SOCIAL_ICONS } from '@/icons';
 import { getServerI18n } from '@/lib/i18n/utils/get-server-i18n';
 import type { MessageDescriptor } from '@lingui/core';
 import type { FooterSocialLinkType } from '@/sections/Footer/types';
-import { LocaleSwitcher } from '@/sections/Footer/components/LocaleSwitcher';
 import { theme } from '@/theme';
 import { Separator } from '@base-ui/react/separator';
 import { styled } from '@linaria/react';
@@ -95,7 +94,6 @@ export function Bottom({ copyright, links }: BottomProps) {
     <BottomGrid>
       <CopyrightRow>
         <Copyright>{i18n._(copyright)}</Copyright>
-        <LocaleSwitcher />
       </CopyrightRow>
       <SocialNav aria-label="Social media">
         {links.map((link, index) => {

--- a/packages/twenty-website-new/src/sections/Footer/data.ts
+++ b/packages/twenty-website-new/src/sections/Footer/data.ts
@@ -12,7 +12,6 @@ export const FOOTER_DATA: FooterDataType = {
       ctas: [],
       links: [
         { label: msg`Home`, href: '/', external: false },
-        { label: msg`Product`, href: '/product', external: false },
         { label: msg`Pricing`, href: '/pricing', external: false },
         { label: msg`Partners`, href: '/partners', external: false },
         {
@@ -20,7 +19,6 @@ export const FOOTER_DATA: FooterDataType = {
           href: '/why-twenty',
           external: false,
         },
-        { label: msg`Articles`, href: '/articles', external: false },
       ],
     },
     {

--- a/packages/twenty-website-new/src/sections/Menu/data.ts
+++ b/packages/twenty-website-new/src/sections/Menu/data.ts
@@ -1,5 +1,4 @@
 import { msg } from '@lingui/core/macro';
-import { getPublishedArticles } from '@/lib/articles';
 import { getLatestReleasePreview } from '@/lib/releases/get-latest-release-preview';
 import type {
   MenuDataType,
@@ -16,14 +15,12 @@ const FALLBACK_RELEASES_PREVIEW: MenuNavChildPreview = {
   description: msg`Track every release with changelogs, highlights and demos of the newest features.`,
 };
 
-const HAS_PUBLISHED_ARTICLES = getPublishedArticles().length > 0;
-
 function buildNavItems(): MenuNavItemType[] {
   const releasesPreview =
     getLatestReleasePreview() ?? FALLBACK_RELEASES_PREVIEW;
 
   return [
-    { label: msg`Product`, href: '/product' },
+    { label: msg`Why`, href: '/why-twenty' },
     {
       label: msg`Resources`,
       children: [
@@ -56,18 +53,6 @@ function buildNavItems(): MenuNavItemType[] {
           },
         },
         {
-          label: msg`Why Twenty`,
-          description: msg`Our story and vision`,
-          href: '/why-twenty',
-          icon: 'lightbulb',
-          preview: {
-            image: '/images/product/demo/kanban.webp',
-            imageAlt: 'Twenty CRM pipeline view',
-            title: msg`Why Twenty`,
-            description: msg`Our story: building a CRM teams can truly own.`,
-          },
-        },
-        {
           label: msg`Partners`,
           description: msg`Find a Twenty partner`,
           href: '/partners',
@@ -87,16 +72,6 @@ function buildNavItems(): MenuNavItemType[] {
           icon: 'tag',
           preview: releasesPreview,
         },
-        ...(HAS_PUBLISHED_ARTICLES
-          ? [
-              {
-                label: msg`Articles`,
-                description: msg`Read Twenty insights`,
-                href: '/articles',
-                icon: 'book' as const,
-              },
-            ]
-          : []),
       ],
     },
     { label: msg`Customers`, href: '/customers' },


### PR DESCRIPTION
Restore "Why" as the top-level nav item, remove Product and Articles from menu and footer, and hide the language switcher in the footer for this release. Pages remain accessible via direct URL and stay indexed.

Will re-add once the release is out.