### PR TITLE
feat(twenty-server): replace hard throttle with loop detection and prioritize manual triggers

### DIFF
--- a/packages/twenty-server/src/engine/core-modules/metrics/types/metrics-keys.type.ts
+++ b/packages/twenty-server/src/engine/core-modules/metrics/types/metrics-keys.type.ts
@@ -20,7 +20,7 @@ export enum MetricsKeys {
   WorkflowRunCompleted = 'workflow-run/completed',
   WorkflowRunFailed = 'workflow-run/failed',
   WorkflowRunStopped = 'workflow-run/stopped',
-  WorkflowRunThrottled = 'workflow-run/throttled',
+  WorkflowRunTriggerLoopDetected = 'workflow-run/trigger-loop-detected',
   WorkflowRunFailedToEnqueue = 'workflow-run/failed/to-enqueue',
   WorkflowRunSystemError = 'workflow-run/system-error',
   AiChatToolExecutionSucceeded = 'ai-chat/tool-execution-succeeded',

--- a/packages/twenty-server/src/engine/core-modules/twenty-config/config-variables.ts
+++ b/packages/twenty-server/src/engine/core-modules/twenty-config/config-variables.ts
@@ -1553,6 +1553,24 @@ export class ConfigVariables {
   @ConfigVariablesMetadata({
     group: ConfigVariablesGroup.RATE_LIMITING,
     description:
+      'Maximum triggers per workflow per time window before loop detection kicks in.',
+    type: ConfigVariableType.NUMBER,
+  })
+  @CastToPositiveNumber()
+  WORKFLOW_TRIGGER_LOOP_LIMIT = 500;
+
+  @ConfigVariablesMetadata({
+    group: ConfigVariablesGroup.RATE_LIMITING,
+    description:
+      'Time window in milliseconds for workflow trigger loop detection.',
+    type: ConfigVariableType.NUMBER,
+  })
+  @CastToPositiveNumber()
+  WORKFLOW_TRIGGER_LOOP_TTL = 60_000;
+
+  @ConfigVariablesMetadata({
+    group: ConfigVariablesGroup.RATE_LIMITING,
+    description:
       'Throttle limit for workflow execution. Remaining will not be enqueued immediately.',
     type: ConfigVariableType.NUMBER,
   })
@@ -1567,24 +1585,6 @@ export class ConfigVariables {
   })
   @CastToPositiveNumber()
   WORKFLOW_EXEC_SOFT_THROTTLE_TTL = 60_000;
-
-  @ConfigVariablesMetadata({
-    group: ConfigVariablesGroup.RATE_LIMITING,
-    description:
-      'Throttle limit for workflow execution. Remaining will be marked as failed.',
-    type: ConfigVariableType.NUMBER,
-  })
-  @CastToPositiveNumber()
-  WORKFLOW_EXEC_HARD_THROTTLE_LIMIT = 5000;
-
-  @ConfigVariablesMetadata({
-    group: ConfigVariablesGroup.RATE_LIMITING,
-    description:
-      'Time-to-live for workflow execution throttle in milliseconds. Remaining will be marked as failed.',
-    type: ConfigVariableType.NUMBER,
-  })
-  @CastToPositiveNumber()
-  WORKFLOW_EXEC_HARD_THROTTLE_TTL = 3_600_000; // 1 hour;
 
   @ConfigVariablesMetadata({
     group: ConfigVariablesGroup.CAPTCHA_CONFIG,

--- a/packages/twenty-server/src/modules/workflow/workflow-runner/workflow-run-queue/workspace-services/workflow-throttling.workspace-service.ts
+++ b/packages/twenty-server/src/modules/workflow/workflow-runner/workflow-run-queue/workspace-services/workflow-throttling.workspace-service.ts
@@ -40,12 +40,12 @@ export class WorkflowThrottlingWorkspaceService {
     );
   }
 
-  async throttleOrThrowIfHardLimitReached(workspaceId: string) {
+  async checkTriggerLoopOrThrow(workflowId: string) {
     await this.throttlerService.tokenBucketThrottleOrThrow(
-      this.getWorkflowExecutionHardThrottleCacheKey(workspaceId),
+      this.getWorkflowTriggerLoopCacheKey(workflowId),
       1,
-      this.twentyConfigService.get('WORKFLOW_EXEC_HARD_THROTTLE_LIMIT'),
-      this.twentyConfigService.get('WORKFLOW_EXEC_HARD_THROTTLE_TTL'),
+      this.twentyConfigService.get('WORKFLOW_TRIGGER_LOOP_LIMIT'),
+      this.twentyConfigService.get('WORKFLOW_TRIGGER_LOOP_TTL'),
     );
   }
 
@@ -172,9 +172,7 @@ export class WorkflowThrottlingWorkspaceService {
     return `workflow:execution-soft-throttle:${workspaceId}`;
   }
 
-  private getWorkflowExecutionHardThrottleCacheKey(
-    workspaceId: string,
-  ): string {
-    return `workflow:execution-hard-throttle:${workspaceId}`;
+  private getWorkflowTriggerLoopCacheKey(workflowId: string): string {
+    return `workflow:trigger-loop:${workflowId}`;
   }
 }

--- a/packages/twenty-server/src/modules/workflow/workflow-runner/workspace-services/workflow-runner.workspace-service.ts
+++ b/packages/twenty-server/src/modules/workflow/workflow-runner/workspace-services/workflow-runner.workspace-service.ts
@@ -80,11 +80,8 @@ export class WorkflowRunnerWorkspaceService {
     const isManualTrigger =
       workflowVersion.trigger?.type === WorkflowTriggerType.MANUAL;
 
-    const isHardThrottled = await this.checkHardThrottleLimit(workspaceId);
-
-    if (isHardThrottled) {
-      this.logger.log(`Workflow throttled for workspace ${workspaceId}`);
-      return this.createFailedWorkflowRun({
+    if (isManualTrigger) {
+      return this.enqueueWorkflowRun({
         workspaceId,
         workflowVersionId,
         initialWorkflowRunId,
@@ -93,13 +90,22 @@ export class WorkflowRunnerWorkspaceService {
       });
     }
 
-    if (isManualTrigger) {
-      return this.enqueueWorkflowRun({
+    const isTriggerLoop = await this.checkTriggerLoop(
+      workflowVersion.workflowId,
+    );
+
+    if (isTriggerLoop) {
+      this.logger.log(
+        `Trigger loop detected for workflow ${workflowVersion.workflowId} in workspace ${workspaceId}`,
+      );
+
+      return this.createFailedWorkflowRun({
         workspaceId,
         workflowVersionId,
         initialWorkflowRunId,
         source,
         payload,
+        error: 'Trigger loop detected',
       });
     }
 
@@ -261,17 +267,17 @@ export class WorkflowRunnerWorkspaceService {
     };
   }
 
-  private async checkHardThrottleLimit(workspaceId: string): Promise<boolean> {
+  private async checkTriggerLoop(workflowId: string): Promise<boolean> {
     try {
-      await this.workflowThrottlingWorkspaceService.throttleOrThrowIfHardLimitReached(
-        workspaceId,
+      await this.workflowThrottlingWorkspaceService.checkTriggerLoopOrThrow(
+        workflowId,
       );
 
       return false;
     } catch {
       void this.metricsService.incrementCounterForEvent({
-        key: MetricsKeys.WorkflowRunThrottled,
-        eventId: workspaceId,
+        key: MetricsKeys.WorkflowRunTriggerLoopDetected,
+        eventId: workflowId,
       });
 
       return true;
@@ -284,12 +290,14 @@ export class WorkflowRunnerWorkspaceService {
     initialWorkflowRunId,
     source,
     payload,
+    error,
   }: {
     workspaceId: string;
     workflowVersionId: string;
     initialWorkflowRunId?: string;
     source: ActorMetadata;
     payload: object;
+    error: string;
   }) {
     const workflowRunId =
       await this.workflowRunWorkspaceService.createWorkflowRun({
@@ -298,7 +306,7 @@ export class WorkflowRunnerWorkspaceService {
         createdBy: source,
         status: WorkflowRunStatus.FAILED,
         triggerPayload: payload,
-        error: 'Throttle limit reached',
+        error,
         workspaceId,
       });
 
@@ -334,6 +342,7 @@ export class WorkflowRunnerWorkspaceService {
         workspaceId,
         workflowRunId,
       },
+      { priority: 1 },
     );
 
     return { workflowRunId };


### PR DESCRIPTION
## Summary

- **Replace workspace-wide hard throttle** (5000 runs/hour) with two targeted loop detection mechanisms:
  - **Per-run step limit**: persisted `totalExecutedStepsCount` on `WorkflowRunState`, fails the run when exceeding `WORKFLOW_MAX_STEPS_PER_RUN` (default 10,000)
  - **Per-workflow trigger rate check**: token-bucket rate limit per `workflowId` (`WORKFLOW_TRIGGER_LOOP_LIMIT` = 500 triggers / 60s), catches DB-event trigger loops without blocking the whole workspace
- **Manual triggers bypass all throttling** and get higher BullMQ priority (1 vs default 2) so they jump ahead of queued automated runs
- Remove hard throttle config vars (`WORKFLOW_EXEC_HARD_THROTTLE_LIMIT`, `WORKFLOW_EXEC_HARD_THROTTLE_TTL`) and rename metric to `WorkflowRunTriggerLoopDetected`

## Motivation

The hard throttle was too blunt -- it punished legitimate high-volume usage and blocked manual triggers. Since we bill per workflow node run (usage-based), users should be able to run as much as they want. The real problems to solve are:
1. Infinite loops (DB event triggers writing back to the same object)
2. Runaway step execution within a single run

These are now handled precisely at the workflow/run level instead of the workspace level.

## Test plan

- [x] Existing executor unit tests pass (17/17)
- [ ] Verify manual triggers get priority 1 in BullMQ
- [ ] Verify trigger loop detection fires after 500 triggers of the same workflow in 60s
- [ ] Verify per-run step limit fails the run after 10,000 steps
- [ ] Verify soft throttle still works unchanged for automated triggers