### PR TITLE
Log total generation time for mock data

### DIFF
--- a/packages/twenty-front/scripts/generate-mock-data.ts
+++ b/packages/twenty-front/scripts/generate-mock-data.ts
@@ -10,6 +10,7 @@ import { generateViews } from './mock-data/generate-views.js';
 import { authenticate } from './mock-data/utils.js';
 
 const main = async () => {
+  console.time('Total generation time');
   const token = await authenticate();
 
   const metadata = await generateObjectMetadata(token);
@@ -34,6 +35,14 @@ const main = async () => {
     console.warn('Skipping API keys generation:', (error as Error).message);
   }
 
+  console.log('All mock data generated!');
+  console.timeEnd('Total generation time');
+};
+
+main().catch((error) => {
+  console.error('Fatal error:', error);
+  process.exit(1);
+});
   console.log('All mock data generated!');
 };
 


### PR DESCRIPTION
Added timing for total generation process.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/21913?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

