### PR TITLE
Add Docker deploy: droplet + GitHub Actions CI/CD

### DIFF
--- a/.github/workflows/deploy-droplet.yaml
+++ b/.github/workflows/deploy-droplet.yaml
@@ -1,0 +1,87 @@
+name: Deploy to droplet
+
+# Despliega en cada push a main. El build pesado (frontend + imagen Docker)
+# corre aqui, en los runners de GitHub (con RAM de sobra). El droplet solo
+# hace pull de la imagen ya construida y reinicia los contenedores.
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  packages: write
+
+concurrency:
+  group: deploy-droplet
+  cancel-in-progress: false
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 24
+
+      # Pre-construir el frontend en el runner (tiene RAM de sobra). El Dockerfile
+      # detecta packages/twenty-front/build/ y se salta el build pesado en Docker.
+      - name: Build frontend
+        run: |
+          corepack enable
+          yarn install --immutable
+          npx nx build twenty-front
+        env:
+          NODE_OPTIONS: --max-old-space-size=8192
+
+      - uses: docker/setup-buildx-action@v3
+
+      - name: Login a GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build & push imagen
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: packages/twenty-docker/twenty/Dockerfile
+          target: twenty
+          push: true
+          tags: |
+            ghcr.io/bridgestudio-mx/crm_sf:${{ github.sha }}
+            ghcr.io/bridgestudio-mx/crm_sf:latest
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+  deploy:
+    needs: build-and-push
+    runs-on: ubuntu-latest
+    # Despliega a cada servidor de la lista en paralelo. Para agregar maquinas,
+    # edita la variable DEPLOY_HOSTS (Settings -> Variables) con un JSON, ej:
+    #   ["157.230.52.8","10.0.0.5"]
+    # El acceso usa usuario+contrasena (secrets DROPLET_USER / DROPLET_PASSWORD).
+    strategy:
+      fail-fast: false
+      matrix:
+        host: ${{ fromJSON(vars.DEPLOY_HOSTS) }}
+    steps:
+      - name: SSH al servidor ${{ matrix.host }} y redeploy
+        uses: appleboy/ssh-action@v1
+        with:
+          host: ${{ matrix.host }}
+          username: ${{ secrets.DROPLET_USER }}
+          password: ${{ secrets.DROPLET_PASSWORD }}
+          script: |
+            set -e
+            cd /opt/twenty
+            echo "${{ secrets.GHCR_TOKEN }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
+            sed -i "s/^TAG=.*/TAG=${{ github.sha }}/" .env
+            docker compose pull
+            docker compose up -d
+            docker image prune -f

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 **/**/.env
+**/.env.local
 .DS_Store
 /.idea
 .claude/*

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -217,6 +217,24 @@ This handles everything: starts Postgres + Redis (auto-detects local services vs
 
 **Note:** CI workflows (GitHub Actions) manage services via Actions service containers and run setup steps individually — they don't use this script.
 
+### Trigger: "Carga los cambios en local"
+
+When the user says **"Carga los cambios en local"** (or a clear variant like "levanta el local", "corre la app en local con hot-reload"), Claude must start the local hybrid dev environment so that code changes reflect automatically:
+
+```bash
+# 1. Infra (Postgres + Redis) in Docker + .env files + migrations (idempotent)
+bash packages/twenty-utils/setup-dev-env.sh --docker
+
+# 2. App with hot-reload: frontend + backend + worker in watch mode
+yarn start
+```
+
+- Run `yarn start` in the background (it is long-running) and report the URL.
+- App URL: **http://localhost:3001** (frontend); server API on `:3000`.
+- Vite (frontend) and NestJS (backend) recompile on save — no manual rebuild needed.
+- To stop: kill `yarn start`, then `bash packages/twenty-utils/setup-dev-env.sh --down`.
+- This is the documented local flow in `deploy/README.md`. It is unrelated to production deploy (which happens via GitHub Actions on push to `main`).
+
 ## Important Files
 - `nx.json` - Nx workspace configuration with task definitions
 - `tsconfig.base.json` - Base TypeScript configuration

--- a/deploy/.env.example
+++ b/deploy/.env.example
@@ -1,0 +1,15 @@
+# Copia este archivo a .env en el servidor (/opt/twenty/.env) y rellena los valores.
+# El .env NUNCA se commitea (esta en .gitignore).
+
+# Tag de la imagen a correr. El workflow de deploy lo sobreescribe con el SHA del commit.
+TAG=latest
+
+# URL publica del CRM. DEBE ser la real desde el primer arranque o el login falla.
+SERVER_URL=https://parks.bridgehub.mx
+
+# Usuario y contrasena de Postgres. SIN caracteres especiales (van en una URL de conexion).
+PG_DATABASE_USER=
+PG_DATABASE_PASSWORD=
+
+# Clave de cifrado. Genera con: openssl rand -base64 32
+ENCRYPTION_KEY=

--- a/deploy/Caddyfile
+++ b/deploy/Caddyfile
@@ -1,0 +1,5 @@
+# Caddy obtiene y renueva el certificado SSL (Let's Encrypt) automaticamente,
+# guardandolo dentro del droplet (volumen caddy-data). No necesitas comprar SSL.
+parks.bridgehub.mx {
+    reverse_proxy server:3000
+}

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -1,0 +1,150 @@
+# Deploy de Twenty (crm_sf)
+
+CI/CD: cada push a `main` dispara GitHub Actions, que construye la imagen
+(frontend + backend), la sube a GHCR y reinicia los contenedores en el droplet
+via SSH. El droplet **no compila**, solo corre la imagen ya construida.
+
+```
+git push main  ->  GitHub Actions (build + push a GHCR)  ->  SSH al droplet (pull + up -d)
+```
+
+- Imagen: `ghcr.io/bridgestudio-mx/crm_sf`
+- Produccion: `https://parks.bridgehub.mx` (IP `157.230.52.8`)
+
+---
+
+# DEPLOY DE CERO (primera vez) — sigue los pasos en orden
+
+## Paso 1 — Configurar GitHub (una vez)
+
+Repo `BridgeStudio-MX/crm_sf` -> Settings -> Secrets and variables -> Actions.
+
+Pestaña **Secrets** -> New repository secret (x3):
+
+| Secret             | Valor                             |
+| ------------------ | --------------------------------- |
+| `DROPLET_USER`     | `root`                            |
+| `DROPLET_PASSWORD` | la contrasena de root del droplet |
+| `GHCR_TOKEN`       | PAT (classic) con scope `read:packages` (lo creas en github.com/settings/tokens) |
+
+Pestaña **Variables** -> New repository variable (x1):
+
+| Variable       | Valor              |
+| -------------- | ------------------ |
+| `DEPLOY_HOSTS` | `["157.230.52.8"]` |
+
+## Paso 2 — Subir el codigo a `main` (dispara el primer build)
+
+Estos archivos (`deploy/` + `.github/workflows/deploy-droplet.yaml`) deben estar
+en `main`. Al llegar ahi, GitHub Actions arranca solo: construye la imagen y la
+sube a GHCR.
+
+```bash
+git add deploy .github/workflows/deploy-droplet.yaml .gitignore
+git commit -m "Add Docker deploy (droplet + GitHub Actions)"
+git push origin main   # o via Pull Request -> merge a main
+```
+
+Verifica en la pestaña **Actions** del repo que el workflow "Deploy to droplet"
+termine el job de build (el job de deploy fallara aqui: aun no preparamos el
+droplet; lo hacemos en el paso 3). Tras esto, la imagen ya existe en GHCR.
+
+> El `.env` con secretos NO se sube a git (esta en .gitignore). Llega al droplet
+> por separado en el paso 3. La imagen viaja SIN secretos.
+
+## Paso 3 — Preparar el droplet (una vez)
+
+Desde tu maquina, en la raiz del repo. El `scp` lleva la carpeta `deploy`
+COMPLETA, incluido `deploy/.env` (la copia real con los secretos), al droplet.
+
+```bash
+scp -r deploy root@157.230.52.8:/opt/twenty
+
+ssh root@157.230.52.8
+GHCR_USER=TU_USUARIO_GITHUB GHCR_TOKEN=TU_PAT bash /opt/twenty/setup-droplet.sh
+```
+
+El script hace TODO en el droplet (idempotente, seguro re-ejecutar):
+Docker + swap + firewall + deja el `.env` en `/opt/twenty/` + login a GHCR +
+baja la imagen + levanta server + worker + Postgres + Redis + Caddy.
+
+## Paso 4 — DNS (una vez)
+
+En tu proveedor de dominio, crea el registro:
+
+```
+A    parks.bridgehub.mx    ->    157.230.52.8
+```
+
+Caddy emite el certificado SSL (Let's Encrypt) automaticamente en cuanto el DNS
+apunte al droplet. No compras nada.
+
+## Paso 5 — Verificar
+
+```bash
+ssh root@157.230.52.8 'cd /opt/twenty && docker compose ps && docker compose logs --tail=50 server'
+```
+
+Abre `https://parks.bridgehub.mx`. Listo.
+
+---
+
+# OPERACION DIARIA (despues del setup)
+
+A partir de aqui, desplegar = hacer push. Nada manual.
+
+```bash
+git push origin main
+```
+
+Cada push a `main`: Actions reconstruye la imagen, la sube a GHCR, y el droplet
+hace `pull` + `up -d` con el nuevo codigo. El `.env` del droplet se reutiliza.
+
+---
+
+# REFERENCIA
+
+## Desarrollo LOCAL con hot-reload (http://localhost:3001)
+
+Enfoque hibrido: Docker corre solo Postgres + Redis; la app corre con `yarn
+start` en modo watch, asi cada cambio en el codigo se refleja automaticamente.
+
+```bash
+# 1. Infra (Postgres + Redis) en Docker + .env + migraciones (idempotente)
+bash packages/twenty-utils/setup-dev-env.sh --docker
+
+# 2. App con hot-reload (frontend + backend + worker)
+yarn start
+
+# Abre http://localhost:3001   (server en :3000)
+```
+
+Cada vez que guardas un archivo, Vite (frontend) y NestJS (backend) recompilan
+y reflejan el cambio solos. Para detener: Ctrl+C, y apagar la infra con
+`bash packages/twenty-utils/setup-dev-env.sh --down`.
+
+> Atajo: dile a Claude **"Carga los cambios en local"** y ejecuta estos pasos
+> por ti (definido en `CLAUDE.md`).
+
+## Archivos
+
+| Archivo                    | Uso                                                  |
+| -------------------------- | ---------------------------------------------------- |
+| `docker-compose.yml`       | Produccion: server + worker + db + redis + Caddy SSL |
+| `Caddyfile`                | Reverse proxy + SSL automatico (Let's Encrypt)       |
+| `setup-droplet.sh`         | Bootstrap del droplet en una corrida                 |
+| `.env`                     | Secretos reales (NO en git, copia local + droplet)   |
+| `.env.example`             | Plantilla de variables de produccion                 |
+| (local con hot-reload)     | `setup-dev-env.sh --docker` + `yarn start` (ver abajo)     |
+
+## Agregar mas servidores
+
+Prepara cada servidor nuevo con el Paso 3, y añade su IP a la variable
+`DEPLOY_HOSTS`, ej: `["157.230.52.8","10.0.0.5"]`. El workflow despliega a todos
+en paralelo (deben aceptar el mismo usuario/contrasena, o ajusta los secrets).
+
+## Como llegan los secretos a produccion
+
+El `.env` NO viaja por git ni por la imagen. Llega al droplet UNA vez (via el
+`scp` del Paso 3, o generado por `setup-droplet.sh`) y queda en `/opt/twenty/.env`
+de forma permanente. Cada deploy lo reutiliza; nunca lo sobreescribe.

--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -1,0 +1,89 @@
+name: twenty
+
+services:
+  caddy:
+    image: caddy:2
+    ports:
+      - "80:80"
+      - "443:443"
+    volumes:
+      - ./Caddyfile:/etc/caddy/Caddyfile:ro
+      - caddy-data:/data
+      - caddy-config:/config
+    depends_on:
+      - server
+    restart: always
+
+  server:
+    image: ghcr.io/bridgestudio-mx/crm_sf:${TAG:-latest}
+    volumes:
+      - server-local-data:/app/packages/twenty-server/.local-storage
+    environment:
+      NODE_PORT: 3000
+      PG_DATABASE_URL: postgres://${PG_DATABASE_USER:-postgres}:${PG_DATABASE_PASSWORD}@db:5432/default
+      SERVER_URL: ${SERVER_URL}
+      REDIS_URL: redis://redis:6379
+      STORAGE_TYPE: local
+      ENCRYPTION_KEY: ${ENCRYPTION_KEY}
+    depends_on:
+      db:
+        condition: service_healthy
+      redis:
+        condition: service_healthy
+    healthcheck:
+      test: curl --fail http://localhost:3000/healthz
+      interval: 10s
+      timeout: 5s
+      retries: 20
+    restart: always
+
+  worker:
+    image: ghcr.io/bridgestudio-mx/crm_sf:${TAG:-latest}
+    volumes:
+      - server-local-data:/app/packages/twenty-server/.local-storage
+    command: ["yarn", "worker:prod"]
+    environment:
+      PG_DATABASE_URL: postgres://${PG_DATABASE_USER:-postgres}:${PG_DATABASE_PASSWORD}@db:5432/default
+      SERVER_URL: ${SERVER_URL}
+      REDIS_URL: redis://redis:6379
+      DISABLE_DB_MIGRATIONS: "true" # migrations run on the server
+      DISABLE_CRON_JOBS_REGISTRATION: "true" # cron registration runs on the server
+      STORAGE_TYPE: local
+      ENCRYPTION_KEY: ${ENCRYPTION_KEY}
+    depends_on:
+      db:
+        condition: service_healthy
+      server:
+        condition: service_healthy
+    restart: always
+
+  db:
+    image: postgres:16
+    volumes:
+      - db-data:/var/lib/postgresql/data
+    environment:
+      POSTGRES_DB: default
+      POSTGRES_PASSWORD: ${PG_DATABASE_PASSWORD}
+      POSTGRES_USER: ${PG_DATABASE_USER:-postgres}
+    healthcheck:
+      test: pg_isready -U ${PG_DATABASE_USER:-postgres} -h localhost -d postgres
+      interval: 10s
+      timeout: 5s
+      retries: 10
+    restart: always
+
+  redis:
+    image: redis
+    command: ["--maxmemory-policy", "noeviction"]
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 10s
+      timeout: 5s
+      retries: 10
+    restart: always
+
+volumes:
+  db-data:
+  server-local-data:
+  caddy-data:
+  caddy-config:

--- a/deploy/setup-droplet.sh
+++ b/deploy/setup-droplet.sh
@@ -1,0 +1,152 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# ============================================================================
+# setup-droplet.sh
+# Bootstrap de produccion para Twenty (crm_sf) en un droplet de DigitalOcean.
+#
+# Configura un droplet VACIO en una sola corrida (idempotente):
+#   - Instala Docker + compose plugin
+#   - Crea swap de 2GB
+#   - Abre firewall (SSH, 80, 443)
+#   - Genera /opt/twenty/.env con secretos aleatorios (solo si no existe)
+#   - Hace login a GHCR, baja la imagen y levanta el stack
+#     (server + worker + Postgres + Redis + Caddy con SSL automatico)
+#
+# USO (como root en el droplet):
+#   1. Sube la carpeta deploy:   scp -r deploy root@157.230.52.8:/opt/twenty
+#   2. Conectate:                ssh root@157.230.52.8
+#   3. Ejecuta:
+#        GHCR_USER=tu_usuario_github GHCR_TOKEN=tu_pat bash /opt/twenty/setup-droplet.sh
+#
+# Re-ejecutarlo es seguro: NO rota secretos ni borra datos.
+# ============================================================================
+
+DEPLOY_DIR="/opt/twenty"
+DOMAIN="parks.bridgehub.mx"
+SERVER_URL="https://${DOMAIN}"
+IMAGE="ghcr.io/bridgestudio-mx/crm_sf"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+log() { echo -e "\n\033[1;32m==> $*\033[0m"; }
+warn() { echo -e "\033[1;33m[!] $*\033[0m"; }
+
+# ----------------------------------------------------------------------------
+# 0. Verificaciones
+# ----------------------------------------------------------------------------
+if [ "$(id -u)" -ne 0 ]; then
+  echo "Este script debe correr como root." >&2
+  exit 1
+fi
+
+# ----------------------------------------------------------------------------
+# 1. Docker + compose plugin
+# ----------------------------------------------------------------------------
+if command -v docker >/dev/null 2>&1; then
+  log "Docker ya instalado, omito."
+else
+  log "Instalando Docker..."
+  curl -fsSL https://get.docker.com | sh
+fi
+
+# ----------------------------------------------------------------------------
+# 2. Swap de 2GB (da margen aunque el droplet tenga 4GB)
+# ----------------------------------------------------------------------------
+if swapon --show 2>/dev/null | grep -q '/swapfile'; then
+  log "Swap ya configurado, omito."
+else
+  log "Creando swap de 2GB..."
+  fallocate -l 2G /swapfile
+  chmod 600 /swapfile
+  mkswap /swapfile
+  swapon /swapfile
+  grep -q '/swapfile' /etc/fstab || echo '/swapfile none swap sw 0 0' >> /etc/fstab
+fi
+
+# ----------------------------------------------------------------------------
+# 3. Firewall (SSH + HTTP + HTTPS)
+# ----------------------------------------------------------------------------
+if command -v ufw >/dev/null 2>&1; then
+  log "Configurando firewall (ufw)..."
+  ufw allow OpenSSH >/dev/null 2>&1 || ufw allow 22 >/dev/null 2>&1 || true
+  ufw allow 80 >/dev/null 2>&1 || true
+  ufw allow 443 >/dev/null 2>&1 || true
+  ufw --force enable >/dev/null 2>&1 || true
+else
+  warn "ufw no esta disponible; configura el firewall manualmente (22, 80, 443)."
+fi
+
+# ----------------------------------------------------------------------------
+# 4. Carpeta de deploy y archivos de compose
+# ----------------------------------------------------------------------------
+log "Preparando $DEPLOY_DIR..."
+mkdir -p "$DEPLOY_DIR"
+if [ "$SCRIPT_DIR" != "$DEPLOY_DIR" ]; then
+  cp "$SCRIPT_DIR/docker-compose.yml" "$DEPLOY_DIR/"
+  cp "$SCRIPT_DIR/Caddyfile" "$DEPLOY_DIR/"
+fi
+
+# ----------------------------------------------------------------------------
+# 5. .env (genera secretos aleatorios solo si no existe)
+# ----------------------------------------------------------------------------
+ENV_FILE="$DEPLOY_DIR/.env"
+# Si subiste deploy/.env junto a la carpeta, se respeta. Si no, lo generamos.
+if [ ! -f "$ENV_FILE" ] && [ -f "$SCRIPT_DIR/.env" ] && [ "$SCRIPT_DIR" != "$DEPLOY_DIR" ]; then
+  cp "$SCRIPT_DIR/.env" "$ENV_FILE"
+fi
+
+if [ -f "$ENV_FILE" ]; then
+  log ".env ya existe en $DEPLOY_DIR, conservo los secretos actuales."
+else
+  log "Generando $ENV_FILE con secretos aleatorios..."
+  PG_USER="twenty_$(openssl rand -hex 4)"      # usuario aleatorio
+  PG_PASS="$(openssl rand -hex 24)"            # hex: sin simbolos (va en una URL)
+  ENC_KEY="$(openssl rand -base64 32)"
+  cat > "$ENV_FILE" <<EOF
+TAG=latest
+SERVER_URL=${SERVER_URL}
+PG_DATABASE_USER=${PG_USER}
+PG_DATABASE_PASSWORD=${PG_PASS}
+ENCRYPTION_KEY=${ENC_KEY}
+EOF
+  chmod 600 "$ENV_FILE"
+fi
+
+# ----------------------------------------------------------------------------
+# 6. Login a GHCR (para bajar la imagen privada)
+# ----------------------------------------------------------------------------
+if [ -n "${GHCR_USER:-}" ] && [ -n "${GHCR_TOKEN:-}" ]; then
+  log "Login a GHCR como $GHCR_USER..."
+  echo "$GHCR_TOKEN" | docker login ghcr.io -u "$GHCR_USER" --password-stdin
+else
+  warn "GHCR_USER/GHCR_TOKEN no definidos. Haz login manual antes de continuar:"
+  warn "  echo TU_PAT | docker login ghcr.io -u TU_USUARIO --password-stdin"
+fi
+
+# ----------------------------------------------------------------------------
+# 7. Arrancar el stack
+# ----------------------------------------------------------------------------
+cd "$DEPLOY_DIR"
+log "Bajando imagenes..."
+if ! docker compose pull; then
+  warn "No se pudo bajar la imagen $IMAGE."
+  warn "Probablemente aun no existe en GHCR: haz un push a 'main' (o corre el"
+  warn "workflow 'Deploy to droplet') para construirla, luego re-ejecuta este script."
+  exit 1
+fi
+
+log "Levantando contenedores..."
+docker compose up -d
+
+log "Listo. Estado:"
+docker compose ps
+
+cat <<EOF
+
+----------------------------------------------------------------------------
+ SIGUIENTE PASO MANUAL (fuera del droplet):
+ - DNS: crea el registro A   ${DOMAIN} -> $(curl -s ifconfig.me 2>/dev/null || echo 'IP_DEL_DROPLET')
+   Caddy emite el certificado SSL automaticamente cuando el DNS apunte aqui.
+ - Logs del server:  cd ${DEPLOY_DIR} && docker compose logs -f server
+----------------------------------------------------------------------------
+EOF


### PR DESCRIPTION
- Production stack (server, worker, Postgres, Redis, Caddy with auto SSL)
- GitHub Actions workflow: build image on push to main, push to GHCR, deploy via SSH
- One-shot droplet bootstrap script (setup-droplet.sh)
- Local hot-reload dev flow documented + 'Carga los cambios en local' trigger in CLAUDE.md
- Secrets stay out of git (.env gitignored)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/21891?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

