### PR TITLE
feat(workflow): phase A — backfill + dual-write workflowVersion to core

### DIFF
--- a/packages/twenty-server/src/database/commands/upgrade-version-command/2-14/2-14-upgrade-version-command.module.ts
+++ b/packages/twenty-server/src/database/commands/upgrade-version-command/2-14/2-14-upgrade-version-command.module.ts
@@ -1,10 +1,13 @@
 import { Module } from '@nestjs/common';
 
 import { WorkspaceIteratorModule } from 'src/database/commands/command-runners/workspace-iterator.module';
+import { BackfillWorkflowVersionsToCoreCommand } from 'src/database/commands/upgrade-version-command/2-14/2-14-workspace-command-1781700000000-backfill-workflow-versions-to-core.command';
 import { SyncCallRecordingRequestStatusCommand } from 'src/database/commands/upgrade-version-command/2-14/2-14-workspace-command-1799000065000-sync-call-recording-request-status.command';
 import { DropCalendarEventRecordingPreferenceCommand } from 'src/database/commands/upgrade-version-command/2-14/2-14-workspace-command-1799000066000-drop-calendar-event-recording-preference.command';
 import { FixStandardRelationFieldLabelsIconsCommand } from 'src/database/commands/upgrade-version-command/2-14/2-14-workspace-command-1799000040000-fix-standard-relation-field-labels-icons.command';
 import { ApplicationModule } from 'src/engine/core-modules/application/application.module';
+import { WorkflowVersionCoreModule } from 'src/engine/core-modules/workflow/workflow-version-core.module';
+import { GlobalWorkspaceDataSourceModule } from 'src/engine/twenty-orm/global-workspace-datasource/global-workspace-datasource.module';
 import { WorkspaceCacheModule } from 'src/engine/workspace-cache/workspace-cache.module';
 import { WorkspaceMigrationModule } from 'src/engine/workspace-manager/workspace-migration/workspace-migration.module';
 
@@ -14,11 +17,14 @@ import { WorkspaceMigrationModule } from 'src/engine/workspace-manager/workspace
     WorkspaceCacheModule,
     WorkspaceIteratorModule,
     WorkspaceMigrationModule,
+    WorkflowVersionCoreModule,
+    GlobalWorkspaceDataSourceModule,
   ],
   providers: [
     FixStandardRelationFieldLabelsIconsCommand,
     SyncCallRecordingRequestStatusCommand,
     DropCalendarEventRecordingPreferenceCommand,
+    BackfillWorkflowVersionsToCoreCommand,
   ],
 })
 export class V2_14_UpgradeVersionCommandModule {}

