### PR TITLE
fix(server): include IF_ELSE branch edges in workflow step parent detection

### DIFF
--- a/packages/twenty-server/src/modules/workflow/workflow-executor/utils/__tests__/get-parent-steps.util.spec.ts
+++ b/packages/twenty-server/src/modules/workflow/workflow-executor/utils/__tests__/get-parent-steps.util.spec.ts
@@ -1,0 +1,68 @@
+import { getParentSteps } from 'src/modules/workflow/workflow-executor/utils/get-parent-steps.util';
+import {
+  type WorkflowAction,
+  WorkflowActionType,
+} from 'src/modules/workflow/workflow-executor/workflow-actions/types/workflow-action.type';
+
+const makeStep = (step: Partial<WorkflowAction> & { id: string }) =>
+  ({
+    type: WorkflowActionType.CODE,
+    nextStepIds: [],
+    ...step,
+  }) as unknown as WorkflowAction;
+
+const makeIfElse = (
+  id: string,
+  branches: { nextStepIds: string[] }[],
+): WorkflowAction =>
+  ({
+    id,
+    type: WorkflowActionType.IF_ELSE,
+    nextStepIds: [],
+    settings: { input: { branches } },
+  }) as unknown as WorkflowAction;
+
+describe('getParentSteps', () => {
+  it('detects a parent via step-level nextStepIds', () => {
+    const parent = makeStep({ id: 'parent', nextStepIds: ['target'] });
+    const target = makeStep({ id: 'target' });
+
+    const result = getParentSteps(target, [parent, target]);
+
+    expect(result.map((s) => s.id)).toEqual(['parent']);
+  });
+
+  it('detects a parent via IF_ELSE branch nextStepIds', () => {
+    const ifElse = makeIfElse('if-else', [
+      { nextStepIds: ['branch-a'] },
+      { nextStepIds: ['target'] },
+    ]);
+    const target = makeStep({ id: 'target' });
+
+    const result = getParentSteps(target, [ifElse, target]);
+
+    expect(result.map((s) => s.id)).toEqual(['if-else']);
+  });
+
+  it('detects a convergence step reached from both a normal step and an IF_ELSE branch', () => {
+    // if-else --(branch true)--> findStep --> target
+    //         --(branch false)-----------------> target   (re-converges)
+    const ifElse = makeIfElse('if-else', [
+      { nextStepIds: ['find-step'] },
+      { nextStepIds: ['target'] },
+    ]);
+    const findStep = makeStep({ id: 'find-step', nextStepIds: ['target'] });
+    const target = makeStep({ id: 'target' });
+
+    const result = getParentSteps(target, [ifElse, findStep, target]);
+
+    expect(result.map((s) => s.id).sort()).toEqual(['find-step', 'if-else']);
+  });
+
+  it('returns an empty array when the step has no parents', () => {
+    const orphan = makeStep({ id: 'orphan' });
+    const other = makeStep({ id: 'other', nextStepIds: ['somewhere-else'] });
+
+    expect(getParentSteps(orphan, [orphan, other])).toEqual([]);
+  });
+});

--- a/packages/twenty-server/src/modules/workflow/workflow-executor/utils/get-parent-steps.util.ts
+++ b/packages/twenty-server/src/modules/workflow/workflow-executor/utils/get-parent-steps.util.ts
@@ -1,0 +1,39 @@
+import { isDefined } from 'twenty-shared/utils';
+
+import { isWorkflowIfElseAction } from 'src/modules/workflow/workflow-executor/workflow-actions/if-else/guards/is-workflow-if-else-action.guard';
+import { type WorkflowAction } from 'src/modules/workflow/workflow-executor/workflow-actions/types/workflow-action.type';
+
+/**
+ * Returns the steps that can lead into `step`.
+ *
+ * A parent is any step whose `nextStepIds` includes `step.id`. For IF_ELSE
+ * steps the outgoing edges live on each branch (`branches[].nextStepIds`)
+ * rather than on the step-level `nextStepIds`, so those are included as well.
+ *
+ * Without this, a step reached only through an IF_ELSE branch has no
+ * detectable parent. When branches re-converge onto a shared downstream step,
+ * the not-taken branch marks that step SKIPPED and — because the IF_ELSE is not
+ * recognised as a parent — it is never revived, silently halting the run before
+ * the convergence point.
+ */
+export const getParentSteps = (
+  step: WorkflowAction,
+  steps: WorkflowAction[],
+): WorkflowAction[] =>
+  steps.filter((parentStep) => {
+    if (!isDefined(parentStep)) {
+      return false;
+    }
+
+    if (parentStep.nextStepIds?.includes(step.id)) {
+      return true;
+    }
+
+    if (isWorkflowIfElseAction(parentStep)) {
+      return (parentStep.settings.input.branches ?? []).some((branch) =>
+        branch.nextStepIds?.includes(step.id),
+      );
+    }
+
+    return false;
+  });

--- a/packages/twenty-server/src/modules/workflow/workflow-executor/utils/should-execute-step.util.ts
+++ b/packages/twenty-server/src/modules/workflow/workflow-executor/utils/should-execute-step.util.ts
@@ -1,7 +1,7 @@
-import { isDefined } from 'twenty-shared/utils';
 import { type WorkflowRunStepInfos } from 'twenty-shared/workflow';
 
 import { WorkflowRunStatus } from 'src/modules/workflow/common/standard-objects/workflow-run.workspace-entity';
