### PR TITLE
Remove twenty-shared import from postcard app

### DIFF
--- a/packages/twenty-apps/examples/postcard/src/components/card.front-component.tsx
+++ b/packages/twenty-apps/examples/postcard/src/components/card.front-component.tsx
@@ -185,9 +185,9 @@ const PostCardPreview = () => {
 
   return (
     <CardDisplay
-      name={postCard!.name}
-      content={postCard!.content}
-      status={postCard!.status}
+      name={postCard.name}
+      content={postCard.content}
+      status={postCard.status}
     />
   );
 };

--- a/packages/twenty-apps/examples/postcard/src/components/card.front-component.tsx
+++ b/packages/twenty-apps/examples/postcard/src/components/card.front-component.tsx
@@ -2,8 +2,8 @@ import { useCallback, useEffect, useState } from 'react';
 import { CoreApiClient } from 'twenty-client-sdk/core';
 import { defineFrontComponent } from 'twenty-sdk/define';
 import { useRecordId } from 'twenty-sdk/front-component';
-import { isDefined } from 'twenty-shared/utils';
 
+import { isDefined } from 'src/utils/isDefined';
 import { CARD_TEST_IDS } from './card-test-ids';
 
 export const CARD_FRONT_COMPONENT_UNIVERSAL_IDENTIFIER =
@@ -185,9 +185,9 @@ const PostCardPreview = () => {
 
   return (
     <CardDisplay
-      name={postCard.name}
-      content={postCard.content}
-      status={postCard.status}
+      name={postCard!.name}
+      content={postCard!.content}
+      status={postCard!.status}
     />
   );
 };

--- a/packages/twenty-apps/examples/postcard/src/navigation-menu-items/post-cards.navigation-menu-item.ts
+++ b/packages/twenty-apps/examples/postcard/src/navigation-menu-items/post-cards.navigation-menu-item.ts
@@ -1,5 +1,7 @@
-import { defineNavigationMenuItem } from 'twenty-sdk/define';
-import { NavigationMenuItemType } from 'twenty-shared/types';
+import {
+  defineNavigationMenuItem,
+  NavigationMenuItemType,
+} from 'twenty-sdk/define';
 import { POST_CARD_UNIVERSAL_IDENTIFIER } from '../objects/post-card.object';
 
 export default defineNavigationMenuItem({

--- a/packages/twenty-apps/examples/postcard/src/utils/isDefined.ts
+++ b/packages/twenty-apps/examples/postcard/src/utils/isDefined.ts
@@ -1,0 +1,3 @@
+export const isDefined = <T>(
+  value: T | null | undefined,
+): value is NonNullable<T> => value !== null && value !== undefined;

--- a/packages/twenty-apps/examples/postcard/src/views/all-post-cards.view.ts
+++ b/packages/twenty-apps/examples/postcard/src/views/all-post-cards.view.ts
@@ -1,11 +1,10 @@
-import { defineView } from 'twenty-sdk/define';
+import { defineView, ViewType } from 'twenty-sdk/define';
 import {
   CONTENT_FIELD_UNIVERSAL_IDENTIFIER,
   NAME_FIELD_UNIVERSAL_IDENTIFIER,
   POST_CARD_UNIVERSAL_IDENTIFIER,
 } from '../objects/post-card.object';
 import { RECIPIENT_ON_POST_CARD_ID } from '../fields/recipient-on-post-card.field';
-import { ViewType } from 'twenty-shared/types';
 
 export const ALL_POST_CARDS_VIEW_ID = 'b1a2b3c4-0001-4a7b-8c9d-0e1f2a3b4c5d';
 


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/21786?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

