### PR TITLE
fix: prevent workflow from disappearing after activation

### DIFF
--- a/packages/twenty-front/src/modules/workflow/hooks/useEffectiveDraftVersionId.ts
+++ b/packages/twenty-front/src/modules/workflow/hooks/useEffectiveDraftVersionId.ts
@@ -63,7 +63,13 @@ export const useEffectiveDraftVersionId = (
     return { effectiveDraftId: previouslyKnownDraftId, lastDiscardedDraftId };
   }
 
-  setLastDiscardedDraftId(previouslyKnownDraftId);
+  const wasDiscarded =
+    isDefined(cachedDraft) && isDefined(cachedDraft.deletedAt);
+
+  if (wasDiscarded) {
+    setLastDiscardedDraftId(previouslyKnownDraftId);
+  }
+
   setPreviouslyKnownDraftId(undefined);
 
   return { effectiveDraftId: undefined, lastDiscardedDraftId };


### PR DESCRIPTION
## Summary
- Fixes a regression from #21176 where activating a workflow caused it to disappear until page refresh
- Root cause: when a draft is activated (status DRAFT→ACTIVE), `useEffectiveDraftVersionId` incorrectly treated it as a discard because the cached version was no longer DRAFT, filtering it from the versions list
- Fix: only set `lastDiscardedDraftId` when `deletedAt` is actually set on the cached version, not when the status simply changes

## Test plan
- [x] Open a workflow with a DRAFT version
- [x] Activate the workflow → verify it does NOT disappear
- [x] Discard a draft → verify header does NOT flicker between DRAFT/ACTIVE