### PR TITLE
chore: disable dependabot version-update PRs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,7 +6,10 @@ updates:
       - "packages/twenty-apps/**"
     schedule:
       interval: "weekly"
-    open-pull-requests-limit: 3
+    # Version-update PRs disabled (limit 0). Security advisory updates are a
+    # separate channel and still open automatically — only routine version
+    # bumps are turned off to stop the constant PR churn.
+    open-pull-requests-limit: 0
     versioning-strategy: "lockfile-only"
     assignees:
       - "mabdullahabaid"
@@ -25,7 +28,7 @@ updates:
       - "/packages/twenty-apps/public/*"
     schedule:
       interval: "weekly"
-    open-pull-requests-limit: 3
+    open-pull-requests-limit: 0
     versioning-strategy: "lockfile-only"
     groups:
       twenty-apps-public:
@@ -37,7 +40,7 @@ updates:
       - "/packages/twenty-apps/internal/*"
     schedule:
       interval: "weekly"
-    open-pull-requests-limit: 3
+    open-pull-requests-limit: 0
     versioning-strategy: "lockfile-only"
     groups:
       twenty-apps-internal:


### PR DESCRIPTION
## What

Sets `open-pull-requests-limit: 0` on all three npm entries in `.github/dependabot.yml`, disabling routine version-update PRs.

## Why

Dependabot's `open-pull-requests-limit` is a *concurrent* cap, not a weekly throughput cap. With a large dependency backlog, every time a PR is closed or merged Dependabot backfills the freed slot with the next outdated dependency — producing an endless trickle of individual PRs rather than the intended "few per week".

Setting the limit to `0` stops version-update PRs entirely.

## Impact

- **Routine version-bump PRs:** disabled across root + public/internal apps.
- **Security advisory updates:** unaffected — these are a separate Dependabot channel not governed by this limit, so vulnerability patches still open automatically.

The existing `groups:` config on the apps entries is now inert but left in place, so version updates can be re-enabled later by simply raising the limit.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/22119?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

