### PR TITLE
fix: prevent deletion of standard fields via API

### DIFF
--- a/packages/twenty-server/src/engine/metadata-modules/flat-field-metadata/utils/__tests__/from-delete-field-input-to-flat-field-metadatas-to-delete.spec.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/flat-field-metadata/utils/__tests__/from-delete-field-input-to-flat-field-metadatas-to-delete.spec.ts
@@ -1,3 +1,4 @@
+import { TWENTY_STANDARD_APPLICATION_UNIVERSAL_IDENTIFIER } from 'twenty-shared/application';
 import { FieldMetadataType } from 'twenty-shared/types';
 
 import { createEmptyFlatEntityMaps } from 'src/engine/metadata-modules/flat-entity/constant/create-empty-flat-entity-maps.constant';
@@ -133,5 +134,32 @@ describe('fromDeleteFieldInputToFlatFieldMetadatasToDelete', () => {
         flatIndexMaps: createEmptyFlatEntityMaps(),
       }),
     ).toThrow(FieldMetadataException);
+  });
+
+  it('should throw FIELD_MUTATION_NOT_ALLOWED when field belongs to twenty standard app', () => {
+    const objectId = 'obj-1';
+    const standardAppField = getFlatFieldMetadataMock({
+      universalIdentifier: 'standard-app-field-uid',
+      objectMetadataId: objectId,
+      type: FieldMetadataType.TEXT,
+      name: 'standardAppField',
+      isCustom: true,
+      isSystem: false,
+      applicationUniversalIdentifier:
+        TWENTY_STANDARD_APPLICATION_UNIVERSAL_IDENTIFIER,
+    });
+
+    expect(() =>
+      fromDeleteFieldInputToFlatFieldMetadatasToDelete({
+        deleteOneFieldInput: { id: standardAppField.id },
+        flatFieldMetadataMaps: buildFlatFieldMetadataMaps([standardAppField]),
+        flatObjectMetadataMaps: buildFlatObjectMetadataMaps(objectId),
+        flatIndexMaps: createEmptyFlatEntityMaps(),
+      }),
+    ).toThrow(
+      expect.objectContaining({
+        code: FieldMetadataExceptionCode.FIELD_MUTATION_NOT_ALLOWED,
+      }),
+    );
   });
 });

