### PR TITLE
refactor(filters): pass fieldMetadataItems array to dispatcher

### DIFF
--- a/packages/twenty-front/src/modules/command-menu-item/engine-command/utils/buildHeadlessCommandContextApi.ts
+++ b/packages/twenty-front/src/modules/command-menu-item/engine-command/utils/buildHeadlessCommandContextApi.ts
@@ -9,7 +9,7 @@ import { contextStoreFilterGroupsComponentState } from '@/context-store/states/c
 import { contextStoreFiltersComponentState } from '@/context-store/states/contextStoreFiltersComponentState';
 import { contextStoreTargetedRecordsRuleComponentState } from '@/context-store/states/contextStoreTargetedRecordsRuleComponentState';
 import { computeContextStoreFilters } from '@/context-store/utils/computeContextStoreFilters';
-import { fieldMetadataItemByIdMapSelector } from '@/object-metadata/states/fieldMetadataItemByIdMapSelector';
+import { flattenedFieldMetadataItemsSelector } from '@/object-metadata/states/flattenedFieldMetadataItemsSelector';
 import { objectMetadataItemsSelector } from '@/object-metadata/states/objectMetadataItemsSelector';
 import { type EnrichedObjectMetadataItem } from '@/object-metadata/types/EnrichedObjectMetadataItem';
 import { recordStoreFamilyState } from '@/object-record/record-store/states/recordStoreFamilyState';
