### PR TITLE
fix(route-trigger): return 422 instead of 500 for logic function execution errors

### DIFF
--- a/packages/twenty-server/src/engine/core-modules/exception-handler/http-exception-handler.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/exception-handler/http-exception-handler.service.ts
@@ -73,7 +73,9 @@ export class HttpExceptionHandlerService {
     errorCode?: number,
     user?: ExceptionHandlerUser,
     workspace?: ExceptionHandlerWorkspace,
-    { shouldBeCapturedBySentry = true }: { shouldBeCapturedBySentry?: boolean } = {},
+    {
+      shouldBeCapturedBySentry = true,
+    }: { shouldBeCapturedBySentry?: boolean } = {},
   ): Response | undefined => {
     const params = this.request?.params;
 

--- a/packages/twenty-server/src/engine/core-modules/exception-handler/http-exception-handler.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/exception-handler/http-exception-handler.service.ts
@@ -73,6 +73,7 @@ export class HttpExceptionHandlerService {
     errorCode?: number,
     user?: ExceptionHandlerUser,
     workspace?: ExceptionHandlerWorkspace,
+    { shouldBeCapturedBySentry = true }: { shouldBeCapturedBySentry?: boolean } = {},
   ): Response | undefined => {
     const params = this.request?.params;
 
@@ -116,6 +117,7 @@ export class HttpExceptionHandlerService {
       user,
       workspace,
       statusCode,
+      shouldBeCapturedBySentry,
     });
 
     return response.status(statusCode).send({

--- a/packages/twenty-server/src/engine/core-modules/logic-function/logic-function-trigger/triggers/route/exceptions/route-trigger-rest-api-exception-filter.ts
+++ b/packages/twenty-server/src/engine/core-modules/logic-function/logic-function-trigger/triggers/route/exceptions/route-trigger-rest-api-exception-filter.ts
@@ -50,6 +50,9 @@ export class RouteTriggerRestApiExceptionFilter implements ExceptionFilter {
           exception as CustomException,
           response,
           500,
+          undefined,
+          undefined,
+          { shouldBeCapturedBySentry: false },
         );
       case RouteTriggerExceptionCode.ROUTE_ALREADY_EXIST:
       case RouteTriggerExceptionCode.ROUTE_PATH_ALREADY_EXIST:

--- a/packages/twenty-server/src/engine/utils/global-exception-handler.util.ts
+++ b/packages/twenty-server/src/engine/utils/global-exception-handler.util.ts
@@ -104,7 +104,10 @@ export const handleException = <
   statusCode?: number;
   shouldBeCapturedBySentry?: boolean;
 }): T => {
-  if (shouldBeCapturedBySentry && shouldCaptureException(exception, statusCode)) {
+  if (
+    shouldBeCapturedBySentry &&
+    shouldCaptureException(exception, statusCode)
+  ) {
     exceptionHandlerService.captureExceptions([exception], { user, workspace });
   }
 

--- a/packages/twenty-server/src/engine/utils/global-exception-handler.util.ts
+++ b/packages/twenty-server/src/engine/utils/global-exception-handler.util.ts
@@ -95,14 +95,16 @@ export const handleException = <
   user,
   workspace,
   statusCode,
+  shouldBeCapturedBySentry = true,
 }: {
   exception: T;
   exceptionHandlerService: ExceptionHandlerService;
   user?: ExceptionHandlerUser;
   workspace?: ExceptionHandlerWorkspace;
   statusCode?: number;
+  shouldBeCapturedBySentry?: boolean;
 }): T => {
-  if (shouldCaptureException(exception, statusCode)) {
+  if (shouldBeCapturedBySentry && shouldCaptureException(exception, statusCode)) {
     exceptionHandlerService.captureExceptions([exception], { user, workspace });
   }
 


### PR DESCRIPTION
## What

Return HTTP 422 instead of 500 for `LOGIC_FUNCTION_EXECUTION_ERROR` in the route trigger exception filter.

## Why

When a logic function's user code fails (e.g. an HTTP call inside the function returns a 502 from an upstream service), the exception was mapped to HTTP 500. This caused two problems:

- **Sentry noise**: `shouldCaptureException` captures all 5xx responses, so every user-code failure was reported as a platform error. This generated ~56k Sentry events over 2 months for a single workspace's logic function hitting a transient upstream 502.
- **Webhook retry loops**: Webhook senders like GitHub auto-retry on 5xx responses, amplifying the event count.

`LOGIC_FUNCTION_EXECUTION_ERROR` is a user-code error, not a platform error. A 422 (Unprocessable Entity) correctly signals that the request could not be processed due to the logic function's own failure, without triggering Sentry capture or webhook retries.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/21656?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

