### PR TITLE
Fix navigation opened section spacing

### DIFF
--- a/packages/twenty-front/src/modules/navigation-menu-item/display/sections/components/NavigationDrawerOpenedSection.tsx
+++ b/packages/twenty-front/src/modules/navigation-menu-item/display/sections/components/NavigationDrawerOpenedSection.tsx
@@ -17,15 +17,15 @@ export const NavigationDrawerOpenedSection = () => {
     (item) => item.id === objectMetadataIdForOpenedSection,
   );
 
-  const shouldShowOpenedSection = isDefined(objectMetadataItem);
+  if (!isDefined(objectMetadataItem)) {
+    return null;
+  }
 
   return (
-    <AnimatedExpandableContainer isExpanded={shouldShowOpenedSection}>
+    <AnimatedExpandableContainer isExpanded>
       <NavigationDrawerSectionForObjectMetadataItems
         sectionTitle={t`Opened`}
-        objectMetadataItems={
-          isDefined(objectMetadataItem) ? [objectMetadataItem] : []
-        }
+        objectMetadataItems={[objectMetadataItem]}
       />
     </AnimatedExpandableContainer>
   );


### PR DESCRIPTION
## Summary

- Remove the collapsed empty `Opened` sidebar section when no opened object exists.
- Restore the first navigation section top alignment with the settings `User` section.

## Before/After

Visual verification after the fix: in the current fixture data, the first visible main sidebar section (`Favorites`) starts at y=92, matching the settings `User` section at y=92. This confirms there is no collapsed `Opened` spacer pushing the main drawer content down.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/22222?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->