### PR TITLE
ci(front): run lingui extract & compile on PRs to gate i18n breakage

### DIFF
--- a/.github/workflows/ci-front.yaml
+++ b/.github/workflows/ci-front.yaml
@@ -200,7 +200,7 @@ jobs:
       TASK_CACHE_KEY: front-task-${{ matrix.task }}
     strategy:
       matrix:
-        task: [lint, typecheck, test]
+        task: [lint, typecheck, test, lingui:extract]
     steps:
       - name: Fetch custom Github Actions and base branch history
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1

--- a/.github/workflows/ci-front.yaml
+++ b/.github/workflows/ci-front.yaml
@@ -200,7 +200,7 @@ jobs:
       TASK_CACHE_KEY: front-task-${{ matrix.task }}
     strategy:
       matrix:
-        task: [lint, typecheck, test, lingui:extract]
+        task: [lint, typecheck, test, lingui:extract, lingui:compile]
     steps:
       - name: Fetch custom Github Actions and base branch history
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1


### PR DESCRIPTION
## Why

`lingui extract` currently only runs **after merge** — in `i18n-push.yaml`, which triggers on push to `main`. PR CI (`ci-front.yaml`) runs `lint`, `typecheck`, `test`, and `build`, but never `lingui extract`. So a change that crashes extraction passes every PR check and only blows up later in the CD `build-front / s3-build` job.

That's exactly what happened with the spread-in-`i18n._()` crash fixed in #22080:

```
Cannot process file .../build-crud-tool-status-message.util.ts:
Cannot read properties of undefined (reading 'name')
  at @lingui/babel-plugin-extract-messages/dist/index.cjs:88:22
```

## What

Add `lingui:extract` to the `front-task` matrix in `ci-front.yaml`. It now runs alongside `lint`/`typecheck`/`test` via the existing `nx-affected` action:

```
npx nx affected -t=lingui:extract --exclude='*,!tag:scope:frontend'
```

This runs the **exact command that fails** in the CD build, so it catches this bug class — and any other change that breaks extraction — before merge, not after.

## Notes / verification

- Confirmed `lingui extract --overwrite --clean` exits **non-zero** on the crash (verified locally on the pre-fix source: exit code 1), so the matrix job fails as intended.
- The job only runs when frontend files change (`changed-files-check` gate), and `nx affected -t=lingui:extract` only runs for projects that actually have the target, so non-frontend projects are skipped.
- Extract writes to `.po` files in the runner; that's ephemeral and not committed — the gate only asserts the command succeeds, it does not check catalog diffs.
- Scope is intentionally frontend-only (this workflow is `ci-front`). `twenty-server` / `twenty-emails` extraction is not gated on PRs by this change; a follow-up could add the equivalent to the backend CI if desired.

Companion to #22080 (the actual fix); this PR closes the process gap that let it through.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/22084?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

