### PR TITLE
fix(ci): bump claude-code-action to v1.0.146 (CVE-2026-47751)

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -80,7 +80,7 @@ jobs:
         uses: ./.github/actions/yarn-install
       - name: Run Claude Code
         id: claude-code
-        uses: anthropics/claude-code-action@dde2242db6af13460b916652159b6ba19a598f30 # v1
+        uses: anthropics/claude-code-action@ac7e24bf2938964b8ab203e417a2773802392ddd # v1.0.146
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           additional_permissions: |
@@ -170,7 +170,7 @@ jobs:
             core.setOutput('issue_number', p.issue_number);
       - name: Run Claude Code
         id: claude
-        uses: anthropics/claude-code-action@dde2242db6af13460b916652159b6ba19a598f30 # v1
+        uses: anthropics/claude-code-action@ac7e24bf2938964b8ab203e417a2773802392ddd # v1.0.146
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           prompt: ${{ steps.prompt.outputs.prompt }}


### PR DESCRIPTION
## What

Bumps both \`anthropics/claude-code-action\` pins in \`.github/workflows/claude.yml\` from the floating \`v1\` SHA (\`dde2242\`) to \`v1.0.146\` (\`ac7e24b\`).

## Why

The old pin predates the fix for **CVE-2026-47751** (Tenable TRA-2026-27, CVSSv4 5.3): claude-code-action checks out the PR head branch and unconditionally sets \`enableAllProjectMcpServers: true\`, so an attacker could ship a malicious \`.mcp.json\` in a PR branch and get arbitrary command execution in the runner — with access to workflow secrets — once a privileged user triggers the action.

Fixed upstream in **claude-code-action 1.0.78** (released 2026-03-24). This pins to the current release, v1.0.146.

## Notes
- \`claude.yml\` is the only workflow in the repo referencing the action; both job invocations (\`claude\` and \`claude-cross-repo\`) were updated.
- All existing \`with:\` inputs remain valid in v1.0.146 — no deprecated args.

Ref: https://www.tenable.com/security/research/tra-2026-27

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/21499?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

