### PR TITLE
fix(server): remove "for for" duplicate-word typo in workflow-clean job comments

### DIFF
--- a/packages/twenty-server/src/modules/workflow/workflow-runner/workflow-run-queue/jobs/workflow-clean-workflow-runs.job.ts
+++ b/packages/twenty-server/src/modules/workflow/workflow-runner/workflow-run-queue/jobs/workflow-clean-workflow-runs.job.ts
@@ -92,7 +92,7 @@ export class WorkflowCleanWorkflowRunsJob {
         ],
       );
 
-      // TypeORM's dataSource.query() for for DELETE ... RETURNING returns a tuple [rows, affectedCount]
+      // TypeORM's dataSource.query() for DELETE ... RETURNING returns a tuple [rows, affectedCount]
       deletedCount = result[0].length;
       totalDeleted += deletedCount;
     } while (deletedCount > 0);
@@ -139,7 +139,7 @@ export class WorkflowCleanWorkflowRunsJob {
         ],
       );
 
-      // TypeORM's dataSource.query() for for DELETE ... RETURNING returns a tuple [rows, affectedCount]
+      // TypeORM's dataSource.query() for DELETE ... RETURNING returns a tuple [rows, affectedCount]
       deletedCount = result[0].length;
       totalDeleted += deletedCount;
     } while (deletedCount > 0);


### PR DESCRIPTION
## Summary

Two identical inline comments in \`workflow-clean-workflow-runs.job.ts\` (lines 95 and 142) share a duplicated \`for\`:

\`\`\`diff
- // TypeORM's dataSource.query() for for DELETE ... RETURNING returns a tuple [rows, affectedCount]
+ // TypeORM's dataSource.query() for DELETE ... RETURNING returns a tuple [rows, affectedCount]
\`\`\`

Same comment is repeated in two near-identical \`do { ... } while\` loops inside the job, suggesting a copy-paste of the original typo. Both occurrences fixed.

Diff is exactly 2 lines, comment-only — no runtime behaviour change.

## Novelty

\`gh pr list -R twentyhq/twenty --search 'for for DELETE'\` and \`--search 'workflow-clean'\` return no open PR touching this file. No open typo PRs at all.

## Test plan

- [x] Pure comment edit — no behaviour change.
- [x] \`grep -n 'for for ' packages/twenty-server/src/modules/workflow/workflow-runner/workflow-run-queue/jobs/workflow-clean-workflow-runs.job.ts\` returns no matches after the fix.