### PR TITLE
feat(website): magic-link partner review page

### DIFF
--- a/packages/twenty-website/.env.example
+++ b/packages/twenty-website/.env.example
@@ -1,5 +1,11 @@
 PARTNER_APPLICATION_WEBHOOK_URL=
 
+# Base URL of the brief-review backend: the magic-link review page reads it and
+# the /api/brief-pick proxy posts to it. Same host as PARTNER_APPLICATION_WEBHOOK_URL
+# with the trailing /partner-applications swapped for /brief-review (no trailing
+# slash); the proxy appends /pick, the page appends ?token=. Reuses PARTNER_APPLICATION_SECRET.
+BRIEF_REVIEW_BASE_URL=
+
 # Optional GitHub personal-access token (no scopes required) used by the
 # community-stats fetcher (`src/lib/community/fetch-github-star-count.ts`).
 # When set, requests use the 5000/hr authenticated limit instead of the

--- a/packages/twenty-website/src/app/[locale]/partners/review/[token]/BriefReviewPageContent.tsx
+++ b/packages/twenty-website/src/app/[locale]/partners/review/[token]/BriefReviewPageContent.tsx
@@ -1,18 +1,43 @@
 'use client';
 
+import {
+  SERVED_GEO_LABELS,
+  SPOKEN_LANGUAGE_LABELS,
+} from '@/app/[locale]/partners/list/components/chip-labels';
+import { chipBaseStyles } from '@/app/[locale]/partners/list/components/chip-styles';
+import { PartnerAvatar } from '@/app/[locale]/partners/list/components/PartnerAvatar';
+import { PartnerChipRow } from '@/app/[locale]/partners/list/components/PartnerChipRow';
+import { PartnerMoneyRow } from '@/app/[locale]/partners/list/components/PartnerMoneyRow';
+import { Body } from '@/design-system/components';
+import {
+  BaseButton,
+  buttonBaseStyles,
+} from '@/design-system/components/Button/BaseButton';
+import { Logo } from '@/icons';
 import { theme } from '@/theme';
+import type { MessageDescriptor } from '@lingui/core';
+import { msg } from '@lingui/core/macro';
 import { styled } from '@linaria/react';
+import { IconArrowUpRight, IconCheck } from '@tabler/icons-react';
 import { useRouter } from 'next/navigation';
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 
 export type Candidate = {
   applicationId: string;
   state: string;
   pitch: string | null;
   partner: {
+    slug: string | null;
     name: string | null;
-    skills: string[] | null;
+    introduction: string | null;
     country: string | null;
+    city: string | null;
+    region: string[] | null;
+    languagesSpoken: string[] | null;
+    skills: string[] | null;
+    hourlyRateUsd: number | null;
+    projectBudgetMinUsd: number | null;
+    profilePictureUrl: string | null;
   } | null;
 };
 
@@ -30,107 +55,602 @@ export type ReviewData =
     }
   | { ok: false; reason: string };
 
-const Background = styled.div`
-  align-items: center;
-  background: #0c0c0c;
-  display: flex;
-  justify-content: center;
-  min-height: 100vh;
-`;
+// The chip-label maps are typed to the website's own enums; the CRM hands us the
+// same string values, so widen the lookup type and let PartnerChipRow's built-in
+// title-case fallback cover anything not in the map.
+const GEO_LABELS = SERVED_GEO_LABELS as Record<string, MessageDescriptor>;
+const LANGUAGE_LABELS = SPOKEN_LANGUAGE_LABELS as Record<
+  string,
+  MessageDescriptor
+>;
 
