### PR TITLE
fix(ai-chat): clean up orphan thread when first send fails

### DIFF
--- a/packages/twenty-front/src/modules/ai/hooks/useAgentChat.ts
+++ b/packages/twenty-front/src/modules/ai/hooks/useAgentChat.ts
@@ -11,6 +11,7 @@ import { AGENT_CHAT_REFETCH_MESSAGES_EVENT_NAME } from '@/ai/constants/AgentChat
 import { AGENT_CHAT_RESTORE_EDITOR_CONTENT_EVENT_NAME } from '@/ai/constants/AgentChatRestoreEditorContentEventName';
 import { AGENT_CHAT_SEND_MESSAGE_EVENT_NAME } from '@/ai/constants/AgentChatSendMessageEventName';
 import { AGENT_CHAT_STOP_EVENT_NAME } from '@/ai/constants/AgentChatStopEventName';
+import { DELETE_CHAT_THREAD } from '@/ai/graphql/mutations/deleteChatThread';
 import { SEND_CHAT_MESSAGE } from '@/ai/graphql/mutations/sendChatMessage';
 import { STOP_AGENT_CHAT_STREAM } from '@/ai/graphql/mutations/stopAgentChatStream';
 import { useAgentChatModelId } from '@/ai/hooks/useAgentChatModelId';
@@ -29,9 +30,13 @@ import { agentChatUploadedFilesState } from '@/ai/states/agentChatUploadedFilesS
 import { currentAiChatThreadState } from '@/ai/states/currentAiChatThreadState';
 import { useListenToBrowserEvent } from '@/browser-event/hooks/useListenToBrowserEvent';
 import { dispatchBrowserEvent } from '@/browser-event/utils/dispatchBrowserEvent';
+import { useUpdateMetadataStoreDraft } from '@/metadata-store/hooks/useUpdateMetadataStoreDraft';
 import { useSnackBar } from '@/ui/feedback/snack-bar-manager/hooks/useSnackBar';
 import { useAtomState } from '@/ui/utilities/state/jotai/hooks/useAtomState';
 import { useSetAtomState } from '@/ui/utilities/state/jotai/hooks/useSetAtomState';
