### PR TITLE
fix(ui): default Monaco CodeEditor to scrollBeyondLastLine: false

### DIFF
--- a/packages/twenty-ui-deprecated/src/input/code-editor/components/CodeEditor.tsx
+++ b/packages/twenty-ui-deprecated/src/input/code-editor/components/CodeEditor.tsx
@@ -215,6 +215,7 @@ export const CodeEditor = ({
             formatOnPaste: true,
             formatOnType: true,
             overviewRulerLanes: 0,
+            scrollBeyondLastLine: false,
             scrollbar: {
               vertical: 'hidden',
               horizontal: 'hidden',

--- a/packages/twenty-ui/src/input/code-editor/components/CodeEditor.tsx
+++ b/packages/twenty-ui/src/input/code-editor/components/CodeEditor.tsx
@@ -144,6 +144,7 @@ export const CodeEditor = ({
             formatOnPaste: true,
             formatOnType: true,
             overviewRulerLanes: 0,
+            scrollBeyondLastLine: false,
             scrollbar: {
               vertical: 'hidden',
               horizontal: 'hidden',


### PR DESCRIPTION
## Problem

In the AI chat "Python Code Execution" panel (`CodeExecutionDisplay`), scrolling the code goes far past the last line, leaving a large empty area below the code.

The root cause is in the shared `CodeEditor`: Monaco's `scrollBeyondLastLine` option **defaults to `true`**, which lets the viewport scroll roughly a full editor height past the last line. The shared component never set this option, so the Monaco default leaked through to every consumer.

This affected every read-only viewer built on `CodeEditor` — the code interpreter, `WorkflowReadonlyActionCode`, `WorkflowStepExecutionResult`, and `SettingsLogicFunctionTriggerPayloadFormat` — and each one had to remember to disable it (only `WorkflowEditActionCode` did).

## Change

Set `scrollBeyondLastLine: false` in the shared `CodeEditor` defaults, in both the active `twenty-ui-deprecated` copy and the `twenty-ui` copy (kept in sync). Since `options` is spread last, any editor that genuinely wants scroll-past-end can still opt back in with `scrollBeyondLastLine: true`.

## Impact

- **Auto-fixed** the read-only viewers that showed dead scroll space (code interpreter, workflow readonly action, step execution result, trigger payload sample).
- The editable editors that previously inherited Monaco's default (`SettingsLogicFunctionCodeEditor`, `RawJsonFieldInput`, `SettingsLogicFunctionTestTab`, `ConfigVariableDatabaseInput`) now also stop at the last line — consistent with `WorkflowEditActionCode`, which already opted out. Any of these can re-enable scroll-past-end via `options` if desired.

## Testing

Behavior verified by inspection against Monaco's option semantics and existing usages. Note: dependencies were not installed in the authoring environment, so `lint`/`typecheck` were not run locally — `scrollBeyondLastLine: false` is a standard, type-safe Monaco option already used with this component elsewhere. Worth a CI check.

https://claude.ai/code/session_01CWzyw1spKF8Dog9E5tcdj4

---
_Generated by [Claude Code](https://claude.ai/code/session_01CWzyw1spKF8Dog9E5tcdj4)_

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/21657?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

