### PR TITLE
Dispatch preview environments to ci-public

### DIFF
--- a/.github/workflows/preview-env-dispatch.yaml
+++ b/.github/workflows/preview-env-dispatch.yaml
@@ -33,14 +33,14 @@ jobs:
     timeout-minutes: 5
     runs-on: ubuntu-latest
     steps:
-      - name: Dispatch preview-env to ci-privileged
+      - name: Dispatch preview-env to ci-public
         env:
-          GH_TOKEN: ${{ secrets.CI_PRIVILEGED_DISPATCH_TOKEN }}
+          GH_TOKEN: ${{ secrets.CI_PUBLIC_DISPATCH_TOKEN }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
           PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
           REPOSITORY: ${{ github.repository }}
         run: |
-          gh api repos/twentyhq/ci-privileged/dispatches \
+          gh api repos/twentyhq/ci-public/dispatches \
             -f event_type=preview-environment \
             -f "client_payload[pr_number]=$PR_NUMBER" \
             -f "client_payload[pr_head_sha]=$PR_HEAD_SHA" \


### PR DESCRIPTION
Moves the PR preview environment out of ci-privileged. The expensive 5h build/tunnel/keepalive now runs in [ci-public](https://github.com/twentyhq/ci-public), and the GitHub App key that can write to twenty stays off that runner entirely.

Flow: this dispatcher → ci-public (build + tunnel) → ci-public dispatches the tunnel URL back to ci-privileged, which posts the PR comment. ci-public starts the tunnel and hands off the URL **before** any of the PR's attacker-controlled code runs, so no privileged secret is ever present while untrusted code executes.

This PR only repoints the dispatch to ci-public. Companion changes: [ci-public#main](https://github.com/twentyhq/ci-public) (workflow live) and [ci-privileged#40](https://github.com/twentyhq/ci-privileged/pull/40) (comment callback).

Do not merge until the secrets are configured: `CI_PUBLIC_DISPATCH_TOKEN` here, and on ci-public `CI_PRIVILEGED_DISPATCH_TOKEN` + `DOCKERHUB_RO_TOKEN` / `DOCKERHUB_RO_USERNAME`.