### PR TITLE
fix(ai-agent) - tool loading + caching

### DIFF
--- a/packages/twenty-server/src/engine/metadata-modules/ai/ai-agent-execution/services/agent-async-executor.service.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/ai/ai-agent-execution/services/agent-async-executor.service.ts
@@ -427,27 +427,14 @@ export class AgentAsyncExecutorService {
       categorySet.has(entry.category),
     );
 
-    const toolContext = {
-      workspaceId,
-      roleId: agentRoleId,
-      userId:
-        isDefined(authContext) && isUserAuthContext(authContext)
-          ? authContext.user.id
-          : undefined,
-      userWorkspaceId:
-        isDefined(authContext) && isUserAuthContext(authContext)
-          ? authContext.userWorkspaceId
-          : undefined,
-    };
-
     const tools: ToolSet = {
       [LEARN_TOOLS_TOOL_NAME]: createLearnToolsTool(
         this.toolRegistry,
-        toolContext,
+        toolProviderContext,
       ),
       [EXECUTE_TOOL_TOOL_NAME]: createExecuteToolTool(
         this.toolRegistry,
-        toolContext,
+        toolProviderContext,
         { compactOutput: true },
       ),
     };

--- a/packages/twenty-server/src/engine/metadata-modules/ai/ai-agent-execution/services/agent-async-executor.service.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/ai/ai-agent-execution/services/agent-async-executor.service.ts
@@ -8,7 +8,9 @@ import {
   Output,
   stepCountIs,
   type StepResult,
+  type SystemModelMessage,
   type ToolSet,
+  type UserModelMessage,
 } from 'ai';
 import { AUTO_SELECT_SMART_MODEL_ID } from 'twenty-shared/constants';
 import { type ActorMetadata } from 'twenty-shared/types';
@@ -20,10 +22,18 @@ import { type WorkspaceAuthContext } from 'src/engine/core-modules/auth/types/wo
 import { BillingUsageService } from 'src/engine/core-modules/billing/services/billing-usage.service';
 import { type ToolProviderContext } from 'src/engine/core-modules/tool-provider/interfaces/tool-provider-context.type';
 import { ToolRegistryService } from 'src/engine/core-modules/tool-provider/services/tool-registry.service';
+import {
+  createExecuteToolTool,
+  createLearnToolsTool,
+  EXECUTE_TOOL_TOOL_NAME,
+  LEARN_TOOLS_TOOL_NAME,
+} from 'src/engine/core-modules/tool-provider/tools';
+import { type ToolIndexEntry } from 'src/engine/core-modules/tool-provider/types/tool-index-entry.type';
 import { UsageOperationType } from 'src/engine/core-modules/usage/enums/usage-operation-type.enum';
 import { WorkspaceEntity } from 'src/engine/core-modules/workspace/workspace.entity';
 import { WORKFLOW_AGENT_REGISTRY_TOOL_CATEGORIES } from 'src/engine/metadata-modules/ai/ai-agent-execution/constants/workflow-agent-registry-tool-categories.const';
 import { type AgentExecutionResult } from 'src/engine/metadata-modules/ai/ai-agent-execution/types/agent-execution-result.type';
+import { buildAgentSystemPrompt } from 'src/engine/metadata-modules/ai/ai-agent-execution/utils/build-agent-system-prompt.util';
 import { AGENT_CONFIG } from 'src/engine/metadata-modules/ai/ai-agent/constants/agent-config.const';
 import { WORKFLOW_SYSTEM_PROMPTS } from 'src/engine/metadata-modules/ai/ai-agent/constants/agent-system-prompts.const';
 import { type AgentEntity } from 'src/engine/metadata-modules/ai/ai-agent/entities/agent.entity';
@@ -37,6 +47,10 @@ import {
   extractCacheCreationTokensFromSteps,
 } from 'src/engine/metadata-modules/ai/ai-billing/utils/extract-cache-creation-tokens.util';
 import { mergeLanguageModelUsage } from 'src/engine/metadata-modules/ai/ai-billing/utils/merge-language-model-usage.util';
+import {
+  getCacheProviderOptions,
+  getCallLevelCacheProviderOptions,
+} from 'src/engine/metadata-modules/ai/ai-chat/utils/inject-cache-breakpoint.util';
 import { AI_TELEMETRY_CONFIG } from 'src/engine/metadata-modules/ai/ai-models/constants/ai-telemetry.const';
 import { AiModelConfigService } from 'src/engine/metadata-modules/ai/ai-models/services/ai-model-config.service';
 import { AiModelRegistryService } from 'src/engine/metadata-modules/ai/ai-models/services/ai-model-registry.service';
