### PR TITLE
Fix: focus stack overwritten when auto-opening title cell on new record

### DIFF
--- a/packages/twenty-front/src/modules/app/effect-components/PageChangeEffect.tsx
+++ b/packages/twenty-front/src/modules/app/effect-components/PageChangeEffect.tsx
@@ -224,6 +224,23 @@ export const PageChangeEffect = () => {
       }
       case isMatchingLocation(location, AppPath.RecordShowPage): {
         const isNewRecord = location.state?.isNewRecord === true;
+        const isSidePanelOpen = store.get(isSidePanelOpenedState.atom);
+
+        if (!isSidePanelOpen) {
+          resetFocusStackToFocusItem({
+            focusStackItem: {
+              focusId: PageFocusId.RecordShowPage,
+              componentInstance: {
+                componentType: FocusComponentType.PAGE,
+                componentInstanceId: PageFocusId.RecordShowPage,
+              },
+              globalHotkeysConfig: {
+                enableGlobalHotkeysWithModifiers: true,
+                enableGlobalHotkeysConflictingWithKeyboard: true,
+              },
+            },
+          });
+        }
 
         if (
           isNewRecord &&
@@ -234,26 +251,6 @@ export const PageChangeEffect = () => {
             fieldName: location.state.labelIdentifierFieldName,
           });
         }
-
-        const isSidePanelOpen = store.get(isSidePanelOpenedState.atom);
-
-        if (isSidePanelOpen) {
-          return;
-        }
-
-        resetFocusStackToFocusItem({
-          focusStackItem: {
-            focusId: PageFocusId.RecordShowPage,
-            componentInstance: {
-              componentType: FocusComponentType.PAGE,
-              componentInstanceId: PageFocusId.RecordShowPage,
-            },
-            globalHotkeysConfig: {
-              enableGlobalHotkeysWithModifiers: true,
-              enableGlobalHotkeysConflictingWithKeyboard: true,
-            },
-          },
-        });
         break;
       }
       case isMatchingLocation(location, AppPath.SignInUp): {


### PR DESCRIPTION
Fixes https://github.com/twentyhq/twenty/issues/20894

In `PageChangeEffect` `resetFocusStackToFocusItem` ran right after `openNewRecordTitleCell`, wiping the title cell entry. Typing in the auto-opened breadcrumb input (e.g. new workflow) triggered global shortcuts and ignored Enter / Escape / Tab.

Reordered so the page reset runs first, then the title cell push lands on top.

## Before

https://github.com/user-attachments/assets/d3c0c266-a493-46b8-b99b-32f4381b8664


## After

https://github.com/user-attachments/assets/3a886386-f438-46d2-a6ea-9ee6908d6df2

