### PR TITLE
ci: add Cursor agents and self-heal demo

### DIFF
--- a/.cursor/agents/backend-engineer.md
+++ b/.cursor/agents/backend-engineer.md
@@ -1,0 +1,27 @@
+---
+name: backend-engineer
+description: Backend persona for Twenty CRM that owns server-side work exclusively in packages/twenty-server. Use proactively whenever a task involves adding or changing API behavior, GraphQL resolvers, NestJS services, or server-side data access.
+---
+
+You are a senior backend engineer working on Twenty CRM. You own all server-side work and operate exclusively within `packages/twenty-server`.
+
+When invoked:
+1. Before writing any code, inspect the existing NestJS module, resolver, and service patterns in `packages/twenty-server`. Study how modules are declared, how resolvers are wired, and how services are injected. Follow these patterns exactly — do not invent new conventions.
+2. Implement new functionality as a GraphQL query or mutation on an EXISTING object, plus a backing service method that contains the business logic. Do NOT introduce a new metadata-defined custom object.
+3. Respect dependency injection, existing module boundaries, and the PostgreSQL / BullMQ / Redis conventions already present in the codebase. Reuse existing repositories, providers, and queue/cache patterns rather than creating parallel ones.
+4. Keep changes minimal and consistent: types over interfaces, named exports only, no `any`, and the naming/formatting conventions enforced in this repo.
+
+Before finishing:
+- Run the server typecheck: `npx nx typecheck twenty-server`
+- Run the server unit tests: `npx nx test twenty-server` (or the focused single-file test target for the code you touched)
+- Fix any type errors or test failures you introduce.
+
+Provide a concise summary of:
+- The GraphQL query/mutation and service method added
+- The existing module/object it attaches to
+- The results of typecheck and tests
+
+## Important Notes
+- This persona must ONLY edit files under `packages/twenty-server`.
+- It must NEVER touch `packages/twenty-front` or any other package.
+- These constraints allow this persona to run safely in parallel with other agents.

--- a/.cursor/agents/docs-writer.md
+++ b/.cursor/agents/docs-writer.md
@@ -1,0 +1,22 @@
+---
+name: docs-writer
+description: Documentation persona for Twenty CRM that records new functionality in user-facing docs and the changelog. Use proactively when a task involves documenting a feature, updating the changelog, or writing release notes.
+---
+
+You are a documentation writer for Twenty CRM. You record new functionality in user-facing docs and the changelog.
+
+When invoked:
+1. Summarize what changed from a user's perspective — focus on the capability and how someone uses it, not the internal implementation.
+2. Add a changelog entry in the repo's existing format. Inspect the current changelog/release-notes file first and match its structure, sectioning, and wording style exactly.
+3. Update or add relevant documentation (e.g. under the `packages/twenty-website` docs) following the existing tone, file structure, and front-matter conventions. Reuse existing doc pages where the feature fits rather than creating redundant ones.
+4. Keep entries concise and accurate to the actual code change. Verify claims against the implementation; do not document behavior that does not exist.
+
+Provide a concise summary of:
+- The changelog entry added
+- The docs pages created or updated
+- Any assumptions you made about user-facing behavior
+
+## Important Notes
+- This persona edits ONLY documentation and changelog files (e.g. Markdown/MDX docs, the changelog/release-notes files).
+- It must NEVER modify source code or tests.
+- These constraints allow this persona to run in parallel with the engineering personas.

--- a/.cursor/agents/frontend-engineer.md
+++ b/.cursor/agents/frontend-engineer.md
@@ -1,0 +1,34 @@
+---
+name: frontend-engineer
+description: Frontend persona for Twenty CRM that owns UI work exclusively in packages/twenty-front. Use proactively on tasks involving React components, UI state, or wiring the UI to the GraphQL API.
+model: composer-2.5-fast
+---
+
+You are a senior frontend engineer working on Twenty CRM. You own all UI work and operate exclusively within `packages/twenty-front`.
+
+When invoked:
+
+1. Before writing any code, inspect the existing component, state-management (Jotai/Recoil), and Apollo Client query/mutation patterns in `packages/twenty-front`. Match these patterns exactly — how components are structured, how atoms/selectors are defined, and how hooks wrap GraphQL operations.
+2. Build new UI using the project's existing design-system components and its CSS-in-JS styling conventions (Emotion/Linaria). Do not introduce new styling approaches or ad-hoc component primitives when an existing one fits.
+3. Consume the backend through Apollo Client against the EXISTING GraphQL schema. Reuse generated types and existing query/mutation hooks; regenerate GraphQL types if the schema changed (`npx nx run twenty-front:graphql:generate`).
+4. Internationalize all user-facing strings with Lingui exactly the way the codebase does (e.g. the `t` / `<Trans>` macros). Never hardcode user-visible copy.
+5. Follow repo conventions: functional components only, named exports only, types over interfaces, no `any`, event handlers over `useEffect` for state updates.
+
+Before finishing:
+
+- Run the frontend typecheck: `npx nx typecheck twenty-front`
+- Run the frontend unit tests: `npx nx test twenty-front` (or the focused single-file test target for the code you touched)
+- Fix any type errors or test failures you introduce.
+
+Provide a concise summary of:
+
+- The components/hooks added or changed
+- The GraphQL operations consumed
+- The results of typecheck and tests
+
+## Important Notes
+
+- This persona only edits files under `packages/twenty-front`.
+- It NEVER modifies `packages/twenty-server` or any other package.
+- These constraints allow this persona to run in parallel with other agents.
+

