### PR TITLE
fix(server): reject standalone rich text widget on non-dashboard layouts

### DIFF
--- a/packages/twenty-server/src/engine/metadata-modules/flat-entity/constant/all-metadata-required-metadata-for-validation.constant.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/flat-entity/constant/all-metadata-required-metadata-for-validation.constant.ts
@@ -101,6 +101,7 @@ export const ALL_METADATA_REQUIRED_METADATA_FOR_VALIDATION = {
   },
   pageLayoutWidget: {
     objectMetadata: true,
+    pageLayout: true,
     pageLayoutTab: true,
     frontComponent: true,
   },

--- a/packages/twenty-server/src/engine/metadata-modules/flat-page-layout-widget/validators/utils/__tests__/validate-standalone-rich-text-page-layout-type.util.spec.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/flat-page-layout-widget/validators/utils/__tests__/validate-standalone-rich-text-page-layout-type.util.spec.ts
@@ -1,0 +1,43 @@
+import { validateStandaloneRichTextPageLayoutType } from 'src/engine/metadata-modules/flat-page-layout-widget/validators/utils/validate-standalone-rich-text-page-layout-type.util';
+import { PageLayoutType } from 'src/engine/metadata-modules/page-layout/enums/page-layout-type.enum';
+
+type Args = Parameters<typeof validateStandaloneRichTextPageLayoutType>[0];
+
+const buildArgs = (pageLayoutType: PageLayoutType): Args =>
+  ({
+    flatEntityToValidate: {
+      pageLayoutTabUniversalIdentifier: 'tab-uid',
+      universalOverrides: null,
+    },
+    optimisticFlatEntityMapsAndRelatedFlatEntityMaps: {
+      flatPageLayoutTabMaps: {
+        byUniversalIdentifier: {
+          'tab-uid': { pageLayoutUniversalIdentifier: 'layout-uid' },
+        },
+      },
+      flatPageLayoutMaps: {
+        byUniversalIdentifier: {
+          'layout-uid': { type: pageLayoutType },
+        },
+      },
+    },
+  }) as unknown as Args;
+
+describe('validateStandaloneRichTextPageLayoutType', () => {
+  it('rejects a standalone rich text widget on a non-dashboard layout', () => {
+    const errors = validateStandaloneRichTextPageLayoutType(
+      buildArgs(PageLayoutType.RECORD_PAGE),
+    );
+
+    expect(errors).toHaveLength(1);
+    expect(errors[0].value).toBe(PageLayoutType.RECORD_PAGE);
+  });
+
+  it('allows a standalone rich text widget on a dashboard layout', () => {
+    const errors = validateStandaloneRichTextPageLayoutType(
+      buildArgs(PageLayoutType.DASHBOARD),
+    );
+
+    expect(errors).toEqual([]);
+  });
+});

--- a/packages/twenty-server/src/engine/metadata-modules/flat-page-layout-widget/validators/utils/validate-standalone-rich-text-flat-page-layout-widget-for-creation.util.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/flat-page-layout-widget/validators/utils/validate-standalone-rich-text-flat-page-layout-widget-for-creation.util.ts
@@ -5,6 +5,7 @@ import { type ValidateFlatPageLayoutWidgetTypeSpecificitiesForCreationArgs } fro
 import { type FlatPageLayoutWidgetValidationError } from 'src/engine/metadata-modules/flat-page-layout-widget/types/flat-page-layout-widget-validation-error.type';
 import { validateStandaloneRichTextBody } from 'src/engine/metadata-modules/flat-page-layout-widget/validators/utils/validate-standalone-rich-text-body.util';
 import { validateStandaloneRichTextConfigurationType } from 'src/engine/metadata-modules/flat-page-layout-widget/validators/utils/validate-standalone-rich-text-configuration-type.util';
