### PR TITLE
chore: force tmp >= 0.2.7 for root dev tooling (nx/zapier)

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,8 @@
     "@wyw-in-js/transform@npm:0.6.0": "patch:@wyw-in-js/transform@npm%3A0.7.0#~/.yarn/patches/@wyw-in-js-transform-npm-0.7.0-ba641dc99f.patch",
     "@wyw-in-js/transform@npm:0.7.0": "patch:@wyw-in-js/transform@npm%3A0.7.0#~/.yarn/patches/@wyw-in-js-transform-npm-0.7.0-ba641dc99f.patch",
     "@opentelemetry/api": "1.9.1",
-    "chokidar": "^3.6.0"
+    "chokidar": "^3.6.0",
+    "tmp": "^0.2.7"
   },
   "version": "0.2.1",
   "nx": {},

--- a/yarn.lock
+++ b/yarn.lock
@@ -47101,13 +47101,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"os-tmpdir@npm:~1.0.2":
-  version: 1.0.2
-  resolution: "os-tmpdir@npm:1.0.2"
-  checksum: 10c0/f438450224f8e2687605a8dd318f0db694b6293c5d835ae509a69e97c8de38b6994645337e5577f5001115470414638978cc49da1cdcc25106dad8738dc69990
-  languageName: node
-  linkType: hard
-
 "otplib@npm:^12.0.1":
   version: 12.0.1
   resolution: "otplib@npm:12.0.1"
@@ -55756,25 +55749,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"tmp@npm:0.2.1":
-  version: 0.2.1
-  resolution: "tmp@npm:0.2.1"
-  dependencies:
-    rimraf: "npm:^3.0.0"
-  checksum: 10c0/67607aa012059c9ce697bee820ee51bc0f39b29a8766def4f92d3f764d67c7cf9205d537d24e0cb1ce9685c40d4c628ead010910118ea18348666b5c46ed9123
-  languageName: node
-  linkType: hard
-
-"tmp@npm:^0.0.33":
-  version: 0.0.33
-  resolution: "tmp@npm:0.0.33"
-  dependencies:
-    os-tmpdir: "npm:~1.0.2"
-  checksum: 10c0/69863947b8c29cabad43fe0ce65cec5bb4b481d15d4b4b21e036b060b3edbf3bc7a5541de1bacb437bb3f7c4538f669752627fdf9b4aaf034cebd172ba373408
-  languageName: node
-  linkType: hard
-
-"tmp@npm:^0.2.0, tmp@npm:^0.2.5, tmp@npm:~0.2.1":
+"tmp@npm:^0.2.7":
   version: 0.2.7
   resolution: "tmp@npm:0.2.7"
   checksum: 10c0/59eb55584f2f07210d3231b6a1f6b5c2b9794d8a7b509c8ee867ed2acad6d2245ee2448b7937b676ffbff3155a70077edde8a69f9d7cf0f90c86a62e8910c357


### PR DESCRIPTION
Resolves the **root** `tmp` Dependabot alert (`tmp < 0.2.6`, #1308).

In the root workspace, `tmp` is a transitive dep of `nx` (`~0.2.1`) and `zapier-platform-cli` (exact `0.2.1`) — dev/CLI tooling that **exact-pins old tmp with no fixed parent to upgrade to** (verified: even latest `zapier-platform-cli@15.19.0` still pins `0.2.1`). So it's pinned to the patched **0.2.7** via a root `resolutions` entry — the correct tool for un-dedupe-able transitive pins. Not in the prod image.

### Why the `twenty-apps/*` alerts are not fixed here
Those come from a different source — `twenty-sdk → inquirer ^10 → @inquirer/editor 4.x → external-editor → tmp@0.0.33`. Rather than add a `resolutions` block to every app's `package.json` (which doesn't scale — every newly-scaffolded app would need it), they'll be fixed **centrally** by bumping `inquirer` in `twenty-sdk` (`^10 → ^12`, which reaches `@inquirer/editor 5.x` that dropped external-editor). Separate PR — apps inherit the fix on the next SDK release with no manual additions.
