### PR TITLE
fix: use canonical oxlint rule id in lint-disable directives

### DIFF
--- a/packages/twenty-front/src/loading/components/__stories__/Loading.stories.tsx
+++ b/packages/twenty-front/src/loading/components/__stories__/Loading.stories.tsx
@@ -30,7 +30,7 @@ export default meta;
 export type Story = StoryObj<typeof RecordIndexPage>;
 
 export const Default: Story = {
-  // oxlint-disable-next-line @typescripttypescript/ban-ts-comment
+  // oxlint-disable-next-line typescript/ban-ts-comment
   // @ts-ignore
   decorators: [LoadingDecorator, PageDecorator],
   play: async ({ canvasElement }) => {

--- a/packages/twenty-front/src/loading/components/__stories__/UserOrMetadataLoader.stories.tsx
+++ b/packages/twenty-front/src/loading/components/__stories__/UserOrMetadataLoader.stories.tsx
@@ -79,7 +79,7 @@ export type Story = StoryObj<typeof RecordIndexPage>;
 
 export const Default: Story = {
   parameters: userMetadataLoaderMocks,
-  // oxlint-disable-next-line @typescripttypescript/ban-ts-comment
+  // oxlint-disable-next-line typescript/ban-ts-comment
   // @ts-ignore
   decorators: [PageDecorator],
   play: async ({ canvasElement }) => {

--- a/packages/twenty-front/src/modules/ui/navigation/step-bar/components/StepBar.tsx
+++ b/packages/twenty-front/src/modules/ui/navigation/step-bar/components/StepBar.tsx
@@ -32,7 +32,7 @@ export const StepBar = ({ activeStep, children }: StepBarProps) => {
         }
 
         // If the child is not a Step, return it as-is
-        // oxlint-disable-next-line @typescripttypescript/ban-ts-comment
+        // oxlint-disable-next-line typescript/ban-ts-comment
         // @ts-expect-error
         if (child.type?.displayName !== Step.displayName) {
           return child;

--- a/packages/twenty-front/src/pages/object-record/__stories__/RecordShowPage.stories.tsx
+++ b/packages/twenty-front/src/pages/object-record/__stories__/RecordShowPage.stories.tsx
@@ -64,7 +64,7 @@ export type Story = StoryObj<typeof RecordShowPage>;
 
 // TEMP_DISABLED_TEST: Temporarily commented out due to test failure
 // export const Default: Story = {
-//   // oxlint-disable-next-line @typescripttypescript/ban-ts-comment
+//   // oxlint-disable-next-line typescript/ban-ts-comment
 //   // @ts-ignore
 //   decorators: [PageDecorator, ContextStoreDecorator],
 //   play: async ({ canvasElement }) => {

--- a/packages/twenty-front/src/testing/mock-data/workflow-run.ts
+++ b/packages/twenty-front/src/testing/mock-data/workflow-run.ts
@@ -1,4 +1,4 @@
-// oxlint-disable-next-line @typescripttypescript/ban-ts-comment
+// oxlint-disable-next-line typescript/ban-ts-comment
 // @ts-ignore
 import { type WorkflowRun } from '@/workflow/types/Workflow';
 import { StepStatus } from 'twenty-shared/workflow';

--- a/packages/twenty-server/src/database/clickHouse/clickHouse.service.ts
+++ b/packages/twenty-server/src/database/clickHouse/clickHouse.service.ts
@@ -139,7 +139,7 @@ export class ClickHouseService implements OnModuleInit, OnModuleDestroy {
     }
   }
 
-  // oxlint-disable-next-line @typescripttypescript/no-explicit-any
+  // oxlint-disable-next-line typescript/no-explicit-any
   public async insert<T extends Record<string, any>>(
     table: string,
     values: T[],
@@ -170,7 +170,7 @@ export class ClickHouseService implements OnModuleInit, OnModuleDestroy {
   // Method to execute a select query
   public async select<T>(
     query: string,
-    // oxlint-disable-next-line @typescripttypescript/no-explicit-any
+    // oxlint-disable-next-line typescript/no-explicit-any
     params?: Record<string, any>,
     clientId?: string,
   ): Promise<T[]> {
@@ -237,7 +237,7 @@ export class ClickHouseService implements OnModuleInit, OnModuleDestroy {
 
   public async executeCommand(
     query: string,
-    // oxlint-disable-next-line @typescripttypescript/no-explicit-any
+    // oxlint-disable-next-line typescript/no-explicit-any
     params?: Record<string, any>,
     clientId?: string,
   ): Promise<boolean> {
@@ -263,7 +263,7 @@ export class ClickHouseService implements OnModuleInit, OnModuleDestroy {
     }
   }
 
-  // oxlint-disable-next-line @typescripttypescript/no-explicit-any
+  // oxlint-disable-next-line typescript/no-explicit-any
   private async insertInChunks<T extends Record<string, any>>(
     client: ClickHouseClient,
     table: string,

--- a/packages/twenty-server/src/database/commands/logger.ts
+++ b/packages/twenty-server/src/database/commands/logger.ts
@@ -21,7 +21,7 @@ export class CommandLogger {
     this.verboseFlag = options.verbose ?? false;
   }
 
-  // oxlint-disable-next-line @typescripttypescript/no-explicit-any
+  // oxlint-disable-next-line typescript/no-explicit-any
   log(message: string, ...optionalParams: [...any, string?]) {
     this.logger.log(message, ...optionalParams);
   }
@@ -30,17 +30,17 @@ export class CommandLogger {
     this.logger.error(message, stack, context);
   }
 
-  // oxlint-disable-next-line @typescripttypescript/no-explicit-any
+  // oxlint-disable-next-line typescript/no-explicit-any
   warn(message: string, ...optionalParams: [...any, string?]) {
     this.logger.warn(message, ...optionalParams);
   }
 
-  // oxlint-disable-next-line @typescripttypescript/no-explicit-any
+  // oxlint-disable-next-line typescript/no-explicit-any
   debug(message: string, ...optionalParams: [...any, string?]) {
     this.logger.debug(message, ...optionalParams);
   }
 
-  // oxlint-disable-next-line @typescripttypescript/no-explicit-any
+  // oxlint-disable-next-line typescript/no-explicit-any
   verbose(message: string, ...optionalParams: [...any, string?]) {
     if (this.verboseFlag) {
       this.logger.log(message, ...optionalParams);

--- a/packages/twenty-server/src/engine/api/common/common-args-processors/query-runner-args.factory.ts
+++ b/packages/twenty-server/src/engine/api/common/common-args-processors/query-runner-args.factory.ts
@@ -14,7 +14,7 @@ export class QueryRunnerArgsFactory {
 
   async overrideValueByFieldMetadata(
     key: string,
-    // oxlint-disable-next-line @typescripttypescript/no-explicit-any
+    // oxlint-disable-next-line typescript/no-explicit-any
     value: any,
     fieldIdByName: Record<string, string>,
     flatObjectMetadata: FlatObjectMetadata,

--- a/packages/twenty-server/src/engine/api/common/common-nested-relations-processor/process-nested-relations-v2.helper.ts
+++ b/packages/twenty-server/src/engine/api/common/common-nested-relations-processor/process-nested-relations-v2.helper.ts
@@ -52,7 +52,7 @@ export class ProcessNestedRelationsV2Helper {
     flatFieldMetadataMaps: FlatEntityMaps<FlatFieldMetadata>;
     parentObjectMetadataItem: FlatObjectMetadata;
     parentObjectRecords: T[];
-    // oxlint-disable-next-line @typescripttypescript/no-explicit-any
+    // oxlint-disable-next-line typescript/no-explicit-any
     parentObjectRecordsAggregatedValues?: Record<string, any>;
     relations: Record<string, FindOptionsRelations<ObjectLiteral>>;
     aggregate?: Record<string, AggregationField>;
@@ -60,7 +60,7 @@ export class ProcessNestedRelationsV2Helper {
     authContext: WorkspaceAuthContext;
     workspaceDataSource: GlobalWorkspaceDataSource;
     rolePermissionConfig?: RolePermissionConfig;
-    // oxlint-disable-next-line @typescripttypescript/no-explicit-any
+    // oxlint-disable-next-line typescript/no-explicit-any
     selectedFields: Record<string, any>;
   }): Promise<void> {
     const processRelationTasks = Object.entries(relations).map(
@@ -107,7 +107,7 @@ export class ProcessNestedRelationsV2Helper {
     flatFieldMetadataMaps: FlatEntityMaps<FlatFieldMetadata>;
     parentObjectMetadataItem: FlatObjectMetadata;
     parentObjectRecords: T[];
-    // oxlint-disable-next-line @typescripttypescript/no-explicit-any
+    // oxlint-disable-next-line typescript/no-explicit-any
     parentObjectRecordsAggregatedValues: Record<string, any>;
     sourceFieldName: string;
     nestedRelations: FindOptionsRelations<ObjectLiteral>;
@@ -333,7 +333,7 @@ export class ProcessNestedRelationsV2Helper {
   }: {
     records: ObjectRecord[];
     idField: string;
-    // oxlint-disable-next-line @typescripttypescript/no-explicit-any
+    // oxlint-disable-next-line typescript/no-explicit-any
   }): any[] {
     return [...new Set(records.map((item) => item[idField]))];
   }
@@ -347,24 +347,24 @@ export class ProcessNestedRelationsV2Helper {
     sourceFieldName,
     targetObjectNameSingular,
   }: {
-    // oxlint-disable-next-line @typescripttypescript/no-explicit-any
+    // oxlint-disable-next-line typescript/no-explicit-any
     referenceQueryBuilder: WorkspaceSelectQueryBuilder<any>;
     column: string;
-    // oxlint-disable-next-line @typescripttypescript/no-explicit-any
+    // oxlint-disable-next-line typescript/no-explicit-any
     ids: any[];
     limit: number;
-    // oxlint-disable-next-line @typescripttypescript/no-explicit-any
+    // oxlint-disable-next-line typescript/no-explicit-any
     aggregate: Record<string, any>;
     sourceFieldName: string;
     targetObjectNameSingular: string;
-    // oxlint-disable-next-line @typescripttypescript/no-explicit-any
+    // oxlint-disable-next-line typescript/no-explicit-any
   }): Promise<{ relationResults: any[]; relationAggregatedFieldsResult: any }> {
     if (ids.length === 0) {
       return { relationResults: [], relationAggregatedFieldsResult: {} };
     }
 
     const aggregateForRelation = aggregate[sourceFieldName];
-    // oxlint-disable-next-line @typescripttypescript/no-explicit-any
+    // oxlint-disable-next-line typescript/no-explicit-any
     let relationAggregatedFieldsResult: Record<string, any> = {};
 
     if (aggregateForRelation) {
@@ -427,11 +427,11 @@ export class ProcessNestedRelationsV2Helper {
     selectedFields,
   }: {
     parentRecords: ObjectRecord[];
-    // oxlint-disable-next-line @typescripttypescript/no-explicit-any
+    // oxlint-disable-next-line typescript/no-explicit-any
     parentObjectRecordsAggregatedValues: Record<string, any>;
-    // oxlint-disable-next-line @typescripttypescript/no-explicit-any
+    // oxlint-disable-next-line typescript/no-explicit-any
     relationResults: any[];
-    // oxlint-disable-next-line @typescripttypescript/no-explicit-any
+    // oxlint-disable-next-line typescript/no-explicit-any
     relationAggregatedFieldsResult: Record<string, any>;
     sourceFieldName: string;
     joinField: string;

--- a/packages/twenty-server/src/engine/api/common/common-nested-relations-processor/process-nested-relations.helper.ts
+++ b/packages/twenty-server/src/engine/api/common/common-nested-relations-processor/process-nested-relations.helper.ts
@@ -36,7 +36,7 @@ export class ProcessNestedRelationsHelper {
     flatFieldMetadataMaps: FlatEntityMaps<FlatFieldMetadata>;
     parentObjectMetadataItem: FlatObjectMetadata;
     parentObjectRecords: T[];
-    // oxlint-disable-next-line @typescripttypescript/no-explicit-any
+    // oxlint-disable-next-line typescript/no-explicit-any
     parentObjectRecordsAggregatedValues?: Record<string, any>;
     relations: Record<string, FindOptionsRelations<ObjectLiteral>>;
     aggregate?: Record<string, AggregationField>;
@@ -44,7 +44,7 @@ export class ProcessNestedRelationsHelper {
     authContext: WorkspaceAuthContext;
     workspaceDataSource: GlobalWorkspaceDataSource;
     rolePermissionConfig?: RolePermissionConfig;
-    // oxlint-disable-next-line @typescripttypescript/no-explicit-any
+    // oxlint-disable-next-line typescript/no-explicit-any
     selectedFields: Record<string, any>;
   }): Promise<void> {
     return this.processNestedRelationsV2Helper.processNestedRelations({

--- a/packages/twenty-server/src/engine/api/common/common-result-getters/handlers/field-handlers/rich-text-field-query-result-getter.handler.ts
+++ b/packages/twenty-server/src/engine/api/common/common-result-getters/handlers/field-handlers/rich-text-field-query-result-getter.handler.ts
@@ -11,7 +11,7 @@ import { type FileUrlService } from 'src/engine/core-modules/file/file-url/file-
 import { extractFileIdFromUrl } from 'src/engine/core-modules/file/files-field/utils/extract-file-id-from-url.util';
 import { type FlatFieldMetadata } from 'src/engine/metadata-modules/flat-field-metadata/types/flat-field-metadata.type';
 
-// oxlint-disable-next-line @typescripttypescript/no-explicit-any
+// oxlint-disable-next-line typescript/no-explicit-any
 type RichTextBlock = Record<string, any>;
 
 const parseBlocknoteJsonSafely = (

--- a/packages/twenty-server/src/engine/api/graphql/graphql-config/hooks/use-cached-metadata.ts
+++ b/packages/twenty-server/src/engine/api/graphql/graphql-config/hooks/use-cached-metadata.ts
@@ -7,9 +7,9 @@ import { isDefined } from 'twenty-shared/utils';
 import { InternalServerError } from 'src/engine/core-modules/graphql/utils/graphql-errors.util';
 
 export type CacheMetadataPluginConfig = {
-  // oxlint-disable-next-line @typescripttypescript/no-explicit-any
+  // oxlint-disable-next-line typescript/no-explicit-any
   cacheGetter: (key: string) => any;
-  // oxlint-disable-next-line @typescripttypescript/no-explicit-any
+  // oxlint-disable-next-line typescript/no-explicit-any
   cacheSetter: (key: string, value: any) => void;
   operationsToCache: string[];
 };
@@ -41,7 +41,7 @@ export function useCachedMetadata(config: CacheMetadataPluginConfig): Plugin {
     return `graphql:operations:${operationName}:${workspace.id}:${workspaceMetadataVersion}:${locale}:${queryHash}`;
   };
 
-  // oxlint-disable-next-line @typescripttypescript/no-explicit-any
+  // oxlint-disable-next-line typescript/no-explicit-any
   const getOperationName = (serverContext: any) =>
     serverContext?.req?.body?.operationName;
 

--- a/packages/twenty-server/src/engine/api/graphql/graphql-query-runner/graphql-query-parsers/graphql-query-filter/graphql-query-filter-condition.parser.ts
+++ b/packages/twenty-server/src/engine/api/graphql/graphql-query-runner/graphql-query-parsers/graphql-query-filter/graphql-query-filter-condition.parser.ts
@@ -77,7 +77,7 @@ export class GraphqlQueryFilterConditionParser {
     outerQueryBuilder: WorkspaceSelectQueryBuilder<ObjectLiteral>,
     objectNameSingular: string,
     key: string,
-    // oxlint-disable-next-line @typescripttypescript/no-explicit-any
+    // oxlint-disable-next-line typescript/no-explicit-any
     value: any,
     isFirst = false,
   ): void {

--- a/packages/twenty-server/src/engine/api/graphql/graphql-query-runner/graphql-query-parsers/graphql-query-filter/graphql-query-filter-field.parser.ts
+++ b/packages/twenty-server/src/engine/api/graphql/graphql-query-runner/graphql-query-parsers/graphql-query-filter/graphql-query-filter-field.parser.ts
@@ -60,7 +60,7 @@ export class GraphqlQueryFilterFieldParser {
     outerQueryBuilder: WorkspaceSelectQueryBuilder<ObjectLiteral>,
     objectNameSingular: string,
     key: string,
-    // oxlint-disable-next-line @typescripttypescript/no-explicit-any
+    // oxlint-disable-next-line typescript/no-explicit-any
     filterValue: any,
     isFirst = false,
     useDirectTableReference = false,
@@ -214,7 +214,7 @@ export class GraphqlQueryFilterFieldParser {
     queryBuilder: WhereExpressionBuilder,
     fieldMetadata: FlatFieldMetadata,
     objectNameSingular: string,
-    // oxlint-disable-next-line @typescripttypescript/no-explicit-any
+    // oxlint-disable-next-line typescript/no-explicit-any
     fieldValue: any,
     isFirst = false,
     useDirectTableReference = false,
@@ -243,7 +243,7 @@ export class GraphqlQueryFilterFieldParser {
       const fullFieldName = `${fieldMetadata.name}${capitalize(subFieldKey)}`;
 
       const [[operator, value]] = Object.entries(
-        // oxlint-disable-next-line @typescripttypescript/no-explicit-any
+        // oxlint-disable-next-line typescript/no-explicit-any
         subFieldFilter as Record<string, any>,
       );
 

--- a/packages/twenty-server/src/engine/api/graphql/graphql-query-runner/graphql-query-parsers/graphql-query-selected-fields/graphql-selected-fields-aggregate.parser.ts
+++ b/packages/twenty-server/src/engine/api/graphql/graphql-query-runner/graphql-query-parsers/graphql-query-selected-fields/graphql-selected-fields-aggregate.parser.ts
@@ -12,7 +12,7 @@ import { type FlatObjectMetadata } from 'src/engine/metadata-modules/flat-object
 
 export class GraphqlQuerySelectedFieldsAggregateParser {
   parse(
-    // oxlint-disable-next-line @typescripttypescript/no-explicit-any
+    // oxlint-disable-next-line typescript/no-explicit-any
     graphqlSelectedFields: Partial<Record<string, any>>,
     flatObjectMetadata: FlatObjectMetadata,
     flatFieldMetadataMaps: FlatEntityMaps<FlatFieldMetadata>,

--- a/packages/twenty-server/src/engine/api/graphql/graphql-query-runner/graphql-query-parsers/graphql-query-selected-fields/graphql-selected-fields-relation.parser.ts
+++ b/packages/twenty-server/src/engine/api/graphql/graphql-query-runner/graphql-query-parsers/graphql-query-selected-fields/graphql-selected-fields-relation.parser.ts
@@ -27,7 +27,7 @@ export class GraphqlQuerySelectedFieldsRelationParser {
       | FlatFieldMetadata<FieldMetadataType.RELATION>
       | FlatFieldMetadata<FieldMetadataType.MORPH_RELATION>,
     fieldKey: string,
-    // oxlint-disable-next-line @typescripttypescript/no-explicit-any
+    // oxlint-disable-next-line typescript/no-explicit-any
     fieldValue: any,
     accumulator: GraphqlQuerySelectedFieldsResult,
     isFromOneToManyRelation?: boolean,

--- a/packages/twenty-server/src/engine/api/graphql/graphql-query-runner/graphql-query-parsers/graphql-query-selected-fields/graphql-selected-fields.parser.ts
+++ b/packages/twenty-server/src/engine/api/graphql/graphql-query-runner/graphql-query-parsers/graphql-query-selected-fields/graphql-selected-fields.parser.ts
@@ -17,11 +17,11 @@ import { isFlatFieldMetadataOfType } from 'src/engine/metadata-modules/flat-fiel
 import { type FlatObjectMetadata } from 'src/engine/metadata-modules/flat-object-metadata/types/flat-object-metadata.type';
 
 export type GraphqlQuerySelectedFieldsResult = {
-  // oxlint-disable-next-line @typescripttypescript/no-explicit-any
+  // oxlint-disable-next-line typescript/no-explicit-any
   select: Record<string, any>;
-  // oxlint-disable-next-line @typescripttypescript/no-explicit-any
+  // oxlint-disable-next-line typescript/no-explicit-any
   relations: Record<string, any>;
-  // oxlint-disable-next-line @typescripttypescript/no-explicit-any
+  // oxlint-disable-next-line typescript/no-explicit-any
   aggregate: Record<string, any>;
   relationFieldsCount: number;
   hasAtLeastTwoNestedOneToManyRelations: boolean;
@@ -48,7 +48,7 @@ export class GraphqlQuerySelectedFieldsParser {
   }
 
   parse(
-    // oxlint-disable-next-line @typescripttypescript/no-explicit-any
+    // oxlint-disable-next-line typescript/no-explicit-any
     graphqlSelectedFields: Partial<Record<string, any>>,
     flatObjectMetadata: FlatObjectMetadata,
     isFromOneToManyRelation?: boolean,
@@ -90,7 +90,7 @@ export class GraphqlQuerySelectedFieldsParser {
   }
 
   private parseRecordFields(
-    // oxlint-disable-next-line @typescripttypescript/no-explicit-any
+    // oxlint-disable-next-line typescript/no-explicit-any
     graphqlSelectedFields: Partial<Record<string, any>>,
     flatObjectMetadata: FlatObjectMetadata,
     accumulator: GraphqlQuerySelectedFieldsResult,
@@ -203,7 +203,7 @@ export class GraphqlQuerySelectedFieldsParser {
   }
 
   private parseConnectionField(
-    // oxlint-disable-next-line @typescripttypescript/no-explicit-any
+    // oxlint-disable-next-line typescript/no-explicit-any
     graphqlSelectedFields: Partial<Record<string, any>>,
     flatObjectMetadata: FlatObjectMetadata,
     accumulator: GraphqlQuerySelectedFieldsResult,
@@ -227,7 +227,7 @@ export class GraphqlQuerySelectedFieldsParser {
   }
 
   private isRootConnection(
-    // oxlint-disable-next-line @typescripttypescript/no-explicit-any
+    // oxlint-disable-next-line typescript/no-explicit-any
     graphqlSelectedFields: Partial<Record<string, any>>,
   ): boolean {
     return Object.keys(graphqlSelectedFields).includes('edges');
@@ -235,9 +235,9 @@ export class GraphqlQuerySelectedFieldsParser {
 
   private parseCompositeField(
     fieldMetadata: FlatFieldMetadata,
-    // oxlint-disable-next-line @typescripttypescript/no-explicit-any
+    // oxlint-disable-next-line typescript/no-explicit-any
     fieldValue: any,
-    // oxlint-disable-next-line @typescripttypescript/no-explicit-any
+    // oxlint-disable-next-line typescript/no-explicit-any
   ): Record<string, any> {
     const compositeType = compositeTypeDefinitions.get(
       fieldMetadata.type as CompositeFieldMetadataType,
@@ -269,7 +269,7 @@ export class GraphqlQuerySelectedFieldsParser {
 
           return acc;
         },
-        // oxlint-disable-next-line @typescripttypescript/no-explicit-any
+        // oxlint-disable-next-line typescript/no-explicit-any
         {} as Record<string, any>,
       );
   }

--- a/packages/twenty-server/src/engine/api/graphql/graphql-query-runner/graphql-query-parsers/graphql-query.parser.ts
+++ b/packages/twenty-server/src/engine/api/graphql/graphql-query-runner/graphql-query-parsers/graphql-query.parser.ts
@@ -61,11 +61,11 @@ export class GraphqlQueryParser {
   }
 
   public applyFilterToBuilder(
-    // oxlint-disable-next-line @typescripttypescript/no-explicit-any
+    // oxlint-disable-next-line typescript/no-explicit-any
     queryBuilder: WorkspaceSelectQueryBuilder<any>,
     objectNameSingular: string,
     recordFilter: Partial<ObjectRecordFilter>,
-    // oxlint-disable-next-line @typescripttypescript/no-explicit-any
+    // oxlint-disable-next-line typescript/no-explicit-any
   ): WorkspaceSelectQueryBuilder<any> {
     return this.filterConditionParser.parse(
       queryBuilder,
@@ -75,10 +75,10 @@ export class GraphqlQueryParser {
   }
 
   public applyDeletedAtToBuilder(
-    // oxlint-disable-next-line @typescripttypescript/no-explicit-any
+    // oxlint-disable-next-line typescript/no-explicit-any
     queryBuilder: WorkspaceSelectQueryBuilder<any>,
     recordFilter: Partial<ObjectRecordFilter>,
-    // oxlint-disable-next-line @typescripttypescript/no-explicit-any
+    // oxlint-disable-next-line typescript/no-explicit-any
   ): WorkspaceSelectQueryBuilder<any> {
     if (this.checkForDeletedAtFilter(recordFilter)) {
       queryBuilder.withDeleted();
@@ -119,7 +119,7 @@ export class GraphqlQueryParser {
   };
 
   public applyOrderToBuilder(
-    // oxlint-disable-next-line @typescripttypescript/no-explicit-any
+    // oxlint-disable-next-line typescript/no-explicit-any
     queryBuilder: WorkspaceSelectQueryBuilder<any>,
     orderBy: ObjectRecordOrderBy | OrderByWithGroupBy,
     objectNameSingular: string,
@@ -146,7 +146,7 @@ export class GraphqlQueryParser {
   }
 
   public addRelationOrderColumnsToBuilder(
-    // oxlint-disable-next-line @typescripttypescript/no-explicit-any
+    // oxlint-disable-next-line typescript/no-explicit-any
     queryBuilder: WorkspaceSelectQueryBuilder<any>,
     parsedOrderBy: Record<string, OrderByClause>,
     objectNameSingular: string,
@@ -224,11 +224,11 @@ export class GraphqlQueryParser {
   }
 
   public applyGroupByOrderToBuilder(
-    // oxlint-disable-next-line @typescripttypescript/no-explicit-any
+    // oxlint-disable-next-line typescript/no-explicit-any
     queryBuilder: WorkspaceSelectQueryBuilder<any>,
     orderBy: ObjectRecordOrderBy | OrderByWithGroupBy,
     groupByFields: GroupByField[],
-    // oxlint-disable-next-line @typescripttypescript/no-explicit-any
+    // oxlint-disable-next-line typescript/no-explicit-any
   ): WorkspaceSelectQueryBuilder<any> {
     const parsedOrderBys = this.orderGroupByParser.parse({
       orderBy,
@@ -249,7 +249,7 @@ export class GraphqlQueryParser {
   }
 
   public parseSelectedFields(
-    // oxlint-disable-next-line @typescripttypescript/no-explicit-any
+    // oxlint-disable-next-line typescript/no-explicit-any
     graphqlSelectedFields: Partial<Record<string, any>>,
   ): GraphqlQuerySelectedFieldsResult {
     const selectedFieldsParser = new GraphqlQuerySelectedFieldsParser(

--- a/packages/twenty-server/src/engine/api/graphql/graphql-query-runner/helpers/object-records-to-graphql-connection.helper.ts
+++ b/packages/twenty-server/src/engine/api/graphql/graphql-query-runner/helpers/object-records-to-graphql-connection.helper.ts
@@ -57,9 +57,9 @@ export class ObjectRecordsToGraphqlConnectionHelper {
   }: {
     objectRecords: T[];
     parentObjectRecord?: T;
-    // oxlint-disable-next-line @typescripttypescript/no-explicit-any
+    // oxlint-disable-next-line typescript/no-explicit-any
     objectRecordsAggregatedValues?: Record<string, any>;
-    // oxlint-disable-next-line @typescripttypescript/no-explicit-any
+    // oxlint-disable-next-line typescript/no-explicit-any
     selectedAggregatedFields?: Record<string, any>;
     objectName: string;
     take: number;
@@ -119,7 +119,7 @@ export class ObjectRecordsToGraphqlConnectionHelper {
     objectRecordsAggregatedValues,
   }: {
     selectedAggregatedFields: Record<string, AggregationField[]>;
-    // oxlint-disable-next-line @typescripttypescript/no-explicit-any
+    // oxlint-disable-next-line typescript/no-explicit-any
     objectRecordsAggregatedValues: Record<string, any>;
   }) => {
     if (!isDefined(objectRecordsAggregatedValues)) {
@@ -145,7 +145,7 @@ export class ObjectRecordsToGraphqlConnectionHelper {
     );
   };
 
-  // oxlint-disable-next-line @typescripttypescript/no-explicit-any
+  // oxlint-disable-next-line typescript/no-explicit-any
   public processRecord<T extends Record<string, any>>({
     objectRecord,
     objectName,
@@ -158,9 +158,9 @@ export class ObjectRecordsToGraphqlConnectionHelper {
   }: {
     objectRecord: T;
     objectName: string;
-    // oxlint-disable-next-line @typescripttypescript/no-explicit-any
+    // oxlint-disable-next-line typescript/no-explicit-any
     objectRecordsAggregatedValues?: Record<string, any>;
-    // oxlint-disable-next-line @typescripttypescript/no-explicit-any
+    // oxlint-disable-next-line typescript/no-explicit-any
     selectedAggregatedFields?: Record<string, any>;
     take: number;
     totalCount: number;
@@ -182,7 +182,7 @@ export class ObjectRecordsToGraphqlConnectionHelper {
       flatEntityMaps: this.flatObjectMetadataMaps,
     });
 
-    // oxlint-disable-next-line @typescripttypescript/no-explicit-any
+    // oxlint-disable-next-line typescript/no-explicit-any
     const processedObjectRecord: Record<string, any> = {};
 
     for (const fieldId of flatObjectMetadata.fieldIds) {
@@ -284,9 +284,9 @@ export class ObjectRecordsToGraphqlConnectionHelper {
 
   private processCompositeField(
     fieldMetadata: FlatFieldMetadata,
-    // oxlint-disable-next-line @typescripttypescript/no-explicit-any
+    // oxlint-disable-next-line typescript/no-explicit-any
     fieldValue: any,
-    // oxlint-disable-next-line @typescripttypescript/no-explicit-any
+    // oxlint-disable-next-line typescript/no-explicit-any
   ): Record<string, any> {
     const compositeType = compositeTypeDefinitions.get(
       fieldMetadata.type as CompositeFieldMetadataType,
@@ -319,12 +319,12 @@ export class ObjectRecordsToGraphqlConnectionHelper {
 
         return acc;
       },
-      // oxlint-disable-next-line @typescripttypescript/no-explicit-any
+      // oxlint-disable-next-line typescript/no-explicit-any
       {} as Record<string, any>,
     );
   }
 
-  // oxlint-disable-next-line @typescripttypescript/no-explicit-any
+  // oxlint-disable-next-line typescript/no-explicit-any
   private formatFieldValue(value: any, fieldType: FieldMetadataType) {
     switch (fieldType) {
       case FieldMetadataType.DATE:

--- a/packages/twenty-server/src/engine/api/graphql/graphql-query-runner/helpers/process-aggregate.helper.ts
+++ b/packages/twenty-server/src/engine/api/graphql/graphql-query-runner/helpers/process-aggregate.helper.ts
@@ -12,7 +12,7 @@ export class ProcessAggregateHelper {
     objectMetadataNameSingular,
   }: {
     selectedAggregatedFields: Record<string, AggregationField>;
-    // oxlint-disable-next-line @typescripttypescript/no-explicit-any
+    // oxlint-disable-next-line typescript/no-explicit-any
     queryBuilder: WorkspaceSelectQueryBuilder<any>;
     objectMetadataNameSingular: string;
   }) => {

--- a/packages/twenty-server/src/engine/api/graphql/graphql-query-runner/utils/compute-where-condition-parts.ts
+++ b/packages/twenty-server/src/engine/api/graphql/graphql-query-runner/utils/compute-where-condition-parts.ts
@@ -30,7 +30,7 @@ export const computeWhereConditionParts = ({
   objectNameSingular: string;
   key: string;
   subFieldKey?: string;
-  // oxlint-disable-next-line @typescripttypescript/no-explicit-any
+  // oxlint-disable-next-line typescript/no-explicit-any
   value: any;
   fieldMetadataType: FieldMetadataType;
   useDirectTableReference?: boolean;

--- a/packages/twenty-server/src/engine/api/graphql/graphql-query-runner/utils/cursors.util.ts
+++ b/packages/twenty-server/src/engine/api/graphql/graphql-query-runner/utils/cursors.util.ts
@@ -17,7 +17,7 @@ import { buildFieldMapsFromFlatObjectMetadata } from 'src/engine/metadata-module
 import { type FlatObjectMetadata } from 'src/engine/metadata-modules/flat-object-metadata/types/flat-object-metadata.type';
 
 export interface CursorData {
-  // oxlint-disable-next-line @typescripttypescript/no-explicit-any
+  // oxlint-disable-next-line typescript/no-explicit-any
   [key: string]: any;
 }
 
@@ -49,7 +49,7 @@ export const encodeCursor = <T extends ObjectRecord = ObjectRecord>({
     flatObjectMetadata,
   );
 
-  // oxlint-disable-next-line @typescripttypescript/no-explicit-any
+  // oxlint-disable-next-line typescript/no-explicit-any
   const orderByValues: Record<string, any> = {};
 
   for (const orderByEntry of order ?? []) {
@@ -103,9 +103,9 @@ export const encodeCursorData = (cursorData: CursorData) => {
 };
 
 export const getCursor = (
-  // oxlint-disable-next-line @typescripttypescript/no-explicit-any
+  // oxlint-disable-next-line typescript/no-explicit-any
   args: FindManyResolverArgs<any, any>,
-  // oxlint-disable-next-line @typescripttypescript/no-explicit-any
+  // oxlint-disable-next-line typescript/no-explicit-any
 ): Record<string, any> | undefined => {
   if (args.after) return decodeCursor(args.after);
   if (args.before) return decodeCursor(args.before);

--- a/packages/twenty-server/src/engine/api/graphql/workspace-query-builder/interfaces/object-record.interface.ts
+++ b/packages/twenty-server/src/engine/api/graphql/workspace-query-builder/interfaces/object-record.interface.ts
@@ -7,7 +7,7 @@ import {
 } from 'twenty-shared/types';
 
 export type ObjectRecordFilter = Partial<{
-  // oxlint-disable-next-line @typescripttypescript/no-explicit-any
+  // oxlint-disable-next-line typescript/no-explicit-any
   [Property in keyof ObjectRecord]: any;
 }>;
 

--- a/packages/twenty-server/src/engine/api/graphql/workspace-query-builder/utils/stringify-without-key-quote.util.ts
+++ b/packages/twenty-server/src/engine/api/graphql/workspace-query-builder/utils/stringify-without-key-quote.util.ts
@@ -1,4 +1,4 @@
-// oxlint-disable-next-line @typescripttypescript/no-explicit-any
+// oxlint-disable-next-line typescript/no-explicit-any
 export const stringifyWithoutKeyQuote = (obj: any) => {
   const jsonString = JSON.stringify(obj);
   const jsonWithoutQuotes = jsonString?.replace(/"(\w+)"\s*:/g, '$1:');

--- a/packages/twenty-server/src/engine/api/graphql/workspace-query-runner/utils/parse-result.util.ts
+++ b/packages/twenty-server/src/engine/api/graphql/workspace-query-runner/utils/parse-result.util.ts
@@ -4,10 +4,10 @@ import {
 } from 'src/engine/api/graphql/workspace-query-builder/utils/composite-field-metadata.util';
 
 export const handleCompositeKey = (
-  // oxlint-disable-next-line @typescripttypescript/no-explicit-any
+  // oxlint-disable-next-line typescript/no-explicit-any
   result: any,
   key: string,
-  // oxlint-disable-next-line @typescripttypescript/no-explicit-any
+  // oxlint-disable-next-line typescript/no-explicit-any
   value: any,
 ): void => {
   const parsedFieldKey = parseCompositeFieldKey(key);
@@ -24,7 +24,7 @@ export const handleCompositeKey = (
   result[parsedFieldKey.parentFieldName][parsedFieldKey.childFieldName] = value;
 };
 
-// oxlint-disable-next-line @typescripttypescript/no-explicit-any
+// oxlint-disable-next-line typescript/no-explicit-any
 export const parseResult = (obj: any): any => {
   if (obj === null || typeof obj !== 'object' || typeof obj === 'function') {
     return obj;
@@ -34,7 +34,7 @@ export const parseResult = (obj: any): any => {
     return obj.map((item) => parseResult(item));
   }
 
-  // oxlint-disable-next-line @typescripttypescript/no-explicit-any
+  // oxlint-disable-next-line typescript/no-explicit-any
   const result: any = {};
 
   for (const key in obj) {

--- a/packages/twenty-server/src/engine/api/graphql/workspace-resolver-builder/interfaces/workspace-resolvers-builder.interface.ts
+++ b/packages/twenty-server/src/engine/api/graphql/workspace-resolver-builder/interfaces/workspace-resolvers-builder.interface.ts
@@ -13,7 +13,7 @@ import {
 import { RESOLVER_METHOD_NAMES } from 'src/engine/api/graphql/workspace-resolver-builder/constants/resolver-method-names';
 import { type workspaceResolverBuilderMethodNames } from 'src/engine/api/graphql/workspace-resolver-builder/factories/factories';
 
-// oxlint-disable-next-line @typescripttypescript/no-explicit-any
+// oxlint-disable-next-line typescript/no-explicit-any
 export type Resolver<Args = any> = GraphQLFieldResolver<any, any, Args>;
 
 // Use RESOLVER_METHOD_NAMES as the single source of truth for operation names
@@ -77,7 +77,7 @@ export interface UpdateOneResolverArgs<
 
 export interface UpdateManyResolverArgs<
   Data extends Partial<ObjectRecord> = Partial<ObjectRecord>,
-  // oxlint-disable-next-line @typescripttypescript/no-explicit-any
+  // oxlint-disable-next-line typescript/no-explicit-any
   Filter = any,
 > {
   filter: Filter;
@@ -88,7 +88,7 @@ export interface DeleteOneResolverArgs {
   id: string;
 }
 
-// oxlint-disable-next-line @typescripttypescript/no-explicit-any
+// oxlint-disable-next-line typescript/no-explicit-any
 export interface DeleteManyResolverArgs<Filter = any> {
   filter: Filter;
 }
@@ -97,7 +97,7 @@ export interface RestoreOneResolverArgs {
   id: string;
 }
 
-// oxlint-disable-next-line @typescripttypescript/no-explicit-any
+// oxlint-disable-next-line typescript/no-explicit-any
 export interface RestoreManyResolverArgs<Filter = any> {
   filter: Filter;
 }
@@ -112,7 +112,7 @@ export interface DestroyOneResolverArgs {
   id: string;
 }
 
-// oxlint-disable-next-line @typescripttypescript/no-explicit-any
+// oxlint-disable-next-line typescript/no-explicit-any
 export interface DestroyManyResolverArgs<Filter = any> {
   filter: Filter;
 }

--- a/packages/twenty-server/src/engine/api/graphql/workspace-schema-builder/graphql-types/scalars/position.scalar.ts
+++ b/packages/twenty-server/src/engine/api/graphql/workspace-schema-builder/graphql-types/scalars/position.scalar.ts
@@ -10,7 +10,7 @@ const isValidStringPosition = (value: string): boolean =>
 const isValidNumberPosition = (value: number): boolean =>
   typeof value === 'number';
 
-// oxlint-disable-next-line @typescripttypescript/no-explicit-any
+// oxlint-disable-next-line typescript/no-explicit-any
 const checkPosition = (value: any): PositionType => {
   if (isValidNumberPosition(value) || isValidStringPosition(value)) {
     return value;

--- a/packages/twenty-server/src/engine/api/graphql/workspace-schema-builder/graphql-types/scalars/uuid.scalar.ts
+++ b/packages/twenty-server/src/engine/api/graphql/workspace-schema-builder/graphql-types/scalars/uuid.scalar.ts
@@ -3,7 +3,7 @@ import { validate as uuidValidate } from 'uuid';
 
 import { ValidationError } from 'src/engine/core-modules/graphql/utils/graphql-errors.util';
 
-// oxlint-disable-next-line @typescripttypescript/no-explicit-any
+// oxlint-disable-next-line typescript/no-explicit-any
 const checkUUID = (value: any): string => {
   if (typeof value !== 'string') {
     throw new ValidationError('UUID must be a string');

--- a/packages/twenty-server/src/engine/core-modules/admin-panel/admin-panel-health.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/admin-panel/admin-panel-health.service.ts
@@ -49,7 +49,7 @@ export class AdminPanelHealthService {
       : AdminPanelHealthServiceStatus.OUTAGE;
   }
 
-  // oxlint-disable-next-line @typescripttypescript/no-explicit-any
+  // oxlint-disable-next-line typescript/no-explicit-any
   private transformServiceDetails(details: any) {
     if (!details) return details;
 

--- a/packages/twenty-server/src/engine/core-modules/admin-panel/utils/health-state-manager.util.ts
+++ b/packages/twenty-server/src/engine/core-modules/admin-panel/utils/health-state-manager.util.ts
@@ -1,11 +1,11 @@
 export class HealthStateManager {
   private lastKnownState: {
     timestamp: Date;
-    // oxlint-disable-next-line @typescripttypescript/no-explicit-any
+    // oxlint-disable-next-line typescript/no-explicit-any
     details: Record<string, any>;
   } | null = null;
 
-  // oxlint-disable-next-line @typescripttypescript/no-explicit-any
+  // oxlint-disable-next-line typescript/no-explicit-any
   updateState(details: Record<string, any>) {
     this.lastKnownState = {
       timestamp: new Date(),

--- a/packages/twenty-server/src/engine/core-modules/app-token/app-token.auto-resolver-opts.ts
+++ b/packages/twenty-server/src/engine/core-modules/app-token/app-token.auto-resolver-opts.ts
@@ -9,13 +9,13 @@ import { CreateAppTokenInput } from 'src/engine/core-modules/app-token/dtos/crea
 import { WorkspaceAuthGuard } from 'src/engine/guards/workspace-auth.guard';
 
 export const appTokenAutoResolverOpts: AutoResolverOpts<
-  // oxlint-disable-next-line @typescripttypescript/no-explicit-any
+  // oxlint-disable-next-line typescript/no-explicit-any
   any,
-  // oxlint-disable-next-line @typescripttypescript/no-explicit-any
+  // oxlint-disable-next-line typescript/no-explicit-any
   any,
   unknown,
   unknown,
-  // oxlint-disable-next-line @typescripttypescript/no-explicit-any
+  // oxlint-disable-next-line typescript/no-explicit-any
   ReadResolverOpts<any>,
   PagingStrategies
 >[] = [

--- a/packages/twenty-server/src/engine/core-modules/app-token/hooks/before-create-one-app-token.hook.ts
+++ b/packages/twenty-server/src/engine/core-modules/app-token/hooks/before-create-one-app-token.hook.ts
@@ -10,7 +10,7 @@ export class BeforeCreateOneAppToken<
 > implements BeforeCreateOneHook<T> {
   async run(
     instance: CreateOneInputType<T>,
-    // oxlint-disable-next-line @typescripttypescript/no-explicit-any
+    // oxlint-disable-next-line typescript/no-explicit-any
     context: any,
   ): Promise<CreateOneInputType<T>> {
     const userId = context?.req?.user?.id;

--- a/packages/twenty-server/src/engine/core-modules/application-logs/application-logs.module.ts
+++ b/packages/twenty-server/src/engine/core-modules/application-logs/application-logs.module.ts
@@ -37,7 +37,7 @@ export class ApplicationLogsModule extends ConfigurableModuleClass {
   static forRootAsync(options: typeof ASYNC_OPTIONS_TYPE): DynamicModule {
     const provider = {
       provide: APPLICATION_LOG_DRIVER,
-      // oxlint-disable-next-line @typescripttypescript/no-explicit-any
+      // oxlint-disable-next-line typescript/no-explicit-any
       useFactory: async (
         clickHouseService: ClickHouseService,
         ...args: unknown[]

--- a/packages/twenty-server/src/engine/core-modules/application/application-package/utils/copy-yarn-engine-and-build-dependencies.ts
+++ b/packages/twenty-server/src/engine/core-modules/application/application-package/utils/copy-yarn-engine-and-build-dependencies.ts
@@ -32,7 +32,7 @@ export const copyYarnEngineAndBuildDependencies = async (
         env: cleanEnv,
       },
     );
-    // oxlint-disable-next-line @typescripttypescript/no-explicit-any
+    // oxlint-disable-next-line typescript/no-explicit-any
   } catch (error: any) {
     const errorMessage =
       [error?.stdout, error?.stderr].filter(Boolean).join('\n') ||

--- a/packages/twenty-server/src/engine/core-modules/audit/dtos/create-object-event.input.ts
+++ b/packages/twenty-server/src/engine/core-modules/audit/dtos/create-object-event.input.ts
@@ -32,6 +32,6 @@ export class CreateObjectEventInput {
   @Field(() => GraphQLJSON, { nullable: true })
   @IsObject()
   @IsOptional()
-  // oxlint-disable-next-line @typescripttypescript/no-explicit-any
+  // oxlint-disable-next-line typescript/no-explicit-any
   properties?: Record<string, any>;
 }

--- a/packages/twenty-server/src/engine/core-modules/audit/utils/events/workspace-event/track.ts
+++ b/packages/twenty-server/src/engine/core-modules/audit/utils/events/workspace-event/track.ts
@@ -11,7 +11,7 @@ export const genericTrackSchema = baseEventSchema.extend({
 export type GenericTrackEvent<E extends string = string> = {
   type: 'track';
   event: E;
-  // oxlint-disable-next-line @typescripttypescript/no-explicit-any
+  // oxlint-disable-next-line typescript/no-explicit-any
   properties: any;
   timestamp: string;
   version: string;
@@ -19,10 +19,10 @@ export type GenericTrackEvent<E extends string = string> = {
   workspaceId?: string;
 };
 
-// oxlint-disable-next-line @typescripttypescript/no-explicit-any
+// oxlint-disable-next-line typescript/no-explicit-any
 export const eventsRegistry = new Map<string, z.ZodSchema<any>>();
 
-// oxlint-disable-next-line @typescripttypescript/no-explicit-any
+// oxlint-disable-next-line typescript/no-explicit-any
 export function registerEvent<E extends string, S extends z.ZodObject<any>>(
   event: E,
   schema: S,

--- a/packages/twenty-server/src/engine/core-modules/auth/controllers/sso-auth.controller.ts
+++ b/packages/twenty-server/src/engine/core-modules/auth/controllers/sso-auth.controller.ts
@@ -62,7 +62,7 @@ export class SSOAuthController {
     PublicEndpointGuard,
     NoPermissionGuard,
   )
-  // oxlint-disable-next-line @typescripttypescript/no-explicit-any
+  // oxlint-disable-next-line typescript/no-explicit-any
   async generateMetadata(@Req() req: any): Promise<string | void> {
     return generateServiceProviderMetadata({
       wantAssertionsSigned: true,

--- a/packages/twenty-server/src/engine/core-modules/auth/guards/oidc-auth.guard.ts
+++ b/packages/twenty-server/src/engine/core-modules/auth/guards/oidc-auth.guard.ts
@@ -26,7 +26,7 @@ export class OIDCAuthGuard extends AuthGuard('openidconnect') {
     super();
   }
 
-  // oxlint-disable-next-line @typescripttypescript/no-explicit-any
+  // oxlint-disable-next-line typescript/no-explicit-any
   private getStateByRequest(request: any): {
     identityProviderId: string;
   } {

--- a/packages/twenty-server/src/engine/core-modules/auth/strategies/google-apis-oauth-request-code.auth.strategy.ts
+++ b/packages/twenty-server/src/engine/core-modules/auth/strategies/google-apis-oauth-request-code.auth.strategy.ts
@@ -16,7 +16,7 @@ export class GoogleAPIsOauthRequestCodeStrategy extends GoogleAPIsOauthCommonStr
     super(twentyConfigService);
   }
 
-  // oxlint-disable-next-line @typescripttypescript/no-explicit-any
+  // oxlint-disable-next-line typescript/no-explicit-any
   authenticate(req: any, options: any) {
     options = {
       ...options,

--- a/packages/twenty-server/src/engine/core-modules/auth/strategies/google.auth.strategy.ts
+++ b/packages/twenty-server/src/engine/core-modules/auth/strategies/google.auth.strategy.ts
@@ -48,7 +48,7 @@ export class GoogleStrategy extends PassportStrategy(Strategy, 'google') {
     });
   }
 
-  // oxlint-disable-next-line @typescripttypescript/no-explicit-any
+  // oxlint-disable-next-line typescript/no-explicit-any
   authenticate(req: Request, options: any) {
     options = {
       ...options,

--- a/packages/twenty-server/src/engine/core-modules/auth/strategies/microsoft-apis-oauth-request-code.auth.strategy.ts
+++ b/packages/twenty-server/src/engine/core-modules/auth/strategies/microsoft-apis-oauth-request-code.auth.strategy.ts
@@ -11,7 +11,7 @@ export class MicrosoftAPIsOauthRequestCodeStrategy extends MicrosoftAPIsOauthCom
     super(twentyConfigService);
   }
 
-  // oxlint-disable-next-line @typescripttypescript/no-explicit-any
+  // oxlint-disable-next-line typescript/no-explicit-any
   authenticate(req: any, options: any) {
     options = {
       ...options,

--- a/packages/twenty-server/src/engine/core-modules/auth/strategies/microsoft.auth.strategy.ts
+++ b/packages/twenty-server/src/engine/core-modules/auth/strategies/microsoft.auth.strategy.ts
@@ -47,7 +47,7 @@ export class MicrosoftStrategy extends PassportStrategy(Strategy, 'microsoft') {
     });
   }
 
-  // oxlint-disable-next-line @typescripttypescript/no-explicit-any
+  // oxlint-disable-next-line typescript/no-explicit-any
   authenticate(req: Request, options: any) {
     options = {
       ...options,

--- a/packages/twenty-server/src/engine/core-modules/auth/strategies/oidc.auth.strategy.ts
+++ b/packages/twenty-server/src/engine/core-modules/auth/strategies/oidc.auth.strategy.ts
@@ -46,7 +46,7 @@ export class OIDCAuthStrategy extends PassportStrategy(
     });
   }
 
-  // oxlint-disable-next-line @typescripttypescript/no-explicit-any
+  // oxlint-disable-next-line typescript/no-explicit-any
   authenticate(req: Request, options: any) {
     return super.authenticate(req, {
       ...options,
@@ -86,7 +86,7 @@ export class OIDCAuthStrategy extends PassportStrategy(
   async validate(
     req: Request,
     tokenset: TokenSet,
-    // oxlint-disable-next-line @typescripttypescript/no-explicit-any
+    // oxlint-disable-next-line typescript/no-explicit-any
     done: (err: any, user?: OIDCRequest['user']) => void,
   ) {
     try {

--- a/packages/twenty-server/src/engine/core-modules/cache-lock/with-lock.decorator.ts
+++ b/packages/twenty-server/src/engine/core-modules/cache-lock/with-lock.decorator.ts
@@ -16,7 +16,7 @@ export const WithLock = (
 
     const originalMethod = descriptor.value;
 
-    // oxlint-disable-next-line @typescripttypescript/no-explicit-any
+    // oxlint-disable-next-line typescript/no-explicit-any
     descriptor.value = async function (...args: any[]) {
       const self = this as { cacheLockService: CacheLockService };
 

--- a/packages/twenty-server/src/engine/core-modules/cache-storage/cache-storage.module.ts
+++ b/packages/twenty-server/src/engine/core-modules/cache-storage/cache-storage.module.ts
@@ -34,9 +34,9 @@ export class CacheStorageModule implements OnModuleDestroy {
   constructor(@Inject(CACHE_MANAGER) private cacheManager: Cache) {}
 
   async onModuleDestroy() {
-    // oxlint-disable-next-line @typescripttypescript/no-explicit-any
+    // oxlint-disable-next-line typescript/no-explicit-any
     if ((this.cacheManager.store as any)?.name === 'redis') {
-      // oxlint-disable-next-line @typescripttypescript/no-explicit-any
+      // oxlint-disable-next-line typescript/no-explicit-any
       await (this.cacheManager.store as any).client.quit();
     }
   }

--- a/packages/twenty-server/src/engine/core-modules/cache-storage/services/cache-storage.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/cache-storage/services/cache-storage.service.ts
@@ -403,7 +403,7 @@ end`;
   }
 
   private isRedisCache() {
-    // oxlint-disable-next-line @typescripttypescript/no-explicit-any
+    // oxlint-disable-next-line typescript/no-explicit-any
     return (this.cache.store as any)?.name === 'redis';
   }
 

--- a/packages/twenty-server/src/engine/core-modules/cron/sentry-cron-monitor.decorator.ts
+++ b/packages/twenty-server/src/engine/core-modules/cron/sentry-cron-monitor.decorator.ts
@@ -2,14 +2,14 @@ import * as Sentry from '@sentry/node';
 
 export function SentryCronMonitor(monitorSlug: string, schedule: string) {
   return function (
-    // oxlint-disable-next-line @typescripttypescript/no-explicit-any
+    // oxlint-disable-next-line typescript/no-explicit-any
     _target: any,
     _propertyKey: string,
     descriptor: PropertyDescriptor,
   ) {
     const originalMethod = descriptor.value;
 
-    // oxlint-disable-next-line @typescripttypescript/no-explicit-any
+    // oxlint-disable-next-line typescript/no-explicit-any
     descriptor.value = async function (...args: any[]) {
       if (!Sentry.isInitialized()) {
         return await originalMethod.apply(this, args);

--- a/packages/twenty-server/src/engine/core-modules/event-emitter/utils/object-record-changed-values.ts
+++ b/packages/twenty-server/src/engine/core-modules/event-emitter/utils/object-record-changed-values.ts
@@ -96,7 +96,7 @@ export const objectRecordChangedValues = (
       return diffAccumulator;
     },
 
-    // oxlint-disable-next-line @typescripttypescript/no-explicit-any
+    // oxlint-disable-next-line typescript/no-explicit-any
     {} as Record<string, { before: any; after: any }>,
   );
 

--- a/packages/twenty-server/src/engine/core-modules/event-emitter/utils/object-record-diff-merge.ts
+++ b/packages/twenty-server/src/engine/core-modules/event-emitter/utils/object-record-diff-merge.ts
@@ -1,11 +1,11 @@
 export function objectRecordDiffMerge(
-  // oxlint-disable-next-line @typescripttypescript/no-explicit-any
+  // oxlint-disable-next-line typescript/no-explicit-any
   oldRecord: Record<string, any>,
-  // oxlint-disable-next-line @typescripttypescript/no-explicit-any
+  // oxlint-disable-next-line typescript/no-explicit-any
   newRecord: Record<string, any>,
-  // oxlint-disable-next-line @typescripttypescript/no-explicit-any
+  // oxlint-disable-next-line typescript/no-explicit-any
 ): Record<string, any> {
-  // oxlint-disable-next-line @typescripttypescript/no-explicit-any
+  // oxlint-disable-next-line typescript/no-explicit-any
   const result: Record<string, any> = { diff: {} };
 
   // Iterate over the keys in the oldRecord diff

--- a/packages/twenty-server/src/engine/core-modules/exception-handler/drivers/console.driver.ts
+++ b/packages/twenty-server/src/engine/core-modules/exception-handler/drivers/console.driver.ts
@@ -5,7 +5,7 @@ import { type ExceptionHandlerDriverInterface } from 'src/engine/core-modules/ex
 
 export class ExceptionHandlerConsoleDriver implements ExceptionHandlerDriverInterface {
   captureExceptions(
-    // oxlint-disable-next-line @typescripttypescript/no-explicit-any
+    // oxlint-disable-next-line typescript/no-explicit-any
     exceptions: ReadonlyArray<any>,
     options?: ExceptionHandlerOptions,
   ) {

--- a/packages/twenty-server/src/engine/core-modules/exception-handler/drivers/sentry.driver.ts
+++ b/packages/twenty-server/src/engine/core-modules/exception-handler/drivers/sentry.driver.ts
@@ -14,7 +14,7 @@ import { CustomException } from 'src/utils/custom-exception';
 
 export class ExceptionHandlerSentryDriver implements ExceptionHandlerDriverInterface {
   captureExceptions(
-    // oxlint-disable-next-line @typescripttypescript/no-explicit-any
+    // oxlint-disable-next-line typescript/no-explicit-any
     exceptions: ReadonlyArray<any>,
     options?: ExceptionHandlerOptions,
   ) {

--- a/packages/twenty-server/src/engine/core-modules/exception-handler/exception-handler.module.ts
+++ b/packages/twenty-server/src/engine/core-modules/exception-handler/exception-handler.module.ts
@@ -37,7 +37,7 @@ export class ExceptionHandlerModule extends ConfigurableModuleClass {
   static forRootAsync(options: typeof ASYNC_OPTIONS_TYPE): DynamicModule {
     const provider = {
       provide: EXCEPTION_HANDLER_DRIVER,
-      // oxlint-disable-next-line @typescripttypescript/no-explicit-any
+      // oxlint-disable-next-line typescript/no-explicit-any
       useFactory: async (...args: any[]) => {
         const config = await options?.useFactory?.(...args);
 

--- a/packages/twenty-server/src/engine/core-modules/exception-handler/exception-handler.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/exception-handler/exception-handler.service.ts
@@ -13,7 +13,7 @@ export class ExceptionHandlerService {
   ) {}
 
   captureExceptions(
-    // oxlint-disable-next-line @typescripttypescript/no-explicit-any
+    // oxlint-disable-next-line typescript/no-explicit-any
     exceptions: ReadonlyArray<any>,
     options?: ExceptionHandlerOptions,
   ): string[] {

--- a/packages/twenty-server/src/engine/core-modules/exception-handler/interfaces/exception-handler-driver.interface.ts
+++ b/packages/twenty-server/src/engine/core-modules/exception-handler/interfaces/exception-handler-driver.interface.ts
@@ -2,7 +2,7 @@ import { type ExceptionHandlerOptions } from 'src/engine/core-modules/exception-
 
 export interface ExceptionHandlerDriverInterface {
   captureExceptions(
-    // oxlint-disable-next-line @typescripttypescript/no-explicit-any
+    // oxlint-disable-next-line typescript/no-explicit-any
     exceptions: ReadonlyArray<any>,
     options?: ExceptionHandlerOptions,
   ): string[];

--- a/packages/twenty-server/src/engine/core-modules/exception-handler/interfaces/exception-handler-options.interface.ts
+++ b/packages/twenty-server/src/engine/core-modules/exception-handler/interfaces/exception-handler-options.interface.ts
@@ -9,7 +9,7 @@ export interface ExceptionHandlerOptions {
     name: string;
   };
   document?: string;
-  // oxlint-disable-next-line @typescripttypescript/no-explicit-any
+  // oxlint-disable-next-line typescript/no-explicit-any
   additionalData?: Record<string, any>;
   user?: ExceptionHandlerUser | null;
   workspace?: ExceptionHandlerWorkspace | null;

--- a/packages/twenty-server/src/engine/core-modules/exception-handler/mocks/exception-handler-mock.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/exception-handler/mocks/exception-handler-mock.service.ts
@@ -7,7 +7,7 @@ import { type ExceptionHandlerDriverInterface } from 'src/engine/core-modules/ex
 @Injectable()
 export class ExceptionHandlerMockService implements ExceptionHandlerDriverInterface {
   captureExceptions(
-    // oxlint-disable-next-line @typescripttypescript/no-explicit-any
+    // oxlint-disable-next-line typescript/no-explicit-any
     exceptions: readonly any[],
     _?: ExceptionHandlerOptions | undefined,
   ): string[] {

--- a/packages/twenty-server/src/engine/core-modules/exception-handler/mocks/mock-unhandled-exception.filter.ts
+++ b/packages/twenty-server/src/engine/core-modules/exception-handler/mocks/mock-unhandled-exception.filter.ts
@@ -10,7 +10,7 @@ export class MockedUnhandledExceptionFilter
   extends BaseExceptionFilter
   implements ExceptionFilter
 {
-  // oxlint-disable-next-line @typescripttypescript/no-explicit-any
+  // oxlint-disable-next-line typescript/no-explicit-any
   catch(exception: any, _host: ArgumentsHost) {
     throw exception;
   }

--- a/packages/twenty-server/src/engine/core-modules/file/controllers/file.controller.ts
+++ b/packages/twenty-server/src/engine/core-modules/file/controllers/file.controller.ts
@@ -118,7 +118,7 @@ export class FileController {
     @Param('fileFolder') fileFolder: SupportedFileFolder,
     @Param('id') fileId: string,
   ) {
-    // oxlint-disable-next-line @typescripttypescript/no-explicit-any
+    // oxlint-disable-next-line typescript/no-explicit-any
     const workspaceId = (req as any)?.workspaceId;
 
     const fileResponse = await this.fileService

--- a/packages/twenty-server/src/engine/core-modules/graphql/pipes/resolver-validation.pipe.ts
+++ b/packages/twenty-server/src/engine/core-modules/graphql/pipes/resolver-validation.pipe.ts
@@ -42,7 +42,7 @@ export class ResolverValidationPipe implements PipeTransform {
     throw new UserInputError(errorMessage);
   }
 
-  // oxlint-disable-next-line @typescripttypescript/no-explicit-any
+  // oxlint-disable-next-line typescript/no-explicit-any
   private toValidate(metatype: Type<any>): boolean {
     const types: unknown[] = [String, Boolean, Number, Array, Object];
 

--- a/packages/twenty-server/src/engine/core-modules/graphql/utils/graphql-errors.util.ts
+++ b/packages/twenty-server/src/engine/core-modules/graphql/utils/graphql-errors.util.ts
@@ -41,7 +41,7 @@ type RestrictedGraphQLErrorExtensions = {
 };
 
 export class BaseGraphQLError extends GraphQLError {
-  // oxlint-disable-next-line @typescripttypescript/no-explicit-any
+  // oxlint-disable-next-line typescript/no-explicit-any
   public extensions: Record<string, any>;
   override readonly name!: string;
   readonly locations: ReadonlyArray<SourceLocation> | undefined;
@@ -51,12 +51,12 @@ export class BaseGraphQLError extends GraphQLError {
   readonly nodes: ReadonlyArray<ASTNode> | undefined;
   public originalError: Error | undefined;
 
-  // oxlint-disable-next-line @typescripttypescript/no-explicit-any
+  // oxlint-disable-next-line typescript/no-explicit-any
   [key: string]: any;
   constructor(
     exceptionOrMessage: string | CustomException,
     code?: string,
-    // oxlint-disable-next-line @typescripttypescript/no-explicit-any
+    // oxlint-disable-next-line typescript/no-explicit-any
     extensions?: Record<string, any>,
   ) {
     if (exceptionOrMessage instanceof CustomException) {

--- a/packages/twenty-server/src/engine/core-modules/jwt/services/jwt-wrapper.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/jwt/services/jwt-wrapper.service.ts
@@ -70,7 +70,7 @@ export class JwtWrapperService {
     return jwt.sign(payload as object, signingKey.privateKeyPem, signOptions);
   }
 
-  // oxlint-disable-next-line @typescripttypescript/no-explicit-any
+  // oxlint-disable-next-line typescript/no-explicit-any
   verify<T extends object = any>(
     token: string,
     options?: { secret: string },
@@ -78,7 +78,7 @@ export class JwtWrapperService {
     return this.jwtService.verify(token, options);
   }
 
-  // oxlint-disable-next-line @typescripttypescript/no-explicit-any
+  // oxlint-disable-next-line typescript/no-explicit-any
   decode<T = any>(payload: string, options?: jwt.DecodeOptions): T {
     return this.jwtService.decode(payload, options);
   }
@@ -129,7 +129,7 @@ export class JwtWrapperService {
   async verifyJwtToken(
     token: string,
     options?: JwtVerifyOptions,
-    // oxlint-disable-next-line @typescripttypescript/no-explicit-any
+    // oxlint-disable-next-line typescript/no-explicit-any
   ): Promise<any> {
     const header = decodeJwtHeader(token);
     const payload = this.decode<JwtPayload>(token, { json: true });

--- a/packages/twenty-server/src/engine/core-modules/key-value-pair/key-value-pair.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/key-value-pair/key-value-pair.service.ts
@@ -8,7 +8,7 @@ import {
 } from 'src/engine/core-modules/key-value-pair/key-value-pair.entity';
 
 export class KeyValuePairService<
-  // oxlint-disable-next-line @typescripttypescript/no-explicit-any
+  // oxlint-disable-next-line typescript/no-explicit-any
   KeyValueTypesMap extends Record<string, any> = Record<string, any>,
 > {
   constructor(

--- a/packages/twenty-server/src/engine/core-modules/logger/logger.module.ts
+++ b/packages/twenty-server/src/engine/core-modules/logger/logger.module.ts
@@ -39,7 +39,7 @@ export class LoggerModule extends ConfigurableModuleClass {
   static forRootAsync(options: typeof ASYNC_OPTIONS_TYPE): DynamicModule {
     const provider = {
       provide: LOGGER_DRIVER,
-      // oxlint-disable-next-line @typescripttypescript/no-explicit-any
+      // oxlint-disable-next-line typescript/no-explicit-any
       useFactory: async (...args: any[]) => {
         const config = await options?.useFactory?.(...args);
 

--- a/packages/twenty-server/src/engine/core-modules/logger/logger.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/logger/logger.service.ts
@@ -18,12 +18,12 @@ type LoggerDriverType = ConsoleLogger & {
 export class LoggerService implements LoggerServiceInterface {
   constructor(@Inject(LOGGER_DRIVER) private driver: LoggerDriverType) {}
 
-  // oxlint-disable-next-line @typescripttypescript/no-explicit-any
+  // oxlint-disable-next-line typescript/no-explicit-any
   log(message: any, category: string, ...optionalParams: any[]) {
     this.driver.log.apply(this.driver, [message, category, ...optionalParams]);
   }
 
-  // oxlint-disable-next-line @typescripttypescript/no-explicit-any
+  // oxlint-disable-next-line typescript/no-explicit-any
   error(message: any, category: string, ...optionalParams: any[]) {
     this.driver.error.apply(this.driver, [
       message,
@@ -32,12 +32,12 @@ export class LoggerService implements LoggerServiceInterface {
     ]);
   }
 
-  // oxlint-disable-next-line @typescripttypescript/no-explicit-any
+  // oxlint-disable-next-line typescript/no-explicit-any
   warn(message: any, category: string, ...optionalParams: any[]) {
     this.driver.warn.apply(this.driver, [message, category, ...optionalParams]);
   }
 
-  // oxlint-disable-next-line @typescripttypescript/no-explicit-any
+  // oxlint-disable-next-line typescript/no-explicit-any
   debug?(message: any, category: string, ...optionalParams: any[]) {
     this.driver.debug?.apply(this.driver, [
       message,
@@ -46,7 +46,7 @@ export class LoggerService implements LoggerServiceInterface {
     ]);
   }
 
-  // oxlint-disable-next-line @typescripttypescript/no-explicit-any
+  // oxlint-disable-next-line typescript/no-explicit-any
   verbose?(message: any, category: string, ...optionalParams: any[]) {
     this.driver.verbose?.apply(this.driver, [
       message,

--- a/packages/twenty-server/src/engine/core-modules/logic-function/logic-function-drivers/utils/intercept-console.ts
+++ b/packages/twenty-server/src/engine/core-modules/logic-function/logic-function-drivers/utils/intercept-console.ts
@@ -12,11 +12,11 @@ export class ConsoleListener {
     };
   }
 
-  // oxlint-disable-next-line @typescripttypescript/no-explicit-any
+  // oxlint-disable-next-line typescript/no-explicit-any
   intercept(callback: (type: string, message: any[]) => void) {
     Object.keys(this.originalConsole).forEach((method) => {
       // @ts-expect-error legacy noImplicitAny
-      // oxlint-disable-next-line @typescripttypescript/no-explicit-any
+      // oxlint-disable-next-line typescript/no-explicit-any
       console[method] = (...args: any[]) => {
         callback(method, args);
       };
@@ -26,7 +26,7 @@ export class ConsoleListener {
   release() {
     Object.keys(this.originalConsole).forEach((method) => {
       // @ts-expect-error legacy noImplicitAny
-      // oxlint-disable-next-line @typescripttypescript/no-explicit-any
+      // oxlint-disable-next-line typescript/no-explicit-any
       console[method] = (...args: any[]) => {
         // @ts-expect-error legacy noImplicitAny
         this.originalConsole[method](...args);

--- a/packages/twenty-server/src/engine/core-modules/message-queue/drivers/sync.driver.ts
+++ b/packages/twenty-server/src/engine/core-modules/message-queue/drivers/sync.driver.ts
@@ -39,7 +39,7 @@ export class SyncDriver implements MessageQueueDriver {
       id: '',
       name: jobName,
       // TODO: Fix this type issue
-      // oxlint-disable-next-line @typescripttypescript/no-explicit-any
+      // oxlint-disable-next-line typescript/no-explicit-any
       data: data as any,
     });
   }

--- a/packages/twenty-server/src/engine/core-modules/message-queue/interfaces/message-queue-job.interface.ts
+++ b/packages/twenty-server/src/engine/core-modules/message-queue/interfaces/message-queue-job.interface.ts
@@ -1,4 +1,4 @@
-// oxlint-disable-next-line @typescripttypescript/no-explicit-any
+// oxlint-disable-next-line typescript/no-explicit-any
 export interface MessageQueueJob<T = any> {
   id: string;
   name: string;
@@ -12,6 +12,6 @@ export interface MessageQueueCronJobData<
 }
 
 export interface MessageQueueJobData {
-  // oxlint-disable-next-line @typescripttypescript/no-explicit-any
+  // oxlint-disable-next-line typescript/no-explicit-any
   [key: string]: any;
 }

--- a/packages/twenty-server/src/engine/core-modules/message-queue/interfaces/message-queue-module-options.interface.ts
+++ b/packages/twenty-server/src/engine/core-modules/message-queue/interfaces/message-queue-module-options.interface.ts
@@ -14,7 +14,7 @@ export interface BullMQDriverFactoryOptions {
 
 export interface SyncDriverFactoryOptions {
   type: MessageQueueDriverType.Sync;
-  // oxlint-disable-next-line @typescripttypescript/no-explicit-any
+  // oxlint-disable-next-line typescript/no-explicit-any
   options: Record<string, any>;
 }
 

--- a/packages/twenty-server/src/engine/core-modules/message-queue/message-queue-core.module.ts
+++ b/packages/twenty-server/src/engine/core-modules/message-queue/message-queue-core.module.ts
@@ -62,7 +62,7 @@ export class MessageQueueCoreModule extends ConfigurableModuleClass {
 
     const driverProvider: Provider = {
       provide: QUEUE_DRIVER,
-      // oxlint-disable-next-line @typescripttypescript/no-explicit-any
+      // oxlint-disable-next-line typescript/no-explicit-any
       useFactory: async (...args: any[]) => {
         if (options.useFactory) {
           const config = await options.useFactory(...args);

--- a/packages/twenty-server/src/engine/core-modules/record-crud/types/object-record-properties.type.ts
+++ b/packages/twenty-server/src/engine/core-modules/record-crud/types/object-record-properties.type.ts
@@ -1,2 +1,2 @@
-// oxlint-disable-next-line @typescripttypescript/no-explicit-any
+// oxlint-disable-next-line typescript/no-explicit-any
 export type ObjectRecordProperties = Record<string, any>;

--- a/packages/twenty-server/src/engine/core-modules/record-crud/types/record-crud-input.type.ts
+++ b/packages/twenty-server/src/engine/core-modules/record-crud/types/record-crud-input.type.ts
@@ -26,14 +26,14 @@ export type DeleteRecordInput = {
 export type FindRecordsInput = {
   objectName: string;
   filter?: {
-    // oxlint-disable-next-line @typescripttypescript/no-explicit-any
+    // oxlint-disable-next-line typescript/no-explicit-any
     recordFilterGroups?: any;
-    // oxlint-disable-next-line @typescripttypescript/no-explicit-any
+    // oxlint-disable-next-line typescript/no-explicit-any
     recordFilters?: any;
     gqlOperationFilter?: Partial<ObjectRecordFilter>[];
   };
   orderBy?: {
-    // oxlint-disable-next-line @typescripttypescript/no-explicit-any
+    // oxlint-disable-next-line typescript/no-explicit-any
     recordSorts?: any;
     gqlOperationOrderBy?: Partial<ObjectRecordOrderBy>;
   };

--- a/packages/twenty-server/src/engine/core-modules/record-transformer/services/record-input-transformer.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/record-transformer/services/record-input-transformer.service.ts
@@ -65,9 +65,9 @@ export class RecordInputTransformerService {
 
   private async transformFieldValue(
     fieldType: FieldMetadataType,
-    // oxlint-disable-next-line @typescripttypescript/no-explicit-any
+    // oxlint-disable-next-line typescript/no-explicit-any
     value: any,
-    // oxlint-disable-next-line @typescripttypescript/no-explicit-any
+    // oxlint-disable-next-line typescript/no-explicit-any
   ): Promise<any> {
     if (!isDefined(value)) {
       return value;
@@ -91,7 +91,7 @@ export class RecordInputTransformerService {
     }
   }
 
-  // oxlint-disable-next-line @typescripttypescript/no-explicit-any
+  // oxlint-disable-next-line typescript/no-explicit-any
   private stringifySubFields(fieldMetadataType: FieldMetadataType, value: any) {
     const compositeType = compositeTypeDefinitions.get(fieldMetadataType);
 
@@ -120,7 +120,7 @@ export class RecordInputTransformerService {
     );
   }
 
-  // oxlint-disable-next-line @typescripttypescript/no-explicit-any
+  // oxlint-disable-next-line typescript/no-explicit-any
   private parseSubFields(fieldMetadataType: FieldMetadataType, value: any) {
     const compositeType = compositeTypeDefinitions.get(fieldMetadataType);
 
@@ -129,7 +129,7 @@ export class RecordInputTransformerService {
     }
 
     return Object.entries(value).reduce(
-      // oxlint-disable-next-line @typescripttypescript/no-explicit-any
+      // oxlint-disable-next-line typescript/no-explicit-any
       (acc, [subFieldName, subFieldValue]: [string, any]) => {
         const subFieldType = compositeType.properties.find(
           (property) => property.name === subFieldName,

--- a/packages/twenty-server/src/engine/core-modules/record-transformer/utils/transform-emails-value.util.ts
+++ b/packages/twenty-server/src/engine/core-modules/record-transformer/utils/transform-emails-value.util.ts
@@ -2,9 +2,9 @@ import { isNonEmptyArray, isNonEmptyString } from '@sniptt/guards';
 import { isDefined } from 'class-validator';
 
 export const transformEmailsValue = (
-  // oxlint-disable-next-line @typescripttypescript/no-explicit-any
+  // oxlint-disable-next-line typescript/no-explicit-any
   value: any,
-  // oxlint-disable-next-line @typescripttypescript/no-explicit-any
+  // oxlint-disable-next-line typescript/no-explicit-any
 ): any => {
   if (!isDefined(value)) {
     return value;

--- a/packages/twenty-server/src/engine/core-modules/record-transformer/utils/transform-rich-text.util.ts
+++ b/packages/twenty-server/src/engine/core-modules/record-transformer/utils/transform-rich-text.util.ts
@@ -30,7 +30,7 @@ const getServerBlockNoteEditor = async (): Promise<ServerBlockNoteEditor> => {
 };
 
 export const transformRichTextValue = async (
-  // oxlint-disable-next-line @typescripttypescript/no-explicit-any
+  // oxlint-disable-next-line typescript/no-explicit-any
   richTextValue: any,
 ): Promise<RichTextMetadata> => {
   const parsedValue = isNonEmptyString(richTextValue)

--- a/packages/twenty-server/src/engine/core-modules/sso/dtos/validators/x509.validator.ts
+++ b/packages/twenty-server/src/engine/core-modules/sso/dtos/validators/x509.validator.ts
@@ -11,7 +11,7 @@ import {
 
 @ValidatorConstraint({ async: false })
 export class IsX509CertificateConstraint implements ValidatorConstraintInterface {
-  // oxlint-disable-next-line @typescripttypescript/no-explicit-any
+  // oxlint-disable-next-line typescript/no-explicit-any
   validate(value: any) {
     if (typeof value !== 'string') {
       return false;

--- a/packages/twenty-server/src/engine/core-modules/twenty-config/conversion/config-value-converter.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/twenty-config/conversion/config-value-converter.service.ts
@@ -76,7 +76,7 @@ export class ConfigValueConverterService {
         return appValue;
       }
 
-      // oxlint-disable-next-line @typescripttypescript/no-explicit-any
+      // oxlint-disable-next-line typescript/no-explicit-any
       return transformer.toStorage(appValue as any, options);
     } catch (error) {
       if (error instanceof ConfigVariableException) {

--- a/packages/twenty-server/src/engine/core-modules/twenty-config/decorators/assert-or-warn.decorator.ts
+++ b/packages/twenty-server/src/engine/core-modules/twenty-config/decorators/assert-or-warn.decorator.ts
@@ -5,11 +5,11 @@ import {
 } from 'class-validator';
 
 export const AssertOrWarn = (
-  // oxlint-disable-next-line @typescripttypescript/no-explicit-any
+  // oxlint-disable-next-line typescript/no-explicit-any
   condition: (object: any, value: any) => boolean,
   validationOptions?: ValidationOptions,
 ) => {
-  // oxlint-disable-next-line @typescripttypescript/no-explicit-any
+  // oxlint-disable-next-line typescript/no-explicit-any
   return function (object: any, propertyName: string) {
     registerDecorator({
       name: 'AssertOrWarn',
@@ -21,7 +21,7 @@ export const AssertOrWarn = (
       },
       constraints: [condition],
       validator: {
-        // oxlint-disable-next-line @typescripttypescript/no-explicit-any
+        // oxlint-disable-next-line typescript/no-explicit-any
         validate(value: any, args: ValidationArguments) {
           return condition(args.object, value);
         },

--- a/packages/twenty-server/src/engine/core-modules/twenty-config/decorators/cast-to-log-level-array.decorator.ts
+++ b/packages/twenty-server/src/engine/core-modules/twenty-config/decorators/cast-to-log-level-array.decorator.ts
@@ -5,7 +5,7 @@ const VALID_LOG_LEVELS = ['log', 'error', 'warn', 'debug', 'verbose'];
 export const CastToLogLevelArray = () =>
   Transform(({ value }: { value: string }) => toLogLevelArray(value));
 
-// oxlint-disable-next-line @typescripttypescript/no-explicit-any
+// oxlint-disable-next-line typescript/no-explicit-any
 const toLogLevelArray = (value: any) => {
   if (typeof value === 'string') {
     const rawLogLevels = value.split(',').map((level) => level.trim());

--- a/packages/twenty-server/src/engine/core-modules/twenty-config/decorators/cast-to-typeorm-log-level-array.decorator.ts
+++ b/packages/twenty-server/src/engine/core-modules/twenty-config/decorators/cast-to-typeorm-log-level-array.decorator.ts
@@ -4,7 +4,7 @@ import { isNonEmptyString } from '@sniptt/guards';
 export const CastToTypeORMLogLevelArray = () =>
   Transform(({ value }: { value: string }) => toTypeORMLogLevelArray(value));
 
-// oxlint-disable-next-line @typescripttypescript/no-explicit-any
+// oxlint-disable-next-line typescript/no-explicit-any
 const toTypeORMLogLevelArray = (value: any) => {
   if (isNonEmptyString(value)) {
     const rawLogLevels = value.split(',').map((level) => level.trim());

--- a/packages/twenty-server/src/engine/core-modules/twenty-config/decorators/is-strictly-lower-than.decorator.ts
+++ b/packages/twenty-server/src/engine/core-modules/twenty-config/decorators/is-strictly-lower-than.decorator.ts
@@ -16,10 +16,10 @@ export const IsStrictlyLowerThan = (
       constraints: [property],
       options: validationOptions,
       validator: {
-        // oxlint-disable-next-line @typescripttypescript/no-explicit-any
+        // oxlint-disable-next-line typescript/no-explicit-any
         validate(value: any, args: ValidationArguments) {
           const [relatedPropertyName] = args.constraints;
-          // oxlint-disable-next-line @typescripttypescript/no-explicit-any
+          // oxlint-disable-next-line typescript/no-explicit-any
           const relatedValue = (args.object as any)[relatedPropertyName];
 
           return (

--- a/packages/twenty-server/src/engine/core-modules/twenty-config/twenty-config.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/twenty-config/twenty-config.service.ts
@@ -246,10 +246,10 @@ export class TwentyConfigService {
 
   private maskSensitiveValue<T extends keyof ConfigVariables>(
     key: T,
-    // oxlint-disable-next-line @typescripttypescript/no-explicit-any
+    // oxlint-disable-next-line typescript/no-explicit-any
     value: any,
     metadata: ConfigVariablesMetadataOptions,
-    // oxlint-disable-next-line @typescripttypescript/no-explicit-any
+    // oxlint-disable-next-line typescript/no-explicit-any
   ): any {
     if (key in CONFIG_VARIABLES_MASKING_CONFIG) {
       if (!isString(value)) {

--- a/packages/twenty-server/src/engine/core-modules/twenty-config/utils/type-transformers.registry.ts
+++ b/packages/twenty-server/src/engine/core-modules/twenty-config/utils/type-transformers.registry.ts
@@ -31,7 +31,7 @@ export interface TypeTransformer<T> {
 
 export const typeTransformers: Record<
   ConfigVariableType,
-  // oxlint-disable-next-line @typescripttypescript/no-explicit-any
+  // oxlint-disable-next-line typescript/no-explicit-any
   TypeTransformer<any>
 > = {
   [ConfigVariableType.BOOLEAN]: {

--- a/packages/twenty-server/src/engine/core-modules/user/user-vars/services/user-vars.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/user/user-vars/services/user-vars.service.ts
@@ -8,7 +8,7 @@ import { mergeUserVars } from 'src/engine/core-modules/user/user-vars/utils/merg
 
 @Injectable()
 export class UserVarsService<
-  // oxlint-disable-next-line @typescripttypescript/no-explicit-any
+  // oxlint-disable-next-line typescript/no-explicit-any
   KeyValueTypesMap extends Record<string, any> = Record<string, any>,
 > {
   constructor(private readonly keyValuePairService: KeyValuePairService) {}
@@ -22,7 +22,7 @@ export class UserVarsService<
     workspaceId?: string;
     key: Extract<K, string>;
   }): Promise<KeyValueTypesMap[K]> {
-    // oxlint-disable-next-line @typescripttypescript/no-explicit-any
+    // oxlint-disable-next-line typescript/no-explicit-any
     let userVarWorkspaceLevel: any[] = [];
 
     if (workspaceId) {
@@ -40,7 +40,7 @@ export class UserVarsService<
       );
     }
 
-    // oxlint-disable-next-line @typescripttypescript/no-explicit-any
+    // oxlint-disable-next-line typescript/no-explicit-any
     let userVarUserLevel: any[] = [];
 
     if (userId) {
@@ -56,7 +56,7 @@ export class UserVarsService<
       throw new Error(`Multiple values found for key ${key} at user level`);
     }
 
-    // oxlint-disable-next-line @typescripttypescript/no-explicit-any
+    // oxlint-disable-next-line typescript/no-explicit-any
     let userVarWorkspaceAndUserLevel: any[] = [];
 
     if (userId && workspaceId) {
@@ -87,9 +87,9 @@ export class UserVarsService<
   }: {
     userId?: string;
     workspaceId?: string;
-    // oxlint-disable-next-line @typescripttypescript/no-explicit-any
+    // oxlint-disable-next-line typescript/no-explicit-any
   }): Promise<Map<Extract<keyof KeyValueTypesMap, string>, any>> {
-    // oxlint-disable-next-line @typescripttypescript/no-explicit-any
+    // oxlint-disable-next-line typescript/no-explicit-any
     let result: any[] = [];
 
     if (userId) {

--- a/packages/twenty-server/src/engine/core-modules/user/user.auto-resolver-opts.ts
+++ b/packages/twenty-server/src/engine/core-modules/user/user.auto-resolver-opts.ts
@@ -8,13 +8,13 @@ import { UserEntity } from 'src/engine/core-modules/user/user.entity';
 import { WorkspaceAuthGuard } from 'src/engine/guards/workspace-auth.guard';
 
 export const userAutoResolverOpts: AutoResolverOpts<
-  // oxlint-disable-next-line @typescripttypescript/no-explicit-any
+  // oxlint-disable-next-line typescript/no-explicit-any
   any,
-  // oxlint-disable-next-line @typescripttypescript/no-explicit-any
+  // oxlint-disable-next-line typescript/no-explicit-any
   any,
   unknown,
   unknown,
-  // oxlint-disable-next-line @typescripttypescript/no-explicit-any
+  // oxlint-disable-next-line typescript/no-explicit-any
   ReadResolverOpts<any>,
   PagingStrategies
 >[] = [

--- a/packages/twenty-server/src/engine/core-modules/workspace/workspace.auto-resolver-opts.ts
+++ b/packages/twenty-server/src/engine/core-modules/workspace/workspace.auto-resolver-opts.ts
@@ -9,13 +9,13 @@ import { WorkspaceAuthGuard } from 'src/engine/guards/workspace-auth.guard';
 import { WorkspaceEntity } from 'src/engine/core-modules/workspace/workspace.entity';
 
 export const workspaceAutoResolverOpts: AutoResolverOpts<
-  // oxlint-disable-next-line @typescripttypescript/no-explicit-any
+  // oxlint-disable-next-line typescript/no-explicit-any
   any,
-  // oxlint-disable-next-line @typescripttypescript/no-explicit-any
+  // oxlint-disable-next-line typescript/no-explicit-any
   any,
   unknown,
   unknown,
-  // oxlint-disable-next-line @typescripttypescript/no-explicit-any
+  // oxlint-disable-next-line typescript/no-explicit-any
   ReadResolverOpts<any>,
   PagingStrategies
 >[] = [

--- a/packages/twenty-server/src/engine/decorators/metadata/is-valid-metadata-name.decorator.ts
+++ b/packages/twenty-server/src/engine/decorators/metadata/is-valid-metadata-name.decorator.ts
@@ -12,7 +12,7 @@ export function IsValidMetadataName(validationOptions?: ValidationOptions) {
       propertyName: propertyName,
       options: validationOptions,
       validator: {
-        // oxlint-disable-next-line @typescripttypescript/no-explicit-any
+        // oxlint-disable-next-line typescript/no-explicit-any
         validate(value: any) {
           return /^(?!(?:not|or|and|Int|Float|Boolean|String|ID)$)[^'"\\;.=*/]+$/.test(
             value,

--- a/packages/twenty-server/src/engine/metadata-modules/field-metadata/dtos/field-metadata.dto.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/field-metadata/dtos/field-metadata.dto.ts
@@ -44,7 +44,7 @@ registerEnumType(FieldMetadataType, {
 
 @ObjectType('Field')
 @Authorize({
-  // oxlint-disable-next-line @typescripttypescript/no-explicit-any
+  // oxlint-disable-next-line typescript/no-explicit-any
   authorize: (context: any) => ({
     workspaceId: { eq: context?.req?.workspace?.id },
   }),

--- a/packages/twenty-server/src/engine/metadata-modules/field-metadata/interceptors/field-metadata-graphql-api-exception.interceptor.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/field-metadata/interceptors/field-metadata-graphql-api-exception.interceptor.ts
@@ -11,7 +11,7 @@ import { fieldMetadataGraphqlApiExceptionHandler } from 'src/engine/metadata-mod
 
 @Injectable()
 export class FieldMetadataGraphqlApiExceptionInterceptor implements NestInterceptor {
-  // oxlint-disable-next-line @typescripttypescript/no-explicit-any
+  // oxlint-disable-next-line typescript/no-explicit-any
   intercept(_context: ExecutionContext, next: CallHandler): Observable<any> {
     return next
       .handle()

--- a/packages/twenty-server/src/engine/metadata-modules/flat-entity/constant/all-metadata-serialized-relation.constant.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/flat-entity/constant/all-metadata-serialized-relation.constant.ts
@@ -7,7 +7,7 @@ type MetadataSerializedRelationProperties = {
   [TSourceMetadataName in AllMetadataName]: [
     AllJsonbPropertiesWithSerializedPropertiesForMetadataName<TSourceMetadataName>,
   ] extends [never]
-    ? // oxlint-disable-next-line @typescripttypescript/no-empty-object-type
+    ? // oxlint-disable-next-line typescript/no-empty-object-type
       {}
     : Partial<Record<AllMetadataName, true>>;
 };

--- a/packages/twenty-server/src/engine/metadata-modules/flat-entity/types/flat-entity-from.type.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/flat-entity/types/flat-entity-from.type.ts
@@ -26,5 +26,5 @@ export type FlatEntityFrom<
           ? FromMetadataEntityToMetadataName<TEntity>
           : TMetadataName
       > & { universalIdentifier: string }
-    : // oxlint-disable-next-line @typescripttypescript/no-empty-object-type
+    : // oxlint-disable-next-line typescript/no-empty-object-type
       {});

--- a/packages/twenty-server/src/engine/metadata-modules/index-metadata/dtos/index-field-metadata.dto.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/index-metadata/dtos/index-field-metadata.dto.ts
@@ -23,7 +23,7 @@ import { IndexMetadataDTO } from './index-metadata.dto';
 
 @ObjectType('IndexField')
 @Authorize({
-  // oxlint-disable-next-line @typescripttypescript/no-explicit-any
+  // oxlint-disable-next-line typescript/no-explicit-any
   authorize: (context: any) => ({
     workspaceId: { eq: context?.req?.workspace?.id },
   }),

--- a/packages/twenty-server/src/engine/metadata-modules/index-metadata/dtos/index-metadata.dto.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/index-metadata/dtos/index-metadata.dto.ts
@@ -35,7 +35,7 @@ registerEnumType(IndexType, {
 
 @ObjectType('Index')
 @Authorize({
-  // oxlint-disable-next-line @typescripttypescript/no-explicit-any
+  // oxlint-disable-next-line typescript/no-explicit-any
   authorize: (context: any) => ({
     workspaceId: { eq: context?.req?.workspace?.id },
   }),

--- a/packages/twenty-server/src/engine/metadata-modules/logic-function/dtos/logic-function.dto.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/logic-function/dtos/logic-function.dto.ts
@@ -38,7 +38,7 @@ registerEnumType(LogicFunctionExecutionMode, {
 
 @ObjectType('LogicFunction')
 @Authorize({
-  // oxlint-disable-next-line @typescripttypescript/no-explicit-any
+  // oxlint-disable-next-line typescript/no-explicit-any
   authorize: (context: any) => ({
     workspaceId: { eq: context?.req?.workspace?.id },
   }),

--- a/packages/twenty-server/src/engine/metadata-modules/logic-function/utils/logic-function-graphql-api-exception-handler.utils.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/logic-function/utils/logic-function-graphql-api-exception-handler.utils.ts
@@ -12,7 +12,7 @@ import {
   LogicFunctionExceptionCode,
 } from 'src/engine/metadata-modules/logic-function/logic-function.exception';
 
-// oxlint-disable-next-line @typescripttypescript/no-explicit-any
+// oxlint-disable-next-line typescript/no-explicit-any
 export const logicFunctionGraphQLApiExceptionHandler = (error: any) => {
   if (error instanceof LogicFunctionException) {
     switch (error.code) {

--- a/packages/twenty-server/src/engine/metadata-modules/object-metadata/dtos/object-metadata.dto.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/object-metadata/dtos/object-metadata.dto.ts
@@ -16,7 +16,7 @@ import { ObjectStandardOverridesDTO } from 'src/engine/metadata-modules/object-m
 
 @ObjectType('Object')
 @Authorize({
-  // oxlint-disable-next-line @typescripttypescript/no-explicit-any
+  // oxlint-disable-next-line typescript/no-explicit-any
   authorize: (context: any) => ({
     workspaceId: { eq: context?.req?.workspace?.id },
   }),

--- a/packages/twenty-server/src/engine/metadata-modules/object-metadata/interceptors/object-metadata-graphql-api-exception.interceptor.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/object-metadata/interceptors/object-metadata-graphql-api-exception.interceptor.ts
@@ -11,7 +11,7 @@ import { objectMetadataGraphqlApiExceptionHandler } from 'src/engine/metadata-mo
 
 @Injectable()
 export class ObjectMetadataGraphqlApiExceptionInterceptor implements NestInterceptor {
-  // oxlint-disable-next-line @typescripttypescript/no-explicit-any
+  // oxlint-disable-next-line typescript/no-explicit-any
   intercept(_context: ExecutionContext, next: CallHandler): Observable<any> {
     return next
       .handle()

--- a/packages/twenty-server/src/engine/metadata-modules/webhook/types/webhook-job-data.type.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/webhook/types/webhook-job-data.type.ts
@@ -15,7 +15,7 @@ export type CallWebhookJobData = WebhookJobBase & {
   objectMetadata: { id: string; nameSingular: string };
   workspaceMemberId?: string;
   applicationId?: string;
-  // oxlint-disable-next-line @typescripttypescript/no-explicit-any
+  // oxlint-disable-next-line typescript/no-explicit-any
   record: any;
   updatedFields?: string[];
 };

--- a/packages/twenty-server/src/engine/middlewares/middleware.service.ts
+++ b/packages/twenty-server/src/engine/middlewares/middleware.service.ts
@@ -38,7 +38,7 @@ export class MiddlewareService {
     return !!token;
   }
 
-  // oxlint-disable-next-line @typescripttypescript/no-explicit-any
+  // oxlint-disable-next-line typescript/no-explicit-any
   public writeRestResponseOnExceptionCaught(res: Response, error: any) {
     const statusCode = this.getStatus(error);
 
@@ -61,7 +61,7 @@ export class MiddlewareService {
     res.end();
   }
 
-  // oxlint-disable-next-line @typescripttypescript/no-explicit-any
+  // oxlint-disable-next-line typescript/no-explicit-any
   public writeGraphqlResponseOnExceptionCaught(res: Response, error: any) {
     let errors;
 
@@ -139,7 +139,7 @@ export class MiddlewareService {
     return isDefined((error as { status: number })?.status);
   }
 
-  // oxlint-disable-next-line @typescripttypescript/no-explicit-any
+  // oxlint-disable-next-line typescript/no-explicit-any
   private getStatus(error: any): number {
     if (this.hasErrorStatus(error)) {
       return error.status;

--- a/packages/twenty-server/src/engine/object-metadata-repository/object-metadata-repository.decorator.ts
+++ b/packages/twenty-server/src/engine/object-metadata-repository/object-metadata-repository.decorator.ts
@@ -4,7 +4,7 @@ import { capitalize } from 'twenty-shared/utils';
 
 import { convertClassNameToObjectMetadataName } from 'src/engine/workspace-manager/utils/convert-class-to-object-metadata-name.util';
 
-// oxlint-disable-next-line @typescripttypescript/no-explicit-any
+// oxlint-disable-next-line typescript/no-explicit-any
 export const InjectObjectMetadataRepository = (objectMetadata: any) => {
   const token = `${capitalize(
     convertClassNameToObjectMetadataName(objectMetadata.name),

--- a/packages/twenty-server/src/engine/twenty-orm/entity-manager/workspace-entity-manager.ts
+++ b/packages/twenty-server/src/engine/twenty-orm/entity-manager/workspace-entity-manager.ts
@@ -74,7 +74,7 @@ type PermissionOptions = {
 };
 
 export class WorkspaceEntityManager extends EntityManager {
-  // oxlint-disable-next-line @typescripttypescript/no-explicit-any
+  // oxlint-disable-next-line typescript/no-explicit-any
   readonly repositories: Map<string, Repository<any>>;
   declare connection: GlobalWorkspaceDataSource;
 
@@ -428,7 +428,7 @@ export class WorkspaceEntityManager extends EntityManager {
     if (isNaN(Number(value)))
       throw new TypeORMError(`Value "${value}" is not a number.`);
     // convert possible embeded path "social.likes" into object { social: { like: () => value } }
-    // oxlint-disable-next-line @typescripttypescript/no-explicit-any
+    // oxlint-disable-next-line typescript/no-explicit-any
     const values = propertyPath.split('.').reduceRight<any>(
       (value, key) => ({ [key]: value }),
       () => this.connection.driver.escape(column.databaseName) + ' + ' + value,
@@ -487,7 +487,7 @@ export class WorkspaceEntityManager extends EntityManager {
     return this.connection.getMetadata(target).name;
   }
 
-  // oxlint-disable-next-line @typescripttypescript/no-explicit-any
+  // oxlint-disable-next-line typescript/no-explicit-any
   private extractTargetNameSingularFromEntity(entity: any): string {
     return this.connection.getMetadata(entity.constructor).name;
   }
@@ -1040,7 +1040,7 @@ export class WorkspaceEntityManager extends EntityManager {
       );
     if (isNaN(Number(value)))
       throw new TypeORMError(`Value "${value}" is not a number.`);
-    // oxlint-disable-next-line @typescripttypescript/no-explicit-any
+    // oxlint-disable-next-line typescript/no-explicit-any
     const values = propertyPath.split('.').reduceRight<any>(
       (value, key) => ({ [key]: value }),
       () => this.connection.driver.escape(column.databaseName) + ' - ' + value,
@@ -1280,7 +1280,7 @@ export class WorkspaceEntityManager extends EntityManager {
       )
         .execute()
         .then(() => formattedEntityOrEntities as Entity[])
-        // oxlint-disable-next-line @typescripttypescript/no-misused-promises
+        // oxlint-disable-next-line typescript/no-misused-promises
         .finally(() => queryRunnerForEntityPersistExecutor.release());
 
       if (isDefined(filesFieldFileIds)) {
@@ -1501,7 +1501,7 @@ export class WorkspaceEntityManager extends EntityManager {
     )
       .execute()
       .then(() => formattedEntity as Entity | Entity[])
-      // oxlint-disable-next-line @typescripttypescript/no-misused-promises
+      // oxlint-disable-next-line typescript/no-misused-promises
       .finally(() => queryRunnerForEntityPersistExecutor.release());
 
     const formattedResult = formatResult<Entity[]>(
@@ -1650,7 +1650,7 @@ export class WorkspaceEntityManager extends EntityManager {
     )
       .execute()
       .then(() => formattedEntity as Entity)
-      // oxlint-disable-next-line @typescripttypescript/no-misused-promises
+      // oxlint-disable-next-line typescript/no-misused-promises
       .finally(() => queryRunnerForEntityPersistExecutor.release());
 
     const formattedResult = formatResult<Entity[]>(
@@ -1800,7 +1800,7 @@ export class WorkspaceEntityManager extends EntityManager {
     )
       .execute()
       .then(() => formattedEntity as Entity)
-      // oxlint-disable-next-line @typescripttypescript/no-misused-promises
+      // oxlint-disable-next-line typescript/no-misused-promises
       .finally(() => queryRunnerForEntityPersistExecutor.release());
 
     const formattedResult = formatResult<Entity[]>(
@@ -1834,7 +1834,7 @@ export class WorkspaceEntityManager extends EntityManager {
 
   // Forbidden methods
 
-  // oxlint-disable-next-line @typescripttypescript/no-explicit-any
+  // oxlint-disable-next-line typescript/no-explicit-any
   override query<T = any>(_query: string, _parameters?: any[]): Promise<T> {
     throw new PermissionsException(
       'Method not allowed.',

--- a/packages/twenty-server/src/engine/twenty-orm/global-workspace-datasource/global-workspace-datasource.ts
+++ b/packages/twenty-server/src/engine/twenty-orm/global-workspace-datasource/global-workspace-datasource.ts
@@ -116,7 +116,7 @@ export class GlobalWorkspaceDataSource extends DataSource {
 
     Object.assign(queryRunner, { manager: manager });
 
-    // oxlint-disable-next-line @typescripttypescript/no-explicit-any
+    // oxlint-disable-next-line typescript/no-explicit-any
     return queryRunner as any as WorkspaceQueryRunner;
   }
 
@@ -181,17 +181,17 @@ export class GlobalWorkspaceDataSource extends DataSource {
 
   override createQueryBuilder(
     queryRunner?: QueryRunner,
-    options?: CreateQueryBuilderOptions, // oxlint-disable-next-line @typescripttypescript/no-explicit-any
+    options?: CreateQueryBuilderOptions, // oxlint-disable-next-line typescript/no-explicit-any
   ): SelectQueryBuilder<any>;
 
   // Only callable from workspaceEntityManager to guarantee a permission check was run
   override createQueryBuilder(
-    // oxlint-disable-next-line @typescripttypescript/no-explicit-any
+    // oxlint-disable-next-line typescript/no-explicit-any
     queryRunnerOrEntityClass?: QueryRunner | EntityTarget<any>,
     aliasOrOptions?: string | CreateQueryBuilderOptions,
     queryRunner?: QueryRunner,
     options?: CreateQueryBuilderOptions,
-    // oxlint-disable-next-line @typescripttypescript/no-explicit-any
+    // oxlint-disable-next-line typescript/no-explicit-any
   ): SelectQueryBuilder<any> {
     let calledByWorkspaceEntityManager;
 
@@ -214,7 +214,7 @@ export class GlobalWorkspaceDataSource extends DataSource {
     }
 
     if (isCalledWithEntityTarget) {
-      // oxlint-disable-next-line @typescripttypescript/no-explicit-any
+      // oxlint-disable-next-line typescript/no-explicit-any
       const entityClass = queryRunnerOrEntityClass as EntityTarget<any>;
 
       return super.createQueryBuilder(
@@ -229,10 +229,10 @@ export class GlobalWorkspaceDataSource extends DataSource {
     }
   }
 
-  // oxlint-disable-next-line @typescripttypescript/no-explicit-any
+  // oxlint-disable-next-line typescript/no-explicit-any
   override query<T = any>(
     query: string,
-    // oxlint-disable-next-line @typescripttypescript/no-explicit-any
+    // oxlint-disable-next-line typescript/no-explicit-any
     parameters?: any[],
     queryRunner?: QueryRunner,
     options?: {

--- a/packages/twenty-server/src/engine/twenty-orm/repository/workspace-select-query-builder.ts
+++ b/packages/twenty-server/src/engine/twenty-orm/repository/workspace-select-query-builder.ts
@@ -71,7 +71,7 @@ export class WorkspaceSelectQueryBuilder<
     return workspaceSelectQueryBuilder;
   }
 
-  // oxlint-disable-next-line @typescripttypescript/no-explicit-any
+  // oxlint-disable-next-line typescript/no-explicit-any
   override async execute(): Promise<any> {
     try {
       this.validatePermissions();
@@ -132,7 +132,7 @@ export class WorkspaceSelectQueryBuilder<
     }
   }
 
-  // oxlint-disable-next-line @typescripttypescript/no-explicit-any
+  // oxlint-disable-next-line typescript/no-explicit-any
   override async getRawOne<U = any>(): Promise<U | undefined> {
     try {
       this.validatePermissions();
@@ -143,7 +143,7 @@ export class WorkspaceSelectQueryBuilder<
     }
   }
 
-  // oxlint-disable-next-line @typescripttypescript/no-explicit-any
+  // oxlint-disable-next-line typescript/no-explicit-any
   override async getRawMany<U = any>(): Promise<U[]> {
     try {
       this.validatePermissions();

--- a/packages/twenty-server/src/engine/twenty-orm/utils/apply-row-level-permission-predicates.util.ts
+++ b/packages/twenty-server/src/engine/twenty-orm/utils/apply-row-level-permission-predicates.util.ts
@@ -131,7 +131,7 @@ const parseKeyFilter = ({
   outerQueryBuilder: WorkspaceSelectQueryBuilder<ObjectLiteral>;
   objectNameSingular: string;
   key: string;
-  // oxlint-disable-next-line @typescripttypescript/no-explicit-any
+  // oxlint-disable-next-line typescript/no-explicit-any
   value: any;
   isFirst: boolean;
   fieldParser: GraphqlQueryFilterFieldParser;

--- a/packages/twenty-server/src/engine/twenty-orm/utils/format-data.util.ts
+++ b/packages/twenty-server/src/engine/twenty-orm/utils/format-data.util.ts
@@ -40,7 +40,7 @@ export function formatData<T>(
 
   const { fieldIdByName, fieldIdByJoinColumnName } = fieldMaps;
 
-  // oxlint-disable-next-line @typescripttypescript/no-explicit-any
+  // oxlint-disable-next-line typescript/no-explicit-any
   const newData: Record<string, any> = {};
 
   for (const [key, value] of Object.entries(data)) {
@@ -73,10 +73,10 @@ export function formatData<T>(
 }
 
 export function formatCompositeField(
-  // oxlint-disable-next-line @typescripttypescript/no-explicit-any
+  // oxlint-disable-next-line typescript/no-explicit-any
   value: any,
   fieldMetadata: FlatFieldMetadata,
-  // oxlint-disable-next-line @typescripttypescript/no-explicit-any
+  // oxlint-disable-next-line typescript/no-explicit-any
 ): Record<string, any> {
   const compositeType = compositeTypeDefinitions.get(
     fieldMetadata.type as CompositeFieldMetadataType,
@@ -88,7 +88,7 @@ export function formatCompositeField(
     );
   }
 
-  // oxlint-disable-next-line @typescripttypescript/no-explicit-any
+  // oxlint-disable-next-line typescript/no-explicit-any
   const formattedCompositeField: Record<string, any> = {};
 
   for (const property of compositeType.properties) {
@@ -107,7 +107,7 @@ export function formatCompositeField(
 }
 
 function formatFieldMetadataValue(
-  // oxlint-disable-next-line @typescripttypescript/no-explicit-any
+  // oxlint-disable-next-line typescript/no-explicit-any
   value: any,
   fieldMetadata: FlatFieldMetadata,
 ) {

--- a/packages/twenty-server/src/engine/twenty-orm/utils/format-result.util.ts
+++ b/packages/twenty-server/src/engine/twenty-orm/utils/format-result.util.ts
@@ -27,7 +27,7 @@ import { getCompositeFieldMetadataCollection } from 'src/engine/twenty-orm/utils
 import { isFieldMetadataEntityOfType } from 'src/engine/utils/is-field-metadata-of-type.util';
 
 export function formatResult<T>(
-  // oxlint-disable-next-line @typescripttypescript/no-explicit-any
+  // oxlint-disable-next-line typescript/no-explicit-any
   data: any,
   flatObjectMetadata: FlatObjectMetadata | undefined,
   flatObjectMetadataMaps: FlatEntityMaps<FlatObjectMetadata>,
@@ -246,7 +246,7 @@ export function getCompositeFieldMetadataMap(
 }
 
 function formatFieldMetadataValue(
-  // oxlint-disable-next-line @typescripttypescript/no-explicit-any
+  // oxlint-disable-next-line typescript/no-explicit-any
   value: any,
   fieldMetadataType: FieldMetadataType,
 ) {
@@ -321,7 +321,7 @@ function formatCompositeFieldValue(
  * or records with incomplete data.
  */
 function handleEmptyCompositeFields(
-  // oxlint-disable-next-line @typescripttypescript/no-explicit-any
+  // oxlint-disable-next-line typescript/no-explicit-any
   data: Record<string, any>,
   flatObjectMetadata: FlatObjectMetadata,
   flatFieldMetadataMaps: FlatEntityMaps<FlatFieldMetadata>,
@@ -344,7 +344,7 @@ function handleEmptyCompositeFields(
       continue;
     }
 
-    // oxlint-disable-next-line @typescripttypescript/no-explicit-any
+    // oxlint-disable-next-line typescript/no-explicit-any
     const typedFieldValue = fieldValue as Record<string, any>;
 
     // Check if all required properties are null/undefined
@@ -377,7 +377,7 @@ function handleEmptyCompositeFields(
  */
 function getDefaultCompositeFieldValue(
   fieldType: FieldMetadataType,
-  // oxlint-disable-next-line @typescripttypescript/no-explicit-any
+  // oxlint-disable-next-line typescript/no-explicit-any
 ): Record<string, any> | null {
   switch (fieldType) {
     case FieldMetadataType.ACTOR:

--- a/packages/twenty-server/src/engine/twenty-orm/utils/is-record-matching-rls-row-level-permission-predicate.util.ts
+++ b/packages/twenty-server/src/engine/twenty-orm/utils/is-record-matching-rls-row-level-permission-predicate.util.ts
@@ -81,7 +81,7 @@ export const isRecordMatchingRLSRowLevelPermissionPredicate = ({
   flatFieldMetadataMaps,
   shouldIgnoreSoftDeleteDefaultFilter,
 }: {
-  // oxlint-disable-next-line @typescripttypescript/no-explicit-any
+  // oxlint-disable-next-line typescript/no-explicit-any
   record: any;
   filter: RecordGqlOperationFilter;
   flatObjectMetadata: FlatObjectMetadata;

--- a/packages/twenty-server/src/engine/utils/generate-fake-value.ts
+++ b/packages/twenty-server/src/engine/utils/generate-fake-value.ts
@@ -26,7 +26,7 @@ const generatePrimitiveValue = (valueType: string): FakeValueTypes => {
 
     return Array.from({ length: 3 }, () => generateFakeValue(elementType));
   } else if (valueType.startsWith('{') && valueType.endsWith('}')) {
-    // oxlint-disable-next-line @typescripttypescript/no-explicit-any
+    // oxlint-disable-next-line typescript/no-explicit-any
     const objData: Record<string, any> = {};
 
     const properties = valueType

--- a/packages/twenty-server/src/engine/workspace-cache-storage/workspace-cache-storage.service.ts
+++ b/packages/twenty-server/src/engine/workspace-cache-storage/workspace-cache-storage.service.ts
@@ -47,10 +47,10 @@ export class WorkspaceCacheStorageService {
   setORMEntitySchema(
     workspaceId: string,
     metadataVersion: number,
-    // oxlint-disable-next-line @typescripttypescript/no-explicit-any
+    // oxlint-disable-next-line typescript/no-explicit-any
     entitySchemas: EntitySchemaOptions<any>[],
   ) {
-    // oxlint-disable-next-line @typescripttypescript/no-explicit-any
+    // oxlint-disable-next-line typescript/no-explicit-any
     return this.cacheStorageService.set<EntitySchemaOptions<any>[]>(
       `${METADATA_VERSIONED_WORKSPACE_CACHE_KEY.ORMEntitySchemas}:${workspaceId}:${metadataVersion}`,
       entitySchemas,
@@ -61,9 +61,9 @@ export class WorkspaceCacheStorageService {
   getORMEntitySchema(
     workspaceId: string,
     metadataVersion: number,
-    // oxlint-disable-next-line @typescripttypescript/no-explicit-any
+    // oxlint-disable-next-line typescript/no-explicit-any
   ): Promise<EntitySchemaOptions<any>[] | undefined> {
-    // oxlint-disable-next-line @typescripttypescript/no-explicit-any
+    // oxlint-disable-next-line typescript/no-explicit-any
     return this.cacheStorageService.get<EntitySchemaOptions<any>[]>(
       `${METADATA_VERSIONED_WORKSPACE_CACHE_KEY.ORMEntitySchemas}:${workspaceId}:${metadataVersion}`,
     );

--- a/packages/twenty-server/src/engine/workspace-datasource/workspace-datasource.service.ts
+++ b/packages/twenty-server/src/engine/workspace-datasource/workspace-datasource.service.ts
@@ -90,11 +90,11 @@ export class WorkspaceDataSourceService {
 
   public async executeRawQuery(
     _query: string,
-    // oxlint-disable-next-line @typescripttypescript/no-explicit-any
+    // oxlint-disable-next-line typescript/no-explicit-any
     _parameters: any[] = [],
     _workspaceId: string,
     _transactionManager?: EntityManager,
-    // oxlint-disable-next-line @typescripttypescript/no-explicit-any
+    // oxlint-disable-next-line typescript/no-explicit-any
   ): Promise<any> {
     throw new PermissionsException(
       'Method not allowed as permissions are not handled at datasource level.',

--- a/packages/twenty-server/src/filters/unhandled-exception.filter.ts
+++ b/packages/twenty-server/src/filters/unhandled-exception.filter.ts
@@ -12,7 +12,7 @@ import { type Response } from 'express';
 // This class add CORS headers to exception response to avoid misleading CORS error
 @Catch()
 export class UnhandledExceptionFilter implements ExceptionFilter {
-  // oxlint-disable-next-line @typescripttypescript/no-explicit-any
+  // oxlint-disable-next-line typescript/no-explicit-any
   catch(exception: any, host: ArgumentsHost) {
     const ctx = host.switchToHttp();
     const response = ctx.getResponse<Response>();

--- a/packages/twenty-server/src/modules/calendar/calendar-event-import-manager/drivers/utils/sanitizeCalendarEvent.ts
+++ b/packages/twenty-server/src/modules/calendar/calendar-event-import-manager/drivers/utils/sanitizeCalendarEvent.ts
@@ -1,6 +1,6 @@
 import { isDefined } from 'twenty-shared/utils';
 
-// oxlint-disable-next-line @typescripttypescript/no-explicit-any
+// oxlint-disable-next-line typescript/no-explicit-any
 export const sanitizeCalendarEvent = <T extends Record<string, any>>(
   event: T,
   propertiesToSanitize: (keyof T)[],

--- a/packages/twenty-server/src/modules/messaging/message-import-manager/drivers/microsoft/services/microsoft-get-messages.interface.ts
+++ b/packages/twenty-server/src/modules/messaging/message-import-manager/drivers/microsoft/services/microsoft-get-messages.interface.ts
@@ -13,7 +13,7 @@ export interface MicrosoftGraphBatchResponse {
       createdDateTime?: string;
       lastModifiedDateTime?: string;
       changeKey?: string;
-      // oxlint-disable-next-line @typescripttypescript/no-explicit-any
+      // oxlint-disable-next-line typescript/no-explicit-any
       categories?: any[];
       receivedDateTime?: string;
       sentDateTime?: string;

--- a/packages/twenty-server/src/modules/messaging/message-import-manager/drivers/microsoft/services/microsoft-get-messages.service.ts
+++ b/packages/twenty-server/src/modules/messaging/message-import-manager/drivers/microsoft/services/microsoft-get-messages.service.ts
@@ -166,7 +166,7 @@ export class MicrosoftGetMessagesService {
       return [];
     }
 
-    // oxlint-disable-next-line @typescripttypescript/no-explicit-any
+    // oxlint-disable-next-line typescript/no-explicit-any
     return batchResponse.responses.map((response: any) => {
       if (response.status === 200) {
         return response.body;

--- a/packages/twenty-server/src/modules/messaging/message-import-manager/drivers/microsoft/services/microsoft-message-list-fetch-error-handler.service.ts
+++ b/packages/twenty-server/src/modules/messaging/message-import-manager/drivers/microsoft/services/microsoft-message-list-fetch-error-handler.service.ts
@@ -13,7 +13,7 @@ export class MicrosoftMessageListFetchErrorHandler {
     private readonly microsoftNetworkErrorHandler: MicrosoftNetworkErrorHandler,
   ) {}
 
-  // oxlint-disable-next-line @typescripttypescript/no-explicit-any
+  // oxlint-disable-next-line typescript/no-explicit-any
   public handleError(error: any): void {
     this.logger.error(`Error fetching message list: ${JSON.stringify(error)}`);
 

--- a/packages/twenty-server/src/modules/messaging/message-import-manager/drivers/microsoft/services/microsoft-messages-import-error-handler.service.ts
+++ b/packages/twenty-server/src/modules/messaging/message-import-manager/drivers/microsoft/services/microsoft-messages-import-error-handler.service.ts
@@ -13,7 +13,7 @@ export class MicrosoftMessagesImportErrorHandler {
     private readonly microsoftNetworkErrorHandler: MicrosoftNetworkErrorHandler,
   ) {}
 
-  // oxlint-disable-next-line @typescripttypescript/no-explicit-any
+  // oxlint-disable-next-line typescript/no-explicit-any
   public handleError(error: any): void {
     this.logger.error(`Error fetching messages: ${JSON.stringify(error)}`);
 

--- a/packages/twenty-server/src/modules/messaging/message-import-manager/drivers/microsoft/services/microsoft-network-error-handler.service.ts
+++ b/packages/twenty-server/src/modules/messaging/message-import-manager/drivers/microsoft/services/microsoft-network-error-handler.service.ts
@@ -10,7 +10,7 @@ import { isMicrosoftClientTemporaryError } from 'src/modules/messaging/message-i
 export class MicrosoftNetworkErrorHandler {
   private readonly logger = new Logger(MicrosoftNetworkErrorHandler.name);
 
-  // oxlint-disable-next-line @typescripttypescript/no-explicit-any
+  // oxlint-disable-next-line typescript/no-explicit-any
   public handleError(error: any): MessageImportDriverException | null {
     const isBodyString = error.body && typeof error.body === 'string';
     const isTemporaryError =

--- a/packages/twenty-server/src/modules/workflow/workflow-builder/workflow-schema/types/output-schema.type.ts
+++ b/packages/twenty-server/src/modules/workflow/workflow-builder/workflow-schema/types/output-schema.type.ts
@@ -6,7 +6,7 @@ export type Leaf = {
   icon?: string;
   label?: string;
   description?: string;
-  // oxlint-disable-next-line @typescripttypescript/no-explicit-any
+  // oxlint-disable-next-line typescript/no-explicit-any
   value: any;
   isCompositeSubField?: boolean;
 };

--- a/packages/twenty-server/src/modules/workflow/workflow-builder/workflow-version-step/utils/__tests__/remove-step.spec.ts
+++ b/packages/twenty-server/src/modules/workflow/workflow-builder/workflow-version-step/utils/__tests__/remove-step.spec.ts
@@ -1,4 +1,4 @@
-// oxlint-disable-next-line @typescripttypescript/ban-ts-comment
+// oxlint-disable-next-line typescript/ban-ts-comment
 // @ts-nocheck
 // Disabled type checking due to tsgo performance issue with deep spread operations
 // See: https://github.com/microsoft/typescript-go/issues/2551

--- a/packages/twenty-server/src/modules/workflow/workflow-executor/workflow-actions/code/types/workflow-code-action-input.type.ts
+++ b/packages/twenty-server/src/modules/workflow/workflow-executor/workflow-actions/code/types/workflow-code-action-input.type.ts
@@ -1,7 +1,7 @@
 export type WorkflowCodeActionInput = {
   logicFunctionId: string;
   logicFunctionInput: {
-    // oxlint-disable-next-line @typescripttypescript/no-explicit-any
+    // oxlint-disable-next-line typescript/no-explicit-any
     [key: string]: any;
   };
 };

--- a/packages/twenty-server/src/modules/workflow/workflow-executor/workflow-actions/form/types/workflow-form-action-settings.type.ts
+++ b/packages/twenty-server/src/modules/workflow/workflow-executor/workflow-actions/form/types/workflow-form-action-settings.type.ts
@@ -6,10 +6,10 @@ export type FormFieldMetadata = {
   name: string;
   label: string;
   type: WorkflowFormFieldType;
-  // oxlint-disable-next-line @typescripttypescript/no-explicit-any
+  // oxlint-disable-next-line typescript/no-explicit-any
   value?: any;
   placeholder?: string;
-  // oxlint-disable-next-line @typescripttypescript/no-explicit-any
+  // oxlint-disable-next-line typescript/no-explicit-any
   settings?: Record<string, any>;
 };
 

--- a/packages/twenty-server/src/modules/workflow/workflow-executor/workflow-actions/iterator/types/workflow-iterator-action-settings.type.ts
+++ b/packages/twenty-server/src/modules/workflow/workflow-executor/workflow-actions/iterator/types/workflow-iterator-action-settings.type.ts
@@ -1,7 +1,7 @@
 import { type BaseWorkflowActionSettings } from 'src/modules/workflow/workflow-executor/workflow-actions/types/workflow-action-settings.type';
 
 export type WorkflowIteratorActionInput = {
-  // oxlint-disable-next-line @typescripttypescript/no-explicit-any
+  // oxlint-disable-next-line typescript/no-explicit-any
   items?: Array<any> | string;
   initialLoopStepIds?: string[];
   shouldContinueOnIterationFailure?: boolean;

--- a/packages/twenty-server/src/modules/workflow/workflow-executor/workflow-actions/logic-function/types/workflow-logic-function-action-input.type.ts
+++ b/packages/twenty-server/src/modules/workflow/workflow-executor/workflow-actions/logic-function/types/workflow-logic-function-action-input.type.ts
@@ -1,7 +1,7 @@
 export type WorkflowLogicFunctionActionInput = {
   logicFunctionId: string;
   logicFunctionInput: {
-    // oxlint-disable-next-line @typescripttypescript/no-explicit-any
+    // oxlint-disable-next-line typescript/no-explicit-any
     [key: string]: any;
   };
 };

--- a/packages/twenty-server/src/modules/workflow/workflow-trigger/utils/assert-version-can-be-activated.util.ts
+++ b/packages/twenty-server/src/modules/workflow/workflow-trigger/utils/assert-version-can-be-activated.util.ts
@@ -85,7 +85,7 @@ function assertVersionIsValid(workflowVersion: WorkflowVersionWorkspaceEntity) {
 
 function assertTriggerSettingsAreValid(
   triggerType: WorkflowTriggerType,
-  // oxlint-disable-next-line @typescripttypescript/no-explicit-any
+  // oxlint-disable-next-line typescript/no-explicit-any
   settings: any,
 ) {
   switch (triggerType) {
@@ -109,7 +109,7 @@ function assertTriggerSettingsAreValid(
   }
 }
 
-// oxlint-disable-next-line @typescripttypescript/no-explicit-any
+// oxlint-disable-next-line typescript/no-explicit-any
 function assertCronTriggerSettingsAreValid(settings: any) {
   if (!settings?.type) {
     throw new WorkflowTriggerException(
@@ -251,7 +251,7 @@ function assertCronTriggerSettingsAreValid(settings: any) {
   }
 }
 
-// oxlint-disable-next-line @typescripttypescript/no-explicit-any
+// oxlint-disable-next-line typescript/no-explicit-any
 function assertDatabaseEventTriggerSettingsAreValid(settings: any) {
   if (!settings?.eventName) {
     throw new WorkflowTriggerException(

--- a/packages/twenty-server/src/utils/camel-case.ts
+++ b/packages/twenty-server/src/utils/camel-case.ts
@@ -13,7 +13,7 @@ export const camelCaseDeep = <T>(value: T): CamelCasedPropertiesDeep<T> => {
 
   // Check if it's an object
   if (isObject(value)) {
-    // oxlint-disable-next-line @typescripttypescript/no-explicit-any
+    // oxlint-disable-next-line typescript/no-explicit-any
     const result: Record<string, any> = {};
 
     for (const key in value) {

--- a/packages/twenty-server/src/utils/date/isValidDate.ts
+++ b/packages/twenty-server/src/utils/date/isValidDate.ts
@@ -1,4 +1,4 @@
-// oxlint-disable-next-line @typescripttypescript/no-explicit-any
+// oxlint-disable-next-line typescript/no-explicit-any
 export const isValidDate = (date: any): date is Date => {
   return date instanceof Date && !isNaN(date.getTime());
 };

--- a/packages/twenty-server/src/utils/kebab-case.ts
+++ b/packages/twenty-server/src/utils/kebab-case.ts
@@ -13,7 +13,7 @@ export const kebabCaseDeep = <T>(value: T): KebabCasedPropertiesDeep<T> => {
 
   // Check if it's an object
   if (isObject(value)) {
-    // oxlint-disable-next-line @typescripttypescript/no-explicit-any
+    // oxlint-disable-next-line typescript/no-explicit-any
     const result: Record<string, any> = {};
 
     for (const key in value) {

--- a/packages/twenty-server/src/utils/remove-secret-from-webhook-record.ts
+++ b/packages/twenty-server/src/utils/remove-secret-from-webhook-record.ts
@@ -1,8 +1,8 @@
 export const removeSecretFromWebhookRecord = (
-  // oxlint-disable-next-line @typescripttypescript/no-explicit-any
+  // oxlint-disable-next-line typescript/no-explicit-any
   record: Record<string, any> | undefined,
   isWebhookEvent: boolean,
-  // oxlint-disable-next-line @typescripttypescript/no-explicit-any
+  // oxlint-disable-next-line typescript/no-explicit-any
 ): Record<string, any> | undefined => {
   if (!isWebhookEvent || !record) return record;
 


### PR DESCRIPTION
## What

Many `oxlint-disable` / `eslint-disable` directives across the repo carry a corrupted rule id — `@typescripttypescript/<rule>` — most likely a find-and-replace accident that mangled the eslint-era `@typescript-eslint/` prefix.

oxlint matches disable directives **loosely by rule name**, so these still suppress in practice (not a silent no-op), but the id is malformed and misleading.

## Change

Replace them with the **canonical oxlint id** `typescript/<rule>` — matching the plugin name and rule keys declared in `.oxlintrc.json` — **127 files, 262 directives**:

| rule | count |
| --- | ----- |
| `typescript/no-explicit-any` | 250 |
| `typescript/ban-ts-comment` | 6 |
| `typescript/no-misused-promises` | 4 |
| `typescript/no-empty-object-type` | 2 |

- `twenty-server`: 122 files
- `twenty-front`: 5 files

Comment-only — no code or runtime changes.

## Verification

`oxlint --type-aware -c .oxlintrc.json` reports **0 warnings / 0 errors** for both `twenty-server` and `twenty-front`. Every changed line is exactly the id correction inside a disable directive (262 insertions / 262 deletions, no collateral edits).

> Addresses the cubic review, which flagged that the canonical oxlint id is `typescript/...` (no `@`). Worth noting the original `@typescripttypescript/` was not actually a silent no-op — oxlint matches these directives loosely by rule name — but `typescript/` is the correct, config-aligned id.
