### PR TITLE
chore(server): remove stray comment in flat-entity-maps spec

### DIFF
--- a/packages/twenty-server/src/engine/workspace-manager/workspace-migration/utils/__tests__/add-flat-entity-to-flat-entity-maps-through-mutation-or-throw.util.spec.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/workspace-migration/utils/__tests__/add-flat-entity-to-flat-entity-maps-through-mutation-or-throw.util.spec.ts
@@ -55,7 +55,6 @@ describe('addFlatEntityToFlatEntityMapsThroughMutationOrThrow', () => {
       flatEntityMapsToMutate.universalIdentifiersByApplicationId['app-1'];
 
     expect(universalIdentifiers).toEqual(['uid-1', 'uid-2']);
-    // Distinct entities, so each universalIdentifier appears exactly once
     expect(new Set(universalIdentifiers).size).toBe(
       universalIdentifiers?.length,
     );


### PR DESCRIPTION
Follow-up to #21585: removes an explanatory comment in the test that slipped through before merge.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/21599?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

