### PR TITLE
fix(deps): bump engine.io + socket.io-adapter to drop vulnerable ws 8.17.1

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -22641,7 +22641,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/ws@npm:^8.18.1, @types/ws@npm:^8.5.10":
+"@types/ws@npm:^8.18.1, @types/ws@npm:^8.5.10, @types/ws@npm:^8.5.12":
   version: 8.18.1
   resolution: "@types/ws@npm:8.18.1"
   dependencies:
@@ -30063,7 +30063,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"debug@npm:~4.3.1, debug@npm:~4.3.2, debug@npm:~4.3.4":
+"debug@npm:~4.3.2":
   version: 4.3.7
   resolution: "debug@npm:4.3.7"
   dependencies:
@@ -31281,19 +31281,20 @@ __metadata:
   linkType: hard
 
 "engine.io@npm:~6.6.0":
-  version: 6.6.4
-  resolution: "engine.io@npm:6.6.4"
+  version: 6.6.9
+  resolution: "engine.io@npm:6.6.9"
   dependencies:
     "@types/cors": "npm:^2.8.12"
     "@types/node": "npm:>=10.0.0"
+    "@types/ws": "npm:^8.5.12"
     accepts: "npm:~1.3.4"
     base64id: "npm:2.0.0"
     cookie: "npm:~0.7.2"
     cors: "npm:~2.8.5"
-    debug: "npm:~4.3.1"
+    debug: "npm:~4.4.1"
     engine.io-parser: "npm:~5.2.1"
-    ws: "npm:~8.17.1"
-  checksum: 10c0/845761163f8ea7962c049df653b75dafb6b3693ad6f59809d4474751d7b0392cbf3dc2730b8a902ff93677a91fd28711d34ab29efd348a8a4b49c6b0724021ab
+    ws: "npm:~8.21.0"
+  checksum: 10c0/8e4a64b6e3861ffc3ab3fa7f864fd06358b918b85696c5fb53113ddde6661bb2f31f2d091a2613511ff16dbb0bff970a166e5c2dfaf2be51a022f7e6573b1153
   languageName: node
   linkType: hard
 
@@ -49848,12 +49849,12 @@ __metadata:
   linkType: hard
 
 "socket.io-adapter@npm:~2.5.2":
-  version: 2.5.5
-  resolution: "socket.io-adapter@npm:2.5.5"
+  version: 2.5.8
+  resolution: "socket.io-adapter@npm:2.5.8"
   dependencies:
-    debug: "npm:~4.3.4"
-    ws: "npm:~8.17.1"
-  checksum: 10c0/04a5a2a9c4399d1b6597c2afc4492ab1e73430cc124ab02b09e948eabf341180b3866e2b61b5084cb899beb68a4db7c328c29bda5efb9207671b5cb0bc6de44e
+    debug: "npm:~4.4.1"
+    ws: "npm:~8.21.0"
+  checksum: 10c0/17fc68a7953d6b640b78b2191d8a575b30c7efb9fdec91b4f0788e2f9d093dfb9a84f6fcb396f9b922c32dd0584b01c2d3410a8f69b4cae3f309530b8859bc8a
   languageName: node
   linkType: hard
 
@@ -55751,7 +55752,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ws@npm:8.21.0, ws@npm:^8.18.0, ws@npm:^8.18.3, ws@npm:^8.19.0, ws@npm:^8.20.0, ws@npm:^8.21.0":
+"ws@npm:8.21.0, ws@npm:^8.18.0, ws@npm:^8.18.3, ws@npm:^8.19.0, ws@npm:^8.20.0, ws@npm:^8.21.0, ws@npm:~8.21.0":
   version: 8.21.0
   resolution: "ws@npm:8.21.0"
   peerDependencies:
@@ -55787,21 +55788,6 @@ __metadata:
   dependencies:
     async-limiter: "npm:~1.0.0"
   checksum: 10c0/5c2b9474164f9cb68c7776a1d10b0461c186f3a69bffb1028fca33eba5ab7206a09173fb0b311d6c5a81c8cf148406f8deb0b7d899542ab8ca67407d99717dad
-  languageName: node
-  linkType: hard
-
-"ws@npm:~8.17.1":
-  version: 8.17.1
-  resolution: "ws@npm:8.17.1"
-  peerDependencies:
-    bufferutil: ^4.0.1
-    utf-8-validate: ">=5.0.2"
-  peerDependenciesMeta:
-    bufferutil:
-      optional: true
-    utf-8-validate:
-      optional: true
-  checksum: 10c0/f4a49064afae4500be772abdc2211c8518f39e1c959640457dcee15d4488628620625c783902a52af2dd02f68558da2868fd06e6fd0e67ebcd09e6881b1b5bfe
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary

Bumps the transitive **`engine.io`** `6.6.4 → 6.6.9` and **`socket.io-adapter`** `2.5.5 → 2.5.8` (both within socket.io's declared ranges — socket.io is pulled by mintlify / react-email build tooling), which declare `ws ~8.21.0` instead of `~8.17.1`, **evicting the last vulnerable `ws@8.17.1`**. Resolves two Dependabot alerts:

- [#1502](https://github.com/twentyhq/twenty/security/dependabot/1502) (high) — GHSA-96hv-2xvq-fx4p, ws memory-exhaustion DoS (`>=8.0.0 <8.21.0`)
- [#1238](https://github.com/twentyhq/twenty/security/dependabot/1238) (med) — GHSA-58qx-3vcg-4xpx, ws uninitialized memory disclosure (`>=8.0.0 <8.20.1`)

## Why a parent-bump (not a resolution)

- The only vulnerable ws left was `8.17.1`, pinned by `engine.io@6.6.4` (`ws ~8.17.1`) and `socket.io-adapter@2.5.5` (`ws ~8.17.1`). (The earlier koa PR already dropped the dts-plugin `ws@8.18.0`.)
- `engine.io@6.6.9` and `socket.io-adapter@2.5.8` declare `ws ~8.21.0`, and both bumps are within socket.io's existing ranges — so `yarn up -R` carries the fix in-range, with no `resolutions` entry to maintain.
- (The pre-existing `@nestjs/graphql/ws: 8.21.0` resolution is unrelated and untouched.)

## Result

- ws is now `8.21.0` (plus non-vulnerable `7.5.11` / `6.2.4`); nothing in `[8.0.0, 8.21.0)`.
- `package.json` untouched; engine.io/socket.io are build / email-preview tooling, not the server runtime.

## Verification

- `yarn install --immutable` passes.
- No vulnerable ws remains in `yarn.lock`; diff is contained to ws / engine.io / socket.io-adapter (+ a `debug` descriptor cleanup).
