### PR TITLE
feat(helm): add nodeSelector, tolerations and DNS overrides to server and worker

### DIFF
--- a/packages/twenty-docker/helm/twenty/templates/deployment-server.yaml
+++ b/packages/twenty-docker/helm/twenty/templates/deployment-server.yaml
@@ -32,6 +32,21 @@ spec:
     spec:
       securityContext:
 {{- toYaml .Values.securityContext | nindent 8 }}
+      {{- with .Values.server.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.server.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.server.dnsPolicy }}
+      dnsPolicy: {{ . }}
+      {{- end }}
+      {{- with .Values.server.dnsConfig }}
+      dnsConfig:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       volumes:
         {{- if .Values.server.dockerDataPersistence.enabled }}
         - name: docker-data

--- a/packages/twenty-docker/helm/twenty/templates/deployment-server.yaml
+++ b/packages/twenty-docker/helm/twenty/templates/deployment-server.yaml
@@ -40,6 +40,10 @@ spec:
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- with .Values.server.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       {{- with .Values.server.dnsPolicy }}
       dnsPolicy: {{ . }}
       {{- end }}

--- a/packages/twenty-docker/helm/twenty/templates/deployment-worker.yaml
+++ b/packages/twenty-docker/helm/twenty/templates/deployment-worker.yaml
@@ -28,6 +28,21 @@ spec:
     spec:
       securityContext:
 {{- toYaml .Values.securityContext | nindent 8 }}
+      {{- with .Values.worker.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.worker.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.worker.dnsPolicy }}
+      dnsPolicy: {{ . }}
+      {{- end }}
+      {{- with .Values.worker.dnsConfig }}
+      dnsConfig:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       initContainers:
         - name: wait-for-db
           image: postgres:16-alpine

--- a/packages/twenty-docker/helm/twenty/templates/deployment-worker.yaml
+++ b/packages/twenty-docker/helm/twenty/templates/deployment-worker.yaml
@@ -36,6 +36,10 @@ spec:
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- with .Values.worker.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       {{- with .Values.worker.dnsPolicy }}
       dnsPolicy: {{ . }}
       {{- end }}

--- a/packages/twenty-docker/helm/twenty/values.schema.json
+++ b/packages/twenty-docker/helm/twenty/values.schema.json
@@ -138,7 +138,14 @@
             "accessModes": { "type": "array", "items": { "type": "string" } },
             "size": { "type": "string" }
           }
-        }
+        },
+        "nodeSelector": { "type": "object" },
+        "tolerations": {
+          "type": "array",
+          "items": { "type": "object" }
+        },
+        "dnsPolicy": { "type": ["string", "null"], "enum": ["ClusterFirst", "ClusterFirstWithHostNet", "Default", "None", null] },
+        "dnsConfig": { "type": "object" }
       }
     },
 
@@ -173,7 +180,14 @@
               { "required": ["valueFrom"] }
             ]
           }
-        }
+        },
+        "nodeSelector": { "type": "object" },
+        "tolerations": {
+          "type": "array",
+          "items": { "type": "object" }
+        },
+        "dnsPolicy": { "type": ["string", "null"], "enum": ["ClusterFirst", "ClusterFirstWithHostNet", "Default", "None", null] },
+        "dnsConfig": { "type": "object" }
       }
     },
 

--- a/packages/twenty-docker/helm/twenty/values.schema.json
+++ b/packages/twenty-docker/helm/twenty/values.schema.json
@@ -144,6 +144,7 @@
           "type": "array",
           "items": { "type": "object" }
         },
+        "affinity": { "type": "object" },
         "dnsPolicy": { "type": ["string", "null"], "enum": ["ClusterFirst", "ClusterFirstWithHostNet", "Default", "None", null] },
         "dnsConfig": { "type": "object" }
       }
@@ -186,6 +187,7 @@
           "type": "array",
           "items": { "type": "object" }
         },
+        "affinity": { "type": "object" },
         "dnsPolicy": { "type": ["string", "null"], "enum": ["ClusterFirst", "ClusterFirstWithHostNet", "Default", "None", null] },
         "dnsConfig": { "type": "object" }
       }

--- a/packages/twenty-docker/helm/twenty/values.yaml
+++ b/packages/twenty-docker/helm/twenty/values.yaml
@@ -98,6 +98,12 @@ server:
 
   extraVolumeMounts: []
 
+  # Pod scheduling and DNS
+  nodeSelector: {}
+  tolerations: []
+  dnsPolicy: ~
+  dnsConfig: {}
+
 # Worker deployment
 worker:
   enabled: true
@@ -114,6 +120,12 @@ worker:
       memory: 2048Mi
 
   extraEnv: []
+
+  # Pod scheduling and DNS
+  nodeSelector: {}
+  tolerations: []
+  dnsPolicy: ~
+  dnsConfig: {}
 
 # PostgreSQL
 db:

--- a/packages/twenty-docker/helm/twenty/values.yaml
+++ b/packages/twenty-docker/helm/twenty/values.yaml
@@ -101,6 +101,7 @@ server:
   # Pod scheduling and DNS
   nodeSelector: {}
   tolerations: []
+  affinity: {}
   dnsPolicy: ~
   dnsConfig: {}
 
@@ -124,6 +125,7 @@ worker:
   # Pod scheduling and DNS
   nodeSelector: {}
   tolerations: []
+  affinity: {}
   dnsPolicy: ~
   dnsConfig: {}
 


### PR DESCRIPTION
Closes #22250

## What

Adds four standard pod spec fields to both server and worker Deployments of the Helm chart, exposed under `server.*` and `worker.*` in `values.yaml`:

- `nodeSelector`
- `tolerations`
- `dnsPolicy`
- `dnsConfig`

## Why

Self-hosters who run Twenty on clusters with dedicated nodes, taints, or custom DNS requirements currently need to fork the chart or patch rendered manifests with Kustomize. These are the standard pod spec fields supported by virtually every other community chart (Bitnami, prometheus-community, cert-manager, etc.) and are commonly needed in production setups.

## How

Uses the same `{{- with }}` pattern already present in the chart (e.g. `extraEnv`, `extraVolumeMounts`), so empty defaults skip rendering entirely:

```yaml
{{- with .Values.server.nodeSelector }}
nodeSelector:
  {{- toYaml . | nindent 8 }}
{{- end }}
```

## Backward compatibility

Fully backward compatible. Defaults are empty:

```yaml
server:
  nodeSelector: {}
  tolerations: []
  dnsPolicy: ~
  dnsConfig: {}
```

`helm template` output is bit-identical to the previous version for any existing install.

## Schema note

`dnsPolicy` is typed as `[string, null]` and the enum includes `null` so the empty default (`dnsPolicy: ~`) passes validation. The `{{- with }}` guard treats null as falsy and renders nothing.

## Validation

- `helm lint` passes
- `helm template` with default values produces bit-identical output to before this PR
- `helm template` with values set renders the four fields correctly on both server and worker
- Live install validated on a multi-node Kubernetes cluster, pinning Twenty to a dedicated tainted node with custom DNS (`ndots: 1`); server and worker scheduled and started successfully

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/22233?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

