### PR TITLE
feat(website): add /partners/apply standalone page

### DIFF
--- a/packages/twenty-website/src/app/[locale]/partners/apply/PartnerApplicationPageContent.tsx
+++ b/packages/twenty-website/src/app/[locale]/partners/apply/PartnerApplicationPageContent.tsx
@@ -22,9 +22,6 @@ const ApplyPageContainer = styled.div`
   display: flex;
   flex-direction: column;
   gap: ${theme.spacing(4)};
-  margin-left: auto;
-  margin-right: auto;
-  max-width: min(720px, 100%);
   min-height: 100vh;
   padding: ${theme.spacing(5)} ${theme.spacing(4)};
 

--- a/packages/twenty-website/src/app/[locale]/partners/apply/PartnerApplicationPageContent.tsx
+++ b/packages/twenty-website/src/app/[locale]/partners/apply/PartnerApplicationPageContent.tsx
@@ -1,0 +1,68 @@
+'use client';
+
+import { PartnerApplicationWizard } from '@/sections/PartnerApplication/wizard/PartnerApplicationWizard';
+import { theme } from '@/theme';
+import { styled } from '@linaria/react';
+import { useRouter } from 'next/navigation';
+import { useState, type ReactElement } from 'react';
+
+function PassTitle({ render }: { render?: ReactElement }) {
+  return <>{render}</>;
+}
+
+function PassDescription({ render }: { render?: ReactElement }) {
+  return <>{render}</>;
+}
+
+const PAGE_SLOTS = { Title: PassTitle, Description: PassDescription };
+
+const ApplyPageWrapper = styled.div`
+  background-color: ${theme.colors.primary.background[100]};
+  min-height: 100vh;
+  padding: ${theme.spacing(8)} ${theme.spacing(4)};
+
+  @media (min-width: ${theme.breakpoints.md}px) {
+    padding: ${theme.spacing(12)} ${theme.spacing(6)};
+  }
+`;
+
+const ApplyPageCard = styled.div`
+  background: #0c0c0c;
+  border-radius: ${theme.radius(2)};
+  box-sizing: border-box;
+  display: flex;
+  flex-direction: column;
+  gap: ${theme.spacing(4)};
+  margin-left: auto;
+  margin-right: auto;
+  max-width: min(720px, 100%);
+  overflow-y: auto;
+  padding-bottom: ${theme.spacing(6)};
+  padding-left: ${theme.spacing(4)};
+  padding-right: ${theme.spacing(4)};
+  padding-top: ${theme.spacing(5)};
+
+  @media (min-width: ${theme.breakpoints.md}px) {
+    padding-bottom: ${theme.spacing(8)};
+    padding-left: ${theme.spacing(6)};
+    padding-right: ${theme.spacing(6)};
+    padding-top: ${theme.spacing(6)};
+  }
+`;
+
+export function PartnerApplicationPageContent() {
+  const router = useRouter();
+  const [resetSignal] = useState(0);
+
+  return (
+    <ApplyPageWrapper>
+      <ApplyPageCard>
+        <PartnerApplicationWizard
+          resetSignal={resetSignal}
+          onSuccess={() => router.push('/partners/list')}
+          slots={PAGE_SLOTS}
+        />
+      </ApplyPageCard>
+    </ApplyPageWrapper>
+  );
+}

--- a/packages/twenty-website/src/app/[locale]/partners/apply/PartnerApplicationPageContent.tsx
+++ b/packages/twenty-website/src/app/[locale]/partners/apply/PartnerApplicationPageContent.tsx
@@ -16,13 +16,19 @@ function PassDescription({ render }: { render?: ReactElement }) {
 
 const PAGE_SLOTS = { Title: PassTitle, Description: PassDescription };
 
-const ApplyPageContainer = styled.div`
+const ApplyPageBackground = styled.div`
   background: #0c0c0c;
+  min-height: 100vh;
+`;
+
+const ApplyPageContainer = styled.div`
   box-sizing: border-box;
   display: flex;
   flex-direction: column;
   gap: ${theme.spacing(4)};
-  min-height: 100vh;
+  margin-left: auto;
+  margin-right: auto;
+  max-width: min(720px, 100%);
   padding: ${theme.spacing(5)} ${theme.spacing(4)};
 
   @media (min-width: ${theme.breakpoints.md}px) {
@@ -34,12 +40,14 @@ export function PartnerApplicationPageContent() {
   const router = useRouter();
 
   return (
-    <ApplyPageContainer>
-      <PartnerApplicationWizard
-        resetSignal={0}
-        onSuccess={() => router.push('/partners/list')}
-        slots={PAGE_SLOTS}
-      />
-    </ApplyPageContainer>
+    <ApplyPageBackground>
+      <ApplyPageContainer>
+        <PartnerApplicationWizard
+          resetSignal={0}
+          onSuccess={() => router.push('/partners/list')}
+          slots={PAGE_SLOTS}
+        />
+      </ApplyPageContainer>
+    </ApplyPageBackground>
   );
 }

--- a/packages/twenty-website/src/app/[locale]/partners/apply/PartnerApplicationPageContent.tsx
+++ b/packages/twenty-website/src/app/[locale]/partners/apply/PartnerApplicationPageContent.tsx
@@ -16,19 +16,8 @@ function PassDescription({ render }: { render?: ReactElement }) {
 
 const PAGE_SLOTS = { Title: PassTitle, Description: PassDescription };
 
-const ApplyPageWrapper = styled.div`
-  background-color: ${theme.colors.primary.background[100]};
-  min-height: 100vh;
-  padding: ${theme.spacing(8)} ${theme.spacing(4)};
-
-  @media (min-width: ${theme.breakpoints.md}px) {
-    padding: ${theme.spacing(12)} ${theme.spacing(6)};
-  }
-`;
-
-const ApplyPageCard = styled.div`
+const ApplyPageContainer = styled.div`
   background: #0c0c0c;
-  border-radius: ${theme.radius(2)};
   box-sizing: border-box;
   display: flex;
   flex-direction: column;
@@ -36,17 +25,11 @@ const ApplyPageCard = styled.div`
   margin-left: auto;
   margin-right: auto;
   max-width: min(720px, 100%);
