### PR TITLE
ci: migrate cross-repo dispatch senders to workflow_dispatch (actions:write)

### DIFF
--- a/.github/workflows/cd-deploy-main.yaml
+++ b/.github/workflows/cd-deploy-main.yaml
@@ -23,9 +23,8 @@ jobs:
           repositories: twenty-infra
           permission-actions: write
 
-      - name: Trigger twenty-infra deploys
+      - name: Trigger twenty-infra deploy
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
-          gh workflow run dev-cd.yaml --repo twentyhq/twenty-infra --ref main
-          gh workflow run deploy-website.yaml --repo twentyhq/twenty-infra --ref main
+          gh workflow run auto-deploy-main.yaml --repo twentyhq/twenty-infra --ref main

--- a/.github/workflows/cd-deploy-main.yaml
+++ b/.github/workflows/cd-deploy-main.yaml
@@ -17,8 +17,8 @@ jobs:
         id: app-token
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
-          client-id: ${{ vars.CI_BOT_PUBLIC_CLIENT_ID }}
-          private-key: ${{ secrets.CI_BOT_PUBLIC_APP_PRIVATE_KEY }}
+          client-id: ${{ vars.TWENTY_WORKFLOW_DISPATCHER_CLIENT_ID }}
+          private-key: ${{ secrets.TWENTY_WORKFLOW_DISPATCHER_PRIVATE_KEY }}
           owner: twentyhq
           repositories: twenty-infra
           permission-actions: write

--- a/.github/workflows/cd-deploy-main.yaml
+++ b/.github/workflows/cd-deploy-main.yaml
@@ -17,7 +17,7 @@ jobs:
         id: app-token
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
-          app-id: ${{ vars.CI_BOT_PUBLIC_APP_ID }}
+          client-id: ${{ vars.CI_BOT_PUBLIC_CLIENT_ID }}
           private-key: ${{ secrets.CI_BOT_PUBLIC_APP_PRIVATE_KEY }}
           owner: twentyhq
           repositories: twenty-infra

--- a/.github/workflows/cd-deploy-main.yaml
+++ b/.github/workflows/cd-deploy-main.yaml
@@ -13,9 +13,19 @@ jobs:
     timeout-minutes: 3
     runs-on: ubuntu-latest
     steps:
-      - name: Repository Dispatch
+      - name: Mint twenty-infra dispatch token
+        id: app-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          app-id: ${{ vars.CI_BOT_PUBLIC_APP_ID }}
+          private-key: ${{ secrets.CI_BOT_PUBLIC_APP_PRIVATE_KEY }}
+          owner: twentyhq
+          repositories: twenty-infra
+          permission-actions: write
+
+      - name: Trigger twenty-infra deploys
         env:
-          GH_TOKEN: ${{ secrets.TWENTY_INFRA_TOKEN }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
-          gh api repos/twentyhq/twenty-infra/dispatches \
-            -f event_type=auto-deploy-main
+          gh workflow run dev-cd.yaml --repo twentyhq/twenty-infra --ref main
+          gh workflow run deploy-website.yaml --repo twentyhq/twenty-infra --ref main

--- a/.github/workflows/cd-deploy-tag.yaml
+++ b/.github/workflows/cd-deploy-tag.yaml
@@ -7,7 +7,6 @@ on:
   push:
     tags:
       - 'twenty/v*'
-      - 'sdk/v*'
 
 defaults:
   run:
@@ -18,31 +17,19 @@ jobs:
     timeout-minutes: 3
     runs-on: ubuntu-latest
     steps:
-      - name: Resolve dispatch event from tag family
-        id: target
-        env:
-          REF_NAME: ${{ github.ref_name }}
-        run: |
-          case "$REF_NAME" in
-            twenty/v*)
-              event_type=auto-deploy-twenty
-              ;;
-            sdk/v*)
-              event_type=auto-publish-npm
-              ;;
-            *)
-              echo "Unsupported tag '$REF_NAME', expected 'twenty/v*' or 'sdk/v*'." >&2
-              exit 1
-              ;;
-          esac
-          printf 'event_type=%s\n' "$event_type" >> "$GITHUB_OUTPUT"
+      - name: Mint twenty-infra dispatch token
+        id: app-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          app-id: ${{ vars.CI_BOT_PUBLIC_APP_ID }}
+          private-key: ${{ secrets.CI_BOT_PUBLIC_APP_PRIVATE_KEY }}
+          owner: twentyhq
+          repositories: twenty-infra
+          permission-actions: write
 
-      - name: Repository Dispatch
+      - name: Trigger staging CD
         env:
