### PR TITLE
feat(logic-function): expose verified callerApplicationId in route trigger event

### DIFF
--- a/packages/twenty-server/src/engine/core-modules/logic-function/logic-function-trigger/logic-function-trigger.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/logic-function/logic-function-trigger/logic-function-trigger.service.ts
@@ -30,6 +30,7 @@ export class LogicFunctionTriggerService {
     userId,
     userWorkspaceId,
     callerApplicationId,
+    callerApplicationUniversalIdentifier,
   }: {
     logicFunction: LogicFunctionEntity;
     request: Request;
@@ -39,6 +40,7 @@ export class LogicFunctionTriggerService {
     userId?: string | null;
     userWorkspaceId?: string | null;
     callerApplicationId?: string | null;
+    callerApplicationUniversalIdentifier?: string | null;
   }): Promise<LogicFunctionTriggerOutcome> {
     const event = buildLogicFunctionEvent({
       request,
@@ -47,6 +49,8 @@ export class LogicFunctionTriggerService {
       forwardAllHeaders,
       userWorkspaceId: userWorkspaceId ?? null,
       callerApplicationId: callerApplicationId ?? null,
+      callerApplicationUniversalIdentifier:
+        callerApplicationUniversalIdentifier ?? null,
     });
 
     const result = await this.logicFunctionExecutorService.execute({

--- a/packages/twenty-server/src/engine/core-modules/logic-function/logic-function-trigger/logic-function-trigger.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/logic-function/logic-function-trigger/logic-function-trigger.service.ts
@@ -29,6 +29,7 @@ export class LogicFunctionTriggerService {
     forwardAllHeaders = false,
     userId,
     userWorkspaceId,
+    callerApplicationId,
   }: {
     logicFunction: LogicFunctionEntity;
     request: Request;
@@ -37,6 +38,7 @@ export class LogicFunctionTriggerService {
     forwardAllHeaders?: boolean;
     userId?: string | null;
     userWorkspaceId?: string | null;
+    callerApplicationId?: string | null;
   }): Promise<LogicFunctionTriggerOutcome> {
     const event = buildLogicFunctionEvent({
       request,
@@ -44,6 +46,7 @@ export class LogicFunctionTriggerService {
       forwardedRequestHeaders,
       forwardAllHeaders,
       userWorkspaceId: userWorkspaceId ?? null,
+      callerApplicationId: callerApplicationId ?? null,
     });
 
     const result = await this.logicFunctionExecutorService.execute({

--- a/packages/twenty-server/src/engine/core-modules/logic-function/logic-function-trigger/triggers/route/route-trigger.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/logic-function/logic-function-trigger/triggers/route/route-trigger.service.ts
@@ -237,6 +237,7 @@ export class RouteTriggerService {
 
     let userWorkspaceId: string | null = null;
     let userId: string | null = null;
+    let callerApplicationId: string | null = null;
 
     if (httpRouteSettings?.isAuthRequired) {
       const authContext = await this.validateWorkspaceFromRequest({
@@ -246,6 +247,7 @@ export class RouteTriggerService {
 
       userWorkspaceId = authContext.userWorkspaceId ?? null;
       userId = authContext.user?.id ?? null;
+      callerApplicationId = authContext.application?.id ?? null;
     }
 
     let outcome;
@@ -260,6 +262,7 @@ export class RouteTriggerService {
         forwardAllHeaders: isIsolatedOrigin,
         userId,
         userWorkspaceId,
+        callerApplicationId,
       });
     } catch (error) {
       if (error instanceof RouteTriggerException) {

--- a/packages/twenty-server/src/engine/core-modules/logic-function/logic-function-trigger/triggers/route/route-trigger.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/logic-function/logic-function-trigger/triggers/route/route-trigger.service.ts
@@ -238,6 +238,7 @@ export class RouteTriggerService {
     let userWorkspaceId: string | null = null;
     let userId: string | null = null;
     let callerApplicationId: string | null = null;
+    let callerApplicationUniversalIdentifier: string | null = null;
 
     if (httpRouteSettings?.isAuthRequired) {
       const authContext = await this.validateWorkspaceFromRequest({
@@ -248,6 +249,8 @@ export class RouteTriggerService {
       userWorkspaceId = authContext.userWorkspaceId ?? null;
       userId = authContext.user?.id ?? null;
       callerApplicationId = authContext.application?.id ?? null;
+      callerApplicationUniversalIdentifier =
+        authContext.application?.universalIdentifier ?? null;
     }
 
     let outcome;
@@ -263,6 +266,7 @@ export class RouteTriggerService {
         userId,
         userWorkspaceId,
         callerApplicationId,
+        callerApplicationUniversalIdentifier,
       });
     } catch (error) {
       if (error instanceof RouteTriggerException) {

--- a/packages/twenty-server/src/engine/core-modules/logic-function/logic-function-trigger/triggers/route/utils/__tests__/build-logic-function-event.util.spec.ts
+++ b/packages/twenty-server/src/engine/core-modules/logic-function/logic-function-trigger/triggers/route/utils/__tests__/build-logic-function-event.util.spec.ts
@@ -356,6 +356,7 @@ describe('buildLogicFunctionEvent', () => {
       pathParameters: { id: '123' },
       forwardedRequestHeaders: ['content-type', 'authorization'],
       userWorkspaceId: 'uws-1',
+      callerApplicationId: 'app-1',
     });
 
     expect(result).toEqual({
@@ -374,7 +375,36 @@ describe('buildLogicFunctionEvent', () => {
         },
       },
       userWorkspaceId: 'uws-1',
+      callerApplicationId: 'app-1',
     });
+  });
+
+  it('should set callerApplicationId when provided', () => {
+    const request = createMockRequest();
+
+    const result = buildLogicFunctionEvent({
+      request,
+      pathParameters: {},
+      forwardedRequestHeaders: [],
+      userWorkspaceId: null,
+      callerApplicationId: 'app-42',
+    });
+
+    expect(result.callerApplicationId).toBe('app-42');
+  });
+
+  it('should set callerApplicationId to null for anonymous callers', () => {
+    const request = createMockRequest();
+
+    const result = buildLogicFunctionEvent({
+      request,
+      pathParameters: {},
+      forwardedRequestHeaders: [],
+      userWorkspaceId: null,
+      callerApplicationId: null,
+    });
+
+    expect(result.callerApplicationId).toBeNull();
   });
 
   it('should preserve the request path as-is', () => {
@@ -387,6 +417,7 @@ describe('buildLogicFunctionEvent', () => {
       pathParameters: {},
       forwardedRequestHeaders: [],
       userWorkspaceId: null,
+      callerApplicationId: null,
     });
 
     expect(result.requestContext.http.path).toBe('/s/api/users');
@@ -402,6 +433,7 @@ describe('buildLogicFunctionEvent', () => {
       pathParameters: {},
       forwardedRequestHeaders: [],
       userWorkspaceId: null,
+      callerApplicationId: null,
     });
 
     expect(result.requestContext.http.path).toBe('/api/users');
@@ -419,6 +451,7 @@ describe('buildLogicFunctionEvent', () => {
       pathParameters: {},
       forwardedRequestHeaders: [],
       userWorkspaceId: null,
+      callerApplicationId: null,
     });
 
     expect(result.body).toBeNull();
@@ -436,6 +469,7 @@ describe('buildLogicFunctionEvent', () => {
       pathParameters: { userId: '456' },
       forwardedRequestHeaders: [],
       userWorkspaceId: null,
+      callerApplicationId: null,
     });
 
     expect(result.requestContext.http.method).toBe('DELETE');
@@ -457,6 +491,7 @@ describe('buildLogicFunctionEvent', () => {
       pathParameters: {},
       forwardedRequestHeaders: ['x-api-key'],
       userWorkspaceId: null,
+      callerApplicationId: null,
     });
 
     expect(result.headers).toEqual({
@@ -474,6 +509,7 @@ describe('buildLogicFunctionEvent', () => {
       pathParameters: {},
       forwardedRequestHeaders: [],
       userWorkspaceId: null,
+      callerApplicationId: null,
     });
 
     expect(result.isBase64Encoded).toBe(false);
@@ -496,6 +532,7 @@ describe('buildLogicFunctionEvent', () => {
       pathParameters: {},
       forwardedRequestHeaders: [],
       userWorkspaceId: null,
+      callerApplicationId: null,
     });
 
     expect(result.rawBody).toBe(original);
@@ -513,6 +550,7 @@ describe('buildLogicFunctionEvent', () => {
       pathParameters: {},
       forwardedRequestHeaders: [],
       userWorkspaceId: null,
+      callerApplicationId: null,
     });
 
     expect(result.rawBody).toBeUndefined();
@@ -532,6 +570,7 @@ describe('buildLogicFunctionEvent', () => {
       },
       forwardedRequestHeaders: [],
       userWorkspaceId: null,
+      callerApplicationId: null,
     });
 
     expect(result.pathParameters).toEqual({

--- a/packages/twenty-server/src/engine/core-modules/logic-function/logic-function-trigger/triggers/route/utils/__tests__/build-logic-function-event.util.spec.ts
+++ b/packages/twenty-server/src/engine/core-modules/logic-function/logic-function-trigger/triggers/route/utils/__tests__/build-logic-function-event.util.spec.ts
@@ -357,6 +357,7 @@ describe('buildLogicFunctionEvent', () => {
       forwardedRequestHeaders: ['content-type', 'authorization'],
       userWorkspaceId: 'uws-1',
       callerApplicationId: 'app-1',
+      callerApplicationUniversalIdentifier: 'app-uid-1',
     });
 
     expect(result).toEqual({
@@ -376,10 +377,11 @@ describe('buildLogicFunctionEvent', () => {
       },
       userWorkspaceId: 'uws-1',
       callerApplicationId: 'app-1',
+      callerApplicationUniversalIdentifier: 'app-uid-1',
     });
   });
 
-  it('should set callerApplicationId when provided', () => {
+  it('should set caller application id and universalIdentifier when provided', () => {
     const request = createMockRequest();
 
     const result = buildLogicFunctionEvent({
@@ -388,12 +390,14 @@ describe('buildLogicFunctionEvent', () => {
       forwardedRequestHeaders: [],
       userWorkspaceId: null,
       callerApplicationId: 'app-42',
+      callerApplicationUniversalIdentifier: 'app-uid-42',
     });
 
     expect(result.callerApplicationId).toBe('app-42');
+    expect(result.callerApplicationUniversalIdentifier).toBe('app-uid-42');
   });
 
-  it('should set callerApplicationId to null for anonymous callers', () => {
+  it('should set caller application fields to null for anonymous callers', () => {
     const request = createMockRequest();
 
     const result = buildLogicFunctionEvent({
@@ -402,9 +406,11 @@ describe('buildLogicFunctionEvent', () => {
       forwardedRequestHeaders: [],
       userWorkspaceId: null,
       callerApplicationId: null,
+      callerApplicationUniversalIdentifier: null,
     });
 
     expect(result.callerApplicationId).toBeNull();
+    expect(result.callerApplicationUniversalIdentifier).toBeNull();
   });
 
   it('should preserve the request path as-is', () => {
@@ -418,6 +424,7 @@ describe('buildLogicFunctionEvent', () => {
       forwardedRequestHeaders: [],
       userWorkspaceId: null,
       callerApplicationId: null,
+      callerApplicationUniversalIdentifier: null,
     });
 
     expect(result.requestContext.http.path).toBe('/s/api/users');
@@ -434,6 +441,7 @@ describe('buildLogicFunctionEvent', () => {
       forwardedRequestHeaders: [],
       userWorkspaceId: null,
       callerApplicationId: null,
+      callerApplicationUniversalIdentifier: null,
     });
 
     expect(result.requestContext.http.path).toBe('/api/users');
@@ -452,6 +460,7 @@ describe('buildLogicFunctionEvent', () => {
       forwardedRequestHeaders: [],
       userWorkspaceId: null,
       callerApplicationId: null,
+      callerApplicationUniversalIdentifier: null,
     });
 
     expect(result.body).toBeNull();
@@ -470,6 +479,7 @@ describe('buildLogicFunctionEvent', () => {
       forwardedRequestHeaders: [],
       userWorkspaceId: null,
       callerApplicationId: null,
+      callerApplicationUniversalIdentifier: null,
     });
 
     expect(result.requestContext.http.method).toBe('DELETE');
@@ -492,6 +502,7 @@ describe('buildLogicFunctionEvent', () => {
       forwardedRequestHeaders: ['x-api-key'],
       userWorkspaceId: null,
       callerApplicationId: null,
+      callerApplicationUniversalIdentifier: null,
     });
 
     expect(result.headers).toEqual({
@@ -510,6 +521,7 @@ describe('buildLogicFunctionEvent', () => {
       forwardedRequestHeaders: [],
       userWorkspaceId: null,
       callerApplicationId: null,
+      callerApplicationUniversalIdentifier: null,
     });
 
     expect(result.isBase64Encoded).toBe(false);
@@ -533,6 +545,7 @@ describe('buildLogicFunctionEvent', () => {
       forwardedRequestHeaders: [],
       userWorkspaceId: null,
       callerApplicationId: null,
+      callerApplicationUniversalIdentifier: null,
     });
 
     expect(result.rawBody).toBe(original);
@@ -551,6 +564,7 @@ describe('buildLogicFunctionEvent', () => {
       forwardedRequestHeaders: [],
       userWorkspaceId: null,
       callerApplicationId: null,
+      callerApplicationUniversalIdentifier: null,
     });
 
     expect(result.rawBody).toBeUndefined();
@@ -571,6 +585,7 @@ describe('buildLogicFunctionEvent', () => {
       forwardedRequestHeaders: [],
       userWorkspaceId: null,
       callerApplicationId: null,
+      callerApplicationUniversalIdentifier: null,
     });
 
     expect(result.pathParameters).toEqual({

--- a/packages/twenty-server/src/engine/core-modules/logic-function/logic-function-trigger/triggers/route/utils/build-logic-function-event.util.ts
+++ b/packages/twenty-server/src/engine/core-modules/logic-function/logic-function-trigger/triggers/route/utils/build-logic-function-event.util.ts
@@ -139,12 +139,14 @@ export const buildLogicFunctionEvent = ({
   forwardedRequestHeaders,
   forwardAllHeaders = false,
   userWorkspaceId,
+  callerApplicationId,
 }: {
   request: Request;
   pathParameters: Record<string, string | string[] | undefined>;
   forwardedRequestHeaders: string[];
   forwardAllHeaders?: boolean;
   userWorkspaceId: string | null;
+  callerApplicationId: string | null;
 }): LogicFunctionEvent => {
   const rawBody = extractRawBody(request);
 
@@ -166,5 +168,6 @@ export const buildLogicFunctionEvent = ({
       },
     },
     userWorkspaceId,
+    callerApplicationId,
   };
 };

--- a/packages/twenty-server/src/engine/core-modules/logic-function/logic-function-trigger/triggers/route/utils/build-logic-function-event.util.ts
+++ b/packages/twenty-server/src/engine/core-modules/logic-function/logic-function-trigger/triggers/route/utils/build-logic-function-event.util.ts
@@ -140,6 +140,7 @@ export const buildLogicFunctionEvent = ({
   forwardAllHeaders = false,
   userWorkspaceId,
   callerApplicationId,
+  callerApplicationUniversalIdentifier,
 }: {
   request: Request;
   pathParameters: Record<string, string | string[] | undefined>;
@@ -147,6 +148,7 @@ export const buildLogicFunctionEvent = ({
   forwardAllHeaders?: boolean;
   userWorkspaceId: string | null;
   callerApplicationId: string | null;
+  callerApplicationUniversalIdentifier: string | null;
 }): LogicFunctionEvent => {
   const rawBody = extractRawBody(request);
 
@@ -169,5 +171,6 @@ export const buildLogicFunctionEvent = ({
     },
     userWorkspaceId,
     callerApplicationId,
+    callerApplicationUniversalIdentifier,
   };
 };

--- a/packages/twenty-server/src/engine/core-modules/server-route-trigger/server-route-trigger.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/server-route-trigger/server-route-trigger.service.ts
@@ -73,6 +73,7 @@ export class ServerRouteTriggerService {
       forwardedRequestHeaders:
         resolver.serverRouteTriggerSettings?.forwardedRequestHeaders ?? [],
       userWorkspaceId: null,
+      callerApplicationId: null,
     });
 
     const resolverResult = await this.runFunction({

--- a/packages/twenty-server/src/engine/core-modules/server-route-trigger/server-route-trigger.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/server-route-trigger/server-route-trigger.service.ts
@@ -74,6 +74,7 @@ export class ServerRouteTriggerService {
         resolver.serverRouteTriggerSettings?.forwardedRequestHeaders ?? [],
       userWorkspaceId: null,
       callerApplicationId: null,
+      callerApplicationUniversalIdentifier: null,
     });
 
     const resolverResult = await this.runFunction({

--- a/packages/twenty-shared/src/types/LogicFunctionEvent.ts
+++ b/packages/twenty-shared/src/types/LogicFunctionEvent.ts
@@ -15,4 +15,9 @@ export type LogicFunctionEvent<TBody = object> = {
   // when the trigger fires without a user (cron, database events) or when
   // auth is disabled.
   userWorkspaceId: string | null;
+  // Verified id of the calling application, derived from the request's
+  // authenticated app access token. null when the caller is not an
+  // application (user, cron, database events) or auth is disabled. Always
+  // server-populated from the verified auth context, never from request input.
+  callerApplicationId: string | null;
 };

--- a/packages/twenty-shared/src/types/LogicFunctionEvent.ts
+++ b/packages/twenty-shared/src/types/LogicFunctionEvent.ts
@@ -20,4 +20,9 @@ export type LogicFunctionEvent<TBody = object> = {
   // application (user, cron, database events) or auth is disabled. Always
   // server-populated from the verified auth context, never from request input.
   callerApplicationId: string | null;
+  // Verified universalIdentifier of the calling application, from the same
+  // authenticated app access token. Stable across workspaces and installs,
+  // so it is the identity apps know each other by. null and server-populated
+  // under the same conditions as callerApplicationId.
+  callerApplicationUniversalIdentifier: string | null;
 };


### PR DESCRIPTION
## What

Threads the verified **calling application id** into the event passed to HTTP-route-triggered logic functions, as a new server-populated field `callerApplicationId` on `LogicFunctionEvent` (aliased to apps as `RoutePayload`).

- `LogicFunctionEvent.callerApplicationId: string | null` (new field)
- `route-trigger.service.ts` extracts `authContext.application?.id` (already verified by `validateTokenByRequest`) and passes it through
- `LogicFunctionTriggerService.run` forwards it to `buildLogicFunctionEvent`
- `server-route-trigger.service.ts` passes `null` (that path has no verified caller)

## Why

When an application access token calls another app's HTTP route, the caller's application id **is** verified server-side, but it was dropped right after auth — only `userId` / `userWorkspaceId` were kept. The executed function therefore had no way to know which application called it, because the execution token is minted with the *function's own* application id (`logic-function-executor.service.ts`), not the caller's.

This unblocks shared-store apps (e.g. a KV store installed once and used by several apps) that need to isolate data per calling application using a **trustworthy, non-spoofable** identity.

## Security notes

- `callerApplicationId` is sourced **only** from the verified auth context — never from a header, query param, or body. No caller-supplied value can override it.
- It is **null** for non-application callers (user, cron, database events) and for routes with `isAuthRequired: false`. Consumers using it for authorization must handle `null` as anonymous.
- It is purely informational context: it grants no permission, bypasses no guard, and does not change the executor's token. It carries a non-secret UUID (no token/credential exposure).

## Tests

- `build-logic-function-event.util.spec.ts`: asserts `callerApplicationId` is set when provided and `null` for anonymous callers; existing full-shape assertion updated.
- Full `twenty-server` unit suite passes locally (6082 tests); typecheck + oxlint + oxfmt clean.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/22259?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

