### PR TITLE
feat(helm): parametrize liveness, readiness and startup probes for server

### DIFF
--- a/packages/twenty-docker/helm/twenty/templates/deployment-server.yaml
+++ b/packages/twenty-docker/helm/twenty/templates/deployment-server.yaml
@@ -184,22 +184,18 @@ spec:
             - name: http-tcp
               containerPort: {{ include "twenty.server.containerPort" . }}
               protocol: TCP
+          {{- with .Values.server.startupProbe }}
+          startupProbe:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.server.livenessProbe }}
           livenessProbe:
-            httpGet:
-              path: /
-              port: {{ include "twenty.server.containerPort" . }}
-            initialDelaySeconds: 60
-            periodSeconds: 10
-            timeoutSeconds: 5
-            failureThreshold: 5
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.server.readinessProbe }}
           readinessProbe:
-            httpGet:
-              path: /
-              port: {{ include "twenty.server.containerPort" . }}
-            initialDelaySeconds: 40
-            periodSeconds: 5
-            timeoutSeconds: 5
-            failureThreshold: 5
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           resources:
             {{- toYaml .Values.server.resources | nindent 12 }}
           volumeMounts:

--- a/packages/twenty-docker/helm/twenty/values.schema.json
+++ b/packages/twenty-docker/helm/twenty/values.schema.json
@@ -3,6 +3,54 @@
   "title": "Twenty Helm Chart Values",
   "type": "object",
   "additionalProperties": true,
+  "definitions": {
+    "probe": {
+      "oneOf": [
+        { "type": "null" },
+        {
+          "type": "object",
+          "properties": {
+            "httpGet": {
+              "type": "object",
+              "properties": {
+                "path": { "type": "string" },
+                "port": { "type": ["string", "integer"] },
+                "scheme": { "type": "string", "enum": ["HTTP", "HTTPS"] },
+                "host": { "type": "string" },
+                "httpHeaders": { "type": "array" }
+              }
+            },
+            "tcpSocket": {
+              "type": "object",
+              "properties": {
+                "port": { "type": ["string", "integer"] },
+                "host": { "type": "string" }
+              },
+              "required": ["port"]
+            },
+            "exec": {
+              "type": "object",
+              "properties": {
+                "command": { "type": "array", "items": { "type": "string" } }
+              },
+              "required": ["command"]
+            },
+            "initialDelaySeconds": { "type": "integer", "minimum": 0 },
+            "periodSeconds": { "type": "integer", "minimum": 1 },
+            "timeoutSeconds": { "type": "integer", "minimum": 1 },
+            "successThreshold": { "type": "integer", "minimum": 1 },
+            "failureThreshold": { "type": "integer", "minimum": 1 },
+            "terminationGracePeriodSeconds": { "type": "integer", "minimum": 1 }
+          },
+          "oneOf": [
+            { "required": ["httpGet"] },
+            { "required": ["tcpSocket"] },
+            { "required": ["exec"] }
+          ]
+        }
+      ]
+    }
+  },
   "properties": {
     "image": {
       "type": "object",
@@ -146,7 +194,10 @@
         },
         "affinity": { "type": "object" },
         "dnsPolicy": { "type": ["string", "null"], "enum": ["ClusterFirst", "ClusterFirstWithHostNet", "Default", "None", null] },
-        "dnsConfig": { "type": "object" }
+        "dnsConfig": { "type": "object" },
+        "startupProbe": { "$ref": "#/definitions/probe" },
+        "livenessProbe": { "$ref": "#/definitions/probe" },
+        "readinessProbe": { "$ref": "#/definitions/probe" }
       }
     },
 

--- a/packages/twenty-docker/helm/twenty/values.yaml
+++ b/packages/twenty-docker/helm/twenty/values.yaml
@@ -105,6 +105,36 @@ server:
   dnsPolicy: ~
   dnsConfig: {}
 
+  # Health probes - set any probe to null to disable it.
+  # The `port: http-tcp` references the named container port, so the chart's
+  # configurable server port is honoured automatically.
+  # livenessProbe carries a generous initialDelaySeconds as a safety net for
+  # users who disable startupProbe; if startupProbe is kept, this delay is
+  # redundant but harmless because liveness only starts after startup passes.
+  startupProbe:
+    httpGet:
+      path: /healthz
+      port: http-tcp
+    periodSeconds: 10
+    timeoutSeconds: 5
+    failureThreshold: 30
+  livenessProbe:
+    httpGet:
+      path: /healthz
+      port: http-tcp
+    initialDelaySeconds: 120
+    periodSeconds: 30
+    timeoutSeconds: 5
+    failureThreshold: 3
+  readinessProbe:
+    httpGet:
+      path: /healthz
+      port: http-tcp
+    initialDelaySeconds: 30
+    periodSeconds: 10
+    timeoutSeconds: 5
+    failureThreshold: 3
+
 # Worker deployment
 worker:
   enabled: true

--- a/packages/twenty-docker/helm/twenty/values.yaml
+++ b/packages/twenty-docker/helm/twenty/values.yaml
@@ -105,12 +105,9 @@ server:
   dnsPolicy: ~
   dnsConfig: {}
 
