### PR TITLE
Bump twenty-ui to 1.0.0-alpha.0 for first npm pre-release

### DIFF
--- a/packages/twenty-ui/package.json
+++ b/packages/twenty-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "twenty-ui",
-  "version": "0.1.0",
+  "version": "1.0.0-alpha.0",
   "description": "Twenty's shared React UI component library.",
   "license": "AGPL-3.0",
   "repository": {


### PR DESCRIPTION
Sets `twenty-ui` to `1.0.0-alpha.0` so it can be published as the first pre-release on npm.

The package name was previously published once (`0.23.4`) and fully unpublished in Sept 2024. Starting at `1.0.0-alpha.0` avoids the burned version, stays above the old number, and publishes to the `alpha` dist-tag (not `latest`) via the existing twenty-infra publish workflow, so it can be dogfooded before a stable `1.0.0`.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/22040?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

