### PR TITLE
fix(ui): freeze framer-motion in Argos runs to stop flaky visual diffs

### DIFF
--- a/packages/twenty-ui-deprecated/.storybook/vitest.setup.ts
+++ b/packages/twenty-ui-deprecated/.storybook/vitest.setup.ts
@@ -1,5 +1,12 @@
 import { setProjectAnnotations } from '@storybook/react-vite';
+import { MotionGlobalConfig } from 'framer-motion';
 import * as projectAnnotations from './preview';
+
+// Freeze framer-motion so Argos screenshots are deterministic. Playwright's
+// `animations: "disabled"` only halts CSS animations/transitions, not
+// framer-motion's main-thread (rAF) animations, so loaders/spinners were
+// captured mid-frame and flagged as visual changes on every run.
+MotionGlobalConfig.skipAnimations = true;
 
 // Apply Storybook's preview configuration to Vitest runs.
 setProjectAnnotations([projectAnnotations]);

--- a/packages/twenty-ui-deprecated/src/feedback/progress-bar/components/__stories__/CircularProgressBar.stories.tsx
+++ b/packages/twenty-ui-deprecated/src/feedback/progress-bar/components/__stories__/CircularProgressBar.stories.tsx
@@ -10,9 +10,6 @@ const meta: Meta<typeof CircularProgressBar> = {
   args: {
     size: 50,
   },
-  parameters: {
-    chromatic: { disableSnapshot: true },
-  },
 };
 
 export default meta;

--- a/packages/twenty-ui-deprecated/src/feedback/progress-bar/components/__stories__/ProgressBar.stories.tsx
+++ b/packages/twenty-ui-deprecated/src/feedback/progress-bar/components/__stories__/ProgressBar.stories.tsx
@@ -42,7 +42,4 @@ export const Animated: Story = {
       return <Story args={{ value }} />;
     },
   ],
-  parameters: {
-    chromatic: { disableSnapshot: true },
-  },
 };

--- a/packages/twenty-ui/.storybook/vitest.setup.ts
+++ b/packages/twenty-ui/.storybook/vitest.setup.ts
@@ -1,5 +1,12 @@
 import { setProjectAnnotations } from '@storybook/react-vite';
+import { MotionGlobalConfig } from 'framer-motion';
 import * as projectAnnotations from './preview';
+
+// Freeze framer-motion so Argos screenshots are deterministic. Playwright's
+// `animations: "disabled"` only halts CSS animations/transitions, not
+// framer-motion's main-thread (rAF) animations, so loaders/spinners were
+// captured mid-frame and flagged as visual changes on every run.
+MotionGlobalConfig.skipAnimations = true;
 
 // Apply Storybook's preview configuration to Vitest runs.
 setProjectAnnotations([projectAnnotations]);


### PR DESCRIPTION
## Problem

twenty-ui Argos visual tests are flaky — `Loader`, `CircularProgressBar`, `ProgressBar` get flagged as changed with no relevant code change.

## Cause

Argos screenshots use Playwright's `animations: "disabled"`, which only freezes CSS animations. These components animate via framer-motion (main-thread rAF), so each run captures a different frame.

## Fix

Set `MotionGlobalConfig.skipAnimations = true` in the Vitest setup of both UI packages — freezes framer-motion to a deterministic state during Argos runs only (interactive Storybook unaffected). Removes the now-redundant per-story `disableSnapshot` opt-outs.

Note: removing `CircularProgressBar`'s opt-out adds new baselines (one-time Argos approval, not flakiness).