### PR TITLE
fix(integ-testing) - should reject a non-ACCESS token even with API key permission

### DIFF
--- a/packages/twenty-server/src/engine/core-modules/api-key/api-key.resolver.ts
+++ b/packages/twenty-server/src/engine/core-modules/api-key/api-key.resolver.ts
@@ -1,4 +1,4 @@
-import { UseGuards } from '@nestjs/common';
+import { UseFilters, UseGuards } from '@nestjs/common';
 import { Args, Mutation, Parent, Query, ResolveField } from '@nestjs/graphql';
 
 import { type QueryDeepPartialEntity } from 'typeorm/query-builder/QueryPartialEntity';
@@ -12,6 +12,7 @@ import { GetApiKeyInput } from 'src/engine/core-modules/api-key/dtos/get-api-key
 import { RevokeApiKeyInput } from 'src/engine/core-modules/api-key/dtos/revoke-api-key.input';
 import { UpdateApiKeyInput } from 'src/engine/core-modules/api-key/dtos/update-api-key.input';
 import { apiKeyGraphqlApiExceptionHandler } from 'src/engine/core-modules/api-key/utils/api-key-graphql-api-exception-handler.util';
+import { AuthGraphqlApiExceptionFilter } from 'src/engine/core-modules/auth/filters/auth-graphql-api-exception.filter';
 import { WorkspaceEntity } from 'src/engine/core-modules/workspace/workspace.entity';
 import { AuthWorkspace } from 'src/engine/decorators/auth/auth-workspace.decorator';
 import { SettingsPermissionGuard } from 'src/engine/guards/settings-permission.guard';
@@ -22,6 +23,7 @@ import { ApiKeyRoleService } from './services/api-key-role.service';
 import { ApiKeyService } from './services/api-key.service';
 
 @MetadataResolver(() => ApiKeyEntity)
+@UseFilters(AuthGraphqlApiExceptionFilter)
 @UseGuards(
   WorkspaceAuthGuard,
   SettingsPermissionGuard(PermissionFlagType.API_KEYS_AND_WEBHOOKS),


### PR DESCRIPTION
**Root cause:** The test createApiKey › should reject a non-ACCESS token even with API key permission fails because res.body.data is undefined instead of null.

When RequireAccessTokenGuard throws an AuthException(FORBIDDEN_EXCEPTION), NestJS needs an exception filter to convert it into a proper GraphQL ForbiddenError. Without the filter, the exception propagates without being converted, producing a response body that has errors but no data key at all, hence undefined.

Contrast with generateApiKeyToken in auth.resolver.ts, which has @UseFilters(AuthGraphqlApiExceptionFilter) at the class level, so its AuthException is correctly converted to { data: null, errors: [{ extensions: { code: 'FORBIDDEN' } }] }.