### PR TITLE
fix(sdk): restore nested defineFrontComponent  (create command menu items

### DIFF
--- a/packages/twenty-sdk/src/cli/utilities/build/manifest/manifest-build.ts
+++ b/packages/twenty-sdk/src/cli/utilities/build/manifest/manifest-build.ts
@@ -51,7 +51,7 @@ import {
   getInputSchemaFromSourceCode,
   jsonSchemaToInputSchema,
 } from 'twenty-shared/logic-function';
-import { assertUnreachable } from 'twenty-shared/utils';
+import { assertUnreachable, isDefined } from 'twenty-shared/utils';
 
 const loadSources = async (appPath: string): Promise<string[]> => {
   return await glob(['**/*.ts', '**/*.tsx'], {
@@ -358,7 +358,7 @@ export const buildManifest = async (
         errors.push(...extract.errors);
         warnings.push(...(extract.warnings ?? []));
 
-        const { component, ...rest } = extract.config;
+        const { component, command, ...rest } = extract.config;
 
         const relativeFilePath = relative(appPath, filePath);
 
@@ -373,6 +373,14 @@ export const buildManifest = async (
 
         frontComponents.push(config);
         frontComponentsFilePaths.push(relativePath);
+
+        if (isDefined(command)) {
+          commandMenuItems.push({
+            ...command,
+            frontComponentUniversalIdentifier: config.universalIdentifier,
+          } as unknown as CommandMenuItemManifest);
+          commandMenuItemsFilePaths.push(relativePath);
+        }
 
         break;
       }

--- a/packages/twenty-sdk/src/sdk/define/front-component/define-front-component.ts
+++ b/packages/twenty-sdk/src/sdk/define/front-component/define-front-component.ts
@@ -19,6 +19,16 @@ export const defineFrontComponent: DefineEntity<FrontComponentConfig> = (
     errors.push('Front component component must be a React component');
   }
 
+  if (config.command) {
+    if (!config.command.universalIdentifier) {
+      errors.push('Command must have a universalIdentifier');
+    }
+
+    if (!config.command.label) {
+      errors.push('Command must have a label');
+    }
+  }
+
   return createValidationResult({
     config,
     errors,

--- a/packages/twenty-sdk/src/sdk/define/front-component/front-component-config.ts
+++ b/packages/twenty-sdk/src/sdk/define/front-component/front-component-config.ts
@@ -1,6 +1,16 @@
-import { type FrontComponentManifest } from 'twenty-shared/application';
+import {
+  type FrontComponentCommandManifest,
+  type FrontComponentManifest,
+} from 'twenty-shared/application';
 
 export type FrontComponentType = React.ComponentType<any>;
+
+export type FrontComponentCommandConfig = Omit<
+  FrontComponentCommandManifest,
+  'conditionalAvailabilityExpression'
+> & {
+  conditionalAvailabilityExpression?: boolean | string;
+};
 
 export type FrontComponentConfig = Omit<
   FrontComponentManifest,
@@ -11,4 +21,5 @@ export type FrontComponentConfig = Omit<
   | 'usesSdkClient'
 > & {
   component: FrontComponentType;
+  command?: FrontComponentCommandConfig;
 };

--- a/packages/twenty-shared/src/application/frontComponentManifestType.ts
+++ b/packages/twenty-shared/src/application/frontComponentManifestType.ts
@@ -15,6 +15,11 @@ export type CommandMenuItemManifest = SyncableEntityOptions & {
   conditionalAvailabilityExpression?: string;
 };
 
+export type FrontComponentCommandManifest = Omit<
+  CommandMenuItemManifest,
+  'frontComponentUniversalIdentifier'
+>;
+
 export type FrontComponentManifest = {
   universalIdentifier: string;
   name?: string;

--- a/packages/twenty-shared/src/application/index.ts
+++ b/packages/twenty-shared/src/application/index.ts
@@ -34,6 +34,7 @@ export type {
 } from './fieldManifestType';
 export type {
   CommandMenuItemManifest,
+  FrontComponentCommandManifest,
   FrontComponentManifest,
 } from './frontComponentManifestType';
 export type { IndexFieldManifest } from './indexFieldManifestType';


### PR DESCRIPTION
## What

`defineFrontComponent({ command: {...} })` silently stopped creating a `CommandMenuItem`. The front component is synced, but its command never appears in the command menu (Cmd+K).

#20256 ("add defineCommandMenuItem") was meant to let nested and standalone forms coexist, but it removed the nested path entirely: `command` was dropped from
`FrontComponentConfig`/`FrontComponentManifest`, its validation in `defineFrontComponent`, and the manifest-build extraction — without a replacement, deprecation, or warning. Apps using
 the nested form get a front component with no command menu item.

  ## Fix

  Re-introduce the nested `command`, but **lower it into the top-level `commandMenuItems` array at build time** instead of restoring the old "store on manifest + expand server-side" path:

  - `twenty-shared`: re-add `FrontComponentCommandManifest` (+ barrel export).
  - `twenty-sdk`: re-add `FrontComponentCommandConfig` and `command?` on `FrontComponentConfig`; re-add nested-command validation in `defineFrontComponent`.
  - `manifest-build`: when a front component has a `command`, push it into `commandMenuItems` with `frontComponentUniversalIdentifier` set to the component's id.
