### PR TITLE
feat(logic-function): add buildStatus enum, deprecate isBuildUpToDate

### DIFF
--- a/packages/twenty-server/src/database/commands/upgrade-version-command/2-11/2-11-instance-command-fast-1799000040000-add-logic-function-build-status.ts
+++ b/packages/twenty-server/src/database/commands/upgrade-version-command/2-11/2-11-instance-command-fast-1799000040000-add-logic-function-build-status.ts
@@ -1,0 +1,30 @@
+import { type QueryRunner } from 'typeorm';
+
+import { RegisteredInstanceCommand } from 'src/engine/core-modules/upgrade/decorators/registered-instance-command.decorator';
+import { type FastInstanceCommand } from 'src/engine/core-modules/upgrade/interfaces/fast-instance-command.interface';
+
+@RegisteredInstanceCommand('2.11.0', 1799000040000)
+export class AddLogicFunctionBuildStatusFastInstanceCommand
+  implements FastInstanceCommand
+{
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `CREATE TYPE "core"."logicFunction_buildstatus_enum" AS ENUM('NOT_BUILT', 'CODE_BUILT', 'READY', 'DEPLOY_FAILED')`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "core"."logicFunction" ADD "buildStatus" "core"."logicFunction_buildstatus_enum" NOT NULL DEFAULT 'READY'`,
+    );
+    await queryRunner.query(
+      `UPDATE "core"."logicFunction" SET "buildStatus" = CASE WHEN "isBuildUpToDate" THEN 'READY' ELSE 'NOT_BUILT' END`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "core"."logicFunction" DROP COLUMN "buildStatus"`,
+    );
+    await queryRunner.query(
+      `DROP TYPE "core"."logicFunction_buildstatus_enum"`,
+    );
+  }
+}

--- a/packages/twenty-server/src/database/commands/upgrade-version-command/instance-commands.constant.ts
+++ b/packages/twenty-server/src/database/commands/upgrade-version-command/instance-commands.constant.ts
@@ -60,6 +60,7 @@ import { AddLogicFunctionExecutionModeFastInstanceCommand } from 'src/database/c
 import { EncryptNonSecretApplicationVariableSlowInstanceCommand } from 'src/database/commands/upgrade-version-command/2-9/2-9-instance-command-slow-1798400000000-encrypt-non-secret-application-variable';
 import { MigrateAiModelPreferencesSlowInstanceCommand } from 'src/database/commands/upgrade-version-command/2-9/2-9-instance-command-slow-1799000010000-migrate-ai-model-preferences';
 import { DropEmailingDomainDriverColumnFastInstanceCommand } from 'src/database/commands/upgrade-version-command/2-11/2-11-instance-command-fast-1780926908000-drop-emailing-domain-driver-column';