--- a/.cursor/agents/test-engineer.md
+++ b/.cursor/agents/test-engineer.md
@@ -1,0 +1,27 @@
+---
+name: test-engineer
+description: Testing persona for Twenty CRM that adds and strengthens automated tests for newly added functionality. Use proactively when a task is about test coverage, writing unit tests, or verifying new behavior.
+---
+
+You are a test engineer working on Twenty CRM. You add and strengthen automated tests for newly added functionality.
+
+When invoked:
+1. Locate the implementation that needs coverage. Read the source to understand the inputs, outputs, dependencies, and branches that need exercising.
+2. Write tests following the repo's existing Jest conventions and file co-location:
+   - In `packages/twenty-server`: co-located `*.spec.ts` files next to the implementation.
+   - In `packages/twenty-front`: co-located `*.test.tsx` files or tests under `__tests__` directories, using `@testing-library/react` and `@testing-library/user-event`.
+3. Cover the happy path plus the key edge and error cases for the new code. Test behavior from the consumer's perspective, not implementation details. Query by user-visible elements (text, roles, labels) over test IDs on the frontend. Clear mocks between tests with `jest.clearAllMocks()`.
+4. Use descriptive test names: "should [behavior] when [condition]".
+
+Before finishing:
+- Run the relevant test target to confirm tests pass, e.g. `npx jest path/to/test --config=packages/PROJECT/jest.config.mjs`, or `npx nx test twenty-server` / `npx nx test twenty-front`.
+
+Provide a concise summary of:
+- Which files/behaviors you covered
+- The happy-path and edge/error cases tested
+- The test run results
+
+## Important Notes
+- This persona edits ONLY test files (`*.spec.ts`, `*.test.tsx`, files under `__tests__`, and test setup/fixtures).
+- It must NOT change implementation code, so it can run alongside the other personas without conflicts.
+- If a test cannot pass because of an implementation gap or bug, report the gap clearly rather than editing source code to make the test pass.

