### PR TITLE
feat(application): auto-install app dependencies from package.json

### DIFF
--- a/packages/twenty-server/src/engine/core-modules/application/application-exception-filter.ts
+++ b/packages/twenty-server/src/engine/core-modules/application/application-exception-filter.ts
@@ -33,6 +33,8 @@ export class ApplicationExceptionFilter implements ExceptionFilter {
       case ApplicationExceptionCode.CANNOT_DOWNGRADE_APPLICATION:
       case ApplicationExceptionCode.SERVER_VERSION_INCOMPATIBLE:
       case ApplicationExceptionCode.INVALID_APP_ENGINE_REQUIREMENT:
+      case ApplicationExceptionCode.APP_DEPENDENCY_VERSION_INCOMPATIBLE:
+      case ApplicationExceptionCode.APP_DEPENDENCY_CYCLE_DETECTED:
         throw new UserInputError(exception);
       case ApplicationExceptionCode.PACKAGE_RESOLUTION_FAILED:
       case ApplicationExceptionCode.POST_INSTALL_ERROR:

--- a/packages/twenty-server/src/engine/core-modules/application/application-install/application-install.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/application/application-install/application-install.service.ts
@@ -5,6 +5,7 @@ import { promises as fs } from 'fs';
 import { resolve } from 'path';
 
 import semver from 'semver';
+import { type PackageJson } from 'type-fest';
 import { Manifest } from 'twenty-shared/application';
 import { FileFolder } from 'twenty-shared/types';
 import { isDefined } from 'twenty-shared/utils';
@@ -18,6 +19,7 @@ import { ApplicationRegistrationEntity } from 'src/engine/core-modules/applicati
 import { ApplicationRegistrationSourceType } from 'src/engine/core-modules/application/application-registration/enums/application-registration-source-type.enum';
 import { ApplicationEntity } from 'src/engine/core-modules/application/application.entity';
 import { ApplicationService } from 'src/engine/core-modules/application/application.service';
+import { assertAppDependencyInstallable } from 'src/engine/core-modules/application/application-install/utils/assert-app-dependency-installable.util';
 import { ApplicationPackageFetcherService } from 'src/engine/core-modules/application/application-package/application-package-fetcher.service';
 import {
   ApplicationVersionValidationService,
@@ -67,11 +69,14 @@ export class ApplicationInstallService {
     private readonly workspaceCacheService: WorkspaceCacheService,
   ) {}
 
-  async installApplication(params: {
-    appRegistrationId: string;
-    version?: string;
-    workspaceId: string;
-  }): Promise<boolean> {
+  async installApplication(
+    params: {
+      appRegistrationId: string;
+      version?: string;
+      workspaceId: string;
+    },
+    installingUniversalIdentifiers: Set<string> = new Set(),
+  ): Promise<boolean> {
     const appRegistration = await this.appRegistrationRepository.findOne({
       where: { id: params.appRegistrationId },
     });
@@ -108,10 +113,14 @@ export class ApplicationInstallService {
 
     return this.cacheLockService.withLock(
       () =>
-        this.doInstallApplication(appRegistration, {
-          version: params.version,
-          workspaceId: params.workspaceId,
-        }),
+        this.doInstallApplication(
+          appRegistration,
+          {
+            version: params.version,
+            workspaceId: params.workspaceId,
+          },
+          installingUniversalIdentifiers,
+        ),
       lockKey,
       { ttl: 60_000, ms: 500, maxRetries: 120 },
     );
@@ -120,6 +129,7 @@ export class ApplicationInstallService {
   private async doInstallApplication(
     appRegistration: ApplicationRegistrationEntity,
     params: { version?: string; workspaceId: string },
+    installingUniversalIdentifiers: Set<string> = new Set(),
   ): Promise<boolean> {
     const resolvedPackage =
       await this.applicationPackageFetcherService.resolvePackage(
@@ -215,6 +225,13 @@ export class ApplicationInstallService {
         }
       }
 
+      await this.installDeclaredAppDependencies({
+        packageJson: resolvedPackage.packageJson,
+        workspaceId: params.workspaceId,
+        dependentUniversalIdentifier: universalIdentifier,
+        installingUniversalIdentifiers,
+      });
+
       await this.writeFilesToStorage(
         resolvedPackage.extractedDir,
         resolvedPackage.manifest,
@@ -281,6 +298,140 @@ export class ApplicationInstallService {
         );
       }
     }
+  }
+
+  private async installDeclaredAppDependencies(params: {
+    packageJson: PackageJson;
+    workspaceId: string;
+    dependentUniversalIdentifier: string;
+    installingUniversalIdentifiers: Set<string>;
+  }): Promise<void> {
+    const dependencies = params.packageJson.dependencies ?? {};
+
+    for (const [packageName, versionRange] of Object.entries(dependencies)) {
+      if (!isDefined(versionRange)) {
+        continue;
+      }
+
+      const resolvedDependency = await this.resolveAppDependencyOrNull(
+        packageName,
+        versionRange,
+      );
+
+      if (!isDefined(resolvedDependency)) {
+        continue;
+      }
+
+      const { universalIdentifier, version, displayName } = resolvedDependency;
+
+      assertAppDependencyInstallable({
+        dependentUniversalIdentifier: params.dependentUniversalIdentifier,
+        dependencyPackageName: packageName,
+        dependencyUniversalIdentifier: universalIdentifier,
+        resolvedVersion: version,
+        versionRange,
+        installingUniversalIdentifiers: params.installingUniversalIdentifiers,
+      });
+
+      const existingApplication =
+        await this.applicationService.findByUniversalIdentifier({
+          universalIdentifier,
+          workspaceId: params.workspaceId,
+        });
+
+      if (
+        isDefined(existingApplication) &&
+        isDefined(existingApplication.version) &&
+        semver.satisfies(existingApplication.version, versionRange)
+      ) {
+        continue;
+      }
+
+      const registration = await this.ensureNpmRegistration({
+        universalIdentifier,
+        name: displayName,
+        sourcePackage: packageName,
+        latestAvailableVersion: version,
+      });
+
+      await this.installApplication(
+        {
+          appRegistrationId: registration.id,
+          version,
+          workspaceId: params.workspaceId,
+        },
+        new Set([
+          ...params.installingUniversalIdentifiers,
+          params.dependentUniversalIdentifier,
+        ]),
+      );
+    }
+  }
+
+  private async resolveAppDependencyOrNull(
+    packageName: string,
+    versionRange: string,
+  ): Promise<{
+    universalIdentifier: string;
+    version: string;
+    displayName: string;
+  } | null> {
+    let resolvedPackage;
+
+    try {
+      resolvedPackage =
+        await this.applicationPackageFetcherService.resolveNpmPackageByName(
+          packageName,
+          semver.validRange(versionRange) ? undefined : versionRange,
+        );
+    } catch {
+      return null;
+    }
+
+    try {
+      const universalIdentifier =
+        resolvedPackage.manifest.application?.universalIdentifier;
+      const version = resolvedPackage.packageJson.version;
+
+      if (!isDefined(universalIdentifier) || !isDefined(version)) {
+        return null;
+      }
+
+      return {
+        universalIdentifier,
+        version,
+        displayName: resolvedPackage.manifest.application.displayName,
+      };
+    } finally {
+      await this.applicationPackageFetcherService.cleanupExtractedDir(
+        resolvedPackage.cleanupDir,
+      );
+    }
+  }
+
+  private async ensureNpmRegistration(params: {
+    universalIdentifier: string;
+    name: string;
+    sourcePackage: string;
+    latestAvailableVersion: string;
+  }): Promise<ApplicationRegistrationEntity> {
+    const existing = await this.appRegistrationRepository.findOne({
+      where: { universalIdentifier: params.universalIdentifier },
+    });
+
+    if (isDefined(existing)) {
+      return existing;
+    }
+
+    return this.appRegistrationRepository.save(
+      this.appRegistrationRepository.create({
+        universalIdentifier: params.universalIdentifier,
+        name: params.name,
+        sourceType: ApplicationRegistrationSourceType.NPM,
+        sourcePackage: params.sourcePackage,
+        latestAvailableVersion: params.latestAvailableVersion,
+      }),
+    );
   }
 
   private async runPreInstallHook(params: {

--- a/packages/twenty-server/src/engine/core-modules/application/application-install/utils/__tests__/assert-app-dependency-installable.util.spec.ts
+++ b/packages/twenty-server/src/engine/core-modules/application/application-install/utils/__tests__/assert-app-dependency-installable.util.spec.ts
@@ -1,0 +1,84 @@
+import {
+  ApplicationException,
+  ApplicationExceptionCode,
+} from 'src/engine/core-modules/application/application.exception';
+import { assertAppDependencyInstallable } from 'src/engine/core-modules/application/application-install/utils/assert-app-dependency-installable.util';
+
+const DEPENDENT = 'aaaaaaaa-aaaa-4aaa-aaaa-aaaaaaaaaaaa';
+const DEPENDENCY = 'bbbbbbbb-bbbb-4bbb-bbbb-bbbbbbbbbbbb';
+
+const baseParams = {
+  dependentUniversalIdentifier: DEPENDENT,
+  dependencyPackageName: 'kv-value-store',
+  dependencyUniversalIdentifier: DEPENDENCY,
+  resolvedVersion: '1.2.0',
+  versionRange: '^1.0.0',
+  installingUniversalIdentifiers: new Set<string>(),
+};
+
+describe('assertAppDependencyInstallable', () => {
+  it('passes when the resolved version satisfies the range and there is no cycle', () => {
+    expect(() =>
+      assertAppDependencyInstallable(baseParams),
+    ).not.toThrow();
+  });
+
+  it('throws APP_DEPENDENCY_VERSION_INCOMPATIBLE when the version does not satisfy the range', () => {
+    expect.assertions(2);
+
+    try {
+      assertAppDependencyInstallable({
+        ...baseParams,
+        resolvedVersion: '2.0.0',
+        versionRange: '^1.0.0',
+      });
+    } catch (error) {
+      expect(error).toBeInstanceOf(ApplicationException);
+      expect((error as ApplicationException).code).toBe(
+        ApplicationExceptionCode.APP_DEPENDENCY_VERSION_INCOMPATIBLE,
+      );
+    }
+  });
+
+  it('throws APP_DEPENDENCY_CYCLE_DETECTED when the dependency is an ancestor being installed', () => {
+    expect.assertions(2);
+
+    try {
+      assertAppDependencyInstallable({
+        ...baseParams,
+        installingUniversalIdentifiers: new Set([DEPENDENCY]),
+      });
+    } catch (error) {
+      expect(error).toBeInstanceOf(ApplicationException);
+      expect((error as ApplicationException).code).toBe(
+        ApplicationExceptionCode.APP_DEPENDENCY_CYCLE_DETECTED,
+      );
+    }
+  });
+
+  it('throws APP_DEPENDENCY_CYCLE_DETECTED when an app depends on itself', () => {
+    expect(() =>
+      assertAppDependencyInstallable({
+        ...baseParams,
+        dependencyUniversalIdentifier: DEPENDENT,
+      }),
+    ).toThrow(ApplicationException);
+  });
+
+  it('checks the version before the cycle (incompatible self-dependency reports version error)', () => {
+    expect.assertions(1);
+
+    try {
+      assertAppDependencyInstallable({
+        ...baseParams,
+        dependencyUniversalIdentifier: DEPENDENT,
+        resolvedVersion: '2.0.0',
+        versionRange: '^1.0.0',
+      });
+    } catch (error) {
+      expect((error as ApplicationException).code).toBe(
+        ApplicationExceptionCode.APP_DEPENDENCY_VERSION_INCOMPATIBLE,
+      );
+    }
+  });
+});

--- a/packages/twenty-server/src/engine/core-modules/application/application-install/utils/__tests__/assert-app-dependency-installable.util.spec.ts
+++ b/packages/twenty-server/src/engine/core-modules/application/application-install/utils/__tests__/assert-app-dependency-installable.util.spec.ts
@@ -18,9 +18,7 @@ const baseParams = {
 
 describe('assertAppDependencyInstallable', () => {
   it('passes when the resolved version satisfies the range and there is no cycle', () => {
-    expect(() =>
-      assertAppDependencyInstallable(baseParams),
-    ).not.toThrow();
+    expect(() => assertAppDependencyInstallable(baseParams)).not.toThrow();
   });
 
   it('throws APP_DEPENDENCY_VERSION_INCOMPATIBLE when the version does not satisfy the range', () => {

--- a/packages/twenty-server/src/engine/core-modules/application/application-install/utils/assert-app-dependency-installable.util.ts
+++ b/packages/twenty-server/src/engine/core-modules/application/application-install/utils/assert-app-dependency-installable.util.ts
@@ -1,0 +1,39 @@
+import semver from 'semver';
+
+import {
+  ApplicationException,
+  ApplicationExceptionCode,
+} from 'src/engine/core-modules/application/application.exception';
+
+export const assertAppDependencyInstallable = ({
+  dependentUniversalIdentifier,
+  dependencyPackageName,
+  dependencyUniversalIdentifier,
+  resolvedVersion,
+  versionRange,
+  installingUniversalIdentifiers,
+}: {
+  dependentUniversalIdentifier: string;
+  dependencyPackageName: string;
+  dependencyUniversalIdentifier: string;
+  resolvedVersion: string;
+  versionRange: string;
+  installingUniversalIdentifiers: Set<string>;
+}): void => {
+  if (!semver.satisfies(resolvedVersion, versionRange)) {
+    throw new ApplicationException(
+      `App "${dependentUniversalIdentifier}" depends on "${dependencyPackageName}@${versionRange}" but the available version is ${resolvedVersion}.`,
+      ApplicationExceptionCode.APP_DEPENDENCY_VERSION_INCOMPATIBLE,
+    );
+  }
+
+  if (
+    dependencyUniversalIdentifier === dependentUniversalIdentifier ||
+    installingUniversalIdentifiers.has(dependencyUniversalIdentifier)
+  ) {
+    throw new ApplicationException(
+      `Circular app dependency detected involving "${dependencyUniversalIdentifier}".`,
+      ApplicationExceptionCode.APP_DEPENDENCY_CYCLE_DETECTED,
+    );
+  }
+};

--- a/packages/twenty-server/src/engine/core-modules/application/application-package/application-package-fetcher.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/application/application-package/application-package-fetcher.service.ts
@@ -90,6 +90,13 @@ export class ApplicationPackageFetcherService implements OnModuleInit {
     }
   }
 
+  async resolveNpmPackageByName(
+    packageName: string,
+    targetVersion?: string,
+  ): Promise<ResolvedPackage> {
+    return this.resolveFromNpm(packageName, targetVersion);
+  }
+
   async cleanupExtractedDir(extractedDir: string): Promise<void> {
     try {
       await fs.rm(extractedDir, { recursive: true, force: true });

--- a/packages/twenty-server/src/engine/core-modules/application/application-rest-api-exception.filter.ts
+++ b/packages/twenty-server/src/engine/core-modules/application/application-rest-api-exception.filter.ts
@@ -35,6 +35,8 @@ const applicationExceptionCodeToHttpStatus = (
     case ApplicationExceptionCode.CANNOT_DOWNGRADE_APPLICATION:
     case ApplicationExceptionCode.SERVER_VERSION_INCOMPATIBLE:
     case ApplicationExceptionCode.INVALID_APP_ENGINE_REQUIREMENT:
+    case ApplicationExceptionCode.APP_DEPENDENCY_VERSION_INCOMPATIBLE:
+    case ApplicationExceptionCode.APP_DEPENDENCY_CYCLE_DETECTED:
       return 400;
     case ApplicationExceptionCode.PACKAGE_RESOLUTION_FAILED:
     case ApplicationExceptionCode.POST_INSTALL_ERROR:

--- a/packages/twenty-server/src/engine/core-modules/application/application.exception.ts
+++ b/packages/twenty-server/src/engine/core-modules/application/application.exception.ts
@@ -25,6 +25,8 @@ export enum ApplicationExceptionCode {
   SERVER_VERSION_INCOMPATIBLE = 'SERVER_VERSION_INCOMPATIBLE',
   INVALID_APP_ENGINE_REQUIREMENT = 'INVALID_APP_ENGINE_REQUIREMENT',
   INVALID_SERVER_VERSION = 'INVALID_SERVER_VERSION',
+  APP_DEPENDENCY_VERSION_INCOMPATIBLE = 'APP_DEPENDENCY_VERSION_INCOMPATIBLE',
+  APP_DEPENDENCY_CYCLE_DETECTED = 'APP_DEPENDENCY_CYCLE_DETECTED',
 }
 
 const getApplicationExceptionUserFriendlyMessage = (
@@ -71,6 +73,10 @@ const getApplicationExceptionUserFriendlyMessage = (
       return msg`The app manifest declares an invalid server version requirement.`;
     case ApplicationExceptionCode.INVALID_SERVER_VERSION:
       return msg`The server's APP_VERSION is not a valid semver version. Self-hosted instances must configure a valid APP_VERSION.`;
+    case ApplicationExceptionCode.APP_DEPENDENCY_VERSION_INCOMPATIBLE:
+      return msg`A required application dependency is not available at a compatible version.`;
+    case ApplicationExceptionCode.APP_DEPENDENCY_CYCLE_DETECTED:
+      return msg`A circular dependency between applications was detected.`;
     default:
       assertUnreachable(code);
   }


### PR DESCRIPTION
> Draft — Phase 2 of app-to-app dependencies. Opening for design review before hardening. Companion to #22259 (caller-application id), independent of it.

## What

Lets a Twenty app depend on another Twenty app by declaring it as a normal **npm dependency** in `package.json`:

```jsonc
// consumer app package.json
"dependencies": { "kv-value-store": "^0.1.0" }
```

At install time the server reads the dependent's `package.json` dependencies; for each one that resolves to a Twenty app (its manifest has `application.universalIdentifier`), it ensures that app is installed in the workspace at a satisfying version **before** the dependent is synced. Plain code libraries (react, sdk…) don't resolve to an app manifest and are skipped.

## Why package.json (not a new manifest field)

npm dependencies are keyed by **package name**, and the app registry resolves packages **by name** (`resolveFromNpm(name, …)`). So the package name is the resolvable handle — this sidesteps the fact that there is **no `universalIdentifier → package` lookup** anywhere in the platform, which is what blocks resolving an arbitrary declared dependency.

## How

- `ApplicationPackageFetcherService.resolveNpmPackageByName(name)` — resolve a package by name to detect whether it's a Twenty app.
- `ApplicationInstallService.installDeclaredAppDependencies(...)` — detect app deps, dedupe against already-installed apps (`findByUniversalIdentifier`), create an NPM `ApplicationRegistration` on the fly, and install recursively (reusing `installApplication`'s per-app lock + rollback) before `synchronizeFromManifest`. A cycle guard threads in-progress `universalIdentifier`s through the recursion.
- `assertAppDependencyInstallable(...)` — pure guard (semver satisfaction + cycle/self-dependency detection), unit-tested (5 cases).
- Two new `ApplicationExceptionCode`s wired through the exhaustive exception filters.

## Tests

- Unit tests for the dependency guard (`assert-app-dependency-installable.util.spec.ts`) — version-incompatible, cycle, self-dependency, version-checked-before-cycle.
- `twenty-server` typecheck + oxlint + oxfmt clean.

## Known limitations (deliberate follow-ups)

1. **Detection cost** — to decide if a dependency is an app, the server currently downloads its tarball to read the manifest; non-apps are filtered *after* fetch. Should become a metadata/`keywords:twenty-app` check that avoids downloading non-app packages.
2. **Double fetch** — the dependency is resolved once for detection and again by the recursive install.
3. **Install-path only** — no persisted dependency edge yet, so uninstalling/upgrading a depended-on app is not guarded (Layer 2: an `ApplicationDependency` table + uninstall guard + upgrade reverse-check).
4. **Version selection** — installs the registry-resolved version and asserts it satisfies the range (satisfy-or-fail); no historical range resolution.

Looking for a sanity check on the package.json-based approach and the auto-install-before-sync placement before I build out Layer 2 + the detection optimization.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/22269?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

