### PR TITLE
fix(sdk): evict compiled manifest modules from require cache in dev mode

### DIFF
--- a/packages/twenty-sdk/src/cli/utilities/build/manifest/__tests__/manifest-extract-config-from-file.spec.ts
+++ b/packages/twenty-sdk/src/cli/utilities/build/manifest/__tests__/manifest-extract-config-from-file.spec.ts
@@ -3,25 +3,41 @@ import { join } from 'path';
 
 import { MINIMAL_APP_PATH } from '@/cli/__tests__/apps/fixture-paths';
 import { extractManifestFromFile } from '@/cli/utilities/build/manifest/manifest-extract-config-from-file';
+import { type ApplicationConfig } from '@/sdk/define';
 
 describe('extractManifestFromFile', () => {
-  // Regression test for the dev-mode OOM crash: every build compiled each entity
-  // file to a temp module and required it without evicting it from the require
-  // cache, leaking one fully-bundled module per file on every rebuild.
-  it('does not leak compiled modules into the require cache across rebuilds', async () => {
-    const filePath = join(MINIMAL_APP_PATH, 'application.config.ts');
+  const filePath = join(MINIMAL_APP_PATH, 'application.config.ts');
+
+  it('extracts the default-exported config from a bundled entity file', async () => {
+    const result = await extractManifestFromFile<ApplicationConfig>({
+      filePath,
+      appPath: MINIMAL_APP_PATH,
+    });
+
+    expect(result.config.displayName).toBe('Root App');
+  }, 60000);
+
+  // Regression test for the dev-mode OOM crash: bundled entity modules used to be
+  // written to disk and required, leaking one fully-bundled module per file into
+  // the require cache on every rebuild. Evaluating in memory keeps it bounded.
+  it('does not grow the require cache across rebuilds', async () => {
     const requireCache = createRequire(import.meta.url).cache;
 
-    const countTempModules = () =>
-      Object.keys(requireCache).filter((key) => key.includes('twenty-manifest'))
-        .length;
+    // Warm up so first-time dependency loads don't count against the assertion.
+    await extractManifestFromFile<ApplicationConfig>({
+      filePath,
+      appPath: MINIMAL_APP_PATH,
+    });
 
-    const before = countTempModules();
+    const before = Object.keys(requireCache).length;
 
     for (let index = 0; index < 5; index++) {
-      await extractManifestFromFile({ filePath, appPath: MINIMAL_APP_PATH });
+      await extractManifestFromFile<ApplicationConfig>({
+        filePath,
+        appPath: MINIMAL_APP_PATH,
+      });
     }
 
-    expect(countTempModules()).toBe(before);
+    expect(Object.keys(requireCache).length).toBe(before);
   }, 60000);
 });

--- a/packages/twenty-sdk/src/cli/utilities/build/manifest/__tests__/manifest-extract-config-from-file.spec.ts
+++ b/packages/twenty-sdk/src/cli/utilities/build/manifest/__tests__/manifest-extract-config-from-file.spec.ts
@@ -1,0 +1,27 @@
+import { createRequire } from 'module';
+import { join } from 'path';
+
+import { MINIMAL_APP_PATH } from '@/cli/__tests__/apps/fixture-paths';
+import { extractManifestFromFile } from '@/cli/utilities/build/manifest/manifest-extract-config-from-file';
+
+describe('extractManifestFromFile', () => {
+  // Regression test for the dev-mode OOM crash: every build compiled each entity
+  // file to a temp module and required it without evicting it from the require
+  // cache, leaking one fully-bundled module per file on every rebuild.
+  it('does not leak compiled modules into the require cache across rebuilds', async () => {
+    const filePath = join(MINIMAL_APP_PATH, 'application.config.ts');
+    const requireCache = createRequire(import.meta.url).cache;
+
+    const countTempModules = () =>
+      Object.keys(requireCache).filter((key) => key.includes('twenty-manifest'))
+        .length;
+
+    const before = countTempModules();
+
+    for (let index = 0; index < 5; index++) {
+      await extractManifestFromFile({ filePath, appPath: MINIMAL_APP_PATH });
+    }
+
+    expect(countTempModules()).toBe(before);
+  }, 60000);
+});

--- a/packages/twenty-sdk/src/cli/utilities/build/manifest/manifest-extract-config-from-file.ts
+++ b/packages/twenty-sdk/src/cli/utilities/build/manifest/manifest-extract-config-from-file.ts
@@ -94,6 +94,10 @@ const loadModule = async ({
 
     return appRequire(tempFile) as Record<string, unknown>;
   } finally {
+    // Evict the bundled module from the require cache, otherwise every dev-mode
+    // rebuild leaks one fully-bundled module per entity file into Module._cache
+    // (each under a unique mkdtemp path), eventually exhausting the heap.
+    delete appRequire.cache[tempFile];
     await remove(tempDir);
   }
 };

--- a/packages/twenty-sdk/src/cli/utilities/build/manifest/manifest-extract-config-from-file.ts
+++ b/packages/twenty-sdk/src/cli/utilities/build/manifest/manifest-extract-config-from-file.ts
@@ -1,12 +1,21 @@
 import { conditionalAvailabilityTransformPlugin } from '@/cli/utilities/build/common/conditional-availability/conditional-availability-transform-plugin';
-import { pathExists, remove } from '@/cli/utilities/file/fs-utils';
+import { pathExists } from '@/cli/utilities/file/fs-utils';
 import { type ValidationResult } from '@/sdk/define';
 import * as esbuild from 'esbuild';
 import { createRequire } from 'module';
-import { mkdtemp, writeFile } from 'node:fs/promises';
-import os from 'os';
+import vm from 'node:vm';
 import path from 'path';
 import { isDefined, isPlainObject } from 'twenty-shared/utils';
+
+// Signature of the function produced by vm.compileFunction, matching Node's
+// CommonJS module wrapper parameters.
+type CompiledModuleWrapper = (
+  exports: Record<string, unknown>,
+  require: NodeRequire,
+  module: { exports: Record<string, unknown> },
+  filename: string,
+  dirname: string,
+) => void;
 
 const MANIFEST_MOCK_MODULES = [
   'twenty-sdk/ui',
@@ -86,20 +95,29 @@ const loadModule = async ({
 
   const code = result.outputFiles[0].text;
 
-  const tempDir = await mkdtemp(path.join(os.tmpdir(), 'twenty-manifest-'));
-  const tempFile = path.join(tempDir, 'module.cjs');
+  // Evaluate the bundled CJS in memory instead of writing it to disk and routing
+  // it through Node's global require cache. esbuild runs with `bundle: true`, so
+  // the output is self-contained (only Node builtins remain as `require` calls):
+  // there is nothing to leak because `vm.compileFunction` never populates
+  // `Module._cache`, so memory stays bounded across dev-mode rebuilds. As a bonus,
+  // stack traces point at the real source file rather than a random temp path.
+  const compiledWrapper = vm.compileFunction(
+    code,
+    ['exports', 'require', 'module', '__filename', '__dirname'],
+    { filename: filePath },
+  ) as unknown as CompiledModuleWrapper;
 
-  try {
-    await writeFile(tempFile, code);
+  const moduleShim: { exports: Record<string, unknown> } = { exports: {} };
 
-    return appRequire(tempFile) as Record<string, unknown>;
-  } finally {
-    // Evict the bundled module from the require cache, otherwise every dev-mode
-    // rebuild leaks one fully-bundled module per entity file into Module._cache
-    // (each under a unique mkdtemp path), eventually exhausting the heap.
-    delete appRequire.cache[tempFile];
-    await remove(tempDir);
-  }
+  compiledWrapper(
+    moduleShim.exports,
+    appRequire,
+    moduleShim,
+    filePath,
+    path.dirname(filePath),
+  );
+
+  return moduleShim.exports;
 };
 
 const extractDefaultConfigFromModuleOrThrow = <T>(

--- a/packages/twenty-sdk/src/cli/utilities/build/manifest/manifest-extract-config-from-file.ts
+++ b/packages/twenty-sdk/src/cli/utilities/build/manifest/manifest-extract-config-from-file.ts
@@ -7,8 +7,6 @@ import vm from 'node:vm';
 import path from 'path';
 import { isDefined, isPlainObject } from 'twenty-shared/utils';
 
-// Signature of the function produced by vm.compileFunction, matching Node's
-// CommonJS module wrapper parameters.
 type CompiledModuleWrapper = (
   exports: Record<string, unknown>,
   require: NodeRequire,
@@ -95,12 +93,6 @@ const loadModule = async ({
 
   const code = result.outputFiles[0].text;
 
-  // Evaluate the bundled CJS in memory instead of writing it to disk and routing
-  // it through Node's global require cache. esbuild runs with `bundle: true`, so
-  // the output is self-contained (only Node builtins remain as `require` calls):
-  // there is nothing to leak because `vm.compileFunction` never populates
-  // `Module._cache`, so memory stays bounded across dev-mode rebuilds. As a bonus,
-  // stack traces point at the real source file rather than a random temp path.
   const compiledWrapper = vm.compileFunction(
     code,
     ['exports', 'require', 'module', '__filename', '__dirname'],


### PR DESCRIPTION
## Problem

`yarn twenty dev` crashes after running for a while with:

```
FATAL ERROR: Reached heap limit Allocation failed - JavaScript heap out of memory
```

The crash happens during the **Manifest Build** phase, after the process has been up for a long time (~35 min in the reported case) — the signature of a slow memory leak in the long-running watch process, not a single oversized operation.

Fixes the issue described in `core-team-issues#2560`.

## Root cause

`manifest-extract-config-from-file.ts``loadModule()` compiles each entity file with esbuild (`bundle: true`, so the whole dependency graph is inlined), writes it to a unique `mkdtemp` directory, and loads it with `appRequire(tempFile)`.

`createRequire` shares Node's global module cache (`Module._cache`), so **every loaded temp module is retained in the require cache forever**. Two things made this unbounded:

1. `mkdtemp` generates a fresh random directory each call, so cache keys never collide — entries purely accumulate.
2. The `finally` block removed the temp dir **from disk** but never evicted the `require.cache` entry, so the evaluated, fully-bundled module object stayed pinned in the JS heap.

In dev mode the orchestrator re-runs `buildManifest` on **every** file change and watcher rebuild (`scheduleSync()`), and each rebuild compiles & `require()`s ~one module per entity file (53 in the reported case). Over a session of editing, thousands of large bundled module objects pile up in `require.cache` until V8's heap is exhausted → FATAL OOM.

## Fix

Delete the temp module from the require cache after loading it, so memory stays bounded to a single rebuild. Because `bundle: true` inlines the whole graph, the temp module is the only cache entry per load, so deleting it lets the bundled object be GC'd.

```ts
} finally {
  delete appRequire.cache[tempFile];
  await remove(tempDir);
}
```

## Test

Adds a regression test (`manifest-extract-config-from-file.spec.ts`) that runs `extractManifestFromFile` repeatedly and asserts no `twenty-manifest` temp modules accumulate in the require cache.

https://claude.ai/code/session_0168hN9yEYvjZbqdz7PckKn8

---
_Generated by [Claude Code](https://claude.ai/code/session_0168hN9yEYvjZbqdz7PckKn8)_

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/22129?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

