### PR TITLE
fix: block self-impersonation in admin panel

### DIFF
--- a/packages/twenty-front/src/modules/auth/hooks/useAuth.ts
+++ b/packages/twenty-front/src/modules/auth/hooks/useAuth.ts
@@ -272,6 +272,7 @@ export const useAuth = () => {
           handleSetLoginToken(loginToken);
           navigate(AppPath.SignInUp);
           setSignInUpStep(SignInUpStep.TwoFactorAuthenticationProvision);
+          return;
         }
 
         if (
@@ -283,7 +284,9 @@ export const useAuth = () => {
           handleSetLoginToken(loginToken);
           navigate(AppPath.SignInUp);
           setSignInUpStep(SignInUpStep.TwoFactorAuthenticationVerification);
+          return;
         }
+        throw error;
       }
     },
     [

--- a/packages/twenty-front/src/modules/auth/hooks/useImpersonationSession.ts
+++ b/packages/twenty-front/src/modules/auth/hooks/useImpersonationSession.ts
@@ -1,5 +1,5 @@
-import { useCallback } from 'react';
 import { useStore } from 'jotai';
+import { useCallback } from 'react';
 
 import { useAuth } from '@/auth/hooks/useAuth';
 import { tokenPairState } from '@/auth/states/tokenPairState';
@@ -42,9 +42,9 @@ export const useImpersonationSession = () => {
 
       try {
         await getAuthTokensFromLoginToken(loginToken);
-      } catch {
+      } catch (error) {
         sessionStorage.removeItem(IMPERSONATION_SESSION_KEY);
-        throw new Error('Failed to start impersonation session');
+        throw error;
       }
 
       reloadWithSession(targetPath);

--- a/packages/twenty-front/src/modules/auth/hooks/useImpersonationSession.ts
+++ b/packages/twenty-front/src/modules/auth/hooks/useImpersonationSession.ts
@@ -40,7 +40,13 @@ export const useImpersonationSession = () => {
         );
       }
 
-      await getAuthTokensFromLoginToken(loginToken);
+      try {
+        await getAuthTokensFromLoginToken(loginToken);
+      } catch {
+        sessionStorage.removeItem(IMPERSONATION_SESSION_KEY);
+        throw new Error('Failed to start impersonation session');
+      }
+
       reloadWithSession(targetPath);
     },
     [store, getAuthTokensFromLoginToken],

--- a/packages/twenty-front/src/modules/settings/admin-panel/hooks/useHandleImpersonate.ts
+++ b/packages/twenty-front/src/modules/settings/admin-panel/hooks/useHandleImpersonate.ts
@@ -1,10 +1,13 @@
 import { useState } from 'react';
 
 import { useMutation } from '@apollo/client/react';
+import { t } from '@lingui/core/macro';
 import { AppPath } from 'twenty-shared/types';
+import { isDefined } from 'twenty-shared/utils';
 
-import { currentWorkspaceState } from '@/auth/states/currentWorkspaceState';
 import { useImpersonationSession } from '@/auth/hooks/useImpersonationSession';
+import { currentUserState } from '@/auth/states/currentUserState';
+import { currentWorkspaceState } from '@/auth/states/currentWorkspaceState';
 import { useRedirectToWorkspaceDomain } from '@/domain-manager/hooks/useRedirectToWorkspaceDomain';
 import { useSnackBar } from '@/ui/feedback/snack-bar-manager/hooks/useSnackBar';
 import { useAtomStateValue } from '@/ui/utilities/state/jotai/hooks/useAtomStateValue';
