### PR TITLE
[Website] force-static releases page & move workspace bullet to pro self-host

### DIFF
--- a/packages/twenty-website/src/app/[locale]/releases/page.tsx
+++ b/packages/twenty-website/src/app/[locale]/releases/page.tsx
@@ -18,6 +18,8 @@ import { theme } from '@/theme';
 import { buildReleaseListJsonLd, buildRouteMetadata, JsonLd } from '@/lib/seo';
 import { Fragment } from 'react';
 
+export const dynamic = 'force-static';
+
 export const generateMetadata = buildRouteMetadata('releases');
 
 type ReleasesPageProps = {

--- a/packages/twenty-website/src/sections/Plans/data.ts
+++ b/packages/twenty-website/src/sections/Plans/data.ts
@@ -23,6 +23,7 @@ const PRO_BULLETS_YEARLY = [
 const PRO_BULLETS_SELF_HOST = [
   msg`Full customization`,
   msg`Create custom apps`,
+  msg`Up to 5 workspaces`,
   msg`Community support`,
 ];
 
@@ -48,7 +49,6 @@ const ORGANIZATION_BULLETS_SELF_HOST = [
   msg`Row-level permissions`,
   msg`SAML/OIDC SSO`,
   msg`Twenty team support`,
-  msg`Up to 5 workspaces`,
 ];
 
 export const PLANS_DATA = {


### PR DESCRIPTION
Add `export const dynamic = 'force-static'` to the releases page to prevent runtime re-renders on Cloudflare Workers where fs is unavailable, which caused stale "Releases were not found" errors after ISR cache eviction. 

Also moves the "Up to 5 workspaces" bullet from the Organization plan to the Pro plan on the self-hosting pricing view.