### PR TITLE
Marketing emails: existing-workspace backfill (deferred — register at launch)

### DIFF
--- a/packages/twenty-server/src/database/commands/upgrade-version-command/2-13/2-13-upgrade-version-command.module.ts
+++ b/packages/twenty-server/src/database/commands/upgrade-version-command/2-13/2-13-upgrade-version-command.module.ts
@@ -1,6 +1,8 @@
 import { Module } from '@nestjs/common';
 
 import { WorkspaceIteratorModule } from 'src/database/commands/command-runners/workspace-iterator.module';
+import { BackfillMessageStandardObjectsCommand } from 'src/database/commands/upgrade-version-command/2-13/2-13-workspace-command-1799000031000-backfill-message-standard-objects.command';
+import { AddComposeCampaignCommandMenuItemCommand } from 'src/database/commands/upgrade-version-command/2-13/2-13-workspace-command-1799000040000-add-compose-campaign-command-menu-item.command';
 import { SyncStandardUiCapabilityFlagsCommand } from 'src/database/commands/upgrade-version-command/2-13/2-13-workspace-command-1781277460000-sync-standard-ui-capability-flags.command';
 import { SyncCreateRecordCommandAvailabilityExpressionCommand } from 'src/database/commands/upgrade-version-command/2-13/2-13-workspace-command-1781277470000-sync-create-record-command-availability-expression.command';
 import { ApplicationModule } from 'src/engine/core-modules/application/application.module';
@@ -15,6 +17,8 @@ import { WorkspaceMigrationModule } from 'src/engine/workspace-manager/workspace
     WorkspaceMigrationModule,
   ],
   providers: [
+    BackfillMessageStandardObjectsCommand,
+    AddComposeCampaignCommandMenuItemCommand,
     SyncStandardUiCapabilityFlagsCommand,
     SyncCreateRecordCommandAvailabilityExpressionCommand,
   ],

