### PR TITLE
Fix: Hide Timeline/Tasks/Notes/Files tabs when relations are removed from custom objects

### DIFF
--- a/packages/twenty-front/src/modules/page-layout/components/PageLayoutTabsRenderer.tsx
+++ b/packages/twenty-front/src/modules/page-layout/components/PageLayoutTabsRenderer.tsx
@@ -103,7 +103,7 @@ export const PageLayoutTabsRenderer = () => {
 
     const allWidgetRelationFieldNames = Object.values(
       WIDGET_TYPE_TO_RELATION_FIELD_NAME,
-    );
+    ).filter(isDefined);
 
     return new Set(
       allWidgetRelationFieldNames.filter(

--- a/packages/twenty-front/src/modules/page-layout/components/PageLayoutTabsRenderer.tsx
+++ b/packages/twenty-front/src/modules/page-layout/components/PageLayoutTabsRenderer.tsx
@@ -90,15 +90,25 @@ export const PageLayoutTabsRenderer = () => {
       return new Set<string>();
     }
 
-    return new Set(
+    const activeRelationFieldNames = new Set(
       objectMetadataItem.fields
         .filter(
           (field) =>
-            !field.isActive &&
+            field.isActive &&
             (field.type === FieldMetadataType.RELATION ||
               field.type === FieldMetadataType.MORPH_RELATION),
         )
         .map((field) => field.name),
+    );
+
+    const allWidgetRelationFieldNames = Object.values(
+      WIDGET_TYPE_TO_RELATION_FIELD_NAME,
+    );
+
+    return new Set(
+      allWidgetRelationFieldNames.filter(
+        (fieldName) => !activeRelationFieldNames.has(fieldName),
+      ),
     );
   }, [objectMetadataItems, targetRecordIdentifier]);
 

--- a/packages/twenty-front/src/modules/page-layout/components/PageLayoutTabsRenderer.tsx
+++ b/packages/twenty-front/src/modules/page-layout/components/PageLayoutTabsRenderer.tsx
@@ -16,6 +16,7 @@ import { getScrollWrapperInstanceIdFromPageLayoutId } from '@/page-layout/utils/
 import { getTabListInstanceIdFromPageLayoutAndRecord } from '@/page-layout/utils/getTabListInstanceIdFromPageLayoutAndRecord';
 import { getTabsByDisplayMode } from '@/page-layout/utils/getTabsByDisplayMode';
 import { getTabsWithVisibleWidgets } from '@/page-layout/utils/getTabsWithVisibleWidgets';
+import { getUnavailableWidgetRelationFieldNames } from '@/page-layout/utils/getUnavailableWidgetRelationFieldNames';
 import { shouldEnableTabEditingFeatures } from '@/page-layout/utils/shouldEnableTabEditingFeatures';
 import { sortTabsByPosition } from '@/page-layout/utils/sortTabsByPosition';
 import { useLayoutRenderingContext } from '@/ui/layout/contexts/LayoutRenderingContext';
@@ -25,7 +26,6 @@ import { useAtomComponentStateValue } from '@/ui/utilities/state/jotai/hooks/use
 import { useAtomFamilyStateValue } from '@/ui/utilities/state/jotai/hooks/useAtomFamilyStateValue';
 import { styled } from '@linaria/react';
 import { useMemo } from 'react';
-import { FieldMetadataType } from 'twenty-shared/types';
 import { isDefined } from 'twenty-shared/utils';
 import { useIsMobile } from 'twenty-ui/utilities';
 
@@ -76,7 +76,7 @@ export const PageLayoutTabsRenderer = () => {
 
   const { objectMetadataItems } = useObjectMetadataItems();
 
-  const inactiveRelationFieldNames = useMemo(() => {
+  const unavailableRelationFieldNames = useMemo(() => {
     if (!isDefined(targetRecordIdentifier)) {
       return new Set<string>();
     }
@@ -90,26 +90,7 @@ export const PageLayoutTabsRenderer = () => {
       return new Set<string>();
     }
 
-    const activeRelationFieldNames = new Set(
-      objectMetadataItem.fields
-        .filter(
-          (field) =>
-            field.isActive &&
-            (field.type === FieldMetadataType.RELATION ||
-              field.type === FieldMetadataType.MORPH_RELATION),
-        )
-        .map((field) => field.name),
-    );
-
-    const allWidgetRelationFieldNames = Object.values(
-      WIDGET_TYPE_TO_RELATION_FIELD_NAME,
-    ).filter(isDefined);
-
-    return new Set(
-      allWidgetRelationFieldNames.filter(
-        (fieldName) => !activeRelationFieldNames.has(fieldName),
-      ),
-    );
+    return getUnavailableWidgetRelationFieldNames(objectMetadataItem.fields);
   }, [objectMetadataItems, targetRecordIdentifier]);
 
   const isMobile = useIsMobile();
@@ -166,11 +147,11 @@ export const PageLayoutTabsRenderer = () => {
             WIDGET_TYPE_TO_RELATION_FIELD_NAME[widgetType];
           return (
             isDefined(relationFieldName) &&
-            inactiveRelationFieldNames.has(relationFieldName)
+            unavailableRelationFieldNames.has(relationFieldName)
           );
         });
       }),
-    [sortedTabs, inactiveRelationFieldNames],
+    [sortedTabs, unavailableRelationFieldNames],
   );
 
   const activeTabExistsInCurrentPageLayout = currentPageLayout.tabs.some(

--- a/packages/twenty-front/src/modules/page-layout/utils/__tests__/getUnavailableWidgetRelationFieldNames.test.ts
+++ b/packages/twenty-front/src/modules/page-layout/utils/__tests__/getUnavailableWidgetRelationFieldNames.test.ts
@@ -1,0 +1,82 @@
+import { type FieldMetadataItem } from '@/object-metadata/types/FieldMetadataItem';
+import { getUnavailableWidgetRelationFieldNames } from '@/page-layout/utils/getUnavailableWidgetRelationFieldNames';
+import { FieldMetadataType } from 'twenty-shared/types';
+
+type TestField = Pick<FieldMetadataItem, 'name' | 'isActive' | 'type'>;
+
+const createRelationField = (
+  name: string,
+  isActive: boolean,
+): TestField => ({
+  name,
+  isActive,
+  type: FieldMetadataType.RELATION,
+});
+
+describe('getUnavailableWidgetRelationFieldNames', () => {
+  it('should mark a widget relation as unavailable when the field is inactive', () => {
+    const result = getUnavailableWidgetRelationFieldNames([
+      createRelationField('taskTargets', false),
+      createRelationField('noteTargets', true),
+    ]);
+
+    expect(result.has('taskTargets')).toBe(true);
+    expect(result.has('noteTargets')).toBe(false);
+  });
+
+  it('should mark a widget relation as unavailable when the field is absent from the object', () => {
+    const result = getUnavailableWidgetRelationFieldNames([
+      createRelationField('noteTargets', true),
+    ]);
+
+    // taskTargets was fully removed from the object, so it is never present in fields
+    expect(result.has('taskTargets')).toBe(true);
+    expect(result.has('noteTargets')).toBe(false);
+  });
+
+  it('should not mark a widget relation as unavailable when the field is active', () => {
+    const result = getUnavailableWidgetRelationFieldNames([
+      createRelationField('taskTargets', true),
+      createRelationField('noteTargets', true),
+      createRelationField('attachments', true),
+      createRelationField('timelineActivities', true),
+    ]);
+
+    expect(result.has('taskTargets')).toBe(false);
+    expect(result.has('noteTargets')).toBe(false);
+    expect(result.has('attachments')).toBe(false);
+    expect(result.has('timelineActivities')).toBe(false);
+  });
+
+  it('should treat a morph relation field as available when active', () => {
+    const result = getUnavailableWidgetRelationFieldNames([
+      {
+        name: 'taskTargets',
+        isActive: true,
+        type: FieldMetadataType.MORPH_RELATION,
+      },
+    ]);
+
+    expect(result.has('taskTargets')).toBe(false);
+  });
+
+  it('should mark every widget relation as unavailable when the object has no active relations', () => {
+    const result = getUnavailableWidgetRelationFieldNames([]);
+
+    expect(result.has('taskTargets')).toBe(true);
+    expect(result.has('noteTargets')).toBe(true);
+    expect(result.has('attachments')).toBe(true);
+    expect(result.has('timelineActivities')).toBe(true);
+    expect(result.has('messageParticipants')).toBe(true);
+    expect(result.has('calendarEventParticipants')).toBe(true);
+  });
+
+  it('should ignore non-relation fields when computing availability', () => {
+    const result = getUnavailableWidgetRelationFieldNames([
+      { name: 'taskTargets', isActive: true, type: FieldMetadataType.TEXT },
+    ]);
+
+    // taskTargets exists but is not a relation field, so the widget relation is unavailable
+    expect(result.has('taskTargets')).toBe(true);
+  });
+});

--- a/packages/twenty-front/src/modules/page-layout/utils/getUnavailableWidgetRelationFieldNames.ts
+++ b/packages/twenty-front/src/modules/page-layout/utils/getUnavailableWidgetRelationFieldNames.ts
@@ -1,0 +1,33 @@
+import { type FieldMetadataItem } from '@/object-metadata/types/FieldMetadataItem';
+import { WIDGET_TYPE_TO_RELATION_FIELD_NAME } from '@/page-layout/constants/WidgetTypeToRelationFieldName';
+import { FieldMetadataType } from 'twenty-shared/types';
+import { isDefined } from 'twenty-shared/utils';
+
+// A widget tab maps to a standard relation field (e.g. Tasks -> taskTargets).
+// Such a tab must be hidden when its relation is either deactivated or fully
+// removed from the object: a removed field is simply absent from `fields`, so
+// we treat any widget relation field that is not currently active as unavailable.
+export const getUnavailableWidgetRelationFieldNames = (
+  fields: Pick<FieldMetadataItem, 'name' | 'isActive' | 'type'>[],
+): Set<string> => {
+  const activeRelationFieldNames = new Set(
+    fields
+      .filter(
+        (field) =>
+          field.isActive &&
+          (field.type === FieldMetadataType.RELATION ||
+            field.type === FieldMetadataType.MORPH_RELATION),
+      )
+      .map((field) => field.name),
+  );
+
+  const widgetRelationFieldNames = Object.values(
+    WIDGET_TYPE_TO_RELATION_FIELD_NAME,
+  ).filter(isDefined);
+
+  return new Set(
+    widgetRelationFieldNames.filter(
+      (fieldName) => !activeRelationFieldNames.has(fieldName),
+    ),
+  );
+};


### PR DESCRIPTION
### Problem

When all standard relations (Timeline, Tasks, Notes, Files) are removed from a custom object, the corresponding tabs were still visible in the record detail view. Clicking them produced runtime errors:
`Invalid filter: taskTarget object doesn't have any "targetCarModelId" field.`

### Root cause
The tab visibility logic in `PageLayoutTabsRenderer `only hid tabs for relation fields marked as inactive (`isActive: false`). When a relation is completely deleted from the object, the field no longer exists in `objectMetadataItem.fields` at all , so it was never flagged as inactive, and the tab kept rendering.

### Fix
Inverted the filtering approach. Instead of looking for inactive fields, we now:

1- Build a set of relation field names that are active on the current object
2- Treat any widget-mapped relation field that is absent or inactive as unavailable
3- Filter out the corresponding tabs

This correctly handles both cases: fields marked inactive and fields completely removed from the object.

this fixes Bug : #19990

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/22239?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

