### PR TITLE
fix: improve native print output for dashboards via CSS @media print

### DIFF
--- a/packages/twenty-front/src/modules/object-record/record-table/components/RecordTableWithWrappers.tsx
+++ b/packages/twenty-front/src/modules/object-record/record-table/components/RecordTableWithWrappers.tsx
@@ -11,6 +11,21 @@ import { RecordTableRecordLimitReloadEffect } from '@/object-record/record-table
 import { PageFocusId } from '@/types/PageFocusId';
 import { useHotkeysOnFocusedElement } from '@/ui/utilities/hotkey/hooks/useHotkeysOnFocusedElement';
 import { ScrollWrapper } from '@/ui/utilities/scroll/components/ScrollWrapper';
+import { styled } from '@linaria/react';
+
+// The record table is virtualized: only the rows in the visible window exist in
+// the DOM, positioned absolutely over a placeholder that fakes the full scroll
+// height. It cannot paginate across a printout, so it is clipped to a single page
+// when printing instead of stretching the placeholder into many blank pages.
+const StyledRecordTablePrintBoundary = styled.div`
+  display: contents;
+
+  @media print {
+    display: block;
+    max-height: 100vh;
+    overflow: hidden;
+  }
+`;
 
 type RecordTableWithWrappersProps = {
   objectNameSingular: string;
@@ -60,12 +75,14 @@ export const RecordTableWithWrappers = ({
         onRecordIdentifierClick={handleRecordIdentifierClick}
       >
         <EntityDeleteContext.Provider value={deleteOneRecord}>
-          <ScrollWrapper
-            componentInstanceId={`record-table-scroll-${recordTableId}`}
-          >
-            <RecordTableRecordLimitReloadEffect />
-            <RecordTable />
-          </ScrollWrapper>
+          <StyledRecordTablePrintBoundary>
+            <ScrollWrapper
+              componentInstanceId={`record-table-scroll-${recordTableId}`}
+            >
+              <RecordTableRecordLimitReloadEffect />
+              <RecordTable />
+            </ScrollWrapper>
+          </StyledRecordTablePrintBoundary>
         </EntityDeleteContext.Provider>
       </RecordTableContextProvider>
     </RecordTableComponentInstance>

--- a/packages/twenty-front/src/modules/page-layout/components/PageLayoutGridLayout.tsx
+++ b/packages/twenty-front/src/modules/page-layout/components/PageLayoutGridLayout.tsx
@@ -86,6 +86,32 @@ const StyledGridContainer = styled.div`
   .react-grid-item:hover .widget-card-resize-handle {
     display: block !important;
   }
+
+  @media print {
+    min-height: auto;
+    padding: 0;
+    user-select: auto;
+
+    .react-grid-layout {
+      height: auto !important;
+    }
+
+    .react-grid-item {
+      break-inside: avoid;
+      height: auto !important;
+      margin-bottom: ${themeCssVariables.spacing[4]};
+      page-break-inside: avoid;
+      position: static !important;
+      transform: none !important;
+      width: auto !important;
+    }
+
+    .react-grid-placeholder,
+    .react-resizable-handle,
+    .widget-card-resize-handle {
+      display: none !important;
+    }
+  }
 `;
 
 type ExtendedResponsiveProps = ResponsiveProps & {

--- a/packages/twenty-front/src/modules/page-layout/components/PageLayoutTabsRenderer.tsx
+++ b/packages/twenty-front/src/modules/page-layout/components/PageLayoutTabsRenderer.tsx
@@ -36,17 +36,41 @@ const StyledContainer = styled.div<{ hasPinnedTab: boolean }>`
   grid-template-rows: minmax(0, 1fr);
   height: 100%;
   width: 100%;
+
+  @media print {
+    display: block;
+    height: auto;
+    width: 100%;
+  }
 `;
 
 const StyledTabsAndDashboardContainer = styled.div`
   display: flex;
   flex-direction: column;
   overflow: hidden;
+
+  @media print {
+    display: block;
+    overflow: visible;
+
+    .page-layout-tab-list-print-hidden {
+      display: none;
+    }
+  }
 `;
 
 const StyledScrollWrapperContainer = styled.div`
   flex: 1;
   min-height: 0;
+
+  @media print {
+    min-height: auto;
+
+    .page-layout-scroll-wrapper {
+      height: auto;
+      overflow: visible;
+    }
+  }
 `;
 
 export const PageLayoutTabsRenderer = () => {
@@ -184,6 +208,7 @@ export const PageLayoutTabsRenderer = () => {
         />
         {(sortedActiveTabs.length > 1 || isPageLayoutInEditMode) && (
           <PageLayoutTabList
+            className="page-layout-tab-list-print-hidden"
             tabs={sortedActiveTabs}
             behaveAsLinks={!isInSidePanel && !isPageLayoutInEditMode}
             isInSidePanel={isInSidePanel}
@@ -206,6 +231,7 @@ export const PageLayoutTabsRenderer = () => {
 
         <StyledScrollWrapperContainer>
           <ScrollWrapper
+            className="page-layout-scroll-wrapper"
             componentInstanceId={getScrollWrapperInstanceIdFromPageLayoutId(
               currentPageLayout.id,
             )}

--- a/packages/twenty-front/src/modules/ui/layout/page/components/DefaultLayout.tsx
+++ b/packages/twenty-front/src/modules/ui/layout/page/components/DefaultLayout.tsx
@@ -38,6 +38,13 @@ const StyledLayout = styled.div`
   *::-webkit-scrollbar-thumb {
     border-radius: ${themeCssVariables.border.radius.sm};
   }
+
+  @media print {
+    background: ${themeCssVariables.background.primary};
+    height: auto;
+    min-height: 100%;
+    overflow: visible;
+  }
 `;
 
 const StyledPageContainer = styled.div`
@@ -46,10 +53,21 @@ const StyledPageContainer = styled.div`
   flex-direction: row;
   min-height: 0;
   min-width: 0;
+
+  @media print {
+    display: block;
+    min-height: auto;
+    min-width: auto;
+    overflow: visible;
+  }
 `;
 
 const StyledNavigationDrawerWrapper = styled.div`
   flex-shrink: 0;
+
+  @media print {
+    display: none;
+  }
 `;
 
 const StyledMainContainer = styled.div`
@@ -57,6 +75,12 @@ const StyledMainContainer = styled.div`
   flex: 0 1 100%;
   min-width: 0;
   overflow: hidden;
+
+  @media print {
+    display: block;
+    min-width: auto;
+    overflow: visible;
+  }
 `;
 
 export const DefaultLayout = () => {

--- a/packages/twenty-front/src/modules/ui/layout/page/components/MainAppLayoutWithSidePanel.tsx
+++ b/packages/twenty-front/src/modules/ui/layout/page/components/MainAppLayoutWithSidePanel.tsx
@@ -23,6 +23,18 @@ const StyledRow = styled.div`
   flex-direction: row;
   min-height: 0;
   min-width: 0;
+
+  @media print {
+    display: block;
+    min-height: auto;
+    min-width: auto;
+
+    // Only the main content (first child) is printed; the side panel and its
+    // resize chrome that follow it are hidden.
+    > *:not(:first-child) {
+      display: none;
+    }
+  }
 `;
 
 const StyledContent = styled.div`
@@ -31,6 +43,13 @@ const StyledContent = styled.div`
   min-height: 0;
   min-width: 0;
   overflow: hidden;
+
+  @media print {
+    display: block;
+    min-height: auto;
+    min-width: auto;
+    overflow: visible;
+  }
 `;
 
 const StyledContentTransitionContainer = styled.div`
@@ -39,6 +58,13 @@ const StyledContentTransitionContainer = styled.div`
   min-height: 0;
   min-width: 0;
   overflow: hidden;
+
+  @media print {
+    display: block;
+    min-height: auto;
+    min-width: auto;
+    overflow: visible;
+  }
 `;
 
 const StyledContentTransitionPage = styled(motion.div)`
@@ -47,6 +73,12 @@ const StyledContentTransitionPage = styled(motion.div)`
   min-height: 0;
   min-width: 0;
   width: 100%;
+
+  @media print {
+    display: block;
+    min-height: auto;
+    min-width: auto;
+  }
 `;
 
 const MainAppLayoutOutlet = () => {

--- a/packages/twenty-front/src/modules/ui/layout/page/components/PageCardLayout.tsx
+++ b/packages/twenty-front/src/modules/ui/layout/page/components/PageCardLayout.tsx
@@ -16,6 +16,12 @@ const StyledRoot = styled.div`
   flex-direction: row;
   min-height: 0;
   min-width: 0;
+
+  @media print {
+    display: block;
+    min-height: auto;
+    min-width: auto;
+  }
 `;
 
 const StyledMainCardWrapper = styled.div`
@@ -26,6 +32,14 @@ const StyledMainCardWrapper = styled.div`
   min-width: 0;
   padding-left: 4px;
   width: 0;
+
+  @media print {
+    display: block;
+    margin-left: 0;
+    min-width: auto;
+    padding-left: 0;
+    width: auto;
+  }
 `;
 
 // oxlint-disable-next-line twenty/no-hardcoded-colors
@@ -48,6 +62,14 @@ const StyledCard = styled.div`
       -4px 0 4px 0 rgba(0, 0, 0, 0.03),
       0 0 0 1px ${themeCssVariables.border.color.medium};
   }
+
+  @media print {
+    border-radius: 0;
+    box-shadow: none;
+    display: block;
+    min-height: auto;
+    overflow: visible;
+  }
 `;
 
 const StyledBodyContent = styled.div`
@@ -56,6 +78,17 @@ const StyledBodyContent = styled.div`
   flex-direction: column;
   min-height: 0;
   width: 100%;
+
+  @media print {
+    display: block;
+    min-height: auto;
+  }
+`;
+
+const StyledPrintHidden = styled.div`
+  @media print {
+    display: none;
+  }
 `;
 
 export const PageCardLayout = ({
@@ -68,10 +101,14 @@ export const PageCardLayout = ({
     <StyledRoot>
       <StyledMainCardWrapper>
         <StyledCard>
-          {header}
-          {secondaryBar}
+          <StyledPrintHidden>{header}</StyledPrintHidden>
+          <StyledPrintHidden>{secondaryBar}</StyledPrintHidden>
           <StyledBodyContent>
-            {showInformationBanner && <InformationBannerWrapper />}
+            {showInformationBanner && (
+              <StyledPrintHidden>
+                <InformationBannerWrapper />
+              </StyledPrintHidden>
+            )}
             {children}
           </StyledBodyContent>
         </StyledCard>

--- a/packages/twenty-front/src/pages/page-layout/StandalonePageLayoutPage.tsx
+++ b/packages/twenty-front/src/pages/page-layout/StandalonePageLayoutPage.tsx
@@ -17,6 +17,12 @@ const StyledPageLayoutContainer = styled.div`
   flex-direction: column;
   min-height: 0;
   overflow-y: auto;
+
+  @media print {
+    display: block;
+    min-height: auto;
+    overflow: visible;
+  }
 `;
 
 export const StandalonePageLayoutPage = () => {


### PR DESCRIPTION
## Summary

Improves native browser print (Cmd+P / "Save as PDF") for dashboards using a CSS-only `@media print` approach, with no JavaScript. Supersedes the JS-snapshot approach explored in #22272 — per review the goal is to rely exclusively on `@media print`.

### What prints cleanly now
- The navigation drawer, side panel, page header, secondary bar and resize chrome are hidden in print.
- The dashboard grid is un-positioned (`react-grid-layout` uses absolute transforms on screen) so widgets flow vertically and their charts (canvas/SVG) paginate natively instead of being clipped to the screen viewport.

### Record tables
The record table is virtualized — only the visible window of rows exists in the DOM, positioned absolutely over a placeholder that fakes the full scroll height. It cannot paginate across a printout with CSS alone, so it is clipped to a single page when printing rather than expanding the placeholder into blank pages. Printing the full table would require JavaScript, which is intentionally out of scope.

## Changes
- `@media print` rules in the layout components: `DefaultLayout`, `MainAppLayoutWithSidePanel`, `PageCardLayout`, `PageLayoutGridLayout`, `PageLayoutTabsRenderer`, `StandalonePageLayoutPage`.
- A transparent `display: contents` print boundary around the virtualized record table (only engages in print).

## Notes
- The side panel is hidden via `> *:not(:first-child)` (the main content is always the first child) rather than `:last-child`, which broke on mobile where the command menu portals out and the main content becomes the last child.

Credit to @vittolago for the original investigation and the layout `@media print` rules in #22272.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/22283?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

