### PR TITLE
fix(server): scope server-route target dispatch to the resolver's application

### DIFF
--- a/packages/twenty-server/src/engine/core-modules/server-route-trigger/__tests__/server-route-trigger.service.spec.ts
+++ b/packages/twenty-server/src/engine/core-modules/server-route-trigger/__tests__/server-route-trigger.service.spec.ts
@@ -171,14 +171,20 @@ describe('ServerRouteTriggerService', () => {
         id: 'tenant-copy',
         workspaceId: 'tenant-ws',
         application: {
-          applicationRegistration: { id: 'reg-1', ownerWorkspaceId: 'owner-ws' },
+          applicationRegistration: {
+            id: 'reg-1',
+            ownerWorkspaceId: 'owner-ws',
+          },
         },
       }),
       buildResolverRow({
         id: 'owner-copy',
         workspaceId: 'owner-ws',
         application: {
-          applicationRegistration: { id: 'reg-1', ownerWorkspaceId: 'owner-ws' },
+          applicationRegistration: {
+            id: 'reg-1',
+            ownerWorkspaceId: 'owner-ws',
+          },
         },
       }),
       // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/packages/twenty-server/src/engine/core-modules/server-route-trigger/__tests__/server-route-trigger.service.spec.ts
+++ b/packages/twenty-server/src/engine/core-modules/server-route-trigger/__tests__/server-route-trigger.service.spec.ts
@@ -69,7 +69,7 @@ describe('ServerRouteTriggerService', () => {
     workspaceId: 'owner-ws',
     serverRouteTriggerSettings: { forwardedRequestHeaders: ['x-test'] },
     application: {
-      applicationRegistration: { ownerWorkspaceId: 'owner-ws' },
+      applicationRegistration: { id: 'reg-1', ownerWorkspaceId: 'owner-ws' },
     },
     ...overrides,
   });
@@ -171,14 +171,14 @@ describe('ServerRouteTriggerService', () => {
         id: 'tenant-copy',
         workspaceId: 'tenant-ws',
         application: {
-          applicationRegistration: { ownerWorkspaceId: 'owner-ws' },
+          applicationRegistration: { id: 'reg-1', ownerWorkspaceId: 'owner-ws' },
         },
       }),
       buildResolverRow({
         id: 'owner-copy',
         workspaceId: 'owner-ws',
         application: {
-          applicationRegistration: { ownerWorkspaceId: 'owner-ws' },
+          applicationRegistration: { id: 'reg-1', ownerWorkspaceId: 'owner-ws' },
         },
       }),
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -320,6 +320,59 @@ describe('ServerRouteTriggerService', () => {
 
     await expect(handle()).rejects.toMatchObject({
       code: ServerRouteTriggerExceptionCode.RATE_LIMIT_EXCEEDED,
+    });
+  });
+
+  it('scopes the target lookup to the resolver application registration', async () => {
+    await handle();
+
+    // First findOne resolves the resolver (no registration scoping); the
+    // second resolves the target and must be constrained to the resolver's
+    // own application registration so it cannot reach another app's functions
+    // or a workspace where the app is not installed.
+    expect(logicFunctionRepository.findOne).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({
+        where: expect.objectContaining({
+          universalIdentifier: TARGET_UID,
+          workspaceId: 'target-ws',
+          application: { applicationRegistrationId: 'reg-1' },
+        }),
+      }),
+    );
+  });
+
+  it('throws LOGIC_FUNCTION_NOT_FOUND when the resolver is not linked to an application registration', async () => {
+    logicFunctionRepository.find.mockResolvedValue([
+      buildResolverRow({
+        application: {
+          applicationRegistration: { ownerWorkspaceId: 'owner-ws' },
+        },
+      }),
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    ] as any);
+
+    await expect(handle()).rejects.toMatchObject({
+      code: ServerRouteTriggerExceptionCode.LOGIC_FUNCTION_NOT_FOUND,
+    });
+  });
+
+  it('does not leak the raw executor error message to the caller', async () => {
+    logicFunctionExecutorService.execute.mockReset();
+    logicFunctionExecutorService.execute
+      .mockResolvedValueOnce(
+        buildExecuteResult({
+          workspaceId: 'target-ws',
+          targetLogicFunctionUniversalIdentifier: TARGET_UID,
+        }),
+      )
+      .mockRejectedValueOnce(
+        new Error('internal: connection to lambda-internal:5000 refused'),
+      );
+
+    await expect(handle()).rejects.toMatchObject({
+      code: ServerRouteTriggerExceptionCode.SERVER_ROUTE_PLATFORM_ERROR,
+      message: 'An unexpected error occurred while handling the server route',
     });
   });
 });

