### PR TITLE
fix(settings): gate APIs & Webhooks page on API_KEYS_AND_WEBHOOKS, not WORKSPACE

### DIFF
--- a/packages/twenty-front/src/modules/app/components/SettingsRoutes.tsx
+++ b/packages/twenty-front/src/modules/app/components/SettingsRoutes.tsx
@@ -656,10 +656,6 @@ export const SettingsRoutes = ({ isAdminPageEnabled }: SettingsRoutesProps) => (
           path={SettingsPath.EmailGroupChannelDetail}
           element={<SettingsWorkspaceEmailGroupChannelDetail />}
         />
-        <Route
-          path={SettingsPath.ApiWebhooks}
-          element={<SettingsApiWebhooks />}
-        />
         <Route path={SettingsPath.Billing} element={<SettingsBilling />} />
         <Route path={SettingsPath.Usage} element={<SettingsUsage />} />
         <Route
@@ -825,6 +821,10 @@ export const SettingsRoutes = ({ isAdminPageEnabled }: SettingsRoutesProps) => (
           />
         }
       >
+        <Route
+          path={SettingsPath.ApiWebhooks}
+          element={<SettingsApiWebhooks />}
+        />
         <Route
           path={`${SettingsPath.GraphQLPlayground}`}
           element={<SettingsGraphQLPlayground />}


### PR DESCRIPTION
## Summary

The **APIs & Webhooks** settings page (`SettingsPath.ApiWebhooks`) is gated by the wrong permission flag. Its route sits in the `PermissionFlagType.WORKSPACE` group in `SettingsRoutes.tsx`, but everything else about the page is gated on `API_KEYS_AND_WEBHOOKS`:

- The **nav item** is hidden behind `API_KEYS_AND_WEBHOOKS` (`useSettingsNavigationItems.tsx`).
- All its **sub-routes** — new/detail API key, new/detail webhook, and the GraphQL & REST playgrounds — already live under the `API_KEYS_AND_WEBHOOKS` wrapper.

So a role with **"API Keys & Webhooks"** enabled but **without "Workspace"** sees the nav item (and the **"Set up MCP"** button in *Settings → AI*, which links to `/settings/api-webhooks#mcp`), but on arrival `SettingsProtectedRouteWrapper` finds no `WORKSPACE` flag and redirects them to the **Profile** page. The entry points are visible; the destination is unreachable.

## Root cause

The route was grouped under the `WORKSPACE` wrapper while its nav item and sub-pages are gated on `API_KEYS_AND_WEBHOOKS` — the page's route gate and its nav gate disagree.

## Changes

- `SettingsRoutes.tsx` — move the `SettingsPath.ApiWebhooks` route out of the `WORKSPACE` group and into the existing `API_KEYS_AND_WEBHOOKS` group, alongside its own sub-routes.

This is the same class of fix as #21239 (*gate the AI settings page on `AI_SETTINGS`, not the chat flag*).

## Test plan

- [ ] Role with **only "API Keys & Webhooks"** (`API_KEYS_AND_WEBHOOKS`, no `WORKSPACE`): *Settings → APIs & Webhooks* is reachable; the nav item and the *Settings → AI* "Set up MCP" link both land on the page instead of redirecting to Profile.
- [ ] Role with **"Workspace" but not "API Keys & Webhooks"**: the APIs & Webhooks nav item stays hidden and the route is not reachable (was previously reachable — now consistent with the nav).
- [ ] Admin (both flags): unchanged.