+import { AddLogicFunctionBuildStatusFastInstanceCommand } from 'src/database/commands/upgrade-version-command/2-11/2-11-instance-command-fast-1799000040000-add-logic-function-build-status';
 
 export const INSTANCE_COMMANDS = [
   AddViewFieldGroupIdIndexOnViewFieldFastInstanceCommand,
@@ -122,4 +123,5 @@ export const INSTANCE_COMMANDS = [
   MigrateAiModelPreferencesSlowInstanceCommand,
   EncryptNonSecretApplicationVariableSlowInstanceCommand,
   DropEmailingDomainDriverColumnFastInstanceCommand,
+  AddLogicFunctionBuildStatusFastInstanceCommand,
 ];

--- a/packages/twenty-server/src/engine/core-modules/application/application-manifest/converters/from-logic-function-manifest-to-universal-flat-logic-function.util.ts
+++ b/packages/twenty-server/src/engine/core-modules/application/application-manifest/converters/from-logic-function-manifest-to-universal-flat-logic-function.util.ts
@@ -3,6 +3,7 @@ import { parse } from 'path';
 import { type LogicFunctionManifest } from 'twenty-shared/application';
 
 import {
+  LogicFunctionBuildStatus,
   LogicFunctionExecutionMode,
   LogicFunctionRuntime,
 } from 'src/engine/metadata-modules/logic-function/logic-function.entity';
@@ -40,6 +41,7 @@ export const fromLogicFunctionManifestToUniversalFlatLogicFunction = ({
     workflowActionTriggerSettings:
       logicFunctionManifest.workflowActionTriggerSettings ?? null,
     isBuildUpToDate: true,
+    buildStatus: LogicFunctionBuildStatus.READY,
     executionMode: LogicFunctionExecutionMode.LIVE,
     createdAt: now,
     updatedAt: now,

--- a/packages/twenty-server/src/engine/core-modules/logic-function/logic-function-drivers/drivers/lambda.driver.ts
+++ b/packages/twenty-server/src/engine/core-modules/logic-function/logic-function-drivers/drivers/lambda.driver.ts
@@ -33,7 +33,7 @@ import {
   LogicFunctionExceptionCode,
 } from 'src/engine/metadata-modules/logic-function/logic-function.exception';
 import { type FlatLogicFunction } from 'src/engine/metadata-modules/logic-function/types/flat-logic-function.type';
-import { isLogicFunctionReadyForPrebuiltInstall } from 'src/engine/metadata-modules/logic-function/utils/is-logic-function-ready-for-prebuilt-install.util';
+import { resolveEffectiveLogicFunctionExecutionMode } from 'src/engine/metadata-modules/logic-function/utils/resolve-effective-logic-function-execution-mode.util';
 
 export {
   type LambdaDriverOptions,
@@ -114,17 +114,23 @@ export class LambdaDriver implements LogicFunctionDriver {
     timeoutMs = 900_000,
     forceExecutionMode,
   }: LogicFunctionExecuteParams): Promise<LogicFunctionExecuteResult> {
-    const executionMode = forceExecutionMode ?? flatLogicFunction.executionMode;
+    const requestedExecutionMode =
+      forceExecutionMode ?? flatLogicFunction.executionMode;
 
-    if (
-      executionMode === LogicFunctionExecutionMode.PREBUILT &&
-      !isLogicFunctionReadyForPrebuiltInstall(flatLogicFunction)
-    ) {
+    const { effectiveExecutionMode, canExecute } =
+      resolveEffectiveLogicFunctionExecutionMode({
+        requestedExecutionMode,
+        flatLogicFunction,
+      });
+
+    if (!canExecute) {
       throw new LogicFunctionException(
         `Cannot run logic function '${flatLogicFunction.id}' in PREBUILT mode: bundle is not installed`,
         LogicFunctionExceptionCode.LOGIC_FUNCTION_PREBUILT_BUNDLE_NOT_INSTALLED,
       );
     }
+
+    const executionMode = effectiveExecutionMode;
 
     let currentPhase: LambdaExecutionPhase = LambdaExecutionPhase.BUILD;
     let buildExecutorMs = 0;

--- a/packages/twenty-server/src/engine/core-modules/logic-function/logic-function-drivers/drivers/local.driver.ts
+++ b/packages/twenty-server/src/engine/core-modules/logic-function/logic-function-drivers/drivers/local.driver.ts
@@ -27,7 +27,7 @@ import {
   LogicFunctionExceptionCode,
 } from 'src/engine/metadata-modules/logic-function/logic-function.exception';
 import { type FlatLogicFunction } from 'src/engine/metadata-modules/logic-function/types/flat-logic-function.type';
-import { isLogicFunctionReadyForPrebuiltInstall } from 'src/engine/metadata-modules/logic-function/utils/is-logic-function-ready-for-prebuilt-install.util';
+import { resolveEffectiveLogicFunctionExecutionMode } from 'src/engine/metadata-modules/logic-function/utils/resolve-effective-logic-function-execution-mode.util';
 
 export { type LocalDriverOptions } from 'src/engine/core-modules/logic-function/logic-function-drivers/drivers/local/types/local-driver.type';
 
@@ -111,17 +111,23 @@ export class LocalDriver implements LogicFunctionDriver {
     timeoutMs = 900_000,
     forceExecutionMode,
   }: LogicFunctionExecuteParams): Promise<LogicFunctionExecuteResult> {
-    const executionMode = forceExecutionMode ?? flatLogicFunction.executionMode;
+    const requestedExecutionMode =
+      forceExecutionMode ?? flatLogicFunction.executionMode;
 
-    if (
-      executionMode === LogicFunctionExecutionMode.PREBUILT &&
-      !isLogicFunctionReadyForPrebuiltInstall(flatLogicFunction)
-    ) {
+    const { effectiveExecutionMode, canExecute } =
+      resolveEffectiveLogicFunctionExecutionMode({
+        requestedExecutionMode,
+        flatLogicFunction,
+      });
+
+    if (!canExecute) {
       throw new LogicFunctionException(
         `Cannot run logic function '${flatLogicFunction.id}' in PREBUILT mode: bundle is not installed`,
         LogicFunctionExceptionCode.LOGIC_FUNCTION_PREBUILT_BUNDLE_NOT_INSTALLED,
       );
     }
+
+    const executionMode = effectiveExecutionMode;
 
     await this.layerManager.ensureDepsLayer({
       flatApplication,

--- a/packages/twenty-server/src/engine/core-modules/logic-function/logic-function-executor/logic-function-executor.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/logic-function/logic-function-executor/logic-function-executor.service.ts
@@ -45,6 +45,7 @@ import {
   LogicFunctionExceptionCode,
 } from 'src/engine/metadata-modules/logic-function/logic-function.exception';
 import { FlatLogicFunction } from 'src/engine/metadata-modules/logic-function/types/flat-logic-function.type';
+import { resolveEffectiveLogicFunctionExecutionMode } from 'src/engine/metadata-modules/logic-function/utils/resolve-effective-logic-function-execution-mode.util';
 import { SubscriptionChannel } from 'src/engine/subscriptions/enums/subscription-channel.enum';
 import { SubscriptionService } from 'src/engine/subscriptions/subscription.service';
 import { EventLogLiveService } from 'src/engine/core-modules/event-logs/live/event-log-live.service';
@@ -122,11 +123,24 @@ export class LogicFunctionExecutorService {
 
     const driver = this.logicFunctionDriverFactory.getCurrentDriver();
 
-    const effectiveExecutionMode = await this.resolveEffectiveExecutionMode({
+    const requestedExecutionMode = await this.resolveEffectiveExecutionMode({
       workspaceId,
       flatLogicFunction,
       callerOverride: executionMode,
     });
+
+    const { effectiveExecutionMode, canExecute } =
+      resolveEffectiveLogicFunctionExecutionMode({
+        requestedExecutionMode,
+        flatLogicFunction,
+      });
+
+    if (!canExecute) {
+      throw new LogicFunctionException(
+        `Cannot run logic function '${flatLogicFunction.id}' in PREBUILT mode: bundle is not installed`,
+        LogicFunctionExceptionCode.LOGIC_FUNCTION_PREBUILT_BUNDLE_NOT_INSTALLED,
+      );
+    }
 
     if (effectiveExecutionMode === LogicFunctionExecutionMode.PREBUILT) {
       await this.assertPrebuiltBundleInstalled({

--- a/packages/twenty-server/src/engine/metadata-modules/flat-entity/constant/all-entity-properties-configuration-by-metadata-name.constant.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/flat-entity/constant/all-entity-properties-configuration-by-metadata-name.constant.ts
@@ -587,6 +587,11 @@ export const ALL_ENTITY_PROPERTIES_CONFIGURATION_BY_METADATA_NAME = {
       toStringify: false,
       universalProperty: undefined,
     },
+    buildStatus: {
+      toCompare: true,
+      toStringify: false,
+      universalProperty: undefined,
+    },
     executionMode: {
       toCompare: true,
       toStringify: false,

--- a/packages/twenty-server/src/engine/metadata-modules/logic-function/constants/flat-logic-function-editable-properties.constant.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/logic-function/constants/flat-logic-function-editable-properties.constant.ts
@@ -13,4 +13,5 @@ export const FLAT_LOGIC_FUNCTION_EDITABLE_PROPERTIES = [
   'toolTriggerSettings',
   'workflowActionTriggerSettings',
   'isBuildUpToDate',
+  'buildStatus',
 ] as const satisfies MetadataEntityPropertyName<'logicFunction'>[];

--- a/packages/twenty-server/src/engine/metadata-modules/logic-function/logic-function.entity.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/logic-function/logic-function.entity.ts
@@ -31,6 +31,13 @@ export enum LogicFunctionExecutionMode {
   PREBUILT = 'PREBUILT',
 }
 
+export enum LogicFunctionBuildStatus {
+  NOT_BUILT = 'NOT_BUILT', // source not compiled to a built artifact yet
+  CODE_BUILT = 'CODE_BUILT', // built from source; not yet deployed to the executor (reserved for PR2)
+  READY = 'READY', // ready to run in its execution mode (LIVE: built; PREBUILT: deployed w/ matching checksum)
+  DEPLOY_FAILED = 'DEPLOY_FAILED', // deploying the built artifact to the executor failed (reserved for PR2)
+}
+
 @Entity('logicFunction')
 @Index('IDX_LOGIC_FUNCTION_ID_DELETED_AT', ['id', 'deletedAt'])
 export class LogicFunctionEntity
@@ -65,8 +72,17 @@ export class LogicFunctionEntity
   @Column({ nullable: true, type: 'text' })
   checksum: string | null;
 
+  /** @deprecated use buildStatus. Kept in sync for one release. */
   @Column({ nullable: false, type: 'boolean', default: true })
   isBuildUpToDate: boolean;
+
+  @Column({
+    type: 'enum',
+    enum: LogicFunctionBuildStatus,
+    default: LogicFunctionBuildStatus.READY,
+    nullable: false,
+  })
+  buildStatus: LogicFunctionBuildStatus;
 
   @Column({
     type: 'enum',

--- a/packages/twenty-server/src/engine/metadata-modules/logic-function/services/logic-function-from-source.service.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/logic-function/services/logic-function-from-source.service.ts
@@ -14,7 +14,10 @@ import { findFlatEntityByIdInFlatEntityMapsOrThrow } from 'src/engine/metadata-m
 import { CreateLogicFunctionFromSourceInput } from 'src/engine/metadata-modules/logic-function/dtos/create-logic-function-from-source.input';
 import { LogicFunctionExecutionResultDTO } from 'src/engine/metadata-modules/logic-function/dtos/logic-function-execution-result.dto';
 import { LogicFunctionDTO } from 'src/engine/metadata-modules/logic-function/dtos/logic-function.dto';
-import { LogicFunctionExecutionMode } from 'src/engine/metadata-modules/logic-function/logic-function.entity';
+import {
+  LogicFunctionBuildStatus,
+  LogicFunctionExecutionMode,
+} from 'src/engine/metadata-modules/logic-function/logic-function.entity';
 import {
   LogicFunctionException,
   LogicFunctionExceptionCode,
@@ -169,6 +172,7 @@ export class LogicFunctionFromSourceService {
         description: existingLogicFunction.description,
         timeoutSeconds: existingLogicFunction.timeoutSeconds,
         isBuildUpToDate: existingLogicFunction.isBuildUpToDate,
+        buildStatus: existingLogicFunction.buildStatus,
         checksum: existingLogicFunction.checksum,
         executionMode: LogicFunctionExecutionMode.LIVE,
         handlerName: existingLogicFunction.handlerName,
@@ -337,6 +341,7 @@ export class LogicFunctionFromSourceService {
         ...flatLogicFunction,
         checksum,
         isBuildUpToDate: true,
+        buildStatus: LogicFunctionBuildStatus.READY,
         updatedAt: new Date().toISOString(),
       },
       workspaceId,

--- a/packages/twenty-server/src/engine/metadata-modules/logic-function/utils/build-universal-flat-logic-function-to-create.util.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/logic-function/utils/build-universal-flat-logic-function-to-create.util.ts
@@ -1,6 +1,7 @@
 import { v4 } from 'uuid';
 
 import {
+  LogicFunctionBuildStatus,
   LogicFunctionExecutionMode,
   LogicFunctionRuntime,
 } from 'src/engine/metadata-modules/logic-function/logic-function.entity';
@@ -43,6 +44,11 @@ export const buildUniversalFlatLogicFunctionToCreate = (
     timeoutSeconds: input.timeoutSeconds ?? 300,
     checksum: input.checksum ?? null,
     isBuildUpToDate: input.isBuildUpToDate,
+    buildStatus:
+      input.buildStatus ??
+      (input.isBuildUpToDate
+        ? LogicFunctionBuildStatus.READY
+        : LogicFunctionBuildStatus.NOT_BUILT),
     executionMode: input.executionMode ?? LogicFunctionExecutionMode.LIVE,
     handlerName: input.handlerName,
     sourceHandlerPath: input.sourceHandlerPath,

--- a/packages/twenty-server/src/engine/metadata-modules/logic-function/utils/from-create-logic-function-from-source-input-to-universal-flat-logic-function-to-create.util.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/logic-function/utils/from-create-logic-function-from-source-input-to-universal-flat-logic-function-to-create.util.ts
@@ -2,6 +2,7 @@ import { trimAndRemoveDuplicatedWhitespacesFromObjectStringProperties } from 'tw
 import { v4 } from 'uuid';
 
 import {
+  LogicFunctionBuildStatus,
   LogicFunctionExecutionMode,
   LogicFunctionRuntime,
 } from 'src/engine/metadata-modules/logic-function/logic-function.entity';
@@ -46,6 +47,9 @@ export const fromCreateLogicFunctionFromSourceInputToUniversalFlatLogicFunctionT
       timeoutSeconds: createLogicFunctionFromSourceInput.timeoutSeconds ?? 300,
       checksum,
       isBuildUpToDate,
+      buildStatus: isBuildUpToDate
+        ? LogicFunctionBuildStatus.READY
+        : LogicFunctionBuildStatus.NOT_BUILT,
       executionMode: LogicFunctionExecutionMode.LIVE,
       handlerName,
       sourceHandlerPath,

--- a/packages/twenty-server/src/engine/metadata-modules/logic-function/utils/from-update-logic-function-from-source-input-to-flat-logic-function-to-update.util.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/logic-function/utils/from-update-logic-function-from-source-input-to-flat-logic-function-to-update.util.ts
@@ -1,5 +1,6 @@
 import { isDefined } from 'twenty-shared/utils';
 
+import { LogicFunctionBuildStatus } from 'src/engine/metadata-modules/logic-function/logic-function.entity';
 import { FLAT_LOGIC_FUNCTION_EDITABLE_PROPERTIES } from 'src/engine/metadata-modules/logic-function/constants/flat-logic-function-editable-properties.constant';
 import { type UpdateLogicFunctionFromSourceInput } from 'src/engine/metadata-modules/logic-function/dtos/update-logic-function-from-source.input';
 import { type FlatLogicFunction } from 'src/engine/metadata-modules/logic-function/types/flat-logic-function.type';
@@ -22,7 +23,12 @@ export const fromUpdateLogicFunctionFromSourceInputToFlatLogicFunctionToUpdate =
         properties: [...FLAT_LOGIC_FUNCTION_EDITABLE_PROPERTIES],
         update: {
           ...metadataUpdates,
-          ...(isDefined(sourceHandlerCode) ? { isBuildUpToDate: false } : {}),
+          ...(isDefined(sourceHandlerCode)
+            ? {
+                isBuildUpToDate: false,
+                buildStatus: LogicFunctionBuildStatus.NOT_BUILT,
+              }
+            : {}),
         },
       }),
       updatedAt: new Date().toISOString(),

--- a/packages/twenty-server/src/engine/metadata-modules/logic-function/utils/is-logic-function-ready-for-prebuilt-install.util.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/logic-function/utils/is-logic-function-ready-for-prebuilt-install.util.ts
@@ -1,16 +1,19 @@
 import { isNonEmptyString } from '@sniptt/guards';
 
-import { LogicFunctionExecutionMode } from 'src/engine/metadata-modules/logic-function/logic-function.entity';
+import {
+  LogicFunctionBuildStatus,
+  LogicFunctionExecutionMode,
+} from 'src/engine/metadata-modules/logic-function/logic-function.entity';
 import { type FlatLogicFunction } from 'src/engine/metadata-modules/logic-function/types/flat-logic-function.type';
 
 export type LogicFunctionPrebuiltStateFields = Pick<
   FlatLogicFunction,
-  'executionMode' | 'isBuildUpToDate' | 'checksum'
+  'executionMode' | 'buildStatus' | 'checksum'
 >;
 
 export const isLogicFunctionReadyForPrebuiltInstall = (
   flatLogicFunction: LogicFunctionPrebuiltStateFields,
 ): boolean =>
   flatLogicFunction.executionMode === LogicFunctionExecutionMode.PREBUILT &&
-  flatLogicFunction.isBuildUpToDate === true &&
+  flatLogicFunction.buildStatus === LogicFunctionBuildStatus.READY &&
   isNonEmptyString(flatLogicFunction.checksum);

--- a/packages/twenty-server/src/engine/metadata-modules/logic-function/utils/resolve-effective-logic-function-execution-mode.util.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/logic-function/utils/resolve-effective-logic-function-execution-mode.util.ts
@@ -1,0 +1,60 @@
+import {
+  LogicFunctionBuildStatus,
+  LogicFunctionExecutionMode,
+} from 'src/engine/metadata-modules/logic-function/logic-function.entity';
+import {
+  isLogicFunctionReadyForPrebuiltInstall,
+  type LogicFunctionPrebuiltStateFields,
+} from 'src/engine/metadata-modules/logic-function/utils/is-logic-function-ready-for-prebuilt-install.util';
+
+export type ResolveEffectiveExecutionModeResult =
+  | { effectiveExecutionMode: LogicFunctionExecutionMode; canExecute: true }
+  | { effectiveExecutionMode: null; canExecute: false };
+
+/**
+ * Resolves the execution mode actually used to invoke a logic function, given
+ * the requested mode and the function's build state.
+ *
+ * - PREBUILT requested AND ready (built, deployed, matching checksum) -> PREBUILT
+ * - buildStatus CODE_BUILT or DEPLOY_FAILED -> LIVE fallback (artifact exists,
+ *   ship code on demand). Dormant in PR1: those states are never written yet.
+ * - otherwise (NOT_BUILT in PREBUILT mode) -> cannot execute (caller throws)
+ *
+ * For LIVE requests this always returns LIVE.
+ */
+export const resolveEffectiveLogicFunctionExecutionMode = ({
+  requestedExecutionMode,
+  flatLogicFunction,
+}: {
+  requestedExecutionMode: LogicFunctionExecutionMode;
+  flatLogicFunction: LogicFunctionPrebuiltStateFields;
+}): ResolveEffectiveExecutionModeResult => {
+  if (requestedExecutionMode !== LogicFunctionExecutionMode.PREBUILT) {
+    return {
+      effectiveExecutionMode: requestedExecutionMode,
+      canExecute: true,
+    };
+  }
+
+  if (isLogicFunctionReadyForPrebuiltInstall(flatLogicFunction)) {
+    return {
+      effectiveExecutionMode: LogicFunctionExecutionMode.PREBUILT,
+      canExecute: true,
+    };
+  }
+
+  if (
+    flatLogicFunction.buildStatus === LogicFunctionBuildStatus.CODE_BUILT ||
+    flatLogicFunction.buildStatus === LogicFunctionBuildStatus.DEPLOY_FAILED
+  ) {
+    return {
+      effectiveExecutionMode: LogicFunctionExecutionMode.LIVE,
+      canExecute: true,
+    };
+  }
+
+  return {
+    effectiveExecutionMode: null,
+    canExecute: false,
+  };
+};

--- a/packages/twenty-server/src/engine/workspace-manager/workspace-migration/workspace-migration-builder/validators/services/flat-logic-function-validator.service.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/workspace-migration/workspace-migration-builder/validators/services/flat-logic-function-validator.service.ts
@@ -85,9 +85,8 @@ export class FlatLogicFunctionValidatorService {
       executionMode:
         flatEntityUpdate.executionMode ??
         existingFlatLogicFunction.executionMode,
-      isBuildUpToDate:
-        flatEntityUpdate.isBuildUpToDate ??
-        existingFlatLogicFunction.isBuildUpToDate,
+      buildStatus:
+        flatEntityUpdate.buildStatus ?? existingFlatLogicFunction.buildStatus,
       checksum:
         flatEntityUpdate.checksum !== undefined
           ? flatEntityUpdate.checksum

--- a/packages/twenty-server/src/engine/workspace-manager/workspace-migration/workspace-migration-runner/action-handlers/logic-function/services/update-logic-function-action-handler.service.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/workspace-migration/workspace-migration-runner/action-handlers/logic-function/services/update-logic-function-action-handler.service.ts
@@ -12,6 +12,7 @@ import { findFlatEntityByIdInFlatEntityMapsOrThrow } from 'src/engine/metadata-m
 import type { LogicFunctionDriverFactory } from 'src/engine/core-modules/logic-function/logic-function-drivers/logic-function-driver.factory';
 import { findFlatEntityByUniversalIdentifierOrThrow } from 'src/engine/metadata-modules/flat-entity/utils/find-flat-entity-by-universal-identifier-or-throw.util';
 import {
+  LogicFunctionBuildStatus,
   LogicFunctionEntity,
   LogicFunctionExecutionMode,
 } from 'src/engine/metadata-modules/logic-function/logic-function.entity';
@@ -133,6 +134,7 @@ export class UpdateLogicFunctionActionHandlerService extends WorkspaceMigrationR
         update.executionMode ?? existingLogicFunction.executionMode,
       isBuildUpToDate:
         update.isBuildUpToDate ?? existingLogicFunction.isBuildUpToDate,
+      buildStatus: update.buildStatus ?? existingLogicFunction.buildStatus,
       checksum: update.checksum ?? existingLogicFunction.checksum,
     };
 
@@ -159,6 +161,7 @@ export class UpdateLogicFunctionActionHandlerService extends WorkspaceMigrationR
           ...newLogicFunction,
           executionMode: LogicFunctionExecutionMode.PREBUILT,
           isBuildUpToDate: true,
+          buildStatus: LogicFunctionBuildStatus.READY,
         },
         flatApplication: context.flatApplication,
         applicationUniversalIdentifier,


### PR DESCRIPTION
## Why

Logic-function build state is tracked today by a single boolean `isBuildUpToDate`, which conflates **two** distinct stages:

1. the code is **built** from source into an artifact (file storage + checksum), and
2. the built artifact is **deployed** into the executor (e.g. the Lambda gets the code embedded — `installPrebuiltBundle`).

We need to tell those apart so we can move stage 2 (the slow, external executor deploy) out of the workspace-migration DB transaction and run it asynchronously. Today that deploy runs *inside* the migration transaction, so a deploy touching N functions serializes N Lambda updates under one open transaction — which times out the request gateway and can kill the connection mid-transaction (surfaced recently as a `Migration action 'update' for 'logicFunction' failed` / `Query runner already released` incident).

This is **PR 1 of 2** and is intentionally **behavior-preserving**: it introduces the state model and switches the read path, but does **not** change where the deploy happens yet.

## What

`LogicFunctionBuildStatus`:

| Value | Code built? | Deployed to executor? | Runs as |
|---|---|---|---|
| `NOT_BUILT` | no | — | not runnable |
| `CODE_BUILT` | yes | not yet | LIVE *(reserved for PR2)* |
| `READY` | yes | yes (or LIVE mode) | PREBUILT / LIVE |
| `DEPLOY_FAILED` | yes | failed | LIVE *(reserved for PR2)* |

- New enum + `buildStatus` column on `LogicFunctionEntity` (default `READY`). `isBuildUpToDate` kept and **mirrored**, marked `@deprecated` (removed in a follow-up once call-sites migrate).
- **Behavior-preserving:** every site that wrote `isBuildUpToDate` now also writes `buildStatus` (`false → NOT_BUILT`, `true → READY`). `CODE_BUILT`/`DEPLOY_FAILED` are defined but **never written** in this PR.
- Read path switched to `buildStatus === READY`. Invoke-time mode resolution extracted into `resolveEffectiveLogicFunctionExecutionMode`, which falls back to **LIVE** for `CODE_BUILT`/`DEPLOY_FAILED` (dormant until PR 2) and blocks only `NOT_BUILT` — identical outcomes to today for the only states that occur here.
- Schema via a **fast instance command** in `2-11/` (TypeORM migrations are frozen), creating the enum type, adding the column (default `READY`), and backfilling from `isBuildUpToDate`.
- Registered `buildStatus` in the flat-entity property config + editable properties. **GraphQL DTO intentionally untouched** to avoid schema-snapshot churn.

## Follow-up (PR 2)
Move `installPrebuiltBundle` out of the migration transaction onto the `logicFunctionQueue`: the migration commits with `buildStatus = CODE_BUILT`, an async job deploys and flips to `READY` (or `DEPLOY_FAILED`), functions run LIVE in the meantime, and a reconcile sweep retries stragglers. Also: stop masking the underlying error in `WorkspaceMigrationRunnerService` and guard the rollback when the query runner is already released.

## Testing
- `npx nx typecheck twenty-server` — clean.
- Server jest suite not run locally — relying on CI. Reviewers: please check any exhaustive flat-property snapshot/spec for `logicFunction`.