### PR TITLE
security: scoped ajv 8.20.0 resolution for react-doc-viewer (Dependabot alert 481)

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,9 +52,10 @@
     "@ptc-org/nestjs-query-typeorm/uuid": "11.1.1",
     "typeorm/uuid": "11.1.1",
     "node-ical/uuid": "11.1.1",
-    "googleapis-common/uuid": "11.1.1"
+    "googleapis-common/uuid": "11.1.1",
+    "@cyntler/react-doc-viewer/ajv": "8.20.0"
   },
-  "//resolutions": "qs 6.15.2 -> CVE fix for verdaccio + @mintlify/previewing (pin old express 4.22.x); next/postcss 8.5.15 -> CVE fix for next, which pins old postcss 8.4.31 exact on every stable release (fix only in the 16.3.0 canary); <pkg>/uuid 11.1.1 -> CVE fix scoped to parents pinning uuid <11 that can't be cleanly bumped (sockjs+wds & @ptc-org/nestjs-query-typeorm at latest; typeorm is a patch:dep ORM core; node-ical 0.26 & googleapis 173 are large breaking migrations; @cypress/request transitive). bullmq/msal-node/blocknote were bumped instead. Preserves the intentional uuid 13.x; remove each once upstream ships a patched/clean version",
+  "//resolutions": "qs 6.15.2 -> CVE fix for verdaccio + @mintlify/previewing (pin old express 4.22.x); next/postcss 8.5.15 -> CVE fix for next, which pins old postcss 8.4.31 exact on every stable release (fix only in the 16.3.0 canary); <pkg>/uuid 11.1.1 -> CVE fix scoped to parents pinning uuid <11 that can't be cleanly bumped (sockjs+wds & @ptc-org/nestjs-query-typeorm at latest; typeorm is a patch:dep ORM core; node-ical 0.26 & googleapis 173 are large breaking migrations; @cypress/request transitive). bullmq/msal-node/blocknote were bumped instead. Preserves the intentional uuid 13.x; @cyntler/react-doc-viewer/ajv 8.20.0 -> CVE fix; react-doc-viewer pins ajv ^7 (latest still does) but never imports ajv, so forcing v8 is safe; remove each once upstream ships a patched/clean version",
   "version": "0.2.1",
   "nx": {},
   "scripts": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -27403,6 +27403,18 @@ __metadata:
   languageName: node
   linkType: hard
 
+"ajv@npm:8.20.0, ajv@npm:^8.0.0, ajv@npm:^8.17.1, ajv@npm:^8.18.0, ajv@npm:^8.9.0":
+  version: 8.20.0
+  resolution: "ajv@npm:8.20.0"
+  dependencies:
+    fast-deep-equal: "npm:^3.1.3"
+    fast-uri: "npm:^3.0.1"
+    json-schema-traverse: "npm:^1.0.0"
+    require-from-string: "npm:^2.0.2"
+  checksum: 10c0/5df9a1c8f83863cde1bd3a9ddb426f599718f88e3dc9153616c79fb28e0be455335830d7f21d745576519f057b371352daa31047b6a33d7036fe08777d60cf2a
+  languageName: node
+  linkType: hard
+
 "ajv@npm:^6.12.4, ajv@npm:^6.12.5":
   version: 6.15.0
   resolution: "ajv@npm:6.15.0"
@@ -27412,30 +27424,6 @@ __metadata:
     json-schema-traverse: "npm:^0.4.1"
     uri-js: "npm:^4.2.2"
   checksum: 10c0/67966499dd272ecde1c2e467084411132891523d057487587879d39ac04207f4351b7b2324c83198013967fbfa632c1612adc960114a30770fbe07a0773b32c2
-  languageName: node
-  linkType: hard
-
-"ajv@npm:^7.2.4":
-  version: 7.2.4
-  resolution: "ajv@npm:7.2.4"
-  dependencies:
-    fast-deep-equal: "npm:^3.1.1"
-    json-schema-traverse: "npm:^1.0.0"
-    require-from-string: "npm:^2.0.2"
-    uri-js: "npm:^4.2.2"
-  checksum: 10c0/420b72d7f6af89c7e63e00856b894e16a8a2ea107b2b2a76ff36d8dd05f6d708ab120a8c7cc627983ad1f75c6990363eda7c68f45943635f084de62353ca1c56
-  languageName: node
-  linkType: hard
-
-"ajv@npm:^8.0.0, ajv@npm:^8.17.1, ajv@npm:^8.18.0, ajv@npm:^8.9.0":
-  version: 8.20.0
-  resolution: "ajv@npm:8.20.0"
-  dependencies:
-    fast-deep-equal: "npm:^3.1.3"
-    fast-uri: "npm:^3.0.1"
-    json-schema-traverse: "npm:^1.0.0"
-    require-from-string: "npm:^2.0.2"
-  checksum: 10c0/5df9a1c8f83863cde1bd3a9ddb426f599718f88e3dc9153616c79fb28e0be455335830d7f21d745576519f057b371352daa31047b6a33d7036fe08777d60cf2a
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Closes the **final** open Dependabot alert — ajv [481](https://github.com/twentyhq/twenty/security/dependabot/481) — with a scoped resolution.

### Why a resolution (no parent path)
`ajv >= 7.0.0 < 8.18.0` is pulled **only** by `@cyntler/react-doc-viewer`, which pins `ajv ^7.2.4`. Its **latest (1.17.1) still pins `^7`** — there is no react-doc-viewer version on ajv 8 (no 1.18/2.0) — so it can't be closed by upgrading the parent.

### Why it's completely safe
`@cyntler/react-doc-viewer` **never imports ajv** — zero references in its dist; ajv is a declared-but-unused dependency. So forcing it to ajv 8 has **no functional impact**, and the ajv 7→8 breaking-change concern is moot. Scoped to `@cyntler/react-doc-viewer/ajv` so it touches nothing else.

### Verification
- `yarn install --immutable` ✓; every ajv now resolves to **8.18.0 / 8.20.0** (safe) or `6.12.x` (outside the advisory range) — no vulnerable ajv remains.

Documented in the top-level `//resolutions` note with a removal trigger. **This was the last open alert.**