--- a/packages/twenty-server/src/engine/metadata-modules/flat-field-metadata/utils/__tests__/from-delete-field-input-to-flat-field-metadatas-to-delete.spec.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/flat-field-metadata/utils/__tests__/from-delete-field-input-to-flat-field-metadatas-to-delete.spec.ts
@@ -1,0 +1,140 @@
+import { FieldMetadataType } from 'twenty-shared/types';
+
+import {
+  FieldMetadataException,
+  FieldMetadataExceptionCode,
+} from 'src/engine/metadata-modules/field-metadata/field-metadata.exception';
+import {
+  getFlatFieldMetadataMock,
+  getStandardFlatFieldMetadataMock,
+} from 'src/engine/metadata-modules/flat-field-metadata/__mocks__/get-flat-field-metadata.mock';
+import { fromDeleteFieldInputToFlatFieldMetadatasToDelete } from 'src/engine/metadata-modules/flat-field-metadata/utils/from-delete-field-input-to-flat-field-metadatas-to-delete.util';
+
+const buildFlatFieldMetadataMaps = (
+  fields: ReturnType<typeof getFlatFieldMetadataMock>[],
+) => ({
+  byUniversalIdentifier: Object.fromEntries(
+    fields.map((field) => [field.universalIdentifier, field]),
+  ),
+  universalIdentifierById: Object.fromEntries(
+    fields.map((field) => [field.id, field.universalIdentifier]),
+  ),
+  universalIdentifiersByApplicationId: {},
+});
+
+const buildFlatObjectMetadataMaps = (objectId: string) => ({
+  byUniversalIdentifier: {
+    [objectId]: {
+      id: objectId,
+      universalIdentifier: objectId,
+      fieldUniversalIdentifiers: [],
+    },
+  },
+  universalIdentifierById: { [objectId]: objectId },
+  universalIdentifiersByApplicationId: {},
+});
+
+const buildEmptyFlatIndexMaps = () => ({
+  byUniversalIdentifier: {},
+  universalIdentifierById: {},
+  universalIdentifiersByApplicationId: {},
+});
+
+describe('fromDeleteFieldInputToFlatFieldMetadatasToDelete', () => {
+  it('should throw FIELD_METADATA_NOT_FOUND when field does not exist', () => {
+    expect(() =>
+      fromDeleteFieldInputToFlatFieldMetadatasToDelete({
+        deleteOneFieldInput: { id: 'non-existent-id' },
+        flatFieldMetadataMaps: buildFlatFieldMetadataMaps([]),
+        flatObjectMetadataMaps: buildFlatObjectMetadataMaps('obj-1'),
+        flatIndexMaps: buildEmptyFlatIndexMaps(),
+      }),
+    ).toThrow(
+      expect.objectContaining({
+        code: FieldMetadataExceptionCode.FIELD_METADATA_NOT_FOUND,
+      }),
+    );
+  });
+
+  it('should throw FIELD_MUTATION_NOT_ALLOWED when deleting a standard field', () => {
+    const objectId = 'obj-1';
+    const standardField = getStandardFlatFieldMetadataMock({
+      universalIdentifier: 'standard-field-uid',
+      objectMetadataId: objectId,
+      type: FieldMetadataType.TEXT,
+      name: 'jobTitle',
+    });
+
+    expect(() =>
+      fromDeleteFieldInputToFlatFieldMetadatasToDelete({
+        deleteOneFieldInput: { id: standardField.id },
+        flatFieldMetadataMaps: buildFlatFieldMetadataMaps([standardField]),
+        flatObjectMetadataMaps: buildFlatObjectMetadataMaps(objectId),
+        flatIndexMaps: buildEmptyFlatIndexMaps(),
+      }),
+    ).toThrow(
+      expect.objectContaining({
+        code: FieldMetadataExceptionCode.FIELD_MUTATION_NOT_ALLOWED,
+      }),
+    );
+  });
+
+  it('should throw FIELD_MUTATION_NOT_ALLOWED with the field name in message', () => {
+    const objectId = 'obj-1';
+    const standardField = getStandardFlatFieldMetadataMock({
+      universalIdentifier: 'standard-field-uid',
+      objectMetadataId: objectId,
+      type: FieldMetadataType.TEXT,
+      name: 'city',
+    });
+
+    expect(() =>
+      fromDeleteFieldInputToFlatFieldMetadatasToDelete({
+        deleteOneFieldInput: { id: standardField.id },
+        flatFieldMetadataMaps: buildFlatFieldMetadataMaps([standardField]),
+        flatObjectMetadataMaps: buildFlatObjectMetadataMaps(objectId),
+        flatIndexMaps: buildEmptyFlatIndexMaps(),
+      }),
+    ).toThrow(new RegExp('Cannot delete standard field "city"'));
+  });
+
+  it('should allow deletion of a custom field', () => {
+    const objectId = 'obj-1';
+    const customField = getFlatFieldMetadataMock({
+      universalIdentifier: 'custom-field-uid',
+      objectMetadataId: objectId,
+      type: FieldMetadataType.TEXT,
+      isCustom: true,
+    });
+
+    const result = fromDeleteFieldInputToFlatFieldMetadatasToDelete({
+      deleteOneFieldInput: { id: customField.id },
+      flatFieldMetadataMaps: buildFlatFieldMetadataMaps([customField]),
+      flatObjectMetadataMaps: buildFlatObjectMetadataMaps(objectId),
+      flatIndexMaps: buildEmptyFlatIndexMaps(),
+    });
+
+    expect(result.flatFieldMetadatasToDelete).toContainEqual(
+      expect.objectContaining({ id: customField.id }),
+    );
+  });
+
+  it('should be an instance of FieldMetadataException when rejecting standard field', () => {
+    const objectId = 'obj-1';
+    const standardField = getStandardFlatFieldMetadataMock({
+      universalIdentifier: 'standard-field-uid',
+      objectMetadataId: objectId,
+      type: FieldMetadataType.TEXT,
+      name: 'avatarUrl',
+    });
+
+    expect(() =>
+      fromDeleteFieldInputToFlatFieldMetadatasToDelete({
+        deleteOneFieldInput: { id: standardField.id },
+        flatFieldMetadataMaps: buildFlatFieldMetadataMaps([standardField]),
+        flatObjectMetadataMaps: buildFlatObjectMetadataMaps(objectId),
+        flatIndexMaps: buildEmptyFlatIndexMaps(),
+      }),
+    ).toThrow(FieldMetadataException);
+  });
+});

