### PR TITLE
fix(sdk): render CLI OAuth success page on localhost (twenty dev)

### DIFF
--- a/packages/twenty-sdk/src/cli/utilities/auth/__tests__/callback-server.test.ts
+++ b/packages/twenty-sdk/src/cli/utilities/auth/__tests__/callback-server.test.ts
@@ -83,10 +83,11 @@ describe('startCallbackServer', () => {
     }
   });
 
-  // Reproduces the dev-mode failure: the caller resolves waitForCallback and
-  // immediately tears the server down (closeAllConnections destroys the
-  // socket). The page must still arrive complete because we resolve only after
-  // the body has flushed — otherwise the teardown RST leaves a dead page.
+  // Reproduces the dev-mode failure: the caller tears the server down the
+  // instant the callback resolves. waitForCallback only resolves once the
+  // socket has closed gracefully, so the browser receives the complete page —
+  // whereas hard-destroying the socket (the old closeAllConnections) would RST
+  // it and leave a blank page on fast localhost.
   it('should deliver the full page even when the server is closed right after the callback resolves', async () => {
     const server = await startCallbackServer();
 

--- a/packages/twenty-sdk/src/cli/utilities/auth/__tests__/callback-server.test.ts
+++ b/packages/twenty-sdk/src/cli/utilities/auth/__tests__/callback-server.test.ts
@@ -81,6 +81,25 @@ describe('startCallbackServer', () => {
     }
   });
 
+  // Reproduces the dev-mode failure: the caller resolves waitForCallback and
+  // immediately tears the server down (closeAllConnections destroys the
+  // socket). The page must still arrive complete because we resolve only after
+  // the body has flushed — otherwise the teardown RST leaves a dead page.
+  it('should deliver the full page even when the server is closed right after the callback resolves', async () => {
+    const server = await startCallbackServer();
+
+    const responsePromise = httpGet(`${server.callbackUrl}?code=test-auth-code`);
+
+    await server.waitForCallback();
+    server.close();
+
+    const response = await responsePromise;
+
+    expect(response.status).toBe(200);
+    expect(response.body).toContain('Authentication successful');
+    expect(response.body).toContain('</html>');
+  });
+
   it('should resolve with error when callback contains an error', async () => {
     const server = await startCallbackServer();
 

--- a/packages/twenty-sdk/src/cli/utilities/auth/__tests__/callback-server.test.ts
+++ b/packages/twenty-sdk/src/cli/utilities/auth/__tests__/callback-server.test.ts
@@ -66,7 +66,9 @@ describe('startCallbackServer', () => {
     try {
       const waitPromise = server.waitForCallback();
 
-      const response = await httpGet(`${server.callbackUrl}?code=test-auth-code`);
+      const response = await httpGet(
+        `${server.callbackUrl}?code=test-auth-code`,
+      );
 
       await waitPromise;
 
@@ -88,7 +90,9 @@ describe('startCallbackServer', () => {
   it('should deliver the full page even when the server is closed right after the callback resolves', async () => {
     const server = await startCallbackServer();
 
-    const responsePromise = httpGet(`${server.callbackUrl}?code=test-auth-code`);
+    const responsePromise = httpGet(
+      `${server.callbackUrl}?code=test-auth-code`,
+    );
 
     await server.waitForCallback();
     server.close();

--- a/packages/twenty-sdk/src/cli/utilities/auth/__tests__/callback-server.test.ts
+++ b/packages/twenty-sdk/src/cli/utilities/auth/__tests__/callback-server.test.ts
@@ -2,14 +2,26 @@ import http from 'node:http';
 
 import { startCallbackServer } from '../callback-server';
 
-const httpGet = (url: string): Promise<{ status: number; body: string }> =>
+const httpGet = (
+  url: string,
+): Promise<{
+  status: number;
+  body: string;
+  headers: http.IncomingHttpHeaders;
+}> =>
   new Promise((resolve, reject) => {
     http
       .get(url, (res) => {
         let body = '';
 
         res.on('data', (chunk: string) => (body += chunk));
-        res.on('end', () => resolve({ status: res.statusCode ?? 0, body }));
+        res.on('end', () =>
+          resolve({
+            status: res.statusCode ?? 0,
+            body,
+            headers: res.headers,
+          }),
+        );
       })
       .on('error', reject);
   });
@@ -39,6 +51,31 @@ describe('startCallbackServer', () => {
       const result = await waitPromise;
 
       expect(result).toEqual({ success: true, code: 'test-auth-code' });
+    } finally {
+      server.close();
+    }
+  });
+
+  // The page is delivered length-delimited (not chunked) so the browser treats
+  // it as complete the moment the bytes arrive, even though the CLI destroys the
+  // socket right after the code is in hand. Chunked framing depends on a clean
+  // close and renders a blank page when the teardown races in on fast localhost.
+  it('should send the success page with an explicit Content-Length (not chunked)', async () => {
+    const server = await startCallbackServer();
+
+    try {
+      const waitPromise = server.waitForCallback();
+
+      const response = await httpGet(`${server.callbackUrl}?code=test-auth-code`);
+
+      await waitPromise;
+
+      expect(response.status).toBe(200);
+      expect(response.headers['transfer-encoding']).toBeUndefined();
+      expect(response.headers['content-length']).toBe(
+        String(Buffer.byteLength(response.body)),
+      );
+      expect(response.body).toContain('Authentication successful');
     } finally {
       server.close();
     }

--- a/packages/twenty-sdk/src/cli/utilities/auth/__tests__/callback-server.test.ts
+++ b/packages/twenty-sdk/src/cli/utilities/auth/__tests__/callback-server.test.ts
@@ -56,10 +56,6 @@ describe('startCallbackServer', () => {
     }
   });
 
-  // The page is delivered length-delimited (not chunked) so the browser treats
-  // it as complete the moment the bytes arrive, even though the CLI destroys the
-  // socket right after the code is in hand. Chunked framing depends on a clean
-  // close and renders a blank page when the teardown races in on fast localhost.
   it('should send the success page with an explicit Content-Length (not chunked)', async () => {
     const server = await startCallbackServer();
 
@@ -83,11 +79,6 @@ describe('startCallbackServer', () => {
     }
   });
 
-  // Reproduces the dev-mode failure: the caller tears the server down the
-  // instant the callback resolves. waitForCallback only resolves once the
-  // socket has closed gracefully, so the browser receives the complete page —
-  // whereas hard-destroying the socket (the old closeAllConnections) would RST
-  // it and leave a blank page on fast localhost.
   it('should deliver the full page even when the server is closed right after the callback resolves', async () => {
     const server = await startCallbackServer();
 

--- a/packages/twenty-sdk/src/cli/utilities/auth/callback-server.ts
+++ b/packages/twenty-sdk/src/cli/utilities/auth/callback-server.ts
@@ -205,21 +205,31 @@ export const startCallbackServer = (options?: {
       const error = url.searchParams.get('error');
       const isDarkMode = url.searchParams.get('theme') === 'dark';
 
-      const headers = {
-        'Content-Type': 'text/html',
-        Connection: 'close',
+      // Frame the response with an explicit Content-Length. Without it Node
+      // streams the (large) page with chunked transfer encoding, so the browser
+      // only treats it as complete once it sees the terminating chunk and a
+      // clean connection close. The CLI tears the server down the moment it has
+      // the code (closeAllConnections destroys the socket), and on fast
+      // localhost that race truncates the chunked stream — the browser renders a
+      // blank page (ERR_INCOMPLETE_CHUNKED_ENCODING). A length-delimited body is
+      // considered complete as soon as the bytes arrive, regardless of teardown.
+      const sendHtml = (body: string) => {
+        res.writeHead(200, {
+          'Content-Type': 'text/html',
+          'Content-Length': Buffer.byteLength(body),
+          Connection: 'close',
+        });
+        res.end(body);
       };
 
       if (code) {
-        res.writeHead(200, headers);
-        res.end(successHtml(isDarkMode));
+        sendHtml(successHtml(isDarkMode));
         callbackResolve({ success: true, code });
       } else {
         const errorMessage =
           error ?? url.searchParams.get('error_description') ?? 'Unknown error';
 
-        res.writeHead(200, headers);
-        res.end(errorHtml(errorMessage, isDarkMode));
+        sendHtml(errorHtml(errorMessage, isDarkMode));
         callbackResolve({ success: false, error: errorMessage });
       }
     });

--- a/packages/twenty-sdk/src/cli/utilities/auth/callback-server.ts
+++ b/packages/twenty-sdk/src/cli/utilities/auth/callback-server.ts
@@ -205,32 +205,39 @@ export const startCallbackServer = (options?: {
       const error = url.searchParams.get('error');
       const isDarkMode = url.searchParams.get('theme') === 'dark';
 
-      // Frame the response with an explicit Content-Length. Without it Node
-      // streams the (large) page with chunked transfer encoding, so the browser
-      // only treats it as complete once it sees the terminating chunk and a
-      // clean connection close. The CLI tears the server down the moment it has
-      // the code (closeAllConnections destroys the socket), and on fast
-      // localhost that race truncates the chunked stream — the browser renders a
-      // blank page (ERR_INCOMPLETE_CHUNKED_ENCODING). A length-delimited body is
-      // considered complete as soon as the bytes arrive, regardless of teardown.
-      const sendHtml = (body: string) => {
+      // Frame the response with an explicit Content-Length (rather than letting
+      // Node fall back to chunked transfer encoding) and only resolve the
+      // callback once the body has been fully flushed to the socket.
+      //
+      // The caller (login-oauth) resolves waitForCallback, exchanges the code
+      // for tokens, then tears the server down — close() calls
+      // closeAllConnections(), which destroys the still-open socket with a RST.
+      // Against a remote server the token exchange is slow enough that the page
+      // flushes first, but on localhost it returns almost instantly, so the
+      // teardown races in before the bytes leave and the browser is left with a
+      // dead/blank page (connection refused/reset). Resolving in the res.end
+      // completion callback guarantees the page is delivered before the token
+      // exchange and teardown can run.
+      const sendHtml = (body: string, onFlushed: () => void) => {
         res.writeHead(200, {
           'Content-Type': 'text/html',
           'Content-Length': Buffer.byteLength(body),
           Connection: 'close',
         });
-        res.end(body);
+        res.end(body, onFlushed);
       };
 
       if (code) {
-        sendHtml(successHtml(isDarkMode));
-        callbackResolve({ success: true, code });
+        sendHtml(successHtml(isDarkMode), () =>
+          callbackResolve({ success: true, code }),
+        );
       } else {
         const errorMessage =
           error ?? url.searchParams.get('error_description') ?? 'Unknown error';
 
-        sendHtml(errorHtml(errorMessage, isDarkMode));
-        callbackResolve({ success: false, error: errorMessage });
+        sendHtml(errorHtml(errorMessage, isDarkMode), () =>
+          callbackResolve({ success: false, error: errorMessage }),
+        );
       }
     });
 

--- a/packages/twenty-sdk/src/cli/utilities/auth/callback-server.ts
+++ b/packages/twenty-sdk/src/cli/utilities/auth/callback-server.ts
@@ -195,7 +195,7 @@ export const startCallbackServer = (options?: {
       const url = new URL(req.url ?? '/', `http://127.0.0.1`);
 
       if (url.pathname !== '/callback') {
-        res.writeHead(404);
+        res.writeHead(404, { Connection: 'close' });
         res.end('Not found');
 
         return;
@@ -205,40 +205,36 @@ export const startCallbackServer = (options?: {
       const error = url.searchParams.get('error');
       const isDarkMode = url.searchParams.get('theme') === 'dark';
 
-      // Frame the response with an explicit Content-Length (rather than letting
-      // Node fall back to chunked transfer encoding) and only resolve the
-      // callback once the body has been fully flushed to the socket.
-      //
-      // The caller (login-oauth) resolves waitForCallback, exchanges the code
-      // for tokens, then tears the server down — close() calls
-      // closeAllConnections(), which destroys the still-open socket with a RST.
-      // Against a remote server the token exchange is slow enough that the page
-      // flushes first, but on localhost it returns almost instantly, so the
-      // teardown races in before the bytes leave and the browser is left with a
-      // dead/blank page (connection refused/reset). Resolving in the res.end
-      // completion callback guarantees the page is delivered before the token
-      // exchange and teardown can run.
-      const sendHtml = (body: string, onFlushed: () => void) => {
-        res.writeHead(200, {
-          'Content-Type': 'text/html',
-          'Content-Length': Buffer.byteLength(body),
-          Connection: 'close',
-        });
-        res.end(body, onFlushed);
-      };
+      const result: CallbackResult = code
+        ? { success: true, code }
+        : {
+            success: false,
+            error:
+              error ??
+              url.searchParams.get('error_description') ??
+              'Unknown error',
+          };
 
-      if (code) {
-        sendHtml(successHtml(isDarkMode), () =>
-          callbackResolve({ success: true, code }),
-        );
-      } else {
-        const errorMessage =
-          error ?? url.searchParams.get('error_description') ?? 'Unknown error';
+      const body = result.success
+        ? successHtml(isDarkMode)
+        : errorHtml(result.error, isDarkMode);
 
-        sendHtml(errorHtml(errorMessage, isDarkMode), () =>
-          callbackResolve({ success: false, error: errorMessage }),
-        );
-      }
+      res.writeHead(200, {
+        'Content-Type': 'text/html',
+        'Content-Length': Buffer.byteLength(body),
+        Connection: 'close',
+      });
+
+      // Resolve the callback only once this socket has fully closed, not as soon
+      // as the body is written. The caller (login-oauth) tears the server down
+      // the instant waitForCallback resolves; if we resolved earlier the
+      // teardown would hard-destroy the still-open socket with a TCP RST, and on
+      // fast localhost the RST reaches the browser before it has drained the
+      // response — the kernel then discards the unread bytes and the page is
+      // blank. Letting the socket close gracefully (Connection: close → FIN)
+      // guarantees the page is delivered before we hand control back.
+      res.on('close', () => callbackResolve(result));
+      res.end(body);
     });
 
     server.listen(0, '127.0.0.1', () => {
@@ -269,8 +265,13 @@ export const startCallbackServer = (options?: {
         },
         close: () => {
           clearTimeout(timeoutHandle);
-          server.closeAllConnections();
+          // Stop accepting new connections and free the port immediately, but
+          // never hard-destroy live sockets: closeAllConnections() would RST the
+          // socket still delivering the page and leave the browser blank.
+          // closeIdleConnections() only reaps idle keep-alive sockets (which
+          // carry no pending response) so the process can still exit.
           server.close();
+          server.closeIdleConnections();
         },
       });
     });

--- a/packages/twenty-sdk/src/cli/utilities/auth/callback-server.ts
+++ b/packages/twenty-sdk/src/cli/utilities/auth/callback-server.ts
@@ -225,14 +225,6 @@ export const startCallbackServer = (options?: {
         Connection: 'close',
       });
 
-      // Resolve the callback only once this socket has fully closed, not as soon
-      // as the body is written. The caller (login-oauth) tears the server down
-      // the instant waitForCallback resolves; if we resolved earlier the
-      // teardown would hard-destroy the still-open socket with a TCP RST, and on
-      // fast localhost the RST reaches the browser before it has drained the
-      // response — the kernel then discards the unread bytes and the page is
-      // blank. Letting the socket close gracefully (Connection: close → FIN)
-      // guarantees the page is delivered before we hand control back.
       res.on('close', () => callbackResolve(result));
       res.end(body);
     });
@@ -265,11 +257,6 @@ export const startCallbackServer = (options?: {
         },
         close: () => {
           clearTimeout(timeoutHandle);
-          // Stop accepting new connections and free the port immediately, but
-          // never hard-destroy live sockets: closeAllConnections() would RST the
-          // socket still delivering the page and leave the browser blank.
-          // closeIdleConnections() only reaps idle keep-alive sockets (which
-          // carry no pending response) so the process can still exit.
           server.close();
           server.closeIdleConnections();
         },


### PR DESCRIPTION
## Problem

When authenticating the CLI via OAuth on localhost (e.g. during `twenty dev`), the browser lands on a blank / dead page instead of the "Authentication successful" screen — even though the CLI **receives the code, completes the token exchange, and dev mode continues normally**. The same flow renders fine against a remote server (e.g. `remote:add`), which is what made this confusing.

## Root cause

`remote:add` and `twenty dev` share the same `authLoginOAuth` → `startCallbackServer` code, so the difference is purely **timing** in how the loopback callback server is torn down:

```
handler:  res.end(html)  →  callbackResolve()      ← resolves before the page is delivered
caller:   exchange code for tokens                 ← fast on localhost, slow on remote
finally:  close() → server.closeAllConnections()   ← hard-destroys the socket with a TCP RST
```

`closeAllConnections()` calls `socket.destroy()`, which sends a **TCP RST**. On a remote server the token exchange is slow enough that the page is delivered first, but on localhost it returns almost instantly, so the RST reaches the browser before it has drained the response. The kernel discards unread bytes on RST, so the browser renders a blank page — while the CLI side has already succeeded.

`Content-Length` framing and resolving on the `res.end` flush callback aren't enough: the `finish` event only means the bytes were handed to the OS, not that the client received them, so the RST still wins the race.

## Fix

- Resolve `waitForCallback` only once the response socket has **fully closed gracefully** (`Connection: close` → FIN). TCP guarantees all data is delivered before a graceful close, so the page always renders before the CLI tears the server down.
- Replace `closeAllConnections()` with `closeIdleConnections()` in `close()` — it reaps idle keep-alive sockets (so the process can still exit) but never RSTs a socket with a live response.
- Send the explicit `Content-Length` (length-delimited, not chunked) and `Connection: close` on the 404 path too.

Verified with a standalone reproduction mirroring the exact flow: the page is delivered complete, the port is freed after `close()`, and the process does not hang (idle sockets are reaped).

## Test plan

- [x] Regression test: server closed immediately after the callback resolves still delivers the full page
- [x] Existing callback-server tests still cover Content-Length framing, success/error/timeout/404 paths
- [ ] CI green

https://claude.ai/code/session_01TY3fNdK9zuMRrfZmTeCaHM

---
_Generated by [Claude Code](https://claude.ai/code/session_01TY3fNdK9zuMRrfZmTeCaHM)_