### PR TITLE
docs(user-guide): remove unsupported Between operator for Date filters

### DIFF
--- a/packages/twenty-docs/user-guide/views-pipelines/capabilities/filters-and-sorting.mdx
+++ b/packages/twenty-docs/user-guide/views-pipelines/capabilities/filters-and-sorting.mdx
@@ -21,7 +21,7 @@ Filters help you focus on specific records by showing only those that match your
 |------------|---------------------|
 | Text | Equals, Contains, Starts with, Ends with, Is empty |
 | Number | Equals, Greater than, Less than, Is empty |
-| Date | Equals, Before, After, Between, Is empty |
+| Date | Equals, Before, After, Is empty |
 | Select | Equals, Is any of, Is empty |
 | Checkbox | Is true, Is false |
 | Relation | Equals, Is empty |


### PR DESCRIPTION
## What

The Filters & Sorting user guide lists a **Between** operator for **Date** fields, but this operator is not currently supported by the product.

This removes it from the Date operators table.

| Field Type | Before | After |
|---|---|---|
| Date | Equals, Before, After, **Between**, Is empty | Equals, Before, After, Is empty |

## Why

Avoids documenting a capability that does not currently exist.

The shared `ViewFilterOperand` enum does not define an `IS_BETWEEN` operand, and the Date filter operands map does not include a Between operator.

Related to #20932.

## Notes

- Documentation-only change.
- Only the canonical English source is edited.
- Localized copies under `packages/twenty-docs/l/*` are expected to be regenerated by the existing docs translation workflow.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/22136?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