-  overflow-y: auto;
-  padding-bottom: ${theme.spacing(6)};
-  padding-left: ${theme.spacing(4)};
-  padding-right: ${theme.spacing(4)};
-  padding-top: ${theme.spacing(5)};
+  min-height: 100vh;
+  padding: ${theme.spacing(5)} ${theme.spacing(4)};
 
   @media (min-width: ${theme.breakpoints.md}px) {
-    padding-bottom: ${theme.spacing(8)};
-    padding-left: ${theme.spacing(6)};
-    padding-right: ${theme.spacing(6)};
-    padding-top: ${theme.spacing(6)};
+    padding: ${theme.spacing(6)};
   }
 `;
 
@@ -54,14 +37,12 @@ export function PartnerApplicationPageContent() {
   const router = useRouter();
 
   return (
-    <ApplyPageWrapper>
-      <ApplyPageCard>
-        <PartnerApplicationWizard
-          resetSignal={0}
-          onSuccess={() => router.push('/partners/list')}
-          slots={PAGE_SLOTS}
-        />
-      </ApplyPageCard>
-    </ApplyPageWrapper>
+    <ApplyPageContainer>
+      <PartnerApplicationWizard
+        resetSignal={0}
+        onSuccess={() => router.push('/partners/list')}
+        slots={PAGE_SLOTS}
+      />
+    </ApplyPageContainer>
   );
 }

--- a/packages/twenty-website/src/app/[locale]/partners/apply/PartnerApplicationPageContent.tsx
+++ b/packages/twenty-website/src/app/[locale]/partners/apply/PartnerApplicationPageContent.tsx
@@ -17,7 +17,10 @@ function PassDescription({ render }: { render?: ReactElement }) {
 const PAGE_SLOTS = { Title: PassTitle, Description: PassDescription };
 
 const ApplyPageBackground = styled.div`
+  align-items: center;
   background: #0c0c0c;
