### PR TITLE
security: bump uuid 9 → 11 (server, shared, front)

### DIFF
--- a/packages/twenty-front/package.json
+++ b/packages/twenty-front/package.json
@@ -142,7 +142,7 @@
     "twenty-ui": "workspace:*",
     "type-fest": "4.10.1",
     "use-debounce": "^10.0.0",
-    "uuid": "^9.0.0",
+    "uuid": "^11.1.1",
     "xlsx-ugnis": "^0.19.3",
     "zod": "^4.1.11"
   },

--- a/packages/twenty-front/src/modules/object-record/hooks/__tests__/useCreateManyRecords.test.tsx
+++ b/packages/twenty-front/src/modules/object-record/hooks/__tests__/useCreateManyRecords.test.tsx
@@ -22,7 +22,9 @@ jest.mocked(useRefetchAggregateQueries).mockReturnValue({
 });
 
 jest
-  .mocked(v4)
+  // uuid v11+ types add a Uint8Array overload to v4; pin to the string
+  // signature so the mocked return values type-check.
+  .mocked(v4 as () => string)
   .mockReturnValueOnce(variables.data[0].id)
   .mockReturnValueOnce(variables.data[1].id);
 

--- a/packages/twenty-server/package.json
+++ b/packages/twenty-server/package.json
@@ -169,7 +169,7 @@
     "type-fest": "4.10.1",
     "typeorm": "patch:typeorm@0.3.20#./patches/typeorm+0.3.20.patch",
     "unzipper": "^0.12.3",
-    "uuid": "9.0.1",
+    "uuid": "^11.1.1",
     "zod": "^4.1.11"
   },
   "devDependencies": {

--- a/packages/twenty-shared/package.json
+++ b/packages/twenty-shared/package.json
@@ -56,7 +56,7 @@
     "react-router-dom": "^6.4.4",
     "temporal-polyfill": "^0.3.0",
     "transliteration": "^2.3.5",
-    "uuid": "^9.0.0",
+    "uuid": "^11.1.1",
     "zod": "^4.1.11"
   },
   "exports": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -56703,7 +56703,7 @@ __metadata:
     twenty-ui: "workspace:*"
     type-fest: "npm:4.10.1"
     use-debounce: "npm:^10.0.0"
-    uuid: "npm:^9.0.0"
+    uuid: "npm:^11.1.1"
     vite-plugin-svgr: "npm:^4.3.0"
     vite-tsconfig-paths: "npm:^4.2.1"
     xlsx-ugnis: "npm:^0.19.3"
@@ -57036,7 +57036,7 @@ __metadata:
     type-fest: "npm:4.10.1"
     typeorm: "patch:typeorm@0.3.20#./patches/typeorm+0.3.20.patch"
     unzipper: "npm:^0.12.3"
-    uuid: "npm:9.0.1"
+    uuid: "npm:^11.1.1"
     zod: "npm:^4.1.11"
   languageName: unknown
   linkType: soft
@@ -57081,7 +57081,7 @@ __metadata:
     tsc-alias: "npm:^1.8.16"
     tsx: "npm:^4.19.3"
     typescript: "npm:^5.9.3"
-    uuid: "npm:^9.0.0"
+    uuid: "npm:^11.1.1"
     vite: "npm:^7.0.0"
     vite-plugin-dts: "npm:3.8.1"
     vite-tsconfig-paths: "npm:^4.2.1"
@@ -58639,6 +58639,15 @@ __metadata:
   bin:
     uuid: dist/esm/bin/uuid
   checksum: 10c0/34aa51b9874ae398c2b799c88a127701408cd581ee89ec3baa53509dd8728cbb25826f2a038f9465f8b7be446f0fbf11558862965b18d21c993684297628d4d3
+  languageName: node
+  linkType: hard
+
+"uuid@npm:^11.1.1":
+  version: 11.1.1
+  resolution: "uuid@npm:11.1.1"
+  bin:
+    uuid: dist/esm/bin/uuid
+  checksum: 10c0/9e3af58eba872ece5a5e76f4773a94fc78a0ef2c2444c38dbe6b42f41dadf76c01850fd783604f27986f6195e6286aef064d45987d401b2a33127b98ddf7c0c5
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Clears the `uuid` "missing buffer bounds check in v3/v5/v6" advisory — patched in **11.1.1**. Bumps `twenty-server`, `twenty-shared`, `twenty-front` from 9 → `^11.1.1`.

### Why 11 and not 13
uuid **11.1.x still ships a CommonJS build**, so jest loads it with **no config changes**. uuid went **ESM-only at v12+**, which would otherwise force `transformIgnorePatterns` workarounds across the jest projects (and broke server/integration/storybook CI on the earlier 13 attempt). 11.1.1 is the actual patched version, so this is the minimal fix.

### Changes
- `uuid` → `^11.1.1` in the three workspaces (lockfile regenerated under hardened mode)
- one test (`useCreateManyRecords.test.tsx`): pin the mocked `v4` to its string-returning overload — uuid's types declare a `Uint8Array` overload that `jest.mocked` resolves to (present in v11 too, unrelated to ESM).

All usages are named imports, so no source migration. typecheck passes (server/shared/front); affected specs pass. **No jest config changes.**