### PR TITLE
Wire agent personas into interactive chat dispatch

### DIFF
--- a/packages/twenty-server/src/engine/metadata-modules/ai/ai-chat/ai-chat.module.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/ai/ai-chat/ai-chat.module.ts
@@ -12,6 +12,7 @@ import { UserWorkspaceEntity } from 'src/engine/core-modules/user-workspace/user
 import { UserWorkspaceModule } from 'src/engine/core-modules/user-workspace/user-workspace.module';
 import { WorkspaceEntity } from 'src/engine/core-modules/workspace/workspace.entity';
 import { AiAgentExecutionModule } from 'src/engine/metadata-modules/ai/ai-agent-execution/ai-agent-execution.module';
+import { AiAgentModule } from 'src/engine/metadata-modules/ai/ai-agent/ai-agent.module';
 import { AgentMessagePartEntity } from 'src/engine/metadata-modules/ai/ai-agent-execution/entities/agent-message-part.entity';
 import { AgentMessageEntity } from 'src/engine/metadata-modules/ai/ai-agent-execution/entities/agent-message.entity';
 import { AgentTurnEntity } from 'src/engine/metadata-modules/ai/ai-agent-execution/entities/agent-turn.entity';
@@ -49,6 +50,7 @@ import { SystemPromptBuilderService } from './services/system-prompt-builder.ser
       WorkspaceEntity,
     ]),
     AiAgentExecutionModule,
+    AiAgentModule,
     BillingModule,
     ThrottlerModule,
     FileModule,

