### PR TITLE
fix(security): remove vulnerable lodash 4.17.23 (code injection + prototype pollution)

### DIFF
--- a/packages/twenty-client-sdk/package.json
+++ b/packages/twenty-client-sdk/package.json
@@ -55,7 +55,7 @@
     "prettier": "^3.8.3"
   },
   "devDependencies": {
-    "@types/lodash": "^4.17.15",
+    "@types/lodash": "^4.17.24",
     "@typescript/native-preview": "^7.0.0-dev.20260116.1",
     "tsc-alias": "^1.8.16",
     "twenty-shared": "workspace:*",

--- a/yarn.lock
+++ b/yarn.lock
@@ -20786,7 +20786,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@stoplight/spectral-core@npm:^1.18.3, @stoplight/spectral-core@npm:^1.19.2, @stoplight/spectral-core@npm:^1.19.4":
+"@stoplight/spectral-core@npm:1.23.0, @stoplight/spectral-core@npm:^1.18.3, @stoplight/spectral-core@npm:^1.19.2":
   version: 1.23.0
   resolution: "@stoplight/spectral-core@npm:1.23.0"
   dependencies:
@@ -20828,21 +20828,21 @@ __metadata:
   linkType: hard
 
 "@stoplight/spectral-functions@npm:^1.7.2":
-  version: 1.10.1
-  resolution: "@stoplight/spectral-functions@npm:1.10.1"
+  version: 1.10.3
+  resolution: "@stoplight/spectral-functions@npm:1.10.3"
   dependencies:
     "@stoplight/better-ajv-errors": "npm:1.0.3"
     "@stoplight/json": "npm:^3.17.1"
-    "@stoplight/spectral-core": "npm:^1.19.4"
+    "@stoplight/spectral-core": "npm:1.23.0"
     "@stoplight/spectral-formats": "npm:^1.8.1"
     "@stoplight/spectral-runtime": "npm:^1.1.2"
-    ajv: "npm:^8.17.1"
+    ajv: "npm:^8.18.0"
     ajv-draft-04: "npm:~1.0.0"
     ajv-errors: "npm:~3.0.0"
     ajv-formats: "npm:~2.1.1"
-    lodash: "npm:~4.17.21"
+    lodash: "npm:^4.18.1"
     tslib: "npm:^2.8.1"
-  checksum: 10c0/f26af18a8ff107f5d49a86e4134f10d244fc9bc64833b92c487d1372740b2b3839a72bb76d2061320f33498e65c2704aba5062635ec4c24c16139a4cf83497ca
+  checksum: 10c0/430f9453cb114735442dab230da39c244691037ffd239ce599be6c9db089c92cda1ddba0ee68ed16407bd9f9b468d87544594a95ff477408378e7cec2344e1ad
   languageName: node
   linkType: hard
 
@@ -41650,13 +41650,6 @@ __metadata:
   version: 4.18.1
   resolution: "lodash@npm:4.18.1"
   checksum: 10c0/757228fc68805c59789e82185135cf85f05d0b2d3d54631d680ca79ec21944ec8314d4533639a14b8bcfbd97a517e78960933041a5af17ecb693ec6eecb99a27
-  languageName: node
-  linkType: hard
-
-"lodash@npm:~4.17.21":
-  version: 4.17.23
-  resolution: "lodash@npm:4.17.23"
-  checksum: 10c0/1264a90469f5bb95d4739c43eb6277d15b6d9e186df4ac68c3620443160fc669e2f14c11e7d8b2ccf078b81d06147c01a8ccced9aab9f9f63d50dcf8cace6bf6
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -23231,14 +23231,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/lodash@npm:*":
-  version: 4.17.15
-  resolution: "@types/lodash@npm:4.17.15"
-  checksum: 10c0/2eb2dc6d231f5fb4603d176c08c8d7af688f574d09af47466a179cd7812d9f64144ba74bb32ca014570ffdc544eedc51b7a5657212bad083b6eecbd72223f9bb
-  languageName: node
-  linkType: hard
-
-"@types/lodash@npm:^4.17.15":
+"@types/lodash@npm:*, @types/lodash@npm:^4.17.24":
   version: 4.17.24
   resolution: "@types/lodash@npm:4.17.24"
   checksum: 10c0/b72f60d4daacdad1fa643edb3faba204c02a01eb1ac00a83ff73496a6d236fc55e459c06106e8ced42277dba932d087d8fc090f8de4ef590d3f91e6d6f7ce85a
@@ -54324,7 +54317,7 @@ __metadata:
   resolution: "twenty-client-sdk@workspace:packages/twenty-client-sdk"
   dependencies:
     "@genql/runtime": "npm:^2.10.0"
-    "@types/lodash": "npm:^4.17.15"
+    "@types/lodash": "npm:^4.17.24"
     "@typescript/native-preview": "npm:^7.0.0-dev.20260116.1"
     esbuild: "npm:^0.28.1"
     graphql: "npm:^16.8.1"


### PR DESCRIPTION
## fix(security): remove vulnerable lodash 4.17.23 (code injection + prototype pollution)

Resolves [Dependabot Alert #824](https://github.com/twentyhq/twenty/security/dependabot/824) and [#823](https://github.com/twentyhq/twenty/security/dependabot/823).

### What

`lodash` `<= 4.17.23` is affected by:
- **Code injection via `_.template`** ([#824](https://github.com/twentyhq/twenty/security/dependabot/824), High)
- **Prototype pollution via `_.unset`/`_.omit`** ([#823](https://github.com/twentyhq/twenty/security/dependabot/823), Medium)

Both are patched in `4.18.0`. The repo already resolved lodash to `4.18.1` everywhere **except** one copy held at `4.17.23` by `@stoplight/spectral-functions@1.10.1`, whose `~4.17.21` range capped lodash below `4.18.0`.

### How

Instead of a standing `resolutions` override, this bumps the parent that imposed the cap: **`@stoplight/spectral-functions` 1.10.1 → 1.10.3** (pulled transitively via `@asyncapi/parser` ← `@mintlify/common`, accepted through `^1.7.2`). 1.10.3 widened its lodash dependency to `^4.18.1`, so the capped bucket collapses into the existing `4.18.1` resolution and the vulnerable copy is removed — leaving the dependency graph honest with no lingering override.

### Also

Refreshes `@types/lodash` to the latest **4.17.24**: bumps the `twenty-client-sdk` pin `^4.17.15 → ^4.17.24` and dedupes the stale transitive `*` bucket (4.17.15) into a single `4.17.24` resolution. Type-stub only.

### Verification

- The only real `lodash` resolution is now `4.18.1` (remaining `4.17.x` entries are `@types/lodash` type stubs, not the library); `@types/lodash` resolves to a single `4.17.24` bucket.
- Lockfile-only dependency change; `yarn install --immutable` passes; `twenty-client-sdk` typecheck passes.