### PR TITLE
fix(contact-creation): handle multi-comma "Last, First, Suffix" display names

### DIFF
--- a/packages/twenty-server/src/modules/contact-creation-manager/utils/__tests__/get-parsed-name-from-display-name.util.spec.ts
+++ b/packages/twenty-server/src/modules/contact-creation-manager/utils/__tests__/get-parsed-name-from-display-name.util.spec.ts
@@ -63,6 +63,62 @@ describe('getParsedNameFromDisplayName', () => {
           expected: { firstName: 'John', lastName: 'Doe' },
         },
       },
+      {
+        title:
+          'should keep a multi-word first name intact when paired with a last name',
+        context: {
+          displayName: 'Smith, Mary Jane',
+          expected: { firstName: 'Mary Jane', lastName: 'Smith' },
+        },
+      },
+    ];
+
+    test.each(testCases)('$title', ({ context: { displayName, expected } }) => {
+      expect(getParsedNameFromDisplayName(displayName)).toEqual(expected);
+    });
+  });
+
+  describe('multi-comma comma-inverted forms', () => {
+    const testCases: TestCase[] = [
+      {
+        title:
+          'should treat the segment before the first comma as the last name and merge the rest into the first name',
+        context: {
+          displayName: 'Smith, Jane, Jr.',
+          expected: { firstName: 'Jane Jr.', lastName: 'Smith' },
+        },
+      },
+      {
+        title: 'should keep credential suffixes attached to the first name',
+        context: {
+          displayName: "O'Brien, Mary, MD",
+          expected: { firstName: 'Mary MD', lastName: "O'Brien" },
+        },
+      },
+      {
+        title:
+          'should fold a three-part "Last, First, Middle" form into a multi-word first name',
+        context: {
+          displayName: 'Doe, John, Patrick',
+          expected: { firstName: 'John Patrick', lastName: 'Doe' },
+        },
+      },
+      {
+        title:
+          'should collapse extra whitespace around the inner commas as it merges',
+        context: {
+          displayName: 'Smith ,  Jane  ,  Jr.',
+          expected: { firstName: 'Jane Jr.', lastName: 'Smith' },
+        },
+      },
+      {
+        title:
+          'should still strip a trailing :GROUP tag after a multi-comma swap',
+        context: {
+          displayName: 'Smith, Jane, Jr.:GROUP',
+          expected: { firstName: 'Jane Jr.', lastName: 'Smith' },
+        },
+      },
     ];
 
     test.each(testCases)('$title', ({ context: { displayName, expected } }) => {

--- a/packages/twenty-server/src/modules/contact-creation-manager/utils/get-parsed-name-from-display-name.util.ts
+++ b/packages/twenty-server/src/modules/contact-creation-manager/utils/get-parsed-name-from-display-name.util.ts
@@ -24,13 +24,26 @@ export const getParsedNameFromDisplayName = (
     lastName: stripTrailingGroupTag(parsed.lastName),
   });
 
-  const commaMatch = cleaned.match(/^([^,]+),\s*([^,]+)$/);
+  // Comma-inverted forms: "Last, First", "Last, First Middle", and
+  // multi-comma shapes like "Last, First, Jr." or "Last, First, MD" that some
+  // address books and ATSes emit. We split on the first comma and treat the
+  // remainder as the first name, collapsing any further commas to spaces so
+  // the stored firstName never contains a stray comma.
+  const commaMatch = cleaned.match(/^([^,]+),\s*(.+)$/);
 
   if (isDefined(commaMatch)) {
-    return withGroupTagsStripped({
-      firstName: commaMatch[2].trim(),
-      lastName: commaMatch[1].trim(),
-    });
+    const lastName = commaMatch[1].trim();
+    const firstName = commaMatch[2]
+      .trim()
+      .replace(/\s*,\s*/g, ' ')
+      .replace(/\s+/g, ' ');
+
+    if (isNonEmptyString(firstName) && isNonEmptyString(lastName)) {
+      return withGroupTagsStripped({
+        firstName,
+        lastName,
+      });
+    }
   }
 
   const [firstToken, ...rest] = cleaned.split(/\s+/);


### PR DESCRIPTION
## Summary

Loosens the comma-inverted swap in the email/calendar auto-create name parser so it handles multi-comma display names like `"Smith, Jane, Jr."`, `"O'Brien, Mary, MD"`, and `"Doe, John, Patrick"` instead of falling through to the space-split fallback (which kept the comma in `firstName` and produced a garbled record like `"Barbey, Julien"` showing up under a single "B" avatar).

### Before
- Regex required *exactly* one comma and two non-empty halves: `/^([^,]+),\s*([^,]+)$/`.
- `"Smith, Jane, Jr."` → no match → space-split → `firstName: "Smith,"`, `lastName: "Jane, Jr."`.

### After
- Regex splits on the first comma: `/^([^,]+),\s*(.+)$/`.
- The remainder becomes the first name, with any additional commas collapsed to single spaces.
- `"Smith, Jane, Jr."` → `firstName: "Jane Jr."`, `lastName: "Smith"`.
- `"Doe, John"` still resolves to `firstName: "John"`, `lastName: "Doe"` (single-comma case unchanged).
- Trailing `:GROUP` mail-server tag stripping still applies on top.

Scope: this only affects the auto-creation path (email + calendar imports). CSV import, manual UI entry, workflow `create-record`, and the GraphQL API still store whatever they're given — out of scope here.

## Test plan

- [x] 5 new test cases in [`get-parsed-name-from-display-name.util.spec.ts`](packages/twenty-server/src/modules/contact-creation-manager/utils/__tests__/get-parsed-name-from-display-name.util.spec.ts) covering `Last, First, Suffix`, credential suffixes (`MD`), three-token forms, whitespace around inner commas, and `:GROUP` tag interaction
- [x] 1 new test on the single-comma path covering `Smith, Mary Jane` (multi-word first name still passes through)
- [x] All 15 existing parser test cases still pass
- [x] All 107 tests in `contact-creation-manager` pass
- [x] `npx nx typecheck twenty-server`
- [x] `npx oxlint --type-aware` + `npx oxfmt --check` on changed files