### PR TITLE
Run instance command, allow above next version bundle cursor

### DIFF
--- a/packages/twenty-server/src/database/commands/run-instance-commands.command.ts
+++ b/packages/twenty-server/src/database/commands/run-instance-commands.command.ts
@@ -3,6 +3,7 @@ import { InjectDataSource } from '@nestjs/typeorm';
 
 import chalk from 'chalk';
 import { Command, CommandRunner, Option } from 'nest-commander';
+import { isDefined } from 'twenty-shared/utils';
 import { DataSource } from 'typeorm';
 
 import { TWENTY_PREVIOUS_VERSIONS } from 'src/engine/core-modules/upgrade/constants/twenty-previous-versions.constant';
@@ -142,25 +143,40 @@ export class RunInstanceCommandsCommand extends CommandRunner {
     const previousVersion =
       TWENTY_PREVIOUS_VERSIONS[TWENTY_PREVIOUS_VERSIONS.length - 1];
 
-    const lastWorkspaceCommand =
-      this.upgradeCommandRegistryService.getLastWorkspaceCommandForVersion(
+    const previousVersionLastCommand =
+      this.upgradeCommandRegistryService.getLastCommandForVersion(
         previousVersion,
       );
 
-    if (!lastWorkspaceCommand) {
+    if (!previousVersionLastCommand) {
       return;
     }
 
-    const allAtPreviousVersion =
-      await this.upgradeMigrationService.areAllWorkspacesAtCommand({
-        commandName: lastWorkspaceCommand.name,
-        workspaceIds: activeOrSuspendedWorkspaceIds,
-      });
+    const workspaceCursors =
+      await this.upgradeMigrationService.getWorkspaceLastAttemptedCommandNameOrThrow(
+        activeOrSuspendedWorkspaceIds,
+      );
 
-    if (!allAtPreviousVersion) {
+    const laggingWorkspaceIds = activeOrSuspendedWorkspaceIds.filter(
+      (workspaceId) => {
+        const cursor = workspaceCursors.get(workspaceId);
+
+        if (!isDefined(cursor)) {
+          return true;
+        }
+
+        return !this.upgradeSequenceReaderService.isCursorAtOrPastStep({
+          cursor: { name: cursor.name, status: cursor.status },
+          requiredStepName: previousVersionLastCommand.name,
+        });
+      },
+    );
+
+    if (laggingWorkspaceIds.length > 0) {
       throw new Error(
-        'Unable to run instance commands. Some workspace(s) have not completed ' +
-          `the last workspace command for ${previousVersion} ("${lastWorkspaceCommand.name}").\n` +
+        'Unable to run instance commands. Some workspace(s) have not reached ' +
+          `the last command for ${previousVersion} ("${previousVersionLastCommand.name}").\n` +
+          `Lagging workspace(s): ${laggingWorkspaceIds.join(', ')}.\n` +
           'Please ensure all workspaces are upgraded to at least the previous version before running migrations.\n' +
           'Use --force to bypass this check (not recommended).',
       );

--- a/packages/twenty-server/src/engine/core-modules/upgrade/services/__tests__/upgrade-command-registry.service.spec.ts
+++ b/packages/twenty-server/src/engine/core-modules/upgrade/services/__tests__/upgrade-command-registry.service.spec.ts
@@ -444,4 +444,58 @@ describe('UpgradeCommandRegistryService', () => {
       `${VERSION_A}_SlowMigration1780000000000_1780000000000`,
     ]);
   });
+
+  describe('getLastCommandForVersion', () => {
+    it('should return the last workspace command when the bundle has workspace commands', async () => {
+      const service = await buildRegistryService([
+        new MigrationA1770000000000(),
+        new WorkspaceCommandA(),
+        new WorkspaceCommandB(),
+      ]);
+
+      expect(service.getLastCommandForVersion(VERSION_A)?.name).toBe(
+        `${VERSION_A}_WorkspaceCommandB_1774000000000`,
+      );
+    });
+
+    it('should fall back to the last slow instance command when the bundle has no workspace command', async () => {
+      @RegisteredInstanceCommand(VERSION_B, 1768500000000, { type: 'slow' })
+      class SlowMigrationB1768500000000 implements SlowInstanceCommand {
+        name = 'SlowMigrationB1768500000000';
+
+        async runDataMigration(_dataSource: DataSource): Promise<void> {}
+        async up(): Promise<void> {}
+        async down(): Promise<void> {}
+      }
+
+      const service = await buildRegistryService([
+        new WorkspaceCommandA(),
+        new MigrationD1769000000000(),
+        new SlowMigrationB1768500000000(),
+      ]);
+
+      expect(service.getLastCommandForVersion(VERSION_B)?.name).toBe(
+        `${VERSION_B}_SlowMigrationB1768500000000_1768500000000`,
+      );
+    });
+
+    it('should fall back to the last fast instance command when the bundle has only fast instance commands', async () => {
+      const service = await buildRegistryService([
+        new WorkspaceCommandA(),
+        new MigrationD1769000000000(),
+      ]);
+
+      expect(service.getLastCommandForVersion(VERSION_B)?.name).toBe(
+        `${VERSION_B}_MigrationD1769000000000_1769000000000`,
+      );
+    });
+
+    it('should return undefined for a version with no commands', async () => {
+      const service = await buildRegistryService([new WorkspaceCommandA()]);
+
+      expect(
+        service.getLastCommandForVersion('99.0.0' as typeof VERSION_A),
+      ).toBeUndefined();
+    });
+  });
 });

--- a/packages/twenty-server/src/engine/core-modules/upgrade/services/__tests__/upgrade-sequence-reader.service.spec.ts
+++ b/packages/twenty-server/src/engine/core-modules/upgrade/services/__tests__/upgrade-sequence-reader.service.spec.ts
@@ -296,4 +296,95 @@ describe('UpgradeSequenceReaderService', () => {
       expect(result).toEqual({ name: 'Ic1', status: 'failed' });
     });
   });