--- a/packages/twenty-server/src/engine/metadata-modules/flat-field-metadata/utils/__tests__/from-delete-field-input-to-flat-field-metadatas-to-delete.spec.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/flat-field-metadata/utils/__tests__/from-delete-field-input-to-flat-field-metadatas-to-delete.spec.ts
@@ -1,5 +1,7 @@
 import { FieldMetadataType } from 'twenty-shared/types';
 
+import { createEmptyFlatEntityMaps } from 'src/engine/metadata-modules/flat-entity/constant/create-empty-flat-entity-maps.constant';
+import { addFlatEntityToFlatEntityMapsOrThrow } from 'src/engine/metadata-modules/flat-entity/utils/add-flat-entity-to-flat-entity-maps-or-throw.util';
 import {
   FieldMetadataException,
   FieldMetadataExceptionCode,
@@ -8,37 +10,32 @@ import {
   getFlatFieldMetadataMock,
   getStandardFlatFieldMetadataMock,
 } from 'src/engine/metadata-modules/flat-field-metadata/__mocks__/get-flat-field-metadata.mock';
+import { getFlatObjectMetadataMock } from 'src/engine/metadata-modules/flat-object-metadata/__mocks__/get-flat-object-metadata.mock';
 import { fromDeleteFieldInputToFlatFieldMetadatasToDelete } from 'src/engine/metadata-modules/flat-field-metadata/utils/from-delete-field-input-to-flat-field-metadatas-to-delete.util';
 
 const buildFlatFieldMetadataMaps = (
   fields: ReturnType<typeof getFlatFieldMetadataMock>[],
-) => ({
-  byUniversalIdentifier: Object.fromEntries(
-    fields.map((field) => [field.universalIdentifier, field]),
-  ),
-  universalIdentifierById: Object.fromEntries(
-    fields.map((field) => [field.id, field.universalIdentifier]),
-  ),
-  universalIdentifiersByApplicationId: {},
-});
+) =>
+  fields.reduce(
+    (maps, field) =>
+      addFlatEntityToFlatEntityMapsOrThrow({
+        flatEntity: field,
+        flatEntityMaps: maps,
+      }),
+    createEmptyFlatEntityMaps(),
+  );
 
