### PR TITLE
security: clear picomatch High alert via @angular-devkit/core resolution

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,8 @@
     "make-fetch-happen": "^15.0.0",
     "@electron/rebuild/tar": "npm:^7.5.16",
     "@electron/node-gyp/tar": "npm:^7.5.16",
-    "pacote/tar": "npm:^7.5.16"
+    "pacote/tar": "npm:^7.5.16",
+    "@angular-devkit/core": "19.2.24"
   },
   "version": "0.2.1",
   "nx": {},

--- a/yarn.lock
+++ b/yarn.lock
@@ -246,14 +246,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@angular-devkit/core@npm:19.2.17":
-  version: 19.2.17
-  resolution: "@angular-devkit/core@npm:19.2.17"
+"@angular-devkit/core@npm:19.2.24":
+  version: 19.2.24
+  resolution: "@angular-devkit/core@npm:19.2.24"
   dependencies:
-    ajv: "npm:8.17.1"
+    ajv: "npm:8.18.0"
     ajv-formats: "npm:3.0.1"
     jsonc-parser: "npm:3.3.1"
-    picomatch: "npm:4.0.2"
+    picomatch: "npm:4.0.4"
     rxjs: "npm:7.8.1"
     source-map: "npm:0.7.4"
   peerDependencies:
@@ -261,26 +261,7 @@ __metadata:
   peerDependenciesMeta:
     chokidar:
       optional: true
-  checksum: 10c0/721c34da992e7060156c1e523703f754b64524d0212efbbdf9a88ef794ef3c9ebb8e8994743f013c3b99c0a9201362ed2a8ecc2979a1bb72a02b2a6cd4887699
-  languageName: node
-  linkType: hard
-
-"@angular-devkit/core@npm:19.2.19":
-  version: 19.2.19
-  resolution: "@angular-devkit/core@npm:19.2.19"
-  dependencies:
-    ajv: "npm:8.17.1"
-    ajv-formats: "npm:3.0.1"
-    jsonc-parser: "npm:3.3.1"
-    picomatch: "npm:4.0.2"
-    rxjs: "npm:7.8.1"
-    source-map: "npm:0.7.4"
-  peerDependencies:
-    chokidar: ^4.0.0
-  peerDependenciesMeta:
-    chokidar:
-      optional: true
-  checksum: 10c0/3729fbb53439c6f9279803c4e1156ae3a0813845a66e1e9851ae159b1d5da0ba577d7d568c1f428adcb7839e5e6bcf2620c84baa0235163de1fcf18dd9749e2e
+  checksum: 10c0/0386cf938cfc1ac2cc203087d61463b1424711befe058ec16f9774dfbfb6c81e2004a00e97a2056e9051ad50e1fc3675234e590760c11cdd40032fb5d86220c1
   languageName: node
   linkType: hard
 
@@ -27354,18 +27335,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ajv@npm:8.17.1":
-  version: 8.17.1
-  resolution: "ajv@npm:8.17.1"
-  dependencies:
-    fast-deep-equal: "npm:^3.1.3"
-    fast-uri: "npm:^3.0.1"
-    json-schema-traverse: "npm:^1.0.0"
-    require-from-string: "npm:^2.0.2"
-  checksum: 10c0/ec3ba10a573c6b60f94639ffc53526275917a2df6810e4ab5a6b959d87459f9ef3f00d5e7865b82677cb7d21590355b34da14d1d0b9c32d75f95a187e76fff35
-  languageName: node
-  linkType: hard
-
 "ajv@npm:8.18.0, ajv@npm:~8.18.0":
   version: 8.18.0
   resolution: "ajv@npm:8.18.0"
@@ -46858,13 +46827,6 @@ __metadata:
   version: 1.1.1
   resolution: "picocolors@npm:1.1.1"
   checksum: 10c0/e2e3e8170ab9d7c7421969adaa7e1b31434f789afb9b3f115f6b96d91945041ac3ceb02e9ec6fe6510ff036bcc0bf91e69a1772edc0b707e12b19c0f2d6bcf58
-  languageName: node
-  linkType: hard
-
-"picomatch@npm:4.0.2":
-  version: 4.0.2
-  resolution: "picomatch@npm:4.0.2"
-  checksum: 10c0/7c51f3ad2bb42c776f49ebf964c644958158be30d0a510efd5a395e8d49cb5acfed5b82c0c5b365523ce18e6ab85013c9ebe574f60305892ec3fa8eee8304ccc
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## What

Clears the root `picomatch` High alert (GHSA-c2c7-rcm5-vvqj, range `>=4.0.0 <4.0.4`).

`picomatch@4.0.2` is exact-pinned by `@angular-devkit/core@19.2.x`, pulled by NestJS's codegen tooling (`@nestjs/schematics` + `@nestjs/cli` use Angular's schematics engine). angular-devkit/core backported the picomatch 4.0.4 fix in **19.2.24**.

## Why a resolution here (not a parent bump)

The clean parent-bump — bumping `@nestjs/cli` so it pulls patched angular-devkit — **breaks `nest build`**. `@nestjs/cli` 11.0.17+ has an SWC-builder output-path change: it writes compiled files under `dist/`**`src/`**`…` instead of `dist/…`, breaking every `node dist/<path>` reference (`main`, `command`, worker, `database/scripts/*`). This is what failed in the first revision of this PR (`Cannot find module '…/dist/database/scripts/truncate-db.js'`).

- The cli's angular-devkit pin is **exact**, so there's no clean refresh.
- Every `@nestjs/cli` ≥11.0.17 (incl. the latest 11.0.23) has the regression.
- There's no stable NestJS 12/13 to move to (12 is alpha-only).
- `tsconfig` `rootDir` doesn't override the output base.

So a one-patch resolution is genuinely the cleaner, lower-risk fix:

```jsonc
"@angular-devkit/core": "19.2.24"   // patch within the same 19.2 minor
```

`@nestjs/cli` stays 11.0.16 (correct `dist/` layout), and picomatch resolves to 4.0.4.

## Verification
- picomatch now **4.0.4 + 2.3.2** (both patched); no 4.0.2 in the lockfile
- `nx build twenty-server` emits `dist/main.js` and `dist/database/scripts/*.js` at the correct paths (the prior CI failure)
- `yarn install --immutable` clean