### PR TITLE
fix(front): pass auth headers to GraphiQL fetcher for introspection

### DIFF
--- a/packages/twenty-front/src/modules/settings/playground/components/GraphQLPlayground.tsx
+++ b/packages/twenty-front/src/modules/settings/playground/components/GraphQLPlayground.tsx
@@ -58,6 +58,9 @@ export const GraphQLPlayground = ({
 
   const fetcher = createGraphiQLFetcher({
     url: baseUrl,
+    headers: {
+      Authorization: `Bearer ${playgroundApiKey.token}`,
+    },
   });
 
   return (


### PR DESCRIPTION
## Summary
https://discord.com/channels/1130383047699738754/1517429151328374896
- The GraphiQL playground's automatic introspection query was firing without an `Authorization` header, causing "GraphQL introspection has been disabled" errors in production
- `defaultHeaders` only pre-fills the GraphiQL headers editor UI — it does not inject headers into actual fetch requests
- Added `headers` to the `createGraphiQLFetcher` config so all requests (including auto-introspection on load) are authenticated


## Test plan

- [x] Open Settings > API & Webhooks, select Core schema + GraphQL, click Launch
- [x] Verify the introspection query in the network tab now includes the `Authorization: Bearer ...` header
- [x] Confirm the schema explorer loads successfully in a production environment (or with `NODE_ENV=production`)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/21821?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

