### PR TITLE
fix(workflow): label manual trigger record output as Record/Records

### DIFF
--- a/packages/twenty-front/src/modules/workflow/workflow-variables/utils/generate/__tests__/computeStepOutputSchema.test.ts
+++ b/packages/twenty-front/src/modules/workflow/workflow-variables/utils/generate/__tests__/computeStepOutputSchema.test.ts
@@ -199,7 +199,7 @@ describe('computeStepOutputSchema', () => {
 
       expect((result as any).payload).toMatchObject({
         isLeaf: false,
-        label: 'Payload',
+        label: 'Record',
       });
       expect((result as any).payload.value).toHaveProperty(
         '_outputSchemaType',
@@ -223,6 +223,10 @@ describe('computeStepOutputSchema', () => {
         objectMetadataItems: [mockCompanyObjectMetadataItem],
       });
 
+      expect((result as any).payload).toMatchObject({
+        isLeaf: false,
+        label: 'Records',
+      });
       expect((result as any).payload.value).toHaveProperty('companies');
       expect((result as any).payload.value.companies).toMatchObject({
         isLeaf: true,

--- a/packages/twenty-front/src/modules/workflow/workflow-variables/utils/generate/computeStepOutputSchema.ts
+++ b/packages/twenty-front/src/modules/workflow/workflow-variables/utils/generate/computeStepOutputSchema.ts
@@ -15,7 +15,8 @@ import {
   buildManualTriggerMetadataNode,
   WORKFLOW_TRIGGER_METADATA_KEY,
   WORKFLOW_TRIGGER_PAYLOAD_KEY,
-  WORKFLOW_TRIGGER_PAYLOAD_LABEL,
+  WORKFLOW_TRIGGER_RECORD_LABEL,
+  WORKFLOW_TRIGGER_RECORDS_LABEL,
 } from 'twenty-shared/workflow';
 import { DatabaseEventAction } from '~/generated-metadata/graphql';
 
@@ -130,7 +131,7 @@ export const computeStepOutputSchema = ({
             [WORKFLOW_TRIGGER_PAYLOAD_KEY]: {
               isLeaf: false,
               icon: objectMetadataItem.icon ?? undefined,
-              label: WORKFLOW_TRIGGER_PAYLOAD_LABEL,
+              label: WORKFLOW_TRIGGER_RECORD_LABEL,
               value: generateRecordOutputSchema(objectMetadataItem),
             },
             [WORKFLOW_TRIGGER_METADATA_KEY]: buildManualTriggerMetadataNode(),
@@ -142,7 +143,7 @@ export const computeStepOutputSchema = ({
           [WORKFLOW_TRIGGER_PAYLOAD_KEY]: {
             isLeaf: false,
             type: 'object',
-            label: WORKFLOW_TRIGGER_PAYLOAD_LABEL,
+            label: WORKFLOW_TRIGGER_RECORDS_LABEL,
             value: {
               [objectMetadataItem.namePlural]: {
                 isLeaf: true,

--- a/packages/twenty-server/src/modules/workflow/workflow-builder/workflow-schema/workflow-schema.workspace-service.ts
+++ b/packages/twenty-server/src/modules/workflow/workflow-builder/workflow-schema/workflow-schema.workspace-service.ts
@@ -18,7 +18,8 @@ import {
   TRIGGER_STEP_ID,
   WORKFLOW_TRIGGER_METADATA_KEY,
   WORKFLOW_TRIGGER_PAYLOAD_KEY,
-  WORKFLOW_TRIGGER_PAYLOAD_LABEL,
+  WORKFLOW_TRIGGER_RECORD_LABEL,
+  WORKFLOW_TRIGGER_RECORDS_LABEL,
   WorkflowActionType,
 } from 'twenty-shared/workflow';
 
@@ -480,7 +481,7 @@ export class WorkflowSchemaWorkspaceService {
       const payload: Node = {
         isLeaf: false,
         type: 'object',
-        label: WORKFLOW_TRIGGER_PAYLOAD_LABEL,
+        label: WORKFLOW_TRIGGER_RECORD_LABEL,
         value: recordOutputSchema,
       };
 
@@ -500,7 +501,7 @@ export class WorkflowSchemaWorkspaceService {
       const payload: Node = {
         isLeaf: false,
         type: 'object',
-        label: WORKFLOW_TRIGGER_PAYLOAD_LABEL,
+        label: WORKFLOW_TRIGGER_RECORDS_LABEL,
         value: {
           [objectMetadataInfo.flatObjectMetadata.namePlural]: {
             label: objectMetadataInfo.flatObjectMetadata.labelPlural,

--- a/packages/twenty-shared/src/workflow/constants/WorkflowTriggerPayloadLabel.ts
+++ b/packages/twenty-shared/src/workflow/constants/WorkflowTriggerPayloadLabel.ts
@@ -1,1 +1,0 @@
-export const WORKFLOW_TRIGGER_PAYLOAD_LABEL = 'Payload';

--- a/packages/twenty-shared/src/workflow/constants/WorkflowTriggerRecordLabel.ts
+++ b/packages/twenty-shared/src/workflow/constants/WorkflowTriggerRecordLabel.ts
@@ -1,0 +1,1 @@
+export const WORKFLOW_TRIGGER_RECORD_LABEL = 'Record';

--- a/packages/twenty-shared/src/workflow/constants/WorkflowTriggerRecordsLabel.ts
+++ b/packages/twenty-shared/src/workflow/constants/WorkflowTriggerRecordsLabel.ts
@@ -1,0 +1,1 @@
+export const WORKFLOW_TRIGGER_RECORDS_LABEL = 'Records';

--- a/packages/twenty-shared/src/workflow/index.ts
+++ b/packages/twenty-shared/src/workflow/index.ts
@@ -17,7 +17,8 @@ export { WORKFLOW_TRIGGER_METADATA_LABEL } from './constants/WorkflowTriggerMeta
 export { WORKFLOW_TRIGGER_METADATA_WORKSPACE_MEMBER_ID_KEY } from './constants/WorkflowTriggerMetadataWorkspaceMemberIdKey';
 export { WORKFLOW_TRIGGER_METADATA_WORKSPACE_MEMBER_ID_LABEL } from './constants/WorkflowTriggerMetadataWorkspaceMemberIdLabel';
 export { WORKFLOW_TRIGGER_PAYLOAD_KEY } from './constants/WorkflowTriggerPayloadKey';
-export { WORKFLOW_TRIGGER_PAYLOAD_LABEL } from './constants/WorkflowTriggerPayloadLabel';
+export { WORKFLOW_TRIGGER_RECORD_LABEL } from './constants/WorkflowTriggerRecordLabel';
+export { WORKFLOW_TRIGGER_RECORDS_LABEL } from './constants/WorkflowTriggerRecordsLabel';
 export { WORKFLOW_DIAGRAM_DEFAULT_NODE_DIMENSIONS } from './layout/constants/WorkflowDiagramDefaultNodeDimensions';
 export { WORKFLOW_LAYOUT_DEFAULT_OPTIONS } from './layout/constants/WorkflowLayoutDefaultOptions';
 export type {


### PR DESCRIPTION
## What

The manual trigger output schema exposed the triggering record(s) under a node labeled **Payload**. Relabels it to match what the node actually contains:

- **Single-record** availability → **Record**
- **Bulk-records** availability → **Records**

## Why

"Payload" was a misnomer — the node holds the record(s) that triggered the workflow. This is a display-label-only change.

## Notes for reviewers

- **No migration.** The persisted output schema key stays `payload`, so existing variable references (`{{trigger.payload.x}}`) are unaffected.
- The front recomputes the output schema on the fly (`computeStepOutputSchema`), so the variable picker shows the new labels immediately, including for existing triggers.
- The backend (`workflow-schema.workspace-service`) is updated to match for newly persisted/re-saved schemas. Previously persisted schemas keep "Payload" until re-saved.
- Added `WORKFLOW_TRIGGER_RECORD_LABEL` / `WORKFLOW_TRIGGER_RECORDS_LABEL` and removed the now-unused `WORKFLOW_TRIGGER_PAYLOAD_LABEL`.
- Unit tests updated for both single and bulk cases (55/55 passing).

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/21832?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

