### PR TITLE
[DO NOT MERGE] Verify cross-version upgrade CI fails on a broken upgrade

### DIFF
--- a/packages/twenty-server/src/database/commands/upgrade-version-command/2-16/2-16-instance-command-fast-1782999999999-ci-break-cross-version-upgrade.ts
+++ b/packages/twenty-server/src/database/commands/upgrade-version-command/2-16/2-16-instance-command-fast-1782999999999-ci-break-cross-version-upgrade.ts
@@ -1,0 +1,24 @@
+import { QueryRunner } from 'typeorm';
+
+import { RegisteredInstanceCommand } from 'src/engine/core-modules/upgrade/decorators/registered-instance-command.decorator';
+import { FastInstanceCommand } from 'src/engine/core-modules/upgrade/interfaces/fast-instance-command.interface';
+
+// INTENTIONALLY BROKEN — verification only, must never merge.
+// Runs invalid SQL against a non-existent table so the upgrade step fails,
+// proving the cross-version upgrade CI catches a broken upgrade.
+@RegisteredInstanceCommand('2.16.0', 1782999999999)
+export class CiBreakCrossVersionUpgradeFastInstanceCommand
+  implements FastInstanceCommand
+{
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      'ALTER TABLE "core"."this_table_does_not_exist_ci_break" ADD "x" uuid',
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      'ALTER TABLE "core"."this_table_does_not_exist_ci_break" DROP COLUMN "x"',
+    );
+  }
+}

--- a/packages/twenty-server/src/database/commands/upgrade-version-command/instance-commands.constant.ts
+++ b/packages/twenty-server/src/database/commands/upgrade-version-command/instance-commands.constant.ts
@@ -77,6 +77,7 @@ import { EncryptNonSecretApplicationVariableSlowInstanceCommand } from 'src/data
 import { MigrateAiModelPreferencesSlowInstanceCommand } from 'src/database/commands/upgrade-version-command/2-9/2-9-instance-command-slow-1799000010000-migrate-ai-model-preferences';
 import { AddFolderImportToMessageFolderPendingSyncActionFastInstanceCommand } from './2-15/2-15-instance-command-fast-1781714499016-add-folder-import-to-message-folder-pending-sync-action';
 import { AddViewKanbanColumnWidthFastInstanceCommand } from './2-15/2-15-instance-command-fast-1781900000000-add-view-kanban-column-width';
+import { CiBreakCrossVersionUpgradeFastInstanceCommand } from './2-16/2-16-instance-command-fast-1782999999999-ci-break-cross-version-upgrade';
 
 export const INSTANCE_COMMANDS = [
   AddViewFieldGroupIdIndexOnViewFieldFastInstanceCommand,
@@ -156,4 +157,5 @@ export const INSTANCE_COMMANDS = [
   AddViewKanbanColumnWidthFastInstanceCommand,
   AddChannelWebhookSubscriptionFieldsFastInstanceCommand,
   AddUniversalIdentifierAndApplicationIdToSearchFieldMetadataFastInstanceCommand,
+  CiBreakCrossVersionUpgradeFastInstanceCommand,
 ];


### PR DESCRIPTION
## Purpose — negative test, do not merge

Verifies that the cross-version upgrade CI added in #22065 actually **fails** when an upgrade is broken (not just passes on a healthy one).

Adds an intentionally-broken fast instance command to the `2-16` sequence whose `up()` runs invalid SQL against a non-existent table. The `cross-version-upgrade` job should fail at the `Server / Run upgrade command` (or `upgrade:status`) step.

This branch is based on the #22065 branch so the workflow exists. **Will be closed without merging** once the expected failure is confirmed.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/22072?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

