### PR TITLE
feat(record-table): aggregate totals follow the field's number format

### DIFF
--- a/packages/twenty-front/src/modules/object-record/record-aggregate/utils/__tests__/transformAggregateRawValueIntoAggregateDisplayValue.test.ts
+++ b/packages/twenty-front/src/modules/object-record/record-aggregate/utils/__tests__/transformAggregateRawValueIntoAggregateDisplayValue.test.ts
@@ -120,6 +120,86 @@ describe('transformAggregateRawValueIntoAggregateDisplayValue', () => {
     ).toBe('100,000,000');
   });
 
+  it('should return full currency value when the field format is set to full', () => {
+    const mockCurrencyFieldMetadataItem = {
+      ...mockCompanyEmployeesFieldMetadataItem,
+      type: FieldMetadataType.CURRENCY,
+      settings: { format: 'full' },
+    } as FieldMetadataItem;
+
+    expect(
+      transformAggregateRawValueIntoAggregateDisplayValue({
+        aggregateFieldMetadataItem: mockCurrencyFieldMetadataItem,
+        aggregateOperation: AggregateOperations.SUM,
+        aggregateRawValue: 230440000000,
+        dateFormat: DateFormat.DAY_FIRST,
+        timeFormat: TimeFormat.HOUR_24,
+        localeCatalog: enUS,
+        timeZone: 'UTC',
+      }),
+    ).toBe('230,440');
+  });
+
+  it('should return short currency value when the field format is set to short', () => {
+    const mockCurrencyFieldMetadataItem = {
+      ...mockCompanyEmployeesFieldMetadataItem,
+      type: FieldMetadataType.CURRENCY,
+      settings: { format: 'short' },
+    } as FieldMetadataItem;
+
+    expect(
+      transformAggregateRawValueIntoAggregateDisplayValue({
+        aggregateFieldMetadataItem: mockCurrencyFieldMetadataItem,
+        aggregateOperation: AggregateOperations.SUM,
+        aggregateRawValue: 230440000000,
+        dateFormat: DateFormat.DAY_FIRST,
+        timeFormat: TimeFormat.HOUR_24,
+        localeCatalog: enUS,
+        timeZone: 'UTC',
+      }),
+    ).toBe('230.4k');
+  });
+
+  it('should return short number value when the field type is shortNumber', () => {
+    const mockShortNumberFieldMetadataItem = {
+      ...mockCompanyEmployeesFieldMetadataItem,
+      type: FieldMetadataType.NUMBER,
+      settings: { type: 'shortNumber' },
+    } as FieldMetadataItem;
+
+    expect(
+      transformAggregateRawValueIntoAggregateDisplayValue({
+        aggregateFieldMetadataItem: mockShortNumberFieldMetadataItem,
+        aggregateOperation: AggregateOperations.SUM,
+        aggregateRawValue: 100000000,
+        dateFormat: DateFormat.DAY_FIRST,
+        timeFormat: TimeFormat.HOUR_24,
+        localeCatalog: enUS,
+        timeZone: 'UTC',
+      }),
+    ).toBe('100m');
+  });
+
+  it('should return full number value when the field type is number', () => {
+    const mockNumberFieldMetadataItem = {
+      ...mockCompanyEmployeesFieldMetadataItem,
+      type: FieldMetadataType.NUMBER,
+      settings: { type: 'number' },
+    } as FieldMetadataItem;
+
+    expect(
+      transformAggregateRawValueIntoAggregateDisplayValue({
+        aggregateFieldMetadataItem: mockNumberFieldMetadataItem,
+        aggregateOperation: AggregateOperations.SUM,
+        aggregateRawValue: 100000000,
+        dateFormat: DateFormat.DAY_FIRST,
+        timeFormat: TimeFormat.HOUR_24,
+        localeCatalog: enUS,
+        timeZone: 'UTC',
+      }),
+    ).toBe('100,000,000');
+  });
+
   it('should return correct DATE formatted value', () => {
     const mockDateFieldMetadataItem = {
       ...mockCompanyEmployeesFieldMetadataItem,

--- a/packages/twenty-front/src/modules/object-record/record-aggregate/utils/transformAggregateRawValueIntoAggregateDisplayValue.ts
+++ b/packages/twenty-front/src/modules/object-record/record-aggregate/utils/transformAggregateRawValueIntoAggregateDisplayValue.ts
@@ -8,7 +8,10 @@ import { type ExtendedAggregateOperations } from '@/object-record/record-table/t
 import { FieldMetadataType, type Nullable } from 'twenty-shared/types';
 import { formatToShortNumber, isDefined } from 'twenty-shared/utils';
 import { type AggregateOperations } from '~/generated-metadata/graphql';
-import { formatNumber } from '~/utils/format/formatNumber';
+import {
+  DEFAULT_DECIMAL_VALUE,
+  formatNumber,
+} from '~/utils/format/formatNumber';
 import { formatDateString } from '~/utils/string/formatDateString';
 import { formatDateTimeString } from '~/utils/string/formatDateTimeString';
 
@@ -48,14 +51,28 @@ export const transformAggregateRawValueIntoAggregateDisplayValue = ({
   } else {
     switch (aggregateFieldMetadataItem.type) {
       case FieldMetadataType.CURRENCY: {
-        return formatToShortNumber(Number(aggregateRawValue) / 1_000_000);
+        const amount = Number(aggregateRawValue) / 1_000_000;
+        const { format, decimals } = aggregateFieldMetadataItem.settings ?? {};
+
+        // Mirror the currency cell display: abbreviate unless the field is set to 'full'.
+        return format === 'full'
+          ? formatNumber(amount, {
+              decimals: decimals ?? DEFAULT_DECIMAL_VALUE,
+            })
+          : formatToShortNumber(amount);
       }
 
       case FieldMetadataType.NUMBER: {
         const castedValue = Number(aggregateRawValue);
         const { decimals, type } = aggregateFieldMetadataItem.settings ?? {};
-        return type === 'percentage'
-          ? `${formatNumber(castedValue * 100, { decimals })}%`
+
+        if (type === 'percentage') {
+          return `${formatNumber(castedValue * 100, { decimals })}%`;
+        }
+
+        // Mirror the number cell display: abbreviate only when the field uses 'shortNumber'.
+        return type === 'shortNumber'
+          ? formatToShortNumber(castedValue)
           : formatNumber(castedValue, { decimals });
       }
 


### PR DESCRIPTION
## Context

Currency and Number fields let users pick **Short** (`$1.2m`) vs **Full** (`$1,200,000`) display, and the table **cells** honor it. But the column-footer aggregates (Sum/Min/Max/Avg), record-index group totals, and the pie-chart center metric go through `transformAggregateRawValueIntoAggregateDisplayValue`, which ignored the field's format — so a **Full** currency column still showed a **short** footer total.

Closes #21525

## What changed

`transformAggregateRawValueIntoAggregateDisplayValue` now mirrors the cell displays:
- **Currency** → full when `settings.format === 'full'`, else short (matches `CurrencyDisplay`)
- **Number** → short when `settings.type === 'shortNumber'`, else full (matches `NumberFieldDisplay`)

All three consumers (footer, record-index, pie-center) already pass the field metadata, so they're fixed by this single change. No new GraphQL, no migration, no snapshot changes. Percentage and COUNT are untouched.

## Screenshots

| Before (footer abbreviated) | 
<img width="295" height="887" alt="Screenshot_4" src="https://github.com/user-attachments/assets/92f7b2df-2998-4e48-b735-596608e38587" />



| After (footer follows the field) |

<img width="298" height="886" alt="Screenshot_3" src="https://github.com/user-attachments/assets/146fc73e-77a9-4484-ad44-18092a1fd60f" />



## Test plan

- Extended `transformAggregateRawValueIntoAggregateDisplayValue` unit tests with currency `full`/`short` and number `shortNumber`/`number` cases.
- Manual: set a Currency field to **Full** → its column footer Sum now shows the full number, matching the cells.




<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/21526?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

