### PR TITLE
fix(front): focus new Field widget and open side panel on add

### DIFF
--- a/packages/twenty-front/src/modules/page-layout/hooks/useCreateRecordPageFieldWidget.ts
+++ b/packages/twenty-front/src/modules/page-layout/hooks/useCreateRecordPageFieldWidget.ts
@@ -3,14 +3,17 @@ import { isDefined } from 'twenty-shared/utils';
 import { usePageLayoutContentContext } from '@/page-layout/contexts/PageLayoutContentContext';
 import { useCurrentPageLayoutOrThrow } from '@/page-layout/hooks/useCurrentPageLayoutOrThrow';
 import { pageLayoutDraftComponentState } from '@/page-layout/states/pageLayoutDraftComponentState';
+import { pageLayoutEditingWidgetIdComponentState } from '@/page-layout/states/pageLayoutEditingWidgetIdComponentState';
 import { addWidgetToTab } from '@/page-layout/utils/addWidgetToTab';
 import { createDefaultFieldWidget } from '@/page-layout/utils/createDefaultFieldWidget';
 import { useFieldWidgetEligibleFields } from '@/page-layout/widgets/field/hooks/useFieldWidgetEligibleFields';
 import { getFieldWidgetDefaultDisplayMode } from '@/page-layout/widgets/field/utils/getFieldWidgetDisplayModeConfig';
+import { useNavigatePageLayoutSidePanel } from '@/side-panel/pages/page-layout/hooks/useNavigatePageLayoutSidePanel';
 import { useTargetRecord } from '@/ui/layout/contexts/useTargetRecord';
 import { useAtomComponentStateCallbackState } from '@/ui/utilities/state/jotai/hooks/useAtomComponentStateCallbackState';
 import { useStore } from 'jotai';
 import { useCallback } from 'react';
+import { SidePanelPages } from 'twenty-shared/types';
 import { v4 as uuidv4 } from 'uuid';
 import { WidgetConfigurationType } from '~/generated-metadata/graphql';
 
@@ -32,6 +35,12 @@ export const useCreateRecordPageFieldWidget = () => {
   const pageLayoutDraftState = useAtomComponentStateCallbackState(
     pageLayoutDraftComponentState,
   );
+
+  const pageLayoutEditingWidgetIdState = useAtomComponentStateCallbackState(
+    pageLayoutEditingWidgetIdComponentState,
+  );
+
+  const { navigatePageLayoutSidePanel } = useNavigatePageLayoutSidePanel();
 
   const store = useStore();
 
@@ -82,11 +91,21 @@ export const useCreateRecordPageFieldWidget = () => {
       ...prev,
       tabs: addWidgetToTab(prev.tabs, tabId, newWidget),
     }));
+
+    store.set(pageLayoutEditingWidgetIdState, widgetId);
+
+    navigatePageLayoutSidePanel({
+      sidePanelPage: SidePanelPages.RecordPageFieldSettings,
+      focusTitleInput: true,
+      resetNavigationStack: true,
+    });
   }, [
     allFieldWidgetFields,
     currentPageLayout.tabs,
+    navigatePageLayoutSidePanel,
     objectMetadataItem.id,
     pageLayoutDraftState,
+    pageLayoutEditingWidgetIdState,
     store,
     tabId,
   ]);


### PR DESCRIPTION
## Context
In the record-page edit mode, the "Add widget" section has three menu items:
`Fields group`, `Field`, and `More widgets`. `Fields group` creates the widget, focuses it, and opens its settings side panel. `Field` only added the widget to the draft — no focus, no panel — which left the user without visible confirmation or a way to immediately edit the new widget.

## Change
Updated `useCreateRecordPageFieldWidget` to mirror `useCreateRecordPageFieldsWidget`: 
After appending the new widget to the draft, it now sets `pageLayoutEditingWidgetIdComponentState` to the new widget's id and navigates the side panel to `SidePanelPages.RecordPageFieldSettings` (with `focusTitleInput: true`, `resetNavigationStack: true`).
This matches the behavior of clicking an existing field widget in `useOpenWidgetSettingsInSidePanel` (`WidgetType.FIELD` branch).
