### PR TITLE
Add search navigation menu item

### DIFF
--- a/packages/twenty-front/src/modules/navigation-menu-item/common/constants/NavigationMenuItemSearchId.ts
+++ b/packages/twenty-front/src/modules/navigation-menu-item/common/constants/NavigationMenuItemSearchId.ts
@@ -1,0 +1,1 @@
+export const NAVIGATION_MENU_ITEM_SEARCH_ID = 'navigation-menu-item-search';

--- a/packages/twenty-front/src/modules/navigation-menu-item/common/constants/NavigationMenuItemSearchLink.ts
+++ b/packages/twenty-front/src/modules/navigation-menu-item/common/constants/NavigationMenuItemSearchLink.ts
@@ -1,0 +1,1 @@
+export const NAVIGATION_MENU_ITEM_SEARCH_LINK = 'twenty://search';

--- a/packages/twenty-front/src/modules/navigation-menu-item/common/utils/__tests__/buildCreateNavigationMenuItemInput.test.ts
+++ b/packages/twenty-front/src/modules/navigation-menu-item/common/utils/__tests__/buildCreateNavigationMenuItemInput.test.ts
@@ -1,0 +1,37 @@
+import { NAVIGATION_MENU_ITEM_SEARCH_LINK } from '@/navigation-menu-item/common/constants/NavigationMenuItemSearchLink';
+import { buildCreateNavigationMenuItemInput } from '@/navigation-menu-item/common/utils/buildCreateNavigationMenuItemInput';
+import {
+  type NavigationMenuItem,
+  NavigationMenuItemType,
+} from '~/generated-metadata/graphql';
+
+const buildLinkNavigationMenuItem = (link: string): NavigationMenuItem =>
+  ({
+    id: 'navigation-menu-item-id',
+    type: NavigationMenuItemType.LINK,
+    name: 'Search',
+    link,
+    position: 0,
+    createdAt: '',
+    updatedAt: '',
+  }) as NavigationMenuItem;
+
+describe('buildCreateNavigationMenuItemInput', () => {
+  it('should preserve the search navigation action link', () => {
+    expect(
+      buildCreateNavigationMenuItemInput(
+        buildLinkNavigationMenuItem(NAVIGATION_MENU_ITEM_SEARCH_LINK),
+        (folderId) => folderId,
+      ).link,
+    ).toBe(NAVIGATION_MENU_ITEM_SEARCH_LINK);
+  });
+
+  it('should still make regular link navigation menu items absolute', () => {
+    expect(
+      buildCreateNavigationMenuItemInput(
+        buildLinkNavigationMenuItem('example.com'),
+        (folderId) => folderId,
+      ).link,
+    ).toBe('https://example.com');
+  });
+});

--- a/packages/twenty-front/src/modules/navigation-menu-item/common/utils/__tests__/isNavigationMenuItemSearch.test.ts
+++ b/packages/twenty-front/src/modules/navigation-menu-item/common/utils/__tests__/isNavigationMenuItemSearch.test.ts
@@ -1,0 +1,41 @@
+import { NAVIGATION_MENU_ITEM_SEARCH_LINK } from '@/navigation-menu-item/common/constants/NavigationMenuItemSearchLink';
+import { isNavigationMenuItemSearch } from '@/navigation-menu-item/common/utils/isNavigationMenuItemSearch';
+import { NavigationMenuItemType } from 'twenty-shared/types';
+
+describe('isNavigationMenuItemSearch', () => {
+  it('should return true for the search navigation menu item link', () => {
+    expect(
+      isNavigationMenuItemSearch({
+        type: NavigationMenuItemType.LINK,
+        link: NAVIGATION_MENU_ITEM_SEARCH_LINK,
+      }),
+    ).toBe(true);
+  });
+
+  it('should return true when the search link has surrounding whitespace', () => {
+    expect(
+      isNavigationMenuItemSearch({
+        type: NavigationMenuItemType.LINK,
+        link: ` ${NAVIGATION_MENU_ITEM_SEARCH_LINK} `,
+      }),
+    ).toBe(true);
+  });
+
+  it('should return false for regular link navigation menu items', () => {
+    expect(
+      isNavigationMenuItemSearch({
+        type: NavigationMenuItemType.LINK,
+        link: 'https://example.com',
+      }),
+    ).toBe(false);
+  });
+
+  it('should return false for non-link navigation menu items', () => {
+    expect(
+      isNavigationMenuItemSearch({
+        type: NavigationMenuItemType.OBJECT,
+        link: NAVIGATION_MENU_ITEM_SEARCH_LINK,
+      }),
+    ).toBe(false);
+  });
+});

--- a/packages/twenty-front/src/modules/navigation-menu-item/common/utils/buildCreateNavigationMenuItemInput.ts
+++ b/packages/twenty-front/src/modules/navigation-menu-item/common/utils/buildCreateNavigationMenuItemInput.ts
@@ -7,6 +7,7 @@ import { ensureAbsoluteUrl, isDefined } from 'twenty-shared/utils';
 
 import { isNavigationMenuItemFolder } from '@/navigation-menu-item/common/utils/isNavigationMenuItemFolder';
 import { isNavigationMenuItemLink } from '@/navigation-menu-item/common/utils/isNavigationMenuItemLink';
