### PR TITLE
Fix permission flag removed flag property from diffing

### DIFF
--- a/packages/twenty-server/src/engine/metadata-modules/flat-entity/constant/__tests__/__snapshots__/all-universal-flat-entity-properties-to-compare-and-stringify.constant.spec.ts.snap
+++ b/packages/twenty-server/src/engine/metadata-modules/flat-entity/constant/__tests__/__snapshots__/all-universal-flat-entity-properties-to-compare-and-stringify.constant.spec.ts.snap
@@ -258,7 +258,6 @@ exports[`ALL_UNIVERSAL_FLAT_ENTITY_PROPERTIES_TO_COMPARE_AND_STRINGIFY should ma
     "propertiesToCompare": [
       "permissionFlagUniversalIdentifier",
       "roleUniversalIdentifier",
-      "flag",
     ],
     "propertiesToStringify": [],
   },

--- a/packages/twenty-server/src/engine/metadata-modules/flat-entity/constant/all-entity-properties-configuration-by-metadata-name.constant.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/flat-entity/constant/all-entity-properties-configuration-by-metadata-name.constant.ts
@@ -1198,7 +1198,7 @@ export const ALL_ENTITY_PROPERTIES_CONFIGURATION_BY_METADATA_NAME = {
       universalProperty: 'roleUniversalIdentifier',
     },
     flag: {
-      toCompare: true,
+      toCompare: false,
       toStringify: false,
       universalProperty: undefined,
     },


### PR DESCRIPTION
## Why it fixes the bug

RolePermissionFlagEntity.flag (role-permission-flag.entity.ts:54) is marked @WasRemovedInUpgrade for 2.7.0_FinalizeRolePermissionFlagCutoverFastInstanceCommand. 
After 2.7.0, the column is gone from real DBs and the metadata layer no longer accepts writes to it — but the diffing config still listed flag with toCompare: true. So when an SDK-generated manifest carried a flag value, computeUniversalFlatEntityPropertiesToCompareAndStringify (all-universal-flat-entity-properties-to-compare-and-stringify.constant.ts:55-69) included it in the comparison, the diff emitted { update: { flag: "UPLOAD_FILE" } }, and the metadata update failed with Property "flag" was not found in "RolePermissionFlagEntity".

Switching toCompare: false makes the diff skip flag; the only properties compared are now permissionFlagUniversalIdentifier and roleUniversalIdentifier, which is what the post-cutover
entity actually supports.

Fixes https://github.com/twentyhq/twenty/issues/20843