### PR TITLE
fix(server): delete leaked default views in 2.14.0 upgrade

### DIFF
--- a/packages/twenty-server/src/database/commands/upgrade-version-command/2-14/2-14-instance-command-slow-1799000050000-delete-leaked-default-views.ts
+++ b/packages/twenty-server/src/database/commands/upgrade-version-command/2-14/2-14-instance-command-slow-1799000050000-delete-leaked-default-views.ts
@@ -1,0 +1,108 @@
+import { Logger } from '@nestjs/common';
+
+import { DataSource, QueryRunner } from 'typeorm';
+
+import { RegisteredInstanceCommand } from 'src/engine/core-modules/upgrade/decorators/registered-instance-command.decorator';
+import { SlowInstanceCommand } from 'src/engine/core-modules/upgrade/interfaces/slow-instance-command.interface';
+
+// Between 2.13.0 and 2.14.0, useCreateDefaultViewForObject (a temporary
+// runtime fallback) leaked core.view + core.viewField rows on every
+// record-index load: each created view got a fresh id that never matched the
+// requested contextStoreCurrentViewId, so the next load missed again and
+// re-created another duplicate view (plus ~one viewField per field) without
+// bound. See the root-cause fix in useCreateDefaultViewForObject.
+//
+// This deletes those leaked rows. A leaked view is recognized by the exact
+// shape the fallback produced — and is only removed when the object keeps at
+// least one other view, so no object is ever left view-less:
+//   - key IS NULL            (real default/index views are key = 'INDEX')
+//   - isCustom = false
+//   - overrides IS NULL
+//   - no filter / sort / group / field-group / filter-group  (bare)
+//   - not referenced by a navigationMenuItem                 (not in the nav)
+// Deleting the view cascades to its viewField (and any other) children.
+
+const DELETE_BATCH_SIZE = 5000;
+
+const LEAKED_DEFAULT_VIEW_IDS_TO_DELETE = `
+  WITH candidate AS (
+    SELECT v.id, v."workspaceId", v."objectMetadataId", v."createdAt"
+    FROM core.view v
+    WHERE v."deletedAt" IS NULL
+      AND v.key IS NULL
+      AND v."isCustom" = false
+      AND v.overrides IS NULL
+      AND NOT EXISTS (SELECT 1 FROM core."viewFilter" f WHERE f."viewId" = v.id)
+      AND NOT EXISTS (SELECT 1 FROM core."viewSort" s WHERE s."viewId" = v.id)
+      AND NOT EXISTS (SELECT 1 FROM core."viewGroup" g WHERE g."viewId" = v.id)
+      AND NOT EXISTS (SELECT 1 FROM core."viewFieldGroup" fg WHERE fg."viewId" = v.id)
+      AND NOT EXISTS (SELECT 1 FROM core."viewFilterGroup" flg WHERE flg."viewId" = v.id)
+      AND NOT EXISTS (SELECT 1 FROM core."navigationMenuItem" n WHERE n."viewId" = v.id)
+  ),
+  object_has_real_sibling AS (
+    SELECT DISTINCT v."workspaceId", v."objectMetadataId"
+    FROM core.view v
+    WHERE v."deletedAt" IS NULL
+      AND NOT EXISTS (SELECT 1 FROM candidate c WHERE c.id = v.id)
+  ),
+  ranked AS (
+    SELECT
+      c.id,
+      row_number() OVER (
+        PARTITION BY c."workspaceId", c."objectMetadataId"
+        ORDER BY c."createdAt" ASC, c.id ASC
+      ) AS rn,
+      (s."workspaceId" IS NOT NULL) AS object_has_real_sibling
+    FROM candidate c
+    LEFT JOIN object_has_real_sibling s
+      ON s."workspaceId" = c."workspaceId"
+     AND s."objectMetadataId" = c."objectMetadataId"
+  )
+  SELECT id
+  FROM ranked
+  WHERE object_has_real_sibling = true OR rn > 1
+  LIMIT $1
+`;
+
+@RegisteredInstanceCommand('2.14.0', 1799000050000, { type: 'slow' })
+export class DeleteLeakedDefaultViewsSlowInstanceCommand
+  implements SlowInstanceCommand
+{
+  private readonly logger = new Logger(
+    DeleteLeakedDefaultViewsSlowInstanceCommand.name,
+  );
+
+  async runDataMigration(dataSource: DataSource): Promise<void> {
+    let totalDeleted = 0;
+
+    // Batched so we never hold a single huge transaction / long lock on a
+    // table that may have accumulated millions of leaked rows.
+    while (true) {
+      const rows: { id: string }[] = await dataSource.query(
+        LEAKED_DEFAULT_VIEW_IDS_TO_DELETE,
+        [DELETE_BATCH_SIZE],
+      );
+
+      if (rows.length === 0) {
+        break;
+      }
+
+      const ids = rows.map((row) => row.id);
+
+      // viewField and the other view children cascade-delete with the view.
+      await dataSource.query(`DELETE FROM core.view WHERE id = ANY($1)`, [ids]);
+
+      totalDeleted += ids.length;
+    }
+
+    this.logger.log(`Deleted ${totalDeleted} leaked default view(s)`);
+  }
+
+  public async up(_queryRunner: QueryRunner): Promise<void> {
+    return;
+  }
+
+  public async down(_queryRunner: QueryRunner): Promise<void> {
+    return;
+  }
+}

