### PR TITLE
fix: prevent background page scrolling when ScrollWrapper reaches the end

### DIFF
--- a/packages/twenty-front/src/modules/ui/utilities/scroll/components/ScrollWrapper.tsx
+++ b/packages/twenty-front/src/modules/ui/utilities/scroll/components/ScrollWrapper.tsx
@@ -17,6 +17,8 @@ const StyledScrollWrapper = styled.div<{ autoHeight?: boolean }>`
   height: ${({ autoHeight }) => (autoHeight ? 'auto' : '100%')};
   overflow-x: hidden;
   overflow-y: hidden;
+  overscroll-behavior: contain;
+  -webkit-overflow-scrolling: touch;
   width: 100%;
 `;
 


### PR DESCRIPTION
### Summary

Prevents the parent page from scrolling when the `ScrollWrapper` reaches its scroll boundaries.

### Problem

When the user scrolled to the top or bottom of the content inside `ScrollWrapper` and continued scrolling, the scroll chained to the parent page. As a result:

- The entire page started scrolling.
- The drawer moved along with the page.
- The application background became visible behind the drawer.

This was not the intended scrolling behavior.

### Root Cause

The scrollable container allowed scroll chaining to the parent page after reaching its scroll boundaries.


https://github.com/user-attachments/assets/c5ec963d-c28a-46f8-92ef-31747b19a332



### Solution

Updated `ScrollWrapper` to contain scrolling within the component by adding:

```css
overscroll-behavior: contain;
-webkit-overflow-scrolling: touch;
```

- `overscroll-behavior: contain` prevents scroll chaining to parent containers.
- `-webkit-overflow-scrolling: touch` preserves smooth native scrolling behavior on WebKit-based browsers.

### Result

- Scrolling remains contained within `ScrollWrapper`.
- The parent page no longer scrolls when the container reaches its boundaries.
- The drawer stays fixed, preventing the background from being revealed.

### Testing

- Verified scrolling inside `ScrollWrapper`.
- Verified behavior at both the top and bottom scroll boundaries.
- Confirmed the parent page no longer scrolls when the scrollable content reaches its limits.
- Verified the scrolling experience remains smooth.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/22253?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