--- a/packages/twenty-server/src/database/commands/upgrade-version-command/2-13/2-13-workspace-command-1799000031000-backfill-message-standard-objects.command.ts
+++ b/packages/twenty-server/src/database/commands/upgrade-version-command/2-13/2-13-workspace-command-1799000031000-backfill-message-standard-objects.command.ts
@@ -1,0 +1,420 @@
+import { Command } from 'nest-commander';
+import {
+  STANDARD_OBJECTS,
+  STANDARD_PAGE_LAYOUT_UNIVERSAL_IDENTIFIERS,
+} from 'twenty-shared/metadata';
+import { isDefined } from 'twenty-shared/utils';
+
+import { ActiveOrSuspendedWorkspaceCommandRunner } from 'src/database/commands/command-runners/active-or-suspended-workspace.command-runner';
+import { WorkspaceIteratorService } from 'src/database/commands/command-runners/workspace-iterator.service';
+import { type RunOnWorkspaceArgs } from 'src/database/commands/command-runners/workspace.command-runner';
+import { buildNavigationCommandMenuItemOperationsOrThrow } from 'src/database/commands/upgrade-version-command/2-10/utils/build-navigation-command-menu-item-operations-or-throw.util';
+import {
+  getExistingOrStandardFlatEntityOrThrow,
+  getStandardFlatEntitiesToCreateOrThrow,
+} from 'src/database/commands/upgrade-version-command/2-10/utils/get-standard-flat-entities-to-create-or-throw.util';
+import { ApplicationService } from 'src/engine/core-modules/application/application.service';
+import { getWorkspaceSchemaName } from 'src/engine/workspace-datasource/utils/get-workspace-schema-name.util';
+import { type FlatFieldMetadata } from 'src/engine/metadata-modules/flat-field-metadata/types/flat-field-metadata.type';
+import { type FlatIndexMetadata } from 'src/engine/metadata-modules/flat-index-metadata/types/flat-index-metadata.type';
+import { type FlatObjectMetadata } from 'src/engine/metadata-modules/flat-object-metadata/types/flat-object-metadata.type';
+import { type FlatPageLayoutTab } from 'src/engine/metadata-modules/flat-page-layout-tab/types/flat-page-layout-tab.type';
+import { type FlatPageLayoutWidget } from 'src/engine/metadata-modules/flat-page-layout-widget/types/flat-page-layout-widget.type';
+import { type FlatPageLayout } from 'src/engine/metadata-modules/flat-page-layout/types/flat-page-layout.type';
+import { WorkspaceCacheService } from 'src/engine/workspace-cache/services/workspace-cache.service';
+import { computeTwentyStandardApplicationAllFlatEntityMaps } from 'src/engine/workspace-manager/twenty-standard-application/utils/twenty-standard-application-all-flat-entity-maps.constant';
+import { WorkspaceMigrationValidateBuildAndRunService } from 'src/engine/workspace-manager/workspace-migration/services/workspace-migration-validate-build-and-run-service';
+
+const getUniversalIdentifiers = (
+  entitiesByName: Record<string, { universalIdentifier: string }>,
+): string[] =>
+  Object.values(entitiesByName).map((entity) => entity.universalIdentifier);
+
+const MESSAGE_OBJECT_UNIVERSAL_IDENTIFIERS = [
+  STANDARD_OBJECTS.messageCampaign.universalIdentifier,
+  STANDARD_OBJECTS.messageList.universalIdentifier,
+  STANDARD_OBJECTS.messageListMember.universalIdentifier,
+];
+
+const NEW_FIELDS_ON_EXISTING_OBJECTS_UNIVERSAL_IDENTIFIERS = [
+  STANDARD_OBJECTS.person.fields.listMemberships.universalIdentifier,
+  STANDARD_OBJECTS.timelineActivity.fields.targetMessageList
+    .universalIdentifier,
+  STANDARD_OBJECTS.timelineActivity.fields.targetMessageCampaign
+    .universalIdentifier,
+  STANDARD_OBJECTS.message.fields.messageCampaign.universalIdentifier,
+  STANDARD_OBJECTS.message.fields.deliveryStatus.universalIdentifier,
+  STANDARD_OBJECTS.messageParticipant.fields.messageCampaign
+    .universalIdentifier,
+];
+
+const MESSAGE_FIELD_UNIVERSAL_IDENTIFIERS = [
+  ...getUniversalIdentifiers(STANDARD_OBJECTS.messageCampaign.fields),
+  ...getUniversalIdentifiers(STANDARD_OBJECTS.messageList.fields),
+  ...getUniversalIdentifiers(STANDARD_OBJECTS.messageListMember.fields),
+  ...NEW_FIELDS_ON_EXISTING_OBJECTS_UNIVERSAL_IDENTIFIERS,
+];
+
+const MESSAGE_INDEX_UNIVERSAL_IDENTIFIERS = [
+  ...getUniversalIdentifiers(STANDARD_OBJECTS.messageCampaign.indexes),
+  ...getUniversalIdentifiers(STANDARD_OBJECTS.messageList.indexes),
+  ...getUniversalIdentifiers(STANDARD_OBJECTS.messageListMember.indexes),
+  STANDARD_OBJECTS.message.indexes.messageCampaignIdIndex.universalIdentifier,
+  STANDARD_OBJECTS.messageParticipant.indexes.messageCampaignIdIndex
+    .universalIdentifier,
+];
+
+const MESSAGE_NAVIGABLE_OBJECT_UNIVERSAL_IDENTIFIERS = [
+  STANDARD_OBJECTS.messageCampaign.universalIdentifier,
+  STANDARD_OBJECTS.messageList.universalIdentifier,
+];
+
+const MESSAGE_RECORD_PAGE_KEYS = [
+  'messageCampaignRecordPage',
+  'messageListRecordPage',
+] as const;
+
+const MESSAGE_PAGE_LAYOUT_UNIVERSAL_IDENTIFIERS = MESSAGE_RECORD_PAGE_KEYS.map(
+  (key) => STANDARD_PAGE_LAYOUT_UNIVERSAL_IDENTIFIERS[key].universalIdentifier,
+);
+
+const MESSAGE_PAGE_LAYOUT_TAB_UNIVERSAL_IDENTIFIERS =
+  MESSAGE_RECORD_PAGE_KEYS.flatMap((key) =>
+    getUniversalIdentifiers(
+      STANDARD_PAGE_LAYOUT_UNIVERSAL_IDENTIFIERS[key].tabs,
+    ),
+  );
+
+const MESSAGE_RECORD_PAGE_WIDGET_UNIVERSAL_IDENTIFIERS =
+  MESSAGE_RECORD_PAGE_KEYS.flatMap((key) =>
+    Object.values(STANDARD_PAGE_LAYOUT_UNIVERSAL_IDENTIFIERS[key].tabs).flatMap(
+      (tab) => getUniversalIdentifiers(tab.widgets),
+    ),
+  );
+
+const PERSON_PAGE_LAYOUT_WIDGET_UNIVERSAL_IDENTIFIERS = [
+  STANDARD_PAGE_LAYOUT_UNIVERSAL_IDENTIFIERS.personRecordPage.tabs.home.widgets
+    .listMemberships.universalIdentifier,
+];
+
+const MESSAGE_PAGE_LAYOUT_WIDGET_UNIVERSAL_IDENTIFIERS = [
+  ...MESSAGE_RECORD_PAGE_WIDGET_UNIVERSAL_IDENTIFIERS,
+  ...PERSON_PAGE_LAYOUT_WIDGET_UNIVERSAL_IDENTIFIERS,
+];
+
+@Command({
+  name: 'upgrade:2-13:backfill-message-standard-objects',
+  description:
+    'Create the message marketing standard objects (messageCampaign, messageList, messageListMember) in existing workspaces',
+})
+export class BackfillMessageStandardObjectsCommand extends ActiveOrSuspendedWorkspaceCommandRunner {
+  constructor(
+    protected readonly workspaceIteratorService: WorkspaceIteratorService,
+    private readonly applicationService: ApplicationService,
+    private readonly workspaceCacheService: WorkspaceCacheService,
+    private readonly workspaceMigrationValidateBuildAndRunService: WorkspaceMigrationValidateBuildAndRunService,
+  ) {
+    super(workspaceIteratorService);
+  }
+
+  override async runOnWorkspace({
+    workspaceId,
+    dataSource,
+    options,
+  }: RunOnWorkspaceArgs): Promise<void> {
+    const isDryRun = options.dryRun ?? false;
+
+    const {
+      flatObjectMetadataMaps,
+      flatFieldMetadataMaps,
+      flatIndexMaps,
+      flatPageLayoutMaps,
+      flatPageLayoutTabMaps,
+      flatPageLayoutWidgetMaps,
+      flatCommandMenuItemMaps,
+    } = await this.workspaceCacheService.getOrRecompute(workspaceId, [
+      'flatObjectMetadataMaps',
+      'flatFieldMetadataMaps',
+      'flatIndexMaps',
+      'flatPageLayoutMaps',
+      'flatPageLayoutTabMaps',
+      'flatPageLayoutWidgetMaps',
+      'flatCommandMenuItemMaps',
+    ]);
+
+    const hasPrerequisiteObjects = [
+      STANDARD_OBJECTS.person.universalIdentifier,
+      STANDARD_OBJECTS.message.universalIdentifier,
+      STANDARD_OBJECTS.timelineActivity.universalIdentifier,
+    ].every((universalIdentifier) =>
+      isDefined(
+        flatObjectMetadataMaps.byUniversalIdentifier[universalIdentifier],
+      ),
+    );
+
+    if (!hasPrerequisiteObjects) {
+      this.logger.warn(
+        `Workspace ${workspaceId} is missing prerequisite standard objects (person/message/timelineActivity), skipping message standard objects backfill`,
+      );
+
+      return;
+    }
+
+    const { twentyStandardFlatApplication } =
+      await this.applicationService.findWorkspaceTwentyStandardAndCustomApplicationOrThrow(
+        { workspaceId },
+      );
+
+    const now = new Date().toISOString();
+
+    const { allFlatEntityMaps: standardAllFlatEntityMaps } =
+      computeTwentyStandardApplicationAllFlatEntityMaps({
+        now,
+        workspaceId,
+        twentyStandardApplicationId: twentyStandardFlatApplication.id,
+      });
+
+    const fieldMetadataRenameUpdates =
+      NEW_FIELDS_ON_EXISTING_OBJECTS_UNIVERSAL_IDENTIFIERS.flatMap(
+        (universalIdentifier) => {
+          const standardField =
+            standardAllFlatEntityMaps.flatFieldMetadataMaps
+              .byUniversalIdentifier[universalIdentifier];
+
+          if (!isDefined(standardField)) {
+            return [];
+          }
+
+          const collidingField = Object.values(
+            flatFieldMetadataMaps.byUniversalIdentifier,
+          ).find(
+            (field) =>
+              isDefined(field) &&
+              field.universalIdentifier !== universalIdentifier &&
+              field.objectMetadataUniversalIdentifier ===
+                standardField.objectMetadataUniversalIdentifier &&
+              field.name === standardField.name,
+          );
+
+          if (!isDefined(collidingField)) {
+            return [];
+          }
+
+          return [
+            {
+              ...collidingField,
+              name: `${collidingField.name}Old`,
+              label: `${collidingField.label} (Old)`,
+              isLabelSyncedWithName: false,
+              updatedAt: now,
+            },
+          ];
+        },
+      );
+
+    const navigationCommandMenuItemOperations =
+      buildNavigationCommandMenuItemOperationsOrThrow({
+        existingFlatCommandMenuItemMaps: flatCommandMenuItemMaps,
+        objectMetadatasForNavigation:
+          MESSAGE_NAVIGABLE_OBJECT_UNIVERSAL_IDENTIFIERS.map(
+            (universalIdentifier) =>
+              getExistingOrStandardFlatEntityOrThrow<FlatObjectMetadata>({
+                standardFlatEntityMaps:
+                  standardAllFlatEntityMaps.flatObjectMetadataMaps,
+                existingFlatEntityMaps: flatObjectMetadataMaps,
+                universalIdentifier,
+              }),
+          ),
+        applicationId: twentyStandardFlatApplication.id,
+        workspaceId,
+        now,
+        renamedCollisionObjectMetadatas: [],
+      });
+
+    const allFlatEntityOperationByMetadataName = {
+      objectMetadata: {
+        flatEntityToCreate:
+          getStandardFlatEntitiesToCreateOrThrow<FlatObjectMetadata>({
+            standardFlatEntityMaps:
+              standardAllFlatEntityMaps.flatObjectMetadataMaps,
+            existingFlatEntityMaps: flatObjectMetadataMaps,
+            universalIdentifiers: MESSAGE_OBJECT_UNIVERSAL_IDENTIFIERS,
+          }),
+        flatEntityToDelete: [],
+        flatEntityToUpdate: [],
+      },
+      fieldMetadata: {
+        flatEntityToCreate:
+          getStandardFlatEntitiesToCreateOrThrow<FlatFieldMetadata>({
+            standardFlatEntityMaps:
+              standardAllFlatEntityMaps.flatFieldMetadataMaps,
+            existingFlatEntityMaps: flatFieldMetadataMaps,
+            universalIdentifiers: MESSAGE_FIELD_UNIVERSAL_IDENTIFIERS,
+          }),
+        flatEntityToDelete: [],
+        flatEntityToUpdate: [],
+      },
+      index: {
+        flatEntityToCreate:
+          getStandardFlatEntitiesToCreateOrThrow<FlatIndexMetadata>({
+            standardFlatEntityMaps: standardAllFlatEntityMaps.flatIndexMaps,
+            existingFlatEntityMaps: flatIndexMaps,
+            universalIdentifiers: MESSAGE_INDEX_UNIVERSAL_IDENTIFIERS,
+          }),
+        flatEntityToDelete: [],
+        flatEntityToUpdate: [],
+      },
+      pageLayout: {
+        flatEntityToCreate:
+          getStandardFlatEntitiesToCreateOrThrow<FlatPageLayout>({
+            standardFlatEntityMaps:
+              standardAllFlatEntityMaps.flatPageLayoutMaps,
+            existingFlatEntityMaps: flatPageLayoutMaps,
+            universalIdentifiers: MESSAGE_PAGE_LAYOUT_UNIVERSAL_IDENTIFIERS,
+          }),
+        flatEntityToDelete: [],
+        flatEntityToUpdate: [],
+      },
+      pageLayoutTab: {
+        flatEntityToCreate:
+          getStandardFlatEntitiesToCreateOrThrow<FlatPageLayoutTab>({
+            standardFlatEntityMaps:
+              standardAllFlatEntityMaps.flatPageLayoutTabMaps,
+            existingFlatEntityMaps: flatPageLayoutTabMaps,
+            universalIdentifiers: MESSAGE_PAGE_LAYOUT_TAB_UNIVERSAL_IDENTIFIERS,
+          }),
+        flatEntityToDelete: [],
+        flatEntityToUpdate: [],
+      },
+      pageLayoutWidget: {
+        flatEntityToCreate:
+          getStandardFlatEntitiesToCreateOrThrow<FlatPageLayoutWidget>({
+            standardFlatEntityMaps:
+              standardAllFlatEntityMaps.flatPageLayoutWidgetMaps,
+            existingFlatEntityMaps: flatPageLayoutWidgetMaps,
+            universalIdentifiers:
+              MESSAGE_PAGE_LAYOUT_WIDGET_UNIVERSAL_IDENTIFIERS,
+          }),
+        flatEntityToDelete: [],
+        flatEntityToUpdate: [],
+      },
+      commandMenuItem: navigationCommandMenuItemOperations,
+    };
+
+    const totalOperationCount =
+      fieldMetadataRenameUpdates.length +
+      Object.values(allFlatEntityOperationByMetadataName).reduce(
+        (total, operations) => total + operations.flatEntityToCreate.length,
+        0,
+      );
+
+    if (totalOperationCount === 0) {
+      this.logger.log(
+        `Message standard objects already exist for workspace ${workspaceId}, skipping`,
+      );
+
+      return;
+    }
+
+    if (isDryRun) {
+      if (fieldMetadataRenameUpdates.length > 0) {
+        this.logger.log(
+          `[DRY RUN] Would rename ${fieldMetadataRenameUpdates.length} colliding custom field(s) for workspace ${workspaceId}`,
+        );
+      }
+
+      this.logger.log(
+        `[DRY RUN] Would apply ${totalOperationCount} message standard metadata operations for workspace ${workspaceId}`,
+      );
+
+      return;
+    }
+
+    const collisionRenameMigrations = fieldMetadataRenameUpdates.map(
+      (flatFieldMetadata) => ({
+        applicationUniversalIdentifier:
+          flatFieldMetadata.applicationUniversalIdentifier,
+        allFlatEntityOperationByMetadataName: {
+          fieldMetadata: {
+            flatEntityToCreate: [],
+            flatEntityToDelete: [],
+            flatEntityToUpdate: [flatFieldMetadata],
+          },
+        },
+      }),
+    );
+
+    for (const {
+      applicationUniversalIdentifier,
+      allFlatEntityOperationByMetadataName: renameOperations,
+    } of collisionRenameMigrations) {
+      const renameResult =
+        await this.workspaceMigrationValidateBuildAndRunService.validateBuildAndRunWorkspaceMigration(
+          {
+            isSystemBuild: true,
+            applicationUniversalIdentifier,
+            workspaceId,
+            allFlatEntityOperationByMetadataName: renameOperations,
+          },
+        );
+
+      if (renameResult.status === 'fail') {
+        throw new Error(
+          `Failed to rename colliding entity for workspace ${workspaceId}: ${JSON.stringify(
+            renameResult,
+            null,
+            2,
+          )}`,
+        );
+      }
+    }
+
+    const validateAndBuildResult =
+      await this.workspaceMigrationValidateBuildAndRunService.validateBuildAndRunWorkspaceMigration(
+        {
+          isSystemBuild: true,
+          applicationUniversalIdentifier:
+            twentyStandardFlatApplication.universalIdentifier,
+          workspaceId,
+          allFlatEntityOperationByMetadataName,
+        },
+      );
+
+    if (validateAndBuildResult.status === 'fail') {
+      throw new Error(
+        `Failed to create message standard objects for workspace ${workspaceId}: ${JSON.stringify(
+          validateAndBuildResult,
+          null,
+          2,
+        )}`,
+      );
+    }
+
+    this.logger.log(
+      `Applied ${totalOperationCount} message standard metadata operations for workspace ${workspaceId}`,
+    );
+
+    if (!isDefined(dataSource)) {
+      return;
+    }
+
+    const schemaName = getWorkspaceSchemaName(workspaceId);
+
+    const recipientBackfillResult = await dataSource.query(
+      `UPDATE "${schemaName}"."messageParticipant" mp
+       SET "messageCampaignId" = m."messageCampaignId"
+       FROM "${schemaName}"."message" m
+       WHERE mp."messageId" = m.id
+         AND m."messageCampaignId" IS NOT NULL
+         AND mp."role" = 'TO'
+         AND mp."messageCampaignId" IS NULL`,
+      undefined,
+      undefined,
+      { shouldBypassPermissionChecks: true },
+    );
+
+    this.logger.log(
+      `Backfilled messageCampaignId for ${recipientBackfillResult?.[1] ?? 0} recipient participants in workspace ${workspaceId}`,
+    );
+  }
+}

