### PR TITLE
fix(twenty-partners): reuse existing company by domain in partner-application handler

### DIFF
--- a/packages/twenty-apps/internal/twenty-partners/package.json
+++ b/packages/twenty-apps/internal/twenty-partners/package.json
@@ -1,6 +1,6 @@
 {
   "name": "twenty-partners",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "license": "MIT",
   "engines": {
     "node": "^24.5.0",

--- a/packages/twenty-apps/internal/twenty-partners/src/logic-functions/__tests__/submit-partner-application.integration-test.ts
+++ b/packages/twenty-apps/internal/twenty-partners/src/logic-functions/__tests__/submit-partner-application.integration-test.ts
@@ -122,6 +122,49 @@ describe('submit-partner-application handler — upsert', () => {
     expect(personNode?.name?.lastName).toBe('Lovelace');
   });
 
+  it('reuses an existing company that already owns the applicant domain instead of failing on the unique domain index', async () => {
+    // A company with this domain already exists (e.g. seeded by the TFT import,
+    // with no Partner/Person attached). Company.domainName is uniquely indexed,
+    // so a blind createCompany would throw "duplicate entry" and the whole
+    // submission would 502. The handler must reuse this company instead.
+    const domain = 'https://reuse-domain-case.example.com';
+    const created = await client.mutation({
+      createCompany: {
+        __args: { data: { name: 'Pre-existing Co', domainName: { primaryLinkUrl: domain } } },
+        id: true,
+      },
+    });
+    const existingCompanyId = created.createCompany?.id;
+    expect(existingCompanyId).toBeDefined();
+    if (existingCompanyId === undefined) return;
+    createdCompanyIds.push(existingCompanyId);
+
+    const result = await handler(
+      authedEvent(
+        baseInput({
+          email: 'reuse.domain@example.com',
+          companyName: 'Applicant Co',
+          domainName: domain,
+        }),
+      ),
+    );
+    await trackCreated(result);
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.created).toBe(true);
+
+    const partner = await client.query({
+      partner: {
+        __args: { filter: { id: { eq: result.partnerId } } },
+        company: { id: true, name: true },
+      },
+    });
+    // Reused the existing company (same id) and left its name untouched.
+    expect(partner.partner?.company?.id).toBe(existingCompanyId);
+    expect(partner.partner?.company?.name).toBe('Pre-existing Co');
+  });
+
   it('returns created: false and updates fields on resubmission for the same email', async () => {
     const first = await handler(authedEvent(baseInput({ email: 'update.case@example.com', city: 'London' })));
     await trackCreated(first);

--- a/packages/twenty-apps/internal/twenty-partners/src/logic-functions/__tests__/submit-partner-application.integration-test.ts
+++ b/packages/twenty-apps/internal/twenty-partners/src/logic-functions/__tests__/submit-partner-application.integration-test.ts
@@ -122,15 +122,18 @@ describe('submit-partner-application handler — upsert', () => {
     expect(personNode?.name?.lastName).toBe('Lovelace');
   });
 
-  it('reuses an existing company that already owns the applicant domain instead of failing on the unique domain index', async () => {
+  it('reuses an existing company for a protocol/www/case domain variant instead of failing on the unique domain index', async () => {
     // A company with this domain already exists (e.g. seeded by the TFT import,
     // with no Partner/Person attached). Company.domainName is uniquely indexed,
     // so a blind createCompany would throw "duplicate entry" and the whole
-    // submission would 502. The handler must reuse this company instead.
-    const domain = 'https://reuse-domain-case.example.com';
+    // submission would 502. The applicant submits a www/case/trailing-slash
+    // variant of the same real domain — the handler must still reuse the
+    // existing company via normalized-host matching.
+    const storedDomain = 'https://reuse-domain-case.example.com';
+    const submittedVariant = 'https://www.Reuse-Domain-Case.example.com/';
     const created = await client.mutation({
       createCompany: {
-        __args: { data: { name: 'Pre-existing Co', domainName: { primaryLinkUrl: domain } } },
+        __args: { data: { name: 'Pre-existing Co', domainName: { primaryLinkUrl: storedDomain } } },
         id: true,
       },
     });
@@ -144,7 +147,7 @@ describe('submit-partner-application handler — upsert', () => {
         baseInput({
           email: 'reuse.domain@example.com',
           companyName: 'Applicant Co',
-          domainName: domain,
+          domainName: submittedVariant,
         }),
       ),
     );

--- a/packages/twenty-apps/internal/twenty-partners/src/logic-functions/submit-partner-application.logic-function.ts
+++ b/packages/twenty-apps/internal/twenty-partners/src/logic-functions/submit-partner-application.logic-function.ts
@@ -118,7 +118,7 @@ function normalizeDomainHost(
     .toLowerCase()
     .replace(/^https?:\/\//, '')
     .replace(/^www\./, '')
-    .replace(/[/:].*$/, '');
+    .replace(/[/:?#].*$/, '');
   return host.length > 0 ? host : undefined;
 }
 
@@ -134,7 +134,8 @@ function normalizeDomainHost(
 // free-text companyName.
 // ponytail: matches active rows only (a soft-deleted company still holds the
 // unique index — clear those with `yarn purge:prod`), and caps the prefilter at
-// 20 candidates, which is ample for a single real host.
+// 100 candidates — far more than the handful of URLs that can share one real
+// host, so the exact-host match is never paged out in practice.
 async function findOrCreateCompanyId(
   client: CoreApiClient,
   input: SubmitPartnerApplicationInput,
@@ -149,7 +150,7 @@ async function findOrCreateCompanyId(
       companies: {
         __args: {
           filter: { domainName: { primaryLinkUrl: { ilike: `%${host}%` } } },
-          first: 20,
+          first: 100,
         },
         edges: { node: { id: true, domainName: { primaryLinkUrl: true } } },
       },

--- a/packages/twenty-apps/internal/twenty-partners/src/logic-functions/submit-partner-application.logic-function.ts
+++ b/packages/twenty-apps/internal/twenty-partners/src/logic-functions/submit-partner-application.logic-function.ts
@@ -130,30 +130,24 @@ async function findOrCreateCompanyId(
   const host = normalizeDomainHost(domain);
 
   if (host !== undefined) {
-    // eq for bare-domain forms; anchored ilike for any protocol/path variant.
-    // Each pattern is host-anchored so first:1 is safe — false positives can't
-    // page out the real match.
+    // Broad ilike catches all stored URL forms (bare domain, any protocol, paths,
+    // www variants). Client-side normalization filters false positives.
+    // first:20 is a safe bound — a specific domain substring appears in at most
+    // one or two CRM records in practice, so the real match is never paged out.
     const existing = await client.query({
       companies: {
         __args: {
-          filter: {
-            or: [
-              { domainName: { primaryLinkUrl: { eq: host } } },
-              { domainName: { primaryLinkUrl: { eq: `www.${host}` } } },
-              { domainName: { primaryLinkUrl: { ilike: `%://${host}` } } },
-              { domainName: { primaryLinkUrl: { ilike: `%://${host}/%` } } },
-              { domainName: { primaryLinkUrl: { ilike: `%://www.${host}` } } },
-              { domainName: { primaryLinkUrl: { ilike: `%://www.${host}/%` } } },
-            ],
-          },
-          first: 1,
+          filter: { domainName: { primaryLinkUrl: { ilike: `%${host}%` } } },
+          first: 20,
         },
-        edges: { node: { id: true } },
+        edges: { node: { id: true, domainName: { primaryLinkUrl: true } } },
       },
     });
-    const match = existing.companies?.edges?.[0]?.node;
+    const match = existing.companies?.edges?.find(
+      (edge) => normalizeDomainHost(edge.node.domainName?.primaryLinkUrl) === host,
+    );
     if (match !== undefined) {
-      return match.id;
+      return match.node.id;
     }
   }
 

--- a/packages/twenty-apps/internal/twenty-partners/src/logic-functions/submit-partner-application.logic-function.ts
+++ b/packages/twenty-apps/internal/twenty-partners/src/logic-functions/submit-partner-application.logic-function.ts
@@ -106,9 +106,6 @@ function buildPartnerFields(input: SubmitPartnerApplicationInput): PartnerFields
   return fields;
 }
 
-// Reduce a URL to a comparable host key: lowercase, no protocol, no leading
-// "www.", no port/path. Lets http/https, www, casing and trailing-slash
-// variants of the same real domain resolve to one company.
 function normalizeDomainHost(
   value: string | null | undefined,
 ): string | undefined {
@@ -122,20 +119,7 @@ function normalizeDomainHost(
   return host.length > 0 ? host : undefined;
 }
 
-// Company.domainName has a UNIQUE index, so a blind createCompany throws
-// "duplicate entry" whenever a company with the applicant's domain already
-// exists — which is common, since the TFT import seeds companies. Reuse that
-// company instead of creating a second one; only create when no domain matches.
-// We dedupe on the normalized host (not the raw URL) so protocol/www/case
-// variants still match. The stored URLs are raw, so we prefilter server-side
-// with a broad ilike on the host, then confirm with an exact host comparison
-// in code (the ilike alone would match unrelated substrings). We never rename
-// the matched company: the CRM's existing name wins over the applicant's
-// free-text companyName.
-// ponytail: matches active rows only (a soft-deleted company still holds the
-// unique index — clear those with `yarn purge:prod`), and caps the prefilter at
-// 100 candidates — far more than the handful of URLs that can share one real
-// host, so the exact-host match is never paged out in practice.
+// ponytail: matches active rows only — soft-deleted companies still hold the unique index; clear those with `yarn purge:prod`.
 async function findOrCreateCompanyId(
   client: CoreApiClient,
   input: SubmitPartnerApplicationInput,
@@ -146,25 +130,40 @@ async function findOrCreateCompanyId(
   const host = normalizeDomainHost(domain);
 
   if (host !== undefined) {
+    const urlVariants = [
+      host,
+      `http://${host}`,
+      `https://${host}`,
+      `http://www.${host}`,
+      `https://www.${host}`,
+      `http://${host}/`,
+      `https://${host}/`,
+      `http://www.${host}/`,
+      `https://www.${host}/`,
+    ];
     const existing = await client.query({
       companies: {
         __args: {
-          filter: { domainName: { primaryLinkUrl: { ilike: `%${host}%` } } },
-          first: 100,
+          filter: {
+            or: urlVariants.map((v) => ({ domainName: { primaryLinkUrl: { eq: v } } })),
+          },
+          first: 1,
         },
-        edges: { node: { id: true, domainName: { primaryLinkUrl: true } } },
+        edges: { node: { id: true } },
       },
     });
-    const match = existing.companies?.edges?.find(
-      (edge) => normalizeDomainHost(edge.node.domainName?.primaryLinkUrl) === host,
-    );
-    if (match !== undefined) return match.node.id;
+    const match = existing.companies?.edges?.[0]?.node;
+    if (match !== undefined) {
+      return match.id;
+    }
   }
 
   const companyData: CoreSchema.CompanyCreateInput = {
     name: input.companyName.trim(),
   };
-  if (domain !== undefined) companyData.domainName = { primaryLinkUrl: domain };
+  if (domain !== undefined) {
+    companyData.domainName = { primaryLinkUrl: domain };
+  }
   const companyResult = await client.mutation({
     createCompany: { __args: { data: companyData }, id: true },
   });

--- a/packages/twenty-apps/internal/twenty-partners/src/logic-functions/submit-partner-application.logic-function.ts
+++ b/packages/twenty-apps/internal/twenty-partners/src/logic-functions/submit-partner-application.logic-function.ts
@@ -106,6 +106,50 @@ function buildPartnerFields(input: SubmitPartnerApplicationInput): PartnerFields
   return fields;
 }
 
+// Company.domainName has a UNIQUE index, so a blind createCompany throws
+// "duplicate entry" whenever a company with the applicant's domain already
+// exists — which is common, since the TFT import seeds companies. Reuse that
+// company instead of creating a second one; only create when no domain matches.
+// We never rename the matched company: the CRM's existing name wins over the
+// applicant's free-text companyName.
+// ponytail: matches active rows only. A soft-deleted company still holds the
+// unique index and would re-collide — clear those with `yarn purge:prod`.
+async function findOrCreateCompanyId(
+  client: CoreApiClient,
+  input: SubmitPartnerApplicationInput,
+): Promise<string> {
+  const domain = isNonEmptyString(input.domainName)
+    ? input.domainName.trim()
+    : undefined;
+
+  if (domain !== undefined) {
+    const existing = await client.query({
+      companies: {
+        __args: {
+          filter: { domainName: { primaryLinkUrl: { eq: domain } } },
+          first: 1,
+        },
+        edges: { node: { id: true } },
+      },
+    });
+    const existingId = existing.companies?.edges?.[0]?.node?.id;
+    if (existingId !== undefined) return existingId;
+  }
+
+  const companyData: CoreSchema.CompanyCreateInput = {
+    name: input.companyName.trim(),
+  };
+  if (domain !== undefined) companyData.domainName = { primaryLinkUrl: domain };
+  const companyResult = await client.mutation({
+    createCompany: { __args: { data: companyData }, id: true },
+  });
+  const companyId = companyResult.createCompany?.id;
+  if (companyId === undefined) {
+    throw new Error('createCompany did not return an id');
+  }
+  return companyId;
+}
+
 type SubmitPartnerApplicationEvent = {
   headers?: Record<string, string | undefined>;
   body?: unknown;
@@ -191,17 +235,7 @@ export const handler = async (
       return { ok: true, created: false, partnerId };
     }
 
-    const companyData: CoreSchema.CompanyCreateInput = { name: input.companyName.trim() };
-    if (isNonEmptyString(input.domainName)) {
-      companyData.domainName = { primaryLinkUrl: input.domainName.trim() };
-    }
-    const companyResult = await client.mutation({
-      createCompany: { __args: { data: companyData }, id: true },
-    });
-    const companyId = companyResult.createCompany?.id;
-    if (companyId === undefined) {
-      throw new Error('createCompany did not return an id');
-    }
+    const companyId = await findOrCreateCompanyId(client, input);
 
     const partnerResult = await client.mutation({
       createPartner: {

--- a/packages/twenty-apps/internal/twenty-partners/src/logic-functions/submit-partner-application.logic-function.ts
+++ b/packages/twenty-apps/internal/twenty-partners/src/logic-functions/submit-partner-application.logic-function.ts
@@ -130,22 +130,21 @@ async function findOrCreateCompanyId(
   const host = normalizeDomainHost(domain);
 
   if (host !== undefined) {
-    const urlVariants = [
-      host,
-      `http://${host}`,
-      `https://${host}`,
-      `http://www.${host}`,
-      `https://www.${host}`,
-      `http://${host}/`,
-      `https://${host}/`,
-      `http://www.${host}/`,
-      `https://www.${host}/`,
-    ];
+    // eq for bare-domain forms; anchored ilike for any protocol/path variant.
+    // Each pattern is host-anchored so first:1 is safe — false positives can't
+    // page out the real match.
     const existing = await client.query({
       companies: {
         __args: {
           filter: {
-            or: urlVariants.map((v) => ({ domainName: { primaryLinkUrl: { eq: v } } })),
+            or: [
+              { domainName: { primaryLinkUrl: { eq: host } } },
+              { domainName: { primaryLinkUrl: { eq: `www.${host}` } } },
+              { domainName: { primaryLinkUrl: { ilike: `%://${host}` } } },
+              { domainName: { primaryLinkUrl: { ilike: `%://${host}/%` } } },
+              { domainName: { primaryLinkUrl: { ilike: `%://www.${host}` } } },
+              { domainName: { primaryLinkUrl: { ilike: `%://www.${host}/%` } } },
+            ],
           },
           first: 1,
         },

--- a/packages/twenty-apps/internal/twenty-partners/src/logic-functions/submit-partner-application.logic-function.ts
+++ b/packages/twenty-apps/internal/twenty-partners/src/logic-functions/submit-partner-application.logic-function.ts
@@ -106,14 +106,35 @@ function buildPartnerFields(input: SubmitPartnerApplicationInput): PartnerFields
   return fields;
 }
 
+// Reduce a URL to a comparable host key: lowercase, no protocol, no leading
+// "www.", no port/path. Lets http/https, www, casing and trailing-slash
+// variants of the same real domain resolve to one company.
+function normalizeDomainHost(
+  value: string | null | undefined,
+): string | undefined {
+  if (!isNonEmptyString(value)) return undefined;
+  const host = value
+    .trim()
+    .toLowerCase()
+    .replace(/^https?:\/\//, '')
+    .replace(/^www\./, '')
+    .replace(/[/:].*$/, '');
+  return host.length > 0 ? host : undefined;
+}
+
 // Company.domainName has a UNIQUE index, so a blind createCompany throws
 // "duplicate entry" whenever a company with the applicant's domain already
 // exists — which is common, since the TFT import seeds companies. Reuse that
 // company instead of creating a second one; only create when no domain matches.
-// We never rename the matched company: the CRM's existing name wins over the
-// applicant's free-text companyName.
-// ponytail: matches active rows only. A soft-deleted company still holds the
-// unique index and would re-collide — clear those with `yarn purge:prod`.
+// We dedupe on the normalized host (not the raw URL) so protocol/www/case
+// variants still match. The stored URLs are raw, so we prefilter server-side
+// with a broad ilike on the host, then confirm with an exact host comparison
+// in code (the ilike alone would match unrelated substrings). We never rename
+// the matched company: the CRM's existing name wins over the applicant's
+// free-text companyName.
+// ponytail: matches active rows only (a soft-deleted company still holds the
+// unique index — clear those with `yarn purge:prod`), and caps the prefilter at
+// 20 candidates, which is ample for a single real host.
 async function findOrCreateCompanyId(
   client: CoreApiClient,
   input: SubmitPartnerApplicationInput,
@@ -121,19 +142,22 @@ async function findOrCreateCompanyId(
   const domain = isNonEmptyString(input.domainName)
     ? input.domainName.trim()
     : undefined;
+  const host = normalizeDomainHost(domain);
 
-  if (domain !== undefined) {
+  if (host !== undefined) {
     const existing = await client.query({
       companies: {
         __args: {
-          filter: { domainName: { primaryLinkUrl: { eq: domain } } },
-          first: 1,
+          filter: { domainName: { primaryLinkUrl: { ilike: `%${host}%` } } },
+          first: 20,
         },
-        edges: { node: { id: true } },
+        edges: { node: { id: true, domainName: { primaryLinkUrl: true } } },
       },
     });
-    const existingId = existing.companies?.edges?.[0]?.node?.id;
-    if (existingId !== undefined) return existingId;
+    const match = existing.companies?.edges?.find(
+      (edge) => normalizeDomainHost(edge.node.domainName?.primaryLinkUrl) === host,
+    );
+    if (match !== undefined) return match.node.id;
   }
 
   const companyData: CoreSchema.CompanyCreateInput = {

--- a/packages/twenty-apps/internal/twenty-partners/src/logic-functions/submit-partner-application.logic-function.ts
+++ b/packages/twenty-apps/internal/twenty-partners/src/logic-functions/submit-partner-application.logic-function.ts
@@ -130,25 +130,31 @@ async function findOrCreateCompanyId(
   const host = normalizeDomainHost(domain);
 
   if (host !== undefined) {
-    // Broad ilike catches all stored URL forms (bare domain, any protocol, paths,
-    // www variants). Client-side normalization filters false positives.
-    // first:20 is a safe bound — a specific domain substring appears in at most
-    // one or two CRM records in practice, so the real match is never paged out.
-    const existing = await client.query({
-      companies: {
-        __args: {
-          filter: { domainName: { primaryLinkUrl: { ilike: `%${host}%` } } },
-          first: 20,
+    // Broad ilike catches every stored URL form (bare, any protocol, paths, www).
+    // Paginate to exhaustion so the real match is never paged out; client-side
+    // normalization rejects false positives on each page.
+    let cursor: string | null = null;
+    do {
+      const existing = await client.query({
+        companies: {
+          __args: {
+            filter: { domainName: { primaryLinkUrl: { ilike: `%${host}%` } } },
+            first: 20,
+            ...(cursor !== null ? { after: cursor } : {}),
+          },
+          pageInfo: { hasNextPage: true, endCursor: true },
+          edges: { node: { id: true, domainName: { primaryLinkUrl: true } } },
         },
-        edges: { node: { id: true, domainName: { primaryLinkUrl: true } } },
-      },
-    });
-    const match = existing.companies?.edges?.find(
-      (edge) => normalizeDomainHost(edge.node.domainName?.primaryLinkUrl) === host,
-    );
-    if (match !== undefined) {
-      return match.node.id;
-    }
+      });
+      const match = existing.companies?.edges?.find(
+        (edge) => normalizeDomainHost(edge.node.domainName?.primaryLinkUrl) === host,
+      );
+      if (match !== undefined) {
+        return match.node.id;
+      }
+      const pageInfo = existing.companies?.pageInfo;
+      cursor = pageInfo?.hasNextPage ? (pageInfo.endCursor ?? null) : null;
+    } while (cursor !== null);
   }
 
   const companyData: CoreSchema.CompanyCreateInput = {


### PR DESCRIPTION
## Problem

Partner applications **502** for any applicant whose company is already in the CRM.

The `submit-partner-application` logic function dedupes applicants **only by person email**. When no person matches that email, it takes the create path and calls `createCompany` unconditionally. But `Company.domainName` has a **UNIQUE index**, so whenever a company with the applicant's domain already exists — which is common, since the **TFT import seeds companies** — the mutation throws `"duplicate entry"`. The handler's `catch` returns `{ ok: false }`, and the website `/api/partner-application` route surfaces it as a **502**. The applicant can never be submitted.

Real case that surfaced this: an applicant whose company (`BKG Integration UG`, domain `bkg-integration.de`) was already present from the TFT import with no Partner/Person attached.

## Fix

Extract `findOrCreateCompanyId`:
- Look the company up by **exact domain** (`domainName.primaryLinkUrl eq`) and **reuse** it when found.
- Only `createCompany` when no domain matches.
- The matched company is **never renamed** — the existing CRM name wins over the applicant's free-text `companyName`.

Person-email dedup is unchanged (already handled upstream in the handler).

### Known limitation
Matches **active** rows only. A *soft-deleted* company still holds the unique index and would re-collide; clear those with `yarn purge:prod`. Noted inline.

## Tests
Adds an integration test: pre-seed a company by domain → submit an application with the same domain → assert the partner reuses the same company id and the company name is untouched.

## Version
`twenty-partners` 0.5.1 → **0.5.2** (patch: bug fix, no schema change).

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/21615?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

