### PR TITLE
chore(deps): bump @xmldom/xmldom to 0.8.13 (security)

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -25915,17 +25915,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@xmldom/xmldom@npm:^0.8.10, @xmldom/xmldom@npm:^0.8.5":
-  version: 0.8.10
-  resolution: "@xmldom/xmldom@npm:0.8.10"
-  checksum: 10c0/c7647c442502720182b0d65b17d45d2d95317c1c8c497626fe524bda79b4fb768a9aa4fae2da919f308e7abcff7d67c058b102a9d641097e9a57f0b80187851f
-  languageName: node
-  linkType: hard
-
-"@xmldom/xmldom@npm:^0.8.8":
-  version: 0.8.11
-  resolution: "@xmldom/xmldom@npm:0.8.11"
-  checksum: 10c0/e768623de72c95d3dae6b5da8e33dda0d81665047811b5498d23a328d45b13feb5536fe921d0308b96a4a8dd8addf80b1f6ef466508051c0b581e63e0dc74ed5
+"@xmldom/xmldom@npm:^0.8.10, @xmldom/xmldom@npm:^0.8.5, @xmldom/xmldom@npm:^0.8.8":
+  version: 0.8.13
+  resolution: "@xmldom/xmldom@npm:0.8.13"
+  checksum: 10c0/06405ee6fffba631abf715a305ace338420ebcea8baf1317f19f2752f5c505952b7df45159908e7be8451a42faa54326b780616ab4d08242b20477b2973da24b
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary
- Re-resolves the transitive `@xmldom/xmldom` dependency to `0.8.13` to fix four high-severity Dependabot alerts.
- yarn.lock-only change: all four upstream consumers (`@node-saml/node-saml`, `plist`, `xml-crypto`, `xml-encryption`) accept `^0.8.x`, so the previous `0.8.10` / `0.8.11` entries collapse onto a single `0.8.13` resolution. No `package.json` change needed.

## Alerts fixed
-  XML node injection through unvalidated comment serialization (high)
- XML node injection through unvalidated processing instruction serialization (high)
- XML injection through unvalidated DocumentType serialization (high)
- Uncontrolled recursion in XML serialization leads to DoS (high)

All four advisories are patched in `0.8.13`, the latest release in the `0.8.x` line.

