### PR TITLE
fix(server): add fallback index lookup when disabling field uniqueness

### DIFF
--- a/packages/twenty-server/src/engine/metadata-modules/flat-field-metadata/utils/__tests__/handle-index-changes-during-field-update.spec.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/flat-field-metadata/utils/__tests__/handle-index-changes-during-field-update.spec.ts
@@ -1,0 +1,337 @@
+import { FieldMetadataType } from 'twenty-shared/types';
+
+import { createEmptyFlatEntityMaps } from 'src/engine/metadata-modules/flat-entity/constant/create-empty-flat-entity-maps.constant';
+import { addFlatEntityToFlatEntityMapsOrThrow } from 'src/engine/metadata-modules/flat-entity/utils/add-flat-entity-to-flat-entity-maps-or-throw.util';
+import { FieldMetadataExceptionCode } from 'src/engine/metadata-modules/field-metadata/field-metadata.exception';
+import { getFlatFieldMetadataMock } from 'src/engine/metadata-modules/flat-field-metadata/__mocks__/get-flat-field-metadata.mock';
+import { handleIndexChangesDuringFieldUpdate } from 'src/engine/metadata-modules/flat-field-metadata/utils/handle-index-changes-during-field-update.util';
+import { getFlatIndexMetadataMock } from 'src/engine/metadata-modules/flat-index-metadata/__mocks__/get-flat-index-metadata.mock';
+import { getFlatObjectMetadataMock } from 'src/engine/metadata-modules/flat-object-metadata/__mocks__/get-flat-object-metadata.mock';
+
+const OBJECT_ID = 'test-object-id';
+const FIELD_ID = 'test-field-id';
+const APP_ID = 'test-app-id';
+
+const buildFlatObjectMetadata = (indexMetadataIds: string[] = []) =>
+  getFlatObjectMetadataMock({
+    id: OBJECT_ID,
+    universalIdentifier: OBJECT_ID,
+    indexMetadataIds,
+  });
+
+const buildFlatFieldMetadata = (overrides: Record<string, unknown> = {}) =>
+  getFlatFieldMetadataMock({
+    id: FIELD_ID,
+    universalIdentifier: 'test-field-uid',
+    objectMetadataId: OBJECT_ID,
+    type: FieldMetadataType.TEXT,
+    isUnique: true,
+    isCustom: true,
+    applicationId: APP_ID,
+    ...overrides,
+  });
+
+const buildFlatApplication = () => ({
+  id: APP_ID,
+  universalIdentifier: 'test-app-uid',
+});
+
+describe('handleIndexChangesDuringFieldUpdate', () => {
+  describe('when toggling isUnique from true to false', () => {
+    it('should delete the unique index when name matches (standard path)', () => {
+      const fromField = buildFlatFieldMetadata({ isUnique: true });
+      const toField = buildFlatFieldMetadata({ isUnique: false });
+
+      const matchingIndex = getFlatIndexMetadataMock({
+        universalIdentifier: 'index-uid',
+        objectMetadataId: OBJECT_ID,
+        objectMetadataUniversalIdentifier: OBJECT_ID,
+        applicationUniversalIdentifier: 'test-app-uid',
+        isUnique: true,
+        isCustom: true,
+        applicationId: APP_ID,
+        name: 'IDX_UNIQUE_test-object-id_1_test-field-uid',
+        flatIndexFieldMetadatas: [
+          {
+            fieldMetadataId: FIELD_ID,
+          } as any,
+        ],
+      });
+
+      const indexMaps = addFlatEntityToFlatEntityMapsOrThrow({
+        flatEntity: matchingIndex,
+        flatEntityMaps: createEmptyFlatEntityMaps(),
+      });
+
+      const objectMeta = buildFlatObjectMetadata([matchingIndex.id]);
+
+      const objectMaps = addFlatEntityToFlatEntityMapsOrThrow({
+        flatEntity: objectMeta,
+        flatEntityMaps: createEmptyFlatEntityMaps(),
+      });
+
+      const fieldMaps = addFlatEntityToFlatEntityMapsOrThrow({
+        flatEntity: fromField,
+        flatEntityMaps: createEmptyFlatEntityMaps(),
+      });
+
+      const result = handleIndexChangesDuringFieldUpdate({
+        fromFlatFieldMetadata: fromField,
+        toFlatFieldMetadata: toField,
+        flatIndexMaps: indexMaps,
+        flatObjectMetadataMaps: objectMaps,
+        flatFieldMetadataMaps: fieldMaps,
+        flatApplication: buildFlatApplication() as any,
+      });
+
+      expect(result.status).toBe('success');
+
+      if (result.status === 'success') {
+        expect(result.result.flatIndexMetadatasToDelete).toHaveLength(1);
+      }
+    });
+
+    it('should delete a legacy-named unique index via the fallback path', () => {
+      const fromField = buildFlatFieldMetadata({ isUnique: true });
+      const toField = buildFlatFieldMetadata({ isUnique: false });
+
+      const legacyIndex = getFlatIndexMetadataMock({
+        universalIdentifier: 'legacy-index-uid',
+        objectMetadataId: OBJECT_ID,
+        objectMetadataUniversalIdentifier: OBJECT_ID,
+        applicationUniversalIdentifier: 'test-app-uid',
+        isUnique: true,
+        isCustom: true,
+        applicationId: APP_ID,
+        name: 'LEGACY_OLD_NAME_THAT_DOES_NOT_MATCH',
+        flatIndexFieldMetadatas: [
+          {
+            fieldMetadataId: FIELD_ID,
+          } as any,
+        ],
+      });
+
+      const indexMaps = addFlatEntityToFlatEntityMapsOrThrow({
+        flatEntity: legacyIndex,
+        flatEntityMaps: createEmptyFlatEntityMaps(),
+      });
+
+      const objectMeta = buildFlatObjectMetadata([legacyIndex.id]);
+
+      const objectMaps = addFlatEntityToFlatEntityMapsOrThrow({
+        flatEntity: objectMeta,
+        flatEntityMaps: createEmptyFlatEntityMaps(),
+      });
+
+      const fieldMaps = addFlatEntityToFlatEntityMapsOrThrow({
+        flatEntity: fromField,
+        flatEntityMaps: createEmptyFlatEntityMaps(),
+      });
+
+      const result = handleIndexChangesDuringFieldUpdate({
+        fromFlatFieldMetadata: fromField,
+        toFlatFieldMetadata: toField,
+        flatIndexMaps: indexMaps,
+        flatObjectMetadataMaps: objectMaps,
+        flatFieldMetadataMaps: fieldMaps,
+        flatApplication: buildFlatApplication() as any,
+      });
+
+      expect(result.status).toBe('success');
+
+      if (result.status === 'success') {
+        expect(result.result.flatIndexMetadatasToDelete).toHaveLength(1);
+        expect(result.result.flatIndexMetadatasToDelete[0].name).toBe(
+          'LEGACY_OLD_NAME_THAT_DOES_NOT_MATCH',
+        );
+      }
+    });
+
+    it('should NOT delete a composite unique index via the fallback path', () => {
+      const fromField = buildFlatFieldMetadata({ isUnique: true });
+      const toField = buildFlatFieldMetadata({ isUnique: false });
+
+      const compositeIndex = getFlatIndexMetadataMock({
+        universalIdentifier: 'composite-index-uid',
+        objectMetadataId: OBJECT_ID,
+        objectMetadataUniversalIdentifier: OBJECT_ID,
+        applicationUniversalIdentifier: 'test-app-uid',
+        isUnique: true,
+        isCustom: true,
+        applicationId: APP_ID,
+        name: 'COMPOSITE_INDEX_NAME',
+        flatIndexFieldMetadatas: [
+          {
+            fieldMetadataId: FIELD_ID,
+          } as any,
+          {
+            fieldMetadataId: 'other-field-id',
+          } as any,
+        ],
+      });
+
+      const indexMaps = addFlatEntityToFlatEntityMapsOrThrow({
+        flatEntity: compositeIndex,
+        flatEntityMaps: createEmptyFlatEntityMaps(),
+      });
+
+      const objectMeta = buildFlatObjectMetadata([compositeIndex.id]);
+
+      const objectMaps = addFlatEntityToFlatEntityMapsOrThrow({
+        flatEntity: objectMeta,
+        flatEntityMaps: createEmptyFlatEntityMaps(),
+      });
+
+      const fieldMaps = addFlatEntityToFlatEntityMapsOrThrow({
+        flatEntity: fromField,
+        flatEntityMaps: createEmptyFlatEntityMaps(),
+      });
+
+      const result = handleIndexChangesDuringFieldUpdate({
+        fromFlatFieldMetadata: fromField,
+        toFlatFieldMetadata: toField,
+        flatIndexMaps: indexMaps,
+        flatObjectMetadataMaps: objectMaps,
+        flatFieldMetadataMaps: fieldMaps,
+        flatApplication: buildFlatApplication() as any,
+      });
+
+      expect(result.status).toBe('success');
+
+      if (result.status === 'success') {
+        expect(result.result.flatIndexMetadatasToDelete).toHaveLength(0);
+      }
+    });
+
+    it('should return authorization error for non-custom-app indexes', () => {
+      const fromField = buildFlatFieldMetadata({ isUnique: true });
+      const toField = buildFlatFieldMetadata({ isUnique: false });
+
+      const nonCustomIndex = getFlatIndexMetadataMock({
+        universalIdentifier: 'non-custom-index-uid',
+        objectMetadataId: OBJECT_ID,
+        objectMetadataUniversalIdentifier: OBJECT_ID,
+        applicationUniversalIdentifier: 'test-app-uid',
+        isUnique: true,
+        isCustom: false,
+        applicationId: APP_ID,
+        name: 'NON_CUSTOM_INDEX',
+        flatIndexFieldMetadatas: [
+          {
+            fieldMetadataId: FIELD_ID,
+          } as any,
+        ],
+      });
+
+      const indexMaps = addFlatEntityToFlatEntityMapsOrThrow({
+        flatEntity: nonCustomIndex,
+        flatEntityMaps: createEmptyFlatEntityMaps(),
+      });
+
+      const objectMeta = buildFlatObjectMetadata([nonCustomIndex.id]);
+
+      const objectMaps = addFlatEntityToFlatEntityMapsOrThrow({
+        flatEntity: objectMeta,
+        flatEntityMaps: createEmptyFlatEntityMaps(),
+      });
+
+      const fieldMaps = addFlatEntityToFlatEntityMapsOrThrow({
+        flatEntity: fromField,
+        flatEntityMaps: createEmptyFlatEntityMaps(),
+      });
+
+      const result = handleIndexChangesDuringFieldUpdate({
+        fromFlatFieldMetadata: fromField,
+        toFlatFieldMetadata: toField,
+        flatIndexMaps: indexMaps,
+        flatObjectMetadataMaps: objectMaps,
+        flatFieldMetadataMaps: fieldMaps,
+        flatApplication: buildFlatApplication() as any,
+      });
+
+      expect(result.status).toBe('fail');
+
+      if (result.status === 'fail') {
+        expect(result.errors[0].code).toBe(
+          FieldMetadataExceptionCode.INVALID_FIELD_INPUT,
+        );
+      }
+    });
+
+    it('should return empty delete list when no matching unique index exists', () => {
+      const fromField = buildFlatFieldMetadata({ isUnique: true });
+      const toField = buildFlatFieldMetadata({ isUnique: false });
+
+      const nonUniqueIndex = getFlatIndexMetadataMock({
+        universalIdentifier: 'non-unique-index-uid',
+        objectMetadataId: OBJECT_ID,
+        objectMetadataUniversalIdentifier: OBJECT_ID,
+        applicationUniversalIdentifier: 'test-app-uid',
+        isUnique: false,
+        isCustom: true,
+        applicationId: APP_ID,
+        name: 'SOME_NON_UNIQUE_INDEX',
+        flatIndexFieldMetadatas: [
+          {
+            fieldMetadataId: FIELD_ID,
+          } as any,
+        ],
+      });
+
+      const indexMaps = addFlatEntityToFlatEntityMapsOrThrow({
+        flatEntity: nonUniqueIndex,
+        flatEntityMaps: createEmptyFlatEntityMaps(),
+      });
+
+      const objectMeta = buildFlatObjectMetadata([nonUniqueIndex.id]);
+
+      const objectMaps = addFlatEntityToFlatEntityMapsOrThrow({
+        flatEntity: objectMeta,
+        flatEntityMaps: createEmptyFlatEntityMaps(),
+      });
+
+      const fieldMaps = addFlatEntityToFlatEntityMapsOrThrow({
+        flatEntity: fromField,
+        flatEntityMaps: createEmptyFlatEntityMaps(),
+      });
+
+      const result = handleIndexChangesDuringFieldUpdate({
+        fromFlatFieldMetadata: fromField,
+        toFlatFieldMetadata: toField,
+        flatIndexMaps: indexMaps,
+        flatObjectMetadataMaps: objectMaps,
+        flatFieldMetadataMaps: fieldMaps,
+        flatApplication: buildFlatApplication() as any,
+      });
+
+      expect(result.status).toBe('success');
+
+      if (result.status === 'success') {
+        expect(result.result.flatIndexMetadatasToDelete).toHaveLength(0);
+      }
+    });
+  });
+
+  describe('when no index-relevant changes', () => {
+    it('should return empty side effects', () => {
+      const field = buildFlatFieldMetadata({ isUnique: true });
+
+      const result = handleIndexChangesDuringFieldUpdate({
+        fromFlatFieldMetadata: field,
+        toFlatFieldMetadata: field,
+        flatIndexMaps: createEmptyFlatEntityMaps(),
+        flatObjectMetadataMaps: createEmptyFlatEntityMaps(),
+        flatFieldMetadataMaps: createEmptyFlatEntityMaps(),
+        flatApplication: buildFlatApplication() as any,
+      });
+
+      expect(result.status).toBe('success');
+
+      if (result.status === 'success') {
+        expect(result.result.flatIndexMetadatasToDelete).toHaveLength(0);
+        expect(result.result.flatIndexMetadatasToCreate).toHaveLength(0);
+        expect(result.result.flatIndexMetadatasToUpdate).toHaveLength(0);
+      }
+    });
+  });
+});

