### PR TITLE
fix(docs): correct typos in multiple files

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -28,7 +28,7 @@ npx jest path/to/test.test.ts --config=packages/PROJECT/jest.config.mjs
 npx nx test twenty-front      # Frontend unit tests
 npx nx test twenty-server     # Backend unit tests
 npx nx run twenty-server:test:integration:with-db-reset  # Integration tests with DB reset
-# To run an indivual test or a pattern of tests, use the following command:
+# To run an individual test or a pattern of tests, use the following command:
 cd packages/{workspace} && npx jest "pattern or filename"
 
 # Storybook

--- a/packages/twenty-docs/user-guide/getting-started/how-tos/navigate-around-twenty.mdx
+++ b/packages/twenty-docs/user-guide/getting-started/how-tos/navigate-around-twenty.mdx
@@ -36,7 +36,7 @@ From there, you can:
 <img src="/images/user-guide/home/command-menu.png" style={{width:'100%'}}/>
 
 ## The Search Bar
-The search bar is accesible via the Command Menu, at the top of your navigation bar, or by pressing `/` to focus on it instantly. Search works across all object.
+The search bar is accessible via the Command Menu, at the top of your navigation bar, or by pressing `/` to focus on it instantly. Search works across all object.
 
 <img src="/images/user-guide/home/search-bar.png" style={{width:'100%'}}/>
 

--- a/packages/twenty-docs/user-guide/getting-started/how-tos/navigate-around-twenty.mdx
+++ b/packages/twenty-docs/user-guide/getting-started/how-tos/navigate-around-twenty.mdx
@@ -36,7 +36,7 @@ From there, you can:
 <img src="/images/user-guide/home/command-menu.png" style={{width:'100%'}}/>
 
 ## The Search Bar
-The search bar is accessible via the Command Menu, at the top of your navigation bar, or by pressing `/` to focus on it instantly. Search works across all object.
++The search bar is accessible via the Command Menu, at the top of your navigation bar, or by pressing `/` to focus on it instantly. Search works across all objects.
 
 <img src="/images/user-guide/home/search-bar.png" style={{width:'100%'}}/>
 

--- a/packages/twenty-docs/user-guide/views-pipelines/overview.mdx
+++ b/packages/twenty-docs/user-guide/views-pipelines/overview.mdx
@@ -44,7 +44,7 @@ There are two ways to create a new view.
 
 <VimeoEmbed videoId="1145648745" title="Video demonstration" />
 
-### Start by editting an existing view
+### Start by editing an existing view
 1. Navigate to any object (People, Companies, etc.)
 2. Choose a layout (Table, Kanban, or Calendar) under **Options** or Add filters and sorting as needed
 3. Click on **Save as new view**


### PR DESCRIPTION
Corrects spelling errors across three documentation files.

- `indivual` -> `individual` in `./CLAUDE.md`
- `accesible` -> `accessible` in `./packages/twenty-docs/user-guide/getting-started/how-tos/navigate-around-twenty.mdx`
- `editting` -> `editing` in `packages/twenty-docs/user-guide/views-pipelines/overview.mdx`

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/22173?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

