### PR TITLE
Fix twenty sdk billing exports

### DIFF
--- a/packages/twenty-sdk/package.json
+++ b/packages/twenty-sdk/package.json
@@ -119,6 +119,9 @@
   },
   "typesVersions": {
     "*": {
+      "billing": [
+        "dist/billing/index.d.ts"
+      ],
       "define": [
         "dist/define/index.d.ts"
       ],

--- a/packages/twenty-sdk/project.json
+++ b/packages/twenty-sdk/project.json
@@ -92,6 +92,7 @@
       "dependsOn": ["^build"],
       "inputs": ["{projectRoot}/src/sdk/**/*"],
       "outputs": [
+        "{projectRoot}/dist/billing",
         "{projectRoot}/dist/define",
         "{projectRoot}/dist/front-component",
         "{projectRoot}/dist/logic-function",
@@ -99,7 +100,7 @@
       ],
       "options": {
         "cwd": "{projectRoot}",
-        "command": "npx vite build -c vite.config.define.ts && npx vite build -c vite.config.front-component.ts && npx vite build -c vite.config.logic-function.ts && npx vite build -c vite.config.utils.ts && npx rollup -c rollup.config.sdk-dts.mjs"
+        "command": "npx vite build -c vite.config.define.ts && npx vite build -c vite.config.billing.ts && npx vite build -c vite.config.front-component.ts && npx vite build -c vite.config.logic-function.ts && npx vite build -c vite.config.utils.ts && npx rollup -c rollup.config.sdk-dts.mjs"
       }
     }
   }


### PR DESCRIPTION
Fix two omissions from #19973 that prevented `twenty-sdk/billing` from being a fully exported subpath:

- `package.json`: add `billing` to `typesVersions` (every other subpath was listed; billing was the only one missing, breaking type resolution for consumers using classic TS moduleResolution).
- `project.json`: add the billing vite build and `dist/billing` output to the `build:sdk` target 