+  display: flex;
+  justify-content: center;
   min-height: 100vh;
 `;
 
@@ -26,10 +29,9 @@ const ApplyPageContainer = styled.div`
   display: flex;
   flex-direction: column;
   gap: ${theme.spacing(4)};
-  margin-left: auto;
-  margin-right: auto;
   max-width: min(720px, 100%);
   padding: ${theme.spacing(5)} ${theme.spacing(4)};
+  width: 100%;
 
   @media (min-width: ${theme.breakpoints.md}px) {
     padding: ${theme.spacing(6)};

--- a/packages/twenty-website/src/app/[locale]/partners/apply/PartnerApplicationPageContent.tsx
+++ b/packages/twenty-website/src/app/[locale]/partners/apply/PartnerApplicationPageContent.tsx
@@ -4,7 +4,7 @@ import { PartnerApplicationWizard } from '@/sections/PartnerApplication/wizard/P
 import { theme } from '@/theme';
 import { styled } from '@linaria/react';
 import { useRouter } from 'next/navigation';
-import { useState, type ReactElement } from 'react';
+import { type ReactElement } from 'react';
 
 function PassTitle({ render }: { render?: ReactElement }) {
   return <>{render}</>;
@@ -52,13 +52,12 @@ const ApplyPageCard = styled.div`
 
 export function PartnerApplicationPageContent() {
   const router = useRouter();
-  const [resetSignal] = useState(0);
 
   return (
     <ApplyPageWrapper>
       <ApplyPageCard>
         <PartnerApplicationWizard
-          resetSignal={resetSignal}
+          resetSignal={0}
           onSuccess={() => router.push('/partners/list')}
           slots={PAGE_SLOTS}
         />

--- a/packages/twenty-website/src/app/[locale]/partners/apply/page.tsx
+++ b/packages/twenty-website/src/app/[locale]/partners/apply/page.tsx
@@ -1,9 +1,5 @@
 import { buildRouteMetadata } from '@/lib/seo';
 import { getRouteI18n, type LocaleRouteParams } from '@/lib/i18n/server';
-import { fetchCommunityStats } from '@/lib/community/fetch-community-stats';
-import { mergeSocialLinkLabels } from '@/lib/community/merge-social-link-labels';
-import { Menu, MENU_DATA } from '@/sections/Menu';
-import { theme } from '@/theme';
 import { PartnerApplicationPageContent } from './PartnerApplicationPageContent';
 
 export const generateMetadata = buildRouteMetadata('partnersApply', {
@@ -15,19 +11,7 @@ type ApplyPageProps = {
 };
 
 export default async function PartnerApplyPage({ params }: ApplyPageProps) {
-  const [, stats] = await Promise.all([
-    getRouteI18n(params),
-    fetchCommunityStats(),
-  ]);
-  const menuSocialLinks = mergeSocialLinkLabels(MENU_DATA.socialLinks, stats);
+  await getRouteI18n(params);
 
-  return (
-    <>
-      <Menu
-        backgroundColor={theme.colors.primary.background[100]}
-        socialLinks={menuSocialLinks}
-      />
-      <PartnerApplicationPageContent />
-    </>
-  );
+  return <PartnerApplicationPageContent />;
 }

--- a/packages/twenty-website/src/app/[locale]/partners/apply/page.tsx
+++ b/packages/twenty-website/src/app/[locale]/partners/apply/page.tsx
@@ -6,7 +6,9 @@ import { Menu, MENU_DATA } from '@/sections/Menu';
 import { theme } from '@/theme';
 import { PartnerApplicationPageContent } from './PartnerApplicationPageContent';
 
-export const generateMetadata = buildRouteMetadata('partnersApply');
+export const generateMetadata = buildRouteMetadata('partnersApply', {
+  extend: { robots: { index: false, follow: false } },
+});
 
 type ApplyPageProps = {
   params: Promise<LocaleRouteParams>;

--- a/packages/twenty-website/src/app/[locale]/partners/apply/page.tsx
+++ b/packages/twenty-website/src/app/[locale]/partners/apply/page.tsx
@@ -1,0 +1,31 @@
+import { buildRouteMetadata } from '@/lib/seo';
+import { getRouteI18n, type LocaleRouteParams } from '@/lib/i18n/server';
+import { fetchCommunityStats } from '@/lib/community/fetch-community-stats';
+import { mergeSocialLinkLabels } from '@/lib/community/merge-social-link-labels';
+import { Menu, MENU_DATA } from '@/sections/Menu';
+import { theme } from '@/theme';
+import { PartnerApplicationPageContent } from './PartnerApplicationPageContent';
+
+export const generateMetadata = buildRouteMetadata('partnersApply');
+
+type ApplyPageProps = {
+  params: Promise<LocaleRouteParams>;
+};
+
+export default async function PartnerApplyPage({ params }: ApplyPageProps) {
+  const [, stats] = await Promise.all([
+    getRouteI18n(params),
+    fetchCommunityStats(),
+  ]);
+  const menuSocialLinks = mergeSocialLinkLabels(MENU_DATA.socialLinks, stats);
+
+  return (
+    <>
+      <Menu
+        backgroundColor={theme.colors.primary.background[100]}
+        socialLinks={menuSocialLinks}
+      />
+      <PartnerApplicationPageContent />
+    </>
+  );
+}

--- a/packages/twenty-website/src/app/__tests__/robots.test.ts
+++ b/packages/twenty-website/src/app/__tests__/robots.test.ts
@@ -7,7 +7,12 @@ describe('robots', () => {
 
     expect(rule).toMatchObject({
       allow: '/',
-      disallow: ['/api/', '/partners/apply', '/halftone', '/enterprise/activate'],
+      disallow: [
+        '/api/',
+        '/partners/apply',
+        '/halftone',
+        '/enterprise/activate',
+      ],
       userAgent: '*',
     });
   });

--- a/packages/twenty-website/src/app/__tests__/robots.test.ts
+++ b/packages/twenty-website/src/app/__tests__/robots.test.ts
@@ -7,7 +7,7 @@ describe('robots', () => {
 
     expect(rule).toMatchObject({
       allow: '/',
-      disallow: ['/api/', '/halftone', '/enterprise/activate'],
+      disallow: ['/api/', '/partners/apply', '/halftone', '/enterprise/activate'],
       userAgent: '*',
     });
   });

--- a/packages/twenty-website/src/app/_components/FooterVisibilityGate.tsx
+++ b/packages/twenty-website/src/app/_components/FooterVisibilityGate.tsx
@@ -11,7 +11,7 @@ type FooterVisibilityGateProps = {
 export function FooterVisibilityGate({ children }: FooterVisibilityGateProps) {
   const route = useUnlocalizedPathname();
 
-  if (route === '/halftone') {
+  if (route === '/halftone' || route === '/partners/apply') {
     return null;
   }
 

--- a/packages/twenty-website/src/app/api/partner-application/__tests__/route.test.ts
+++ b/packages/twenty-website/src/app/api/partner-application/__tests__/route.test.ts
@@ -142,7 +142,7 @@ describe('POST /api/partner-application', () => {
   it('forwards a valid submission to the webhook with camelCase payload + header auth and returns 200', async () => {
     const fetchSpy = jest
       .fn()
-      .mockResolvedValue(new Response(null, { status: 200 }));
+      .mockResolvedValue(new Response(JSON.stringify({ ok: true, created: true, partnerId: 'test-id' }), { status: 200 }));
     global.fetch = fetchSpy;
 
     const { POST } = await loadRoute();
@@ -170,7 +170,7 @@ describe('POST /api/partner-application', () => {
   it('forwards rich optional wizard fields with camelCase keys', async () => {
     const fetchSpy = jest
       .fn()
-      .mockResolvedValue(new Response(null, { status: 200 }));
+      .mockResolvedValue(new Response(JSON.stringify({ ok: true, created: true, partnerId: 'test-id' }), { status: 200 }));
     global.fetch = fetchSpy;
 
     const { POST } = await loadRoute();
@@ -202,7 +202,7 @@ describe('POST /api/partner-application', () => {
   it('omits optional rich fields when not provided', async () => {
     const fetchSpy = jest
       .fn()
-      .mockResolvedValue(new Response(null, { status: 200 }));
+      .mockResolvedValue(new Response(JSON.stringify({ ok: true, created: true, partnerId: 'test-id' }), { status: 200 }));
     global.fetch = fetchSpy;
 
     const { POST } = await loadRoute();
@@ -246,7 +246,9 @@ describe('POST /api/partner-application', () => {
   it('rate-limits the same IP after the burst capacity is spent', async () => {
     global.fetch = jest
       .fn()
-      .mockResolvedValue(new Response(null, { status: 200 }));
+      .mockImplementation(() =>
+        Promise.resolve(new Response(JSON.stringify({ ok: true, created: true, partnerId: 'test-id' }), { status: 200 })),
+      );
     const { POST } = await loadRoute();
     const ip = '203.0.113.99';
     const statuses: number[] = [];
@@ -261,7 +263,7 @@ describe('POST /api/partner-application', () => {
   it('attaches a Retry-After header on 429 responses', async () => {
     global.fetch = jest
       .fn()
-      .mockResolvedValue(new Response(null, { status: 200 }));
+      .mockResolvedValue(new Response(JSON.stringify({ ok: true, created: true, partnerId: 'test-id' }), { status: 200 }));
     const { POST } = await loadRoute();
     const ip = '203.0.113.100';
     for (let i = 0; i < 5; i++) await POST(buildRequest({ ip }));

--- a/packages/twenty-website/src/app/api/partner-application/__tests__/route.test.ts
+++ b/packages/twenty-website/src/app/api/partner-application/__tests__/route.test.ts
@@ -142,7 +142,12 @@ describe('POST /api/partner-application', () => {
   it('forwards a valid submission to the webhook with camelCase payload + header auth and returns 200', async () => {
     const fetchSpy = jest
       .fn()
-      .mockResolvedValue(new Response(JSON.stringify({ ok: true, created: true, partnerId: 'test-id' }), { status: 200 }));
+      .mockResolvedValue(
+        new Response(
+          JSON.stringify({ ok: true, created: true, partnerId: 'test-id' }),
+          { status: 200 },
+        ),
+      );
     global.fetch = fetchSpy;
 
     const { POST } = await loadRoute();
@@ -170,7 +175,12 @@ describe('POST /api/partner-application', () => {
   it('forwards rich optional wizard fields with camelCase keys', async () => {
     const fetchSpy = jest
       .fn()
-      .mockResolvedValue(new Response(JSON.stringify({ ok: true, created: true, partnerId: 'test-id' }), { status: 200 }));
+      .mockResolvedValue(
+        new Response(
+          JSON.stringify({ ok: true, created: true, partnerId: 'test-id' }),
+          { status: 200 },
+        ),
+      );
     global.fetch = fetchSpy;
 
     const { POST } = await loadRoute();
@@ -202,7 +212,12 @@ describe('POST /api/partner-application', () => {
   it('omits optional rich fields when not provided', async () => {
     const fetchSpy = jest
       .fn()
-      .mockResolvedValue(new Response(JSON.stringify({ ok: true, created: true, partnerId: 'test-id' }), { status: 200 }));
+      .mockResolvedValue(
+        new Response(
+          JSON.stringify({ ok: true, created: true, partnerId: 'test-id' }),
+          { status: 200 },
+        ),
+      );
     global.fetch = fetchSpy;
 
     const { POST } = await loadRoute();
@@ -247,7 +262,12 @@ describe('POST /api/partner-application', () => {
     global.fetch = jest
       .fn()
       .mockImplementation(() =>
-        Promise.resolve(new Response(JSON.stringify({ ok: true, created: true, partnerId: 'test-id' }), { status: 200 })),
+        Promise.resolve(
+          new Response(
+            JSON.stringify({ ok: true, created: true, partnerId: 'test-id' }),
+            { status: 200 },
+          ),
+        ),
       );
     const { POST } = await loadRoute();
     const ip = '203.0.113.99';
@@ -263,7 +283,12 @@ describe('POST /api/partner-application', () => {
   it('attaches a Retry-After header on 429 responses', async () => {
     global.fetch = jest
       .fn()
-      .mockResolvedValue(new Response(JSON.stringify({ ok: true, created: true, partnerId: 'test-id' }), { status: 200 }));
+      .mockResolvedValue(
+        new Response(
+          JSON.stringify({ ok: true, created: true, partnerId: 'test-id' }),
+          { status: 200 },
+        ),
+      );
     const { POST } = await loadRoute();
     const ip = '203.0.113.100';
     for (let i = 0; i < 5; i++) await POST(buildRequest({ ip }));

--- a/packages/twenty-website/src/app/api/partner-application/route.ts
+++ b/packages/twenty-website/src/app/api/partner-application/route.ts
@@ -149,19 +149,46 @@ export async function POST(request: Request) {
     );
   }
 
+  let upstreamBody: string;
+  try {
+    upstreamBody = await upstream.response.text();
+  } catch {
+    upstreamBody = '';
+  }
+
   if (!upstream.response.ok) {
-    let upstreamBody = '';
-    try {
-      upstreamBody = await upstream.response.text();
-    } catch {
-      upstreamBody = '(could not read upstream body)';
-    }
     console.error(
       '[partner-application] upstream returned non-2xx',
       JSON.stringify({
         url: webhookUrl,
         status: upstream.response.status,
         statusText: upstream.response.statusText,
+        body: upstreamBody.slice(0, 2000),
+        payloadKeys: Object.keys(payload),
+      }),
+    );
+    return NextResponse.json(
+      { error: 'Partner application could not be submitted.' },
+      { status: 502 },
+    );
+  }
+
+  let logicResult: unknown;
+  try {
+    logicResult = JSON.parse(upstreamBody);
+  } catch {
+    logicResult = null;
+  }
+
+  if (
+    typeof logicResult !== 'object' ||
+    logicResult === null ||
+    (logicResult as Record<string, unknown>)['ok'] !== true
+  ) {
+    console.error(
+      '[partner-application] logic function returned non-ok result',
+      JSON.stringify({
+        url: webhookUrl,
         body: upstreamBody.slice(0, 2000),
         payloadKeys: Object.keys(payload),
       }),

--- a/packages/twenty-website/src/lib/website-routing/__tests__/website-routes.test.ts
+++ b/packages/twenty-website/src/lib/website-routing/__tests__/website-routes.test.ts
@@ -41,6 +41,7 @@ describe('website route registry', () => {
 
   it('derives robots disallow paths from routes marked private', () => {
     expect(getRobotsDisallowedRoutePaths()).toEqual([
+      '/partners/apply',
       '/halftone',
       '/enterprise/activate',
     ]);

--- a/packages/twenty-website/src/lib/website-routing/static-website-routes.ts
+++ b/packages/twenty-website/src/lib/website-routing/static-website-routes.ts
@@ -58,6 +58,16 @@ export const STATIC_WEBSITE_ROUTES = [
     indexed: true,
   },
   {
+    id: 'partnersApply',
+    path: '/partners/apply',
+    title: msg`Become a Twenty Partner — Application`,
+    description: msg`Apply to join the Twenty certified partner ecosystem.`,
+    changeFrequency: 'yearly',
+    priority: 0,
+    indexed: false,
+    robotsDisallow: true,
+  },
+  {
     id: 'releases',
     path: '/releases',
     title: msg`Twenty Releases — What's New in the Open Source CRM`,

--- a/packages/twenty-website/src/lib/website-routing/types.ts
+++ b/packages/twenty-website/src/lib/website-routing/types.ts
@@ -9,6 +9,7 @@ export type WebsiteRouteId =
   | 'pricing'
   | 'partners'
   | 'partnersList'
+  | 'partnersApply'
   | 'releases'
   | 'customers'
   | 'articles'

--- a/packages/twenty-website/src/sections/PartnerApplication/wizard/PartnerApplicationWizard.tsx
+++ b/packages/twenty-website/src/sections/PartnerApplication/wizard/PartnerApplicationWizard.tsx
@@ -150,16 +150,26 @@ function StepRenderer({
   }
 }
 
+type DialogPrimitive = React.ComponentType<{ render?: React.ReactElement }>;
+
+type WizardSlots = {
+  Title?: DialogPrimitive;
+  Description?: DialogPrimitive;
+};
+
 type WizardProps = {
   resetSignal: number;
   onSuccess: () => void;
+  slots?: WizardSlots;
 };
 
 export function PartnerApplicationWizard({
   resetSignal,
   onSuccess,
+  slots,
 }: WizardProps) {
   const { i18n } = useLingui();
+  const { Title = Modal.Title as DialogPrimitive, Description = Modal.Description as DialogPrimitive } = slots ?? {};
   const controller = usePartnerApplicationState();
   const {
     state,
@@ -247,7 +257,7 @@ export function PartnerApplicationWizard({
     return (
       <>
         <TitleBlock>
-          <Modal.Title
+          <Title
             render={
               <TitleHeadingWrapper>
                 <Heading as="h2" size="lg" weight="light">
@@ -286,7 +296,7 @@ export function PartnerApplicationWizard({
       <TitleBlock>
         {stepIndex === 0 ? (
           <>
-            <Modal.Title
+            <Title
               render={
                 <TitleHeadingWrapper>
                   <Heading as="h2" size="lg" weight="light">
@@ -301,7 +311,7 @@ export function PartnerApplicationWizard({
                 </TitleHeadingWrapper>
               }
             />
-            <Modal.Description
+            <Description
               render={
                 <SubtitleStack>
                   <Body size="md">
@@ -319,7 +329,7 @@ export function PartnerApplicationWizard({
           {stepIndex === 0 ? (
             <HeaderLabel>{stepLabelNode}</HeaderLabel>
           ) : (
-            <Modal.Title render={<HeaderLabel>{stepLabelNode}</HeaderLabel>} />
+            <Title render={<HeaderLabel>{stepLabelNode}</HeaderLabel>} />
           )}
           <StepIndicator stepCount={STEPS.length} activeStepIndex={stepIndex} />
         </HeaderStrip>

--- a/packages/twenty-website/src/sections/PartnerApplication/wizard/PartnerApplicationWizard.tsx
+++ b/packages/twenty-website/src/sections/PartnerApplication/wizard/PartnerApplicationWizard.tsx
@@ -169,7 +169,10 @@ export function PartnerApplicationWizard({
   slots,
 }: WizardProps) {
   const { i18n } = useLingui();
-  const { Title = Modal.Title as DialogPrimitive, Description = Modal.Description as DialogPrimitive } = slots ?? {};
+  const {
+    Title = Modal.Title as DialogPrimitive,
+    Description = Modal.Description as DialogPrimitive,
+  } = slots ?? {};
   const controller = usePartnerApplicationState();
   const {
     state,


### PR DESCRIPTION
## Summary

- Adds a standalone `/partners/apply` page — a shareable URL that opens the partner application wizard full-page (no modal, no nav, no footer), on a plain black background
- Adds a `slots` prop to `PartnerApplicationWizard` so it can render outside a `Dialog.Root` context (Base UI), keeping the existing modal on `/partners` completely untouched
- Surfaces logic function errors to the user: the API route now checks the webhook response body for `ok: true`, so a silent backend failure no longer shows a false success state

## Test plan

- [ ] `yarn jest --no-coverage` — 365/365 passing
- [ ] `npx oxlint -c .oxlintrc.json .` — 0 errors (1 pre-existing warning unrelated to this PR)
- [ ] `npx oxfmt --check .` — clean
- [ ] `npx tsc --noEmit` — clean
- [ ] Visit `/partners/apply` — wizard loads full-page on black background, no menu, no footer
- [ ] Complete the wizard and submit — redirects to `/partners/list`
- [ ] Visit `/partners` — "Become a partner" modal still opens normally