### PR TITLE
fix: allow null phone default values in phones field schema

### DIFF
--- a/packages/twenty-front/src/modules/object-record/record-field/ui/types/FieldMetadata.ts
+++ b/packages/twenty-front/src/modules/object-record/record-field/ui/types/FieldMetadata.ts
@@ -336,7 +336,7 @@ export type PhoneRecord = {
 };
 
 export type FieldPhonesValue = {
-  primaryPhoneNumber: string;
+  primaryPhoneNumber: string | null;
   primaryPhoneCountryCode: string;
   primaryPhoneCallingCode?: string;
   additionalPhones?: PhoneRecord[] | null;

--- a/packages/twenty-front/src/modules/object-record/record-field/ui/validation-schemas/phonesFieldValueSchema.ts
+++ b/packages/twenty-front/src/modules/object-record/record-field/ui/validation-schemas/phonesFieldValueSchema.ts
@@ -3,7 +3,7 @@ import { z } from 'zod';
 import { type FieldPhonesValue } from '@/object-record/record-field/ui/types/FieldMetadata';
 
 export const phonesFieldValueSchema = z.object({
-  primaryPhoneNumber: z.string(),
+  primaryPhoneNumber: z.string().nullable(),
   primaryPhoneCountryCode: z.string(),
   primaryPhoneCallingCode: z.string().optional(),
   additionalPhones: z


### PR DESCRIPTION
## What

Fixes an issue where changing the Default Country Code on a Phones field did not enable the Save button.

## Root cause

Existing Phones fields can contain a `null` value for `primaryPhoneNumber`, while the validation schema required a string.

This caused the form to remain invalid even after the user changed the country code, preventing the Save button from being enabled.

## Fix

Updated the phones field validation schema to accept nullable phone numbers, aligning the schema with persisted field values.
JAM: https://jam.dev/c/0775febd-1be1-4c52-b022-7b6bb4de6d1e

## Testing

* Opened an existing Phones field in Data Model settings.
* Changed the Default Country Code.
* Verified the Save button becomes enabled.
* Verified the field can be saved successfully.

close #21780


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/21782?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

