### PR TITLE
fix(security): refresh undici across lockfiles (6.x → 6.27.0, 7.x → 7.28.0)

### DIFF
--- a/packages/twenty-apps/community/github-connector/yarn.lock
+++ b/packages/twenty-apps/community/github-connector/yarn.lock
@@ -2515,9 +2515,9 @@ __metadata:
   linkType: hard
 
 "undici@npm:^6.25.0":
-  version: 6.26.0
-  resolution: "undici@npm:6.26.0"
-  checksum: 10c0/cf2b4caf58c33d6582970991290cc7a6486d6e738845f25dcdd16952d708ec844815c6d30362919764fcaf30f719891289341f1ada496f003ce2700310453a47
+  version: 6.27.0
+  resolution: "undici@npm:6.27.0"
+  checksum: 10c0/f88c3dae3957dbf9d93cb481440aced317bd3c4941b5914fea5efba516d51138988cdb5c76006f0bb1337e41d56c3443351055d492e73af2428521c37ba2a76f
   languageName: node
   linkType: hard
 

--- a/packages/twenty-apps/internal/exa/yarn.lock
+++ b/packages/twenty-apps/internal/exa/yarn.lock
@@ -2503,9 +2503,9 @@ __metadata:
   linkType: hard
 
 "undici@npm:^6.25.0":
-  version: 6.26.0
-  resolution: "undici@npm:6.26.0"
-  checksum: 10c0/cf2b4caf58c33d6582970991290cc7a6486d6e738845f25dcdd16952d708ec844815c6d30362919764fcaf30f719891289341f1ada496f003ce2700310453a47
+  version: 6.27.0
+  resolution: "undici@npm:6.27.0"
+  checksum: 10c0/f88c3dae3957dbf9d93cb481440aced317bd3c4941b5914fea5efba516d51138988cdb5c76006f0bb1337e41d56c3443351055d492e73af2428521c37ba2a76f
   languageName: node
   linkType: hard
 

--- a/packages/twenty-apps/internal/people-data-labs/yarn.lock
+++ b/packages/twenty-apps/internal/people-data-labs/yarn.lock
@@ -2498,9 +2498,9 @@ __metadata:
   linkType: hard
 
 "undici@npm:^6.25.0":
-  version: 6.26.0
-  resolution: "undici@npm:6.26.0"
-  checksum: 10c0/cf2b4caf58c33d6582970991290cc7a6486d6e738845f25dcdd16952d708ec844815c6d30362919764fcaf30f719891289341f1ada496f003ce2700310453a47
+  version: 6.27.0
+  resolution: "undici@npm:6.27.0"
+  checksum: 10c0/f88c3dae3957dbf9d93cb481440aced317bd3c4941b5914fea5efba516d51138988cdb5c76006f0bb1337e41d56c3443351055d492e73af2428521c37ba2a76f
   languageName: node
   linkType: hard
 

--- a/packages/twenty-apps/internal/twenty-discord/yarn.lock
+++ b/packages/twenty-apps/internal/twenty-discord/yarn.lock
@@ -2455,9 +2455,9 @@ __metadata:
   linkType: hard
 
 "undici@npm:^6.25.0":
-  version: 6.26.0
-  resolution: "undici@npm:6.26.0"
-  checksum: 10c0/cf2b4caf58c33d6582970991290cc7a6486d6e738845f25dcdd16952d708ec844815c6d30362919764fcaf30f719891289341f1ada496f003ce2700310453a47
+  version: 6.27.0
+  resolution: "undici@npm:6.27.0"
+  checksum: 10c0/f88c3dae3957dbf9d93cb481440aced317bd3c4941b5914fea5efba516d51138988cdb5c76006f0bb1337e41d56c3443351055d492e73af2428521c37ba2a76f
   languageName: node
   linkType: hard
 

--- a/packages/twenty-apps/internal/twenty-fireflies/yarn.lock
+++ b/packages/twenty-apps/internal/twenty-fireflies/yarn.lock
@@ -2456,9 +2456,9 @@ __metadata:
   linkType: hard
 
 "undici@npm:^6.25.0":
