### PR TITLE
Fix default layout type to STANDALONE_PAGE for missing pages

### DIFF
--- a/packages/twenty-server/src/engine/core-modules/application/application-manifest/converters/__tests__/from-page-layout-manifest-to-universal-flat-page-layout.util.spec.ts
+++ b/packages/twenty-server/src/engine/core-modules/application/application-manifest/converters/__tests__/from-page-layout-manifest-to-universal-flat-page-layout.util.spec.ts
@@ -20,7 +20,7 @@ describe('fromPageLayoutManifestToUniversalFlatPageLayout', () => {
       applicationUniversalIdentifier,
     );
     expect(result.name).toBe('My Page Layout');
-    expect(result.type).toBe(PageLayoutType.RECORD_PAGE);
+    expect(result.type).toBe(PageLayoutType.STANDALONE_PAGE);
     expect(result.objectMetadataUniversalIdentifier).toBeNull();
     expect(
       result.defaultTabToFocusOnMobileAndSidePanelUniversalIdentifier,
@@ -47,5 +47,19 @@ describe('fromPageLayoutManifestToUniversalFlatPageLayout', () => {
     expect(
       result.defaultTabToFocusOnMobileAndSidePanelUniversalIdentifier,
     ).toBe('tab-uuid-1');
+  });
+
+  it('should default to RECORD_PAGE when objectUniversalIdentifier is present but type is omitted', () => {
+    const result = fromPageLayoutManifestToUniversalFlatPageLayout({
+      pageLayoutManifest: {
+        universalIdentifier: 'pl-uuid-3',
+        name: 'Record Page Layout',
+        objectUniversalIdentifier: 'obj-uuid-2',
+      },
+      applicationUniversalIdentifier,
+      now,
+    });
+
+    expect(result.type).toBe(PageLayoutType.RECORD_PAGE);
   });
 });

--- a/packages/twenty-server/src/engine/core-modules/application/application-manifest/converters/from-page-layout-manifest-to-universal-flat-page-layout.util.ts
+++ b/packages/twenty-server/src/engine/core-modules/application/application-manifest/converters/from-page-layout-manifest-to-universal-flat-page-layout.util.ts
@@ -17,7 +17,10 @@ export const fromPageLayoutManifestToUniversalFlatPageLayout = ({
     applicationUniversalIdentifier,
     name: pageLayoutManifest.name,
     type:
-      (pageLayoutManifest.type as PageLayoutType) ?? PageLayoutType.RECORD_PAGE,
+      (pageLayoutManifest.type as PageLayoutType) ??
+      (pageLayoutManifest.objectUniversalIdentifier
+        ? PageLayoutType.RECORD_PAGE
+        : PageLayoutType.STANDALONE_PAGE),
     objectMetadataUniversalIdentifier:
       pageLayoutManifest.objectUniversalIdentifier ?? null,
     defaultTabToFocusOnMobileAndSidePanelUniversalIdentifier:


### PR DESCRIPTION
### Description

Fixes #22251.

When creating a custom standalone page using `definePageLayout` (not attached to a standard object like Company/Person) and linking it to the sidebar via `defineNavigationMenuItem` with type: `PAGE_LAYOUT`, the SPA router fails to load the component because it defaults to `RECORD_PAGE` when the `type` property is missing.

This PR updates the application manifest converter to intelligently infer the `type` when it is omitted:
- If `objectUniversalIdentifier` is present, it defaults to `RECORD_PAGE` (maintaining existing backwards compatibility).
- If `objectUniversalIdentifier` is absent, it intelligently defaults to `STANDALONE_PAGE`.

This prevents custom standalone pages created without an explicit type from being blocked by the frontend route guard, fixing the 404 "Off track" error.

### Changes Made
- Updated `fromPageLayoutManifestToUniversalFlatPageLayout` to infer `STANDALONE_PAGE` when appropriate.
- Updated existing test cases to assert the new `STANDALONE_PAGE` default behavior.
- Added a new test case to ensure `RECORD_PAGE` inference still works when an object ID is provided.

### Validation
- Tests in `packages/twenty-server` pass (`yarn workspace twenty-server jest from-page-layout-manifest-to-universal-flat-page-layout.util.spec.ts`).


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/22255?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

