### PR TITLE
fix(security): bump react-router to 6.30.4 via react-router-dom (open redirect)

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -17657,10 +17657,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@remix-run/router@npm:1.23.2":
-  version: 1.23.2
-  resolution: "@remix-run/router@npm:1.23.2"
-  checksum: 10c0/7096b7f2086b2cd80c9e06873b71a8317e04858c01edc06a6fed187b660408a90f47c8e120e8af4c369cf1fa6b6a316a66b0917f42b6eb8a566e98b277c50449
+"@remix-run/router@npm:1.23.3":
+  version: 1.23.3
+  resolution: "@remix-run/router@npm:1.23.3"
+  checksum: 10c0/73622465dd9e9a2c5a7ced7d1151ea6e9195a8a979c99b4f70a67093eeff7f339daf03a7c6304709a9c27deb2081a8fff6737663aacb33529c1a12a0a0827a17
   languageName: node
   linkType: hard
 
@@ -48341,26 +48341,26 @@ __metadata:
   linkType: hard
 
 "react-router-dom@npm:^6.4.4":
-  version: 6.30.3
-  resolution: "react-router-dom@npm:6.30.3"
+  version: 6.30.4
+  resolution: "react-router-dom@npm:6.30.4"
   dependencies:
-    "@remix-run/router": "npm:1.23.2"
-    react-router: "npm:6.30.3"
+    "@remix-run/router": "npm:1.23.3"
+    react-router: "npm:6.30.4"
   peerDependencies:
     react: ">=16.8"
     react-dom: ">=16.8"
-  checksum: 10c0/e8a1e13c662ed6ee71a785bd3418ba04b700bcd8aff6ea7b32524371e8abb1c85568cd4fe9b9e9d555b8101fd415f6f1796531f593da60be179ce75b37038657
+  checksum: 10c0/1b25ab26a288da852f7b58eec5c14b3f37919e6773a557cd846d3a05d7a7d890c8d49bda93c0a7f497f240df1df8b0ad50635f990aafb55f2fc545ad8269a822
   languageName: node
   linkType: hard
 
-"react-router@npm:6.30.3":
-  version: 6.30.3
-  resolution: "react-router@npm:6.30.3"
+"react-router@npm:6.30.4":
+  version: 6.30.4
+  resolution: "react-router@npm:6.30.4"
   dependencies:
-    "@remix-run/router": "npm:1.23.2"
+    "@remix-run/router": "npm:1.23.3"
   peerDependencies:
     react: ">=16.8"
-  checksum: 10c0/a0a74bf5a933cf0abd47e0eac1d3a505cd66b866e3ee8f20d8016885d3b4361ba3ba72dee026248c6125e631b191ba6ad109184c892281cea6cb747c71bf5940
+  checksum: 10c0/fb6de7d1002bcab9ea12c4072d93792eca494f1e4f30cfec334ccb6523756d23ce3e093c7c1241399296cebed94789a3fb89f96ee76004e0e746458a8f6bab33
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## fix(security): bump react-router to 6.30.4 via react-router-dom (open redirect)

Resolves [Dependabot Alert #1382](https://github.com/twentyhq/twenty/security/dependabot/1382).

### What

`react-router` `>= 6.7.0, < 6.30.4` has an **open redirect**: a same-origin redirect with a path starting `//` is reinterpreted as a protocol-relative URL (Moderate). Patched in `6.30.4`.

### How — parent-bump, no resolution

`react-router` is exact-pinned by `react-router-dom`, which is our **direct** dependency (`^6.4.4` in twenty-front/ui/shared). `react-router-dom 6.30.4` pins `react-router 6.30.4`, and our range already permits it — so this refreshes `react-router-dom 6.30.3 -> 6.30.4` within range (and its internal `@remix-run/router` 1.23.2 -> 1.23.3). No `resolutions` override.

### Verification

- No `react-router`/`react-router-dom` `< 6.30.4` resolution remains.
- Patch-level bump; `typecheck twenty-front` passes.
- Lockfile-only change (react-router family only); `yarn install --immutable` passes.