### PR TITLE
feat(logic-functions): add Redis-backed key-value store for apps

### DIFF
--- a/packages/twenty-sdk/src/sdk/logic-function/index.ts
+++ b/packages/twenty-sdk/src/sdk/logic-function/index.ts
@@ -51,5 +51,8 @@ export type { AppConnection } from '@/sdk/logic-function/connections/types/app-c
 export { runAgent } from '@/sdk/logic-function/agents/run-agent';
 export type { RunAgentInput, RunAgentResult } from 'twenty-shared/application';
 
+export { kv } from '@/sdk/logic-function/kv-store/kv-store';
+export type { KvSetOptions } from '@/sdk/logic-function/kv-store/kv-store';
+
 export { Response } from '@/sdk/logic-function/response';
 export type { ResponseInit } from '@/sdk/logic-function/response';

--- a/packages/twenty-sdk/src/sdk/logic-function/kv-store/__tests__/kv-store.spec.ts
+++ b/packages/twenty-sdk/src/sdk/logic-function/kv-store/__tests__/kv-store.spec.ts
@@ -105,9 +105,7 @@ describe('kv', () => {
         ),
       );
 
-      await expect(kv.set('my-key', 'value')).rejects.toThrow(
-        /quota exceeded/,
-      );
+      await expect(kv.set('my-key', 'value')).rejects.toThrow(/quota exceeded/);
     });
   });
 