--- a/packages/twenty-server/src/engine/core-modules/server-route-trigger/__tests__/server-route-trigger.service.spec.ts
+++ b/packages/twenty-server/src/engine/core-modules/server-route-trigger/__tests__/server-route-trigger.service.spec.ts
@@ -326,10 +326,6 @@ describe('ServerRouteTriggerService', () => {
   it('scopes the target lookup to the resolver application registration', async () => {
     await handle();
 
-    // First findOne resolves the resolver (no registration scoping); the
-    // second resolves the target and must be constrained to the resolver's
-    // own application registration so it cannot reach another app's functions
-    // or a workspace where the app is not installed.
     expect(logicFunctionRepository.findOne).toHaveBeenNthCalledWith(
       2,
       expect.objectContaining({

--- a/packages/twenty-server/src/engine/core-modules/server-route-trigger/server-route-trigger.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/server-route-trigger/server-route-trigger.service.ts
@@ -66,6 +66,20 @@ export class ServerRouteTriggerService {
       );
     }
 
+    // The application registration the resolver belongs to is the trust
+    // boundary: the resolver may only dispatch to a target that belongs to the
+    // same registration. findResolver already guarantees this relation is
+    // loaded for the selected candidate.
+    const applicationRegistrationId =
+      resolver.application?.applicationRegistration?.id;
+
+    if (!isDefined(applicationRegistrationId)) {
+      throw new ServerRouteTriggerException(
+        `Server resolver function ${resolverLogicFunctionUniversalIdentifier} is not linked to an application registration`,
+        ServerRouteTriggerExceptionCode.LOGIC_FUNCTION_NOT_FOUND,
+      );
+    }
+
     const event = buildLogicFunctionEvent({
       request,
       pathParameters: {},
@@ -81,11 +95,16 @@ export class ServerRouteTriggerService {
     });
     const resolved = this.parseResolverResult(resolverResult);
 
+    // Scope the target to the resolver's own application registration. This
+    // enforces tenant isolation: the resolver cannot reach a function from a
+    // different application, nor a workspace where its application is not
+    // installed (no installed copy means no matching row).
     const targetResult = await this.runFunction({
       logicFunctionUniversalIdentifier:
         resolved.targetLogicFunctionUniversalIdentifier,
       workspaceId: resolved.workspaceId,
       payload: resolved.payload ?? event,
+      applicationRegistrationId,
     });
 
     if (isDefined(targetResult.error)) {
@@ -160,16 +179,24 @@ export class ServerRouteTriggerService {
     logicFunctionUniversalIdentifier,
     workspaceId,
     payload,
+    applicationRegistrationId,
   }: {
     logicFunctionUniversalIdentifier: string;
     workspaceId: string;
     payload: object;
+    applicationRegistrationId?: string;
   }): Promise<{ data: object | null; error?: { errorMessage: string } }> {
     const logicFunction = await this.logicFunctionRepository.findOne({
       where: {
         universalIdentifier: logicFunctionUniversalIdentifier,
         workspaceId,
+        ...(isDefined(applicationRegistrationId)
+          ? { application: { applicationRegistrationId } }
+          : {}),
       },
+      ...(isDefined(applicationRegistrationId)
+        ? { relations: { application: true } }
+        : {}),
     });
 
     if (!isDefined(logicFunction)) {
@@ -190,10 +217,28 @@ export class ServerRouteTriggerService {
         `Server logic function ${logicFunction.id} failed in workspace ${workspaceId}: ${error instanceof Error ? error.message : String(error)}`,
         error instanceof Error ? error.stack : undefined,
       );
+      // Do not surface raw executor/internal error messages to the
+      // (unauthenticated) caller — log the detail above and return a generic
+      // message keyed off the mapped code instead.
+      const code = this.mapExecutorErrorToServerRouteCode(error);
+
       throw new ServerRouteTriggerException(
-        error instanceof Error ? error.message : String(error),
-        this.mapExecutorErrorToServerRouteCode(error),
+        this.getPublicErrorMessageForCode(code),
+        code,
       );
+    }
+  }
+
+  private getPublicErrorMessageForCode(
+    code: ServerRouteTriggerExceptionCode,
+  ): string {
+    switch (code) {
+      case ServerRouteTriggerExceptionCode.RATE_LIMIT_EXCEEDED:
+        return 'Rate limit exceeded';
+      case ServerRouteTriggerExceptionCode.LOGIC_FUNCTION_NOT_FOUND:
+        return 'Logic function not found';
+      default:
+        return 'An unexpected error occurred while handling the server route';
     }
   }
 

--- a/packages/twenty-server/src/engine/core-modules/server-route-trigger/server-route-trigger.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/server-route-trigger/server-route-trigger.service.ts
@@ -66,10 +66,6 @@ export class ServerRouteTriggerService {
       );
     }
 
-    // The application registration the resolver belongs to is the trust
-    // boundary: the resolver may only dispatch to a target that belongs to the
-    // same registration. findResolver already guarantees this relation is
-    // loaded for the selected candidate.
     const applicationRegistrationId =
       resolver.application?.applicationRegistration?.id;
 
@@ -95,10 +91,6 @@ export class ServerRouteTriggerService {
     });
     const resolved = this.parseResolverResult(resolverResult);
 
-    // Scope the target to the resolver's own application registration. This
-    // enforces tenant isolation: the resolver cannot reach a function from a
-    // different application, nor a workspace where its application is not
-    // installed (no installed copy means no matching row).
     const targetResult = await this.runFunction({
       logicFunctionUniversalIdentifier:
         resolved.targetLogicFunctionUniversalIdentifier,
@@ -217,9 +209,6 @@ export class ServerRouteTriggerService {
         `Server logic function ${logicFunction.id} failed in workspace ${workspaceId}: ${error instanceof Error ? error.message : String(error)}`,
         error instanceof Error ? error.stack : undefined,
       );
-      // Do not surface raw executor/internal error messages to the
-      // (unauthenticated) caller — log the detail above and return a generic
-      // message keyed off the mapped code instead.
       const code = this.mapExecutorErrorToServerRouteCode(error);
 
       throw new ServerRouteTriggerException(


### PR DESCRIPTION
## Summary

Security follow-up to #22002 (server-exposed logic functions). That PR's `ServerRouteTriggerService` resolved the **target** logic function by `(universalIdentifier, workspaceId)` alone, with no application scoping:

```ts
// before
const logicFunction = await this.logicFunctionRepository.findOne({
  where: { universalIdentifier, workspaceId },
});
```

Both values come straight from the resolver's return value. Because the only gate was "a function with that UID exists in that workspace", a resolver (owner-workspace code) could dispatch to a logic function belonging to a **different application**, or to a workspace where its own application is **not installed**, and read the target's return value back in the HTTP response (`buildRouteTriggerResponse(targetResult.data)`) — a cross-tenant / cross-application isolation break.

The implementation this replaced (the deleted `server-webhook-trigger.service.ts`) enforced both checks: the app had to be installed in the target workspace, and the target function was scoped by `applicationId`. This PR restores that guarantee.

## Changes

- **Scope the target dispatch to the resolver's `applicationRegistration`.** `handle()` captures `resolver.application.applicationRegistration.id` and threads it into the target `findOne` as `application: { applicationRegistrationId }` (joining the `application` relation). The target must belong to the same registration — which also guarantees the application is installed in the resolved workspace (no installed copy → no matching row). The resolver lookup itself is unchanged.
- **Stop leaking raw internal error messages.** The `runFunction` catch block logged the raw executor/`Error.message` *and* returned it to the (unauthenticated) caller. It now logs the detail server-side and returns a generic, per-code message.
- **Tests**: fixtures carry an `applicationRegistration.id`; new cases assert the target lookup is scoped to the resolver's registration, that a resolver not linked to a registration is rejected, and that a platform error returns the generic message instead of the raw internal text.

Feature remains gated behind `IS_SERVER_LOGIC_FUNCTION_ENABLED` (default off).

## Test plan
- [ ] `npx jest server-route-trigger` (verifying locally; environment dependency install was flaky)
- [ ] `npx nx typecheck twenty-server`
- [ ] `npx nx lint:diff-with-main twenty-server`

https://claude.ai/code/session_014TNdRvQjjR8wN6MLTJ7rTE

---
_Generated by [Claude Code](https://claude.ai/code/session_014TNdRvQjjR8wN6MLTJ7rTE)_

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/22101?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

