### PR TITLE
fix(website): bump @opennextjs/cloudflare to 1.20.0 (R2 deploy on Node 24)

### DIFF
--- a/packages/twenty-website/package.json
+++ b/packages/twenty-website/package.json
@@ -41,7 +41,7 @@
     "@lingui/conf": "5.1.2",
     "@lingui/format-po": "5.1.2",
     "@lingui/swc-plugin": "^5.11.0",
-    "@opennextjs/cloudflare": "^1.0.0",
+    "@opennextjs/cloudflare": "^1.20.0",
     "@testing-library/jest-dom": "^6.6.3",
     "@testing-library/react": "^16.3.0",
     "@testing-library/user-event": "^14.6.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -14362,9 +14362,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@opennextjs/cloudflare@npm:^1.0.0":
-  version: 1.19.10
-  resolution: "@opennextjs/cloudflare@npm:1.19.10"
+"@opennextjs/cloudflare@npm:^1.20.0":
+  version: 1.20.0
+  resolution: "@opennextjs/cloudflare@npm:1.20.0"
   dependencies:
     "@ast-grep/napi": "npm:^0.40.5"
     "@dotenvx/dotenvx": "npm:1.31.0"
@@ -14378,10 +14378,14 @@ __metadata:
     yargs: "npm:^18.0.0"
   peerDependencies:
     next: ">=15.5.18 <16 || >=16.2.6"
+    rclone.js: ^0.6.6
     wrangler: ^4.86.0
+  peerDependenciesMeta:
+    rclone.js:
+      optional: true
   bin:
     opennextjs-cloudflare: dist/cli/index.js
-  checksum: 10c0/441b268a67467b8b25d7cd9f210dc79d058211dacb541f0bde5feb69537172bfa965fc2388382c9d684a8d943730c0fbd177b6eb35f60b33d9518d8b5680eb6b
+  checksum: 10c0/a28b29fc3548dc81252daa2f4e319727f1cd471f7d26a3508d622209cfd13b47301fb904b89a8c1f241dca4d1fb88655a89d5ffa54a23aba8d8c2de32f8ffa6d
   languageName: node
   linkType: hard
 
@@ -53385,7 +53389,7 @@ __metadata:
     "@lingui/react": "npm:^5.1.2"
     "@lingui/swc-plugin": "npm:^5.11.0"
     "@lottiefiles/dotlottie-react": "npm:^0.18.10"
-    "@opennextjs/cloudflare": "npm:^1.0.0"
+    "@opennextjs/cloudflare": "npm:^1.20.0"
     "@tabler/icons-react": "npm:^3.41.1"
     "@testing-library/jest-dom": "npm:^6.6.3"
     "@testing-library/react": "npm:^16.3.0"


### PR DESCRIPTION
## What

The twenty-infra **"Deploy Website"** workflow has failed every run since 06-26 — at OpenNext's R2 incremental-cache step, **not** the build:

```
Failed to provision remote R2 bucket "twenty-website-cache-dev"
for binding "NEXT_INC_CACHE_R2_BUCKET":
Failed to check whether bucket exists: … Premature close
```

## Root cause

`@opennextjs/cloudflare`'s `ensureR2Bucket()` calls the Cloudflare SDK's `r2.buckets.get()`. On **Node 24** (which the deploy pins) undici truncates the **gzip-compressed** Cloudflare API response → `Premature close`. The SDK's own retries don't help (it's systematic, not flaky), and pre-creating the bucket doesn't help (it always `.get()`s first).

This is **pre-existing and unrelated to the multi-locale change** (#22257): the *Build Worker* step succeeds, and the identical error appears on 06-26 runs (two days before that merged).

## Fix

opennext **1.20.0** fixes this precisely — it passes `defaultHeaders: { "Accept-Encoding": "identity" }` to the Cloudflare SDK client, so the API returns **uncompressed** responses (no decompression → no premature close). **Node 24 is kept**, and no twenty-infra change is needed — the deploy runs `twenty`'s own `npx opennextjs-cloudflare`, so bumping the dep here is enough.

`^1.0.0 → ^1.20.0`. **1.20.0, not the latest 1.20.1**, because the repo's `npmMinimalAgeGate: 3d` still quarantines 1.20.1 (published 06-26); 1.20.0 (06-25) is past the gate and carries the same fix.

## Verification

- Resolved to `1.20.0`; confirmed `Accept-Encoding: identity` is in the installed `dist/cli/utils/ensure-r2-bucket.js`.
- `nx typecheck twenty-website` green (OpenNext config API unchanged across the bump).
- Diff is just `package.json` + `yarn.lock`.

⚠️ Full confirmation needs a **Deploy Website** run (exercises the build + the R2 provision step), which I can't trigger — please re-run it after merge.
