### PR TITLE
fix(messaging): exclude message/calendar participants from related-person walk

### DIFF
--- a/packages/twenty-server/src/engine/core-modules/related-person-ids/utils/__tests__/find-relation-paths-to-person.util.spec.ts
+++ b/packages/twenty-server/src/engine/core-modules/related-person-ids/utils/__tests__/find-relation-paths-to-person.util.spec.ts
@@ -261,6 +261,65 @@ describe('findRelationPathsToPerson', () => {
     ]);
   });
 
+  it('does not reach person through the messageParticipant junction (would flood the timeline with the owner mailbox)', () => {
+    const { flatObjectMetadataMaps, flatFieldMetadataMaps } =
+      buildGraphFixtures({
+        opportunity: [
+          {
+            fieldName: 'pointOfContact',
+            relationType: RelationType.MANY_TO_ONE,
+            targetObjectNameSingular: 'person',
+            inverseFieldName: 'pointOfContactForOpportunities',
+          },
+          {
+            fieldName: 'owner',
+            relationType: RelationType.MANY_TO_ONE,
+            targetObjectNameSingular: 'workspaceMember',
+            inverseFieldName: 'opportunities',
+          },
+        ],
+        workspaceMember: [
+          {
+            fieldName: 'messageParticipants',
+            relationType: RelationType.ONE_TO_MANY,
+            targetObjectNameSingular: 'messageParticipant',
+            inverseFieldName: 'workspaceMember',
+          },
+        ],
+        messageParticipant: [
+          {
+            fieldName: 'workspaceMember',
+            relationType: RelationType.MANY_TO_ONE,
+            targetObjectNameSingular: 'workspaceMember',
+            inverseFieldName: 'messageParticipants',
+          },
+          {
+            fieldName: 'person',
+            relationType: RelationType.MANY_TO_ONE,
+            targetObjectNameSingular: 'person',
+            inverseFieldName: 'messageParticipants',
+          },
+        ],
+        person: [],
+      });
+
+    expect(
+      findRelationPathsToPerson({
+        rootObjectNameSingular: 'opportunity',
+        flatObjectMetadataMaps,
+        flatFieldMetadataMaps,
+      }),
+    ).toEqual([
+      [
+        {
+          direction: RelationType.MANY_TO_ONE,
+          queryObjectNameSingular: 'opportunity',
+          joinColumnName: 'pointOfContactId',
+        },
+      ],
+    ]);
+  });
+
   it('returns no path when person is unreachable, terminating on relation cycles', () => {
     const { flatObjectMetadataMaps, flatFieldMetadataMaps } =
       buildGraphFixtures({

--- a/packages/twenty-server/src/engine/core-modules/related-person-ids/utils/find-relation-paths-to-person.util.ts
+++ b/packages/twenty-server/src/engine/core-modules/related-person-ids/utils/find-relation-paths-to-person.util.ts
@@ -15,6 +15,13 @@ import { buildObjectIdByNameMaps } from 'src/engine/metadata-modules/flat-object
 const PERSON_OBJECT_NAME_SINGULAR = 'person';
 const DEFAULT_MAX_RELATION_DEPTH_TO_PERSON = 3;
 
+// Skip participant junctions: traversing them pulls in the owner's whole
+// mailbox via owner -> participant -> person.
+const EXCLUDED_INTERMEDIATE_OBJECT_NAME_SINGULARS = new Set<string>([
+  'messageParticipant',
+  'calendarEventParticipant',
+]);
+
 export type RelationHopToPerson = {
   direction: RelationType;
   queryObjectNameSingular: string;
@@ -110,7 +117,12 @@ export const findRelationPathsToPerson = ({
           PERSON_OBJECT_NAME_SINGULAR
         ) {
           pathsToPerson.push(nextPath);
-        } else if (!visitedObjectIds.has(targetObjectId)) {
+        } else if (
+          !visitedObjectIds.has(targetObjectId) &&
+          !EXCLUDED_INTERMEDIATE_OBJECT_NAME_SINGULARS.has(
+            relation.targetObjectMetadata.nameSingular,
+          )
+        ) {
           objectIdsReachedThisDepth.add(targetObjectId);
           nextFrontier.push({ objectId: targetObjectId, path: nextPath });
         }


### PR DESCRIPTION
## The issue

The record Emails/Calendar timeline finds "related people" by walking relations from the record to `person`. It traversed `messageParticipant` and `calendarEventParticipant`, so via a record's owner it pulled in everyone the owner ever emailed. An opportunity's Emails tab showed the owner's whole mailbox instead of the record's contacts.

## Fix

Skip those two participant junctions in the walk. Direct relations (point of contact, company people, note/task targets) are unaffected. Added a regression test.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/22182?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

