### PR TITLE
fix(server): default timeline thread visibility to METADATA

### DIFF
--- a/packages/twenty-server/src/engine/core-modules/messaging/utils/format-threads.util.ts
+++ b/packages/twenty-server/src/engine/core-modules/messaging/utils/format-threads.util.ts
@@ -25,7 +25,9 @@ export const formatThreads = (
   return threads
     .filter((thread) => isDefined(threadParticipantsByThreadId[thread.id]))
     .map((thread) => {
-      const visibility = threadVisibilityByThreadId[thread.id];
+      const visibility =
+        threadVisibilityByThreadId[thread.id] ??
+        MessageChannelVisibility.METADATA;
 
       return {
         ...thread,


### PR DESCRIPTION
Orphaned messageChannelMessageAssociation rows (channel deleted in core, association left behind when cleanup cron was down) made visibility unresolvable, so formatThreads emitted null for the non-nullable TimelineThread.visibility field and 500'd the whole timeline query.

Fail closed to METADATA (most restrictive existing tier) so a missing channel hides subject/body instead of breaking the page.

/closes TWENTY-SERVER-FM6

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/21669?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

