### PR TITLE
ci: remove merge queue, run e2e on push to main

### DIFF
--- a/.github/workflows/ci-e2e-main.yaml
+++ b/.github/workflows/ci-e2e-main.yaml
@@ -1,7 +1,8 @@
-name: CI Merge Queue
+name: CI E2E Main
 
 on:
-  merge_group:
+  push:
+    branches: [main]
 
   pull_request:
     types: [labeled, synchronize, opened, reopened]
@@ -16,7 +17,7 @@ concurrency:
 jobs:
   e2e-test:
     if: >
-      github.event_name == 'merge_group' ||
+      github.event_name == 'push' ||
       (github.event_name == 'pull_request' &&
        contains(github.event.pull_request.labels.*.name, 'run-merge-queue'))
     runs-on: ubuntu-latest-8-cores
@@ -127,7 +128,7 @@ jobs:
             packages/twenty-e2e-testing/test-results/
           retention-days: 7
 
-  ci-merge-queue-status-check:
+  ci-e2e-main-status-check:
     if: always() && !cancelled()
     timeout-minutes: 5
     runs-on: ubuntu-latest
@@ -136,3 +137,19 @@ jobs:
       - name: Fail job if any needs failed
         if: contains(needs.*.result, 'failure')
         run: exit 1
+
+  notify-main-ci-failure:
+    if: always() && github.event_name == 'push' && contains(needs.*.result, 'failure')
+    timeout-minutes: 5
+    runs-on: ubuntu-latest
+    needs: [e2e-test]
+    steps:
+      - name: Ping engineering on main CI failure
+        run: |
+          curl -fsS -X POST https://engineering.twenty.com/s/main-ci-failing \
+            -H 'Content-Type: application/json' \
+            -d '{
+              "commit": "${{ github.sha }}",
+              "actor": "${{ github.actor }}",
+              "run_url": "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+            }'

--- a/.github/workflows/ci-front-component-renderer.yaml
+++ b/.github/workflows/ci-front-component-renderer.yaml
@@ -2,7 +2,6 @@ name: CI Front Component Renderer
 
 on:
   pull_request:
-  merge_group:
 
 permissions:
   contents: read
@@ -13,7 +12,6 @@ concurrency:
 
 jobs:
   changed-files-check:
-    if: github.event_name != 'merge_group'
     uses: ./.github/workflows/changed-files.yaml
     with:
       files: |

--- a/.github/workflows/ci-front.yaml
+++ b/.github/workflows/ci-front.yaml
@@ -2,7 +2,6 @@ name: CI Front
 
 on:
   pull_request:
-  merge_group:
   push:
     branches: [main]
 

--- a/.github/workflows/ci-new-ui.yaml
+++ b/.github/workflows/ci-new-ui.yaml
@@ -2,7 +2,6 @@ name: CI New UI
 
 on:
   pull_request:
-  merge_group:
   push:
     branches: [main]
 

--- a/.github/workflows/ci-sdk.yaml
+++ b/.github/workflows/ci-sdk.yaml
@@ -2,7 +2,6 @@ name: CI SDK
 
 on:
   pull_request:
-  merge_group:
 
 permissions:
   contents: read
@@ -13,7 +12,6 @@ concurrency:
 
 jobs:
   changed-files-check:
-    if: github.event_name != 'merge_group'
     uses: ./.github/workflows/changed-files.yaml
     with:
       files: |

--- a/.github/workflows/ci-server.yaml
+++ b/.github/workflows/ci-server.yaml
@@ -2,7 +2,6 @@ name: CI Server
 
 on:
   pull_request:
-  merge_group:
 
 permissions:
   contents: read
@@ -16,7 +15,6 @@ env:
 
 jobs:
   changed-files-check:
-    if: github.event_name != 'merge_group'
     uses: ./.github/workflows/changed-files.yaml
     with:
       files: |

--- a/.github/workflows/ci-shared.yaml
+++ b/.github/workflows/ci-shared.yaml
@@ -2,7 +2,6 @@ name: CI Shared
 
 on:
   pull_request:
-  merge_group:
 
 permissions:
   contents: read
@@ -13,7 +12,6 @@ concurrency:
 
 jobs:
   changed-files-check:
-    if: github.event_name != 'merge_group'
     uses: ./.github/workflows/changed-files.yaml
     with:
       files: |

--- a/.github/workflows/ci-test-docker-compose.yaml
+++ b/.github/workflows/ci-test-docker-compose.yaml
@@ -5,7 +5,6 @@ permissions:
 
 on:
   pull_request:
-  merge_group:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -13,7 +12,6 @@ concurrency:
 
 jobs:
   changed-files-check:
-    if: github.event_name != 'merge_group'
     uses: ./.github/workflows/changed-files.yaml
     with:
       files: |

--- a/.github/workflows/ci-website.yaml
+++ b/.github/workflows/ci-website.yaml
@@ -2,7 +2,6 @@ name: CI Website
 
 on:
   pull_request:
-  merge_group:
 
 permissions:
   contents: read
@@ -13,7 +12,6 @@ concurrency:
 
 jobs:
   changed-files-check:
-    if: github.event_name != 'merge_group'
     uses: ./.github/workflows/changed-files.yaml
     with:
       files: |


### PR DESCRIPTION
## What

Removes the GitHub merge queue and runs what the queue used to gate — the E2E (Playwright) suite — directly on push to `main`. If that run fails on `main`, we ping engineering via webhook.

## Why

In the queue, only the `e2e-test` job in `ci-merge-queue.yaml` ran real work — every other CI workflow's `merge_group` path skipped its `changed-files-check` and tests, so the queue's status checks for those were effectively green no-ops. The expensive thing actually gated was E2E. Moving it to `push: main` validates the merged state post-merge without the queue's batching overhead.

## Changes

- **Rename** `ci-merge-queue.yaml` → `ci-e2e-main.yaml` (`name: CI E2E Main`).
  - `e2e-test` now triggers on `push` to `main` (the `run-merge-queue` PR label is kept as a manual opt-in for running E2E on a PR).
  - Status-check job renamed `ci-e2e-main-status-check`.
  - New `notify-main-ci-failure` job: on a failed **main push**, `POST`s to `https://engineering.twenty.com/s/main-ci-failing` with the commit SHA, actor, and run URL.
- **Strip dead merge-queue config** from the other CI workflows: removed the `merge_group:` triggers and the now-unreachable `if: github.event_name != 'merge_group'` guards from `ci-server`, `ci-shared`, `ci-sdk`, `ci-front-component-renderer`, `ci-test-docker-compose`, `ci-website`, and the `merge_group:` trigger from `ci-front`, `ci-ui`, `ci-new-ui`.

## Required follow-up (not in this PR)

The merge queue itself is a **repo setting**, not code. After this merges, disable **"Require merge queue"** on the `main` ruleset/branch protection (Settings → Rules), otherwise GitHub keeps batching. Required status checks tied to the old queue should also be dropped/updated.

## Behavior change

E2E now runs **after** merge rather than blocking it in the queue — a bad change lands on `main` and then alerts (the webhook is the mitigation), instead of being held back pre-merge.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/21722?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

