### PR TITLE
fix(security): bump protobufjs to 7.6.4 (DoS + property shadowing)

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -16334,10 +16334,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@protobufjs/eventemitter@npm:^1.1.0":
-  version: 1.1.0
-  resolution: "@protobufjs/eventemitter@npm:1.1.0"
-  checksum: 10c0/1eb0a75180e5206d1033e4138212a8c7089a3d418c6dfa5a6ce42e593a4ae2e5892c4ef7421f38092badba4040ea6a45f0928869989411001d8c1018ea9a6e70
+"@protobufjs/eventemitter@npm:^1.1.1":
+  version: 1.1.1
+  resolution: "@protobufjs/eventemitter@npm:1.1.1"
+  checksum: 10c0/8e06193d4629c5e7c09d4f8c2ddba8fc4dfa739f0149f33a1d901568d35bb7b8b5277a4e8452baf3bdd0b302fd599cf255d193267aa93a0a4747e23cd073c4ac
   languageName: node
   linkType: hard
 
@@ -16354,13 +16354,6 @@ __metadata:
   version: 1.0.2
   resolution: "@protobufjs/float@npm:1.0.2"
   checksum: 10c0/18f2bdede76ffcf0170708af15c9c9db6259b771e6b84c51b06df34a9c339dbbeec267d14ce0bddd20acc142b1d980d983d31434398df7f98eb0c94a0eb79069
-  languageName: node
-  linkType: hard
-
-"@protobufjs/inquire@npm:^1.1.2":
-  version: 1.1.2
-  resolution: "@protobufjs/inquire@npm:1.1.2"
-  checksum: 10c0/af69597818a14cac6a00a74cd5b3fb85aa96658b9dbbae73e6d907cb154ebf470953a8c537b3e6095a43de565ec4e6c5b40227c72f4a7d762d34fbec7ac179e7
   languageName: node
   linkType: hard
 
@@ -47863,22 +47856,21 @@ __metadata:
   linkType: hard
 
 "protobufjs@npm:^7.3.0":
-  version: 7.6.0
-  resolution: "protobufjs@npm:7.6.0"
+  version: 7.6.4
+  resolution: "protobufjs@npm:7.6.4"
   dependencies:
     "@protobufjs/aspromise": "npm:^1.1.2"
     "@protobufjs/base64": "npm:^1.1.2"
     "@protobufjs/codegen": "npm:^2.0.5"
-    "@protobufjs/eventemitter": "npm:^1.1.0"
+    "@protobufjs/eventemitter": "npm:^1.1.1"
     "@protobufjs/fetch": "npm:^1.1.1"
     "@protobufjs/float": "npm:^1.0.2"
-    "@protobufjs/inquire": "npm:^1.1.2"
     "@protobufjs/path": "npm:^1.1.2"
     "@protobufjs/pool": "npm:^1.1.0"
     "@protobufjs/utf8": "npm:^1.1.1"
     "@types/node": "npm:>=13.7.0"
     long: "npm:^5.3.2"
-  checksum: 10c0/013339777bc29610ef141876d734aa538a7982d278930a121513171f32958b3b38411b259476d9118c56d55f67980a8f433476cfbfdd1d1c60b4a06f36d3f689
+  checksum: 10c0/6403eaa9c5a72cc6450c11f38fefafdde243fd806e7ac606ac8d591bc3fdaec45ae764febf83181a2d9aac51aca624e0f46dec368ceea191f7e85e2d6ccaaf93
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## fix(security): bump protobufjs to 7.6.4 (DoS + property shadowing)

Resolves [Dependabot Alert #1508](https://github.com/twentyhq/twenty/security/dependabot/1508) and [#1507](https://github.com/twentyhq/twenty/security/dependabot/1507).

### What

`protobufjs` in the 7.x line is affected by two advisories:
- [GHSA-wcpc-wj8m-hjx6](https://github.com/advisories/GHSA-wcpc-wj8m-hjx6) (**High**, [#1508](https://github.com/twentyhq/twenty/security/dependabot/1508)) — DoS through unbounded `Any` expansion during JSON conversion. Patched in `7.6.1`.
- [GHSA-f38q-mgvj-vph7](https://github.com/advisories/GHSA-f38q-mgvj-vph7) (**Moderate**, [#1507](https://github.com/twentyhq/twenty/security/dependabot/1507)) — schema-derived names can shadow runtime-significant properties. Patched in `7.6.3`.

### How

`protobufjs` is pulled transitively via `^7.3.0`, which already permits the patched releases. This refreshes the stale lockfile resolution `7.6.0 → 7.6.4` (the latest `7.x`; `>= 7.6.3` covers both advisories) within the existing range — no `resolutions` override needed. The `8.x` ranges in these advisories do not apply.

### Verification

- `protobufjs` resolves to a single `7.6.4` bucket (`>= 7.6.1` and `>= 7.6.3`), clearing both alerts.
- Diff is limited to the protobufjs family (`protobufjs` + its `@protobufjs/*` utility deps).
- Lockfile-only change; `yarn install --immutable` passes.