### PR TITLE
fix(billing): return empty credit usage when workspace has no subscription

### DIFF
--- a/packages/twenty-server/src/engine/core-modules/billing/services/billing-usage.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/billing/services/billing-usage.service.ts
@@ -75,9 +75,13 @@ export class BillingUsageService {
     workspace: WorkspaceEntity,
   ): Promise<BillingResourceCreditUsageDTO[]> {
     const subscription =
-      await this.billingSubscriptionService.getCurrentBillingSubscriptionOrThrow(
-        { workspaceId: workspace.id },
-      );
+      await this.billingSubscriptionService.getCurrentBillingSubscription({
+        workspaceId: workspace.id,
+      });
+
+    if (!isDefined(subscription)) {
+      return [];
+    }
 
     const resourceCreditItemDetail =
       await this.billingSubscriptionItemService.getResourceCreditSubscriptionItemDetails(


### PR DESCRIPTION
## Problem

`getResourceCreditProductUsage` calls `getCurrentBillingSubscriptionOrThrow`, which throws `BILLING_SUBSCRIPTION_NOT_FOUND` when a workspace has no active (non-canceled) subscription. The frontend polls `GetResourceCreditUsage` on load, so every suspended/trial workspace without a subscription produces a thrown error on each poll — the single largest error stream in `twenty-server`, Sentry `TWENTY-SERVER-CQN` (132k+ events).

This is the same class of issue as #21510, on a path that fix didn't cover.

## Fix

Use the non-throwing `getCurrentBillingSubscription` and return an empty list when there's no subscription. A workspace without a subscription simply has no resource-credit usage to report, so an empty result is the correct response. Behavior for workspaces with a subscription is unchanged.

## Impact

- Eliminates ~132k/month Sentry errors masking real signal.
- The credit-usage widget degrades gracefully (empty) for no-subscription workspaces instead of erroring.

Fixes TWENTY-SERVER-CQN


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/21631?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

