### PR TITLE
fix(security): bump http-proxy-middleware to 3.0.7 (multipart field injection)

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -37323,8 +37323,8 @@ __metadata:
   linkType: hard
 
 "http-proxy-middleware@npm:^3.0.5":
-  version: 3.0.5
-  resolution: "http-proxy-middleware@npm:3.0.5"
+  version: 3.0.7
+  resolution: "http-proxy-middleware@npm:3.0.7"
   dependencies:
     "@types/http-proxy": "npm:^1.17.15"
     debug: "npm:^4.3.6"
@@ -37332,7 +37332,7 @@ __metadata:
     is-glob: "npm:^4.0.3"
     is-plain-object: "npm:^5.0.0"
     micromatch: "npm:^4.0.8"
-  checksum: 10c0/89ff3c8fe65b22b8042a6173ae1b8f77c5171f7eecf3c8b5d6dcffe3c9d688acae7bcf498cc08d1525f566dc0781efaec4e2ddc49224b1f16f020de7987a446b
+  checksum: 10c0/2308a09b1ae7682bb91bed45653d3b17379b87e2bb8cad4e7e71c68eeb2cedb8fd5506f80f6890178d8aa4132a3ce71eaf58979e7ef04cfefac923117da41817
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## fix(security): bump http-proxy-middleware to 3.0.7 (multipart field injection)

Resolves [Dependabot Alert #1517](https://github.com/twentyhq/twenty/security/dependabot/1517).

### What

`http-proxy-middleware` `3.0.4 – 3.0.6` is affected by [GHSA-gcq2-9pq2-cxqm](https://github.com/advisories/GHSA-gcq2-9pq2-cxqm) (**High**) — multipart/form-data field injection via unescaped CRLF in `fixRequestBody`. Patched in `3.0.7` for the 3.x line.

### How

`http-proxy-middleware` is pulled transitively by `@nx/module-federation` and `@nx/react` via `^3.0.5`, which already permits `3.0.7`. This refreshes the stale lockfile resolution `3.0.5 → 3.0.7` within the existing range — no `resolutions` override needed. The separate `2.0.9` bucket (from `webpack-dev-server`) is outside the advisory's `>= 3.0.4` range and is left unchanged.

### Verification

- No `http-proxy-middleware` copy in the vulnerable `3.0.4 – 3.0.6` range remains; the 3.x bucket resolves to `3.0.7`.
- Diff is limited to the resolved version + checksum.
- Lockfile-only change; `yarn install --immutable` passes.