### PR TITLE
Public assets server s3 redirection

### DIFF
--- a/packages/twenty-server/src/engine/core-modules/file/controllers/file.controller.spec.ts
+++ b/packages/twenty-server/src/engine/core-modules/file/controllers/file.controller.spec.ts
@@ -61,8 +61,8 @@ describe('FileController', () => {
           provide: FileService,
           useValue: {
             getFileStreamById: jest.fn(),
-            getFileResponseByPath: jest.fn(),
-            getFileResponseById: jest.fn(),
+            getFilePresignedUrlOrStreamByPath: jest.fn(),
+            getFilePresignedUrlOrStreamById: jest.fn(),
           },
         },
       ],
@@ -90,7 +90,7 @@ describe('FileController', () => {
 
   describe('getFileById', () => {
     it('should 302 redirect when presigned URL is available', async () => {
-      jest.spyOn(fileService, 'getFileResponseById').mockResolvedValue({
+      jest.spyOn(fileService, 'getFilePresignedUrlOrStreamById').mockResolvedValue({
         type: 'redirect',
         presignedUrl: 'https://s3.example.com/file?signed=abc',
       });
@@ -105,7 +105,7 @@ describe('FileController', () => {
         'file-123',
       );
 
-      expect(fileService.getFileResponseById).toHaveBeenCalledWith({
+      expect(fileService.getFilePresignedUrlOrStreamById).toHaveBeenCalledWith({
         fileId: 'file-123',
         workspaceId: 'workspace-id',
         fileFolder: FileFolder.Workflow,
@@ -119,7 +119,7 @@ describe('FileController', () => {
     it('should stream with headers when no presigned URL (local driver)', async () => {
       const mockStream = createMockStream();
 
-      jest.spyOn(fileService, 'getFileResponseById').mockResolvedValue({
+      jest.spyOn(fileService, 'getFilePresignedUrlOrStreamById').mockResolvedValue({
         type: 'stream',
         stream: mockStream,
         mimeType: 'image/png',
@@ -153,7 +153,7 @@ describe('FileController', () => {
     it('should force attachment disposition for non-safe MIME types', async () => {
       const mockStream = createMockStream();
 
-      jest.spyOn(fileService, 'getFileResponseById').mockResolvedValue({
+      jest.spyOn(fileService, 'getFilePresignedUrlOrStreamById').mockResolvedValue({
         type: 'stream',
         stream: mockStream,
         mimeType: 'text/html',
@@ -180,7 +180,7 @@ describe('FileController', () => {
     });
 
     it('should throw FILE_NOT_FOUND when the service yields null', async () => {
-      jest.spyOn(fileService, 'getFileResponseById').mockResolvedValue(null);
+      jest.spyOn(fileService, 'getFilePresignedUrlOrStreamById').mockResolvedValue(null);
 
       const mockRequest = { workspaceId: 'workspace-id' } as any;
       const mockResponse = createMockResponse() as any;
@@ -206,7 +206,7 @@ describe('FileController', () => {
       );
 
       jest
-        .spyOn(fileService, 'getFileResponseById')
+        .spyOn(fileService, 'getFilePresignedUrlOrStreamById')
         .mockRejectedValue(underlyingError);
 
       const mockRequest = { workspaceId: 'workspace-id' } as any;
@@ -228,7 +228,7 @@ describe('FileController', () => {
       await expect(promise).rejects.not.toThrow(/secret-host/);
 
       expect(loggerSpy).toHaveBeenCalledWith(
-        'getFileResponseById failed unexpectedly',
+        'getFilePresignedUrlOrStreamById failed unexpectedly',
         { error: underlyingError },
       );
     });
@@ -236,7 +236,7 @@ describe('FileController', () => {
     it('should throw INTERNAL_SERVER_ERROR when the stream errors before headers are sent', async () => {
       const mockStream = createMockStream();
 
-      jest.spyOn(fileService, 'getFileResponseById').mockResolvedValue({
+      jest.spyOn(fileService, 'getFilePresignedUrlOrStreamById').mockResolvedValue({
         type: 'stream',
         stream: mockStream,
         mimeType: 'image/png',
@@ -267,7 +267,7 @@ describe('FileController', () => {
     it('should destroy the response without throwing when the stream errors after headers are sent', async () => {
       const mockStream = createMockStream();
 
-      jest.spyOn(fileService, 'getFileResponseById').mockResolvedValue({
+      jest.spyOn(fileService, 'getFilePresignedUrlOrStreamById').mockResolvedValue({
         type: 'stream',
         stream: mockStream,
         mimeType: 'image/png',
@@ -293,7 +293,7 @@ describe('FileController', () => {
 
   describe('getPublicAssets', () => {
     it('should 302 redirect when presigned URL is available', async () => {
-      jest.spyOn(fileService, 'getFileResponseByPath').mockResolvedValue({
+      jest.spyOn(fileService, 'getFilePresignedUrlOrStreamByPath').mockResolvedValue({
         type: 'redirect',
         presignedUrl: 'https://s3.example.com/public-asset/logo.png?signed=abc',
       });
@@ -311,7 +311,7 @@ describe('FileController', () => {
         'app-id',
       );
 
-      expect(fileService.getFileResponseByPath).toHaveBeenCalledWith({
+      expect(fileService.getFilePresignedUrlOrStreamByPath).toHaveBeenCalledWith({
         workspaceId: 'workspace-id',
         applicationId: 'app-id',
         fileFolder: FileFolder.PublicAsset,
@@ -326,7 +326,7 @@ describe('FileController', () => {
     it('should stream with headers when no presigned URL (local driver)', async () => {
       const mockStream = createMockStream();
 
-      jest.spyOn(fileService, 'getFileResponseByPath').mockResolvedValue({
+      jest.spyOn(fileService, 'getFilePresignedUrlOrStreamByPath').mockResolvedValue({
         type: 'stream',
         stream: mockStream,
         mimeType: 'image/png',
@@ -345,7 +345,7 @@ describe('FileController', () => {
         'app-id',
       );
 
-      expect(fileService.getFileResponseByPath).toHaveBeenCalledWith({
+      expect(fileService.getFilePresignedUrlOrStreamByPath).toHaveBeenCalledWith({
         workspaceId: 'workspace-id',
         applicationId: 'app-id',
         fileFolder: FileFolder.PublicAsset,
@@ -369,7 +369,7 @@ describe('FileController', () => {
     it('should handle single-segment path', async () => {
       const mockStream = createMockStream();
 
-      jest.spyOn(fileService, 'getFileResponseByPath').mockResolvedValue({
+      jest.spyOn(fileService, 'getFilePresignedUrlOrStreamByPath').mockResolvedValue({
         type: 'stream',
         stream: mockStream,
         mimeType: 'image/x-icon',
@@ -388,7 +388,7 @@ describe('FileController', () => {
         'app-id',
       );
 
-      expect(fileService.getFileResponseByPath).toHaveBeenCalledWith({
+      expect(fileService.getFilePresignedUrlOrStreamByPath).toHaveBeenCalledWith({
         workspaceId: 'workspace-id',
         applicationId: 'app-id',
         fileFolder: FileFolder.PublicAsset,
@@ -397,7 +397,7 @@ describe('FileController', () => {
     });
 
     it('should throw FILE_NOT_FOUND when the service yields null', async () => {
-      jest.spyOn(fileService, 'getFileResponseByPath').mockResolvedValue(null);
+      jest.spyOn(fileService, 'getFilePresignedUrlOrStreamByPath').mockResolvedValue(null);
 
       const mockRequest = {
         params: { path: ['missing-asset.png'] },
@@ -426,7 +426,7 @@ describe('FileController', () => {
       );
 
       jest
-        .spyOn(fileService, 'getFileResponseByPath')
+        .spyOn(fileService, 'getFilePresignedUrlOrStreamByPath')
         .mockRejectedValue(underlyingError);
 
       const mockRequest = {
@@ -451,7 +451,7 @@ describe('FileController', () => {
       await expect(promise).rejects.not.toThrow(/secret-host/);
 
       expect(loggerSpy).toHaveBeenCalledWith(
-        'getFileResponseByPath failed unexpectedly',
+        'getFilePresignedUrlOrStreamByPath failed unexpectedly',
         { error: underlyingError },
       );
     });
@@ -459,7 +459,7 @@ describe('FileController', () => {
     it('should throw INTERNAL_SERVER_ERROR when the stream errors before headers are sent', async () => {
       const mockStream = createMockStream();
 
-      jest.spyOn(fileService, 'getFileResponseByPath').mockResolvedValue({
+      jest.spyOn(fileService, 'getFilePresignedUrlOrStreamByPath').mockResolvedValue({
         type: 'stream',
         stream: mockStream,
         mimeType: 'image/png',
@@ -493,7 +493,7 @@ describe('FileController', () => {
     it('should destroy the response without throwing when the stream errors after headers are sent', async () => {
       const mockStream = createMockStream();
 
-      jest.spyOn(fileService, 'getFileResponseByPath').mockResolvedValue({
+      jest.spyOn(fileService, 'getFilePresignedUrlOrStreamByPath').mockResolvedValue({
         type: 'stream',
         stream: mockStream,
         mimeType: 'image/png',

--- a/packages/twenty-server/src/engine/core-modules/file/controllers/file.controller.spec.ts
+++ b/packages/twenty-server/src/engine/core-modules/file/controllers/file.controller.spec.ts
@@ -61,7 +61,7 @@ describe('FileController', () => {
           provide: FileService,
           useValue: {
             getFileStreamById: jest.fn(),
-            getFileStreamByPath: jest.fn(),
+            getFileResponseByPath: jest.fn(),
             getFileResponseById: jest.fn(),
           },
         },
@@ -292,10 +292,42 @@ describe('FileController', () => {
   });
 
   describe('getPublicAssets', () => {
-    it('should call fileService.getFileStreamByPath and pipe with headers', async () => {
+    it('should 302 redirect when presigned URL is available', async () => {
+      jest.spyOn(fileService, 'getFileResponseByPath').mockResolvedValue({
+        type: 'redirect',
+        presignedUrl: 'https://s3.example.com/public-asset/logo.png?signed=abc',
+      });
+
+      const mockRequest = {
+        params: { path: ['images', 'logo.png'] },
+      } as any;
+
+      const mockResponse = createMockResponse() as any;
+
+      await controller.getPublicAssets(
+        mockResponse,
+        mockRequest,
+        'workspace-id',
+        'app-id',
+      );
+
+      expect(fileService.getFileResponseByPath).toHaveBeenCalledWith({
+        workspaceId: 'workspace-id',
+        applicationId: 'app-id',
+        fileFolder: FileFolder.PublicAsset,
+        filepath: 'images/logo.png',
+      });
+      expect(mockResponse.redirect).toHaveBeenCalledWith(
+        'https://s3.example.com/public-asset/logo.png?signed=abc',
+      );
+      expect(mockResponse.setHeader).not.toHaveBeenCalled();
+    });
+
+    it('should stream with headers when no presigned URL (local driver)', async () => {
       const mockStream = createMockStream();
 
-      jest.spyOn(fileService, 'getFileStreamByPath').mockResolvedValue({
+      jest.spyOn(fileService, 'getFileResponseByPath').mockResolvedValue({
+        type: 'stream',
         stream: mockStream,
         mimeType: 'image/png',
       });
@@ -313,7 +345,7 @@ describe('FileController', () => {
         'app-id',
       );
 
-      expect(fileService.getFileStreamByPath).toHaveBeenCalledWith({
+      expect(fileService.getFileResponseByPath).toHaveBeenCalledWith({
         workspaceId: 'workspace-id',
         applicationId: 'app-id',
         fileFolder: FileFolder.PublicAsset,
@@ -337,7 +369,8 @@ describe('FileController', () => {
     it('should handle single-segment path', async () => {
       const mockStream = createMockStream();
 
-      jest.spyOn(fileService, 'getFileStreamByPath').mockResolvedValue({
+      jest.spyOn(fileService, 'getFileResponseByPath').mockResolvedValue({
+        type: 'stream',
         stream: mockStream,
         mimeType: 'image/x-icon',
       });
@@ -355,7 +388,7 @@ describe('FileController', () => {
         'app-id',
       );
 
-      expect(fileService.getFileStreamByPath).toHaveBeenCalledWith({
+      expect(fileService.getFileResponseByPath).toHaveBeenCalledWith({
         workspaceId: 'workspace-id',
         applicationId: 'app-id',
         fileFolder: FileFolder.PublicAsset,
@@ -364,7 +397,7 @@ describe('FileController', () => {
     });
 
     it('should throw FILE_NOT_FOUND when the service yields null', async () => {
-      jest.spyOn(fileService, 'getFileStreamByPath').mockResolvedValue(null);
+      jest.spyOn(fileService, 'getFileResponseByPath').mockResolvedValue(null);
 
       const mockRequest = {
         params: { path: ['missing-asset.png'] },
@@ -393,7 +426,7 @@ describe('FileController', () => {
       );
 
       jest
-        .spyOn(fileService, 'getFileStreamByPath')
+        .spyOn(fileService, 'getFileResponseByPath')
         .mockRejectedValue(underlyingError);
 
       const mockRequest = {
@@ -418,7 +451,7 @@ describe('FileController', () => {
       await expect(promise).rejects.not.toThrow(/secret-host/);
 
       expect(loggerSpy).toHaveBeenCalledWith(
-        'getFileStreamByPath failed unexpectedly',
+        'getFileResponseByPath failed unexpectedly',
         { error: underlyingError },
       );
     });
@@ -426,7 +459,8 @@ describe('FileController', () => {
     it('should throw INTERNAL_SERVER_ERROR when the stream errors before headers are sent', async () => {
       const mockStream = createMockStream();
 
-      jest.spyOn(fileService, 'getFileStreamByPath').mockResolvedValue({
+      jest.spyOn(fileService, 'getFileResponseByPath').mockResolvedValue({
+        type: 'stream',
         stream: mockStream,
         mimeType: 'image/png',
       });
@@ -459,7 +493,8 @@ describe('FileController', () => {
     it('should destroy the response without throwing when the stream errors after headers are sent', async () => {
       const mockStream = createMockStream();
 
-      jest.spyOn(fileService, 'getFileStreamByPath').mockResolvedValue({
+      jest.spyOn(fileService, 'getFileResponseByPath').mockResolvedValue({
+        type: 'stream',
         stream: mockStream,
         mimeType: 'image/png',
       });
@@ -472,8 +507,6 @@ describe('FileController', () => {
 
       const mockResponse = createMockResponse({ headersSent: true }) as any;
 
-      // No throw expected — once headers are out, the controller cannot honestly
-      // switch to a 500 response, so it tears the socket down instead.
       await controller.getPublicAssets(
         mockResponse,
         mockRequest,

--- a/packages/twenty-server/src/engine/core-modules/file/controllers/file.controller.spec.ts
+++ b/packages/twenty-server/src/engine/core-modules/file/controllers/file.controller.spec.ts
@@ -90,10 +90,12 @@ describe('FileController', () => {
 
   describe('getFileById', () => {
     it('should 302 redirect when presigned URL is available', async () => {
-      jest.spyOn(fileService, 'getFilePresignedUrlOrStreamById').mockResolvedValue({
-        type: 'redirect',
-        presignedUrl: 'https://s3.example.com/file?signed=abc',
-      });
+      jest
+        .spyOn(fileService, 'getFilePresignedUrlOrStreamById')
+        .mockResolvedValue({
+          type: 'redirect',
+          presignedUrl: 'https://s3.example.com/file?signed=abc',
+        });
 
       const mockRequest = { workspaceId: 'workspace-id' } as any;
       const mockResponse = createMockResponse() as any;
@@ -119,11 +121,13 @@ describe('FileController', () => {
     it('should stream with headers when no presigned URL (local driver)', async () => {
       const mockStream = createMockStream();
 
-      jest.spyOn(fileService, 'getFilePresignedUrlOrStreamById').mockResolvedValue({
-        type: 'stream',
-        stream: mockStream,
-        mimeType: 'image/png',
-      });
+      jest
+        .spyOn(fileService, 'getFilePresignedUrlOrStreamById')
+        .mockResolvedValue({
+          type: 'stream',
+          stream: mockStream,
+          mimeType: 'image/png',
+        });
 
       const mockRequest = { workspaceId: 'workspace-id' } as any;
       const mockResponse = createMockResponse() as any;
@@ -153,11 +157,13 @@ describe('FileController', () => {
     it('should force attachment disposition for non-safe MIME types', async () => {
       const mockStream = createMockStream();
 
-      jest.spyOn(fileService, 'getFilePresignedUrlOrStreamById').mockResolvedValue({
-        type: 'stream',
-        stream: mockStream,
-        mimeType: 'text/html',
-      });
+      jest
+        .spyOn(fileService, 'getFilePresignedUrlOrStreamById')
+        .mockResolvedValue({
+          type: 'stream',
+          stream: mockStream,
+          mimeType: 'text/html',
+        });
 
       const mockRequest = { workspaceId: 'workspace-id' } as any;
       const mockResponse = createMockResponse() as any;
@@ -180,7 +186,9 @@ describe('FileController', () => {
     });
 
     it('should throw FILE_NOT_FOUND when the service yields null', async () => {
-      jest.spyOn(fileService, 'getFilePresignedUrlOrStreamById').mockResolvedValue(null);
+      jest
+        .spyOn(fileService, 'getFilePresignedUrlOrStreamById')
+        .mockResolvedValue(null);
 
       const mockRequest = { workspaceId: 'workspace-id' } as any;
       const mockResponse = createMockResponse() as any;
@@ -236,11 +244,13 @@ describe('FileController', () => {
     it('should throw INTERNAL_SERVER_ERROR when the stream errors before headers are sent', async () => {
       const mockStream = createMockStream();
 
-      jest.spyOn(fileService, 'getFilePresignedUrlOrStreamById').mockResolvedValue({
-        type: 'stream',
-        stream: mockStream,
-        mimeType: 'image/png',
-      });
+      jest
+        .spyOn(fileService, 'getFilePresignedUrlOrStreamById')
+        .mockResolvedValue({
+          type: 'stream',
+          stream: mockStream,
+          mimeType: 'image/png',
+        });
 
       mockPipeline.mockRejectedValue(new Error('source backend exploded'));
 
@@ -267,11 +277,13 @@ describe('FileController', () => {
     it('should destroy the response without throwing when the stream errors after headers are sent', async () => {
       const mockStream = createMockStream();
 
-      jest.spyOn(fileService, 'getFilePresignedUrlOrStreamById').mockResolvedValue({
-        type: 'stream',
-        stream: mockStream,
-        mimeType: 'image/png',
-      });
+      jest
+        .spyOn(fileService, 'getFilePresignedUrlOrStreamById')
+        .mockResolvedValue({
+          type: 'stream',
+          stream: mockStream,
+          mimeType: 'image/png',
+        });
 
       mockPipeline.mockRejectedValue(new Error('socket reset mid-flight'));
 
@@ -293,10 +305,13 @@ describe('FileController', () => {
 
   describe('getPublicAssets', () => {
     it('should 302 redirect when presigned URL is available', async () => {
-      jest.spyOn(fileService, 'getFilePresignedUrlOrStreamByPath').mockResolvedValue({
-        type: 'redirect',
-        presignedUrl: 'https://s3.example.com/public-asset/logo.png?signed=abc',
-      });
+      jest
+        .spyOn(fileService, 'getFilePresignedUrlOrStreamByPath')
+        .mockResolvedValue({
+          type: 'redirect',
+          presignedUrl:
+            'https://s3.example.com/public-asset/logo.png?signed=abc',
+        });
 
       const mockRequest = {
         params: { path: ['images', 'logo.png'] },
@@ -311,7 +326,9 @@ describe('FileController', () => {
         'app-id',
       );
 
-      expect(fileService.getFilePresignedUrlOrStreamByPath).toHaveBeenCalledWith({
+      expect(
+        fileService.getFilePresignedUrlOrStreamByPath,
+      ).toHaveBeenCalledWith({
         workspaceId: 'workspace-id',
         applicationId: 'app-id',
         fileFolder: FileFolder.PublicAsset,
@@ -326,11 +343,13 @@ describe('FileController', () => {
     it('should stream with headers when no presigned URL (local driver)', async () => {
       const mockStream = createMockStream();
 
-      jest.spyOn(fileService, 'getFilePresignedUrlOrStreamByPath').mockResolvedValue({
-        type: 'stream',
-        stream: mockStream,
-        mimeType: 'image/png',
-      });
+      jest
+        .spyOn(fileService, 'getFilePresignedUrlOrStreamByPath')
+        .mockResolvedValue({
+          type: 'stream',
+          stream: mockStream,
+          mimeType: 'image/png',
+        });
 
       const mockRequest = {
         params: { path: ['images', 'logo.png'] },
@@ -345,7 +364,9 @@ describe('FileController', () => {
         'app-id',
       );
 
-      expect(fileService.getFilePresignedUrlOrStreamByPath).toHaveBeenCalledWith({
+      expect(
+        fileService.getFilePresignedUrlOrStreamByPath,
+      ).toHaveBeenCalledWith({
         workspaceId: 'workspace-id',
         applicationId: 'app-id',
         fileFolder: FileFolder.PublicAsset,
@@ -369,11 +390,13 @@ describe('FileController', () => {
     it('should handle single-segment path', async () => {
       const mockStream = createMockStream();
 
-      jest.spyOn(fileService, 'getFilePresignedUrlOrStreamByPath').mockResolvedValue({
-        type: 'stream',
-        stream: mockStream,
-        mimeType: 'image/x-icon',
-      });
+      jest
+        .spyOn(fileService, 'getFilePresignedUrlOrStreamByPath')
+        .mockResolvedValue({
+          type: 'stream',
+          stream: mockStream,
+          mimeType: 'image/x-icon',
+        });
 
       const mockRequest = {
         params: { path: ['favicon.ico'] },
@@ -388,7 +411,9 @@ describe('FileController', () => {
         'app-id',
       );
 
-      expect(fileService.getFilePresignedUrlOrStreamByPath).toHaveBeenCalledWith({
+      expect(
+        fileService.getFilePresignedUrlOrStreamByPath,
+      ).toHaveBeenCalledWith({
         workspaceId: 'workspace-id',
         applicationId: 'app-id',
         fileFolder: FileFolder.PublicAsset,
@@ -397,7 +422,9 @@ describe('FileController', () => {
     });
 
     it('should throw FILE_NOT_FOUND when the service yields null', async () => {
-      jest.spyOn(fileService, 'getFilePresignedUrlOrStreamByPath').mockResolvedValue(null);
+      jest
+        .spyOn(fileService, 'getFilePresignedUrlOrStreamByPath')
+        .mockResolvedValue(null);
 
       const mockRequest = {
         params: { path: ['missing-asset.png'] },
@@ -459,11 +486,13 @@ describe('FileController', () => {
     it('should throw INTERNAL_SERVER_ERROR when the stream errors before headers are sent', async () => {
       const mockStream = createMockStream();
 
-      jest.spyOn(fileService, 'getFilePresignedUrlOrStreamByPath').mockResolvedValue({
-        type: 'stream',
-        stream: mockStream,
-        mimeType: 'image/png',
-      });
+      jest
+        .spyOn(fileService, 'getFilePresignedUrlOrStreamByPath')
+        .mockResolvedValue({
+          type: 'stream',
+          stream: mockStream,
+          mimeType: 'image/png',
+        });
 
       mockPipeline.mockRejectedValue(new Error('source backend exploded'));
 
@@ -493,11 +522,13 @@ describe('FileController', () => {
     it('should destroy the response without throwing when the stream errors after headers are sent', async () => {
       const mockStream = createMockStream();
 
-      jest.spyOn(fileService, 'getFilePresignedUrlOrStreamByPath').mockResolvedValue({
-        type: 'stream',
-        stream: mockStream,
-        mimeType: 'image/png',
-      });
+      jest
+        .spyOn(fileService, 'getFilePresignedUrlOrStreamByPath')
+        .mockResolvedValue({
+          type: 'stream',
+          stream: mockStream,
+          mimeType: 'image/png',
+        });
 
       mockPipeline.mockRejectedValue(new Error('socket reset mid-flight'));
 

--- a/packages/twenty-server/src/engine/core-modules/file/controllers/file.controller.ts
+++ b/packages/twenty-server/src/engine/core-modules/file/controllers/file.controller.ts
@@ -60,15 +60,15 @@ export class FileController {
       );
     }
 
-    const fileStream = await this.fileService
-      .getFileStreamByPath({
+    const fileResponse = await this.fileService
+      .getFileResponseByPath({
         workspaceId,
         applicationId,
         fileFolder: FileFolder.PublicAsset,
         filepath,
       })
       .catch((error) => {
-        this.logger.error('getFileStreamByPath failed unexpectedly', {
+        this.logger.error('getFileResponseByPath failed unexpectedly', {
           error,
         });
 
@@ -78,19 +78,21 @@ export class FileController {
         );
       });
 
-    if (fileStream === null) {
+    if (fileResponse === null) {
       throw new FileException(
         'File not found',
         FileExceptionCode.FILE_NOT_FOUND,
       );
     }
 
-    const { stream, mimeType } = fileStream;
+    if (fileResponse.type === 'redirect') {
+      return res.redirect(fileResponse.presignedUrl);
+    }
 
-    setFileResponseHeaders(res, mimeType);
+    setFileResponseHeaders(res, fileResponse.mimeType);
 
     try {
-      await pipeline(stream, res);
+      await pipeline(fileResponse.stream, res);
     } catch (error) {
       this.logger.error('Public asset stream failed mid-transfer', { error });
 

--- a/packages/twenty-server/src/engine/core-modules/file/controllers/file.controller.ts
+++ b/packages/twenty-server/src/engine/core-modules/file/controllers/file.controller.ts
@@ -61,14 +61,14 @@ export class FileController {
     }
 
     const fileResponse = await this.fileService
-      .getFileResponseByPath({
+      .getFilePresignedUrlOrStreamByPath({
         workspaceId,
         applicationId,
         fileFolder: FileFolder.PublicAsset,
         filepath,
       })
       .catch((error) => {
-        this.logger.error('getFileResponseByPath failed unexpectedly', {
+        this.logger.error('getFilePresignedUrlOrStreamByPath failed unexpectedly', {
           error,
         });
 
@@ -119,13 +119,13 @@ export class FileController {
     const workspaceId = (req as any)?.workspaceId;
 
     const fileResponse = await this.fileService
-      .getFileResponseById({
+      .getFilePresignedUrlOrStreamById({
         fileId,
         workspaceId,
         fileFolder,
       })
       .catch((error) => {
-        this.logger.error('getFileResponseById failed unexpectedly', {
+        this.logger.error('getFilePresignedUrlOrStreamById failed unexpectedly', {
           error,
         });
 

--- a/packages/twenty-server/src/engine/core-modules/file/controllers/file.controller.ts
+++ b/packages/twenty-server/src/engine/core-modules/file/controllers/file.controller.ts
@@ -68,9 +68,12 @@ export class FileController {
         filepath,
       })
       .catch((error) => {
-        this.logger.error('getFilePresignedUrlOrStreamByPath failed unexpectedly', {
-          error,
-        });
+        this.logger.error(
+          'getFilePresignedUrlOrStreamByPath failed unexpectedly',
+          {
+            error,
+          },
+        );
 
         throw new FileException(
           'Error retrieving file',
@@ -125,9 +128,12 @@ export class FileController {
         fileFolder,
       })
       .catch((error) => {
-        this.logger.error('getFilePresignedUrlOrStreamById failed unexpectedly', {
-          error,
-        });
+        this.logger.error(
+          'getFilePresignedUrlOrStreamById failed unexpectedly',
+          {
+            error,
+          },
+        );
 
         throw new FileException(
           'Error retrieving file',

--- a/packages/twenty-server/src/engine/core-modules/file/services/file.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/file/services/file.service.ts
@@ -36,7 +36,7 @@ export class FileService {
     private readonly applicationRepository: Repository<ApplicationEntity>,
   ) {}
 
-  async getFileResponseByPath({
+  async getFilePresignedUrlOrStreamByPath({
     workspaceId,
     applicationId,
     filepath,
@@ -69,7 +69,7 @@ export class FileService {
       return null;
     }
 
-    return this.buildFileResponse({
+    return this.getFilePresignedUrlOrStream({
       resourcePath: filepath,
       fileFolder,
       applicationUniversalIdentifier: application.universalIdentifier,
@@ -137,7 +137,7 @@ export class FileService {
     }
   }
 
-  async getFileResponseById(params: {
+  async getFilePresignedUrlOrStreamById(params: {
     fileId: string;
     workspaceId: string;
     fileFolder: FileFolder;
@@ -168,7 +168,7 @@ export class FileService {
       return null;
     }
 
-    return this.buildFileResponse({
+    return this.getFilePresignedUrlOrStream({
       resourcePath: removeFileFolderFromFileEntityPath(file.path),
       fileFolder: params.fileFolder,
       applicationUniversalIdentifier: application.universalIdentifier,
@@ -177,7 +177,7 @@ export class FileService {
     });
   }
 
-  private async buildFileResponse({
+  private async getFilePresignedUrlOrStream({
     resourcePath,
     fileFolder,
     applicationUniversalIdentifier,

--- a/packages/twenty-server/src/engine/core-modules/file/services/file.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/file/services/file.service.ts
@@ -36,7 +36,7 @@ export class FileService {
     private readonly applicationRepository: Repository<ApplicationEntity>,
   ) {}
 
-  async getFileStreamByPath({
+  async getFileResponseByPath({
     workspaceId,
     applicationId,
     filepath,
@@ -46,7 +46,7 @@ export class FileService {
     applicationId: string;
     filepath: string;
     fileFolder: FileFolder;
-  }): Promise<{ stream: Readable; mimeType: string } | null> {
+  }): Promise<FileResponse | null> {
     const application = await this.applicationRepository.findOne({
       where: {
         id: applicationId,
@@ -69,28 +69,13 @@ export class FileService {
       return null;
     }
 
-    try {
-      const stream = await this.fileStorageService.readFile({
-        resourcePath: filepath,
-        fileFolder,
-        applicationUniversalIdentifier: application.universalIdentifier,
-        workspaceId,
-      });
-
-      return {
-        stream,
-        mimeType: file.mimeType,
-      };
-    } catch (error) {
-      if (
-        error instanceof FileStorageException &&
-        error.code === FileStorageExceptionCode.FILE_NOT_FOUND
-      ) {
-        return null;
-      }
-
-      throw error;
-    }
+    return this.buildFileResponse({
+      resourcePath: filepath,
+      fileFolder,
+      applicationUniversalIdentifier: application.universalIdentifier,
+      workspaceId,
+      mimeType: file.mimeType,
+    });
   }
 
   async getFileStreamById({
@@ -183,12 +168,33 @@ export class FileService {
       return null;
     }
 
-    const mimeType = file.mimeType ?? 'application/octet-stream';
-    const resourceIdentifier = {
+    return this.buildFileResponse({
       resourcePath: removeFileFolderFromFileEntityPath(file.path),
       fileFolder: params.fileFolder,
       applicationUniversalIdentifier: application.universalIdentifier,
       workspaceId: params.workspaceId,
+      mimeType: file.mimeType,
+    });
+  }
+
+  private async buildFileResponse({
+    resourcePath,
+    fileFolder,
+    applicationUniversalIdentifier,
+    workspaceId,
+    mimeType,
+  }: {
+    resourcePath: string;
+    fileFolder: FileFolder;
+    applicationUniversalIdentifier: string;
+    workspaceId: string;
+    mimeType: string;
+  }): Promise<FileResponse | null> {
+    const resourceIdentifier = {
+      resourcePath,
+      fileFolder,
+      applicationUniversalIdentifier,
+      workspaceId,
     };
 
     const presignedUrl = await this.fileStorageService.getPresignedUrl({
@@ -267,7 +273,7 @@ export class FileService {
 
       return {
         buffer,
-        mimeType: file.mimeType ?? 'application/octet-stream',
+        mimeType: file.mimeType,
       };
     } catch (error) {
       if (

--- a/packages/twenty-server/src/engine/twenty-orm/workspace-scoped-repository/workspace-scoped-repository.ts
+++ b/packages/twenty-server/src/engine/twenty-orm/workspace-scoped-repository/workspace-scoped-repository.ts
@@ -104,8 +104,8 @@ export class WorkspaceScopedRepository<T extends WorkspaceScopedEntity> {
   ): Promise<number | null> {
     this.assertWorkspaceId(workspaceId);
 
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     return this.repository.maximum(
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
       columnName as any,
       where
         ? this.mergeWorkspaceIdIntoCriteria(workspaceId, where)


### PR DESCRIPTION
# Introduction
Avoid overloading the server on file streaming
Take profit of the different origin implied by the redirection to the s3
Only concern being the expiration date on a public file which is acceptable

closes https://github.com/twentyhq/private-issues/issues/483
related https://github.com/twentyhq/private-issues/issues/491