### PR TITLE
Show app logo and name in workflow step side panel header

### DIFF
--- a/packages/twenty-front/src/modules/logic-functions/hooks/useLogicFunctionThirdPartyApplication.ts
+++ b/packages/twenty-front/src/modules/logic-functions/hooks/useLogicFunctionThirdPartyApplication.ts
@@ -1,0 +1,35 @@
+import { useApplicationChipData } from '@/applications/hooks/useApplicationChipData';
+import { useIsThirdPartyApplication } from '@/applications/hooks/useIsThirdPartyApplication';
+import { logicFunctionsSelector } from '@/logic-functions/states/logicFunctionsSelector';
+import { useAtomStateValue } from '@/ui/utilities/state/jotai/hooks/useAtomStateValue';
+import { isDefined } from 'twenty-shared/utils';
+
+type LogicFunctionThirdPartyApplication = {
+  applicationId: string;
+  name: string;
+};
+
+export const useLogicFunctionThirdPartyApplication = (
+  logicFunctionId?: string,
+): LogicFunctionThirdPartyApplication | undefined => {
+  const logicFunctions = useAtomStateValue(logicFunctionsSelector);
+
+  const applicationId = isDefined(logicFunctionId)
+    ? logicFunctions.find(
+        (logicFunction) => logicFunction.id === logicFunctionId,
+      )?.applicationId
+    : undefined;
+
+  const isThirdPartyApplication = useIsThirdPartyApplication(applicationId);
+
+  const { applicationChipData } = useApplicationChipData({ applicationId });
+
+  if (!isThirdPartyApplication || !isDefined(applicationId)) {
+    return undefined;
+  }
+
+  return {
+    applicationId,
+    name: applicationChipData.name,
+  };
+};

--- a/packages/twenty-front/src/modules/logic-functions/hooks/useLogicFunctionThirdPartyApplicationInformation.ts
+++ b/packages/twenty-front/src/modules/logic-functions/hooks/useLogicFunctionThirdPartyApplicationInformation.ts
@@ -4,14 +4,14 @@ import { logicFunctionsSelector } from '@/logic-functions/states/logicFunctionsS
 import { useAtomStateValue } from '@/ui/utilities/state/jotai/hooks/useAtomStateValue';
 import { isDefined } from 'twenty-shared/utils';
 
