### PR TITLE
fix(security): dedupe uuid to 11.1.1 (missing buffer bounds check)

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -56465,21 +56465,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"uuid@npm:11.1.1, uuid@npm:^11.1.1":
+"uuid@npm:11.1.1, uuid@npm:^11.1.0, uuid@npm:^11.1.1":
   version: 11.1.1
   resolution: "uuid@npm:11.1.1"
   bin:
     uuid: dist/esm/bin/uuid
   checksum: 10c0/9e3af58eba872ece5a5e76f4773a94fc78a0ef2c2444c38dbe6b42f41dadf76c01850fd783604f27986f6195e6286aef064d45987d401b2a33127b98ddf7c0c5
-  languageName: node
-  linkType: hard
-
-"uuid@npm:^11.1.0":
-  version: 11.1.0
-  resolution: "uuid@npm:11.1.0"
-  bin:
-    uuid: dist/esm/bin/uuid
-  checksum: 10c0/34aa51b9874ae398c2b799c88a127701408cd581ee89ec3baa53509dd8728cbb25826f2a038f9465f8b7be446f0fbf11558862965b18d21c993684297628d4d3
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## fix(security): dedupe uuid to 11.1.1 (missing buffer bounds check)

Resolves [Dependabot Alert #1289](https://github.com/twentyhq/twenty/security/dependabot/1289).

### What

`uuid` `< 11.1.1` is affected by [GHSA-w5hq-g745-h8pq](https://github.com/advisories/GHSA-w5hq-g745-h8pq) (**Moderate**) — a missing buffer bounds check in `v3`/`v5`/`v6` when a `buf` argument is provided. Patched in `11.1.1`.

### How

The only vulnerable copy was a transitive `11.1.0` bucket pinned via `^11.1.0` by `typeorm@0.3.26` and `@recallai/desktop-sdk` — both ranges already permit `11.1.1`, and a `11.1.1` bucket already existed (our own packages resolve there). `yarn dedupe uuid` collapses the `^11.1.0` descriptor into the existing `11.1.1` resolution, removing the vulnerable copy. No `resolutions` override; the unrelated `13.x` bucket is left untouched.

### Verification

- No `uuid < 11.1.1` resolution remains.
- Our packages already resolved to `11.1.1`, so compiled output is unaffected (the change only lifts the transitive `typeorm`/`@recallai` copy).
- Lockfile-only change (net −9 lines); `yarn install --immutable` passes.