### PR TITLE
fix(workflow): avoid 'file not found' when duplicating unbuilt code steps

### DIFF
--- a/packages/twenty-server/src/engine/core-modules/logic-function/logic-function-resource/logic-function-resource.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/logic-function/logic-function-resource/logic-function-resource.service.ts
@@ -227,6 +227,17 @@ export class LogicFunctionResourceService {
       },
     });
 
+    const builtFileExists = await this.fileStorageService.checkFileExists({
+      workspaceId,
+      applicationUniversalIdentifier,
+      fileFolder: FileFolder.BuiltLogicFunction,
+      resourcePath: fromBuiltHandlerPath,
+    });
+
+    if (!builtFileExists) {
+      return;
+    }
+
     await this.fileStorageService.copy({
       from: {
         workspaceId,


### PR DESCRIPTION
## Context
Duplicating a workflow version (e.g. when editing an active workflow) clones each Code step's logic function via copyResources, which copied both the source and the built artifact unconditionally. Logic functions created from source are not built yet (no index.mjs, isBuildUpToDate=false), so copying the missing built file threw FILE_NOT_FOUND.

Copy the built artifact only when it exists. This is safe because the duplicate inherits isBuildUpToDate=false and is rebuilt lazily on activation or run.

In seed dev case for example, they are created with source but never built

## Test

https://github.com/user-attachments/assets/5a7febba-413b-4041-985e-f84a99a5ebda

