### PR TITLE
[Website] Straighten the footer 20 model

### DIFF
--- a/packages/twenty-website-redone/src/sections/footer/footer-backdrop-config.ts
+++ b/packages/twenty-website-redone/src/sections/footer/footer-backdrop-config.ts
@@ -50,9 +50,9 @@ export const FOOTER_BACKDROP: Pick<
   },
   initialPose: {
     rotationX: -0.5858908325312259,
-    rotationY: 0.45733435420243096,
+    rotationY: 0.363343542024313,
     targetRotationX: -0.5858908325312265,
-    targetRotationY: 0.4573343542024313,
+    targetRotationY: 0.363343542024313,
     timeElapsed: 287.372499999977,
   },
 };


### PR DESCRIPTION
Reduce the footer model's resting yaw (rotationY 0.457 -> 0.363) so the "20" sits level instead of leaning.

<img width="1512" height="578" alt="image" src="https://github.com/user-attachments/assets/6f3151b1-b1c4-4d6e-9cec-6881e4e33845" />