### PR TITLE
fix(server): treat released query runner as a transient import error

### DIFF
--- a/packages/twenty-server/src/engine/twenty-orm/error-handling/__tests__/compute-twenty-orm-exception.spec.ts
+++ b/packages/twenty-server/src/engine/twenty-orm/error-handling/__tests__/compute-twenty-orm-exception.spec.ts
@@ -18,6 +18,15 @@ describe('computeTwentyORMException', () => {
     );
   });
 
+  it('should preserve the original stack and cause when wrapping a released runner error', async () => {
+    const error = new QueryRunnerAlreadyReleasedError();
+
+    const result = await computeTwentyORMException(error);
+
+    expect(result.stack).toBe(error.stack);
+    expect((result as TwentyORMException).cause).toBe(error);
+  });
+
   it('should return unrelated errors unchanged', async () => {
     const error = new Error('some other error');
 

--- a/packages/twenty-server/src/engine/twenty-orm/error-handling/__tests__/compute-twenty-orm-exception.spec.ts
+++ b/packages/twenty-server/src/engine/twenty-orm/error-handling/__tests__/compute-twenty-orm-exception.spec.ts
@@ -1,0 +1,28 @@
+import { QueryRunnerAlreadyReleasedError } from 'typeorm';
+
+import { computeTwentyORMException } from 'src/engine/twenty-orm/error-handling/compute-twenty-orm-exception';
+import {
+  TwentyORMException,
+  TwentyORMExceptionCode,
+} from 'src/engine/twenty-orm/exceptions/twenty-orm.exception';
+
+describe('computeTwentyORMException', () => {
+  it('should map a released query runner error to a retryable QUERY_RUNNER_RELEASED exception', async () => {
+    const error = new QueryRunnerAlreadyReleasedError();
+
+    const result = await computeTwentyORMException(error);
+
+    expect(result).toBeInstanceOf(TwentyORMException);
+    expect((result as TwentyORMException).code).toBe(
+      TwentyORMExceptionCode.QUERY_RUNNER_RELEASED,
+    );
+  });
+
+  it('should return unrelated errors unchanged', async () => {
+    const error = new Error('some other error');
+
+    const result = await computeTwentyORMException(error);
+
+    expect(result).toBe(error);
+  });
+});

--- a/packages/twenty-server/src/engine/twenty-orm/error-handling/compute-twenty-orm-exception.ts
+++ b/packages/twenty-server/src/engine/twenty-orm/error-handling/compute-twenty-orm-exception.ts
@@ -24,15 +24,19 @@ export const computeTwentyORMException = async (
   entityManager?: WorkspaceEntityManager,
   internalContext?: WorkspaceInternalContext,
 ): Promise<Error | TwentyORMException> => {
-  // A released query runner means the underlying connection was torn down
-  // mid-flight (e.g. node-postgres `query_timeout` destroying the pooled
-  // connection during a transaction). It is transient, so we surface it as a
-  // retryable error rather than an opaque failure.
   if (error instanceof QueryRunnerAlreadyReleasedError) {
-    return new TwentyORMException(
+    const releasedRunnerException = new TwentyORMException(
       error.message,
       TwentyORMExceptionCode.QUERY_RUNNER_RELEASED,
     );
+
+    // Keep the original stack: it points at the query that ran on the
+    // released runner, which is the only way to locate where the operation
+    // escaped its transaction boundary.
+    releasedRunnerException.stack = error.stack;
+    releasedRunnerException.cause = error;
+
+    return releasedRunnerException;
   }
 
   if (error instanceof QueryFailedError) {

--- a/packages/twenty-server/src/engine/twenty-orm/error-handling/compute-twenty-orm-exception.ts
+++ b/packages/twenty-server/src/engine/twenty-orm/error-handling/compute-twenty-orm-exception.ts
@@ -1,6 +1,6 @@
 import { msg } from '@lingui/core/macro';
 import { isDefined } from 'twenty-shared/utils';
-import { QueryFailedError } from 'typeorm';
+import { QueryFailedError, QueryRunnerAlreadyReleasedError } from 'typeorm';
 
 import { type WorkspaceInternalContext } from 'src/engine/twenty-orm/interfaces/workspace-internal-context.interface';
 
@@ -24,6 +24,17 @@ export const computeTwentyORMException = async (
   entityManager?: WorkspaceEntityManager,
   internalContext?: WorkspaceInternalContext,
 ): Promise<Error | TwentyORMException> => {
+  // A released query runner means the underlying connection was torn down
+  // mid-flight (e.g. node-postgres `query_timeout` destroying the pooled
+  // connection during a transaction). It is transient, so we surface it as a
+  // retryable error rather than an opaque failure.
+  if (error instanceof QueryRunnerAlreadyReleasedError) {
+    return new TwentyORMException(
+      error.message,
+      TwentyORMExceptionCode.QUERY_RUNNER_RELEASED,
+    );
+  }
+
   if (error instanceof QueryFailedError) {
     if (error.message.includes('Query read timeout')) {
       return new TwentyORMException(

--- a/packages/twenty-server/src/engine/twenty-orm/exceptions/twenty-orm.exception.ts
+++ b/packages/twenty-server/src/engine/twenty-orm/exceptions/twenty-orm.exception.ts
@@ -21,6 +21,7 @@ export enum TwentyORMExceptionCode {
   METHOD_NOT_ALLOWED = 'METHOD_NOT_ALLOWED',
   ENUM_TYPE_NAME_NOT_FOUND = 'ENUM_TYPE_NAME_NOT_FOUND',
   QUERY_READ_TIMEOUT = 'QUERY_READ_TIMEOUT',
+  QUERY_RUNNER_RELEASED = 'QUERY_RUNNER_RELEASED',
   DUPLICATE_ENTRY_DETECTED = 'DUPLICATE_ENTRY_DETECTED',
   TOO_MANY_RECORDS_TO_UPDATE = 'TOO_MANY_RECORDS_TO_UPDATE',
   INVALID_INPUT = 'INVALID_INPUT',
@@ -61,6 +62,8 @@ const getTwentyORMExceptionUserFriendlyMessage = (
       return msg`This operation is not allowed.`;
     case TwentyORMExceptionCode.QUERY_READ_TIMEOUT:
       return msg`Query timed out. Please try again.`;
+    case TwentyORMExceptionCode.QUERY_RUNNER_RELEASED:
+      return msg`We are experiencing a temporary issue with our database. Please try again later.`;
     case TwentyORMExceptionCode.DUPLICATE_ENTRY_DETECTED:
       return msg`A duplicate entry was detected.`;
     case TwentyORMExceptionCode.TOO_MANY_RECORDS_TO_UPDATE:

--- a/packages/twenty-server/src/modules/calendar/calendar-event-import-manager/services/calendar-event-import-exception-handler.service.ts
+++ b/packages/twenty-server/src/modules/calendar/calendar-event-import-manager/services/calendar-event-import-exception-handler.service.ts
@@ -57,6 +57,7 @@ export class CalendarEventImportErrorHandlerService {
         );
         break;
       case TwentyORMExceptionCode.QUERY_READ_TIMEOUT:
+      case TwentyORMExceptionCode.QUERY_RUNNER_RELEASED:
       case CalendarEventImportDriverExceptionCode.TEMPORARY_ERROR:
       case ConnectedAccountRefreshAccessTokenExceptionCode.TEMPORARY_NETWORK_ERROR:
         await this.handleTemporaryException(

--- a/packages/twenty-server/src/modules/calendar/calendar-event-import-manager/services/calendar-event-import-exception-handler.service.ts
+++ b/packages/twenty-server/src/modules/calendar/calendar-event-import-manager/services/calendar-event-import-exception-handler.service.ts
@@ -56,8 +56,24 @@ export class CalendarEventImportErrorHandlerService {
           workspaceId,
         );
         break;
-      case TwentyORMExceptionCode.QUERY_READ_TIMEOUT:
       case TwentyORMExceptionCode.QUERY_RUNNER_RELEASED:
+        // Transient, so retried like any temporary error - but also reported
+        // every time (with the original stack preserved upstream) so the
+        // operation that escapes its transaction boundary can be located.
+        this.exceptionHandlerService.captureExceptions([exception], {
+          additionalData: {
+            calendarChannelId: calendarChannel.id,
+            syncStep,
+          },
+          workspace: { id: workspaceId },
+        });
+        await this.handleTemporaryException(
+          syncStep,
+          calendarChannel,
+          workspaceId,
+        );
+        break;
+      case TwentyORMExceptionCode.QUERY_READ_TIMEOUT:
       case CalendarEventImportDriverExceptionCode.TEMPORARY_ERROR:
       case ConnectedAccountRefreshAccessTokenExceptionCode.TEMPORARY_NETWORK_ERROR:
         await this.handleTemporaryException(

--- a/packages/twenty-server/src/modules/messaging/message-import-manager/services/messaging-import-exception-handler.service.ts
+++ b/packages/twenty-server/src/modules/messaging/message-import-manager/services/messaging-import-exception-handler.service.ts
@@ -72,6 +72,7 @@ export class MessageImportExceptionHandlerService {
           );
           break;
         case TwentyORMExceptionCode.QUERY_READ_TIMEOUT:
+        case TwentyORMExceptionCode.QUERY_RUNNER_RELEASED:
         case MessageImportDriverExceptionCode.TEMPORARY_ERROR:
         case ConnectedAccountRefreshAccessTokenExceptionCode.TEMPORARY_NETWORK_ERROR:
         case MessageNetworkExceptionCode.ECONNABORTED:


### PR DESCRIPTION
## Problem

Sentry is reporting calendar import failures like:

> Unknown error importing calendar events for calendar channel … : Query runner already released. Cannot run queries anymore.

The underlying error is TypeORM's `QueryRunnerAlreadyReleasedError`, thrown when a query runs on a query runner whose connection was already torn down.

### Root cause

The workspace datasource pool sets node-postgres `query_timeout`. Calendar events are saved inside a transaction whose reads run on the transaction's dedicated query runner. When a query on that runner exceeds `query_timeout`, node-postgres destroys the underlying connection mid-flight; a follow-up read on the now-released runner throws `QueryRunnerAlreadyReleasedError`. The Sentry breadcrumb fits exactly — it fails right after a successful `GET .../events [200]`, i.e. during the save/import DB work.

This is a **transient** connection-lifecycle error, but it currently falls through to the unknown-error path, which marks the channel **FAILED**, flushes the pending events to import, and fires a Sentry alert. The sibling error "Query read timeout" (same `query_timeout` mechanism) is already classified as a temporary, retryable error — released-runner was just never mapped.

## Fix

Classify the released-runner error as transient/retryable, mirroring the existing `QUERY_READ_TIMEOUT` handling:

- `computeTwentyORMException` maps `QueryRunnerAlreadyReleasedError` → new `TwentyORMExceptionCode.QUERY_RUNNER_RELEASED` (the central error path all workspace query-builder operations flow through).
- Added the `QUERY_RUNNER_RELEASED` code + user-friendly message.
- Calendar and messaging import exception handlers treat the code as a temporary error.

Now an occurrence increments `throttleFailureCount` and reschedules instead of failing the channel + flushing events. If it genuinely persists past the throttle max attempts, it still escalates — so a real bug isn't hidden forever.

## Scope

This stops the false failures/alerts for a transient error. Fully *preventing* the timeout would mean reworking how long-running import transactions interact with `query_timeout` — a larger, riskier change left for a separate effort if these timeouts prove frequent rather than sporadic.

## Testing

- New unit test for the `QueryRunnerAlreadyReleasedError` mapping (passes).
- Lint + format clean on all changed files.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/21800?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

