### PR TITLE
feat: add cancel and done buttons to select field bulk edit

### DIFF
--- a/packages/twenty-front/src/modules/settings/data-model/fields/forms/select/components/SettingsDataModelFieldSelectForm.tsx
+++ b/packages/twenty-front/src/modules/settings/data-model/fields/forms/select/components/SettingsDataModelFieldSelectForm.tsx
@@ -141,6 +141,22 @@ const StyledButtonContainer = styled.div`
   }
 `;
 
+const StyledBulkEditButtonContainer = styled.div`
+  display: flex;
+  width: 100%;
+
+  > button {
+    flex: 1;
+    justify-content: center;
+  }
+`;
+
+const StyledBulkEditButtonSeparator = styled.div`
+  align-self: stretch;
+  background: ${themeCssVariables.border.color.medium};
+  width: 1px;
+`;
+
 const StyledOptionsHeaderContainer = styled.div`
   align-items: center;
   display: flex;
@@ -190,6 +206,9 @@ export const SettingsDataModelFieldSelectForm = ({
   const [hasAppliedNewOption, setHasAppliedNewOption] = useState(false);
   const [isBulkInputMode, setIsBulkInputMode] = useState(false);
   const [bulkInputText, setBulkInputText] = useState('');
+  const [optionsBeforeBulkEdit, setOptionsBeforeBulkEdit] = useState<
+    FieldMetadataItemOption[] | null
+  >(null);
 
   const OPTIONS_DROPDOWN_ID =
     'settings-data-model-field-select-options-dropdown';
@@ -310,6 +329,18 @@ export const SettingsDataModelFieldSelectForm = ({
     setFormValue('options', newOptions, { shouldDirty: true });
   };
 
+  const handleEnterBulkInputMode = (options: FieldMetadataItemOption[]) => {
+    setOptionsBeforeBulkEdit(options);
+    setBulkInputText(convertOptionsToBulkText(options));
+    setIsBulkInputMode(true);
+  };
+
+  const handleExitBulkInputMode = () => {
+    setIsBulkInputMode(false);
+    setOptionsBeforeBulkEdit(null);
+    setBulkInputText('');
+  };
+
   return (
     <>
       <Controller
@@ -322,9 +353,25 @@ export const SettingsDataModelFieldSelectForm = ({
         name="options"
         control={control}
         defaultValue={initialOptions}
-        render={({ field: { onChange, value: options } }) => (
-          <>
-            <StyledContainerWrapper>
+        render={({ field: { onChange, value: options } }) => {
+          const handleBulkEditCancel = () => {
+            if (isDefined(optionsBeforeBulkEdit)) {
+              onChange(optionsBeforeBulkEdit);
+            }
+
+            handleExitBulkInputMode();
+          };
+
+          const handleBulkEditDone = () => {
+            const nextOptions = convertBulkTextToOptions(bulkInputText, options);
+
+            onChange(nextOptions);
+            handleExitBulkInputMode();
+          };
+
+          return (
+            <>
+              <StyledContainerWrapper>
               <CardContent>
                 <StyledOptionsHeaderContainer>
                   <StyledLabelContainer>
@@ -374,14 +421,12 @@ export const SettingsDataModelFieldSelectForm = ({
                               }
                               LeftIcon={IconPencil}
                               onClick={() => {
-                                if (!isBulkInputMode) {
-                                  setBulkInputText(
-                                    convertOptionsToBulkText(options),
-                                  );
+                                if (isBulkInputMode) {
+                                  handleBulkEditDone();
+                                } else {
+                                  handleEnterBulkInputMode(options);
                                 }
-                                setIsBulkInputMode(
-                                  (currentInputMode) => !currentInputMode,
-                                );
+
                                 closeOptionsDropdown(OPTIONS_DROPDOWN_ID);
                               }}
                             />
@@ -412,12 +457,6 @@ export const SettingsDataModelFieldSelectForm = ({
                           return;
                         }
 
-                        const nextOptions = convertBulkTextToOptions(
-                          nextOptionAsText,
-                          options,
-                        );
-
-                        onChange(nextOptions);
                         setBulkInputText(nextOptionAsText);
                       }}
                       minRows={5}
@@ -518,6 +557,25 @@ export const SettingsDataModelFieldSelectForm = ({
                 )}
               </CardContent>
             </StyledContainerWrapper>
+            {!disabled && isBulkInputMode && (
+              <StyledFooterContainer>
+                <CardFooter>
+                  <StyledBulkEditButtonContainer>
+                    <LightButton
+                      title={t`Cancel`}
+                      accent="tertiary"
+                      onClick={handleBulkEditCancel}
+                    />
+                    <StyledBulkEditButtonSeparator />
+                    <LightButton
+                      title={t`Done`}
+                      accent="secondary"
+                      onClick={handleBulkEditDone}
+                    />
+                  </StyledBulkEditButtonContainer>
+                </CardFooter>
+              </StyledFooterContainer>
+            )}
             {!disabled && !isBulkInputMode && (
               <StyledFooterContainer>
                 <CardFooter>
@@ -531,8 +589,9 @@ export const SettingsDataModelFieldSelectForm = ({
                 </CardFooter>
               </StyledFooterContainer>
             )}
-          </>
-        )}
+            </>
+          );
+        }}
       />
     </>
   );


### PR DESCRIPTION
### Summary
- Resolves #20998 
- Added Cancel and Done actions to the bulk edit footer in `SettingsDataModelFieldSelectForm` (select/multi-select field settings, e.g. Opportunities -> Stage).
- bulk edits are deferred until **Done** and **Cancel** restore options from before bulk edit started.

### Test plan
- Go to Settings -> Objects -> Opportunities -> Stage
- Open options menu -> Bulk edit
- Edit lines in the textarea -> confirm options do not change until Done
- Click Cancel -> bulk changes are discarded and single-edit view returns
- Re-enter bulk edit -> click Done -> options update and single-edit view returns
- Switch via Single edit menu item -> changes are applied

### Screencast
#### Before:

https://github.com/user-attachments/assets/3915478f-e775-41ee-9823-38a4ae67cc07

#### After:

https://github.com/user-attachments/assets/ef9c5fe5-7b76-4c09-896d-d471f58ea958

