### PR TITLE
fix(twenty-server): fix AI tools description for SELECT view filter values

### DIFF
--- a/packages/twenty-server/src/engine/metadata-modules/view-filter/tools/view-filter-tools.factory.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/view-filter/tools/view-filter-tools.factory.ts
@@ -42,7 +42,7 @@ const CreateViewFilterInputSchema = z.object({
       z.record(z.string(), z.unknown()),
     ])
     .describe(
-      'Filter value. Format depends on operand and field type: string for TEXT/SELECT, number for NUMBER/CURRENCY, array of option values for MULTI_SELECT IS/IS_NOT, empty string "" for IS_EMPTY/IS_NOT_EMPTY operators.',
+      'Filter value. Format depends on operand and field type: string for TEXT, array of option values for SELECT/MULTI_SELECT (e.g. ["OPTION_1", "OPTION_2"]), number for NUMBER/CURRENCY, empty string "" for IS_EMPTY/IS_NOT_EMPTY operators.',
     ),
   subFieldName: z
     .string()
@@ -75,7 +75,9 @@ const UpdateViewFilterInputSchema = z.object({
       z.record(z.string(), z.unknown()),
     ])
     .optional()
-    .describe('New filter value'),
+    .describe(
+      'New filter value. Use array of option values for SELECT/MULTI_SELECT (e.g. ["OPTION_1"]).',
+    ),
   subFieldName: z
     .string()
     .optional()


### PR DESCRIPTION
Fixes https://github.com/twentyhq/twenty/issues/20840

## Summary
- Fix the AI tools factory (`view-filter-tools.factory.ts`) description that incorrectly described SELECT filter values as plain strings, causing agents to write values like `"CLOSED_LOST"` instead of the required array format `["CLOSED_LOST"]`

This led to production crashes when later trying to update/delete select options on fields that had view filters created by AI agents with invalid format.

## Test plan
- No behavior change in existing code — only the tool description is updated to guide AI agents correctly
- Manual: confirm AI agents now create SELECT filters with array values