### PR TITLE
fix(front): prevent lingui extract crash in buildCrudToolStatusMessage

### DIFF
--- a/packages/twenty-front/src/modules/ai/utils/tool-display/build-crud-tool-status-message.util.ts
+++ b/packages/twenty-front/src/modules/ai/utils/tool-display/build-crud-tool-status-message.util.ts
@@ -35,9 +35,12 @@ export const buildCrudToolStatusMessage = ({
     return null;
   }
 
+  const loadingDescriptor = { ...verbs.loading, values: { objectLabel } };
+  const completedDescriptor = { ...verbs.completed, values: { objectLabel } };
+
   return pickStatusLabel({
     isFinished,
-    loadingLabel: i18n._({ ...verbs.loading, values: { objectLabel } }),
-    completedLabel: i18n._({ ...verbs.completed, values: { objectLabel } }),
+    loadingLabel: i18n._(loadingDescriptor),
+    completedLabel: i18n._(completedDescriptor),
   });
 };


### PR DESCRIPTION
## Problem

The `build-front / s3-build` CD job fails during the `Build frontend` step, in the `twenty-front:lingui:extract` target (`lingui extract --overwrite --clean`):

```
Cannot process file .../build-crud-tool-status-message.util.ts:
Cannot read properties of undefined (reading 'name')
  at @lingui/babel-plugin-extract-messages/dist/index.cjs:88:22
  at extractFromObjectExpression (...index.cjs:87:18)
  at extractFromMessageDescriptor (...index.cjs:121:19)
  at PluginPass.CallExpression (...index.cjs:189:11)
```

## Root cause

`buildCrudToolStatusMessage` called `i18n._()` with an inline object literal containing a spread:

```ts
i18n._({ ...verbs.loading, values: { objectLabel } })
```

Lingui's `extract-messages` babel plugin fires on every `i18n._(...)` call. When the first argument is an `ObjectExpression`, it runs `extractFromObjectExpression`, which reads `key.name` for **every** property. The spread element `...verbs.loading` has no `key`, so `key.name` throws `Cannot read properties of undefined (reading 'name')`, crashing `lingui extract` and failing the whole S3 publish job.

## Fix

Hoist the descriptors into variables so `i18n._()` receives an identifier rather than an inline object expression. The plugin then skips extraction (no statically-extractable id), so no crash. Runtime behavior is unchanged — the translatable strings are still extracted from the `msg` macros in `CRUD_TOOL_OPERATION_VERBS`.

## Testing

- Reproduced the **exact** CI crash locally on `main` by running `lingui extract --overwrite --clean` (same file, message, and stack frames).
- After the fix, `lingui extract --overwrite --clean` runs clean (exit 0).
- `build-crud-tool-status-message.util.test.ts` passes (2/2).
- `nx lint:diff-with-main twenty-front` passes (0 warnings, 0 errors, formatting clean).


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/22080?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

