### PR TITLE
fix(server): backport viewFilter relationTargetFieldMetadataId gate to 2.6 (#21267)

### DIFF
--- a/packages/twenty-server/src/engine/metadata-modules/view-filter/entities/view-filter.entity.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/view-filter/entities/view-filter.entity.ts
@@ -12,6 +12,7 @@ import {
   UpdateDateColumn,
 } from 'typeorm';
 
+import { WasIntroducedInUpgrade } from 'src/engine/core-modules/upgrade/decorators/was-introduced-in-upgrade.decorator';
 import { type JsonbProperty } from 'src/engine/workspace-manager/workspace-migration/universal-flat-entity/types/jsonb-property.type';
 import { FieldMetadataEntity } from 'src/engine/metadata-modules/field-metadata/field-metadata.entity';
 import { ViewFilterGroupEntity } from 'src/engine/metadata-modules/view-filter-group/entities/view-filter-group.entity';
@@ -64,6 +65,10 @@ export class ViewFilterEntity
   @Column({ nullable: true, type: 'text', default: null })
   subFieldName: string | null;
 
+  @WasIntroducedInUpgrade({
+    upgradeCommandName:
+      '2.6.0_AddRelationTargetFieldMetadataIdToViewFilterFastInstanceCommand_1798000005000',
+  })
   @Column({ nullable: true, type: 'uuid', default: null })
   relationTargetFieldMetadataId: string | null;
 


### PR DESCRIPTION
## Backport of #21267 to the **2.6** line (target: v2.6.3)

### Why
Cross-version upgrades crossing 2.6 can abort with:
```
column ViewFilterEntity.relationTargetFieldMetadataId does not exist
  at WorkspaceFlatViewFilterMapCacheService.computeForCache
```
`relationTargetFieldMetadataId` is added to `core.viewFilter` only at the **2.6.0** cursor, but the workspace cache recompute SELECTs every column of the entity during earlier (2.5) workspace steps. When the workspace cursor has advanced past the 2.3/2.4/2.5 backport instance commands from a **prior failed upgrade attempt** — without the column ever being created — the SELECT fails and the upgrade aborts (issue #20699).

### Fix
Identical one-property change as #21267: gate the column with `@WasIntroducedInUpgrade` pointing at the 2.6.0 command that adds it. `UpgradeAwareRepositoryProxy` then hides the column from reads while the cursor is < 2.6, so the cache recompute omits it — no crash — and it becomes visible once the 2.6.0 command has run.

### Why 2.6 needs it
v2.6.0/1/2 ship the ungated column. The fix only landed in **v2.9.2**; the 2.6 line was never patched. The `@WasIntroducedInUpgrade` decorator and the `2.6.0_AddRelationTargetFieldMetadataIdToViewFilterFastInstanceCommand_1798000005000` command both already exist at v2.6.2, so the referenced command resolves and the validator accepts it.

### Validation context
A clean single-hop CI upgrade does **not** reproduce the crash (the 2.4 backport command runs ahead of the resume cursor and creates the column first) — this gate is what protects the **phantom-cursor recovery** path that a clean upgrade can't exercise. See #20699 for the exact repro.

Base branch `release/v2.6.3` was cut from the `v2.6.2` tag, so version constants are already correct for the 2.6 line — this PR is **only** the 5-line gate.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/21661?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

