### PR TITLE
fix: prevent Create Workspace redirect from being cancelled

### DIFF
--- a/packages/twenty-front/src/modules/ui/navigation/navigation-drawer/components/MultiWorkspaceDropdown/internal/MultiWorkspaceDropdownDefaultComponents.tsx
+++ b/packages/twenty-front/src/modules/ui/navigation/navigation-drawer/components/MultiWorkspaceDropdown/internal/MultiWorkspaceDropdownDefaultComponents.tsx
@@ -85,11 +85,7 @@ export const MultiWorkspaceDropdownDefaultComponents = () => {
     );
   };
 
-  // The workspace name (and logo + subdomain) are collected by the shared
-  // creation form on the root domain, so we send the user there on the
-  // WorkspaceCreation step instead of creating a nameless workspace on the fly.
   const createWorkspace = () => {
-    closeDropdown(MULTI_WORKSPACE_DROPDOWN_ID);
     redirectToDefaultDomain({
       pathname: AppPath.SignInUp,
       searchParams: { action: 'create-new-workspace' },


### PR DESCRIPTION
## Summary

Clicking **Create Workspace** in the multi-workspace dropdown did nothing.

The handler closed the dropdown right before redirecting:

```ts
const createWorkspace = () => {
  closeDropdown(MULTI_WORKSPACE_DROPDOWN_ID); // unmounts this component
  redirectToDefaultDomain({ ... });           // schedules window.open ~1ms later
};
```

`redirectToDefaultDomain` → `useRedirect` wraps the navigation in `useDebouncedCallback(..., 1)`. `closeDropdown` flips the dropdown content to `{isDropdownOpen && ...}` → `false`, unmounting `MultiWorkspaceDropdownDefaultComponents` — the component that owns that debounced callback. `use-debounce` drops the pending call on unmount, so the queued `window.open` never fires. React commits the unmount before the 1ms timer, so it loses every time. Regression from #21723, which added the `closeDropdown` call.

## Fix

Remove the `closeDropdown` call. The redirect navigates the whole page away, so closing the dropdown first is unnecessary — and it mirrors the sibling "switch workspace" handler, which already redirects without closing.

## Why not reorder, or drop the debounce?

The 1ms debounce in `useRedirect` is intentional (#9079, "sleep before redirect"). Callers set cookie-backed state immediately before redirecting — e.g. `redirectToDefaultDomain` clears the `lastAuthenticateWorkspaceDomain` cookie via `useCookieStorage`. Deferring the hard navigation by one macrotask lets that cookie write flush before the page tears down; removing it risks dropping the write. Reordering wouldn't help either, since the unmount still beats the timer. So the debounce is left untouched.

## Logout is not affected

`signOut` → `clearSession` navigates with `window.location.assign(...)` directly (synchronous, not debounced) and never calls `closeDropdown`, so it can't hit this race.

## Testing

- Before: clicking Create Workspace → `window.open` called 0 times, page unchanged.
- After: navigates to `<defaultDomain>/welcome?action=create-new-workspace` and renders the "Create your workspace" form.
- Switch-workspace and Log out both still work.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/21835?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

