### PR TITLE
Wrap file-type parser call in try-catch to convert unhandled PDF metadata parsing errors into a FileStorageException wit

### DIFF
--- a/packages/twenty-server/src/engine/core-modules/file/utils/__tests__/extract-file-info-or-throw.utils.spec.ts
+++ b/packages/twenty-server/src/engine/core-modules/file/utils/__tests__/extract-file-info-or-throw.utils.spec.ts
@@ -130,16 +130,18 @@ describe('extractFileInfoOrThrow', () => {
 
   describe('when file-type parser throws', () => {
     it('should throw FileStorageException', async () => {
-      jest.spyOn(FileTypeParser.prototype, 'fromBuffer').mockRejectedValue(
-        new Error('Non-whitespace before first tag.'),
-      );
+      jest
+        .spyOn(FileTypeParser.prototype, 'fromBuffer')
+        .mockRejectedValue(new Error('Non-whitespace before first tag.'));
 
       await expect(
         extractFileInfoOrThrow({
           file: pdfBuffer,
           filename: 'test.pdf',
         }),
-      ).rejects.toThrow(/File content detection failed: Non-whitespace before first tag./);
+      ).rejects.toThrow(
+        /File content detection failed: Non-whitespace before first tag./,
+      );
     });
   });
 });

--- a/packages/twenty-server/src/engine/core-modules/file/utils/__tests__/extract-file-info-or-throw.utils.spec.ts
+++ b/packages/twenty-server/src/engine/core-modules/file/utils/__tests__/extract-file-info-or-throw.utils.spec.ts
@@ -1,3 +1,5 @@
+import { FileTypeParser } from 'file-type';
+
 import { extractFileInfoOrThrow } from '../extract-file-info-or-throw.utils';
 
 const pngBuffer = Buffer.from([
@@ -9,6 +11,10 @@ const textBuffer = Buffer.from('Hello, world!', 'utf-8');
 const zipBuffer = Buffer.from([0x50, 0x4b, 0x03, 0x04]);
 
 describe('extractFileInfoOrThrow', () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
   it.each([
     {
       name: 'PNG',
@@ -120,5 +126,20 @@ describe('extractFileInfoOrThrow', () => {
         expect(result.mimeType).toBe(expectedMime);
       },
     );
+  });
+
+  describe('when file-type parser throws', () => {
+    it('should throw FileStorageException', async () => {
+      jest.spyOn(FileTypeParser.prototype, 'fromBuffer').mockRejectedValue(
+        new Error('Non-whitespace before first tag.'),
+      );
+
+      await expect(
+        extractFileInfoOrThrow({
+          file: pdfBuffer,
+          filename: 'test.pdf',
+        }),
+      ).rejects.toThrow(/File content detection failed: Non-whitespace before first tag./);
+    });
   });
 });

--- a/packages/twenty-server/src/engine/core-modules/file/utils/extract-file-info-or-throw.utils.ts
+++ b/packages/twenty-server/src/engine/core-modules/file/utils/extract-file-info-or-throw.utils.ts
@@ -26,8 +26,22 @@ export const extractFileInfoOrThrow = async ({
 }) => {
   const { ext: declaredExt } = buildFileInfo(filename);
 
-  const { ext: detectedExt, mime: detectedMime } =
-    (await fileTypeParser.fromBuffer(file)) ?? {};
+  let detectedExt: string | undefined;
+  let detectedMime: string | undefined;
+
+  try {
+    const result = await fileTypeParser.fromBuffer(file);
+    detectedExt = result?.ext;
+    detectedMime = result?.mime;
+  } catch (error) {
+    throw new FileStorageException(
+      `File content detection failed: ${(error as Error).message}`,
+      FileStorageExceptionCode.INVALID_EXTENSION,
+      {
+        userFriendlyMessage: msg`The file content could not be detected. The file may be corrupted or have an unsupported format.`,
+      },
+    );
+  }
 
   if (isDefined(detectedExt) && isDefined(detectedMime)) {
     return {


### PR DESCRIPTION
Fixes #21401.

Wrap file-type parser call in try-catch to convert unhandled PDF metadata parsing errors into a FileStorageException with INVALID_EXTENSION code, preventing server crash. When fileTypeParser.fromBuffer is called with a malformed PDF, @file-type/pdf's SAX parser throws an unhandled error (e.g., 'Non-whitespace before first tag.'), which propagates as an uncaught exception. The existing exception filter only catches FileStorageException, so the error becomes an unhandled rejection that crashes the request. Wrapping the call in a try-catch and rethrowing as FileStorageException ensures the error is handled gracefully and returned as a user-friendly validation error.

I ran the available lightweight check for the frontend change.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/21488?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

