### PR TITLE
feat(i18n): Complete es-ES Spanish translation (100% coverage)

### DIFF
--- a/packages/twenty-front/src/locales/es-ES.po
+++ b/packages/twenty-front/src/locales/es-ES.po
@@ -1,22 +1,23 @@
+#
 msgid ""
 msgstr ""
-"POT-Creation-Date: 2025-01-30 18:16+0100\n"
-"MIME-Version: 1.0\n"
-"Content-Type: text/plain; charset=UTF-8\n"
-"Content-Transfer-Encoding: 8bit\n"
-"X-Generator: @lingui/cli\n"
-"Language: es\n"
 "Project-Id-Version: cf448e737e0d6d7b78742f963d761c61\n"
 "Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2025-01-30 18:16+0100\n"
 "PO-Revision-Date: 2025-01-01 00:00\n"
 "Last-Translator: \n"
 "Language-Team: Spanish\n"
+"Language: es\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
-"X-Crowdin-Project: cf448e737e0d6d7b78742f963d761c61\n"
-"X-Crowdin-Project-ID: 1\n"
-"X-Crowdin-Language: es\n"
 "X-Crowdin-File: /packages/twenty-front/src/locales/en.po\n"
 "X-Crowdin-File-ID: 29\n"
+"X-Crowdin-Language: es\n"
+"X-Crowdin-Project: cf448e737e0d6d7b78742f963d761c61\n"
+"X-Crowdin-Project-ID: 1\n"
+"X-Generator: @lingui/cli\n"
 
 #. js-lingui-id: lndIq/
 #: src/modules/settings/billing/hooks/useBillingWording.ts
@@ -116,16 +117,24 @@ msgstr "[cadeia vazia]"
 #. placeholder {1}: failedResults.length
 #. placeholder {2}: failedResults.length
 #: src/modules/settings/admin-panel/health-status/hooks/useDeleteJobs.ts
-msgid "{0, plural, one {{1} job could not be deleted} other {{2} jobs could not be deleted}}"
-msgstr "{0, plural, one {{1} trabajo no pudo ser eliminado} other {{2} trabajos no pudieron ser eliminados}}"
+msgid ""
+"{0, plural, one {{1} job could not be deleted} other {{2} jobs could not be "
+"deleted}}"
+msgstr ""
+"{0, plural, one {{1} trabajo no pudo ser eliminado} other {{2} trabajos no "
+"pudieron ser eliminados}}"
 
 #. js-lingui-id: VjPlMz
 #. placeholder {0}: failedResults.length
 #. placeholder {1}: failedResults.length
 #. placeholder {2}: failedResults.length
 #: src/modules/settings/admin-panel/health-status/hooks/useRetryJobs.ts
-msgid "{0, plural, one {{1} job could not be retried} other {{2} jobs could not be retried}}"
-msgstr "{0, plural, one {{1} trabajo no pudo ser reintento} other {{2} trabajos no pudieron ser reintentados}}"
+msgid ""
+"{0, plural, one {{1} job could not be retried} other {{2} jobs could not be "
+"retried}}"
+msgstr ""
+"{0, plural, one {{1} trabajo no pudo ser reintento} other {{2} trabajos no "
+"pudieron ser reintentados}}"
 
 #. js-lingui-id: 0LMb5P
 #. placeholder {0}: Math.abs(days)
@@ -149,38 +158,46 @@ msgstr "{0, plural, one {# Objeto} other {# Objetos}}"
 #. js-lingui-id: 8ob0vY
 #. placeholder {0}: failedCount + behindCount
 #: src/modules/settings/admin-panel/utils/getWorkspacesUpgradeHealthText.ts
-msgid "{0, plural, one {# workspace failed or behind} other {# workspaces failed or behind}}"
+msgid ""
+"{0, plural, one {# workspace failed or behind} other {# workspaces failed or"
+" behind}}"
 msgstr ""
+"{0, plural, one {# espacio de trabajo fallido o retrasado} other {# "
+"espaciosde trabajo fallidos o retrasados}}"
 
 #. js-lingui-id: WTc9VY
 #. placeholder {0}: restriction.fieldNames.length
 #: src/modules/page-layout/widgets/components/PageLayoutWidgetForbiddenDisplay.tsx
-msgid "{0, plural, one {You do not have permission to access the {fieldsList} field} other {You do not have permission to access the {fieldsList} fields}}"
-msgstr "{0, plural, one {No tienes permiso para acceder al campo {fieldsList}} other {No tienes permiso para acceder a los campos {fieldsList}}}"
+msgid ""
+"{0, plural, one {You do not have permission to access the {fieldsList} "
+"field} other {You do not have permission to access the {fieldsList} fields}}"
+msgstr ""
+"{0, plural, one {No tienes permiso para acceder al campo {fieldsList}} other"
+" {No tienes permiso para acceder a los campos {fieldsList}}}"
 
 #. js-lingui-id: pZCK0D
 #. placeholder {0}: registration.name
 #: src/pages/settings/applications/components/SettingsApplicationRegistrationConfigVariableDetail.tsx
 msgid "{0} - Config"
-msgstr ""
+msgstr "{0} - Configuración"
 
 #. js-lingui-id: stCODw
 #. placeholder {0}: appObject.fields.length
 #: src/modules/settings/applications/hooks/useComputeObjectAndFieldsContentForApplication.ts
 msgid "{0} fields"
-msgstr ""
+msgstr "{0} campos"
 
 #. js-lingui-id: T8aKxO
 #. placeholder {0}: layout.name
 #: src/modules/settings/applications/hooks/useComputeApplicationContentForLayoutAndLogic.ts
 msgid "{0} layout"
-msgstr ""
+msgstr "{0} diseño"
 
 #. js-lingui-id: Zo6POu
 #. placeholder {0}: recordPageLayoutObject.labelPlural
 #: src/modules/layout-customization/components/LayoutCustomizationBar.tsx
 msgid "{0} layout edition"
-msgstr ""
+msgstr "{0} edición de diseño"
 
 #. js-lingui-id: peiknr
 #. placeholder {0}: activeVisibleFieldLabels.length
@@ -190,47 +207,59 @@ msgstr ""
 #: src/modules/side-panel/pages/page-layout/hooks/useRecordTableSettingsDescriptions.ts
 #: src/modules/side-panel/pages/page-layout/hooks/useRecordTableSettingsDescriptions.ts
 msgid "{0} shown"
-msgstr ""
+msgstr "{0} mostrados"
 
 #. js-lingui-id: r4l/MK
 #. placeholder {0}: formatUsageValue(totalCredits)
 #: src/pages/settings/SettingsUsageUserDetail.tsx
 msgid "{0} used"
-msgstr ""
+msgstr "{0} usados"
 
 #. js-lingui-id: izNf/z
 #. placeholder {0}: view.name
 #: src/modules/settings/applications/hooks/useComputeApplicationContentForLayoutAndLogic.ts
 msgid "{0} view"
-msgstr ""
+msgstr "{0} vista"
 
 #. js-lingui-id: /ZFL82
 #. placeholder {0}: widgets.length
 #: src/pages/settings/layout/SettingsLayoutPageLayoutDetail.tsx
 msgid "{0} widgets"
-msgstr ""
+msgstr "{0} widgets"
 
 #. js-lingui-id: 2UKfhY
 #. placeholder {0}: selectedItemNames.length
 #: src/modules/object-record/record-field/ui/form-types/components/FormWorkspaceMemberFilterValueInput.tsx
 msgid "{0} workspace members"
-msgstr ""
+msgstr "{0} miembros del espacio de trabajo"
 
 #. js-lingui-id: xTgz1F
 #. placeholder {1}: provider.displayName
 #: src/pages/settings/applications/tabs/SettingsApplicationConnectionsSection.tsx
-msgid "{1} OAuth is not yet set up by your server administrator. They need to fill in the OAuth client ID and secret on the application registration before you can add a connection."
+msgid ""
+"{1} OAuth is not yet set up by your server administrator. They need to fill "
+"in the OAuth client ID and secret on the application registration before you"
+" can add a connection."
 msgstr ""
+"{1} OAuth aún no está configurado por el administrador del "
+"servidor.Necesitan completar el ID de cliente y el secreto de OAuth en el "
+"registro dela aplicación antes de que puedas añadir una conexión."
 
 #. js-lingui-id: qdQhzv
 #: src/modules/views/advanced-filter-chip/components/AdvancedFilterChip.tsx
-msgid "{advancedFilterCount, plural, one {{advancedFilterCount} advanced rule} other {{advancedFilterCount} advanced rules}}"
-msgstr "{advancedFilterCount, plural, one {{advancedFilterCount} regla avanzada} other {{advancedFilterCount} reglas avanzadas}}"
+msgid ""
+"{advancedFilterCount, plural, one {{advancedFilterCount} advanced rule} "
+"other {{advancedFilterCount} advanced rules}}"
+msgstr ""
+"{advancedFilterCount, plural, one {{advancedFilterCount} regla avanzada} "
+"other {{advancedFilterCount} reglas avanzadas}}"
 
 #. js-lingui-id: XWd9bY
 #: src/modules/settings/roles/role-settings/components/SettingsRoleSettingsDeleteRoleConfirmationModalSubtitle.tsx
-msgid "{agentCount, plural, one {{agentCount} agent} other {{agentCount} agents}}"
+msgid ""
+"{agentCount, plural, one {{agentCount} agent} other {{agentCount} agents}}"
 msgstr ""
+"{agentCount, plural, one {{agentCount} agente} other {{agentCount} agentes}}"
 
 #. js-lingui-id: WGnqk6
 #: src/modules/workflow/workflow-steps/workflow-actions/ai-agent-action/hooks/useWorkflowAiAgentPermissionActions.ts
@@ -249,24 +278,31 @@ msgstr "{aggregateLabel} de {fieldLabel}"
 
 #. js-lingui-id: WhHyQh
 #: src/modules/settings/roles/role-settings/components/SettingsRoleSettingsDeleteRoleConfirmationModalSubtitle.tsx
-msgid "{apiKeyCount, plural, one {{apiKeyCount} API key} other {{apiKeyCount} API keys}}"
+msgid ""
+"{apiKeyCount, plural, one {{apiKeyCount} API key} other {{apiKeyCount} API "
+"keys}}"
 msgstr ""
+"{apiKeyCount, plural, one {{apiKeyCount} clave API} other "
+"{{apiKeyCount}claves API}}"
 
 #. js-lingui-id: u1mVnV
 #: src/modules/marketplace/components/SettingsApplicationInstallPermissionValidationModal.tsx
 msgid "{appDisplayName} would like to:"
-msgstr ""
+msgstr "{appDisplayName} desea:"
 
 #. js-lingui-id: ZZZxmp
 #: src/pages/auth/Authorize.tsx
 msgid "{appName} would like to:"
-msgstr ""
+msgstr "{appName} desea:"
 
 #. js-lingui-id: y9covz
 #: src/pages/settings/admin-panel/SettingsAdminWorkspacesStatus.tsx
 #: src/modules/settings/admin-panel/utils/getWorkspacesUpgradeHealthText.ts
-msgid "{behindCount, plural, one {# workspace behind} other {# workspaces behind}}"
+msgid ""
+"{behindCount, plural, one {# workspace behind} other {# workspaces behind}}"
 msgstr ""
+"{behindCount, plural, one {# espacio de trabajo retrasado} other {# "
+"espaciosde trabajo retrasados}}"
 
 #. js-lingui-id: SU5Crx
 #: src/modules/ai/components/internal/AiChatContextUsageButton.tsx
@@ -284,13 +320,17 @@ msgstr "{contextStoreNumberOfSelectedRecords} seleccionados"
 #. placeholder {2}: (type === 'percentage' ? 99 : 1000).toFixed(count)
 #. placeholder {3}: type === 'percentage' ? '%' : ''
 #: src/modules/settings/data-model/fields/forms/number/components/SettingsDataModelFieldNumberForm.tsx
-msgid "{count, plural, one {E.g. {0}{1} for {count} decimal} other {E.g. {2}{3} for {count} decimals}}"
-msgstr "{count, plural, one {Ej. {0}{1} para {count} decimal} other {Ej. {2}{3} para {count} decimales}}"
+msgid ""
+"{count, plural, one {E.g. {0}{1} for {count} decimal} other {E.g. {2}{3} for"
+" {count} decimals}}"
+msgstr ""
+"{count, plural, one {Ej. {0}{1} para {count} decimal} other {Ej. {2}{3} para"
+" {count} decimales}}"
 
 #. js-lingui-id: q8RNNe
 #: src/modules/settings/billing/components/internal/ResourceCreditPriceSelector.tsx
 msgid "{credits} Credits - ${priceDisplay}"
-msgstr ""
+msgstr "{credits} Créditos - ${priceDisplay}"
 
 #. js-lingui-id: jsKQu8
 #: src/modules/object-record/record-show/hooks/useRecordShowPagePagination.ts
@@ -306,14 +346,22 @@ msgstr "{days, plural, one {{days} día} other {{days} días}}"
 #. placeholder {0}: (1000).toFixed(decimals)
 #. placeholder {1}: (1000).toFixed(decimals)
 #: src/modules/settings/data-model/fields/forms/currency/components/SettingsDataModelFieldCurrencyForm.tsx
-msgid "{decimals, plural, one {E.g. {0} for {decimals} decimal} other {E.g. {1} for {decimals} decimals}}"
-msgstr "{decimals, plural, one {Ej. {0} para {decimals} decimal} other {Ej. {1} para {decimals} decimales}}"
+msgid ""
+"{decimals, plural, one {E.g. {0} for {decimals} decimal} other {E.g. {1} for"
+" {decimals} decimals}}"
+msgstr ""
+"{decimals, plural, one {Ej. {0} para {decimals} decimal} other {Ej. {1} para"
+" {decimals} decimales}}"
 
 #. js-lingui-id: MIIEDl
 #: src/modules/settings/admin-panel/health-status/hooks/useDeleteJobs.ts
 #: src/modules/settings/admin-panel/health-status/hooks/useDeleteJobs.ts
-msgid "{deletedCount, plural, one {Successfully deleted {deletedCount} job} other {Successfully deleted {deletedCount} jobs}}"
-msgstr "{deletedCount, plural, one {Eliminado con éxito {deletedCount} trabajo} other {Eliminados con éxito {deletedCount} trabajos}}"
+msgid ""
+"{deletedCount, plural, one {Successfully deleted {deletedCount} job} other "
+"{Successfully deleted {deletedCount} jobs}}"
+msgstr ""
+"{deletedCount, plural, one {Eliminado con éxito {deletedCount} trabajo} "
+"other {Eliminados con éxito {deletedCount} trabajos}}"
 
 #. js-lingui-id: 2Xxop4
 #: src/modules/settings/billing/components/TrialCard.tsx
@@ -328,8 +376,11 @@ msgstr "{eventAction} un {eventObject} relacionado"
 #. js-lingui-id: nRKZKb
 #: src/pages/settings/admin-panel/SettingsAdminWorkspacesStatus.tsx
 #: src/modules/settings/admin-panel/utils/getWorkspacesUpgradeHealthText.ts
-msgid "{failedCount, plural, one {# workspace failed} other {# workspaces failed}}"
+msgid ""
+"{failedCount, plural, one {# workspace failed} other {# workspaces failed}}"
 msgstr ""
+"{failedCount, plural, one {# espacio de trabajo fallido} other {# espaciosde"
+" trabajo fallidos}}"
 
 #. js-lingui-id: POhzPf
 #: src/modules/ai/hooks/useAiChatFileUpload.ts
@@ -344,7 +395,7 @@ msgstr "{fieldCount} campos en {recordLabel}"
 #. js-lingui-id: fO/Qa9
 #: src/modules/settings/applications/hooks/useComputeObjectAndFieldsContentForApplication.ts
 msgid "{fieldsCount} fields"
-msgstr ""
+msgstr "{fieldsCount} campos"
 
 #. js-lingui-id: /9/Y5z
 #: src/modules/spreadsheet-import/steps/components/UploadStep/components/DropZone.tsx
@@ -353,23 +404,35 @@ msgstr "Carga de {fileName} rechazada"
 
 #. js-lingui-id: bv2QCV
 #: src/modules/side-panel/pages/page-layout/hooks/useChartSettingsValues.ts
-msgid "{filterRulesCount, plural, one {{filterRulesCount} rule} other {{filterRulesCount} rules}}"
-msgstr "{filterRulesCount, plural, one {{filterRulesCount} regla} other {{filterRulesCount} reglas}}"
+msgid ""
+"{filterRulesCount, plural, one {{filterRulesCount} rule} other "
+"{{filterRulesCount} rules}}"
+msgstr ""
+"{filterRulesCount, plural, one {{filterRulesCount} regla} other "
+"{{filterRulesCount} reglas}}"
 
 #. js-lingui-id: WS/avX
 #: src/modules/spreadsheet-import/steps/components/ImportDataStep.tsx
-msgid "{formattedCreatedRecordsProgress} out of {formattedRecordsToImportCount} records imported."
-msgstr "{formattedCreatedRecordsProgress} de {formattedRecordsToImportCount} registros importados."
+msgid ""
+"{formattedCreatedRecordsProgress} out of {formattedRecordsToImportCount} "
+"records imported."
+msgstr ""
+"{formattedCreatedRecordsProgress} de {formattedRecordsToImportCount} "
+"registros importados."
 
 #. js-lingui-id: iokIra
 #: src/modules/settings/applications/hooks/useComputeApplicationContentForLayoutAndLogic.ts
 msgid "{formattedType} of {objectLabel}"
-msgstr ""
+msgstr "{formattedType} de {objectLabel}"
 
 #. js-lingui-id: YF/a2j
 #: src/modules/settings/roles/role-permissions/objects-permissions/components/SettingsRolePermissionsObjectsTableRow.tsx
-msgid "{grantedBy, plural, one {Granted for {grantedBy} object} other {Granted for {grantedBy} objects}}"
-msgstr "{grantedBy, plural, one {Concedido para {grantedBy} objeto} other {Concedido para {grantedBy} objetos}}"
+msgid ""
+"{grantedBy, plural, one {Granted for {grantedBy} object} other {Granted for "
+"{grantedBy} objects}}"
+msgstr ""
+"{grantedBy, plural, one {Concedido para {grantedBy} objeto} other {Concedido"
+" para {grantedBy} objetos}}"
 
 #. js-lingui-id: LB2Hw6
 #: src/modules/workflow/workflow-steps/workflow-actions/http-request-action/components/HttpRequestExecutionResult.tsx
@@ -388,38 +451,61 @@ msgstr "Se enviaron {invitationCount} invitaciones"
 
 #. js-lingui-id: j9A2IB
 #: src/modules/settings/admin-panel/health-status/components/SettingsAdminDeleteJobsConfirmationModal.tsx
-msgid "{jobCount, plural, one {Delete {jobCount} Job} other {Delete {jobCount} Jobs}}"
-msgstr "{jobCount, plural, one {Eliminar {jobCount} trabajo} other {Eliminar {jobCount} trabajos}}"
+msgid ""
+"{jobCount, plural, one {Delete {jobCount} Job} other {Delete {jobCount} "
+"Jobs}}"
+msgstr ""
+"{jobCount, plural, one {Eliminar {jobCount} trabajo} other {Eliminar "
+"{jobCount} trabajos}}"
 
 #. js-lingui-id: 48w++B
 #: src/modules/settings/admin-panel/health-status/components/SettingsAdminRetryJobsConfirmationModal.tsx
-msgid "{jobCount, plural, one {Retry {jobCount} Job} other {Retry {jobCount} Jobs}}"
-msgstr "{jobCount, plural, one {Reintentar {jobCount} trabajo} other {Reintentar {jobCount} trabajos}}"
+msgid ""
+"{jobCount, plural, one {Retry {jobCount} Job} other {Retry {jobCount} Jobs}}"
+msgstr ""
+"{jobCount, plural, one {Reintentar {jobCount} trabajo} other {Reintentar "
+"{jobCount} trabajos}}"
 
 #. js-lingui-id: X78+Nn
 #: src/modules/settings/admin-panel/health-status/components/SettingsAdminDeleteJobsConfirmationModal.tsx
-msgid "{jobCount, plural, one {This will permanently remove it from the queue. This action cannot be undone.} other {This will permanently remove them from the queue. This action cannot be undone.}}"
-msgstr "{jobCount, plural, one {Esto lo eliminará permanentemente de la cola. Esta acción no puede deshacerse.} other {Esto los eliminará permanentemente de la cola. Esta acción no puede deshacerse.}}"
+msgid ""
+"{jobCount, plural, one {This will permanently remove it from the queue. This"
+" action cannot be undone.} other {This will permanently remove them from the"
+" queue. This action cannot be undone.}}"
+msgstr ""
+"{jobCount, plural, one {Esto lo eliminará permanentemente de la cola. Esta "
+"acción no puede deshacerse.} other {Esto los eliminará permanentemente de la"
+" cola. Esta acción no puede deshacerse.}}"
 
 #. js-lingui-id: QJYN9L
 #: src/modules/settings/admin-panel/health-status/components/SettingsAdminRetryJobsConfirmationModal.tsx
-msgid "{jobCount, plural, one {This will retry the selected job. It will be re-executed from the beginning.} other {This will retry the selected jobs. They will be re-executed from the beginning.}}"
-msgstr "{jobCount, plural, one {Esto reintentará el trabajo seleccionado. Será reejecutado desde el principio.} other {Esto reintentará los trabajos seleccionados. Serán reejecutados desde el principio.}}"
+msgid ""
+"{jobCount, plural, one {This will retry the selected job. It will be re-"
+"executed from the beginning.} other {This will retry the selected jobs. They"
+" will be re-executed from the beginning.}}"
+msgstr ""
+"{jobCount, plural, one {Esto reintentará el trabajo seleccionado. Será "
+"reejecutado desde el principio.} other {Esto reintentará los trabajos "
+"seleccionados. Serán reejecutados desde el principio.}}"
 
 #. js-lingui-id: FdY/eP
 #: src/modules/settings/applications/hooks/useComputeApplicationContentForLayoutAndLogic.ts
 msgid "{label} list"
-msgstr ""
+msgstr "lista de {label}"
 
 #. js-lingui-id: 1DrH/j
 #: src/modules/settings/roles/role-settings/components/SettingsRoleSettingsDeleteRoleConfirmationModalSubtitle.tsx
-msgid "{memberCount, plural, one {{memberCount} member} other {{memberCount} members}}"
+msgid ""
+"{memberCount, plural, one {{memberCount} member} other {{memberCount} "
+"members}}"
 msgstr ""
+"{memberCount, plural, one {{memberCount} miembro} other "
+"{{memberCount}miembros}}"
 
 #. js-lingui-id: Y32cMj
 #: src/modules/page-layout/widgets/email-thread/components/EmailThreadIntermediaryMessages.tsx
 msgid "{messagesLength} emails"
-msgstr ""
+msgstr "{messagesLength} correos electrónicos"
 
 #. js-lingui-id: Koe99p
 #: src/modules/settings/data-model/object-details/components/SettingsObjectRelationItemTableRow.tsx
@@ -429,7 +515,9 @@ msgstr "{morphRelationCount} objetos"
 
 #. js-lingui-id: g9mDO3
 #: src/utils/format/getOrdinalNumber.ts
-msgid "{num, selectordinal, one {{num}st} two {{num}nd} few {{num}rd} other {{num}th}}"
+msgid ""
+"{num, selectordinal, one {{num}st} two {{num}nd} few {{num}rd} other "
+"{{num}th}}"
 msgstr "{num, selectordinal, one {{num}º} other {{num}.º}}"
 
 #. js-lingui-id: fTSz8d
@@ -445,12 +533,12 @@ msgstr "{objectLabelPlural} ({totalCount})"
 #. js-lingui-id: FaQB54
 #: src/modules/workflow/workflow-steps/workflow-actions/ai-agent-action/hooks/useWorkflowAiAgentPermissionActions.ts
 msgid "{permissionLabel} permission removed"
-msgstr ""
+msgstr "permiso {permissionLabel} eliminado"
 
 #. js-lingui-id: VsXMnq
 #: src/modules/workflow/workflow-steps/workflow-actions/ai-agent-action/hooks/useWorkflowAiAgentPermissionActions.ts
 msgid "{permissionLabel} Permission removed"
-msgstr ""
+msgstr "Permiso {permissionLabel} eliminado"
 
 #. js-lingui-id: HpUf/k
 #: src/modules/object-record/record-merge/components/MergeSettingsTab.tsx
@@ -465,13 +553,21 @@ msgstr "{recordCount} de {totalCount} registros"
 #. js-lingui-id: 5d0hY6
 #: src/modules/settings/admin-panel/health-status/hooks/useRetryJobs.ts
 #: src/modules/settings/admin-panel/health-status/hooks/useRetryJobs.ts
-msgid "{retriedCount, plural, one {Successfully retried {retriedCount} job} other {Successfully retried {retriedCount} jobs}}"
-msgstr "{retriedCount, plural, one {Reintentos con éxito {retriedCount} trabajo} other {Reintentos con éxito {retriedCount} trabajos}}"
+msgid ""
+"{retriedCount, plural, one {Successfully retried {retriedCount} job} other "
+"{Successfully retried {retriedCount} jobs}}"
+msgstr ""
+"{retriedCount, plural, one {Reintentos con éxito {retriedCount} trabajo} "
+"other {Reintentos con éxito {retriedCount} trabajos}}"
 
 #. js-lingui-id: hcRYEH
 #: src/modules/settings/roles/role-permissions/objects-permissions/components/SettingsRolePermissionsObjectsTableRow.tsx
-msgid "{revokedBy, plural, one {Revoked for {revokedBy} object} other {Revoked for {revokedBy} objects}}"
-msgstr "{revokedBy, plural, one {Revocado para {revokedBy} objeto} other {Revocado para {revokedBy} objetos}}"
+msgid ""
+"{revokedBy, plural, one {Revoked for {revokedBy} object} other {Revoked for "
+"{revokedBy} objects}}"
+msgstr ""
+"{revokedBy, plural, one {Revocado para {revokedBy} objeto} other {Revocado "
+"para {revokedBy} objetos}}"
 
 #. js-lingui-id: OeIgEg
 #: src/modules/settings/roles/role-permissions/object-level-permissions/components/SettingsRolePermissionsObjectLevelOverrideCell.tsx
@@ -491,17 +587,25 @@ msgstr "{roleTargetName} será asignado al rol \"{newRoleName}\"."
 #. js-lingui-id: UsskHt
 #: src/modules/settings/applications/hooks/useComputeApplicationContentForLayoutAndLogic.ts
 msgid "{scopeCount} scopes"
-msgstr ""
+msgstr "{scopeCount} ámbitos"
 
 #. js-lingui-id: kvVMdH
 #: src/modules/settings/admin-panel/health-status/components/SettingsAdminQueueJobsTable.tsx
-msgid "{selectedCount, plural, one {Delete {selectedCount} Job} other {Delete {selectedCount} Jobs}}"
-msgstr "{selectedCount, plural, one {Eliminar {selectedCount} trabajo} other {Eliminar {selectedCount} trabajos}}"
+msgid ""
+"{selectedCount, plural, one {Delete {selectedCount} Job} other {Delete "
+"{selectedCount} Jobs}}"
+msgstr ""
+"{selectedCount, plural, one {Eliminar {selectedCount} trabajo} other "
+"{Eliminar {selectedCount} trabajos}}"
 
 #. js-lingui-id: 1y0QK1
 #: src/modules/settings/admin-panel/health-status/components/SettingsAdminQueueJobsTable.tsx
-msgid "{selectedCount, plural, one {Retry {selectedCount} Job} other {Retry {selectedCount} Jobs}}"
-msgstr "{selectedCount, plural, one {Reintentar {selectedCount} trabajo} other {Reintentar {selectedCount} trabajos}}"
+msgid ""
+"{selectedCount, plural, one {Retry {selectedCount} Job} other {Retry "
+"{selectedCount} Jobs}}"
+msgstr ""
+"{selectedCount, plural, one {Reintentar {selectedCount} trabajo} other "
+"{Reintentar {selectedCount} trabajos}}"
 
 #. js-lingui-id: e5lBpY
 #: src/modules/object-record/object-filter-dropdown/components/ObjectFilterDropdownSourceSelect.tsx
@@ -526,7 +630,7 @@ msgstr "{stepNumber}. Calendario"
 #. js-lingui-id: bI/mcH
 #: src/modules/settings/applications/hooks/useComputeApplicationContentForLayoutAndLogic.ts
 msgid "{tabCount} tabs"
-msgstr ""
+msgstr "{tabCount} pestañas"
 
 #. js-lingui-id: p38XKy
 #: src/modules/side-panel/components/SidePanelMultipleRecordsInfo.tsx
@@ -536,7 +640,7 @@ msgstr "{totalCount} seleccionados"
 #. js-lingui-id: XdG+hI
 #: src/modules/side-panel/pages/page-layout/components/record-page/SidePanelRecordPageFieldsSettings.tsx
 msgid "{totalFieldsCount} visible fields"
-msgstr ""
+msgstr "{totalFieldsCount} campos visibles"
 
 #. js-lingui-id: ITVweg
 #: src/modules/object-record/object-options-dropdown/components/ObjectOptionsDropdownDefaultView.tsx
@@ -547,12 +651,16 @@ msgstr "{visibleFieldsCount} mostrados"
 #. js-lingui-id: WjjsAL
 #: src/modules/side-panel/pages/page-layout/components/record-page/SidePanelRecordPageFieldSettings.tsx
 msgid "{visibleFieldsCount} visible fields"
-msgstr ""
+msgstr "{visibleFieldsCount} campos visibles"
 
 #. js-lingui-id: riMLMq
 #: src/modules/workflow/workflow-steps/workflow-actions/iterator-action/components/WorkflowIteratorSubStepSwitcher.tsx
-msgid "{workflowRunIteratorSubStepIterationsCount, plural, one {# item} other {# items}}"
-msgstr "{workflowRunIteratorSubStepIterationsCount, plural, one {# elemento} other {# elementos}}"
+msgid ""
+"{workflowRunIteratorSubStepIterationsCount, plural, one {# item} other {# "
+"items}}"
+msgstr ""
+"{workflowRunIteratorSubStepIterationsCount, plural, one {# elemento} other "
+"{# elementos}}"
 
 #. js-lingui-id: WN9tFl
 #: src/modules/settings/roles/role-assignment/components/SettingsRoleAssignmentConfirmationModalSubtitle.tsx
@@ -562,21 +670,23 @@ msgstr "{workspaceMemberName} dejará de estar asignado al siguiente rol:"
 #. js-lingui-id: XxzXhf
 #: src/pages/settings/layout/SettingsLayoutViewDetail.tsx
 msgid "#"
-msgstr ""
+msgstr "#"
 
 #. js-lingui-id: n9nj+X
 #. placeholder {0}: aiChatThreadPendingDelete?.threadTitle ?? ''
 #: src/modules/ai/components/AiChatThreadDeleteConfirmationModal.tsx
 msgid "<0>{0}</0> and all its messages will be removed."
-msgstr ""
+msgstr "<0>{0}</0> y todos sus mensajes serán eliminados."
 
 #. js-lingui-id: SMgdEJ
-#. placeholder {0}: formatNumber(preview.estimatedTokenCount, { abbreviate: true, decimals: 1, })
-#. placeholder {0}: formatNumber( section.estimatedTokenCount, { abbreviate: true, decimals: 1, }, )
+#. placeholder {0}: formatNumber(preview.estimatedTokenCount, { abbreviate:
+#. true, decimals: 1, })
+#. placeholder {0}: formatNumber( section.estimatedTokenCount, { abbreviate:
+#. true, decimals: 1, }, )
 #: src/pages/settings/ai/SettingsAiPrompts.tsx
 #: src/pages/settings/ai/SettingsAiPrompts.tsx
 msgid "~ {0} tokens"
-msgstr ""
+msgstr "~ {0} tokens"
 
 #. js-lingui-id: Cx0xl3
 #: src/modules/workflow/workflow-steps/workflow-actions/delay-actions/components/WorkflowEditActionDelay.tsx
@@ -594,17 +704,17 @@ msgstr "0 */1 * * *"
 #. js-lingui-id: Mkh9C8
 #: src/modules/settings/applications/hooks/useComputeApplicationContentForLayoutAndLogic.ts
 msgid "1 scope"
-msgstr ""
+msgstr "1 ámbito"
 
 #. js-lingui-id: W/OU4i
 #: src/modules/settings/applications/hooks/useComputeApplicationContentForLayoutAndLogic.ts
 msgid "1 tab"
-msgstr ""
+msgstr "1 pestaña"
 
 #. js-lingui-id: m60AP0
 #: src/pages/settings/layout/SettingsLayoutPageLayoutDetail.tsx
 msgid "1 widget"
-msgstr ""
+msgstr "1 widget"
 
 #. js-lingui-id: tEdOxj
 #: src/pages/settings/accounts/SettingsAccountsConfigurationStepEmail.tsx
@@ -631,7 +741,7 @@ msgstr "1. Tipo"
 #. js-lingui-id: rU05hS
 #: src/modules/settings/experience/components/DateTimeSettingsTimeFormatSelect.tsx
 msgid "12h"
-msgstr ""
+msgstr "12h"
 
 #. js-lingui-id: 4EdXYs
 #: src/pages/settings/profile/appearance/components/DateTimeSettingsTimeFormatSelect.tsx
@@ -641,7 +751,7 @@ msgstr "12h ({hour12Label})"
 #. js-lingui-id: wk1eMj
 #: src/modules/ai/constants/AgentChatThreadLastActivityFilterLabels.ts
 msgid "1d"
-msgstr ""
+msgstr "1d"
 
 #. js-lingui-id: yXvRMf
 #: src/modules/settings/data-model/components/SettingsDataModelNewFieldBreadcrumbDropDown.tsx
@@ -672,7 +782,7 @@ msgstr "200 OK - {duration}ms"
 #. js-lingui-id: W1k7eB
 #: src/modules/settings/experience/components/DateTimeSettingsTimeFormatSelect.tsx
 msgid "24h"
-msgstr ""
+msgstr "24h"
 
 #. js-lingui-id: QsMprd
 #: src/pages/settings/profile/appearance/components/DateTimeSettingsTimeFormatSelect.tsx
@@ -692,17 +802,17 @@ msgstr "Restablecer el método de 2FA"
 #. js-lingui-id: cI6f7l
 #: src/modules/ai/constants/AgentChatThreadLastActivityFilterLabels.ts
 msgid "30d"
-msgstr ""
+msgstr "30d"
 
 #. js-lingui-id: XO2NLh
 #: src/modules/ai/constants/AgentChatThreadLastActivityFilterLabels.ts
 msgid "3d"
-msgstr ""
+msgstr "3d"
 
 #. js-lingui-id: 2Lvxm0
 #: src/pages/onboarding/internal/ChooseYourPlanContent.tsx
 msgid "50,000 workflow node executions"
-msgstr ""
+msgstr "50.000 ejecuciones de nodos de flujo de trabajo"
 
 #. js-lingui-id: 4lbHin
 #: src/modules/logic-functions/components/LogicFunctionExecutionResult.tsx
@@ -712,7 +822,7 @@ msgstr "500 Error - {duration}ms"
 #. js-lingui-id: wH8/eh
 #: src/modules/ai/constants/AgentChatThreadLastActivityFilterLabels.ts
 msgid "7d"
-msgstr ""
+msgstr "7d"
 
 #. js-lingui-id: 43TqJC
 #: src/pages/settings/admin-panel/SettingsAdminNewAiProvider.tsx
@@ -726,8 +836,11 @@ msgstr "Ya existe un borrador"
 
 #. js-lingui-id: OITESn
 #: src/modules/workflow/components/OverrideWorkflowDraftConfirmationModal.tsx
-msgid "A draft already exists for this workflow. Are you sure you want to erase it?"
-msgstr "Ya existe un borrador para este flujo de trabajo. ¿Estás seguro de que deseas borrarlo?"
+msgid ""
+"A draft already exists for this workflow. Are you sure you want to erase it?"
+msgstr ""
+"Ya existe un borrador para este flujo de trabajo. ¿Estás seguro de que "
+"deseas borrarlo?"
 
 #. js-lingui-id: C6xZqR
 #: src/pages/settings/developers/api-keys/SettingsDevelopersApiKeyDetail.tsx
@@ -736,8 +849,12 @@ msgstr "Debe seleccionar un rol para la clave API"
 
 #. js-lingui-id: nMTB1f
 #: src/pages/onboarding/CreateWorkspace.tsx
-msgid "A shared environment where you will be able to manage your customer relations with your team."
-msgstr "Un entorno compartido donde podrás gestionar tus relaciones con clientes junto a tu equipo."
+msgid ""
+"A shared environment where you will be able to manage your customer "
+"relations with your team."
+msgstr ""
+"Un entorno compartido donde podrás gestionar tus relaciones con clientes "
+"junto a tu equipo."
 
 #. js-lingui-id: /cSHSG
 #: src/modules/auth/sign-in-up/components/EmailVerificationSent.tsx
@@ -767,12 +884,16 @@ msgstr "Habilidad para editar todas las configuraciones"
 #. js-lingui-id: MjUIIf
 #: src/modules/settings/roles/role-permissions/object-level-permissions/record-level-permissions/components/SettingsRolePermissionsObjectLevelRecordLevelSection.tsx
 msgid "Ability to filter the records a user can interact with"
-msgstr "Posibilidad de filtrar los registros con los que un usuario puede interactuar"
+msgstr ""
+"Posibilidad de filtrar los registros con los que un usuario puede "
+"interactuar"
 
 #. js-lingui-id: 7J3Y++
 #: src/modules/settings/roles/role-permissions/object-level-permissions/record-level-permissions/components/SettingsRolePermissionsObjectLevelRecordLevelSection.tsx
 msgid "Ability to filter the records a user can interact with."
-msgstr "Posibilidad de filtrar los registros con los que un usuario puede interactuar."
+msgstr ""
+"Posibilidad de filtrar los registros con los que un usuario puede "
+"interactuar."
 
 #. js-lingui-id: wTKqOI
 #: src/modules/settings/roles/role-permissions/object-level-permissions/field-permissions/components/SettingsRolePermissionsObjectLevelObjectFieldPermissionTable.tsx
@@ -815,12 +936,12 @@ msgstr "Sobre este espacio de trabajo"
 #. js-lingui-id: HfdWGA
 #: src/pages/settings/applications/components/SettingsApplicationRegistrationGeneralInfo.tsx
 msgid "About your app"
-msgstr ""
+msgstr "Sobre tu aplicación"
 
 #. js-lingui-id: LuXP9q
 #: src/pages/settings/applications/tabs/SettingsApplicationsDeveloperTab.tsx
 msgid "Access"
-msgstr ""
+msgstr "Acceso"
 
 #. js-lingui-id: pNW+Rt
 #: src/pages/settings/admin-panel/SettingsAdminNewAiProvider.tsx
@@ -830,12 +951,16 @@ msgstr "ID de clave de acceso"
 #. js-lingui-id: CrjDqe
 #: src/pages/auth/Authorize.tsx
 msgid "Access your workspace data"
-msgstr ""
+msgstr "Acceder a los datos de tu espacio de trabajo"
 
 #. js-lingui-id: c2UA7k
 #: src/pages/settings/ai/components/SettingsAiMCP.tsx
-msgid "Access your workspace data from your favorite MCP client like Claude Desktop, Windsurf or Cursor."
+msgid ""
+"Access your workspace data from your favorite MCP client like Claude "
+"Desktop, Windsurf or Cursor."
 msgstr ""
+"Accede a los datos de tu espacio de trabajo desde tu cliente MCP favorito "
+"como Claude Desktop, Windsurf o Cursor."
 
 #. js-lingui-id: AeXO77
 #: src/pages/settings/accounts/SettingsAccountsConfigurationStepEmail.tsx
@@ -991,8 +1116,12 @@ msgstr "Agregar un grupo"
 
 #. js-lingui-id: CZDwqQ
 #: src/modules/ai/components/suggested-prompts/default-suggested-prompts.ts
-msgid "Add a new company we're in touch with (e.g. name, website, industry). Details: "
-msgstr "Añade una nueva empresa con la que estamos en contacto (p. ej., nombre, sitio web, sector). Detalles: "
+msgid ""
+"Add a new company we're in touch with (e.g. name, website, industry). "
+"Details: "
+msgstr ""
+"Añade una nueva empresa con la que estamos en contacto (p. ej., nombre, "
+"sitio web, sector). Detalles: "
 
 #. js-lingui-id: nGv1DN
 #: src/modules/side-panel/utils/getSidePanelSubPageTitle.ts
@@ -1043,17 +1172,23 @@ msgstr "Añadir CC"
 #. js-lingui-id: Rop0cs
 #: src/pages/settings/applications/tabs/SettingsApplicationConnectionsSection.tsx
 msgid "Add connection"
-msgstr ""
+msgstr "Añadir conexión"
 
 #. js-lingui-id: RVp8im
 #: src/modules/settings/admin-panel/ai/components/SettingsAdminAI.tsx
 msgid "Add custom endpoints, private gateways, or additional regions."
-msgstr "Añade endpoints personalizados, puertas de enlace privadas o regiones adicionales."
+msgstr ""
+"Añade endpoints personalizados, puertas de enlace privadas o regiones "
+"adicionales."
 
 #. js-lingui-id: GuJvBr
 #: src/pages/settings/ai/components/SettingsAiMoreTab.tsx
-msgid "Add custom instructions specific to your workspace (appended to system prompt)"
-msgstr "Añade instrucciones personalizadas específicas de tu espacio de trabajo (se añaden al prompt del sistema)"
+msgid ""
+"Add custom instructions specific to your workspace (appended to system "
+"prompt)"
+msgstr ""
+"Añade instrucciones personalizadas específicas de tu espacio de trabajo (se "
+"añaden al prompt del sistema)"
 
 #. js-lingui-id: 4JviOV
 #: src/modules/settings/admin-panel/ai/components/SettingsAdminAiProviderListCard.tsx
@@ -1064,12 +1199,12 @@ msgstr "Añadir proveedor personalizado"
 #. js-lingui-id: +Gf1IN
 #: src/modules/settings/workspace/components/SettingsWorkspaceEmailGroupSection.tsx
 msgid "Add email handle"
-msgstr ""
+msgstr "Añadir identificador de correo"
 
 #. js-lingui-id: HMM0Sc
 #: src/modules/settings/workspace/components/SettingsWorkspaceEmailingDomainsSection.tsx
 msgid "Add emailing domain"
-msgstr ""
+msgstr "Añadir dominio de correo"
 
 #. js-lingui-id: DpV70M
 #: src/modules/workflow/workflow-steps/workflow-actions/form-action/components/WorkflowEditActionFormBuilder.tsx
@@ -1115,7 +1250,7 @@ msgstr "Agregar In-Reply-To"
 #: src/modules/settings/data-model/object-details/components/tabs/SettingsObjectIndexesSection.tsx
 #: src/modules/settings/data-model/object-details/components/tabs/SettingsObjectIndexesSection.tsx
 msgid "Add Index"
-msgstr ""
+msgstr "Añadir índice"
 
 #. js-lingui-id: 7XzAKI
 #: src/modules/workflow/workflow-steps/workflow-actions/form-action/components/WorkflowEditActionFormBuilder.tsx
@@ -1215,7 +1350,7 @@ msgstr "Añadir campo de salida"
 #: src/modules/workflow/workflow-steps/workflow-actions/ai-agent-action/components/WorkflowEditActionAiAgent.tsx
 #: src/modules/workflow/workflow-steps/workflow-actions/ai-agent-action/components/WorkflowAiAgentPermissionsTab.tsx
 msgid "Add permission"
-msgstr ""
+msgstr "Añadir permiso"
 
 #. js-lingui-id: wTsnV9
 #: src/modules/settings/domains/components/SettingsPublicDomainsListCard.tsx
@@ -1275,6 +1410,8 @@ msgstr "Agregar tarea"
 #: src/pages/settings/ai/components/SettingsAgentEvalsTab.tsx
 msgid "Add test input for evaluation (e.g., \"Find all customers in NY\")"
 msgstr ""
+"Añadir entrada de prueba para evaluación (ej., \"Buscar todos los clientes "
+"en NY\")"
 
 #. js-lingui-id: FQArA8
 #: src/modules/settings/emailing-domains/components/SettingsEmailingDomainVerificationRecords.tsx
@@ -1295,7 +1432,7 @@ msgstr "Añadir a favoritos"
 #. js-lingui-id: XnwceV
 #: src/pages/settings/applications/components/SettingsApplicationRegistrationRedirectURIsInput.tsx
 msgid "Add URI"
-msgstr ""
+msgstr "Añadir URI"
 
 #. js-lingui-id: q9e2Bs
 #: src/modules/views/view-picker/components/ViewPickerListContent.tsx
@@ -1318,12 +1455,12 @@ msgstr "Agregar widget"
 #. js-lingui-id: 8zCitC
 #: src/modules/side-panel/pages/page-layout/components/WidgetSettingsPlacementSection.tsx
 msgid "Add widget above"
-msgstr ""
+msgstr "Añadir widget arriba"
 
 #. js-lingui-id: yy7F6M
 #: src/modules/side-panel/pages/page-layout/components/WidgetSettingsPlacementSection.tsx
 msgid "Add widget below"
-msgstr ""
+msgstr "Añadir widget abajo"
 
 #. js-lingui-id: m2qDV8
 #: src/modules/object-record/record-table/empty-state/utils/getEmptyStateTitle.ts
@@ -1364,7 +1501,7 @@ msgstr "Dirección 2"
 #. js-lingui-id: U3pytU
 #: src/modules/settings/members/components/MemberInfosTab.tsx
 msgid "Admin"
-msgstr ""
+msgstr "Administrador"
 
 #. js-lingui-id: g1in8j
 #: src/pages/settings/admin-panel/SettingsAdminNewAiProvider.tsx
@@ -1380,22 +1517,22 @@ msgstr "Panel de administración"
 #: src/pages/settings/admin-panel/SettingsAdminWorkspaceChatThread.tsx
 #: src/pages/settings/admin-panel/SettingsAdminAiProviderDetail.tsx
 msgid "Admin Panel - AI"
-msgstr ""
+msgstr "Panel de administración - IA"
 
 #. js-lingui-id: 2GX/U+
 #: src/pages/settings/admin-panel/SettingsAdminApplicationRegistrationDetail.tsx
 msgid "Admin Panel - Apps"
-msgstr ""
+msgstr "Panel de administración - Aplicaciones"
 
 #. js-lingui-id: JA5LSq
 #: src/pages/settings/admin-panel/SettingsAdminConfigVariableDetails.tsx
 msgid "Admin Panel - Config"
-msgstr ""
+msgstr "Panel de administración - Configuración"
 
 #. js-lingui-id: 6X68yA
 #: src/pages/settings/admin-panel/SettingsAdminUserDetail.tsx
 msgid "Admin Panel - General"
-msgstr ""
+msgstr "Panel de administración - General"
 
 #. js-lingui-id: v/zjIb
 #: src/pages/settings/admin-panel/SettingsAdminWorkspacesStatus.tsx
@@ -1404,7 +1541,7 @@ msgstr ""
 #: src/pages/settings/admin-panel/SettingsAdminInferredVersion.tsx
 #: src/pages/settings/admin-panel/SettingsAdminIndicatorHealthStatus.tsx
 msgid "Admin Panel - Health"
-msgstr ""
+msgstr "Panel de administración - Salud"
 
 #. js-lingui-id: sxkWRg
 #: src/modules/workflow/workflow-trigger/components/WorkflowEditTriggerDatabaseEventForm.tsx
@@ -1417,7 +1554,7 @@ msgstr "Avanzado"
 #. js-lingui-id: cBdysG
 #: src/modules/settings/enterprise/components/EnterprisePlanModal.tsx
 msgid "Advanced Encryption"
-msgstr ""
+msgstr "Cifrado avanzado"
 
 #. js-lingui-id: tMFFwF
 #: src/modules/views/components/ViewBarFilterDropdownAdvancedFilterButton.tsx
@@ -1478,8 +1615,11 @@ msgstr "Ejecución del agente"
 
 #. js-lingui-id: WrQ+BN
 #: src/pages/settings/ai/components/SettingsAgentLogsTab.tsx
-msgid "Agent interactions will appear here once the agent is used in conversations"
+msgid ""
+"Agent interactions will appear here once the agent is used in conversations"
 msgstr ""
+"Las interacciones del agente aparecerán aquí una vez que el agente se use en"
+" conversaciones"
 
 #. js-lingui-id: mDXkHu
 #: src/pages/settings/ai/SettingsAgentForm.tsx
@@ -1500,7 +1640,7 @@ msgstr "Tokens del agente"
 #: src/pages/settings/applications/SettingsAvailableApplicationDetails.tsx
 #: src/pages/settings/applications/SettingsApplicationDetails.tsx
 msgid "agents"
-msgstr ""
+msgstr "agentes"
 
 #. js-lingui-id: 8Uv5e6
 #: src/pages/settings/applications/tabs/SettingsApplicationDetailContentTab.tsx
@@ -1512,7 +1652,7 @@ msgstr "Agentes"
 #: src/modules/side-panel/pages/page-layout/constants/GraphTypeInformation.ts
 #: src/modules/page-layout/utils/getWidgetTitle.ts
 msgid "Aggregate Chart"
-msgstr ""
+msgstr "Gráfico agregado"
 
 #. js-lingui-id: jsQZMk
 #: src/pages/settings/members/roles/SettingsRoleAddObjectLevel.tsx
@@ -1525,8 +1665,7 @@ msgstr ""
 #: src/pages/settings/ai/SettingsAgentTurnDetail.tsx
 #: src/pages/settings/ai/SettingsAgentTurnDetail.tsx
 #: src/pages/settings/ai/SettingsAgentForm.tsx
-#: src/pages/settings/ai/SettingsAI.tsx
-#: src/pages/settings/ai/SettingsAI.tsx
+#: src/pages/settings/ai/SettingsAI.tsx src/pages/settings/ai/SettingsAI.tsx
 #: src/modules/workflow/workflow-steps/workflow-actions/utils/getActionHeaderTypeOrThrow.ts
 #: src/modules/side-panel/pages/workflow/action/components/SidePanelWorkflowSelectAction.tsx
 #: src/modules/settings/roles/role-permissions/permission-flags/hooks/useSettingsRolePermissionFlagConfig.ts
@@ -1544,17 +1683,17 @@ msgstr "Chat de IA"
 #. js-lingui-id: qiD/6r
 #: src/pages/settings/admin-panel/SettingsAdminWorkspaceDetail.tsx
 msgid "AI chat threads for this workspace"
-msgstr ""
+msgstr "Hilos de chat de IA para este espacio de trabajo"
 
 #. js-lingui-id: E/lGXl
 #: src/modules/settings/admin-panel/ai/components/SettingsAdminAI.tsx
 msgid "AI consumption across all workspaces."
-msgstr ""
+msgstr "Consumo de IA en todos los espacios de trabajo."
 
 #. js-lingui-id: kkfXGh
 #: src/pages/settings/ai/components/SettingsAiUsageTab.tsx
 msgid "AI consumption over time."
-msgstr ""
+msgstr "Consumo de IA a lo largo del tiempo."
 
 #. js-lingui-id: kNfr85
 #: src/pages/settings/ai/forms/components/SettingsAiAgentForm.tsx
@@ -1564,8 +1703,12 @@ msgstr "Modelo de IA"
 
 #. js-lingui-id: Sfwld8
 #: src/modules/ai/components/AiChatApiKeyNotConfiguredMessage.tsx
-msgid "AI not configured. Set OPENAI_API_KEY, ANTHROPIC_API_KEY, or XAI_API_KEY in your environment."
-msgstr "IA no configurada. Establece OPENAI_API_KEY, ANTHROPIC_API_KEY o XAI_API_KEY en tu entorno."
+msgid ""
+"AI not configured. Set OPENAI_API_KEY, ANTHROPIC_API_KEY, or XAI_API_KEY in "
+"your environment."
+msgstr ""
+"IA no configurada. Establece OPENAI_API_KEY, ANTHROPIC_API_KEY o XAI_API_KEY"
+" en tu entorno."
 
 #. js-lingui-id: jwOWhc
 #: src/modules/ai/components/RoutingDebugDisplay.tsx
@@ -1577,7 +1720,7 @@ msgstr "Preparación de la solicitud de IA"
 #: src/modules/settings/logic-functions/components/tabs/SettingsLogicFunctionTestTab.tsx
 #: src/modules/logic-functions/utils/getLogicFunctionTriggerLabel.ts
 msgid "AI tool"
-msgstr ""
+msgstr "Herramienta de IA"
 
 #. js-lingui-id: tzhisR
 #: src/pages/settings/ai/SettingsAiUsageUserDetail.tsx
@@ -1586,59 +1729,67 @@ msgstr ""
 #: src/pages/settings/ai/components/SettingsAiUsageTab.tsx
 #: src/pages/settings/ai/components/SettingsAiUsageTab.tsx
 msgid "AI Usage"
-msgstr ""
+msgstr "Uso de IA"
 
 #. js-lingui-id: Ad11E9
 #: src/modules/settings/admin-panel/ai/components/SettingsAdminAI.tsx
-msgid "AI usage analytics across workspaces is available with an Enterprise key."
+msgid ""
+"AI usage analytics across workspaces is available with an Enterprise key."
 msgstr ""
+"Las analíticas de uso de IA entre espacios de trabajo están disponibles con "
+"una clave Enterprise."
 
 #. js-lingui-id: zkptxb
 #: src/pages/settings/ai/components/SettingsAiUsageTab.tsx
 msgid "AI usage analytics is available with an Enterprise key."
 msgstr ""
+"Las analíticas de uso de IA están disponibles con una clave Enterprise."
 
 #. js-lingui-id: U2F/HK
 #: src/pages/settings/ai/components/SettingsAiUsageTab.tsx
 msgid "AI usage analytics requires ClickHouse. Contact your administrator."
 msgstr ""
+"Las analíticas de uso de IA requieren ClickHouse. Contacta a tu "
+"administrador."
 
 #. js-lingui-id: KgAAyO
 #: src/pages/settings/ai/components/SettingsAiUsageTab.tsx
 msgid "AI usage analytics will appear here once you start using AI features."
 msgstr ""
+"Las analíticas de uso de IA aparecerán aquí una vez que comiences a usar "
+"funciones de IA."
 
 #. js-lingui-id: SknniY
 #: src/pages/settings/ai/SettingsAiUsageUserDetail.tsx
 #: src/pages/settings/ai/components/SettingsAiUsageTab.tsx
 msgid "AI Usage by Model"
-msgstr ""
+msgstr "Uso de IA por modelo"
 
 #. js-lingui-id: ehjYr9
 #: src/pages/settings/ai/SettingsAiUsageUserDetail.tsx
 #: src/pages/settings/ai/components/SettingsAiUsageTab.tsx
 msgid "AI Usage by Type"
-msgstr ""
+msgstr "Uso de IA por tipo"
 
 #. js-lingui-id: X2afmM
 #: src/pages/settings/ai/components/SettingsAiUsageTab.tsx
 msgid "AI Usage by User"
-msgstr ""
+msgstr "Uso de IA por usuario"
 
 #. js-lingui-id: jyqPfh
 #: src/modules/settings/admin-panel/ai/components/SettingsAdminAI.tsx
 msgid "AI Usage by Workspace"
-msgstr ""
+msgstr "Uso de IA por espacio de trabajo"
 
 #. js-lingui-id: KLyZ6L
 #: src/pages/settings/ai/SettingsAiUsageUserDetail.tsx
 msgid "AI User Usage"
-msgstr ""
+msgstr "Uso de IA por usuario"
 
 #. js-lingui-id: TLbVxH
 #: src/modules/settings/usage/utils/getOperationTypeLabel.ts
 msgid "AI Workflow"
-msgstr ""
+msgstr "Flujo de trabajo de IA"
 
 #. js-lingui-id: BAiyFV
 #: src/pages/settings/admin-panel/SettingsAdminNewAiProvider.tsx
@@ -1682,8 +1833,12 @@ msgstr "Todos los registros de aplicaciones"
 
 #. js-lingui-id: ZrLLkh
 #: src/modules/settings/admin-panel/apps/components/SettingsAdminApps.tsx
-msgid "All application registrations across the platform, including orphaned marketplace apps"
-msgstr "Todos los registros de aplicaciones en toda la plataforma, incluidas las aplicaciones huérfanas del Marketplace"
+msgid ""
+"All application registrations across the platform, including orphaned "
+"marketplace apps"
+msgstr ""
+"Todos los registros de aplicaciones en toda la plataforma, incluidas las "
+"aplicaciones huérfanas del Marketplace"
 
 #. js-lingui-id: 1kLn6M
 #: src/modules/activities/calendar/components/CalendarEventRow.tsx
@@ -1692,8 +1847,12 @@ msgstr "Todo el día"
 
 #. js-lingui-id: dJn2LR
 #: src/modules/settings/accounts/components/SettingsAccountsRowDropdownMenu.tsx
-msgid "All emails and events linked to this account ({accountHandle}) will be deleted"
-msgstr "Todos los correos electrónicos y eventos vinculados a esta cuenta ({accountHandle}) se eliminarán"
+msgid ""
+"All emails and events linked to this account ({accountHandle}) will be "
+"deleted"
+msgstr ""
+"Todos los correos electrónicos y eventos vinculados a esta cuenta "
+"({accountHandle}) se eliminarán"
 
 #. js-lingui-id: GNJgJf
 #: src/modules/settings/admin-panel/health-status/hooks/useRetryJobs.ts
@@ -1708,7 +1867,7 @@ msgstr "Todos los campos"
 #. js-lingui-id: Ynglvj
 #: src/modules/object-record/record-table/record-table-header/components/RecordTableHeaderPlusButtonContent.tsx
 msgid "All fields are already visible"
-msgstr ""
+msgstr "Todos los campos ya son visibles"
 
 #. js-lingui-id: BKoJRa
 #: src/modules/settings/admin-panel/config-variables/components/SettingsAdminConfigVariables.tsx
@@ -1733,7 +1892,7 @@ msgstr "Todos los metadatos"
 #. js-lingui-id: zIk4M6
 #: src/modules/side-panel/components/SidePanelObjectFilterDropdownContent.tsx
 msgid "All objects"
-msgstr ""
+msgstr "Todos los objetos"
 
 #. js-lingui-id: aFE/OW
 #: src/pages/settings/security/event-logs/components/EventLogFilters.tsx
@@ -1772,6 +1931,7 @@ msgstr "Todas las tareas abordadas. Mantén el impulso."
 #: src/pages/settings/applications/components/SettingsApplicationsTable.tsx
 msgid "All the applications currently installed on this workspace"
 msgstr ""
+"Todas las aplicaciones instaladas actualmente en este espacio de trabajo"
 
 #. js-lingui-id: XuuWVF
 #: src/modules/settings/roles/role-permissions/object-level-permissions/components/SettingsRolePermissionsObjectLevelObjectPicker.tsx
@@ -1801,7 +1961,9 @@ msgstr "Permitir la descarga de archivos y archivos adjuntos"
 #. js-lingui-id: 6BV/aG
 #: src/modules/settings/security/components/SettingsSecurityAuthBypassOptionsList.tsx
 msgid "Allow email & password login for SSO bypass users."
-msgstr "Permitir inicio de sesión con correo electrónico y contraseña para los usuarios que omitan SSO."
+msgstr ""
+"Permitir inicio de sesión con correo electrónico y contraseña para los "
+"usuarios que omitan SSO."
 
 #. js-lingui-id: +XmkDf
 #: src/modules/settings/roles/role-permissions/permission-flags/hooks/useActionRolePermissionFlagConfig.ts
@@ -1811,7 +1973,9 @@ msgstr "Permitir exportar datos a archivos CSV"
 #. js-lingui-id: q/pgyN
 #: src/modules/settings/security/components/SettingsSecurityAuthBypassOptionsList.tsx
 msgid "Allow Google-based login for users with SSO bypass permissions."
-msgstr "Permitir inicio de sesión basado en Google para usuarios con permisos para omitir SSO."
+msgstr ""
+"Permitir inicio de sesión basado en Google para usuarios con permisos para "
+"omitir SSO."
 
 #. js-lingui-id: gCnKdT
 #: src/modules/settings/roles/role-permissions/permission-flags/hooks/useActionRolePermissionFlagConfig.ts
@@ -1821,22 +1985,28 @@ msgstr "Permitir importar datos desde archivos CSV"
 #. js-lingui-id: irI8Y5
 #: src/pages/settings/admin-panel/SettingsAdminApplicationRegistrationGeneralToggles.tsx
 msgid "Allow installation"
-msgstr ""
+msgstr "Permitir instalación"
 
 #. js-lingui-id: GMx1K0
 #: src/modules/settings/security/components/SettingsSecurityAuthProvidersOptionsList.tsx
 msgid "Allow logins through Google's single sign-on functionality."
-msgstr "Permitir el inicio de sesión a través de la funcionalidad de inicio de sesión único de Google."
+msgstr ""
+"Permitir el inicio de sesión a través de la funcionalidad de inicio de "
+"sesión único de Google."
 
 #. js-lingui-id: dea+zy
 #: src/modules/settings/security/components/SettingsSecurityAuthProvidersOptionsList.tsx
 msgid "Allow logins through Microsoft's single sign-on functionality."
-msgstr "Permitir el inicio de sesión a través de la funcionalidad de inicio de sesión único de Microsoft."
+msgstr ""
+"Permitir el inicio de sesión a través de la funcionalidad de inicio de "
+"sesión único de Microsoft."
 
 #. js-lingui-id: pf6MGm
 #: src/modules/settings/security/components/SettingsSecurityAuthBypassOptionsList.tsx
 msgid "Allow Microsoft-based login for users with SSO bypass permissions."
-msgstr "Permitir inicio de sesión basado en Microsoft para usuarios con permisos para omitir SSO."
+msgstr ""
+"Permitir inicio de sesión basado en Microsoft para usuarios con permisos "
+"para omitir SSO."
 
 #. js-lingui-id: U6bnfj
 #: src/modules/settings/workspace/components/ToggleImpersonate.tsx
@@ -1846,7 +2016,9 @@ msgstr "Permitir acceso al equipo de soporte"
 #. js-lingui-id: wMg43c
 #: src/modules/settings/security/components/SettingsSecurityAuthProvidersOptionsList.tsx
 msgid "Allow the invitation of new users by sharing an invite link."
-msgstr "Permitir la invitación de nuevos usuarios compartiendo un enlace de invitación."
+msgstr ""
+"Permitir la invitación de nuevos usuarios compartiendo un enlace de "
+"invitación."
 
 #. js-lingui-id: JBjv4v
 #: src/modules/settings/roles/role-permissions/permission-flags/hooks/useActionRolePermissionFlagConfig.ts
@@ -1856,7 +2028,9 @@ msgstr "Permitir la carga de archivos y archivos adjuntos"
 #. js-lingui-id: vHeVg5
 #: src/modules/settings/security/components/SettingsSecurityAuthProvidersOptionsList.tsx
 msgid "Allow users to sign in with an email and password."
-msgstr "Permitir que los usuarios inicien sesión con un correo electrónico y una contraseña."
+msgstr ""
+"Permitir que los usuarios inicien sesión con un correo electrónico y una "
+"contraseña."
 
 #. js-lingui-id: vj+OHl
 #: src/pages/settings/applications/tabs/SettingsApplicationRegistrationOAuthTab.tsx
@@ -1952,13 +2126,21 @@ msgstr "Se produjo un error."
 
 #. js-lingui-id: 2xLtB4
 #: src/modules/metadata-error-handler/hooks/useMetadataErrorHandler.ts
-msgid "An internal error occurred while applying your changes. Please contact support and try again later."
-msgstr "Ocurrió un error interno al aplicar sus cambios. Por favor, contacte soporte e intente nuevamente más tarde."
+msgid ""
+"An internal error occurred while applying your changes. Please contact "
+"support and try again later."
+msgstr ""
+"Ocurrió un error interno al aplicar sus cambios. Por favor, contacte soporte"
+" e intente nuevamente más tarde."
 
 #. js-lingui-id: oRksj8
 #: src/modules/metadata-error-handler/hooks/useMetadataErrorHandler.ts
-msgid "An internal error occurred while validating your changes. Please contact support."
-msgstr "Ocurrió un error interno al validar sus cambios. Por favor, contacte soporte."
+msgid ""
+"An internal error occurred while validating your changes. Please contact "
+"support."
+msgstr ""
+"Ocurrió un error interno al validar sus cambios. Por favor, contacte "
+"soporte."
 
 #. js-lingui-id: U+NKyj
 #: src/modules/settings/data-model/objects/forms/components/SettingsDataModelObjectAboutForm.tsx
@@ -1996,7 +2178,7 @@ msgstr "Cualquier campo {fieldLabel}"
 #: src/modules/side-panel/pages/page-layout/hooks/useVisibilityLabels.ts
 #: src/modules/side-panel/pages/page-layout/hooks/useTranslatedVisibilityLabel.ts
 msgid "Any device"
-msgstr ""
+msgstr "Cualquier dispositivo"
 
 #. js-lingui-id: I8f+hC
 #: src/modules/views/components/AnyFieldSearchChip.tsx
@@ -2006,12 +2188,16 @@ msgstr "Cualquier campo"
 #. js-lingui-id: SI4CMD
 #: src/pages/settings/applications/components/SettingsApplicationConnectScopePickerModal.tsx
 msgid "Anyone in this workspace can use this credential."
-msgstr ""
+msgstr "Cualquiera en este espacio de trabajo puede usar esta credencial."
 
 #. js-lingui-id: xJR+Wq
 #: src/pages/settings/members/tabs/SettingsWorkspaceMembersInviteTab.tsx
-msgid "Anyone with an email address at these domains is allowed to sign up for this workspace."
-msgstr "Cualquiera con una dirección de correo electrónico en estos dominios puede registrarse en este espacio de trabajo."
+msgid ""
+"Anyone with an email address at these domains is allowed to sign up for this"
+" workspace."
+msgstr ""
+"Cualquiera con una dirección de correo electrónico en estos dominios puede "
+"registrarse en este espacio de trabajo."
 
 #. js-lingui-id: OZtEcz
 #: src/modules/settings/playground/components/PlaygroundSetupForm.tsx
@@ -2053,7 +2239,7 @@ msgstr "La clave de API es obligatoria"
 #. js-lingui-id: sb6i1L
 #: src/pages/settings/developers/api-keys/SettingsDevelopersApiKeyDetail.tsx
 msgid "API key name cannot be empty"
-msgstr ""
+msgstr "El nombre de la clave API no puede estar vacío"
 
 #. js-lingui-id: Widx6n
 #: src/modules/settings/roles/components/SettingsRolesList.tsx
@@ -2123,7 +2309,7 @@ msgstr "API y Webhooks"
 #. js-lingui-id: 0UMxlw
 #: src/modules/settings/experience/components/NumberFormatSelect.tsx
 msgid "Apostrophe and dot"
-msgstr ""
+msgstr "Apóstrofe y punto"
 
 #. js-lingui-id: LMUw1U
 #: src/pages/settings/data-model/SettingsObjectFieldTable.tsx
@@ -2137,7 +2323,7 @@ msgstr "Aplicación"
 #. js-lingui-id: qKnSyT
 #: src/pages/settings/admin-panel/SettingsAdminApplicationRegistrationDangerZone.tsx
 msgid "App deleted successfully"
-msgstr ""
+msgstr "Aplicación eliminada con éxito"
 
 #. js-lingui-id: aAIQg2
 #: src/pages/settings/profile/appearance/components/SettingsExperience.tsx
@@ -2165,7 +2351,7 @@ msgstr "Aplicación"
 #. js-lingui-id: N+cUnB
 #: src/modules/front-components/hooks/useFrontComponentExecutionContext.ts
 msgid "Application copied \"{preview}\" to your clipboard"
-msgstr ""
+msgstr "La aplicación copió \"{preview}\" a tu portapapeles"
 
 #. js-lingui-id: vdieHo
 #: src/pages/settings/applications/SettingsApplicationDetails.tsx
@@ -2180,17 +2366,20 @@ msgstr "Aplicación instalada con éxito."
 #. js-lingui-id: LllWIc
 #: src/pages/settings/security/event-logs/components/EventLogTableSelector.tsx
 msgid "Application Logs"
-msgstr ""
+msgstr "Registros de la aplicación"
 
 #. js-lingui-id: l/T809
 #: src/pages/settings/applications/components/SettingsApplicationDetailTitle.tsx
-msgid "Application not listed on the marketplace. It was shared via a direct link"
+msgid ""
+"Application not listed on the marketplace. It was shared via a direct link"
 msgstr ""
+"Aplicación no listada en el mercado. Fue compartida mediante un enlace "
+"directo"
 
 #. js-lingui-id: +tE2x9
 #: src/pages/settings/applications/SettingsApplicationDetails.tsx
 msgid "Application successfully uninstalled."
-msgstr ""
+msgstr "Aplicación desinstalada con éxito."
 
 #. js-lingui-id: V+GSWz
 #: src/modules/marketplace/hooks/useUpgradeApplication.ts
@@ -2200,7 +2389,7 @@ msgstr "Aplicación actualizada con éxito."
 #. js-lingui-id: Okob8q
 #: src/modules/metadata-error-handler/hooks/useMetadataErrorHandler.ts
 msgid "application variable"
-msgstr ""
+msgstr "variable de aplicación"
 
 #. js-lingui-id: fL7WXr
 #: src/pages/settings/logic-functions/SettingsLogicFunctionDetail.tsx
@@ -2220,7 +2409,7 @@ msgstr "Aplicaciones"
 #: src/pages/settings/applications/SettingsApplicationRegistrationDetails.tsx
 #: src/pages/settings/applications/components/SettingsApplicationRegistrationConfigVariableDetail.tsx
 msgid "Applications - Developer"
-msgstr ""
+msgstr "Aplicaciones - Desarrollador"
 
 #. js-lingui-id: DB8zMK
 #: src/modules/object-record/record-update-multiple/components/UpdateMultipleRecordsFooter.tsx
@@ -2252,12 +2441,12 @@ msgstr "Aplicaciones"
 #. js-lingui-id: dEnE1D
 #: src/pages/settings/applications/tabs/SettingsApplicationsDeveloperTab.tsx
 msgid "Apps made by other developers published on npm"
-msgstr ""
+msgstr "Aplicaciones creadas por otros desarrolladores publicadas en npm"
 
 #. js-lingui-id: EzsAEI
 #: src/pages/settings/applications/tabs/SettingsApplicationsDeveloperTab.tsx
 msgid "Apps you're the developer of"
-msgstr ""
+msgstr "Aplicaciones de las que eres desarrollador"
 
 #. js-lingui-id: 8HV3WN
 #: src/pages/settings/profile/appearance/components/LocalePicker.tsx
@@ -2267,82 +2456,115 @@ msgstr "Árabe"
 #. js-lingui-id: B495Gs
 #: src/modules/ai/components/AiChatThreadItemMenu.tsx
 msgid "Archive"
-msgstr ""
+msgstr "Archivar"
 
 #. js-lingui-id: i19Zro
 #: src/modules/activities/files/components/DocumentViewer.tsx
-msgid "Archive files cannot be previewed. Please download the file to access its contents."
-msgstr "Los archivos comprimidos no se pueden previsualizar. Descarga el archivo para acceder a su contenido."
+msgid ""
+"Archive files cannot be previewed. Please download the file to access its "
+"contents."
+msgstr ""
+"Los archivos comprimidos no se pueden previsualizar. Descarga el archivo "
+"para acceder a su contenido."
 
 #. js-lingui-id: TdfEV7
 #: src/modules/ai/constants/AgentChatThreadFilterStatusLabels.ts
 msgid "Archived"
-msgstr ""
+msgstr "Archivado"
 
 #. js-lingui-id: Yzbh3i
 #. placeholder {0}: emailingDomain.domain
 #: src/pages/settings/emailing-domains/SettingsEmailingDomainDetail.tsx
-msgid "Are you sure you want to delete {0}? Outbound mail through this domain will stop working."
+msgid ""
+"Are you sure you want to delete {0}? Outbound mail through this domain will "
+"stop working."
 msgstr ""
+"¿Estás seguro de que deseas eliminar {0}? El correo saliente a través de "
+"este dominio dejará de funcionar."
 
 #. js-lingui-id: Faev6R
 #: src/pages/settings/workspace/SettingsWorkspaceEmailGroupChannelDetail.tsx
-msgid "Are you sure you want to delete {sourceHandle}? Inbound mail forwarded to this address and outbound replies from it will stop working."
+msgid ""
+"Are you sure you want to delete {sourceHandle}? Inbound mail forwarded to "
+"this address and outbound replies from it will stop working."
 msgstr ""
+"¿Estás seguro de que deseas eliminar {sourceHandle}? El correo entrante "
+"reenviado a esta dirección y las respuestas salientes dejarán de funcionar."
 
 #. js-lingui-id: 4CHeVx
 #: src/pages/settings/ai/components/SettingsAgentEvalsTab.tsx
 msgid "Are you sure you want to delete this evaluation input?"
-msgstr ""
+msgstr "¿Estás seguro de que deseas eliminar esta entrada de evaluación?"
 
 #. js-lingui-id: RqYOrT
 #: src/modules/object-record/record-field-list/record-detail-section/relation/components/RecordDetailRelationRecordsListItem.tsx
-msgid "Are you sure you want to delete this related {relationObjectMetadataNameSingular}?<0/>This action will break all its relationships with other objects."
-msgstr "¿Estás seguro de que quieres eliminar este {relationObjectMetadataNameSingular} relacionado?<0/>Esta acción romperá todas sus relaciones con otros objetos."
+msgid ""
+"Are you sure you want to delete this related "
+"{relationObjectMetadataNameSingular}?<0/>This action will break all its "
+"relationships with other objects."
+msgstr ""
+"¿Estás seguro de que quieres eliminar este "
+"{relationObjectMetadataNameSingular} relacionado?<0/>Esta acción romperá "
+"todas sus relaciones con otros objetos."
 
 #. js-lingui-id: 4Li0Pw
 #: src/pages/settings/ai/SettingsSkillForm.tsx
-msgid "Are you sure you want to delete this skill? This action cannot be undone."
-msgstr "¿Está seguro de que desea eliminar esta habilidad? Esta acción no se puede deshacer."
+msgid ""
+"Are you sure you want to delete this skill? This action cannot be undone."
+msgstr ""
+"¿Está seguro de que desea eliminar esta habilidad? Esta acción no se puede "
+"deshacer."
 
 #. js-lingui-id: 0Cs5HS
 #: src/pages/settings/ai/SettingsToolDetail.tsx
-msgid "Are you sure you want to delete this tool? This action cannot be undone."
+msgid ""
+"Are you sure you want to delete this tool? This action cannot be undone."
 msgstr ""
+"¿Estás seguro de que deseas eliminar esta herramienta? Esta acción no se "
+"puede deshacer."
 
 #. js-lingui-id: EySr+c
 #. placeholder {0}: objectMetadataItem.labelPlural
 #: src/modules/command-menu-item/engine-command/record/components/DestroyRecordsCommand.tsx
-msgid "Are you sure you want to destroy these {0}? They won't be recoverable anymore."
+msgid ""
+"Are you sure you want to destroy these {0}? They won't be recoverable "
+"anymore."
 msgstr ""
+"¿Estás seguro de que deseas destruir estos {0}? Ya no serán recuperables."
 
 #. js-lingui-id: GfgNgF
 #. placeholder {0}: objectMetadataItem.labelSingular
 #: src/modules/command-menu-item/engine-command/record/components/DestroyRecordsCommand.tsx
-msgid "Are you sure you want to destroy this {0}? It cannot be recovered anymore."
+msgid ""
+"Are you sure you want to destroy this {0}? It cannot be recovered anymore."
 msgstr ""
+"¿Estás seguro de que deseas destruir este {0}? Ya no se puede recuperar."
 
 #. js-lingui-id: +UIjOX
 #: src/modules/settings/config-variables/components/ConfigVariableEdit.tsx
 msgid "Are you sure you want to reset this variable?"
-msgstr ""
+msgstr "¿Estás seguro de que deseas restablecer esta variable?"
 
 #. js-lingui-id: RzJL8J
 #. placeholder {0}: objectMetadataItem.labelPlural
 #: src/modules/command-menu-item/engine-command/record/components/RestoreRecordsCommand.tsx
 msgid "Are you sure you want to restore these {0}?"
-msgstr ""
+msgstr "¿Estás seguro de que deseas restaurar estos {0}?"
 
 #. js-lingui-id: XTKWxO
 #. placeholder {0}: objectMetadataItem.labelSingular
 #: src/modules/command-menu-item/engine-command/record/components/RestoreRecordsCommand.tsx
 msgid "Are you sure you want to restore this {0}?"
-msgstr ""
+msgstr "¿Estás seguro de que deseas restaurar este {0}?"
 
 #. js-lingui-id: 9JFf0y
 #: src/modules/settings/members/components/MemberPermissionsTab.tsx
-msgid "Are you sure you want to update the role of this user from \"{oldRoleLabel}\" to \"{newRoleLabel}\"?"
-msgstr "¿Está seguro de que desea actualizar el rol de este usuario de \"{oldRoleLabel}\" a \"{newRoleLabel}\"?"
+msgid ""
+"Are you sure you want to update the role of this user from "
+"\"{oldRoleLabel}\" to \"{newRoleLabel}\"?"
+msgstr ""
+"¿Está seguro de que desea actualizar el rol de este usuario de "
+"\"{oldRoleLabel}\" a \"{newRoleLabel}\"?"
 
 #. js-lingui-id: rnCqBK
 #: src/modules/spreadsheet-import/provider/components/SpreadsheetImport.tsx
@@ -2352,7 +2574,7 @@ msgstr "¿Estás seguro? Tu información actual no será guardada."
 #. js-lingui-id: cybVUo
 #: src/modules/settings/members/components/MemberInfosTab.tsx
 msgid "As it will be displayed in the workspace"
-msgstr ""
+msgstr "Como se mostrará en el espacio de trabajo"
 
 #. js-lingui-id: 54PdN4
 #: src/modules/side-panel/pages/page-layout/utils/getSortLabelSuffixForFieldType.ts
@@ -2392,7 +2614,7 @@ msgstr "¿Asignar a {roleTargetName}?"
 #. js-lingui-id: nerbkq
 #: src/modules/settings/roles/components/SettingsRolesList.tsx
 msgid "Assign roles to specify access permissions"
-msgstr ""
+msgstr "Asigna roles para especificar permisos de acceso"
 
 #. js-lingui-id: krsgB0
 #: src/modules/settings/roles/role-assignment/constants/RoleTargetConfig.ts
@@ -2422,7 +2644,7 @@ msgstr "Asignable a Claves API"
 #. js-lingui-id: OUbMUU
 #: src/modules/settings/roles/role-settings/components/SettingsRoleApplicability.tsx
 msgid "Assignable to Workspace Members"
-msgstr ""
+msgstr "Asignable a miembros del espacio de trabajo"
 
 #. js-lingui-id: 7qh2Hx
 #: src/modules/settings/roles/role-assignment/components/SettingsRoleAssignmentTable.tsx
@@ -2436,8 +2658,13 @@ msgstr "Asignado a"
 
 #. js-lingui-id: TzM/0+
 #: src/modules/settings/roles/components/SettingsRolesDefaultRole.tsx
-msgid "Assigned to users who join via invite link, approved domain, or SSO, and used as fallback when an assigned role is deleted"
-msgstr "Asignado a los usuarios que se unen mediante un enlace de invitación, un dominio aprobado o SSO, y se utiliza como respaldo cuando se elimina un rol asignado"
+msgid ""
+"Assigned to users who join via invite link, approved domain, or SSO, and "
+"used as fallback when an assigned role is deleted"
+msgstr ""
+"Asignado a los usuarios que se unen mediante un enlace de invitación, un "
+"dominio aprobado o SSO, y se utiliza como respaldo cuando se elimina un rol "
+"asignado"
 
 #. js-lingui-id: 0dtKl9
 #: src/modules/settings/roles/role/components/SettingsRole.tsx
@@ -2447,12 +2674,16 @@ msgstr "Asignación"
 #. js-lingui-id: d/bvvp
 #: src/pages/settings/ai/SettingsAgentTurnDetail.tsx
 msgid "Assistant"
-msgstr ""
+msgstr "Asistente"
 
 #. js-lingui-id: 4H6WHS
 #: src/modules/settings/admin-panel/health-status/components/SettingsAdminHealthStatus.tsx
-msgid "Asymmetric public keys used to sign and verify access tokens. Revoking a key immediately invalidates every JWT signed with it."
+msgid ""
+"Asymmetric public keys used to sign and verify access tokens. Revoking a key"
+" immediately invalidates every JWT signed with it."
 msgstr ""
+"Claves públicas asimétricas usadas para firmar y verificar tokens de acceso."
+" Revocar una clave invalida inmediatamente cada JWT firmado con ella."
 
 #. js-lingui-id: UHs3Ds
 #: src/modules/workflow/workflow-trigger/utils/cron-to-human/descriptors/getHoursDescription.ts
@@ -2538,13 +2769,21 @@ msgstr "Registros de auditoría"
 
 #. js-lingui-id: X0+U3u
 #: src/pages/settings/security/event-logs/SettingsEventLogs.tsx
-msgid "Audit logs are available with an Enterprise subscription. Please upgrade to access this feature."
-msgstr "Los registros de auditoría están disponibles con una suscripción Enterprise. Por favor, actualice para acceder a esta función."
+msgid ""
+"Audit logs are available with an Enterprise subscription. Please upgrade to "
+"access this feature."
+msgstr ""
+"Los registros de auditoría están disponibles con una suscripción Enterprise."
+" Por favor, actualice para acceder a esta función."
 
 #. js-lingui-id: rNQ4RB
 #: src/pages/settings/security/event-logs/SettingsEventLogs.tsx
-msgid "Audit logs require ClickHouse to be configured. Please contact your administrator to set up ClickHouse."
-msgstr "Los registros de auditoría requieren que ClickHouse esté configurado. Póngase en contacto con su administrador para configurar ClickHouse."
+msgid ""
+"Audit logs require ClickHouse to be configured. Please contact your "
+"administrator to set up ClickHouse."
+msgstr ""
+"Los registros de auditoría requieren que ClickHouse esté configurado. "
+"Póngase en contacto con su administrador para configurar ClickHouse."
 
 #. js-lingui-id: kIuOL4
 #: src/modules/workflow/workflow-trigger/components/WorkflowEditTriggerWebhookForm.tsx
@@ -2554,7 +2793,7 @@ msgstr "Autenticación"
 #. js-lingui-id: cNBqH+
 #: src/pages/settings/applications/SettingsApplicationConnectionDetail.tsx
 msgid "Auth failed at"
-msgstr ""
+msgstr "Autenticación fallida el"
 
 #. js-lingui-id: P8fBlG
 #: src/pages/settings/security/SettingsSecurity.tsx
@@ -2578,8 +2817,15 @@ msgstr "Aplicación de Autenticación"
 
 #. js-lingui-id: 9aB4Rs
 #: src/pages/settings/SettingsTwoFactorAuthenticationMethod.tsx
-msgid "Authenticator apps and browser extensions like 1Password, Authy, Microsoft Authenticator, etc. generate one-time passwords that are used as a second factor to verify your identity when prompted during sign-in."
-msgstr "Las aplicaciones de autenticación y las extensiones de navegador como 1Password, Authy, Microsoft Authenticator, etc., generan contraseñas de un solo uso que se utilizan como un segundo factor para verificar tu identidad cuando se te solicita durante el inicio de sesión."
+msgid ""
+"Authenticator apps and browser extensions like 1Password, Authy, Microsoft "
+"Authenticator, etc. generate one-time passwords that are used as a second "
+"factor to verify your identity when prompted during sign-in."
+msgstr ""
+"Las aplicaciones de autenticación y las extensiones de navegador como "
+"1Password, Authy, Microsoft Authenticator, etc., generan contraseñas de un "
+"solo uso que se utilizan como un segundo factor para verificar tu identidad "
+"cuando se te solicita durante el inicio de sesión."
 
 #. js-lingui-id: SIFUTh
 #: src/pages/auth/Authorize.tsx
@@ -2614,12 +2860,16 @@ msgstr "Creación automática"
 #. js-lingui-id: HX/jD4
 #: src/modules/workflow/workflow-steps/workflow-actions/ai-agent-action/hooks/useWorkflowAiAgentPermissionActions.ts
 msgid "Auto-generated role for {agentDisplayName}"
-msgstr ""
+msgstr "Rol generado automáticamente para {agentDisplayName}"
 
 #. js-lingui-id: YRT7ZW
 #: src/modules/settings/accounts/components/SettingsAccountsCalendarChannelDetails.tsx
-msgid "Automatically create contacts for people you've participated in an event with."
-msgstr "Crear automáticamente contactos para las personas con las que has participado en un evento."
+msgid ""
+"Automatically create contacts for people you've participated in an event "
+"with."
+msgstr ""
+"Crear automáticamente contactos para las personas con las que has "
+"participado en un evento."
 
 #. js-lingui-id: lgw3U4
 #: src/modules/settings/accounts/components/SettingsAccountsCalendarChannelDetails.tsx
@@ -2629,12 +2879,14 @@ msgstr "Crear automáticamente contactos para las personas."
 #. js-lingui-id: RpExX0
 #: src/modules/settings/accounts/components/SettingsAccountsMessageChannelDetails.tsx
 msgid "Automatically create People records when receiving or sending emails"
-msgstr "Crear automáticamente registros de personas al recibir o enviar correos electrónicos"
+msgstr ""
+"Crear automáticamente registros de personas al recibir o enviar correos "
+"electrónicos"
 
 #. js-lingui-id: BJgDIM
 #: src/pages/settings/applications/tabs/SettingsApplicationDetailContentTab.tsx
 msgid "Automation, AI, and access this app provides"
-msgstr ""
+msgstr "Automatización, IA y acceso que proporciona esta aplicación"
 
 #. js-lingui-id: lXkUEV
 #: src/pages/settings/applications/tabs/SettingsApplicationCommandMenuItemSettingsTab.tsx
@@ -2689,7 +2941,7 @@ msgstr "Volver al contenido"
 #. js-lingui-id: 9aZHfH
 #: src/modules/marketplace/components/SettingsApplicationInstallPermissionValidationModal.tsx
 msgid "Back to settings"
-msgstr ""
+msgstr "Volver a configuración"
 
 #. js-lingui-id: GtJbUa
 #: src/modules/error-handler/components/AppRootErrorFallback.tsx
@@ -2721,7 +2973,7 @@ msgstr "La URL base es obligatoria"
 #: src/modules/activities/emails/components/EmailComposerFields.tsx
 #: src/modules/activities/emails/components/EmailComposerFields.tsx
 msgid "Bcc"
-msgstr ""
+msgstr "Cco"
 
 #. js-lingui-id: PFohi3
 #: src/modules/workflow/workflow-steps/workflow-actions/components/WorkflowEditActionEmailBase.tsx
@@ -2730,8 +2982,15 @@ msgstr "CCO"
 
 #. js-lingui-id: IQUZ9h
 #: src/modules/workflow/workflow-steps/workflow-actions/form-action/components/WorkflowEditActionFormBuilder.tsx
-msgid "Because this workflow is not using a manual trigger, the form will not open on top of the interface. To fill it, open the corresponding workflow run and complete the form there."
-msgstr "Dado que este flujo de trabajo no utiliza un desencadenador manual, el formulario no se abrirá sobre la interfaz. Para completarlo, abre la ejecución del flujo de trabajo correspondiente y completa el formulario allí."
+msgid ""
+"Because this workflow is not using a manual trigger, the form will not open "
+"on top of the interface. To fill it, open the corresponding workflow run and"
+" complete the form there."
+msgstr ""
+"Dado que este flujo de trabajo no utiliza un desencadenador manual, el "
+"formulario no se abrirá sobre la interfaz. Para completarlo, abre la "
+"ejecución del flujo de trabajo correspondiente y completa el formulario "
+"allí."
 
 #. js-lingui-id: EmSrGB
 #: src/modules/object-record/record-calendar/month/hooks/useRecordCalendarQueryDateRangeFilter.tsx
@@ -2742,12 +3001,12 @@ msgstr "Antes"
 #: src/modules/settings/admin-panel/utils/getUpgradeHealthStatusBadge.ts
 #: src/modules/settings/admin-panel/health-status/components/SettingsAdminWorkspacesStatusSummaryCard.tsx
 msgid "Behind"
-msgstr ""
+msgstr "Retrasado"
 
 #. js-lingui-id: KYr9vA
 #: src/pages/settings/ai/components/SettingsAiModelsTab.tsx
 msgid "Best"
-msgstr ""
+msgstr "Mejor"
 
 #. js-lingui-id: NgFKo1
 #: src/modules/workflow/workflow-trigger/utils/cron-to-human/descriptors/getMonthsDescription.ts
@@ -2771,8 +3030,7 @@ msgstr "entre el {startOrdinal} y {endOrdinal} del mes"
 
 #. js-lingui-id: R+w/Va
 #: src/pages/settings/SettingsUsageUserDetail.tsx
-#: src/pages/settings/SettingsUsage.tsx
-#: src/pages/settings/SettingsBilling.tsx
+#: src/pages/settings/SettingsUsage.tsx src/pages/settings/SettingsBilling.tsx
 #: src/pages/settings/SettingsBilling.tsx
 #: src/pages/settings/admin-panel/SettingsAdminWorkspaceDetail.tsx
 #: src/modules/settings/roles/role-permissions/permission-flags/hooks/useSettingsRolePermissionFlagConfig.ts
@@ -2840,13 +3098,13 @@ msgstr "Ambos"
 #. js-lingui-id: b8ZbRG
 #: src/modules/settings/domains/components/SettingPublicDomain.tsx
 msgid "Bound App"
-msgstr ""
+msgstr "Aplicación vinculada"
 
 #. js-lingui-id: 1hGdwj
 #: src/pages/settings/ai/SettingsAiUsageUserDetail.tsx
 #: src/pages/settings/ai/components/SettingsAiUsageTab.tsx
 msgid "Breakdown across AI models."
-msgstr ""
+msgstr "Desglose por modelos de IA."
 
 #. js-lingui-id: qDsMss
 #: src/modules/workflow/workflow-steps/workflow-actions/ai-agent-action/components/WorkflowOutputSchemaBuilder.tsx
@@ -2866,22 +3124,29 @@ msgstr "Marrón"
 #. js-lingui-id: GsXRxc
 #: src/modules/settings/data-model/indexes/forms/components/SettingsObjectIndexOptionsForm.tsx
 msgid "BTREE (default, good for sorting and equality)"
-msgstr ""
+msgstr "BTREE (predeterminado, bueno para ordenación e igualdad)"
 
 #. js-lingui-id: vwZV+4
 #: src/modules/ai/components/suggested-prompts/default-suggested-prompts.ts
-msgid "Build a dashboard that shows: (1) total pipeline value by stage for the last 3 months, (2) count of deals won vs lost per month, (3) average deal size. Use our standard pipeline stages."
-msgstr "Crea un panel de control que muestre: (1) el valor total del pipeline por etapa durante los últimos 3 meses, (2) el número de oportunidades ganadas frente a perdidas por mes, (3) el importe medio de la oportunidad. Usa nuestras etapas estándar del pipeline."
+msgid ""
+"Build a dashboard that shows: (1) total pipeline value by stage for the last"
+" 3 months, (2) count of deals won vs lost per month, (3) average deal size. "
+"Use our standard pipeline stages."
+msgstr ""
+"Crea un panel de control que muestre: (1) el valor total del pipeline por "
+"etapa durante los últimos 3 meses, (2) el número de oportunidades ganadas "
+"frente a perdidas por mes, (3) el importe medio de la oportunidad. Usa "
+"nuestras etapas estándar del pipeline."
 
 #. js-lingui-id: pN5hZf
 #: src/pages/settings/applications/tabs/SettingsApplicationFrontComponentSettingsTab.tsx
 msgid "Build and runtime metadata for this component"
-msgstr ""
+msgstr "Metadatos de compilación y ejecución para este componente"
 
 #. js-lingui-id: f2qxNx
 #: src/pages/settings/applications/tabs/SettingsApplicationFrontComponentSettingsTab.tsx
 msgid "Build checksum"
-msgstr ""
+msgstr "Suma de verificación de compilación"
 
 #. js-lingui-id: alSW5d
 #: src/modules/settings/data-model/fields/forms/morph-relation/components/SettingsDataModelFieldRelationJunctionForm.tsx
@@ -2891,12 +3156,16 @@ msgstr "Crear relaciones de muchos a muchos"
 #. js-lingui-id: uvoIrk
 #: src/pages/settings/admin-panel/SettingsAdminAiProviderDetail.tsx
 msgid "Built-in models from this provider. Toggle to enable or disable."
-msgstr "Modelos integrados de este proveedor. Usa el interruptor para habilitarlos o deshabilitarlos."
+msgstr ""
+"Modelos integrados de este proveedor. Usa el interruptor para habilitarlos o"
+" deshabilitarlos."
 
 #. js-lingui-id: 30JOri
 #: src/modules/settings/admin-panel/ai/components/SettingsAdminAI.tsx
 msgid "Built-in providers activated by API key. Click to manage models."
-msgstr "Proveedores integrados activados mediante clave de API. Haz clic para gestionar los modelos."
+msgstr ""
+"Proveedores integrados activados mediante clave de API. Haz clic para "
+"gestionar los modelos."
 
 #. js-lingui-id: 1QEPf7
 #: src/modules/settings/data-model/fields/forms/select/components/SettingsDataModelFieldSelectForm.tsx
@@ -2916,7 +3185,7 @@ msgstr "Lista con Viñetas"
 #. js-lingui-id: 9emr42
 #: src/modules/settings/logic-functions/components/tabs/SettingsLogicFunctionTriggersTab.tsx
 msgid "Bundled with {applicationName}"
-msgstr ""
+msgstr "Incluido con {applicationName}"
 
 #. js-lingui-id: 8ds4Hj
 #: src/pages/settings/applications/components/SettingsAvailableApplicationCard.tsx
@@ -3013,7 +3282,9 @@ msgstr "Sincronización del calendario"
 #. js-lingui-id: CpnBmA
 #: src/modules/settings/admin-panel/health-status/components/SettingsAdminConnectedAccountHealthStatus.tsx
 msgid "Calendar Sync is not available because the service is down"
-msgstr "La sincronización del calendario no está disponible porque el servicio está inactivo"
+msgstr ""
+"La sincronización del calendario no está disponible porque el servicio está "
+"inactivo"
 
 #. js-lingui-id: alkXJ5
 #: src/modules/object-record/object-options-dropdown/components/ObjectOptionsDropdownLayoutContent.tsx
@@ -3070,12 +3341,12 @@ msgstr "Cancelar"
 #. js-lingui-id: J8nuSF
 #: src/modules/settings/billing/components/SettingsBillingSubscriptionInfo.tsx
 msgid "Cancel credit pack switching"
-msgstr ""
+msgstr "Cancelar cambio de paquete de créditos"
 
 #. js-lingui-id: ztnpYZ
 #: src/modules/settings/billing/components/SettingsBillingSubscriptionInfo.tsx
 msgid "Cancel credit pack switching?"
-msgstr ""
+msgstr "¿Cancelar cambio de paquete de créditos?"
 
 #. js-lingui-id: dV4HC5
 #: src/modules/settings/billing/components/SettingsBillingSubscriptionInfo.tsx
@@ -3106,7 +3377,7 @@ msgstr "¿Cancelar cambio de plan?"
 #. js-lingui-id: AnRu/j
 #: src/modules/page-layout/widgets/email-thread/components/EmailThreadComposer.tsx
 msgid "Cancel reply"
-msgstr ""
+msgstr "Cancelar respuesta"
 
 #. js-lingui-id: N6gPiD
 #: src/pages/settings/enterprise/SettingsEnterprise.tsx
@@ -3122,7 +3393,7 @@ msgstr "Cancelado"
 #. js-lingui-id: dC0BTo
 #: src/modules/settings/admin-panel/components/SettingsAdminWorkspaceBillingContent.tsx
 msgid "Canceled at"
-msgstr ""
+msgstr "Cancelado el"
 
 #. js-lingui-id: y4uH7j
 #: src/pages/settings/enterprise/SettingsEnterprise.tsx
@@ -3132,12 +3403,12 @@ msgstr "Cancelando"
 #. js-lingui-id: zbbpgB
 #: src/modules/settings/admin-panel/components/SettingsAdminWorkspaceBillingContent.tsx
 msgid "Cancels at"
-msgstr ""
+msgstr "Se cancela el"
 
 #. js-lingui-id: 2CAby/
 #: src/modules/settings/admin-panel/components/SettingsAdminWorkspaceBillingContent.tsx
 msgid "Cancels at period end"
-msgstr ""
+msgstr "Se cancela al final del período"
 
 #. js-lingui-id: WbPx+C
 #: src/pages/settings/enterprise/SettingsEnterprise.tsx
@@ -3179,7 +3450,7 @@ msgstr "El Captcha (verificación anti-bot) sigue cargando, inténtelo de nuevo"
 #: src/modules/side-panel/pages/page-layout/components/record-page/SidePanelRecordPageFieldSettings.tsx
 #: src/modules/side-panel/pages/page-layout/components/dropdown-content/FieldWidgetLayoutDropdownContent.tsx
 msgid "Card"
-msgstr ""
+msgstr "Tarjeta"
 
 #. js-lingui-id: M1RLfx
 #: src/pages/settings/profile/appearance/components/LocalePicker.tsx
@@ -3195,7 +3466,7 @@ msgstr "Categoría"
 #: src/modules/activities/emails/components/EmailComposerFields.tsx
 #: src/modules/activities/emails/components/EmailComposerFields.tsx
 msgid "Cc"
-msgstr ""
+msgstr "Cc"
 
 #. js-lingui-id: XdZeJk
 #: src/modules/workflow/workflow-steps/workflow-actions/components/WorkflowEditActionEmailBase.tsx
@@ -3205,7 +3476,7 @@ msgstr "CC"
 #. js-lingui-id: Dgsw8A
 #: src/modules/activities/emails/components/EmailComposerFields.tsx
 msgid "Cc/Bcc"
-msgstr ""
+msgstr "Cc/Cco"
 
 #. js-lingui-id: tHntRt
 #: src/modules/page-layout/widgets/standalone-rich-text/components/DashboardEditorSideMenu.tsx
@@ -3226,7 +3497,7 @@ msgstr "Cambiar tipo de nodo"
 #. js-lingui-id: GptGxg
 #: src/modules/settings/accounts/components/SettingsAccountsPasswordController.tsx
 msgid "Change password"
-msgstr ""
+msgstr "Cambiar contraseña"
 
 #. js-lingui-id: VhMDMg
 #: src/pages/auth/PasswordReset.tsx
@@ -3262,12 +3533,16 @@ msgstr "Cambiar a anual?"
 #. js-lingui-id: LhVon3
 #: src/pages/settings/applications/SettingsApplicationConnectionDetail.tsx
 msgid "Change visibility?"
-msgstr ""
+msgstr "¿Cambiar visibilidad?"
 
 #. js-lingui-id: rnTfap
 #: src/pages/settings/applications/SettingsApplicationConnectionDetail.tsx
-msgid "Changing visibility requires reconnecting this OAuth connection. You will be redirected to authorize it again."
+msgid ""
+"Changing visibility requires reconnecting this OAuth connection. You will be"
+" redirected to authorize it again."
 msgstr ""
+"Cambiar la visibilidad requiere reconectar esta conexión OAuth. Se te "
+"redirigirá para autorizarla nuevamente."
 
 #. js-lingui-id: nuBbBr
 #: src/modules/side-panel/pages/page-layout/components/SidePanelPageLayoutDashboardWidgetTypeSelect.tsx
@@ -3283,22 +3558,22 @@ msgstr "Chat"
 #. js-lingui-id: rlwve5
 #: src/modules/ai/components/AiChatThreadItemMenu.tsx
 msgid "Chat actions"
-msgstr ""
+msgstr "Acciones del chat"
 
 #. js-lingui-id: eKz2ln
 #: src/pages/settings/admin-panel/SettingsAdminWorkspaceChatThread.tsx
 msgid "Chat conversation"
-msgstr ""
+msgstr "Conversación del chat"
 
 #. js-lingui-id: tDlhkF
 #: src/modules/ai/components/NavigationDrawerAiChatThreadItem.tsx
 msgid "Chat name"
-msgstr ""
+msgstr "Nombre del chat"
 
 #. js-lingui-id: jTS+KY
 #: src/pages/settings/admin-panel/SettingsAdminWorkspaceDetail.tsx
 msgid "Chat Sessions"
-msgstr ""
+msgstr "Sesiones de chat"
 
 #. js-lingui-id: UxeiNP
 #: src/modules/settings/roles/role-permissions/permission-flags/hooks/useActionRolePermissionFlagConfig.ts
@@ -3308,7 +3583,7 @@ msgstr "Chatear con agentes de IA y usar funciones de IA"
 #. js-lingui-id: 8Q+lLG
 #: src/pages/settings/admin-panel/SettingsAdminWorkspaceDetail.tsx
 msgid "Chats"
-msgstr ""
+msgstr "Chats"
 
 #. js-lingui-id: xK2nU3
 #: src/pages/settings/updates/SettingsUpdates.tsx
@@ -3328,12 +3603,16 @@ msgstr "Revisar tus correos electrónicos"
 #. js-lingui-id: hXXBiE
 #: src/modules/settings/profile/hooks/useUpdateEmail.ts
 msgid "Check your inbox to verify your new email address."
-msgstr "Revisa tu bandeja de entrada para verificar tu nueva dirección de correo electrónico."
+msgstr ""
+"Revisa tu bandeja de entrada para verificar tu nueva dirección de correo "
+"electrónico."
 
 #. js-lingui-id: SxwQE8
 #: src/modules/settings/billing/hooks/useHandleCheckoutSession.ts
 msgid "Checkout session error. Please retry or contact Twenty team"
-msgstr "Error en la sesión de pago. Por favor, reintente o contacte al equipo de Twenty"
+msgstr ""
+"Error en la sesión de pago. Por favor, reintente o contacte al equipo de "
+"Twenty"
 
 #. js-lingui-id: SviKkE
 #: src/pages/settings/profile/appearance/components/LocalePicker.tsx
@@ -3392,8 +3671,12 @@ msgstr "Elige qué sucede al hacer clic en una dirección de correo electrónico
 
 #. js-lingui-id: 02EFne
 #: src/pages/settings/security/SettingsSecurity.tsx
-msgid "Choose which profile fields users with the Edit Profile permission can modify"
-msgstr "Elegir qué campos de perfil pueden modificar los usuarios con el permiso Editar Perfil"
+msgid ""
+"Choose which profile fields users with the Edit Profile permission can "
+"modify"
+msgstr ""
+"Elegir qué campos de perfil pueden modificar los usuarios con el permiso "
+"Editar Perfil"
 
 #. js-lingui-id: 9qP96p
 #: src/pages/onboarding/internal/ChooseYourPlanContent.tsx
@@ -3418,7 +3701,7 @@ msgstr "Limpiar"
 #. js-lingui-id: u8JHrO
 #: src/modules/ai/components/AiChatThreadFilterDropdownRootMenu.tsx
 msgid "Clear filters"
-msgstr ""
+msgstr "Limpiar filtros"
 
 #. js-lingui-id: wu0RfR
 #: src/modules/settings/admin-panel/config-variables/components/ConfigVariableHelpText.tsx
@@ -3433,13 +3716,30 @@ msgstr "Haz clic en un usuario para ver su desglose diario."
 
 #. js-lingui-id: HevGC0
 #: src/modules/workflow/workflow-steps/workflow-actions/form-action/components/WorkflowEditActionFormBuilder.tsx
-msgid "Click on \"Add Field\" below to add the first input to your form. The form will pop up on the user's screen when the workflow is launched from a manual trigger. For other types of triggers, it will be displayed in the Workflow run record page."
-msgstr "Haz clic en \"Agregar Campo\" a continuación para añadir la primera entrada a tu formulario. El formulario aparecerá en la pantalla del usuario cuando el workflow se inicie desde un activador manual. Para otros tipos de activadores, se mostrará en la página de registro de ejecución del Workflow."
+msgid ""
+"Click on \"Add Field\" below to add the first input to your form. The form "
+"will pop up on the user's screen when the workflow is launched from a manual"
+" trigger. For other types of triggers, it will be displayed in the Workflow "
+"run record page."
+msgstr ""
+"Haz clic en \"Agregar Campo\" a continuación para añadir la primera entrada "
+"a tu formulario. El formulario aparecerá en la pantalla del usuario cuando "
+"el workflow se inicie desde un activador manual. Para otros tipos de "
+"activadores, se mostrará en la página de registro de ejecución del Workflow."
 
 #. js-lingui-id: RFmRvm
 #: src/modules/workflow/workflow-steps/workflow-actions/ai-agent-action/components/WorkflowOutputSchemaBuilder.tsx
-msgid "Click on \"Add Output Field\" below to define the structure of your AI agent's response. These fields will be used to format and validate the AI's output when the workflow is executed, and can be referenced by subsequent workflow steps."
-msgstr "Haga clic en \"Añadir campo de salida\" a continuación para definir la estructura de la respuesta de su agente de IA. Estos campos se usarán para formatear y validar la salida de la IA cuando se ejecute el flujo de trabajo, y pueden ser referenciados por los pasos subsiguientes del flujo de trabajo."
+msgid ""
+"Click on \"Add Output Field\" below to define the structure of your AI "
+"agent's response. These fields will be used to format and validate the AI's "
+"output when the workflow is executed, and can be referenced by subsequent "
+"workflow steps."
+msgstr ""
+"Haga clic en \"Añadir campo de salida\" a continuación para definir la "
+"estructura de la respuesta de su agente de IA. Estos campos se usarán para "
+"formatear y validar la salida de la IA cuando se ejecute el flujo de "
+"trabajo, y pueden ser referenciados por los pasos subsiguientes del flujo de"
+" trabajo."
 
 #. js-lingui-id: b8wwse
 #: src/modules/settings/admin-panel/config-variables/components/ConfigVariableHelpText.tsx
@@ -3464,7 +3764,9 @@ msgstr "Haz clic para seleccionar el icono {iconAriaLabel}"
 #. js-lingui-id: ZwIUeU
 #: src/pages/settings/security/SettingsSecurity.tsx
 msgid "ClickHouse is required for audit logs. Contact your administrator."
-msgstr "Se requiere ClickHouse para los registros de auditoría. Póngase en contacto con su administrador."
+msgstr ""
+"Se requiere ClickHouse para los registros de auditoría. Póngase en contacto "
+"con su administrador."
 
 #. js-lingui-id: CTdw8/
 #: src/pages/settings/security/event-logs/SettingsEventLogs.tsx
@@ -3488,7 +3790,8 @@ msgstr "Secreto del cliente"
 #. js-lingui-id: 6uKe4W
 #: src/pages/settings/applications/tabs/SettingsApplicationRegistrationOAuthTab.tsx
 msgid "Client secret rotated. Copy it now — it won't be shown again."
-msgstr "Se rotó el secreto del cliente. Cópialo ahora — no se volverá a mostrar."
+msgstr ""
+"Se rotó el secreto del cliente. Cópialo ahora — no se volverá a mostrar."
 
 #. js-lingui-id: XUe4cu
 #: src/modules/settings/security/components/SSO/SettingsSSOOIDCForm.tsx
@@ -3497,8 +3800,12 @@ msgstr "Configuración de Cliente"
 
 #. js-lingui-id: mekEJ5
 #: src/hooks/useCopyToClipboard.tsx
-msgid "Clipboard requires a secure connection (HTTPS). Please access this app over HTTPS to enable copying."
-msgstr "El portapapeles requiere una conexión segura (HTTPS). Accede a esta aplicación mediante HTTPS para habilitar la copia."
+msgid ""
+"Clipboard requires a secure connection (HTTPS). Please access this app over "
+"HTTPS to enable copying."
+msgstr ""
+"El portapapeles requiere una conexión segura (HTTPS). Accede a esta "
+"aplicación mediante HTTPS para habilitar la copia."
 
 #. js-lingui-id: yz7wBu
 #: src/modules/ui/feedback/snack-bar-manager/components/SnackBar.tsx
@@ -3514,7 +3821,7 @@ msgstr "Cerrar banner"
 #. js-lingui-id: vcpc5o
 #: src/modules/blocknote-editor/components/BlockEditor.tsx
 msgid "Close menu"
-msgstr ""
+msgstr "Cerrar menú"
 
 #. js-lingui-id: saip/v
 #: src/modules/side-panel/components/SidePanelToggleButton.tsx
@@ -3580,8 +3887,12 @@ msgstr "Colores"
 
 #. js-lingui-id: P8gRog
 #: src/modules/spreadsheet-import/utils/setColumn.ts
-msgid "column data is not compatible with Multi-Select. Format required is '[\"option1\", \"option2\"]' or option1,option2."
-msgstr "los datos de la columna no son compatibles con Selección Múltiple. El formato requerido es '[\"opción1\", \"opción2\"]' o opción1,opción2."
+msgid ""
+"column data is not compatible with Multi-Select. Format required is "
+"'[\"option1\", \"option2\"]' or option1,option2."
+msgstr ""
+"los datos de la columna no son compatibles con Selección Múltiple. El "
+"formato requerido es '[\"opción1\", \"opción2\"]' o opción1,opción2."
 
 #. js-lingui-id: 93hd3e
 #: src/modules/spreadsheet-import/steps/components/MatchColumnsStep/MatchColumnsStep.tsx
@@ -3591,12 +3902,12 @@ msgstr "Columnas no coinciden:"
 #. js-lingui-id: efhuJR
 #: src/pages/settings/layout/SettingsLayoutViewDetail.tsx
 msgid "Columns shown in this view, in display order"
-msgstr ""
+msgstr "Columnas mostradas en esta vista, en orden de visualización"
 
 #. js-lingui-id: pOJNDA
 #: src/pages/settings/applications/SettingsAvailableApplicationDetails.tsx
 msgid "command"
-msgstr ""
+msgstr "comando"
 
 #. js-lingui-id: cj9UFG
 #: src/pages/settings/applications/tabs/SettingsApplicationRegistrationDistributionTab.tsx
@@ -3622,18 +3933,18 @@ msgstr "elemento del menú de comandos"
 #: src/pages/settings/applications/SettingsApplicationCommandMenuItemDetail.tsx
 #: src/pages/settings/applications/tabs/SettingsApplicationCommandMenuItemSettingsTab.tsx
 msgid "Command menu item"
-msgstr ""
+msgstr "Elemento del menú de comandos"
 
 #. js-lingui-id: yVBJNs
 #: src/pages/settings/applications/SettingsApplicationCommandMenuItemDetail.tsx
 #: src/pages/settings/applications/tabs/SettingsApplicationDetailContentTab.tsx
 msgid "Command menu items"
-msgstr ""
+msgstr "Elementos del menú de comandos"
 
 #. js-lingui-id: 9HKBNN
 #: src/pages/settings/applications/SettingsAvailableApplicationDetails.tsx
 msgid "commands"
-msgstr ""
+msgstr "comandos"
 
 #. js-lingui-id: 4XlFx/
 #: src/pages/settings/applications/tabs/SettingsApplicationsDeveloperTab.tsx
@@ -3643,12 +3954,12 @@ msgstr "Comandos copiados al portapapeles"
 #. js-lingui-id: QeCopv
 #: src/modules/settings/experience/components/NumberFormatSelect.tsx
 msgid "Commas and dot"
-msgstr ""
+msgstr "Comas y punto"
 
 #. js-lingui-id: NBdIgR
 #: src/pages/settings/ai/SettingsAgentTurnDetail.tsx
 msgid "Comment"
-msgstr ""
+msgstr "Comentario"
 
 #. js-lingui-id: NM9bMd
 #: src/modules/object-record/object-options-dropdown/components/ObjectOptionsDropdownLayoutContent.tsx
@@ -3681,23 +3992,27 @@ msgstr "Completado"
 
 #. js-lingui-id: 6y7/Rf
 #: src/pages/settings/admin-panel/SettingsAdminQueueDetail.tsx
-msgid "Completed jobs kept for {completedDuration}, failed jobs kept for {failedDuration} (max {maxCount} each)"
-msgstr "Trabajos completados guardados por {completedDuration}, trabajos fallidos guardados por {failedDuration} (máximo {maxCount} cada uno)"
+msgid ""
+"Completed jobs kept for {completedDuration}, failed jobs kept for "
+"{failedDuration} (max {maxCount} each)"
+msgstr ""
+"Trabajos completados guardados por {completedDuration}, trabajos fallidos "
+"guardados por {failedDuration} (máximo {maxCount} cada uno)"
 
 #. js-lingui-id: 3pJ7V5
 #: src/pages/settings/applications/tabs/SettingsApplicationFrontComponentSettingsTab.tsx
 msgid "Component name"
-msgstr ""
+msgstr "Nombre del componente"
 
 #. js-lingui-id: BglnOD
 #: src/modules/settings/admin-panel/health-status/components/SettingsAdminWorkspacesStatusSummaryCard.tsx
 msgid "Computed at"
-msgstr ""
+msgstr "Calculado el"
 
 #. js-lingui-id: PLbVix
 #: src/pages/settings/applications/tabs/SettingsApplicationCommandMenuItemSettingsTab.tsx
 msgid "Conditional availability"
-msgstr ""
+msgstr "Disponibilidad condicional"
 
 #. js-lingui-id: 0CuAor
 #: src/modules/workflow/workflow-steps/workflow-actions/if-else-action/components/WorkflowEditActionIfElseBody.tsx
@@ -3711,6 +4026,7 @@ msgstr "Condiciones"
 #: src/pages/settings/layout/SettingsLayoutViewDetail.tsx
 msgid "Conditions applied to records before they appear in this view"
 msgstr ""
+"Condiciones aplicadas a los registros antes de que aparezcan en esta vista"
 
 #. js-lingui-id: 14PdY0
 #: src/pages/settings/applications/SettingsApplicationRegistrationDetails.tsx
@@ -3733,7 +4049,7 @@ msgstr "Configuración"
 #. js-lingui-id: ais8E1
 #: src/pages/settings/applications/tabs/SettingsApplicationCommandMenuItemSettingsTab.tsx
 msgid "Configuration of this command menu item"
-msgstr ""
+msgstr "Configuración de este elemento del menú de comandos"
 
 #. js-lingui-id: iAL9tI
 #: src/pages/settings/applications/tabs/SettingsApplicationRegistrationGeneralTab.tsx
@@ -3754,22 +4070,26 @@ msgstr "Configura y personaliza tus preferencias de calendario."
 #. js-lingui-id: 6MDr1S
 #: src/modules/settings/accounts/components/SettingsAccountsConnectionForm.tsx
 msgid "Configure CalDAV settings to sync your calendar events."
-msgstr "Configura los ajustes de CalDAV para sincronizar tus eventos de calendario."
+msgstr ""
+"Configura los ajustes de CalDAV para sincronizar tus eventos de calendario."
 
 #. js-lingui-id: ahqAfe
 #: src/pages/settings/profile/appearance/components/SettingsExperience.tsx
 msgid "Configure date, time, number, timezone, and calendar start day"
-msgstr "Configurar fecha, hora, número, zona horaria y día de inicio del calendario"
+msgstr ""
+"Configurar fecha, hora, número, zona horaria y día de inicio del calendario"
 
 #. js-lingui-id: utsXG8
 #: src/pages/settings/security/SettingsSecurity.tsx
 msgid "Configure fallback login methods for users with SSO bypass permissions"
-msgstr "Configurar métodos de inicio de sesión de respaldo para usuarios con permisos para omitir SSO"
+msgstr ""
+"Configurar métodos de inicio de sesión de respaldo para usuarios con "
+"permisos para omitir SSO"
 
 #. js-lingui-id: OLqG0t
 #: src/modules/settings/data-model/object-details/components/tabs/ObjectSettings.tsx
 msgid "Configure how this object appears in search results"
-msgstr ""
+msgstr "Configura cómo aparece este objeto en los resultados de búsqueda"
 
 #. js-lingui-id: ghdb7+
 #: src/modules/settings/accounts/components/SettingsAccountsCalendarChannelsGeneral.tsx
@@ -3779,7 +4099,9 @@ msgstr "Configurar cómo debemos mostrar tus eventos en tu calendario"
 #. js-lingui-id: jbuOOX
 #: src/modules/settings/accounts/components/SettingsAccountsConnectionForm.tsx
 msgid "Configure IMAP settings to receive and sync your emails."
-msgstr "Configura los ajustes de IMAP para recibir y sincronizar tus correos electrónicos."
+msgstr ""
+"Configura los ajustes de IMAP para recibir y sincronizar tus correos "
+"electrónicos."
 
 #. js-lingui-id: gk/8eh
 #: src/modules/settings/accounts/components/SettingsAccountsConnectionForm.tsx
@@ -3789,7 +4111,9 @@ msgstr "Configura los ajustes SMTP para enviar correos desde tu cuenta."
 #. js-lingui-id: TiCmQz
 #: src/modules/settings/admin-panel/ai/components/SettingsAdminAI.tsx
 msgid "Configure the default AI models for all workspaces"
-msgstr "Configura los modelos de IA predeterminados para todos los espacios de trabajo"
+msgstr ""
+"Configura los modelos de IA predeterminados para todos los espacios de "
+"trabajo"
 
 #. js-lingui-id: qA9AGQ
 #: src/modules/settings/domains/components/SettingsDomainRecords.tsx
@@ -3804,7 +4128,7 @@ msgstr "Configura este widget para visualizar campos"
 #. js-lingui-id: hzDiM0
 #: src/pages/settings/ai/components/SettingsAiModelsTab.tsx
 msgid "Configure your default AI model"
-msgstr ""
+msgstr "Configura tu modelo de IA predeterminado"
 
 #. js-lingui-id: Bh4GBD
 #: src/modules/settings/accounts/components/SettingsAccountsSettingsSection.tsx
@@ -3837,17 +4161,22 @@ msgstr "Confirmar"
 #. js-lingui-id: q2rgqr
 #: src/modules/settings/billing/components/internal/ResourceCreditPriceSelector.tsx
 msgid "Confirm changing your current resource credit allocation."
-msgstr ""
+msgstr "Confirma el cambio de tu asignación actual de créditos de recursos."
 
 #. js-lingui-id: SU6Tym
 #: src/modules/settings/roles/role-settings/components/SettingsRoleSettingsDeleteRoleConfirmationModalSubtitle.tsx
 msgid "Confirm deletion of {roleName} role? This cannot be undone."
 msgstr ""
+"¿Confirmar eliminación del rol {roleName}? Esta acción no se puede deshacer."
 
 #. js-lingui-id: W7S+Tm
 #: src/modules/settings/roles/role-settings/components/SettingsRoleSettingsDeleteRoleConfirmationModalSubtitle.tsx
-msgid "Confirm deletion of {roleName} role? This cannot be undone. {reassignSubject} will be reassigned to the default role."
+msgid ""
+"Confirm deletion of {roleName} role? This cannot be undone. "
+"{reassignSubject} will be reassigned to the default role."
 msgstr ""
+"¿Confirmar eliminación del rol {roleName}? Esta acción no se puede deshacer."
+" {reassignSubject} será reasignado al rol predeterminado."
 
 #. js-lingui-id: kZkFSm
 #: src/modules/settings/billing/components/internal/ResourceCreditPriceSelector.tsx
@@ -3867,12 +4196,12 @@ msgstr "Confirmar actualización"
 #. js-lingui-id: LOM1MR
 #: src/pages/auth/Authorize.tsx
 msgid "Connect {appName} to your account"
-msgstr ""
+msgstr "Conecta {appName} a tu cuenta"
 
 #. js-lingui-id: mFiwDA
 #: src/pages/settings/applications/components/SettingsApplicationConnectScopePickerModal.tsx
 msgid "Connect {providerDisplayName}"
-msgstr ""
+msgstr "Conectar {providerDisplayName}"
 
 #. js-lingui-id: D8ATlr
 #: src/modules/settings/accounts/components/SettingsNewAccountSection.tsx
@@ -3882,7 +4211,7 @@ msgstr "Conectar una nueva cuenta a su espacio de trabajo"
 #. js-lingui-id: YLx3sC
 #: src/modules/settings/accounts/components/SettingsAccountsListEmptyStateCard.tsx
 msgid "Connect via IMAP/SMTP"
-msgstr ""
+msgstr "Conectar vía IMAP/SMTP"
 
 #. js-lingui-id: Zgi9Fd
 #: src/modules/settings/accounts/components/SettingsAccountsListEmptyStateCard.tsx
@@ -3898,7 +4227,7 @@ msgstr "Conectar con Microsoft"
 #: src/pages/settings/applications/SettingsApplicationConnectionDetail.tsx
 #: src/pages/settings/applications/tabs/SettingsApplicationConnectionsSection.tsx
 msgid "Connected"
-msgstr ""
+msgstr "Conectado"
 
 #. js-lingui-id: 9TzudL
 #: src/pages/settings/accounts/SettingsAccounts.tsx
@@ -3910,22 +4239,22 @@ msgstr "Cuentas conectadas"
 #: src/pages/settings/applications/SettingsApplicationConnectionDetail.tsx
 #: src/pages/settings/applications/tabs/SettingsApplicationConnectionsSection.tsx
 msgid "Connection"
-msgstr ""
+msgstr "Conexión"
 
 #. js-lingui-id: XYeKcu
 #: src/pages/settings/applications/SettingsApplicationConnectionDetail.tsx
 msgid "Connection not found"
-msgstr ""
+msgstr "Conexión no encontrada"
 
 #. js-lingui-id: 54WNJ6
 #: src/modules/metadata-error-handler/hooks/useMetadataErrorHandler.ts
 msgid "connection provider"
-msgstr ""
+msgstr "proveedor de conexión"
 
 #. js-lingui-id: sbBqyy
 #: src/pages/settings/applications/tabs/SettingsApplicationDetailContentTab.tsx
 msgid "Connection providers"
-msgstr ""
+msgstr "Proveedores de conexión"
 
 #. js-lingui-id: W4Kgwq
 #: src/modules/settings/accounts/components/SettingsAccountsRowDropdownMenu.tsx
@@ -3944,13 +4273,17 @@ msgstr "Conexión actualizada con éxito"
 
 #. js-lingui-id: JdGr7p
 #: src/modules/side-panel/pages/page-layout/components/ChartLimitInfoBanner.tsx
-msgid "Consider adding a filter or changing the date granularity to display more data."
+msgid ""
+"Consider adding a filter or changing the date granularity to display more "
+"data."
 msgstr ""
+"Considera añadir un filtro o cambiar la granularidad de fecha para mostrar "
+"más datos."
 
 #. js-lingui-id: G++HwN
 #: src/modules/side-panel/pages/page-layout/components/ChartLimitInfoBanner.tsx
 msgid "Consider adding a filter to display more data."
-msgstr ""
+msgstr "Considera añadir un filtro para mostrar más datos."
 
 #. js-lingui-id: Y2y0mC
 #: src/modules/settings/accounts/components/SettingsAccountsMessageChannelDetails.tsx
@@ -3961,7 +4294,9 @@ msgstr "Creación automática de contactos"
 #. js-lingui-id: cByGGA
 #: src/modules/information-banner/components/billing/InformationBannerEndTrialPeriod.tsx
 msgid "Contact your admin to continue using Workflow or AI features."
-msgstr "Ponte en contacto con tu administrador para seguir usando las funciones de flujo de trabajo o de IA."
+msgstr ""
+"Ponte en contacto con tu administrador para seguir usando las funciones de "
+"flujo de trabajo o de IA."
 
 #. js-lingui-id: /5mghO
 #: src/modules/object-record/object-filter-dropdown/utils/getOperandLabel.ts
@@ -4009,10 +4344,8 @@ msgstr "Ventana de contexto"
 
 #. js-lingui-id: xGVfLh
 #: src/pages/settings/applications/components/SettingsApplicationConnectScopePickerModal.tsx
-#: src/pages/onboarding/SyncEmails.tsx
-#: src/pages/onboarding/SyncEmails.tsx
-#: src/pages/onboarding/SyncEmails.tsx
-#: src/pages/onboarding/InviteTeam.tsx
+#: src/pages/onboarding/SyncEmails.tsx src/pages/onboarding/SyncEmails.tsx
+#: src/pages/onboarding/SyncEmails.tsx src/pages/onboarding/InviteTeam.tsx
 #: src/pages/onboarding/CreateWorkspace.tsx
 #: src/pages/onboarding/CreateProfile.tsx
 #: src/pages/onboarding/internal/ChooseYourPlanContent.tsx
@@ -4105,7 +4438,7 @@ msgstr "Copiar enlace de invitación"
 #. js-lingui-id: 4jdeR0
 #: src/modules/settings/admin-panel/signing-keys/components/SettingsAdminSigningKeysTable.tsx
 msgid "Copy key ID"
-msgstr ""
+msgstr "Copiar ID de clave"
 
 #. js-lingui-id: y1eoq1
 #: src/modules/workspace/components/WorkspaceInviteLink.tsx
@@ -4135,7 +4468,7 @@ msgstr "Copiar clave de configuración"
 #. js-lingui-id: Ip9rQi
 #: src/pages/settings/applications/components/SettingsApplicationRegistrationShareLinkButtons.tsx
 msgid "Copy sharing link"
-msgstr ""
+msgstr "Copiar enlace para compartir"
 
 #. js-lingui-id: Ej5euX
 #: src/pages/settings/developers/api-keys/SettingsDevelopersApiKeyDetail.tsx
@@ -4182,7 +4515,7 @@ msgstr "Costo"
 #. js-lingui-id: Z9Z9PX
 #: src/modules/settings/ai/components/SettingsAiModelHoverCard.tsx
 msgid "Cost per 1M tokens"
-msgstr ""
+msgstr "Costo por 1M de tokens"
 
 #. js-lingui-id: 3X5ngu
 #: src/pages/settings/admin-panel/SettingsAdminNewAiModel.tsx
@@ -4201,8 +4534,12 @@ msgstr "No se pudo eliminar el dominio de acceso aprobado"
 
 #. js-lingui-id: KqYYBp
 #: src/pages/settings/enterprise/SettingsEnterprise.tsx
-msgid "Could not open billing portal. Please check your enterprise key is present, or contact support."
-msgstr "No se pudo abrir el portal de facturación. Comprueba que tu clave Enterprise esté configurada o ponte en contacto con soporte."
+msgid ""
+"Could not open billing portal. Please check your enterprise key is present, "
+"or contact support."
+msgstr ""
+"No se pudo abrir el portal de facturación. Comprueba que tu clave Enterprise"
+" esté configurada o ponte en contacto con soporte."
 
 #. js-lingui-id: ZuI4Sl
 #: src/modules/settings/enterprise/components/EnterprisePlanModal.tsx
@@ -4212,7 +4549,8 @@ msgstr "No se pudo abrir Stripe. Ponte en contacto con soporte."
 #. js-lingui-id: wVw4Am
 #: src/pages/settings/enterprise/SettingsEnterprise.tsx
 msgid "Could not refresh validity token. Please contact support."
-msgstr "No se pudo actualizar el token de validez. Ponte en contacto con soporte."
+msgstr ""
+"No se pudo actualizar el token de validez. Ponte en contacto con soporte."
 
 #. js-lingui-id: s8lFtq
 #: src/hooks/useCopyToClipboard.tsx
@@ -4288,8 +4626,16 @@ msgstr "Crear un panel de control"
 
 #. js-lingui-id: AR+f0K
 #: src/modules/ai/components/suggested-prompts/default-suggested-prompts.ts
-msgid "Create a dashboard with a chart of deal value by pipeline stage (New, Meeting, Proposal, Negotiation, Closed Won/Lost) for the current quarter, and a table of my top 10 open opportunities with amount, stage and expected close date."
-msgstr "Crea un panel de control con un gráfico del valor de las oportunidades por etapa del pipeline (Nuevo, Reunión, Propuesta, Negociación, Cerrada ganada/perdida) para el trimestre actual y una tabla con mis 10 principales oportunidades abiertas con importe, etapa y fecha de cierre prevista."
+msgid ""
+"Create a dashboard with a chart of deal value by pipeline stage (New, "
+"Meeting, Proposal, Negotiation, Closed Won/Lost) for the current quarter, "
+"and a table of my top 10 open opportunities with amount, stage and expected "
+"close date."
+msgstr ""
+"Crea un panel de control con un gráfico del valor de las oportunidades por "
+"etapa del pipeline (Nuevo, Reunión, Propuesta, Negociación, Cerrada "
+"ganada/perdida) para el trimestre actual y una tabla con mis 10 principales "
+"oportunidades abiertas con importe, etapa y fecha de cierre prevista."
 
 #. js-lingui-id: fQFALn
 #: src/modules/ai/components/suggested-prompts/default-suggested-prompts.ts
@@ -4324,7 +4670,7 @@ msgstr "Crear Espacio de Trabajo"
 #. js-lingui-id: /WlFSf
 #: src/pages/settings/applications/tabs/SettingsApplicationsDeveloperTab.tsx
 msgid "Create an application"
-msgstr ""
+msgstr "Crear una aplicación"
 
 #. js-lingui-id: 8ZjIgO
 #: src/modules/settings/roles/role-permissions/permission-flags/hooks/useSettingsRolePermissionFlagConfig.ts
@@ -4424,7 +4770,7 @@ msgstr "Creado"
 #. js-lingui-id: 4fBuqE
 #: src/modules/side-panel/components/SidePanelRecordInfo.tsx
 msgid "Created {beautifiedCreatedAt}"
-msgstr ""
+msgstr "Creado {beautifiedCreatedAt}"
 
 #. js-lingui-id: NCIYDF
 #: src/modules/settings/applications/components/SettingsApplicationAboutSidebar.tsx
@@ -4435,7 +4781,7 @@ msgstr "Creado por"
 #. placeholder {0}: beautifyExactDateTime(signingKey.createdAt)
 #: src/modules/settings/admin-panel/signing-keys/components/SettingsAdminSigningKeysTable.tsx
 msgid "Created on {0}"
-msgstr ""
+msgstr "Creado el {0}"
 
 #. js-lingui-id: fR16ki
 #: src/pages/onboarding/CreateWorkspace.tsx
@@ -4461,7 +4807,7 @@ msgstr "Credenciales y ámbitos para los flujos de autorización de OAuth"
 #. js-lingui-id: 3hkXRB
 #: src/modules/settings/admin-panel/components/SettingsAdminWorkspaceBillingContent.tsx
 msgid "Credit balance"
-msgstr ""
+msgstr "Saldo de créditos"
 
 #. js-lingui-id: 7iwYAn
 #: src/modules/settings/usage/components/SettingsUsageAnalyticsSection.tsx
@@ -4471,12 +4817,12 @@ msgstr "Consumo de créditos a lo largo del tiempo."
 #. js-lingui-id: CYpB9A
 #: src/modules/settings/billing/components/SettingsBillingSubscriptionInfo.tsx
 msgid "Credit pack switching has been cancelled."
-msgstr ""
+msgstr "Se ha cancelado el cambio de paquete de créditos."
 
 #. js-lingui-id: qtEx+T
 #: src/modules/ai/components/AIChatNoMoreBillingCreditsBanner.tsx
 msgid "Credit plan upgraded."
-msgstr ""
+msgstr "Plan de créditos actualizado."
 
 #. js-lingui-id: c1ojkj
 #: src/modules/settings/billing/components/SettingsBillingCreditsSection.tsx
@@ -4492,7 +4838,7 @@ msgstr "Desglose del uso de créditos de tu espacio de trabajo."
 #. js-lingui-id: UQ4Hjl
 #: src/modules/settings/admin-panel/components/SettingsAdminWorkspaceBillingContent.tsx
 msgid "credits"
-msgstr ""
+msgstr "créditos"
 
 #. js-lingui-id: lDIOek
 #: src/pages/settings/SettingsUsageUserDetail.tsx
@@ -4508,7 +4854,9 @@ msgstr "Créditos por período"
 #. js-lingui-id: EABlI0
 #: src/modules/ai/components/AiChatCreditsExhaustedMessage.tsx
 msgid "Credits exhausted. Please contact your workspace admin to upgrade."
-msgstr "Créditos agotados. Ponte en contacto con el administrador de tu espacio de trabajo para actualizar el plan."
+msgstr ""
+"Créditos agotados. Ponte en contacto con el administrador de tu espacio de "
+"trabajo para actualizar el plan."
 
 #. js-lingui-id: JIXvMy
 #: src/modules/ai/components/AiChatCreditsExhaustedMessage.tsx
@@ -4519,11 +4867,17 @@ msgstr "Créditos agotados. Actualiza tu plan para obtener más créditos."
 #: src/modules/information-banner/components/billing/InformationBannerNoMoreCredits.tsx
 msgid "Credits limit reached. Contact your admin to resume Workflows and AI."
 msgstr ""
+"Límite de créditos alcanzado. Contacta a tu administrador para reanudar "
+"flujos de trabajo e IA."
 
 #. js-lingui-id: 2rAG3K
 #: src/modules/information-banner/components/billing/InformationBannerNoMoreCredits.tsx
-msgid "Credits limit reached. Update your credit plan to keep Workflows and AI running."
+msgid ""
+"Credits limit reached. Update your credit plan to keep Workflows and AI "
+"running."
 msgstr ""
+"Límite de créditos alcanzado. Actualiza tu plan de créditos para mantener "
+"los flujos de trabajo e IA funcionando."
 
 #. js-lingui-id: n3kKrs
 #: src/modules/settings/billing/components/SettingsBillingCreditsSection.tsx
@@ -4533,7 +4887,7 @@ msgstr "Créditos Usados"
 #. js-lingui-id: 5oMPMN
 #: src/modules/settings/admin-panel/components/SettingsAdminWorkspaceBillingContent.tsx
 msgid "credits/period"
-msgstr ""
+msgstr "créditos/período"
 
 #. js-lingui-id: e73uuf
 #: src/modules/settings/data-model/fields/forms/select/components/SettingsDataModelFieldSelectFormOptionRow.tsx
@@ -4549,8 +4903,11 @@ msgstr "Cron"
 
 #. js-lingui-id: rV1+uS
 #: src/modules/settings/logic-functions/components/triggers/SettingsLogicFunctionCronTriggerSection.tsx
-msgid "Cron triggers pass no payload — the handler is called with an empty object."
+msgid ""
+"Cron triggers pass no payload — the handler is called with an empty object."
 msgstr ""
+"Los disparadores Cron no pasan ningún payload — el controlador se llama con "
+"un objeto vacío."
 
 #. js-lingui-id: zovbHa
 #: src/modules/workflow/workflow-trigger/components/WorkflowEditTriggerCronForm.tsx
@@ -4561,7 +4918,7 @@ msgstr "Cron se activará a la hora UTC"
 #: src/modules/workflow/workflow-steps/workflow-actions/ai-agent-action/components/WorkflowAiAgentPermissionsCrudList.tsx
 #: src/modules/workflow/workflow-steps/workflow-actions/ai-agent-action/components/WorkflowAiAgentPermissionList.tsx
 msgid "CRUD"
-msgstr ""
+msgstr "CRUD"
 
 #. js-lingui-id: J1QT+3
 #: src/modules/side-panel/pages/page-layout/constants/settings/ChartConfigurationSettingLabels.ts
@@ -4593,17 +4950,19 @@ msgstr "Actual"
 #. js-lingui-id: nSK0mT
 #: src/modules/settings/admin-panel/components/SettingsAdminWorkspaceBillingContent.tsx
 msgid "Current period"
-msgstr ""
+msgstr "Período actual"
 
 #. js-lingui-id: C6vAhD
 #: src/modules/settings/admin-panel/components/SettingsAdminWorkspaceBillingContent.tsx
 msgid "Current subscription state and line items"
-msgstr ""
+msgstr "Estado actual de la suscripción y líneas"
 
 #. js-lingui-id: 6YzXhC
 #: src/modules/settings/admin-panel/config-variables/components/ConfigVariableHelpText.tsx
 msgid "Current value from server environment. Set a custom value to override."
-msgstr "Valor actual del entorno del servidor. Establece un valor personalizado para anular."
+msgstr ""
+"Valor actual del entorno del servidor. Establece un valor personalizado para"
+" anular."
 
 #. js-lingui-id: Hd06oy
 #: src/pages/settings/applications/components/SettingsApplicationVersionContainer.tsx
@@ -4628,7 +4987,7 @@ msgstr "Personalizado"
 #. js-lingui-id: +V9e6z
 #: src/modules/settings/enterprise/components/EnterprisePlanModal.tsx
 msgid "Custom AI Models"
-msgstr ""
+msgstr "Modelos de IA personalizados"
 
 #. js-lingui-id: XQ681Q
 #: src/modules/settings/domains/components/SettingsWorkspaceDomainCard.tsx
@@ -4672,12 +5031,17 @@ msgstr "Vista personalizada"
 #. js-lingui-id: 876pfE
 #: src/modules/settings/admin-panel/components/SettingsAdminWorkspaceBillingContent.tsx
 msgid "Customer"
-msgstr ""
+msgstr "Cliente"
 
 #. js-lingui-id: MNGIVW
 #: src/modules/settings/data-model/object-details/components/tabs/ObjectFields.tsx
-msgid "Customise the fields available in the {objectLabelSingular} views and their display order in the {objectLabelSingular} detail view and menus."
-msgstr "Personaliza los campos disponibles en las vistas de {objectLabelSingular} y su orden de visualización en la vista de detalle de {objectLabelSingular} y en los menús."
+msgid ""
+"Customise the fields available in the {objectLabelSingular} views and their "
+"display order in the {objectLabelSingular} detail view and menus."
+msgstr ""
+"Personaliza los campos disponibles en las vistas de {objectLabelSingular} y "
+"su orden de visualización en la vista de detalle de {objectLabelSingular} y "
+"en los menús."
 
 #. js-lingui-id: qqLY+j
 #: src/pages/settings/data-model/new-field/SettingsObjectNewFieldConfigure.tsx
@@ -4710,12 +5074,12 @@ msgstr "Personalizar diseños de página y estructura de UI"
 #. js-lingui-id: LMX+xC
 #: src/modules/settings/data-model/object-details/components/tabs/ObjectLayout.tsx
 msgid "Customize record page"
-msgstr ""
+msgstr "Personalizar página de registro"
 
 #. js-lingui-id: 1KIzk7
 #: src/modules/settings/data-model/object-details/components/tabs/ObjectLayout.tsx
 msgid "Customize the layout for this role"
-msgstr ""
+msgstr "Personalizar el diseño para este rol"
 
 #. js-lingui-id: ZBgSzH
 #: src/modules/settings/members/components/MemberPermissionsTab.tsx
@@ -4741,7 +5105,7 @@ msgstr "Checo"
 #: src/pages/settings/ai/SettingsAiUsageUserDetail.tsx
 #: src/pages/settings/ai/components/SettingsAiUsageTab.tsx
 msgid "Daily AI Usage"
-msgstr ""
+msgstr "Uso diario de IA"
 
 #. js-lingui-id: KXQkvT
 #: src/pages/settings/SettingsUsageUserDetail.tsx
@@ -4955,13 +5319,19 @@ msgstr "Desactivar"
 #. js-lingui-id: 7OGvrU
 #: src/pages/settings/ai/SettingsSkillForm.tsx
 msgid "Deactivate \"Synchronize Label and API Name\" to set a custom API name"
-msgstr "Desactive \"Sincronizar etiqueta y nombre de API\" para establecer un nombre de API personalizado"
+msgstr ""
+"Desactive \"Sincronizar etiqueta y nombre de API\" para establecer un nombre"
+" de API personalizado"
 
 #. js-lingui-id: qk4i22
 #: src/modules/settings/data-model/objects/forms/components/SettingsDataModelObjectAboutForm.tsx
 #: src/modules/settings/data-model/fields/forms/components/SettingsDataModelFieldIconLabelForm.tsx
-msgid "Deactivate \"Synchronize Objects Labels and API Names\" to set a custom API name"
-msgstr "Desactive \"Sincronizar etiquetas de objetos y nombres de API\" para establecer un nombre de API personalizado"
+msgid ""
+"Deactivate \"Synchronize Objects Labels and API Names\" to set a custom API "
+"name"
+msgstr ""
+"Desactive \"Sincronizar etiquetas de objetos y nombres de API\" para "
+"establecer un nombre de API personalizado"
 
 #. js-lingui-id: T2YbXF
 #: src/modules/settings/data-model/object-details/components/tabs/ObjectSettings.tsx
@@ -5002,7 +5372,7 @@ msgstr "Decide qué campos de subdirección deseas mostrar"
 #. js-lingui-id: Bn9+El
 #: src/modules/ai/hooks/useAiModelOptions.ts
 msgid "default"
-msgstr ""
+msgstr "predeterminado"
 
 #. js-lingui-id: ovBPCi
 #: src/pages/settings/layout/SettingsLayoutViewDetail.tsx
@@ -5090,13 +5460,14 @@ msgstr "Definir roles de usuario y niveles de acceso"
 #. js-lingui-id: ErLA3E
 #: src/pages/settings/ai/SettingsToolDetail.tsx
 msgid "Define what this tool does"
-msgstr ""
+msgstr "Define qué hace esta herramienta"
 
 #. js-lingui-id: bQkkFU
 #: src/modules/settings/accounts/components/SettingsAccountsMessageChannelDetails.tsx
 #: src/modules/settings/accounts/components/SettingsAccountsCalendarChannelDetails.tsx
 msgid "Define what will be visible to other users in your workspace"
-msgstr "Define lo que será visible para otros usuarios en tu espacio de trabajo"
+msgstr ""
+"Define lo que será visible para otros usuarios en tu espacio de trabajo"
 
 #. js-lingui-id: EcAkBs
 #: src/modules/workflow/workflow-steps/workflow-actions/delay-actions/components/WorkflowEditActionDelay.tsx
@@ -5198,7 +5569,9 @@ msgstr "Eliminar la cuenta y todos los datos asociados"
 #. js-lingui-id: kvHBHg
 #: src/modules/settings/profile/components/DeleteAccount.tsx
 msgid "Delete account and all the associated data or leave workspace"
-msgstr "Eliminar la cuenta y todos los datos asociados o abandonar el espacio de trabajo"
+msgstr ""
+"Eliminar la cuenta y todos los datos asociados o abandonar el espacio de "
+"trabajo"
 
 #. js-lingui-id: YMNj8z
 #: src/pages/settings/ai/components/SettingsAgentSettingsTab.tsx
@@ -5221,22 +5594,22 @@ msgstr "Eliminar aplicación"
 #. js-lingui-id: YFpLoV
 #: src/modules/ai/components/AiChatThreadDeleteConfirmationModal.tsx
 msgid "Delete chat"
-msgstr ""
+msgstr "Eliminar chat"
 
 #. js-lingui-id: cC09EO
 #: src/pages/settings/workspace/SettingsWorkspaceEmailGroupChannelDetail.tsx
 msgid "Delete email handle"
-msgstr ""
+msgstr "Eliminar identificador de correo"
 
 #. js-lingui-id: yZyuut
 #: src/pages/settings/emailing-domains/SettingsEmailingDomainDetail.tsx
 msgid "Delete emailing domain"
-msgstr ""
+msgstr "Eliminar dominio de correo"
 
 #. js-lingui-id: gf2eXy
 #: src/pages/settings/ai/components/SettingsAgentEvalsTab.tsx
 msgid "Delete Evaluation Input"
-msgstr ""
+msgstr "Eliminar entrada de evaluación"
 
 #. js-lingui-id: x2p4/4
 #: src/modules/workflow/workflow-steps/workflow-actions/form-action/components/WorkflowEditActionFormBuilder.tsx
@@ -5296,7 +5669,7 @@ msgstr "Eliminar este agente"
 #. js-lingui-id: +RYIn9
 #: src/modules/settings/data-model/object-details/components/tabs/SettingsObjectIndexesSection.tsx
 msgid "Delete this index?"
-msgstr ""
+msgstr "¿Eliminar este índice?"
 
 #. js-lingui-id: T6S2Ns
 #: src/pages/settings/developers/api-keys/SettingsDevelopersApiKeyDetail.tsx
@@ -5311,7 +5684,7 @@ msgstr "Eliminar este rol y asignar un nuevo rol a sus miembros"
 #. js-lingui-id: UvEQr6
 #: src/pages/settings/ai/SettingsToolDetail.tsx
 msgid "Delete this tool"
-msgstr ""
+msgstr "Eliminar esta herramienta"
 
 #. js-lingui-id: KSOhjo
 #: src/modules/settings/developers/components/SettingsDevelopersWebhookForm.tsx
@@ -5321,7 +5694,7 @@ msgstr "Eliminar este webhook"
 #. js-lingui-id: rQiOWg
 #: src/pages/settings/ai/SettingsToolDetail.tsx
 msgid "Delete Tool"
-msgstr ""
+msgstr "Eliminar herramienta"
 
 #. js-lingui-id: jPvFKE
 #: src/modules/settings/two-factor-authentication/components/DeleteTwoFactorAuthenticationMethod.tsx
@@ -5375,7 +5748,7 @@ msgstr "Eliminar este método lo eliminará permanentemente de tu cuenta."
 #. js-lingui-id: Ssdrw4
 #: src/modules/settings/ai/components/SettingsAiModelsTable.tsx
 msgid "Deprecated"
-msgstr ""
+msgstr "Obsoleto"
 
 #. js-lingui-id: O3LJh6
 #: src/modules/side-panel/pages/page-layout/utils/getSortLabelSuffixForFieldType.ts
@@ -5417,13 +5790,13 @@ msgstr "Descripción"
 #: src/pages/settings/layout/components/SettingsLayoutDetailScaffold.tsx
 #: src/pages/settings/applications/tabs/SettingsApplicationFrontComponentSettingsTab.tsx
 msgid "Description provided by the application"
-msgstr ""
+msgstr "Descripción proporcionada por la aplicación"
 
 #. js-lingui-id: BBqGS9
 #: src/modules/side-panel/pages/page-layout/hooks/useVisibilityLabels.ts
 #: src/modules/side-panel/pages/page-layout/hooks/useTranslatedVisibilityLabel.ts
 msgid "Desktop"
-msgstr ""
+msgstr "Escritorio"
 
 #. js-lingui-id: +ow7t4
 #: src/modules/settings/roles/role-permissions/object-level-permissions/utils/objectPermissionKeyToHumanReadableText.ts
@@ -5449,7 +5822,7 @@ msgstr "Desvincular"
 #. js-lingui-id: crxufE
 #: src/pages/settings/admin-panel/SettingsAdminWorkspacesStatus.tsx
 msgid "Detail per workspace"
-msgstr ""
+msgstr "Detalle por espacio de trabajo"
 
 #. js-lingui-id: URmyfc
 #: src/pages/settings/security/event-logs/utils/getColumnsForEventLogTable.ts
@@ -5464,7 +5837,7 @@ msgstr "Detalles"
 #. js-lingui-id: /RlqQE
 #: src/pages/settings/admin-panel/SettingsAdminInferredVersion.tsx
 msgid "Detected application version running on this instance"
-msgstr ""
+msgstr "Versión de aplicación detectada ejecutándose en esta instancia"
 
 #. js-lingui-id: 7aDnUb
 #: src/pages/settings/applications/SettingsApplications.tsx
@@ -5479,23 +5852,23 @@ msgstr "Enlaces para desarrolladores"
 #. js-lingui-id: MRB7nI
 #: src/pages/settings/layout/SettingsLayoutViewDetail.tsx
 msgid "Direction"
-msgstr ""
+msgstr "Dirección"
 
 #. js-lingui-id: E/QGRL
 #: src/modules/page-layout/components/PageLayoutTabListNewTabDropdownContent.tsx
 msgid "Disabled"
-msgstr ""
+msgstr "Desactivado"
 
 #. js-lingui-id: +K0AvT
 #: src/pages/settings/applications/SettingsApplicationConnectionDetail.tsx
 #: src/pages/settings/applications/SettingsApplicationConnectionDetail.tsx
 msgid "Disconnect"
-msgstr ""
+msgstr "Desconectar"
 
 #. js-lingui-id: TauHgw
 #: src/pages/settings/applications/SettingsApplicationConnectionDetail.tsx
 msgid "Disconnect connection?"
-msgstr ""
+msgstr "¿Desconectar conexión?"
 
 #. js-lingui-id: Xm/s+u
 #: src/modules/settings/accounts/components/SettingsAccountsCalendarChannelsGeneral.tsx
@@ -5510,7 +5883,9 @@ msgstr "Mostrar el botón \"Más campos\""
 #. js-lingui-id: r/aDR/
 #: src/modules/workflow/workflow-trigger/components/WorkflowEditTriggerManual.tsx
 msgid "Display a button in the top navbar to trigger this workflow"
-msgstr "Mostrar un botón en la barra de navegación superior para activar este flujo de trabajo"
+msgstr ""
+"Mostrar un botón en la barra de navegación superior para activar este flujo "
+"de trabajo"
 
 #. js-lingui-id: 8Vg8H7
 #: src/modules/settings/data-model/fields/forms/number/components/SettingsDataModelFieldNumberForm.tsx
@@ -5535,7 +5910,7 @@ msgstr "Mostrar texto en varias líneas"
 #. js-lingui-id: ljWYXA
 #: src/pages/settings/admin-panel/SettingsAdminApplicationRegistrationGeneralToggles.tsx
 msgid "Display this app in the NPM packages list"
-msgstr ""
+msgstr "Mostrar esta aplicación en la lista de paquetes NPM"
 
 #. js-lingui-id: vU/Hht
 #: src/pages/settings/applications/SettingsApplicationRegistrationDetails.tsx
@@ -5592,8 +5967,12 @@ msgstr "Configuración de dominio"
 
 #. js-lingui-id: 7kVRe6
 #: src/pages/settings/security/SettingsSecurityApprovedAccessDomain.tsx
-msgid "Domains have to be smaller than 256 characters, cannot contain spaces and cannot contain any special characters."
-msgstr "Los dominios deben tener menos de 256 caracteres, no pueden contener espacios y no pueden contener caracteres especiales."
+msgid ""
+"Domains have to be smaller than 256 characters, cannot contain spaces and "
+"cannot contain any special characters."
+msgstr ""
+"Los dominios deben tener menos de 256 caracteres, no pueden contener "
+"espacios y no pueden contener caracteres especiales."
 
 #. js-lingui-id: KUxVkp
 #: src/modules/settings/accounts/components/SettingsAccountsMessageAutoCreationCard.tsx
@@ -5613,7 +5992,7 @@ msgstr "No sincronizar correos de team@ support@ noreply@..."
 #. js-lingui-id: Wm78zZ
 #: src/modules/settings/experience/components/NumberFormatSelect.tsx
 msgid "Dots and comma"
-msgstr ""
+msgstr "Puntos y coma"
 
 #. js-lingui-id: LE8J+K
 #: src/modules/settings/billing/components/internal/ResourceCreditPriceSelector.tsx
@@ -5686,7 +6065,7 @@ msgstr "Nodo duplicado"
 #. js-lingui-id: mMsEuG
 #: src/modules/side-panel/pages/page-layout/components/WidgetSettingsFooter.tsx
 msgid "Duplicate widget"
-msgstr ""
+msgstr "Duplicar widget"
 
 #. js-lingui-id: cheWPw
 #: src/modules/object-record/record-field-list/record-detail-section/duplicate/components/RecordDetailDuplicatesSection.tsx
@@ -5763,7 +6142,9 @@ msgstr "p. ej., OpenAI EU"
 #. js-lingui-id: p5P8NB
 #: src/pages/settings/ai/components/SettingsAiMoreTab.tsx
 msgid "E.g., \"We are a B2B SaaS company. Always use formal language...\""
-msgstr "p. ej., \"Somos una empresa SaaS B2B. Utiliza siempre un lenguaje formal...\""
+msgstr ""
+"p. ej., \"Somos una empresa SaaS B2B. Utiliza siempre un lenguaje "
+"formal...\""
 
 #. js-lingui-id: GhTFTJ
 #: src/modules/workflow/workflow-steps/workflow-actions/ai-agent-action/components/WorkflowOutputSchemaBuilder.tsx
@@ -5772,8 +6153,14 @@ msgstr "ej., resumen, estado, conteo"
 
 #. js-lingui-id: npNQJR
 #: src/pages/settings/data-model/new-index/SettingsObjectNewIndex.tsx
-msgid "Each index speeds up reads on the fields it covers, but slows down every insert and update, and uses disk space. Only add an index when you know which queries it serves."
+msgid ""
+"Each index speeds up reads on the fields it covers, but slows down every "
+"insert and update, and uses disk space. Only add an index when you know "
+"which queries it serves."
 msgstr ""
+"Cada índice acelera las lecturas en los campos que cubre, pero ralentiza "
+"cada inserción y actualización, y usa espacio en disco. Solo añade un índice"
+" cuando sepas qué consultas sirve."
 
 #. js-lingui-id: 79hamt
 #: src/modules/side-panel/pages/page-layout/constants/settings/ChartConfigurationSettingLabels.ts
@@ -5830,7 +6217,7 @@ msgstr "Editar Cuenta"
 #: src/modules/command-menu-item/edit/components/CommandMenuItemEditButton.tsx
 #: src/modules/command-menu-item/edit/components/CommandMenuItemEditButton.tsx
 msgid "Edit actions"
-msgstr ""
+msgstr "Editar acciones"
 
 #. js-lingui-id: DMIYL8
 #: src/modules/settings/roles/role-permissions/permission-flags/hooks/useSettingsRolePermissionFlagConfig.ts
@@ -5908,7 +6295,8 @@ msgstr "Editar vista"
 #. js-lingui-id: 6o1M/Q
 #: src/pages/settings/SettingsWorkspace.tsx
 msgid "Edit your subdomain name or set a custom domain."
-msgstr "Edite el nombre de su subdominio o establezca un dominio personalizado."
+msgstr ""
+"Edite el nombre de su subdominio o establezca un dominio personalizado."
 
 #. js-lingui-id: xMkLkW
 #: src/pages/settings/security/SettingsSecurity.tsx
@@ -5988,7 +6376,7 @@ msgstr "Editor de Correo Electrónico"
 #. js-lingui-id: nsVRM/
 #: src/modules/settings/workspace/components/SettingsWorkspaceEmailGroupSection.tsx
 msgid "Email Handles"
-msgstr ""
+msgstr "Identificadores de correo"
 
 #. js-lingui-id: lfQsvW
 #: src/pages/onboarding/internal/ChooseYourPlanContent.tsx
@@ -6014,12 +6402,12 @@ msgstr "El correo electrónico o el dominio ya están en la lista de bloqueo"
 #. js-lingui-id: Xl929X
 #: src/modules/activities/emails/hooks/useSendEmail.ts
 msgid "Email sent successfully"
-msgstr ""
+msgstr "Correo electrónico enviado con éxito"
 
 #. js-lingui-id: jvneza
 #: src/modules/settings/applications/components/SettingsApplicationAboutSidebar.tsx
 msgid "Email support"
-msgstr ""
+msgstr "Soporte por correo electrónico"
 
 #. js-lingui-id: LimKOG
 #: src/pages/settings/security/SettingsSecurityApprovedAccessDomain.tsx
@@ -6053,8 +6441,12 @@ msgstr "Correo electrónico/Dominio"
 
 #. js-lingui-id: H2lcB9
 #: src/pages/settings/emailing-domains/SettingsNewEmailingDomain.tsx
-msgid "Emailing domain created successfully. Please verify the domain to start using it."
-msgstr "Dominio de correo electrónico creado con éxito. Por favor verifica el dominio para empezar a usarlo."
+msgid ""
+"Emailing domain created successfully. Please verify the domain to start "
+"using it."
+msgstr ""
+"Dominio de correo electrónico creado con éxito. Por favor verifica el "
+"dominio para empezar a usarlo."
 
 #. js-lingui-id: XDpopO
 #: src/pages/settings/emailing-domains/SettingsEmailingDomainDetail.tsx
@@ -6081,8 +6473,12 @@ msgstr "Correos electrónicos y calendario"
 
 #. js-lingui-id: mHrqHa
 #: src/modules/settings/accounts/components/SettingsAccountsMessageChannelDetails.tsx
-msgid "Emails from the blocklist will be ignored. Manage blocklist on the \"Accounts\" setting page."
-msgstr "Los correos electrónicos de la lista de bloqueo serán ignorados. Gestiona la lista de bloqueo en la página de configuración de \"Cuentas\"."
+msgid ""
+"Emails from the blocklist will be ignored. Manage blocklist on the "
+"\"Accounts\" setting page."
+msgstr ""
+"Los correos electrónicos de la lista de bloqueo serán ignorados. Gestiona la"
+" lista de bloqueo en la página de configuración de \"Cuentas\"."
 
 #. js-lingui-id: Ww/M6X
 #: src/modules/settings/accounts/components/SettingsAccountsRowDropdownMenu.tsx
@@ -6152,7 +6548,7 @@ msgstr "Objeto vacío"
 #: src/pages/settings/layout/SettingsLayoutPageLayoutDetail.tsx
 #: src/modules/page-layout/components/PageLayoutTabListNewTabDropdownContent.tsx
 msgid "Empty tab"
-msgstr ""
+msgstr "Pestaña vacía"
 
 #. js-lingui-id: q11Dk2
 #: src/modules/settings/roles/role-permissions/permission-flags/hooks/useSettingsRolePermissionFlagConfig.ts
@@ -6167,7 +6563,7 @@ msgstr "Habilitar funciones específicas del modelo"
 #. js-lingui-id: IrI9pg
 #: src/modules/settings/admin-panel/health-status/maintenance-mode/components/SettingsAdminMaintenanceMode.tsx
 msgid "End date"
-msgstr ""
+msgstr "Fecha de finalización"
 
 #. js-lingui-id: VFv2ZC
 #: src/pages/settings/security/event-logs/components/EventLogFilters.tsx
@@ -6177,7 +6573,7 @@ msgstr "Fecha de finalización"
 #. js-lingui-id: Fqu/aC
 #: src/modules/settings/admin-panel/health-status/maintenance-mode/components/SettingsAdminMaintenanceMode.tsx
 msgid "End date must be after start date."
-msgstr ""
+msgstr "La fecha de finalización debe ser posterior a la fecha de inicio."
 
 #. js-lingui-id: k1i50B
 #: src/modules/information-banner/components/billing/InformationBannerEndTrialPeriod.tsx
@@ -6187,7 +6583,9 @@ msgstr "Finalizar periodo de prueba"
 #. js-lingui-id: QEUZoG
 #: src/modules/information-banner/components/billing/InformationBannerEndTrialPeriod.tsx
 msgid "End trial period to continue using Workflow or AI features."
-msgstr "Finaliza el periodo de prueba para seguir usando las funciones de flujo de trabajo o de IA."
+msgstr ""
+"Finaliza el periodo de prueba para seguir usando las funciones de flujo de "
+"trabajo o de IA."
 
 #. js-lingui-id: T3juzf
 #: src/modules/settings/developers/components/SettingsDevelopersWebhookForm.tsx
@@ -6197,7 +6595,8 @@ msgstr "URL del endpoint"
 #. js-lingui-id: Vv4JVS
 #: src/modules/settings/security/components/Toggle2FA.tsx
 msgid "Enforce two-step verification for every user login."
-msgstr "Imponer verificación en dos pasos para cada inicio de sesión de usuario."
+msgstr ""
+"Imponer verificación en dos pasos para cada inicio de sesión de usuario."
 
 #. js-lingui-id: lYGfRP
 #: src/pages/settings/profile/appearance/components/LocalePicker.tsx
@@ -6228,7 +6627,7 @@ msgstr "Introduce un objeto JSON"
 #. js-lingui-id: peBb6B
 #: src/modules/settings/admin-panel/config-variables/components/ConfigVariableValueInput.tsx
 msgid "Enter a new secret value"
-msgstr ""
+msgstr "Introduce un nuevo valor secreto"
 
 #. js-lingui-id: u2fAme
 #: src/modules/object-record/record-field/ui/form-types/components/FormNumberFieldInput.tsx
@@ -6351,7 +6750,9 @@ msgstr "Introduce una opción por línea"
 #. js-lingui-id: Xj6ylP
 #: src/modules/settings/data-model/fields/forms/select/components/SettingsDataModelFieldSelectForm.tsx
 msgid "Enter one option per line. Each line will become a new option."
-msgstr "Introduce una opción por línea. Cada línea se convertirá en una nueva opción."
+msgstr ""
+"Introduce una opción por línea. Cada línea se convertirá en una nueva "
+"opción."
 
 #. js-lingui-id: waLOUb
 #: src/modules/object-record/record-field/ui/form-types/components/FormPhoneFieldInput.tsx
@@ -6392,13 +6793,20 @@ msgstr "Ingrese la información para establecer la conexión"
 #. js-lingui-id: 3EF9HN
 #: src/pages/settings/ai/forms/components/SettingsAiAgentForm.tsx
 #: src/pages/settings/ai/components/SettingsAgentSettingsTab.tsx
-msgid "Enter the system prompt that defines this agent's behavior and capabilities"
-msgstr "Ingrese el aviso del sistema que define el comportamiento y las capacidades de este agente"
+msgid ""
+"Enter the system prompt that defines this agent's behavior and capabilities"
+msgstr ""
+"Ingrese el aviso del sistema que define el comportamiento y las capacidades "
+"de este agente"
 
 #. js-lingui-id: tEWpbi
 #: src/pages/settings/admin-panel/SettingsAdminApplicationRegistrationDangerZone.tsx
-msgid "Enter the workspace subdomain to transfer this app to. You will lose access to manage it."
-msgstr "Introduce el subdominio del espacio de trabajo al que transferir esta aplicación. Perderás el acceso para gestionarla."
+msgid ""
+"Enter the workspace subdomain to transfer this app to. You will lose access "
+"to manage it."
+msgstr ""
+"Introduce el subdominio del espacio de trabajo al que transferir esta "
+"aplicación. Perderás el acceso para gestionarla."
 
 #. js-lingui-id: pubQie
 #: src/modules/workflow/workflow-steps/workflow-actions/code-action/components/WorkflowEditActionCodeFields.tsx
@@ -6438,7 +6846,7 @@ msgstr "Empresa"
 #: src/pages/settings/ai/components/SettingsAiUsageTab.tsx
 #: src/modules/settings/admin-panel/ai/components/SettingsAdminAI.tsx
 msgid "Enterprise feature"
-msgstr ""
+msgstr "Función Enterprise"
 
 #. js-lingui-id: Kjjkt3
 #: src/pages/settings/security/event-logs/SettingsEventLogs.tsx
@@ -6564,7 +6972,8 @@ msgstr "Error al analizar teléfonos adicionales: {error}"
 #. js-lingui-id: zRXcyv
 #: src/pages/settings/enterprise/SettingsEnterprise.tsx
 msgid "Error refreshing validity token. Please contact support."
-msgstr "Error al actualizar el token de validez. Ponte en contacto con soporte."
+msgstr ""
+"Error al actualizar el token de validez. Ponte en contacto con soporte."
 
 #. js-lingui-id: PfAip2
 #: src/pages/settings/developers/api-keys/SettingsDevelopersApiKeyDetail.tsx
@@ -6579,7 +6988,7 @@ msgstr "Error al reenviar la invitación"
 #. js-lingui-id: XuMw6C
 #: src/modules/settings/config-variables/components/ConfigVariableEdit.tsx
 msgid "Error resetting variable"
-msgstr ""
+msgstr "Error al restablecer la variable"
 
 #. js-lingui-id: cpGsq/
 #: src/pages/settings/applications/tabs/SettingsApplicationRegistrationOAuthTab.tsx
@@ -6589,7 +6998,7 @@ msgstr "Error al rotar el secreto del cliente"
 #. js-lingui-id: 5Vy8D1
 #: src/pages/settings/applications/SettingsApplicationDetails.tsx
 msgid "Error uninstalling application."
-msgstr ""
+msgstr "Error al desinstalar la aplicación."
 
 #. js-lingui-id: fQYyhK
 #: src/pages/settings/applications/tabs/SettingsApplicationRegistrationOAuthTab.tsx
@@ -6614,7 +7023,7 @@ msgstr "Error al validar el dominio de acceso aprobado"
 #. js-lingui-id: du6d5C
 #: src/modules/settings/billing/components/SettingsBillingSubscriptionInfo.tsx
 msgid "Error while cancelling credit pack switching."
-msgstr ""
+msgstr "Error al cancelar el cambio de paquete de créditos."
 
 #. js-lingui-id: pt7mmi
 #: src/modules/settings/billing/components/SettingsBillingSubscriptionInfo.tsx
@@ -6629,12 +7038,14 @@ msgstr "Error al cancelar el cambio de plan."
 #. js-lingui-id: QmR+2U
 #: src/modules/settings/billing/hooks/useEndSubscriptionTrialPeriod.ts
 msgid "Error while ending trial period. Please contact Twenty team."
-msgstr "Error al finalizar el período de prueba. Por favor, póngase en contacto con el equipo de Twenty."
+msgstr ""
+"Error al finalizar el período de prueba. Por favor, póngase en contacto con "
+"el equipo de Twenty."
 
 #. js-lingui-id: 5g78zo
 #: src/pages/settings/members/SettingsWorkspaceMember.tsx
 msgid "Error while saving the name"
-msgstr ""
+msgstr "Error al guardar el nombre"
 
 #. js-lingui-id: QEee5f
 #: src/modules/settings/billing/components/SettingsBillingSubscriptionInfo.tsx
@@ -6650,17 +7061,18 @@ msgstr "Error al cambiar la suscripción."
 #: src/pages/settings/workspace/SettingsApiWebhooks.tsx
 #: src/pages/settings/developers/webhooks/components/SettingsWebhooks.tsx
 msgid "Establish Webhook endpoints for notifications on asynchronous events."
-msgstr "Establezca endpoints de Webhook para notificaciones de eventos asincrónicos."
+msgstr ""
+"Establezca endpoints de Webhook para notificaciones de eventos asincrónicos."
 
 #. js-lingui-id: 4ASb34
 #: src/pages/settings/ai/SettingsAgentForm.tsx
 msgid "Evals"
-msgstr ""
+msgstr "Evaluaciones"
 
 #. js-lingui-id: UKdZ7G
 #: src/pages/settings/ai/components/SettingsAgentLogsTab.tsx
 msgid "Evaluate"
-msgstr ""
+msgstr "Evaluar"
 
 #. js-lingui-id: FDRUdE
 #: src/pages/settings/ai/components/SettingsAgentLogsTab.tsx
@@ -6670,7 +7082,7 @@ msgstr "Evaluando"
 #. js-lingui-id: Y3MReI
 #: src/pages/settings/ai/SettingsAgentTurnDetail.tsx
 msgid "Evaluations"
-msgstr ""
+msgstr "Evaluaciones"
 
 #. js-lingui-id: 0pC/y6
 #: src/pages/settings/security/event-logs/utils/getColumnsForEventLogTable.ts
@@ -6708,8 +7120,11 @@ msgstr "cada {stepNumStr} días"
 
 #. js-lingui-id: iRozlI
 #: src/modules/workflow/workflow-trigger/utils/cron-to-human/descriptors/getDayOfMonthDescription.ts
-msgid "every {stepNumStr} days, between the {startOrdinal} and {endOrdinal} of the month"
-msgstr "cada {stepNumStr} días, entre el {startOrdinal} y {endOrdinal} del mes"
+msgid ""
+"every {stepNumStr} days, between the {startOrdinal} and {endOrdinal} of the "
+"month"
+msgstr ""
+"cada {stepNumStr} días, entre el {startOrdinal} y {endOrdinal} del mes"
 
 #. js-lingui-id: iCnbJU
 #: src/modules/workflow/workflow-trigger/utils/cron-to-human/descriptors/getHoursDescription.ts
@@ -6792,16 +7207,21 @@ msgstr "Excluir correos electrónicos no profesionales"
 #: src/modules/settings/accounts/components/SettingsAccountsBlocklistSection.tsx
 msgid "Exclude the following people and domains from my email sync."
 msgstr ""
+"Excluir las siguientes personas y dominios de mi sincronización de correo."
 
 #. js-lingui-id: yhhfqh
 #: src/modules/settings/accounts/components/SettingsAccountsBlocklistSection.tsx
-msgid "Exclude the following people and domains from my email sync. Internal conversations will not be imported"
-msgstr "Excluir las siguientes personas y dominios de mi sincronización de correo electrónico. Las conversaciones internas no se importarán"
+msgid ""
+"Exclude the following people and domains from my email sync. Internal "
+"conversations will not be imported"
+msgstr ""
+"Excluir las siguientes personas y dominios de mi sincronización de correo "
+"electrónico. Las conversaciones internas no se importarán"
 
 #. js-lingui-id: B0clc7
 #: src/pages/settings/security/event-logs/utils/getColumnsForEventLogTable.ts
 msgid "Execution ID"
-msgstr ""
+msgstr "ID de ejecución"
 
 #. js-lingui-id: YzI8cc
 #: src/modules/workflow/workflow-steps/workflow-actions/form-action/components/WorkflowFormFieldSettingsSelect.tsx
@@ -6931,12 +7351,13 @@ msgstr "Exportar CSV"
 #. js-lingui-id: leUV74
 #: src/modules/settings/logic-functions/components/triggers/SettingsLogicFunctionWorkflowActionTriggerSection.tsx
 msgid "Exposes the function as a step in the workflow builder"
-msgstr ""
+msgstr "Expone la función como un paso en el constructor de flujos de trabajo"
 
 #. js-lingui-id: Kh6fBo
 #: src/modules/settings/logic-functions/components/triggers/SettingsLogicFunctionToolTriggerSection.tsx
 msgid "Exposes the function as a tool that AI agents can call"
 msgstr ""
+"Expone la función como una herramienta que los agentes de IA pueden llamar"
 
 #. js-lingui-id: 1JBTZV
 #: src/modules/workflow/workflow-trigger/components/WorkflowEditTriggerCronForm.tsx
@@ -6962,18 +7383,32 @@ msgstr "Trabajos fallidos"
 
 #. js-lingui-id: QvHpKb
 #: src/modules/metadata-error-handler/hooks/useMetadataErrorHandler.ts
-msgid "Failed to {translatedOperationType} {translatedMetadataName}. Please try again."
-msgstr "Fallo al {translatedOperationType} {translatedMetadataName}. Por favor, intente de nuevo."
+msgid ""
+"Failed to {translatedOperationType} {translatedMetadataName}. Please try "
+"again."
+msgstr ""
+"Fallo al {translatedOperationType} {translatedMetadataName}. Por favor, "
+"intente de nuevo."
 
 #. js-lingui-id: BZm3ZK
 #: src/modules/metadata-error-handler/hooks/useMetadataErrorHandler.ts
-msgid "Failed to {translatedOperationType} {translatedMetadataName}. Related {relatedEntityNames} validation failed. Please check your configuration and try again."
-msgstr "Fallo al {translatedOperationType} {translatedMetadataName}. La validación de {relatedEntityNames} relacionada falló. Verifique su configuración e intente de nuevo."
+msgid ""
+"Failed to {translatedOperationType} {translatedMetadataName}. Related "
+"{relatedEntityNames} validation failed. Please check your configuration and "
+"try again."
+msgstr ""
+"Fallo al {translatedOperationType} {translatedMetadataName}. La validación "
+"de {relatedEntityNames} relacionada falló. Verifique su configuración e "
+"intente de nuevo."
 
 #. js-lingui-id: R1XJV1
 #: src/pages/settings/enterprise/SettingsEnterprise.tsx
-msgid "Failed to activate enterprise license. Please check your key or contact support."
-msgstr "No se pudo activar la licencia Enterprise. Comprueba tu clave o ponte en contacto con soporte."
+msgid ""
+"Failed to activate enterprise license. Please check your key or contact "
+"support."
+msgstr ""
+"No se pudo activar la licencia Enterprise. Comprueba tu clave o ponte en "
+"contacto con soporte."
 
 #. js-lingui-id: vJiM7T
 #: src/pages/settings/ai/components/SettingsAgentSkills.tsx
@@ -6992,8 +7427,12 @@ msgstr "Error al añadir el proveedor"
 
 #. js-lingui-id: L9UnOU
 #: src/modules/settings/accounts/components/SettingsAccountsNewEmailGroupChannel.tsx
-msgid "Failed to create email handle. Email handles may not be configured on this server."
+msgid ""
+"Failed to create email handle. Email handles may not be configured on this "
+"server."
 msgstr ""
+"Error al crear el identificador de correo. Es posible que los "
+"identificadores de correo no estén configurados en este servidor."
 
 #. js-lingui-id: WM7GKt
 #: src/pages/settings/ai/SettingsAI.tsx
@@ -7003,7 +7442,7 @@ msgstr "No se pudo crear la herramienta"
 #. js-lingui-id: lWoewm
 #: src/pages/settings/workspace/SettingsWorkspaceEmailGroupChannelDetail.tsx
 msgid "Failed to delete email handle."
-msgstr ""
+msgstr "Error al eliminar el identificador de correo."
 
 #. js-lingui-id: pUligB
 #: src/modules/settings/admin-panel/health-status/hooks/useDeleteJobs.ts
@@ -7018,7 +7457,7 @@ msgstr "No se pudo eliminar la habilidad"
 #. js-lingui-id: AUprM8
 #: src/pages/settings/ai/SettingsToolDetail.tsx
 msgid "Failed to delete tool"
-msgstr ""
+msgstr "Error al eliminar la herramienta"
 
 #. js-lingui-id: NUmmdc
 #: src/modules/command-menu-item/engine-command/record/single-record/dashboard/components/DuplicateDashboardSingleRecordCommand.tsx
@@ -7033,12 +7472,12 @@ msgstr "Error al duplicar el flujo de trabajo"
 #. js-lingui-id: dqEkUR
 #: src/pages/settings/ai/components/SettingsAgentLogsTab.tsx
 msgid "Failed to evaluate turn"
-msgstr ""
+msgstr "Error al evaluar el turno"
 
 #. js-lingui-id: P/885a
 #: src/pages/settings/ai/components/SettingsAgentEvalsTab.tsx
 msgid "Failed to execute evaluation input"
-msgstr ""
+msgstr "Error al ejecutar la entrada de evaluación"
 
 #. js-lingui-id: Ukrbw5
 #: src/modules/ai/components/AiChatErrorMessage.tsx
@@ -7075,7 +7514,7 @@ msgstr "No se pudo analizar el contexto: {contextValue}"
 #: src/pages/settings/admin-panel/SettingsAdminInstanceStatus.tsx
 #: src/pages/settings/admin-panel/SettingsAdminInferredVersion.tsx
 msgid "Failed to refresh upgrade status"
-msgstr ""
+msgstr "Error al actualizar el estado de actualización"
 
 #. js-lingui-id: 3YA1cX
 #: src/pages/settings/admin-panel/SettingsAdminAiProviderDetail.tsx
@@ -7095,12 +7534,14 @@ msgstr "Error al eliminar el proveedor"
 #. js-lingui-id: SJEIIJ
 #: src/modules/settings/admin-panel/health-status/hooks/useRetryJobs.ts
 msgid "Failed to retry jobs. Please try again later."
-msgstr "No se pudieron reintentar los trabajos. Por favor, inténtelo de nuevo más tarde."
+msgstr ""
+"No se pudieron reintentar los trabajos. Por favor, inténtelo de nuevo más "
+"tarde."
 
 #. js-lingui-id: 70UyPr
 #: src/modules/settings/admin-panel/signing-keys/hooks/useRevokeSigningKey.ts
 msgid "Failed to revoke signing key. Please try again later."
-msgstr ""
+msgstr "Error al revocar la clave de firma. Inténtalo de nuevo más tarde."
 
 #. js-lingui-id: farFvy
 #: src/modules/layout-customization/hooks/useSaveLayoutCustomization.ts
@@ -7122,17 +7563,18 @@ msgstr "Error al guardar las instrucciones del espacio de trabajo"
 #: src/modules/activities/emails/hooks/useSendEmail.ts
 #: src/modules/activities/emails/hooks/useSendEmail.ts
 msgid "Failed to send email"
-msgstr ""
+msgstr "Error al enviar el correo electrónico"
 
 #. js-lingui-id: aj02T8
 #: src/modules/settings/admin-panel/health-status/maintenance-mode/components/SettingsAdminMaintenanceMode.tsx
 msgid "Failed to set maintenance mode."
-msgstr ""
+msgstr "Error al establecer el modo de mantenimiento."
 
 #. js-lingui-id: LVcnN8
 #: src/pages/settings/admin-panel/SettingsAdminApplicationRegistrationDangerZone.tsx
 msgid "Failed to transfer ownership. Check that the subdomain is correct."
-msgstr "No se pudo transferir la propiedad. Verifica que el subdominio sea correcto."
+msgstr ""
+"No se pudo transferir la propiedad. Verifica que el subdominio sea correcto."
 
 #. js-lingui-id: 2D6TRg
 #: src/modules/settings/admin-panel/ai/components/SettingsAdminAI.tsx
@@ -7160,7 +7602,7 @@ msgstr "Error al actualizar la recomendación del modelo"
 #. js-lingui-id: q1MtjM
 #: src/modules/settings/admin-panel/ai/components/SettingsAdminAI.tsx
 msgid "Failed to update model recommendations"
-msgstr ""
+msgstr "Error al actualizar las recomendaciones de modelos"
 
 #. js-lingui-id: rCUG3c
 #: src/pages/settings/ai/components/SettingsAiModelsTab.tsx
@@ -7175,7 +7617,7 @@ msgstr "No se pudieron actualizar los registros. Inténtalo de nuevo."
 #. js-lingui-id: j5vd/9
 #: src/modules/settings/billing/components/internal/ResourceCreditPriceSelector.tsx
 msgid "Failed to update resource credits."
-msgstr ""
+msgstr "Error al actualizar los créditos de recursos."
 
 #. js-lingui-id: QGaQRo
 #: src/modules/settings/members/components/MemberPermissionsTab.tsx
@@ -7185,7 +7627,7 @@ msgstr "Error al actualizar el rol"
 #. js-lingui-id: 204Qo2
 #: src/modules/ai/components/AIChatNoMoreBillingCreditsBanner.tsx
 msgid "Failed to upgrade credit plan."
-msgstr ""
+msgstr "Error al actualizar el plan de créditos."
 
 #. js-lingui-id: pBEL6J
 #: src/modules/marketplace/hooks/useUpgradeApplication.ts
@@ -7222,7 +7664,7 @@ msgstr "Tasa de fallos"
 #. js-lingui-id: 8wngZM
 #: src/modules/command-menu-item/display/components/SidePanelCommandMenuItemDisplayPage.tsx
 msgid "Fallback"
-msgstr ""
+msgstr "Alternativo"
 
 #. js-lingui-id: ocUvR+
 #: src/modules/ui/field/display/components/BooleanDisplay.tsx
@@ -7254,7 +7696,7 @@ msgstr "Indicador de característica"
 #: src/pages/settings/admin-panel/SettingsAdminWorkspaceDetail.tsx
 #: src/pages/settings/admin-panel/SettingsAdminWorkspaceDetail.tsx
 msgid "Feature Flags"
-msgstr ""
+msgstr "Indicadores de funciones"
 
 #. js-lingui-id: F1sJEJ
 #: src/pages/settings/applications/tabs/SettingsApplicationsAvailableTab.tsx
@@ -7301,18 +7743,18 @@ msgstr "Campo en destino"
 #. js-lingui-id: P8JCfj
 #: src/modules/metadata-error-handler/hooks/useMetadataErrorHandler.ts
 msgid "field permission"
-msgstr ""
+msgstr "permiso de campo"
 
 #. js-lingui-id: lcNTiF
 #: src/modules/side-panel/pages/page-layout/utils/getPageLayoutPageTitle.ts
 #: src/modules/side-panel/hooks/useOpenWidgetSettingsInSidePanel.ts
 msgid "Field widget"
-msgstr ""
+msgstr "Widget de campo"
 
 #. js-lingui-id: hlVgd/
 #: src/modules/side-panel/components/hooks/usePageLayoutHeaderInfo.ts
 msgid "Field Widget"
-msgstr ""
+msgstr "Widget de campo"
 
 #. js-lingui-id: RnX5oc
 #: src/pages/settings/applications/SettingsAvailableApplicationDetails.tsx
@@ -7349,7 +7791,7 @@ msgstr "Campos (opcional)"
 #. js-lingui-id: h5NDR9
 #: src/pages/settings/applications/tabs/SettingsApplicationDetailContentTab.tsx
 msgid "Fields added to other objects"
-msgstr ""
+msgstr "Campos añadidos a otros objetos"
 
 #. js-lingui-id: Tnz22x
 #: src/modules/object-record/record-merge/components/MergeSettingsTab.tsx
@@ -7412,7 +7854,7 @@ msgstr "Archivo \"{fileName}\" subido correctamente"
 #. js-lingui-id: EYl2hs
 #: src/modules/activities/files/hooks/useUploadAttachmentFile.tsx
 msgid "File field not found for attachment object"
-msgstr ""
+msgstr "Campo de archivo no encontrado para el objeto adjunto"
 
 #. js-lingui-id: N793lP
 #: src/modules/object-record/record-field/ui/meta-types/input/components/FilesFieldInput.tsx
@@ -7423,7 +7865,7 @@ msgstr "Etiqueta del archivo"
 #. placeholder {0}: file.label
 #: src/modules/ui/field/display/components/FileChip.tsx
 msgid "File no longer exists - {0}"
-msgstr ""
+msgstr "El archivo ya no existe - {0}"
 
 #. js-lingui-id: ncBVqE
 #: src/modules/object-record/record-field/ui/meta-types/hooks/useUploadFilesFieldFile.ts
@@ -7433,7 +7875,7 @@ msgstr "Error al subir el archivo"
 #. js-lingui-id: BZGmTs
 #: src/modules/settings/logic-functions/components/tabs/SettingsLogicFunctionTestTab.tsx
 msgid "Fill with sample input from"
-msgstr ""
+msgstr "Rellenar con entrada de ejemplo de"
 
 #. js-lingui-id: o7J4JM
 #: src/modules/workflow/workflow-steps/workflow-actions/find-records-action/components/WorkflowEditActionFindRecords.tsx
@@ -7455,7 +7897,7 @@ msgstr "Filtrar por evento"
 #. js-lingui-id: yZOiaW
 #: src/modules/side-panel/components/SidePanelObjectFilterDropdown.tsx
 msgid "Filter by object type"
-msgstr ""
+msgstr "Filtrar por tipo de objeto"
 
 #. js-lingui-id: gVEHcL
 #: src/pages/settings/security/event-logs/components/EventLogFilters.tsx
@@ -7465,7 +7907,7 @@ msgstr "Filtrar por ID de registro"
 #. js-lingui-id: /+U0Y/
 #: src/modules/ai/components/AiChatThreadFilterDropdown.tsx
 msgid "Filter chats"
-msgstr ""
+msgstr "Filtrar chats"
 
 #. js-lingui-id: /VmB4B
 #: src/modules/object-record/advanced-filter/components/AdvancedFilterRecordFilterGroupOptionsDropdown.tsx
@@ -7475,7 +7917,7 @@ msgstr "Opciones de reglas del grupo de filtros"
 #. js-lingui-id: YrBWVK
 #: src/modules/object-record/record-index/utils/getNonReadableViewFieldSubTitle.ts
 msgid "filtering"
-msgstr ""
+msgstr "filtrado"
 
 #. js-lingui-id: cSev+j
 #: src/pages/settings/layout/SettingsLayoutViewDetail.tsx
@@ -7540,7 +7982,7 @@ msgstr "Primeras 5 líneas"
 #. js-lingui-id: V1EGGU
 #: src/modules/object-metadata/hooks/useSortSubFieldChoicesForField.ts
 msgid "First name"
-msgstr ""
+msgstr "Nombre"
 
 #. js-lingui-id: kODvZJ
 #: src/pages/onboarding/CreateProfile.tsx
@@ -7559,7 +8001,9 @@ msgstr "El nombre no puede estar vacío"
 #. js-lingui-id: JREYkg
 #: src/pages/settings/enterprise/SettingsEnterprise.tsx
 msgid "Fix the payment issue to keep your enterprise features active."
-msgstr "Soluciona el problema de pago para mantener activas tus funciones Enterprise."
+msgstr ""
+"Soluciona el problema de pago para mantener activas tus funciones "
+"Enterprise."
 
 #. js-lingui-id: ylQd2j
 #: src/modules/workflow/workflow-steps/workflow-actions/utils/getActionHeaderTypeOrThrow.ts
@@ -7589,7 +8033,7 @@ msgstr "Carpetas"
 #. js-lingui-id: Ghistm
 #: src/modules/settings/applications/hooks/useComputeApplicationContentForLayoutAndLogic.ts
 msgid "for {objectLabel}"
-msgstr ""
+msgstr "para {objectLabel}"
 
 #. js-lingui-id: glx6on
 #: src/modules/auth/sign-in-up/components/SignInUpWorkspaceScopeForm.tsx
@@ -7626,12 +8070,12 @@ msgstr "Formatos"
 #: src/pages/settings/workspace/SettingsWorkspaceEmailGroupChannelDetail.tsx
 #: src/modules/settings/workspace/components/SettingsWorkspaceEmailGroupSection.tsx
 msgid "Forwarding address"
-msgstr ""
+msgstr "Dirección de reenvío"
 
 #. js-lingui-id: TFf85Z
 #: src/pages/settings/workspace/SettingsWorkspaceEmailGroupChannelDetail.tsx
 msgid "Forwarding address copied to clipboard"
-msgstr ""
+msgstr "Dirección de reenvío copiada al portapapeles"
 
 #. js-lingui-id: 1hxId5
 #: src/modules/workflow/workflow-trigger/utils/cron-to-human/descriptors/getDayOfWeekDescription.ts
@@ -7645,8 +8089,11 @@ msgstr "Cuarto"
 
 #. js-lingui-id: aUj1gh
 #: src/modules/ai/components/AiChatCreditsExhaustedMessage.tsx
-msgid "Free trial credits exhausted. Subscribe now to continue using AI features."
-msgstr "Se han agotado los créditos de la prueba gratuita. Suscríbete ahora para seguir usando las funciones de IA."
+msgid ""
+"Free trial credits exhausted. Subscribe now to continue using AI features."
+msgstr ""
+"Se han agotado los créditos de la prueba gratuita. Suscríbete ahora para "
+"seguir usando las funciones de IA."
 
 #. js-lingui-id: nLC6tu
 #: src/pages/settings/profile/appearance/components/LocalePicker.tsx
@@ -7656,7 +8103,7 @@ msgstr "Francés"
 #. js-lingui-id: ejVYRQ
 #: src/modules/activities/emails/components/EmailComposerFields.tsx
 msgid "From"
-msgstr ""
+msgstr "Desde"
 
 #. js-lingui-id: qR8gT9
 #: src/modules/workflow/workflow-trigger/utils/cron-to-human/descriptors/getDayOfWeekDescription.ts
@@ -7674,12 +8121,12 @@ msgstr "componente de frontend"
 #: src/pages/settings/applications/tabs/SettingsApplicationFrontComponentSettingsTab.tsx
 #: src/pages/settings/applications/tabs/SettingsApplicationCommandMenuItemSettingsTab.tsx
 msgid "Front component"
-msgstr ""
+msgstr "Componente frontal"
 
 #. js-lingui-id: +M+QLN
 #: src/pages/settings/applications/SettingsApplicationDetails.tsx
 msgid "front components"
-msgstr ""
+msgstr "componentes frontales"
 
 #. js-lingui-id: IvIKDS
 #: src/pages/settings/applications/SettingsApplicationFrontComponentDetail.tsx
@@ -7702,12 +8149,12 @@ msgstr "Acceso total"
 #. js-lingui-id: Ld0Tt4
 #: src/modules/side-panel/components/hooks/usePageLayoutHeaderInfo.ts
 msgid "Full tab widget"
-msgstr ""
+msgstr "Widget de pestaña completa"
 
 #. js-lingui-id: YMZBxa
 #: src/pages/settings/security/event-logs/utils/getColumnsForEventLogTable.ts
 msgid "Function"
-msgstr ""
+msgstr "Función"
 
 #. js-lingui-id: AHOl4W
 #: src/modules/settings/logic-functions/components/SettingsLogicFunctionLabelContainer.tsx
@@ -7779,7 +8226,7 @@ msgstr "Obtener clave Enterprise"
 #. js-lingui-id: Et23WT
 #: src/modules/ai/components/AIChatNoMoreBillingCreditsBanner.tsx
 msgid "Get more credits"
-msgstr ""
+msgstr "Obtener más créditos"
 
 #. js-lingui-id: NXEW3h
 #: src/pages/onboarding/InviteTeam.tsx
@@ -7794,12 +8241,12 @@ msgstr "Obtenga su suscripción"
 #. js-lingui-id: XXtAx5
 #: src/modules/settings/data-model/indexes/forms/components/SettingsObjectIndexOptionsForm.tsx
 msgid "GIN (full-text search and JSONB)"
-msgstr ""
+msgstr "GIN (búsqueda de texto completo y JSONB)"
 
 #. js-lingui-id: lwDz5R
 #: src/modules/settings/data-model/object-details/components/tabs/SettingsObjectSearchSection.tsx
 msgid "Global search"
-msgstr ""
+msgstr "Búsqueda global"
 
 #. js-lingui-id: sr0UJD
 #: src/pages/settings/security/event-logs/SettingsEventLogs.tsx
@@ -7844,7 +8291,8 @@ msgstr "Google OIDC"
 #. js-lingui-id: 6eo66Q
 #: src/modules/settings/workspace/components/ToggleImpersonate.tsx
 msgid "Grant access to your workspace so we can troubleshoot problems."
-msgstr "Conceda acceso a su espacio de trabajo para que podamos resolver problemas."
+msgstr ""
+"Conceda acceso a su espacio de trabajo para que podamos resolver problemas."
 
 #. js-lingui-id: WUgtid
 #: src/modules/settings/roles/role-permissions/object-level-permissions/object-form/components/SettingsRolePermissionsObjectLevelObjectFormObjectLevelTableRow.tsx
@@ -7854,12 +8302,13 @@ msgstr "Concedido para este objeto"
 #. js-lingui-id: MkDC2z
 #: src/pages/settings/applications/SettingsApplicationConnectionDetail.tsx
 msgid "Granted OAuth scopes"
-msgstr ""
+msgstr "Ámbitos OAuth concedidos"
 
 #. js-lingui-id: fcUyLo
 #: src/modules/settings/roles/role-permissions/permission-flags/components/SettingsRolePermissionsToolSection.tsx
 msgid "Grants permission to perform all available actions without restriction"
-msgstr "Concede permiso para realizar todas las acciones disponibles sin restricción"
+msgstr ""
+"Concede permiso para realizar todas las acciones disponibles sin restricción"
 
 #. js-lingui-id: gBiL6J
 #: src/modules/settings/playground/components/PlaygroundSetupForm.tsx
@@ -7946,7 +8395,7 @@ msgstr "h3"
 #. js-lingui-id: Nf7oXL
 #: src/pages/settings/applications/SettingsApplicationConnectionDetail.tsx
 msgid "Handle"
-msgstr ""
+msgstr "Identificador"
 
 #. js-lingui-id: HUk3sK
 #: src/modules/workflow/workflow-steps/workflow-actions/http-request-action/components/WorkflowEditActionHttpRequest.tsx
@@ -7991,12 +8440,12 @@ msgstr "Encabezado 3"
 #. js-lingui-id: 6Ef36Q
 #: src/pages/settings/applications/tabs/SettingsApplicationFrontComponentSettingsTab.tsx
 msgid "Headless"
-msgstr ""
+msgstr "Sin interfaz"
 
 #. js-lingui-id: oEpvJo
 #: src/pages/settings/applications/tabs/SettingsApplicationFrontComponentPreviewTab.tsx
 msgid "Headless component"
-msgstr ""
+msgstr "Componente sin interfaz"
 
 #. js-lingui-id: UPqS9C
 #: src/modules/settings/admin-panel/components/SettingsAdminContent.tsx
@@ -8006,7 +8455,7 @@ msgstr "Salud"
 #. js-lingui-id: HyaXse
 #: src/pages/settings/admin-panel/SettingsAdminInstanceStatus.tsx
 msgid "Health of the latest instance command"
-msgstr ""
+msgstr "Salud del último comando de instancia"
 
 #. js-lingui-id: I1IOmb
 #: src/modules/settings/admin-panel/health-status/components/SettingsAdminHealthStatus.tsx
@@ -8070,12 +8519,12 @@ msgstr "Ocultar grupos ocultos"
 #. js-lingui-id: 2ouyMV
 #: src/modules/command-menu-item/edit/components/CommandMenuItemOptionsDropdown.tsx
 msgid "Hide label"
-msgstr ""
+msgstr "Ocultar etiqueta"
 
 #. js-lingui-id: y9sG4l
 #: src/modules/settings/data-model/object-details/components/tabs/SettingsObjectIndexesSection.tsx
 msgid "Hide system indexes"
-msgstr ""
+msgstr "Ocultar índices del sistema"
 
 #. js-lingui-id: i0qMbr
 #: src/modules/navigation/components/MainNavigationDrawerTabsRow.tsx
@@ -8086,7 +8535,7 @@ msgstr "Inicio"
 #: src/modules/side-panel/pages/page-layout/constants/GraphTypeInformation.ts
 #: src/modules/page-layout/utils/getWidgetTitle.ts
 msgid "Horizontal Bar Chart"
-msgstr ""
+msgstr "Gráfico de barras horizontales"
 
 #. js-lingui-id: WOXdI6
 #: src/pages/settings/applications/utils/getCustomApplicationDescription.ts
@@ -8115,6 +8564,29 @@ msgid ""
 "\n"
 "See the [Getting Started guide](https://twenty.com/developers/extend/apps/getting-started) for the full walkthrough, and [Building Apps](https://twenty.com/developers/extend/apps/building) for the `defineApplication` / `defineEntity` APIs."
 msgstr ""
+"Aloja las personalizaciones y anulaciones de tu espacio de trabajo.\n"
+"\n"
+"#### Qué incluye\n"
+"Cada extensión que creas sobre la aplicación estándar se agrupa bajo Personalizado. Mantiene tus cambios de esquema, de interfaz y la lógica específica del espacio de trabajo en un solo lugar.\n"
+"\n"
+"- Objetos y campos personalizados para tu propio modelo de datos\n"
+"- Vistas, elementos de navegación y diseños de registros que dan forma a cómo trabaja tu equipo\n"
+"- Funciones lógicas, componentes frontales y agentes que automatizan o extienden el espacio de trabajo\n"
+"\n"
+"#### Por qué existe\n"
+"Usa esta aplicación para personalización específica del espacio de trabajo que deba permanecer local.\n"
+"\n"
+"Si estás configurando un espacio de trabajo para un negocio, manténlo aquí. Si estás construyendo una aplicación de negocio reutilizable con su propio modelo de datos, interfaz y automatización que deba versionarse, compartirse o instalarse en varios espacios de trabajo, crea una aplicación dedicada en su lugar.\n"
+"\n"
+"#### Construye tu propia aplicación\n"
+"\n"
+"Crea una nueva aplicación con un solo comando:\n"
+"\n"
+"```bash\n"
+"npx create-twenty-app@latest my-twenty-app\n"
+"```\n"
+"\n"
+"Consulta la [guía de inicio](https://twenty.com/developers/extend/apps/getting-started) para el recorrido completo, y [Construyendo aplicaciones](https://twenty.com/developers/extend/apps/building) para las APIs `defineApplication` / `defineEntity`."
 
 #. js-lingui-id: yY8wAv
 #: src/modules/workflow/workflow-steps/workflow-actions/delay-actions/components/WorkflowEditActionDelay.tsx
@@ -8129,12 +8601,12 @@ msgstr "Horas entre activadores"
 #. js-lingui-id: xUNmcx
 #: src/modules/settings/billing/components/SettingsBillingCreditsSection.tsx
 msgid "How credits work"
-msgstr ""
+msgstr "Cómo funcionan los créditos"
 
 #. js-lingui-id: WC32k6
 #: src/pages/settings/applications/tabs/SettingsApplicationDetailContentTab.tsx
 msgid "How records, pages, and navigation are displayed"
-msgstr ""
+msgstr "Cómo se muestran los registros, páginas y navegación"
 
 #. js-lingui-id: B06Bgk
 #: src/pages/onboarding/CreateProfile.tsx
@@ -8151,7 +8623,7 @@ msgstr "Cómo está funcionando tu sistema"
 #: src/modules/settings/logic-functions/components/tabs/SettingsLogicFunctionTestTab.tsx
 #: src/modules/logic-functions/utils/getLogicFunctionTriggerLabel.ts
 msgid "HTTP"
-msgstr ""
+msgstr "HTTP"
 
 #. js-lingui-id: DUhAFW
 #: src/modules/workflow/workflow-trigger/components/WorkflowEditTriggerWebhookForm.tsx
@@ -8211,8 +8683,14 @@ msgstr "Húngaro"
 
 #. js-lingui-id: YUJ1ey
 #: src/modules/ai/components/suggested-prompts/default-suggested-prompts.ts
-msgid "I need a dashboard for lead conversion: number of new leads by source this month, how many moved to opportunity, and conversion rate by source. Include a simple table and a bar chart."
-msgstr "Necesito un panel de control para la conversión de leads: número de leads nuevos por fuente este mes, cuántos pasaron a oportunidad y la tasa de conversión por fuente. Incluye una tabla sencilla y un gráfico de barras."
+msgid ""
+"I need a dashboard for lead conversion: number of new leads by source this "
+"month, how many moved to opportunity, and conversion rate by source. Include"
+" a simple table and a bar chart."
+msgstr ""
+"Necesito un panel de control para la conversión de leads: número de leads "
+"nuevos por fuente este mes, cuántos pasaron a oportunidad y la tasa de "
+"conversión por fuente. Incluye una tabla sencilla y un gráfico de barras."
 
 #. js-lingui-id: VNC0Db
 #: src/modules/settings/admin-panel/ai/components/SettingsAdminAiProviderListCard.tsx
@@ -8227,12 +8705,12 @@ msgstr "Credenciales de IAM configuradas"
 #. js-lingui-id: LlQirF
 #: src/modules/settings/admin-panel/ai/components/SettingsAdminAiProviderListCard.tsx
 msgid "IAM role"
-msgstr ""
+msgstr "Rol IAM"
 
 #. js-lingui-id: VjDLrJ
 #: src/pages/settings/admin-panel/SettingsAdminAiProviderDetail.tsx
 msgid "IAM role (instance profile)"
-msgstr ""
+msgstr "Rol IAM (perfil de instancia)"
 
 #. js-lingui-id: wwu18a
 #: src/pages/settings/layout/SettingsLayoutViewDetail.tsx
@@ -8271,7 +8749,7 @@ msgstr "si"
 #. js-lingui-id: bTDz/2
 #: src/modules/settings/admin-panel/health-status/maintenance-mode/components/SettingsAdminMaintenanceMode.tsx
 msgid "If there's no link, no button will appear."
-msgstr ""
+msgstr "Si no hay enlace, no aparecerá ningún botón."
 
 #. js-lingui-id: ZfP/Ap
 #: src/modules/object-record/record-table/empty-state/components/RecordTableEmptyStateRemote.tsx
@@ -8280,13 +8758,23 @@ msgstr "Si esto es inesperado, por favor verifique su configuración."
 
 #. js-lingui-id: Yn4NZ1
 #: src/pages/settings/applications/tabs/SettingsApplicationRegistrationOAuthTab.tsx
-msgid "If you rotate this secret, any integration using the current secret will stop working. Please type \"{confirmationValue}\" to confirm."
-msgstr "Si rotas este secreto, cualquier integración que use el secreto actual dejará de funcionar. Escribe \"{confirmationValue}\" para confirmar."
+msgid ""
+"If you rotate this secret, any integration using the current secret will "
+"stop working. Please type \"{confirmationValue}\" to confirm."
+msgstr ""
+"Si rotas este secreto, cualquier integración que use el secreto actual "
+"dejará de funcionar. Escribe \"{confirmationValue}\" para confirmar."
 
 #. js-lingui-id: j843N3
 #: src/pages/settings/developers/api-keys/SettingsDevelopersApiKeyDetail.tsx
-msgid "If you’ve lost this key, you can regenerate it, but be aware that any script using this key will need to be updated. Please type\"{confirmationValue}\" to confirm."
-msgstr "Si ha perdido esta clave, puede regenerarla, pero tenga en cuenta que cualquier script que utilice esta clave deberá ser actualizado. Escriba \"{confirmationValue}\" para confirmar."
+msgid ""
+"If you’ve lost this key, you can regenerate it, but be aware that any script"
+" using this key will need to be updated. Please type\"{confirmationValue}\" "
+"to confirm."
+msgstr ""
+"Si ha perdido esta clave, puede regenerarla, pero tenga en cuenta que "
+"cualquier script que utilice esta clave deberá ser actualizado. Escriba "
+"\"{confirmationValue}\" para confirmar."
 
 #. js-lingui-id: KDMdBi
 #: src/modules/side-panel/pages/page-layout/components/SidePanelPageLayoutDashboardWidgetTypeSelect.tsx
@@ -8442,6 +8930,8 @@ msgstr "Bandeja de entrada"
 #: src/pages/settings/security/SettingsSecurity.tsx
 msgid "Include emails where all participants share the same domain."
 msgstr ""
+"Incluir correos electrónicos donde todos los participantes comparten el "
+"mismo dominio."
 
 #. js-lingui-id: mtGDyy
 #: src/pages/settings/enterprise/SettingsEnterprise.tsx
@@ -8461,12 +8951,12 @@ msgstr "Índice"
 #. js-lingui-id: O+81DP
 #: src/pages/settings/data-model/new-index/SettingsObjectNewIndex.tsx
 msgid "Index created"
-msgstr ""
+msgstr "Índice creado"
 
 #. js-lingui-id: R6uY2r
 #: src/modules/settings/data-model/object-details/components/tabs/SettingsObjectIndexesSection.tsx
 msgid "Index deleted"
-msgstr ""
+msgstr "Índice eliminado"
 
 #. js-lingui-id: pZ/USH
 #: src/modules/settings/data-model/object-details/components/tabs/ObjectSettings.tsx
@@ -8480,7 +8970,7 @@ msgstr "Índices"
 #: src/modules/settings/admin-panel/health-status/components/SettingsAdminUpgradeStatusListCard.tsx
 #: src/modules/settings/admin-panel/components/SettingsAdminWorkspaceContent.tsx
 msgid "Inferred version"
-msgstr ""
+msgstr "Versión inferida"
 
 #. js-lingui-id: CE+M2e
 #: src/pages/settings/admin-panel/SettingsAdminWorkspaceDetail.tsx
@@ -8490,8 +8980,12 @@ msgstr "Información"
 
 #. js-lingui-id: iaXnN5
 #: src/pages/settings/ai/SettingsAiPrompts.tsx
-msgid "Information about the current user (auto-generated and included in each request)"
-msgstr "Información sobre el usuario actual (generada automáticamente e incluida en cada solicitud)"
+msgid ""
+"Information about the current user (auto-generated and included in each "
+"request)"
+msgstr ""
+"Información sobre el usuario actual (generada automáticamente e incluida en "
+"cada solicitud)"
 
 #. js-lingui-id: 623chP
 #: src/pages/settings/members/SettingsWorkspaceMember.tsx
@@ -8513,7 +9007,7 @@ msgstr "Entrada"
 #. js-lingui-id: /OdOC/
 #: src/modules/workflow/workflow-steps/workflow-actions/ai-agent-action/components/WorkflowAiAgentPromptTab.tsx
 msgid "Input (Prompt)"
-msgstr ""
+msgstr "Entrada (Indicación)"
 
 #. js-lingui-id: JE2tjr
 #: src/pages/settings/ai/SettingsSkillForm.tsx
@@ -8525,7 +9019,7 @@ msgstr "La entrada debe estar en camel case y no puede comenzar con un número"
 #. js-lingui-id: VmBcTm
 #: src/pages/settings/ai/SettingsToolDetail.tsx
 msgid "Input parameters accepted by this tool"
-msgstr ""
+msgstr "Parámetros de entrada aceptados por esta herramienta"
 
 #. js-lingui-id: /6i28D
 #: src/modules/workflow/workflow-steps/workflow-actions/form-action/components/WorkflowEditActionFormFieldSettings.tsx
@@ -8541,7 +9035,7 @@ msgstr "Tokens de entrada"
 #. js-lingui-id: Dlxuac
 #: src/modules/settings/logic-functions/components/tabs/SettingsLogicFunctionTestTab.tsx
 msgid "Insert a JSON input, then press \"Run Function\"."
-msgstr ""
+msgstr "Introduce una entrada JSON, luego presiona \"Ejecutar función\"."
 
 #. js-lingui-id: TKQ7K+
 #: src/pages/settings/applications/tabs/SettingsApplicationDetailAboutTab.tsx
@@ -8552,7 +9046,7 @@ msgstr "Instalar"
 #. js-lingui-id: XOHdRf
 #: src/modules/marketplace/components/SettingsApplicationInstallPermissionValidationModal.tsx
 msgid "Install {appDisplayName} on your workspace"
-msgstr ""
+msgstr "Instalar {appDisplayName} en tu espacio de trabajo"
 
 #. js-lingui-id: 4ZM8/a
 #: src/modules/settings/roles/role-permissions/permission-flags/hooks/useSettingsRolePermissionFlagConfig.ts
@@ -8574,7 +9068,7 @@ msgstr "Instalada"
 #. js-lingui-id: OMxM9j
 #: src/pages/settings/applications/components/SettingsApplicationsTable.tsx
 msgid "Installed apps"
-msgstr ""
+msgstr "Aplicaciones instaladas"
 
 #. js-lingui-id: wJJ+Wy
 #: src/pages/settings/applications/tabs/SettingsApplicationDetailAboutTab.tsx
@@ -8587,7 +9081,7 @@ msgstr "Instalando..."
 #: src/pages/settings/admin-panel/SettingsAdminInstanceStatus.tsx
 #: src/modules/settings/admin-panel/health-status/components/SettingsAdminUpgradeStatusListCard.tsx
 msgid "Instance status"
-msgstr ""
+msgstr "Estado de la instancia"
 
 #. js-lingui-id: AwUsnG
 #: src/pages/settings/data-model/constants/SettingsObjectTableMetadata.ts
@@ -8597,7 +9091,7 @@ msgstr "Instancias"
 #. js-lingui-id: tc328m
 #: src/modules/workflow/workflow-steps/workflow-actions/ai-agent-action/components/WorkflowOutputSchemaBuilder.tsx
 msgid "Instruction for AI"
-msgstr ""
+msgstr "Instrucción para la IA"
 
 #. js-lingui-id: NxHkkp
 #: src/pages/settings/ai/SettingsSkillForm.tsx
@@ -8647,7 +9141,8 @@ msgstr "Configuración no válida"
 #. js-lingui-id: fSwqXe
 #: src/modules/page-layout/widgets/components/PageLayoutWidgetInvalidConfigDisplay.tsx
 msgid "Invalid configuration. Click edit to configure this widget."
-msgstr "Configuración no válida. Haga clic en editar para configurar este widget."
+msgstr ""
+"Configuración no válida. Haga clic en editar para configurar este widget."
 
 #. js-lingui-id: ER/0YT
 #: src/modules/workflow/workflow-trigger/utils/getTriggerScheduleDescription.ts
@@ -8666,13 +9161,24 @@ msgstr "Valor de día no válido '{newDay}'. Debe ser un entero mayor que 1"
 
 #. js-lingui-id: u3hwhx
 #: src/modules/settings/domains/utils/getDomainValidationSchema.ts
-msgid "Invalid domain. Domains have to be smaller than 256 characters in length, cannot be IP addresses, cannot contain spaces, cannot contain any special characters such as _~`!@#$%^*()=+{}[]|\\;:'\",<>/? and cannot begin or end with a '-' character."
-msgstr "Dominio no válido. Los dominios deben tener menos de 256 caracteres de longitud, no pueden ser direcciones IP, no pueden contener espacios, no pueden contener caracteres especiales como _~`!@#$%^*()=+{}[]|\\;:'\",<>/? y no pueden comenzar ni terminar con un carácter '-'."
+msgid ""
+"Invalid domain. Domains have to be smaller than 256 characters in length, "
+"cannot be IP addresses, cannot contain spaces, cannot contain any special "
+"characters such as _~`!@#$%^*()=+{}[]|\\;:'\",<>/? and cannot begin or end "
+"with a '-' character."
+msgstr ""
+"Dominio no válido. Los dominios deben tener menos de 256 caracteres de "
+"longitud, no pueden ser direcciones IP, no pueden contener espacios, no "
+"pueden contener caracteres especiales como _~`!@#$%^*()=+{}[]|\\;:'\",<>/? y"
+" no pueden comenzar ni terminar con un carácter '-'."
 
 #. js-lingui-id: Vxmaf0
 #: src/modules/settings/domains/utils/getDomainValidationSchema.ts
-msgid "Invalid domain. Please include at least one subdomain (e.g., sub.example.com)."
-msgstr "Dominio no válido. Incluya al menos un subdominio (p. ej., sub.example.com)."
+msgid ""
+"Invalid domain. Please include at least one subdomain (e.g., "
+"sub.example.com)."
+msgstr ""
+"Dominio no válido. Incluya al menos un subdominio (p. ej., sub.example.com)."
 
 #. js-lingui-id: B2Tpo0
 #: src/modules/auth/sign-in-up/hooks/useHandleResetPassword.ts
@@ -8699,23 +9205,29 @@ msgstr "Archivo no válido"
 #. js-lingui-id: 04zLGG
 #: src/modules/workflow/workflow-trigger/components/WorkflowEditTriggerCronForm.tsx
 msgid "Invalid hour value '{newHour}'. Should be integer between 0 and 23"
-msgstr "Valor de hora inválido '{newHour}'. Debe ser un número entero entre 0 y 23"
+msgstr ""
+"Valor de hora inválido '{newHour}'. Debe ser un número entero entre 0 y 23"
 
 #. js-lingui-id: fLMLtY
 #: src/modules/workflow/workflow-trigger/components/WorkflowEditTriggerCronForm.tsx
 msgid "Invalid hour value '{newHour}'. Should be integer greater than 1"
-msgstr "Valor de hora inválido '{newHour}'. Debe ser un número entero mayor que 1"
+msgstr ""
+"Valor de hora inválido '{newHour}'. Debe ser un número entero mayor que 1"
 
 #. js-lingui-id: +Yi3bs
 #: src/modules/workflow/workflow-trigger/components/WorkflowEditTriggerCronForm.tsx
 #: src/modules/workflow/workflow-trigger/components/WorkflowEditTriggerCronForm.tsx
 msgid "Invalid minute value '{newMinute}'. Should be integer between 0 and 59"
-msgstr "Valor de minuto inválido '{newMinute}'. Debe ser un número entero entre 0 y 59"
+msgstr ""
+"Valor de minuto inválido '{newMinute}'. Debe ser un número entero entre 0 y "
+"59"
 
 #. js-lingui-id: 942L1w
 #: src/modules/workflow/workflow-trigger/components/WorkflowEditTriggerCronForm.tsx
 msgid "Invalid minute value '{newMinute}'. Should be integer greater than 1"
-msgstr "Valor de minuto inválido '{newMinute}'. Debe ser un número entero mayor que 1"
+msgstr ""
+"Valor de minuto inválido '{newMinute}'. Debe ser un número entero mayor que "
+"1"
 
 #. js-lingui-id: WY8amq
 #: src/modules/object-record/record-field/ui/form-types/components/FormNumberFieldInput.tsx
@@ -8961,7 +9473,7 @@ msgstr "Únete al equipo de {workspaceName}"
 #. js-lingui-id: B2Zb/F
 #: src/pages/settings/ai/components/SettingsAgentResponseFormat.tsx
 msgid "JSON"
-msgstr ""
+msgstr "JSON"
 
 #. js-lingui-id: UpNpMK
 #: src/pages/settings/applications/SettingsApplicationConnectionDetail.tsx
@@ -8969,7 +9481,7 @@ msgstr ""
 #: src/pages/settings/applications/tabs/SettingsApplicationConnectionsSection.tsx
 #: src/pages/settings/applications/components/SettingsApplicationConnectScopePickerModal.tsx
 msgid "Just for me"
-msgstr ""
+msgstr "Solo para mí"
 
 #. js-lingui-id: OGXtL8
 #: src/modules/views/view-picker/constants/ViewPickerTypeSelectOptions.ts
@@ -8986,12 +9498,12 @@ msgstr "Clave"
 #. js-lingui-id: wCSQOc
 #: src/modules/settings/admin-panel/signing-keys/components/SettingsAdminSigningKeysTable.tsx
 msgid "Key ID"
-msgstr ""
+msgstr "ID de clave"
 
 #. js-lingui-id: Gtjqi6
 #: src/modules/settings/admin-panel/signing-keys/components/SettingsAdminSigningKeysTable.tsx
 msgid "Key ID copied"
-msgstr ""
+msgstr "ID de clave copiado"
 
 #. js-lingui-id: VOAmkS
 #: src/modules/workflow/workflow-steps/workflow-actions/http-request-action/components/BodyInput.tsx
@@ -9060,12 +9572,14 @@ msgstr "Última 1 Hora (del más antiguo → al más nuevo)"
 #. js-lingui-id: YoKFgq
 #: src/modules/settings/admin-panel/components/SettingsAdminGeneral.tsx
 msgid "Last 10 users created. Click to impersonate."
-msgstr ""
+msgstr "Últimos 10 usuarios creados. Haz clic para suplantar."
 
 #. js-lingui-id: sgqwjE
 #: src/modules/settings/admin-panel/components/SettingsAdminGeneral.tsx
 msgid "Last 10 users created. Click to manage feature flags or impersonate."
 msgstr ""
+"Últimos 10 usuarios creados. Haz clic para gestionar indicadores de "
+"funciones o suplantar."
 
 #. js-lingui-id: XUlP/Y
 #: src/modules/settings/admin-panel/health-status/constants/WorkerQueueMetricsSelectOptions.ts
@@ -9116,25 +9630,25 @@ msgstr "Últimos 90 días"
 #: src/modules/ai/components/AiChatThreadFilterDropdownRootMenu.tsx
 #: src/modules/ai/components/AiChatThreadFilterDropdownLastActivityMenu.tsx
 msgid "Last activity"
-msgstr ""
+msgstr "Última actividad"
 
 #. js-lingui-id: IpCCj8
 #: src/pages/settings/admin-panel/SettingsAdminInstanceStatus.tsx
 #: src/modules/settings/admin-panel/components/SettingsAdminWorkspaceContent.tsx
 msgid "Last command"
-msgstr ""
+msgstr "Último comando"
 
 #. js-lingui-id: cdB4EG
 #: src/pages/settings/admin-panel/SettingsAdminInstanceStatus.tsx
 #: src/modules/settings/admin-panel/components/SettingsAdminWorkspaceContent.tsx
 msgid "Last command result"
-msgstr ""
+msgstr "Resultado del último comando"
 
 #. js-lingui-id: wW6NCp
 #: src/pages/settings/admin-panel/SettingsAdminInstanceStatus.tsx
 #: src/modules/settings/admin-panel/components/SettingsAdminWorkspaceContent.tsx
 msgid "Last error"
-msgstr ""
+msgstr "Último error"
 
 #. js-lingui-id: c5zxSg
 #: src/modules/ai/components/internal/AiChatContextUsageButton.tsx
@@ -9150,7 +9664,7 @@ msgstr "Último mensaje {lastMessageSentAtFormatted}"
 #: src/modules/settings/members/components/MemberNameFields.tsx
 #: src/modules/object-metadata/hooks/useSortSubFieldChoicesForField.ts
 msgid "Last name"
-msgstr ""
+msgstr "Apellido"
 
 #. js-lingui-id: UXBCwc
 #: src/pages/onboarding/CreateProfile.tsx
@@ -9178,18 +9692,18 @@ msgstr "El último pago falló. Por favor, actualice sus datos de facturación."
 #. js-lingui-id: uPb/1Y
 #: src/pages/settings/applications/SettingsApplicationConnectionDetail.tsx
 msgid "Last refreshed"
-msgstr ""
+msgstr "Última actualización"
 
 #. js-lingui-id: NYwqoV
 #: src/pages/settings/applications/SettingsApplicationConnectionDetail.tsx
 msgid "Last signed in"
-msgstr ""
+msgstr "Último inicio de sesión"
 
 #. js-lingui-id: C3yOz3
 #: src/pages/settings/admin-panel/SettingsAdminInstanceStatus.tsx
 #: src/modules/settings/admin-panel/components/SettingsAdminWorkspaceContent.tsx
 msgid "Last updated"
-msgstr ""
+msgstr "Última actualización"
 
 #. js-lingui-id: wL3cK8
 #: src/modules/settings/applications/components/SettingsApplicationAboutSidebar.tsx
@@ -9212,7 +9726,7 @@ msgstr "Última versión"
 #. js-lingui-id: Q7hYLw
 #: src/modules/object-metadata/hooks/useSortSubFieldChoicesForField.ts
 msgid "Latitude"
-msgstr ""
+msgstr "Latitud"
 
 #. js-lingui-id: ZEP8tT
 #: src/modules/settings/playground/components/PlaygroundSetupForm.tsx
@@ -9244,13 +9758,13 @@ msgstr "Personalización del diseño"
 #. js-lingui-id: euTsq6
 #: src/modules/layout-customization/components/LayoutCustomizationBarMenuDropdown.tsx
 msgid "Layout customization menu"
-msgstr ""
+msgstr "Menú de personalización de diseño"
 
 #. js-lingui-id: uQ0+Yc
 #. placeholder {0}: tab.layoutMode
 #: src/pages/settings/layout/SettingsLayoutPageLayoutDetail.tsx
 msgid "Layout mode: {0}"
-msgstr ""
+msgstr "Modo de diseño: {0}"
 
 #. js-lingui-id: yU0QVO
 #: src/modules/settings/roles/role-permissions/permission-flags/hooks/useSettingsRolePermissionFlagConfig.ts
@@ -9308,22 +9822,22 @@ msgstr "Abandonar el espacio de trabajo"
 #. js-lingui-id: Sn1jT8
 #: src/modules/settings/admin-panel/signing-keys/components/SettingsAdminSigningKeysTable.tsx
 msgid "Legacy"
-msgstr ""
+msgstr "Heredado"
 
 #. js-lingui-id: CpT2ez
 #: src/modules/settings/admin-panel/signing-keys/components/SettingsAdminSigningKeysTable.tsx
 msgid "Legacy (HS256)"
-msgstr ""
+msgstr "Heredado (HS256)"
 
 #. js-lingui-id: KZ7vMS
 #: src/modules/settings/admin-panel/signing-keys/components/SettingsAdminSigningKeysTable.tsx
 msgid "Legacy HS256 verifications across all tokens"
-msgstr ""
+msgstr "Verificaciones HS256 heredadas en todos los tokens"
 
 #. js-lingui-id: MP1v+1
 #: src/modules/side-panel/pages/page-layout/constants/settings/ChartConfigurationSettingLabels.ts
 msgid "Legend"
-msgstr ""
+msgstr "Leyenda"
 
 #. js-lingui-id: 8PPI2g
 #: src/modules/object-record/object-filter-dropdown/utils/getOperandLabel.ts
@@ -9333,7 +9847,7 @@ msgstr "Menor o igual"
 #. js-lingui-id: oCHfGC
 #: src/pages/settings/security/event-logs/utils/getColumnsForEventLogTable.ts
 msgid "Level"
-msgstr ""
+msgstr "Nivel"
 
 #. js-lingui-id: 3qg5Ro
 #: src/pages/settings/enterprise/SettingsEnterprise.tsx
@@ -9545,7 +10059,9 @@ msgstr "Configuración regional"
 #. js-lingui-id: B6ANJW
 #: src/modules/ai/components/suggested-prompts/default-suggested-prompts.ts
 msgid "Log a new deal (company, amount, stage, expected close). Details: "
-msgstr "Registra una nueva oportunidad (empresa, importe, etapa, fecha de cierre prevista). Detalles: "
+msgstr ""
+"Registra una nueva oportunidad (empresa, importe, etapa, fecha de cierre "
+"prevista). Detalles: "
 
 #. js-lingui-id: FgAxTj
 #: src/pages/onboarding/internal/ChooseYourPlanContent.tsx
@@ -9567,7 +10083,7 @@ msgstr "Conectado como {impersonatedUser}"
 #. js-lingui-id: wuCnq1
 #: src/pages/settings/applications/tabs/SettingsApplicationDetailContentTab.tsx
 msgid "Logic"
-msgstr ""
+msgstr "Lógica"
 
 #. js-lingui-id: sTlKkx
 #: src/pages/settings/applications/SettingsAvailableApplicationDetails.tsx
@@ -9580,19 +10096,22 @@ msgstr "función de lógica"
 #: src/pages/settings/applications/SettingsAvailableApplicationDetails.tsx
 #: src/pages/settings/applications/SettingsApplicationDetails.tsx
 msgid "logic functions"
-msgstr ""
+msgstr "funciones lógicas"
 
 #. js-lingui-id: QTVVDd
 #: src/pages/settings/logic-functions/SettingsLogicFunctionDetail.tsx
 #: src/pages/settings/logic-functions/SettingsLogicFunctionDetail.tsx
 #: src/pages/settings/applications/tabs/SettingsApplicationDetailContentTab.tsx
 msgid "Logic functions"
-msgstr ""
+msgstr "Funciones lógicas"
 
 #. js-lingui-id: VLuNNu
 #: src/modules/auth/components/TwoFactorAuthenticationProvisionEffect.tsx
-msgid "Login token missing. Two Factor Authentication setup can not be initiated."
-msgstr "Token de inicio de sesión faltante. No se puede iniciar la configuración de la Autenticación de Dos Factores."
+msgid ""
+"Login token missing. Two Factor Authentication setup can not be initiated."
+msgstr ""
+"Token de inicio de sesión faltante. No se puede iniciar la configuración de "
+"la Autenticación de Dos Factores."
 
 #. js-lingui-id: nOhz3x
 #: src/modules/settings/hooks/useSettingsNavigationItems.tsx
@@ -9609,7 +10128,7 @@ msgstr "Registros"
 #. js-lingui-id: FJBbw5
 #: src/modules/object-metadata/hooks/useSortSubFieldChoicesForField.ts
 msgid "Longitude"
-msgstr ""
+msgstr "Longitud"
 
 #. js-lingui-id: tL2lBI
 #: src/modules/workflow/workflow-diagram/utils/generateNodesAndEdgesForIteratorNode.ts
@@ -9624,28 +10143,28 @@ msgstr "Cuenta de Correo"
 #. js-lingui-id: 6Dd2PM
 #: src/modules/settings/admin-panel/health-status/maintenance-mode/components/SettingsAdminMaintenanceMode.tsx
 msgid "Maintenance"
-msgstr ""
+msgstr "Mantenimiento"
 
 #. js-lingui-id: /hmUGb
 #: src/modules/settings/admin-panel/health-status/maintenance-mode/components/SettingsAdminMaintenanceMode.tsx
 msgid "Maintenance mode"
-msgstr ""
+msgstr "Modo de mantenimiento"
 
 #. js-lingui-id: MOLprz
 #: src/modules/settings/roles/role-permissions/permission-flags/hooks/useActionRolePermissionFlagConfig.ts
 msgid "Make HTTP requests to external APIs"
-msgstr ""
+msgstr "Realizar solicitudes HTTP a APIs externas"
 
 #. js-lingui-id: icpEdc
 #: src/pages/settings/applications/SettingsApplicationConnectionDetail.tsx
 msgid "Make private"
-msgstr ""
+msgstr "Hacer privado"
 
 #. js-lingui-id: wckWOP
 #: src/modules/side-panel/pages/page-layout/components/WidgetSettingsManageSection.tsx
 #: src/modules/side-panel/pages/page-layout/components/CanvasTabSettingsContent.tsx
 msgid "Manage"
-msgstr ""
+msgstr "Gestionar"
 
 #. js-lingui-id: n0FHLv
 #: src/modules/settings/roles/role-permissions/permission-flags/hooks/useSettingsRolePermissionFlagConfig.ts
@@ -9668,7 +10187,7 @@ msgstr "Administrar la información de facturación"
 #. placeholder {0}: provider.displayName
 #: src/pages/settings/applications/tabs/SettingsApplicationConnectionsSection.tsx
 msgid "Manage connections used by this app to call {0}."
-msgstr ""
+msgstr "Gestionar conexiones usadas por esta aplicación para llamar a {0}."
 
 #. js-lingui-id: U8dG4j
 #: src/modules/views/view-picker/components/ViewPickerOptionDropdown.tsx
@@ -9679,7 +10198,7 @@ msgstr "Gestionar favorito"
 #. js-lingui-id: Dt05oz
 #: src/pages/settings/admin-panel/SettingsAdminWorkspaceDetail.tsx
 msgid "Manage feature flags for this workspace"
-msgstr ""
+msgstr "Gestionar indicadores de funciones para este espacio de trabajo"
 
 #. js-lingui-id: T6YjCk
 #: src/pages/settings/members/tabs/SettingsWorkspaceMembersTeamTab.tsx
@@ -9704,7 +10223,7 @@ msgstr "Gestione aquí los miembros de su espacio de trabajo"
 #. js-lingui-id: 5UjiOC
 #: src/pages/settings/applications/SettingsApplicationConnectionDetail.tsx
 msgid "Manage this application's OAuth connection."
-msgstr ""
+msgstr "Gestionar la conexión OAuth de esta aplicación."
 
 #. js-lingui-id: /berfj
 #: src/modules/settings/roles/role-permissions/permission-flags/hooks/useActionRolePermissionFlagConfig.ts
@@ -9724,7 +10243,7 @@ msgstr "Gestione sus cuentas de internet."
 #. js-lingui-id: waFx9W
 #: src/pages/settings/ai/components/SettingsToolsTable.tsx
 msgid "Managed"
-msgstr ""
+msgstr "Gestionado"
 
 #. js-lingui-id: BWTzAb
 #: src/modules/side-panel/pages/page-layout/hooks/useGraphXSortOptionLabels.ts
@@ -9756,8 +10275,12 @@ msgstr "Máx"
 
 #. js-lingui-id: HFjNu6
 #: src/modules/spreadsheet-import/steps/components/UploadStep/components/DropZone.tsx
-msgid "Max import capacity: {formatSpreadsheetMaxRecordImportCapacity} records. Otherwise, consider splitting your file or using the API."
-msgstr "Capacidad máxima de importación: {formatSpreadsheetMaxRecordImportCapacity} registros. De lo contrario, considere dividir su archivo o usar la API."
+msgid ""
+"Max import capacity: {formatSpreadsheetMaxRecordImportCapacity} records. "
+"Otherwise, consider splitting your file or using the API."
+msgstr ""
+"Capacidad máxima de importación: {formatSpreadsheetMaxRecordImportCapacity} "
+"registros. De lo contrario, considere dividir su archivo o usar la API."
 
 #. js-lingui-id: S8w4XA
 #: src/pages/settings/admin-panel/SettingsAdminNewAiModel.tsx
@@ -9836,7 +10359,7 @@ msgstr "Miembro de"
 #. js-lingui-id: cNIHA/
 #: src/pages/settings/members/SettingsWorkspaceMember.tsx
 msgid "Member removed from workspace"
-msgstr ""
+msgstr "Miembro eliminado del espacio de trabajo"
 
 #. js-lingui-id: wlQNTg
 #: src/pages/settings/security/SettingsSecurityApprovedAccessDomain.tsx
@@ -9882,7 +10405,7 @@ msgstr "Fusionando..."
 #. js-lingui-id: xDAtGP
 #: src/pages/settings/security/event-logs/utils/getColumnsForEventLogTable.ts
 msgid "Message"
-msgstr ""
+msgstr "Mensaje"
 
 #. js-lingui-id: U15XwX
 #: src/modules/activities/timeline-activities/rows/message/components/EventCardMessage.tsx
@@ -9896,13 +10419,18 @@ msgstr "Sincronización de mensajes"
 
 #. js-lingui-id: i2zgN4
 #: src/modules/settings/admin-panel/health-status/components/SettingsAdminConnectedAccountHealthStatus.tsx
-msgid "Message Sync and Calendar Sync are not available because the service is down"
-msgstr "La sincronización de mensajes y calendario no están disponibles porque el servicio está inactivo"
+msgid ""
+"Message Sync and Calendar Sync are not available because the service is down"
+msgstr ""
+"La sincronización de mensajes y calendario no están disponibles porque el "
+"servicio está inactivo"
 
 #. js-lingui-id: VRi9O8
 #: src/modules/settings/admin-panel/health-status/components/SettingsAdminConnectedAccountHealthStatus.tsx
 msgid "Message Sync is not available because the service is down"
-msgstr "La sincronización de mensajes no está disponible porque el servicio está inactivo"
+msgstr ""
+"La sincronización de mensajes no está disponible porque el servicio está "
+"inactivo"
 
 #. js-lingui-id: t7TeQU
 #: src/pages/settings/ai/SettingsAgentTurnDetail.tsx
@@ -9954,8 +10482,13 @@ msgstr "Menta"
 
 #. js-lingui-id: G6wJK8
 #: src/modules/workflow/workflow-trigger/components/WorkflowEditTriggerCronForm.tsx
-msgid "Minute value cannot exceed 60. For intervals greater than 60 minutes, use the \"Hours\" trigger type or a custom cron expression"
-msgstr "El valor de los minutos no puede exceder 60. Para intervalos superiores a 60 minutos, usa el tipo de activación \"Horas\" o una expresión cron personalizada"
+msgid ""
+"Minute value cannot exceed 60. For intervals greater than 60 minutes, use "
+"the \"Hours\" trigger type or a custom cron expression"
+msgstr ""
+"El valor de los minutos no puede exceder 60. Para intervalos superiores a 60"
+" minutos, usa el tipo de activación \"Horas\" o una expresión cron "
+"personalizada"
 
 #. js-lingui-id: agRWc1
 #: src/modules/workflow/workflow-steps/workflow-actions/delay-actions/components/WorkflowEditActionDelay.tsx
@@ -9981,12 +10514,12 @@ msgstr "¡Misión cumplida!"
 #: src/modules/side-panel/pages/page-layout/hooks/useVisibilityLabels.ts
 #: src/modules/side-panel/pages/page-layout/hooks/useTranslatedVisibilityLabel.ts
 msgid "Mobile"
-msgstr ""
+msgstr "Móvil"
 
 #. js-lingui-id: scu3wk
 #: src/modules/workflow/workflow-steps/workflow-actions/ai-agent-action/components/WorkflowAiAgentPromptTab.tsx
 msgid "Model"
-msgstr ""
+msgstr "Modelo"
 
 #. js-lingui-id: bC/dq9
 #. placeholder {0}: values.label.trim()
@@ -10024,7 +10557,9 @@ msgstr "Modelos disponibles en el selector de modelos del chat"
 #. js-lingui-id: tNFUgB
 #: src/pages/settings/admin-panel/SettingsAdminAiProviderDetail.tsx
 msgid "Models for this provider. Toggle to enable or disable."
-msgstr "Modelos para este proveedor. Usa el interruptor para habilitarlos o deshabilitarlos."
+msgstr ""
+"Modelos para este proveedor. Usa el interruptor para habilitarlos o "
+"deshabilitarlos."
 
 #. js-lingui-id: hty0d5
 #: src/pages/settings/profile/appearance/components/DateTimeSettingsCalendarStartDaySelect.tsx
@@ -10035,12 +10570,16 @@ msgstr "Lunes"
 #. js-lingui-id: 8g3Cgz
 #: src/modules/settings/admin-panel/health-status/components/SettingsAdminConnectedAccountHealthStatus.tsx
 msgid "Monitor the execution of your calendar events sync job"
-msgstr "Monitorea la ejecución de tu trabajo de sincronización de eventos del calendario"
+msgstr ""
+"Monitorea la ejecución de tu trabajo de sincronización de eventos del "
+"calendario"
 
 #. js-lingui-id: IL/nIb
 #: src/modules/settings/admin-panel/health-status/components/SettingsAdminConnectedAccountHealthStatus.tsx
 msgid "Monitor the execution of your emails sync job"
-msgstr "Monitorea la ejecución de tu trabajo de sincronización de correos electrónicos"
+msgstr ""
+"Monitorea la ejecución de tu trabajo de sincronización de correos "
+"electrónicos"
 
 #. js-lingui-id: kY2ll9
 #: src/modules/settings/billing/hooks/useBillingWording.ts
@@ -10070,13 +10609,13 @@ msgstr "mensual"
 #: src/modules/settings/enterprise/components/EnterprisePlanModal.tsx
 #: src/modules/settings/admin-panel/components/SettingsAdminWorkspaceBillingContent.tsx
 msgid "Monthly"
-msgstr ""
+msgstr "Mensual"
 
 #. js-lingui-id: 6jefe3
 #: src/modules/side-panel/pages/page-layout/utils/getDateGranularityPluralLabel.ts
 #: src/modules/side-panel/pages/page-layout/utils/getDateGranularityPluralLabel.ts
 msgid "months"
-msgstr ""
+msgstr "meses"
 
 #. js-lingui-id: 2FYpfJ
 #: src/pages/settings/ai/SettingsAI.tsx
@@ -10126,7 +10665,7 @@ msgstr "Mover hacia abajo"
 #. js-lingui-id: bAvovP
 #: src/modules/side-panel/pages/page-layout/components/WidgetSettingsPlacementSection.tsx
 msgid "Move Down"
-msgstr ""
+msgstr "Mover abajo"
 
 #. js-lingui-id: iSLA/r
 #: src/modules/side-panel/pages/page-layout/components/RegularTabSettingsContent.tsx
@@ -10152,7 +10691,7 @@ msgstr "Mover a una carpeta"
 #. js-lingui-id: TH+XKl
 #: src/modules/side-panel/pages/page-layout/components/WidgetSettingsPlacementSection.tsx
 msgid "Move to another tab"
-msgstr ""
+msgstr "Mover a otra pestaña"
 
 #. js-lingui-id: JCPOml
 #: src/modules/navigation-menu-item/edit/side-panel/components/SidePanelEditOrganizeActions.tsx
@@ -10167,7 +10706,7 @@ msgstr "Mover hacia arriba"
 #. js-lingui-id: Bpglf1
 #: src/modules/side-panel/pages/page-layout/components/WidgetSettingsPlacementSection.tsx
 msgid "Move Up"
-msgstr ""
+msgstr "Mover arriba"
 
 #. js-lingui-id: asWVA5
 #: src/modules/object-record/spreadsheet-import/utils/getSpreadSheetFieldValidationDefinitions.ts
@@ -10176,13 +10715,23 @@ msgstr "debe ser un número"
 
 #. js-lingui-id: qJVW/e
 #: src/modules/object-record/spreadsheet-import/utils/getSpreadSheetFieldValidationDefinitions.ts
-msgid "must be an array of object with valid phone, calling code and country code (format: '[{\"number\":\"123456789\", \"callingCode\":\"+33\", \"countryCode\":\"FR\"}]')"
-msgstr "debe ser un arreglo de objetos con teléfono válido, código de llamada y código de país (formato: '[{\"number\":\"123456789\", \"callingCode\":\"+33\", \"countryCode\":\"FR\"}]')"
+msgid ""
+"must be an array of object with valid phone, calling code and country code "
+"(format: '[{\"number\":\"123456789\", \"callingCode\":\"+33\", "
+"\"countryCode\":\"FR\"}]')"
+msgstr ""
+"debe ser un arreglo de objetos con teléfono válido, código de llamada y "
+"código de país (formato: '[{\"number\":\"123456789\", "
+"\"callingCode\":\"+33\", \"countryCode\":\"FR\"}]')"
 
 #. js-lingui-id: hTW2Fw
 #: src/modules/object-record/spreadsheet-import/utils/getSpreadSheetFieldValidationDefinitions.ts
-msgid "must be an array of object with valid url and label (format: '[{\"url\":\"valid.url\", \"label\":\"label value\")}]'"
-msgstr "debe ser un arreglo de objetos con URL y etiqueta válidos (formato: '[{\"url\":\"valid.url\", \"label\":\"valor de la etiqueta\")}]')"
+msgid ""
+"must be an array of object with valid url and label (format: "
+"'[{\"url\":\"valid.url\", \"label\":\"label value\")}]'"
+msgstr ""
+"debe ser un arreglo de objetos con URL y etiqueta válidos (formato: "
+"'[{\"url\":\"valid.url\", \"label\":\"valor de la etiqueta\")}]')"
 
 #. js-lingui-id: 5rovyq
 #: src/modules/object-record/spreadsheet-import/utils/getSpreadSheetFieldValidationDefinitions.ts
@@ -10192,7 +10741,7 @@ msgstr "debe ser un arreglo de correos electrónicos válidos"
 #. js-lingui-id: OJCJh9
 #: src/pages/settings/applications/tabs/SettingsApplicationsDeveloperTab.tsx
 msgid "My apps"
-msgstr ""
+msgstr "Mis aplicaciones"
 
 #. js-lingui-id: XTGSZU
 #: src/modules/views/view-picker/components/ViewPickerListContent.tsx
@@ -10211,11 +10760,10 @@ msgstr "mySkill"
 #: src/modules/settings/admin-panel/components/SettingsAdminWorkspaceContent.tsx
 #: src/modules/settings/admin-panel/components/SettingsAdminWorkspaceContent.tsx
 msgid "N/A"
-msgstr ""
+msgstr "N/D"
 
 #. js-lingui-id: 6YtxFj
-#: src/testing/mock-data/tableData.ts
-#: src/pages/settings/SettingsWorkspace.tsx
+#: src/testing/mock-data/tableData.ts src/pages/settings/SettingsWorkspace.tsx
 #: src/pages/settings/SettingsProfile.tsx
 #: src/pages/settings/members/tabs/SettingsWorkspaceMembersTeamTab.tsx
 #: src/pages/settings/developers/api-keys/SettingsDevelopersApiKeysNew.tsx
@@ -10274,8 +10822,11 @@ msgstr "El nombre no puede estar vacío"
 
 #. js-lingui-id: zaxmAs
 #: src/modules/settings/data-model/object-details/components/tabs/ObjectSettings.tsx
-msgid "Name in both singular (e.g., 'Invoice') and plural (e.g., 'Invoices') forms."
-msgstr "Nombre tanto en forma singular (ej., 'Factura') como en plural (ej., 'Facturas')."
+msgid ""
+"Name in both singular (e.g., 'Invoice') and plural (e.g., 'Invoices') forms."
+msgstr ""
+"Nombre tanto en forma singular (ej., 'Factura') como en plural (ej., "
+"'Facturas')."
 
 #. js-lingui-id: z+6jaZ
 #: src/pages/settings/developers/api-keys/SettingsDevelopersApiKeysNew.tsx
@@ -10301,7 +10852,7 @@ msgstr "elemento del menú de navegación"
 #. js-lingui-id: jRptK+
 #: src/pages/settings/applications/tabs/SettingsApplicationDetailContentTab.tsx
 msgid "Navigation menu items"
-msgstr ""
+msgstr "Elementos del menú de navegación"
 
 #. js-lingui-id: s2HXiD
 #: src/modules/navigation/components/MainNavigationDrawerTabsRow.tsx
@@ -10374,7 +10925,7 @@ msgstr "Nuevo chat"
 #. js-lingui-id: TsXckK
 #: src/modules/sign-in-background-mock/components/BackgroundMockPage.tsx
 msgid "New Company"
-msgstr ""
+msgstr "Nueva empresa"
 
 #. js-lingui-id: +HY5kX
 #: src/modules/side-panel/components/SidePanelTopBarRightCornerIcon.tsx
@@ -10384,13 +10935,13 @@ msgstr "Nueva conversación"
 #. js-lingui-id: 3RwJHq
 #: src/modules/side-panel/hooks/useOpenComposeEmailInSidePanel.ts
 msgid "New Email"
-msgstr ""
+msgstr "Nuevo correo"
 
 #. js-lingui-id: VJZNJt
 #: src/modules/settings/accounts/components/SettingsAccountsNewEmailGroupChannel.tsx
 #: src/modules/settings/accounts/components/SettingsAccountsNewEmailGroupChannel.tsx
 msgid "New Email Handle"
-msgstr ""
+msgstr "Nuevo identificador de correo"
 
 #. js-lingui-id: wqoYqp
 #: src/pages/settings/emailing-domains/SettingsNewEmailingDomain.tsx
@@ -10421,7 +10972,7 @@ msgstr "Nuevo grupo"
 #: src/pages/settings/data-model/new-index/SettingsObjectNewIndex.tsx
 #: src/pages/settings/data-model/new-index/SettingsObjectNewIndex.tsx
 msgid "New Index"
-msgstr ""
+msgstr "Nuevo índice"
 
 #. js-lingui-id: o8MyXb
 #: src/pages/settings/developers/api-keys/SettingsDevelopersApiKeysNew.tsx
@@ -10482,7 +11033,7 @@ msgstr "Nuevo proveedor SSO"
 #. js-lingui-id: 3YvS+c
 #: src/modules/page-layout/components/PageLayoutTabListNewTabDropdownContent.tsx
 msgid "New tab"
-msgstr ""
+msgstr "Nueva pestaña"
 
 #. js-lingui-id: Db+TX4
 #: src/modules/page-layout/components/PageLayoutTabList.tsx
@@ -10491,7 +11042,7 @@ msgstr ""
 #: src/modules/page-layout/components/PageLayoutTabList.tsx
 #: src/modules/page-layout/components/PageLayoutTabList.tsx
 msgid "New Tab"
-msgstr ""
+msgstr "Nueva pestaña"
 
 #. js-lingui-id: wl18ST
 #: src/modules/activities/tasks/components/TaskGroups.tsx
@@ -10513,7 +11064,7 @@ msgstr "Nuevo Webhook"
 #: src/modules/side-panel/components/hooks/usePageLayoutHeaderInfo.ts
 #: src/modules/side-panel/components/hooks/usePageLayoutHeaderInfo.ts
 msgid "New widget"
-msgstr ""
+msgstr "Nuevo widget"
 
 #. js-lingui-id: hXzOVo
 #: src/pages/settings/accounts/SettingsAccountsConfigurationStepEmail.tsx
@@ -10574,7 +11125,7 @@ msgstr "No se encontró ningún {objectLabelSingular}"
 #. js-lingui-id: glQp+P
 #: src/modules/settings/admin-panel/components/SettingsAdminWorkspaceBillingContent.tsx
 msgid "No active subscription."
-msgstr ""
+msgstr "Sin suscripción activa."
 
 #. js-lingui-id: aXFOuf
 #: src/modules/activities/timeline-activities/components/TimelineCard.tsx
@@ -10599,12 +11150,12 @@ msgstr "No hay agentes que coincidan con tu búsqueda"
 #. js-lingui-id: nPalt1
 #: src/pages/settings/ai/SettingsAiUsageUserDetail.tsx
 msgid "No AI consumption recorded for this user."
-msgstr ""
+msgstr "No hay consumo de IA registrado para este usuario."
 
 #. js-lingui-id: 42kV9p
 #: src/modules/settings/admin-panel/ai/components/SettingsAdminAI.tsx
 msgid "No AI usage data recorded yet."
-msgstr ""
+msgstr "Aún no hay datos de uso de IA registrados."
 
 #. js-lingui-id: 9mx36q
 #: src/modules/settings/roles/role-assignment/components/SettingsRoleAssignmentTable.tsx
@@ -10624,7 +11175,7 @@ msgstr "No hay claves API que coincidan con tu búsqueda"
 #. js-lingui-id: /VRg8Z
 #: src/pages/settings/applications/tabs/SettingsApplicationsDeveloperTab.tsx
 msgid "No application found"
-msgstr ""
+msgstr "No se encontró la aplicación"
 
 #. js-lingui-id: rxBnh8
 #: src/pages/settings/applications/tabs/SettingsApplicationsAvailableTab.tsx
@@ -10639,12 +11190,12 @@ msgstr "No hay campos disponibles para seleccionar"
 #. js-lingui-id: Yd55ZI
 #: src/modules/side-panel/pages/page-layout/components/dropdown-content/MoveToTabDropdownContent.tsx
 msgid "No available tabs"
-msgstr ""
+msgstr "No hay pestañas disponibles"
 
 #. js-lingui-id: 8whThc
 #: src/modules/settings/admin-panel/components/SettingsAdminWorkspaceBillingContent.tsx
 msgid "No billing data is available for this workspace."
-msgstr ""
+msgstr "No hay datos de facturación disponibles para este espacio de trabajo."
 
 #. js-lingui-id: V/RzSE
 #: src/modules/workflow/workflow-steps/workflow-actions/http-request-action/components/BodyInput.tsx
@@ -10659,17 +11210,17 @@ msgstr "Sin código de llamada"
 #. js-lingui-id: d14J3J
 #: src/modules/ai/components/NavigationDrawerAiChatContent.tsx
 msgid "No chat"
-msgstr ""
+msgstr "Sin chat"
 
 #. js-lingui-id: NjIy4U
 #: src/pages/settings/admin-panel/SettingsAdminWorkspaceDetail.tsx
 msgid "No chat threads found."
-msgstr ""
+msgstr "No se encontraron hilos de chat."
 
 #. js-lingui-id: wgUPZ1
 #: src/pages/settings/ai/SettingsAgentTurnDetail.tsx
 msgid "No comment"
-msgstr ""
+msgstr "Sin comentarios"
 
 #. js-lingui-id: qTxPPY
 #: src/modules/settings/roles/role-permissions/object-level-permissions/record-level-permissions/components/SettingsRolePermissionsObjectLevelRecordLevelPermissionMeValueSelect.tsx
@@ -10678,8 +11229,12 @@ msgstr "No hay campos compatibles"
 
 #. js-lingui-id: YFLMyY
 #: src/modules/settings/admin-panel/config-variables/components/SettingsAdminConfigVariables.tsx
-msgid "No config variables match your current filters. Try adjusting your filters or search criteria."
-msgstr "Ninguna variable de configuración coincide con sus filtros actuales. Intente ajustar sus filtros o criterios de búsqueda."
+msgid ""
+"No config variables match your current filters. Try adjusting your filters "
+"or search criteria."
+msgstr ""
+"Ninguna variable de configuración coincide con sus filtros actuales. Intente"
+" ajustar sus filtros o criterios de búsqueda."
 
 #. js-lingui-id: PlVbP6
 #: src/modules/ai/components/RoutingDebugDisplay.tsx
@@ -10734,7 +11289,8 @@ msgstr "No hay datos disponibles para la Tabla Remota"
 #. js-lingui-id: VwYM0e
 #: src/modules/page-layout/widgets/components/PageLayoutWidgetNoDataDisplay.tsx
 msgid "No data available. Click edit to configure this widget."
-msgstr "No hay datos disponibles. Haga clic en editar para configurar este widget."
+msgstr ""
+"No hay datos disponibles. Haga clic en editar para configurar este widget."
 
 #. js-lingui-id: pxvJ9B
 #: src/modules/spreadsheet-import/steps/components/ValidationStep/ValidationStep.tsx
@@ -10755,12 +11311,12 @@ msgstr "Sin campo de fecha"
 #: src/modules/side-panel/pages/page-layout/components/RegularTabSettingsContent.tsx
 #: src/modules/side-panel/pages/page-layout/components/CanvasTabSettingsContent.tsx
 msgid "No default configuration available for this tab"
-msgstr ""
+msgstr "No hay configuración predeterminada disponible para esta pestaña"
 
 #. js-lingui-id: B8I32S
 #: src/modules/side-panel/pages/page-layout/components/WidgetSettingsManageSection.tsx
 msgid "No default configuration available for this widget"
-msgstr ""
+msgstr "No hay configuración predeterminada disponible para este widget"
 
 #. js-lingui-id: P4KXUa
 #: src/modules/object-record/record-table/empty-state/components/RecordTableEmptyStateSoftDelete.tsx
@@ -10770,27 +11326,32 @@ msgstr "No se encontró {objectLabelSingular} Eliminado"
 #. js-lingui-id: s7QKq9
 #: src/modules/object-record/record-table/empty-state/components/RecordTableEmptyStateSoftDelete.tsx
 msgid "No deleted records matching the filter criteria were found."
-msgstr "No se encontraron registros eliminados que coincidan con los criterios del filtro."
+msgstr ""
+"No se encontraron registros eliminados que coincidan con los criterios del "
+"filtro."
 
 #. js-lingui-id: RRRePs
 #: src/pages/settings/applications/tabs/SettingsApplicationDetailAboutTab.tsx
 msgid "No description available for this application"
-msgstr ""
+msgstr "No hay descripción disponible para esta aplicación"
 
 #. js-lingui-id: mINrlz
 #: src/modules/activities/emails/components/EmptyInboxPlaceholder.tsx
 msgid "No email exchange has occurred with this record yet."
-msgstr "Todavía no ha habido intercambio de correos electrónicos con este registro."
+msgstr ""
+"Todavía no ha habido intercambio de correos electrónicos con este registro."
 
 #. js-lingui-id: p3Hivn
 #: src/pages/settings/ai/components/SettingsAgentEvalsTab.tsx
 msgid "No evaluation inputs yet. Add your first test input above."
 msgstr ""
+"Aún no hay entradas de evaluación. Añade tu primera entrada de prueba "
+"arriba."
 
 #. js-lingui-id: ntMCci
 #: src/pages/settings/ai/SettingsAgentTurnDetail.tsx
 msgid "No evaluations yet for this turn"
-msgstr ""
+msgstr "Aún no hay evaluaciones para este turno"
 
 #. js-lingui-id: SIR5Ix
 #: src/pages/settings/security/event-logs/components/EventLogResultsTable.tsx
@@ -10809,8 +11370,12 @@ msgstr "Aún no se han programado eventos con este {objectName}."
 
 #. js-lingui-id: K8KcHw
 #: src/pages/settings/applications/tabs/SettingsApplicationsAvailableTab.tsx
-msgid "No featured applications found. {nonFeaturedCount} non-featured result(s) available — "
-msgstr "No se encontraron aplicaciones destacadas. {nonFeaturedCount} resultados no destacados disponibles — "
+msgid ""
+"No featured applications found. {nonFeaturedCount} non-featured result(s) "
+"available — "
+msgstr ""
+"No se encontraron aplicaciones destacadas. {nonFeaturedCount} resultados no "
+"destacados disponibles — "
 
 #. js-lingui-id: h+tLhU
 #: src/modules/page-layout/widgets/field/components/FieldWidget.tsx
@@ -10820,7 +11385,7 @@ msgstr "Ningún campo configurado"
 #. js-lingui-id: /hvarH
 #: src/modules/side-panel/pages/page-layout/components/dropdown-content/ChartGroupByFieldSelectionRelationFieldView.tsx
 msgid "No fields available"
-msgstr ""
+msgstr "No hay campos disponibles"
 
 #. js-lingui-id: RM6uKY
 #: src/modules/settings/security/components/SettingsSecurityEditableProfileFields.tsx
@@ -10855,12 +11420,12 @@ msgstr "No se encontraron carpetas para esta cuenta"
 #. js-lingui-id: 9kCSLK
 #: src/pages/settings/data-model/SettingsObjectIndexTable.tsx
 msgid "No indexes match your filters."
-msgstr ""
+msgstr "No hay índices que coincidan con tus filtros."
 
 #. js-lingui-id: gIrKyO
 #: src/pages/settings/ai/components/SettingsAgentLogsTab.tsx
 msgid "No input"
-msgstr ""
+msgstr "Sin entrada"
 
 #. js-lingui-id: LVdJ+2
 #: src/modules/workflow/workflow-steps/workflow-actions/logic-function-action/components/WorkflowEditActionLogicFunction.tsx
@@ -10891,7 +11456,7 @@ msgstr "No se encontró la última versión"
 #. js-lingui-id: 5sf2dF
 #: src/pages/settings/ai/components/SettingsAgentLogsTab.tsx
 msgid "No logs yet"
-msgstr ""
+msgstr "Aún no hay registros"
 
 #. js-lingui-id: UwvrGq
 #: src/pages/settings/members/tabs/SettingsWorkspaceMembersTeamTab.tsx
@@ -10911,12 +11476,12 @@ msgstr "No hay miembros que coincidan con tu búsqueda"
 #. js-lingui-id: JzzHsG
 #: src/pages/settings/ai/SettingsAgentTurnDetail.tsx
 msgid "No messages found for this turn"
-msgstr ""
+msgstr "No se encontraron mensajes para este turno"
 
 #. js-lingui-id: IohPnt
 #: src/modules/settings/admin-panel/components/SettingsAdminChatThreadMessageList.tsx
 msgid "No messages found."
-msgstr ""
+msgstr "No se encontraron mensajes."
 
 #. js-lingui-id: 0NudpV
 #: src/modules/settings/admin-panel/health-status/components/SettingsAdminWorkerMetricsGraph.tsx
@@ -10926,8 +11491,11 @@ msgstr "No hay datos de métricas disponibles"
 #. js-lingui-id: UWZZdQ
 #: src/pages/settings/ai/forms/components/SettingsAiAgentForm.tsx
 #: src/pages/settings/ai/components/SettingsAgentSettingsTab.tsx
-msgid "No models available. Please configure AI models in your workspace settings."
-msgstr "No hay modelos disponibles. Por favor configure modelos de IA en la configuración de su espacio de trabajo."
+msgid ""
+"No models available. Please configure AI models in your workspace settings."
+msgstr ""
+"No hay modelos disponibles. Por favor configure modelos de IA en la "
+"configuración de su espacio de trabajo."
 
 #. js-lingui-id: 9VrTfZ
 #: src/modules/activities/notes/components/NotesCard.tsx
@@ -10937,7 +11505,7 @@ msgstr "Sin notas"
 #. js-lingui-id: 14uqQk
 #: src/pages/settings/applications/components/SettingsApplicationDataTable.tsx
 msgid "No object found"
-msgstr ""
+msgstr "No se encontró el objeto"
 
 #. js-lingui-id: YFHO2u
 #: src/modules/navigation-menu-item/edit/side-panel/components/SidePanelNewSidebarItemViewObjectPickerSubView.tsx
@@ -10967,12 +11535,14 @@ msgstr "Sin parámetros"
 #. js-lingui-id: 5pSj4j
 #: src/modules/settings/billing/hooks/useEndSubscriptionTrialPeriod.ts
 msgid "No payment method found. Please update your billing details."
-msgstr "No se encontró ningún método de pago. Por favor, actualice sus datos de facturación."
+msgstr ""
+"No se encontró ningún método de pago. Por favor, actualice sus datos de "
+"facturación."
 
 #. js-lingui-id: orE/ux
 #: src/pages/settings/applications/SettingsApplicationDetails.tsx
 msgid "No permission defined for this application"
-msgstr ""
+msgstr "No hay permisos definidos para esta aplicación"
 
 #. js-lingui-id: Od1X93
 #: src/pages/settings/applications/tabs/SettingsApplicationPermissionsTab.tsx
@@ -10988,7 +11558,7 @@ msgstr "No se han establecido permisos para objetos individuales."
 #: src/modules/object-record/record-field/ui/form-types/components/FormSingleRecordPicker.tsx
 #: src/modules/object-record/record-field/ui/form-types/components/FormSingleRecordFieldChip.tsx
 msgid "No record"
-msgstr ""
+msgstr "Sin registro"
 
 #. js-lingui-id: ePgApM
 #: src/modules/workflow/workflow-trigger/components/WorkflowEditTriggerManual.tsx
@@ -10999,7 +11569,7 @@ msgstr "No se requiere ningún registro para activar este flujo de trabajo"
 #: src/modules/command-menu-item/edit/components/CommandMenuItemEditRecordSelectionDropdown.tsx
 #: src/modules/command-menu-item/edit/components/CommandMenuItemEditRecordSelectionDropdown.tsx
 msgid "No record selected"
-msgstr ""
+msgstr "Ningún registro seleccionado"
 
 #. js-lingui-id: EqGTpW
 #: src/modules/object-record/record-table/empty-state/components/RecordTableEmptyStateReadOnly.tsx
@@ -11010,7 +11580,8 @@ msgstr "No se encontraron registros"
 #. js-lingui-id: FwUgy3
 #: src/modules/object-record/record-table/empty-state/components/RecordTableEmptyStateNoRecordFoundForFilter.tsx
 msgid "No records matching the filter criteria were found."
-msgstr "No se encontraron registros que coincidan con los criterios del filtro."
+msgstr ""
+"No se encontraron registros que coincidan con los criterios del filtro."
 
 #. js-lingui-id: Ev2r9A
 #: src/modules/views/components/ViewFieldsSearchDropdownSection.tsx
@@ -11074,12 +11645,16 @@ msgstr "No se encontraron objetos del sistema con vistas"
 #. js-lingui-id: ZCTuAQ
 #: src/modules/settings/logic-functions/components/tabs/SettingsLogicFunctionTriggersTab.tsx
 msgid "No trigger is configured for this function."
-msgstr ""
+msgstr "No hay disparador configurado para esta función."
 
 #. js-lingui-id: g/fpDP
 #: src/modules/settings/logic-functions/components/tabs/SettingsLogicFunctionTriggersTab.tsx
-msgid "No trigger is enabled. Toggle one of the options above to choose how this function gets invoked."
+msgid ""
+"No trigger is enabled. Toggle one of the options above to choose how this "
+"function gets invoked."
 msgstr ""
+"Ningún disparador está habilitado. Activa una de las opciones de arriba para"
+" elegir cómo se invoca esta función."
 
 #. js-lingui-id: WwlPOG
 #: src/pages/settings/SettingsUsageUserDetail.tsx
@@ -11091,12 +11666,13 @@ msgstr "Sin datos de uso"
 #: src/pages/settings/ai/components/SettingsAiUsageTab.tsx
 #: src/modules/settings/usage/components/SettingsUsageAnalyticsSection.tsx
 msgid "No usage data yet"
-msgstr ""
+msgstr "Aún no hay datos de uso"
 
 #. js-lingui-id: EsP4NW
 #: src/modules/settings/admin-panel/components/SettingsAdminGeneral.tsx
 msgid "No users found matching your search criteria."
 msgstr ""
+"No se encontraron usuarios que coincidan con tus criterios de búsqueda."
 
 #. js-lingui-id: wJwIUq
 #: src/modules/object-record/record-field/ui/form-types/components/FormSelectFieldInput.tsx
@@ -11116,7 +11692,7 @@ msgstr "No se encontraron variables"
 #. js-lingui-id: OCektF
 #: src/pages/settings/applications/tabs/SettingsApplicationDetailEnvironmentVariablesTable.tsx
 msgid "No variables to set for this application"
-msgstr ""
+msgstr "No hay variables que configurar para esta aplicación"
 
 #. js-lingui-id: 0uWxPM
 #: src/modules/object-record/record-table/empty-state/utils/getEmptyStateTitle.ts
@@ -11131,12 +11707,12 @@ msgstr "Aún no hay versiones de flujo de trabajo"
 #. js-lingui-id: Q4dFjT
 #: src/pages/settings/admin-panel/SettingsAdminWorkspacesStatus.tsx
 msgid "No workspace behind"
-msgstr ""
+msgstr "Ningún espacio de trabajo retrasado"
 
 #. js-lingui-id: apOMfI
 #: src/pages/settings/admin-panel/SettingsAdminWorkspacesStatus.tsx
 msgid "No workspace failed"
-msgstr ""
+msgstr "Ningún espacio de trabajo fallido"
 
 #. js-lingui-id: rPAZRd
 #: src/modules/settings/lab/hooks/useLabPublicFeatureFlags.ts
@@ -11147,6 +11723,8 @@ msgstr "Ningún espacio de trabajo seleccionado"
 #: src/modules/settings/admin-panel/components/SettingsAdminGeneral.tsx
 msgid "No workspaces found matching your search criteria."
 msgstr ""
+"No se encontraron espacios de trabajo que coincidan con tus criterios de "
+"búsqueda."
 
 #. js-lingui-id: Ah7JCB
 #: src/modules/side-panel/pages/workflow/step/view-run/components/SidePanelWorkflowRunViewStepContent.tsx
@@ -11236,28 +11814,27 @@ msgstr "No sincronizado"
 #. js-lingui-id: VngD1z
 #: src/pages/settings/applications/SettingsApplicationDetails.tsx
 msgid "Nothing to configure for this application"
-msgstr ""
+msgstr "Nada que configurar para esta aplicación"
 
 #. js-lingui-id: DYCPYF
 #: src/modules/page-layout/widgets/components/StandaloneWidgetPlaceholder.tsx
 msgid "Nothing to see"
-msgstr ""
+msgstr "Nada que ver"
 
 #. js-lingui-id: YwzE9K
-#: src/utils/date-utils.ts
-#: src/utils/date-utils.ts
+#: src/utils/date-utils.ts src/utils/date-utils.ts
 msgid "now"
 msgstr "ahora"
 
 #. js-lingui-id: OduKuG
 #: src/modules/settings/applications/components/SettingsApplicationAboutSidebar.tsx
 msgid "Npm package"
-msgstr ""
+msgstr "Paquete Npm"
 
 #. js-lingui-id: p7abaY
 #: src/pages/settings/applications/tabs/SettingsApplicationsDeveloperTab.tsx
 msgid "NPM packages"
-msgstr ""
+msgstr "Paquetes NPM"
 
 #. js-lingui-id: VVexZo
 #: src/modules/advanced-text-editor/extensions/slash-command/DefaultSlashCommands.ts
@@ -11279,7 +11856,8 @@ msgstr "Formato de número"
 #. js-lingui-id: +cbzNC
 #: src/pages/settings/security/SettingsSecurity.tsx
 msgid "Number of days to retain audit logs (30-1095 days)"
-msgstr "Número de días para conservar los registros de auditoría (30-1095 días)"
+msgstr ""
+"Número de días para conservar los registros de auditoría (30-1095 días)"
 
 #. js-lingui-id: 0fRFSb
 #: src/modules/settings/data-model/fields/forms/number/components/SettingsDataModelFieldNumberForm.tsx
@@ -11318,12 +11896,12 @@ msgstr "OAuth"
 #. js-lingui-id: IxKj9Y
 #: src/modules/settings/applications/hooks/useComputeApplicationContentForLayoutAndLogic.ts
 msgid "OAuth 2.0"
-msgstr ""
+msgstr "OAuth 2.0"
 
 #. js-lingui-id: C1b55F
 #: src/pages/settings/applications/SettingsApplicationConnectionDetail.tsx
 msgid "OAuth credential metadata for this application connection"
-msgstr ""
+msgstr "Metadatos de credenciales OAuth para esta conexión de aplicación"
 
 #. js-lingui-id: pNEViR
 #: src/pages/settings/applications/SettingsAvailableApplicationDetails.tsx
@@ -11374,7 +11952,7 @@ msgstr "ID del objeto"
 #. js-lingui-id: PezPrT
 #: src/modules/object-record/record-index/components/RecordIndexEmptyStateNotShared.tsx
 msgid "Object not shared"
-msgstr ""
+msgstr "Objeto no compartido"
 
 #. js-lingui-id: wZpAXW
 #: src/modules/metadata-error-handler/hooks/useMetadataErrorHandler.ts
@@ -11429,7 +12007,7 @@ msgstr "Objetos"
 #. js-lingui-id: tmyEbd
 #: src/pages/settings/applications/components/SettingsApplicationDataTable.tsx
 msgid "Objects and fields managed by this app"
-msgstr ""
+msgstr "Objetos y campos gestionados por esta aplicación"
 
 #. js-lingui-id: /8Yh6y
 #: src/modules/settings/roles/role-permissions/objects-permissions/components/SettingsRolePermissionsObjectsSection.tsx
@@ -11464,7 +12042,7 @@ msgstr "Omitir valores cero"
 #: src/modules/settings/applications/hooks/useComputeObjectAndFieldsContentForApplication.ts
 #: src/modules/settings/applications/hooks/useComputeObjectAndFieldsContentForApplication.ts
 msgid "on {0}"
-msgstr ""
+msgstr "en {0}"
 
 #. js-lingui-id: jcwJgk
 #: src/modules/workflow/workflow-trigger/utils/cron-to-human/descriptors/getDayOfMonthDescription.ts
@@ -11567,12 +12145,13 @@ msgstr "Solo se comparte el asunto"
 #. js-lingui-id: 50ETCF
 #: src/modules/onboarding/constants/OnboardingSyncEmailsOptions.ts
 msgid "Only the timestamp & participants will be shared with your team."
-msgstr "Solo la marca de tiempo y los participantes se compartirán con tu equipo."
+msgstr ""
+"Solo la marca de tiempo y los participantes se compartirán con tu equipo."
 
 #. js-lingui-id: Lp+2YF
 #: src/pages/settings/applications/components/SettingsApplicationConnectScopePickerModal.tsx
 msgid "Only you can use this credential."
-msgstr ""
+msgstr "Solo tú puedes usar esta credencial."
 
 #. js-lingui-id: 1TNIig
 #: src/pages/settings/members/tabs/SettingsWorkspaceMembersTeamTab.tsx
@@ -11600,7 +12179,7 @@ msgstr "Abrir en"
 #. js-lingui-id: noLjKT
 #: src/modules/settings/data-model/fields/forms/components/SettingsDataModelFieldOnClickActionForm.tsx
 msgid "Open in app"
-msgstr ""
+msgstr "Abrir en la aplicación"
 
 #. js-lingui-id: DP5C7w
 #: src/modules/settings/members/components/MemberPermissionsTab.tsx
@@ -11615,7 +12194,7 @@ msgstr "Abrir Outlook"
 #. js-lingui-id: p9J4lB
 #: src/pages/settings/layout/SettingsLayoutViewDetail.tsx
 msgid "Open records in"
-msgstr ""
+msgstr "Abrir registros en"
 
 #. js-lingui-id: bY2Xkv
 #: src/modules/side-panel/components/SidePanelToggleButton.tsx
@@ -11630,7 +12209,7 @@ msgstr "Abierto"
 #. js-lingui-id: Fzfj4N
 #: src/pages/settings/layout/SettingsLayoutViewDetail.tsx
 msgid "Operand"
-msgstr ""
+msgstr "Operando"
 
 #. js-lingui-id: 8m1COB
 #: src/modules/settings/admin-panel/health-status/components/SettingsAdminHealthStatusRightContainer.tsx
@@ -11650,8 +12229,11 @@ msgstr "Opcional — usa el rol de IAM si está vacío"
 
 #. js-lingui-id: hY8F2i
 #: src/modules/settings/developers/components/SettingsDevelopersWebhookForm.tsx
-msgid "Optional secret used to compute the HMAC signature for webhook payloads"
-msgstr "Secreto opcional utilizado para calcular la firma HMAC de los datos del webhook"
+msgid ""
+"Optional secret used to compute the HMAC signature for webhook payloads"
+msgstr ""
+"Secreto opcional utilizado para calcular la firma HMAC de los datos del "
+"webhook"
 
 #. js-lingui-id: 0zpgxV
 #: src/pages/settings/data-model/new-index/SettingsObjectNewIndex.tsx
@@ -11682,7 +12264,7 @@ msgstr "Naranja"
 #. js-lingui-id: I/EsFC
 #: src/pages/settings/layout/SettingsLayoutViewDetail.tsx
 msgid "Order in which records are displayed"
-msgstr ""
+msgstr "Orden en que se muestran los registros"
 
 #. js-lingui-id: VWupWc
 #: src/modules/advanced-text-editor/extensions/slash-command/DefaultSlashCommands.ts
@@ -11764,8 +12346,12 @@ msgstr "El OTP debe tener exactamente 6 dígitos"
 
 #. js-lingui-id: p5ufK6
 #: src/pages/onboarding/BookCallDecision.tsx
-msgid "Our team can help you set up your workspace to match your specific needs and workflows."
-msgstr "Nuestro equipo puede ayudarle a configurar su espacio de trabajo para que se adapte a sus necesidades y flujos de trabajo específicos."
+msgid ""
+"Our team can help you set up your workspace to match your specific needs and"
+" workflows."
+msgstr ""
+"Nuestro equipo puede ayudarle a configurar su espacio de trabajo para que se"
+" adapte a sus necesidades y flujos de trabajo específicos."
 
 #. js-lingui-id: yL8XdR
 #: src/modules/settings/admin-panel/health-status/components/SettingsAdminHealthStatusRightContainer.tsx
@@ -11838,7 +12424,7 @@ msgstr "diseño de página"
 #: src/pages/settings/layout/SettingsLayoutPageLayoutDetail.tsx
 #: src/modules/settings/applications/hooks/useComputeApplicationContentForLayoutAndLogic.ts
 msgid "Page layout"
-msgstr ""
+msgstr "Diseño de página"
 
 #. js-lingui-id: HFlGEK
 #: src/modules/metadata-error-handler/hooks/useMetadataErrorHandler.ts
@@ -11854,7 +12440,7 @@ msgstr "widget de Diseño de página"
 #: src/pages/settings/layout/SettingsLayoutPageLayoutDetail.tsx
 #: src/pages/settings/applications/tabs/SettingsApplicationDetailContentTab.tsx
 msgid "Page layouts"
-msgstr ""
+msgstr "Diseños de página"
 
 #. js-lingui-id: IVBjIH
 #: src/pages/settings/security/event-logs/components/EventLogFilters.tsx
@@ -11885,7 +12471,7 @@ msgstr "Párrafo"
 #. js-lingui-id: F18WP3
 #: src/pages/settings/ai/SettingsToolDetail.tsx
 msgid "Parameters"
-msgstr ""
+msgstr "Parámetros"
 
 #. js-lingui-id: 8ZsakT
 #: src/modules/settings/security/components/SettingsSecurityAuthProvidersOptionsList.tsx
@@ -11908,12 +12494,14 @@ msgstr "La contraseña ha sido actualizada"
 #: src/pages/auth/PasswordReset.tsx
 #: src/modules/auth/sign-in-up/hooks/useSignInUpForm.ts
 msgid "Password must be between 8 and 50 characters"
-msgstr ""
+msgstr "La contraseña debe tener entre 8 y 50 caracteres"
 
 #. js-lingui-id: mi6Rel
 #: src/modules/auth/sign-in-up/hooks/useHandleResetPassword.ts
 msgid "Password reset link has been sent to the email"
-msgstr "El enlace de restablecimiento de contraseña ha sido enviado al correo electrónico"
+msgstr ""
+"El enlace de restablecimiento de contraseña ha sido enviado al correo "
+"electrónico"
 
 #. js-lingui-id: cpStVq
 #: src/modules/auth/sign-in-up/components/internal/SignInUpTwoFactorAuthenticationVerification.tsx
@@ -11955,7 +12543,9 @@ msgstr "Pendiente"
 #. js-lingui-id: PxBA+g
 #: src/modules/settings/accounts/components/SettingsAccountsMessageAutoCreationCard.tsx
 msgid "People I’ve sent emails to and received emails from."
-msgstr "Personas a las que he enviado correos electrónicos y de quienes he recibido correos electrónicos."
+msgstr ""
+"Personas a las que he enviado correos electrónicos y de quienes he recibido "
+"correos electrónicos."
 
 #. js-lingui-id: U/UvMm
 #: src/modules/settings/accounts/components/SettingsAccountsMessageAutoCreationCard.tsx
@@ -11965,7 +12555,7 @@ msgstr "Personas a las que he enviado correos electrónicos."
 #. js-lingui-id: qMTN0w
 #: src/pages/settings/ai/SettingsAiUsageUserDetail.tsx
 msgid "Per-day AI consumption."
-msgstr ""
+msgstr "Consumo de IA por día."
 
 #. js-lingui-id: i9iYjM
 #: src/pages/settings/SettingsUsageUserDetail.tsx
@@ -12000,6 +12590,7 @@ msgstr "Porcentaje"
 #: src/modules/settings/members/components/MemberInfosTab.tsx
 msgid "Perform administrative actions or permanently delete this user"
 msgstr ""
+"Realizar acciones administrativas o eliminar permanentemente este usuario"
 
 #. js-lingui-id: wSpwGR
 #: src/pages/settings/security/SettingsSecurity.tsx
@@ -12009,12 +12600,12 @@ msgstr "Eliminación permanente. Introduzca el número de días."
 #. js-lingui-id: EPkrPQ
 #: src/modules/command-menu-item/engine-command/record/components/DestroyRecordsCommand.tsx
 msgid "Permanently Destroy"
-msgstr ""
+msgstr "Destruir permanentemente"
 
 #. js-lingui-id: 64gHBj
 #: src/modules/command-menu-item/engine-command/record/components/DestroyRecordsCommand.tsx
 msgid "Permanently Destroy {objectLabel}"
-msgstr ""
+msgstr "Destruir permanentemente {objectLabel}"
 
 #. js-lingui-id: yWmZKk
 #: src/modules/metadata-error-handler/hooks/useMetadataErrorHandler.ts
@@ -12071,13 +12662,23 @@ msgstr "Selecciona un objeto"
 
 #. js-lingui-id: JHXjkT
 #: src/pages/settings/data-model/new-index/SettingsObjectNewIndex.tsx
-msgid "Pick one or more fields. The order you select them in becomes the column order in the index — important for composite queries. For composite fields like Address, pick the specific sub-column to index."
+msgid ""
+"Pick one or more fields. The order you select them in becomes the column "
+"order in the index — important for composite queries. For composite fields "
+"like Address, pick the specific sub-column to index."
 msgstr ""
+"Elige uno o más campos. El orden en que los selecciones se convierte en el "
+"orden de columnas en el índice — importante para consultas compuestas. Para "
+"campos compuestos como Dirección, elige la subcolumna específica a indexar."
 
 #. js-lingui-id: X1kz7Q
 #: src/pages/settings/data-model/new-index/SettingsObjectNewIndex.tsx
-msgid "Pick the index type. BTREE covers most queries; GIN is for full-text and JSONB."
+msgid ""
+"Pick the index type. BTREE covers most queries; GIN is for full-text and "
+"JSONB."
 msgstr ""
+"Elige el tipo de índice. BTREE cubre la mayoría de las consultas; GIN es "
+"para texto completo y JSONB."
 
 #. js-lingui-id: N0+GsR
 #: src/pages/settings/SettingsWorkspace.tsx
@@ -12096,7 +12697,7 @@ msgstr "Gráfico de pastel"
 #. js-lingui-id: 3pU8e+
 #: src/modules/side-panel/pages/page-layout/components/CanvasTabSettingsContent.tsx
 msgid "Pin tab"
-msgstr ""
+msgstr "Fijar pestaña"
 
 #. js-lingui-id: 2FIjLb
 #: src/modules/settings/data-model/fields/forms/select/components/SettingsDataModelFieldSelectFormOptionRow.tsx
@@ -12108,7 +12709,7 @@ msgstr "Rosa"
 #: src/modules/command-menu-item/edit/components/SidePanelCommandMenuItemEditPage.tsx
 #: src/modules/command-menu-item/display/components/SidePanelCommandMenuItemDisplayPage.tsx
 msgid "Pinned"
-msgstr ""
+msgstr "Fijado"
 
 #. js-lingui-id: hx1ePY
 #: src/modules/workflow/workflow-steps/workflow-actions/form-action/components/WorkflowFormFieldSettingsText.tsx
@@ -12120,7 +12721,7 @@ msgstr "Marcador de posición"
 #: src/modules/side-panel/pages/page-layout/components/WidgetSettingsPlacementSection.tsx
 #: src/modules/side-panel/pages/page-layout/components/CanvasTabSettingsContent.tsx
 msgid "Placement"
-msgstr ""
+msgstr "Ubicación"
 
 #. js-lingui-id: fQtTho
 #: src/modules/advanced-text-editor/extensions/slash-command/DefaultSlashCommands.ts
@@ -12142,7 +12743,7 @@ msgstr "El cambio de plan ha sido cancelado."
 #: src/modules/settings/admin-panel/health-status/maintenance-mode/components/SettingsAdminMaintenanceMode.tsx
 #: src/modules/settings/admin-panel/health-status/maintenance-mode/components/SettingsAdminMaintenanceMode.tsx
 msgid "Planned for {formattedStartDate}"
-msgstr ""
+msgstr "Planificado para {formattedStartDate}"
 
 #. js-lingui-id: VUi6Nf
 #: src/modules/workflow/workflow-trigger/components/CronExpressionHelper.tsx
@@ -12152,7 +12753,8 @@ msgstr "Por favor, revisa la sintaxis de tu expresión cron."
 #. js-lingui-id: 90/XJz
 #: src/pages/settings/security/SettingsSecurityApprovedAccessDomain.tsx
 msgid "Please check your email for a verification link."
-msgstr "Por favor, revisa tu correo electrónico para un enlace de verificación."
+msgstr ""
+"Por favor, revisa tu correo electrónico para un enlace de verificación."
 
 #. js-lingui-id: jEw0Mr
 #: src/pages/settings/applications/components/SettingsApplicationRegistrationRedirectURIsInput.tsx
@@ -12162,8 +12764,11 @@ msgstr "Por favor, introduzca una URL válida"
 
 #. js-lingui-id: qg68zg
 #: src/modules/information-banner/components/reconnect-account/InformationBannerReconnectAccountEmailAliases.tsx
-msgid "Please reconnect your mailbox {mailboxHandle} to update your email aliases:"
-msgstr "Vuelve a conectar tu buzón {mailboxHandle} para actualizar tus alias de correo:"
+msgid ""
+"Please reconnect your mailbox {mailboxHandle} to update your email aliases:"
+msgstr ""
+"Vuelve a conectar tu buzón {mailboxHandle} para actualizar tus alias de "
+"correo:"
 
 #. js-lingui-id: CjNkdJ
 #: src/modules/error-handler/components/AppRootErrorFallback.tsx
@@ -12174,7 +12779,8 @@ msgstr "Por favor, actualiza la página."
 #. js-lingui-id: wCgL30
 #: src/pages/settings/data-model/new-field/SettingsObjectNewFieldConfigure.tsx
 msgid "Please select at least one destination object for this relation."
-msgstr "Por favor, seleccione al menos un objeto de destino para esta relación."
+msgstr ""
+"Por favor, seleccione al menos un objeto de destino para esta relación."
 
 #. js-lingui-id: 8YnlGz
 #: src/modules/settings/billing/components/internal/ResourceCreditPriceSelector.tsx
@@ -12183,18 +12789,32 @@ msgstr "Por favor, inicia tu suscripción primero"
 
 #. js-lingui-id: 6nsIo3
 #: src/pages/settings/developers/api-keys/SettingsDevelopersApiKeyDetail.tsx
-msgid "Please type \"{confirmationValue}\" to confirm you want to delete this API Key. Be aware that any script using this key will stop working."
-msgstr "Escriba \"{confirmationValue}\" para confirmar que desea eliminar esta clave API. Tenga en cuenta que cualquier script que utilice esta clave dejará de funcionar."
+msgid ""
+"Please type \"{confirmationValue}\" to confirm you want to delete this API "
+"Key. Be aware that any script using this key will stop working."
+msgstr ""
+"Escriba \"{confirmationValue}\" para confirmar que desea eliminar esta clave"
+" API. Tenga en cuenta que cualquier script que utilice esta clave dejará de "
+"funcionar."
 
 #. js-lingui-id: osUElx
 #: src/pages/settings/admin-panel/SettingsAdminApplicationRegistrationDangerZone.tsx
-msgid "Please type \"{confirmationValue}\" to confirm you want to delete this app. All workspace installations linked to it will lose their OAuth credentials."
-msgstr "Escribe \"{confirmationValue}\" para confirmar que deseas eliminar esta aplicación. Todas las instalaciones de espacios de trabajo vinculadas a ella perderán sus credenciales de OAuth."
+msgid ""
+"Please type \"{confirmationValue}\" to confirm you want to delete this app. "
+"All workspace installations linked to it will lose their OAuth credentials."
+msgstr ""
+"Escribe \"{confirmationValue}\" para confirmar que deseas eliminar esta "
+"aplicación. Todas las instalaciones de espacios de trabajo vinculadas a ella"
+" perderán sus credenciales de OAuth."
 
 #. js-lingui-id: L0SEpC
 #: src/pages/settings/applications/tabs/SettingsApplicationDetailAboutTab.tsx
-msgid "Please type \"{confirmationValue}\" to confirm you want to uninstall this application."
+msgid ""
+"Please type \"{confirmationValue}\" to confirm you want to uninstall this "
+"application."
 msgstr ""
+"Escribe \"{confirmationValue}\" para confirmar que deseas desinstalar esta "
+"aplicación."
 
 #. js-lingui-id: GbtYRD
 #: src/modules/settings/developers/components/SettingsDevelopersWebhookForm.tsx
@@ -12252,7 +12872,7 @@ msgstr "Código postal"
 #. js-lingui-id: VFf6Bm
 #: src/modules/logic-functions/utils/getLogicFunctionTriggerLabel.ts
 msgid "Post-install"
-msgstr ""
+msgstr "Post-instalación"
 
 #. js-lingui-id: OKJUcC
 #: src/modules/settings/data-model/fields/forms/address/constants/DefaultSelectionAddressWithMessages.ts
@@ -12263,12 +12883,12 @@ msgstr "Código postal"
 #. js-lingui-id: W88dRa
 #: src/modules/logic-functions/utils/getLogicFunctionTriggerLabel.ts
 msgid "Pre-install"
-msgstr ""
+msgstr "Pre-instalación"
 
 #. js-lingui-id: q+Xhwx
 #: src/modules/settings/admin-panel/apps/components/SettingsAdminApps.tsx
 msgid "Pre-installed only"
-msgstr ""
+msgstr "Solo preinstalado"
 
 #. js-lingui-id: /v6Rp9
 #: src/pages/onboarding/CreateWorkspace.tsx
@@ -12305,7 +12925,7 @@ msgstr "Anterior"
 #. js-lingui-id: x97ifc
 #: src/modules/ai/utils/groupThreadsByDate.ts
 msgid "Previous 7 days"
-msgstr ""
+msgstr "Últimos 7 días"
 
 #. js-lingui-id: aHCEmh
 #: src/pages/settings/admin-panel/SettingsAdminNewAiModel.tsx
@@ -12354,7 +12974,7 @@ msgstr "Política de privacidad"
 #. js-lingui-id: zwBp5t
 #: src/pages/settings/applications/tabs/SettingsApplicationRegistrationDistributionTab.tsx
 msgid "Private"
-msgstr ""
+msgstr "Privado"
 
 #. js-lingui-id: 3fPjUY
 #: src/modules/settings/billing/hooks/useBillingWording.ts
@@ -12394,7 +13014,7 @@ msgstr "Foto de perfil"
 #. js-lingui-id: W9uQXX
 #: src/modules/workflow/workflow-steps/workflow-actions/ai-agent-action/components/WorkflowEditActionAiAgent.tsx
 msgid "Prompt"
-msgstr ""
+msgstr "Indicación"
 
 #. js-lingui-id: l/UFPv
 #: src/pages/settings/security/event-logs/utils/getColumnsForEventLogTable.ts
@@ -12408,7 +13028,7 @@ msgstr "Propiedades"
 #: src/pages/settings/applications/tabs/SettingsApplicationFrontComponentSettingsTab.tsx
 #: src/pages/settings/applications/tabs/SettingsApplicationCommandMenuItemSettingsTab.tsx
 msgid "Property"
-msgstr ""
+msgstr "Propiedad"
 
 #. js-lingui-id: 56xUL1
 #: src/modules/workflow/workflow-steps/workflow-actions/http-request-action/components/BodyInput.tsx
@@ -12454,8 +13074,13 @@ msgstr "Proveedores"
 
 #. js-lingui-id: Ktkc8d
 #: src/pages/settings/applications/tabs/SettingsApplicationsDeveloperTab.tsx
-msgid "Provision a complete and secure hosting environment on these domains. Bind a domain to a specific app to expose only that app's HTTP routes."
+msgid ""
+"Provision a complete and secure hosting environment on these domains. Bind a"
+" domain to a specific app to expose only that app's HTTP routes."
 msgstr ""
+"Provisión de un entorno de alojamiento completo y seguro en estos dominios. "
+"Vincula un dominio a una aplicación específica para exponer solo las rutas "
+"HTTP de esa aplicación."
 
 #. js-lingui-id: YJgRqq
 #: src/pages/settings/profile/appearance/components/LocalePicker.tsx
@@ -12465,7 +13090,7 @@ msgstr "Pseudoinglés"
 #. js-lingui-id: 7d1a0d
 #: src/pages/settings/applications/tabs/SettingsApplicationRegistrationDistributionTab.tsx
 msgid "Public"
-msgstr ""
+msgstr "Público"
 
 #. js-lingui-id: knP82t
 #: src/modules/settings/domains/components/SettingPublicDomain.tsx
@@ -12492,7 +13117,7 @@ msgstr "Dominio público eliminado con éxito"
 #. js-lingui-id: 8PGHE/
 #: src/modules/settings/domains/components/SettingPublicDomain.tsx
 msgid "Public domain updated successfully"
-msgstr ""
+msgstr "Dominio público actualizado con éxito"
 
 #. js-lingui-id: g55kfn
 #: src/pages/settings/applications/tabs/SettingsApplicationsDeveloperTab.tsx
@@ -12502,7 +13127,7 @@ msgstr "Dominios Públicos"
 #. js-lingui-id: zSYgxW
 #: src/pages/settings/applications/tabs/SettingsApplicationRegistrationDistributionTab.tsx
 msgid "Publish your app to the marketplace so others can install it"
-msgstr ""
+msgstr "Publica tu aplicación en el mercado para que otros puedan instalarla"
 
 #. js-lingui-id: mF9LxA
 #: src/modules/settings/data-model/fields/forms/select/components/SettingsDataModelFieldSelectFormOptionRow.tsx
@@ -12528,17 +13153,23 @@ msgstr "Trimestre del año"
 #: src/modules/side-panel/pages/page-layout/utils/getDateGranularityPluralLabel.ts
 #: src/modules/side-panel/pages/page-layout/utils/getDateGranularityPluralLabel.ts
 msgid "quarters"
-msgstr ""
+msgstr "trimestres"
 
 #. js-lingui-id: Z9go8W
 #: src/modules/settings/data-model/object-details/components/tabs/SettingsObjectIndexesSection.tsx
-msgid "Queries that relied on it will fall back to a sequential scan. You can recreate it later."
+msgid ""
+"Queries that relied on it will fall back to a sequential scan. You can "
+"recreate it later."
 msgstr ""
+"Las consultas que dependían de él recurrirán a un escaneo secuencial. Puedes"
+" recrearlo más tarde."
 
 #. js-lingui-id: /IUt/5
 #: src/modules/settings/admin-panel/health-status/components/SettingsAdminWorkerHealthStatus.tsx
 msgid "Queue information is not available because the worker is down"
-msgstr "La información de la cola no está disponible porque el trabajador está inactivo"
+msgstr ""
+"La información de la cola no está disponible porque el trabajador está "
+"inactivo"
 
 #. js-lingui-id: e9OqcR
 #: src/modules/settings/admin-panel/health-status/components/SettingsAdminWorkerQueueMetricsSection.tsx
@@ -12586,18 +13217,21 @@ msgstr "Leer documentación"
 #. js-lingui-id: U26cMX
 #: src/pages/settings/ai/components/SettingsAiMoreTab.tsx
 msgid "Read system prompts"
-msgstr ""
+msgstr "Leer indicaciones del sistema"
 
 #. js-lingui-id: EKsFda
 #: src/pages/settings/ai/components/SettingsAiMoreTab.tsx
 msgid "Read the system prompts to understand how the AI works"
-msgstr ""
+msgstr "Leer las indicaciones del sistema para entender cómo funciona la IA"
 
 #. js-lingui-id: 0URVx8
-#. placeholder {0}: formatNumber( systemPromptTokenCount, { abbreviate: true, decimals: 1, }, )
+#. placeholder {0}: formatNumber( systemPromptTokenCount, { abbreviate: true,
+#. decimals: 1, }, )
 #: src/pages/settings/ai/components/SettingsAiMoreTab.tsx
 msgid "Read the system prompts to understand how the AI works (~{0} tokens)"
 msgstr ""
+"Leer las indicaciones del sistema para entender cómo funciona la IA (~{0} "
+"tokens)"
 
 #. js-lingui-id: afMuDE
 #: src/pages/auth/Authorize.tsx
@@ -12608,12 +13242,14 @@ msgstr "Leer tu perfil"
 #: src/pages/settings/ai/SettingsAiPrompts.tsx
 #: src/pages/settings/ai/SettingsAiPrompts.tsx
 msgid "Read-only"
-msgstr ""
+msgstr "Solo lectura"
 
 #. js-lingui-id: 6wOBcu
 #: src/pages/settings/layout/components/SettingsLayoutDetailScaffold.tsx
 msgid "Read-only {entityTypeLabel} definition shipped by this app"
 msgstr ""
+"Definición de solo lectura de {entityTypeLabel} proporcionada por esta "
+"aplicación"
 
 #. js-lingui-id: W+ApAD
 #: src/modules/workflow/workflow-steps/workflow-actions/components/WorkflowEditActionEmailBase.tsx
@@ -12623,12 +13259,14 @@ msgstr "Volver a autorizar"
 #. js-lingui-id: BT7pY+
 #: src/modules/settings/profile/components/SetOrChangePassword.tsx
 msgid "Receive an email containing password set link"
-msgstr "Recibir un correo electrónico con un enlace para establecer la contraseña"
+msgstr ""
+"Recibir un correo electrónico con un enlace para establecer la contraseña"
 
 #. js-lingui-id: v3xM25
 #: src/modules/settings/profile/components/SetOrChangePassword.tsx
 msgid "Receive an email containing password update link"
-msgstr "Recibir un correo electrónico con un enlace para actualizar la contraseña"
+msgstr ""
+"Recibir un correo electrónico con un enlace para actualizar la contraseña"
 
 #. js-lingui-id: ZVr1+K
 #: src/modules/settings/admin-panel/health-status/components/SettingsAdminWorkerMetricsGraph.tsx
@@ -12638,18 +13276,18 @@ msgstr "Eventos Recientes (del más antiguo → al más nuevo)"
 #. js-lingui-id: EoiSFI
 #: src/modules/settings/admin-panel/components/SettingsAdminGeneral.tsx
 msgid "Recent Users"
-msgstr ""
+msgstr "Usuarios recientes"
 
 #. js-lingui-id: AQbgLJ
 #: src/modules/ai/components/NavigationDrawerAiChatContent.tsx
 #: src/modules/ai/components/AiChatThreadsList.tsx
 msgid "Recents"
-msgstr ""
+msgstr "Recientes"
 
 #. js-lingui-id: yPrbsy
 #: src/modules/activities/emails/components/EmailComposerFields.tsx
 msgid "Recipients"
-msgstr ""
+msgstr "Destinatarios"
 
 #. js-lingui-id: b2+5uV
 #: src/modules/settings/admin-panel/ai/components/SettingsAdminAI.tsx
@@ -12667,13 +13305,13 @@ msgstr "Reconectar"
 #. js-lingui-id: NSOx3j
 #: src/pages/settings/applications/SettingsApplicationConnectionDetail.tsx
 msgid "Reconnect and change visibility"
-msgstr ""
+msgstr "Reconectar y cambiar visibilidad"
 
 #. js-lingui-id: XsIxsL
 #: src/pages/settings/applications/SettingsApplicationConnectionDetail.tsx
 #: src/pages/settings/applications/tabs/SettingsApplicationConnectionsSection.tsx
 msgid "Reconnect needed"
-msgstr ""
+msgstr "Reconexión necesaria"
 
 #. js-lingui-id: hVS0gK
 #: src/modules/workflow/workflow-steps/workflow-actions/form-action/components/WorkflowFormFieldSettingsRecordPicker.tsx
@@ -12698,8 +13336,11 @@ msgstr "Registro (ID)"
 
 #. js-lingui-id: 2CUci6
 #: src/modules/object-record/hooks/useBatchCreateManyRecords.ts
-msgid "Record creation stopped. {formattedCreatedRecordsCount} records created."
-msgstr "La creación de registros se detuvo. {formattedCreatedRecordsCount} registros creados."
+msgid ""
+"Record creation stopped. {formattedCreatedRecordsCount} records created."
+msgstr ""
+"La creación de registros se detuvo. {formattedCreatedRecordsCount} registros"
+" creados."
 
 #. js-lingui-id: S2Kvcv
 #: src/modules/object-record/advanced-filter/components/AdvancedFilterRecordFilterOptionsDropdown.tsx
@@ -12750,7 +13391,7 @@ msgstr "Nivel de registro"
 #: src/modules/command-menu-item/edit/components/CommandMenuItemEditRecordSelectionDropdown.tsx
 #: src/modules/command-menu-item/edit/components/CommandMenuItemEditRecordSelectionDropdown.tsx
 msgid "Record(s) selected"
-msgstr ""
+msgstr "Registro(s) seleccionado(s)"
 
 #. js-lingui-id: PWlTvh
 #: src/modules/settings/roles/role-permissions/object-level-permissions/components/SettingsRolePermissionsObjectLevelTableHeader.tsx
@@ -12792,7 +13433,7 @@ msgstr "Actualizar"
 #: src/pages/settings/admin-panel/SettingsAdminInstanceStatus.tsx
 #: src/pages/settings/admin-panel/SettingsAdminInferredVersion.tsx
 msgid "Refresh status"
-msgstr ""
+msgstr "Actualizar estado"
 
 #. js-lingui-id: vpZcGd
 #: src/pages/settings/developers/api-keys/SettingsDevelopersApiKeyDetail.tsx
@@ -12849,8 +13490,12 @@ msgstr "Relaciones"
 
 #. js-lingui-id: ZrUSCK
 #: src/modules/settings/data-model/fields/forms/morph-relation/components/SettingsDataModelFieldRelationForm.tsx
-msgid "Relations cannot include the source object when multiple destinations are selected."
-msgstr "Las relaciones no pueden incluir el objeto de origen cuando se seleccionan múltiples destinos."
+msgid ""
+"Relations cannot include the source object when multiple destinations are "
+"selected."
+msgstr ""
+"Las relaciones no pueden incluir el objeto de origen cuando se seleccionan "
+"múltiples destinos."
 
 #. js-lingui-id: HR+PwH
 #: src/modules/settings/data-model/fields/forms/date/utils/getDisplayFormatLabel.ts
@@ -12924,7 +13569,7 @@ msgstr "Eliminar filtro Eliminado"
 #. js-lingui-id: /hrkZs
 #: src/modules/settings/data-model/indexes/forms/components/SettingsObjectIndexFieldsForm.tsx
 msgid "Remove field"
-msgstr ""
+msgstr "Eliminar campo"
 
 #. js-lingui-id: 9VZ6f0
 #: src/modules/navigation-menu-item/edit/side-panel/components/SidePanelEditOrganizeActions.tsx
@@ -13005,7 +13650,7 @@ msgstr "Renombrar"
 #. js-lingui-id: 6PsaMr
 #: src/modules/ai/components/AiChatThreadListItem.tsx
 msgid "Rename chat"
-msgstr ""
+msgstr "Renombrar chat"
 
 #. js-lingui-id: oQjB9l
 #: src/modules/settings/billing/components/SettingsBillingSubscriptionInfo.tsx
@@ -13025,7 +13670,7 @@ msgstr "Reordenar opciones"
 #. js-lingui-id: q8Id6J
 #: src/modules/side-panel/pages/page-layout/components/WidgetSettingsManageSection.tsx
 msgid "Replace widget"
-msgstr ""
+msgstr "Reemplazar widget"
 
 #. js-lingui-id: ImOQa9
 #: src/modules/side-panel/hooks/useOpenComposeEmailInSidePanel.ts
@@ -13042,12 +13687,12 @@ msgstr "Responder a todos"
 #. js-lingui-id: fiPYZo
 #: src/modules/page-layout/widgets/email-thread/components/EmailThreadComposer.tsx
 msgid "Reply..."
-msgstr ""
+msgstr "Responder..."
 
 #. js-lingui-id: Q3LOVJ
 #: src/modules/settings/applications/components/SettingsApplicationAboutSidebar.tsx
 msgid "Report an issue"
-msgstr ""
+msgstr "Informar de un problema"
 
 #. js-lingui-id: /laZGZ
 #: src/modules/workflow/workflow-steps/workflow-actions/http-request-action/components/HttpRequestExecutionResult.tsx
@@ -13057,7 +13702,7 @@ msgstr "Solicitud fallida"
 #. js-lingui-id: +gFBV8
 #: src/modules/settings/logic-functions/components/triggers/SettingsLogicFunctionHttpTriggerSection.tsx
 msgid "Require authentication"
-msgstr ""
+msgstr "Requerir autenticación"
 
 #. js-lingui-id: TMLAx2
 #: src/pages/settings/ai/components/SettingsToolParameterTable.tsx
@@ -13092,16 +13737,18 @@ msgstr "Restablecer 2FA"
 #: src/modules/settings/data-model/object-details/components/tabs/ObjectLayout.tsx
 msgid "Reset all overrides on this layout to return it to the app default"
 msgstr ""
+"Restablecer todas las anulaciones en este diseño para devolverlo al "
+"predeterminado de la aplicación"
 
 #. js-lingui-id: YdI8A2
 #: src/modules/command-menu-item/edit/components/CommandMenuItemOptionsDropdown.tsx
 msgid "Reset label to default"
-msgstr ""
+msgstr "Restablecer etiqueta al predeterminado"
 
 #. js-lingui-id: AASIAQ
 #: src/modules/layout-customization/components/LayoutCustomizationBarMenuDropdown.tsx
 msgid "Reset record page layout"
-msgstr ""
+msgstr "Restablecer diseño de página de registro"
 
 #. js-lingui-id: L+rMC9
 #: src/modules/side-panel/pages/page-layout/components/WidgetSettingsManageSection.tsx
@@ -13131,12 +13778,12 @@ msgstr "Restablecer variable"
 #. js-lingui-id: ICm0YO
 #: src/modules/settings/billing/components/internal/ResourceCreditPriceSelector.tsx
 msgid "Resource credits"
-msgstr ""
+msgstr "Créditos de recursos"
 
 #. js-lingui-id: N0vrR6
 #: src/modules/settings/billing/components/internal/ResourceCreditPriceSelector.tsx
 msgid "Resource credits updated."
-msgstr ""
+msgstr "Créditos de recursos actualizados."
 
 #. js-lingui-id: esl+Tv
 #: src/pages/settings/security/event-logs/utils/getColumnsForEventLogTable.ts
@@ -13151,7 +13798,7 @@ msgstr "Respuesta"
 #. js-lingui-id: WMdA7Y
 #: src/pages/settings/ai/components/SettingsAgentResponseFormat.tsx
 msgid "Response Format"
-msgstr ""
+msgstr "Formato de respuesta"
 
 #. js-lingui-id: WHiaOl
 #: src/pages/settings/developers/playground/SettingsRestPlayground.tsx
@@ -13183,7 +13830,7 @@ msgstr "Restaurar"
 #. js-lingui-id: 8KyDbM
 #: src/modules/command-menu-item/engine-command/record/components/RestoreRecordsCommand.tsx
 msgid "Restore {objectLabel}"
-msgstr ""
+msgstr "Restaurar {objectLabel}"
 
 #. js-lingui-id: hO3AfV
 #: src/pages/settings/ai/components/SettingsAiModelsTab.tsx
@@ -13192,8 +13839,12 @@ msgstr "Restringir los modelos disponibles a una lista seleccionada"
 
 #. js-lingui-id: fqD5xB
 #: src/modules/settings/domains/components/SettingPublicDomain.tsx
-msgid "Restrict this domain to the HTTP routes of a specific app. Leave empty to expose all workspace HTTP routes."
+msgid ""
+"Restrict this domain to the HTTP routes of a specific app. Leave empty to "
+"expose all workspace HTTP routes."
 msgstr ""
+"Restringe este dominio a las rutas HTTP de una aplicación específica. Déjalo"
+" vacío para exponer todas las rutas HTTP del espacio de trabajo."
 
 #. js-lingui-id: RD6AE9
 #: src/modules/workflow/workflow-steps/workflow-actions/logic-function-action/components/WorkflowEditActionLogicFunction.tsx
@@ -13238,18 +13889,18 @@ msgstr "alfabético inverso"
 #: src/modules/settings/admin-panel/signing-keys/components/SettingsAdminSigningKeysTable.tsx
 #: src/modules/settings/admin-panel/signing-keys/components/SettingsAdminRevokeSigningKeyConfirmationModal.tsx
 msgid "Revoke"
-msgstr ""
+msgstr "Revocar"
 
 #. js-lingui-id: rJrWw4
 #: src/modules/settings/admin-panel/signing-keys/components/SettingsAdminRevokeSigningKeyConfirmationModal.tsx
 msgid "Revoke signing key"
-msgstr ""
+msgstr "Revocar clave de firma"
 
 #. js-lingui-id: xGiT1z
 #: src/modules/settings/admin-panel/signing-keys/components/SettingsAdminSigningKeysTable.tsx
 #: src/modules/settings/admin-panel/signing-keys/components/SettingsAdminSigningKeysTable.tsx
 msgid "Revoked"
-msgstr ""
+msgstr "Revocado"
 
 #. js-lingui-id: GG37FL
 #: src/modules/settings/roles/role-permissions/object-level-permissions/object-form/components/SettingsRolePermissionsObjectLevelObjectFormObjectLevelTableRow.tsx
@@ -13258,8 +13909,12 @@ msgstr "Revocado para este objeto"
 
 #. js-lingui-id: lrTLOv
 #: src/modules/settings/admin-panel/signing-keys/components/SettingsAdminRevokeSigningKeyConfirmationModal.tsx
-msgid "Revoking this key will invalidate every JWT signed with it. Users with active tokens signed by this key will be logged out."
+msgid ""
+"Revoking this key will invalidate every JWT signed with it. Users with "
+"active tokens signed by this key will be logged out."
 msgstr ""
+"Revocar esta clave invalidará cada JWT firmado con ella. Los usuarios con "
+"tokens activos firmados por esta clave cerrarán sesión."
 
 #. js-lingui-id: NP5Nbf
 #: src/modules/side-panel/pages/page-layout/components/SidePanelPageLayoutDashboardWidgetTypeSelect.tsx
@@ -13304,12 +13959,12 @@ msgstr "El nombre del rol no puede estar vacío"
 #. js-lingui-id: VMX1Oy
 #: src/modules/metadata-error-handler/hooks/useMetadataErrorHandler.ts
 msgid "role permission flag"
-msgstr ""
+msgstr "indicador de permiso de rol"
 
 #. js-lingui-id: jLNGne
 #: src/modules/metadata-error-handler/hooks/useMetadataErrorHandler.ts
 msgid "role target"
-msgstr ""
+msgstr "objetivo de rol"
 
 #. js-lingui-id: M9SCiK
 #: src/pages/settings/developers/api-keys/SettingsDevelopersApiKeyDetail.tsx
@@ -13320,7 +13975,7 @@ msgstr "Rol actualizado con éxito"
 #. js-lingui-id: i9AFmv
 #: src/pages/settings/applications/SettingsAvailableApplicationDetails.tsx
 msgid "roles"
-msgstr ""
+msgstr "roles"
 
 #. js-lingui-id: 5dJK4M
 #: src/pages/settings/members/SettingsWorkspaceMembers.tsx
@@ -13386,7 +14041,7 @@ msgstr "Rubí"
 #. js-lingui-id: 3JjdaA
 #: src/pages/settings/ai/components/SettingsAgentEvalsTab.tsx
 msgid "Run"
-msgstr ""
+msgstr "Ejecutar"
 
 #. js-lingui-id: UX0N2y
 #: src/modules/object-record/record-table/empty-state/utils/getEmptyStateSubTitle.ts
@@ -13421,7 +14076,7 @@ msgstr "Ruso"
 #. js-lingui-id: 3hNFUc
 #: src/modules/settings/logic-functions/components/triggers/SettingsLogicFunctionTriggerPayloadFormat.tsx
 msgid "Sample input"
-msgstr ""
+msgstr "Entrada de ejemplo"
 
 #. js-lingui-id: +5kO8P
 #: src/pages/settings/profile/appearance/components/DateTimeSettingsCalendarStartDaySelect.tsx
@@ -13442,7 +14097,7 @@ msgstr "Guardar como nueva vista"
 #. js-lingui-id: 7byqGp
 #: src/modules/layout-customization/hooks/useEnterLayoutCustomizationMode.ts
 msgid "Save or cancel dashboard changes before editing the layout."
-msgstr ""
+msgstr "Guarda o cancela los cambios del panel antes de editar el diseño."
 
 #. js-lingui-id: gmB6oO
 #: src/modules/workflow/workflow-trigger/components/CronExpressionHelper.tsx
@@ -13452,12 +14107,12 @@ msgstr "Programación"
 #. js-lingui-id: Ys/D8h
 #: src/modules/settings/admin-panel/health-status/maintenance-mode/components/SettingsAdminMaintenanceMode.tsx
 msgid "Schedule a maintenance window and notify all users"
-msgstr ""
+msgstr "Programa una ventana de mantenimiento y notifica a todos los usuarios"
 
 #. js-lingui-id: f5yMQc
 #: src/modules/information-banner/components/maintenance/InformationBannerMaintenance.tsx
 msgid "Scheduled maintenance: {startFormatted} — {endFormatted}"
-msgstr ""
+msgstr "Mantenimiento programado: {startFormatted} — {endFormatted}"
 
 #. js-lingui-id: QJ8HBJ
 #: src/modules/settings/playground/components/PlaygroundSetupForm.tsx
@@ -13472,7 +14127,7 @@ msgstr "Nombre del esquema"
 #. js-lingui-id: IYEdtc
 #: src/pages/settings/applications/tabs/SettingsApplicationDetailContentTab.tsx
 msgid "Schema this app contributes to your workspace"
-msgstr ""
+msgstr "Esquema que esta aplicación aporta a tu espacio de trabajo"
 
 #. js-lingui-id: N/rFzD
 #: src/pages/settings/applications/tabs/SettingsApplicationRegistrationOAuthTab.tsx
@@ -13484,7 +14139,7 @@ msgstr "Ámbitos"
 #: src/pages/settings/ai/components/SettingsAgentLogsTab.tsx
 #: src/pages/settings/ai/components/SettingsAgentLogsTab.tsx
 msgid "Score"
-msgstr ""
+msgstr "Puntuación"
 
 #. js-lingui-id: hJjXGo
 #: src/pages/settings/admin-panel/SettingsAdminAiProviderDetail.tsx
@@ -13556,7 +14211,7 @@ msgstr "Buscar un miembro del equipo..."
 #. js-lingui-id: VNmPqQ
 #: src/pages/settings/ai/components/SettingsToolsTable.tsx
 msgid "Search a tool..."
-msgstr ""
+msgstr "Buscar una herramienta..."
 
 #. js-lingui-id: lnDfeK
 #: src/modules/settings/data-model/fields/forms/components/SettingsObjectNewFieldSelector.tsx
@@ -13571,7 +14226,7 @@ msgstr "Buscar una vista..."
 #. js-lingui-id: N7Z3jc
 #: src/modules/settings/data-model/object-details/components/tabs/SettingsObjectSearchSection.tsx
 msgid "Search across indexed fields..."
-msgstr ""
+msgstr "Buscar en campos indexados..."
 
 #. js-lingui-id: +7s4fw
 #: src/modules/settings/roles/role-assignment/components/SettingsRoleAssignmentEntityPickerDropdown.tsx
@@ -13630,12 +14285,12 @@ msgstr "Buscar claves API"
 #. js-lingui-id: iRegw9
 #: src/modules/settings/admin-panel/components/SettingsAdminGeneral.tsx
 msgid "Search by name, email, or user ID..."
-msgstr ""
+msgstr "Buscar por nombre, correo electrónico o ID de usuario..."
 
 #. js-lingui-id: KI1xjO
 #: src/modules/settings/admin-panel/components/SettingsAdminGeneral.tsx
 msgid "Search by workspace name, subdomain, or ID..."
-msgstr ""
+msgstr "Buscar por nombre del espacio de trabajo, subdominio o ID..."
 
 #. js-lingui-id: yI4D/V
 #: src/modules/side-panel/pages/page-layout/components/dropdown-content/ChartColorSelectionDropdownContent.tsx
@@ -13767,7 +14422,7 @@ msgstr "asiento / mes - facturado anualmente"
 #. js-lingui-id: MpFIca
 #: src/modules/settings/admin-panel/components/SettingsAdminWorkspaceBillingContent.tsx
 msgid "seats"
-msgstr ""
+msgstr "licencias"
 
 #. js-lingui-id: grt0Pu
 #: src/modules/settings/billing/components/SettingsBillingSubscriptionInfo.tsx
@@ -13837,12 +14492,12 @@ msgstr "Ver todos los {relationLabelPlural} vinculados a este registro"
 #. js-lingui-id: 3o+CgI
 #: src/pages/settings/applications/components/SettingsApplicationRegistrationShareLinkButtons.tsx
 msgid "See app page"
-msgstr ""
+msgstr "Ver página de la aplicación"
 
 #. js-lingui-id: sFsCOG
 #: src/pages/settings/members/tabs/SettingsWorkspaceMembersTeamTab.tsx
 msgid "See data model settings"
-msgstr ""
+msgstr "Ver configuración del modelo de datos"
 
 #. js-lingui-id: oGROXc
 #: src/modules/settings/roles/role-permissions/object-level-permissions/components/SettingsRolePermissionsObjectLevelTableHeader.tsx
@@ -13852,18 +14507,18 @@ msgstr "Ver Campos"
 #. js-lingui-id: RpeN29
 #: src/pages/settings/ai/components/SettingsToolParameterTable.tsx
 msgid "See function"
-msgstr ""
+msgstr "Ver función"
 
 #. js-lingui-id: V7TecA
 #: src/pages/settings/applications/components/SettingsApplicationRegistrationShareLinkButtons.tsx
 msgid "See on marketplace"
-msgstr ""
+msgstr "Ver en el mercado"
 
 #. js-lingui-id: vn4aKq
 #: src/pages/settings/members/tabs/SettingsWorkspaceMembersTeamTab.tsx
 #: src/pages/settings/data-model/SettingsObjectDetailPage.tsx
 msgid "See records"
-msgstr ""
+msgstr "Ver registros"
 
 #. js-lingui-id: irbH/8
 #: src/modules/settings/roles/role-permissions/objects-permissions/components/SettingsRolePermissionsObjectsSection.tsx
@@ -13873,7 +14528,7 @@ msgstr "Ver registros en todos los objetos"
 #. js-lingui-id: Hhnssf
 #: src/pages/settings/applications/components/SettingsApplicationTableRow.tsx
 msgid "Seeded"
-msgstr ""
+msgstr "Inicializado"
 
 #. js-lingui-id: rG3WVm
 #: src/modules/spreadsheet-import/steps/components/ValidationStep/components/columns.tsx
@@ -13901,7 +14556,7 @@ msgstr "Selecciona una fecha"
 #. js-lingui-id: 1YV5aa
 #: src/modules/settings/data-model/indexes/forms/components/SettingsObjectIndexFieldsForm.tsx
 msgid "Select a field"
-msgstr ""
+msgstr "Selecciona un campo"
 
 #. js-lingui-id: bP/w4M
 #: src/modules/workflow/workflow-steps/filters/components/WorkflowStepFilterFieldSelect.tsx
@@ -14066,8 +14721,11 @@ msgstr "Seleccionar un valor"
 
 #. js-lingui-id: RKE3bT
 #: src/modules/settings/admin-panel/ai/components/SettingsAdminAI.tsx
-msgid "Select which models appear as recommended in the workspace model picker"
-msgstr "Selecciona qué modelos aparecen como recomendados en el selector de modelos del espacio de trabajo"
+msgid ""
+"Select which models appear as recommended in the workspace model picker"
+msgstr ""
+"Selecciona qué modelos aparecen como recomendados en el selector de modelos "
+"del espacio de trabajo"
 
 #. js-lingui-id: AXTJAW
 #: src/pages/settings/profile/appearance/components/SettingsExperience.tsx
@@ -14079,7 +14737,7 @@ msgstr "Selecciona tu idioma preferido"
 #: src/modules/page-layout/widgets/email-thread/components/EmailThreadComposer.tsx
 #: src/modules/activities/emails/components/EmailComposer.tsx
 msgid "Send"
-msgstr ""
+msgstr "Enviar"
 
 #. js-lingui-id: mjK8F3
 #: src/pages/settings/members/tabs/SettingsWorkspaceMembersInviteTab.tsx
@@ -14132,6 +14790,8 @@ msgstr "Variables del servidor"
 #: src/pages/settings/applications/tabs/SettingsApplicationRegistrationConfigTab.tsx
 msgid "Server variables are applied to all workspace installations."
 msgstr ""
+"Las variables del servidor se aplican a todas las instalaciones del espacio "
+"de trabajo."
 
 #. js-lingui-id: LUc0oL
 #: src/modules/settings/security/components/SSO/SettingsSSOSAMLForm.tsx
@@ -14166,7 +14826,9 @@ msgstr "Establecer como principal"
 #. js-lingui-id: V7fgiB
 #: src/modules/settings/accounts/components/SettingsAccountsSettingsSection.tsx
 msgid "Set email visibility, manage your blocklist and more."
-msgstr "Configura la visibilidad del correo electrónico, gestiona tu lista de bloqueo y más."
+msgstr ""
+"Configura la visibilidad del correo electrónico, gestiona tu lista de "
+"bloqueo y más."
 
 #. js-lingui-id: qFjlHh
 #: src/modules/side-panel/pages/page-layout/components/NewFieldDefaultVisibilityToggle.tsx
@@ -14187,12 +14849,15 @@ msgstr "Establecer contraseña"
 #. js-lingui-id: qNbuWB
 #: src/modules/settings/domains/components/SettingsCustomDomain.tsx
 msgid "Set the name of your custom domain and configure your DNS records."
-msgstr "Establece el nombre de tu dominio personalizado y configura tus registros DNS."
+msgstr ""
+"Establece el nombre de tu dominio personalizado y configura tus registros "
+"DNS."
 
 #. js-lingui-id: d+3DrP
 #: src/modules/settings/domains/components/SettingPublicDomain.tsx
 msgid "Set the name of your public domain and configure your DNS records."
-msgstr "Establece el nombre de tu dominio público y configura tus registros DNS."
+msgstr ""
+"Establece el nombre de tu dominio público y configura tus registros DNS."
 
 #. js-lingui-id: tn41zE
 #: src/modules/settings/domains/components/SettingsSubdomain.tsx
@@ -14212,7 +14877,7 @@ msgstr "Configura un campo de selección en {objectLabel} para crear un Kanban"
 #. js-lingui-id: l6W1lM
 #: src/pages/settings/workspace/SettingsWorkspaceEmailGroupChannelDetail.tsx
 msgid "Set up forwarding from the source address to this destination."
-msgstr ""
+msgstr "Configura el reenvío desde la dirección de origen a este destino."
 
 #. js-lingui-id: 9HNKkV
 #: src/pages/settings/applications/tabs/SettingsApplicationDetailEnvironmentVariablesTable.tsx
@@ -14222,7 +14887,7 @@ msgstr "Configurar variables de configuración de su aplicación"
 #. js-lingui-id: 9qcWSO
 #: src/pages/settings/applications/components/SettingsApplicationRegistrationConfigVariableDetail.tsx
 msgid "set-config-value"
-msgstr ""
+msgstr "establecer-valor-config"
 
 #. js-lingui-id: dQsqpC
 #: src/pages/onboarding/CreateWorkspace.tsx
@@ -14291,27 +14956,34 @@ msgstr "Compartir"
 #. js-lingui-id: Vy9kmk
 #: src/pages/settings/members/tabs/SettingsWorkspaceMembersInviteTab.tsx
 msgid "Share this link to invite users to join your workspace"
-msgstr "Comparte este enlace para invitar a los usuarios a unirse a tu espacio de trabajo"
+msgstr ""
+"Comparte este enlace para invitar a los usuarios a unirse a tu espacio de "
+"trabajo"
 
 #. js-lingui-id: bM7Rp3
 #: src/pages/settings/applications/SettingsApplicationConnectionDetail.tsx
 msgid "Share with workspace"
-msgstr ""
+msgstr "Compartir con el espacio de trabajo"
 
 #. js-lingui-id: gaJRur
 #: src/pages/settings/applications/tabs/SettingsApplicationRegistrationDistributionTab.tsx
-msgid "Share your app to other workspaces without pushing it on the marketplace"
+msgid ""
+"Share your app to other workspaces without pushing it on the marketplace"
 msgstr ""
+"Comparte tu aplicación con otros espacios de trabajo sin publicarla en el "
+"mercado"
 
 #. js-lingui-id: 9ZxCpH
 #: src/modules/settings/workspace/components/SettingsWorkspaceEmailGroupSection.tsx
 msgid "Shared addresses your workspace uses to send and receive email."
 msgstr ""
+"Direcciones compartidas que tu espacio de trabajo usa para enviar y recibir "
+"correo."
 
 #. js-lingui-id: NyIsOu
 #: src/pages/settings/applications/components/SettingsApplicationRegistrationShareLinkButtons.tsx
 msgid "Sharing link copied to clipboard"
-msgstr ""
+msgstr "Enlace para compartir copiado al portapapeles"
 
 #. js-lingui-id: RRXpo1
 #: src/modules/settings/data-model/fields/forms/number/constants/NumberDataModelSelectOptions.ts
@@ -14321,17 +14993,21 @@ msgstr "Corto"
 #. js-lingui-id: 2rtIq8
 #: src/pages/settings/applications/tabs/SettingsApplicationCommandMenuItemSettingsTab.tsx
 msgid "Short label"
-msgstr ""
+msgstr "Etiqueta corta"
 
 #. js-lingui-id: gWk8gY
 #: src/modules/settings/data-model/fields/forms/components/SettingsDataModelFieldIconLabelForm.tsx
 msgid "Should changing a field's label also change the API name?"
-msgstr "¿Debería cambiar también el nombre de la API al cambiar la etiqueta de un campo?"
+msgstr ""
+"¿Debería cambiar también el nombre de la API al cambiar la etiqueta de un "
+"campo?"
 
 #. js-lingui-id: WFtdWr
 #: src/modules/settings/data-model/objects/forms/components/SettingsDataModelObjectAboutForm.tsx
 msgid "Should changing an object's label also change the API?"
-msgstr "¿Debería cambiar también el nombre de la API al cambiar la etiqueta de un objeto?"
+msgstr ""
+"¿Debería cambiar también el nombre de la API al cambiar la etiqueta de un "
+"objeto?"
 
 #. js-lingui-id: zasxcV
 #: src/pages/settings/ai/SettingsSkillForm.tsx
@@ -14356,7 +15032,7 @@ msgstr "Mostrar grupos ocultos"
 #. js-lingui-id: eOY8jq
 #: src/modules/side-panel/components/SidePanelObjectFilterDropdownContent.tsx
 msgid "Show hidden objects"
-msgstr ""
+msgstr "Mostrar objetos ocultos"
 
 #. js-lingui-id: qi+g0a
 #: src/modules/spreadsheet-import/steps/components/ValidationStep/ValidationStep.tsx
@@ -14366,12 +15042,12 @@ msgstr "Mostrar solo filas con errores"
 #. js-lingui-id: 3UVA3z
 #: src/modules/settings/data-model/object-details/components/tabs/SettingsObjectSearchSection.tsx
 msgid "Show this object's records in the command menu (⌘K)."
-msgstr ""
+msgstr "Mostrar los registros de este objeto en el menú de comandos (⌘K)."
 
 #. js-lingui-id: TJ4tz9
 #: src/modules/side-panel/pages/page-layout/constants/settings/ChartConfigurationSettingLabels.ts
 msgid "Show value in center"
-msgstr ""
+msgstr "Mostrar valor en el centro"
 
 #. js-lingui-id: uVg8dY
 #: src/modules/object-record/object-options-dropdown/components/ObjectOptionsDropdownLayoutOpenInContent.tsx
@@ -14398,16 +15074,17 @@ msgstr "Registrarse"
 #: src/modules/auth/sign-in-up/components/internal/SignInUpWithCredentials.tsx
 msgid "Sign-up is temporarily unavailable during maintenance."
 msgstr ""
+"El registro no está disponible temporalmente durante el mantenimiento."
 
 #. js-lingui-id: X1zsRT
 #: src/modules/settings/admin-panel/signing-keys/hooks/useRevokeSigningKey.ts
 msgid "Signing key revoked"
-msgstr ""
+msgstr "Clave de firma revocada"
 
 #. js-lingui-id: Gzr66P
 #: src/modules/settings/admin-panel/health-status/components/SettingsAdminHealthStatus.tsx
 msgid "Signing Keys"
-msgstr ""
+msgstr "Claves de firma"
 
 #. js-lingui-id: BZdVGR
 #: src/modules/settings/data-model/fields/forms/select/components/SettingsDataModelFieldSelectForm.tsx
@@ -14442,7 +15119,7 @@ msgstr "Sexto"
 #. js-lingui-id: Cj2Gtd
 #: src/pages/settings/layout/SettingsLayoutViewDetail.tsx
 msgid "Size"
-msgstr ""
+msgstr "Tamaño"
 
 #. js-lingui-id: Nbjq/v
 #: src/pages/settings/admin-panel/SettingsAdminNewAiProvider.tsx
@@ -14486,7 +15163,7 @@ msgstr "No se encontró la habilidad"
 #. js-lingui-id: gPdJ1+
 #: src/pages/settings/applications/SettingsAvailableApplicationDetails.tsx
 msgid "skills"
-msgstr ""
+msgstr "habilidades"
 
 #. js-lingui-id: PCSkw2
 #: src/pages/settings/applications/tabs/SettingsApplicationDetailContentTab.tsx
@@ -14496,8 +15173,7 @@ msgid "Skills"
 msgstr "Habilidades"
 
 #. js-lingui-id: 6Uau97
-#: src/pages/onboarding/InviteTeam.tsx
-#: src/pages/onboarding/BookCall.tsx
+#: src/pages/onboarding/InviteTeam.tsx src/pages/onboarding/BookCall.tsx
 msgid "Skip"
 msgstr "Omitir"
 
@@ -14509,7 +15185,8 @@ msgstr "Omitir la creación de un campo Nombre "
 #. js-lingui-id: PlF+NA
 #: src/modules/settings/data-model/fields/forms/morph-relation/components/SettingsDataModelFieldRelationJunctionForm.tsx
 msgid "Skip the junction object (similar to many-to-many relations)"
-msgstr "Omitir el objeto de unión (similar a las relaciones de muchos a muchos)"
+msgstr ""
+"Omitir el objeto de unión (similar a las relaciones de muchos a muchos)"
 
 #. js-lingui-id: BIZl8w
 #: src/modules/settings/data-model/fields/forms/select/components/SettingsDataModelFieldSelectFormOptionRow.tsx
@@ -14624,7 +15301,7 @@ msgstr "Ordenar por grupo"
 #. js-lingui-id: fLIwZB
 #: src/modules/object-record/record-index/utils/getNonReadableViewFieldSubTitle.ts
 msgid "sorting"
-msgstr ""
+msgstr "ordenación"
 
 #. js-lingui-id: 0pWTum
 #: src/pages/settings/layout/SettingsLayoutViewDetail.tsx
@@ -14648,17 +15325,17 @@ msgstr "Fuente"
 #. js-lingui-id: Pp9DbE
 #: src/pages/settings/workspace/SettingsWorkspaceEmailGroupChannelDetail.tsx
 msgid "Source address"
-msgstr ""
+msgstr "Dirección de origen"
 
 #. js-lingui-id: 5f1fxa
 #: src/modules/settings/accounts/components/SettingsAccountsNewEmailGroupChannel.tsx
 msgid "Source Email Address"
-msgstr ""
+msgstr "Dirección de correo electrónico de origen"
 
 #. js-lingui-id: xqlr9R
 #: src/modules/settings/experience/components/NumberFormatSelect.tsx
 msgid "Spaces and comma"
-msgstr ""
+msgstr "Espacios y coma"
 
 #. js-lingui-id: 65A04M
 #: src/pages/settings/profile/appearance/components/LocalePicker.tsx
@@ -14667,8 +15344,13 @@ msgstr "Español"
 
 #. js-lingui-id: pyfee5
 #: src/modules/settings/data-model/object-details/components/tabs/ObjectSettings.tsx
-msgid "Speed up reads on the fields you filter or sort by most. Each index also slows down writes and uses disk space, so add them with intent."
+msgid ""
+"Speed up reads on the fields you filter or sort by most. Each index also "
+"slows down writes and uses disk space, so add them with intent."
 msgstr ""
+"Acelera las lecturas en los campos que filtras u ordenas más. Cada índice "
+"también ralentiza las escrituras y usa espacio en disco, así que añádelos "
+"con intención."
 
 #. js-lingui-id: gsifzp
 #: src/modules/side-panel/pages/page-layout/utils/__tests__/shouldHideChartSetting.test.ts
@@ -14730,7 +15412,9 @@ msgstr "Comenzar"
 #. js-lingui-id: ASqWQi
 #: src/pages/settings/enterprise/SettingsEnterprise.tsx
 msgid "Start a new enterprise subscription to re-enable enterprise features."
-msgstr "Inicia una nueva suscripción Enterprise para volver a habilitar las funciones Enterprise."
+msgstr ""
+"Inicia una nueva suscripción Enterprise para volver a habilitar las "
+"funciones Enterprise."
 
 #. js-lingui-id: OC6rnK
 #: src/pages/settings/enterprise/SettingsEnterprise.tsx
@@ -14740,7 +15424,7 @@ msgstr "Inicia una nueva suscripción Enterprise."
 #. js-lingui-id: WAjFYI
 #: src/modules/settings/admin-panel/health-status/maintenance-mode/components/SettingsAdminMaintenanceMode.tsx
 msgid "Start date"
-msgstr ""
+msgstr "Fecha de inicio"
 
 #. js-lingui-id: D3iCkb
 #: src/pages/settings/security/event-logs/components/EventLogFilters.tsx
@@ -14824,27 +15508,27 @@ msgstr "Dirección 2"
 #. js-lingui-id: UJNV7l
 #: src/pages/settings/ai/components/SettingsAgentResponseFormat.tsx
 msgid "String"
-msgstr ""
+msgstr "Texto"
 
 #. js-lingui-id: zHJ27S
 #: src/modules/settings/admin-panel/components/SettingsAdminWorkspaceBillingContent.tsx
 msgid "Stripe customer"
-msgstr ""
+msgstr "Cliente de Stripe"
 
 #. js-lingui-id: Zk8585
 #: src/modules/settings/admin-panel/components/SettingsAdminWorkspaceBillingContent.tsx
 msgid "Stripe customer linked to this workspace"
-msgstr ""
+msgstr "Cliente de Stripe vinculado a este espacio de trabajo"
 
 #. js-lingui-id: Yiplcx
 #: src/modules/settings/admin-panel/components/SettingsAdminWorkspaceBillingContent.tsx
 msgid "Stripe subscription"
-msgstr ""
+msgstr "Suscripción de Stripe"
 
 #. js-lingui-id: 1CalO6
 #: src/modules/side-panel/pages/page-layout/constants/ChartSettingsHeadings.ts
 msgid "Style"
-msgstr ""
+msgstr "Estilo"
 
 #. js-lingui-id: WIUeUf
 #: src/modules/settings/data-model/fields/forms/address/components/SettingsDataModelFieldAddressForm.tsx
@@ -14911,7 +15595,8 @@ msgstr "Asunto no compartido"
 #. js-lingui-id: J9ylmk
 #: src/modules/settings/accounts/components/SettingsAccountsMessageVisibilityCard.tsx
 msgid "Subject, body and attachments will be shared with your team."
-msgstr "El asunto, el cuerpo y los archivos adjuntos se compartirán con tu equipo."
+msgstr ""
+"El asunto, el cuerpo y los archivos adjuntos se compartirán con tu equipo."
 
 #. js-lingui-id: hQRttt
 #: src/modules/workflow/workflow-steps/workflow-actions/form-action/components/WorkflowEditActionFormFiller.tsx
@@ -14960,8 +15645,11 @@ msgstr "La suscripción se cambiará a mensual el {beautifiedRenewDate}."
 
 #. js-lingui-id: WB5mu5
 #: src/modules/settings/billing/components/SettingsBillingSubscriptionInfo.tsx
-msgid "Subscription will be switched to {oppositPlan} Plan the {beautifiedRenewDate}."
-msgstr "La suscripción se cambiará al plan {oppositPlan} el {beautifiedRenewDate}."
+msgid ""
+"Subscription will be switched to {oppositPlan} Plan the "
+"{beautifiedRenewDate}."
+msgstr ""
+"La suscripción se cambiará al plan {oppositPlan} el {beautifiedRenewDate}."
 
 #. js-lingui-id: pEToQK
 #: src/modules/advanced-text-editor/extensions/slash-command/DefaultSlashCommands.ts
@@ -14976,7 +15664,9 @@ msgstr "Éxito"
 #. js-lingui-id: OjK1bU
 #: src/modules/object-record/record-merge/hooks/useMergeRecordsActions.ts
 msgid "Successfully merged {recordCount} records"
-msgstr "{recordCount, plural, one {Se ha fusionado con éxito {recordCount} registro} other {Se han fusionado con éxito {recordCount} registros}}"
+msgstr ""
+"{recordCount, plural, one {Se ha fusionado con éxito {recordCount} registro}"
+" other {Se han fusionado con éxito {recordCount} registros}}"
 
 #. js-lingui-id: QJz8/3
 #: src/modules/side-panel/pages/page-layout/constants/settings/ChartConfigurationSettingLabels.ts
@@ -15060,12 +15750,14 @@ msgstr "Sincronización fallida"
 #. js-lingui-id: tVKt7G
 #: src/pages/settings/security/SettingsSecurity.tsx
 msgid "Sync Internal Emails"
-msgstr ""
+msgstr "Sincronizar correos internos"
 
 #. js-lingui-id: ZS+BPb
 #: src/modules/information-banner/components/reconnect-account/InformationBannerReconnectAccountInsufficientPermissions.tsx
 msgid "Sync lost with mailbox {mailboxHandle}. Please reconnect for updates:"
-msgstr "Se perdió la sincronización con el buzón {mailboxHandle}. Vuelve a conectarlo para recibir actualizaciones:"
+msgstr ""
+"Se perdió la sincronización con el buzón {mailboxHandle}. Vuelve a "
+"conectarlo para recibir actualizaciones:"
 
 #. js-lingui-id: L4+l7C
 #: src/pages/onboarding/SyncEmails.tsx
@@ -15079,8 +15771,11 @@ msgstr "Sincronizar con Outlook"
 
 #. js-lingui-id: +9x4tK
 #: src/pages/onboarding/SyncEmails.tsx
-msgid "Sync your Emails and Calendar with Twenty. Choose your privacy settings."
-msgstr "Sincroniza tus correos electrónicos y calendario con Twenty. Elige tu configuración de privacidad."
+msgid ""
+"Sync your Emails and Calendar with Twenty. Choose your privacy settings."
+msgstr ""
+"Sincroniza tus correos electrónicos y calendario con Twenty. Elige tu "
+"configuración de privacidad."
 
 #. js-lingui-id: N2FcBE
 #: src/modules/settings/accounts/components/SettingsAccountsConnectedAccountsRowRightContainer.tsx
@@ -15171,7 +15866,7 @@ msgstr "Pestaña"
 #. placeholder {0}: tab.title
 #: src/pages/settings/layout/SettingsLayoutPageLayoutDetail.tsx
 msgid "Tab {tabNumber}: {0}"
-msgstr ""
+msgstr "Pestaña {tabNumber}: {0}"
 
 #. js-lingui-id: zr20ox
 #: src/modules/side-panel/pages/page-layout/utils/getPageLayoutPageTitle.ts
@@ -15213,7 +15908,7 @@ msgstr "Título de la tarea"
 #. js-lingui-id: KM6m8p
 #: src/pages/settings/members/SettingsWorkspaceMembers.tsx
 msgid "Team"
-msgstr ""
+msgstr "Equipo"
 
 #. js-lingui-id: lKXcJz
 #: src/pages/settings/emailing-domains/utils/getEmailingDomainStatusText.ts
@@ -15279,11 +15974,18 @@ msgstr "Editor de texto"
 #: src/pages/settings/workspace/SettingsWorkspaceEmailGroupChannelDetail.tsx
 msgid "The address your workspace sends and receives email from."
 msgstr ""
+"La dirección desde la que tu espacio de trabajo envía y recibe correo."
 
 #. js-lingui-id: Z4WP0F
 #: src/modules/settings/accounts/components/SettingsAccountsNewEmailGroupChannel.tsx
-msgid "The address your workspace will send and receive email from (e.g. support@mycompany.com). Outbound sending requires the domain to be verified in Outbound Domains."
+msgid ""
+"The address your workspace will send and receive email from (e.g. "
+"support@mycompany.com). Outbound sending requires the domain to be verified "
+"in Outbound Domains."
 msgstr ""
+"La dirección desde la que tu espacio de trabajo enviará y recibirá correo "
+"(ej. soporte@miempresa.com). El envío saliente requiere que el dominio esté "
+"verificado en Dominios de Salida."
 
 #. js-lingui-id: oVH0Mt
 #: src/pages/settings/admin-panel/SettingsAdminNewAiProvider.tsx
@@ -15329,6 +16031,36 @@ msgid ""
 "\n"
 "See the [Getting Started guide](https://twenty.com/developers/extend/apps/getting-started) for the full walkthrough, and [Building Apps](https://twenty.com/developers/extend/apps/building) for the `defineApplication` / `defineEntity` APIs."
 msgstr ""
+"El modelo de datos base sobre el que funciona todo espacio de trabajo de Twenty.\n"
+"\n"
+"#### Qué significa \"fundación\"\n"
+"\n"
+"Todo espacio de trabajo de Twenty comienza con este conjunto de objetos. Definen la forma de tu CRM, incluyendo relaciones, actividad e informes. Todo lo demás, incluyendo aplicaciones del mercado, agentes de IA y objetos personalizados, se conecta a ellos.\n"
+"\n"
+"#### Objetos incluidos\n"
+"- **Personas y Empresas**: registros de contactos y cuentas\n"
+"- **Oportunidades**: tu pipeline de ventas\n"
+"- **Notas y Tareas**: actividad y seguimientos\n"
+"- **Flujos de trabajo y Paneles**: automatización e informes\n"
+"\n"
+"Elimina esta aplicación y el resto de Twenty no tendrá dónde apoyarse.\n"
+"\n"
+"#### Construye tu propia aplicación\n"
+"\n"
+"Extiende Twenty con tus propios objetos, campos, funciones lógicas o habilidades de IA. Crea una nueva aplicación con un solo comando:\n"
+"\n"
+"```bash\n"
+"npx create-twenty-app@latest my-twenty-app\n"
+"```\n"
+"\n"
+"Luego dentro de la carpeta:\n"
+"\n"
+"```bash\n"
+"cd my-twenty-app\n"
+"yarn twenty dev\n"
+"```\n"
+"\n"
+"Consulta la [guía de inicio](https://twenty.com/developers/extend/apps/getting-started) para el recorrido completo, y [Construyendo aplicaciones](https://twenty.com/developers/extend/apps/building) para las APIs `defineApplication` / `defineEntity`."
 
 #. js-lingui-id: 1xQkU9
 #: src/modules/settings/data-model/fields/forms/phones/components/SettingsDataModelFieldPhonesForm.tsx
@@ -15353,7 +16085,7 @@ msgstr "El nombre de dominio que deseas usar para enviar correos electrónicos"
 #. js-lingui-id: xJSPh6
 #: src/modules/settings/members/components/MemberInfosTab.tsx
 msgid "The email associated to this account"
-msgstr ""
+msgstr "El correo electrónico asociado a esta cuenta"
 
 #. js-lingui-id: VGZYbZ
 #: src/pages/settings/SettingsProfile.tsx
@@ -15363,7 +16095,9 @@ msgstr "El correo electrónico asociado a tu cuenta"
 #. js-lingui-id: diO3fm
 #: src/modules/workflow/workflow-trigger/components/WorkflowEditTriggerManual.tsx
 msgid "The icon your workflow trigger will display in the command menu"
-msgstr "El icono que tu disparador de flujo de trabajo mostrará en el menú de comandos"
+msgstr ""
+"El icono que tu disparador de flujo de trabajo mostrará en el menú de "
+"comandos"
 
 #. js-lingui-id: HiI1Lo
 #: src/pages/settings/admin-panel/SettingsAdminNewAiModel.tsx
@@ -15393,8 +16127,11 @@ msgstr "El nombre de tu organización"
 
 #. js-lingui-id: L97sPr
 #: src/pages/not-found/NotFound.tsx
-msgid "The page you're seeking is either gone or never was. Let's get you back on track"
-msgstr "La página que buscas ha desaparecido o nunca existió. Volvamos a la pista"
+msgid ""
+"The page you're seeking is either gone or never was. Let's get you back on "
+"track"
+msgstr ""
+"La página que buscas ha desaparecido o nunca existió. Volvamos a la pista"
 
 #. js-lingui-id: jrCR2X
 #: src/modules/workflow/workflow-trigger/components/WorkflowEditTriggerManual.tsx
@@ -15403,8 +16140,12 @@ msgstr "El registro seleccionado se pasará a su flujo de trabajo"
 
 #. js-lingui-id: aCcfHJ
 #: src/modules/workflow/workflow-trigger/components/WorkflowEditTriggerManual.tsx
-msgid "The selected records (up to {maxRecordsFormatted}) will be passed to your workflow"
+msgid ""
+"The selected records (up to {maxRecordsFormatted}) will be passed to your "
+"workflow"
 msgstr ""
+"Los registros seleccionados (hasta {maxRecordsFormatted}) se pasarán a tu "
+"flujo de trabajo"
 
 #. js-lingui-id: uWikAA
 #: src/pages/settings/data-model/SettingsObjectFieldEdit.tsx
@@ -15448,18 +16189,29 @@ msgstr "No hay notas asociadas con este registro."
 
 #. js-lingui-id: /cSDOy
 #: src/modules/spreadsheet-import/steps/components/MatchColumnsStep/MatchColumnsStep.tsx
-msgid "There are required columns that are not matched or ignored. Do you want to continue?"
-msgstr "Hay columnas requeridas que no están asignadas o ignoradas. ¿Quieres continuar?"
+msgid ""
+"There are required columns that are not matched or ignored. Do you want to "
+"continue?"
+msgstr ""
+"Hay columnas requeridas que no están asignadas o ignoradas. ¿Quieres "
+"continuar?"
 
 #. js-lingui-id: luL9RX
 #: src/modules/spreadsheet-import/steps/components/ValidationStep/ValidationStep.tsx
-msgid "There are still some rows that contain errors. Rows with errors will be ignored when submitting."
-msgstr "Todavía hay algunas filas que contienen errores. Las filas con errores serán ignoradas al enviar."
+msgid ""
+"There are still some rows that contain errors. Rows with errors will be "
+"ignored when submitting."
+msgstr ""
+"Todavía hay algunas filas que contienen errores. Las filas con errores serán"
+" ignoradas al enviar."
 
 #. js-lingui-id: CA9PTn
 #: src/pages/settings/enterprise/SettingsEnterprise.tsx
-msgid "There is a payment issue with your subscription. Please update your payment method."
-msgstr "Hay un problema de pago con tu suscripción. Actualiza tu método de pago."
+msgid ""
+"There is a payment issue with your subscription. Please update your payment "
+"method."
+msgstr ""
+"Hay un problema de pago con tu suscripción. Actualiza tu método de pago."
 
 #. js-lingui-id: WQk7Cf
 #: src/modules/activities/timeline-activities/components/TimelineCard.tsx
@@ -15475,6 +16227,8 @@ msgstr "Hubo un error al actualizar la contraseña."
 #: src/pages/settings/applications/tabs/SettingsApplicationsDeveloperTab.tsx
 msgid "These apps are not vetted. Use at your own risk."
 msgstr ""
+"Estas aplicaciones no están verificadas. Úsalas bajo tu propia "
+"responsabilidad."
 
 #. js-lingui-id: AUV+TY
 #: src/modules/ai/components/ThinkingStepsDisplay.tsx
@@ -15498,19 +16252,24 @@ msgstr "Tercero"
 
 #. js-lingui-id: 9BFd/R
 #: src/modules/workflow/workflow-steps/workflow-actions/components/WorkflowEditActionEmailBase.tsx
-msgid "This account is connected, but we don't have permission to draft emails on your behalf yet. You'll be redirected to approve this access."
-msgstr "Esta cuenta está conectada, pero aún no tenemos permiso para crear borradores de correos electrónicos en tu nombre. Se te redirigirá para aprobar este acceso."
+msgid ""
+"This account is connected, but we don't have permission to draft emails on "
+"your behalf yet. You'll be redirected to approve this access."
+msgstr ""
+"Esta cuenta está conectada, pero aún no tenemos permiso para crear "
+"borradores de correos electrónicos en tu nombre. Se te redirigirá para "
+"aprobar este acceso."
 
 #. js-lingui-id: h4vGCD
 #: src/modules/workflow/workflow-steps/workflow-actions/find-records-action/components/WorkflowEditActionFindRecords.tsx
 msgid "This action can return up to {maxRecordsFormatted} records."
-msgstr ""
+msgstr "Esta acción puede devolver hasta {maxRecordsFormatted} registros."
 
 #. js-lingui-id: 2xOCJW
 #: src/modules/settings/data-model/object-details/components/tabs/ObjectLayout.tsx
 #: src/modules/layout-customization/components/LayoutCustomizationBarResetConfirmationModal.tsx
 msgid "This action cannot be undone."
-msgstr ""
+msgstr "Esta acción no se puede deshacer."
 
 #. js-lingui-id: Ox1hE7
 #: src/modules/settings/profile/components/DeleteAccount.tsx
@@ -15523,54 +16282,89 @@ msgstr ""
 
 #. js-lingui-id: bNY3MH
 #: src/pages/settings/ai/components/SettingsAgentDeleteConfirmationModal.tsx
-msgid "This action cannot be undone. This will permanently delete your agent.<0/>Please type in the agent name to confirm."
-msgstr "Esta acción no se puede deshacer. Esto eliminará permanentemente tu agente.<0/>Por favor escribe el nombre del agente para confirmar."
+msgid ""
+"This action cannot be undone. This will permanently delete your "
+"agent.<0/>Please type in the agent name to confirm."
+msgstr ""
+"Esta acción no se puede deshacer. Esto eliminará permanentemente tu "
+"agente.<0/>Por favor escribe el nombre del agente para confirmar."
 
 #. js-lingui-id: gWGuHC
 #: src/modules/settings/profile/components/DeleteWorkspace.tsx
-msgid "This action cannot be undone. This will permanently delete your entire workspace. <0/> Please type in your email to confirm."
-msgstr "Esta acción no se puede deshacer. Esto eliminará permanentemente todo tu espacio de trabajo. <0/> Escribe tu correo electrónico para confirmar."
+msgid ""
+"This action cannot be undone. This will permanently delete your entire "
+"workspace. <0/> Please type in your email to confirm."
+msgstr ""
+"Esta acción no se puede deshacer. Esto eliminará permanentemente todo tu "
+"espacio de trabajo. <0/> Escribe tu correo electrónico para confirmar."
 
 #. js-lingui-id: fTuKde
 #: src/pages/settings/members/SettingsWorkspaceMember.tsx
-msgid "This action cannot be undone. This will permanently remove this member from this workspace and remove them from all their assignments."
-msgstr "Esta acción no se puede deshacer. Esto eliminará permanentemente a este miembro de este espacio de trabajo y lo eliminará de todas sus asignaciones."
+msgid ""
+"This action cannot be undone. This will permanently remove this member from "
+"this workspace and remove them from all their assignments."
+msgstr ""
+"Esta acción no se puede deshacer. Esto eliminará permanentemente a este "
+"miembro de este espacio de trabajo y lo eliminará de todas sus asignaciones."
 
 #. js-lingui-id: Ik52hF
 #: src/modules/settings/profile/components/DeleteAccount.tsx
-msgid "This action cannot be undone. This will permanently remove your membership from this workspace."
-msgstr "Esta acción no se puede deshacer. Esto eliminará permanentemente su membresía de este espacio de trabajo."
+msgid ""
+"This action cannot be undone. This will permanently remove your membership "
+"from this workspace."
+msgstr ""
+"Esta acción no se puede deshacer. Esto eliminará permanentemente su "
+"membresía de este espacio de trabajo."
 
 #. js-lingui-id: o5vUsG
 #: src/modules/settings/two-factor-authentication/components/DeleteTwoFactorAuthenticationMethod.tsx
-msgid "This action cannot be undone. This will permanently reset your two factor authentication method. <0/> Please type in your email to confirm."
-msgstr "Esta acción no se puede deshacer. Esto restablecerá permanentemente tu método de autenticación de dos factores. <0/> Escribe tu correo electrónico para confirmar."
+msgid ""
+"This action cannot be undone. This will permanently reset your two factor "
+"authentication method. <0/> Please type in your email to confirm."
+msgstr ""
+"Esta acción no se puede deshacer. Esto restablecerá permanentemente tu "
+"método de autenticación de dos factores. <0/> Escribe tu correo electrónico "
+"para confirmar."
 
 #. js-lingui-id: XxxrMw
 #. placeholder {2}: favoritesEdit.navigationMenuItemCount
 #: src/modules/navigation-menu-item/display/folder/components/NavigationMenuItemFolderDnd.tsx
-msgid "This action will delete this folder and all {2} navigation menu items inside. Do you want to continue?"
-msgstr "Esta acción eliminará esta carpeta y todos los {2} elementos del menú de navegación que contiene. ¿Deseas continuar?"
+msgid ""
+"This action will delete this folder and all {2} navigation menu items "
+"inside. Do you want to continue?"
+msgstr ""
+"Esta acción eliminará esta carpeta y todos los {2} elementos del menú de "
+"navegación que contiene. ¿Deseas continuar?"
 
 #. js-lingui-id: gSO0+U
 #: src/modules/navigation-menu-item/display/folder/components/NavigationMenuItemFolderDnd.tsx
-msgid "This action will delete this folder and the navigation menu item inside. Do you want to continue?"
-msgstr "Esta acción eliminará esta carpeta y el elemento del menú de navegación que contiene. ¿Deseas continuar?"
+msgid ""
+"This action will delete this folder and the navigation menu item inside. Do "
+"you want to continue?"
+msgstr ""
+"Esta acción eliminará esta carpeta y el elemento del menú de navegación que "
+"contiene. ¿Deseas continuar?"
 
 #. js-lingui-id: E5I/qG
 #: src/pages/settings/applications/tabs/SettingsApplicationRegistrationGeneralTab.tsx
-msgid "This app has required server variables that are not configured. Users won't be able to install it until all required variables are set."
+msgid ""
+"This app has required server variables that are not configured. Users won't "
+"be able to install it until all required variables are set."
 msgstr ""
+"Esta aplicación tiene variables de servidor obligatorias que no están "
+"configuradas. Los usuarios no podrán instalarla hasta que todas las "
+"variables obligatorias estén configuradas."
 
 #. js-lingui-id: WCa/7U
 #: src/pages/settings/applications/tabs/SettingsApplicationFrontComponentPreviewTab.tsx
 msgid "This component runs without a UI and renders nothing here."
-msgstr ""
+msgstr "Este componente se ejecuta sin interfaz y no renderiza nada aquí."
 
 #. js-lingui-id: LqhE3c
 #: src/pages/settings/applications/SettingsApplicationConnectionDetail.tsx
-msgid "This connection does not exist or is not available for this application."
-msgstr ""
+msgid ""
+"This connection does not exist or is not available for this application."
+msgstr "Esta conexión no existe o no está disponible para esta aplicación."
 
 #. js-lingui-id: SLIRqz
 #: src/modules/settings/admin-panel/config-variables/components/ConfigVariableHelpText.tsx
@@ -15585,12 +16379,16 @@ msgstr "Esta funcionalidad forma parte del plan Enterprise"
 #. js-lingui-id: own57K
 #: src/modules/activities/files/components/DocumentViewer.tsx
 msgid "This file cannot be previewed because it is hosted locally."
-msgstr "Este archivo no se puede previsualizar porque está alojado localmente."
+msgstr ""
+"Este archivo no se puede previsualizar porque está alojado localmente."
 
 #. js-lingui-id: hMvPrD
 #: src/modules/activities/files/components/DocumentViewer.tsx
-msgid "This file type cannot be previewed. Please download the file to view it."
-msgstr "Este tipo de archivo no se puede previsualizar. Descarga el archivo para verlo."
+msgid ""
+"This file type cannot be previewed. Please download the file to view it."
+msgstr ""
+"Este tipo de archivo no se puede previsualizar. Descarga el archivo para "
+"verlo."
 
 #. js-lingui-id: 3eMupJ
 #: src/modules/workflow/workflow-steps/workflow-actions/form-action/components/WorkflowEditActionFormBuilder.tsx
@@ -15599,8 +16397,12 @@ msgstr "Este formulario aparecerá en las ejecuciones del flujo de trabajo."
 
 #. js-lingui-id: 2UWdFd
 #: src/modules/settings/logic-functions/components/tabs/SettingsLogicFunctionTriggersTab.tsx
-msgid "This function has no trigger configured, so it can only be invoked from the Test tab or by other functions."
+msgid ""
+"This function has no trigger configured, so it can only be invoked from the "
+"Test tab or by other functions."
 msgstr ""
+"Esta función no tiene disparador configurado, por lo que solo puede "
+"invocarse desde la pestaña de prueba o por otras funciones."
 
 #. js-lingui-id: njWene
 #: src/modules/settings/data-model/fields/forms/morph-relation/components/SettingsDataModelFieldRelationJunctionForm.tsx
@@ -15614,8 +16416,14 @@ msgstr "Esto es necesario para habilitar el reordenamiento manual de filas."
 
 #. js-lingui-id: xrVx9A
 #: src/modules/settings/admin-panel/signing-keys/components/SettingsAdminRevokeSigningKeyConfirmationModal.tsx
-msgid "This is the current signing key. Revoking it will invalidate every JWT signed with it and users may need to sign in again. A new signing key will be generated automatically on the next request."
+msgid ""
+"This is the current signing key. Revoking it will invalidate every JWT "
+"signed with it and users may need to sign in again. A new signing key will "
+"be generated automatically on the next request."
 msgstr ""
+"Esta es la clave de firma actual. Revocarla invalidará cada JWT firmado con "
+"ella y los usuarios podrían necesitar iniciar sesión de nuevo. Se generará "
+"una nueva clave de firma automáticamente en la próxima solicitud."
 
 #. js-lingui-id: yLvOxg
 #: src/modules/workflow/workflow-steps/workflow-actions/http-request-action/components/KeyValuePairInput.tsx
@@ -15625,17 +16433,22 @@ msgstr "Esta clave debe establecerse mediante la entrada del cuerpo"
 #. js-lingui-id: Wuvfgw
 #: src/pages/settings/admin-panel/SettingsAdminAiProviderDetail.tsx
 msgid "This model will be removed from the provider. You can re-add it later."
-msgstr "Este modelo se eliminará del proveedor. Podrás volver a añadirlo más tarde."
+msgstr ""
+"Este modelo se eliminará del proveedor. Podrás volver a añadirlo más tarde."
 
 #. js-lingui-id: NCA55L
 #: src/modules/page-layout/widgets/components/StandaloneWidgetPlaceholder.tsx
 msgid "This page has no content"
-msgstr ""
+msgstr "Esta página no tiene contenido"
 
 #. js-lingui-id: R/PuIn
 #: src/pages/settings/admin-panel/SettingsAdminNewAiProvider.tsx
-msgid "This provider doesn't have a native SDK yet — it will use OpenAI-compatible mode. Need native support? Reach out to us."
-msgstr "Este proveedor aún no tiene un SDK nativo — utilizará el modo compatible con OpenAI. ¿Necesitas compatibilidad nativa? Ponte en contacto con nosotros."
+msgid ""
+"This provider doesn't have a native SDK yet — it will use OpenAI-compatible "
+"mode. Need native support? Reach out to us."
+msgstr ""
+"Este proveedor aún no tiene un SDK nativo — utilizará el modo compatible con"
+" OpenAI. ¿Necesitas compatibilidad nativa? Ponte en contacto con nosotros."
 
 #. js-lingui-id: dWJTyU
 #: src/modules/information-banner/components/deleted-record/InformationBannerDeletedRecord.tsx
@@ -15654,13 +16467,17 @@ msgstr "Este rol está asignado a estos {roleTargetDisplayName}."
 
 #. js-lingui-id: fp6HUI
 #: src/pages/settings/ai/components/SettingsAgentRoleTab.tsx
-msgid "This role is shared with other users or agents and cannot be edited here."
+msgid ""
+"This role is shared with other users or agents and cannot be edited here."
 msgstr ""
+"Este rol se comparte con otros usuarios o agentes y no se puede editar aquí."
 
 #. js-lingui-id: C/wr0z
 #: src/modules/settings/admin-panel/config-variables/components/ConfigVariableHelpText.tsx
 msgid "This setting can only be configured through environment variables."
-msgstr "Esta configuración solo se puede configurar a través de variables de entorno."
+msgstr ""
+"Esta configuración solo se puede configurar a través de variables de "
+"entorno."
 
 #. js-lingui-id: iAubP2
 #: src/modules/settings/admin-panel/config-variables/components/ConfigVariableHelpText.tsx
@@ -15681,14 +16498,18 @@ msgstr "Este valor se guardará en la base de datos."
 #. placeholder {0}: nonReadableViewFieldInfo.fieldLabel
 #. placeholder {1}: nonReadableViewFieldInfo.objectLabel
 #: src/modules/object-record/record-index/utils/getNonReadableViewFieldSubTitle.ts
-msgid "This view uses {usageLabel} on field \"{0}\" on \"{1}\" which is not accessible."
+msgid ""
+"This view uses {usageLabel} on field \"{0}\" on \"{1}\" which is not "
+"accessible."
 msgstr ""
+"Esta vista usa {usageLabel} en el campo \"{0}\" en \"{1}\" que no es "
+"accesible."
 
 #. js-lingui-id: IbwUNd
 #. placeholder {0}: nonReadableViewFieldInfo.objectLabel
 #: src/modules/object-record/record-index/utils/getNonReadableViewFieldSubTitle.ts
 msgid "This view uses {usageLabel} on object \"{0}\" which is not accessible."
-msgstr ""
+msgstr "Esta vista usa {usageLabel} en el objeto \"{0}\" que no es accesible."
 
 #. js-lingui-id: yByRxz
 #: src/modules/settings/admin-panel/health-status/constants/WorkerQueueMetricsSelectOptions.ts
@@ -15698,53 +16519,95 @@ msgstr "Esta semana"
 #. js-lingui-id: DF2voz
 #: src/modules/side-panel/pages/page-layout/components/RegularTabSettingsContent.tsx
 #: src/modules/side-panel/pages/page-layout/components/CanvasTabSettingsContent.tsx
-msgid "This will cancel all modifications done on the tab and its widgets. Edit mode will be canceled and the page will refresh. This action cannot be undone."
+msgid ""
+"This will cancel all modifications done on the tab and its widgets. Edit "
+"mode will be canceled and the page will refresh. This action cannot be "
+"undone."
 msgstr ""
+"Esto cancelará todas las modificaciones realizadas en la pestaña y sus "
+"widgets. Se cancelará el modo de edición y la página se actualizará. Esta "
+"acción no se puede deshacer."
 
 #. js-lingui-id: VbVocX
 #: src/modules/side-panel/pages/page-layout/components/WidgetSettingsManageSection.tsx
-msgid "This will cancel all modifications done on the widget. This action cannot be undone."
+msgid ""
+"This will cancel all modifications done on the widget. This action cannot be"
+" undone."
 msgstr ""
+"Esto cancelará todas las modificaciones realizadas en el widget. Esta acción"
+" no se puede deshacer."
 
 #. js-lingui-id: h4VeOo
 #: src/modules/settings/billing/hooks/useBillingWording.ts
-msgid "This will cancel the scheduled interval change and keep your current billing interval ({currentIntervalLabel})."
-msgstr "Esto cancelará el cambio de intervalo programado y mantendrá su intervalo de facturación actual ({currentIntervalLabel})."
+msgid ""
+"This will cancel the scheduled interval change and keep your current billing"
+" interval ({currentIntervalLabel})."
+msgstr ""
+"Esto cancelará el cambio de intervalo programado y mantendrá su intervalo de"
+" facturación actual ({currentIntervalLabel})."
 
 #. js-lingui-id: XpARoU
 #: src/modules/settings/billing/hooks/useBillingWording.ts
-msgid "This will cancel the scheduled plan change and keep your current plan ({planKeyWord})."
-msgstr "Esto cancelará el cambio de plan programado y mantendrá su plan actual ({planKeyWord})."
+msgid ""
+"This will cancel the scheduled plan change and keep your current plan "
+"({planKeyWord})."
+msgstr ""
+"Esto cancelará el cambio de plan programado y mantendrá su plan actual "
+"({planKeyWord})."
 
 #. js-lingui-id: PJ4qQa
 #: src/pages/settings/applications/SettingsApplicationConnectionDetail.tsx
 msgid "This will disconnect {connectionLabel} from this application."
-msgstr ""
+msgstr "Esto desconectará {connectionLabel} de esta aplicación."
 
 #. js-lingui-id: 0+L84I
 #: src/pages/settings/admin-panel/SettingsAdminAiProviderDetail.tsx
-msgid "This will disconnect all models from this provider. Models will no longer be available until a new provider is configured."
-msgstr "Esto desconectará todos los modelos de este proveedor. Los modelos dejarán de estar disponibles hasta que se configure un nuevo proveedor."
+msgid ""
+"This will disconnect all models from this provider. Models will no longer be"
+" available until a new provider is configured."
+msgstr ""
+"Esto desconectará todos los modelos de este proveedor. Los modelos dejarán "
+"de estar disponibles hasta que se configure un nuevo proveedor."
 
 #. js-lingui-id: y8xx3L
 #: src/modules/object-record/record-update-multiple/components/UpdateMultipleRecordsContainer.tsx
-msgid "This will modify {contextStoreNumberOfSelectedRecords} records. This action cannot be undone."
-msgstr "Esto modificará {contextStoreNumberOfSelectedRecords} registros. Esta acción no se puede deshacer."
+msgid ""
+"This will modify {contextStoreNumberOfSelectedRecords} records. This action "
+"cannot be undone."
+msgstr ""
+"Esto modificará {contextStoreNumberOfSelectedRecords} registros. Esta acción"
+" no se puede deshacer."
 
 #. js-lingui-id: XGDxrH
 #: src/pages/settings/data-model/SettingsObjectFieldEdit.tsx
-msgid "This will permanently delete the field and all its data from {objectLabel}. Type \"yes\" to confirm."
-msgstr "Esto eliminará permanentemente el campo y todos sus datos de {objectLabel}. Escribe \"yes\" para confirmar."
+msgid ""
+"This will permanently delete the field and all its data from {objectLabel}. "
+"Type \"yes\" to confirm."
+msgstr ""
+"Esto eliminará permanentemente el campo y todos sus datos de {objectLabel}. "
+"Escribe \"yes\" para confirmar."
 
 #. js-lingui-id: L85ZX9
 #: src/modules/settings/data-model/object-details/components/tabs/ObjectSettings.tsx
-msgid "This will permanently delete the object and all its records. Type \"yes\" to confirm."
-msgstr "Esto eliminará permanentemente el objeto y todos sus registros. Escribe \"yes\" para confirmar."
+msgid ""
+"This will permanently delete the object and all its records. Type \"yes\" to"
+" confirm."
+msgstr ""
+"Esto eliminará permanentemente el objeto y todos sus registros. Escribe "
+"\"yes\" para confirmar."
 
 #. js-lingui-id: qEODFi
 #: src/modules/settings/two-factor-authentication/components/DeleteTwoFactorAuthenticationMethod.tsx
-msgid "This will permanently delete your two factor authentication method.<0/>Since 2FA is mandatory in your workspace, you will be logged out after deletion and will be asked to configure it again upon login. <1/>Please type in your email to confirm."
-msgstr "Esto eliminará permanentemente tu método de autenticación de dos factores.<0/>Como 2FA es obligatorio en tu espacio de trabajo, se cerrará tu sesión después de la eliminación y se te pedirá configurarlo nuevamente al iniciar sesión. <1/>Escribe tu correo electrónico para confirmar."
+msgid ""
+"This will permanently delete your two factor authentication method.<0/>Since"
+" 2FA is mandatory in your workspace, you will be logged out after deletion "
+"and will be asked to configure it again upon login. <1/>Please type in your "
+"email to confirm."
+msgstr ""
+"Esto eliminará permanentemente tu método de autenticación de dos "
+"factores.<0/>Como 2FA es obligatorio en tu espacio de trabajo, se cerrará tu"
+" sesión después de la eliminación y se te pedirá configurarlo nuevamente al "
+"iniciar sesión. <1/>Escribe tu correo electrónico para confirmar."
 
 #. js-lingui-id: f8HOUp
 #: src/modules/ai/components/ThinkingStepsDisplay.tsx
@@ -15817,7 +16680,7 @@ msgstr "título"
 #. js-lingui-id: MHrjPM
 #: src/pages/settings/admin-panel/SettingsAdminWorkspaceDetail.tsx
 msgid "Title"
-msgstr ""
+msgstr "Título"
 
 #. js-lingui-id: /jQctM
 #: src/modules/workflow/workflow-steps/workflow-actions/components/WorkflowEditActionEmailBase.tsx
@@ -15874,7 +16737,7 @@ msgstr "Mañana"
 #. placeholder {1}: composerState.maxRecipients
 #: src/modules/activities/emails/components/EmailComposer.tsx
 msgid "Too many recipients ({0}/{1})."
-msgstr ""
+msgstr "Demasiados destinatarios ({0}/{1})."
 
 #. js-lingui-id: WrMXsY
 #: src/modules/spreadsheet-import/steps/components/UploadStep/UploadStep.tsx
@@ -15886,7 +16749,7 @@ msgstr "Demasiados registros. Se permiten hasta {maxRecordsString}"
 #. placeholder {0}: part.toolName
 #: src/modules/settings/admin-panel/components/SettingsAdminChatThreadMessageList.tsx
 msgid "Tool call: {0}"
-msgstr ""
+msgstr "Llamada de herramienta: {0}"
 
 #. js-lingui-id: GnoLfm
 #: src/modules/ai/components/RoutingDebugDisplay.tsx
@@ -15901,7 +16764,7 @@ msgstr "Herramienta creada"
 #. js-lingui-id: i5A3/7
 #: src/pages/settings/ai/SettingsToolDetail.tsx
 msgid "Tool deleted"
-msgstr ""
+msgstr "Herramienta eliminada"
 
 #. js-lingui-id: OvFVjH
 #: src/modules/ai/components/ToolStepRenderer.tsx
@@ -15922,17 +16785,17 @@ msgstr "Herramientas"
 #. js-lingui-id: nCq25C
 #: src/modules/settings/admin-panel/components/SettingsAdminGeneral.tsx
 msgid "Top 10 workspaces by number of users"
-msgstr ""
+msgstr "Top 10 espacios de trabajo por número de usuarios"
 
 #. js-lingui-id: A4dnvW
 #: src/modules/settings/admin-panel/components/SettingsAdminGeneral.tsx
 msgid "Top Workspaces"
-msgstr ""
+msgstr "Espacios de trabajo principales"
 
 #. js-lingui-id: 72c5Qo
 #: src/modules/page-layout/widgets/graph/graph-widget-pie-chart/hooks/usePieChartCenterMetricData.ts
 msgid "Total"
-msgstr ""
+msgstr "Total"
 
 #. js-lingui-id: Fm0Lw/
 #: src/modules/settings/billing/components/SettingsBillingCreditsSection.tsx
@@ -15960,7 +16823,7 @@ msgstr "Tiempo total"
 #: src/pages/settings/ai/components/SettingsAiUsageTab.tsx
 #: src/pages/settings/ai/components/SettingsAiUsageTab.tsx
 msgid "Track AI consumption across your workspace."
-msgstr ""
+msgstr "Rastrea el consumo de IA en tu espacio de trabajo."
 
 #. js-lingui-id: YT/cKI
 #: src/modules/settings/billing/components/SettingsBillingCreditsSection.tsx
@@ -15993,12 +16856,13 @@ msgstr "La prueba ha expirado. Por favor, contacte a su administrador"
 #. js-lingui-id: y985qL
 #: src/modules/information-banner/components/billing/InformationBannerBillingSubscriptionPaused.tsx
 msgid "Trial expired. Please update your billing details."
-msgstr "Periodo de prueba expirado. Por favor, actualice sus datos de facturación."
+msgstr ""
+"Periodo de prueba expirado. Por favor, actualice sus datos de facturación."
 
 #. js-lingui-id: 67waeA
 #: src/modules/settings/admin-panel/components/SettingsAdminWorkspaceBillingContent.tsx
 msgid "Trial period"
-msgstr ""
+msgstr "Período de prueba"
 
 #. js-lingui-id: H2Sfhg
 #: src/modules/workflow/workflow-diagram/workflow-nodes/components/WorkflowDiagramEmptyTriggerReadonly.tsx
@@ -16044,12 +16908,12 @@ msgstr "Activa la función a intervalos regulares"
 #. js-lingui-id: /oEL03
 #: src/modules/settings/logic-functions/components/triggers/SettingsLogicFunctionDatabaseEventTriggerSection.tsx
 msgid "Triggers the function when a record changes"
-msgstr ""
+msgstr "Activa la función cuando un registro cambia"
 
 #. js-lingui-id: YdQqyX
 #: src/modules/settings/logic-functions/components/triggers/SettingsLogicFunctionHttpTriggerSection.tsx
 msgid "Triggers the function with an HTTP request"
-msgstr ""
+msgstr "Activa la función con una solicitud HTTP"
 
 #. js-lingui-id: c+xCSz
 #: src/modules/ui/field/display/components/BooleanDisplay.tsx
@@ -16069,8 +16933,12 @@ msgstr "Prueba nuestros entornos de prueba de API REST o GraphQL."
 
 #. js-lingui-id: 3WWUB9
 #: src/pages/settings/updates/SettingsUpdates.tsx
-msgid "Try our upcoming features. Note they are still in beta. Please bear with us and report any issues you find."
-msgstr "Prueba nuestras próximas funciones. Ten en cuenta que aún están en beta. Te pedimos paciencia y que nos informes de cualquier problema que encuentres."
+msgid ""
+"Try our upcoming features. Note they are still in beta. Please bear with us "
+"and report any issues you find."
+msgstr ""
+"Prueba nuestras próximas funciones. Ten en cuenta que aún están en beta. Te "
+"pedimos paciencia y que nos informes de cualquier problema que encuentres."
 
 #. js-lingui-id: LQdi+H
 #: src/modules/auth/sign-in-up/components/EmailVerificationSent.tsx
@@ -16092,28 +16960,28 @@ msgstr "Turco"
 #: src/pages/settings/ai/SettingsAgentTurnDetail.tsx
 #: src/pages/settings/ai/SettingsAgentTurnDetail.tsx
 msgid "Turn"
-msgstr ""
+msgstr "Turno"
 
 #. js-lingui-id: qsUXL3
 #: src/pages/settings/ai/SettingsAgentTurnDetail.tsx
 #: src/pages/settings/ai/SettingsAgentTurnDetail.tsx
 msgid "Turn Details"
-msgstr ""
+msgstr "Detalles del turno"
 
 #. js-lingui-id: fFSDTy
 #: src/pages/settings/ai/components/SettingsAgentLogsTab.tsx
 msgid "Turn evaluated successfully"
-msgstr ""
+msgstr "Turno evaluado con éxito"
 
 #. js-lingui-id: 8680YN
 #: src/pages/settings/ai/SettingsAgentTurnDetail.tsx
 msgid "Turn not found"
-msgstr ""
+msgstr "Turno no encontrado"
 
 #. js-lingui-id: NCGTnP
 #: src/pages/settings/ai/SettingsAgentTurnDetail.tsx
 msgid "Turn Not Found"
-msgstr ""
+msgstr "Turno no encontrado"
 
 #. js-lingui-id: EdHWDU
 #: src/modules/settings/data-model/fields/forms/select/components/SettingsDataModelFieldSelectFormOptionRow.tsx
@@ -16151,7 +17019,8 @@ msgstr "Autenticación de Dos Factores"
 #. js-lingui-id: cRM1ec
 #: src/modules/settings/two-factor-authentication/hooks/useTwoFactorVerificationForSettings.ts
 msgid "Two-factor authentication setup completed successfully!"
-msgstr "¡La configuración de la autenticación de dos factores se completó con éxito!"
+msgstr ""
+"¡La configuración de la autenticación de dos factores se completó con éxito!"
 
 #. js-lingui-id: +zy2Nq
 #: src/pages/settings/layout/SettingsLayoutViewDetail.tsx
@@ -16186,7 +17055,7 @@ msgstr "Escribe cualquier cosa..."
 #. js-lingui-id: LaEX5I
 #: src/modules/activities/emails/components/EmailComposerFields.tsx
 msgid "Type something or press \"/\" to see commands"
-msgstr ""
+msgstr "Escribe algo o pulsa \"/\" para ver comandos"
 
 #. js-lingui-id: UhqKcC
 #: src/modules/navigation-menu-item/edit/side-panel/components/SidePanelNewSidebarItemRecordSubPage.tsx
@@ -16211,12 +17080,14 @@ msgstr "ul"
 #. js-lingui-id: N/XI5S
 #: src/pages/settings/members/SettingsWorkspaceMember.tsx
 msgid "Unable to delete member right now"
-msgstr ""
+msgstr "No se puede eliminar al miembro en este momento"
 
 #. js-lingui-id: HSLWzn
 #: src/pages/auth/Authorize.tsx
 msgid "Unable to load application details. Please try again later."
-msgstr "No se pudieron cargar los detalles de la aplicación. Por favor, inténtelo más tarde."
+msgstr ""
+"No se pudieron cargar los detalles de la aplicación. Por favor, inténtelo "
+"más tarde."
 
 #. js-lingui-id: l+ALBd
 #: src/modules/client-config/components/ClientConfigProvider.tsx
@@ -16226,7 +17097,7 @@ msgstr "Incapaz de alcanzar el Back-end"
 #. js-lingui-id: 5JOLV9
 #: src/modules/ai/components/AiChatThreadItemMenu.tsx
 msgid "Unarchive"
-msgstr ""
+msgstr "Desarchivar"
 
 #. js-lingui-id: EUHN7i
 #: src/modules/settings/admin-panel/config-variables/components/ConfigVariableValueInput.tsx
@@ -16236,43 +17107,45 @@ msgstr "Indefinido"
 #. js-lingui-id: o23uCL
 #: src/modules/side-panel/pages/page-layout/utils/getChartLimitMessage.ts
 msgid "Undisplayed data: max {maxItems} {granularityLabel} per chart."
-msgstr ""
+msgstr "Datos no mostrados: máximo {maxItems} {granularityLabel} por gráfico."
 
 #. js-lingui-id: LshHRh
 #: src/modules/side-panel/pages/page-layout/utils/getChartLimitMessage.ts
 msgid "Undisplayed data: max {maxItems} bars per chart."
-msgstr ""
+msgstr "Datos no mostrados: máximo {maxItems} barras por gráfico."
 
 #. js-lingui-id: 8MwfeU
 #: src/modules/side-panel/pages/page-layout/utils/getChartLimitMessage.ts
 msgid "Undisplayed data: max {maxItems} data points per chart."
-msgstr ""
+msgstr "Datos no mostrados: máximo {maxItems} puntos de datos por gráfico."
 
 #. js-lingui-id: 0LZhoy
 #: src/modules/side-panel/pages/page-layout/utils/getChartLimitMessage.ts
 msgid "Undisplayed data: max {maxItems} slices per chart."
-msgstr ""
+msgstr "Datos no mostrados: máximo {maxItems} segmentos por gráfico."
 
 #. js-lingui-id: fo0VXg
 #: src/pages/settings/applications/tabs/SettingsApplicationDetailAboutTab.tsx
 #: src/pages/settings/applications/tabs/SettingsApplicationDetailAboutTab.tsx
 msgid "Uninstall"
-msgstr ""
+msgstr "Desinstalar"
 
 #. js-lingui-id: Qtg9Qc
 #: src/pages/settings/applications/tabs/SettingsApplicationDetailAboutTab.tsx
 msgid "Uninstall Application?"
-msgstr ""
+msgstr "¿Desinstalar aplicación?"
 
 #. js-lingui-id: 7S4EZE
 #: src/pages/settings/admin-panel/SettingsAdminApplicationRegistrationDangerZone.tsx
 msgid "Uninstall this app from all workspaces before deleting it"
-msgstr "Desinstala esta aplicación de todos los espacios de trabajo antes de eliminarla"
+msgstr ""
+"Desinstala esta aplicación de todos los espacios de trabajo antes de "
+"eliminarla"
 
 #. js-lingui-id: ItfvBz
 #: src/pages/settings/applications/tabs/SettingsApplicationDetailAboutTab.tsx
 msgid "Uninstalling..."
-msgstr ""
+msgstr "Desinstalando..."
 
 #. js-lingui-id: wSXm5S
 #: src/pages/settings/data-model/SettingsObjectIndexTable.tsx
@@ -16303,7 +17176,7 @@ msgstr "ID universal"
 #: src/pages/settings/applications/tabs/SettingsApplicationFrontComponentSettingsTab.tsx
 #: src/pages/settings/applications/tabs/SettingsApplicationCommandMenuItemSettingsTab.tsx
 msgid "Universal identifier"
-msgstr ""
+msgstr "Identificador universal"
 
 #. js-lingui-id: Ef7StM
 #: src/pages/settings/emailing-domains/utils/getEmailingDomainStatusText.ts
@@ -16347,7 +17220,7 @@ msgstr "Objeto desconocido"
 #. js-lingui-id: m/o1+r
 #: src/modules/settings/admin-panel/health-status/components/SettingsAdminWorkspacesByHealthAccordion.tsx
 msgid "Unknown workspace"
-msgstr ""
+msgstr "Espacio de trabajo desconocido"
 
 #. js-lingui-id: GQCXQS
 #: src/pages/onboarding/internal/ChooseYourPlanContent.tsx
@@ -16363,20 +17236,23 @@ msgstr "No listadas"
 
 #. js-lingui-id: Ep1uUU
 #: src/pages/settings/enterprise/SettingsEnterprise.tsx
-msgid "Unlock enterprise features like SSO, row-level security, and audit logs."
-msgstr "Desbloquea funciones Enterprise como SSO, seguridad a nivel de fila y registros de auditoría."
+msgid ""
+"Unlock enterprise features like SSO, row-level security, and audit logs."
+msgstr ""
+"Desbloquea funciones Enterprise como SSO, seguridad a nivel de fila y "
+"registros de auditoría."
 
 #. js-lingui-id: Te2H8x
 #: src/pages/settings/developers/api-keys/SettingsDevelopersApiKeyDetail.tsx
 #: src/pages/settings/developers/api-keys/SettingsDevelopersApiKeyDetail.tsx
 #: src/modules/settings/developers/components/SettingsApiKeysFieldItemTableRow.tsx
 msgid "Unnamed API Key"
-msgstr ""
+msgstr "Clave API sin nombre"
 
 #. js-lingui-id: a3Hy65
 #: src/modules/settings/admin-panel/components/SettingsAdminWorkspaceBillingContent.tsx
 msgid "Unnamed product"
-msgstr ""
+msgstr "Producto sin nombre"
 
 #. js-lingui-id: eQMhFX
 #: src/modules/advanced-text-editor/extensions/slash-command/DefaultSlashCommands.ts
@@ -16417,7 +17293,7 @@ msgstr "{labelSingular} sin título"
 #. js-lingui-id: zJsHrW
 #: src/modules/workflow/workflow-steps/workflow-actions/ai-agent-action/components/WorkflowOutputSchemaBuilder.tsx
 msgid "Untitled field"
-msgstr ""
+msgstr "Campo sin título"
 
 #. js-lingui-id: RBz20h
 #: src/modules/side-panel/pages/page-layout/components/SidePanelPageLayoutDashboardWidgetTypeSelect.tsx
@@ -16437,18 +17313,20 @@ msgstr "Flujo de trabajo sin título"
 
 #. js-lingui-id: TnJsyB
 #: src/modules/settings/billing/components/SettingsBillingCreditsSection.tsx
-msgid "Unused credits from the previous period. Expired at the end of the period."
+msgid ""
+"Unused credits from the previous period. Expired at the end of the period."
 msgstr ""
+"Créditos no utilizados del período anterior. Expiraron al final del período."
 
 #. js-lingui-id: j5CWO4
 #: src/modules/settings/admin-panel/utils/getUpgradeHealthStatusBadge.ts
 msgid "Up to date"
-msgstr ""
+msgstr "Actualizado"
 
 #. js-lingui-id: hmc//6
 #: src/modules/workflow/workflow-trigger/components/CronExpressionHelper.tsx
 msgid "Upcoming execution time ({timeZone})"
-msgstr ""
+msgstr "Próxima hora de ejecución ({timeZone})"
 
 #. js-lingui-id: Y8zko3
 #: src/modules/settings/roles/role-permissions/object-level-permissions/utils/objectPermissionKeyToHumanReadableText.ts
@@ -16476,7 +17354,7 @@ msgstr "Actualizar método de pago"
 #. js-lingui-id: tIoZo5
 #: src/modules/information-banner/components/billing/InformationBannerNoMoreCredits.tsx
 msgid "Update plan"
-msgstr ""
+msgstr "Actualizar plan"
 
 #. js-lingui-id: 0KAL3W
 #: src/modules/side-panel/hooks/useOpenUpdateMultipleRecordsPageInSidePanel.tsx
@@ -16497,8 +17375,12 @@ msgstr "Actualizar vista"
 
 #. js-lingui-id: qbg8VE
 #: src/modules/settings/accounts/components/SettingsAccountsConnectionForm.tsx
-msgid "Update your account's configuration. Configure any combination of IMAP, SMTP, and CalDAV as needed."
-msgstr "Actualiza la configuración de tu cuenta. Configura cualquier combinación de IMAP, SMTP y CalDAV según sea necesario."
+msgid ""
+"Update your account's configuration. Configure any combination of IMAP, "
+"SMTP, and CalDAV as needed."
+msgstr ""
+"Actualiza la configuración de tu cuenta. Configura cualquier combinación de "
+"IMAP, SMTP y CalDAV según sea necesario."
 
 #. js-lingui-id: x4Xp3c
 #: src/modules/activities/timeline-activities/rows/main-object/components/EventRowMainObjectUpdated.tsx
@@ -16538,17 +17420,17 @@ msgstr "Actualizar"
 #. js-lingui-id: IEtN5Y
 #: src/modules/settings/admin-panel/health-status/components/SettingsAdminWorkspacesStatusSummaryCard.tsx
 msgid "Upgrade health"
-msgstr ""
+msgstr "Salud de actualización"
 
 #. js-lingui-id: 88ZkNH
 #: src/pages/settings/admin-panel/SettingsAdminWorkspacesStatus.tsx
 msgid "Upgrade health across all workspaces"
-msgstr ""
+msgstr "Salud de actualización en todos los espacios de trabajo"
 
 #. js-lingui-id: +awaFr
 #: src/modules/settings/admin-panel/health-status/components/SettingsAdminHealthStatus.tsx
 msgid "Upgrade health across instance and workspaces"
-msgstr ""
+msgstr "Salud de actualización en instancia y espacios de trabajo"
 
 #. js-lingui-id: 7aHRdp
 #: src/modules/ai/components/AiChatCreditsExhaustedMessage.tsx
@@ -16559,14 +17441,14 @@ msgstr "Actualizar plan"
 #: src/modules/settings/admin-panel/health-status/components/SettingsAdminHealthStatus.tsx
 #: src/modules/settings/admin-panel/components/SettingsAdminWorkspaceContent.tsx
 msgid "Upgrade Status"
-msgstr ""
+msgstr "Estado de actualización"
 
 #. js-lingui-id: /l59TO
 #: src/pages/settings/admin-panel/SettingsAdminWorkspacesStatus.tsx
 #: src/pages/settings/admin-panel/SettingsAdminInstanceStatus.tsx
 #: src/pages/settings/admin-panel/SettingsAdminInferredVersion.tsx
 msgid "Upgrade status refreshed"
-msgstr ""
+msgstr "Estado de actualización actualizado"
 
 #. js-lingui-id: pKCx2F
 #: src/pages/settings/applications/tabs/SettingsApplicationDetailAboutTab.tsx
@@ -16576,8 +17458,12 @@ msgstr "Actualizar a {latestAvailableVersion}"
 
 #. js-lingui-id: Kutw4+
 #: src/modules/ai/components/AIChatNoMoreBillingCreditsBanner.tsx
-msgid "Upgrade to {nextResourceCreditsAmount} credits for ${nextResourceCreditPrice}/{nextTierInterval}."
+msgid ""
+"Upgrade to {nextResourceCreditsAmount} credits for "
+"${nextResourceCreditPrice}/{nextTierInterval}."
 msgstr ""
+"Actualiza a {nextResourceCreditsAmount} créditos por "
+"${nextResourceCreditPrice}/{nextTierInterval}."
 
 #. js-lingui-id: ggd+Ee
 #: src/modules/settings/roles/role-permissions/object-level-permissions/record-level-permissions/components/SettingsRolePermissionsObjectLevelRecordLevelSection.tsx
@@ -16587,7 +17473,7 @@ msgstr "Actualiza para acceder"
 #. js-lingui-id: Wurpq2
 #: src/pages/settings/security/SettingsSecurity.tsx
 msgid "Upgrade to Enterprise to access audit logs."
-msgstr ""
+msgstr "Actualiza a Enterprise para acceder a los registros de auditoría."
 
 #. js-lingui-id: +Gi3x1
 #: src/pages/settings/applications/tabs/SettingsApplicationDetailAboutTab.tsx
@@ -16647,12 +17533,12 @@ msgstr "Subiendo..."
 #. js-lingui-id: 87NUzq
 #: src/pages/settings/applications/components/SettingsApplicationRegistrationRedirectURIsTable.tsx
 msgid "URI"
-msgstr ""
+msgstr "URI"
 
 #. js-lingui-id: T6liqF
 #: src/pages/settings/applications/components/SettingsApplicationRegistrationRedirectURIsInput.tsx
 msgid "URI is already in redirect URIs list"
-msgstr ""
+msgstr "La URI ya está en la lista de URIs de redirección"
 
 #. js-lingui-id: IagCbF
 #: src/modules/workflow/workflow-steps/workflow-actions/http-request-action/components/WorkflowEditActionHttpRequest.tsx
@@ -16663,7 +17549,7 @@ msgstr "URL"
 #. js-lingui-id: UtDm3q
 #: src/modules/settings/logic-functions/components/triggers/SettingsLogicFunctionHttpTriggerSection.tsx
 msgid "URL copied to clipboard"
-msgstr ""
+msgstr "URL copiada al portapapeles"
 
 #. js-lingui-id: pphDjD
 #: src/modules/side-panel/pages/page-layout/components/dashboard/SidePanelDashboardIframeSettings.tsx
@@ -16677,8 +17563,7 @@ msgstr "us-east-1"
 
 #. js-lingui-id: 7FaY4u
 #: src/pages/settings/SettingsUsageUserDetail.tsx
-#: src/pages/settings/SettingsUsage.tsx
-#: src/pages/settings/SettingsUsage.tsx
+#: src/pages/settings/SettingsUsage.tsx src/pages/settings/SettingsUsage.tsx
 #: src/pages/settings/ai/SettingsAI.tsx
 #: src/modules/settings/usage/components/UsageByUserTableSection.tsx
 #: src/modules/settings/admin-panel/ai/components/SettingsAdminAI.tsx
@@ -16700,11 +17585,13 @@ msgstr "Analíticas de uso"
 #: src/modules/settings/usage/components/SettingsUsageAnalyticsSection.tsx
 msgid "Usage analytics requires ClickHouse. Contact your administrator."
 msgstr ""
+"Las analíticas de uso requieren ClickHouse. Contacta a tu administrador."
 
 #. js-lingui-id: XglEba
 #: src/modules/settings/usage/components/SettingsUsageAnalyticsSection.tsx
 msgid "Usage analytics will appear here once you start using credits."
 msgstr ""
+"Las analíticas de uso aparecerán aquí una vez que comiences a usar créditos."
 
 #. js-lingui-id: 7vRxpC
 #: src/pages/settings/SettingsUsageUserDetail.tsx
@@ -16724,8 +17611,12 @@ msgstr "Eventos de uso"
 
 #. js-lingui-id: 6kLyt5
 #: src/modules/auth/sign-in-up/components/internal/SignInUpTwoFactorAuthenticationProvision.tsx
-msgid "Use authenticator apps and browser extensions like 1Password, Authy, Microsoft Authenticator to generate one-time passwords"
-msgstr "Usa aplicaciones de autenticación y extensiones de navegador como 1Password, Authy, Microsoft Authenticator para generar contraseñas de un solo uso"
+msgid ""
+"Use authenticator apps and browser extensions like 1Password, Authy, "
+"Microsoft Authenticator to generate one-time passwords"
+msgstr ""
+"Usa aplicaciones de autenticación y extensiones de navegador como 1Password,"
+" Authy, Microsoft Authenticator para generar contraseñas de un solo uso"
 
 #. js-lingui-id: hCZsJ0
 #: src/pages/settings/ai/components/SettingsAiModelsTab.tsx
@@ -16736,17 +17627,20 @@ msgstr "Usar solo los mejores modelos"
 #: src/pages/settings/ai/components/SettingsToolsTable.tsx
 #: src/pages/settings/ai/components/SettingsAgentSkills.tsx
 msgid "Use filter to see existing tools or create your own"
-msgstr ""
+msgstr "Usa el filtro para ver herramientas existentes o crea las tuyas"
 
 #. js-lingui-id: 1Y7Unr
 #: src/pages/settings/data-model/new-index/SettingsObjectNewIndex.tsx
 msgid "Use indexes sparingly"
-msgstr ""
+msgstr "Usa índices con moderación"
 
 #. js-lingui-id: oTTQsc
 #: src/modules/settings/domains/utils/getSubdomainValidationSchema.ts
-msgid "Use letter, number and dash only. Start and finish with a letter or a number"
-msgstr "Utiliza solo letras, números y guiones. Empieza y termina con una letra o un número"
+msgid ""
+"Use letter, number and dash only. Start and finish with a letter or a number"
+msgstr ""
+"Utiliza solo letras, números y guiones. Empieza y termina con una letra o un"
+" número"
 
 #. js-lingui-id: c6uZUV
 #: src/modules/object-record/record-table/empty-state/utils/getEmptyStateSubTitle.ts
@@ -16827,22 +17721,26 @@ msgstr "Usuarios"
 #. js-lingui-id: UIOjSC
 #: src/modules/settings/admin-panel/signing-keys/components/SettingsAdminSigningKeysTable.tsx
 msgid "Uses (last {verifyWindowDays}d)"
-msgstr ""
+msgstr "Usos (últimos {verifyWindowDays}d)"
 
 #. js-lingui-id: mnudjQ
 #: src/pages/settings/applications/tabs/SettingsApplicationFrontComponentSettingsTab.tsx
 msgid "Uses SDK client"
-msgstr ""
+msgstr "Usa cliente SDK"
 
 #. js-lingui-id: vUr1/5
 #: src/modules/settings/admin-panel/config-variables/components/ConfigVariableHelpText.tsx
 msgid "Using default application value. Configure via environment variables."
-msgstr "Usando el valor de aplicación predeterminado. Configurar a través de variables de entorno."
+msgstr ""
+"Usando el valor de aplicación predeterminado. Configurar a través de "
+"variables de entorno."
 
 #. js-lingui-id: 8Drj7i
 #: src/modules/settings/admin-panel/config-variables/components/ConfigVariableHelpText.tsx
 msgid "Using default value. Set a custom value to override."
-msgstr "Usando el valor predeterminado. Establece un valor personalizado para anular."
+msgstr ""
+"Usando el valor predeterminado. Establece un valor personalizado para "
+"anular."
 
 #. js-lingui-id: zzp4XX
 #: src/pages/settings/enterprise/SettingsEnterprise.tsx
@@ -16881,8 +17779,12 @@ msgstr "Valor"
 
 #. js-lingui-id: UZHvVi
 #: src/modules/settings/admin-panel/config-variables/components/ConfigVariableHelpText.tsx
-msgid "Value is set in the server environment, it may be a different value on the worker."
-msgstr "El valor está configurado en el entorno del servidor, puede ser un valor diferente en el trabajador."
+msgid ""
+"Value is set in the server environment, it may be a different value on the "
+"worker."
+msgstr ""
+"El valor está configurado en el entorno del servidor, puede ser un valor "
+"diferente en el trabajador."
 
 #. js-lingui-id: fXVIZq
 #: src/pages/settings/data-model/SettingsObjectFieldEdit.tsx
@@ -16893,17 +17795,17 @@ msgstr "Valores"
 #. js-lingui-id: M9lOpp
 #: src/modules/settings/config-variables/components/ConfigVariableEdit.tsx
 msgid "Variable {title} reset"
-msgstr ""
+msgstr "Variable {title} restablecida"
 
 #. js-lingui-id: d2GZm6
 #: src/modules/settings/config-variables/components/ConfigVariableEdit.tsx
 msgid "Variable {title} updated"
-msgstr ""
+msgstr "Variable {title} actualizada"
 
 #. js-lingui-id: +woNYv
 #: src/modules/workflow/workflow-steps/workflow-actions/ai-agent-action/components/WorkflowOutputSchemaBuilder.tsx
 msgid "Variable Name"
-msgstr ""
+msgstr "Nombre de variable"
 
 #. js-lingui-id: dY/1ir
 #: src/modules/object-record/record-field/ui/form-types/components/VariableChip.tsx
@@ -16929,6 +17831,8 @@ msgstr "Verificar el código desde la aplicación"
 #: src/modules/settings/workspace/components/SettingsWorkspaceEmailingDomainsSection.tsx
 msgid "Verify domains so the workspace can send outbound email through them."
 msgstr ""
+"Verifica los dominios para que el espacio de trabajo pueda enviar correo "
+"saliente a través de ellos."
 
 #. js-lingui-id: zS/rMV
 #: src/pages/settings/SettingsTwoFactorAuthenticationMethod.tsx
@@ -16944,7 +17848,7 @@ msgstr "Versión de la aplicación"
 #: src/modules/side-panel/pages/page-layout/constants/GraphTypeInformation.ts
 #: src/modules/page-layout/utils/getWidgetTitle.ts
 msgid "Vertical Bar Chart"
-msgstr ""
+msgstr "Gráfico de barras verticales"
 
 #. js-lingui-id: vSJd18
 #: src/pages/settings/admin-panel/SettingsAdminNewAiModel.tsx
@@ -16977,17 +17881,17 @@ msgstr "Vista"
 #. js-lingui-id: 8qPdO7
 #: src/modules/workflow/workflow-steps/components/WorkflowStepFooter.tsx
 msgid "View Agent"
-msgstr ""
+msgstr "Ver agente"
 
 #. js-lingui-id: noHthC
 #: src/modules/settings/usage/components/SettingsUsageAnalyticsSection.tsx
 msgid "View AI usage breakdown"
-msgstr ""
+msgstr "Ver desglose de uso de IA"
 
 #. js-lingui-id: nK72s8
 #: src/pages/settings/ai/components/SettingsAgentLogsTab.tsx
 msgid "View all evaluations"
-msgstr ""
+msgstr "Ver todas las evaluaciones"
 
 #. js-lingui-id: XVf/G7
 #: src/pages/settings/security/SettingsSecurity.tsx
@@ -17059,7 +17963,7 @@ msgstr "Ver registros"
 #. js-lingui-id: sAPirx
 #: src/modules/object-record/record-index/components/RecordIndexEmptyStateNotShared.tsx
 msgid "View not shared"
-msgstr ""
+msgstr "Vista no compartida"
 
 #. js-lingui-id: ecVcAx
 #: src/modules/command-menu-item/engine-command/constants/EngineComponentKeyHeadlessComponentMap.tsx
@@ -17069,12 +17973,12 @@ msgstr "Ver chats previos de IA"
 #. js-lingui-id: hAAsm/
 #: src/modules/workflow/workflow-steps/workflow-actions/ai-agent-action/components/WorkflowEditActionAiAgent.tsx
 msgid "View role"
-msgstr ""
+msgstr "Ver rol"
 
 #. js-lingui-id: mzftV9
 #: src/modules/workflow/workflow-steps/components/WorkflowStepFooter.tsx
 msgid "View Role"
-msgstr ""
+msgstr "Ver rol"
 
 #. js-lingui-id: 4y776f
 #: src/modules/metadata-error-handler/hooks/useMetadataErrorHandler.ts
@@ -17121,17 +18025,17 @@ msgstr "Visibilidad"
 #. js-lingui-id: XQC+sL
 #: src/modules/side-panel/pages/page-layout/components/CanvasTabSettingsContent.tsx
 msgid "Visibility restriction"
-msgstr ""
+msgstr "Restricción de visibilidad"
 
 #. js-lingui-id: gkAApJ
 #: src/modules/side-panel/pages/page-layout/components/WidgetSettingsManageSection.tsx
 msgid "Visibility Restriction"
-msgstr ""
+msgstr "Restricción de visibilidad"
 
 #. js-lingui-id: oh8+os
 #: src/pages/settings/layout/SettingsLayoutViewDetail.tsx
 msgid "Visible"
-msgstr ""
+msgstr "Visible"
 
 #. js-lingui-id: zYTdqe
 #: src/modules/views/components/ViewBarFilterDropdownFieldSelectMenu.tsx
@@ -17197,8 +18101,12 @@ msgstr "Hemos encontrado un problema verificando"
 
 #. js-lingui-id: 6d9mjh
 #: src/modules/workflow/workflow-steps/workflow-actions/components/WorkflowEditActionUpsertRecord.tsx
-msgid "We match on these fields. If a {objectLabelSingular} already exists, we update it. Otherwise, we create a new one."
-msgstr "<0>Cotejamos</0> en estos campos. Si un {objectLabelSingular} ya existe, lo actualizamos. De lo contrario, creamos uno nuevo."
+msgid ""
+"We match on these fields. If a {objectLabelSingular} already exists, we "
+"update it. Otherwise, we create a new one."
+msgstr ""
+"<0>Cotejamos</0> en estos campos. Si un {objectLabelSingular} ya existe, lo "
+"actualizamos. De lo contrario, creamos uno nuevo."
 
 #. js-lingui-id: id6ein
 #: src/modules/ui/input/components/ImageInput.tsx
@@ -17213,13 +18121,21 @@ msgstr "Activaremos tu plan de pago. ¿Quieres proceder?"
 
 #. js-lingui-id: KIfYq0
 #: src/modules/settings/developers/components/SettingsDevelopersWebhookForm.tsx
-msgid "We will send a POST request to this endpoint for each new event in application/json format"
-msgstr "Enviaremos una solicitud POST a este endpoint para cada nuevo evento en formato application/json"
+msgid ""
+"We will send a POST request to this endpoint for each new event in "
+"application/json format"
+msgstr ""
+"Enviaremos una solicitud POST a este endpoint para cada nuevo evento en "
+"formato application/json"
 
 #. js-lingui-id: K4HbuR
 #: src/modules/settings/developers/components/SettingsDevelopersWebhookForm.tsx
-msgid "We will send a POST request to this endpoint for each new event in application/json format."
-msgstr "Enviaremos una solicitud POST a este endpoint para cada nuevo evento en formato application/json."
+msgid ""
+"We will send a POST request to this endpoint for each new event in "
+"application/json format."
+msgstr ""
+"Enviaremos una solicitud POST a este endpoint para cada nuevo evento en "
+"formato application/json."
 
 #. js-lingui-id: PI4LiB
 #: src/pages/settings/security/SettingsSecurityApprovedAccessDomain.tsx
@@ -17299,12 +18215,12 @@ msgstr "Semana"
 #. js-lingui-id: IAUiSh
 #: src/modules/side-panel/pages/page-layout/utils/getDateGranularityPluralLabel.ts
 msgid "weeks"
-msgstr ""
+msgstr "semanas"
 
 #. js-lingui-id: WKHqM+
 #: src/modules/settings/data-model/object-details/components/tabs/SettingsObjectSearchSection.tsx
 msgid "Weight"
-msgstr ""
+msgstr "Peso"
 
 #. js-lingui-id: nTuObL
 #: src/pages/auth/SignInUp.tsx
@@ -17330,22 +18246,44 @@ msgstr "¿En qué puedo ayudarte?"
 #: src/pages/settings/developers/api-keys/SettingsDevelopersApiKeysNew.tsx
 #: src/pages/settings/developers/api-keys/SettingsDevelopersApiKeyDetail.tsx
 msgid "What this API can do: Select a user role to define its permissions."
-msgstr "Lo que puede hacer esta API: Selecciona un rol de usuario para definir sus permisos."
+msgstr ""
+"Lo que puede hacer esta API: Selecciona un rol de usuario para definir sus "
+"permisos."
 
 #. js-lingui-id: m7GziZ
 #: src/modules/ai/components/suggested-prompts/default-suggested-prompts.ts
-msgid "When a deal's stage changes to Closed Won, create a task assigned to the deal owner, due 7 days after the close date, with title \"Post-sale check-in\" and the company name in the description."
-msgstr "Cuando la etapa de una oportunidad cambie a Cerrada ganada, crea una tarea asignada al propietario de la oportunidad, con vencimiento 7 días después de la fecha de cierre, con el título \"Seguimiento posventa\" y el nombre de la empresa en la descripción."
+msgid ""
+"When a deal's stage changes to Closed Won, create a task assigned to the "
+"deal owner, due 7 days after the close date, with title \"Post-sale check-"
+"in\" and the company name in the description."
+msgstr ""
+"Cuando la etapa de una oportunidad cambie a Cerrada ganada, crea una tarea "
+"asignada al propietario de la oportunidad, con vencimiento 7 días después de"
+" la fecha de cierre, con el título \"Seguimiento posventa\" y el nombre de "
+"la empresa en la descripción."
 
 #. js-lingui-id: IHLoUB
 #: src/modules/ai/components/suggested-prompts/default-suggested-prompts.ts
-msgid "When a new lead is created with source \"Website\", assign it to the sales rep whose territory (by region/country) matches the lead's address; if no match, assign to the team lead."
-msgstr "Cuando se cree un nuevo lead con la fuente \"Website\", asígnalo al representante de ventas cuyo territorio (por región/país) coincida con la dirección del lead; si no hay coincidencia, asígnalo al líder del equipo."
+msgid ""
+"When a new lead is created with source \"Website\", assign it to the sales "
+"rep whose territory (by region/country) matches the lead's address; if no "
+"match, assign to the team lead."
+msgstr ""
+"Cuando se cree un nuevo lead con la fuente \"Website\", asígnalo al "
+"representante de ventas cuyo territorio (por región/país) coincida con la "
+"dirección del lead; si no hay coincidencia, asígnalo al líder del equipo."
 
 #. js-lingui-id: haFWB2
 #: src/modules/ai/components/suggested-prompts/default-suggested-prompts.ts
-msgid "When any deal with amount over $100,000 has its stage or amount updated, send a notification to the sales channel with the deal name, company, new stage, amount and owner."
-msgstr "Cuando cualquier oportunidad con un importe superior a $100,000 tenga su etapa o su importe actualizado, envía una notificación al canal de ventas con el nombre de la oportunidad, la empresa, la nueva etapa, el importe y el propietario."
+msgid ""
+"When any deal with amount over $100,000 has its stage or amount updated, "
+"send a notification to the sales channel with the deal name, company, new "
+"stage, amount and owner."
+msgstr ""
+"Cuando cualquier oportunidad con un importe superior a $100,000 tenga su "
+"etapa o su importe actualizado, envía una notificación al canal de ventas "
+"con el nombre de la oportunidad, la empresa, la nueva etapa, el importe y el"
+" propietario."
 
 #. js-lingui-id: C51ilI
 #: src/pages/settings/developers/api-keys/SettingsDevelopersApiKeysNew.tsx
@@ -17373,12 +18311,12 @@ msgstr "Si este modelo admite razonamiento con cadena de pensamiento"
 #. js-lingui-id: dmoPOu
 #: src/pages/settings/applications/SettingsAvailableApplicationDetails.tsx
 msgid "widget"
-msgstr ""
+msgstr "widget"
 
 #. js-lingui-id: AHXN2z
 #: src/pages/settings/layout/SettingsLayoutPageLayoutDetail.tsx
 msgid "Widget"
-msgstr ""
+msgstr "Widget"
 
 #. js-lingui-id: fANaAS
 #: src/modules/side-panel/pages/page-layout/components/SidePanelPageLayoutRecordPageWidgetTypeSelect.tsx
@@ -17389,7 +18327,7 @@ msgstr "Tipo de Widget"
 #. js-lingui-id: YR3K7M
 #: src/pages/settings/applications/SettingsAvailableApplicationDetails.tsx
 msgid "widgets"
-msgstr ""
+msgstr "widgets"
 
 #. js-lingui-id: j6ncOZ
 #: src/modules/workflow/workflow-steps/workflow-actions/iterator-action/components/WorkflowEditActionIterator.tsx
@@ -17420,12 +18358,12 @@ msgstr "Trabajador"
 #: src/modules/settings/logic-functions/components/triggers/SettingsLogicFunctionWorkflowActionTriggerSection.tsx
 #: src/modules/logic-functions/utils/getLogicFunctionTriggerLabel.ts
 msgid "Workflow action"
-msgstr ""
+msgstr "Acción del flujo de trabajo"
 
 #. js-lingui-id: Kqs5vQ
 #: src/pages/settings/ai/components/SettingsAiAgentsTable.tsx
 msgid "Workflow agents"
-msgstr ""
+msgstr "Agentes del flujo de trabajo"
 
 #. js-lingui-id: 2jzcC5
 #: src/modules/command-menu-item/engine-command/record/single-record/workflow/components/DuplicateWorkflowSingleRecordCommand.tsx
@@ -17446,8 +18384,7 @@ msgstr "Workflows"
 #: src/pages/settings/SettingsWorkspaceEmail.tsx
 #: src/pages/settings/SettingsWorkspace.tsx
 #: src/pages/settings/SettingsUsageUserDetail.tsx
-#: src/pages/settings/SettingsUsage.tsx
-#: src/pages/settings/SettingsBilling.tsx
+#: src/pages/settings/SettingsUsage.tsx src/pages/settings/SettingsBilling.tsx
 #: src/pages/settings/workspace/SettingsWorkspaceEmailGroupChannelDetail.tsx
 #: src/pages/settings/workspace/SettingsApiWebhooks.tsx
 #: src/pages/settings/security/SettingsSecuritySSOIdentifyProvider.tsx
@@ -17520,7 +18457,7 @@ msgstr "Espacio de trabajo"
 #. js-lingui-id: 0uEKEb
 #: src/modules/settings/domains/components/SettingPublicDomain.tsx
 msgid "Workspace (all apps)"
-msgstr ""
+msgstr "Espacio de trabajo (todas las aplicaciones)"
 
 #. js-lingui-id: fQ8teq
 #: src/modules/auth/sign-in-up/hooks/useSignUpInNewWorkspace.ts
@@ -17557,7 +18494,7 @@ msgstr "Instrucciones del espacio de trabajo"
 #. js-lingui-id: Ce7yfm
 #: src/pages/settings/admin-panel/SettingsAdminWorkspacesStatus.tsx
 msgid "Workspace lists by upgrade status"
-msgstr ""
+msgstr "Listas de espacios de trabajo por estado de actualización"
 
 #. js-lingui-id: Y0Fj4S
 #: src/pages/onboarding/CreateWorkspace.tsx
@@ -17572,7 +18509,7 @@ msgstr "Miembro del espacio de trabajo"
 #. js-lingui-id: wtxjAY
 #: src/pages/settings/admin-panel/SettingsAdminWorkspaceDetail.tsx
 msgid "Workspace members"
-msgstr ""
+msgstr "Miembros del espacio de trabajo"
 
 #. js-lingui-id: CozWO1
 #: src/pages/onboarding/CreateWorkspace.tsx
@@ -17585,17 +18522,18 @@ msgstr "Nombre del espacio de trabajo"
 #: src/pages/settings/applications/tabs/SettingsApplicationConnectionsSection.tsx
 #: src/pages/settings/applications/components/SettingsApplicationConnectScopePickerModal.tsx
 msgid "Workspace shared"
-msgstr ""
+msgstr "Espacio de trabajo compartido"
 
 #. js-lingui-id: Smg70n
 #: src/modules/settings/admin-panel/components/SettingsAdminWorkspaceContent.tsx
 msgid "Workspace upgrade health"
-msgstr ""
+msgstr "Salud de actualización del espacio de trabajo"
 
 #. js-lingui-id: QZi0YX
 #: src/modules/object-record/object-options-dropdown/components/ObjectOptionsDropdownVisibilityContent.tsx
 msgid "Workspace views require manage views permission"
-msgstr "Las vistas del espacio de trabajo requieren permiso para administrar vistas"
+msgstr ""
+"Las vistas del espacio de trabajo requieren permiso para administrar vistas"
 
 #. js-lingui-id: pmt7u4
 #: src/pages/settings/admin-panel/SettingsAdminUserDetail.tsx
@@ -17607,12 +18545,13 @@ msgstr "Espacios de trabajo"
 #: src/pages/settings/admin-panel/SettingsAdminWorkspacesStatus.tsx
 #: src/modules/settings/admin-panel/health-status/components/SettingsAdminUpgradeStatusListCard.tsx
 msgid "Workspaces status"
-msgstr ""
+msgstr "Estado de los espacios de trabajo"
 
 #. js-lingui-id: QPsQMb
 #: src/modules/object-record/record-group/components/RecordGroupReorderConfirmationModal.tsx
 msgid "Would you like to remove {recordIndexRecordGroupSort} group sorting?"
-msgstr "¿Le gustaría quitar la ordenación del grupo {recordIndexRecordGroupSort}?"
+msgstr ""
+"¿Le gustaría quitar la ordenación del grupo {recordIndexRecordGroupSort}?"
 
 #. js-lingui-id: 5iSD9O
 #: src/modules/settings/data-model/fields/forms/components/text/SettingsDataModelFieldTextForm.tsx
@@ -17678,7 +18617,7 @@ msgstr "anual"
 #: src/modules/settings/enterprise/components/EnterprisePlanModal.tsx
 #: src/modules/settings/admin-panel/components/SettingsAdminWorkspaceBillingContent.tsx
 msgid "Yearly"
-msgstr ""
+msgstr "Anual"
 
 #. js-lingui-id: +BGee5
 #: src/modules/side-panel/pages/page-layout/utils/getDateGranularityPluralLabel.ts
@@ -17737,17 +18676,22 @@ msgstr "No tiene permiso para crear registros en este objeto"
 #. js-lingui-id: iibZbD
 #: src/pages/settings/applications/tabs/SettingsApplicationsDeveloperTab.tsx
 msgid "You can either create a private app or share it to others"
-msgstr ""
+msgstr "Puedes crear una aplicación privada o compartirla con otros"
 
 #. js-lingui-id: CNAoaw
 #: src/modules/workflow/workflow-steps/workflow-actions/logic-function-action/components/WorkflowEditActionLogicFunction.tsx
 msgid "You can see the function logic in your application settings."
-msgstr "Puedes ver la lógica de la función en la configuración de la aplicación."
+msgstr ""
+"Puedes ver la lógica de la función en la configuración de la aplicación."
 
 #. js-lingui-id: OLE3Ky
 #: src/modules/settings/accounts/components/SettingsAccountsConnectionForm.tsx
-msgid "You can set up any combination of IMAP (receiving emails), SMTP (sending emails), and CalDAV (calendar sync)."
-msgstr "Puedes configurar cualquier combinación de IMAP (recibir correos), SMTP (enviar correos) y CalDAV (sincronización de calendario)."
+msgid ""
+"You can set up any combination of IMAP (receiving emails), SMTP (sending "
+"emails), and CalDAV (calendar sync)."
+msgstr ""
+"Puedes configurar cualquier combinación de IMAP (recibir correos), SMTP "
+"(enviar correos) y CalDAV (sincronización de calendario)."
 
 #. js-lingui-id: eqUj2Z
 #: src/modules/page-layout/widgets/components/PageLayoutWidgetForbiddenDisplay.tsx
@@ -17762,12 +18706,12 @@ msgstr "No tienes permiso para ver este widget"
 #. js-lingui-id: SDVtJI
 #: src/modules/object-record/record-index/components/RecordIndexEmptyStateNotShared.tsx
 msgid "You don't have access to this object."
-msgstr ""
+msgstr "No tienes acceso a este objeto."
 
 #. js-lingui-id: RDAH2t
 #: src/modules/settings/billing/components/SettingsBillingSubscriptionInfo.tsx
 msgid "You have scheduled a credit pack change. Do you want to cancel it?"
-msgstr ""
+msgstr "Has programado un cambio de paquete de créditos. ¿Deseas cancelarlo?"
 
 #. js-lingui-id: z8eKS7
 #: src/modules/settings/billing/hooks/useBillingWording.ts
@@ -17776,8 +18720,12 @@ msgstr "se le cobrará ${enterprisePrice} por usuario al mes"
 
 #. js-lingui-id: u3S6u8
 #: src/modules/settings/billing/hooks/useBillingWording.ts
-msgid "You will be charged ${monthlyPrice} per user per month billed monthly. The change will be applied the {beautifiedRenewDate}."
-msgstr "Se te cobrará ${monthlyPrice} por usuario al mes facturado mensualmente. El cambio se aplicará el {beautifiedRenewDate}."
+msgid ""
+"You will be charged ${monthlyPrice} per user per month billed monthly. The "
+"change will be applied the {beautifiedRenewDate}."
+msgstr ""
+"Se te cobrará ${monthlyPrice} por usuario al mes facturado mensualmente. El "
+"cambio se aplicará el {beautifiedRenewDate}."
 
 #. js-lingui-id: /T5zAB
 #: src/modules/settings/billing/hooks/useBillingWording.ts
@@ -17786,8 +18734,12 @@ msgstr "Se le cobrará ${proPrice} por usuario al mes"
 
 #. js-lingui-id: W3k5LA
 #: src/modules/settings/billing/hooks/useBillingWording.ts
-msgid "You will be charged ${yearlyPrice} per user per year billed annually. A prorata with your current subscription will be applied."
-msgstr "Se te cobrará ${yearlyPrice} por usuario por año facturado anualmente. Se aplicará un prorrateo con tu suscripción actual."
+msgid ""
+"You will be charged ${yearlyPrice} per user per year billed annually. A "
+"prorata with your current subscription will be applied."
+msgstr ""
+"Se te cobrará ${yearlyPrice} por usuario por año facturado anualmente. Se "
+"aplicará un prorrateo con tu suscripción actual."
 
 #. js-lingui-id: C2d+Xk
 #: src/modules/spreadsheet-import/steps/components/MatchColumnsStep/MatchColumnsStep.tsx
@@ -17796,8 +18748,12 @@ msgstr "Perderás todas tus asignaciones."
 
 #. js-lingui-id: Cl+hUj
 #: src/modules/settings/domains/components/SettingsSubdomain.tsx
-msgid "You're about to change your workspace subdomain. This action will log out all users."
-msgstr "Estás a punto de cambiar el subdominio de tu espacio de trabajo. Esta acción cerrará la sesión de todos los usuarios."
+msgid ""
+"You're about to change your workspace subdomain. This action will log out "
+"all users."
+msgstr ""
+"Estás a punto de cambiar el subdominio de tu espacio de trabajo. Esta acción"
+" cerrará la sesión de todos los usuarios."
 
 #. js-lingui-id: Z5uTAF
 #: src/modules/ai/components/AIChatNoMoreBillingCreditsBanner.tsx
@@ -17805,6 +18761,8 @@ msgid ""
 "You've hit your usage limit. \n"
 "Reach to our support team to upgrade."
 msgstr ""
+"Has alcanzado tu límite de uso. \n"
+"Contacta a nuestro equipo de soporte para actualizar."
 
 #. js-lingui-id: /fksQo
 #: src/modules/ai/components/AIChatNoMoreBillingCreditsBanner.tsx
@@ -17812,11 +18770,13 @@ msgid ""
 "You've hit your usage limit. \n"
 "Upgrade to {nextResourceCreditsAmount} credits for ${nextResourceCreditPrice}/{nextTierInterval}."
 msgstr ""
+"Has alcanzado tu límite de uso. \n"
+"Actualiza a {nextResourceCreditsAmount} créditos por ${nextResourceCreditPrice}/{nextTierInterval}."
 
 #. js-lingui-id: yZ0wRS
 #: src/modules/ai/components/AIChatNoMoreBillingCreditsBanner.tsx
 msgid "You've hit your usage limit. Subscribe for more usage."
-msgstr ""
+msgstr "Has alcanzado tu límite de uso. Suscríbete para más uso."
 
 #. js-lingui-id: nIF+FL
 #: src/pages/onboarding/PaymentSuccess.tsx
@@ -17826,17 +18786,23 @@ msgstr "Tu cuenta ha sido activada."
 #. js-lingui-id: tOPGvO
 #: src/modules/apollo/services/apollo.factory.ts
 msgid "Your app version is out of date. Please refresh the page."
-msgstr "La versión de su aplicación está desactualizada. Por favor, actualice la página."
+msgstr ""
+"La versión de su aplicación está desactualizada. Por favor, actualice la "
+"página."
 
 #. js-lingui-id: +5YqGH
 #: src/modules/onboarding/constants/OnboardingSyncEmailsOptions.ts
 msgid "Your email subjects and meeting titles will be shared with your team."
-msgstr "Los asuntos de tus correos electrónicos y los títulos de las reuniones se compartirán con tu equipo."
+msgstr ""
+"Los asuntos de tus correos electrónicos y los títulos de las reuniones se "
+"compartirán con tu equipo."
 
 #. js-lingui-id: la0RPA
 #: src/modules/onboarding/constants/OnboardingSyncEmailsOptions.ts
 msgid "Your emails and events content will be shared with your team."
-msgstr "El contenido de tus correos electrónicos y eventos se compartirá con tu equipo."
+msgstr ""
+"El contenido de tus correos electrónicos y eventos se compartirá con tu "
+"equipo."
 
 #. js-lingui-id: ahEwS4
 #: src/pages/settings/enterprise/SettingsEnterprise.tsx
@@ -17845,8 +18811,15 @@ msgstr "Tus funciones Enterprise están activas"
 
 #. js-lingui-id: XMZLU/
 #: src/pages/settings/enterprise/SettingsEnterprise.tsx
-msgid "Your enterprise features are active but your enterprise key is missing or invalid. This may be expected, but if not, please set a valid signed enterprise key to manage your subscription, or contact support."
-msgstr "Tus funciones Enterprise están activas, pero falta tu clave Enterprise o no es válida. Esto puede ser esperado; si no es así, configura una clave Enterprise firmada válida para gestionar tu suscripción o ponte en contacto con soporte."
+msgid ""
+"Your enterprise features are active but your enterprise key is missing or "
+"invalid. This may be expected, but if not, please set a valid signed "
+"enterprise key to manage your subscription, or contact support."
+msgstr ""
+"Tus funciones Enterprise están activas, pero falta tu clave Enterprise o no "
+"es válida. Esto puede ser esperado; si no es así, configura una clave "
+"Enterprise firmada válida para gestionar tu suscripción o ponte en contacto "
+"con soporte."
 
 #. js-lingui-id: AxcwNj
 #: src/pages/settings/enterprise/SettingsEnterprise.tsx
@@ -17865,18 +18838,32 @@ msgstr "Tu suscripción Enterprise se ha cancelado."
 
 #. js-lingui-id: leFkCA
 #: src/modules/settings/logic-functions/components/triggers/SettingsLogicFunctionDatabaseEventTriggerSection.tsx
-msgid "Your handler receives this event object. \"after\" holds the new state, \"before\" the previous one (null for created), and \"updatedFields\" lists the field names that changed on update."
+msgid ""
+"Your handler receives this event object. \"after\" holds the new state, "
+"\"before\" the previous one (null for created), and \"updatedFields\" lists "
+"the field names that changed on update."
 msgstr ""
+"Tu controlador recibe este objeto de evento. \"after\" contiene el nuevo "
+"estado, \"before\" el anterior (nulo para creados), y \"updatedFields\" "
+"lista los nombres de campos que cambiaron en la actualización."
 
 #. js-lingui-id: aNI1bz
 #: src/modules/settings/logic-functions/components/triggers/SettingsLogicFunctionHttpTriggerSection.tsx
-msgid "Your handler receives this object. The body holds the parsed JSON sent by the client."
+msgid ""
+"Your handler receives this object. The body holds the parsed JSON sent by "
+"the client."
 msgstr ""
+"Tu controlador recibe este objeto. El cuerpo contiene el JSON analizado "
+"enviado por el cliente."
 
 #. js-lingui-id: GJewTO
 #: src/modules/settings/logic-functions/components/triggers/SettingsLogicFunctionHttpTriggerSection.tsx
-msgid "Your handler receives this object. The body is empty because GET requests carry no payload."
+msgid ""
+"Your handler receives this object. The body is empty because GET requests "
+"carry no payload."
 msgstr ""
+"Tu controlador recibe este objeto. El cuerpo está vacío porque las "
+"solicitudes GET no llevan payload."
 
 #. js-lingui-id: 9ivpwk
 #: src/pages/settings/SettingsProfile.tsx
@@ -17895,8 +18882,12 @@ msgstr "Tu clave de API del proveedor para la autenticación"
 
 #. js-lingui-id: 319YPG
 #: src/pages/settings/enterprise/SettingsEnterprise.tsx
-msgid "Your subscription is active but your validity token is invalid or has expired. Try reloading it or contact support."
-msgstr "Tu suscripción está activa, pero tu token de validez no es válido o ha caducado. Intenta recargarlo o ponte en contacto con soporte."
+msgid ""
+"Your subscription is active but your validity token is invalid or has "
+"expired. Try reloading it or contact support."
+msgstr ""
+"Tu suscripción está activa, pero tu token de validez no es válido o ha "
+"caducado. Intenta recargarlo o ponte en contacto con soporte."
 
 #. js-lingui-id: Fx0axg
 #: src/pages/settings/enterprise/SettingsEnterprise.tsx
@@ -17920,8 +18911,14 @@ msgstr "Su período de prueba terminará, y "
 
 #. js-lingui-id: 2Fkd7s
 #: src/modules/settings/billing/hooks/useBillingWording.ts
-msgid "Your trial period will end, and you will be charged ${yearlyPrice} per user per year billed annually. A prorata with your current subscription will be applied."
-msgstr "Su período de prueba terminará, y se le cobrará ${yearlyPrice} por usuario por año facturado anualmente. Se aplicará un prorrateo con su suscripción actual."
+msgid ""
+"Your trial period will end, and you will be charged ${yearlyPrice} per user "
+"per year billed annually. A prorata with your current subscription will be "
+"applied."
+msgstr ""
+"Su período de prueba terminará, y se le cobrará ${yearlyPrice} por usuario "
+"por año facturado anualmente. Se aplicará un prorrateo con su suscripción "
+"actual."
 
 #. js-lingui-id: oC6WBs
 #: src/modules/information-banner/components/billing/InformationBannerNoBillingSubscription.tsx
@@ -17930,8 +18927,12 @@ msgstr "Su espacio de trabajo no tiene una suscripción activa."
 
 #. js-lingui-id: QBTEtW
 #: src/modules/information-banner/components/billing/InformationBannerNoBillingSubscription.tsx
-msgid "Your workspace doesn't have an active subscription. Please contact your admin."
-msgstr "Su espacio de trabajo no tiene una suscripción activa. Por favor, contacte a su administrador."
+msgid ""
+"Your workspace doesn't have an active subscription. Please contact your "
+"admin."
+msgstr ""
+"Su espacio de trabajo no tiene una suscripción activa. Por favor, contacte a"
+" su administrador."
 
 #. js-lingui-id: RhNbPE
 #: src/modules/settings/billing/components/SettingsBillingContent.tsx

--- a/packages/twenty-server/src/engine/core-modules/i18n/locales/es-ES.po
+++ b/packages/twenty-server/src/engine/core-modules/i18n/locales/es-ES.po
@@ -1,46 +1,51 @@
+#
 msgid ""
 msgstr ""
-"POT-Creation-Date: 2025-01-29 18:14+0100\n"
-"MIME-Version: 1.0\n"
-"Content-Type: text/plain; charset=UTF-8\n"
-"Content-Transfer-Encoding: 8bit\n"
-"X-Generator: @lingui/cli\n"
-"Language: es\n"
 "Project-Id-Version: cf448e737e0d6d7b78742f963d761c61\n"
 "Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2025-01-29 18:14+0100\n"
 "PO-Revision-Date: 2025-01-01 00:00\n"
 "Last-Translator: \n"
 "Language-Team: Spanish\n"
+"Language: es\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
-"X-Crowdin-Project: cf448e737e0d6d7b78742f963d761c61\n"
-"X-Crowdin-Project-ID: 1\n"
-"X-Crowdin-Language: es\n"
 "X-Crowdin-File: /packages/twenty-server/src/engine/core-modules/i18n/locales/en.po\n"
 "X-Crowdin-File-ID: 31\n"
+"X-Crowdin-Language: es\n"
+"X-Crowdin-Project: cf448e737e0d6d7b78742f963d761c61\n"
+"X-Crowdin-Project-ID: 1\n"
+"X-Generator: @lingui/cli\n"
 
 #. js-lingui-id: ZM94I5
 #. placeholder {0}: flatField.label
 #: src/engine/metadata-modules/index-metadata/services/index-metadata.service.ts
-msgid "\"{0}\" is a one-to-many relation and can't be indexed directly. Index the foreign-key side instead."
+msgid ""
+"\"{0}\" is a one-to-many relation and can't be indexed directly. Index the "
+"foreign-key side instead."
 msgstr ""
+"\"{0}\" es una relación uno-a-muchos y no se puede indexar directamente. "
+"Indexa el lado de la clave foránea en su lugar."
 
 #. js-lingui-id: bxSgKk
 #. placeholder {0}: flatField.label
 #: src/engine/metadata-modules/index-metadata/services/index-metadata.service.ts
 msgid "\"{0}\" is not a composite field — remove the sub-field selection."
-msgstr ""
+msgstr "\"{0}\" no es un campo compuesto — elimina la selección de subcampo."
 
 #. js-lingui-id: 6RLdgl
 #. placeholder {0}: input.subFieldName
 #. placeholder {1}: flatField.label
 #: src/engine/metadata-modules/index-metadata/services/index-metadata.service.ts
 msgid "\"{0}\" is not a valid sub-field of \"{1}\"."
-msgstr ""
+msgstr "\"{0}\" no es un subcampo válido de \"{1}\"."
 
 #. js-lingui-id: SsRDX3
 #: src/engine/core-modules/user/utils/assert-workspace-member-update-non-custom-fields.util.ts
 msgid "\"{payloadKey}\" is not a valid workspace member field."
-msgstr ""
+msgstr "\"{payloadKey}\" no es un campo válido de miembro del espacio de trabajo."
 
 #. js-lingui-id: Q0ISF1
 #: src/engine/twenty-orm/utils/compute-relation-connect-query-configs.util.ts
@@ -61,22 +66,24 @@ msgstr "Los campos de {fieldType} no pueden tener un valor predeterminado."
 #. js-lingui-id: VEmyIu
 #: src/engine/metadata-modules/page-layout-widget/utils/validate-chart-configuration-field-references.util.ts
 msgid "{fullMessage}"
-msgstr ""
+msgstr "{fullMessage}"
 
 #. js-lingui-id: iEZavm
 #: src/engine/core-modules/dns-manager/services/dns-manager.service.ts
 msgid "{hostnameCount} hostnames found for domain '{domainName}'. Expect 1"
-msgstr "Se encontraron {hostnameCount} nombres de host para el dominio '{domainName}'. Esperar 1"
+msgstr ""
+"Se encontraron {hostnameCount} nombres de host para el dominio "
+"'{domainName}'. Esperar 1"
 
 #. js-lingui-id: 0eYXBl
 #: src/engine/workspace-manager/twenty-standard-application/utils/field-metadata/compute-workspace-member-standard-flat-field-metadata.util.ts
 msgid "12HRS"
-msgstr ""
+msgstr "12H"
 
 #. js-lingui-id: iMVAB9
 #: src/engine/workspace-manager/twenty-standard-application/utils/field-metadata/compute-workspace-member-standard-flat-field-metadata.util.ts
 msgid "24HRS"
-msgstr ""
+msgstr "24H"
 
 #. js-lingui-id: kZR6+h
 #: src/engine/workspace-manager/twenty-standard-application/utils/object-metadata/create-standard-flat-object-metadata.util.ts
@@ -85,13 +92,17 @@ msgstr "Una empresa"
 
 #. js-lingui-id: JYntnV
 #: src/engine/workspace-manager/workspace-migration/workspace-migration-builder/validators/services/flat-connection-provider-validator.service.ts
-msgid "A connection provider with this name already exists for this application"
+msgid ""
+"A connection provider with this name already exists for this application"
 msgstr ""
+"Ya existe un proveedor de conexión con este nombre para esta aplicación"
 
 #. js-lingui-id: jzhZvB
 #: src/engine/core-modules/application/connection-provider/connection-provider.exception.ts
-msgid "A connection provider with this name already exists for this application."
+msgid ""
+"A connection provider with this name already exists for this application."
 msgstr ""
+"Ya existe un proveedor de conexión con este nombre para esta aplicación."
 
 #. js-lingui-id: cOSBjW
 #: src/engine/workspace-manager/twenty-standard-application/utils/object-metadata/create-standard-flat-object-metadata.util.ts
@@ -125,8 +136,12 @@ msgstr "Ya existe una función con este nombre."
 
 #. js-lingui-id: 6yZjO1
 #: src/engine/core-modules/application/application.exception.ts
-msgid "A higher version of this application is already installed. Downgrading is not allowed."
+msgid ""
+"A higher version of this application is already installed. Downgrading is "
+"not allowed."
 msgstr ""
+"Ya hay instalada una versión superior de esta aplicación. No se permite "
+"retroceder de versión."
 
 #. js-lingui-id: Nh/ZZe
 #: src/engine/metadata-modules/object-metadata/object-metadata.exception.ts
@@ -150,13 +165,17 @@ msgstr "Un objetivo de nota"
 
 #. js-lingui-id: HC18ok
 #: src/engine/core-modules/file-storage/utils/validate-path-segments-safety.util.ts
-msgid "A path segment contains invalid characters. Only alphanumeric, dots, dashes and underscores are allowed"
+msgid ""
+"A path segment contains invalid characters. Only alphanumeric, dots, dashes "
+"and underscores are allowed"
 msgstr ""
+"Un segmento de ruta contiene caracteres inválidos. Solo se permiten "
+"alfanuméricos, puntos, guiones y guiones bajos"
 
 #. js-lingui-id: 5VSRdB
 #: src/engine/core-modules/file-storage/utils/validate-path-segments-safety.util.ts
 msgid "A path segment exceeds the maximum length of 255 characters"
-msgstr ""
+msgstr "Un segmento de ruta excede la longitud máxima de 255 caracteres"
 
 #. js-lingui-id: W6LTzL
 #: src/engine/core-modules/billing/billing.exception.ts
@@ -308,7 +327,7 @@ msgstr "Un miembro del espacio de trabajo"
 #. js-lingui-id: bzMKg7
 #: src/engine/workspace-manager/twenty-standard-application/utils/field-metadata/compute-calendar-event-participant-standard-flat-field-metadata.util.ts
 msgid "Accepted"
-msgstr ""
+msgstr "Aceptado"
 
 #. js-lingui-id: qjrxU8
 #: src/engine/core-modules/file-storage/interfaces/file-storage-exception.ts
@@ -359,7 +378,7 @@ msgstr "Activo"
 #. js-lingui-id: ffpvxH
 #: src/engine/core-modules/user/utils/assert-workspace-member-update-non-custom-fields.util.ts
 msgid "Add at least one field to update."
-msgstr ""
+msgstr "Añade al menos un campo para actualizar."
 
 #. js-lingui-id: Du6bPw
 #: src/engine/workspace-manager/twenty-standard-application/utils/field-metadata/compute-company-standard-flat-field-metadata.util.ts
@@ -407,7 +426,9 @@ msgstr "El campo de agregación es obligatorio para el widget de gráfico"
 #. js-lingui-id: /Z4Wk1
 #: src/engine/metadata-modules/flat-page-layout-widget/validators/utils/validate-base-graph-fields.util.ts
 msgid "Aggregate field metadata is required for graph widget \"{widgetTitle}\""
-msgstr "Los metadatos del campo de agregación son obligatorios para el widget de gráfico \"{widgetTitle}\""
+msgstr ""
+"Los metadatos del campo de agregación son obligatorios para el widget de "
+"gráfico \"{widgetTitle}\""
 
 #. js-lingui-id: uhRAsd
 #: src/engine/metadata-modules/flat-page-layout-widget/validators/utils/validate-base-graph-fields.util.ts
@@ -417,7 +438,9 @@ msgstr "La operación de agregación es obligatoria para el widget de gráfico"
 #. js-lingui-id: YCzwBK
 #: src/engine/metadata-modules/flat-page-layout-widget/validators/utils/validate-base-graph-fields.util.ts
 msgid "Aggregate operation is required for graph widget \"{widgetTitle}\""
-msgstr "La operación de agregación es obligatoria para el widget de gráfico \"{widgetTitle}\""
+msgstr ""
+"La operación de agregación es obligatoria para el widget de gráfico "
+"\"{widgetTitle}\""
 
 #. js-lingui-id: W58PBh
 #: src/engine/workspace-manager/twenty-standard-application/utils/object-metadata/create-standard-flat-object-metadata.util.ts
@@ -462,12 +485,13 @@ msgstr "Se produjo un error durante la migración del espacio de trabajo."
 #. js-lingui-id: X3mSup
 #: src/engine/core-modules/messaging-webhooks/messaging-webhook.exception.ts
 msgid "An error occurred while processing the webhook."
-msgstr ""
+msgstr "Ocurrió un error al procesar el webhook."
 
 #. js-lingui-id: S7yZl9
 #: src/engine/core-modules/two-factor-authentication/two-factor-authentication.exception.ts
 msgid "An error occurred with two-factor authentication data."
-msgstr "Se produjo un error con los datos de la autenticación de dos factores."
+msgstr ""
+"Se produjo un error con los datos de la autenticación de dos factores."
 
 #. js-lingui-id: XyOToQ
 #: src/engine/core-modules/graphql/utils/generate-graphql-error-from-error.util.ts
@@ -489,7 +513,7 @@ msgstr "Un índice debe contener al menos un campo"
 #. js-lingui-id: KvWKJI
 #: src/engine/core-modules/secret-encryption/exceptions/secret-encryption.exception.ts
 msgid "An internal error occurred while handling encrypted data."
-msgstr ""
+msgstr "Ocurrió un error interno al manejar datos cifrados."
 
 #. js-lingui-id: SOp/Vw
 #: src/engine/core-modules/workspace-invitation/workspace-invitation.exception.ts
@@ -540,13 +564,21 @@ msgstr "Se produjo un error desconocido del calendario."
 
 #. js-lingui-id: JKWicb
 #: src/engine/workspace-manager/twenty-standard-application/utils/field-metadata/compute-company-standard-flat-field-metadata.util.ts
-msgid "Annual Recurring Revenue: The actual or estimated annual revenue of the company"
-msgstr "Ingresos recurrentes anuales: los ingresos anuales reales o estimados de la empresa"
+msgid ""
+"Annual Recurring Revenue: The actual or estimated annual revenue of the "
+"company"
+msgstr ""
+"Ingresos recurrentes anuales: los ingresos anuales reales o estimados de la "
+"empresa"
 
 #. js-lingui-id: 4XvK/4
 #: src/engine/workspace-manager/workspace-migration/workspace-migration-builder/validators/services/flat-permission-flag-validator.service.ts
-msgid "Another application in this workspace has already registered a permission flag with this key."
+msgid ""
+"Another application in this workspace has already registered a permission "
+"flag with this key."
 msgstr ""
+"Otra aplicación en este espacio de trabajo ya ha registrado un indicador de "
+"permiso con esta clave."
 
 #. js-lingui-id: fRWsMD
 #: src/engine/metadata-modules/ai/ai.exception.ts
@@ -571,17 +603,19 @@ msgstr "Rol de clave de API no encontrado."
 #. js-lingui-id: 0UMxlw
 #: src/engine/workspace-manager/twenty-standard-application/utils/field-metadata/compute-workspace-member-standard-flat-field-metadata.util.ts
 msgid "Apostrophe and dot"
-msgstr ""
+msgstr "Apóstrofe y punto"
 
 #. js-lingui-id: ue106l
 #: src/engine/core-modules/application/application.exception.ts
 msgid "Application is not installed in this workspace. Install it first."
-msgstr "La aplicación no está instalada en este espacio de trabajo. Instálala primero."
+msgstr ""
+"La aplicación no está instalada en este espacio de trabajo. Instálala "
+"primero."
 
 #. js-lingui-id: t77Ey9
 #: src/engine/core-modules/public-domain/public-domain.exception.ts
 msgid "Application not found in this workspace."
-msgstr ""
+msgstr "Aplicación no encontrada en este espacio de trabajo."
 
 #. js-lingui-id: ltvmAF
 #: src/engine/workspace-manager/workspace-migration/workspace-migration-runner/exceptions/workspace-migration-runner.exception.ts
@@ -596,12 +630,12 @@ msgstr "Aplicación no encontrada."
 #. js-lingui-id: kuNcoR
 #: src/engine/core-modules/application/application.exception.ts
 msgid "Application post-install logic function failed."
-msgstr ""
+msgstr "La función de lógica post-instalación de la aplicación falló."
 
 #. js-lingui-id: UTxpa1
 #: src/engine/core-modules/application/application.exception.ts
 msgid "Application pre-install logic function failed."
-msgstr ""
+msgstr "La función de lógica pre-instalación de la aplicación falló."
 
 #. js-lingui-id: DE/icK
 #: src/engine/core-modules/application/application-registration/application-registration.exception.ts
@@ -622,13 +656,13 @@ msgstr "La actualización de la aplicación falló."
 #: src/engine/workspace-manager/workspace-migration/workspace-migration-builder/validators/services/flat-application-variable-validator.service.ts
 #: src/engine/workspace-manager/workspace-migration/workspace-migration-builder/validators/services/flat-application-variable-validator.service.ts
 msgid "Application variable key is required"
-msgstr ""
+msgstr "La clave de variable de aplicación es obligatoria"
 
 #. js-lingui-id: K+YEBR
 #: src/engine/workspace-manager/workspace-migration/workspace-migration-builder/validators/services/flat-application-variable-validator.service.ts
 #: src/engine/workspace-manager/workspace-migration/workspace-migration-builder/validators/services/flat-application-variable-validator.service.ts
 msgid "Application variable key must be unique"
-msgstr ""
+msgstr "La clave de variable de aplicación debe ser única"
 
 #. js-lingui-id: e6tjp1
 #: src/engine/workspace-manager/workspace-migration/workspace-migration-builder/validators/services/flat-application-variable-validator.service.ts
@@ -636,7 +670,7 @@ msgstr ""
 #: src/engine/workspace-manager/workspace-migration/workspace-migration-builder/validators/services/flat-application-variable-validator.service.ts
 #: src/engine/workspace-manager/workspace-migration/workspace-migration-builder/validators/services/flat-application-variable-validator.service.ts
 msgid "Application variable not found"
-msgstr ""
+msgstr "Variable de aplicación no encontrada"
 
 #. js-lingui-id: 9qtW5o
 #: src/engine/core-modules/application/application-variable/application-variable.exception.ts
@@ -651,7 +685,9 @@ msgstr "El dominio de acceso aprobado ya ha sido registrado."
 #. js-lingui-id: DGW5iN
 #: src/engine/core-modules/approved-access-domain/services/approved-access-domain.service.ts
 msgid "Approved access domain does not match email domain"
-msgstr "El dominio aprobado de acceso no coincide con el dominio del correo electrónico"
+msgstr ""
+"El dominio aprobado de acceso no coincide con el dominio del correo "
+"electrónico"
 
 #. js-lingui-id: BKvuAq
 #: src/engine/core-modules/approved-access-domain/services/approved-access-domain.service.ts
@@ -672,12 +708,12 @@ msgstr "Abril"
 #. js-lingui-id: B495Gs
 #: src/engine/workspace-manager/twenty-standard-application/utils/field-metadata/compute-attachment-standard-flat-field-metadata.util.ts
 msgid "Archive"
-msgstr ""
+msgstr "Archivar"
 
 #. js-lingui-id: TdfEV7
 #: src/engine/workspace-manager/twenty-standard-application/utils/field-metadata/compute-workflow-version-standard-flat-field-metadata.util.ts
 msgid "Archived"
-msgstr ""
+msgstr "Archivado"
 
 #. js-lingui-id: 3EiOLz
 #: src/engine/workspace-manager/twenty-standard-application/utils/field-metadata/compute-company-standard-flat-field-metadata.util.ts
@@ -702,7 +738,7 @@ msgstr "ID de usuario asociado"
 #. js-lingui-id: IlaQdj
 #: src/engine/metadata-modules/flat-field-metadata/validators/utils/validate-morph-relation-creation-payload.util.ts
 msgid "At least one relation is required"
-msgstr ""
+msgstr "Al menos una relación es obligatoria"
 
 #. js-lingui-id: UY1vmE
 #: src/engine/workspace-manager/twenty-standard-application/utils/object-metadata/create-standard-flat-object-metadata.util.ts
@@ -712,7 +748,7 @@ msgstr "Adjunto"
 #. js-lingui-id: btKdFz
 #: src/engine/workspace-manager/twenty-standard-application/utils/field-metadata/compute-attachment-standard-flat-field-metadata.util.ts
 msgid "Attachment file"
-msgstr ""
+msgstr "Archivo adjunto"
 
 #. js-lingui-id: u3pBxa
 #: src/engine/workspace-manager/twenty-standard-application/utils/field-metadata/compute-attachment-standard-flat-field-metadata.util.ts
@@ -732,7 +768,7 @@ msgstr "Nombre del adjunto"
 #. js-lingui-id: F990we
 #: src/engine/workspace-manager/twenty-standard-application/utils/field-metadata/compute-attachment-standard-flat-field-metadata.util.ts
 msgid "Attachment record position"
-msgstr ""
+msgstr "Posición del registro adjunto"
 
 #. js-lingui-id: RWMEBF
 #: src/engine/workspace-manager/twenty-standard-application/utils/field-metadata/compute-attachment-standard-flat-field-metadata.util.ts
@@ -743,7 +779,7 @@ msgstr ""
 #: src/engine/workspace-manager/twenty-standard-application/utils/field-metadata/compute-attachment-standard-flat-field-metadata.util.ts
 #: src/engine/workspace-manager/twenty-standard-application/utils/field-metadata/compute-attachment-standard-flat-field-metadata.util.ts
 msgid "Attachment target"
-msgstr ""
+msgstr "Destino del adjunto"
 
 #. js-lingui-id: w/Sphq
 #: src/engine/workspace-manager/twenty-standard-application/utils/object-metadata/create-standard-flat-object-metadata.util.ts
@@ -809,8 +845,12 @@ msgstr "La autenticación no está habilitada con este proveedor."
 
 #. js-lingui-id: Tsx+z2
 #: src/engine/metadata-modules/permissions/permissions.service.ts
-msgid "Authentication is required to access this feature. Please sign in and try again."
-msgstr "Se requiere autenticación para acceder a esta función. Por favor, inicie sesión e intente de nuevo."
+msgid ""
+"Authentication is required to access this feature. Please sign in and try "
+"again."
+msgstr ""
+"Se requiere autenticación para acceder a esta función. Por favor, inicie "
+"sesión e intente de nuevo."
 
 #. js-lingui-id: cgNV3G
 #: src/engine/metadata-modules/permissions/permissions.exception.ts
@@ -841,7 +881,7 @@ msgstr "Avatar"
 #. js-lingui-id: qDKGpf
 #: src/engine/workspace-manager/twenty-standard-application/utils/field-metadata/compute-person-standard-flat-field-metadata.util.ts
 msgid "Avatar File"
-msgstr ""
+msgstr "Archivo de avatar"
 
 #. js-lingui-id: S/mJUR
 #: src/engine/workspace-manager/twenty-standard-application/utils/field-metadata/compute-workspace-member-standard-flat-field-metadata.util.ts
@@ -851,7 +891,7 @@ msgstr "URL del avatar"
 #. js-lingui-id: /xLNEx
 #: src/engine/workspace-manager/twenty-standard-application/utils/field-metadata/compute-message-participant-standard-flat-field-metadata.util.ts
 msgid "Bcc"
-msgstr ""
+msgstr "Cco"
 
 #. js-lingui-id: rkIGWa
 #: src/engine/core-modules/billing/billing.exception.ts
@@ -909,7 +949,7 @@ msgstr "Entrada de la lista de bloqueos no encontrada."
 #. js-lingui-id: w4auss
 #: src/engine/workspace-manager/twenty-standard-application/utils/field-metadata/compute-blocklist-standard-flat-field-metadata.util.ts
 msgid "Blocklist record position"
-msgstr ""
+msgstr "Posición del registro de lista de bloqueo"
 
 #. js-lingui-id: Tv2hxv
 #: src/engine/workspace-manager/twenty-standard-application/utils/field-metadata/compute-workspace-member-standard-flat-field-metadata.util.ts
@@ -930,12 +970,15 @@ msgstr "Cuerpo"
 #. js-lingui-id: Ara8xP
 #: src/engine/metadata-modules/flat-page-layout-widget/validators/utils/validate-standalone-rich-text-body.util.ts
 msgid "Body is required for standalone rich text widget"
-msgstr "El cuerpo es obligatorio para el widget de texto enriquecido independiente"
+msgstr ""
+"El cuerpo es obligatorio para el widget de texto enriquecido independiente"
 
 #. js-lingui-id: I6oEwz
 #: src/engine/metadata-modules/flat-page-layout-widget/validators/utils/validate-standalone-rich-text-body.util.ts
 msgid "Body is required for standalone rich text widget \"{widgetTitle}\""
-msgstr "El cuerpo es obligatorio para el widget de texto enriquecido independiente \"{widgetTitle}\""
+msgstr ""
+"El cuerpo es obligatorio para el widget de texto enriquecido independiente "
+"\"{widgetTitle}\""
 
 #. js-lingui-id: YCGofH
 #: src/engine/metadata-modules/flat-page-layout-widget/validators/utils/validate-standalone-rich-text-body.util.ts
@@ -951,23 +994,25 @@ msgstr "El cuerpo debe ser un objeto para el widget \"{widgetTitle}\""
 #: src/engine/workspace-manager/workspace-migration/workspace-migration-builder/validators/services/flat-front-component-validator.service.ts
 #: src/engine/workspace-manager/workspace-migration/workspace-migration-builder/validators/services/flat-front-component-validator.service.ts
 msgid "Built component path is invalid"
-msgstr ""
+msgstr "La ruta del componente compilado es inválida"
 
 #. js-lingui-id: OeM+/V
 #: src/engine/workspace-manager/workspace-migration/workspace-migration-builder/validators/services/flat-logic-function-validator.service.ts
 #: src/engine/workspace-manager/workspace-migration/workspace-migration-builder/validators/services/flat-logic-function-validator.service.ts
 msgid "Built handler path is invalid"
-msgstr ""
+msgstr "La ruta del controlador compilado es inválida"
 
 #. js-lingui-id: HOWEGX
 #: src/modules/blocklist/query-hooks/blocklist-update-many.pre-query.hook.ts
 msgid "Bulk update of blocklist entries is not allowed."
-msgstr "No se permite la actualización masiva de las entradas de la lista de bloqueos."
+msgstr ""
+"No se permite la actualización masiva de las entradas de la lista de "
+"bloqueos."
 
 #. js-lingui-id: 9N+p+g
 #: src/engine/metadata-modules/view-field-group/constants/standard-view-field-group-names.ts
 msgid "Business"
-msgstr ""
+msgstr "Negocio"
 
 #. js-lingui-id: 8mVqF7
 #: src/engine/workspace-manager/twenty-standard-application/utils/field-metadata/compute-timeline-activity-standard-flat-field-metadata.util.ts
@@ -988,7 +1033,7 @@ msgstr "Asociación de eventos del canal de calendario"
 #. js-lingui-id: 5ePwMy
 #: src/engine/workspace-manager/twenty-standard-application/utils/field-metadata/compute-calendar-channel-event-association-standard-flat-field-metadata.util.ts
 msgid "Calendar channel event association record position"
-msgstr ""
+msgstr "Posición del registro de asociación de evento del canal de calendario"
 
 #. js-lingui-id: kYNT3F
 #: src/engine/workspace-manager/twenty-standard-application/utils/object-metadata/create-standard-flat-object-metadata.util.ts
@@ -1026,7 +1071,7 @@ msgstr "Participante del evento del calendario"
 #. js-lingui-id: B/QIsg
 #: src/engine/workspace-manager/twenty-standard-application/utils/field-metadata/compute-calendar-event-participant-standard-flat-field-metadata.util.ts
 msgid "Calendar event participant record position"
-msgstr ""
+msgstr "Posición del registro de participante de evento de calendario"
 
 #. js-lingui-id: AWDqkQ
 #: src/engine/workspace-manager/twenty-standard-application/utils/object-metadata/create-standard-flat-object-metadata.util.ts
@@ -1045,7 +1090,7 @@ msgstr "Participantes del evento del calendario"
 #. js-lingui-id: u0R1Ba
 #: src/engine/workspace-manager/twenty-standard-application/utils/field-metadata/compute-calendar-event-standard-flat-field-metadata.util.ts
 msgid "Calendar event record position"
-msgstr ""
+msgstr "Posición del registro de evento de calendario"
 
 #. js-lingui-id: X9A2xC
 #: src/engine/workspace-manager/twenty-standard-application/utils/object-metadata/create-standard-flat-object-metadata.util.ts
@@ -1065,8 +1110,12 @@ msgstr "Error de sincronización del calendario."
 
 #. js-lingui-id: eSaCR/
 #: src/engine/twenty-orm/field-operations/relation-nested-queries/utils/formatConnectRecordNotFoundErrorMessage.util.ts
-msgid "Can't connect to {connectFieldName}. No unique record found with condition: {formattedConnectCondition}"
-msgstr "No se puede conectar a {connectFieldName}. No se encontró un registro único con la condición: {formattedConnectCondition}"
+msgid ""
+"Can't connect to {connectFieldName}. No unique record found with condition: "
+"{formattedConnectCondition}"
+msgstr ""
+"No se puede conectar a {connectFieldName}. No se encontró un registro único "
+"con la condición: {formattedConnectCondition}"
 
 #. js-lingui-id: 2oVE+z
 #: src/engine/guards/impersonate-permission.guard.ts
@@ -1076,7 +1125,8 @@ msgstr "No se puede suplantar al usuario mediante la clave API."
 #. js-lingui-id: vxbVwc
 #: src/modules/workflow/workflow-trigger/utils/assert-version-can-be-activated.util.ts
 msgid "Cannot activate non-draft or non-last-published version"
-msgstr "No se puede activar una versión que no sea borrador o la última publicada"
+msgstr ""
+"No se puede activar una versión que no sea borrador o la última publicada"
 
 #. js-lingui-id: QYS2AB
 #: src/engine/metadata-modules/permissions/permissions.exception.ts
@@ -1096,22 +1146,32 @@ msgstr "No se puede completar la operación debido a registros relacionados."
 #. js-lingui-id: 6Sk/wo
 #: src/modules/blocklist/blocklist-validation-manager/services/blocklist-validation.service.ts
 msgid "Cannot create blocklist entry for another workspace member."
-msgstr "No se puede crear una entrada de la lista de bloqueos para otro miembro del espacio de trabajo."
+msgstr ""
+"No se puede crear una entrada de la lista de bloqueos para otro miembro del "
+"espacio de trabajo."
 
 #. js-lingui-id: LIPsWu
 #: src/modules/workflow/common/workspace-services/workflow-version-validation.workspace-service.ts
 msgid "Cannot create multiple draft versions for the same workflow"
-msgstr "No se pueden crear múltiples versiones de borrador para el mismo flujo de trabajo"
+msgstr ""
+"No se pueden crear múltiples versiones de borrador para el mismo flujo de "
+"trabajo"
 
 #. js-lingui-id: RggZr4
 #: src/modules/workflow/common/workspace-services/workflow-version-validation.workspace-service.ts
 msgid "Cannot create workflow version with status other than draft"
-msgstr "No se puede crear una versión de flujo de trabajo con un estado que no sea en borrador"
+msgstr ""
+"No se puede crear una versión de flujo de trabajo con un estado que no sea "
+"en borrador"
 
 #. js-lingui-id: VPXcr5
 #: src/engine/core-modules/user/services/user.service.ts
-msgid "Cannot delete account: you are the only admin. Assign another admin or delete the workspace(s) first."
-msgstr "No se puede eliminar la cuenta: usted es el único administrador. Asigne otro administrador o elimine el(los) espacio(s) de trabajo primero."
+msgid ""
+"Cannot delete account: you are the only admin. Assign another admin or "
+"delete the workspace(s) first."
+msgstr ""
+"No se puede eliminar la cuenta: usted es el único administrador. Asigne otro"
+" administrador o elimine el(los) espacio(s) de trabajo primero."
 
 #. js-lingui-id: RYRFbW
 #: src/engine/workspace-manager/workspace-migration/workspace-migration-builder/validators/services/flat-agent-validator.service.ts
@@ -1123,7 +1183,7 @@ msgstr "No se puede eliminar el agente estándar"
 #: src/engine/workspace-manager/workspace-migration/workspace-migration-builder/validators/services/flat-permission-flag-validator.service.ts
 #: src/engine/workspace-manager/workspace-migration/workspace-migration-builder/validators/services/flat-permission-flag-validator.service.ts
 msgid "Cannot delete standard permission flag definition"
-msgstr ""
+msgstr "No se puede eliminar la definición de indicador de permiso estándar"
 
 #. js-lingui-id: EN2+6i
 #: src/engine/workspace-manager/workspace-migration/workspace-migration-builder/validators/services/flat-skill-validator.service.ts
@@ -1144,23 +1204,41 @@ msgstr "No se puede eliminar la única vista de este objeto"
 
 #. js-lingui-id: aqua7x
 #: src/engine/metadata-modules/role/role.service.ts
-msgid "Cannot delete this role: it is still assigned to one or more agents, and the workspace default role cannot be assigned to agents. Please reassign these agents to another role first."
+msgid ""
+"Cannot delete this role: it is still assigned to one or more agents, and the"
+" workspace default role cannot be assigned to agents. Please reassign these "
+"agents to another role first."
 msgstr ""
+"No se puede eliminar este rol: aún está asignado a uno o más agentes, y el "
+"rol predeterminado del espacio de trabajo no puede asignarse a agentes. "
+"Reasigna estos agentes a otro rol primero."
 
 #. js-lingui-id: mGasIh
 #: src/engine/metadata-modules/role/role.service.ts
-msgid "Cannot delete this role: it is still assigned to one or more API keys, and the workspace default role cannot be assigned to API keys. Please reassign these API keys to another role first."
+msgid ""
+"Cannot delete this role: it is still assigned to one or more API keys, and "
+"the workspace default role cannot be assigned to API keys. Please reassign "
+"these API keys to another role first."
 msgstr ""
+"No se puede eliminar este rol: aún está asignado a una o más claves API, y "
+"el rol predeterminado del espacio de trabajo no puede asignarse a claves "
+"API. Reasigna estas claves API a otro rol primero."
 
 #. js-lingui-id: mWk3X+
 #: src/engine/metadata-modules/flat-field-metadata/utils/handle-index-changes-during-field-update.util.ts
-msgid "Cannot delete unique index that have not been created by the workspace custom application"
-msgstr "No se puede eliminar un índice único que no haya sido creado por la aplicación personalizada del espacio de trabajo"
+msgid ""
+"Cannot delete unique index that have not been created by the workspace "
+"custom application"
+msgstr ""
+"No se puede eliminar un índice único que no haya sido creado por la "
+"aplicación personalizada del espacio de trabajo"
 
 #. js-lingui-id: AQyr9X
 #: src/engine/workspace-manager/workspace-migration/workspace-migration-builder/validators/services/flat-field-metadata-validator.service.ts
 msgid "Cannot delete, please update the label identifier field first"
-msgstr "No se puede eliminar, por favor actualice primero el campo del identificador de la etiqueta"
+msgstr ""
+"No se puede eliminar, por favor actualice primero el campo del identificador"
+" de la etiqueta"
 
 #. js-lingui-id: lDTqT7
 #: src/engine/metadata-modules/permissions/permissions.exception.ts
@@ -1180,7 +1258,8 @@ msgstr "No se puede tener más de una versión activa del flujo de trabajo"
 #. js-lingui-id: DAGexD
 #: src/engine/metadata-modules/row-level-permission-predicate/exceptions/row-level-permission-predicate.exception.ts
 msgid "Cannot modify predicate belonging to a different object."
-msgstr "No se puede modificar el predicado que pertenece a un objeto diferente."
+msgstr ""
+"No se puede modificar el predicado que pertenece a un objeto diferente."
 
 #. js-lingui-id: xO923u
 #: src/engine/metadata-modules/row-level-permission-predicate/exceptions/row-level-permission-predicate.exception.ts
@@ -1190,12 +1269,16 @@ msgstr "No se puede modificar el predicado que pertenece a un rol diferente."
 #. js-lingui-id: eiujBX
 #: src/engine/metadata-modules/row-level-permission-predicate/exceptions/row-level-permission-predicate-group.exception.ts
 msgid "Cannot modify predicate group belonging to a different object."
-msgstr "No se puede modificar el grupo de predicados que pertenece a un objeto diferente."
+msgstr ""
+"No se puede modificar el grupo de predicados que pertenece a un objeto "
+"diferente."
 
 #. js-lingui-id: 3niIR5
 #: src/engine/metadata-modules/row-level-permission-predicate/exceptions/row-level-permission-predicate-group.exception.ts
 msgid "Cannot modify predicate group belonging to a different role."
-msgstr "No se puede modificar el grupo de predicados que pertenece a un rol diferente."
+msgstr ""
+"No se puede modificar el grupo de predicados que pertenece a un rol "
+"diferente."
 
 #. js-lingui-id: Su850d
 #: src/engine/workspace-manager/workspace-migration/workspace-migration-builder/validators/services/flat-row-level-permission-predicate-group-validator.service.ts
@@ -1204,8 +1287,12 @@ msgstr "No se puede modificar el grupo de predicados para cambiar su objeto"
 
 #. js-lingui-id: /lHFxo
 #: src/engine/workspace-manager/workspace-migration/workspace-migration-builder/validators/services/flat-row-level-permission-predicate-group-validator.service.ts
-msgid "Cannot modify predicate group to change its object from {existingObjectMetadataIdentifier} to {updatedObjectMetadataIdentifier}"
-msgstr "No se puede modificar el grupo de predicados para cambiar su objeto de {existingObjectMetadataIdentifier} a {updatedObjectMetadataIdentifier}"
+msgid ""
+"Cannot modify predicate group to change its object from "
+"{existingObjectMetadataIdentifier} to {updatedObjectMetadataIdentifier}"
+msgstr ""
+"No se puede modificar el grupo de predicados para cambiar su objeto de "
+"{existingObjectMetadataIdentifier} a {updatedObjectMetadataIdentifier}"
 
 #. js-lingui-id: jm1hwE
 #: src/engine/workspace-manager/workspace-migration/workspace-migration-builder/validators/services/flat-row-level-permission-predicate-group-validator.service.ts
@@ -1214,8 +1301,12 @@ msgstr "No se puede modificar el grupo de predicados para cambiar su rol"
 
 #. js-lingui-id: yxykz2
 #: src/engine/workspace-manager/workspace-migration/workspace-migration-builder/validators/services/flat-row-level-permission-predicate-group-validator.service.ts
-msgid "Cannot modify predicate group to change its role from {existingRoleIdentifier} to {updatedRoleIdentifier}"
-msgstr "No se puede modificar el grupo de predicados para cambiar su rol de {existingRoleIdentifier} a {updatedRoleIdentifier}"
+msgid ""
+"Cannot modify predicate group to change its role from "
+"{existingRoleIdentifier} to {updatedRoleIdentifier}"
+msgstr ""
+"No se puede modificar el grupo de predicados para cambiar su rol de "
+"{existingRoleIdentifier} a {updatedRoleIdentifier}"
 
 #. js-lingui-id: HDo5ie
 #: src/engine/workspace-manager/workspace-migration/workspace-migration-builder/validators/services/flat-row-level-permission-predicate-validator.service.ts
@@ -1224,8 +1315,12 @@ msgstr "No se puede modificar el predicado para cambiar su objeto"
 
 #. js-lingui-id: ku/9og
 #: src/engine/workspace-manager/workspace-migration/workspace-migration-builder/validators/services/flat-row-level-permission-predicate-validator.service.ts
-msgid "Cannot modify predicate to change its object from {existingObjectMetadataIdentifier} to {updatedObjectMetadataIdentifier}"
-msgstr "No se puede modificar el predicado para cambiar su objeto de {existingObjectMetadataIdentifier} a {updatedObjectMetadataIdentifier}"
+msgid ""
+"Cannot modify predicate to change its object from "
+"{existingObjectMetadataIdentifier} to {updatedObjectMetadataIdentifier}"
+msgstr ""
+"No se puede modificar el predicado para cambiar su objeto de "
+"{existingObjectMetadataIdentifier} a {updatedObjectMetadataIdentifier}"
 
 #. js-lingui-id: 7JaPm8
 #: src/engine/workspace-manager/workspace-migration/workspace-migration-builder/validators/services/flat-row-level-permission-predicate-validator.service.ts
@@ -1234,8 +1329,12 @@ msgstr "No se puede modificar el predicado para cambiar su rol"
 
 #. js-lingui-id: uoi9Wy
 #: src/engine/workspace-manager/workspace-migration/workspace-migration-builder/validators/services/flat-row-level-permission-predicate-validator.service.ts
-msgid "Cannot modify predicate to change its role from {existingRoleIdentifier} to {updatedRoleIdentifier}"
-msgstr "No se puede modificar el predicado para cambiar su rol de {existingRoleIdentifier} a {updatedRoleIdentifier}"
+msgid ""
+"Cannot modify predicate to change its role from {existingRoleIdentifier} to "
+"{updatedRoleIdentifier}"
+msgstr ""
+"No se puede modificar el predicado para cambiar su rol de "
+"{existingRoleIdentifier} a {updatedRoleIdentifier}"
 
 #. js-lingui-id: Q0diyJ
 #: src/engine/metadata-modules/permissions/permissions.exception.ts
@@ -1255,13 +1354,13 @@ msgstr "No se puede cambiar el plan de la suscripción."
 #. js-lingui-id: jNnzPT
 #: src/engine/workspace-manager/workspace-migration/workspace-migration-builder/validators/utils/validate-role-belongs-to-caller-application.util.ts
 msgid "Cannot target a role owned by another application"
-msgstr ""
+msgstr "No se puede dirigir un rol propiedad de otra aplicación"
 
 #. js-lingui-id: 2ET75e
 #: src/engine/workspace-manager/workspace-migration/workspace-migration-builder/validators/utils/validate-role-belongs-to-caller-application.util.ts
 #: src/engine/metadata-modules/permissions/permissions.exception.ts
 msgid "Cannot target a role owned by another application."
-msgstr ""
+msgstr "No se puede dirigir un rol propiedad de otra aplicación."
 
 #. js-lingui-id: fpzw+t
 #: src/engine/workspace-manager/workspace-migration/workspace-migration-builder/validators/services/flat-agent-validator.service.ts
@@ -1273,23 +1372,29 @@ msgstr "No se puede actualizar el agente estándar"
 #: src/engine/workspace-manager/workspace-migration/workspace-migration-builder/validators/services/flat-permission-flag-validator.service.ts
 #: src/engine/workspace-manager/workspace-migration/workspace-migration-builder/validators/services/flat-permission-flag-validator.service.ts
 msgid "Cannot update standard permission flag definition"
-msgstr ""
+msgstr "No se puede actualizar la definición de indicador de permiso estándar"
 
 #. js-lingui-id: I2EmgT
 #: src/engine/workspace-manager/workspace-migration/workspace-migration-builder/validators/services/flat-skill-validator.service.ts
 #: src/engine/workspace-manager/workspace-migration/workspace-migration-builder/validators/services/flat-skill-validator.service.ts
-msgid "Cannot update standard skill properties (only activation/deactivation allowed)"
-msgstr "No se pueden actualizar las propiedades de la habilidad estándar (solo se permite la activación/desactivación)"
+msgid ""
+"Cannot update standard skill properties (only activation/deactivation "
+"allowed)"
+msgstr ""
+"No se pueden actualizar las propiedades de la habilidad estándar (solo se "
+"permite la activación/desactivación)"
 
 #. js-lingui-id: 4DKo3U
 #: src/modules/workflow/common/workspace-services/workflow-version-validation.workspace-service.ts
 msgid "Cannot update workflow version status manually"
-msgstr "No se puede actualizar manualmente el estado de la versión del flujo de trabajo"
+msgstr ""
+"No se puede actualizar manualmente el estado de la versión del flujo de "
+"trabajo"
 
 #. js-lingui-id: RpYfjZ
 #: src/engine/workspace-manager/twenty-standard-application/utils/field-metadata/compute-message-participant-standard-flat-field-metadata.util.ts
 msgid "Cc"
-msgstr ""
+msgstr "Cc"
 
 #. js-lingui-id: 4IVK41
 #: src/engine/workspace-manager/twenty-standard-application/utils/field-metadata/compute-calendar-channel-event-association-standard-flat-field-metadata.util.ts
@@ -1300,34 +1405,40 @@ msgstr "ID del canal"
 #. js-lingui-id: erTWgO
 #: src/engine/metadata-modules/ai/ai.exception.ts
 msgid "Chat message not found."
-msgstr ""
+msgstr "Mensaje del chat no encontrado."
 
 #. js-lingui-id: /VxChJ
 #: src/engine/metadata-modules/ai/ai.exception.ts
 msgid "Chat thread not found."
-msgstr ""
+msgstr "Hilo del chat no encontrado."
 
 #. js-lingui-id: eLQjKW
 #: src/engine/metadata-modules/ai/ai.exception.ts
 msgid "Chat thread title cannot be empty."
-msgstr ""
+msgstr "El título del hilo del chat no puede estar vacío."
 
 #. js-lingui-id: NGL+Sl
 #: src/engine/workspace-manager/workspace-migration/workspace-migration-builder/validators/services/flat-navigation-menu-item-validator.service.ts
 #: src/engine/workspace-manager/workspace-migration/workspace-migration-builder/validators/services/flat-navigation-menu-item-validator.service.ts
 msgid "Circular dependency detected in navigation menu item hierarchy"
-msgstr "Se detectó una dependencia circular en la jerarquía de elementos del menú de navegación"
+msgstr ""
+"Se detectó una dependencia circular en la jerarquía de elementos del menú de"
+" navegación"
 
 #. js-lingui-id: /WTI79
 #: src/engine/metadata-modules/navigation-menu-item/navigation-menu-item.exception.ts
 msgid "Circular dependency detected in navigation menu item hierarchy."
-msgstr "Se detectó una dependencia circular en la jerarquía de elementos del menú de navegación."
+msgstr ""
+"Se detectó una dependencia circular en la jerarquía de elementos del menú de"
+" navegación."
 
 #. js-lingui-id: 9uirl8
 #: src/engine/workspace-manager/workspace-migration/workspace-migration-builder/validators/services/flat-view-filter-group-validator.service.ts
 #: src/engine/workspace-manager/workspace-migration/workspace-migration-builder/validators/services/flat-view-filter-group-validator.service.ts
 msgid "Circular dependency detected in view filter group hierarchy"
-msgstr "Se detectó una dependencia circular en la jerarquía del grupo de filtros de vista"
+msgstr ""
+"Se detectó una dependencia circular en la jerarquía del grupo de filtros de "
+"vista"
 
 #. js-lingui-id: 3wV73y
 #: src/engine/workspace-manager/twenty-standard-application/utils/field-metadata/compute-person-standard-flat-field-metadata.util.ts
@@ -1338,6 +1449,8 @@ msgstr "Ciudad"
 #: src/engine/core-modules/application/connection-provider/connection-provider.exception.ts
 msgid "Client credentials are not configured for this OAuth provider."
 msgstr ""
+"Las credenciales del cliente no están configuradas para este proveedor "
+"OAuth."
 
 #. js-lingui-id: NRF7pg
 #: src/engine/workspace-manager/twenty-standard-application/utils/field-metadata/compute-opportunity-standard-flat-field-metadata.util.ts
@@ -1370,7 +1483,7 @@ msgstr "Elemento del menú de comandos no encontrado."
 #. js-lingui-id: QeCopv
 #: src/engine/workspace-manager/twenty-standard-application/utils/field-metadata/compute-workspace-member-standard-flat-field-metadata.util.ts
 msgid "Commas and dot"
-msgstr ""
+msgstr "Comas y punto"
 
 #. js-lingui-id: s2QZS6
 #: src/engine/workspace-manager/twenty-standard-application/utils/object-metadata/create-standard-flat-object-metadata.util.ts
@@ -1414,17 +1527,21 @@ msgstr "La configuración es obligatoria para el widget de campos"
 #. js-lingui-id: tj1Qu0
 #: src/engine/metadata-modules/flat-page-layout-widget/validators/utils/validate-fields-flat-page-layout-widget-for-creation.util.ts
 msgid "Configuration is required for fields widget \"{widgetTitle}\""
-msgstr "La configuración es obligatoria para el widget de campos \"{widgetTitle}\""
+msgstr ""
+"La configuración es obligatoria para el widget de campos \"{widgetTitle}\""
 
 #. js-lingui-id: 3UUjIe
 #: src/engine/metadata-modules/flat-page-layout-widget/validators/utils/validate-front-component-flat-page-layout-widget-for-creation.util.ts
 msgid "Configuration is required for front component widget"
-msgstr "La configuración es obligatoria para el widget de componente de front-end"
+msgstr ""
+"La configuración es obligatoria para el widget de componente de front-end"
 
 #. js-lingui-id: tBK3H8
 #: src/engine/metadata-modules/flat-page-layout-widget/validators/utils/validate-front-component-flat-page-layout-widget-for-creation.util.ts
 msgid "Configuration is required for front component widget \"{title}\""
-msgstr "La configuración es obligatoria para el widget de componente de front-end \"{title}\""
+msgstr ""
+"La configuración es obligatoria para el widget de componente de front-end "
+"\"{title}\""
 
 #. js-lingui-id: wOVBIH
 #: src/engine/metadata-modules/flat-page-layout-widget/validators/utils/validate-graph-flat-page-layout-widget-for-creation.util.ts
@@ -1434,7 +1551,8 @@ msgstr "La configuración es obligatoria para el widget de gráfico"
 #. js-lingui-id: 9fX6Jd
 #: src/engine/metadata-modules/flat-page-layout-widget/validators/utils/validate-graph-flat-page-layout-widget-for-creation.util.ts
 msgid "Configuration is required for graph widget \"{widgetTitle}\""
-msgstr "La configuración es obligatoria para el widget de gráfico \"{widgetTitle}\""
+msgstr ""
+"La configuración es obligatoria para el widget de gráfico \"{widgetTitle}\""
 
 #. js-lingui-id: heMezC
 #: src/engine/metadata-modules/flat-page-layout-widget/validators/utils/validate-iframe-flat-page-layout-widget-for-creation.util.ts
@@ -1444,17 +1562,23 @@ msgstr "La configuración es obligatoria para el widget de iframe"
 #. js-lingui-id: liZHXq
 #: src/engine/metadata-modules/flat-page-layout-widget/validators/utils/validate-iframe-flat-page-layout-widget-for-creation.util.ts
 msgid "Configuration is required for iframe widget \"{widgetTitle}\""
-msgstr "La configuración es obligatoria para el widget de iframe \"{widgetTitle}\""
+msgstr ""
+"La configuración es obligatoria para el widget de iframe \"{widgetTitle}\""
 
 #. js-lingui-id: viS7/+
 #: src/engine/metadata-modules/flat-page-layout-widget/validators/utils/validate-standalone-rich-text-flat-page-layout-widget-for-creation.util.ts
 msgid "Configuration is required for standalone rich text widget"
-msgstr "La configuración es obligatoria para el widget de texto enriquecido independiente"
+msgstr ""
+"La configuración es obligatoria para el widget de texto enriquecido "
+"independiente"
 
 #. js-lingui-id: rVKk74
 #: src/engine/metadata-modules/flat-page-layout-widget/validators/utils/validate-standalone-rich-text-flat-page-layout-widget-for-creation.util.ts
-msgid "Configuration is required for standalone rich text widget \"{widgetTitle}\""
-msgstr "La configuración es obligatoria para el widget de texto enriquecido independiente \"{widgetTitle}\""
+msgid ""
+"Configuration is required for standalone rich text widget \"{widgetTitle}\""
+msgstr ""
+"La configuración es obligatoria para el widget de texto enriquecido "
+"independiente \"{widgetTitle}\""
 
 #. js-lingui-id: XZ4djQ
 #: src/engine/metadata-modules/flat-page-layout-widget/validators/utils/validate-simple-record-page-widget-for-creation.util.ts
@@ -1513,8 +1637,12 @@ msgstr "Código de país telefónico en conflicto."
 
 #. js-lingui-id: 1fFL4B
 #: src/engine/twenty-orm/utils/compute-relation-connect-query-configs.util.ts
-msgid "Connect is not allowed for {connectFieldName} on {objectMetadataNameSingular}"
-msgstr "La conexión no está permitida para {connectFieldName} en {objectMetadataNameSingular}."
+msgid ""
+"Connect is not allowed for {connectFieldName} on "
+"{objectMetadataNameSingular}"
+msgstr ""
+"La conexión no está permitida para {connectFieldName} en "
+"{objectMetadataNameSingular}."
 
 #. js-lingui-id: /OJTzk
 #: src/engine/metadata-modules/connected-account/connected-account.exception.ts
@@ -1525,18 +1653,18 @@ msgstr "Cuenta conectada no encontrada."
 #. js-lingui-id: xQ2DfP
 #: src/engine/workspace-manager/workspace-migration/workspace-migration-builder/validators/services/flat-connection-provider-validator.service.ts
 msgid "Connection provider display name is required"
-msgstr ""
+msgstr "El nombre para mostrar del proveedor de conexión es obligatorio"
 
 #. js-lingui-id: zYcf9G
 #: src/engine/workspace-manager/workspace-migration/workspace-migration-builder/validators/services/flat-connection-provider-validator.service.ts
 msgid "Connection provider displayName is required"
-msgstr ""
+msgstr "El nombre para mostrar del proveedor de conexión es obligatorio"
 
 #. js-lingui-id: WsuFPo
 #: src/engine/workspace-manager/workspace-migration/workspace-migration-builder/validators/services/flat-connection-provider-validator.service.ts
 #: src/engine/workspace-manager/workspace-migration/workspace-migration-builder/validators/services/flat-connection-provider-validator.service.ts
 msgid "Connection provider name is required"
-msgstr ""
+msgstr "El nombre del proveedor de conexión es obligatorio"
 
 #. js-lingui-id: mTAp1w
 #: src/engine/workspace-manager/workspace-migration/workspace-migration-builder/validators/services/flat-connection-provider-validator.service.ts
@@ -1544,33 +1672,34 @@ msgstr ""
 #: src/engine/workspace-manager/workspace-migration/workspace-migration-builder/validators/services/flat-connection-provider-validator.service.ts
 #: src/engine/workspace-manager/workspace-migration/workspace-migration-builder/validators/services/flat-connection-provider-validator.service.ts
 msgid "Connection provider not found"
-msgstr ""
+msgstr "Proveedor de conexión no encontrado"
 
 #. js-lingui-id: b+xWjq
 #: src/engine/core-modules/application/connection-provider/connection-provider.exception.ts
 msgid "Connection provider not found."
-msgstr ""
+msgstr "Proveedor de conexión no encontrado."
 
 #. js-lingui-id: z2V1Q6
 #: src/engine/workspace-manager/workspace-migration/workspace-migration-builder/validators/services/flat-connection-provider-validator.service.ts
 msgid "Connection provider oauthConfig.{label} is required"
-msgstr ""
+msgstr "Connection provider oauthConfig.{label} es obligatorio"
 
 #. js-lingui-id: vOKvb8
 #. placeholder {0}: flatConnectionProvider.name
 #: src/engine/workspace-manager/workspace-migration/workspace-migration-builder/validators/services/flat-connection-provider-validator.service.ts
 msgid "Connection provider with name {0} already exists for this application"
 msgstr ""
+"Ya existe un proveedor de conexión con nombre {0} para esta aplicación"
 
 #. js-lingui-id: YQTVfF
 #: src/engine/workspace-manager/workspace-migration/workspace-migration-builder/validators/services/flat-connection-provider-validator.service.ts
 msgid "Connection provider with type 'oauth' is missing oauthConfig"
-msgstr ""
+msgstr "El proveedor de conexión de tipo 'oauth' no tiene oauthConfig"
 
 #. js-lingui-id: jfC/xh
 #: src/engine/metadata-modules/view-field-group/constants/standard-view-field-group-names.ts
 msgid "Contact"
-msgstr ""
+msgstr "Contacto"
 
 #. js-lingui-id: rx63gq
 #: src/engine/workspace-manager/workspace-migration/workspace-migration-builder/validators/utils/validate-skill-required-properties.util.ts
@@ -1581,12 +1710,14 @@ msgstr "El contenido no puede estar vacío"
 #. js-lingui-id: 869Uds
 #: src/engine/api/common/common-args-processors/data-arg-processor/validator-utils/validate-rich-text-field-or-throw.util.ts
 msgid "Content contains a URL with a dangerous protocol."
-msgstr ""
+msgstr "El contenido contiene una URL con un protocolo peligroso."
 
 #. js-lingui-id: cmBz2p
 #: src/engine/metadata-modules/object-permission/field-permission/field-permission.service.ts
-msgid "Contradicting field permissions have been detected on a relation field."
+msgid ""
+"Contradicting field permissions have been detected on a relation field."
 msgstr ""
+"Se han detectado permisos de campo contradictorios en un campo de relación."
 
 #. js-lingui-id: xuYXJX
 #: src/engine/workspace-manager/workspace-migration/workspace-migration-builder/validators/services/flat-view-sort-validator.service.ts
@@ -1596,18 +1727,25 @@ msgstr "Se requiere una dirección válida"
 
 #. js-lingui-id: s+lEnL
 #: src/engine/twenty-orm/workspace-schema-manager/exceptions/workspace-schema-manager.exception.ts
-msgid "Could not create the index because it must run outside a database transaction."
+msgid ""
+"Could not create the index because it must run outside a database "
+"transaction."
 msgstr ""
+"No se pudo crear el índice porque debe ejecutarse fuera de una transacción "
+"de base de datos."
 
 #. js-lingui-id: Fep47m
 #: src/engine/metadata-modules/flat-entity/utils/resolve-entity-relation-universal-identifiers.util.ts
 msgid "Could not find {targetMetadataName} for given {foreignKey}"
-msgstr "No se pudo encontrar {targetMetadataName} para el {foreignKey} proporcionado"
+msgstr ""
+"No se pudo encontrar {targetMetadataName} para el {foreignKey} proporcionado"
 
 #. js-lingui-id: qs7GyL
 #: src/engine/workspace-manager/workspace-migration/universal-flat-entity/utils/resolve-universal-relation-identifiers-to-ids.util.ts
 msgid "Could not find {targetMetadataName} for given {universalForeignKey}"
-msgstr "No se pudo encontrar {targetMetadataName} para el {universalForeignKey} proporcionado"
+msgstr ""
+"No se pudo encontrar {targetMetadataName} para el {universalForeignKey} "
+"proporcionado"
 
 #. js-lingui-id: LZf/L8
 #: src/engine/metadata-modules/flat-entity/utils/find-flat-entity-by-id-in-flat-entity-maps-or-throw.util.ts
@@ -1628,7 +1766,7 @@ msgstr "No se pudo encontrar el metadato del objeto relacionado con el índice"
 #. js-lingui-id: P23sJE
 #: src/engine/metadata-modules/index-metadata/services/index-metadata.service.ts
 msgid "Could not find the object for this index."
-msgstr ""
+msgstr "No se pudo encontrar el objeto para este índice."
 
 #. js-lingui-id: KwGZ0m
 #: src/engine/metadata-modules/flat-field-metadata/validators/utils/validate-morph-or-relation-flat-field-metadata.util.ts
@@ -1665,7 +1803,8 @@ msgstr "Creado por"
 #. js-lingui-id: 2ZhYYy
 #: src/engine/metadata-modules/flat-field-metadata/utils/from-create-field-input-to-flat-field-metadatas-to-create.util.ts
 msgid "Created field metadata, parent object metadata not found"
-msgstr "Metadatos del campo creados, metadatos del objeto padre no encontrados"
+msgstr ""
+"Metadatos del campo creados, metadatos del objeto padre no encontrados"
 
 #. js-lingui-id: wPvFAD
 #: src/engine/workspace-manager/twenty-standard-application/utils/field-metadata/compute-workspace-member-standard-flat-field-metadata.util.ts
@@ -1745,7 +1884,9 @@ msgstr "Dominio personalizado no encontrado."
 #. js-lingui-id: zsYQk/
 #: src/engine/core-modules/workspace/workspace.exception.ts
 msgid "Custom domains are disabled for this workspace."
-msgstr "Los dominios personalizados están deshabilitados para este espacio de trabajo."
+msgstr ""
+"Los dominios personalizados están deshabilitados para este espacio de "
+"trabajo."
 
 #. js-lingui-id: qHZppf
 #: src/engine/metadata-modules/object-metadata/object-metadata.exception.ts
@@ -1780,7 +1921,7 @@ msgstr "Posición del registro del tablero"
 #. js-lingui-id: xGgnPh
 #: src/engine/workspace-manager/twenty-standard-application/utils/field-metadata/compute-dashboard-standard-flat-field-metadata.util.ts
 msgid "Dashboard title"
-msgstr ""
+msgstr "Título del panel"
 
 #. js-lingui-id: w6iIMm
 #: src/engine/workspace-manager/twenty-standard-application/utils/object-metadata/create-standard-flat-object-metadata.util.ts
@@ -1805,7 +1946,7 @@ msgstr "La configuración de la base de datos está deshabilitada."
 #. js-lingui-id: +i2Hzi
 #: src/engine/workspace-manager/twenty-standard-application/utils/field-metadata/compute-workflow-automated-trigger-standard-flat-field-metadata.util.ts
 msgid "Database Event"
-msgstr ""
+msgstr "Evento de base de datos"
 
 #. js-lingui-id: Lhd0oQ
 #: src/engine/workspace-manager/twenty-standard-application/utils/field-metadata/compute-workspace-member-standard-flat-field-metadata.util.ts
@@ -1843,7 +1984,7 @@ msgstr "Fecha de eliminación del registro"
 #. js-lingui-id: yiROdD
 #: src/engine/workspace-manager/twenty-standard-application/utils/field-metadata/compute-workspace-member-standard-flat-field-metadata.util.ts
 msgid "Day First"
-msgstr ""
+msgstr "Día primero"
 
 #. js-lingui-id: yAT3be
 #: src/engine/workspace-manager/twenty-standard-application/utils/field-metadata/compute-workflow-version-standard-flat-field-metadata.util.ts
@@ -1854,22 +1995,22 @@ msgstr "Desactivado"
 #. js-lingui-id: 3jX0AP
 #: src/engine/metadata-modules/view-field-group/constants/standard-view-field-group-names.ts
 msgid "Deal"
-msgstr ""
+msgstr "Negocio"
 
 #. js-lingui-id: pqRl9s
 #: src/engine/metadata-modules/page-layout-widget/constants/standard-page-layout-widget-titles.ts
 msgid "Deal value created this month"
-msgstr ""
+msgstr "Valor de negocios creado este mes"
 
 #. js-lingui-id: gb/ZlH
 #: src/engine/metadata-modules/page-layout-widget/constants/standard-page-layout-widget-titles.ts
 msgid "Deals by Company"
-msgstr ""
+msgstr "Negocios por empresa"
 
 #. js-lingui-id: 8veD+Q
 #: src/engine/metadata-modules/page-layout-widget/constants/standard-page-layout-widget-titles.ts
 msgid "Deals created this month"
-msgstr ""
+msgstr "Negocios creados este mes"
 
 #. js-lingui-id: r6zgGo
 #: src/engine/api/graphql/graphql-query-runner/group-by/resolvers/utils/format-result-with-group-by-dimension-values.util.ts
@@ -1879,7 +2020,7 @@ msgstr "Diciembre"
 #. js-lingui-id: ztGxi6
 #: src/engine/workspace-manager/twenty-standard-application/utils/field-metadata/compute-calendar-event-participant-standard-flat-field-metadata.util.ts
 msgid "Declined"
-msgstr ""
+msgstr "Rechazado"
 
 #. js-lingui-id: cgV4xo
 #: src/engine/metadata-modules/permissions/permissions.exception.ts
@@ -1890,7 +2031,9 @@ msgstr "Rol predeterminado no encontrado."
 #: src/engine/metadata-modules/flat-field-metadata/validators/utils/validate-enum-flat-field-metadata.util.ts
 #: src/engine/metadata-modules/flat-field-metadata/validators/utils/validate-enum-flat-field-metadata.util.ts
 msgid "Default value \"{defaultValue}\" must be one of the option values"
-msgstr "El valor por defecto \"{defaultValue}\" debe ser uno de los valores de opción"
+msgstr ""
+"El valor por defecto \"{defaultValue}\" debe ser uno de los valores de "
+"opción"
 
 #. js-lingui-id: XeWfi3
 #: src/engine/workspace-manager/workspace-migration/workspace-migration-builder/validators/services/flat-field-metadata-validator.service.ts
@@ -1964,7 +2107,9 @@ msgstr "Nombre para mostrar"
 #. js-lingui-id: IymH4t
 #: src/engine/core-modules/public-domain/public-domain.service.ts
 msgid "Domain already used for workspace custom domain"
-msgstr "El dominio ya se utiliza para el dominio personalizado del espacio de trabajo."
+msgstr ""
+"El dominio ya se utiliza para el dominio personalizado del espacio de "
+"trabajo."
 
 #. js-lingui-id: 2sIVDj
 #: src/engine/core-modules/dns-manager/services/dns-manager.service.ts
@@ -1984,18 +2129,18 @@ msgstr "Nombre de dominio"
 #. js-lingui-id: DPfwMq
 #: src/engine/workspace-manager/twenty-standard-application/utils/field-metadata/compute-task-standard-flat-field-metadata.util.ts
 msgid "Done"
-msgstr ""
+msgstr "Listo"
 
 #. js-lingui-id: Wm78zZ
 #: src/engine/workspace-manager/twenty-standard-application/utils/field-metadata/compute-workspace-member-standard-flat-field-metadata.util.ts
 msgid "Dots and comma"
-msgstr ""
+msgstr "Puntos y coma"
 
 #. js-lingui-id: eneWvv
 #: src/engine/workspace-manager/twenty-standard-application/utils/field-metadata/compute-workflow-version-standard-flat-field-metadata.util.ts
 #: src/engine/workspace-manager/twenty-standard-application/utils/field-metadata/compute-workflow-standard-flat-field-metadata.util.ts
 msgid "Draft"
-msgstr ""
+msgstr "Borrador"
 
 #. js-lingui-id: YOowcq
 #: src/engine/workspace-manager/twenty-standard-application/utils/field-metadata/compute-task-standard-flat-field-metadata.util.ts
@@ -2004,8 +2149,12 @@ msgstr "Fecha de vencimiento"
 
 #. js-lingui-id: UrzTjS
 #: src/engine/core-modules/graphql/hooks/use-validate-graphql-query-complexity.hook.ts
-msgid "Duplicate root resolver found. Each root resolver can only be called once per document."
-msgstr "Se encontró un resolver raíz duplicado. Cada resolver raíz solo puede llamarse una vez por documento."
+msgid ""
+"Duplicate root resolver found. Each root resolver can only be called once "
+"per document."
+msgstr ""
+"Se encontró un resolver raíz duplicado. Cada resolver raíz solo puede "
+"llamarse una vez por documento."
 
 #. js-lingui-id: BXtAxc
 #: src/engine/metadata-modules/flat-field-metadata/validators/utils/validate-enum-flat-field-metadata.util.ts
@@ -2016,7 +2165,8 @@ msgstr "Opción duplicada {field}"
 #. js-lingui-id: n6jNyT
 #: src/engine/metadata-modules/command-menu-item/command-menu-item.exception.ts
 msgid "Either workflow version or front component is required."
-msgstr "Se requiere la versión del flujo de trabajo o el componente de frontend."
+msgstr ""
+"Se requiere la versión del flujo de trabajo o el componente de frontend."
 
 #. js-lingui-id: AcnTuz
 #: src/engine/core-modules/user/services/user.service.ts
@@ -2031,7 +2181,9 @@ msgstr "El correo electrónico ya está verificado."
 #. js-lingui-id: LT5dFi
 #: src/engine/core-modules/user/services/user.service.ts
 msgid "Email can only be updated when you belong to a single workspace."
-msgstr "El correo electrónico solo se puede actualizar cuando usted pertenece a un solo espacio de trabajo."
+msgstr ""
+"El correo electrónico solo se puede actualizar cuando usted pertenece a un "
+"solo espacio de trabajo."
 
 #. js-lingui-id: MYgdAv
 #: src/engine/core-modules/emailing-domain/drivers/exceptions/emailing-domain-driver.exception.ts
@@ -2046,7 +2198,7 @@ msgstr "Dominio de correo electrónico no encontrado."
 #. js-lingui-id: MhPwKU
 #: src/engine/metadata-modules/message-channel/message-channel.exception.ts
 msgid "Email group is not configured on this server."
-msgstr ""
+msgstr "El grupo de correo no está configurado en este servidor."
 
 #. js-lingui-id: m9fD11
 #: src/engine/core-modules/email-verification/email-verification.exception.ts
@@ -2076,7 +2228,9 @@ msgstr "El correo electrónico es obligatorio."
 #. js-lingui-id: 3wAyvl
 #: src/utils/get-domain-name-by-email.ts
 msgid "Email is required. Please provide a valid email address."
-msgstr "El correo electrónico es obligatorio. Por favor, proporciona una dirección de correo electrónico válida."
+msgstr ""
+"El correo electrónico es obligatorio. Por favor, proporciona una dirección "
+"de correo electrónico válida."
 
 #. js-lingui-id: y+BSWq
 #: src/engine/core-modules/user/user.exception.ts
@@ -2086,7 +2240,9 @@ msgstr "El correo electrónico no ha cambiado."
 #. js-lingui-id: q87JH5
 #: src/engine/core-modules/user/user.exception.ts
 msgid "Email update is restricted to single workspace users."
-msgstr "La actualización del correo electrónico está restringida a usuarios de un solo espacio de trabajo."
+msgstr ""
+"La actualización del correo electrónico está restringida a usuarios de un "
+"solo espacio de trabajo."
 
 #. js-lingui-id: PeMFTI
 #: src/engine/core-modules/email-verification/email-verification.exception.ts
@@ -2134,7 +2290,7 @@ msgstr "Se requiere engineComponentKey"
 #. js-lingui-id: ZzZwe/
 #: src/engine/workspace-manager/twenty-standard-application/utils/field-metadata/compute-workflow-run-standard-flat-field-metadata.util.ts
 msgid "Enqueued"
-msgstr ""
+msgstr "En cola"
 
 #. js-lingui-id: ArAFBo
 #: src/engine/core-modules/auth/auth.exception.ts
@@ -2154,8 +2310,11 @@ msgstr "La operación de enumeración falló."
 
 #. js-lingui-id: EzGlkq
 #: src/engine/core-modules/dns-manager/validator/dns-manager.validate.ts
-msgid "Environment variable CLOUDFLARE_API_KEY must be defined to use this feature."
-msgstr "La variable de entorno CLOUDFLARE_API_KEY debe estar definida para usar esta función."
+msgid ""
+"Environment variable CLOUDFLARE_API_KEY must be defined to use this feature."
+msgstr ""
+"La variable de entorno CLOUDFLARE_API_KEY debe estar definida para usar esta"
+" función."
 
 #. js-lingui-id: SlfejT
 #: src/engine/core-modules/feature-flag/validates/feature-flag.validate.spec.ts
@@ -2205,7 +2364,7 @@ msgstr "Participantes del evento"
 #: src/engine/workspace-manager/twenty-standard-application/utils/field-metadata/compute-timeline-activity-standard-flat-field-metadata.util.ts
 #: src/engine/workspace-manager/twenty-standard-application/utils/field-metadata/compute-timeline-activity-standard-flat-field-metadata.util.ts
 msgid "Event target"
-msgstr ""
+msgstr "Destino del evento"
 
 #. js-lingui-id: LxOGsB
 #: src/engine/workspace-manager/twenty-standard-application/utils/field-metadata/compute-timeline-activity-standard-flat-field-metadata.util.ts
@@ -2240,8 +2399,12 @@ msgstr "Ejecutado por"
 
 #. js-lingui-id: AiFXmG
 #: src/engine/twenty-orm/utils/compute-relation-connect-query-configs.util.ts
-msgid "Expected the same constraint fields to be used consistently across all operations for {connectFieldName}."
-msgstr "Se esperaba que los mismos campos de restricción se usaran de manera consistente en todas las operaciones para {connectFieldName}."
+msgid ""
+"Expected the same constraint fields to be used consistently across all "
+"operations for {connectFieldName}."
+msgstr ""
+"Se esperaba que los mismos campos de restricción se usaran de manera "
+"consistente en todas las operaciones para {connectFieldName}."
 
 #. js-lingui-id: 7Bj3x9
 #: src/engine/workspace-manager/twenty-standard-application/utils/field-metadata/compute-workflow-run-standard-flat-field-metadata.util.ts
@@ -2251,7 +2414,7 @@ msgstr "Fallido"
 #. js-lingui-id: rl11Jd
 #: src/engine/metadata-modules/logic-function/logic-function.exception.ts
 msgid "Failed to build function dependencies."
-msgstr ""
+msgstr "Error al compilar las dependencias de la función."
 
 #. js-lingui-id: E7Dsiq
 #: src/engine/metadata-modules/ai/ai-agent-monitor/resolvers/agent-turn.resolver.ts
@@ -2297,6 +2460,7 @@ msgstr "Error al duplicar el tablero."
 #: src/engine/core-modules/application/connection-provider/connection-provider.exception.ts
 msgid "Failed to exchange the authorization code for an access token."
 msgstr ""
+"Error al intercambiar el código de autorización por un token de acceso."
 
 #. js-lingui-id: MIto3A
 #: src/engine/core-modules/sdk-client/exceptions/sdk-client.exception.ts
@@ -2331,7 +2495,7 @@ msgstr "No se pudo registrar el evento de facturación."
 #. js-lingui-id: eQmx6a
 #: src/engine/core-modules/application/connection-provider/connection-provider.exception.ts
 msgid "Failed to refresh the access token."
-msgstr ""
+msgstr "Error al actualizar el token de acceso."
 
 #. js-lingui-id: SJEIIJ
 #: src/engine/core-modules/admin-panel/admin-panel-queue.service.ts
@@ -2377,11 +2541,16 @@ msgstr "El campo no se puede indexar ya que pertenece a un objeto diferente"
 #: src/engine/metadata-modules/flat-object-metadata/validators/utils/validate-flat-object-metadata-identifiers.util.ts
 msgid "Field cannot be used as label identifier due to its type"
 msgstr ""
+"El campo no puede usarse como identificador de etiqueta debido a su tipo"
 
 #. js-lingui-id: QMSXe6
 #: src/engine/metadata-modules/flat-object-metadata/validators/utils/validate-flat-object-metadata-identifiers.util.ts
-msgid "Field cannot be used as label identifier due to its type: should be of type UUID, text or full name"
+msgid ""
+"Field cannot be used as label identifier due to its type: should be of type "
+"UUID, text or full name"
 msgstr ""
+"El campo no puede usarse como identificador de etiqueta debido a su tipo: "
+"debe ser de tipo UUID, texto o nombre completo"
 
 #. js-lingui-id: F6OLoA
 #: src/engine/metadata-modules/flat-object-metadata/validators/utils/validate-flat-object-metadata-identifiers.util.ts
@@ -2460,45 +2629,49 @@ msgstr "Campo no encontrado."
 #. js-lingui-id: krbBsy
 #: src/engine/workspace-manager/workspace-migration/workspace-migration-builder/validators/services/flat-field-permission-validator.service.ts
 msgid "Field permission already exists"
-msgstr ""
+msgstr "El permiso de campo ya existe"
 
 #. js-lingui-id: J4IqxN
 #: src/engine/workspace-manager/workspace-migration/workspace-migration-builder/validators/services/flat-field-permission-validator.service.ts
 #: src/engine/workspace-manager/workspace-migration/workspace-migration-builder/validators/services/flat-field-permission-validator.service.ts
 msgid "Field permission for this role, object and field already exists"
-msgstr ""
+msgstr "El permiso de campo para este rol, objeto y campo ya existe"
 
 #. js-lingui-id: 8mkDdX
 #: src/engine/workspace-manager/workspace-migration/workspace-migration-builder/validators/services/flat-field-permission-validator.service.ts
 #: src/engine/workspace-manager/workspace-migration/workspace-migration-builder/validators/services/flat-field-permission-validator.service.ts
 msgid "Field permission not found"
-msgstr ""
+msgstr "Permiso de campo no encontrado"
 
 #. js-lingui-id: yqmAnC
 #: src/engine/metadata-modules/permissions/permissions.exception.ts
 msgid "Field permission not found."
-msgstr ""
+msgstr "Permiso de campo no encontrado."
 
 #. js-lingui-id: 7OZNMg
 #: src/engine/workspace-manager/workspace-migration/workspace-migration-builder/validators/services/flat-field-permission-validator.service.ts
 msgid "Field permission to delete not found"
-msgstr ""
+msgstr "Permiso de campo a eliminar no encontrado"
 
 #. js-lingui-id: rR7vkH
 #: src/engine/workspace-manager/workspace-migration/workspace-migration-builder/validators/services/flat-field-permission-validator.service.ts
 msgid "Field permission to update not found"
-msgstr ""
+msgstr "Permiso de campo a actualizar no encontrado"
 
 #. js-lingui-id: A2VI9D
 #. placeholder {0}: flatFieldPermissionToValidate.universalIdentifier
 #: src/engine/workspace-manager/workspace-migration/workspace-migration-builder/validators/services/flat-field-permission-validator.service.ts
 msgid "Field permission with universal identifier {0} already exists"
-msgstr ""
+msgstr "El permiso de campo con identificador universal {0} ya existe"
 
 #. js-lingui-id: QXuG8C
 #: src/engine/metadata-modules/object-permission/field-permission/field-permission.service.ts
-msgid "Field permissions can only be used to restrict access, not to grant additional permissions."
-msgstr "Los permisos de campo solo se pueden usar para restringir el acceso, no para otorgar permisos adicionales."
+msgid ""
+"Field permissions can only be used to restrict access, not to grant "
+"additional permissions."
+msgstr ""
+"Los permisos de campo solo se pueden usar para restringir el acceso, no para"
+" otorgar permisos adicionales."
 
 #. js-lingui-id: S+y2Wg
 #: src/engine/workspace-manager/workspace-migration/workspace-migration-builder/validators/services/flat-index-metadata-validator.service.ts
@@ -2528,7 +2701,7 @@ msgstr "Campo para actualizar los metadatos del objeto no encontrado"
 #. js-lingui-id: stY5BO
 #: src/engine/metadata-modules/flat-field-metadata/services/flat-field-metadata-type-validator.service.ts
 msgid "Field type NUMERIC is not supported. Use Number instead."
-msgstr ""
+msgstr "El tipo de campo NUMERIC no es compatible. Usa Number en su lugar."
 
 #. js-lingui-id: p6JTHU
 #: src/engine/metadata-modules/flat-field-metadata/validators/utils/validate-position-flat-field-metadata.util.ts
@@ -2552,8 +2725,14 @@ msgstr "El tipo de campo TS_VECTOR debe llamarse \"searchVector\""
 
 #. js-lingui-id: NuL8km
 #: src/engine/metadata-modules/flat-field-metadata/validators/utils/validate-ts-vector-flat-field-metadata.util.ts
-msgid "Field type TS_VECTOR must have an expression. This may have failed to be built because record identifier field does not exist or is not of a searchable type."
+msgid ""
+"Field type TS_VECTOR must have an expression. This may have failed to be "
+"built because record identifier field does not exist or is not of a "
+"searchable type."
 msgstr ""
+"El tipo de campo TS_VECTOR debe tener una expresión. Esto puede haber "
+"fallado porque el campo identificador de registro no existe o no es de un "
+"tipo que permita búsqueda."
 
 #. js-lingui-id: 5Buorv
 #: src/engine/metadata-modules/field-metadata/field-metadata.exception.ts
@@ -2625,12 +2804,13 @@ msgstr "FieldMetadataId es necesario para crear un orden de vista."
 #. js-lingui-id: VgGXR3
 #: src/engine/core-modules/file/files-field/services/files-field.service.ts
 msgid "fieldMetadataId or fieldMetadataUniversalIdentifier must be provided"
-msgstr "Se debe proporcionar fieldMetadataId o fieldMetadataUniversalIdentifier"
+msgstr ""
+"Se debe proporcionar fieldMetadataId o fieldMetadataUniversalIdentifier"
 
 #. js-lingui-id: vF68cg
 #: src/engine/metadata-modules/page-layout-widget/constants/standard-page-layout-widget-titles.ts
 msgid "Fields"
-msgstr ""
+msgstr "Campos"
 
 #. js-lingui-id: 9HjeLQ
 #: src/engine/metadata-modules/view-field-group/services/fields-widget-upsert.service.ts
@@ -2649,13 +2829,19 @@ msgstr "Archivo"
 
 #. js-lingui-id: ycn/wp
 #: src/engine/twenty-orm/field-operations/files-field-sync/files-field-sync.ts
-msgid "File {fileId} is already associated with a permanent files field. Please re-upload the file."
-msgstr "El archivo {fileId} ya está asociado a un campo de archivos permanente. Vuelve a subir el archivo."
+msgid ""
+"File {fileId} is already associated with a permanent files field. Please re-"
+"upload the file."
+msgstr ""
+"El archivo {fileId} ya está asociado a un campo de archivos permanente. "
+"Vuelve a subir el archivo."
 
 #. js-lingui-id: v+527c
 #: src/engine/twenty-orm/field-operations/files-field-sync/files-field-sync.ts
-msgid "File {fileId} was not uploaded for this field. Please re-upload the file."
-msgstr "El archivo {fileId} no se subió para este campo. Vuelve a subir el archivo."
+msgid ""
+"File {fileId} was not uploaded for this field. Please re-upload the file."
+msgstr ""
+"El archivo {fileId} no se subió para este campo. Vuelve a subir el archivo."
 
 #. js-lingui-id: i+AQUz
 #: src/engine/workspace-manager/twenty-standard-application/utils/field-metadata/compute-attachment-standard-flat-field-metadata.util.ts
@@ -2665,7 +2851,8 @@ msgstr "Categoría de archivos"
 #. js-lingui-id: OR7oBd
 #: src/engine/core-modules/sdk-client/exceptions/sdk-client.exception.ts
 msgid "File not found in SDK client archive."
-msgstr "No se encontró el archivo dentro del archivo comprimido del cliente del SDK."
+msgstr ""
+"No se encontró el archivo dentro del archivo comprimido del cliente del SDK."
 
 #. js-lingui-id: weWV3g
 #: src/engine/core-modules/tool/tools/email-tool/exceptions/email-tool.exception.ts
@@ -2677,7 +2864,7 @@ msgstr "Archivo no encontrado."
 #. js-lingui-id: I7Jff2
 #: src/engine/core-modules/file-storage/utils/validate-file-path.util.ts
 msgid "Filename must have an extension"
-msgstr ""
+msgstr "El nombre del archivo debe tener una extensión"
 
 #. js-lingui-id: sER+bs
 #: src/engine/metadata-modules/page-layout-widget/constants/standard-page-layout-widget-titles.ts
@@ -2693,12 +2880,12 @@ msgstr "El campo Files no es compatible con campos únicos"
 #. js-lingui-id: MkIaen
 #: src/engine/workspace-manager/workspace-migration/workspace-migration-builder/validators/services/flat-view-filter-validator.service.ts
 msgid "Filter operand is not supported for this field type"
-msgstr ""
+msgstr "El operando de filtro no es compatible con este tipo de campo"
 
 #. js-lingui-id: 4GaFCQ
 #: src/engine/workspace-manager/workspace-migration/interceptors/utils/__tests__/build-metadata-validation-error-payload.util.spec.ts
 msgid "First friendly message"
-msgstr ""
+msgstr "Primer mensaje amigable"
 
 #. js-lingui-id: ylQd2j
 #: src/engine/metadata-modules/page-layout-widget/constants/standard-page-layout-widget-titles.ts
@@ -2714,18 +2901,24 @@ msgstr "El nombre de la carpeta es obligatorio"
 
 #. js-lingui-id: Hxo3YN
 #: src/engine/core-modules/file-storage/utils/validate-folder-path.util.ts
-msgid "Folder path must not contain a file extension — use deleteFile for file paths"
+msgid ""
+"Folder path must not contain a file extension — use deleteFile for file "
+"paths"
 msgstr ""
+"La ruta de carpeta no debe contener una extensión de archivo — usa "
+"deleteFile para rutas de archivos"
 
 #. js-lingui-id: eWmJYU
 #: src/engine/workspace-manager/workspace-migration/workspace-migration-builder/validators/services/flat-field-metadata-validator.service.ts
 msgid "Forbidden updated properties for relation field metadata"
-msgstr "Propiedades actualizadas prohibidas para los metadatos del campo de relación"
+msgstr ""
+"Propiedades actualizadas prohibidas para los metadatos del campo de relación"
 
 #. js-lingui-id: kuN9I4
 #: src/modules/workflow/workflow-trigger/utils/assert-form-step-is-valid.util.ts
 msgid "Form action fields must have a defined label and type"
-msgstr "Los campos de acción de formulario deben tener una etiqueta y tipo definidos"
+msgstr ""
+"Los campos de acción de formulario deben tener una etiqueta y tipo definidos"
 
 #. js-lingui-id: QK3OvQ
 #: src/modules/workflow/workflow-trigger/utils/assert-form-step-is-valid.util.ts
@@ -2745,7 +2938,7 @@ msgstr "viernes"
 #. js-lingui-id: ejVYRQ
 #: src/engine/workspace-manager/twenty-standard-application/utils/field-metadata/compute-message-participant-standard-flat-field-metadata.util.ts
 msgid "From"
-msgstr ""
+msgstr "Desde"
 
 #. js-lingui-id: Wed+Kp
 #: src/engine/metadata-modules/front-component/front-component.exception.ts
@@ -2755,18 +2948,23 @@ msgstr "El componente del front-end no está listo."
 #. js-lingui-id: A7aUMa
 #: src/engine/workspace-manager/workspace-migration/workspace-migration-builder/validators/services/flat-command-menu-item-validator.service.ts
 msgid "Front component is required for front component renderer items"
-msgstr "Se requiere el componente de interfaz para los elementos del renderizador de componentes de interfaz"
+msgstr ""
+"Se requiere el componente de interfaz para los elementos del renderizador de"
+" componentes de interfaz"
 
 #. js-lingui-id: 0aXgXb
 #: src/engine/workspace-manager/workspace-migration/workspace-migration-builder/validators/services/flat-command-menu-item-validator.service.ts
 #: src/engine/workspace-manager/workspace-migration/workspace-migration-builder/validators/services/flat-command-menu-item-validator.service.ts
 msgid "Front component must not be set for this item type"
-msgstr "El componente de interfaz no debe establecerse para este tipo de elemento"
+msgstr ""
+"El componente de interfaz no debe establecerse para este tipo de elemento"
 
 #. js-lingui-id: AfxLzg
 #: src/engine/workspace-manager/workspace-migration/workspace-migration-builder/validators/services/flat-command-menu-item-validator.service.ts
 msgid "Front component must not be set for workflow trigger items"
-msgstr "El componente de interfaz no debe establecerse para los elementos de activación de flujos de trabajo"
+msgstr ""
+"El componente de interfaz no debe establecerse para los elementos de "
+"activación de flujos de trabajo"
 
 #. js-lingui-id: BzEbyv
 #: src/engine/workspace-manager/workspace-migration/workspace-migration-builder/validators/services/flat-front-component-validator.service.ts
@@ -2790,19 +2988,31 @@ msgstr "Componente de interfaz no encontrado."
 
 #. js-lingui-id: 4wM9Cs
 #: src/engine/workspace-manager/workspace-migration/workspace-migration-builder/validators/services/flat-command-menu-item-validator.service.ts
-msgid "frontComponentId is required when engineComponentKey is FRONT_COMPONENT_RENDERER"
-msgstr "frontComponentId es obligatorio cuando engineComponentKey es FRONT_COMPONENT_RENDERER"
+msgid ""
+"frontComponentId is required when engineComponentKey is "
+"FRONT_COMPONENT_RENDERER"
+msgstr ""
+"frontComponentId es obligatorio cuando engineComponentKey es "
+"FRONT_COMPONENT_RENDERER"
 
 #. js-lingui-id: N6YN7J
 #: src/engine/workspace-manager/workspace-migration/workspace-migration-builder/validators/services/flat-command-menu-item-validator.service.ts
 #: src/engine/workspace-manager/workspace-migration/workspace-migration-builder/validators/services/flat-command-menu-item-validator.service.ts
-msgid "frontComponentId must not be set for engine component key {engineComponentKey}"
-msgstr "frontComponentId no debe establecerse para la clave del componente del motor {engineComponentKey}"
+msgid ""
+"frontComponentId must not be set for engine component key "
+"{engineComponentKey}"
+msgstr ""
+"frontComponentId no debe establecerse para la clave del componente del motor"
+" {engineComponentKey}"
 
 #. js-lingui-id: z8/E1J
 #: src/engine/workspace-manager/workspace-migration/workspace-migration-builder/validators/services/flat-command-menu-item-validator.service.ts
-msgid "frontComponentId must not be set when engineComponentKey is TRIGGER_WORKFLOW_VERSION"
-msgstr "frontComponentId no debe establecerse cuando engineComponentKey es TRIGGER_WORKFLOW_VERSION"
+msgid ""
+"frontComponentId must not be set when engineComponentKey is "
+"TRIGGER_WORKFLOW_VERSION"
+msgstr ""
+"frontComponentId no debe establecerse cuando engineComponentKey es "
+"TRIGGER_WORKFLOW_VERSION"
 
 #. js-lingui-id: oQA+cA
 #: src/engine/workspace-manager/twenty-standard-application/utils/field-metadata/compute-attachment-standard-flat-field-metadata.util.ts
@@ -2812,7 +3022,7 @@ msgstr "Ruta completa"
 #. js-lingui-id: yQDBsf
 #: src/engine/metadata-modules/logic-function/logic-function.exception.ts
 msgid "Function code failed to compile."
-msgstr ""
+msgstr "El código de la función falló al compilar."
 
 #. js-lingui-id: pouguB
 #: src/engine/metadata-modules/logic-function/logic-function.exception.ts
@@ -2822,7 +3032,7 @@ msgstr "El código de la función no ha cambiado."
 #. js-lingui-id: rqDhd1
 #: src/engine/metadata-modules/logic-function/logic-function.exception.ts
 msgid "Function execution failed."
-msgstr ""
+msgstr "La ejecución de la función falló."
 
 #. js-lingui-id: Ho3UAo
 #: src/engine/metadata-modules/logic-function/logic-function.exception.ts
@@ -2852,19 +3062,27 @@ msgstr "Función no encontrada."
 #. js-lingui-id: Weq9zb
 #: src/engine/metadata-modules/view-field-group/constants/standard-view-field-group-names.ts
 msgid "General"
-msgstr ""
+msgstr "General"
 
 #. js-lingui-id: V8DWC+
 #. placeholder {0}: field.label
 #: src/engine/metadata-modules/index-metadata/utils/validate-index-type-against-fields.util.ts
-msgid "GIN indexes work on multi-select, array, JSON, and search-vector columns. \"{0}\" doesn't qualify."
+msgid ""
+"GIN indexes work on multi-select, array, JSON, and search-vector columns. "
+"\"{0}\" doesn't qualify."
 msgstr ""
+"Los índices GIN funcionan en columnas de selección múltiple, array, JSON y "
+"vector de búsqueda. \"{0}\" no cumple los requisitos."
 
 #. js-lingui-id: xaBJxq
 #. placeholder {0}: field.label
 #: src/engine/metadata-modules/index-metadata/utils/validate-index-type-against-fields.util.ts
-msgid "GIN indexes work on multi-select, array, JSON, and search-vector columns. \"{0}\" sub-properties don't qualify."
+msgid ""
+"GIN indexes work on multi-select, array, JSON, and search-vector columns. "
+"\"{0}\" sub-properties don't qualify."
 msgstr ""
+"Los índices GIN funcionan en columnas de selección múltiple, array, JSON y "
+"vector de búsqueda. Las subpropiedades de \"{0}\" no cumplen los requisitos."
 
 #. js-lingui-id: cvJ2e6
 #: src/engine/core-modules/auth/auth.exception.ts
@@ -2885,7 +3103,9 @@ msgstr "El campo de agrupación es obligatorio para el gráfico circular"
 #. js-lingui-id: G5/lsy
 #: src/engine/metadata-modules/flat-page-layout-widget/validators/utils/validate-pie-chart-configuration.util.ts
 msgid "Group by field is required for pie chart widget \"{widgetTitle}\""
-msgstr "El campo de agrupación es obligatorio para el widget de gráfico circular \"{widgetTitle}\""
+msgstr ""
+"El campo de agrupación es obligatorio para el widget de gráfico circular "
+"\"{widgetTitle}\""
 
 #. js-lingui-id: Nf7oXL
 #: src/engine/workspace-manager/twenty-standard-application/utils/field-metadata/compute-message-participant-standard-flat-field-metadata.util.ts
@@ -2977,8 +3197,12 @@ msgstr "ID"
 
 #. js-lingui-id: yEFb1B
 #: src/engine/workspace-manager/twenty-standard-application/utils/field-metadata/compute-company-standard-flat-field-metadata.util.ts
-msgid "Ideal Customer Profile: Indicates whether the company is the most suitable and valuable customer for you"
+msgid ""
+"Ideal Customer Profile: Indicates whether the company is the most suitable "
+"and valuable customer for you"
 msgstr ""
+"Perfil de cliente ideal: indica si la empresa es el cliente más adecuado y "
+"valioso para ti"
 
 #. js-lingui-id: 6cVc+b
 #: src/engine/core-modules/sso/sso.exception.ts
@@ -3004,7 +3228,7 @@ msgstr "En progreso"
 #. js-lingui-id: RAMaAx
 #: src/engine/workspace-manager/twenty-standard-application/utils/field-metadata/compute-message-channel-message-association-standard-flat-field-metadata.util.ts
 msgid "Incoming"
-msgstr ""
+msgstr "Entrante"
 
 #. js-lingui-id: Kfy/ML
 #: src/engine/workspace-manager/workspace-migration/workspace-migration-builder/validators/services/flat-index-metadata-validator.service.ts
@@ -3092,7 +3316,7 @@ msgstr "Parámetro de campos agregados no válido."
 #. js-lingui-id: 56bSD0
 #: src/engine/core-modules/application/application-variable/application-variable.exception.ts
 msgid "Invalid application variable input."
-msgstr ""
+msgstr "Entrada de variable de aplicación inválida."
 
 #. js-lingui-id: KNrRpL
 #: src/engine/metadata-modules/permissions/permissions.exception.ts
@@ -3112,7 +3336,9 @@ msgstr "Tipo de auditoría no válido."
 #. js-lingui-id: mIrUSZ
 #: src/engine/core-modules/imap-smtp-caldav-connection/services/imap-smtp-caldav-connection.service.ts
 msgid "Invalid CALDAV credentials. Please check your username and password."
-msgstr "Credenciales de CALDAV no válidas. Por favor, verifica tu nombre de usuario y contraseña."
+msgstr ""
+"Credenciales de CALDAV no válidas. Por favor, verifica tu nombre de usuario "
+"y contraseña."
 
 #. js-lingui-id: cizVEW
 #: src/engine/metadata-modules/calendar-channel/calendar-channel.exception.ts
@@ -3146,18 +3372,28 @@ msgstr "Tipo de configuración no válido para el widget de campos"
 
 #. js-lingui-id: luyinP
 #: src/engine/metadata-modules/flat-page-layout-widget/validators/utils/validate-fields-flat-page-layout-widget-for-creation.util.ts
-msgid "Invalid configuration type for fields widget \"{widgetTitle}\". Expected FIELDS, got {actualString}"
-msgstr "Tipo de configuración no válido para el widget de campos \"{widgetTitle}\". Se esperaba FIELDS, se obtuvo {actualString}"
+msgid ""
+"Invalid configuration type for fields widget \"{widgetTitle}\". Expected "
+"FIELDS, got {actualString}"
+msgstr ""
+"Tipo de configuración no válido para el widget de campos \"{widgetTitle}\". "
+"Se esperaba FIELDS, se obtuvo {actualString}"
 
 #. js-lingui-id: /xPxQo
 #: src/engine/metadata-modules/flat-page-layout-widget/validators/utils/validate-front-component-configuration-type.util.ts
 msgid "Invalid configuration type for front component widget"
-msgstr "Tipo de configuración no válido para el widget de componente de front-end"
+msgstr ""
+"Tipo de configuración no válido para el widget de componente de front-end"
 
 #. js-lingui-id: 8G4vdK
 #: src/engine/metadata-modules/flat-page-layout-widget/validators/utils/validate-front-component-configuration-type.util.ts
-msgid "Invalid configuration type for front component widget \"{title}\". Expected FRONT_COMPONENT, got {configurationTypeString}"
-msgstr "Tipo de configuración no válido para el widget de componente de front-end \"{title}\". Se esperaba FRONT_COMPONENT, se obtuvo {configurationTypeString}"
+msgid ""
+"Invalid configuration type for front component widget \"{title}\". Expected "
+"FRONT_COMPONENT, got {configurationTypeString}"
+msgstr ""
+"Tipo de configuración no válido para el widget de componente de front-end "
+"\"{title}\". Se esperaba FRONT_COMPONENT, se obtuvo "
+"{configurationTypeString}"
 
 #. js-lingui-id: PXgd1R
 #: src/engine/metadata-modules/flat-page-layout-widget/validators/utils/validate-graph-configuration-type.util.ts
@@ -3166,8 +3402,13 @@ msgstr "Tipo de configuración no válido para el widget de gráfico"
 
 #. js-lingui-id: g4PB8S
 #: src/engine/metadata-modules/flat-page-layout-widget/validators/utils/validate-graph-configuration-type.util.ts
-msgid "Invalid configuration type for graph widget \"{widgetTitle}\". Expected one of {expectedConfigurationTypes}, got {configurationTypeString}"
-msgstr "Tipo de configuración no válido para el widget de gráfico \"{widgetTitle}\". Se esperaba uno de {expectedConfigurationTypes}, se obtuvo {configurationTypeString}"
+msgid ""
+"Invalid configuration type for graph widget \"{widgetTitle}\". Expected one "
+"of {expectedConfigurationTypes}, got {configurationTypeString}"
+msgstr ""
+"Tipo de configuración no válido para el widget de gráfico \"{widgetTitle}\"."
+" Se esperaba uno de {expectedConfigurationTypes}, se obtuvo "
+"{configurationTypeString}"
 
 #. js-lingui-id: KZhbBk
 #: src/engine/metadata-modules/flat-page-layout-widget/validators/utils/validate-iframe-configuration-type.util.ts
@@ -3176,18 +3417,30 @@ msgstr "Tipo de configuración no válido para el widget de iframe"
 
 #. js-lingui-id: SKoxDC
 #: src/engine/metadata-modules/flat-page-layout-widget/validators/utils/validate-iframe-configuration-type.util.ts
-msgid "Invalid configuration type for iframe widget \"{widgetTitle}\". Expected IFRAME, got {configurationTypeString}"
-msgstr "Tipo de configuración no válido para el widget de iframe \"{widgetTitle}\". Se esperaba IFRAME, se obtuvo {configurationTypeString}"
+msgid ""
+"Invalid configuration type for iframe widget \"{widgetTitle}\". Expected "
+"IFRAME, got {configurationTypeString}"
+msgstr ""
+"Tipo de configuración no válido para el widget de iframe \"{widgetTitle}\". "
+"Se esperaba IFRAME, se obtuvo {configurationTypeString}"
 
 #. js-lingui-id: JmuFK8
 #: src/engine/metadata-modules/flat-page-layout-widget/validators/utils/validate-standalone-rich-text-configuration-type.util.ts
 msgid "Invalid configuration type for standalone rich text widget"
-msgstr "Tipo de configuración no válido para el widget de texto enriquecido independiente"
+msgstr ""
+"Tipo de configuración no válido para el widget de texto enriquecido "
+"independiente"
 
 #. js-lingui-id: 9uz7OL
 #: src/engine/metadata-modules/flat-page-layout-widget/validators/utils/validate-standalone-rich-text-configuration-type.util.ts
-msgid "Invalid configuration type for standalone rich text widget \"{widgetTitle}\". Expected STANDALONE_RICH_TEXT, got {configurationTypeString}"
-msgstr "Tipo de configuración no válido para el widget de texto enriquecido independiente \"{widgetTitle}\". Se esperaba STANDALONE_RICH_TEXT, se obtuvo {configurationTypeString}"
+msgid ""
+"Invalid configuration type for standalone rich text widget "
+"\"{widgetTitle}\". Expected STANDALONE_RICH_TEXT, got "
+"{configurationTypeString}"
+msgstr ""
+"Tipo de configuración no válido para el widget de texto enriquecido "
+"independiente \"{widgetTitle}\". Se esperaba STANDALONE_RICH_TEXT, se obtuvo"
+" {configurationTypeString}"
 
 #. js-lingui-id: IptMRL
 #: src/engine/metadata-modules/flat-page-layout-widget/validators/utils/validate-simple-record-page-widget-for-update.util.ts
@@ -3198,8 +3451,12 @@ msgstr "Tipo de configuración no válido para el widget"
 #. js-lingui-id: nFIvYZ
 #: src/engine/metadata-modules/flat-page-layout-widget/validators/utils/validate-simple-record-page-widget-for-update.util.ts
 #: src/engine/metadata-modules/flat-page-layout-widget/validators/utils/validate-simple-record-page-widget-for-creation.util.ts
-msgid "Invalid configuration type for widget \"{widgetTitle}\". Expected {expectedString}, got {actualString}"
-msgstr "Tipo de configuración no válido para el widget \"{widgetTitle}\". Se esperaba {expectedString}, se obtuvo {actualString}"
+msgid ""
+"Invalid configuration type for widget \"{widgetTitle}\". Expected "
+"{expectedString}, got {actualString}"
+msgstr ""
+"Tipo de configuración no válido para el widget \"{widgetTitle}\". Se "
+"esperaba {expectedString}, se obtuvo {actualString}"
 
 #. js-lingui-id: jUt31O
 #: src/engine/core-modules/tool/tools/email-tool/exceptions/email-tool.exception.ts
@@ -3261,7 +3518,7 @@ msgstr "Entrada de campo no válida."
 #. placeholder {0}: Object.keys(allowedExtensions).join(', ')
 #: src/engine/core-modules/file-storage/utils/validate-file-extension.util.ts
 msgid "Invalid file extension. Allowed extensions: {0}"
-msgstr ""
+msgstr "Extensión de archivo inválida. Extensiones permitidas: {0}"
 
 #. js-lingui-id: dqt3x1
 #: src/engine/core-modules/file/file.exception.ts
@@ -3276,12 +3533,17 @@ msgstr "ID de archivo no válido."
 #. js-lingui-id: +ECOke
 #: src/engine/api/common/common-args-processors/filter-arg-processor/filter-arg-processor.service.ts
 msgid "Invalid filter : {nameSingular} object doesn't have any \"{key}\" field."
-msgstr "Filtro no válido: el objeto {nameSingular} no tiene ningún campo \"{key}\"."
+msgstr ""
+"Filtro no válido: el objeto {nameSingular} no tiene ningún campo \"{key}\"."
 
 #. js-lingui-id: kFbvma
 #: src/engine/api/common/common-args-processors/filter-arg-processor/utils/validate-operator-for-field-type-or-throw.util.ts
-msgid "Invalid filter : Operator \"{operator}\" is not valid for this \"{fieldName}\" {fieldType} field"
-msgstr "Filtro no válido: el operador \"{operator}\" no es válido para el campo \"{fieldName}\" de tipo {fieldType}"
+msgid ""
+"Invalid filter : Operator \"{operator}\" is not valid for this "
+"\"{fieldName}\" {fieldType} field"
+msgstr ""
+"Filtro no válido: el operador \"{operator}\" no es válido para el campo "
+"\"{fieldName}\" de tipo {fieldType}"
 
 #. js-lingui-id: 1yoHmO
 #: src/engine/api/rest/input-request-parsers/rest-input-request-parser.exception.ts
@@ -3299,7 +3561,7 @@ msgstr "Valor de filtro no válido: \"{value}\""
 #. js-lingui-id: NOU3zh
 #: src/engine/api/common/common-args-processors/filter-arg-processor/utils/validate-string-operator-value-or-throw.util.ts
 msgid "Invalid filter: \"{operator}\" operator requires a String"
-msgstr ""
+msgstr "Filtro inválido: el operador \"{operator}\" requiere un texto"
 
 #. js-lingui-id: +GVjEm
 #: src/engine/api/common/common-args-processors/filter-arg-processor/utils/validate-array-operator-value-or-throw.util.ts
@@ -3324,12 +3586,14 @@ msgstr "Filtro no válido: el valor del filtro debe ser un objeto"
 #. js-lingui-id: rpkTUe
 #: src/engine/api/common/common-args-processors/filter-arg-processor/filter-arg-processor.service.ts
 msgid "Invalid filter: filtering by relation field \"{key}\" is not supported"
-msgstr ""
+msgstr "Filtro inválido: filtrar por campo de relación \"{key}\" no es compatible"
 
 #. js-lingui-id: bNNDED
 #: src/engine/api/common/common-args-processors/filter-arg-processor/filter-arg-processor.service.ts
 msgid "Invalid filter: use \"{joinColumnName}\" to filter by this relation field"
 msgstr ""
+"Filtro inválido: usa \"{joinColumnName}\" para filtrar por este campo de "
+"relación"
 
 #. js-lingui-id: rFH0az
 #: src/engine/metadata-modules/front-component/front-component.exception.ts
@@ -3387,7 +3651,7 @@ msgstr "Parámetro de límite no válido."
 #. js-lingui-id: 7SBmhB
 #: src/engine/metadata-modules/logic-function/logic-function.exception.ts
 msgid "Invalid logic function input."
-msgstr ""
+msgstr "Entrada de función lógica inválida."
 
 #. js-lingui-id: fNaXqL
 #: src/engine/metadata-modules/message-channel/message-channel.exception.ts
@@ -3434,7 +3698,8 @@ msgstr "Parámetro de ordenación (ORDER BY) no válido."
 #. js-lingui-id: f7SWSg
 #: src/engine/api/rest/input-request-parsers/rest-input-request-parser.exception.ts
 msgid "Invalid order by with group by parameter."
-msgstr "Parámetro de ordenación (ORDER BY) con agrupación (GROUP BY) no válido."
+msgstr ""
+"Parámetro de ordenación (ORDER BY) con agrupación (GROUP BY) no válido."
 
 #. js-lingui-id: LM08/z
 #: src/engine/metadata-modules/page-layout/exceptions/page-layout.exception.ts
@@ -3460,12 +3725,12 @@ msgstr "Se proporcionaron parámetros no válidos."
 #. js-lingui-id: LI7Gn/
 #: src/engine/metadata-modules/permission-flag/permission-flag.exception.ts
 msgid "Invalid permission flag key."
-msgstr ""
+msgstr "Clave de indicador de permiso inválida."
 
 #. js-lingui-id: OqxwMi
 #: src/engine/metadata-modules/permission-flag/permission-flag.exception.ts
 msgid "Invalid permission flag permission type."
-msgstr ""
+msgstr "Tipo de permiso de indicador de permiso inválido."
 
 #. js-lingui-id: mMHHVP
 #: src/engine/workspace-manager/workspace-migration/workspace-migration-builder/validators/services/flat-role-permission-flag-validator.service.ts
@@ -3482,7 +3747,7 @@ msgstr "Configuración de permiso no válida."
 #: src/engine/workspace-manager/workspace-migration/workspace-migration-builder/validators/services/flat-permission-flag-validator.service.ts
 #: src/engine/workspace-manager/workspace-migration/workspace-migration-builder/validators/services/flat-permission-flag-validator.service.ts
 msgid "Invalid permission type"
-msgstr ""
+msgstr "Tipo de permiso inválido"
 
 #. js-lingui-id: 0D0YwP
 #: src/engine/core-modules/record-transformer/record-transformer.exception.ts
@@ -3523,7 +3788,7 @@ msgstr "Carga útil de creación de relación no válida"
 #: src/engine/metadata-modules/flat-field-metadata/validators/utils/validate-morph-relation-flat-field-metadata.util.ts
 #: src/engine/metadata-modules/flat-field-metadata/validators/utils/validate-morph-or-relation-flat-field-metadata.util.ts
 msgid "Invalid relation field target"
-msgstr ""
+msgstr "Destino de campo de relación inválido"
 
 #. js-lingui-id: lOyHVQ
 #: src/engine/core-modules/record-crud/exceptions/record-crud.exception.ts
@@ -3599,12 +3864,15 @@ msgstr "Se proporcionó una URL de destino no válida"
 #. js-lingui-id: 9mW6V7
 #: src/engine/metadata-modules/webhook/webhook.exception.ts
 msgid "Invalid target URL. Please provide a valid HTTP or HTTPS URL."
-msgstr "URL de destino no válida. Por favor, proporcione una URL HTTP o HTTPS válida."
+msgstr ""
+"URL de destino no válida. Por favor, proporcione una URL HTTP o HTTPS "
+"válida."
 
 #. js-lingui-id: sHcAMD
 #: src/modules/workflow/workflow-trigger/utils/assert-version-can-be-activated.util.ts
 msgid "Invalid trigger type for enabling workflow trigger"
-msgstr "Tipo de disparador inválido para habilitar el disparador de flujo de trabajo"
+msgstr ""
+"Tipo de disparador inválido para habilitar el disparador de flujo de trabajo"
 
 #. js-lingui-id: spfaiG
 #: src/engine/core-modules/two-factor-authentication/two-factor-authentication.exception.ts
@@ -3633,8 +3901,12 @@ msgstr "Token de validación no válido."
 
 #. js-lingui-id: xvTxwi
 #: src/engine/api/common/common-args-processors/data-arg-processor/validator-utils/validate-files-field-or-throw.util.ts
-msgid "Invalid value \"{inspectedValue}\" for FILES field \"{fieldName}\" - It should be an array of objects with \"fileId\" and \"label\" properties."
-msgstr "Valor no válido \"{inspectedValue}\" para el campo FILES \"{fieldName}\" - Debe ser una matriz de objetos con las propiedades \"fileId\" y \"label\"."
+msgid ""
+"Invalid value \"{inspectedValue}\" for FILES field \"{fieldName}\" - It "
+"should be an array of objects with \"fileId\" and \"label\" properties."
+msgstr ""
+"Valor no válido \"{inspectedValue}\" para el campo FILES \"{fieldName}\" - "
+"Debe ser una matriz de objetos con las propiedades \"fileId\" y \"label\"."
 
 #. js-lingui-id: XOA98j
 #: src/engine/api/common/common-args-processors/filter-arg-processor/utils/validate-is-operator-filter-value-or-throw.util.ts
@@ -3659,14 +3931,21 @@ msgstr "Valor no válido para moneda."
 #. js-lingui-id: MnHbVB
 #: src/engine/api/common/common-args-processors/filter-arg-processor/validator-utils/validate-date-time-field-or-throw.util.ts
 #: src/engine/api/common/common-args-processors/data-arg-processor/validator-utils/validate-date-time-field-or-throw.util.ts
-msgid "Invalid value for date-time: \"{inspectedValue}\". Expected format: 'YYYY-MM-DDTHH:mm:ssZ'"
-msgstr "Valor no válido para fecha y hora: \"{inspectedValue}\". Formato esperado: 'YYYY-MM-DDTHH:mm:ssZ'"
+msgid ""
+"Invalid value for date-time: \"{inspectedValue}\". Expected format: 'YYYY-"
+"MM-DDTHH:mm:ssZ'"
+msgstr ""
+"Valor no válido para fecha y hora: \"{inspectedValue}\". Formato esperado: "
+"'YYYY-MM-DDTHH:mm:ssZ'"
 
 #. js-lingui-id: U4Wdjc
 #: src/engine/api/common/common-args-processors/filter-arg-processor/validator-utils/validate-date-field-or-throw.util.ts
 #: src/engine/api/common/common-args-processors/data-arg-processor/validator-utils/validate-date-field-or-throw.util.ts
-msgid "Invalid value for date: \"{inspectedValue}\". Expected format: 'YYYY-MM-DD'"
-msgstr "Valor no válido para fecha: \"{inspectedValue}\". Formato esperado: 'YYYY-MM-DD'"
+msgid ""
+"Invalid value for date: \"{inspectedValue}\". Expected format: 'YYYY-MM-DD'"
+msgstr ""
+"Valor no válido para fecha: \"{inspectedValue}\". Formato esperado: 'YYYY-"
+"MM-DD'"
 
 #. js-lingui-id: mANTdg
 #: src/engine/api/common/common-args-processors/data-arg-processor/validator-utils/validate-emails-field-or-throw.util.ts
@@ -3676,7 +3955,7 @@ msgstr "Valor no válido para correos electrónicos."
 #. js-lingui-id: qvqNco
 #: src/engine/api/common/common-args-processors/data-arg-processor/validator-utils/validate-rating-and-select-field-or-throw.util.ts
 msgid "Invalid value for field \"{fieldName}\""
-msgstr ""
+msgstr "Valor inválido para el campo \"{fieldName}\""
 
 #. js-lingui-id: tfoEIq
 #: src/engine/api/common/common-args-processors/data-arg-processor/validator-utils/validate-files-field-or-throw.util.ts
@@ -3761,12 +4040,16 @@ msgstr "Código de verificación inválido. Por favor, inténtelo de nuevo."
 #. js-lingui-id: UV7Pll
 #: src/engine/metadata-modules/flat-page-layout-widget/validators/utils/validate-fields-flat-page-layout-widget-for-creation.util.ts
 msgid "Invalid viewUniversalIdentifier for fields widget"
-msgstr ""
+msgstr "viewUniversalIdentifier inválido para el widget de campos"
 
 #. js-lingui-id: Bj1WZ+
 #: src/engine/metadata-modules/flat-page-layout-widget/validators/utils/validate-fields-flat-page-layout-widget-for-creation.util.ts
-msgid "Invalid viewUniversalIdentifier for fields widget \"{widgetTitle}\". Expected a valid UUID"
+msgid ""
+"Invalid viewUniversalIdentifier for fields widget \"{widgetTitle}\". "
+"Expected a valid UUID"
 msgstr ""
+"viewUniversalIdentifier inválido para el widget de campos \"{widgetTitle}\"."
+" Se esperaba un UUID válido"
 
 #. js-lingui-id: z68tnU
 #: src/engine/metadata-modules/webhook/webhook.exception.ts
@@ -3853,8 +4136,12 @@ msgstr "Es organizador"
 
 #. js-lingui-id: 1bOGPq
 #: src/engine/core-modules/enterprise/enterprise.exception.ts
-msgid "IS_CONFIG_VARIABLES_IN_DB_ENABLED is false on your server. Please add ENTERPRISE_KEY to your .env file manually."
-msgstr "IS_CONFIG_VARIABLES_IN_DB_ENABLED está establecido en false en su servidor. Agregue ENTERPRISE_KEY a su archivo .env manualmente."
+msgid ""
+"IS_CONFIG_VARIABLES_IN_DB_ENABLED is false on your server. Please add "
+"ENTERPRISE_KEY to your .env file manually."
+msgstr ""
+"IS_CONFIG_VARIABLES_IN_DB_ENABLED está establecido en false en su servidor. "
+"Agregue ENTERPRISE_KEY a su archivo .env manualmente."
 
 #. js-lingui-id: rjyWPb
 #: src/engine/api/graphql/graphql-query-runner/group-by/resolvers/utils/format-result-with-group-by-dimension-values.util.ts
@@ -3873,8 +4160,11 @@ msgstr "Se requiere el nombre de la columna de unión."
 
 #. js-lingui-id: 6pkAO8
 #: src/engine/workspace-manager/twenty-standard-application/utils/object-metadata/create-standard-flat-object-metadata.util.ts
-msgid "Join table linking message channel message associations to message folders"
+msgid ""
+"Join table linking message channel message associations to message folders"
 msgstr ""
+"Tabla de unión que vincula asociaciones de mensajes del canal de mensajes "
+"con carpetas de mensajes"
 
 #. js-lingui-id: PviVyk
 #: src/engine/core-modules/workspace-invitation/services/workspace-invitation.service.ts
@@ -3884,12 +4174,12 @@ msgstr "Únete a tu equipo en Twenty"
 #. js-lingui-id: AQuLwi
 #: src/engine/workspace-manager/twenty-standard-application/utils/field-metadata/compute-workflow-version-standard-flat-field-metadata.util.ts
 msgid "Json object to provide steps"
-msgstr ""
+msgstr "Objeto Json para proporcionar pasos"
 
 #. js-lingui-id: fOjmZ1
 #: src/engine/workspace-manager/twenty-standard-application/utils/field-metadata/compute-workflow-version-standard-flat-field-metadata.util.ts
 msgid "Json object to provide trigger"
-msgstr ""
+msgstr "Objeto Json para proporcionar disparador"
 
 #. js-lingui-id: eCBMag
 #: src/engine/workspace-manager/workspace-migration/workspace-migration-builder/validators/utils/validate-agent-response-format.util.ts
@@ -3899,7 +4189,7 @@ msgstr "El formato de respuesta JSON requiere un esquema"
 #. js-lingui-id: TVc0/Q
 #: src/engine/workspace-manager/twenty-standard-application/utils/field-metadata/compute-timeline-activity-standard-flat-field-metadata.util.ts
 msgid "Json value for event details"
-msgstr ""
+msgstr "Valor Json para detalles del evento"
 
 #. js-lingui-id: u4ex5r
 #: src/engine/api/graphql/graphql-query-runner/group-by/resolvers/utils/format-result-with-group-by-dimension-values.util.ts
@@ -3909,7 +4199,8 @@ msgstr "julio"
 #. js-lingui-id: ADIjmK
 #: src/engine/metadata-modules/flat-field-metadata/validators/utils/validate-junction-target-settings.util.ts
 msgid "Junction configuration is only valid for ONE_TO_MANY relations"
-msgstr "La configuración de la unión solo es válida para relaciones ONE_TO_MANY"
+msgstr ""
+"La configuración de la unión solo es válida para relaciones ONE_TO_MANY"
 
 #. js-lingui-id: bpqhFq
 #: src/engine/metadata-modules/flat-field-metadata/validators/utils/validate-junction-target-settings.util.ts
@@ -3944,14 +4235,16 @@ msgstr "junio"
 #: src/engine/workspace-manager/workspace-migration/workspace-migration-builder/validators/services/flat-view-validator.service.ts
 #: src/engine/workspace-manager/workspace-migration/workspace-migration-builder/validators/services/flat-view-validator.service.ts
 msgid "Kanban main group by field metadata not found"
-msgstr "No se encontraron los metadatos del campo principal de agrupación de Kanban"
+msgstr ""
+"No se encontraron los metadatos del campo principal de agrupación de Kanban"
 
 #. js-lingui-id: ZfLcEk
 #: src/engine/workspace-manager/workspace-migration/workspace-migration-builder/validators/services/flat-view-validator.service.ts
 #: src/engine/workspace-manager/workspace-migration/workspace-migration-builder/validators/services/flat-view-validator.service.ts
 #: src/engine/workspace-manager/workspace-migration/workspace-migration-builder/validators/services/flat-view-validator.service.ts
 msgid "Kanban main group by field must be a select field"
-msgstr "El campo principal de agrupación de Kanban debe ser un campo de selección"
+msgstr ""
+"El campo principal de agrupación de Kanban debe ser un campo de selección"
 
 #. js-lingui-id: RoCvZe
 #: src/engine/workspace-manager/workspace-migration/workspace-migration-builder/validators/services/flat-view-validator.service.ts
@@ -3971,12 +4264,12 @@ msgstr "La vista Kanban debe tener un campo principal de agrupación"
 #. js-lingui-id: WDgCbh
 #: src/engine/workspace-manager/workspace-migration/workspace-migration-builder/validators/services/flat-permission-flag-validator.service.ts
 msgid "Key cannot be changed"
-msgstr ""
+msgstr "La clave no se puede cambiar"
 
 #. js-lingui-id: QV1ZPO
 #: src/engine/workspace-manager/workspace-migration/workspace-migration-builder/validators/services/flat-permission-flag-validator.service.ts
 msgid "Key is required"
-msgstr ""
+msgstr "La clave es obligatoria"
 
 #. js-lingui-id: 6sFS+I
 #: src/engine/workspace-manager/workspace-migration/workspace-migration-builder/validators/utils/validate-skill-required-properties.util.ts
@@ -4008,7 +4301,9 @@ msgstr "El campo de vista del identificador de etiqueta no se puede eliminar"
 #: src/engine/workspace-manager/workspace-migration/workspace-migration-builder/validators/utils/validate-label-identifier-field-metadata-id-flat-view-field.util.ts
 #: src/engine/workspace-manager/workspace-migration/workspace-migration-builder/validators/utils/validate-label-identifier-field-metadata-id-flat-view-field.util.ts
 msgid "Label identifier view field has to be in the lowest position"
-msgstr "El campo de vista del identificador de etiqueta tiene que estar en la posición más baja"
+msgstr ""
+"El campo de vista del identificador de etiqueta tiene que estar en la "
+"posición más baja"
 
 #. js-lingui-id: PqTWJf
 #: src/engine/workspace-manager/workspace-migration/workspace-migration-builder/validators/utils/validate-label-identifier-field-metadata-id-flat-view-field.util.ts
@@ -4044,12 +4339,12 @@ msgstr "La etiqueta no debe contener una coma"
 #. js-lingui-id: vXIe7J
 #: src/engine/workspace-manager/twenty-standard-application/utils/field-metadata/compute-workspace-member-standard-flat-field-metadata.util.ts
 msgid "Language"
-msgstr ""
+msgstr "Idioma"
 
 #. js-lingui-id: WvYp6o
 #: src/engine/workspace-manager/twenty-standard-application/utils/field-metadata/compute-workflow-standard-flat-field-metadata.util.ts
 msgid "Last published Version Id"
-msgstr ""
+msgstr "ID de la última versión publicada"
 
 #. js-lingui-id: tGwswq
 #: src/engine/workspace-manager/twenty-standard-application/utils/field-metadata/compute-workspace-member-standard-flat-field-metadata.util.ts
@@ -4077,7 +4372,7 @@ msgstr ""
 #: src/engine/workspace-manager/twenty-standard-application/utils/field-metadata/compute-blocklist-standard-flat-field-metadata.util.ts
 #: src/engine/workspace-manager/twenty-standard-application/utils/field-metadata/compute-attachment-standard-flat-field-metadata.util.ts
 msgid "Last time the record was changed"
-msgstr ""
+msgstr "Última vez que se modificó el registro"
 
 #. js-lingui-id: o1zvNS
 #: src/engine/workspace-manager/twenty-standard-application/utils/field-metadata/compute-workspace-member-standard-flat-field-metadata.util.ts
@@ -4105,7 +4400,7 @@ msgstr ""
 #: src/engine/workspace-manager/twenty-standard-application/utils/field-metadata/compute-blocklist-standard-flat-field-metadata.util.ts
 #: src/engine/workspace-manager/twenty-standard-application/utils/field-metadata/compute-attachment-standard-flat-field-metadata.util.ts
 msgid "Last update"
-msgstr ""
+msgstr "Última actualización"
 
 #. js-lingui-id: 0x2TQ/
 #: src/engine/metadata-modules/flat-page-layout-widget/validators/utils/validate-bar-chart-configuration.util.ts
@@ -4115,7 +4410,9 @@ msgstr "El diseño es obligatorio para el gráfico de barras"
 #. js-lingui-id: qBrKIA
 #: src/engine/metadata-modules/flat-page-layout-widget/validators/utils/validate-bar-chart-configuration.util.ts
 msgid "Layout is required for bar chart widget \"{widgetTitle}\""
-msgstr "El diseño es obligatorio para el widget de gráfico de barras \"{widgetTitle}\""
+msgstr ""
+"El diseño es obligatorio para el widget de gráfico de barras "
+"\"{widgetTitle}\""
 
 #. js-lingui-id: oDC0sf
 #: src/engine/workspace-manager/workspace-migration/workspace-migration-builder/validators/services/flat-navigation-menu-item-validator.service.ts
@@ -4127,35 +4424,36 @@ msgstr "El enlace es obligatorio para el tipo LINK"
 #: src/engine/workspace-manager/twenty-standard-application/utils/field-metadata/compute-timeline-activity-standard-flat-field-metadata.util.ts
 #: src/engine/workspace-manager/twenty-standard-application/utils/field-metadata/compute-timeline-activity-standard-flat-field-metadata.util.ts
 msgid "Linked Object Metadata Id"
-msgstr ""
+msgstr "ID de metadatos del objeto vinculado"
 
 #. js-lingui-id: 6YiMr4
 #: src/engine/workspace-manager/twenty-standard-application/utils/field-metadata/compute-timeline-activity-standard-flat-field-metadata.util.ts
 msgid "Linked Record cached name"
-msgstr ""
+msgstr "Nombre en caché del registro vinculado"
 
 #. js-lingui-id: sgHAxx
 #: src/engine/workspace-manager/twenty-standard-application/utils/field-metadata/compute-timeline-activity-standard-flat-field-metadata.util.ts
 #: src/engine/workspace-manager/twenty-standard-application/utils/field-metadata/compute-timeline-activity-standard-flat-field-metadata.util.ts
 msgid "Linked Record id"
-msgstr ""
+msgstr "ID del registro vinculado"
 
 #. js-lingui-id: uCA6be
 #: src/engine/workspace-manager/twenty-standard-application/utils/field-metadata/compute-person-standard-flat-field-metadata.util.ts
 #: src/engine/workspace-manager/twenty-standard-application/utils/field-metadata/compute-company-standard-flat-field-metadata.util.ts
 msgid "Linkedin"
-msgstr ""
+msgstr "LinkedIn"
 
 #. js-lingui-id: LeFv/R
 #: src/engine/workspace-manager/twenty-standard-application/utils/field-metadata/compute-person-standard-flat-field-metadata.util.ts
 msgid "List of opportunities for which that person is the point of contact"
 msgstr ""
+"Lista de oportunidades para las que esa persona es el punto de contacto"
 
 #. js-lingui-id: wJijgU
 #: src/engine/workspace-manager/twenty-standard-application/utils/field-metadata/compute-calendar-event-standard-flat-field-metadata.util.ts
 #: src/engine/workspace-manager/twenty-standard-application/utils/field-metadata/compute-calendar-event-standard-flat-field-metadata.util.ts
 msgid "Location"
-msgstr ""
+msgstr "Ubicación"
 
 #. js-lingui-id: V5AXjr
 #: src/engine/workspace-manager/workspace-migration/workspace-migration-builder/validators/services/flat-logic-function-validator.service.ts
@@ -4195,7 +4493,7 @@ msgstr "La función lógica con el mismo identificador universal ya existe"
 #: src/engine/workspace-manager/workspace-migration/interceptors/utils/build-metadata-validation-error-payload.util.ts
 #: src/engine/workspace-manager/workspace-migration/interceptors/utils/__tests__/build-metadata-validation-error-payload.util.spec.ts
 msgid "Many validation errors"
-msgstr ""
+msgstr "Muchos errores de validación"
 
 #. js-lingui-id: hg6l4j
 #: src/engine/api/graphql/graphql-query-runner/group-by/resolvers/utils/format-result-with-group-by-dimension-values.util.ts
@@ -4210,17 +4508,25 @@ msgstr "El número máximo de archivos es {filesFieldMaxNumberOfValues}"
 #. js-lingui-id: J9favo
 #: src/engine/api/common/common-args-processors/data-arg-processor/validator-utils/validate-files-field-or-throw.util.ts
 msgid "Max number of files is {maxNumberOfValues} for field \"{fieldName}\""
-msgstr "El número máximo de archivos es {maxNumberOfValues} para el campo \"{fieldName}\""
+msgstr ""
+"El número máximo de archivos es {maxNumberOfValues} para el campo "
+"\"{fieldName}\""
 
 #. js-lingui-id: hw7Mwk
 #: src/engine/api/common/common-query-runners/common-create-many-query-runner/common-create-many-query-runner.service.ts
 msgid "Maximum number of records to upsert is {QUERY_MAX_RECORDS}."
-msgstr "El número máximo de registros para insertar/actualizar es {QUERY_MAX_RECORDS}."
+msgstr ""
+"El número máximo de registros para insertar/actualizar es "
+"{QUERY_MAX_RECORDS}."
 
 #. js-lingui-id: b85bAt
 #: src/engine/metadata-modules/flat-field-metadata/validators/utils/validate-files-flat-field-metadata.util.ts
-msgid "maxNumberOfValues must be defined in settings and be a number greater than 0 and less than or equal to {FILES_FIELD_MAX_NUMBER_OF_VALUES}"
-msgstr "maxNumberOfValues debe estar definido en la configuración y ser un número mayor que 0 y menor o igual a {FILES_FIELD_MAX_NUMBER_OF_VALUES}"
+msgid ""
+"maxNumberOfValues must be defined in settings and be a number greater than 0"
+" and less than or equal to {FILES_FIELD_MAX_NUMBER_OF_VALUES}"
+msgstr ""
+"maxNumberOfValues debe estar definido en la configuración y ser un número "
+"mayor que 0 y menor o igual a {FILES_FIELD_MAX_NUMBER_OF_VALUES}"
 
 #. js-lingui-id: 3JzsDb
 #: src/engine/api/graphql/graphql-query-runner/group-by/resolvers/utils/format-result-with-group-by-dimension-values.util.ts
@@ -4231,12 +4537,12 @@ msgstr "mayo"
 #: src/engine/workspace-manager/twenty-standard-application/utils/field-metadata/compute-calendar-event-standard-flat-field-metadata.util.ts
 #: src/engine/workspace-manager/twenty-standard-application/utils/field-metadata/compute-calendar-event-standard-flat-field-metadata.util.ts
 msgid "Meet Link"
-msgstr ""
+msgstr "Enlace de reunión"
 
 #. js-lingui-id: oE8Gmu
 #: src/engine/workspace-manager/twenty-standard-application/utils/field-metadata/compute-opportunity-standard-flat-field-metadata.util.ts
 msgid "Meeting"
-msgstr ""
+msgstr "Reunión"
 
 #. js-lingui-id: xDAtGP
 #: src/engine/workspace-manager/twenty-standard-application/utils/object-metadata/create-standard-flat-object-metadata.util.ts
@@ -4244,51 +4550,53 @@ msgstr ""
 #: src/engine/workspace-manager/twenty-standard-application/utils/field-metadata/compute-message-participant-standard-flat-field-metadata.util.ts
 #: src/engine/workspace-manager/twenty-standard-application/utils/field-metadata/compute-message-participant-standard-flat-field-metadata.util.ts
 msgid "Message"
-msgstr ""
+msgstr "Mensaje"
 
 #. js-lingui-id: DzU4a3
 #: src/engine/workspace-manager/twenty-standard-application/utils/field-metadata/compute-message-thread-standard-flat-field-metadata.util.ts
 #: src/engine/workspace-manager/twenty-standard-application/utils/field-metadata/compute-message-standard-flat-field-metadata.util.ts
 msgid "Message Channel Association"
-msgstr ""
+msgstr "Asociación de canal de mensajes"
 
 #. js-lingui-id: wd/R++
 #: src/engine/workspace-manager/twenty-standard-application/utils/field-metadata/compute-message-channel-message-association-standard-flat-field-metadata.util.ts
 #: src/engine/workspace-manager/twenty-standard-application/utils/field-metadata/compute-message-channel-message-association-standard-flat-field-metadata.util.ts
 msgid "Message Channel Id"
-msgstr ""
+msgstr "ID del canal de mensajes"
 
 #. js-lingui-id: disipM
 #: src/engine/workspace-manager/twenty-standard-application/utils/object-metadata/create-standard-flat-object-metadata.util.ts
 #: src/engine/workspace-manager/twenty-standard-application/utils/field-metadata/compute-message-channel-message-association-message-folder-standard-flat-field-metadata.util.ts
 #: src/engine/workspace-manager/twenty-standard-application/utils/field-metadata/compute-message-channel-message-association-message-folder-standard-flat-field-metadata.util.ts
 msgid "Message Channel Message Association"
-msgstr ""
+msgstr "Asociación de mensaje del canal de mensajes"
 
 #. js-lingui-id: 3BMS+k
 #: src/engine/workspace-manager/twenty-standard-application/utils/object-metadata/create-standard-flat-object-metadata.util.ts
 msgid "Message Channel Message Association Message Folder"
-msgstr ""
+msgstr "Carpeta de mensajes de asociación de mensaje del canal de mensajes"
 
 #. js-lingui-id: pFe3WO
 #: src/engine/workspace-manager/twenty-standard-application/utils/field-metadata/compute-message-channel-message-association-message-folder-standard-flat-field-metadata.util.ts
 msgid "Message channel message association message folder record position"
 msgstr ""
+"Posición del registro de carpeta de mensajes de asociación de mensaje del "
+"canal de mensajes"
 
 #. js-lingui-id: 5RRTyw
 #: src/engine/workspace-manager/twenty-standard-application/utils/object-metadata/create-standard-flat-object-metadata.util.ts
 msgid "Message Channel Message Association Message Folders"
-msgstr ""
+msgstr "Carpetas de mensajes de asociación de mensaje del canal de mensajes"
 
 #. js-lingui-id: ndzpor
 #: src/engine/workspace-manager/twenty-standard-application/utils/field-metadata/compute-message-channel-message-association-standard-flat-field-metadata.util.ts
 msgid "Message channel message association record position"
-msgstr ""
+msgstr "Posición del registro de asociación de mensaje del canal de mensajes"
 
 #. js-lingui-id: ijQY3P
 #: src/engine/workspace-manager/twenty-standard-application/utils/object-metadata/create-standard-flat-object-metadata.util.ts
 msgid "Message Channel Message Associations"
-msgstr ""
+msgstr "Asociaciones de mensajes del canal de mensajes"
 
 #. js-lingui-id: vjIbbe
 #: src/engine/metadata-modules/message-channel/message-channel.exception.ts
@@ -4298,18 +4606,18 @@ msgstr "Canal de mensajes no encontrado."
 #. js-lingui-id: /4uGJc
 #: src/engine/workspace-manager/twenty-standard-application/utils/field-metadata/compute-message-channel-message-association-standard-flat-field-metadata.util.ts
 msgid "Message Direction"
-msgstr ""
+msgstr "Dirección del mensaje"
 
 #. js-lingui-id: fBw8fQ
 #: src/engine/workspace-manager/twenty-standard-application/utils/field-metadata/compute-message-channel-message-association-standard-flat-field-metadata.util.ts
 msgid "Message External Id"
-msgstr ""
+msgstr "ID externo del mensaje"
 
 #. js-lingui-id: CStLnc
 #: src/engine/workspace-manager/twenty-standard-application/utils/field-metadata/compute-message-channel-message-association-message-folder-standard-flat-field-metadata.util.ts
 #: src/engine/workspace-manager/twenty-standard-application/utils/field-metadata/compute-message-channel-message-association-message-folder-standard-flat-field-metadata.util.ts
 msgid "Message Folder"
-msgstr ""
+msgstr "Carpeta de mensajes"
 
 #. js-lingui-id: BZbxut
 #: src/engine/metadata-modules/message-folder/message-folder.exception.ts
@@ -4319,38 +4627,38 @@ msgstr "Carpeta de mensajes no encontrada."
 #. js-lingui-id: p4ANpY
 #: src/engine/workspace-manager/twenty-standard-application/utils/field-metadata/compute-message-channel-message-association-standard-flat-field-metadata.util.ts
 msgid "Message Folders"
-msgstr ""
+msgstr "Carpetas de mensajes"
 
 #. js-lingui-id: 3m/jfT
 #: src/engine/workspace-manager/twenty-standard-application/utils/field-metadata/compute-message-channel-message-association-standard-flat-field-metadata.util.ts
 msgid "Message Folders (supports multiple folders/labels)"
-msgstr ""
+msgstr "Carpetas de mensajes (soporta múltiples carpetas/etiquetas)"
 
 #. js-lingui-id: 6icznk
 #: src/engine/workspace-manager/twenty-standard-application/utils/field-metadata/compute-message-channel-message-association-standard-flat-field-metadata.util.ts
 #: src/engine/workspace-manager/twenty-standard-application/utils/field-metadata/compute-message-channel-message-association-standard-flat-field-metadata.util.ts
 msgid "Message Id"
-msgstr ""
+msgstr "ID del mensaje"
 
 #. js-lingui-id: 9FJSpK
 #: src/engine/workspace-manager/twenty-standard-application/utils/field-metadata/compute-message-standard-flat-field-metadata.util.ts
 msgid "Message id from the message header"
-msgstr ""
+msgstr "ID del mensaje del encabezado del mensaje"
 
 #. js-lingui-id: yaC1Aq
 #: src/engine/workspace-manager/twenty-standard-application/utils/field-metadata/compute-message-channel-message-association-standard-flat-field-metadata.util.ts
 msgid "Message id from the messaging provider"
-msgstr ""
+msgstr "ID del mensaje del proveedor de mensajería"
 
 #. js-lingui-id: IUmVwu
 #: src/engine/workspace-manager/twenty-standard-application/utils/object-metadata/create-standard-flat-object-metadata.util.ts
 msgid "Message Participant"
-msgstr ""
+msgstr "Participante del mensaje"
 
 #. js-lingui-id: s97wWW
 #: src/engine/workspace-manager/twenty-standard-application/utils/field-metadata/compute-message-participant-standard-flat-field-metadata.util.ts
 msgid "Message Participant record position"
-msgstr ""
+msgstr "Posición del registro de participante del mensaje"
 
 #. js-lingui-id: FhIFx7
 #: src/engine/workspace-manager/twenty-standard-application/utils/object-metadata/create-standard-flat-object-metadata.util.ts
@@ -4362,23 +4670,23 @@ msgstr ""
 #: src/engine/workspace-manager/twenty-standard-application/utils/field-metadata/compute-message-standard-flat-field-metadata.util.ts
 #: src/engine/workspace-manager/twenty-standard-application/utils/field-metadata/compute-message-standard-flat-field-metadata.util.ts
 msgid "Message Participants"
-msgstr ""
+msgstr "Participantes del mensaje"
 
 #. js-lingui-id: w9lbnZ
 #: src/engine/workspace-manager/twenty-standard-application/utils/field-metadata/compute-message-standard-flat-field-metadata.util.ts
 msgid "Message record position"
-msgstr ""
+msgstr "Posición del registro de mensaje"
 
 #. js-lingui-id: IC5A8V
 #: src/engine/workspace-manager/twenty-standard-application/utils/object-metadata/create-standard-flat-object-metadata.util.ts
 msgid "Message Synced with a Message Channel"
-msgstr ""
+msgstr "Mensaje sincronizado con un canal de mensajes"
 
 #. js-lingui-id: de2nM/
 #: src/engine/workspace-manager/twenty-standard-application/utils/object-metadata/create-standard-flat-object-metadata.util.ts
 #: src/engine/workspace-manager/twenty-standard-application/utils/object-metadata/create-standard-flat-object-metadata.util.ts
 msgid "Message Thread"
-msgstr ""
+msgstr "Hilo de mensajes"
 
 #. js-lingui-id: km1jgD
 #: src/engine/workspace-manager/twenty-standard-application/utils/field-metadata/compute-message-standard-flat-field-metadata.util.ts
@@ -4386,34 +4694,34 @@ msgstr ""
 #: src/engine/workspace-manager/twenty-standard-application/utils/field-metadata/compute-message-channel-message-association-standard-flat-field-metadata.util.ts
 #: src/engine/workspace-manager/twenty-standard-application/utils/field-metadata/compute-message-channel-message-association-standard-flat-field-metadata.util.ts
 msgid "Message Thread Id"
-msgstr ""
+msgstr "ID del hilo de mensajes"
 
 #. js-lingui-id: l2/A0/
 #: src/engine/workspace-manager/twenty-standard-application/utils/field-metadata/compute-message-thread-standard-flat-field-metadata.util.ts
 msgid "Message Thread record position"
-msgstr ""
+msgstr "Posición del registro de hilo de mensajes"
 
 #. js-lingui-id: RD0ecC
 #: src/engine/workspace-manager/twenty-standard-application/utils/object-metadata/create-standard-flat-object-metadata.util.ts
 msgid "Message Threads"
-msgstr ""
+msgstr "Hilos de mensajes"
 
 #. js-lingui-id: t7TeQU
 #: src/engine/workspace-manager/twenty-standard-application/utils/object-metadata/create-standard-flat-object-metadata.util.ts
 #: src/engine/workspace-manager/twenty-standard-application/utils/field-metadata/compute-message-thread-standard-flat-field-metadata.util.ts
 msgid "Messages"
-msgstr ""
+msgstr "Mensajes"
 
 #. js-lingui-id: WoWdku
 #: src/engine/workspace-manager/twenty-standard-application/utils/field-metadata/compute-message-thread-standard-flat-field-metadata.util.ts
 #: src/engine/workspace-manager/twenty-standard-application/utils/field-metadata/compute-message-standard-flat-field-metadata.util.ts
 msgid "Messages from the channel."
-msgstr ""
+msgstr "Mensajes del canal."
 
 #. js-lingui-id: rYPBO7
 #: src/engine/workspace-manager/twenty-standard-application/utils/field-metadata/compute-message-thread-standard-flat-field-metadata.util.ts
 msgid "Messages from the thread."
-msgstr ""
+msgstr "Mensajes del hilo."
 
 #. js-lingui-id: PslTPV
 #: src/engine/workspace-manager/workspace-migration/interceptors/utils/build-metadata-validation-error-payload.util.ts
@@ -4439,8 +4747,13 @@ msgstr "La ejecución de la migración falló."
 
 #. js-lingui-id: G6wJK8
 #: src/modules/workflow/workflow-trigger/utils/assert-version-can-be-activated.util.ts
-msgid "Minute value cannot exceed 60. For intervals greater than 60 minutes, use the \"Hours\" trigger type or a custom cron expression"
-msgstr "El valor de los minutos no puede exceder 60. Para intervalos superiores a 60 minutos, usa el tipo de activación \"Horas\" o una expresión cron personalizada"
+msgid ""
+"Minute value cannot exceed 60. For intervals greater than 60 minutes, use "
+"the \"Hours\" trigger type or a custom cron expression"
+msgstr ""
+"El valor de los minutos no puede exceder 60. Para intervalos superiores a 60"
+" minutos, usa el tipo de activación \"Horas\" o una expresión cron "
+"personalizada"
 
 #. js-lingui-id: lCnasH
 #: src/engine/workspace-cache/exceptions/workspace-cache.exception.ts
@@ -4459,8 +4772,12 @@ msgstr "Falta el cuerpo de la solicitud."
 
 #. js-lingui-id: SzCMUQ
 #: src/engine/twenty-orm/utils/compute-relation-connect-query-configs.util.ts
-msgid "Missing required fields: at least one unique constraint have to be fully populated for '{connectFieldName}'."
-msgstr "Campos requeridos faltantes: al menos una restricción única debe estar completamente poblada para '{connectFieldName}'."
+msgid ""
+"Missing required fields: at least one unique constraint have to be fully "
+"populated for '{connectFieldName}'."
+msgstr ""
+"Campos requeridos faltantes: al menos una restricción única debe estar "
+"completamente poblada para '{connectFieldName}'."
 
 #. js-lingui-id: AHuHeg
 #: src/engine/workspace-manager/workspace-migration/workspace-migration-builder/validators/utils/validate-agent-required-properties.util.ts
@@ -4476,7 +4793,7 @@ msgstr "Lunes"
 #. js-lingui-id: Er0m61
 #: src/engine/workspace-manager/twenty-standard-application/utils/field-metadata/compute-workspace-member-standard-flat-field-metadata.util.ts
 msgid "Month First"
-msgstr ""
+msgstr "Mes primero"
 
 #. js-lingui-id: Lcqv5g
 #: src/engine/metadata-modules/flat-field-metadata/validators/utils/validate-morph-relation-flat-field-metadata.util.ts
@@ -4486,12 +4803,18 @@ msgstr "El campo de relación morph debe tener un ID de morph"
 #. js-lingui-id: Wu/pkS
 #: src/engine/metadata-modules/flat-field-metadata/validators/utils/validate-enum-flat-field-metadata.util.ts
 msgid "Multi-select field default value must be an array"
-msgstr "El valor por defecto del campo de selección múltiple debe ser un arreglo"
+msgstr ""
+"El valor por defecto del campo de selección múltiple debe ser un arreglo"
 
 #. js-lingui-id: 6rLmLu
 #: src/engine/api/common/common-query-runners/common-create-many-query-runner/utils/get-matching-record-id.util.ts
-msgid "Multiple records found with the same unique field values for {conflictingFieldsValues}. Cannot determine which record to update."
-msgstr "Se encontraron múltiples registros con los mismos valores de campo único para {conflictingFieldsValues}. No se puede determinar qué registro actualizar."
+msgid ""
+"Multiple records found with the same unique field values for "
+"{conflictingFieldsValues}. Cannot determine which record to update."
+msgstr ""
+"Se encontraron múltiples registros con los mismos valores de campo único "
+"para {conflictingFieldsValues}. No se puede determinar qué registro "
+"actualizar."
 
 #. js-lingui-id: B9dbXq
 #: src/engine/core-modules/billing/billing.exception.ts
@@ -4508,7 +4831,7 @@ msgstr "Se encontraron múltiples suscripciones donde se esperaba una."
 #: src/engine/workspace-manager/twenty-standard-application/utils/field-metadata/compute-company-standard-flat-field-metadata.util.ts
 #: src/engine/workspace-manager/twenty-standard-application/utils/field-metadata/compute-attachment-standard-flat-field-metadata.util.ts
 msgid "Name"
-msgstr ""
+msgstr "Nombre"
 
 #. js-lingui-id: 2m6Fru
 #: src/engine/metadata-modules/flat-field-metadata/validators/utils/validate-flat-field-metadata-name-availability.util.ts
@@ -4524,6 +4847,8 @@ msgstr "El nombre \"{name}\" no está disponible ya que ya lo utiliza otro campo
 #: src/engine/metadata-modules/flat-field-metadata/validators/utils/validate-flat-field-metadata-name-availability.util.ts
 msgid "Name \"{name}\" is not available as it is already used by join column name"
 msgstr ""
+"El nombre \"{name}\" no está disponible ya que está usado por el nombre de "
+"columna de unión"
 
 #. js-lingui-id: Aam+mb
 #: src/engine/metadata-modules/utils/exceptions/invalid-metadata.exception.ts
@@ -4534,8 +4859,12 @@ msgstr "El nombre no está sincronizado con la etiqueta."
 #: src/engine/metadata-modules/flat-object-metadata/validators/utils/validate-flat-object-metadata-name.util.ts
 #: src/engine/metadata-modules/flat-field-metadata/validators/utils/validate-flat-field-metadata-name.util.ts
 #: src/engine/metadata-modules/flat-field-metadata/validators/utils/validate-flat-field-metadata-name.util.ts
-msgid "Name is not valid: it must start with lowercase letter and contain only alphanumeric letters"
-msgstr "El nombre no es válido: debe comenzar con una letra minúscula y contener solo letras y números alfanuméricos."
+msgid ""
+"Name is not valid: it must start with lowercase letter and contain only "
+"alphanumeric letters"
+msgstr ""
+"El nombre no es válido: debe comenzar con una letra minúscula y contener "
+"solo letras y números alfanuméricos."
 
 #. js-lingui-id: zjh2SJ
 #: src/engine/metadata-modules/flat-object-metadata/validators/utils/validate-flat-object-metadata-name.util.ts
@@ -4559,7 +4888,7 @@ msgstr "El nombre debe estar en formato camelCase."
 #. js-lingui-id: csMjko
 #: src/engine/workspace-manager/twenty-standard-application/utils/field-metadata/compute-workflow-run-standard-flat-field-metadata.util.ts
 msgid "Name of the workflow run"
-msgstr ""
+msgstr "Nombre de la ejecución del flujo de trabajo"
 
 #. js-lingui-id: Dr0xtb
 #: src/engine/metadata-modules/flat-object-metadata/validators/utils/validate-flat-object-metadata-name-and-labels.util.ts
@@ -4571,18 +4900,25 @@ msgstr "Los nombres no están sincronizados con las etiquetas."
 #: src/engine/workspace-manager/workspace-migration/workspace-migration-builder/validators/services/flat-navigation-menu-item-validator.service.ts
 #: src/engine/workspace-manager/workspace-migration/workspace-migration-builder/validators/services/flat-navigation-menu-item-validator.service.ts
 msgid "Navigation menu item cannot be its own parent"
-msgstr "El elemento del menú de navegación no puede ser su propio elemento padre"
+msgstr ""
+"El elemento del menú de navegación no puede ser su propio elemento padre"
 
 #. js-lingui-id: t38VAr
 #: src/engine/workspace-manager/workspace-migration/workspace-migration-builder/validators/services/flat-navigation-menu-item-validator.service.ts
 #: src/engine/workspace-manager/workspace-migration/workspace-migration-builder/validators/services/flat-navigation-menu-item-validator.service.ts
-msgid "Navigation menu item hierarchy exceeds maximum depth of {NAVIGATION_MENU_ITEM_MAX_DEPTH}"
-msgstr "La jerarquía del elemento del menú de navegación supera la profundidad máxima de {NAVIGATION_MENU_ITEM_MAX_DEPTH}"
+msgid ""
+"Navigation menu item hierarchy exceeds maximum depth of "
+"{NAVIGATION_MENU_ITEM_MAX_DEPTH}"
+msgstr ""
+"La jerarquía del elemento del menú de navegación supera la profundidad "
+"máxima de {NAVIGATION_MENU_ITEM_MAX_DEPTH}"
 
 #. js-lingui-id: E+iJnK
 #: src/engine/metadata-modules/navigation-menu-item/navigation-menu-item.exception.ts
 msgid "Navigation menu item hierarchy exceeds maximum depth."
-msgstr "La jerarquía del elemento del menú de navegación supera la profundidad máxima."
+msgstr ""
+"La jerarquía del elemento del menú de navegación supera la profundidad "
+"máxima."
 
 #. js-lingui-id: s+CGNO
 #: src/engine/workspace-manager/workspace-migration/workspace-migration-builder/validators/services/flat-navigation-menu-item-validator.service.ts
@@ -4606,12 +4942,12 @@ msgstr "El tipo de elemento del menú de navegación es obligatorio"
 #. js-lingui-id: t6LpHj
 #: src/engine/workspace-manager/twenty-standard-application/utils/field-metadata/compute-calendar-event-participant-standard-flat-field-metadata.util.ts
 msgid "Needs Action"
-msgstr ""
+msgstr "Requiere acción"
 
 #. js-lingui-id: isRobC
 #: src/engine/workspace-manager/twenty-standard-application/utils/field-metadata/compute-opportunity-standard-flat-field-metadata.util.ts
 msgid "New"
-msgstr ""
+msgstr "Nuevo"
 
 #. js-lingui-id: TYhxR+
 #: src/engine/core-modules/user/services/user.service.ts
@@ -4631,7 +4967,9 @@ msgstr "No se encontró ninguna suscripción activa."
 #. js-lingui-id: hQQZse
 #: src/modules/workflow/workflow-trigger/utils/assert-version-can-be-activated.util.ts
 msgid "No event name provided in database event trigger"
-msgstr "No se proporcionó el nombre del evento en el disparador de eventos de la base de datos"
+msgstr ""
+"No se proporcionó el nombre del evento en el disparador de eventos de la "
+"base de datos"
 
 #. js-lingui-id: 6GG2MJ
 #: src/engine/core-modules/search/exceptions/search.exception.ts
@@ -4650,8 +4988,12 @@ msgstr "No se proporcionó patrón en el disparador CUSTOM de cron"
 
 #. js-lingui-id: 2iURlq
 #: src/engine/metadata-modules/object-permission/field-permission/field-permission.service.ts
-msgid "No permissions are set for this role on the selected object. Please set object permissions first."
-msgstr "No se establecieron permisos para este rol en el objeto seleccionado. Por favor, establezca primero los permisos del objeto."
+msgid ""
+"No permissions are set for this role on the selected object. Please set "
+"object permissions first."
+msgstr ""
+"No se establecieron permisos para este rol en el objeto seleccionado. Por "
+"favor, establezca primero los permisos del objeto."
 
 #. js-lingui-id: D2A/H0
 #: src/engine/metadata-modules/permissions/permissions.exception.ts
@@ -4706,12 +5048,14 @@ msgstr "No se encontró un contexto de autenticación válido."
 #. js-lingui-id: AzXrd9
 #: src/engine/core-modules/auth/services/reset-password.service.ts
 msgid "No workspace found with password auth enabled."
-msgstr "No se encontró ningún espacio de trabajo con la autenticación por contraseña habilitada."
+msgstr ""
+"No se encontró ningún espacio de trabajo con la autenticación por contraseña"
+" habilitada."
 
 #. js-lingui-id: eRIGld
 #: src/engine/core-modules/application/connection-provider/connection-provider.exception.ts
 msgid "Not authorized to access this OAuth provider."
-msgstr ""
+msgstr "No autorizado para acceder a este proveedor OAuth."
 
 #. js-lingui-id: NpVtef
 #: src/modules/dashboard/chart-data/utils/format-dimension-value.util.ts
@@ -4722,7 +5066,7 @@ msgstr "No establecido"
 #. js-lingui-id: mu1gVr
 #: src/engine/workspace-manager/twenty-standard-application/utils/field-metadata/compute-workflow-run-standard-flat-field-metadata.util.ts
 msgid "Not started"
-msgstr ""
+msgstr "No iniciado"
 
 #. js-lingui-id: KiJn9B
 #: src/engine/workspace-manager/twenty-standard-application/utils/object-metadata/create-standard-flat-object-metadata.util.ts
@@ -4735,37 +5079,37 @@ msgstr "Nota"
 #. js-lingui-id: GGlkb7
 #: src/engine/workspace-manager/twenty-standard-application/utils/field-metadata/compute-note-standard-flat-field-metadata.util.ts
 msgid "Note attachments"
-msgstr ""
+msgstr "Adjuntos de la nota"
 
 #. js-lingui-id: Q1Rz+6
 #: src/engine/workspace-manager/twenty-standard-application/utils/field-metadata/compute-note-standard-flat-field-metadata.util.ts
 msgid "Note body"
-msgstr ""
+msgstr "Cuerpo de la nota"
 
 #. js-lingui-id: Yp057F
 #: src/engine/workspace-manager/twenty-standard-application/utils/field-metadata/compute-note-standard-flat-field-metadata.util.ts
 msgid "Note record position"
-msgstr ""
+msgstr "Posición del registro de nota"
 
 #. js-lingui-id: spaO7l
 #: src/engine/workspace-manager/twenty-standard-application/utils/object-metadata/create-standard-flat-object-metadata.util.ts
 msgid "Note Target"
-msgstr ""
+msgstr "Destino de la nota"
 
 #. js-lingui-id: mkchvJ
 #: src/engine/workspace-manager/twenty-standard-application/utils/field-metadata/compute-note-standard-flat-field-metadata.util.ts
 msgid "Note targets"
-msgstr ""
+msgstr "Destinos de la nota"
 
 #. js-lingui-id: tD4BxK
 #: src/engine/workspace-manager/twenty-standard-application/utils/object-metadata/create-standard-flat-object-metadata.util.ts
 msgid "Note Targets"
-msgstr ""
+msgstr "Destinos de las notas"
 
 #. js-lingui-id: jDThel
 #: src/engine/workspace-manager/twenty-standard-application/utils/field-metadata/compute-note-standard-flat-field-metadata.util.ts
 msgid "Note title"
-msgstr ""
+msgstr "Título de la nota"
 
 #. js-lingui-id: 1DBGsz
 #: src/engine/workspace-manager/twenty-standard-application/utils/object-metadata/create-standard-flat-object-metadata.util.ts
@@ -4780,34 +5124,34 @@ msgstr "Notas"
 #. js-lingui-id: fXBE74
 #: src/engine/workspace-manager/twenty-standard-application/utils/field-metadata/compute-company-standard-flat-field-metadata.util.ts
 msgid "Notes tied to the company"
-msgstr ""
+msgstr "Notas vinculadas a la empresa"
 
 #. js-lingui-id: iQ5AH6
 #: src/engine/workspace-manager/twenty-standard-application/utils/field-metadata/compute-person-standard-flat-field-metadata.util.ts
 msgid "Notes tied to the contact"
-msgstr ""
+msgstr "Notas vinculadas al contacto"
 
 #. js-lingui-id: 0bi/Eh
 #: src/engine/workspace-manager/twenty-standard-application/utils/field-metadata/compute-opportunity-standard-flat-field-metadata.util.ts
 msgid "Notes tied to the opportunity"
-msgstr ""
+msgstr "Notas vinculadas a la oportunidad"
 
 #. js-lingui-id: /mH0jo
 #: src/engine/workspace-manager/twenty-standard-application/utils/field-metadata/compute-note-target-standard-flat-field-metadata.util.ts
 msgid "NoteTarget note"
-msgstr ""
+msgstr "Nota del destino de nota"
 
 #. js-lingui-id: sX4Xu7
 #: src/engine/workspace-manager/twenty-standard-application/utils/field-metadata/compute-note-target-standard-flat-field-metadata.util.ts
 msgid "NoteTarget record position"
-msgstr ""
+msgstr "Posición del registro de destino de nota"
 
 #. js-lingui-id: mqwohF
 #: src/engine/workspace-manager/twenty-standard-application/utils/field-metadata/compute-note-target-standard-flat-field-metadata.util.ts
 #: src/engine/workspace-manager/twenty-standard-application/utils/field-metadata/compute-note-target-standard-flat-field-metadata.util.ts
 #: src/engine/workspace-manager/twenty-standard-application/utils/field-metadata/compute-note-target-standard-flat-field-metadata.util.ts
 msgid "NoteTarget target"
-msgstr ""
+msgstr "Destino del destino de nota"
 
 #. js-lingui-id: t9QlBd
 #: src/engine/api/graphql/graphql-query-runner/group-by/resolvers/utils/format-result-with-group-by-dimension-values.util.ts
@@ -4817,17 +5161,17 @@ msgstr "noviembre"
 #. js-lingui-id: bR2sEm
 #: src/engine/workspace-manager/twenty-standard-application/utils/field-metadata/compute-workspace-member-standard-flat-field-metadata.util.ts
 msgid "Number format"
-msgstr ""
+msgstr "Formato de número"
 
 #. js-lingui-id: ioJFzx
 #: src/engine/workspace-manager/twenty-standard-application/utils/field-metadata/compute-company-standard-flat-field-metadata.util.ts
 msgid "Number of employees in the company"
-msgstr ""
+msgstr "Número de empleados en la empresa"
 
 #. js-lingui-id: MKdH/S
 #: src/engine/workspace-manager/workspace-migration/workspace-migration-builder/validators/services/flat-connection-provider-validator.service.ts
 msgid "OAuth {label} is required"
-msgstr ""
+msgstr "OAuth {label} es obligatorio"
 
 #. js-lingui-id: 08qKzD
 #: src/engine/core-modules/auth/auth.exception.ts
@@ -4838,11 +5182,12 @@ msgstr "Se denegó el acceso OAuth."
 #: src/engine/workspace-manager/workspace-migration/workspace-migration-builder/validators/services/flat-connection-provider-validator.service.ts
 msgid "OAuth connection provider is missing its oauth config block"
 msgstr ""
+"El proveedor de conexión OAuth no tiene su bloque de configuración oauth"
 
 #. js-lingui-id: xodh4N
 #: src/engine/core-modules/application/connection-provider/connection-provider.exception.ts
 msgid "OAuth provider not found."
-msgstr ""
+msgstr "Proveedor OAuth no encontrado."
 
 #. js-lingui-id: ECRKYR
 #: src/engine/metadata-modules/flat-object-metadata/validators/utils/validate-flat-object-metadata-name-and-labels.util.ts
@@ -4946,7 +5291,9 @@ msgstr "Objeto relacionado con el campo a actualizar no encontrado"
 #. js-lingui-id: MnOwTp
 #: src/engine/workspace-manager/workspace-migration/workspace-migration-builder/validators/services/flat-field-metadata-validator.service.ts
 msgid "Object related to updated field does not have a label identifier"
-msgstr "El objeto relacionado con el campo actualizado no tiene un identificador de etiqueta"
+msgstr ""
+"El objeto relacionado con el campo actualizado no tiene un identificador de "
+"etiqueta"
 
 #. js-lingui-id: 6unt40
 #: src/engine/metadata-modules/flat-field-metadata/validators/utils/validate-relation-creation-payload.util.ts
@@ -4994,7 +5341,7 @@ msgstr "La acción On delete solo es compatible con relaciones de muchos a uno"
 #. js-lingui-id: DWJeR1
 #: src/engine/metadata-modules/index-metadata/services/index-metadata.service.ts
 msgid "One of the selected fields does not belong to this object."
-msgstr ""
+msgstr "Uno de los campos seleccionados no pertenece a este objeto."
 
 #. js-lingui-id: JZB2eY
 #: src/engine/api/common/common-query-runners/common-merge-many-query-runner.service.ts
@@ -5014,7 +5361,7 @@ msgstr "Uno o más ámbitos solicitados no son válidos."
 #. js-lingui-id: XLn1DI
 #: src/engine/workspace-manager/workspace-migration/interceptors/utils/__tests__/build-metadata-validation-error-payload.util.spec.ts
 msgid "Only error"
-msgstr ""
+msgstr "Solo error"
 
 #. js-lingui-id: eYgzEd
 #: src/engine/metadata-modules/permissions/permissions.exception.ts
@@ -5024,8 +5371,12 @@ msgstr "Solo se permiten restricciones de campo."
 #. js-lingui-id: vX5t8O
 #. placeholder {0}: allowedOperands.join(', ')
 #: src/engine/workspace-manager/workspace-migration/workspace-migration-builder/validators/services/flat-view-filter-validator.service.ts
-msgid "Operand \"{operand}\" is not supported on field type \"{effectiveFieldType}\". Supported operands: {0}."
+msgid ""
+"Operand \"{operand}\" is not supported on field type "
+"\"{effectiveFieldType}\". Supported operands: {0}."
 msgstr ""
+"El operando \"{operand}\" no es compatible con el tipo de campo "
+"\"{effectiveFieldType}\". Operandos compatibles: {0}."
 
 #. js-lingui-id: 4MyDFl
 #: src/engine/workspace-manager/twenty-standard-application/utils/object-metadata/create-standard-flat-object-metadata.util.ts
@@ -5033,62 +5384,62 @@ msgstr ""
 #: src/engine/workspace-manager/twenty-standard-application/utils/field-metadata/compute-company-standard-flat-field-metadata.util.ts
 #: src/engine/metadata-modules/page-layout-widget/constants/standard-page-layout-widget-titles.ts
 msgid "Opportunities"
-msgstr ""
+msgstr "Oportunidades"
 
 #. js-lingui-id: vTpjG9
 #: src/engine/metadata-modules/page-layout-widget/constants/standard-page-layout-widget-titles.ts
 msgid "Opportunities by Owner"
-msgstr ""
+msgstr "Oportunidades por propietario"
 
 #. js-lingui-id: 5QgKbT
 #: src/engine/workspace-manager/twenty-standard-application/utils/field-metadata/compute-company-standard-flat-field-metadata.util.ts
 msgid "Opportunities linked to the company."
-msgstr ""
+msgstr "Oportunidades vinculadas a la empresa."
 
 #. js-lingui-id: zvf8hK
 #: src/engine/workspace-manager/twenty-standard-application/utils/field-metadata/compute-workspace-member-standard-flat-field-metadata.util.ts
 msgid "Opportunities owned by the workspace member"
-msgstr ""
+msgstr "Oportunidades propiedad del miembro del espacio de trabajo"
 
 #. js-lingui-id: SV/iis
 #: src/engine/workspace-manager/twenty-standard-application/utils/object-metadata/create-standard-flat-object-metadata.util.ts
 msgid "Opportunity"
-msgstr ""
+msgstr "Oportunidad"
 
 #. js-lingui-id: WnMlKn
 #: src/engine/workspace-manager/twenty-standard-application/utils/field-metadata/compute-opportunity-standard-flat-field-metadata.util.ts
 msgid "Opportunity amount"
-msgstr ""
+msgstr "Monto de la oportunidad"
 
 #. js-lingui-id: aj3fnv
 #: src/engine/workspace-manager/twenty-standard-application/utils/field-metadata/compute-opportunity-standard-flat-field-metadata.util.ts
 msgid "Opportunity close date"
-msgstr ""
+msgstr "Fecha de cierre de la oportunidad"
 
 #. js-lingui-id: 3NYczb
 #: src/engine/workspace-manager/twenty-standard-application/utils/field-metadata/compute-opportunity-standard-flat-field-metadata.util.ts
 msgid "Opportunity company"
-msgstr ""
+msgstr "Empresa de la oportunidad"
 
 #. js-lingui-id: r3rEzW
 #: src/engine/workspace-manager/twenty-standard-application/utils/field-metadata/compute-opportunity-standard-flat-field-metadata.util.ts
 msgid "Opportunity owner"
-msgstr ""
+msgstr "Propietario de la oportunidad"
 
 #. js-lingui-id: as45IN
 #: src/engine/workspace-manager/twenty-standard-application/utils/field-metadata/compute-opportunity-standard-flat-field-metadata.util.ts
 msgid "Opportunity point of contact"
-msgstr ""
+msgstr "Punto de contacto de la oportunidad"
 
 #. js-lingui-id: Q1dzBp
 #: src/engine/workspace-manager/twenty-standard-application/utils/field-metadata/compute-opportunity-standard-flat-field-metadata.util.ts
 msgid "Opportunity record position"
-msgstr ""
+msgstr "Posición del registro de oportunidad"
 
 #. js-lingui-id: 5ugYS3
 #: src/engine/workspace-manager/twenty-standard-application/utils/field-metadata/compute-opportunity-standard-flat-field-metadata.util.ts
 msgid "Opportunity stage"
-msgstr ""
+msgstr "Etapa de la oportunidad"
 
 #. js-lingui-id: 2mFkfl
 #: src/engine/metadata-modules/flat-field-metadata/validators/utils/validate-enum-flat-field-metadata.util.ts
@@ -5166,33 +5517,33 @@ msgstr "Se requieren opciones para campos de tipo enumeración"
 #. js-lingui-id: /IX/7x
 #: src/engine/workspace-manager/twenty-standard-application/utils/field-metadata/compute-attachment-standard-flat-field-metadata.util.ts
 msgid "Other"
-msgstr ""
+msgstr "Otro"
 
 #. js-lingui-id: 4romcD
 #: src/engine/workspace-manager/workspace-migration/interceptors/utils/__tests__/build-metadata-validation-error-payload.util.spec.ts
 msgid "Other error"
-msgstr ""
+msgstr "Otro error"
 
 #. js-lingui-id: O0Z2Xr
 #: src/engine/workspace-manager/twenty-standard-application/utils/field-metadata/compute-message-channel-message-association-standard-flat-field-metadata.util.ts
 msgid "Outgoing"
-msgstr ""
+msgstr "Saliente"
 
 #. js-lingui-id: 6ua+9g
 #: src/engine/workspace-manager/twenty-standard-application/utils/field-metadata/compute-workspace-member-standard-flat-field-metadata.util.ts
 msgid "Owned opportunities"
-msgstr ""
+msgstr "Oportunidades propias"
 
 #. js-lingui-id: LtI9AS
 #: src/engine/workspace-manager/twenty-standard-application/utils/field-metadata/compute-opportunity-standard-flat-field-metadata.util.ts
 #: src/engine/metadata-modules/page-layout-widget/constants/standard-page-layout-widget-titles.ts
 msgid "Owner"
-msgstr ""
+msgstr "Propietario"
 
 #. js-lingui-id: AODALE
 #: src/engine/workspace-manager/twenty-standard-application/utils/field-metadata/compute-dashboard-standard-flat-field-metadata.util.ts
 msgid "Page Layout ID"
-msgstr ""
+msgstr "ID de diseño de página"
 
 #. js-lingui-id: ZKtamk
 #: src/engine/workspace-manager/workspace-migration/workspace-migration-builder/validators/services/flat-page-layout-validator.service.ts
@@ -5277,14 +5628,18 @@ msgstr "No se encontró el widget de diseño de página para actualizar"
 
 #. js-lingui-id: hGYqrE
 #: src/engine/workspace-manager/workspace-migration/workspace-migration-builder/validators/services/flat-page-layout-widget-validator.service.ts
-msgid "Page layout widget with universal identifier {flatPageLayoutWidgetUniversalIdentifier} already exists"
-msgstr "El widget de diseño de página con el identificador universal {flatPageLayoutWidgetUniversalIdentifier} ya existe"
+msgid ""
+"Page layout widget with universal identifier "
+"{flatPageLayoutWidgetUniversalIdentifier} already exists"
+msgstr ""
+"El widget de diseño de página con el identificador universal "
+"{flatPageLayoutWidgetUniversalIdentifier} ya existe"
 
 #. js-lingui-id: RDkmYK
 #: src/engine/workspace-manager/workspace-migration/workspace-migration-builder/validators/services/flat-navigation-menu-item-validator.service.ts
 #: src/engine/workspace-manager/workspace-migration/workspace-migration-builder/validators/services/flat-navigation-menu-item-validator.service.ts
 msgid "pageLayoutId is required for PAGE_LAYOUT type"
-msgstr ""
+msgstr "pageLayoutId es obligatorio para el tipo PAGE_LAYOUT"
 
 #. js-lingui-id: T1gSWA
 #: src/engine/workspace-manager/workspace-migration/workspace-migration-builder/validators/services/flat-navigation-menu-item-validator.service.ts
@@ -5300,7 +5655,8 @@ msgstr "Elemento padre del menú de navegación no encontrado"
 #: src/engine/workspace-manager/workspace-migration/workspace-migration-builder/validators/services/flat-row-level-permission-predicate-group-validator.service.ts
 #: src/engine/workspace-manager/workspace-migration/workspace-migration-builder/validators/services/flat-row-level-permission-predicate-group-validator.service.ts
 msgid "Parent row level permission predicate group not found"
-msgstr "No se encontró el grupo padre de predicados de permisos a nivel de fila"
+msgstr ""
+"No se encontró el grupo padre de predicados de permisos a nivel de fila"
 
 #. js-lingui-id: 6OzP7Y
 #: src/engine/workspace-manager/workspace-migration/workspace-migration-builder/validators/services/flat-view-filter-group-validator.service.ts
@@ -5317,8 +5673,12 @@ msgstr "La contraseña es demasiado débil."
 
 #. js-lingui-id: cd6AP5
 #: src/engine/core-modules/auth/services/reset-password.service.ts
-msgid "Password reset token has already been generated. Please wait for {timeToWait} to generate again."
-msgstr "Ya se ha generado un token de restablecimiento de contraseña. Por favor, espera {timeToWait} para generarlo de nuevo."
+msgid ""
+"Password reset token has already been generated. Please wait for "
+"{timeToWait} to generate again."
+msgstr ""
+"Ya se ha generado un token de restablecimiento de contraseña. Por favor, "
+"espera {timeToWait} para generarlo de nuevo."
 
 #. js-lingui-id: wT0H4O
 #: src/engine/core-modules/auth/services/sign-in-up.service.ts
@@ -5328,94 +5688,111 @@ msgstr "Contraseña demasiado débil"
 #. js-lingui-id: DpnDl6
 #: src/engine/workspace-manager/workspace-migration/workspace-migration-builder/validators/services/flat-command-menu-item-validator.service.ts
 msgid "Payload is required for navigation items"
-msgstr ""
+msgstr "El payload es obligatorio para elementos de navegación"
 
 #. js-lingui-id: Enmszs
 #: src/engine/workspace-manager/workspace-migration/workspace-migration-builder/validators/services/flat-command-menu-item-validator.service.ts
 msgid "payload is required when engineComponentKey is NAVIGATION"
-msgstr ""
+msgstr "el payload es obligatorio cuando engineComponentKey es NAVIGATION"
 
 #. js-lingui-id: QXVtcO
 #: src/engine/workspace-manager/workspace-migration/workspace-migration-builder/validators/services/flat-command-menu-item-validator.service.ts
 msgid "payload must contain either a \"path\" or \"objectMetadataItemId\" property"
-msgstr ""
+msgstr "el payload debe contener una propiedad \"path\" u \"objectMetadataItemId\""
 
 #. js-lingui-id: Z+s6mX
 #: src/engine/workspace-manager/workspace-migration/workspace-migration-builder/validators/services/flat-command-menu-item-validator.service.ts
-msgid "Payload must contain either a path or an object metadata item identifier"
+msgid ""
+"Payload must contain either a path or an object metadata item identifier"
 msgstr ""
+"El payload debe contener una ruta o un identificador de elemento de "
+"metadatos de objeto"
 
 #. js-lingui-id: 1wdjme
 #: src/engine/workspace-manager/twenty-standard-application/utils/object-metadata/create-standard-flat-object-metadata.util.ts
 #: src/engine/workspace-manager/twenty-standard-application/utils/field-metadata/compute-company-standard-flat-field-metadata.util.ts
 #: src/engine/metadata-modules/page-layout-widget/constants/standard-page-layout-widget-titles.ts
 msgid "People"
-msgstr ""
+msgstr "Personas"
 
 #. js-lingui-id: E1zc7W
 #: src/engine/workspace-manager/twenty-standard-application/utils/field-metadata/compute-company-standard-flat-field-metadata.util.ts
 msgid "People linked to the company."
-msgstr ""
+msgstr "Personas vinculadas a la empresa."
 
 #. js-lingui-id: 3zRddX
 #: src/engine/metadata-modules/permission-flag/permission-flag.exception.ts
 msgid "Permission flag already exists."
-msgstr ""
+msgstr "El indicador de permiso ya existe."
 
 #. js-lingui-id: vUfYBs
 #: src/engine/workspace-manager/workspace-migration/workspace-migration-builder/validators/services/flat-permission-flag-validator.service.ts
 msgid "Permission flag definition already exists"
-msgstr ""
+msgstr "La definición de indicador de permiso ya existe"
 
 #. js-lingui-id: si69+A
 #: src/engine/workspace-manager/workspace-migration/workspace-migration-builder/validators/services/flat-permission-flag-validator.service.ts
 msgid "Permission flag definition key cannot be changed after creation"
 msgstr ""
+"La clave de definición de indicador de permiso no se puede cambiar después "
+"de la creación"
 
 #. js-lingui-id: vCvEfM
 #: src/engine/workspace-manager/workspace-migration/workspace-migration-builder/validators/services/flat-permission-flag-validator.service.ts
 msgid "Permission flag definition key is required"
-msgstr ""
+msgstr "La clave de definición de indicador de permiso es obligatoria"
 
 #. js-lingui-id: IPm2ty
 #: src/engine/workspace-manager/workspace-migration/workspace-migration-builder/validators/services/flat-permission-flag-validator.service.ts
 #: src/engine/workspace-manager/workspace-migration/workspace-migration-builder/validators/services/flat-permission-flag-validator.service.ts
 msgid "Permission flag definition not found"
-msgstr ""
+msgstr "Definición de indicador de permiso no encontrada"
 
 #. js-lingui-id: /amTA5
 #: src/engine/workspace-manager/workspace-migration/workspace-migration-builder/validators/services/flat-permission-flag-validator.service.ts
 #: src/engine/workspace-manager/workspace-migration/workspace-migration-builder/validators/services/flat-permission-flag-validator.service.ts
-msgid "Permission flag definition permission type must be 'settings' or 'tool'"
+msgid ""
+"Permission flag definition permission type must be 'settings' or 'tool'"
 msgstr ""
+"El tipo de permiso de definición de indicador de permiso debe ser 'settings'"
+" o 'tool'"
 
 #. js-lingui-id: dKSPBk
 #: src/engine/workspace-manager/workspace-migration/workspace-migration-builder/validators/services/flat-permission-flag-validator.service.ts
 msgid "Permission flag definition to delete not found"
-msgstr ""
+msgstr "Definición de indicador de permiso a eliminar no encontrada"
 
 #. js-lingui-id: 5phRcJ
 #: src/engine/workspace-manager/workspace-migration/workspace-migration-builder/validators/services/flat-permission-flag-validator.service.ts
 msgid "Permission flag definition to update not found"
-msgstr ""
+msgstr "Definición de indicador de permiso a actualizar no encontrada"
 
 #. js-lingui-id: KNBagU
 #. placeholder {0}: flatPermissionFlagToValidate.key
 #: src/engine/workspace-manager/workspace-migration/workspace-migration-builder/validators/services/flat-permission-flag-validator.service.ts
-msgid "Permission flag definition with key \"{0}\" is already registered in this workspace."
+msgid ""
+"Permission flag definition with key \"{0}\" is already registered in this "
+"workspace."
 msgstr ""
+"La definición de indicador de permiso con clave \"{0}\" ya está registrada "
+"en este espacio de trabajo."
 
 #. js-lingui-id: FxbCOo
 #. placeholder {0}: existing.key
 #: src/engine/workspace-manager/workspace-migration/workspace-migration-builder/validators/services/flat-permission-flag-validator.service.ts
 msgid "Permission flag definition with key {0} is still assigned to a role"
 msgstr ""
+"La definición de indicador de permiso con clave {0} aún está asignada a un "
+"rol"
 
 #. js-lingui-id: px8Wqt
 #. placeholder {0}: flatPermissionFlagToValidate.universalIdentifier
 #: src/engine/workspace-manager/workspace-migration/workspace-migration-builder/validators/services/flat-permission-flag-validator.service.ts
-msgid "Permission flag definition with universal identifier {0} already exists"
+msgid ""
+"Permission flag definition with universal identifier {0} already exists"
 msgstr ""
+"La definición de indicador de permiso con identificador universal {0} ya "
+"existe"
 
 #. js-lingui-id: qG245w
 #: src/engine/workspace-manager/workspace-migration/workspace-migration-builder/validators/services/flat-role-permission-flag-validator.service.ts
@@ -5426,12 +5803,12 @@ msgstr "El indicador de permiso para este rol y esta configuración ya existe"
 #. js-lingui-id: 7A0rAw
 #: src/engine/metadata-modules/permission-flag/permission-flag.exception.ts
 msgid "Permission flag is still assigned to a role."
-msgstr ""
+msgstr "El indicador de permiso aún está asignado a un rol."
 
 #. js-lingui-id: 09NaoU
 #: src/engine/metadata-modules/permission-flag/permission-flag.exception.ts
 msgid "Permission flag key cannot be changed."
-msgstr ""
+msgstr "La clave del indicador de permiso no se puede cambiar."
 
 #. js-lingui-id: 2mZr45
 #: src/engine/workspace-manager/workspace-migration/workspace-migration-builder/validators/services/flat-role-permission-flag-validator.service.ts
@@ -5444,7 +5821,7 @@ msgstr "Indicador de permiso no encontrado"
 #. js-lingui-id: 3qYOk2
 #: src/engine/metadata-modules/permission-flag/permission-flag.exception.ts
 msgid "Permission flag not found."
-msgstr ""
+msgstr "Indicador de permiso no encontrado."
 
 #. js-lingui-id: dqLRwc
 #: src/engine/workspace-manager/workspace-migration/workspace-migration-builder/validators/services/flat-role-permission-flag-validator.service.ts
@@ -5468,43 +5845,53 @@ msgstr "Permiso no encontrado."
 #: src/engine/workspace-manager/twenty-standard-application/utils/field-metadata/compute-calendar-event-participant-standard-flat-field-metadata.util.ts
 #: src/engine/workspace-manager/twenty-standard-application/utils/field-metadata/compute-calendar-event-participant-standard-flat-field-metadata.util.ts
 msgid "Person"
-msgstr ""
+msgstr "Persona"
 
 #. js-lingui-id: c3Qq6o
 #: src/engine/workspace-manager/twenty-standard-application/utils/field-metadata/compute-person-standard-flat-field-metadata.util.ts
 msgid "Person record Position"
-msgstr ""
+msgstr "Posición del registro de persona"
 
 #. js-lingui-id: m2ivgq
 #: src/engine/workspace-manager/twenty-standard-application/utils/field-metadata/compute-person-standard-flat-field-metadata.util.ts
 msgid "Phones"
-msgstr ""
+msgstr "Teléfonos"
 
 #. js-lingui-id: RrxR7k
 #. placeholder {0}: flatField.label
 #: src/engine/metadata-modules/index-metadata/services/index-metadata.service.ts
-msgid "Pick a specific sub-field of \"{0}\" — composite fields can't be indexed as a whole."
+msgid ""
+"Pick a specific sub-field of \"{0}\" — composite fields can't be indexed as "
+"a whole."
 msgstr ""
+"Elige un subcampo específico de \"{0}\" — los campos compuestos no se pueden"
+" indexar como un todo."
 
 #. js-lingui-id: TtfDdb
 #: src/engine/metadata-modules/index-metadata/services/index-metadata.service.ts
 msgid "Pick at least one field for the index."
-msgstr ""
+msgstr "Elige al menos un campo para el índice."
 
 #. js-lingui-id: f0YMH6
 #: src/engine/metadata-modules/page-layout-widget/constants/standard-page-layout-widget-titles.ts
 msgid "Pipeline Value by Stage"
-msgstr ""
+msgstr "Valor del pipeline por etapa"
 
 #. js-lingui-id: rxi3R2
 #: src/engine/core-modules/imap-smtp-caldav-connection/services/imap-smtp-caldav-connection-validator.service.ts
-msgid "Please check your connection settings. Make sure the server host, port, and password are correct."
-msgstr "Por favor, revise su configuración de conexión. Asegúrese de que el host del servidor, el puerto y la contraseña sean correctos."
+msgid ""
+"Please check your connection settings. Make sure the server host, port, and "
+"password are correct."
+msgstr ""
+"Por favor, revise su configuración de conexión. Asegúrese de que el host del"
+" servidor, el puerto y la contraseña sean correctos."
 
 #. js-lingui-id: PdKZim
 #: src/engine/core-modules/admin-panel/admin-panel.exception.ts
 msgid "Please choose an end date and time after the start date and time."
 msgstr ""
+"Elige una fecha y hora de finalización posteriores a la fecha y hora de "
+"inicio."
 
 #. js-lingui-id: mqzu5F
 #: src/engine/core-modules/email-verification/services/email-verification.service.ts
@@ -5514,7 +5901,7 @@ msgstr "Por favor, confirma tu correo electrónico actualizado"
 #. js-lingui-id: qgasuj
 #: src/engine/core-modules/imap-smtp-caldav-connection/services/imap-smtp-caldav-connection-validator.service.ts
 msgid "Please provide a password for this connection."
-msgstr ""
+msgstr "Proporciona una contraseña para esta conexión."
 
 #. js-lingui-id: NR22yi
 #: src/engine/workspace-manager/workspace-migration/workspace-migration-builder/validators/services/flat-webhook-validator.service.ts
@@ -5525,7 +5912,9 @@ msgstr "Por favor, proporcione una URL HTTP o HTTPS válida"
 #. js-lingui-id: RDvKTq
 #: src/engine/core-modules/imap-smtp-caldav-connection/services/imap-smtp-caldav-connection-validator.service.ts
 msgid "Please provide connection details to configure your email account."
-msgstr "Por favor, proporcione los detalles de conexión para configurar su cuenta de correo electrónico."
+msgstr ""
+"Por favor, proporcione los detalles de conexión para configurar su cuenta de"
+" correo electrónico."
 
 #. js-lingui-id: sa9Q+R
 #: src/engine/api/common/common-query-runners/common-merge-many-query-runner.service.ts
@@ -5541,7 +5930,9 @@ msgstr "Utilice un dominio de correo electrónico corporativo."
 #: src/modules/workspace-member/query-hooks/workspace-member-delete-one.pre-query.hook.ts
 #: src/modules/workspace-member/query-hooks/workspace-member-delete-many.pre-query.hook.ts
 msgid "Please use Settings to remove a workspace member."
-msgstr "Por favor, use Configuración para eliminar a un miembro del espacio de trabajo."
+msgstr ""
+"Por favor, use Configuración para eliminar a un miembro del espacio de "
+"trabajo."
 
 #. js-lingui-id: f8ypJ4
 #: src/engine/core-modules/auth/auth.exception.ts
@@ -5552,7 +5943,7 @@ msgstr "Utilice el inicio de sesión único para autenticarse."
 #: src/engine/workspace-manager/twenty-standard-application/utils/field-metadata/compute-opportunity-standard-flat-field-metadata.util.ts
 #: src/engine/metadata-modules/page-layout-widget/constants/standard-page-layout-widget-titles.ts
 msgid "Point of Contact"
-msgstr ""
+msgstr "Punto de contacto"
 
 #. js-lingui-id: p/78dY
 #: src/engine/workspace-manager/twenty-standard-application/utils/field-metadata/compute-workspace-member-standard-flat-field-metadata.util.ts
@@ -5580,12 +5971,16 @@ msgstr ""
 #: src/engine/workspace-manager/twenty-standard-application/utils/field-metadata/compute-blocklist-standard-flat-field-metadata.util.ts
 #: src/engine/workspace-manager/twenty-standard-application/utils/field-metadata/compute-attachment-standard-flat-field-metadata.util.ts
 msgid "Position"
-msgstr ""
+msgstr "Posición"
 
 #. js-lingui-id: c7uZDh
 #: src/engine/workspace-manager/workspace-migration/workspace-migration-builder/validators/services/flat-page-layout-widget-validator.service.ts
-msgid "Position layoutMode \"{layoutMode}\" does not match tab layoutMode \"{tabLayoutMode}\""
-msgstr "El layoutMode de la posición \"{layoutMode}\" no coincide con el layoutMode de la pestaña \"{tabLayoutMode}\""
+msgid ""
+"Position layoutMode \"{layoutMode}\" does not match tab layoutMode "
+"\"{tabLayoutMode}\""
+msgstr ""
+"El layoutMode de la posición \"{layoutMode}\" no coincide con el layoutMode "
+"de la pestaña \"{tabLayoutMode}\""
 
 #. js-lingui-id: rFj1tD
 #: src/engine/workspace-manager/workspace-migration/workspace-migration-builder/validators/services/flat-navigation-menu-item-validator.service.ts
@@ -5598,37 +5993,49 @@ msgstr "La posición debe ser un número finito"
 #. js-lingui-id: TTHIbk
 #: src/engine/workspace-manager/twenty-standard-application/utils/field-metadata/compute-workspace-member-standard-flat-field-metadata.util.ts
 msgid "Preferred color scheme"
-msgstr ""
+msgstr "Esquema de colores preferido"
 
 #. js-lingui-id: 5v4qYi
 #: src/engine/workspace-manager/twenty-standard-application/utils/field-metadata/compute-workspace-member-standard-flat-field-metadata.util.ts
 msgid "Preferred language"
-msgstr ""
+msgstr "Idioma preferido"
 
 #. js-lingui-id: FOoDGS
 #: src/engine/workspace-manager/twenty-standard-application/utils/field-metadata/compute-attachment-standard-flat-field-metadata.util.ts
 msgid "Presentation"
-msgstr ""
+msgstr "Presentación"
 
 #. js-lingui-id: +DJKfQ
 #: src/engine/metadata-modules/flat-page-layout-widget/validators/utils/validate-bar-chart-configuration.util.ts
 msgid "Primary axis group by field is required for bar chart"
-msgstr "El campo de agrupación del eje principal es obligatorio para el gráfico de barras"
+msgstr ""
+"El campo de agrupación del eje principal es obligatorio para el gráfico de "
+"barras"
 
 #. js-lingui-id: CV1zCG
 #: src/engine/metadata-modules/flat-page-layout-widget/validators/utils/validate-bar-chart-configuration.util.ts
-msgid "Primary axis group by field is required for bar chart widget \"{widgetTitle}\""
-msgstr "El campo de agrupación del eje principal es obligatorio para el widget de gráfico de barras \"{widgetTitle}\""
+msgid ""
+"Primary axis group by field is required for bar chart widget "
+"\"{widgetTitle}\""
+msgstr ""
+"El campo de agrupación del eje principal es obligatorio para el widget de "
+"gráfico de barras \"{widgetTitle}\""
 
 #. js-lingui-id: SdXGbu
 #: src/engine/metadata-modules/flat-page-layout-widget/validators/utils/validate-line-chart-configuration.util.ts
 msgid "Primary axis group by field is required for line chart"
-msgstr "El campo de agrupación del eje principal es obligatorio para el gráfico de líneas"
+msgstr ""
+"El campo de agrupación del eje principal es obligatorio para el gráfico de "
+"líneas"
 
 #. js-lingui-id: v874L+
 #: src/engine/metadata-modules/flat-page-layout-widget/validators/utils/validate-line-chart-configuration.util.ts
-msgid "Primary axis group by field is required for line chart widget \"{widgetTitle}\""
-msgstr "El campo de agrupación del eje principal es obligatorio para el widget de gráfico de líneas \"{widgetTitle}\""
+msgid ""
+"Primary axis group by field is required for line chart widget "
+"\"{widgetTitle}\""
+msgstr ""
+"El campo de agrupación del eje principal es obligatorio para el widget de "
+"gráfico de líneas \"{widgetTitle}\""
 
 #. js-lingui-id: t/0e9D
 #: src/engine/workspace-manager/workspace-migration/workspace-migration-builder/validators/utils/validate-agent-required-properties.util.ts
@@ -5639,12 +6046,12 @@ msgstr "El prompt no puede estar vacío"
 #. js-lingui-id: OTJNm9
 #: src/engine/workspace-manager/workspace-migration/workspace-migration-builder/validators/utils/validate-role-required-properties-are-defined.util.ts
 msgid "Property {property} is required for role"
-msgstr ""
+msgstr "La propiedad {property} es obligatoria para el rol"
 
 #. js-lingui-id: qcybNQ
 #: src/engine/workspace-manager/twenty-standard-application/utils/field-metadata/compute-opportunity-standard-flat-field-metadata.util.ts
 msgid "Proposal"
-msgstr ""
+msgstr "Propuesta"
 
 #. js-lingui-id: dtGxRz
 #: src/engine/core-modules/record-transformer/utils/transform-phones-value.util.ts
@@ -5659,7 +6066,8 @@ msgstr "El código de país proporcionado e inferido están en conflicto"
 #. js-lingui-id: HZ45ox
 #: src/engine/core-modules/record-transformer/utils/transform-phones-value.util.ts
 msgid "Provided country code and calling code are conflicting"
-msgstr "El código de país proporcionado y el código de llamada están en conflicto"
+msgstr ""
+"El código de país proporcionado y el código de llamada están en conflicto"
 
 #. js-lingui-id: A4Ohxb
 #: src/engine/core-modules/record-transformer/utils/transform-phones-value.util.ts
@@ -5678,8 +6086,12 @@ msgstr "Dominio público no encontrado."
 
 #. js-lingui-id: Capzni
 #: src/engine/core-modules/dns-manager/services/dns-manager.service.ts
-msgid "Public domain URL is not defined. Please set the PUBLIC_DOMAIN_URL environment variable"
-msgstr "La URL de dominio público no está definida. Por favor, establezca la variable de entorno PUBLIC_DOMAIN_URL"
+msgid ""
+"Public domain URL is not defined. Please set the PUBLIC_DOMAIN_URL "
+"environment variable"
+msgstr ""
+"La URL de dominio público no está definida. Por favor, establezca la "
+"variable de entorno PUBLIC_DOMAIN_URL"
 
 #. js-lingui-id: vVCf2E
 #: src/modules/dashboard/chart-data/exceptions/chart-data.exception.ts
@@ -5699,7 +6111,9 @@ msgstr "La consulta agotó el tiempo de espera. Por favor, inténtelo de nuevo."
 #. js-lingui-id: xD2MTL
 #: src/engine/core-modules/throttler/throttler.exception.ts
 msgid "Rate limit reached. Please try again later."
-msgstr "Se alcanzó el límite de solicitudes. Por favor, inténtelo de nuevo más tarde."
+msgstr ""
+"Se alcanzó el límite de solicitudes. Por favor, inténtelo de nuevo más "
+"tarde."
 
 #. js-lingui-id: 8G8dJM
 #: src/engine/metadata-modules/permissions/permissions.exception.ts
@@ -5709,7 +6123,7 @@ msgstr "No se permiten consultas SQL sin procesar."
 #. js-lingui-id: YfbwOB
 #: src/engine/workspace-manager/twenty-standard-application/utils/field-metadata/compute-message-standard-flat-field-metadata.util.ts
 msgid "Received At"
-msgstr ""
+msgstr "Recibido el"
 
 #. js-lingui-id: EESfI5
 #: src/engine/twenty-orm/exceptions/twenty-orm.exception.ts
@@ -5724,19 +6138,19 @@ msgstr "Registro no encontrado."
 #. js-lingui-id: LVUF8D
 #: src/engine/metadata-modules/view/services/view-widget-upsert.service.ts
 msgid "Record table widget has no associated view"
-msgstr ""
+msgstr "El widget de tabla de registros no tiene vista asociada"
 
 #. js-lingui-id: KnnILY
 #: src/engine/metadata-modules/view/services/view-widget-upsert.service.ts
 #: src/engine/metadata-modules/view/services/view-widget-upsert.service.ts
 msgid "Record table widget not found"
-msgstr ""
+msgstr "Widget de tabla de registros no encontrado"
 
 #. js-lingui-id: 9gXJw8
 #: src/engine/workspace-manager/twenty-standard-application/utils/field-metadata/compute-calendar-channel-event-association-standard-flat-field-metadata.util.ts
 #: src/engine/workspace-manager/twenty-standard-application/utils/field-metadata/compute-calendar-channel-event-association-standard-flat-field-metadata.util.ts
 msgid "Recurring Event ID"
-msgstr ""
+msgstr "ID de evento recurrente"
 
 #. js-lingui-id: 1GvzpH
 #: src/engine/metadata-modules/connected-account/exceptions/connected-account-refresh-tokens.exception.ts
@@ -5751,7 +6165,7 @@ msgstr "Registro relacionado no encontrado."
 #. js-lingui-id: 2LpFdR
 #: src/engine/workspace-manager/twenty-standard-application/utils/field-metadata/compute-workspace-member-standard-flat-field-metadata.util.ts
 msgid "Related user email address"
-msgstr ""
+msgstr "Dirección de correo electrónico del usuario relacionado"
 
 #. js-lingui-id: 2LXGtF
 #: src/engine/metadata-modules/field-metadata/field-metadata.exception.ts
@@ -5773,18 +6187,19 @@ msgstr "Metadatos de destino de campo de relación no encontrados"
 #: src/engine/api/graphql/graphql-query-runner/graphql-query-parsers/graphql-query-filter/graphql-query-filter-field.parser.ts
 #: src/engine/api/graphql/graphql-query-runner/graphql-query-parsers/graphql-query-filter/graphql-query-filter-field.parser.ts
 msgid "Relation filter is misconfigured"
-msgstr ""
+msgstr "El filtro de relación está mal configurado"
 
 #. js-lingui-id: 1RF4/e
 #: src/engine/api/graphql/graphql-query-runner/graphql-query-parsers/graphql-query-filter/graphql-query-filter-field.parser.ts
 msgid "Relation filter is not supported here"
-msgstr ""
+msgstr "El filtro de relación no es compatible aquí"
 
 #. js-lingui-id: L8AY9P
 #: src/engine/api/graphql/graphql-query-runner/graphql-query-parsers/graphql-query-filter/graphql-query-filter-field.parser.ts
 #: src/engine/api/common/common-args-processors/filter-arg-processor/filter-arg-processor.service.ts
 msgid "Relation filters can only traverse one relation deep"
 msgstr ""
+"Los filtros de relación solo pueden recorrer una relación de profundidad"
 
 #. js-lingui-id: 83atrc
 #: src/engine/metadata-modules/field-metadata/field-metadata.exception.ts
@@ -5796,7 +6211,7 @@ msgstr "La relación no está habilitada para este campo."
 #: src/engine/workspace-manager/twenty-standard-application/utils/field-metadata/compute-note-standard-flat-field-metadata.util.ts
 #: src/engine/metadata-modules/view-field-group/constants/standard-view-field-group-names.ts
 msgid "Relations"
-msgstr ""
+msgstr "Relaciones"
 
 #. js-lingui-id: PWdFkY
 #: src/engine/workspace-manager/workspace-migration/workspace-migration-builder/validators/services/flat-field-metadata-validator.service.ts
@@ -5814,7 +6229,7 @@ msgstr "Los objetos remotos no son compatibles todavía"
 #. js-lingui-id: yFLhnq
 #: src/engine/workspace-manager/workspace-migration/workspace-migration-builder/validators/services/flat-permission-flag-validator.service.ts
 msgid "Remove this permission from all roles before deleting it"
-msgstr ""
+msgstr "Elimina este permiso de todos los roles antes de eliminarlo"
 
 #. js-lingui-id: pCsIQQ
 #: src/engine/core-modules/email-verification/email-verification-exception-filter.util.ts
@@ -5824,37 +6239,40 @@ msgstr "La solicitud ha expirado, por favor intente de nuevo."
 #. js-lingui-id: uAJ5BF
 #: src/engine/core-modules/file-storage/utils/validate-safe-relative-path.util.ts
 msgid "Resource path contains null bytes"
-msgstr ""
+msgstr "La ruta del recurso contiene bytes nulos"
 
 #. js-lingui-id: PxO731
 #: src/engine/core-modules/file-storage/utils/validate-path-segments-safety.util.ts
 msgid "Resource path exceeds maximum length of {MAX_PATH_LENGTH} characters"
 msgstr ""
+"La ruta del recurso excede la longitud máxima de {MAX_PATH_LENGTH} "
+"caracteres"
 
 #. js-lingui-id: s7cqdG
 #: src/engine/core-modules/file-storage/utils/validate-safe-relative-path.util.ts
 msgid "Resource path must be relative, not absolute"
-msgstr ""
+msgstr "La ruta del recurso debe ser relativa, no absoluta"
 
 #. js-lingui-id: Q7KCby
 #: src/engine/core-modules/file-storage/utils/validate-safe-relative-path.util.ts
 msgid "Resource path must not be empty"
-msgstr ""
+msgstr "La ruta del recurso no debe estar vacía"
 
 #. js-lingui-id: lS6C4L
 #: src/engine/core-modules/file-storage/utils/validate-safe-relative-path.util.ts
 msgid "Resource path must not contain backslashes"
-msgstr ""
+msgstr "La ruta del recurso no debe contener barras invertidas"
 
 #. js-lingui-id: 1mnXbh
 #: src/engine/core-modules/file-storage/utils/validate-path-segments-safety.util.ts
 msgid "Resource path must not contain empty segments or trailing slashes"
 msgstr ""
+"La ruta del recurso no debe contener segmentos vacíos ni barras finales"
 
 #. js-lingui-id: SkT3Lf
 #: src/engine/core-modules/file-storage/utils/validate-safe-relative-path.util.ts
 msgid "Resource path must not contain path traversal (..)"
-msgstr ""
+msgstr "La ruta del recurso no debe contener recorrido de ruta (..)"
 
 #. js-lingui-id: KPIUoa
 #: src/engine/workspace-manager/workspace-migration/workspace-migration-builder/validators/utils/validate-agent-response-format.util.ts
@@ -5875,36 +6293,36 @@ msgstr "El formato de respuesta con tipo \"text\" no debe incluir un esquema"
 #: src/engine/workspace-manager/twenty-standard-application/utils/field-metadata/compute-calendar-event-participant-standard-flat-field-metadata.util.ts
 #: src/engine/workspace-manager/twenty-standard-application/utils/field-metadata/compute-calendar-event-participant-standard-flat-field-metadata.util.ts
 msgid "Response Status"
-msgstr ""
+msgstr "Estado de respuesta"
 
 #. js-lingui-id: 1AYnSb
 #: src/engine/metadata-modules/page-layout-widget/constants/standard-page-layout-widget-titles.ts
 msgid "Revenue Timeline"
-msgstr ""
+msgstr "Línea de tiempo de ingresos"
 
 #. js-lingui-id: GDvlUT
 #: src/engine/workspace-manager/twenty-standard-application/utils/field-metadata/compute-message-participant-standard-flat-field-metadata.util.ts
 #: src/engine/workspace-manager/twenty-standard-application/utils/field-metadata/compute-message-participant-standard-flat-field-metadata.util.ts
 msgid "Role"
-msgstr ""
+msgstr "Rol"
 
 #. js-lingui-id: QbW1ho
 #: src/engine/workspace-manager/workspace-migration/workspace-migration-builder/validators/utils/validate-flat-role-target-assignation-availability.util.ts
 #: src/engine/workspace-manager/workspace-migration/workspace-migration-builder/validators/utils/validate-flat-role-target-assignation-availability.util.ts
 msgid "Role \"{roleLabel}\" cannot be assigned to agents"
-msgstr ""
+msgstr "El rol \"{roleLabel}\" no puede asignarse a agentes"
 
 #. js-lingui-id: u1Fm8i
 #: src/engine/workspace-manager/workspace-migration/workspace-migration-builder/validators/utils/validate-flat-role-target-assignation-availability.util.ts
 #: src/engine/workspace-manager/workspace-migration/workspace-migration-builder/validators/utils/validate-flat-role-target-assignation-availability.util.ts
 msgid "Role \"{roleLabel}\" cannot be assigned to API keys"
-msgstr ""
+msgstr "El rol \"{roleLabel}\" no puede asignarse a claves API"
 
 #. js-lingui-id: 9ZQkou
 #: src/engine/workspace-manager/workspace-migration/workspace-migration-builder/validators/utils/validate-flat-role-target-assignation-availability.util.ts
 #: src/engine/workspace-manager/workspace-migration/workspace-migration-builder/validators/utils/validate-flat-role-target-assignation-availability.util.ts
 msgid "Role \"{roleLabel}\" cannot be assigned to users"
-msgstr ""
+msgstr "El rol \"{roleLabel}\" no puede asignarse a usuarios"
 
 #. js-lingui-id: ViBevc
 #: src/engine/metadata-modules/role/exceptions/role-target.exception.ts
@@ -5932,7 +6350,7 @@ msgstr "El rol debe tener al menos un destino."
 #. js-lingui-id: BEtj6u
 #: src/engine/workspace-manager/workspace-migration/interceptors/utils/__tests__/build-metadata-validation-error-payload.util.spec.ts
 msgid "Role name is invalid"
-msgstr ""
+msgstr "El nombre del rol es inválido"
 
 #. js-lingui-id: MvTCyk
 #: src/engine/workspace-manager/workspace-migration/workspace-migration-builder/validators/services/flat-row-level-permission-predicate-validator.service.ts
@@ -5964,7 +6382,7 @@ msgstr ""
 #: src/engine/workspace-manager/workspace-migration/workspace-migration-builder/validators/services/flat-field-permission-validator.service.ts
 #: src/engine/workspace-manager/workspace-migration/workspace-migration-builder/validators/services/flat-field-permission-validator.service.ts
 msgid "Role not found"
-msgstr ""
+msgstr "Rol no encontrado"
 
 #. js-lingui-id: /BTyf+
 #: src/engine/metadata-modules/row-level-permission-predicate/exceptions/row-level-permission-predicate.exception.ts
@@ -5978,13 +6396,14 @@ msgstr "Rol no encontrado."
 #. js-lingui-id: zlsZBc
 #: src/engine/workspace-manager/workspace-migration/workspace-migration-builder/validators/services/flat-role-permission-flag-validator.service.ts
 msgid "Role permission flag already exists"
-msgstr ""
+msgstr "El indicador de permiso de rol ya existe"
 
 #. js-lingui-id: 2NHP+l
 #. placeholder {0}: flatRolePermissionFlagToValidate.universalIdentifier
 #: src/engine/workspace-manager/workspace-migration/workspace-migration-builder/validators/services/flat-role-permission-flag-validator.service.ts
 msgid "Role permission flag with universal identifier {0} already exists"
 msgstr ""
+"El indicador de permiso de rol con identificador universal {0} ya existe"
 
 #. js-lingui-id: K+Gn31
 #: src/engine/workspace-manager/workspace-migration/workspace-migration-builder/validators/services/flat-role-target-validator.service.ts
@@ -5999,8 +6418,11 @@ msgstr "Falta el identificador del destino del rol."
 #. js-lingui-id: oCyyzG
 #: src/engine/workspace-manager/workspace-migration/workspace-migration-builder/validators/utils/validate-flat-role-target-targets-only-one-entity.util.ts
 #: src/engine/workspace-manager/workspace-migration/workspace-migration-builder/validators/utils/validate-flat-role-target-targets-only-one-entity.util.ts
-msgid "Role target must have exactly one of: apiKeyId, userWorkspaceId, or agentId"
+msgid ""
+"Role target must have exactly one of: apiKeyId, userWorkspaceId, or agentId"
 msgstr ""
+"El objetivo de rol debe tener exactamente uno de: apiKeyId, userWorkspaceId "
+"o agentId"
 
 #. js-lingui-id: oNYUjk
 #: src/engine/workspace-manager/workspace-migration/workspace-migration-builder/validators/services/flat-role-target-validator.service.ts
@@ -6008,7 +6430,7 @@ msgstr ""
 #: src/engine/workspace-manager/workspace-migration/workspace-migration-builder/validators/services/flat-role-target-validator.service.ts
 #: src/engine/workspace-manager/workspace-migration/workspace-migration-builder/validators/services/flat-role-target-validator.service.ts
 msgid "Role target not found"
-msgstr ""
+msgstr "Objetivo de rol no encontrado"
 
 #. js-lingui-id: gz6uii
 #: src/engine/metadata-modules/role/exceptions/role-target.exception.ts
@@ -6049,7 +6471,8 @@ msgstr "El predicado de permisos a nivel de fila ya existe"
 #: src/engine/metadata-modules/row-level-permission-predicate/exceptions/row-level-permission-predicate.exception.ts
 #: src/engine/metadata-modules/row-level-permission-predicate/exceptions/row-level-permission-predicate-group.exception.ts
 msgid "Row level permission predicate feature is disabled."
-msgstr "La función de predicado de permisos a nivel de fila está deshabilitada."
+msgstr ""
+"La función de predicado de permisos a nivel de fila está deshabilitada."
 
 #. js-lingui-id: lG+q53
 #: src/engine/workspace-manager/workspace-migration/workspace-migration-builder/validators/services/flat-row-level-permission-predicate-group-validator.service.ts
@@ -6073,18 +6496,26 @@ msgstr "No se encontró el grupo de predicados de permisos a nivel de fila."
 #: src/engine/workspace-manager/workspace-migration/workspace-migration-builder/validators/services/flat-row-level-permission-predicate-group-validator.service.ts
 #: src/engine/workspace-manager/workspace-migration/workspace-migration-builder/validators/services/flat-row-level-permission-predicate-group-validator.service.ts
 msgid "Row level permission predicate group to delete not found"
-msgstr "No se encontró el grupo de predicados de permisos a nivel de fila para eliminar"
+msgstr ""
+"No se encontró el grupo de predicados de permisos a nivel de fila para "
+"eliminar"
 
 #. js-lingui-id: NhW7fb
 #: src/engine/workspace-manager/workspace-migration/workspace-migration-builder/validators/services/flat-row-level-permission-predicate-group-validator.service.ts
 #: src/engine/workspace-manager/workspace-migration/workspace-migration-builder/validators/services/flat-row-level-permission-predicate-group-validator.service.ts
 msgid "Row level permission predicate group to update not found"
-msgstr "No se encontró el grupo de predicados de permisos a nivel de fila para actualizar"
+msgstr ""
+"No se encontró el grupo de predicados de permisos a nivel de fila para "
+"actualizar"
 
 #. js-lingui-id: j4iZI5
 #: src/engine/workspace-manager/workspace-migration/workspace-migration-builder/validators/services/flat-row-level-permission-predicate-group-validator.service.ts
-msgid "Row level permission predicate group with this universal identifier already exists"
-msgstr "El grupo de predicados de permisos a nivel de fila con este identificador universal ya existe"
+msgid ""
+"Row level permission predicate group with this universal identifier already "
+"exists"
+msgstr ""
+"El grupo de predicados de permisos a nivel de fila con este identificador "
+"universal ya existe"
 
 #. js-lingui-id: fEazMl
 #: src/engine/metadata-modules/row-level-permission-predicate/exceptions/row-level-permission-predicate.exception.ts
@@ -6101,23 +6532,27 @@ msgstr "No se encontró el predicado de permisos a nivel de fila para eliminar"
 #: src/engine/workspace-manager/workspace-migration/workspace-migration-builder/validators/services/flat-row-level-permission-predicate-validator.service.ts
 #: src/engine/workspace-manager/workspace-migration/workspace-migration-builder/validators/services/flat-row-level-permission-predicate-validator.service.ts
 msgid "Row level permission predicate to update not found"
-msgstr "No se encontró el predicado de permisos a nivel de fila para actualizar"
+msgstr ""
+"No se encontró el predicado de permisos a nivel de fila para actualizar"
 
 #. js-lingui-id: B4yoLq
 #: src/engine/workspace-manager/workspace-migration/workspace-migration-builder/validators/services/flat-row-level-permission-predicate-validator.service.ts
-msgid "Row level permission predicate with this universal identifier already exists"
-msgstr "El predicado de permisos a nivel de fila con este identificador universal ya existe"
+msgid ""
+"Row level permission predicate with this universal identifier already exists"
+msgstr ""
+"El predicado de permisos a nivel de fila con este identificador universal ya"
+" existe"
 
 #. js-lingui-id: RiQMUh
 #: src/engine/workspace-manager/twenty-standard-application/utils/field-metadata/compute-workflow-run-standard-flat-field-metadata.util.ts
 msgid "Running"
-msgstr ""
+msgstr "Ejecutando"
 
 #. js-lingui-id: Tpm2G9
 #: src/engine/workspace-manager/twenty-standard-application/utils/field-metadata/compute-workflow-version-standard-flat-field-metadata.util.ts
 #: src/engine/workspace-manager/twenty-standard-application/utils/field-metadata/compute-workflow-standard-flat-field-metadata.util.ts
 msgid "Runs"
-msgstr ""
+msgstr "Ejecuciones"
 
 #. js-lingui-id: +5kO8P
 #: src/engine/api/graphql/graphql-query-runner/group-by/resolvers/utils/format-result-with-group-by-dimension-values.util.ts
@@ -6127,12 +6562,16 @@ msgstr "Sábado"
 #. js-lingui-id: cOh+MI
 #: src/engine/workspace-manager/twenty-standard-application/utils/field-metadata/compute-opportunity-standard-flat-field-metadata.util.ts
 msgid "Screening"
-msgstr ""
+msgstr "Evaluación"
 
 #. js-lingui-id: eKi1df
 #: src/engine/core-modules/sdk-client/exceptions/sdk-client.exception.ts
-msgid "SDK client archive not found. The SDK client may not have been generated for this application."
-msgstr "No se encontró el archivo comprimido del cliente del SDK. Es posible que el cliente del SDK no se haya generado para esta aplicación."
+msgid ""
+"SDK client archive not found. The SDK client may not have been generated for"
+" this application."
+msgstr ""
+"No se encontró el archivo comprimido del cliente del SDK. Es posible que el "
+"cliente del SDK no se haya generado para esta aplicación."
 
 #. js-lingui-id: PdVIJC
 #: src/engine/workspace-manager/twenty-standard-application/utils/field-metadata/compute-workspace-member-standard-flat-field-metadata.util.ts
@@ -6166,7 +6605,7 @@ msgstr "Vector de búsqueda"
 #. js-lingui-id: CTcVpP
 #: src/engine/core-modules/emailing-domain/drivers/exceptions/emailing-domain-driver.exception.ts
 msgid "Sending is currently suspended for this email domain."
-msgstr ""
+msgstr "El envío está actualmente suspendido para este dominio de correo."
 
 #. js-lingui-id: hgvbYY
 #: src/engine/api/graphql/graphql-query-runner/group-by/resolvers/utils/format-result-with-group-by-dimension-values.util.ts
@@ -6176,7 +6615,7 @@ msgstr "septiembre"
 #. js-lingui-id: Tz0i8g
 #: src/engine/workspace-manager/twenty-standard-application/utils/field-metadata/compute-workflow-automated-trigger-standard-flat-field-metadata.util.ts
 msgid "Settings"
-msgstr ""
+msgstr "Configuración"
 
 #. js-lingui-id: e1k+No
 #: src/engine/core-modules/auth/auth.exception.ts
@@ -6209,27 +6648,39 @@ msgstr "Ya existe una habilidad con el nombre \"{name}\""
 #. js-lingui-id: kIKb9e
 #: src/engine/metadata-modules/view-field-group/constants/standard-view-field-group-names.ts
 msgid "Social"
-msgstr ""
+msgstr "Social"
 
 #. js-lingui-id: RyE+Of
 #: src/engine/workspace-manager/workspace-migration/workspace-migration-builder/validators/utils/validate-role-required-properties-are-defined.util.ts
-msgid "Some of the information provided is invalid. Please check your input and try again."
-msgstr "Parte de la información proporcionada es inválida. Por favor, revise su entrada e intente de nuevo."
+msgid ""
+"Some of the information provided is invalid. Please check your input and try"
+" again."
+msgstr ""
+"Parte de la información proporcionada es inválida. Por favor, revise su "
+"entrada e intente de nuevo."
 
 #. js-lingui-id: 01Sxb6
 #: src/engine/metadata-modules/role-permission-flag/role-permission-flag.service.ts
-msgid "Some of the permissions you selected are not valid. Please try again with valid permission settings."
-msgstr "Algunos de los permisos seleccionados no son válidos. Por favor, intenta de nuevo con configuraciones de permisos válidas."
+msgid ""
+"Some of the permissions you selected are not valid. Please try again with "
+"valid permission settings."
+msgstr ""
+"Algunos de los permisos seleccionados no son válidos. Por favor, intenta de "
+"nuevo con configuraciones de permisos válidas."
 
 #. js-lingui-id: aPJopM
 #: src/engine/metadata-modules/user-role/user-role.service.ts
-msgid "Some workspace memberships could not be found. They may no longer have access to this workspace."
-msgstr "No se pudieron encontrar algunas membresías del espacio de trabajo. Puede que ya no tengan acceso a este espacio de trabajo."
+msgid ""
+"Some workspace memberships could not be found. They may no longer have "
+"access to this workspace."
+msgstr ""
+"No se pudieron encontrar algunas membresías del espacio de trabajo. Puede "
+"que ya no tengan acceso a este espacio de trabajo."
 
 #. js-lingui-id: fWsBTs
 #: src/engine/core-modules/admin-panel/admin-panel.exception.ts
 msgid "Something went wrong. Please try again."
-msgstr ""
+msgstr "Algo salió mal. Por favor, inténtalo de nuevo."
 
 #. js-lingui-id: Oa7nLQ
 #: src/engine/core-modules/application/application.exception.ts
@@ -6240,28 +6691,28 @@ msgstr "Incompatibilidad del canal de origen."
 #: src/engine/workspace-manager/workspace-migration/workspace-migration-builder/validators/services/flat-front-component-validator.service.ts
 #: src/engine/workspace-manager/workspace-migration/workspace-migration-builder/validators/services/flat-front-component-validator.service.ts
 msgid "Source component path is invalid"
-msgstr ""
+msgstr "La ruta del componente de origen es inválida"
 
 #. js-lingui-id: o0N9e6
 #: src/engine/workspace-manager/workspace-migration/workspace-migration-builder/validators/services/flat-logic-function-validator.service.ts
 #: src/engine/workspace-manager/workspace-migration/workspace-migration-builder/validators/services/flat-logic-function-validator.service.ts
 msgid "Source handler path is invalid"
-msgstr ""
+msgstr "La ruta del controlador de origen es inválida"
 
 #. js-lingui-id: OmgwCE
 #: src/engine/metadata-modules/flat-field-metadata/validators/utils/validate-morph-relation-flat-field-metadata.util.ts
 msgid "Source object cannot be the target object"
-msgstr ""
+msgstr "El objeto de origen no puede ser el objeto de destino"
 
 #. js-lingui-id: xqlr9R
 #: src/engine/workspace-manager/twenty-standard-application/utils/field-metadata/compute-workspace-member-standard-flat-field-metadata.util.ts
 msgid "Spaces and comma"
-msgstr ""
+msgstr "Espacios y coma"
 
 #. js-lingui-id: jAoGz1
 #: src/engine/workspace-manager/twenty-standard-application/utils/field-metadata/compute-attachment-standard-flat-field-metadata.util.ts
 msgid "Spreadsheet"
-msgstr ""
+msgstr "Hoja de cálculo"
 
 #. js-lingui-id: IP+RN5
 #: src/engine/core-modules/sso/sso.exception.ts
@@ -6276,7 +6727,7 @@ msgstr "El SSO está deshabilitado."
 #. js-lingui-id: 3PRxO3
 #: src/engine/workspace-manager/twenty-standard-application/utils/field-metadata/compute-opportunity-standard-flat-field-metadata.util.ts
 msgid "Stage"
-msgstr ""
+msgstr "Etapa"
 
 #. js-lingui-id: 7XNKWU
 #: src/engine/metadata-modules/ai/ai.exception.ts
@@ -6292,7 +6743,7 @@ msgstr "Los objetos estándar no se pueden eliminar"
 #. js-lingui-id: Xn/1qY
 #: src/engine/metadata-modules/permission-flag/permission-flag.exception.ts
 msgid "Standard permission flags cannot be modified."
-msgstr ""
+msgstr "Los indicadores de permiso estándar no se pueden modificar."
 
 #. js-lingui-id: H8j7uw
 #: src/engine/metadata-modules/skill/skill.exception.ts
@@ -6303,32 +6754,32 @@ msgstr "Las habilidades estándar no pueden modificarse."
 #: src/engine/workspace-manager/twenty-standard-application/utils/field-metadata/compute-calendar-event-standard-flat-field-metadata.util.ts
 #: src/engine/workspace-manager/twenty-standard-application/utils/field-metadata/compute-calendar-event-standard-flat-field-metadata.util.ts
 msgid "Start Date"
-msgstr ""
+msgstr "Fecha de inicio"
 
 #. js-lingui-id: amGzX5
 #: src/engine/workspace-manager/twenty-standard-application/utils/field-metadata/compute-workspace-member-standard-flat-field-metadata.util.ts
 msgid "Start of the week"
-msgstr ""
+msgstr "Inicio de la semana"
 
 #. js-lingui-id: RS0o7b
 #: src/engine/workspace-manager/twenty-standard-application/utils/field-metadata/compute-workflow-run-standard-flat-field-metadata.util.ts
 msgid "State"
-msgstr ""
+msgstr "Estado"
 
 #. js-lingui-id: nY8GL/
 #: src/engine/workspace-manager/twenty-standard-application/utils/field-metadata/compute-workflow-run-standard-flat-field-metadata.util.ts
 msgid "State of the workflow run"
-msgstr ""
+msgstr "Estado de la ejecución del flujo de trabajo"
 
 #. js-lingui-id: uAQUqI
 #: src/engine/workspace-manager/twenty-standard-application/utils/field-metadata/compute-task-standard-flat-field-metadata.util.ts
 msgid "Status"
-msgstr ""
+msgstr "Estado"
 
 #. js-lingui-id: Db4W3/
 #: src/engine/workspace-manager/twenty-standard-application/utils/field-metadata/compute-workflow-standard-flat-field-metadata.util.ts
 msgid "Statuses"
-msgstr ""
+msgstr "Estados"
 
 #. js-lingui-id: S7DRR+
 #: src/modules/workflow/common/utils/assert-workflow-statuses-not-set.ts
@@ -6343,17 +6794,17 @@ msgstr "El paso no es un formulario"
 #. js-lingui-id: 1D+4NY
 #: src/engine/metadata-modules/page-layout-widget/constants/standard-page-layout-widget-titles.ts
 msgid "Stock market (Iframe)"
-msgstr ""
+msgstr "Mercado de valores (Iframe)"
 
 #. js-lingui-id: NnvXp5
 #: src/engine/workspace-manager/twenty-standard-application/utils/field-metadata/compute-workflow-run-standard-flat-field-metadata.util.ts
 msgid "Stopped"
-msgstr ""
+msgstr "Detenido"
 
 #. js-lingui-id: 161NCV
 #: src/engine/workspace-manager/twenty-standard-application/utils/field-metadata/compute-workflow-run-standard-flat-field-metadata.util.ts
 msgid "Stopping"
-msgstr ""
+msgstr "Deteniendo"
 
 #. js-lingui-id: An2IAh
 #: src/engine/core-modules/workspace/workspace.exception.ts
@@ -6366,7 +6817,7 @@ msgstr "Subdominio no encontrado."
 #: src/engine/workspace-manager/twenty-standard-application/utils/field-metadata/compute-message-standard-flat-field-metadata.util.ts
 #: src/engine/workspace-manager/twenty-standard-application/utils/field-metadata/compute-message-standard-flat-field-metadata.util.ts
 msgid "Subject"
-msgstr ""
+msgstr "Asunto"
 
 #. js-lingui-id: x0Vn7k
 #: src/engine/core-modules/billing/billing.exception.ts
@@ -6399,7 +6850,7 @@ msgstr "Domingo"
 #: src/engine/workspace-manager/twenty-standard-application/utils/field-metadata/compute-workspace-member-standard-flat-field-metadata.util.ts
 #: src/engine/metadata-modules/view-field-group/constants/standard-view-field-group-names.ts
 msgid "System"
-msgstr ""
+msgstr "Sistema"
 
 #. js-lingui-id: Bhmfez
 #: src/engine/metadata-modules/flat-object-metadata/validators/utils/validate-object-metadata-system-fields-integrity.util.ts
@@ -6425,6 +6876,8 @@ msgstr "Los campos del sistema no se pueden actualizar"
 #: src/engine/metadata-modules/index-metadata/services/index-metadata.service.ts
 msgid "System indexes are required for Twenty to work and cannot be deleted."
 msgstr ""
+"Los índices del sistema son necesarios para que Twenty funcione y no se "
+"pueden eliminar."
 
 #. js-lingui-id: /ojawH
 #: src/engine/workspace-manager/workspace-migration/workspace-migration-builder/validators/services/flat-object-metadata-validator.service.ts
@@ -6439,13 +6892,17 @@ msgstr "Los objetos del sistema no se pueden actualizar"
 
 #. js-lingui-id: aF4zgq
 #: src/engine/workspace-manager/workspace-migration/workspace-migration-builder/validators/services/flat-object-metadata-validator.service.ts
-msgid "System objects cannot be updated directly. Use standardOverrides for cosmetic changes."
-msgstr "No se pueden actualizar directamente los objetos del sistema. Utilice standardOverrides para cambios cosméticos."
+msgid ""
+"System objects cannot be updated directly. Use standardOverrides for "
+"cosmetic changes."
+msgstr ""
+"No se pueden actualizar directamente los objetos del sistema. Utilice "
+"standardOverrides para cambios cosméticos."
 
 #. js-lingui-id: HiXp3D
 #: src/engine/metadata-modules/page-layout-tab/constants/standard-page-layout-tab-titles.ts
 msgid "Tab 1"
-msgstr ""
+msgstr "Pestaña 1"
 
 #. js-lingui-id: 8UWeLh
 #: src/engine/metadata-modules/page-layout/exceptions/page-layout.exception.ts
@@ -6476,12 +6933,13 @@ msgstr "No se encontró la pestaña para duplicar el widget."
 #: src/engine/workspace-manager/twenty-standard-application/utils/field-metadata/compute-attachment-standard-flat-field-metadata.util.ts
 #: src/engine/workspace-manager/twenty-standard-application/utils/field-metadata/compute-attachment-standard-flat-field-metadata.util.ts
 msgid "Target"
-msgstr ""
+msgstr "Destino"
 
 #. js-lingui-id: 5y3Wbw
 #: src/engine/twenty-orm/utils/compute-relation-connect-query-configs.util.ts
 msgid "Target object metadata not found for {connectFieldName}"
-msgstr "No se encontró la metadatos del objeto de destino para {connectFieldName}"
+msgstr ""
+"No se encontró la metadatos del objeto de destino para {connectFieldName}"
 
 #. js-lingui-id: 1ssKrE
 #: src/engine/metadata-modules/flat-field-metadata/validators/utils/validate-morph-or-relation-flat-field-metadata.util.ts
@@ -6491,7 +6949,8 @@ msgstr "El campo de relación de destino no pertenece al objeto esperado"
 #. js-lingui-id: wG8PVB
 #: src/engine/metadata-modules/flat-field-metadata/validators/utils/validate-morph-or-relation-flat-field-metadata.util.ts
 msgid "Target relation field does not reference the source object"
-msgstr "El campo de relación de destino no hace referencia al objeto de origen"
+msgstr ""
+"El campo de relación de destino no hace referencia al objeto de origen"
 
 #. js-lingui-id: xLsFda
 #: src/engine/metadata-modules/flat-field-metadata/validators/utils/validate-morph-or-relation-flat-field-metadata.util.ts
@@ -6514,64 +6973,65 @@ msgstr "targetObjectMetadataId es obligatorio para el tipo OBJECT"
 #: src/engine/workspace-manager/workspace-migration/workspace-migration-builder/validators/services/flat-navigation-menu-item-validator.service.ts
 #: src/engine/workspace-manager/workspace-migration/workspace-migration-builder/validators/services/flat-navigation-menu-item-validator.service.ts
 msgid "targetRecordId and targetObjectMetadataId are required for RECORD type"
-msgstr "targetRecordId y targetObjectMetadataId son obligatorios para el tipo RECORD"
+msgstr ""
+"targetRecordId y targetObjectMetadataId son obligatorios para el tipo RECORD"
 
 #. js-lingui-id: Q3P/4s
 #: src/engine/workspace-manager/twenty-standard-application/utils/object-metadata/create-standard-flat-object-metadata.util.ts
 #: src/engine/workspace-manager/twenty-standard-application/utils/field-metadata/compute-task-target-standard-flat-field-metadata.util.ts
 #: src/engine/metadata-modules/page-layout-widget/constants/standard-page-layout-widget-titles.ts
 msgid "Task"
-msgstr ""
+msgstr "Tarea"
 
 #. js-lingui-id: kS+Ym6
 #: src/engine/workspace-manager/twenty-standard-application/utils/field-metadata/compute-task-standard-flat-field-metadata.util.ts
 msgid "Task assignee"
-msgstr ""
+msgstr "Asignado de la tarea"
 
 #. js-lingui-id: 7fYQ6E
 #: src/engine/workspace-manager/twenty-standard-application/utils/field-metadata/compute-task-standard-flat-field-metadata.util.ts
 msgid "Task attachments"
-msgstr ""
+msgstr "Adjuntos de la tarea"
 
 #. js-lingui-id: X8fs74
 #: src/engine/workspace-manager/twenty-standard-application/utils/field-metadata/compute-task-standard-flat-field-metadata.util.ts
 msgid "Task body"
-msgstr ""
+msgstr "Cuerpo de la tarea"
 
 #. js-lingui-id: EPxYHS
 #: src/engine/workspace-manager/twenty-standard-application/utils/field-metadata/compute-task-standard-flat-field-metadata.util.ts
 msgid "Task due date"
-msgstr ""
+msgstr "Fecha de vencimiento de la tarea"
 
 #. js-lingui-id: fUw1j+
 #: src/engine/workspace-manager/twenty-standard-application/utils/field-metadata/compute-task-standard-flat-field-metadata.util.ts
 msgid "Task record position"
-msgstr ""
+msgstr "Posición del registro de tarea"
 
 #. js-lingui-id: I6+0ph
 #: src/engine/workspace-manager/twenty-standard-application/utils/field-metadata/compute-task-standard-flat-field-metadata.util.ts
 msgid "Task status"
-msgstr ""
+msgstr "Estado de la tarea"
 
 #. js-lingui-id: WSiiWf
 #: src/engine/workspace-manager/twenty-standard-application/utils/object-metadata/create-standard-flat-object-metadata.util.ts
 msgid "Task Target"
-msgstr ""
+msgstr "Destino de la tarea"
 
 #. js-lingui-id: khGQLP
 #: src/engine/workspace-manager/twenty-standard-application/utils/field-metadata/compute-task-standard-flat-field-metadata.util.ts
 msgid "Task targets"
-msgstr ""
+msgstr "Destinos de la tarea"
 
 #. js-lingui-id: 836FiO
 #: src/engine/workspace-manager/twenty-standard-application/utils/object-metadata/create-standard-flat-object-metadata.util.ts
 msgid "Task Targets"
-msgstr ""
+msgstr "Destinos de las tareas"
 
 #. js-lingui-id: R+s8S+
 #: src/engine/workspace-manager/twenty-standard-application/utils/field-metadata/compute-task-standard-flat-field-metadata.util.ts
 msgid "Task title"
-msgstr ""
+msgstr "Título de la tarea"
 
 #. js-lingui-id: GtycJ/
 #: src/engine/workspace-manager/twenty-standard-application/utils/object-metadata/create-standard-flat-object-metadata.util.ts
@@ -6586,39 +7046,39 @@ msgstr "Tareas"
 #. js-lingui-id: HlDeG3
 #: src/engine/workspace-manager/twenty-standard-application/utils/field-metadata/compute-workspace-member-standard-flat-field-metadata.util.ts
 msgid "Tasks assigned to the workspace member"
-msgstr ""
+msgstr "Tareas asignadas al miembro del espacio de trabajo"
 
 #. js-lingui-id: M4rBti
 #: src/engine/workspace-manager/twenty-standard-application/utils/field-metadata/compute-company-standard-flat-field-metadata.util.ts
 msgid "Tasks tied to the company"
-msgstr ""
+msgstr "Tareas vinculadas a la empresa"
 
 #. js-lingui-id: /VaiDW
 #: src/engine/workspace-manager/twenty-standard-application/utils/field-metadata/compute-person-standard-flat-field-metadata.util.ts
 msgid "Tasks tied to the contact"
-msgstr ""
+msgstr "Tareas vinculadas al contacto"
 
 #. js-lingui-id: 1TfX9U
 #: src/engine/workspace-manager/twenty-standard-application/utils/field-metadata/compute-opportunity-standard-flat-field-metadata.util.ts
 msgid "Tasks tied to the opportunity"
-msgstr ""
+msgstr "Tareas vinculadas a la oportunidad"
 
 #. js-lingui-id: V9OANc
 #: src/engine/workspace-manager/twenty-standard-application/utils/field-metadata/compute-task-target-standard-flat-field-metadata.util.ts
 msgid "TaskTarget record position"
-msgstr ""
+msgstr "Posición del registro de destino de tarea"
 
 #. js-lingui-id: ZNDHIy
 #: src/engine/workspace-manager/twenty-standard-application/utils/field-metadata/compute-task-target-standard-flat-field-metadata.util.ts
 #: src/engine/workspace-manager/twenty-standard-application/utils/field-metadata/compute-task-target-standard-flat-field-metadata.util.ts
 #: src/engine/workspace-manager/twenty-standard-application/utils/field-metadata/compute-task-target-standard-flat-field-metadata.util.ts
 msgid "TaskTarget target"
-msgstr ""
+msgstr "Destino del destino de tarea"
 
 #. js-lingui-id: pciKLT
 #: src/engine/workspace-manager/twenty-standard-application/utils/field-metadata/compute-task-target-standard-flat-field-metadata.util.ts
 msgid "TaskTarget task"
-msgstr ""
+msgstr "Tarea del destino de tarea"
 
 #. js-lingui-id: 2kFzQB
 #: src/engine/core-modules/file/file.exception.ts
@@ -6628,7 +7088,7 @@ msgstr "No se puede descargar el archivo temporal."
 #. js-lingui-id: 3WYP3r
 #: src/engine/workspace-manager/twenty-standard-application/utils/field-metadata/compute-calendar-event-participant-standard-flat-field-metadata.util.ts
 msgid "Tentative"
-msgstr ""
+msgstr "Provisional"
 
 #. js-lingui-id: M10it4
 #: src/utils/__test__/custom-exception.spec.ts
@@ -6646,12 +7106,12 @@ msgstr "Mensaje de prueba amigable para el usuario"
 #: src/engine/workspace-manager/twenty-standard-application/utils/field-metadata/compute-message-standard-flat-field-metadata.util.ts
 #: src/engine/workspace-manager/twenty-standard-application/utils/field-metadata/compute-message-standard-flat-field-metadata.util.ts
 msgid "Text"
-msgstr ""
+msgstr "Texto"
 
 #. js-lingui-id: 39/rgD
 #: src/engine/workspace-manager/twenty-standard-application/utils/field-metadata/compute-attachment-standard-flat-field-metadata.util.ts
 msgid "Text Document"
-msgstr ""
+msgstr "Documento de texto"
 
 #. js-lingui-id: mQj02P
 #: src/engine/workspace-manager/workspace-migration/workspace-migration-builder/validators/utils/validate-agent-response-format.util.ts
@@ -6660,19 +7120,29 @@ msgstr "El formato de respuesta de texto no debe tener un esquema"
 
 #. js-lingui-id: GekZDw
 #: src/engine/metadata-modules/ai/ai-agent/utils/from-update-agent-input-to-flat-agent-to-update.util.ts
-msgid "The agent you are looking for could not be found. It may have been deleted or you may not have access to it."
-msgstr "El agente que está buscando no se pudo encontrar. Puede que haya sido eliminado o que no tenga acceso."
+msgid ""
+"The agent you are looking for could not be found. It may have been deleted "
+"or you may not have access to it."
+msgstr ""
+"El agente que está buscando no se pudo encontrar. Puede que haya sido "
+"eliminado o que no tenga acceso."
 
 #. js-lingui-id: eC8p5b
 #: src/engine/metadata-modules/permissions/permissions.service.ts
-msgid "The API key does not have a valid role assigned. Please check your API key configuration."
-msgstr "La clave API no tiene un rol válido asignado. Por favor, revisa la configuración de tu clave API."
+msgid ""
+"The API key does not have a valid role assigned. Please check your API key "
+"configuration."
+msgstr ""
+"La clave API no tiene un rol válido asignado. Por favor, revisa la "
+"configuración de tu clave API."
 
 #. js-lingui-id: Z4AMcp
 #: src/engine/core-modules/application/application.exception.ts
 #: src/engine/core-modules/application/application-registration/application-registration.exception.ts
 msgid "The app manifest declares an invalid server version requirement."
 msgstr ""
+"El manifiesto de la aplicación declara un requisito de versión del servidor "
+"inválido."
 
 #. js-lingui-id: MQn14a
 #: src/engine/core-modules/application/application-registration/application-registration.exception.ts
@@ -6681,33 +7151,40 @@ msgstr "El canal de origen de la aplicación no coincide con el tipo esperado."
 
 #. js-lingui-id: IU78DA
 #: src/engine/metadata-modules/permissions/permissions.service.ts
-msgid "The application does not have a valid role assigned. Please check your application configuration."
-msgstr "La aplicación no tiene un rol válido asignado. Por favor, revisa la configuración de tu aplicación."
+msgid ""
+"The application does not have a valid role assigned. Please check your "
+"application configuration."
+msgstr ""
+"La aplicación no tiene un rol válido asignado. Por favor, revisa la "
+"configuración de tu aplicación."
 
 #. js-lingui-id: qnNFrW
 #: src/engine/workspace-manager/twenty-standard-application/utils/field-metadata/compute-company-standard-flat-field-metadata.util.ts
 msgid "The company Linkedin account"
-msgstr ""
+msgstr "La cuenta de LinkedIn de la empresa"
 
 #. js-lingui-id: N31Pso
 #: src/engine/workspace-manager/twenty-standard-application/utils/field-metadata/compute-company-standard-flat-field-metadata.util.ts
 msgid "The company name"
-msgstr ""
+msgstr "El nombre de la empresa"
 
 #. js-lingui-id: BHFCqB
 #: src/engine/workspace-manager/twenty-standard-application/utils/field-metadata/compute-company-standard-flat-field-metadata.util.ts
 msgid "The company Twitter/X account"
-msgstr ""
+msgstr "La cuenta de Twitter/X de la empresa"
 
 #. js-lingui-id: OBmU0K
 #: src/engine/workspace-manager/twenty-standard-application/utils/field-metadata/compute-company-standard-flat-field-metadata.util.ts
 msgid "The company website URL. We use this url to fetch the company icon"
 msgstr ""
+"La URL del sitio web de la empresa. Usamos esta URL para obtener el icono de"
+" la empresa"
 
 #. js-lingui-id: j6q6l+
 #: src/engine/core-modules/application/connection-provider/connection-provider.exception.ts
 msgid "The connection-provider manifest is missing required fields."
 msgstr ""
+"El manifiesto del proveedor de conexión no tiene los campos obligatorios."
 
 #. js-lingui-id: zGBDEH
 #: src/engine/workspace-manager/twenty-standard-application/utils/field-metadata/compute-workspace-member-standard-flat-field-metadata.util.ts
@@ -6734,22 +7211,26 @@ msgstr ""
 #: src/engine/workspace-manager/twenty-standard-application/utils/field-metadata/compute-blocklist-standard-flat-field-metadata.util.ts
 #: src/engine/workspace-manager/twenty-standard-application/utils/field-metadata/compute-attachment-standard-flat-field-metadata.util.ts
 msgid "The creator of the record"
-msgstr ""
+msgstr "El creador del registro"
 
 #. js-lingui-id: bMyVOx
 #: src/engine/workspace-manager/twenty-standard-application/utils/field-metadata/compute-workflow-standard-flat-field-metadata.util.ts
 msgid "The current statuses of the workflow versions"
-msgstr ""
+msgstr "Los estados actuales de las versiones del flujo de trabajo"
 
 #. js-lingui-id: 0bo4Q0
 #: src/engine/workspace-manager/twenty-standard-application/utils/field-metadata/compute-message-standard-flat-field-metadata.util.ts
 msgid "The date the message was received"
-msgstr ""
+msgstr "La fecha en que se recibió el mensaje"
 
 #. js-lingui-id: nCXfEw
 #: src/engine/metadata-modules/role/role.service.ts
-msgid "The default role cannot be deleted as it is required for the workspace to function properly."
-msgstr "El rol predeterminado no puede ser eliminado ya que es necesario para el correcto funcionamiento del espacio de trabajo."
+msgid ""
+"The default role cannot be deleted as it is required for the workspace to "
+"function properly."
+msgstr ""
+"El rol predeterminado no puede ser eliminado ya que es necesario para el "
+"correcto funcionamiento del espacio de trabajo."
 
 #. js-lingui-id: 0biWRI
 #: src/engine/metadata-modules/permissions/permissions.exception.ts
@@ -6758,8 +7239,12 @@ msgstr "El rol predeterminado no se puede eliminar."
 
 #. js-lingui-id: 6BBrjb
 #: src/engine/metadata-modules/role/role.service.ts
-msgid "The default role for this workspace could not be found. Please contact support for assistance."
-msgstr "El rol predeterminado para este espacio de trabajo no se pudo encontrar. Por favor, contacte al soporte para asistencia."
+msgid ""
+"The default role for this workspace could not be found. Please contact "
+"support for assistance."
+msgstr ""
+"El rol predeterminado para este espacio de trabajo no se pudo encontrar. Por"
+" favor, contacte al soporte para asistencia."
 
 #. js-lingui-id: 22Peto
 #: src/engine/core-modules/approved-access-domain/approved-access-domain.exception.ts
@@ -6769,22 +7254,34 @@ msgstr "El dominio no coincide con su dominio de correo electrónico."
 #. js-lingui-id: 8h4mhq
 #: src/engine/workspace-manager/twenty-standard-application/utils/field-metadata/compute-workflow-run-standard-flat-field-metadata.util.ts
 msgid "The executor of the workflow"
-msgstr ""
+msgstr "El ejecutor del flujo de trabajo"
 
 #. js-lingui-id: o6DGfJ
 #: src/engine/core-modules/workspace/services/workspace.service.ts
-msgid "The field \"{field}\" cannot be updated. Please contact your workspace administrator."
-msgstr "El campo \"{field}\" no puede ser actualizado. Por favor, contacte con su administrador de espacio de trabajo."
+msgid ""
+"The field \"{field}\" cannot be updated. Please contact your workspace "
+"administrator."
+msgstr ""
+"El campo \"{field}\" no puede ser actualizado. Por favor, contacte con su "
+"administrador de espacio de trabajo."
 
 #. js-lingui-id: LdhPiK
 #: src/engine/metadata-modules/object-permission/field-permission/field-permission.service.ts
-msgid "The field you are trying to set permissions for could not be found. It may have been deleted."
-msgstr "El campo para el que está intentando establecer permisos no se pudo encontrar. Es posible que haya sido eliminado."
+msgid ""
+"The field you are trying to set permissions for could not be found. It may "
+"have been deleted."
+msgstr ""
+"El campo para el que está intentando establecer permisos no se pudo "
+"encontrar. Es posible que haya sido eliminado."
 
 #. js-lingui-id: bAGU1r
 #: src/engine/core-modules/file/utils/extract-file-info-or-throw.utils.ts
-msgid "The file extension doesn't match the file content. Please check that your file is not corrupted and has the correct extension."
-msgstr "La extensión del archivo no coincide con el contenido del archivo. Compruebe que su archivo no esté dañado y que tenga la extensión correcta."
+msgid ""
+"The file extension doesn't match the file content. Please check that your "
+"file is not corrupted and has the correct extension."
+msgstr ""
+"La extensión del archivo no coincide con el contenido del archivo. Compruebe"
+" que su archivo no esté dañado y que tenga la extensión correcta."
 
 #. js-lingui-id: EJUSll
 #: src/modules/workflow/common/workspace-services/workflow-version-validation.workspace-service.ts
@@ -6794,49 +7291,74 @@ msgstr "La versión inicial de un flujo de trabajo no se puede eliminar"
 #. js-lingui-id: kdTB4e
 #: src/engine/core-modules/application/connection-provider/connection-provider.exception.ts
 msgid "The OAuth request is missing required parameters."
-msgstr ""
+msgstr "La solicitud OAuth no tiene los parámetros obligatorios."
 
 #. js-lingui-id: mCM5lH
 #: src/engine/core-modules/application/connection-provider/connection-provider.exception.ts
 msgid "The OAuth state parameter is invalid or expired."
-msgstr ""
+msgstr "El parámetro de estado de OAuth es inválido o ha expirado."
 
 #. js-lingui-id: hx2IZ4
 #: src/engine/metadata-modules/object-permission/object-permission.service.ts
 #: src/engine/metadata-modules/object-permission/field-permission/field-permission.service.ts
-msgid "The object you are trying to set permissions for could not be found. It may have been deleted."
-msgstr "El objeto para el que está intentando establecer permisos no se pudo encontrar. Es posible que haya sido eliminado."
+msgid ""
+"The object you are trying to set permissions for could not be found. It may "
+"have been deleted."
+msgstr ""
+"El objeto para el que está intentando establecer permisos no se pudo "
+"encontrar. Es posible que haya sido eliminado."
 
 #. js-lingui-id: DbWmKZ
 #: src/engine/workspace-manager/twenty-standard-application/utils/field-metadata/compute-opportunity-standard-flat-field-metadata.util.ts
 msgid "The opportunity name"
-msgstr ""
+msgstr "El nombre de la oportunidad"
 
 #. js-lingui-id: tl8xOZ
 #: src/utils/get-domain-name-by-email.ts
-msgid "The provided email address is missing a domain. Please use a standard email format (e.g., user@example.com)."
-msgstr "A la dirección de correo electrónico proporcionada le falta un dominio. Por favor, usa un formato de correo electrónico estándar (p. ej., user@example.com)."
+msgid ""
+"The provided email address is missing a domain. Please use a standard email "
+"format (e.g., user@example.com)."
+msgstr ""
+"A la dirección de correo electrónico proporcionada le falta un dominio. Por "
+"favor, usa un formato de correo electrónico estándar (p. ej., "
+"user@example.com)."
 
 #. js-lingui-id: h8R4RO
 #: src/utils/get-domain-name-by-email.ts
-msgid "The provided email address is not valid. Please use a standard email format (e.g., user@example.com)."
-msgstr "La dirección de correo electrónico proporcionada no es válida. Por favor, usa un formato de correo electrónico estándar (p. ej., user@example.com)."
+msgid ""
+"The provided email address is not valid. Please use a standard email format "
+"(e.g., user@example.com)."
+msgstr ""
+"La dirección de correo electrónico proporcionada no es válida. Por favor, "
+"usa un formato de correo electrónico estándar (p. ej., user@example.com)."
 
 #. js-lingui-id: pv+BoZ
 #: src/engine/core-modules/graphql/hooks/use-validate-graphql-query-complexity.hook.ts
-msgid "The request is too complex to process. Please try reducing the amount of requested fields."
-msgstr "La solicitud es demasiado compleja para procesarla. Intente reducir la cantidad de campos solicitados."
+msgid ""
+"The request is too complex to process. Please try reducing the amount of "
+"requested fields."
+msgstr ""
+"La solicitud es demasiado compleja para procesarla. Intente reducir la "
+"cantidad de campos solicitados."
 
 #. js-lingui-id: 4LVaa7
 #: src/engine/core-modules/graphql/hooks/use-validate-graphql-query-complexity.hook.ts
-msgid "The request is too complex to process. Please try reducing the amount of requested root resolvers."
-msgstr "La solicitud es demasiado compleja para procesarla. Intente reducir la cantidad de resolvers raíz solicitados."
+msgid ""
+"The request is too complex to process. Please try reducing the amount of "
+"requested root resolvers."
+msgstr ""
+"La solicitud es demasiado compleja para procesarla. Intente reducir la "
+"cantidad de resolvers raíz solicitados."
 
 #. js-lingui-id: Zi9X+u
 #: src/engine/metadata-modules/flat-role/utils/from-update-role-input-to-flat-role-to-update-or-throw.util.ts
 #: src/engine/metadata-modules/flat-role/utils/from-delete-role-input-to-flat-role-or-throw.util.ts
-msgid "The role you are looking for could not be found. It may have been deleted or you may not have access to it."
-msgstr "El rol que está buscando no se pudo encontrar. Puede que haya sido eliminado o que no tenga acceso."
+msgid ""
+"The role you are looking for could not be found. It may have been deleted or"
+" you may not have access to it."
+msgstr ""
+"El rol que está buscando no se pudo encontrar. Puede que haya sido eliminado"
+" o que no tenga acceso."
 
 #. js-lingui-id: woRk0z
 #: src/engine/metadata-modules/role-permission-flag/role-permission-flag.service.ts
@@ -6847,18 +7369,26 @@ msgstr "El rol que está intentando modificar no se pudo encontrar."
 #. js-lingui-id: eaW27s
 #: src/engine/metadata-modules/index-metadata/services/index-metadata.service.ts
 msgid "The same column cannot appear twice in an index."
-msgstr ""
+msgstr "La misma columna no puede aparecer dos veces en un índice."
 
 #. js-lingui-id: vD3FVp
 #: src/engine/core-modules/imap-smtp-caldav-connection/services/imap-smtp-caldav-connection-validator.service.ts
-msgid "The server address you entered is not allowed. Please use a public server address."
-msgstr "La dirección del servidor que has introducido no está permitida. Por favor, usa una dirección de servidor pública."
+msgid ""
+"The server address you entered is not allowed. Please use a public server "
+"address."
+msgstr ""
+"La dirección del servidor que has introducido no está permitida. Por favor, "
+"usa una dirección de servidor pública."
 
 #. js-lingui-id: 6N5Pv5
 #: src/engine/core-modules/application/application.exception.ts
 #: src/engine/core-modules/application/application-registration/application-registration.exception.ts
-msgid "The server's APP_VERSION is not a valid semver version. Self-hosted instances must configure a valid APP_VERSION."
+msgid ""
+"The server's APP_VERSION is not a valid semver version. Self-hosted "
+"instances must configure a valid APP_VERSION."
 msgstr ""
+"El APP_VERSION del servidor no es una versión semver válida. Las instancias "
+"autoalojadas deben configurar un APP_VERSION válido."
 
 #. js-lingui-id: FOEWHl
 #: src/engine/metadata-modules/flat-object-metadata/validators/utils/validate-flat-object-metadata-name.util.ts
@@ -6868,42 +7398,42 @@ msgstr "Los nombres singular y plural no pueden ser los mismos para un objeto"
 #. js-lingui-id: 9bYo5E
 #: src/engine/core-modules/messaging-webhooks/messaging-webhook.exception.ts
 msgid "The webhook request could not be authenticated."
-msgstr ""
+msgstr "La solicitud del webhook no pudo ser autenticada."
 
 #. js-lingui-id: 3nHyuH
 #: src/engine/core-modules/messaging-webhooks/messaging-webhook.exception.ts
 msgid "The webhook request could not be processed."
-msgstr ""
+msgstr "La solicitud del webhook no pudo ser procesada."
 
 #. js-lingui-id: 5N6QtE
 #: src/engine/workspace-manager/twenty-standard-application/utils/field-metadata/compute-workflow-automated-trigger-standard-flat-field-metadata.util.ts
 msgid "The workflow automated trigger settings"
-msgstr ""
+msgstr "La configuración del disparador automatizado del flujo de trabajo"
 
 #. js-lingui-id: SpKbfT
 #: src/engine/workspace-manager/twenty-standard-application/utils/field-metadata/compute-workflow-automated-trigger-standard-flat-field-metadata.util.ts
 msgid "The workflow automated trigger type"
-msgstr ""
+msgstr "El tipo de disparador automatizado del flujo de trabajo"
 
 #. js-lingui-id: od0omS
 #: src/engine/workspace-manager/twenty-standard-application/utils/field-metadata/compute-workflow-standard-flat-field-metadata.util.ts
 msgid "The workflow last published version id"
-msgstr ""
+msgstr "El ID de la última versión publicada del flujo de trabajo"
 
 #. js-lingui-id: /EdWx6
 #: src/engine/workspace-manager/twenty-standard-application/utils/field-metadata/compute-workflow-standard-flat-field-metadata.util.ts
 msgid "The workflow name"
-msgstr ""
+msgstr "El nombre del flujo de trabajo"
 
 #. js-lingui-id: EhAsND
 #: src/engine/workspace-manager/twenty-standard-application/utils/field-metadata/compute-workflow-version-standard-flat-field-metadata.util.ts
 msgid "The workflow version name"
-msgstr ""
+msgstr "El nombre de la versión del flujo de trabajo"
 
 #. js-lingui-id: dhx13p
 #: src/engine/workspace-manager/twenty-standard-application/utils/field-metadata/compute-workflow-version-standard-flat-field-metadata.util.ts
 msgid "The workflow version status"
-msgstr ""
+msgstr "El estado de la versión del flujo de trabajo"
 
 #. js-lingui-id: a6NBQe
 #: src/engine/workspace-manager/twenty-standard-application/utils/field-metadata/compute-workspace-member-standard-flat-field-metadata.util.ts
@@ -6932,6 +7462,7 @@ msgstr ""
 #: src/engine/workspace-manager/twenty-standard-application/utils/field-metadata/compute-attachment-standard-flat-field-metadata.util.ts
 msgid "The workspace member who last updated the record"
 msgstr ""
+"El miembro del espacio de trabajo que actualizó el registro por última vez"
 
 #. js-lingui-id: mTxjri
 #: src/engine/core-modules/workspace-invitation/workspace-invitation.exception.ts
@@ -6945,8 +7476,12 @@ msgstr "Hay un problema con su token. Por favor, intente de nuevo."
 
 #. js-lingui-id: Iy9pZw
 #: src/engine/api/graphql/workspace-query-runner/utils/handle-duplicate-key-error.util.ts
-msgid "This {fieldLabel} value is already in use. Please check your data and try again."
-msgstr "El valor de {fieldLabel} ya está en uso. Por favor, revise sus datos e intente de nuevo."
+msgid ""
+"This {fieldLabel} value is already in use. Please check your data and try "
+"again."
+msgstr ""
+"El valor de {fieldLabel} ya está en uso. Por favor, revise sus datos e "
+"intente de nuevo."
 
 #. js-lingui-id: Izdz+Y
 #: src/engine/core-modules/api-key/services/api-key.service.ts
@@ -6976,13 +7511,21 @@ msgstr "Esta clave de API no tiene ningún rol asignado."
 #. js-lingui-id: zISk4k
 #: src/engine/core-modules/application/application.exception.ts
 #: src/engine/core-modules/application/application-registration/application-registration.exception.ts
-msgid "This app requires a newer version of the Twenty server. Please upgrade your server or use a compatible app version."
+msgid ""
+"This app requires a newer version of the Twenty server. Please upgrade your "
+"server or use a compatible app version."
 msgstr ""
+"Esta aplicación requiere una versión más reciente del servidor de Twenty. "
+"Actualiza tu servidor o usa una versión compatible de la aplicación."
 
 #. js-lingui-id: 99gsJ/
 #: src/engine/metadata-modules/index-metadata/utils/validate-no-duplicate-unique-index.util.ts
-msgid "This column is already marked as unique. Toggle the field's \"Unique\" off first if you want to manage the constraint here."
+msgid ""
+"This column is already marked as unique. Toggle the field's \"Unique\" off "
+"first if you want to manage the constraint here."
 msgstr ""
+"Esta columna ya está marcada como única. Desactiva \"Único\" del campo "
+"primero si deseas gestionar la restricción aquí."
 
 #. js-lingui-id: ADtO2E
 #: src/engine/twenty-orm/exceptions/twenty-orm.exception.ts
@@ -7022,7 +7565,7 @@ msgstr "Este correo electrónico ya está en uso."
 #. js-lingui-id: mjE4RD
 #: src/engine/metadata-modules/ai/ai-agent-monitor/services/agent-turn-grader.service.ts
 msgid "This evaluation target could not be found."
-msgstr ""
+msgstr "Este objetivo de evaluación no se pudo encontrar."
 
 #. js-lingui-id: hsi+jf
 #: src/engine/core-modules/workspace/workspace.exception.ts
@@ -7043,12 +7586,12 @@ msgstr "Este nombre de campo no está disponible."
 #: src/engine/workspace-manager/workspace-migration/workspace-migration-builder/validators/services/flat-field-permission-validator.service.ts
 #: src/engine/workspace-manager/workspace-migration/workspace-migration-builder/validators/services/flat-field-permission-validator.service.ts
 msgid "This field permission is already set for the role"
-msgstr ""
+msgstr "Este permiso de campo ya está configurado para el rol"
 
 #. js-lingui-id: 7f5dRA
 #: src/engine/metadata-modules/index-metadata/services/index-metadata.service.ts
 msgid "This index does not exist or has already been deleted."
-msgstr ""
+msgstr "Este índice no existe o ya ha sido eliminado."
 
 #. js-lingui-id: 6Z/zIt
 #: src/engine/metadata-modules/permissions/permissions.exception.ts
@@ -7070,8 +7613,12 @@ msgstr "Este nombre no está disponible."
 #: src/engine/metadata-modules/flat-object-metadata/validators/utils/validate-flat-object-metadata-name.util.ts
 #: src/engine/metadata-modules/flat-field-metadata/validators/utils/validate-flat-field-metadata-name.util.ts
 #: src/engine/metadata-modules/flat-field-metadata/validators/utils/validate-flat-field-metadata-name.util.ts
-msgid "This name is reserved. Use a different name or the system will add \"Custom\" suffix."
+msgid ""
+"This name is reserved. Use a different name or the system will add "
+"\"Custom\" suffix."
 msgstr ""
+"Este nombre está reservado. Usa un nombre diferente o el sistema añadirá el "
+"sufijo \"Personalizado\"."
 
 #. js-lingui-id: R8zIJd
 #: src/engine/metadata-modules/object-metadata/object-metadata.exception.ts
@@ -7091,8 +7638,12 @@ msgstr "Esta operación no está permitida."
 
 #. js-lingui-id: eitC3W
 #: src/engine/workspace-datasource/workspace-datasource.service.ts
-msgid "This operation is not allowed. Please try a different approach or contact support if you need assistance."
-msgstr "Esta operación no está permitida. Por favor, intente un enfoque diferente o contacte al soporte si necesita asistencia."
+msgid ""
+"This operation is not allowed. Please try a different approach or contact "
+"support if you need assistance."
+msgstr ""
+"Esta operación no está permitida. Por favor, intente un enfoque diferente o "
+"contacte al soporte si necesita asistencia."
 
 #. js-lingui-id: bEhTPN
 #: src/engine/workspace-manager/workspace-migration/workspace-migration-runner/exceptions/workspace-migration-action-execution.exception.ts
@@ -7119,7 +7670,8 @@ msgstr "Este dominio público ya está registrado."
 #: src/engine/api/graphql/workspace-query-runner/utils/handle-duplicate-key-error.util.ts
 #: src/engine/api/graphql/workspace-query-runner/utils/handle-duplicate-key-error.util.ts
 msgid "This record already exists. Please check your data and try again."
-msgstr "Este registro ya existe. Por favor, revise sus datos e intente de nuevo."
+msgstr ""
+"Este registro ya existe. Por favor, revise sus datos e intente de nuevo."
 
 #. js-lingui-id: 0arbc4
 #: src/engine/api/common/common-query-runners/common-update-one-query-runner.service.ts
@@ -7164,13 +7716,17 @@ msgstr "Este rol no se puede editar."
 #: src/engine/workspace-manager/workspace-migration/workspace-migration-builder/validators/services/flat-field-permission-validator.service.ts
 #: src/engine/workspace-manager/workspace-migration/workspace-migration-builder/validators/services/flat-field-permission-validator.service.ts
 #: src/engine/workspace-manager/workspace-migration/workspace-migration-builder/validators/services/flat-field-permission-validator.service.ts
-msgid "This role cannot be modified because it is a system role. Only custom roles can be edited."
-msgstr "Este rol no puede ser modificado porque es un rol del sistema. Solo se pueden editar roles personalizados."
+msgid ""
+"This role cannot be modified because it is a system role. Only custom roles "
+"can be edited."
+msgstr ""
+"Este rol no puede ser modificado porque es un rol del sistema. Solo se "
+"pueden editar roles personalizados."
 
 #. js-lingui-id: nzveUr
 #: src/engine/metadata-modules/object-permission/field-permission/__tests__/field-permissions.service.spec.ts
 msgid "This role cannot be modified."
-msgstr ""
+msgstr "Este rol no se puede modificar."
 
 #. js-lingui-id: nFIPim
 #: src/engine/core-modules/workspace/workspace.exception.ts
@@ -7199,28 +7755,34 @@ msgstr "Esta variable solo se puede establecer mediante el entorno."
 
 #. js-lingui-id: Y5Fzhi
 #: src/engine/core-modules/application/application-registration/application-registration.exception.ts
-msgid "This version is not higher than the currently deployed version. Please bump the version in package.json before deploying again."
+msgid ""
+"This version is not higher than the currently deployed version. Please bump "
+"the version in package.json before deploying again."
 msgstr ""
+"Esta versión no es superior a la versión actualmente desplegada. Incrementa "
+"la versión en package.json antes de desplegar de nuevo."
 
 #. js-lingui-id: ZXnasf
 #: src/engine/core-modules/application/application.exception.ts
-msgid "This version of the application is already installed in this workspace."
+msgid ""
+"This version of the application is already installed in this workspace."
 msgstr ""
+"Esta versión de la aplicación ya está instalada en este espacio de trabajo."
 
 #. js-lingui-id: e66y2Z
 #: src/engine/metadata-modules/page-layout-widget/constants/standard-page-layout-widget-titles.ts
 msgid "Thread"
-msgstr ""
+msgstr "Hilo"
 
 #. js-lingui-id: Zl0BJl
 #: src/engine/workspace-manager/twenty-standard-application/utils/field-metadata/compute-message-channel-message-association-standard-flat-field-metadata.util.ts
 msgid "Thread External Id"
-msgstr ""
+msgstr "ID externo del hilo"
 
 #. js-lingui-id: RSSbWN
 #: src/engine/workspace-manager/twenty-standard-application/utils/field-metadata/compute-message-channel-message-association-standard-flat-field-metadata.util.ts
 msgid "Thread id from the messaging provider"
-msgstr ""
+msgstr "ID del hilo del proveedor de mensajería"
 
 #. js-lingui-id: kkDQ8m
 #: src/engine/api/graphql/graphql-query-runner/group-by/resolvers/utils/format-result-with-group-by-dimension-values.util.ts
@@ -7230,12 +7792,12 @@ msgstr "jueves"
 #. js-lingui-id: n9nSNJ
 #: src/engine/workspace-manager/twenty-standard-application/utils/field-metadata/compute-workspace-member-standard-flat-field-metadata.util.ts
 msgid "Time format"
-msgstr ""
+msgstr "Formato de hora"
 
 #. js-lingui-id: Mz2JN2
 #: src/engine/workspace-manager/twenty-standard-application/utils/field-metadata/compute-workspace-member-standard-flat-field-metadata.util.ts
 msgid "Time zone"
-msgstr ""
+msgstr "Zona horaria"
 
 #. js-lingui-id: cklVjM
 #: src/engine/metadata-modules/page-layout-widget/constants/standard-page-layout-widget-titles.ts
@@ -7254,57 +7816,57 @@ msgstr "Cronología"
 #: src/engine/workspace-manager/twenty-standard-application/utils/field-metadata/compute-dashboard-standard-flat-field-metadata.util.ts
 #: src/engine/workspace-manager/twenty-standard-application/utils/field-metadata/compute-company-standard-flat-field-metadata.util.ts
 msgid "Timeline Activities"
-msgstr ""
+msgstr "Actividades de la línea de tiempo"
 
 #. js-lingui-id: fqKMpF
 #: src/engine/workspace-manager/twenty-standard-application/utils/field-metadata/compute-company-standard-flat-field-metadata.util.ts
 msgid "Timeline Activities linked to the company"
-msgstr ""
+msgstr "Actividades de la línea de tiempo vinculadas a la empresa"
 
 #. js-lingui-id: CNev+0
 #: src/engine/workspace-manager/twenty-standard-application/utils/field-metadata/compute-dashboard-standard-flat-field-metadata.util.ts
 msgid "Timeline activities linked to the dashboard"
-msgstr ""
+msgstr "Actividades de la línea de tiempo vinculadas al panel"
 
 #. js-lingui-id: 4/UzU5
 #: src/engine/workspace-manager/twenty-standard-application/utils/field-metadata/compute-note-standard-flat-field-metadata.util.ts
 msgid "Timeline Activities linked to the note."
-msgstr ""
+msgstr "Actividades de la línea de tiempo vinculadas a la nota."
 
 #. js-lingui-id: p6feIz
 #: src/engine/workspace-manager/twenty-standard-application/utils/field-metadata/compute-opportunity-standard-flat-field-metadata.util.ts
 msgid "Timeline Activities linked to the opportunity."
-msgstr ""
+msgstr "Actividades de la línea de tiempo vinculadas a la oportunidad."
 
 #. js-lingui-id: yvPwuF
 #: src/engine/workspace-manager/twenty-standard-application/utils/field-metadata/compute-workflow-run-standard-flat-field-metadata.util.ts
 msgid "Timeline activities linked to the run"
-msgstr ""
+msgstr "Actividades de la línea de tiempo vinculadas a la ejecución"
 
 #. js-lingui-id: q96UvB
 #: src/engine/workspace-manager/twenty-standard-application/utils/field-metadata/compute-task-standard-flat-field-metadata.util.ts
 msgid "Timeline Activities linked to the task."
-msgstr ""
+msgstr "Actividades de la línea de tiempo vinculadas a la tarea."
 
 #. js-lingui-id: N9HMa/
 #: src/engine/workspace-manager/twenty-standard-application/utils/field-metadata/compute-workflow-version-standard-flat-field-metadata.util.ts
 msgid "Timeline activities linked to the version"
-msgstr ""
+msgstr "Actividades de la línea de tiempo vinculadas a la versión"
 
 #. js-lingui-id: B1CYKX
 #: src/engine/workspace-manager/twenty-standard-application/utils/field-metadata/compute-workflow-standard-flat-field-metadata.util.ts
 msgid "Timeline activities linked to the workflow"
-msgstr ""
+msgstr "Actividades de la línea de tiempo vinculadas al flujo de trabajo"
 
 #. js-lingui-id: K/kU4E
 #: src/engine/workspace-manager/twenty-standard-application/utils/object-metadata/create-standard-flat-object-metadata.util.ts
 msgid "Timeline Activity"
-msgstr ""
+msgstr "Actividad de la línea de tiempo"
 
 #. js-lingui-id: HSkSOA
 #: src/engine/workspace-manager/twenty-standard-application/utils/field-metadata/compute-timeline-activity-standard-flat-field-metadata.util.ts
 msgid "Timeline activity record position"
-msgstr ""
+msgstr "Posición del registro de actividad de la línea de tiempo"
 
 #. js-lingui-id: MHrjPM
 #: src/engine/workspace-manager/twenty-standard-application/utils/field-metadata/compute-task-standard-flat-field-metadata.util.ts
@@ -7313,17 +7875,17 @@ msgstr ""
 #: src/engine/workspace-manager/twenty-standard-application/utils/field-metadata/compute-calendar-event-standard-flat-field-metadata.util.ts
 #: src/engine/workspace-manager/twenty-standard-application/utils/field-metadata/compute-calendar-event-standard-flat-field-metadata.util.ts
 msgid "Title"
-msgstr ""
+msgstr "Título"
 
 #. js-lingui-id: /jQctM
 #: src/engine/workspace-manager/twenty-standard-application/utils/field-metadata/compute-message-participant-standard-flat-field-metadata.util.ts
 msgid "To"
-msgstr ""
+msgstr "Para"
 
 #. js-lingui-id: rZ9HZq
 #: src/engine/workspace-manager/twenty-standard-application/utils/field-metadata/compute-task-standard-flat-field-metadata.util.ts
 msgid "To do"
-msgstr ""
+msgstr "Pendiente"
 
 #. js-lingui-id: /ObxXq
 #: src/engine/metadata-modules/permissions/permissions.exception.ts
@@ -7333,7 +7895,7 @@ msgstr "Se encontraron demasiados candidatos a administrador."
 #. js-lingui-id: qSInGy
 #: src/engine/core-modules/tool/tools/email-tool/exceptions/email-tool.exception.ts
 msgid "Too many recipients."
-msgstr ""
+msgstr "Demasiados destinatarios."
 
 #. js-lingui-id: MYdvBz
 #: src/engine/api/graphql/workspace-query-runner/workspace-query-runner.exception.ts
@@ -7355,6 +7917,8 @@ msgstr "Demasiadas solicitudes. Por favor, inténtelo de nuevo más tarde."
 #: src/engine/core-modules/workspace-invitation/services/workspace-invitation.service.ts
 msgid "Too many workspace invitations sent. Please try again later."
 msgstr ""
+"Se han enviado demasiadas invitaciones al espacio de trabajo. Inténtalo de "
+"nuevo más tarde."
 
 #. js-lingui-id: tEb/hR
 #: src/modules/dashboard/chart-data/exceptions/chart-data.exception.ts
@@ -7404,8 +7968,11 @@ msgstr "No se puede recuperar el paquete de la aplicación."
 #. js-lingui-id: WWSSTx
 #: src/engine/workspace-manager/workspace-migration/workspace-migration-builder/validators/services/flat-index-metadata-validator.service.ts
 #: src/engine/workspace-manager/workspace-migration/workspace-migration-builder/validators/services/flat-index-metadata-validator.service.ts
-msgid "Unique index cannot be created for field {fieldName} of type {fieldType}"
-msgstr "No se puede crear un índice único para el campo {fieldName} del tipo {fieldType}"
+msgid ""
+"Unique index cannot be created for field {fieldName} of type {fieldType}"
+msgstr ""
+"No se puede crear un índice único para el campo {fieldName} del tipo "
+"{fieldType}"
 
 #. js-lingui-id: tEncxN
 #: src/engine/metadata-modules/permissions/permissions.exception.ts
@@ -7451,18 +8018,20 @@ msgstr "Tipo de widget de diseño de página no soportado {widgetType}"
 #. js-lingui-id: s+FRCn
 #: src/engine/metadata-modules/page-layout-widget/constants/standard-page-layout-widget-titles.ts
 msgid "Untitled Rich Text"
-msgstr ""
+msgstr "Texto enriquecido sin título"
 
 #. js-lingui-id: 0gY5lO
 #: src/engine/workspace-manager/twenty-standard-application/utils/field-metadata/compute-calendar-event-standard-flat-field-metadata.util.ts
 #: src/engine/workspace-manager/twenty-standard-application/utils/field-metadata/compute-calendar-event-standard-flat-field-metadata.util.ts
 msgid "Update DateTime"
-msgstr ""
+msgstr "Actualizar fecha y hora"
 
 #. js-lingui-id: lHCFXi
 #: src/engine/metadata-modules/permissions/permissions.exception.ts
 msgid "Update field restrictions only apply to updatable objects."
-msgstr "Las restricciones de actualización de campos solo se aplican a objetos actualizables."
+msgstr ""
+"Las restricciones de actualización de campos solo se aplican a objetos "
+"actualizables."
 
 #. js-lingui-id: KQsreu
 #: src/engine/workspace-manager/twenty-standard-application/utils/field-metadata/compute-workspace-member-standard-flat-field-metadata.util.ts
@@ -7490,7 +8059,7 @@ msgstr "Las restricciones de actualización de campos solo se aplican a objetos 
 #: src/engine/workspace-manager/twenty-standard-application/utils/field-metadata/compute-blocklist-standard-flat-field-metadata.util.ts
 #: src/engine/workspace-manager/twenty-standard-application/utils/field-metadata/compute-attachment-standard-flat-field-metadata.util.ts
 msgid "Updated by"
-msgstr ""
+msgstr "Actualizado por"
 
 #. js-lingui-id: r5C2wB
 #: src/engine/workspace-manager/workspace-migration/workspace-migration-builder/validators/services/flat-field-metadata-validator.service.ts
@@ -7533,7 +8102,7 @@ msgstr "El usuario no tiene permiso."
 #. js-lingui-id: YFciqL
 #: src/engine/workspace-manager/twenty-standard-application/utils/field-metadata/compute-workspace-member-standard-flat-field-metadata.util.ts
 msgid "User Email"
-msgstr ""
+msgstr "Correo electrónico del usuario"
 
 #. js-lingui-id: EHZMfR
 #: src/utils/__test__/custom-exception.spec.ts
@@ -7544,7 +8113,7 @@ msgstr "Mensaje de error amigable para el usuario"
 #. js-lingui-id: d1BTW8
 #: src/engine/workspace-manager/twenty-standard-application/utils/field-metadata/compute-workspace-member-standard-flat-field-metadata.util.ts
 msgid "User Id"
-msgstr ""
+msgstr "ID del usuario"
 
 #. js-lingui-id: NJT8W8
 #: src/modules/blocklist/query-hooks/blocklist-update-one.pre-query.hook.ts
@@ -7575,7 +8144,7 @@ msgstr "Usuario no encontrado. Por favor, revise el correo electrónico o ID."
 #. js-lingui-id: 4juE7s
 #: src/engine/workspace-manager/twenty-standard-application/utils/field-metadata/compute-workspace-member-standard-flat-field-metadata.util.ts
 msgid "User time zone"
-msgstr ""
+msgstr "Zona horaria del usuario"
 
 #. js-lingui-id: VkcC68
 #: src/engine/core-modules/auth/services/auth.service.ts
@@ -7595,38 +8164,41 @@ msgstr "Espacio de trabajo del usuario no encontrado."
 #. js-lingui-id: 9mCrQp
 #: src/engine/twenty-orm/exceptions/twenty-orm.exception.ts
 msgid "User workspace role configuration not found."
-msgstr "Configuración de rol del espacio de trabajo del usuario no encontrada."
+msgstr ""
+"Configuración de rol del espacio de trabajo del usuario no encontrada."
 
 #. js-lingui-id: UBPzFQ
 #: src/engine/metadata-modules/flat-field-metadata/validators/utils/validate-enum-flat-field-metadata.util.ts
 #: src/engine/metadata-modules/flat-field-metadata/validators/utils/validate-enum-flat-field-metadata.util.ts
 msgid "Value must be in UPPER_CASE and follow snake_case \"{sanitizedValue}\""
-msgstr "El valor debe estar en MAYÚSCULAS y seguir el formato snake_case \"{sanitizedValue}\""
+msgstr ""
+"El valor debe estar en MAYÚSCULAS y seguir el formato snake_case "
+"\"{sanitizedValue}\""
 
 #. js-lingui-id: 7aatUy
 #: src/engine/workspace-manager/twenty-standard-application/utils/field-metadata/compute-workflow-version-standard-flat-field-metadata.util.ts
 msgid "Version status"
-msgstr ""
+msgstr "Estado de la versión"
 
 #. js-lingui-id: CdQeU7
 #: src/engine/workspace-manager/twenty-standard-application/utils/field-metadata/compute-workflow-version-standard-flat-field-metadata.util.ts
 msgid "Version steps"
-msgstr ""
+msgstr "Pasos de la versión"
 
 #. js-lingui-id: PGMPIi
 #: src/engine/workspace-manager/twenty-standard-application/utils/field-metadata/compute-workflow-version-standard-flat-field-metadata.util.ts
 msgid "Version trigger"
-msgstr ""
+msgstr "Disparador de la versión"
 
 #. js-lingui-id: IYNSdp
 #: src/engine/workspace-manager/twenty-standard-application/utils/field-metadata/compute-workflow-standard-flat-field-metadata.util.ts
 msgid "Versions"
-msgstr ""
+msgstr "Versiones"
 
 #. js-lingui-id: vSJd18
 #: src/engine/workspace-manager/twenty-standard-application/utils/field-metadata/compute-attachment-standard-flat-field-metadata.util.ts
 msgid "Video"
-msgstr ""
+msgstr "Vídeo"
 
 #. js-lingui-id: HhN1Bv
 #: src/engine/workspace-manager/workspace-migration/workspace-migration-builder/validators/services/flat-view-validator.service.ts
@@ -7681,7 +8253,8 @@ msgstr "No se encontró el grupo de campos de la vista a actualizar."
 #. js-lingui-id: oKThPN
 #: src/engine/workspace-manager/workspace-migration/workspace-migration-builder/validators/services/flat-view-field-group-validator.service.ts
 msgid "View field group with this universal identifier already exists"
-msgstr "El grupo de campos de la vista con este identificador universal ya existe"
+msgstr ""
+"El grupo de campos de la vista con este identificador universal ya existe"
 
 #. js-lingui-id: 7jUWQ+
 #: src/engine/workspace-manager/workspace-migration/workspace-migration-builder/validators/services/flat-view-field-validator.service.ts
@@ -7691,19 +8264,26 @@ msgstr "Los metadatos del campo de vista ya existen"
 #. js-lingui-id: mdX5P2
 #: src/engine/workspace-manager/workspace-migration/workspace-migration-builder/validators/services/flat-view-field-validator.service.ts
 msgid "View field metadata with this universal identifier already exists"
-msgstr "Los metadatos del campo de vista con este identificador universal ya existen"
+msgstr ""
+"Los metadatos del campo de vista con este identificador universal ya existen"
 
 #. js-lingui-id: 7LMaUn
 #: src/engine/workspace-manager/workspace-migration/workspace-migration-builder/validators/services/flat-view-field-validator.service.ts
 #: src/engine/workspace-manager/workspace-migration/workspace-migration-builder/validators/services/flat-view-field-validator.service.ts
-msgid "View field position cannot be lower than label identifier view field position"
-msgstr "La posición del campo de vista no puede ser inferior a la posición del campo de vista del identificador de etiqueta"
+msgid ""
+"View field position cannot be lower than label identifier view field "
+"position"
+msgstr ""
+"La posición del campo de vista no puede ser inferior a la posición del campo"
+" de vista del identificador de etiqueta"
 
 #. js-lingui-id: WZzm3R
 #: src/engine/workspace-manager/workspace-migration/workspace-migration-builder/validators/services/flat-view-field-validator.service.ts
 #: src/engine/workspace-manager/workspace-migration/workspace-migration-builder/validators/services/flat-view-field-validator.service.ts
 msgid "View field related view object metadata not found"
-msgstr "Metadatos del objeto de vista relacionados con el campo de vista no encontrados"
+msgstr ""
+"Metadatos del objeto de vista relacionados con el campo de vista no "
+"encontrados"
 
 #. js-lingui-id: XJlyZS
 #: src/engine/workspace-manager/workspace-migration/workspace-migration-builder/validators/services/flat-view-field-validator.service.ts
@@ -7734,12 +8314,17 @@ msgstr "Campo de vista para actualizar la vista principal no encontrado"
 #: src/engine/workspace-manager/workspace-migration/workspace-migration-builder/validators/services/flat-view-field-validator.service.ts
 #: src/engine/workspace-manager/workspace-migration/workspace-migration-builder/validators/services/flat-view-field-validator.service.ts
 msgid "View field to update parent view object not found"
-msgstr "Campo de vista para actualizar el objeto de la vista principal no encontrado"
+msgstr ""
+"Campo de vista para actualizar el objeto de la vista principal no encontrado"
 
 #. js-lingui-id: Zqbr+6
 #: src/engine/workspace-manager/workspace-migration/workspace-migration-builder/validators/services/flat-view-field-validator.service.ts
-msgid "View field with same fieldMetadataUniversalIdentifier and viewUniversalIdentifier already exists"
-msgstr "El campo de vista con el mismo fieldMetadataUniversalIdentifier y viewUniversalIdentifier ya existe"
+msgid ""
+"View field with same fieldMetadataUniversalIdentifier and "
+"viewUniversalIdentifier already exists"
+msgstr ""
+"El campo de vista con el mismo fieldMetadataUniversalIdentifier y "
+"viewUniversalIdentifier ya existe"
 
 #. js-lingui-id: sbHaOg
 #: src/engine/workspace-manager/workspace-migration/workspace-migration-builder/validators/services/flat-view-filter-validator.service.ts
@@ -7760,8 +8345,12 @@ msgstr "El grupo de filtros de vista no puede ser su propio grupo principal"
 #. js-lingui-id: tir/7Q
 #: src/engine/workspace-manager/workspace-migration/workspace-migration-builder/validators/services/flat-view-filter-group-validator.service.ts
 #: src/engine/workspace-manager/workspace-migration/workspace-migration-builder/validators/services/flat-view-filter-group-validator.service.ts
-msgid "View filter group hierarchy exceeds maximum depth of {VIEW_FILTER_GROUP_MAX_DEPTH}"
-msgstr "La jerarquía del grupo de filtros de vista supera la profundidad máxima de {VIEW_FILTER_GROUP_MAX_DEPTH}"
+msgid ""
+"View filter group hierarchy exceeds maximum depth of "
+"{VIEW_FILTER_GROUP_MAX_DEPTH}"
+msgstr ""
+"La jerarquía del grupo de filtros de vista supera la profundidad máxima de "
+"{VIEW_FILTER_GROUP_MAX_DEPTH}"
 
 #. js-lingui-id: eUPMYZ
 #: src/engine/workspace-manager/workspace-migration/workspace-migration-builder/validators/services/flat-view-filter-validator.service.ts
@@ -7778,7 +8367,8 @@ msgstr "No se encontró el grupo de filtros de vista"
 #. js-lingui-id: inVepb
 #: src/engine/workspace-manager/workspace-migration/workspace-migration-builder/validators/services/flat-view-filter-group-validator.service.ts
 msgid "View filter group with this universal identifier already exists"
-msgstr "El grupo de filtros de vista con este identificador universal ya existe"
+msgstr ""
+"El grupo de filtros de vista con este identificador universal ya existe"
 
 #. js-lingui-id: 1KSqGE
 #: src/engine/workspace-manager/workspace-migration/workspace-migration-builder/validators/services/flat-view-filter-validator.service.ts
@@ -7815,8 +8405,12 @@ msgstr "Los metadatos del grupo de vista ya existen"
 
 #. js-lingui-id: c1XRE3
 #: src/engine/workspace-manager/workspace-migration/workspace-migration-builder/validators/services/flat-view-group-validator.service.ts
-msgid "View group metadata with universal identifier {flatViewGroupUniversalIdentifier} already exists"
-msgstr "Los metadatos del grupo de vista con el identificador universal {flatViewGroupUniversalIdentifier} ya existen"
+msgid ""
+"View group metadata with universal identifier "
+"{flatViewGroupUniversalIdentifier} already exists"
+msgstr ""
+"Los metadatos del grupo de vista con el identificador universal "
+"{flatViewGroupUniversalIdentifier} ya existen"
 
 #. js-lingui-id: JdAvYa
 #: src/engine/workspace-manager/workspace-migration/workspace-migration-builder/validators/services/flat-view-group-validator.service.ts
@@ -7881,7 +8475,7 @@ msgstr "No se encontró la vista después del upsert"
 #. js-lingui-id: RAcTQ1
 #: src/engine/metadata-modules/view/services/view-widget-upsert.service.ts
 msgid "View not found for widget"
-msgstr ""
+msgstr "Vista no encontrada para el widget"
 
 #. js-lingui-id: yheEin
 #: src/engine/metadata-modules/view/exceptions/flat-view.exception.ts
@@ -7917,7 +8511,8 @@ msgstr "No se encontró la ordenación de la vista para actualizar"
 #: src/engine/workspace-manager/workspace-migration/workspace-migration-builder/validators/services/flat-view-sort-validator.service.ts
 #: src/engine/workspace-manager/workspace-migration/workspace-migration-builder/validators/services/flat-view-sort-validator.service.ts
 msgid "View sort to update parent view not found"
-msgstr "No se encontró la ordenación de la vista para actualizar la vista principal"
+msgstr ""
+"No se encontró la ordenación de la vista para actualizar la vista principal"
 
 #. js-lingui-id: RP+pKP
 #: src/engine/workspace-manager/workspace-migration/workspace-migration-builder/validators/services/flat-view-sort-validator.service.ts
@@ -7932,12 +8527,14 @@ msgstr "La ordenación de la vista tiene una dirección no válida"
 #. js-lingui-id: ezJrlG
 #: src/engine/workspace-manager/workspace-migration/workspace-migration-builder/validators/services/flat-view-sort-validator.service.ts
 msgid "View sort with invalid direction, should be ASC or DESC"
-msgstr "La ordenación de la vista tiene una dirección no válida, debe ser ASC o DESC"
+msgstr ""
+"La ordenación de la vista tiene una dirección no válida, debe ser ASC o DESC"
 
 #. js-lingui-id: 9/BbL9
 #: src/engine/workspace-manager/workspace-migration/workspace-migration-builder/validators/services/flat-view-sort-validator.service.ts
 msgid "View sort with same fieldMetadataId and viewId already exists"
-msgstr "La ordenación de la vista con el mismo fieldMetadataId y viewId ya existe"
+msgstr ""
+"La ordenación de la vista con el mismo fieldMetadataId y viewId ya existe"
 
 #. js-lingui-id: toB/08
 #: src/engine/metadata-modules/flat-view/utils/from-delete-view-input-to-flat-view-or-throw.util.ts
@@ -7992,38 +8589,66 @@ msgstr "ViewId es necesario para crear un orden de vista."
 
 #. js-lingui-id: xvV2NJ
 #: src/engine/twenty-orm/error-handling/compute-twenty-orm-exception.ts
-msgid "We are experiencing a temporary issue with our database. Please try again later."
-msgstr "Estamos experimentando un problema temporal con nuestra base de datos. Por favor, inténtelo de nuevo más tarde."
+msgid ""
+"We are experiencing a temporary issue with our database. Please try again "
+"later."
+msgstr ""
+"Estamos experimentando un problema temporal con nuestra base de datos. Por "
+"favor, inténtelo de nuevo más tarde."
 
 #. js-lingui-id: B3CG/U
 #: src/engine/core-modules/imap-smtp-caldav-connection/services/imap-smtp-caldav-connection.service.ts
-msgid "We couldn't connect to your CalDAV server. Please check your server settings and try again."
-msgstr "No pudimos conectar con su servidor CalDAV. Por favor verifique la configuración de su servidor e intente nuevamente."
+msgid ""
+"We couldn't connect to your CalDAV server. Please check your server settings"
+" and try again."
+msgstr ""
+"No pudimos conectar con su servidor CalDAV. Por favor verifique la "
+"configuración de su servidor e intente nuevamente."
 
 #. js-lingui-id: ax8unE
 #: src/engine/core-modules/imap-smtp-caldav-connection/services/imap-smtp-caldav-connection.service.ts
-msgid "We couldn't connect to your email server. Please check your server settings and try again."
-msgstr "No pudimos conectar con su servidor de correo electrónico. Por favor, revise la configuración de su servidor e inténtelo de nuevo."
+msgid ""
+"We couldn't connect to your email server. Please check your server settings "
+"and try again."
+msgstr ""
+"No pudimos conectar con su servidor de correo electrónico. Por favor, revise"
+" la configuración de su servidor e inténtelo de nuevo."
 
 #. js-lingui-id: g4rOV3
 #: src/engine/core-modules/imap-smtp-caldav-connection/services/imap-smtp-caldav-connection.service.ts
-msgid "We couldn't connect to your outgoing email server. Please check your SMTP settings and try again."
-msgstr "No pudimos conectar con su servidor de correo saliente. Por favor, revise las configuraciones SMTP e intente de nuevo."
+msgid ""
+"We couldn't connect to your outgoing email server. Please check your SMTP "
+"settings and try again."
+msgstr ""
+"No pudimos conectar con su servidor de correo saliente. Por favor, revise "
+"las configuraciones SMTP e intente de nuevo."
 
 #. js-lingui-id: jNr0+j
 #: src/engine/core-modules/imap-smtp-caldav-connection/services/imap-smtp-caldav-connection.service.ts
-msgid "We couldn't find any calendars on your CalDAV server. Please make sure your account has at least one calendar."
+msgid ""
+"We couldn't find any calendars on your CalDAV server. Please make sure your "
+"account has at least one calendar."
 msgstr ""
+"No pudimos encontrar calendarios en tu servidor CalDAV. Asegúrate de que tu "
+"cuenta tenga al menos un calendario."
 
 #. js-lingui-id: v8UNEA
 #: src/engine/core-modules/imap-smtp-caldav-connection/services/imap-smtp-caldav-connection.service.ts
-msgid "We couldn't log in to your email account. Please check your email address and password, then try again."
-msgstr "No pudimos iniciar sesión en su cuenta de correo electrónico. Por favor, verifique su dirección de correo y contraseña, y vuelva a intentarlo."
+msgid ""
+"We couldn't log in to your email account. Please check your email address "
+"and password, then try again."
+msgstr ""
+"No pudimos iniciar sesión en su cuenta de correo electrónico. Por favor, "
+"verifique su dirección de correo y contraseña, y vuelva a intentarlo."
 
 #. js-lingui-id: YxBvFz
 #: src/engine/core-modules/imap-smtp-caldav-connection/services/imap-smtp-caldav-connection.service.ts
-msgid "We encountered an issue connecting to your email account. Please check your settings and try again."
-msgstr "Encontramos un problema al conectar con su cuenta de correo electrónico. Por favor, revise su configuración e intente nuevamente."
+msgid ""
+"We encountered an issue connecting to your email account. Please check your "
+"settings and try again."
+msgstr ""
+"Encontramos un problema al conectar con su cuenta de correo electrónico. Por"
+" favor, revise su configuración e intente nuevamente."
 
 #. js-lingui-id: mnANRQ
 #: src/engine/workspace-manager/workspace-migration/workspace-migration-builder/validators/services/flat-webhook-validator.service.ts
@@ -8065,12 +8690,12 @@ msgstr "El widget se extiende más allá del ancho de la cuadrícula"
 #. js-lingui-id: +9R1ka
 #: src/engine/metadata-modules/page-layout-widget/utils/validate-page-layout-widget-vertical-list-position.util.ts
 msgid "Widget index must be a non-negative integer"
-msgstr ""
+msgstr "El índice del widget debe ser un número entero no negativo"
 
 #. js-lingui-id: znCTbL
 #: src/engine/metadata-modules/page-layout-widget/utils/validate-page-layout-widget-vertical-list-position.util.ts
 msgid "Widget index must be an integer"
-msgstr ""
+msgstr "El índice del widget debe ser un número entero"
 
 #. js-lingui-id: 09IBNJ
 #: src/modules/dashboard/chart-data/exceptions/chart-data.exception.ts
@@ -8081,6 +8706,8 @@ msgstr "No se encontró el widget."
 #: src/engine/workspace-manager/workspace-migration/workspace-migration-builder/validators/services/flat-page-layout-widget-validator.service.ts
 msgid "Widget position type must match the tab layout mode"
 msgstr ""
+"El tipo de posición del widget debe coincidir con el modo de diseño de la "
+"pestaña"
 
 #. js-lingui-id: D5gHL1
 #: src/engine/metadata-modules/page-layout-widget/utils/validate-widget-grid-position.util.ts
@@ -8097,7 +8724,7 @@ msgstr "El tipo de widget VIEW aún no está soportado."
 #. js-lingui-id: qRILxq
 #: src/engine/metadata-modules/view-field-group/constants/standard-view-field-group-names.ts
 msgid "Work"
-msgstr ""
+msgstr "Trabajo"
 
 #. js-lingui-id: bLt/0J
 #: src/engine/workspace-manager/twenty-standard-application/utils/object-metadata/create-standard-flat-object-metadata.util.ts
@@ -8106,22 +8733,24 @@ msgstr ""
 #: src/engine/workspace-manager/twenty-standard-application/utils/field-metadata/compute-workflow-automated-trigger-standard-flat-field-metadata.util.ts
 #: src/engine/metadata-modules/page-layout-widget/constants/standard-page-layout-widget-titles.ts
 msgid "Workflow"
-msgstr ""
+msgstr "Flujo de trabajo"
 
 #. js-lingui-id: Fd5Tey
 #: src/engine/workspace-manager/twenty-standard-application/utils/object-metadata/create-standard-flat-object-metadata.util.ts
 msgid "Workflow Automated Trigger"
-msgstr ""
+msgstr "Disparador automatizado del flujo de trabajo"
 
 #. js-lingui-id: 9h8c8+
 #: src/engine/workspace-manager/twenty-standard-application/utils/object-metadata/create-standard-flat-object-metadata.util.ts
 msgid "Workflow Automated Triggers"
-msgstr ""
+msgstr "Disparadores automatizados del flujo de trabajo"
 
 #. js-lingui-id: hdtWQn
 #: src/engine/workspace-manager/twenty-standard-application/utils/field-metadata/compute-workflow-standard-flat-field-metadata.util.ts
 msgid "Workflow automated triggers linked to the workflow."
 msgstr ""
+"Disparadores automatizados del flujo de trabajo vinculados al flujo de "
+"trabajo."
 
 #. js-lingui-id: KSK8fH
 #: src/modules/workflow/common/exceptions/workflow-version-edge.exception.ts
@@ -8131,7 +8760,7 @@ msgstr "Arista del flujo de trabajo no encontrada."
 #. js-lingui-id: vwSkSW
 #: src/engine/workspace-manager/twenty-standard-application/utils/field-metadata/compute-workflow-run-standard-flat-field-metadata.util.ts
 msgid "Workflow linked to the run."
-msgstr ""
+msgstr "Flujo de trabajo vinculado a la ejecución."
 
 #. js-lingui-id: R67jts
 #: src/modules/workflow/workflow-trigger/exceptions/workflow-trigger.exception.ts
@@ -8141,7 +8770,7 @@ msgstr "Flujo de trabajo no encontrado."
 #. js-lingui-id: y9tnFx
 #: src/engine/workspace-manager/twenty-standard-application/utils/field-metadata/compute-workflow-standard-flat-field-metadata.util.ts
 msgid "Workflow record position"
-msgstr ""
+msgstr "Posición del registro de flujo de trabajo"
 
 #. js-lingui-id: ysb9m+
 #: src/modules/workflow/workflow-runner/exceptions/workflow-run.exception.ts
@@ -8151,24 +8780,25 @@ msgstr "Paso raíz del flujo de trabajo no encontrado."
 #. js-lingui-id: 5vIcqC
 #: src/engine/workspace-manager/twenty-standard-application/utils/object-metadata/create-standard-flat-object-metadata.util.ts
 msgid "Workflow Run"
-msgstr ""
+msgstr "Ejecución del flujo de trabajo"
 
 #. js-lingui-id: TgOSaQ
 #: src/modules/workflow/workflow-runner/workspace-services/workflow-runner.workspace-service.ts
 msgid "Workflow run cannot be stopped in its current status"
-msgstr "La ejecución del flujo de trabajo no se puede detener en su estado actual"
+msgstr ""
+"La ejecución del flujo de trabajo no se puede detener en su estado actual"
 
 #. js-lingui-id: 3Iz+qz
 #: src/engine/workspace-manager/twenty-standard-application/utils/field-metadata/compute-workflow-run-standard-flat-field-metadata.util.ts
 #: src/engine/workspace-manager/twenty-standard-application/utils/field-metadata/compute-workflow-run-standard-flat-field-metadata.util.ts
 msgid "Workflow run ended at"
-msgstr ""
+msgstr "Ejecución del flujo de trabajo finalizada el"
 
 #. js-lingui-id: NKQlas
 #: src/engine/workspace-manager/twenty-standard-application/utils/field-metadata/compute-workflow-run-standard-flat-field-metadata.util.ts
 #: src/engine/workspace-manager/twenty-standard-application/utils/field-metadata/compute-workflow-run-standard-flat-field-metadata.util.ts
 msgid "Workflow run enqueued at"
-msgstr ""
+msgstr "Ejecución del flujo de trabajo encolada el"
 
 #. js-lingui-id: AzylSS
 #: src/modules/workflow/workflow-runner/exceptions/workflow-run.exception.ts
@@ -8183,34 +8813,34 @@ msgstr "Ejecución del flujo de trabajo no encontrada."
 #. js-lingui-id: IUaK6s
 #: src/engine/workspace-manager/twenty-standard-application/utils/field-metadata/compute-workflow-run-standard-flat-field-metadata.util.ts
 msgid "Workflow run position"
-msgstr ""
+msgstr "Posición de ejecución del flujo de trabajo"
 
 #. js-lingui-id: zaN7tH
 #: src/engine/workspace-manager/twenty-standard-application/utils/field-metadata/compute-workflow-run-standard-flat-field-metadata.util.ts
 #: src/engine/workspace-manager/twenty-standard-application/utils/field-metadata/compute-workflow-run-standard-flat-field-metadata.util.ts
 msgid "Workflow run started at"
-msgstr ""
+msgstr "Ejecución del flujo de trabajo iniciada el"
 
 #. js-lingui-id: 1TU2A8
 #: src/engine/workspace-manager/twenty-standard-application/utils/field-metadata/compute-workflow-run-standard-flat-field-metadata.util.ts
 #: src/engine/workspace-manager/twenty-standard-application/utils/field-metadata/compute-workflow-run-standard-flat-field-metadata.util.ts
 msgid "Workflow run status"
-msgstr ""
+msgstr "Estado de ejecución del flujo de trabajo"
 
 #. js-lingui-id: u6DF/V
 #: src/engine/workspace-manager/twenty-standard-application/utils/object-metadata/create-standard-flat-object-metadata.util.ts
 msgid "Workflow Runs"
-msgstr ""
+msgstr "Ejecuciones del flujo de trabajo"
 
 #. js-lingui-id: 9nOy7k
 #: src/engine/workspace-manager/twenty-standard-application/utils/field-metadata/compute-workflow-version-standard-flat-field-metadata.util.ts
 msgid "Workflow runs linked to the version."
-msgstr ""
+msgstr "Ejecuciones del flujo de trabajo vinculadas a la versión."
 
 #. js-lingui-id: c37F3j
 #: src/engine/workspace-manager/twenty-standard-application/utils/field-metadata/compute-workflow-standard-flat-field-metadata.util.ts
 msgid "Workflow runs linked to the workflow."
-msgstr ""
+msgstr "Ejecuciones del flujo de trabajo vinculadas al flujo de trabajo."
 
 #. js-lingui-id: dD9Vpa
 #: src/modules/workflow/workflow-executor/exceptions/workflow-step-executor.exception.ts
@@ -8221,12 +8851,12 @@ msgstr "Paso del flujo de trabajo no encontrado."
 #. js-lingui-id: lTXctu
 #: src/engine/workspace-manager/twenty-standard-application/utils/field-metadata/compute-workflow-run-standard-flat-field-metadata.util.ts
 msgid "Workflow version"
-msgstr ""
+msgstr "Versión del flujo de trabajo"
 
 #. js-lingui-id: +wYPET
 #: src/engine/workspace-manager/twenty-standard-application/utils/object-metadata/create-standard-flat-object-metadata.util.ts
 msgid "Workflow Version"
-msgstr ""
+msgstr "Versión del flujo de trabajo"
 
 #. js-lingui-id: n4/IOE
 #: src/modules/workflow/common/utils/assert-workflow-version-has-steps.ts
@@ -8247,74 +8877,92 @@ msgstr "La versión del flujo de trabajo no está en estado de borrador"
 #. js-lingui-id: 4OOQwW
 #: src/engine/workspace-manager/workspace-migration/workspace-migration-builder/validators/services/flat-command-menu-item-validator.service.ts
 msgid "Workflow version is required for workflow trigger items"
-msgstr "La versión del flujo de trabajo es obligatoria para los elementos de activación de flujos de trabajo"
+msgstr ""
+"La versión del flujo de trabajo es obligatoria para los elementos de "
+"activación de flujos de trabajo"
 
 #. js-lingui-id: CocTJJ
 #: src/engine/workspace-manager/twenty-standard-application/utils/field-metadata/compute-workflow-run-standard-flat-field-metadata.util.ts
 msgid "Workflow version linked to the run."
-msgstr ""
+msgstr "Versión del flujo de trabajo vinculada a la ejecución."
 
 #. js-lingui-id: LrPIBF
 #: src/engine/workspace-manager/workspace-migration/workspace-migration-builder/validators/services/flat-command-menu-item-validator.service.ts
 msgid "Workflow version must not be set for front component renderer items"
-msgstr "La versión del flujo de trabajo no debe establecerse para los elementos del renderizador de componentes de interfaz"
+msgstr ""
+"La versión del flujo de trabajo no debe establecerse para los elementos del "
+"renderizador de componentes de interfaz"
 
 #. js-lingui-id: f9Rp2t
 #: src/engine/workspace-manager/workspace-migration/workspace-migration-builder/validators/services/flat-command-menu-item-validator.service.ts
 #: src/engine/workspace-manager/workspace-migration/workspace-migration-builder/validators/services/flat-command-menu-item-validator.service.ts
 msgid "Workflow version must not be set for this item type"
-msgstr "La versión del flujo de trabajo no debe establecerse para este tipo de elemento"
+msgstr ""
+"La versión del flujo de trabajo no debe establecerse para este tipo de "
+"elemento"
 
 #. js-lingui-id: 9l+pJT
 #: src/engine/workspace-manager/twenty-standard-application/utils/field-metadata/compute-workflow-version-standard-flat-field-metadata.util.ts
 msgid "Workflow version position"
-msgstr ""
+msgstr "Posición de la versión del flujo de trabajo"
 
 #. js-lingui-id: OCyhkn
 #: src/engine/workspace-manager/twenty-standard-application/utils/object-metadata/create-standard-flat-object-metadata.util.ts
 msgid "Workflow Versions"
-msgstr ""
+msgstr "Versiones del flujo de trabajo"
 
 #. js-lingui-id: 018fP9
 #: src/engine/workspace-manager/twenty-standard-application/utils/field-metadata/compute-workflow-standard-flat-field-metadata.util.ts
 msgid "Workflow versions linked to the workflow."
-msgstr ""
+msgstr "Versiones del flujo de trabajo vinculadas al flujo de trabajo."
 
 #. js-lingui-id: NBReV8
 #: src/engine/workspace-manager/twenty-standard-application/utils/field-metadata/compute-workflow-automated-trigger-standard-flat-field-metadata.util.ts
 msgid "WorkflowAutomatedTrigger record position"
-msgstr ""
+msgstr "Posición del registro de disparador automatizado del flujo de trabajo"
 
 #. js-lingui-id: 96bCgZ
 #: src/engine/workspace-manager/twenty-standard-application/utils/field-metadata/compute-workflow-automated-trigger-standard-flat-field-metadata.util.ts
 msgid "WorkflowAutomatedTrigger workflow"
-msgstr ""
+msgstr "Flujo de trabajo del disparador automatizado"
 
 #. js-lingui-id: woYYQq
 #: src/engine/workspace-manager/twenty-standard-application/utils/object-metadata/create-standard-flat-object-metadata.util.ts
 msgid "Workflows"
-msgstr ""
+msgstr "Flujos de trabajo"
 
 #. js-lingui-id: b4kire
 #: src/engine/workspace-manager/twenty-standard-application/utils/field-metadata/compute-workflow-version-standard-flat-field-metadata.util.ts
 msgid "WorkflowVersion workflow"
-msgstr ""
+msgstr "Flujo de trabajo de la versión del flujo de trabajo"
 
 #. js-lingui-id: m34s12
 #: src/engine/workspace-manager/workspace-migration/workspace-migration-builder/validators/services/flat-command-menu-item-validator.service.ts
-msgid "workflowVersionId is required when engineComponentKey is TRIGGER_WORKFLOW_VERSION"
-msgstr "workflowVersionId es obligatorio cuando engineComponentKey es TRIGGER_WORKFLOW_VERSION"
+msgid ""
+"workflowVersionId is required when engineComponentKey is "
+"TRIGGER_WORKFLOW_VERSION"
+msgstr ""
+"workflowVersionId es obligatorio cuando engineComponentKey es "
+"TRIGGER_WORKFLOW_VERSION"
 
 #. js-lingui-id: +67q2u
 #: src/engine/workspace-manager/workspace-migration/workspace-migration-builder/validators/services/flat-command-menu-item-validator.service.ts
 #: src/engine/workspace-manager/workspace-migration/workspace-migration-builder/validators/services/flat-command-menu-item-validator.service.ts
-msgid "workflowVersionId must not be set for engine component key {engineComponentKey}"
-msgstr "workflowVersionId no debe establecerse para la clave del componente del motor {engineComponentKey}"
+msgid ""
+"workflowVersionId must not be set for engine component key "
+"{engineComponentKey}"
+msgstr ""
+"workflowVersionId no debe establecerse para la clave del componente del "
+"motor {engineComponentKey}"
 
 #. js-lingui-id: lscvqN
 #: src/engine/workspace-manager/workspace-migration/workspace-migration-builder/validators/services/flat-command-menu-item-validator.service.ts
-msgid "workflowVersionId must not be set when engineComponentKey is FRONT_COMPONENT_RENDERER"
-msgstr "workflowVersionId no debe establecerse cuando engineComponentKey es FRONT_COMPONENT_RENDERER"
+msgid ""
+"workflowVersionId must not be set when engineComponentKey is "
+"FRONT_COMPONENT_RENDERER"
+msgstr ""
+"workflowVersionId no debe establecerse cuando engineComponentKey es "
+"FRONT_COMPONENT_RENDERER"
 
 #. js-lingui-id: bK8AyJ
 #: src/engine/core-modules/billing-webhook/services/billing-webhook-subscription.service.ts
@@ -8326,11 +8974,14 @@ msgstr "Espacio de trabajo {workspaceId} no encontrado."
 #: src/engine/core-modules/billing/billing.exception.ts
 msgid "Workspace cannot be deleted: subscription is not yet canceled."
 msgstr ""
+"El espacio de trabajo no se puede eliminar: la suscripción aún no se ha "
+"cancelado."
 
 #. js-lingui-id: XsSVrR
 #: src/engine/core-modules/auth/services/sign-in-up.service.ts
 msgid "Workspace creation is restricted to admins"
-msgstr "La creación de espacios de trabajo está restringida a los administradores"
+msgstr ""
+"La creación de espacios de trabajo está restringida a los administradores"
 
 #. js-lingui-id: qSQPRS
 #: src/engine/core-modules/auth/services/auth.service.ts
@@ -8350,13 +9001,17 @@ msgstr "El espacio de trabajo no está listo para recibir nuevos miembros"
 
 #. js-lingui-id: iN7doz
 #: src/engine/core-modules/auth/services/sign-in-up.service.ts
-msgid "Workspace limit reached. A valid enterprise key is required to create more workspaces."
+msgid ""
+"Workspace limit reached. A valid enterprise key is required to create more "
+"workspaces."
 msgstr ""
+"Límite de espacios de trabajo alcanzado. Se requiere una clave Enterprise "
+"válida para crear más espacios de trabajo."
 
 #. js-lingui-id: CbGxon
 #: src/engine/workspace-manager/twenty-standard-application/utils/field-metadata/compute-message-participant-standard-flat-field-metadata.util.ts
 msgid "Workspace member"
-msgstr ""
+msgstr "Miembro del espacio de trabajo"
 
 #. js-lingui-id: qc38qR
 #: src/engine/workspace-manager/twenty-standard-application/utils/object-metadata/create-standard-flat-object-metadata.util.ts
@@ -8365,12 +9020,12 @@ msgstr ""
 #: src/engine/workspace-manager/twenty-standard-application/utils/field-metadata/compute-calendar-event-participant-standard-flat-field-metadata.util.ts
 #: src/engine/workspace-manager/twenty-standard-application/utils/field-metadata/compute-calendar-event-participant-standard-flat-field-metadata.util.ts
 msgid "Workspace Member"
-msgstr ""
+msgstr "Miembro del espacio de trabajo"
 
 #. js-lingui-id: R1S9pO
 #: src/engine/workspace-manager/twenty-standard-application/utils/field-metadata/compute-workspace-member-standard-flat-field-metadata.util.ts
 msgid "Workspace member avatar"
-msgstr ""
+msgstr "Avatar del miembro del espacio de trabajo"
 
 #. js-lingui-id: SWTQfb
 #: src/modules/blocklist/blocklist-validation-manager/services/blocklist-validation.service.ts
@@ -8380,7 +9035,7 @@ msgstr "No se puede actualizar al miembro del espacio de trabajo."
 #. js-lingui-id: 5VCX7o
 #: src/engine/workspace-manager/twenty-standard-application/utils/field-metadata/compute-workspace-member-standard-flat-field-metadata.util.ts
 msgid "Workspace member name"
-msgstr ""
+msgstr "Nombre del miembro del espacio de trabajo"
 
 #. js-lingui-id: rnnLQA
 #: src/engine/metadata-modules/permissions/permissions.exception.ts
@@ -8390,12 +9045,12 @@ msgstr "Miembro del espacio de trabajo no encontrado."
 #. js-lingui-id: NiUpuN
 #: src/engine/workspace-manager/twenty-standard-application/utils/field-metadata/compute-workspace-member-standard-flat-field-metadata.util.ts
 msgid "Workspace member position"
-msgstr ""
+msgstr "Posición del miembro del espacio de trabajo"
 
 #. js-lingui-id: YCAEr+
 #: src/engine/workspace-manager/twenty-standard-application/utils/object-metadata/create-standard-flat-object-metadata.util.ts
 msgid "Workspace Members"
-msgstr ""
+msgstr "Miembros del espacio de trabajo"
 
 #. js-lingui-id: JYc1v3
 #: src/engine/core-modules/user-workspace/guards/upload-profile-picture-permission.guard.ts
@@ -8426,13 +9081,15 @@ msgstr "Espacio de trabajo no encontrado."
 #. js-lingui-id: mMbNCo
 #: src/engine/core-modules/admin-panel/services/admin-panel-user-lookup.service.ts
 msgid "Workspace not found. Please check the ID."
-msgstr ""
+msgstr "Espacio de trabajo no encontrado. Verifica el ID."
 
 #. js-lingui-id: osscRx
 #: src/engine/workspace-manager/workspace-migration/workspace-migration-runner/exceptions/workspace-migration-runner.exception.ts
 #: src/engine/workspace-datasource/exceptions/workspace-datasource.exception.ts
 msgid "Workspace schema changes are temporarily locked."
 msgstr ""
+"Los cambios de esquema del espacio de trabajo están temporalmente "
+"bloqueados."
 
 #. js-lingui-id: 7wxAZI
 #: src/engine/twenty-orm/exceptions/twenty-orm.exception.ts
@@ -8473,12 +9130,12 @@ msgstr "WorkspaceId es necesario para crear una vista."
 #: src/engine/workspace-manager/twenty-standard-application/utils/field-metadata/compute-blocklist-standard-flat-field-metadata.util.ts
 #: src/engine/workspace-manager/twenty-standard-application/utils/field-metadata/compute-blocklist-standard-flat-field-metadata.util.ts
 msgid "WorkspaceMember"
-msgstr ""
+msgstr "MiembroDelEspacioDeTrabajo"
 
 #. js-lingui-id: 9RXJsb
 #: src/engine/workspace-manager/workspace-migration/interceptors/utils/__tests__/build-metadata-validation-error-payload.util.spec.ts
 msgid "Would not reach this"
-msgstr ""
+msgstr "No alcanzaría esto"
 
 #. js-lingui-id: VddeYt
 #: src/engine/core-modules/file-storage/interfaces/file-storage-exception.ts
@@ -8499,12 +9156,12 @@ msgstr "Contraseña incorrecta."
 #: src/engine/workspace-manager/twenty-standard-application/utils/field-metadata/compute-person-standard-flat-field-metadata.util.ts
 #: src/engine/workspace-manager/twenty-standard-application/utils/field-metadata/compute-company-standard-flat-field-metadata.util.ts
 msgid "X"
-msgstr ""
+msgstr "X"
 
 #. js-lingui-id: eTlYxu
 #: src/engine/workspace-manager/twenty-standard-application/utils/field-metadata/compute-workspace-member-standard-flat-field-metadata.util.ts
 msgid "Year First"
-msgstr ""
+msgstr "Año primero"
 
 #. js-lingui-id: l75CjT
 #: src/modules/dashboard/chart-data/utils/format-dimension-value.util.ts
@@ -8518,8 +9175,12 @@ msgstr "No está autorizado para realizar esta acción."
 
 #. js-lingui-id: TRUO3G
 #: src/engine/metadata-modules/index-metadata/services/index-metadata.service.ts
-msgid "You can have at most {MAX_CUSTOM_INDEXES_PER_OBJECT} custom indexes per object. Delete one before creating a new one."
+msgid ""
+"You can have at most {MAX_CUSTOM_INDEXES_PER_OBJECT} custom indexes per "
+"object. Delete one before creating a new one."
 msgstr ""
+"Puedes tener como máximo {MAX_CUSTOM_INDEXES_PER_OBJECT} índices "
+"personalizados por objeto. Elimina uno antes de crear uno nuevo."
 
 #. js-lingui-id: 84/Dko
 #: src/engine/api/common/common-query-runners/common-merge-many-query-runner.service.ts
@@ -8534,33 +9195,53 @@ msgstr "Solo puedes actualizar un registro con el campo de archivos a la vez."
 #. js-lingui-id: 4ysDL0
 #: src/engine/twenty-orm/repository/workspace-update-query-builder.ts
 msgid "You can only update up to {QUERY_MAX_RECORDS} records at once."
-msgstr ""
+msgstr "Solo puedes actualizar hasta {QUERY_MAX_RECORDS} registros a la vez."
 
 #. js-lingui-id: 1SQnFB
 #: src/engine/metadata-modules/role/role.resolver.ts
-msgid "You cannot change your own role. Please ask another administrator to update your role."
-msgstr "No puede cambiar su propio rol. Por favor, pídale a otro administrador que actualice su rol."
+msgid ""
+"You cannot change your own role. Please ask another administrator to update "
+"your role."
+msgstr ""
+"No puede cambiar su propio rol. Por favor, pídale a otro administrador que "
+"actualice su rol."
 
 #. js-lingui-id: y5haJ4
 #: src/engine/workspace-manager/workspace-migration/workspace-migration-builder/validators/utils/validate-role-read-write-permissions-consistency.util.ts
 #: src/engine/metadata-modules/object-permission/object-permission.service.ts
-msgid "You cannot grant edit permissions without also granting read permissions. Please enable read access first."
-msgstr "No puedes otorgar permisos de edición sin también otorgar permisos de lectura. Por favor, habilite el acceso de lectura primero."
+msgid ""
+"You cannot grant edit permissions without also granting read permissions. "
+"Please enable read access first."
+msgstr ""
+"No puedes otorgar permisos de edición sin también otorgar permisos de "
+"lectura. Por favor, habilite el acceso de lectura primero."
 
 #. js-lingui-id: 8wovNr
 #: src/engine/metadata-modules/user-role/user-role.service.ts
-msgid "You cannot remove the admin role from the last administrator. Please assign another administrator first."
-msgstr "No puedes eliminar el rol de administrador del último administrador. Por favor, asigna otro administrador primero."
+msgid ""
+"You cannot remove the admin role from the last administrator. Please assign "
+"another administrator first."
+msgstr ""
+"No puedes eliminar el rol de administrador del último administrador. Por "
+"favor, asigna otro administrador primero."
 
 #. js-lingui-id: WUcQVb
 #: src/engine/metadata-modules/object-permission/field-permission/field-permission.service.ts
-msgid "You cannot set field permissions on system objects as they are managed by the platform."
-msgstr "No puedes establecer permisos de campo en objetos del sistema, ya que son gestionados por la plataforma."
+msgid ""
+"You cannot set field permissions on system objects as they are managed by "
+"the platform."
+msgstr ""
+"No puedes establecer permisos de campo en objetos del sistema, ya que son "
+"gestionados por la plataforma."
 
 #. js-lingui-id: SI6USg
 #: src/engine/metadata-modules/object-permission/object-permission.service.ts
-msgid "You cannot set permissions on system objects as they are managed by the platform."
-msgstr "No puedes establecer permisos en objetos del sistema, ya que son gestionados por la plataforma."
+msgid ""
+"You cannot set permissions on system objects as they are managed by the "
+"platform."
+msgstr ""
+"No puedes establecer permisos en objetos del sistema, ya que son gestionados"
+" por la plataforma."
 
 #. js-lingui-id: bAPURS
 #: src/engine/metadata-modules/permissions/permissions.exception.ts
@@ -8589,8 +9270,12 @@ msgstr "No tienes acceso a esta carpeta de mensajes."
 
 #. js-lingui-id: EFQeXU
 #: src/engine/guards/settings-permission.guard.ts
-msgid "You do not have permission to access this feature. Please contact your workspace administrator for access."
-msgstr "No tiene permiso para acceder a esta función. Por favor, contacte con su administrador de espacio de trabajo para obtener acceso."
+msgid ""
+"You do not have permission to access this feature. Please contact your "
+"workspace administrator for access."
+msgstr ""
+"No tiene permiso para acceder a esta función. Por favor, contacte con su "
+"administrador de espacio de trabajo para obtener acceso."
 
 #. js-lingui-id: nPwrik
 #: src/modules/workflow/workflow-trigger/exceptions/workflow-trigger.exception.ts
@@ -8599,23 +9284,42 @@ msgstr "No tiene permiso para acceder a este flujo de trabajo."
 
 #. js-lingui-id: sjYS9x
 #: src/engine/metadata-modules/navigation-menu-item/services/navigation-menu-item-access.service.ts
-msgid "You do not have permission to create workspace-level navigation menu items. Please contact your workspace administrator for access."
-msgstr "No tiene permiso para crear elementos del menú de navegación a nivel de espacio de trabajo. Por favor, contacte con su administrador de espacio de trabajo para obtener acceso."
+msgid ""
+"You do not have permission to create workspace-level navigation menu items. "
+"Please contact your workspace administrator for access."
+msgstr ""
+"No tiene permiso para crear elementos del menú de navegación a nivel de "
+"espacio de trabajo. Por favor, contacte con su administrador de espacio de "
+"trabajo para obtener acceso."
 
 #. js-lingui-id: P69VwK
 #: src/engine/core-modules/user/user.resolver.ts
-msgid "You do not have permission to delete this user from the workspace. Please contact your workspace administrator for access."
-msgstr "No tiene permiso para eliminar a este usuario del espacio de trabajo. Por favor, contacte con su administrador del espacio de trabajo para obtener acceso."
+msgid ""
+"You do not have permission to delete this user from the workspace. Please "
+"contact your workspace administrator for access."
+msgstr ""
+"No tiene permiso para eliminar a este usuario del espacio de trabajo. Por "
+"favor, contacte con su administrador del espacio de trabajo para obtener "
+"acceso."
 
 #. js-lingui-id: NuG0g3
 #: src/engine/metadata-modules/navigation-menu-item/services/navigation-menu-item-access.service.ts
-msgid "You do not have permission to delete workspace-level navigation menu items. Please contact your workspace administrator for access."
-msgstr "No tiene permiso para eliminar elementos del menú de navegación a nivel de espacio de trabajo. Por favor, contacte con su administrador de espacio de trabajo para obtener acceso."
+msgid ""
+"You do not have permission to delete workspace-level navigation menu items. "
+"Please contact your workspace administrator for access."
+msgstr ""
+"No tiene permiso para eliminar elementos del menú de navegación a nivel de "
+"espacio de trabajo. Por favor, contacte con su administrador de espacio de "
+"trabajo para obtener acceso."
 
 #. js-lingui-id: +2vVRB
 #: src/engine/guards/impersonate-permission.guard.ts
-msgid "You do not have permission to impersonate users. Please contact your workspace administrator for access."
-msgstr "No tiene permiso para suplantar usuarios. Por favor, contacte con su administrador de espacio de trabajo para obtener acceso."
+msgid ""
+"You do not have permission to impersonate users. Please contact your "
+"workspace administrator for access."
+msgstr ""
+"No tiene permiso para suplantar usuarios. Por favor, contacte con su "
+"administrador de espacio de trabajo para obtener acceso."
 
 #. js-lingui-id: q5OVn+
 #: src/engine/metadata-modules/permissions/permissions.exception.ts
@@ -8632,23 +9336,37 @@ msgstr "No tiene permiso para realizar esta acción del flujo de trabajo."
 
 #. js-lingui-id: 1dsy9v
 #: src/engine/core-modules/workspace/services/workspace.service.ts
-msgid "You do not have permission to update these fields: {fieldsList}. Please contact your workspace administrator."
-msgstr "No tiene permiso para actualizar estos campos: {fieldsList}. Por favor, contacte con su administrador de espacio de trabajo."
+msgid ""
+"You do not have permission to update these fields: {fieldsList}. Please "
+"contact your workspace administrator."
+msgstr ""
+"No tiene permiso para actualizar estos campos: {fieldsList}. Por favor, "
+"contacte con su administrador de espacio de trabajo."
 
 #. js-lingui-id: ZCNAGE
 #: src/engine/core-modules/user/user.resolver.ts
 msgid "You do not have permission to update this workspace member."
 msgstr ""
+"No tienes permiso para actualizar este miembro del espacio de trabajo."
 
 #. js-lingui-id: RZzKii
 #: src/engine/metadata-modules/navigation-menu-item/services/navigation-menu-item-access.service.ts
-msgid "You do not have permission to update workspace-level navigation menu items. Please contact your workspace administrator for access."
-msgstr "No tiene permiso para actualizar elementos del menú de navegación a nivel de espacio de trabajo. Por favor, contacte con su administrador de espacio de trabajo para obtener acceso."
+msgid ""
+"You do not have permission to update workspace-level navigation menu items. "
+"Please contact your workspace administrator for access."
+msgstr ""
+"No tiene permiso para actualizar elementos del menú de navegación a nivel de"
+" espacio de trabajo. Por favor, contacte con su administrador de espacio de "
+"trabajo para obtener acceso."
 
 #. js-lingui-id: ZPo5fR
 #: src/engine/core-modules/user-workspace/guards/upload-profile-picture-permission.guard.ts
-msgid "You do not have permission to upload profile pictures. Please contact your workspace administrator for access."
-msgstr "No tiene permiso para subir fotos de perfil. Por favor, contacte con su administrador de espacio de trabajo para obtener acceso."
+msgid ""
+"You do not have permission to upload profile pictures. Please contact your "
+"workspace administrator for access."
+msgstr ""
+"No tiene permiso para subir fotos de perfil. Por favor, contacte con su "
+"administrador de espacio de trabajo para obtener acceso."
 
 #. js-lingui-id: M1he8p
 #: src/engine/metadata-modules/view/exceptions/view.exception.ts
@@ -8679,12 +9397,15 @@ msgstr "Debe estar autenticado para realizar esta acción."
 #. js-lingui-id: 8pqpv/
 #: src/engine/core-modules/graphql/hooks/use-graphql-error-handler.hook.ts
 msgid "Your app version is out of date. Please refresh the page to continue."
-msgstr "La versión de su aplicación está desactualizada. Por favor actualice la página para continuar."
+msgstr ""
+"La versión de su aplicación está desactualizada. Por favor actualice la "
+"página para continuar."
 
 #. js-lingui-id: J5Vm4Q
 #: src/engine/core-modules/billing/billing.validate.ts
 msgid "Your billing subscription is corrupted. Please contact support."
-msgstr "Su suscripción de facturación está corrupta. Por favor, contacte al soporte."
+msgstr ""
+"Su suscripción de facturación está corrupta. Por favor, contacte al soporte."
 
 #. js-lingui-id: bTyBrW
 #: src/engine/core-modules/auth/services/auth.service.ts
@@ -8695,15 +9416,24 @@ msgstr "Tu contraseña ha sido cambiada con éxito"
 #: src/engine/metadata-modules/user-role/user-role.service.ts
 #: src/engine/metadata-modules/permissions/permissions.service.ts
 #: src/engine/metadata-modules/permissions/permissions.service.ts
-msgid "Your role in this workspace could not be found. Please contact your workspace administrator."
-msgstr "Su rol en este espacio de trabajo no se pudo encontrar. Por favor, contacte con su administrador de espacio de trabajo."
+msgid ""
+"Your role in this workspace could not be found. Please contact your "
+"workspace administrator."
+msgstr ""
+"Su rol en este espacio de trabajo no se pudo encontrar. Por favor, contacte "
+"con su administrador de espacio de trabajo."
 
 #. js-lingui-id: vPccnr
 #: src/engine/workspace-manager/twenty-standard-application/utils/field-metadata/compute-company-standard-flat-field-metadata.util.ts
 msgid "Your team member responsible for managing the company account"
 msgstr ""
+"Tu miembro del equipo responsable de gestionar la cuenta de la empresa"
 
 #. js-lingui-id: ej/tZF
 #: src/engine/core-modules/graphql/hooks/use-graphql-error-handler.hook.ts
-msgid "Your workspace has been updated with a new data model. Please refresh the page."
-msgstr "Su espacio de trabajo se ha actualizado con un nuevo modelo de datos. Por favor refresque la página."
+msgid ""
+"Your workspace has been updated with a new data model. Please refresh the "
+"page."
+msgstr ""
+"Su espacio de trabajo se ha actualizado con un nuevo modelo de datos. Por "
+"favor refresque la página."


### PR DESCRIPTION
## Complete es-ES Spanish Translation

### Summary
Completes all previously-untranslated strings for the es-ES locale, achieving 100% coverage for both frontend and server catalogs.

### Changes

**Frontend** (`packages/twenty-front/src/locales/es-ES.po`):
- 540 previously untranslated strings → now translated
- Coverage: 2639/3179 (83%) → **3179/3179 (100%)**

**Server** (`packages/twenty-server/src/engine/core-modules/i18n/locales/es-ES.po`):
- 402 previously untranslated strings → now translated
- Coverage: 1130/1532 (74%) → **1532/1532 (100%)**

### Translation Conventions
- Uses **"tú"** for UI (standard es-ES software convention)
- Technical terms kept in English: API, SSO, SMTP, webhook, etc.
- CRM terminology: Contacto (contact), Empresa (company), Oportunidad (opportunity), Cliente potencial (lead)
- All ICU interpolation markers (`{variable}`, `{count, plural, ...}`, `<0>`) preserved exactly
- Lingui IDs and source references preserved

### Testing
- Verified 100% coverage with `polib` parser
- Compiled `.po` → `.ts` and validated generated TypeScript catalogs as valid JSON
- Tested on self-hosted Twenty instance — Spanish UI renders correctly without 404 errors on locale files

### Motivation
Self-hosted Twenty instances that register es-ES as a locale currently see many English fallback strings due to incomplete translations. This PR ensures a complete Spanish experience for Latin American and Spanish users.

Relates to #105 (i18n improvements)