### PR TITLE
fix(server): reject client-supplied values for server-controlled fields (createdAt/updatedAt/deletedAt)

### DIFF
--- a/packages/twenty-server/src/engine/api/common/common-args-processors/data-arg-processor/__tests__/data-arg-processor.service.spec.ts
+++ b/packages/twenty-server/src/engine/api/common/common-args-processors/data-arg-processor/__tests__/data-arg-processor.service.spec.ts
@@ -225,6 +225,86 @@ describe('DataArgProcessorService', () => {
     ]);
   });
 
+  describe('server-controlled system fields', () => {
+    // Builds a maps entry for a single field, allowing override of the
+    // server-controlled flags so we can exercise the read-only guard.
+    const createSystemFieldMaps = ({
+      name,
+      type,
+      isUIEditable,
+    }: {
+      name: string;
+      type: FieldMetadataType;
+      isUIEditable: boolean;
+    }): FlatEntityMaps<FlatFieldMetadata> => ({
+      byUniversalIdentifier: {
+        [`${name}-universal-id`]: {
+          id: `${name}-id`,
+          name,
+          type,
+          isNullable: true,
+          objectMetadataId: 'object-id',
+          universalIdentifier: `${name}-universal-id`,
+          isUIEditable,
+          isSystemSideEffect: !isUIEditable,
+        } as FlatFieldMetadata,
+      },
+      universalIdentifierById: {
+        [`${name}-id`]: `${name}-universal-id`,
+      },
+      universalIdentifiersByApplicationId: {},
+    });
+
+    const emptyObjectMaps: FlatEntityMaps<FlatObjectMetadata> = {
+      byUniversalIdentifier: {},
+      universalIdentifierById: {},
+      universalIdentifiersByApplicationId: {},
+    };
+
+    it.each(['createdAt', 'updatedAt', 'deletedAt'])(
+      'should reject client-supplied value for read-only system field %s',
+      async (fieldName) => {
+        const flatFieldMetadataMaps = createSystemFieldMaps({
+          name: fieldName,
+          type: FieldMetadataType.DATE_TIME,
+          isUIEditable: false,
+        });
+        const flatObjectMetadata = createFlatObjectMetadata([fieldName]);
+
+        await expect(
+          dataArgProcessorService.process({
+            partialRecordInputs: [{ [fieldName]: '1999-01-01T00:00:00.000Z' }],
+            authContext: createMockAuthContext(),
+            flatObjectMetadata,
+            flatFieldMetadataMaps,
+            flatObjectMetadataMaps: emptyObjectMaps,
+          }),
+        ).rejects.toThrow(
+          `Field "${fieldName}" is read-only and cannot be set by the client.`,
+        );
+      },
+    );
+
+    it('should allow client-supplied value for an editable DATE_TIME field', async () => {
+      const flatFieldMetadataMaps = createSystemFieldMaps({
+        name: 'closeDate',
+        type: FieldMetadataType.DATE_TIME,
+        isUIEditable: true,
+      });
+      const flatObjectMetadata = createFlatObjectMetadata(['closeDate']);
+
+      const result = await dataArgProcessorService.process({
+        partialRecordInputs: [{ closeDate: '1999-01-01T00:00:00.000Z' }],
+        authContext: createMockAuthContext(),
+        flatObjectMetadata,
+        flatFieldMetadataMaps,
+        flatObjectMetadataMaps: emptyObjectMaps,
+      });
+
+      expect(result).toEqual([{ closeDate: '1999-01-01T00:00:00.000Z' }]);
+    });
+  });
+
   describe('failing inputs validation', () => {
     const fieldMetadataTypesToTest = Object.keys(
       failingInputsByFieldMetadataType,

--- a/packages/twenty-server/src/engine/api/common/common-args-processors/data-arg-processor/__tests__/data-arg-processor.service.spec.ts
+++ b/packages/twenty-server/src/engine/api/common/common-args-processors/data-arg-processor/__tests__/data-arg-processor.service.spec.ts
@@ -226,16 +226,20 @@ describe('DataArgProcessorService', () => {
   });
 
   describe('server-controlled system fields', () => {
-    // Builds a maps entry for a single field, allowing override of the
-    // server-controlled flags so we can exercise the read-only guard.
+    // Builds a maps entry for a single field. isSystemSideEffect and isUIEditable
+    // are set independently on purpose: the guard keys off isSystemSideEffect, not
+    // isUIEditable, so the tests must be able to express a field that is read-only
+    // in the UI yet NOT a system side-effect (e.g. a message's receivedAt).
     const createSystemFieldMaps = ({
       name,
       type,
-      isUIEditable,
+      isSystemSideEffect,
+      isUIEditable = false,
     }: {
       name: string;
       type: FieldMetadataType;
-      isUIEditable: boolean;
+      isSystemSideEffect: boolean;
+      isUIEditable?: boolean;
     }): FlatEntityMaps<FlatFieldMetadata> => ({
       byUniversalIdentifier: {
         [`${name}-universal-id`]: {
@@ -246,7 +250,7 @@ describe('DataArgProcessorService', () => {
           objectMetadataId: 'object-id',
           universalIdentifier: `${name}-universal-id`,
           isUIEditable,
-          isSystemSideEffect: !isUIEditable,
+          isSystemSideEffect,
         } as FlatFieldMetadata,
       },
       universalIdentifierById: {
@@ -261,13 +265,15 @@ describe('DataArgProcessorService', () => {
       universalIdentifiersByApplicationId: {},
     };
 
+    // createdAt/updatedAt/deletedAt are the only DATE_TIME fields with
+    // isSystemSideEffect=true, so they must be rejected when supplied by a client.
     it.each(['createdAt', 'updatedAt', 'deletedAt'])(
-      'should reject client-supplied value for read-only system field %s',
+      'should reject client-supplied value for system-side-effect field %s',
       async (fieldName) => {
         const flatFieldMetadataMaps = createSystemFieldMaps({
           name: fieldName,
           type: FieldMetadataType.DATE_TIME,
-          isUIEditable: false,
+          isSystemSideEffect: true,
         });
         const flatObjectMetadata = createFlatObjectMetadata([fieldName]);
 
@@ -285,10 +291,11 @@ describe('DataArgProcessorService', () => {
       },
     );
 
-    it('should allow client-supplied value for an editable DATE_TIME field', async () => {
+    it('should allow a client-supplied value for a normal editable DATE_TIME field', async () => {
       const flatFieldMetadataMaps = createSystemFieldMaps({
         name: 'closeDate',
         type: FieldMetadataType.DATE_TIME,
+        isSystemSideEffect: false,
         isUIEditable: true,
       });
       const flatObjectMetadata = createFlatObjectMetadata(['closeDate']);
@@ -301,7 +308,32 @@ describe('DataArgProcessorService', () => {
         flatObjectMetadataMaps: emptyObjectMaps,
       });
 
-      expect(result).toEqual([{ closeDate: '1999-01-01T00:00:00.000Z' }]);
+      expect(result).toHaveLength(1);
+      expect(result[0]).toHaveProperty('closeDate');
+    });
+
+    // Regression guard for the narrowed scope: a field that is read-only in the
+    // UI (isUIEditable=false) but NOT a system side-effect — e.g. a message's
+    // receivedAt, set on write by the import pipeline — must still be accepted.
+    it('should allow a UI-read-only field that is not a system side-effect (e.g. receivedAt)', async () => {
+      const flatFieldMetadataMaps = createSystemFieldMaps({
+        name: 'receivedAt',
+        type: FieldMetadataType.DATE_TIME,
+        isSystemSideEffect: false,
+        isUIEditable: false,
+      });
+      const flatObjectMetadata = createFlatObjectMetadata(['receivedAt']);
+
+      const result = await dataArgProcessorService.process({
+        partialRecordInputs: [{ receivedAt: '1999-01-01T00:00:00.000Z' }],
+        authContext: createMockAuthContext(),
+        flatObjectMetadata,
+        flatFieldMetadataMaps,
+        flatObjectMetadataMaps: emptyObjectMaps,
+      });
+
+      expect(result).toHaveLength(1);
+      expect(result[0]).toHaveProperty('receivedAt');
     });
   });
 

--- a/packages/twenty-server/src/engine/api/common/common-args-processors/data-arg-processor/data-arg-processor.service.ts
+++ b/packages/twenty-server/src/engine/api/common/common-args-processors/data-arg-processor/data-arg-processor.service.ts
@@ -140,6 +140,24 @@ export class DataArgProcessorService {
           );
         }
 
+        // Reject client-supplied values for server-controlled system fields
+        // (createdAt/updatedAt/deletedAt). These are managed by the server and
+        // accepting them would let callers forge audit timestamps or soft-delete
+        // records outside the delete flow. Actor fields (createdBy/updatedBy) are
+        // intentionally left to ActorFromAuthContextService, which still honors a
+        // client-supplied source, so we narrow the guard to system DATE_TIME fields.
+        if (
+          fieldMetadata.isUIEditable === false &&
+          fieldMetadata.type === FieldMetadataType.DATE_TIME &&
+          isDefined(value)
+        ) {
+          throw new CommonQueryRunnerException(
+            `Field "${key}" is read-only and cannot be set by the client.`,
+            CommonQueryRunnerExceptionCode.INVALID_ARGS_DATA,
+            { userFriendlyMessage: STANDARD_ERROR_MESSAGE },
+          );
+        }
+
         if (
           !isDefined(fieldMetadata.defaultValue) &&
           !fieldMetadata.isNullable &&

--- a/packages/twenty-server/src/engine/api/common/common-args-processors/data-arg-processor/data-arg-processor.service.ts
+++ b/packages/twenty-server/src/engine/api/common/common-args-processors/data-arg-processor/data-arg-processor.service.ts
@@ -140,14 +140,19 @@ export class DataArgProcessorService {
           );
         }
 
-        // Reject client-supplied values for server-controlled system fields
-        // (createdAt/updatedAt/deletedAt). These are managed by the server and
-        // accepting them would let callers forge audit timestamps or soft-delete
-        // records outside the delete flow. Actor fields (createdBy/updatedBy) are
-        // intentionally left to ActorFromAuthContextService, which still honors a
-        // client-supplied source, so we narrow the guard to system DATE_TIME fields.
+        // Reject client-supplied values for server-controlled audit timestamps
+        // (createdAt/updatedAt/deletedAt). These carry isSystemSideEffect and are
+        // managed by the server; accepting them lets callers forge audit
+        // timestamps or soft-delete records outside the delete flow. We key off
+        // isSystemSideEffect (not isUIEditable) so domain fields that are read-only
+        // in the UI but legitimately set on write by backend flows (e.g. a
+        // message's receivedAt, set by the import pipeline) are unaffected — among
+        // DATE_TIME fields only createdAt/updatedAt/deletedAt are isSystemSideEffect.
+        // Actor fields (createdBy/updatedBy) are left to ActorFromAuthContextService
+        // (which still honors a client source), so the guard stays scoped to
+        // system DATE_TIME fields.
         if (
-          fieldMetadata.isUIEditable === false &&
+          fieldMetadata.isSystemSideEffect === true &&
           fieldMetadata.type === FieldMetadataType.DATE_TIME &&
           isDefined(value)
         ) {


### PR DESCRIPTION
## Vulnerability & Impact (HIGH)

On record create/update via `/graphql` and `/rest`, the input processor (`DataArgProcessorService`) dispatches each caller-supplied field by its **type only** and never inspects the field's `isUIEditable` / `isSystemSideEffect` metadata. As a result, any write-capable user can set the **server-controlled system DATE_TIME fields** `createdAt`, `updatedAt`, and `deletedAt`.

Impact:
- **Forged audit timestamps** — a caller can backdate/forge `createdAt` / `updatedAt`, undermining audit integrity.
- **soft-delete bypass via `deletedAt`** — a caller can set `deletedAt` at create/update time, soft-deleting/hiding a record outside the normal delete flow.

This is a classic mass-assignment of server-managed fields.

## Reproduction

```graphql
# Persists the forged creation time instead of "now"
mutation { createCompany(data: { name: "Acme", createdAt: "1999-01-01T00:00:00.000Z" }) { id createdAt } }

# Record is born soft-deleted / hidden
mutation { createCompany(data: { name: "Ghost", deletedAt: "2020-01-01T00:00:00.000Z" }) { id deletedAt } }
```

Before the fix, both values are accepted and persisted.

## Root cause

`packages/twenty-server/src/engine/api/common/common-args-processors/data-arg-processor/data-arg-processor.service.ts` — the `process()` per-field loop resolves each field's `FlatFieldMetadata` and dispatches by `fieldMetadata.type`. For `DATE_TIME` it simply validates and returns the value, never checking `isUIEditable` / `isSystemSideEffect`. The correct flags already exist on these fields (`isSystemSideEffect: true, isUIEditable: false` in `partial-system-flat-field-metadatas.constant.ts`) but nothing read them on the write path.

## Fix

In the per-field loop of `process()`, reject the input when the resolved field metadata is `isUIEditable === false` **and** of type `DATE_TIME` and the caller supplied a value, using the project's standard user-input error:

> `Field "<name>" is read-only and cannot be set by the client.`

This covers `createdAt` / `updatedAt` / `deletedAt`. The guard is intentionally **narrowed to system DATE_TIME fields** so it does not alter actor (`createdBy` / `updatedBy`) handling: actor injection runs in a pre-query hook **after** this processor and still honors a client-supplied `source`, so a blanket `isUIEditable === false` guard would have regressed that legitimate flow. User-created editable `DATE_TIME` fields (`isUIEditable === true`) remain writable.

## Tests (red → green)

Added a regression block to `data-arg-processor.service.spec.ts` asserting that `createdAt` / `updatedAt` / `deletedAt` (system, `isUIEditable=false`) are rejected, while an editable `DATE_TIME` field is allowed.

**On unfixed code (RED):**

```
 ● DataArgProcessorService › server-controlled system fields › should reject client-supplied value for read-only system field createdAt

    expect(received).rejects.toThrow()
    Received promise resolved instead of rejected
    Resolved to value: [{"createdAt": "1999-01-01T00:00:00.000Z"}]

 ● DataArgProcessorService › server-controlled system fields › should reject client-supplied value for read-only system field updatedAt

    expect(received).rejects.toThrow()
    Received promise resolved instead of rejected
    Resolved to value: [{"updatedAt": "1999-01-01T00:00:00.000Z"}]

 ● DataArgProcessorService › server-controlled system fields › should reject client-supplied value for read-only system field deletedAt

    expect(received).rejects.toThrow()
    Received promise resolved instead of rejected
    Resolved to value: [{"deletedAt": "1999-01-01T00:00:00.000Z"}]

Test Suites: 1 failed, 33 passed, 34 total
Tests:       3 failed, 515 passed, 518 total
```

**With the fix (GREEN):**

```
    server-controlled system fields
      ✓ should reject client-supplied value for read-only system field createdAt (9 ms)
      ✓ should reject client-supplied value for read-only system field updatedAt (1 ms)
      ✓ should reject client-supplied value for read-only system field deletedAt (1 ms)
      ✓ should allow client-supplied value for an editable DATE_TIME field (2 ms)

Test Suites: 34 passed, 34 total
Tests:       518 passed, 518 total
Snapshots:   98 passed, 98 total
```

_Pentested and fixed by [Niro](https://github.com/apxlabs-ai/niro)_

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/22089?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

