### PR TITLE
fix(ci): ensure ui-sb-test runs on push to main

### DIFF
--- a/.github/workflows/ci-ui.yaml
+++ b/.github/workflows/ci-ui.yaml
@@ -67,6 +67,7 @@ jobs:
     timeout-minutes: 30
     runs-on: ubuntu-latest
     needs: ui-sb-build
+    if: always() && needs.ui-sb-build.result == 'success'
     steps:
       - name: Fetch custom Github Actions and base branch history
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1


### PR DESCRIPTION
## Summary

- Add explicit `if: always() && needs.ui-sb-build.result == 'success'` to `ui-sb-test` job

## Context

After merging #21217, the main-branch Argos baseline pipeline doesn't work: `ui-sb-test` is silently skipped on push to main, so no `argos-screenshots-twenty-ui` artifact is produced.

**Root cause:** `changed-files-check` is skipped on push events (PR-only). `ui-sb-build` handles this with `if: always() && ...`, but `ui-sb-test` has no explicit `if` — GitHub Actions propagates the skip through the transitive dependency chain (`changed-files-check` → `ui-sb-build` → `ui-sb-test`).

## Test plan

- Merge this PR and verify the next push to main produces the `argos-screenshots-twenty-ui` artifact
- Verify `dispatch-main` successfully triggers ci-privileged with the artifact