--- a/packages/twenty-server/src/database/commands/upgrade-version-command/instance-commands.constant.ts
+++ b/packages/twenty-server/src/database/commands/upgrade-version-command/instance-commands.constant.ts
@@ -70,6 +70,7 @@ import { RenameIsUiReadOnlyToIsUiEditableFastInstanceCommand } from 'src/databas
 import { BackfillNonUiCreatableStandardSystemObjectsSlowInstanceCommand } from 'src/database/commands/upgrade-version-command/2-13/2-13-instance-command-slow-1781277480000-backfill-non-ui-creatable-standard-system-objects';
 import { CommandMenuItemOverridableEntityFastInstanceCommand } from 'src/database/commands/upgrade-version-command/2-13/2-13-instance-command-fast-1781253016028-command-menu-item-overridable-entity';
 import { SetTableWidgetViewsVisibilityToWorkspaceSlowInstanceCommand } from 'src/database/commands/upgrade-version-command/2-14/2-14-instance-command-slow-1781515653781-set-table-widget-views-visibility-to-workspace';
+import { DeleteLeakedDefaultViewsSlowInstanceCommand } from 'src/database/commands/upgrade-version-command/2-14/2-14-instance-command-slow-1799000050000-delete-leaked-default-views';
 
 export const INSTANCE_COMMANDS = [
   AddViewFieldGroupIdIndexOnViewFieldFastInstanceCommand,
@@ -142,4 +143,5 @@ export const INSTANCE_COMMANDS = [
   BackfillNonUiCreatableStandardSystemObjectsSlowInstanceCommand,
   CommandMenuItemOverridableEntityFastInstanceCommand,
   SetTableWidgetViewsVisibilityToWorkspaceSlowInstanceCommand,
+  DeleteLeakedDefaultViewsSlowInstanceCommand,
 ];


### PR DESCRIPTION
## Context

Follow-up to #21592 (the root-cause front-end fix). Between 2.13.0 and 2.14.0, `useCreateDefaultViewForObject` — a temporary runtime fallback — leaked `core.view` + `core.viewField` rows on every record-index load: each created view got a *fresh* id that never matched the requested `contextStoreCurrentViewId`, so the next load missed again and re-created another duplicate view (plus ~one `viewField` per field) without bound. The accumulating rows then fed a quadratic flat-map rebuild, ramping `POST /metadata` tail latency and CPU.

#21592 stops the leak. This PR is the **cleanup pass** for the already-leaked rows.

## What this does

Adds a slow instance command (`2.14.0`) that hard-deletes the leaked views. Deleting a view cascade-deletes its `viewField` (and other) children.

**Hard delete is required:** the flat-view map cache loads views with `withDeleted: true` (`workspace-flat-view-map-cache.service.ts`), so soft-deleted rows would still feed the quadratic rebuild and not relieve the perf pressure.

## How a leaked view is identified

A view is a cleanup candidate only when it matches the exact shape the fallback produced:

- `key IS NULL` (real default/index views are `key = 'INDEX'`)
- `isCustom = false`
- `overrides IS NULL`
- no filter / sort / group / field-group / filter-group (bare)
- not referenced by a `navigationMenuItem` (not in the nav)

A candidate is deleted **only when its object keeps at least one other live view** (a real sibling, or an older candidate is kept as survivor) — so no object is ever left view-less. Survivor selection prefers any non-candidate view; otherwise the oldest candidate is kept.

## Safety / rollout

- Batched (5k views/iteration) to avoid a single huge transaction / long lock on a table that may hold millions of leaked rows.
- Diagnostic SQL (sizing + a "no object left view-less" safety check, which must return 0) is being run against prod before this ships.
- `down()` is a no-op (deleted garbage rows are not restorable).

## Follow-ups (tracked elsewhere)

- O(N²)→O(N) flat-map builder: #21585
- The cache-first bootstrap experiment (#21532) that opened the trigger window should be reviewed/gated.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/21614?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

