### PR TITLE
Remove cli tools packages from the ageGate

### DIFF
--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -10,4 +10,9 @@ nodeLinker: node-modules
 
 npmMinimalAgeGate: 3d
 
+npmPreapprovedPackages:
+  - twenty-sdk
+  - twenty-client-sdk
+  - create-twenty-app
+
 yarnPath: .yarn/releases/yarn-4.13.0.cjs


### PR DESCRIPTION
avoids waiting 3 days to une the latest cli tools

<img width="861" height="178" alt="image" src="https://github.com/user-attachments/assets/fff21074-ddcf-4159-bf3c-eabcc64acb67" />
