### PR TITLE
Disable Claude Code attribution on commits and PRs

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://json.schemastore.org/claude-code-settings.json",
+  "attribution": {
+    "commit": "",
+    "pr": ""
+  }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,8 @@
 **/**/.env
 .DS_Store
 /.idea
-.claude/
+.claude/*
+!.claude/settings.json
 .cursor/debug-*.log
 **/**/node_modules/
 .cache


### PR DESCRIPTION
## What

Adds a committed `.claude/settings.json` that turns off Claude Code's git attribution:

```json
{ "attribution": { "commit": "", "pr": "" } }
```

- `commit: ""` removes the `Co-Authored-By: Claude` trailer from commit messages.
- `pr: ""` removes the "Generated with Claude Code" text from PR descriptions.

Also narrows the `.gitignore` rule from `.claude/` to `.claude/*` + `!.claude/settings.json`, so this one shared config is tracked while personal `.claude/` files (plans, `settings.local.json`, etc.) stay ignored. Includes the schemastore `$schema` for editor autocomplete/validation.

## Why

Cloud (Claude Code on the web) sessions clone the repo fresh and read **committed** repo config, but do **not** read a developer's local `~/.claude/settings.json`. Setting attribution only at the user level (the usual advice) therefore has no effect on cloud-created commits/PRs. Committing it to the repo is what applies to every future cloud session — and to all contributors using Claude Code on this repo.

## Scope

This is repo-wide: it affects every contributor using Claude Code on `twenty`, not just one person. Easy to scope down later via `.claude/settings.local.json` if anyone wants attribution back locally.

## Follow-up / verification

Per the docs, `attribution.commit: ""` hides commit text "including any trailers", so it should also suppress the cloud-only `Claude-Session:` trailer and the PR session-URL line — but that cloud trailer is undocumented, so it will be confirmed on the first cloud PR opened from a session based on `main` after this merges. If it survives, a one-line guard in `CLAUDE.md` (also loaded in cloud) is the fallback.

---
_Generated by [Claude Code](https://claude.ai/code/session_01PipZFnzew1VuU48kiHm35R)_

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/21798?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

