### PR TITLE
Fix AI chat signed file cache busting

### DIFF
--- a/packages/twenty-server/src/engine/metadata-modules/ai/ai-chat/services/agent-chat-streaming.service.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/ai/ai-chat/services/agent-chat-streaming.service.ts
@@ -4,13 +4,11 @@ import { generateId } from 'ai';
 import {
   type ExtendedFileUIPart,
   type ExtendedUIMessagePart,
-  isExtendedFileUIPart,
 } from 'twenty-shared/ai';
 import { FileFolder } from 'twenty-shared/types';
 import { In, Like } from 'typeorm';
 
 import { FileEntity } from 'src/engine/core-modules/file/entities/file.entity';
-import { FileUrlService } from 'src/engine/core-modules/file/file-url/file-url.service';
 import { InjectMessageQueue } from 'src/engine/core-modules/message-queue/decorators/message-queue.decorator';
 import { MessageQueue } from 'src/engine/core-modules/message-queue/message-queue.constants';
 import { MessageQueueService } from 'src/engine/core-modules/message-queue/services/message-queue.service';
@@ -57,7 +55,6 @@ export class AgentChatStreamingService {
     private readonly messageQueueService: MessageQueueService,
     private readonly agentChatService: AgentChatService,
     private readonly eventPublisherService: AgentChatEventPublisherService,
-    private readonly fileUrlService: FileUrlService,
   ) {}
 
   async streamAgentChat({
@@ -271,31 +268,12 @@ export class AgentChatStreamingService {
       (message) => message.status !== AgentMessageStatus.QUEUED,
     );
 
-    return Promise.all(
-      filteredMessages.map(async (message) => ({
-        id: message.id,
-        role: message.role as 'user' | 'assistant' | 'system',
-        parts: await Promise.all(
-          mapDBPartsToUIMessageParts(message.parts ?? []).map(async (part) => {
-            if (isExtendedFileUIPart(part as Record<string, unknown>)) {
-              const filePart = part as ExtendedFileUIPart;
-
-              return {
-                ...filePart,
-                url: await this.fileUrlService.signFileByIdUrl({
-                  fileId: filePart.fileId,
-                  workspaceId,
-                  fileFolder: FileFolder.AgentChat,
-                }),
-              } as ExtendedFileUIPart;
-            }
-
-            return part;
-          }),
-        ),
-        createdAt: message.createdAt,
-      })),
-    );
+    return filteredMessages.map((message) => ({
+      id: message.id,
+      role: message.role as 'user' | 'assistant' | 'system',
+      parts: mapDBPartsToUIMessageParts(message.parts),
+      createdAt: message.createdAt,
+    }));
   }
 
   private async buildFilePartsFromAttachments(

--- a/packages/twenty-server/src/engine/metadata-modules/ai/ai-chat/services/chat-execution.service.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/ai/ai-chat/services/chat-execution.service.ts
@@ -268,12 +268,21 @@ export class ChatExecutionService {
 
     const messagesWithInlinedFiles = await inlineFilePartsAsBase64(
       processedMessages,
-      (fileId) =>
-        this.fileService.getFileContentById({
+      async (fileId) => {
+        const content = await this.fileService.getFileContentById({
           fileId,
           workspaceId: workspace.id,
           fileFolder: FileFolder.AgentChat,
-        }),
+        });
+
+        if (!isDefined(content)) {
+          this.logger.warn(
+            `Could not load AI chat attachment ${fileId} for workspace ${workspace.id}; it will be marked as unavailable in the prompt.`,
+          );
+        }
+
+        return content;
+      },
     );
 
     const rawModelMessages = await convertToModelMessages(

--- a/packages/twenty-server/src/engine/metadata-modules/ai/ai-chat/services/chat-execution.service.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/ai/ai-chat/services/chat-execution.service.ts
@@ -12,7 +12,7 @@ import {
   type UIMessage,
   type UITools,
 } from 'ai';
-import { AppPath } from 'twenty-shared/types';
+import { AppPath, FileFolder } from 'twenty-shared/types';
 import { getAppPath, isDefined } from 'twenty-shared/utils';
 
 import { MetricsService } from 'src/engine/core-modules/metrics/metrics.service';
@@ -25,6 +25,7 @@ import { type CodeExecutionStreamEmitter } from 'src/engine/core-modules/tool-pr
 import { CodeInterpreterService } from 'src/engine/core-modules/code-interpreter/code-interpreter.service';
 import { WorkspaceDomainsService } from 'src/engine/core-modules/domain/workspace-domains/services/workspace-domains.service';
 import { ExceptionHandlerService } from 'src/engine/core-modules/exception-handler/exception-handler.service';
+import { FileService } from 'src/engine/core-modules/file/services/file.service';
 import { ToolRegistryService } from 'src/engine/core-modules/tool-provider/services/tool-registry.service';
 import {
   createExecuteToolTool,
@@ -58,6 +59,7 @@ import {
   getCallLevelCacheProviderOptions,
   injectCacheBreakpoint,
 } from 'src/engine/metadata-modules/ai/ai-chat/utils/inject-cache-breakpoint.util';
+import { inlineFilePartsAsBase64 } from 'src/engine/metadata-modules/ai/ai-chat/utils/inline-file-parts-as-base64.util';
 import { AI_TELEMETRY_CONFIG } from 'src/engine/metadata-modules/ai/ai-models/constants/ai-telemetry.const';
 import { AiModelRegistryService } from 'src/engine/metadata-modules/ai/ai-models/services/ai-model-registry.service';
 import { NativeToolBinderService } from 'src/engine/metadata-modules/ai/ai-models/services/native-tool-binder.service';
@@ -100,6 +102,7 @@ export class ChatExecutionService {
     private readonly nativeToolBinder: NativeToolBinderService,
     private readonly messagePruningService: MessagePruningService,
     private readonly metricsService: MetricsService,
+    private readonly fileService: FileService,
   ) {}
 
   async streamChat({
@@ -263,7 +266,19 @@ export class ChatExecutionService {
       providerOptions: getCacheProviderOptions(registeredModel.sdkPackage),
     };
 
-    const rawModelMessages = await convertToModelMessages(processedMessages);
+    const messagesWithInlinedFiles = await inlineFilePartsAsBase64(
+      processedMessages,
+      (fileId) =>
+        this.fileService.getFileContentById({
+          fileId,
+          workspaceId: workspace.id,
+          fileFolder: FileFolder.AgentChat,
+        }),
+    );
+
+    const rawModelMessages = await convertToModelMessages(
+      messagesWithInlinedFiles,
+    );
 
     const pruningResult =
       this.messagePruningService.pruneIfOverContextWindowLimit(

--- a/packages/twenty-server/src/engine/metadata-modules/ai/ai-chat/utils/inline-file-parts-as-base64.util.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/ai/ai-chat/utils/inline-file-parts-as-base64.util.ts
@@ -28,7 +28,12 @@ export const inlineFilePartsAsBase64 = async (
           const content = await loadFileContent(part.fileId);
 
           if (!isDefined(content)) {
-            return null;
+            return {
+              type: 'text' as const,
+              text: `[Attachment${
+                part.filename ? ` "${part.filename}"` : ''
+              } could not be loaded and is unavailable.]`,
+            };
           }
 
           return {
@@ -43,7 +48,7 @@ export const inlineFilePartsAsBase64 = async (
 
       return {
         ...message,
-        parts: inlinedParts.filter(isDefined),
+        parts: inlinedParts,
       };
     }),
   );

--- a/packages/twenty-server/src/engine/metadata-modules/ai/ai-chat/utils/inline-file-parts-as-base64.util.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/ai/ai-chat/utils/inline-file-parts-as-base64.util.ts
@@ -1,0 +1,50 @@
+import { type UIMessage } from 'ai';
+import { isExtendedFileUIPart } from 'twenty-shared/ai';
+import { isDefined } from 'twenty-shared/utils';
+
+type FileContent = {
+  buffer: Buffer;
+  mimeType: string;
+};
+
+type LoadFileContent = (fileId: string) => Promise<FileContent | null>;
+
+export const inlineFilePartsAsBase64 = async (
+  messages: UIMessage[],
+  loadFileContent: LoadFileContent,
+): Promise<UIMessage[]> => {
+  return Promise.all(
+    messages.map(async (message) => {
+      const inlinedParts = await Promise.all(
+        message.parts.map(async (part) => {
+          if (!isExtendedFileUIPart(part)) {
+            return part;
+          }
+
+          if (part.url.startsWith('data:')) {
+            return part;
+          }
+
+          const content = await loadFileContent(part.fileId);
+
+          if (!isDefined(content)) {
+            return null;
+          }
+
+          return {
+            ...part,
+            mediaType: content.mimeType,
+            url: `data:${content.mimeType};base64,${content.buffer.toString(
+              'base64',
+            )}`,
+          };
+        }),
+      );
+
+      return {
+        ...message,
+        parts: inlinedParts.filter(isDefined),
+      };
+    }),
+  );
+};


### PR DESCRIPTION
## What

When you upload a file in AI chat, the prompt cache was getting busted on every turn, any thread with a file just never hit the cache.

Why: we store only the `fileId` and re-signed a fresh url each time the thread was loaded. That signed url gets handed straight to the provider, and since the token changes every turn, the cached conversation prefix changes too and the cache misses.

## Fix

Instead of giving the provider a signed URL, we download the file on our side and inline it as base64 bytes right before the model call. The bytes don't change between turns, so the cached prefix stays stable.

## Follow-ups / things considered

- **File byte cache (later if needed):** we re-download and re-encode the thread's files from storage on every turn. It's fine for now (storage reads are cheap and the provider caches the bytes after the first turn), but if it ever shows up in latency we can cache the bytes by fileId since file content is immutable. Skipped for now to keep this focused.
- **Per-provider Files API (didn't do):** the "cleanest" version is to upload each file to the provider once and reference it by their file id, so bytes never get re-sent. We didn't go this route because we support 8 providers, not all of them have a files API, they all differ, and they come with expiry/lifecycle we'd have to manage. base64 is the one representation that works the same across every provider. Worth revisiting if we ever narrow down the provider list.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/21639?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

