### PR TITLE
feat(workflow): allow passing the whole iterated item in iterator node

### DIFF
--- a/packages/twenty-front/src/modules/workflow/workflow-variables/components/WorkflowVariablesDropdownStepItems.tsx
+++ b/packages/twenty-front/src/modules/workflow/workflow-variables/components/WorkflowVariablesDropdownStepItems.tsx
@@ -9,6 +9,7 @@ import { DropdownContent } from '@/ui/layout/dropdown/components/DropdownContent
 import { DropdownMenuHeaderLeftComponent } from '@/ui/layout/dropdown/components/DropdownMenuHeader/internal/DropdownMenuHeaderLeftComponent';
 import { GenericDropdownContentWidth } from '@/ui/layout/dropdown/constants/GenericDropdownContentWidth';
 import { useVariableDropdown } from '@/workflow/workflow-variables/hooks/useVariableDropdown';
+import { isIteratorOutputSchema } from '@/workflow/workflow-variables/types/guards/isIteratorOutputSchema';
 import { isRecordOutputSchemaV2 } from '@/workflow/workflow-variables/types/guards/isRecordOutputSchemaV2';
 import { type StepOutputSchemaV2 } from '@/workflow/workflow-variables/types/StepOutputSchemaV2';
 import { getCurrentSubStepFromPath } from '@/workflow/workflow-variables/utils/getCurrentSubStepFromPath';
@@ -80,6 +81,39 @@ export const WorkflowVariablesDropdownStepItems = ({
     );
   };
 
+  // The iterator exposes the element currently being iterated on as `currentItem`.
+  // When it is an object we let the user select the whole item, not only one of its fields.
+  const iteratorCurrentItemNode = isIteratorOutputSchema(
+    step.type,
+    step.outputSchema,
+  )
+    ? step.outputSchema.currentItem
+    : undefined;
+
+  const isViewingIteratorCurrentItem =
+    isDefined(iteratorCurrentItemNode) &&
+    !iteratorCurrentItemNode.isLeaf &&
+    currentPath.length === 1 &&
+    currentPath[0] === 'currentItem';
+
+  const isWholeItemFoundThroughSearch = isDefined(searchInputValue)
+    ? (iteratorCurrentItemNode?.label
+        ?.toLowerCase()
+        .includes(searchInputValue.toLowerCase()) ?? false)
+    : true;
+
+  const shouldDisplayWholeIteratorItem =
+    isViewingIteratorCurrentItem && isWholeItemFoundThroughSearch;
+
+  const handleSelectWholeIteratorItem = () => {
+    onSelect(
+      getVariableTemplateFromPath({
+        stepId: step.id,
+        path: currentPath,
+      }),
+    );
+  };
+
   const displayedSubStepObject = getDisplayedSubStepObject();
 
   const displayedSubStepObjectMetadata = isDefined(displayedSubStepObject)
@@ -136,6 +170,17 @@ export const WorkflowVariablesDropdownStepItems = ({
       />
       <DropdownMenuSeparator />
       <DropdownMenuItemsContainer hasMaxHeight>
+        {shouldDisplayWholeIteratorItem && (
+          <MenuItemSelect
+            selected={false}
+            focused={false}
+            onClick={handleSelectWholeIteratorItem}
+            text={iteratorCurrentItemNode?.label ?? ''}
+            hasSubMenu={false}
+            LeftIcon={getIcon(iteratorCurrentItemNode?.icon ?? 'IconBraces')}
+            contextualText={t`Use the whole item`}
+          />
+        )}
         {shouldDisplaySubStepObject && (
           <MenuItemSelect
             selected={false}
@@ -148,9 +193,10 @@ export const WorkflowVariablesDropdownStepItems = ({
             contextualText={t`Pick a ${objectLabel} record`}
           />
         )}
-        {filteredOptions.length > 0 && shouldDisplaySubStepObject && (
-          <DropdownMenuSeparator />
-        )}
+        {filteredOptions.length > 0 &&
+          (shouldDisplaySubStepObject || shouldDisplayWholeIteratorItem) && (
+            <DropdownMenuSeparator />
+          )}
         {filteredOptions.map(([key, subStep]) => {
           if (!isDefined(subStep)) {
             return null;

--- a/packages/twenty-shared/src/workflow/workflow-schema/utils/__tests__/search-variable-in-output-schema.iterator.test.ts
+++ b/packages/twenty-shared/src/workflow/workflow-schema/utils/__tests__/search-variable-in-output-schema.iterator.test.ts
@@ -108,6 +108,21 @@ describe('searchVariableInOutputSchema - iterator output schema', () => {
     });
   });
 
+  it('should handle selecting the whole currentItem correctly', () => {
+    const result = searchVariableThroughIteratorOutputSchema({
+      stepName: 'Iterate Companies',
+      iteratorOutputSchema: mockIteratorSchema,
+      rawVariableName: '{{step1.currentItem}}',
+      isFullRecord: false,
+    });
+
+    expect(result).toEqual({
+      variableLabel: 'Current Item',
+      variablePathLabel: 'Iterate Companies > Current Item',
+      variableType: 'unknown',
+    });
+  });
+
   it('should return undefined for invalid field name', () => {
     const result = searchVariableThroughIteratorOutputSchema({
       stepName: 'Iterate Companies',


### PR DESCRIPTION
## Context

In a workflow, when using the **Iterator** node, the variable picker only let you reference *one of the fields* of the element being iterated on (`currentItem`). There was no way to pass along the **whole value** being iterated on to a downstream step.

This is useful when iterating over arrays of plain objects (e.g. from a Code / HTTP Request / Webhook step) or records, and you want to forward the entire item — not just a single field.

## What changed

The backend already stores the full `currentItem` in the iterator step result, and the variable search/display logic (`searchVariableInOutputSchema`) already resolves a bare `{{stepId.currentItem}}` to the whole item. The only missing piece was the **UI affordance** to select it.

- `WorkflowVariablesDropdownStepItems.tsx`: when the user has drilled into the iterator's `currentItem` object node, a new menu item is shown at the top of the dropdown that selects the **whole item** (`{{stepId.currentItem}}`), in addition to the existing per-field selection. It coexists with the existing "Pick a record" option (which selects the record id).
- Added a unit test for selecting the whole `currentItem` in `search-variable-in-output-schema.iterator.test.ts`.

## Behavior

- Iterating over an array of objects/records → you can now select the entire current item as a variable.
- Leaf items (primitives) were already selectable directly at the iterator root, so they are unaffected.

## Testing notes

`node_modules` is not installed in this worktree, so the jest run could not resolve deps (`expr-eval-fork`) — this is environmental, not related to the change. The added test is a pure-logic case following the existing `searchThroughIteratorOutputSchema` fall-through path. CI will validate.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/21955?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

