### PR TITLE
Tidy website ImportVisual markup and CSS

### DIFF
--- a/packages/twenty-website/src/sections/product-feature/ImportVisual/ImportVisual.test.tsx
+++ b/packages/twenty-website/src/sections/product-feature/ImportVisual/ImportVisual.test.tsx
@@ -1,0 +1,41 @@
+import { i18n } from '@lingui/core';
+import { I18nProvider } from '@lingui/react';
+import { render, screen } from '@testing-library/react';
+
+import { ImportVisual } from './ImportVisual';
+
+i18n.load('en', {});
+i18n.activate('en');
+
+function renderVisual() {
+  return render(
+    <I18nProvider i18n={i18n}>
+      <ImportVisual active />
+    </I18nProvider>,
+  );
+}
+
+describe('ImportVisual', () => {
+  it('renders the imported-data and twenty-fields columns', () => {
+    renderVisual();
+
+    expect(screen.getByText('Imported data')).toBeInTheDocument();
+    expect(screen.getByText('Twenty fields')).toBeInTheDocument();
+  });
+
+  it('renders each imported column with its example value', () => {
+    renderVisual();
+
+    expect(screen.getByText('First Name')).toBeInTheDocument();
+    expect(screen.getByText('ex: Dario')).toBeInTheDocument();
+    expect(screen.getByText('ex: dario@anthropic.com')).toBeInTheDocument();
+  });
+
+  it('maps the imported columns onto Twenty fields', () => {
+    renderVisual();
+
+    expect(screen.getByText('Name')).toBeInTheDocument();
+    expect(screen.getByText('Emails')).toBeInTheDocument();
+    expect(screen.getAllByText('Company')).toHaveLength(2);
+  });
+});

--- a/packages/twenty-website/src/sections/product-feature/ImportVisual/ImportVisual.tsx
+++ b/packages/twenty-website/src/sections/product-feature/ImportVisual/ImportVisual.tsx
@@ -1,5 +1,7 @@
 'use client';
 
+import { msg } from '@lingui/core/macro';
+import { useLingui } from '@lingui/react';
 import { styled } from '@linaria/react';
 import { THEME_LIGHT } from 'twenty-ui/theme';
 
