### PR TITLE
fix(security): use textContent instead of innerHTML for script injection

### DIFF
--- a/packages/twenty-front/src/modules/support/hooks/useInstantiateSupportChat.ts
+++ b/packages/twenty-front/src/modules/support/hooks/useInstantiateSupportChat.ts
@@ -20,7 +20,7 @@ const insertScript = ({
 }) => {
   const script = document.createElement('script');
   if (isNonEmptyString(src)) script.src = src;
-  if (isNonEmptyString(innerHTML)) script.innerHTML = innerHTML;
+  if (isNonEmptyString(innerHTML)) script.textContent = innerHTML;
   if (isDefined(onLoad)) script.onload = onLoad;
   script.defer = defer;
   document.body.appendChild(script);


### PR DESCRIPTION
## Summary
- Replace `script.innerHTML = innerHTML` with `script.textContent = innerHTML` in `packages/twenty-front/src/modules/support/hooks/useInstantiateSupportChat.ts`
- `innerHTML` parses the value as HTML, which means if the `innerHTML` parameter contains user-controlled data or is sourced from an untrusted config, it could execute arbitrary JavaScript (XSS)
- `textContent` is the correct API for setting inline script text — it treats the value as plain text, not HTML

## Security Impact
**MEDIUM** — If `innerHTML` is ever populated from an untrusted source, this is an XSS vector. Even if currently safe, using `textContent` is the correct practice for script tag content.

## Test plan
- [ ] Verify support chat (Front) still loads and initializes correctly
- [ ] Verify inline script configuration is applied as expected

🤖 Generated with [Claude Code](https://claude.com/claude-code)