### PR TITLE
fix mobile side panel close

### DIFF
--- a/packages/twenty-front/src/modules/side-panel/components/SidePanelTopBar.tsx
+++ b/packages/twenty-front/src/modules/side-panel/components/SidePanelTopBar.tsx
@@ -142,7 +142,7 @@ export const SidePanelTopBar = () => {
 
   const shouldShowBackButton = canGoBack;
 
-  const shouldShowCloseButton = !isMobile || !shouldShowBackButton;
+  const shouldHideCloseButton = isMobile && shouldShowBackButton;
 
   const lastChip = contextChips.at(-1);
 
@@ -182,7 +182,7 @@ export const SidePanelTopBar = () => {
       </StyledContentContainer>
       <StyledRightControlsContainer>
         <SidePanelTopBarRightCornerIcon />
-        {shouldShowCloseButton && (
+        {!shouldHideCloseButton && (
           <IconButton
             Icon={IconX}
             size="small"

--- a/packages/twenty-front/src/modules/side-panel/components/SidePanelTopBar.tsx
+++ b/packages/twenty-front/src/modules/side-panel/components/SidePanelTopBar.tsx
@@ -142,10 +142,6 @@ export const SidePanelTopBar = () => {
 
   const shouldShowBackButton = canGoBack;
 
-  // On mobile the back button doubles as the dismiss action (going back from
-  // the root closes the panel), so we hide the close button to avoid
-  // redundancy. But when there is no back button the panel would otherwise be
-  // impossible to close, so we always keep the close button available then.
   const shouldShowCloseButton = !isMobile || !shouldShowBackButton;
 
   const lastChip = contextChips.at(-1);

--- a/packages/twenty-front/src/modules/side-panel/components/SidePanelTopBar.tsx
+++ b/packages/twenty-front/src/modules/side-panel/components/SidePanelTopBar.tsx
@@ -142,7 +142,11 @@ export const SidePanelTopBar = () => {
 
   const shouldShowBackButton = canGoBack;
 
-  const shouldShowCloseButton = !isMobile;
+  // On mobile the back button doubles as the dismiss action (going back from
+  // the root closes the panel), so we hide the close button to avoid
+  // redundancy. But when there is no back button the panel would otherwise be
+  // impossible to close, so we always keep the close button available then.
+  const shouldShowCloseButton = !isMobile || !shouldShowBackButton;
 
   const lastChip = contextChips.at(-1);
 

--- a/packages/twenty-front/src/modules/side-panel/components/__stories__/SidePanelTopBar.stories.tsx
+++ b/packages/twenty-front/src/modules/side-panel/components/__stories__/SidePanelTopBar.stories.tsx
@@ -1,5 +1,9 @@
-import { type Decorator, type Meta, type StoryObj } from '@storybook/react-vite';
-import { expect, waitFor, within } from 'storybook/test';
+import {
+  type Decorator,
+  type Meta,
+  type StoryObj,
+} from '@storybook/react-vite';
+import { expect, within } from 'storybook/test';
 
 import { SidePanelTopBar } from '@/side-panel/components/SidePanelTopBar';
 import { isSidePanelOpenedState } from '@/side-panel/states/isSidePanelOpenedState';
@@ -12,47 +16,35 @@ import { ComponentWithRouterDecorator } from '~/testing/decorators/ComponentWith
 import { ObjectMetadataItemsDecorator } from '~/testing/decorators/ObjectMetadataItemsDecorator';
 import { SnackBarDecorator } from '~/testing/decorators/SnackBarDecorator';
 
-type NavigationStackItem = {
+type SidePanelNavigationStackItem = {
   page: SidePanelPages;
   pageTitle: string;
   pageIcon: typeof IconDotsVertical;
   pageId: string;
 };
 
-const ROOT_COMMAND_MENU_STACK: NavigationStackItem[] = [
-  {
-    page: SidePanelPages.CommandMenuDisplay,
-    pageTitle: 'Command Menu',
-    pageIcon: IconDotsVertical,
-    pageId: 'command-menu',
-  },
-];
+const ROOT_PAGE: SidePanelNavigationStackItem = {
+  page: SidePanelPages.CommandMenuDisplay,
+  pageTitle: 'Command Menu',
+  pageIcon: IconDotsVertical,
+  pageId: 'command-menu',
+};
 
-const COMMAND_MENU_SUBPAGE_STACK: NavigationStackItem[] = [
-  ...ROOT_COMMAND_MENU_STACK,
-  {
-    page: SidePanelPages.CommandMenuEdit,
-    pageTitle: 'Edit',
-    pageIcon: IconDotsVertical,
-    pageId: 'command-menu-edit',
-  },
-];
+const SUBPAGE: SidePanelNavigationStackItem = {
+  page: SidePanelPages.CommandMenuEdit,
+  pageTitle: 'Edit',
+  pageIcon: IconDotsVertical,
+  pageId: 'command-menu-edit',
+};
 
-const DIRECTLY_OPENED_RECORD_STACK: NavigationStackItem[] = [
-  {
-    page: SidePanelPages.ViewRecord,
-    pageTitle: 'Company',
-    pageIcon: IconDotsVertical,
-    pageId: 'view-record',
-  },
-];
-
-const createSidePanelStateDecorator = (
-  navigationStack: NavigationStackItem[],
+const createSidePanelDecorator = (
+  navigationStack: SidePanelNavigationStackItem[],
 ): Decorator => {
   return (Story) => {
+    const currentPage = navigationStack[navigationStack.length - 1];
+
     jotaiStore.set(isSidePanelOpenedState.atom, true);
-    jotaiStore.set(sidePanelPageState.atom, navigationStack.at(-1)!.page);
+    jotaiStore.set(sidePanelPageState.atom, currentPage.page);
     jotaiStore.set(sidePanelNavigationStackState.atom, navigationStack);
 
     return <Story />;
@@ -73,7 +65,7 @@ export default meta;
 type Story = StoryObj<typeof SidePanelTopBar>;
 
 export const RootCommandMenu: Story = {
-  decorators: [createSidePanelStateDecorator(ROOT_COMMAND_MENU_STACK)],
+  decorators: [createSidePanelDecorator([ROOT_PAGE])],
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
 
@@ -86,8 +78,8 @@ export const RootCommandMenu: Story = {
   },
 };
 
-export const CommandMenuSubpage: Story = {
-  decorators: [createSidePanelStateDecorator(COMMAND_MENU_SUBPAGE_STACK)],
+export const Subpage: Story = {
+  decorators: [createSidePanelDecorator([ROOT_PAGE, SUBPAGE])],
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
 
@@ -95,58 +87,5 @@ export const CommandMenuSubpage: Story = {
     expect(
       await canvas.findByRole('button', { name: 'Close side panel' }),
     ).toBeVisible();
-  },
-};
-
-export const OpenedDirectly: Story = {
-  decorators: [createSidePanelStateDecorator(DIRECTLY_OPENED_RECORD_STACK)],
-  play: async ({ canvasElement }) => {
-    const canvas = within(canvasElement);
-
-    expect(
-      await canvas.findByRole('button', { name: 'Close side panel' }),
-    ).toBeVisible();
-    expect(
-      canvas.queryByRole('button', { name: 'Back' }),
-    ).not.toBeInTheDocument();
-  },
-};
-
-// On mobile the close button must stay available when there is no back button,
-// otherwise the side panel cannot be dismissed.
-export const MobileRoot: Story = {
-  decorators: [createSidePanelStateDecorator(ROOT_COMMAND_MENU_STACK)],
-  parameters: {
-    viewport: {
-      defaultViewport: 'mobile1',
-    },
-  },
-  play: async ({ canvasElement }) => {
-    const canvas = within(canvasElement);
-
-    expect(
-      await canvas.findByRole('button', { name: 'Close side panel' }),
-    ).toBeVisible();
-  },
-};
-
-// On mobile the back button doubles as the dismiss action, so the close button
-// is hidden to avoid redundancy when a back button is available.
-export const MobileSubpage: Story = {
-  decorators: [createSidePanelStateDecorator(COMMAND_MENU_SUBPAGE_STACK)],
-  parameters: {
-    viewport: {
-      defaultViewport: 'mobile1',
-    },
-  },
-  play: async ({ canvasElement }) => {
-    const canvas = within(canvasElement);
-
-    expect(await canvas.findByRole('button', { name: 'Back' })).toBeVisible();
-    await waitFor(() => {
-      expect(
-        canvas.queryByRole('button', { name: 'Close side panel' }),
-      ).not.toBeInTheDocument();
-    });
   },
 };

--- a/packages/twenty-front/src/modules/side-panel/components/__stories__/SidePanelTopBar.stories.tsx
+++ b/packages/twenty-front/src/modules/side-panel/components/__stories__/SidePanelTopBar.stories.tsx
@@ -1,0 +1,152 @@
+import { type Decorator, type Meta, type StoryObj } from '@storybook/react-vite';
+import { expect, waitFor, within } from 'storybook/test';
+
+import { SidePanelTopBar } from '@/side-panel/components/SidePanelTopBar';
+import { isSidePanelOpenedState } from '@/side-panel/states/isSidePanelOpenedState';
+import { sidePanelNavigationStackState } from '@/side-panel/states/sidePanelNavigationStackState';
+import { sidePanelPageState } from '@/side-panel/states/sidePanelPageState';
+import { jotaiStore } from '@/ui/utilities/state/jotai/jotaiStore';
+import { SidePanelPages } from 'twenty-shared/types';
+import { IconDotsVertical } from 'twenty-ui/icon';
+import { ComponentWithRouterDecorator } from '~/testing/decorators/ComponentWithRouterDecorator';
+import { ObjectMetadataItemsDecorator } from '~/testing/decorators/ObjectMetadataItemsDecorator';
+import { SnackBarDecorator } from '~/testing/decorators/SnackBarDecorator';
+
+type NavigationStackItem = {
+  page: SidePanelPages;
+  pageTitle: string;
+  pageIcon: typeof IconDotsVertical;
+  pageId: string;
+};
+
+const ROOT_COMMAND_MENU_STACK: NavigationStackItem[] = [
+  {
+    page: SidePanelPages.CommandMenuDisplay,
+    pageTitle: 'Command Menu',
+    pageIcon: IconDotsVertical,
+    pageId: 'command-menu',
+  },
+];
+
+const COMMAND_MENU_SUBPAGE_STACK: NavigationStackItem[] = [
+  ...ROOT_COMMAND_MENU_STACK,
+  {
+    page: SidePanelPages.CommandMenuEdit,
+    pageTitle: 'Edit',
+    pageIcon: IconDotsVertical,
+    pageId: 'command-menu-edit',
+  },
+];
+
+const DIRECTLY_OPENED_RECORD_STACK: NavigationStackItem[] = [
+  {
+    page: SidePanelPages.ViewRecord,
+    pageTitle: 'Company',
+    pageIcon: IconDotsVertical,
+    pageId: 'view-record',
+  },
+];
+
+const createSidePanelStateDecorator = (
+  navigationStack: NavigationStackItem[],
+): Decorator => {
+  return (Story) => {
+    jotaiStore.set(isSidePanelOpenedState.atom, true);
+    jotaiStore.set(sidePanelPageState.atom, navigationStack.at(-1)!.page);
+    jotaiStore.set(sidePanelNavigationStackState.atom, navigationStack);
+
+    return <Story />;
+  };
+};
+
+const meta: Meta<typeof SidePanelTopBar> = {
+  title: 'Modules/SidePanel/SidePanelTopBar',
+  component: SidePanelTopBar,
+  decorators: [
+    ObjectMetadataItemsDecorator,
+    SnackBarDecorator,
+    ComponentWithRouterDecorator,
+  ],
+};
+
+export default meta;
+type Story = StoryObj<typeof SidePanelTopBar>;
+
+export const RootCommandMenu: Story = {
+  decorators: [createSidePanelStateDecorator(ROOT_COMMAND_MENU_STACK)],
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    expect(
+      await canvas.findByRole('button', { name: 'Close side panel' }),
+    ).toBeVisible();
+    expect(
+      canvas.queryByRole('button', { name: 'Back' }),
+    ).not.toBeInTheDocument();
+  },
+};
+
+export const CommandMenuSubpage: Story = {
+  decorators: [createSidePanelStateDecorator(COMMAND_MENU_SUBPAGE_STACK)],
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    expect(await canvas.findByRole('button', { name: 'Back' })).toBeVisible();
+    expect(
+      await canvas.findByRole('button', { name: 'Close side panel' }),
+    ).toBeVisible();
+  },
+};
+
+export const OpenedDirectly: Story = {
+  decorators: [createSidePanelStateDecorator(DIRECTLY_OPENED_RECORD_STACK)],
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    expect(
+      await canvas.findByRole('button', { name: 'Close side panel' }),
+    ).toBeVisible();
+    expect(
+      canvas.queryByRole('button', { name: 'Back' }),
+    ).not.toBeInTheDocument();
+  },
+};
+
+// On mobile the close button must stay available when there is no back button,
+// otherwise the side panel cannot be dismissed.
+export const MobileRoot: Story = {
+  decorators: [createSidePanelStateDecorator(ROOT_COMMAND_MENU_STACK)],
+  parameters: {
+    viewport: {
+      defaultViewport: 'mobile1',
+    },
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    expect(
+      await canvas.findByRole('button', { name: 'Close side panel' }),
+    ).toBeVisible();
+  },
+};
+
+// On mobile the back button doubles as the dismiss action, so the close button
+// is hidden to avoid redundancy when a back button is available.
+export const MobileSubpage: Story = {
+  decorators: [createSidePanelStateDecorator(COMMAND_MENU_SUBPAGE_STACK)],
+  parameters: {
+    viewport: {
+      defaultViewport: 'mobile1',
+    },
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    expect(await canvas.findByRole('button', { name: 'Back' })).toBeVisible();
+    await waitFor(() => {
+      expect(
+        canvas.queryByRole('button', { name: 'Close side panel' }),
+      ).not.toBeInTheDocument();
+    });
+  },
+};

--- a/packages/twenty-front/src/modules/side-panel/components/__tests__/SidePanelTopBar.test.tsx
+++ b/packages/twenty-front/src/modules/side-panel/components/__tests__/SidePanelTopBar.test.tsx
@@ -150,56 +150,6 @@ describe('SidePanelTopBar', () => {
     });
   });
 
-  it('shows only the close button on the root command menu', () => {
-    renderSidePanelCommandMenu();
-
-    expect(
-      screen.getByRole('button', { name: 'Close side panel' }),
-    ).toBeInTheDocument();
-    expect(
-      screen.queryByRole('button', { name: 'Back' }),
-    ).not.toBeInTheDocument();
-  });
-
-  it('shows the close button on mobile when there is no back button to dismiss the panel', () => {
-    mockIsMobile = true;
-
-    renderSidePanelCommandMenu();
-
-    expect(
-      screen.getByRole('button', { name: 'Close side panel' }),
-    ).toBeInTheDocument();
-  });
-
-  it('hides the close button on mobile when a back button is available', () => {
-    mockIsMobile = true;
-
-    renderSidePanelCommandMenu(
-      createSidePanelTopBarStore({
-        sidePanelPage: SidePanelPages.SearchRecords,
-        sidePanelNavigationStack: [
-          {
-            page: SidePanelPages.CommandMenuDisplay,
-            pageTitle: 'Command Menu',
-            pageIcon: IconDotsVertical,
-            pageId: 'command-menu',
-          },
-          {
-            page: SidePanelPages.SearchRecords,
-            pageTitle: 'Search',
-            pageIcon: IconDotsVertical,
-            pageId: 'search-records',
-          },
-        ],
-      }),
-    );
-
-    expect(screen.getByRole('button', { name: 'Back' })).toBeInTheDocument();
-    expect(
-      screen.queryByRole('button', { name: 'Close side panel' }),
-    ).not.toBeInTheDocument();
-  });
-
   it('renders the close button after the command menu content', () => {
     renderSidePanelCommandMenu();
 
@@ -214,55 +164,5 @@ describe('SidePanelTopBar', () => {
         Node.DOCUMENT_POSITION_FOLLOWING,
       ),
     ).toBe(true);
-  });
-
-  it('shows both back and close buttons for command menu subpages', () => {
-    renderSidePanelCommandMenu(
-      createSidePanelTopBarStore({
-        sidePanelPage: SidePanelPages.SearchRecords,
-        sidePanelNavigationStack: [
-          {
-            page: SidePanelPages.CommandMenuDisplay,
-            pageTitle: 'Command Menu',
-            pageIcon: IconDotsVertical,
-            pageId: 'command-menu',
-          },
-          {
-            page: SidePanelPages.SearchRecords,
-            pageTitle: 'Search',
-            pageIcon: IconDotsVertical,
-            pageId: 'search-records',
-          },
-        ],
-      }),
-    );
-
-    expect(screen.getByRole('button', { name: 'Back' })).toBeInTheDocument();
-    expect(
-      screen.getByRole('button', { name: 'Close side panel' }),
-    ).toBeInTheDocument();
-  });
-
-  it('shows only the close button when a page was opened directly', () => {
-    renderSidePanelCommandMenu(
-      createSidePanelTopBarStore({
-        sidePanelPage: SidePanelPages.ViewRecord,
-        sidePanelNavigationStack: [
-          {
-            page: SidePanelPages.ViewRecord,
-            pageTitle: 'Company',
-            pageIcon: IconDotsVertical,
-            pageId: 'view-record',
-          },
-        ],
-      }),
-    );
-
-    expect(
-      screen.getByRole('button', { name: 'Close side panel' }),
-    ).toBeInTheDocument();
-    expect(
-      screen.queryByRole('button', { name: 'Back' }),
-    ).not.toBeInTheDocument();
   });
 });

--- a/packages/twenty-front/src/modules/side-panel/components/__tests__/SidePanelTopBar.test.tsx
+++ b/packages/twenty-front/src/modules/side-panel/components/__tests__/SidePanelTopBar.test.tsx
@@ -161,11 +161,40 @@ describe('SidePanelTopBar', () => {
     ).not.toBeInTheDocument();
   });
 
-  it('does not show the close button on mobile', () => {
+  it('shows the close button on mobile when there is no back button to dismiss the panel', () => {
     mockIsMobile = true;
 
     renderSidePanelCommandMenu();
 
+    expect(
+      screen.getByRole('button', { name: 'Close side panel' }),
+    ).toBeInTheDocument();
+  });
+
+  it('hides the close button on mobile when a back button is available', () => {
+    mockIsMobile = true;
+
+    renderSidePanelCommandMenu(
+      createSidePanelTopBarStore({
+        sidePanelPage: SidePanelPages.SearchRecords,
+        sidePanelNavigationStack: [
+          {
+            page: SidePanelPages.CommandMenuDisplay,
+            pageTitle: 'Command Menu',
+            pageIcon: IconDotsVertical,
+            pageId: 'command-menu',
+          },
+          {
+            page: SidePanelPages.SearchRecords,
+            pageTitle: 'Search',
+            pageIcon: IconDotsVertical,
+            pageId: 'search-records',
+          },
+        ],
+      }),
+    );
+
+    expect(screen.getByRole('button', { name: 'Back' })).toBeInTheDocument();
     expect(
       screen.queryByRole('button', { name: 'Close side panel' }),
     ).not.toBeInTheDocument();

--- a/packages/twenty-front/src/modules/side-panel/components/__tests__/SidePanelTopBar.test.tsx
+++ b/packages/twenty-front/src/modules/side-panel/components/__tests__/SidePanelTopBar.test.tsx
@@ -165,4 +165,43 @@ describe('SidePanelTopBar', () => {
       ),
     ).toBe(true);
   });
+
+  it('shows the close button on mobile when there is no back button to dismiss the panel', () => {
+    mockIsMobile = true;
+
+    renderSidePanelCommandMenu();
+
+    expect(
+      screen.getByRole('button', { name: 'Close side panel' }),
+    ).toBeInTheDocument();
+  });
+
+  it('hides the close button on mobile when a back button is available', () => {
+    mockIsMobile = true;
+
+    renderSidePanelCommandMenu(
+      createSidePanelTopBarStore({
+        sidePanelPage: SidePanelPages.SearchRecords,
+        sidePanelNavigationStack: [
+          {
+            page: SidePanelPages.CommandMenuDisplay,
+            pageTitle: 'Command Menu',
+            pageIcon: IconDotsVertical,
+            pageId: 'command-menu',
+          },
+          {
+            page: SidePanelPages.SearchRecords,
+            pageTitle: 'Search',
+            pageIcon: IconDotsVertical,
+            pageId: 'search-records',
+          },
+        ],
+      }),
+    );
+
+    expect(screen.getByRole('button', { name: 'Back' })).toBeInTheDocument();
+    expect(
+      screen.queryByRole('button', { name: 'Close side panel' }),
+    ).not.toBeInTheDocument();
+  });
 });


### PR DESCRIPTION
The side panel close (X) button was hidden on all mobile views, while the back button only renders when there is navigation history. When the side panel is opened at the root (e.g. viewing a record directly with a single-item navigation stack), neither button was shown, leaving no way to dismiss the panel on mobile.

Keep the close button available on mobile whenever there is no back button to fall back on, so the panel is always dismissable.

## Before

https://github.com/user-attachments/assets/61891d25-26b8-4ba4-8b05-73fd44f92d89

## After

https://github.com/user-attachments/assets/41342722-bcaf-420b-83bb-3cafaec49516

