### PR TITLE
Fix typecheck

### DIFF
--- a/packages/twenty-front/src/modules/workflow/workflow-diagram/components/WorkflowDiagramCanvasEditable.tsx
+++ b/packages/twenty-front/src/modules/workflow/workflow-diagram/components/WorkflowDiagramCanvasEditable.tsx
@@ -30,6 +30,7 @@ import {
   ReactFlowProvider,
   type Connection,
   type Edge,
+  type OnNodeDrag,
 } from '@xyflow/react';
 import { useCallback } from 'react';
 import { isDefined } from 'twenty-shared/utils';
@@ -133,10 +134,7 @@ export const WorkflowDiagramCanvasEditable = () => {
     });
   };
 
-  const onNodeDragStop = async (
-    _: MouseEvent | TouchEvent,
-    node: WorkflowDiagramNode,
-  ) => {
+  const onNodeDragStop: OnNodeDrag<WorkflowDiagramNode> = async (_, node) => {
     const stepToUpdate =
       workflowWithCurrentVersion?.currentVersion?.steps?.find(
         (step) => step.id === node.id,


### PR DESCRIPTION
Typed `onNodeDragStop` as `@xyflow/react`'s `OnNodeDrag<WorkflowDiagramNode>` instead of hand-annotating the event param with the global DOM `MouseEvent | TouchEvent`, which didn't match the prop's expected React `MouseEvent` and broke typecheck.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/21783?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->