### PR TITLE
Twenty server:Fix REST pagination issues

### DIFF
--- a/packages/twenty-server/src/engine/api/common/common-query-runners/common-find-many-query-runner.service.ts
+++ b/packages/twenty-server/src/engine/api/common/common-query-runners/common-find-many-query-runner.service.ts
@@ -124,7 +124,7 @@ export class CommonFindManyQueryRunnerService extends CommonBaseQueryRunnerServi
         isForwardPagination,
       );
 
-      appliedFilters = (args.filter
+      appliedFilters = (args.filter && Object.keys(args.filter).length > 0
         ? {
             and: [args.filter, { or: cursorArgFilter }],
           }

--- a/packages/twenty-server/src/engine/api/graphql/graphql-query-runner/utils/compute-where-condition-parts.ts
+++ b/packages/twenty-server/src/engine/api/graphql/graphql-query-runner/utils/compute-where-condition-parts.ts
@@ -1,6 +1,6 @@
 import { randomBytes } from 'crypto';
 
-import { type FieldMetadataType } from 'twenty-shared/types';
+import { FieldMetadataType } from 'twenty-shared/types';
 import { isDefined } from 'twenty-shared/utils';
 import { type ObjectLiteral } from 'typeorm';
 
@@ -43,6 +43,11 @@ export const computeWhereConditionParts = ({
     ? `"${key}"`
     : `"${objectNameSingular}"."${key}"`;
 
+  const isDateTimeField = fieldMetadataType === FieldMetadataType.DATE_TIME;
+  const comparisonFieldReference = isDateTimeField
+    ? `date_trunc('milliseconds', ${fieldReference})`
+    : fieldReference;
+
   //TODO : Remove filter null equivalence injection once feature flag removed + null equivalence transformation added in ORM
   const nullEquivalentFieldValue = findPostgresDefaultNullEquivalentValue(
     value,
@@ -60,32 +65,32 @@ export const computeWhereConditionParts = ({
       };
     case 'eq':
       return {
-        sql: `${fieldReference} = :${key}${paramSuffix}${hasNullEquivalentFieldValue ? ` OR ${fieldReference} IS NULL` : ''}`,
+        sql: `${comparisonFieldReference} = :${key}${paramSuffix}${hasNullEquivalentFieldValue ? ` OR ${fieldReference} IS NULL` : ''}`,
         params: { [`${key}${paramSuffix}`]: value },
       };
     case 'neq':
       return {
-        sql: `${fieldReference} != :${key}${paramSuffix}${hasNullEquivalentFieldValue ? ` AND ${fieldReference} IS NOT NULL` : ''}`,
+        sql: `${comparisonFieldReference} != :${key}${paramSuffix}${hasNullEquivalentFieldValue ? ` AND ${fieldReference} IS NOT NULL` : ''}`,
         params: { [`${key}${paramSuffix}`]: value },
       };
     case 'gt':
       return {
-        sql: `${fieldReference} > :${key}${paramSuffix}`,
+        sql: `${comparisonFieldReference} > :${key}${paramSuffix}`,
         params: { [`${key}${paramSuffix}`]: value },
       };
     case 'gte':
       return {
-        sql: `${fieldReference} >= :${key}${paramSuffix}`,
+        sql: `${comparisonFieldReference} >= :${key}${paramSuffix}`,
         params: { [`${key}${paramSuffix}`]: value },
       };
     case 'lt':
       return {
-        sql: `${fieldReference} < :${key}${paramSuffix}`,
+        sql: `${comparisonFieldReference} < :${key}${paramSuffix}`,
         params: { [`${key}${paramSuffix}`]: value },
       };
     case 'lte':
       return {
-        sql: `${fieldReference} <= :${key}${paramSuffix}`,
+        sql: `${comparisonFieldReference} <= :${key}${paramSuffix}`,
         params: { [`${key}${paramSuffix}`]: value },
       };
     case 'in':

--- a/packages/twenty-server/src/engine/api/graphql/graphql-query-runner/utils/compute-where-condition-parts.ts
+++ b/packages/twenty-server/src/engine/api/graphql/graphql-query-runner/utils/compute-where-condition-parts.ts
@@ -44,9 +44,6 @@ export const computeWhereConditionParts = ({
     : `"${objectNameSingular}"."${key}"`;
 
   const isDateTimeField = fieldMetadataType === FieldMetadataType.DATE_TIME;
-  const comparisonFieldReference = isDateTimeField
-    ? `date_trunc('milliseconds', ${fieldReference})`
-    : fieldReference;
 
   //TODO : Remove filter null equivalence injection once feature flag removed + null equivalence transformation added in ORM
   const nullEquivalentFieldValue = findPostgresDefaultNullEquivalentValue(
@@ -64,33 +61,61 @@ export const computeWhereConditionParts = ({
         params: {},
       };
     case 'eq':
+      if (isDateTimeField) {
+        return {
+          sql: `(${fieldReference} >= :${key}${paramSuffix} AND ${fieldReference} < :${key}${paramSuffix}::timestamptz + interval '1 millisecond')${hasNullEquivalentFieldValue ? ` OR ${fieldReference} IS NULL` : ''}`,
+          params: { [`${key}${paramSuffix}`]: value },
+        };
+      }
+
       return {
-        sql: `${comparisonFieldReference} = :${key}${paramSuffix}${hasNullEquivalentFieldValue ? ` OR ${fieldReference} IS NULL` : ''}`,
+        sql: `${fieldReference} = :${key}${paramSuffix}${hasNullEquivalentFieldValue ? ` OR ${fieldReference} IS NULL` : ''}`,
         params: { [`${key}${paramSuffix}`]: value },
       };
     case 'neq':
+      if (isDateTimeField) {
+        return {
+          sql: `(${fieldReference} < :${key}${paramSuffix} OR ${fieldReference} >= :${key}${paramSuffix}::timestamptz + interval '1 millisecond')${hasNullEquivalentFieldValue ? ` AND ${fieldReference} IS NOT NULL` : ''}`,
+          params: { [`${key}${paramSuffix}`]: value },
+        };
+      }
+
       return {
-        sql: `${comparisonFieldReference} != :${key}${paramSuffix}${hasNullEquivalentFieldValue ? ` AND ${fieldReference} IS NOT NULL` : ''}`,
+        sql: `${fieldReference} != :${key}${paramSuffix}${hasNullEquivalentFieldValue ? ` AND ${fieldReference} IS NOT NULL` : ''}`,
         params: { [`${key}${paramSuffix}`]: value },
       };
     case 'gt':
+      if (isDateTimeField) {
+        return {
+          sql: `${fieldReference} >= :${key}${paramSuffix}::timestamptz + interval '1 millisecond'`,
+          params: { [`${key}${paramSuffix}`]: value },
+        };
+      }
+
       return {
-        sql: `${comparisonFieldReference} > :${key}${paramSuffix}`,
+        sql: `${fieldReference} > :${key}${paramSuffix}`,
         params: { [`${key}${paramSuffix}`]: value },
       };
     case 'gte':
       return {
-        sql: `${comparisonFieldReference} >= :${key}${paramSuffix}`,
+        sql: `${fieldReference} >= :${key}${paramSuffix}`,
         params: { [`${key}${paramSuffix}`]: value },
       };
     case 'lt':
       return {
-        sql: `${comparisonFieldReference} < :${key}${paramSuffix}`,
+        sql: `${fieldReference} < :${key}${paramSuffix}`,
         params: { [`${key}${paramSuffix}`]: value },
       };
     case 'lte':
+      if (isDateTimeField) {
+        return {
+          sql: `${fieldReference} < :${key}${paramSuffix}::timestamptz + interval '1 millisecond'`,
+          params: { [`${key}${paramSuffix}`]: value },
+        };
+      }
+
       return {
-        sql: `${comparisonFieldReference} <= :${key}${paramSuffix}`,
+        sql: `${fieldReference} <= :${key}${paramSuffix}`,
         params: { [`${key}${paramSuffix}`]: value },
       };
     case 'in':

--- a/packages/twenty-server/src/engine/api/graphql/graphql-query-runner/utils/cursors.util.ts
+++ b/packages/twenty-server/src/engine/api/graphql/graphql-query-runner/utils/cursors.util.ts
@@ -38,7 +38,28 @@ export const encodeCursor = <T extends ObjectRecord = ObjectRecord>(
   const orderByKeys = Object.keys(orderBy ?? {});
 
   orderByKeys?.forEach((key) => {
-    orderByValues[key] = objectRecord[key];
+    const orderByEntry = orderBy?.[key];
+    const recordValue = objectRecord[key];
+
+    // For nested entries
+    if (
+      typeof orderByEntry === 'object' &&
+      orderByEntry !== null &&
+      typeof recordValue === 'object' &&
+      recordValue !== null
+    ) {
+      const projectedValue: Record<string, unknown> = {};
+
+      for (const subKey of Object.keys(orderByEntry)) {
+        projectedValue[subKey] = recordValue[subKey];
+      }
+
+      orderByValues[key] = projectedValue;
+
+      return;
+    }
+
+    orderByValues[key] = recordValue;
   });
 
   const cursorData: CursorData = {

--- a/packages/twenty-server/src/engine/api/graphql/graphql-query-runner/utils/cursors.util.ts
+++ b/packages/twenty-server/src/engine/api/graphql/graphql-query-runner/utils/cursors.util.ts
@@ -38,28 +38,7 @@ export const encodeCursor = <T extends ObjectRecord = ObjectRecord>(
   const orderByKeys = Object.keys(orderBy ?? {});
 
   orderByKeys?.forEach((key) => {
-    const orderByEntry = orderBy?.[key];
-    const recordValue = objectRecord[key];
-
-    // For nested entries
-    if (
-      typeof orderByEntry === 'object' &&
-      orderByEntry !== null &&
-      typeof recordValue === 'object' &&
-      recordValue !== null
-    ) {
-      const projectedValue: Record<string, unknown> = {};
-
-      for (const subKey of Object.keys(orderByEntry)) {
-        projectedValue[subKey] = recordValue[subKey];
-      }
-
-      orderByValues[key] = projectedValue;
-
-      return;
-    }
-
-    orderByValues[key] = recordValue;
+    orderByValues[key] = objectRecord[key];
   });
 
   const cursorData: CursorData = {


### PR DESCRIPTION
Fixes #20109 

The entry was repeating because in the database we store DateTime fields with microsecond precision (timestamptz), but when JS parses timestamptz into a Date object it only keeps millisecond precision.

### Example
If previous cursor was:
```
{
    name: "Quick Lead",
    createdAt: "2026-05-21T15:33:00.708Z",
}
```
The resulting query look something like:
```
...
WHERE (
  "workflow"."name" > "Quick Lead"
  OR (
    "workflow"."name" = "Quick Lead"
    AND "workflow"."createdAt" > "2026-05-21T15:33:00.708Z"
  )
  OR (
    "workflow"."name" = "Quick Lead"
    AND "workflow"."createdAt" = "2026-05-21T15:33:00.708Z"
    AND "workflow"."id" > "8b213cac-a68b-4ffe-817a-3ec994e9932d"
  )
)
```
So, when comparing the 2nd condition the `"workflow"."createdAt" > "2026-05-21T15:33:00.708Z"` would always result to true because in db the data for createdAt is `2026-05-21 21:03:00.708 +0530` which will always be greater than `2026-05-21T15:33:00.708Z`
The second condition `"workflow"."createdAt" > "2026-05-21T15:33:00.708Z"` always evaluates to true, because the value actually stored in the DB for createdAt is something like `2026-05-21 21:03:00.708264 +0530`, which is always greater than `2026-05-21T15:33:00.708Z` in the cursor. The row used to generate the cursor therefore reappears on the next page.

### My solution
Truncate the column to milliseconds in the comparison so both sides have the same precision: `date_trunc('milliseconds', ${fieldReference})`.

For the issue of nested sorting filters, when ordering by a composite field (e.g. `createdBy.name`), `encodeCursor` stored the entire composite object (`source`, `workspaceMemberId`, `name`, `context`). The where-condition builder later iterated those sub-keys and threw "Invalid cursor" because only name had an orderBy direction.

P.S: Duplicate of #20867 because last fork got polluted.