### PR TITLE
fix(docker): upgrade Alpine system OpenSSL libs to patched 3.5.7-r0

### DIFF
--- a/packages/twenty-docker/twenty/Dockerfile
+++ b/packages/twenty-docker/twenty/Dockerfile
@@ -88,9 +88,17 @@ RUN if [ -d /app/packages/twenty-front/build ]; then \
 
 FROM node:24.16.0-alpine3.23@sha256:2bdb65ed1dab192432bc31c95f94155ca5ad7fc1392fb7eb7526ab682fa5bf14 AS twenty-server
 
+# Upgrade the Alpine system OpenSSL libs (libcrypto3/libssl3) to the patched
+# build. These are NOT used by the app at runtime (Node bundles and links its
+# own OpenSSL), but they ship in the base filesystem as deps of apk-tools and
+# ssl_client, so the scanner flags them by version. Pinning a patched floor
+# forces apk to upgrade them at build time, same technique as curl/nghttp2.
+# (Node's bundled OpenSSL is upgraded separately via the Node base bump above.)
 RUN apk add --no-cache \
     'curl>=8.19.0-r0' \
     'nghttp2-libs>=1.69.0-r0' \
+    'libcrypto3>=3.5.7-r0' \
+    'libssl3>=3.5.7-r0' \
     'postgresql18-client>=18.4-r0' \
     jq
 
@@ -213,9 +221,13 @@ RUN tar -C / -Jxpf /tmp/s6-overlay-noarch.tar.xz \
  && tar -C / -Jxpf /tmp/s6-overlay-arch.tar.xz \
  && rm /tmp/s6-overlay-*.tar.xz
 
+# See the twenty-server stage above: upgrade the Alpine system OpenSSL libs to
+# the patched build (not used by Node at runtime, but flagged by the scanner).
 RUN apk add --no-cache \
     postgresql18 postgresql18-contrib \
     redis \
+    'libcrypto3>=3.5.7-r0' \
+    'libssl3>=3.5.7-r0' \
     curl jq su-exec
 
 # Workspace root config

--- a/packages/twenty-docker/twenty/Dockerfile
+++ b/packages/twenty-docker/twenty/Dockerfile
@@ -88,12 +88,9 @@ RUN if [ -d /app/packages/twenty-front/build ]; then \
 
 FROM node:24.16.0-alpine3.23@sha256:2bdb65ed1dab192432bc31c95f94155ca5ad7fc1392fb7eb7526ab682fa5bf14 AS twenty-server
 
-# Upgrade the Alpine system OpenSSL libs (libcrypto3/libssl3) to the patched
-# build. These are NOT used by the app at runtime (Node bundles and links its
-# own OpenSSL), but they ship in the base filesystem as deps of apk-tools and
-# ssl_client, so the scanner flags them by version. Pinning a patched floor
-# forces apk to upgrade them at build time, same technique as curl/nghttp2.
-# (Node's bundled OpenSSL is upgraded separately via the Node base bump above.)
+# Force the patched Alpine OpenSSL libs (base bakes 3.5.6-r0; repo ships
+# 3.5.7-r0). Node bundles its own OpenSSL, but psql/curl link these system
+# libs, so the upgrade hardens runtime TLS and clears the scanner.
 RUN apk add --no-cache \
     'curl>=8.19.0-r0' \
     'nghttp2-libs>=1.69.0-r0' \
@@ -221,8 +218,8 @@ RUN tar -C / -Jxpf /tmp/s6-overlay-noarch.tar.xz \
  && tar -C / -Jxpf /tmp/s6-overlay-arch.tar.xz \
  && rm /tmp/s6-overlay-*.tar.xz
 
-# See the twenty-server stage above: upgrade the Alpine system OpenSSL libs to
-# the patched build (not used by Node at runtime, but flagged by the scanner).
+# See twenty-server above: patched Alpine OpenSSL libs (psql/curl/redis link
+# these system libs; Node bundles its own).
 RUN apk add --no-cache \
     postgresql18 postgresql18-contrib \
     redis \


### PR DESCRIPTION
## Context

Image scanner flags the `prod-twenty` server image for OpenSSL CVEs. The image carries **two independent OpenSSL surfaces**, and they are fixed by different levers:

| Surface | Version (before) | Used by app at runtime? | Fix lever |
|---|---|---|---|
| **Node-bundled** OpenSSL | `3.5.6` | ✅ yes (Node links its own) | Node base bump (separate; `24.16.0-alpine3.23` is already the latest digest) |
| **Alpine system** `libcrypto3`/`libssl3` | `3.5.6-r0` | ❌ no (`ldd node` shows no link) | **this PR** — apk upgrade to `3.5.7-r0` |

The pinned `node:24.16.0-alpine3.23` base bakes `libcrypto3`/`libssl3` at `3.5.6-r0`, while the Alpine v3.23 repo now ships `3.5.7-r0`. These libs ship as deps of `apk-tools`/`libapk`/`ssl_client` (so they can't be removed), and Node does not link them — but the scanner still flags them by version.

## Change

Pin a patched floor (`libcrypto3>=3.5.7-r0`, `libssl3>=3.5.7-r0`) in the `apk add` lines of both runtime stages (`twenty-server` and `twenty-app-dev`) so apk upgrades them at build time. Same technique already used for `curl`/`nghttp2-libs`/`postgresql18-client` (#20805).

## Verification

- Built `--target twenty-server`; image builds clean.
- On the built image, `libcrypto3` and `libssl3` resolve to `3.5.7-r0`.
- Node-bundled OpenSSL is unaffected by this change (separate surface, no Dockerfile-side upgrade path until a newer Node release links a patched OpenSSL).