-          GH_TOKEN: ${{ secrets.TWENTY_INFRA_TOKEN }}
-          EVENT_TYPE: ${{ steps.target.outputs.event_type }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
           REF_NAME: ${{ github.ref_name }}
         run: |
-          gh api repos/twentyhq/twenty-infra/dispatches \
-            -f "event_type=$EVENT_TYPE" \
-            -f "client_payload[github][ref_name]=$REF_NAME"
+          gh workflow run staging-ci.yaml --repo twentyhq/twenty-infra --ref main -f tag="$REF_NAME"

--- a/.github/workflows/cd-deploy-tag.yaml
+++ b/.github/workflows/cd-deploy-tag.yaml
@@ -21,7 +21,7 @@ jobs:
         id: app-token
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
-          app-id: ${{ vars.CI_BOT_PUBLIC_APP_ID }}
+          client-id: ${{ vars.CI_BOT_PUBLIC_CLIENT_ID }}
           private-key: ${{ secrets.CI_BOT_PUBLIC_APP_PRIVATE_KEY }}
           owner: twentyhq
           repositories: twenty-infra

--- a/.github/workflows/cd-deploy-tag.yaml
+++ b/.github/workflows/cd-deploy-tag.yaml
@@ -21,8 +21,8 @@ jobs:
         id: app-token
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
-          client-id: ${{ vars.CI_BOT_PUBLIC_CLIENT_ID }}
-          private-key: ${{ secrets.CI_BOT_PUBLIC_APP_PRIVATE_KEY }}
+          client-id: ${{ vars.TWENTY_WORKFLOW_DISPATCHER_CLIENT_ID }}
+          private-key: ${{ secrets.TWENTY_WORKFLOW_DISPATCHER_PRIVATE_KEY }}
           owner: twentyhq
           repositories: twenty-infra
           permission-actions: write

--- a/.github/workflows/ci-ai-catalog-sync.yaml
+++ b/.github/workflows/ci-ai-catalog-sync.yaml
@@ -59,9 +59,20 @@ jobs:
           labels: ai, automated
           delete-branch: true
 
+      - name: Mint twenty-infra dispatch token
+        id: app-token
+        if: steps.changes.outputs.changed == 'true'
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          app-id: ${{ vars.CI_BOT_PUBLIC_APP_ID }}
+          private-key: ${{ secrets.CI_BOT_PUBLIC_APP_PRIVATE_KEY }}
+          owner: twentyhq
+          repositories: twenty-infra
+          permission-actions: write
+
       - name: Trigger automerge
         if: steps.changes.outputs.changed == 'true'
         env:
-          GH_TOKEN: ${{ secrets.TWENTY_INFRA_TOKEN }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
-          gh api repos/twentyhq/twenty-infra/dispatches -f event_type=automated-pr-ready
+          gh workflow run automerge-i18n.yaml --repo twentyhq/twenty-infra --ref main

--- a/.github/workflows/ci-ai-catalog-sync.yaml
+++ b/.github/workflows/ci-ai-catalog-sync.yaml
@@ -64,8 +64,8 @@ jobs:
         if: steps.changes.outputs.changed == 'true'
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
-          client-id: ${{ vars.CI_BOT_PUBLIC_CLIENT_ID }}
-          private-key: ${{ secrets.CI_BOT_PUBLIC_APP_PRIVATE_KEY }}
+          client-id: ${{ vars.TWENTY_WORKFLOW_DISPATCHER_CLIENT_ID }}
+          private-key: ${{ secrets.TWENTY_WORKFLOW_DISPATCHER_PRIVATE_KEY }}
           owner: twentyhq
           repositories: twenty-infra
           permission-actions: write

--- a/.github/workflows/ci-ai-catalog-sync.yaml
+++ b/.github/workflows/ci-ai-catalog-sync.yaml
@@ -64,7 +64,7 @@ jobs:
         if: steps.changes.outputs.changed == 'true'
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
-          app-id: ${{ vars.CI_BOT_PUBLIC_APP_ID }}
+          client-id: ${{ vars.CI_BOT_PUBLIC_CLIENT_ID }}
           private-key: ${{ secrets.CI_BOT_PUBLIC_APP_PRIVATE_KEY }}
           owner: twentyhq
           repositories: twenty-infra

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -188,7 +188,7 @@ jobs:
         if: always()
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
-          app-id: ${{ vars.CI_BOT_PUBLIC_APP_ID }}
+          client-id: ${{ vars.CI_BOT_PUBLIC_CLIENT_ID }}
           private-key: ${{ secrets.CI_BOT_PUBLIC_APP_PRIVATE_KEY }}
           owner: twentyhq
           repositories: ci-privileged

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -183,18 +183,26 @@ jobs:
                 "PG_DATABASE_URL": "postgres://postgres:postgres@localhost:5432/default"
               }
             }
+      - name: Mint ci-privileged dispatch token
+        id: app-token
+        if: always()
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          app-id: ${{ vars.CI_BOT_PUBLIC_APP_ID }}
+          private-key: ${{ secrets.CI_BOT_PUBLIC_APP_PRIVATE_KEY }}
+          owner: twentyhq
+          repositories: ci-privileged
+          permission-actions: write
+
       - name: Dispatch response to ci-privileged
         if: always()
         env:
