### PR TITLE
security: bump path-to-regexp and defu to patched versions (lockfile refresh)

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -32956,9 +32956,9 @@ __metadata:
   linkType: hard
 
 "defu@npm:^6.1.4":
-  version: 6.1.4
-  resolution: "defu@npm:6.1.4"
-  checksum: 10c0/2d6cc366262dc0cb8096e429368e44052fdf43ed48e53ad84cc7c9407f890301aa5fcb80d0995abaaf842b3949f154d060be4160f7a46cb2bc2f7726c81526f5
+  version: 6.1.7
+  resolution: "defu@npm:6.1.7"
+  checksum: 10c0/e6635388103c8be3c574ac31302f6930e5e6eeedba32cb1b30cf993c7d9fb571aec2485446dfa23bfa63e55e66156fe109027a9695db82a50f931e91e8d4bedb
   languageName: node
   linkType: hard
 
@@ -47963,24 +47963,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"path-to-regexp@npm:8.4.2, path-to-regexp@npm:^8.4.0":
+"path-to-regexp@npm:8.4.2, path-to-regexp@npm:^8.0.0, path-to-regexp@npm:^8.4.0":
   version: 8.4.2
   resolution: "path-to-regexp@npm:8.4.2"
   checksum: 10c0/05b115c49b47ad252ce05faa32930f643f23769c68b8bcfe78ad833545140c48bbffb3266986d6c8d5db13a64cf12e07e0d72d9882cab830efeefa553533ebaf
   languageName: node
   linkType: hard
 
-"path-to-regexp@npm:^8.0.0":
-  version: 8.3.0
-  resolution: "path-to-regexp@npm:8.3.0"
-  checksum: 10c0/ee1544a73a3f294a97a4c663b0ce71bbf1621d732d80c9c9ed201b3e911a86cb628ebad691b9d40f40a3742fe22011e5a059d8eed2cf63ec2cb94f6fb4efe67c
-  languageName: node
-  linkType: hard
-
 "path-to-regexp@npm:~0.1.12":
-  version: 0.1.12
-  resolution: "path-to-regexp@npm:0.1.12"
-  checksum: 10c0/1c6ff10ca169b773f3bba943bbc6a07182e332464704572962d277b900aeee81ac6aa5d060ff9e01149636c30b1f63af6e69dd7786ba6e0ddb39d4dee1f0645b
+  version: 0.1.13
+  resolution: "path-to-regexp@npm:0.1.13"
+  checksum: 10c0/1cae3921739c154a8926e136185a10c916f79a249b9072a5001b266d96e193860ca03867e8e8cc808b786862d750f427ed93686bc259355442c3407a62deab1a
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## What

Clears two **High** Dependabot alerts (https://github.com/twentyhq/twenty/security/dependabot) from the root tree **without resolutions/overrides** — by refreshing the lockfile so the existing semver ranges pick up the already-patched releases.

| Package | From → To | Requested by | Advisory |
|---|---|---|---|
| path-to-regexp | 8.3.0 → 8.4.2 | `router` (`^8.0.0`) | GHSA-j3q9-mxjg-w52f |
| defu | 6.1.4 → 6.1.7 | `radix-vue` (`^6.1.4`) | GHSA-737v-mqg7-c878 |

Only `yarn.lock` changes — no `package.json` edits, no `resolutions`.

## Why only these two

I traced every vulnerable transitive back to its parent. Only `defu` and `path-to-regexp` were stuck purely on a stale lockfile (their parents' ranges already allow the patched version). The remaining root High alerts can **not** be fixed by a parent update:

- **next** — latest `@react-email/preview-server` (5.2.10) still ships `next@16.1.7`, itself vulnerable
- **immutable** — `@ardatan/relay-compiler@12.0.0` is terminal and pins `~3.7.6`
- **minimatch / lodash / ws** — exact-pinned deep in dev tooling (api-extractor, spectral, NestJS, graphql-tools) with no fixed upstream release

Those will be handled separately.

## Verification

- `nx typecheck` passes for twenty-server and twenty-front