### PR TITLE
fix(workflow): restore initial input fields on code step creation

### DIFF
--- a/packages/twenty-server/src/modules/workflow/workflow-builder/workflow-version-step/__tests__/workflow-version-step-operations.workspace-service.spec.ts
+++ b/packages/twenty-server/src/modules/workflow/workflow-builder/workflow-version-step/__tests__/workflow-version-step-operations.workspace-service.spec.ts
@@ -1,6 +1,8 @@
 import { Test, type TestingModule } from '@nestjs/testing';
 import { getRepositoryToken } from '@nestjs/typeorm';
 
+import { SEED_WORKFLOW_ACTION_TRIGGER_SETTINGS } from 'twenty-shared/logic-function';
+
 import { AiAgentRoleService } from 'src/engine/metadata-modules/ai/ai-agent-role/ai-agent-role.service';
 import { AgentService } from 'src/engine/metadata-modules/ai/ai-agent/agent.service';
 import { createEmptyAllFlatEntityMaps } from 'src/engine/metadata-modules/flat-entity/constant/create-empty-all-flat-entity-maps.constant';
@@ -55,7 +57,7 @@ describe('WorkflowVersionStepOperationsWorkspaceService', () => {
         handlerName: 'main',
         checksum: null,
         toolTriggerSettings: null,
-        workflowActionTriggerSettings: null,
+        workflowActionTriggerSettings: SEED_WORKFLOW_ACTION_TRIGGER_SETTINGS,
         universalIdentifier: 'universal-id',
         applicationId: 'application-id',
         cronTriggerSettings: null,
@@ -284,7 +286,7 @@ describe('WorkflowVersionStepOperationsWorkspaceService', () => {
   });
 
   describe('runStepCreationSideEffectsAndBuildStep', () => {
-    it('should create code step with logic function', async () => {
+    it('should create code step with logic function and seed input fields', async () => {
       const result = await service.runStepCreationSideEffectsAndBuildStep({
         type: WorkflowActionType.CODE,
         workspaceId: mockWorkspaceId,
@@ -296,11 +298,16 @@ describe('WorkflowVersionStepOperationsWorkspaceService', () => {
         settings: {
           input: {
             logicFunctionId: string;
+            logicFunctionInput: Record<string, unknown>;
           };
         };
       };
 
       expect(codeResult.settings.input.logicFunctionId).toBe('new-function-id');
+      expect(codeResult.settings.input.logicFunctionInput).toEqual({
+        a: null,
+        b: null,
+      });
     });
 
     it('should create form step', async () => {

--- a/packages/twenty-server/src/modules/workflow/workflow-builder/workflow-version-step/code-step/services/code-step-build.service.ts
+++ b/packages/twenty-server/src/modules/workflow/workflow-builder/workflow-version-step/code-step/services/code-step-build.service.ts
@@ -1,5 +1,6 @@
 import { Injectable } from '@nestjs/common';
 
+import { SEED_WORKFLOW_ACTION_TRIGGER_SETTINGS } from 'twenty-shared/logic-function';
 import { isDefined } from 'twenty-shared/utils';
 
 import { WorkspaceManyOrAllFlatEntityMapsCacheService } from 'src/engine/metadata-modules/flat-entity/services/workspace-many-or-all-flat-entity-maps-cache.service';
@@ -29,6 +30,7 @@ export class CodeStepBuildService {
         id: logicFunctionId,
         name: 'A Code Step',
         description: '',
+        workflowActionTriggerSettings: SEED_WORKFLOW_ACTION_TRIGGER_SETTINGS,
       },
       workspaceId,
     });

--- a/packages/twenty-shared/src/logic-function/constants/SeedWorkflowActionTriggerSettings.ts
+++ b/packages/twenty-shared/src/logic-function/constants/SeedWorkflowActionTriggerSettings.ts
@@ -1,0 +1,13 @@
+import { type WorkflowActionTriggerSettings } from '@/application';
+import { jsonSchemaToInputSchema } from '@/logic-function/json-schema-to-input-schema';
+
+export const SEED_WORKFLOW_ACTION_TRIGGER_SETTINGS: WorkflowActionTriggerSettings =
+  {
+    inputSchema: jsonSchemaToInputSchema({
+      type: 'object',
+      properties: {
+        a: { type: 'string' },
+        b: { type: 'number' },
+      },
+    }),
+  };

--- a/packages/twenty-shared/src/logic-function/index.ts
+++ b/packages/twenty-shared/src/logic-function/index.ts
@@ -8,6 +8,7 @@
  */
 
 export { DEFAULT_TOOL_INPUT_SCHEMA } from './constants/DefaultToolInputSchema';
+export { SEED_WORKFLOW_ACTION_TRIGGER_SETTINGS } from './constants/SeedWorkflowActionTriggerSettings';
 export { getInputSchemaFromSourceCode } from './get-input-schema-from-source-code';
 export { getOutputSchemaFromValue } from './get-output-schema-from-value';
 export type { InputJsonSchema } from './input-json-schema.type';


### PR DESCRIPTION
## Summary

- Fixes a regression from #20208 where creating a new CODE workflow step shows no input fields
- The split-triggers PR removed `SEED_LOGIC_FUNCTION_INPUT_SCHEMA` and replaced `toolInputSchema` with `workflowActionTriggerSettings`, but `CodeStepBuildService.createCodeStepLogicFunction` was not updated to pass the seed schema — causing `logicFunctionInput` to default to `{}` and no fields to render
- Adds `SEED_WORKFLOW_ACTION_TRIGGER_SETTINGS` constant (matching the seed template's `{ a: string, b: number }` params) and passes it when creating the seed logic function

## Test plan

- [x] Unit test updated to assert `logicFunctionInput` contains `{ a: null, b: null }` on code step creation
- [x] Create a new CODE step in the workflow builder and verify input fields `a` and `b` appear immediately