### PR TITLE
fix: use correct userWorkspaceId for navigation menu comparisons

### DIFF
--- a/packages/twenty-front/src/modules/command-menu-item/engine-command/record/single-record/components/AddToFavoritesSingleRecordCommand.tsx
+++ b/packages/twenty-front/src/modules/command-menu-item/engine-command/record/single-record/components/AddToFavoritesSingleRecordCommand.tsx
@@ -18,7 +18,7 @@ export const AddToFavoritesSingleRecordCommand = () => {
   }
 
   const { createManyNavigationMenuItems } = useCreateManyNavigationMenuItems();
-  const { navigationMenuItems, currentWorkspaceMemberId } =
+  const { navigationMenuItems, currentUserWorkspaceId } =
     useNavigationMenuItemsData();
 
   const handleExecute = () => {
@@ -41,7 +41,7 @@ export const AddToFavoritesSingleRecordCommand = () => {
         type: NavigationMenuItemType.RECORD,
         targetRecordId: selectedRecord.id,
         targetObjectMetadataId: objectMetadataItem.id,
-        userWorkspaceId: currentWorkspaceMemberId,
+        userWorkspaceId: currentUserWorkspaceId,
         position: maxPosition + 1,
       },
     ]);

--- a/packages/twenty-front/src/modules/navigation-menu-item/display/hooks/useNavigationMenuItemsData.ts
+++ b/packages/twenty-front/src/modules/navigation-menu-item/display/hooks/useNavigationMenuItemsData.ts
@@ -42,6 +42,7 @@ export const useNavigationMenuItemsData = (): NavigationMenuItemsData => {
     navigationMenuItems: userNavigationMenuItems,
     workspaceNavigationMenuItems,
     currentWorkspaceMemberId,
-    currentUserWorkspaceId: currentWorkspaceMember?.userWorkspaceId ?? undefined,
+    currentUserWorkspaceId:
+      currentWorkspaceMember?.userWorkspaceId ?? undefined,
   };
 };

--- a/packages/twenty-front/src/modules/navigation-menu-item/display/hooks/useNavigationMenuItemsData.ts
+++ b/packages/twenty-front/src/modules/navigation-menu-item/display/hooks/useNavigationMenuItemsData.ts
@@ -12,6 +12,7 @@ type NavigationMenuItemsData = {
   navigationMenuItems: NavigationMenuItem[];
   workspaceNavigationMenuItems: NavigationMenuItem[];
   currentWorkspaceMemberId: string | undefined;
+  currentUserWorkspaceId: string | undefined;
 };
 
 export const useNavigationMenuItemsData = (): NavigationMenuItemsData => {
@@ -41,5 +42,6 @@ export const useNavigationMenuItemsData = (): NavigationMenuItemsData => {
     navigationMenuItems: userNavigationMenuItems,
     workspaceNavigationMenuItems,
     currentWorkspaceMemberId,
+    currentUserWorkspaceId: currentWorkspaceMember?.userWorkspaceId,
   };
 };

--- a/packages/twenty-front/src/modules/navigation-menu-item/display/hooks/useNavigationMenuItemsData.ts
+++ b/packages/twenty-front/src/modules/navigation-menu-item/display/hooks/useNavigationMenuItemsData.ts
@@ -42,6 +42,6 @@ export const useNavigationMenuItemsData = (): NavigationMenuItemsData => {
     navigationMenuItems: userNavigationMenuItems,
     workspaceNavigationMenuItems,
     currentWorkspaceMemberId,
-    currentUserWorkspaceId: currentWorkspaceMember?.userWorkspaceId,
+    currentUserWorkspaceId: currentWorkspaceMember?.userWorkspaceId ?? undefined,
   };
 };

