### PR TITLE
Add dashboard print action

### DIFF
--- a/packages/twenty-front/src/modules/page-layout/components/PageLayoutDashboardActions.tsx
+++ b/packages/twenty-front/src/modules/page-layout/components/PageLayoutDashboardActions.tsx
@@ -1,0 +1,34 @@
+import { t } from '@lingui/core/macro';
+import { styled } from '@linaria/react';
+import { IconPrinter } from 'twenty-ui/icon';
+import { Button } from 'twenty-ui/input';
+
+const StyledContainer = styled.div`
+  align-items: center;
+  display: flex;
+  flex-shrink: 0;
+  justify-content: flex-end;
+  padding: 0 8px 8px;
+
+  @media print {
+    display: none;
+  }
+`;
+
+export const PageLayoutDashboardActions = () => {
+  const handlePrintDashboard = () => {
+    window.print();
+  };
+
+  return (
+    <StyledContainer data-print-hidden>
+      <Button
+        Icon={IconPrinter}
+        onClick={handlePrintDashboard}
+        size="small"
+        title={t`Print dashboard`}
+        variant="secondary"
+      />
+    </StyledContainer>
+  );
+};

--- a/packages/twenty-front/src/modules/page-layout/components/PageLayoutTabsRenderer.tsx
+++ b/packages/twenty-front/src/modules/page-layout/components/PageLayoutTabsRenderer.tsx
@@ -1,6 +1,7 @@
 import { metadataStoreState } from '@/metadata-store/states/metadataStoreState';
 import { type FlatObjectMetadataItem } from '@/metadata-store/types/FlatObjectMetadataItem';
 import { useObjectMetadataItems } from '@/object-metadata/hooks/useObjectMetadataItems';
+import { PageLayoutDashboardActions } from '@/page-layout/components/PageLayoutDashboardActions';
 import { PageLayoutLeftPanel } from '@/page-layout/components/PageLayoutLeftPanel';
 import { PageLayoutTabList } from '@/page-layout/components/PageLayoutTabList';
 import { PageLayoutTabListEffect } from '@/page-layout/components/PageLayoutTabListEffect';
@@ -26,6 +27,7 @@ import { useAtomFamilyStateValue } from '@/ui/utilities/state/jotai/hooks/useAto
 import { styled } from '@linaria/react';
 import { useMemo } from 'react';
 import { FieldMetadataType } from 'twenty-shared/types';
+import { PageLayoutType } from '~/generated-metadata/graphql';
 import { isDefined } from 'twenty-shared/utils';
 import { useIsMobile } from 'twenty-ui/utilities';
 
@@ -36,17 +38,32 @@ const StyledContainer = styled.div<{ hasPinnedTab: boolean }>`
   grid-template-rows: minmax(0, 1fr);
   height: 100%;
   width: 100%;
+
+  @media print {
+    display: block;
+    height: auto;
+    width: auto;
+  }
 `;
 
 const StyledTabsAndDashboardContainer = styled.div`
   display: flex;
   flex-direction: column;
   overflow: hidden;
+
+  @media print {
+    display: block;
+    overflow: visible;
+  }
 `;
 
 const StyledScrollWrapperContainer = styled.div`
   flex: 1;
   min-height: 0;
+
+  @media print {
+    min-height: auto;
+  }
 `;
 
 export const PageLayoutTabsRenderer = () => {
@@ -203,6 +220,9 @@ export const PageLayoutTabsRenderer = () => {
             pageLayoutType={currentPageLayout.type}
           />
         )}
+
+        {currentPageLayout.type === PageLayoutType.DASHBOARD &&
+          !isPageLayoutInEditMode && <PageLayoutDashboardActions />}
 
         <StyledScrollWrapperContainer>
           <ScrollWrapper


### PR DESCRIPTION
## Summary
- add a dashboard-level "Print dashboard" action for dashboard page layouts
- call the browser print dialog so users can print or save dashboards as PDF
- add print-safe layout styles so dashboard content can expand instead of being clipped by the app scroll containers

## Test Plan
- [x] `PATH=/opt/data/.local/node/node-v24.5.0-linux-x64/bin:$PATH npx oxlint --type-aware -c packages/twenty-front/.oxlintrc.json packages/twenty-front/src/modules/page-layout/components/PageLayoutTabsRenderer.tsx packages/twenty-front/src/modules/page-layout/components/PageLayoutDashboardActions.tsx`
- [x] `PATH=/opt/data/.local/node/node-v24.5.0-linux-x64/bin:$PATH corepack yarn nx typecheck twenty-front`
- [x] `PATH=/opt/data/.local/node/node-v24.5.0-linux-x64/bin:$PATH corepack yarn nx build twenty-front`


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/22195?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

