### PR TITLE
fix: lowercase OAuth handle to prevent duplicate connected accounts

### DIFF
--- a/packages/twenty-server/src/engine/core-modules/auth/controllers/google-apis-auth.controller.ts
+++ b/packages/twenty-server/src/engine/core-modules/auth/controllers/google-apis-auth.controller.ts
@@ -96,7 +96,7 @@ export class GoogleAPIsAuthController {
         id: workspaceId,
       });
 
-      const handle = emails[0].value;
+      const handle = emails[0].value.toLowerCase();
 
       const connectedAccountId =
         await this.googleAPIsService.refreshGoogleRefreshToken({

--- a/packages/twenty-server/src/engine/core-modules/auth/controllers/microsoft-apis-auth.controller.ts
+++ b/packages/twenty-server/src/engine/core-modules/auth/controllers/microsoft-apis-auth.controller.ts
@@ -103,7 +103,7 @@ export class MicrosoftAPIsAuthController {
         );
       }
 
-      const handle = emails[0].value;
+      const handle = emails[0].value.toLowerCase();
 
       const connectedAccountId =
         await this.microsoftAPIsService.refreshMicrosoftRefreshToken({


### PR DESCRIPTION
Google and Microsoft connect flows stored the provider-returned email verbatim, so a re-auth with different casing (Sam@ vs sam@) missed the existing-account lookup and created a duplicate. Normalize the handle to lowercase at extraction, matching the SSO controller.

Note: not doing backfill for now