### PR TITLE
fix(server): trigger a workflow at most once per database event

### DIFF
--- a/packages/twenty-server/src/modules/workflow/workflow-trigger/automated-trigger/listeners/__tests__/workflow-database-event-trigger.listener.spec.ts
+++ b/packages/twenty-server/src/modules/workflow/workflow-trigger/automated-trigger/listeners/__tests__/workflow-database-event-trigger.listener.spec.ts
@@ -352,6 +352,56 @@ describe('WorkflowDatabaseEventTriggerListener', () => {
       );
     });
 
+    it('should trigger workflow only once when duplicate automated trigger rows exist for the same workflow', async () => {
+      mockRepository.find.mockResolvedValue([
+        mockEventListeners[0],
+        { ...mockEventListeners[0] },
+        { ...mockEventListeners[0] },
+      ]);
+
+      await listener.handleObjectRecordUpdateEvent(mockPayload);
+
+      expect(messageQueueService.add).toHaveBeenCalledTimes(1);
+      expect(messageQueueService.add).toHaveBeenCalledWith(
+        WorkflowTriggerJob.name,
+        {
+          workspaceId,
+          workflowId,
+          payload: mockPayload.events[0],
+        },
+        { retryLimit: 3 },
+      );
+    });
+
+    it('should trigger each distinct workflow once when duplicates exist for several workflows', async () => {
+      const otherWorkflowId = 'test-workflow-2';
+
+      mockRepository.find.mockResolvedValue([
+        mockEventListeners[0],
+        { ...mockEventListeners[0] },
+        { ...mockEventListeners[0], workflowId: otherWorkflowId },
+        { ...mockEventListeners[0], workflowId: otherWorkflowId },
+      ]);
+
+      await listener.handleObjectRecordUpdateEvent(mockPayload);
+
+      expect(messageQueueService.add).toHaveBeenCalledTimes(2);
+      expect(messageQueueService.add).toHaveBeenCalledWith(
+        WorkflowTriggerJob.name,
+        { workspaceId, workflowId, payload: mockPayload.events[0] },
+        { retryLimit: 3 },
+      );
+      expect(messageQueueService.add).toHaveBeenCalledWith(
+        WorkflowTriggerJob.name,
+        {
+          workspaceId,
+          workflowId: otherWorkflowId,
+          payload: mockPayload.events[0],
+        },
+        { retryLimit: 3 },
+      );
+    });
+
     it('should trigger workflow for position-only updates when no fields are specified', async () => {
       const positionOnlyPayload: WorkspaceEventBatch<any> = {
         ...mockPayload,

--- a/packages/twenty-server/src/modules/workflow/workflow-trigger/automated-trigger/listeners/workflow-database-event-trigger.listener.ts
+++ b/packages/twenty-server/src/modules/workflow/workflow-trigger/automated-trigger/listeners/workflow-database-event-trigger.listener.ts
@@ -1,5 +1,6 @@
 import { Injectable, Logger } from '@nestjs/common';
 
+import uniqBy from 'lodash.uniqby';
 import {
   ObjectRecordEvent,
   type ObjectRecordCreateEvent,
@@ -366,7 +367,13 @@ export class WorkflowDatabaseEventTriggerListener {
         },
       });
 
-      for (const eventListener of eventListeners) {
+      // A workflow has a single trigger, so it must run at most once per event.
+      // Duplicate automated trigger rows can exist for the same workflowId
+      // (e.g. trash/restore cycles re-create a row alongside a restored one),
+      // which would otherwise enqueue the same workflow several times.
+      const uniqueEventListeners = uniqBy(eventListeners, 'workflowId');
+
+      for (const eventListener of uniqueEventListeners) {
         for (const eventPayload of payload.events) {
           const shouldTriggerJob = this.shouldTriggerJob({
             eventPayload,


### PR DESCRIPTION
## Problem

A workflow with a database-event trigger (e.g. *Record is updated*) runs **multiple times (2–10+) for a single record change**. Reported via Discord and matching the previously closed [#15653](https://github.com/twentyhq/twenty/issues/15653), where users observed several `WorkflowTriggerJob` → `RunWorkflowJob` pairs for one update, and found duplicate `DATABASE_EVENT` rows in `workflowAutomatedTrigger` with the same `workflowId`.

## Root cause

A workflow has exactly **one** trigger, so `WorkflowDatabaseEventTriggerListener.handleEvent` should enqueue it at most once per event. Instead it enqueues **one `WorkflowTriggerJob` per matching `workflowAutomatedTrigger` row**:

```ts
for (const eventListener of eventListeners) {
  for (const eventPayload of payload.events) {
    if (shouldTriggerJob) await this.messageQueueService.add(...)
  }
}
```

Duplicate rows for the same `workflowId` therefore fan out into duplicate runs. Such duplicates can arise from several paths, e.g. the trash/restore lifecycle in `handleWorkflowSubEntities`: deleting a workflow **soft-deletes** its automated trigger and deactivates the version, but restoring **`restore()`s** that soft-deleted row back to a live state — so a subsequent re-activation `insert`s a *second* live row alongside it. Two live rows ⇒ two runs.

## Fix

Deduplicate the matched automated triggers by `workflowId` before enqueuing, enforcing one run per workflow per event. Because the guard sits at the fan-out point, it is robust to **any** cause of duplicate rows and **heals already-corrupted databases without a migration**.

```ts
const uniqueEventListeners = uniqBy(eventListeners, 'workflowId');
```

Uses `lodash.uniqby`, already the codebase convention for this pattern.

## Notes
- The incoming-webhook trigger controller and the publish/activate flow (which deletes by `workflowId` before inserting) were both verified to run exactly once — no change needed there.
- A single DB write emitting both `UPDATED` and `UPSERTED` is by design (distinct event names; a workflow matches only one) and is not a duplication source.

## Test plan
- [x] Added regression tests to `workflow-database-event-trigger.listener.spec.ts`: duplicate rows for one `workflowId` enqueue exactly one job; duplicates across two workflows enqueue one job each.
- [x] `npx jest workflow-database-event-trigger.listener` — 13 passed.
- [x] `oxlint --type-aware` and `oxfmt --check` clean on changed files.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/22008?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

