### PR TITLE
test: verify visual regression does NOT trigger for non-ui changes

### DIFF
--- a/packages/twenty-server/src/engine/core-modules/audit/README.md
+++ b/packages/twenty-server/src/engine/core-modules/audit/README.md
@@ -2,6 +2,8 @@
 
 This module provides analytics tracking functionality for the Twenty application.
 
+<!-- test: verify visual regression does not trigger for non-ui changes -->
+
 ## Usage
 
 ### Tracking Events


### PR DESCRIPTION
Test PR — only changes `packages/twenty-server/`. The CI UI workflow should run but `changed-files-check` should report `any_changed == false`, so `ui-sb-build` and `ui-sb-test` should be **skipped**. No visual regression dispatch should fire.

**Delete after verifying.**