### PR TITLE
fix(server): detect retroactively-inserted instance commands when resuming at a workspace step

### DIFF
--- a/packages/twenty-server/src/engine/core-modules/upgrade/services/__tests__/upgrade-sequence-runner.service.spec.ts
+++ b/packages/twenty-server/src/engine/core-modules/upgrade/services/__tests__/upgrade-sequence-runner.service.spec.ts
@@ -1,0 +1,228 @@
+import 'reflect-metadata';
+
+import {
+  type UpgradeStep,
+  UpgradeSequenceReaderService,
+} from 'src/engine/core-modules/upgrade/services/upgrade-sequence-reader.service';
+import { UpgradeSequenceRunnerService } from 'src/engine/core-modules/upgrade/services/upgrade-sequence-runner.service';
+import { UpgradeMigrationService } from 'src/engine/core-modules/upgrade/services/upgrade-migration.service';
+import { InstanceCommandRunnerService } from 'src/engine/core-modules/upgrade/services/instance-command-runner.service';
+import { WorkspaceCommandRunnerService } from 'src/engine/core-modules/upgrade/services/workspace-command-runner.service';
+import { UpgradeAwareEntityMetadataAdapter } from 'src/engine/twenty-orm/upgrade-aware/upgrade-aware-entity-metadata.adapter';
+import { WorkspaceIteratorService } from 'src/database/commands/command-runners/workspace-iterator.service';
+import { WorkspaceVersionService } from 'src/engine/workspace-manager/workspace-version/services/workspace-version.service';
+import { TWENTY_CURRENT_VERSION } from 'src/engine/core-modules/upgrade/constants/twenty-current-version.constant';
+
+const VERSION = TWENTY_CURRENT_VERSION;
+const noopAsync = async () => {};
+
+const makeFastInstanceStep = (name: string): UpgradeStep =>
+  ({
+    kind: 'fast-instance',
+    name,
+    command: { up: noopAsync, down: noopAsync },
+    version: VERSION,
+    timestamp: 0,
+  }) as unknown as UpgradeStep;
+
+const makeWorkspaceStep = (name: string): UpgradeStep =>
+  ({
+    kind: 'workspace',
+    name,
+    command: { runOnWorkspace: noopAsync },
+    version: VERSION,
+    timestamp: 0,
+  }) as unknown as UpgradeStep;
+
+const buildRunner = ({
+  lastAttemptedCommand,
+  completedInstanceCommands,
+  workspaceCursorsByWorkspaceId,
+  workspaceIds = ['ws-1'],
+}: {
+  lastAttemptedCommand: { name: string; status: 'completed' | 'failed' };
+  completedInstanceCommands: Set<string>;
+  workspaceCursorsByWorkspaceId: Map<
+    string,
+    { workspaceId: string; name: string; status: 'completed' | 'failed'; executedByVersion: string; errorMessage: null; createdAt: Date; isInitial: boolean }
+  >;
+  workspaceIds?: string[];
+}): {
+  runner: UpgradeSequenceRunnerService;
+  runFastInstanceCommandMock: jest.Mock;
+  runWorkspaceCommandsMock: jest.Mock;
+} => {
+  const runFastInstanceCommandMock = jest.fn().mockResolvedValue({ status: 'success' });
+  const runWorkspaceCommandsMock = jest.fn().mockResolvedValue(undefined);
+
+  const upgradeMigrationService = {
+    getLastAttemptedCommandNameOrThrow: jest.fn().mockResolvedValue(lastAttemptedCommand),
+    getWorkspaceLastAttemptedCommandNameOrThrow: jest.fn().mockResolvedValue(workspaceCursorsByWorkspaceId),
+    isLastAttemptCompleted: jest.fn(({ name }: { name: string; workspaceId: null }) =>
+      Promise.resolve(completedInstanceCommands.has(name)),
+    ),
+  } as unknown as UpgradeMigrationService;
+
+  const instanceCommandRunnerService = {
+    runFastInstanceCommand: runFastInstanceCommandMock,
+    runSlowInstanceCommand: jest.fn().mockResolvedValue({ status: 'success' }),
+  } as unknown as InstanceCommandRunnerService;
+
+  const workspaceCommandRunnerService = {
+    runWorkspaceCommands: runWorkspaceCommandsMock,
+  } as unknown as WorkspaceCommandRunnerService;
+
+  const upgradeSequenceReaderService = new UpgradeSequenceReaderService(
+    null as never,
+  );
+
+  const upgradeAwareEntityMetadataAdapter = {
+    refresh: jest.fn().mockResolvedValue(undefined),
+  } as unknown as UpgradeAwareEntityMetadataAdapter;
+
+  const workspaceIteratorService = {
+    iterate: jest.fn(
+      async ({
+        workspaceIds: ids,
+        callback,
+      }: {
+        workspaceIds: string[];
+        dryRun: boolean;
+        callback: (ctx: { workspaceId: string }) => Promise<void>;
+      }) => {
+        const successes: string[] = [];
+        const failures: string[] = [];
+
+        for (const workspaceId of ids) {
+          try {
+            await callback({ workspaceId });
+            successes.push(workspaceId);
+          } catch {
+            failures.push(workspaceId);
+          }
+        }
+
+        return { success: successes, fail: failures };
+      },
+    ),
+  } as unknown as WorkspaceIteratorService;
+
+  const workspaceVersionService = {
+    getActiveOrSuspendedWorkspaceIds: jest.fn().mockResolvedValue(workspaceIds),
+  } as unknown as WorkspaceVersionService;
+
+  const runner = new UpgradeSequenceRunnerService(
+    upgradeMigrationService,
+    instanceCommandRunnerService,
+    workspaceCommandRunnerService,
+    upgradeSequenceReaderService,
+    upgradeAwareEntityMetadataAdapter,
+    workspaceIteratorService,
+    workspaceVersionService,
+  );
+
+  return { runner, runFastInstanceCommandMock, runWorkspaceCommandsMock };
+};
+
+describe('UpgradeSequenceRunnerService', () => {
+  describe('cursor-recovery edge case (issue #20699)', () => {
+    // Scenario: a retroactive fix ships a new instance command with a timestamp
+    // earlier than other commands in the same version (e.g. PR #20664 adding
+    // AddRelationTargetFieldMetadataId to the 2.5 slot). The workspace step that
+    // follows it previously failed. On resume, resolveStartCursor must NOT jump
+    // straight to the workspace segment — it must first run the new instance
+    // command that was inserted before it.
+    it('should run a new instance command inserted before a failed workspace step on resume', async () => {
+      // Sequence: [Ic-old (completed), Ic-new (NOT in DB), Wc (failed)]
+      //
+      // Ic-old ran before the fix shipped. Ic-new was added retroactively with
+      // a lower timestamp. On startup, the last-attempted command is Wc/failed.
+      // The runner must detect Ic-new as pending and start from there.
+      const IC_OLD = 'Ic-old';
+      const IC_NEW = 'Ic-new';
+      const WC = 'Wc';
+
+      const sequence: UpgradeStep[] = [
+        makeFastInstanceStep(IC_OLD),
+        makeFastInstanceStep(IC_NEW),
+        makeWorkspaceStep(WC),
+      ];
+
+      const workspaceCursors = new Map([
+        [
+          'ws-1',
+          {
+            workspaceId: 'ws-1',
+            name: WC,
+            status: 'failed' as const,
+            executedByVersion: '2.5.0',
+            errorMessage: null,
+            createdAt: new Date(),
+            isInitial: false,
+          },
+        ],
+      ]);
+
+      const { runner, runFastInstanceCommandMock } = buildRunner({
+        lastAttemptedCommand: { name: WC, status: 'failed' },
+        // IC_OLD completed; IC_NEW was never run (not in DB)
+        completedInstanceCommands: new Set([IC_OLD]),
+        workspaceCursorsByWorkspaceId: workspaceCursors,
+      });
+
+      await runner.run({
+        sequence,
+        options: { dryRun: false },
+      });
+
+      // IC_NEW must have been invoked
+      expect(runFastInstanceCommandMock).toHaveBeenCalledWith(
+        expect.objectContaining({ name: IC_NEW }),
+      );
+    });
+
+    it('should not re-run already-completed instance commands before a failed workspace step', async () => {
+      // When ALL instance commands before the workspace step are already
+      // completed, the runner should resume at the workspace step directly
+      // and must NOT call runFastInstanceCommand for them.
+      const IC_OLD = 'Ic-old';
+      const WC = 'Wc';
+
+      const sequence: UpgradeStep[] = [
+        makeFastInstanceStep(IC_OLD),
+        makeWorkspaceStep(WC),
+      ];
+
+      const workspaceCursors = new Map([
+        [
+          'ws-1',
+          {
+            workspaceId: 'ws-1',
+            name: WC,
+            status: 'failed' as const,
+            executedByVersion: '2.5.0',
+            errorMessage: null,
+            createdAt: new Date(),
+            isInitial: false,
+          },
+        ],
+      ]);
+
+      const { runner, runFastInstanceCommandMock } = buildRunner({
+        lastAttemptedCommand: { name: WC, status: 'failed' },
+        completedInstanceCommands: new Set([IC_OLD]),
+        workspaceCursorsByWorkspaceId: workspaceCursors,
+      });
+
+      await runner.run({
+        sequence,
+        options: { dryRun: false },
+      });
+
+      // IC_OLD is already completed — runner must not invoke it again
+      expect(runFastInstanceCommandMock).not.toHaveBeenCalledWith(
+        expect.objectContaining({ name: IC_OLD }),
+      );
+    });
+  });
+});

