### PR TITLE
fix(settings): enable save button on data model currency change

### DIFF
--- a/packages/twenty-front/src/pages/settings/data-model/utils/getFieldMetadataItemInitialValues.ts
+++ b/packages/twenty-front/src/pages/settings/data-model/utils/getFieldMetadataItemInitialValues.ts
@@ -23,7 +23,7 @@ export const getFieldMetadataItemInitialValues = (
   const currencyCode = isNonEmptyString(
     fieldMetadataItem.defaultValue?.currencyCode,
   )
-    ? fieldMetadataItem.defaultValue?.currencyCode
+    ? applySimpleQuotesToString(fieldMetadataItem.defaultValue?.currencyCode)
     : applySimpleQuotesToString(CurrencyCode.USD);
 
   const defaultValue = {


### PR DESCRIPTION
### PR Description

**Context**
When editing a currency field in the data model (settings), changing the currency (e.g. USD to EUR) left the "Save" button disabled. It only became active after another field (like formatting or labels) was modified.

**Root Cause**
The form uses currencyFieldDefaultValueSchema to validate the currency field's default values. This schema requires the currencyCode to be wrapped in single quotes (e.g. "'USD'").
On page load, getFieldMetadataItemInitialValues extracted the raw currency code directly from the field metadata (e.g., "USD" without single quotes).
Since the initial value loaded without quotes, the form was instantly in an invalid validation state (isValid was false), meaning the "Save" button remained disabled even after selecting another currency.

**Solution**
Wrapped the loaded default currencyCode in simple quotes using applySimpleQuotesToString inside getFieldMetadataItemInitialValues.
This ensures the initial form state matches the format expected by the option values and the validation schema, enabling the "Save" button immediately upon currency selection changes.

**Testing Done**
Verified compilation and type-safety of twenty-front.
Verified code standards with oxlint.

Closes #21711 

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/21767?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

