### PR TITLE
fix(front): reject backslash paths in isValidReturnToPath (open-redirect hardening)

### DIFF
--- a/packages/twenty-front/src/modules/auth/utils/__tests__/isValidReturnToPath.test.ts
+++ b/packages/twenty-front/src/modules/auth/utils/__tests__/isValidReturnToPath.test.ts
@@ -18,7 +18,6 @@ describe('isValidReturnToPath', () => {
   });
 
   it('should return false for backslash-tricked paths', () => {
-    // Browsers normalize "\" to "/", so these resolve like "//evil.com".
     expect(isValidReturnToPath('/\\evil.com')).toBe(false);
     expect(isValidReturnToPath('/\\/evil.com')).toBe(false);
     expect(isValidReturnToPath('/objects\\..\\evil')).toBe(false);

--- a/packages/twenty-front/src/modules/auth/utils/__tests__/isValidReturnToPath.test.ts
+++ b/packages/twenty-front/src/modules/auth/utils/__tests__/isValidReturnToPath.test.ts
@@ -17,6 +17,13 @@ describe('isValidReturnToPath', () => {
     expect(isValidReturnToPath('//evil.com')).toBe(false);
   });
 
+  it('should return false for backslash-tricked paths', () => {
+    // Browsers normalize "\" to "/", so these resolve like "//evil.com".
+    expect(isValidReturnToPath('/\\evil.com')).toBe(false);
+    expect(isValidReturnToPath('/\\/evil.com')).toBe(false);
+    expect(isValidReturnToPath('/objects\\..\\evil')).toBe(false);
+  });
+
   it('should return false for onboarding paths', () => {
     expect(isValidReturnToPath('/create/workspace')).toBe(false);
     expect(isValidReturnToPath('/create/profile')).toBe(false);

--- a/packages/twenty-front/src/modules/auth/utils/isValidReturnToPath.ts
+++ b/packages/twenty-front/src/modules/auth/utils/isValidReturnToPath.ts
@@ -16,15 +16,7 @@ export const isValidReturnToPath = (path: string): boolean => {
     return false;
   }
 
-  if (!path.startsWith('/') || path.startsWith('//')) {
-    return false;
-  }
-
-  // Browsers normalize "\" to "/", so "/\evil.com" resolves like the
-  // protocol-relative "//evil.com" (an external URL) even though it passes the
-  // "//" check above. Reject backslashes so a returnTo can only ever be a
-  // same-site absolute path.
-  if (path.includes('\\')) {
+  if (!path.startsWith('/') || path.startsWith('//') || path.includes('\\')) {
     return false;
   }
 

--- a/packages/twenty-front/src/modules/auth/utils/isValidReturnToPath.ts
+++ b/packages/twenty-front/src/modules/auth/utils/isValidReturnToPath.ts
@@ -20,5 +20,13 @@ export const isValidReturnToPath = (path: string): boolean => {
     return false;
   }
 
+  // Browsers normalize "\" to "/", so "/\evil.com" resolves like the
+  // protocol-relative "//evil.com" (an external URL) even though it passes the
+  // "//" check above. Reject backslashes so a returnTo can only ever be a
+  // same-site absolute path.
+  if (path.includes('\\')) {
+    return false;
+  }
+
   return !EXCLUDED_PATH_PREFIXES.some((prefix) => path.startsWith(prefix));
 };


### PR DESCRIPTION
## Summary

`isValidReturnToPath` validates the post-login `returnTo` path and already rejects protocol-relative `//` paths — but not the backslash variant. Browsers normalize `\` to `/`, so `/\evil.com` resolves like `//evil.com` (a protocol-relative, external URL) while still passing the existing `//` check:

```ts
isValidReturnToPath("/\\evil.com"); // returns true today; should be false
```

This hardens the open-redirect guard by rejecting any path containing a backslash, so a `returnTo` can only ever be a same-site absolute path.

## Changes
- `isValidReturnToPath`: reject paths containing `\`.
- Added tests for backslash-tricked paths.

Framed as defense-in-depth — the validator should reject this class regardless of how each consumer performs the redirect.
