### PR TITLE
Docs: clarify numberOfSelectedRecords usage for RECORD_SELECTION items

### DIFF
--- a/packages/twenty-docs/developers/extend/apps/layout/command-menu-items.mdx
+++ b/packages/twenty-docs/developers/extend/apps/layout/command-menu-items.mdx
@@ -103,6 +103,10 @@ export default defineCommandMenuItem({
 });
 ```
 
+<Note>
+  `RECORD_SELECTION` already implies a non-empty selection — use `numberOfSelectedRecords` only for specific counts (e.g. `>= 2`).
+</Note>
+
 ### Context variables
 
 These represent the current state of the page:


### PR DESCRIPTION
Add a note to the command menu items docs explaining that RECORD_SELECTION already guarantees a non-empty selection, so numberOfSelectedRecords > 0 is redundant in conditionalAvailabilityExpression.