### PR TITLE
fix(server): load cross-application view children when building workspace migrations

### DIFF
--- a/packages/twenty-server/src/engine/workspace-manager/workspace-migration/services/utils/__tests__/get-one-to-many-children-application-ids.util.spec.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/workspace-migration/services/utils/__tests__/get-one-to-many-children-application-ids.util.spec.ts
@@ -1,0 +1,120 @@
+import { type AllFlatEntityMaps } from 'src/engine/metadata-modules/flat-entity/types/all-flat-entity-maps.type';
+import { getOneToManyChildrenApplicationIds } from 'src/engine/workspace-manager/workspace-migration/services/utils/get-one-to-many-children-application-ids.util';
+
+const TWENTY_STANDARD_APPLICATION_ID = '20202020-0000-0000-0000-000000000001';
+const WORKSPACE_CUSTOM_APPLICATION_ID = '20202020-0000-0000-0000-000000000002';
+
+const STANDARD_VIEW_FIELD_UNIVERSAL_IDENTIFIER = 'view-field-standard';
+const CUSTOM_VIEW_FIELD_UNIVERSAL_IDENTIFIER = 'view-field-custom-country';
+const CUSTOM_VIEW_SORT_UNIVERSAL_IDENTIFIER = 'view-sort-custom-country';
+
+// A standard view that also holds a custom-application view field and view sort
+// (the canonical "custom field added to a standard object" case).
+const buildStandardViewFlatEntity = () => ({
+  universalIdentifier: 'view-all-workspace-members',
+  applicationId: TWENTY_STANDARD_APPLICATION_ID,
+  viewFieldUniversalIdentifiers: [
+    STANDARD_VIEW_FIELD_UNIVERSAL_IDENTIFIER,
+    CUSTOM_VIEW_FIELD_UNIVERSAL_IDENTIFIER,
+  ],
+  viewFilterUniversalIdentifiers: [],
+  viewFilterGroupUniversalIdentifiers: [],
+  viewGroupUniversalIdentifiers: [],
+  viewFieldGroupUniversalIdentifiers: [],
+  viewSortUniversalIdentifiers: [CUSTOM_VIEW_SORT_UNIVERSAL_IDENTIFIER],
+});
+
+const buildAllRelatedFlatEntityMaps = (): Partial<AllFlatEntityMaps> =>
+  ({
+    flatViewFieldMaps: {
+      byUniversalIdentifier: {
+        [STANDARD_VIEW_FIELD_UNIVERSAL_IDENTIFIER]: {
+          universalIdentifier: STANDARD_VIEW_FIELD_UNIVERSAL_IDENTIFIER,
+          applicationId: TWENTY_STANDARD_APPLICATION_ID,
+        },
+        [CUSTOM_VIEW_FIELD_UNIVERSAL_IDENTIFIER]: {
+          universalIdentifier: CUSTOM_VIEW_FIELD_UNIVERSAL_IDENTIFIER,
+          applicationId: WORKSPACE_CUSTOM_APPLICATION_ID,
+        },
+      },
+    },
+    flatViewSortMaps: {
+      byUniversalIdentifier: {
+        [CUSTOM_VIEW_SORT_UNIVERSAL_IDENTIFIER]: {
+          universalIdentifier: CUSTOM_VIEW_SORT_UNIVERSAL_IDENTIFIER,
+          applicationId: WORKSPACE_CUSTOM_APPLICATION_ID,
+        },
+      },
+    },
+  }) as unknown as Partial<AllFlatEntityMaps>;
+
+describe('getOneToManyChildrenApplicationIds', () => {
+  it('returns the applications owning a parent’s children across applications', () => {
+    const result = getOneToManyChildrenApplicationIds({
+      metadataName: 'view',
+      flatEntity: buildStandardViewFlatEntity(),
+      allRelatedFlatEntityMaps: buildAllRelatedFlatEntityMaps(),
+    });
+
+    // Regression: the custom-application view field and view sort that live
+    // inside the standard view must surface their owning application.
+    expect(result).toEqual(
+      expect.arrayContaining([
+        TWENTY_STANDARD_APPLICATION_ID,
+        WORKSPACE_CUSTOM_APPLICATION_ID,
+      ]),
+    );
+    expect(result).toHaveLength(2);
+  });
+
+  it('returns an empty array for a metadata type without one-to-many relations', () => {
+    const result = getOneToManyChildrenApplicationIds({
+      metadataName: 'agent',
+      flatEntity: { universalIdentifier: 'agent-1' },
+      allRelatedFlatEntityMaps: buildAllRelatedFlatEntityMaps(),
+    });
+
+    expect(result).toEqual([]);
+  });
+
+  it('returns an empty array when the parent has no children', () => {
+    const result = getOneToManyChildrenApplicationIds({
+      metadataName: 'view',
+      flatEntity: {
+        universalIdentifier: 'empty-view',
+        applicationId: TWENTY_STANDARD_APPLICATION_ID,
+        viewFieldUniversalIdentifiers: [],
+        viewFilterUniversalIdentifiers: [],
+        viewFilterGroupUniversalIdentifiers: [],
+        viewGroupUniversalIdentifiers: [],
+        viewFieldGroupUniversalIdentifiers: [],
+        viewSortUniversalIdentifiers: [],
+      },
+      allRelatedFlatEntityMaps: buildAllRelatedFlatEntityMaps(),
+    });
+
+    expect(result).toEqual([]);
+  });
+
+  it('skips child maps that are not loaded without throwing', () => {
+    const allRelatedFlatEntityMaps = buildAllRelatedFlatEntityMaps();
+
+    delete (allRelatedFlatEntityMaps as Record<string, unknown>)
+      .flatViewSortMaps;
+
+    const result = getOneToManyChildrenApplicationIds({
+      metadataName: 'view',
+      flatEntity: buildStandardViewFlatEntity(),
+      allRelatedFlatEntityMaps,
+    });
+
+    // The view-field maps are still present, so both apps owning view fields are
+    // returned; the missing view-sort map is simply skipped.
+    expect(result).toEqual(
+      expect.arrayContaining([
+        TWENTY_STANDARD_APPLICATION_ID,
+        WORKSPACE_CUSTOM_APPLICATION_ID,
+      ]),
+    );
+  });
+});

