### PR TITLE
 fix: broadcast timeline activities to live SSE subscriptions

### DIFF
--- a/packages/twenty-front/src/modules/activities/timeline-activities/hooks/useTimelineActivities.ts
+++ b/packages/twenty-front/src/modules/activities/timeline-activities/hooks/useTimelineActivities.ts
@@ -85,8 +85,12 @@ export const useTimelineActivities = (
   });
 
   const handleTimelineActivityOperation = useCallback(() => {
+    if (!hasTimelineActivityField) {
+      return;
+    }
+
     refetch();
-  }, [refetch]);
+  }, [hasTimelineActivityField, refetch]);
 
   useListenToObjectRecordOperationBrowserEvent({
     onObjectRecordOperationBrowserEvent: handleTimelineActivityOperation,

--- a/packages/twenty-front/src/modules/activities/timeline-activities/hooks/useTimelineActivities.ts
+++ b/packages/twenty-front/src/modules/activities/timeline-activities/hooks/useTimelineActivities.ts
@@ -1,10 +1,17 @@
+import { useCallback, useMemo } from 'react';
+
 import { useLinkedObjectsTitle } from '@/activities/timeline-activities/hooks/useLinkedObjectsTitle';
 import { type TimelineActivity } from '@/activities/timeline-activities/types/TimelineActivity';
 import { type ActivityTargetableObject } from '@/activities/types/ActivityTargetableEntity';
+import { useListenToObjectRecordOperationBrowserEvent } from '@/browser-event/hooks/useListenToObjectRecordOperationBrowserEvent';
 import { useObjectMetadataItem } from '@/object-metadata/hooks/useObjectMetadataItem';
 import { useGenerateDepthRecordGqlFieldsFromObject } from '@/object-record/graphql/record-gql-fields/hooks/useGenerateDepthRecordGqlFieldsFromObject';
 import { useFindManyRecords } from '@/object-record/hooks/useFindManyRecords';
-import { CoreObjectNameSingular } from 'twenty-shared/types';
+import { useListenToEventsForQuery } from '@/sse-db-event/hooks/useListenToEventsForQuery';
+import {
+  CoreObjectNameSingular,
+  type RecordGqlOperationFilter,
+} from 'twenty-shared/types';
 import { capitalize, isDefined } from 'twenty-shared/utils';
 
 // do we need to test this?
@@ -12,6 +19,15 @@ export const useTimelineActivities = (
   targetableObject: ActivityTargetableObject,
 ) => {
   const targetableObjectFieldIdName = `target${capitalize(targetableObject.targetObjectNameSingular)}Id`;
+
+  const filter: RecordGqlOperationFilter = useMemo(
+    () => ({
+      [targetableObjectFieldIdName]: {
+        eq: targetableObject.id,
+      },
+    }),
+    [targetableObjectFieldIdName, targetableObject.id],
+  );
 
   const { objectMetadataItem: timelineActivityMetadata } =
     useObjectMetadataItem({
@@ -38,14 +54,11 @@ export const useTimelineActivities = (
     records: timelineActivities,
     loading: loadingTimelineActivities,
     fetchMoreRecords,
+    refetch,
   } = useFindManyRecords<TimelineActivity>({
     skip: !hasTimelineActivityField,
     objectNameSingular: CoreObjectNameSingular.TimelineActivity,
-    filter: {
-      [targetableObjectFieldIdName]: {
-        eq: targetableObject.id,
-      },
-    },
+    filter,
     orderBy: [
       {
         createdAt: 'DescNullsFirst',
@@ -53,6 +66,31 @@ export const useTimelineActivities = (
     ],
     recordGqlFields: depthOneRecordGqlFields,
     fetchPolicy: 'cache-and-network',
+  });
+
+  const operationSignature = useMemo(
+    () => ({
+      objectNameSingular: CoreObjectNameSingular.TimelineActivity,
+      variables: {
+        filter,
+      },
+    }),
+    [filter],
+  );
+
+  useListenToEventsForQuery({
+    queryId: `timeline-activities-${targetableObject.targetObjectNameSingular}-${targetableObject.id}`,
+    operationSignature,
+    skip: !hasTimelineActivityField,
+  });
+
+  const handleTimelineActivityOperation = useCallback(() => {
+    refetch();
+  }, [refetch]);
+
+  useListenToObjectRecordOperationBrowserEvent({
+    onObjectRecordOperationBrowserEvent: handleTimelineActivityOperation,
+    objectMetadataItemId: timelineActivityMetadata.id,
   });
 
   const activityIds = timelineActivities

--- a/packages/twenty-front/src/modules/sse-db-event/hooks/useListenToEventsForQuery.ts
+++ b/packages/twenty-front/src/modules/sse-db-event/hooks/useListenToEventsForQuery.ts
@@ -59,7 +59,11 @@ export const useListenToEventsForQuery = ({
   );
 
   useEffect(() => {
-    changeQueryIdListenState(!skip, queryId, operationSignature);
+    if (skip) {
+      return;
+    }
+
+    changeQueryIdListenState(true, queryId, operationSignature);
 
     return () => {
       changeQueryIdListenState(false, queryId, operationSignature);

--- a/packages/twenty-front/src/modules/sse-db-event/hooks/useListenToEventsForQuery.ts
+++ b/packages/twenty-front/src/modules/sse-db-event/hooks/useListenToEventsForQuery.ts
@@ -9,11 +9,13 @@ import { useStore } from 'jotai';
 export const useListenToEventsForQuery = ({
   queryId,
   operationSignature,
+  skip = false,
 }: {
   queryId: string;
   operationSignature:
     | RecordGqlOperationSignature
     | MetadataGqlOperationSignature;
+  skip?: boolean;
 }) => {
   const store = useStore();
   const changeQueryIdListenState = useCallback(
@@ -57,10 +59,10 @@ export const useListenToEventsForQuery = ({
   );
 
   useEffect(() => {
-    changeQueryIdListenState(true, queryId, operationSignature);
+    changeQueryIdListenState(!skip, queryId, operationSignature);
 
     return () => {
       changeQueryIdListenState(false, queryId, operationSignature);
     };
-  }, [changeQueryIdListenState, queryId, operationSignature]);
+  }, [changeQueryIdListenState, queryId, operationSignature, skip]);
 };

--- a/packages/twenty-server/src/engine/api/common/common-select-fields/common-select-fields-helper.ts
+++ b/packages/twenty-server/src/engine/api/common/common-select-fields/common-select-fields-helper.ts
@@ -115,6 +115,13 @@ export class CommonSelectFieldsHelper {
           flatEntityId: flatField.relationTargetObjectMetadataId,
         });
 
+      if (
+        !objectsPermissions[relationTargetObjectMetadata.id]
+          ?.canReadObjectRecords
+      ) {
+        continue;
+      }
+
       const relationFieldSelectFields = getAllSelectableFields({
         restrictedFields:
           objectsPermissions[relationTargetObjectMetadata.id].restrictedFields,

--- a/packages/twenty-server/src/engine/api/graphql/workspace-query-runner/listeners/entity-events-to-db.listener.ts
+++ b/packages/twenty-server/src/engine/api/graphql/workspace-query-runner/listeners/entity-events-to-db.listener.ts
@@ -9,6 +9,7 @@ import {
   type ObjectRecordRestoreEvent,
   type ObjectRecordUpdateEvent,
 } from 'twenty-shared/database-events';
+import { STANDARD_OBJECTS } from 'twenty-shared/metadata';
 
 import { OnDatabaseBatchEvent } from 'src/engine/api/graphql/graphql-query-runner/decorators/on-database-batch-event.decorator';
 import { DatabaseEventAction } from 'src/engine/api/graphql/graphql-query-runner/enums/database-event-action';
@@ -68,6 +69,15 @@ export class EntityEventsToDbListener {
     batchEvent: WorkspaceEventBatch<T>,
     action: DatabaseEventAction,
   ) {
+    if (
+      batchEvent.objectMetadata.universalIdentifier ===
+      STANDARD_OBJECTS.timelineActivity.universalIdentifier
+    ) {
+      await this.objectRecordEventPublisher.publish(batchEvent);
+
+      return;
+    }
+
     const isAuditLogBatchEvent = batchEvent.objectMetadata?.isAuditLogged;
 
     const batchEventForWebhook = {

--- a/packages/twenty-server/src/engine/subscriptions/object-record-event/object-record-event-publisher.ts
+++ b/packages/twenty-server/src/engine/subscriptions/object-record-event/object-record-event-publisher.ts
@@ -235,8 +235,9 @@ export class ObjectRecordEventPublisher {
       } catch (error) {
         this.logger.warn(
           `Failed to enrich nested relations for ${workspaceEventBatch.name} subscription event, broadcasting without them: ${
-            (error as Error)?.message
+            error instanceof Error ? error.message : String(error)
           }`,
+          error instanceof Error ? error.stack : undefined,
         );
       }
 

--- a/packages/twenty-server/src/engine/subscriptions/object-record-event/object-record-event-publisher.ts
+++ b/packages/twenty-server/src/engine/subscriptions/object-record-event/object-record-event-publisher.ts
@@ -1,4 +1,4 @@
-import { Injectable } from '@nestjs/common';
+import { Injectable, Logger } from '@nestjs/common';
 
 import { QUERY_MAX_RECORDS_FROM_RELATION } from 'twenty-shared/constants';
 import { type ObjectRecordEvent } from 'twenty-shared/database-events';
@@ -50,6 +50,8 @@ import { parseEventNameOrThrow } from 'src/engine/workspace-event-emitter/utils/
 
 @Injectable()
 export class ObjectRecordEventPublisher {
+  private readonly logger = new Logger(ObjectRecordEventPublisher.name);
+
   constructor(
     private readonly subscriptionService: SubscriptionService,
     private readonly eventStreamService: EventStreamService,
@@ -219,16 +221,24 @@ export class ObjectRecordEventPublisher {
     }
 
     if (matchedEvents.length > 0) {
-      await this.enrichEventBatchWithNestedRelations({
-        objectMetadata: workspaceEventBatch.objectMetadata,
-        events: matchedEvents.map(
-          (matchedEvent) => matchedEvent.objectRecordEvent,
-        ),
-        streamData,
-        permissionsContext,
-        workspaceId: workspaceEventBatch.workspaceId,
-        roleId,
-      });
+      try {
+        await this.enrichEventBatchWithNestedRelations({
+          objectMetadata: workspaceEventBatch.objectMetadata,
+          events: matchedEvents.map(
+            (matchedEvent) => matchedEvent.objectRecordEvent,
+          ),
+          streamData,
+          permissionsContext,
+          workspaceId: workspaceEventBatch.workspaceId,
+          roleId,
+        });
+      } catch (error) {
+        this.logger.warn(
+          `Failed to enrich nested relations for ${workspaceEventBatch.name} subscription event, broadcasting without them: ${
+            (error as Error)?.message
+          }`,
+        );
+      }
 
       const payload: EventStreamPayload = {
         objectRecordEventsWithQueryIds: matchedEvents,

--- a/packages/twenty-server/src/engine/twenty-orm/utils/format-twenty-orm-event-to-database-batch-event.util.ts
+++ b/packages/twenty-server/src/engine/twenty-orm/utils/format-twenty-orm-event-to-database-batch-event.util.ts
@@ -7,7 +7,6 @@ import {
   ObjectRecordUpsertEvent,
   type ObjectRecordDiff,
 } from 'twenty-shared/database-events';
-import { STANDARD_OBJECTS } from 'twenty-shared/metadata';
 import {
   assertUnreachable,
   isDefined,
@@ -47,13 +46,6 @@ export const formatTwentyOrmEventToDatabaseBatchEvent = <
   recordsAfter?: T[];
   recordsBefore?: T[];
 }): DatabaseBatchEventInput<T, DatabaseEventAction> | undefined => {
-  if (
-    objectMetadataItem.universalIdentifier ===
-    STANDARD_OBJECTS.timelineActivity.universalIdentifier
-  ) {
-    return;
-  }
-
   const objectMetadataNameSingular = objectMetadataItem.nameSingular;
 
   let events: (

--- a/packages/twenty-server/src/engine/twenty-orm/utils/is-record-matching-rls-row-level-permission-predicate.util.ts
+++ b/packages/twenty-server/src/engine/twenty-orm/utils/is-record-matching-rls-row-level-permission-predicate.util.ts
@@ -208,7 +208,8 @@ export const isRecordMatchingRLSRowLevelPermissionPredicate = ({
       objectFields.find((field) => field.name === filterKey) ??
       objectFields.find(
         (field) =>
-          field.type === FieldMetadataType.RELATION &&
+          (field.type === FieldMetadataType.RELATION ||
+            field.type === FieldMetadataType.MORPH_RELATION) &&
           computeMorphOrRelationFieldJoinColumnName({ name: field.name }) ===
             filterKey,
       );
@@ -411,7 +412,8 @@ export const isRecordMatchingRLSRowLevelPermissionPredicate = ({
           });
         });
       }
-      case FieldMetadataType.RELATION: {
+      case FieldMetadataType.RELATION:
+      case FieldMetadataType.MORPH_RELATION: {
         const isJoinColumn =
           computeMorphOrRelationFieldJoinColumnName({
             name: objectMetadataField.name,


### PR DESCRIPTION
## Context
Timeline activities never updated in real time. They were explicitly excluded from the database-event pipeline (formatTwentyOrmEventToDatabaseBatchEvent early-returned for the timelineActivity object), so no SSE event was ever broadcast, and the frontend timeline only refreshed on mount/manual refetch.

## Implementation
Backend
- Feat: Stop dropping timeline-activity events in formatTwentyOrmEventToDatabaseBatchEvent. 
Instead route them through EntityEventsToDbListener, which publishes them directly to live subscriptions (but still skipping webhook/audit handling).
- Fix: Harden ObjectRecordEventPublisher: wrap nested-relation enrichment in try/catch so a failure broadcasts the event without relations instead of dropping it (logs a warning).
- Fix: Skip unreadable relation targets in CommonSelectFieldsHelper when the role lacks canReadObjectRecords, preventing errors while computing selected fields.
- Fix: Support MORPH_RELATION alongside RELATION in RLS row-level permission predicate matching (timeline activities use morph targets).

Frontend
- Feat: useTimelineActivities now registers the timeline query with the SSE system via useListenToEventsForQuery and refetches on incoming timeline-activity record operations.
- Feat: Add a skip option to useListenToEventsForQuery so the listener isn't registered when the object has no timeline field.

## Test

https://github.com/user-attachments/assets/ed1d1c66-d6ea-434d-ac9c-9b83d2b78338


Note: "UpdatedBy" seems to be listen to and visible in the timeline activity summary, this is probably a bug that we want to fix