--- a/packages/twenty-server/src/engine/metadata-modules/flat-field-metadata/utils/handle-index-changes-during-field-update.util.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/flat-field-metadata/utils/handle-index-changes-during-field-update.util.ts
@@ -148,15 +148,25 @@ const handleExistingIndexes = ({
       flatObjectMetadata,
     });
 
-    const uniqueIndexToDelete = relatedIndexes.find(
+    const uniqueIndexByName = relatedIndexes.find(
       (index) => index.name === expectedUniqueIndex.name,
     );
 
+    const indexToDelete =
+      uniqueIndexByName ??
+      relatedIndexes.find(
+        (index) =>
+          index.isUnique &&
+          index.flatIndexFieldMetadatas.length === 1 &&
+          index.flatIndexFieldMetadatas[0].fieldMetadataId ===
+            fromFlatFieldMetadata.id,
+      );
+
     if (
-      isDefined(uniqueIndexToDelete) &&
-      ((isDefined(uniqueIndexToDelete.applicationId) &&
-        uniqueIndexToDelete.applicationId !== flatApplication.id) ||
-        !uniqueIndexToDelete.isCustom)
+      isDefined(indexToDelete) &&
+      ((isDefined(indexToDelete.applicationId) &&
+        indexToDelete.applicationId !== flatApplication.id) ||
+        !indexToDelete.isCustom)
     ) {
       return {
         status: 'fail',
@@ -175,9 +185,7 @@ const handleExistingIndexes = ({
       status: 'success',
       result: {
         ...FIELD_METADATA_UPDATE_INDEX_SIDE_EFFECT,
-        flatIndexMetadatasToDelete: uniqueIndexToDelete
-          ? [uniqueIndexToDelete]
-          : [],
+        flatIndexMetadatasToDelete: indexToDelete ? [indexToDelete] : [],
       },
     };
   }

--- a/packages/twenty-server/src/engine/workspace-manager/workspace-migration/workspace-migration-builder/validators/services/flat-field-metadata-validator.service.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/workspace-migration/workspace-migration-builder/validators/services/flat-field-metadata-validator.service.ts
@@ -191,6 +191,9 @@ export class FlatFieldMetadataValidatorService {
     }
 
     if (
+      !isMorphOrRelationUniversalFlatFieldMetadata(
+        flatFieldMetadataToValidate,
+      ) &&
       flatFieldMetadataToValidate.isNullable === false &&
       flatFieldMetadataToValidate.defaultValue === null
     ) {

--- a/packages/twenty-server/src/engine/workspace-manager/workspace-migration/workspace-migration-builder/validators/services/flat-field-metadata-validator.service.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/workspace-migration/workspace-migration-builder/validators/services/flat-field-metadata-validator.service.ts
@@ -191,9 +191,6 @@ export class FlatFieldMetadataValidatorService {
     }
 
     if (
-      !isMorphOrRelationUniversalFlatFieldMetadata(
-        flatFieldMetadataToValidate,
-      ) &&
       flatFieldMetadataToValidate.isNullable === false &&
       flatFieldMetadataToValidate.defaultValue === null
     ) {


### PR DESCRIPTION
## Description

Toggling a field's `isUnique` from `true` to `false` does not persist — the API response still returns `isUnique: true`. The Settings UI appears saved locally, but subsequent reads resolve uniqueness as still enabled.

### Root Cause

Since v2.8, `isUnique` is derived from `IndexMetadata` (the column was dropped from `FieldMetadata`). When disabling uniqueness, the backend must delete the backing unique index.

In [`handle-index-changes-during-field-update.util.ts`](https://github.com/twentyhq/twenty/blob/main/packages/twenty-server/src/engine/metadata-modules/flat-field-metadata/utils/handle-index-changes-during-field-update.util.ts#L151-L153), the deletion logic generates an "expected" index name and matches **only by name**:

```typescript
const uniqueIndexToDelete = relatedIndexes.find(
  (index) => index.name === expectedUniqueIndex.name,
);
```

If the stored index name doesn't match the generated name (legacy/pre-normalized naming from earlier versions), the `find()` returns `undefined`, and the function returns an empty delete list — a **silent no-op**. API reads still see `isUnique: true` because the index row still exists.

## Fix

Added a fallback lookup when name-based matching fails. The fallback finds the unique index by field relationship instead:

```diff
-    const uniqueIndexToDelete = relatedIndexes.find(
+    const uniqueIndexByName = relatedIndexes.find(
       (index) => index.name === expectedUniqueIndex.name,
     );

+    // Fallback: if name-based match fails (legacy/pre-normalized index names),
+    // find the unique index by field relationship instead.
+    // Restricted to single-field unique indexes to avoid deleting composite ones.
+    const indexToDelete =
+      uniqueIndexByName ??
+      relatedIndexes.find(
+        (index) =>
+          index.isUnique === true &&
+          index.flatIndexFieldMetadatas.length === 1 &&
+          index.flatIndexFieldMetadatas[0].fieldMetadataId ===
+            fromFlatFieldMetadata.id,
+      );
```

### Fallback safety constraints
- `index.isUnique === true` — only targets unique indexes
- `flatIndexFieldMetadatas.length === 1` — avoids deleting **composite** unique indexes
- `fieldMetadataId === fromFlatFieldMetadata.id` — ensures the index belongs to the exact field being updated

## Tests Added

New test file: `handle-index-changes-during-field-update.util.spec.ts`

| Test Case | What it verifies |
|-----------|-----------------|
| Standard name-based deletion | Existing behavior preserved |
| Legacy-named index fallback | Fallback path deletes correctly |
| Composite index safety | Multi-field unique indexes NOT deleted |
| Authorization error | Non-custom-app indexes blocked |
| No matching index | Empty delete list returned |
| No index-relevant changes | Early return with empty side effects |

## Verification
- `tsc --noEmit` ✅ zero errors on twenty-server
- ESLint ✅ clean

Fixes #21383

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/21877?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