--- a/packages/twenty-server/src/engine/core-modules/upgrade/services/upgrade-sequence-runner.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/upgrade/services/upgrade-sequence-runner.service.ts
@@ -223,7 +223,20 @@ export class UpgradeSequenceRunnerService {
           workspaceSliceBounds,
         });
 
-        return workspaceSliceBounds.startCursor;
+        // When resuming at a workspace segment, scan backward through instance
+        // commands that precede it to catch any that were inserted into earlier
+        // version slots by a retroactive fix (e.g. PR #20664). Such commands
+        // have an earlier timestamp than the existing completed commands, so the
+        // cursor jumps over them when the workspace step is the resume point.
+        // Instance-command runner already guards against double-execution via
+        // isLastAttemptCompleted, so this is safe to run unconditionally.
+        const pendingInstanceCursor =
+          await this.findEarliestPendingInstanceCommandBefore({
+            sequence,
+            beforeCursor: workspaceSliceBounds.startCursor,
+          });
+
+        return pendingInstanceCursor ?? workspaceSliceBounds.startCursor;
       }
       default:
         assertUnreachable(lastAttemptedStep);
@@ -407,6 +420,40 @@ export class UpgradeSequenceRunnerService {
     }
 
     return workspaceIds;
+  }
+
+  // Scans backward from beforeCursor (exclusive) through contiguous instance
+  // commands, stopping at any workspace step or the start of the sequence.
+  // Returns the index of the earliest unrun instance command, or null if all
+  // preceding instance commands have already been completed.
+  private async findEarliestPendingInstanceCommandBefore({
+    sequence,
+    beforeCursor,
+  }: {
+    sequence: UpgradeStep[];
+    beforeCursor: number;
+  }): Promise<number | null> {
+    let earliestPending: number | null = null;
+
+    for (let i = beforeCursor - 1; i >= 0; i--) {
+      const step = sequence[i];
+
+      if (step.kind === 'workspace') {
+        break;
+      }
+
+      const isCompleted =
+        await this.upgradeMigrationService.isLastAttemptCompleted({
+          name: step.name,
+          workspaceId: null,
+        });
+
+      if (!isCompleted) {
+        earliestPending = i;
+      }
+    }
+
+    return earliestPending;
   }
 
   private enforceWorkspacesCompletedPreviousWorkspaceSegment({


### PR DESCRIPTION
## Summary

When a workspace command fails and the upgrade sequence is resumed on the next server start, `resolveStartCursor` jumps straight to the start of the workspace segment. If a retroactive fix (like [PR #20664](https://github.com/twentyhq/twenty/pull/20664)) has shipped a new instance command with an earlier timestamp into a version slot that precedes the workspace segment, that command is completely skipped.

**Concrete reproduction** (issue #20699):
1. Instance upgraded from ≤2.2 → ~2.5, cursor advances through 2.3→2.4→2.5
2. `2.5.0/NormalizeCompositeFieldDefaults` fails — `relationTargetFieldMetadataId` column doesn't exist
3. Operator upgrades to v2.6.1 which includes the fix from #20664 (adds a 2.5.0 `ADD COLUMN IF NOT EXISTS` guard before the workspace commands)
4. On startup, `resolveStartCursor` sees last-attempted = `NormalizeCompositeFieldDefaults/failed` → returns `workspaceSliceBounds.startCursor`, skipping the new 2.5 instance command entirely
5. Same error, upgrade still blocked

## Fix

Before returning the workspace segment start cursor, `resolveStartCursor` now scans backward through the contiguous instance commands that precede the segment and finds the earliest one not yet recorded as completed in `upgradeMigration`. If any are pending, it returns that earlier position so the runner executes them first.

The instance-command runner already guards against double-execution via `isLastAttemptCompleted`, so this is safe — previously-completed commands are fast-skipped.

## Test

New spec `upgrade-sequence-runner.service.spec.ts` exercises the exact recovery scenario:
- Sequence `[Ic-old (completed), Ic-new (not in DB), Wc (failed)]`
- Last attempted = `Wc/failed`
- Asserts that `runFastInstanceCommand` is called for `Ic-new`
- Also asserts already-completed commands are NOT re-invoked

Closes #20699

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/21653?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

