### PR TITLE
fix(front): unwrap react-qr-code default export to fix 2FA crash on prod

### DIFF
--- a/packages/twenty-front/src/modules/auth/sign-in-up/components/internal/SignInUpTwoFactorAuthenticationProvision.tsx
+++ b/packages/twenty-front/src/modules/auth/sign-in-up/components/internal/SignInUpTwoFactorAuthenticationProvision.tsx
@@ -7,7 +7,7 @@ import {
 import { extractSecretFromOtpUri } from '@/settings/two-factor-authentication/utils/extractSecretFromOtpUri';
 import { styled } from '@linaria/react';
 import { Trans, useLingui } from '@lingui/react/macro';
-import QRCode from 'react-qr-code';
+import QRCodeModule from 'react-qr-code';
 import { useSetAtomState } from '@/ui/utilities/state/jotai/hooks/useSetAtomState';
 import { IconCopy } from 'twenty-ui/icon';
 import { Loader } from 'twenty-ui/feedback';
@@ -15,7 +15,10 @@ import { MainButton } from 'twenty-ui/input';
 import { useContext } from 'react';
 import { ThemeContext, themeCssVariables } from 'twenty-ui/theme-constants';
 import { useAtomStateValue } from '@/ui/utilities/state/jotai/hooks/useAtomStateValue';
+import { resolveCjsModuleDefaultExport } from '~/utils/resolveCjsModuleDefaultExport';
 import { useCopyToClipboard } from '~/hooks/useCopyToClipboard';
+
+const QRCode = resolveCjsModuleDefaultExport(QRCodeModule);
 
 const StyledMainContentContainer = styled.div`
   margin-bottom: ${themeCssVariables.spacing[8]};

--- a/packages/twenty-front/src/pages/settings/profile/SettingsTwoFactorAuthenticationMethod.tsx
+++ b/packages/twenty-front/src/pages/settings/profile/SettingsTwoFactorAuthenticationMethod.tsx
@@ -1,7 +1,7 @@
 import { styled } from '@linaria/react';
 import { Trans, useLingui } from '@lingui/react/macro';
 import { FormProvider } from 'react-hook-form';
-import QRCode from 'react-qr-code';
+import QRCodeModule from 'react-qr-code';
 
 import { qrCodeState } from '@/auth/states/qrCode';
 import { SaveAndCancelButtons } from '@/settings/components/SaveAndCancelButtons/SaveAndCancelButtons';
@@ -20,7 +20,10 @@ import { Loader } from 'twenty-ui/feedback';
 import { Section } from 'twenty-ui/layout';
 import { useAtomStateValue } from '@/ui/utilities/state/jotai/hooks/useAtomStateValue';
 import { themeCssVariables } from 'twenty-ui/theme-constants';
+import { resolveCjsModuleDefaultExport } from '~/utils/resolveCjsModuleDefaultExport';
 import { useCopyToClipboard } from '~/hooks/useCopyToClipboard';
+
+const QRCode = resolveCjsModuleDefaultExport(QRCodeModule);
 
 const StyledQRCodeContainer = styled.div`
   align-items: flex-start;

--- a/packages/twenty-front/src/utils/resolveCjsModuleDefaultExport.ts
+++ b/packages/twenty-front/src/utils/resolveCjsModuleDefaultExport.ts
@@ -1,0 +1,10 @@
+import { isDefined } from 'twenty-shared/utils';
+
+export const resolveCjsModuleDefaultExport = <TDefaultExport>(
+  importedModule: TDefaultExport,
+): TDefaultExport => {
+  const defaultExport = (importedModule as { default?: TDefaultExport })
+    .default;
+
+  return isDefined(defaultExport) ? defaultExport : importedModule;
+};


### PR DESCRIPTION
## Problem

2FA is broken on prod (critical, reported on Discord and in #21649): instead of the 2FA setup screen, users hit the app-wide error page — both at login-time provisioning and on **Settings > Profile > Two-Factor Authentication**. The 2FA screen flashes briefly (loader) and then the error page replaces it.

Fixes #21649.

## Root cause

The crash is a React render error — *"Element type is invalid: got object"* — at the exact moment the QR code renders (when `qrCode` flips from `null` to a value).

`react-qr-code` is a CommonJS package (`__esModule: true`, `exports.default = QRCode`). The recent **Vite 8 / rolldown** bundler migration changed how its CommonJS default export is resolved into an ESM import: `import QRCode from 'react-qr-code'` now resolves to the **module namespace object** `{ default, QRCode }` instead of the component itself. Rendering that object as a React element throws and trips the error boundary.

The import code never changed — only the bundler's module resolution did, which is why this regressed without any 2FA code change. Reproduced the resolution with an esbuild/rolldown-style bundle: the default import comes back as `{ default, QRCode }`, with the real `forwardRef` component sitting on `.default`.

## Fix

Add a small `resolveCjsModuleDefaultExport` helper that returns the default export when a CommonJS import is handed back as a namespace object, and a no-op otherwise. Use it in the two 2FA QR render paths:

- `SignInUpTwoFactorAuthenticationProvision.tsx` (login-time provisioning)
- `SettingsTwoFactorAuthenticationMethod.tsx` (profile settings)

## Verification

- `npx nx lint:diff-with-main twenty-front` ✅ (lint + format)
- `npx nx typecheck twenty-front` ✅ (CI)
