### PR TITLE
Fix broken CSV import grid layout

### DIFF
--- a/packages/twenty-front/src/modules/spreadsheet-import/components/SpreadsheetImportTable.tsx
+++ b/packages/twenty-front/src/modules/spreadsheet-import/components/SpreadsheetImportTable.tsx
@@ -1,6 +1,7 @@
 import { styled } from '@linaria/react';
 import { useContext } from 'react';
 import { DataGrid, type DataGridProps } from 'react-data-grid';
+import 'react-data-grid/lib/styles.css';
 import { useSpreadsheetImportInternal } from '@/spreadsheet-import/hooks/useSpreadsheetImportInternal';
 import { ThemeContext, themeCssVariables } from 'twenty-ui/theme-constants';
 

--- a/packages/twenty-front/src/modules/spreadsheet-import/steps/components/ValidationStep/components/columns.tsx
+++ b/packages/twenty-front/src/modules/spreadsheet-import/steps/components/ValidationStep/components/columns.tsx
@@ -56,10 +56,12 @@ const StyledInputContainer = styled.div`
 `;
 
 const StyledDefaultContainer = styled.div`
+  align-content: center;
   min-height: 100%;
   min-width: 100%;
   overflow: hidden;
   text-overflow: ellipsis;
+  white-space: nowrap;
 `;
 
 const StyledSelectReadonlyValueContianer = styled.div`


### PR DESCRIPTION
## What

Import `react-data-grid/lib/styles.css` in `SpreadsheetImportTable`, the single component that renders the import grid (used by the Validate Data and Select Header steps).

## Why

The React 19 migration (#21531) bumped `react-data-grid` from `7.0.0-beta.13` to `7.0.0-beta.59`. The old beta auto-injected its layout CSS; beta.59 ships it as a separate `react-data-grid/lib/styles.css` export that must be imported manually. It was never imported, so the grid lost its base layout (grid template, row heights, cell positioning): rows stacked at full height and columns no longer aligned. The library scopes its styles under `@layer rdg`, so the existing Linaria theme overrides still take precedence.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/21867?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->


## Before
<img width="2540" height="1448" alt="CleanShot 2026-06-19 at 17 43 58@2x" src="https://github.com/user-attachments/assets/a208b518-9088-4988-8245-4fdc4f8bc8de" />


## After
<img width="2454" height="1392" alt="CleanShot 2026-06-19 at 18 02 36@2x" src="https://github.com/user-attachments/assets/e0b30d71-8244-4363-86aa-60b12a2dfdd9" />


