### PR TITLE
chore(twenty-server): temporary instrumentation for app-install 504

### DIFF
--- a/packages/twenty-server/src/database/typeorm/core/core.datasource.ts
+++ b/packages/twenty-server/src/database/typeorm/core/core.datasource.ts
@@ -41,6 +41,10 @@ export const typeORMCoreModuleOptions: TypeOrmModuleOptions = {
   url: process.env.PG_DATABASE_URL,
   type: 'postgres',
   logging: getLoggingConfig(),
+  // TODO(install-perf): added to surface slow queries during the app-install
+  // 504 investigation. Generally useful — keep or remove with the rest of the
+  // [install-perf] instrumentation.
+  maxQueryExecutionTime: Number(process.env.PG_SLOW_QUERY_MS ?? 1000),
   schema: 'core',
   entities:
     process.env.IS_BILLING_ENABLED === 'true'

--- a/packages/twenty-server/src/database/typeorm/core/core.datasource.ts
+++ b/packages/twenty-server/src/database/typeorm/core/core.datasource.ts
@@ -41,10 +41,6 @@ export const typeORMCoreModuleOptions: TypeOrmModuleOptions = {
   url: process.env.PG_DATABASE_URL,
   type: 'postgres',
   logging: getLoggingConfig(),
-  // TODO(install-perf): added to surface slow queries during the app-install
-  // 504 investigation. Generally useful — keep or remove with the rest of the
-  // [install-perf] instrumentation.
-  maxQueryExecutionTime: Number(process.env.PG_SLOW_QUERY_MS ?? 1000),
   schema: 'core',
   entities:
     process.env.IS_BILLING_ENABLED === 'true'

--- a/packages/twenty-server/src/engine/core-modules/application/application-manifest/application-manifest-migration.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/application/application-manifest/application-manifest-migration.service.ts
@@ -181,7 +181,7 @@ export class ApplicationManifestMigrationService {
 
     // TODO(install-perf): temporary timing for the app-install 504 — remove
     // with the rest of the [install-perf] instrumentation.
-    const recomputeStartNs = process.hrtime.bigint();
+    const recomputeStart = performance.now();
     const cacheResult = await this.workspaceCacheService.getOrRecompute(
       workspaceId,
       [
@@ -189,11 +189,9 @@ export class ApplicationManifestMigrationService {
         'featureFlagsMap',
       ],
     );
-    const recomputeMs =
-      Number(process.hrtime.bigint() - recomputeStartNs) / 1e6;
+    const recomputeMs = performance.now() - recomputeStart;
 
-    // oxlint-disable-next-line no-console
-    console.log(
+    this.logger.log(
       `[install-perf] syncMetadataFromManifest ALL_METADATA_NAME getOrRecompute flat-maps took ${recomputeMs.toFixed(1)}ms (logicFunctions=${manifest.logicFunctions.length})`,
     );
 
@@ -221,7 +219,7 @@ export class ApplicationManifestMigrationService {
       fromAllFlatEntityMaps: existingAllFlatEntityMaps,
     });
 
-    const validateBuildRunStartNs = process.hrtime.bigint();
+    const validateBuildRunStart = performance.now();
     const validateAndBuildResult =
       await this.workspaceMigrationValidateBuildAndRunService.validateBuildAndRunWorkspaceMigrationFromTo(
         {
@@ -241,11 +239,9 @@ export class ApplicationManifestMigrationService {
           dryRun,
         },
       );
-    const validateBuildRunMs =
-      Number(process.hrtime.bigint() - validateBuildRunStartNs) / 1e6;
+    const validateBuildRunMs = performance.now() - validateBuildRunStart;
 
-    // oxlint-disable-next-line no-console
-    console.log(
+    this.logger.log(
       `[install-perf] syncMetadataFromManifest validateBuildAndRunWorkspaceMigrationFromTo took ${validateBuildRunMs.toFixed(1)}ms (dryRun=${dryRun}, actions=${validateAndBuildResult.status === 'success' ? validateAndBuildResult.workspaceMigration.actions.length : 'n/a-failed'})`,
     );
 

--- a/packages/twenty-server/src/engine/core-modules/application/application-manifest/application-manifest-migration.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/application/application-manifest/application-manifest-migration.service.ts
@@ -179,12 +179,22 @@ export class ApplicationManifestMigrationService {
         { workspaceId },
       );
 
+    // TODO(install-perf): temporary timing for the app-install 504 — remove
+    // with the rest of the [install-perf] instrumentation.
+    const recomputeStartNs = process.hrtime.bigint();
     const cacheResult = await this.workspaceCacheService.getOrRecompute(
       workspaceId,
       [
         ...Object.values(ALL_METADATA_NAME).map(getMetadataFlatEntityMapsKey),
         'featureFlagsMap',
       ],
+    );
+    const recomputeMs =
+      Number(process.hrtime.bigint() - recomputeStartNs) / 1e6;
+
+    // oxlint-disable-next-line no-console
+    console.log(
+      `[install-perf] syncMetadataFromManifest ALL_METADATA_NAME getOrRecompute flat-maps took ${recomputeMs.toFixed(1)}ms (logicFunctions=${manifest.logicFunctions.length})`,
     );
 
     const { featureFlagsMap, ...existingAllFlatEntityMaps } = cacheResult;
@@ -211,6 +221,7 @@ export class ApplicationManifestMigrationService {
       fromAllFlatEntityMaps: existingAllFlatEntityMaps,
     });
 
+    const validateBuildRunStartNs = process.hrtime.bigint();
     const validateAndBuildResult =
       await this.workspaceMigrationValidateBuildAndRunService.validateBuildAndRunWorkspaceMigrationFromTo(
         {
@@ -230,6 +241,13 @@ export class ApplicationManifestMigrationService {
           dryRun,
         },
       );
+    const validateBuildRunMs =
+      Number(process.hrtime.bigint() - validateBuildRunStartNs) / 1e6;
+
+    // oxlint-disable-next-line no-console
+    console.log(
+      `[install-perf] syncMetadataFromManifest validateBuildAndRunWorkspaceMigrationFromTo took ${validateBuildRunMs.toFixed(1)}ms (dryRun=${dryRun}, actions=${validateAndBuildResult.status === 'success' ? validateAndBuildResult.workspaceMigration.actions.length : 'n/a-failed'})`,
+    );
 
     if (validateAndBuildResult.status === 'fail') {
       throw new WorkspaceMigrationBuilderException(

--- a/packages/twenty-server/src/engine/core-modules/application/application-manifest/application-manifest-migration.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/application/application-manifest/application-manifest-migration.service.ts
@@ -179,8 +179,7 @@ export class ApplicationManifestMigrationService {
         { workspaceId },
       );
 
-    // TODO(install-perf): temporary timing for the app-install 504 — remove
-    // with the rest of the [install-perf] instrumentation.
+    // TODO(install-perf): temporary, remove.
     const recomputeStart = performance.now();
     const cacheResult = await this.workspaceCacheService.getOrRecompute(
       workspaceId,

--- a/packages/twenty-server/src/engine/workspace-manager/workspace-migration/services/workspace-migration-validate-build-and-run-service.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/workspace-migration/services/workspace-migration-validate-build-and-run-service.ts
@@ -369,8 +369,7 @@ export class WorkspaceMigrationValidateBuildAndRunService {
     const { idByUniversalIdentifierByMetadataName, dryRun, ...buildArgs } =
       args;
 
-    // TODO(install-perf): temporary timing for the app-install 504 — remove
-    // with the rest of the [install-perf] instrumentation.
+    // TODO(install-perf): temporary, remove.
     const buildStart = performance.now();
     const validateAndBuildResult =
       await this.workspaceMigrationBuildOrchestratorService

--- a/packages/twenty-server/src/engine/workspace-manager/workspace-migration/services/workspace-migration-validate-build-and-run-service.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/workspace-migration/services/workspace-migration-validate-build-and-run-service.ts
@@ -371,7 +371,7 @@ export class WorkspaceMigrationValidateBuildAndRunService {
 
     // TODO(install-perf): temporary timing for the app-install 504 — remove
     // with the rest of the [install-perf] instrumentation.
-    const buildStartNs = process.hrtime.bigint();
+    const buildStart = performance.now();
     const validateAndBuildResult =
       await this.workspaceMigrationBuildOrchestratorService
         .buildWorkspaceMigration(buildArgs)
@@ -382,10 +382,9 @@ export class WorkspaceMigrationValidateBuildAndRunService {
             WorkspaceMigrationV2ExceptionCode.BUILDER_INTERNAL_SERVER_ERROR,
           );
         });
-    const buildMs = Number(process.hrtime.bigint() - buildStartNs) / 1e6;
+    const buildMs = performance.now() - buildStart;
 
-    // oxlint-disable-next-line no-console
-    console.log(
+    this.logger.log(
       `[install-perf] buildWorkspaceMigration took ${buildMs.toFixed(1)}ms (status=${validateAndBuildResult.status})`,
     );
 
@@ -420,21 +419,19 @@ export class WorkspaceMigrationValidateBuildAndRunService {
         (actionCountsByTypeAndMetadataName[key] ?? 0) + 1;
     }
 
-    // oxlint-disable-next-line no-console
-    console.log(
+    this.logger.log(
       `[install-perf] validateBuildAndRunWorkspaceMigrationFromTo running ${workspaceMigration.actions.length} actions: ${JSON.stringify(actionCountsByTypeAndMetadataName)}`,
     );
 
-    const runStartNs = process.hrtime.bigint();
+    const runStart = performance.now();
     const { hasSchemaMetadataChanged, metadataEvents } =
       await this.workspaceMigrationRunnerService.run({
         workspaceId: args.workspaceId,
         workspaceMigration,
       });
-    const runMs = Number(process.hrtime.bigint() - runStartNs) / 1e6;
+    const runMs = performance.now() - runStart;
 
-    // oxlint-disable-next-line no-console
-    console.log(
+    this.logger.log(
       `[install-perf] workspaceMigrationRunnerService.run took ${runMs.toFixed(1)}ms for ${workspaceMigration.actions.length} actions`,
     );
 

--- a/packages/twenty-server/src/engine/workspace-manager/workspace-migration/services/workspace-migration-validate-build-and-run-service.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/workspace-migration/services/workspace-migration-validate-build-and-run-service.ts
@@ -369,6 +369,9 @@ export class WorkspaceMigrationValidateBuildAndRunService {
     const { idByUniversalIdentifierByMetadataName, dryRun, ...buildArgs } =
       args;
 
+    // TODO(install-perf): temporary timing for the app-install 504 — remove
+    // with the rest of the [install-perf] instrumentation.
+    const buildStartNs = process.hrtime.bigint();
     const validateAndBuildResult =
       await this.workspaceMigrationBuildOrchestratorService
         .buildWorkspaceMigration(buildArgs)
@@ -379,6 +382,12 @@ export class WorkspaceMigrationValidateBuildAndRunService {
             WorkspaceMigrationV2ExceptionCode.BUILDER_INTERNAL_SERVER_ERROR,
           );
         });
+    const buildMs = Number(process.hrtime.bigint() - buildStartNs) / 1e6;
+
+    // oxlint-disable-next-line no-console
+    console.log(
+      `[install-perf] buildWorkspaceMigration took ${buildMs.toFixed(1)}ms (status=${validateAndBuildResult.status})`,
+    );
 
     if (validateAndBuildResult.status === 'fail') {
       if (this.isDebugEnabled) {
@@ -402,11 +411,32 @@ export class WorkspaceMigrationValidateBuildAndRunService {
       };
     }
 
+    const actionCountsByTypeAndMetadataName: Record<string, number> = {};
+
+    for (const action of workspaceMigration.actions) {
+      const key = `${action.type}:${action.metadataName}`;
+
+      actionCountsByTypeAndMetadataName[key] =
+        (actionCountsByTypeAndMetadataName[key] ?? 0) + 1;
+    }
+
+    // oxlint-disable-next-line no-console
+    console.log(
+      `[install-perf] validateBuildAndRunWorkspaceMigrationFromTo running ${workspaceMigration.actions.length} actions: ${JSON.stringify(actionCountsByTypeAndMetadataName)}`,
+    );
+
+    const runStartNs = process.hrtime.bigint();
     const { hasSchemaMetadataChanged, metadataEvents } =
       await this.workspaceMigrationRunnerService.run({
         workspaceId: args.workspaceId,
         workspaceMigration,
       });
+    const runMs = Number(process.hrtime.bigint() - runStartNs) / 1e6;
+
+    // oxlint-disable-next-line no-console
+    console.log(
+      `[install-perf] workspaceMigrationRunnerService.run took ${runMs.toFixed(1)}ms for ${workspaceMigration.actions.length} actions`,
+    );
 
     this.metadataEventEmitter.emitMetadataEvents({
       metadataEvents: metadataEvents,

--- a/packages/twenty-server/src/engine/workspace-manager/workspace-migration/workspace-migration-runner/action-handlers/logic-function/services/update-logic-function-action-handler.service.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/workspace-migration/workspace-migration-runner/action-handlers/logic-function/services/update-logic-function-action-handler.service.ts
@@ -106,8 +106,7 @@ export class UpdateLogicFunctionActionHandlerService extends WorkspaceMigrationR
     });
 
     if (builtPathChanged) {
-      // TODO(install-perf): temporary timing for the app-install 504 — remove
-      // with the rest of the [install-perf] instrumentation.
+      // TODO(install-perf): temporary, remove.
       const deleteFileStart = performance.now();
 
       await this.fileStorageService.deleteFile({

--- a/packages/twenty-server/src/engine/workspace-manager/workspace-migration/workspace-migration-runner/action-handlers/logic-function/services/update-logic-function-action-handler.service.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/workspace-migration/workspace-migration-runner/action-handlers/logic-function/services/update-logic-function-action-handler.service.ts
@@ -106,12 +106,24 @@ export class UpdateLogicFunctionActionHandlerService extends WorkspaceMigrationR
     });
 
     if (builtPathChanged) {
+      // TODO(install-perf): temporary timing for the app-install 504 — remove
+      // with the rest of the [install-perf] instrumentation.
+      const deleteFileStartNs = process.hrtime.bigint();
+
       await this.fileStorageService.deleteFile({
         workspaceId,
         applicationUniversalIdentifier,
         fileFolder: FileFolder.BuiltLogicFunction,
         resourcePath: existingLogicFunction.builtHandlerPath,
       });
+
+      const deleteFileMs =
+        Number(process.hrtime.bigint() - deleteFileStartNs) / 1e6;
+
+      // oxlint-disable-next-line no-console
+      console.log(
+        `[install-perf] update logicFunction fileStorageService.deleteFile took ${deleteFileMs.toFixed(1)}ms (fnId=${entityId})`,
+      );
     }
   }
 

--- a/packages/twenty-server/src/engine/workspace-manager/workspace-migration/workspace-migration-runner/action-handlers/logic-function/services/update-logic-function-action-handler.service.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/workspace-migration/workspace-migration-runner/action-handlers/logic-function/services/update-logic-function-action-handler.service.ts
@@ -108,7 +108,7 @@ export class UpdateLogicFunctionActionHandlerService extends WorkspaceMigrationR
     if (builtPathChanged) {
       // TODO(install-perf): temporary timing for the app-install 504 — remove
       // with the rest of the [install-perf] instrumentation.
-      const deleteFileStartNs = process.hrtime.bigint();
+      const deleteFileStart = performance.now();
 
       await this.fileStorageService.deleteFile({
         workspaceId,
@@ -117,12 +117,11 @@ export class UpdateLogicFunctionActionHandlerService extends WorkspaceMigrationR
         resourcePath: existingLogicFunction.builtHandlerPath,
       });
 
-      const deleteFileMs =
-        Number(process.hrtime.bigint() - deleteFileStartNs) / 1e6;
+      const deleteFileMs = performance.now() - deleteFileStart;
 
-      // oxlint-disable-next-line no-console
-      console.log(
+      this.logger.log(
         `[install-perf] update logicFunction fileStorageService.deleteFile took ${deleteFileMs.toFixed(1)}ms (fnId=${entityId})`,
+        UpdateLogicFunctionActionHandlerService.name,
       );
     }
   }

--- a/packages/twenty-server/src/engine/workspace-manager/workspace-migration/workspace-migration-runner/services/workspace-migration-runner.service.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/workspace-migration/workspace-migration-runner/services/workspace-migration-runner.service.ts
@@ -170,9 +170,10 @@ export class WorkspaceMigrationRunnerService {
   // TODO(install-perf): temporary, remove. Snapshots blocking DB sessions on a fresh connection.
   private async logBlockingDbActivity(): Promise<void> {
     try {
+      // Metadata only (no query text) to avoid logging literals from other sessions.
       const rows = await this.coreDataSource.query(
         `SELECT pid, state, wait_event_type, wait_event,
-                now() - query_start AS running_for, left(query, 200) AS query
+                now() - query_start AS running_for, pg_blocking_pids(pid) AS blocked_by
          FROM pg_stat_activity
          WHERE datname = current_database()
            AND state <> 'idle'
@@ -282,9 +283,6 @@ export class WorkspaceMigrationRunnerService {
     await queryRunner.connect();
     await queryRunner.startTransaction();
 
-    // TODO(install-perf): temporary, remove. Fail fast on lock waits (< 10s query_timeout) for a clear error.
-    await queryRunner.query(`SET LOCAL lock_timeout = '8s'`);
-
     const allMetadataEvents: MetadataEvent[] = [];
 
     // TODO(install-perf): temporary, remove.
@@ -294,6 +292,9 @@ export class WorkspaceMigrationRunnerService {
     let actionCount = 0;
 
     try {
+      // TODO(install-perf): temporary, remove. Fail fast on lock waits (< 10s query_timeout) for a clear error.
+      await queryRunner.query(`SET LOCAL lock_timeout = '8s'`);
+
       for (const action of actions) {
         const actionStart = performance.now();
         const { partialOptimisticCache, metadataEvents } =

--- a/packages/twenty-server/src/engine/workspace-manager/workspace-migration/workspace-migration-runner/services/workspace-migration-runner.service.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/workspace-migration/workspace-migration-runner/services/workspace-migration-runner.service.ts
@@ -359,12 +359,14 @@ export class WorkspaceMigrationRunnerService {
       await this.logBlockingDbActivity();
 
       if (queryRunner.isTransactionActive && !queryRunner.isReleased) {
-        await queryRunner.rollbackTransaction().catch((rollbackError) =>
-          this.logger.error(
-            `[install-perf] rollback failed: ${rollbackError.message}`,
-            'Runner',
-          ),
-        );
+        await queryRunner
+          .rollbackTransaction()
+          .catch((rollbackError) =>
+            this.logger.error(
+              `[install-perf] rollback failed: ${rollbackError.message}`,
+              'Runner',
+            ),
+          );
       } else {
         this.logger.error(
           `[install-perf] skipping rollback (txnActive=${queryRunner.isTransactionActive} released=${queryRunner.isReleased})`,

--- a/packages/twenty-server/src/engine/workspace-manager/workspace-migration/workspace-migration-runner/services/workspace-migration-runner.service.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/workspace-migration/workspace-migration-runner/services/workspace-migration-runner.service.ts
@@ -167,10 +167,7 @@ export class WorkspaceMigrationRunnerService {
     );
   }
 
-  // TODO(install-perf): temporary — best-effort snapshot of concurrent DB
-  // sessions to identify what was blocking a slow/locked migration action.
-  // Runs on a fresh pooled connection (the migration's own connection may be
-  // dead). Remove with the rest of the app-install 504 instrumentation.
+  // TODO(install-perf): temporary, remove. Snapshots blocking DB sessions on a fresh connection.
   private async logBlockingDbActivity(): Promise<void> {
     try {
       const rows = await this.coreDataSource.query(
@@ -285,17 +282,12 @@ export class WorkspaceMigrationRunnerService {
     await queryRunner.connect();
     await queryRunner.startTransaction();
 
-    // TODO(install-perf): temporary instrumentation for the app-install 504.
-    // Fail fast (8s) on lock waits — below the 10s node-pg query_timeout — so a
-    // blocked migration action surfaces as a clear "canceling statement due to
-    // lock timeout" instead of the opaque connection kill + "Query runner
-    // already released". Remove with the rest of the [install-perf] logging.
+    // TODO(install-perf): temporary, remove. Fail fast on lock waits (< 10s query_timeout) for a clear error.
     await queryRunner.query(`SET LOCAL lock_timeout = '8s'`);
 
     const allMetadataEvents: MetadataEvent[] = [];
 
-    // TODO(install-perf): temporary per-action timing — remove with the rest of
-    // the [install-perf] install-504 instrumentation.
+    // TODO(install-perf): temporary, remove.
     const transactionStart = performance.now();
     let slowestActionMs = 0;
     let slowestActionLabel = 'n/a';
@@ -356,10 +348,7 @@ export class WorkspaceMigrationRunnerService {
 
       this.logger.timeEnd('Runner', 'Transaction execution');
     } catch (error) {
-      // TODO(install-perf): temporary instrumentation for the app-install 504.
-      // Log the real failure + a snapshot of blocking DB activity, and guard the
-      // rollback so a released/dead connection doesn't mask the cause with
-      // "Query runner already released". Remove once the bottleneck is fixed.
+      // TODO(install-perf): temporary, remove. Logs the real cause + blockers and guards the rollback.
       this.logger.error(
         `[install-perf] migration failed after ${actionCount} action(s): ${
           error instanceof Error ? error.message : String(error)

--- a/packages/twenty-server/src/engine/workspace-manager/workspace-migration/workspace-migration-runner/services/workspace-migration-runner.service.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/workspace-migration/workspace-migration-runner/services/workspace-migration-runner.service.ts
@@ -183,18 +183,18 @@ export class WorkspaceMigrationRunnerService {
          ORDER BY query_start ASC`,
       );
 
-      // oxlint-disable-next-line no-console
-      console.error(
+      this.logger.error(
         `[install-perf] active DB sessions at failure: ${JSON.stringify(rows)}`,
+        'Runner',
       );
     } catch (snapshotError) {
-      // oxlint-disable-next-line no-console
-      console.error(
+      this.logger.error(
         `[install-perf] could not snapshot pg_stat_activity: ${
           snapshotError instanceof Error
             ? snapshotError.message
             : String(snapshotError)
         }`,
+        'Runner',
       );
     }
   }
@@ -221,7 +221,7 @@ export class WorkspaceMigrationRunnerService {
     this.logger.time('Runner', 'Total execution');
     this.logger.time('Runner', 'Initial cache retrieval');
 
-    const initialCacheRetrievalStartNs = process.hrtime.bigint();
+    const initialCacheRetrievalStart = performance.now();
 
     const queryRunner = this.coreDataSource.createQueryRunner();
 
@@ -253,11 +253,11 @@ export class WorkspaceMigrationRunnerService {
     this.logger.timeEnd('Runner', 'Initial cache retrieval');
 
     const initialCacheRetrievalMs =
-      Number(process.hrtime.bigint() - initialCacheRetrievalStartNs) / 1e6;
+      performance.now() - initialCacheRetrievalStart;
 
-    // oxlint-disable-next-line no-console
-    console.log(
+    this.logger.log(
       `[install-perf] Runner initial cache retrieval (getOrRecomputeManyOrAllFlatEntityMaps) took ${initialCacheRetrievalMs.toFixed(1)}ms for ${allFlatEntityMapsKeys.length} flat-maps keys`,
+      'Runner',
     );
 
     const { flatApplicationMaps } =
@@ -296,14 +296,14 @@ export class WorkspaceMigrationRunnerService {
 
     // TODO(install-perf): temporary per-action timing — remove with the rest of
     // the [install-perf] install-504 instrumentation.
-    const transactionStartNs = process.hrtime.bigint();
+    const transactionStart = performance.now();
     let slowestActionMs = 0;
     let slowestActionLabel = 'n/a';
     let actionCount = 0;
 
     try {
       for (const action of actions) {
-        const actionStartNs = process.hrtime.bigint();
+        const actionStart = performance.now();
         const { partialOptimisticCache, metadataEvents } =
           await this.workspaceMigrationRunnerActionHandlerRegistry.executeActionHandler(
             {
@@ -318,7 +318,7 @@ export class WorkspaceMigrationRunnerService {
             },
           );
 
-        const actionMs = Number(process.hrtime.bigint() - actionStartNs) / 1e6;
+        const actionMs = performance.now() - actionStart;
 
         actionCount += 1;
 
@@ -328,9 +328,9 @@ export class WorkspaceMigrationRunnerService {
         }
 
         if (actionMs > 50) {
-          // oxlint-disable-next-line no-console
-          console.log(
+          this.logger.log(
             `[install-perf] slow action ${action.type}:${action.metadataName} took ${actionMs.toFixed(1)}ms`,
+            'Runner',
           );
         }
 
@@ -342,17 +342,16 @@ export class WorkspaceMigrationRunnerService {
         allMetadataEvents.push(...metadataEvents);
       }
 
-      const commitStartNs = process.hrtime.bigint();
+      const commitStart = performance.now();
 
       await queryRunner.commitTransaction();
 
-      const commitMs = Number(process.hrtime.bigint() - commitStartNs) / 1e6;
-      const transactionMs =
-        Number(process.hrtime.bigint() - transactionStartNs) / 1e6;
+      const commitMs = performance.now() - commitStart;
+      const transactionMs = performance.now() - transactionStart;
 
-      // oxlint-disable-next-line no-console
-      console.log(
+      this.logger.log(
         `[install-perf] Runner transaction summary: ${actionCount} actions, total transaction ${transactionMs.toFixed(1)}ms (commit ${commitMs.toFixed(1)}ms), slowest action ${slowestActionLabel} ${slowestActionMs.toFixed(1)}ms`,
+        'Runner',
       );
 
       this.logger.timeEnd('Runner', 'Transaction execution');
@@ -361,25 +360,25 @@ export class WorkspaceMigrationRunnerService {
       // Log the real failure + a snapshot of blocking DB activity, and guard the
       // rollback so a released/dead connection doesn't mask the cause with
       // "Query runner already released". Remove once the bottleneck is fixed.
-      // oxlint-disable-next-line no-console
-      console.error(
+      this.logger.error(
         `[install-perf] migration failed after ${actionCount} action(s): ${
           error instanceof Error ? error.message : String(error)
         }`,
+        'Runner',
       );
       await this.logBlockingDbActivity();
 
       if (queryRunner.isTransactionActive && !queryRunner.isReleased) {
         await queryRunner.rollbackTransaction().catch((rollbackError) =>
-          // oxlint-disable-next-line no-console
-          console.error(
+          this.logger.error(
             `[install-perf] rollback failed: ${rollbackError.message}`,
+            'Runner',
           ),
         );
       } else {
-        // oxlint-disable-next-line no-console
-        console.error(
+        this.logger.error(
           `[install-perf] skipping rollback (txnActive=${queryRunner.isTransactionActive} released=${queryRunner.isReleased})`,
+          'Runner',
         );
       }
 
@@ -423,7 +422,7 @@ export class WorkspaceMigrationRunnerService {
       await queryRunner.release();
     }
 
-    const postCommitInvalidateStartNs = process.hrtime.bigint();
+    const postCommitInvalidateStart = performance.now();
 
     try {
       await this.invalidateCache({
@@ -438,11 +437,11 @@ export class WorkspaceMigrationRunnerService {
     }
 
     const postCommitInvalidateMs =
-      Number(process.hrtime.bigint() - postCommitInvalidateStartNs) / 1e6;
+      performance.now() - postCommitInvalidateStart;
 
-    // oxlint-disable-next-line no-console
-    console.log(
+    this.logger.log(
       `[install-perf] Runner post-commit invalidateCache took ${postCommitInvalidateMs.toFixed(1)}ms for ${allFlatEntityMapsKeys.length} flat-maps keys`,
+      'Runner',
     );
 
     const hasSchemaMetadataChanged =

--- a/packages/twenty-server/src/engine/workspace-manager/workspace-migration/workspace-migration-runner/services/workspace-migration-runner.service.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/workspace-migration/workspace-migration-runner/services/workspace-migration-runner.service.ts
@@ -167,6 +167,38 @@ export class WorkspaceMigrationRunnerService {
     );
   }
 
+  // TODO(install-perf): temporary — best-effort snapshot of concurrent DB
+  // sessions to identify what was blocking a slow/locked migration action.
+  // Runs on a fresh pooled connection (the migration's own connection may be
+  // dead). Remove with the rest of the app-install 504 instrumentation.
+  private async logBlockingDbActivity(): Promise<void> {
+    try {
+      const rows = await this.coreDataSource.query(
+        `SELECT pid, state, wait_event_type, wait_event,
+                now() - query_start AS running_for, left(query, 200) AS query
+         FROM pg_stat_activity
+         WHERE datname = current_database()
+           AND state <> 'idle'
+           AND pid <> pg_backend_pid()
+         ORDER BY query_start ASC`,
+      );
+
+      // oxlint-disable-next-line no-console
+      console.error(
+        `[install-perf] active DB sessions at failure: ${JSON.stringify(rows)}`,
+      );
+    } catch (snapshotError) {
+      // oxlint-disable-next-line no-console
+      console.error(
+        `[install-perf] could not snapshot pg_stat_activity: ${
+          snapshotError instanceof Error
+            ? snapshotError.message
+            : String(snapshotError)
+        }`,
+      );
+    }
+  }
+
   run = async ({
     workspaceMigration: { actions, applicationUniversalIdentifier },
     workspaceId,
@@ -188,6 +220,8 @@ export class WorkspaceMigrationRunnerService {
 
     this.logger.time('Runner', 'Total execution');
     this.logger.time('Runner', 'Initial cache retrieval');
+
+    const initialCacheRetrievalStartNs = process.hrtime.bigint();
 
     const queryRunner = this.coreDataSource.createQueryRunner();
 
@@ -218,6 +252,14 @@ export class WorkspaceMigrationRunnerService {
 
     this.logger.timeEnd('Runner', 'Initial cache retrieval');
 
+    const initialCacheRetrievalMs =
+      Number(process.hrtime.bigint() - initialCacheRetrievalStartNs) / 1e6;
+
+    // oxlint-disable-next-line no-console
+    console.log(
+      `[install-perf] Runner initial cache retrieval (getOrRecomputeManyOrAllFlatEntityMaps) took ${initialCacheRetrievalMs.toFixed(1)}ms for ${allFlatEntityMapsKeys.length} flat-maps keys`,
+    );
+
     const { flatApplicationMaps } =
       await this.workspaceCacheService.getOrRecompute(workspaceId, [
         'flatApplicationMaps',
@@ -243,10 +285,25 @@ export class WorkspaceMigrationRunnerService {
     await queryRunner.connect();
     await queryRunner.startTransaction();
 
+    // TODO(install-perf): temporary instrumentation for the app-install 504.
+    // Fail fast (8s) on lock waits — below the 10s node-pg query_timeout — so a
+    // blocked migration action surfaces as a clear "canceling statement due to
+    // lock timeout" instead of the opaque connection kill + "Query runner
+    // already released". Remove with the rest of the [install-perf] logging.
+    await queryRunner.query(`SET LOCAL lock_timeout = '8s'`);
+
     const allMetadataEvents: MetadataEvent[] = [];
+
+    // TODO(install-perf): temporary per-action timing — remove with the rest of
+    // the [install-perf] install-504 instrumentation.
+    const transactionStartNs = process.hrtime.bigint();
+    let slowestActionMs = 0;
+    let slowestActionLabel = 'n/a';
+    let actionCount = 0;
 
     try {
       for (const action of actions) {
+        const actionStartNs = process.hrtime.bigint();
         const { partialOptimisticCache, metadataEvents } =
           await this.workspaceMigrationRunnerActionHandlerRegistry.executeActionHandler(
             {
@@ -261,6 +318,22 @@ export class WorkspaceMigrationRunnerService {
             },
           );
 
+        const actionMs = Number(process.hrtime.bigint() - actionStartNs) / 1e6;
+
+        actionCount += 1;
+
+        if (actionMs > slowestActionMs) {
+          slowestActionMs = actionMs;
+          slowestActionLabel = `${action.type}:${action.metadataName}`;
+        }
+
+        if (actionMs > 50) {
+          // oxlint-disable-next-line no-console
+          console.log(
+            `[install-perf] slow action ${action.type}:${action.metadataName} took ${actionMs.toFixed(1)}ms`,
+          );
+        }
+
         allFlatEntityMaps = {
           ...allFlatEntityMaps,
           ...partialOptimisticCache,
@@ -269,16 +342,46 @@ export class WorkspaceMigrationRunnerService {
         allMetadataEvents.push(...metadataEvents);
       }
 
+      const commitStartNs = process.hrtime.bigint();
+
       await queryRunner.commitTransaction();
+
+      const commitMs = Number(process.hrtime.bigint() - commitStartNs) / 1e6;
+      const transactionMs =
+        Number(process.hrtime.bigint() - transactionStartNs) / 1e6;
+
+      // oxlint-disable-next-line no-console
+      console.log(
+        `[install-perf] Runner transaction summary: ${actionCount} actions, total transaction ${transactionMs.toFixed(1)}ms (commit ${commitMs.toFixed(1)}ms), slowest action ${slowestActionLabel} ${slowestActionMs.toFixed(1)}ms`,
+      );
 
       this.logger.timeEnd('Runner', 'Transaction execution');
     } catch (error) {
-      await queryRunner.rollbackTransaction().catch((rollbackError) =>
-        // oxlint-disable-next-line no-console
-        console.trace(
-          `Failed to rollback transaction: ${rollbackError.message}`,
-        ),
+      // TODO(install-perf): temporary instrumentation for the app-install 504.
+      // Log the real failure + a snapshot of blocking DB activity, and guard the
+      // rollback so a released/dead connection doesn't mask the cause with
+      // "Query runner already released". Remove once the bottleneck is fixed.
+      // oxlint-disable-next-line no-console
+      console.error(
+        `[install-perf] migration failed after ${actionCount} action(s): ${
+          error instanceof Error ? error.message : String(error)
+        }`,
       );
+      await this.logBlockingDbActivity();
+
+      if (queryRunner.isTransactionActive && !queryRunner.isReleased) {
+        await queryRunner.rollbackTransaction().catch((rollbackError) =>
+          // oxlint-disable-next-line no-console
+          console.error(
+            `[install-perf] rollback failed: ${rollbackError.message}`,
+          ),
+        );
+      } else {
+        // oxlint-disable-next-line no-console
+        console.error(
+          `[install-perf] skipping rollback (txnActive=${queryRunner.isTransactionActive} released=${queryRunner.isReleased})`,
+        );
+      }
 
       const invertedActions = [...actions].reverse();
 
@@ -320,6 +423,8 @@ export class WorkspaceMigrationRunnerService {
       await queryRunner.release();
     }
 
+    const postCommitInvalidateStartNs = process.hrtime.bigint();
+
     try {
       await this.invalidateCache({
         allFlatEntityMapsKeys,
@@ -331,6 +436,14 @@ export class WorkspaceMigrationRunnerService {
         'Runner',
       );
     }
+
+    const postCommitInvalidateMs =
+      Number(process.hrtime.bigint() - postCommitInvalidateStartNs) / 1e6;
+
+    // oxlint-disable-next-line no-console
+    console.log(
+      `[install-perf] Runner post-commit invalidateCache took ${postCommitInvalidateMs.toFixed(1)}ms for ${allFlatEntityMapsKeys.length} flat-maps keys`,
+    );
 
     const hasSchemaMetadataChanged =
       allFlatEntityMapsKeys.includes('flatObjectMetadataMaps') ||

--- a/packages/twenty-server/test/integration/metadata/suites/application/logic-function-install-performance.integration-spec.ts
+++ b/packages/twenty-server/test/integration/metadata/suites/application/logic-function-install-performance.integration-spec.ts
@@ -1,0 +1,156 @@
+import { buildBaseManifest } from 'test/integration/metadata/suites/application/utils/build-base-manifest.util';
+import { cleanupApplicationAndAppRegistration } from 'test/integration/metadata/suites/application/utils/cleanup-application-and-app-registration.util';
+import { setupApplicationForSync } from 'test/integration/metadata/suites/application/utils/setup-application-for-sync.util';
+import { syncApplication } from 'test/integration/metadata/suites/application/utils/sync-application.util';
+import {
+  type LogicFunctionManifest,
+  type Manifest,
+} from 'twenty-shared/application';
+import { v4 as uuidv4 } from 'uuid';
+
+/**
+ * Performance harness for installing / updating many logic functions through
+ * application manifest sync. The goal is to find what could take >10s in prod
+ * (which trips the node-postgres `query_timeout` in core.datasource.ts and
+ * produces "Migration action 'update' for 'logicFunction' failed" + 504).
+ *
+ * IMPORTANT: the integration harness boots the NestJS app in-process with
+ * `fakeTimers.enableGlobally: true`, so `Date.now()` / `setTimeout` are FAKE in
+ * the server code. All server-side timing instrumentation uses
+ * `process.hrtime.bigint()` (NOT faked). Here in the test we call
+ * `jest.useRealTimers()` so cache-lock retry delays etc. do not hang.
+ */
+
+// Real timers for the whole suite — see note above.
+jest.useRealTimers();
+
+jest.setTimeout(120000);
+
+const FN_COUNTS = [1, 8, 30];
+
+// Stable universalIdentifiers across versions so the second sync exercises
+// UPDATE (the actual incident), not CREATE+DELETE.
+const buildManifest = ({
+  appId,
+  roleId,
+  universalIdentifiers,
+  checksumVersion,
+}: {
+  appId: string;
+  roleId: string;
+  universalIdentifiers: string[];
+  checksumVersion: 'v1' | 'v2';
+}): Manifest => {
+  const logicFunctions: LogicFunctionManifest[] = universalIdentifiers.map(
+    (universalIdentifier, i) => ({
+      universalIdentifier,
+      name: `PerfFn${i}`,
+      description: `Perf logic function ${i}`,
+      handlerName: 'handler',
+      sourceHandlerPath: `src/fn-${i}.ts`,
+      builtHandlerPath: `dist/fn-${i}.mjs`,
+      builtHandlerChecksum: `checksum-${i}-${checksumVersion}`,
+      httpRouteTriggerSettings: {
+        path: `/fn-${i}`,
+        httpMethod: 'GET',
+        isAuthRequired: true,
+      },
+    }),
+  );
+
+  return buildBaseManifest({
+    appId,
+    roleId,
+    overrides: { logicFunctions },
+  });
+};
+
+const timeSync = async (
+  label: string,
+  manifest: Manifest,
+): Promise<number> => {
+  const startNs = process.hrtime.bigint();
+
+  await syncApplication({ manifest, expectToFail: false });
+
+  const ms = Number(process.hrtime.bigint() - startNs) / 1e6;
+
+  // oxlint-disable-next-line no-console
+  console.log(`[install-perf][test] ${label} took ${ms.toFixed(1)}ms`);
+
+  return ms;
+};
+
+// TODO(install-perf): manual perf harness for the app-install 504 investigation.
+// Skipped in CI (it runs many syncs and only logs timings, no assertions). Run
+// locally with: npx nx test:integration:with-db-reset -- --testPathPattern
+// "logic-function-install-performance". Remove with the rest of the
+// [install-perf] instrumentation.
+describe.skip('Logic function install performance', () => {
+  it.each(FN_COUNTS)(
+    'create + update sync with %i logic functions',
+    async (count) => {
+      const appId = uuidv4();
+      const roleId = uuidv4();
+      const universalIdentifiers = Array.from({ length: count }, () =>
+        uuidv4(),
+      );
+
+      await setupApplicationForSync({
+        applicationUniversalIdentifier: appId,
+        name: `Perf App ${count}`,
+        description: `Perf app with ${count} logic functions`,
+        sourcePath: `perf-app-${count}`,
+      });
+
+      jest.useRealTimers();
+
+      try {
+        // No built-handler file upload is needed: the migration create/update
+        // handlers never read the built file for LIVE functions (prebuilt
+        // install is skipped), and uploading N files would trip the file-upload
+        // rate limiter (30 per 30s). We only measure migration + cache cost.
+
+        // oxlint-disable-next-line no-console
+        console.log(
+          `[install-perf][test] ===== N=${count} : FIRST SYNC (create ${count} functions) =====`,
+        );
+
+        const createMs = await timeSync(
+          `N=${count} create sync`,
+          buildManifest({
+            appId,
+            roleId,
+            universalIdentifiers,
+            checksumVersion: 'v1',
+          }),
+        );
+
+        // oxlint-disable-next-line no-console
+        console.log(
+          `[install-perf][test] ===== N=${count} : SECOND SYNC (update ${count} functions, checksum v2) =====`,
+        );
+
+        const updateMs = await timeSync(
+          `N=${count} update sync`,
+          buildManifest({
+            appId,
+            roleId,
+            universalIdentifiers,
+            checksumVersion: 'v2',
+          }),
+        );
+
+        // oxlint-disable-next-line no-console
+        console.log(
+          `[install-perf][test] ===== N=${count} SUMMARY: create=${createMs.toFixed(1)}ms update=${updateMs.toFixed(1)}ms =====`,
+        );
+      } finally {
+        await cleanupApplicationAndAppRegistration({
+          applicationUniversalIdentifier: appId,
+        });
+      }
+    },
+    120000,
+  );
+});

--- a/packages/twenty-server/test/integration/metadata/suites/application/logic-function-install-performance.integration-spec.ts
+++ b/packages/twenty-server/test/integration/metadata/suites/application/logic-function-install-performance.integration-spec.ts
@@ -80,11 +80,7 @@ const timeSync = async (
   return ms;
 };
 
-// TODO(install-perf): manual perf harness for the app-install 504 investigation.
-// Skipped in CI (it runs many syncs and only logs timings, no assertions). Run
-// locally with: npx nx test:integration:with-db-reset -- --testPathPattern
-// "logic-function-install-performance". Remove with the rest of the
-// [install-perf] instrumentation.
+// TODO(install-perf): temporary manual perf harness, remove. Skipped in CI.
 describe.skip('Logic function install performance', () => {
   it.each(FN_COUNTS)(
     'create + update sync with %i logic functions',

--- a/packages/twenty-server/test/integration/metadata/suites/application/logic-function-install-performance.integration-spec.ts
+++ b/packages/twenty-server/test/integration/metadata/suites/application/logic-function-install-performance.integration-spec.ts
@@ -15,10 +15,9 @@ import { v4 as uuidv4 } from 'uuid';
  * produces "Migration action 'update' for 'logicFunction' failed" + 504).
  *
  * IMPORTANT: the integration harness boots the NestJS app in-process with
- * `fakeTimers.enableGlobally: true`, so `Date.now()` / `setTimeout` are FAKE in
- * the server code. All server-side timing instrumentation uses
- * `process.hrtime.bigint()` (NOT faked). Here in the test we call
- * `jest.useRealTimers()` so cache-lock retry delays etc. do not hang.
+ * `fakeTimers.enableGlobally: true`. We call `jest.useRealTimers()` for the whole
+ * suite so timing (`performance.now()`) is real and cache-lock retry delays etc.
+ * do not hang.
  */
 
 // Real timers for the whole suite — see note above.
@@ -69,11 +68,11 @@ const timeSync = async (
   label: string,
   manifest: Manifest,
 ): Promise<number> => {
-  const startNs = process.hrtime.bigint();
+  const start = performance.now();
 
   await syncApplication({ manifest, expectToFail: false });
 
-  const ms = Number(process.hrtime.bigint() - startNs) / 1e6;
+  const ms = performance.now() - start;
 
   // oxlint-disable-next-line no-console
   console.log(`[install-perf][test] ${label} took ${ms.toFixed(1)}ms`);


### PR DESCRIPTION
## Why

App installs on cloud intermittently fail with a 504, surfacing in Sentry as `Migration action 'update' for 'logicFunction' failed` + `Failed to rollback transaction: Query runner already released`. This is **temporary instrumentation** to pin down where the time goes — to be reverted once the bottleneck is fixed. Everything is greppable via `[install-perf]` and marked `// TODO(install-perf)`.

## What the local repro already told us

I instrumented the manifest-sync/migration path and ran a local harness (new skipped spec) installing **1 / 8 / 30 logic functions**, for both create and the checksum-bump **update** (the incident path):

| stage (N=30, update) | ms |
|---|---|
| flat-maps recompute | ~1 |
| build migration | ~11 |
| transaction (all actions + commit) | ~79 |
| post-commit cache invalidate | ~6 |
| **full sync** | **~135** |

Nothing approached 1s, let alone 10s; no slow queries logged. So the migration/cache code is **not** the algorithmic cause. Given the in-transaction `UPDATE ... WHERE id=?` is intrinsically fast, a >10s in prod almost certainly means it was **blocked on a lock**, and the 10s node-pg `query_timeout` (`core.datasource.ts`) then killed the connection → the observed errors + 504. Local can't reproduce prod lock contention / table sizes, hence this instrumentation.

## What this adds (all `TODO`-marked)

- **hrtime per-stage timing** — flat-maps recompute, build vs run, per-action (`>50ms`), transaction summary, post-commit cache invalidation. Uses `process.hrtime` because the integration harness enables fake timers (so `Date.now()` is useless there).
- **`maxQueryExecutionTime`** slow-query logging on the core datasource (logs the offending SQL).
- **Scoped `SET LOCAL lock_timeout = '8s'`** on the migration transaction (below the 10s `query_timeout`) → a blocked action fails fast with a clear *"canceling statement due to lock timeout"* instead of the opaque connection kill.
- **Best-effort `pg_stat_activity` snapshot on failure** (on a fresh pooled connection) to identify the blocking session, plus a **guarded rollback** so a released connection stops masking the real error.
- **Skipped local perf harness** (`logic-function-install-performance.integration-spec.ts`) — run manually with `nx test:integration:with-db-reset -- --testPathPattern "logic-function-install-performance"`.

## How we'll use it

Deploy, reproduce the failing install, and read the `[install-perf]` logs: the per-action timing names the action, the `lock_timeout` message + `pg_stat_activity` snapshot name the **blocking** query/PID. Then revert this PR and fix the actual contention.

Typecheck (`nx typecheck twenty-server`) is clean.