### PR TITLE
fix(docker): pin patched curl/nghttp2/postgresql18-client apk versions

### DIFF
--- a/packages/twenty-docker/twenty/Dockerfile
+++ b/packages/twenty-docker/twenty/Dockerfile
@@ -86,7 +86,11 @@ RUN if [ -d /app/packages/twenty-front/build ]; then \
 
 FROM node:24.15.0-alpine3.23@sha256:d1b3b4da11eefd5941e7f0b9cf17783fc99d9c6fc34884a665f40a06dbdfc94f AS twenty-server
 
-RUN apk add --no-cache curl jq postgresql-client
+RUN apk add --no-cache \
+    'curl>=8.19.0-r0' \
+    'nghttp2-libs>=1.69.0-r0' \
+    'postgresql18-client>=18.4-r0' \
+    jq
 
 COPY ./packages/twenty-docker/twenty/entrypoint.sh /app/entrypoint.sh
 RUN chmod +x /app/entrypoint.sh


### PR DESCRIPTION
## Summary

- ECR Inspector still flags `prod-twenty` for the High-severity CVEs that PR #20603 was meant to fix (8x `postgresql18-18.3-r0`, `nghttp2-1.68.0-r0`, `curl-8.17.0-r1`, plus the related Medium `curl` CVE).
- Root cause: PR #20603 pinned the `node:24.15.0-alpine3.23` digest to invalidate the buildx GHA cache once, but the cache layer was first repopulated (on the PR branch) before Alpine 3.23 published `18.4-r0` / `1.69.0-r0` / `8.19.0-r0`. Every build since — including today's prod v2.6.2 — hits `#26 [twenty-server 2/19] RUN apk add --no-cache curl jq postgresql-client / #26 CACHED` and ships the stale packages.
- Pinning minimum versions in the `apk add` spec changes the RUN text → forces a new buildx cache key → apk re-resolves against the current Alpine mirror. apk also refuses to install anything below the floor, so the image can't silently regress if a stale layer ever matches the key again.

