### PR TITLE
fix(front): show newly created/deleted views in sidebar without refresh

### DIFF
--- a/packages/twenty-front/src/modules/views/hooks/internal/__tests__/usePerformViewAPIPersist.test.tsx
+++ b/packages/twenty-front/src/modules/views/hooks/internal/__tests__/usePerformViewAPIPersist.test.tsx
@@ -16,9 +16,6 @@ import { getTestEnrichedObjectMetadataItemsMock } from '~/testing/utils/getTestE
 const NEW_VIEW_ID = '20202020-0000-0000-0000-000000000002';
 const EXISTING_VIEW_ID = '20202020-0000-0000-0000-000000000003';
 
-// Use a real object id from the default test metadata so the views
-// consistency guard in applyChanges (every view must belong to a known
-// object) is satisfied without overriding the wrapper's object metadata.
 const objectMetadataItemsMock = getTestEnrichedObjectMetadataItemsMock();
 const OBJECT_METADATA_ID =
   objectMetadataItemsMock.find((item) => item.nameSingular === 'company')?.id ??

--- a/packages/twenty-front/src/modules/views/hooks/internal/__tests__/usePerformViewAPIPersist.test.tsx
+++ b/packages/twenty-front/src/modules/views/hooks/internal/__tests__/usePerformViewAPIPersist.test.tsx
@@ -1,0 +1,158 @@
+import { metadataStoreState } from '@/metadata-store/states/metadataStoreState';
+import { type FlatView } from '@/metadata-store/types/FlatView';
+import { jotaiStore } from '@/ui/utilities/state/jotai/jotaiStore';
+import { usePerformViewAPIPersist } from '@/views/hooks/internal/usePerformViewAPIPersist';
+import { act, renderHook } from '@testing-library/react';
+import {
+  CreateViewDocument,
+  DestroyViewDocument,
+  ViewOpenRecordIn,
+  ViewType,
+  ViewVisibility,
+} from '~/generated-metadata/graphql';
+import { getJestMetadataAndApolloMocksWrapper } from '~/testing/jest/getJestMetadataAndApolloMocksWrapper';
+import { getTestEnrichedObjectMetadataItemsMock } from '~/testing/utils/getTestEnrichedObjectMetadataItemsMock';
+
+const NEW_VIEW_ID = '20202020-0000-0000-0000-000000000002';
+const EXISTING_VIEW_ID = '20202020-0000-0000-0000-000000000003';
+
+// Use a real object id from the default test metadata so the views
+// consistency guard in applyChanges (every view must belong to a known
+// object) is satisfied without overriding the wrapper's object metadata.
+const objectMetadataItemsMock = getTestEnrichedObjectMetadataItemsMock();
+const OBJECT_METADATA_ID =
+  objectMetadataItemsMock.find((item) => item.nameSingular === 'company')?.id ??
+  objectMetadataItemsMock[0].id;
+
+const createViewInput = {
+  id: NEW_VIEW_ID,
+  name: 'My Kanban',
+  icon: 'IconLayoutKanban',
+  key: null,
+  type: ViewType.KANBAN,
+  objectMetadataId: OBJECT_METADATA_ID,
+  openRecordIn: ViewOpenRecordIn.SIDE_PANEL,
+  visibility: ViewVisibility.WORKSPACE,
+};
+
+const createdViewResponse = {
+  __typename: 'View',
+  id: NEW_VIEW_ID,
+  name: 'My Kanban',
+  objectMetadataId: OBJECT_METADATA_ID,
+  type: ViewType.KANBAN,
+  key: null,
+  icon: 'IconLayoutKanban',
+  position: 3,
+  isCompact: false,
+  openRecordIn: ViewOpenRecordIn.SIDE_PANEL,
+  kanbanAggregateOperation: null,
+  kanbanAggregateOperationFieldMetadataId: null,
+  mainGroupByFieldMetadataId: null,
+  shouldHideEmptyGroups: false,
+  kanbanColumnWidth: null,
+  anyFieldFilterValue: null,
+  calendarFieldMetadataId: null,
+  calendarLayout: null,
+  visibility: ViewVisibility.WORKSPACE,
+  createdByUserWorkspaceId: null,
+  isActive: true,
+  viewFields: [],
+  viewFieldGroups: [],
+  viewFilters: [],
+  viewFilterGroups: [],
+  viewSorts: [],
+  viewGroups: [],
+};
+
+const existingView = {
+  ...createdViewResponse,
+  id: EXISTING_VIEW_ID,
+  name: 'Existing Kanban',
+  position: 0,
+} as unknown as FlatView;
+
+const seedViews = (views: FlatView[]) => {
+  jotaiStore.set(metadataStoreState.atomFamily('views'), {
+    current: views,
+    draft: [],
+    status: 'up-to-date',
+  });
+};
+
+const getStoredViews = () =>
+  jotaiStore.get(metadataStoreState.atomFamily('views')).current as FlatView[];
+
+describe('usePerformViewAPIPersist', () => {
+  it('should add the created view to the metadata store so the sidebar updates without a refresh', async () => {
+    const Wrapper = getJestMetadataAndApolloMocksWrapper({
+      apolloMocks: [
+        {
+          request: {
+            query: CreateViewDocument,
+            variables: { input: createViewInput },
+          },
+          result: { data: { createView: createdViewResponse } },
+        },
+      ],
+      onInitializeJotaiStore: () => seedViews([]),
+    });
+
+    const { result } = renderHook(() => usePerformViewAPIPersist(), {
+      wrapper: Wrapper,
+    });
+
+    let apiResult: { status: string } | undefined;
+    await act(async () => {
+      apiResult = await result.current.performViewAPICreate(
+        { input: createViewInput },
+        OBJECT_METADATA_ID,
+      );
+    });
+
+    expect(apiResult?.status).toBe('successful');
+
+    const storedViews = getStoredViews();
+    expect(storedViews).toHaveLength(1);
+    expect(storedViews[0]).toEqual(
+      expect.objectContaining({
+        id: NEW_VIEW_ID,
+        objectMetadataId: OBJECT_METADATA_ID,
+        isActive: true,
+      }),
+    );
+  });
+
+  it('should remove the destroyed view from the metadata store so it disappears from the sidebar without a refresh', async () => {
+    const Wrapper = getJestMetadataAndApolloMocksWrapper({
+      apolloMocks: [
+        {
+          request: {
+            query: DestroyViewDocument,
+            variables: { id: EXISTING_VIEW_ID },
+          },
+          result: { data: { destroyView: true } },
+        },
+      ],
+      onInitializeJotaiStore: () => seedViews([existingView]),
+    });
+
+    const { result } = renderHook(() => usePerformViewAPIPersist(), {
+      wrapper: Wrapper,
+    });
+
+    let apiResult: { status: string } | undefined;
+    await act(async () => {
+      apiResult = await result.current.performViewAPIDestroy({
+        id: EXISTING_VIEW_ID,
+      });
+    });
+
+    expect(apiResult?.status).toBe('successful');
+
+    const storedViews = getStoredViews();
+    expect(storedViews.some((view) => view.id === EXISTING_VIEW_ID)).toBe(
+      false,
+    );
+  });
+});