+import { validateStandaloneRichTextPageLayoutType } from 'src/engine/metadata-modules/flat-page-layout-widget/validators/utils/validate-standalone-rich-text-page-layout-type.util';
 import { PageLayoutWidgetExceptionCode } from 'src/engine/metadata-modules/page-layout-widget/exceptions/page-layout-widget.exception';
 
 export const validateStandaloneRichTextFlatPageLayoutWidgetForCreation = (
@@ -13,6 +14,8 @@ export const validateStandaloneRichTextFlatPageLayoutWidgetForCreation = (
   const { flatEntityToValidate } = args;
   const { universalConfiguration, title: widgetTitle } = flatEntityToValidate;
   const errors: FlatPageLayoutWidgetValidationError[] = [];
+
+  errors.push(...validateStandaloneRichTextPageLayoutType(args));
 
   if (!isDefined(universalConfiguration)) {
     errors.push({

--- a/packages/twenty-server/src/engine/metadata-modules/flat-page-layout-widget/validators/utils/validate-standalone-rich-text-flat-page-layout-widget-for-update.util.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/flat-page-layout-widget/validators/utils/validate-standalone-rich-text-flat-page-layout-widget-for-update.util.ts
@@ -4,6 +4,7 @@ import { type ValidateFlatPageLayoutWidgetTypeSpecificitiesForUpdateArgs } from 
 import { type FlatPageLayoutWidgetValidationError } from 'src/engine/metadata-modules/flat-page-layout-widget/types/flat-page-layout-widget-validation-error.type';
 import { validateStandaloneRichTextBody } from 'src/engine/metadata-modules/flat-page-layout-widget/validators/utils/validate-standalone-rich-text-body.util';
 import { validateStandaloneRichTextConfigurationType } from 'src/engine/metadata-modules/flat-page-layout-widget/validators/utils/validate-standalone-rich-text-configuration-type.util';
+import { validateStandaloneRichTextPageLayoutType } from 'src/engine/metadata-modules/flat-page-layout-widget/validators/utils/validate-standalone-rich-text-page-layout-type.util';
 
 export const validateStandaloneRichTextFlatPageLayoutWidgetForUpdate = (
   args: ValidateFlatPageLayoutWidgetTypeSpecificitiesForUpdateArgs,
@@ -12,8 +13,10 @@ export const validateStandaloneRichTextFlatPageLayoutWidgetForUpdate = (
   const { universalConfiguration, title: widgetTitle } = flatEntityToValidate;
   const errors: FlatPageLayoutWidgetValidationError[] = [];
 
+  errors.push(...validateStandaloneRichTextPageLayoutType(args));
+
   if (!isDefined(universalConfiguration)) {
-    return [];
+    return errors;
   }
 
   const result = validateStandaloneRichTextConfigurationType({

--- a/packages/twenty-server/src/engine/metadata-modules/flat-page-layout-widget/validators/utils/validate-standalone-rich-text-page-layout-type.util.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/flat-page-layout-widget/validators/utils/validate-standalone-rich-text-page-layout-type.util.ts
@@ -1,0 +1,56 @@
+import { msg, t } from '@lingui/core/macro';
+import { isDefined } from 'twenty-shared/utils';
+
+import { findFlatEntityByUniversalIdentifier } from 'src/engine/metadata-modules/flat-entity/utils/find-flat-entity-by-universal-identifier.util';
+import { type GenericValidateFlatPageLayoutWidgetTypeSpecificitiesArgs } from 'src/engine/metadata-modules/flat-page-layout-widget/services/flat-page-layout-widget-type-validator.service';
+import { type FlatPageLayoutWidgetValidationError } from 'src/engine/metadata-modules/flat-page-layout-widget/types/flat-page-layout-widget-validation-error.type';
+import { PageLayoutType } from 'src/engine/metadata-modules/page-layout/enums/page-layout-type.enum';
+import { PageLayoutWidgetExceptionCode } from 'src/engine/metadata-modules/page-layout-widget/exceptions/page-layout-widget.exception';
+
+// Standalone rich text has no field reference, so it only makes sense on dashboards;
+// record pages render rich text through a field-backed widget instead.
+export const validateStandaloneRichTextPageLayoutType = ({
+  flatEntityToValidate,
+  optimisticFlatEntityMapsAndRelatedFlatEntityMaps: {
+    flatPageLayoutTabMaps,
+    flatPageLayoutMaps,
+  },
+}: Pick<
+  GenericValidateFlatPageLayoutWidgetTypeSpecificitiesArgs,
+  'flatEntityToValidate' | 'optimisticFlatEntityMapsAndRelatedFlatEntityMaps'
+>): FlatPageLayoutWidgetValidationError[] => {
+  const pageLayoutTabUniversalIdentifier =
+    flatEntityToValidate.universalOverrides?.pageLayoutTabUniversalIdentifier ??
+    flatEntityToValidate.pageLayoutTabUniversalIdentifier;
+
+  const referencedPageLayoutTab = findFlatEntityByUniversalIdentifier({
+    universalIdentifier: pageLayoutTabUniversalIdentifier,
+    flatEntityMaps: flatPageLayoutTabMaps,
+  });
+
+  if (!isDefined(referencedPageLayoutTab)) {
+    return [];
+  }
+
+  const referencedPageLayout = findFlatEntityByUniversalIdentifier({
+    universalIdentifier: referencedPageLayoutTab.pageLayoutUniversalIdentifier,
+    flatEntityMaps: flatPageLayoutMaps,
+  });
+
+  if (!isDefined(referencedPageLayout)) {
+    return [];
+  }
+
+  if (referencedPageLayout.type === PageLayoutType.DASHBOARD) {
+    return [];
+  }
+
+  return [
+    {
+      code: PageLayoutWidgetExceptionCode.INVALID_PAGE_LAYOUT_WIDGET_DATA,
+      message: t`Standalone rich text widgets are only supported on dashboards`,
+      userFriendlyMessage: msg`Rich text widgets can only be added to dashboards`,
+      value: referencedPageLayout.type,
+    },
+  ];
+};


### PR DESCRIPTION
## Context

`STANDALONE_RICH_TEXT` widgets could be created on record page layout tabs
through the metadata API. The mutation succeeded and `getPageLayoutWidgets`
returned the widget, but the record page rendered nothing — the renderer is
dashboard-only, so the widget silently resolved to `null`.

Closes #21093

## Changes

Server-side validation now rejects `STANDALONE_RICH_TEXT` widgets whose page
layout is not a dashboard — on both create and update — returning a clear
`INVALID_PAGE_LAYOUT_WIDGET_DATA` error instead of persisting a widget that
renders nothing.

- Resolve the widget's page layout type in the existing widget-type validator
  layer (widget → tab → layout)
- Wire the check into the standalone rich text creation and update validators
- Expose `flatPageLayoutMaps` to the page-layout-widget validator (mirrors the
  existing page-layout-tab validator wiring)

## Not included

Widgets already persisted on non-dashboard layouts are not backfilled — this
prevents new ones only.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/21775?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

