### PR TITLE
fix(upgrade): invalidate upgrade-status cache on command end

### DIFF
--- a/packages/twenty-server/src/database/commands/run-instance-commands.command.ts
+++ b/packages/twenty-server/src/database/commands/run-instance-commands.command.ts
@@ -10,6 +10,7 @@ import { InstanceCommandRunnerService } from 'src/engine/core-modules/upgrade/se
 import { UpgradeCommandRegistryService } from 'src/engine/core-modules/upgrade/services/upgrade-command-registry.service';
 import { UpgradeMigrationService } from 'src/engine/core-modules/upgrade/services/upgrade-migration.service';
 import { UpgradeSequenceReaderService } from 'src/engine/core-modules/upgrade/services/upgrade-sequence-reader.service';
+import { UpgradeStatusService } from 'src/engine/core-modules/upgrade/services/upgrade-status.service';
 import { WorkspaceVersionService } from 'src/engine/workspace-manager/workspace-version/services/workspace-version.service';
 
 type RunInstanceCommandsOptions = {
@@ -34,6 +35,7 @@ export class RunInstanceCommandsCommand extends CommandRunner {
     private readonly upgradeSequenceReaderService: UpgradeSequenceReaderService,
     private readonly instanceUpgradeService: InstanceCommandRunnerService,
     private readonly upgradeMigrationService: UpgradeMigrationService,
+    private readonly upgradeStatusService: UpgradeStatusService,
   ) {
     super();
   }
@@ -102,6 +104,20 @@ export class RunInstanceCommandsCommand extends CommandRunner {
         chalk.red(`Instance commands failed: ${error.message}`),
       );
       throw error;
+    } finally {
+      await this.safeInvalidateUpgradeStatusCache();
+    }
+  }
+
+  private async safeInvalidateUpgradeStatusCache(): Promise<void> {
+    try {
+      await this.upgradeStatusService.invalidateInstanceAndAllWorkspacesStatus();
+    } catch (error) {
+      this.logger.warn(
+        `Failed to invalidate upgrade-status cache: ${
+          error instanceof Error ? error.message : String(error)
+        }`,
+      );
     }
   }
 

--- a/packages/twenty-server/src/database/commands/upgrade-version-command/upgrade.command.ts
+++ b/packages/twenty-server/src/database/commands/upgrade-version-command/upgrade.command.ts
@@ -4,6 +4,7 @@ import { isDefined } from 'twenty-shared/utils';
 import { CommandLogger } from 'src/database/commands/logger';
 import { UpgradeSequenceReaderService } from 'src/engine/core-modules/upgrade/services/upgrade-sequence-reader.service';
 import { UpgradeSequenceRunnerService } from 'src/engine/core-modules/upgrade/services/upgrade-sequence-runner.service';
+import { UpgradeStatusService } from 'src/engine/core-modules/upgrade/services/upgrade-status.service';
 import { formatUpgradeLog } from 'src/engine/core-modules/upgrade/utils/format-upgrade-log.util';
 
 type RawUpgradeCommandOptions = {
@@ -32,6 +33,7 @@ export class UpgradeCommand extends CommandRunner {
   constructor(
     protected readonly upgradeSequenceReaderService: UpgradeSequenceReaderService,
     protected readonly upgradeSequenceRunnerService: UpgradeSequenceRunnerService,
+    protected readonly upgradeStatusService: UpgradeStatusService,
   ) {
     super();
     this.logger = new CommandLogger({
@@ -190,6 +192,23 @@ export class UpgradeCommand extends CommandRunner {
         }),
       );
       throw error;
+    } finally {
+      await this.safeInvalidateUpgradeStatusCache();
+    }
+  }
+
+  private async safeInvalidateUpgradeStatusCache(): Promise<void> {
+    try {
+      await this.upgradeStatusService.invalidateInstanceAndAllWorkspacesStatus();
+    } catch (error) {
+      this.logger.error(
+        formatUpgradeLog({
+          humanMessage: `Failed to invalidate upgrade-status cache: ${
+            error instanceof Error ? error.message : String(error)
+          }`,
+          event: 'cache.invalidate.failed',
+        }),
+      );
     }
   }
 }


### PR DESCRIPTION
## Problem

The "Twenty / Upgrade Status" Grafana dashboard shows stale workspace counts (e.g. `N behind / 0 up-to-date` while the instance reads `UP_TO_DATE`) that disagree with `command:prod upgrade:status`. The CLI is correct; the dashboard lags, sometimes for the full hour.

## Root cause

The dashboard is fed by the `twenty_upgrade_workspaces_*` gauges, which read their workspace counts from a Redis snapshot (`UpgradeStatusCacheService`). That snapshot is only invalidated **per-command, inside the runners' `finally` blocks**. Two gaps:

1. An instance command that is already applied returns **before** its invalidation runs (`isAlreadyCompleted` early-return in `InstanceCommandRunnerService`). So a plain **redeploy** — which changes the deployed upgrade sequence, and thus the "behind" answer, without executing any command — never refreshes the snapshot. This is most visible on an instance-only release.
2. The snapshot then stays frozen until its 60-minute TTL, while the CLI reads live and disagrees.

"Behind" is derived from the deployed sequence, not just the ledger, so the correct answer changes on events (deploys) that run no command — which is exactly why per-command invalidation isn't enough on its own.

## Fix

Invalidate the upgrade-status cache **once, unconditionally, at the end of both upgrade entrypoints** — `run-instance-commands` (the deploy/migrate step) and `upgrade` — in a `finally`. Every run, including a no-op redeploy where all commands are already applied, now clears the snapshot, so the next gauge scrape recomputes against the current sequence. Best-effort (failures are logged, never block the command). The existing per-command invalidation is kept for mid-run progress.

This keeps the read path untouched.

## Reproduction + verification (live, local)

Served twenty-server (`NODE_PORT=4000`, `METER_DRIVER=prometheus`) against the seeded DB, whose latest version `2.12.0` is instance-only.

1. Froze the gauge at `behind 4 / up_to_date 0` while the DB was brought up-to-date (snapshot not invalidated) — reproduced the dashboard/CLI divergence.
2. Ran the **patched** `run-instance-commands --force`. Every step logged `already executed, skipping` — and the `finally` still deleted the Redis snapshot.
3. On the next recompute the gauge self-healed to `instance_health 1, behind 0, up_to_date 4`, matching the live CLI.

With the old code the snapshot stayed frozen at `behind 4` until the TTL.
