### PR TITLE
fix: preserve node position during drag in workflow diagram merge (#15682)

### DIFF
--- a/packages/twenty-front/src/modules/workflow/workflow-diagram/utils/__tests__/mergeWorkflowDiagrams.test.ts
+++ b/packages/twenty-front/src/modules/workflow/workflow-diagram/utils/__tests__/mergeWorkflowDiagrams.test.ts
@@ -133,3 +133,88 @@ it('Replaces duplicated properties with the next value', () => {
 }
 `);
 });
+
+it('Preserves the local position of a node that is being dragged when the next diagram has a stale position', () => {
+  const previousDiagram: WorkflowDiagram = {
+    nodes: [
+      {
+        data: {
+          nodeType: 'action',
+          name: '',
+          actionType: 'CODE',
+          hasNextStepIds: false,
+          position: { x: 120, y: 240 },
+          stepId: '',
+        },
+        id: '1',
+        position: { x: 120, y: 240 },
+        dragging: true,
+      },
+    ],
+    edges: [],
+  };
+  const nextDiagram: WorkflowDiagram = {
+    nodes: [
+      {
+        data: {
+          nodeType: 'action',
+          name: '',
+          actionType: 'CODE',
+          hasNextStepIds: false,
+          position: { x: 0, y: 0 },
+          stepId: '',
+        },
+        id: '1',
+        position: { x: 0, y: 0 },
+      },
+    ],
+    edges: [],
+  };
+
+  const result = mergeWorkflowDiagrams(previousDiagram, nextDiagram);
+
+  expect(result.nodes[0].position).toEqual({ x: 120, y: 240 });
+  expect(result.nodes[0].dragging).toBe(true);
+});
+
+it('Uses the next position when the node is not being dragged', () => {
+  const previousDiagram: WorkflowDiagram = {
+    nodes: [
+      {
+        data: {
+          nodeType: 'action',
+          name: '',
+          actionType: 'CODE',
+          hasNextStepIds: false,
+          position: { x: 120, y: 240 },
+          stepId: '',
+        },
+        id: '1',
+        position: { x: 120, y: 240 },
+        dragging: false,
+      },
+    ],
+    edges: [],
+  };
+  const nextDiagram: WorkflowDiagram = {
+    nodes: [
+      {
+        data: {
+          nodeType: 'action',
+          name: '',
+          actionType: 'CODE',
+          hasNextStepIds: false,
+          position: { x: 300, y: 400 },
+          stepId: '',
+        },
+        id: '1',
+        position: { x: 300, y: 400 },
+      },
+    ],
+    edges: [],
+  };
+
+  const result = mergeWorkflowDiagrams(previousDiagram, nextDiagram);
+
+  expect(result.nodes[0].position).toEqual({ x: 300, y: 400 });
+});

--- a/packages/twenty-front/src/modules/workflow/workflow-diagram/utils/mergeWorkflowDiagrams.ts
+++ b/packages/twenty-front/src/modules/workflow/workflow-diagram/utils/mergeWorkflowDiagrams.ts
@@ -26,7 +26,14 @@ export const mergeWorkflowDiagrams = (
       {} as Partial<WorkflowDiagramNode>,
     );
 
-    return Object.assign(nodeWithPreservedProperties, nextNode);
+    const mergedNode = Object.assign(nodeWithPreservedProperties, nextNode);
+
+    if (previousNode?.dragging === true) {
+      mergedNode.dragging = true;
+      mergedNode.position = previousNode.position;
+    }
+
+    return mergedNode;
   });
 
   return {


### PR DESCRIPTION
## Fixes #15682

### Problem
When editing the workflow builder quickly — clicking a node fast and nudging it on each click — nodes "break in many ways": they jump back to a previous position mid-edit.

### Root cause
The diagram is recomputed from server state whenever `currentVersion` changes (`WorkflowDiagramEffect`), then reconciled with the local diagram via `mergeWorkflowDiagrams`. That merge only preserved `selected` and `measured` and **always took the server `position`** (`Object.assign(..., nextNode)`).

So when a node is being dragged: `onNodeDragStop` fires an async `updateStep({ position })`, a cache update re-runs the effect, and if another drag is already in progress the merge overwrites the in-progress local position with the stale server one → the node snaps back.

### Fix
In `mergeWorkflowDiagrams`, if a node is currently being dragged (`dragging === true`), preserve its local `position` (and `dragging` flag) instead of the incoming server position. The normal sync path is unchanged for non-dragging nodes. xyflow sets `dragging` on the node and it is persisted into the diagram state via `applyNodeChanges`, so it is reliably `true` at merge time during a drag.

### Tests
Added two unit tests to `mergeWorkflowDiagrams.test.ts`:
- preserves the local position of a node being dragged when the next diagram has a stale position
- uses the next (server) position when the node is not being dragged

All existing tests (including snapshots) still pass; lint, format, and typecheck are green.

### Verification
- Unit tests: 4/4 pass.
- Verified against a locally running instance (full stack + seeded data): exercising the real `mergeWorkflowDiagrams` from the running app bundle confirms a dragged node keeps its local position when a stale server position arrives, while non-dragging nodes still take the server position. Workflow builder renders with no console errors.

Note: the organic "fast mouse" race is timing-dependent and hard to reproduce deterministically through browser automation (xyflow uses d3-drag pointer sequencing); verification above targets the exact reconciliation logic where the bug originates.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/21915?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

