### PR TITLE
Fix OpenAI ZDR chat history replay

### DIFF
--- a/packages/twenty-server/.env.example
+++ b/packages/twenty-server/.env.example
@@ -87,6 +87,7 @@ FRONTEND_URL=http://localhost:3001
 # ———————— AI ————————
 # API keys for built-in providers (also editable from Admin Panel > Config Variables):
 # OPENAI_API_KEY=
+# OPENAI_ZERO_DATA_RETENTION_ENABLED=false
 # ANTHROPIC_API_KEY=
 # GOOGLE_API_KEY=
 # XAI_API_KEY=

--- a/packages/twenty-server/src/engine/core-modules/twenty-config/config-variables.ts
+++ b/packages/twenty-server/src/engine/core-modules/twenty-config/config-variables.ts
@@ -1370,6 +1370,15 @@ export class ConfigVariables {
 
   @ConfigVariablesMetadata({
     group: ConfigVariablesGroup.LLM,
+    description:
+      'Enable compatibility mode for OpenAI organizations or projects with Zero Data Retention. Replays prior tool results as text instead of OpenAI item references.',
+    type: ConfigVariableType.BOOLEAN,
+  })
+  @IsOptional()
+  OPENAI_ZERO_DATA_RETENTION_ENABLED = false;
+
+  @ConfigVariablesMetadata({
+    group: ConfigVariablesGroup.LLM,
     isSensitive: true,
     description: 'API key for Anthropic models (Claude)',
     type: ConfigVariableType.STRING,

--- a/packages/twenty-server/src/engine/metadata-modules/ai/ai-chat/services/chat-execution.service.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/ai/ai-chat/services/chat-execution.service.ts
@@ -27,6 +27,7 @@ import { WorkspaceDomainsService } from 'src/engine/core-modules/domain/workspac
 import { ExceptionHandlerService } from 'src/engine/core-modules/exception-handler/exception-handler.service';
 import { NativeToolBinderService } from 'src/engine/core-modules/tool-provider/native/native-tool-binder.service';
 import { ToolRegistryService } from 'src/engine/core-modules/tool-provider/services/tool-registry.service';
+import { TwentyConfigService } from 'src/engine/core-modules/twenty-config/twenty-config.service';
 import {
   createExecuteToolTool,
   createLearnToolsTool,
@@ -59,6 +60,8 @@ import {
   getCallLevelCacheProviderOptions,
   injectCacheBreakpoint,
 } from 'src/engine/metadata-modules/ai/ai-chat/utils/inject-cache-breakpoint.util';
+import { sanitizeOpenAiZdrMessageHistory } from 'src/engine/metadata-modules/ai/ai-chat/utils/sanitize-openai-zdr-message-history.util';
+import { AI_SDK_OPENAI } from 'src/engine/metadata-modules/ai/ai-models/constants/ai-sdk-package.const';
 import { AI_TELEMETRY_CONFIG } from 'src/engine/metadata-modules/ai/ai-models/constants/ai-telemetry.const';
 import { AiModelRegistryService } from 'src/engine/metadata-modules/ai/ai-models/services/ai-model-registry.service';
 import { type AiModelConfig } from 'src/engine/metadata-modules/ai/ai-models/types/ai-model-config.type';
@@ -99,6 +102,7 @@ export class ChatExecutionService {
     private readonly nativeToolBinder: NativeToolBinderService,
     private readonly messagePruningService: MessagePruningService,
     private readonly metricsService: MetricsService,
+    private readonly twentyConfigService: TwentyConfigService,
   ) {}
 
   async streamChat({
@@ -257,7 +261,19 @@ export class ChatExecutionService {
       providerOptions: getCacheProviderOptions(registeredModel.sdkPackage),
     };
 
-    const rawModelMessages = await convertToModelMessages(processedMessages);
+    const isOpenAiZeroDataRetentionEnabled = this.twentyConfigService.get(
+      'OPENAI_ZERO_DATA_RETENTION_ENABLED',
+    );
+
+    // OpenAI Zero Data Retention organizations do not persist response items,
+    // so replay tool results as plain text instead of tool-call item IDs.
+    const messagesForModel =
+      registeredModel.sdkPackage === AI_SDK_OPENAI &&
+      isOpenAiZeroDataRetentionEnabled
+        ? sanitizeOpenAiZdrMessageHistory(processedMessages)
+        : processedMessages;
+
+    const rawModelMessages = await convertToModelMessages(messagesForModel);
 
     const pruningResult =
       this.messagePruningService.pruneIfOverContextWindowLimit(

--- a/packages/twenty-server/src/engine/metadata-modules/ai/ai-chat/utils/__tests__/sanitize-openai-zdr-message-history.util.spec.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/ai/ai-chat/utils/__tests__/sanitize-openai-zdr-message-history.util.spec.ts
@@ -1,0 +1,94 @@
+import { type UIMessage } from 'ai';
+
+import { sanitizeOpenAiZdrMessageHistory } from 'src/engine/metadata-modules/ai/ai-chat/utils/sanitize-openai-zdr-message-history.util';
+
+describe('sanitizeOpenAiZdrMessageHistory', () => {
+  it('replaces persisted tool parts with text so OpenAI ZDR does not receive tool call ids', () => {
+    const messages = [
+      {
+        id: 'message-1',
+        role: 'assistant',
+        parts: [
+          {
+            type: 'tool-get_people',
+            toolCallId: 'fc_123',
+            input: { limit: 1 },
+            output: { people: [{ name: 'Ada Lovelace' }] },
+            state: 'output-available',
+          },
+          {
+            type: 'text',
+            text: 'Found one person.',
+          },
+        ],
+      },
+    ] as unknown as UIMessage[];
+
+    const sanitized = sanitizeOpenAiZdrMessageHistory(messages);
+
+    expect(sanitized).toEqual([
+      {
+        id: 'message-1',
+        role: 'assistant',
+        parts: [
+          {
+            type: 'text',
+            text: [
+              'Tool result (get_people):',
+              JSON.stringify({ people: [{ name: 'Ada Lovelace' }] }, null, 2),
+            ].join('\n'),
+          },
+          {
+            type: 'text',
+            text: 'Found one person.',
+          },
+        ],
+      },
+    ]);
+    expect(JSON.stringify(sanitized)).not.toContain('fc_123');
+    expect(JSON.stringify(sanitized)).not.toContain('toolCallId');
+  });
+
+  it('keeps user and non-tool assistant parts unchanged', () => {
+    const messages = [
+      {
+        id: 'message-1',
+        role: 'user',
+        parts: [{ type: 'text', text: 'Summarize this file' }],
+      },
+      {
+        id: 'message-2',
+        role: 'assistant',
+        parts: [
+          {
+            type: 'source-url',
+            sourceId: 'source-1',
+            url: 'https://example.com',
+            title: 'Example',
+          },
+        ],
+      },
+    ] as unknown as UIMessage[];
+
+    expect(sanitizeOpenAiZdrMessageHistory(messages)).toEqual(messages);
+  });
+
+  it('drops messages that only contain tool calls without output or errors', () => {
+    const messages = [
+      {
+        id: 'message-1',
+        role: 'assistant',
+        parts: [
+          {
+            type: 'tool-get_people',
+            toolCallId: 'fc_123',
+            input: { limit: 1 },
+            state: 'input-available',
+          },
+        ],
+      },
+    ] as unknown as UIMessage[];
+
+    expect(sanitizeOpenAiZdrMessageHistory(messages)).toEqual([]);
+  });
+});

--- a/packages/twenty-server/src/engine/metadata-modules/ai/ai-chat/utils/sanitize-openai-zdr-message-history.util.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/ai/ai-chat/utils/sanitize-openai-zdr-message-history.util.ts
@@ -1,0 +1,68 @@
+import { type UIDataTypes, type UIMessage, type UITools } from 'ai';
+import { isDefined } from 'twenty-shared/utils';
+
+type ChatUIMessage = UIMessage<unknown, UIDataTypes, UITools>;
+type ChatUIMessagePart = ChatUIMessage['parts'][number];
+
+const isToolPart = (
+  part: ChatUIMessagePart,
+): part is ChatUIMessagePart & {
+  type: `tool-${string}`;
+  output?: unknown;
+  errorText?: string;
+} => part.type.startsWith('tool-');
+
+const serializeToolValue = (value: unknown): string => {
+  if (typeof value === 'string') {
+    return value;
+  }
+
+  try {
+    return JSON.stringify(value, null, 2);
+  } catch {
+    return String(value);
+  }
+};
+
+const toolPartToTextPart = (
+  part: ChatUIMessagePart & {
+    type: `tool-${string}`;
+    output?: unknown;
+    errorText?: string;
+  },
+): ChatUIMessagePart | null => {
+  const toolName = part.type.replace(/^tool-/, '');
+
+  if (isDefined(part.output)) {
+    return {
+      type: 'text',
+      text: `Tool result (${toolName}):\n${serializeToolValue(part.output)}`,
+    };
+  }
+
+  if (isDefined(part.errorText) && part.errorText !== '') {
+    return {
+      type: 'text',
+      text: `Tool error (${toolName}):\n${part.errorText}`,
+    };
+  }
+
+  return null;
+};
+
+export const sanitizeOpenAiZdrMessageHistory = (
+  messages: ChatUIMessage[],
+): ChatUIMessage[] => {
+  return messages
+    .map((message) => {
+      const parts = message.parts
+        .map((part) => (isToolPart(part) ? toolPartToTextPart(part) : part))
+        .filter(isDefined);
+
+      return {
+        ...message,
+        parts,
+      };
+    })
+    .filter((message) => message.parts.length > 0);
+};


### PR DESCRIPTION
## Summary

Adds an opt-in OpenAI Zero Data Retention compatibility mode for AI chat history replay.

When `OPENAI_ZERO_DATA_RETENTION_ENABLED=true` and the selected SDK package is `@ai-sdk/openai`, replayed chat history is sanitized before model-message conversion. Prior tool results/errors are preserved as plain text context, while provider-specific persisted tool/item IDs are removed so ZDR organizations do not receive references to non-persisted OpenAI items.

The setting defaults to `false`, so existing OpenAI and non-OpenAI behavior is unchanged unless explicitly enabled.

## Tests

Passed:
- `node_modules/.bin/tsgo -p packages/twenty-server/tsconfig.json`
- Focused AI ZDR Jest spec: 3 tests passed
- Full `twenty-server` Jest suite: passed
- Changed-file lint: passed
- Changed-file format: passed
- Full server format check: passed
- `git diff --check`

Could not verify locally:
- `yarn nx typecheck twenty-server` failed before project execution with `Failed to start plugin worker`.
- Full server lint fails on existing unrelated files outside this change.

Related to issue #20877