--- a/packages/twenty-front/src/modules/views/hooks/internal/usePerformViewAPIPersist.ts
+++ b/packages/twenty-front/src/modules/views/hooks/internal/usePerformViewAPIPersist.ts
@@ -1,9 +1,12 @@
 import { useCallback } from 'react';
 
 import { useMetadataErrorHandler } from '@/metadata-error-handler/hooks/useMetadataErrorHandler';
+import { useUpdateMetadataStoreDraft } from '@/metadata-store/hooks/useUpdateMetadataStoreDraft';
+import { splitViewWithRelated } from '@/metadata-store/utils/splitViewWithRelated';
 import { type MetadataRequestResult } from '@/object-metadata/types/MetadataRequestResult.type';
 import { useSnackBar } from '@/ui/feedback/snack-bar-manager/hooks/useSnackBar';
 import { useViewsSideEffectsOnViewGroups } from '@/views/hooks/useViewsSideEffectsOnViewGroups';
+import { type ViewWithRelations } from '@/views/types/ViewWithRelations';
 import { CombinedGraphQLErrors } from '@apollo/client/errors';
 import { t } from '@lingui/core/macro';
 import { CrudOperationType } from 'twenty-shared/types';
@@ -23,6 +26,9 @@ export const usePerformViewAPIPersist = () => {
   const [destroyViewMutation] = useMutation(DestroyViewDocument);
   const { triggerViewGroupOptimisticEffectAtViewCreation } =
     useViewsSideEffectsOnViewGroups();
+
+  const { addToDraft, removeFromDraft, applyChanges } =
+    useUpdateMetadataStoreDraft();
 
   const { handleMetadataError } = useMetadataErrorHandler();
   const { enqueueErrorSnackBar } = useSnackBar();
@@ -62,6 +68,28 @@ export const usePerformViewAPIPersist = () => {
           };
         }
 
