### PR TITLE
feat(settings): add cancel and done buttons to select field bulk edit (#20986)

### DIFF
--- a/packages/twenty-front/src/modules/settings/data-model/fields/forms/select/components/SettingsDataModelFieldSelectForm.tsx
+++ b/packages/twenty-front/src/modules/settings/data-model/fields/forms/select/components/SettingsDataModelFieldSelectForm.tsx
@@ -395,11 +395,6 @@ export const SettingsDataModelFieldSelectForm = ({
                                   setOriginalOptions(options);
                                   setIsBulkInputMode(true);
                                 } else {
-                                  const nextOptions = convertBulkTextToOptions(
-                                    bulkInputText,
-                                    originalOptions,
-                                  );
-                                  onChange(nextOptions);
                                   setIsBulkInputMode(false);
                                 }
                                 closeOptionsDropdown(OPTIONS_DROPDOWN_ID);

--- a/packages/twenty-front/src/modules/settings/data-model/fields/forms/select/components/SettingsDataModelFieldSelectForm.tsx
+++ b/packages/twenty-front/src/modules/settings/data-model/fields/forms/select/components/SettingsDataModelFieldSelectForm.tsx
@@ -141,6 +141,17 @@ const StyledButtonContainer = styled.div`
   }
 `;
 
+const StyledBulkEditButtonContainer = styled.div`
+  display: flex;
+  gap: ${themeCssVariables.spacing[2]};
+  width: 100%;
+
+  > button {
+    justify-content: center;
+    flex: 1;
+  }
+`;
+
 const StyledOptionsHeaderContainer = styled.div`
   align-items: center;
   display: flex;
@@ -190,6 +201,9 @@ export const SettingsDataModelFieldSelectForm = ({
   const [hasAppliedNewOption, setHasAppliedNewOption] = useState(false);
   const [isBulkInputMode, setIsBulkInputMode] = useState(false);
   const [bulkInputText, setBulkInputText] = useState('');
+  const [originalOptions, setOriginalOptions] = useState<
+    FieldMetadataItemOption[]
+  >([]);
 
   const OPTIONS_DROPDOWN_ID =
     'settings-data-model-field-select-options-dropdown';
@@ -378,10 +392,16 @@ export const SettingsDataModelFieldSelectForm = ({
                                   setBulkInputText(
                                     convertOptionsToBulkText(options),
                                   );
+                                  setOriginalOptions(options);
+                                  setIsBulkInputMode(true);
+                                } else {
+                                  const nextOptions = convertBulkTextToOptions(
+                                    bulkInputText,
+                                    originalOptions,
+                                  );
+                                  onChange(nextOptions);
+                                  setIsBulkInputMode(false);
                                 }
-                                setIsBulkInputMode(
-                                  (currentInputMode) => !currentInputMode,
-                                );
                                 closeOptionsDropdown(OPTIONS_DROPDOWN_ID);
                               }}
                             />
@@ -412,12 +432,6 @@ export const SettingsDataModelFieldSelectForm = ({
                           return;
                         }
 
-                        const nextOptions = convertBulkTextToOptions(
-                          nextOptionAsText,
-                          options,
-                        );
-
-                        onChange(nextOptions);
                         setBulkInputText(nextOptionAsText);
                       }}
                       minRows={5}
@@ -528,6 +542,32 @@ export const SettingsDataModelFieldSelectForm = ({
                       onClick={handleAddOption}
                     />
                   </StyledButtonContainer>
+                </CardFooter>
+              </StyledFooterContainer>
+            )}
+            {!disabled && isBulkInputMode && (
+              <StyledFooterContainer>
+                <CardFooter>
+                  <StyledBulkEditButtonContainer>
+                    <LightButton
+                      title={t`Cancel`}
+                      accent="tertiary"
+                      onClick={() => {
+                        setIsBulkInputMode(false);
+                      }}
+                    />
+                    <LightButton
+                      title={t`Done`}
+                      onClick={() => {
+                        const nextOptions = convertBulkTextToOptions(
+                          bulkInputText,
+                          originalOptions,
+                        );
+                        onChange(nextOptions);
+                        setIsBulkInputMode(false);
+                      }}
+                    />
+                  </StyledBulkEditButtonContainer>
                 </CardFooter>
               </StyledFooterContainer>
             )}


### PR DESCRIPTION
This PR adds Cancel and Done buttons to the bottom of the select/multi-select field options bulk edit mode. It defers updating the form options until Done is clicked, and cancels/discards any changes when Cancel is clicked. Closes #20986.