### PR TITLE
fix: add missing admin privilege check in workspace-level impersonation token exchange

### DIFF
--- a/packages/twenty-server/src/engine/core-modules/auth/auth.resolver.ts
+++ b/packages/twenty-server/src/engine/core-modules/auth/auth.resolver.ts
@@ -770,7 +770,28 @@ export class AuthResolver {
         AuthExceptionCode.FORBIDDEN_EXCEPTION,
       );
     }
+// SECURITY FIX (GHSA-q7fm-83gr-cqg5): Workspace-level impersonators must not
+    // be able to obtain tokens for admin users. Mirror the check from
+    // impersonation.service.ts to prevent privilege escalation at token-exchange time.
+    const targetHasAdminPrivileges =
+      toImpersonateUserWorkspace.user.canImpersonate === true ||
+      toImpersonateUserWorkspace.user.canAccessFullAdminPanel === true;
 
+    const impersonatorHasAdminPrivileges =
+      impersonatorUserWorkspace.user.canImpersonate === true ||
+      impersonatorUserWorkspace.user.canAccessFullAdminPanel === true;
+
+    if (targetHasAdminPrivileges && !impersonatorHasAdminPrivileges) {
+      void eventLogContext.insertWorkspaceEvent(IMPERSONATION_EVENT, {
+        level: 'workspace',
+        action: 'token_exchange_failed',
+        message: `Impersonation of admin user ${targetUserEmail} denied for non-admin userId ${impersonatorUserWorkspace.user.id}`,
+      });
+      throw new AuthException(
+        'Cannot impersonate a user with admin privileges. Only administrators can impersonate other administrators.',
+        AuthExceptionCode.FORBIDDEN_EXCEPTION,
+      );
+    }
     void eventLogContext.insertWorkspaceEvent(IMPERSONATION_EVENT, {
       level: 'workspace',
       action: 'token_exchange_success',


### PR DESCRIPTION
Closes the privilege escalation described in GHSA-q7fm-83gr-cqg5.

The admin check existed in impersonation.service.ts (Step 1) but was
missing in auth.resolver.ts validateAndLogImpersonation() (Step 2).
This mirrors the same targetHasAdminPrivileges check to the token
exchange step.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/21707?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