--- a/.cursor/skills/twenty-local-server/SKILL.md
+++ b/.cursor/skills/twenty-local-server/SKILL.md
@@ -1,0 +1,180 @@
+---
+name: twenty-local-server
+description: Start, stop, restart, and check status of the Twenty CRM local dev stack (Postgres, Redis, Nest API, Vite frontend, Bull worker). Use when the user asks to run Twenty locally, start/stop/restart the dev server, or bring the CRM up or down.
+---
+
+# Twenty Local Server Lifecycle
+
+Manage the full local dev stack: **Postgres**, **Redis**, **API** (`:3000`), **frontend** (default `:3001`), and **worker**.
+
+## Quick commands
+
+From repo root:
+
+```bash
+bash .cursor/skills/twenty-local-server/scripts/twenty-dev.sh start     # infra + yarn start
+bash .cursor/skills/twenty-local-server/scripts/twenty-dev.sh stop      # app + Postgres/Redis
+bash .cursor/skills/twenty-local-server/scripts/twenty-dev.sh restart   # full stop, then infra + app
+bash .cursor/skills/twenty-local-server/scripts/twenty-dev.sh status    # ports + services
+```
+
+Make executable once: `chmod +x .cursor/skills/twenty-local-server/scripts/twenty-dev.sh`
+
+## Command behavior
+
+| Command | What it does |
+|---------|----------------|
+| **start** | Start Docker Postgres/Redis (compose or fallback containers), then `yarn start` |
+| **stop** | Stop API, frontend, worker, **and** Docker infra (`twenty-dev` compose + `twenty-local-*` containers) |
+| **restart** | Full **stop**, then **start** (fresh infra + app) |
+| **status** | Report configured ports and what is up |
+
+`stop-all` is an alias for `stop`.
+
+## Defaults
+
+| Service | URL / port |
+|---------|------------|
+| API | http://localhost:3000 |
+| Frontend | http://localhost:3001 |
+| Health | http://localhost:3000/healthz |
+| Postgres | `localhost:5432` |
+| Redis | `localhost:6379` |
+
+Dev login (after `database:reset` seed): **tim@apple.dev** / **tim@apple.dev** (`SIGN_IN_PREFILLED=true` prefills email).
+
+## First-time setup
+
+Run once before first `start`:
+
+```bash
+yarn install
+bash packages/twenty-utils/setup-dev-env.sh   # Postgres, Redis, .env files
+npx nx build twenty-shared
+npx nx database:reset twenty-server
+```
+
+`setup-dev-env.sh` copies `packages/twenty-server/.env` and `packages/twenty-front/.env` from examples.
+
+## Start
+
+```bash
+bash .cursor/skills/twenty-local-server/scripts/twenty-dev.sh start
+```
+
+Starts supporting infra first, then:
+
+```bash
+yarn start   # server + front via nx; worker after :3000 is up
+```
+
+### Automated shells: `yarn start` hangs on `generateBarrels`
+
+In non-interactive/automated shells, `yarn start` (and any `npx nx start ...`) re-runs the
+`^build` dependency, which gets stuck on `nx run twenty-shared:generateBarrels` and never binds
+`:3000`. This is expected here. When the script's `yarn start` stalls (no `Nest application` /
+`ready in` after ~1–2 min and `generateBarrels` is still running), do **not** wait — stop it,
+prebuild shared/ui once, then launch each service **directly** (bypassing Nx so it can't
+re-trigger the build):
+
+```bash
+# 1. Stop the stalled launcher + infra stays up
+bash .cursor/skills/twenty-local-server/scripts/twenty-dev.sh stop
+docker start twenty-local-pg twenty-local-redis   # keep infra; stop also tore it down
+
+# 2. Prebuild shared + ui (one-off bypass, see generateBarrels section below)
+npx tsx packages/twenty-shared/scripts/generateBarrels.ts
+cd packages/twenty-shared && npx vite build && npx tsgo -p tsconfig.lib.json --declaration --emitDeclarationOnly --noEmit false --outDir dist --rootDir src && cd ../..
+npx tsx packages/twenty-ui/scripts/generateBarrels.ts
+cd packages/twenty-ui && npx vite build && cd ../..
+
+# 3. Start each service directly (run each in its own background shell)
+cd packages/twenty-server && NODE_ENV=development npx nest start --watch                                   # API :3000
+cd packages/twenty-front  && REACT_APP_PORT=3003 npx vite                                                  # frontend (match FRONTEND_URL port)
+cd packages/twenty-server && NODE_ENV=development npx nest start --watch --entryFile queue-worker/queue-worker  # worker
+```
+
+Use the frontend port from `FRONTEND_URL` in `packages/twenty-server/.env` (e.g. `3003`), not the
+`3001` default. Verify with `curl -sf http://localhost:3000/healthz`.
+
+> **Note:** `npx nx start twenty-server` / `npx nx start twenty-front` also depend on `^build` and
+> will hit the same hang in automated shells. Prefer the direct `nest` / `vite` commands above.
+> Avoid double-starting the API — a second `nest start` on a live `:3000` fails with `EADDRINUSE`.
+
+## Stop
+
+Stops **everything** Twenty uses locally (not just the Node processes):
+
+```bash
+bash .cursor/skills/twenty-local-server/scripts/twenty-dev.sh stop
+```
+
+Equivalent infra teardown:
+
+```bash
+bash packages/twenty-utils/setup-dev-env.sh --down
+```
+
+## Restart
+
+Full teardown then cold start (infra + app):
+
+```bash
+bash .cursor/skills/twenty-local-server/scripts/twenty-dev.sh restart
+```
+
+Does not re-run migrations or reseed unless you run `npx nx database:reset twenty-server` separately.
+
+## Port conflicts
+
+If `setup-dev-env.sh` fails with **port 5432 already allocated** (SSH tunnel, local Postgres), use alternate Docker containers and update `packages/twenty-server/.env`:
+
+```env
+PG_DATABASE_URL=postgres://postgres:postgres@localhost:5433/default
+REDIS_URL=redis://localhost:6380
+```
+
+The lifecycle script creates `twenty-local-pg` / `twenty-local-redis` on 5433/6380 when compose cannot bind 5432/6379.
+
+If **3001** is busy (e.g. another app), set frontend port before start:
+
+```bash
+export REACT_APP_PORT=3003
+# and match the API CORS/redirect setting:
+# FRONTEND_URL=http://localhost:3003  (in packages/twenty-server/.env)
+bash .cursor/skills/twenty-local-server/scripts/twenty-dev.sh start
+```
+
+## Verify running
+
+```bash
+bash .cursor/skills/twenty-local-server/scripts/twenty-dev.sh status
+curl -sf http://localhost:3000/healthz
+```
+
+Open the frontend URL from `status` or `FRONTEND_URL` in server `.env`.
+
+## When Nx hangs on `generateBarrels`
+
+Some automated shells hang on `nx run twenty-shared:generateBarrels`. This affects **any** Nx
+target that depends on `^build`, including `nx build`, `yarn start`, and `npx nx start <project>`.
+Bypass for a one-off build:
+
+```bash
+npx tsx packages/twenty-shared/scripts/generateBarrels.ts
+cd packages/twenty-shared && npx vite build && npx tsgo -p tsconfig.lib.json --declaration --emitDeclarationOnly --noEmit false --outDir dist --rootDir src
+npx tsx packages/twenty-ui/scripts/generateBarrels.ts
+cd packages/twenty-ui && npx vite build
+cd packages/twenty-server && npx nest build --path ./tsconfig.build.json
+```
+
+For running the dev stack (not just building), prebuilding alone is not enough — `yarn start`
+re-triggers `generateBarrels` anyway. Use the direct `nest` / `vite` start commands in the
+[Automated shells](#automated-shells-yarn-start-hangs-on-generatebarrels) section instead. Prefer
+`yarn start` in the user's own terminal when Nx is unreliable.
+
+## Reset database (optional)
+
+```bash
+npx nx database:reset twenty-server
+```

--- a/.cursor/skills/twenty-local-server/scripts/twenty-dev.sh
+++ b/.cursor/skills/twenty-local-server/scripts/twenty-dev.sh
@@ -1,0 +1,203 @@
+#!/bin/bash
+# Twenty local dev lifecycle: start | stop | restart | status
+# stop = app + Docker Postgres/Redis; restart = full stop then start
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../../../.." && pwd)"
+COMPOSE_FILE="$REPO_ROOT/packages/twenty-docker/docker-compose.dev.yml"
+SERVER_ENV="$REPO_ROOT/packages/twenty-server/.env"
+
+info() { echo "=> $*"; }
+ok() { echo "   $*"; }
+
+port_from_url() {
+  local url="$1" default_port="$2"
+  if [[ "$url" =~ :([0-9]+)(/|$) ]]; then
+    echo "${BASH_REMATCH[1]}"
+  else
+    echo "$default_port"
+  fi
+}
+
+read_env_ports() {
+  PG_PORT=5432
+  REDIS_PORT=6379
+  API_PORT=3000
+  FRONT_PORT=3001
+  if [[ -f "$SERVER_ENV" ]]; then
+    local pg_url redis_url frontend_url
+    pg_url="$(grep -E '^PG_DATABASE_URL=' "$SERVER_ENV" | cut -d= -f2- || true)"
+    redis_url="$(grep -E '^REDIS_URL=' "$SERVER_ENV" | cut -d= -f2- || true)"
+    frontend_url="$(grep -E '^FRONTEND_URL=' "$SERVER_ENV" | cut -d= -f2- || true)"
+    [[ -n "$pg_url" ]] && PG_PORT="$(port_from_url "$pg_url" 5432)"
+    [[ -n "$redis_url" ]] && REDIS_PORT="$(port_from_url "$redis_url" 6379)"
+    [[ -n "$frontend_url" ]] && FRONT_PORT="$(port_from_url "$frontend_url" 3001)"
+  fi
+}
+
+pids_on_port() {
+  lsof -ti ":$1" 2>/dev/null || true
+}
+
+kill_port() {
+  local port="$1"
+  local pids
+  pids="$(pids_on_port "$port")"
+  if [[ -n "$pids" ]]; then
+    info "Stopping processes on port $port"
+    echo "$pids" | xargs kill 2>/dev/null || true
+    sleep 1
+    pids="$(pids_on_port "$port")"
+    [[ -n "$pids" ]] && echo "$pids" | xargs kill -9 2>/dev/null || true
+  fi
+}
+
+stop_app() {
+  read_env_ports
+  kill_port "$API_PORT"
+  kill_port "$FRONT_PORT"
+  kill_port 3002
+  kill_port 3003
+  pkill -f "nest start --watch" 2>/dev/null || true
+  pkill -f "twenty-server:worker" 2>/dev/null || true
+  pkill -f "nx run-many -t start -p twenty-server twenty-front" 2>/dev/null || true
+  pkill -f "packages/twenty-front.*vite" 2>/dev/null || true
+  ok "App processes stopped"
+}
+
+pg_is_up() {
+  if command -v pg_isready &>/dev/null; then
+    pg_isready -h localhost -p "$PG_PORT" -U postgres -q 2>/dev/null
+  else
+    docker run --rm postgres:16 pg_isready -h host.docker.internal -p "$PG_PORT" -U postgres -q 2>/dev/null
+  fi
+}
+
+redis_is_up() {
+  if command -v redis-cli &>/dev/null; then
+    redis-cli -h localhost -p "$REDIS_PORT" ping 2>/dev/null | grep -q PONG
+  else
+    docker run --rm redis:alpine redis-cli -h host.docker.internal -p "$REDIS_PORT" ping 2>/dev/null | grep -q PONG
+  fi
+}
+
+start_infra_docker_compose() {
+  if docker compose -f "$COMPOSE_FILE" version &>/dev/null 2>&1; then
+    docker compose -f "$COMPOSE_FILE" up -d db redis 2>/dev/null && return 0
+  fi
+  return 1
+}
+
+start_infra_fallback() {
+  if ! docker inspect twenty-local-pg &>/dev/null; then
+    docker run -d --name twenty-local-pg \
+      -e POSTGRES_USER=postgres -e POSTGRES_PASSWORD=postgres -e POSTGRES_DB=default \
+      -p 5433:5432 postgres:16
+    ok "Created twenty-local-pg on port 5433"
+  else
+    docker start twenty-local-pg &>/dev/null || true
+  fi
+  if ! docker inspect twenty-local-redis &>/dev/null; then
+    docker run -d --name twenty-local-redis -p 6380:6379 redis:7 --maxmemory-policy noeviction
+    ok "Created twenty-local-redis on port 6380"
+  else
+    docker start twenty-local-redis &>/dev/null || true
+  fi
+}
+
+start_infra() {
+  read_env_ports
+  if pg_is_up && redis_is_up; then
+    ok "Postgres ($PG_PORT) and Redis ($REDIS_PORT) already running"
+    return
+  fi
+  info "Starting Postgres + Redis..."
+  if start_infra_docker_compose; then
+    sleep 3
+  fi
+  if ! pg_is_up || ! redis_is_up; then
+    info "Compose failed or ports busy — using fallback containers (5433/6380)"
+    start_infra_fallback
+    sleep 3
+  fi
+  if ! pg_is_up || ! redis_is_up; then
+    echo "FAIL: Postgres/Redis not reachable. Run: bash packages/twenty-utils/setup-dev-env.sh" >&2
+    exit 1
+  fi
+  ok "Postgres ($PG_PORT) and Redis ($REDIS_PORT) ready"
+}
+
+stop_infra() {
+  info "Stopping Postgres + Redis (Docker)..."
+  docker compose -f "$COMPOSE_FILE" down 2>/dev/null || true
+  docker stop twenty-local-pg twenty-local-redis 2>/dev/null || true
+  ok "Infra stopped"
+}
+
+stop_all() {
+  stop_app
+  stop_infra
+}
+
+status() {
+  read_env_ports
+  echo "Ports (from packages/twenty-server/.env when present):"
+  echo "  API:      $API_PORT"
+  echo "  Frontend: $FRONT_PORT"
+  echo "  Postgres: $PG_PORT"
+  echo "  Redis:    $REDIS_PORT"
+  echo ""
+  for port in "$API_PORT" "$FRONT_PORT" 3002 3003; do
+    if pids="$(pids_on_port "$port")"; [[ -n "$pids" ]]; then
+      ok "Port $port: running (pid $pids)"
+    else
+      echo "   Port $port: free"
+    fi
+  done
+  if pg_is_up; then ok "Postgres: up"; else echo "   Postgres: down"; fi
+  if redis_is_up; then ok "Redis: up"; else echo "   Redis: down"; fi
+}
+
+start_app() {
+  cd "$REPO_ROOT"
+  if [[ ! -d node_modules ]]; then
+    info "Installing dependencies..."
+    yarn install
+  fi
+  if [[ ! -f packages/twenty-server/.env ]]; then
+    info "Creating .env files..."
+    npx nx reset:env twenty-server
+    npx nx reset:env twenty-front
+  fi
+  if pids="$(pids_on_port "$API_PORT")"; [[ -n "$pids" ]]; then
+    echo "FAIL: API port $API_PORT already in use. Run: $0 stop" >&2
+    exit 1
+  fi
+  info "Starting yarn start (server + frontend + worker)..."
+  export REACT_APP_PORT="${REACT_APP_PORT:-$FRONT_PORT}"
+  exec yarn start
+}
+
+cmd="${1:-}"
+case "$cmd" in
+  start)
+    start_infra
+    start_app
+    ;;
+  stop | stop-all)
+    stop_all
+    ;;
+  restart)
+    stop_all
+    start_infra
+    start_app
+    ;;
+  status)
+    status
+    ;;
+  *)
+    echo "Usage: $0 {start|stop|restart|status}" >&2
+    exit 1
+    ;;
+esac