+
+  describe('isCursorAtOrPastStep', () => {
+    // Models a 2.14 → 2.15 sequence. The previous-version boundary is the last
+    // 2.14 command (Wc_2.14c). 2.15 adds an instance command then a workspace command.
+    const buildBoundaryService = () =>
+      buildServiceWithMockedSequence([
+        makeFastInstance('Ic_2.14'),
+        makeWorkspace('Wc_2.14a'),
+        makeWorkspace('Wc_2.14b'),
+        makeWorkspace('Wc_2.14c'),
+        makeFastInstance('Ic_2.15'),
+        makeWorkspace('Wc_2.15a'),
+      ]);
+
+    it('should accept a cursor strictly after the boundary (workspace created on the newer version)', async () => {
+      const service = await buildBoundaryService();
+
+      expect(
+        service.isCursorAtOrPastStep({
+          cursor: { name: 'Wc_2.15a', status: 'completed' },
+          requiredStepName: 'Wc_2.14c',
+        }),
+      ).toBe(true);
+    });
+
+    it('should accept a cursor after the boundary even when its latest step failed', async () => {
+      const service = await buildBoundaryService();
+
+      expect(
+        service.isCursorAtOrPastStep({
+          cursor: { name: 'Wc_2.15a', status: 'failed' },
+          requiredStepName: 'Wc_2.14c',
+        }),
+      ).toBe(true);
+    });
+
+    it('should accept an instance-command cursor positioned after the boundary', async () => {
+      const service = await buildBoundaryService();
+
+      expect(
+        service.isCursorAtOrPastStep({
+          cursor: { name: 'Ic_2.15', status: 'completed' },
+          requiredStepName: 'Wc_2.14c',
+        }),
+      ).toBe(true);
+    });
+
+    it('should accept a cursor exactly on the boundary when completed', async () => {
+      const service = await buildBoundaryService();
+
+      expect(
+        service.isCursorAtOrPastStep({
+          cursor: { name: 'Wc_2.14c', status: 'completed' },
+          requiredStepName: 'Wc_2.14c',
+        }),
+      ).toBe(true);
+    });
+
+    it('should reject a cursor exactly on the boundary when not completed', async () => {
+      const service = await buildBoundaryService();
+
+      expect(
+        service.isCursorAtOrPastStep({
+          cursor: { name: 'Wc_2.14c', status: 'failed' },
+          requiredStepName: 'Wc_2.14c',
+        }),
+      ).toBe(false);
+    });
+
+    it('should reject a cursor before the boundary', async () => {
+      const service = await buildBoundaryService();
+
+      expect(
+        service.isCursorAtOrPastStep({
+          cursor: { name: 'Wc_2.14b', status: 'completed' },
+          requiredStepName: 'Wc_2.14c',
+        }),
+      ).toBe(false);
+    });
+
+    it('should reject a cursor that predates the supported sequence window', async () => {
+      const service = await buildBoundaryService();
+
+      expect(
+        service.isCursorAtOrPastStep({
+          cursor: { name: 'Wc_2.13_unknown', status: 'completed' },
+          requiredStepName: 'Wc_2.14c',
+        }),
+      ).toBe(false);
+    });
+  });
 });

--- a/packages/twenty-server/src/engine/core-modules/upgrade/services/__tests__/upgrade-sequence-reader.service.spec.ts
+++ b/packages/twenty-server/src/engine/core-modules/upgrade/services/__tests__/upgrade-sequence-reader.service.spec.ts
@@ -1,15 +1,15 @@
 import 'reflect-metadata';
 
-import { Test } from '@nestjs/testing';
 import { DiscoveryService } from '@nestjs/core';
+import { Test } from '@nestjs/testing';
 
+import { TWENTY_CURRENT_VERSION } from 'src/engine/core-modules/upgrade/constants/twenty-current-version.constant';
+import { RegisteredWorkspaceCommand } from 'src/engine/core-modules/upgrade/decorators/registered-workspace-command.decorator';
+import { UpgradeCommandRegistryService } from 'src/engine/core-modules/upgrade/services/upgrade-command-registry.service';
 import {
   type UpgradeStep,
   UpgradeSequenceReaderService,
 } from 'src/engine/core-modules/upgrade/services/upgrade-sequence-reader.service';
