### PR TITLE
fix: qr code setup

### DIFF
--- a/packages/twenty-front/src/modules/auth/sign-in-up/components/internal/SignInUpTwoFactorAuthenticationProvision.tsx
+++ b/packages/twenty-front/src/modules/auth/sign-in-up/components/internal/SignInUpTwoFactorAuthenticationProvision.tsx
@@ -7,7 +7,7 @@ import {
 import { extractSecretFromOtpUri } from '@/settings/two-factor-authentication/utils/extractSecretFromOtpUri';
 import { styled } from '@linaria/react';
 import { Trans, useLingui } from '@lingui/react/macro';
-import QRCode from 'react-qr-code';
+import { QRCode } from 'react-qr-code';
 import { useSetAtomState } from '@/ui/utilities/state/jotai/hooks/useSetAtomState';
 import { IconCopy } from 'twenty-ui/icon';
 import { Loader } from 'twenty-ui/feedback';

--- a/packages/twenty-front/src/modules/types/react-qr-code.d.ts
+++ b/packages/twenty-front/src/modules/types/react-qr-code.d.ts
@@ -1,0 +1,5 @@
+declare module 'react-qr-code' {
+  import { type ComponentType } from 'react';
+
+  export const QRCode: ComponentType<QRCodeProps>;
+}

--- a/packages/twenty-front/src/pages/settings/profile/SettingsTwoFactorAuthenticationMethod.tsx
+++ b/packages/twenty-front/src/pages/settings/profile/SettingsTwoFactorAuthenticationMethod.tsx
@@ -1,7 +1,7 @@
 import { styled } from '@linaria/react';
 import { Trans, useLingui } from '@lingui/react/macro';
 import { FormProvider } from 'react-hook-form';
-import QRCode from 'react-qr-code';
+import { QRCode } from 'react-qr-code';
 
 import { qrCodeState } from '@/auth/states/qrCode';
 import { SaveAndCancelButtons } from '@/settings/components/SaveAndCancelButtons/SaveAndCancelButtons';


### PR DESCRIPTION
## Problem

The TOTP two-factor authentication pages crash with Element type is invalid: expected a string but got: object once the QR code renders.

react-qr-code is a CommonJS package, and Vite's dep optimizer exposes its default export as the whole module.exports object ({ QRCode, default }) rather than the component. 
So import QRCode from 'react-qr-code' bound QRCode to a plain object, which React rejects as an element type.

## Fix

Use the named import, which resolves to the actual forwardRef component:

import { QRCode } from 'react-qr-code';

Applied to both files that render the QR code:
- SettingsTwoFactorAuthenticationMethod.tsx (settings 2FA)
- SignInUpTwoFactorAuthenticationProvision.tsx (sign-in 2FA, same latent crash)

TS CI fix: Since the package's bundled types only declare a default export, a small module augmentation (react-qr-code.d.ts) declares the QRCode named export so TypeScript matches the runtime resolution. (following the existing `apollo-upload-client.d.ts` precedent)

## Test
<img width="750" height="503" alt="Screenshot 2026-06-18 at 22 47 18" src="https://github.com/user-attachments/assets/9a6b0bbe-b018-4057-a1e9-2ec50955c21b" />
