### PR TITLE
Fix record table footer hidden when an information banner is visible

### DIFF
--- a/packages/twenty-front/src/modules/object-record/record-index/components/RecordIndexContainerGater.tsx
+++ b/packages/twenty-front/src/modules/object-record/record-index/components/RecordIndexContainerGater.tsx
@@ -26,7 +26,8 @@ import { useCallback } from 'react';
 
 const StyledIndexContainer = styled.div`
   display: flex;
-  height: 100%;
+  flex: 1;
+  min-height: 0;
   width: 100%;
 `;
 


### PR DESCRIPTION
Fixes #21765.

When a page-level information banner (e.g. the mailbox sync-lost banner) is visible, the record index content was rendered with `height: 100%` while sharing a flex column with the banner. It demanded the full parent height regardless of the banner above it, overflowing the card bottom (clipped by `overflow: hidden`). This hid the table footer and pushed the scroll wrapper's real bottom below the viewport, so drag-select autoscroll could never reach its trigger zone.

The fix makes `StyledIndexContainer` reserve only the remaining space after the banner (`flex: 1; min-height: 0`), matching the convention already used by the body content and the Kanban/Calendar wrappers. It's layout-only, banner-agnostic, and applies to all view types.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/21860?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

