### PR TITLE
fix(twenty-ui): prevent local visual diffs from polluting CI baselines

### DIFF
--- a/packages/twenty-ui/scripts/visual-diff.sh
+++ b/packages/twenty-ui/scripts/visual-diff.sh
@@ -12,20 +12,23 @@ ARGOS_API_BASE_URL="${ARGOS_API_BASE_URL:-http://127.0.0.1:4002/v2/}"
 ARGOS_TOKEN="${ARGOS_TOKEN:?ARGOS_TOKEN is required – set it in packages/twenty-ui/.env}"
 
 USERNAME=$(whoami)
-BRANCH="${ARGOS_BRANCH:-$(git rev-parse --abbrev-ref HEAD 2>/dev/null || echo "main")}"
+GIT_BRANCH="${ARGOS_BRANCH:-$(git rev-parse --abbrev-ref HEAD 2>/dev/null || echo "unknown")}"
 COMMIT="${ARGOS_COMMIT:-$(git rev-parse HEAD 2>/dev/null || echo "unknown")}"
+REFERENCE_COMMIT="${ARGOS_REFERENCE_COMMIT:-$(git merge-base HEAD main 2>/dev/null || echo "")}"
 
 export ARGOS_API_BASE_URL
 export ARGOS_TOKEN
 export ARGOS_BUILD_NAME="${USERNAME}/twenty-ui"
-export ARGOS_BRANCH="$BRANCH"
+export ARGOS_BRANCH="${USERNAME}/${GIT_BRANCH}"
 export ARGOS_COMMIT="$COMMIT"
+export ARGOS_REFERENCE_COMMIT="${REFERENCE_COMMIT}"
 
 echo "Argos visual diff"
 echo "  API:        $ARGOS_API_BASE_URL"
 echo "  Build name: $ARGOS_BUILD_NAME"
 echo "  Branch:     $ARGOS_BRANCH"
 echo "  Commit:     ${ARGOS_COMMIT:0:12}"
+echo "  Ref commit: ${ARGOS_REFERENCE_COMMIT:0:12}"
 echo ""
 
 npx http-server storybook-static --port 6007 --silent &

--- a/packages/twenty-ui/vitest.config.ts
+++ b/packages/twenty-ui/vitest.config.ts
@@ -31,6 +31,7 @@ export default defineConfig({
             buildName: process.env.ARGOS_BUILD_NAME || undefined,
             branch: process.env.ARGOS_BRANCH || undefined,
             commit: process.env.ARGOS_COMMIT || undefined,
+            referenceCommit: process.env.ARGOS_REFERENCE_COMMIT || undefined,
           }),
         ],
         test: {


### PR DESCRIPTION
## Summary

- **Username-prefix branches**: Local visual-diff builds now use `charles/main` instead of `main` as the branch name, preventing local runs from creating auto-approved reference builds that could overwrite CI baselines.
- **Local merge-base computation**: Computes `ARGOS_REFERENCE_COMMIT` via `git merge-base HEAD main` locally, so the Argos SDK skips `git fetch origin <branch>` — fixing the "fatal: couldn't find remote ref" error when running from non-pushed branches.
- **Pass `referenceCommit` to vitest plugin**: Ensures the locally computed merge-base is forwarded to the Argos upload.

## Test plan

- [x] Verified local visual-diff works from `main` branch (branch becomes `charles/main`, not auto-approved)
- [x] Verified local visual-diff works from a non-pushed branch (`test/local-only-visual-diff` → build uploaded successfully)