@@ -144,51 +158,29 @@ export class AgentAsyncExecutorService {
       let tools: ToolSet = {};
       let providerOptions = {};
 
-      if (agent) {
-        const agentRoleId = await this.getAgentRoleId(
-          agent.id,
-          agent.workspaceId,
-        );
+      const agentRoleId = isDefined(agent)
+        ? await this.getAgentRoleId(agent.id, agent.workspaceId)
+        : undefined;
 
+      const { tools: registryTools, toolCatalog } =
+        await this.buildRegistryTools({
+          agentRoleId,
+          workspaceId,
+          authContext,
+          actorContext,
+        });
+
+      const systemPrompt = buildAgentSystemPrompt(
+        agent?.prompt ?? '',
+        toolCatalog,
+      );
+
+      if (isDefined(agent)) {
         const nativeModelToolOptions: NativeModelToolOptions = {
           webSearch: agent.modelConfiguration?.webSearch?.enabled === true,
           twitterSearch:
             agent.modelConfiguration?.twitterSearch?.enabled === true,
         };
-
-        let registryTools: ToolSet = {};
-
-        // Workflow agent registry tools are scoped exclusively by the agent
-        // permission-tab role. No role means no registry tools.
-        if (isDefined(agentRoleId)) {
-          const agentRolePermissionConfig: RolePermissionConfig = {
-            unionOf: [agentRoleId],
-          };
-
-          const toolProviderContext: ToolProviderContext = {
-            workspaceId: agent.workspaceId,
-            roleId: agentRoleId,
-            rolePermissionConfig: agentRolePermissionConfig,
-            authContext,
-            actorContext,
-            userId:
-              isDefined(authContext) && isUserAuthContext(authContext)
-                ? authContext.user.id
-                : undefined,
-            userWorkspaceId:
-              isDefined(authContext) && isUserAuthContext(authContext)
-                ? authContext.userWorkspaceId
-                : undefined,
-          };
-
-          registryTools = await this.toolRegistry.getToolsByCategories(
-            toolProviderContext,
-            {
-              categories: WORKFLOW_AGENT_REGISTRY_TOOL_CATEGORIES,
-              wrapWithErrorContext: false,
-            },
-          );
-        }
 
         const nativeTools = this.nativeToolBinder.bind(
           registeredModel,
@@ -200,21 +192,35 @@ export class AgentAsyncExecutorService {
           ...nativeTools,
         };
 
-        providerOptions =
-          this.aiModelConfigService.getReasoningProviderOptions(
+        providerOptions = {
+          ...this.aiModelConfigService.getReasoningProviderOptions(
             registeredModel,
-          );
+          ),
+          ...getCallLevelCacheProviderOptions(registeredModel.sdkPackage),
+        };
       }
 
-      this.logger.log(`Generated ${Object.keys(tools).length} tools for agent`);
+      this.logger.log(
+        `Generated ${Object.keys(tools).length} direct tools for agent`,
+      );
 
       let hasNoMoreAvailableCredits = false;
 
+      const systemMessage: SystemModelMessage = {
+        role: 'system',
+        content: systemPrompt,
+        providerOptions: getCacheProviderOptions(registeredModel.sdkPackage),
+      };
+
+      const userMessage: UserModelMessage = {
+        role: 'user',
+        content: [{ type: 'text', text: userPrompt }],
+      };
+
       const textResponse = await generateText({
-        system: `${WORKFLOW_SYSTEM_PROMPTS.BASE}\n\n${agent ? agent.prompt : ''}`,
-        tools,
         model: registeredModel.model,
-        prompt: userPrompt,
+        messages: [systemMessage, userMessage],
+        tools,
         stopWhen: (step) =>
           stepCountIs(AGENT_CONFIG.MAX_STEPS)(step) ||
           hasNoMoreAvailableCredits,
@@ -376,5 +382,76 @@ export class AgentAsyncExecutorService {
         userWorkspaceId,
       );
     }
+  }
+
+  private async buildRegistryTools({
+    agentRoleId,
+    workspaceId,
+    authContext,
+    actorContext,
+  }: {
+    agentRoleId: string | undefined;
+    workspaceId: string;
+    authContext?: WorkspaceAuthContext;
+    actorContext?: ActorMetadata;
+  }): Promise<{ tools: ToolSet; toolCatalog: ToolIndexEntry[] }> {
+    if (!isDefined(agentRoleId)) {
+      return { tools: {}, toolCatalog: [] };
+    }
+
+    const agentRolePermissionConfig: RolePermissionConfig = {
+      unionOf: [agentRoleId],
+    };
+
+    const toolProviderContext: ToolProviderContext = {
+      workspaceId,
+      roleId: agentRoleId,
+      rolePermissionConfig: agentRolePermissionConfig,
+      authContext,
+      actorContext,
+      userId:
+        isDefined(authContext) && isUserAuthContext(authContext)
+          ? authContext.user.id
+          : undefined,
+      userWorkspaceId:
+        isDefined(authContext) && isUserAuthContext(authContext)
+          ? authContext.userWorkspaceId
+          : undefined,
+    };
+
+    const fullCatalog = await this.toolRegistry.getCatalog(toolProviderContext);
+
+    const categorySet = new Set(WORKFLOW_AGENT_REGISTRY_TOOL_CATEGORIES);
+
+    const toolCatalog = fullCatalog.filter((entry) =>
+      categorySet.has(entry.category),
+    );
+
+    const toolContext = {
+      workspaceId,
+      roleId: agentRoleId,
+      userId:
+        isDefined(authContext) && isUserAuthContext(authContext)
+          ? authContext.user.id
+          : undefined,
+      userWorkspaceId:
+        isDefined(authContext) && isUserAuthContext(authContext)
+          ? authContext.userWorkspaceId
+          : undefined,
+    };
+
+    const tools: ToolSet = {
+      [LEARN_TOOLS_TOOL_NAME]: createLearnToolsTool(
+        this.toolRegistry,
+        toolContext,
+      ),
+      [EXECUTE_TOOL_TOOL_NAME]: createExecuteToolTool(
+        this.toolRegistry,
+        toolContext,
+        { compactOutput: true },
+      ),
+    };
+
+    return { tools, toolCatalog };
   }
 }

--- a/packages/twenty-server/src/engine/metadata-modules/ai/ai-agent-execution/utils/build-agent-system-prompt.util.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/ai/ai-agent-execution/utils/build-agent-system-prompt.util.ts
@@ -24,17 +24,14 @@ export const buildAgentSystemPrompt = (
 };
 
 const buildToolCatalogSection = (toolCatalog: ToolIndexEntry[]): string => {
-  const objectToolsMap = new Map<string, string[]>();
+  const objectNames = new Set<string>();
   const actionTools: ToolIndexEntry[] = [];
   const operationOrder: string[] = [];
   const seenOps = new Set<string>();
 
   for (const tool of toolCatalog) {
     if (tool.objectName && tool.operation) {
-      const ops = objectToolsMap.get(tool.objectName) ?? [];
-
-      ops.push(tool.operation);
-      objectToolsMap.set(tool.objectName, ops);
+      objectNames.add(tool.objectName);
 
       if (!seenOps.has(tool.operation)) {
         seenOps.add(tool.operation);
@@ -51,16 +48,16 @@ const buildToolCatalogSection = (toolCatalog: ToolIndexEntry[]): string => {
     `Use \`${LEARN_TOOLS_TOOL_NAME}\` to get the schema, then \`${EXECUTE_TOOL_TOOL_NAME}\` to call any tool below.`,
   ];
 
-  if (objectToolsMap.size > 0) {
-    const objectNames = [...objectToolsMap.keys()].sort();
+  if (objectNames.size > 0) {
+    const sortedObjectNames = [...objectNames].sort();
 
     lines.push('');
     lines.push('### Database CRUD');
     lines.push('Operations per object:');
     lines.push(...operationOrder.map((op) => `- \`${op}_{object}\``));
     lines.push('');
-    lines.push(`Objects (${objectNames.length}):`);
-    lines.push(...objectNames.map((name) => `- \`${name}\``));
+    lines.push(`Objects (${sortedObjectNames.length}):`);
+    lines.push(...sortedObjectNames.map((name) => `- \`${name}\``));
   }
 
   if (actionTools.length > 0) {

--- a/packages/twenty-server/src/engine/metadata-modules/ai/ai-agent-execution/utils/build-agent-system-prompt.util.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/ai/ai-agent-execution/utils/build-agent-system-prompt.util.ts
@@ -1,0 +1,75 @@
+import {
+  EXECUTE_TOOL_TOOL_NAME,
+  LEARN_TOOLS_TOOL_NAME,
+} from 'src/engine/core-modules/tool-provider/tools';
+import { type ToolIndexEntry } from 'src/engine/core-modules/tool-provider/types/tool-index-entry.type';
+
+import { WORKFLOW_SYSTEM_PROMPTS } from 'src/engine/metadata-modules/ai/ai-agent/constants/agent-system-prompts.const';
+
+export const buildAgentSystemPrompt = (
+  agentPrompt: string,
+  toolCatalog: ToolIndexEntry[],
+): string => {
+  const parts: string[] = [WORKFLOW_SYSTEM_PROMPTS.BASE];
+
+  if (toolCatalog.length > 0) {
+    parts.push(buildToolCatalogSection(toolCatalog));
+  }
+
+  if (agentPrompt) {
+    parts.push(agentPrompt);
+  }
+
+  return parts.join('\n\n');
+};
+
+const buildToolCatalogSection = (toolCatalog: ToolIndexEntry[]): string => {
+  const objectToolsMap = new Map<string, string[]>();
+  const actionTools: ToolIndexEntry[] = [];
+  const operationOrder: string[] = [];
+  const seenOps = new Set<string>();
+
+  for (const tool of toolCatalog) {
+    if (tool.objectName && tool.operation) {
+      const ops = objectToolsMap.get(tool.objectName) ?? [];
+
+      ops.push(tool.operation);
+      objectToolsMap.set(tool.objectName, ops);
+
+      if (!seenOps.has(tool.operation)) {
+        seenOps.add(tool.operation);
+        operationOrder.push(tool.operation);
+      }
+    } else {
+      actionTools.push(tool);
+    }
+  }
+
+  const lines: string[] = [
+    `## Available Tools (${toolCatalog.length} total)`,
+    '',
+    `Use \`${LEARN_TOOLS_TOOL_NAME}\` to get the schema, then \`${EXECUTE_TOOL_TOOL_NAME}\` to call any tool below.`,
+  ];
+
+  if (objectToolsMap.size > 0) {
+    const objectNames = [...objectToolsMap.keys()].sort();
+
+    lines.push('');
+    lines.push('### Database CRUD');
+    lines.push('Operations per object:');
+    lines.push(...operationOrder.map((op) => `- \`${op}_{object}\``));
+    lines.push('');
+    lines.push(`Objects (${objectNames.length}):`);
+    lines.push(...objectNames.map((name) => `- \`${name}\``));
+  }
+
+  if (actionTools.length > 0) {
+    lines.push('');
+    lines.push('### Action Tools');
+    lines.push(
+      ...actionTools.map((tool) => `- \`${tool.name}\`: ${tool.description}`),
+    );
+  }
+
+  return lines.join('\n');
+};

--- a/packages/twenty-server/src/engine/metadata-modules/ai/ai-agent/constants/agent-system-prompts.const.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/ai/ai-agent/constants/agent-system-prompts.const.ts
@@ -6,6 +6,7 @@ export const WORKFLOW_SYSTEM_PROMPTS = {
   BASE: `You are executing as part of a workflow automation in Twenty CRM.
 
 Tool usage strategy:
+- To use a tool, first call \`learn_tools\` with the exact tool name(s) to learn the input schema, then call \`execute_tool\` with the tool name and arguments.
 - Chain multiple tools to solve complex tasks
 - Prefer batch tools (\`create_many_*\`, \`update_many_*\`, \`upsert_many_*\`, etc.) over looping single-item calls
 - Use \`upsert_many_*\` instead of \`update_many_*\` when records have different data to set individually, or when some records may not exist yet


### PR DESCRIPTION
**Lazy tool loading (learn_tools → execute_tool)**
File: agent-async-executor.service.ts
Before: All ~190 CRUD + action tools loaded eagerly with full JSON schemas via getToolsByCategories({ includeSchemas: true }) and passed directly to generateText({ tools })
After: Only 2 meta-tools (learn_tools, execute_tool) + native tools passed directly. A lightweight catalog (names only, no schemas) is fetched via getCatalog() and listed in the system prompt so the model knows what's available.

**System prompt with tool catalog**
File: agent-system-prompts.const.ts + new buildSystemPrompt/buildToolCatalogSection methods
Added instruction: "To use a tool, first call learn_tools... then call execute_tool..."
System prompt now includes a compact listing of all available tools (operation names + object names), not full schemas.

**Full Anthropic/Bedrock cache setup (matching AI chat exactly)**
File: agent-async-executor.service.ts
providerOptions (call-level) — Anthropic — cacheControl: { type: 'ephemeral' } — enables automatic prefix caching
systemMessage.providerOptions — Bedrock — cachePoint: { type: 'default' } — caches system prompt

**Token savings**
****Tool definitions sent per step:****
Before: ~190 tools × full JSON schemas (~150K-250K tokens)
After: 2 tools with tiny schemas (~500 tokens)
**System prompt:**
Before: ~200 tokens (no catalog)
After: ~1,500 tokens (compact catalog listing)
**Total prefix per step:**
Before: ~150K-250K tokens
After: ~2,000 tokens
**Cache hit benefit (Anthropic):**
Before: None (no caching)
After: 90% discount on cached prefix from step 2+

Trade-off: The model needs 1-2 extra tool calls per unique tool used (learn schema, then execute). But for a 10-step agent that uses 3-4 different tools, that's ~8 extra tool calls vs. saving ~1.5M+ input tokens.