### PR TITLE
fix(server): stop paging Sentry for transient query read timeouts in background jobs

### DIFF
--- a/packages/twenty-server/src/engine/core-modules/message-queue/message-queue.explorer.ts
+++ b/packages/twenty-server/src/engine/core-modules/message-queue/message-queue.explorer.ts
@@ -21,6 +21,7 @@ import { type MessageQueueService } from 'src/engine/core-modules/message-queue/
 import { type MessageQueue } from 'src/engine/core-modules/message-queue/message-queue.constants';
 import { QUEUE_WORKER_OPTIONS } from 'src/engine/core-modules/message-queue/message-queue-worker-options.constant';
 import { getQueueToken } from 'src/engine/core-modules/message-queue/utils/get-queue-token.util';
+import { isQueryReadTimeoutError } from 'src/engine/twenty-orm/error-handling/is-query-read-timeout-error.util';
 import { shouldCaptureException } from 'src/engine/utils/global-exception-handler.util';
 
 interface ProcessorGroup {
@@ -210,7 +211,14 @@ export class MessageQueueExplorer implements OnModuleInit {
         // @ts-expect-error legacy noImplicitAny
         await instance[processMethodName].call(instance, job.data);
       } catch (err) {
-        if (shouldCaptureException(err)) {
+        // Transient query read timeouts are caused by database/worker load, not a code
+        // defect. They are retried by BullMQ and recovered by the sync crons, so we let
+        // them fail without paging Sentry to avoid drowning real errors in noise.
+        if (isQueryReadTimeoutError(err)) {
+          this.logger.warn(
+            `Skipping Sentry capture for transient query read timeout in job ${job.name}: ${err.message}`,
+          );
+        } else if (shouldCaptureException(err)) {
           this.exceptionHandlerService.captureExceptions([err]);
         }
         throw err;

--- a/packages/twenty-server/src/engine/twenty-orm/error-handling/__tests__/is-query-read-timeout-error.util.spec.ts
+++ b/packages/twenty-server/src/engine/twenty-orm/error-handling/__tests__/is-query-read-timeout-error.util.spec.ts
@@ -1,0 +1,51 @@
+import { QueryFailedError } from 'typeorm';
+
+import {
+  QUERY_READ_TIMEOUT_ERROR_MESSAGE,
+  isQueryReadTimeoutError,
+} from 'src/engine/twenty-orm/error-handling/is-query-read-timeout-error.util';
+import {
+  TwentyORMException,
+  TwentyORMExceptionCode,
+} from 'src/engine/twenty-orm/exceptions/twenty-orm.exception';
+
+const buildQueryFailedError = (message: string): QueryFailedError =>
+  new QueryFailedError('SELECT 1', [], new Error(message));
+
+describe('isQueryReadTimeoutError', () => {
+  it('should return true for a QueryFailedError caused by a query read timeout', () => {
+    const error = buildQueryFailedError(QUERY_READ_TIMEOUT_ERROR_MESSAGE);
+
+    expect(isQueryReadTimeoutError(error)).toBe(true);
+  });
+
+  it('should return true for a TwentyORMException with the QUERY_READ_TIMEOUT code', () => {
+    const error = new TwentyORMException(
+      QUERY_READ_TIMEOUT_ERROR_MESSAGE,
+      TwentyORMExceptionCode.QUERY_READ_TIMEOUT,
+    );
+
+    expect(isQueryReadTimeoutError(error)).toBe(true);
+  });
+
+  it('should return false for a QueryFailedError with another driver error', () => {
+    const error = buildQueryFailedError('duplicate key value');
+
+    expect(isQueryReadTimeoutError(error)).toBe(false);
+  });
+
+  it('should return false for a TwentyORMException with another code', () => {
+    const error = new TwentyORMException(
+      'Workspace not found',
+      TwentyORMExceptionCode.WORKSPACE_NOT_FOUND,
+    );
+
+    expect(isQueryReadTimeoutError(error)).toBe(false);
+  });
+
+  it('should return false for a generic error that merely mentions a timeout', () => {
+    const error = new Error(QUERY_READ_TIMEOUT_ERROR_MESSAGE);
+
+    expect(isQueryReadTimeoutError(error)).toBe(false);
+  });
+});

--- a/packages/twenty-server/src/engine/twenty-orm/error-handling/compute-twenty-orm-exception.ts
+++ b/packages/twenty-server/src/engine/twenty-orm/error-handling/compute-twenty-orm-exception.ts
@@ -8,6 +8,7 @@ import { type WorkspaceInternalContext } from 'src/engine/twenty-orm/interfaces/
 import { POSTGRESQL_ERROR_CODES } from 'src/engine/api/graphql/workspace-query-runner/constants/postgres-error-codes.constants';
 import { handleDuplicateKeyError } from 'src/engine/api/graphql/workspace-query-runner/utils/handle-duplicate-key-error.util';
 import { PostgresException } from 'src/engine/api/graphql/workspace-query-runner/utils/postgres-exception';
+import { QUERY_READ_TIMEOUT_ERROR_MESSAGE } from 'src/engine/twenty-orm/error-handling/is-query-read-timeout-error.util';
 import { type FlatObjectMetadata } from 'src/engine/metadata-modules/flat-object-metadata/types/flat-object-metadata.type';
 import { type WorkspaceEntityManager } from 'src/engine/twenty-orm/entity-manager/workspace-entity-manager';
 import {
@@ -32,9 +33,9 @@ export const computeTwentyORMException = async (
   internalContext?: WorkspaceInternalContext,
 ): Promise<Error | TwentyORMException> => {
   if (error instanceof QueryFailedError) {
-    if (error.message.includes('Query read timeout')) {
+    if (error.message.includes(QUERY_READ_TIMEOUT_ERROR_MESSAGE)) {
       return new TwentyORMException(
-        'Query read timeout',
+        QUERY_READ_TIMEOUT_ERROR_MESSAGE,
         TwentyORMExceptionCode.QUERY_READ_TIMEOUT,
         {
           userFriendlyMessage: msg`We are experiencing a temporary issue with our database. Please try again later.`,

--- a/packages/twenty-server/src/engine/twenty-orm/error-handling/is-query-read-timeout-error.util.ts
+++ b/packages/twenty-server/src/engine/twenty-orm/error-handling/is-query-read-timeout-error.util.ts
@@ -1,0 +1,25 @@
+import { QueryFailedError } from 'typeorm';
+
+import {
+  TwentyORMException,
+  TwentyORMExceptionCode,
+} from 'src/engine/twenty-orm/exceptions/twenty-orm.exception';
+
+// node-postgres aborts queries that exceed its `query_timeout` with this exact message.
+// It reflects transient database/worker load rather than a code defect, so it is retried
+// (BullMQ failure metric + sync recovery crons) instead of being surfaced as a bug.
+export const QUERY_READ_TIMEOUT_ERROR_MESSAGE = 'Query read timeout';
+
+export const isQueryReadTimeoutError = (error: Error): boolean => {
+  if (
+    error instanceof TwentyORMException &&
+    error.code === TwentyORMExceptionCode.QUERY_READ_TIMEOUT
+  ) {
+    return true;
+  }
+
+  return (
+    error instanceof QueryFailedError &&
+    error.message.includes(QUERY_READ_TIMEOUT_ERROR_MESSAGE)
+  );
+};


### PR DESCRIPTION
## Problem

Sentry is flooded by a high-volume background-job error (~1.1k events / 714 users, high priority):

> `QueryFailedError: Query read timeout`
> `globalWorkspaceOrmManager.executeInWorkspaceContext.lite (calendar-event-list-fetch.job)`

It fires on a trivial primary-key lookup (`calendarChannelRepository.findOne({ where: { id, isSyncEnabled, workspaceId } })`), so the query itself isn't slow.

## Root cause

The datasources set node-postgres `query_timeout` (`PG_DATABASE_PRIMARY_TIMEOUT_MS`, default 10s). Under transient database/worker load (the breadcrumbs show `Missing lock for job … moveToFinished` and memory pressure — i.e. a saturated worker event loop), node-postgres aborts the in-flight query with `Query read timeout` even for a cheap PK read.

This error is **transient and self-healing**:
- It is already classified as temporary/retryable elsewhere (`TwentyORMExceptionCode.QUERY_READ_TIMEOUT`, with a user-facing "temporary issue, please try again later" message).
- A failed `calendar-event-list-fetch` leaves the channel in `CALENDAR_EVENT_LIST_FETCH_SCHEDULED`, which the hourly `CalendarOngoingStaleJob` resets back to `…_PENDING` for re-fetch.

But the failing `findOne` runs on the **core** datasource, so it throws a raw `QueryFailedError` (not the coded `TwentyORMException`) and is unprotected by any handler. It reaches `MessageQueueExplorer.invokeProcessMethods`, where `shouldCaptureException` only filters GraphQL/HTTP < 500 — so every occurrence is captured to Sentry, then rethrown.

## Fix

Skip Sentry capture for this transient read timeout **in the job-processing path only**, while still rethrowing so the BullMQ failure metric and the sync-recovery crons are unaffected. This mirrors how `shouldCaptureException` already suppresses expected 4xx noise.

- New pure util `isQueryReadTimeoutError` (handles both the raw `QueryFailedError` and the wrapped `TwentyORMException` code) + the shared `QUERY_READ_TIMEOUT_ERROR_MESSAGE` constant, reused in `computeTwentyORMException` to drop the duplicated magic string.
- `MessageQueueExplorer` logs a `warn` and skips Sentry capture for it.

The GraphQL/HTTP path is intentionally left untouched, so a genuinely pathological query that read-times-out on a user request stays visible in Sentry (e.g. the cartesian-product bug fixed in #19892).

## Scope

This removes the false high-priority alerts for a transient, self-healing error. Actually *preventing* the timeouts (reworking how long jobs interact with `query_timeout` / worker load) is a larger, riskier change left out on purpose.

## Testing

- New unit test for `isQueryReadTimeoutError` (5 cases — raw timeout, wrapped code, other driver error, other ORM code, generic error). Passes.
- Existing `computeTwentyORMException` spec still green after the constant dedupe.
- Lint + format clean on all changed files.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/22006?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