@@ -37,11 +39,12 @@ const HeaderCell = styled.span`
 `;
 
 export function ImportVisual({ active: _active }: { active: boolean }) {
+  const { i18n } = useLingui();
   return (
     <Root>
       <HeaderRow>
-        <HeaderCell>Imported data</HeaderCell>
-        <HeaderCell>Twenty fields</HeaderCell>
+        <HeaderCell>{i18n._(msg`Imported data`)}</HeaderCell>
+        <HeaderCell>{i18n._(msg`Twenty fields`)}</HeaderCell>
       </HeaderRow>
       {MAPPINGS.map((mapping) => (
         <MappingRow key={mapping.header} mapping={mapping} />

--- a/packages/twenty-website/src/sections/product-feature/ImportVisual/ImportVisual.tsx
+++ b/packages/twenty-website/src/sections/product-feature/ImportVisual/ImportVisual.tsx
@@ -11,16 +11,10 @@ import { MAPPINGS } from './data/import-mappings';
 const Root = styled.div`
   background-color: ${THEME_LIGHT.background.primary};
   display: flex;
+  flex-direction: column;
   font-family: var(--font-product), sans-serif;
   height: 100%;
-  justify-content: center;
   overflow: hidden;
-  width: 100%;
-`;
-
-const Grid = styled.div`
-  display: flex;
-  flex-direction: column;
   width: 100%;
 `;
 
@@ -45,15 +39,13 @@ const HeaderCell = styled.span`
 export function ImportVisual({ active: _active }: { active: boolean }) {
   return (
     <Root>
-      <Grid>
-        <HeaderRow>
-          <HeaderCell>Imported data</HeaderCell>
-          <HeaderCell>Twenty fields</HeaderCell>
-        </HeaderRow>
-        {MAPPINGS.map((mapping) => (
-          <MappingRow key={mapping.header} mapping={mapping} />
-        ))}
-      </Grid>
+      <HeaderRow>
+        <HeaderCell>Imported data</HeaderCell>
+        <HeaderCell>Twenty fields</HeaderCell>
+      </HeaderRow>
+      {MAPPINGS.map((mapping) => (
+        <MappingRow key={mapping.header} mapping={mapping} />
+      ))}
     </Root>
   );
 }

--- a/packages/twenty-website/src/sections/product-feature/ImportVisual/components/MappingRow.test.tsx
+++ b/packages/twenty-website/src/sections/product-feature/ImportVisual/components/MappingRow.test.tsx
@@ -1,0 +1,31 @@
+import { i18n } from '@lingui/core';
+import { I18nProvider } from '@lingui/react';
+import { IconUser } from '@tabler/icons-react';
+import { render, screen } from '@testing-library/react';
+
+import { type ColumnMapping } from '../types/column-mapping';
+import { MappingRow } from './MappingRow';
+
+i18n.load('en', {});
+i18n.activate('en');
+
+const MAPPING: ColumnMapping = {
+  Icon: IconUser,
+  example: 'Dario',
+  field: { id: 'Name' },
+  header: 'First Name',
+};
+
+describe('MappingRow', () => {
+  it('renders the imported column, its example and the mapped field', () => {
+    render(
+      <I18nProvider i18n={i18n}>
+        <MappingRow mapping={MAPPING} />
+      </I18nProvider>,
+    );
+
+    expect(screen.getByText('First Name')).toBeInTheDocument();
+    expect(screen.getByText('ex: Dario')).toBeInTheDocument();
+    expect(screen.getByText('Name')).toBeInTheDocument();
+  });
+});

--- a/packages/twenty-website/src/sections/product-feature/ImportVisual/components/MappingRow.tsx
+++ b/packages/twenty-website/src/sections/product-feature/ImportVisual/components/MappingRow.tsx
@@ -9,6 +9,7 @@ import { type ColumnMapping } from '../types/column-mapping';
 const Row = styled.div`
   border-bottom: 1px solid ${THEME_LIGHT.border.color.medium};
   display: flex;
+  font-size: ${previewFontSize(THEME_LIGHT.font.size.md)};
   min-height: 64px;
 
   &:last-child {
@@ -28,7 +29,6 @@ const ImportedCell = styled.div`
 
 const ColumnHeader = styled.span`
   color: ${THEME_LIGHT.font.color.primary};
-  font-size: ${previewFontSize(THEME_LIGHT.font.size.md)};
   font-weight: ${THEME_LIGHT.font.weight.medium};
   overflow: hidden;
   text-overflow: ellipsis;
@@ -69,7 +69,6 @@ const FieldSelect = styled.span`
 const FieldName = styled.span`
   color: ${THEME_LIGHT.font.color.primary};
   flex: 1;
-  font-size: ${previewFontSize(THEME_LIGHT.font.size.md)};
   min-width: 0;
   overflow: hidden;
   text-overflow: ellipsis;

--- a/packages/twenty-website/src/sections/product-feature/ImportVisual/components/MappingRow.tsx
+++ b/packages/twenty-website/src/sections/product-feature/ImportVisual/components/MappingRow.tsx
@@ -1,3 +1,7 @@
+'use client';
+
+import { msg } from '@lingui/core/macro';
+import { useLingui } from '@lingui/react';
 import { styled } from '@linaria/react';
 import { IconChevronDown } from '@tabler/icons-react';
 import { THEME_LIGHT } from 'twenty-ui/theme';
@@ -83,18 +87,19 @@ const FieldIcon = styled.span`
 
 export function MappingRow({ mapping }: { mapping: ColumnMapping }) {
   const { Icon, example, field, header } = mapping;
+  const { i18n } = useLingui();
   return (
     <Row>
       <ImportedCell>
         <ColumnHeader>{header}</ColumnHeader>
-        <ColumnExample>ex: {example}</ColumnExample>
+        <ColumnExample>{i18n._(msg`ex: ${example}`)}</ColumnExample>
       </ImportedCell>
       <FieldCell>
         <FieldSelect>
           <FieldIcon>
             <Icon size={16} stroke={2} />
           </FieldIcon>
-          <FieldName>{field}</FieldName>
+          <FieldName>{i18n._(field)}</FieldName>
           <FieldIcon>
             <IconChevronDown size={16} stroke={2} />
           </FieldIcon>

--- a/packages/twenty-website/src/sections/product-feature/ImportVisual/data/import-mappings.ts
+++ b/packages/twenty-website/src/sections/product-feature/ImportVisual/data/import-mappings.ts
@@ -1,3 +1,4 @@
+import { msg } from '@lingui/core/macro';
 import {
   IconBriefcase,
   IconBuildingSkyscraper,
@@ -8,23 +9,23 @@ import {
 import { type ColumnMapping } from '../types/column-mapping';
 
 export const MAPPINGS: ColumnMapping[] = [
-  { Icon: IconUser, example: 'Dario', field: 'Name', header: 'First Name' },
+  { Icon: IconUser, example: 'Dario', field: msg`Name`, header: 'First Name' },
   {
     Icon: IconMail,
     example: 'dario@anthropic.com',
-    field: 'Emails',
+    field: msg`Emails`,
     header: 'Email',
   },
   {
     Icon: IconBuildingSkyscraper,
     example: 'Anthropic',
-    field: 'Company',
+    field: msg`Company`,
     header: 'Company',
   },
   {
     Icon: IconBriefcase,
     example: 'CEO',
-    field: 'Job Title',
+    field: msg`Job Title`,
     header: 'Job Title',
   },
 ];

--- a/packages/twenty-website/src/sections/product-feature/ImportVisual/types/column-mapping.ts
+++ b/packages/twenty-website/src/sections/product-feature/ImportVisual/types/column-mapping.ts
@@ -1,3 +1,4 @@
+import { type MessageDescriptor } from '@lingui/core';
 import { type ComponentType } from 'react';
 
 type FieldGlyph = ComponentType<{ size?: number; stroke?: number }>;
@@ -5,6 +6,6 @@ type FieldGlyph = ComponentType<{ size?: number; stroke?: number }>;
 export type ColumnMapping = {
   Icon: FieldGlyph;
   example: string;
-  field: string;
+  field: MessageDescriptor;
   header: string;
 };


### PR DESCRIPTION
Markup/CSS tidy-up of `ImportVisual` — no visual change.

- Collapse the redundant `Grid` wrapper into `Root` (now `flex-direction: column`) and drop the no-op `justify-content: center` (the child was already full-width).
- Hoist the duplicated `font-size: previewFontSize(md)` to the mapping `Row` (the `sm` example keeps its override).

<img width="574" height="604" alt="image" src="https://github.com/user-attachments/assets/dcc72567-5c13-4d54-884a-f3120cc5a345" />

