### PR TITLE
fix: allow dropping favorites to last position of open folder

### DIFF
--- a/packages/twenty-front/src/modules/navigation-menu-item/display/folder/components/NavigationMenuItemFolderDnd.tsx
+++ b/packages/twenty-front/src/modules/navigation-menu-item/display/folder/components/NavigationMenuItemFolderDnd.tsx
@@ -382,7 +382,7 @@ export const NavigationMenuItemFolderDnd = ({
                 folderId={folderId}
                 index={navigationMenuItems.length}
                 sectionId={sectionId}
-                compact={isCompact}
+                compact={false}
                 dropTargetIdOverride={getDndKitDropTargetId(
                   folderContentDroppableId,
                   navigationMenuItems.length,


### PR DESCRIPTION
## Problem

Users cannot drop a favorite to the last position of an open/active folder. The drop target at the end of the folder content has zero height, making it impossible to hover over and drop onto.

## Root Cause

The last drop target in a favorite folder was rendered with `compact={isCompact}`, where `isCompact = true` for favorites. This sets `min-height: 0` on the drop target element.

Unlike workspace folders in edit mode — which render an **Add menu item** button that provides height — favorite folders only contain the drop target itself at the last position. With `min-height: 0`, the droppable slot collapses to zero height and @dnd-kit's collision detection cannot register pointer intersection.

## Fix

Changed the last drop target's `compact` prop from `isCompact` to `false`, ensuring it always has `min-height: spacing[2]` (~8px) for collision detection.

This is a minimal visual change (barely noticeable 8px) that fixes the drop interaction without affecting the spacing between items inside the folder.

## Before / After

| Before | After |
|--------|-------|
| Last drop target: 0px height → undroppable | Last drop target: 8px height → droppable |

Fixes #9213