### PR TITLE
fix: remove duplicate syncCursor DB update in calendar event fetch

### DIFF
--- a/packages/twenty-server/src/modules/calendar/calendar-event-import-manager/services/calendar-fetch-events.service.ts
+++ b/packages/twenty-server/src/modules/calendar/calendar-event-import-manager/services/calendar-fetch-events.service.ts
@@ -88,13 +88,6 @@ export class CalendarFetchEventsService {
           const nextSyncCursor = getCalendarEventsResponse.nextSyncCursor;
 
           if (!calendarEvents || calendarEvents?.length === 0) {
-            await this.calendarChannelRepository.update(
-              { id: calendarChannel.id, workspaceId },
-              {
-                syncCursor: nextSyncCursor,
-              },
-            );
-
             await this.calendarChannelSyncStatusService.markAsCalendarEventListFetchPending(
               [calendarChannel.id],
               workspaceId,


### PR DESCRIPTION
## Summary
- Remove a redundant `calendarChannelRepository.update()` call in `packages/twenty-server/src/modules/calendar/calendar-event-import-manager/services/calendar-fetch-events.service.ts`
- The `syncCursor` was being updated **twice** when `calendarEvents` was empty: once inside the `if (!calendarEvents || calendarEvents?.length === 0)` block and once unconditionally after it
- The unconditional update on line 104-109 already covers all cases (empty and non-empty events), making the one inside the if block redundant
- Removed the duplicate DB write to reduce unnecessary database load during calendar sync

## How I found this
The duplicate update is clearly visible — lines 91-96 and 104-109 perform the exact same repository update with the same values.

## Test plan
- [ ] Verify calendar event sync still works correctly when no events are returned
- [ ] Verify calendar event sync still works correctly when events are returned
- [ ] Verify syncCursor is correctly persisted in both cases

🤖 Generated with [Claude Code](https://claude.com/claude-code)