### PR TITLE
Hide logic functions that are not exposed as tools

### DIFF
--- a/packages/twenty-front/src/modules/side-panel/pages/workflow/action/components/SidePanelWorkflowSelectAction.tsx
+++ b/packages/twenty-front/src/modules/side-panel/pages/workflow/action/components/SidePanelWorkflowSelectAction.tsx
@@ -1,4 +1,7 @@
+import { isWorkspaceCustomApplication } from '@/applications/utils/isWorkspaceCustomApplication';
+import { currentWorkspaceState } from '@/auth/states/currentWorkspaceState';
 import { logicFunctionsSelector } from '@/logic-functions/states/logicFunctionsSelector';
+import { ToolMenuItem } from '@/side-panel/pages/workflow/action/components/ToolMenuItem';
 import { WorkflowActionMenuItems } from '@/side-panel/pages/workflow/action/components/WorkflowActionMenuItems';
 import { useAtomStateValue } from '@/ui/utilities/state/jotai/hooks/useAtomStateValue';
 import { type WorkflowActionType } from '@/workflow/types/Workflow';
@@ -9,7 +12,6 @@ import { CORE_ACTIONS } from '@/workflow/workflow-steps/workflow-actions/constan
 import { FLOW_ACTIONS } from '@/workflow/workflow-steps/workflow-actions/constants/FlowActions';
 import { HUMAN_INPUT_ACTIONS } from '@/workflow/workflow-steps/workflow-actions/constants/HumanInputActions';
 import { RECORD_ACTIONS } from '@/workflow/workflow-steps/workflow-actions/constants/RecordActions';
-import { ToolMenuItem } from '@/side-panel/pages/workflow/action/components/ToolMenuItem';
 import { useLingui } from '@lingui/react/macro';
 import { isDefined } from 'twenty-shared/utils';
 
@@ -26,9 +28,13 @@ export const SidePanelWorkflowSelectAction = ({
   const { t } = useLingui();
 
   const logicFunctions = useAtomStateValue(logicFunctionsSelector);
+  const currentWorkspace = useAtomStateValue(currentWorkspaceState);
 
-  const toolFunctions = logicFunctions.filter((fn) =>
-    isDefined(fn.workflowActionTriggerSettings),
+  const toolFunctions = logicFunctions.filter(
+    (fn) =>
+      isDefined(fn.workflowActionTriggerSettings) &&
+      isDefined(fn.applicationId) &&
+      !isWorkspaceCustomApplication({ id: fn.applicationId }, currentWorkspace),
   );
 
   const handleActionClick = (actionType: WorkflowActionType) => {


### PR DESCRIPTION
each time we create a workflow node that is a logic function, it creates a logic function that is then exposed in the options for future nodes.
Let's hide them by only showing here functions that were added by applications that are not the workspace application. If a logic function was meant to be exposed as a tool by an application, it will still show. Decided to go with this as I see no case where we create a logic function from the main app that we want exposed as a tool. 

<img width="614" height="927" alt="image" src="https://github.com/user-attachments/assets/e51d38a6-234f-4eee-a993-32d02ce6ad1e" />


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/21598?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

