### PR TITLE
fix: hide the Favorites collapse toggle when there are no favorites

### DIFF
--- a/packages/twenty-front/src/modules/navigation-menu-item/display/sections/components/NavigationMenuItemSection.tsx
+++ b/packages/twenty-front/src/modules/navigation-menu-item/display/sections/components/NavigationMenuItemSection.tsx
@@ -9,6 +9,7 @@ type NavigationMenuItemSectionProps = {
   title: string;
   isOpen: boolean;
   onToggle: () => void;
+  isToggleable?: boolean;
   rightIcon?: ReactNode;
   alwaysShowRightIcon?: boolean;
   forceExpanded?: boolean;
@@ -20,6 +21,7 @@ export const NavigationMenuItemSection = ({
   title,
   isOpen,
   onToggle,
+  isToggleable = true,
   rightIcon,
   alwaysShowRightIcon,
   forceExpanded = false,
@@ -28,7 +30,7 @@ export const NavigationMenuItemSection = ({
 }: NavigationMenuItemSectionProps) => {
   const content = (
     <AnimatedExpandableContainer
-      isExpanded={isOpen || forceExpanded}
+      isExpanded={(isToggleable && isOpen) || forceExpanded}
       dimension="height"
       mode="fit-content"
       containAnimation
@@ -43,10 +45,10 @@ export const NavigationMenuItemSection = ({
       <NavigationDrawerAnimatedCollapseWrapper>
         <NavigationDrawerSectionTitle
           label={title}
-          onClick={onToggle}
+          onClick={isToggleable ? onToggle : undefined}
           rightIcon={rightIcon}
           alwaysShowRightIcon={alwaysShowRightIcon}
-          isOpen={isOpen}
+          isOpen={isToggleable ? isOpen : undefined}
         />
       </NavigationDrawerAnimatedCollapseWrapper>
       {contentWrapper ? contentWrapper(content) : content}

--- a/packages/twenty-front/src/modules/navigation-menu-item/display/sections/favorites/components/FavoritesSection.tsx
+++ b/packages/twenty-front/src/modules/navigation-menu-item/display/sections/favorites/components/FavoritesSection.tsx
@@ -123,6 +123,7 @@ export const FavoritesSection = () => {
     <NavigationMenuItemSection
       title={t`Favorites`}
       isOpen={topLevelItems.length > 0 && isNavigationSectionOpen}
+      isToggleable={topLevelItems.length > 0}
       onToggle={toggleNavigationSection}
       rightIcon={
         <LightIconButton


### PR DESCRIPTION
## What

The Favorites navigation section always renders now, but when it's empty the collapse chevron (and click-to-toggle on the title) still appeared on hover — there's nothing to expand. This hides the toggle until there's at least one favorite.

| | |
|---|---|
| **Before** | empty "Favorites" shows a `>` toggle on hover |
| **After** | no toggle when empty; it returns once you add a favorite |

## How

`NavigationDrawerSectionTitle` already hides its chevron when `isOpen === undefined`. Added an `isToggleable` prop to `NavigationMenuItemSection` (default `true`, so every other section — Workspace, folders, page layouts — is unchanged): when `false`, the title gets `isOpen={undefined}` (no chevron) and `onClick={undefined}` (not click-to-toggle), and the content stays collapsed.

`FavoritesSection` passes `isToggleable={topLevelItems.length > 0}`. The `+` add button is untouched and still available to add the first favorite.