+import { isGraphqlErrorOfType } from '~/utils/is-graphql-error-of-type.util';
+
+const AI_THREAD_NOT_FOUND_ERROR_CODE = 'THREAD_NOT_FOUND';
 
 export const useAgentChat = (
   ensureThreadIdForSend: () => Promise<string | null>,
@@ -42,6 +47,7 @@ export const useAgentChat = (
   const apolloClient = useApolloClient();
   const { enqueueErrorSnackBar } = useSnackBar();
   const setCurrentAiChatThread = useSetAtomState(currentAiChatThreadState);
+  const { removeFromDraft, applyChanges } = useUpdateMetadataStoreDraft();
   const store = useStore();
 
   const [, setPendingThreadIdAfterFirstSend] = useState<string | null>(null);
@@ -193,8 +199,20 @@ export const useAgentChat = (
         return null;
       });
     } catch (error) {
-      const restoredDraftKey =
-        draftKey === AGENT_CHAT_NEW_THREAD_DRAFT_KEY ? threadId : draftKey;
+      const isFirstSendForNewThread =
+        draftKey === AGENT_CHAT_NEW_THREAD_DRAFT_KEY;
+      const isThreadMissing = isGraphqlErrorOfType(
+        error,
+        AI_THREAD_NOT_FOUND_ERROR_CODE,
+      );
+      const shouldResetToNewThread = isFirstSendForNewThread || isThreadMissing;
+
+      const restoredDraftKey = shouldResetToNewThread
+        ? AGENT_CHAT_NEW_THREAD_DRAFT_KEY
+        : draftKey;
+      const errorTargetThreadId = shouldResetToNewThread
+        ? AGENT_CHAT_NEW_THREAD_DRAFT_KEY
+        : threadId;
 
       rollbackOptimisticUnarchive?.();
 
@@ -202,9 +220,6 @@ export const useAgentChat = (
       setAgentChatDraftsByThreadId((prev) => ({
         ...prev,
         [restoredDraftKey]: contentToSend,
-        ...(draftKey === AGENT_CHAT_NEW_THREAD_DRAFT_KEY
-          ? { [AGENT_CHAT_NEW_THREAD_DRAFT_KEY]: '' }
-          : {}),
       }));
       setAgentChatUploadedFiles(uploadedFilesSnapshot);
 
@@ -215,19 +230,38 @@ export const useAgentChat = (
         latestMessages.filter((message) => message.id !== messageId),
       );
 
-      store.set(
-        errorAtom,
+      const normalizedError =
         CombinedGraphQLErrors.is(error) || error instanceof Error
           ? error
-          : new Error('An unexpected error occurred'),
+          : new Error('An unexpected error occurred');
+
+      store.set(
+        agentChatErrorComponentFamilyState.atomFamily({
+          instanceId: AGENT_CHAT_INSTANCE_ID,
+          familyKey: { threadId: errorTargetThreadId },
+        }),
+        normalizedError,
       );
 
       dispatchBrowserEvent(AGENT_CHAT_RESTORE_EDITOR_CONTENT_EVENT_NAME, {
         content: contentToSend,
       });
 
-      if (draftKey === AGENT_CHAT_NEW_THREAD_DRAFT_KEY) {
-        setCurrentAiChatThread(threadId);
+      if (shouldResetToNewThread) {
+        removeFromDraft({ key: 'agentChatThreads', itemIds: [threadId] });
+        applyChanges();
+        setCurrentAiChatThread(AGENT_CHAT_NEW_THREAD_DRAFT_KEY);
+
+        if (isFirstSendForNewThread) {
+          // Best-effort orphan cleanup; safe to ignore failure because
+          // currentAiChatThreadState is already reset.
+          apolloClient
+            .mutate({
+              mutation: DELETE_CHAT_THREAD,
+              variables: { id: threadId },
+            })
+            .catch(() => undefined);
+        }
       }
 
       setPendingThreadIdAfterFirstSend(null);


### PR DESCRIPTION
## Bug

When the user tries to send their first AI chat message without an API key configured (or the worker is otherwise unable to handle the send), the frontend:

1. Calls `createChatThread`, which **succeeds** — a thread row is persisted in the database.
2. Calls `sendChatMessage`, which fails (e.g. `API_KEY_NOT_CONFIGURED`).
3. Commits the freshly created threadId into `currentAiChatThreadState`.

After the user configures the API key and retries, the chat panel can end up stuck on \"Chat thread not found.\" — the persisted threadId no longer resolves to a usable thread, and there is no way to recover from the UI without manually starting a new chat.

## Fix

In `useAgentChat`'s catch block, treat two cases as \"reset to a fresh new-thread state\":

- **First send for a brand-new thread fails** (`draftKey === AGENT_CHAT_NEW_THREAD_DRAFT_KEY`):
  - Best-effort `deleteChatThread` on the backend so the orphan doesn't linger.
  - Remove the thread from the metadata store.
  - Reset `currentAiChatThreadState` to the new-thread placeholder.
  - Show the error and restore the draft against the placeholder so the next send creates a fresh thread.
- **Any send fails with `THREAD_NOT_FOUND`** (detected via GraphQL error `subCode`):
  - Same reset path. The thread is already gone, so we skip the backend delete.

Other send errors keep the existing behavior (error shown on the existing thread, draft restored on the existing thread).

## Test plan

- [ ] Ask AI with no API key configured: send a message → see error.
- [ ] Configure an API key → next send creates a new thread and succeeds (no \"Chat thread not found\").
- [ ] Backend: confirm no orphan rows in `agent_chat_thread` after the failure path.
- [ ] Existing thread: artificially delete the thread (e.g. via DB) → next send resets to a new thread instead of staying stuck.
- [ ] Regular send error (e.g. credit exhaustion) on an existing thread still shows the error inline without resetting.