### PR TITLE
Hide Input and Test tabs for app logic function nodes

### DIFF
--- a/packages/twenty-front/src/modules/workflow/workflow-steps/workflow-actions/logic-function-action/components/WorkflowEditActionLogicFunction.tsx
+++ b/packages/twenty-front/src/modules/workflow/workflow-steps/workflow-actions/logic-function-action/components/WorkflowEditActionLogicFunction.tsx
@@ -185,7 +185,8 @@ export const WorkflowEditActionLogicFunction = ({
 
   const isLogicFunctionFromApp = isDefined(logicFunction?.applicationId);
 
-  const isTestTabActive = !isLogicFunctionFromApp && activeTabId === TEST_TAB_ID;
+  const isTestTabActive =
+    !isLogicFunctionFromApp && activeTabId === TEST_TAB_ID;
 
   const tabs = [
     {

--- a/packages/twenty-front/src/modules/workflow/workflow-steps/workflow-actions/logic-function-action/components/WorkflowEditActionLogicFunction.tsx
+++ b/packages/twenty-front/src/modules/workflow/workflow-steps/workflow-actions/logic-function-action/components/WorkflowEditActionLogicFunction.tsx
@@ -1,3 +1,5 @@
+import { isTwentyStandardApplication } from '@/applications/utils/isTwentyStandardApplication';
+import { isWorkspaceCustomApplication } from '@/applications/utils/isWorkspaceCustomApplication';
 import { currentWorkspaceState } from '@/auth/states/currentWorkspaceState';
 import { LogicFunctionExecutionResult } from '@/logic-functions/components/LogicFunctionExecutionResult';
 import { LogicFunctionLogs } from '@/logic-functions/components/LogicFunctionLogs';
@@ -187,15 +189,18 @@ export const WorkflowEditActionLogicFunction = ({
 
   const hasInputFields = Object.keys(functionInput).length > 0;
 
-  const workspaceCustomApplicationId =
-    currentWorkspace?.workspaceCustomApplication?.id;
+  const logicFunctionApplication = currentWorkspace?.installedApplications.find(
+    (installedApplication) =>
+      installedApplication.id === logicFunction?.applicationId,
+  );
 
-  const isManagedLogicFunction =
-    isDefined(logicFunction?.applicationId) &&
-    logicFunction.applicationId !== workspaceCustomApplicationId;
+  const isLogicFunctionFromIntegrationApp =
+    isDefined(logicFunctionApplication) &&
+    !isTwentyStandardApplication(logicFunctionApplication) &&
+    !isWorkspaceCustomApplication(logicFunctionApplication, currentWorkspace);
 
   const isTestTabActive =
-    !isManagedLogicFunction && activeTabId === TEST_TAB_ID;
+    !isLogicFunctionFromIntegrationApp && activeTabId === TEST_TAB_ID;
 
   const tabs = [
     {
@@ -213,7 +218,7 @@ export const WorkflowEditActionLogicFunction = ({
   return (
     <>
       <LogicFunctionTestInputInitEffect logicFunctionId={logicFunctionId} />
-      {!isManagedLogicFunction && (
+      {!isLogicFunctionFromIntegrationApp && (
         <StyledTabListContainer>
           <TabList
             tabs={tabs}

--- a/packages/twenty-front/src/modules/workflow/workflow-steps/workflow-actions/logic-function-action/components/WorkflowEditActionLogicFunction.tsx
+++ b/packages/twenty-front/src/modules/workflow/workflow-steps/workflow-actions/logic-function-action/components/WorkflowEditActionLogicFunction.tsx
@@ -183,6 +183,10 @@ export const WorkflowEditActionLogicFunction = ({
 
   const hasInputFields = Object.keys(functionInput).length > 0;
 
+  const isLogicFunctionFromApp = isDefined(logicFunction?.applicationId);
+
+  const isTestTabActive = !isLogicFunctionFromApp && activeTabId === TEST_TAB_ID;
+
   const tabs = [
     {
       id: INPUT_TAB_ID,
@@ -199,17 +203,19 @@ export const WorkflowEditActionLogicFunction = ({
   return (
     <>
       <LogicFunctionTestInputInitEffect logicFunctionId={logicFunctionId} />
-      <StyledTabListContainer>
-        <TabList
-          tabs={tabs}
-          behaveAsLinks={false}
-          componentInstanceId={
-            WORKFLOW_LOGIC_FUNCTION_ACTION_TAB_LIST_COMPONENT_ID
-          }
-        />
-      </StyledTabListContainer>
+      {!isLogicFunctionFromApp && (
+        <StyledTabListContainer>
+          <TabList
+            tabs={tabs}
+            behaveAsLinks={false}
+            componentInstanceId={
+              WORKFLOW_LOGIC_FUNCTION_ACTION_TAB_LIST_COMPONENT_ID
+            }
+          />
+        </StyledTabListContainer>
+      )}
       <WorkflowStepBody>
-        {activeTabId === TEST_TAB_ID ? (
+        {isTestTabActive ? (
           <>
             <WorkflowEditActionCodeFields
               functionInput={testInput}
@@ -262,7 +268,7 @@ export const WorkflowEditActionLogicFunction = ({
         <WorkflowStepFooter
           stepId={action.id}
           additionalActions={
-            activeTabId === TEST_TAB_ID
+            isTestTabActive
               ? [
                   <WorkflowStepCmdEnterButton
                     title={t`Test`}

--- a/packages/twenty-front/src/modules/workflow/workflow-steps/workflow-actions/logic-function-action/components/WorkflowEditActionLogicFunction.tsx
+++ b/packages/twenty-front/src/modules/workflow/workflow-steps/workflow-actions/logic-function-action/components/WorkflowEditActionLogicFunction.tsx
@@ -1,3 +1,4 @@
+import { currentWorkspaceState } from '@/auth/states/currentWorkspaceState';
 import { LogicFunctionExecutionResult } from '@/logic-functions/components/LogicFunctionExecutionResult';
 import { LogicFunctionLogs } from '@/logic-functions/components/LogicFunctionLogs';
 import { LogicFunctionTestInputInitEffect } from '@/logic-functions/components/LogicFunctionTestInputInitEffect';
@@ -7,6 +8,7 @@ import { InputLabel } from '@/ui/input/components/InputLabel';
 import { TabList } from '@/ui/layout/tab-list/components/TabList';
 import { activeTabIdComponentState } from '@/ui/layout/tab-list/states/activeTabIdComponentState';
 import { useAtomComponentStateValue } from '@/ui/utilities/state/jotai/hooks/useAtomComponentStateValue';
+import { useAtomStateValue } from '@/ui/utilities/state/jotai/hooks/useAtomStateValue';
 import { type WorkflowLogicFunctionAction } from '@/workflow/types/Workflow';
 import { WorkflowStepBody } from '@/workflow/workflow-steps/components/WorkflowStepBody';
 import { WorkflowStepCmdEnterButton } from '@/workflow/workflow-steps/components/WorkflowStepCmdEnterButton';
@@ -74,6 +76,8 @@ export const WorkflowEditActionLogicFunction = ({
   const { logicFunction, loading } = useGetOneLogicFunction({
     id: logicFunctionId,
   });
+
+  const currentWorkspace = useAtomStateValue(currentWorkspaceState);
 
   const activeTabId = useAtomComponentStateValue(
     activeTabIdComponentState,
@@ -183,10 +187,15 @@ export const WorkflowEditActionLogicFunction = ({
 
   const hasInputFields = Object.keys(functionInput).length > 0;
 
-  const isLogicFunctionFromApp = isDefined(logicFunction?.applicationId);
+  const workspaceCustomApplicationId =
+    currentWorkspace?.workspaceCustomApplication?.id;
+
+  const isManagedLogicFunction =
+    isDefined(logicFunction?.applicationId) &&
+    logicFunction.applicationId !== workspaceCustomApplicationId;
 
   const isTestTabActive =
-    !isLogicFunctionFromApp && activeTabId === TEST_TAB_ID;
+    !isManagedLogicFunction && activeTabId === TEST_TAB_ID;
 
   const tabs = [
     {
@@ -204,7 +213,7 @@ export const WorkflowEditActionLogicFunction = ({
   return (
     <>
       <LogicFunctionTestInputInitEffect logicFunctionId={logicFunctionId} />
-      {!isLogicFunctionFromApp && (
+      {!isManagedLogicFunction && (
         <StyledTabListContainer>
           <TabList
             tabs={tabs}

--- a/packages/twenty-front/src/modules/workflow/workflow-steps/workflow-actions/logic-function-action/components/WorkflowEditActionLogicFunction.tsx
+++ b/packages/twenty-front/src/modules/workflow/workflow-steps/workflow-actions/logic-function-action/components/WorkflowEditActionLogicFunction.tsx
@@ -1,6 +1,4 @@
-import { isTwentyStandardApplication } from '@/applications/utils/isTwentyStandardApplication';
-import { isWorkspaceCustomApplication } from '@/applications/utils/isWorkspaceCustomApplication';
-import { currentWorkspaceState } from '@/auth/states/currentWorkspaceState';
+import { useIsThirdPartyApplication } from '@/applications/hooks/useIsThirdPartyApplication';
 import { LogicFunctionExecutionResult } from '@/logic-functions/components/LogicFunctionExecutionResult';
 import { LogicFunctionLogs } from '@/logic-functions/components/LogicFunctionLogs';
 import { LogicFunctionTestInputInitEffect } from '@/logic-functions/components/LogicFunctionTestInputInitEffect';
@@ -10,7 +8,6 @@ import { InputLabel } from '@/ui/input/components/InputLabel';
 import { TabList } from '@/ui/layout/tab-list/components/TabList';
 import { activeTabIdComponentState } from '@/ui/layout/tab-list/states/activeTabIdComponentState';
 import { useAtomComponentStateValue } from '@/ui/utilities/state/jotai/hooks/useAtomComponentStateValue';
-import { useAtomStateValue } from '@/ui/utilities/state/jotai/hooks/useAtomStateValue';
 import { type WorkflowLogicFunctionAction } from '@/workflow/types/Workflow';
 import { WorkflowStepBody } from '@/workflow/workflow-steps/components/WorkflowStepBody';
 import { WorkflowStepCmdEnterButton } from '@/workflow/workflow-steps/components/WorkflowStepCmdEnterButton';
@@ -79,7 +76,9 @@ export const WorkflowEditActionLogicFunction = ({
     id: logicFunctionId,
   });
 
-  const currentWorkspace = useAtomStateValue(currentWorkspaceState);
+  const isThirdPartyApp = useIsThirdPartyApplication(
+    logicFunction?.applicationId,
+  );
 
   const activeTabId = useAtomComponentStateValue(
     activeTabIdComponentState,
@@ -189,18 +188,7 @@ export const WorkflowEditActionLogicFunction = ({
 
   const hasInputFields = Object.keys(functionInput).length > 0;
 
-  const logicFunctionApplication = currentWorkspace?.installedApplications.find(
-    (installedApplication) =>
-      installedApplication.id === logicFunction?.applicationId,
-  );
-
-  const isLogicFunctionFromIntegrationApp =
-    isDefined(logicFunctionApplication) &&
-    !isTwentyStandardApplication(logicFunctionApplication) &&
-    !isWorkspaceCustomApplication(logicFunctionApplication, currentWorkspace);
-
-  const isTestTabActive =
-    !isLogicFunctionFromIntegrationApp && activeTabId === TEST_TAB_ID;
+  const isTestTabActive = !isThirdPartyApp && activeTabId === TEST_TAB_ID;
 
   const tabs = [
     {
@@ -218,7 +206,7 @@ export const WorkflowEditActionLogicFunction = ({
   return (
     <>
       <LogicFunctionTestInputInitEffect logicFunctionId={logicFunctionId} />
-      {!isLogicFunctionFromIntegrationApp && (
+      {!isThirdPartyApp && (
         <StyledTabListContainer>
           <TabList
             tabs={tabs}


### PR DESCRIPTION
When opening a logic function node that comes from an app (e.g. "Enrich Company" from People Data Labs), the node detail panel was showing **Input** and **Test** tabs. App-sourced functions should only expose their input fields, with no test surface.

This hides the tab list when the logic function has an `applicationId`, rendering the input fields directly. The test tab is also never treated as active for these nodes, which guards against a stale "test" tab state leaking in from a previously-opened custom function (the tab list shares one component instance id).

## Before

<img width="800" height="546" alt="CleanShot 2026-06-16 at 15 11 32@2x" src="https://github.com/user-attachments/assets/c4582e27-9a41-4ebd-a436-49404cefb515" />

## After

<img width="800" height="454" alt="CleanShot 2026-06-16 at 15 11 09@2x" src="https://github.com/user-attachments/assets/2756e07b-fa28-410a-be14-ad5f49e2d7ed" />


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/21671?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

