### PR TITLE
fix(client-sdk): regenerate metadata client after isCustomDomainEnabled schema change

### DIFF
--- a/packages/twenty-client-sdk/src/metadata/generated/schema.graphql
+++ b/packages/twenty-client-sdk/src/metadata/generated/schema.graphql
@@ -2231,6 +2231,7 @@ type DomainValidRecords {
   id: UUID!
   domain: String!
   records: [DomainRecord!]!
+  isCustomDomainEnabled: Boolean
 }
 
 type UpsertRowLevelPermissionPredicatesResult {

--- a/packages/twenty-client-sdk/src/metadata/generated/schema.ts
+++ b/packages/twenty-client-sdk/src/metadata/generated/schema.ts
@@ -1871,6 +1871,7 @@ export interface DomainValidRecords {
     id: Scalars['UUID']
     domain: Scalars['String']
     records: DomainRecord[]
+    isCustomDomainEnabled?: Scalars['Boolean']
     __typename: 'DomainValidRecords'
 }
 
@@ -4956,6 +4957,7 @@ export interface DomainValidRecordsGenqlSelection{
     id?: boolean | number
     domain?: boolean | number
     records?: DomainRecordGenqlSelection
+    isCustomDomainEnabled?: boolean | number
     __typename?: boolean | number
     __scalar?: boolean | number
 }

--- a/packages/twenty-client-sdk/src/metadata/generated/types.ts
+++ b/packages/twenty-client-sdk/src/metadata/generated/types.ts
@@ -4344,6 +4344,9 @@ export default {
             "records": [
                 232
             ],
+            "isCustomDomainEnabled": [
+                6
+            ],
             "__typename": [
                 1
             ]


### PR DESCRIPTION
## Problem

#22037 added the nullable `isCustomDomainEnabled` field to the `DomainValidRecords` GraphQL type but did not regenerate `twenty-client-sdk`. This breaks the **SDK metadata client up-to-date check** on main (`ci-server.yaml` runs `npx nx run twenty-client-sdk:generate-metadata-client` and fails if `git diff` on `packages/twenty-client-sdk/src/metadata/generated` is non-empty), as flagged by @prastoin [here](https://github.com/twentyhq/twenty/pull/22037#issuecomment-4781217291).

## Fix

Regenerate `packages/twenty-client-sdk/src/metadata/generated` to include the new field:
- `schema.graphql`: `isCustomDomainEnabled: Boolean` on `DomainValidRecords`
- `schema.ts`: the field on the `DomainValidRecords` interface and its `GenqlSelection`
- `types.ts`: the field in the runtime type descriptor

## Verification

Since there's no live backend in this environment, I ran the actual genql generator (`twenty-client-sdk`'s vendored `generate`) against the updated `/metadata` SDL into a scratch dir and confirmed the output is **byte-identical** to the committed files (`diff` reports no differences for `schema.graphql`, `schema.ts`, `types.ts`; `index.ts` and `runtime/` are unaffected — the field addition doesn't touch them). So `generate-metadata-client` + `git diff` will be clean in CI.

I also re-ran the **front** metadata codegen offline against the same SDL to double-check #22037's hand-edited `twenty-front/src/generated-metadata/graphql.ts`: zero diffs in the `DomainValidRecords` / `CheckCustomDomain` regions, confirming that file is already correct and only the SDK was stale.

https://claude.ai/code/session_01BB6C6bpPZMUbMzKSCydEaj

---
_Generated by [Claude Code](https://claude.ai/code/session_01BB6C6bpPZMUbMzKSCydEaj)_

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/22043?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

