### PR TITLE
Add CI workflow for people data labs app

### DIFF
--- a/.github/workflows/ci-people-data-labs.yaml
+++ b/.github/workflows/ci-people-data-labs.yaml
@@ -1,0 +1,67 @@
+name: CI People Data Labs
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+
+jobs:
+  changed-files-check:
+    uses: ./.github/workflows/changed-files.yaml
+    with:
+      files: |
+        packages/twenty-apps/internal/people-data-labs/**
+        .github/workflows/ci-people-data-labs.yaml
+
+  people-data-labs:
+    needs: changed-files-check
+    if: needs.changed-files-check.outputs.any_changed == 'true'
+    timeout-minutes: 15
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: packages/twenty-apps/internal/people-data-labs
+    steps:
+      - name: Checkout
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+
+      - name: Enable Corepack
+        run: corepack enable
+
+      - name: Setup Node.js
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        with:
+          node-version: '24'
+          cache: yarn
+          cache-dependency-path: packages/twenty-apps/internal/people-data-labs/yarn.lock
+
+      - name: Install dependencies
+        run: yarn install --immutable
+
+      - name: Run linter
+        run: yarn lint
+
+      - name: Run typecheck
+        run: yarn typecheck
+
+      - name: Run tests
+        run: yarn test
+
+  ci-people-data-labs-status-check:
+    if: always() && !cancelled()
+    timeout-minutes: 5
+    runs-on: ubuntu-latest
+    needs: [changed-files-check, people-data-labs]
+    steps:
+      - name: Fail job if any needs failed
+        if: contains(needs.*.result, 'failure')
+        run: exit 1


### PR DESCRIPTION
Adds a dedicated CI workflow for the People Data Labs app that runs lint, typecheck, and unit tests only when files under `packages/twenty-apps/internal/people-data-labs/` change.

The app is a standalone yarn project (its own lockfile, pinned published SDKs), so it isn't covered by the existing package CI workflows. The workflow gates on the app folder via the reusable `changed-files.yaml`, installs dependencies inside the app directory, and runs `yarn lint`, `yarn typecheck`, and `yarn test`. A status-check job aggregates results and stays green on skips, so it's safe to mark as a required check.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/21487?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

