### PR TITLE
fix: add isFieldRichText to getFieldButtonIcon to show edit icon for …

### DIFF
--- a/packages/twenty-front/src/modules/object-record/record-field/ui/utils/__tests__/getFieldButtonIcon.test.ts
+++ b/packages/twenty-front/src/modules/object-record/record-field/ui/utils/__tests__/getFieldButtonIcon.test.ts
@@ -1,0 +1,29 @@
+import {
+  linksFieldDefinition,
+  richTextFieldDefinition,
+  textfieldDefinition,
+} from '@/object-record/record-field/ui/__mocks__/fieldDefinitions';
+import { getFieldButtonIcon } from '@/object-record/record-field/ui/utils/getFieldButtonIcon';
+import { IconPencil } from 'twenty-ui/icon';
+
+describe('getFieldButtonIcon', () => {
+  it('should return undefined when the field definition is undefined', () => {
+    expect(getFieldButtonIcon(undefined)).toBeUndefined();
+  });
+
+  it('should return undefined when the field definition is null', () => {
+    expect(getFieldButtonIcon(null)).toBeUndefined();
+  });
+
+  it('should return the pencil icon for rich text fields', () => {
+    expect(getFieldButtonIcon(richTextFieldDefinition)).toBe(IconPencil);
+  });
+
+  it('should return the pencil icon for links fields', () => {
+    expect(getFieldButtonIcon(linksFieldDefinition)).toBe(IconPencil);
+  });
+
+  it('should return undefined for text fields edited in place', () => {
+    expect(getFieldButtonIcon(textfieldDefinition)).toBeUndefined();
+  });
+});

--- a/packages/twenty-front/src/modules/object-record/record-field/ui/utils/getFieldButtonIcon.ts
+++ b/packages/twenty-front/src/modules/object-record/record-field/ui/utils/getFieldButtonIcon.ts
@@ -5,6 +5,7 @@ import { isFieldEmails } from '@/object-record/record-field/ui/types/guards/isFi
 import { isFieldLinks } from '@/object-record/record-field/ui/types/guards/isFieldLinks';
 import { isFieldMultiSelect } from '@/object-record/record-field/ui/types/guards/isFieldMultiSelect';
 import { isFieldPhones } from '@/object-record/record-field/ui/types/guards/isFieldPhones';
+import { isFieldRichText } from '@/object-record/record-field/ui/types/guards/isFieldRichText';
 import { isFieldRelation } from '@/object-record/record-field/ui/types/guards/isFieldRelation';
 import { isUndefinedOrNull } from '~/utils/isUndefinedOrNull';
 
@@ -30,6 +31,7 @@ export const getFieldButtonIcon = (
     isFieldEmails(fieldDefinition) ||
     isFieldArray(fieldDefinition) ||
     isFieldFiles(fieldDefinition) ||
+    isFieldRichText(fieldDefinition) ||
     isFieldPhones(fieldDefinition)
   ) {
     return IconPencil;

--- a/packages/twenty-front/src/modules/object-record/record-field/ui/utils/getFieldButtonIcon.ts
+++ b/packages/twenty-front/src/modules/object-record/record-field/ui/utils/getFieldButtonIcon.ts
@@ -5,8 +5,8 @@ import { isFieldEmails } from '@/object-record/record-field/ui/types/guards/isFi
 import { isFieldLinks } from '@/object-record/record-field/ui/types/guards/isFieldLinks';
 import { isFieldMultiSelect } from '@/object-record/record-field/ui/types/guards/isFieldMultiSelect';
 import { isFieldPhones } from '@/object-record/record-field/ui/types/guards/isFieldPhones';
-import { isFieldRichText } from '@/object-record/record-field/ui/types/guards/isFieldRichText';
 import { isFieldRelation } from '@/object-record/record-field/ui/types/guards/isFieldRelation';
+import { isFieldRichText } from '@/object-record/record-field/ui/types/guards/isFieldRichText';
 import { isUndefinedOrNull } from '~/utils/isUndefinedOrNull';
 
 import { isFieldArray } from '@/object-record/record-field/ui/types/guards/isFieldArray';


### PR DESCRIPTION
Fixes #20288

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/21904?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

