### PR TITLE
Fix missing WasIntroducedInUpgrade for overridable view entity

### DIFF
--- a/packages/twenty-server/src/engine/metadata-modules/view/entities/view.entity.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/view/entities/view.entity.ts
@@ -22,6 +22,7 @@ import {
   ViewVisibility,
 } from 'twenty-shared/types';
 
+import { WasIntroducedInUpgrade } from 'src/engine/core-modules/upgrade/decorators/was-introduced-in-upgrade.decorator';
 import { UserWorkspaceEntity } from 'src/engine/core-modules/user-workspace/user-workspace.entity';
 import { FieldMetadataEntity } from 'src/engine/metadata-modules/field-metadata/field-metadata.entity';
 import { ObjectMetadataEntity } from 'src/engine/metadata-modules/object-metadata/object-metadata.entity';
@@ -236,3 +237,13 @@ export class ViewEntity
   )
   viewFilterGroups: Relation<ViewFilterGroupEntity[]>;
 }
+
+const VIEW_OVERRIDABLE_COLUMNS_UPGRADE_COMMAND_NAME =
+  '2.12.0_ViewOverridableEntityFastInstanceCommand_1781114009075';
+
+WasIntroducedInUpgrade({
+  upgradeCommandName: VIEW_OVERRIDABLE_COLUMNS_UPGRADE_COMMAND_NAME,
+})(ViewEntity.prototype, 'overrides');
+WasIntroducedInUpgrade({
+  upgradeCommandName: VIEW_OVERRIDABLE_COLUMNS_UPGRADE_COMMAND_NAME,
+})(ViewEntity.prototype, 'isActive');


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/21483?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

