### PR TITLE
fix(server): add type guards to isMatchingTSVectorFilter to prevent runtime crash

### DIFF
--- a/packages/twenty-shared/src/utils/filter/utils/__tests__/isMatchingTSVectorFilter.test.ts
+++ b/packages/twenty-shared/src/utils/filter/utils/__tests__/isMatchingTSVectorFilter.test.ts
@@ -48,6 +48,53 @@ describe('isMatchingTSVectorFilter', () => {
     });
   });
 
+  describe('type safety', () => {
+    it('returns false when search is a number instead of string', () => {
+      expect(
+        isMatchingTSVectorFilter({
+          tsVectorFilter: { search: 123 as any },
+          value: 'test document',
+        }),
+      ).toBe(false);
+    });
+
+    it('returns false when search is null', () => {
+      expect(
+        isMatchingTSVectorFilter({
+          tsVectorFilter: { search: null as any },
+          value: 'test document',
+        }),
+      ).toBe(false);
+    });
+
+    it('returns false when search is an object', () => {
+      expect(
+        isMatchingTSVectorFilter({
+          tsVectorFilter: { search: {} as any },
+          value: 'test document',
+        }),
+      ).toBe(false);
+    });
+
+    it('returns false when value is not a string', () => {
+      expect(
+        isMatchingTSVectorFilter({
+          tsVectorFilter: { search: 'test' },
+          value: 123 as any,
+        }),
+      ).toBe(false);
+    });
+
+    it('returns false when both search and value are non-string', () => {
+      expect(
+        isMatchingTSVectorFilter({
+          tsVectorFilter: { search: 123 as any },
+          value: 456 as any,
+        }),
+      ).toBe(false);
+    });
+  });
+
   describe('error handling', () => {
     it('should throw error for unknown filter type', () => {
       expect(() =>

--- a/packages/twenty-shared/src/utils/filter/utils/isMatchingTSVectorFilter.ts
+++ b/packages/twenty-shared/src/utils/filter/utils/isMatchingTSVectorFilter.ts
@@ -14,6 +14,15 @@ export const isMatchingTSVectorFilter = ({
 
   switch (true) {
     case tsVectorFilter.search !== undefined: {
+      // Guard against non-string search values that crash .toLowerCase() / .split()
+      if (typeof tsVectorFilter.search !== 'string') {
+        return false;
+      }
+
+      if (typeof value !== 'string') {
+        return false;
+      }
+
       const searchQuery = tsVectorFilter.search.toLowerCase();
       const searchValue = value.toLowerCase();
       const searchWords = searchQuery.split(/\s+/).filter(Boolean);


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix — prevents a runtime `TypeError: e.split is not a function` crash in the realtime event matching path.

Fixes #21647

## What is the current behavior?

When `tsVectorFilter.search` is a non-string value (e.g. `number`, `null`, `object`) — which can happen in the realtime subscription event matching path — calling `.toLowerCase()` or `.split()` on it throws `TypeError: e.split is not a function`. This crashes the `isRecordMatchingRLSRowLevelPermissionPredicate` utility and aborts event matching for that event.

Reported error:
```
[Nest] 1 - ERROR [Event] e.split is not a function
TypeError: e.split is not a function
    at xn (/app/packages/twenty-shared/dist/utils-Cef6YHzD.js:1:27243)
    at R (/app/packages/twenty-shared/dist/utils-Cef6YHzD.js:1:26520)
    at Vn (/app/packages/twenty-shared/dist/utils-Cef6YHzD.js:1:29633)
    at isRecordMatchingRLSRowLevelPermissionPredicate
```

## What is the new behavior?

- Added `typeof` guards before `.toLowerCase()` and `.split()` calls in `isMatchingTSVectorFilter`
- When `tsVectorFilter.search` or `value` is not a string, the function returns `false` instead of crashing
- This is consistent with other filter matchers in `twenty-shared` that also return `false` for type mismatches
- Added 5 new test cases covering `number`, `null`, `object`, and mixed non-string edge cases

## Acceptance criteria

| Scenario | Before | After |
|----------|--------|-------|
| Normal string search | ✅ works | ✅ works (no change) |
| `search` is a number | 💥 crash | ✅ returns `false` |
| `search` is null | 💥 crash | ✅ returns `false` |
| `search` is an object | 💥 crash | ✅ returns `false` |
| `value` is non-string | 💥 crash | ✅ returns `false` |
| Both non-string | 💥 crash | ✅ returns `false` |

I have read the CONTRIBUTING.md file.
YES

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/21683?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

