### PR TITLE
Deprecate dummy enterprise key 2/2

### DIFF
--- a/packages/twenty-client-sdk/src/metadata/generated/schema.graphql
+++ b/packages/twenty-client-sdk/src/metadata/generated/schema.graphql
@@ -957,7 +957,6 @@ type Workspace {
   installedApplications: [Application!]!
   currentBillingSubscription: BillingSubscription
   billingEntitlements: [BillingEntitlement!]!
-  hasValidEnterpriseKey: Boolean!
   hasValidSignedEnterpriseKey: Boolean!
   hasValidEnterpriseValidityToken: Boolean!
   workspaceUrls: WorkspaceUrls!

--- a/packages/twenty-client-sdk/src/metadata/generated/schema.ts
+++ b/packages/twenty-client-sdk/src/metadata/generated/schema.ts
@@ -674,7 +674,6 @@ export interface Workspace {
     installedApplications: Application[]
     currentBillingSubscription?: BillingSubscription
     billingEntitlements: BillingEntitlement[]
-    hasValidEnterpriseKey: Scalars['Boolean']
     hasValidSignedEnterpriseKey: Scalars['Boolean']
     hasValidEnterpriseValidityToken: Scalars['Boolean']
     workspaceUrls: WorkspaceUrls
@@ -3601,7 +3600,6 @@ export interface WorkspaceGenqlSelection{
     installedApplications?: ApplicationGenqlSelection
     currentBillingSubscription?: BillingSubscriptionGenqlSelection
     billingEntitlements?: BillingEntitlementGenqlSelection
-    hasValidEnterpriseKey?: boolean | number
     hasValidSignedEnterpriseKey?: boolean | number
     hasValidEnterpriseValidityToken?: boolean | number
     workspaceUrls?: WorkspaceUrlsGenqlSelection

--- a/packages/twenty-client-sdk/src/metadata/generated/types.ts
+++ b/packages/twenty-client-sdk/src/metadata/generated/types.ts
@@ -1896,9 +1896,6 @@ export default {
             "billingEntitlements": [
                 230
             ],
-            "hasValidEnterpriseKey": [
-                6
-            ],
             "hasValidSignedEnterpriseKey": [
                 6
             ],

--- a/packages/twenty-front/src/generated-metadata/graphql.ts
+++ b/packages/twenty-front/src/generated-metadata/graphql.ts
@@ -5970,7 +5970,6 @@ export type Workspace = {
   eventLogRetentionDays: Scalars['Float'];
   fastModel: Scalars['String'];
   featureFlags?: Maybe<Array<FeatureFlag>>;
-  hasValidEnterpriseKey: Scalars['Boolean'];
   hasValidEnterpriseValidityToken: Scalars['Boolean'];
   hasValidSignedEnterpriseKey: Scalars['Boolean'];
   id: Scalars['UUID'];

--- a/packages/twenty-front/src/modules/object-metadata/hooks/__tests__/useColumnDefinitionsFromObjectMetadata.test.ts
+++ b/packages/twenty-front/src/modules/object-metadata/hooks/__tests__/useColumnDefinitionsFromObjectMetadata.test.ts
@@ -35,7 +35,6 @@ describe('useColumnDefinitionsFromObjectMetadata', () => {
       allowImpersonation: false,
       subdomain: 'test',
       activationStatus: WorkspaceActivationStatus.ACTIVE,
-      hasValidEnterpriseKey: false,
       hasValidSignedEnterpriseKey: false,
       hasValidEnterpriseValidityToken: false,
       metadataVersion: 1,

--- a/packages/twenty-front/src/testing/mock-data/users.ts
+++ b/packages/twenty-front/src/testing/mock-data/users.ts
@@ -2,19 +2,19 @@ import { type CurrentUserWorkspace } from '@/auth/states/currentUserWorkspaceSta
 import { CUSTOM_WORKSPACE_APPLICATION_MOCK } from '@/object-metadata/hooks/__tests__/constants/CustomWorkspaceApplicationMock.test.constant';
 import { type WorkspaceMember } from '@/workspace-member/types/WorkspaceMember';
 import {
-  AUTO_SELECT_FAST_MODEL_ID,
-  AUTO_SELECT_SMART_MODEL_ID,
+    AUTO_SELECT_FAST_MODEL_ID,
+    AUTO_SELECT_SMART_MODEL_ID,
 } from 'twenty-shared/constants';
 import {
-  OnboardingStatus,
-  PermissionFlagType,
-  SubscriptionInterval,
-  SubscriptionStatus,
-  type User,
-  type Workspace,
-  WorkspaceActivationStatus,
-  WorkspaceMemberDateFormatEnum,
-  WorkspaceMemberTimeFormatEnum,
+    OnboardingStatus,
+    PermissionFlagType,
+    SubscriptionInterval,
+    SubscriptionStatus,
+    type User,
+    type Workspace,
+    WorkspaceActivationStatus,
+    WorkspaceMemberDateFormatEnum,
+    WorkspaceMemberTimeFormatEnum,
 } from '~/generated-metadata/graphql';
 import { mockBillingPlans } from '~/testing/mock-data/billing-plans';
 import { getTestEnrichedObjectMetadataItemsMock } from '~/testing/utils/getTestEnrichedObjectMetadataItemsMock';
@@ -70,7 +70,6 @@ export const mockCurrentWorkspace = {
   isPublicInviteLinkEnabled: true,
   allowImpersonation: true,
   activationStatus: WorkspaceActivationStatus.ACTIVE,
-  hasValidEnterpriseKey: false,
   hasValidSignedEnterpriseKey: false,
   hasValidEnterpriseValidityToken: false,
   isGoogleAuthEnabled: true,

--- a/packages/twenty-front/src/testing/mock-data/users.ts
+++ b/packages/twenty-front/src/testing/mock-data/users.ts
@@ -2,19 +2,19 @@ import { type CurrentUserWorkspace } from '@/auth/states/currentUserWorkspaceSta
 import { CUSTOM_WORKSPACE_APPLICATION_MOCK } from '@/object-metadata/hooks/__tests__/constants/CustomWorkspaceApplicationMock.test.constant';
 import { type WorkspaceMember } from '@/workspace-member/types/WorkspaceMember';
 import {
-    AUTO_SELECT_FAST_MODEL_ID,
-    AUTO_SELECT_SMART_MODEL_ID,
+  AUTO_SELECT_FAST_MODEL_ID,
+  AUTO_SELECT_SMART_MODEL_ID,
 } from 'twenty-shared/constants';
 import {
-    OnboardingStatus,
-    PermissionFlagType,
-    SubscriptionInterval,
-    SubscriptionStatus,
-    type User,
-    type Workspace,
-    WorkspaceActivationStatus,
-    WorkspaceMemberDateFormatEnum,
-    WorkspaceMemberTimeFormatEnum,
+  OnboardingStatus,
+  PermissionFlagType,
+  SubscriptionInterval,
+  SubscriptionStatus,
+  type User,
+  type Workspace,
+  WorkspaceActivationStatus,
+  WorkspaceMemberDateFormatEnum,
+  WorkspaceMemberTimeFormatEnum,
 } from '~/generated-metadata/graphql';
 import { mockBillingPlans } from '~/testing/mock-data/billing-plans';
 import { getTestEnrichedObjectMetadataItemsMock } from '~/testing/utils/getTestEnrichedObjectMetadataItemsMock';

--- a/packages/twenty-server/.env.test
+++ b/packages/twenty-server/.env.test
@@ -1,4 +1,4 @@
-PG_DATABASE_URL=postgres://postgres:postgres@localhost:5432/test
+PG_DATABASE_URL=postgres://mariestoppa:postgres@localhost:5432/default
 REDIS_URL=redis://localhost:6379
 
 APP_SECRET=replace_me_with_a_random_string

--- a/packages/twenty-server/.env.test
+++ b/packages/twenty-server/.env.test
@@ -1,4 +1,4 @@
-PG_DATABASE_URL=postgres://mariestoppa:postgres@localhost:5432/default
+PG_DATABASE_URL=postgres://postgres:postgres@localhost:5432/test
 REDIS_URL=redis://localhost:6379
 
 APP_SECRET=replace_me_with_a_random_string

--- a/packages/twenty-server/src/engine/core-modules/workspace/workspace.resolver.ts
+++ b/packages/twenty-server/src/engine/core-modules/workspace/workspace.resolver.ts
@@ -310,11 +310,6 @@ export class WorkspaceResolver {
   }
 
   @ResolveField(() => Boolean)
-  hasValidEnterpriseKey(): boolean {
-    return this.enterprisePlanService.hasValidSignedEnterpriseKey();
-  }
-
-  @ResolveField(() => Boolean)
   hasValidSignedEnterpriseKey(): boolean {
     return this.enterprisePlanService.hasValidSignedEnterpriseKey();
   }


### PR DESCRIPTION
Following [1/2](https://github.com/twentyhq/twenty/pull/20890)

Now that all usages of hasValidEnterpriseKey has been removed in prod and deployed, we can safely remove it altogether.