### PR TITLE
Add search input to manual record trigger object select

### DIFF
--- a/packages/twenty-front/src/modules/workflow/workflow-trigger/components/WorkflowEditTriggerManual.tsx
+++ b/packages/twenty-front/src/modules/workflow/workflow-trigger/components/WorkflowEditTriggerManual.tsx
@@ -146,6 +146,7 @@ export const WorkflowEditTriggerManual = ({
             }}
             dropdownOffset={{ y: 4 }}
             dropdownWidth={GenericDropdownContentWidth.ExtraLarge}
+            withSearchInput
           />
         ) : null}
 


### PR DESCRIPTION
When configuring a manual record trigger in the workflow editor, the object selector could only be scrolled, not searched. This adds a search input to the object `Select` (via the existing `withSearchInput` prop), matching the behavior already used in the create-record action's object selector.

## Before

<img width="786" height="544" alt="CleanShot 2026-06-18 at 13 35 45@2x" src="https://github.com/user-attachments/assets/30426a16-927e-4be3-80b6-73a296253c16" />

## After
<img width="786" height="628" alt="CleanShot 2026-06-18 at 13 35 22@2x" src="https://github.com/user-attachments/assets/57455518-0f95-483b-81d4-e1f4547c0d30" />

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/21777?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

