### PR TITLE
Fix playwright CI

### DIFF
--- a/.github/workflows/ci-front-component-renderer.yaml
+++ b/.github/workflows/ci-front-component-renderer.yaml
@@ -80,10 +80,20 @@ jobs:
         with:
           name: storybook-twenty-front-component-renderer
           path: packages/twenty-front-component-renderer/storybook-static
+      - name: Resolve Playwright version
+        id: playwright-version
+        run: echo "version=$(node -p "require('@playwright/test/package.json').version")" >> "$GITHUB_OUTPUT"
+      - name: Cache Playwright browsers
+        id: playwright-cache
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
+        with:
+          path: ~/.cache/ms-playwright
+          key: v4-playwright-browsers-${{ runner.os }}-${{ steps.playwright-version.outputs.version }}
       - name: Install Playwright
+        if: steps.playwright-cache.outputs.cache-hit != 'true'
         run: |
           cd packages/twenty-front-component-renderer
-          npx playwright install
+          npx playwright install chromium
       - name: Serve storybook & run tests
         run: |
           npx http-server packages/twenty-front-component-renderer/storybook-static --port 6008 --silent &

--- a/.github/workflows/ci-front.yaml
+++ b/.github/workflows/ci-front.yaml
@@ -96,10 +96,20 @@ jobs:
         with:
           name: storybook-static
           path: packages/twenty-front/storybook-static
+      - name: Resolve Playwright version
+        id: playwright-version
+        run: echo "version=$(node -p "require('@playwright/test/package.json').version")" >> "$GITHUB_OUTPUT"
+      - name: Cache Playwright browsers
+        id: playwright-cache
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
+        with:
+          path: ~/.cache/ms-playwright
+          key: v4-playwright-browsers-${{ runner.os }}-${{ steps.playwright-version.outputs.version }}
       - name: Install Playwright
+        if: steps.playwright-cache.outputs.cache-hit != 'true'
         run: |
           cd packages/twenty-front
-          npx playwright install
+          npx playwright install chromium
       - name: Front / Write .env
         run: npx nx reset:env twenty-front
       - name: Serve storybook & run tests


### PR DESCRIPTION
## Context
The Install Playwright step ran npx playwright install with no arguments, which downloads all browsers (Chromium + Firefox + WebKit + ffmpeg, ~500MB+) on every run with no caching.

Fix:
- Install Chromium only — npx playwright install chromium instead of all browsers.
- Cache the browser binaries — actions/cache on ~/.cache/ms-playwright, keyed on the resolved Playwright version (v4-playwright-browsers-${{ runner.os }}-<version>). On a cache hit the install step is skipped entirely; the cache invalidates automatically when the Playwright version bumps.