### PR TITLE
test: verify visual regression DOES trigger for twenty-ui changes

### DIFF
--- a/packages/twenty-ui/src/display/checkmark/components/Checkmark.tsx
+++ b/packages/twenty-ui/src/display/checkmark/components/Checkmark.tsx
@@ -16,6 +16,7 @@ const StyledContainer = styled.div`
 `;
 
 export type CheckmarkProps = React.ComponentPropsWithoutRef<'div'> & {
+  /** Optional CSS class name for custom styling */
   className?: string;
 };
 


### PR DESCRIPTION
Test PR — changes `packages/twenty-ui/`. The CI UI workflow should run, `changed-files-check` should report `any_changed == true`, so `ui-sb-build` → `ui-sb-test` → visual regression dispatch should all fire.

This also validates the `ci-privileged` build polling fix ([#35](https://github.com/twentyhq/ci-privileged/pull/35)) once merged.

**Delete after verifying.**