### PR TITLE
fix(server): prevent stale workspace cache writes from racing invalidation

### DIFF
--- a/packages/twenty-server/src/engine/workspace-cache/services/__tests__/workspace-cache.service.spec.ts
+++ b/packages/twenty-server/src/engine/workspace-cache/services/__tests__/workspace-cache.service.spec.ts
@@ -47,6 +47,7 @@ describe('WorkspaceCacheService', () => {
             mget: jest.fn(),
             mset: jest.fn(),
             mdel: jest.fn(),
+            incrBy: jest.fn(),
           },
         },
         {
@@ -227,9 +228,10 @@ describe('WorkspaceCacheService', () => {
       await service.getOrRecompute(WORKSPACE_ID, ['featureFlagsMap']);
 
       // Verify Redis was rechecked after TTL expired
-      // Each getOrRecompute triggers: 1 hash check + 1 atomic data/hash fetch = 2 mget calls
-      // Total: 4 mget calls (2 per getOrRecompute)
-      expect(cacheStorageService.mget).toHaveBeenCalledTimes(4);
+      // Each getOrRecompute triggers: 1 hash check + 1 atomic data/hash fetch,
+      // plus 2 generation reads around the recompute = 4 mget calls
+      // Total: 8 mget calls (4 per getOrRecompute)
+      expect(cacheStorageService.mget).toHaveBeenCalledTimes(8);
     });
   });
 
