### PR TITLE
fix(twenty-shared): promote formatToShortNumber to next unit on rounding carry

### DIFF
--- a/packages/twenty-shared/src/utils/__tests__/formatToShortNumber.test.ts
+++ b/packages/twenty-shared/src/utils/__tests__/formatToShortNumber.test.ts
@@ -30,6 +30,13 @@ describe('formatToShortNumber', () => {
     expect(formatToShortNumber(0)).toBe('0');
   });
 
+  it('promotes to the next unit when rounding carries over to 1000', () => {
+    expect(formatToShortNumber(999999)).toBe('1m');
+    expect(formatToShortNumber(999999999)).toBe('1b');
+    expect(formatToShortNumber(999.95)).toBe('1k');
+    expect(formatToShortNumber(-999999)).toBe('-1m');
+  });
+
   describe('negative numbers', () => {
     it('formats negative numbers less than 1000 correctly', () => {
       expect(formatToShortNumber(-500)).toBe('-500');

--- a/packages/twenty-shared/src/utils/format/formatToShortNumber.ts
+++ b/packages/twenty-shared/src/utils/format/formatToShortNumber.ts
@@ -1,26 +1,26 @@
+// Ordered from largest to smallest. An empty suffix is the base unit.
+// `next` is the unit to promote to when rounding carries over to 1000
+// (e.g. 999_999 / 1000 → "1000.0" must become "1m", not "1000k").
+const UNITS = [
+  { threshold: 1_000_000_000, suffix: 'b', next: 'b' },
+  { threshold: 1_000_000, suffix: 'm', next: 'b' },
+  { threshold: 1000, suffix: 'k', next: 'm' },
+  { threshold: 1, suffix: '', next: 'k' },
+] as const;
+
 export const formatToShortNumber = (amount: number) => {
   const sign = amount < 0 ? '-' : '';
   const absoluteAmount = Math.abs(amount);
 
-  if (absoluteAmount < 1000) {
-    return sign + absoluteAmount.toFixed(1).replace(/\.?0+$/, '');
+  const unit =
+    UNITS.find(({ threshold }) => absoluteAmount >= threshold) ??
+    UNITS[UNITS.length - 1];
+
+  const rounded = (absoluteAmount / unit.threshold).toFixed(1);
+
+  if (rounded === '1000.0') {
+    return sign + '1' + unit.next;
   }
 
-  if (absoluteAmount < 1_000_000) {
-    return (
-      sign + (absoluteAmount / 1000).toFixed(1).replace(/\.?0+$/, '') + 'k'
-    );
-  }
-
-  if (absoluteAmount < 1_000_000_000) {
-    return (
-      sign + (absoluteAmount / 1_000_000).toFixed(1).replace(/\.?0+$/, '') + 'm'
-    );
-  }
-
-  return (
-    sign +
-    (absoluteAmount / 1_000_000_000).toFixed(1).replace(/\.?0+$/, '') +
-    'b'
-  );
+  return sign + rounded.replace(/\.?0+$/, '') + unit.suffix;
 };


### PR DESCRIPTION
## What's broken

`formatToShortNumber` returns the wrong unit at magnitude boundaries:

```
999999     => "1000k"   (expected "1m")
999999999  => "1000m"   (expected "1b")
999.95     => "1000"     (expected "1k")
```

It picks the unit (k/m/b) from the unrounded value, then `.toFixed(1)` rounds the quotient up to `1000.0`, which is never promoted to the next unit. This surfaces on aggregate numeric displays (record counts, currency sums).

## Why it happens

Unit selection uses the unrounded amount (`< 1_000_000` → k-branch), but the displayed figure is `(amount/1000).toFixed(1)`, which rounds. `999999/1000 = 999.999` → `"1000.0"` → `"1000k"`. The rounding carry crosses the boundary after the unit is already chosen.

## Fix

Pick the unit from a threshold table, round once, and if the rounded quotient is `1000.0`, emit `1` of the next unit up.

## Test

Added a case asserting `999999 → "1m"`, `999999999 → "1b"`, `999.95 → "1k"`, `-999999 → "-1m"`. All 11 existing cases still pass.
