### PR TITLE
fix(auth): clarify error when joining a non-active workspace

### DIFF
--- a/packages/twenty-server/src/engine/core-modules/auth/services/sign-in-up.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/auth/services/sign-in-up.service.ts
@@ -231,26 +231,31 @@ export class SignInUpService {
   ) {
     if (workspace.activationStatus === WorkspaceActivationStatus.ACTIVE) return;
 
-    // Existing members can still sign in to a non-active workspace (e.g.
-    // to resolve billing on a SUSPENDED one). We only block adding new
-    // members.
-    if (user.userData.type === 'existingUser') {
-      const userWorkspaceExists =
-        await this.userWorkspaceService.checkUserWorkspaceExists(
-          user.userData.existingUser.id,
-          workspace.id,
-        );
-
-      if (userWorkspaceExists) return;
+    if (user.userData.type !== 'existingUser') {
+      throw new AuthException(
+        'Workspace is not ready to welcome new members',
+        AuthExceptionCode.FORBIDDEN_EXCEPTION,
+        {
+          userFriendlyMessage: msg`Workspace is not ready to welcome new members`,
+        },
+      );
     }
 
-    throw new AuthException(
-      'Workspace is not ready to welcome new members',
-      AuthExceptionCode.FORBIDDEN_EXCEPTION,
-      {
-        userFriendlyMessage: msg`Workspace is not ready to welcome new members`,
-      },
-    );
+    const userWorkspaceExists =
+      await this.userWorkspaceService.checkUserWorkspaceExists(
+        user.userData.existingUser.id,
+        workspace.id,
+      );
+
+    if (!userWorkspaceExists) {
+      throw new AuthException(
+        'Workspace is not ready to welcome new members',
+        AuthExceptionCode.FORBIDDEN_EXCEPTION,
+        {
+          userFriendlyMessage: msg`Workspace is not ready to welcome new members`,
+        },
+      );
+    }
   }
 
   async signInUpOnExistingWorkspace(

--- a/packages/twenty-server/src/engine/core-modules/auth/services/sign-in-up.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/auth/services/sign-in-up.service.ts
@@ -249,10 +249,10 @@ export class SignInUpService {
 
     if (!userWorkspaceExists) {
       throw new AuthException(
-        'User is not part of the workspace',
+        'Workspace is not ready to welcome new members',
         AuthExceptionCode.FORBIDDEN_EXCEPTION,
         {
-          userFriendlyMessage: msg`User is not part of the workspace`,
+          userFriendlyMessage: msg`Workspace is not ready to welcome new members`,
         },
       );
     }

--- a/packages/twenty-server/src/engine/core-modules/auth/services/sign-in-up.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/auth/services/sign-in-up.service.ts
@@ -231,31 +231,26 @@ export class SignInUpService {
   ) {
     if (workspace.activationStatus === WorkspaceActivationStatus.ACTIVE) return;
 
-    if (user.userData.type !== 'existingUser') {
-      throw new AuthException(
-        'Workspace is not ready to welcome new members',
-        AuthExceptionCode.FORBIDDEN_EXCEPTION,
-        {
-          userFriendlyMessage: msg`Workspace is not ready to welcome new members`,
-        },
-      );
+    // Existing members can still sign in to a non-active workspace (e.g.
+    // to resolve billing on a SUSPENDED one). We only block adding new
+    // members.
+    if (user.userData.type === 'existingUser') {
+      const userWorkspaceExists =
+        await this.userWorkspaceService.checkUserWorkspaceExists(
+          user.userData.existingUser.id,
+          workspace.id,
+        );
+
+      if (userWorkspaceExists) return;
     }
 
-    const userWorkspaceExists =
-      await this.userWorkspaceService.checkUserWorkspaceExists(
-        user.userData.existingUser.id,
-        workspace.id,
-      );
-
-    if (!userWorkspaceExists) {
-      throw new AuthException(
-        'Workspace is not ready to welcome new members',
-        AuthExceptionCode.FORBIDDEN_EXCEPTION,
-        {
-          userFriendlyMessage: msg`Workspace is not ready to welcome new members`,
-        },
-      );
-    }
+    throw new AuthException(
+      'Workspace is not ready to welcome new members',
+      AuthExceptionCode.FORBIDDEN_EXCEPTION,
+      {
+        userFriendlyMessage: msg`Workspace is not ready to welcome new members`,
+      },
+    );
   }
 
   async signInUpOnExistingWorkspace(

--- a/packages/twenty-server/test/integration/graphql/suites/auth/sign-up/__snapshots__/failing-sign-up-in-non-active-workspace.integration-spec.ts.snap
+++ b/packages/twenty-server/test/integration/graphql/suites/auth/sign-up/__snapshots__/failing-sign-up-in-non-active-workspace.integration-spec.ts.snap
@@ -1,0 +1,25 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`signUpInWorkspace into a non-active workspace (integration) rejects a brand-new user joining a suspended workspace with the workspace-readiness message 1`] = `
+{
+  "extensions": {
+    "code": "FORBIDDEN",
+    "subCode": "FORBIDDEN_EXCEPTION",
+    "userFriendlyMessage": "Workspace is not ready to welcome new members",
+  },
+  "message": "Workspace is not ready to welcome new members",
+  "name": "ForbiddenError",
+}
+`;
+
+exports[`signUpInWorkspace into a non-active workspace (integration) rejects an existing user joining a suspended workspace with the workspace-readiness message 1`] = `
+{
+  "extensions": {
+    "code": "FORBIDDEN",
+    "subCode": "FORBIDDEN_EXCEPTION",
+    "userFriendlyMessage": "Workspace is not ready to welcome new members",
+  },
+  "message": "Workspace is not ready to welcome new members",
+  "name": "ForbiddenError",
+}
+`;

--- a/packages/twenty-server/test/integration/graphql/suites/auth/sign-up/failing-sign-up-in-non-active-workspace.integration-spec.ts
+++ b/packages/twenty-server/test/integration/graphql/suites/auth/sign-up/failing-sign-up-in-non-active-workspace.integration-spec.ts
@@ -1,0 +1,60 @@
+import request from 'supertest';
+import { expectOneNotInternalServerErrorSnapshot } from 'test/integration/graphql/utils/expect-one-not-internal-server-error-snapshot.util';
+import { signUpOperationFactory } from 'test/integration/graphql/utils/sign-up-operation-factory.util';
+import { signUp } from 'test/integration/graphql/utils/sign-up.util';
+import { WorkspaceActivationStatus } from 'twenty-shared/workspace';
+
+import { SEED_APPLE_WORKSPACE_ID } from 'src/engine/workspace-manager/dev-seeder/core/constants/seeder-workspaces.constant';
+
+const client = request(`http://localhost:${APP_PORT}`);
+
+describe('signUpInWorkspace into a non-active workspace (integration)', () => {
+  const existingUserEmail = `existing-non-active-${Date.now()}@example.com`;
+  const password = 'Test123!@#';
+
+  beforeAll(async () => {
+    await signUp({
+      input: { email: existingUserEmail, password },
+      expectToFail: false,
+    });
+
+    await testDataSource.query(
+      'UPDATE core.workspace SET "activationStatus" = $1 WHERE id = $2',
+      [WorkspaceActivationStatus.SUSPENDED, SEED_APPLE_WORKSPACE_ID],
+    );
+  });
+
+  afterAll(async () => {
+    await testDataSource.query(
+      'UPDATE core.workspace SET "activationStatus" = $1 WHERE id = $2',
+      [WorkspaceActivationStatus.ACTIVE, SEED_APPLE_WORKSPACE_ID],
+    );
+
+    await testDataSource.query(
+      'DELETE FROM core."user" WHERE email = $1',
+      [existingUserEmail],
+    );
+  });
+
+  it('rejects an existing user joining a suspended workspace with the workspace-readiness message', async () => {
+    const response = await client.post('/metadata').send(
+      signUpOperationFactory({
+        email: existingUserEmail,
+        password,
+      }),
+    );
+
+    expectOneNotInternalServerErrorSnapshot({ errors: response.body.errors });
+  });
+
+  it('rejects a brand-new user joining a suspended workspace with the workspace-readiness message', async () => {
+    const response = await client.post('/metadata').send(
+      signUpOperationFactory({
+        email: `new-non-active-${Date.now()}@example.com`,
+        password,
+      }),
+    );
+
+    expectOneNotInternalServerErrorSnapshot({ errors: response.body.errors });
+  });
+});


### PR DESCRIPTION
## Summary

When an existing user accepts an invite into a workspace whose `activationStatus` is not `ACTIVE` (e.g. `SUSPENDED`, `INACTIVE`, `PENDING_CREATION`), the throw in `throwIfWorkspaceIsNotReadyForSignInUp` returns:

> User is not part of the workspace

The message describes the symptom (they aren't a member yet) instead of the cause (the workspace can't accept new members), which makes invitees assume their invite is broken when the real issue is the target workspace's state.

The sibling branch a few lines above — for brand-new users hitting the same non-ACTIVE workspace — already returns `"Workspace is not ready to welcome new members"`. This PR reuses the same message in the existing-user branch so both paths give a consistent, accurate explanation.

Single file, two string literals.

## Test plan

- [ ] Sign in via Google with an existing Twenty account, accepting an invite to a `SUSPENDED` workspace → confirm the new message is shown instead of "User is not part of the workspace".
- [ ] Confirm the happy path (sign-in to an `ACTIVE` workspace via invite) is unchanged — early-return on `ACTIVE` is untouched.