### PR TITLE
Various fixes - some AI findings

### DIFF
--- a/packages/twenty-docs/developers/extend/apps/layout/views.mdx
+++ b/packages/twenty-docs/developers/extend/apps/layout/views.mdx
@@ -70,7 +70,7 @@ filters: [
 | `CURRENCY.currencyCode`                                                                            | `IS`, `IS_NOT`, `IS_EMPTY`, `IS_NOT_EMPTY`                                                                         |
 | `DATE`, `DATE_TIME`                                                                                | `IS`, `IS_RELATIVE`, `IS_IN_PAST`, `IS_IN_FUTURE`, `IS_TODAY`, `IS_BEFORE`, `IS_AFTER`, `IS_EMPTY`, `IS_NOT_EMPTY` |
 | `BOOLEAN`                                                                                          | `IS`                                                                                                               |
-| `UUID`                                                                                             | `IS`                                                                                                               |
+| `UUID`                                                                                             | `IS`, `IS_NOT`, `IS_EMPTY`, `IS_NOT_EMPTY`                                                                         |
 | `TS_VECTOR`                                                                                        | `VECTOR_SEARCH`                                                                                                    |
 
 > Field types with similar names can use entirely different operands — `SELECT` and `MULTI_SELECT` being a common case.

--- a/packages/twenty-front/src/pages/settings/applications/tabs/SettingsApplicationPermissionsTab.tsx
+++ b/packages/twenty-front/src/pages/settings/applications/tabs/SettingsApplicationPermissionsTab.tsx
@@ -148,10 +148,11 @@ const buildFieldMetadataItemFromMarketplaceField = (
   field: ObjectFieldManifest,
 ): FieldMetadataItem => {
   const now = new Date().toISOString();
+  const universalIdentifier = field.universalIdentifier ?? uuidv4();
 
   return {
-    id: field.universalIdentifier ?? uuidv4(),
-    universalIdentifier: field.universalIdentifier ?? uuidv4(),
+    id: universalIdentifier,
+    universalIdentifier,
     name: field.name,
     label: field.label,
     type: (field.type as FieldMetadataType) ?? FieldMetadataType.TEXT,
@@ -172,7 +173,7 @@ const buildFieldMetadataItemFromMarketplaceField = (
   };
 };
 
-const buildobjectMetadataItemsFromMarketplaceApp = (
+const buildObjectMetadataItemsFromMarketplaceApp = (
   defaultRole: RoleManifest,
   objectUniversalIdToIdMap: Record<string, string>,
   marketplaceAppObjects: ObjectManifest[],
@@ -292,7 +293,7 @@ const MarketplaceRoleEffect = ({
           fieldUniversalIdToIdMap,
         ),
         objectMetadataItemsFromMarketplaceApp:
-          buildobjectMetadataItemsFromMarketplaceApp(
+          buildObjectMetadataItemsFromMarketplaceApp(
             defaultRole,
             objectUniversalIdToIdMap,
             marketplaceAppObjects,

--- a/packages/twenty-server/src/engine/metadata-modules/flat-field-metadata/__tests__/__snapshots__/morph-relation-from-create-field-input-to-flat-field-metadatas-to-create.spec.ts.snap
+++ b/packages/twenty-server/src/engine/metadata-modules/flat-field-metadata/__tests__/__snapshots__/morph-relation-from-create-field-input-to-flat-field-metadatas-to-create.spec.ts.snap
@@ -62,7 +62,7 @@ exports[`fromCreateFieldInputToFlatFieldMetadatasToCreate MORPH_RELATION test su
       "message": "Morph relation creation payloads are empty",
       "userFriendlyMessage": {
         "id": Any<String>,
-        "message": "At least one relation is require",
+        "message": "At least one relation is required",
       },
     },
   ],

--- a/packages/twenty-server/src/engine/metadata-modules/flat-field-metadata/validators/utils/validate-morph-relation-creation-payload.util.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/flat-field-metadata/validators/utils/validate-morph-relation-creation-payload.util.ts
@@ -37,7 +37,7 @@ export const validateMorphRelationCreationPayload = async ({
         {
           code: FieldMetadataExceptionCode.FIELD_METADATA_RELATION_MALFORMED,
           message: 'Morph relation creation payloads are empty',
-          userFriendlyMessage: msg`At least one relation is require`,
+          userFriendlyMessage: msg`At least one relation is required`,
         },
       ],
     };

--- a/packages/twenty-server/src/engine/metadata-modules/view/services/view-widget-upsert.service.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/view/services/view-widget-upsert.service.ts
@@ -750,7 +750,9 @@ export class ViewWidgetUpsertService {
             inputFilter.positionInViewFilterGroup ||
           existingFilter.subFieldName !== inputFilter.subFieldName ||
           existingFilter.relationTargetFieldMetadataId !==
-            (inputFilter.relationTargetFieldMetadataId ?? null);
+            (inputFilter.relationTargetFieldMetadataId ??
+              existingFilter.relationTargetFieldMetadataId ??
+              null);
 
         if (hasChanged) {
           const {
@@ -763,7 +765,8 @@ export class ViewWidgetUpsertService {
               fieldMetadataId: inputFilter.fieldMetadataId,
               viewFilterGroupId: inputFilter.viewFilterGroupId,
               relationTargetFieldMetadataId:
-                inputFilter.relationTargetFieldMetadataId,
+                inputFilter.relationTargetFieldMetadataId ??
+                existingFilter.relationTargetFieldMetadataId,
             },
             flatEntityMaps: {
               flatFieldMetadataMaps,
@@ -786,7 +789,9 @@ export class ViewWidgetUpsertService {
             subFieldName:
               inputFilter.subFieldName ?? existingFilter.subFieldName,
             relationTargetFieldMetadataId:
-              inputFilter.relationTargetFieldMetadataId ?? null,
+              inputFilter.relationTargetFieldMetadataId ??
+              existingFilter.relationTargetFieldMetadataId ??
+              null,
             relationTargetFieldMetadataUniversalIdentifier,
             updatedAt: now,
           });

--- a/packages/twenty-server/src/engine/metadata-modules/view/services/view-widget-upsert.service.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/view/services/view-widget-upsert.service.ts
@@ -750,9 +750,7 @@ export class ViewWidgetUpsertService {
             inputFilter.positionInViewFilterGroup ||
           existingFilter.subFieldName !== inputFilter.subFieldName ||
           existingFilter.relationTargetFieldMetadataId !==
-            (inputFilter.relationTargetFieldMetadataId ??
-              existingFilter.relationTargetFieldMetadataId ??
-              null);
+            (inputFilter.relationTargetFieldMetadataId ?? null);
 
         if (hasChanged) {
           const {
@@ -765,8 +763,7 @@ export class ViewWidgetUpsertService {
               fieldMetadataId: inputFilter.fieldMetadataId,
               viewFilterGroupId: inputFilter.viewFilterGroupId,
               relationTargetFieldMetadataId:
-                inputFilter.relationTargetFieldMetadataId ??
-                existingFilter.relationTargetFieldMetadataId,
+                inputFilter.relationTargetFieldMetadataId,
             },
             flatEntityMaps: {
               flatFieldMetadataMaps,
@@ -789,9 +786,7 @@ export class ViewWidgetUpsertService {
             subFieldName:
               inputFilter.subFieldName ?? existingFilter.subFieldName,
             relationTargetFieldMetadataId:
-              inputFilter.relationTargetFieldMetadataId ??
-              existingFilter.relationTargetFieldMetadataId ??
-              null,
+              inputFilter.relationTargetFieldMetadataId ?? null,
             relationTargetFieldMetadataUniversalIdentifier,
             updatedAt: now,
           });

--- a/packages/twenty-server/test/integration/metadata/suites/field-metadata/morph-relation/__snapshots__/failing-create-one-field-metadata-morph-relation-v2.integration-spec.ts.snap
+++ b/packages/twenty-server/test/integration/metadata/suites/field-metadata/morph-relation/__snapshots__/failing-create-one-field-metadata-morph-relation-v2.integration-spec.ts.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
-exports[`failing createOne FieldMetadataService morph relation fields v2 Morh relation collision tests suite it should fail to create a already existing morph relation with samefield 1`] = `
+exports[`failing createOne FieldMetadataService morph relation fields v2 Morph relation collision tests suite it should fail to create a already existing morph relation with same field 1`] = `
 {
   "extensions": {
     "code": "METADATA_VALIDATION_FAILED",
@@ -91,7 +91,7 @@ exports[`failing createOne FieldMetadataService morph relation fields v2 Morh re
 }
 `;
 
-exports[`failing createOne FieldMetadataService morph relation fields v2 Morh relation collision tests suite it should fail to create a field with name than result in existing morph relation field join column 1`] = `
+exports[`failing createOne FieldMetadataService morph relation fields v2 Morph relation collision tests suite it should fail to create a field with name than result in existing morph relation field join column 1`] = `
 {
   "extensions": {
     "code": "METADATA_VALIDATION_FAILED",
@@ -612,7 +612,7 @@ exports[`failing createOne FieldMetadataService morph relation fields v2 it shou
             {
               "code": "FIELD_METADATA_RELATION_MALFORMED",
               "message": "Morph relation creation payloads are empty",
-              "userFriendlyMessage": "At least one relation is require",
+              "userFriendlyMessage": "At least one relation is required",
             },
           ],
           "flatEntityMinimalInformation": {
@@ -628,7 +628,7 @@ exports[`failing createOne FieldMetadataService morph relation fields v2 it shou
       "fieldMetadata": 1,
       "totalErrors": 1,
     },
-    "userFriendlyMessage": "At least one relation is require",
+    "userFriendlyMessage": "At least one relation is required",
   },
   "message": "Multiple validation errors occurred while creating field",
   "name": "GraphQLError",

--- a/packages/twenty-server/test/integration/metadata/suites/field-metadata/morph-relation/failing-create-one-field-metadata-morph-relation-v2.integration-spec.ts
+++ b/packages/twenty-server/test/integration/metadata/suites/field-metadata/morph-relation/failing-create-one-field-metadata-morph-relation-v2.integration-spec.ts
@@ -446,7 +446,7 @@ describe('failing createOne FieldMetadataService morph relation fields v2', () =
     },
   );
 
-  describe('Morh relation collision tests suite', () => {
+  describe('Morph relation collision tests suite', () => {
     beforeAll(async () => {
       const morphRelationCreateFieldInput: Omit<
         CreateFieldInput,
@@ -502,7 +502,7 @@ describe('failing createOne FieldMetadataService morph relation fields v2', () =
       expect(firstError.extensions.code).not.toBe('INTERNAL_SERVER_ERROR');
     });
 
-    it('it should fail to create a already existing morph relation with samefield', async () => {
+    it('it should fail to create a already existing morph relation with same field', async () => {
       const morphRelationCreateFieldInput: Omit<
         CreateFieldInput,
         'workspaceId'


### PR DESCRIPTION
App permissions tab:
- The fallback uuidv4() for a marketplace field was generated twice, so id and universalIdentifier could diverge; it's now computed once and reused as it seemed to be the intention (even though I don't really think it's a good idea)
- Renamed buildobjectMetadataItemsFromMarketplaceApp → buildObjectMetadataItemsFromMarketplaceApp to follow camelCase.

Morph relation validation:
- Fixed the user-facing message "At least one relation is require" → "...is required"
- Typos in the related test descriptions (Morh → Morph, samefield → same field) and their snapshots.

Docs
- The UUID field-type row in views.mdx only listed IS; updated to the full set supported by FILTER_OPERANDS_MAP (IS, IS_NOT, IS_EMPTY, IS_NOT_EMPTY).