### PR TITLE
fix(ui): restore content-box sizing for components broken by the global border-box reset

### DIFF
--- a/packages/twenty-front/src/modules/page-layout/widgets/fields/components/FieldsConfigurationGroupDraggableHeader.tsx
+++ b/packages/twenty-front/src/modules/page-layout/widgets/fields/components/FieldsConfigurationGroupDraggableHeader.tsx
@@ -9,6 +9,8 @@ import {
 
 const StyledContainer = styled.div`
   align-items: center;
+  /* Height below is sized against the content box. */
+  box-sizing: content-box;
   cursor: grab;
   display: flex;
   gap: ${themeCssVariables.spacing[2]};

--- a/packages/twenty-front/src/modules/ui/layout/dropdown/components/DropdownMenuSearchInput.tsx
+++ b/packages/twenty-front/src/modules/ui/layout/dropdown/components/DropdownMenuSearchInput.tsx
@@ -8,6 +8,8 @@ import { themeCssVariables } from 'twenty-ui-deprecated/theme-constants';
 const StyledDropdownMenuSearchInputContainer = styled.div`
   --vertical-padding: ${themeCssVariables.spacing[2]};
   align-items: center;
+  /* min-height below is sized against the content box. */
+  box-sizing: content-box;
   display: flex;
   flex-direction: row;
   min-height: calc(36px - 2 * var(--vertical-padding));

--- a/packages/twenty-ui-deprecated/src/components/chip/Chip.tsx
+++ b/packages/twenty-ui-deprecated/src/components/chip/Chip.tsx
@@ -63,6 +63,8 @@ const StyledContainer = styled.div<
   --chip-horizontal-padding: ${themeCssVariables.spacing[1]};
   --chip-vertical-padding: ${themeCssVariables.spacing[1]};
 
+  /* Height and max-width are sized against the content box. */
+  box-sizing: content-box;
   text-decoration: none;
   align-items: center;
 

--- a/packages/twenty-ui-deprecated/src/navigation/link/components/RoundedLink.tsx
+++ b/packages/twenty-ui-deprecated/src/navigation/link/components/RoundedLink.tsx
@@ -15,6 +15,8 @@ const StyledLink = styled.a`
   background-color: ${themeCssVariables.background.transparent.lighter};
   border: 1px solid ${themeCssVariables.border.color.strong};
   border-radius: 50px;
+  /* Height and max-width are sized against the content box. */
+  box-sizing: content-box;
   color: ${themeCssVariables.font.color.primary};
   cursor: pointer;
   display: inline-flex;

--- a/packages/twenty-ui-deprecated/src/navigation/menu/menu-item/components/MenuItemSelect.tsx
+++ b/packages/twenty-ui-deprecated/src/navigation/menu/menu-item/components/MenuItemSelect.tsx
@@ -24,6 +24,8 @@ export const StyledMenuItemSelect = styled.div<{
 }>`
   --horizontal-padding: ${themeCssVariables.spacing[1]};
   --vertical-padding: ${themeCssVariables.spacing[2]};
+  /* Height and width below are sized against the content box. */
+  box-sizing: content-box;
   align-items: center;
   border-radius: ${themeCssVariables.border.radius.sm};
   display: flex;

--- a/packages/twenty-ui-deprecated/src/navigation/menu/menu-item/components/MenuItemSuggestion.tsx
+++ b/packages/twenty-ui-deprecated/src/navigation/menu/menu-item/components/MenuItemSuggestion.tsx
@@ -23,6 +23,8 @@ const StyledSuggestionMenuItem = styled.li<{
   --horizontal-padding: ${themeCssVariables.spacing[1]};
   --vertical-padding: ${themeCssVariables.spacing[2]};
 
+  /* Height below is sized against the content box. */
+  box-sizing: content-box;
   align-items: center;
 
   border-radius: ${themeCssVariables.border.radius.sm};

--- a/packages/twenty-ui-deprecated/src/navigation/menu/menu-item/internals/components/StyledMenuItemBase.tsx
+++ b/packages/twenty-ui-deprecated/src/navigation/menu/menu-item/internals/components/StyledMenuItemBase.tsx
@@ -16,6 +16,8 @@ export type MenuItemBaseProps = {
 export const StyledMenuItemBase = styled.div<MenuItemBaseProps>`
   --horizontal-padding: ${themeCssVariables.spacing[1]};
   --vertical-padding: ${themeCssVariables.spacing[2]};
+  /* Height and width below are sized against the content box. */
+  box-sizing: content-box;
   align-items: center;
 
   border-radius: ${themeCssVariables.border.radius.sm};
@@ -148,6 +150,8 @@ type HoverableMenuItemBaseProps = {
 export const StyledHoverableMenuItemBase = styled.div<HoverableMenuItemBaseProps>`
   --horizontal-padding: ${themeCssVariables.spacing[1]};
   --vertical-padding: ${themeCssVariables.spacing[2]};
+  /* Height and width below are sized against the content box. */
+  box-sizing: content-box;
   align-items: center;
   border-radius: ${themeCssVariables.border.radius.sm};
   display: flex;


### PR DESCRIPTION
## Problem

Since the `twenty-ui` → `twenty-ui-deprecated` / `twenty-new-ui` → `twenty-ui` rename (#21315), many deprecated components render with **compacted height** — e.g. dropdown menu items collapse from 32px to 16px, and chips from ~24px to 16px.

## Root cause

The new `twenty-ui` (formerly `twenty-new-ui`) ships a global reset in `packages/twenty-ui/src/styles/base/reset.scss`:

```css
*, *::before, *::after {
  box-sizing: border-box;
}
```

This is bundled into `twenty-ui/style.css`, which the app imports in `index.tsx`. #21315 did not change the `import 'twenty-ui/style.css'` line, but it changed what `twenty-ui` resolves to (old → new), so this **global `border-box` reset now applies app-wide**.

Several deprecated components were authored against the **content box**, e.g. `StyledMenuItemBase`:

```css
height: calc(32px - 2 * var(--vertical-padding));
padding: var(--vertical-padding) var(--horizontal-padding);
```

With `content-box` the padding sits *outside* the declared height → 32px total. Under the new `border-box` reset the padding is folded *inside* → 16px total. (`Chip` uses `height: spacing[4]` + outside padding — same failure mode.)

Verified in the running app: the collapsed menu item computes `box-sizing: border-box`, matched by the rule `*, ::before, ::after { box-sizing: border-box }`; `height` resolves to `calc(32px - 2 * 8px) = 16px`.

## Fix

Add `box-sizing: content-box` to the affected deprecated components. A class selector outranks the universal `*` reset, so this restores their intended sizing **without touching the global reset** (which the new `twenty-ui` components rely on).

Affected: `StyledMenuItemBase` (and its hoverable variant), `MenuItemSelect`, `MenuItemSuggestion`, `Chip`.
