### PR TITLE
Fix copyToClipboard in frontComponents on Safari

### DIFF
--- a/packages/twenty-front-component-renderer/src/host/utils/__tests__/frontComponentClipboardGate.test.ts
+++ b/packages/twenty-front-component-renderer/src/host/utils/__tests__/frontComponentClipboardGate.test.ts
@@ -1,0 +1,78 @@
+import {
+  armClipboardWriteFromUserGesture,
+  fulfillClipboardWriteFromUserGesture,
+} from '../frontComponentClipboardGate';
+
+type FakeClipboardItemData = Record<string, Promise<Blob> | Blob | string>;
+
+class FakeClipboardItem {
+  items: FakeClipboardItemData;
+
+  constructor(items: FakeClipboardItemData) {
+    this.items = items;
+  }
+}
+
+describe('frontComponentClipboardGate', () => {
+  let write: jest.Mock;
+
+  beforeEach(() => {
+    jest.useFakeTimers();
+
+    write = jest.fn((items: FakeClipboardItem[]) =>
+      Promise.all(items.flatMap((item) => Object.values(item.items))).then(
+        () => undefined,
+      ),
+    );
+
+    (globalThis as unknown as { ClipboardItem: unknown }).ClipboardItem =
+      FakeClipboardItem;
+
+    Object.defineProperty(globalThis.navigator, 'clipboard', {
+      value: { write },
+      configurable: true,
+    });
+  });
+
+  afterEach(() => {
+    jest.runOnlyPendingTimers();
+    jest.useRealTimers();
+  });
+
+  it('should return null when fulfilling without an armed gesture', () => {
+    expect(fulfillClipboardWriteFromUserGesture('text')).toBeNull();
+    expect(write).not.toHaveBeenCalled();
+  });
+
+  it('should arm a clipboard write and resolve it when fulfilled', async () => {
+    armClipboardWriteFromUserGesture();
+
+    expect(write).toHaveBeenCalledTimes(1);
+
+    const writePromise = fulfillClipboardWriteFromUserGesture('copied text');
+
+    expect(writePromise).not.toBeNull();
+    await expect(writePromise).resolves.toBeUndefined();
+  });
+
+  it('should do nothing when the async clipboard API is unsupported', () => {
+    (globalThis as unknown as { ClipboardItem?: unknown }).ClipboardItem =
+      undefined;
+
+    armClipboardWriteFromUserGesture();
+
+    expect(write).not.toHaveBeenCalled();
+    expect(fulfillClipboardWriteFromUserGesture('text')).toBeNull();
+  });
+
+  it('should arm a fresh write when re-armed within the same window', async () => {
+    armClipboardWriteFromUserGesture();
+    armClipboardWriteFromUserGesture();
+
+    expect(write).toHaveBeenCalledTimes(2);
+
+    const writePromise = fulfillClipboardWriteFromUserGesture('text');
+
+    await expect(writePromise).resolves.toBeUndefined();
+  });
+});

--- a/packages/twenty-front-component-renderer/src/host/utils/createHtmlHostWrapper.ts
+++ b/packages/twenty-front-component-renderer/src/host/utils/createHtmlHostWrapper.ts
@@ -17,6 +17,7 @@ import {
   FrontComponentInputFocusContext,
   type SetEditableFocused,
 } from '@/host/contexts/FrontComponentInputFocusContext';
+import { armClipboardWriteFromUserGesture } from '@/host/utils/frontComponentClipboardGate';
 import { sanitizeIframeSandbox } from '@/host/utils/sanitizeIframeSandbox';
 
 const INTERNAL_PROPS = new Set(['element', 'receiver', 'components']);
@@ -280,8 +281,17 @@ const serializeEvent = (event: unknown): SerializedEventData => {
   return serialized;
 };
 
+const ACTIVATION_EVENT_TYPES = new Set(['click', 'pointerup', 'touchend']);
+
 const wrapEventHandler = (handler: (detail: SerializedEventData) => void) => {
   return (event: unknown) => {
+    if (isObject(event)) {
+      const eventType = (event as Record<string, unknown>).type;
+      if (isString(eventType) && ACTIVATION_EVENT_TYPES.has(eventType)) {
+        armClipboardWriteFromUserGesture();
+      }
+    }
+
     handler(serializeEvent(event));
   };
 };