@@ -90,8 +90,8 @@ export const buildHeadlessCommandContextApi = ({
       ? (currentWorkspaceMember?.timeZone ?? systemTimeZone)
       : systemTimeZone;
 
-  const fieldMetadataItemByIdMap = store.get(
-    fieldMetadataItemByIdMapSelector.atom,
+  const flattenedFieldMetadataItems = store.get(
+    flattenedFieldMetadataItemsSelector.atom,
   );
 
   const graphqlFilter = isDefined(objectMetadataItem)
@@ -100,7 +100,7 @@ export const buildHeadlessCommandContextApi = ({
         contextStoreFilters: filters,
         contextStoreFilterGroups: filterGroups,
         objectMetadataItem,
-        findFieldMetadataItemById: (id) => fieldMetadataItemByIdMap.get(id),
+        fieldMetadataItems: flattenedFieldMetadataItems,
         filterValueDependencies: {
           currentWorkspaceMemberId: currentWorkspaceMember?.id,
           timeZone: userTimezone,

--- a/packages/twenty-front/src/modules/context-store/hooks/useFindManyRecordsSelectedInContextStore.ts
+++ b/packages/twenty-front/src/modules/context-store/hooks/useFindManyRecordsSelectedInContextStore.ts
@@ -6,6 +6,7 @@ import { contextStoreTargetedRecordsRuleComponentState } from '@/context-store/s
 import { computeContextStoreFilters } from '@/context-store/utils/computeContextStoreFilters';
 import { useObjectMetadataItemById } from '@/object-metadata/hooks/useObjectMetadataItemById';
 import { fieldMetadataItemByIdMapSelector } from '@/object-metadata/states/fieldMetadataItemByIdMapSelector';
+import { flattenedFieldMetadataItemsSelector } from '@/object-metadata/states/flattenedFieldMetadataItemsSelector';
 import { useFindManyRecords } from '@/object-record/hooks/useFindManyRecords';
 import { useFilterValueDependencies } from '@/object-record/record-filter/hooks/useFilterValueDependencies';
 import { RecordFilterOperand } from '@/object-record/record-filter/types/RecordFilterOperand';
@@ -54,6 +55,10 @@ export const useFindManyRecordsSelectedInContextStore = ({
     fieldMetadataItemByIdMapSelector,
   );
 
+  const flattenedFieldMetadataItems = useAtomStateValue(
+    flattenedFieldMetadataItemsSelector,
+  );
+
   const isSoftDeleteFilterActive = contextStoreFilters.some(
     (filter) =>
       fieldMetadataItemByIdMap.get(filter.fieldMetadataId)?.name ===
@@ -65,7 +70,7 @@ export const useFindManyRecordsSelectedInContextStore = ({
     contextStoreFilters,
     contextStoreFilterGroups,
     objectMetadataItem,
-    findFieldMetadataItemById: (id) => fieldMetadataItemByIdMap.get(id),
+    fieldMetadataItems: flattenedFieldMetadataItems,
     filterValueDependencies,
     contextStoreAnyFieldFilterValue,
   });

--- a/packages/twenty-front/src/modules/context-store/utils/__tests__/computeContextStoreFilters.test.ts
+++ b/packages/twenty-front/src/modules/context-store/utils/__tests__/computeContextStoreFilters.test.ts
@@ -29,8 +29,7 @@ describe('computeContextStoreFilters', () => {
       contextStoreFilters: [],
       contextStoreFilterGroups: [],
       objectMetadataItem: personObjectMetadataItem,
-      findFieldMetadataItemById: (id) =>
-        personObjectMetadataItem.fields.find((field) => field.id === id),
+      fieldMetadataItems: personObjectMetadataItem.fields,
       filterValueDependencies: mockFilterValueDependencies,
       contextStoreAnyFieldFilterValue: '',
     });
@@ -75,8 +74,7 @@ describe('computeContextStoreFilters', () => {
       contextStoreFilters,
       contextStoreFilterGroups: [],
       objectMetadataItem: personObjectMetadataItem,
-      findFieldMetadataItemById: (id) =>
-        personObjectMetadataItem.fields.find((field) => field.id === id),
+      fieldMetadataItems: personObjectMetadataItem.fields,
       filterValueDependencies: mockFilterValueDependencies,
       contextStoreAnyFieldFilterValue: '',
     });

--- a/packages/twenty-front/src/modules/context-store/utils/computeContextStoreFilters.ts
+++ b/packages/twenty-front/src/modules/context-store/utils/computeContextStoreFilters.ts
@@ -7,9 +7,9 @@ import {
   type RecordFilterValueDependencies,
   type RecordGqlOperationFilter,
 } from 'twenty-shared/types';
+import { type FieldMetadataItem } from '@/object-metadata/types/FieldMetadataItem';
 import {
   computeRecordGqlOperationFilter,
-  type FindFieldMetadataItemById,
   turnAnyFieldFilterIntoRecordGqlFilter,
 } from 'twenty-shared/utils';
 
@@ -18,7 +18,7 @@ type ComputeContextStoreFiltersProps = {
   contextStoreFilters: RecordFilter[];
   contextStoreFilterGroups: RecordFilterGroup[];
   objectMetadataItem: EnrichedObjectMetadataItem;
-  findFieldMetadataItemById: FindFieldMetadataItemById;
+  fieldMetadataItems: FieldMetadataItem[];
   filterValueDependencies: RecordFilterValueDependencies;
   contextStoreAnyFieldFilterValue: string;
 };
@@ -28,7 +28,7 @@ export const computeContextStoreFilters = ({
   contextStoreFilters,
   contextStoreFilterGroups,
   objectMetadataItem,
-  findFieldMetadataItemById,
+  fieldMetadataItems,
   filterValueDependencies,
   contextStoreAnyFieldFilterValue,
 }: ComputeContextStoreFiltersProps) => {
@@ -45,7 +45,7 @@ export const computeContextStoreFilters = ({
       recordGqlFilterForAnyFieldFilter,
       computeRecordGqlOperationFilter({
         filterValueDependencies,
-        findFieldMetadataItemById,
+        fieldMetadataItems,
         recordFilters: contextStoreFilters,
         recordFilterGroups: contextStoreFilterGroups,
       }),
@@ -74,7 +74,7 @@ export const computeContextStoreFilters = ({
       },
       computeRecordGqlOperationFilter({
         filterValueDependencies,
-        findFieldMetadataItemById,
+        fieldMetadataItems,
         recordFilters: contextStoreFilters,
         recordFilterGroups: contextStoreFilterGroups,
       }),

--- a/packages/twenty-front/src/modules/object-record/record-calendar/month/hooks/useRecordCalendarQueryDateRangeFilter.tsx
+++ b/packages/twenty-front/src/modules/object-record/record-calendar/month/hooks/useRecordCalendarQueryDateRangeFilter.tsx
@@ -1,4 +1,4 @@
-import { fieldMetadataItemByIdMapSelector } from '@/object-metadata/states/fieldMetadataItemByIdMapSelector';
+import { flattenedFieldMetadataItemsSelector } from '@/object-metadata/states/flattenedFieldMetadataItemsSelector';
 import { useRecordCalendarContextOrThrow } from '@/object-record/record-calendar/contexts/RecordCalendarContext';
 import { useRecordCalendarMonthDaysRange } from '@/object-record/record-calendar/month/hooks/useRecordCalendarMonthDaysRange';
 import { currentRecordFilterGroupsComponentState } from '@/object-record/record-filter-group/states/currentRecordFilterGroupsComponentState';
@@ -48,8 +48,8 @@ export const useRecordCalendarQueryDateRangeFilter = (
 
   const { filterValueDependencies } = useFilterValueDependencies();
 
-  const fieldMetadataItemByIdMap = useAtomStateValue(
-    fieldMetadataItemByIdMapSelector,
+  const flattenedFieldMetadataItems = useAtomStateValue(
+    flattenedFieldMetadataItemsSelector,
   );
 
   const anyFieldFilterValue = useAtomComponentStateValue(
@@ -110,7 +110,7 @@ export const useRecordCalendarQueryDateRangeFilter = (
     filterValueDependencies,
     recordFilters: calendarRecordFilters,
     recordFilterGroups: currentRecordFilterGroups,
-    findFieldMetadataItemById: (id) => fieldMetadataItemByIdMap.get(id),
+    fieldMetadataItems: flattenedFieldMetadataItems,
   });
 
   const { recordGqlOperationFilter: anyFieldFilter } =

--- a/packages/twenty-front/src/modules/object-record/record-filter/utils/__tests__/computeViewRecordGqlOperationFilter.test.ts
+++ b/packages/twenty-front/src/modules/object-record/record-filter/utils/__tests__/computeViewRecordGqlOperationFilter.test.ts
@@ -22,14 +22,11 @@ const petMockObjectMetadataItem = getMockObjectMetadataItemOrThrow('pet');
 
 const personMockObjectMetadataItem = getMockObjectMetadataItemOrThrow('person');
 
-const findCompanyFieldById = (id: string) =>
-  companyMockObjectMetadataItem.fields.find((field) => field.id === id);
+const companyFields = companyMockObjectMetadataItem.fields;
 
-const findPersonFieldById = (id: string) =>
-  personMockObjectMetadataItem.fields.find((field) => field.id === id);
+const personFields = personMockObjectMetadataItem.fields;
 
-const findPetFieldById = (id: string) =>
-  petMockObjectMetadataItem.fields.find((field) => field.id === id);
+const petFields = petMockObjectMetadataItem.fields;
 
 const mockFilterValueDependencies: RecordFilterValueDependencies = {
   currentWorkspaceMemberId: '32219445-f587-4c40-b2b1-6d3205ed96da',
@@ -63,7 +60,7 @@ describe('computeViewRecordGqlOperationFilter', () => {
       filterValueDependencies: mockFilterValueDependencies,
       recordFilters: [nameFilter],
       recordFilterGroups: [],
-      findFieldMetadataItemById: findCompanyFieldById,
+      fieldMetadataItems: companyFields,
     });
 
     expect(result).toEqual({
@@ -116,7 +113,7 @@ describe('computeViewRecordGqlOperationFilter', () => {
       filterValueDependencies: mockFilterValueDependencies,
       recordFilters: [nameFilter, employeesFilter],
       recordFilterGroups: [],
-      findFieldMetadataItemById: findCompanyFieldById,
+      fieldMetadataItems: companyFields,
     });
 
     expect(result).toEqual({
@@ -196,7 +193,7 @@ describe('should work as expected for the different field types', () => {
         addressFilterIsNotEmpty,
       ],
       recordFilterGroups: [],
-      findFieldMetadataItemById: findCompanyFieldById,
+      fieldMetadataItems: companyFields,
     });
 
     expect(result).toEqual({
@@ -660,7 +657,7 @@ describe('should work as expected for the different field types', () => {
         phonesFilterIsNotEmpty,
       ],
       recordFilterGroups: [],
-      findFieldMetadataItemById: findPersonFieldById,
+      fieldMetadataItems: personFields,
     });
 
     expect(result).toEqual({
@@ -857,7 +854,7 @@ describe('should work as expected for the different field types', () => {
         emailsFilterIsNotEmpty,
       ],
       recordFilterGroups: [],
-      findFieldMetadataItemById: findPersonFieldById,
+      fieldMetadataItems: personFields,
     });
 
     expect(result).toEqual({
@@ -1069,7 +1066,7 @@ describe('should work as expected for the different field types', () => {
         dateFilterIsNotEmpty,
       ],
       recordFilterGroups: [],
-      findFieldMetadataItemById: findCompanyFieldById,
+      fieldMetadataItems: companyFields,
     });
 
     expect(result).toEqual({
@@ -1171,7 +1168,7 @@ describe('should work as expected for the different field types', () => {
         employeesFilterIsNotEmpty,
       ],
       recordFilterGroups: [],
-      findFieldMetadataItemById: findCompanyFieldById,
+      fieldMetadataItems: companyFields,
     });
 
     expect(result).toEqual({
@@ -1273,7 +1270,7 @@ describe('should work as expected for the different field types', () => {
         ARRFilterIsNot,
       ],
       recordFilterGroups: [],
-      findFieldMetadataItemById: findCompanyFieldById,
+      fieldMetadataItems: companyFields,
     });
 
     expect(result).toEqual({
@@ -1350,7 +1347,7 @@ describe('should work as expected for the different field types', () => {
       filterValueDependencies: mockFilterValueDependencies,
       recordFilters: [ARRFilterIn, ARRFilterNotIn],
       recordFilterGroups: [],
-      findFieldMetadataItemById: findCompanyFieldById,
+      fieldMetadataItems: companyFields,
     });
 
     expect(result).toEqual({
@@ -1410,7 +1407,7 @@ describe('should work as expected for the different field types', () => {
       filterValueDependencies: mockFilterValueDependencies,
       recordFilters: [selectFilterIs, selectFilterIsNot],
       recordFilterGroups: [],
-      findFieldMetadataItemById: findPetFieldById,
+      fieldMetadataItems: petFields,
     });
 
     expect(result).toEqual({
@@ -1483,7 +1480,7 @@ describe('should work as expected for the different field types', () => {
         multiSelectFilterDoesNotContain,
       ],
       recordFilterGroups: [],
-      findFieldMetadataItemById: findCompanyFieldById,
+      fieldMetadataItems: companyFields,
     });
 
     expect(result).toEqual({

--- a/packages/twenty-front/src/modules/object-record/record-index/components/RecordIndexContainerContextStoreNumberOfSelectedRecordsEffect.tsx
+++ b/packages/twenty-front/src/modules/object-record/record-index/components/RecordIndexContainerContextStoreNumberOfSelectedRecordsEffect.tsx
@@ -6,7 +6,7 @@ import { contextStoreTargetedRecordsRuleComponentState } from '@/context-store/s
 import { computeContextStoreFilters } from '@/context-store/utils/computeContextStoreFilters';
 import { useObjectMetadataItem } from '@/object-metadata/hooks/useObjectMetadataItem';
 import { useObjectNameSingularFromPlural } from '@/object-metadata/hooks/useObjectNameSingularFromPlural';
-import { fieldMetadataItemByIdMapSelector } from '@/object-metadata/states/fieldMetadataItemByIdMapSelector';
+import { flattenedFieldMetadataItemsSelector } from '@/object-metadata/states/flattenedFieldMetadataItemsSelector';
 import { useFindManyRecords } from '@/object-record/hooks/useFindManyRecords';
 import { useFilterValueDependencies } from '@/object-record/record-filter/hooks/useFilterValueDependencies';
 import { useRecordIndexContextOrThrow } from '@/object-record/record-index/contexts/RecordIndexContext';
@@ -54,8 +54,8 @@ export const RecordIndexContainerContextStoreNumberOfSelectedRecordsEffect =
 
     const { filterValueDependencies } = useFilterValueDependencies();
 
-    const fieldMetadataItemByIdMap = useAtomStateValue(
-      fieldMetadataItemByIdMapSelector,
+    const flattenedFieldMetadataItems = useAtomStateValue(
+      flattenedFieldMetadataItemsSelector,
     );
 
     const computedFilter = computeContextStoreFilters({
@@ -63,7 +63,7 @@ export const RecordIndexContainerContextStoreNumberOfSelectedRecordsEffect =
       contextStoreFilters,
       contextStoreFilterGroups,
       objectMetadataItem,
-      findFieldMetadataItemById: (id) => fieldMetadataItemByIdMap.get(id),
+      fieldMetadataItems: flattenedFieldMetadataItems,
       filterValueDependencies,
       contextStoreAnyFieldFilterValue,
     });

--- a/packages/twenty-front/src/modules/object-record/record-index/export/hooks/useRecordIndexLazyFetchRecords.ts
+++ b/packages/twenty-front/src/modules/object-record/record-index/export/hooks/useRecordIndexLazyFetchRecords.ts
@@ -7,7 +7,7 @@ import { contextStoreFilterGroupsComponentState } from '@/context-store/states/c
 import { contextStoreFiltersComponentState } from '@/context-store/states/contextStoreFiltersComponentState';
 import { contextStoreTargetedRecordsRuleComponentState } from '@/context-store/states/contextStoreTargetedRecordsRuleComponentState';
 import { computeContextStoreFilters } from '@/context-store/utils/computeContextStoreFilters';
-import { fieldMetadataItemByIdMapSelector } from '@/object-metadata/states/fieldMetadataItemByIdMapSelector';
+import { flattenedFieldMetadataItemsSelector } from '@/object-metadata/states/flattenedFieldMetadataItemsSelector';
 import { type EnrichedObjectMetadataItem } from '@/object-metadata/types/EnrichedObjectMetadataItem';
 import { useLazyFetchAllRecords } from '@/object-record/hooks/useLazyFetchAllRecords';
 import { EXPORT_TABLE_DATA_DEFAULT_PAGE_SIZE } from '@/object-record/object-options-dropdown/constants/ExportTableDataDefaultPageSize';
@@ -89,8 +89,8 @@ export const useRecordIndexLazyFetchRecords = ({
 
   const { filterValueDependencies } = useFilterValueDependencies();
 
-  const fieldMetadataItemByIdMap = useAtomStateValue(
-    fieldMetadataItemByIdMapSelector,
+  const flattenedFieldMetadataItems = useAtomStateValue(
+    flattenedFieldMetadataItemsSelector,
   );
 
   const findManyRecordsParams = useFindManyRecordIndexTableParams(
@@ -107,7 +107,7 @@ export const useRecordIndexLazyFetchRecords = ({
     contextStoreFilters,
     contextStoreFilterGroups,
     objectMetadataItem,
-    findFieldMetadataItemById: (id) => fieldMetadataItemByIdMap.get(id),
+    fieldMetadataItems: flattenedFieldMetadataItems,
     filterValueDependencies,
     contextStoreAnyFieldFilterValue,
   });

--- a/packages/twenty-front/src/modules/object-record/record-index/hooks/useFindManyRecordIndexTableParams.ts
+++ b/packages/twenty-front/src/modules/object-record/record-index/hooks/useFindManyRecordIndexTableParams.ts
@@ -1,6 +1,6 @@
 import { useObjectMetadataItem } from '@/object-metadata/hooks/useObjectMetadataItem';
 import { useObjectMetadataItems } from '@/object-metadata/hooks/useObjectMetadataItems';
-import { fieldMetadataItemByIdMapSelector } from '@/object-metadata/states/fieldMetadataItemByIdMapSelector';
+import { flattenedFieldMetadataItemsSelector } from '@/object-metadata/states/flattenedFieldMetadataItemsSelector';
 import { turnSortsIntoOrderBy } from '@/object-record/object-sort-dropdown/utils/turnSortsIntoOrderBy';
 import { currentRecordFilterGroupsComponentState } from '@/object-record/record-filter-group/states/currentRecordFilterGroupsComponentState';
 import { useFilterValueDependencies } from '@/object-record/record-filter/hooks/useFilterValueDependencies';
@@ -49,12 +49,12 @@ export const useFindManyRecordIndexTableParams = (
 
   const { filterValueDependencies } = useFilterValueDependencies();
 
-  const fieldMetadataItemByIdMap = useAtomStateValue(
-    fieldMetadataItemByIdMapSelector,
+  const flattenedFieldMetadataItems = useAtomStateValue(
+    flattenedFieldMetadataItemsSelector,
   );
 
   const currentFilters = computeRecordGqlOperationFilter({
-    findFieldMetadataItemById: (id) => fieldMetadataItemByIdMap.get(id),
+    fieldMetadataItems: flattenedFieldMetadataItems,
     recordFilterGroups: currentRecordFilterGroups,
     recordFilters: currentRecordFilters,
     filterValueDependencies,

--- a/packages/twenty-front/src/modules/object-record/record-index/hooks/useRecordIndexGroupCommonQueryVariables.ts
+++ b/packages/twenty-front/src/modules/object-record/record-index/hooks/useRecordIndexGroupCommonQueryVariables.ts
@@ -1,5 +1,5 @@
 import { useObjectMetadataItems } from '@/object-metadata/hooks/useObjectMetadataItems';
-import { fieldMetadataItemByIdMapSelector } from '@/object-metadata/states/fieldMetadataItemByIdMapSelector';
+import { flattenedFieldMetadataItemsSelector } from '@/object-metadata/states/flattenedFieldMetadataItemsSelector';
 import { turnSortsIntoOrderBy } from '@/object-record/object-sort-dropdown/utils/turnSortsIntoOrderBy';
 import { useRelevantRecordsGqlFields } from '@/object-record/record-field/hooks/useRelevantRecordsGqlFields';
 import { currentRecordFilterGroupsComponentState } from '@/object-record/record-filter-group/states/currentRecordFilterGroupsComponentState';
@@ -38,15 +38,15 @@ export const useRecordIndexGroupCommonQueryVariables = () => {
 
   const { filterValueDependencies } = useFilterValueDependencies();
 
-  const fieldMetadataItemByIdMap = useAtomStateValue(
-    fieldMetadataItemByIdMapSelector,
+  const flattenedFieldMetadataItems = useAtomStateValue(
+    flattenedFieldMetadataItemsSelector,
   );
 
   const requestFilters = computeRecordGqlOperationFilter({
     filterValueDependencies,
     recordFilters: currentRecordFilters,
     recordFilterGroups: currentRecordFilterGroups,
-    findFieldMetadataItemById: (id) => fieldMetadataItemByIdMap.get(id),
+    fieldMetadataItems: flattenedFieldMetadataItems,
   });
 
   const anyFieldFilterValue = useAtomComponentStateValue(

--- a/packages/twenty-front/src/modules/object-record/record-index/hooks/useRecordIndexGroupsAggregatesGroupBy.ts
+++ b/packages/twenty-front/src/modules/object-record/record-index/hooks/useRecordIndexGroupsAggregatesGroupBy.ts
@@ -1,5 +1,5 @@
 import { useApolloCoreClient } from '@/object-metadata/hooks/useApolloCoreClient';
-import { fieldMetadataItemByIdMapSelector } from '@/object-metadata/states/fieldMetadataItemByIdMapSelector';
+import { flattenedFieldMetadataItemsSelector } from '@/object-metadata/states/flattenedFieldMetadataItemsSelector';
 import { type FieldMetadataItem } from '@/object-metadata/types/FieldMetadataItem';
 import { type EnrichedObjectMetadataItem } from '@/object-metadata/types/EnrichedObjectMetadataItem';
 import { EMPTY_QUERY } from '@/object-record/constants/EmptyQuery';
@@ -48,15 +48,15 @@ export const useRecordIndexGroupsAggregatesGroupBy = ({
 
   const { filterValueDependencies } = useFilterValueDependencies();
 
-  const fieldMetadataItemByIdMap = useAtomStateValue(
-    fieldMetadataItemByIdMapSelector,
+  const flattenedFieldMetadataItems = useAtomStateValue(
+    flattenedFieldMetadataItemsSelector,
   );
 
   const requestFilters = computeRecordGqlOperationFilter({
     filterValueDependencies,
     recordFilters: currentRecordFilters,
     recordFilterGroups: currentRecordFilterGroups,
-    findFieldMetadataItemById: (id) => fieldMetadataItemByIdMap.get(id),
+    fieldMetadataItems: flattenedFieldMetadataItems,
   });
 
   const { recordAggregateGqlField } =

--- a/packages/twenty-front/src/modules/object-record/record-table/components/RecordTableEmptyHasNewRecordEffect.tsx
+++ b/packages/twenty-front/src/modules/object-record/record-table/components/RecordTableEmptyHasNewRecordEffect.tsx
@@ -1,6 +1,6 @@
 import { useListenToObjectRecordOperationBrowserEvent } from '@/browser-event/hooks/useListenToObjectRecordOperationBrowserEvent';
 import { type ObjectRecordOperationBrowserEventDetail } from '@/browser-event/types/ObjectRecordOperationBrowserEventDetail';
-import { fieldMetadataItemByIdMapSelector } from '@/object-metadata/states/fieldMetadataItemByIdMapSelector';
+import { flattenedFieldMetadataItemsSelector } from '@/object-metadata/states/flattenedFieldMetadataItemsSelector';
 import { turnSortsIntoOrderBy } from '@/object-record/object-sort-dropdown/utils/turnSortsIntoOrderBy';
 import { currentRecordFilterGroupsComponentState } from '@/object-record/record-filter-group/states/currentRecordFilterGroupsComponentState';
 import { useFilterValueDependencies } from '@/object-record/record-filter/hooks/useFilterValueDependencies';
@@ -40,8 +40,8 @@ export const RecordTableEmptyHasNewRecordEffect = () => {
 
   const { filterValueDependencies } = useFilterValueDependencies();
 
-  const fieldMetadataItemByIdMap = useAtomStateValue(
-    fieldMetadataItemByIdMapSelector,
+  const flattenedFieldMetadataItems = useAtomStateValue(
+    flattenedFieldMetadataItemsSelector,
   );
 
   const currentRecordFilters = useAtomComponentStateValue(
@@ -63,7 +63,7 @@ export const RecordTableEmptyHasNewRecordEffect = () => {
       objectNameSingular: objectMetadataItem.nameSingular,
       variables: {
         filter: computeRecordGqlOperationFilter({
-          findFieldMetadataItemById: (id) => fieldMetadataItemByIdMap.get(id),
+          fieldMetadataItems: flattenedFieldMetadataItems,
           recordFilters: currentRecordFilters,
           recordFilterGroups: currentRecordFilterGroups,
           filterValueDependencies,
@@ -77,7 +77,7 @@ export const RecordTableEmptyHasNewRecordEffect = () => {
       currentRecordFilterGroups,
       filterValueDependencies,
       currentRecordSorts,
-      fieldMetadataItemByIdMap,
+      flattenedFieldMetadataItems,
     ],
   );
 

--- a/packages/twenty-front/src/modules/object-record/record-table/record-table-footer/hooks/useAggregateRecordsForRecordTableColumnFooter.tsx
+++ b/packages/twenty-front/src/modules/object-record/record-table/record-table-footer/hooks/useAggregateRecordsForRecordTableColumnFooter.tsx
@@ -1,4 +1,4 @@
-import { fieldMetadataItemByIdMapSelector } from '@/object-metadata/states/fieldMetadataItemByIdMapSelector';
+import { flattenedFieldMetadataItemsSelector } from '@/object-metadata/states/flattenedFieldMetadataItemsSelector';
 import { useAggregateRecords } from '@/object-record/hooks/useAggregateRecords';
 import { transformAggregateRawValueIntoAggregateDisplayValue } from '@/object-record/record-aggregate/utils/transformAggregateRawValueIntoAggregateDisplayValue';
 import { getAggregateOperationLabel } from '@/object-record/record-board/record-board-column/utils/getAggregateOperationLabel';
@@ -46,14 +46,14 @@ export const useAggregateRecordsForRecordTableColumnFooter = (
 
   const dateLocale = useAtomStateValue(dateLocaleState);
 
-  const fieldMetadataItemByIdMap = useAtomStateValue(
-    fieldMetadataItemByIdMapSelector,
+  const flattenedFieldMetadataItems = useAtomStateValue(
+    flattenedFieldMetadataItemsSelector,
   );
 
   const { filterValueDependencies } = useFilterValueDependencies();
 
   const requestFilters = computeRecordGqlOperationFilter({
-    findFieldMetadataItemById: (id) => fieldMetadataItemByIdMap.get(id),
+    fieldMetadataItems: flattenedFieldMetadataItems,
     filterValueDependencies,
     recordFilterGroups: currentRecordFilterGroups,
     recordFilters: currentRecordFilters,

--- a/packages/twenty-front/src/modules/object-record/record-table/virtualization/components/RecordTableVirtualizedSSESubscribeEffect.tsx
+++ b/packages/twenty-front/src/modules/object-record/record-table/virtualization/components/RecordTableVirtualizedSSESubscribeEffect.tsx
@@ -1,6 +1,6 @@
 import { useMemo } from 'react';
 
-import { fieldMetadataItemByIdMapSelector } from '@/object-metadata/states/fieldMetadataItemByIdMapSelector';
+import { flattenedFieldMetadataItemsSelector } from '@/object-metadata/states/flattenedFieldMetadataItemsSelector';
 import { turnSortsIntoOrderBy } from '@/object-record/object-sort-dropdown/utils/turnSortsIntoOrderBy';
 import { currentRecordFilterGroupsComponentState } from '@/object-record/record-filter-group/states/currentRecordFilterGroupsComponentState';
 import { useFilterValueDependencies } from '@/object-record/record-filter/hooks/useFilterValueDependencies';
@@ -16,8 +16,8 @@ export const RecordTableVirtualizedSSESubscribeEffect = () => {
   const { objectMetadataItem } = useRecordIndexContextOrThrow();
   const { filterValueDependencies } = useFilterValueDependencies();
 
-  const fieldMetadataItemByIdMap = useAtomStateValue(
-    fieldMetadataItemByIdMapSelector,
+  const flattenedFieldMetadataItems = useAtomStateValue(
+    flattenedFieldMetadataItemsSelector,
   );
 
   const currentRecordFilters = useAtomComponentStateValue(
@@ -39,7 +39,7 @@ export const RecordTableVirtualizedSSESubscribeEffect = () => {
       objectNameSingular: objectMetadataItem.nameSingular,
       variables: {
         filter: computeRecordGqlOperationFilter({
-          findFieldMetadataItemById: (id) => fieldMetadataItemByIdMap.get(id),
+          fieldMetadataItems: flattenedFieldMetadataItems,
           recordFilters: currentRecordFilters,
           recordFilterGroups: currentRecordFilterGroups,
           filterValueDependencies,
@@ -53,7 +53,7 @@ export const RecordTableVirtualizedSSESubscribeEffect = () => {
       currentRecordFilterGroups,
       filterValueDependencies,
       currentRecordSorts,
-      fieldMetadataItemByIdMap,
+      flattenedFieldMetadataItems,
     ],
   );
 

--- a/packages/twenty-front/src/modules/object-record/record-update-multiple/hooks/useUpdateMultipleRecordsActions.ts
+++ b/packages/twenty-front/src/modules/object-record/record-update-multiple/hooks/useUpdateMultipleRecordsActions.ts
@@ -4,7 +4,7 @@ import { contextStoreFilterGroupsComponentState } from '@/context-store/states/c
 import { contextStoreFiltersComponentState } from '@/context-store/states/contextStoreFiltersComponentState';
 import { contextStoreTargetedRecordsRuleComponentState } from '@/context-store/states/contextStoreTargetedRecordsRuleComponentState';
 import { computeContextStoreFilters } from '@/context-store/utils/computeContextStoreFilters';
-import { fieldMetadataItemByIdMapSelector } from '@/object-metadata/states/fieldMetadataItemByIdMapSelector';
+import { flattenedFieldMetadataItemsSelector } from '@/object-metadata/states/flattenedFieldMetadataItemsSelector';
 import { useIncrementalUpdateManyRecords } from '@/object-record/hooks/useIncrementalUpdateManyRecords';
 import { useFilterValueDependencies } from '@/object-record/record-filter/hooks/useFilterValueDependencies';
 import { useAtomComponentStateValue } from '@/ui/utilities/state/jotai/hooks/useAtomComponentStateValue';
@@ -45,8 +45,8 @@ export const useUpdateMultipleRecordsActions = ({
 
   const { filterValueDependencies } = useFilterValueDependencies();
 
-  const fieldMetadataItemByIdMap = useAtomStateValue(
-    fieldMetadataItemByIdMapSelector,
+  const flattenedFieldMetadataItems = useAtomStateValue(
+    flattenedFieldMetadataItemsSelector,
   );
 
   const graphqlFilter = computeContextStoreFilters({
@@ -54,7 +54,7 @@ export const useUpdateMultipleRecordsActions = ({
     contextStoreFilters,
     contextStoreFilterGroups,
     objectMetadataItem,
-    findFieldMetadataItemById: (id) => fieldMetadataItemByIdMap.get(id),
+    fieldMetadataItems: flattenedFieldMetadataItems,
     filterValueDependencies,
     contextStoreAnyFieldFilterValue,
   });

--- a/packages/twenty-front/src/modules/page-layout/widgets/graph/hooks/useGraphWidgetQueryCommon.ts
+++ b/packages/twenty-front/src/modules/page-layout/widgets/graph/hooks/useGraphWidgetQueryCommon.ts
@@ -1,5 +1,5 @@
 import { useObjectMetadataItemById } from '@/object-metadata/hooks/useObjectMetadataItemById';
-import { fieldMetadataItemByIdMapSelector } from '@/object-metadata/states/fieldMetadataItemByIdMapSelector';
+import { flattenedFieldMetadataItemsSelector } from '@/object-metadata/states/flattenedFieldMetadataItemsSelector';
 import { useFilterValueDependencies } from '@/object-record/record-filter/hooks/useFilterValueDependencies';
 import { useAtomStateValue } from '@/ui/utilities/state/jotai/hooks/useAtomStateValue';
 import {
@@ -40,14 +40,14 @@ export const useGraphWidgetQueryCommon = ({
 
   const { filterValueDependencies } = useFilterValueDependencies();
 
-  const fieldMetadataItemByIdMap = useAtomStateValue(
-    fieldMetadataItemByIdMapSelector,
+  const flattenedFieldMetadataItems = useAtomStateValue(
+    flattenedFieldMetadataItemsSelector,
   );
 
   const widgetRecordFilters = configuration.filter?.recordFilters ?? [];
 
   const gqlOperationFilter = computeRecordGqlOperationFilter({
-    findFieldMetadataItemById: (id) => fieldMetadataItemByIdMap.get(id),
+    fieldMetadataItems: flattenedFieldMetadataItems,
     filterValueDependencies,
     recordFilters: widgetRecordFilters,
     recordFilterGroups: configuration.filter?.recordFilterGroups ?? [],

--- a/packages/twenty-front/src/modules/views/hooks/internal/useGetRecordIndexTotalCount.ts
+++ b/packages/twenty-front/src/modules/views/hooks/internal/useGetRecordIndexTotalCount.ts
@@ -1,5 +1,5 @@
 import { useContextStoreObjectMetadataItemOrThrow } from '@/context-store/hooks/useContextStoreObjectMetadataItemOrThrow';
-import { fieldMetadataItemByIdMapSelector } from '@/object-metadata/states/fieldMetadataItemByIdMapSelector';
+import { flattenedFieldMetadataItemsSelector } from '@/object-metadata/states/flattenedFieldMetadataItemsSelector';
 import { useAggregateRecords } from '@/object-record/hooks/useAggregateRecords';
 import { currentRecordFilterGroupsComponentState } from '@/object-record/record-filter-group/states/currentRecordFilterGroupsComponentState';
 import { useFilterValueDependencies } from '@/object-record/record-filter/hooks/useFilterValueDependencies';
@@ -27,8 +27,8 @@ export const useGetRecordIndexTotalCount = () => {
 
   const { filterValueDependencies } = useFilterValueDependencies();
 
-  const fieldMetadataItemByIdMap = useAtomStateValue(
-    fieldMetadataItemByIdMapSelector,
+  const flattenedFieldMetadataItems = useAtomStateValue(
+    flattenedFieldMetadataItemsSelector,
   );
 
   const recordGroupsVisibilityFilter = useGetViewGroupsFilters();
@@ -37,7 +37,7 @@ export const useGetRecordIndexTotalCount = () => {
     filterValueDependencies,
     recordFilters: [...currentRecordFilters, ...recordGroupsVisibilityFilter],
     recordFilterGroups: currentRecordFilterGroups,
-    findFieldMetadataItemById: (id) => fieldMetadataItemByIdMap.get(id),
+    fieldMetadataItems: flattenedFieldMetadataItems,
   });
 
   const anyFieldFilterValue = useAtomComponentStateValue(

--- a/packages/twenty-front/src/modules/views/hooks/useQueryVariablesFromParentView.ts
+++ b/packages/twenty-front/src/modules/views/hooks/useQueryVariablesFromParentView.ts
@@ -1,7 +1,7 @@
 import { MAIN_CONTEXT_STORE_INSTANCE_ID } from '@/context-store/constants/MainContextStoreInstanceId';
 import { contextStoreRecordShowParentViewComponentState } from '@/context-store/states/contextStoreRecordShowParentViewComponentState';
 import { useObjectMetadataItems } from '@/object-metadata/hooks/useObjectMetadataItems';
-import { fieldMetadataItemByIdMapSelector } from '@/object-metadata/states/fieldMetadataItemByIdMapSelector';
+import { flattenedFieldMetadataItemsSelector } from '@/object-metadata/states/flattenedFieldMetadataItemsSelector';
 import { type EnrichedObjectMetadataItem } from '@/object-metadata/types/EnrichedObjectMetadataItem';
 import { useFilterValueDependencies } from '@/object-record/record-filter/hooks/useFilterValueDependencies';
 import { useAtomComponentStateValue } from '@/ui/utilities/state/jotai/hooks/useAtomComponentStateValue';
@@ -15,8 +15,8 @@ export const useQueryVariablesFromParentView = ({
 }) => {
   const { objectMetadataItems } = useObjectMetadataItems();
 
-  const fieldMetadataItemByIdMap = useAtomStateValue(
-    fieldMetadataItemByIdMapSelector,
+  const flattenedFieldMetadataItems = useAtomStateValue(
+    flattenedFieldMetadataItemsSelector,
   );
 
   const contextStoreRecordShowParentView = useAtomComponentStateValue(
@@ -33,7 +33,7 @@ export const useQueryVariablesFromParentView = ({
     recordSorts: contextStoreRecordShowParentView?.parentViewSorts ?? [],
     objectMetadataItem,
     objectMetadataItems,
-    findFieldMetadataItemById: (id) => fieldMetadataItemByIdMap.get(id),
+    fieldMetadataItems: flattenedFieldMetadataItems,
     filterValueDependencies,
   });
 

--- a/packages/twenty-front/src/modules/views/utils/getQueryVariablesFromFiltersAndSorts.ts
+++ b/packages/twenty-front/src/modules/views/utils/getQueryVariablesFromFiltersAndSorts.ts
@@ -1,13 +1,11 @@
 import { type EnrichedObjectMetadataItem } from '@/object-metadata/types/EnrichedObjectMetadataItem';
+import { type FieldMetadataItem } from '@/object-metadata/types/FieldMetadataItem';
 import { turnSortsIntoOrderBy } from '@/object-record/object-sort-dropdown/utils/turnSortsIntoOrderBy';
 import { type RecordFilterGroup } from '@/object-record/record-filter-group/types/RecordFilterGroup';
 import { type RecordFilter } from '@/object-record/record-filter/types/RecordFilter';
 import { type RecordSort } from '@/object-record/record-sort/types/RecordSort';
 import { type RecordFilterValueDependencies } from 'twenty-shared/types';
-import {
-  computeRecordGqlOperationFilter,
-  type FindFieldMetadataItemById,
-} from 'twenty-shared/utils';
+import { computeRecordGqlOperationFilter } from 'twenty-shared/utils';
 
 export const getQueryVariablesFromFiltersAndSorts = ({
   recordFilterGroups,
@@ -15,7 +13,7 @@ export const getQueryVariablesFromFiltersAndSorts = ({
   recordSorts,
   objectMetadataItem,
   objectMetadataItems = [],
-  findFieldMetadataItemById,
+  fieldMetadataItems,
   filterValueDependencies,
 }: {
   recordFilterGroups: RecordFilterGroup[];
@@ -23,11 +21,11 @@ export const getQueryVariablesFromFiltersAndSorts = ({
   recordSorts: RecordSort[];
   objectMetadataItem: EnrichedObjectMetadataItem;
   objectMetadataItems?: EnrichedObjectMetadataItem[];
-  findFieldMetadataItemById: FindFieldMetadataItemById;
+  fieldMetadataItems: FieldMetadataItem[];
   filterValueDependencies: RecordFilterValueDependencies;
 }) => {
   const filter = computeRecordGqlOperationFilter({
-    findFieldMetadataItemById,
+    fieldMetadataItems,
     filterValueDependencies,
     recordFilterGroups,
     recordFilters,

--- a/packages/twenty-server/src/engine/api/common/common-query-runners/common-group-by-query-runner.service.ts
+++ b/packages/twenty-server/src/engine/api/common/common-query-runners/common-group-by-query-runner.service.ts
@@ -259,11 +259,9 @@ export class CommonGroupByQueryRunnerService extends CommonBaseQueryRunnerServic
     const filtersFromView = computeRecordGqlOperationFilter({
       recordFilters,
       recordFilterGroups: recordFilterGroups,
-      findFieldMetadataItemById: (id) =>
-        findFlatEntityByIdInFlatEntityMaps({
-          flatEntityId: id,
-          flatEntityMaps: flatFieldMetadataMaps,
-        }),
+      fieldMetadataItems: Object.values(
+        flatFieldMetadataMaps.byUniversalIdentifier,
+      ).filter(isDefined),
       filterValueDependencies: {
         timeZone: 'UTC', // TODO: see if we use workspace member timezone here
       },

--- a/packages/twenty-server/src/engine/metadata-modules/view/services/view-query-params.service.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/view/services/view-query-params.service.ts
@@ -108,11 +108,9 @@ export class ViewQueryParamsService {
     }));
 
     const filter = computeRecordGqlOperationFilter({
-      findFieldMetadataItemById: (id) =>
-        findFlatEntityByIdInFlatEntityMaps({
-          flatEntityId: id,
-          flatEntityMaps: flatFieldMetadataMaps,
-        }),
+      fieldMetadataItems: Object.values(
+        flatFieldMetadataMaps.byUniversalIdentifier,
+      ).filter(isDefined),
       recordFilters,
       recordFilterGroups,
       filterValueDependencies: { currentWorkspaceMemberId, timeZone },

--- a/packages/twenty-server/src/engine/twenty-orm/utils/build-row-level-permission-record-filter.util.ts
+++ b/packages/twenty-server/src/engine/twenty-orm/utils/build-row-level-permission-record-filter.util.ts
@@ -218,11 +218,9 @@ export const buildRowLevelPermissionRecordFilter = ({
   return computeRecordGqlOperationFilter({
     recordFilters,
     recordFilterGroups,
-    findFieldMetadataItemById: (id) =>
-      findFlatEntityByIdInFlatEntityMaps({
-        flatEntityId: id,
-        flatEntityMaps: flatFieldMetadataMaps,
-      }),
+    fieldMetadataItems: Object.values(
+      flatFieldMetadataMaps.byUniversalIdentifier,
+    ).filter(isDefined),
     filterValueDependencies: {
       currentWorkspaceMemberId: workspaceMember?.id,
     },

--- a/packages/twenty-server/src/modules/dashboard/chart-data/utils/convert-chart-filter-to-gql-operation-filter.util.ts
+++ b/packages/twenty-server/src/modules/dashboard/chart-data/utils/convert-chart-filter-to-gql-operation-filter.util.ts
@@ -74,11 +74,9 @@ export const convertChartFilterToGqlOperationFilter = ({
     }));
 
   return computeRecordGqlOperationFilter({
-    findFieldMetadataItemById: (id) =>
-      findFlatEntityByIdInFlatEntityMaps({
-        flatEntityId: id,
-        flatEntityMaps: flatFieldMetadataMaps,
-      }),
+    fieldMetadataItems: Object.values(
+      flatFieldMetadataMaps.byUniversalIdentifier,
+    ).filter(isDefined),
     recordFilters: convertedRecordFilters,
     recordFilterGroups: convertedRecordFilterGroups,
     filterValueDependencies: {

--- a/packages/twenty-server/src/modules/workflow/workflow-executor/workflow-actions/record-crud/find-records.workflow-action.ts
+++ b/packages/twenty-server/src/modules/workflow/workflow-executor/workflow-actions/record-crud/find-records.workflow-action.ts
@@ -2,6 +2,7 @@ import { Injectable } from '@nestjs/common';
 
 import {
   computeRecordGqlOperationFilter,
+  isDefined,
   isRecordFilterValueValid,
   resolveInput,
 } from 'twenty-shared/utils';
@@ -9,7 +10,6 @@ import {
 import { type WorkflowAction } from 'src/modules/workflow/workflow-executor/interfaces/workflow-action.interface';
 
 import { FindRecordsService } from 'src/engine/core-modules/record-crud/services/find-records.service';
-import { findFlatEntityByIdInFlatEntityMaps } from 'src/engine/metadata-modules/flat-entity/utils/find-flat-entity-by-id-in-flat-entity-maps.util';
 import { WorkflowCommonWorkspaceService } from 'src/modules/workflow/common/workspace-services/workflow-common.workspace-service';
 import {
   WorkflowStepExecutorException,
@@ -79,11 +79,9 @@ export class FindRecordsWorkflowAction implements WorkflowAction {
       workflowActionInput.filter?.recordFilters &&
       workflowActionInput.filter?.recordFilterGroups
         ? computeRecordGqlOperationFilter({
-            findFieldMetadataItemById: (id) =>
-              findFlatEntityByIdInFlatEntityMaps({
-                flatEntityId: id,
-                flatEntityMaps: flatFieldMetadataMaps,
-              }),
+            fieldMetadataItems: Object.values(
+              flatFieldMetadataMaps.byUniversalIdentifier,
+            ).filter(isDefined),
             recordFilters: workflowActionInput.filter.recordFilters,
             recordFilterGroups: workflowActionInput.filter.recordFilterGroups,
             filterValueDependencies: {

--- a/packages/twenty-shared/src/utils/filter/__tests__/computeRecordGqlOperationFilter.test.ts
+++ b/packages/twenty-shared/src/utils/filter/__tests__/computeRecordGqlOperationFilter.test.ts
@@ -27,8 +27,7 @@ describe('computeRecordGqlOperationFilter', () => {
     ];
 
     const filter = computeRecordGqlOperationFilter({
-      findFieldMetadataItemById: (id) =>
-        id === companyIdField.id ? companyIdField : undefined,
+      fieldMetadataItems: [companyIdField],
       recordFilters,
       recordFilterGroups: [],
       filterValueDependencies: {

--- a/packages/twenty-shared/src/utils/filter/__tests__/turnRecordFilterGroupIntoGqlOperationFilter.test.ts
+++ b/packages/twenty-shared/src/utils/filter/__tests__/turnRecordFilterGroupIntoGqlOperationFilter.test.ts
@@ -21,14 +21,15 @@ describe('turnRecordFilterGroupsIntoGqlOperationFilter', () => {
     },
   ];
 
-  const fieldById = new Map(fields.map((field) => [field.id, field]));
-  const findFieldMetadataItemById = (id: string) => fieldById.get(id);
+  const fieldMetadataItemById = new Map(
+    fields.map((field) => [field.id, field]),
+  );
 
   it('should return undefined when group is not found', () => {
     const result = turnRecordFilterGroupsIntoGqlOperationFilter({
       filterValueDependencies: {},
       filters: [],
-      findFieldMetadataItemById,
+      fieldMetadataItemById,
       recordFilterGroups: [],
       currentRecordFilterGroupId: 'nonexistent',
     });
@@ -48,7 +49,7 @@ describe('turnRecordFilterGroupsIntoGqlOperationFilter', () => {
           recordFilterGroupId: 'group1',
         },
       ],
-      findFieldMetadataItemById,
+      fieldMetadataItemById,
       recordFilterGroups: [
         {
           id: 'group1',
@@ -73,7 +74,7 @@ describe('turnRecordFilterGroupsIntoGqlOperationFilter', () => {
           recordFilterGroupId: 'group1',
         },
       ],
-      findFieldMetadataItemById,
+      fieldMetadataItemById,
       recordFilterGroups: [
         {
           id: 'group1',
@@ -98,7 +99,7 @@ describe('turnRecordFilterGroupsIntoGqlOperationFilter', () => {
           recordFilterGroupId: 'subgroup1',
         },
       ],
-      findFieldMetadataItemById,
+      fieldMetadataItemById,
       recordFilterGroups: [
         {
           id: 'group1',

--- a/packages/twenty-shared/src/utils/filter/__tests__/turnRecordFilterIntoGqlOperationFilter.test.ts
+++ b/packages/twenty-shared/src/utils/filter/__tests__/turnRecordFilterIntoGqlOperationFilter.test.ts
@@ -131,9 +131,7 @@ const fields = [
 
 const filterValueDependencies = { timeZone: 'UTC' };
 
-const fieldMetadataItemById = new Map(
-  fields.map((field) => [field.id, field]),
-);
+const fieldMetadataItemById = new Map(fields.map((field) => [field.id, field]));
 
 const makeFilter = (
   fieldMetadataId: string,

--- a/packages/twenty-shared/src/utils/filter/__tests__/turnRecordFilterIntoGqlOperationFilter.test.ts
+++ b/packages/twenty-shared/src/utils/filter/__tests__/turnRecordFilterIntoGqlOperationFilter.test.ts
@@ -131,8 +131,9 @@ const fields = [
 
 const filterValueDependencies = { timeZone: 'UTC' };
 
-const fieldById = new Map(fields.map((field) => [field.id, field]));
-const findFieldMetadataItemById = (id: string) => fieldById.get(id);
+const fieldMetadataItemById = new Map(
+  fields.map((field) => [field.id, field]),
+);
 
 const makeFilter = (
   fieldMetadataId: string,
@@ -159,7 +160,7 @@ describe('turnRecordFilterIntoRecordGqlOperationFilter', () => {
         RecordFilterOperand.CONTAINS,
         'x',
       ),
-      findFieldMetadataItemById,
+      fieldMetadataItemById,
     });
 
     expect(result).toBeUndefined();
@@ -169,7 +170,7 @@ describe('turnRecordFilterIntoRecordGqlOperationFilter', () => {
     const result = turnRecordFilterIntoRecordGqlOperationFilter({
       filterValueDependencies,
       recordFilter: makeFilter('f-text', RecordFilterOperand.CONTAINS, ''),
-      findFieldMetadataItemById,
+      fieldMetadataItemById,
     });
 
     expect(result).toBeUndefined();
@@ -184,7 +185,7 @@ describe('turnRecordFilterIntoRecordGqlOperationFilter', () => {
           RecordFilterOperand.CONTAINS,
           'test',
         ),
-        findFieldMetadataItemById,
+        fieldMetadataItemById,
       });
 
       expect(result).toEqual({ name: { ilike: '%test%' } });
@@ -198,7 +199,7 @@ describe('turnRecordFilterIntoRecordGqlOperationFilter', () => {
           RecordFilterOperand.DOES_NOT_CONTAIN,
           'test',
         ),
-        findFieldMetadataItemById,
+        fieldMetadataItemById,
       });
 
       expect(result).toEqual({ not: { name: { ilike: '%test%' } } });
@@ -210,7 +211,7 @@ describe('turnRecordFilterIntoRecordGqlOperationFilter', () => {
       const result = turnRecordFilterIntoRecordGqlOperationFilter({
         filterValueDependencies,
         recordFilter: makeFilter('f-number', RecordFilterOperand.IS, '42'),
-        findFieldMetadataItemById,
+        fieldMetadataItemById,
       });
 
       expect(result).toEqual({ amount: { eq: 42 } });
@@ -220,7 +221,7 @@ describe('turnRecordFilterIntoRecordGqlOperationFilter', () => {
       const result = turnRecordFilterIntoRecordGqlOperationFilter({
         filterValueDependencies,
         recordFilter: makeFilter('f-number', RecordFilterOperand.IS_NOT, '42'),
-        findFieldMetadataItemById,
+        fieldMetadataItemById,
       });
 
       expect(result).toEqual({ not: { amount: { eq: 42 } } });
@@ -234,7 +235,7 @@ describe('turnRecordFilterIntoRecordGqlOperationFilter', () => {
           RecordFilterOperand.GREATER_THAN_OR_EQUAL,
           '10',
         ),
-        findFieldMetadataItemById,
+        fieldMetadataItemById,
       });
 
       expect(result).toEqual({ amount: { gte: 10 } });
@@ -248,7 +249,7 @@ describe('turnRecordFilterIntoRecordGqlOperationFilter', () => {
           RecordFilterOperand.LESS_THAN_OR_EQUAL,
           '100',
         ),
-        findFieldMetadataItemById,
+        fieldMetadataItemById,
       });
 
       expect(result).toEqual({ amount: { lte: 100 } });
@@ -264,7 +265,7 @@ describe('turnRecordFilterIntoRecordGqlOperationFilter', () => {
           RecordFilterOperand.IS_AFTER,
           '2024-03-15',
         ),
-        findFieldMetadataItemById,
+        fieldMetadataItemById,
       });
 
       expect(result).toEqual({ createdAt: { gte: '2024-03-15' } });
@@ -278,7 +279,7 @@ describe('turnRecordFilterIntoRecordGqlOperationFilter', () => {
           RecordFilterOperand.IS_BEFORE,
           '2024-03-15',
         ),
-        findFieldMetadataItemById,
+        fieldMetadataItemById,
       });
 
       expect(result).toEqual({ createdAt: { lt: '2024-03-15' } });
@@ -292,7 +293,7 @@ describe('turnRecordFilterIntoRecordGqlOperationFilter', () => {
           RecordFilterOperand.IS,
           '2024-03-15',
         ),
-        findFieldMetadataItemById,
+        fieldMetadataItemById,
       });
 
       expect(result).toEqual({ createdAt: { eq: '2024-03-15' } });
@@ -302,7 +303,7 @@ describe('turnRecordFilterIntoRecordGqlOperationFilter', () => {
       const result = turnRecordFilterIntoRecordGqlOperationFilter({
         filterValueDependencies,
         recordFilter: makeFilter('f-date', RecordFilterOperand.IS_IN_PAST, ''),
-        findFieldMetadataItemById,
+        fieldMetadataItemById,
       });
 
       expect(result).toHaveProperty('createdAt.lt');
@@ -316,7 +317,7 @@ describe('turnRecordFilterIntoRecordGqlOperationFilter', () => {
           RecordFilterOperand.IS_IN_FUTURE,
           '',
         ),
-        findFieldMetadataItemById,
+        fieldMetadataItemById,
       });
 
       expect(result).toHaveProperty('createdAt.gte');
@@ -326,7 +327,7 @@ describe('turnRecordFilterIntoRecordGqlOperationFilter', () => {
       const result = turnRecordFilterIntoRecordGqlOperationFilter({
         filterValueDependencies,
         recordFilter: makeFilter('f-date', RecordFilterOperand.IS_TODAY, ''),
-        findFieldMetadataItemById,
+        fieldMetadataItemById,
       });
 
       expect(result).toHaveProperty('createdAt.eq');
@@ -340,7 +341,7 @@ describe('turnRecordFilterIntoRecordGqlOperationFilter', () => {
           RecordFilterOperand.IS_RELATIVE,
           'PAST_7_DAY',
         ),
-        findFieldMetadataItemById,
+        fieldMetadataItemById,
       });
 
       expect(result).toHaveProperty('and');
@@ -356,7 +357,7 @@ describe('turnRecordFilterIntoRecordGqlOperationFilter', () => {
           RecordFilterOperand.IS_AFTER,
           '2024-03-15T10:00:00Z',
         ),
-        findFieldMetadataItemById,
+        fieldMetadataItemById,
       });
 
       expect(result).toHaveProperty('updatedAt.gte');
@@ -370,7 +371,7 @@ describe('turnRecordFilterIntoRecordGqlOperationFilter', () => {
           RecordFilterOperand.IS_BEFORE,
           '2024-03-15T10:00:00Z',
         ),
-        findFieldMetadataItemById,
+        fieldMetadataItemById,
       });
 
       expect(result).toHaveProperty('updatedAt.lt');
@@ -384,7 +385,7 @@ describe('turnRecordFilterIntoRecordGqlOperationFilter', () => {
           RecordFilterOperand.IS,
           '2024-03-15T10:00:00Z',
         ),
-        findFieldMetadataItemById,
+        fieldMetadataItemById,
       });
 
       expect(result).toHaveProperty('and');
@@ -398,7 +399,7 @@ describe('turnRecordFilterIntoRecordGqlOperationFilter', () => {
           RecordFilterOperand.IS_IN_PAST,
           '',
         ),
-        findFieldMetadataItemById,
+        fieldMetadataItemById,
       });
 
       expect(result).toHaveProperty('updatedAt.lt');
@@ -412,7 +413,7 @@ describe('turnRecordFilterIntoRecordGqlOperationFilter', () => {
           RecordFilterOperand.IS_IN_FUTURE,
           '',
         ),
-        findFieldMetadataItemById,
+        fieldMetadataItemById,
       });
 
       expect(result).toHaveProperty('updatedAt.gt');
@@ -426,7 +427,7 @@ describe('turnRecordFilterIntoRecordGqlOperationFilter', () => {
           RecordFilterOperand.IS_TODAY,
           '',
         ),
-        findFieldMetadataItemById,
+        fieldMetadataItemById,
       });
 
       expect(result).toHaveProperty('and');
@@ -440,7 +441,7 @@ describe('turnRecordFilterIntoRecordGqlOperationFilter', () => {
           RecordFilterOperand.IS_RELATIVE,
           `PAST_7_DAY;;UTC;;`,
         ),
-        findFieldMetadataItemById,
+        fieldMetadataItemById,
       });
 
       expect(result).toHaveProperty('and');
@@ -452,7 +453,7 @@ describe('turnRecordFilterIntoRecordGqlOperationFilter', () => {
       const result = turnRecordFilterIntoRecordGqlOperationFilter({
         filterValueDependencies,
         recordFilter: makeFilter('f-rating', RecordFilterOperand.IS, '3'),
-        findFieldMetadataItemById,
+        fieldMetadataItemById,
       });
 
       expect(result).toHaveProperty('rating.eq');
@@ -466,7 +467,7 @@ describe('turnRecordFilterIntoRecordGqlOperationFilter', () => {
           RecordFilterOperand.GREATER_THAN_OR_EQUAL,
           '3',
         ),
-        findFieldMetadataItemById,
+        fieldMetadataItemById,
       });
 
       expect(result).toHaveProperty('rating.in');
@@ -480,7 +481,7 @@ describe('turnRecordFilterIntoRecordGqlOperationFilter', () => {
           RecordFilterOperand.LESS_THAN_OR_EQUAL,
           '3',
         ),
-        findFieldMetadataItemById,
+        fieldMetadataItemById,
       });
 
       expect(result).toHaveProperty('rating.in');
@@ -492,7 +493,7 @@ describe('turnRecordFilterIntoRecordGqlOperationFilter', () => {
       const result = turnRecordFilterIntoRecordGqlOperationFilter({
         filterValueDependencies,
         recordFilter: makeFilter('f-bool', RecordFilterOperand.IS, 'true'),
-        findFieldMetadataItemById,
+        fieldMetadataItemById,
       });
 
       expect(result).toEqual({ isActive: { eq: true } });
@@ -502,7 +503,7 @@ describe('turnRecordFilterIntoRecordGqlOperationFilter', () => {
       const result = turnRecordFilterIntoRecordGqlOperationFilter({
         filterValueDependencies,
         recordFilter: makeFilter('f-bool', RecordFilterOperand.IS, 'false'),
-        findFieldMetadataItemById,
+        fieldMetadataItemById,
       });
 
       expect(result).toEqual({ isActive: { eq: false } });
@@ -518,7 +519,7 @@ describe('turnRecordFilterIntoRecordGqlOperationFilter', () => {
           RecordFilterOperand.IS,
           '["ACTIVE","PENDING"]',
         ),
-        findFieldMetadataItemById,
+        fieldMetadataItemById,
       });
 
       expect(result).toHaveProperty('status.in');
@@ -532,7 +533,7 @@ describe('turnRecordFilterIntoRecordGqlOperationFilter', () => {
           RecordFilterOperand.IS_NOT,
           '["ACTIVE"]',
         ),
-        findFieldMetadataItemById,
+        fieldMetadataItemById,
       });
 
       expect(result).toHaveProperty('not');
@@ -548,7 +549,7 @@ describe('turnRecordFilterIntoRecordGqlOperationFilter', () => {
           RecordFilterOperand.CONTAINS,
           '["TAG1","TAG2"]',
         ),
-        findFieldMetadataItemById,
+        fieldMetadataItemById,
       });
 
       expect(result).toHaveProperty('tags.containsAny');
@@ -562,7 +563,7 @@ describe('turnRecordFilterIntoRecordGqlOperationFilter', () => {
           RecordFilterOperand.DOES_NOT_CONTAIN,
           '["TAG1"]',
         ),
-        findFieldMetadataItemById,
+        fieldMetadataItemById,
       });
 
       expect(result).toHaveProperty('or');
@@ -578,7 +579,7 @@ describe('turnRecordFilterIntoRecordGqlOperationFilter', () => {
           RecordFilterOperand.IS,
           '["550e8400-e29b-41d4-a716-446655440000"]',
         ),
-        findFieldMetadataItemById,
+        fieldMetadataItemById,
       });
 
       expect(result).toHaveProperty('companyId.in');
@@ -592,7 +593,7 @@ describe('turnRecordFilterIntoRecordGqlOperationFilter', () => {
           RecordFilterOperand.IS_NOT,
           '["550e8400-e29b-41d4-a716-446655440000"]',
         ),
-        findFieldMetadataItemById,
+        fieldMetadataItemById,
       });
 
       expect(result).toHaveProperty('or');
@@ -608,7 +609,7 @@ describe('turnRecordFilterIntoRecordGqlOperationFilter', () => {
           RecordFilterOperand.CONTAINS,
           'test',
         ),
-        findFieldMetadataItemById,
+        fieldMetadataItemById,
       });
 
       expect(result).toEqual({ metadata: { like: '%test%' } });
@@ -622,7 +623,7 @@ describe('turnRecordFilterIntoRecordGqlOperationFilter', () => {
           RecordFilterOperand.DOES_NOT_CONTAIN,
           'test',
         ),
-        findFieldMetadataItemById,
+        fieldMetadataItemById,
       });
 
       expect(result).toEqual({ not: { metadata: { like: '%test%' } } });
@@ -638,7 +639,7 @@ describe('turnRecordFilterIntoRecordGqlOperationFilter', () => {
           RecordFilterOperand.CONTAINS,
           'doc',
         ),
-        findFieldMetadataItemById,
+        fieldMetadataItemById,
       });
 
       expect(result).toEqual({ attachments: { like: '%doc%' } });
@@ -654,7 +655,7 @@ describe('turnRecordFilterIntoRecordGqlOperationFilter', () => {
           RecordFilterOperand.VECTOR_SEARCH,
           'hello world',
         ),
-        findFieldMetadataItemById,
+        fieldMetadataItemById,
       });
 
       expect(result).toEqual({ search: { search: 'hello world' } });
@@ -672,7 +673,7 @@ describe('turnRecordFilterIntoRecordGqlOperationFilter', () => {
           'CURRENCY',
           'amountMicros',
         ),
-        findFieldMetadataItemById,
+        fieldMetadataItemById,
       });
 
       expect(result).toHaveProperty('revenue');
@@ -688,7 +689,7 @@ describe('turnRecordFilterIntoRecordGqlOperationFilter', () => {
           RecordFilterOperand.CONTAINS,
           'John',
         ),
-        findFieldMetadataItemById,
+        fieldMetadataItemById,
       });
 
       expect(result).toHaveProperty('or');
@@ -704,7 +705,7 @@ describe('turnRecordFilterIntoRecordGqlOperationFilter', () => {
           RecordFilterOperand.CONTAINS,
           'Paris',
         ),
-        findFieldMetadataItemById,
+        fieldMetadataItemById,
       });
 
       expect(result).toHaveProperty('or');
@@ -720,7 +721,7 @@ describe('turnRecordFilterIntoRecordGqlOperationFilter', () => {
           RecordFilterOperand.CONTAINS,
           'api',
         ),
-        findFieldMetadataItemById,
+        fieldMetadataItemById,
       });
 
       expect(result).toEqual({
@@ -747,7 +748,7 @@ describe('turnRecordFilterIntoRecordGqlOperationFilter', () => {
           RecordFilterOperand.CONTAINS,
           'xyz123',
         ),
-        findFieldMetadataItemById,
+        fieldMetadataItemById,
       });
 
       expect(result).toEqual({
@@ -772,7 +773,7 @@ describe('turnRecordFilterIntoRecordGqlOperationFilter', () => {
           RecordFilterOperand.DOES_NOT_CONTAIN,
           'api',
         ),
-        findFieldMetadataItemById,
+        fieldMetadataItemById,
       });
 
       expect(result).toEqual({
@@ -803,7 +804,7 @@ describe('turnRecordFilterIntoRecordGqlOperationFilter', () => {
           RecordFilterOperand.DOES_NOT_CONTAIN,
           'xyz123',
         ),
-        findFieldMetadataItemById,
+        fieldMetadataItemById,
       });
 
       expect(result).toEqual({
@@ -834,7 +835,7 @@ describe('turnRecordFilterIntoRecordGqlOperationFilter', () => {
           'PHONES',
           'primaryPhoneNumber',
         ),
-        findFieldMetadataItemById,
+        fieldMetadataItemById,
       });
 
       expect(result).toBeDefined();
@@ -852,7 +853,7 @@ describe('turnRecordFilterIntoRecordGqlOperationFilter', () => {
           'EMAILS',
           'primaryEmail',
         ),
-        findFieldMetadataItemById,
+        fieldMetadataItemById,
       });
 
       expect(result).toBeDefined();
@@ -870,7 +871,7 @@ describe('turnRecordFilterIntoRecordGqlOperationFilter', () => {
           'LINKS',
           'primaryLinkUrl',
         ),
-        findFieldMetadataItemById,
+        fieldMetadataItemById,
       });
 
       expect(result).toBeDefined();
@@ -886,7 +887,7 @@ describe('turnRecordFilterIntoRecordGqlOperationFilter', () => {
           RecordFilterOperand.CONTAINS,
           '["item1"]',
         ),
-        findFieldMetadataItemById,
+        fieldMetadataItemById,
       });
 
       expect(result).toBeDefined();
@@ -900,7 +901,7 @@ describe('turnRecordFilterIntoRecordGqlOperationFilter', () => {
           RecordFilterOperand.DOES_NOT_CONTAIN,
           '["item1"]',
         ),
-        findFieldMetadataItemById,
+        fieldMetadataItemById,
       });
 
       expect(result).toHaveProperty('not');
@@ -916,7 +917,7 @@ describe('turnRecordFilterIntoRecordGqlOperationFilter', () => {
           RecordFilterOperand.IS,
           '["550e8400-e29b-41d4-a716-446655440000"]',
         ),
-        findFieldMetadataItemById,
+        fieldMetadataItemById,
       });
 
       expect(result).toHaveProperty('recordId.in');
@@ -934,7 +935,7 @@ describe('turnRecordFilterIntoRecordGqlOperationFilter', () => {
           ...makeFilter('f-relation', RecordFilterOperand.CONTAINS, 'Acme'),
           relationTargetFieldMetadataId: 'f-text',
         } as RecordFilter,
-        findFieldMetadataItemById,
+        fieldMetadataItemById,
       });
 
       expect(result).toEqual({ company: { name: { ilike: '%Acme%' } } });
@@ -951,7 +952,7 @@ describe('turnRecordFilterIntoRecordGqlOperationFilter', () => {
           ...makeFilter('f-relation', RecordFilterOperand.CONTAINS, 'Acme'),
           relationTargetFieldMetadataId: 'nonexistent-target',
         } as RecordFilter,
-        findFieldMetadataItemById,
+        fieldMetadataItemById,
       });
 
       expect(result).toBeUndefined();
@@ -966,7 +967,7 @@ describe('turnRecordFilterIntoRecordGqlOperationFilter', () => {
           ...makeFilter('f-relation', RecordFilterOperand.IS_EMPTY, ''),
           relationTargetFieldMetadataId: 'f-text',
         } as RecordFilter,
-        findFieldMetadataItemById,
+        fieldMetadataItemById,
       });
 
       // Without traversal, the RELATION case would have produced a filter
@@ -987,7 +988,7 @@ describe('turnRecordFilterIntoRecordGqlOperationFilter', () => {
           ...makeFilter('f-relation', RecordFilterOperand.IS, '["ACTIVE"]'),
           relationTargetFieldMetadataId: 'f-select',
         } as RecordFilter,
-        findFieldMetadataItemById,
+        fieldMetadataItemById,
       });
 
       expect(result).toEqual({ company: { status: { in: ['ACTIVE'] } } });
@@ -1004,7 +1005,7 @@ describe('turnRecordFilterIntoRecordGqlOperationFilter', () => {
           RecordFilterOperand.IS,
           '["550e8400-e29b-41d4-a716-446655440000"]',
         ),
-        findFieldMetadataItemById,
+        fieldMetadataItemById,
       });
 
       expect(result).toHaveProperty('companyId.in');

--- a/packages/twenty-shared/src/utils/filter/computeRecordGqlOperationFilter.ts
+++ b/packages/twenty-shared/src/utils/filter/computeRecordGqlOperationFilter.ts
@@ -8,29 +8,33 @@ import {
   type RecordFilterGroup,
 } from '@/utils/filter/turnRecordFilterGroupIntoGqlOperationFilter';
 import {
-  type FindFieldMetadataItemById,
+  type FieldShared,
   turnRecordFilterIntoRecordGqlOperationFilter,
 } from '@/utils/filter/turnRecordFilterIntoGqlOperationFilter';
 import { isDefined } from '@/utils/validation/isDefined';
 
 export const computeRecordGqlOperationFilter = ({
-  findFieldMetadataItemById,
+  fieldMetadataItems,
   recordFilters,
   recordFilterGroups,
   filterValueDependencies,
 }: {
   recordFilters: Omit<RecordFilter, 'id'>[];
-  findFieldMetadataItemById: FindFieldMetadataItemById;
+  fieldMetadataItems: FieldShared[];
   recordFilterGroups: RecordFilterGroup[];
   filterValueDependencies: RecordFilterValueDependencies;
 }): RecordGqlOperationFilter => {
+  const fieldMetadataItemById = new Map(
+    fieldMetadataItems.map((field) => [field.id, field]),
+  );
+
   const regularRecordGqlOperationFilter: RecordGqlOperationFilter[] =
     recordFilters
       .filter((filter) => !isDefined(filter.recordFilterGroupId))
       .map((regularFilter) => {
         return turnRecordFilterIntoRecordGqlOperationFilter({
           recordFilter: regularFilter,
-          findFieldMetadataItemById,
+          fieldMetadataItemById,
           filterValueDependencies,
         });
       })
@@ -44,7 +48,7 @@ export const computeRecordGqlOperationFilter = ({
     turnRecordFilterGroupsIntoGqlOperationFilter({
       filterValueDependencies,
       filters: recordFilters,
-      findFieldMetadataItemById,
+      fieldMetadataItemById,
       recordFilterGroups,
       currentRecordFilterGroupId: outermostFilterGroupId,
     });

--- a/packages/twenty-shared/src/utils/filter/turnAnyFieldFilterIntoRecordGqlFilter.ts
+++ b/packages/twenty-shared/src/utils/filter/turnAnyFieldFilterIntoRecordGqlFilter.ts
@@ -221,13 +221,15 @@ export const turnAnyFieldFilterIntoRecordGqlFilter = ({
     }
   }
 
-  const fieldById = new Map(fields.map((field) => [field.id, field]));
+  const fieldMetadataItemById = new Map(
+    fields.map((field) => [field.id, field]),
+  );
 
   const baseRecordGqlOperationFilters = anyFieldRecordFilters
     .map((recordFilter) =>
       turnRecordFilterIntoRecordGqlOperationFilter({
         filterValueDependencies: {},
-        findFieldMetadataItemById: (id) => fieldById.get(id),
+        fieldMetadataItemById,
         recordFilter,
       }),
     )

--- a/packages/twenty-shared/src/utils/filter/turnRecordFilterGroupIntoGqlOperationFilter.ts
+++ b/packages/twenty-shared/src/utils/filter/turnRecordFilterGroupIntoGqlOperationFilter.ts
@@ -9,7 +9,7 @@ import {
 
 import { isDefined } from '@/utils';
 import {
-  type FindFieldMetadataItemById,
+  type FieldShared,
   turnRecordFilterIntoRecordGqlOperationFilter,
 } from '@/utils/filter/turnRecordFilterIntoGqlOperationFilter';
 
@@ -33,13 +33,13 @@ export type RecordFilterGroup = {
 export const turnRecordFilterGroupsIntoGqlOperationFilter = ({
   filterValueDependencies,
   filters,
-  findFieldMetadataItemById,
+  fieldMetadataItemById,
   recordFilterGroups,
   currentRecordFilterGroupId,
 }: {
   filterValueDependencies: RecordFilterValueDependencies;
   filters: Omit<RecordFilter, 'id'>[];
-  findFieldMetadataItemById: FindFieldMetadataItemById;
+  fieldMetadataItemById: Map<string, FieldShared>;
   recordFilterGroups: RecordFilterGroup[];
   currentRecordFilterGroupId?: string;
 }): RecordGqlOperationFilter | undefined => {
@@ -60,7 +60,7 @@ export const turnRecordFilterGroupsIntoGqlOperationFilter = ({
       turnRecordFilterIntoRecordGqlOperationFilter({
         filterValueDependencies,
         recordFilter: recordFilter,
-        findFieldMetadataItemById,
+        fieldMetadataItemById,
       }),
     )
     .filter(isDefined);
@@ -75,7 +75,7 @@ export const turnRecordFilterGroupsIntoGqlOperationFilter = ({
       turnRecordFilterGroupsIntoGqlOperationFilter({
         filterValueDependencies,
         filters,
-        findFieldMetadataItemById,
+        fieldMetadataItemById,
         recordFilterGroups,
         currentRecordFilterGroupId: subRecordFilterGroup.id,
       }),

--- a/packages/twenty-shared/src/utils/filter/turnRecordFilterIntoGqlOperationFilter.ts
+++ b/packages/twenty-shared/src/utils/filter/turnRecordFilterIntoGqlOperationFilter.ts
@@ -55,29 +55,27 @@ import { arrayOfStringsOrVariablesSchema } from '@/utils/filter/utils/validation
 import { arrayOfUuidOrVariableSchema } from '@/utils/filter/utils/validation-schemas/arrayOfUuidsOrVariablesSchema';
 import { jsonRelationFilterValueSchema } from '@/utils/filter/utils/validation-schemas/jsonRelationFilterValueSchema';
 
-type FieldShared = {
+export type FieldShared = {
   id: string;
   name: string;
   type: FieldMetadataType;
   label: string;
 };
 
-export type FindFieldMetadataItemById = (id: string) => FieldShared | undefined;
-
 type TurnRecordFilterIntoRecordGqlOperationFilterParams = {
   filterValueDependencies: RecordFilterValueDependencies;
   recordFilter: Omit<RecordFilter, 'id'>;
-  findFieldMetadataItemById: FindFieldMetadataItemById;
+  fieldMetadataItemById: Map<string, FieldShared>;
 };
 
 export const turnRecordFilterIntoRecordGqlOperationFilter = ({
   recordFilter,
-  findFieldMetadataItemById,
+  fieldMetadataItemById,
   filterValueDependencies,
 }: TurnRecordFilterIntoRecordGqlOperationFilterParams):
   | RecordGqlOperationFilter
   | undefined => {
-  const sourceFieldMetadataItem = findFieldMetadataItemById(
+  const sourceFieldMetadataItem = fieldMetadataItemById.get(
     recordFilter.fieldMetadataId,
   );
 
@@ -93,7 +91,7 @@ export const turnRecordFilterIntoRecordGqlOperationFilter = ({
     sourceFieldMetadataItem.type === FieldMetadataType.RELATION &&
     isDefined(recordFilter.relationTargetFieldMetadataId)
   ) {
-    const targetFieldMetadataItem = findFieldMetadataItemById(
+    const targetFieldMetadataItem = fieldMetadataItemById.get(
       recordFilter.relationTargetFieldMetadataId,
     );
 

--- a/packages/twenty-shared/src/utils/index.ts
+++ b/packages/twenty-shared/src/utils/index.ts
@@ -104,7 +104,7 @@ export type {
   RecordFilterGroup,
 } from './filter/turnRecordFilterGroupIntoGqlOperationFilter';
 export { turnRecordFilterGroupsIntoGqlOperationFilter } from './filter/turnRecordFilterGroupIntoGqlOperationFilter';
-export type { FindFieldMetadataItemById } from './filter/turnRecordFilterIntoGqlOperationFilter';
+export type { FieldShared } from './filter/turnRecordFilterIntoGqlOperationFilter';
 export { turnRecordFilterIntoRecordGqlOperationFilter } from './filter/turnRecordFilterIntoGqlOperationFilter';
 export { combineFilters } from './filter/utils/combineFilters';
 export { convertViewFilterOperandToCoreOperand } from './filter/utils/convert-view-filter-operand-to-core-operand.util';


### PR DESCRIPTION
## Summary

Alternative to #20717. Same goal (clean up the filter dispatcher API after #20670) but smaller and follows the codebase's "pass data, not behavior" style.

The dispatcher takes a `fieldMetadataItems: FieldShared[]` array directly instead of a `findFieldMetadataItemById: (id) => FieldShared | undefined` callback. The util builds the id lookup internally — once per call, used for both source-field and relation-target-field lookups. No new types, no separate hydration step.

## What changes

**`twenty-shared`**
- `computeRecordGqlOperationFilter` / `turnRecordFilterIntoRecordGqlOperationFilter` / `turnRecordFilterGroupsIntoGqlOperationFilter`: replace `findFieldMetadataItemById` param with `fieldMetadataItems` / `fieldMetadataItemById` (internal Map).
- Remove the exported `FindFieldMetadataItemById` type.
- `turnAnyFieldFilterIntoRecordGqlFilter`: rename its internal `fieldById` Map for consistency.
- Tests updated to pass arrays.

**Frontend (15 call sites)**
- Switch from `fieldMetadataItemByIdMapSelector` to `flattenedFieldMetadataItemsSelector`.
- Pass `fieldMetadataItems: flattenedFieldMetadataItems` to the dispatcher.
- `useFindManyRecordsSelectedInContextStore` keeps the Map selector because it still does a per-filter lookup for the soft-delete check.

**Server (5 call sites)**
- Pass `Object.values(flatFieldMetadataMaps.byUniversalIdentifier).filter(isDefined)`.

## Why this over #20717

#20717 moves resolution into a separate hydration step + introduces a `HydratedRecordFilter` type. The bug that #20717 originally surfaced was Sentry catching 4 critical runtime errors during review (`fieldMetadataItemByIdMap` declared but not passed). The added type and the explicit hydration boundary are extra surface area for not much benefit — the existing API was a callback wrapping a Map at every call site, and the natural simplification is to just pass the Map (or its array) directly.

Net diff: **196 insertions, 203 deletions** (~7 lines net removed). 32 files.

## Test plan
- [x] Shared filter unit tests pass (461 tests)
- [x] Frontend filter/context-store tests pass (13 tests)
- [x] Frontend typecheck passes
- [x] Server typecheck passes
- [x] Lint passes (frontend + server)
- [ ] Integration tests on #20670 still pass — workflow find-records + chart-data with relation-traversal filter still work end-to-end through the new array param