### PR TITLE
chore: replace vite-tsconfig-paths with resolve.tsconfigPaths

### DIFF
--- a/packages/create-twenty-app/package.json
+++ b/packages/create-twenty-app/package.json
@@ -51,8 +51,7 @@
     "twenty-shared": "workspace:*",
     "typescript": "^5.9.3",
     "vite": "^8.0.0",
-    "vite-plugin-dts": "^4.5.4",
-    "vite-tsconfig-paths": "^4.2.1"
+    "vite-plugin-dts": "^4.5.4"
   },
   "engines": {
     "node": "^24.5.0",

--- a/packages/create-twenty-app/src/constants/template/package.json
+++ b/packages/create-twenty-app/src/constants/template/package.json
@@ -26,7 +26,6 @@
     "twenty-client-sdk": "TO-BE-GENERATED",
     "twenty-sdk": "TO-BE-GENERATED",
     "typescript": "^5.9.3",
-    "vite-tsconfig-paths": "^4.2.1",
     "vitest": "^3.1.1"
   }
 }

--- a/packages/create-twenty-app/src/constants/template/vitest.config.ts
+++ b/packages/create-twenty-app/src/constants/template/vitest.config.ts
@@ -1,4 +1,3 @@
-import tsconfigPaths from 'vite-tsconfig-paths';
 import { defineConfig } from 'vitest/config';
 
 const TWENTY_API_URL = process.env.TWENTY_API_URL ?? 'http://localhost:2020';
