### PR TITLE
fix(server): run 2-14 standard relation label/icon heal as a system build

### DIFF
--- a/packages/twenty-server/src/database/commands/upgrade-version-command/2-14/2-14-workspace-command-1799000040000-fix-standard-relation-field-labels-icons.command.ts
+++ b/packages/twenty-server/src/database/commands/upgrade-version-command/2-14/2-14-workspace-command-1799000040000-fix-standard-relation-field-labels-icons.command.ts
@@ -136,8 +136,23 @@ export class FixStandardRelationFieldLabelsIconsCommand extends ActiveOrSuspende
       );
 
     if (result.status === 'fail') {
+      const failureDetails = Object.values(result.report)
+        .flat()
+        .map((failedValidation) => {
+          const errorMessages = failedValidation.errors
+            .map((error) => `${error.code}: ${error.message}`)
+            .join('; ');
+
+          return `[${failedValidation.metadataName}] ${failedValidation.flatEntityMinimalInformation.universalIdentifier ?? failedValidation.flatEntityMinimalInformation.id ?? 'unknown'} -> ${errorMessages}`;
+        })
+        .join('\n');
+
+      this.logger.error(
+        `Migration build failed for workspace ${workspaceId} while healing standard relation field labels/icons:\n${failureDetails}`,
+      );
+
       throw new Error(
-        `Migration failed for workspace ${workspaceId} while healing standard relation field labels/icons`,
+        `Migration failed for workspace ${workspaceId} while healing standard relation field labels/icons:\n${failureDetails}`,
       );
     }
 


### PR DESCRIPTION
## Problem

The `2-14:fix-standard-relation-field-labels-icons` workspace upgrade command aborted the upgrade on app-main, failing for 13 workspaces with:

```
FIELD_MUTATION_NOT_ALLOWED: System fields only allow updating: universalSettings, isActive. Forbidden properties: icon
```

The default relation fields it heals (note/task/attachment/timeline) on standard objects are **system-owned**. The flat-field-metadata validator forbids mutating any property other than `universalSettings`/`isActive` on a system field **unless the migration runs as a system build** (`buildOptions.isSystemBuild`). The command omitted `isSystemBuild`, so it defaulted to `false` and every workspace with actual drift to heal was rejected.

## Root cause was hidden

The command also threw a generic error that discarded `result.report`, so the original logs showed only `Migration failed for workspace ...` with no detail. This made the failure impossible to diagnose.

## Changes

1. **Fix:** pass `isSystemBuild: true` when building the heal migration — consistent with every other standard-metadata upgrade command (2-3, 2-5, 2-7, 2-8, 2-9, 2-10, 2-13, other 2-14 commands).
2. **Diagnostics:** flatten `result.report` into the logged/thrown error so future build failures surface the real per-field validation errors instead of a generic message.

## Notes

- `label` and `icon` are both in `FLAT_FIELD_METADATA_RELATION_PROPERTIES_TO_COMPARE`, so the relation-field validator (which is not gated on `isSystemBuild`) already permits them — the system-build flag was the only blocker.
- Dry-run returns before the build step, so this only manifests on real runs.