--- a/packages/twenty-front/src/modules/navigation-menu-item/edit/hooks/useNavigationMenuItemEditController.ts
+++ b/packages/twenty-front/src/modules/navigation-menu-item/edit/hooks/useNavigationMenuItemEditController.ts
@@ -47,7 +47,7 @@ export const useNavigationMenuItemEditController = () => {
   const {
     navigationMenuItems,
     workspaceNavigationMenuItems,
-    currentWorkspaceMemberId,
+    currentUserWorkspaceId,
   } = useNavigationMenuItemsData();
   const setNavigationMenuItemsDraft = useSetAtomState(
     navigationMenuItemsDraftState,
@@ -62,7 +62,7 @@ export const useNavigationMenuItemEditController = () => {
     : navigationMenuItems;
   const targetUserWorkspaceId = isDraftMode
     ? undefined
-    : currentWorkspaceMemberId;
+    : currentUserWorkspaceId;
 
   const createItem = (
     input: NewNavigationMenuItemInput,

--- a/packages/twenty-front/src/modules/views/view-picker/components/ViewPickerOptionDropdown.tsx
+++ b/packages/twenty-front/src/modules/views/view-picker/components/ViewPickerOptionDropdown.tsx
@@ -56,7 +56,7 @@ export const ViewPickerOptionDropdown = ({
   const hasViewsPermission = useHasPermissionFlag(PermissionFlagType.VIEWS);
 
   const { createManyNavigationMenuItems } = useCreateManyNavigationMenuItems();
-  const { navigationMenuItems, currentWorkspaceMemberId } =
+  const { navigationMenuItems, currentUserWorkspaceId } =
     useNavigationMenuItemsData();
 
   // Users with VIEWS permission can edit all views
@@ -67,7 +67,7 @@ export const ViewPickerOptionDropdown = ({
   const isFavorite = navigationMenuItems.some(
     (item) =>
       item.viewId === view.id &&
-      item.userWorkspaceId === currentWorkspaceMemberId,
+      item.userWorkspaceId === currentUserWorkspaceId,
   );
 
   const handleDelete = () => {
@@ -92,7 +92,7 @@ export const ViewPickerOptionDropdown = ({
           id: uuidv4(),
           type: NavigationMenuItemType.VIEW,
           viewId: view.id,
-          userWorkspaceId: currentWorkspaceMemberId,
+          userWorkspaceId: currentUserWorkspaceId,
           position: maxPosition + 1,
         },
       ]);

--- a/packages/twenty-front/src/modules/workspace-member/types/WorkspaceMember.ts
+++ b/packages/twenty-front/src/modules/workspace-member/types/WorkspaceMember.ts
@@ -21,6 +21,7 @@ export type WorkspaceMember = {
   updatedAt: string;
   userEmail: string;
   userId: string;
+  userWorkspaceId?: string | null;
   timeZone?: string | null;
   dateFormat?: WorkspaceMemberDateFormatEnum | null;
   timeFormat?: WorkspaceMemberTimeFormatEnum | null;


### PR DESCRIPTION
## What does this PR do?

Fixes a bug where `NavigationMenuItem.userWorkspaceId` was being compared/set to `WorkspaceMember.id` instead of the correct `UserWorkspace.id`, causing the favorites functionality to not work correctly.

Fixes #21291

## Problem

The `isFavorite` check in `ViewPickerOptionDropdown` and `createManyNavigationMenuItems` calls in multiple files were using `currentWorkspaceMemberId` (which is `WorkspaceMember.id` from the `workspace_*` schema) instead of the correct `UserWorkspace.id` (from the `core` schema).

This caused:
- `isFavorite` to always return `false` for user favorites
- Navigation menu items to be created with incorrect `userWorkspaceId`

## Root Cause

In `useNavigationMenuItemsData.ts`:
- `currentWorkspaceMemberId` was derived from `currentWorkspaceMember?.id` (WorkspaceMember.id)
- But `NavigationMenuItem.userWorkspaceId` expects a `UserWorkspace.id`
- These are two different entities from different schemas (core vs workspace)

## Solution

1. Added `currentUserWorkspaceId` to the `useNavigationMenuItemsData` hook return type
2. `currentUserWorkspaceId` is derived from `currentWorkspaceMember?.userWorkspaceId` 
3. Updated all comparisons and assignments to use `currentUserWorkspaceId` when dealing with `userWorkspaceId`

## Files Changed

- `packages/twenty-front/src/modules/navigation-menu-item/display/hooks/useNavigationMenuItemsData.ts` - Added `currentUserWorkspaceId` to return type
- `packages/twenty-front/src/modules/views/view-picker/components/ViewPickerOptionDropdown.tsx` - Fixed `isFavorite` check and `createManyNavigationMenuItems` call
- `packages/twenty-front/src/modules/command-menu-item/engine-command/record/single-record/components/AddToFavoritesSingleRecordCommand.tsx` - Fixed `createManyNavigationMenuItems` call
- `packages/twenty-front/src/modules/navigation-menu-item/edit/hooks/useNavigationMenuItemEditController.ts` - Fixed `targetUserWorkspaceId` assignment

## Testing

- No existing tests directly cover the `useNavigationMenuItemsData` hook
- The fix is a simple type/field correction that should not affect other components
- CI will verify TypeScript compilation and linting

## Checklist

- [x] I have read the [CONTRIBUTING.md](https://github.com/twentyhq/twenty/blob/main/.github/CONTRIBUTING.md) file
- [x] Changes are tested locally (TypeScript compilation)
- [x] Commit message follows repository conventions
- [x] PR is linked to the relevant issue (#21291)