### PR TITLE
fix: frontend build failing after code formatting library update

### DIFF
--- a/packages/twenty-client-sdk/src/generate/genql/render/requestTypes/unionType.ts
+++ b/packages/twenty-client-sdk/src/generate/genql/render/requestTypes/unionType.ts
@@ -1,6 +1,6 @@
 // @ts-nocheck
 import { GraphQLUnionType } from 'graphql'
-import uniq from 'lodash/uniq'
+import uniq from 'lodash/uniq.js'
 import { typeComment } from '../common/comment'
 import { RenderContext } from '../common/RenderContext'
 import { requestTypeName } from './requestTypeName'

--- a/packages/twenty-client-sdk/src/generate/genql/render/typeMap/unionType.ts
+++ b/packages/twenty-client-sdk/src/generate/genql/render/typeMap/unionType.ts
@@ -2,7 +2,7 @@
 import { GraphQLUnionType } from 'graphql'
 import { RenderContext } from '../common/RenderContext'
 import { FieldMap } from '../../runtime/types'
-import uniq from 'lodash/uniq'
+import uniq from 'lodash/uniq.js'
 
 export const unionType = (type: GraphQLUnionType, _: RenderContext) => {
     const types = type.getTypes()

--- a/packages/twenty-client-sdk/src/generate/genql/tasks/clientTasks.ts
+++ b/packages/twenty-client-sdk/src/generate/genql/tasks/clientTasks.ts
@@ -1,5 +1,5 @@
 import { GraphQLEnumType, GraphQLSchema, isEnumType } from 'graphql';
-import camelCase from 'lodash/camelCase';
+import camelCase from 'lodash/camelCase.js';
 
 import { type Config } from '../config';
 import { ensurePath, writeFileToPath } from '../helpers/files';

--- a/packages/twenty-client-sdk/vite.config.ts
+++ b/packages/twenty-client-sdk/vite.config.ts
@@ -11,9 +11,9 @@ const entries = [
 ];
 
 const externalDeps = [
-  ...Object.keys((packageJson as any).dependencies || {}),
-  ...Object.keys((packageJson as any).devDependencies || {}).filter(
-    (dep: string) => dep !== 'twenty-shared',
+  ...Object.keys(packageJson.dependencies),
+  ...Object.keys(packageJson.devDependencies).filter(
+    (dep) => dep !== 'twenty-shared',
   ),
   'node:fs/promises',
   'node:fs',

--- a/packages/twenty-client-sdk/vite.config.ts
+++ b/packages/twenty-client-sdk/vite.config.ts
@@ -10,6 +10,21 @@ const entries = [
   'src/generate/index.ts',
 ];
 
+const externalDeps = [
+  ...Object.keys((packageJson as any).dependencies || {}),
+  ...Object.keys((packageJson as any).devDependencies || {}).filter(
+    (dep: string) => dep !== 'twenty-shared',
+  ),
+  'node:fs/promises',
+  'node:fs',
+  'node:path',
+  'node:os',
+  'node:url',
+];
+
+const isExternal = (id: string) =>
+  externalDeps.some((dep) => id === dep || id.startsWith(`${dep}/`));
+
 const entryFileNames = (chunk: any, extension: 'cjs' | 'mjs') => {
   if (!chunk.isEntry) {
     throw new Error(
@@ -50,17 +65,7 @@ export default defineConfig(() => {
       outDir: 'dist',
       lib: { entry: entries, name: 'twenty-client-sdk' },
       rollupOptions: {
-        external: [
-          ...Object.keys((packageJson as any).dependencies || {}),
-          ...Object.keys((packageJson as any).devDependencies || {}).filter(
-            (dep: string) => dep !== 'twenty-shared',
-          ),
-          'node:fs/promises',
-          'node:fs',
-          'node:path',
-          'node:os',
-          'node:url',
-        ],
+        external: isExternal,
         output: [
           {
             format: 'es',

--- a/packages/twenty-e2e-testing/lib/utils/getAccessAuthToken.ts
+++ b/packages/twenty-e2e-testing/lib/utils/getAccessAuthToken.ts
@@ -1,30 +1,22 @@
 import { type Page } from '@playwright/test';
 
-const decodeToken = (cookie: any) =>
-  JSON.parse(decodeURIComponent(cookie.value)).accessOrWorkspaceAgnosticToken
-    ?.token;
-
-  const decodePayload = (jwt: string) =>
-    JSON.parse(Buffer.from(jwt.split('.')[1], 'base64url').toString());
-
+// Mirrors TOKEN_PAIR_LOCAL_STORAGE_KEY from twenty-front
+// (packages/twenty-front/src/modules/auth/states/tokenPairState.ts).
+// Since #21507 the frontend stores the auth token pair in localStorage
+// instead of a cookie.
+const TOKEN_PAIR_LOCAL_STORAGE_KEY = 'tokenPairState';
 
 export const getAccessAuthToken = async (page: Page) => {
   const storageState = await page.context().storageState();
-  const tokenCookies = storageState.cookies.filter(
-    (cookie) => cookie.name === 'tokenPair',
-  );
-  if (!tokenCookies) {
-    throw new Error('No auth cookie found');
+  const tokenPairItem = storageState.origins
+    .flatMap((origin) => origin.localStorage)
+    .find((item) => item.name === TOKEN_PAIR_LOCAL_STORAGE_KEY);
+
+  if (tokenPairItem === undefined) {
+    throw new Error('No auth token pair found in local storage');
   }
-  const accessTokenCookie = tokenCookies.find(
-    (cookie) => {
-      const payload = decodePayload(decodeToken(cookie) ?? '');
-      return payload.type === 'ACCESS';
-    }
-  );
 
-  const token = JSON.parse(decodeURIComponent(accessTokenCookie?.value ?? '')).accessOrWorkspaceAgnosticToken
-  .token;
+  const { accessOrWorkspaceAgnosticToken } = JSON.parse(tokenPairItem.value);
 
-  return { authToken: token };
+  return { authToken: accessOrWorkspaceAgnosticToken.token };
 };


### PR DESCRIPTION
Starting the frontend(`nx start twenty-front`) was failing because one of its dependencies - the client SDK - can not be built. A recent update made the sdk compatible with a newer version of Prettier. That update started using parts of prettier that the build setup did not recognize, so the build stopped with an error about a missing module. This PR updated the SDK’s build configuration, so it correctly handles those prettier imports.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/21519?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

