### PR TITLE
[Website] Restore shared build dependency for typecheck

### DIFF
--- a/packages/twenty-website/project.json
+++ b/packages/twenty-website/project.json
@@ -113,7 +113,7 @@
       ]
     },
     "typecheck": {
-      "dependsOn": ["generate-release-manifest"]
+      "dependsOn": ["generate-release-manifest", "^build"]
     },
     "test": {},
     "fmt": {


### PR DESCRIPTION
Should fix the CI failure on `typecheck` by building twenty-shared first.