### PR TITLE
fix(security): bump tar to 7.5.16 in seed-dependencies (PAX file smuggling)

### DIFF
--- a/packages/twenty-server/src/engine/core-modules/application/application-package/constants/seed-dependencies/yarn.lock
+++ b/packages/twenty-server/src/engine/core-modules/application/application-package/constants/seed-dependencies/yarn.lock
@@ -2945,15 +2945,15 @@ __metadata:
   linkType: hard
 
 "tar@npm:^7.5.4":
-  version: 7.5.13
-  resolution: "tar@npm:7.5.13"
+  version: 7.5.16
+  resolution: "tar@npm:7.5.16"
   dependencies:
     "@isaacs/fs-minipass": "npm:^4.0.0"
     chownr: "npm:^3.0.0"
     minipass: "npm:^7.1.2"
     minizlib: "npm:^3.1.0"
     yallist: "npm:^5.0.0"
-  checksum: 10c0/5c65b8084799bde7a791593a1c1a45d3d6ee98182e3700b24c247b7b8f8654df4191642abbdb07ff25043d45dcff35620827c3997b88ae6c12040f64bed5076b
+  checksum: 10c0/4f37f3c4bd2ca2755fd736a5df1d573c1a868ec1b1e893346aeafa95ac510f9e2fd1469420bd866cc7904799e5bd4ac62b5d4f03fe27747d6e1e373b44505c5c
   languageName: node
   linkType: hard
 

--- a/packages/twenty-server/src/engine/core-modules/application/application-package/utils/get-default-application-package-fields.util.ts
+++ b/packages/twenty-server/src/engine/core-modules/application/application-package/utils/get-default-application-package-fields.util.ts
@@ -8,7 +8,7 @@ import { SEED_DEPENDENCIES_DIRNAME } from 'src/engine/core-modules/application/a
 // package.json: hash(JSON.stringify(JSON.parse(content))). yarn.lock: hash(content).
 // Both use first 32 chars of SHA512 hex digest.
 const DEFAULT_PACKAGE_JSON_CHECKSUM = '6ec55ff4ec55f433415417c845bc5c04';
-const DEFAULT_YARN_LOCK_CHECKSUM = 'ad4e63ae552e06ea2d30791365a3b5e5';
+const DEFAULT_YARN_LOCK_CHECKSUM = '57cfae64905e3804cc1df95a0fa0707d';
 
 export type DefaultApplicationPackageFields = {
   packageJsonChecksum: string;


### PR DESCRIPTION
## fix(security): bump tar to 7.5.16 in seed-dependencies (PAX file smuggling)

Resolves [Dependabot Alert #1500](https://github.com/twentyhq/twenty/security/dependabot/1500).

### What

`tar` (`node-tar`) `<= 7.5.15` applies a PAX size override to intermediary GNU long-name/long-link headers, causing a tar-parser interpretation differential (file smuggling) — [GHSA-vmf3-w455-68vh](https://github.com/advisories/GHSA-vmf3-w455-68vh). Patched in `7.5.16`.

This is the **seed-dependencies holdout** deferred from the main tar PR (#21813): that lockfile + its checksum constants were also touched by the form-data PR, so it was carved out to avoid a conflict. The form-data PR has since merged, unblocking it.

### How

- Refreshed `tar` `7.5.13 -> 7.5.16` in `seed-dependencies/yarn.lock` (transitive via `^7.5.4`, which already permits it) — an in-range refresh, no override.
- Regenerated `DEFAULT_YARN_LOCK_CHECKSUM` in `get-default-application-package-fields.util.ts` so the row-stored checksum matches the value recomputed from file content in `application.service.ts` (the deps-layer cache key; `logicFunctionCreateHash` = SHA-512, first 32 hex). `package.json` is unchanged, so `DEFAULT_PACKAGE_JSON_CHECKSUM` is unaffected.

### Verification

- No `tar <= 7.5.15` remains in the seed lockfile.
- Both checksum constants verified to match the canonical recompute of the current seed files.
- Lint + format pass on the changed `.ts` file.