### PR TITLE
Fix workflow cron trigger cache stuck without TTL

### DIFF
--- a/packages/twenty-server/src/engine/core-modules/cache-storage/services/cache-storage.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/cache-storage/services/cache-storage.service.ts
@@ -342,6 +342,31 @@ end`;
     }) as Promise<number>;
   }
 
+  async hashSetWithExpire({
+    key,
+    field,
+    value,
+    ttlMs,
+  }: {
+    key: string;
+    field: string;
+    value: string;
+    ttlMs: Milliseconds;
+  }): Promise<void> {
+    if (!this.isRedisCache()) {
+      throw new Error('hashSetWithExpire is only supported with Redis cache');
+    }
+
+    const redisClient = (this.cache as RedisCache).store.client;
+    const prefixedKey = this.getKey(key);
+
+    await redisClient
+      .multi()
+      .hSet(prefixedKey, field, value)
+      .pExpire(prefixedKey, ttlMs)
+      .exec();
+  }
+
   async hashDelete({
     key,
     field,

--- a/packages/twenty-server/src/engine/core-modules/cache-storage/services/cache-storage.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/cache-storage/services/cache-storage.service.ts
@@ -342,34 +342,6 @@ end`;
     }) as Promise<number>;
   }
 
-  async hashSetWithExpire({
-    key,
-    field,
-    value,
-    ttlMs,
-  }: {
-    key: string;
-    field: string;
-    value: string;
-    ttlMs: Milliseconds;
-  }): Promise<number> {
-    if (!this.isRedisCache()) {
-      throw new Error('hashSetWithExpire is only supported with Redis cache');
-    }
-
-    const redisClient = (this.cache as RedisCache).store.client;
-
-    const script = `
-local result = redis.call('HSET', KEYS[1], ARGV[1], ARGV[2])
-redis.call('PEXPIRE', KEYS[1], ARGV[3])
-return result`;
-
-    return redisClient.eval(script, {
-      keys: [this.getKey(key)],
-      arguments: [field, value, String(ttlMs)],
-    }) as Promise<number>;
-  }
-
   async hashDelete({
     key,
     field,

--- a/packages/twenty-server/src/engine/core-modules/cache-storage/services/cache-storage.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/cache-storage/services/cache-storage.service.ts
@@ -342,6 +342,34 @@ end`;
     }) as Promise<number>;
   }
 
+  async hashSetWithExpire({
+    key,
+    field,
+    value,
+    ttlMs,
+  }: {
+    key: string;
+    field: string;
+    value: string;
+    ttlMs: Milliseconds;
+  }): Promise<number> {
+    if (!this.isRedisCache()) {
+      throw new Error('hashSetWithExpire is only supported with Redis cache');
+    }
+
+    const redisClient = (this.cache as RedisCache).store.client;
+
+    const script = `
+local result = redis.call('HSET', KEYS[1], ARGV[1], ARGV[2])
+redis.call('PEXPIRE', KEYS[1], ARGV[3])
+return result`;
+
+    return redisClient.eval(script, {
+      keys: [this.getKey(key)],
+      arguments: [field, value, String(ttlMs)],
+    }) as Promise<number>;
+  }
+
   async hashDelete({
     key,
     field,

--- a/packages/twenty-server/src/modules/workflow/workflow-trigger/automated-trigger/crons/jobs/__tests__/workflow-cron-trigger-cron.job.spec.ts
+++ b/packages/twenty-server/src/modules/workflow/workflow-trigger/automated-trigger/crons/jobs/__tests__/workflow-cron-trigger-cron.job.spec.ts
@@ -32,7 +32,7 @@ const mockExceptionHandlerService = {
 const mockCacheStorageService = {
   hashGetValues: jest.fn(),
   hashSet: jest.fn(),
-  expire: jest.fn(),
+  hashSetWithExpire: jest.fn(),
 };
 
 describe('WorkflowCronTriggerCronJob', () => {
@@ -156,7 +156,7 @@ describe('WorkflowCronTriggerCronJob', () => {
       await job.handle();
 
       expect(mockCacheStorageService.hashSet).not.toHaveBeenCalled();
-      expect(mockCacheStorageService.expire).not.toHaveBeenCalled();
+      expect(mockCacheStorageService.hashSetWithExpire).not.toHaveBeenCalled();
     });
   });
 
@@ -176,7 +176,7 @@ describe('WorkflowCronTriggerCronJob', () => {
       expect(mockCoreDataSource.query).toHaveBeenCalledTimes(3);
     });
 
-    it('should write all triggers to cache and set TTL exactly once, right after the first write', async () => {
+    it('should use hashSetWithExpire for the first trigger and hashSet for the rest', async () => {
       mockCacheStorageService.hashGetValues.mockResolvedValue([]);
       mockWorkspaceRepository.find.mockResolvedValue([
         { id: WORKSPACE_1 },
@@ -203,17 +203,21 @@ describe('WorkflowCronTriggerCronJob', () => {
 
       const callOrder: string[] = [];
 
+      mockCacheStorageService.hashSetWithExpire.mockImplementation(
+        ({ field }) => {
+          callOrder.push(`hashSetWithExpire:${field}`);
+        },
+      );
       mockCacheStorageService.hashSet.mockImplementation(({ field }) => {
         callOrder.push(`hashSet:${field}`);
-      });
-      mockCacheStorageService.expire.mockImplementation(() => {
-        callOrder.push('expire');
       });
 
       await job.handle();
 
-      expect(mockCacheStorageService.hashSet).toHaveBeenCalledTimes(2);
-      expect(mockCacheStorageService.hashSet).toHaveBeenCalledWith({
+      expect(mockCacheStorageService.hashSetWithExpire).toHaveBeenCalledTimes(
+        1,
+      );
+      expect(mockCacheStorageService.hashSetWithExpire).toHaveBeenCalledWith({
         key: WORKFLOW_CRON_TRIGGER_CACHE_KEY,
         field: 'workflow-1',
         value: JSON.stringify({
@@ -221,7 +225,10 @@ describe('WorkflowCronTriggerCronJob', () => {
           workflowId: 'workflow-1',
           pattern: '* * * * *',
         }),
+        ttlMs: WORKFLOW_CRON_TRIGGER_CACHE_TTL_MS,
       });
+
+      expect(mockCacheStorageService.hashSet).toHaveBeenCalledTimes(1);
       expect(mockCacheStorageService.hashSet).toHaveBeenCalledWith({
         key: WORKFLOW_CRON_TRIGGER_CACHE_KEY,
         field: 'workflow-2',
@@ -232,17 +239,10 @@ describe('WorkflowCronTriggerCronJob', () => {
         }),
       });
 
-      expect(mockCacheStorageService.expire).toHaveBeenCalledTimes(1);
-      expect(mockCacheStorageService.expire).toHaveBeenCalledWith(
-        WORKFLOW_CRON_TRIGGER_CACHE_KEY,
-        WORKFLOW_CRON_TRIGGER_CACHE_TTL_MS,
-      );
-
-      // Guarantees the key is never observable without a TTL for more than
-      // a single Redis round-trip: expire must follow the very first hashSet.
+      // Guarantees the cache key is never observable without a TTL: the very
+      // first write (the one that creates the key) is atomic with PEXPIRE.
       expect(callOrder).toEqual([
-        'hashSet:workflow-1',
-        'expire',
+        'hashSetWithExpire:workflow-1',
         'hashSet:workflow-2',
       ]);
     });
@@ -255,7 +255,7 @@ describe('WorkflowCronTriggerCronJob', () => {
       await job.handle();
 
       expect(mockCacheStorageService.hashSet).not.toHaveBeenCalled();
-      expect(mockCacheStorageService.expire).not.toHaveBeenCalled();
+      expect(mockCacheStorageService.hashSetWithExpire).not.toHaveBeenCalled();
     });
   });
 

--- a/packages/twenty-server/src/modules/workflow/workflow-trigger/automated-trigger/crons/jobs/__tests__/workflow-cron-trigger-cron.job.spec.ts
+++ b/packages/twenty-server/src/modules/workflow/workflow-trigger/automated-trigger/crons/jobs/__tests__/workflow-cron-trigger-cron.job.spec.ts
@@ -176,7 +176,7 @@ describe('WorkflowCronTriggerCronJob', () => {
       expect(mockCoreDataSource.query).toHaveBeenCalledTimes(3);
     });
 
-    it('should use hashSetWithExpire for the first trigger and hashSet for the rest', async () => {
+    it('should use hashSetWithExpire for every trigger so the TTL is always set', async () => {
       mockCacheStorageService.hashGetValues.mockResolvedValue([]);
       mockWorkspaceRepository.find.mockResolvedValue([
         { id: WORKSPACE_1 },
@@ -201,50 +201,42 @@ describe('WorkflowCronTriggerCronJob', () => {
           },
         ]);
 
-      const callOrder: string[] = [];
-
-      mockCacheStorageService.hashSetWithExpire.mockImplementation(
-        ({ field }) => {
-          callOrder.push(`hashSetWithExpire:${field}`);
-        },
-      );
-      mockCacheStorageService.hashSet.mockImplementation(({ field }) => {
-        callOrder.push(`hashSet:${field}`);
-      });
-
       await job.handle();
 
+      // hashSet must never be called during a rebuild: any non-atomic write
+      // could recreate the key without a TTL if it was flushed/evicted
+      // mid-rebuild, leaving cron workflows permanently stuck.
+      expect(mockCacheStorageService.hashSet).not.toHaveBeenCalled();
+
       expect(mockCacheStorageService.hashSetWithExpire).toHaveBeenCalledTimes(
-        1,
+        2,
       );
-      expect(mockCacheStorageService.hashSetWithExpire).toHaveBeenCalledWith({
-        key: WORKFLOW_CRON_TRIGGER_CACHE_KEY,
-        field: 'workflow-1',
-        value: JSON.stringify({
-          workspaceId: WORKSPACE_1,
-          workflowId: 'workflow-1',
-          pattern: '* * * * *',
-        }),
-        ttlMs: WORKFLOW_CRON_TRIGGER_CACHE_TTL_MS,
-      });
-
-      expect(mockCacheStorageService.hashSet).toHaveBeenCalledTimes(1);
-      expect(mockCacheStorageService.hashSet).toHaveBeenCalledWith({
-        key: WORKFLOW_CRON_TRIGGER_CACHE_KEY,
-        field: 'workflow-2',
-        value: JSON.stringify({
-          workspaceId: WORKSPACE_3,
-          workflowId: 'workflow-2',
-          pattern: '* * * * *',
-        }),
-      });
-
-      // Guarantees the cache key is never observable without a TTL: the very
-      // first write (the one that creates the key) is atomic with PEXPIRE.
-      expect(callOrder).toEqual([
-        'hashSetWithExpire:workflow-1',
-        'hashSet:workflow-2',
-      ]);
+      expect(mockCacheStorageService.hashSetWithExpire).toHaveBeenNthCalledWith(
+        1,
+        {
+          key: WORKFLOW_CRON_TRIGGER_CACHE_KEY,
+          field: 'workflow-1',
+          value: JSON.stringify({
+            workspaceId: WORKSPACE_1,
+            workflowId: 'workflow-1',
+            pattern: '* * * * *',
+          }),
+          ttlMs: WORKFLOW_CRON_TRIGGER_CACHE_TTL_MS,
+        },
+      );
+      expect(mockCacheStorageService.hashSetWithExpire).toHaveBeenNthCalledWith(
+        2,
+        {
+          key: WORKFLOW_CRON_TRIGGER_CACHE_KEY,
+          field: 'workflow-2',
+          value: JSON.stringify({
+            workspaceId: WORKSPACE_3,
+            workflowId: 'workflow-2',
+            pattern: '* * * * *',
+          }),
+          ttlMs: WORKFLOW_CRON_TRIGGER_CACHE_TTL_MS,
+        },
+      );
     });
 
     it('should not write to cache when no workspaces have cron triggers', async () => {

--- a/packages/twenty-server/src/modules/workflow/workflow-trigger/automated-trigger/crons/jobs/__tests__/workflow-cron-trigger-cron.job.spec.ts
+++ b/packages/twenty-server/src/modules/workflow/workflow-trigger/automated-trigger/crons/jobs/__tests__/workflow-cron-trigger-cron.job.spec.ts
@@ -32,7 +32,7 @@ const mockExceptionHandlerService = {
 const mockCacheStorageService = {
   hashGetValues: jest.fn(),
   hashSet: jest.fn(),
-  hashSetWithExpire: jest.fn(),
+  expire: jest.fn(),
 };
 
 describe('WorkflowCronTriggerCronJob', () => {
@@ -156,7 +156,7 @@ describe('WorkflowCronTriggerCronJob', () => {
       await job.handle();
 
       expect(mockCacheStorageService.hashSet).not.toHaveBeenCalled();
-      expect(mockCacheStorageService.hashSetWithExpire).not.toHaveBeenCalled();
+      expect(mockCacheStorageService.expire).not.toHaveBeenCalled();
     });
   });
 
@@ -176,7 +176,7 @@ describe('WorkflowCronTriggerCronJob', () => {
       expect(mockCoreDataSource.query).toHaveBeenCalledTimes(3);
     });
 
-    it('should use hashSetWithExpire for the first trigger and hashSet for the rest', async () => {
+    it('should write all triggers to cache and set TTL exactly once, right after the first write', async () => {
       mockCacheStorageService.hashGetValues.mockResolvedValue([]);
       mockWorkspaceRepository.find.mockResolvedValue([
         { id: WORKSPACE_1 },
@@ -203,21 +203,17 @@ describe('WorkflowCronTriggerCronJob', () => {
 
       const callOrder: string[] = [];
 
-      mockCacheStorageService.hashSetWithExpire.mockImplementation(
-        ({ field }) => {
-          callOrder.push(`hashSetWithExpire:${field}`);
-        },
-      );
       mockCacheStorageService.hashSet.mockImplementation(({ field }) => {
         callOrder.push(`hashSet:${field}`);
+      });
+      mockCacheStorageService.expire.mockImplementation(() => {
+        callOrder.push('expire');
       });
 
       await job.handle();
 
-      expect(mockCacheStorageService.hashSetWithExpire).toHaveBeenCalledTimes(
-        1,
-      );
-      expect(mockCacheStorageService.hashSetWithExpire).toHaveBeenCalledWith({
+      expect(mockCacheStorageService.hashSet).toHaveBeenCalledTimes(2);
+      expect(mockCacheStorageService.hashSet).toHaveBeenCalledWith({
         key: WORKFLOW_CRON_TRIGGER_CACHE_KEY,
         field: 'workflow-1',
         value: JSON.stringify({
@@ -225,10 +221,7 @@ describe('WorkflowCronTriggerCronJob', () => {
           workflowId: 'workflow-1',
           pattern: '* * * * *',
         }),
-        ttlMs: WORKFLOW_CRON_TRIGGER_CACHE_TTL_MS,
       });
-
-      expect(mockCacheStorageService.hashSet).toHaveBeenCalledTimes(1);
       expect(mockCacheStorageService.hashSet).toHaveBeenCalledWith({
         key: WORKFLOW_CRON_TRIGGER_CACHE_KEY,
         field: 'workflow-2',
@@ -239,11 +232,17 @@ describe('WorkflowCronTriggerCronJob', () => {
         }),
       });
 
-      // Guarantees the key cannot be observed without a TTL: the first write
-      // (which creates the key) must be atomic; subsequent writes preserve
-      // the TTL automatically.
+      expect(mockCacheStorageService.expire).toHaveBeenCalledTimes(1);
+      expect(mockCacheStorageService.expire).toHaveBeenCalledWith(
+        WORKFLOW_CRON_TRIGGER_CACHE_KEY,
+        WORKFLOW_CRON_TRIGGER_CACHE_TTL_MS,
+      );
+
+      // Guarantees the key is never observable without a TTL for more than
+      // a single Redis round-trip: expire must follow the very first hashSet.
       expect(callOrder).toEqual([
-        'hashSetWithExpire:workflow-1',
+        'hashSet:workflow-1',
+        'expire',
         'hashSet:workflow-2',
       ]);
     });
@@ -256,7 +255,7 @@ describe('WorkflowCronTriggerCronJob', () => {
       await job.handle();
 
       expect(mockCacheStorageService.hashSet).not.toHaveBeenCalled();
-      expect(mockCacheStorageService.hashSetWithExpire).not.toHaveBeenCalled();
+      expect(mockCacheStorageService.expire).not.toHaveBeenCalled();
     });
   });
 

--- a/packages/twenty-server/src/modules/workflow/workflow-trigger/automated-trigger/crons/jobs/__tests__/workflow-cron-trigger-cron.job.spec.ts
+++ b/packages/twenty-server/src/modules/workflow/workflow-trigger/automated-trigger/crons/jobs/__tests__/workflow-cron-trigger-cron.job.spec.ts
@@ -32,7 +32,7 @@ const mockExceptionHandlerService = {
 const mockCacheStorageService = {
   hashGetValues: jest.fn(),
   hashSet: jest.fn(),
-  expire: jest.fn(),
+  hashSetWithExpire: jest.fn(),
 };
 
 describe('WorkflowCronTriggerCronJob', () => {
@@ -156,6 +156,7 @@ describe('WorkflowCronTriggerCronJob', () => {
       await job.handle();
 
       expect(mockCacheStorageService.hashSet).not.toHaveBeenCalled();
+      expect(mockCacheStorageService.hashSetWithExpire).not.toHaveBeenCalled();
     });
   });
 
@@ -175,7 +176,7 @@ describe('WorkflowCronTriggerCronJob', () => {
       expect(mockCoreDataSource.query).toHaveBeenCalledTimes(3);
     });
 
-    it('should write each trigger to cache immediately and set TTL', async () => {
+    it('should use hashSetWithExpire for the first trigger and hashSet for the rest', async () => {
       mockCacheStorageService.hashGetValues.mockResolvedValue([]);
       mockWorkspaceRepository.find.mockResolvedValue([
         { id: WORKSPACE_1 },
@@ -200,10 +201,23 @@ describe('WorkflowCronTriggerCronJob', () => {
           },
         ]);
 
+      const callOrder: string[] = [];
+
+      mockCacheStorageService.hashSetWithExpire.mockImplementation(
+        ({ field }) => {
+          callOrder.push(`hashSetWithExpire:${field}`);
+        },
+      );
+      mockCacheStorageService.hashSet.mockImplementation(({ field }) => {
+        callOrder.push(`hashSet:${field}`);
+      });
+
       await job.handle();
 
-      expect(mockCacheStorageService.hashSet).toHaveBeenCalledTimes(2);
-      expect(mockCacheStorageService.hashSet).toHaveBeenCalledWith({
+      expect(mockCacheStorageService.hashSetWithExpire).toHaveBeenCalledTimes(
+        1,
+      );
+      expect(mockCacheStorageService.hashSetWithExpire).toHaveBeenCalledWith({
         key: WORKFLOW_CRON_TRIGGER_CACHE_KEY,
         field: 'workflow-1',
         value: JSON.stringify({
@@ -211,7 +225,10 @@ describe('WorkflowCronTriggerCronJob', () => {
           workflowId: 'workflow-1',
           pattern: '* * * * *',
         }),
+        ttlMs: WORKFLOW_CRON_TRIGGER_CACHE_TTL_MS,
       });
+
+      expect(mockCacheStorageService.hashSet).toHaveBeenCalledTimes(1);
       expect(mockCacheStorageService.hashSet).toHaveBeenCalledWith({
         key: WORKFLOW_CRON_TRIGGER_CACHE_KEY,
         field: 'workflow-2',
@@ -221,10 +238,14 @@ describe('WorkflowCronTriggerCronJob', () => {
           pattern: '* * * * *',
         }),
       });
-      expect(mockCacheStorageService.expire).toHaveBeenCalledWith(
-        WORKFLOW_CRON_TRIGGER_CACHE_KEY,
-        WORKFLOW_CRON_TRIGGER_CACHE_TTL_MS,
-      );
+
+      // Guarantees the key cannot be observed without a TTL: the first write
+      // (which creates the key) must be atomic; subsequent writes preserve
+      // the TTL automatically.
+      expect(callOrder).toEqual([
+        'hashSetWithExpire:workflow-1',
+        'hashSet:workflow-2',
+      ]);
     });
 
     it('should not write to cache when no workspaces have cron triggers', async () => {
@@ -235,7 +256,7 @@ describe('WorkflowCronTriggerCronJob', () => {
       await job.handle();
 
       expect(mockCacheStorageService.hashSet).not.toHaveBeenCalled();
-      expect(mockCacheStorageService.expire).not.toHaveBeenCalled();
+      expect(mockCacheStorageService.hashSetWithExpire).not.toHaveBeenCalled();
     });
   });
 

--- a/packages/twenty-server/src/modules/workflow/workflow-trigger/automated-trigger/crons/jobs/workflow-cron-trigger-cron.job.ts
+++ b/packages/twenty-server/src/modules/workflow/workflow-trigger/automated-trigger/crons/jobs/workflow-cron-trigger-cron.job.ts
@@ -125,20 +125,23 @@ export class WorkflowCronTriggerCronJob {
       );
 
       for (const trigger of triggersToCache) {
-        await this.cacheStorageService.hashSet({
-          key: WORKFLOW_CRON_TRIGGER_CACHE_KEY,
-          field: trigger.workflowId,
-          value: JSON.stringify(trigger),
-        });
+        if (triggerCount === 0) {
+          await this.cacheStorageService.hashSetWithExpire({
+            key: WORKFLOW_CRON_TRIGGER_CACHE_KEY,
+            field: trigger.workflowId,
+            value: JSON.stringify(trigger),
+            ttlMs: WORKFLOW_CRON_TRIGGER_CACHE_TTL_MS,
+          });
+        } else {
+          await this.cacheStorageService.hashSet({
+            key: WORKFLOW_CRON_TRIGGER_CACHE_KEY,
+            field: trigger.workflowId,
+            value: JSON.stringify(trigger),
+          });
+        }
+
         triggerCount++;
       }
-    }
-
-    if (triggerCount > 0) {
-      await this.cacheStorageService.expire(
-        WORKFLOW_CRON_TRIGGER_CACHE_KEY,
-        WORKFLOW_CRON_TRIGGER_CACHE_TTL_MS,
-      );
     }
 
     this.logger.log(`Cache rebuilt with ${triggerCount} cron triggers`);

--- a/packages/twenty-server/src/modules/workflow/workflow-trigger/automated-trigger/crons/jobs/workflow-cron-trigger-cron.job.ts
+++ b/packages/twenty-server/src/modules/workflow/workflow-trigger/automated-trigger/crons/jobs/workflow-cron-trigger-cron.job.ts
@@ -125,27 +125,12 @@ export class WorkflowCronTriggerCronJob {
       );
 
       for (const trigger of triggersToCache) {
-        if (triggerCount === 0) {
-          // First write creates the cache key — use atomic HSET + PEXPIRE
-          // (MULTI/EXEC transaction) so the key is never observable without
-          // a TTL. Otherwise a worker crash between a plain hashSet and a
-          // follow-up expire() would leave the key alive forever, every
-          // subsequent tick would take the cache-hit branch, and the DB-scan
-          // path would never run again. Subsequent HSETs preserve the TTL,
-          // so we only need atomicity on the first write.
-          await this.cacheStorageService.hashSetWithExpire({
-            key: WORKFLOW_CRON_TRIGGER_CACHE_KEY,
-            field: trigger.workflowId,
-            value: JSON.stringify(trigger),
-            ttlMs: WORKFLOW_CRON_TRIGGER_CACHE_TTL_MS,
-          });
-        } else {
-          await this.cacheStorageService.hashSet({
-            key: WORKFLOW_CRON_TRIGGER_CACHE_KEY,
-            field: trigger.workflowId,
-            value: JSON.stringify(trigger),
-          });
-        }
+        await this.cacheStorageService.hashSetWithExpire({
+          key: WORKFLOW_CRON_TRIGGER_CACHE_KEY,
+          field: trigger.workflowId,
+          value: JSON.stringify(trigger),
+          ttlMs: WORKFLOW_CRON_TRIGGER_CACHE_TTL_MS,
+        });
 
         triggerCount++;
       }

--- a/packages/twenty-server/src/modules/workflow/workflow-trigger/automated-trigger/crons/jobs/workflow-cron-trigger-cron.job.ts
+++ b/packages/twenty-server/src/modules/workflow/workflow-trigger/automated-trigger/crons/jobs/workflow-cron-trigger-cron.job.ts
@@ -125,19 +125,17 @@ export class WorkflowCronTriggerCronJob {
       );
 
       for (const trigger of triggersToCache) {
+        await this.cacheStorageService.hashSet({
+          key: WORKFLOW_CRON_TRIGGER_CACHE_KEY,
+          field: trigger.workflowId,
+          value: JSON.stringify(trigger),
+        });
+
         if (triggerCount === 0) {
-          await this.cacheStorageService.hashSetWithExpire({
-            key: WORKFLOW_CRON_TRIGGER_CACHE_KEY,
-            field: trigger.workflowId,
-            value: JSON.stringify(trigger),
-            ttlMs: WORKFLOW_CRON_TRIGGER_CACHE_TTL_MS,
-          });
-        } else {
-          await this.cacheStorageService.hashSet({
-            key: WORKFLOW_CRON_TRIGGER_CACHE_KEY,
-            field: trigger.workflowId,
-            value: JSON.stringify(trigger),
-          });
+          await this.cacheStorageService.expire(
+            WORKFLOW_CRON_TRIGGER_CACHE_KEY,
+            WORKFLOW_CRON_TRIGGER_CACHE_TTL_MS,
+          );
         }
 
         triggerCount++;

--- a/packages/twenty-server/src/modules/workflow/workflow-trigger/automated-trigger/crons/jobs/workflow-cron-trigger-cron.job.ts
+++ b/packages/twenty-server/src/modules/workflow/workflow-trigger/automated-trigger/crons/jobs/workflow-cron-trigger-cron.job.ts
@@ -125,17 +125,26 @@ export class WorkflowCronTriggerCronJob {
       );
 
       for (const trigger of triggersToCache) {
-        await this.cacheStorageService.hashSet({
-          key: WORKFLOW_CRON_TRIGGER_CACHE_KEY,
-          field: trigger.workflowId,
-          value: JSON.stringify(trigger),
-        });
-
         if (triggerCount === 0) {
-          await this.cacheStorageService.expire(
-            WORKFLOW_CRON_TRIGGER_CACHE_KEY,
-            WORKFLOW_CRON_TRIGGER_CACHE_TTL_MS,
-          );
+          // First write creates the cache key — use atomic HSET + PEXPIRE
+          // (MULTI/EXEC transaction) so the key is never observable without
+          // a TTL. Otherwise a worker crash between a plain hashSet and a
+          // follow-up expire() would leave the key alive forever, every
+          // subsequent tick would take the cache-hit branch, and the DB-scan
+          // path would never run again. Subsequent HSETs preserve the TTL,
+          // so we only need atomicity on the first write.
+          await this.cacheStorageService.hashSetWithExpire({
+            key: WORKFLOW_CRON_TRIGGER_CACHE_KEY,
+            field: trigger.workflowId,
+            value: JSON.stringify(trigger),
+            ttlMs: WORKFLOW_CRON_TRIGGER_CACHE_TTL_MS,
+          });
+        } else {
+          await this.cacheStorageService.hashSet({
+            key: WORKFLOW_CRON_TRIGGER_CACHE_KEY,
+            field: trigger.workflowId,
+            value: JSON.stringify(trigger),
+          });
         }
 
         triggerCount++;


### PR DESCRIPTION
## Problem

The cron-trigger cache key (`module:workflow:workflow-cron-triggers`) can get stuck without a TTL, silently halting **all** cron-triggered workflows for a whole tenant until the key is manually deleted from Redis.

Repro path:

1. Cache miss → DB-scan branch runs.
2. Inner loop writes triggers via `hashSet` (creates the key, **no TTL yet**).
3. Worker crashes / OOMs / gets killed by a deploy between any `hashSet` and the trailing `expire(1h)` call.
4. Key now exists with TTL = `-1` and a partial set of fields.
5. Next tick: `hashGetValues` returns those fields → `cachedValues.length > 0` → **cache-hit branch** → `expire` is never called.
6. Key has no TTL, so it never auto-expires. The DB-scan branch never runs again. New / missing triggers are never picked up. Workflows go silent.

Observed in production: cache key with `TTL: no limit` and 121 fields. Deleting the key restored normal behaviour (next tick rebuilt with TTL ~3600).

## Fix

Set the TTL right after first value is added 

## Monitoring

Added a "Cache miss" log count in workflow dashboard, counted among the last 6 hours. Turns green if >= 5
<img width="1627" height="721" alt="Screenshot 2026-05-21 at 16 46 13" src="https://github.com/user-attachments/assets/8262dd5f-fbbd-43c9-aede-c0ce5d6a0f59" />
