### PR TITLE
fix: resolve timeline crashes by cleaning orphan message association

### DIFF
--- a/packages/twenty-server/src/engine/core-modules/messaging/services/timeline-messaging.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/messaging/services/timeline-messaging.service.ts
@@ -225,6 +225,15 @@ export class TimelineMessagingService {
 
     return this.globalWorkspaceOrmManager.executeInWorkspaceContext(
       async () => {
+        const threadVisibilityByThreadId: {
+          [key: string]: MessageChannelVisibility;
+        } = {};
+
+        for (const threadId of messageThreadIds) {
+          threadVisibilityByThreadId[threadId] =
+            MessageChannelVisibility.METADATA;
+        }
+
         const workspaceMemberRepository =
           await this.globalWorkspaceOrmManager.getRepository<WorkspaceMemberWorkspaceEntity>(
             workspaceId,
@@ -238,7 +247,7 @@ export class TimelineMessagingService {
         });
 
         if (!currentMember) {
-          return {};
+          return threadVisibilityByThreadId;
         }
 
         const currentUserWorkspace = await this.userWorkspaceRepository.findOne(
@@ -249,7 +258,7 @@ export class TimelineMessagingService {
         );
 
         if (!currentUserWorkspace) {
-          return {};
+          return threadVisibilityByThreadId;
         }
 
         const currentUserWorkspaceId = currentUserWorkspace.id;
@@ -286,7 +295,7 @@ export class TimelineMessagingService {
         ];
 
         if (allMessageChannelIds.length === 0) {
-          return {};
+          return threadVisibilityByThreadId;
         }
 
         const messageChannels = await this.messageChannelRepository.find({
@@ -322,10 +331,6 @@ export class TimelineMessagingService {
         );
 
         const visibilityValues = Object.values(MessageChannelVisibility);
-
-        const threadVisibilityByThreadId: {
-          [key: string]: MessageChannelVisibility;
-        } = {};
 
         for (const { id: threadId, messageChannelId } of threadChannelRows) {
           if (!messageChannelId) continue;

--- a/packages/twenty-server/src/engine/core-modules/messaging/utils/format-threads.util.ts
+++ b/packages/twenty-server/src/engine/core-modules/messaging/utils/format-threads.util.ts
@@ -1,10 +1,10 @@
 import { FIELD_RESTRICTED_ADDITIONAL_PERMISSIONS_REQUIRED } from 'twenty-shared/constants';
 import { isDefined } from 'twenty-shared/utils';
 
-import { MessageChannelVisibility } from 'twenty-shared/types';
 import { type TimelineThreadDTO } from 'src/engine/core-modules/messaging/dtos/timeline-thread.dto';
 import { extractParticipantSummary } from 'src/engine/core-modules/messaging/utils/extract-participant-summary.util';
 import { type MessageParticipantWorkspaceEntity } from 'src/modules/messaging/common/standard-objects/message-participant.workspace-entity';
+import { MessageChannelVisibility } from 'twenty-shared/types';
 
 export const formatThreads = (
   threads: Omit<
@@ -25,7 +25,9 @@ export const formatThreads = (
   return threads
     .filter((thread) => isDefined(threadParticipantsByThreadId[thread.id]))
     .map((thread) => {
-      const visibility = threadVisibilityByThreadId[thread.id];
+      const visibility =
+        threadVisibilityByThreadId[thread.id] ??
+        MessageChannelVisibility.METADATA;
 
       return {
         ...thread,

--- a/packages/twenty-server/src/modules/messaging/common/query-hooks/message/apply-messages-visibility-restrictions.service.ts
+++ b/packages/twenty-server/src/modules/messaging/common/query-hooks/message/apply-messages-visibility-restrictions.service.ts
@@ -7,7 +7,6 @@ import { MessageChannelVisibility } from 'twenty-shared/types';
 import { isDefined } from 'twenty-shared/utils';
 import { In, Repository } from 'typeorm';
 
-import { NotFoundError } from 'src/engine/core-modules/graphql/utils/graphql-errors.util';
 import { UserWorkspaceEntity } from 'src/engine/core-modules/user-workspace/user-workspace.entity';
 import { ConnectedAccountEntity } from 'src/engine/metadata-modules/connected-account/entities/connected-account.entity';
 import { MessageChannelEntity } from 'src/engine/metadata-modules/message-channel/entities/message-channel.entity';
@@ -90,7 +89,10 @@ export class ApplyMessagesVisibilityRestrictionsService {
             .filter(isDefined);
 
           if (messageChannels.length === 0) {
-            throw new NotFoundError('Associated message channels not found');
+            messages[i].subject =
+              FIELD_RESTRICTED_ADDITIONAL_PERMISSIONS_REQUIRED;
+            messages[i].text = FIELD_RESTRICTED_ADDITIONAL_PERMISSIONS_REQUIRED;
+            continue;
           }
 
           const messageChannelsGroupByVisibility = groupBy(

--- a/packages/twenty-server/src/modules/messaging/message-cleaner/jobs/messaging-connected-account-deletion-cleanup.job.ts
+++ b/packages/twenty-server/src/modules/messaging/message-cleaner/jobs/messaging-connected-account-deletion-cleanup.job.ts
@@ -23,6 +23,9 @@ export class MessagingConnectedAccountDeletionCleanupJob {
   async handle(
     data: MessagingConnectedAccountDeletionCleanupJobData,
   ): Promise<void> {
+    await this.messageCleanerService.deleteOrphanMessageChannelMessageAssociations(
+      data.workspaceId,
+    );
     await this.messageCleanerService.cleanOrphanMessagesAndThreads(
       data.workspaceId,
     );

--- a/packages/twenty-server/src/modules/messaging/message-cleaner/services/messaging-message-cleaner.service.ts
+++ b/packages/twenty-server/src/modules/messaging/message-cleaner/services/messaging-message-cleaner.service.ts
@@ -190,6 +190,79 @@ export class MessagingMessageCleanerService {
     );
   }
 
+  public async deleteOrphanMessageChannelMessageAssociations(
+    workspaceId: string,
+  ) {
+    const authContext = buildSystemAuthContext(workspaceId);
+
+    await this.globalWorkspaceOrmManager.executeInWorkspaceContext(
+      async () => {
+        const messageChannelMessageAssociationRepository =
+          await this.globalWorkspaceOrmManager.getRepository<MessageChannelMessageAssociationWorkspaceEntity>(
+            workspaceId,
+            'messageChannelMessageAssociation',
+          );
+
+        const workspaceDataSource =
+          await this.globalWorkspaceOrmManager.getGlobalWorkspaceDataSource();
+
+        await workspaceDataSource.transaction(async (manager) => {
+          const transactionManager = manager as WorkspaceEntityManager;
+
+          await deleteUsingPagination(
+            workspaceId,
+            500,
+            async (
+              limit: number,
+              offset: number,
+              _workspaceId: string,
+              transactionManager?: WorkspaceEntityManager,
+            ) => {
+              if (!transactionManager) {
+                throw new Error(
+                  'transactionManager is required for orphan association cleanup',
+                );
+              }
+
+              const orphanedAssociations = await transactionManager
+                .createQueryBuilder(
+                  MessageChannelMessageAssociationWorkspaceEntity,
+                  'messageChannelMessageAssociation',
+                )
+                .leftJoin(
+                  'core.messageChannel',
+                  'messageChannel',
+                  'messageChannel.id = messageChannelMessageAssociation."messageChannelId"',
+                )
+                .where('messageChannel.id IS NULL')
+                .take(limit)
+                .skip(offset)
+                .getMany();
+
+              return orphanedAssociations.map(({ id }) => id);
+            },
+            async (
+              ids: string[],
+              _workspaceId: string,
+              transactionManager?: WorkspaceEntityManager,
+            ) => {
+              this.logger.debug(
+                `WorkspaceId: ${workspaceId} Deleting ${ids.length} orphaned message channel associations`,
+              );
+              await messageChannelMessageAssociationRepository.delete(
+                ids,
+                transactionManager,
+              );
+            },
+            transactionManager,
+          );
+        });
+      },
+      authContext,
+      { lite: true },
+    );
+  }
+
   public async cleanOrphanMessagesAndThreads(workspaceId: string) {
     const authContext = buildSystemAuthContext(workspaceId);
 
@@ -210,81 +283,81 @@ export class MessagingMessageCleanerService {
         const workspaceDataSource =
           await this.globalWorkspaceOrmManager.getGlobalWorkspaceDataSource();
 
-        await workspaceDataSource.transaction(
-          async (transactionManager: WorkspaceEntityManager) => {
-            await deleteUsingPagination(
-              workspaceId,
-              500,
-              async (
-                limit: number,
-                offset: number,
-                _workspaceId: string,
-                transactionManager: WorkspaceEntityManager,
-              ) => {
-                const nonAssociatedMessages = await messageRepository.find(
-                  {
-                    where: {
-                      messageChannelMessageAssociations: {
-                        id: IsNull(),
-                      },
+        await workspaceDataSource.transaction(async (manager) => {
+          const transactionManager = manager as WorkspaceEntityManager;
+
+          await deleteUsingPagination(
+            workspaceId,
+            500,
+            async (
+              limit: number,
+              offset: number,
+              _workspaceId: string,
+              transactionManager?: WorkspaceEntityManager,
+            ) => {
+              const nonAssociatedMessages = await messageRepository.find(
+                {
+                  where: {
+                    messageChannelMessageAssociations: {
+                      id: IsNull(),
                     },
-                    take: limit,
-                    skip: offset,
-                    relations: ['messageChannelMessageAssociations'],
                   },
-                  transactionManager,
-                );
+                  take: limit,
+                  skip: offset,
+                  relations: ['messageChannelMessageAssociations'],
+                },
+                transactionManager,
+              );
 
-                return nonAssociatedMessages.map(({ id }) => id);
-              },
-              async (
-                ids: string[],
-                workspaceId: string,
-                transactionManager?: WorkspaceEntityManager,
-              ) => {
-                this.logger.debug(
-                  `WorkspaceId: ${workspaceId} Deleting ${ids.length} messages from message cleaner`,
-                );
-                await messageRepository.delete(ids, transactionManager);
-              },
-              transactionManager,
-            );
+              return nonAssociatedMessages.map(({ id }) => id);
+            },
+            async (
+              ids: string[],
+              workspaceId: string,
+              transactionManager?: WorkspaceEntityManager,
+            ) => {
+              this.logger.debug(
+                `WorkspaceId: ${workspaceId} Deleting ${ids.length} messages from message cleaner`,
+              );
+              await messageRepository.delete(ids, transactionManager);
+            },
+            transactionManager,
+          );
 
-            await deleteUsingPagination(
-              workspaceId,
-              500,
-              async (
-                limit: number,
-                offset: number,
-                _workspaceId: string,
-                transactionManager?: WorkspaceEntityManager,
-              ) => {
-                const orphanThreads = await messageThreadRepository.find(
-                  {
-                    where: {
-                      messages: {
-                        id: IsNull(),
-                      },
+          await deleteUsingPagination(
+            workspaceId,
+            500,
+            async (
+              limit: number,
+              offset: number,
+              _workspaceId: string,
+              transactionManager?: WorkspaceEntityManager,
+            ) => {
+              const orphanThreads = await messageThreadRepository.find(
+                {
+                  where: {
+                    messages: {
+                      id: IsNull(),
                     },
-                    take: limit,
-                    skip: offset,
                   },
-                  transactionManager,
-                );
+                  take: limit,
+                  skip: offset,
+                },
+                transactionManager,
+              );
 
-                return orphanThreads.map(({ id }) => id);
-              },
-              async (
-                ids: string[],
-                _workspaceId: string,
-                transactionManager?: WorkspaceEntityManager,
-              ) => {
-                await messageThreadRepository.delete(ids, transactionManager);
-              },
-              transactionManager,
-            );
-          },
-        );
+              return orphanThreads.map(({ id }) => id);
+            },
+            async (
+              ids: string[],
+              _workspaceId: string,
+              transactionManager?: WorkspaceEntityManager,
+            ) => {
+              await messageThreadRepository.delete(ids, transactionManager);
+            },
+            transactionManager,
+          );
+        });
       },
       authContext,
       { lite: true },


### PR DESCRIPTION
Deleting an IMAP account in Twenty triggers a cascade delete for the messageChannel, but it doesn't clean up the junction table (messageChannelMessageAssociation). This leaves behind "ghost" rows pointing to deleted channels.

This caused two crashes:

1. GraphQL queries for message visibility were failing because they couldn't find a channel for the message.
2. The ApplyMessagesVisibilityRestrictions hook was throwing an error whenever it hit one of these orphaned messages, which caused the entire UI view to fail instead of just skipping the bad row.

The Fix:

- Cleanup Job: I added a cleanup step to MessagingConnectedAccountDeletionCleanupJob that deletes any messageChannelMessageAssociation rows that point to a non-existent channel. This happens during account deletion.
- Defensive Logic: I updated the visibility services to handle missing channels gracefully. Instead of throwing an error or returning undefined, it now defaults to METADATA visibility or obfuscates the message data. This keeps the UI working even if the database is in a bad state.

This prevents the "All Messages" and "Email" tabs from crashing after re-adding accounts.


closes #21425