### PR TITLE
refactor(server): merge duplicate `TypeOrmModule.forFeature` calls in `MessagingMessageCleanerModule`

### DIFF
--- a/packages/twenty-server/src/modules/messaging/message-cleaner/messaging-message-cleaner.module.ts
+++ b/packages/twenty-server/src/modules/messaging/message-cleaner/messaging-message-cleaner.module.ts
@@ -17,10 +17,9 @@ import { MessagingMessageCleanerService } from 'src/modules/messaging/message-cl
 
 @Module({
   imports: [
-    TypeOrmModule.forFeature([WorkspaceEntity]),
+    TypeOrmModule.forFeature([WorkspaceEntity, MessageChannelEntity]),
     FeatureFlagModule,
     MessagingCommonModule,
-    TypeOrmModule.forFeature([MessageChannelEntity]),
     WorkspaceIteratorModule,
   ],
   providers: [


### PR DESCRIPTION
Combined two separate `TypeOrmModule.forFeature()` calls into one. Both registered entities on the default data source, so no behavioral change.  Repositories for WorkspaceEntity and MessageChannelEntity remain injectable as before.
Cleaner imports, one less redundant call.