### PR TITLE
fix(sdk): resolve front-component "Dynamic require of react" 

### DIFF
--- a/packages/twenty-sdk/src/cli/utilities/build/common/build-application.ts
+++ b/packages/twenty-sdk/src/cli/utilities/build/common/build-application.ts
@@ -100,7 +100,7 @@ export const buildApplication = async (
       metafile: true,
       logLevel: 'silent',
       plugins: [
-        ...getFrontComponentBuildPlugins(),
+        ...getFrontComponentBuildPlugins({ usePreact: true }),
         createStubTwentySdkDefinePlugin(),
       ],
     },

--- a/packages/twenty-sdk/src/cli/utilities/build/common/esbuild-watcher.ts
+++ b/packages/twenty-sdk/src/cli/utilities/build/common/esbuild-watcher.ts
@@ -220,7 +220,7 @@ export const createFrontComponentsWatcher = (
       jsx: 'automatic',
       extraPlugins: [
         createTypecheckPlugin(options.appPath, options.shouldSkipTypecheck),
-        ...getFrontComponentBuildPlugins(),
+        ...getFrontComponentBuildPlugins({ usePreact: true }),
         createStubTwentySdkDefinePlugin(),
       ],
     },

--- a/packages/twenty-sdk/src/cli/utilities/build/common/front-component-build/__tests__/front-component-require-shim-plugin.spec.ts
+++ b/packages/twenty-sdk/src/cli/utilities/build/common/front-component-build/__tests__/front-component-require-shim-plugin.spec.ts
@@ -1,0 +1,93 @@
+import { mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import { createContext, runInContext } from 'node:vm';
+import { join } from 'path';
+
+import * as esbuild from 'esbuild';
+
+import { getBaseFrontComponentBuildOptions } from '@/cli/utilities/build/common/front-component-build/utils/get-base-front-component-build-options';
+import { getFrontComponentBuildPlugins } from '@/cli/utilities/build/common/front-component-build/utils/get-front-component-build-plugins';
+
+// A twenty-sdk/ui component drags in deps whose require("react") is frozen into a
+// captured call (react-responsive's UMD, use-sync-external-store's shim). Bundled
+// for the remote-dom worker, that call throws "Dynamic require of react" unless a
+// worker `require` is provided. This is the real reproduction vector for #21603.
+const ENTRY_SOURCE = `
+  import { Button } from 'twenty-sdk/ui';
+  export default function Component() {
+    return <Button title="x" onClick={() => {}} />;
+  }
+`;
+
+const buildBundle = async (format: 'esm' | 'cjs') => {
+  const directory = await mkdtemp(join(__dirname, 'require-shim-'));
+
+  try {
+    const entryPath = join(directory, 'entry.tsx');
+    await writeFile(entryPath, ENTRY_SOURCE, 'utf-8');
+
+    await esbuild.build({
+      ...getBaseFrontComponentBuildOptions(),
+      plugins: getFrontComponentBuildPlugins({ usePreact: true }),
+      minify: false,
+      format,
+      outExtension: format === 'esm' ? { '.js': '.mjs' } : { '.js': '.cjs' },
+      entryPoints: [entryPath],
+      outdir: directory,
+      logLevel: 'silent',
+    });
+
+    return await readFile(
+      join(directory, format === 'esm' ? 'entry.mjs' : 'entry.cjs'),
+      'utf-8',
+    );
+  } finally {
+    await rm(directory, { recursive: true, force: true });
+  }
+};
+
+describe('front-component require shim plugin', () => {
+  it('injects a prelude that installs globalThis.require mapping the React ids', async () => {
+    const output = await buildBundle('esm');
+
+    expect(output).toContain('globalThis.require =');
+    expect(output).toContain('__frontComponentReactModules');
+    // The component still contains the captured require the shim exists to serve.
+    expect(output).toContain('Dynamic require of');
+  }, 120000);
+
+  it('serves the captured require("react") with Preact in a worker-like context (no require)', async () => {
+    const output = await buildBundle('cjs');
+
+    // A remote-dom worker has no `require`; mirror that by omitting it from the
+    // context. The prelude must define globalThis.require at module-init time.
+    const moduleStub = { exports: {} as Record<string, unknown> };
+    const sandbox: Record<string, unknown> = {
+      module: moduleStub,
+      exports: moduleStub.exports,
+      console,
+      document: {
+        createElement: () => ({ setAttribute() {}, appendChild() {} }),
+        head: { appendChild() {} },
+      },
+      window: { matchMedia: undefined },
+    };
+    sandbox.self = sandbox;
+    sandbox.globalThis = sandbox;
+
+    const context = createContext(sandbox);
+    runInContext(output, context);
+
+    // `require` must not have existed before the prelude ran.
+    expect(typeof sandbox.require).toBe('function');
+
+    const resolvedReact = (sandbox.require as (id: string) => unknown)(
+      'react',
+    ) as Record<string, unknown>;
+
+    // Preact/compat shape — proves the captured require("react") now resolves to
+    // the bundled Preact instead of throwing.
+    expect(typeof resolvedReact.useState).toBe('function');
+    expect(typeof resolvedReact.createElement).toBe('function');
+    expect(typeof resolvedReact.useSyncExternalStore).toBe('function');
+  }, 120000);
+});

--- a/packages/twenty-sdk/src/cli/utilities/build/common/front-component-build/front-component-require-shim-plugin.ts
+++ b/packages/twenty-sdk/src/cli/utilities/build/common/front-component-build/front-component-require-shim-plugin.ts
@@ -1,0 +1,105 @@
+import { dirname } from 'path';
+
+import type * as esbuild from 'esbuild';
+
+// Front components run as ESM in a remote-dom web worker that has no `require`.
+// Some transitive CJS/UMD dependencies reach React through a require captured at
+// their own build time (e.g. `var React = require("react")` frozen into a webpack
+// UMD bundle, or use-sync-external-store's shim). When twenty-ui / twenty-sdk
+// bundle those deps with React externalized, that require survives as an opaque
+// captured call (`ps("react")`) that esbuild cannot rewrite to Preact, because it
+// is not a literal import record. At render time it falls through to esbuild's
+// `__require` helper, which throws: `Dynamic require of "react" is not supported`.
+//
+// The react -> preact aliasing plugins only catch literal `import`/`require`
+// records, so they cannot reach those captured calls. This plugin closes the gap
+// at runtime: it injects a prelude that defines `globalThis.require`, mapping the
+// React module ids to the SAME bundled Preact the rest of the component uses. The
+// prelude imports those ids through the bare specifiers, so they flow through the
+// existing wrapper/alias plugins (one Preact copy). esbuild's `__require` re-reads
+// `typeof require` at call time, so once `globalThis.require` exists the captured
+// calls resolve to Preact instead of throwing.
+const SHIM_NAMESPACE = 'front-component-require-shim';
+const SHIM_ENTRY_PATH = '\0front-component-require-shim';
+
+// The prelude runs at module-init (top-level), before any component render, so it
+// is installed before the lazy __commonJS factories that hold the captured calls
+// are ever evaluated. `react/jsx-dev-runtime` is mapped to the production runtime;
+// the build forces NODE_ENV=production, so jsxDEV is never reached.
+const SHIM_PRELUDE = `
+import * as React from 'react';
+import * as ReactDom from 'react-dom';
+import * as ReactDomClient from 'react-dom/client';
+import * as ReactJsxRuntime from 'react/jsx-runtime';
+
+var __frontComponentReactModules = {
+  'react': React,
+  'react-dom': ReactDom,
+  'react-dom/client': ReactDomClient,
+  'react/jsx-runtime': ReactJsxRuntime,
+  'react/jsx-dev-runtime': ReactJsxRuntime,
+};
+
+if (typeof globalThis.require === 'undefined') {
+  globalThis.require = function frontComponentRequire(moduleId) {
+    if (Object.prototype.hasOwnProperty.call(__frontComponentReactModules, moduleId)) {
+      return __frontComponentReactModules[moduleId];
+    }
+    throw new Error(
+      'Front component require shim: dynamic require of "' +
+        moduleId +
+        '" is not supported in the worker sandbox',
+    );
+  };
+}
+`.trim();
+
+// Resolve a directory from which `preact/*` is resolvable. The prelude's bare
+// React imports are re-resolved by the wrapper/alias plugins relative to this
+// directory, so it must sit inside the dependency tree (the app entry's folder
+// always walks up to a node_modules that provides Preact via twenty-sdk).
+const getResolveDirectory = (
+  buildOptions: esbuild.BuildOptions,
+): string | undefined => {
+  const { absWorkingDir, entryPoints } = buildOptions;
+
+  const firstEntryPoint = Array.isArray(entryPoints)
+    ? entryPoints[0]
+    : entryPoints !== undefined
+      ? Object.values(entryPoints)[0]
+      : undefined;
+
+  const entryPath =
+    typeof firstEntryPoint === 'string'
+      ? firstEntryPoint
+      : firstEntryPoint?.in;
+
+  if (entryPath !== undefined) {
+    return dirname(entryPath);
+  }
+
+  return absWorkingDir;
+};
+
+export const createFrontComponentRequireShimPlugin = (): esbuild.Plugin => ({
+  name: SHIM_NAMESPACE,
+  setup: (build) => {
+    const resolveDirectory = getResolveDirectory(build.initialOptions);
+
+    build.initialOptions.inject = [
+      ...(build.initialOptions.inject ?? []),
+      SHIM_ENTRY_PATH,
+    ];
+
+    build.onResolve({ filter: /^\0front-component-require-shim$/ }, () => ({
+      path: SHIM_ENTRY_PATH,
+      namespace: SHIM_NAMESPACE,
+    }));
+
+    build.onLoad({ filter: /.*/, namespace: SHIM_NAMESPACE }, () => ({
+      contents: SHIM_PRELUDE,
+      loader: 'js' as const,
+      resolveDir: resolveDirectory,
+    }));
+  },
+});

--- a/packages/twenty-sdk/src/cli/utilities/build/common/front-component-build/utils/get-base-front-component-build-options.ts
+++ b/packages/twenty-sdk/src/cli/utilities/build/common/front-component-build/utils/get-base-front-component-build-options.ts
@@ -15,5 +15,5 @@ export const getBaseFrontComponentBuildOptions = (): esbuild.BuildOptions => ({
   logLevel: 'silent',
   minify: true,
   define: { 'process.env.NODE_ENV': '"production"' },
-  plugins: [...getFrontComponentBuildPlugins()],
+  plugins: [...getFrontComponentBuildPlugins({ usePreact: true })],
 });

--- a/packages/twenty-sdk/src/cli/utilities/build/common/front-component-build/utils/get-front-component-build-plugins.ts
+++ b/packages/twenty-sdk/src/cli/utilities/build/common/front-component-build/utils/get-front-component-build-plugins.ts
@@ -1,6 +1,7 @@
 import type * as esbuild from 'esbuild';
 
 import { cssInjectionPlugin } from '../css-injection-plugin';
+import { createFrontComponentRequireShimPlugin } from '../front-component-require-shim-plugin';
 import { createJsxRuntimeRemoteWrapperPlugin } from '../jsx-runtime-remote-wrapper-plugin';
 import { jsxTransformToRemoteDomWorkerFormatPlugin } from '../jsx-transform-to-remote-dom-worker-format-plugin';
 import { createPreactAliasPlugin } from '../preact-alias-plugin';
@@ -16,7 +17,9 @@ export const getFrontComponentBuildPlugins = (
   createJsxRuntimeRemoteWrapperPlugin(
     options?.usePreact ? { usePreact: true } : undefined,
   ),
-  ...(options?.usePreact ? [createPreactAliasPlugin()] : []),
+  ...(options?.usePreact
+    ? [createPreactAliasPlugin(), createFrontComponentRequireShimPlugin()]
+    : []),
   jsxTransformToRemoteDomWorkerFormatPlugin,
   cssInjectionPlugin,
   stripCommentsPlugin,


### PR DESCRIPTION
fix(sdk): resolve front-component "Dynamic require of react" in the worker sandbox

## Problem

Front components crash at render with `Dynamic require of "react" is not supported`. They are bundled as ESM and run inside a remote-dom **web worker** that has no `require`, so any surviving `require(...)` call in the bundle hits esbuild's `__require` helper and throws. Fixes #21603.

## Root cause

The throwing call is **not** a literal import esbuild can rewrite — it is a `require("react")` *frozen into a captured call* by a transitive dependency's own published build (e.g. `var React = require("react")` baked into a webpack UMD bundle, or use-sync-external-store's shim). When React is externalized while those deps are bundled, the require survives as an opaque captured call (`ps("react")`) that esbuild sees as data, not as an import record.

A pristine `Button` front component has **4** such call sites from **two** deps:
- **react-responsive**'s webpack UMD (`MediaQuery = r4(ps("react"))`)
- **use-sync-external-store**'s shim (pulled in via `@base-ui`, reached by nearly every component)

This is why the existing react→preact aliasing plugins (`preact-alias`, `jsx-runtime-remote-wrapper`) cannot fix it: they only rewrite literal `import`/`require` records, and these calls are neither. It is also why removing react-responsive alone does not help — use-sync-external-store still throws, and by build time both are already frozen inside `twenty-sdk/dist/ui`, never re-resolved as modules the bundler could redirect.

## Fix

Close the gap at runtime with a new esbuild plugin (`createFrontComponentRequireShimPlugin`) that injects a prelude into the worker bundle:

- The prelude defines `globalThis.require`, mapping the React module ids (`react`, `react-dom`, `react-dom/client`, `react/jsx-runtime`, `react/jsx-dev-runtime`) to the **same bundled Preact** the rest of the component already uses. It imports those ids through bare specifiers, so they flow through the existing wrapper/alias plugins and resolve to one Preact copy — no second runtime is bundled.
- esbuild's `__require` re-reads `typeof require` at call time, so once the prelude has installed `globalThis.require` at module-init (before any lazy CJS factory runs), the frozen captured calls resolve to Preact instead of throwing.
- `react-dom/client` is imported **separately** so it resolves to `preact/compat/client` (which has `createRoot`/`hydrateRoot`), rather than being aliased to the `react` namespace which lacks them.
- `resolveDir` is derived from the build's `entryPoints` (the app entry's folder, which always walks up to a `node_modules` providing Preact via twenty-sdk's direct `preact` dependency) rather than `process.cwd()`, so Preact resolves correctly even when cwd differs from the app path.

The preact-aliasing path is enabled by passing `{ usePreact: true }` at the three build call sites (`build-application.ts`, `esbuild-watcher.ts`, `get-base-front-component-build-options.ts`); the shim is wired only when `usePreact` is on, after the alias plugins.

## Why a runtime shim and not a build-time rewrite

Removing the root cause was considered (dropping react-responsive from the worker path, or repointing it at a rewireable CJS/source entry) but neither is a complete fix: there is more than one frozen-require source (use-sync-external-store reaches almost every component), and by the time the front-component build runs, these requires are already baked into the published `twenty-sdk` dist as opaque calls — there is no module record left to redirect. The runtime shim handles every such site uniformly, present and future, with a single Preact copy.

## Verification

`front-component-require-shim-plugin.spec.ts`:
- **Static**: the ESM `Button` bundle contains the injected prelude (`globalThis.require =`, `__frontComponentReactModules`) while still containing the captured require the shim exists to serve.
- **Runtime (decisive)**: builds `Button` as CJS and evaluates it in a `node:vm` context with **no `require`** (mirroring the worker). The prelude installs `globalThis.require`, and `require("react")` returns Preact (asserts `useState`/`createElement`/`useSyncExternalStore`).

Also green: `npx nx typecheck twenty-sdk`, `npx nx lint twenty-sdk`. Browser-verified against a `create-twenty-app` scaffold consuming the published `twenty-sdk` — the scaffold front component renders with no "Dynamic require of react" banner and zero console errors.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/22254?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

