### PR TITLE
fix(server): convert amountMicros to display value in formatResult

### DIFF
--- a/packages/twenty-server/src/engine/twenty-orm/utils/format-result.util.ts
+++ b/packages/twenty-server/src/engine/twenty-orm/utils/format-result.util.ts
@@ -301,7 +301,11 @@ function formatCompositeFieldValue(
     case FieldMetadataType.CURRENCY: {
       if (compositePropertyName === 'amountMicros') {
         if (isNonEmptyString(value)) {
-          return parseInt(value);
+          return parseInt(value) / 1_000_000;
+        }
+
+        if (typeof value === 'number') {
+          return value / 1_000_000;
         }
 
         return value;


### PR DESCRIPTION
## Summary

Fixes #21419

The AI assistant ("Ask AI" chat) displayed CURRENCY field values **1000× too large** because `formatCompositeFieldValue` returned raw `amountMicros` without converting back to the display unit.

## Root Cause

`amountMicros` is stored as `value × 1,000,000` (e.g. 656,788 CZK stored as `656788000000`). The `formatCompositeFieldValue` function in `format-result.util.ts` returned `parseInt(value)` directly without dividing by `1,000,000`, so the AI assistant received and displayed the raw micros value.

The rest of the app (UI, REST/GraphQL API, PDF rendering) already handles this conversion correctly — only the AI assistant serialization path was affected.

## Changes

- **`packages/twenty-server/src/engine/twenty-orm/utils/format-result.util.ts`**: Divide `amountMicros` by `1,000,000` when the value is a string (`parseInt`) or a number, returning the correct display value to the AI assistant.

## Test Plan

- [x] Verified the conversion factor matches the rest of the codebase (`turnRecordFilterIntoGqlOperationFilter.ts` multiplies by `1,000,000` on input, so divide by `1,000,000` on output is correct)
- [ ] Manual test: create an Opportunity with a known CURRENCY amount, ask the AI assistant "What is the largest opportunity amount?", confirm it reports the correct value
- [ ] Existing integration tests pass

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/21477?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

