### PR TITLE
feat(front): add DEL/Backspace keyboard shortcut to delete selected records

### DIFF
--- a/packages/twenty-front/src/modules/keyboard-shortcut-menu/constants/KeyboardShortcutsTable.ts
+++ b/packages/twenty-front/src/modules/keyboard-shortcut-menu/constants/KeyboardShortcutsTable.ts
@@ -22,4 +22,10 @@ export const KEYBOARD_SHORTCUTS_TABLE: Shortcut[] = [
     firstHotKey: 'esc',
     areSimultaneous: true,
   },
+  {
+    label: 'Delete selected records',
+    type: ShortcutType.Table,
+    firstHotKey: 'del',
+    areSimultaneous: true,
+  },
 ];

--- a/packages/twenty-front/src/modules/object-record/record-table/record-table-row/hooks/useRecordTableRowHotkeys.ts
+++ b/packages/twenty-front/src/modules/object-record/record-table/record-table-row/hooks/useRecordTableRowHotkeys.ts
@@ -1,4 +1,5 @@
 import { useOpenRecordInSidePanel } from '@/side-panel/hooks/useOpenRecordInSidePanel';
+import { useDeleteManyRecords } from '@/object-record/hooks/useDeleteManyRecords';
 import { useRecordTableContextOrThrow } from '@/object-record/record-table/contexts/RecordTableContext';
 import { useRecordTableRowContextOrThrow } from '@/object-record/record-table/contexts/RecordTableRowContext';
 import { useResetTableRowSelection } from '@/object-record/record-table/hooks/internal/useResetTableRowSelection';
@@ -9,6 +10,7 @@ import { useFocusRecordTableCell } from '@/object-record/record-table/record-tab
 import { getRecordTableCellFocusId } from '@/object-record/record-table/record-table-cell/utils/getRecordTableCellFocusId';
 import { useSetCurrentRowSelected } from '@/object-record/record-table/record-table-row/hooks/useSetCurrentRowSelected';
 import { isAtLeastOneTableRowSelectedSelector } from '@/object-record/record-table/record-table-row/states/isAtLeastOneTableRowSelectedSelector';
+import { selectedRowIdsComponentSelector } from '@/object-record/record-table/states/selectors/selectedRowIdsComponentSelector';
 import { isRecordTableRowFocusActiveComponentState } from '@/object-record/record-table/states/isRecordTableRowFocusActiveComponentState';
 import { usePushFocusItemToFocusStack } from '@/ui/utilities/focus/hooks/usePushFocusItemToFocusStack';
 import { FocusComponentType } from '@/ui/utilities/focus/types/FocusComponentType';
@@ -131,6 +133,37 @@ export const useRecordTableRowHotkeys = (focusId: string) => {
     callback: handleEscape,
     focusId,
     dependencies: [handleEscape],
+  });
+
+  const selectedRowIds = useAtomComponentSelectorValue(
+    selectedRowIdsComponentSelector,
+    recordTableId,
+  );
+
+  const { deleteManyRecords } = useDeleteManyRecords({
+    objectNameSingular,
+  });
+
+  const handleDeleteSelectedRecords = async () => {
+    if (!isAtLeastOneRecordSelected || selectedRowIds.length === 0) {
+      return;
+    }
+
+    await deleteManyRecords({
+      recordIdsToDelete: selectedRowIds,
+    });
+
+    resetTableRowSelection();
+  };
+
+  useHotkeysOnFocusedElement({
+    keys: [Key.Delete, Key.Backspace],
+    callback: handleDeleteSelectedRecords,
+    focusId,
+    dependencies: [handleDeleteSelectedRecords],
+    options: {
+      enableOnFormTags: false,
+    },
   });
 
   const { selectAllRows } = useSelectAllRows();


### PR DESCRIPTION
## Summary

Adds keyboard shortcut support for deleting selected records in table view using the DEL or Backspace key.

Closes #21275

## Changes

- Added `Delete` and `Backspace` key handler in `useRecordTableRowHotkeys` hook
- Guard prevents firing when user is typing inside an input field (`enableOnFormTags: false`)
- Uses existing `useDeleteManyRecords` hook for the actual deletion
- Resets row selection after deletion completes
- Added "Delete selected records" entry to the keyboard shortcuts menu (`KeyboardShortcutsTable`)

## Implementation details

- The hotkey is scoped to the focused row element, following the existing pattern used by `x` (select), `Escape` (clear selection), `Ctrl+A` (select all), etc.
- `selectedRowIdsComponentSelector` is used to get all currently selected record IDs
- Only triggers when `isAtLeastOneRecordSelected` is true and `selectedRowIds` is non-empty
- Reuses the `objectNameSingular` already available from the row context

## Testing

- Select one or multiple records in a table view using `x` key or checkboxes
- Press `Delete` (Windows/Linux) or `Backspace` (macOS)
- Selected records should be soft-deleted with optimistic UI update
- Selection is reset after deletion
- Key should NOT trigger when typing in search bars or input fields

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/21474?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

