### PR TITLE
security: bump serialize-javascript 6 → 7 (RCE)

### DIFF
--- a/packages/twenty-website/package.json
+++ b/packages/twenty-website/package.json
@@ -33,7 +33,7 @@
     "react-dom": "19.2.3",
     "react-markdown": "^10.1.0",
     "remark-gfm": "^4.0.1",
-    "serialize-javascript": "^6.0.2",
+    "serialize-javascript": "^7.0.5",
     "sharp": "^0.33.5",
     "stripe": "^20.3.1",
     "three": "^0.183.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -53087,6 +53087,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"serialize-javascript@npm:^7.0.5":
+  version: 7.0.5
+  resolution: "serialize-javascript@npm:7.0.5"
+  checksum: 10c0/7b7818e5267f6d474ec7a56d36ba69dd712726a13eab37706ec94615fb7ca8945471f2b7fb0dc9dbe8c79c1930c1079d97f66f91315c8c8c2ca6c38898cec96f
+  languageName: node
+  linkType: hard
+
 "serve-index@npm:^1.9.1":
   version: 1.9.2
   resolution: "serve-index@npm:1.9.2"
@@ -57198,7 +57205,7 @@ __metadata:
     react-dom: "npm:19.2.3"
     react-markdown: "npm:^10.1.0"
     remark-gfm: "npm:^4.0.1"
-    serialize-javascript: "npm:^6.0.2"
+    serialize-javascript: "npm:^7.0.5"
     sharp: "npm:^0.33.5"
     stripe: "npm:^20.3.1"
     three: "npm:^0.183.2"


### PR DESCRIPTION
Fixes the **high-severity** `serialize-javascript` RCE advisory (RegExp.flags / Date.prototype.toISOString, patched in **7.0.5**).

- Bumps the direct dep in `twenty-website` `^6.0.2 → ^7.0.5`.
- Only consumer is `src/lib/seo/JsonLd.tsx` (default-export API, unchanged in v7 — the major only drops old Node support).
- `twenty-website` typecheck passes; lockfile regenerated under hardened mode (`--immutable --check-cache` clean).