### PR TITLE
ci: exclude all twenty-apps from dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,7 +3,7 @@ updates:
   - package-ecosystem: "npm"
     directory: "/"
     exclude-paths:
-      - "packages/twenty-apps/community/**"
+      - "packages/twenty-apps/**"
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 3


### PR DESCRIPTION
Dependabot currently only excludes `packages/twenty-apps/community/**`, but the `twenty-apps` package also contains `examples`, `fixtures`, and `internal` apps that shouldn't be picked up either.

This broadens the `exclude-paths` to `packages/twenty-apps/**` so Dependabot ignores apps entirely.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/21554?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

