### PR TITLE
fix(twenty-front): restore top-bar-title testid to unbreak merge queue

### DIFF
--- a/packages/twenty-front/src/modules/object-record/record-show/components/ObjectRecordShowPageBreadcrumb.tsx
+++ b/packages/twenty-front/src/modules/object-record/record-show/components/ObjectRecordShowPageBreadcrumb.tsx
@@ -93,7 +93,7 @@ export const ObjectRecordShowPageBreadcrumb = ({
   }
 
   return (
-    <StyledEditableTitleContainer>
+    <StyledEditableTitleContainer data-testid="top-bar-title">
       <StyledEditableTitlePrefix
         onClick={() => {
           navigateToIndexView();


### PR DESCRIPTION
## Problem

The merge queue is broken. Every queued PR (#21357, #21361, #21364, #21366, …) fails on the same E2E assertion in `workflow-creation.spec.ts:36`:

```
Locator: getByTestId('top-bar-title').getByPlaceholder('Name')
Error: element(s) not found
```

All other E2E tests pass, which pointed to a regression already on `main` rather than any individual PR.

## Root cause

#21308 ("generalize the page primary/secondary bars (flat redesign)") switched `RecordShowPageHeader` from `PageHeader` to the new `PageCardHeader`.

- The old `PageHeader` wrapped its title in `<StyledTitleContainer data-testid="top-bar-title">`.
- The new `PageCardHeader` renders the breadcrumb slot **without** that `data-testid`.

The editable record title cell (the `Name` input the test fills in) still renders fine inside `ObjectRecordShowPageBreadcrumb` — it just lost the `top-bar-title` wrapper that the E2E suite locates it by. The testid is also used by the `blank-workflow` fixture.

## Fix

Restore `data-testid="top-bar-title"` on the record-show breadcrumb container, which wraps exactly what `PageHeader` previously did (the editable `Name` input and, after save, the record name text). Minimal and behavior-preserving; record-index and standalone pages use different header slots and were unaffected (their E2E tests passed throughout).