--- a/packages/twenty-front-component-renderer/src/host/utils/frontComponentClipboardGate.ts
+++ b/packages/twenty-front-component-renderer/src/host/utils/frontComponentClipboardGate.ts
@@ -1,0 +1,74 @@
+import { isDefined } from 'twenty-shared/utils';
+
+const CLIPBOARD_GESTURE_WINDOW_MS = 3000;
+
+type PendingClipboardWrite = {
+  resolveText: (text: string) => void;
+  abortWrite: () => void;
+  writePromise: Promise<void>;
+};
+
+let pendingClipboardWrite: PendingClipboardWrite | null = null;
+let pendingClipboardWriteTimeoutId: ReturnType<typeof setTimeout> | null = null;
+
+const isAsyncClipboardWriteSupported = (): boolean =>
+  typeof navigator !== 'undefined' &&
+  isDefined(navigator.clipboard) &&
+  typeof navigator.clipboard.write === 'function' &&
+  typeof ClipboardItem !== 'undefined';
+
+const clearPendingClipboardWrite = (): void => {
+  if (isDefined(pendingClipboardWriteTimeoutId)) {
+    clearTimeout(pendingClipboardWriteTimeoutId);
+    pendingClipboardWriteTimeoutId = null;
+  }
+  pendingClipboardWrite = null;
+};
+
+export const armClipboardWriteFromUserGesture = (): void => {
+  if (!isAsyncClipboardWriteSupported()) {
+    return;
+  }
+
+  pendingClipboardWrite?.abortWrite();
+  clearPendingClipboardWrite();
+
+  let resolveText: (text: string) => void = () => {};
+  let abortWrite: () => void = () => {};
+
+  const textPromise = new Promise<string>((resolve, reject) => {
+    resolveText = resolve;
+    abortWrite = () => reject(new Error('Clipboard write aborted'));
+  });
+
+  const writePromise = navigator.clipboard.write([
+    new ClipboardItem({
+      'text/plain': textPromise.then(
+        (text) => new Blob([text], { type: 'text/plain' }),
+      ),
+    }),
+  ]);
+
+  writePromise.catch(() => {});
+
+  pendingClipboardWrite = { resolveText, abortWrite, writePromise };
+
+  pendingClipboardWriteTimeoutId = setTimeout(() => {
+    pendingClipboardWrite?.abortWrite();
+    clearPendingClipboardWrite();
+  }, CLIPBOARD_GESTURE_WINDOW_MS);
+};
+
+export const fulfillClipboardWriteFromUserGesture = (
+  text: string,
+): Promise<void> | null => {
+  if (!isDefined(pendingClipboardWrite)) {
+    return null;
+  }
+
+  const { resolveText, writePromise } = pendingClipboardWrite;
+  clearPendingClipboardWrite();
+  resolveText(text);
+
+  return writePromise;
+};

--- a/packages/twenty-front-component-renderer/src/index.ts
+++ b/packages/twenty-front-component-renderer/src/index.ts
@@ -4,6 +4,7 @@ export {
   type SetEditableFocused,
 } from './host/contexts/FrontComponentInputFocusContext';
 export { componentRegistry } from './host/generated/host-component-registry';
+export { fulfillClipboardWriteFromUserGesture } from './host/utils/frontComponentClipboardGate';
 export { FrontComponentErrorEffect } from './remote/components/FrontComponentErrorEffect';
 export { FrontComponentInitializeHostCommunicationApiEffect } from './remote/components/FrontComponentInitializeHostCommunicationApiEffect';
 export { FrontComponentUpdateContextEffect } from './remote/components/FrontComponentUpdateContextEffect';

--- a/packages/twenty-front/src/hooks/useCopyToClipboard.tsx
+++ b/packages/twenty-front/src/hooks/useCopyToClipboard.tsx
@@ -1,14 +1,24 @@
 import { useSnackBar } from '@/ui/feedback/snack-bar-manager/hooks/useSnackBar';
 import { useLingui } from '@lingui/react/macro';
+import { isDefined } from 'twenty-shared/utils';
 import { IconCopy, IconExclamationCircle } from 'twenty-ui/display';
 import { useContext } from 'react';
 import { ThemeContext } from 'twenty-ui/theme-constants';