+import { isNavigationMenuItemSearch } from '@/navigation-menu-item/common/utils/isNavigationMenuItemSearch';
 import { isNavigationMenuItemObject } from '@/navigation-menu-item/common/utils/isNavigationMenuItemObject';
 
 export const buildCreateNavigationMenuItemInput = (
@@ -25,7 +26,11 @@ export const buildCreateNavigationMenuItemInput = (
   } else if (isNavigationMenuItemLink(draftItem)) {
     input.name = draftItem.name ?? 'Link';
     const linkUrl = (draftItem.link ?? '').trim();
-    input.link = linkUrl ? ensureAbsoluteUrl(linkUrl) : undefined;
+    input.link = isNavigationMenuItemSearch(draftItem)
+      ? linkUrl
+      : linkUrl
+        ? ensureAbsoluteUrl(linkUrl)
+        : undefined;
   } else if (isNavigationMenuItemObject(draftItem)) {
     input.targetObjectMetadataId =
       draftItem.targetObjectMetadataId ?? undefined;

--- a/packages/twenty-front/src/modules/navigation-menu-item/common/utils/isNavigationMenuItemSearch.ts
+++ b/packages/twenty-front/src/modules/navigation-menu-item/common/utils/isNavigationMenuItemSearch.ts
@@ -1,0 +1,15 @@
+import { NavigationMenuItemType } from 'twenty-shared/types';
+
+import { NAVIGATION_MENU_ITEM_SEARCH_LINK } from '@/navigation-menu-item/common/constants/NavigationMenuItemSearchLink';
+
+type NavigationMenuItemSearch<T extends { type: string }> = T & {
+  link: typeof NAVIGATION_MENU_ITEM_SEARCH_LINK;
+};
+
+export const isNavigationMenuItemSearch = <
+  T extends { type: string; link?: string | null },
+>(
+  item: T,
+): item is NavigationMenuItemSearch<T> =>
+  item.type === NavigationMenuItemType.LINK &&
+  (item.link ?? '').trim() === NAVIGATION_MENU_ITEM_SEARCH_LINK;

--- a/packages/twenty-front/src/modules/navigation-menu-item/display/components/NavigationMenuItemIcon.tsx
+++ b/packages/twenty-front/src/modules/navigation-menu-item/display/components/NavigationMenuItemIcon.tsx
@@ -5,11 +5,12 @@ import {
   StyledTintedIconTileContainer,
   getIconTileColorShades,
 } from 'twenty-ui/data-display';
-import { IconLink, IconWorld, useIcons } from 'twenty-ui/icon';
+import { IconLink, IconSearch, IconWorld, useIcons } from 'twenty-ui/icon';
 import { themeCssVariables } from 'twenty-ui/theme-constants';
 import { type NavigationMenuItem } from '~/generated-metadata/graphql';
 
 import { getNavigationMenuItemColor } from '@/navigation-menu-item/common/utils/getNavigationMenuItemColor';
+import { isNavigationMenuItemSearch } from '@/navigation-menu-item/common/utils/isNavigationMenuItemSearch';
 import { recordIdentifierToObjectRecordIdentifier } from '@/navigation-menu-item/common/utils/recordIdentifierToObjectRecordIdentifier';
 import { LinkIconWithLinkOverlay } from '@/navigation-menu-item/display/link/components/LinkIconWithLinkOverlay';
 import { getNavigationMenuItemObjectNameSingular } from '@/navigation-menu-item/display/object/utils/getNavigationMenuItemObjectNameSingular';
@@ -70,6 +71,27 @@ export const NavigationMenuItemIcon = ({
           objectMetadataItem,
         )}
       />
+    );
+  }
+
+  if (isNavigationMenuItemSearch(navigationMenuItem)) {
+    const searchIconStyle = getIconTileColorShades(
+      getNavigationMenuItemColor(navigationMenuItem),
+    );
+
+    return (
+      <StyledTintedIconTileContainer
+        $backgroundColor={searchIconStyle.backgroundColor}
+        $borderColor={searchIconStyle.borderColor}
+      >
+        <Avatar
+          size="sm"
+          type="icon"
+          Icon={IconSearch}
+          iconColor={searchIconStyle.iconColor}
+          placeholder={navigationMenuItem.name ?? ''}
+        />
+      </StyledTintedIconTileContainer>
     );
   }
 

--- a/packages/twenty-front/src/modules/navigation-menu-item/display/dnd/hooks/useHandleAddToNavigationDrop.ts
+++ b/packages/twenty-front/src/modules/navigation-menu-item/display/dnd/hooks/useHandleAddToNavigationDrop.ts
@@ -3,18 +3,20 @@ import { useStore } from 'jotai';
 import { useCallback } from 'react';
 import { NavigationMenuItemType } from 'twenty-shared/types';
 import { isDefined, normalizeUrl } from 'twenty-shared/utils';
