### PR TITLE
fix(kanban): contain checkbox hover reveal within card bounds

### DIFF
--- a/packages/twenty-front/src/modules/object-record/record-card/components/RecordCard.tsx
+++ b/packages/twenty-front/src/modules/object-record/record-card/components/RecordCard.tsx
@@ -37,8 +37,10 @@ const StyledBoardCard = styled.div<{
   }
 
   .checkbox-container {
+    flex-shrink: 0;
     max-width: 0;
     opacity: 0;
+    overflow: hidden;
     pointer-events: none;
     transition: all ease-in-out 160ms;
   }


### PR DESCRIPTION
follow up to https://github.com/twentyhq/twenty/pull/20455

before - 

https://github.com/user-attachments/assets/e5a8a328-81ec-4dc4-8e54-1a54cf252135


after - 


https://github.com/user-attachments/assets/61cbb856-564c-487f-81e5-e27adc4a0d2d

