### PR TITLE
chore(sdk): set SDK packages to 2.15.0 for publishing

### DIFF
--- a/packages/create-twenty-app/package.json
+++ b/packages/create-twenty-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-twenty-app",
-  "version": "2.16.0",
+  "version": "2.15.0",
   "description": "Command-line interface to create Twenty application",
   "main": "dist/cli.cjs",
   "bin": "dist/cli.cjs",

--- a/packages/twenty-client-sdk/package.json
+++ b/packages/twenty-client-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "twenty-client-sdk",
-  "version": "2.16.0",
+  "version": "2.15.0",
   "sideEffects": false,
   "license": "AGPL-3.0",
   "scripts": {

--- a/packages/twenty-sdk/package.json
+++ b/packages/twenty-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "twenty-sdk",
-  "version": "2.16.0",
+  "version": "2.15.0",
   "sideEffects": false,
   "bin": {
     "twenty": "dist/cli.cjs"


### PR DESCRIPTION
## Summary

Sets the version of the three published SDK packages to `2.15.0`:

- `twenty-sdk`
- `twenty-client-sdk`
- `create-twenty-app`

## Context

npm currently has `2.14.0` as the latest published version for all three packages. The repo had moved on to `2.16.0` (auto-bumps in #21624 → 2.15.0 and #21973 → 2.16.0), but `2.15.0` was **never published to npm**, leaving a gap.

This sets the package versions back to `2.15.0` so the missing version can be published to npm.

Scope is limited to the three SDK `package.json` files — the server version constants (`TWENTY_CURRENT_VERSION`, etc.) are left at `2.16.0` since they track the app version, not the SDK.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/21996?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

