### PR TITLE
[Website] Add trust center link to the footer

### DIFF
--- a/packages/twenty-website/src/sections/Footer/data.ts
+++ b/packages/twenty-website/src/sections/Footer/data.ts
@@ -55,6 +55,11 @@ export const FOOTER_DATA: FooterDataType = {
           external: false,
         },
         { label: msg`Terms and Conditions`, href: '/terms', external: false },
+        {
+          label: msg`Trust Center`,
+          href: 'https://trust.twenty.com',
+          external: true,
+        },
       ],
     },
     {


### PR DESCRIPTION
Adds a Trust Center entry under the footer Legal group linking to https://trust.twenty.com (external).

<img width="1410" height="546" alt="image" src="https://github.com/user-attachments/assets/a17dcc8e-7285-452d-a6f8-42dd6010223d" />
