### PR TITLE
fix(messaging): stop related-person walk from traversing message/calendar participants

### DIFF
--- a/packages/twenty-server/src/engine/core-modules/related-person-ids/utils/__tests__/find-relation-paths-to-person.util.spec.ts
+++ b/packages/twenty-server/src/engine/core-modules/related-person-ids/utils/__tests__/find-relation-paths-to-person.util.spec.ts
@@ -261,6 +261,65 @@ describe('findRelationPathsToPerson', () => {
     ]);
   });
 
+  it('does not reach person through the messageParticipant junction (would flood the timeline with the owner mailbox)', () => {
+    const { flatObjectMetadataMaps, flatFieldMetadataMaps } =
+      buildGraphFixtures({
+        opportunity: [
+          {
+            fieldName: 'pointOfContact',
+            relationType: RelationType.MANY_TO_ONE,
+            targetObjectNameSingular: 'person',
+            inverseFieldName: 'pointOfContactForOpportunities',
+          },
+          {
+            fieldName: 'owner',
+            relationType: RelationType.MANY_TO_ONE,
+            targetObjectNameSingular: 'workspaceMember',
+            inverseFieldName: 'opportunities',
+          },
+        ],
+        workspaceMember: [
+          {
+            fieldName: 'messageParticipants',
+            relationType: RelationType.ONE_TO_MANY,
+            targetObjectNameSingular: 'messageParticipant',
+            inverseFieldName: 'workspaceMember',
+          },
+        ],
+        messageParticipant: [
+          {
+            fieldName: 'workspaceMember',
+            relationType: RelationType.MANY_TO_ONE,
+            targetObjectNameSingular: 'workspaceMember',
+            inverseFieldName: 'messageParticipants',
+          },
+          {
+            fieldName: 'person',
+            relationType: RelationType.MANY_TO_ONE,
+            targetObjectNameSingular: 'person',
+            inverseFieldName: 'messageParticipants',
+          },
+        ],
+        person: [],
+      });
+
+    expect(
+      findRelationPathsToPerson({
+        rootObjectNameSingular: 'opportunity',
+        flatObjectMetadataMaps,
+        flatFieldMetadataMaps,
+      }),
+    ).toEqual([
+      [
+        {
+          direction: RelationType.MANY_TO_ONE,
+          queryObjectNameSingular: 'opportunity',
+          joinColumnName: 'pointOfContactId',
+        },
+      ],
+    ]);
+  });
+
   it('returns no path when person is unreachable, terminating on relation cycles', () => {
     const { flatObjectMetadataMaps, flatFieldMetadataMaps } =
       buildGraphFixtures({

--- a/packages/twenty-server/src/engine/core-modules/related-person-ids/utils/find-relation-paths-to-person.util.ts
+++ b/packages/twenty-server/src/engine/core-modules/related-person-ids/utils/find-relation-paths-to-person.util.ts
@@ -15,6 +15,17 @@ import { buildObjectIdByNameMaps } from 'src/engine/metadata-modules/flat-object
 const PERSON_OBJECT_NAME_SINGULAR = 'person';
 const DEFAULT_MAX_RELATION_DEPTH_TO_PERSON = 3;
 
+// Junction objects that must not be traversed when resolving the people related
+// to a record. Walking through message/calendar participants makes the
+// definition circular: from a record's owner (a workspace member) the walk
+// would reach every person who ever co-participated in any of the owner's
+// messages or events, flooding the record's email/calendar timeline with the
+// owner's entire mailbox instead of the record's actual contacts.
+const EXCLUDED_INTERMEDIATE_OBJECT_NAME_SINGULARS = new Set<string>([
+  'messageParticipant',
+  'calendarEventParticipant',
+]);
+
 export type RelationHopToPerson = {
   direction: RelationType;
   queryObjectNameSingular: string;
@@ -110,7 +121,12 @@ export const findRelationPathsToPerson = ({
           PERSON_OBJECT_NAME_SINGULAR
         ) {
           pathsToPerson.push(nextPath);
-        } else if (!visitedObjectIds.has(targetObjectId)) {
+        } else if (
+          !visitedObjectIds.has(targetObjectId) &&
+          !EXCLUDED_INTERMEDIATE_OBJECT_NAME_SINGULARS.has(
+            relation.targetObjectMetadata.nameSingular,
+          )
+        ) {
           objectIdsReachedThisDepth.add(targetObjectId);
           nextFrontier.push({ objectId: targetObjectId, path: nextPath });
         }


### PR DESCRIPTION
## Problem

The record email/calendar timeline resolves "related people" by walking the relation graph from the record to the `person` object (`findRelationPathsToPerson`, up to 3 hops). This walk traversed the `messageParticipant` and `calendarEventParticipant` junctions.

Because of that, from a record's owner (a workspace member) the walk reached **every person who ever co-participated in any of the owner's messages or calendar events**. On an Opportunity, the Emails tab then showed the owner's entire mailbox (hundreds of unrelated threads) instead of the opportunity's actual contacts.

It's effectively a circular definition: the email timeline ends up including people who are "related" only by appearing in emails.

### Repro
1. Open an Opportunity whose `owner` has a synced mailbox.
2. Open the Emails tab.
3. Observe threads from unrelated companies (everything the owner ever emailed), not just the opportunity's contacts.

## Fix

Exclude the `messageParticipant` and `calendarEventParticipant` junction objects from the traversal. Direct relations to `person` (point of contact, company people, note/task targets) are unaffected.

## Tests

Added a regression test reproducing the `opportunity -> owner -> messageParticipant -> person` leak; it now resolves to only the point-of-contact path. All existing tests in the suite pass.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/22181?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

