### PR TITLE
Prevent self-hosting app from re-matching/re-creating people on no-op updates

### DIFF
--- a/packages/twenty-apps/internal/self-hosting/package.json
+++ b/packages/twenty-apps/internal/self-hosting/package.json
@@ -1,6 +1,6 @@
 {
   "name": "self-hosting",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "license": "MIT",
   "engines": {
     "node": "^24.5.0",

--- a/packages/twenty-apps/internal/self-hosting/src/logic-functions/match-telemetry-event-with-people.ts
+++ b/packages/twenty-apps/internal/self-hosting/src/logic-functions/match-telemetry-event-with-people.ts
@@ -1,6 +1,11 @@
-import { defineLogicFunction, type DatabaseEventPayload, type ObjectRecordCreateEvent, type ObjectRecordUpdateEvent } from 'twenty-sdk/define';
 import { SELF_HOSTING_USER_NAME_SINGULAR } from 'src/objects/selfHostingUser.object';
 import { CoreApiClient } from 'twenty-client-sdk/core';
+import {
+  defineLogicFunction,
+  type DatabaseEventPayload,
+  type ObjectRecordCreateEvent,
+  type ObjectRecordUpdateEvent,
+} from 'twenty-sdk/define';
 
 type SelfHostingUser = {
   id: string;
@@ -28,6 +33,17 @@ const handler = async (
   const email = params.properties.after.email?.primaryEmail;
 
   if (!email) {
+    return;
+  }
+
+  const existingPersonId = params.properties.after.personId;
+  const previousEmail =
+    'before' in params.properties
+      ? params.properties.before?.email?.primaryEmail
+      : undefined;
+  const emailChanged = previousEmail !== email;
+
+  if (existingPersonId && !emailChanged) {
     return;
   }
 


### PR DESCRIPTION
The match-telemetry-event-with-people logic function triggers on selfHostingUser.* (both created and updated) and unconditionally wrote personId back to the record on every run. Since the handler's own write produces an updated event — and the telemetry webhook also updates unrelated fields (name, serverUrl, etc.) on returning signups — the matching logic re-ran unnecessarily, querying people and writing on each pass.

This adds an early-return guard so the handler only does work when there's actually something to match:

Skip when the selfHostingUser is already linked (personId set) and the primary email hasn't changed.
Still (re)match on first link and on genuine email changes — the legitimate reasons for listening on updated.
The guard reads before.email.primaryEmail via an 'before' in properties narrowing so it stays type-safe across the create/update event union.