### PR TITLE
fix: add timeout to ClickHouse client initialization busy-wait

### DIFF
--- a/packages/twenty-server/src/database/clickHouse/clickHouse.service.ts
+++ b/packages/twenty-server/src/database/clickHouse/clickHouse.service.ts
@@ -51,8 +51,17 @@ export class ClickHouseService implements OnModuleInit, OnModuleDestroy {
     }
 
     // Wait for a bit before trying again if another initialization is in progress
-    while (this.isClientInitializing.get(clientId)) {
-      await new Promise((resolve) => setTimeout(resolve, 10));
+    let retries = 0;
+    while (this.isClientInitializing.get(clientId) && retries < 300) {
+      await new Promise((resolve) => setTimeout(resolve, 100));
+      retries++;
+    }
+
+    if (this.isClientInitializing.get(clientId)) {
+      this.logger.error(
+        `Timeout waiting for ClickHouse client ${clientId} initialization`,
+      );
+      return undefined;
     }
 
     if (this.clients.has(clientId)) {


### PR DESCRIPTION
## Summary
- Add a 30-second timeout to the busy-wait loop in `ClickHouseService.connectToClient()` (`packages/twenty-server/src/database/clickHouse/clickHouse.service.ts`)
- Previously, if `isClientInitializing` was never cleared (e.g. due to a network hang or unexpected error), the `while` loop would spin forever, consuming CPU and blocking the request
- Now uses 300 retries × 100ms = 30s timeout, after which it logs an error and returns `undefined` instead of hanging

## Impact
**HIGH** — Without this fix, a stuck ClickHouse initialization can hang the server indefinitely.

## Test plan
- [ ] Verify ClickHouse connections still work normally
- [ ] Verify that a stuck initialization is properly handled with a timeout and error log

🤖 Generated with [Claude Code](https://claude.com/claude-code)