### PR TITLE
fix(build): resolve monaco-graphql alias in Vite config for Rolldown compatibility

### DIFF
--- a/packages/twenty-front/vite.config.ts
+++ b/packages/twenty-front/vite.config.ts
@@ -1,3 +1,4 @@
+import { createRequire } from 'module';
 import { lingui } from '@lingui/vite-plugin';
 import { isNonEmptyString } from '@sniptt/guards';
 import react from '@vitejs/plugin-react-swc';
@@ -15,6 +16,8 @@ import svgr from 'vite-plugin-svgr';
 import tsconfigPaths from 'vite-tsconfig-paths';
 
 import { createWywProfilingPlugin } from 'twenty-shared/vite';
+
+const require = createRequire(import.meta.url);
 
 export default defineConfig(({ mode }) => {
   const env = loadEnv(mode, __dirname, '');
@@ -267,6 +270,15 @@ export default defineConfig(({ mode }) => {
         { find: /^@\//, replacement: path.resolve(__dirname, 'src/modules') + '/' },
         { find: /^~\//, replacement: path.resolve(__dirname, 'src') + '/' },
         { find: 'path', replacement: 'rollup-plugin-node-polyfills/polyfills/path' },
+        // Rolldown (Vite 8 production bundler) does not walk nested node_modules,
+        // so monaco-graphql must be aliased to its package directory explicitly.
+        // require.resolve('pkg/package.json') gives the directory regardless of hoisting;
+        // require.resolve('monaco-graphql') alone resolves to the entry-point file and
+        // breaks sub-path imports like monaco-graphql/esm/graphql.worker.js.
+        {
+          find: 'monaco-graphql',
+          replacement: path.dirname(require.resolve('monaco-graphql/package.json')),
+        },
       ],
     },
   };


### PR DESCRIPTION
## Context

Production builds using Rolldown (Vite 8) fail when `monaco-graphql` is not hoisted to the workspace root by the package manager. Rolldown does not walk nested `node_modules`, so imports of `monaco-graphql` (which may live under a peer dependency's `node_modules`) result in a module-not-found error on clean builds without NX cache.

## Solution

Added an explicit alias in `vite.config.ts` using `require.resolve('monaco-graphql')`. This resolves the module path at config-evaluation time using Node's standard resolution algorithm, so the alias always points to the correct location regardless of where the package manager decides to hoist the package.

## Test plan

- [x] `nx run twenty-front:build --skip-nx-cache` completes without module-not-found errors for `monaco-graphql`
- [x] The GraphQL editor in the API playground still loads correctly in development

🤖 Generated with [Claude Code](https://claude.ai/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/21889?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

