### PR TITLE
Set website default port to 3002

### DIFF
--- a/packages/twenty-website/package.json
+++ b/packages/twenty-website/package.json
@@ -3,9 +3,9 @@
   "private": true,
   "scripts": {
     "nx": "NX_DEFAULT_PROJECT=twenty-website node ../../node_modules/nx/bin/nx.js",
-    "dev": "npx next dev",
+    "dev": "npx next dev --port 3002",
     "build": "npx next build",
-    "start": "npx next start",
+    "start": "npx next start --port 3002",
     "convert-images": "node ./scripts/convert-png-to-webp.mjs",
     "preview": "opennextjs-cloudflare build && opennextjs-cloudflare preview",
     "deploy:dev": "opennextjs-cloudflare build && opennextjs-cloudflare deploy --env dev",

--- a/packages/twenty-website/project.json
+++ b/packages/twenty-website/project.json
@@ -21,7 +21,7 @@
       "cache": false,
       "options": {
         "cwd": "{projectRoot}",
-        "command": "npx next dev"
+        "command": "npx next dev --port 3002"
       }
     },
     "start": {
@@ -30,7 +30,7 @@
       "dependsOn": ["build"],
       "options": {
         "cwd": "{projectRoot}",
-        "command": "npx next start"
+        "command": "npx next start --port 3002"
       }
     },
     "check-boundaries": {


### PR DESCRIPTION
## Summary

- Set `twenty-website`'s `dev` script to run Next.js on port `3002` by default.
- Set `twenty-website`'s `start` script to use the same default port.

## Why

`twenty-website` previously inherited Next.js' default port `3000`, which is also Twenty's backend/server default. The main Twenty frontend already defaults to `3001`, so using `3002` for the website avoids local port collisions when running the website next to the app server and frontend.

This keeps the local convention sequential:

- `3000`: Twenty backend/server
- `3001`: Twenty frontend app
- `3002`: Twenty website

## Validation

- Parsed `packages/twenty-website/package.json` successfully with Node.
- Ran `git diff --check` for the changed package file.
- Verified Next.js supports the `--port` option for `next dev`.