### PR TITLE
Fix settings page root overflow

### DIFF
--- a/packages/twenty-front/src/modules/ui/layout/page/components/DefaultLayout.tsx
+++ b/packages/twenty-front/src/modules/ui/layout/page/components/DefaultLayout.tsx
@@ -29,6 +29,7 @@ const StyledLayout = styled.div`
   display: flex;
   flex-direction: column;
   height: 100dvh;
+  overflow: hidden;
   position: relative;
   scrollbar-color: ${themeCssVariables.border.color.medium} transparent;
   scrollbar-width: 4px;


### PR DESCRIPTION
## Summary

- Clamp the fixed app shell with `overflow: hidden` so long nested settings scroll content no longer contributes to the document root scroll range.
- Keeps the object permission page scrolling inside its existing settings `ScrollWrapper` instead of letting the whole page slide under the viewport.

## Screenshots

Before: root document can scroll under the bottom of the viewport and exposes the gray app background.

![Before root scroll](https://raw.githubusercontent.com/twentyhq/twenty/bonapara/pr-screenshots-settings-root-scroll-20260626/.github/pr-screenshots/fix-settings-root-scroll/before-object-permission-root-scroll.png)

After: the same root scroll attempt leaves the app shell fixed to the viewport.

![After root scroll](https://raw.githubusercontent.com/twentyhq/twenty/bonapara/pr-screenshots-settings-root-scroll-20260626/.github/pr-screenshots/fix-settings-root-scroll/after-object-permission-root-scroll.png)

## Browser Validation

Route tested: `/settings/members/roles/78fa69cb-1237-43b5-bfa5-5a11a47bf781/object/5ab1a16b-7811-471f-ac53-940666c667dd`

- Before on `http://apple.localhost:3001`: `window.scrollTo(0, 9999)` moved the root to `scrollY=244.5`; `htmlScrollHeight=1287`, `htmlClientHeight=1043`.
- After on `http://apple.localhost:3002`: the same root scroll attempt stayed at `scrollY=0`; `htmlScrollHeight=1043`, `htmlClientHeight=1043`.
- The settings content still scrolls internally: wrapper `scrollHeight=1475`, `clientHeight=955`.

## Checks

- `git diff --check`
- `yarn oxfmt --check packages/twenty-front/src/modules/ui/layout/page/components/DefaultLayout.tsx`
- `cd packages/twenty-front && npx oxlint --type-aware -c .oxlintrc.json src/modules/ui/layout/page/components/DefaultLayout.tsx`


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/22207?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

