### PR TITLE
fix(deps): bump http-proxy-middleware to 2.0.10

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -36884,8 +36884,8 @@ __metadata:
   linkType: hard
 
 "http-proxy-middleware@npm:^2.0.9":
-  version: 2.0.9
-  resolution: "http-proxy-middleware@npm:2.0.9"
+  version: 2.0.10
+  resolution: "http-proxy-middleware@npm:2.0.10"
   dependencies:
     "@types/http-proxy": "npm:^1.17.8"
     http-proxy: "npm:^1.18.1"
@@ -36897,7 +36897,7 @@ __metadata:
   peerDependenciesMeta:
     "@types/express":
       optional: true
-  checksum: 10c0/8e9032af625f7c9f2f0d318f6cdb14eb725cc16ffe7b4ccccea25cf591fa819bb7c3bb579e0b543e0ae9c73059b505a6d728290c757bff27bae526a6ed11c05e
+  checksum: 10c0/363cd25fbac18f851af93cea34ac7068656413c9af5af12d3b2a127adc70623d2c0d6e9e12037bbac5a4744b762fd9f89fb16e16c29ad06af2b17766890c1b26
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary

Bumps the transitive **http-proxy-middleware** `2.0.9` → `2.0.10`, resolving [Dependabot alert #1574](https://github.com/twentyhq/twenty/security/dependabot/1574) (vulnerable range `>=0.16.0 <2.0.10`).

## Details

- The parent's `^2.0.9` range already permits the fix, so this is a **lockfile-only** bump (`yarn up -R http-proxy-middleware`) — no `package.json` change and no `resolutions` entry needed.
- The unrelated `http-proxy-middleware@^3.0.5 → 3.0.7` is outside the advisory range and untouched.
- Transitive **build-tooling** dependency — not part of the production server runtime; patch-level security fix.

## Verification

- `yarn install --immutable` passes (lockfile consistent with CI).
- No `2.0.9` remnant remains in `yarn.lock`.