-type LogicFunctionThirdPartyApplication = {
+type LogicFunctionThirdPartyApplicationInformation = {
   applicationId: string;
   name: string;
 };
 
-export const useLogicFunctionThirdPartyApplication = (
+export const useLogicFunctionThirdPartyApplicationInformation = (
   logicFunctionId?: string,
-): LogicFunctionThirdPartyApplication | undefined => {
+): LogicFunctionThirdPartyApplicationInformation | undefined => {
   const logicFunctions = useAtomStateValue(logicFunctionsSelector);
 
   const applicationId = isDefined(logicFunctionId)

--- a/packages/twenty-front/src/modules/side-panel/components/SidePanelWorkflowStepInfo.tsx
+++ b/packages/twenty-front/src/modules/side-panel/components/SidePanelWorkflowStepInfo.tsx
@@ -150,6 +150,8 @@ export const SidePanelWorkflowStepInfo = ({
 
   const headerType = isTrigger ? t`Trigger` : t`Action`;
 
+  const label = isThirdPartyApplication ? applicationChipData.name : headerType;
+
   const Icon = getIcon(headerIcon ?? 'IconDefault');
 
   const saveTitle = async () => {
@@ -219,13 +221,7 @@ export const SidePanelWorkflowStepInfo = ({
           onShiftTab={saveTitle}
         />
       }
-      label={
-        isThirdPartyApplication
-          ? applicationChipData.name
-          : isTrigger
-            ? t`Trigger`
-            : t`Action`
-      }
+      label={label}
     />
   );
 };

--- a/packages/twenty-front/src/modules/side-panel/components/SidePanelWorkflowStepInfo.tsx
+++ b/packages/twenty-front/src/modules/side-panel/components/SidePanelWorkflowStepInfo.tsx
@@ -1,4 +1,5 @@
 import { AppChip } from '@/applications/components/AppChip';
+import { useApplicationChipData } from '@/applications/hooks/useApplicationChipData';
 import { useIsThirdPartyApplication } from '@/applications/hooks/useIsThirdPartyApplication';
 import { logicFunctionsSelector } from '@/logic-functions/states/logicFunctionsSelector';
 import { useUpdateSidePanelPageInfo } from '@/side-panel/hooks/useUpdateSidePanelPageInfo';
@@ -103,6 +104,10 @@ export const SidePanelWorkflowStepInfo = ({
   const isThirdPartyApplication = useIsThirdPartyApplication(
     logicFunctionApplicationId,
   );
+
+  const { applicationChipData } = useApplicationChipData({
+    applicationId: logicFunctionApplicationId,
+  });
 
   const agentId = getAgentIdFromStep(stepDefinition);
   const { updateAgentLabel } = useUpdateAgentLabel(agentId);
@@ -214,7 +219,13 @@ export const SidePanelWorkflowStepInfo = ({
           onShiftTab={saveTitle}
         />
       }
-      label={isTrigger ? t`Trigger` : t`Action`}
+      label={
+        isThirdPartyApplication
+          ? applicationChipData.name
+          : isTrigger
+            ? t`Trigger`
+            : t`Action`
+      }
     />
   );
 };

--- a/packages/twenty-front/src/modules/side-panel/components/SidePanelWorkflowStepInfo.tsx
+++ b/packages/twenty-front/src/modules/side-panel/components/SidePanelWorkflowStepInfo.tsx
@@ -24,7 +24,7 @@ import { getTriggerIconColor } from '@/workflow/workflow-trigger/utils/getTrigge
 import { t } from '@lingui/core/macro';
 import { useContext, useState } from 'react';
 import { CoreObjectNameSingular, SidePanelPages } from 'twenty-shared/types';
-import { findById, isDefined } from 'twenty-shared/utils';
+import { isDefined } from 'twenty-shared/utils';
 import { TRIGGER_STEP_ID } from 'twenty-shared/workflow';
 import { useIcons } from 'twenty-ui-deprecated/display';
 import { SidePanelPageInfoLayout } from './SidePanelPageInfoLayout';
@@ -98,7 +98,9 @@ export const SidePanelWorkflowStepInfo = ({
       : undefined;
 
   const logicFunctionApplicationId = isDefined(logicFunctionId)
-    ? logicFunctions.find(findById(logicFunctionId))?.applicationId
+    ? logicFunctions.find(
+        (logicFunction) => logicFunction.id === logicFunctionId,
+      )?.applicationId
     : undefined;
 
   const isThirdPartyApplication = useIsThirdPartyApplication(

--- a/packages/twenty-front/src/modules/side-panel/components/SidePanelWorkflowStepInfo.tsx
+++ b/packages/twenty-front/src/modules/side-panel/components/SidePanelWorkflowStepInfo.tsx
@@ -1,7 +1,5 @@
 import { AppChip } from '@/applications/components/AppChip';
-import { useApplicationChipData } from '@/applications/hooks/useApplicationChipData';
-import { useIsThirdPartyApplication } from '@/applications/hooks/useIsThirdPartyApplication';
-import { logicFunctionsSelector } from '@/logic-functions/states/logicFunctionsSelector';
+import { useLogicFunctionThirdPartyApplication } from '@/logic-functions/hooks/useLogicFunctionThirdPartyApplication';
 import { useUpdateSidePanelPageInfo } from '@/side-panel/hooks/useUpdateSidePanelPageInfo';
 import { useSidePanelWorkflowIdOrThrow } from '@/side-panel/pages/workflow/hooks/useSidePanelWorkflowIdOrThrow';
 import { sidePanelWorkflowStepIdComponentState } from '@/side-panel/pages/workflow/states/sidePanelWorkflowStepIdComponentState';
@@ -39,8 +37,6 @@ export const SidePanelWorkflowStepInfo = ({
   const { getIcon } = useIcons();
 
   const sidePanelPage = useAtomStateValue(sidePanelPageState);
-
-  const logicFunctions = useAtomStateValue(logicFunctionsSelector);
 
   const workflowId = useSidePanelWorkflowIdOrThrow();
 
@@ -97,19 +93,8 @@ export const SidePanelWorkflowStepInfo = ({
       ? stepDefinition.definition.settings.input.logicFunctionId
       : undefined;
 
-  const logicFunctionApplicationId = isDefined(logicFunctionId)
-    ? logicFunctions.find(
-        (logicFunction) => logicFunction.id === logicFunctionId,
-      )?.applicationId
-    : undefined;
-
-  const isThirdPartyApplication = useIsThirdPartyApplication(
-    logicFunctionApplicationId,
-  );
-
-  const { applicationChipData } = useApplicationChipData({
-    applicationId: logicFunctionApplicationId,
-  });
+  const thirdPartyApplication =
+    useLogicFunctionThirdPartyApplication(logicFunctionId);
 
   const agentId = getAgentIdFromStep(stepDefinition);
   const { updateAgentLabel } = useUpdateAgentLabel(agentId);
@@ -152,7 +137,9 @@ export const SidePanelWorkflowStepInfo = ({
 
   const headerType = isTrigger ? t`Trigger` : t`Action`;
 
-  const label = isThirdPartyApplication ? applicationChipData.name : headerType;
+  const label = isDefined(thirdPartyApplication)
+    ? thirdPartyApplication.name
+    : headerType;
 
   const Icon = getIcon(headerIcon ?? 'IconDefault');
 
@@ -197,9 +184,9 @@ export const SidePanelWorkflowStepInfo = ({
   return (
     <SidePanelPageInfoLayout
       icon={
-        isThirdPartyApplication ? (
+        isDefined(thirdPartyApplication) ? (
           <AppChip
-            applicationId={logicFunctionApplicationId}
+            applicationId={thirdPartyApplication.applicationId}
             size="md"
             chipOnly
           />
@@ -207,7 +194,7 @@ export const SidePanelWorkflowStepInfo = ({
           <Icon size={theme.icon.size.md} stroke={theme.icon.stroke.sm} />
         ) : undefined
       }
-      iconColor={isThirdPartyApplication ? undefined : headerIconColor}
+      iconColor={isDefined(thirdPartyApplication) ? undefined : headerIconColor}
       title={
         <TitleInput
           instanceId={`workflow-step-title-${sidePanelPageInstanceId}`}

--- a/packages/twenty-front/src/modules/side-panel/components/SidePanelWorkflowStepInfo.tsx
+++ b/packages/twenty-front/src/modules/side-panel/components/SidePanelWorkflowStepInfo.tsx
@@ -1,3 +1,6 @@
+import { AppChip } from '@/applications/components/AppChip';
+import { useIsThirdPartyApplication } from '@/applications/hooks/useIsThirdPartyApplication';
+import { logicFunctionsSelector } from '@/logic-functions/states/logicFunctionsSelector';
 import { useUpdateSidePanelPageInfo } from '@/side-panel/hooks/useUpdateSidePanelPageInfo';
 import { useSidePanelWorkflowIdOrThrow } from '@/side-panel/pages/workflow/hooks/useSidePanelWorkflowIdOrThrow';
 import { sidePanelWorkflowStepIdComponentState } from '@/side-panel/pages/workflow/states/sidePanelWorkflowStepIdComponentState';
@@ -20,7 +23,7 @@ import { getTriggerIconColor } from '@/workflow/workflow-trigger/utils/getTrigge
 import { t } from '@lingui/core/macro';
 import { useContext, useState } from 'react';
 import { CoreObjectNameSingular, SidePanelPages } from 'twenty-shared/types';
-import { isDefined } from 'twenty-shared/utils';
+import { findById, isDefined } from 'twenty-shared/utils';
 import { TRIGGER_STEP_ID } from 'twenty-shared/workflow';
 import { useIcons } from 'twenty-ui-deprecated/display';
 import { SidePanelPageInfoLayout } from './SidePanelPageInfoLayout';
@@ -35,6 +38,8 @@ export const SidePanelWorkflowStepInfo = ({
   const { getIcon } = useIcons();
 
   const sidePanelPage = useAtomStateValue(sidePanelPageState);
+
+  const logicFunctions = useAtomStateValue(logicFunctionsSelector);
 
   const workflowId = useSidePanelWorkflowIdOrThrow();
 
@@ -84,6 +89,20 @@ export const SidePanelWorkflowStepInfo = ({
       : undefined;
 
   const isTrigger = stepDefinition?.type === 'trigger';
+
+  const logicFunctionId =
+    stepDefinition?.type === 'action' &&
+    stepDefinition.definition.type === 'LOGIC_FUNCTION'
+      ? stepDefinition.definition.settings.input.logicFunctionId
+      : undefined;
+
+  const logicFunctionApplicationId = isDefined(logicFunctionId)
+    ? logicFunctions.find(findById(logicFunctionId))?.applicationId
+    : undefined;
+
+  const isThirdPartyApplication = useIsThirdPartyApplication(
+    logicFunctionApplicationId,
+  );
 
   const agentId = getAgentIdFromStep(stepDefinition);
   const { updateAgentLabel } = useUpdateAgentLabel(agentId);
@@ -169,11 +188,17 @@ export const SidePanelWorkflowStepInfo = ({
   return (
     <SidePanelPageInfoLayout
       icon={
-        headerIcon ? (
+        isThirdPartyApplication ? (
+          <AppChip
+            applicationId={logicFunctionApplicationId}
+            size="md"
+            chipOnly
+          />
+        ) : headerIcon ? (
           <Icon size={theme.icon.size.md} stroke={theme.icon.stroke.sm} />
         ) : undefined
       }
-      iconColor={headerIconColor}
+      iconColor={isThirdPartyApplication ? undefined : headerIconColor}
       title={
         <TitleInput
           instanceId={`workflow-step-title-${sidePanelPageInstanceId}`}

--- a/packages/twenty-front/src/modules/side-panel/components/SidePanelWorkflowStepInfo.tsx
+++ b/packages/twenty-front/src/modules/side-panel/components/SidePanelWorkflowStepInfo.tsx
@@ -1,5 +1,5 @@
 import { AppChip } from '@/applications/components/AppChip';
-import { useLogicFunctionThirdPartyApplication } from '@/logic-functions/hooks/useLogicFunctionThirdPartyApplication';
+import { useLogicFunctionThirdPartyApplicationInformation } from '@/logic-functions/hooks/useLogicFunctionThirdPartyApplicationInformation';
 import { useUpdateSidePanelPageInfo } from '@/side-panel/hooks/useUpdateSidePanelPageInfo';
 import { useSidePanelWorkflowIdOrThrow } from '@/side-panel/pages/workflow/hooks/useSidePanelWorkflowIdOrThrow';
 import { sidePanelWorkflowStepIdComponentState } from '@/side-panel/pages/workflow/states/sidePanelWorkflowStepIdComponentState';
@@ -93,8 +93,8 @@ export const SidePanelWorkflowStepInfo = ({
       ? stepDefinition.definition.settings.input.logicFunctionId
       : undefined;
 
-  const thirdPartyApplication =
-    useLogicFunctionThirdPartyApplication(logicFunctionId);
+  const thirdPartyApplicationInformation =
+    useLogicFunctionThirdPartyApplicationInformation(logicFunctionId);
 
   const agentId = getAgentIdFromStep(stepDefinition);
   const { updateAgentLabel } = useUpdateAgentLabel(agentId);
@@ -137,8 +137,8 @@ export const SidePanelWorkflowStepInfo = ({
 
   const headerType = isTrigger ? t`Trigger` : t`Action`;
 
-  const label = isDefined(thirdPartyApplication)
-    ? thirdPartyApplication.name
+  const label = isDefined(thirdPartyApplicationInformation)
+    ? thirdPartyApplicationInformation.name
     : headerType;
 
   const Icon = getIcon(headerIcon ?? 'IconDefault');
@@ -184,9 +184,9 @@ export const SidePanelWorkflowStepInfo = ({
   return (
     <SidePanelPageInfoLayout
       icon={
-        isDefined(thirdPartyApplication) ? (
+        isDefined(thirdPartyApplicationInformation) ? (
           <AppChip
-            applicationId={thirdPartyApplication.applicationId}
+            applicationId={thirdPartyApplicationInformation.applicationId}
             size="md"
             chipOnly
           />
@@ -194,7 +194,11 @@ export const SidePanelWorkflowStepInfo = ({
           <Icon size={theme.icon.size.md} stroke={theme.icon.stroke.sm} />
         ) : undefined
       }
-      iconColor={isDefined(thirdPartyApplication) ? undefined : headerIconColor}
+      iconColor={
+        isDefined(thirdPartyApplicationInformation)
+          ? undefined
+          : headerIconColor
+      }
       title={
         <TitleInput
           instanceId={`workflow-step-title-${sidePanelPageInstanceId}`}


### PR DESCRIPTION
Show app logo and name in workflow step side panel header

## Before

<img width="798" height="106" alt="CleanShot 2026-06-16 at 17 59 39@2x" src="https://github.com/user-attachments/assets/a8881d1c-355c-4e3a-9379-0c3a7cfbf42f" />

## After

<img width="800" height="102" alt="CleanShot 2026-06-16 at 18 05 27@2x" src="https://github.com/user-attachments/assets/43820d1a-6445-42d8-8f45-963e8741cbb7" />

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/21689?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

