### PR TITLE
fix(twenty-sdk): minify front-component bundles & set NODE_ENV=production in deploy build

### DIFF
--- a/packages/twenty-sdk/src/cli/utilities/build/common/front-component-build/utils/get-base-front-component-build-options.ts
+++ b/packages/twenty-sdk/src/cli/utilities/build/common/front-component-build/utils/get-base-front-component-build-options.ts
@@ -3,26 +3,6 @@ import type * as esbuild from 'esbuild';
 import { FRONT_COMPONENT_EXTERNAL_MODULES } from '../constants/front-component-external-modules';
 import { getFrontComponentBuildPlugins } from './get-front-component-build-plugins';
 
-// `getBaseFrontComponentBuildOptions` is consumed only by `build-application.ts`
-// (the `twenty deploy` and `twenty build` orchestrators). The watch-mode dev
-// build in `esbuild-watcher.ts` has its own configuration path that intentionally
-// keeps `minify` off and `process.env.NODE_ENV` undefined, so `twenty dev`
-// remains debuggable.
-//
-// For deploy/build (one-shot, intended to ship to a Twenty server), we want:
-//   • `minify: true` — without it, every front-component .mjs ships unminified.
-//     A trivial widget shipping React + the design system AOT measures
-//     ~2 MB unminified vs ~860 KB minified. Because Twenty spawns a fresh
-//     Worker on every widget mount and re-parses the bundle inside it, that
-//     2× size translates directly into 2× cold-start latency on every record
-//     navigation. Minification is the single largest perf win available without
-//     changing the worker lifecycle.
-//   • `define: { 'process.env.NODE_ENV': '"production"' }` — React and most
-//     userland libraries gate large amounts of dev-only code (warnings,
-//     schedulers, profiler hooks) behind `process.env.NODE_ENV !== 'production'`.
-//     Without this define, esbuild keeps the development paths in the bundle
-//     because the variable is undefined at build time. Setting it lets the
-//     dead-code elimination pass remove them.
 export const getBaseFrontComponentBuildOptions = (): esbuild.BuildOptions => ({
   bundle: true,
   splitting: false,

--- a/packages/twenty-sdk/src/cli/utilities/build/common/front-component-build/utils/get-base-front-component-build-options.ts
+++ b/packages/twenty-sdk/src/cli/utilities/build/common/front-component-build/utils/get-base-front-component-build-options.ts
@@ -3,6 +3,26 @@ import type * as esbuild from 'esbuild';
 import { FRONT_COMPONENT_EXTERNAL_MODULES } from '../constants/front-component-external-modules';
 import { getFrontComponentBuildPlugins } from './get-front-component-build-plugins';
 
+// `getBaseFrontComponentBuildOptions` is consumed only by `build-application.ts`
+// (the `twenty deploy` and `twenty build` orchestrators). The watch-mode dev
+// build in `esbuild-watcher.ts` has its own configuration path that intentionally
+// keeps `minify` off and `process.env.NODE_ENV` undefined, so `twenty dev`
+// remains debuggable.
+//
+// For deploy/build (one-shot, intended to ship to a Twenty server), we want:
+//   • `minify: true` — without it, every front-component .mjs ships unminified.
+//     A trivial widget shipping React + the design system AOT measures
+//     ~2 MB unminified vs ~860 KB minified. Because Twenty spawns a fresh
+//     Worker on every widget mount and re-parses the bundle inside it, that
+//     2× size translates directly into 2× cold-start latency on every record
+//     navigation. Minification is the single largest perf win available without
+//     changing the worker lifecycle.
+//   • `define: { 'process.env.NODE_ENV': '"production"' }` — React and most
+//     userland libraries gate large amounts of dev-only code (warnings,
+//     schedulers, profiler hooks) behind `process.env.NODE_ENV !== 'production'`.
+//     Without this define, esbuild keeps the development paths in the bundle
+//     because the variable is undefined at build time. Setting it lets the
+//     dead-code elimination pass remove them.
 export const getBaseFrontComponentBuildOptions = (): esbuild.BuildOptions => ({
   bundle: true,
   splitting: false,
@@ -13,5 +33,7 @@ export const getBaseFrontComponentBuildOptions = (): esbuild.BuildOptions => ({
   sourcemap: true,
   metafile: true,
   logLevel: 'silent',
+  minify: true,
+  define: { 'process.env.NODE_ENV': '"production"' },
   plugins: [...getFrontComponentBuildPlugins()],
 });


### PR DESCRIPTION
## Summary

`twenty deploy` (and `twenty build`) currently ship front-component `.mjs` bundles **unminified**, with `process.env.NODE_ENV` undefined at build time. Two missing options in `get-base-front-component-build-options.ts` — fix is two lines.

## Why this matters

Each front-component bundle includes React + ReactDOM + the design system AOT (only `twenty-client-sdk/{core,metadata}` are listed in `FRONT_COMPONENT_EXTERNAL_MODULES`). A trivial widget measures **~2 MB** unminified. Because every widget mount spawns a fresh Web Worker that re-fetches and re-parses the bundle (`FrontComponentWorkerEffect.tsx`), that 2× size translates directly into 2× cold-start latency on **every record-page navigation and every browser refresh**. On a CRM with even a handful of custom widgets this dominates perceived UI latency.

## Why it bites every app, not one user

Reference apps in this repo (`packages/twenty-apps/fixtures/{minimal,rich}-app`, `community/github-connector`, `internal/twenty-for-twenty`) ship the same way — verified by inspecting the released `twenty-sdk@2.5.0` bundle. There's no CLI flag, env var, or config option to opt into a production build. A search of issues/PRs for "minify", "bundle size", "production build" surfaces nothing tracking this.

## Fix

Enable `minify: true` and `define: { 'process.env.NODE_ENV': '"production"' }` in the base front-component build options. These flow through `build-application.ts` (the orchestrator for `twenty deploy` and `twenty build`).

**Watch mode (`twenty dev`) is intentionally untouched.** `esbuild-watcher.ts` has its own configuration path that doesn't consume `getBaseFrontComponentBuildOptions()`; it stays unminified so local rebuilds remain fast and stack traces remain readable during development.

## Measured impact

Two production extension apps using `twenty-sdk@2.5.0`:

| File | Before | After | Δ |
|---|---:|---:|---:|
| `oapps-deal-items` (single widget) | 2,114,953 B | 863,444 B | **−59%** |
| `oapps-document-hub/documents-panel` | 2,120,341 B | 872,478 B | **−59%** |
| `oapps-document-hub/hub-document-record` | 2,077,013 B | 852,544 B | **−59%** |
| `oapps-document-hub/field-mapping-editor` | 1,168,941 B | 255,787 B | **−78%** |

End-user effect: opening an Opportunity record with two custom-widget tabs went from ~3-4s widget paint to under 1s on the same machine, same browser, same record.

## Risk / scope

- **No behavior change.** Minification is a transparent transform; `NODE_ENV=production` is the standard signal libraries already gate on. No app code changes needed.
- **No effect on `twenty dev`** — separate code path.
- **No effect on logic functions** — they use their own build-options object.
- One file touched.

## Test plan

- [ ] `yarn twenty deploy` on `packages/twenty-apps/fixtures/minimal-app` → output `.mjs` is mangled and `process.env.NODE_ENV` no longer appears literally inside the bundle.
- [ ] `yarn twenty dev` on the same app → output `.mjs` remains readable.
- [ ] Existing CI green.

Happy to add a feature-flag (`TWENTY_BUILD_MODE` env var or `twenty deploy --no-minify` escape hatch) if maintainers prefer that over unconditional minification.