### PR TITLE
ci(server,emails): run lingui extract & compile on PRs to gate i18n breakage

### DIFF
--- a/.github/workflows/ci-emails.yaml
+++ b/.github/workflows/ci-emails.yaml
@@ -35,6 +35,8 @@ jobs:
         uses: ./.github/actions/yarn-install
       - name: Build twenty-emails
         run: npx nx build twenty-emails
+      - name: Extract translations (lingui)
+        run: npx nx run twenty-emails:lingui:extract
       - name: Run email tests
         run: |
           # Start the email server in the background

--- a/.github/workflows/ci-emails.yaml
+++ b/.github/workflows/ci-emails.yaml
@@ -37,6 +37,8 @@ jobs:
         run: npx nx build twenty-emails
       - name: Extract translations (lingui)
         run: npx nx run twenty-emails:lingui:extract
+      - name: Compile translations (lingui)
+        run: npx nx run twenty-emails:lingui:compile
       - name: Run email tests
         run: |
           # Start the email server in the background

--- a/.github/workflows/ci-server.yaml
+++ b/.github/workflows/ci-server.yaml
@@ -77,11 +77,11 @@ jobs:
         uses: ./.github/actions/yarn-install
       - name: Build twenty-shared
         run: npx nx build twenty-shared
-      - name: Server / Run lint & typecheck
+      - name: Server / Run lint, typecheck & lingui extract
         uses: ./.github/actions/nx-affected
         with:
           tag: scope:backend
-          tasks: lint,typecheck
+          tasks: lint,typecheck,lingui:extract
 
   server-previous-version-upgrade-mutation-guard:
     timeout-minutes: 5

--- a/.github/workflows/ci-server.yaml
+++ b/.github/workflows/ci-server.yaml
@@ -82,6 +82,12 @@ jobs:
         with:
           tag: scope:backend
           tasks: lint,typecheck,lingui:extract
+      # Separate step so compile never races extract on the .po files.
+      - name: Server / Run lingui compile
+        uses: ./.github/actions/nx-affected
+        with:
+          tag: scope:backend
+          tasks: lingui:compile
 
   server-previous-version-upgrade-mutation-guard:
     timeout-minutes: 5


### PR DESCRIPTION
## Why

Translations for `twenty-server` and `twenty-emails` are only extracted **after merge** — in `i18n-push.yaml` (push to `main`). Their PR workflows (`ci-server.yaml`, `ci-emails.yaml`) never run `lingui extract`, so a change that crashes extraction passes every PR check and only fails post-merge — the same process gap that let the frontend crash through (fixed in #22080, frontend gate in #22084).

Both projects have a `lingui:extract` target and are extracted by `i18n-push.yaml`, so the equivalent guard applies.

## What

- **`ci-server.yaml`** — add `lingui:extract` to the existing `server-lint-typecheck` job's `nx-affected` tasks (`tag: scope:backend`). That job already builds `twenty-shared` and is already part of `ci-server-status-check`, so no new job/wiring is needed:
  ```
  tasks: lint,typecheck  ->  tasks: lint,typecheck,lingui:extract
  ```
- **`ci-emails.yaml`** — add a `lingui:extract` step to the `emails-test` job (this workflow has no `nx-affected` job, so a direct target run fits):
  ```yaml
  - name: Extract translations (lingui)
    run: npx nx run twenty-emails:lingui:extract
  ```

Both run the same extraction command as the post-merge `i18n-push` workflow, so failures are caught before merge.

## Notes

- `lingui extract` exits non-zero on extraction failures (verified on the frontend crash: exit code 1), so these steps genuinely fail the job.
- Both jobs already gate on `changed-files-check`, so extract only runs when the respective package changes.
- `nx affected -t=lingui:extract` only runs for projects that have the target; `lingui:extract`'s `^build` dependency is resolved automatically by nx.

Completes the extract-gate coverage started for the frontend in #22084.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/22086?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

