### PR TITLE
Restore content-box sizing for components broken by the global border-box reset

### DIFF
--- a/packages/twenty-front/src/modules/onboarding/components/OnboardingModalCircularIcon.tsx
+++ b/packages/twenty-front/src/modules/onboarding/components/OnboardingModalCircularIcon.tsx
@@ -11,6 +11,7 @@ const StyledCheckContainer = styled.div<{ color: string }>`
   border: 2px solid ${({ color }) => color};
   border-radius: ${themeCssVariables.border.radius.rounded};
   box-shadow: ${({ color }) => color && `-4px 4px 0 -2px ${color}`};
+  box-sizing: content-box;
   display: flex;
   height: 36px;
   justify-content: center;

--- a/packages/twenty-front/src/modules/ui/input/components/ImageInput.tsx
+++ b/packages/twenty-front/src/modules/ui/input/components/ImageInput.tsx
@@ -11,11 +11,11 @@ import {
   IconX,
 } from 'twenty-ui-deprecated/display';
 import { Button } from 'twenty-ui-deprecated/input';
-import { REACT_APP_SERVER_BASE_URL } from '~/config';
 import {
   ThemeContext,
   themeCssVariables,
 } from 'twenty-ui-deprecated/theme-constants';
+import { REACT_APP_SERVER_BASE_URL } from '~/config';
 const StyledContainer = styled.div`
   display: flex;
   flex-direction: row;
@@ -29,6 +29,7 @@ const StyledPicture = styled.button<{ withPicture: boolean }>`
       : themeCssVariables.background.transparent.light};
   border: 1px solid ${themeCssVariables.border.color.medium};
   border-radius: ${themeCssVariables.border.radius.sm};
+  box-sizing: content-box;
   color: ${themeCssVariables.font.color.light};
   cursor: ${({ disabled }) => (disabled ? 'not-allowed' : 'pointer')};
   display: flex;

--- a/packages/twenty-ui-deprecated/src/components/tag/Tag.tsx
+++ b/packages/twenty-ui-deprecated/src/components/tag/Tag.tsx
@@ -2,10 +2,10 @@ import { styled } from '@linaria/react';
 
 import { type IconComponent } from '@ui/display/icon/types/IconComponent';
 import { OverflowingTextWithTooltip } from '@ui/display/tooltip/OverflowingTextWithTooltip';
-import { isDefined } from 'twenty-shared/utils';
 import { type ThemeColor } from '@ui/theme';
 import { ThemeContext, themeCssVariables } from '@ui/theme-constants';
 import { useContext } from 'react';
+import { isDefined } from 'twenty-shared/utils';
 
 const StyledTag = styled.span<{
   color: TagColor;
@@ -14,6 +14,7 @@ const StyledTag = styled.span<{
   preventShrink?: boolean;
   preventPadding?: boolean;
 }>`
+  box-sizing: content-box;
   align-items: center;
   background: ${({ color }) =>
     color === 'transparent'

--- a/packages/twenty-ui-deprecated/src/display/color/components/ColorSample.tsx
+++ b/packages/twenty-ui-deprecated/src/display/color/components/ColorSample.tsx
@@ -29,6 +29,7 @@ const getBorderColor = (colorName: ThemeColor) => {
 };
 
 const StyledColorSample = styled.div<StyledColorSampleProps>`
+  box-sizing: content-box;
   background-color: ${({ colorName, color }) => getColor(colorName, color)};
   border: ${({ variant, colorName }) =>
     variant === 'pipeline' ? '0' : `1px solid ${getBorderColor(colorName)}`};

--- a/packages/twenty-ui-deprecated/src/input/components/Checkbox.tsx
+++ b/packages/twenty-ui-deprecated/src/input/components/Checkbox.tsx
@@ -153,6 +153,7 @@ const StyledCheckboxContainer = styled.div<InputProps>`
   }
 
   input + label:before {
+    box-sizing: content-box;
     background: var(--checkbox-bg);
     border-color: var(--checkbox-border-color);
     border-radius: var(--checkbox-border-radius);

--- a/packages/twenty-ui-deprecated/src/input/components/Radio.tsx
+++ b/packages/twenty-ui-deprecated/src/input/components/Radio.tsx
@@ -33,6 +33,7 @@ type RadioInputProps = {
 };
 
 const StyledRadioInputBase = styled.input<RadioInputProps>`
+  box-sizing: content-box;
   -webkit-appearance: none;
   appearance: none;
   background-color: transparent;

--- a/packages/twenty-ui-deprecated/src/navigation/menu/menu-item/components/MenuItemHotKeys.tsx
+++ b/packages/twenty-ui-deprecated/src/navigation/menu/menu-item/components/MenuItemHotKeys.tsx
@@ -18,6 +18,7 @@ const StyledCommandText = styled.div`
 `;
 
 const StyledCommandKey = styled.div`
+  box-sizing: content-box;
   align-items: center;
   background-color: ${themeCssVariables.background.secondary};
   border: 1px solid ${themeCssVariables.border.color.strong};


### PR DESCRIPTION
Since [#21315](https://github.com/twentyhq/twenty/pull/21315), the new twenty-ui's global border-box reset applies app-wide, shrinking legacy content-box components: most visibly, off-center checkboxes. [#21349](https://github.com/twentyhq/twenty/pull/21349) missed a few; this adds box-sizing: content-box to Checkbox, Radio, ColorSample, MenuItemHotKeys, Tag, ImageInput, and OnboardingModalCircularIcon.