### PR TITLE
fix(ui): prevent dragging files empty-state placeholder image

### DIFF
--- a/packages/twenty-ui/src/feedback/AnimatedPlaceholder/AnimatedPlaceholder.module.scss
+++ b/packages/twenty-ui/src/feedback/AnimatedPlaceholder/AnimatedPlaceholder.module.scss
@@ -9,6 +9,8 @@
 .backgroundImage {
   max-height: 160px;
   max-width: 160px;
+  user-select: none;
+  -webkit-user-drag: none;
 }
 
 // error404 and error500 placeholders use a larger background illustration
@@ -22,6 +24,9 @@
   z-index: 2;
   max-width: 130px;
   max-height: 130px;
+  pointer-events: none;
+  user-select: none;
+  -webkit-user-drag: none;
   transform: translate(var(--parallax-x, 0), var(--parallax-y, 0));
   transition: transform duration(normal) ease-out;
 }

--- a/packages/twenty-ui/src/feedback/AnimatedPlaceholder/AnimatedPlaceholder.tsx
+++ b/packages/twenty-ui/src/feedback/AnimatedPlaceholder/AnimatedPlaceholder.tsx
@@ -70,6 +70,7 @@ export const AnimatedPlaceholder = ({ type }: AnimatedPlaceholderProps) => {
       <img
         src={colorScheme === 'dark' ? DARK_BACKGROUND[type] : BACKGROUND[type]}
         alt=""
+        draggable={false}
         className={clsx(
           styles.backgroundImage,
           isLarge && styles.backgroundImageLarge,
@@ -81,6 +82,7 @@ export const AnimatedPlaceholder = ({ type }: AnimatedPlaceholderProps) => {
           colorScheme === 'dark' ? DARK_MOVING_IMAGE[type] : MOVING_IMAGE[type]
         }
         alt=""
+        draggable={false}
         className={clsx(styles.movingImage, isLarge && styles.movingImageLarge)}
       />
     </div>


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/22288?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

