### PR TITLE
fix : Change default state of showInactive to false

### DIFF
--- a/packages/twenty-front/src/pages/settings/data-model/SettingsObjectFieldTable.tsx
+++ b/packages/twenty-front/src/pages/settings/data-model/SettingsObjectFieldTable.tsx
@@ -80,7 +80,7 @@ export const SettingsObjectFieldTable = ({
 }: SettingsObjectFieldTableProps) => {
   const { t } = useLingui();
   const [searchTerm, setSearchTerm] = useState('');
-  const [showInactive, setShowInactive] = useState(true);
+  const [showInactive, setShowInactive] = useState(false);
   const [showSystemFields, setShowSystemFields] = useState(false);
 
   const isAdvancedModeEnabled = useAtomStateValue(isAdvancedModeEnabledState);


### PR DESCRIPTION
Hide inactive fields by default in the Object Fields table.

Changes
Changed the initial value of showInactive from true to false
Inactive fields can still be displayed using the existing filter toggle

Expected Behavior
Active fields are shown by default
Inactive fields remain accessible through the "Inactive" filter

fixes#21890

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/21897?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

