### PR TITLE
fix: correct typo occurence -> occurrence in metadata-event-emitter.ts

### DIFF
--- a/packages/twenty-server/src/engine/subscriptions/metadata-event/metadata-event-emitter.ts
+++ b/packages/twenty-server/src/engine/subscriptions/metadata-event/metadata-event-emitter.ts
@@ -98,9 +98,9 @@ export class MetadataEventEmitter {
         metadataName,
         type,
       });
-      const occurence = grouped.get(eventName);
+      const occurrence = grouped.get(eventName);
 
-      if (!isDefined(occurence)) {
+      if (!isDefined(occurrence)) {
         grouped.set(eventName, {
           eventName,
           metadataName,
@@ -111,8 +111,8 @@ export class MetadataEventEmitter {
       }
 
       grouped.set(eventName, {
-        ...occurence,
-        events: [...occurence.events, metadataEvent],
+        ...occurrence,
+        events: [...occurrence.events, metadataEvent],
       });
     }
 


### PR DESCRIPTION
## Summary

Fixes a spelling typo in `packages/twenty-server/src/engine/subscriptions/metadata-event/metadata-event-emitter.ts`:

- Variable name `occurence` → `occurrence` (4 references on lines 101, 103, 114, 115)

## Changes

- `packages/twenty-server/src/engine/subscriptions/metadata-event/metadata-event-emitter.ts` — rename misspelled variable