-import { IconFolder, IconLink, useIcons } from 'twenty-ui/icon';
+import { IconFolder, IconLink, IconSearch, useIcons } from 'twenty-ui/icon';
 
 import { useEnterLayoutCustomizationMode } from '@/layout-customization/hooks/useEnterLayoutCustomizationMode';
 import { isLayoutCustomizationModeEnabledState } from '@/layout-customization/states/isLayoutCustomizationModeEnabledState';
 import { ADD_TO_NAV_SOURCE_DROPPABLE_ID } from '@/navigation-menu-item/common/constants/AddToNavSourceDroppableId';
 import { DEFAULT_NAVIGATION_MENU_ITEM_COLOR_FOLDER } from '@/navigation-menu-item/common/constants/NavigationMenuItemDefaultColorFolder';
 import { DEFAULT_NAVIGATION_MENU_ITEM_COLOR_LINK } from '@/navigation-menu-item/common/constants/NavigationMenuItemDefaultColorLink';
+import { NAVIGATION_MENU_ITEM_SEARCH_LINK } from '@/navigation-menu-item/common/constants/NavigationMenuItemSearchLink';
 import { addToNavPayloadRegistryState } from '@/navigation-menu-item/common/states/addToNavPayloadRegistryState';
 import { navigationMenuItemEditSectionState } from '@/navigation-menu-item/common/states/navigationMenuItemEditSectionState';
 import { openNavigationMenuItemFolderIdsState } from '@/navigation-menu-item/common/states/openNavigationMenuItemFolderIdsState';
 import { canNavigationMenuItemBeDroppedIn } from '@/navigation-menu-item/common/utils/canNavigationMenuItemBeDroppedIn';
 import { getObjectMetadataIdsInDraft } from '@/navigation-menu-item/common/utils/getObjectMetadataIdsInDraft';