--- a/packages/twenty-server/src/engine/workspace-manager/workspace-migration/services/utils/get-one-to-many-children-application-ids.util.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/workspace-migration/services/utils/get-one-to-many-children-application-ids.util.ts
@@ -1,0 +1,67 @@
+import { type AllMetadataName } from 'twenty-shared/metadata';
+import { isDefined } from 'twenty-shared/utils';
+
+import { ALL_ONE_TO_MANY_METADATA_RELATIONS } from 'src/engine/metadata-modules/flat-entity/constant/all-one-to-many-metadata-relations.constant';
+import { type AllFlatEntityMaps } from 'src/engine/metadata-modules/flat-entity/types/all-flat-entity-maps.type';
+import { getMetadataFlatEntityMapsKey } from 'src/engine/metadata-modules/flat-entity/utils/get-metadata-flat-entity-maps-key.util';
+
+/**
+ * Application ids owning the one-to-many children of `flatEntity`.
+ *
+ * A parent can own children in another application (e.g. a custom field's view
+ * field inside a standard view). Validators enumerate a parent's full children
+ * set across applications, so those apps must be part of the build scope too.
+ */
+export const getOneToManyChildrenApplicationIds = ({
+  metadataName,
+  flatEntity,
+  allRelatedFlatEntityMaps,
+}: {
+  metadataName: AllMetadataName;
+  flatEntity: Record<string, unknown>;
+  allRelatedFlatEntityMaps: Partial<AllFlatEntityMaps>;
+}): string[] => {
+  const applicationIds = new Set<string>();
+
+  for (const oneToManyRelation of Object.values(
+    ALL_ONE_TO_MANY_METADATA_RELATIONS[metadataName],
+  ) as ({
+    metadataName: AllMetadataName;
+    universalFlatEntityForeignKeyAggregator: string;
+  } | null)[]) {
+    if (!isDefined(oneToManyRelation)) {
+      continue;
+    }
+
+    const childFlatEntityMaps =
+      allRelatedFlatEntityMaps[
+        getMetadataFlatEntityMapsKey(oneToManyRelation.metadataName)
+      ];
+
+    if (!isDefined(childFlatEntityMaps)) {
+      continue;
+    }
+
+    const childUniversalIdentifiers =
+      flatEntity[oneToManyRelation.universalFlatEntityForeignKeyAggregator];
+
+    if (!Array.isArray(childUniversalIdentifiers)) {
+      continue;
+    }
+
+    for (const childUniversalIdentifier of childUniversalIdentifiers) {
+      if (typeof childUniversalIdentifier !== 'string') {
+        continue;
+      }
+
+      const childFlatEntity =
+        childFlatEntityMaps.byUniversalIdentifier[childUniversalIdentifier];
+
+      if (isDefined(childFlatEntity)) {
+        applicationIds.add(childFlatEntity.applicationId);
+      }
+    }
+  }
+
+  return [...applicationIds];
+};

--- a/packages/twenty-server/src/engine/workspace-manager/workspace-migration/services/workspace-migration-validate-build-and-run-service.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/workspace-migration/services/workspace-migration-validate-build-and-run-service.ts
@@ -31,6 +31,7 @@ import {
   enrichCreateWorkspaceMigrationActionsWithIds,
   IdByUniversalIdentifierByMetadataName,
 } from 'src/engine/workspace-manager/workspace-migration/services/utils/enrich-create-workspace-migration-action-with-ids.util';
