### PR TITLE
feat(website): migrate dev hostname website-new.twenty-main.com → website.twenty-main.com

### DIFF
--- a/packages/twenty-website/wrangler.jsonc
+++ b/packages/twenty-website/wrangler.jsonc
@@ -16,7 +16,7 @@
       "name": "twenty-website-dev",
       "routes": [
         {
-          "pattern": "website-new.twenty-main.com",
+          "pattern": "website.twenty-main.com",
           "custom_domain": true,
         },
       ],


### PR DESCRIPTION
## Summary
Last "-new" trace in the source repo, follow-up to the rename in #20745. The dev Worker custom domain swaps from `website-new.twenty-main.com` to `website.twenty-main.com`, matching the prod pattern (no "-new" anywhere).

## Live operations already performed
- Deleted the legacy CNAME at `website.twenty-main.com` that pointed at the dev EKS NLB (record id `52b4a4174dfd382ecf38111b7f08e642`, was the Docusaurus dev deploy that had been 503'ing)
- Redeployed `twenty-website-dev` Worker — Wrangler provisioned the new custom domain via the CF API
- Verified `https://website.twenty-main.com/` returns 200 with `x-opennext: 1` and `x-nextjs-cache: HIT`

The old hostname `website-new.twenty-main.com` is now unbound; Wrangler removed its DNS record when the route disappeared from this file. Visitors get 522, which is the desired state for a retired hostname.

## Companion infra PR
https://github.com/twentyhq/twenty-infra/pull/683 — removes `charts/dev/apps/website` Helm chart (the legacy Docusaurus deploy) + ArgoCD app, updates `cloudflare/website/dev.env` and `docs/4-environments.md`.

## Out of scope
- Legacy `website.twenty-staging.com` and `website.twenty.com` are still alive serving Docusaurus content. Decommissioning those is a separate decision (those URLs may still be linked externally).