### PR TITLE
fix(ai-chat) - fix breaking cache because of signed files

### DIFF
--- a/packages/twenty-server/src/engine/metadata-modules/ai/ai-chat/services/agent-chat-streaming.service.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/ai/ai-chat/services/agent-chat-streaming.service.ts
@@ -113,6 +113,7 @@ export class AgentChatStreamingService {
       threadId,
       userWorkspaceId,
       workspace.id,
+      savedUserMessage.id,
     );
 
     const streamId = generateId();
@@ -209,7 +210,12 @@ export class AgentChatStreamingService {
     });
 
     const [uiMessages, thread] = await Promise.all([
-      this.loadMessagesFromDB(threadId, userWorkspaceId, workspaceId),
+      this.loadMessagesFromDB(
+        threadId,
+        userWorkspaceId,
+        workspaceId,
+        nextQueued.id,
+      ),
       this.threadRepository.findOneByOrFail({ id: threadId }),
     ]);
 
@@ -248,6 +254,7 @@ export class AgentChatStreamingService {
     threadId: string,
     userWorkspaceId: string,
     workspaceId: string,
+    currentMessageId: string,
   ) {
     const allMessages = await this.agentChatService.getMessagesForThread(
       threadId,
@@ -264,9 +271,13 @@ export class AgentChatStreamingService {
         role: message.role as 'user' | 'assistant' | 'system',
         parts: await Promise.all(
           mapDBPartsToUIMessageParts(message.parts ?? []).map(async (part) => {
-            if (isExtendedFileUIPart(part as Record<string, unknown>)) {
-              const filePart = part as ExtendedFileUIPart;
+            if (!isExtendedFileUIPart(part as Record<string, unknown>)) {
+              return part;
+            }
 
+            const filePart = part as ExtendedFileUIPart;
+
+            if (message.id === currentMessageId) {
               return {
                 ...filePart,
                 url: await this.fileUrlService.signFileByIdUrl({
@@ -277,7 +288,10 @@ export class AgentChatStreamingService {
               } as ExtendedFileUIPart;
             }
 
-            return part;
+            return {
+              type: 'text' as const,
+              text: `[attached: ${filePart.filename || filePart.fileId}]`,
+            };
           }),
         ),
         createdAt: message.createdAt,


### PR DESCRIPTION
Each message that contains a file attachment gets a different URL on each new turn. 
The AI SDK passes these URLs into the model messages, so from the model's perspective every previous file-containing message has changed → no cache hit is possible for any conversation containing file attachments, regardless of how many turns ago the file was shared.