@@ -12,6 +15,7 @@ import { ImpersonateDocument } from '~/generated-metadata/graphql';
 import { getWorkspaceUrl } from '~/utils/getWorkspaceUrl';
 
 export const useHandleImpersonate = () => {
+  const currentUser = useAtomStateValue(currentUserState);
   const currentWorkspace = useAtomStateValue(currentWorkspaceState);
   const { enqueueErrorSnackBar } = useSnackBar();
   const { startImpersonating } = useImpersonationSession();
@@ -22,6 +26,14 @@ export const useHandleImpersonate = () => {
   );
 
   const handleImpersonate = async (userId: string, workspaceId: string) => {
+    if (!isDefined(currentUser?.id) || userId === currentUser.id) {
+      enqueueErrorSnackBar({
+        message: t`You cannot impersonate your own account`,
+      });
+
+      return;
+    }
+
     setImpersonatingUserId(userId);
 
     await impersonate({
@@ -31,7 +43,13 @@ export const useHandleImpersonate = () => {
         const isCurrentWorkspace = workspace.id === currentWorkspace?.id;
 
         if (isCurrentWorkspace) {
-          await startImpersonating(loginToken.token);
+          try {
+            await startImpersonating(loginToken.token);
+          } catch {
+            enqueueErrorSnackBar({
+              message: t`Failed to impersonate user`,
+            });
+          }
 
           return;
         }

--- a/packages/twenty-front/src/modules/settings/admin-panel/hooks/useHandleImpersonate.ts
+++ b/packages/twenty-front/src/modules/settings/admin-panel/hooks/useHandleImpersonate.ts
@@ -43,13 +43,7 @@ export const useHandleImpersonate = () => {
         const isCurrentWorkspace = workspace.id === currentWorkspace?.id;
 
         if (isCurrentWorkspace) {
-          try {
-            await startImpersonating(loginToken.token);
-          } catch {
-            enqueueErrorSnackBar({
-              message: t`Failed to impersonate user`,
-            });
-          }
+          await startImpersonating(loginToken.token);
 
           return;
         }

--- a/packages/twenty-front/src/pages/settings/admin-panel/SettingsAdminUserDetail.tsx
+++ b/packages/twenty-front/src/pages/settings/admin-panel/SettingsAdminUserDetail.tsx
@@ -166,7 +166,8 @@ export const SettingsAdminUserDetail = () => {
               />
               {currentUser?.canImpersonate &&
                 activeWorkspace &&
-                isDefined(user) && (
+                isDefined(user) &&
+                user.id !== currentUser.id && (
                   <StyledButtonContainer>
                     <Button
                       Icon={IconEyeShare}

--- a/packages/twenty-front/src/pages/settings/admin-panel/SettingsAdminWorkspaceDetail.tsx
+++ b/packages/twenty-front/src/pages/settings/admin-panel/SettingsAdminWorkspaceDetail.tsx
@@ -285,20 +285,22 @@ export const SettingsAdminWorkspaceDetail = () => {
                       </TableCell>
                       <TableCell>{user.email}</TableCell>
                       <TableCell align="right">
-                        {workspace.allowImpersonation && (
-                          <Button
-                            Icon={IconEyeShare}
-                            variant="secondary"
-                            size="small"
-                            title={t`Impersonate`}
-                            onClick={(e) => {
-                              e.preventDefault();
-                              e.stopPropagation();
-                              handleImpersonate(userId, workspaceId!);
-                            }}
-                            disabled={impersonatingUserId === userId}
-                          />
-                        )}
+                        {workspace.allowImpersonation &&
+                          isDefined(currentUser?.id) &&
+                          userId !== currentUser.id && (
+                            <Button
+                              Icon={IconEyeShare}
+                              variant="secondary"
+                              size="small"
+                              title={t`Impersonate`}
+                              onClick={(e) => {
+                                e.preventDefault();
+                                e.stopPropagation();
+                                handleImpersonate(userId, workspaceId!);
+                              }}
+                              disabled={impersonatingUserId === userId}
+                            />
+                          )}
                       </TableCell>
                     </TableRow>
                   );

--- a/packages/twenty-front/src/pages/settings/members/SettingsWorkspaceMember.tsx
+++ b/packages/twenty-front/src/pages/settings/members/SettingsWorkspaceMember.tsx
@@ -1,9 +1,8 @@
 import { useParams } from 'react-router-dom';
 import { useDebouncedCallback } from 'use-debounce';
 
-import { CoreObjectNameSingular, SettingsPath } from 'twenty-shared/types';
-import { useFindOneRecord } from '@/object-record/hooks/useFindOneRecord';
 import { useImpersonationSession } from '@/auth/hooks/useImpersonationSession';
+import { useFindOneRecord } from '@/object-record/hooks/useFindOneRecord';
 import { SettingsPageContainer } from '@/settings/components/SettingsPageContainer';
 import { SettingsRolesQueryEffect } from '@/settings/roles/components/SettingsRolesQueryEffect';
 import { useHasPermissionFlag } from '@/settings/roles/hooks/useHasPermissionFlag';
@@ -14,8 +13,9 @@ import { SubMenuTopBarContainer } from '@/ui/layout/page/components/SubMenuTopBa
 import { TabList } from '@/ui/layout/tab-list/components/TabList';
 import { activeTabIdComponentState } from '@/ui/layout/tab-list/states/activeTabIdComponentState';
 import { useAtomComponentStateValue } from '@/ui/utilities/state/jotai/hooks/useAtomComponentStateValue';
-import { t } from '@lingui/core/macro';
 import { useAtomStateValue } from '@/ui/utilities/state/jotai/hooks/useAtomStateValue';
+import { t } from '@lingui/core/macro';
+import { CoreObjectNameSingular, SettingsPath } from 'twenty-shared/types';
 import { getSettingsPath, isDefined } from 'twenty-shared/utils';
 import { IconInfoCircle, IconLockOpen } from 'twenty-ui/display';
 import { useNavigateSettings } from '~/hooks/useNavigateSettings';
@@ -30,9 +30,9 @@ import { useWorkspaceMemberRoles } from '@/settings/members/hooks/useWorkspaceMe
 import { type WorkspaceMember } from '@/workspace-member/types/WorkspaceMember';
 import { useMutation } from '@apollo/client/react';
 import {
-  PermissionFlagType,
   DeleteUserWorkspaceDocument,
   ImpersonateDocument,
+  PermissionFlagType,
 } from '~/generated-metadata/graphql';
 
 const SETTINGS_WORKSPACE_MEMBER_TABS = {
@@ -145,10 +145,7 @@ export const SettingsWorkspaceMember = () => {
       return;
     }
 
-    if (
-      !isDefined(currentUser?.id) ||
-      member.userId === currentUser.id
-    ) {
+    if (!isDefined(currentUser?.id) || member.userId === currentUser.id) {
       enqueueErrorSnackBar({
         message: t`You cannot impersonate your own account`,
         options: { duration: 2000 },
@@ -165,14 +162,7 @@ export const SettingsWorkspaceMember = () => {
       onCompleted: async (data) => {
         const { loginToken } = data.impersonate;
 
-        try {
-          await startImpersonating(loginToken.token);
-        } catch {
-          enqueueErrorSnackBar({
-            message: t`Cannot impersonate selected user`,
-            options: { duration: 2000 },
-          });
-        }
+        await startImpersonating(loginToken.token);
       },
       onError: () => {
         enqueueErrorSnackBar({

--- a/packages/twenty-front/src/pages/settings/members/SettingsWorkspaceMember.tsx
+++ b/packages/twenty-front/src/pages/settings/members/SettingsWorkspaceMember.tsx
@@ -16,10 +16,11 @@ import { activeTabIdComponentState } from '@/ui/layout/tab-list/states/activeTab
 import { useAtomComponentStateValue } from '@/ui/utilities/state/jotai/hooks/useAtomComponentStateValue';
 import { t } from '@lingui/core/macro';
 import { useAtomStateValue } from '@/ui/utilities/state/jotai/hooks/useAtomStateValue';
-import { getSettingsPath } from 'twenty-shared/utils';
+import { getSettingsPath, isDefined } from 'twenty-shared/utils';
 import { IconInfoCircle, IconLockOpen } from 'twenty-ui/display';
 import { useNavigateSettings } from '~/hooks/useNavigateSettings';
 
+import { currentUserState } from '@/auth/states/currentUserState';
 import { currentWorkspaceState } from '@/auth/states/currentWorkspaceState';
 import { isImpersonatingState } from '@/auth/states/isImpersonatingState';
 import { useUpdateOneRecord } from '@/object-record/hooks/useUpdateOneRecord';
@@ -49,6 +50,7 @@ export const SettingsWorkspaceMember = () => {
   const navigateSettings = useNavigateSettings();
   const { enqueueErrorSnackBar, enqueueSuccessSnackBar } = useSnackBar();
   const { openModal, closeModal } = useModal();
+  const currentUser = useAtomStateValue(currentUserState);
   const currentWorkspace = useAtomStateValue(currentWorkspaceState);
   const { startImpersonating } = useImpersonationSession();
   const [impersonate] = useMutation(ImpersonateDocument);
@@ -143,6 +145,18 @@ export const SettingsWorkspaceMember = () => {
       return;
     }
 
+    if (
+      !isDefined(currentUser?.id) ||
+      member.userId === currentUser.id
+    ) {
+      enqueueErrorSnackBar({
+        message: t`You cannot impersonate your own account`,
+        options: { duration: 2000 },
+      });
+
+      return;
+    }
+
     await impersonate({
       variables: {
         userId: member.userId,
@@ -150,7 +164,15 @@ export const SettingsWorkspaceMember = () => {
       },
       onCompleted: async (data) => {
         const { loginToken } = data.impersonate;
-        await startImpersonating(loginToken.token);
+
+        try {
+          await startImpersonating(loginToken.token);
+        } catch {
+          enqueueErrorSnackBar({
+            message: t`Cannot impersonate selected user`,
+            options: { duration: 2000 },
+          });
+        }
       },
       onError: () => {
         enqueueErrorSnackBar({
@@ -203,7 +225,14 @@ export const SettingsWorkspaceMember = () => {
             {activeTabId === SETTINGS_WORKSPACE_MEMBER_TABS.TABS_IDS.INFOS && (
               <MemberInfosTab
                 member={member}
-                onImpersonate={canImpersonate ? handleImpersonate : undefined}
+                onImpersonate={
+                  canImpersonate &&
+                  isDefined(member.userId) &&
+                  isDefined(currentUser?.id) &&
+                  member.userId !== currentUser.id
+                    ? handleImpersonate
+                    : undefined
+                }
                 onNameChange={debouncedUpdateName}
                 onDelete={() => openModal(DELETE_MEMBER_MODAL_ID)}
               />

--- a/packages/twenty-server/src/engine/core-modules/auth/auth.resolver.ts
+++ b/packages/twenty-server/src/engine/core-modules/auth/auth.resolver.ts
@@ -704,6 +704,15 @@ export class AuthResolver {
       );
     }
 
+    if (
+      impersonatorUserWorkspace.userId === toImpersonateUserWorkspace.userId
+    ) {
+      throw new AuthException(
+        'User cannot impersonate themselves',
+        AuthExceptionCode.FORBIDDEN_EXCEPTION,
+      );
+    }
+
     const isServerLevelImpersonation =
       toImpersonateUserWorkspace.workspace.id !==
       impersonatorUserWorkspace.workspace.id;

--- a/packages/twenty-server/src/engine/core-modules/impersonation/__tests__/impersonation.service.spec.ts
+++ b/packages/twenty-server/src/engine/core-modules/impersonation/__tests__/impersonation.service.spec.ts
@@ -297,6 +297,43 @@ describe('ImpersonationService', () => {
     );
   });
 
+  it('should throw an error when impersonating the same user', async () => {
+    const sameUserWorkspace = {
+      id: 'same-user-workspace-id',
+      userId: 'same-user-id',
+      workspaceId: 'workspace-id',
+      user: {
+        id: 'same-user-id',
+        email: 'same@example.com',
+        canImpersonate: true,
+        canAccessFullAdminPanel: false,
+      },
+      workspace: {
+        id: 'workspace-id',
+        allowImpersonation: true,
+      },
+      twoFactorAuthenticationMethods: [],
+    };
+
+    UserWorkspaceFindOneMock.mockResolvedValueOnce(sameUserWorkspace);
+    UserWorkspaceFindOneMock.mockResolvedValueOnce(sameUserWorkspace);
+
+    await expect(
+      service.impersonate(
+        'same-user-id',
+        'workspace-id',
+        'same-user-workspace-id',
+      ),
+    ).rejects.toThrow(
+      new AuthException(
+        'User cannot impersonate themselves',
+        AuthExceptionCode.FORBIDDEN_EXCEPTION,
+      ),
+    );
+
+    expect(LoginTokenServiceGenerateLoginTokenMock).not.toHaveBeenCalled();
+  });
+
   it('should throw an error when impersonation is not enabled for the workspace', async () => {
     const mockToImpersonateUserWorkspace = {
       userId: 'target-user-id',

--- a/packages/twenty-server/src/engine/core-modules/impersonation/services/impersonation.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/impersonation/services/impersonation.service.ts
@@ -63,6 +63,15 @@ export class ImpersonationService {
       );
     }
 
+    if (
+      toImpersonateUserWorkspace.userId === impersonatorUserWorkspace.userId
+    ) {
+      throw new AuthException(
+        'User cannot impersonate themselves',
+        AuthExceptionCode.FORBIDDEN_EXCEPTION,
+      );
+    }
+
     const isServerLevelImpersonation =
       toImpersonateUserWorkspace.workspace.id !==
       impersonatorUserWorkspace.workspace.id;


### PR DESCRIPTION
## Issue
- From Settings -> Admin Panel -> Workspace -> Members, impersonating the currently logged-in user still issued an impersonation login token. Token exchange produced invalid impersonation JWTs (`impersonatorUserWorkspaceId === impersonatedUserWorkspaceId`). JWT validation then failed with `User cannot impersonate themselves`, leaving the app in an endless loading state until cookies were cleared.
- Closes #21086

### Before:
<img width="830" height="413" alt="Screenshot 2026-06-02 122224" src="https://github.com/user-attachments/assets/46f38a74-8bd6-4ffa-b749-500ce18314f1" />

### After:
<img width="795" height="369" alt="Screenshot 2026-06-02 122333" src="https://github.com/user-attachments/assets/62ece4a8-d38b-4f91-817f-792ff49b146b" />