### PR TITLE
docs: rewrite billing credits page to clarify credit value and usage

### DIFF
--- a/packages/twenty-docs/user-guide/billing/capabilities/credits.mdx
+++ b/packages/twenty-docs/user-guide/billing/capabilities/credits.mdx
@@ -1,55 +1,70 @@
 ---
 title: Credits
-description: Understanding how credits power workflows, AI agents, and the AI chatbot — and how to manage your balance.
+description: One simple balance that powers your workflows, AI agents, and AI chat — what a credit is worth, how far it goes, and how to manage it.
 ---
 
-## Overview
+## What are credits?
 
-Credits power workflow automations and AI capabilities. They are consumed when workflow actions execute, when AI agents process tasks inside workflows, and whithin the AI chat.
+Credits are a single balance that powers everything we run on your behalf that has a real cost: **workflow automations**, **AI agents**, and the **AI chat**. Instead of juggling separate quotas for "automation runs" and "AI tokens," you have one simple balance to keep an eye on.
 
-## Credit Allocation
+**1 credit = $1 of usage.** A credit is just a dollar of work, so your balance is easy to reason about — no abstract units to convert.
 
-Credits are based on your billing cycle, not your plan:
+## How far does a credit go?
 
-| Billing Cycle | Credits |
-|---------------|---------|
-| Monthly | 5/month |
-| Yearly | 50/year |
+Cost scales with the work. Everyday automation and quick AI messages cost a tiny fraction of a credit; large, multi-step AI agent tasks cost more. Here's the rough shape:
+
+| What you do | Roughly costs | What that means |
+|-------------|---------------|-----------------|
+| Run a standard workflow step (search, create, update records) | ~$0.0001 | About **10,000 steps per credit** |
+| Call an external API or run a code node | A small fraction of a credit | Thousands per credit |
+| Send a quick AI chat message or simple AI step | A fraction of a cent | Hundreds per credit |
+| Run a large AI agent task (e.g. "configure 10 workspace objects") | Can run to **~$1 or more** | A few per credit |
+| Run an AI web search | A fixed per-search cost | Hundreds of searches per credit |
 
 <Note>
-The 5 monthly credits are designed to empower you to run automations without worrying about costs. For most workflows using standard actions, this is more than enough. You'll only need additional credits when running advanced code nodes or AI-powered features.
+For most teams, standard automations are effectively free — you'll only make a noticeable dent in your balance when you lean on AI features or run heavy code nodes. That's by design: the included credits are meant to let you build without watching a meter.
 </Note>
 
-## Credit Rollover
+## How AI usage is metered
 
-Unused credits at the end of a billing period are automatically carried over to the next period.
+When an action calls an AI model, we measure the exact tokens used and price them at **the model provider's published rates**, then convert that dollar amount straight into credits — so what you spend tracks the real cost of the work, not a marked-up internal rate. A short chat message costs a fraction of a cent. A large agent task — say, configuring ten workspace objects — makes many model calls over a growing context, so it can add up to a dollar or more. You're billed for what you actually use, down to the token.
 
-- **Cap**: The rollover amount is capped at one period's full allocation, so you can never carry over more credits than your plan provides per period.
-- **Visibility**: When rollover credits are available, they appear as a separate **Rollover Credits** line in **Settings → Billing**, alongside a **Total Available** balance.
+Cost varies by model: a lightweight model is dramatically cheaper per message than a top-tier reasoning model. You can see the per-action breakdown — including which model was used — in **Settings → Billing**.
 
-## Credit Consumption
+## What's included
 
-Different actions consume different amounts of credits:
+Every subscription includes credits, and the amount depends on your **billing cycle**, not your plan:
 
-| Action Type | Credit Usage |
-|-------------|--------------|
-| **Basic operations** (search, update, create records) | Minimal |
-| **Complex operations** (code nodes, external API calls) | More credits |
-| **AI prompt & AI chats** | Variable based on usage |
+| Billing Cycle | Included Credits | Equivalent usage |
+|---------------|------------------|------------------|
+| Monthly | 5 / month | ~$5 of usage each month |
+| Yearly | 50 / year | ~$50 of usage each year |
 
-Credits are deducted in real-time when workflows execute.
+These credits are designed to cover everyday automation comfortably. Five credits covers tens of thousands of standard automation steps or hundreds of quick AI messages — though a handful of large, multi-step agent tasks can use it up faster. You can top up at any time (see below).
+
+## Credit rollover
+
+Unused credits roll over automatically to the next billing period.
+
+- **Cap**: Rollover is capped at one period's full allocation, so you'll never carry over more than your plan provides per period.
+- **Visibility**: When you have rollover credits, they appear as a separate **Rollover Credits** line in **Settings → Billing**, alongside your **Total Available** balance.
 
 ## Monitoring Usage
 
-Track your credit consumption:
-1. Go to **Settings → Billing**
-2. View your current usage and remaining credits
-3. Monitor trends to plan for additional credits if needed
+Keep track of your balance and where it's going:
 
-## Purchasing Additional Credits
-
-Need more credits?
 1. Go to **Settings → Billing**
-2. Click on the option to purchase additional credit packs
+2. See your **remaining credits** and **usage for the current period**
+3. Drill into the breakdown to see which workflows and AI actions are consuming credits — and which models AI actions used
+
+Reviewing this regularly makes it easy to spot a heavy workflow early and decide whether to optimize it or top up.
+
+## Need more credits?
+
+If you run out — or want a buffer before a big automation push — you can buy additional credit packs at any time:
+
+1. Go to **Settings → Billing**
+2. Choose to **purchase additional credits**
 3. Select the amount you need
 
+Purchased credits are added to your available balance immediately.


### PR DESCRIPTION
Rewrites the billing **Credits** doc so it actually explains what a credit is worth and how far it goes — the previous version listed bare credit counts and described AI cost only as "variable based on usage."

What changed:
- Leads with **1 credit = $1 of usage**, so the balance is easy to reason about.
- Adds a "How far does a credit go?" table grounded in how billing actually works: standard workflow steps cost ~$0.0001 each, quick AI messages a fraction of a cent, while large multi-step agent tasks (e.g. configuring several objects) can run to ~$1 or more.
- Explains that AI usage is metered at the model providers' published token rates and converted straight to credits — no marked-up internal rate.
- Reframes allocation (5/mo, 50/yr) in terms of equivalent dollar usage, and tightens the rollover, monitoring, and top-up sections.

Docs-only change; no code or behavior affected.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/22099?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