--- a/.cursor/skills/twenty-release-notes/SKILL.md
+++ b/.cursor/skills/twenty-release-notes/SKILL.md
@@ -1,0 +1,109 @@
+---
+name: twenty-release-notes
+description: Encodes Twenty's release-note and commit convention — conventional-commit prefixes (feat/fix/chore/refactor/docs/perf) with a package-area scope (server, front, auth, ai, sdk...), and assembles release notes grouped by twenty-server vs twenty-front. Use when writing a commit/PR title for Twenty, drafting release notes or a developer changelog from merged commits, or grouping changes by package.
+---
+
+# Twenty Release-Note Convention
+
+Twenty uses Conventional Commits with a package-area scope, and developer release notes are grouped by package (twenty-server vs twenty-front, plus shared/other). This skill covers two tasks: writing a conforming commit/PR title, and assembling grouped release notes from commit history.
+
+For the user-facing marketing changelog (the `.mdx` files on the website), use the `changelog-process` rule instead — that is a different, image-driven artifact.
+
+## Commit / PR title format
+
+```
+type(scope): short imperative summary (#PR_NUMBER)
+```
+
+- `type` — required, lowercase. See types below.
+- `(scope)` — optional but strongly preferred; the package area (see scopes below).
+- summary — imperative mood, lowercase start, no trailing period.
+- `(#PR_NUMBER)` — appended automatically on squash-merge; include it in release notes, not when authoring.
+
+Examples (real):
+
+```
+feat(server): opt-in FRONT_AUTO_BASE_URL for hostname-relative API URL
+fix(front): ignore IME composition Enter in input hotkeys
+fix(ai): route xAI search through Responses API as native tools
+chore(deps): bump typescript from 5.9.2 to 5.9.3
+refactor(twenty-orm): migrate 23 grandfathered entities to WorkspaceScopedRepository
+```
+
+## Types
+
+Ordered by how common they are in this repo:
+
+| Type | Use for |
+|------|---------|
+| `fix` | Bug fixes |
+| `feat` | New user-facing or API capability |
+| `chore` | Deps bumps, catalog syncs, version bumps, housekeeping |
+| `refactor` | Internal restructuring, no behavior change |
+| `docs` | Documentation only |
+| `perf` | Performance improvements |
+| `ci` | CI/workflow/pipeline changes |
+| `revert` | Reverting a prior commit |
+| `test` | Test-only changes |
+
+Use `chore(deps)` / `chore(deps-dev)` for dependency bumps and `chore(security)` for CVE bumps.
+
+## Scopes
+
+Scope is the package area, not the literal package folder. Prefer the short form (`server`, `front`) over the package name (`twenty-server`, `twenty-front`) — both appear, short form is more common. Use a feature/module scope when it is more specific and meaningful (e.g. `auth`, `messaging`, `dashboards`).
+
+Common scopes in use: `server`, `front`, `auth`, `ai`, `ai-billing`, `sdk`, `messaging`, `upgrade`, `twenty-orm`, `filters`, `page-layout`, `settings`, `dashboards`, `sso`, `role`, `rest-api`, `localization`, `contact-creation`, `secret-encryption`, `website`, `docker`, `ci`, `deps`, `deps-dev`, `security`, `shared`, `docs`, `self-host`.
+
+When unsure, omit the scope (`fix: ...`) rather than invent one — bare-type commits are accepted.
+
+## Release-note grouping
+
+Developer release notes group entries by package. Map each commit's scope to a group:
+
+| Group | Scopes |
+|-------|--------|
+| **twenty-server** | `server`, `twenty-server`, `auth`, `sso`, `ai`, `ai-billing`, `ai-chat`, `messaging`, `upgrade`, `secret-encryption`, `twenty-orm`, `rest-api`, `role`, `data-model`, `contact-creation`, `email` |
+| **twenty-front** | `front`, `twenty-front`, `settings`, `dashboards`, `filters`, `page-layout`, `navigation`, `navigation-drawer`, `address`, `localization`, `front-component-renderer`, `command-menu` |
+| **Shared / Other** | `shared`, `sdk`, `website`, `docs`, `self-host`, `docker`, `ci`, `deps`, `deps-dev`, `security`, `preview-env`, and anything unmapped |
+
+Within each group, sort by type in this order: `feat`, then `fix`, then `refactor`/`perf`, then `chore`/`docs`/`ci`.
+
+## Generating grouped release notes
+
+1. Collect commits in the range (between two tags, or since the last release):
+
+```bash
+git log v2.8.0..v2.9.0 --pretty=format:'%s' --no-merges
+# or since a date:
+git log --since="2 weeks ago" --pretty=format:'%s' --no-merges
+```
+
+2. Parse each subject as `type(scope): summary (#PR)`. Keep the `(#PR)` reference.
+3. Assign to a group via the scope mapping above. Commits without a recognizable scope go to **Shared / Other** unless their summary clearly belongs to a package.
+4. Drop noise from developer release notes: `chore(deps)` bumps, `i18n - translations` commits, and pure `ci`/internal `chore` entries — or fold them into a single "Maintenance" line.
+
+## Output template
+
+```markdown
+## {VERSION}
+
+### twenty-server
+- feat(auth): resume workspace selection on /welcome with valid tokenPair cookie (#20575)
+- fix(server): map PermissionsException to proper HTTP status on REST API (#20739)
+
+### twenty-front
+- feat(settings): move email handles and emailing domains to dedicated Email page (#21008)
+- fix(front): ignore IME composition Enter in input hotkeys (#20958)
+
+### Shared / Other
+- chore(deps): dependency bumps and catalog syncs
+- docs(sdk): document DatabaseEventPayload and simplify its type (#20754)
+```
+
+## Handling non-conforming commits
+
+A meaningful share of history does not follow the convention (e.g. `Fix latency spike on application lookup (#21042)`, `[Website] i18n module ...`, `Ses outbound followup`). When assembling notes:
+
+- Do not rewrite history. Reclassify in the notes only.
+- Infer type from the leading verb (`Fix` → fix, `Add` → feat) and infer the group from the summary's subject area.
+- If a commit cannot be confidently placed, list it under **Shared / Other**.

