### PR TITLE
Deploy website only when twenty-website changes

### DIFF
--- a/.github/workflows/cd-deploy-main.yaml
+++ b/.github/workflows/cd-deploy-main.yaml
@@ -9,7 +9,13 @@ on:
       - main
 
 jobs:
+  website-changed-files:
+    uses: ./.github/workflows/changed-files.yaml
+    with:
+      files: packages/twenty-website/**
+
   deploy-main:
+    needs: website-changed-files
     timeout-minutes: 3
     runs-on: ubuntu-latest
     steps:
@@ -26,5 +32,6 @@ jobs:
       - name: Trigger twenty-infra deploy
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          DEPLOY_WEBSITE: ${{ needs.website-changed-files.outputs.any_changed }}
         run: |
-          gh workflow run auto-deploy-main.yaml --repo twentyhq/twenty-infra --ref main
+          gh workflow run auto-deploy-main.yaml --repo twentyhq/twenty-infra --ref main -f deploy_website="$DEPLOY_WEBSITE"


### PR DESCRIPTION
## Problem

Every push to `main` redeploys the website. `cd-deploy-main.yaml` dispatches the infra `auto-deploy-main` fan-out, which unconditionally triggered `deploy-website`. Since most PRs don't touch `packages/twenty-website/**`, the majority were full, identical Cloudflare builds — wasted CI and noise.

## Fix

Detect website changes here (using the existing reusable `changed-files.yaml`) and pass the result as a `deploy_website` input on the **single** `auto-deploy-main` dispatch:

- New `website-changed-files` job checks `packages/twenty-website/**`.
- The existing `auto-deploy-main` dispatch now carries `-f deploy_website=<true|false>`.
- This repo keeps triggering **only** `auto-deploy-main` — it never dispatches `deploy-website` directly. `twenty-infra` decides whether to run the website deploy (per @FelixMalfait's review: the public repo shouldn't be able to run arbitrary `twenty-infra` workflows directly).
- Server/front deploy is **unchanged** — still every merge.

## Paired change & merge order

Companion PR: **twentyhq/twenty-infra#747** — adds the `deploy_website` input to `auto-deploy-main` and gates the website dispatch on it.

**Merge twenty-infra#747 FIRST**, then this one. (If this merges first, it would pass an input the old `auto-deploy-main` doesn't accept, failing the dispatch. Infra-first only delays website auto-deploys until this lands — no breakage.)