### PR TITLE
fix(server): compare DATE_TIME fields at millisecond precision in filters

### DIFF
--- a/packages/twenty-server/src/engine/api/graphql/graphql-query-runner/utils/__tests__/compute-where-condition-parts.spec.ts
+++ b/packages/twenty-server/src/engine/api/graphql/graphql-query-runner/utils/__tests__/compute-where-condition-parts.spec.ts
@@ -1,0 +1,41 @@
+import { FieldMetadataType } from 'twenty-shared/types';
+
+import { computeWhereConditionParts } from 'src/engine/api/graphql/graphql-query-runner/utils/compute-where-condition-parts';
+
+describe('computeWhereConditionParts', () => {
+  describe('DATE_TIME precision (#20520)', () => {
+    // DATE_TIME values are millisecond-precision in the app layer but stored as
+    // microsecond timestamptz. Comparisons must truncate the column to
+    // milliseconds so cursor pagination can advance over rows sharing a
+    // millisecond.
+    it.each(['eq', 'neq', 'gt', 'gte', 'lt', 'lte'])(
+      'truncates the column to milliseconds for "%s"',
+      (operator) => {
+        const { sql } = computeWhereConditionParts({
+          operator,
+          objectNameSingular: 'noteTarget',
+          key: 'updatedAt',
+          value: '2026-02-18T09:18:30.061Z',
+          fieldMetadataType: FieldMetadataType.DATE_TIME,
+        });
+
+        expect(sql).toContain(
+          `date_trunc('milliseconds', "noteTarget"."updatedAt")`,
+        );
+      },
+    );
+
+    it('does not truncate non-DATE_TIME fields', () => {
+      const { sql } = computeWhereConditionParts({
+        operator: 'gt',
+        objectNameSingular: 'person',
+        key: 'name',
+        value: 'John',
+        fieldMetadataType: FieldMetadataType.TEXT,
+      });
+
+      expect(sql).not.toContain('date_trunc');
+      expect(sql).toContain('"person"."name" >');
+    });
+  });
+});

--- a/packages/twenty-server/src/engine/api/graphql/graphql-query-runner/utils/compute-where-condition-parts.ts
+++ b/packages/twenty-server/src/engine/api/graphql/graphql-query-runner/utils/compute-where-condition-parts.ts
@@ -1,6 +1,6 @@
 import { randomBytes } from 'crypto';
 
-import { type FieldMetadataType } from 'twenty-shared/types';
+import { FieldMetadataType } from 'twenty-shared/types';
 import { isDefined } from 'twenty-shared/utils';
 import { type ObjectLiteral } from 'typeorm';
 
