### PR TITLE
fix: guard against NaN from non-numeric PG timeout env vars

### DIFF
--- a/packages/twenty-server/src/database/typeorm/core/core.datasource.ts
+++ b/packages/twenty-server/src/database/typeorm/core/core.datasource.ts
@@ -72,8 +72,8 @@ export const typeORMCoreModuleOptions: TypeOrmModuleOptions = {
         }
       : undefined,
   extra: {
-    query_timeout: Number(process.env.PG_DATABASE_PRIMARY_TIMEOUT_MS ?? 10000),
-    idleTimeoutMillis: Number(process.env.PG_POOL_IDLE_TIMEOUT_MS ?? 600000),
+    query_timeout: Number(process.env.PG_DATABASE_PRIMARY_TIMEOUT_MS ?? 10000) || 10000,
+    idleTimeoutMillis: Number(process.env.PG_POOL_IDLE_TIMEOUT_MS ?? 600000) || 600000,
     allowExitOnIdle: process.env.PG_POOL_ALLOW_EXIT_ON_IDLE === 'true',
   },
 };


### PR DESCRIPTION
## Summary
- Add NaN guard for `query_timeout` and `idleTimeoutMillis` in `packages/twenty-server/src/database/typeorm/core/core.datasource.ts`
- `Number(process.env.PG_DATABASE_PRIMARY_TIMEOUT_MS)` returns `NaN` if the env var contains a non-numeric string (e.g. `"10s"` or an accidental space)
- NaN timeouts cause TypeORM/pg to use undefined timeout behavior, which can manifest as connections that never time out or immediate failures
- Added `|| defaultValue` fallback to ensure valid numeric values are always used

## Test plan
- [ ] Verify database connections work with valid env vars
- [ ] Verify database connections fall back to defaults when env vars are missing or non-numeric

🤖 Generated with [Claude Code](https://claude.com/claude-code)