### PR TITLE
fix(front): keep the filename when a file has no extension

### DIFF
--- a/packages/twenty-front/src/utils/file/__tests__/getFileNameAndExtension.test.ts
+++ b/packages/twenty-front/src/utils/file/__tests__/getFileNameAndExtension.test.ts
@@ -20,8 +20,24 @@ describe('getFileNameAndExtension', () => {
   it('should handle files with no extension', () => {
     const result = getFileNameAndExtension('README');
     expect(result).toEqual({
-      name: '',
-      extension: 'README',
+      name: 'README',
+      extension: '',
+    });
+  });
+
+  it('should keep the full name when there is no dot at all', () => {
+    const result = getFileNameAndExtension('my document file');
+    expect(result).toEqual({
+      name: 'my document file',
+      extension: '',
+    });
+  });
+
+  it('should handle a trailing dot', () => {
+    const result = getFileNameAndExtension('file.');
+    expect(result).toEqual({
+      name: 'file',
+      extension: '.',
     });
   });
 

--- a/packages/twenty-front/src/utils/file/getFileNameAndExtension.ts
+++ b/packages/twenty-front/src/utils/file/getFileNameAndExtension.ts
@@ -1,6 +1,15 @@
 export const getFileNameAndExtension = (filenameWithExtension: string) => {
   const lastDotIndex = filenameWithExtension.lastIndexOf('.');
 
+  // Without a dot, substring(0, -1) and substring(-1) would put the whole
+  // filename into the extension, so keep it as the name with an empty extension.
+  if (lastDotIndex === -1) {
+    return {
+      name: filenameWithExtension,
+      extension: '',
+    };
+  }
+
   return {
     name: filenameWithExtension.substring(0, lastDotIndex),
     extension: filenameWithExtension.substring(lastDotIndex),


### PR DESCRIPTION
Closes #21575.

## Summary

`getFileNameAndExtension` split filenames with `lastIndexOf('.')`. For an extensionless name (`README`, `Makefile`), `lastIndexOf` returns `-1` and `substring`'s negative-index clamping returned `{ name: '', extension: 'README' }` — losing the whole name into the extension. In the attachments UI this rendered an empty rename field and corrupted the name on edit.

## Changes

- Early return `{ name, extension: '' }` when there is no dot
- Correct the existing test that asserted the buggy output; add no-dot + trailing-dot cases

## Testing

Pure, dependency-free function — verified deterministically (17/17 assertions, red-green proven: reverting the fix fails the corrected `README` assertion). Note: twenty's full nx lint/test wasn't run locally (repo wants Node ^24.5.0; this box is on Node 26), so CI is the authoritative check for lint/format.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/21576?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

