### PR TITLE
fix(phones-field): wire defaultCountryCode setting into phone input

### DIFF
--- a/packages/twenty-front/src/modules/object-record/record-field/ui/meta-types/input/components/PhonesFieldInput.tsx
+++ b/packages/twenty-front/src/modules/object-record/record-field/ui/meta-types/input/components/PhonesFieldInput.tsx
@@ -87,7 +87,7 @@ export const PhonesFieldInput = () => {
   const phones = createPhonesFromFieldValue(draftValue);
 
   const defaultCountry =
-  fieldDefinition?.metadata?.settings?.defaultCountryCode ??
+  fieldDefinition?.metadata?.settings?.defaultCountryCode ||
   stripSimpleQuotesFromString(
     fieldDefinition?.defaultValue?.primaryPhoneCountryCode,
   );

--- a/packages/twenty-front/src/modules/object-record/record-field/ui/meta-types/input/components/PhonesFieldInput.tsx
+++ b/packages/twenty-front/src/modules/object-record/record-field/ui/meta-types/input/components/PhonesFieldInput.tsx
@@ -1,10 +1,10 @@
-import { t } from '@lingui/core/macro';
 import { usePhonesField } from '@/object-record/record-field/ui/meta-types/hooks/usePhonesField';
 import { PhonesFieldMenuItem } from '@/object-record/record-field/ui/meta-types/input/components/PhonesFieldMenuItem';
 import { recordFieldInputIsFieldInErrorComponentState } from '@/object-record/record-field/ui/states/recordFieldInputIsFieldInErrorComponentState';
 import { phoneSchema } from '@/object-record/record-field/ui/validation-schemas/phoneSchema';
 import { useSetAtomComponentState } from '@/ui/utilities/state/jotai/hooks/useSetAtomComponentState';
 import { styled } from '@linaria/react';
+import { t } from '@lingui/core/macro';
 import { parsePhoneNumber, type E164Number } from 'libphonenumber-js';
 import ReactPhoneNumberInput from 'react-phone-number-input';
 import 'react-phone-number-input/style.css';
@@ -86,7 +86,9 @@ export const PhonesFieldInput = () => {
 
   const phones = createPhonesFromFieldValue(draftValue);
 
-  const defaultCountry = stripSimpleQuotesFromString(
+  const defaultCountry =
+  fieldDefinition?.metadata?.settings?.defaultCountryCode ??
+  stripSimpleQuotesFromString(
     fieldDefinition?.defaultValue?.primaryPhoneCountryCode,
   );
 


### PR DESCRIPTION
## Summary

Fixes #21473

When a PHONES field has a `defaultCountryCode` configured in Settings, the phone input component was ignoring it — showing the 🌐 "no country" selector instead of the configured country flag, and mis-parsing prefix-less local numbers against the wrong locale.

## Root Cause

The `PhonesFieldInput` component was reading the default country from `fieldDefinition.defaultValue.primaryPhoneCountryCode`, but the setting is stored at `fieldDefinition.metadata.settings.defaultCountryCode`. These are two separate fields — the input was never wired to the correct one.

The `metadata.settings` object was already being accessed in the same component (for `maxNumberOfValues`), so the data was available — it just wasn't being used for the country code.

## Fix

Updated `PhonesFieldInput.tsx` to read `defaultCountryCode` from `fieldDefinition.metadata.settings` first, with a fallback to `defaultValue.primaryPhoneCountryCode` for backwards compatibility.

```tsx
// Before
const defaultCountry = stripSimpleQuotesFromString(
  fieldDefinition?.defaultValue?.primaryPhoneCountryCode,
);

// After
const defaultCountry =
  fieldDefinition?.metadata?.settings?.defaultCountryCode ??
  stripSimpleQuotesFromString(
    fieldDefinition?.defaultValue?.primaryPhoneCountryCode,
  );
```

## Testing

1. On any object, open a PHONES field's settings and set **Default country code** (e.g. `Czechia (+420)`)
2. Open a record, edit that phone field, click **Add**
3. ✅ Country selector now shows 🇨🇿 instead of 🌐
4. Type a local number without prefix e.g. `608123456`
5. ✅ Parses correctly as `+420 608 123 456` instead of a wrong country

## Changes

- `packages/twenty-front/src/modules/object-record/record-field/meta-types/input/components/PhonesFieldInput.tsx`

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/21485?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

