### PR TITLE
fix: prevent duplicate workflow job from ending an active run mid-iteration (#21408)

### DIFF
--- a/packages/twenty-server/src/modules/workflow/workflow-runner/jobs/__tests__/run-workflow.job.spec.ts
+++ b/packages/twenty-server/src/modules/workflow/workflow-runner/jobs/__tests__/run-workflow.job.spec.ts
@@ -29,12 +29,10 @@ describe('RunWorkflowJob', () => {
 
   beforeEach(async () => {
     workflowRunWorkspaceService = {
-      getWorkflowRunOrFail: jest
-        .fn()
-        .mockResolvedValue({
-          status: WorkflowRunStatus.ENQUEUED,
-          workflowVersionId,
-        }),
+      getWorkflowRunOrFail: jest.fn().mockResolvedValue({
+        status: WorkflowRunStatus.ENQUEUED,
+        workflowVersionId,
+      }),
       startWorkflowRun: jest.fn(),
       endWorkflowRun: jest.fn(),
     } as any;

--- a/packages/twenty-server/src/modules/workflow/workflow-runner/jobs/__tests__/run-workflow.job.spec.ts
+++ b/packages/twenty-server/src/modules/workflow/workflow-runner/jobs/__tests__/run-workflow.job.spec.ts
@@ -1,0 +1,123 @@
+import { Test, type TestingModule } from '@nestjs/testing';
+
+import { MetricsService } from 'src/engine/core-modules/metrics/metrics.service';
+import { GlobalWorkspaceOrmManager } from 'src/engine/twenty-orm/global-workspace-datasource/global-workspace-orm.manager';
+import { WorkflowRunStatus } from 'src/modules/workflow/common/standard-objects/workflow-run.workspace-entity';
+import { WorkflowCommonWorkspaceService } from 'src/modules/workflow/common/workspace-services/workflow-common.workspace-service';
+import { CodeStepBuildService } from 'src/modules/workflow/workflow-builder/workflow-version-step/code-step/services/code-step-build.service';
+import { WorkflowExecutorWorkspaceService } from 'src/modules/workflow/workflow-executor/workspace-services/workflow-executor.workspace-service';
+import { RunWorkflowJob } from 'src/modules/workflow/workflow-runner/jobs/run-workflow.job';
+import { WorkflowRunWorkspaceService } from 'src/modules/workflow/workflow-runner/workflow-run/workflow-run.workspace-service';
+import { WorkflowTriggerType } from 'src/modules/workflow/workflow-trigger/types/workflow-trigger.type';
+
+describe('RunWorkflowJob', () => {
+  let job: RunWorkflowJob;
+  let workflowRunWorkspaceService: jest.Mocked<WorkflowRunWorkspaceService>;
+  let workflowCommonWorkspaceService: jest.Mocked<WorkflowCommonWorkspaceService>;
+  let workflowExecutorWorkspaceService: jest.Mocked<WorkflowExecutorWorkspaceService>;
+  let codeStepBuildService: jest.Mocked<CodeStepBuildService>;
+  let metricsService: jest.Mocked<MetricsService>;
+
+  const workflowRunId = 'workflow-run-1';
+  const workspaceId = 'workspace-1';
+  const workflowVersionId = 'workflow-version-1';
+
+  const workflowVersion = {
+    trigger: { type: WorkflowTriggerType.MANUAL, nextStepIds: ['step-1'] },
+    steps: [{ id: 'step-1' }],
+  };
+
+  beforeEach(async () => {
+    workflowRunWorkspaceService = {
+      getWorkflowRunOrFail: jest
+        .fn()
+        .mockResolvedValue({
+          status: WorkflowRunStatus.ENQUEUED,
+          workflowVersionId,
+        }),
+      startWorkflowRun: jest.fn(),
+      endWorkflowRun: jest.fn(),
+    } as any;
+
+    workflowCommonWorkspaceService = {
+      getWorkflowVersionOrFail: jest.fn().mockResolvedValue(workflowVersion),
+    } as any;
+
+    workflowExecutorWorkspaceService = {
+      executeFromSteps: jest.fn(),
+    } as any;
+
+    codeStepBuildService = {
+      buildCodeStepsFromSourceForSteps: jest.fn(),
+    } as any;
+
+    metricsService = {
+      incrementCounterForEvent: jest.fn(),
+    } as any;
+
+    const globalWorkspaceOrmManager = {
+      executeInWorkspaceContext: jest.fn((callback: () => Promise<void>) =>
+        callback(),
+      ),
+    } as unknown as GlobalWorkspaceOrmManager;
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        RunWorkflowJob,
+        {
+          provide: WorkflowCommonWorkspaceService,
+          useValue: workflowCommonWorkspaceService,
+        },
+        { provide: CodeStepBuildService, useValue: codeStepBuildService },
+        {
+          provide: WorkflowExecutorWorkspaceService,
+          useValue: workflowExecutorWorkspaceService,
+        },
+        {
+          provide: WorkflowRunWorkspaceService,
+          useValue: workflowRunWorkspaceService,
+        },
+        { provide: MetricsService, useValue: metricsService },
+        {
+          provide: GlobalWorkspaceOrmManager,
+          useValue: globalWorkspaceOrmManager,
+        },
+      ],
+    }).compile();
+
+    job = await module.resolve<RunWorkflowJob>(RunWorkflowJob);
+  });
+
+  it('executes the workflow steps when it wins the start race', async () => {
+    workflowRunWorkspaceService.startWorkflowRun.mockResolvedValue(true);
+
+    await job.handle({ workflowRunId, workspaceId });
+
+    expect(
+      workflowExecutorWorkspaceService.executeFromSteps,
+    ).toHaveBeenCalledWith({
+      stepIds: ['step-1'],
+      workflowRunId,
+      workspaceId,
+    });
+    expect(workflowRunWorkspaceService.endWorkflowRun).not.toHaveBeenCalled();
+  });
+
+  it('bails out without failing the run when another job already started it', async () => {
+    // Simulate the TOCTOU race: the unlocked pre-check still sees ENQUEUED,
+    // but by the time the locked startWorkflowRun runs another job has already
+    // moved the run to RUNNING, so it returns false.
+    workflowRunWorkspaceService.startWorkflowRun.mockResolvedValue(false);
+
+    await job.handle({ workflowRunId, workspaceId });
+
+    // The late job must not execute steps...
+    expect(
+      workflowExecutorWorkspaceService.executeFromSteps,
+    ).not.toHaveBeenCalled();
+    // ...and must NOT end the run that the winning job is actively executing
+    // (this is what produced "Workflow has been ended before this step was
+    // completed" on a RUNNING iterator step).
+    expect(workflowRunWorkspaceService.endWorkflowRun).not.toHaveBeenCalled();
+  });
+});

--- a/packages/twenty-server/src/modules/workflow/workflow-runner/jobs/run-workflow.job.ts
+++ b/packages/twenty-server/src/modules/workflow/workflow-runner/jobs/run-workflow.job.ts
@@ -120,7 +120,12 @@ export class RunWorkflowJob {
     if (!hasStarted) {
       // A concurrent RunWorkflowJob already started this run. Bail out so we
       // don't execute its steps twice (and so we don't end a run that another
-      // job is actively executing).
+      // job is actively executing). Logged so duplicate enqueue / lock
+      // contention stays observable in production.
+      this.logger.warn(
+        `Skipping workflow run ${workflowRunId} in workspace ${workspaceId}: already started by another job.`,
+      );
+
       return;
     }
 

--- a/packages/twenty-server/src/modules/workflow/workflow-runner/jobs/run-workflow.job.ts
+++ b/packages/twenty-server/src/modules/workflow/workflow-runner/jobs/run-workflow.job.ts
@@ -112,10 +112,17 @@ export class RunWorkflowJob {
       steps: workflowVersion.steps,
     });
 
-    await this.workflowRunWorkspaceService.startWorkflowRun({
+    const hasStarted = await this.workflowRunWorkspaceService.startWorkflowRun({
       workflowRunId,
       workspaceId,
     });
+
+    if (!hasStarted) {
+      // A concurrent RunWorkflowJob already started this run. Bail out so we
+      // don't execute its steps twice (and so we don't end a run that another
+      // job is actively executing).
+      return;
+    }
 
     await this.incrementTriggerMetrics({
       workflowRunId,

--- a/packages/twenty-server/src/modules/workflow/workflow-runner/workflow-run/workflow-run.workspace-service.ts
+++ b/packages/twenty-server/src/modules/workflow/workflow-runner/workflow-run/workflow-run.workspace-service.ts
@@ -146,7 +146,7 @@ export class WorkflowRunWorkspaceService {
   }: {
     workflowRunId: string;
     workspaceId: string;
-  }) {
+  }): Promise<boolean> {
     const workflowRunToUpdate = await this.getWorkflowRunOrFail({
       workflowRunId,
       workspaceId,
@@ -156,10 +156,14 @@ export class WorkflowRunWorkspaceService {
       workflowRunToUpdate.status !== WorkflowRunStatus.ENQUEUED &&
       workflowRunToUpdate.status !== WorkflowRunStatus.NOT_STARTED
     ) {
-      throw new WorkflowRunException(
-        'Workflow run is not enqueued or not started',
-        WorkflowRunExceptionCode.INVALID_OPERATION,
-      );
+      // Another RunWorkflowJob already started this run. This can happen when a
+      // duplicate/late job is processed for the same workflowRunId. We must not
+      // throw here: the throw used to bubble up to RunWorkflowJob.handle()'s
+      // catch block and end the whole run as FAILED, which rewrote the
+      // already-RUNNING steps (e.g. an iterator mid-loop) to
+      // "Workflow has been ended before this step was completed".
+      // Returning false lets the late job bail out without side effects.
+      return false;
     }
 
     const partialUpdate = {
@@ -179,6 +183,8 @@ export class WorkflowRunWorkspaceService {
     };
 
     await this.updateWorkflowRun({ workflowRunId, workspaceId, partialUpdate });
+
+    return true;
   }
 
   @WithLock('workflowRunId')


### PR DESCRIPTION
## Fixes #21408

### Problem
Iterator-based workflows (e.g. `Schedule -> Search Records -> Iterator -> Create Record`) fail with `Workflow has been ended before this step was completed`, killing the run mid-loop before the downstream actions run.

### Root cause
That error string is only produced by `markRunningStepsAsFailed()` inside `endWorkflowRun()`, which rewrites every `RUNNING`/`PENDING` step to `FAILED`. The iterator step is intentionally kept `RUNNING` while it loops (`shouldRemainRunning`), so it is exactly the step that gets clobbered.

`RunWorkflowJob.handle()` wraps `startWorkflowExecution()` in a catch-all that calls `endWorkflowRun(..., FAILED, isSystemError)` on **any** throw. The pre-check in `startWorkflowExecution()` is unlocked, but `startWorkflowRun()` (`@WithLock`) **threw** `INVALID_OPERATION` when the run was no longer `ENQUEUED/NOT_STARTED` - a TOCTOU race. When a duplicate/late `RunWorkflowJob` is processed for the same `workflowRunId`:

1. job A wins the lock, sets the run `RUNNING`, and starts the iterator loop;
2. job B passes the unlocked pre-check, then throws `INVALID_OPERATION` inside the lock;
3. the catch-all ends the whole run as `FAILED`, rewriting job A's actively-running iterator step to the reported error.

(The `#16314` enqueue lock only serializes enqueueing per workspace; it does not make this start path idempotent, so the failure mode is still reachable on `main`.)

### Fix
- `startWorkflowRun()` now returns a `boolean` and **returns `false` instead of throwing** when the run is already past `ENQUEUED/NOT_STARTED`.
- `RunWorkflowJob.startWorkflowExecution()` bails out when `startWorkflowRun()` returns `false`, so a duplicate/late job neither double-executes steps nor force-fails an active run.

### Tests
- Added `run-workflow.job.spec.ts` with regression coverage for the start-race bail-out (asserts the late job does not execute steps and does not end the run).
- Ran the full `src/modules/workflow/` suite locally: **48 suites / 498 tests pass**.

### Note for maintainers
@thomtrp - you mentioned it fails *every* time, which is unusual for a pure race. Code paths outside `executeStep()`'s try/catch can also throw deterministically and surface as this same message through the same catch-all; the `Uncompiled message ... compile your catalog` log flood in the report may be a deterministic trigger. Happy to follow up if you can share full server logs from before the flood for one failing run.
