### PR TITLE
fix: update yarn.lock after removing dotenv and zod from twenty-sdk

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -34151,7 +34151,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"dotenv@npm:^16.0.0, dotenv@npm:^16.0.3, dotenv@npm:^16.3.0, dotenv@npm:^16.4.0, dotenv@npm:^16.4.5, dotenv@npm:^16.5.0":
+"dotenv@npm:^16.0.0, dotenv@npm:^16.0.3, dotenv@npm:^16.3.0, dotenv@npm:^16.4.5, dotenv@npm:^16.5.0":
   version: 16.6.1
   resolution: "dotenv@npm:16.6.1"
   checksum: 10c0/15ce56608326ea0d1d9414a5c8ee6dcf0fffc79d2c16422b4ac2268e7e2d76ff5a572d37ffe747c377de12005f14b3cc22361e79fc7f1061cce81f77d2c973dc
@@ -57040,7 +57040,6 @@ __metadata:
     chalk: "npm:^5.3.0"
     chokidar: "npm:^4.0.0"
     commander: "npm:^12.0.0"
-    dotenv: "npm:^16.4.0"
     esbuild: "npm:^0.25.0"
     graphql: "npm:^16.8.1"
     graphql-sse: "npm:^2.5.4"
@@ -57065,7 +57064,6 @@ __metadata:
     vite-plugin-dts: "npm:^4.5.4"
     vite-tsconfig-paths: "npm:^4.2.1"
     wait-on: "npm:^7.2.0"
-    zod: "npm:^4.1.11"
   bin:
     twenty: dist/cli.cjs
   languageName: unknown


### PR DESCRIPTION
## Summary

- Commit b330105470 removed `dotenv` and `zod` from `packages/twenty-sdk/package.json` dependencies but did not run `yarn install`, leaving the lockfile out of sync.
- `yarn install --immutable` in CI was failing with `YN0028: The lockfile would have been modified by this install` on those two packages.
- This PR just runs `yarn install` to sync the lockfile — no logic changes.

## Root cause

[Failing CI run](https://github.com/twentyhq/twenty-infra/actions/runs/26883193920/job/79288298420):
```
YN0028: -    dotenv: "npm:^16.4.0"
YN0028: -    zod: "npm:^4.1.11"
YN0028: The lockfile would have been modified by this install, which is explicitly forbidden.
```

## Changes

`yarn.lock` only — removes the `dotenv@^16.4.0` range and the `twenty-sdk` metadata entries for `dotenv` and `zod`.