### PR TITLE
fix(e2e): reach Settings via workspace dropdown to unbreak merge queue

### DIFF
--- a/packages/twenty-e2e-testing/lib/pom/leftMenu.ts
+++ b/packages/twenty-e2e-testing/lib/pom/leftMenu.ts
@@ -22,7 +22,9 @@ export class LeftMenu {
     this.workspaceDropdown = page.getByTestId('workspace-dropdown');
     this.leftMenu = page.getByRole('button').first();
     this.searchSubTab = page.getByText('Search');
-    this.settingsTab = page.getByRole('button', { name: 'Settings' });
+    // Since #21523 Settings lives inside the workspace switcher dropdown
+    // instead of the main navigation, so it must be opened first.
+    this.settingsTab = page.getByRole('link', { name: 'Settings' });
     this.peopleTab = page.getByRole('link', { name: 'People' });
     this.companiesTab = page.getByRole('link', { name: 'Companies' });
     this.opportunitiesTab = page.getByRole('link', { name: 'Opportunities' });
@@ -56,6 +58,7 @@ export class LeftMenu {
   }
 
   async goToSettings() {
+    await this.workspaceDropdown.click();
     await this.settingsTab.click();
   }
 

--- a/packages/twenty-e2e-testing/lib/pom/leftMenu.ts
+++ b/packages/twenty-e2e-testing/lib/pom/leftMenu.ts
@@ -22,8 +22,6 @@ export class LeftMenu {
     this.workspaceDropdown = page.getByTestId('workspace-dropdown');
     this.leftMenu = page.getByRole('button').first();
     this.searchSubTab = page.getByText('Search');
-    // Since #21523 Settings lives inside the workspace switcher dropdown
-    // instead of the main navigation, so it must be opened first.
     this.settingsTab = page.getByRole('link', { name: 'Settings' });
     this.peopleTab = page.getByRole('link', { name: 'People' });
     this.companiesTab = page.getByRole('link', { name: 'Companies' });

--- a/packages/twenty-e2e-testing/tests/authentication/signup_invite_email.spec.ts
+++ b/packages/twenty-e2e-testing/tests/authentication/signup_invite_email.spec.ts
@@ -45,7 +45,7 @@ test('Sign up with invite link via email', async ({
   });
 
   await test.step('Delete account from workspace', async () => {
-    await expect(page.getByRole('button', { name: 'Settings' })).toBeVisible();
+    await expect(page.getByTestId('workspace-dropdown')).toBeVisible();
     await leftMenu.goToSettings();
     await settingsPage.goToProfileSection();
     await profileSection.deleteAccount();

--- a/packages/twenty-e2e-testing/tests/create-kanban-view.spec.ts
+++ b/packages/twenty-e2e-testing/tests/create-kanban-view.spec.ts
@@ -1,7 +1,8 @@
 import { expect, test } from '../lib/fixtures/screenshot';
 test.describe.serial('Create Kanban View', () => {
 test('Create Industry Select Field', async ({ page }) => {
-    await page.getByRole('button', { name: 'Settings' }).click();
+    await page.getByTestId('workspace-dropdown').click();
+    await page.getByRole('link', { name: 'Settings' }).click();
     await page.getByRole('link', { name: 'Data model' }).click();
     await page.getByRole('link', { name: 'Opportunities' }).click();
     await expect(page.getByRole('button', { name: 'New Field' })).toBeVisible();


### PR DESCRIPTION
## Problem

The merge queue is red. Two e2e tests fail consistently on `merge_group` runs, both timing out while clicking `Settings`:

- `tests/create-kanban-view.spec.ts` ("Create Industry Select Field")
- `tests/authentication/signup_invite_email.spec.ts` ("Go to Settings and copy invite link")

The earlier tokenPair localStorage fix (#21507 / e2e read in #21519) restored login, so auth works again — but the navigation/settings polish in #21523 then **moved the Settings entry out of the main app navigation and into the workspace switcher dropdown** ("Moves Settings below Support in the workspace switcher menu").

The e2e tests still looked for a top-level `getByRole('button', { name: 'Settings' })`, which no longer exists, so they timed out.

## Fix

Reach Settings the new way — open the workspace switcher dropdown, then click the `Settings` link (it is now an `UndecoratedLink`/`MenuItem`, role `link`, in `MultiWorkspaceDropdownDefaultComponents`):

- `lib/pom/leftMenu.ts`: `goToSettings()` now opens `workspace-dropdown` first; `settingsTab` locator switched from `button` to `link`.
- `tests/create-kanban-view.spec.ts`: open the workspace dropdown before clicking the Settings link.
- `tests/authentication/signup_invite_email.spec.ts`: the post-signup "logged in" assertion now checks the `workspace-dropdown` is visible instead of the removed Settings button.

## Testing

Triggering the merge-queue e2e suite via the `run-merge-queue` label on this PR.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/21528?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

