### PR TITLE
fix(server): backport viewFilter relationTargetFieldMetadataId gate to 2.8 (#21267)

### DIFF
--- a/packages/twenty-server/src/engine/metadata-modules/view-filter/entities/view-filter.entity.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/view-filter/entities/view-filter.entity.ts
@@ -12,6 +12,7 @@ import {
   UpdateDateColumn,
 } from 'typeorm';
 
+import { WasIntroducedInUpgrade } from 'src/engine/core-modules/upgrade/decorators/was-introduced-in-upgrade.decorator';
 import { type JsonbProperty } from 'src/engine/workspace-manager/workspace-migration/universal-flat-entity/types/jsonb-property.type';
 import { FieldMetadataEntity } from 'src/engine/metadata-modules/field-metadata/field-metadata.entity';
 import { ViewFilterGroupEntity } from 'src/engine/metadata-modules/view-filter-group/entities/view-filter-group.entity';
@@ -64,6 +65,10 @@ export class ViewFilterEntity
   @Column({ nullable: true, type: 'text', default: null })
   subFieldName: string | null;
 
+  @WasIntroducedInUpgrade({
+    upgradeCommandName:
+      '2.6.0_AddRelationTargetFieldMetadataIdToViewFilterFastInstanceCommand_1798000005000',
+  })
   @Column({ nullable: true, type: 'uuid', default: null })
   relationTargetFieldMetadataId: string | null;
 


### PR DESCRIPTION
## Backport of #21267 to the **2.8** line (target: release/v2.8.5)

### Why
Cross-version upgrades crossing 2.6 can abort with:
```
column ViewFilterEntity.relationTargetFieldMetadataId does not exist
  at WorkspaceFlatViewFilterMapCacheService.computeForCache
```
`relationTargetFieldMetadataId` is added to `core.viewFilter` only at the **2.6.0** cursor, but the workspace cache recompute SELECTs every column of the entity during earlier (2.5) workspace steps. When the workspace cursor has advanced past the 2.3/2.4/2.5 backport instance commands from a **prior failed upgrade attempt** — without the column ever being created — the SELECT fails and the upgrade aborts (issue #20699).

### Fix
Identical one-property change as #21267: gate the column with `@WasIntroducedInUpgrade` pointing at the 2.6.0 command that adds it. `UpgradeAwareRepositoryProxy` then hides the column from reads while the cursor is < 2.6, so the cache recompute omits it — no crash — and it becomes visible once the 2.6.0 command has run.

### Why 2.8 needs it
The 2.8 line ships the ungated column; the fix only landed in **v2.9.2**. This line's latest patch tips at #21257 (the *sibling* role-permission cache guard) but never received #21267. The `@WasIntroducedInUpgrade` decorator and the referenced `2.6.0_AddRelationTargetFieldMetadataIdToViewFilterFastInstanceCommand_1798000005000` command both already exist in this line, so the validator accepts the gate.

### Validation context
A clean single-hop CI upgrade does **not** reproduce the crash (the 2.4 backport command runs ahead of the resume cursor and creates the column first) — this gate protects the **phantom-cursor recovery** path that a clean upgrade can't exercise. See #20699.

Base branch `release/v2.8.5` was cut from this line's latest release tag, so version constants are already correct — this PR is **only** the 5-line gate.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/21663?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

