### PR TITLE
Fix BUILDER_INTERNAL_SERVER_ERROR message

### DIFF
--- a/packages/twenty-server/src/engine/workspace-manager/workspace-migration/services/workspace-migration-validate-build-and-run-service.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/workspace-migration/services/workspace-migration-validate-build-and-run-service.ts
@@ -373,8 +373,8 @@ export class WorkspaceMigrationValidateBuildAndRunService {
         .catch((error) => {
           this.logger.error(error);
           throw new WorkspaceMigrationV2Exception(
-            WorkspaceMigrationV2ExceptionCode.BUILDER_INTERNAL_SERVER_ERROR,
             error.message,
+            WorkspaceMigrationV2ExceptionCode.BUILDER_INTERNAL_SERVER_ERROR,
           );
         });
 


### PR DESCRIPTION
The throw site was passing (code, message) to a constructor whose signature is (message, code), so exception.message ended up as the literal string "BUILDER_INTERNAL_SERVER_ERROR" and the real error.message was stored in exception.code where nothing reads it. Swapping the two args puts the real error message back into exception.message, which is the field Yoga's error handler copies into the GraphQL response's top-level message — and that's the field the CLI prints.