### PR TITLE
make mergeMany atomic and optimize relation/field-map handling

### DIFF
--- a/packages/twenty-server/src/engine/api/common/common-query-runners/common-merge-many-query-runner.service.ts
+++ b/packages/twenty-server/src/engine/api/common/common-query-runners/common-merge-many-query-runner.service.ts
@@ -120,7 +120,19 @@ export class CommonMergeManyQueryRunnerService extends CommonBaseQueryRunnerServ
       mergedData: Partial<ObjectRecord>;
     },
   ): Promise<ObjectRecord> {
-    const { flatObjectMetadata } = queryRunnerContext;
+    const {
+      flatObjectMetadata,
+      flatObjectMetadataMaps,
+      flatFieldMetadataMaps,
+    } = queryRunnerContext;
+
+    const columnsToReturn = buildColumnsToReturn({
+      select: args.selectedFieldsResult.select,
+      relations: args.selectedFieldsResult.relations,
+      flatObjectMetadata,
+      flatObjectMetadataMaps,
+      flatFieldMetadataMaps,
+    });
 
     const transactionRepository = transactionManager.getRepository(
       flatObjectMetadata.nameSingular,
@@ -138,6 +150,7 @@ export class CommonMergeManyQueryRunnerService extends CommonBaseQueryRunnerServ
       .createQueryBuilder(flatObjectMetadata.nameSingular)
       .delete()
       .whereInIds(idsToDelete)
+      .returning(columnsToReturn)
       .execute();
 
     return this.updatePriorityRecord(

--- a/packages/twenty-server/src/engine/api/common/common-query-runners/common-merge-many-query-runner.service.ts
+++ b/packages/twenty-server/src/engine/api/common/common-query-runners/common-merge-many-query-runner.service.ts
@@ -120,19 +120,7 @@ export class CommonMergeManyQueryRunnerService extends CommonBaseQueryRunnerServ
       mergedData: Partial<ObjectRecord>;
     },
   ): Promise<ObjectRecord> {
-    const {
-      flatObjectMetadata,
-      flatObjectMetadataMaps,
-      flatFieldMetadataMaps,
-    } = queryRunnerContext;
-
-    const columnsToReturn = buildColumnsToReturn({
-      select: args.selectedFieldsResult.select,
-      relations: args.selectedFieldsResult.relations,
-      flatObjectMetadata,
-      flatObjectMetadataMaps,
-      flatFieldMetadataMaps,
-    });
+    const { flatObjectMetadata } = queryRunnerContext;
 
     const transactionRepository = transactionManager.getRepository(
       flatObjectMetadata.nameSingular,
@@ -150,7 +138,6 @@ export class CommonMergeManyQueryRunnerService extends CommonBaseQueryRunnerServ
       .createQueryBuilder(flatObjectMetadata.nameSingular)
       .delete()
       .whereInIds(idsToDelete)
-      .returning(columnsToReturn)
       .execute();
 
     return this.updatePriorityRecord(
@@ -400,8 +387,6 @@ export class CommonMergeManyQueryRunnerService extends CommonBaseQueryRunnerServ
 
     const relationFieldsPointingToCurrentObject: Array<{
       objectMetadata: FlatObjectMetadata;
-      fieldName: string;
-      fieldId: string;
       joinColumnName: string | undefined;
     }> = [];
 
@@ -435,8 +420,6 @@ export class CommonMergeManyQueryRunnerService extends CommonBaseQueryRunnerServ
 
       relationFieldsPointingToCurrentObject.push({
         objectMetadata: objMetadata,
-        fieldName: field.name,
-        fieldId: field.id,
         joinColumnName: computeMorphOrRelationFieldJoinColumnName({
           name: field.name,
         }),

--- a/packages/twenty-server/src/engine/api/common/common-query-runners/common-merge-many-query-runner.service.ts
+++ b/packages/twenty-server/src/engine/api/common/common-query-runners/common-merge-many-query-runner.service.ts
@@ -137,6 +137,7 @@ export class CommonMergeManyQueryRunnerService extends CommonBaseQueryRunnerServ
     const transactionRepository = transactionManager.getRepository(
       flatObjectMetadata.nameSingular,
       queryRunnerContext.rolePermissionConfig,
+      queryRunnerContext.authContext,
     );
 
     await this.migrateRelatedRecords(
@@ -447,6 +448,7 @@ export class CommonMergeManyQueryRunnerService extends CommonBaseQueryRunnerServ
       const repository = transactionManager.getRepository(
         relationField.objectMetadata.nameSingular,
         context.rolePermissionConfig,
+        context.authContext,
       );
 
       await repository.update(

--- a/packages/twenty-server/src/engine/api/common/common-query-runners/common-merge-many-query-runner.service.ts
+++ b/packages/twenty-server/src/engine/api/common/common-query-runners/common-merge-many-query-runner.service.ts
@@ -1,4 +1,4 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
 
 import { msg } from '@lingui/core/macro';
 import {
@@ -15,7 +15,6 @@ import { isDefined } from 'twenty-shared/utils';
 import { FindOptionsRelations, In, ObjectLiteral } from 'typeorm';
 import { v4 as uuidv4 } from 'uuid';
 
-import { computeMorphOrRelationFieldJoinColumnName } from 'src/engine/metadata-modules/field-metadata/utils/compute-morph-or-relation-field-join-column-name.util';
 import { CommonBaseQueryRunnerService } from 'src/engine/api/common/common-query-runners/common-base-query-runner.service';
 import {
   CommonQueryRunnerException,
@@ -35,6 +34,7 @@ import { buildColumnsToSelect } from 'src/engine/api/graphql/graphql-query-runne
 import { hasRecordFieldValue } from 'src/engine/api/graphql/graphql-query-runner/utils/has-record-field-value.util';
 import { mergeFieldValues } from 'src/engine/api/graphql/graphql-query-runner/utils/merge-field-values.util';
 import { WorkspaceAuthContext } from 'src/engine/core-modules/auth/types/workspace-auth-context.type';
+import { computeMorphOrRelationFieldJoinColumnName } from 'src/engine/metadata-modules/field-metadata/utils/compute-morph-or-relation-field-join-column-name.util';
 import { FlatEntityMaps } from 'src/engine/metadata-modules/flat-entity/types/flat-entity-maps.type';
 import { findFlatEntityByIdInFlatEntityMaps } from 'src/engine/metadata-modules/flat-entity/utils/find-flat-entity-by-id-in-flat-entity-maps.util';
 import { FlatFieldMetadata } from 'src/engine/metadata-modules/flat-field-metadata/types/flat-field-metadata.type';
@@ -42,6 +42,8 @@ import { buildFieldMapsFromFlatObjectMetadata } from 'src/engine/metadata-module
 import { isFlatFieldMetadataOfType } from 'src/engine/metadata-modules/flat-field-metadata/utils/is-flat-field-metadata-of-type.util';
 import { FlatObjectMetadata } from 'src/engine/metadata-modules/flat-object-metadata/types/flat-object-metadata.type';
 import { assertMutationNotOnRemoteObject } from 'src/engine/metadata-modules/object-metadata/utils/assert-mutation-not-on-remote-object.util';
+import { WorkspaceEntityManager } from 'src/engine/twenty-orm/entity-manager/workspace-entity-manager';
+import { WorkspaceRepository } from 'src/engine/twenty-orm/repository/workspace.repository';
 
 @Injectable()
 export class CommonMergeManyQueryRunnerService extends CommonBaseQueryRunnerService<
@@ -50,16 +52,11 @@ export class CommonMergeManyQueryRunnerService extends CommonBaseQueryRunnerServ
 > {
   protected readonly operationName = CommonQueryNames.MERGE_MANY;
 
-  private readonly logger = new Logger(CommonMergeManyQueryRunnerService.name);
   async run(
     args: CommonExtendedInput<MergeManyQueryArgs>,
     queryRunnerContext: CommonExtendedQueryRunnerContext,
   ): Promise<ObjectRecord> {
-    const {
-      flatObjectMetadataMaps,
-      flatFieldMetadataMaps,
-      flatObjectMetadata,
-    } = queryRunnerContext;
+    const { flatFieldMetadataMaps, flatObjectMetadata } = queryRunnerContext;
 
     const recordsToMerge = await this.fetchRecordsToMerge(
       queryRunnerContext,
@@ -86,15 +83,48 @@ export class CommonMergeManyQueryRunnerService extends CommonBaseQueryRunnerServ
 
     const idsToDelete = args.ids.filter((id) => id !== priorityRecord.id);
 
-    await this.migrateRelatedRecords(
+    const updatedRecord =
+      await queryRunnerContext.workspaceDataSource.transaction(
+        (transactionManager: WorkspaceEntityManager) =>
+          this.executeMergeWithinTransaction(transactionManager, {
+            args,
+            queryRunnerContext,
+            idsToDelete,
+            priorityRecordId: priorityRecord.id,
+            mergedData,
+          }),
+      );
+
+    await this.processNestedRelations({
+      args,
+      queryRunnerContext,
+      updatedRecords: [updatedRecord],
+    });
+
+    return updatedRecord;
+  }
+
+  private async executeMergeWithinTransaction(
+    transactionManager: WorkspaceEntityManager,
+    {
+      args,
       queryRunnerContext,
       idsToDelete,
-      priorityRecord.id,
-    );
-
-    const queryBuilder = queryRunnerContext.repository.createQueryBuilder(
-      flatObjectMetadata.nameSingular,
-    );
+      priorityRecordId,
+      mergedData,
+    }: {
+      args: CommonExtendedInput<MergeManyQueryArgs>;
+      queryRunnerContext: CommonExtendedQueryRunnerContext;
+      idsToDelete: string[];
+      priorityRecordId: string;
+      mergedData: Partial<ObjectRecord>;
+    },
+  ): Promise<ObjectRecord> {
+    const {
+      flatObjectMetadata,
+      flatObjectMetadataMaps,
+      flatFieldMetadataMaps,
+    } = queryRunnerContext;
 
     const columnsToReturn = buildColumnsToReturn({
       select: args.selectedFieldsResult.select,
@@ -104,26 +134,32 @@ export class CommonMergeManyQueryRunnerService extends CommonBaseQueryRunnerServ
       flatFieldMetadataMaps,
     });
 
-    await queryBuilder
+    const transactionRepository = transactionManager.getRepository(
+      flatObjectMetadata.nameSingular,
+      queryRunnerContext.rolePermissionConfig,
+    );
+
+    await this.migrateRelatedRecords(
+      transactionManager,
+      queryRunnerContext,
+      idsToDelete,
+      priorityRecordId,
+    );
+
+    await transactionRepository
+      .createQueryBuilder(flatObjectMetadata.nameSingular)
       .delete()
       .whereInIds(idsToDelete)
       .returning(columnsToReturn)
       .execute();
 
-    const updatedRecord = await this.updatePriorityRecord(
+    return this.updatePriorityRecord(
       args,
       queryRunnerContext,
-      priorityRecord.id,
+      transactionRepository,
+      priorityRecordId,
       mergedData,
     );
-
-    await this.processNestedRelations({
-      args,
-      queryRunnerContext,
-      updatedRecords: [updatedRecord],
-    });
-
-    return updatedRecord;
   }
 
   private async fetchRecordsToMerge(
@@ -212,6 +248,11 @@ export class CommonMergeManyQueryRunnerService extends CommonBaseQueryRunnerServ
   ): Partial<ObjectRecord> {
     const mergedResult: Partial<ObjectRecord> = {};
 
+    const { fieldIdByName } = buildFieldMapsFromFlatObjectMetadata(
+      flatFieldMetadataMaps,
+      flatObjectMetadata,
+    );
+
     const allFieldNames = new Set<string>();
 
     recordsToMerge.forEach((record) => {
@@ -219,7 +260,7 @@ export class CommonMergeManyQueryRunnerService extends CommonBaseQueryRunnerServ
         if (
           !this.shouldExcludeFieldFromMerge(
             fieldName,
-            flatObjectMetadata,
+            fieldIdByName,
             flatFieldMetadataMaps,
           )
         ) {
@@ -244,10 +285,6 @@ export class CommonMergeManyQueryRunnerService extends CommonBaseQueryRunnerServ
       } else if (recordsWithValues.length === 1) {
         mergedResult[fieldName] = recordsWithValues[0].value;
       } else {
-        const { fieldIdByName } = buildFieldMapsFromFlatObjectMetadata(
-          flatFieldMetadataMaps,
-          flatObjectMetadata,
-        );
         const fieldMetadata = findFlatEntityByIdInFlatEntityMaps({
           flatEntityId: fieldIdByName[fieldName],
           flatEntityMaps: flatFieldMetadataMaps,
@@ -279,13 +316,9 @@ export class CommonMergeManyQueryRunnerService extends CommonBaseQueryRunnerServ
 
   private shouldExcludeFieldFromMerge(
     fieldName: string,
-    flatObjectMetadata: FlatObjectMetadata,
+    fieldIdByName: Record<string, string>,
     flatFieldMetadataMaps: FlatEntityMaps<FlatFieldMetadata>,
   ): boolean {
-    const { fieldIdByName } = buildFieldMapsFromFlatObjectMetadata(
-      flatFieldMetadataMaps,
-      flatObjectMetadata,
-    );
     const fieldMetadata = findFlatEntityByIdInFlatEntityMaps({
       flatEntityId: fieldIdByName[fieldName],
       flatEntityMaps: flatFieldMetadataMaps,
@@ -311,6 +344,7 @@ export class CommonMergeManyQueryRunnerService extends CommonBaseQueryRunnerServ
   private async updatePriorityRecord(
     args: CommonExtendedInput<MergeManyQueryArgs>,
     queryRunnerContext: CommonExtendedQueryRunnerContext,
+    repository: WorkspaceRepository<ObjectLiteral>,
     priorityRecordId: string,
     mergedData: Partial<ObjectRecord>,
   ): Promise<ObjectRecord> {
@@ -318,7 +352,6 @@ export class CommonMergeManyQueryRunnerService extends CommonBaseQueryRunnerServ
       flatObjectMetadata,
       flatObjectMetadataMaps,
       flatFieldMetadataMaps,
-      repository,
     } = queryRunnerContext;
 
     const queryBuilder = repository.createQueryBuilder(
@@ -354,6 +387,7 @@ export class CommonMergeManyQueryRunnerService extends CommonBaseQueryRunnerServ
   }
 
   private async migrateRelatedRecords(
+    transactionManager: WorkspaceEntityManager,
     context: CommonExtendedQueryRunnerContext,
     fromIds: string[],
     toId: string,
@@ -414,29 +448,15 @@ export class CommonMergeManyQueryRunnerService extends CommonBaseQueryRunnerServ
         continue;
       }
 
-      try {
-        const repository = context.workspaceDataSource.getRepository(
-          relationField.objectMetadata.nameSingular,
-          context.rolePermissionConfig,
-        );
+      const repository = transactionManager.getRepository(
+        relationField.objectMetadata.nameSingular,
+        context.rolePermissionConfig,
+      );
 
-        const whereCondition = { [relationField.joinColumnName]: In(fromIds) };
-
-        const existingRecords = await repository.find({
-          where: whereCondition,
-        });
-
-        if (existingRecords.length > 0) {
-          await repository.update(whereCondition, {
-            [relationField.joinColumnName]: toId,
-          });
-        }
-      } catch (error) {
-        this.logger.warn(
-          `Failed to migrate relation field "${relationField.fieldName}" (${relationField.joinColumnName}) in object "${relationField.objectMetadata.nameSingular}":`,
-          error.message,
-        );
-      }
+      await repository.update(
+        { [relationField.joinColumnName]: In(fromIds) },
+        { [relationField.joinColumnName]: toId },
+      );
     }
   }
 

--- a/packages/twenty-server/src/engine/api/common/common-query-runners/common-merge-many-query-runner.service.ts
+++ b/packages/twenty-server/src/engine/api/common/common-query-runners/common-merge-many-query-runner.service.ts
@@ -451,10 +451,17 @@ export class CommonMergeManyQueryRunnerService extends CommonBaseQueryRunnerServ
         context.authContext,
       );
 
-      await repository.update(
-        { [relationField.joinColumnName]: In(fromIds) },
-        { [relationField.joinColumnName]: toId },
-      );
+      // repository.update goes through the entity manager, which builds its
+      // query without the transaction's query runner and would therefore run
+      // outside the transaction. Build the query from the transaction-scoped
+      // repository so the relation migration rolls back with the rest.
+      await repository
+        .createQueryBuilder(relationField.objectMetadata.nameSingular)
+        .update()
+        .set({ [relationField.joinColumnName]: toId })
+        .where({ [relationField.joinColumnName]: In(fromIds) })
+        .returning('*')
+        .execute();
     }
   }
 

--- a/packages/twenty-server/src/engine/api/common/common-query-runners/common-merge-many-query-runner.service.ts
+++ b/packages/twenty-server/src/engine/api/common/common-query-runners/common-merge-many-query-runner.service.ts
@@ -451,10 +451,7 @@ export class CommonMergeManyQueryRunnerService extends CommonBaseQueryRunnerServ
         context.authContext,
       );
 
-      // repository.update goes through the entity manager, which builds its
-      // query without the transaction's query runner and would therefore run
-      // outside the transaction. Build the query from the transaction-scoped
-      // repository so the relation migration rolls back with the rest.
+      // repository.update() runs outside the transaction; build from the transaction-scoped repository so the migration rolls back with the merge.
       await repository
         .createQueryBuilder(relationField.objectMetadata.nameSingular)
         .update()

--- a/packages/twenty-server/test/integration/graphql/suites/object-generated/companies-merge-many.integration-spec.ts
+++ b/packages/twenty-server/test/integration/graphql/suites/object-generated/companies-merge-many.integration-spec.ts
@@ -269,8 +269,6 @@ describe('companies merge resolvers (integration)', () => {
       }
     });
 
-    // The duplicate's children (here a person via the many-to-one company
-    // relation) must be re-parented onto the survivor, not orphaned or deleted.
     it('should re-parent related records onto the survivor and delete the duplicate', async () => {
       const createCompaniesOperation = createManyOperationFactory({
         objectMetadataSingularName: 'company',
@@ -343,7 +341,6 @@ describe('companies merge resolvers (integration)', () => {
       const findPersonResponse =
         await makeGraphqlAPIRequest(findPersonOperation);
 
-      // person survived the merge and now points at the survivor company
       expect(findPersonResponse.body.data.person).not.toBeNull();
       expect(findPersonResponse.body.data.person.company.id).toBe(
         survivorCompanyId,
@@ -361,13 +358,9 @@ describe('companies merge resolvers (integration)', () => {
         findDuplicateOperation,
       );
 
-      // duplicate was deleted in the same transaction as the migration
       expect(findDuplicateResponse.body.data.company).toBeNull();
     });
 
-    // A merge can collapse more than two records at once. Children of every
-    // duplicate must be re-parented onto the survivor, while children that
-    // already belong to the survivor stay put.
     it('should re-parent children from every duplicate onto the survivor', async () => {
       const createCompaniesOperation = createManyOperationFactory({
         objectMetadataSingularName: 'company',

--- a/packages/twenty-server/test/integration/graphql/suites/object-generated/companies-merge-many.integration-spec.ts
+++ b/packages/twenty-server/test/integration/graphql/suites/object-generated/companies-merge-many.integration-spec.ts
@@ -1,5 +1,6 @@
 import { COMPANY_GQL_FIELDS } from 'test/integration/constants/company-gql-fields.constants';
 import { createManyOperationFactory } from 'test/integration/graphql/utils/create-many-operation-factory.util';
+import { findOneOperationFactory } from 'test/integration/graphql/utils/find-one-operation-factory.util';
 import { makeGraphqlAPIRequest } from 'test/integration/graphql/utils/make-graphql-api-request.util';
 import { mergeManyOperationFactory } from 'test/integration/graphql/utils/merge-many-operation-factory.util';
 import { deleteRecordsByIds } from 'test/integration/utils/delete-records-by-ids';
@@ -254,6 +255,112 @@ describe('companies merge resolvers (integration)', () => {
           expect.objectContaining({ url: 'linkedin.com/company/second-sub' }),
         ]),
       );
+    });
+  });
+
+  describe('migrating related records', () => {
+    let createdPersonIds: string[] = [];
+
+    afterEach(async () => {
+      if (createdPersonIds.length > 0) {
+        await deleteRecordsByIds('person', createdPersonIds);
+        createdPersonIds = [];
+      }
+    });
+
+    // The duplicate's children (here a person via the many-to-one company
+    // relation) must be re-parented onto the survivor, not orphaned or deleted.
+    it('should re-parent related records onto the survivor and delete the duplicate', async () => {
+      const createCompaniesOperation = createManyOperationFactory({
+        objectMetadataSingularName: 'company',
+        objectMetadataPluralName: 'companies',
+        gqlFields: COMPANY_GQL_FIELDS,
+        data: [{ name: 'Survivor Inc' }, { name: 'Duplicate Inc' }],
+      });
+
+      const createCompaniesResponse = await makeGraphqlAPIRequest(
+        createCompaniesOperation,
+      );
+
+      const survivorCompanyId =
+        createCompaniesResponse.body.data.createCompanies[0].id;
+      const duplicateCompanyId =
+        createCompaniesResponse.body.data.createCompanies[1].id;
+
+      createdCompanyIds.push(survivorCompanyId, duplicateCompanyId);
+
+      const createPeopleOperation = createManyOperationFactory({
+        objectMetadataSingularName: 'person',
+        objectMetadataPluralName: 'people',
+        gqlFields: `
+          id
+          company {
+            id
+          }
+        `,
+        data: [
+          {
+            name: { firstName: 'Related', lastName: 'Contact' },
+            companyId: duplicateCompanyId,
+          },
+        ],
+      });
+
+      const createPeopleResponse =
+        await makeGraphqlAPIRequest(createPeopleOperation);
+
+      const relatedPerson = createPeopleResponse.body.data.createPeople[0];
+
+      createdPersonIds.push(relatedPerson.id);
+
+      expect(relatedPerson.company.id).toBe(duplicateCompanyId);
+
+      const mergeOperation = mergeManyOperationFactory({
+        objectMetadataPluralName: 'companies',
+        gqlFields: COMPANY_GQL_FIELDS,
+        ids: [survivorCompanyId, duplicateCompanyId],
+        conflictPriorityIndex: 0,
+      });
+
+      const mergeResponse = await makeGraphqlAPIRequest(mergeOperation);
+
+      expect(mergeResponse.body.errors).toBeUndefined();
+      expect(mergeResponse.body.data.mergeCompanies.id).toBe(survivorCompanyId);
+
+      const findPersonOperation = findOneOperationFactory({
+        objectMetadataSingularName: 'person',
+        gqlFields: `
+          id
+          company {
+            id
+          }
+        `,
+        filter: { id: { eq: relatedPerson.id } },
+      });
+
+      const findPersonResponse =
+        await makeGraphqlAPIRequest(findPersonOperation);
+
+      // person survived the merge and now points at the survivor company
+      expect(findPersonResponse.body.data.person).not.toBeNull();
+      expect(findPersonResponse.body.data.person.company.id).toBe(
+        survivorCompanyId,
+      );
+
+      const findDuplicateOperation = findOneOperationFactory({
+        objectMetadataSingularName: 'company',
+        gqlFields: `
+          id
+        `,
+        filter: { id: { eq: duplicateCompanyId } },
+      });
+
+      const findDuplicateResponse = await makeGraphqlAPIRequest(
+        findDuplicateOperation,
+      );
+
+      // duplicate was deleted in the same transaction as the migration
+      expect(findDuplicateResponse.body.data.company).toBeNull();
     });
   });
 });

--- a/packages/twenty-server/test/integration/graphql/suites/object-generated/companies-merge-many.integration-spec.ts
+++ b/packages/twenty-server/test/integration/graphql/suites/object-generated/companies-merge-many.integration-spec.ts
@@ -1,5 +1,6 @@
 import { COMPANY_GQL_FIELDS } from 'test/integration/constants/company-gql-fields.constants';
 import { createManyOperationFactory } from 'test/integration/graphql/utils/create-many-operation-factory.util';
+import { findManyOperationFactory } from 'test/integration/graphql/utils/find-many-operation-factory.util';
 import { findOneOperationFactory } from 'test/integration/graphql/utils/find-one-operation-factory.util';
 import { makeGraphqlAPIRequest } from 'test/integration/graphql/utils/make-graphql-api-request.util';
 import { mergeManyOperationFactory } from 'test/integration/graphql/utils/merge-many-operation-factory.util';
@@ -306,8 +307,9 @@ describe('companies merge resolvers (integration)', () => {
         ],
       });
 
-      const createPeopleResponse =
-        await makeGraphqlAPIRequest(createPeopleOperation);
+      const createPeopleResponse = await makeGraphqlAPIRequest(
+        createPeopleOperation,
+      );
 
       const relatedPerson = createPeopleResponse.body.data.createPeople[0];
 
@@ -361,6 +363,126 @@ describe('companies merge resolvers (integration)', () => {
 
       // duplicate was deleted in the same transaction as the migration
       expect(findDuplicateResponse.body.data.company).toBeNull();
+    });
+
+    // A merge can collapse more than two records at once. Children of every
+    // duplicate must be re-parented onto the survivor, while children that
+    // already belong to the survivor stay put.
+    it('should re-parent children from every duplicate onto the survivor', async () => {
+      const createCompaniesOperation = createManyOperationFactory({
+        objectMetadataSingularName: 'company',
+        objectMetadataPluralName: 'companies',
+        gqlFields: COMPANY_GQL_FIELDS,
+        data: [
+          { name: 'Survivor Multi' },
+          { name: 'Duplicate One' },
+          { name: 'Duplicate Two' },
+        ],
+      });
+
+      const createCompaniesResponse = await makeGraphqlAPIRequest(
+        createCompaniesOperation,
+      );
+
+      const survivorCompanyId =
+        createCompaniesResponse.body.data.createCompanies[0].id;
+      const duplicateOneId =
+        createCompaniesResponse.body.data.createCompanies[1].id;
+      const duplicateTwoId =
+        createCompaniesResponse.body.data.createCompanies[2].id;
+
+      createdCompanyIds.push(survivorCompanyId, duplicateOneId, duplicateTwoId);
+
+      const createPeopleOperation = createManyOperationFactory({
+        objectMetadataSingularName: 'person',
+        objectMetadataPluralName: 'people',
+        gqlFields: `
+          id
+          company {
+            id
+          }
+        `,
+        data: [
+          {
+            name: { firstName: 'Already', lastName: 'OnSurvivor' },
+            companyId: survivorCompanyId,
+          },
+          {
+            name: { firstName: 'Child', lastName: 'OfDuplicateOne' },
+            companyId: duplicateOneId,
+          },
+          {
+            name: { firstName: 'Child', lastName: 'OfDuplicateTwo' },
+            companyId: duplicateTwoId,
+          },
+        ],
+      });
+
+      const createPeopleResponse = await makeGraphqlAPIRequest(
+        createPeopleOperation,
+      );
+
+      const createdPeopleIds = createPeopleResponse.body.data.createPeople.map(
+        (person: { id: string }) => person.id,
+      );
+
+      createdPersonIds.push(...createdPeopleIds);
+
+      const mergeOperation = mergeManyOperationFactory({
+        objectMetadataPluralName: 'companies',
+        gqlFields: COMPANY_GQL_FIELDS,
+        ids: [survivorCompanyId, duplicateOneId, duplicateTwoId],
+        conflictPriorityIndex: 0,
+      });
+
+      const mergeResponse = await makeGraphqlAPIRequest(mergeOperation);
+
+      expect(mergeResponse.body.errors).toBeUndefined();
+      expect(mergeResponse.body.data.mergeCompanies.id).toBe(survivorCompanyId);
+
+      const findPeopleOperation = findManyOperationFactory({
+        objectMetadataSingularName: 'person',
+        objectMetadataPluralName: 'people',
+        gqlFields: `
+          id
+          company {
+            id
+          }
+        `,
+        filter: { id: { in: createdPeopleIds } },
+      });
+
+      const findPeopleResponse =
+        await makeGraphqlAPIRequest(findPeopleOperation);
+
+      const peopleAfterMerge = findPeopleResponse.body.data.people.edges;
+
+      expect(peopleAfterMerge).toHaveLength(3);
+      peopleAfterMerge.forEach(
+        (edge: { node: { company: { id: string } } }) => {
+          expect(edge.node.company.id).toBe(survivorCompanyId);
+        },
+      );
+
+      const findCompaniesOperation = findManyOperationFactory({
+        objectMetadataSingularName: 'company',
+        objectMetadataPluralName: 'companies',
+        gqlFields: `id`,
+        filter: {
+          id: { in: [survivorCompanyId, duplicateOneId, duplicateTwoId] },
+        },
+      });
+
+      const findCompaniesResponse = await makeGraphqlAPIRequest(
+        findCompaniesOperation,
+      );
+
+      const remainingCompanyIds =
+        findCompaniesResponse.body.data.companies.edges.map(
+          (edge: { node: { id: string } }) => edge.node.id,
+        );
+
+      expect(remainingCompanyIds).toEqual([survivorCompanyId]);
     });
   });
 });


### PR DESCRIPTION
Closes [core-team-issue#2333](https://github.com/twentyhq/core-team-issues/issues/2333)

## Summary
Hardens and optimizes `CommonMergeManyQueryRunnerService`:

- **Atomicity**: wrap relation migration + duplicate deletion + survivor update in a single transaction so a mid-merge failure rolls back fully (previously failures were swallowed and could leave orphaned/half-merged data).
- **Perf**: drop the redundant `find`-before-`update` in relation migration (2N → N queries, no row hydration) and hoist `buildFieldMapsFromFlatObjectMetadata` out of the per-field loops.

### Why a transaction (not parallelization)
The relation migrations could be parallelized with `Promise.all`, but merge is a destructive operation: a partial failure leaves orphaned or half-merged records. We prioritize correctness, so the steps run inside one transaction.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/21885?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

