### PR TITLE
fix: i18n missing hardcoded strings in settings

### DIFF
--- a/packages/twenty-front/src/locales/en.po
+++ b/packages/twenty-front/src/locales/en.po
@@ -5735,6 +5735,11 @@ msgstr "Don't create contacts from/to Gmail, Outlook emails"
 msgid "Don't sync emails from team@ support@ noreply@..."
 msgstr "Don't sync emails from team@ support@ noreply@..."
 
+#. js-lingui-id: DPfwMq
+#: src/modules/page-layout/widgets/fields/components/FieldsConfigurationGroupRenameInput.tsx
+msgid "Done"
+msgstr "Done"
+
 #. js-lingui-id: Wm78zZ
 #: src/modules/settings/experience/components/NumberFormatSelect.tsx
 msgid "Dots and comma"
@@ -13170,6 +13175,11 @@ msgstr "Reload validity token"
 #: src/pages/settings/enterprise/SettingsEnterprise.tsx
 msgid "Reloading..."
 msgstr "Reloading..."
+
+#. js-lingui-id: qlAIQ1
+#: src/modules/settings/components/SettingsItemTypeTag.tsx
+msgid "Remote"
+msgstr "Remote"
 
 #. js-lingui-id: t/YqKh
 #: src/pages/settings/admin-panel/SettingsAdminAiProviderDetail.tsx

--- a/packages/twenty-front/src/modules/page-layout/widgets/fields/components/FieldsConfigurationGroupRenameInput.tsx
+++ b/packages/twenty-front/src/modules/page-layout/widgets/fields/components/FieldsConfigurationGroupRenameInput.tsx
@@ -68,7 +68,7 @@ export const FieldsConfigurationGroupRenameInput = ({
         variant="primary"
         accent="blue"
         size="small"
-        title="Done"
+        title={t`Done`}
         onClick={handleSave}
       />
     </StyledContainer>

--- a/packages/twenty-front/src/modules/settings/components/SettingsItemTypeTag.tsx
+++ b/packages/twenty-front/src/modules/settings/components/SettingsItemTypeTag.tsx
@@ -1,3 +1,5 @@
+import { t } from '@lingui/core/macro';
+
 import { AppChip } from '@/applications/components/AppChip';
 import { Avatar } from 'twenty-ui-deprecated/display';
 import { Chip, ChipAccent, ChipVariant } from 'twenty-ui-deprecated/components';
@@ -22,7 +24,7 @@ export const SettingsItemTypeTag = ({
     return (
       <Chip
         className={className}
-        label="Remote"
+        label={t`Remote`}
         variant={ChipVariant.Transparent}
         accent={ChipAccent.TextPrimary}
         leftComponent={


### PR DESCRIPTION
## What

Two user-visible strings in the Settings area were never wrapped with Lingui, so they were excluded from i18n extraction and shipped untranslated regardless of the selected language:

- **"Remote"** — the type chip shown for remote objects in **Settings → Data Model** (`SettingsItemTypeTag`)
- **"Done"** — the confirm button of the fields configuration group rename input (`FieldsConfigurationGroupRenameInput`)

## Changes

- Wrap the `Chip` `label` with the `t` macro in `SettingsItemTypeTag.tsx` (the `placeholder` / `placeholderColorSeed` props are intentionally left as-is — they drive the avatar initial and color hash, not display text).
- Wrap the `Button` `title` with the existing `t` from `useLingui()` in `FieldsConfigurationGroupRenameInput.tsx`.
- Add the corresponding source entries to `en.po` so Crowdin can propagate the translations to all supported locales.

Both follow i18n patterns already used throughout the codebase — these two were simply missed.

## Screenshots

Both components rendered via Storybook (source `en` locale) after the change — the strings now resolve through Lingui's `t` macro without breaking rendering:

![i18n settings strings](https://raw.githubusercontent.com/AmilGael/twenty/pr-assets/.github/pr-assets/i18n-hardcoded-strings-settings.png)

## How to test

1. Switch the workspace language to a non-English locale.
2. Go to **Settings → Data Model** with a remote object present → the type chip reads "Remote" translated.
3. Rename a fields configuration group → the confirm button reads "Done" translated.
