### PR TITLE
fix: add queue attribute to jobs waiting gauge metric

### DIFF
--- a/packages/twenty-server/src/engine/core-modules/message-queue/drivers/bullmq.driver.ts
+++ b/packages/twenty-server/src/engine/core-modules/message-queue/drivers/bullmq.driver.ts
@@ -54,7 +54,7 @@ export class BullMQDriver
   ) {}
 
   onModuleInit() {
-    this.metricsService.createMultiObservableGauge({
+    this.metricsService.createObservableGauge({
       metricName: 'twenty_queue_jobs_waiting_total',
       options: { description: 'Current number of jobs waiting in queue' },
       callback: async () => {

--- a/packages/twenty-server/src/engine/core-modules/message-queue/drivers/bullmq.driver.ts
+++ b/packages/twenty-server/src/engine/core-modules/message-queue/drivers/bullmq.driver.ts
@@ -54,27 +54,25 @@ export class BullMQDriver
   ) {}
 
   onModuleInit() {
-    this.metricsService.createObservableGauge({
-      metricName: 'twenty_queue_jobs_waiting_total',
-      options: { description: 'Current number of jobs waiting in queue' },
-      callback: async () => {
-        let totalWaiting = 0;
+    const gauge = this.metricsService
+      .getMeter()
+      .createObservableGauge('twenty_queue_jobs_waiting_total', {
+        description: 'Current number of jobs waiting in queue',
+      });
 
-        for (const [queueName, queue] of Object.entries(this.queueMap)) {
-          try {
-            const waitingCount = await queue.count();
+    gauge.addCallback(async (observableResult) => {
+      for (const [queueName, queue] of Object.entries(this.queueMap)) {
+        try {
+          const waitingCount = await queue.count();
 
-            totalWaiting += waitingCount;
-          } catch (error) {
-            this.logger.error(
-              `Failed to collect waiting jobs metrics for queue ${queueName}`,
-              error,
-            );
-          }
+          observableResult.observe(waitingCount, { queue: queueName });
+        } catch (error) {
+          this.logger.error(
+            `Failed to collect waiting jobs metrics for queue ${queueName}`,
+            error,
+          );
         }
-
-        return totalWaiting;
-      },
+      }
     });
   }
 

--- a/packages/twenty-server/src/engine/core-modules/message-queue/drivers/bullmq.driver.ts
+++ b/packages/twenty-server/src/engine/core-modules/message-queue/drivers/bullmq.driver.ts
@@ -54,25 +54,33 @@ export class BullMQDriver
   ) {}
 
   onModuleInit() {
-    const gauge = this.metricsService
-      .getMeter()
-      .createObservableGauge('twenty_queue_jobs_waiting_total', {
-        description: 'Current number of jobs waiting in queue',
-      });
+    this.metricsService.createMultiObservableGauge({
+      metricName: 'twenty_queue_jobs_waiting_total',
+      options: { description: 'Current number of jobs waiting in queue' },
+      callback: async () => {
+        const observations: Array<{
+          value: number;
+          attributes: { queue: string };
+        }> = [];
 
-    gauge.addCallback(async (observableResult) => {
-      for (const [queueName, queue] of Object.entries(this.queueMap)) {
-        try {
-          const waitingCount = await queue.count();
+        for (const [queueName, queue] of Object.entries(this.queueMap)) {
+          try {
+            const waitingCount = await queue.count();
 
-          observableResult.observe(waitingCount, { queue: queueName });
-        } catch (error) {
-          this.logger.error(
-            `Failed to collect waiting jobs metrics for queue ${queueName}`,
-            error,
-          );
+            observations.push({
+              value: waitingCount,
+              attributes: { queue: queueName },
+            });
+          } catch (error) {
+            this.logger.error(
+              `Failed to collect waiting jobs metrics for queue ${queueName}`,
+              error,
+            );
+          }
         }
-      }
+
+        return observations;
+      },
     });
   }
 

--- a/packages/twenty-server/src/engine/core-modules/message-queue/drivers/bullmq.driver.ts
+++ b/packages/twenty-server/src/engine/core-modules/message-queue/drivers/bullmq.driver.ts
@@ -54,7 +54,7 @@ export class BullMQDriver
   ) {}
 
   onModuleInit() {
-    this.metricsService.createObservableGauge({
+    this.metricsService.createMultiObservableGauge({
       metricName: 'twenty_queue_jobs_waiting_total',
       options: { description: 'Current number of jobs waiting in queue' },
       callback: async () => {

--- a/packages/twenty-server/src/engine/core-modules/metrics/metrics.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/metrics/metrics.service.ts
@@ -40,7 +40,10 @@ export class MetricsService {
   }: {
     metricName: string;
     options: MetricOptions;
-    callback: () => number | Promise<number>;
+    callback: () =>
+      | number
+      | Array<{ value: number; attributes: Attributes }>
+      | Promise<number | Array<{ value: number; attributes: Attributes }>>;
     cacheValue?: boolean;
   }): ObservableGauge {
     const gauge = this.getMeter().createObservableGauge(metricName, options);
@@ -48,10 +51,12 @@ export class MetricsService {
     gauge.addCallback(async (observableResult) => {
       if (cacheValue) {
         const cachedResult =
-          await this.healthCacheStorage.get<number>(metricName);
+          await this.healthCacheStorage.get<
+            number | Array<{ value: number; attributes: Attributes }>
+          >(metricName);
 
         if (isDefined(cachedResult)) {
-          observableResult.observe(cachedResult);
+          this.observeResult(observableResult, cachedResult);
 
           return;
         }
@@ -60,7 +65,7 @@ export class MetricsService {
       try {
         const result = await callback();
 
-        observableResult.observe(result);
+        this.observeResult(observableResult, result);
 
         if (cacheValue) {
           await this.healthCacheStorage.set(
@@ -80,60 +85,21 @@ export class MetricsService {
     return gauge;
   }
 
-  createMultiObservableGauge({
-    metricName,
-    options,
-    callback,
-    cacheValue = false,
-  }: {
-    metricName: string;
-    options: MetricOptions;
-    callback: () =>
-      | Array<{ value: number; attributes: Attributes }>
-      | Promise<Array<{ value: number; attributes: Attributes }>>;
-    cacheValue?: boolean;
-  }): ObservableGauge {
-    const gauge = this.getMeter().createObservableGauge(metricName, options);
+  private observeResult(
+    observableResult: Parameters<
+      Parameters<ObservableGauge['addCallback']>[0]
+    >[0],
+    result: number | Array<{ value: number; attributes: Attributes }>,
+  ) {
+    if (typeof result === 'number') {
+      observableResult.observe(result);
 
-    gauge.addCallback(async (observableResult) => {
-      if (cacheValue) {
-        const cachedResult =
-          await this.healthCacheStorage.get<
-            Array<{ value: number; attributes: Attributes }>
-          >(metricName);
+      return;
+    }
 
-        if (isDefined(cachedResult)) {
-          for (const observation of cachedResult) {
-            observableResult.observe(observation.value, observation.attributes);
-          }
-
-          return;
-        }
-      }
-
-      try {
-        const observations = await callback();
-
-        for (const observation of observations) {
-          observableResult.observe(observation.value, observation.attributes);
-        }
-
-        if (cacheValue) {
-          await this.healthCacheStorage.set(
-            metricName,
-            observations,
-            METRICS_CACHE_TTL,
-          );
-        }
-      } catch (error) {
-        this.logger.error(
-          `Failed to collect gauge metric ${metricName}`,
-          error,
-        );
-      }
-    });
-
-    return gauge;
+    for (const observation of result) {
+      observableResult.observe(observation.value, observation.attributes);
+    }
   }
 
   createInfoGauge({

--- a/packages/twenty-server/src/engine/core-modules/metrics/metrics.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/metrics/metrics.service.ts
@@ -41,7 +41,7 @@ export class MetricsService {
   }: {
     metricName: string;
     options: MetricOptions;
-    callback: () => number;
+    callback: () => number | Promise<number>;
     cacheValue?: boolean;
   }): ObservableGauge {
     return this.createObservableGaugeInternal({
@@ -63,7 +63,7 @@ export class MetricsService {
   }: {
     metricName: string;
     options: MetricOptions;
-    callback: () => Array<{ value: number; attributes: Attributes }>;
+    callback: () => Promise<Array<{ value: number; attributes: Attributes }>>;
     cacheValue?: boolean;
   }): ObservableGauge {
     return this.createObservableGaugeInternal({

--- a/packages/twenty-server/src/engine/core-modules/metrics/metrics.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/metrics/metrics.service.ts
@@ -41,7 +41,7 @@ export class MetricsService {
   }: {
     metricName: string;
     options: MetricOptions;
-    callback: () => number | Promise<number>;
+    callback: () => number;
     cacheValue?: boolean;
   }): ObservableGauge {
     return this.createObservableGaugeInternal({
@@ -63,9 +63,7 @@ export class MetricsService {
   }: {
     metricName: string;
     options: MetricOptions;
-    callback: () =>
-      | Array<{ value: number; attributes: Attributes }>
-      | Promise<Array<{ value: number; attributes: Attributes }>>;
+    callback: () => Array<{ value: number; attributes: Attributes }>;
     cacheValue?: boolean;
   }): ObservableGauge {
     return this.createObservableGaugeInternal({

--- a/packages/twenty-server/src/engine/core-modules/metrics/metrics.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/metrics/metrics.service.ts
@@ -6,6 +6,7 @@ import {
   type Meter,
   type MetricOptions,
   type ObservableGauge,
+  type ObservableResult,
 } from '@opentelemetry/api';
 import { isDefined } from 'twenty-shared/utils';
 
@@ -40,23 +41,68 @@ export class MetricsService {
   }: {
     metricName: string;
     options: MetricOptions;
-    callback: () =>
-      | number
-      | Array<{ value: number; attributes: Attributes }>
-      | Promise<number | Array<{ value: number; attributes: Attributes }>>;
+    callback: () => number | Promise<number>;
     cacheValue?: boolean;
+  }): ObservableGauge {
+    return this.createObservableGaugeInternal({
+      metricName,
+      options,
+      callback,
+      cacheValue,
+      observeResult: (observableResult, result) => {
+        observableResult.observe(result);
+      },
+    });
+  }
+
+  createMultiObservableGauge({
+    metricName,
+    options,
+    callback,
+    cacheValue = false,
+  }: {
+    metricName: string;
+    options: MetricOptions;
+    callback: () =>
+      | Array<{ value: number; attributes: Attributes }>
+      | Promise<Array<{ value: number; attributes: Attributes }>>;
+    cacheValue?: boolean;
+  }): ObservableGauge {
+    return this.createObservableGaugeInternal({
+      metricName,
+      options,
+      callback,
+      cacheValue,
+      observeResult: (observableResult, observations) => {
+        for (const observation of observations) {
+          observableResult.observe(observation.value, observation.attributes);
+        }
+      },
+    });
+  }
+
+  private createObservableGaugeInternal<T>({
+    metricName,
+    options,
+    callback,
+    cacheValue,
+    observeResult,
+  }: {
+    metricName: string;
+    options: MetricOptions;
+    callback: () => T | Promise<T>;
+    cacheValue: boolean;
+    observeResult: (observableResult: ObservableResult, result: T) => void;
   }): ObservableGauge {
     const gauge = this.getMeter().createObservableGauge(metricName, options);
 
     gauge.addCallback(async (observableResult) => {
       if (cacheValue) {
         const cachedResult =
-          await this.healthCacheStorage.get<
-            number | Array<{ value: number; attributes: Attributes }>
-          >(metricName);
+          await this.healthCacheStorage.get<T>(metricName);
 
         if (isDefined(cachedResult)) {
-          this.observeResult(observableResult, cachedResult);
+          observeResult(observableResult, cachedResult);
 
           return;
         }
@@ -65,7 +111,7 @@ export class MetricsService {
       try {
         const result = await callback();
 
-        this.observeResult(observableResult, result);
+        observeResult(observableResult, result);
 
         if (cacheValue) {
           await this.healthCacheStorage.set(
@@ -83,23 +129,6 @@ export class MetricsService {
     });
 
     return gauge;
-  }
-
-  private observeResult(
-    observableResult: Parameters<
-      Parameters<ObservableGauge['addCallback']>[0]
-    >[0],
-    result: number | Array<{ value: number; attributes: Attributes }>,
-  ) {
-    if (typeof result === 'number') {
-      observableResult.observe(result);
-
-      return;
-    }
-
-    for (const observation of result) {
-      observableResult.observe(observation.value, observation.attributes);
-    }
   }
 
   createInfoGauge({

--- a/packages/twenty-server/src/engine/core-modules/metrics/metrics.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/metrics/metrics.service.ts
@@ -80,6 +80,62 @@ export class MetricsService {
     return gauge;
   }
 
+  createMultiObservableGauge({
+    metricName,
+    options,
+    callback,
+    cacheValue = false,
+  }: {
+    metricName: string;
+    options: MetricOptions;
+    callback: () =>
+      | Array<{ value: number; attributes: Attributes }>
+      | Promise<Array<{ value: number; attributes: Attributes }>>;
+    cacheValue?: boolean;
+  }): ObservableGauge {
+    const gauge = this.getMeter().createObservableGauge(metricName, options);
+
+    gauge.addCallback(async (observableResult) => {
+      if (cacheValue) {
+        const cachedResult =
+          await this.healthCacheStorage.get<
+            Array<{ value: number; attributes: Attributes }>
+          >(metricName);
+
+        if (isDefined(cachedResult)) {
+          for (const observation of cachedResult) {
+            observableResult.observe(observation.value, observation.attributes);
+          }
+
+          return;
+        }
+      }
+
+      try {
+        const observations = await callback();
+
+        for (const observation of observations) {
+          observableResult.observe(observation.value, observation.attributes);
+        }
+
+        if (cacheValue) {
+          await this.healthCacheStorage.set(
+            metricName,
+            observations,
+            METRICS_CACHE_TTL,
+          );
+        }
+      } catch (error) {
+        this.logger.error(
+          `Failed to collect gauge metric ${metricName}`,
+          error,
+        );
+      }
+    });
+
+    return gauge;
+  }
+
   createInfoGauge({
     metricName,
     options,

--- a/packages/twenty-server/src/engine/core-modules/metrics/metrics.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/metrics/metrics.service.ts
@@ -96,8 +96,7 @@ export class MetricsService {
 
     gauge.addCallback(async (observableResult) => {
       if (cacheValue) {
-        const cachedResult =
-          await this.healthCacheStorage.get<T>(metricName);
+        const cachedResult = await this.healthCacheStorage.get<T>(metricName);
 
         if (isDefined(cachedResult)) {
           observeResult(observableResult, cachedResult);


### PR DESCRIPTION
## Summary
- The `twenty_queue_jobs_waiting_total` gauge was summing all queues into a single value without a `queue` label, making the Grafana "Jobs Waiting by Queue" panel show a single aggregated line instead of per-queue breakdown.
- Uses `getMeter()` directly to call `observableResult.observe(count, { queue: queueName })` per queue, matching the `by (queue)` grouping the dashboard already expects.

## Test plan
- [x] Deploy and verify the Grafana "Jobs Waiting by Queue" panel displays separate series per queue
- [x] Confirm Prometheus scrape returns `twenty_queue_jobs_waiting_total{queue="..."}` with distinct queue labels