--- a/packages/twenty-server/src/database/commands/upgrade-version-command/2-14/2-14-workspace-command-1781700000000-backfill-workflow-versions-to-core.command.ts
+++ b/packages/twenty-server/src/database/commands/upgrade-version-command/2-14/2-14-workspace-command-1781700000000-backfill-workflow-versions-to-core.command.ts
@@ -1,0 +1,104 @@
+import { Command } from 'nest-commander';
+import { isDefined } from 'twenty-shared/utils';
+
+import { ActiveOrSuspendedWorkspaceCommandRunner } from 'src/database/commands/command-runners/active-or-suspended-workspace.command-runner';
+import { WorkspaceIteratorService } from 'src/database/commands/command-runners/workspace-iterator.service';
+import { type RunOnWorkspaceArgs } from 'src/database/commands/command-runners/workspace.command-runner';
+import { RegisteredWorkspaceCommand } from 'src/engine/core-modules/upgrade/decorators/registered-workspace-command.decorator';
+import {
+  WorkflowVersionEntity,
+  WorkflowVersionStatus as CoreWorkflowVersionStatus,
+} from 'src/engine/core-modules/workflow/entities/workflow-version.entity';
+import { GlobalWorkspaceOrmManager } from 'src/engine/twenty-orm/global-workspace-datasource/global-workspace-orm.manager';
+import { buildSystemAuthContext } from 'src/engine/twenty-orm/utils/build-system-auth-context.util';
+import { InjectWorkspaceScopedRepository } from 'src/engine/twenty-orm/workspace-scoped-repository/inject-workspace-scoped-repository.decorator';
+import { WorkspaceScopedRepository } from 'src/engine/twenty-orm/workspace-scoped-repository/workspace-scoped-repository';
+import { type WorkflowVersionWorkspaceEntity } from 'src/modules/workflow/common/standard-objects/workflow-version.workspace-entity';
+
+const UPSERT_CHUNK_SIZE = 100;
+
+@RegisteredWorkspaceCommand('2.14.0', 1781700000000)
+@Command({
+  name: 'upgrade:2-14:backfill-workflow-versions-to-core',
+  description:
+    'Copy workspace workflowVersion rows into the core WorkflowVersionEntity, preserving id (idempotent). --dry-run reports drift.',
+})
+export class BackfillWorkflowVersionsToCoreCommand extends ActiveOrSuspendedWorkspaceCommandRunner {
+  constructor(
+    protected readonly workspaceIteratorService: WorkspaceIteratorService,
+    private readonly globalWorkspaceOrmManager: GlobalWorkspaceOrmManager,
+    @InjectWorkspaceScopedRepository(WorkflowVersionEntity)
+    private readonly coreWorkflowVersionRepository: WorkspaceScopedRepository<WorkflowVersionEntity>,
+  ) {
+    super(workspaceIteratorService);
+  }
+
+  override async runOnWorkspace({
+    workspaceId,
+    options,
+  }: RunOnWorkspaceArgs): Promise<void> {
+    const isDryRun = options.dryRun ?? false;
+
+    const workspaceWorkflowVersions =
+      await this.readWorkspaceWorkflowVersions(workspaceId);
+
+    if (workspaceWorkflowVersions.length === 0) {
+      this.logger.log(`No workflowVersion rows for workspace ${workspaceId}`);
+
+      return;
+    }
+
+    if (isDryRun) {
+      const alreadyInCore = await this.coreWorkflowVersionRepository.count(
+        workspaceId,
+        { withDeleted: true },
+      );
+
+      this.logger.log(
+        `[DRY RUN] workspace ${workspaceId}: ${workspaceWorkflowVersions.length} workspace versions, ${alreadyInCore} already in core`,
+      );
+
+      return;
+    }
+
+    const entities = workspaceWorkflowVersions.map((record) => ({
+      id: record.id,
+      workflowId: record.workflowId,
+      name: record.name ?? null,
+      status: record.status as unknown as CoreWorkflowVersionStatus,
+      position: record.position ?? 0,
+      trigger: record.trigger ?? null,
+      steps: record.steps ?? null,
+      deletedAt: isDefined(record.deletedAt) ? new Date(record.deletedAt) : null,
+    }));
+
+    for (let index = 0; index < entities.length; index += UPSERT_CHUNK_SIZE) {
+      await this.coreWorkflowVersionRepository.upsert(
+        workspaceId,
+        entities.slice(index, index + UPSERT_CHUNK_SIZE),
+        ['id'],
+      );
+    }
+
+    this.logger.log(
+      `Backfilled ${entities.length} workflow versions into core for workspace ${workspaceId}`,
+    );
+  }
+
+  private async readWorkspaceWorkflowVersions(
+    workspaceId: string,
+  ): Promise<WorkflowVersionWorkspaceEntity[]> {
+    const workflowVersionRepository =
+      await this.globalWorkspaceOrmManager.getRepository<WorkflowVersionWorkspaceEntity>(
+        workspaceId,
+        'workflowVersion',
+      );
+
+    const authContext = buildSystemAuthContext(workspaceId);
+
+    return this.globalWorkspaceOrmManager.executeInWorkspaceContext(
+      () => workflowVersionRepository.find({ withDeleted: true }),
+      authContext,
+    );
+  }
+}

--- a/packages/twenty-server/src/engine/core-modules/workflow/workflow-version-core.module.ts
+++ b/packages/twenty-server/src/engine/core-modules/workflow/workflow-version-core.module.ts
@@ -3,6 +3,7 @@ import { TypeOrmModule } from '@nestjs/typeorm';
 
 import { WorkflowVersionEntity } from 'src/engine/core-modules/workflow/entities/workflow-version.entity';
 import { WorkspaceWorkflowAutomatedTriggerMapCacheService } from 'src/engine/core-modules/workflow/services/workspace-workflow-automated-trigger-map-cache.service';
