### PR TITLE
security: force lodash 4.18.1 to close code-injection CVE (#824) + prototype pollution

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "graphql": "16.8.1",
     "type-fest": "4.10.1",
     "typescript": "5.9.3",
+    "lodash": "4.18.1",
     "nodemailer": "8.0.10",
     "graphql-redis-subscriptions/ioredis": "^5.6.0",
     "@lingui/core": "5.1.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -41843,24 +41843,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"lodash@npm:4, lodash@npm:4.18.1, lodash@npm:^4.17.14, lodash@npm:^4.17.15, lodash@npm:^4.17.19, lodash@npm:^4.17.20, lodash@npm:^4.17.21, lodash@npm:^4.17.4, lodash@npm:^4.18.1":
+"lodash@npm:4.18.1":
   version: 4.18.1
   resolution: "lodash@npm:4.18.1"
   checksum: 10c0/757228fc68805c59789e82185135cf85f05d0b2d3d54631d680ca79ec21944ec8314d4533639a14b8bcfbd97a517e78960933041a5af17ecb693ec6eecb99a27
-  languageName: node
-  linkType: hard
-
-"lodash@npm:4.17.21":
-  version: 4.17.21
-  resolution: "lodash@npm:4.17.21"
-  checksum: 10c0/d8cbea072bb08655bb4c989da418994b073a608dffa608b09ac04b43a791b12aeae7cd7ad919aa4c925f33b48490b5cfe6c1f71d827956071dae2e7bb3a6b74c
-  languageName: node
-  linkType: hard
-
-"lodash@npm:~4.17.0, lodash@npm:~4.17.21":
-  version: 4.17.23
-  resolution: "lodash@npm:4.17.23"
-  checksum: 10c0/1264a90469f5bb95d4739c43eb6277d15b6d9e186df4ac68c3620443160fc669e2f14c11e7d8b2ccf078b81d06147c01a8ccced9aab9f9f63d50dcf8cace6bf6
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Adds a single `lodash` → **4.18.1** resolution to close the remaining lodash CVEs.

### Why a resolution
The dependency *union* already resolved to 4.18.1, but vulnerable copies remained because parents pin older versions that have no in-range patch:
- `4.17.21` pinned exact by `@nestjs/config@3.3.0`, `zapier-platform-*`, and `verdaccio`
- `4.17.23` via `~4.17.x` ranges (`@graphql-tools`, socket.io)

4.18.0 is the first patched release, so the only way to force the parent-pinned copies up is an override. lodash 4.18.1 is an API-compatible security release; after the resolution **every** `lodash` copy resolves to 4.18.1 and none below it remains.

This does **not** touch the separate `lodash.*` single-function packages (`lodash.merge`, `lodash.camelcase`, …), which are unaffected by these advisories.

### Closes
- **#824 — `_.template` code injection (HIGH)**
- #823 — prototype pollution in `_.unset` / `_.omit`
- #385 — prototype pollution in `_.unset` / `_.omit`

Verified with `yarn install --immutable` (passes the hardened-mode 3-day age gate; 4.18.1 was published 2026-04-01).