--- a/packages/twenty-sdk/src/sdk/logic-function/kv-store/__tests__/kv-store.spec.ts
+++ b/packages/twenty-sdk/src/sdk/logic-function/kv-store/__tests__/kv-store.spec.ts
@@ -1,0 +1,140 @@
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+  type MockInstance,
+} from 'vitest';
+
+import { kv } from '@/sdk/logic-function/kv-store/kv-store';
+
+describe('kv', () => {
+  let fetchSpy: MockInstance<typeof fetch>;
+
+  beforeEach(() => {
+    process.env.TWENTY_API_URL = 'https://api.test';
+    process.env.TWENTY_APP_ACCESS_TOKEN = 'app-token';
+    fetchSpy = vi.spyOn(globalThis, 'fetch');
+  });
+
+  afterEach(() => {
+    delete process.env.TWENTY_API_URL;
+    delete process.env.TWENTY_APP_ACCESS_TOKEN;
+    fetchSpy.mockRestore();
+  });
+
+  describe('get', () => {
+    it('returns the stored value', async () => {
+      fetchSpy.mockResolvedValue(
+        new Response(
+          JSON.stringify({ data: { appKeyValue: { value: 'cached' } } }),
+          { status: 200 },
+        ),
+      );
+
+      const result = await kv.get('my-key');
+
+      expect(result).toEqual({ value: 'cached' });
+
+      const [url, requestInit] = fetchSpy.mock.calls[0];
+
+      expect(url).toBe('https://api.test/metadata');
+
+      const sentBody = JSON.parse(requestInit?.body as string);
+
+      expect(sentBody.query).toContain('appKeyValue(key: $key)');
+      expect(sentBody.variables).toEqual({ key: 'my-key' });
+    });
+
+    it('returns null when the key is absent', async () => {
+      fetchSpy.mockResolvedValue(
+        new Response(JSON.stringify({ data: { appKeyValue: null } }), {
+          status: 200,
+        }),
+      );
+
+      const result = await kv.get('missing');
+
+      expect(result).toBeNull();
+    });
+  });
+
+  describe('set', () => {
+    it('POSTs the setAppKeyValue mutation with the ttl', async () => {
+      fetchSpy.mockResolvedValue(
+        new Response(JSON.stringify({ data: { setAppKeyValue: true } }), {
+          status: 200,
+        }),
+      );
+
+      await kv.set('my-key', 'value', { ttlInSeconds: 60 });
+
+      const sentBody = JSON.parse(fetchSpy.mock.calls[0][1]?.body as string);
+
+      expect(sentBody.query).toContain('setAppKeyValue(input: $input)');
+      expect(sentBody.variables).toEqual({
+        input: { key: 'my-key', value: 'value', ttlInSeconds: 60 },
+      });
+    });
+
+    it('omits the ttl when not provided', async () => {
+      fetchSpy.mockResolvedValue(
+        new Response(JSON.stringify({ data: { setAppKeyValue: true } }), {
+          status: 200,
+        }),
+      );
+
+      await kv.set('my-key', 'value');
+
+      const sentBody = JSON.parse(fetchSpy.mock.calls[0][1]?.body as string);
+
+      expect(sentBody.variables).toEqual({
+        input: { key: 'my-key', value: 'value', ttlInSeconds: undefined },
+      });
+    });
+
+    it('surfaces GraphQL errors (e.g. quota exceeded) as a regular Error', async () => {
+      fetchSpy.mockResolvedValue(
+        new Response(
+          JSON.stringify({
+            errors: [{ message: 'Key-value storage quota exceeded.' }],
+          }),
+          { status: 200 },
+        ),
+      );
+
+      await expect(kv.set('my-key', 'value')).rejects.toThrow(
+        /quota exceeded/,
+      );
+    });
+  });
+
+  describe('delete', () => {
+    it('POSTs the deleteAppKeyValue mutation', async () => {
+      fetchSpy.mockResolvedValue(
+        new Response(JSON.stringify({ data: { deleteAppKeyValue: true } }), {
+          status: 200,
+        }),
+      );
+
+      await kv.delete('my-key');
+
+      const sentBody = JSON.parse(fetchSpy.mock.calls[0][1]?.body as string);
+
+      expect(sentBody.query).toContain('deleteAppKeyValue(key: $key)');
+      expect(sentBody.variables).toEqual({ key: 'my-key' });
+    });
+  });
+
+  it('throws when the runtime env vars are missing', async () => {
+    delete process.env.TWENTY_API_URL;
+
+    await expect(kv.get('my-key')).rejects.toThrow(
+      /requires the app runtime env vars/,
+    );
+
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+});

--- a/packages/twenty-sdk/src/sdk/logic-function/kv-store/kv-store.ts
+++ b/packages/twenty-sdk/src/sdk/logic-function/kv-store/kv-store.ts
@@ -1,0 +1,72 @@
+import { postGraphqlRequest } from '@/sdk/logic-function/utils/post-graphql-request.util';
+
+export type KvSetOptions = {
+  ttlInSeconds?: number;
+};
+
+const GET_APP_KEY_VALUE_QUERY = `
+  query AppKeyValue($key: String!) {
+    appKeyValue(key: $key) {
+      value
+    }
+  }
+`;
+
+const SET_APP_KEY_VALUE_MUTATION = `
+  mutation SetAppKeyValue($input: SetAppKeyValueInput!) {
+    setAppKeyValue(input: $input)
+  }
+`;
+
+const DELETE_APP_KEY_VALUE_MUTATION = `
+  mutation DeleteAppKeyValue($key: String!) {
+    deleteAppKeyValue(key: $key)
+  }
+`;
+
+const get = async (key: string): Promise<{ value: string } | null> => {
+  const { appKeyValue } = await postGraphqlRequest<
+    { key: string },
+    { appKeyValue: { value: string } | null }
+  >({
+    query: GET_APP_KEY_VALUE_QUERY,
+    variables: { key },
+    caller: 'kv.get',
+  });
+
+  return appKeyValue;
+};
+
+const set = async (
+  key: string,
+  value: string,
+  options?: KvSetOptions,
+): Promise<void> => {
+  await postGraphqlRequest<
+    { input: { key: string; value: string; ttlInSeconds?: number } },
+    { setAppKeyValue: boolean }
+  >({
+    query: SET_APP_KEY_VALUE_MUTATION,
+    variables: {
+      input: { key, value, ttlInSeconds: options?.ttlInSeconds },
+    },
+    caller: 'kv.set',
+  });
+};
+
+const deleteKey = async (key: string): Promise<void> => {
+  await postGraphqlRequest<{ key: string }, { deleteAppKeyValue: boolean }>({
+    query: DELETE_APP_KEY_VALUE_MUTATION,
+    variables: { key },
+    caller: 'kv.delete',
+  });
+};
+
+// Lightweight, server-side key-value store for logic functions. Mirrors the
+// Attio `kv` API (get / set / delete) and is backed by the Twenty server's
+// Redis cache, scoped per application per workspace.
+export const kv = {
+  get,
+  set,
+  delete: deleteKey,
+};

--- a/packages/twenty-server/src/engine/core-modules/application/key-value-store/application-key-value-store.module.ts
+++ b/packages/twenty-server/src/engine/core-modules/application/key-value-store/application-key-value-store.module.ts
@@ -1,0 +1,13 @@
+import { Module } from '@nestjs/common';
+
+import { ApplicationKeyValueStoreResolver } from 'src/engine/core-modules/application/key-value-store/application-key-value-store.resolver';
+import { ApplicationKeyValueStoreService } from 'src/engine/core-modules/application/key-value-store/services/application-key-value-store.service';
+
+@Module({
+  providers: [
+    ApplicationKeyValueStoreService,
+    ApplicationKeyValueStoreResolver,
+  ],
+  exports: [ApplicationKeyValueStoreService],
+})
+export class ApplicationKeyValueStoreModule {}

--- a/packages/twenty-server/src/engine/core-modules/application/key-value-store/application-key-value-store.resolver.ts
+++ b/packages/twenty-server/src/engine/core-modules/application/key-value-store/application-key-value-store.resolver.ts
@@ -1,0 +1,63 @@
+import { UseGuards } from '@nestjs/common';
+import { Args, Mutation, Query } from '@nestjs/graphql';
+
+import { MetadataResolver } from 'src/engine/api/graphql/graphql-config/decorators/metadata-resolver.decorator';
+import { AppKeyValueObjectDto } from 'src/engine/core-modules/application/key-value-store/dtos/app-key-value.object';
+import { SetAppKeyValueInput } from 'src/engine/core-modules/application/key-value-store/dtos/set-app-key-value.input';
+import { ApplicationKeyValueStoreService } from 'src/engine/core-modules/application/key-value-store/services/application-key-value-store.service';
+import { type FlatApplication } from 'src/engine/core-modules/application/types/flat-application.type';
+import { type FlatWorkspace } from 'src/engine/core-modules/workspace/types/flat-workspace.type';
+import { AuthApplication } from 'src/engine/decorators/auth/auth-application.decorator';
+import { AuthWorkspace } from 'src/engine/decorators/auth/auth-workspace.decorator';
+import { NoPermissionGuard } from 'src/engine/guards/no-permission.guard';
+import { WorkspaceAuthGuard } from 'src/engine/guards/workspace-auth.guard';
+
+@UseGuards(WorkspaceAuthGuard, NoPermissionGuard)
+@MetadataResolver()
+export class ApplicationKeyValueStoreResolver {
+  constructor(
+    private readonly keyValueStoreService: ApplicationKeyValueStoreService,
+  ) {}
+
+  @Query(() => AppKeyValueObjectDto, { nullable: true })
+  async appKeyValue(
+    @AuthApplication() application: FlatApplication,
+    @AuthWorkspace() workspace: FlatWorkspace,
+    @Args('key') key: string,
+  ): Promise<AppKeyValueObjectDto | null> {
+    return this.keyValueStoreService.get(
+      { applicationId: application.id, workspaceId: workspace.id },
+      key,
+    );
+  }
+
+  @Mutation(() => Boolean)
+  async setAppKeyValue(
+    @AuthApplication() application: FlatApplication,
+    @AuthWorkspace() workspace: FlatWorkspace,
+    @Args('input') input: SetAppKeyValueInput,
+  ): Promise<boolean> {
+    await this.keyValueStoreService.set(
+      { applicationId: application.id, workspaceId: workspace.id },
+      input.key,
+      input.value,
+      input.ttlInSeconds,
+    );
+
+    return true;
+  }
+
+  @Mutation(() => Boolean)
+  async deleteAppKeyValue(
+    @AuthApplication() application: FlatApplication,
+    @AuthWorkspace() workspace: FlatWorkspace,
+    @Args('key') key: string,
+  ): Promise<boolean> {
+    await this.keyValueStoreService.delete(
+      { applicationId: application.id, workspaceId: workspace.id },
+      key,
+    );
+
+    return true;
+  }
+}

--- a/packages/twenty-server/src/engine/core-modules/application/key-value-store/dtos/app-key-value.object.ts
+++ b/packages/twenty-server/src/engine/core-modules/application/key-value-store/dtos/app-key-value.object.ts
@@ -1,0 +1,7 @@
+import { Field, ObjectType } from '@nestjs/graphql';
+
+@ObjectType('AppKeyValue')
+export class AppKeyValueObjectDto {
+  @Field()
+  value: string;
+}

--- a/packages/twenty-server/src/engine/core-modules/application/key-value-store/dtos/set-app-key-value.input.ts
+++ b/packages/twenty-server/src/engine/core-modules/application/key-value-store/dtos/set-app-key-value.input.ts
@@ -1,0 +1,21 @@
+import { Field, InputType, Int } from '@nestjs/graphql';
+
+import { IsInt, IsNotEmpty, IsOptional, IsString, Min } from 'class-validator';
+
+@InputType('SetAppKeyValueInput')
+export class SetAppKeyValueInput {
+  @IsString()
+  @IsNotEmpty()
+  @Field()
+  key: string;
+
+  @IsString()
+  @Field()
+  value: string;
+
+  @IsInt()
+  @Min(1)
+  @IsOptional()
+  @Field(() => Int, { nullable: true })
+  ttlInSeconds?: number;
+}

--- a/packages/twenty-server/src/engine/core-modules/application/key-value-store/errors/application-key-value-store-quota-exceeded.error.ts
+++ b/packages/twenty-server/src/engine/core-modules/application/key-value-store/errors/application-key-value-store-quota-exceeded.error.ts
@@ -1,0 +1,9 @@
+import { BadRequestException } from '@nestjs/common';
+
+export class ApplicationKeyValueStoreQuotaExceededError extends BadRequestException {
+  constructor(maxSizeInBytes: number) {
+    super(
+      `Key-value storage quota exceeded. The application key-value store is limited to ${maxSizeInBytes} bytes per workspace.`,
+    );
+  }
+}

--- a/packages/twenty-server/src/engine/core-modules/application/key-value-store/services/__tests__/application-key-value-store.service.spec.ts
+++ b/packages/twenty-server/src/engine/core-modules/application/key-value-store/services/__tests__/application-key-value-store.service.spec.ts
@@ -1,0 +1,123 @@
+import { Test, type TestingModule } from '@nestjs/testing';
+
+import { ApplicationKeyValueStoreQuotaExceededError } from 'src/engine/core-modules/application/key-value-store/errors/application-key-value-store-quota-exceeded.error';
+import { ApplicationKeyValueStoreService } from 'src/engine/core-modules/application/key-value-store/services/application-key-value-store.service';
+import { CacheStorageService } from 'src/engine/core-modules/cache-storage/services/cache-storage.service';
+import { CacheStorageNamespace } from 'src/engine/core-modules/cache-storage/types/cache-storage-namespace.enum';
+import { TwentyConfigService } from 'src/engine/core-modules/twenty-config/twenty-config.service';
+
+const scope = { applicationId: 'app-1', workspaceId: 'ws-1' };
+
+describe('ApplicationKeyValueStoreService', () => {
+  let service: ApplicationKeyValueStoreService;
+  let cacheStorageService: jest.Mocked<CacheStorageService>;
+  let twentyConfigService: jest.Mocked<TwentyConfigService>;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        ApplicationKeyValueStoreService,
+        {
+          provide: CacheStorageNamespace.EngineApplicationKeyValue,
+          useValue: {
+            getString: jest.fn(),
+            setString: jest.fn(),
+            getStringLength: jest.fn(),
+            scanAndSumStringLengths: jest.fn(),
+            del: jest.fn(),
+          },
+        },
+        {
+          provide: TwentyConfigService,
+          useValue: { get: jest.fn() },
+        },
+      ],
+    }).compile();
+
+    service = module.get(ApplicationKeyValueStoreService);
+    cacheStorageService = module.get(
+      CacheStorageNamespace.EngineApplicationKeyValue,
+    );
+    twentyConfigService = module.get(TwentyConfigService);
+  });
+
+  describe('get', () => {
+    it('returns { value } when the key exists', async () => {
+      cacheStorageService.getString.mockResolvedValue('cached');
+
+      await expect(service.get(scope, 'key')).resolves.toEqual({
+        value: 'cached',
+      });
+      expect(cacheStorageService.getString).toHaveBeenCalledWith(
+        'ws-1:app-1:key',
+      );
+    });
+
+    it('returns null when the key is absent', async () => {
+      cacheStorageService.getString.mockResolvedValue(null);
+
+      await expect(service.get(scope, 'key')).resolves.toBeNull();
+    });
+  });
+
+  describe('set', () => {
+    beforeEach(() => {
+      twentyConfigService.get.mockReturnValue(100);
+    });
+
+    it('stores the value when below the quota', async () => {
+      cacheStorageService.scanAndSumStringLengths.mockResolvedValue(10);
+      cacheStorageService.getStringLength.mockResolvedValue(0);
+
+      await service.set(scope, 'key', 'value', 60);
+
+      expect(cacheStorageService.setString).toHaveBeenCalledWith(
+        'ws-1:app-1:key',
+        'value',
+        60_000,
+      );
+    });
+
+    it('passes no ttl when ttlInSeconds is omitted', async () => {
+      cacheStorageService.scanAndSumStringLengths.mockResolvedValue(0);
+      cacheStorageService.getStringLength.mockResolvedValue(0);
+
+      await service.set(scope, 'key', 'value');
+
+      expect(cacheStorageService.setString).toHaveBeenCalledWith(
+        'ws-1:app-1:key',
+        'value',
+        undefined,
+      );
+    });
+
+    it('excludes the overwritten entry size from the projected total', async () => {
+      // total already at quota, but the existing entry (95 bytes) is being
+      // replaced by a 5-byte value, so it fits.
+      cacheStorageService.scanAndSumStringLengths.mockResolvedValue(100);
+      cacheStorageService.getStringLength.mockResolvedValue(95);
+
+      await service.set(scope, 'key', 'value');
+
+      expect(cacheStorageService.setString).toHaveBeenCalled();
+    });
+
+    it('throws when the projected total exceeds the quota', async () => {
+      cacheStorageService.scanAndSumStringLengths.mockResolvedValue(98);
+      cacheStorageService.getStringLength.mockResolvedValue(0);
+
+      await expect(service.set(scope, 'key', 'value')).rejects.toBeInstanceOf(
+        ApplicationKeyValueStoreQuotaExceededError,
+      );
+      expect(cacheStorageService.setString).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('delete', () => {
+    it('deletes the scoped entry key', async () => {
+      await service.delete(scope, 'key');
+
+      expect(cacheStorageService.del).toHaveBeenCalledWith('ws-1:app-1:key');
+    });
+  });
+});

--- a/packages/twenty-server/src/engine/core-modules/application/key-value-store/services/application-key-value-store.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/application/key-value-store/services/application-key-value-store.service.ts
@@ -1,0 +1,80 @@
+import { Injectable } from '@nestjs/common';
+
+import { InjectCacheStorage } from 'src/engine/core-modules/cache-storage/decorators/cache-storage.decorator';
+import { CacheStorageService } from 'src/engine/core-modules/cache-storage/services/cache-storage.service';
+import { CacheStorageNamespace } from 'src/engine/core-modules/cache-storage/types/cache-storage-namespace.enum';
+import { TwentyConfigService } from 'src/engine/core-modules/twenty-config/twenty-config.service';
+
+import { ApplicationKeyValueStoreQuotaExceededError } from 'src/engine/core-modules/application/key-value-store/errors/application-key-value-store-quota-exceeded.error';
+
+type Scope = {
+  applicationId: string;
+  workspaceId: string;
+};
+
+// Redis-backed key-value store handed to logic functions so they can cache
+// intermediate results across executions. Entries are scoped per application
+// per workspace and the total stored size is capped (see the
+// APPLICATION_KEY_VALUE_STORAGE_MAX_SIZE_IN_BYTES config variable).
+@Injectable()
+export class ApplicationKeyValueStoreService {
+  constructor(
+    @InjectCacheStorage(CacheStorageNamespace.EngineApplicationKeyValue)
+    private readonly cacheStorageService: CacheStorageService,
+    private readonly twentyConfigService: TwentyConfigService,
+  ) {}
+
+  async get(scope: Scope, key: string): Promise<{ value: string } | null> {
+    const value = await this.cacheStorageService.getString(
+      this.getEntryKey(scope, key),
+    );
+
+    return value === null ? null : { value };
+  }
+
+  async set(
+    scope: Scope,
+    key: string,
+    value: string,
+    ttlInSeconds?: number,
+  ): Promise<void> {
+    const maxSizeInBytes = this.twentyConfigService.get(
+      'APPLICATION_KEY_VALUE_STORAGE_MAX_SIZE_IN_BYTES',
+    );
+
+    const entryKey = this.getEntryKey(scope, key);
+    const newEntrySize = Buffer.byteLength(value, 'utf8');
+
+    const [currentTotalSize, existingEntrySize] = await Promise.all([
+      this.cacheStorageService.scanAndSumStringLengths(
+        `${this.getScopePrefix(scope)}*`,
+      ),
+      this.cacheStorageService.getStringLength(entryKey),
+    ]);
+
+    const projectedTotalSize =
+      currentTotalSize - existingEntrySize + newEntrySize;
+
+    if (projectedTotalSize > maxSizeInBytes) {
+      throw new ApplicationKeyValueStoreQuotaExceededError(maxSizeInBytes);
+    }
+
+    await this.cacheStorageService.setString(
+      entryKey,
+      value,
+      ttlInSeconds ? ttlInSeconds * 1000 : undefined,
+    );
+  }
+
+  async delete(scope: Scope, key: string): Promise<void> {
+    await this.cacheStorageService.del(this.getEntryKey(scope, key));
+  }
+
+  private getScopePrefix({ workspaceId, applicationId }: Scope): string {
+    return `${workspaceId}:${applicationId}:`;
+  }
+
+  private getEntryKey(scope: Scope, key: string): string {
+    return `${this.getScopePrefix(scope)}${key}`;
+  }
+}

--- a/packages/twenty-server/src/engine/core-modules/cache-storage/services/cache-storage.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/cache-storage/services/cache-storage.service.ts
@@ -402,6 +402,88 @@ end`;
     return false;
   }
 
+  // Raw string read/write used by the application key-value store, where we
+  // need byte-accurate accounting (STRLEN) and therefore store the value
+  // verbatim instead of going through cache-manager's JSON serialization.
+  async getString(key: string): Promise<string | null> {
+    if (this.isRedisCache()) {
+      const value = await (this.cache as RedisCache).store.client.get(
+        this.getKey(key),
+      );
+
+      return value ?? null;
+    }
+
+    return (await this.get<string>(key)) ?? null;
+  }
+
+  async setString(
+    key: string,
+    value: string,
+    ttlMs?: Milliseconds,
+  ): Promise<void> {
+    if (this.isRedisCache()) {
+      await (this.cache as RedisCache).store.client.set(
+        this.getKey(key),
+        value,
+        ttlMs ? { PX: ttlMs } : undefined,
+      );
+
+      return;
+    }
+
+    await this.set(key, value, ttlMs);
+  }
+
+  async getStringLength(key: string): Promise<number> {
+    if (this.isRedisCache()) {
+      return (this.cache as RedisCache).store.client.strLen(this.getKey(key));
+    }
+
+    return (await this.getString(key))?.length ?? 0;
+  }
+
+  async scanAndSumStringLengths(scanPattern: string): Promise<number> {
+    if (!this.isRedisCache()) {
+      throw new Error(
+        'scanAndSumStringLengths is only supported with Redis cache',
+      );
+    }
+
+    const redisClient = (this.cache as RedisCache).store.client;
+    let cursor = 0;
+    let totalLength = 0;
+
+    do {
+      const result = await redisClient.scan(cursor, {
+        MATCH: `${this.namespace}:${scanPattern}`,
+        COUNT: 100,
+      });
+
+      cursor = result.cursor;
+      const keys = result.keys;
+
+      if (keys.length > 0) {
+        const pipeline = redisClient.multi();
+
+        for (const key of keys) {
+          pipeline.strLen(key);
+        }
+
+        const results = await pipeline.exec();
+
+        for (const result of results) {
+          if (result instanceof Error) {
+            throw result;
+          }
+          totalLength += result as number;
+        }
+      }
+    } while (cursor !== 0);
+
+    return totalLength;
+  }
+
   private isRedisCache() {
     // oxlint-disable-next-line typescript/no-explicit-any
     return (this.cache.store as any)?.name === 'redis';

--- a/packages/twenty-server/src/engine/core-modules/cache-storage/types/cache-storage-namespace.enum.ts
+++ b/packages/twenty-server/src/engine/core-modules/cache-storage/types/cache-storage-namespace.enum.ts
@@ -10,5 +10,6 @@ export enum CacheStorageNamespace {
   EngineSubscriptions = 'engine:subscriptions',
   EngineBillingUsage = 'engine:billing-usage',
   EngineOnboardingInviteSuggestions = 'engine:onboarding-invite-suggestions',
+  EngineApplicationKeyValue = 'engine:application-key-value',
   IntegrationTests = 'integration-tests',
 }

--- a/packages/twenty-server/src/engine/core-modules/twenty-config/config-variables.ts
+++ b/packages/twenty-server/src/engine/core-modules/twenty-config/config-variables.ts
@@ -616,6 +616,15 @@ export class ConfigVariables {
 
   @ConfigVariablesMetadata({
     group: ConfigVariablesGroup.LOGIC_FUNCTION_CONFIG,
+    description:
+      'Maximum size in bytes of the key-value store available to each application per workspace',
+    type: ConfigVariableType.NUMBER,
+  })
+  @CastToPositiveNumber()
+  APPLICATION_KEY_VALUE_STORAGE_MAX_SIZE_IN_BYTES: number = 10 * 1024 * 1024;
+
+  @ConfigVariablesMetadata({
+    group: ConfigVariablesGroup.LOGIC_FUNCTION_CONFIG,
     description: 'Region for AWS Lambda functions',
     type: ConfigVariableType.STRING,
   })

--- a/packages/twenty-server/src/engine/metadata-modules/metadata-engine.module.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/metadata-engine.module.ts
@@ -7,6 +7,7 @@ import { AiChatModule } from 'src/engine/metadata-modules/ai/ai-chat/ai-chat.mod
 import { AiGenerateTextModule } from 'src/engine/metadata-modules/ai/ai-generate-text/ai-generate-text.module';
 import { AiWorkspaceStatsModule } from 'src/engine/metadata-modules/ai/ai-workspace-stats/ai-workspace-stats.module';
 import { ApplicationConnectionsModule } from 'src/engine/core-modules/application/connection-provider/connections/application-connections.module';
+import { ApplicationKeyValueStoreModule } from 'src/engine/core-modules/application/key-value-store/application-key-value-store.module';
 import { CalendarChannelMetadataModule } from 'src/engine/metadata-modules/calendar-channel/calendar-channel-metadata.module';
 import { ConnectedAccountMetadataModule } from 'src/engine/metadata-modules/connected-account/connected-account-metadata.module';
 import { CommandMenuItemModule } from 'src/engine/metadata-modules/command-menu-item/command-menu-item.module';
@@ -48,6 +49,7 @@ import { WorkspaceMetadataVersionModule } from 'src/engine/metadata-modules/work
     AiGenerateTextModule,
     AiWorkspaceStatsModule,
     ApplicationConnectionsModule,
+    ApplicationKeyValueStoreModule,
     MinimalMetadataModule,
     ViewModule,
     WorkspaceMetadataVersionModule,


### PR DESCRIPTION
## Context

Closes [core-team-issues#2427](https://github.com/twentyhq/core-team-issues/issues/2427).

Logic functions need a way to store intermediate results / cache data across executions. This adds a lightweight server-side **key-value store** for applications, mirroring the [Attio `kv` API](https://docs.attio.com/sdk/server/kv-store) and backed by the existing Redis cache.

## What this does

`kv` is exported from `twenty-sdk/logic-function`:

```ts
import { kv } from 'twenty-sdk/logic-function';

const cached = await kv.get('users');           // { value: string } | null
await kv.set('users', data, { ttlInSeconds: 60 * 60 * 24 });
await kv.delete('users');
```

- **twenty-sdk**: `kv.get` / `kv.set` / `kv.delete` call new metadata GraphQL operations (`appKeyValue`, `setAppKeyValue`, `deleteAppKeyValue`) through the same app-runtime request helper used by `runAgent` / `getConnection`.
- **twenty-server**: new `ApplicationKeyValueStore` module + metadata resolver, scoped **per application per workspace** via the app access token (`@AuthApplication` + `@AuthWorkspace`, exactly like the app connections resolver). Storage is backed by the Redis cache (new `engine:application-key-value` namespace) with native TTL.
- **Quota**: total stored size is capped per application per workspace. New `APPLICATION_KEY_VALUE_STORAGE_MAX_SIZE_IN_BYTES` config variable, **default 10MB**, in the `LOGIC_FUNCTION_CONFIG` group and **editable from the admin settings UI**. Usage is computed live from Redis (`SCAN` + `STRLEN`) so native-TTL expiry never causes the accounting to drift.

## Design notes / decisions to confirm

- **Value type is `string`**, matching Attio's documented `set(key, value: string, ...)` / `get(): { value: string } | null` signatures. Callers `JSON.stringify` structured data themselves. Happy to switch to accepting arbitrary JSON-serializable values + stringifying server-side if preferred.
- **Quota accounting** is recomputed on each `set` via a Redis `SCAN`/`STRLEN` sweep of the app+workspace keyspace. This is simple and always accurate (no counter drift from TTL expiry), at the cost of a scan per write. Fine for cache-style workloads; can switch to a maintained counter if write-heavy apps need it.
- Requires Redis (the scan/quota path throws on the in-memory cache), consistent with the other Redis-only `CacheStorageService` methods.

## Tests

- `twenty-sdk`: `kv-store.spec.ts` — get/set/delete request shape, ttl passthrough, null handling, error surfacing.
- `twenty-server`: `application-key-value-store.service.spec.ts` — scoping, ttl conversion, quota enforcement incl. the overwrite-delta case.

## TODO before marking ready

- [ ] Regenerate the client-sdk metadata schema (`nx run twenty-client-sdk:generate-metadata-client`) — needs a running server; will be done as part of getting CI green.
- [ ] Confirm the design decisions above.

https://claude.ai/code/session_01BVSGVbF1wawgysJV16HAty

---
_Generated by [Claude Code](https://claude.ai/code/session_01BVSGVbF1wawgysJV16HAty)_

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/22058?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

