### PR TITLE
Point New UI visual regression at the twenty-ui Argos project

### DIFF
--- a/.github/workflows/ci-new-ui.yaml
+++ b/.github/workflows/ci-new-ui.yaml
@@ -60,7 +60,7 @@ jobs:
       - name: Upload storybook build
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
-          name: storybook-twenty-new-ui
+          name: storybook-twenty-ui
           path: packages/twenty-ui/storybook-static
           retention-days: 1
   new-ui-sb-test:
@@ -80,7 +80,7 @@ jobs:
       - name: Download storybook build
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
-          name: storybook-twenty-new-ui
+          name: storybook-twenty-ui
           path: packages/twenty-ui/storybook-static
       - name: Install Playwright
         run: |
@@ -92,7 +92,7 @@ jobs:
         if: always() && !cancelled()
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
-          name: argos-screenshots-twenty-new-ui
+          name: argos-screenshots-twenty-ui
           path: packages/twenty-ui/screenshots
           retention-days: 1
   ci-new-ui-status-check:

--- a/.github/workflows/visual-regression-dispatch.yaml
+++ b/.github/workflows/visual-regression-dispatch.yaml
@@ -39,7 +39,7 @@ jobs:
           script: |
             const name = context.payload.workflow_run.name;
             const projectByWorkflow = {
-              'CI New UI': 'twenty-new-ui',
+              'CI New UI': 'twenty-ui',
               'CI Front': 'twenty-front',
             };
             const project = projectByWorkflow[name] ?? 'twenty-front';


### PR DESCRIPTION
The `twenty-new-ui` Argos project is being renamed to `twenty-ui` (and the old `twenty-ui` / `twenty-ui-vs-new-ui` projects removed).

Updates the New UI visual-regression flow to target `twenty-ui`: the dispatch project mapping and the screenshot artifact name (which must match `argos-screenshots-${project}`), plus the internal storybook artifact name for consistency.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/21728?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

