### PR TITLE
feat(sdk): let docker:start choose the server version (pinned as code)

### DIFF
--- a/packages/create-twenty-app/src/constants/template/package.json
+++ b/packages/create-twenty-app/src/constants/template/package.json
@@ -9,6 +9,9 @@
   },
   "keywords": [],
   "packageManager": "yarn@4.9.2",
+  "twenty": {
+    "serverVersion": "TO-BE-GENERATED"
+  },
   "scripts": {
     "twenty": "twenty",
     "lint": "oxlint -c .oxlintrc.json .",

--- a/packages/create-twenty-app/src/create-app.command.ts
+++ b/packages/create-twenty-app/src/create-app.command.ts
@@ -15,8 +15,10 @@ import {
   ConfigService,
   DEV_API_KEY,
   DEV_API_URL,
+  getImageForVersion,
   serverStart,
 } from 'twenty-sdk/cli';
+import createTwentyAppPackageJson from 'package.json';
 import { isDefined, normalizeUrl } from 'twenty-shared/utils';
 import {
   getDockerInstallInstructions,
@@ -24,7 +26,10 @@ import {
 } from '@/utils/docker-install';
 
 const CURRENT_EXECUTION_DIRECTORY = process.env.INIT_CWD || process.cwd();
-const IMAGE = 'twentycrm/twenty-app-dev:latest';
+// Pin to the version this scaffolder ships, matching the generated app's
+// `twenty.serverVersion`, so the started server and the app stay in lockstep.
+const SERVER_VERSION = createTwentyAppPackageJson.version;
+const IMAGE = getImageForVersion(SERVER_VERSION);
 
 export type AuthenticationMethod = 'oauth' | 'apiKey';
 
@@ -299,6 +304,7 @@ export class CreateAppCommand {
     }
 
     const startResult = await serverStart({
+      version: SERVER_VERSION,
       onProgress: (message: string) => this.logDetail(message),
     });
 

--- a/packages/create-twenty-app/src/utils/__tests__/app-template.spec.ts
+++ b/packages/create-twenty-app/src/utils/__tests__/app-template.spec.ts
@@ -154,6 +154,9 @@ describe('copyBaseApplicationProject', () => {
     expect(packageJson.devDependencies['twenty-client-sdk']).toBe(
       createTwentyAppPackageJson.version,
     );
+    expect(packageJson.twenty.serverVersion).toBe(
+      createTwentyAppPackageJson.version,
+    );
   });
 
   it('should create an empty public directory in the scaffolded project', async () => {

--- a/packages/create-twenty-app/src/utils/app-template.ts
+++ b/packages/create-twenty-app/src/utils/app-template.ts
@@ -125,6 +125,13 @@ const updatePackageJson = async ({
   packageJson.devDependencies['twenty-client-sdk'] =
     createTwentyAppPackageJson.version;
 
+  // Pin the local server image to the version this app was scaffolded with so
+  // `twenty docker:start` is reproducible. Edit `twenty.serverVersion` to change it.
+  packageJson.twenty = {
+    ...packageJson.twenty,
+    serverVersion: createTwentyAppPackageJson.version,
+  };
+
   await fs.writeFile(
     join(appDirectory, 'package.json'),
     JSON.stringify(packageJson, null, 2),

--- a/packages/twenty-docs/developers/extend/apps/getting-started/local-server.mdx
+++ b/packages/twenty-docs/developers/extend/apps/getting-started/local-server.mdx
@@ -11,6 +11,7 @@ Use `yarn twenty docker:*` to control the local Twenty container:
 | Command | What it does |
 |---------|--------------|
 | `yarn twenty docker:start` | Start the server (pulls the image if needed) |
+| `yarn twenty docker:start 2.2.0` | Start a specific server version |
 | `yarn twenty docker:start --port 3030` | Start on a custom port |
 | `yarn twenty docker:stop` | Stop the server (preserves data) |
 | `yarn twenty docker:status` | Show URL, version, and login credentials |
@@ -20,6 +21,20 @@ Use `yarn twenty docker:*` to control the local Twenty container:
 | `yarn twenty docker:upgrade 2.2.0` | Upgrade to a specific version |
 
 Data persists across restarts in two Docker volumes (`twenty-app-dev-data` for PostgreSQL, `twenty-app-dev-storage` for files). Use `reset` to wipe everything.
+
+## Pinning the server version
+
+When no version is passed, `docker:start` uses the `twenty.serverVersion` field in your app's `package.json`, falling back to `latest`. Scaffolded apps pin this to the version they were created with, so the server stays reproducible as code:
+
+```json filename="package.json"
+{
+  "twenty": {
+    "serverVersion": "2.2.0"
+  }
+}
+```
+
+Pass a version explicitly to override the pin for a single run: `yarn twenty docker:start 2.3.0`. This only affects a freshly created container — an existing container keeps its image until you `docker:upgrade` or `docker:reset`.
 
 ## Upgrading the server image
 

--- a/packages/twenty-sdk/src/cli/commands/docker/index.ts
+++ b/packages/twenty-sdk/src/cli/commands/docker/index.ts
@@ -15,7 +15,10 @@ import chalk from 'chalk';
 import type { Command } from 'commander';
 import { execSync, spawnSync } from 'node:child_process';
 
-const startAction = async (options: { port?: string; test?: boolean }) => {
+const startAction = async (
+  version: string | undefined,
+  options: { port?: string; test?: boolean },
+) => {
   const defaultPort = options.test ? DEFAULT_TEST_PORT : DEFAULT_PORT;
   const port = options.port ? parseInt(options.port, 10) : defaultPort;
 
@@ -27,6 +30,7 @@ const startAction = async (options: { port?: string; test?: boolean }) => {
   const result = await serverStart({
     port,
     test: options.test,
+    version,
     onProgress: (message) => console.log(chalk.gray(message)),
   });
 
@@ -173,8 +177,10 @@ const upgradeAction = async (
 
 export const registerServerCommands = (program: Command): void => {
   program
-    .command('docker:start')
-    .description('Start the local Twenty container')
+    .command('docker:start [version]')
+    .description(
+      'Start the local Twenty container (version defaults to the app-pinned `twenty.serverVersion`, then `latest`)',
+    )
     .option('-p, --port <port>', 'HTTP port')
     .option('--test', 'Start a separate test instance (port 2021)')
     .action(startAction);
@@ -225,13 +231,18 @@ export const registerServerCommands = (program: Command): void => {
     );
 
   server
-    .command('start')
+    .command('start [version]')
     .option('-p, --port <port>', 'HTTP port')
     .option('--test', 'Start a separate test instance (port 2021)')
-    .action(async (options: { port?: string; test?: boolean }) => {
-      deprecate('start', 'docker:start');
-      await startAction(options);
-    });
+    .action(
+      async (
+        version: string | undefined,
+        options: { port?: string; test?: boolean },
+      ) => {
+        deprecate('start', 'docker:start');
+        await startAction(version, options);
+      },
+    );
 
   server
     .command('stop')

--- a/packages/twenty-sdk/src/cli/operations/index.ts
+++ b/packages/twenty-sdk/src/cli/operations/index.ts
@@ -40,6 +40,7 @@ export {
   getImageDigest,
   getImageForVersion,
 } from '@/cli/utilities/server/docker-container';
+export { getAppServerVersion } from '@/cli/utilities/version/get-app-server-version';
 
 // Config
 export { ConfigService } from '@/cli/utilities/config/config-service';

--- a/packages/twenty-sdk/src/cli/operations/server-start.ts
+++ b/packages/twenty-sdk/src/cli/operations/server-start.ts
@@ -10,7 +10,7 @@ import {
   DEFAULT_TEST_PORT,
   getContainerPort,
   getDockerNotRunningMessage,
-  IMAGE,
+  getImageForVersion,
   isContainerRunning,
   TEST_CONTAINER_NAME,
 } from '@/cli/utilities/server/docker-container';
@@ -19,6 +19,7 @@ import {
   detectLocalServer,
 } from '@/cli/utilities/server/detect-local-server';
 import { checkServerVersionCompatibility } from '@/cli/utilities/version/check-server-version-compatibility';
+import { getAppServerVersion } from '@/cli/utilities/version/get-app-server-version';
 import { execSync, spawn, spawnSync } from 'node:child_process';
 import chalk from 'chalk';
 
@@ -107,6 +108,9 @@ const waitForHealthy = async (
 export type ServerStartOptions = {
   port?: number;
   test?: boolean;
+  // Server image version to run. Falls back to the app's pinned
+  // `twenty.serverVersion` (package.json), then to 'latest'.
+  version?: string;
   onProgress?: (message: string) => void;
 };
 
@@ -119,6 +123,9 @@ const innerServerStart = async (
   options: ServerStartOptions = {},
 ): Promise<CommandResult<ServerStartResult>> => {
   const { onProgress, test: isTest } = options;
+
+  const version = options.version ?? getAppServerVersion() ?? 'latest';
+  const image = getImageForVersion(version);
 
   const containerName = isTest ? TEST_CONTAINER_NAME : CONTAINER_NAME;
   const defaultPort = isTest ? DEFAULT_TEST_PORT : DEFAULT_PORT;
@@ -211,7 +218,9 @@ const innerServerStart = async (
     onProgress?.('Starting existing container...');
     execSync(`docker start ${containerName}`, { stdio: 'ignore' });
   } else {
-    onProgress?.('Pulling Docker image and starting Twenty container...');
+    onProgress?.(
+      `Pulling Docker image (${image}) and starting Twenty container...`,
+    );
 
     const runResult = spawnSync(
       'docker',
@@ -230,7 +239,7 @@ const innerServerStart = async (
         `${volumeData}:/data/postgres`,
         '-v',
         `${volumeStorage}:/app/packages/twenty-server/.local-storage`,
-        IMAGE,
+        image,
       ],
       { stdio: 'inherit' },
     );

--- a/packages/twenty-sdk/src/cli/utilities/version/__tests__/get-app-server-version.test.ts
+++ b/packages/twenty-sdk/src/cli/utilities/version/__tests__/get-app-server-version.test.ts
@@ -1,0 +1,63 @@
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { getAppServerVersion } from '@/cli/utilities/version/get-app-server-version';
+
+const createPackageJson = (contents: unknown): string => {
+  const dir = mkdtempSync(join(tmpdir(), 'twenty-app-server-version-'));
+
+  writeFileSync(join(dir, 'package.json'), JSON.stringify(contents), 'utf-8');
+
+  return dir;
+};
+
+describe('getAppServerVersion', () => {
+  const createdDirs: string[] = [];
+
+  const seed = (contents: unknown): string => {
+    const dir = createPackageJson(contents);
+
+    createdDirs.push(dir);
+
+    return dir;
+  };
+
+  afterEach(() => {
+    while (createdDirs.length > 0) {
+      rmSync(createdDirs.pop() as string, { recursive: true, force: true });
+    }
+  });
+
+  it('returns the pinned twenty.serverVersion', () => {
+    const dir = seed({ twenty: { serverVersion: '1.4.2' } });
+
+    expect(getAppServerVersion(dir)).toBe('1.4.2');
+  });
+
+  it('trims surrounding whitespace', () => {
+    const dir = seed({ twenty: { serverVersion: '  1.4.2  ' } });
+
+    expect(getAppServerVersion(dir)).toBe('1.4.2');
+  });
+
+  it('returns null when the field is missing', () => {
+    const dir = seed({ name: 'my-app' });
+
+    expect(getAppServerVersion(dir)).toBeNull();
+  });
+
+  it('returns null when the field is empty', () => {
+    const dir = seed({ twenty: { serverVersion: '   ' } });
+
+    expect(getAppServerVersion(dir)).toBeNull();
+  });
+
+  it('returns null when no package.json exists', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'twenty-app-server-version-empty-'));
+
+    createdDirs.push(dir);
+
+    expect(getAppServerVersion(dir)).toBeNull();
+  });
+});

--- a/packages/twenty-sdk/src/cli/utilities/version/get-app-server-version.ts
+++ b/packages/twenty-sdk/src/cli/utilities/version/get-app-server-version.ts
@@ -1,0 +1,23 @@
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+import { CURRENT_EXECUTION_DIRECTORY } from '@/cli/utilities/config/current-execution-directory';
+
+// Reads the server version an app pins in its package.json under `twenty.serverVersion`.
+// Lets each generated app declare which Twenty server image it runs against, as code.
+// Returns null when no package.json, no field, or an empty value is found.
+export const getAppServerVersion = (
+  cwd: string = CURRENT_EXECUTION_DIRECTORY,
+): string | null => {
+  try {
+    const pkg = JSON.parse(
+      readFileSync(join(cwd, 'package.json'), 'utf-8'),
+    ) as { twenty?: { serverVersion?: string } };
+
+    const serverVersion = pkg.twenty?.serverVersion?.trim();
+
+    return serverVersion ? serverVersion : null;
+  } catch {
+    return null;
+  }
+};


### PR DESCRIPTION
## What

`yarn twenty docker:start` always ran `twentycrm/twenty-app-dev:latest`. This makes the version selectable, with the chosen version living **as code** in each app's `package.json`.

Two layers of resolution:

1. **Explicit flag** — `yarn twenty docker:start [version]`, mirroring the existing `docker:upgrade [version]`.
2. **App-pinned default** — when no version is passed, `docker:start` reads `twenty.serverVersion` from the app's `package.json`, falling back to `latest`.

Scaffolded apps now pin `twenty.serverVersion` to the version they were created with (next to the existing `twenty-sdk` / `twenty-client-sdk` pins), so the local server is reproducible. `create-twenty-app` also pulls/starts that pinned image instead of `latest`.

```json filename="package.json"
{
  "twenty": {
    "serverVersion": "2.2.0"
  }
}
```

## Changes

- `twenty-sdk`: new `getAppServerVersion()` util reads `twenty.serverVersion` from the cwd's `package.json`; `serverStart` gains a `version` option and resolves `option → app pin → latest`, building the image via `getImageForVersion()`; `docker:start [version]` (and the deprecated `server start [version]` alias) wired up.
- `create-twenty-app`: template `package.json` gets a `twenty.serverVersion` field, filled with the scaffolder's version; `create-app` pins its background pull + `serverStart` to that version.
- Docs: `local-server.mdx` documents version selection and the pin.

## Behavior notes

- Version only matters when **creating** a fresh container — an existing container keeps its image until `docker:upgrade` / `docker:reset` (unchanged).
- Default with no pin and no flag is still `latest`.

## Testing

- New unit tests for `getAppServerVersion` (5 cases).
- Extended the `app-template` scaffolding test to assert `twenty.serverVersion`.
- `twenty-sdk` cli vitest suite (273) and `create-twenty-app` jest suite (9) pass; oxlint + oxfmt clean on changed files.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/21686?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

