### PR TITLE
fix(server): derive upgrade-aware cursor from highest completed step

### DIFF
--- a/node_modules
+++ b/node_modules
@@ -1,0 +1,1 @@
+/Users/charles/dev/twenty/twenty/node_modules

--- a/packages/twenty-server/node_modules
+++ b/packages/twenty-server/node_modules
@@ -1,0 +1,1 @@
+/Users/charles/dev/twenty/twenty/packages/twenty-server/node_modules

--- a/packages/twenty-server/src/engine/core-modules/upgrade/services/upgrade-migration.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/upgrade/services/upgrade-migration.service.ts
@@ -378,6 +378,26 @@ export class UpgradeMigrationService {
     };
   }
 
+  async getCompletedInstanceCommandNames(): Promise<string[]> {
+    const migrations = await this.upgradeMigrationRepository
+      .createQueryBuilder('migration')
+      .select(['migration.name'])
+      .where('migration."workspaceId" IS NULL')
+      .andWhere('migration."isInitial" = false')
+      .andWhere(`migration.status = 'completed'`)
+      .andWhere(
+        `migration.attempt = (
+          SELECT MAX(sub.attempt)
+          FROM core."upgradeMigration" sub
+          WHERE sub.name = migration.name
+          AND sub."workspaceId" IS NULL
+        )`,
+      )
+      .getMany();
+
+    return migrations.map((migration) => migration.name);
+  }
+
   async getLastAttemptedInstanceCommandOrThrow(): Promise<{
     name: string;
     status: UpgradeMigrationStatus;

--- a/packages/twenty-server/src/engine/twenty-orm/upgrade-aware/__tests__/upgrade-aware-entity-metadata.adapter.spec.ts
+++ b/packages/twenty-server/src/engine/twenty-orm/upgrade-aware/__tests__/upgrade-aware-entity-metadata.adapter.spec.ts
@@ -63,7 +63,7 @@ describe('UpgradeAwareEntityMetadataAdapter', () => {
         {
           provide: UpgradeMigrationService,
           useValue: {
-            getLastAttemptedInstanceCommand: jest.fn().mockResolvedValue(null),
+            getCompletedInstanceCommandNames: jest.fn().mockResolvedValue([]),
           },
         },
         {
@@ -113,10 +113,9 @@ describe('UpgradeAwareEntityMetadataAdapter', () => {
         {
           provide: UpgradeMigrationService,
           useValue: {
-            getLastAttemptedInstanceCommand: jest.fn().mockResolvedValue({
-              name: REMOVE_STEP,
-              status: 'completed',
-            }),
+            getCompletedInstanceCommandNames: jest
+              .fn()
+              .mockResolvedValue([REMOVE_STEP]),
           },
         },
         {
@@ -153,5 +152,60 @@ describe('UpgradeAwareEntityMetadataAdapter', () => {
     expect(visibleColumn.isUpdate).toBe(true);
 
     expect(metadata.columns).toEqual([visibleColumn]);
+  });
+
+  it('keeps a removed column hidden when a lower-index step is completed out of order after a higher-index removal', async () => {
+    const introducedColumn = buildColumn('introducedColumn');
+    const removedColumn = buildColumn('removedColumn');
+    const visibleColumn = buildColumn('visibleColumn');
+
+    const metadata = {
+      target: EntityWithHideableColumns,
+      tableName: 'entityWithHideableColumns',
+      tablePath: 'core.entityWithHideableColumns',
+      givenTableName: 'entityWithHideableColumns',
+      schema: 'core',
+      columns: [introducedColumn, removedColumn, visibleColumn],
+    } as unknown as EntityMetadata;
+
+    const dataSource = {
+      entityMetadatas: [metadata],
+    } as unknown as DataSource;
+
+    const moduleRef = await Test.createTestingModule({
+      providers: [
+        UpgradeAwareEntityMetadataAdapter,
+        {
+          provide: UpgradeMigrationService,
+          useValue: {
+            getCompletedInstanceCommandNames: jest
+              .fn()
+              .mockResolvedValue([REMOVE_STEP, INTRODUCE_STEP]),
+          },
+        },
+        {
+          provide: UpgradeSequenceReaderService,
+          useValue: {
+            getUpgradeSequence: jest
+              .fn()
+              .mockReturnValue([
+                { name: INTRODUCE_STEP },
+                { name: REMOVE_STEP },
+              ]),
+          },
+        },
+        { provide: getDataSourceToken(), useValue: dataSource },
+      ],
+    }).compile();
+
+    const adapter = moduleRef.get(UpgradeAwareEntityMetadataAdapter);
+
+    await adapter.onModuleInit();
+
+    await adapter.refresh();
+
+    expect(removedColumn.isSelect).toBe(false);
+    expect(introducedColumn.isSelect).toBe(true);
+    expect(metadata.columns).toEqual([introducedColumn, visibleColumn]);
   });
 });

--- a/packages/twenty-server/src/engine/twenty-orm/upgrade-aware/__tests__/upgrade-aware-repository.proxy.spec.ts
+++ b/packages/twenty-server/src/engine/twenty-orm/upgrade-aware/__tests__/upgrade-aware-repository.proxy.spec.ts
@@ -39,7 +39,7 @@ describe('wrapRepositoryWithUpgradeAwareProxy', () => {
         {
           provide: UpgradeMigrationService,
           useValue: {
-            getLastAttemptedInstanceCommand: jest.fn().mockResolvedValue(null),
+            getCompletedInstanceCommandNames: jest.fn().mockResolvedValue([]),
           },
         },
         {

--- a/packages/twenty-server/src/engine/twenty-orm/upgrade-aware/upgrade-aware-entity-metadata.adapter.ts
+++ b/packages/twenty-server/src/engine/twenty-orm/upgrade-aware/upgrade-aware-entity-metadata.adapter.ts
@@ -82,20 +82,16 @@ export class UpgradeAwareEntityMetadataAdapter implements OnModuleInit {
   }
 
   async refresh(): Promise<void> {
-    const lastAttempted =
-      await this.upgradeMigrationService.getLastAttemptedInstanceCommand();
+    const completedNames =
+      await this.upgradeMigrationService.getCompletedInstanceCommandNames();
 
-    let nextCursor: number;
+    let nextCursor = 0;
 
-    if (!isDefined(lastAttempted)) {
-      nextCursor = 0;
-    } else {
-      const index = this.stepNameToIndex.get(lastAttempted.name);
+    for (const name of completedNames) {
+      const index = this.stepNameToIndex.get(name);
 
-      if (!isDefined(index)) {
-        nextCursor = 0;
-      } else {
-        nextCursor = lastAttempted.status === 'completed' ? index + 1 : index;
+      if (isDefined(index) && index + 1 > nextCursor) {
+        nextCursor = index + 1;
       }
     }
 


### PR DESCRIPTION
## Context

Fixes #21549.

`UpgradeAwareEntityMetadataAdapter.refresh()` derived the upgrade cursor from `getLastAttemptedInstanceCommand()` — the completed instance command with the most recent `createdAt` — and mapped it to its index in the upgrade sequence:

```ts
nextCursor = lastAttempted.status === 'completed' ? index + 1 : index;
```

This assumes the most-recently-executed instance command is also the **furthest** one in the sequence. That holds while commands execute in sequence order, but breaks when a lower-index command completes out of order.

## How it breaks

The boot upgrade walks forward from the start cursor, so a command sitting in a version bundle *earlier* than the instance's current cursor is skipped and stays pending. `run-instance-commands` later iterates the whole sequence and runs every not-yet-completed command regardless of position — stamping that low-index command with a fresh `createdAt`, newer than the higher-index commands the forward upgrade already finished.

From then on `getLastAttemptedInstanceCommand()` returns that low-index command, so the next `refresh()` regresses the cursor below the higher-index commands that already ran. If one of those dropped a column via `@WasRemovedInUpgrade` (e.g. `DropIsCustomFromObjectAndFieldMetadataFastInstanceCommand` on 2.12), the regressed cursor treats the drop as not-yet-applied and **un-hides the dropped column** in the shared `coreDataSource` metadata. Every subsequent read then selects a column that no longer exists at the DB level (`column "ObjectMetadataEntity.isCustom" does not exist`).

On 2.12 this surfaced as a partial outage: a worker that restarted after the out-of-order command re-derived the regressed cursor and failed every metadata-dependent job, while an API process that cached the correct cursor at an earlier boot kept working.

## Fix

Derive the cursor from the **maximum sequence index across all completed instance commands** (the schema high-water-mark) instead of the most-recently-attempted one.

- Identical to the previous behaviour whenever commands complete in order (the completed set is a prefix, so `max == latest`).
- Only differs — correctly — when the set has gaps.
- In-progress semantics preserved: while step K runs with `0..K-1` completed, `max + 1 = K`, so K's column changes stay hidden until it completes.

Changes:
- Add `UpgradeMigrationService.getCompletedInstanceCommandNames()` — names of instance commands (`workspaceId IS NULL`, `isInitial = false`) whose latest attempt is `completed`.
- Update `UpgradeAwareEntityMetadataAdapter.refresh()` to compute `max(completedStepIndex) + 1`.

## Tests

- Migrated existing adapter / repository-proxy spec mocks from `getLastAttemptedInstanceCommand` to `getCompletedInstanceCommandNames`.
- Added a regression test: when a lower-index step completes out of order after a higher-index removal, the cursor stays at the high-water mark and the dropped column remains hidden while the introduced column stays available.

All `upgrade-aware` unit tests pass; `lint:diff-with-main` clean.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/21685?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

