### PR TITLE
fix(website) - fix getPartners

### DIFF
--- a/packages/twenty-website/src/lib/partners-api/__tests__/client.test.ts
+++ b/packages/twenty-website/src/lib/partners-api/__tests__/client.test.ts
@@ -50,7 +50,7 @@ describe('partnersApiFetch', () => {
       Authorization: 'Bearer test-key-123',
       Accept: 'application/json',
     });
-    expect((init as RequestInit).cache).toBe('no-store');
+    expect((init as RequestInit).cache).toBeUndefined();
   });
 
   it('throws on non-2xx with status, path, and body snippet', async () => {

--- a/packages/twenty-website/src/lib/partners-api/client.ts
+++ b/packages/twenty-website/src/lib/partners-api/client.ts
@@ -17,7 +17,6 @@ export const partnersApiFetch = async (
 
   const base = baseUrl.replace(/\/$/, '');
   const response = await fetch(`${base}${path}`, {
-    cache: 'no-store',
     ...init,
     headers: {
       Authorization: `Bearer ${apiKey}`,

--- a/packages/twenty-website/src/lib/partners-api/get-partners.ts
+++ b/packages/twenty-website/src/lib/partners-api/get-partners.ts
@@ -1,3 +1,5 @@
+import { unstable_cache } from 'next/cache';
+
 import { partnersApiFetch } from './client';
 import type { MarketplacePartner } from './partner-types';
 
@@ -20,7 +22,9 @@ type ApiResponse = { ok: boolean; count: number; partners: ApiPartner[] };
 const normalizeUrl = (raw: string): string =>
   raw && !raw.includes('://') ? `https://${raw}` : raw;
 
-export const getPartners = async (): Promise<readonly MarketplacePartner[]> => {
+const fetchPartnersUncached = async (): Promise<
+  readonly MarketplacePartner[]
+> => {
   try {
     const data = (await partnersApiFetch('/s/partners')) as ApiResponse;
     if (!Array.isArray(data.partners)) {
@@ -42,3 +46,9 @@ export const getPartners = async (): Promise<readonly MarketplacePartner[]> => {
     return [];
   }
 };
+
+export const getPartners = unstable_cache(
+  fetchPartnersUncached,
+  ['partners-api:list'],
+  { revalidate: 300, tags: ['partners-api'] },
+);


### PR DESCRIPTION
**Context**
Fix empty marketplace at /partners/list: page was being statically prerendered with getPartners() returning [] (build-time fetch failure), then served from OpenNext's R2 cache forever — so the partners API was never actually called in production.

**Change**
Wrap getPartners in unstable_cache with revalidate: 300, matching the existing fetchGithubStarCount / fetchDiscordMemberCount ISR pattern. After deploy, the cached empty result expires within 5 minutes and the worker refetches from the partners API at runtime (where the env vars actually exist), populating the page. Also drops the now-redundant cache: 'no-store' from partnersApiFetch.