### PR TITLE
fix: workspace root redirect to use last visited object

### DIFF
--- a/packages/twenty-front/src/modules/navigation/hooks/__tests__/useDefaultHomePagePath.test.ts
+++ b/packages/twenty-front/src/modules/navigation/hooks/__tests__/useDefaultHomePagePath.test.ts
@@ -2,9 +2,10 @@ import { currentUserState } from '@/auth/states/currentUserState';
 import { currentUserWorkspaceState } from '@/auth/states/currentUserWorkspaceState';
 import { metadataStoreState } from '@/metadata-store/states/metadataStoreState';
 import { useDefaultHomePagePath } from '@/navigation/hooks/useDefaultHomePagePath';
+import { lastVisitedObjectMetadataItemIdState } from '@/navigation/states/lastVisitedObjectMetadataItemIdState';
 import { AggregateOperations } from '@/object-record/record-table/constants/AggregateOperations';
 import { useSetAtomState } from '@/ui/utilities/state/jotai/hooks/useSetAtomState';
-import { jotaiStore } from '@/ui/utilities/state/jotai/jotaiStore';
+import { jotaiStore, resetJotaiStore } from '@/ui/utilities/state/jotai/jotaiStore';
 import { renderHook, waitFor } from '@testing-library/react';
 import { Provider as JotaiProvider } from 'jotai';
 import { createElement, useEffect, type ReactNode } from 'react';
@@ -98,6 +99,11 @@ const renderHooks = ({
 };
 
 describe('useDefaultHomePagePath', () => {
+  beforeEach(() => {
+    jotaiStore.set(lastVisitedObjectMetadataItemIdState.atom, null);
+    localStorage.removeItem(lastVisitedObjectMetadataItemIdState.key);
+  });
+
   it('should return proper path when no currentUser', async () => {
     const { result } = renderHooks({
       withCurrentUser: false,
@@ -152,6 +158,43 @@ describe('useDefaultHomePagePath', () => {
 
     await waitFor(() => {
       expect(result.current.defaultHomePagePath).toEqual(AppPath.Index);
+    });
+  });
+
+  it('should return last visited object path when lastVisitedObjectMetadataItemId is set', async () => {
+    const personObjectMetadataItem = getMockObjectMetadataItemOrThrow('person');
+
+    jotaiStore.set(
+      lastVisitedObjectMetadataItemIdState.atom,
+      personObjectMetadataItem.id,
+    );
+
+    const { result } = renderHooks({
+      withCurrentUser: true,
+      withExistingView: false,
+    });
+
+    await waitFor(() => {
+      expect(result.current.defaultHomePagePath).toEqual('/objects/people');
+    });
+  });
+
+  it('should hydrate last visited object path from localStorage on init', async () => {
+    const personObjectMetadataItem = getMockObjectMetadataItemOrThrow('person');
+
+    resetJotaiStore();
+    localStorage.setItem(
+      lastVisitedObjectMetadataItemIdState.key,
+      JSON.stringify(personObjectMetadataItem.id),
+    );
+
+    const { result } = renderHooks({
+      withCurrentUser: true,
+      withExistingView: false,
+    });
+
+    await waitFor(() => {
+      expect(result.current.defaultHomePagePath).toEqual('/objects/people');
     });
   });
 });

--- a/packages/twenty-front/src/modules/navigation/hooks/useDefaultHomePagePath.ts
+++ b/packages/twenty-front/src/modules/navigation/hooks/useDefaultHomePagePath.ts
@@ -12,11 +12,12 @@ import isEmpty from 'lodash.isempty';
 import { useCallback, useMemo } from 'react';
 import { AppPath, SettingsPath } from 'twenty-shared/types';
 import { getAppPath, getSettingsPath, isDefined } from 'twenty-shared/utils';
-import { useStore } from 'jotai';
 
 export const useDefaultHomePagePath = () => {
-  const store = useStore();
   const currentUser = useAtomStateValue(currentUserState);
+  const lastVisitedObjectMetadataItemId = useAtomStateValue(
+    lastVisitedObjectMetadataItemIdState,
+  );
   const { objectPermissionsByObjectMetadataId } = useObjectPermissions();
   const metadataStore = useAtomFamilyStateValue(
     metadataStoreState,
@@ -69,11 +70,7 @@ export const useDefaultHomePagePath = () => {
     return { objectMetadataItem: firstObjectMetadataItem, view };
   }, [getFirstView, readableNonSystemObjectMetadataItems]);
 
-  const getDefaultObjectPathInfo = useCallback(() => {
-    const lastVisitedObjectMetadataItemId = store.get(
-      lastVisitedObjectMetadataItemIdState.atom,
-    );
-
+  const defaultObjectPathInfo = useMemo<ObjectPathInfo | null>(() => {
     const lastVisitedObjectMetadataItem = isDefined(
       lastVisitedObjectMetadataItemId,
     )
@@ -92,7 +89,7 @@ export const useDefaultHomePagePath = () => {
     firstObjectPathInfo,
     getActiveObjectMetadataItemMatchingId,
     getFirstView,
-    store,
+    lastVisitedObjectMetadataItemId,
   ]);
 
   const defaultHomePagePath = useMemo(() => {
@@ -113,8 +110,6 @@ export const useDefaultHomePagePath = () => {
       return getSettingsPath(SettingsPath.ProfilePage);
     }
 
-    const defaultObjectPathInfo = getDefaultObjectPathInfo();
-
     if (!isDefined(defaultObjectPathInfo)) {
       return AppPath.NotFound;
     }
@@ -129,7 +124,7 @@ export const useDefaultHomePagePath = () => {
     );
   }, [
     currentUser,
-    getDefaultObjectPathInfo,
+    defaultObjectPathInfo,
     readableNonSystemObjectMetadataItems,
     areObjectMetadataItemsLoaded,
   ]);

--- a/packages/twenty-front/src/modules/ui/utilities/state/jotai/utils/createAtomState.ts
+++ b/packages/twenty-front/src/modules/ui/utilities/state/jotai/utils/createAtomState.ts
@@ -63,7 +63,7 @@ export const createAtomState = <ValueType>({
       key,
       defaultValue,
       undefined,
-      localStorageOptions ?? undefined,
+      { getOnInit: true, ...localStorageOptions },
     ) as StateAtom<ValueType>;
   } else {
     baseAtom = atom(defaultValue);


### PR DESCRIPTION
## Summary
- Fixes #21166
- Visiting `/` always redirected to the alphabetically first object (e.g. Activities / Companies) instead of the last visited object.
- So the solution is: Reading last visited object from `localStorage` on page load and react when it changes, so `/` sends us back to the object we were on instead of always picking the first one alphabetically.

## Testing
- Open People (`/objects/people`), navigate to `/` -> lands on People, not the first object alphabetically
- Hard refresh on `/` after visiting another object -> still redirects to last visited
- Fresh workspace with no last visited -> still falls back to first readable non-system object (alphabetical)
- Unit tests

## Screencast
### Before:
https://github.com/user-attachments/assets/c3e0f125-fad1-4aca-abab-9995aeea2f13

### After:
https://github.com/user-attachments/assets/6d2f6b02-332d-4e4e-9f7c-6d4b489301ae