+import { isNavigationMenuItemSearch } from '@/navigation-menu-item/common/utils/isNavigationMenuItemSearch';
 import { validateAndExtractWorkspaceFolderId } from '@/navigation-menu-item/common/utils/validateAndExtractWorkspaceFolderId';
 import {
   type NewNavigationMenuItemInput,
@@ -125,17 +127,24 @@ export const useHandleAddToNavigationDrop = () => {
           return;
         }
         case NavigationMenuItemType.LINK: {
+          const isSearchNavigationMenuItem =
+            isNavigationMenuItemSearch(payload);
+
           addToWorkspaceAndOpenEdit(
             {
               type: NavigationMenuItemType.LINK,
               name: payload.name || t`Link label`,
-              link: normalizeUrl(payload.link),
+              link: isSearchNavigationMenuItem
+                ? NAVIGATION_MENU_ITEM_SEARCH_LINK
+                : normalizeUrl(payload.link),
               color: DEFAULT_NAVIGATION_MENU_ITEM_COLOR_LINK,
             },
             { targetFolderId: folderId, targetIndex: index },
             {
-              pageTitle: t`Edit link`,
-              pageIcon: IconLink,
+              pageTitle: isSearchNavigationMenuItem
+                ? t`Edit search`
+                : t`Edit link`,
+              pageIcon: isSearchNavigationMenuItem ? IconSearch : IconLink,
               focusTitleInput: true,
             },
           );

--- a/packages/twenty-front/src/modules/navigation-menu-item/display/folder/components/NavigationMenuItemFolderSubItem.tsx
+++ b/packages/twenty-front/src/modules/navigation-menu-item/display/folder/components/NavigationMenuItemFolderSubItem.tsx
@@ -6,6 +6,7 @@ import { type NavigationMenuItem } from '~/generated-metadata/graphql';
 
 import { lastClickedNavigationMenuItemIdState } from '@/navigation-menu-item/common/states/lastClickedNavigationMenuItemIdState';
 import { getNavigationMenuItemColor } from '@/navigation-menu-item/common/utils/getNavigationMenuItemColor';
+import { isNavigationMenuItemSearch } from '@/navigation-menu-item/common/utils/isNavigationMenuItemSearch';
 import { NavigationMenuItemIcon } from '@/navigation-menu-item/display/components/NavigationMenuItemIcon';
 import { useIdentifyActiveNavigationMenuItems } from '@/navigation-menu-item/display/hooks/useIdentifyActiveNavigationMenuItems';
 import { useIsNavigationMenuItemEditHighlighted } from '@/navigation-menu-item/display/hooks/useIsNavigationMenuItemEditHighlighted';
@@ -22,6 +23,7 @@ import { useAtomStateValue } from '@/ui/utilities/state/jotai/hooks/useAtomState
 import { useSetAtomState } from '@/ui/utilities/state/jotai/hooks/useSetAtomState';
 import { viewsSelector } from '@/views/states/selectors/viewsSelector';
 import { lastVisitedViewPerObjectMetadataItemState } from '@/navigation/states/lastVisitedViewPerObjectMetadataItemState';
+import { useOpenRecordsSearchPageInSidePanel } from '@/side-panel/hooks/useOpenRecordsSearchPageInSidePanel';
 
 type NavigationMenuItemFolderSubItemProps = {
   navigationMenuItem: NavigationMenuItem;
@@ -58,11 +60,14 @@ export const NavigationMenuItemFolderSubItem = ({
   const setLastClickedNavigationMenuItemId = useSetAtomState(
     lastClickedNavigationMenuItemIdState,
   );
+  const { openRecordsSearchPage } = useOpenRecordsSearchPageInSidePanel();
 
   const { activeNavigationMenuItemIds } =
     useIdentifyActiveNavigationMenuItems();
 
   const isActive = activeNavigationMenuItemIds.includes(navigationMenuItem.id);
+  const isSearchNavigationMenuItem =
+    isNavigationMenuItemSearch(navigationMenuItem);
 
   const label = getNavigationMenuItemLabel(
     navigationMenuItem,
@@ -105,10 +110,12 @@ export const NavigationMenuItemFolderSubItem = ({
             item: navigationMenuItem,
             objectMetadataItem: objectMetadataItem ?? undefined,
           })
-      : () => {
-          setLastClickedNavigationMenuItemId(navigationMenuItem.id);
-          navigate(computedLink);
-        });
+      : isSearchNavigationMenuItem
+        ? openRecordsSearchPage
+        : () => {
+            setLastClickedNavigationMenuItemId(navigationMenuItem.id);
+            navigate(computedLink);
+          });
 
   return (
     <NavigationDrawerSubItem
@@ -128,7 +135,11 @@ export const NavigationMenuItemFolderSubItem = ({
         navigationMenuItem,
         objectMetadataItem ?? undefined,
       )}
-      to={isDragging || isEditable ? undefined : computedLink}
+      to={
+        isDragging || isEditable || isSearchNavigationMenuItem
+          ? undefined
+          : computedLink
+      }
       onClick={handleClick}
       active={isActive}
       isSelectedInEditMode={isEditHighlightedInNavigationMenu}

--- a/packages/twenty-front/src/modules/navigation-menu-item/display/link/components/NavigationMenuItemLinkDisplay.tsx
+++ b/packages/twenty-front/src/modules/navigation-menu-item/display/link/components/NavigationMenuItemLinkDisplay.tsx
@@ -3,10 +3,12 @@ import { IconArrowUpRight } from 'twenty-ui/icon';
 import { ThemeContext, themeCssVariables } from 'twenty-ui/theme-constants';
 
 import { isLayoutCustomizationModeEnabledState } from '@/layout-customization/states/isLayoutCustomizationModeEnabledState';
+import { isNavigationMenuItemSearch } from '@/navigation-menu-item/common/utils/isNavigationMenuItemSearch';
 import { NavigationMenuItemIcon } from '@/navigation-menu-item/display/components/NavigationMenuItemIcon';
 import { getLinkNavigationMenuItemComputedLink } from '@/navigation-menu-item/display/link/utils/getLinkNavigationMenuItemComputedLink';
 import { getLinkNavigationMenuItemLabel } from '@/navigation-menu-item/display/link/utils/getLinkNavigationMenuItemLabel';
 import type { NavigationMenuItemSectionContentProps } from '@/navigation-menu-item/display/sections/types/NavigationMenuItemSectionContentProps';
+import { useOpenRecordsSearchPageInSidePanel } from '@/side-panel/hooks/useOpenRecordsSearchPageInSidePanel';
 import { NavigationDrawerItem } from '@/ui/navigation/navigation-drawer/components/NavigationDrawerItem';
 import { useAtomStateValue } from '@/ui/utilities/state/jotai/hooks/useAtomStateValue';
 
@@ -22,30 +24,37 @@ export const NavigationMenuItemLinkDisplay = ({
     isLayoutCustomizationModeEnabledState,
   );
   const { theme } = useContext(ThemeContext);
+  const { openRecordsSearchPage } = useOpenRecordsSearchPageInSidePanel();
 
   const label = getLinkNavigationMenuItemLabel(item);
   const computedLink = getLinkNavigationMenuItemComputedLink(item);
+  const isSearchNavigationMenuItem = isNavigationMenuItemSearch(item);
 
-  const defaultRightOptions = !isLayoutCustomizationModeEnabled && (
-    <IconArrowUpRight
-      size={theme.icon.size.sm}
-      stroke={theme.icon.stroke.md}
-      color={themeCssVariables.font.color.light}
-    />
-  );
+  const defaultRightOptions = !isLayoutCustomizationModeEnabled &&
+    !isSearchNavigationMenuItem && (
+      <IconArrowUpRight
+        size={theme.icon.size.sm}
+        stroke={theme.icon.stroke.md}
+        color={themeCssVariables.font.color.light}
+      />
+    );
 
   return (
     <NavigationDrawerItem
       label={label}
       to={
-        isLayoutCustomizationModeEnabled || isDragging
+        isLayoutCustomizationModeEnabled ||
+        isDragging ||
+        isSearchNavigationMenuItem
           ? undefined
           : computedLink
       }
       onClick={
         isLayoutCustomizationModeEnabled
           ? editModeProps?.onEditModeClick
-          : undefined
+          : isSearchNavigationMenuItem
+            ? openRecordsSearchPage
+            : undefined
       }
       Icon={() => <NavigationMenuItemIcon navigationMenuItem={item} />}
       active={false}

--- a/packages/twenty-front/src/modules/navigation-menu-item/display/link/utils/__tests__/getLinkNavigationMenuItemComputedLink.test.ts
+++ b/packages/twenty-front/src/modules/navigation-menu-item/display/link/utils/__tests__/getLinkNavigationMenuItemComputedLink.test.ts
@@ -1,0 +1,32 @@
+import { NAVIGATION_MENU_ITEM_SEARCH_LINK } from '@/navigation-menu-item/common/constants/NavigationMenuItemSearchLink';
+import { getLinkNavigationMenuItemComputedLink } from '@/navigation-menu-item/display/link/utils/getLinkNavigationMenuItemComputedLink';
+import { NavigationMenuItemType } from 'twenty-shared/types';
+
+describe('getLinkNavigationMenuItemComputedLink', () => {
+  it('should preserve the search navigation action link', () => {
+    expect(
+      getLinkNavigationMenuItemComputedLink({
+        type: NavigationMenuItemType.LINK,
+        link: NAVIGATION_MENU_ITEM_SEARCH_LINK,
+      }),
+    ).toBe(NAVIGATION_MENU_ITEM_SEARCH_LINK);
+  });
+
+  it('should preserve an absolute link', () => {
+    expect(
+      getLinkNavigationMenuItemComputedLink({
+        type: NavigationMenuItemType.LINK,
+        link: 'https://example.com',
+      }),
+    ).toBe('https://example.com');
+  });
+
+  it('should add a scheme to a regular link without one', () => {
+    expect(
+      getLinkNavigationMenuItemComputedLink({
+        type: NavigationMenuItemType.LINK,
+        link: 'example.com',
+      }),
+    ).toBe('https://example.com');
+  });
+});

--- a/packages/twenty-front/src/modules/navigation-menu-item/display/link/utils/getLinkNavigationMenuItemComputedLink.ts
+++ b/packages/twenty-front/src/modules/navigation-menu-item/display/link/utils/getLinkNavigationMenuItemComputedLink.ts
@@ -1,8 +1,14 @@
 import { type NavigationMenuItem } from '~/generated-metadata/graphql';
 
+import { isNavigationMenuItemSearch } from '@/navigation-menu-item/common/utils/isNavigationMenuItemSearch';
+
 export const getLinkNavigationMenuItemComputedLink = (
-  item: Pick<NavigationMenuItem, 'link'>,
+  item: Pick<NavigationMenuItem, 'type' | 'link'>,
 ): string => {
+  if (isNavigationMenuItemSearch(item)) {
+    return item.link ?? '';
+  }
+
   const linkUrl = (item.link ?? '').trim();
   if (linkUrl.startsWith('http://') || linkUrl.startsWith('https://')) {
     return linkUrl;

--- a/packages/twenty-front/src/modules/navigation-menu-item/display/link/utils/getLinkNavigationMenuItemLabel.ts
+++ b/packages/twenty-front/src/modules/navigation-menu-item/display/link/utils/getLinkNavigationMenuItemLabel.ts
@@ -1,8 +1,14 @@
 import { type NavigationMenuItem } from '~/generated-metadata/graphql';
 
+import { isNavigationMenuItemSearch } from '@/navigation-menu-item/common/utils/isNavigationMenuItemSearch';
+
 export const getLinkNavigationMenuItemLabel = (
-  item: Pick<NavigationMenuItem, 'name' | 'link'>,
+  item: Pick<NavigationMenuItem, 'type' | 'name' | 'link'>,
 ): string => {
+  if (isNavigationMenuItemSearch(item)) {
+    return item.name ?? 'Search';
+  }
+
   const linkUrl = (item.link ?? '').trim();
   return (item.name ?? linkUrl) || 'Link';
 };

--- a/packages/twenty-front/src/modules/navigation-menu-item/display/utils/__tests__/getNavigationMenuItemLabel.test.ts
+++ b/packages/twenty-front/src/modules/navigation-menu-item/display/utils/__tests__/getNavigationMenuItemLabel.test.ts
@@ -6,6 +6,7 @@ import {
   type NavigationMenuItem,
 } from '~/generated-metadata/graphql';
 
+import { NAVIGATION_MENU_ITEM_SEARCH_LINK } from '@/navigation-menu-item/common/constants/NavigationMenuItemSearchLink';
 import { getNavigationMenuItemLabel } from '@/navigation-menu-item/display/utils/getNavigationMenuItemLabel';
 
 type ObjectMetadata = Pick<
@@ -144,6 +145,19 @@ describe('getNavigationMenuItemLabel', () => {
 
       expect(getNavigationMenuItemLabel(item, objectMetadataItems, views)).toBe(
         'Link',
+      );
+    });
+
+    it('should return "Search" for the search navigation action link', () => {
+      const item = {
+        ...baseItem,
+        type: NavigationMenuItemType.LINK,
+        name: null,
+        link: NAVIGATION_MENU_ITEM_SEARCH_LINK,
+      };
+
+      expect(getNavigationMenuItemLabel(item, objectMetadataItems, views)).toBe(
+        'Search',
       );
     });
   });

--- a/packages/twenty-front/src/modules/navigation-menu-item/edit/side-panel/components/SidePanelNavigationMenuItemEditPage.tsx
+++ b/packages/twenty-front/src/modules/navigation-menu-item/edit/side-panel/components/SidePanelNavigationMenuItemEditPage.tsx
@@ -15,6 +15,7 @@ import { SidePanelEditOrganizeActions } from '@/navigation-menu-item/edit/side-p
 import { SidePanelEditOwnerSection } from '@/navigation-menu-item/edit/side-panel/components/SidePanelEditOwnerSection';
 import { useNavigationMenuItemEditOrganizeActions } from '@/navigation-menu-item/edit/side-panel/hooks/useNavigationMenuItemEditOrganizeActions';
 import { getOrganizeActionsSelectableItemIds } from '@/navigation-menu-item/edit/side-panel/utils/getOrganizeActionsSelectableItemIds';
+import { isNavigationMenuItemSearch } from '@/navigation-menu-item/common/utils/isNavigationMenuItemSearch';
 import { SidePanelGroup } from '@/side-panel/components/SidePanelGroup';
 import { SidePanelList } from '@/side-panel/components/SidePanelList';
 import { useSidePanelSubPageHistory } from '@/side-panel/hooks/useSidePanelSubPageHistory';
@@ -138,6 +139,22 @@ export const SidePanelNavigationMenuItemEditPage = () => {
         isDefined(selectedItem) &&
         selectedItem.type === NavigationMenuItemType.LINK
       ) {
+        if (isNavigationMenuItemSearch(selectedItem)) {
+          return (
+            <SidePanelEditObjectViewBase
+              onOpenFolderPicker={openFolderPicker}
+              showMoveToFolder={canMoveToOtherFolder}
+              canMoveUp={canMoveUp}
+              canMoveDown={canMoveDown}
+              onMoveUp={onMoveUp}
+              onMoveDown={onMoveDown}
+              onRemove={onRemove}
+              onAddBefore={onAddBefore}
+              onAddAfter={onAddAfter}
+            />
+          );
+        }
+
         return (
           <SidePanelEditLinkItemView
             key={selectedItem.id}

--- a/packages/twenty-front/src/modules/navigation-menu-item/edit/side-panel/components/SidePanelNewSidebarItemMainMenu.tsx
+++ b/packages/twenty-front/src/modules/navigation-menu-item/edit/side-panel/components/SidePanelNewSidebarItemMainMenu.tsx
@@ -6,14 +6,18 @@ import {
   IconBuildingSkyscraper,
   IconFolder,
   IconLink,
+  IconSearch,
   IconTable,
 } from 'twenty-ui/icon';
 import { themeCssVariables } from 'twenty-ui/theme-constants';
 
 import { CommandMenuItem } from '@/command-menu/components/CommandMenuItem';
+import { NAVIGATION_MENU_ITEM_SEARCH_ID } from '@/navigation-menu-item/common/constants/NavigationMenuItemSearchId';
+import { NAVIGATION_MENU_ITEM_SEARCH_LINK } from '@/navigation-menu-item/common/constants/NavigationMenuItemSearchLink';
 import { pendingInsertionNavigationMenuItemState } from '@/navigation-menu-item/common/states/pendingInsertionNavigationMenuItemState';
 import { useAddFolderToNavigationMenu } from '@/navigation-menu-item/edit/side-panel/hooks/useAddFolderToNavigationMenu';
 import { useAddLinkToNavigationMenu } from '@/navigation-menu-item/edit/side-panel/hooks/useAddLinkToNavigationMenu';
+import { useAddSearchToNavigationMenu } from '@/navigation-menu-item/edit/side-panel/hooks/useAddSearchToNavigationMenu';
 import { SidePanelAddToNavigationDroppable } from '@/side-panel/components/SidePanelAddToNavigationDroppable';
 import { SidePanelGroup } from '@/side-panel/components/SidePanelGroup';
 import { SidePanelItemWithAddToNavigationDrag } from '@/side-panel/components/SidePanelItemWithAddToNavigationDrag';
@@ -31,6 +35,7 @@ const MAIN_MENU_ITEM_TYPES = [
   NavigationMenuItemType.OBJECT,
   NavigationMenuItemType.VIEW,
   NavigationMenuItemType.RECORD,
+  NAVIGATION_MENU_ITEM_SEARCH_ID,
   NavigationMenuItemType.FOLDER,
   NavigationMenuItemType.LINK,
 ] as const;
@@ -46,6 +51,7 @@ export const SidePanelNewSidebarItemMainMenu = ({
   );
   const { handleAddFolder } = useAddFolderToNavigationMenu();
   const { handleAddLink } = useAddLinkToNavigationMenu();
+  const { handleAddSearch } = useAddSearchToNavigationMenu();
 
   const isAddingToFolder = isDefined(
     pendingInsertionNavigationMenuItem?.folderId,
@@ -113,6 +119,24 @@ export const SidePanelNewSidebarItemMainMenu = ({
             </SidePanelGroup>
             <SidePanelGroup heading={t`Other`}>
               <SelectableListItem
+                itemId={NAVIGATION_MENU_ITEM_SEARCH_ID}
+                onEnter={handleAddSearch}
+              >
+                <SidePanelItemWithAddToNavigationDrag
+                  icon={IconSearch}
+                  label={t`Search`}
+                  id={NAVIGATION_MENU_ITEM_SEARCH_ID}
+                  onClick={handleAddSearch}
+                  dragIndex={3}
+                  payload={{
+                    type: NavigationMenuItemType.LINK,
+                    linkId: NAVIGATION_MENU_ITEM_SEARCH_ID,
+                    name: t`Search`,
+                    link: NAVIGATION_MENU_ITEM_SEARCH_LINK,
+                  }}
+                />
+              </SelectableListItem>
+              <SelectableListItem
                 itemId={NavigationMenuItemType.FOLDER}
                 onEnter={isAddingToFolder ? undefined : handleAddFolder}
               >
@@ -121,7 +145,7 @@ export const SidePanelNewSidebarItemMainMenu = ({
                   label={t`Folder`}
                   id={NavigationMenuItemType.FOLDER}
                   onClick={handleAddFolder}
-                  dragIndex={3}
+                  dragIndex={4}
                   payload={{
                     type: NavigationMenuItemType.FOLDER,
                     folderId: 'new',
@@ -139,7 +163,7 @@ export const SidePanelNewSidebarItemMainMenu = ({
                   label={t`Link`}
                   id={NavigationMenuItemType.LINK}
                   onClick={handleAddLink}
-                  dragIndex={4}
+                  dragIndex={5}
                   payload={{
                     type: NavigationMenuItemType.LINK,
                     linkId: 'new',

--- a/packages/twenty-front/src/modules/navigation-menu-item/edit/side-panel/hooks/useAddSearchToNavigationMenu.ts
+++ b/packages/twenty-front/src/modules/navigation-menu-item/edit/side-panel/hooks/useAddSearchToNavigationMenu.ts
@@ -1,0 +1,46 @@
+import { useLingui } from '@lingui/react/macro';
+import { NavigationMenuItemType } from 'twenty-shared/types';
+import { IconSearch } from 'twenty-ui/icon';
+
+import { DEFAULT_NAVIGATION_MENU_ITEM_COLOR_LINK } from '@/navigation-menu-item/common/constants/NavigationMenuItemDefaultColorLink';
+import { NAVIGATION_MENU_ITEM_SEARCH_LINK } from '@/navigation-menu-item/common/constants/NavigationMenuItemSearchLink';
+import { pendingInsertionNavigationMenuItemState } from '@/navigation-menu-item/common/states/pendingInsertionNavigationMenuItemState';
+import { useNavigationMenuItemEditController } from '@/navigation-menu-item/edit/hooks/useNavigationMenuItemEditController';
+import { useOpenNavigationMenuItemInSidePanel } from '@/navigation-menu-item/edit/hooks/useOpenNavigationMenuItemInSidePanel';
+import { useAtomState } from '@/ui/utilities/state/jotai/hooks/useAtomState';
+
+export const useAddSearchToNavigationMenu = () => {
+  const { t } = useLingui();
+  const { createItem } = useNavigationMenuItemEditController();
+  const { openNavigationMenuItemInSidePanel } =
+    useOpenNavigationMenuItemInSidePanel();
+  const [
+    pendingInsertionNavigationMenuItem,
+    setPendingInsertionNavigationMenuItem,
+  ] = useAtomState(pendingInsertionNavigationMenuItemState);
+
+  const handleAddSearch = () => {
+    const itemId = createItem(
+      {
+        type: NavigationMenuItemType.LINK,
+        name: t`Search`,
+        link: NAVIGATION_MENU_ITEM_SEARCH_LINK,
+        color: DEFAULT_NAVIGATION_MENU_ITEM_COLOR_LINK,
+      },
+      {
+        targetFolderId: pendingInsertionNavigationMenuItem?.folderId ?? null,
+        targetIndex: pendingInsertionNavigationMenuItem?.position,
+      },
+    );
+
+    setPendingInsertionNavigationMenuItem(null);
+    openNavigationMenuItemInSidePanel({
+      itemId,
+      pageTitle: t`Edit search`,
+      pageIcon: IconSearch,
+      focusTitleInput: true,
+    });
+  };
+
+  return { handleAddSearch };
+};

--- a/packages/twenty-front/src/modules/navigation-menu-item/edit/utils/__tests__/buildUpdateInputsFromDraft.test.ts
+++ b/packages/twenty-front/src/modules/navigation-menu-item/edit/utils/__tests__/buildUpdateInputsFromDraft.test.ts
@@ -1,0 +1,87 @@
+import { NAVIGATION_MENU_ITEM_SEARCH_LINK } from '@/navigation-menu-item/common/constants/NavigationMenuItemSearchLink';
+import { buildUpdateInputsFromDraft } from '@/navigation-menu-item/edit/utils/buildUpdateInputsFromDraft';
+import {
+  type NavigationMenuItem,
+  NavigationMenuItemType,
+} from '~/generated-metadata/graphql';
+
+const buildLinkNavigationMenuItem = ({
+  id,
+  link,
+}: {
+  id: string;
+  link: string;
+}): NavigationMenuItem =>
+  ({
+    id,
+    type: NavigationMenuItemType.LINK,
+    name: 'Search',
+    link,
+    position: 0,
+    createdAt: '',
+    updatedAt: '',
+  }) as NavigationMenuItem;
+
+describe('buildUpdateInputsFromDraft', () => {
+  it('should preserve the search navigation action link', () => {
+    const draftItem = buildLinkNavigationMenuItem({
+      id: 'navigation-menu-item-id',
+      link: NAVIGATION_MENU_ITEM_SEARCH_LINK,
+    });
+
+    expect(
+      buildUpdateInputsFromDraft({
+        draft: [draftItem],
+        workspaceItemsById: new Map([
+          [
+            draftItem.id,
+            buildLinkNavigationMenuItem({
+              id: draftItem.id,
+              link: 'https://example.com',
+            }),
+          ],
+        ]),
+        idsToRecreateSet: new Set(),
+        resolveFolderId: (folderId) => folderId,
+      }),
+    ).toEqual([
+      {
+        id: draftItem.id,
+        update: {
+          link: NAVIGATION_MENU_ITEM_SEARCH_LINK,
+        },
+      },
+    ]);
+  });
+
+  it('should still make regular link navigation menu item updates absolute', () => {
+    const draftItem = buildLinkNavigationMenuItem({
+      id: 'navigation-menu-item-id',
+      link: 'example.com',
+    });
+
+    expect(
+      buildUpdateInputsFromDraft({
+        draft: [draftItem],
+        workspaceItemsById: new Map([
+          [
+            draftItem.id,
+            buildLinkNavigationMenuItem({
+              id: draftItem.id,
+              link: 'https://old.example.com',
+            }),
+          ],
+        ]),
+        idsToRecreateSet: new Set(),
+        resolveFolderId: (folderId) => folderId,
+      }),
+    ).toEqual([
+      {
+        id: draftItem.id,
+        update: {
+          link: 'https://example.com',
+        },
+      },
+    ]);
+  });
+});

--- a/packages/twenty-front/src/modules/navigation-menu-item/edit/utils/buildUpdateInputsFromDraft.ts
+++ b/packages/twenty-front/src/modules/navigation-menu-item/edit/utils/buildUpdateInputsFromDraft.ts
@@ -6,6 +6,7 @@ import {
 
 import { isNavigationMenuItemFolder } from '@/navigation-menu-item/common/utils/isNavigationMenuItemFolder';
 import { isNavigationMenuItemLink } from '@/navigation-menu-item/common/utils/isNavigationMenuItemLink';
+import { isNavigationMenuItemSearch } from '@/navigation-menu-item/common/utils/isNavigationMenuItemSearch';
 
 export const buildUpdateInputsFromDraft = ({
   draft,
@@ -76,7 +77,11 @@ export const buildUpdateInputsFromDraft = ({
     }
     if (linkChanged && isNavigationMenuItemLink(draftItem)) {
       const linkUrl = (draftItem.link ?? '').trim();
-      updatePayload.link = linkUrl ? ensureAbsoluteUrl(linkUrl) : null;
+      updatePayload.link = isNavigationMenuItemSearch(draftItem)
+        ? linkUrl
+        : linkUrl
+          ? ensureAbsoluteUrl(linkUrl)
+          : null;
     }
     if (iconChanged && isNavigationMenuItemFolder(draftItem)) {
       updatePayload.icon = draftItem.icon ?? null;


### PR DESCRIPTION
## Summary
- Add a Search option to the custom layout “Add sidebar item” menu.
- Persist Search as a special LINK navigation item using the internal `twenty://search` action link.
- Route Search navigation items to the existing records search side panel instead of external navigation, while preserving create/update behavior and edit-panel organization controls.
- Add focused tests for the search sentinel, computed link handling, create/update input building, and labels.

## Screenshot
![Search navigation item](https://raw.githubusercontent.com/twentyhq/twenty/codex/search-navigation-menu-item-screenshot/.github/pr-assets/search-navigation-menu-item.png)

## Testing
- `git diff --check`
- `PATH=$HOME/.nvm/versions/node/v24.5.0/bin:$PATH corepack yarn workspace twenty-front exec jest --config jest.config.mjs --runTestsByPath packages/twenty-front/src/modules/navigation-menu-item/common/utils/__tests__/isNavigationMenuItemSearch.test.ts packages/twenty-front/src/modules/navigation-menu-item/display/link/utils/__tests__/getLinkNavigationMenuItemComputedLink.test.ts packages/twenty-front/src/modules/navigation-menu-item/common/utils/__tests__/buildCreateNavigationMenuItemInput.test.ts packages/twenty-front/src/modules/navigation-menu-item/edit/utils/__tests__/buildUpdateInputsFromDraft.test.ts packages/twenty-front/src/modules/navigation-menu-item/display/utils/__tests__/getNavigationMenuItemLabel.test.ts --coverage=false --runInBand`
- `PATH=$HOME/.nvm/versions/node/v24.5.0/bin:$PATH NX_DAEMON=false corepack yarn nx lint twenty-front`
- `PATH=$HOME/.nvm/versions/node/v24.5.0/bin:$PATH NX_DAEMON=false corepack yarn nx typecheck twenty-front`

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/22000?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