-  version: 6.26.0
-  resolution: "undici@npm:6.26.0"
-  checksum: 10c0/cf2b4caf58c33d6582970991290cc7a6486d6e738845f25dcdd16952d708ec844815c6d30362919764fcaf30f719891289341f1ada496f003ce2700310453a47
+  version: 6.27.0
+  resolution: "undici@npm:6.27.0"
+  checksum: 10c0/f88c3dae3957dbf9d93cb481440aced317bd3c4941b5914fea5efba516d51138988cdb5c76006f0bb1337e41d56c3443351055d492e73af2428521c37ba2a76f
   languageName: node
   linkType: hard
 

--- a/packages/twenty-apps/internal/twenty-last-contact/yarn.lock
+++ b/packages/twenty-apps/internal/twenty-last-contact/yarn.lock
@@ -2580,9 +2580,9 @@ __metadata:
   linkType: hard
 
 "undici@npm:^6.25.0":
-  version: 6.26.0
-  resolution: "undici@npm:6.26.0"
-  checksum: 10c0/cf2b4caf58c33d6582970991290cc7a6486d6e738845f25dcdd16952d708ec844815c6d30362919764fcaf30f719891289341f1ada496f003ce2700310453a47
+  version: 6.27.0
+  resolution: "undici@npm:6.27.0"
+  checksum: 10c0/f88c3dae3957dbf9d93cb481440aced317bd3c4941b5914fea5efba516d51138988cdb5c76006f0bb1337e41d56c3443351055d492e73af2428521c37ba2a76f
   languageName: node
   linkType: hard
 

--- a/packages/twenty-apps/internal/twenty-linear/yarn.lock
+++ b/packages/twenty-apps/internal/twenty-linear/yarn.lock
@@ -2477,9 +2477,9 @@ __metadata:
   linkType: hard
 
 "undici@npm:^6.25.0":
-  version: 6.26.0
-  resolution: "undici@npm:6.26.0"
-  checksum: 10c0/cf2b4caf58c33d6582970991290cc7a6486d6e738845f25dcdd16952d708ec844815c6d30362919764fcaf30f719891289341f1ada496f003ce2700310453a47
+  version: 6.27.0
+  resolution: "undici@npm:6.27.0"
+  checksum: 10c0/f88c3dae3957dbf9d93cb481440aced317bd3c4941b5914fea5efba516d51138988cdb5c76006f0bb1337e41d56c3443351055d492e73af2428521c37ba2a76f
   languageName: node
   linkType: hard
 

--- a/packages/twenty-apps/internal/twenty-meeting-bot/yarn.lock
+++ b/packages/twenty-apps/internal/twenty-meeting-bot/yarn.lock
@@ -2711,9 +2711,9 @@ __metadata:
   linkType: hard
 
 "undici@npm:^6.25.0":
-  version: 6.26.0
-  resolution: "undici@npm:6.26.0"
-  checksum: 10c0/cf2b4caf58c33d6582970991290cc7a6486d6e738845f25dcdd16952d708ec844815c6d30362919764fcaf30f719891289341f1ada496f003ce2700310453a47
+  version: 6.27.0
+  resolution: "undici@npm:6.27.0"
+  checksum: 10c0/f88c3dae3957dbf9d93cb481440aced317bd3c4941b5914fea5efba516d51138988cdb5c76006f0bb1337e41d56c3443351055d492e73af2428521c37ba2a76f
   languageName: node
   linkType: hard
 

--- a/packages/twenty-apps/internal/twenty-partners/yarn.lock
+++ b/packages/twenty-apps/internal/twenty-partners/yarn.lock
@@ -2540,9 +2540,9 @@ __metadata:
   linkType: hard
 
 "undici@npm:^6.25.0":
