### PR TITLE
fix(server): block deactivating system fields so creation date keeps showing

### DIFF
--- a/packages/twenty-server/src/engine/metadata-modules/flat-field-metadata/utils/__tests__/sanitize-raw-update-field-input.spec.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/flat-field-metadata/utils/__tests__/sanitize-raw-update-field-input.spec.ts
@@ -1,0 +1,106 @@
+import { TWENTY_STANDARD_APPLICATION_UNIVERSAL_IDENTIFIER } from 'twenty-shared/application';
+import { FieldMetadataType } from 'twenty-shared/types';
+
+import { type UpdateFieldInput } from 'src/engine/metadata-modules/field-metadata/dtos/update-field.input';
+import { FieldMetadataExceptionCode } from 'src/engine/metadata-modules/field-metadata/field-metadata.exception';
+import { getFlatFieldMetadataMock } from 'src/engine/metadata-modules/flat-field-metadata/__mocks__/get-flat-field-metadata.mock';
+import { sanitizeRawUpdateFieldInput } from 'src/engine/metadata-modules/flat-field-metadata/utils/sanitize-raw-update-field-input';
+
+const getSystemFieldMock = () =>
+  getFlatFieldMetadataMock({
+    universalIdentifier: 'created-at-uid',
+    objectMetadataId: 'obj-1',
+    type: FieldMetadataType.DATE_TIME,
+    name: 'createdAt',
+    isSystem: true,
+    isActive: true,
+    applicationUniversalIdentifier:
+      TWENTY_STANDARD_APPLICATION_UNIVERSAL_IDENTIFIER,
+  });
+
+const buildInput = (
+  existingId: string,
+  workspaceId: string,
+  overrides: Partial<UpdateFieldInput>,
+): UpdateFieldInput => ({
+  id: existingId,
+  workspaceId,
+  ...overrides,
+});
+
+describe('sanitizeRawUpdateFieldInput', () => {
+  it('should throw FIELD_MUTATION_NOT_ALLOWED when deactivating a system field', () => {
+    const existingFlatFieldMetadata = getSystemFieldMock();
+
+    expect(() =>
+      sanitizeRawUpdateFieldInput({
+        existingFlatFieldMetadata,
+        rawUpdateFieldInput: buildInput(
+          existingFlatFieldMetadata.id,
+          existingFlatFieldMetadata.workspaceId,
+          { isActive: false },
+        ),
+        isSystemBuild: false,
+      }),
+    ).toThrow(
+      expect.objectContaining({
+        code: FieldMetadataExceptionCode.FIELD_MUTATION_NOT_ALLOWED,
+      }),
+    );
+  });
+
+  it('should allow reactivating a system field', () => {
+    const existingFlatFieldMetadata = getSystemFieldMock();
+
+    expect(() =>
+      sanitizeRawUpdateFieldInput({
+        existingFlatFieldMetadata,
+        rawUpdateFieldInput: buildInput(
+          existingFlatFieldMetadata.id,
+          existingFlatFieldMetadata.workspaceId,
+          { isActive: true },
+        ),
+        isSystemBuild: false,
+      }),
+    ).not.toThrow();
+  });
+
+  it('should allow deactivating a system field during a system build', () => {
+    const existingFlatFieldMetadata = getSystemFieldMock();
+
+    expect(() =>
+      sanitizeRawUpdateFieldInput({
+        existingFlatFieldMetadata,
+        rawUpdateFieldInput: buildInput(
+          existingFlatFieldMetadata.id,
+          existingFlatFieldMetadata.workspaceId,
+          { isActive: false },
+        ),
+        isSystemBuild: true,
+      }),
+    ).not.toThrow();
+  });
+
+  it('should allow deactivating a non-system field', () => {
+    const existingFlatFieldMetadata = getFlatFieldMetadataMock({
+      universalIdentifier: 'job-title-uid',
+      objectMetadataId: 'obj-1',
+      type: FieldMetadataType.TEXT,
+      name: 'jobTitle',
+      isSystem: false,
+      isActive: true,
+    });
+
+    expect(() =>
+      sanitizeRawUpdateFieldInput({
+        existingFlatFieldMetadata,
+        rawUpdateFieldInput: buildInput(
+          existingFlatFieldMetadata.id,
+          existingFlatFieldMetadata.workspaceId,
+          { isActive: false },
+        ),
+        isSystemBuild: false,
+      }),
+    ).not.toThrow();
+  });
+});

--- a/packages/twenty-server/src/engine/metadata-modules/flat-field-metadata/utils/sanitize-raw-update-field-input.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/flat-field-metadata/utils/sanitize-raw-update-field-input.ts
@@ -58,6 +58,20 @@ export const sanitizeRawUpdateFieldInput = ({
       });
   }
 
+  // System fields (createdAt, updatedAt, createdBy, ...) are framework-managed and
+  // must stay active: deactivating one drops its value from the UI and silently
+  // no-ops sorting while the column stays populated. Deletion is blocked the same way.
+  if (
+    !isSystemBuild &&
+    existingFlatFieldMetadata.isSystem &&
+    updatedEditableFieldProperties.isActive === false
+  ) {
+    throw new FieldMetadataException(
+      `Cannot deactivate system field "${existingFlatFieldMetadata.name}"`,
+      FieldMetadataExceptionCode.FIELD_MUTATION_NOT_ALLOWED,
+    );
+  }
+
   if (!isStandardField || isSystemBuild) {
     return {
       updatedEditableFieldProperties,


### PR DESCRIPTION
## Problem

Reported (high severity): on one workspace the **Creation date** field shows blank in the UI and **sorting by it does nothing**, even though the value is present in the DB column. It could not be reproduced on a fresh workspace — i.e. it depends on workspace metadata state.

## Root cause

`createdAt` (like the other system fields `updatedAt`, `deletedAt`, `createdBy`, `updatedBy`) is `isSystem: true` and must always stay active. But the field-update path allowed setting `isActive: false` on system fields — `isActive` is in the standard editable properties and there was no guard, even though **deletion** of system fields is already blocked.

Once a system field is deactivated:

- The frontend filters it out of the object's active fields (`isActiveFieldMetadataItem`), so `mapViewFieldsToColumnDefinitions` drops it → the value stops rendering.
- `turnSortsIntoOrderBy` can't resolve the `fieldMetadataId` among active fields → the sort silently no-ops.
- The underlying column keeps its data, which is why it's still visible in the DB.

This exactly matches the report: value in the column, blank field, dead sort, persists across refresh, workspace-specific.

## Fix

Block deactivating a system field on the user update path in `sanitizeRawUpdateFieldInput`, mirroring the existing delete guard. Reactivation (`isActive: true`) and internal `isSystemBuild` operations are unaffected, so this can't happen again and affected workspaces can recover by reactivating the field.

## Tests

Added `sanitize-raw-update-field-input.spec.ts`:
- throws `FIELD_MUTATION_NOT_ALLOWED` when deactivating a system field
- allows reactivating a system field
- allows deactivating a system field during a system build
- allows deactivating a non-system field

## Notes / follow-up

This prevents new occurrences. Workspaces already in the broken state need the affected system field reactivated (`isActive: true`); a one-off data sweep to reactivate inactive system fields could be a follow-up if needed.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/21998?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

