### PR TITLE
Fix: Prevent hotkey/Enter handling during IME composition

### DIFF
--- a/packages/twenty-front/src/modules/settings/accounts/components/SettingsAccountsBlocklistInput.tsx
+++ b/packages/twenty-front/src/modules/settings/accounts/components/SettingsAccountsBlocklistInput.tsx
@@ -74,6 +74,9 @@ export const SettingsAccountsBlocklistInput = ({
   });
 
   const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    if (e.nativeEvent.isComposing || e.keyCode === 229) {
+      return;
+    }
     if (e.key === Key.Enter) {
       submit();
     }

--- a/packages/twenty-front/src/modules/ui/utilities/hotkey/hooks/useHotkeysOnFocusedElement.ts
+++ b/packages/twenty-front/src/modules/ui/utilities/hotkey/hooks/useHotkeysOnFocusedElement.ts
@@ -48,6 +48,10 @@ export const useHotkeysOnFocusedElement = ({
   return useHotkeys(
     keys,
     (keyboardEvent, hotkeysEvent) => {
+      if (keyboardEvent.isComposing || keyboardEvent.keyCode === 229) {
+        return;
+      }
+
       callScopedHotkeyCallback({
         keyboardEvent,
         hotkeysEvent,

--- a/packages/twenty-front/src/pages/onboarding/CreateWorkspace.tsx
+++ b/packages/twenty-front/src/pages/onboarding/CreateWorkspace.tsx
@@ -141,6 +141,9 @@ export const CreateWorkspace = () => {
   );
 
   const handleKeyDown = (event: React.KeyboardEvent<HTMLInputElement>) => {
+    if (event.nativeEvent.isComposing || event.keyCode === 229) {
+      return;
+    }
     if (event.key === Key.Enter) {
       event.preventDefault();
       handleSubmit(onSubmit)();

--- a/packages/twenty-front/src/pages/settings/developers/api-keys/SettingsDevelopersApiKeysNew.tsx
+++ b/packages/twenty-front/src/pages/settings/developers/api-keys/SettingsDevelopersApiKeysNew.tsx
@@ -159,6 +159,9 @@ export const SettingsDevelopersApiKeysNew = () => {
             placeholder={t`E.g. backoffice integration`}
             value={formValues.name}
             onKeyDown={(e) => {
+              if (e.nativeEvent.isComposing || e.keyCode === 229) {
+                return;
+              }
               if (e.key === Key.Enter) {
                 handleSave();
               }


### PR DESCRIPTION
Fixes https://github.com/twentyhq/twenty/issues/20954
Prevents keyboard handlers from firing while users are composing characters with an IME (e.g. Japanese, Chinese, Korean input). When typing with an IME, pressing Enter to confirm a candidate would previously trigger submit/hotkey actions unintentionally.

Added isComposing / keyCode === 229 guards in:
- useHotkeysOnFocusedElement — global hotkey hook
- SettingsAccountsBlocklistInput — blocklist entry submit
- CreateWorkspace — onboarding form submit
- SettingsDevelopersApiKeysNew — API key name submit

## Video QA

https://github.com/user-attachments/assets/8fc385e1-bdda-4e34-899e-a248df9bfdd7