### PR TITLE
refactor(server): extract metadata schema builder from components.utils.ts

### DIFF
--- a/packages/twenty-server/src/engine/core-modules/open-api/utils/components.utils.ts
+++ b/packages/twenty-server/src/engine/core-modules/open-api/utils/components.utils.ts
@@ -7,6 +7,10 @@ import { capitalize, isDefined } from 'twenty-shared/utils';
 
 import { RelationType } from 'src/engine/metadata-modules/field-metadata/interfaces/relation-type.interface';
 
+import {
+  computeMetadataSchemaForEntity,
+  type MetadataSchemaConfig,
+} from 'src/engine/core-modules/open-api/utils/compute-metadata-schema-for-entity.util';
 import { generateRandomFieldValue } from 'src/engine/core-modules/open-api/utils/generate-random-field-value.util';
 import {
   computeAggregateParameters,
@@ -313,1017 +317,493 @@ export const computeParameterComponents = (
   };
 };
 
+const FIELD_OPTIONS_PROPERTY: OpenAPIV3_1.SchemaObject = {
+  type: 'array',
+  description: 'For enum field types like SELECT or MULTI_SELECT',
+  items: {
+    type: 'object',
+    properties: {
+      color: { type: 'string' },
+      label: { type: 'string' },
+      value: {
+        type: 'string',
+        pattern: '^[A-Z0-9]+_[A-Z0-9]+$',
+        example: 'OPTION_1',
+      },
+      position: { type: 'number' },
+    },
+  },
+};
+
+const METADATA_ENTITY_SCHEMA_CONFIGS: Record<
+  string,
+  Omit<MetadataSchemaConfig, 'nameSingular' | 'namePlural'>
+> = {
+  object: {
+    description: 'An object',
+    properties: {
+      nameSingular: { type: 'string' },
+      namePlural: { type: 'string' },
+      labelSingular: { type: 'string' },
+      labelPlural: { type: 'string' },
+      description: { type: 'string' },
+      icon: { type: 'string' },
+      labelIdentifierFieldMetadataId: { type: 'string', format: 'uuid' },
+      imageIdentifierFieldMetadataId: { type: 'string', format: 'uuid' },
+    },
+    updateDescription: 'An object',
+    updateProperties: {
+      isActive: { type: 'boolean' },
+    },
+    responseExtraProperties: {
+      dataSourceId: { type: 'string', format: 'uuid' },
+      isCustom: { type: 'boolean' },
+      isActive: { type: 'boolean' },
+      isSystem: { type: 'boolean' },
+    },
+    responseCommonProperties: {
+      createdAt: { type: 'string', format: 'date-time' },
+      updatedAt: { type: 'string', format: 'date-time' },
+      fields: {
+        type: 'array',
+        items: {
+          $ref: '#/components/schemas/FieldForResponse',
+        },
+      },
+    },
+  },
+  field: {
+    description: 'A field',
+    properties: {
+      type: {
+        type: 'string',
+        enum: Object.keys(FieldMetadataType),
+      },
+      objectMetadataId: { type: 'string', format: 'uuid' },
+      name: { type: 'string' },
+      label: { type: 'string' },
+      description: { type: 'string' },
+      icon: { type: 'string' },
+      defaultValue: {},
+      isNullable: { type: 'boolean' },
+      settings: { type: 'object' },
+      options: FIELD_OPTIONS_PROPERTY,
+    },
+    requiredFields: ['type', 'name', 'label', 'objectMetadataId'],
+    updateDescription: 'A field',
+    updateProperties: {
+      name: { type: 'string' },
+      label: { type: 'string' },
+      description: { type: 'string' },
+      icon: { type: 'string' },
+      defaultValue: {},
+      isNullable: { type: 'boolean' },
+      settings: { type: 'object' },
+      options: FIELD_OPTIONS_PROPERTY,
+    },
+    responseExtraProperties: {
+      isCustom: { type: 'boolean' },
+      isActive: { type: 'boolean' },
+      isSystem: { type: 'boolean' },
+    },
+    responseCommonProperties: {
+      createdAt: { type: 'string', format: 'date-time' },
+      updatedAt: { type: 'string', format: 'date-time' },
+    },
+  },
+  webhook: {
+    description: 'A webhook',
+    properties: {
+      targetUrl: { type: 'string' },
+      operations: {
+        type: 'array',
+        items: { type: 'string' },
+        default: ['*.*'],
+      },
+      description: { type: 'string' },
+      secret: { type: 'string' },
+    },
+    requiredFields: ['targetUrl'],
+    updateProperties: {
+      targetUrl: { type: 'string' },
+      operations: {
+        type: 'array',
+        items: { type: 'string' },
+        default: [],
+      },
+      description: { type: 'string' },
+      secret: { type: 'string' },
+    },
+  },
+  apiKey: {
+    description: 'An API key',
+    properties: {
+      name: { type: 'string' },
+      expiresAt: { type: 'string', format: 'date-time' },
+      roleId: { type: 'string', format: 'uuid' },
+    },
+    requiredFields: ['name', 'expiresAt', 'roleId'],
+    updateProperties: {
+      name: { type: 'string' },
+      expiresAt: { type: 'string', format: 'date-time' },
+      revokedAt: {
+        type: 'string',
+        format: 'date-time',
+        description:
+          'Set to null to clear revocation. Defaults to null if not provided.',
+      },
+    },
+    responseExtraProperties: {
+      revokedAt: { type: 'string', format: 'date-time' },
+    },
+    responseCommonProperties: {
+      workspaceId: { type: 'string', format: 'uuid' },
+      createdAt: { type: 'string', format: 'date-time' },
+      updatedAt: { type: 'string', format: 'date-time' },
+    },
+  },
+  view: {
+    description: 'A view',
+    properties: {
+      name: { type: 'string' },
+      objectMetadataId: { type: 'string', format: 'uuid' },
+      type: {
+        type: 'string',
+        enum: ['TABLE', 'KANBAN'],
+        default: 'TABLE',
+      },
+      key: { type: 'string', default: 'INDEX' },
+      icon: { type: 'string' },
+      position: { type: 'number', default: 0 },
+      isCompact: { type: 'boolean', default: false },
+      openRecordIn: {
+        type: 'string',
+        enum: ['SIDE_PANEL', 'RECORD_PAGE'],
+        default: 'SIDE_PANEL',
+      },
+      kanbanAggregateOperation: {
+        type: 'string',
+        enum: ['AVG', 'COUNT', 'MAX', 'MIN', 'SUM'],
+      },
+      kanbanAggregateOperationFieldMetadataId: {
+        type: 'string',
+        format: 'uuid',
+      },
+      anyFieldFilterValue: { type: 'string' },
+    },
+    requiredFields: ['name', 'objectMetadataId', 'icon'],
+    updateProperties: {
+      name: { type: 'string' },
+      type: {
+        type: 'string',
+        enum: ['TABLE', 'KANBAN'],
+      },
+      key: { type: 'string' },
+      icon: { type: 'string' },
+      position: { type: 'number' },
+      isCompact: { type: 'boolean' },
+      openRecordIn: {
+        type: 'string',
+        enum: ['SIDE_PANEL', 'RECORD_PAGE'],
+      },
+      kanbanAggregateOperation: {
+        type: 'string',
+        enum: ['AVG', 'COUNT', 'MAX', 'MIN', 'SUM'],
+      },
+      kanbanAggregateOperationFieldMetadataId: {
+        type: 'string',
+        format: 'uuid',
+      },
+      anyFieldFilterValue: { type: 'string' },
+    },
+  },
+  viewField: {
+    description: 'A view field',
+    properties: {
+      fieldMetadataId: { type: 'string', format: 'uuid' },
+      viewId: { type: 'string', format: 'uuid' },
+      isVisible: { type: 'boolean', default: true },
+      size: { type: 'number', default: 0 },
+      position: { type: 'number', default: 0 },
+      aggregateOperation: {
+        type: 'string',
+        enum: ['AVG', 'COUNT', 'MAX', 'MIN', 'SUM'],
+      },
+    },
+    requiredFields: ['fieldMetadataId', 'viewId'],
+    updateProperties: {
+      isVisible: { type: 'boolean' },
+      size: { type: 'number' },
+      position: { type: 'number' },
+      aggregateOperation: {
+        type: 'string',
+        enum: ['AVG', 'COUNT', 'MAX', 'MIN', 'SUM'],
+      },
+    },
+  },
+  viewFilter: {
+    description: 'A view filter',
+    properties: {
+      fieldMetadataId: { type: 'string', format: 'uuid' },
+      viewId: { type: 'string', format: 'uuid' },
+      operand: {
+        type: 'string',
+        enum: [
+          'IS',
+          'IS_NOT_NULL',
+          'IS_NOT',
+          'LESS_THAN_OR_EQUAL',
+          'GREATER_THAN_OR_EQUAL',
+          'IS_BEFORE',
+          'IS_AFTER',
+          'CONTAINS',
+          'DOES_NOT_CONTAIN',
+          'IS_EMPTY',
+          'IS_NOT_EMPTY',
+          'IS_RELATIVE',
+          'IS_IN_PAST',
+          'IS_IN_FUTURE',
+          'IS_TODAY',
+          'VECTOR_SEARCH',
+        ],
+        default: 'CONTAINS',
+      },
+      value: {
+        type: 'object',
+        description: 'Filter value (JSON format)',
+      },
+      viewFilterGroupId: { type: 'string', format: 'uuid' },
+      positionInViewFilterGroup: { type: 'number' },
+      subFieldName: { type: 'string' },
+    },
+    requiredFields: ['fieldMetadataId', 'viewId', 'value'],
+    updateProperties: {
+      operand: {
+        type: 'string',
+        enum: [
+          'IS',
+          'IS_NOT_NULL',
+          'IS_NOT',
+          'LESS_THAN_OR_EQUAL',
+          'GREATER_THAN_OR_EQUAL',
+          'IS_BEFORE',
+          'IS_AFTER',
+          'CONTAINS',
+          'DOES_NOT_CONTAIN',
+          'IS_EMPTY',
+          'IS_NOT_EMPTY',
+          'IS_RELATIVE',
+          'IS_IN_PAST',
+          'IS_IN_FUTURE',
+          'IS_TODAY',
+          'VECTOR_SEARCH',
+        ],
+      },
+      value: {
+        type: 'object',
+        description: 'Filter value (JSON format)',
+      },
+      viewFilterGroupId: { type: 'string', format: 'uuid' },
+      positionInViewFilterGroup: { type: 'number' },
+      subFieldName: { type: 'string' },
+    },
+  },
+  viewSort: {
+    description: 'A view sort',
+    properties: {
+      fieldMetadataId: { type: 'string', format: 'uuid' },
+      viewId: { type: 'string', format: 'uuid' },
+      direction: {
+        type: 'string',
+        enum: ['ASC', 'DESC'],
+        default: 'ASC',
+      },
+    },
+    requiredFields: ['fieldMetadataId', 'viewId'],
+    updateProperties: {
+      direction: {
+        type: 'string',
+        enum: ['ASC', 'DESC'],
+      },
+    },
+  },
+  viewGroup: {
+    description: 'A view group',
+    properties: {
+      fieldMetadataId: { type: 'string', format: 'uuid' },
+      viewId: { type: 'string', format: 'uuid' },
+      fieldValue: { type: 'string' },
+      isVisible: { type: 'boolean', default: true },
+      position: { type: 'number', default: 0 },
+    },
+    requiredFields: ['fieldMetadataId', 'viewId', 'fieldValue'],
+    updateProperties: {
+      fieldValue: { type: 'string' },
+      isVisible: { type: 'boolean' },
+      position: { type: 'number' },
+    },
+  },
+  viewFilterGroup: {
+    description: 'A view filter group',
+    properties: {
+      viewId: { type: 'string', format: 'uuid' },
+      parentViewFilterGroupId: { type: 'string', format: 'uuid' },
+      logicalOperator: {
+        type: 'string',
+        enum: ['AND', 'OR', 'NOT'],
+        default: 'AND',
+      },
+      positionInViewFilterGroup: { type: 'number' },
+    },
+    requiredFields: ['viewId'],
+    updateProperties: {
+      parentViewFilterGroupId: { type: 'string', format: 'uuid' },
+      logicalOperator: {
+        type: 'string',
+        enum: ['AND', 'OR', 'NOT'],
+      },
+      positionInViewFilterGroup: { type: 'number' },
+    },
+  },
+  pageLayout: {
+    description: 'A page layout',
+    properties: {
+      name: { type: 'string' },
+      type: {
+        type: 'string',
+        enum: [
+          'RECORD_INDEX',
+          'RECORD_PAGE',
+          'DASHBOARD',
+          'STANDALONE_PAGE',
+        ],
+        default: 'RECORD_PAGE',
+      },
+      objectMetadataId: { type: 'string', format: 'uuid' },
+    },
+    requiredFields: ['name'],
+    updateProperties: {
+      name: { type: 'string' },
+      type: {
+        type: 'string',
+        enum: [
+          'RECORD_INDEX',
+          'RECORD_PAGE',
+          'DASHBOARD',
+          'STANDALONE_PAGE',
+        ],
+      },
+      objectMetadataId: { type: 'string', format: 'uuid' },
+    },
+    responseExtraProperties: {
+      tabs: {
+        type: 'array',
+        items: {
+          $ref: '#/components/schemas/PageLayoutTabForResponse',
+        },
+      },
+    },
+  },
+  pageLayoutTab: {
+    description: 'A page layout tab',
+    properties: {
+      title: { type: 'string' },
+      position: { type: 'number', default: 0 },
+      pageLayoutId: { type: 'string', format: 'uuid' },
+    },
+    requiredFields: ['title', 'pageLayoutId'],
+    updateProperties: {
+      title: { type: 'string' },
+      position: { type: 'number' },
+    },
+  },
+  pageLayoutWidget: {
+    description: 'A page layout widget',
+    properties: {
+      pageLayoutTabId: { type: 'string', format: 'uuid' },
+      title: { type: 'string' },
+      type: {
+        type: 'string',
+        enum: [
+          'VIEW',
+          'IFRAME',
+          'FIELDS',
+          'GRAPH',
+          'TIMELINE',
+          'TASKS',
+          'NOTES',
+          'FILES',
+          'EMAILS',
+          'CALENDAR',
+        ],
+        default: 'VIEW',
+      },
+      objectMetadataId: { type: 'string', format: 'uuid' },
+      gridPosition: {
+        $ref: '#/components/schemas/GridPosition',
+      },
+      configuration: {
+        type: 'object',
+        description: 'Widget-specific configuration',
+      },
+    },
+    requiredFields: ['pageLayoutTabId', 'title', 'gridPosition'],
+    updateProperties: {
+      title: { type: 'string' },
+      type: {
+        type: 'string',
+        enum: ['VIEW', 'IFRAME', 'FIELDS', 'GRAPH'],
+      },
+      objectMetadataId: { type: 'string', format: 'uuid' },
+      gridPosition: {
+        $ref: '#/components/schemas/GridPosition',
+      },
+      configuration: {
+        type: 'object',
+        description: 'Widget-specific configuration',
+      },
+    },
+    responseExtraProperties: {
+      type: {
+        type: 'string',
+        enum: ['VIEW', 'IFRAME', 'FIELDS', 'GRAPH'],
+      },
+    },
+    extraSchemas: {
+      GridPosition: {
+        type: 'object',
+        description: 'Grid position for widget placement',
+        properties: {
+          row: { type: 'number', minimum: 0 },
+          column: { type: 'number', minimum: 0 },
+          rowSpan: { type: 'number', minimum: 1 },
+          columnSpan: { type: 'number', minimum: 1 },
+        },
+        required: ['row', 'column', 'rowSpan', 'columnSpan'],
+      },
+    },
+  },
+};
+
 export const computeMetadataSchemaComponents = (
   metadataSchema: { nameSingular: string; namePlural: string }[],
 ): Record<string, OpenAPIV3_1.SchemaObject> => {
   return metadataSchema.reduce(
     (schemas, item) => {
-      switch (item.nameSingular) {
-        case 'object': {
-          schemas[`${capitalize(item.nameSingular)}`] = {
-            type: 'object',
-            description: `An object`,
-            properties: {
-              nameSingular: { type: 'string' },
-              namePlural: { type: 'string' },
-              labelSingular: { type: 'string' },
-              labelPlural: { type: 'string' },
-              description: { type: 'string' },
-              icon: { type: 'string' },
-              labelIdentifierFieldMetadataId: {
-                type: 'string',
-                format: 'uuid',
-              },
-              imageIdentifierFieldMetadataId: {
-                type: 'string',
-                format: 'uuid',
-              },
-            },
-          };
-          schemas[`${capitalize(item.namePlural)}`] = {
-            type: 'array',
-            description: `A list of ${item.namePlural}`,
-            items: {
-              $ref: `#/components/schemas/${capitalize(item.nameSingular)}`,
-            },
-          };
-          schemas[`${capitalize(item.nameSingular)}ForUpdate`] = {
-            type: 'object',
-            description: `An object`,
-            properties: {
-              isActive: { type: 'boolean' },
-            },
-          };
-          schemas[`${capitalize(item.nameSingular)}ForResponse`] = {
-            ...schemas[`${capitalize(item.nameSingular)}`],
-            properties: {
-              ...schemas[`${capitalize(item.nameSingular)}`].properties,
-              id: { type: 'string', format: 'uuid' },
-              dataSourceId: { type: 'string', format: 'uuid' },
-              isCustom: { type: 'boolean' },
-              isActive: { type: 'boolean' },
-              isSystem: { type: 'boolean' },
-              createdAt: { type: 'string', format: 'date-time' },
-              updatedAt: { type: 'string', format: 'date-time' },
-              fields: {
-                type: 'array',
-                items: {
-                  $ref: '#/components/schemas/FieldForResponse',
-                },
-              },
-            },
-          };
-          schemas[`${capitalize(item.namePlural)}ForResponse`] = {
-            type: 'array',
-            description: `A list of ${item.namePlural}`,
-            items: {
-              $ref: `#/components/schemas/${capitalize(item.nameSingular)}ForResponse`,
-            },
-          };
+      const entityConfig =
+        METADATA_ENTITY_SCHEMA_CONFIGS[item.nameSingular];
 
-          return schemas;
-        }
-        case 'field': {
-          const baseFieldProperties = ({
-            withImmutableFields,
-            withRequiredFields,
-          }: {
-            withImmutableFields: boolean;
-            withRequiredFields: boolean;
-          }): OpenAPIV3_1.SchemaObject => ({
-            type: 'object',
-            description: `A field`,
-            properties: {
-              ...(withImmutableFields
-                ? {
-                    type: {
-                      type: 'string',
-                      enum: Object.keys(FieldMetadataType),
-                    },
-                    objectMetadataId: { type: 'string', format: 'uuid' },
-                  }
-                : {}),
-              name: { type: 'string' },
-              label: { type: 'string' },
-              description: { type: 'string' },
-              icon: { type: 'string' },
-              defaultValue: {},
-              isNullable: { type: 'boolean' },
-              settings: { type: 'object' },
-              options: {
-                type: 'array',
-                description: 'For enum field types like SELECT or MULTI_SELECT',
-                items: {
-                  type: 'object',
-                  properties: {
-                    color: { type: 'string' },
-                    label: { type: 'string' },
-                    value: {
-                      type: 'string',
-                      pattern: '^[A-Z0-9]+_[A-Z0-9]+$',
-                      example: 'OPTION_1',
-                    },
-                    position: { type: 'number' },
-                  },
-                },
-              },
-            },
-            ...(withRequiredFields
-              ? { required: ['type', 'name', 'label', 'objectMetadataId'] }
-              : {}),
-          });
-
-          schemas[`${capitalize(item.nameSingular)}`] = baseFieldProperties({
-            withImmutableFields: true,
-            withRequiredFields: true,
-          });
-          schemas[`${capitalize(item.namePlural)}`] = {
-            type: 'array',
-            description: `A list of ${item.namePlural}`,
-            items: {
-              $ref: `#/components/schemas/${capitalize(item.nameSingular)}`,
-            },
-          };
-          schemas[`${capitalize(item.nameSingular)}ForUpdate`] =
-            baseFieldProperties({
-              withImmutableFields: false,
-              withRequiredFields: false,
-            });
-          schemas[`${capitalize(item.nameSingular)}ForResponse`] = {
-            ...baseFieldProperties({
-              withImmutableFields: true,
-              withRequiredFields: false,
-            }),
-            properties: {
-              ...schemas[`${capitalize(item.nameSingular)}`].properties,
-              id: { type: 'string', format: 'uuid' },
-              isCustom: { type: 'boolean' },
-              isActive: { type: 'boolean' },
-              isSystem: { type: 'boolean' },
-              createdAt: { type: 'string', format: 'date-time' },
-              updatedAt: { type: 'string', format: 'date-time' },
-            },
-          };
-          schemas[`${capitalize(item.namePlural)}ForResponse`] = {
-            type: 'array',
-            description: `A list of ${item.namePlural}`,
-            items: {
-              $ref: `#/components/schemas/${capitalize(item.nameSingular)}ForResponse`,
-            },
-          };
-
-          return schemas;
-        }
-        case 'webhook': {
-          schemas[`${capitalize(item.nameSingular)}`] = {
-            type: 'object',
-            description: `A webhook`,
-            properties: {
-              targetUrl: { type: 'string' },
-              operations: {
-                type: 'array',
-                items: { type: 'string' },
-                default: ['*.*'],
-              },
-              description: { type: 'string' },
-              secret: { type: 'string' },
-            },
-            required: ['targetUrl'],
-          };
-          schemas[`${capitalize(item.namePlural)}`] = {
-            type: 'array',
-            description: `A list of ${item.namePlural}`,
-            items: {
-              $ref: `#/components/schemas/${capitalize(item.nameSingular)}`,
-            },
-          };
-          schemas[`${capitalize(item.nameSingular)}ForUpdate`] = {
-            type: 'object',
-            description: `A webhook for update`,
-            properties: {
-              targetUrl: { type: 'string' },
-              operations: {
-                type: 'array',
-                items: { type: 'string' },
-                default: [],
-              },
-              description: { type: 'string' },
-              secret: { type: 'string' },
-            },
-          };
-          schemas[`${capitalize(item.nameSingular)}ForResponse`] = {
-            type: 'object',
-            description: `A webhook`,
-            properties: {
-              id: { type: 'string', format: 'uuid' },
-              targetUrl: { type: 'string' },
-              operations: {
-                type: 'array',
-                items: { type: 'string' },
-              },
-              description: { type: 'string' },
-              secret: { type: 'string' },
-              workspaceId: { type: 'string', format: 'uuid' },
-              createdAt: { type: 'string', format: 'date-time' },
-              updatedAt: { type: 'string', format: 'date-time' },
-              deletedAt: { type: 'string', format: 'date-time' },
-            },
-          };
-          schemas[`${capitalize(item.namePlural)}ForResponse`] = {
-            type: 'array',
-            description: `A list of ${item.namePlural}`,
-            items: {
-              $ref: `#/components/schemas/${capitalize(item.nameSingular)}ForResponse`,
-            },
-          };
-
-          return schemas;
-        }
-        case 'apiKey': {
-          schemas[`${capitalize(item.nameSingular)}`] = {
-            type: 'object',
-            description: `An API key`,
-            properties: {
-              name: { type: 'string' },
-              expiresAt: { type: 'string', format: 'date-time' },
-              roleId: { type: 'string', format: 'uuid' },
-            },
-            required: ['name', 'expiresAt', 'roleId'],
-          };
-          schemas[`${capitalize(item.namePlural)}`] = {
-            type: 'array',
-            description: `A list of ${item.namePlural}`,
-            items: {
-              $ref: `#/components/schemas/${capitalize(item.nameSingular)}`,
-            },
-          };
-          schemas[`${capitalize(item.nameSingular)}ForUpdate`] = {
-            type: 'object',
-            description: `An API key for update`,
-            properties: {
-              name: { type: 'string' },
-              expiresAt: { type: 'string', format: 'date-time' },
-              revokedAt: {
-                type: 'string',
-                format: 'date-time',
-                description:
-                  'Set to null to clear revocation. Defaults to null if not provided.',
-              },
-            },
-          };
-          schemas[`${capitalize(item.nameSingular)}ForResponse`] = {
-            type: 'object',
-            description: `An API key`,
-            properties: {
-              id: { type: 'string', format: 'uuid' },
-              name: { type: 'string' },
-              expiresAt: { type: 'string', format: 'date-time' },
-              revokedAt: { type: 'string', format: 'date-time' },
-              roleId: { type: 'string', format: 'uuid' },
-              workspaceId: { type: 'string', format: 'uuid' },
-              createdAt: { type: 'string', format: 'date-time' },
-              updatedAt: { type: 'string', format: 'date-time' },
-            },
-          };
-          schemas[`${capitalize(item.namePlural)}ForResponse`] = {
-            type: 'array',
-            description: `A list of ${item.namePlural}`,
-            items: {
-              $ref: `#/components/schemas/${capitalize(item.nameSingular)}ForResponse`,
-            },
-          };
-
-          return schemas;
-        }
-        case 'view': {
-          schemas[`${capitalize(item.nameSingular)}`] = {
-            type: 'object',
-            description: `A view`,
-            properties: {
-              name: { type: 'string' },
-              objectMetadataId: { type: 'string', format: 'uuid' },
-              type: {
-                type: 'string',
-                enum: ['TABLE', 'KANBAN'],
-                default: 'TABLE',
-              },
-              key: { type: 'string', default: 'INDEX' },
-              icon: { type: 'string' },
-              position: { type: 'number', default: 0 },
-              isCompact: { type: 'boolean', default: false },
-              openRecordIn: {
-                type: 'string',
-                enum: ['SIDE_PANEL', 'RECORD_PAGE'],
-                default: 'SIDE_PANEL',
-              },
-              kanbanAggregateOperation: {
-                type: 'string',
-                enum: ['AVG', 'COUNT', 'MAX', 'MIN', 'SUM'],
-              },
-              kanbanAggregateOperationFieldMetadataId: {
-                type: 'string',
-                format: 'uuid',
-              },
-              anyFieldFilterValue: { type: 'string' },
-            },
-            required: ['name', 'objectMetadataId', 'icon'],
-          };
-          schemas[`${capitalize(item.namePlural)}`] = {
-            type: 'array',
-            description: `A list of ${item.namePlural}`,
-            items: {
-              $ref: `#/components/schemas/${capitalize(item.nameSingular)}`,
-            },
-          };
-          schemas[`${capitalize(item.nameSingular)}ForUpdate`] = {
-            type: 'object',
-            description: `A view for update`,
-            properties: {
-              name: { type: 'string' },
-              type: {
-                type: 'string',
-                enum: ['TABLE', 'KANBAN'],
-              },
-              key: { type: 'string' },
-              icon: { type: 'string' },
-              position: { type: 'number' },
-              isCompact: { type: 'boolean' },
-              openRecordIn: {
-                type: 'string',
-                enum: ['SIDE_PANEL', 'RECORD_PAGE'],
-              },
-              kanbanAggregateOperation: {
-                type: 'string',
-                enum: ['AVG', 'COUNT', 'MAX', 'MIN', 'SUM'],
-              },
-              kanbanAggregateOperationFieldMetadataId: {
-                type: 'string',
-                format: 'uuid',
-              },
-              anyFieldFilterValue: { type: 'string' },
-            },
-          };
-          schemas[`${capitalize(item.nameSingular)}ForResponse`] = {
-            type: 'object',
-            description: `A view`,
-            properties: {
-              id: { type: 'string', format: 'uuid' },
-              name: { type: 'string' },
-              objectMetadataId: { type: 'string', format: 'uuid' },
-              type: {
-                type: 'string',
-                enum: ['TABLE', 'KANBAN'],
-              },
-              key: { type: 'string' },
-              icon: { type: 'string' },
-              position: { type: 'number' },
-              isCompact: { type: 'boolean' },
-              openRecordIn: {
-                type: 'string',
-                enum: ['SIDE_PANEL', 'RECORD_PAGE'],
-              },
-              kanbanAggregateOperation: {
-                type: 'string',
-                enum: ['AVG', 'COUNT', 'MAX', 'MIN', 'SUM'],
-              },
-              kanbanAggregateOperationFieldMetadataId: {
-                type: 'string',
-                format: 'uuid',
-              },
-              anyFieldFilterValue: { type: 'string' },
-              workspaceId: { type: 'string', format: 'uuid' },
-              createdAt: { type: 'string', format: 'date-time' },
-              updatedAt: { type: 'string', format: 'date-time' },
-              deletedAt: { type: 'string', format: 'date-time' },
-            },
-          };
-          schemas[`${capitalize(item.namePlural)}ForResponse`] = {
-            type: 'array',
-            description: `A list of ${item.namePlural}`,
-            items: {
-              $ref: `#/components/schemas/${capitalize(item.nameSingular)}ForResponse`,
-            },
-          };
-
-          return schemas;
-        }
-        case 'viewField': {
-          schemas[`${capitalize(item.nameSingular)}`] = {
-            type: 'object',
-            description: `A view field`,
-            properties: {
-              fieldMetadataId: { type: 'string', format: 'uuid' },
-              viewId: { type: 'string', format: 'uuid' },
-              isVisible: { type: 'boolean', default: true },
-              size: { type: 'number', default: 0 },
-              position: { type: 'number', default: 0 },
-              aggregateOperation: {
-                type: 'string',
-                enum: ['AVG', 'COUNT', 'MAX', 'MIN', 'SUM'],
-              },
-            },
-            required: ['fieldMetadataId', 'viewId'],
-          };
-          schemas[`${capitalize(item.namePlural)}`] = {
-            type: 'array',
-            description: `A list of ${item.namePlural}`,
-            items: {
-              $ref: `#/components/schemas/${capitalize(item.nameSingular)}`,
-            },
-          };
-          schemas[`${capitalize(item.nameSingular)}ForUpdate`] = {
-            type: 'object',
-            description: `A view field for update`,
-            properties: {
-              isVisible: { type: 'boolean' },
-              size: { type: 'number' },
-              position: { type: 'number' },
-              aggregateOperation: {
-                type: 'string',
-                enum: ['AVG', 'COUNT', 'MAX', 'MIN', 'SUM'],
-              },
-            },
-          };
-          schemas[`${capitalize(item.nameSingular)}ForResponse`] = {
-            type: 'object',
-            description: `A view field`,
-            properties: {
-              id: { type: 'string', format: 'uuid' },
-              fieldMetadataId: { type: 'string', format: 'uuid' },
-              viewId: { type: 'string', format: 'uuid' },
-              isVisible: { type: 'boolean' },
-              size: { type: 'number' },
-              position: { type: 'number' },
-              aggregateOperation: {
-                type: 'string',
-                enum: ['AVG', 'COUNT', 'MAX', 'MIN', 'SUM'],
-              },
-              workspaceId: { type: 'string', format: 'uuid' },
-              createdAt: { type: 'string', format: 'date-time' },
-              updatedAt: { type: 'string', format: 'date-time' },
-              deletedAt: { type: 'string', format: 'date-time' },
-            },
-          };
-          schemas[`${capitalize(item.namePlural)}ForResponse`] = {
-            type: 'array',
-            description: `A list of ${item.namePlural}`,
-            items: {
-              $ref: `#/components/schemas/${capitalize(item.nameSingular)}ForResponse`,
-            },
-          };
-
-          return schemas;
-        }
-        case 'viewFilter': {
-          schemas[`${capitalize(item.nameSingular)}`] = {
-            type: 'object',
-            description: `A view filter`,
-            properties: {
-              fieldMetadataId: { type: 'string', format: 'uuid' },
-              viewId: { type: 'string', format: 'uuid' },
-              operand: {
-                type: 'string',
-                enum: [
-                  'IS',
-                  'IS_NOT_NULL',
-                  'IS_NOT',
-                  'LESS_THAN_OR_EQUAL',
-                  'GREATER_THAN_OR_EQUAL',
-                  'IS_BEFORE',
-                  'IS_AFTER',
-                  'CONTAINS',
-                  'DOES_NOT_CONTAIN',
-                  'IS_EMPTY',
-                  'IS_NOT_EMPTY',
-                  'IS_RELATIVE',
-                  'IS_IN_PAST',
-                  'IS_IN_FUTURE',
-                  'IS_TODAY',
-                  'VECTOR_SEARCH',
-                ],
-                default: 'CONTAINS',
-              },
-              value: {
-                type: 'object',
-                description: 'Filter value (JSON format)',
-              },
-              viewFilterGroupId: { type: 'string', format: 'uuid' },
-              positionInViewFilterGroup: { type: 'number' },
-              subFieldName: { type: 'string' },
-            },
-            required: ['fieldMetadataId', 'viewId', 'value'],
-          };
-          schemas[`${capitalize(item.namePlural)}`] = {
-            type: 'array',
-            description: `A list of ${item.namePlural}`,
-            items: {
-              $ref: `#/components/schemas/${capitalize(item.nameSingular)}`,
-            },
-          };
-          schemas[`${capitalize(item.nameSingular)}ForUpdate`] = {
-            type: 'object',
-            description: `A view filter for update`,
-            properties: {
-              operand: {
-                type: 'string',
-                enum: [
-                  'IS',
-                  'IS_NOT_NULL',
-                  'IS_NOT',
-                  'LESS_THAN_OR_EQUAL',
-                  'GREATER_THAN_OR_EQUAL',
-                  'IS_BEFORE',
-                  'IS_AFTER',
-                  'CONTAINS',
-                  'DOES_NOT_CONTAIN',
-                  'IS_EMPTY',
-                  'IS_NOT_EMPTY',
-                  'IS_RELATIVE',
-                  'IS_IN_PAST',
-                  'IS_IN_FUTURE',
-                  'IS_TODAY',
-                  'VECTOR_SEARCH',
-                ],
-              },
-              value: {
-                type: 'object',
-                description: 'Filter value (JSON format)',
-              },
-              viewFilterGroupId: { type: 'string', format: 'uuid' },
-              positionInViewFilterGroup: { type: 'number' },
-              subFieldName: { type: 'string' },
-            },
-          };
-          schemas[`${capitalize(item.nameSingular)}ForResponse`] = {
-            type: 'object',
-            description: `A view filter`,
-            properties: {
-              id: { type: 'string', format: 'uuid' },
-              fieldMetadataId: { type: 'string', format: 'uuid' },
-              viewId: { type: 'string', format: 'uuid' },
-              operand: {
-                type: 'string',
-                enum: [
-                  'IS',
-                  'IS_NOT_NULL',
-                  'IS_NOT',
-                  'LESS_THAN_OR_EQUAL',
-                  'GREATER_THAN_OR_EQUAL',
-                  'IS_BEFORE',
-                  'IS_AFTER',
-                  'CONTAINS',
-                  'DOES_NOT_CONTAIN',
-                  'IS_EMPTY',
-                  'IS_NOT_EMPTY',
-                  'IS_RELATIVE',
-                  'IS_IN_PAST',
-                  'IS_IN_FUTURE',
-                  'IS_TODAY',
-                  'VECTOR_SEARCH',
-                ],
-              },
-              value: {
-                type: 'object',
-                description: 'Filter value (JSON format)',
-              },
-              viewFilterGroupId: { type: 'string', format: 'uuid' },
-              positionInViewFilterGroup: { type: 'number' },
-              subFieldName: { type: 'string' },
-              workspaceId: { type: 'string', format: 'uuid' },
-              createdAt: { type: 'string', format: 'date-time' },
-              updatedAt: { type: 'string', format: 'date-time' },
-              deletedAt: { type: 'string', format: 'date-time' },
-            },
-          };
-          schemas[`${capitalize(item.namePlural)}ForResponse`] = {
-            type: 'array',
-            description: `A list of ${item.namePlural}`,
-            items: {
-              $ref: `#/components/schemas/${capitalize(item.nameSingular)}ForResponse`,
-            },
-          };
-
-          return schemas;
-        }
-        case 'viewSort': {
-          schemas[`${capitalize(item.nameSingular)}`] = {
-            type: 'object',
-            description: `A view sort`,
-            properties: {
-              fieldMetadataId: { type: 'string', format: 'uuid' },
-              viewId: { type: 'string', format: 'uuid' },
-              direction: {
-                type: 'string',
-                enum: ['ASC', 'DESC'],
-                default: 'ASC',
-              },
-            },
-            required: ['fieldMetadataId', 'viewId'],
-          };
-          schemas[`${capitalize(item.namePlural)}`] = {
-            type: 'array',
-            description: `A list of ${item.namePlural}`,
-            items: {
-              $ref: `#/components/schemas/${capitalize(item.nameSingular)}`,
-            },
-          };
-          schemas[`${capitalize(item.nameSingular)}ForUpdate`] = {
-            type: 'object',
-            description: `A view sort for update`,
-            properties: {
-              direction: {
-                type: 'string',
-                enum: ['ASC', 'DESC'],
-              },
-            },
-          };
-          schemas[`${capitalize(item.nameSingular)}ForResponse`] = {
-            type: 'object',
-            description: `A view sort`,
-            properties: {
-              id: { type: 'string', format: 'uuid' },
-              fieldMetadataId: { type: 'string', format: 'uuid' },
-              viewId: { type: 'string', format: 'uuid' },
-              direction: {
-                type: 'string',
-                enum: ['ASC', 'DESC'],
-              },
-              workspaceId: { type: 'string', format: 'uuid' },
-              createdAt: { type: 'string', format: 'date-time' },
-              updatedAt: { type: 'string', format: 'date-time' },
-              deletedAt: { type: 'string', format: 'date-time' },
-            },
-          };
-          schemas[`${capitalize(item.namePlural)}ForResponse`] = {
-            type: 'array',
-            description: `A list of ${item.namePlural}`,
-            items: {
-              $ref: `#/components/schemas/${capitalize(item.nameSingular)}ForResponse`,
-            },
-          };
-
-          return schemas;
-        }
-        case 'viewGroup': {
-          schemas[`${capitalize(item.nameSingular)}`] = {
-            type: 'object',
-            description: `A view group`,
-            properties: {
-              fieldMetadataId: { type: 'string', format: 'uuid' },
-              viewId: { type: 'string', format: 'uuid' },
-              fieldValue: { type: 'string' },
-              isVisible: { type: 'boolean', default: true },
-              position: { type: 'number', default: 0 },
-            },
-            required: ['fieldMetadataId', 'viewId', 'fieldValue'],
-          };
-          schemas[`${capitalize(item.namePlural)}`] = {
-            type: 'array',
-            description: `A list of ${item.namePlural}`,
-            items: {
-              $ref: `#/components/schemas/${capitalize(item.nameSingular)}`,
-            },
-          };
-          schemas[`${capitalize(item.nameSingular)}ForUpdate`] = {
-            type: 'object',
-            description: `A view group for update`,
-            properties: {
-              fieldValue: { type: 'string' },
-              isVisible: { type: 'boolean' },
-              position: { type: 'number' },
-            },
-          };
-          schemas[`${capitalize(item.nameSingular)}ForResponse`] = {
-            type: 'object',
-            description: `A view group`,
-            properties: {
-              id: { type: 'string', format: 'uuid' },
-              fieldMetadataId: { type: 'string', format: 'uuid' },
-              viewId: { type: 'string', format: 'uuid' },
-              fieldValue: { type: 'string' },
-              isVisible: { type: 'boolean' },
-              position: { type: 'number' },
-              workspaceId: { type: 'string', format: 'uuid' },
-              createdAt: { type: 'string', format: 'date-time' },
-              updatedAt: { type: 'string', format: 'date-time' },
-              deletedAt: { type: 'string', format: 'date-time' },
-            },
-          };
-          schemas[`${capitalize(item.namePlural)}ForResponse`] = {
-            type: 'array',
-            description: `A list of ${item.namePlural}`,
-            items: {
-              $ref: `#/components/schemas/${capitalize(item.nameSingular)}ForResponse`,
-            },
-          };
-
-          return schemas;
-        }
-        case 'viewFilterGroup': {
-          schemas[`${capitalize(item.nameSingular)}`] = {
-            type: 'object',
-            description: `A view filter group`,
-            properties: {
-              viewId: { type: 'string', format: 'uuid' },
-              parentViewFilterGroupId: { type: 'string', format: 'uuid' },
-              logicalOperator: {
-                type: 'string',
-                enum: ['AND', 'OR', 'NOT'],
-                default: 'AND',
-              },
-              positionInViewFilterGroup: { type: 'number' },
-            },
-            required: ['viewId'],
-          };
-          schemas[`${capitalize(item.namePlural)}`] = {
-            type: 'array',
-            description: `A list of ${item.namePlural}`,
-            items: {
-              $ref: `#/components/schemas/${capitalize(item.nameSingular)}`,
-            },
-          };
-          schemas[`${capitalize(item.nameSingular)}ForUpdate`] = {
-            type: 'object',
-            description: `A view filter group for update`,
-            properties: {
-              parentViewFilterGroupId: { type: 'string', format: 'uuid' },
-              logicalOperator: {
-                type: 'string',
-                enum: ['AND', 'OR', 'NOT'],
-              },
-              positionInViewFilterGroup: { type: 'number' },
-            },
-          };
-          schemas[`${capitalize(item.nameSingular)}ForResponse`] = {
-            type: 'object',
-            description: `A view filter group`,
-            properties: {
-              id: { type: 'string', format: 'uuid' },
-              viewId: { type: 'string', format: 'uuid' },
-              parentViewFilterGroupId: { type: 'string', format: 'uuid' },
-              logicalOperator: {
-                type: 'string',
-                enum: ['AND', 'OR', 'NOT'],
-              },
-              positionInViewFilterGroup: { type: 'number' },
-              workspaceId: { type: 'string', format: 'uuid' },
-              createdAt: { type: 'string', format: 'date-time' },
-              updatedAt: { type: 'string', format: 'date-time' },
-              deletedAt: { type: 'string', format: 'date-time' },
-            },
-          };
-          schemas[`${capitalize(item.namePlural)}ForResponse`] = {
-            type: 'array',
-            description: `A list of ${item.namePlural}`,
-            items: {
-              $ref: `#/components/schemas/${capitalize(item.nameSingular)}ForResponse`,
-            },
-          };
-
-          return schemas;
-        }
-        case 'pageLayout': {
-          schemas[`${capitalize(item.nameSingular)}`] = {
-            type: 'object',
-            description: `A page layout`,
-            properties: {
-              name: { type: 'string' },
-              type: {
-                type: 'string',
-                enum: [
-                  'RECORD_INDEX',
-                  'RECORD_PAGE',
-                  'DASHBOARD',
-                  'STANDALONE_PAGE',
-                ],
-                default: 'RECORD_PAGE',
-              },
-              objectMetadataId: { type: 'string', format: 'uuid' },
-            },
-            required: ['name'],
-          };
-          schemas[`${capitalize(item.namePlural)}`] = {
-            type: 'array',
-            description: `A list of ${item.namePlural}`,
-            items: {
-              $ref: `#/components/schemas/${capitalize(item.nameSingular)}`,
-            },
-          };
-          schemas[`${capitalize(item.nameSingular)}ForUpdate`] = {
-            type: 'object',
-            description: `A page layout for update`,
-            properties: {
-              name: { type: 'string' },
-              type: {
-                type: 'string',
-                enum: [
-                  'RECORD_INDEX',
-                  'RECORD_PAGE',
-                  'DASHBOARD',
-                  'STANDALONE_PAGE',
-                ],
-              },
-              objectMetadataId: { type: 'string', format: 'uuid' },
-            },
-          };
-          schemas[`${capitalize(item.nameSingular)}ForResponse`] = {
-            type: 'object',
-            description: `A page layout`,
-            properties: {
-              id: { type: 'string', format: 'uuid' },
-              name: { type: 'string' },
-              type: {
-                type: 'string',
-                enum: [
-                  'RECORD_INDEX',
-                  'RECORD_PAGE',
-                  'DASHBOARD',
-                  'STANDALONE_PAGE',
-                ],
-              },
-              objectMetadataId: { type: 'string', format: 'uuid' },
-              tabs: {
-                type: 'array',
-                items: {
-                  $ref: '#/components/schemas/PageLayoutTabForResponse',
-                },
-              },
-              workspaceId: { type: 'string', format: 'uuid' },
-              createdAt: { type: 'string', format: 'date-time' },
-              updatedAt: { type: 'string', format: 'date-time' },
-              deletedAt: { type: 'string', format: 'date-time' },
-            },
-          };
-          schemas[`${capitalize(item.namePlural)}ForResponse`] = {
-            type: 'array',
-            description: `A list of ${item.namePlural}`,
-            items: {
-              $ref: `#/components/schemas/${capitalize(item.nameSingular)}ForResponse`,
-            },
-          };
-
-          return schemas;
-        }
-        case 'pageLayoutTab': {
-          schemas[`${capitalize(item.nameSingular)}`] = {
-            type: 'object',
-            description: `A page layout tab`,
-            properties: {
-              title: { type: 'string' },
-              position: { type: 'number', default: 0 },
-              pageLayoutId: { type: 'string', format: 'uuid' },
-            },
-            required: ['title', 'pageLayoutId'],
-          };
-          schemas[`${capitalize(item.namePlural)}`] = {
-            type: 'array',
-            description: `A list of ${item.namePlural}`,
-            items: {
-              $ref: `#/components/schemas/${capitalize(item.nameSingular)}`,
-            },
-          };
-          schemas[`${capitalize(item.nameSingular)}ForUpdate`] = {
-            type: 'object',
-            description: `A page layout tab for update`,
-            properties: {
-              title: { type: 'string' },
-              position: { type: 'number' },
-            },
-          };
-          schemas[`${capitalize(item.nameSingular)}ForResponse`] = {
-            type: 'object',
-            description: `A page layout tab`,
-            properties: {
-              id: { type: 'string', format: 'uuid' },
-              title: { type: 'string' },
-              position: { type: 'number' },
-              pageLayoutId: { type: 'string', format: 'uuid' },
-              workspaceId: { type: 'string', format: 'uuid' },
-              createdAt: { type: 'string', format: 'date-time' },
-              updatedAt: { type: 'string', format: 'date-time' },
-              deletedAt: { type: 'string', format: 'date-time' },
-            },
-          };
-          schemas[`${capitalize(item.namePlural)}ForResponse`] = {
-            type: 'array',
-            description: `A list of ${item.namePlural}`,
-            items: {
-              $ref: `#/components/schemas/${capitalize(item.nameSingular)}ForResponse`,
-            },
-          };
-
-          return schemas;
-        }
-        case 'pageLayoutWidget': {
-          schemas['GridPosition'] = {
-            type: 'object',
-            description: 'Grid position for widget placement',
-            properties: {
-              row: { type: 'number', minimum: 0 },
-              column: { type: 'number', minimum: 0 },
-              rowSpan: { type: 'number', minimum: 1 },
-              columnSpan: { type: 'number', minimum: 1 },
-            },
-            required: ['row', 'column', 'rowSpan', 'columnSpan'],
-          };
-
-          schemas[`${capitalize(item.nameSingular)}`] = {
-            type: 'object',
-            description: `A page layout widget`,
-            properties: {
-              pageLayoutTabId: { type: 'string', format: 'uuid' },
-              title: { type: 'string' },
-              type: {
-                type: 'string',
-                enum: [
-                  'VIEW',
-                  'IFRAME',
-                  'FIELDS',
-                  'GRAPH',
-                  'TIMELINE',
-                  'TASKS',
-                  'NOTES',
-                  'FILES',
-                  'EMAILS',
-                  'CALENDAR',
-                ],
-                default: 'VIEW',
-              },
-              objectMetadataId: { type: 'string', format: 'uuid' },
-              gridPosition: {
-                $ref: '#/components/schemas/GridPosition',
-              },
-              configuration: {
-                type: 'object',
-                description: 'Widget-specific configuration',
-              },
-            },
-            required: ['pageLayoutTabId', 'title', 'gridPosition'],
-          };
-          schemas[`${capitalize(item.namePlural)}`] = {
-            type: 'array',
-            description: `A list of ${item.namePlural}`,
-            items: {
-              $ref: `#/components/schemas/${capitalize(item.nameSingular)}`,
-            },
-          };
-          schemas[`${capitalize(item.nameSingular)}ForUpdate`] = {
-            type: 'object',
-            description: `A page layout widget for update`,
-            properties: {
-              title: { type: 'string' },
-              type: {
-                type: 'string',
-                enum: ['VIEW', 'IFRAME', 'FIELDS', 'GRAPH'],
-              },
-              objectMetadataId: { type: 'string', format: 'uuid' },
-              gridPosition: {
-                $ref: '#/components/schemas/GridPosition',
-              },
-              configuration: {
-                type: 'object',
-                description: 'Widget-specific configuration',
-              },
-            },
-          };
-          schemas[`${capitalize(item.nameSingular)}ForResponse`] = {
-            type: 'object',
-            description: `A page layout widget`,
-            properties: {
-              id: { type: 'string', format: 'uuid' },
-              pageLayoutTabId: { type: 'string', format: 'uuid' },
-              title: { type: 'string' },
-              type: {
-                type: 'string',
-                enum: ['VIEW', 'IFRAME', 'FIELDS', 'GRAPH'],
-              },
-              objectMetadataId: { type: 'string', format: 'uuid' },
-              gridPosition: {
-                $ref: '#/components/schemas/GridPosition',
-              },
-              configuration: {
-                type: 'object',
-                description: 'Widget-specific configuration',
-              },
-              workspaceId: { type: 'string', format: 'uuid' },
-              createdAt: { type: 'string', format: 'date-time' },
-              updatedAt: { type: 'string', format: 'date-time' },
-              deletedAt: { type: 'string', format: 'date-time' },
-            },
-          };
-          schemas[`${capitalize(item.namePlural)}ForResponse`] = {
-            type: 'array',
-            description: `A list of ${item.namePlural}`,
-            items: {
-              $ref: `#/components/schemas/${capitalize(item.nameSingular)}ForResponse`,
-            },
-          };
-
-          return schemas;
-        }
+      if (!entityConfig) {
+        return schemas;
       }
 
-      return schemas;
+      const entitySchemas = computeMetadataSchemaForEntity({
+        nameSingular: item.nameSingular,
+        namePlural: item.namePlural,
+        ...entityConfig,
+      });
+
+      return { ...schemas, ...entitySchemas };
     },
     {} as Record<string, OpenAPIV3_1.SchemaObject>,
   );

--- a/packages/twenty-server/src/engine/core-modules/open-api/utils/components.utils.ts
+++ b/packages/twenty-server/src/engine/core-modules/open-api/utils/components.utils.ts
@@ -671,12 +671,7 @@ const METADATA_ENTITY_SCHEMA_CONFIGS: Record<
       name: { type: 'string' },
       type: {
         type: 'string',
-        enum: [
-          'RECORD_INDEX',
-          'RECORD_PAGE',
-          'DASHBOARD',
-          'STANDALONE_PAGE',
-        ],
+        enum: ['RECORD_INDEX', 'RECORD_PAGE', 'DASHBOARD', 'STANDALONE_PAGE'],
         default: 'RECORD_PAGE',
       },
       objectMetadataId: { type: 'string', format: 'uuid' },
@@ -686,12 +681,7 @@ const METADATA_ENTITY_SCHEMA_CONFIGS: Record<
       name: { type: 'string' },
       type: {
         type: 'string',
-        enum: [
-          'RECORD_INDEX',
-          'RECORD_PAGE',
-          'DASHBOARD',
-          'STANDALONE_PAGE',
-        ],
+        enum: ['RECORD_INDEX', 'RECORD_PAGE', 'DASHBOARD', 'STANDALONE_PAGE'],
       },
       objectMetadataId: { type: 'string', format: 'uuid' },
     },
@@ -790,8 +780,7 @@ export const computeMetadataSchemaComponents = (
 ): Record<string, OpenAPIV3_1.SchemaObject> => {
   return metadataSchema.reduce(
     (schemas, item) => {
-      const entityConfig =
-        METADATA_ENTITY_SCHEMA_CONFIGS[item.nameSingular];
+      const entityConfig = METADATA_ENTITY_SCHEMA_CONFIGS[item.nameSingular];
 
       if (!entityConfig) {
         return schemas;

--- a/packages/twenty-server/src/engine/core-modules/open-api/utils/compute-metadata-schema-for-entity.util.ts
+++ b/packages/twenty-server/src/engine/core-modules/open-api/utils/compute-metadata-schema-for-entity.util.ts
@@ -1,0 +1,106 @@
+import { type OpenAPIV3_1 } from 'openapi-types';
+import { capitalize } from 'twenty-shared/utils';
+
+type SchemaOrRef = OpenAPIV3_1.SchemaObject | OpenAPIV3_1.ReferenceObject;
+
+export type MetadataSchemaConfig = {
+  nameSingular: string;
+  namePlural: string;
+  description: string;
+  properties: Record<string, SchemaOrRef>;
+  requiredFields?: string[];
+  updateDescription?: string;
+  updateProperties: Record<string, SchemaOrRef>;
+  responseExtraProperties?: Record<string, SchemaOrRef>;
+  responseCommonProperties?: Record<string, SchemaOrRef>;
+  extraSchemas?: Record<string, OpenAPIV3_1.SchemaObject>;
+};
+
+const DEFAULT_RESPONSE_COMMON_PROPERTIES: Record<string, SchemaOrRef> = {
+  workspaceId: { type: 'string', format: 'uuid' },
+  createdAt: { type: 'string', format: 'date-time' },
+  updatedAt: { type: 'string', format: 'date-time' },
+  deletedAt: { type: 'string', format: 'date-time' },
+};
+
+const stripDefaults = (
+  properties: Record<string, SchemaOrRef>,
+): Record<string, SchemaOrRef> => {
+  return Object.fromEntries(
+    Object.entries(properties).map(([key, value]) => {
+      if ('default' in value) {
+        const { default: _, ...rest } = value;
+
+        return [key, rest];
+      }
+
+      return [key, value];
+    }),
+  );
+};
+
+export const computeMetadataSchemaForEntity = (
+  config: MetadataSchemaConfig,
+): Record<string, OpenAPIV3_1.SchemaObject> => {
+  const {
+    nameSingular,
+    namePlural,
+    description,
+    properties,
+    requiredFields,
+    updateDescription,
+    updateProperties,
+    responseExtraProperties = {},
+    responseCommonProperties = DEFAULT_RESPONSE_COMMON_PROPERTIES,
+    extraSchemas = {},
+  } = config;
+
+  const singularKey = capitalize(nameSingular);
+  const pluralKey = capitalize(namePlural);
+
+  const schemas: Record<string, OpenAPIV3_1.SchemaObject> = {
+    ...extraSchemas,
+  };
+
+  schemas[singularKey] = {
+    type: 'object',
+    description,
+    properties,
+    ...(requiredFields?.length ? { required: requiredFields } : {}),
+  };
+
+  schemas[pluralKey] = {
+    type: 'array',
+    description: `A list of ${namePlural}`,
+    items: {
+      $ref: `#/components/schemas/${singularKey}`,
+    },
+  };
+
+  schemas[`${singularKey}ForUpdate`] = {
+    type: 'object',
+    description: updateDescription ?? `${description} for update`,
+    properties: updateProperties,
+  };
+
+  schemas[`${singularKey}ForResponse`] = {
+    type: 'object',
+    description,
+    properties: {
+      id: { type: 'string', format: 'uuid' },
+      ...stripDefaults(properties),
+      ...responseExtraProperties,
+      ...responseCommonProperties,
+    },
+  };
+
+  schemas[`${pluralKey}ForResponse`] = {
+    type: 'array',
+    description: `A list of ${namePlural}`,
+    items: {
+      $ref: `#/components/schemas/${singularKey}ForResponse`,
+    },
+  };
+
+  return schemas;
+};


### PR DESCRIPTION
## Summary
- Extracted a reusable `computeMetadataSchemaForEntity` helper from the 1000+ line switch statement in `computeMetadataSchemaComponents`
- Replaced 13 near-identical switch cases with a declarative config record + loop
- `components.utils.ts`: 1330 → 810 lines; new `compute-metadata-schema-for-entity.util.ts`: 107 lines

## Test plan
- [ ] CI passes (lint, typecheck, tests)
- [ ] No behavior change — byte-for-byte equivalent OpenAPI output