### PR TITLE
fix(api-keys): refresh API keys list after key creation

### DIFF
--- a/packages/twenty-front/src/pages/settings/developers/api-keys/SettingsDevelopersApiKeysNew.tsx
+++ b/packages/twenty-front/src/pages/settings/developers/api-keys/SettingsDevelopersApiKeysNew.tsx
@@ -21,6 +21,7 @@ import { Section } from 'twenty-ui/layout';
 import {
   CreateApiKeyDocument,
   GenerateApiKeyTokenDocument,
+  GetApiKeysDocument,
   GetRolesDocument,
 } from '~/generated-metadata/graphql';
 import { useNavigateSettings } from '~/hooks/useNavigateSettings';
@@ -58,7 +59,10 @@ export const SettingsDevelopersApiKeysNew = () => {
     }
   }, [rolesData]);
 
-  const [createApiKey] = useMutation(CreateApiKeyDocument);
+  const [createApiKey] = useMutation(CreateApiKeyDocument, {
+    refetchQueries: [GetApiKeysDocument],
+    awaitRefetchQueries: true,
+  });
 
   const jotaiStore = useStore();
 


### PR DESCRIPTION

New API keys are created successfully but the API keys table can keep showing a stale pre-create result, so users think the key vanished. This blocks key management from the expected UI flow.

Fix: Updated the API key creation mutation to explicitly synchronize Apollo cache for the API keys list:

- In `SettingsDevelopersApiKeysNew.tsx`, imported `GetApiKeysDocument`.
- Changed `useMutation(CreateApiKeyDocument)` to:
  - `refetchQueries: [GetApiKeysDocument]`
  - `awaitRefetchQueries: true`

Why: the list page (`SettingsApiKeysTable`) reads from `GetApiKeysDocument`, and creation previously did not invalidate/refetch that query. With this change, successful creation refreshes the list query so the new key appears when the user returns to APIs & Webhooks.

Validation attempted:
- `npx nx lint:diff-with-main twenty-front` → failed due missing Nx modules in this environment.
- `npx nx typecheck twenty-front` → failed due missing Nx modules in this environment.

Authored by Sonarly by autonomous analysis (run 44851).