### PR TITLE
Improve log visibility in dev mode

### DIFF
--- a/packages/twenty-sdk/src/cli/utilities/dev/orchestrator/dev-mode-orchestrator-state.ts
+++ b/packages/twenty-sdk/src/cli/utilities/dev/orchestrator/dev-mode-orchestrator-state.ts
@@ -11,6 +11,7 @@ import { type FileFolder } from 'twenty-shared/types';
 export type OrchestratorStateStepEvent = {
   message: string;
   status: 'info' | 'success' | 'error' | 'warning';
+  spacingBefore?: boolean;
 };
 
 export type OrchestratorStateEvent = OrchestratorStateStepEvent & {

--- a/packages/twenty-sdk/src/cli/utilities/dev/orchestrator/steps/start-watchers-orchestrator-step.ts
+++ b/packages/twenty-sdk/src/cli/utilities/dev/orchestrator/steps/start-watchers-orchestrator-step.ts
@@ -109,6 +109,7 @@ export class StartWatchersOrchestratorStep {
     this.state.addEvent({
       message: `Change detected: ${sourcePath}`,
       status: 'info',
+      spacingBefore: true,
     });
 
     if (event === 'unlink') {

--- a/packages/twenty-sdk/src/cli/utilities/dev/ui/components/dev-ui-event-log.tsx
+++ b/packages/twenty-sdk/src/cli/utilities/dev/ui/components/dev-ui-event-log.tsx
@@ -16,7 +16,7 @@ export const DevUiEventItem = ({
   const time = formatTime(event.timestamp);
 
   return (
-    <Box>
+    <Box marginTop={event.spacingBefore ? 1 : 0}>
       <Text dimColor>{time} </Text>
       <Text color={color}>{event.message}</Text>
     </Box>


### PR DESCRIPTION
Small PR to improve logging in twenty sdk dev mode

## After
<img width="1406" height="580" alt="image" src="https://github.com/user-attachments/assets/a14edc2d-2194-420a-8b0b-b3ca35c31ccd" />