### PR TITLE
ci(zapier): retry Zapier test step to absorb server warm-up flakiness

### DIFF
--- a/.github/workflows/ci-zapier.yaml
+++ b/.github/workflows/ci-zapier.yaml
@@ -82,7 +82,19 @@ jobs:
       - name: Zapier / Build
         run: npx nx build twenty-zapier
 
+      # The server warms its metadata/GraphQL schema lazily, so the first Zapier
+      # requests can hit it before it is fully request-ready and fail with a
+      # "Premature close". Retry once against the now-warm server before failing.
       - name: Zapier / Run Tests
+        id: zapier-tests
+        continue-on-error: true
+        uses: ./.github/actions/nx-affected
+        with:
+          tag: scope:zapier
+          tasks: test
+
+      - name: Zapier / Run Tests (retry)
+        if: steps.zapier-tests.outcome == 'failure'
         uses: ./.github/actions/nx-affected
         with:
           tag: scope:zapier


### PR DESCRIPTION
## Problem
`CI Zapier` (`server-setup` job) intermittently fails with:
```
AppError: query: ... error: Invalid response body while trying to fetch http://localhost:3000/graphql: Premature close
```
This blocks unrelated PRs (e.g. workflow/front changes) whose code is correct.

## Root cause
The job starts the server with `start:ci &` and waits **only** for `/healthz`. The Zapier tests then immediately call `/graphql` and `/metadata`, which can still be building the workspace metadata schema. Requests that land during that warm-up window get a dropped connection (`Premature close`). The server itself starts cleanly (all routes mapped, "Nest application successfully started", no crash/OOM) — it's purely a readiness/timing window.

This was verified by running the exact failing Zapier suites (`authentication`, `crud_record`) against a locally-running server built from an affected branch — **all pass** (8/8). So the failure is a CI readiness race, not a code defect.

## Fix
Retry the Zapier test step once. The server is started in an earlier step and persists across steps, so the retry runs against a now-warm server. The first attempt is `continue-on-error`; if it fails, a second attempt runs and determines the job result.

Minimal, no new action dependencies.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/22198?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

