### PR TITLE
Billing - Fix credit upgrade invoice error

### DIFF
--- a/packages/twenty-server/src/engine/core-modules/billing/stripe/services/stripe-invoice.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/billing/stripe/services/stripe-invoice.service.ts
@@ -68,7 +68,7 @@ export class StripeInvoiceService {
     });
 
     await this.stripe.invoices.finalizeInvoice(invoice.id, {
-      auto_advance: true,
+      auto_advance: false,
     });
 
     await this.stripe.invoices.pay(invoice.id);


### PR DESCRIPTION
In createImmediateUpgradeInvoice, the invoice is finalized with auto_advance: true, which causes Stripe to automatically attempt payment asynchronously. Then the explicit stripe.invoices.pay(invoice.id) call races against that auto-payment — if Stripe already paid it, this throws "Invoice is already paid".

The fix is to finalize with auto_advance: false and keep the explicit pay call