### PR TITLE
fix(calendar): mark channel completed on no-events fetch

### DIFF
--- a/packages/twenty-server/src/modules/calendar/calendar-event-import-manager/services/calendar-fetch-events.service.ts
+++ b/packages/twenty-server/src/modules/calendar/calendar-event-import-manager/services/calendar-fetch-events.service.ts
@@ -87,7 +87,7 @@ export class CalendarFetchEventsService {
               workspaceId,
             );
           } else {
-            await this.calendarChannelSyncStatusService.markAsCalendarEventListFetchPending(
+            await this.calendarChannelSyncStatusService.markAsCompletedAndMarkAsCalendarEventListFetchPending(
               [calendarChannel.id],
               workspaceId,
             );


### PR DESCRIPTION
No-events branch left channels stuck on syncStatus=ONGOING and stopped bumping the active metric (flatlined dashboard), since markAsCalendarEventListFetchPending only resets the stage.

Switched it to markAsCompletedAndMarkAsCalendarEventListFetchPending so status, syncedAt, throttle and the metric reset properly, matching the messaging side. Regression from #22015.