+import { getOneToManyChildrenApplicationIds } from 'src/engine/workspace-manager/workspace-migration/services/utils/get-one-to-many-children-application-ids.util';
 import { WorkspaceMigrationBuildOrchestratorService } from 'src/engine/workspace-manager/workspace-migration/services/workspace-migration-build-orchestrator.service';
 import { WorkspaceMigrationBuilderAdditionalCacheDataMaps } from 'src/engine/workspace-manager/workspace-migration/types/workspace-migration-builder-additional-cache-data-maps.type';
 import {
@@ -139,6 +140,24 @@ export class WorkspaceMigrationValidateBuildAndRunService {
           applicationIds.add(entityApplicationId);
         }
 
+        // An operated parent's children may live in other applications.
+        const operatedFlatEntity =
+          allRelatedFlatEntityMaps[getMetadataFlatEntityMapsKey(metadataName)]
+            ?.byUniversalIdentifier[flatEntity.universalIdentifier];
+
+        if (isDefined(operatedFlatEntity)) {
+          for (const childApplicationId of getOneToManyChildrenApplicationIds({
+            metadataName,
+            flatEntity: operatedFlatEntity as unknown as Record<
+              string,
+              unknown
+            >,
+            allRelatedFlatEntityMaps,
+          })) {
+            applicationIds.add(childApplicationId);
+          }
+        }
+
         for (const relation of Object.values(relations) as ({
           foreignKey: string;
           metadataName: AllMetadataName;
@@ -177,6 +196,21 @@ export class WorkspaceMigrationValidateBuildAndRunService {
 
           if (isDefined(referencedEntity)) {
             applicationIds.add(referencedEntity.applicationId);
+
+            // A referenced parent's children may live in other applications
+            // (e.g. a standard view holding a custom field's view field).
+            for (const childApplicationId of getOneToManyChildrenApplicationIds(
+              {
+                metadataName: targetMetadataName,
+                flatEntity: referencedEntity as unknown as Record<
+                  string,
+                  unknown
+                >,
+                allRelatedFlatEntityMaps,
+              },
+            )) {
+              applicationIds.add(childApplicationId);
+            }
           }
         }
       }


### PR DESCRIPTION
## Problem

Adding a **standard** field to an object whose standard view also contains a **view field owned by another application** crashes the workspace-migration build:

```
FlatEntityMapsException: Could not find flat entity with universal identifier <id>
  at FlatViewFieldValidatorService.validateFlatViewFieldCreation
```

The canonical trigger: a user adds a **custom field to a standard object** (e.g. `workspaceMember`) and it shows up in that object's standard "All …" view. The custom field's view field lives inside the standard view but is owned by the workspace custom application.

This was hit in production by the `2.17` `AddWorkspaceMemberJobTitleField` upgrade command — every workspace that had a custom field on `workspaceMember` failed at that step (the rest upgraded fine), aborting the per-workspace upgrade sequence.

## Root cause

When `FieldMetadataService.createManyFields` adds the standard `jobTitle` field, it also creates the field's view fields and runs `WorkspaceMigrationValidateBuildAndRunService`.

`computeAllInvolvedApplicationIds` collects the applications "involved" in the build (the owner application, Twenty Standard, and applications referenced via the many-to-one relations of the operated entities). `computeAllRelatedFlatEntityMaps` then filters the universal flat maps down to those applications via `getSubFlatEntityMapsByApplicationIdsOrThrow` to form the **dependency/validation context**.

However a view lists **all** of its children in `viewFieldUniversalIdentifiers` regardless of application (`from-view-entity-to-flat-view.util.ts`), and `FlatViewFieldValidatorService.validateFlatViewFieldCreation` resolves that full list against the (application-filtered) dependency view-field maps. When building a standard field, only Twenty Standard view fields are in scope, so the custom-application view field the standard view legitimately references cannot be resolved → it throws.

## Fix

`computeAllInvolvedApplicationIds` now also includes the applications that own the **children** (view fields / filters / sorts / groups) of any view the migration touches — a view being mutated, or a view referenced by one of its children (e.g. a view field). Those children are then loaded into the dependency maps and resolvable by the view validators.

The lookup is extracted into a small pure util, `getInvolvedViewChildrenApplicationIds`, with unit tests.

## Why this is safe

The change only enlarges the **validation/dependency context** (`dependencyAllFlatEntityMaps` → `optimisticAllFlatEntityMaps`, consumed as `dependencyOptimisticFlatEntityMaps` and for cross-entity validation). The actual create / delete / update **actions** are computed from the per-entity `from`/`to` maps (`fromToAllFlatEntityMaps`), which are built from the unfiltered universal maps and are **not** modified here — so deletion inference and the produced migration are unaffected. The change strictly makes more of the genuinely-related context available to the validators.

Trade-off: for view-touching migrations the dependency maps grow to include the cross-application children's applications (typically the workspace custom application) — bounded, and consistent with how Twenty Standard is already always included.

## Test

`get-involved-view-children-application-ids.util.spec.ts` covers the cross-application case (a custom view field/sort inside a standard view surfaces its owning application) plus the empty / view-not-found / missing-map guards.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/22294?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

