### PR TITLE
refactor(jwt): gate signing-key auto-rotation cron on SIGNING_KEY_ROTATION_DAYS

### DIFF
--- a/packages/twenty-docs/developers/self-host/capabilities/key-rotation.mdx
+++ b/packages/twenty-docs/developers/self-host/capabilities/key-rotation.mdx
@@ -16,10 +16,9 @@ Each key carries a `publicKey` (kept indefinitely so it can verify previously is
 
 ### Rotate the current key
 
-- **Manual** — **Settings → Admin Panel → Signing keys → Revoke** on the current row. Revoking wipes its encrypted private material and demotes it; the next sign call automatically mints a fresh ES256 keypair as the new current. Tokens signed under any other (non-revoked) `kid` keep verifying until they expire.
-- **Automatic** — set `SIGNING_KEY_ROTATION_DAYS` to opt in: a daily cron then issues a new current key once the existing one is older than that threshold. Previous keys are *not* revoked, so tokens signed under them keep verifying. Leave the variable unset to disable auto-rotation.
+Set `SIGNING_KEY_ROTATION_DAYS` to opt in: a daily cron then issues a new current key once the existing one is older than that threshold. Previous keys are *not* revoked, so tokens signed under them keep verifying. Leave the variable unset to disable auto-rotation.
 
-  <Note>Auto-rotation ships in v2.6+.</Note>
+<Note>Auto-rotation ships in v2.6+.</Note>
 
 ### Revoke a key (leak / emergency only)
 

--- a/packages/twenty-docs/developers/self-host/capabilities/key-rotation.mdx
+++ b/packages/twenty-docs/developers/self-host/capabilities/key-rotation.mdx
@@ -17,9 +17,9 @@ Each key carries a `publicKey` (kept indefinitely so it can verify previously is
 ### Rotate the current key
 
 - **Manual** — **Settings → Admin Panel → Signing keys → Revoke** on the current row. Revoking wipes its encrypted private material and demotes it; the next sign call automatically mints a fresh ES256 keypair as the new current. Tokens signed under any other (non-revoked) `kid` keep verifying until they expire.
-- **Enterprise (automatic)** — a daily cron (`'15 3 * * *'` UTC) issues a new current key once the existing one has been current for `SIGNING_KEY_ROTATION_DAYS` (default `90`). The previous key is *not* revoked, so tokens signed under it keep verifying. Set `IS_SIGNING_KEY_AUTO_ROTATION_ENABLED=true` (default `false`) so `yarn command:prod cron:register:all` includes it, then register all crons once with that command. Running `yarn command:prod cron:rotate-signing-keys` directly always registers it regardless of the flag.
+- **Enterprise (automatic)** — a daily cron (`'15 3 * * *'` UTC) issues a new current key once the existing one has been current for `SIGNING_KEY_ROTATION_DAYS`. Setting this variable both opts in to the rotation and configures the threshold; when it is unset, `yarn command:prod cron:register:all` skips the rotation cron and any direct `yarn command:prod cron:rotate-signing-keys` invocation is a no-op. The previous key is *not* revoked, so tokens signed under it keep verifying.
 
-  <Note>The Enterprise cron, `IS_SIGNING_KEY_AUTO_ROTATION_ENABLED` and `SIGNING_KEY_ROTATION_DAYS` ship in v2.6+.</Note>
+  <Note>The Enterprise cron and `SIGNING_KEY_ROTATION_DAYS` ship in v2.6+.</Note>
 
 ### Revoke a key (leak / emergency only)
 

--- a/packages/twenty-docs/developers/self-host/capabilities/key-rotation.mdx
+++ b/packages/twenty-docs/developers/self-host/capabilities/key-rotation.mdx
@@ -17,9 +17,9 @@ Each key carries a `publicKey` (kept indefinitely so it can verify previously is
 ### Rotate the current key
 
 - **Manual** — **Settings → Admin Panel → Signing keys → Revoke** on the current row. Revoking wipes its encrypted private material and demotes it; the next sign call automatically mints a fresh ES256 keypair as the new current. Tokens signed under any other (non-revoked) `kid` keep verifying until they expire.
-- **Enterprise (automatic)** — a daily cron (`'15 3 * * *'` UTC) issues a new current key once the existing one has been current for `SIGNING_KEY_ROTATION_DAYS` (default `90`). The previous key is *not* revoked, so tokens signed under it keep verifying. Register it once with `yarn command:prod cron:register:all`.
+- **Enterprise (automatic)** — a daily cron (`'15 3 * * *'` UTC) issues a new current key once the existing one has been current for `SIGNING_KEY_ROTATION_DAYS` (default `90`). The previous key is *not* revoked, so tokens signed under it keep verifying. Set `IS_SIGNING_KEY_AUTO_ROTATION_ENABLED=true` (default `false`) so `yarn command:prod cron:register:all` includes it, then register all crons once with that command. Running `yarn command:prod cron:rotate-signing-keys` directly always registers it regardless of the flag.
 
-  <Note>The Enterprise cron and `SIGNING_KEY_ROTATION_DAYS` ship in v2.6+.</Note>
+  <Note>The Enterprise cron, `IS_SIGNING_KEY_AUTO_ROTATION_ENABLED` and `SIGNING_KEY_ROTATION_DAYS` ship in v2.6+.</Note>
 
 ### Revoke a key (leak / emergency only)
 

--- a/packages/twenty-docs/developers/self-host/capabilities/key-rotation.mdx
+++ b/packages/twenty-docs/developers/self-host/capabilities/key-rotation.mdx
@@ -17,9 +17,9 @@ Each key carries a `publicKey` (kept indefinitely so it can verify previously is
 ### Rotate the current key
 
 - **Manual** — **Settings → Admin Panel → Signing keys → Revoke** on the current row. Revoking wipes its encrypted private material and demotes it; the next sign call automatically mints a fresh ES256 keypair as the new current. Tokens signed under any other (non-revoked) `kid` keep verifying until they expire.
-- **Enterprise (automatic)** — a daily cron (`'15 3 * * *'` UTC) issues a new current key once the existing one has been current for `SIGNING_KEY_ROTATION_DAYS`. Setting this variable both opts in to the rotation and configures the threshold; when it is unset, `yarn command:prod cron:register:all` skips the rotation cron and any direct `yarn command:prod cron:rotate-signing-keys` invocation is a no-op. The previous key is *not* revoked, so tokens signed under it keep verifying.
+- **Automatic** — set `SIGNING_KEY_ROTATION_DAYS` to opt in: a daily cron then issues a new current key once the existing one is older than that threshold. Previous keys are *not* revoked, so tokens signed under them keep verifying. Leave the variable unset to disable auto-rotation.
 
-  <Note>The Enterprise cron and `SIGNING_KEY_ROTATION_DAYS` ship in v2.6+.</Note>
+  <Note>Auto-rotation ships in v2.6+.</Note>
 
 ### Revoke a key (leak / emergency only)
 

--- a/packages/twenty-server/src/database/commands/cron-register-all.command.ts
+++ b/packages/twenty-server/src/database/commands/cron-register-all.command.ts
@@ -10,6 +10,7 @@ import { EventLogCleanupCronCommand } from 'src/engine/core-modules/event-logs/c
 import { RotateSigningKeysCronCommand } from 'src/engine/core-modules/jwt/crons/commands/rotate-signing-keys.cron.command';
 import { CronTriggerCronCommand } from 'src/engine/core-modules/logic-function/logic-function-trigger/triggers/cron/cron-trigger.cron.command';
 import { CheckPublicDomainsValidRecordsCronCommand } from 'src/engine/core-modules/public-domain/crons/commands/check-public-domains-valid-records.cron.command';
+import { TwentyConfigService } from 'src/engine/core-modules/twenty-config/twenty-config.service';
 import { CheckCustomDomainValidRecordsCronCommand } from 'src/engine/core-modules/workspace/crons/commands/check-custom-domain-valid-records.cron.command';
 import { TrashCleanupCronCommand } from 'src/engine/trash-cleanup/commands/trash-cleanup.cron.command';
 import { CleanOnboardingWorkspacesCronCommand } from 'src/engine/workspace-manager/workspace-cleaner/commands/clean-onboarding-workspaces.cron.command';
@@ -62,12 +63,17 @@ export class CronRegisterAllCommand extends CommandRunner {
     private readonly marketplaceCatalogSyncCronCommand: MarketplaceCatalogSyncCronCommand,
     private readonly applicationVersionCheckCronCommand: ApplicationVersionCheckCronCommand,
     private readonly staleRegistrationCleanupCronCommand: StaleRegistrationCleanupCronCommand,
+    private readonly twentyConfigService: TwentyConfigService,
   ) {
     super();
   }
 
   async run(): Promise<void> {
     this.logger.log('Registering all background sync cron jobs...');
+
+    const isSigningKeyAutoRotationEnabled = this.twentyConfigService.get(
+      'IS_SIGNING_KEY_AUTO_ROTATION_ENABLED',
+    );
 
     const allCommands = [
       {
@@ -161,6 +167,7 @@ export class CronRegisterAllCommand extends CommandRunner {
       {
         name: 'RotateSigningKeys',
         command: this.rotateSigningKeysCronCommand,
+        isEnabled: isSigningKeyAutoRotationEnabled,
       },
       {
         name: 'StaleRegistrationCleanup',
@@ -172,8 +179,15 @@ export class CronRegisterAllCommand extends CommandRunner {
     let failureCount = 0;
     const failures: string[] = [];
     const successes: string[] = [];
+    const skipped: string[] = [];
 
-    for (const { name, command } of allCommands) {
+    for (const { name, command, isEnabled = true } of allCommands) {
+      if (!isEnabled) {
+        this.logger.log(`Skipping ${name} cron job (disabled by config)`);
+        skipped.push(name);
+        continue;
+      }
+
       try {
         this.logger.log(`Registering ${name} cron job...`);
         await command.run();
@@ -188,7 +202,7 @@ export class CronRegisterAllCommand extends CommandRunner {
     }
 
     this.logger.log(
-      `Cron job registration completed: ${successCount} successful, ${failureCount} failed`,
+      `Cron job registration completed: ${successCount} successful, ${failureCount} failed, ${skipped.length} skipped`,
     );
 
     if (failures.length > 0) {
@@ -197,6 +211,10 @@ export class CronRegisterAllCommand extends CommandRunner {
 
     if (successCount > 0) {
       this.logger.log(`Successful commands: ${successes.join(', ')}`);
+    }
+
+    if (skipped.length > 0) {
+      this.logger.log(`Skipped commands: ${skipped.join(', ')}`);
     }
   }
 }

--- a/packages/twenty-server/src/database/commands/cron-register-all.command.ts
+++ b/packages/twenty-server/src/database/commands/cron-register-all.command.ts
@@ -1,6 +1,7 @@
 import { Logger } from '@nestjs/common';
 
 import { Command, CommandRunner } from 'nest-commander';
+import { isDefined } from 'twenty-shared/utils';
 
 import { MarketplaceCatalogSyncCronCommand } from 'src/engine/core-modules/application/application-marketplace/crons/commands/marketplace-catalog-sync.cron.command';
 import { StaleRegistrationCleanupCronCommand } from 'src/engine/core-modules/application/application-oauth/stale-registration-cleanup/commands/stale-registration-cleanup.cron.command';
@@ -71,8 +72,8 @@ export class CronRegisterAllCommand extends CommandRunner {
   async run(): Promise<void> {
     this.logger.log('Registering all background sync cron jobs...');
 
-    const isSigningKeyAutoRotationEnabled = this.twentyConfigService.get(
-      'IS_SIGNING_KEY_AUTO_ROTATION_ENABLED',
+    const isSigningKeyAutoRotationEnabled = isDefined(
+      this.twentyConfigService.get('SIGNING_KEY_ROTATION_DAYS'),
     );
 
     const allCommands = [

--- a/packages/twenty-server/src/engine/core-modules/twenty-config/config-variables.ts
+++ b/packages/twenty-server/src/engine/core-modules/twenty-config/config-variables.ts
@@ -1187,6 +1187,15 @@ export class ConfigVariables {
   @ConfigVariablesMetadata({
     group: ConfigVariablesGroup.SERVER_CONFIG,
     description:
+      'Enable the Enterprise JWT signing key auto-rotation cron when registering background jobs via cron:register:all. When false (default), the cron is not registered.',
+    type: ConfigVariableType.BOOLEAN,
+  })
+  @IsOptional()
+  IS_SIGNING_KEY_AUTO_ROTATION_ENABLED = false;
+
+  @ConfigVariablesMetadata({
+    group: ConfigVariablesGroup.SERVER_CONFIG,
+    description:
       'Number of days after which the Enterprise auto-rotation cron issues a new current JWT signing key. When unset, the cron is a no-op. Previous keys remain in the database to keep verifying tokens they signed; revocation stays a manual admin action.',
     type: ConfigVariableType.NUMBER,
   })

--- a/packages/twenty-server/src/engine/core-modules/twenty-config/config-variables.ts
+++ b/packages/twenty-server/src/engine/core-modules/twenty-config/config-variables.ts
@@ -1185,18 +1185,9 @@ export class ConfigVariables {
   FALLBACK_ENCRYPTION_KEY: string;
 
   @ConfigVariablesMetadata({
-    group: ConfigVariablesGroup.SERVER_CONFIG,
+    group: ConfigVariablesGroup.ADVANCED_SETTINGS,
     description:
-      'Enable the Enterprise JWT signing key auto-rotation cron when registering background jobs via cron:register:all. When false (default), the cron is not registered.',
-    type: ConfigVariableType.BOOLEAN,
-  })
-  @IsOptional()
-  IS_SIGNING_KEY_AUTO_ROTATION_ENABLED = false;
-
-  @ConfigVariablesMetadata({
-    group: ConfigVariablesGroup.SERVER_CONFIG,
-    description:
-      'Number of days after which the Enterprise auto-rotation cron issues a new current JWT signing key. When unset, the cron is a no-op. Previous keys remain in the database to keep verifying tokens they signed; revocation stays a manual admin action.',
+      'Number of days after which the Enterprise auto-rotation cron issues a new current JWT signing key. When unset, cron:register:all skips the rotation cron and any direct invocation is a no-op. Previous keys remain in the database to keep verifying tokens they signed; revocation stays a manual admin action.',
     type: ConfigVariableType.NUMBER,
   })
   @CastToPositiveNumber()

--- a/packages/twenty-server/src/engine/core-modules/twenty-config/config-variables.ts
+++ b/packages/twenty-server/src/engine/core-modules/twenty-config/config-variables.ts
@@ -1187,7 +1187,7 @@ export class ConfigVariables {
   @ConfigVariablesMetadata({
     group: ConfigVariablesGroup.ADVANCED_SETTINGS,
     description:
-      'Number of days after which the Enterprise auto-rotation cron issues a new current JWT signing key. When unset, cron:register:all skips the rotation cron and any direct invocation is a no-op. Previous keys remain in the database to keep verifying tokens they signed; revocation stays a manual admin action.',
+      'Days the current JWT signing key stays valid before the rotation cron issues a new one. Leave unset to disable auto-rotation.',
     type: ConfigVariableType.NUMBER,
   })
   @CastToPositiveNumber()


### PR DESCRIPTION
Only register the JWT signing-key rotation cron when `SIGNING_KEY_ROTATION_DAYS` is set, and move that variable to Advanced Settings.