-          GH_TOKEN: ${{ secrets.CI_PRIVILEGED_DISPATCH_TOKEN }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
           REPO: ${{ steps.prompt.outputs.repo }}
           ISSUE_NUMBER: ${{ steps.prompt.outputs.issue_number }}
-          RUN_ID: ${{ github.run_id }}
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
         run: |
-          gh api repos/twentyhq/ci-privileged/dispatches \
-            -f event_type=claude-cross-repo-response \
-            -f "client_payload[repo]=$REPO" \
-            -f "client_payload[issue_number]=$ISSUE_NUMBER" \
-            -f "client_payload[run_id]=$RUN_ID" \
-            -f "client_payload[run_url]=$RUN_URL"
+          gh workflow run post-claude-response.yaml --repo twentyhq/ci-privileged --ref main \
+            -f repo="$REPO" \
+            -f issue_number="$ISSUE_NUMBER" \
+            -f run_url="$RUN_URL"

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -188,8 +188,8 @@ jobs:
         if: always()
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
-          client-id: ${{ vars.CI_BOT_PUBLIC_CLIENT_ID }}
-          private-key: ${{ secrets.CI_BOT_PUBLIC_APP_PRIVATE_KEY }}
+          client-id: ${{ vars.TWENTY_WORKFLOW_DISPATCHER_CLIENT_ID }}
+          private-key: ${{ secrets.TWENTY_WORKFLOW_DISPATCHER_PRIVATE_KEY }}
           owner: twentyhq
           repositories: ci-privileged
           permission-actions: write

--- a/.github/workflows/docs-i18n-pull.yaml
+++ b/.github/workflows/docs-i18n-pull.yaml
@@ -151,9 +151,20 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Mint twenty-infra dispatch token
+        id: app-token
+        if: github.event_name != 'pull_request' && steps.check_changes.outputs.changes_detected == 'true'
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          app-id: ${{ vars.CI_BOT_PUBLIC_APP_ID }}
+          private-key: ${{ secrets.CI_BOT_PUBLIC_APP_PRIVATE_KEY }}
+          owner: twentyhq
+          repositories: twenty-infra
+          permission-actions: write
+
       - name: Trigger i18n automerge
         if: github.event_name != 'pull_request' && steps.check_changes.outputs.changes_detected == 'true'
         env:
-          GH_TOKEN: ${{ secrets.TWENTY_INFRA_TOKEN }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
-          gh api repos/twentyhq/twenty-infra/dispatches -f event_type=i18n-pr-ready
+          gh workflow run automerge-i18n.yaml --repo twentyhq/twenty-infra --ref main

--- a/.github/workflows/docs-i18n-pull.yaml
+++ b/.github/workflows/docs-i18n-pull.yaml
@@ -156,7 +156,7 @@ jobs:
         if: github.event_name != 'pull_request' && steps.check_changes.outputs.changes_detected == 'true'
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
-          app-id: ${{ vars.CI_BOT_PUBLIC_APP_ID }}
+          client-id: ${{ vars.CI_BOT_PUBLIC_CLIENT_ID }}
           private-key: ${{ secrets.CI_BOT_PUBLIC_APP_PRIVATE_KEY }}
           owner: twentyhq
           repositories: twenty-infra

--- a/.github/workflows/docs-i18n-pull.yaml
+++ b/.github/workflows/docs-i18n-pull.yaml
@@ -156,8 +156,8 @@ jobs:
         if: github.event_name != 'pull_request' && steps.check_changes.outputs.changes_detected == 'true'
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
-          client-id: ${{ vars.CI_BOT_PUBLIC_CLIENT_ID }}
-          private-key: ${{ secrets.CI_BOT_PUBLIC_APP_PRIVATE_KEY }}
+          client-id: ${{ vars.TWENTY_WORKFLOW_DISPATCHER_CLIENT_ID }}
+          private-key: ${{ secrets.TWENTY_WORKFLOW_DISPATCHER_PRIVATE_KEY }}
           owner: twentyhq
           repositories: twenty-infra
           permission-actions: write

--- a/.github/workflows/external-contributor-pr-auto-draft.yaml
+++ b/.github/workflows/external-contributor-pr-auto-draft.yaml
@@ -16,13 +16,20 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
+      - name: Mint ci-privileged dispatch token
+        id: app-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          app-id: ${{ vars.CI_BOT_PUBLIC_APP_ID }}
+          private-key: ${{ secrets.CI_BOT_PUBLIC_APP_PRIVATE_KEY }}
+          owner: twentyhq
+          repositories: ci-privileged
+          permission-actions: write
+
       - name: Dispatch to ci-privileged
         env:
-          GH_TOKEN: ${{ secrets.CI_PRIVILEGED_DISPATCH_TOKEN }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
-          PR_NODE_ID: ${{ github.event.pull_request.node_id }}
         run: |
-          gh api repos/twentyhq/ci-privileged/dispatches \
-            -f event_type=convert-pr-to-draft \
-            -f "client_payload[pr_number]=$PR_NUMBER" \
-            -f "client_payload[pr_node_id]=$PR_NODE_ID"
+          gh workflow run convert-pr-to-draft.yaml --repo twentyhq/ci-privileged --ref main \
+            -f pr_number="$PR_NUMBER"

--- a/.github/workflows/external-contributor-pr-auto-draft.yaml
+++ b/.github/workflows/external-contributor-pr-auto-draft.yaml
@@ -20,8 +20,8 @@ jobs:
         id: app-token
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
-          client-id: ${{ vars.CI_BOT_PUBLIC_CLIENT_ID }}
-          private-key: ${{ secrets.CI_BOT_PUBLIC_APP_PRIVATE_KEY }}
+          client-id: ${{ vars.TWENTY_WORKFLOW_DISPATCHER_CLIENT_ID }}
+          private-key: ${{ secrets.TWENTY_WORKFLOW_DISPATCHER_PRIVATE_KEY }}
           owner: twentyhq
           repositories: ci-privileged
           permission-actions: write

--- a/.github/workflows/external-contributor-pr-auto-draft.yaml
+++ b/.github/workflows/external-contributor-pr-auto-draft.yaml
@@ -20,7 +20,7 @@ jobs:
         id: app-token
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
-          app-id: ${{ vars.CI_BOT_PUBLIC_APP_ID }}
+          client-id: ${{ vars.CI_BOT_PUBLIC_CLIENT_ID }}
           private-key: ${{ secrets.CI_BOT_PUBLIC_APP_PRIVATE_KEY }}
           owner: twentyhq
           repositories: ci-privileged

--- a/.github/workflows/i18n-pull.yaml
+++ b/.github/workflows/i18n-pull.yaml
@@ -142,8 +142,8 @@ jobs:
         if: steps.compile_translations.outputs.changes_detected == 'true'
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
-          client-id: ${{ vars.CI_BOT_PUBLIC_CLIENT_ID }}
-          private-key: ${{ secrets.CI_BOT_PUBLIC_APP_PRIVATE_KEY }}
+          client-id: ${{ vars.TWENTY_WORKFLOW_DISPATCHER_CLIENT_ID }}
+          private-key: ${{ secrets.TWENTY_WORKFLOW_DISPATCHER_PRIVATE_KEY }}
           owner: twentyhq
           repositories: twenty-infra
           permission-actions: write

--- a/.github/workflows/i18n-pull.yaml
+++ b/.github/workflows/i18n-pull.yaml
@@ -137,9 +137,20 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Mint twenty-infra dispatch token
+        id: app-token
+        if: steps.compile_translations.outputs.changes_detected == 'true'
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          app-id: ${{ vars.CI_BOT_PUBLIC_APP_ID }}
+          private-key: ${{ secrets.CI_BOT_PUBLIC_APP_PRIVATE_KEY }}
+          owner: twentyhq
+          repositories: twenty-infra
+          permission-actions: write
+
       - name: Trigger i18n automerge
         if: steps.compile_translations.outputs.changes_detected == 'true'
         env:
-          GH_TOKEN: ${{ secrets.TWENTY_INFRA_TOKEN }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
-          gh api repos/twentyhq/twenty-infra/dispatches -f event_type=i18n-pr-ready
+          gh workflow run automerge-i18n.yaml --repo twentyhq/twenty-infra --ref main

--- a/.github/workflows/i18n-pull.yaml
+++ b/.github/workflows/i18n-pull.yaml
@@ -142,7 +142,7 @@ jobs:
         if: steps.compile_translations.outputs.changes_detected == 'true'
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
-          app-id: ${{ vars.CI_BOT_PUBLIC_APP_ID }}
+          client-id: ${{ vars.CI_BOT_PUBLIC_CLIENT_ID }}
           private-key: ${{ secrets.CI_BOT_PUBLIC_APP_PRIVATE_KEY }}
           owner: twentyhq
           repositories: twenty-infra

--- a/.github/workflows/i18n-push.yaml
+++ b/.github/workflows/i18n-push.yaml
@@ -108,8 +108,8 @@ jobs:
         if: steps.check_extract_changes.outputs.changes_detected == 'true' || steps.check_compile_changes.outputs.changes_detected == 'true'
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
-          client-id: ${{ vars.CI_BOT_PUBLIC_CLIENT_ID }}
-          private-key: ${{ secrets.CI_BOT_PUBLIC_APP_PRIVATE_KEY }}
+          client-id: ${{ vars.TWENTY_WORKFLOW_DISPATCHER_CLIENT_ID }}
+          private-key: ${{ secrets.TWENTY_WORKFLOW_DISPATCHER_PRIVATE_KEY }}
           owner: twentyhq
           repositories: twenty-infra
           permission-actions: write

--- a/.github/workflows/i18n-push.yaml
+++ b/.github/workflows/i18n-push.yaml
@@ -108,7 +108,7 @@ jobs:
         if: steps.check_extract_changes.outputs.changes_detected == 'true' || steps.check_compile_changes.outputs.changes_detected == 'true'
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
-          app-id: ${{ vars.CI_BOT_PUBLIC_APP_ID }}
+          client-id: ${{ vars.CI_BOT_PUBLIC_CLIENT_ID }}
           private-key: ${{ secrets.CI_BOT_PUBLIC_APP_PRIVATE_KEY }}
           owner: twentyhq
           repositories: twenty-infra

--- a/.github/workflows/i18n-push.yaml
+++ b/.github/workflows/i18n-push.yaml
@@ -103,9 +103,20 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Mint twenty-infra dispatch token
+        id: app-token
+        if: steps.check_extract_changes.outputs.changes_detected == 'true' || steps.check_compile_changes.outputs.changes_detected == 'true'
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          app-id: ${{ vars.CI_BOT_PUBLIC_APP_ID }}
+          private-key: ${{ secrets.CI_BOT_PUBLIC_APP_PRIVATE_KEY }}
+          owner: twentyhq
+          repositories: twenty-infra
+          permission-actions: write
+
       - name: Trigger i18n automerge
         if: steps.check_extract_changes.outputs.changes_detected == 'true' || steps.check_compile_changes.outputs.changes_detected == 'true'
         env:
-          GH_TOKEN: ${{ secrets.TWENTY_INFRA_TOKEN }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
-          gh api repos/twentyhq/twenty-infra/dispatches -f event_type=i18n-pr-ready
+          gh workflow run automerge-i18n.yaml --repo twentyhq/twenty-infra --ref main

--- a/.github/workflows/post-ci-comments.yaml
+++ b/.github/workflows/post-ci-comments.yaml
@@ -66,8 +66,8 @@ jobs:
         if: steps.pr-info.outputs.has_pr == 'true'
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
-          client-id: ${{ vars.CI_BOT_PUBLIC_CLIENT_ID }}
-          private-key: ${{ secrets.CI_BOT_PUBLIC_APP_PRIVATE_KEY }}
+          client-id: ${{ vars.TWENTY_WORKFLOW_DISPATCHER_CLIENT_ID }}
+          private-key: ${{ secrets.TWENTY_WORKFLOW_DISPATCHER_PRIVATE_KEY }}
           owner: twentyhq
           repositories: ci-privileged
           permission-actions: write

--- a/.github/workflows/post-ci-comments.yaml
+++ b/.github/workflows/post-ci-comments.yaml
@@ -66,7 +66,7 @@ jobs:
         if: steps.pr-info.outputs.has_pr == 'true'
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
-          app-id: ${{ vars.CI_BOT_PUBLIC_APP_ID }}
+          client-id: ${{ vars.CI_BOT_PUBLIC_CLIENT_ID }}
           private-key: ${{ secrets.CI_BOT_PUBLIC_APP_PRIVATE_KEY }}
           owner: twentyhq
           repositories: ci-privileged

--- a/.github/workflows/post-ci-comments.yaml
+++ b/.github/workflows/post-ci-comments.yaml
@@ -61,18 +61,28 @@ jobs:
             core.setOutput('has_pr', 'true');
             core.info(`PR #${prNumber}, Run ID: ${runId}`);
 
+      - name: Mint ci-privileged dispatch token
+        id: app-token
+        if: steps.pr-info.outputs.has_pr == 'true'
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          app-id: ${{ vars.CI_BOT_PUBLIC_APP_ID }}
+          private-key: ${{ secrets.CI_BOT_PUBLIC_APP_PRIVATE_KEY }}
+          owner: twentyhq
+          repositories: ci-privileged
+          permission-actions: write
+
       - name: Dispatch to ci-privileged
         if: steps.pr-info.outputs.has_pr == 'true'
         env:
-          GH_TOKEN: ${{ secrets.CI_PRIVILEGED_DISPATCH_TOKEN }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
           PR_NUMBER: ${{ steps.pr-info.outputs.pr_number }}
           RUN_ID: ${{ steps.pr-info.outputs.run_id }}
           REPOSITORY: ${{ github.repository }}
           BRANCH_STATE: ${{ github.event.workflow_run.head_branch }}
         run: |
-          gh api repos/twentyhq/ci-privileged/dispatches \
-            -f event_type=breaking-changes-report \
-            -f "client_payload[pr_number]=$PR_NUMBER" \
-            -f "client_payload[run_id]=$RUN_ID" \
-            -f "client_payload[repo]=$REPOSITORY" \
-            -f "client_payload[branch_state]=$BRANCH_STATE"
+          gh workflow run post-breaking-changes-comment.yaml --repo twentyhq/ci-privileged --ref main \
+            -f pr_number="$PR_NUMBER" \
+            -f run_id="$RUN_ID" \
+            -f repo="$REPOSITORY" \
+            -f branch_state="$BRANCH_STATE"

--- a/.github/workflows/pr-auto-review-dispatch.yaml
+++ b/.github/workflows/pr-auto-review-dispatch.yaml
@@ -16,11 +16,20 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
+      - name: Mint ci-privileged dispatch token
+        id: app-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          app-id: ${{ vars.CI_BOT_PUBLIC_APP_ID }}
+          private-key: ${{ secrets.CI_BOT_PUBLIC_APP_PRIVATE_KEY }}
+          owner: twentyhq
+          repositories: ci-privileged
+          permission-actions: write
+
       - name: Dispatch to ci-privileged
         env:
-          GH_TOKEN: ${{ secrets.CI_PRIVILEGED_DISPATCH_TOKEN }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
         run: |
-          gh api repos/twentyhq/ci-privileged/dispatches \
-            -f event_type=pr-review \
-            -f "client_payload[pr_number]=$PR_NUMBER"
+          gh workflow run pr-review.yaml --repo twentyhq/ci-privileged --ref main \
+            -f pr_number="$PR_NUMBER"

--- a/.github/workflows/pr-auto-review-dispatch.yaml
+++ b/.github/workflows/pr-auto-review-dispatch.yaml
@@ -20,8 +20,8 @@ jobs:
         id: app-token
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
-          client-id: ${{ vars.CI_BOT_PUBLIC_CLIENT_ID }}
-          private-key: ${{ secrets.CI_BOT_PUBLIC_APP_PRIVATE_KEY }}
+          client-id: ${{ vars.TWENTY_WORKFLOW_DISPATCHER_CLIENT_ID }}
+          private-key: ${{ secrets.TWENTY_WORKFLOW_DISPATCHER_PRIVATE_KEY }}
           owner: twentyhq
           repositories: ci-privileged
           permission-actions: write

--- a/.github/workflows/pr-auto-review-dispatch.yaml
+++ b/.github/workflows/pr-auto-review-dispatch.yaml
@@ -20,7 +20,7 @@ jobs:
         id: app-token
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
-          app-id: ${{ vars.CI_BOT_PUBLIC_APP_ID }}
+          client-id: ${{ vars.CI_BOT_PUBLIC_CLIENT_ID }}
           private-key: ${{ secrets.CI_BOT_PUBLIC_APP_PRIVATE_KEY }}
           owner: twentyhq
           repositories: ci-privileged

--- a/.github/workflows/preview-env-dispatch.yaml
+++ b/.github/workflows/preview-env-dispatch.yaml
@@ -37,8 +37,8 @@ jobs:
         id: app-token
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
-          client-id: ${{ vars.CI_BOT_PUBLIC_CLIENT_ID }}
-          private-key: ${{ secrets.CI_BOT_PUBLIC_APP_PRIVATE_KEY }}
+          client-id: ${{ vars.TWENTY_WORKFLOW_DISPATCHER_CLIENT_ID }}
+          private-key: ${{ secrets.TWENTY_WORKFLOW_DISPATCHER_PRIVATE_KEY }}
           owner: twentyhq
           repositories: ci-privileged
           permission-actions: write

--- a/.github/workflows/preview-env-dispatch.yaml
+++ b/.github/workflows/preview-env-dispatch.yaml
@@ -37,7 +37,7 @@ jobs:
         id: app-token
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
-          app-id: ${{ vars.CI_BOT_PUBLIC_APP_ID }}
+          client-id: ${{ vars.CI_BOT_PUBLIC_CLIENT_ID }}
           private-key: ${{ secrets.CI_BOT_PUBLIC_APP_PRIVATE_KEY }}
           owner: twentyhq
           repositories: ci-privileged

--- a/.github/workflows/preview-env-dispatch.yaml
+++ b/.github/workflows/preview-env-dispatch.yaml
@@ -33,15 +33,24 @@ jobs:
     timeout-minutes: 5
     runs-on: ubuntu-latest
     steps:
+      - name: Mint ci-privileged dispatch token
+        id: app-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          app-id: ${{ vars.CI_BOT_PUBLIC_APP_ID }}
+          private-key: ${{ secrets.CI_BOT_PUBLIC_APP_PRIVATE_KEY }}
+          owner: twentyhq
+          repositories: ci-privileged
+          permission-actions: write
+
       - name: Dispatch preview-env to ci-privileged
         env:
-          GH_TOKEN: ${{ secrets.CI_PRIVILEGED_DISPATCH_TOKEN }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
           PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
           REPOSITORY: ${{ github.repository }}
         run: |
-          gh api repos/twentyhq/ci-privileged/dispatches \
-            -f event_type=preview-environment \
-            -f "client_payload[pr_number]=$PR_NUMBER" \
-            -f "client_payload[pr_head_sha]=$PR_HEAD_SHA" \
-            -f "client_payload[repo]=$REPOSITORY"
+          gh workflow run preview-env.yaml --repo twentyhq/ci-privileged --ref main \
+            -f pr_number="$PR_NUMBER" \
+            -f pr_head_sha="$PR_HEAD_SHA" \
+            -f repo="$REPOSITORY"

--- a/.github/workflows/visual-regression-dispatch.yaml
+++ b/.github/workflows/visual-regression-dispatch.yaml
@@ -152,8 +152,8 @@ jobs:
         id: app-token
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
-          client-id: ${{ vars.CI_BOT_PUBLIC_CLIENT_ID }}
-          private-key: ${{ secrets.CI_BOT_PUBLIC_APP_PRIVATE_KEY }}
+          client-id: ${{ vars.TWENTY_WORKFLOW_DISPATCHER_CLIENT_ID }}
+          private-key: ${{ secrets.TWENTY_WORKFLOW_DISPATCHER_PRIVATE_KEY }}
           owner: twentyhq
           repositories: ci-privileged
           permission-actions: write
@@ -203,8 +203,8 @@ jobs:
         id: app-token
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
-          client-id: ${{ vars.CI_BOT_PUBLIC_CLIENT_ID }}
-          private-key: ${{ secrets.CI_BOT_PUBLIC_APP_PRIVATE_KEY }}
+          client-id: ${{ vars.TWENTY_WORKFLOW_DISPATCHER_CLIENT_ID }}
+          private-key: ${{ secrets.TWENTY_WORKFLOW_DISPATCHER_PRIVATE_KEY }}
           owner: twentyhq
           repositories: ci-privileged
           permission-actions: write
@@ -241,8 +241,8 @@ jobs:
         id: app-token
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
-          client-id: ${{ vars.CI_BOT_PUBLIC_CLIENT_ID }}
-          private-key: ${{ secrets.CI_BOT_PUBLIC_APP_PRIVATE_KEY }}
+          client-id: ${{ vars.TWENTY_WORKFLOW_DISPATCHER_CLIENT_ID }}
+          private-key: ${{ secrets.TWENTY_WORKFLOW_DISPATCHER_PRIVATE_KEY }}
           owner: twentyhq
           repositories: ci-privileged
           permission-actions: write

--- a/.github/workflows/visual-regression-dispatch.yaml
+++ b/.github/workflows/visual-regression-dispatch.yaml
@@ -4,8 +4,9 @@ name: Visual Regression Dispatch
 # Runs in the context of the base repo (not the fork) so it has access to secrets,
 # making it work for external contributor PRs.
 #
-# All dispatches use the same event_type=visual-regression with project/artifact_name
-# in the payload. ci-privileged routes to the correct Argos project based on these.
+# All paths trigger the same ci-privileged workflow (post-visual-regression-comment.yaml)
+# via workflow_dispatch, passing the project as an input. ci-privileged routes to the
+# correct Argos project based on it.
 
 on:
   workflow_run:
@@ -147,9 +148,19 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
+      - name: Mint ci-privileged dispatch token
+        id: app-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          app-id: ${{ vars.CI_BOT_PUBLIC_APP_ID }}
+          private-key: ${{ secrets.CI_BOT_PUBLIC_APP_PRIVATE_KEY }}
+          owner: twentyhq
+          repositories: ci-privileged
+          permission-actions: write
+
       - name: Dispatch to ci-privileged
         env:
-          GH_TOKEN: ${{ secrets.CI_PRIVILEGED_DISPATCH_TOKEN }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
           PROJECT: ${{ needs.resolve-context.outputs.project }}
           PR_NUMBER: ${{ needs.resolve-context.outputs.pr_number }}
           WORKFLOW_RUN_ID: ${{ github.event.workflow_run.id }}
@@ -160,24 +171,22 @@ jobs:
           ARTIFACT_NAME: ${{ needs.resolve-context.outputs.artifact_name }}
         run: |
           ARGS=(
-            --method POST
-            -f event_type=visual-regression
-            -f "client_payload[project]=$PROJECT"
-            -f "client_payload[artifact_name]=$ARTIFACT_NAME"
-            -f "client_payload[run_id]=$WORKFLOW_RUN_ID"
-            -f "client_payload[repo]=$REPOSITORY"
-            -f "client_payload[branch]=$BRANCH"
-            -f "client_payload[commit]=$COMMIT"
+            -f project="$PROJECT"
+            -f artifact_name="$ARTIFACT_NAME"
+            -f run_id="$WORKFLOW_RUN_ID"
+            -f repo="$REPOSITORY"
+            -f branch="$BRANCH"
+            -f commit="$COMMIT"
           )
 
           if [ -n "$PR_NUMBER" ]; then
-            ARGS+=(-f "client_payload[pr_number]=$PR_NUMBER")
+            ARGS+=(-f pr_number="$PR_NUMBER")
           fi
           if [ -n "$REFERENCE_COMMIT" ]; then
-            ARGS+=(-f "client_payload[reference_commit]=$REFERENCE_COMMIT")
+            ARGS+=(-f reference_commit="$REFERENCE_COMMIT")
           fi
 
-          gh api repos/twentyhq/ci-privileged/dispatches "${ARGS[@]}"
+          gh workflow run post-visual-regression-comment.yaml --repo twentyhq/ci-privileged --ref main "${ARGS[@]}"
 
   # ── Dispatch: cross-comparison baseline (CI UI on main → twenty-ui-vs-new-ui) ──
   dispatch-comparison-baseline:
@@ -190,24 +199,32 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
+      - name: Mint ci-privileged dispatch token
+        id: app-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          app-id: ${{ vars.CI_BOT_PUBLIC_APP_ID }}
+          private-key: ${{ secrets.CI_BOT_PUBLIC_APP_PRIVATE_KEY }}
+          owner: twentyhq
+          repositories: ci-privileged
+          permission-actions: write
+
       - name: Dispatch to ci-privileged (comparison baseline)
         env:
-          GH_TOKEN: ${{ secrets.CI_PRIVILEGED_DISPATCH_TOKEN }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
           WORKFLOW_RUN_ID: ${{ github.event.workflow_run.id }}
           REPOSITORY: ${{ github.repository }}
           BRANCH: ${{ github.event.workflow_run.head_branch }}
           COMMIT: ${{ github.event.workflow_run.head_sha }}
           ARTIFACT_NAME: ${{ needs.resolve-context.outputs.artifact_name }}
         run: |
-          gh api repos/twentyhq/ci-privileged/dispatches \
-            --method POST \
-            -f event_type=visual-regression \
-            -f "client_payload[project]=twenty-ui-vs-new-ui" \
-            -f "client_payload[artifact_name]=$ARTIFACT_NAME" \
-            -f "client_payload[run_id]=$WORKFLOW_RUN_ID" \
-            -f "client_payload[repo]=$REPOSITORY" \
-            -f "client_payload[branch]=$BRANCH" \
-            -f "client_payload[commit]=$COMMIT"
+          gh workflow run post-visual-regression-comment.yaml --repo twentyhq/ci-privileged --ref main \
+            -f project="twenty-ui-vs-new-ui" \
+            -f artifact_name="$ARTIFACT_NAME" \
+            -f run_id="$WORKFLOW_RUN_ID" \
+            -f repo="$REPOSITORY" \
+            -f branch="$BRANCH" \
+            -f commit="$COMMIT"
 
   # ── Dispatch: cross-comparison PR (CI New UI on PRs → twenty-ui-vs-new-ui) ──
   dispatch-comparison-pr:
@@ -220,9 +237,19 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
+      - name: Mint ci-privileged dispatch token
+        id: app-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          app-id: ${{ vars.CI_BOT_PUBLIC_APP_ID }}
+          private-key: ${{ secrets.CI_BOT_PUBLIC_APP_PRIVATE_KEY }}
+          owner: twentyhq
+          repositories: ci-privileged
+          permission-actions: write
+
       - name: Dispatch to ci-privileged (comparison PR)
         env:
-          GH_TOKEN: ${{ secrets.CI_PRIVILEGED_DISPATCH_TOKEN }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
           WORKFLOW_RUN_ID: ${{ github.event.workflow_run.id }}
           REPOSITORY: ${{ github.repository }}
           BRANCH: ${{ github.event.workflow_run.head_branch }}
@@ -232,19 +259,17 @@ jobs:
           ARTIFACT_NAME: ${{ needs.resolve-context.outputs.artifact_name }}
         run: |
           ARGS=(
-            --method POST
-            -f event_type=visual-regression
-            -f "client_payload[project]=twenty-ui-vs-new-ui"
-            -f "client_payload[artifact_name]=$ARTIFACT_NAME"
-            -f "client_payload[run_id]=$WORKFLOW_RUN_ID"
-            -f "client_payload[repo]=$REPOSITORY"
-            -f "client_payload[branch]=$BRANCH"
-            -f "client_payload[commit]=$COMMIT"
-            -f "client_payload[pr_number]=$PR_NUMBER"
+            -f project="twenty-ui-vs-new-ui"
+            -f artifact_name="$ARTIFACT_NAME"
+            -f run_id="$WORKFLOW_RUN_ID"
+            -f repo="$REPOSITORY"
+            -f branch="$BRANCH"
+            -f commit="$COMMIT"
+            -f pr_number="$PR_NUMBER"
           )
 
           if [ -n "$REFERENCE_COMMIT" ]; then
-            ARGS+=(-f "client_payload[reference_commit]=$REFERENCE_COMMIT")
+            ARGS+=(-f reference_commit="$REFERENCE_COMMIT")
           fi
 
-          gh api repos/twentyhq/ci-privileged/dispatches "${ARGS[@]}"
+          gh workflow run post-visual-regression-comment.yaml --repo twentyhq/ci-privileged --ref main "${ARGS[@]}"

--- a/.github/workflows/visual-regression-dispatch.yaml
+++ b/.github/workflows/visual-regression-dispatch.yaml
@@ -152,7 +152,7 @@ jobs:
         id: app-token
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
-          app-id: ${{ vars.CI_BOT_PUBLIC_APP_ID }}
+          client-id: ${{ vars.CI_BOT_PUBLIC_CLIENT_ID }}
           private-key: ${{ secrets.CI_BOT_PUBLIC_APP_PRIVATE_KEY }}
           owner: twentyhq
           repositories: ci-privileged
@@ -203,7 +203,7 @@ jobs:
         id: app-token
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
-          app-id: ${{ vars.CI_BOT_PUBLIC_APP_ID }}
+          client-id: ${{ vars.CI_BOT_PUBLIC_CLIENT_ID }}
           private-key: ${{ secrets.CI_BOT_PUBLIC_APP_PRIVATE_KEY }}
           owner: twentyhq
           repositories: ci-privileged
@@ -241,7 +241,7 @@ jobs:
         id: app-token
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
-          app-id: ${{ vars.CI_BOT_PUBLIC_APP_ID }}
+          client-id: ${{ vars.CI_BOT_PUBLIC_CLIENT_ID }}
           private-key: ${{ secrets.CI_BOT_PUBLIC_APP_PRIVATE_KEY }}
           owner: twentyhq
           repositories: ci-privileged

--- a/.github/workflows/website-i18n-pull.yaml
+++ b/.github/workflows/website-i18n-pull.yaml
@@ -131,8 +131,8 @@ jobs:
         if: steps.compile_translations.outputs.changes_detected == 'true'
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
-          client-id: ${{ vars.CI_BOT_PUBLIC_CLIENT_ID }}
-          private-key: ${{ secrets.CI_BOT_PUBLIC_APP_PRIVATE_KEY }}
+          client-id: ${{ vars.TWENTY_WORKFLOW_DISPATCHER_CLIENT_ID }}
+          private-key: ${{ secrets.TWENTY_WORKFLOW_DISPATCHER_PRIVATE_KEY }}
           owner: twentyhq
           repositories: twenty-infra
           permission-actions: write

--- a/.github/workflows/website-i18n-pull.yaml
+++ b/.github/workflows/website-i18n-pull.yaml
@@ -126,9 +126,20 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Mint twenty-infra dispatch token
+        id: app-token
+        if: steps.compile_translations.outputs.changes_detected == 'true'
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          app-id: ${{ vars.CI_BOT_PUBLIC_APP_ID }}
+          private-key: ${{ secrets.CI_BOT_PUBLIC_APP_PRIVATE_KEY }}
+          owner: twentyhq
+          repositories: twenty-infra
+          permission-actions: write
+
       - name: Trigger i18n automerge
         if: steps.compile_translations.outputs.changes_detected == 'true'
         env:
-          GH_TOKEN: ${{ secrets.TWENTY_INFRA_TOKEN }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
-          gh api repos/twentyhq/twenty-infra/dispatches -f event_type=i18n-pr-ready
+          gh workflow run automerge-i18n.yaml --repo twentyhq/twenty-infra --ref main

--- a/.github/workflows/website-i18n-pull.yaml
+++ b/.github/workflows/website-i18n-pull.yaml
@@ -131,7 +131,7 @@ jobs:
         if: steps.compile_translations.outputs.changes_detected == 'true'
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
-          app-id: ${{ vars.CI_BOT_PUBLIC_APP_ID }}
+          client-id: ${{ vars.CI_BOT_PUBLIC_CLIENT_ID }}
           private-key: ${{ secrets.CI_BOT_PUBLIC_APP_PRIVATE_KEY }}
           owner: twentyhq
           repositories: twenty-infra

--- a/.github/workflows/website-i18n-push.yaml
+++ b/.github/workflows/website-i18n-push.yaml
@@ -102,9 +102,20 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Mint twenty-infra dispatch token
+        id: app-token
+        if: steps.check_extract_changes.outputs.changes_detected == 'true' || steps.check_compile_changes.outputs.changes_detected == 'true'
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          app-id: ${{ vars.CI_BOT_PUBLIC_APP_ID }}
+          private-key: ${{ secrets.CI_BOT_PUBLIC_APP_PRIVATE_KEY }}
+          owner: twentyhq
+          repositories: twenty-infra
+          permission-actions: write
+
       - name: Trigger i18n automerge
         if: steps.check_extract_changes.outputs.changes_detected == 'true' || steps.check_compile_changes.outputs.changes_detected == 'true'
         env:
-          GH_TOKEN: ${{ secrets.TWENTY_INFRA_TOKEN }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
-          gh api repos/twentyhq/twenty-infra/dispatches -f event_type=i18n-pr-ready
+          gh workflow run automerge-i18n.yaml --repo twentyhq/twenty-infra --ref main

--- a/.github/workflows/website-i18n-push.yaml
+++ b/.github/workflows/website-i18n-push.yaml
@@ -107,8 +107,8 @@ jobs:
         if: steps.check_extract_changes.outputs.changes_detected == 'true' || steps.check_compile_changes.outputs.changes_detected == 'true'
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
-          client-id: ${{ vars.CI_BOT_PUBLIC_CLIENT_ID }}
-          private-key: ${{ secrets.CI_BOT_PUBLIC_APP_PRIVATE_KEY }}
+          client-id: ${{ vars.TWENTY_WORKFLOW_DISPATCHER_CLIENT_ID }}
+          private-key: ${{ secrets.TWENTY_WORKFLOW_DISPATCHER_PRIVATE_KEY }}
           owner: twentyhq
           repositories: twenty-infra
           permission-actions: write

--- a/.github/workflows/website-i18n-push.yaml
+++ b/.github/workflows/website-i18n-push.yaml
@@ -107,7 +107,7 @@ jobs:
         if: steps.check_extract_changes.outputs.changes_detected == 'true' || steps.check_compile_changes.outputs.changes_detected == 'true'
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
-          app-id: ${{ vars.CI_BOT_PUBLIC_APP_ID }}
+          client-id: ${{ vars.CI_BOT_PUBLIC_CLIENT_ID }}
           private-key: ${{ secrets.CI_BOT_PUBLIC_APP_PRIVATE_KEY }}
           owner: twentyhq
           repositories: twenty-infra

--- a/.github/workflows/website-preview-dispatch.yaml
+++ b/.github/workflows/website-preview-dispatch.yaml
@@ -39,8 +39,8 @@ jobs:
         id: app-token
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
-          client-id: ${{ vars.CI_BOT_PUBLIC_CLIENT_ID }}
-          private-key: ${{ secrets.CI_BOT_PUBLIC_APP_PRIVATE_KEY }}
+          client-id: ${{ vars.TWENTY_WORKFLOW_DISPATCHER_CLIENT_ID }}
+          private-key: ${{ secrets.TWENTY_WORKFLOW_DISPATCHER_PRIVATE_KEY }}
           owner: twentyhq
           repositories: ci-privileged
           permission-actions: write
@@ -73,8 +73,8 @@ jobs:
         id: app-token
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
-          client-id: ${{ vars.CI_BOT_PUBLIC_CLIENT_ID }}
-          private-key: ${{ secrets.CI_BOT_PUBLIC_APP_PRIVATE_KEY }}
+          client-id: ${{ vars.TWENTY_WORKFLOW_DISPATCHER_CLIENT_ID }}
+          private-key: ${{ secrets.TWENTY_WORKFLOW_DISPATCHER_PRIVATE_KEY }}
           owner: twentyhq
           repositories: ci-privileged
           permission-actions: write

--- a/.github/workflows/website-preview-dispatch.yaml
+++ b/.github/workflows/website-preview-dispatch.yaml
@@ -39,7 +39,7 @@ jobs:
         id: app-token
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
-          app-id: ${{ vars.CI_BOT_PUBLIC_APP_ID }}
+          client-id: ${{ vars.CI_BOT_PUBLIC_CLIENT_ID }}
           private-key: ${{ secrets.CI_BOT_PUBLIC_APP_PRIVATE_KEY }}
           owner: twentyhq
           repositories: ci-privileged
@@ -73,7 +73,7 @@ jobs:
         id: app-token
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
-          app-id: ${{ vars.CI_BOT_PUBLIC_APP_ID }}
+          client-id: ${{ vars.CI_BOT_PUBLIC_CLIENT_ID }}
           private-key: ${{ secrets.CI_BOT_PUBLIC_APP_PRIVATE_KEY }}
           owner: twentyhq
           repositories: ci-privileged

--- a/.github/workflows/website-preview-dispatch.yaml
+++ b/.github/workflows/website-preview-dispatch.yaml
@@ -35,18 +35,28 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
+      - name: Mint ci-privileged dispatch token
+        id: app-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          app-id: ${{ vars.CI_BOT_PUBLIC_APP_ID }}
+          private-key: ${{ secrets.CI_BOT_PUBLIC_APP_PRIVATE_KEY }}
+          owner: twentyhq
+          repositories: ci-privileged
+          permission-actions: write
+
       - name: Dispatch website-preview-build to ci-privileged
         env:
-          GH_TOKEN: ${{ secrets.CI_PRIVILEGED_DISPATCH_TOKEN }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
           PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
           PR_HEAD_REF: ${{ github.event.pull_request.head.ref }}
         run: |
-          gh api repos/twentyhq/ci-privileged/dispatches \
-            -f event_type=website-preview-build \
-            -f "client_payload[pr_number]=$PR_NUMBER" \
-            -f "client_payload[pr_head_sha]=$PR_HEAD_SHA" \
-            -f "client_payload[pr_head_ref]=$PR_HEAD_REF"
+          gh workflow run website-preview.yaml --repo twentyhq/ci-privileged --ref main \
+            -f action=build \
+            -f pr_number="$PR_NUMBER" \
+            -f pr_head_sha="$PR_HEAD_SHA" \
+            -f pr_head_ref="$PR_HEAD_REF"
 
   trigger-cleanup:
     # Covers both merge and close-without-merge — pull_request `closed` fires
@@ -59,11 +69,21 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
+      - name: Mint ci-privileged dispatch token
+        id: app-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          app-id: ${{ vars.CI_BOT_PUBLIC_APP_ID }}
+          private-key: ${{ secrets.CI_BOT_PUBLIC_APP_PRIVATE_KEY }}
+          owner: twentyhq
+          repositories: ci-privileged
+          permission-actions: write
+
       - name: Dispatch website-preview-cleanup to ci-privileged
         env:
-          GH_TOKEN: ${{ secrets.CI_PRIVILEGED_DISPATCH_TOKEN }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
         run: |
-          gh api repos/twentyhq/ci-privileged/dispatches \
-            -f event_type=website-preview-cleanup \
-            -f "client_payload[pr_number]=$PR_NUMBER"
+          gh workflow run website-preview.yaml --repo twentyhq/ci-privileged --ref main \
+            -f action=cleanup \
+            -f pr_number="$PR_NUMBER"


### PR DESCRIPTION
# Introduction
Getting rid of the fine grained PAT used to dispatch to internal repositories.
Repo dispatch requires the contents write permissions which is too wide for such use
Refactored all senders and target to pass through a workflow dispatch instead
Creating a centralize app that forges a token with actions: write only provided permissions to mitigate any token exfiltrations