### PR TITLE
fix(messaging): pin Google OAuth2 client to native fetch

### DIFF
--- a/packages/twenty-server/src/engine/core-modules/auth/services/google-apis-service-availability.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/auth/services/google-apis-service-availability.service.ts
@@ -20,10 +20,11 @@ export class GoogleApisServiceAvailabilityService {
   async checkServicesAvailability(
     accessToken: string,
   ): Promise<GoogleApisServiceAvailability> {
-    const oAuth2Client = new google.auth.OAuth2(
-      this.twentyConfigService.get('AUTH_GOOGLE_CLIENT_ID'),
-      this.twentyConfigService.get('AUTH_GOOGLE_CLIENT_SECRET'),
-    );
+    const oAuth2Client = new google.auth.OAuth2({
+      clientId: this.twentyConfigService.get('AUTH_GOOGLE_CLIENT_ID'),
+      clientSecret: this.twentyConfigService.get('AUTH_GOOGLE_CLIENT_SECRET'),
+      transporterOptions: { fetchImplementation: fetch },
+    });
 
     oAuth2Client.setCredentials({
       access_token: accessToken,

--- a/packages/twenty-server/src/modules/connected-account/oauth2-client-manager/drivers/google/google-oauth2-client.provider.ts
+++ b/packages/twenty-server/src/modules/connected-account/oauth2-client-manager/drivers/google/google-oauth2-client.provider.ts
@@ -72,7 +72,11 @@ export class GoogleOAuth2ClientProvider {
     );
 
     try {
-      const oAuth2Client = new google.auth.OAuth2(clientId, clientSecret);
+      const oAuth2Client = new google.auth.OAuth2({
+        clientId,
+        clientSecret,
+        transporterOptions: { fetchImplementation: fetch },
+      });
 
       oAuth2Client.setCredentials({ refresh_token: plaintextRefreshToken });
 

--- a/packages/twenty-server/src/modules/connected-account/refresh-tokens-manager/drivers/google/services/google-api-refresh-tokens.service.ts
+++ b/packages/twenty-server/src/modules/connected-account/refresh-tokens-manager/drivers/google/services/google-api-refresh-tokens.service.ts
@@ -19,10 +19,11 @@ export class GoogleAPIRefreshAccessTokenService {
   async refreshTokens(
     refreshToken: PlaintextString,
   ): Promise<ConnectedAccountPlaintextTokens> {
-    const oAuth2Client = new google.auth.OAuth2(
-      this.twentyConfigService.get('AUTH_GOOGLE_CLIENT_ID'),
-      this.twentyConfigService.get('AUTH_GOOGLE_CLIENT_SECRET'),
-    );
+    const oAuth2Client = new google.auth.OAuth2({
+      clientId: this.twentyConfigService.get('AUTH_GOOGLE_CLIENT_ID'),
+      clientSecret: this.twentyConfigService.get('AUTH_GOOGLE_CLIENT_SECRET'),
+      transporterOptions: { fetchImplementation: fetch },
+    });
 
     oAuth2Client.setCredentials({
       refresh_token: refreshToken,


### PR DESCRIPTION
/closes TWENTY-SERVER-HFH

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/21668?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

