### PR TITLE
Refactor GitHub Actions workflows for app publishing

### DIFF
--- a/packages/create-twenty-app/src/constants/template/README.md
+++ b/packages/create-twenty-app/src/constants/template/README.md
@@ -18,6 +18,25 @@ Run `yarn twenty help` to list all available commands.
 - `yarn test:unit` - Run unit tests
 - `yarn test` - Run integration tests
 
+## Continuous Integration & Deployment
+
+This app ships with two self-contained GitHub Actions workflows:
+
+- **CI** (`.github/workflows/ci.yml`) - on every push and pull request, spins up a
+  disposable Twenty test instance, then runs lint, typecheck, unit and integration
+  tests. No setup required.
+- **CD** (`.github/workflows/cd.yml`) - on every push to `main` (or manually via
+  "Run workflow"), publishes the app privately to a dedicated Twenty workspace and
+  installs it there.
+
+To enable deployments, add these repository secrets
+(Settings → Secrets and variables → Actions):
+
+- `TWENTY_API_URL` - base URL of your dedicated Twenty workspace
+- `TWENTY_API_KEY` - an API key for that workspace
+
+You can also publish from your machine with `yarn twenty app:publish --private`.
+
 ## Learn More
 
 - [Twenty Apps documentation](https://docs.twenty.com/developers/extend/apps/getting-started/quick-start)

--- a/packages/create-twenty-app/src/constants/template/github/workflows/cd.yml
+++ b/packages/create-twenty-app/src/constants/template/github/workflows/cd.yml
@@ -1,42 +1,65 @@
 name: CD
 
+# Publishes this app privately to a dedicated Twenty workspace.
+#
+# Configure these repository secrets before enabling the workflow
+# (Settings → Secrets and variables → Actions):
+#   - TWENTY_API_URL: base URL of your dedicated Twenty workspace
+#                     (e.g. https://my-workspace.twenty.com)
+#   - TWENTY_API_KEY: an API key for that workspace
 on:
   push:
     branches:
       - main
-  pull_request:
-    types: [labeled]
+  workflow_dispatch: {}
 
 permissions:
   contents: read
-
-env:
-  TWENTY_DEPLOY_URL: http://localhost:2020
 
 concurrency:
   group: cd-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:
-  deploy-and-install:
-    if: >-
-      github.event_name == 'push' ||
-      (github.event_name == 'pull_request' && github.event.label.name == 'deploy')
+  publish:
     runs-on: ubuntu-latest
+    env:
+      TWENTY_API_URL: ${{ secrets.TWENTY_API_URL }}
+      TWENTY_API_KEY: ${{ secrets.TWENTY_API_KEY }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-        with:
-          ref: ${{ github.event.pull_request.head.sha || github.sha }}
 
-      - name: Deploy
-        uses: twentyhq/twenty/.github/actions/deploy-twenty-app@main
-        with:
-          api-url: ${{ env.TWENTY_DEPLOY_URL }}
-          api-key: ${{ secrets.TWENTY_DEPLOY_API_KEY }}
+      - name: Enable Corepack
+        run: corepack enable
 
-      - name: Install
-        uses: twentyhq/twenty/.github/actions/install-twenty-app@main
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
         with:
-          api-url: ${{ env.TWENTY_DEPLOY_URL }}
-          api-key: ${{ secrets.TWENTY_DEPLOY_API_KEY }}
+          node-version-file: '.nvmrc'
+          cache: yarn
+
+      - name: Install dependencies
+        run: yarn install --immutable
+
+      - name: Configure the dedicated workspace remote
+        run: |
+          if [ -z "$TWENTY_API_URL" ] || [ -z "$TWENTY_API_KEY" ]; then
+            echo "::error::Set the TWENTY_API_URL and TWENTY_API_KEY repository secrets."
+            exit 1
+          fi
+          mkdir -p ~/.twenty
+          node -e "
+            const fs = require('fs'), path = require('path'), os = require('os');
+            fs.writeFileSync(path.join(os.homedir(), '.twenty', 'config.json'), JSON.stringify({
+              version: 1,
+              defaultRemote: 'workspace',
+              remotes: { workspace: { apiUrl: process.env.TWENTY_API_URL, apiKey: process.env.TWENTY_API_KEY } }
+            }, null, 2));
+          "
+
+      - name: Publish privately to the workspace
+        run: yarn twenty app:publish --private --remote workspace
+
+      - name: Install on the workspace
+        run: yarn twenty app:install --remote workspace

--- a/packages/create-twenty-app/src/constants/template/github/workflows/ci.yml
+++ b/packages/create-twenty-app/src/constants/template/github/workflows/ci.yml
@@ -10,7 +10,14 @@ permissions:
   contents: read
 
 env:
+  # Public Twenty all-in-one dev image (server + worker + database + redis)
+  # used to run integration tests. Pin to a version tag (e.g. v1.20.0) for
+  # reproducible CI runs.
   TWENTY_VERSION: latest
+  TWENTY_TEST_PORT: '2021'
+  # Seeded API key for the demo workspace shipped inside twenty-app-dev.
+  # This is public test data, not a secret.
+  TWENTY_TEST_API_KEY: eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIyMDIwMjAyMC0xYzI1LTRkMDItYmYyNS02YWVjY2Y3ZWE0MTkiLCJ0eXBlIjoiQVBJX0tFWSIsIndvcmtzcGFjZUlkIjoiMjAyMDIwMjAtMWMyNS00ZDAyLWJmMjUtNmFlY2NmN2VhNDE5IiwiaWF0IjoxNzM1Njg5NjAwLCJleHAiOjQ4OTE0NDk2MDAsImp0aSI6IjIwMjAyMDIwLWY0MDEtNGQ4YS1hNzMxLTY0ZDAwN2MyN2JhZCJ9.bfQjfyN0NEtTCLE_xPyNcwonDzlSXFoP8kdCQTdnuDc
 
 concurrency:
   group: ci-${{ github.ref }}
@@ -23,11 +30,30 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Spawn Twenty test instance
-        id: twenty
-        uses: twentyhq/twenty/.github/actions/spawn-twenty-app-dev-test@main
-        with:
-          twenty-version: ${{ env.TWENTY_VERSION }}
+      - name: Start Twenty test instance
+        run: |
+          docker run -d \
+            --name twenty-test \
+            -p "${TWENTY_TEST_PORT}:${TWENTY_TEST_PORT}" \
+            -e NODE_PORT="${TWENTY_TEST_PORT}" \
+            -e SERVER_URL="http://localhost:${TWENTY_TEST_PORT}" \
+            -e MARKETPLACE_CATALOG_SYNC_CRON_ENABLED=false \
+            "twentycrm/twenty-app-dev:${TWENTY_VERSION}"
+
+          echo "Waiting for the Twenty test instance to become healthy…"
+          TIMEOUT=180
+          ELAPSED=0
+          until curl -sf "http://localhost:${TWENTY_TEST_PORT}/healthz" > /dev/null 2>&1; do
+            if [ "$ELAPSED" -ge "$TIMEOUT" ]; then
+              echo "::error::Twenty did not become healthy within ${TIMEOUT}s"
+              docker logs twenty-test 2>&1 | tail -80
+              exit 1
+            fi
+            sleep 3
+            ELAPSED=$((ELAPSED + 3))
+            echo "  … waited ${ELAPSED}s"
+          done
+          echo "Twenty test instance ready at http://localhost:${TWENTY_TEST_PORT}"
 
       - name: Enable Corepack
         run: corepack enable
@@ -50,8 +76,8 @@ jobs:
       - name: Unit tests
         run: yarn test:unit
 
-      - name: Run integration tests
+      - name: Integration tests
         run: yarn test
         env:
-          TWENTY_API_URL: ${{ steps.twenty.outputs.server-url }}
-          TWENTY_API_KEY: ${{ steps.twenty.outputs.api-key }}
+          TWENTY_API_URL: http://localhost:${{ env.TWENTY_TEST_PORT }}
+          TWENTY_API_KEY: ${{ env.TWENTY_TEST_API_KEY }}


### PR DESCRIPTION
## Summary

Refactored the CI and CD GitHub Actions workflows in the create-twenty-app template to improve reliability, clarity, and user experience. The CD workflow now publishes apps to a dedicated Twenty workspace instead of a local instance, while the CI workflow uses inline Docker commands instead of custom actions.

## Key Changes

### CD Workflow (`cd.yml`)
- **Changed trigger**: Removed pull request label-based deployment; now triggers on pushes to `main` and manual workflow dispatch
- **Removed local deployment**: Replaced hardcoded local deployment (`http://localhost:2020`) with configurable dedicated workspace via repository secrets
- **Updated configuration**: Now requires `TWENTY_API_URL` and `TWENTY_API_KEY` secrets instead of `TWENTY_DEPLOY_API_KEY`
- **Replaced custom actions**: Removed dependency on `twentyhq/twenty` custom actions (`deploy-twenty-app`, `install-twenty-app`)
- **Added inline setup**: Implemented Node.js setup, Corepack, and dependency installation directly in workflow
- **Added workspace configuration**: Implemented inline script to configure the Twenty CLI with workspace credentials
- **Updated deployment commands**: Changed to use `yarn twenty app:publish --private --remote workspace` and `yarn twenty app:install --remote workspace`
- **Added documentation**: Added comprehensive comments explaining required secrets and workflow purpose

### CI Workflow (`ci.yml`)
- **Replaced custom action**: Removed `spawn-twenty-app-dev-test` custom action and replaced with inline Docker commands
- **Added environment variables**: Introduced `TWENTY_TEST_PORT` and `TWENTY_TEST_API_KEY` with documentation
- **Implemented health check**: Added polling logic to wait for Twenty instance to become healthy (up to 180s timeout)
- **Improved error handling**: Added detailed error messages and Docker logs output on timeout
- **Simplified configuration**: Removed action outputs dependency; now uses environment variables directly
- **Enhanced documentation**: Added comments explaining the public test data and Twenty version pinning

### README Updates
- **Added CI/CD section**: New documentation explaining both workflows and their purposes
- **Added setup instructions**: Documented how to enable CD deployments via repository secrets
- **Added local publishing note**: Mentioned `yarn twenty app:publish --private` for local deployments

## Implementation Details

- The CD workflow now validates that required secrets are set before attempting configuration
- The CI workflow uses `twentycrm/twenty-app-dev` Docker image with configurable port and health check polling
- Both workflows include detailed inline documentation for maintainability
- The workflows are now self-contained and don't depend on external custom actions from the Twenty repository

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/22211?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

