### PR TITLE
fix(auth): validate redirect origin in oauth propagator

### DIFF
--- a/packages/twenty-server/src/engine/core-modules/auth/controllers/oauth-propagator.controller.ts
+++ b/packages/twenty-server/src/engine/core-modules/auth/controllers/oauth-propagator.controller.ts
@@ -76,22 +76,6 @@ export class OAuthPropagatorController {
       return true;
     }
 
-    const workspace =
-      await this.workspaceDomainsService.getWorkspaceByOriginOrDefaultWorkspace(
-        url.href,
-      );
-
-    if (!isDefined(workspace)) {
-      return false;
-    }
-
-    const workspaceUrls =
-      this.workspaceDomainsService.getWorkspaceUrls(workspace);
-
-    const allowedOrigins = [workspaceUrls.subdomainUrl, workspaceUrls.customUrl]
-      .filter(isDefined)
-      .map((workspaceUrl) => new URL(workspaceUrl).origin);
-
-    return allowedOrigins.includes(url.origin);
+    return this.workspaceDomainsService.isWorkspaceDomain(url.href);
   }
 }

--- a/packages/twenty-server/src/engine/core-modules/auth/controllers/oauth-propagator.controller.ts
+++ b/packages/twenty-server/src/engine/core-modules/auth/controllers/oauth-propagator.controller.ts
@@ -81,6 +81,17 @@ export class OAuthPropagatorController {
         url.href,
       );
 
-    return isDefined(workspace);
+    if (!isDefined(workspace)) {
+      return false;
+    }
+
+    const workspaceUrls =
+      this.workspaceDomainsService.getWorkspaceUrls(workspace);
+
+    const allowedOrigins = [workspaceUrls.subdomainUrl, workspaceUrls.customUrl]
+      .filter(isDefined)
+      .map((workspaceUrl) => new URL(workspaceUrl).origin);
+
+    return allowedOrigins.includes(url.origin);
   }
 }

--- a/packages/twenty-server/src/engine/core-modules/domain/workspace-domains/services/workspace-domains.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/domain/workspace-domains/services/workspace-domains.service.ts
@@ -97,6 +97,23 @@ export class WorkspaceDomainsService {
     return workspace;
   }
 
+  async isWorkspaceDomain(origin: string): Promise<boolean> {
+    const { workspace } = await this.resolveWorkspaceAndPublicDomain(origin);
+
+    if (!isDefined(workspace)) {
+      return false;
+    }
+
+    const { subdomainUrl, customUrl } = this.getWorkspaceUrls(workspace);
+
+    return [subdomainUrl, customUrl]
+      .filter(isDefined)
+      .some(
+        (workspaceUrl) =>
+          new URL(workspaceUrl).origin === new URL(origin).origin,
+      );
+  }
+
   async resolveWorkspaceAndPublicDomain(origin: string): Promise<{
     workspace: WorkspaceEntity | undefined;
     publicDomain: PublicDomainEntity | null;


### PR DESCRIPTION
The propagator only checked that a workspace resolved but in single workspace mode the default workspace resolves for any origin, so the redirect target was never validated against the workspace's actual domains. 

Match url.origin against the resolved workspace URLs so unknown hosts are rejected.

/closes #22109

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/22159?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

