### PR TITLE
[CI repro – do not merge] confirm vite-8 twenty-emails fresh-build crash is main-wide

### DIFF
--- a/packages/twenty-emails/src/index.ts
+++ b/packages/twenty-emails/src/index.ts
@@ -1,3 +1,4 @@
+// CI repro: bust Nx cache to force a genuinely fresh twenty-emails build.
 export type { JSONContent } from '@tiptap/core';
 export * from './emails/clean-suspended-workspace.email';
 export * from './emails/password-reset-link.email';

--- a/packages/twenty-server/src/main.ts
+++ b/packages/twenty-server/src/main.ts
@@ -1,3 +1,4 @@
+// CI repro: no-op change to force a server-build cache miss (see PR description).
 import { NestFactory } from '@nestjs/core';
 import { type NestExpressApplication } from '@nestjs/platform-express';
 

--- a/packages/twenty-server/src/main.ts
+++ b/packages/twenty-server/src/main.ts
@@ -1,4 +1,4 @@
-// CI repro: no-op change to force a server-build cache miss (see PR description).
+// CI repro: no-op change to trigger CI Server + force a fresh build (see PR description).
 import { NestFactory } from '@nestjs/core';
 import { type NestExpressApplication } from '@nestjs/platform-express';
 


### PR DESCRIPTION
Throwaway draft to confirm that a fresh (cache-miss) server build on main crashes `database:reset` via the Vite-8 `twenty-emails` browser-stub of node `util`. Contains only a no-op comment in `twenty-server/src/main.ts` to force a server-build cache miss. Will be closed once `server-integration-test` result is observed.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/21535?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

