### PR TITLE
fix(workflow): prevent code action variables showing "Not found" on reopen

### DIFF
--- a/packages/twenty-front/src/modules/workflow/workflow-steps/workflow-actions/code-action/components/WorkflowEditActionCode.tsx
+++ b/packages/twenty-front/src/modules/workflow/workflow-steps/workflow-actions/code-action/components/WorkflowEditActionCode.tsx
@@ -35,7 +35,7 @@ import { CODE_ACTION } from '@/workflow/workflow-steps/workflow-actions/constant
 import { type Monaco } from '@monaco-editor/react';
 import { type editor } from 'monaco-editor';
 import { AutoTypings } from 'monaco-editor-auto-typings';
-import { useState } from 'react';
+import { useRef, useState } from 'react';
 import { Key } from 'ts-key-enum';
 import {
   getOutputSchemaFromValue,
@@ -103,15 +103,61 @@ export const WorkflowEditActionCode = ({
   );
   const workflow = useWorkflowWithCurrentVersion(workflowVisualizerWorkflowId);
 
+  // Several handlers below update different parts of the action settings
+  // (code input, function input, output schema). They all funnel through a
+  // single debounced persist call. To avoid a late-firing update built from a
+  // stale `action` snapshot reverting a more recent change (e.g. an input edit
+  // wiping the freshly inferred output schema back to its LINK placeholder,
+  // which makes referencing variables resolve to "Not found"), we accumulate
+  // partial settings deltas and always merge them against the latest action.
+  const latestActionRef = useRef(action);
+  latestActionRef.current = action;
+
+  const pendingSettingsUpdateRef = useRef<
+    Partial<WorkflowCodeAction['settings']>
+  >({});
+
+  const flushActionUpdate = useDebouncedCallback(() => {
+    const pendingSettingsUpdate = pendingSettingsUpdateRef.current;
+    pendingSettingsUpdateRef.current = {};
+
+    if (
+      actionOptions.readonly === true ||
+      Object.keys(pendingSettingsUpdate).length === 0
+    ) {
+      return;
+    }
+
+    actionOptions.onActionUpdate({
+      ...latestActionRef.current,
+      settings: {
+        ...latestActionRef.current.settings,
+        ...pendingSettingsUpdate,
+      },
+    });
+  }, 500);
+
+  const updateActionSettings = (
+    settingsUpdate: Partial<WorkflowCodeAction['settings']>,
+  ) => {
+    if (actionOptions.readonly === true) {
+      return;
+    }
+
+    pendingSettingsUpdateRef.current = {
+      ...pendingSettingsUpdateRef.current,
+      ...settingsUpdate,
+    };
+
+    flushActionUpdate();
+  };
+
   const updateOutputSchemaFromTestResult = async (testResult: object) => {
     if (actionOptions.readonly === true) {
       return;
     }
     const newOutputSchema = getOutputSchemaFromValue(testResult);
-    updateAction({
-      ...action,
-      settings: { ...action.settings, outputSchema: newOutputSchema },
-    });
+    updateActionSettings({ outputSchema: newOutputSchema });
   };
 
   const { formValues, loading, onChange } = useLogicFunctionForm({
@@ -165,23 +211,19 @@ export const WorkflowEditActionCode = ({
 
       updateLogicFunctionInput(newMergedTestInput);
 
-      updateAction({
-        ...action,
-        settings: {
-          ...action.settings,
-          outputSchema: {
-            link: {
-              isLeaf: true,
-              icon: 'IconVariable',
-              tab: 'test',
-              label: t`Generate Function Output`,
-            },
-            _outputSchemaType: 'LINK',
+      updateActionSettings({
+        outputSchema: {
+          link: {
+            isLeaf: true,
+            icon: 'IconVariable',
+            tab: 'test',
+            label: t`Generate Function Output`,
           },
-          input: {
-            ...action.settings.input,
-            logicFunctionInput: newMergedInput,
-          },
+          _outputSchemaType: 'LINK',
+        },
+        input: {
+          ...latestActionRef.current.settings.input,
+          logicFunctionInput: newMergedInput,
         },
       });
     },
@@ -193,14 +235,10 @@ export const WorkflowEditActionCode = ({
 
     setFunctionInput(updatedFunctionInput);
 
-    updateAction({
-      ...action,
-      settings: {
-        ...action.settings,
-        input: {
-          ...action.settings.input,
-          logicFunctionInput: updatedFunctionInput,
-        },
+    updateActionSettings({
+      input: {
+        ...latestActionRef.current.settings.input,
+        logicFunctionInput: updatedFunctionInput,
       },
     });
   };
@@ -224,6 +262,12 @@ export const WorkflowEditActionCode = ({
       return;
     }
 
+    // A pending schema-inference update would reset the output schema back to
+    // its LINK placeholder. If it fired after the test result resolved the real
+    // output schema, variables would resolve to "Not found". Cancel it so the
+    // test result is the source of truth for the output schema.
+    handleUpdateFunctionInputSchema.cancel();
+
     await executeLogicFunction();
   };
 
@@ -239,20 +283,6 @@ export const WorkflowEditActionCode = ({
       debounceDuration: 0,
     });
   };
-
-  const updateAction = useDebouncedCallback(
-    (actionUpdate: Partial<WorkflowCodeAction>) => {
-      if (actionOptions.readonly === true) {
-        return;
-      }
-
-      actionOptions.onActionUpdate({
-        ...action,
-        ...actionUpdate,
-      });
-    },
-    500,
-  );
 
   const handleCodeChange = async (newCode: string) => {
     if (actionOptions.readonly === true || !isDefined(workflow)) {

--- a/packages/twenty-front/src/modules/workflow/workflow-steps/workflow-actions/code-action/components/WorkflowEditActionCode.tsx
+++ b/packages/twenty-front/src/modules/workflow/workflow-steps/workflow-actions/code-action/components/WorkflowEditActionCode.tsx
@@ -199,7 +199,7 @@ export const WorkflowEditActionCode = ({
 
       const newMergedInput = mergeDefaultFunctionInputAndFunctionInput({
         newInput: newFunctionInput,
-        oldInput: action.settings.input.logicFunctionInput,
+        oldInput: latestActionRef.current.settings.input.logicFunctionInput,
       });
 
       const newMergedTestInput = mergeDefaultFunctionInputAndFunctionInput({
@@ -264,9 +264,14 @@ export const WorkflowEditActionCode = ({
 
     // A pending schema-inference update would reset the output schema back to
     // its LINK placeholder. If it fired after the test result resolved the real
-    // output schema, variables would resolve to "Not found". Cancel it so the
-    // test result is the source of truth for the output schema.
+    // output schema, variables would resolve to "Not found". Cancel the
+    // debounced inference and drop any output-schema reset already queued in
+    // the accumulator so the test result stays the source of truth.
     handleUpdateFunctionInputSchema.cancel();
+
+    const remainingPendingUpdate = { ...pendingSettingsUpdateRef.current };
+    delete remainingPendingUpdate.outputSchema;
+    pendingSettingsUpdateRef.current = remainingPendingUpdate;
 
     await executeLogicFunction();
   };


### PR DESCRIPTION
## Problem

When a workflow code/function action's output is used as a variable in a later step, you must run (test) the function to infer its output schema before the variables become selectable. This works, but reopening the step would sometimes show the chosen variable as **"Not found"** in red even though the function is fine.

## Cause

`WorkflowEditActionCode` funnels several independent update sources — the test-result output schema, the code-change schema reset, and input edits — through a single 500ms debounced persist call. Each call captured a full snapshot of `action.settings` at the moment it was scheduled. When two updates overlapped, a later-firing one built from a **stale snapshot** would overwrite a more recent change. In particular, a pending code-change update would revert the freshly inferred `outputSchema` back to its `LINK` placeholder, which resolves referencing variables to "Not found".

## Fix

Instead of spreading a whole stale `settings` snapshot, the handlers now push **partial settings deltas** into an accumulator. At flush time the deltas are merged against the latest action via a ref, so updates compose instead of clobbering each other. Testing a function also cancels any pending schema-inference update so the test result stays the source of truth for the output schema.

No product/UX behavior changes beyond the bug being fixed.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/21622?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

