### PR TITLE
ci(preview-env): run preview environments on free ci-public Actions

### DIFF
--- a/.github/workflows/preview-env-dispatch.yaml
+++ b/.github/workflows/preview-env-dispatch.yaml
@@ -33,24 +33,28 @@ jobs:
     timeout-minutes: 5
     runs-on: ubuntu-latest
     steps:
-      - name: Mint ci-privileged dispatch token
+      # Preview envs run on the PUBLIC ci-public repo so the 5h keepalive job
+      # consumes free Actions minutes (private repos bill them). ci-public holds
+      # no privileged secret: it starts the tunnel and dispatches the URL back to
+      # ci-privileged for the PR comment *before* running any PR-controlled code.
+      - name: Mint ci-public dispatch token
         id: app-token
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
           client-id: ${{ vars.TWENTY_WORKFLOW_DISPATCHER_CLIENT_ID }}
           private-key: ${{ secrets.TWENTY_WORKFLOW_DISPATCHER_PRIVATE_KEY }}
           owner: twentyhq
-          repositories: ci-privileged
+          repositories: ci-public
           permission-actions: write
 
-      - name: Dispatch preview-env to ci-privileged
+      - name: Dispatch preview-env to ci-public
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
           PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
           REPOSITORY: ${{ github.repository }}
         run: |
-          gh workflow run preview-env.yaml --repo twentyhq/ci-privileged --ref main \
+          gh workflow run preview-env.yaml --repo twentyhq/ci-public --ref main \
             -f pr_number="$PR_NUMBER" \
             -f pr_head_sha="$PR_HEAD_SHA" \
             -f repo="$REPOSITORY"


### PR DESCRIPTION
## Why

PR preview environments were broken. The dispatch half (this repo) was fine, but the receiving `preview-env.yaml` in **ci-privileged** failed on every run — and ci-privileged is a **private** repo, so its 5h keepalive job bills paid Actions minutes anyway.

The intended design (started but never wired up) runs the preview env on the **public** `twentyhq/ci-public` repo, where Actions minutes are free, and keeps no privileged token on the runner that executes PR-controlled code. This finishes that migration.

## What this PR does

Repoints `preview-env-dispatch.yaml` to dispatch `preview-env.yaml` on **ci-public** instead of ci-privileged. The dispatcher app token is simply retargeted (still `actions:write` only, via `workflow_dispatch`).

## Companion PRs (must land together)

- **twentyhq/ci-public** — converts `preview-env.yaml` to `workflow_dispatch`; dispatches the tunnel URL back to ci-privileged for the PR comment before any PR code runs.
- **twentyhq/ci-privileged** — adds `preview-env-comment.yaml` (posts the PR comment with the App key) and deletes the now-dead `preview-env.yaml`.

## Manual prerequisites (cannot be done in a PR)

- Install/authorize the `TWENTY_WORKFLOW_DISPATCHER` GitHub App on **ci-public** with `actions:write`.
- On **ci-public**: add `vars.DOCKERHUB_RO_USERNAME`, `secrets.DOCKERHUB_RO_TOKEN`, and `secrets.CI_PRIVILEGED_DISPATCH_TOKEN` (fine-grained PAT, `actions:write` on ci-privileged only).

## Suggested merge order

1. ci-privileged (receiver must exist on `main` before ci-public dispatches to it)
2. ci-public (workflow must exist on `main` before this repo dispatches to it)
3. this PR

## Test plan

- [ ] Open an internal PR touching `packages/twenty-docker/**`; confirm `Preview Environment Dispatch` runs and triggers `Preview Environment` on ci-public.
- [ ] Confirm the trycloudflare URL sticky comment lands on the PR (posted by ci-privileged's `preview-env-comment`).
- [ ] Confirm a `preview-app` label on an external contributor PR triggers the same flow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01VqZBvafHqdCGtHZUT216C5)_

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/22245?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

