### PR TITLE
Update location of settings

### DIFF
--- a/packages/twenty-docs/user-guide/data-model/how-tos/create-many-to-many-relations.mdx
+++ b/packages/twenty-docs/user-guide/data-model/how-tos/create-many-to-many-relations.mdx
@@ -6,11 +6,11 @@ description: Connect records where many items on both sides can be linked togeth
 Many-to-many relations let you connect multiple records on both sides. For example: many People can work on many Projects, and each Project can have many People.
 
 <Warning>
-**Lab Feature**: Junction relations are currently in the Lab. Enable them at **Settings → Updates → Lab** before following this guide.
+**Beta Feature**: Junction relations are currently in beta. Enable them at **Settings → Community → Features** before following this guide.
 </Warning>
 
 <Note>
-This feature also requires **Advanced mode** to be enabled (toggle at the bottom right of Settings).
+This feature also requires **Advanced mode** to be enabled (toggle at the bottom left of Settings).
 </Note>
 
 ## When to Use Many-to-Many
@@ -39,8 +39,8 @@ When you enable the junction relation toggle, Twenty displays linked records dir
 
 ## Prerequisites
 
-1. **Enable Junction Relations in Lab**: Go to **Settings → Updates → Lab** and enable **Junction Relations**
-2. **Enable Advanced mode**: Toggle on **Advanced mode** at the bottom right of the Settings sidebar
+1. **Enable Junction Relations in Beta Features**: Go to **Settings → Community → Features** and enable **Junction Relations**
+2. **Enable Advanced mode**: Toggle on **Advanced mode** at the bottom left of the Settings sidebar
 3. Plan your data model:
    - Which two objects are you connecting?
    - What should the junction object be called?


### PR DESCRIPTION
In the latest version the «Lab Features» are no longer called like that and are in a different location.

See [Discord-Discussion](https://discord.com/channels/1130383047699738754/1508471962308051116)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/22033?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