--- a/.github/workflows/self-heal.yml
+++ b/.github/workflows/self-heal.yml
@@ -1,0 +1,116 @@
+name: CI + Self-Heal
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+permissions:
+  contents: write          # push the autoheal/* branch
+  pull-requests: write     # open the draft PR / comment on the original PR
+  issues: write            # file flaky-test issues
+
+concurrency:               # don't pile up runs on rapid pushes to the same PR
+  group: ci-self-heal-${{ github.head_ref }}
+  cancel-in-progress: true
+
+jobs:
+  # ─── CI. No toolchain needed: Node 22 ships its own test runner. ───
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+      - name: Run tests
+        shell: bash
+        run: |
+          set -o pipefail                                   # so tee can't mask a failure
+          node --test selfheal-demo/ 2>&1 | tee failed.log
+      - name: Save failure log for the healer
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: failed-log
+          path: failed.log
+          retention-days: 1
+
+  # ─── Wakes ONLY when `test` failed. This is the self-healing loop. ───
+  heal:
+    needs: test
+    if: >
+      failure() &&
+      !startsWith(github.head_ref, 'autoheal/') &&
+      github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.AUTOHEAL_PAT }}   # so the agent's fix PR re-triggers this workflow
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+      - name: Get the failure log from the test job
+        uses: actions/download-artifact@v4
+        with:
+          name: failed-log
+      - name: Install the Cursor CLI
+        run: curl https://cursor.com/install -fsSL | bash
+      - name: Diagnose and heal
+        shell: bash
+        env:
+          CURSOR_API_KEY: ${{ secrets.CURSOR_API_KEY }}
+          GH_TOKEN: ${{ secrets.AUTOHEAL_PAT }}
+          HEAD_BRANCH: ${{ github.head_ref }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          INSTRUCTION: |
+            You are a CI self-healing agent. A CI run has just failed. Diagnose the
+            failure, decide whether it is a real regression or a flaky test, and respond
+            appropriately. Never weaken the test suite to make a failure go away.
+
+            1. READ THE FAILURE
+               Open the file ./failed.log and identify the failing test and the error.
+
+            2. REPRODUCE
+               Run the failing test the same way CI does (the command is in the context
+               below). Run it 2-3 times to see whether the failure is consistent.
+
+            3. BRANCH ON THE RESULT
+               If it passes on retry or is intermittent -> FLAKY:
+                 - Quarantine only that test using the project's skip convention, with a
+                   TODO comment linking the issue you file.
+                 - File a GitHub issue titled "Flaky test: <name>" containing the relevant
+                   log excerpt, and apply a flaky-test label.
+                 - Open a DRAFT pull request containing ONLY the quarantine change, with
+                   head branch autoheal/<slug> and base set to the source branch. Do not
+                   attempt a code fix.
+
+               If it reproduces deterministically -> REAL FAILURE:
+                 - Find the root cause in the SOURCE code, not in the test.
+                 - Make the minimal source change that fixes it. Do NOT edit, skip, or
+                   weaken the failing test to make it pass.
+                 - Re-run the failing test until it is green.
+                 - Open a DRAFT pull request with head branch autoheal/<slug>, base set to
+                   the source branch, and title "fix: auto-heal <short summary>".
+
+            4. ALWAYS
+               - The PR or issue body must include: the failing test, your root-cause
+                 diagnosis, exactly what you changed, and the commands you ran to verify.
+               - Leave the PR as a DRAFT. Never merge it. Never push directly to the source
+                 branch. Never force-push.
+               - Touch only what the task requires.
+
+            5. IF YOU CANNOT CONFIDENTLY DIAGNOSE OR FIX
+               Do not guess. Post your diagnosis and the relevant log excerpt as a comment
+               on the original PR (its number is in the context below) and stop.
+        run: |
+          cursor-agent -p --force --output-format text \
+            "$INSTRUCTION
+
+          ---
+          Context for this run:
+          - The failing CI logs are in ./failed.log
+          - Reproduce the failing test with: node --test selfheal-demo/
+          - Source branch: $HEAD_BRANCH
+          - Original PR number: $PR_NUMBER"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,69 @@
+# Twenty CRM — Agent Notes
+
+See `CLAUDE.md` and `.cursor/rules/` for day-to-day development commands (lint, test, Nx targets, database operations).
+
+## Cursor Cloud specific instructions
+
+### Node.js version
+
+The repo requires **Node `^24.5.0`** (`package.json` `engines`). Cloud VMs may ship `/exec-daemon/node` at v22, which wins on `PATH` unless overridden.
+
+- Install/use Node 24 via nvm, then prepend it on `PATH` before any `yarn` / `npx` command (this environment adds that to `~/.bashrc`).
+- Verify with `node -v` → `v24.x`.
+
+### Infrastructure (Postgres + Redis)
+
+First-time (or after `--reset`) setup from repo root:
+
+```bash
+bash packages/twenty-utils/setup-dev-env.sh --docker
+```
+
+- Requires **Docker** with access to `unix:///var/run/docker.sock` (if you see permission errors, `sudo chmod 666 /var/run/docker.sock` or add the user to the `docker` group).
+- Compose file: `packages/twenty-docker/docker-compose.dev.yml` (Postgres **5432**, Redis **6379**, user/password `postgres` / `postgres`, DB `default`).
+- Copies `packages/twenty-front/.env.example` → `.env` and `packages/twenty-server/.env.example` → `.env`.
+
+### Database seed (first run / clean DB)
+
+After infra is up and dependencies installed:
+
+```bash
+npx nx build twenty-shared
+npx nx run twenty-server:database:reset
+```
+
+`database:reset` depends on a **built** `twenty-server` (`dist/`) and **`twenty-emails`** (`dist/index.js`). If `nx run twenty-server:database:reset` appears to hang with no output for many minutes, build dependencies manually (see `CLAUDE.md` / `packages/twenty-server/project.json`) or run the truncate/init/migrate/seed steps via `node dist/...` in `packages/twenty-server`.
+
+### Running the CRM stack
+
+| Service | Port | Start |
+|--------|------|--------|
+| **twenty-server** (API) | 3000 | `npx nx start twenty-server` or `yarn start` |
+| **twenty-front** (UI) | 3001 | `npx nx start twenty-front` or `yarn start` |
+| **Worker** (BullMQ) | — | `npx nx run twenty-server:worker` (included in `yarn start` after `:3000` is up) |
+
+- **`yarn start`** runs server + front + worker (good default for full-stack work).
+- Health check: `curl http://localhost:3000/healthz`
+- Dev sign-in: open `http://localhost:3001`, **Continue with Email**, prefilled **`tim@apple.dev` / `tim@apple.dev`** when `SIGN_IN_PREFILLED=true` in `packages/twenty-server/.env` (seeded “Apple” workspace).
+
+Use **tmux** for long-running dev servers in Cloud Agent VMs.
+
+### Nx / build gotchas
+
+- Some `nx run …` invocations can stall for a long time with little output in this environment; `NX_DAEMON=false` helps for read-only commands like `nx show project`.
+- `twenty-shared` / `twenty-emails` / `twenty-ui` builds are pulled in automatically when using `yarn start` (`dependsOn: ["^build"]`).
+- `twenty-server` lint depends on `twenty-oxlint-rules:build` (`dist/oxlint-plugin.mjs`); build with the `esbuild` command in `packages/twenty-oxlint-rules/project.json` if Nx build is slow.
+
+### Lint and test (quick smoke)
+
+Standard commands are in `CLAUDE.md`. Examples:
+
+```bash
+npx nx lint:diff-with-main twenty-front
+npx nx lint:diff-with-main twenty-server
+cd packages/twenty-shared && npx jest src/utils/validation/__tests__/isDefined.test.ts --config jest.config.mjs
+```
+
+### `.cursor/environment.json`
+
+This repo’s Cloud snapshot may run `yarn install`, `setup-dev-env.sh`, and `database:reset` on environment start. The **update script** only refreshes Yarn dependencies; it does not start Docker or the app (see sections above).

--- a/selfheal-demo/add.test.mjs
+++ b/selfheal-demo/add.test.mjs
@@ -1,0 +1,25 @@
+// selfheal-demo/add.test.mjs
+//
+// Tiny self-contained fixture for the Self-Heal CI demo.
+// It uses Node's built-in test runner (`node --test`), so CI needs ZERO installs:
+// no package.json, no yarn, no Nx — just Node 22.
+//
+// The function below has a deliberate bug; the test catches it. The self-healing
+// agent should fix the FUNCTION (not the test) and open a draft PR.
+//
+// To demo the FLAKY path instead, add a second *.test.mjs file here whose result
+// depends on timing or Math.random() — the agent will quarantine it rather than "fix" it.
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+// ── code under test ──
+export function add(a, b) {
+  return a - b; // BUG: should be a + b
+}
+
+// ── test ──
+test("add() returns the sum of two numbers", () => {
+  assert.equal(add(2, 3), 5);
+  assert.equal(add(-1, 1), 0);
+});


### PR DESCRIPTION
## Summary
- Adds specialized Cursor agent personas for backend, frontend, docs, and test work so future tasks can be delegated with clear package boundaries and verification expectations.
- Adds Cursor skills for managing the local Twenty dev stack and following Twenty's commit/release-note conventions.
- Adds a GitHub Actions self-heal demo workflow that runs a minimal Node test fixture, captures failures, and invokes `cursor-agent` to diagnose failures, open draft fix PRs, or quarantine flaky tests.

## Test plan
- Not run locally: `selfheal-demo/add.test.mjs` intentionally contains a failing implementation so the self-heal workflow has a deterministic failure to diagnose.
- Verified the branch diff is clean and contains one commit on top of `main`.

## Notes
- The workflow expects `CURSOR_API_KEY` and `AUTOHEAL_PAT` repository secrets.
- The demo fixture is intentionally isolated from the main Nx/Yarn test stack and uses Node's built-in test runner.

Made with [Cursor](https://cursor.com)