### PR TITLE
fix(security): patch yaml across both major lines (stack overflow)

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -58185,9 +58185,9 @@ __metadata:
   linkType: hard
 
 "yaml@npm:^1.10.0":
-  version: 1.10.2
-  resolution: "yaml@npm:1.10.2"
-  checksum: 10c0/5c28b9eb7adc46544f28d9a8d20c5b3cb1215a886609a2fd41f51628d8aaa5878ccd628b755dbcd29f6bb4921bd04ffbc6dcc370689bb96e594e2f9813d2605f
+  version: 1.10.3
+  resolution: "yaml@npm:1.10.3"
+  checksum: 10c0/c309ff85a0a569a981d71ab9cf0fef68672a16b9cdf40639d1c3b30034f6cd16ee428602bd6d64ecf006f8c8bee499023cac236538f79898aa99fb5db529a2ed
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -58175,7 +58175,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"yaml@npm:2.9.0, yaml@npm:^2.3.1, yaml@npm:^2.3.4, yaml@npm:^2.8.1, yaml@npm:^2.8.3":
+"yaml@npm:2.9.0, yaml@npm:^2.0.0, yaml@npm:^2.3.1, yaml@npm:^2.3.4, yaml@npm:^2.4.5, yaml@npm:^2.8.1, yaml@npm:^2.8.3":
   version: 2.9.0
   resolution: "yaml@npm:2.9.0"
   bin:
@@ -58188,15 +58188,6 @@ __metadata:
   version: 1.10.2
   resolution: "yaml@npm:1.10.2"
   checksum: 10c0/5c28b9eb7adc46544f28d9a8d20c5b3cb1215a886609a2fd41f51628d8aaa5878ccd628b755dbcd29f6bb4921bd04ffbc6dcc370689bb96e594e2f9813d2605f
-  languageName: node
-  linkType: hard
-
-"yaml@npm:^2.0.0, yaml@npm:^2.4.5":
-  version: 2.8.1
-  resolution: "yaml@npm:2.8.1"
-  bin:
-    yaml: bin.mjs
-  checksum: 10c0/7c587be00d9303d2ae1566e03bc5bc7fe978ba0d9bf39cc418c3139d37929dfcb93a230d9749f2cb578b6aa5d9ebebc322415e4b653cb83acd8bc0bc321707f3
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## fix(security): patch yaml across both major lines (stack overflow)

Resolves [Dependabot Alert #734](https://github.com/twentyhq/twenty/security/dependabot/734) and [#697](https://github.com/twentyhq/twenty/security/dependabot/697).

### What

`yaml` is affected by [GHSA-48c2-rrv3-qjmp](https://github.com/advisories/GHSA-48c2-rrv3-qjmp) (**Moderate**) — stack overflow via deeply nested YAML collections — across two major lines:
- **2.x** (`>= 2.0.0, < 2.8.3`, patched `2.8.3`) — alert #734 (runtime).
- **1.x** (`>= 1.0.0, < 1.10.3`, patched `1.10.3`) — alert #697 (dev, auto-dismissed).

### How

Both vulnerable copies are transitive, and `yaml` is not imported in our source:
- **2.x:** the `2.8.1` bucket (`^2.0.0` / `^2.4.5`, via `vfile-matter` / `@mintlify/openapi-parser`) is deduped into the safe `2.9.0` already in the tree.
- **1.x:** the `1.10.2` bucket (`^1.10.0`, via `cosmiconfig@^7.0.0`) is refreshed to `1.10.3`.

Both move within ranges the parents already declared — no `resolutions` override.

### Verification

- No `yaml` `1.x < 1.10.3` or `2.x < 2.8.3` resolution remains.
- `yaml` is not imported in our source (transitive only).
- Lockfile-only change; `yarn install --immutable` passes.