### PR TITLE
fix(page-layout): render relation field widgets in table display mode

### DIFF
--- a/packages/twenty-front/src/modules/object-record/record-table-widget/components/RecordTableWidgetViewLoadEffect.tsx
+++ b/packages/twenty-front/src/modules/object-record/record-table-widget/components/RecordTableWidgetViewLoadEffect.tsx
@@ -52,12 +52,39 @@ export const RecordTableWidgetViewLoadEffect = ({
   const viewHasFields =
     isDefined(currentView) && currentView.viewFields.length > 0;
 
+  // eslint-disable-next-line no-console
+  console.log(
+    '[REL_TABLE_DEBUG] 4.RecordTableWidgetViewLoadEffect render',
+    JSON.stringify({
+      widgetId,
+      viewId,
+      isPageLayoutInEditMode,
+      hasDraftSnapshot: isDefined(draftSnapshot),
+      draftViewFieldsCount: draftSnapshot?.viewFields?.length ?? null,
+      hasViewFromDraft: isDefined(viewFromDraft),
+      hasViewFromSelector: isDefined(viewFromSelector),
+      hasCurrentView: isDefined(currentView),
+      currentViewFieldsCount: currentView?.viewFields?.length ?? null,
+      viewHasFields,
+    }),
+  );
+
   useEffect(() => {
     if (!isDefined(currentView)) {
+      // eslint-disable-next-line no-console
+      console.log(
+        '[REL_TABLE_DEBUG] 4a.viewLoadEffect SKIP: no currentView',
+        JSON.stringify({ widgetId, viewId }),
+      );
       return;
     }
 
     if (!viewHasFields) {
+      // eslint-disable-next-line no-console
+      console.log(
+        '[REL_TABLE_DEBUG] 4b.viewLoadEffect SKIP: currentView has no viewFields',
+        JSON.stringify({ widgetId, viewId }),
+      );
       return;
     }
 
@@ -74,6 +101,16 @@ export const RecordTableWidgetViewLoadEffect = ({
     if (lastLoadedMatches) {
       return;
     }
+
+    // eslint-disable-next-line no-console
+    console.log(
+      '[REL_TABLE_DEBUG] 4c.viewLoadEffect -> loadRecordIndexStates FIRES',
+      JSON.stringify({
+        widgetId,
+        viewId,
+        viewFieldsCount: currentView.viewFields.length,
+      }),
+    );
 
     loadRecordIndexStates(currentView, objectMetadataItem, {
       skipGlobalIndexStates: true,

--- a/packages/twenty-front/src/modules/page-layout/widgets/field/components/FieldWidget.tsx
+++ b/packages/twenty-front/src/modules/page-layout/widgets/field/components/FieldWidget.tsx
@@ -99,6 +99,21 @@ export const FieldWidget = ({ widget }: FieldWidgetProps) => {
 
   const fieldDisplayMode = widget.configuration.fieldDisplayMode;
 
+  // eslint-disable-next-line no-console
+  console.log(
+    '[REL_TABLE_DEBUG] 0.FieldWidget render',
+    JSON.stringify({
+      widgetId: widget.id,
+      fieldName: fieldMetadataItem.name,
+      fieldType: fieldMetadataItem.type,
+      fieldDisplayMode: fieldDisplayMode ?? null,
+      configViewId:
+        (widget.configuration as { viewId?: string | null }).viewId ?? null,
+      isMorphRelation: isFieldMorphRelation(fieldDefinition),
+      isRelation: isFieldRelation(fieldDefinition),
+    }),
+  );
+
   if (isFieldMorphRelation(fieldDefinition)) {
     if (fieldDisplayMode === FieldDisplayMode.CARD) {
       return (

--- a/packages/twenty-front/src/modules/page-layout/widgets/field/components/FieldWidgetRelationTable.tsx
+++ b/packages/twenty-front/src/modules/page-layout/widgets/field/components/FieldWidgetRelationTable.tsx
@@ -42,6 +42,21 @@ export const FieldWidgetRelationTable = ({
   const relationObjectMetadataId =
     fieldDefinition.metadata.relationObjectMetadataId;
 
+  // eslint-disable-next-line no-console
+  console.log(
+    '[REL_TABLE_DEBUG] 3.FieldWidgetRelationTable render',
+    JSON.stringify({
+      widgetId: widget.id,
+      isFieldWidget: isFieldWidget(widget),
+      viewId: viewId ?? null,
+      relationObjectMetadataId: relationObjectMetadataId ?? null,
+      relationObjectMetadataIdIsEmptyString: relationObjectMetadataId === '',
+      isPageLayoutInEditMode,
+      willReturnNull:
+        !isDefined(viewId) || !isDefined(relationObjectMetadataId),
+    }),
+  );
+
   if (!isDefined(viewId) || !isDefined(relationObjectMetadataId)) {
     return null;
   }

--- a/packages/twenty-front/src/modules/page-layout/widgets/record-table/hooks/useAddDraftViewForFieldRelationTableWidget.ts
+++ b/packages/twenty-front/src/modules/page-layout/widgets/record-table/hooks/useAddDraftViewForFieldRelationTableWidget.ts
@@ -33,6 +33,16 @@ export const useAddDraftViewForFieldRelationTableWidget = (
       );
 
       if (!isDefined(targetObjectMetadataItem)) {
+        // eslint-disable-next-line no-console
+        console.log(
+          '[REL_TABLE_DEBUG] 2.addDraftView -> target object NOT FOUND (returns undefined viewId)',
+          JSON.stringify({
+            widgetId,
+            targetObjectMetadataId,
+            inverseFieldMetadataId,
+            objectMetadataItemsCount: objectMetadataItems.length,
+          }),
+        );
         return undefined;
       }
 
@@ -63,6 +73,18 @@ export const useAddDraftViewForFieldRelationTableWidget = (
         ...prev,
         [widgetId]: snapshot,
       }));
+
+      // eslint-disable-next-line no-console
+      console.log(
+        '[REL_TABLE_DEBUG] 2.addDraftView -> created draft view',
+        JSON.stringify({
+          widgetId,
+          viewId: snapshot.view.id,
+          targetObject: targetObjectMetadataItem.nameSingular,
+          viewFieldsCount: snapshot.viewFields.length,
+          viewFiltersCount: snapshot.viewFilters.length,
+        }),
+      );
 
       return snapshot.view.id;
     },

--- a/packages/twenty-front/src/modules/side-panel/pages/page-layout/components/dropdown-content/FieldWidgetLayoutDropdownContent.tsx
+++ b/packages/twenty-front/src/modules/side-panel/pages/page-layout/components/dropdown-content/FieldWidgetLayoutDropdownContent.tsx
@@ -88,6 +88,29 @@ export const FieldWidgetLayoutDropdownContent = () => {
     const inverseFieldMetadataId =
       fieldMetadataItem?.relation?.targetFieldMetadata.id;
 
+    const willCreateDraftView =
+      fieldDisplayMode === FieldDisplayMode.TABLE &&
+      !isDefined(fieldConfiguration?.viewId) &&
+      isDefined(widgetInEditMode) &&
+      isDefined(targetObjectMetadataId) &&
+      isDefined(inverseFieldMetadataId);
+
+    // eslint-disable-next-line no-console
+    console.log(
+      '[REL_TABLE_DEBUG] 1.handleSelectLayout',
+      JSON.stringify({
+        fieldDisplayMode,
+        currentViewId: fieldConfiguration?.viewId ?? null,
+        widgetInEditModeId: widgetInEditMode?.id ?? null,
+        fieldMetadataId: currentFieldMetadataId ?? null,
+        fieldType: fieldMetadataItem?.type ?? null,
+        relationType: fieldMetadataItem?.relation?.type ?? null,
+        targetObjectMetadataId: targetObjectMetadataId ?? null,
+        inverseFieldMetadataId: inverseFieldMetadataId ?? null,
+        willCreateDraftView,
+      }),
+    );
+
     if (
       fieldDisplayMode === FieldDisplayMode.TABLE &&
       !isDefined(fieldConfiguration?.viewId) &&
@@ -101,6 +124,15 @@ export const FieldWidgetLayoutDropdownContent = () => {
         inverseFieldMetadataId,
       );
 
+      // eslint-disable-next-line no-console
+      console.log(
+        '[REL_TABLE_DEBUG] 1b.handleSelectLayout -> wrote config with viewId',
+        JSON.stringify({
+          widgetId: widgetInEditMode.id,
+          returnedViewId: viewId ?? null,
+        }),
+      );
+
       updateCurrentWidgetConfig({
         configToUpdate: {
           fieldDisplayMode,
@@ -110,6 +142,12 @@ export const FieldWidgetLayoutDropdownContent = () => {
       closeDropdown();
       return;
     }
+
+    // eslint-disable-next-line no-console
+    console.log(
+      '[REL_TABLE_DEBUG] 1c.handleSelectLayout -> FALLBACK (no viewId written)',
+      JSON.stringify({ fieldDisplayMode }),
+    );
 
     updateCurrentWidgetConfig({
       configToUpdate: {


### PR DESCRIPTION
Adding a to-many relation field as a **Table** on a record page rendered an empty widget (header only) in several cases. This fixes three independent defects behind that.

- **Morph inverse relations crashed the table.** The host-scoping view filter (`IS current record`) is built on the relation's inverse field. When that inverse is a `MORPH_RELATION` (attachments, notes, tasks…), `getFilterTypeFromFieldType` fell through to `TEXT` and the GraphQL builder threw `Unknown operand IS for TEXT filter`, unmounting the table via the ErrorBoundary. `MORPH_RELATION` now classifies as `RELATION`, and the relation filter resolves the correct morph join column (e.g. `targetPersonId`) from the current record's object type.
- **Stale `viewId` on field change.** Changing the bound field on a Table widget kept the previous relation's draft view (wrong object/fields/filter). Field selection now regenerates the draft view for the new relation, or clears the stale `viewId` when the new field can't back a table.
- **Label identifier could be hidden or reordered.** Relation-table widget views now pin the label-identifier field first and visible on view creation and save.

Deferred: morph relation filters with arbitrary selected record ids (not just "current record") — needs target-object identity in the filter value schema.

**Test:** open a Person → edit layout → add a Field widget → bind a to-many relation → switch Layout to Table. Previously empty for `attachments` (morph) and for any field changed on an existing Table widget; now scoped to the host record.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/22219?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

