### PR TITLE
fix(security): bump piscina to 4.9.3 (prototype pollution → RCE)

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -46838,14 +46838,14 @@ __metadata:
   linkType: hard
 
 "piscina@npm:^4.3.1":
-  version: 4.9.2
-  resolution: "piscina@npm:4.9.2"
+  version: 4.9.3
+  resolution: "piscina@npm:4.9.3"
   dependencies:
     "@napi-rs/nice": "npm:^1.0.1"
   dependenciesMeta:
     "@napi-rs/nice":
       optional: true
-  checksum: 10c0/ab67830065ff41523cd901db41b11045cb00a0be43bf79323ff7b4ef2fbce5e3a56ad440d99d6c3944ce94451a0a69fd175500e3220b21efe54142e601322189
+  checksum: 10c0/357abfcc6226ec3da411f717ba76e55c105fff692269a6faedf8425eb429053b9c2aa65b58ccd74bae79d77cd30e3a3c677a3a8ed75b35519cf86bf498508a56
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## fix(security): bump piscina to 4.9.3 (prototype pollution → RCE)

Resolves [Dependabot Alert #1515](https://github.com/twentyhq/twenty/security/dependabot/1515).

### What

`piscina` `<= 4.9.2` is affected by [GHSA-x9g3-xrwr-cwfg](https://github.com/advisories/GHSA-x9g3-xrwr-cwfg) / CVE-2026-55388 — a **prototype-pollution gadget enabling RCE via inherited `options.filename`** (High). For the 4.x line, the first patched version is `4.9.3`.

### How

`piscina` is pulled transitively by `@swc/cli@0.8.1` via `^4.3.1`, which already permits `4.9.3`. This refreshes the stale lockfile resolution `4.9.2 → 4.9.3` within the existing range — no `resolutions` override needed.

### Verification

- `piscina` resolves to a single `4.9.3` bucket; no `<= 4.9.2` copy remains.
- Diff is limited to piscina's resolved version + checksum (its dependency set is unchanged).
- Lockfile-only change; `yarn install --immutable` passes.