### PR TITLE
security: bump electron 36 → 39 in twenty-companion

### DIFF
--- a/packages/twenty-companion/package.json
+++ b/packages/twenty-companion/package.json
@@ -33,7 +33,7 @@
     "@electron/fuses": "^1.8.0",
     "@vercel/webpack-asset-relocator-loader": "^1.7.3",
     "css-loader": "^6.11.0",
-    "electron": "36.0.1",
+    "electron": "^39.8.5",
     "node-loader": "^2.1.0",
     "style-loader": "^3.3.4"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -33845,16 +33845,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"electron@npm:36.0.1":
-  version: 36.0.1
-  resolution: "electron@npm:36.0.1"
+"electron@npm:^39.8.5":
+  version: 39.8.10
+  resolution: "electron@npm:39.8.10"
   dependencies:
     "@electron/get": "npm:^2.0.0"
     "@types/node": "npm:^22.7.7"
     extract-zip: "npm:^2.0.1"
   bin:
     electron: cli.js
-  checksum: 10c0/be0dddedf67632ca2cedd2d037106ecabe617a59cb6f65d5fcf5b68455a82c753637441bec3cec2cf91625c36ad3fbf3251e466c1be15093e00ba1fe517eca47
+  checksum: 10c0/a62fc5a9d2cf96b4684547e14d2a9a1dc4350d66bcfdd2747d4154d6af3bdf8e4e0aae21dfaee55617035b870a3326b61102ef84b7bed5cd73040ec9b0ebe595
   languageName: node
   linkType: hard
 
@@ -56440,7 +56440,7 @@ __metadata:
     css-loader: "npm:^6.11.0"
     dotenv: "npm:^16.5.0"
     easymde: "npm:^2.20.0"
-    electron: "npm:36.0.1"
+    electron: "npm:^39.8.5"
     electron-squirrel-startup: "npm:^1.0.1"
     express: "npm:^4.18.2"
     marked: "npm:^5.0.0"


### PR DESCRIPTION
Clears the Electron advisory batch (use-after-free, IPC scoping, origin handling, ASAR integrity, …) — patched in **39.8.5+**, resolves to **39.8.10**.

- `twenty-companion` is the standalone desktop companion app (electron-forge; @electron-forge 7.8 supports Electron 39). Main-process code only uses basic `require('electron')` APIs, stable across 36→39.
- Lockfile + manifest only; gate-safe; hardened install clean.

⚠️ **Verification caveat:** there's no CI job that builds/tests twenty-companion, so this isn't exercised by CI, and I couldn't verify runtime locally (electron-forge packaging downloads the ~100MB Electron binary / needs a display, and the repo's `enableScripts: false` skips the binary). **Recommend a manual smoke test** (`yarn make`/`start` in twenty-companion) before relying on the bump.