### PR TITLE
chore(docs): exclude code blocks and icon frontmatter from Crowdin translation

### DIFF
--- a/.github/crowdin-docs.yml
+++ b/.github/crowdin-docs.yml
@@ -8,31 +8,34 @@
 "base_url": "https://twenty.api.crowdin.com"
 "base_path": ".."
 
-
 files: [
   {
     "source": "packages/twenty-docs/getting-started/**/*.mdx",
     "translation": "packages/twenty-docs/l/%two_letters_code%/getting-started/**/%original_file_name%",
     "type": "mdx_v2",
-    "import_options": { "excludeCodeBlocks": true, "excludedFrontMatterElements": ["icon"] },
+    "exclude_code_blocks": true,
+    "excluded_front_matter_elements": ["icon"],
   },
   {
     "source": "packages/twenty-docs/user-guide/**/*.mdx",
     "translation": "packages/twenty-docs/l/%two_letters_code%/user-guide/**/%original_file_name%",
     "type": "mdx_v2",
-    "import_options": { "excludeCodeBlocks": true, "excludedFrontMatterElements": ["icon"] },
+    "exclude_code_blocks": true,
+    "excluded_front_matter_elements": ["icon"],
   },
   {
     "source": "packages/twenty-docs/developers/**/*.mdx",
     "translation": "packages/twenty-docs/l/%two_letters_code%/developers/**/%original_file_name%",
     "type": "mdx_v2",
-    "import_options": { "excludeCodeBlocks": true, "excludedFrontMatterElements": ["icon"] },
+    "exclude_code_blocks": true,
+    "excluded_front_matter_elements": ["icon"],
   },
   {
     "source": "packages/twenty-docs/twenty-ui/**/*.mdx",
     "translation": "packages/twenty-docs/l/%two_letters_code%/twenty-ui/**/%original_file_name%",
     "type": "mdx_v2",
-    "import_options": { "excludeCodeBlocks": true, "excludedFrontMatterElements": ["icon"] },
+    "exclude_code_blocks": true,
+    "excluded_front_matter_elements": ["icon"],
   },
   {
     #

--- a/.github/crowdin-docs.yml
+++ b/.github/crowdin-docs.yml
@@ -8,35 +8,31 @@
 "base_url": "https://twenty.api.crowdin.com"
 "base_path": ".."
 
+
 files: [
   {
     "source": "packages/twenty-docs/getting-started/**/*.mdx",
     "translation": "packages/twenty-docs/l/%two_letters_code%/getting-started/**/%original_file_name%",
+    "type": "mdx_v2",
+    "import_options": { "excludeCodeBlocks": true, "excludedFrontMatterElements": ["icon"] },
   },
   {
-    #
-    # MDX documentation files - user-guide
-    # Using md type to preserve JSX component structure
-    # This prevents Crowdin from reformatting <Warning>, <Accordion>, etc.
-    #
     "source": "packages/twenty-docs/user-guide/**/*.mdx",
     "translation": "packages/twenty-docs/l/%two_letters_code%/user-guide/**/%original_file_name%",
+    "type": "mdx_v2",
+    "import_options": { "excludeCodeBlocks": true, "excludedFrontMatterElements": ["icon"] },
   },
   {
-    #
-    # MDX documentation files - developers
-    # Using md type to preserve JSX component structure
-    #
     "source": "packages/twenty-docs/developers/**/*.mdx",
     "translation": "packages/twenty-docs/l/%two_letters_code%/developers/**/%original_file_name%",
+    "type": "mdx_v2",
+    "import_options": { "excludeCodeBlocks": true, "excludedFrontMatterElements": ["icon"] },
   },
   {
-    #
-    # MDX documentation files - twenty-ui
-    # Using md type to preserve JSX component structure
-    #
     "source": "packages/twenty-docs/twenty-ui/**/*.mdx",
     "translation": "packages/twenty-docs/l/%two_letters_code%/twenty-ui/**/%original_file_name%",
+    "type": "mdx_v2",
+    "import_options": { "excludeCodeBlocks": true, "excludedFrontMatterElements": ["icon"] },
   },
   {
     #
@@ -46,4 +42,3 @@ files: [
     "translation": "packages/twenty-docs/l/%two_letters_code%/navigation.json",
   }
 ]
-


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/22304?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