+import { getParentSteps } from 'src/modules/workflow/workflow-executor/utils/get-parent-steps.util';
 import { shouldExecuteChildStep } from 'src/modules/workflow/workflow-executor/utils/should-execute-child-step.util';
 import { stepHasBeenStarted } from 'src/modules/workflow/workflow-executor/utils/step-has-been-started.util';
 import { isWorkflowIteratorAction } from 'src/modules/workflow/workflow-executor/workflow-actions/iterator/guards/is-workflow-iterator-action.guard';
@@ -35,10 +35,7 @@ export const shouldExecuteStep = ({
     return false;
   }
 
-  const parentSteps = steps.filter(
-    (parentStep) =>
-      isDefined(parentStep) && parentStep.nextStepIds?.includes(step.id),
-  );
+  const parentSteps = getParentSteps(step, steps);
 
   return shouldExecuteChildStep({
     parentSteps,

--- a/packages/twenty-server/src/modules/workflow/workflow-executor/utils/should-skip-step-execution.util.ts
+++ b/packages/twenty-server/src/modules/workflow/workflow-executor/utils/should-skip-step-execution.util.ts
@@ -1,6 +1,6 @@
-import { isDefined } from 'twenty-shared/utils';
 import { StepStatus, type WorkflowRunStepInfos } from 'twenty-shared/workflow';
 
+import { getParentSteps } from 'src/modules/workflow/workflow-executor/utils/get-parent-steps.util';
 import { isWorkflowIteratorAction } from 'src/modules/workflow/workflow-executor/workflow-actions/iterator/guards/is-workflow-iterator-action.guard';
 import { shouldSkipIteratorStepExecution } from 'src/modules/workflow/workflow-executor/workflow-actions/iterator/utils/should-skip-iterator-step-execution.util';
 import { type WorkflowAction } from 'src/modules/workflow/workflow-executor/workflow-actions/types/workflow-action.type';
@@ -22,10 +22,7 @@ export const shouldSkipStepExecution = ({
     });
   }
 
-  const parentSteps = steps.filter(
-    (parentStep) =>
-      isDefined(parentStep) && parentStep.nextStepIds?.includes(step.id),
-  );
+  const parentSteps = getParentSteps(step, steps);
 
   if (parentSteps.length === 0) {
     return false;


### PR DESCRIPTION
## Problem

Workflow runs can **silently halt** when two `IF_ELSE` branches **re-converge** onto a shared downstream step (a diamond). The run is marked `COMPLETED` (no error), but every step after the convergence point shows `NOT_STARTED` / `SKIPPED` and never executes — so e.g. emails further down the flow are never sent.

### Repro

```
trigger → IF_ELSE (A) ──true──▶ FindRecords ──▶ IF_ELSE (B) ──▶ … ──▶ SendEmail
                       └─false──────────────────▶ IF_ELSE (B)        (re-converges on B)
```

Whichever branch (A) takes, step **(B)** is marked `SKIPPED` and the run dies there:

- **(A) takes the `false` branch** → the `true` branch target (`FindRecords`) is skipped; `(B)`'s only detected parent is `FindRecords` (skipped) → `(B)` skipped.
- **(A) takes the `true` branch** → `(B)` is in the *non-matching* (`false`) branch, so it is marked `SKIPPED` immediately, even though `FindRecords → (B)` is the live path. Once `SKIPPED`, `stepHasBeenStarted` treats it as started and it is never revived.

## Root cause

`shouldExecuteStep` and `shouldSkipStepExecution` compute a step's parents using only **step-level** `nextStepIds`:

```ts
const parentSteps = steps.filter(
  (parentStep) => isDefined(parentStep) && parentStep.nextStepIds?.includes(step.id),
);
```

But `IF_ELSE` steps keep their outgoing edges on `branches[].nextStepIds`, with step-level `nextStepIds` empty. So an `IF_ELSE` that leads into a step is **never recognised as that step's parent**. At a convergence step, `shouldExecuteChildStep` then only sees the skipped sibling-branch parent and never the `IF_ELSE` that actually selected this step → the step is wrongly skipped.

## Fix

Extract parent detection into `getParentSteps(step, steps)`, which considers **both** step-level `nextStepIds` **and** `IF_ELSE` `branches[].nextStepIds`. Use it in `shouldExecuteStep` and `shouldSkipStepExecution`.

With the `IF_ELSE` correctly counted as a parent, a convergence step reachable from the taken branch is no longer prematurely skipped, and the run continues.

## Tests

Added `get-parent-steps.util.spec.ts` covering step-level parents, `IF_ELSE` branch parents, the re-convergence (diamond) case, and the no-parent case.

> Heads-up: I wasn't able to run the full `twenty-server` jest suite locally (deps not installed in my environment); I validated the new util's logic in isolation. Please let CI run the suite. Happy to adjust to match conventions.

## Notes

Observed on Twenty Cloud. Traced against `main`. This only touches parent detection for `IF_ELSE`; iterator handling is unchanged.