### PR TITLE
fix(server): stop reusing tarballFileId on app re-publish (core.file PK collision)

### DIFF
--- a/packages/twenty-server/src/engine/core-modules/application/application-registration/application-tarball.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/application/application-registration/application-tarball.service.ts
@@ -194,7 +194,13 @@ export class ApplicationTarballService {
         applicationUniversalIdentifier:
           workspaceCustomFlatApplication.universalIdentifier,
         workspaceId: params.ownerWorkspaceId,
-        fileId: appRegistration.tarballFileId ?? v4(),
+        // Always mint a fresh file id for the uploaded tarball. Reusing the
+        // registration's existing tarballFileId on a re-publish makes writeFile
+        // INSERT a core.file row whose id already exists (the previous tarball's
+        // row is still present), which fails with a primary-key collision
+        // (PK_36b46d232307066b3a2c9ea3a1d) and silently freezes the published
+        // version. The registration is repointed to the new file below.
+        fileId: v4(),
         settings: {
           isTemporaryFile: false,
           toDelete: false,


### PR DESCRIPTION
### Problem

`ApplicationTarballService.uploadTarball` builds the `writeFile` call with:

```ts
fileId: appRegistration.tarballFileId ?? v4(),
```

On a **re-publish** — when the registration already has a `tarballFileId` from a previous upload — this reuses the existing file id. `FileStorageService.writeFile` then tries to INSERT a new `core.file` row with that id, but the previous tarball's `core.file` row still exists, so the insert fails:

```
Upload failed: duplicate key value violates unique constraint "PK_36b46d232307066b3a2c9ea3a1d"
```

(`PK_36b46d232307066b3a2c9ea3a1d` is the `core.file` primary key.)

The publish aborts **before** `latestAvailableVersion` is advanced, so the registry silently freezes at the previously-published version while `app:install` keeps serving the stale version. To the operator a re-publish appears to "do nothing", and the only recovery is manually nulling `applicationRegistration.tarballFileId` in the DB.

### Steps to reproduce

1. `twenty app:publish --private` an app against an owner workspace.
2. Bump the app version and `twenty app:publish --private` again (same `universalIdentifier`, same owner workspace).
3. The second publish dies on the `core.file` PK collision; `latestAvailableVersion` stays at the first version.

### Fix

A new upload is always a new file, so mint a fresh `fileId` every time instead of reusing the registration's existing one. The registration is repointed to the new file in the `update()` call immediately below, and the FK (`tarballFileId` → `core.file`) is `ON DELETE SET NULL`, so the previous file row is simply superseded.

```diff
-        fileId: appRegistration.tarballFileId ?? v4(),
+        fileId: v4(),
```

### Notes

- This is the minimal fix that resolves the collision. The superseded `core.file` row is left orphaned; a follow-up could best-effort delete it via `FileStorageService.deleteByFileId` after the registration is repointed, if maintainers prefer that here.
- Happy to add a unit test — `uploadTarball` mocks a fair amount (tarball extraction, manifest/package read, version validation, repositories, file storage), so I'd appreciate a pointer to the preferred harness for this service before I do.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/22133?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

