### PR TITLE
fix(record-field): prevent state clobbering and focus loss in dynamic array inputs

### DIFF
--- a/packages/twenty-front/src/modules/object-record/record-field/ui/form-types/components/FormArrayFieldInput.tsx
+++ b/packages/twenty-front/src/modules/object-record/record-field/ui/form-types/components/FormArrayFieldInput.tsx
@@ -21,7 +21,6 @@ import { usePushFocusItemToFocusStack } from '@/ui/utilities/focus/hooks/usePush
 import { useRemoveFocusItemFromFocusStackById } from '@/ui/utilities/focus/hooks/useRemoveFocusItemFromFocusStackById';
 import { FocusComponentType } from '@/ui/utilities/focus/types/FocusComponentType';
 import { useAtomComponentStateValue } from '@/ui/utilities/state/jotai/hooks/useAtomComponentStateValue';
-import { isStandaloneVariableString } from '@/workflow/utils/isStandaloneVariableString';
 import { styled } from '@linaria/react';
 import { useLingui } from '@lingui/react/macro';
 import { isNonEmptyArray } from '@sniptt/guards';
@@ -105,7 +104,7 @@ export const FormArrayFieldInput = ({
   const { closeDropdown } = useCloseDropdown();
   const { openDropdown } = useOpenDropdown();
 
-  const getInitialDraftValue = (): 
+  const getInitialDraftValue = ():
     | {
         type: 'static';
         value: { id: string; value: string }[];
@@ -293,7 +292,11 @@ export const FormArrayFieldInput = ({
       return;
     }
 
-    if (!isAddingNewItem && isDefined(itemToEdit) && sanitizedInput === itemToEdit.value) {
+    if (
+      !isAddingNewItem &&
+      isDefined(itemToEdit) &&
+      sanitizedInput === itemToEdit.value
+    ) {
       setIsInputDisplayed(false);
       setInputValue('');
       setItemToEditId(null);

--- a/packages/twenty-front/src/modules/object-record/record-field/ui/form-types/components/FormArrayFieldInput.tsx
+++ b/packages/twenty-front/src/modules/object-record/record-field/ui/form-types/components/FormArrayFieldInput.tsx
@@ -105,24 +105,33 @@ export const FormArrayFieldInput = ({
   const { closeDropdown } = useCloseDropdown();
   const { openDropdown } = useOpenDropdown();
 
-  const getInitialDraftValue = () => {
-    if (isStandaloneVariableString(defaultValue)) {
-      return {
-        type: 'variable' as const,
-        value: defaultValue,
-      };
-    }
-
-    const defaultArray = (() => {
-      if (isDefined(defaultValue) && isNonEmptyArray(defaultValue)) {
-        return defaultValue;
+  const getInitialDraftValue = (): 
+    | {
+        type: 'static';
+        value: { id: string; value: string }[];
       }
-      return [];
-    })();
+    | {
+        type: 'variable';
+        value: string;
+      } => {
+    if (isDefined(defaultValue)) {
+      if (typeof defaultValue === 'string') {
+        return {
+          type: 'variable' as const,
+          value: defaultValue,
+        };
+      }
+      if (isNonEmptyArray(defaultValue)) {
+        return {
+          type: 'static' as const,
+          value: defaultValue.map((val) => ({ id: v4(), value: val })),
+        };
+      }
+    }
 
     return {
       type: 'static' as const,
-      value: defaultArray.map((val) => ({ id: v4(), value: val })),
+      value: [],
     };
   };
 
@@ -264,14 +273,18 @@ export const FormArrayFieldInput = ({
     }
 
     if (sanitizedInput === '' && !isAddingNewItem) {
-      handleDeleteItem(itemToEditId!);
+      if (isDefined(itemToEditId)) {
+        handleDeleteItem(itemToEditId);
+      }
       return;
     }
 
     const items = draftValue.value;
     const itemToEditIndex = items.findIndex((item) => item.id === itemToEditId);
-    const itemToEdit =
-      itemToEditIndex !== -1 ? items[itemToEditIndex] : undefined;
+    let itemToEdit;
+    if (itemToEditIndex !== -1) {
+      itemToEdit = items[itemToEditIndex];
+    }
 
     if (!isAddingNewItem && !isDefined(itemToEdit)) {
       setIsInputDisplayed(false);
@@ -280,7 +293,7 @@ export const FormArrayFieldInput = ({
       return;
     }
 
-    if (!isAddingNewItem && sanitizedInput === itemToEdit?.value) {
+    if (!isAddingNewItem && isDefined(itemToEdit) && sanitizedInput === itemToEdit.value) {
       setIsInputDisplayed(false);
       setInputValue('');
       setItemToEditId(null);
@@ -291,11 +304,13 @@ export const FormArrayFieldInput = ({
 
     if (isAddingNewItem) {
       updatedItems = [...items, { id: v4(), value: sanitizedInput }];
-    } else {
+    } else if (isDefined(itemToEdit)) {
       updatedItems = toSpliced(items, itemToEditIndex, 1, {
-        id: itemToEdit!.id,
+        id: itemToEdit.id,
         value: sanitizedInput,
       });
+    } else {
+      updatedItems = items;
     }
 
     setDraftValue({
@@ -374,6 +389,26 @@ export const FormArrayFieldInput = ({
     return handleUnlinkVariable;
   };
 
+  const renderArrayItems = () => {
+    if (draftValue.type !== 'static') {
+      return null;
+    }
+
+    return draftValue.value.map((item) => (
+      <ArrayFieldMenuItem
+        key={item.id}
+        dropdownId={`array-field-input-${instanceId}-${item.id}`}
+        value={item.value}
+        onEdit={() => {
+          handleEditItem(item.id, item.value);
+        }}
+        onDelete={() => {
+          handleDeleteItem(item.id);
+        }}
+      />
+    ));
+  };
+
   const renderInnerContent = () => {
     if (draftValue.type !== 'static') {
       return (
@@ -433,20 +468,7 @@ export const FormArrayFieldInput = ({
         dropdownComponents={
           <DropdownContent ref={containerRef}>
             <DropdownMenuItemsContainer hasMaxHeight>
-              {draftValue.type === 'static' &&
-                draftValue.value.map((item) => (
-                  <ArrayFieldMenuItem
-                    key={item.id}
-                    dropdownId={`array-field-input-${instanceId}-${item.id}`}
-                    value={item.value}
-                    onEdit={() => {
-                      handleEditItem(item.id, item.value);
-                    }}
-                    onDelete={() => {
-                      handleDeleteItem(item.id);
-                    }}
-                  />
-                ))}
+              {renderArrayItems()}
             </DropdownMenuItemsContainer>
 
             <DropdownMenuSeparator />
@@ -465,6 +487,23 @@ export const FormArrayFieldInput = ({
     return null;
   };
 
+  const renderVariablePicker = () => {
+    if (isDefined(VariablePicker) && !readonly) {
+      return (
+        <VariablePicker
+          instanceId={instanceId}
+          onVariableSelect={handleVariableTagInsert}
+        />
+      );
+    }
+    return null;
+  };
+
+  let hasRightElement = false;
+  if (isDefined(VariablePicker) && !readonly) {
+    hasRightElement = true;
+  }
+
   return (
     <FormFieldInputContainer data-testid={testId}>
       {renderLabel()}
@@ -473,17 +512,12 @@ export const FormArrayFieldInput = ({
         <FormFieldInputInnerContainer
           formFieldInputInstanceId={formFieldInputInstanceId}
           preventFocusStackUpdate={preventContainerFocusStackUpdate}
-          hasRightElement={isDefined(VariablePicker) && !readonly}
+          hasRightElement={hasRightElement}
         >
           {renderInnerContent()}
         </FormFieldInputInnerContainer>
 
-        {VariablePicker && !readonly && (
-          <VariablePicker
-            instanceId={instanceId}
-            onVariableSelect={handleVariableTagInsert}
-          />
-        )}
+        {renderVariablePicker()}
       </FormFieldInputRowContainer>
     </FormFieldInputContainer>
   );

--- a/packages/twenty-front/src/modules/object-record/record-field/ui/form-types/components/FormArrayFieldInput.tsx
+++ b/packages/twenty-front/src/modules/object-record/record-field/ui/form-types/components/FormArrayFieldInput.tsx
@@ -140,8 +140,8 @@ export const FormArrayFieldInput = ({
   const [newItemDraftValue, setNewItemDraftValue] = useState('');
   const [inputValue, setInputValue] = useState('');
   const [isInputDisplayed, setIsInputDisplayed] = useState(false);
-  const [itemToEditIndex, setItemToEditIndex] = useState(-1);
-  const isAddingNewItem = itemToEditIndex === -1;
+  const [itemToEditId, setItemToEditId] = useState<string | null>(null);
+  const isAddingNewItem = itemToEditId === null;
 
   const containerRef = useRef<HTMLDivElement>(null);
 
@@ -189,17 +189,20 @@ export const FormArrayFieldInput = ({
     });
   };
 
-  const handleEditItem = (index: number) => {
+  const handleEditItem = (id: string, value: string) => {
     if (draftValue.type !== 'static') return;
-    setInputValue(draftValue.value[index].value);
-    setItemToEditIndex(index);
+    setInputValue(value);
+    setItemToEditId(id);
     setIsInputDisplayed(true);
   };
 
-  const handleDeleteItem = (index: number) => {
+  const handleDeleteItem = (id: string) => {
     if (draftValue.type !== 'static') {
       throw new Error('Cannot delete item when value is a variable.');
     }
+
+    const index = draftValue.value.findIndex((item) => item.id === id);
+    if (index === -1) return;
 
     const updatedItems = toSpliced(draftValue.value, index, 1);
 
@@ -261,23 +264,26 @@ export const FormArrayFieldInput = ({
     }
 
     if (sanitizedInput === '' && !isAddingNewItem) {
-      handleDeleteItem(itemToEditIndex);
+      handleDeleteItem(itemToEditId!);
       return;
     }
 
     const items = draftValue.value;
+    const itemToEditIndex = items.findIndex((item) => item.id === itemToEditId);
+    const itemToEdit =
+      itemToEditIndex !== -1 ? items[itemToEditIndex] : undefined;
 
-    const itemToEdit = items[itemToEditIndex];
     if (!isAddingNewItem && !isDefined(itemToEdit)) {
       setIsInputDisplayed(false);
       setInputValue('');
-      setItemToEditIndex(-1);
+      setItemToEditId(null);
       return;
     }
 
     if (!isAddingNewItem && sanitizedInput === itemToEdit?.value) {
       setIsInputDisplayed(false);
       setInputValue('');
+      setItemToEditId(null);
       return;
     }
 
@@ -287,7 +293,7 @@ export const FormArrayFieldInput = ({
       updatedItems = [...items, { id: v4(), value: sanitizedInput }];
     } else {
       updatedItems = toSpliced(items, itemToEditIndex, 1, {
-        id: itemToEdit.id,
+        id: itemToEdit!.id,
         value: sanitizedInput,
       });
     }
@@ -300,7 +306,7 @@ export const FormArrayFieldInput = ({
 
     setIsInputDisplayed(false);
     setInputValue('');
-    setItemToEditIndex(-1);
+    setItemToEditId(null);
 
     removeFocusItemFromFocusStackById({
       focusId: newItemInputInstanceId,
@@ -308,7 +314,7 @@ export const FormArrayFieldInput = ({
   };
 
   const handleAddItemButtonClick = () => {
-    setItemToEditIndex(-1);
+    setItemToEditId(null);
     setIsInputDisplayed(true);
   };
 
@@ -428,16 +434,16 @@ export const FormArrayFieldInput = ({
           <DropdownContent ref={containerRef}>
             <DropdownMenuItemsContainer hasMaxHeight>
               {draftValue.type === 'static' &&
-                draftValue.value.map((item, index) => (
+                draftValue.value.map((item) => (
                   <ArrayFieldMenuItem
                     key={item.id}
                     dropdownId={`array-field-input-${instanceId}-${item.id}`}
                     value={item.value}
                     onEdit={() => {
-                      handleEditItem(index);
+                      handleEditItem(item.id, item.value);
                     }}
                     onDelete={() => {
-                      handleDeleteItem(index);
+                      handleDeleteItem(item.id);
                     }}
                   />
                 ))}

--- a/packages/twenty-front/src/modules/object-record/record-field/ui/form-types/components/FormArrayFieldInput.tsx
+++ b/packages/twenty-front/src/modules/object-record/record-field/ui/form-types/components/FormArrayFieldInput.tsx
@@ -34,6 +34,7 @@ import {
 } from 'twenty-ui-deprecated/theme-constants';
 import { MenuItem } from 'twenty-ui-deprecated/navigation';
 import { toSpliced } from '~/utils/array/toSpliced';
+import { v4 } from 'uuid';
 
 type FormArrayFieldInputProps = {
   label?: string;
@@ -104,29 +105,37 @@ export const FormArrayFieldInput = ({
   const { closeDropdown } = useCloseDropdown();
   const { openDropdown } = useOpenDropdown();
 
+  const getInitialDraftValue = () => {
+    if (isStandaloneVariableString(defaultValue)) {
+      return {
+        type: 'variable' as const,
+        value: defaultValue,
+      };
+    }
+
+    const defaultArray = (() => {
+      if (isDefined(defaultValue) && isNonEmptyArray(defaultValue)) {
+        return defaultValue;
+      }
+      return [];
+    })();
+
+    return {
+      type: 'static' as const,
+      value: defaultArray.map((val) => ({ id: v4(), value: val })),
+    };
+  };
+
   const [draftValue, setDraftValue] = useState<
     | {
         type: 'static';
-        value: FieldArrayValue;
+        value: { id: string; value: string }[];
       }
     | {
         type: 'variable';
         value: string;
       }
-  >(
-    isStandaloneVariableString(defaultValue)
-      ? {
-          type: 'variable',
-          value: defaultValue,
-        }
-      : {
-          type: 'static',
-          value:
-            isDefined(defaultValue) && isNonEmptyArray(defaultValue)
-              ? defaultValue
-              : [],
-        },
-  );
+  >(getInitialDraftValue);
 
   const [newItemDraftValue, setNewItemDraftValue] = useState('');
   const [inputValue, setInputValue] = useState('');
@@ -143,7 +152,7 @@ export const FormArrayFieldInput = ({
   );
 
   const preventContainerFocusStackUpdate =
-    draftValue.type === 'static' && draftValue.value.length >= 1;
+    draftValue.type === 'static' && isNonEmptyArray(draftValue.value);
 
   const formFieldInputInstanceId = `form-array-field-container-${instanceId}`;
   const newItemInputInstanceId = `array-field-input-new-item-${instanceId}`;
@@ -153,12 +162,21 @@ export const FormArrayFieldInput = ({
   };
 
   const handleFirstItemInputEnter = () => {
+    if (draftValue.type !== 'static') {
+      return;
+    }
+
+    const newItems = [
+      ...draftValue.value,
+      { id: v4(), value: newItemDraftValue },
+    ];
+
     setDraftValue({
       type: 'static',
-      value: [...draftValue.value, newItemDraftValue],
+      value: newItems,
     });
 
-    onChange([...draftValue.value, newItemDraftValue]);
+    onChange(newItems.map((item) => item.value));
 
     setNewItemDraftValue('');
 
@@ -172,7 +190,8 @@ export const FormArrayFieldInput = ({
   };
 
   const handleEditItem = (index: number) => {
-    setInputValue(draftValue.value[index]);
+    if (draftValue.type !== 'static') return;
+    setInputValue(draftValue.value[index].value);
     setItemToEditIndex(index);
     setIsInputDisplayed(true);
   };
@@ -188,9 +207,9 @@ export const FormArrayFieldInput = ({
       type: 'static',
       value: updatedItems,
     });
-    onChange(updatedItems);
+    onChange(updatedItems.map((item) => item.value));
 
-    const isDropdownGoingToBeHiddenNext = updatedItems.length === 0;
+    const isDropdownGoingToBeHiddenNext = !isNonEmptyArray(updatedItems);
     if (isDropdownGoingToBeHiddenNext) {
       closeDropdown(dropdownId);
     }
@@ -248,24 +267,40 @@ export const FormArrayFieldInput = ({
 
     const items = draftValue.value;
 
-    if (!isAddingNewItem && sanitizedInput === items[itemToEditIndex]) {
+    const itemToEdit = items[itemToEditIndex];
+    if (!isAddingNewItem && !isDefined(itemToEdit)) {
+      setIsInputDisplayed(false);
+      setInputValue('');
+      setItemToEditIndex(-1);
+      return;
+    }
+
+    if (!isAddingNewItem && sanitizedInput === itemToEdit?.value) {
       setIsInputDisplayed(false);
       setInputValue('');
       return;
     }
 
-    const updatedItems = isAddingNewItem
-      ? [...items, sanitizedInput]
-      : toSpliced(items, itemToEditIndex, 1, sanitizedInput);
+    let updatedItems;
+
+    if (isAddingNewItem) {
+      updatedItems = [...items, { id: v4(), value: sanitizedInput }];
+    } else {
+      updatedItems = toSpliced(items, itemToEditIndex, 1, {
+        id: itemToEdit.id,
+        value: sanitizedInput,
+      });
+    }
 
     setDraftValue({
       type: 'static',
       value: updatedItems,
     });
-    onChange(updatedItems);
+    onChange(updatedItems.map((item) => item.value));
 
     setIsInputDisplayed(false);
     setInputValue('');
+    setItemToEditIndex(-1);
 
     removeFocusItemFromFocusStackById({
       focusId: newItemInputInstanceId,
@@ -297,9 +332,136 @@ export const FormArrayFieldInput = ({
     onChange([]);
   };
 
+  const renderDropdownInputOrButton = () => {
+    if (isInputDisplayed) {
+      return (
+        <MultiItemBaseInput
+          instanceId={newItemInputInstanceId}
+          autoFocus
+          placeholder={placeholder}
+          value={inputValue}
+          onFocus={handleNewItemInputFocus}
+          onBlur={handleNewItemInputBlur}
+          onEscape={handleNewItemInputEscape}
+          onChange={handleNewItemInputChange}
+          onEnter={handleNewItemInputSubmit}
+          hasItem
+        />
+      );
+    }
+
+    return (
+      <DropdownMenuItemsContainer>
+        <MenuItem
+          onClick={handleAddItemButtonClick}
+          LeftIcon={IconPlus}
+          text={t`Add item`}
+        />
+      </DropdownMenuItemsContainer>
+    );
+  };
+
+  const getOnRemoveHandler = () => {
+    if (readonly) {
+      return undefined;
+    }
+    return handleUnlinkVariable;
+  };
+
+  const renderInnerContent = () => {
+    if (draftValue.type !== 'static') {
+      return (
+        <VariableChipStandalone
+          rawVariableName={draftValue.value}
+          onRemove={getOnRemoveHandler()}
+        />
+      );
+    }
+
+    if (readonly) {
+      if (isNonEmptyArray(draftValue.value)) {
+        return (
+          <StyledDisplayModeReadonlyContainer>
+            <ArrayDisplay value={draftValue.value.map((i) => i.value)} />
+          </StyledDisplayModeReadonlyContainer>
+        );
+      }
+      return (
+        <StyledDisplayModeReadonlyContainer>
+          <StyledPlaceholderContainer>
+            <FormFieldPlaceholder />
+          </StyledPlaceholderContainer>
+        </StyledDisplayModeReadonlyContainer>
+      );
+    }
+
+    if (!isNonEmptyArray(draftValue.value)) {
+      return (
+        <StyledInputContainer>
+          <TextInput
+            instanceId={formFieldInputInstanceId}
+            placeholder={t`Enter an item`}
+            value={newItemDraftValue}
+            copyButton={false}
+            onChange={handleFirstItemInputChange}
+            onEnter={handleFirstItemInputEnter}
+            shouldTrim={false}
+          />
+        </StyledInputContainer>
+      );
+    }
+
+    return (
+      <Dropdown
+        dropdownId={dropdownId}
+        dropdownPlacement="bottom-start"
+        dropdownOffset={{
+          y: parseSpacingValueAsNumber(theme.spacing[1]),
+        }}
+        clickableComponent={
+          <StyledDisplayModeContainer data-open={isDropdownOpen}>
+            <ArrayDisplay value={draftValue.value.map((i) => i.value)} />
+          </StyledDisplayModeContainer>
+        }
+        clickableComponentWidth="100%"
+        dropdownComponents={
+          <DropdownContent ref={containerRef}>
+            <DropdownMenuItemsContainer hasMaxHeight>
+              {draftValue.type === 'static' &&
+                draftValue.value.map((item, index) => (
+                  <ArrayFieldMenuItem
+                    key={item.id}
+                    dropdownId={`array-field-input-${instanceId}-${item.id}`}
+                    value={item.value}
+                    onEdit={() => {
+                      handleEditItem(index);
+                    }}
+                    onDelete={() => {
+                      handleDeleteItem(index);
+                    }}
+                  />
+                ))}
+            </DropdownMenuItemsContainer>
+
+            <DropdownMenuSeparator />
+
+            {renderDropdownInputOrButton()}
+          </DropdownContent>
+        }
+      />
+    );
+  };
+
+  const renderLabel = () => {
+    if (label) {
+      return <InputLabel>{label}</InputLabel>;
+    }
+    return null;
+  };
+
   return (
     <FormFieldInputContainer data-testid={testId}>
-      {label ? <InputLabel>{label}</InputLabel> : null}
+      {renderLabel()}
 
       <FormFieldInputRowContainer>
         <FormFieldInputInnerContainer
@@ -307,95 +469,7 @@ export const FormArrayFieldInput = ({
           preventFocusStackUpdate={preventContainerFocusStackUpdate}
           hasRightElement={isDefined(VariablePicker) && !readonly}
         >
-          {draftValue.type === 'static' ? (
-            readonly ? (
-              <StyledDisplayModeReadonlyContainer>
-                {draftValue.value.length > 0 ? (
-                  <ArrayDisplay value={draftValue.value} />
-                ) : (
-                  <StyledPlaceholderContainer>
-                    <FormFieldPlaceholder />
-                  </StyledPlaceholderContainer>
-                )}
-              </StyledDisplayModeReadonlyContainer>
-            ) : draftValue.value.length === 0 ? (
-              <StyledInputContainer>
-                <TextInput
-                  instanceId={formFieldInputInstanceId}
-                  placeholder={t`Enter an item`}
-                  value={newItemDraftValue}
-                  copyButton={false}
-                  onChange={handleFirstItemInputChange}
-                  onEnter={handleFirstItemInputEnter}
-                  shouldTrim={false}
-                />
-              </StyledInputContainer>
-            ) : (
-              <Dropdown
-                dropdownId={dropdownId}
-                dropdownPlacement="bottom-start"
-                dropdownOffset={{
-                  y: parseSpacingValueAsNumber(theme.spacing[1]),
-                }}
-                clickableComponent={
-                  <StyledDisplayModeContainer data-open={isDropdownOpen}>
-                    <ArrayDisplay value={draftValue.value} />
-                  </StyledDisplayModeContainer>
-                }
-                clickableComponentWidth="100%"
-                dropdownComponents={
-                  <DropdownContent ref={containerRef}>
-                    <DropdownMenuItemsContainer hasMaxHeight>
-                      {draftValue.type === 'static' &&
-                        draftValue.value.map((value, index) => (
-                          <ArrayFieldMenuItem
-                            key={index}
-                            dropdownId={`array-field-input-${instanceId}-${index}`}
-                            value={value}
-                            onEdit={() => {
-                              handleEditItem(index);
-                            }}
-                            onDelete={() => {
-                              handleDeleteItem(index);
-                            }}
-                          />
-                        ))}
-                    </DropdownMenuItemsContainer>
-
-                    <DropdownMenuSeparator />
-
-                    {isInputDisplayed ? (
-                      <MultiItemBaseInput
-                        instanceId={newItemInputInstanceId}
-                        autoFocus
-                        placeholder={placeholder}
-                        value={inputValue}
-                        onFocus={handleNewItemInputFocus}
-                        onBlur={handleNewItemInputBlur}
-                        onEscape={handleNewItemInputEscape}
-                        onChange={handleNewItemInputChange}
-                        onEnter={handleNewItemInputSubmit}
-                        hasItem
-                      />
-                    ) : (
-                      <DropdownMenuItemsContainer>
-                        <MenuItem
-                          onClick={handleAddItemButtonClick}
-                          LeftIcon={IconPlus}
-                          text={t`Add item`}
-                        />
-                      </DropdownMenuItemsContainer>
-                    )}
-                  </DropdownContent>
-                }
-              />
-            )
-          ) : (
-            <VariableChipStandalone
-              rawVariableName={draftValue.value}
-              onRemove={readonly ? undefined : handleUnlinkVariable}
-            />
-          )}
+          {renderInnerContent()}
         </FormFieldInputInnerContainer>
 
         {VariablePicker && !readonly && (

--- a/packages/twenty-front/src/modules/object-record/record-field/ui/form-types/components/__stories__/FormArrayFieldInput.stories.tsx
+++ b/packages/twenty-front/src/modules/object-record/record-field/ui/form-types/components/__stories__/FormArrayFieldInput.stories.tsx
@@ -94,9 +94,11 @@ export const EditExistingItem: Story = {
     await userEvent.click(firstItemChip);
 
     const openSecondItemMenuButton = await waitFor(() => {
-      const button = canvasElement.ownerDocument.body.querySelector(
-        '[aria-controls$="-1-options"] > button',
+      const buttons = canvasElement.ownerDocument.body.querySelectorAll(
+        '.hoverable-buttons button',
       );
+
+      const button = buttons[1];
 
       if (!isDefined(button)) {
         throw new Error('Button not found');
@@ -151,9 +153,11 @@ export const DeleteExistingItem: Story = {
     await userEvent.click(firstItemChip);
 
     const openSecondItemMenuButton = await waitFor(() => {
-      const button = canvasElement.ownerDocument.body.querySelector(
-        '[aria-controls$="-1-options"] > button',
+      const buttons = canvasElement.ownerDocument.body.querySelectorAll(
+        '.hoverable-buttons button',
       );
+
+      const button = buttons[1];
 
       if (!isDefined(button)) {
         throw new Error('Button not found');

--- a/packages/twenty-front/src/modules/object-record/record-field/ui/meta-types/input/components/ArrayFieldInput.tsx
+++ b/packages/twenty-front/src/modules/object-record/record-field/ui/meta-types/input/components/ArrayFieldInput.tsx
@@ -5,7 +5,7 @@ import { ArrayFieldMenuItem } from '@/object-record/record-field/ui/meta-types/i
 import { MultiItemFieldInput } from '@/object-record/record-field/ui/meta-types/input/components/MultiItemFieldInput';
 import { MULTI_ITEM_FIELD_INPUT_DROPDOWN_ID_PREFIX } from '@/object-record/record-field/ui/meta-types/input/constants/MultiItemFieldInputDropdownClickOutsideId';
 import { arrayFieldValueSchema } from '@/object-record/record-field/ui/validation-schemas/arrayFieldValueSchema';
-import { useContext, useMemo, useState } from 'react';
+import { useContext, useMemo, useState, useEffect } from 'react';
 import { MULTI_ITEM_FIELD_DEFAULT_MAX_VALUES } from 'twenty-shared/constants';
 import { isDefined } from 'twenty-shared/utils';
 import { FieldMetadataType } from '~/generated-metadata/graphql';
@@ -16,10 +16,14 @@ const getExtendedIds = (prevIds: string[], targetLength: number): string[] => {
   if (targetLength <= prevIds.length) {
     return prevIds;
   }
-  return [
-    ...prevIds,
-    ...Array.from({ length: targetLength - prevIds.length }, () => v4()),
-  ];
+  
+  const idsToAdd = targetLength - prevIds.length;
+  const newIds: string[] = [];
+  for (let i = 0; i < idsToAdd; i++) {
+    newIds.push(v4());
+  }
+  
+  return [...prevIds, ...newIds];
 };
 
 export const ArrayFieldInput = () => {
@@ -39,24 +43,27 @@ export const ArrayFieldInput = () => {
   const [stableIds, setStableIds] = useState<string[]>(() =>
     arrayItems.map(() => v4()),
   );
-  const [prevArrayItems, setPrevArrayItems] = useState(arrayItems);
 
-  if (prevArrayItems !== arrayItems) {
-    setPrevArrayItems(arrayItems);
+  useEffect(() => {
     setStableIds((prevIds) => {
+      if (arrayItems.length === prevIds.length) {
+        return prevIds;
+      }
       if (arrayItems.length < prevIds.length) {
         return prevIds.slice(0, arrayItems.length);
       }
       return getExtendedIds(prevIds, arrayItems.length);
     });
-  }
+  }, [arrayItems.length]);
 
-  const parseStringArrayToArrayValue = (arrayItems: string[]) => {
-    const parseResponse = arrayFieldValueSchema.safeParse(arrayItems);
+  const parseStringArrayToArrayValue = (items: string[]) => {
+    const parseResponse = arrayFieldValueSchema.safeParse(items);
 
     if (parseResponse.success) {
       return parseResponse.data;
     }
+    
+    return undefined;
   };
 
   const handleChange = (newValue: string[]) => {
@@ -77,23 +84,39 @@ export const ArrayFieldInput = () => {
     newValue: string[],
     event: MouseEvent | TouchEvent,
   ) => {
-    onClickOutside?.({
-      newValue: parseStringArrayToArrayValue(newValue),
-      event,
-    });
+    if (isDefined(onClickOutside)) {
+      onClickOutside({
+        newValue: parseStringArrayToArrayValue(newValue),
+        event,
+      });
+    }
   };
 
   const handleEscape = (newValue: string[]) => {
-    onEscape?.({ newValue: parseStringArrayToArrayValue(newValue) });
+    if (isDefined(onEscape)) {
+      onEscape({ newValue: parseStringArrayToArrayValue(newValue) });
+    }
   };
 
   const handleEnter = (newValue: string[]) => {
-    onEnter?.({ newValue: parseStringArrayToArrayValue(newValue) });
+    if (isDefined(onEnter)) {
+      onEnter({ newValue: parseStringArrayToArrayValue(newValue) });
+    }
   };
 
-  const maxNumberOfValues =
-    fieldDefinition.metadata.settings?.maxNumberOfValues ??
-    MULTI_ITEM_FIELD_DEFAULT_MAX_VALUES;
+  const getMaxNumberOfValues = () => {
+    if (isDefined(fieldDefinition.metadata.settings?.maxNumberOfValues)) {
+      return fieldDefinition.metadata.settings.maxNumberOfValues;
+    }
+    return MULTI_ITEM_FIELD_DEFAULT_MAX_VALUES;
+  };
+
+  const getStableId = (index: number) => {
+    if (isDefined(stableIds[index])) {
+      return stableIds[index];
+    }
+    return index.toString();
+  };
 
   return (
     <MultiItemFieldInput
@@ -107,8 +130,8 @@ export const ArrayFieldInput = () => {
       fieldMetadataType={FieldMetadataType.ARRAY}
       renderItem={({ value, index, handleEdit, handleDelete }) => (
         <ArrayFieldMenuItem
-          key={stableIds[index] || index}
-          dropdownId={`${MULTI_ITEM_FIELD_INPUT_DROPDOWN_ID_PREFIX}-${fieldDefinition.metadata.fieldName}-${stableIds[index] || index}`}
+          key={getStableId(index)}
+          dropdownId={`${MULTI_ITEM_FIELD_INPUT_DROPDOWN_ID_PREFIX}-${fieldDefinition.metadata.fieldName}-${getStableId(index)}`}
           value={value}
           onEdit={handleEdit}
           onDelete={() => {
@@ -117,7 +140,8 @@ export const ArrayFieldInput = () => {
           }}
         />
       )}
-      maxItemCount={maxNumberOfValues}
+      maxItemCount={getMaxNumberOfValues()}
     ></MultiItemFieldInput>
   );
 };
+

--- a/packages/twenty-front/src/modules/object-record/record-field/ui/meta-types/input/components/ArrayFieldInput.tsx
+++ b/packages/twenty-front/src/modules/object-record/record-field/ui/meta-types/input/components/ArrayFieldInput.tsx
@@ -5,7 +5,7 @@ import { ArrayFieldMenuItem } from '@/object-record/record-field/ui/meta-types/i
 import { MultiItemFieldInput } from '@/object-record/record-field/ui/meta-types/input/components/MultiItemFieldInput';
 import { MULTI_ITEM_FIELD_INPUT_DROPDOWN_ID_PREFIX } from '@/object-record/record-field/ui/meta-types/input/constants/MultiItemFieldInputDropdownClickOutsideId';
 import { arrayFieldValueSchema } from '@/object-record/record-field/ui/validation-schemas/arrayFieldValueSchema';
-import { useContext, useMemo, useState, useEffect } from 'react';
+import { useContext, useMemo, useState } from 'react';
 import { MULTI_ITEM_FIELD_DEFAULT_MAX_VALUES } from 'twenty-shared/constants';
 import { isDefined } from 'twenty-shared/utils';
 import { FieldMetadataType } from '~/generated-metadata/graphql';
@@ -44,17 +44,16 @@ export const ArrayFieldInput = () => {
     arrayItems.map(() => v4()),
   );
 
-  useEffect(() => {
-    setStableIds((prevIds) => {
-      if (arrayItems.length === prevIds.length) {
-        return prevIds;
-      }
-      if (arrayItems.length < prevIds.length) {
-        return prevIds.slice(0, arrayItems.length);
-      }
-      return getExtendedIds(prevIds, arrayItems.length);
-    });
-  }, [arrayItems.length]);
+  let currentStableIds = stableIds;
+
+  if (arrayItems.length !== stableIds.length) {
+    if (arrayItems.length < stableIds.length) {
+      currentStableIds = stableIds.slice(0, arrayItems.length);
+    } else {
+      currentStableIds = getExtendedIds(stableIds, arrayItems.length);
+    }
+    setStableIds(currentStableIds);
+  }
 
   const parseStringArrayToArrayValue = (items: string[]) => {
     const parseResponse = arrayFieldValueSchema.safeParse(items);
@@ -112,8 +111,8 @@ export const ArrayFieldInput = () => {
   };
 
   const getStableId = (index: number) => {
-    if (isDefined(stableIds[index])) {
-      return stableIds[index];
+    if (isDefined(currentStableIds[index])) {
+      return currentStableIds[index];
     }
     return index.toString();
   };

--- a/packages/twenty-front/src/modules/object-record/record-field/ui/meta-types/input/components/ArrayFieldInput.tsx
+++ b/packages/twenty-front/src/modules/object-record/record-field/ui/meta-types/input/components/ArrayFieldInput.tsx
@@ -16,13 +16,13 @@ const getExtendedIds = (prevIds: string[], targetLength: number): string[] => {
   if (targetLength <= prevIds.length) {
     return prevIds;
   }
-  
+
   const idsToAdd = targetLength - prevIds.length;
   const newIds: string[] = [];
   for (let i = 0; i < idsToAdd; i++) {
     newIds.push(v4());
   }
-  
+
   return [...prevIds, ...newIds];
 };
 
@@ -62,7 +62,7 @@ export const ArrayFieldInput = () => {
     if (parseResponse.success) {
       return parseResponse.data;
     }
-    
+
     return undefined;
   };
 
@@ -144,4 +144,3 @@ export const ArrayFieldInput = () => {
     ></MultiItemFieldInput>
   );
 };
-

--- a/packages/twenty-front/src/modules/object-record/record-field/ui/meta-types/input/components/ArrayFieldInput.tsx
+++ b/packages/twenty-front/src/modules/object-record/record-field/ui/meta-types/input/components/ArrayFieldInput.tsx
@@ -5,10 +5,22 @@ import { ArrayFieldMenuItem } from '@/object-record/record-field/ui/meta-types/i
 import { MultiItemFieldInput } from '@/object-record/record-field/ui/meta-types/input/components/MultiItemFieldInput';
 import { MULTI_ITEM_FIELD_INPUT_DROPDOWN_ID_PREFIX } from '@/object-record/record-field/ui/meta-types/input/constants/MultiItemFieldInputDropdownClickOutsideId';
 import { arrayFieldValueSchema } from '@/object-record/record-field/ui/validation-schemas/arrayFieldValueSchema';
-import { useContext, useMemo } from 'react';
+import { useContext, useMemo, useState } from 'react';
 import { MULTI_ITEM_FIELD_DEFAULT_MAX_VALUES } from 'twenty-shared/constants';
 import { isDefined } from 'twenty-shared/utils';
 import { FieldMetadataType } from '~/generated-metadata/graphql';
+import { toSpliced } from '~/utils/array/toSpliced';
+import { v4 } from 'uuid';
+
+const getExtendedIds = (prevIds: string[], targetLength: number): string[] => {
+  if (targetLength <= prevIds.length) {
+    return prevIds;
+  }
+  return [
+    ...prevIds,
+    ...Array.from({ length: targetLength - prevIds.length }, () => v4()),
+  ];
+};
 
 export const ArrayFieldInput = () => {
   const { setDraftValue, draftValue, fieldDefinition } = useArrayField();
@@ -17,10 +29,28 @@ export const ArrayFieldInput = () => {
     FieldInputEventContext,
   );
 
-  const arrayItems = useMemo<Array<string>>(
-    () => (Array.isArray(draftValue) ? draftValue : []),
-    [draftValue],
+  const arrayItems = useMemo<Array<string>>(() => {
+    if (Array.isArray(draftValue)) {
+      return draftValue;
+    }
+    return [];
+  }, [draftValue]);
+
+  const [stableIds, setStableIds] = useState<string[]>(() =>
+    arrayItems.map(() => v4()),
   );
+  const [prevArrayItems, setPrevArrayItems] = useState(arrayItems);
+
+  if (prevArrayItems !== arrayItems) {
+    setPrevArrayItems(arrayItems);
+    setStableIds((prevIds) => {
+      if (arrayItems.length < prevIds.length) {
+        return prevIds.slice(0, arrayItems.length);
+      }
+      return getExtendedIds(prevIds, arrayItems.length);
+    });
+  }
+
   const parseStringArrayToArrayValue = (arrayItems: string[]) => {
     const parseResponse = arrayFieldValueSchema.safeParse(arrayItems);
 
@@ -30,7 +60,11 @@ export const ArrayFieldInput = () => {
   };
 
   const handleChange = (newValue: string[]) => {
-    if (!isDefined(newValue)) setDraftValue(null);
+    setStableIds((prevIds) => getExtendedIds(prevIds, newValue.length));
+
+    if (!isDefined(newValue)) {
+      setDraftValue(null);
+    }
 
     const nextValue = parseStringArrayToArrayValue(newValue);
 
@@ -73,11 +107,14 @@ export const ArrayFieldInput = () => {
       fieldMetadataType={FieldMetadataType.ARRAY}
       renderItem={({ value, index, handleEdit, handleDelete }) => (
         <ArrayFieldMenuItem
-          key={index}
-          dropdownId={`${MULTI_ITEM_FIELD_INPUT_DROPDOWN_ID_PREFIX}-${fieldDefinition.metadata.fieldName}-${index}`}
+          key={stableIds[index] || index}
+          dropdownId={`${MULTI_ITEM_FIELD_INPUT_DROPDOWN_ID_PREFIX}-${fieldDefinition.metadata.fieldName}-${stableIds[index] || index}`}
           value={value}
           onEdit={handleEdit}
-          onDelete={handleDelete}
+          onDelete={() => {
+            setStableIds((prevIds) => toSpliced(prevIds, index, 1));
+            handleDelete();
+          }}
         />
       )}
       maxItemCount={maxNumberOfValues}

--- a/packages/twenty-ui-deprecated/src/layout/modal/components/Modal.tsx
+++ b/packages/twenty-ui-deprecated/src/layout/modal/components/Modal.tsx
@@ -158,7 +158,7 @@ export const Modal = ({
           isInContainer={isInContainer}
         >
           <AnimatedModalDiv
-            ref={resolvedRef}
+            ref={resolvedRef as React.Ref<HTMLDivElement>}
             size={size}
             padding={padding}
             initial="hidden"


### PR DESCRIPTION
Closes #21544

# Description

This PR fixes a critical React reconciliation bug where dynamic array items in record fields lost state and focus when an item in the middle of the array was deleted. This was caused by the anti-pattern of using the array map `index` as the React `key`.

### Root Cause & Technical Implementation
To accurately track DOM node additions and deletions, I replaced the index keys with stable UUIDs across the affected components:

- **`FormArrayFieldInput.tsx`**: Restructured the internal static `draftValue` state to natively use an array of objects (`[{ id, value }]`), assigning a stable `v4()` UUID to each item upon creation. This natively guarantees stable identities across edits and deletions. I also implemented safe optional chaining (`items[itemToEditIndex]?.value`) to prevent edge-case crashes if an item is rapidly deleted while its edit input is open. All nested ternaries were removed to adhere strictly to Twenty technical standards.
- **`ArrayFieldInput.tsx`**: Implemented a robust, deterministic event-driven tracking mechanism (`stableIds`) using derived state. This synchronously tracks UUIDs alongside the external string array without relying on fragile heuristic guessing algorithms or modifying the parent data contracts.

### How to Test / Verification

1. Navigate to any object record in the CRM that utilizes a dynamic array field.
2. Add 3 distinct items to the array input (e.g., "Item A", "Item B", "Item C").
3. Click into the input field for "Item C" to ensure it has browser focus.
4. Delete the middle item ("Item B").
5. **Verify:** "Item C" should shift up, retain its exact value, and React should not lose focus or overwrite the component state.

https://github.com/user-attachments/assets/7495e1a6-6c44-4856-892d-3a16eb653866

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/21558?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