--- a/packages/twenty-server/src/database/commands/upgrade-version-command/2-13/2-13-workspace-command-1799000040000-add-compose-campaign-command-menu-item.command.ts
+++ b/packages/twenty-server/src/database/commands/upgrade-version-command/2-13/2-13-workspace-command-1799000040000-add-compose-campaign-command-menu-item.command.ts
@@ -1,0 +1,132 @@
+import { Command } from 'nest-commander';
+import { isDefined } from 'twenty-shared/utils';
+
+import { ActiveOrSuspendedWorkspaceCommandRunner } from 'src/database/commands/command-runners/active-or-suspended-workspace.command-runner';
+import { WorkspaceIteratorService } from 'src/database/commands/command-runners/workspace-iterator.service';
+import { type RunOnWorkspaceArgs } from 'src/database/commands/command-runners/workspace.command-runner';
+import { ApplicationService } from 'src/engine/core-modules/application/application.service';
+import { WorkspaceCacheService } from 'src/engine/workspace-cache/services/workspace-cache.service';
+import { STANDARD_COMMAND_MENU_ITEMS } from 'src/engine/workspace-manager/twenty-standard-application/constants/standard-command-menu-item.constant';
+import { computeTwentyStandardApplicationAllFlatEntityMaps } from 'src/engine/workspace-manager/twenty-standard-application/utils/twenty-standard-application-all-flat-entity-maps.constant';
+import { WorkspaceMigrationValidateBuildAndRunService } from 'src/engine/workspace-manager/workspace-migration/services/workspace-migration-validate-build-and-run-service';
+
+const COMPOSE_CAMPAIGN_COMMAND_MENU_ITEM_UNIVERSAL_IDENTIFIERS = [
+  STANDARD_COMMAND_MENU_ITEMS.composeCampaign.universalIdentifier,
+  STANDARD_COMMAND_MENU_ITEMS.composeCampaignPinned.universalIdentifier,
+];
+
+@Command({
+  name: 'upgrade:2-13:add-compose-campaign-command-menu-item',
+  description:
+    'Add the Compose Campaign command menu item to existing workspaces',
+})
+export class AddComposeCampaignCommandMenuItemCommand extends ActiveOrSuspendedWorkspaceCommandRunner {
+  constructor(
+    protected readonly workspaceIteratorService: WorkspaceIteratorService,
+    private readonly applicationService: ApplicationService,
+    private readonly workspaceMigrationValidateBuildAndRunService: WorkspaceMigrationValidateBuildAndRunService,
+    private readonly workspaceCacheService: WorkspaceCacheService,
+  ) {
+    super(workspaceIteratorService);
+  }
+
+  override async runOnWorkspace({
+    workspaceId,
+    options,
+  }: RunOnWorkspaceArgs): Promise<void> {
+    const isDryRun = options.dryRun ?? false;
+
+    this.logger.log(
+      `${isDryRun ? '[DRY RUN] ' : ''}Checking compose campaign command for workspace ${workspaceId}`,
+    );
+
+    const { twentyStandardFlatApplication } =
+      await this.applicationService.findWorkspaceTwentyStandardAndCustomApplicationOrThrow(
+        { workspaceId },
+      );
+
+    const { flatCommandMenuItemMaps: existingFlatCommandMenuItemMaps } =
+      await this.workspaceCacheService.getOrRecompute(workspaceId, [
+        'flatCommandMenuItemMaps',
+      ]);
+
+    const missingUniversalIdentifiers =
+      COMPOSE_CAMPAIGN_COMMAND_MENU_ITEM_UNIVERSAL_IDENTIFIERS.filter(
+        (universalIdentifier) =>
+          !isDefined(
+            existingFlatCommandMenuItemMaps.byUniversalIdentifier[
+              universalIdentifier
+            ],
+          ),
+      );
+
+    if (missingUniversalIdentifiers.length === 0) {
+      this.logger.log(
+        `Compose campaign commands already exist for workspace ${workspaceId}, skipping`,
+      );
+
+      return;
+    }
+
+    const { allFlatEntityMaps: standardAllFlatEntityMaps } =
+      computeTwentyStandardApplicationAllFlatEntityMaps({
+        now: new Date().toISOString(),
+        workspaceId,
+        twentyStandardApplicationId: twentyStandardFlatApplication.id,
+      });
+
+    const itemsToCreate = missingUniversalIdentifiers
+      .map(
+        (universalIdentifier) =>
+          standardAllFlatEntityMaps.flatCommandMenuItemMaps
+            .byUniversalIdentifier[universalIdentifier],
+      )
+      .filter(isDefined);
+
+    if (itemsToCreate.length === 0) {
+      this.logger.warn(
+        `Compose campaign commands not found in standard application for workspace ${workspaceId}`,
+      );
+
+      return;
+    }
+
+    if (isDryRun) {
+      this.logger.log(
+        `[DRY RUN] Would create ${itemsToCreate.length} compose campaign command(s) for workspace ${workspaceId}`,
+      );
+
+      return;
+    }
+
+    const validateAndBuildResult =
+      await this.workspaceMigrationValidateBuildAndRunService.validateBuildAndRunWorkspaceMigration(
+        {
+          allFlatEntityOperationByMetadataName: {
+            commandMenuItem: {
+              flatEntityToCreate: itemsToCreate,
+              flatEntityToDelete: [],
+              flatEntityToUpdate: [],
+            },
+          },
+          workspaceId,
+          applicationUniversalIdentifier:
+            twentyStandardFlatApplication.universalIdentifier,
+        },
+      );
+
+    if (validateAndBuildResult.status === 'fail') {
+      this.logger.error(
+        `Failed to add compose campaign command:\n${JSON.stringify(validateAndBuildResult, null, 2)}`,
+      );
+
+      throw new Error(
+        `Failed to add compose campaign command for workspace ${workspaceId}`,
+      );
+    }
+
+    this.logger.log(
+      `Successfully added compose campaign command for workspace ${workspaceId}`,
+    );
+  }
+}


