### PR TITLE
fix(website): config-only Crowdin pull to match short-code catalogs

### DIFF
--- a/.github/workflows/website-i18n-pull.yaml
+++ b/.github/workflows/website-i18n-pull.yaml
@@ -71,8 +71,6 @@ jobs:
           upload_sources: false
           upload_translations: false
           download_translations: true
-          source: 'packages/twenty-website/src/locales/en.po'
-          translation: 'packages/twenty-website/src/locales/%locale%.po'
           export_only_approved: false
           localization_branch_name: i18n-website
           base_url: 'https://twenty.api.crowdin.com'


### PR DESCRIPTION
## What

`website-i18n-pull.yaml` passed inline `source` + `translation: '…/%locale%.po'` to the Crowdin action *on top of* the config file. After #22257 migrated the website to short-code catalogs (`ar.po`/`es.po`, and `crowdin-website.yml` → `%two_letters_code%`), that inline `%locale%` resolves to **full-code** filenames (`ar-SA.po`/`es-ES.po`) that no longer exist in the repo — so the pull never updates the real catalogs.

## Fix

Drop the inline `source`/`translation` so the step is **config-only**, driven by `.github/crowdin-website.yml` (`%two_letters_code%`) — matching the front/app pull (`i18n-pull.yaml`), which is config-only and works.

## Also (ops, not in this diff)

The pull doesn't run against `main` — its first step is `git checkout -B i18n-website origin/i18n-website`, so it operates on the long-lived `i18n-website` branch (same pattern as `i18n` for front and `i18n-docs` for docs). That branch was still at the **pre-#22257** layout (full-code `.po`, `%locale%` config, old 3-locale list), so it was reset to `main` to carry the new short-code structure. Once this PR merges, a pull run will land translations into the correct `ar.po`/`es.po`/… catalogs.
