### PR TITLE
docs(user-guide): remove unsupported Between operator for Number filters

### DIFF
--- a/packages/twenty-docs/user-guide/views-pipelines/capabilities/filters-and-sorting.mdx
+++ b/packages/twenty-docs/user-guide/views-pipelines/capabilities/filters-and-sorting.mdx
@@ -20,7 +20,7 @@ Filters help you focus on specific records by showing only those that match your
 | Field Type | Available Operators |
 |------------|---------------------|
 | Text | Equals, Contains, Starts with, Ends with, Is empty |
-| Number | Equals, Greater than, Less than, Between, Is empty |
+| Number | Equals, Greater than, Less than, Is empty |
 | Date | Equals, Before, After, Between, Is empty |
 | Select | Equals, Is any of, Is empty |
 | Checkbox | Is true, Is false |


### PR DESCRIPTION
## What

The [Filters & Sorting user guide](https://docs.twenty.com/user-guide/views-pipelines/capabilities/filters-and-sorting) lists a **Between** operator for **Number** fields, but it does not exist in the product and we do not plan to implement it. This removes it from the operators table.

| Field Type | Before | After |
|---|---|---|
| Number | Equals, Greater than, Less than, **Between**, Is empty | Equals, Greater than, Less than, Is empty |

The **Date** row is intentionally left untouched.

## Why

Avoids documenting a capability that does not exist (the same gap that prompted #20932). Closing the external PR that attempted to add it for numbers; the docs should reflect what we actually ship.

## Notes

- Only the canonical English source is edited; localized copies under `packages/twenty-docs/l/*` are regenerated by the existing i18n docs-translation workflow.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/21838?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

