### PR TITLE
fix(front): don't crash whole page when a relation target object is deleted

### DIFF
--- a/packages/twenty-front/src/modules/object-record/graphql/record-gql-fields/utils/__tests__/generateDepthRecordGqlFieldsFromFields.test.ts
+++ b/packages/twenty-front/src/modules/object-record/graphql/record-gql-fields/utils/__tests__/generateDepthRecordGqlFieldsFromFields.test.ts
@@ -1,0 +1,79 @@
+import { generateDepthRecordGqlFieldsFromFields } from '@/object-record/graphql/record-gql-fields/utils/generateDepthRecordGqlFieldsFromFields';
+import { type FieldMetadataItem } from '@/object-metadata/types/FieldMetadataItem';
+import { FieldMetadataType } from 'twenty-shared/types';
+import { isDefined } from 'twenty-shared/utils';
+import { getMockObjectMetadataItemOrThrow } from '~/testing/utils/getMockObjectMetadataItemOrThrow';
+import { getTestEnrichedObjectMetadataItemsMock } from '~/testing/utils/getTestEnrichedObjectMetadataItemsMock';
+
+describe('generateDepthRecordGqlFieldsFromFields', () => {
+  const objectMetadataItems = getTestEnrichedObjectMetadataItemsMock();
+
+  const getFieldOrThrow = (
+    objectNameSingular: string,
+    fieldName: string,
+  ): FieldMetadataItem => {
+    const field = getMockObjectMetadataItemOrThrow(
+      objectNameSingular,
+    ).fields.find((item) => item.name === fieldName);
+
+    if (!isDefined(field)) {
+      throw new Error(
+        `Field ${fieldName} not found on ${objectNameSingular} mock`,
+      );
+    }
+
+    return field;
+  };
+
+  it('should skip a morph target whose object metadata has been deleted instead of throwing', () => {
+    // `timelineActivity.target` is a morph relation targeting many objects.
+    // Simulate one of them (opportunity) being deleted by removing it from the
+    // available object metadata items.
+    const targetField = getFieldOrThrow('timelineActivity', 'target');
+
+    const objectMetadataItemsWithoutOpportunity = objectMetadataItems.filter(
+      (item) => item.nameSingular !== 'opportunity',
+    );
+
+    let result: Record<string, unknown> = {};
+
+    expect(() => {
+      result = generateDepthRecordGqlFieldsFromFields({
+        objectMetadataItems: objectMetadataItemsWithoutOpportunity,
+        fields: [targetField],
+        depth: 1,
+      });
+    }).not.toThrow();
+
+    // The deleted morph target is dropped, the others remain.
+    expect(result).not.toHaveProperty('targetOpportunity');
+    expect(result).not.toHaveProperty('targetOpportunityId');
+    expect(result).toHaveProperty('targetCompany');
+  });
+
+  it('should skip a relation whose target object metadata has been deleted instead of throwing', () => {
+    const targetField = getFieldOrThrow('timelineActivity', 'target');
+
+    const relationField: FieldMetadataItem = {
+      ...targetField,
+      type: FieldMetadataType.RELATION,
+      morphRelations: null,
+      relation: targetField.morphRelations?.[0] ?? null,
+    };
+
+    const targetObjectId =
+      relationField.relation?.targetObjectMetadata.id ?? '';
+
+    const objectMetadataItemsWithoutTarget = objectMetadataItems.filter(
+      (item) => item.id !== targetObjectId,
+    );
+
+    expect(() => {
+      generateDepthRecordGqlFieldsFromFields({
+        objectMetadataItems: objectMetadataItemsWithoutTarget,
+        fields: [relationField],
+        depth: 1,
+      });
+    }).not.toThrow();
+  });
+});

--- a/packages/twenty-front/src/modules/object-record/graphql/record-gql-fields/utils/generateDepthRecordGqlFieldsFromFields.ts
+++ b/packages/twenty-front/src/modules/object-record/graphql/record-gql-fields/utils/generateDepthRecordGqlFieldsFromFields.ts
@@ -56,10 +56,11 @@ export const generateDepthRecordGqlFieldsFromFields = ({
             fieldMetadata.relation?.targetObjectMetadata.id,
         );
 
-        if (!targetObjectMetadataItem) {
-          throw new Error(
-            `Target object metadata item not found for ${fieldMetadata.name}`,
-          );
+        // The target object can be missing when it has been deleted while a
+        // relation still references it. Skip the field instead of throwing so
+        // a single dangling reference does not crash the whole page.
+        if (!isDefined(targetObjectMetadataItem)) {
+          return recordGqlFields;
         }
 
         const isActivityTargetField =
@@ -127,17 +128,19 @@ export const generateDepthRecordGqlFieldsFromFields = ({
           );
         }
 
-        const morphGqlFields = fieldMetadata.morphRelations.map(
-          (morphRelation) => {
+        const morphGqlFields = fieldMetadata.morphRelations
+          .map((morphRelation) => {
             const morphTargetObjectMetadataItem = objectMetadataItems.find(
               (objectMetadataItem) =>
                 objectMetadataItem.id === morphRelation.targetObjectMetadata.id,
             );
 
-            if (!morphTargetObjectMetadataItem) {
-              throw new Error(
-                `Target object metadata item not found for ${fieldMetadata.name} (morph target ${morphRelation.targetObjectMetadata.nameSingular})`,
-              );
+            // A morph target can be missing when the target object has been
+            // deleted while the morph relation still references it. Skip this
+            // target instead of throwing so a single dangling reference does
+            // not crash the whole page.
+            if (!isDefined(morphTargetObjectMetadataItem)) {
+              return undefined;
             }
 
             return {
@@ -154,8 +157,8 @@ export const generateDepthRecordGqlFieldsFromFields = ({
                 morphTargetObjectMetadataItem,
               ),
             };
-          },
-        );
+          })
+          .filter(isDefined);
 
         return {
           ...recordGqlFields,


### PR DESCRIPTION
Building the GraphQL fields for a record threw a hard error when a
relation or morph-relation field still referenced an object metadata
item that no longer existed (e.g. the target object was deleted while a
dashboard widget / morph relation kept pointing at it). The throw
happened in the data layer, above any widget error boundary, taking down
the entire page with "Sorry, something went wrong".

Skip the dangling relation / morph target instead of throwing. Querying a
deleted object's fields is impossible anyway, so dropping it is safe and
lets the rest of the page render (the affected widget then degrades to
its own invalid-configuration state).