+import { getWorkspaceScopedRepositoryToken } from 'src/engine/twenty-orm/workspace-scoped-repository/get-workspace-scoped-repository-token.util';
 import { provideWorkspaceScopedRepository } from 'src/engine/twenty-orm/workspace-scoped-repository/provide-workspace-scoped-repository';
 
 @Module({
@@ -11,6 +12,10 @@ import { provideWorkspaceScopedRepository } from 'src/engine/twenty-orm/workspac
     WorkspaceWorkflowAutomatedTriggerMapCacheService,
     provideWorkspaceScopedRepository(WorkflowVersionEntity),
   ],
-  exports: [TypeOrmModule, WorkspaceWorkflowAutomatedTriggerMapCacheService],
+  exports: [
+    TypeOrmModule,
+    WorkspaceWorkflowAutomatedTriggerMapCacheService,
+    getWorkspaceScopedRepositoryToken(WorkflowVersionEntity),
+  ],
 })
 export class WorkflowVersionCoreModule {}

--- a/packages/twenty-server/src/modules/workflow/workflow-trigger/automated-trigger/automated-trigger.module.ts
+++ b/packages/twenty-server/src/modules/workflow/workflow-trigger/automated-trigger/automated-trigger.module.ts
@@ -2,13 +2,17 @@ import { Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
 
 import { CacheStorageModule } from 'src/engine/core-modules/cache-storage/cache-storage.module';
+import { FeatureFlagModule } from 'src/engine/core-modules/feature-flag/feature-flag.module';
+import { WorkflowVersionCoreModule } from 'src/engine/core-modules/workflow/workflow-version-core.module';
 import { WorkspaceEntity } from 'src/engine/core-modules/workspace/workspace.entity';
+import { WorkspaceCacheModule } from 'src/engine/workspace-cache/workspace-cache.module';
 import { WorkspaceDataSourceModule } from 'src/engine/workspace-datasource/workspace-datasource.module';
 import { WorkflowCommonModule } from 'src/modules/workflow/common/workflow-common.module';
 import { AutomatedTriggerWorkspaceService } from 'src/modules/workflow/workflow-trigger/automated-trigger/automated-trigger.workspace-service';
 import { WorkflowCronTriggerCronCommand } from 'src/modules/workflow/workflow-trigger/automated-trigger/crons/commands/workflow-cron-trigger.cron.command';
 import { WorkflowCronTriggerCronJob } from 'src/modules/workflow/workflow-trigger/automated-trigger/crons/jobs/workflow-cron-trigger-cron.job';
 import { WorkflowDatabaseEventTriggerListener } from 'src/modules/workflow/workflow-trigger/automated-trigger/listeners/workflow-database-event-trigger.listener';
+import { WorkflowVersionCoreSyncListener } from 'src/modules/workflow/workflow-trigger/automated-trigger/listeners/workflow-version-core-sync.listener';
 
 @Module({
   imports: [
@@ -16,10 +20,14 @@ import { WorkflowDatabaseEventTriggerListener } from 'src/modules/workflow/workf
     CacheStorageModule,
     WorkflowCommonModule,
     WorkspaceDataSourceModule,
+    WorkflowVersionCoreModule,
+    FeatureFlagModule,
+    WorkspaceCacheModule,
   ],
   providers: [
     AutomatedTriggerWorkspaceService,
     WorkflowDatabaseEventTriggerListener,
+    WorkflowVersionCoreSyncListener,
     WorkflowCronTriggerCronJob,
     WorkflowCronTriggerCronCommand,
   ],

--- a/packages/twenty-server/src/modules/workflow/workflow-trigger/automated-trigger/listeners/workflow-version-core-sync.listener.ts
+++ b/packages/twenty-server/src/modules/workflow/workflow-trigger/automated-trigger/listeners/workflow-version-core-sync.listener.ts
@@ -1,0 +1,162 @@
+import { Injectable } from '@nestjs/common';
+
+import {
+  type ObjectRecordCreateEvent,
+  type ObjectRecordDeleteEvent,
+  type ObjectRecordDestroyEvent,
+  type ObjectRecordUpdateEvent,
+} from 'twenty-shared/database-events';
+import { FeatureFlagKey } from 'twenty-shared/types';
+import { isDefined } from 'twenty-shared/utils';
+import { In } from 'typeorm';
+
+import { OnDatabaseBatchEvent } from 'src/engine/api/graphql/graphql-query-runner/decorators/on-database-batch-event.decorator';
+import { DatabaseEventAction } from 'src/engine/api/graphql/graphql-query-runner/enums/database-event-action';
+import { FeatureFlagService } from 'src/engine/core-modules/feature-flag/services/feature-flag.service';
+import {
+  WorkflowVersionEntity,
+  WorkflowVersionStatus as CoreWorkflowVersionStatus,
+} from 'src/engine/core-modules/workflow/entities/workflow-version.entity';
+import { InjectWorkspaceScopedRepository } from 'src/engine/twenty-orm/workspace-scoped-repository/inject-workspace-scoped-repository.decorator';
+import { WorkspaceScopedRepository } from 'src/engine/twenty-orm/workspace-scoped-repository/workspace-scoped-repository';
+import { WorkspaceCacheService } from 'src/engine/workspace-cache/services/workspace-cache.service';
+import { type CustomWorkspaceEventBatch } from 'src/engine/workspace-event-emitter/types/custom-workspace-batch-event.type';
+import { type WorkflowVersionWorkspaceEntity } from 'src/modules/workflow/common/standard-objects/workflow-version.workspace-entity';
+
+// Phase A dual-write: mirror workspace `workflowVersion` writes into the core
+// `WorkflowVersionEntity` (sharing the same id) so core stays populated before
+// reads switch in Phase B. Gated by IS_WORKFLOW_VERSION_IN_CORE_ENABLED and
+// removed in Phase C once the workspace columns are dropped.
+@Injectable()
+export class WorkflowVersionCoreSyncListener {
+  constructor(
+    @InjectWorkspaceScopedRepository(WorkflowVersionEntity)
+    private readonly coreWorkflowVersionRepository: WorkspaceScopedRepository<WorkflowVersionEntity>,
+    private readonly featureFlagService: FeatureFlagService,
+    private readonly workspaceCacheService: WorkspaceCacheService,
+  ) {}
+
+  @OnDatabaseBatchEvent('workflowVersion', DatabaseEventAction.CREATED)
+  async handleCreated(
+    batchEvent: CustomWorkspaceEventBatch<
+      ObjectRecordCreateEvent<WorkflowVersionWorkspaceEntity>
+    >,
+  ): Promise<void> {
+    await this.mirror(
+      batchEvent.workspaceId,
+      batchEvent.events.map((event) => event.properties.after),
+    );
+  }
+
+  @OnDatabaseBatchEvent('workflowVersion', DatabaseEventAction.UPDATED)
+  async handleUpdated(
+    batchEvent: CustomWorkspaceEventBatch<
+      ObjectRecordUpdateEvent<WorkflowVersionWorkspaceEntity>
+    >,
+  ): Promise<void> {
+    await this.mirror(
+      batchEvent.workspaceId,
+      batchEvent.events.map((event) => event.properties.after),
+    );
+  }
+
+  @OnDatabaseBatchEvent('workflowVersion', DatabaseEventAction.DELETED)
+  async handleDeleted(
+    batchEvent: CustomWorkspaceEventBatch<
+      ObjectRecordDeleteEvent<WorkflowVersionWorkspaceEntity>
+    >,
+  ): Promise<void> {
+    const { workspaceId } = batchEvent;
+
+    if (!isDefined(workspaceId) || !(await this.isEnabled(workspaceId))) {
+      return;
+    }
+
+    const ids = batchEvent.events
+      .map((event) => event.properties.before?.id)
+      .filter(isDefined);
+
+    if (ids.length === 0) {
+      return;
+    }
+
+    await this.coreWorkflowVersionRepository.softDelete(workspaceId, {
+      id: In(ids),
+    });
+    await this.flushCache(workspaceId);
+  }
+
+  @OnDatabaseBatchEvent('workflowVersion', DatabaseEventAction.DESTROYED)
+  async handleDestroyed(
+    batchEvent: CustomWorkspaceEventBatch<
+      ObjectRecordDestroyEvent<WorkflowVersionWorkspaceEntity>
+    >,
+  ): Promise<void> {
+    const { workspaceId } = batchEvent;
+
+    if (!isDefined(workspaceId) || !(await this.isEnabled(workspaceId))) {
+      return;
+    }
+
+    const ids = batchEvent.events
+      .map((event) => event.properties.before?.id)
+      .filter(isDefined);
+
+    if (ids.length === 0) {
+      return;
+    }
+
+    await this.coreWorkflowVersionRepository.delete(workspaceId, {
+      id: In(ids),
+    });
+    await this.flushCache(workspaceId);
+  }
+
+  private async mirror(
+    workspaceId: string | undefined,
+    records: WorkflowVersionWorkspaceEntity[],
+  ): Promise<void> {
+    if (!isDefined(workspaceId) || !(await this.isEnabled(workspaceId))) {
+      return;
+    }
+
+    const entities = records
+      .filter((record) => isDefined(record?.id))
+      .map((record) => ({
+        id: record.id,
+        workflowId: record.workflowId,
+        name: record.name ?? null,
+        status: record.status as unknown as CoreWorkflowVersionStatus,
+        position: record.position ?? 0,
+        trigger: record.trigger ?? null,
+        steps: record.steps ?? null,
+        // Active records have deletedAt null; setting it explicitly also
+        // restores a previously soft-deleted core row.
+        deletedAt: isDefined(record.deletedAt)
+          ? new Date(record.deletedAt)
+          : null,
+      }));
+
+    if (entities.length === 0) {
+      return;
+    }
+
+    await this.coreWorkflowVersionRepository.upsert(workspaceId, entities, [
+      'id',
+    ]);
+    await this.flushCache(workspaceId);
+  }
+
+  private async isEnabled(workspaceId: string): Promise<boolean> {
+    return this.featureFlagService.isFeatureEnabled(
+      FeatureFlagKey.IS_WORKFLOW_VERSION_IN_CORE_ENABLED,
+      workspaceId,
+    );
+  }
+
+  private async flushCache(workspaceId: string): Promise<void> {
+    await this.workspaceCacheService.flush(workspaceId, [
+      'workflowAutomatedTriggerMaps',
+    ]);
+  }
+}


### PR DESCRIPTION
## What

**Phase A** of the `workflowVersion` → core migration: populate the core `WorkflowVersionEntity` from the workspace `workflowVersion` object, behind `IS_WORKFLOW_VERSION_IN_CORE_ENABLED`. **No behavior change** — reads still come from the workspace object; this just keeps core in sync so Phase B can switch reads safely.

> Stacked on **#21674** (Phase 0). Base branch is `claude/workflow-version-to-core`; review/merge that first. Draft.

## Included
- **`WorkflowVersionCoreSyncListener`** (dual-write) — `@OnDatabaseBatchEvent('workflowVersion', …)` for CREATE/UPDATE/DELETE/DESTROY, mirroring each workspace `workflowVersion` into core **sharing the same id** via the workspace-scoped repository, then flushing the `workflowAutomatedTriggerMaps` cache. Gated by the feature flag. Placed in `automated-trigger.module` (already in the worker graph where these events fire).
- **`BackfillWorkflowVersionsToCoreCommand`** (workspace command, `2-14`) — idempotently upserts every workspace `workflowVersion` into core, preserving id. `--dry-run` reports drift, so it doubles as the reconciliation command.
- **`WorkflowVersionCoreModule`** now exports the scoped-repository token so both consumers inject the same guarded repository.

## Design notes
- **Dual-write via DB events**, not threaded through each service method — captures all write paths centrally and is removed cleanly in Phase C.
- **Id-sharing** (workspace shell row id == core row id) means no extra soft-ref column; the eventual Phase B builder fetches core data by the same id (dashboard/`pageLayout` style).
- **Cache flush** on every mirrored write keeps `workflowAutomatedTriggerMaps` correct for the future cron/db-event dispatch (Phase B); flush is lazy (recompute on next read).
- Workspace `workflowVersion.status` enum → core enum via cast (identical values; unified in Phase C).

## Verification
- ✅ `oxlint` (0 errors, incl. the `prefer-workspace-scoped-repository` rule) and `oxfmt` clean on all changed files.
- ⏳ Type-aware typecheck still deferred — `twenty-server:typecheck`/`build` depend on `twenty-shared:build`, currently failing on pre-existing `tsgo` errors (`resolveRelativeDateFilter*.ts`, identical to main). Once green: `nx typecheck twenty-server`, then run the backfill on a reset DB and confirm core rows match workspace by id via the Postgres MCP, and that toggling the flag mirrors live writes.

## Review focus
The dual-write listener (event coverage + id-sharing + cache flush) and the backfill command's idempotency. This is the groundwork before Phase B switches reads (dispatch/runner/builder) to core.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/21687?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

