### PR TITLE
Logic function handler name hardened validation

### DIFF
--- a/packages/twenty-server/src/engine/core-modules/logic-function/logic-function-drivers/drivers/lambda.driver.ts
+++ b/packages/twenty-server/src/engine/core-modules/logic-function/logic-function-drivers/drivers/lambda.driver.ts
@@ -27,6 +27,7 @@ import { LambdaLayerManagerService } from 'src/engine/core-modules/logic-functio
 import { LambdaToolFunctionsService } from 'src/engine/core-modules/logic-function/logic-function-drivers/drivers/lambda/services/lambda-tool-functions.service';
 import { buildLogicFunctionTimeoutResult } from 'src/engine/core-modules/logic-function/logic-function-drivers/drivers/lambda/utils/build-logic-function-timeout-result.util';
 import { parseLambdaLogResult } from 'src/engine/core-modules/logic-function/logic-function-drivers/drivers/lambda/utils/parse-lambda-log-result.util';
+import { HANDLER_NAME_REGEX } from 'src/engine/metadata-modules/logic-function/constants/handler.contant';
 import { LogicFunctionExecutionStatus } from 'src/engine/metadata-modules/logic-function/dtos/logic-function-execution-result.dto';
 import { LogicFunctionExecutionMode } from 'src/engine/metadata-modules/logic-function/logic-function.entity';
 import {
@@ -157,6 +158,13 @@ export class LambdaDriver implements LogicFunctionDriver {
 
       currentPhase = LambdaExecutionPhase.FETCH_CODE;
       const invokeFlowStart = Date.now();
+
+      if (!HANDLER_NAME_REGEX.test(flatLogicFunction.handlerName)) {
+        throw new LogicFunctionException(
+          `Invalid handlerName "${flatLogicFunction.handlerName}": must be a valid JavaScript identifier or dotted path`,
+          LogicFunctionExceptionCode.INVALID_LOGIC_FUNCTION_INPUT,
+        );
+      }
 
       const executorPayload: LambdaDriverExecutorPayload = {
         params: payload,

--- a/packages/twenty-server/src/engine/core-modules/logic-function/logic-function-drivers/drivers/local/services/local-child-process-runner.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/logic-function/logic-function-drivers/drivers/local/services/local-child-process-runner.service.ts
@@ -78,15 +78,13 @@ export class LocalChildProcessRunnerService {
       // Auto-generated. Do not edit.
       const { pathToFileURL } = require('node:url');
 
-      const HANDLER_NAME = ${JSON.stringify(handlerName)};
-
       (async () => {
         try {
           const builtUrl = pathToFileURL(${JSON.stringify(builtFileAbsPath)});
           const mod = await import(builtUrl.href);
           const handlerFn = ${handlerAccessor};
           if (typeof handlerFn !== 'function') {
-            throw new Error('Export "' + HANDLER_NAME + '" not found in function bundle');
+            throw new Error('Export "' + ${JSON.stringify(handlerName)} + '" not found in function bundle');
           }
 
           let payload = undefined;

--- a/packages/twenty-server/src/engine/core-modules/logic-function/logic-function-drivers/drivers/local/services/local-child-process-runner.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/logic-function/logic-function-drivers/drivers/local/services/local-child-process-runner.service.ts
@@ -73,22 +73,18 @@ export class LocalChildProcessRunnerService {
     }
 
     const runnerPath = join(dir, '__runner.cjs');
+    const handlerAccessor = `mod?.${handlerName.split('.').join('?.')}`;
     const code = `
       // Auto-generated. Do not edit.
       const { pathToFileURL } = require('node:url');
 
       const HANDLER_NAME = ${JSON.stringify(handlerName)};
-      const resolveHandler = (mod) =>
-        HANDLER_NAME.split('.').reduce(
-          (target, key) => (target == null ? undefined : target[key]),
-          mod,
-        );
 
       (async () => {
         try {
           const builtUrl = pathToFileURL(${JSON.stringify(builtFileAbsPath)});
           const mod = await import(builtUrl.href);
-          const handlerFn = resolveHandler(mod);
+          const handlerFn = ${handlerAccessor};
           if (typeof handlerFn !== 'function') {
             throw new Error('Export "' + HANDLER_NAME + '" not found in function bundle');
           }

--- a/packages/twenty-server/src/engine/core-modules/logic-function/logic-function-drivers/drivers/local/services/local-child-process-runner.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/logic-function/logic-function-drivers/drivers/local/services/local-child-process-runner.service.ts
@@ -77,12 +77,20 @@ export class LocalChildProcessRunnerService {
       // Auto-generated. Do not edit.
       const { pathToFileURL } = require('node:url');
 
+      const HANDLER_NAME = ${JSON.stringify(handlerName)};
+      const resolveHandler = (mod) =>
+        HANDLER_NAME.split('.').reduce(
+          (target, key) => (target == null ? undefined : target[key]),
+          mod,
+        );
+
       (async () => {
         try {
           const builtUrl = pathToFileURL(${JSON.stringify(builtFileAbsPath)});
           const mod = await import(builtUrl.href);
-          if (typeof mod.${handlerName} !== 'function') {
-            throw new Error('Export "${handlerName}" not found in function bundle');
+          const handlerFn = resolveHandler(mod);
+          if (typeof handlerFn !== 'function') {
+            throw new Error('Export "' + HANDLER_NAME + '" not found in function bundle');
           }
 
           let payload = undefined;
@@ -90,7 +98,7 @@ export class LocalChildProcessRunnerService {
             process.on('message', async (msg) => {
               if (!msg || msg.type !== 'run') return;
               try {
-                const out = await mod.${handlerName}(msg.payload);
+                const out = await handlerFn(msg.payload);
                 process.send && process.send({ ok: true, result: out });
                 process.exit(0);
               } catch (err) {
@@ -102,7 +110,7 @@ export class LocalChildProcessRunnerService {
             // Fallback: read payload from argv[2] (JSON) and print to stdout
             const json = process.argv[2];
             payload = json ? JSON.parse(json) : undefined;
-            const out = await mod.${handlerName}(payload);
+            const out = await handlerFn(payload);
             process.stdout.write(JSON.stringify({ ok: true, result: out }));
             process.exit(0);
           }

--- a/packages/twenty-server/src/engine/workspace-manager/workspace-migration/workspace-migration-builder/validators/services/flat-logic-function-validator.service.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/workspace-migration/workspace-migration-builder/validators/services/flat-logic-function-validator.service.ts
@@ -7,6 +7,7 @@ import { isDefined } from 'twenty-shared/utils';
 
 import { validateFilePath } from 'src/engine/core-modules/file-storage/utils/validate-file-path.util';
 import { findFlatEntityByUniversalIdentifier } from 'src/engine/metadata-modules/flat-entity/utils/find-flat-entity-by-universal-identifier.util';
+import { HANDLER_NAME_REGEX } from 'src/engine/metadata-modules/logic-function/constants/handler.contant';
 import { LogicFunctionExecutionMode } from 'src/engine/metadata-modules/logic-function/logic-function.entity';
 import { LogicFunctionExceptionCode } from 'src/engine/metadata-modules/logic-function/logic-function.exception';
 import { isLogicFunctionReadyForPrebuiltInstall } from 'src/engine/metadata-modules/logic-function/utils/is-logic-function-ready-for-prebuilt-install.util';
@@ -79,6 +80,17 @@ export class FlatLogicFunctionValidatorService {
           userFriendlyMessage: msg`Source handler path is invalid`,
         });
       }
+    }
+
+    if (
+      isDefined(flatEntityUpdate.handlerName) &&
+      !HANDLER_NAME_REGEX.test(flatEntityUpdate.handlerName)
+    ) {
+      validationResult.errors.push({
+        code: LogicFunctionExceptionCode.INVALID_LOGIC_FUNCTION_INPUT,
+        message: t`handlerName must be a valid JavaScript identifier or dotted path`,
+        userFriendlyMessage: msg`Handler name is invalid`,
+      });
     }
 
     const mergedPrebuiltState = {
@@ -200,6 +212,17 @@ export class FlatLogicFunctionValidatorService {
           userFriendlyMessage: msg`Source handler path is invalid`,
         });
       }
+    }
+
+    if (
+      !isDefined(flatLogicFunctionToValidate.handlerName) ||
+      !HANDLER_NAME_REGEX.test(flatLogicFunctionToValidate.handlerName)
+    ) {
+      validationResult.errors.push({
+        code: LogicFunctionExceptionCode.INVALID_LOGIC_FUNCTION_INPUT,
+        message: t`handlerName must be a valid JavaScript identifier or dotted path`,
+        userFriendlyMessage: msg`Handler name is invalid`,
+      });
     }
 
     if (

--- a/packages/twenty-server/test/integration/metadata/suites/logic-function/__snapshots__/failing-logic-function-handler-name.integration-spec.ts.snap
+++ b/packages/twenty-server/test/integration/metadata/suites/logic-function/__snapshots__/failing-logic-function-handler-name.integration-spec.ts.snap
@@ -1,0 +1,141 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Logic function creation via manifest sync should fail for invalid handlerName when handlerName contains an invalid identifier character 1`] = `
+{
+  "extensions": {
+    "code": "METADATA_VALIDATION_FAILED",
+    "errors": {
+      "logicFunction": [
+        {
+          "errors": [
+            {
+              "code": "INVALID_LOGIC_FUNCTION_INPUT",
+              "message": "handlerName must be a valid JavaScript identifier or dotted path",
+              "userFriendlyMessage": "Handler name is invalid",
+            },
+          ],
+          "flatEntityMinimalInformation": {
+            "universalIdentifier": Any<String>,
+          },
+          "metadataName": "logicFunction",
+          "status": "fail",
+          "type": "create",
+        },
+      ],
+    },
+    "message": "Validation failed for 1 logicFunction",
+    "summary": {
+      "logicFunction": 1,
+      "totalErrors": 1,
+    },
+    "userFriendlyMessage": "Handler name is invalid",
+  },
+  "message": "Validation errors occurred while syncing application manifest metadata",
+  "name": "GraphQLError",
+}
+`;
+
+exports[`Logic function creation via manifest sync should fail for invalid handlerName when handlerName injects a statement via semicolon 1`] = `
+{
+  "extensions": {
+    "code": "METADATA_VALIDATION_FAILED",
+    "errors": {
+      "logicFunction": [
+        {
+          "errors": [
+            {
+              "code": "INVALID_LOGIC_FUNCTION_INPUT",
+              "message": "handlerName must be a valid JavaScript identifier or dotted path",
+              "userFriendlyMessage": "Handler name is invalid",
+            },
+          ],
+          "flatEntityMinimalInformation": {
+            "universalIdentifier": Any<String>,
+          },
+          "metadataName": "logicFunction",
+          "status": "fail",
+          "type": "create",
+        },
+      ],
+    },
+    "message": "Validation failed for 1 logicFunction",
+    "summary": {
+      "logicFunction": 1,
+      "totalErrors": 1,
+    },
+    "userFriendlyMessage": "Handler name is invalid",
+  },
+  "message": "Validation errors occurred while syncing application manifest metadata",
+  "name": "GraphQLError",
+}
+`;
+
+exports[`Logic function creation via manifest sync should fail for invalid handlerName when handlerName is a malformed dotted path (consecutive dots) 1`] = `
+{
+  "extensions": {
+    "code": "METADATA_VALIDATION_FAILED",
+    "errors": {
+      "logicFunction": [
+        {
+          "errors": [
+            {
+              "code": "INVALID_LOGIC_FUNCTION_INPUT",
+              "message": "handlerName must be a valid JavaScript identifier or dotted path",
+              "userFriendlyMessage": "Handler name is invalid",
+            },
+          ],
+          "flatEntityMinimalInformation": {
+            "universalIdentifier": Any<String>,
+          },
+          "metadataName": "logicFunction",
+          "status": "fail",
+          "type": "create",
+        },
+      ],
+    },
+    "message": "Validation failed for 1 logicFunction",
+    "summary": {
+      "logicFunction": 1,
+      "totalErrors": 1,
+    },
+    "userFriendlyMessage": "Handler name is invalid",
+  },
+  "message": "Validation errors occurred while syncing application manifest metadata",
+  "name": "GraphQLError",
+}
+`;
+
+exports[`Logic function creation via manifest sync should fail for invalid handlerName when handlerName is empty 1`] = `
+{
+  "extensions": {
+    "code": "METADATA_VALIDATION_FAILED",
+    "errors": {
+      "logicFunction": [
+        {
+          "errors": [
+            {
+              "code": "INVALID_LOGIC_FUNCTION_INPUT",
+              "message": "handlerName must be a valid JavaScript identifier or dotted path",
+              "userFriendlyMessage": "Handler name is invalid",
+            },
+          ],
+          "flatEntityMinimalInformation": {
+            "universalIdentifier": Any<String>,
+          },
+          "metadataName": "logicFunction",
+          "status": "fail",
+          "type": "create",
+        },
+      ],
+    },
+    "message": "Validation failed for 1 logicFunction",
+    "summary": {
+      "logicFunction": 1,
+      "totalErrors": 1,
+    },
+    "userFriendlyMessage": "Handler name is invalid",
+  },
+  "message": "Validation errors occurred while syncing application manifest metadata",
+  "name": "GraphQLError",
+}
+`;

--- a/packages/twenty-server/test/integration/metadata/suites/logic-function/failing-logic-function-handler-name.integration-spec.ts
+++ b/packages/twenty-server/test/integration/metadata/suites/logic-function/failing-logic-function-handler-name.integration-spec.ts
@@ -1,0 +1,127 @@
+import { expectOneNotInternalServerErrorSnapshot } from 'test/integration/graphql/utils/expect-one-not-internal-server-error-snapshot.util';
+import { buildBaseManifest } from 'test/integration/metadata/suites/application/utils/build-base-manifest.util';
+import { cleanupApplicationAndAppRegistration } from 'test/integration/metadata/suites/application/utils/cleanup-application-and-app-registration.util';
+import { setupApplicationForSync } from 'test/integration/metadata/suites/application/utils/setup-application-for-sync.util';
+import { syncApplication } from 'test/integration/metadata/suites/application/utils/sync-application.util';
+import { uploadApplicationFile } from 'test/integration/metadata/suites/application/utils/upload-application-file.util';
+import {
+  type LogicFunctionManifest,
+  type Manifest,
+} from 'twenty-shared/application';
+import {
+  type EachTestingContext,
+  eachTestingContextFilter,
+} from 'twenty-shared/testing';
+import { v4 as uuidv4 } from 'uuid';
+
+const TEST_APP_ID = uuidv4();
+const TEST_ROLE_ID = uuidv4();
+
+const VALID_BUILT_PATH = 'src/logic-functions/handler.mjs';
+
+const buildLogicFunction = (
+  overrides: Partial<LogicFunctionManifest> = {},
+): LogicFunctionManifest => ({
+  universalIdentifier: uuidv4(),
+  name: 'TestLogicFunction',
+  description: 'A test logic function',
+  sourceHandlerPath: 'src/logic-functions/handler.ts',
+  builtHandlerPath: VALID_BUILT_PATH,
+  builtHandlerChecksum: 'valid-checksum',
+  handlerName: 'handler',
+  ...overrides,
+});
+
+const buildManifest = (
+  logicFunctionOverrides: Partial<LogicFunctionManifest> = {},
+): Manifest =>
+  buildBaseManifest({
+    appId: TEST_APP_ID,
+    roleId: TEST_ROLE_ID,
+    overrides: {
+      logicFunctions: [buildLogicFunction(logicFunctionOverrides)],
+    },
+  });
+
+type TestContext = {
+  manifest: Manifest;
+};
+
+const FAILING_HANDLER_NAME_TEST_CASES: EachTestingContext<TestContext>[] = [
+  {
+    title: 'when handlerName injects a statement via semicolon',
+    context: {
+      manifest: buildManifest({
+        handlerName: 'handler; process.exit(1)',
+      }),
+    },
+  },
+  {
+    title: 'when handlerName contains an invalid identifier character',
+    context: {
+      manifest: buildManifest({
+        handlerName: 'my-handler',
+      }),
+    },
+  },
+  {
+    title: 'when handlerName is a malformed dotted path (consecutive dots)',
+    context: {
+      manifest: buildManifest({
+        handlerName: 'default..handler',
+      }),
+    },
+  },
+  {
+    title: 'when handlerName is empty',
+    context: {
+      manifest: buildManifest({
+        handlerName: '',
+      }),
+    },
+  },
+];
+
+describe('Logic function creation via manifest sync should fail for invalid handlerName', () => {
+  beforeAll(async () => {
+    await setupApplicationForSync({
+      applicationUniversalIdentifier: TEST_APP_ID,
+      name: 'Test Handler Name Logic App',
+      description: 'App for testing handlerName validation on creation',
+      sourcePath: 'test-handler-name-logic',
+    });
+
+    jest.useRealTimers();
+
+    await uploadApplicationFile({
+      applicationUniversalIdentifier: TEST_APP_ID,
+      fileFolder: 'BuiltLogicFunction',
+      filePath: VALID_BUILT_PATH,
+      fileBuffer: Buffer.from('dummy built handler content'),
+      filename: 'handler.mjs',
+      contentType: 'application/javascript',
+      expectToFail: false,
+    });
+
+    jest.useFakeTimers();
+  }, 60000);
+
+  afterAll(async () => {
+    await cleanupApplicationAndAppRegistration({
+      applicationUniversalIdentifier: TEST_APP_ID,
+    });
+  });
+
+  it.each(eachTestingContextFilter(FAILING_HANDLER_NAME_TEST_CASES))(
+    '$title',
+    async ({ context }) => {
+      const { errors } = await syncApplication({
+        manifest: context.manifest,
+        expectToFail: true,
+      });
+
+      expectOneNotInternalServerErrorSnapshot({ errors });
+    },
+    60000,
+  );
+});

--- a/packages/twenty-server/test/integration/metadata/suites/logic-function/successful-logic-function-handler-name.integration-spec.ts
+++ b/packages/twenty-server/test/integration/metadata/suites/logic-function/successful-logic-function-handler-name.integration-spec.ts
@@ -1,0 +1,119 @@
+import { buildBaseManifest } from 'test/integration/metadata/suites/application/utils/build-base-manifest.util';
+import { cleanupApplicationAndAppRegistration } from 'test/integration/metadata/suites/application/utils/cleanup-application-and-app-registration.util';
+import { setupApplicationForSync } from 'test/integration/metadata/suites/application/utils/setup-application-for-sync.util';
+import { syncApplication } from 'test/integration/metadata/suites/application/utils/sync-application.util';
+import { uploadApplicationFile } from 'test/integration/metadata/suites/application/utils/upload-application-file.util';
+import {
+  type LogicFunctionManifest,
+  type Manifest,
+} from 'twenty-shared/application';
+import {
+  type EachTestingContext,
+  eachTestingContextFilter,
+} from 'twenty-shared/testing';
+import { v4 as uuidv4 } from 'uuid';
+
+const TEST_APP_ID = uuidv4();
+const TEST_ROLE_ID = uuidv4();
+
+const VALID_BUILT_PATH = 'src/logic-functions/handler.mjs';
+
+const buildLogicFunction = (
+  overrides: Partial<LogicFunctionManifest> = {},
+): LogicFunctionManifest => ({
+  universalIdentifier: uuidv4(),
+  name: 'TestLogicFunction',
+  description: 'A test logic function',
+  sourceHandlerPath: 'src/logic-functions/handler.ts',
+  builtHandlerPath: VALID_BUILT_PATH,
+  builtHandlerChecksum: 'valid-checksum',
+  handlerName: 'handler',
+  ...overrides,
+});
+
+const buildManifest = (
+  logicFunctionOverrides: Partial<LogicFunctionManifest> = {},
+): Manifest =>
+  buildBaseManifest({
+    appId: TEST_APP_ID,
+    roleId: TEST_ROLE_ID,
+    overrides: {
+      logicFunctions: [buildLogicFunction(logicFunctionOverrides)],
+    },
+  });
+
+type TestContext = {
+  manifest: Manifest;
+};
+
+const SUCCESSFUL_HANDLER_NAME_TEST_CASES: EachTestingContext<TestContext>[] = [
+  {
+    title: 'when handlerName is a simple identifier',
+    context: {
+      manifest: buildManifest({
+        handlerName: 'main',
+      }),
+    },
+  },
+  {
+    title: 'when handlerName is the SDK-emitted dotted path',
+    context: {
+      manifest: buildManifest({
+        handlerName: 'default.config.handler',
+      }),
+    },
+  },
+  {
+    title: 'when handlerName uses identifier-legal symbols ($ and _)',
+    context: {
+      manifest: buildManifest({
+        handlerName: '$run_handler2',
+      }),
+    },
+  },
+];
+
+describe('Logic function creation via manifest sync should succeed for valid handlerName', () => {
+  beforeAll(async () => {
+    await setupApplicationForSync({
+      applicationUniversalIdentifier: TEST_APP_ID,
+      name: 'Test Valid Handler Name Logic App',
+      description: 'App for testing valid handlerName values on creation',
+      sourcePath: 'test-valid-handler-name-logic',
+    });
+
+    jest.useRealTimers();
+
+    await uploadApplicationFile({
+      applicationUniversalIdentifier: TEST_APP_ID,
+      fileFolder: 'BuiltLogicFunction',
+      filePath: VALID_BUILT_PATH,
+      fileBuffer: Buffer.from('dummy built handler content'),
+      filename: 'handler.mjs',
+      contentType: 'application/javascript',
+      expectToFail: false,
+    });
+
+    jest.useFakeTimers();
+  }, 60000);
+
+  afterAll(async () => {
+    await cleanupApplicationAndAppRegistration({
+      applicationUniversalIdentifier: TEST_APP_ID,
+    });
+  });
+
+  it.each(eachTestingContextFilter(SUCCESSFUL_HANDLER_NAME_TEST_CASES))(
+    '$title',
+    async ({ context }) => {
+      const { data, errors } = await syncApplication({
+        manifest: context.manifest,
+        expectToFail: false,
+      });
+
+      expect(errors).toBeUndefined();
+      expect(data?.syncApplication).toBeDefined();
+    },
+    60000,
+  );
+});


### PR DESCRIPTION
# Introduction
Introduce centralized handlerName validation for the logic function handlerName inside the flat logic function validator

Even if not safe by definition, avoid string interpolation inside the local driver executor when retrieving the handler name from the parent module

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/21956?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