-import { UpgradeCommandRegistryService } from 'src/engine/core-modules/upgrade/services/upgrade-command-registry.service';
-import { RegisteredWorkspaceCommand } from 'src/engine/core-modules/upgrade/decorators/registered-workspace-command.decorator';
-import { TWENTY_CURRENT_VERSION } from 'src/engine/core-modules/upgrade/constants/twenty-current-version.constant';
 
 const VERSION = TWENTY_CURRENT_VERSION;
 

--- a/packages/twenty-server/src/engine/core-modules/upgrade/services/upgrade-command-registry.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/upgrade/services/upgrade-command-registry.service.ts
@@ -186,12 +186,20 @@ export class UpgradeCommandRegistryService implements OnModuleInit {
     return this.bundlesByVersion.get(version) ?? buildEmptyVersionBundle();
   }
 
-  getLastWorkspaceCommandForVersion(
+  getLastCommandForVersion(
     version: TwentyAllVersion,
-  ): RegisteredWorkspaceCommand | undefined {
+  ):
+    | RegisteredFastInstanceCommand
+    | RegisteredSlowInstanceCommand
+    | RegisteredWorkspaceCommand
+    | undefined {
     const bundle = this.getBundleForVersion(version);
 
-    return bundle.workspaceCommands[bundle.workspaceCommands.length - 1];
+    return (
+      bundle.workspaceCommands[bundle.workspaceCommands.length - 1] ??
+      bundle.slowInstanceCommands[bundle.slowInstanceCommands.length - 1] ??
+      bundle.fastInstanceCommands[bundle.fastInstanceCommands.length - 1]
+    );
   }
 
   getCrossUpgradeSupportedFastInstanceCommands(): RegisteredFastInstanceCommand[] {

--- a/packages/twenty-server/src/engine/core-modules/upgrade/services/upgrade-migration.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/upgrade/services/upgrade-migration.service.ts
@@ -3,7 +3,7 @@ import { InjectRepository } from '@nestjs/typeorm';
 
 import chunk from 'lodash.chunk';
 import { isDefined } from 'twenty-shared/utils';
-import { In, IsNull, type QueryRunner, Repository } from 'typeorm';
+import { IsNull, type QueryRunner, Repository } from 'typeorm';
 
 import {
   UpgradeMigrationEntity,
@@ -303,37 +303,6 @@ export class UpgradeMigrationService {
     }
 
     return cursors;
-  }
-
-  async areAllWorkspacesAtCommand({
-    commandName,
-    workspaceIds,
-  }: {
-    commandName: string;
-    workspaceIds: string[];
-  }): Promise<boolean> {
-    if (workspaceIds.length === 0) {
-      return true;
-    }
-
-    const completedCount = await this.upgradeMigrationRepository
-      .createQueryBuilder('migration')
-      .where({
-        name: commandName,
-        status: 'completed',
-        workspaceId: In(workspaceIds),
-      })
-      .andWhere(
-        `migration.attempt = (
-          SELECT MAX(sub.attempt)
-          FROM core."upgradeMigration" sub
-          WHERE sub.name = migration.name
-          AND sub."workspaceId" = migration."workspaceId"
-        )`,
-      )
-      .getCount();
-
-    return completedCount === workspaceIds.length;
   }
 
   async getLastAttemptedInstanceCommand(): Promise<{

--- a/packages/twenty-server/src/engine/core-modules/upgrade/services/upgrade-sequence-reader.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/upgrade/services/upgrade-sequence-reader.service.ts
@@ -162,6 +162,35 @@ export class UpgradeSequenceReaderService {
       : workspaceCommands.slice(cursorIndex);
   }
 
+  isCursorAtOrPastStep({
+    cursor,
+    requiredStepName,
+  }: {
+    cursor: { name: string; status: UpgradeMigrationStatus };
+    requiredStepName: string;
+  }): boolean {
+    const sequence = this.getUpgradeSequence();
+
+    const requiredCursor = this.locateStepInSequenceOrThrow({
+      sequence,
+      stepName: requiredStepName,
+    });
+
+    const workspaceCursor = sequence.findIndex(
+      (step) => step.name === cursor.name,
+    );
+
+    if (workspaceCursor === -1 || workspaceCursor < requiredCursor) {
+      return false;
+    }
+
+    if (workspaceCursor > requiredCursor) {
+      return true;
+    }
+
+    return cursor.status === 'completed';
+  }
+
   getInitialCursorForNewWorkspace(lastAttemptedInstanceCommand: {
     name: string;
     status: UpgradeMigrationStatus;


### PR DESCRIPTION
# Introduction
When creating a fresh instance and creating a brand new workspace and just rerunning the instance command the validation would fail

Now allowing a workspace cursor to be above previous bundle last command, in the run instance command guard

## Use cases
- On workspace creation, as the initial workspace cursor on creation is computed to either be the last workspace command of the current version bundle or the latest ( not last ) run version bundle instance command
- On single workspace upgrade funnel ( `upgrade --workspace-id` )

We could make this check stricter but it's overkill to me, by only allowing an above cursor to be in the next version bundle commands range


close https://github.com/twentyhq/twenty/issues/20666