### PR DESCRIPTION
**Do not merge — parked companion to #21173 (marketing emails).**

These two per-workspace upgrade commands backfill the marketing-email standard objects and command-menu-items into **existing** workspaces. They were removed from #21173 because that PR lands the feature dormant: new workspaces already get the schema (flag-hidden) at creation, and existing workspaces don't need it until launch.

### At launch
- Move both commands into the launch version's folder and add `@RegisteredWorkspaceCommand('<launch-version>', <timestamp>)` so the upgrade backfills automatically (they are intentionally unregistered here).
- Rebase against the schema as it stands then — the universal identifiers / flat-entity helpers may have moved.
- **Foot-gun:** do not enable `IS_EMAIL_GROUP_ENABLED` on an existing workspace before its backfill has run, or it will have no `messageCampaign`/`messageList` objects and no Compose Campaign command-menu-item.

### Commands
- `backfill-message-standard-objects` — creates `messageCampaign`/`messageList`/`messageListMember` + new fields on `person`/`message`/`messageParticipant`/`timelineActivity`, renames colliding custom fields, backfills `messageCampaignId` on recipient participants.
- `add-compose-campaign-command-menu-item` — creates the (flag-gated) Compose Campaign global + pinned command-menu-items.

Base is `feat/marketing-emails` (these depend on that branch's standard-schema additions; they won't compile against `main` alone). GitHub will retarget this to `main` once the feature branch merges.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/21534?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