@@ -43,6 +43,18 @@ export const computeWhereConditionParts = ({
     ? `"${key}"`
     : `"${objectNameSingular}"."${key}"`;
 
+  // DATE_TIME values are millisecond-precision in the application layer (a JS
+  // Date cannot hold sub-millisecond digits), but are stored as microsecond
+  // timestamptz in Postgres. Comparing the raw column against a millisecond
+  // value therefore mismatches: e.g. a row stored as ...061789 is never equal
+  // to the cursor value ...061, which breaks cursor pagination over rows
+  // sharing a millisecond (#20520). Compare at millisecond precision so both
+  // sides align. date_trunc floors, matching Date.toISOString().
+  const comparableFieldReference =
+    fieldMetadataType === FieldMetadataType.DATE_TIME
+      ? `date_trunc('milliseconds', ${fieldReference})`
+      : fieldReference;
+
   //TODO : Remove filter null equivalence injection once feature flag removed + null equivalence transformation added in ORM
   const nullEquivalentFieldValue = findPostgresDefaultNullEquivalentValue(
     value,
@@ -60,32 +72,32 @@ export const computeWhereConditionParts = ({
       };
     case 'eq':
       return {
-        sql: `${fieldReference} = :${key}${paramSuffix}${hasNullEquivalentFieldValue ? ` OR ${fieldReference} IS NULL` : ''}`,
+        sql: `${comparableFieldReference} = :${key}${paramSuffix}${hasNullEquivalentFieldValue ? ` OR ${fieldReference} IS NULL` : ''}`,
         params: { [`${key}${paramSuffix}`]: value },
       };
     case 'neq':
       return {
-        sql: `${fieldReference} != :${key}${paramSuffix}${hasNullEquivalentFieldValue ? ` AND ${fieldReference} IS NOT NULL` : ''}`,
+        sql: `${comparableFieldReference} != :${key}${paramSuffix}${hasNullEquivalentFieldValue ? ` AND ${fieldReference} IS NOT NULL` : ''}`,
         params: { [`${key}${paramSuffix}`]: value },
       };
     case 'gt':
       return {
-        sql: `${fieldReference} > :${key}${paramSuffix}`,
+        sql: `${comparableFieldReference} > :${key}${paramSuffix}`,
         params: { [`${key}${paramSuffix}`]: value },
       };
     case 'gte':
       return {
-        sql: `${fieldReference} >= :${key}${paramSuffix}`,
+        sql: `${comparableFieldReference} >= :${key}${paramSuffix}`,
         params: { [`${key}${paramSuffix}`]: value },
       };
     case 'lt':
       return {
-        sql: `${fieldReference} < :${key}${paramSuffix}`,
+        sql: `${comparableFieldReference} < :${key}${paramSuffix}`,
         params: { [`${key}${paramSuffix}`]: value },
       };
     case 'lte':
       return {
-        sql: `${fieldReference} <= :${key}${paramSuffix}`,
+        sql: `${comparableFieldReference} <= :${key}${paramSuffix}`,
         params: { [`${key}${paramSuffix}`]: value },
       };
     case 'in':


### PR DESCRIPTION
## Summary

Closes #20520.

Cursor-based pagination (REST and GraphQL) could return the **same page repeatedly** when several records share the same millisecond in the first sort field — e.g. many `noteTargets` created through the API in a short time, sorted by `updatedAt`.

### Root cause

`DATE_TIME` values are **millisecond**-precision in the application layer — a JS `Date` cannot hold sub-millisecond digits — and the cursor is serialized with `Date.toISOString()` (`encodeCursor` → `JSON.stringify`). But the columns are stored as **microsecond** `timestamptz` in Postgres.

For multi-field cursors the tie-breaker filter is built correctly as:

```
(updatedAt > :v) OR (updatedAt = :v AND id > :id)
```

The problem is the value `:v`. If a row is stored as `...:30.061789Z`, the cursor emitted for it is `...:30.061Z` (microseconds dropped). On the next page:

- `updatedAt = '...061Z'` → **never matches** the stored `...061789Z`, so the `id` tie-breaker branch is dead, and
- `updatedAt > '...061Z'` → **re-selects** `...061789Z` (and every other row in that millisecond),

so the cursor can never advance past that millisecond and the page repeats. With a single distinct value per millisecond this is invisible; with duplicates (the issue's scenario) it loops.

This is why the cursor-filter utilities all look correct in isolation (and their unit tests pass) — the defect only appears once the millisecond cursor value is compared against the microsecond column in the database.

### Fix

Compare `DATE_TIME` columns at millisecond precision so both sides align:

```ts
const comparableFieldReference =
  fieldMetadataType === FieldMetadataType.DATE_TIME
    ? `date_trunc('milliseconds', ${fieldReference})`
    : fieldReference;
```

applied to the ordering/equality operators (`eq`, `neq`, `gt`, `gte`, `lt`, `lte`) in `computeWhereConditionParts`. `date_trunc` **floors**, which matches `Date.toISOString()` — note a `timestamptz(3)` column cast would instead **round** (`...061789` → `...062`) and would *not* match the floored cursor value, so truncation in the comparison is the precision-consistent choice. No schema change or data migration is needed, and it fixes already-stored data.

### Verification

Reproduced against a real Postgres 16 instance with microsecond-precision rows sharing a millisecond, walking three sequential pages:

- **Before:** page after the duplicate group re-returns the already-seen rows (loops).
- **After:** pages advance `A,D → E,F → G` with no repeats and clean termination.

## Test plan

- [x] `npx oxlint --type-aware` / `npx oxfmt --check` — pass on the changed files
- [x] `tsc --noEmit` — no new type errors in the changed file
- [x] Added unit test asserting `date_trunc('milliseconds', ...)` is applied for `DATE_TIME` comparison operators and **not** for other field types
- [x] Existing cursor specs (`compute-cursor-arg-filter`, `build-cursor-composite-field-where-condition`) still pass (30 tests)
- [x] Manual end-to-end pagination walk against Postgres with duplicate-millisecond `timestamptz` data

### Note for reviewers

`date_trunc('milliseconds', "updatedAt")` is not sargable, so a plain btree index on `updatedAt` alone wouldn't be used for these comparisons. I kept the change minimal and consistent across operators; if index usage on large datasets is a concern, an equivalent index-friendly form is to shift the cursor boundary by 1ms instead (`updatedAt >= :v+1ms` for the `>` branch and `:v <= updatedAt < :v+1ms` for the equality branch). Happy to switch to whichever you prefer.