+
+type CopyToClipboardOptions = {
+  writePromise?: Promise<void> | null;
+};
+
 export const useCopyToClipboard = () => {
   const { theme } = useContext(ThemeContext);
   const { enqueueSuccessSnackBar, enqueueErrorSnackBar } = useSnackBar();
   const { t } = useLingui();
 
-  const copyToClipboard = async (valueAsString: string, message?: string) => {
+  const copyToClipboard = async (
+    valueAsString: string,
+    message?: string,
+    options?: CopyToClipboardOptions,
+  ) => {
     if (!window.isSecureContext) {
       enqueueErrorSnackBar({
         message: t`Clipboard requires a secure connection (HTTPS). Please access this app over HTTPS to enable copying.`,
@@ -22,7 +32,10 @@ export const useCopyToClipboard = () => {
     }
 
     try {
-      await navigator.clipboard.writeText(valueAsString);
+      const writePromise = options?.writePromise;
+      await (isDefined(writePromise)
+        ? writePromise
+        : navigator.clipboard.writeText(valueAsString));
 
       enqueueSuccessSnackBar({
         message: message || t`Copied to clipboard`,

--- a/packages/twenty-front/src/modules/front-components/hooks/__tests__/useFrontComponentExecutionContext.test.tsx
+++ b/packages/twenty-front/src/modules/front-components/hooks/__tests__/useFrontComponentExecutionContext.test.tsx
@@ -92,6 +92,10 @@ jest.mock('~/hooks/useCopyToClipboard', () => ({
   }),
 }));
 
+jest.mock('twenty-front-component-renderer', () => ({
+  fulfillClipboardWriteFromUserGesture: jest.fn(() => null),
+}));
+
 const renderUseFrontComponentExecutionContext = (
   params: Omit<
     Parameters<typeof useFrontComponentExecutionContext>[0],

--- a/packages/twenty-front/src/modules/front-components/hooks/useFrontComponentExecutionContext.ts
+++ b/packages/twenty-front/src/modules/front-components/hooks/useFrontComponentExecutionContext.ts
@@ -5,6 +5,7 @@ import { useRef } from 'react';
 import {
   type FrontComponentExecutionContext,
   type FrontComponentHostCommunicationApi,
+  fulfillClipboardWriteFromUserGesture,
 } from 'twenty-front-component-renderer';
 import { type AppPath, type EnqueueSnackbarParams } from 'twenty-shared/types';
 
@@ -191,10 +192,16 @@ export const useFrontComponentExecutionContext = ({
           ? `${text.slice(0, FRONT_COMPONENT_CLIPBOARD_PREVIEW_LENGTH)}…`
           : text;
 
-      await copyToClipboardWithSnackbar(
-        text,
-        t`Application copied "${preview}" to your clipboard`,
-      );
+      const message = t`Application copied "${preview}" to your clipboard`;
+      const gestureWrite = fulfillClipboardWriteFromUserGesture(text);
+
+      if (isDefined(gestureWrite)) {
+        await copyToClipboardWithSnackbar(text, message, {
+          writePromise: gestureWrite,
+        });
+      } else {
+        await copyToClipboardWithSnackbar(text, message);
+      }
     };
 
   const frontComponentHostCommunicationApi: FrontComponentHostCommunicationApi =


### PR DESCRIPTION
## What

`copyToClipboard` from the twenty-sdk worked in Chromium but silently failed in Safari when called from a frontComponent.

## Why

FrontComponents run in a Web Worker, so a click is forwarded async to the worker and the `copyToClipboard` call is RPC'd async back to the host before `navigator.clipboard.writeText()` runs. Safari/WebKit requires the clipboard write to happen synchronously within the user-gesture call stack, so it threw `NotAllowedError`. Chromium tolerates the gap because its transient activation persists across task boundaries.

## How

`wrapEventHandler` is the only host code still running inside the real gesture. On activation events it now "arms" a `ClipboardItem`-with-Promise write (WebKit-supported) synchronously; the host `copyToClipboard` resolves that promise when the worker's RPC arrives. Unused arms self-abort, leaving the clipboard untouched. The imperative `copyToClipboard(text)` SDK API is unchanged.

Note: a copy not triggered by a user gesture still can't work on Safari — an inherent browser restriction.

## Tests

- New unit test for the clipboard gate; existing `useFrontComponentExecutionContext` tests still pass (30/30).
- Typecheck + lint clean.
- Engine-specific behavior should be confirmed with a manual click-test in Safari.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/21769?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

