### PR TITLE
Rename CI New UI workflow to CI UI

### DIFF
--- a/.github/workflows/ci-ui.yaml
+++ b/.github/workflows/ci-ui.yaml
@@ -1,4 +1,4 @@
-name: CI New UI
+name: CI UI
 
 on:
   pull_request:
@@ -22,7 +22,7 @@ jobs:
         yarn.lock
         packages/twenty-ui/**
         packages/twenty-shared/**
-  new-ui-task:
+  ui-task:
     needs: changed-files-check
     if: needs.changed-files-check.outputs.any_changed == 'true'
     timeout-minutes: 30
@@ -39,7 +39,7 @@ jobs:
         uses: ./.github/actions/yarn-install
       - name: Run ${{ matrix.task }}
         run: npx nx ${{ matrix.task }} twenty-ui
-  new-ui-sb-build:
+  ui-sb-build:
     needs: changed-files-check
     if: >-
       always() &&
@@ -62,11 +62,11 @@ jobs:
           name: storybook-twenty-ui
           path: packages/twenty-ui/storybook-static
           retention-days: 1
-  new-ui-sb-test:
+  ui-sb-test:
     timeout-minutes: 30
     runs-on: ubuntu-latest
-    needs: new-ui-sb-build
-    if: always() && needs.new-ui-sb-build.result == 'success'
+    needs: ui-sb-build
+    if: always() && needs.ui-sb-build.result == 'success'
     steps:
       - name: Fetch custom Github Actions and base branch history
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
@@ -94,11 +94,11 @@ jobs:
           name: argos-screenshots-twenty-ui
           path: packages/twenty-ui/screenshots
           retention-days: 1
-  ci-new-ui-status-check:
+  ci-ui-status-check:
     if: always() && !cancelled()
     timeout-minutes: 5
     runs-on: ubuntu-latest
-    needs: [changed-files-check, new-ui-task, new-ui-sb-build, new-ui-sb-test]
+    needs: [changed-files-check, ui-task, ui-sb-build, ui-sb-test]
     steps:
       - name: Fail job if any needs failed
         if: contains(needs.*.result, 'failure')

--- a/.github/workflows/visual-regression-dispatch.yaml
+++ b/.github/workflows/visual-regression-dispatch.yaml
@@ -10,7 +10,7 @@ name: Visual Regression Dispatch
 
 on:
   workflow_run:
-    workflows: ['CI New UI', 'CI Front']
+    workflows: ['CI UI', 'CI Front']
     types: [completed]
 
 permissions:
@@ -39,7 +39,7 @@ jobs:
           script: |
             const name = context.payload.workflow_run.name;
             const projectByWorkflow = {
-              'CI New UI': 'twenty-ui',
+              'CI UI': 'twenty-ui',
               'CI Front': 'twenty-front',
             };
             const project = projectByWorkflow[name] ?? 'twenty-front';


### PR DESCRIPTION
Renames the `CI New UI` workflow to `CI UI`, dropping the "new ui" terminology everywhere it appeared.

- Renamed `.github/workflows/ci-new-ui.yaml` → `ci-ui.yaml`
- Updated the workflow `name`, job names (`ui-task`, `ui-sb-build`, `ui-sb-test`, `ci-ui-status-check`), and internal `needs`/`if` references
- Updated `visual-regression-dispatch.yaml` which keys off the workflow name (`CI UI`)

Note: the required status check in branch protection settings (workflow name / `ci-ui-status-check`) lives in repo settings and will need updating by an admin so PRs don't wait on the old check name.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/22030?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

