### PR TITLE
fix(twenty-front): make copyToClipboard work in Safari

### DIFF
--- a/packages/twenty-front/src/hooks/useCopyToClipboard.tsx
+++ b/packages/twenty-front/src/hooks/useCopyToClipboard.tsx
@@ -2,6 +2,7 @@ import { useSnackBar } from '@/ui/feedback/snack-bar-manager/hooks/useSnackBar';
 import { useLingui } from '@lingui/react/macro';
 import { IconCopy, IconExclamationCircle } from 'twenty-ui/display';
 import { useContext } from 'react';
+import { isDefined } from 'twenty-shared/utils';
 import { ThemeContext } from 'twenty-ui/theme-constants';
 export const useCopyToClipboard = () => {
   const { theme } = useContext(ThemeContext);
@@ -22,7 +23,21 @@ export const useCopyToClipboard = () => {
     }
 
     try {
-      await navigator.clipboard.writeText(valueAsString);
+      // `clipboard.write` keeps working when detached from the user gesture (e.g. front components), unlike `writeText` which Safari rejects.
+      if (
+        typeof ClipboardItem !== 'undefined' &&
+        isDefined(navigator.clipboard.write)
+      ) {
+        await navigator.clipboard.write([
+          new ClipboardItem({
+            'text/plain': Promise.resolve(
+              new Blob([valueAsString], { type: 'text/plain' }),
+            ),
+          }),
+        ]);
+      } else {
+        await navigator.clipboard.writeText(valueAsString);
+      }
 
       enqueueSuccessSnackBar({
         message: message || t`Copied to clipboard`,


### PR DESCRIPTION
## Problem

`copyToClipboard` from `twenty-sdk/front-component` does not work on Safari (reported as high-severity).

Front components run in a Web Worker. When a component calls `copyToClipboard(text)`, the request round-trips through the worker → host bridge (`@quilted/threads` postMessage) before the host finally calls `navigator.clipboard.writeText` in `useCopyToClipboard`.

Because of that round-trip, the actual clipboard write runs in a **later task**, outside the synchronous user-gesture handler. Safari rejects `navigator.clipboard.writeText` in this situation with `NotAllowedError`. Chrome's looser transient-activation window lets the same call through, which is why this only reproduced on Safari.

## Fix

Prefer `navigator.clipboard.write([new ClipboardItem(...)])` over `writeText`. Handing the clipboard a `ClipboardItem` is the documented Safari-safe path that stays valid when the call is detached from the original gesture task. `writeText` is kept as a fallback for browsers without `ClipboardItem` support.

This lives in the shared `useCopyToClipboard` hook, so every copy affordance in the app (record fields, API keys, invite links, …) benefits, not just front components.

References:
- [WebKit bug 222262 — Clipboard `write()` does not work after `await`](https://bugs.webkit.org/show_bug.cgi?id=222262)
- [How to use the Clipboard API in Safari async](https://wolfgangrittner.dev/how-to-use-clipboard-api-in-safari/)

## Tests

Added `useCopyToClipboard.test.tsx` covering:
- the `ClipboardItem` + `write` path is used when available (Safari-safe path)
- fallback to `writeText` when `ClipboardItem` is unavailable
- no clipboard access outside a secure context


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/21766?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