+        // The sidebar reads views from the metadata store, not from Apollo,
+        // so the freshly created view has to be pushed there for it to show
+        // up immediately without a hard refresh.
+        const {
+          flatViews,
+          flatViewFields,
+          flatViewFilters,
+          flatViewSorts,
+          flatViewGroups,
+          flatViewFilterGroups,
+          flatViewFieldGroups,
+        } = splitViewWithRelated([newView as ViewWithRelations]);
+
+        addToDraft({ key: 'views', items: flatViews });
+        addToDraft({ key: 'viewFields', items: flatViewFields });
+        addToDraft({ key: 'viewFilters', items: flatViewFilters });
+        addToDraft({ key: 'viewSorts', items: flatViewSorts });
+        addToDraft({ key: 'viewGroups', items: flatViewGroups });
+        addToDraft({ key: 'viewFilterGroups', items: flatViewFilterGroups });
+        addToDraft({ key: 'viewFieldGroups', items: flatViewFieldGroups });
+        applyChanges();
+
         return {
           status: 'successful',
           response: result,
@@ -85,6 +113,8 @@ export const usePerformViewAPIPersist = () => {
     [
       createViewMutation,
       triggerViewGroupOptimisticEffectAtViewCreation,
+      addToDraft,
+      applyChanges,
       handleMetadataError,
       enqueueErrorSnackBar,
     ],
@@ -100,6 +130,11 @@ export const usePerformViewAPIPersist = () => {
         const result = await destroyViewMutation({
           variables,
         });
+
+        // Mirror the create path: drop the destroyed view from the metadata
+        // store so it disappears from the sidebar without a hard refresh.
+        removeFromDraft({ key: 'views', itemIds: [variables.id] });
+        applyChanges();
 
         return {
           status: 'successful',
@@ -121,7 +156,13 @@ export const usePerformViewAPIPersist = () => {
         };
       }
     },
-    [destroyViewMutation, handleMetadataError, enqueueErrorSnackBar],
+    [
+      destroyViewMutation,
+      removeFromDraft,
+      applyChanges,
+      handleMetadataError,
+      enqueueErrorSnackBar,
+    ],
   );
 
   return {

--- a/packages/twenty-front/src/modules/views/hooks/internal/usePerformViewAPIPersist.ts
+++ b/packages/twenty-front/src/modules/views/hooks/internal/usePerformViewAPIPersist.ts
@@ -68,9 +68,6 @@ export const usePerformViewAPIPersist = () => {
           };
         }
 
-        // The sidebar reads views from the metadata store, not from Apollo,
-        // so the freshly created view has to be pushed there for it to show
-        // up immediately without a hard refresh.
         const {
           flatViews,
           flatViewFields,
@@ -131,8 +128,6 @@ export const usePerformViewAPIPersist = () => {
           variables,
         });
 
-        // Mirror the create path: drop the destroyed view from the metadata
-        // store so it disappears from the sidebar without a hard refresh.
         removeFromDraft({ key: 'views', itemIds: [variables.id] });
         applyChanges();
 


### PR DESCRIPTION
The sidebar reads views from the central metadata store (Jotai), not from Apollo. When a view was updated, usePerformViewAPIUpdate optimistically wrote the change to that store, but the create and destroy paths in usePerformViewAPIPersist ran their mutations without touching the store. As a result a newly created view (e.g. a Kanban view) only appeared in the views list after a hard refresh, which re-ran loadStaleMetadataEntities; likewise a deleted view lingered until refresh.

Mirror the update flow: after a successful create, split the returned view and push it (and any related entities) into the metadata store draft, then applyChanges; after a successful destroy, remove the view from the store. Add regression tests covering both paths.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/22230?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