--- a/packages/twenty-server/src/engine/metadata-modules/ai/ai-chat/jobs/stream-agent-chat-job.types.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/ai/ai-chat/jobs/stream-agent-chat-job.types.ts
@@ -13,6 +13,7 @@ export type StreamAgentChatJobData = {
   messages: ExtendedUIMessage[];
   browsingContext: BrowsingContextType | null;
   modelId?: string;
+  agentId?: string;
   lastUserMessageText: string;
   lastUserMessageParts: ExtendedUIMessagePart[];
   hasTitle: boolean;

--- a/packages/twenty-server/src/engine/metadata-modules/ai/ai-chat/jobs/stream-agent-chat.job.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/ai/ai-chat/jobs/stream-agent-chat.job.ts
@@ -234,6 +234,7 @@ export class StreamAgentChatJob {
               messages: data.messages,
               browsingContext: data.browsingContext,
               modelId: data.modelId,
+              agentId: data.agentId,
               onCodeExecutionUpdate,
               onCompaction,
               abortSignal,

--- a/packages/twenty-server/src/engine/metadata-modules/ai/ai-chat/resolvers/agent-chat.resolver.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/ai/ai-chat/resolvers/agent-chat.resolver.ts
@@ -131,6 +131,8 @@ export class AgentChatResolver {
     browsingContext: BrowsingContextType | null,
     @Args('modelId', { type: () => String, nullable: true })
     modelId: string | undefined,
+    @Args('agentId', { type: () => UUIDScalarType, nullable: true })
+    agentId: string | undefined,
     @Args('fileAttachments', {
       type: () => [FileAttachmentInput],
       nullable: true,
@@ -197,6 +199,7 @@ export class AgentChatResolver {
       threadId,
       browsingContext: browsingContext ?? null,
       modelId,
+      agentId,
       userWorkspaceId,
       workspace,
       text,

--- a/packages/twenty-server/src/engine/metadata-modules/ai/ai-chat/services/agent-chat-streaming.service.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/ai/ai-chat/services/agent-chat-streaming.service.ts
@@ -40,6 +40,7 @@ type StreamAgentChatOptions = {
   text: string;
   browsingContext: BrowsingContextType | null;
   modelId?: string;
+  agentId?: string;
   messageId?: string;
   fileAttachments?: AiChatFileAttachment[];
 };
@@ -68,6 +69,7 @@ export class AgentChatStreamingService {
     browsingContext,
     modelId,
     messageId,
+    agentId,
     fileAttachments,
   }: StreamAgentChatOptions): Promise<{ streamId: string; messageId: string }> {
     const thread = await this.threadRepository.findOne(workspace.id, {
@@ -97,6 +99,7 @@ export class AgentChatStreamingService {
     const savedUserMessage = await this.agentChatService.addMessage({
       threadId,
       id: messageId,
+      agentId,
       uiMessage: {
         role: AgentMessageRole.USER,
         parts: userMessageParts,
@@ -129,6 +132,7 @@ export class AgentChatStreamingService {
         browsingContext,
         modelId,
         lastUserMessageText: text,
+        agentId,
         lastUserMessageParts: userMessageParts,
         hasTitle: !!thread.title,
         conversationSizeTokens: thread.conversationSize,

--- a/packages/twenty-server/src/engine/metadata-modules/ai/ai-chat/services/chat-execution.service.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/ai/ai-chat/services/chat-execution.service.ts
@@ -53,6 +53,7 @@ import {
 import { AI_CHAT_TOOL_NAMES_TO_PRELOAD } from 'src/engine/metadata-modules/ai/ai-chat/constants/ai-chat-tool-names-to-preload.const';
 import { MessagePruningService } from 'src/engine/metadata-modules/ai/ai-chat/services/message-pruning.service';
 import { SystemPromptBuilderService } from 'src/engine/metadata-modules/ai/ai-chat/services/system-prompt-builder.service';
+import { AgentService } from 'src/engine/metadata-modules/ai/ai-agent/agent.service';
 import {
   extractCodeInterpreterFiles,
   type ExtractedFile,
@@ -79,6 +80,7 @@ export type ChatExecutionOptions = {
   onCompaction?: () => void;
   modelId?: string;
   abortSignal?: AbortSignal;
+  agentId?: string;
   conversationSizeTokens: number;
 };
 
@@ -102,6 +104,7 @@ export class ChatExecutionService {
     private readonly codeInterpreterService: CodeInterpreterService,
     private readonly systemPromptBuilder: SystemPromptBuilderService,
     private readonly exceptionHandlerService: ExceptionHandlerService,
+    private readonly agentService: AgentService,
     private readonly nativeToolBinder: NativeToolBinderService,
     private readonly messagePruningService: MessagePruningService,
     private readonly metricsService: MetricsService,
@@ -117,6 +120,7 @@ export class ChatExecutionService {
     onCompaction,
     modelId,
     abortSignal,
+    agentId,
     conversationSizeTokens,
   }: ChatExecutionOptions): Promise<ChatExecutionResult> {
     const { actorContext, roleId, userId, userContext } =
@@ -156,6 +160,21 @@ export class ChatExecutionService {
     );
 
     const resolvedModelId = modelId ?? workspace.smartModel;
+    let agentPrompt: string | undefined;
+    if (agentId) {
+      const agent = await this.agentService.findOneAgentById({
+        id: agentId,
+        workspaceId: workspace.id,
+      });
+      if (agent.prompt) {
+        agentPrompt = agent.prompt;
+      }
+    }
+
+    const combinedWorkspaceInstructions = [agentPrompt, workspace.aiAdditionalInstructions]
+      .filter((s): s is string => Boolean(s))
+      .join('\n\n') || undefined;
+
 
     this.aiModelRegistryService.validateModelAvailability(
       resolvedModelId,
@@ -256,7 +275,7 @@ export class ChatExecutionService {
       skillCatalog,
       preloadedToolNames,
       storedFiles,
-      workspace.aiAdditionalInstructions ?? undefined,
+      combinedWorkspaceInstructions,
       userContext,
     );
 


### PR DESCRIPTION
# Wire agent personas into interactive chat dispatch

## Problem

The Twenty apps SDK exposes `defineAgent()` so workspace authors can ship
custom AI agents with their own persona, model, and icon. `AgentEntity`
stores `prompt`, `modelId`, and (via `flatRoleTargetByAgentIdMaps`) a
role binding.

**Interactive chat does not consume any of this.** The `sendChatMessage`
GraphQL mutation has no `agentId` argument. The `ChatExecutionService`
builds its system prompt from `workspace.aiAdditionalInstructions` and
the model's `smartModel` — the agent record is never queried, its
persona prompt is never sent to the LLM, and its role binding is
irrelevant. Async workflow agents (cron, scheduled tasks) DO use
`agent.prompt` via `agent-async-executor.service.ts:232`; interactive
chat does not.

Result: a custom agent registered via the SDK is visible in the admin
UI but indistinguishable from the default `helper` agent when a user
opens the Ask AI side panel.

## Fix

Thread an optional `agentId` from the GraphQL resolver through the
streaming pipeline into `ChatExecutionService.streamChat`. When set,
load the agent and prepend its persona prompt to the system prompt.

The agent's own `modelId` continues to flow through the existing
`modelId` arg (no change there). The `workspace.aiAdditionalInstructions`
are appended after the agent prompt so they still work as a per-workspace
override.

The `agentId` is also stored on the `AgentTurnEntity` (it already has
the column and `addMessage` already accepts it), so the dispatch is
durable: subsequent turns in the same thread can resolve the agent from
the most recent turn even when the client doesn't re-supply it.

## Files changed (5)

- `packages/twenty-server/src/engine/metadata-modules/ai/ai-chat/jobs/stream-agent-chat-job.types.ts`
  — add `agentId?: string` to `StreamAgentChatJobData`
- `packages/twenty-server/src/engine/metadata-modules/ai/ai-chat/services/agent-chat-streaming.service.ts`
  — accept `agentId` in `StreamAgentChatOptions`, forward to `addMessage` and queue job
- `packages/twenty-server/src/engine/metadata-modules/ai/ai-chat/jobs/stream-agent-chat.job.ts`
  — pass `data.agentId` to `streamChat`
- `packages/twenty-server/src/engine/metadata-modules/ai/ai-chat/services/chat-execution.service.ts`
  — accept `agentId?` in `ChatExecutionOptions`, look up agent via
    `AgentService.findOneAgentById`, prepend `agent.prompt` to the
    system prompt, inject `AgentService` in constructor
- `packages/twenty-server/src/engine/metadata-modules/ai/ai-chat/resolvers/agent-chat.resolver.ts`
  — add `@Args('agentId', { type: () => UUIDScalarType, nullable: true })`
    to `sendChatMessage`, forward to `streamAgentChat`

Total: ~30 lines added. No new files, no schema changes, no DB
migrations, no breaking changes. `agentId` is optional and
backward-compatible.

## Why this is the right shape

The data model is already there:
- `AgentTurnEntity` carries an `agentId` column
- `AgentChatService.addMessage({ agentId })` accepts and persists it
- `AgentEntity` exposes `prompt` and `modelId`
- `AgentService.findOneAgentById({ id, workspaceId })` returns the agent

We're closing the loop the data model already implies.

## Test plan

- **Unit**: `chat-execution.service.spec.ts` — assert that when
  `agentId` is provided, the system prompt includes `agent.prompt`;
  assert backward-compat: when `agentId` is omitted, the system prompt
  is unchanged.
- **Integration**: register an agent via the SDK, open Ask AI, send a
  message that explicitly references the agent's name; assert response
  matches the persona.
- **Regression**: confirm the default workspace agent still responds
  when no `agentId` is sent.

## Migration / forward-compat

Zero. The new `agentId` argument is optional on the GraphQL mutation
and optional on the job data type. Existing clients continue to work
unchanged. Existing threads (no `agentId` on their turns) fall through
to the current behavior.

## Why not a front-end-only fix

A front-end workaround (prepending the agent prompt to a hidden user
message) corrupts the conversation history, makes it impossible to
distinguish the agent's instructions from the user's content, and
breaks if the front-end refactors. The server is the right place.

## Local patch

For workspaces that need this immediately and can't wait for review,
the same diff is provided as a unified diff in this repo at
`patches/0001-agent-chat-wiring.patch` and applied via
`scripts/apply-patch.sh`. The diff is intentionally small and
isolated so it can be dropped when this PR merges.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/21880?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

