### PR TITLE
chore(deps): ignore chokidar in dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,3 +15,6 @@ updates:
       - dependency-name: "@nestjs/graphql"
       - dependency-name: "@ptc-org/nestjs-query-graphql"
       - dependency-name: "typeorm"
+      # chokidar is pinned to v3 via a resolution: v4+ dropped native macOS
+      # FSEvents and hits EMFILE on a repo this size (see #20316)
+      - dependency-name: "chokidar"


### PR DESCRIPTION
## Context

Dependabot keeps proposing a chokidar v3 to v4 bump (e.g. #21555), but chokidar is intentionally pinned to v3 via a `resolutions` entry in the root `package.json`.

chokidar v4 removed the native macOS FSEvents backend and falls back to `node:fs.watch`, which hits `EMFILE` on a repo this size. That was diagnosed and fixed in #20316. The bump can't even be satisfied while the resolution is in place, so the lockfile and `package.json` end up inconsistent and CI goes red.

## Change

Add `chokidar` to the dependabot ignore list so it stops re-proposing the bump every cycle. The pin stays until upstream restores a native watcher backend.

Closes out #21555.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/21564?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

