### PR TITLE
fix(billing): ack Stripe subscription webhooks for deleted workspaces

### DIFF
--- a/packages/twenty-server/src/engine/core-modules/billing-webhook/services/billing-webhook-subscription.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/billing-webhook/services/billing-webhook-subscription.service.ts
@@ -3,7 +3,6 @@
 import { Injectable, Logger } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 
-import { msg } from '@lingui/core/macro';
 import { isDefined } from 'twenty-shared/utils';
 import { WorkspaceActivationStatus } from 'twenty-shared/workspace';
 import { In, Repository } from 'typeorm';
@@ -80,26 +79,22 @@ export class BillingWebhookSubscriptionService {
     });
 
     if (!workspace) {
-      throw new BillingException(
-        `Workspace not found for subscription event ${event.id} / workspaceId: ${workspaceId}`,
-        BillingExceptionCode.BILLING_SUBSCRIPTION_EVENT_WORKSPACE_NOT_FOUND,
-        {
-          userFriendlyMessage: msg`Workspace ${workspaceId} is not found.`,
-        },
+      this.logger.warn(
+        `Skipping subscription event ${event.id}: workspace ${workspaceId} not found`,
       );
+
+      return;
     }
 
     if (
       isDefined(workspace.deletedAt) &&
       type !== BillingWebhookEvent.CUSTOMER_SUBSCRIPTION_DELETED
     ) {
-      throw new BillingException(
-        `Workspace not found for subscription event ${event.id} / workspaceId: ${workspaceId}`,
-        BillingExceptionCode.BILLING_SUBSCRIPTION_EVENT_WORKSPACE_NOT_FOUND,
-        {
-          userFriendlyMessage: msg`Workspace ${workspaceId} is not found.`,
-        },
+      this.logger.warn(
+        `Skipping subscription event ${event.id}: workspace ${workspaceId} is deleted`,
       );
+
+      return;
     }
 
     await this.billingCustomerRepository.upsert(


### PR DESCRIPTION
## Problem

Stripe keeps emitting `customer.subscription.*` events for workspaces that have since been deleted. `BillingWebhookSubscriptionService.processStripeEvent` threw `BILLING_SUBSCRIPTION_EVENT_WORKSPACE_NOT_FOUND` for those, which `getBillingExceptionStatusCode` maps to HTTP **500**. Stripe treats a 5xx as a failed delivery and **retries with backoff for ~3 days**, so a handful of deleted workspaces turn into a steady ~45k Sentry errors (and as many redundant webhook deliveries).

This is the top error stream by volume in `twenty-server` — Sentry `TWENTY-SERVER-EQP` (45k+ events).

## Fix

When the workspace is missing (or soft-deleted and the event isn't a subscription deletion), log a warning and return instead of throwing. There's nothing to process for a workspace that no longer exists; returning lets the controller ack the webhook with `200`, which stops both the Stripe retry loop and the error noise.

Also drops the now-unused `msg` import.

## Impact

- Eliminates ~45k/month Sentry errors that were masking real signal.
- Stops the redundant Stripe webhook retries for deleted workspaces.
- No behavior change for live workspaces.

Fixes TWENTY-SERVER-EQP


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/21630?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

