### PR TITLE
fix(front): stop infinite loading for workspace-less sessions

### DIFF
--- a/packages/twenty-front/src/modules/metadata-store/effect-components/IsMinimalMetadataReadyEffect.tsx
+++ b/packages/twenty-front/src/modules/metadata-store/effect-components/IsMinimalMetadataReadyEffect.tsx
@@ -49,17 +49,11 @@ export const IsMinimalMetadataReadyEffect = () => {
       metadataStoreViews.status === 'up-to-date' &&
       metadataStoreViewFields.status === 'up-to-date';
 
-    if (!areObjectsLoaded) {
-      setIsMinimalMetadataReady(false);
-      return;
-    }
-
     const isReady =
-      isDefined(currentUser) && (!hasActiveWorkspace || areViewsLoaded);
+      isDefined(currentUser) &&
+      (!hasActiveWorkspace || (areObjectsLoaded && areViewsLoaded));
 
-    if (isReady) {
-      setIsMinimalMetadataReady(true);
-    }
+    setIsMinimalMetadataReady(isReady);
   }, [
     hasAccessTokenPair,
     currentUser,


### PR DESCRIPTION
When a persisted access token resolves to a user with no active workspace, the minimal-metadata gate required object metadata that is never loaded in that state, leaving the app stuck on the loader. Require objects/views only when an active workspace exists, mirroring the views check, so the app renders and routing can redirect to workspace selection.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/22246?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

