### PR TITLE
fix(server): encrypt token post refresh

### DIFF
--- a/packages/twenty-server/src/engine/core-modules/application/connection-provider/connections/application-connections.module.ts
+++ b/packages/twenty-server/src/engine/core-modules/application/connection-provider/connections/application-connections.module.ts
@@ -6,6 +6,7 @@ import { ApplicationConnectionsController } from 'src/engine/core-modules/applic
 import { ApplicationConnectionsListService } from 'src/engine/core-modules/application/connection-provider/connections/services/application-connections-list.service';
 import { TokenModule } from 'src/engine/core-modules/auth/token/token.module';
 import { ConnectedAccountEntity } from 'src/engine/metadata-modules/connected-account/entities/connected-account.entity';
+import { ConnectedAccountTokenEncryptionModule } from 'src/engine/metadata-modules/connected-account/services/connected-account-token-encryption.module';
 import { WorkspaceCacheStorageModule } from 'src/engine/workspace-cache-storage/workspace-cache-storage.module';
 import { RefreshTokensManagerModule } from 'src/modules/connected-account/refresh-tokens-manager/connected-account-refresh-tokens-manager.module';
 
@@ -22,6 +23,7 @@ import { RefreshTokensManagerModule } from 'src/modules/connected-account/refres
     TokenModule,
     WorkspaceCacheStorageModule,
     RefreshTokensManagerModule,
+    ConnectedAccountTokenEncryptionModule,
   ],
   providers: [ApplicationConnectionsListService],
   controllers: [ApplicationConnectionsController],

--- a/packages/twenty-server/src/engine/core-modules/application/connection-provider/connections/services/application-connections-list.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/application/connection-provider/connections/services/application-connections-list.service.ts
@@ -9,6 +9,7 @@ import { isDefined } from 'twenty-shared/utils';
 import { ConnectionProviderEntity } from 'src/engine/core-modules/application/connection-provider/connection-provider.entity';
 import { type AppConnectionDto } from 'src/engine/core-modules/application/connection-provider/connections/dtos/app-connection.dto';
 import { ConnectedAccountEntity } from 'src/engine/metadata-modules/connected-account/entities/connected-account.entity';