-  version: 6.26.0
-  resolution: "undici@npm:6.26.0"
-  checksum: 10c0/cf2b4caf58c33d6582970991290cc7a6486d6e738845f25dcdd16952d708ec844815c6d30362919764fcaf30f719891289341f1ada496f003ce2700310453a47
+  version: 6.27.0
+  resolution: "undici@npm:6.27.0"
+  checksum: 10c0/f88c3dae3957dbf9d93cb481440aced317bd3c4941b5914fea5efba516d51138988cdb5c76006f0bb1337e41d56c3443351055d492e73af2428521c37ba2a76f
   languageName: node
   linkType: hard
 

--- a/packages/twenty-apps/internal/twenty-slack/yarn.lock
+++ b/packages/twenty-apps/internal/twenty-slack/yarn.lock
@@ -2750,9 +2750,9 @@ __metadata:
   linkType: hard
 
 "undici@npm:^6.25.0":
-  version: 6.26.0
-  resolution: "undici@npm:6.26.0"
-  checksum: 10c0/cf2b4caf58c33d6582970991290cc7a6486d6e738845f25dcdd16952d708ec844815c6d30362919764fcaf30f719891289341f1ada496f003ce2700310453a47
+  version: 6.27.0
+  resolution: "undici@npm:6.27.0"
+  checksum: 10c0/f88c3dae3957dbf9d93cb481440aced317bd3c4941b5914fea5efba516d51138988cdb5c76006f0bb1337e41d56c3443351055d492e73af2428521c37ba2a76f
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -55171,16 +55171,16 @@ __metadata:
   linkType: hard
 
 "undici@npm:^6.25.0":
-  version: 6.26.0
-  resolution: "undici@npm:6.26.0"
-  checksum: 10c0/cf2b4caf58c33d6582970991290cc7a6486d6e738845f25dcdd16952d708ec844815c6d30362919764fcaf30f719891289341f1ada496f003ce2700310453a47
+  version: 6.27.0
+  resolution: "undici@npm:6.27.0"
+  checksum: 10c0/f88c3dae3957dbf9d93cb481440aced317bd3c4941b5914fea5efba516d51138988cdb5c76006f0bb1337e41d56c3443351055d492e73af2428521c37ba2a76f
   languageName: node
   linkType: hard
 
 "undici@npm:^7.25.0":
-  version: 7.27.2
-  resolution: "undici@npm:7.27.2"
-  checksum: 10c0/714632147c80eb8eda8a52df51b481d346df5e035ccc1d87eb3bbcb8f92ec25d7cbbe81abdeae5db4e37a93e490c8d2fa2359ecdca4b2c5c6c513dcd2626ad47
+  version: 7.28.0
+  resolution: "undici@npm:7.28.0"
+  checksum: 10c0/fe781983a26098795e99bb1f64906cbb7d0bcaa029a26baade007b53ea67f2631d189b8f9671a31f4c8d0cb3773b7559608628ba54452fef51fec90e7c78bb0d
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## fix(security): refresh undici across lockfiles (6.x → 6.27.0, 7.x → 7.28.0)

