### PR TITLE
fix: keep AI chat open when opening a record full-page (e.g. workflows)

### DIFF
--- a/packages/twenty-front/src/modules/object-record/record-index/hooks/useOpenRecordFromIndexView.ts
+++ b/packages/twenty-front/src/modules/object-record/record-index/hooks/useOpenRecordFromIndexView.ts
@@ -1,5 +1,6 @@
 import { useSidePanelMenu } from '@/side-panel/hooks/useSidePanelMenu';
 import { useOpenRecordInSidePanel } from '@/side-panel/hooks/useOpenRecordInSidePanel';
+import { sidePanelPageState } from '@/side-panel/states/sidePanelPageState';
 import { MAIN_CONTEXT_STORE_INSTANCE_ID } from '@/context-store/constants/MainContextStoreInstanceId';
 import { contextStoreRecordShowParentViewComponentState } from '@/context-store/states/contextStoreRecordShowParentViewComponentState';
 import { currentRecordFilterGroupsComponentState } from '@/object-record/record-filter-group/states/currentRecordFilterGroupsComponentState';
@@ -12,7 +13,7 @@ import { useAtomComponentStateCallbackState } from '@/ui/utilities/state/jotai/h
 import { ViewOpenRecordIn } from '~/generated-metadata/graphql';
 import { useStore } from 'jotai';
 import { useCallback } from 'react';
-import { AppPath } from 'twenty-shared/types';
+import { AppPath, SidePanelPages } from 'twenty-shared/types';
 import { useIsMobile } from 'twenty-ui/utilities';
 import { useNavigateApp } from '~/hooks/useNavigateApp';
 
@@ -81,7 +82,13 @@ export const useOpenRecordFromIndexView = () => {
           resetNavigationStack: true,
         });
       } else {
-        closeSidePanelMenu();
+        const isSidePanelAiChat =
+          store.get(sidePanelPageState.atom) === SidePanelPages.AskAI;
+
+        if (!isSidePanelAiChat) {
+          closeSidePanelMenu();
+        }
+
         navigate(AppPath.RecordShowPage, {
           objectNameSingular,
           objectRecordId: recordId,


### PR DESCRIPTION
## Problem

When the AI chat is open in the side panel and you click a workflow from the Workflows list, the AI chat closes as you navigate to the workflow page. Navigating between other index/list pages, or to settings, keeps the chat open — only opening a record full-page closes it.

## Root cause

`useOpenRecordFromIndexView` unconditionally calls `closeSidePanelMenu()` before navigating to a full-page record:

```ts
} else {
  closeSidePanelMenu();
  navigate(AppPath.RecordShowPage, { ... });
}
```

Workflows (and other objects excluded by `canOpenObjectInSidePanel` — `workflow`, `workflowVersion`, `dashboard`) can't open in the side panel, so they *always* take this branch and close the panel, including the AI chat.

This is inconsistent with `PageChangeEffect`, which already lets the AI chat survive navigation by exempting `SidePanelPages.AskAI`. That exemption is why navigating between index pages or to settings doesn't close the chat.

## Fix

Skip the close when the side panel is showing the AI chat, mirroring the exemption already used in `PageChangeEffect`. Any other side panel page still closes as before.

## Testing

- `nx lint:diff-with-main twenty-front` (file lints clean)
- `nx typecheck twenty-front` passes

https://claude.ai/code/session_01LtBBAxjn32FQVduyAi6B37

---
_Generated by [Claude Code](https://claude.ai/code/session_01LtBBAxjn32FQVduyAi6B37)_

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/22036?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