-const Container = styled.div`
-  box-sizing: border-box;
-  color: #fff;
+const titleCase = (raw: string): string =>
+  raw
+    .toLowerCase()
+    .split(/[_\s]+/)
+    .filter(Boolean)
+    .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
+    .join(' ');
+
+const locationLine = (
+  city: string | null,
+  country: string | null,
+): string | null => {
+  const parts = [city, country ? titleCase(country) : null].filter(Boolean);
+  return parts.length ? parts.join(', ') : null;
+};
+
+// Light-locked to match the partner-list / profile surfaces.
+const Page = styled.div`
+  background: var(--color-bg-muted, #f4f4f4);
+  color: ${theme.colors.primary.text[100]};
   display: flex;
   flex-direction: column;
-  gap: ${theme.spacing(4)};
-  max-width: min(720px, 100%);
-  padding: ${theme.spacing(6)} ${theme.spacing(4)};
-  width: 100%;
+  isolation: isolate;
+  min-height: 100dvh;
+  position: relative;
 `;
 
-const Title = styled.h1`
-  font-size: 28px;
-  font-weight: 500;
+// Warm ambient wash borrowed from the partner profile page: the brand accents
+// at low alpha, so the page reads as considered rather than a bare form. Inert.
+const Ambient = styled.div`
+  background:
+    radial-gradient(58% 48% at 12% 0%, rgba(74, 56, 245, 0.1), transparent 70%),
+    radial-gradient(
+      52% 42% at 92% 6%,
+      rgba(237, 135, 252, 0.1),
+      transparent 70%
+    ),
+    radial-gradient(
+      64% 52% at 72% 100%,
+      rgba(137, 252, 154, 0.1),
+      transparent 72%
+    );
+  inset: 0;
+  pointer-events: none;
+  position: fixed;
+  z-index: -1;
+`;
+
+const TopBar = styled.header`
+  align-items: center;
+  background: ${theme.colors.primary.background[100]};
+  border-bottom: 1px solid ${theme.colors.primary.border[10]};
+  display: flex;
+  gap: ${theme.spacing(3)};
+  justify-content: space-between;
+  padding: ${theme.spacing(4)} ${theme.spacing(5)};
+`;
+
+const Brand = styled.div`
+  align-items: center;
+  display: flex;
+  gap: ${theme.spacing(2.5)};
+`;
+
+const Wordmark = styled.span`
+  font-family: ${theme.font.family.sans};
+  font-size: ${theme.font.size(4.5)};
+  font-weight: ${theme.font.weight.medium};
+  letter-spacing: -0.03em;
+`;
+
+const TopEyebrow = styled.span`
+  color: ${theme.colors.primary.text[60]};
+  font-family: ${theme.font.family.mono};
+  font-size: ${theme.font.size(3)};
+  font-weight: ${theme.font.weight.medium};
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+`;
+
+const Main = styled.main`
+  display: flex;
+  flex-direction: column;
+  gap: ${theme.spacing(7)};
+  margin: 0 auto;
+  max-width: 1120px;
+  padding: ${theme.spacing(10)} ${theme.spacing(5)} ${theme.spacing(16)};
+  width: 100%;
+
+  @media (min-width: ${theme.breakpoints.md}px) {
+    padding: ${theme.spacing(14)} ${theme.spacing(8)} ${theme.spacing(20)};
+  }
+`;
+
+const Intro = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: ${theme.spacing(3)};
+  max-width: 720px;
+`;
+
+const IntroEyebrow = styled.span`
+  color: ${theme.colors.highlight[100]};
+  font-family: ${theme.font.family.mono};
+  font-size: ${theme.font.size(3)};
+  font-weight: ${theme.font.weight.medium};
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+`;
+
+const BriefTitle = styled.h1`
+  color: ${theme.colors.primary.text[100]};
+  font-family: ${theme.font.family.serif};
+  font-size: ${theme.font.size(11)};
+  font-weight: ${theme.font.weight.light};
+  letter-spacing: -0.02em;
+  line-height: ${theme.lineHeight(12)};
   margin: 0;
+
+  @media (min-width: ${theme.breakpoints.md}px) {
+    font-size: ${theme.font.size(14)};
+    line-height: ${theme.lineHeight(15)};
+  }
 `;
 
 const Lede = styled.p`
-  color: rgba(255, 255, 255, 0.7);
+  color: ${theme.colors.primary.text[80]};
+  font-family: ${theme.font.family.sans};
+  font-size: ${theme.font.size(4.5)};
+  line-height: 1.5;
   margin: 0;
 `;
 
-const Card = styled.div`
-  border: 1px solid rgba(255, 255, 255, 0.12);
-  border-radius: 8px;
+const Requirements = styled.div`
+  border-left: 2px solid ${theme.colors.primary.border[20]};
   display: flex;
   flex-direction: column;
+  gap: ${theme.spacing(1.5)};
+  margin-top: ${theme.spacing(1)};
+  padding-left: ${theme.spacing(4)};
+`;
+
+const MetaLabel = styled.span`
+  color: ${theme.colors.primary.text[60]};
+  font-family: ${theme.font.family.mono};
+  font-size: ${theme.font.size(2.75)};
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+`;
+
+const Framing = styled.p`
+  color: ${theme.colors.primary.text[100]};
+  font-family: ${theme.font.family.sans};
+  font-size: ${theme.font.size(5)};
+  font-weight: ${theme.font.weight.light};
+  line-height: 1.45;
+  margin: 0;
+  max-width: 720px;
+`;
+
+const Notice = styled.div`
+  border: 1px solid ${theme.colors.primary.border[10]};
+  border-radius: ${theme.radius(2)};
+  color: ${theme.colors.primary.text[80]};
+  font-family: ${theme.font.family.sans};
+  font-size: ${theme.font.size(4)};
+  line-height: 1.5;
+  padding: ${theme.spacing(4)} ${theme.spacing(5)};
+`;
+
+const ClosedNotice = styled(Notice)`
+  background: ${theme.colors.accent.green[70]};
+  border-color: transparent;
+  color: ${theme.colors.primary.text[100]};
+`;
+
+// ponytail: the design system ships no error token; this is the one hardcoded
+// color pair on the page, a WCAG-AA red on a soft red ground.
+const ErrorNotice = styled(Notice)`
+  background: #fdeceb;
+  border-color: #f3c4c0;
+  color: #b3261e;
+`;
+
+const Grid = styled.div`
+  display: grid;
+  gap: ${theme.spacing(5)};
+  grid-template-columns: 1fr;
+
+  @media (min-width: ${theme.breakpoints.md}px) {
+    grid-template-columns: repeat(auto-fit, minmax(340px, 1fr));
+  }
+`;
+
+const Card = styled.article`
+  background: ${theme.colors.primary.background[100]};
+  border: 1px solid ${theme.colors.primary.border[10]};
+  border-radius: ${theme.radius(2)};
+  display: flex;
+  flex-direction: column;
+  gap: ${theme.spacing(4)};
+  padding: ${theme.spacing(6)};
+  transition:
+    border-color 0.25s ease,
+    box-shadow 0.25s ease,
+    transform 0.25s ease;
+
+  &:hover {
+    border-color: ${theme.colors.primary.border[20]};
+    box-shadow: 0 16px 40px -20px rgba(0, 0, 0, 0.22);
+    transform: translateY(-2px);
+  }
+
+  &[data-selected='true'] {
+    border-color: ${theme.colors.primary.text[100]};
+    box-shadow: 0 16px 40px -22px rgba(0, 0, 0, 0.26);
+    transform: none;
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    transition: none;
+
+    &:hover {
+      transform: none;
+    }
+  }
+`;
+
+const CardHeader = styled.div`
+  align-items: flex-start;
+  display: flex;
+  gap: ${theme.spacing(3)};
+`;
+
+const HeaderText = styled.div`
+  display: flex;
+  flex: 1;
+  flex-direction: column;
+  gap: ${theme.spacing(1)};
+  min-width: 0;
+`;
+
+const CardName = styled.h2`
+  color: ${theme.colors.primary.text[100]};
+  font-family: ${theme.font.family.serif};
+  font-size: ${theme.font.size(7)};
+  font-weight: ${theme.font.weight.light};
+  letter-spacing: -0.02em;
+  line-height: ${theme.lineHeight(8)};
+  margin: 0;
+`;
+
+const LocationEyebrow = styled.span`
+  color: ${theme.colors.primary.text[60]};
+  font-family: ${theme.font.family.mono};
+  font-size: ${theme.font.size(3)};
+  font-weight: ${theme.font.weight.medium};
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+`;
+
+const SelectedBadge = styled.span`
+  align-items: center;
+  background: ${theme.colors.accent.green[70]};
+  border-radius: ${theme.radius(4)};
+  color: ${theme.colors.primary.text[100]};
+  display: inline-flex;
+  flex-shrink: 0;
+  font-family: ${theme.font.family.mono};
+  font-size: ${theme.font.size(3)};
+  font-weight: ${theme.font.weight.medium};
+  gap: ${theme.spacing(1)};
+  letter-spacing: 0.04em;
+  padding: ${theme.spacing(1)} ${theme.spacing(2.5)};
+  text-transform: uppercase;
+  white-space: nowrap;
+`;
+
+const PartnerIntro = styled.p`
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: 3;
+  color: ${theme.colors.primary.text[80]};
+  display: -webkit-box;
+  font-family: ${theme.font.family.sans};
+  font-size: ${theme.font.size(4)};
+  line-height: 1.55;
+  margin: 0;
+  overflow: hidden;
+`;
+
+const Chips = styled.div`
+  display: flex;
+  flex-wrap: wrap;
   gap: ${theme.spacing(2)};
+`;
+
+const Facts = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: ${theme.spacing(3)};
+`;
+
+const PitchBlock = styled.div`
+  background: ${theme.colors.primary.text[5]};
+  border-radius: ${theme.radius(2)};
+  display: flex;
+  flex-direction: column;
+  gap: ${theme.spacing(1.5)};
   padding: ${theme.spacing(4)};
 `;
 
-const CardName = styled.div`
-  font-size: 18px;
-  font-weight: 500;
+const PitchText = styled.p`
+  color: ${theme.colors.primary.text[100]};
+  font-family: ${theme.font.family.sans};
+  font-size: ${theme.font.size(4.5)};
+  line-height: 1.5;
+  margin: 0;
 `;
 
-const Meta = styled.div`
-  color: rgba(255, 255, 255, 0.6);
-  font-size: 14px;
+const Divider = styled.hr`
+  background: ${theme.colors.primary.border[10]};
+  border: 0;
+  height: 1px;
+  margin: 0;
+`;
+
+const Actions = styled.div`
+  align-items: center;
+  display: flex;
+  flex-wrap: wrap;
+  gap: ${theme.spacing(4)};
+  margin-top: auto;
+  padding-top: ${theme.spacing(1)};
 `;
 
 const PickButton = styled.button`
-  align-self: flex-start;
-  background: #4a38f5;
-  border: 0;
-  border-radius: 4px;
-  color: #fff;
-  cursor: pointer;
-  font-size: 14px;
-  padding: ${theme.spacing(2)} ${theme.spacing(4)};
+  ${buttonBaseStyles}
 
   &:disabled {
     cursor: default;
     opacity: 0.5;
   }
+
+  &:active:not(:disabled) {
+    transform: translateY(1px);
+  }
 `;
 
-const Selected = styled.div`
-  align-self: flex-start;
-  color: #89fc9a;
-  font-weight: 500;
+const ProfileLink = styled.a`
+  align-items: center;
+  color: ${theme.colors.primary.text[60]};
+  display: inline-flex;
+  font-family: ${theme.font.family.mono};
+  font-size: ${theme.font.size(3)};
+  font-weight: ${theme.font.weight.medium};
+  gap: ${theme.spacing(1)};
+  letter-spacing: 0.04em;
+  text-decoration: none;
+  text-transform: uppercase;
+  transition: color 0.2s ease;
+
+  &:hover {
+    color: ${theme.colors.primary.text[100]};
+  }
+
+  &:focus-visible {
+    outline: 1px solid ${theme.colors.highlight[100]};
+    outline-offset: 2px;
+  }
 `;
 
-const ErrorText = styled.p`
-  color: #ff6b6b;
+const CenterState = styled.main`
+  align-items: center;
+  display: flex;
+  flex: 1;
+  flex-direction: column;
+  gap: ${theme.spacing(4)};
+  justify-content: center;
+  margin: 0 auto;
+  max-width: 480px;
+  padding: ${theme.spacing(16)} ${theme.spacing(5)};
+  text-align: center;
+`;
+
+const StateTitle = styled.h1`
+  color: ${theme.colors.primary.text[100]};
+  font-family: ${theme.font.family.serif};
+  font-size: ${theme.font.size(9)};
+  font-weight: ${theme.font.weight.light};
+  letter-spacing: -0.02em;
+  line-height: ${theme.lineHeight(10)};
   margin: 0;
 `;
 
+const Footer = styled.footer`
+  border-top: 1px solid ${theme.colors.primary.border[10]};
+  color: ${theme.colors.primary.text[60]};
+  font-family: ${theme.font.family.mono};
+  font-size: ${theme.font.size(2.75)};
+  letter-spacing: 0.08em;
+  margin-top: auto;
+  padding: ${theme.spacing(5)};
+  text-align: center;
+  text-transform: uppercase;
+`;
+
+function BrandBar() {
+  return (
+    <TopBar>
+      <Brand>
+        <Logo
+          size={28}
+          fillColor={theme.colors.secondary.text[100]}
+          backgroundColor={theme.colors.secondary.background[100]}
+        />
+        <Wordmark>Twenty</Wordmark>
+      </Brand>
+      <TopEyebrow>Partner review</TopEyebrow>
+    </TopBar>
+  );
+}
+
+function CandidateCard({
+  candidate,
+  locale,
+  isPicked,
+  isClosed,
+  saving,
+  disabled,
+  onPick,
+}: {
+  candidate: Candidate;
+  locale: string;
+  isPicked: boolean;
+  isClosed: boolean;
+  saving: boolean;
+  disabled: boolean;
+  onPick: (applicationId: string) => void;
+}) {
+  const partner = candidate.partner;
+  const partnerName = partner?.name ?? 'Partner';
+  const location = locationLine(
+    partner?.city ?? null,
+    partner?.country ?? null,
+  );
+
+  return (
+    <Card data-selected={isPicked} aria-label={partnerName}>
+      <CardHeader>
+        <PartnerAvatar
+          name={partnerName}
+          slug={partner?.slug ?? partnerName}
+          profilePictureUrl={partner?.profilePictureUrl ?? undefined}
+        />
+        <HeaderText>
+          <CardName>{partnerName}</CardName>
+          {location ? <LocationEyebrow>{location}</LocationEyebrow> : null}
+        </HeaderText>
+        {isPicked ? (
+          <SelectedBadge>
+            <IconCheck size={14} aria-hidden="true" />
+            Selected
+          </SelectedBadge>
+        ) : null}
+      </CardHeader>
+
+      {partner?.introduction ? (
+        <PartnerIntro>{partner.introduction}</PartnerIntro>
+      ) : null}
+
+      {partner?.skills && partner.skills.length > 0 ? (
+        <Chips>
+          {partner.skills.map((skill) => (
+            <span key={skill} className={chipBaseStyles}>
+              {skill}
+            </span>
+          ))}
+        </Chips>
+      ) : null}
+
+      {(partner?.region && partner.region.length > 0) ||
+      (partner?.languagesSpoken && partner.languagesSpoken.length > 0) ? (
+        <Facts>
+          {partner?.region && partner.region.length > 0 ? (
+            <PartnerChipRow
+              label={msg`Regions`}
+              values={partner.region}
+              valueLabels={GEO_LABELS}
+            />
+          ) : null}
+          {partner?.languagesSpoken && partner.languagesSpoken.length > 0 ? (
+            <PartnerChipRow
+              label={msg`Languages`}
+              values={partner.languagesSpoken}
+              valueLabels={LANGUAGE_LABELS}
+            />
+          ) : null}
+        </Facts>
+      ) : null}
+
+      <PartnerMoneyRow
+        hourlyRateUsd={partner?.hourlyRateUsd ?? null}
+        projectBudgetMinUsd={partner?.projectBudgetMinUsd ?? null}
+      />
+
+      {candidate.pitch ? (
+        <PitchBlock>
+          <MetaLabel>Their note on your brief</MetaLabel>
+          <PitchText>{candidate.pitch}</PitchText>
+        </PitchBlock>
+      ) : null}
+
+      <Divider aria-hidden="true" />
+
+      <Actions>
+        {!isPicked && !isClosed ? (
+          <PickButton
+            data-color="secondary"
+            data-size="regular"
+            data-variant="contained"
+            disabled={disabled}
+            onClick={() => onPick(candidate.applicationId)}
+            aria-label={`Pick ${partnerName}`}
+          >
+            <BaseButton
+              color="secondary"
+              variant="contained"
+              label={saving ? 'Saving…' : `Pick ${partnerName}`}
+            />
+          </PickButton>
+        ) : null}
+        {partner?.slug ? (
+          <ProfileLink
+            href={`/${locale}/partners/profile/${partner.slug}`}
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            See full profile
+            <IconArrowUpRight size={14} aria-hidden="true" />
+          </ProfileLink>
+        ) : null}
+      </Actions>
+    </Card>
+  );
+}
+
 export function BriefReviewPageContent({
   token,
+  locale,
   data,
 }: {
   token: string;
+  locale: string;
   data: ReviewData;
 }) {
   const router = useRouter();
   const [pendingId, setPendingId] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
 
+  // Clear the in-flight flag once fresh server data arrives after a pick
+  // (router.refresh updates `data`), so the other cards re-enable instead of
+  // staying stuck on "Saving…".
+  const pickedId = data.ok ? data.picked : null;
+  useEffect(() => {
+    setPendingId(null);
+  }, [pickedId]);
+
   if (!data.ok) {
     return (
-      <Background>
-        <Container>
-          <Title>This link is invalid or has expired.</Title>
-          <Lede>
-            Please check with your Twenty contact for an up-to-date link.
-          </Lede>
-        </Container>
-      </Background>
+      <Page>
+        <Ambient aria-hidden="true" />
+        <BrandBar />
+        <CenterState>
+          <StateTitle>This review link is no longer valid.</StateTitle>
+          <Body as="p" variant="body-paragraph">
+            The link may have expired or been replaced. Please ask your Twenty
+            contact for an up-to-date link.
+          </Body>
+        </CenterState>
+        <Footer>Powered by Twenty</Footer>
+      </Page>
     );
   }
 
-  const isClosed = data.brief.status === 'CLOSED';
+  const { brief, candidates, picked } = data;
+  const isClosed = brief.status === 'CLOSED';
+  const count = candidates.length;
 
   const pick = async (applicationId: string) => {
     setPendingId(applicationId);
@@ -142,51 +662,76 @@ export function BriefReviewPageContent({
         body: JSON.stringify({ token, applicationId }),
       });
       if (!res.ok) {
-        setError('Could not record your choice. Please try again.');
+        setError('We could not record your choice. Please try again.');
         setPendingId(null);
         return;
       }
       router.refresh();
     } catch {
-      setError('Could not record your choice. Please try again.');
+      setError('We could not record your choice. Please try again.');
       setPendingId(null);
     }
   };
 
   return (
-    <Background>
-      <Container>
-        <Title>{data.brief.name ?? 'Your brief'}</Title>
-        {data.brief.need ? <Lede>{data.brief.need}</Lede> : null}
+    <Page>
+      <Ambient aria-hidden="true" />
+      <BrandBar />
+      <Main>
+        <Intro>
+          <IntroEyebrow>
+            {isClosed ? 'Partner review' : 'Choose your partner'}
+          </IntroEyebrow>
+          <BriefTitle>{brief.name ?? 'Your brief'}</BriefTitle>
+          {brief.need ? <Lede>{brief.need}</Lede> : null}
+          {brief.requirements ? (
+            <Requirements>
+              <MetaLabel>Requirements</MetaLabel>
+              <Body as="p" variant="body-paragraph">
+                {brief.requirements}
+              </Body>
+            </Requirements>
+          ) : null}
+        </Intro>
+
         {isClosed ? (
-          <Lede>A partner has been selected — this review is now locked.</Lede>
+          <ClosedNotice>
+            A partner has been selected for this brief. This review is now
+            read-only.
+          </ClosedNotice>
+        ) : count > 0 ? (
+          <Framing>
+            {count === 1 ? '1 partner' : `${count} partners`} reviewed your
+            brief and want to work with you. Compare them below, then pick the
+            one that fits.
+          </Framing>
         ) : null}
-        {data.candidates.map((candidate) => (
-          <Card key={candidate.applicationId}>
-            <CardName>{candidate.partner?.name ?? 'Partner'}</CardName>
-            {candidate.partner?.country ? (
-              <Meta>{candidate.partner.country}</Meta>
-            ) : null}
-            {candidate.partner?.skills?.length ? (
-              <Meta>{candidate.partner.skills.join(', ')}</Meta>
-            ) : null}
-            {candidate.pitch ? <Lede>{candidate.pitch}</Lede> : null}
-            {data.picked === candidate.applicationId ? (
-              <Selected>Selected</Selected>
-            ) : !isClosed ? (
-              <PickButton
+
+        {count === 0 ? (
+          <Notice>
+            No candidates have been added to this brief yet. Check back once
+            your Twenty contact has invited partners.
+          </Notice>
+        ) : (
+          <Grid>
+            {candidates.map((candidate) => (
+              <CandidateCard
+                key={candidate.applicationId}
+                candidate={candidate}
+                locale={locale}
+                isPicked={picked === candidate.applicationId}
+                isClosed={isClosed}
+                saving={pendingId === candidate.applicationId}
                 disabled={pendingId !== null}
-                onClick={() => pick(candidate.applicationId)}
-              >
-                {pendingId === candidate.applicationId
-                  ? 'Saving…'
-                  : 'Pick this partner'}
-              </PickButton>
-            ) : null}
-          </Card>
-        ))}
-        {error ? <ErrorText>{error}</ErrorText> : null}
-      </Container>
-    </Background>
+                onPick={pick}
+              />
+            ))}
+          </Grid>
+        )}
+
+        {error ? <ErrorNotice role="alert">{error}</ErrorNotice> : null}
+      </Main>
+      <Footer>Powered by Twenty</Footer>
+    </Page>
   );
 }

--- a/packages/twenty-website/src/app/[locale]/partners/review/[token]/BriefReviewPageContent.tsx
+++ b/packages/twenty-website/src/app/[locale]/partners/review/[token]/BriefReviewPageContent.tsx
@@ -20,7 +20,7 @@ import { msg } from '@lingui/core/macro';
 import { styled } from '@linaria/react';
 import { IconArrowUpRight, IconCheck } from '@tabler/icons-react';
 import { useRouter } from 'next/navigation';
-import { useEffect, useState } from 'react';
+import { useState } from 'react';
 
 export type Candidate = {
   applicationId: string;
@@ -623,14 +623,6 @@ export function BriefReviewPageContent({
   const [pendingId, setPendingId] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
 
-  // Clear the in-flight flag once fresh server data arrives after a pick
-  // (router.refresh updates `data`), so the other cards re-enable instead of
-  // staying stuck on "Saving…".
-  const pickedId = data.ok ? data.picked : null;
-  useEffect(() => {
-    setPendingId(null);
-  }, [pickedId]);
-
   if (!data.ok) {
     return (
       <Page>
@@ -663,12 +655,15 @@ export function BriefReviewPageContent({
       });
       if (!res.ok) {
         setError('We could not record your choice. Please try again.');
-        setPendingId(null);
         return;
       }
+      // Pull fresh server data (the picked state), then clear the in-flight flag
+      // unconditionally — never relies on `picked` changing, so re-picking the
+      // same partner can't leave a card stuck on "Saving…".
       router.refresh();
     } catch {
       setError('We could not record your choice. Please try again.');
+    } finally {
       setPendingId(null);
     }
   };

--- a/packages/twenty-website/src/app/[locale]/partners/review/[token]/BriefReviewPageContent.tsx
+++ b/packages/twenty-website/src/app/[locale]/partners/review/[token]/BriefReviewPageContent.tsx
@@ -1,0 +1,192 @@
+'use client';
+
+import { theme } from '@/theme';
+import { styled } from '@linaria/react';
+import { useRouter } from 'next/navigation';
+import { useState } from 'react';
+
+export type Candidate = {
+  applicationId: string;
+  state: string;
+  pitch: string | null;
+  partner: {
+    name: string | null;
+    skills: string[] | null;
+    country: string | null;
+  } | null;
+};
+
+export type ReviewData =
+  | {
+      ok: true;
+      brief: {
+        name: string | null;
+        need: string | null;
+        requirements: string | null;
+        status: string;
+      };
+      candidates: Candidate[];
+      picked: string | null;
+    }
+  | { ok: false; reason: string };
+
+const Background = styled.div`
+  align-items: center;
+  background: #0c0c0c;
+  display: flex;
+  justify-content: center;
+  min-height: 100vh;
+`;
+
+const Container = styled.div`
+  box-sizing: border-box;
+  color: #fff;
+  display: flex;
+  flex-direction: column;
+  gap: ${theme.spacing(4)};
+  max-width: min(720px, 100%);
+  padding: ${theme.spacing(6)} ${theme.spacing(4)};
+  width: 100%;
+`;
+
+const Title = styled.h1`
+  font-size: 28px;
+  font-weight: 500;
+  margin: 0;
+`;
+
+const Lede = styled.p`
+  color: rgba(255, 255, 255, 0.7);
+  margin: 0;
+`;
+
+const Card = styled.div`
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  border-radius: 8px;
+  display: flex;
+  flex-direction: column;
+  gap: ${theme.spacing(2)};
+  padding: ${theme.spacing(4)};
+`;
+
+const CardName = styled.div`
+  font-size: 18px;
+  font-weight: 500;
+`;
+
+const Meta = styled.div`
+  color: rgba(255, 255, 255, 0.6);
+  font-size: 14px;
+`;
+
+const PickButton = styled.button`
+  align-self: flex-start;
+  background: #4a38f5;
+  border: 0;
+  border-radius: 4px;
+  color: #fff;
+  cursor: pointer;
+  font-size: 14px;
+  padding: ${theme.spacing(2)} ${theme.spacing(4)};
+
+  &:disabled {
+    cursor: default;
+    opacity: 0.5;
+  }
+`;
+
+const Selected = styled.div`
+  align-self: flex-start;
+  color: #89fc9a;
+  font-weight: 500;
+`;
+
+const ErrorText = styled.p`
+  color: #ff6b6b;
+  margin: 0;
+`;
+
+export function BriefReviewPageContent({
+  token,
+  data,
+}: {
+  token: string;
+  data: ReviewData;
+}) {
+  const router = useRouter();
+  const [pendingId, setPendingId] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  if (!data.ok) {
+    return (
+      <Background>
+        <Container>
+          <Title>This link is invalid or has expired.</Title>
+          <Lede>
+            Please check with your Twenty contact for an up-to-date link.
+          </Lede>
+        </Container>
+      </Background>
+    );
+  }
+
+  const isClosed = data.brief.status === 'CLOSED';
+
+  const pick = async (applicationId: string) => {
+    setPendingId(applicationId);
+    setError(null);
+    try {
+      const res = await fetch('/api/brief-pick', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ token, applicationId }),
+      });
+      if (!res.ok) {
+        setError('Could not record your choice. Please try again.');
+        setPendingId(null);
+        return;
+      }
+      router.refresh();
+    } catch {
+      setError('Could not record your choice. Please try again.');
+      setPendingId(null);
+    }
+  };
+
+  return (
+    <Background>
+      <Container>
+        <Title>{data.brief.name ?? 'Your brief'}</Title>
+        {data.brief.need ? <Lede>{data.brief.need}</Lede> : null}
+        {isClosed ? (
+          <Lede>A partner has been selected — this review is now locked.</Lede>
+        ) : null}
+        {data.candidates.map((candidate) => (
+          <Card key={candidate.applicationId}>
+            <CardName>{candidate.partner?.name ?? 'Partner'}</CardName>
+            {candidate.partner?.country ? (
+              <Meta>{candidate.partner.country}</Meta>
+            ) : null}
+            {candidate.partner?.skills?.length ? (
+              <Meta>{candidate.partner.skills.join(', ')}</Meta>
+            ) : null}
+            {candidate.pitch ? <Lede>{candidate.pitch}</Lede> : null}
+            {data.picked === candidate.applicationId ? (
+              <Selected>Selected</Selected>
+            ) : !isClosed ? (
+              <PickButton
+                disabled={pendingId !== null}
+                onClick={() => pick(candidate.applicationId)}
+              >
+                {pendingId === candidate.applicationId
+                  ? 'Saving…'
+                  : 'Pick this partner'}
+              </PickButton>
+            ) : null}
+          </Card>
+        ))}
+        {error ? <ErrorText>{error}</ErrorText> : null}
+      </Container>
+    </Background>
+  );
+}

--- a/packages/twenty-website/src/app/[locale]/partners/review/[token]/page.tsx
+++ b/packages/twenty-website/src/app/[locale]/partners/review/[token]/page.tsx
@@ -1,0 +1,36 @@
+import { getRouteI18n, type LocaleRouteParams } from '@/lib/i18n/server';
+import { type Metadata } from 'next';
+import {
+  BriefReviewPageContent,
+  type ReviewData,
+} from './BriefReviewPageContent';
+
+// Token-gated, no SEO value — keep it out of the index. (No static-website-routes
+// entry needed: App Router serves the file directly; registration only feeds the
+// sitemap/metadata, which we don't want for this page.)
+export const metadata: Metadata = { robots: { index: false, follow: false } };
+
+type ReviewPageProps = {
+  params: Promise<LocaleRouteParams & { token: string }>;
+};
+
+async function fetchReview(token: string): Promise<ReviewData> {
+  const base = process.env.BRIEF_REVIEW_BASE_URL?.trim().replace(/\/+$/, '');
+  if (!base) return { ok: false, reason: 'NOT_CONFIGURED' };
+  try {
+    const res = await fetch(`${base}?token=${encodeURIComponent(token)}`, {
+      cache: 'no-store',
+    });
+    if (!res.ok) return { ok: false, reason: 'UPSTREAM' };
+    return (await res.json()) as ReviewData;
+  } catch {
+    return { ok: false, reason: 'UPSTREAM' };
+  }
+}
+
+export default async function BriefReviewPage({ params }: ReviewPageProps) {
+  await getRouteI18n(params);
+  const { token } = await params;
+  const data = await fetchReview(token);
+  return <BriefReviewPageContent token={token} data={data} />;
+}

--- a/packages/twenty-website/src/app/[locale]/partners/review/[token]/page.tsx
+++ b/packages/twenty-website/src/app/[locale]/partners/review/[token]/page.tsx
@@ -1,20 +1,18 @@
 import { getRouteI18n, type LocaleRouteParams } from '@/lib/i18n/server';
 import { type Metadata } from 'next';
+import { cache } from 'react';
 import {
   BriefReviewPageContent,
   type ReviewData,
 } from './BriefReviewPageContent';
 
-// Token-gated, no SEO value — keep it out of the index. (No static-website-routes
-// entry needed: App Router serves the file directly; registration only feeds the
-// sitemap/metadata, which we don't want for this page.)
-export const metadata: Metadata = { robots: { index: false, follow: false } };
-
 type ReviewPageProps = {
   params: Promise<LocaleRouteParams & { token: string }>;
 };
 
-async function fetchReview(token: string): Promise<ReviewData> {
+// cache() dedupes the fetch across generateMetadata + the page render in one
+// request (fetch itself isn't memoized under cache: 'no-store').
+const getReview = cache(async (token: string): Promise<ReviewData> => {
   const base = process.env.BRIEF_REVIEW_BASE_URL?.trim().replace(/\/+$/, '');
   if (!base) return { ok: false, reason: 'NOT_CONFIGURED' };
   try {
@@ -26,11 +24,25 @@ async function fetchReview(token: string): Promise<ReviewData> {
   } catch {
     return { ok: false, reason: 'UPSTREAM' };
   }
+});
+
+// Token-gated, no SEO value, so keep it out of the index. Title carries the
+// brief name so the browser tab is identifiable when several reviews are open.
+export async function generateMetadata({
+  params,
+}: ReviewPageProps): Promise<Metadata> {
+  const { token } = await params;
+  const data = await getReview(token);
+  const title =
+    data.ok && data.brief.name
+      ? `${data.brief.name} · Partner review`
+      : 'Partner review · Twenty';
+  return { title, robots: { index: false, follow: false } };
 }
 
 export default async function BriefReviewPage({ params }: ReviewPageProps) {
   await getRouteI18n(params);
-  const { token } = await params;
-  const data = await fetchReview(token);
-  return <BriefReviewPageContent token={token} data={data} />;
+  const { locale, token } = await params;
+  const data = await getReview(token);
+  return <BriefReviewPageContent token={token} locale={locale} data={data} />;
 }

--- a/packages/twenty-website/src/app/api/brief-pick/__tests__/route.test.ts
+++ b/packages/twenty-website/src/app/api/brief-pick/__tests__/route.test.ts
@@ -1,3 +1,8 @@
+// Force module scope: this file uses dynamic import() and global jest, so it
+// has no top-level import/export. Without this, tsc treats it as a global
+// script and its top-level bindings collide with the sibling route tests.
+export {};
+
 const ORIGINAL_FETCH = global.fetch;
 const ORIGINAL_BASE = process.env.BRIEF_REVIEW_BASE_URL;
 const ORIGINAL_SECRET = process.env.PARTNER_APPLICATION_SECRET;

--- a/packages/twenty-website/src/app/api/brief-pick/__tests__/route.test.ts
+++ b/packages/twenty-website/src/app/api/brief-pick/__tests__/route.test.ts
@@ -1,0 +1,114 @@
+const ORIGINAL_FETCH = global.fetch;
+const ORIGINAL_BASE = process.env.BRIEF_REVIEW_BASE_URL;
+const ORIGINAL_SECRET = process.env.PARTNER_APPLICATION_SECRET;
+
+const VALID_BODY = JSON.stringify({
+  token: 'tok-123',
+  applicationId: 'app-456',
+});
+
+function buildRequest({
+  body = VALID_BODY,
+  contentType = 'application/json',
+  ip = '203.0.113.1',
+}: { body?: string; contentType?: string | null; ip?: string } = {}) {
+  const headers = new Headers();
+  if (contentType !== null) headers.set('content-type', contentType);
+  headers.set('x-forwarded-for', ip);
+  return new Request('https://example.com/api/brief-pick', {
+    method: 'POST',
+    headers,
+    body,
+  });
+}
+
+async function loadRoute() {
+  jest.resetModules();
+  return import('@/app/api/brief-pick/route');
+}
+
+describe('POST /api/brief-pick', () => {
+  beforeEach(() => {
+    process.env.BRIEF_REVIEW_BASE_URL =
+      'https://hooks.example/c/app/brief-review';
+    process.env.PARTNER_APPLICATION_SECRET = 'test-key-abc123';
+  });
+  afterEach(() => {
+    global.fetch = ORIGINAL_FETCH;
+    process.env.BRIEF_REVIEW_BASE_URL = ORIGINAL_BASE;
+    process.env.PARTNER_APPLICATION_SECRET = ORIGINAL_SECRET;
+  });
+
+  it('returns 503 when the base URL is not configured', async () => {
+    delete process.env.BRIEF_REVIEW_BASE_URL;
+    const { POST } = await loadRoute();
+    expect((await POST(buildRequest())).status).toBe(503);
+  });
+
+  it('returns 503 when the secret is not configured', async () => {
+    delete process.env.PARTNER_APPLICATION_SECRET;
+    const { POST } = await loadRoute();
+    expect((await POST(buildRequest({ ip: '203.0.113.2' }))).status).toBe(503);
+  });
+
+  it('returns 400 when token/applicationId are missing', async () => {
+    const { POST } = await loadRoute();
+    const res = await POST(
+      buildRequest({ body: JSON.stringify({ token: 'x' }), ip: '203.0.113.3' }),
+    );
+    expect(res.status).toBe(400);
+  });
+
+  it('forwards the pick to <base>/pick with the secret header and returns 200', async () => {
+    const fetchSpy = jest.fn().mockResolvedValue(
+      new Response(JSON.stringify({ ok: true, picked: 'app-456' }), {
+        status: 200,
+      }),
+    );
+    global.fetch = fetchSpy;
+    const { POST } = await loadRoute();
+    const res = await POST(buildRequest({ ip: '203.0.113.4' }));
+    expect(res.status).toBe(200);
+    await expect(res.json()).resolves.toEqual({ success: true });
+    const [url, init] = fetchSpy.mock.calls[0];
+    expect(url).toBe('https://hooks.example/c/app/brief-review/pick');
+    expect(init.method).toBe('POST');
+    expect(init.headers['X-Application-Secret']).toBe('test-key-abc123');
+    expect(JSON.parse(init.body as string)).toEqual({
+      token: 'tok-123',
+      applicationId: 'app-456',
+    });
+  });
+
+  it('returns 502 when the upstream responds non-2xx', async () => {
+    global.fetch = jest
+      .fn()
+      .mockResolvedValue(new Response('boom', { status: 500 }));
+    const { POST } = await loadRoute();
+    expect((await POST(buildRequest({ ip: '203.0.113.5' }))).status).toBe(502);
+  });
+
+  it('returns 502 when the logic function returns ok:false', async () => {
+    global.fetch = jest.fn().mockResolvedValue(
+      new Response(JSON.stringify({ ok: false, reason: 'FORBIDDEN' }), {
+        status: 200,
+      }),
+    );
+    const { POST } = await loadRoute();
+    expect((await POST(buildRequest({ ip: '203.0.113.6' }))).status).toBe(502);
+  });
+
+  it('rate-limits the same IP after the burst capacity is spent', async () => {
+    global.fetch = jest
+      .fn()
+      .mockResolvedValue(
+        new Response(JSON.stringify({ ok: true }), { status: 200 }),
+      );
+    const { POST } = await loadRoute();
+    const ip = '203.0.113.99';
+    const statuses: number[] = [];
+    for (let i = 0; i < 11; i++)
+      statuses.push((await POST(buildRequest({ ip }))).status);
+    expect(statuses[10]).toBe(429);
+  });
+});

--- a/packages/twenty-website/src/app/api/brief-pick/route.ts
+++ b/packages/twenty-website/src/app/api/brief-pick/route.ts
@@ -1,0 +1,144 @@
+import {
+  createRateLimiter,
+  fetchWithTimeout,
+  getClientIpKey,
+  readJsonBody,
+} from '@/lib/api';
+import { NextResponse } from 'next/server';
+import { z } from 'zod';
+
+// z.url() (not z.httpUrl) so localhost destinations are accepted in dev.
+const pickUrlSchema = z
+  .string()
+  .trim()
+  .pipe(z.url({ error: 'Invalid pick URL.' }));
+const secretSchema = z.string().trim().min(1);
+const bodySchema = z.object({
+  token: z.string().trim().min(1),
+  applicationId: z.string().trim().min(1),
+});
+
+const MAX_BODY_BYTES = 4 * 1024;
+const PICK_TIMEOUT_MS = 8_000;
+const checkRateLimit = createRateLimiter({
+  capacity: 10,
+  refillPerSec: 1 / 30,
+});
+
+export async function POST(request: Request) {
+  const base = process.env.BRIEF_REVIEW_BASE_URL?.trim().replace(/\/+$/, '');
+  const pickUrlResult = pickUrlSchema.safeParse(
+    base ? `${base}/pick` : undefined,
+  );
+  const secretResult = secretSchema.safeParse(
+    process.env.PARTNER_APPLICATION_SECRET,
+  );
+
+  if (!pickUrlResult.success || !secretResult.success) {
+    console.error(
+      '[brief-pick] 503 — BRIEF_REVIEW_BASE_URL or PARTNER_APPLICATION_SECRET missing/invalid',
+    );
+    return NextResponse.json(
+      { error: 'Brief pick endpoint is not configured.' },
+      { status: 503 },
+    );
+  }
+
+  const rateLimit = checkRateLimit(getClientIpKey(request));
+  if (!rateLimit.allowed) {
+    const retryAfterSeconds = Math.max(
+      1,
+      Math.ceil(rateLimit.retryAfterMs / 1000),
+    );
+    return NextResponse.json(
+      { error: 'Too many requests. Please try again shortly.' },
+      { status: 429, headers: { 'Retry-After': String(retryAfterSeconds) } },
+    );
+  }
+
+  const bodyResult = await readJsonBody<unknown>(request, {
+    maxBytes: MAX_BODY_BYTES,
+  });
+  if (!bodyResult.ok) {
+    switch (bodyResult.error) {
+      case 'wrong-content-type':
+        return NextResponse.json(
+          { error: 'Content-Type must be application/json.' },
+          { status: 415 },
+        );
+      case 'too-large':
+        return NextResponse.json(
+          { error: 'Request body is too large.' },
+          { status: 413 },
+        );
+      case 'invalid-json':
+        return NextResponse.json(
+          { error: 'Invalid JSON body.' },
+          { status: 400 },
+        );
+    }
+  }
+
+  const parsed = bodySchema.safeParse(bodyResult.value);
+  if (!parsed.success) {
+    return NextResponse.json(
+      { error: 'Invalid request body.' },
+      { status: 400 },
+    );
+  }
+
+  const upstream = await fetchWithTimeout(
+    pickUrlResult.data,
+    {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'X-Application-Secret': secretResult.data,
+      },
+      body: JSON.stringify(parsed.data),
+    },
+    { timeoutMs: PICK_TIMEOUT_MS },
+  );
+
+  if (!upstream.ok) {
+    const status = upstream.error === 'timeout' ? 504 : 502;
+    return NextResponse.json(
+      { error: 'Could not record your choice.' },
+      { status },
+    );
+  }
+
+  let upstreamBody: string;
+  try {
+    upstreamBody = await upstream.response.text();
+  } catch {
+    upstreamBody = '';
+  }
+
+  if (!upstream.response.ok) {
+    return NextResponse.json(
+      { error: 'Could not record your choice.' },
+      { status: 502 },
+    );
+  }
+
+  let logicResult: unknown;
+  try {
+    logicResult = JSON.parse(upstreamBody);
+  } catch {
+    logicResult = null;
+  }
+
+  if (
+    typeof logicResult !== 'object' ||
+    logicResult === null ||
+    (logicResult as Record<string, unknown>)['ok'] !== true
+  ) {
+    return NextResponse.json(
+      { error: 'Could not record your choice.' },
+      { status: 502 },
+    );
+  }
+
+  return NextResponse.json({ success: true });
+}

--- a/packages/twenty-website/src/app/api/brief-pick/route.ts
+++ b/packages/twenty-website/src/app/api/brief-pick/route.ts
@@ -7,11 +7,15 @@ import {
 import { NextResponse } from 'next/server';
 import { z } from 'zod';
 
-// z.url() (not z.httpUrl) so localhost destinations are accepted in dev.
+// z.url() (not z.httpUrl) so localhost destinations are accepted in dev, but
+// constrain the scheme to http(s) so a misconfigured base fails fast.
 const pickUrlSchema = z
   .string()
   .trim()
-  .pipe(z.url({ error: 'Invalid pick URL.' }));
+  .pipe(z.url({ error: 'Invalid pick URL.' }))
+  .refine((value) => /^https?:\/\//i.test(value), {
+    error: 'Pick URL must use http or https.',
+  });
 const secretSchema = z.string().trim().min(1);
 const bodySchema = z.object({
   token: z.string().trim().min(1),


### PR DESCRIPTION
## Summary
The no-login client page for the magic-link partner review (pairs with the partners-app backend on `rk-partner-matching-app`, #21636).

- **`/partners/review/[token]`** — server-fetches the brief via the public token-gated GET endpoint and renders profile-grade candidate cards (avatar, intro, region/language chips, rates, the partner's note, "see full profile") in a responsive side-by-side comparison grid. Brief name in the tab title; noindex.
- **`/api/brief-pick`** — server proxy that adds the `X-Application-Secret` header so the browser never holds the secret.
- **`BRIEF_REVIEW_BASE_URL`** env var, documented in `.env.example`.

Reuses the marketplace's own primitives (`PartnerAvatar`, `PartnerChipRow`, `PartnerMoneyRow`, chip-label maps) so the review cards match the rest of the partner experience.

## Test Plan
- [ ] `npx jest src/app/api/brief-pick` — 7 tests green
- [ ] `npx oxlint -c .oxlintrc.json .` / `npx oxfmt --check .` — clean
- [ ] Open a real `reviewToken`, pick a partner, confirm it flips to "Selected" and only the picked card showed "Saving…"

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/21637?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

