### PR TITLE
Fix workflow cron trigger cache stuck without TTL

### DIFF
--- a/packages/twenty-server/src/engine/core-modules/cache-storage/services/cache-storage.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/cache-storage/services/cache-storage.service.ts
@@ -342,6 +342,37 @@ end`;
     }) as Promise<number>;
   }
 
+  // Atomic HSET + PEXPIRE. Use when the caller must guarantee that the key
+  // is never observable without a TTL — otherwise a crash between a plain
+  // hashSet and a follow-up expire() can leave the key alive forever.
+  async hashSetWithExpire({
+    key,
+    field,
+    value,
+    ttlMs,
+  }: {
+    key: string;
+    field: string;
+    value: string;
+    ttlMs: Milliseconds;
+  }): Promise<number> {
+    if (!this.isRedisCache()) {
+      throw new Error('hashSetWithExpire is only supported with Redis cache');
+    }
+
+    const redisClient = (this.cache as RedisCache).store.client;
+
+    const script = `
+local result = redis.call('HSET', KEYS[1], ARGV[1], ARGV[2])
+redis.call('PEXPIRE', KEYS[1], ARGV[3])
+return result`;
+
+    return redisClient.eval(script, {
+      keys: [this.getKey(key)],
+      arguments: [field, value, String(ttlMs)],
+    }) as Promise<number>;
+  }
+
   async hashDelete({
     key,
     field,

--- a/packages/twenty-server/src/modules/workflow/workflow-trigger/automated-trigger/crons/jobs/__tests__/workflow-cron-trigger-cron.job.spec.ts
+++ b/packages/twenty-server/src/modules/workflow/workflow-trigger/automated-trigger/crons/jobs/__tests__/workflow-cron-trigger-cron.job.spec.ts
@@ -31,8 +31,7 @@ const mockExceptionHandlerService = {
 
 const mockCacheStorageService = {
   hashGetValues: jest.fn(),
-  hashSet: jest.fn(),
-  expire: jest.fn(),
+  hashSetWithExpire: jest.fn(),
 };
 
 describe('WorkflowCronTriggerCronJob', () => {
@@ -155,7 +154,7 @@ describe('WorkflowCronTriggerCronJob', () => {
 
       await job.handle();
 
-      expect(mockCacheStorageService.hashSet).not.toHaveBeenCalled();
+      expect(mockCacheStorageService.hashSetWithExpire).not.toHaveBeenCalled();
     });
   });
 
@@ -175,7 +174,7 @@ describe('WorkflowCronTriggerCronJob', () => {
       expect(mockCoreDataSource.query).toHaveBeenCalledTimes(3);
     });
 
-    it('should write each trigger to cache immediately and set TTL', async () => {
+    it('should write each trigger to cache atomically with TTL', async () => {
       mockCacheStorageService.hashGetValues.mockResolvedValue([]);
       mockWorkspaceRepository.find.mockResolvedValue([
         { id: WORKSPACE_1 },
@@ -202,8 +201,10 @@ describe('WorkflowCronTriggerCronJob', () => {
 
       await job.handle();
 
-      expect(mockCacheStorageService.hashSet).toHaveBeenCalledTimes(2);
-      expect(mockCacheStorageService.hashSet).toHaveBeenCalledWith({
+      expect(mockCacheStorageService.hashSetWithExpire).toHaveBeenCalledTimes(
+        2,
+      );
+      expect(mockCacheStorageService.hashSetWithExpire).toHaveBeenCalledWith({
         key: WORKFLOW_CRON_TRIGGER_CACHE_KEY,
         field: 'workflow-1',
         value: JSON.stringify({
@@ -211,8 +212,9 @@ describe('WorkflowCronTriggerCronJob', () => {
           workflowId: 'workflow-1',
           pattern: '* * * * *',
         }),
+        ttlMs: WORKFLOW_CRON_TRIGGER_CACHE_TTL_MS,
       });
-      expect(mockCacheStorageService.hashSet).toHaveBeenCalledWith({
+      expect(mockCacheStorageService.hashSetWithExpire).toHaveBeenCalledWith({
         key: WORKFLOW_CRON_TRIGGER_CACHE_KEY,
         field: 'workflow-2',
         value: JSON.stringify({
@@ -220,11 +222,8 @@ describe('WorkflowCronTriggerCronJob', () => {
           workflowId: 'workflow-2',
           pattern: '* * * * *',
         }),
+        ttlMs: WORKFLOW_CRON_TRIGGER_CACHE_TTL_MS,
       });
-      expect(mockCacheStorageService.expire).toHaveBeenCalledWith(
-        WORKFLOW_CRON_TRIGGER_CACHE_KEY,
-        WORKFLOW_CRON_TRIGGER_CACHE_TTL_MS,
-      );
     });
 
     it('should not write to cache when no workspaces have cron triggers', async () => {
@@ -234,8 +233,7 @@ describe('WorkflowCronTriggerCronJob', () => {
 
       await job.handle();
 
-      expect(mockCacheStorageService.hashSet).not.toHaveBeenCalled();
-      expect(mockCacheStorageService.expire).not.toHaveBeenCalled();
+      expect(mockCacheStorageService.hashSetWithExpire).not.toHaveBeenCalled();
     });
   });
 

--- a/packages/twenty-server/src/modules/workflow/workflow-trigger/automated-trigger/crons/jobs/workflow-cron-trigger-cron.job.ts
+++ b/packages/twenty-server/src/modules/workflow/workflow-trigger/automated-trigger/crons/jobs/workflow-cron-trigger-cron.job.ts
@@ -125,20 +125,18 @@ export class WorkflowCronTriggerCronJob {
       );
 
       for (const trigger of triggersToCache) {
-        await this.cacheStorageService.hashSet({
+        // Atomic HSET + PEXPIRE so the cache key can never exist without a
+        // TTL. If the worker crashed between hashSet and a separate expire(),
+        // the key would persist forever, every subsequent tick would take the
+        // cache-hit branch, and the DB-scan path would never run again.
+        await this.cacheStorageService.hashSetWithExpire({
           key: WORKFLOW_CRON_TRIGGER_CACHE_KEY,
           field: trigger.workflowId,
           value: JSON.stringify(trigger),
+          ttlMs: WORKFLOW_CRON_TRIGGER_CACHE_TTL_MS,
         });
         triggerCount++;
       }
-    }
-
-    if (triggerCount > 0) {
-      await this.cacheStorageService.expire(
-        WORKFLOW_CRON_TRIGGER_CACHE_KEY,
-        WORKFLOW_CRON_TRIGGER_CACHE_TTL_MS,
-      );
     }
 
     this.logger.log(`Cache rebuilt with ${triggerCount} cron triggers`);


### PR DESCRIPTION
## Problem

The cron-trigger cache key (`module:workflow:workflow-cron-triggers`) can get stuck without a TTL, silently halting **all** cron-triggered workflows for a whole tenant until the key is manually deleted from Redis.

Repro path:

1. Cache miss → DB-scan branch runs.
2. Inner loop writes triggers via `hashSet` (creates the key, **no TTL yet**).
3. Worker crashes / OOMs / gets killed by a deploy between any `hashSet` and the trailing `expire(1h)` call.
4. Key now exists with TTL = `-1` and a partial set of fields.
5. Next tick: `hashGetValues` returns those fields → `cachedValues.length > 0` → **cache-hit branch** → `expire` is never called.
6. Key has no TTL, so it never auto-expires. The DB-scan branch never runs again. New / missing triggers are never picked up. Workflows go silent.

Observed in production: cache key with `TTL: no limit` and 121 fields. Deleting the key restored normal behaviour (next tick rebuilt with TTL ~3600).

## Fix

Make the write + TTL set **atomic** so the key can never be observable without a TTL.

- Add `CacheStorageService.hashSetWithExpire` that runs `HSET` + `PEXPIRE` in a single Lua `EVAL`, mirroring the existing `hashSetIfExists` pattern.
- Replace the `hashSet` + trailing `expire` pair in `WorkflowCronTriggerCronJob` with `hashSetWithExpire`, called per trigger.
- Drop the now-redundant `if (triggerCount > 0) expire(...)` block.

## Test plan

- [x] `workflow-cron-trigger-cron.job.spec.ts` updated; all 10 tests pass
- [x] `oxlint` + `prettier` clean on changed files
- [ ] Verify on the affected self-hosted instance: after this lands, deleting the key once more (or letting it expire) should produce a key whose TTL is always set and refreshed each hour

Made with [Cursor](https://cursor.com)