### PR TITLE
Ignore generated Storybook/Argos screenshot output

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,4 +57,5 @@ TRANSLATION_QA_REPORT.md
 .playwright-cli/
 output/playwright/
 screenshots/
-!**/screenshots/
+!**/public/screenshots/
+!**/assets/screenshots/


### PR DESCRIPTION
## Context

`packages/twenty-front/screenshots/` (and the equivalent under other Storybook packages) holds Argos visual-regression baselines that are generated on demand and not meant to be committed. The existing rules in `.gitignore` were:

```
screenshots/
!**/screenshots/
```

The `!**/screenshots/` negation was added so app images committed under `public/screenshots/` (github-connector) and `assets/screenshots/` (codex-plugin) stay tracked — but it is too broad: it also re-includes the generated output, so a `git add -A` can accidentally commit hundreds of baseline PNGs.

## What this does

Narrows the negation to the two locations where screenshots are intentionally committed:

```
screenshots/
!**/public/screenshots/
!**/assets/screenshots/
```

Generated `screenshots/` directories at package roots (twenty-front, twenty-ui, twenty-ui-deprecated, twenty-front-component-renderer) are now ignored again, while committed app images remain tracked. Verified with `git check-ignore`.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/21589?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

