### PR TITLE
fix: use translated object label in relation section headers

### DIFF
--- a/packages/twenty-front/src/modules/object-record/record-field-list/record-detail-section/relation/components/RecordDetailRelationSection.tsx
+++ b/packages/twenty-front/src/modules/object-record/record-field-list/record-detail-section/relation/components/RecordDetailRelationSection.tsx
@@ -182,8 +182,8 @@ export const RecordDetailRelationSection = ({
   const relationRecordsCount = relationAggregateResult?.id?.COUNT ?? 0;
 
   const sectionTitle = isToOneObject
-    ? (relationObjectMetadataItem.labelSingular || fieldDefinition.label)
-    : (relationObjectMetadataItem.labelPlural || fieldDefinition.label);
+    ? relationObjectMetadataItem.labelSingular || fieldDefinition.label
+    : relationObjectMetadataItem.labelPlural || fieldDefinition.label;
 
   return (
     <FieldInputEventContext.Provider

--- a/packages/twenty-front/src/modules/object-record/record-field-list/record-detail-section/relation/components/RecordDetailRelationSection.tsx
+++ b/packages/twenty-front/src/modules/object-record/record-field-list/record-detail-section/relation/components/RecordDetailRelationSection.tsx
@@ -181,6 +181,10 @@ export const RecordDetailRelationSection = ({
 
   const relationRecordsCount = relationAggregateResult?.id?.COUNT ?? 0;
 
+  const sectionTitle = isToOneObject
+    ? (relationObjectMetadataItem.labelSingular || fieldDefinition.label)
+    : (relationObjectMetadataItem.labelPlural || fieldDefinition.label);
+
   return (
     <FieldInputEventContext.Provider
       value={{
@@ -188,8 +192,8 @@ export const RecordDetailRelationSection = ({
       }}
     >
       <RecordDetailSectionContainer
-        dataTestId={`${fieldDefinition.label.toLowerCase().replace(' ', '-')}-relation`}
-        title={fieldDefinition.label}
+        dataTestId={`${sectionTitle.toLowerCase().replace(' ', '-')}-relation`}
+        title={sectionTitle}
         link={
           isToManyObjects
             ? {


### PR DESCRIPTION
## What

When a user customizes the singular or plural label of an object type (e.g., renaming "People" to "Contacts"), the relation section headers in the record details panel still showed the original untranslated field label instead of the customized object label.

## Root cause

`RecordDetailRelationSection` was passing `fieldDefinition.label` as the `title` prop to `RecordDetailSectionContainer`. The `fieldDefinition.label` is a static, field-level label that does not reflect object-level label customizations. The component already fetches `relationObjectMetadataItem` via `useObjectMetadataItem`, which carries `labelPlural` and `labelSingular` — the user-customized values.

## Fix

Replace the static `fieldDefinition.label` with:
- `relationObjectMetadataItem.labelSingular` for MANY_TO_ONE relations
- `relationObjectMetadataItem.labelPlural` for ONE_TO_MANY relations

Falls back to `fieldDefinition.label` when the metadata label is empty. The `dataTestId` derivation is updated to use the same resolved title for consistency.

## Test plan

- Customize the plural label of an object type (e.g., change "People" to "Contacts") and verify the relation section header in the details panel shows "Contacts"
- Verify MANY_TO_ONE relation shows the singular label (e.g., "Company")
- Verify that objects with empty `labelPlural`/`labelSingular` fall back to the field definition label (no regression)
- Verify standard untranslated objects render identically to before

Fixes #19790

CI: inspection-only (monorepo install too heavy for shallow-clone CI; change is limited to a computed variable in the render path with no new imports or type changes)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/21863?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

