### PR TITLE
Add billing.rxreport.com deploy track

### DIFF
--- a/.github/workflows/billing-image.yml
+++ b/.github/workflows/billing-image.yml
@@ -1,0 +1,62 @@
+# Builds the Twenty image (server + frontend) for RxReport Billing and pushes it
+# to GHCR as ghcr.io/<owner>/twenty:latest and :<sha>.
+#
+# The server on billing.rxreport.com then runs `docker compose pull && up -d`.
+name: billing-image
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'packages/**'
+      - '.github/workflows/billing-image.yml'
+  workflow_dispatch:
+
+concurrency:
+  group: billing-image-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build-and-push:
+    # 8-core/16 GB runner: the in-image twenty-front build requests an 8 GB heap
+    # (Dockerfile) which OOM-kills intermittently on the 7 GB ubuntu-latest box.
+    runs-on: ubuntu-latest-8-cores
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Image metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ghcr.io/${{ github.repository_owner }}/twenty
+          tags: |
+            type=raw,value=latest
+            type=sha,format=long
+
+      - name: "Build and push (target: twenty)"
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: packages/twenty-docker/twenty/Dockerfile
+          target: twenty
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          build-args: |
+            APP_VERSION=${{ github.sha }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/deploy/billing/.env.example
+++ b/deploy/billing/.env.example
@@ -1,0 +1,23 @@
+# RxReport Billing — server .env  →  copy to /opt/rxreport/twenty/.env
+# Generate secrets with:  openssl rand -base64 32
+
+# Public URL (must match the nginx vhost + certbot domain)
+SERVER_URL=https://billing.rxreport.com
+
+# Required app secret (sessions / tokens). Generate a unique value.
+APP_SECRET=replace-me-with-openssl-rand-base64-32
+
+# Image tag to run (CI pushes :latest and :<sha>)
+TAG=latest
+
+# Local file storage (no S3). Switch to s3 + STORAGE_S3_* later if desired.
+STORAGE_TYPE=local
+
+# Postgres — isolated db service in this compose project. Change the password.
+PG_DATABASE_USER=postgres
+PG_DATABASE_PASSWORD=replace-me-with-a-strong-password
+PG_DATABASE_NAME=default
+
+# The server runs migrations + registers cron on first boot — leave unset/empty.
+DISABLE_DB_MIGRATIONS=
+DISABLE_CRON_JOBS_REGISTRATION=

--- a/deploy/billing/README.md
+++ b/deploy/billing/README.md
@@ -1,0 +1,67 @@
+# Deploying Twenty to billing.rxreport.com
+
+Runbook for hosting this Twenty fork at **https://billing.rxreport.com** on the existing
+Linode box (`rxreport@172.234.239.241`), alongside the current rxreport-app / airflow / mssql
+stacks. The host already runs Docker + nginx + certbot; internal services bind `127.0.0.1`.
+
+| Thing | Value |
+|-------|-------|
+| App dir on server | `/opt/rxreport/twenty/` |
+| Image | `ghcr.io/rxreport/twenty:latest` (built by `.github/workflows/billing-image.yml`) |
+| Host port | `127.0.0.1:3100` → container `3000` (3000/3030/4000/4040/8001/8002 are taken) |
+| Reverse proxy | host nginx vhost `billing` → `localhost:3100`, TLS via certbot |
+| Database | fresh, isolated Postgres in the compose project `twenty-billing` |
+
+## 1. Build & publish the image (CI)
+Push to `main` (or run the **billing-image** workflow manually). It builds the `twenty` target
+and pushes `ghcr.io/rxreport/twenty:latest`. Ensure the GitHub repo allows GHCR package writes.
+
+## 2. DNS
+Add an **A record**: `billing.rxreport.com → 172.234.239.241` (only `app` / `api` exist today).
+Wait for it to resolve before running certbot.
+
+## 3. First-time server setup
+```bash
+ssh rxreport-prod
+sudo mkdir -p /opt/rxreport/twenty && sudo chown rxreport:rxreport /opt/rxreport/twenty
+# copy deploy/billing/docker-compose.yml and .env.example into /opt/rxreport/twenty/
+cd /opt/rxreport/twenty
+cp .env.example .env
+# edit .env: set APP_SECRET (openssl rand -base64 32) and PG_DATABASE_PASSWORD
+docker compose pull
+docker compose up -d
+docker compose logs -f server   # wait for migrations + "healthy"; check /healthz
+curl -fsS http://127.0.0.1:3100/healthz && echo OK
+```
+
+## 4. nginx + TLS
+```bash
+sudo cp nginx-billing.conf /etc/nginx/sites-available/billing
+sudo ln -s /etc/nginx/sites-available/billing /etc/nginx/sites-enabled/billing
+sudo nginx -t && sudo systemctl reload nginx
+sudo certbot --nginx -d billing.rxreport.com   # adds the 443 block + http->https redirect
+```
+Visit https://billing.rxreport.com, "Continue with Email", and create the first workspace/user.
+
+## 5. Ship the data model (objects)
+From the `rxreport-billing-app` project (see its README):
+```bash
+yarn twenty remote:add      # url https://billing.rxreport.com + an API key from the workspace
+yarn twenty app:deploy      # installs all objects, fields, relations + the fee-schedule function
+```
+Then do the one-time **Opportunity → Claim** relabel in Settings → Data model
+(steps in `rxreport-billing-app/README.md`).
+
+## 6. Updates later
+```bash
+# after CI pushes a new image:
+cd /opt/rxreport/twenty && docker compose pull && docker compose up -d
+# after changing the data model:
+cd rxreport-billing-app && yarn twenty app:deploy
+```
+
+## Notes
+- **Fresh empty DB**: the compose ships its own Postgres. Nothing is shared with rxreport-app.
+- **Backups**: the `db-data` and `server-local-data` named volumes hold all state.
+- **Frontend build memory**: the image build needs ~8 GB; build in CI (or a 16 GB runner), not
+  on the 23 GB host during traffic.

--- a/deploy/billing/docker-compose.yml
+++ b/deploy/billing/docker-compose.yml
@@ -1,0 +1,87 @@
+# RxReport Billing — production compose for billing.rxreport.com
+# Lives on the server at /opt/rxreport/twenty/docker-compose.yml
+#
+#   cd /opt/rxreport/twenty
+#   docker compose pull && docker compose up -d
+#
+# Isolated from the other stacks on the host: own compose project (twenty-billing),
+# own Postgres/Redis/volumes, and the server bound to 127.0.0.1:3100 behind nginx
+# (host ports 3000/3030/4000/4040/8001/8002 are already taken).
+name: twenty-billing
+
+services:
+  server:
+    image: ghcr.io/rxreport/twenty:${TAG:-latest}
+    volumes:
+      - server-local-data:/app/packages/twenty-server/.local-storage
+    ports:
+      - "127.0.0.1:3100:3000"
+    environment:
+      NODE_PORT: 3000
+      PG_DATABASE_URL: postgres://${PG_DATABASE_USER:-postgres}:${PG_DATABASE_PASSWORD:-postgres}@${PG_DATABASE_HOST:-db}:${PG_DATABASE_PORT:-5432}/default
+      SERVER_URL: ${SERVER_URL}
+      REDIS_URL: ${REDIS_URL:-redis://redis:6379}
+      DISABLE_DB_MIGRATIONS: ${DISABLE_DB_MIGRATIONS}
+      DISABLE_CRON_JOBS_REGISTRATION: ${DISABLE_CRON_JOBS_REGISTRATION}
+      STORAGE_TYPE: ${STORAGE_TYPE:-local}
+      APP_SECRET: ${APP_SECRET}
+    depends_on:
+      db:
+        condition: service_healthy
+      redis:
+        condition: service_healthy
+    healthcheck:
+      test: curl --fail http://localhost:3000/healthz
+      interval: 5s
+      timeout: 5s
+      retries: 20
+    restart: always
+
+  worker:
+    image: ghcr.io/rxreport/twenty:${TAG:-latest}
+    volumes:
+      - server-local-data:/app/packages/twenty-server/.local-storage
+    command: ["yarn", "worker:prod"]
+    environment:
+      PG_DATABASE_URL: postgres://${PG_DATABASE_USER:-postgres}:${PG_DATABASE_PASSWORD:-postgres}@${PG_DATABASE_HOST:-db}:${PG_DATABASE_PORT:-5432}/default
+      SERVER_URL: ${SERVER_URL}
+      REDIS_URL: ${REDIS_URL:-redis://redis:6379}
+      DISABLE_DB_MIGRATIONS: "true"
+      DISABLE_CRON_JOBS_REGISTRATION: "true"
+      STORAGE_TYPE: ${STORAGE_TYPE:-local}
+      APP_SECRET: ${APP_SECRET}
+    depends_on:
+      db:
+        condition: service_healthy
+      server:
+        condition: service_healthy
+    restart: always
+
+  db:
+    image: postgres:16
+    volumes:
+      - db-data:/var/lib/postgresql/data
+    environment:
+      POSTGRES_DB: ${PG_DATABASE_NAME:-default}
+      POSTGRES_USER: ${PG_DATABASE_USER:-postgres}
+      POSTGRES_PASSWORD: ${PG_DATABASE_PASSWORD:-postgres}
+    healthcheck:
+      test: pg_isready -U ${PG_DATABASE_USER:-postgres} -h localhost -d postgres
+      interval: 5s
+      timeout: 5s
+      retries: 10
+    restart: always
+
+  redis:
+    image: redis
+    restart: always
+    command: ["--maxmemory-policy", "noeviction"]
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 5s
+      timeout: 5s
+      retries: 10
+
+volumes:
+  db-data:
+  server-local-data:

--- a/deploy/billing/nginx-billing.conf
+++ b/deploy/billing/nginx-billing.conf
@@ -1,0 +1,26 @@
+# RxReport Billing — nginx vhost for billing.rxreport.com
+# Install on the server as /etc/nginx/sites-available/billing, then:
+#   sudo ln -s /etc/nginx/sites-available/billing /etc/nginx/sites-enabled/billing
+#   sudo nginx -t && sudo systemctl reload nginx
+#   sudo certbot --nginx -d billing.rxreport.com    # adds the TLS block + http->https redirect
+#
+# Mirrors the existing /etc/nginx/sites-available/rxreport pattern (proxy to a
+# localhost port, websocket upgrade headers). Twenty serves both the frontend and
+# the GraphQL API from the same origin, so a single proxy block is enough.
+
+server {
+    listen 80;
+    server_name billing.rxreport.com;
+
+    location / {
+        proxy_pass http://localhost:3100;
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection 'upgrade';
+        proxy_set_header Host $host;
+        proxy_cache_bypass $http_upgrade;
+
+        # Allow file/attachment uploads
+        client_max_body_size 50M;
+    }
+}


### PR DESCRIPTION
## What

Hosts this Twenty fork at **https://billing.rxreport.com** on the existing Linode box (`rxreport@172.234.239.241`), isolated from the rxreport-app / airflow / mssql stacks.

- **`deploy/billing/docker-compose.yml`** — isolated `twenty-billing` compose project, GHCR image, server bound to `127.0.0.1:3100` behind host nginx, own Postgres/Redis/volumes (fresh empty DB).
- **`deploy/billing/.env.example`**, **`nginx-billing.conf`**, **`README.md`** (runbook).
- **`.github/workflows/billing-image.yml`** — builds the `twenty` target (server + frontend) on an 8-core runner and pushes `ghcr.io/rxreport/twenty:latest` + `:<sha>`.

## Why the specifics
- Port `127.0.0.1:3100` because 3000/3030/4000/4040/8001/8002 are already taken on the host.
- 8-core runner because the in-image `twenty-front` build requests an 8 GB heap and OOM-kills intermittently on the 7 GB `ubuntu-latest`.

## Not included here
The workers'-comp pharmacy billing **data model** ships separately as a Twenty SDK app (`rxreport-billing-app`) via `yarn twenty app:deploy` — 7 custom objects, custom fields on Opportunity (used as "Claim") and Company, and a NY/NJ fee-schedule logic function.

## Deploy
See `deploy/billing/README.md`. After merge, CI publishes the image; then on the server: copy `deploy/billing/*` to `/opt/rxreport/twenty/`, set `.env`, `docker compose up -d`, add the nginx vhost + certbot, point DNS `billing → 172.234.239.241`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/21702?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

