### PR TITLE
fix(ci): per-SHA concurrency for main pushes in CI UI workflows

### DIFF
--- a/.github/workflows/ci-new-ui.yaml
+++ b/.github/workflows/ci-new-ui.yaml
@@ -10,7 +10,10 @@ permissions:
   contents: read
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  # On main every push gets its own group: a shared group keeps at most one
+  # pending run, so rapid consecutive merges would cancel queued runs and
+  # leave Argos baseline gaps (base builds are resolved by exact commit).
+  group: ${{ github.workflow }}-${{ github.ref }}${{ github.ref == 'refs/heads/main' && format('-{0}', github.sha) || '' }}
   cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 jobs:

--- a/.github/workflows/ci-ui.yaml
+++ b/.github/workflows/ci-ui.yaml
@@ -10,7 +10,10 @@ permissions:
   contents: read
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  # On main every push gets its own group: a shared group keeps at most one
+  # pending run, so rapid consecutive merges would cancel queued runs and
+  # leave Argos baseline gaps (base builds are resolved by exact commit).
+  group: ${{ github.workflow }}-${{ github.ref }}${{ github.ref == 'refs/heads/main' && format('-{0}', github.sha) || '' }}
   cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 jobs:


### PR DESCRIPTION
## Problem

`CI UI` and `CI New UI` run on push to `main` to produce Argos visual-regression baseline builds. The self-hosted Argos resolves base builds only by **exact reference commit**, so every main push must produce a completed run.

Both workflows use a single concurrency group per ref:

```yaml
concurrency:
  group: ${{ github.workflow }}-${{ github.ref }}
  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
```

GitHub Actions keeps at most **one pending run per concurrency group**: while a run is in progress, each newly queued run cancels the previously pending one (`cancel-in-progress: false` only protects the *in-progress* run, not the queued one). This is observable today — `gh run list --workflow "CI UI" --branch main --event push` shows ~5 of the last 30 main-push runs cancelled seconds after the next push was queued.

Each cancelled run is a main commit with **no Argos baseline**. Any PR whose merge-base is such a commit gets an orphan build where every story is reported as "added" in the PR comment.

## Fix

Give each main push its own concurrency group keyed by commit SHA, so main runs execute in parallel instead of queueing:

```yaml
group: ${{ github.workflow }}-${{ github.ref }}${{ github.ref == 'refs/heads/main' && format('-{0}', github.sha) || '' }}
```

PR and merge-queue behavior is unchanged: still grouped per ref with `cancel-in-progress: true`.

This mirrors the same fix applied to `ci-front.yaml` on `feat/argos-visual-regression-twenty-front`.

`actionlint` passes (no new findings; the pre-existing "description is required" warning on the `yarn-install` composite action is unrelated).

🤖 Generated with [Claude Code](https://claude.com/claude-code)