Resolves the undici **6.x** advisory wave: [#1524](https://github.com/twentyhq/twenty/security/dependabot/1524), [#1525](https://github.com/twentyhq/twenty/security/dependabot/1525), [#1526](https://github.com/twentyhq/twenty/security/dependabot/1526), [#1527](https://github.com/twentyhq/twenty/security/dependabot/1527), [#1528](https://github.com/twentyhq/twenty/security/dependabot/1528), [#1529](https://github.com/twentyhq/twenty/security/dependabot/1529), [#1530](https://github.com/twentyhq/twenty/security/dependabot/1530), [#1531](https://github.com/twentyhq/twenty/security/dependabot/1531), [#1532](https://github.com/twentyhq/twenty/security/dependabot/1532), [#1533](https://github.com/twentyhq/twenty/security/dependabot/1533), [#1534](https://github.com/twentyhq/twenty/security/dependabot/1534), [#1535](https://github.com/twentyhq/twenty/security/dependabot/1535), [#1536](https://github.com/twentyhq/twenty/security/dependabot/1536), [#1537](https://github.com/twentyhq/twenty/security/dependabot/1537), [#1538](https://github.com/twentyhq/twenty/security/dependabot/1538), [#1539](https://github.com/twentyhq/twenty/security/dependabot/1539), [#1540](https://github.com/twentyhq/twenty/security/dependabot/1540), [#1541](https://github.com/twentyhq/twenty/security/dependabot/1541), [#1542](https://github.com/twentyhq/twenty/security/dependabot/1542), [#1543](https://github.com/twentyhq/twenty/security/dependabot/1543), [#1544](https://github.com/twentyhq/twenty/security/dependabot/1544), [#1545](https://github.com/twentyhq/twenty/security/dependabot/1545), [#1546](https://github.com/twentyhq/twenty/security/dependabot/1546), [#1547](https://github.com/twentyhq/twenty/security/dependabot/1547), [#1548](https://github.com/twentyhq/twenty/security/dependabot/1548), [#1549](https://github.com/twentyhq/twenty/security/dependabot/1549), [#1550](https://github.com/twentyhq/twenty/security/dependabot/1550), [#1551](https://github.com/twentyhq/twenty/security/dependabot/1551), [#1552](https://github.com/twentyhq/twenty/security/dependabot/1552), [#1553](https://github.com/twentyhq/twenty/security/dependabot/1553), [#1554](https://github.com/twentyhq/twenty/security/dependabot/1554), [#1555](https://github.com/twentyhq/twenty/security/dependabot/1555), [#1556](https://github.com/twentyhq/twenty/security/dependabot/1556), [#1557](https://github.com/twentyhq/twenty/security/dependabot/1557), [#1558](https://github.com/twentyhq/twenty/security/dependabot/1558), [#1559](https://github.com/twentyhq/twenty/security/dependabot/1559), [#1560](https://github.com/twentyhq/twenty/security/dependabot/1560), [#1561](https://github.com/twentyhq/twenty/security/dependabot/1561), [#1562](https://github.com/twentyhq/twenty/security/dependabot/1562), [#1563](https://github.com/twentyhq/twenty/security/dependabot/1563), [#1564](https://github.com/twentyhq/twenty/security/dependabot/1564), [#1567](https://github.com/twentyhq/twenty/security/dependabot/1567), [#1569](https://github.com/twentyhq/twenty/security/dependabot/1569), [#1571](https://github.com/twentyhq/twenty/security/dependabot/1571).

### What

A large batch of undici advisories landed against the **6.x** line (fixed in `6.27.0`) and the **7.x** line (fixed in `7.28.0`). undici is transitive (not imported in our source), and is scanned across many independent lockfiles, so the 6.x wave alone produced 44 alerts (root + 10 `twenty-apps` lockfiles).

### How

In-range lockfile refreshes only (no `resolutions` override) — every consumer's declared range already permits the patched version:

- **6.x: `^6.25.0` → `6.27.0`** across the root `yarn.lock` and all 10 `twenty-apps` lockfiles. This is the bulk of the wave.
- **7.x: `^7.25.0` → `7.28.0`** in root (7.28.0 has now cleared the npm age gate).

### Not covered (separate follow-up)

The root still has two **exact-pinned** vulnerable 7.x copies with no clean fix yet, so the **7.x alerts (#1522, #1523, #1565, #1566, #1568, #1570, #1572) remain open** until these are addressed:
- `undici@7.24.7` ← `@module-federation/dts-plugin` (latest 2.5.1 still exact-pins it → needs a scoped resolution)
- `undici@7.24.8` ← `miniflare` (fixed in 4.20260617.0, still age-gated)

### Verification

- All 11 changed lockfiles resolve undici 6.x to `6.27.0`; no `6.x < 6.27.0` remains.
- `yarn install --immutable` passes for the root and the app lockfiles.
- Lockfile-only change.