@@ -254,6 +256,7 @@ describe('WorkspaceCacheService', () => {
     });
 
     it('should delete from redis, mark local cache as stale, and recompute', async () => {
+      cacheStorageService.mget.mockResolvedValue([undefined]);
       cacheStorageService.mdel.mockResolvedValue(undefined);
       cacheStorageService.mset.mockResolvedValue(undefined);
 
@@ -294,6 +297,7 @@ describe('WorkspaceCacheService', () => {
 
       await service.onModuleInit();
 
+      cacheStorageService.mget.mockResolvedValue([undefined]);
       cacheStorageService.mdel.mockResolvedValue(undefined);
       cacheStorageService.mset.mockResolvedValue(undefined);
 
@@ -416,6 +420,108 @@ describe('WorkspaceCacheService', () => {
 
       // Should have made additional mget calls to check Redis
       expect(cacheStorageService.mget.mock.calls.length).toBeGreaterThan(1);
+    });
+  });
+
+  describe('recompute racing invalidation', () => {
+    beforeEach(async () => {
+      discoveryService.getProviders.mockReturnValue([
+        { instance: mockProvider },
+      ] as any);
+
+      reflector.get.mockImplementation((key, target) => {
+        if (
+          key === WORKSPACE_CACHE_KEY &&
+          target === MockFeatureFlagsCacheProvider
+        ) {
+          return 'featureFlagsMap';
+        }
+
+        return undefined;
+      });
+
+      await service.onModuleInit();
+    });
+
+    it('should not let a recompute that started before an invalidation overwrite the fresh data', async () => {
+      const redis = new Map<string, unknown>();
+
+      cacheStorageService.mget.mockImplementation(async (keys: string[]) =>
+        keys.map((key) => redis.get(key)),
+      );
+      cacheStorageService.mset.mockImplementation(
+        async (entries: Array<{ key: string; value: unknown }>) => {
+          entries.forEach(({ key, value }) => redis.set(key, value));
+        },
+      );
+      cacheStorageService.mdel.mockImplementation(async (keys: string[]) => {
+        keys.forEach((key) => redis.delete(key));
+      });
+      cacheStorageService.incrBy.mockImplementation(
+        async (key: string, increment: number) => {
+          const newValue = ((redis.get(key) as number) ?? 0) + increment;
+
+          redis.set(key, newValue);
+
+          return newValue;
+        },
+      );
+
+      let releaseStaleCompute = () => {};
+      let signalStaleComputeStarted = () => {};
+      const staleComputeStarted = new Promise<void>((resolve) => {
+        signalStaleComputeStarted = resolve;
+      });
+      const staleComputeGate = new Promise<void>((resolve) => {
+        releaseStaleCompute = resolve;
+      });
+
+      // First compute simulates a database read that started before a
+      // migration commit; subsequent computes return the fresh state.
+      jest
+        .spyOn(mockProvider, 'computeForCache')
+        .mockImplementationOnce(async () => {
+          signalStaleComputeStarted();
+          await staleComputeGate;
+
+          return { testData: 'stale-value' };
+        })
+        .mockResolvedValue({ testData: 'fresh-value' });
+
+      const readerPromise = service.getOrRecompute(WORKSPACE_ID, [
+        'featureFlagsMap',
+      ]);
+
+      await staleComputeStarted;
+
+      await service.invalidateAndRecompute(WORKSPACE_ID, ['featureFlagsMap']);
+
+      releaseStaleCompute();
+
+      // The reader detects the generation bump, discards its stale snapshot
+      // and retries, so even the in-flight caller gets the fresh data.
+      const readerResult = await readerPromise;
+
+      expect(readerResult).toEqual({
+        featureFlagsMap: { testData: 'fresh-value' },
+      });
+
+      expect(
+        redis.get(
+          'feature-flag:feature-flags-map:20202020-0000-4000-8000-000000000000:data',
+        ),
+      ).toEqual({ testData: 'fresh-value' });
+
+      // A later read (past local TTL and memoizer TTL) must serve fresh data.
+      jest.advanceTimersByTime(15_000);
+
+      const laterResult = await service.getOrRecompute(WORKSPACE_ID, [
+        'featureFlagsMap',
+      ]);
+
+      expect(laterResult).toEqual({
+        featureFlagsMap: { testData: 'fresh-value' },
+      });
     });
   });
 

--- a/packages/twenty-server/src/engine/workspace-cache/services/workspace-cache.service.ts
+++ b/packages/twenty-server/src/engine/workspace-cache/services/workspace-cache.service.ts
@@ -166,6 +166,11 @@ export class WorkspaceCacheService implements OnModuleInit {
   ): Promise<void> {
     await this.memoizer.clearKeys(`${workspaceId}-`);
 
+    // Bumping generations fences out in-flight recomputes whose database
+    // read may predate the write being invalidated: they detect the bump
+    // and discard their result instead of overwriting the fresh one below.
+    await this.bumpGenerations(workspaceId, cacheKeyNames);
+
     await this.flush(workspaceId, cacheKeyNames);
     await this.recomputeDataFromProvider(workspaceId, cacheKeyNames);
 
@@ -317,12 +322,18 @@ export class WorkspaceCacheService implements OnModuleInit {
   private async recomputeDataFromProvider(
     workspaceId: string,
     cacheKeyNames: WorkspaceCacheKeyName[],
+    isRetry = false,
   ): Promise<Partial<WorkspaceCacheDataMap>> {
     const result: Partial<WorkspaceCacheDataMap> = {};
 
     if (cacheKeyNames.length === 0) {
       return result;
     }
+
+    const generationsBefore = await this.getGenerations(
+      workspaceId,
+      cacheKeyNames,
+    );
 
     const computePromises = cacheKeyNames.map(async (keyName) => {
       const provider = this.getProviderOrThrow(keyName);
@@ -334,10 +345,25 @@ export class WorkspaceCacheService implements OnModuleInit {
 
     const computed = await Promise.all(computePromises);
 
-    const redisEntries: Array<{ key: string; value: unknown }> = [];
+    // A generation bumped by invalidateAndRecompute while we were computing
+    // means our database read may predate the invalidated write: caching it
+    // would overwrite the fresh recompute and serve stale data until the
+    // next invalidation.
+    const generationsAfter = await this.getGenerations(
+      workspaceId,
+      cacheKeyNames,
+    );
 
-    for (const { keyName, data, hash } of computed) {
+    const redisEntries: Array<{ key: string; value: unknown }> = [];
+    const staleKeyNames: WorkspaceCacheKeyName[] = [];
+
+    for (const [index, { keyName, data, hash }] of computed.entries()) {
       Object.assign(result, { [keyName]: data });
+
+      if (generationsBefore[index] !== generationsAfter[index]) {
+        staleKeyNames.push(keyName);
+        continue;
+      }
 
       const baseKey = this.buildCacheKey(workspaceId, keyName);
 
@@ -354,7 +380,42 @@ export class WorkspaceCacheService implements OnModuleInit {
       await this.cacheStorage.mset(redisEntries);
     }
 
+    if (staleKeyNames.length > 0 && !isRetry) {
+      const retriedResult = await this.recomputeDataFromProvider(
+        workspaceId,
+        staleKeyNames,
+        true,
+      );
+
+      Object.assign(result, retriedResult);
+    }
+
     return result;
+  }
+
+  private async getGenerations(
+    workspaceId: string,
+    cacheKeyNames: WorkspaceCacheKeyName[],
+  ): Promise<(number | undefined)[]> {
+    return await this.cacheStorage.mget<number>(
+      cacheKeyNames.map((keyName) =>
+        this.buildGenerationKey(workspaceId, keyName),
+      ),
+    );
+  }
+
+  private async bumpGenerations(
+    workspaceId: string,
+    cacheKeyNames: WorkspaceCacheKeyName[],
+  ): Promise<void> {
+    await Promise.all(
+      cacheKeyNames.map((keyName) =>
+        this.cacheStorage.incrBy(
+          this.buildGenerationKey(workspaceId, keyName),
+          1,
+        ),
+      ),
+    );
   }
 
   private getFromLocalCache(
@@ -517,5 +578,12 @@ export class WorkspaceCacheService implements OnModuleInit {
     keyName: WorkspaceCacheKeyName,
   ): string {
     return `${WORKSPACE_CACHE_KEYS_V2[keyName]}:${workspaceId}`;
+  }
+
+  private buildGenerationKey(
+    workspaceId: string,
+    keyName: WorkspaceCacheKeyName,
+  ): string {
+    return `${this.buildCacheKey(workspaceId, keyName)}:gen`;
   }
 }


### PR DESCRIPTION
## Context

`example-app-postcard` fails intermittently on the schema integration test, each time missing a **different** subset of freshly synced fields ([run A](https://github.com/twentyhq/twenty/actions/runs/27330191961/job/80740567732) missing `recipient`, [run B](https://github.com/twentyhq/twenty/actions/runs/27333254362/job/80750773762) missing `content`) — even though the sync log shows the fields were created seconds earlier, and even when the assertion polls for 20s. The staleness is permanent, not transient.

## Root cause

`WorkspaceCacheService.recomputeDataFromProvider` has no ordering guard against `invalidateAndRecompute`. On a cache miss, a recompute reads the database; if a migration commits while that read is in flight, the runner's post-commit invalidation flushes and writes fresh data — and then the in-flight recompute lands **last**, `mset`ing its pre-commit snapshot over the fresh data with a brand-new random hash. Every subsequent hash validation agrees with the poisoned value, so the workspace serves stale metadata until the *next* invalidation. App sync runs several migrations back-to-back with reads interleaved (sync response resolution, API client generation), which is why CI hits the window regularly.

This is not just a test problem: any concurrent metadata read racing a schema change can make that change invisible until the next one.

## Fix

Per-key generation counters: `invalidateAndRecompute` bumps `<cacheKey>:gen` (post-commit) before flushing; `recomputeDataFromProvider` snapshots generations before reading the database and re-checks them after. If a generation moved, the result is served to the in-flight caller but never cached, and the compute retries once (the retry reads post-commit state, so callers and the memoizer end up with fresh data).

## Testing

- New regression test simulating the interleaving with an in-memory store: it reproduces the exact failure on the unfixed service (`stale-value` overwrites `fresh-value`) and passes with the guard.
- All 16 workspace-cache specs pass; typecheck and lint clean.

Replaces the earlier retry-the-assertion attempt on this branch — polling couldn't help because the poisoned cache never healed.
