### PR TITLE
fix(front): sanitize chart filters when fields are deactivated or deleted

### DIFF
--- a/packages/twenty-front/src/modules/page-layout/widgets/graph/hooks/useGraphWidgetQueryCommon.ts
+++ b/packages/twenty-front/src/modules/page-layout/widgets/graph/hooks/useGraphWidgetQueryCommon.ts
@@ -46,7 +46,9 @@ export const useGraphWidgetQueryCommon = ({
   );
 
   const objectFieldMetadataIds = new Set(
-    objectMetadataItem.fields.map((field: { id: string }) => field.id),
+    objectMetadataItem.fields
+      .filter((field: { id: string; isActive: boolean }) => field.isActive)
+      .map((field: { id: string; isActive: boolean }) => field.id),
   );
 
   const { recordFilters: sanitizedRecordFilters } =

--- a/packages/twenty-front/src/modules/side-panel/pages/page-layout/components/ChartFiltersDeletedFieldsWarning.tsx
+++ b/packages/twenty-front/src/modules/side-panel/pages/page-layout/components/ChartFiltersDeletedFieldsWarning.tsx
@@ -24,7 +24,7 @@ export const ChartFiltersDeletedFieldsWarning = ({
   return (
     <SidePanelInformationBanner
       variant="warning"
-      message={t`This rule filters on one or more deleted fields that should be removed.`}
+      message={t`One or more filters reference deactivated or deleted fields and will be automatically removed on save.`}
     />
   );
 };

--- a/packages/twenty-front/src/modules/side-panel/pages/page-layout/components/ChartFiltersSettings.tsx
+++ b/packages/twenty-front/src/modules/side-panel/pages/page-layout/components/ChartFiltersSettings.tsx
@@ -4,6 +4,7 @@ import { usePageLayoutIdFromContextStore } from '@/side-panel/pages/page-layout/
 import { useUpdateCurrentWidgetConfig } from '@/side-panel/pages/page-layout/hooks/useUpdateCurrentWidgetConfig';
 import { type ChartWidget } from '@/side-panel/pages/page-layout/types/ChartWidget';
 import { type ChartWidgetConfiguration } from '@/side-panel/pages/page-layout/types/ChartWidgetConfiguration';
+import { dropChartRecordFiltersWithDeletedFields } from '@/side-panel/pages/page-layout/utils/dropChartRecordFiltersWithDeletedFields';
 import { getChartFiltersSettingsInstanceId } from '@/side-panel/pages/page-layout/utils/getChartFiltersSettingsInstanceId';
 
 import { type EnrichedObjectMetadataItem } from '@/object-metadata/types/EnrichedObjectMetadataItem';
@@ -75,12 +76,21 @@ export const ChartFiltersSettings = ({
     const existingRecordFilters = store.get(currentRecordFilters);
     const existingRecordFilterGroups = store.get(currentRecordFilterGroups);
 
+    const { recordFilters: sanitizedRecordFilters, recordFilterGroups: sanitizedRecordFilterGroups } =
+      dropChartRecordFiltersWithDeletedFields({
+        chartFilters: {
+          recordFilters: existingRecordFilters,
+          recordFilterGroups: existingRecordFilterGroups,
+        },
+        validFieldMetadataIds,
+      });
+
     updateCurrentWidgetConfig({
       objectMetadataId: objectMetadataItem.id,
       configToUpdate: {
         filter: {
-          recordFilters: existingRecordFilters,
-          recordFilterGroups: existingRecordFilterGroups,
+          recordFilters: sanitizedRecordFilters,
+          recordFilterGroups: sanitizedRecordFilterGroups,
         },
       } satisfies Partial<ChartWidgetConfiguration>,
     });

--- a/packages/twenty-front/src/modules/side-panel/pages/page-layout/utils/__tests__/dropChartRecordFiltersWithDeletedFields.test.ts
+++ b/packages/twenty-front/src/modules/side-panel/pages/page-layout/utils/__tests__/dropChartRecordFiltersWithDeletedFields.test.ts
@@ -29,9 +29,11 @@ describe('dropChartRecordFiltersWithDeletedFields', () => {
     ]);
   });
 
-  it('should preserve record filter groups', () => {
+  it('should preserve record filter groups that still contain valid filters', () => {
     const chartFilters: ChartFilters = {
-      recordFilters: [],
+      recordFilters: [
+        { id: 'filter-1', fieldMetadataId: 'valid-field', recordFilterGroupId: 'root' },
+      ],
       recordFilterGroups: [
         {
           id: 'root',
@@ -43,7 +45,7 @@ describe('dropChartRecordFiltersWithDeletedFields', () => {
 
     const result = dropChartRecordFiltersWithDeletedFields({
       chartFilters,
-      validFieldMetadataIds: new Set(),
+      validFieldMetadataIds: new Set(['valid-field']),
     });
 
     expect(result.recordFilterGroups).toEqual([
@@ -80,5 +82,93 @@ describe('dropChartRecordFiltersWithDeletedFields', () => {
     });
 
     expect(result.recordFilters).toEqual([]);
+  });
+
+  it('should remove orphaned root group when all its filters are dropped', () => {
+    const chartFilters: ChartFilters = {
+      recordFilters: [
+        { id: 'filter-1', fieldMetadataId: 'deleted-field', recordFilterGroupId: 'root' },
+      ],
+      recordFilterGroups: [
+        {
+          id: 'root',
+          parentRecordFilterGroupId: undefined,
+          logicalOperator: RecordFilterGroupLogicalOperator.AND,
+        },
+      ],
+    } as ChartFilters;
+
+    const result = dropChartRecordFiltersWithDeletedFields({
+      chartFilters,
+      validFieldMetadataIds: new Set(),
+    });
+
+    expect(result.recordFilters).toEqual([]);
+    expect(result.recordFilterGroups).toEqual([]);
+  });
+
+  it('should remove orphaned child group when its only filter is dropped, but keep root group if it has other valid children', () => {
+    const chartFilters: ChartFilters = {
+      recordFilters: [
+        { id: 'filter-1', fieldMetadataId: 'valid-field', recordFilterGroupId: 'root' },
+        { id: 'filter-2', fieldMetadataId: 'deleted-field', recordFilterGroupId: 'child' },
+      ],
+      recordFilterGroups: [
+        {
+          id: 'root',
+          parentRecordFilterGroupId: undefined,
+          logicalOperator: RecordFilterGroupLogicalOperator.AND,
+        },
+        {
+          id: 'child',
+          parentRecordFilterGroupId: 'root',
+          logicalOperator: RecordFilterGroupLogicalOperator.OR,
+        },
+      ],
+    } as ChartFilters;
+
+    const result = dropChartRecordFiltersWithDeletedFields({
+      chartFilters,
+      validFieldMetadataIds: new Set(['valid-field']),
+    });
+
+    expect(result.recordFilters).toEqual([
+      { id: 'filter-1', fieldMetadataId: 'valid-field', recordFilterGroupId: 'root' },
+    ]);
+    expect(result.recordFilterGroups).toEqual([
+      {
+        id: 'root',
+        parentRecordFilterGroupId: undefined,
+        logicalOperator: RecordFilterGroupLogicalOperator.AND,
+      },
+    ]);
+  });
+
+  it('should remove both child and root group when all filters are dropped', () => {
+    const chartFilters: ChartFilters = {
+      recordFilters: [
+        { id: 'filter-1', fieldMetadataId: 'deleted-field', recordFilterGroupId: 'child' },
+      ],
+      recordFilterGroups: [
+        {
+          id: 'root',
+          parentRecordFilterGroupId: undefined,
+          logicalOperator: RecordFilterGroupLogicalOperator.AND,
+        },
+        {
+          id: 'child',
+          parentRecordFilterGroupId: 'root',
+          logicalOperator: RecordFilterGroupLogicalOperator.OR,
+        },
+      ],
+    } as ChartFilters;
+
+    const result = dropChartRecordFiltersWithDeletedFields({
+      chartFilters,
+      validFieldMetadataIds: new Set(),
+    });
+
+    expect(result.recordFilters).toEqual([]);
+    expect(result.recordFilterGroups).toEqual([]);
   });
 });

--- a/packages/twenty-front/src/modules/side-panel/pages/page-layout/utils/dropChartRecordFiltersWithDeletedFields.ts
+++ b/packages/twenty-front/src/modules/side-panel/pages/page-layout/utils/dropChartRecordFiltersWithDeletedFields.ts
@@ -6,9 +6,53 @@ export const dropChartRecordFiltersWithDeletedFields = ({
 }: {
   chartFilters: ChartFilters;
   validFieldMetadataIds: Set<string>;
-}): ChartFilters => ({
-  ...chartFilters,
-  recordFilters: (chartFilters.recordFilters ?? []).filter((recordFilter) =>
-    validFieldMetadataIds.has(recordFilter.fieldMetadataId),
-  ),
-});
+}): ChartFilters => {
+  const validRecordFilters = (chartFilters.recordFilters ?? []).filter(
+    (recordFilter) => validFieldMetadataIds.has(recordFilter.fieldMetadataId),
+  );
+
+  const recordFilterGroups = chartFilters.recordFilterGroups ?? [];
+
+  // Iteratively remove groups that have no valid filters and no child groups remaining.
+  let remainingGroups = [...recordFilterGroups];
+  let changed = true;
+
+  while (changed) {
+    changed = false;
+    const remainingGroupIds = new Set(remainingGroups.map((g) => g.id));
+
+    const nonEmptyGroupIds = new Set(
+      [
+        ...validRecordFilters
+          .map((f) => f.recordFilterGroupId)
+          .filter((id): id is string => id !== undefined),
+        ...remainingGroups
+          .map((g) => g.parentRecordFilterGroupId)
+          .filter((id): id is string => id !== undefined),
+      ].filter((id) => remainingGroupIds.has(id)),
+    );
+
+    const nextGroups = remainingGroups.filter((g) =>
+      nonEmptyGroupIds.has(g.id),
+    );
+
+    if (nextGroups.length !== remainingGroups.length) {
+      remainingGroups = nextGroups;
+      changed = true;
+    }
+  }
+
+  const validRecordFiltersWithDroppedOrphanedGroups = validRecordFilters.filter(
+    (f) => {
+      const groupId = f.recordFilterGroupId;
+      if (groupId === undefined) return true;
+      return remainingGroups.some((g) => g.id === groupId);
+    },
+  );
+
+  return {
+    ...chartFilters,
+    recordFilters: validRecordFiltersWithDroppedOrphanedGroups,
+    recordFilterGroups: remainingGroups,
+  };
+};


### PR DESCRIPTION
## Summary

Fixes a bug in dashboard chart filters: when a field used in a chart filter is **deactivated or deleted**, the chart became unusable for filter editing.

Two distinct symptoms:
1. **Cannot add new filters and save** — an invalid filter (on a deactivated/deleted field) was re-persisted on every update, blocking newly added filters from taking effect.
2. **Cannot delete the filter on the deactivated/deleted field** — the stale filter kept coming back.

## Root causes

- `handleFiltersUpdate` (in `ChartFiltersSettings`) persisted **all** current filters to the widget draft without sanitizing against the set of active fields, so an invalid filter was repeatedly re-saved.
- `useGraphWidgetQueryCommon` treated **all** fields (including `isActive: false`) as valid when building the query filter, so deactivated-field filters were never dropped at query execution time (only fully-deleted ones were).

## Changes

- **`ChartFiltersSettings.tsx`** — sanitize filters via `dropChartRecordFiltersWithDeletedFields` before writing to the draft, dropping any filter whose `fieldMetadataId` is not in the active-fields set.
- **`useGraphWidgetQueryCommon.ts`** — restrict valid field IDs to `isActive` fields so deactivated-field filters are silently dropped at query time, consistent with the save path.
- **`dropChartRecordFiltersWithDeletedFields.ts`** — enhanced to also iteratively clean up orphaned filter groups left behind once their filters are removed (prevents inconsistent state where filters are dropped but empty groups remain).
- **`ChartFiltersDeletedFieldsWarning.tsx`** — updated warning copy to mention both deactivated and deleted fields and clarify filters are removed on save.
- **Tests** — updated existing tests and added cases for orphaned root/child group cleanup.

## Test plan

- [ ] Create a bar chart on a dashboard, add a filter on a field (e.g. `stage` on Opportunity)
- [ ] Deactivate that field — confirm the warning banner appears
- [ ] Add a new filter and save — confirm it saves and the deactivated-field filter is dropped
- [ ] Repeat with a deleted field
- [ ] Confirm the chart query renders without the stale filter
- [ ] `npx jest dropChartRecordFiltersWithDeletedFields`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/21680?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