+import { ConnectedAccountTokenEncryptionService } from 'src/engine/metadata-modules/connected-account/services/connected-account-token-encryption.service';
 import { ConnectedAccountRefreshTokensService } from 'src/modules/connected-account/refresh-tokens-manager/services/connected-account-refresh-tokens.service';
 
 type ListArgs = {
@@ -38,6 +39,7 @@ export class ApplicationConnectionsListService {
 
   constructor(
     private readonly refreshTokensService: ConnectedAccountRefreshTokensService,
+    private readonly connectedAccountTokenEncryptionService: ConnectedAccountTokenEncryptionService,
     @InjectRepository(ConnectedAccountEntity)
     private readonly connectedAccountRepository: Repository<ConnectedAccountEntity>,
     @InjectRepository(ConnectionProviderEntity)
@@ -207,7 +209,7 @@ export class ApplicationConnectionsListService {
     }
 
     try {
-      const tokens = await this.refreshTokensService.resolveTokens(
+      const encryptedTokens = await this.refreshTokensService.resolveTokens(
         account,
         workspaceId,
       );
@@ -219,7 +221,10 @@ export class ApplicationConnectionsListService {
         handle: account.handle,
         visibility: account.visibility as 'user' | 'workspace',
         userWorkspaceId: account.userWorkspaceId,
-        accessToken: tokens.accessToken,
+        accessToken: this.connectedAccountTokenEncryptionService.decrypt({
+          ciphertext: encryptedTokens.accessToken,
+          workspaceId,
+        }),
         scopes: account.scopes ?? provider.oauthConfig?.scopes ?? [],
         authFailedAt: account.authFailedAt?.toISOString() ?? null,
       };

--- a/packages/twenty-server/src/modules/connected-account/refresh-tokens-manager/services/connected-account-refresh-tokens.service.spec.ts
+++ b/packages/twenty-server/src/modules/connected-account/refresh-tokens-manager/services/connected-account-refresh-tokens.service.spec.ts
@@ -12,7 +12,6 @@ import {
   ConnectedAccountRefreshAccessTokenExceptionCode,
 } from 'src/engine/metadata-modules/connected-account/exceptions/connected-account-refresh-tokens.exception';
 import { ConnectedAccountTokenEncryptionService } from 'src/engine/metadata-modules/connected-account/services/connected-account-token-encryption.service';
-import { GlobalWorkspaceOrmManager } from 'src/engine/twenty-orm/global-workspace-datasource/global-workspace-orm.manager';
 import { GoogleAPIRefreshAccessTokenService } from 'src/modules/connected-account/refresh-tokens-manager/drivers/google/services/google-api-refresh-tokens.service';
 import { MicrosoftAPIRefreshAccessTokenService } from 'src/modules/connected-account/refresh-tokens-manager/drivers/microsoft/services/microsoft-api-refresh-tokens.service';
 
@@ -107,15 +106,6 @@ describe('ConnectedAccountRefreshTokensService', () => {
           },
         },
         {
-          provide: GlobalWorkspaceOrmManager,
-          useValue: {
-            executeInWorkspaceContext: jest
-              .fn()
-
-              .mockImplementation((fn: () => any, _authContext?: any) => fn()),
-          },
-        },
-        {
           provide: getRepositoryToken(ConnectedAccountEntity),
           useValue: {
             update: jest.fn(),
@@ -149,7 +139,7 @@ describe('ConnectedAccountRefreshTokensService', () => {
   });
 
   describe('resolveTokens', () => {
-    it('should reuse the cached token, decrypt before returning to the caller, and skip the refresh call entirely', async () => {
+    it('should reuse the cached encrypted tokens as-is when valid, skipping decrypt and the refresh call entirely', async () => {
       const connectedAccount = {
         id: mockConnectedAccountId,
         provider: ConnectedAccountProvider.MICROSOFT,
@@ -164,28 +154,19 @@ describe('ConnectedAccountRefreshTokensService', () => {
       );
 
       expect(result).toEqual({
-        accessToken: mockAccessTokenPlaintext,
-        refreshToken: mockRefreshTokenPlaintext,
+        accessToken: mockEncryptedAccessToken,
+        refreshToken: mockEncryptedRefreshToken,
       });
       expect(
         connectedAccountTokenEncryptionService.decrypt,
-      ).toHaveBeenCalledWith({
-        ciphertext: mockEncryptedAccessToken,
-        workspaceId: mockWorkspaceId,
-      });
-      expect(
-        connectedAccountTokenEncryptionService.decrypt,
-      ).toHaveBeenCalledWith({
-        ciphertext: mockEncryptedRefreshToken,
-        workspaceId: mockWorkspaceId,
-      });
+      ).not.toHaveBeenCalled();
       expect(
         microsoftAPIRefreshAccessTokenService.refreshTokens,
       ).not.toHaveBeenCalled();
       expect(connectedAccountRepository.update).not.toHaveBeenCalled();
     });
 
-    it('should decrypt the stored refresh token before sending to Microsoft, then re-encrypt the rotated tokens before persisting', async () => {
+    it('should decrypt the stored refresh token before sending to Microsoft, persist the re-encrypted tokens, and return them encrypted', async () => {
       const connectedAccount = {
         id: mockConnectedAccountId,
         provider: ConnectedAccountProvider.MICROSOFT,
@@ -194,35 +175,41 @@ describe('ConnectedAccountRefreshTokensService', () => {
         lastCredentialsRefreshedAt: new Date(Date.now() - 2 * 60 * 60 * 1000), // 2 hours ago
       } as ConnectedAccountEntity;
 
-      const newTokens = {
+      const newPlaintextTokens = {
         accessToken: mockNewAccessTokenPlaintext,
         refreshToken: mockRefreshTokenPlaintext,
       };
 
       jest
         .spyOn(microsoftAPIRefreshAccessTokenService, 'refreshTokens')
-        .mockResolvedValue(newTokens);
+        .mockResolvedValue(newPlaintextTokens);
 
       const result = await service.resolveTokens(
         connectedAccount,
         mockWorkspaceId,
       );
 
-      expect(result).toEqual(newTokens);
+      const expectedEncryptedNewAccessToken = `${FAKE_CIPHER_PREFIX}CIPHER(${mockNewAccessTokenPlaintext})`;
+      const expectedEncryptedNewRefreshToken = `${FAKE_CIPHER_PREFIX}CIPHER(${mockRefreshTokenPlaintext})`;
+
+      expect(result).toEqual({
+        accessToken: expectedEncryptedNewAccessToken,
+        refreshToken: expectedEncryptedNewRefreshToken,
+      });
       expect(
         microsoftAPIRefreshAccessTokenService.refreshTokens,
       ).toHaveBeenCalledWith(mockRefreshTokenPlaintext);
       expect(connectedAccountRepository.update).toHaveBeenCalledWith(
         { id: mockConnectedAccountId, workspaceId: mockWorkspaceId },
         expect.objectContaining({
-          accessToken: `${FAKE_CIPHER_PREFIX}CIPHER(${mockNewAccessTokenPlaintext})`,
-          refreshToken: `${FAKE_CIPHER_PREFIX}CIPHER(${mockRefreshTokenPlaintext})`,
+          accessToken: expectedEncryptedNewAccessToken,
+          refreshToken: expectedEncryptedNewRefreshToken,
           lastCredentialsRefreshedAt: expect.any(Date),
         }),
       );
     });
 
-    it('should decrypt the stored refresh token before sending to Google, then re-encrypt the rotated tokens before persisting', async () => {
+    it('should decrypt the stored refresh token before sending to Google, persist the re-encrypted tokens, and return them encrypted', async () => {
       const connectedAccount = {
         id: mockConnectedAccountId,
         provider: ConnectedAccountProvider.GOOGLE,
@@ -231,29 +218,35 @@ describe('ConnectedAccountRefreshTokensService', () => {
         lastCredentialsRefreshedAt: new Date(Date.now() - 2 * 60 * 60 * 1000), // 2 hours ago
       } as ConnectedAccountEntity;
 
-      const newTokens = {
+      const newPlaintextTokens = {
         accessToken: mockNewAccessTokenPlaintext,
         refreshToken: mockRefreshTokenPlaintext,
       };
 
       jest
         .spyOn(googleAPIRefreshAccessTokenService, 'refreshTokens')
-        .mockResolvedValue(newTokens);
+        .mockResolvedValue(newPlaintextTokens);
 
       const result = await service.resolveTokens(
         connectedAccount,
         mockWorkspaceId,
       );
 
-      expect(result).toEqual(newTokens);
+      const expectedEncryptedNewAccessToken = `${FAKE_CIPHER_PREFIX}CIPHER(${mockNewAccessTokenPlaintext})`;
+      const expectedEncryptedNewRefreshToken = `${FAKE_CIPHER_PREFIX}CIPHER(${mockRefreshTokenPlaintext})`;
+
+      expect(result).toEqual({
+        accessToken: expectedEncryptedNewAccessToken,
+        refreshToken: expectedEncryptedNewRefreshToken,
+      });
       expect(
         googleAPIRefreshAccessTokenService.refreshTokens,
       ).toHaveBeenCalledWith(mockRefreshTokenPlaintext);
       expect(connectedAccountRepository.update).toHaveBeenCalledWith(
         { id: mockConnectedAccountId, workspaceId: mockWorkspaceId },
         expect.objectContaining({
-          accessToken: `${FAKE_CIPHER_PREFIX}CIPHER(${mockNewAccessTokenPlaintext})`,
-          refreshToken: `${FAKE_CIPHER_PREFIX}CIPHER(${mockRefreshTokenPlaintext})`,
+          accessToken: expectedEncryptedNewAccessToken,
+          refreshToken: expectedEncryptedNewRefreshToken,
           lastCredentialsRefreshedAt: expect.any(Date),
         }),
       );
@@ -268,35 +261,41 @@ describe('ConnectedAccountRefreshTokensService', () => {
         lastCredentialsRefreshedAt: null,
       } as ConnectedAccountEntity;
 
-      const newTokens = {
+      const newPlaintextTokens = {
         accessToken: mockNewAccessTokenPlaintext,
         refreshToken: mockRefreshTokenPlaintext,
       };
 
       jest
         .spyOn(microsoftAPIRefreshAccessTokenService, 'refreshTokens')
-        .mockResolvedValue(newTokens);
+        .mockResolvedValue(newPlaintextTokens);
 
       const result = await service.resolveTokens(
         connectedAccount,
         mockWorkspaceId,
       );
 
-      expect(result).toEqual(newTokens);
+      const expectedEncryptedNewAccessToken = `${FAKE_CIPHER_PREFIX}CIPHER(${mockNewAccessTokenPlaintext})`;
+      const expectedEncryptedNewRefreshToken = `${FAKE_CIPHER_PREFIX}CIPHER(${mockRefreshTokenPlaintext})`;
+
+      expect(result).toEqual({
+        accessToken: expectedEncryptedNewAccessToken,
+        refreshToken: expectedEncryptedNewRefreshToken,
+      });
       expect(
         microsoftAPIRefreshAccessTokenService.refreshTokens,
       ).toHaveBeenCalledWith(mockRefreshTokenPlaintext);
       expect(connectedAccountRepository.update).toHaveBeenCalledWith(
         { id: mockConnectedAccountId, workspaceId: mockWorkspaceId },
         expect.objectContaining({
-          accessToken: `${FAKE_CIPHER_PREFIX}CIPHER(${mockNewAccessTokenPlaintext})`,
-          refreshToken: `${FAKE_CIPHER_PREFIX}CIPHER(${mockRefreshTokenPlaintext})`,
+          accessToken: expectedEncryptedNewAccessToken,
+          refreshToken: expectedEncryptedNewRefreshToken,
           lastCredentialsRefreshedAt: expect.any(Date),
         }),
       );
     });
 
-    it('should return decrypted access token and null refresh token when access token is valid but no refresh token exists', async () => {
+    it('should return the encrypted access token and null refresh token when access token is valid but no refresh token exists', async () => {
       const connectedAccount = {
         id: mockConnectedAccountId,
         provider: ConnectedAccountProvider.APP,
@@ -311,18 +310,12 @@ describe('ConnectedAccountRefreshTokensService', () => {
       );
 
       expect(result).toEqual({
-        accessToken: mockAccessTokenPlaintext,
+        accessToken: mockEncryptedAccessToken,
         refreshToken: null,
       });
       expect(
         connectedAccountTokenEncryptionService.decrypt,
-      ).toHaveBeenCalledWith({
-        ciphertext: mockEncryptedAccessToken,
-        workspaceId: mockWorkspaceId,
-      });
-      expect(
-        connectedAccountTokenEncryptionService.decrypt,
-      ).toHaveBeenCalledTimes(1);
+      ).not.toHaveBeenCalled();
       expect(connectedAccountRepository.update).not.toHaveBeenCalled();
     });
 
@@ -474,7 +467,7 @@ describe('ConnectedAccountRefreshTokensService', () => {
   });
 
   describe('resolveTokens - OIDC/SAML', () => {
-    it('should decrypt and return existing tokens for OIDC without attempting a refresh', async () => {
+    it('should return existing encrypted tokens for OIDC as-is without attempting a refresh', async () => {
       const connectedAccount = {
         id: mockConnectedAccountId,
         provider: ConnectedAccountProvider.OIDC,
@@ -489,9 +482,12 @@ describe('ConnectedAccountRefreshTokensService', () => {
       );
 
       expect(result).toEqual({
-        accessToken: mockAccessTokenPlaintext,
-        refreshToken: mockRefreshTokenPlaintext,
+        accessToken: mockEncryptedAccessToken,
+        refreshToken: mockEncryptedRefreshToken,
       });
+      expect(
+        connectedAccountTokenEncryptionService.decrypt,
+      ).not.toHaveBeenCalled();
       expect(
         googleAPIRefreshAccessTokenService.refreshTokens,
       ).not.toHaveBeenCalled();
@@ -501,7 +497,7 @@ describe('ConnectedAccountRefreshTokensService', () => {
       expect(connectedAccountRepository.update).not.toHaveBeenCalled();
     });
 
-    it('should decrypt and return existing tokens for SAML without attempting a refresh', async () => {
+    it('should return existing encrypted tokens for SAML as-is without attempting a refresh', async () => {
       const connectedAccount = {
         id: mockConnectedAccountId,
         provider: ConnectedAccountProvider.SAML,
@@ -516,9 +512,12 @@ describe('ConnectedAccountRefreshTokensService', () => {
       );
 
       expect(result).toEqual({
-        accessToken: mockAccessTokenPlaintext,
-        refreshToken: mockRefreshTokenPlaintext,
+        accessToken: mockEncryptedAccessToken,
+        refreshToken: mockEncryptedRefreshToken,
       });
+      expect(
+        connectedAccountTokenEncryptionService.decrypt,
+      ).not.toHaveBeenCalled();
       expect(
         googleAPIRefreshAccessTokenService.refreshTokens,
       ).not.toHaveBeenCalled();

--- a/packages/twenty-server/src/modules/connected-account/refresh-tokens-manager/services/connected-account-refresh-tokens.service.ts
+++ b/packages/twenty-server/src/modules/connected-account/refresh-tokens-manager/services/connected-account-refresh-tokens.service.ts
@@ -37,7 +37,6 @@ export class ConnectedAccountRefreshTokensService {
     private readonly connectedAccountRepository: Repository<ConnectedAccountEntity>,
   ) {}
 
-  // Returns encrypted tokens safe to store on in-memory entities
   async resolveTokens(
     connectedAccount: ConnectedAccountEntity,
     workspaceId: string,

--- a/packages/twenty-server/src/modules/connected-account/refresh-tokens-manager/services/connected-account-refresh-tokens.service.ts
+++ b/packages/twenty-server/src/modules/connected-account/refresh-tokens-manager/services/connected-account-refresh-tokens.service.ts
@@ -12,8 +12,6 @@ import {
   ConnectedAccountRefreshAccessTokenExceptionCode,
 } from 'src/engine/metadata-modules/connected-account/exceptions/connected-account-refresh-tokens.exception';
 import { ConnectedAccountTokenEncryptionService } from 'src/engine/metadata-modules/connected-account/services/connected-account-token-encryption.service';
-import { GlobalWorkspaceOrmManager } from 'src/engine/twenty-orm/global-workspace-datasource/global-workspace-orm.manager';
-import { buildSystemAuthContext } from 'src/engine/twenty-orm/utils/build-system-auth-context.util';
 import { GoogleAPIRefreshAccessTokenService } from 'src/modules/connected-account/refresh-tokens-manager/drivers/google/services/google-api-refresh-tokens.service';
 import { MicrosoftAPIRefreshAccessTokenService } from 'src/modules/connected-account/refresh-tokens-manager/drivers/microsoft/services/microsoft-api-refresh-tokens.service';
 
@@ -34,7 +32,6 @@ export class ConnectedAccountRefreshTokensService {
     private readonly googleAPIRefreshAccessTokenService: GoogleAPIRefreshAccessTokenService,
     private readonly microsoftAPIRefreshAccessTokenService: MicrosoftAPIRefreshAccessTokenService,
     private readonly appOAuthRefreshAccessTokenService: AppOAuthRefreshAccessTokenService,
-    private readonly globalWorkspaceOrmManager: GlobalWorkspaceOrmManager,
     private readonly connectedAccountTokenEncryptionService: ConnectedAccountTokenEncryptionService,
     @InjectRepository(ConnectedAccountEntity)
     private readonly connectedAccountRepository: Repository<ConnectedAccountEntity>,
@@ -119,18 +116,14 @@ export class ConnectedAccountRefreshTokensService {
       workspaceId,
     });
 
-    const authContext = buildSystemAuthContext(workspaceId);
-
-    await this.globalWorkspaceOrmManager.executeInWorkspaceContext(async () => {
-      await this.connectedAccountRepository.update(
-        { id: connectedAccount.id, workspaceId },
-        {
-          accessToken: encryptedAccessToken,
-          refreshToken: reEncryptedRefreshToken,
-          lastCredentialsRefreshedAt: new Date(),
-        },
-      );
-    }, authContext);
+    await this.connectedAccountRepository.update(
+      { id: connectedAccount.id, workspaceId },
+      {
+        accessToken: encryptedAccessToken,
+        refreshToken: reEncryptedRefreshToken,
+        lastCredentialsRefreshedAt: new Date(),
+      },
+    );
 
     return {
       accessToken: encryptedAccessToken,

--- a/packages/twenty-server/src/modules/connected-account/refresh-tokens-manager/services/connected-account-refresh-tokens.service.ts
+++ b/packages/twenty-server/src/modules/connected-account/refresh-tokens-manager/services/connected-account-refresh-tokens.service.ts
@@ -40,6 +40,7 @@ export class ConnectedAccountRefreshTokensService {
     private readonly connectedAccountRepository: Repository<ConnectedAccountEntity>,
   ) {}
 
+  // Returns encrypted tokens safe to store on in-memory entities
   async resolveTokens(
     connectedAccount: ConnectedAccountEntity,
     workspaceId: string,
@@ -52,7 +53,7 @@ export class ConnectedAccountRefreshTokensService {
         `Reusing valid access token for connected account ${connectedAccount.id.slice(0, 7)} in workspace ${workspaceId.slice(0, 7)}`,
       );
 
-      return this.decryptExistingTokens(connectedAccount, workspaceId);
+      return this.getExistingEncryptedTokens(connectedAccount, workspaceId);
     }
 
     const encryptedRefreshToken = connectedAccount.refreshToken;
@@ -75,16 +76,11 @@ export class ConnectedAccountRefreshTokensService {
     );
   }
 
-  private decryptExistingTokens(
+  private getExistingEncryptedTokens(
     connectedAccount: ConnectedAccountEntity,
     workspaceId: string,
   ): ConnectedAccountTokens {
-    const {
-      accessToken: encryptedAccessToken,
-      refreshToken: encryptedRefreshToken,
-    } = connectedAccount;
-
-    if (!isDefined(encryptedAccessToken)) {
+    if (!isDefined(connectedAccount.accessToken)) {
       throw new ConnectedAccountRefreshAccessTokenException(
         `Access token is required for connected account ${connectedAccount.id} in workspace ${workspaceId}`,
         ConnectedAccountRefreshAccessTokenExceptionCode.ACCESS_TOKEN_NOT_FOUND,
@@ -92,16 +88,8 @@ export class ConnectedAccountRefreshTokensService {
     }
 
     return {
-      accessToken: this.connectedAccountTokenEncryptionService.decrypt({
-        ciphertext: encryptedAccessToken,
-        workspaceId,
-      }),
-      refreshToken: isDefined(encryptedRefreshToken)
-        ? this.connectedAccountTokenEncryptionService.decrypt({
-            ciphertext: encryptedRefreshToken,
-            workspaceId,
-          })
-        : null,
+      accessToken: connectedAccount.accessToken,
+      refreshToken: connectedAccount.refreshToken,
     };
   }
 
@@ -116,18 +104,18 @@ export class ConnectedAccountRefreshTokensService {
         workspaceId,
       });
 
-    const connectedAccountTokens = await this.refreshTokens(
+    const plaintextTokens = await this.refreshTokens(
       connectedAccount,
       decryptedRefreshToken,
       workspaceId,
     );
 
     const {
-      encryptedAccessToken: reEncryptedAccessToken,
+      encryptedAccessToken,
       encryptedRefreshToken: reEncryptedRefreshToken,
     } = this.connectedAccountTokenEncryptionService.encryptTokenPair({
-      accessToken: connectedAccountTokens.accessToken,
-      refreshToken: connectedAccountTokens.refreshToken,
+      accessToken: plaintextTokens.accessToken,
+      refreshToken: plaintextTokens.refreshToken,
       workspaceId,
     });
 
@@ -137,14 +125,17 @@ export class ConnectedAccountRefreshTokensService {
       await this.connectedAccountRepository.update(
         { id: connectedAccount.id, workspaceId },
         {
-          accessToken: reEncryptedAccessToken,
+          accessToken: encryptedAccessToken,
           refreshToken: reEncryptedRefreshToken,
           lastCredentialsRefreshedAt: new Date(),
         },
       );
     }, authContext);
 
-    return connectedAccountTokens;
+    return {
+      accessToken: encryptedAccessToken,
+      refreshToken: reEncryptedRefreshToken,
+    };
   }
 
   async isAccessTokenStillValid(

--- a/packages/twenty-server/src/modules/messaging/message-import-manager/services/messaging-message-list-fetch.service.ts
+++ b/packages/twenty-server/src/modules/messaging/message-import-manager/services/messaging-message-list-fetch.service.ts
@@ -110,7 +110,7 @@ export class MessagingMessageListFetchService {
               },
             );
 
-          const messageChannelWithFreshTokens = {
+          const messageChannelAfterAuth = {
             ...freshMessageChannel,
             connectedAccount: {
               ...freshMessageChannel.connectedAccount,
@@ -121,7 +121,7 @@ export class MessagingMessageListFetchService {
 
           const messageFolders =
             await this.syncMessageFoldersService.syncMessageFolders({
-              messageChannel: messageChannelWithFreshTokens,
+              messageChannel: messageChannelAfterAuth,
               workspaceId,
             });
 
@@ -132,7 +132,7 @@ export class MessagingMessageListFetchService {
 
           const messageLists =
             await this.messagingGetMessageListService.getMessageLists(
-              messageChannelWithFreshTokens,
+              messageChannelAfterAuth,
               messageFoldersToSync,
             );
 
@@ -201,7 +201,7 @@ export class MessagingMessageListFetchService {
               totalMessagesToImportCount += messageExternalIdsToImport.length;
 
               await this.cacheStorage.setAdd(
-                `messages-to-import:${workspaceId}:${messageChannelWithFreshTokens.id}`,
+                `messages-to-import:${workspaceId}:${messageChannelAfterAuth.id}`,
                 messageExternalIdsToImport,
                 ONE_WEEK_IN_MILLISECONDS,
               );
@@ -212,7 +212,7 @@ export class MessagingMessageListFetchService {
             const { nextSyncCursor, folderId } = messageList;
 
             await this.messagingCursorService.updateCursor(
-              messageChannelWithFreshTokens,
+              messageChannelAfterAuth,
               nextSyncCursor,
               workspaceId,
               folderId,
@@ -253,7 +253,7 @@ export class MessagingMessageListFetchService {
                   messageExternalIds: toDeleteChunk.filter(
                     (messageExternalId) => isNonEmptyString(messageExternalId),
                   ),
-                  messageChannelId: messageChannelWithFreshTokens.id,
+                  messageChannelId: messageChannelAfterAuth.id,
                 },
               );
             }
@@ -265,7 +265,7 @@ export class MessagingMessageListFetchService {
 
           if (totalMessagesToImportCount === 0) {
             await this.messageChannelSyncStatusService.markAsCompletedAndMarkAsMessagesListFetchPending(
-              [messageChannelWithFreshTokens.id],
+              [messageChannelAfterAuth.id],
               workspaceId,
             );
 
@@ -277,16 +277,16 @@ export class MessagingMessageListFetchService {
           );
 
           await this.messageChannelSyncStatusService.markAsMessagesImportScheduled(
-            [messageChannelWithFreshTokens.id],
+            [messageChannelAfterAuth.id],
             workspaceId,
           );
 
           await this.messagingMessagesImportService.processMessageBatchImport(
             {
-              ...messageChannelWithFreshTokens,
+              ...messageChannelAfterAuth,
               syncStage: MessageChannelSyncStage.MESSAGES_IMPORT_SCHEDULED,
             },
-            messageChannelWithFreshTokens.connectedAccount,
+            messageChannelAfterAuth.connectedAccount,
             workspaceId,
           );
         } catch (error) {

--- a/packages/twenty-server/src/modules/messaging/message-import-manager/services/messaging-message-list-fetch.service.ts
+++ b/packages/twenty-server/src/modules/messaging/message-import-manager/services/messaging-message-list-fetch.service.ts
@@ -110,7 +110,7 @@ export class MessagingMessageListFetchService {
               },
             );
 
-          const messageChannelAfterAuth = {
+          const messageChannelWithFreshTokens = {
             ...freshMessageChannel,
             connectedAccount: {
               ...freshMessageChannel.connectedAccount,
@@ -121,7 +121,7 @@ export class MessagingMessageListFetchService {
 
           const messageFolders =
             await this.syncMessageFoldersService.syncMessageFolders({
-              messageChannel: messageChannelAfterAuth,
+              messageChannel: messageChannelWithFreshTokens,
               workspaceId,
             });
 
@@ -132,7 +132,7 @@ export class MessagingMessageListFetchService {
 
           const messageLists =
             await this.messagingGetMessageListService.getMessageLists(
-              messageChannelAfterAuth,
+              messageChannelWithFreshTokens,
               messageFoldersToSync,
             );
 
@@ -201,7 +201,7 @@ export class MessagingMessageListFetchService {
               totalMessagesToImportCount += messageExternalIdsToImport.length;
 
               await this.cacheStorage.setAdd(
-                `messages-to-import:${workspaceId}:${messageChannelAfterAuth.id}`,
+                `messages-to-import:${workspaceId}:${messageChannelWithFreshTokens.id}`,
                 messageExternalIdsToImport,
                 ONE_WEEK_IN_MILLISECONDS,
               );
@@ -212,7 +212,7 @@ export class MessagingMessageListFetchService {
             const { nextSyncCursor, folderId } = messageList;
 
             await this.messagingCursorService.updateCursor(
-              messageChannelAfterAuth,
+              messageChannelWithFreshTokens,
               nextSyncCursor,
               workspaceId,
               folderId,
@@ -253,7 +253,7 @@ export class MessagingMessageListFetchService {
                   messageExternalIds: toDeleteChunk.filter(
                     (messageExternalId) => isNonEmptyString(messageExternalId),
                   ),
-                  messageChannelId: messageChannelAfterAuth.id,
+                  messageChannelId: messageChannelWithFreshTokens.id,
                 },
               );
             }
@@ -265,7 +265,7 @@ export class MessagingMessageListFetchService {
 
           if (totalMessagesToImportCount === 0) {
             await this.messageChannelSyncStatusService.markAsCompletedAndMarkAsMessagesListFetchPending(
-              [messageChannelAfterAuth.id],
+              [messageChannelWithFreshTokens.id],
               workspaceId,
             );
 
@@ -277,16 +277,16 @@ export class MessagingMessageListFetchService {
           );
 
           await this.messageChannelSyncStatusService.markAsMessagesImportScheduled(
-            [messageChannelAfterAuth.id],
+            [messageChannelWithFreshTokens.id],
             workspaceId,
           );
 
           await this.messagingMessagesImportService.processMessageBatchImport(
             {
-              ...messageChannelAfterAuth,
+              ...messageChannelWithFreshTokens,
               syncStage: MessageChannelSyncStage.MESSAGES_IMPORT_SCHEDULED,
             },
-            messageChannelAfterAuth.connectedAccount,
+            messageChannelWithFreshTokens.connectedAccount,
             workspaceId,
           );
         } catch (error) {


### PR DESCRIPTION
# Introduction
Jobs were refreshing token and returning them as plain text, resulting to underlying code flow failure as expecting encrypted tokens

## Next
We should define a strong typescript signature to avoid such things to happen again, or least have an explicit naming