@@ -11,12 +10,9 @@ process.env.TWENTY_API_URL = TWENTY_API_URL;
 process.env.TWENTY_API_KEY = TWENTY_API_KEY;
 
 export default defineConfig({
-  plugins: [
-    tsconfigPaths({
-      projects: ['tsconfig.spec.json'],
-      ignoreConfigErrors: true,
-    }),
-  ],
+  resolve: {
+    tsconfigPaths: './tsconfig.spec.json',
+  },
   test: {
     testTimeout: 120_000,
     hookTimeout: 120_000,

--- a/packages/create-twenty-app/src/constants/template/vitest.config.ts
+++ b/packages/create-twenty-app/src/constants/template/vitest.config.ts
@@ -11,7 +11,7 @@ process.env.TWENTY_API_KEY = TWENTY_API_KEY;
 
 export default defineConfig({
   resolve: {
-    tsconfigPaths: './tsconfig.spec.json',
+    tsconfigPaths: true,
   },
   test: {
     testTimeout: 120_000,

--- a/packages/create-twenty-app/vite.config.ts
+++ b/packages/create-twenty-app/vite.config.ts
@@ -2,7 +2,6 @@ import fs from 'fs-extra';
 import path from 'path';
 import { defineConfig } from 'vite';
 import dts from 'vite-plugin-dts';
-import tsconfigPaths from 'vite-tsconfig-paths';
 import packageJson from './package.json';
 import type { PackageJson } from 'type-fest';
 
@@ -55,10 +54,10 @@ export default defineConfig(() => {
   return {
     root: __dirname,
     cacheDir: '../../node_modules/.vite/packages/create-twenty-app',
+    resolve: {
+      tsconfigPaths: true,
+    },
     plugins: [
-      tsconfigPaths({
-        root: __dirname,
-      }),
       dts({ entryRoot: './src', tsconfigPath: tsConfigPath }),
       copyAssetPlugin([
         {

--- a/packages/twenty-apps/examples/hello-world/package.json
+++ b/packages/twenty-apps/examples/hello-world/package.json
@@ -24,7 +24,6 @@
     "twenty-client-sdk": "2.13.0",
     "twenty-sdk": "2.13.0",
     "typescript": "^5.9.3",
-    "vite-tsconfig-paths": "^4.2.1",
     "vitest": "^4.0.0"
   }
 }

--- a/packages/twenty-apps/examples/hello-world/vitest.config.ts
+++ b/packages/twenty-apps/examples/hello-world/vitest.config.ts
@@ -1,13 +1,9 @@
-import tsconfigPaths from 'vite-tsconfig-paths';
 import { defineConfig } from 'vitest/config';
 
 export default defineConfig({
-  plugins: [
-    tsconfigPaths({
-      projects: ['tsconfig.spec.json'],
-      ignoreConfigErrors: true,
-    }),
-  ],
+  resolve: {
+    tsconfigPaths: true,
+  },
   test: {
     testTimeout: 120_000,
     hookTimeout: 120_000,

--- a/packages/twenty-apps/examples/postcard/package.json
+++ b/packages/twenty-apps/examples/postcard/package.json
@@ -32,7 +32,6 @@
     "twenty-client-sdk": "2.13.0",
     "twenty-sdk": "2.13.0",
     "typescript": "^5.9.3",
-    "vite-tsconfig-paths": "^4.2.1",
     "vitest": "^4.0.0"
   }
 }

--- a/packages/twenty-apps/examples/postcard/vitest.config.ts
+++ b/packages/twenty-apps/examples/postcard/vitest.config.ts
@@ -1,4 +1,3 @@
-import tsconfigPaths from 'vite-tsconfig-paths';
 import { defineConfig } from 'vitest/config';
 
 const TWENTY_API_URL = process.env.TWENTY_API_URL ?? 'http://localhost:2020';
@@ -11,12 +10,9 @@ process.env.TWENTY_API_URL = TWENTY_API_URL;
 process.env.TWENTY_API_KEY = TWENTY_API_KEY;
 
 export default defineConfig({
-  plugins: [
-    tsconfigPaths({
-      projects: ['tsconfig.spec.json'],
-      ignoreConfigErrors: true,
-    }),
-  ],
+  resolve: {
+    tsconfigPaths: true,
+  },
   test: {
     testTimeout: 120_000,
     hookTimeout: 120_000,

--- a/packages/twenty-client-sdk/package.json
+++ b/packages/twenty-client-sdk/package.json
@@ -62,7 +62,6 @@
     "typescript": "^5.9.3",
     "vite": "^8.0.0",
     "vite-plugin-dts": "^4.5.4",
-    "vite-tsconfig-paths": "^4.2.1",
     "vitest": "^4.1.0"
   },
   "engines": {

--- a/packages/twenty-client-sdk/vite.config.ts
+++ b/packages/twenty-client-sdk/vite.config.ts
@@ -1,6 +1,5 @@
 import path from 'path';
 import { defineConfig } from 'vite';
-import tsconfigPaths from 'vite-tsconfig-paths';
 import packageJson from './package.json';
 
 const entries = [
@@ -51,15 +50,11 @@ export default defineConfig(() => {
     root: __dirname,
     cacheDir: '../../node_modules/.vite/packages/twenty-client-sdk',
     resolve: {
+      tsconfigPaths: true,
       alias: {
         '@/': path.resolve(__dirname, 'src') + '/',
       },
     },
-    plugins: [
-      tsconfigPaths({
-        root: __dirname,
-      }),
-    ],
     build: {
       emptyOutDir: false,
       outDir: 'dist',

--- a/packages/twenty-emails/vite.config.ts
+++ b/packages/twenty-emails/vite.config.ts
@@ -5,7 +5,6 @@ import react from '@vitejs/plugin-react-swc';
 import * as path from 'path';
 import { APP_LOCALES } from 'twenty-shared/translations';
 import { defineConfig, type Plugin } from 'vite';
-import tsconfigPaths from 'vite-tsconfig-paths';
 
 // twenty-emails bundles its deps (the Node server that consumes it doesn't have
 // @react-email et al.) but runs in Node. A plain client/lib build under Vite 8
@@ -41,6 +40,7 @@ export default defineConfig({
   cacheDir: '../../node_modules/.vite/packages/twenty-emails',
 
   resolve: {
+    tsconfigPaths: true,
     alias: {
       '@/': path.resolve(__dirname, 'src') + '/',
       'src/': path.resolve(__dirname, 'src') + '/',
@@ -60,9 +60,6 @@ export default defineConfig({
     }),
     lingui({
       configPath: path.resolve(__dirname, './lingui.config.ts'),
-    }),
-    tsconfigPaths({
-      root: __dirname,
     }),
   ],
 

--- a/packages/twenty-front-component-renderer/.storybook/main.ts
+++ b/packages/twenty-front-component-renderer/.storybook/main.ts
@@ -1,14 +1,11 @@
 import type { StorybookConfig } from '@storybook/react-vite';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
-import tsconfigPaths from 'vite-tsconfig-paths';
 
 const dirname =
   typeof __dirname !== 'undefined'
     ? __dirname
     : path.dirname(fileURLToPath(import.meta.url));
-
-const packageRoot = path.resolve(dirname, '..');
 
 const config: StorybookConfig = {
   stories: ['../src/**/*.stories.@(js|jsx|ts|tsx)'],
@@ -37,6 +34,7 @@ const config: StorybookConfig = {
       ...viteConfig,
       resolve: {
         ...viteConfig.resolve,
+        tsconfigPaths: true,
         alias: {
           ...viteConfig.resolve?.alias,
           '@': path.resolve(dirname, '../src'),
@@ -55,10 +53,6 @@ const config: StorybookConfig = {
           ),
         },
       },
-      plugins: [
-        ...(viteConfig.plugins ?? []),
-        tsconfigPaths({ root: packageRoot }),
-      ],
       optimizeDeps: {
         ...viteConfig.optimizeDeps,
         include: [

--- a/packages/twenty-front-component-renderer/package.json
+++ b/packages/twenty-front-component-renderer/package.json
@@ -50,8 +50,7 @@
     "twenty-sdk": "workspace:*",
     "twenty-shared": "workspace:*",
     "twenty-ui": "workspace:*",
-    "vite-plugin-dts": "^4.5.4",
-    "vite-tsconfig-paths": "^4.2.1"
+    "vite-plugin-dts": "^4.5.4"
   },
   "engines": {
     "node": "^24.5.0",

--- a/packages/twenty-front-component-renderer/vite.config.ts
+++ b/packages/twenty-front-component-renderer/vite.config.ts
@@ -1,7 +1,6 @@
 import path from 'path';
 import { type PackageJson } from 'type-fest';
 import { defineConfig } from 'vite';
-import tsconfigPaths from 'vite-tsconfig-paths';
 
 import packageJson from './package.json';
 
@@ -11,15 +10,11 @@ export default defineConfig(() => {
     cacheDir:
       '../../node_modules/.vite/packages/twenty-front-component-renderer',
     resolve: {
+      tsconfigPaths: true,
       alias: {
         '@/': path.resolve(__dirname, 'src') + '/',
       },
     },
-    plugins: [
-      tsconfigPaths({
-        root: __dirname,
-      }),
-    ],
     worker: {
       format: 'iife',
       rollupOptions: {

--- a/packages/twenty-front/package.json
+++ b/packages/twenty-front/package.json
@@ -204,7 +204,6 @@
     "storybook-addon-mock-date": "2.0.0",
     "storybook-addon-pseudo-states": "^10.3.3",
     "ts-jest": "^29.1.1",
-    "vite-plugin-svgr": "^4.3.0",
-    "vite-tsconfig-paths": "^4.2.1"
+    "vite-plugin-svgr": "^4.3.0"
   }
 }

--- a/packages/twenty-front/vite.config.ts
+++ b/packages/twenty-front/vite.config.ts
@@ -12,7 +12,6 @@ import {
   searchForWorkspaceRoot,
 } from 'vite';
 import svgr from 'vite-plugin-svgr';
-import tsconfigPaths from 'vite-tsconfig-paths';
 
 import { createWywProfilingPlugin } from 'twenty-shared/vite';
 
@@ -73,10 +72,6 @@ export default defineConfig(({ mode }) => {
     plugins: [
       react({
         plugins: [['@lingui/swc-plugin', {}]],
-      }),
-      tsconfigPaths({
-        root: __dirname,
-        projects: ['tsconfig.json'],
       }),
       svgr(),
       lingui({
@@ -260,10 +255,11 @@ export default defineConfig(({ mode }) => {
       },
     },
     resolve: {
+      tsconfigPaths: true,
       alias: [
         // wyw-in-js 1.x resolves modules in its CSS evaluator via vite's
-        // resolve.alias (it no longer picks up vite-tsconfig-paths), so the
-        // `@/` and `~/` tsconfig path aliases must be mirrored here.
+        // resolve.alias (not resolve.tsconfigPaths), so the `@/` and `~/`
+        // tsconfig path aliases must be mirrored here.
         { find: /^@\//, replacement: path.resolve(__dirname, 'src/modules') + '/' },
         { find: /^~\//, replacement: path.resolve(__dirname, 'src') + '/' },
         { find: 'path', replacement: 'rollup-plugin-node-polyfills/polyfills/path' },

--- a/packages/twenty-sdk/package.json
+++ b/packages/twenty-sdk/package.json
@@ -109,7 +109,6 @@
     "twenty-ui": "workspace:*",
     "vite": "^8.0.0",
     "vite-plugin-dts": "^4.5.4",
-    "vite-tsconfig-paths": "^4.2.1",
     "wait-on": "^9.0.10"
   },
   "engines": {

--- a/packages/twenty-sdk/vite.config.billing.ts
+++ b/packages/twenty-sdk/vite.config.billing.ts
@@ -1,7 +1,6 @@
 import path from 'path';
 import { type PackageJson } from 'type-fest';
 import { defineConfig } from 'vite';
-import tsconfigPaths from 'vite-tsconfig-paths';
 
 import packageJson from './package.json';
 
@@ -10,15 +9,11 @@ export default defineConfig(() => {
     root: __dirname,
     cacheDir: '../../node_modules/.vite/packages/twenty-sdk-billing',
     resolve: {
+      tsconfigPaths: true,
       alias: {
         '@/': path.resolve(__dirname, 'src') + '/',
       },
     },
-    plugins: [
-      tsconfigPaths({
-        root: __dirname,
-      }),
-    ],
     build: {
       emptyOutDir: false,
       outDir: 'dist/billing',

--- a/packages/twenty-sdk/vite.config.browser.ts
+++ b/packages/twenty-sdk/vite.config.browser.ts
@@ -1,7 +1,6 @@
 import path from 'path';
 import { type PackageJson } from 'type-fest';
 import { defineConfig } from 'vite';
-import tsconfigPaths from 'vite-tsconfig-paths';
 
 import packageJson from './package.json';
 
@@ -10,15 +9,11 @@ export default defineConfig(() => {
     root: __dirname,
     cacheDir: '../../node_modules/.vite/packages/twenty-sdk-browser',
     resolve: {
+      tsconfigPaths: true,
       alias: {
         '@/': path.resolve(__dirname, 'src') + '/',
       },
     },
-    plugins: [
-      tsconfigPaths({
-        root: __dirname,
-      }),
-    ],
     build: {
       emptyOutDir: false,
       outDir: 'dist',

--- a/packages/twenty-sdk/vite.config.define.ts
+++ b/packages/twenty-sdk/vite.config.define.ts
@@ -1,7 +1,6 @@
 import path from 'path';
 import { type PackageJson } from 'type-fest';
 import { defineConfig } from 'vite';
-import tsconfigPaths from 'vite-tsconfig-paths';
 
 import packageJson from './package.json';
 
@@ -10,15 +9,11 @@ export default defineConfig(() => {
     root: __dirname,
     cacheDir: '../../node_modules/.vite/packages/twenty-sdk-define',
     resolve: {
+      tsconfigPaths: true,
       alias: {
         '@/': path.resolve(__dirname, 'src') + '/',
       },
     },
-    plugins: [
-      tsconfigPaths({
-        root: __dirname,
-      }),
-    ],
     build: {
       emptyOutDir: false,
       outDir: 'dist/define',

--- a/packages/twenty-sdk/vite.config.front-component.ts
+++ b/packages/twenty-sdk/vite.config.front-component.ts
@@ -1,7 +1,6 @@
 import path from 'path';
 import { type PackageJson } from 'type-fest';
 import { defineConfig } from 'vite';
-import tsconfigPaths from 'vite-tsconfig-paths';
 
 import packageJson from './package.json';
 
@@ -10,15 +9,11 @@ export default defineConfig(() => {
     root: __dirname,
     cacheDir: '../../node_modules/.vite/packages/twenty-sdk-front-component',
     resolve: {
+      tsconfigPaths: true,
       alias: {
         '@/': path.resolve(__dirname, 'src') + '/',
       },
     },
-    plugins: [
-      tsconfigPaths({
-        root: __dirname,
-      }),
-    ],
     build: {
       emptyOutDir: false,
       outDir: 'dist/front-component',

--- a/packages/twenty-sdk/vite.config.logic-function.ts
+++ b/packages/twenty-sdk/vite.config.logic-function.ts
@@ -1,7 +1,6 @@
 import path from 'path';
 import { type PackageJson } from 'type-fest';
 import { defineConfig } from 'vite';
-import tsconfigPaths from 'vite-tsconfig-paths';
 
 import packageJson from './package.json';
 
@@ -10,15 +9,11 @@ export default defineConfig(() => {
     root: __dirname,
     cacheDir: '../../node_modules/.vite/packages/twenty-sdk-logic-function',
     resolve: {
+      tsconfigPaths: true,
       alias: {
         '@/': path.resolve(__dirname, 'src') + '/',
       },
     },
-    plugins: [
-      tsconfigPaths({
-        root: __dirname,
-      }),
-    ],
     build: {
       emptyOutDir: false,
       outDir: 'dist/logic-function',

--- a/packages/twenty-sdk/vite.config.node.ts
+++ b/packages/twenty-sdk/vite.config.node.ts
@@ -2,7 +2,6 @@ import fs from 'fs';
 import path from 'path';
 import { type PackageJson } from 'type-fest';
 import { defineConfig } from 'vite';
-import tsconfigPaths from 'vite-tsconfig-paths';
 
 import packageJson from './package.json';
 
@@ -25,16 +24,12 @@ export default defineConfig(() => {
     root: __dirname,
     cacheDir: '../../node_modules/.vite/packages/twenty-sdk-node',
     resolve: {
+      tsconfigPaths: true,
       alias: {
         '@/': path.resolve(__dirname, 'src') + '/',
       },
     },
-    plugins: [
-      tsconfigPaths({
-        root: __dirname,
-      }),
-      copyCoverAssetsPlugin(),
-    ],
+    plugins: [copyCoverAssetsPlugin()],
     build: {
       emptyOutDir: false,
       outDir: 'dist',

--- a/packages/twenty-sdk/vite.config.utils.ts
+++ b/packages/twenty-sdk/vite.config.utils.ts
@@ -1,7 +1,6 @@
 import path from 'path';
 import { type PackageJson } from 'type-fest';
 import { defineConfig } from 'vite';
-import tsconfigPaths from 'vite-tsconfig-paths';
 
 import packageJson from './package.json';
 
@@ -10,15 +9,11 @@ export default defineConfig(() => {
     root: __dirname,
     cacheDir: '../../node_modules/.vite/packages/twenty-sdk-utils',
     resolve: {
+      tsconfigPaths: true,
       alias: {
         '@/': path.resolve(__dirname, 'src') + '/',
       },
     },
-    plugins: [
-      tsconfigPaths({
-        root: __dirname,
-      }),
-    ],
     build: {
       emptyOutDir: false,
       outDir: 'dist/utils',

--- a/packages/twenty-sdk/vitest.config.ts
+++ b/packages/twenty-sdk/vitest.config.ts
@@ -1,13 +1,9 @@
-import tsconfigPaths from 'vite-tsconfig-paths';
 import { defineConfig } from 'vitest/config';
 
 export default defineConfig({
-  plugins: [
-    tsconfigPaths({
-      root: __dirname,
-      ignoreConfigErrors: true,
-    }),
-  ],
+  resolve: {
+    tsconfigPaths: true,
+  },
   test: {
     name: 'twenty-sdk',
     environment: 'node',

--- a/packages/twenty-sdk/vitest.e2e.config.ts
+++ b/packages/twenty-sdk/vitest.e2e.config.ts
@@ -1,13 +1,9 @@
-import tsconfigPaths from 'vite-tsconfig-paths';
 import { defineConfig } from 'vitest/config';
 
 export default defineConfig({
-  plugins: [
-    tsconfigPaths({
-      root: __dirname,
-      ignoreConfigErrors: true,
-    }),
-  ],
+  resolve: {
+    tsconfigPaths: true,
+  },
   test: {
     name: 'twenty-sdk-e2e',
     environment: 'node',

--- a/packages/twenty-sdk/vitest.integration.config.ts
+++ b/packages/twenty-sdk/vitest.integration.config.ts
@@ -1,13 +1,9 @@
-import tsconfigPaths from 'vite-tsconfig-paths';
 import { defineConfig } from 'vitest/config';
 
 export default defineConfig({
-  plugins: [
-    tsconfigPaths({
-      root: __dirname,
-      ignoreConfigErrors: true,
-    }),
-  ],
+  resolve: {
+    tsconfigPaths: true,
+  },
   test: {
     name: 'twenty-sdk-integration',
     environment: 'node',

--- a/packages/twenty-sdk/vitest.unit.config.ts
+++ b/packages/twenty-sdk/vitest.unit.config.ts
@@ -1,13 +1,9 @@
-import tsconfigPaths from 'vite-tsconfig-paths';
 import { defineConfig } from 'vitest/config';
 
 export default defineConfig({
-  plugins: [
-    tsconfigPaths({
-      root: __dirname,
-      ignoreConfigErrors: true,
-    }),
-  ],
+  resolve: {
+    tsconfigPaths: true,
+  },
   test: {
     name: 'twenty-sdk-unit',
     environment: 'node',

--- a/packages/twenty-shared/package.json
+++ b/packages/twenty-shared/package.json
@@ -39,8 +39,7 @@
     "tsx": "^4.19.3",
     "typescript": "^5.9.3",
     "vite": "^8.0.0",
-    "vite-plugin-dts": "^4.5.4",
-    "vite-tsconfig-paths": "^4.2.1"
+    "vite-plugin-dts": "^4.5.4"
   },
   "dependencies": {
     "@dagrejs/dagre": "^1.1.8",

--- a/packages/twenty-shared/vite.config.individual.ts
+++ b/packages/twenty-shared/vite.config.individual.ts
@@ -1,6 +1,5 @@
 import path from 'path';
 import { type UserConfig, defineConfig } from 'vite';
-import tsconfigPaths from 'vite-tsconfig-paths';
 import packageJson from './package.json';
 
 const submodules = Object.keys((packageJson as any).exports || {})
@@ -32,15 +31,11 @@ export default defineConfig((): UserConfig => {
     root: __dirname,
     cacheDir: '../../node_modules/.vite/packages/twenty-shared-individual',
     resolve: {
+      tsconfigPaths: true,
       alias: {
         '@/': path.resolve(__dirname, 'src') + '/',
       },
     },
-    plugins: [
-      tsconfigPaths({
-        root: __dirname,
-      }),
-    ],
     build: {
       minify: 'esbuild',
       sourcemap: true,

--- a/packages/twenty-shared/vite.config.ts
+++ b/packages/twenty-shared/vite.config.ts
@@ -1,7 +1,6 @@
 // @ts-expect-error: no type declarations for path in this config
 import path from 'path';
 import { defineConfig } from 'vite';
-import tsconfigPaths from 'vite-tsconfig-paths';
 // @ts-expect-error: importing JSON without resolveJsonModule
 import packageJson from './package.json';
 
@@ -39,15 +38,11 @@ export default defineConfig(() => {
     root: __dirname,
     cacheDir: '../../node_modules/.vite/packages/twenty-shared',
     resolve: {
+      tsconfigPaths: true,
       alias: {
         '@/': path.resolve(__dirname, 'src') + '/',
       },
     },
-    plugins: [
-      tsconfigPaths({
-        root: __dirname,
-      }),
-    ],
     build: {
       emptyOutDir: false,
       outDir: 'dist',

--- a/packages/twenty-ui/package.json
+++ b/packages/twenty-ui/package.json
@@ -67,7 +67,6 @@
     "vite-plugin-dts": "^4.5.4",
     "vite-plugin-sass-dts": "^1.3.31",
     "vite-plugin-svgr": "^4.3.0",
-    "vite-tsconfig-paths": "^4.2.1",
     "vitest": "^4.1.0"
   },
   "dependencies": {

--- a/packages/twenty-ui/vite.config.individual.ts
+++ b/packages/twenty-ui/vite.config.individual.ts
@@ -2,7 +2,6 @@ import react from '@vitejs/plugin-react-swc';
 import * as path from 'path';
 import { defineConfig } from 'vite';
 import svgr from 'vite-plugin-svgr';
-import tsconfigPaths from 'vite-tsconfig-paths';
 
 import packageJson from './package.json';
 
@@ -17,6 +16,7 @@ const isExternal = (id: string): boolean =>
 export default defineConfig(() => {
   return {
     resolve: {
+      tsconfigPaths: true,
       alias: {
         '@ui/': path.resolve(__dirname, 'src') + '/',
         '@assets/': path.resolve(__dirname, 'src/assets') + '/',
@@ -45,10 +45,6 @@ export default defineConfig(() => {
     assetsInclude: ['src/**/*.svg'],
     plugins: [
       react(),
-      tsconfigPaths({
-        root: __dirname,
-        projects: ['tsconfig.json'],
-      }),
       svgr(),
     ],
     build: {

--- a/packages/twenty-ui/vite.config.individual.ts
+++ b/packages/twenty-ui/vite.config.individual.ts
@@ -43,10 +43,7 @@ export default defineConfig(() => {
     root: __dirname,
     cacheDir: '../../node_modules/.vite/packages/twenty-ui-individual',
     assetsInclude: ['src/**/*.svg'],
-    plugins: [
-      react(),
-      svgr(),
-    ],
+    plugins: [react(), svgr()],
     build: {
       cssCodeSplit: false,
       minify: 'esbuild',

--- a/packages/twenty-ui/vite.config.ts
+++ b/packages/twenty-ui/vite.config.ts
@@ -6,7 +6,6 @@ import checker from 'vite-plugin-checker';
 import dts, { type PluginOptions } from 'vite-plugin-dts';
 import sassDts from 'vite-plugin-sass-dts';
 import svgr from 'vite-plugin-svgr';
-import tsconfigPaths from 'vite-tsconfig-paths';
 
 type Checkers = Parameters<typeof checker>[0];
 
@@ -64,6 +63,7 @@ export default defineConfig(({ command }) => {
 
   return {
     resolve: {
+      tsconfigPaths: true,
       alias: {
         '@ui/': path.resolve(__dirname, 'src') + '/',
         '@assets/': path.resolve(__dirname, 'src/assets') + '/',
@@ -105,10 +105,6 @@ export default defineConfig(({ command }) => {
     assetsInclude: ['src/**/*.svg'],
     plugins: [
       react(),
-      tsconfigPaths({
-        root: __dirname,
-        projects: ['tsconfig.json'],
-      }),
       svgr(),
       // Generates typed *.module.scss.d.ts siblings (dev mode only — backed by
       // sass-embedded). CI/build relies on the ambient src/scss-modules.d.ts.

--- a/packages/twenty-zapier/package.json
+++ b/packages/twenty-zapier/package.json
@@ -28,7 +28,6 @@
     "twenty-shared": "workspace:*",
     "vite": "^8.0.0",
     "vite-plugin-dts": "^4.5.4",
-    "vite-tsconfig-paths": "^4.2.1",
     "zapier-platform-cli": "^19.0.0"
   }
 }

--- a/packages/twenty-zapier/vite.config.ts
+++ b/packages/twenty-zapier/vite.config.ts
@@ -1,6 +1,5 @@
 import { defineConfig } from 'vite';
 
-import tsconfigPaths from 'vite-tsconfig-paths';
 import packageJson from './package.json';
 import type { PackageJson } from 'type-fest';
 
@@ -29,11 +28,9 @@ export default defineConfig(() => {
   return {
     root: __dirname,
     cacheDir: '../../node_modules/.vite/packages/twenty-zapier',
-    plugins: [
-      tsconfigPaths({
-        root: __dirname,
-      }),
-    ],
+    resolve: {
+      tsconfigPaths: true,
+    },
     build: {
       emptyOutDir: false,
       outDir: 'lib',

--- a/yarn.lock
+++ b/yarn.lock
@@ -29277,7 +29277,6 @@ __metadata:
     uuid: "npm:^13.0.2"
     vite: "npm:^8.0.0"
     vite-plugin-dts: "npm:^4.5.4"
-    vite-tsconfig-paths: "npm:^4.2.1"
   bin:
     create-twenty-app: dist/cli.cjs
   languageName: unknown
@@ -34278,13 +34277,6 @@ __metadata:
     slash: "npm:^5.1.0"
     unicorn-magic: "npm:^0.4.0"
   checksum: 10c0/fc0675e01dc1da5095f30dccc46a3047fc38d45ca08c21c1aa871bd79d38682f507d84a159be168019db5fffaa09c5663c3679c29190a2d4f999dc91d7ff6406
-  languageName: node
-  linkType: hard
-
-"globrex@npm:^0.1.2":
-  version: 0.1.2
-  resolution: "globrex@npm:0.1.2"
-  checksum: 10c0/a54c029520cf58bda1d8884f72bd49b4cd74e977883268d931fd83bcbd1a9eb96d57c7dbd4ad80148fb9247467ebfb9b215630b2ed7563b2a8de02e1ff7f89d1
   languageName: node
   linkType: hard
 
@@ -52162,20 +52154,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"tsconfck@npm:^3.0.3":
-  version: 3.1.1
-  resolution: "tsconfck@npm:3.1.1"
-  peerDependencies:
-    typescript: ^5.0.0
-  peerDependenciesMeta:
-    typescript:
-      optional: true
-  bin:
-    tsconfck: bin/tsconfck.js
-  checksum: 10c0/e133eb308ba37e8db8dbac1905bddaaf4a62f0e01aa88143e19867e274a877b86b35cf69c9a0172ca3e7d1a4bb32400381ac7f7a1429e34250a8d7ae55aee3e7
-  languageName: node
-  linkType: hard
-
 "tsconfig-paths-webpack-plugin@npm:4.2.0":
   version: 4.2.0
   resolution: "tsconfig-paths-webpack-plugin@npm:4.2.0"
@@ -52304,7 +52282,6 @@ __metadata:
     typescript: "npm:^5.9.3"
     vite: "npm:^8.0.0"
     vite-plugin-dts: "npm:^4.5.4"
-    vite-tsconfig-paths: "npm:^4.2.1"
     vitest: "npm:^4.1.0"
   languageName: unknown
   linkType: soft
@@ -52430,7 +52407,6 @@ __metadata:
     twenty-shared: "workspace:*"
     twenty-ui: "workspace:*"
     vite-plugin-dts: "npm:^4.5.4"
-    vite-tsconfig-paths: "npm:^4.2.1"
     zod: "npm:^4.1.11"
   languageName: unknown
   linkType: soft
@@ -52611,7 +52587,6 @@ __metadata:
     use-debounce: "npm:^10.0.0"
     uuid: "npm:^11.1.1"
     vite-plugin-svgr: "npm:^4.3.0"
-    vite-tsconfig-paths: "npm:^4.2.1"
     xlsx-ugnis: "npm:^0.19.3"
     zod: "npm:^4.1.11"
   languageName: unknown
@@ -52665,7 +52640,6 @@ __metadata:
     uuid: "npm:^13.0.2"
     vite: "npm:^8.0.0"
     vite-plugin-dts: "npm:^4.5.4"
-    vite-tsconfig-paths: "npm:^4.2.1"
     wait-on: "npm:^9.0.10"
   bin:
     twenty: dist/cli.cjs
@@ -52932,7 +52906,6 @@ __metadata:
     uuid: "npm:^11.1.1"
     vite: "npm:^8.0.0"
     vite-plugin-dts: "npm:^4.5.4"
-    vite-tsconfig-paths: "npm:^4.2.1"
     zod: "npm:^4.1.11"
   languageName: unknown
   linkType: soft
@@ -52988,7 +52961,6 @@ __metadata:
     vite-plugin-dts: "npm:^4.5.4"
     vite-plugin-sass-dts: "npm:^1.3.31"
     vite-plugin-svgr: "npm:^4.3.0"
-    vite-tsconfig-paths: "npm:^4.2.1"
     vitest: "npm:^4.1.0"
     zod: "npm:^4.1.11"
   peerDependencies:
@@ -53068,7 +53040,6 @@ __metadata:
     twenty-shared: "workspace:*"
     vite: "npm:^8.0.0"
     vite-plugin-dts: "npm:^4.5.4"
-    vite-tsconfig-paths: "npm:^4.2.1"
     zapier-platform-cli: "npm:^19.0.0"
     zapier-platform-core: "npm:19.0.0"
     zod: "npm:^4.1.11"
@@ -54722,22 +54693,6 @@ __metadata:
   peerDependencies:
     vite: ">=2.6.0"
   checksum: 10c0/3e1959fec626bb4f5a8ec13ff15bc40ffbc1c0ff38149bebe3f37dc2d67ed1f276f129ff7983e06946cf712e19996affd9d6868aa7d20d8921d1fe4449109b55
-  languageName: node
-  linkType: hard
-
-"vite-tsconfig-paths@npm:^4.2.1":
-  version: 4.3.2
-  resolution: "vite-tsconfig-paths@npm:4.3.2"
-  dependencies:
-    debug: "npm:^4.1.1"
-    globrex: "npm:^0.1.2"
-    tsconfck: "npm:^3.0.3"
-  peerDependencies:
-    vite: "*"
-  peerDependenciesMeta:
-    vite:
-      optional: true
-  checksum: 10c0/f390ac1d1c3992fc5ac50f9274c1090f8b55ab34a89ea88893db9a6924a3b26c9f64bc1163615150ad100749db73b6b2cf1d57f6cd60df6e762ceb5b8ad30024
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
### Summary
Migrates main monorepo packages from the `vite-tsconfig-paths` plugin to vite’s built-in path resolution.

Vite 8 showing this warning when the plugin is detected:
> The plugin "vite-tsconfig-paths" is detected. Vite now supports tsconfig paths resolution natively via the resolve.tsconfigPaths option. You can remove the plugin and set resolve.tsconfigPaths: true in your Vite config instead.

### References
- https://vite.dev/config/shared-options#resolve-tsconfigpaths
- https://vite.dev/guide/features#paths
- https://github.com/vitejs/vite/pull/21781

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/22100?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

