### PR TITLE
Update TypeScript moduleResolution to bundler

### DIFF
--- a/packages/create-twenty-app/src/constants/template/tsconfig.json
+++ b/packages/create-twenty-app/src/constants/template/tsconfig.json
@@ -6,7 +6,7 @@
     "outDir": "./dist",
     "rootDir": ".",
     "jsx": "react-jsx",
-    "moduleResolution": "node",
+    "moduleResolution": "bundler",
     "allowSyntheticDefaultImports": true,
     "emitDecoratorMetadata": true,
     "experimentalDecorators": true,

--- a/packages/twenty-apps/examples/hello-world/tsconfig.json
+++ b/packages/twenty-apps/examples/hello-world/tsconfig.json
@@ -6,7 +6,7 @@
     "outDir": "./dist",
     "rootDir": ".",
     "jsx": "react-jsx",
-    "moduleResolution": "node",
+    "moduleResolution": "bundler",
     "allowSyntheticDefaultImports": true,
     "emitDecoratorMetadata": true,
     "experimentalDecorators": true,

--- a/packages/twenty-apps/examples/postcard/tsconfig.json
+++ b/packages/twenty-apps/examples/postcard/tsconfig.json
@@ -6,7 +6,7 @@
     "outDir": "./dist",
     "rootDir": ".",
     "jsx": "react-jsx",
-    "moduleResolution": "node",
+    "moduleResolution": "bundler",
     "allowSyntheticDefaultImports": true,
     "emitDecoratorMetadata": true,
     "experimentalDecorators": true,


### PR DESCRIPTION
## Summary
Updates the TypeScript `moduleResolution` configuration from `"node"` to `"bundler"` across template and example tsconfig files. This aligns with modern TypeScript best practices for bundler-based projects.

## Changes
- Updated `moduleResolution` setting in `packages/create-twenty-app/src/constants/template/tsconfig.json`
- Updated `moduleResolution` setting in `packages/twenty-apps/examples/hello-world/tsconfig.json`
- Updated `moduleResolution` setting in `packages/twenty-apps/examples/postcard/tsconfig.json`

## Details
The `"bundler"` module resolution strategy is the recommended approach for projects using modern bundlers (Vite, Webpack, etc.) as it provides better compatibility with ESM and package.json exports field resolution. This change ensures that new projects created from the template and example applications follow current TypeScript best practices.

