### PR TITLE
fix(record-field): prevent state clobbering and focus loss in dynamic array inputs

### DIFF
--- a/packages/twenty-front/src/modules/object-record/record-field/ui/form-types/components/FormArrayFieldInput.tsx
+++ b/packages/twenty-front/src/modules/object-record/record-field/ui/form-types/components/FormArrayFieldInput.tsx
@@ -34,6 +34,7 @@ import {
 } from 'twenty-ui-deprecated/theme-constants';
 import { MenuItem } from 'twenty-ui-deprecated/navigation';
 import { toSpliced } from '~/utils/array/toSpliced';
+import { v4 } from 'uuid';
 
 type FormArrayFieldInputProps = {
   label?: string;
@@ -128,11 +129,22 @@ export const FormArrayFieldInput = ({
         },
   );
 
+  const [stableIds, setStableIds] = useState<string[]>(() => {
+    if (isStandaloneVariableString(defaultValue)) {
+      return [];
+    }
+    const initialItems =
+      isDefined(defaultValue) && isNonEmptyArray(defaultValue)
+        ? defaultValue
+        : [];
+    return initialItems.map(() => v4());
+  });
+
   const [newItemDraftValue, setNewItemDraftValue] = useState('');
   const [inputValue, setInputValue] = useState('');
   const [isInputDisplayed, setIsInputDisplayed] = useState(false);
-  const [itemToEditIndex, setItemToEditIndex] = useState(-1);
-  const isAddingNewItem = itemToEditIndex === -1;
+  const [itemToEditId, setItemToEditId] = useState<string | null>(null);
+  const isAddingNewItem = itemToEditId === null;
 
   const containerRef = useRef<HTMLDivElement>(null);
 
@@ -153,12 +165,18 @@ export const FormArrayFieldInput = ({
   };
 
   const handleFirstItemInputEnter = () => {
+    if (draftValue.type !== 'static') {
+      return;
+    }
+
+    const updatedItems = [...draftValue.value, newItemDraftValue];
     setDraftValue({
       type: 'static',
-      value: [...draftValue.value, newItemDraftValue],
+      value: updatedItems,
     });
+    setStableIds((prev) => [...prev, v4()]);
 
-    onChange([...draftValue.value, newItemDraftValue]);
+    onChange(updatedItems);
 
     setNewItemDraftValue('');
 
@@ -171,23 +189,36 @@ export const FormArrayFieldInput = ({
     });
   };
 
-  const handleEditItem = (index: number) => {
-    setInputValue(draftValue.value[index]);
-    setItemToEditIndex(index);
-    setIsInputDisplayed(true);
+  const handleEditItem = (id: string) => {
+    if (draftValue.type !== 'static') {
+      return;
+    }
+    const index = stableIds.indexOf(id);
+    if (index !== -1) {
+      setInputValue(draftValue.value[index]);
+      setItemToEditId(id);
+      setIsInputDisplayed(true);
+    }
   };
 
-  const handleDeleteItem = (index: number) => {
+  const handleDeleteItem = (id: string) => {
     if (draftValue.type !== 'static') {
       throw new Error('Cannot delete item when value is a variable.');
     }
 
+    const index = stableIds.indexOf(id);
+    if (index === -1) {
+      return;
+    }
+
     const updatedItems = toSpliced(draftValue.value, index, 1);
+    const updatedIds = toSpliced(stableIds, index, 1);
 
     setDraftValue({
       type: 'static',
       value: updatedItems,
     });
+    setStableIds(updatedIds);
     onChange(updatedItems);
 
     const isDropdownGoingToBeHiddenNext = updatedItems.length === 0;
@@ -242,27 +273,40 @@ export const FormArrayFieldInput = ({
     }
 
     if (sanitizedInput === '' && !isAddingNewItem) {
-      handleDeleteItem(itemToEditIndex);
+      if (isDefined(itemToEditId)) {
+        handleDeleteItem(itemToEditId);
+      }
       return;
     }
 
     const items = draftValue.value;
 
-    if (!isAddingNewItem && sanitizedInput === items[itemToEditIndex]) {
-      setIsInputDisplayed(false);
-      setInputValue('');
-      return;
+    if (!isAddingNewItem && isDefined(itemToEditId)) {
+      const index = stableIds.indexOf(itemToEditId);
+      if (index !== -1) {
+        if (sanitizedInput === items[index]) {
+          setIsInputDisplayed(false);
+          setInputValue('');
+          return;
+        }
+
+        const updatedItems = toSpliced(items, index, 1, sanitizedInput);
+
+        setDraftValue({
+          type: 'static',
+          value: updatedItems,
+        });
+        onChange(updatedItems);
+      }
+    } else {
+      const updatedItems = [...items, sanitizedInput];
+      setDraftValue({
+        type: 'static',
+        value: updatedItems,
+      });
+      setStableIds((prev) => [...prev, v4()]);
+      onChange(updatedItems);
     }
-
-    const updatedItems = isAddingNewItem
-      ? [...items, sanitizedInput]
-      : toSpliced(items, itemToEditIndex, 1, sanitizedInput);
-
-    setDraftValue({
-      type: 'static',
-      value: updatedItems,
-    });
-    onChange(updatedItems);
 
     setIsInputDisplayed(false);
     setInputValue('');
@@ -273,7 +317,7 @@ export const FormArrayFieldInput = ({
   };
 
   const handleAddItemButtonClick = () => {
-    setItemToEditIndex(-1);
+    setItemToEditId(null);
     setIsInputDisplayed(true);
   };
 
@@ -291,15 +335,164 @@ export const FormArrayFieldInput = ({
       type: 'static',
       value: [],
     });
+    setStableIds([]);
 
     setNewItemDraftValue('');
 
     onChange([]);
   };
 
+  const renderLabel = () => {
+    if (isDefined(label)) {
+      return <InputLabel>{label}</InputLabel>;
+    }
+    return null;
+  };
+
+  const renderReadonlyDisplay = (items: string[]) => {
+    if (items.length > 0) {
+      return <ArrayDisplay value={items} />;
+    }
+    return (
+      <StyledPlaceholderContainer>
+        <FormFieldPlaceholder />
+      </StyledPlaceholderContainer>
+    );
+  };
+
+  const renderEmptyInput = () => {
+    return (
+      <StyledInputContainer>
+        <TextInput
+          instanceId={formFieldInputInstanceId}
+          placeholder={t`Enter an item`}
+          value={newItemDraftValue}
+          copyButton={false}
+          onChange={handleFirstItemInputChange}
+          onEnter={handleFirstItemInputEnter}
+          shouldTrim={false}
+        />
+      </StyledInputContainer>
+    );
+  };
+
+  const renderDropdownMenuItems = (items: string[]) => {
+    return (
+      <DropdownMenuItemsContainer hasMaxHeight>
+        {items.map((value, index) => {
+          const id = stableIds[index] || index.toString();
+          return (
+            <ArrayFieldMenuItem
+              key={id}
+              dropdownId={`array-field-input-${instanceId}-${id}`}
+              value={value}
+              onEdit={() => {
+                handleEditItem(id);
+              }}
+              onDelete={() => {
+                handleDeleteItem(id);
+              }}
+            />
+          );
+        })}
+      </DropdownMenuItemsContainer>
+    );
+  };
+
+  const renderNewItemInputOrAddButton = () => {
+    if (isInputDisplayed) {
+      return (
+        <MultiItemBaseInput
+          instanceId={newItemInputInstanceId}
+          autoFocus
+          placeholder={placeholder}
+          value={inputValue}
+          onFocus={handleNewItemInputFocus}
+          onBlur={handleNewItemInputBlur}
+          onEscape={handleNewItemInputEscape}
+          onChange={handleNewItemInputChange}
+          onEnter={handleNewItemInputSubmit}
+          hasItem
+        />
+      );
+    }
+    return (
+      <DropdownMenuItemsContainer>
+        <MenuItem
+          onClick={handleAddItemButtonClick}
+          LeftIcon={IconPlus}
+          text={t`Add item`}
+        />
+      </DropdownMenuItemsContainer>
+    );
+  };
+
+  const renderDropdown = (items: string[]) => {
+    return (
+      <Dropdown
+        dropdownId={dropdownId}
+        dropdownPlacement="bottom-start"
+        dropdownOffset={{
+          y: parseSpacingValueAsNumber(theme.spacing[1]),
+        }}
+        clickableComponent={
+          <StyledDisplayModeContainer data-open={isDropdownOpen}>
+            <ArrayDisplay value={items} />
+          </StyledDisplayModeContainer>
+        }
+        clickableComponentWidth="100%"
+        dropdownComponents={
+          <DropdownContent ref={containerRef}>
+            {renderDropdownMenuItems(items)}
+            <DropdownMenuSeparator />
+            {renderNewItemInputOrAddButton()}
+          </DropdownContent>
+        }
+      />
+    );
+  };
+
+  const renderStaticContent = (items: string[]) => {
+    if (readonly) {
+      return (
+        <StyledDisplayModeReadonlyContainer>
+          {renderReadonlyDisplay(items)}
+        </StyledDisplayModeReadonlyContainer>
+      );
+    }
+    if (items.length === 0) {
+      return renderEmptyInput();
+    }
+    return renderDropdown(items);
+  };
+
+  const renderInnerContent = () => {
+    if (draftValue.type === 'static') {
+      return renderStaticContent(draftValue.value);
+    }
+    return (
+      <VariableChipStandalone
+        rawVariableName={draftValue.value}
+        onRemove={readonly ? undefined : handleUnlinkVariable}
+      />
+    );
+  };
+
+  const renderVariablePicker = () => {
+    if (isDefined(VariablePicker) && !readonly) {
+      return (
+        <VariablePicker
+          instanceId={instanceId}
+          onVariableSelect={handleVariableTagInsert}
+        />
+      );
+    }
+    return null;
+  };
+
   return (
     <FormFieldInputContainer data-testid={testId}>
-      {label ? <InputLabel>{label}</InputLabel> : null}
+      {renderLabel()}
 
       <FormFieldInputRowContainer>
         <FormFieldInputInnerContainer
@@ -307,103 +500,10 @@ export const FormArrayFieldInput = ({
           preventFocusStackUpdate={preventContainerFocusStackUpdate}
           hasRightElement={isDefined(VariablePicker) && !readonly}
         >
-          {draftValue.type === 'static' ? (
-            readonly ? (
-              <StyledDisplayModeReadonlyContainer>
-                {draftValue.value.length > 0 ? (
-                  <ArrayDisplay value={draftValue.value} />
-                ) : (
-                  <StyledPlaceholderContainer>
-                    <FormFieldPlaceholder />
-                  </StyledPlaceholderContainer>
-                )}
-              </StyledDisplayModeReadonlyContainer>
-            ) : draftValue.value.length === 0 ? (
-              <StyledInputContainer>
-                <TextInput
-                  instanceId={formFieldInputInstanceId}
-                  placeholder={t`Enter an item`}
-                  value={newItemDraftValue}
-                  copyButton={false}
-                  onChange={handleFirstItemInputChange}
-                  onEnter={handleFirstItemInputEnter}
-                  shouldTrim={false}
-                />
-              </StyledInputContainer>
-            ) : (
-              <Dropdown
-                dropdownId={dropdownId}
-                dropdownPlacement="bottom-start"
-                dropdownOffset={{
-                  y: parseSpacingValueAsNumber(theme.spacing[1]),
-                }}
-                clickableComponent={
-                  <StyledDisplayModeContainer data-open={isDropdownOpen}>
-                    <ArrayDisplay value={draftValue.value} />
-                  </StyledDisplayModeContainer>
-                }
-                clickableComponentWidth="100%"
-                dropdownComponents={
-                  <DropdownContent ref={containerRef}>
-                    <DropdownMenuItemsContainer hasMaxHeight>
-                      {draftValue.type === 'static' &&
-                        draftValue.value.map((value, index) => (
-                          <ArrayFieldMenuItem
-                            key={index}
-                            dropdownId={`array-field-input-${instanceId}-${index}`}
-                            value={value}
-                            onEdit={() => {
-                              handleEditItem(index);
-                            }}
-                            onDelete={() => {
-                              handleDeleteItem(index);
-                            }}
-                          />
-                        ))}
-                    </DropdownMenuItemsContainer>
-
-                    <DropdownMenuSeparator />
-
-                    {isInputDisplayed ? (
-                      <MultiItemBaseInput
-                        instanceId={newItemInputInstanceId}
-                        autoFocus
-                        placeholder={placeholder}
-                        value={inputValue}
-                        onFocus={handleNewItemInputFocus}
-                        onBlur={handleNewItemInputBlur}
-                        onEscape={handleNewItemInputEscape}
-                        onChange={handleNewItemInputChange}
-                        onEnter={handleNewItemInputSubmit}
-                        hasItem
-                      />
-                    ) : (
-                      <DropdownMenuItemsContainer>
-                        <MenuItem
-                          onClick={handleAddItemButtonClick}
-                          LeftIcon={IconPlus}
-                          text={t`Add item`}
-                        />
-                      </DropdownMenuItemsContainer>
-                    )}
-                  </DropdownContent>
-                }
-              />
-            )
-          ) : (
-            <VariableChipStandalone
-              rawVariableName={draftValue.value}
-              onRemove={readonly ? undefined : handleUnlinkVariable}
-            />
-          )}
+          {renderInnerContent()}
         </FormFieldInputInnerContainer>
 
-        {VariablePicker && !readonly && (
-          <VariablePicker
-            instanceId={instanceId}
-            onVariableSelect={handleVariableTagInsert}
-          />
-        )}
+        {renderVariablePicker()}
       </FormFieldInputRowContainer>
     </FormFieldInputContainer>
   );

--- a/packages/twenty-front/src/modules/object-record/record-field/ui/form-types/components/__stories__/FormArrayFieldInput.stories.tsx
+++ b/packages/twenty-front/src/modules/object-record/record-field/ui/form-types/components/__stories__/FormArrayFieldInput.stories.tsx
@@ -94,15 +94,15 @@ export const EditExistingItem: Story = {
     await userEvent.click(firstItemChip);
 
     const openSecondItemMenuButton = await waitFor(() => {
-      const button = canvasElement.ownerDocument.body.querySelector(
-        '[aria-controls$="-1-options"] > button',
+      const buttons = canvasElement.ownerDocument.body.querySelectorAll(
+        '[aria-controls$="-options"] > button',
       );
 
-      if (!isDefined(button)) {
+      if (buttons.length < 2) {
         throw new Error('Button not found');
       }
 
-      return button;
+      return buttons[1];
     });
 
     await userEvent.click(openSecondItemMenuButton);
@@ -151,15 +151,15 @@ export const DeleteExistingItem: Story = {
     await userEvent.click(firstItemChip);
 
     const openSecondItemMenuButton = await waitFor(() => {
-      const button = canvasElement.ownerDocument.body.querySelector(
-        '[aria-controls$="-1-options"] > button',
+      const buttons = canvasElement.ownerDocument.body.querySelectorAll(
+        '[aria-controls$="-options"] > button',
       );
 
-      if (!isDefined(button)) {
+      if (buttons.length < 2) {
         throw new Error('Button not found');
       }
 
-      return button;
+      return buttons[1];
     });
 
     await userEvent.click(openSecondItemMenuButton);

--- a/packages/twenty-front/src/modules/object-record/record-field/ui/meta-types/input/components/ArrayFieldInput.tsx
+++ b/packages/twenty-front/src/modules/object-record/record-field/ui/meta-types/input/components/ArrayFieldInput.tsx
@@ -12,7 +12,8 @@ import { FieldMetadataType } from '~/generated-metadata/graphql';
 import { toSpliced } from '~/utils/array/toSpliced';
 import { v4 } from 'uuid';
 
-const useArrayStableIds = (itemsLength: number) => {
+const useArrayStableIds = (items: string[]) => {
+  const itemsLength = items.length;
   const [stableIds, setStableIds] = useState<string[]>(() => {
     const initialIds: string[] = [];
     for (let i = 0; i < itemsLength; i++) {
@@ -21,20 +22,31 @@ const useArrayStableIds = (itemsLength: number) => {
     return initialIds;
   });
 
-  const [prevLength, setPrevLength] = useState(itemsLength);
+  const [prevItems, setPrevItems] = useState(items);
 
-  if (prevLength !== itemsLength) {
-    const diff = itemsLength - prevLength;
+  if (prevItems !== items) {
+    const diff = itemsLength - prevItems.length;
     if (diff > 0) {
       const newIds: string[] = [];
       for (let i = 0; i < diff; i++) {
         newIds.push(v4());
       }
       setStableIds([...stableIds, ...newIds]);
-    } else {
-      setStableIds(stableIds.slice(0, itemsLength));
+    } else if (diff < 0) {
+      if (itemsLength === 0) {
+        setStableIds([]);
+      } else {
+        let deletedIndex = prevItems.length - 1;
+        for (let i = 0; i < itemsLength; i++) {
+          if (prevItems[i] !== items[i]) {
+            deletedIndex = i;
+            break;
+          }
+        }
+        setStableIds(toSpliced(stableIds, deletedIndex, Math.abs(diff)));
+      }
     }
-    setPrevLength(itemsLength);
+    setPrevItems(items);
   }
 
   return { stableIds, setStableIds };
@@ -54,7 +66,7 @@ export const ArrayFieldInput = () => {
     return [];
   }, [draftValue]);
 
-  const { stableIds, setStableIds } = useArrayStableIds(arrayItems.length);
+  const { stableIds, setStableIds } = useArrayStableIds(arrayItems);
 
   const parseStringArrayToArrayValue = (items: string[]) => {
     const parseResponse = arrayFieldValueSchema.safeParse(items);

--- a/packages/twenty-front/src/modules/object-record/record-field/ui/meta-types/input/components/ArrayFieldInput.tsx
+++ b/packages/twenty-front/src/modules/object-record/record-field/ui/meta-types/input/components/ArrayFieldInput.tsx
@@ -5,10 +5,40 @@ import { ArrayFieldMenuItem } from '@/object-record/record-field/ui/meta-types/i
 import { MultiItemFieldInput } from '@/object-record/record-field/ui/meta-types/input/components/MultiItemFieldInput';
 import { MULTI_ITEM_FIELD_INPUT_DROPDOWN_ID_PREFIX } from '@/object-record/record-field/ui/meta-types/input/constants/MultiItemFieldInputDropdownClickOutsideId';
 import { arrayFieldValueSchema } from '@/object-record/record-field/ui/validation-schemas/arrayFieldValueSchema';
-import { useContext, useMemo } from 'react';
+import { useContext, useMemo, useState } from 'react';
 import { MULTI_ITEM_FIELD_DEFAULT_MAX_VALUES } from 'twenty-shared/constants';
 import { isDefined } from 'twenty-shared/utils';
 import { FieldMetadataType } from '~/generated-metadata/graphql';
+import { toSpliced } from '~/utils/array/toSpliced';
+import { v4 } from 'uuid';
+
+const useArrayStableIds = (itemsLength: number) => {
+  const [stableIds, setStableIds] = useState<string[]>(() => {
+    const initialIds: string[] = [];
+    for (let i = 0; i < itemsLength; i++) {
+      initialIds.push(v4());
+    }
+    return initialIds;
+  });
+
+  const [prevLength, setPrevLength] = useState(itemsLength);
+
+  if (prevLength !== itemsLength) {
+    const diff = itemsLength - prevLength;
+    if (diff > 0) {
+      const newIds: string[] = [];
+      for (let i = 0; i < diff; i++) {
+        newIds.push(v4());
+      }
+      setStableIds([...stableIds, ...newIds]);
+    } else {
+      setStableIds(stableIds.slice(0, itemsLength));
+    }
+    setPrevLength(itemsLength);
+  }
+
+  return { stableIds, setStableIds };
+};
 
 export const ArrayFieldInput = () => {
   const { setDraftValue, draftValue, fieldDefinition } = useArrayField();
@@ -17,20 +47,29 @@ export const ArrayFieldInput = () => {
     FieldInputEventContext,
   );
 
-  const arrayItems = useMemo<Array<string>>(
-    () => (Array.isArray(draftValue) ? draftValue : []),
-    [draftValue],
-  );
-  const parseStringArrayToArrayValue = (arrayItems: string[]) => {
-    const parseResponse = arrayFieldValueSchema.safeParse(arrayItems);
+  const arrayItems = useMemo<Array<string>>(() => {
+    if (Array.isArray(draftValue)) {
+      return draftValue;
+    }
+    return [];
+  }, [draftValue]);
+
+  const { stableIds, setStableIds } = useArrayStableIds(arrayItems.length);
+
+  const parseStringArrayToArrayValue = (items: string[]) => {
+    const parseResponse = arrayFieldValueSchema.safeParse(items);
 
     if (parseResponse.success) {
       return parseResponse.data;
     }
+
+    return undefined;
   };
 
   const handleChange = (newValue: string[]) => {
-    if (!isDefined(newValue)) setDraftValue(null);
+    if (!isDefined(newValue)) {
+      setDraftValue(null);
+    }
 
     const nextValue = parseStringArrayToArrayValue(newValue);
 
@@ -43,23 +82,39 @@ export const ArrayFieldInput = () => {
     newValue: string[],
     event: MouseEvent | TouchEvent,
   ) => {
-    onClickOutside?.({
-      newValue: parseStringArrayToArrayValue(newValue),
-      event,
-    });
+    if (isDefined(onClickOutside)) {
+      onClickOutside({
+        newValue: parseStringArrayToArrayValue(newValue),
+        event,
+      });
+    }
   };
 
   const handleEscape = (newValue: string[]) => {
-    onEscape?.({ newValue: parseStringArrayToArrayValue(newValue) });
+    if (isDefined(onEscape)) {
+      onEscape({ newValue: parseStringArrayToArrayValue(newValue) });
+    }
   };
 
   const handleEnter = (newValue: string[]) => {
-    onEnter?.({ newValue: parseStringArrayToArrayValue(newValue) });
+    if (isDefined(onEnter)) {
+      onEnter({ newValue: parseStringArrayToArrayValue(newValue) });
+    }
   };
 
-  const maxNumberOfValues =
-    fieldDefinition.metadata.settings?.maxNumberOfValues ??
-    MULTI_ITEM_FIELD_DEFAULT_MAX_VALUES;
+  const getMaxNumberOfValues = () => {
+    if (isDefined(fieldDefinition.metadata.settings?.maxNumberOfValues)) {
+      return fieldDefinition.metadata.settings.maxNumberOfValues;
+    }
+    return MULTI_ITEM_FIELD_DEFAULT_MAX_VALUES;
+  };
+
+  const getStableId = (index: number) => {
+    if (isDefined(stableIds[index])) {
+      return stableIds[index];
+    }
+    return index.toString();
+  };
 
   return (
     <MultiItemFieldInput
@@ -73,14 +128,17 @@ export const ArrayFieldInput = () => {
       fieldMetadataType={FieldMetadataType.ARRAY}
       renderItem={({ value, index, handleEdit, handleDelete }) => (
         <ArrayFieldMenuItem
-          key={index}
-          dropdownId={`${MULTI_ITEM_FIELD_INPUT_DROPDOWN_ID_PREFIX}-${fieldDefinition.metadata.fieldName}-${index}`}
+          key={getStableId(index)}
+          dropdownId={`${MULTI_ITEM_FIELD_INPUT_DROPDOWN_ID_PREFIX}-${fieldDefinition.metadata.fieldName}-${getStableId(index)}`}
           value={value}
           onEdit={handleEdit}
-          onDelete={handleDelete}
+          onDelete={() => {
+            setStableIds((prevIds) => toSpliced(prevIds, index, 1));
+            handleDelete();
+          }}
         />
       )}
-      maxItemCount={maxNumberOfValues}
+      maxItemCount={getMaxNumberOfValues()}
     ></MultiItemFieldInput>
   );
 };

--- a/packages/twenty-front/src/modules/object-record/record-field/ui/meta-types/input/components/ArrayFieldInput.tsx
+++ b/packages/twenty-front/src/modules/object-record/record-field/ui/meta-types/input/components/ArrayFieldInput.tsx
@@ -22,10 +22,10 @@ const useArrayStableIds = (items: string[]) => {
     return initialIds;
   });
 
-  const [prevItems, setPrevItems] = useState(items);
+  const [prevItemsLength, setPrevItemsLength] = useState(itemsLength);
 
-  if (prevItems !== items) {
-    const diff = itemsLength - prevItems.length;
+  if (prevItemsLength !== itemsLength) {
+    const diff = itemsLength - prevItemsLength;
     if (diff > 0) {
       const newIds: string[] = [];
       for (let i = 0; i < diff; i++) {
@@ -35,18 +35,13 @@ const useArrayStableIds = (items: string[]) => {
     } else if (diff < 0) {
       if (itemsLength === 0) {
         setStableIds([]);
-      } else {
-        let deletedIndex = prevItems.length - 1;
-        for (let i = 0; i < itemsLength; i++) {
-          if (prevItems[i] !== items[i]) {
-            deletedIndex = i;
-            break;
-          }
-        }
-        setStableIds(toSpliced(stableIds, deletedIndex, Math.abs(diff)));
+      } else if (itemsLength < stableIds.length) {
+        // Fallback: outside mutation caused array to shrink without triggering onItemDeleted.
+        // We just slice from the end to maintain length parity.
+        setStableIds(stableIds.slice(0, itemsLength));
       }
     }
-    setPrevItems(items);
+    setPrevItemsLength(itemsLength);
   }
 
   return { stableIds, setStableIds };
@@ -136,6 +131,9 @@ export const ArrayFieldInput = () => {
       onEnter={handleEnter}
       onEscape={handleEscape}
       onClickOutside={handleClickOutside}
+      onItemDeleted={(index) => {
+        setStableIds((prevIds) => toSpliced(prevIds, index, 1));
+      }}
       placeholder={t`Enter value`}
       fieldMetadataType={FieldMetadataType.ARRAY}
       renderItem={({ value, index, handleEdit, handleDelete }) => (

--- a/packages/twenty-front/src/modules/object-record/record-field/ui/meta-types/input/components/ArrayFieldInput.tsx
+++ b/packages/twenty-front/src/modules/object-record/record-field/ui/meta-types/input/components/ArrayFieldInput.tsx
@@ -144,10 +144,7 @@ export const ArrayFieldInput = () => {
           dropdownId={`${MULTI_ITEM_FIELD_INPUT_DROPDOWN_ID_PREFIX}-${fieldDefinition.metadata.fieldName}-${getStableId(index)}`}
           value={value}
           onEdit={handleEdit}
-          onDelete={() => {
-            setStableIds((prevIds) => toSpliced(prevIds, index, 1));
-            handleDelete();
-          }}
+          onDelete={handleDelete}
         />
       )}
       maxItemCount={getMaxNumberOfValues()}

--- a/packages/twenty-front/src/modules/object-record/record-field/ui/meta-types/input/components/MultiItemFieldInput.tsx
+++ b/packages/twenty-front/src/modules/object-record/record-field/ui/meta-types/input/components/MultiItemFieldInput.tsx
@@ -95,13 +95,16 @@ export const MultiItemFieldInput = <T,>({
       }
 
       if (isInputDisplayed) {
-        const { isValid, updatedItems } = validateInputAndComputeUpdatedItems();
+        const { isValid, updatedItems, deletedIndex } = validateInputAndComputeUpdatedItems();
 
         if (!isValid) {
           return;
         }
 
         onChange(updatedItems);
+        if (isDefined(deletedIndex)) {
+          onItemDeleted?.(deletedIndex);
+        }
         onClickOutside(updatedItems, event);
 
         return;
@@ -221,12 +224,16 @@ export const MultiItemFieldInput = <T,>({
   };
 
   const handleEnter = () => {
-    const { isValid, updatedItems } = validateInputAndComputeUpdatedItems();
+    const { isValid, updatedItems, deletedIndex } = validateInputAndComputeUpdatedItems();
     if (!isValid) {
       return;
     }
 
     onChange(updatedItems);
+    if (isDefined(deletedIndex)) {
+      onItemDeleted?.(deletedIndex);
+    }
+    
     if (shouldAutoEnterBecauseOnlyOneItemIsAllowed) {
       onEnter(updatedItems);
     }
@@ -248,6 +255,7 @@ export const MultiItemFieldInput = <T,>({
   const validateInputAndComputeUpdatedItems = (): {
     isValid: boolean;
     updatedItems: T[];
+    deletedIndex?: number;
   } => {
     const { sanitizedInput, isValid, errorMessage } = sanitizeAndValidateInput(
       inputValue,
@@ -277,6 +285,7 @@ export const MultiItemFieldInput = <T,>({
 
     if (isItemDeletion) {
       showInputIfNoItemsRemain(updatedItems);
+      return { isValid: true, updatedItems, deletedIndex: editingIndex as number };
     }
 
     return { isValid: true, updatedItems };

--- a/packages/twenty-front/src/modules/object-record/record-field/ui/meta-types/input/components/MultiItemFieldInput.tsx
+++ b/packages/twenty-front/src/modules/object-record/record-field/ui/meta-types/input/components/MultiItemFieldInput.tsx
@@ -37,6 +37,7 @@ type MultiItemFieldInputProps<T> = {
   onEscape: (newItemsValue: T[]) => void;
   onEnter: (newItemsValue: T[]) => void;
   onClickOutside: (newItemsValue: T[], event: MouseEvent | TouchEvent) => void;
+  onItemDeleted?: (index: number) => void;
   onError?: (hasError: boolean, values: any[]) => void;
   placeholder: string;
   validateInput?: (input: string) => { isValid: boolean; errorMessage: string };
@@ -72,6 +73,7 @@ export const MultiItemFieldInput = <T,>({
   fieldMetadataType,
   renderInput,
   onClickOutside,
+  onItemDeleted,
   maxItemCount,
 }: MultiItemFieldInputProps<T>) => {
   const containerRef = useRef<HTMLDivElement>(null);
@@ -288,6 +290,7 @@ export const MultiItemFieldInput = <T,>({
   const handleDeleteItem = (index: number) => {
     const updatedItems = toSpliced(items, index, 1);
     onChange(updatedItems);
+    onItemDeleted?.(index);
     showInputIfNoItemsRemain(updatedItems);
   };
 

--- a/packages/twenty-front/src/modules/object-record/record-field/ui/meta-types/input/components/MultiItemFieldInput.tsx
+++ b/packages/twenty-front/src/modules/object-record/record-field/ui/meta-types/input/components/MultiItemFieldInput.tsx
@@ -95,7 +95,8 @@ export const MultiItemFieldInput = <T,>({
       }
 
       if (isInputDisplayed) {
-        const { isValid, updatedItems, deletedIndex } = validateInputAndComputeUpdatedItems();
+        const { isValid, updatedItems, deletedIndex } =
+          validateInputAndComputeUpdatedItems();
 
         if (!isValid) {
           return;
@@ -224,7 +225,8 @@ export const MultiItemFieldInput = <T,>({
   };
 
   const handleEnter = () => {
-    const { isValid, updatedItems, deletedIndex } = validateInputAndComputeUpdatedItems();
+    const { isValid, updatedItems, deletedIndex } =
+      validateInputAndComputeUpdatedItems();
     if (!isValid) {
       return;
     }
@@ -233,7 +235,7 @@ export const MultiItemFieldInput = <T,>({
     if (isDefined(deletedIndex)) {
       onItemDeleted?.(deletedIndex);
     }
-    
+
     if (shouldAutoEnterBecauseOnlyOneItemIsAllowed) {
       onEnter(updatedItems);
     }
@@ -285,7 +287,11 @@ export const MultiItemFieldInput = <T,>({
 
     if (isItemDeletion) {
       showInputIfNoItemsRemain(updatedItems);
-      return { isValid: true, updatedItems, deletedIndex: editingIndex as number };
+      return {
+        isValid: true,
+        updatedItems,
+        deletedIndex: editingIndex as number,
+      };
     }
 
     return { isValid: true, updatedItems };


### PR DESCRIPTION
Closes #21544

# Description

This PR fixes a critical React reconciliation bug where dynamic array items in record fields lost state and focus when an item in the middle of the array was deleted. This was caused by the anti-pattern of using the array map `index` as the React `key`.

### Root Cause & Technical Implementation
To accurately track DOM node additions and deletions, I replaced the index keys with stable UUIDs across the affected components while strictly adhering to Twenty technical standards (no ternaries or inline logical operators in JSX, no `useEffect` for derived state).

- **`FormArrayFieldInput.tsx`**: Implemented a parallel `stableIds` state synchronized flawlessly with `draftValue` additions and deletions using standard uncontrolled component event handlers. Extracted all complex inline logic into explicit render functions.
- **`ArrayFieldInput.tsx`**: Used the React-recommended `useState` render-phase pattern to deterministically track and update `stableIds` based on the derived `draftValue` length without `useEffect` or mutating data contracts. 

### How to Test / Verification

1. Navigate to any object record in the CRM that utilizes a dynamic array field.
2. Add 3 distinct items to the array input (e.g., "Item A", "Item B", "Item C").
3. Click into the input field for "Item C" to ensure it has browser focus.
4. Delete the middle item ("Item B").
5. **Verify:** "Item C" should shift up, retain its exact value, and React should not lose focus or overwrite the component state.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/21638?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

