### PR TITLE
Increase logicFunctionQueue worker concurrency to 10

### DIFF
--- a/packages/twenty-server/src/engine/core-modules/message-queue/message-queue-worker-options.constant.ts
+++ b/packages/twenty-server/src/engine/core-modules/message-queue/message-queue-worker-options.constant.ts
@@ -4,4 +4,5 @@ export const QUEUE_WORKER_OPTIONS: Partial<
   Record<MessageQueue, { concurrency: number }>
 > = {
   [MessageQueue.aiStreamQueue]: { concurrency: 20 },
+  [MessageQueue.logicFunctionQueue]: { concurrency: 10 },
 };


### PR DESCRIPTION
## Summary
- Increase BullMQ worker concurrency for `logicFunctionQueue` from 1 (default) to 10
- Logic function executions are I/O-bound Lambda calls — the worker just holds an HTTP connection open, so higher concurrency doesn't add CPU/memory pressure
- With 13 worker pods, this goes from 13 to ~130 concurrent slots, which should resolve the ~3h average queue latency observed in Grafana

## Test plan
- [ ] Monitor `avg_latency_ms` for `logic-function-queue` in the Grafana job queue dashboard after deploy
- [ ] Verify worker pod CPU/memory remains stable