### PR TITLE
fix(server): bypass stale workspace cache when resolving currentUser during onboarding

### DIFF
--- a/packages/twenty-server/src/engine/core-modules/user/services/user.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/user/services/user.service.ts
@@ -7,7 +7,10 @@ import { TypeOrmQueryService } from '@ptc-org/nestjs-query-typeorm';
 import { isNonEmptyString } from '@sniptt/guards';
 import { SOURCE_LOCALE } from 'twenty-shared/translations';
 import { assertIsDefinedOrThrow, isDefined } from 'twenty-shared/utils';
-import { isWorkspaceActiveOrSuspended } from 'twenty-shared/workspace';
+import {
+  isWorkspaceActiveOrSuspended,
+  WorkspaceActivationStatus,
+} from 'twenty-shared/workspace';
 import { type QueryRunner, In, IsNull, Not, Repository } from 'typeorm';
 
 import { CoreEntityCacheService } from 'src/engine/core-entity-cache/services/core-entity-cache.service';
@@ -66,11 +69,32 @@ export class UserService extends TypeOrmQueryService<UserEntity> {
     super(userRepository);
   }
 
+  async refreshWorkspaceIfPendingOrOngoingCreation<
+    TWorkspace extends Pick<WorkspaceEntity, 'id' | 'activationStatus'>,
+  >(workspace: TWorkspace): Promise<TWorkspace | WorkspaceEntity> {
+    const isPendingOrOngoingCreation =
+      workspace.activationStatus ===
+        WorkspaceActivationStatus.PENDING_CREATION ||
+      workspace.activationStatus === WorkspaceActivationStatus.ONGOING_CREATION;
+
+    if (!isPendingOrOngoingCreation) {
+      return workspace;
+    }
+
+    const freshWorkspace = await this.workspaceService.findById(workspace.id);
+
+    return freshWorkspace ?? workspace;
+  }
+
   async loadWorkspaceMember(
     user: Pick<AuthContextUser, 'id'>,
     workspace: Pick<WorkspaceEntity, 'id' | 'activationStatus'>,
   ) {
-    if (!isWorkspaceActiveOrSuspended(workspace)) {
+    // The given workspace can be a stale cache snapshot right after activateWorkspace ran on another instance (#20322)
+    const refreshedWorkspace =
+      await this.refreshWorkspaceIfPendingOrOngoingCreation(workspace);
+
+    if (!isWorkspaceActiveOrSuspended(refreshedWorkspace)) {
       return null;
     }
 
@@ -99,7 +123,11 @@ export class UserService extends TypeOrmQueryService<UserEntity> {
     workspace: Pick<WorkspaceEntity, 'id' | 'activationStatus'>,
     withDeleted = false,
   ) {
-    if (!isWorkspaceActiveOrSuspended(workspace)) {
+    // The given workspace can be a stale cache snapshot right after activateWorkspace ran on another instance (#20322)
+    const refreshedWorkspace =
+      await this.refreshWorkspaceIfPendingOrOngoingCreation(workspace);
+
+    if (!isWorkspaceActiveOrSuspended(refreshedWorkspace)) {
       return [];
     }
 

--- a/packages/twenty-server/src/engine/core-modules/user/user.resolver.ts
+++ b/packages/twenty-server/src/engine/core-modules/user/user.resolver.ts
@@ -149,8 +149,14 @@ export class UserResolver {
       return user;
     }
 
+    // The auth context workspace can be a stale cache snapshot right after activateWorkspace ran on another instance (#20322)
+    const refreshedWorkspace =
+      await this.userService.refreshWorkspaceIfPendingOrOngoingCreation(
+        workspace,
+      );
+
     const currentUserWorkspace = user.userWorkspaces.find(
-      (userWorkspace) => userWorkspace.workspaceId === workspace.id,
+      (userWorkspace) => userWorkspace.workspaceId === refreshedWorkspace.id,
     );
 
     if (!isDefined(currentUserWorkspace)) {
@@ -161,7 +167,7 @@ export class UserResolver {
       fromUserWorkspacePermissionsToUserWorkspacePermissionsDto(
         await this.getUserWorkspacePermissions({
           currentUserWorkspace,
-          workspace,
+          workspace: refreshedWorkspace,
         }),
       );
 
@@ -177,7 +183,7 @@ export class UserResolver {
         ...userWorkspacePermissions,
         twoFactorAuthenticationMethodSummary,
       },
-      currentWorkspace: workspace,
+      currentWorkspace: refreshedWorkspace,
     };
   }
 


### PR DESCRIPTION
## Context

On twenty-main (multi-replica), signing up and naming a workspace lands on a black screen at `/create/profile`; a manual refresh fixes it. From the network trace: the post-activation `currentUser` response carries `onboardingStatus: PROFILE_CREATION` (fresh) together with a non-ACTIVE `currentWorkspace` and `workspaceMember: null` (stale).

## Root cause

`activateWorkspace` invalidates the core entity cache only on the instance that served the mutation. When the follow-up `currentUser` query is routed to a sibling instance, the auth context carries a memoized pre-activation workspace snapshot. A stale transient workspace cascades:

- `workspaceMember`/`workspaceMembers` resolve to null/empty (`loadWorkspaceMember` skips non-active workspaces), permissions fall back to defaults
- the client's metadata store never loads (`MinimalMetadataLoadEffect` skips non-active workspaces), so `MinimalMetadataGater` shows the loading skeleton forever on `/create/profile`

#20322 fixed the same staleness for `onboardingStatus` by reading the workspace fresh from the database in the resolver — which is why the status is fresh while the workspace object isn't, and why the client navigates to a page it can't render.

#21480 bounds the staleness window to the designed 10s (absolute memoizer TTL), but signup lives entirely inside that window: the client reads `currentUser` ~1s after `activateWorkspace` and never refetches while stuck.

## Fix

Apply the #20322 approach at the workspace status resolution layer: `UserService.refreshWorkspaceIfPendingOrOngoingCreation` re-reads the workspace from the database when the auth-context copy is in a transient activation status (`PENDING_CREATION`/`ONGOING_CREATION`). Used in:

- `UserResolver.currentUser` — fresh `currentWorkspace` and permissions
- `UserService.loadWorkspaceMember` / `loadWorkspaceMembers` — covers the `workspaceMember`/`workspaceMembers` resolve fields

No-op for active workspaces; the extra database read only happens for workspaces mid-creation.

## Test plan

- Full `user.service.spec.ts` suite passes; lint and format clean.
- After deploy to twenty-main: sign up, name the workspace, verify `/create/profile` renders the profile form with a populated `workspaceMember` and ACTIVE `currentWorkspace` without refreshing.
