### PR TITLE
Fix dangling relation fields crashing records after deleting a custom object

### DIFF
--- a/packages/twenty-front/src/modules/object-metadata/hooks/useDeleteOneObjectMetadataItem.ts
+++ b/packages/twenty-front/src/modules/object-metadata/hooks/useDeleteOneObjectMetadataItem.ts
@@ -1,9 +1,7 @@
-import { useApolloClient, useMutation } from '@apollo/client/react';
-import {
-  DeleteOneObjectMetadataItemDocument,
-  FindManyCommandMenuItemsDocument,
-} from '~/generated-metadata/graphql';
+import { useMutation } from '@apollo/client/react';
+import { DeleteOneObjectMetadataItemDocument } from '~/generated-metadata/graphql';
 
+import { useInvalidateMetadataStore } from '@/metadata-store/hooks/useInvalidateMetadataStore';
 import { useMetadataErrorHandler } from '@/metadata-error-handler/hooks/useMetadataErrorHandler';
 import { useUpdateMetadataStoreDraft } from '@/metadata-store/hooks/useUpdateMetadataStoreDraft';
 import { type MetadataRequestResult } from '@/object-metadata/types/MetadataRequestResult.type';
@@ -17,11 +15,10 @@ export const useDeleteOneObjectMetadataItem = () => {
     DeleteOneObjectMetadataItemDocument,
   );
 
-  const client = useApolloClient();
   const { handleMetadataError } = useMetadataErrorHandler();
   const { enqueueErrorSnackBar } = useSnackBar();
-  const { removeFromDraft, replaceDraft, applyChanges } =
-    useUpdateMetadataStoreDraft();
+  const { removeFromDraft, applyChanges } = useUpdateMetadataStoreDraft();
+  const { invalidateMetadataStore } = useInvalidateMetadataStore();
 
   const deleteOneObjectMetadataItem = async (
     idToDelete: string,
@@ -40,16 +37,7 @@ export const useDeleteOneObjectMetadataItem = () => {
       removeFromDraft({ key: 'objectMetadataItems', itemIds: [idToDelete] });
       applyChanges();
 
-      const commandMenuItemsResult = await client.query({
-        query: FindManyCommandMenuItemsDocument,
-        fetchPolicy: 'network-only',
-      });
-
-      replaceDraft(
-        'commandMenuItems',
-        commandMenuItemsResult.data?.commandMenuItems ?? [],
-      );
-      applyChanges();
+      invalidateMetadataStore();
 
       return {
         status: 'successful',


### PR DESCRIPTION
Fixes https://github.com/twentyhq/twenty/issues/21706

## Context
Deleting a custom object that has relation/junction fields pointing to it (e.g. a junction object linked from Person and Company) crashes record pages with `Target object metadata item not found for <field>`. 
The backend cascade correctly deletes the related relation fields, view fields and page-layout widgets, but the frontend metadata store only removed the deleted object itself, leaving dangling relation fields (and stale UI-layer references) behind.

## Fix
After a successful deletion, `useDeleteOneObjectMetadataItem` now calls `invalidateMetadataStore()`, triggering the existing reconcile path that refetches objects, fields, indexes, views, view fields and page-layout widgets. This removes
the dangling relations and cleans up the UI layers in one consistent pass (also replacing the previous manual command-menu refetch).

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/21874?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