-  # Health probes - set any probe to null to disable it.
-  # The `port: http-tcp` references the named container port, so the chart's
-  # configurable server port is honoured automatically.
-  # livenessProbe carries a generous initialDelaySeconds as a safety net for
-  # users who disable startupProbe; if startupProbe is kept, this delay is
-  # redundant but harmless because liveness only starts after startup passes.
+  # Health probes for the server container. Set any probe to null to disable it.
+  # startupProbe gates the slow initial boot (up to periodSeconds x failureThreshold),
+  # so liveness/readiness intentionally carry no initialDelaySeconds.
   startupProbe:
     httpGet:
       path: /healthz
@@ -122,7 +119,6 @@ server:
     httpGet:
       path: /healthz
       port: http-tcp
-    initialDelaySeconds: 120
     periodSeconds: 30
     timeoutSeconds: 5
     failureThreshold: 3
@@ -130,7 +126,6 @@ server:
     httpGet:
       path: /healthz
       port: http-tcp
-    initialDelaySeconds: 30
     periodSeconds: 10
     timeoutSeconds: 5
     failureThreshold: 3


### PR DESCRIPTION
Closes #22267
 
## What
 
Exposes `startupProbe`, `livenessProbe` and `readinessProbe` as configurable values under `server.*` in `values.yaml`, with sensible defaults that work out of the box on current Twenty releases. Also switches the probe path from `/` to `/healthz`.
 
## Why
 
The probes are hardcoded in the chart template today, and the defaults are no longer realistic for the current product.
 
On a clean install of `v2.16.1` the server takes about **111 seconds** to reach `Nest application successfully started`. The current hardcoded `livenessProbe` only gives the pod **110 seconds** before killing it (`initialDelaySeconds: 60` + `failureThreshold: 5` x `periodSeconds: 10`). The pod is killed roughly 1 second before it would have been healthy and the deployment enters `CrashLoopBackOff` indefinitely.
 
Twenty's boot time grows release by release as new Nest modules are added (v2.16 already registers 16 minor versions worth of upgrade commands at startup), so the chart's hardcoded defaults will keep drifting away from a working configuration.
 
The probe path `/` returns the SPA HTML (or a 404 depending on routing), not a health response. The correct endpoint is `/healthz`, which returns `{"status":"ok","info":{},"error":{},"details":{}}` from a dedicated Nest controller.
 
## How
 
Uses the same `{{- with }}` pattern already present in the chart (`extraEnv`, `extraVolumeMounts`, and the four scheduling fields added in #22233):
 
```yaml
{{- with .Values.server.startupProbe }}
startupProbe:
  {{- toYaml . | nindent 12 }}
{{- end }}
{{- with .Values.server.livenessProbe }}
livenessProbe:
  {{- toYaml . | nindent 12 }}
{{- end }}
{{- with .Values.server.readinessProbe }}
readinessProbe:
  {{- toYaml . | nindent 12 }}
{{- end }}
```
 
This pattern lets the user disable any probe by setting it to `null`, override individual fields by providing the full block, or fall back to the defaults shipped in `values.yaml`.
 
## Defaults
 
```yaml
server:
  startupProbe:
    httpGet:
      path: /healthz
      port: http-tcp
    periodSeconds: 10
    failureThreshold: 30   # 5 minutes total boot grace
  livenessProbe:
    httpGet:
      path: /healthz
      port: http-tcp
    periodSeconds: 30
    failureThreshold: 3
  readinessProbe:
    httpGet:
      path: /healthz
      port: http-tcp
    periodSeconds: 10
    failureThreshold: 3
```
 
## Scope
 
This PR only touches the server Deployment. The worker Deployment is intentionally out of scope: it does not expose HTTP, had no probes before this change, and any probe added there would need a different shape (`exec` or `tcpSocket`). It can be addressed in a follow-up if maintainers want it.
 
## Backward compatibility
 
For any cluster that booted Twenty correctly with the previous defaults (boot time under 5 minutes), `helm template` output is functionally equivalent: the new `startupProbe` covers the boot window, then `livenessProbe` and `readinessProbe` take over with similar semantics.
 
For clusters where the previous defaults were already failing (such as this one — see "Validation" below), the new defaults make the install work out of the box.
 
Setting any probe value to `null` disables that probe entirely.
 
## Schema note
 
`values.schema.json` updated with `startupProbe`, `livenessProbe` and `readinessProbe` under `server`, all typed as `["object", "null"]` to honour the disable-by-null contract.
 
## Validation
 
- `helm lint` passes.
- `helm template` with default values renders the three probe blocks on the server Deployment.
- `helm template` with one probe set to `null` correctly omits that probe.
- `helm template` with overridden values renders the user-supplied probe configuration.
- Live install validated on a multi-node Kubernetes cluster running Twenty v2.16.1 on an Oracle Cloud ARM64 worker node. With the new `startupProbe` the server reaches `Ready 1/1` in around 2 minutes from fresh pod creation. With the previous hardcoded probes the same pod entered `CrashLoopBackOff` indefinitely (276 restarts in 21 hours observed before applying the fix).
````
 
## Files touched
 
- `packages/twenty-docker/helm/twenty/templates/deployment-server.yaml`
- `packages/twenty-docker/helm/twenty/values.yaml`
- `packages/twenty-docker/helm/twenty/values.schema.json`
## Related
 
- Discovered while validating PR #22233 (nodeSelector / tolerations / DNS overrides).
- Same chart, same pattern, same self-host audience.
- Closes #22267.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/22268?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

