### PR TITLE
fix(server): repair server typecheck broken by isCustom deprecation

### DIFF
--- a/packages/twenty-server/src/engine/api/graphql/graphql-query-runner/graphql-query-parsers/graphql-query-order/__tests__/graphql-query-order-group-by.parser.spec.ts
+++ b/packages/twenty-server/src/engine/api/graphql/graphql-query-runner/graphql-query-parsers/graphql-query-order/__tests__/graphql-query-order-group-by.parser.spec.ts
@@ -15,11 +15,11 @@ import { getFlatFieldMetadataMock } from 'src/engine/metadata-modules/flat-field
 import { type FlatFieldMetadata } from 'src/engine/metadata-modules/flat-field-metadata/types/flat-field-metadata.type';
 import { getFlatObjectMetadataMock } from 'src/engine/metadata-modules/flat-object-metadata/__mocks__/get-flat-object-metadata.mock';
 import { type FlatObjectMetadata } from 'src/engine/metadata-modules/flat-object-metadata/types/flat-object-metadata.type';
-import { computeTableName } from 'src/engine/utils/compute-table-name.util';
+import { computeObjectTargetTable } from 'src/engine/utils/compute-object-target-table.util';
 
 // The query builder aliases the FROM table with `getObjectAlias` (= nameSingular),
 // NOT the physical table name (which is `_`-prefixed for custom objects via
-// `computeTableName`). These tests pin order-by clauses to that alias so the
+// `computeObjectTargetTable`). These tests pin order-by clauses to that alias so the
 // parser stays in sync if the alias convention ever changes.
 describe('GraphqlQueryOrderGroupByParser - object alias in order-by clauses', () => {
   const OBJECT_ID = 'rocket-object-id';
@@ -78,10 +78,7 @@ describe('GraphqlQueryOrderGroupByParser - object alias in order-by clauses', ()
   } as unknown as FlatEntityMaps<FlatObjectMetadata>;
 
   const objectAlias = getObjectAlias(flatObjectMetadata);
-  const physicalTableName = computeTableName(
-    flatObjectMetadata.nameSingular,
-    flatObjectMetadata.isCustom,
-  );
+  const physicalTableName = computeObjectTargetTable(flatObjectMetadata);
 
   const buildParser = () =>
     new GraphqlQueryOrderGroupByParser(


### PR DESCRIPTION
## What

Repairs `server-lint-typecheck`, which is **currently red on `main`**.

After #21228 retyped `FlatObjectMetadata.isCustom` as `WasRemovedInUpgrade<boolean> | undefined`, the spec added in #21311 still passed `flatObjectMetadata.isCustom` to `computeTableName(nameSingular, isCustom: boolean)`:

```
graphql-query-order-group-by.parser.spec.ts(83,5): error TS2345:
Argument of type 'WasRemovedInUpgrade<boolean> | undefined' is not assignable to parameter of type 'boolean'.
```

Both PRs merged via stale bases, and `server-lint-typecheck` only runs on PRs (not `main` pushes), so the regression landed undetected — the next PR to touch anything server-wide surfaces it.

## Fix

Compute the expected physical table name with **`computeObjectTargetTable`** — the production helper that derives custom-ness from the application (`applicationUniversalIdentifier !== TWENTY_STANDARD_APPLICATION`), which is exactly the pattern the `isCustom` deprecation steers callers toward. This stops reading the deprecated field and won't break again when it's removed.

One-line change in a single test file; behaviour is unchanged (custom object → `_`-prefixed physical table).

## Verification

- `nx typecheck twenty-server` ✅ (was failing on `main`, now passes)
- The spec runs green (3/3)
- `nx lint:diff-with-main twenty-server` ✅ (lint + format)