### PR TITLE
fix(front): survive web storage failures in persisted jotai atoms

### DIFF
--- a/packages/twenty-front/src/modules/ui/utilities/state/jotai/utils/__tests__/createResilientJotaiStorage.test.ts
+++ b/packages/twenty-front/src/modules/ui/utilities/state/jotai/utils/__tests__/createResilientJotaiStorage.test.ts
@@ -43,18 +43,19 @@ describe('createResilientJotaiStorage', () => {
     expect(consoleErrorSpy).not.toHaveBeenCalled();
   });
 
-  it('should not throw and should evict the key when a write fails', () => {
-    const removeItem = jest.fn();
-    const fakeStorage = buildFakeStorage({
-      setItem: () => {
-        throw new DOMException('The quota has been exceeded.');
-      },
-      removeItem,
-    });
+  it('should not throw and should clear the stored value when a write fails', () => {
+    const fakeStorage = buildFakeStorage();
     const storage = createResilientJotaiStorage<string>(() => fakeStorage);
 
-    expect(() => storage.setItem('my-key', 'value')).not.toThrow();
-    expect(removeItem).toHaveBeenCalledWith('my-key');
+    storage.setItem('my-key', 'old-value');
+    expect(storage.getItem('my-key', 'fallback')).toBe('old-value');
+
+    fakeStorage.setItem = () => {
+      throw new DOMException('The quota has been exceeded.');
+    };
+
+    expect(() => storage.setItem('my-key', 'new-value')).not.toThrow();
+    expect(storage.getItem('my-key', 'fallback')).toBe('fallback');
     expect(consoleErrorSpy).toHaveBeenCalled();
   });
 

--- a/packages/twenty-front/src/modules/ui/utilities/state/jotai/utils/__tests__/createResilientJotaiStorage.test.ts
+++ b/packages/twenty-front/src/modules/ui/utilities/state/jotai/utils/__tests__/createResilientJotaiStorage.test.ts
@@ -1,0 +1,99 @@
+import { createResilientJotaiStorage } from '@/ui/utilities/state/jotai/utils/createResilientJotaiStorage';
+
+const buildFakeStorage = (overrides: Partial<Storage> = {}): Storage => {
+  const store = new Map<string, string>();
+
+  return {
+    get length() {
+      return store.size;
+    },
+    clear: () => store.clear(),
+    getItem: (key: string) => store.get(key) ?? null,
+    key: (index: number) => [...store.keys()][index] ?? null,
+    removeItem: (key: string) => {
+      store.delete(key);
+    },
+    setItem: (key: string, value: string) => {
+      store.set(key, value);
+    },
+    ...overrides,
+  };
+};
+
+describe('createResilientJotaiStorage', () => {
+  let consoleErrorSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('should round-trip values through the underlying storage', () => {
+    const fakeStorage = buildFakeStorage();
+    const storage = createResilientJotaiStorage<{ count: number }>(
+      () => fakeStorage,
+    );
+
+    storage.setItem('my-key', { count: 2 });
+
+    expect(storage.getItem('my-key', { count: 0 })).toEqual({ count: 2 });
+    expect(consoleErrorSpy).not.toHaveBeenCalled();
+  });
+
+  it('should not throw and should evict the key when a write fails', () => {
+    const removeItem = jest.fn();
+    const fakeStorage = buildFakeStorage({
+      setItem: () => {
+        throw new DOMException('The quota has been exceeded.');
+      },
+      removeItem,
+    });
+    const storage = createResilientJotaiStorage<string>(() => fakeStorage);
+
+    expect(() => storage.setItem('my-key', 'value')).not.toThrow();
+    expect(removeItem).toHaveBeenCalledWith('my-key');
+    expect(consoleErrorSpy).toHaveBeenCalled();
+  });
+
+  it('should not throw when eviction after a failed write also fails', () => {
+    const fakeStorage = buildFakeStorage({
+      setItem: () => {
+        throw new DOMException('The quota has been exceeded.');
+      },
+      removeItem: () => {
+        throw new DOMException('Storage unavailable.');
+      },
+    });
+    const storage = createResilientJotaiStorage<string>(() => fakeStorage);
+
+    expect(() => storage.setItem('my-key', 'value')).not.toThrow();
+    expect(consoleErrorSpy).toHaveBeenCalled();
+  });
+
+  it('should fall back to the initial value when a read fails', () => {
+    const fakeStorage = buildFakeStorage({
+      getItem: () => {
+        throw new DOMException('Storage unavailable.');
+      },
+    });
+    const storage = createResilientJotaiStorage<string>(() => fakeStorage);
+
+    expect(storage.getItem('my-key', 'fallback')).toBe('fallback');
+    expect(consoleErrorSpy).toHaveBeenCalled();
+  });
+
+  it('should not throw when removing a key fails', () => {
+    const fakeStorage = buildFakeStorage({
+      removeItem: () => {
+        throw new DOMException('Storage unavailable.');
+      },
+    });
+    const storage = createResilientJotaiStorage<string>(() => fakeStorage);
+
+    expect(() => storage.removeItem('my-key')).not.toThrow();
+    expect(consoleErrorSpy).toHaveBeenCalled();
+  });
+});

--- a/packages/twenty-front/src/modules/ui/utilities/state/jotai/utils/createAtomFamilyState.ts
+++ b/packages/twenty-front/src/modules/ui/utilities/state/jotai/utils/createAtomFamilyState.ts
@@ -2,6 +2,7 @@ import { atom } from 'jotai';
 import { atomWithStorage } from 'jotai/utils';
 
 import { type FamilyState } from '@/ui/utilities/state/jotai/types/FamilyState';
+import { createResilientJotaiStorage } from '@/ui/utilities/state/jotai/utils/createResilientJotaiStorage';
 
 export const createAtomFamilyState = <ValueType, FamilyKey>({
   key,
@@ -36,7 +37,7 @@ export const createAtomFamilyState = <ValueType, FamilyKey>({
       ? atomWithStorage<ValueType>(
           atomKey,
           defaultValue,
-          undefined,
+          createResilientJotaiStorage<ValueType>(() => localStorage),
           localStorageOptions ?? undefined,
         )
       : atom(defaultValue);

--- a/packages/twenty-front/src/modules/ui/utilities/state/jotai/utils/createAtomState.ts
+++ b/packages/twenty-front/src/modules/ui/utilities/state/jotai/utils/createAtomState.ts
@@ -1,9 +1,10 @@
 import { atom, type WritableAtom } from 'jotai';
-import { atomWithStorage, createJSONStorage } from 'jotai/utils';
+import { atomWithStorage } from 'jotai/utils';
 import { isDefined } from 'twenty-shared/utils';
 
 import { type State } from '@/ui/utilities/state/jotai/types/State';
 import { createJotaiCookieStorage } from '@/ui/utilities/state/jotai/utils/createJotaiCookieStorage';
+import { createResilientJotaiStorage } from '@/ui/utilities/state/jotai/utils/createResilientJotaiStorage';
 
 type CookieStorageConfig<ValueType> = {
   cookieKey: string;
@@ -54,7 +55,9 @@ export const createAtomState = <ValueType>({
       { getOnInit: true },
     ) as StateAtom<ValueType>;
   } else if (useSessionStorage) {
-    const storage = createJSONStorage<ValueType>(() => sessionStorage);
+    const storage = createResilientJotaiStorage<ValueType>(
+      () => sessionStorage,
+    );
     baseAtom = atomWithStorage<ValueType>(key, defaultValue, storage, {
       getOnInit: true,
     }) as StateAtom<ValueType>;
@@ -62,7 +65,7 @@ export const createAtomState = <ValueType>({
     baseAtom = atomWithStorage<ValueType>(
       key,
       defaultValue,
-      undefined,
+      createResilientJotaiStorage<ValueType>(() => localStorage),
       localStorageOptions ?? undefined,
     ) as StateAtom<ValueType>;
   } else {

--- a/packages/twenty-front/src/modules/ui/utilities/state/jotai/utils/createResilientJotaiStorage.ts
+++ b/packages/twenty-front/src/modules/ui/utilities/state/jotai/utils/createResilientJotaiStorage.ts
@@ -1,0 +1,57 @@
+import { createJSONStorage } from 'jotai/utils';
+
+import { logError } from '~/utils/logError';
+
+type ResilientJotaiStorage<ValueType> = ReturnType<
+  typeof createJSONStorage<ValueType>
+>;
+
+// Web storage reads and writes can throw (quota exceeded on large workspaces,
+// privacy modes, disabled storage). Persisted atoms are caches or
+// preferences, never sources of truth, so a storage failure must degrade to
+// in-memory state instead of crashing the app — an unhandled quota error
+// during boot-time metadata persistence used to blank the whole app.
+export const createResilientJotaiStorage = <ValueType>(
+  getStringStorage: () => Storage,
+): ResilientJotaiStorage<ValueType> => {
+  const baseStorage = createJSONStorage<ValueType>(getStringStorage);
+
+  return {
+    ...baseStorage,
+    getItem: (key, initialValue) => {
+      try {
+        return baseStorage.getItem(key, initialValue);
+      } catch (error) {
+        logError(
+          `Failed to read "${key}" from storage; falling back to the initial value. ${error}`,
+        );
+
+        return initialValue;
+      }
+    },
+    setItem: (key, newValue) => {
+      try {
+        baseStorage.setItem(key, newValue);
+      } catch (error) {
+        // Evict the key so an oversized stale copy doesn't linger and its
+        // space is freed for other keys; state stays in memory this session.
+        try {
+          baseStorage.removeItem(key);
+        } catch {
+          // Storage is unavailable altogether; nothing left to clean up.
+        }
+
+        logError(
+          `Failed to persist "${key}" to storage; continuing with in-memory state only. ${error}`,
+        );
+      }
+    },
+    removeItem: (key) => {
+      try {
+        baseStorage.removeItem(key);
+      } catch (error) {
+        logError(`Failed to remove "${key}" from storage. ${error}`);
+      }
+    },
+  };
+};


### PR DESCRIPTION
## Context

Persisted atoms created via `createAtomState` / `createAtomFamilyState` with `useLocalStorage` (or `useSessionStorage`) hand jotai's `atomWithStorage` the default JSON storage, whose `setItem` doesn't catch exceptions. Web storage writes can legitimately throw — most notably `QuotaExceededError` once the origin's ~5 MB localStorage budget is exhausted.

The metadata store persists every collection (`metadataStoreState__objectMetadataItems`, `__fieldMetadataItems`, `__views`, `__pageLayoutWidgets`, …) through this path, each entry holding both a `current` and a `draft` copy. On a metadata-heavy workspace (many custom objects, fields, views) the boot-time write from `loadStaleMetadataEntities` can tip the origin over quota. The `DOMException` escapes as an unhandled rejection and authenticated boot dies on a blank page:

```
Uncaught (in promise) DOMException: The quota has been exceeded.
    setItem …
    loadStaleMetadataEntities …
```

What users experience: the sign-in page renders fine, the app after login is blank, a private window works (empty storage), and a hard refresh doesn't help (storage is untouched). Reproduced on a real workspace whose metadata had grown past the quota; any sufficiently large workspace can hit this.

## What this does

Adds `createResilientJotaiStorage`, a thin wrapper around jotai's `createJSONStorage`, and uses it for the localStorage and sessionStorage branches of `createAtomState` / `createAtomFamilyState`:

- a failed read logs and falls back to the atom's initial value
- a failed write logs, evicts the key (so an oversized stale copy doesn't linger and its space is freed), and continues with in-memory state
- a failed removal logs and is swallowed

Persisted atoms are caches or preferences, never sources of truth, so degrading to in-memory state is always safe. After the eviction frees space, subsequent writes typically succeed again, so the recovery is self-healing rather than permanently disabling persistence.

## Notes

- Cookie-backed storage (`createJotaiCookieStorage`) is untouched — it has its own implementation.
- 5 unit tests cover round-trip, write failure (eviction + no throw), eviction failure, read failure, and removal failure.


Closes #21503
