### PR TITLE
fix(smtp): respect user encryption settings for nodemailer transport

### DIFF
--- a/packages/twenty-server/src/engine/core-modules/imap-smtp-caldav-connection/services/imap-smtp-caldav-connection.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/imap-smtp-caldav-connection/services/imap-smtp-caldav-connection.service.ts
@@ -114,6 +114,7 @@ export class ImapSmtpCaldavService {
     const transport = createTransport({
       host: validatedHost,
       port: params.port,
+      secure: params.secure ?? params.port === 465,
       auth: {
         user: params.username ?? handle,
         pass: params.password,


### PR DESCRIPTION
The testSmtpConnection function was failing to pass the secure parameter from the UI down to the nodemailer.createTransport configuration object. Because the parameter was dropped, Nodemailer defaulted to secure: false for port 587, ignoring the user's explicit request for SSL/TLS encryption.

This PR mirrors the logic found in testImapConnection and injects the secure toggle directly into the transport configuration, using a nullish coalescing operator to respect the user's choice or safely fall back to checking if the port is 465

ref: https://nodemailer.com/smtp#general-options

closes #21300 