### PR TITLE
feat: expose CURRENCY field settings (format/decimals) in shared types

### DIFF
--- a/packages/twenty-server/src/engine/metadata-modules/field-metadata/types/__tests__/field-metadata-entity.test-type.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/field-metadata/types/__tests__/field-metadata-entity.test-type.ts
@@ -114,7 +114,6 @@ type NotDefinedSettings = {
 
 // oxlint-disable-next-line unused-imports/no-unused-vars
 type SettingsAssertions = [
-  Expect<HasAllProperties<CurrencyFieldMetadata, NotDefinedSettings>>,
   Expect<HasAllProperties<FullNameFieldMetadata, NotDefinedSettings>>,
   Expect<HasAllProperties<RatingFieldMetadata, NotDefinedSettings>>,
   Expect<HasAllProperties<SelectFieldMetadata, NotDefinedSettings>>,
@@ -141,6 +140,16 @@ type SettingsAssertions = [
       {
         settings: JsonbProperty<
           FieldMetadataSettingsMapping[FieldMetadataType.NUMBER]
+        >;
+      }
+    >
+  >,
+  Expect<
+    HasAllProperties<
+      CurrencyFieldMetadata,
+      {
+        settings: JsonbProperty<
+          FieldMetadataSettingsMapping[FieldMetadataType.CURRENCY]
         >;
       }
     >

--- a/packages/twenty-shared/src/types/FieldMetadataSettings.ts
+++ b/packages/twenty-shared/src/types/FieldMetadataSettings.ts
@@ -20,10 +20,17 @@ export enum DateDisplayFormat {
 
 export type FieldNumberVariant = 'number' | 'percentage';
 
+export type FieldCurrencyFormat = 'short' | 'full';
+
 type FieldMetadataNumberSettings = {
   dataType?: NumberDataType;
   decimals?: number;
   type?: FieldNumberVariant;
+};
+
+type FieldMetadataCurrencySettings = {
+  format?: FieldCurrencyFormat;
+  decimals?: number;
 };
 
 type FieldMetadataTextSettings = {
@@ -62,6 +69,7 @@ type FieldMetadataTsVectorSettings = {
 
 export type FieldMetadataSettingsMapping = {
   [FieldMetadataType.NUMBER]: FieldMetadataNumberSettings | null;
+  [FieldMetadataType.CURRENCY]: FieldMetadataCurrencySettings | null;
   [FieldMetadataType.DATE]: FieldMetadataDateSettings | null;
   [FieldMetadataType.DATE_TIME]: FieldMetadataDateTimeSettings | null;
   [FieldMetadataType.TEXT]: FieldMetadataTextSettings | null;

--- a/packages/twenty-shared/src/types/index.ts
+++ b/packages/twenty-shared/src/types/index.ts
@@ -105,6 +105,7 @@ export {
 } from './FieldMetadataOptions';
 export type {
   FieldNumberVariant,
+  FieldCurrencyFormat,
   FieldMetadataSettingsMapping,
   AllFieldMetadataSettings,
   FieldMetadataSettings,


### PR DESCRIPTION
## What

Add a `CURRENCY` entry to `FieldMetadataSettingsMapping` (a `FieldMetadataCurrencySettings` type of `{ format?: 'short' | 'full'; decimals?: number }`) so `FieldMetadataSettings<CURRENCY>` resolves to the real settings shape instead of `null`.

## Why

The currency **format** (Short/Full) and **decimals** selectors already ship in the field settings UI and persist through the generic `settings` jsonb column — they render via [`CurrencyDisplay.tsx`](https://github.com/twentyhq/twenty/blob/main/packages/twenty-front/src/modules/ui/field/display/components/CurrencyDisplay.tsx) reading `settings.format` / `settings.decimals` (added in #12542 and #16439).

But `twenty-shared` never got a `CURRENCY` entry in the settings mapping, so `FieldMetadataSettings<CURRENCY>` is `null`. The SDK's `defineField` derives its types from this mapping, so an app author cannot set these from code — `universalSettings: { format: 'full', decimals: 2 }` on a CURRENCY field is a type error, even though the server stores and the frontend honours it. This aligns the type layer with the already-shipped runtime behaviour.

## Changes

- `twenty-shared`: add `FieldMetadataCurrencySettings` + `FieldCurrencyFormat`, wire the `CURRENCY` mapping entry, export `FieldCurrencyFormat`.
- `twenty-server`: move `CurrencyFieldMetadata` from the `NotDefinedSettings` assertions to a defined-settings assertion in the field-metadata entity type test.

No runtime change — the server already accepts and stores these settings via the generic jsonb column; this only makes them visible to the type system and the SDK.

## Test plan

- [ ] `npx nx typecheck twenty-shared` / `twenty-server` pass
- [ ] In an app, `defineField({ type: FieldType.CURRENCY, universalSettings: { format: 'full', decimals: 2 }, ... })` type-checks and deploys
- [ ] Field renders with 2 decimals in full format, matching the equivalent UI configuration

> Follow-up (not in this PR): the frontend keeps its own local `fieldMetadataCurrencyFormat` / `FieldCurrencyFormat`; it could import the shared `FieldCurrencyFormat` to de-duplicate.