-const buildFlatObjectMetadataMaps = (objectId: string) => ({
-  byUniversalIdentifier: {
-    [objectId]: {
-      id: objectId,
-      universalIdentifier: objectId,
-      fieldUniversalIdentifiers: [],
-    },
-  },
-  universalIdentifierById: { [objectId]: objectId },
-  universalIdentifiersByApplicationId: {},
-});
+const buildFlatObjectMetadataMaps = (objectId: string) => {
+  const flatObject = getFlatObjectMetadataMock({
+    universalIdentifier: objectId,
+    id: objectId,
+  });
 
-const buildEmptyFlatIndexMaps = () => ({
-  byUniversalIdentifier: {},
-  universalIdentifierById: {},
-  universalIdentifiersByApplicationId: {},
-});
+  return addFlatEntityToFlatEntityMapsOrThrow({
+    flatEntity: flatObject,
+    flatEntityMaps: createEmptyFlatEntityMaps(),
+  });
+};
 
 describe('fromDeleteFieldInputToFlatFieldMetadatasToDelete', () => {
   it('should throw FIELD_METADATA_NOT_FOUND when field does not exist', () => {
@@ -47,7 +44,7 @@ describe('fromDeleteFieldInputToFlatFieldMetadatasToDelete', () => {
         deleteOneFieldInput: { id: 'non-existent-id' },
         flatFieldMetadataMaps: buildFlatFieldMetadataMaps([]),
         flatObjectMetadataMaps: buildFlatObjectMetadataMaps('obj-1'),
-        flatIndexMaps: buildEmptyFlatIndexMaps(),
+        flatIndexMaps: createEmptyFlatEntityMaps(),
       }),
     ).toThrow(
       expect.objectContaining({
@@ -70,7 +67,7 @@ describe('fromDeleteFieldInputToFlatFieldMetadatasToDelete', () => {
         deleteOneFieldInput: { id: standardField.id },
         flatFieldMetadataMaps: buildFlatFieldMetadataMaps([standardField]),
         flatObjectMetadataMaps: buildFlatObjectMetadataMaps(objectId),
-        flatIndexMaps: buildEmptyFlatIndexMaps(),
+        flatIndexMaps: createEmptyFlatEntityMaps(),
       }),
     ).toThrow(
       expect.objectContaining({
@@ -93,7 +90,7 @@ describe('fromDeleteFieldInputToFlatFieldMetadatasToDelete', () => {
         deleteOneFieldInput: { id: standardField.id },
         flatFieldMetadataMaps: buildFlatFieldMetadataMaps([standardField]),
         flatObjectMetadataMaps: buildFlatObjectMetadataMaps(objectId),
-        flatIndexMaps: buildEmptyFlatIndexMaps(),
+        flatIndexMaps: createEmptyFlatEntityMaps(),
       }),
     ).toThrow(new RegExp('Cannot delete standard field "city"'));
   });
@@ -111,7 +108,7 @@ describe('fromDeleteFieldInputToFlatFieldMetadatasToDelete', () => {
       deleteOneFieldInput: { id: customField.id },
       flatFieldMetadataMaps: buildFlatFieldMetadataMaps([customField]),
       flatObjectMetadataMaps: buildFlatObjectMetadataMaps(objectId),
-      flatIndexMaps: buildEmptyFlatIndexMaps(),
+      flatIndexMaps: createEmptyFlatEntityMaps(),
     });
 
     expect(result.flatFieldMetadatasToDelete).toContainEqual(
@@ -133,7 +130,7 @@ describe('fromDeleteFieldInputToFlatFieldMetadatasToDelete', () => {
         deleteOneFieldInput: { id: standardField.id },
         flatFieldMetadataMaps: buildFlatFieldMetadataMaps([standardField]),
         flatObjectMetadataMaps: buildFlatObjectMetadataMaps(objectId),
-        flatIndexMaps: buildEmptyFlatIndexMaps(),
+        flatIndexMaps: createEmptyFlatEntityMaps(),
       }),
     ).toThrow(FieldMetadataException);
   });

--- a/packages/twenty-server/src/engine/metadata-modules/flat-field-metadata/utils/from-delete-field-input-to-flat-field-metadatas-to-delete.util.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/flat-field-metadata/utils/from-delete-field-input-to-flat-field-metadatas-to-delete.util.ts
@@ -54,7 +54,10 @@ export const fromDeleteFieldInputToFlatFieldMetadatasToDelete = ({
     );
   }
 
-  if (belongsToTwentyStandardApp(flatFieldMetadataToDelete) || flatFieldMetadataToDelete.isSystem) {
+  if (
+    belongsToTwentyStandardApp(flatFieldMetadataToDelete) ||
+    flatFieldMetadataToDelete.isSystem
+  ) {
     throw new FieldMetadataException(
       `Cannot delete standard field "${flatFieldMetadataToDelete.name}"`,
       FieldMetadataExceptionCode.FIELD_MUTATION_NOT_ALLOWED,

--- a/packages/twenty-server/src/engine/metadata-modules/flat-field-metadata/utils/from-delete-field-input-to-flat-field-metadatas-to-delete.util.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/flat-field-metadata/utils/from-delete-field-input-to-flat-field-metadatas-to-delete.util.ts
@@ -53,6 +53,13 @@ export const fromDeleteFieldInputToFlatFieldMetadatasToDelete = ({
     );
   }
 
+  if (!flatFieldMetadataToDelete.isCustom) {
+    throw new FieldMetadataException(
+      `Cannot delete standard field "${flatFieldMetadataToDelete.name}"`,
+      FieldMetadataExceptionCode.FIELD_MUTATION_NOT_ALLOWED,
+    );
+  }
+
   const flatObjectMetadata = findFlatEntityByIdInFlatEntityMaps({
     flatEntityId: flatFieldMetadataToDelete.objectMetadataId,
     flatEntityMaps: existingFlatObjectMetadataMaps,

--- a/packages/twenty-server/src/engine/metadata-modules/flat-field-metadata/utils/from-delete-field-input-to-flat-field-metadatas-to-delete.util.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/flat-field-metadata/utils/from-delete-field-input-to-flat-field-metadatas-to-delete.util.ts
@@ -15,6 +15,7 @@ import { findManyFlatEntityByUniversalIdentifierInUniversalFlatEntityMapsOrThrow
 import { computeFlatFieldMetadataRelatedFlatFieldMetadata } from 'src/engine/metadata-modules/flat-field-metadata/utils/compute-flat-field-metadata-related-flat-field-metadata.util';
 import { type FlatIndexMetadata } from 'src/engine/metadata-modules/flat-index-metadata/types/flat-index-metadata.type';
 import { generateFlatIndexMetadataWithNameOrThrow } from 'src/engine/metadata-modules/index-metadata/utils/generate-flat-index.util';
+import { belongsToTwentyStandardApp } from 'src/engine/metadata-modules/utils/belongs-to-twenty-standard-app.util';
 import { type UniversalFlatFieldMetadata } from 'src/engine/workspace-manager/workspace-migration/universal-flat-entity/types/universal-flat-field-metadata.type';
 import { type UniversalFlatIndexMetadata } from 'src/engine/workspace-manager/workspace-migration/universal-flat-entity/types/universal-flat-index-metadata.type';
 
@@ -53,7 +54,7 @@ export const fromDeleteFieldInputToFlatFieldMetadatasToDelete = ({
     );
   }
 
-  if (!flatFieldMetadataToDelete.isCustom) {
+  if (belongsToTwentyStandardApp(flatFieldMetadataToDelete) || flatFieldMetadataToDelete.isSystem) {
     throw new FieldMetadataException(
       `Cannot delete standard field "${flatFieldMetadataToDelete.name}"`,
       FieldMetadataExceptionCode.FIELD_MUTATION_NOT_ALLOWED,


### PR DESCRIPTION
## Summary
- Adds a server-side guard that rejects deletion of standard fields (`isCustom: false`) in the `deleteOneField` path
- The UI already prevents this, but the API had no enforcement, allowing standard fields to be deleted via direct GraphQL calls

Without this guard, deleting a standard field like `jobTitle` cascades to drop dependent generated columns (e.g. `searchVector`), leaving the object in a broken state where all subsequent queries fail with "Data validation error."

## Test plan
- [x] Call `deleteOneField` with a standard field ID → should return `FIELD_MUTATION_NOT_ALLOWED` error
- [x] Call `deleteOneField` with a custom field ID → should succeed as before
- [x] UI deactivation of standard fields still works (deactivate != delete)