### PR TITLE
[Website] Re-introduce footer language switcher

### DIFF
--- a/packages/twenty-website/src/sections/Footer/components/Bottom.tsx
+++ b/packages/twenty-website/src/sections/Footer/components/Bottom.tsx
@@ -2,6 +2,7 @@ import { ArrowRightUpIcon, SOCIAL_ICONS } from '@/icons';
 import { getServerI18n } from '@/lib/i18n/server';
 import type { MessageDescriptor } from '@lingui/core';
 import type { FooterSocialLinkType } from '@/sections/Footer/types';
+import { LocaleSwitcher } from '@/sections/Footer/components/LocaleSwitcher';
 import { theme } from '@/theme';
 import { Separator } from '@base-ui/react/separator';
 import { styled } from '@linaria/react';
@@ -94,6 +95,7 @@ export function Bottom({ copyright, links }: BottomProps) {
     <BottomGrid>
       <CopyrightRow>
         <Copyright>{i18n._(copyright)}</Copyright>
+        <LocaleSwitcher />
       </CopyrightRow>
       <SocialNav aria-label="Social media">
         {links.map((link, index) => {


### PR DESCRIPTION
Reintroduce locale-switcher in the footer.

<img width="1369" height="514" alt="image" src="https://github.com/user-attachments/assets/b9e4f48a-dd47-4bd1-96f2-fe146b8c8bbe" />
