### PR TITLE
Onboarding v2: dedicated verify step instead of the v1 modal flash

### DIFF
--- a/packages/twenty-front/src/modules/apollo/hooks/useApolloFactory.ts
+++ b/packages/twenty-front/src/modules/apollo/hooks/useApolloFactory.ts
@@ -39,6 +39,9 @@ export const useApolloFactory = (options: Partial<Options> = {}) => {
 
   const setReturnToPath = useSetAtomState(returnToPathState);
   const location = useLocation();
+  // oxlint-disable-next-line twenty/no-state-useref
+  const locationRef = useRef(location);
+  locationRef.current = location;
 
   const { enqueueErrorSnackBar } = useSnackBar();
 
@@ -72,12 +75,13 @@ export const useApolloFactory = (options: Partial<Options> = {}) => {
         setCurrentWorkspace(null);
         setCurrentUserWorkspace(null);
         if (
-          !isMatchingLocation(location, AppPath.Verify) &&
-          !isMatchingLocation(location, AppPath.SignInUp) &&
-          !isMatchingLocation(location, AppPath.Invite) &&
-          !isMatchingLocation(location, AppPath.ResetPassword)
+          !isMatchingLocation(locationRef.current, AppPath.Verify) &&
+          !isMatchingLocation(locationRef.current, AppPath.VerifyV2) &&
+          !isMatchingLocation(locationRef.current, AppPath.SignInUp) &&
+          !isMatchingLocation(locationRef.current, AppPath.Invite) &&
+          !isMatchingLocation(locationRef.current, AppPath.ResetPassword)
         ) {
-          const path = `${location.pathname}${location.search}${location.hash}`;
+          const path = `${locationRef.current.pathname}${locationRef.current.search}${locationRef.current.hash}`;
 
           if (isValidReturnToPath(path)) {
             setReturnToPath(path);

--- a/packages/twenty-front/src/modules/app/hooks/useCreateAppRouter.tsx
+++ b/packages/twenty-front/src/modules/app/hooks/useCreateAppRouter.tsx
@@ -5,6 +5,7 @@ import { VerifyLoginTokenEffect } from '@/auth/components/VerifyLoginTokenEffect
 
 import { VerifyEmailEffect } from '@/auth/components/VerifyEmailEffect';
 import indexAppPath from '@/navigation/utils/indexAppPath';
+import { VerifyV2 } from '~/pages/onboarding/VerifyV2';
 import { RecordIndexSkeletonLoader } from '@/object-record/record-index/components/RecordIndexSkeletonLoader';
 import { BlankLayout } from '@/ui/layout/page/components/BlankLayout';
 import { DefaultLayout } from '@/ui/layout/page/components/DefaultLayout';
@@ -312,6 +313,7 @@ export const useCreateAppRouter = (
               </LazyRoute>
             }
           />
+          <Route path={AppPath.VerifyV2} element={<VerifyV2 />} />
           <Route
             path={AppPath.WorkspaceActivationV2}
             element={

--- a/packages/twenty-front/src/modules/auth/constants/OngoingUserCreationPaths.ts
+++ b/packages/twenty-front/src/modules/auth/constants/OngoingUserCreationPaths.ts
@@ -6,4 +6,5 @@ export const ONGOING_USER_CREATION_PATHS = [
   AppPath.SignInUpV2,
   AppPath.VerifyEmail,
   AppPath.Verify,
+  AppPath.VerifyV2,
 ];

--- a/packages/twenty-front/src/modules/auth/sign-in-up/components/SignInUpWorkspaceActivationV2.tsx
+++ b/packages/twenty-front/src/modules/auth/sign-in-up/components/SignInUpWorkspaceActivationV2.tsx
@@ -1,37 +1,16 @@
 import { SubTitle } from '@/auth/components/SubTitle';
 import { WORKSPACE_ACTIVATION_MESSAGES } from '@/auth/sign-in-up/constants/WorkspaceActivationMessages';
+import { OnboardingPulsingLogo } from '@/onboarding/components/OnboardingPulsingLogo';
 import { styled } from '@linaria/react';
 import { useLingui } from '@lingui/react/macro';
 import { motion, useReducedMotion } from 'framer-motion';
 import { useContext } from 'react';
-import { ThemeContext, themeCssVariables } from 'twenty-ui/theme-constants';
+import { ThemeContext } from 'twenty-ui/theme-constants';
 
 const STEP_OPACITIES = [1, 0.4, 0.12];
 const VISIBLE_STEP_COUNT = STEP_OPACITIES.length;
 const STEP_HEIGHT_IN_PX = 28;
 const STEPS_CONTAINER_HEIGHT_IN_PX = STEP_HEIGHT_IN_PX * VISIBLE_STEP_COUNT;
-
-const StyledLogo = styled.img`
-  animation: signInUpWorkspaceActivationLogoPulse 0.8s ease-in-out infinite
-    alternate;
-  height: ${themeCssVariables.spacing[12]};
-  margin-bottom: ${themeCssVariables.spacing[8]};
-  width: ${themeCssVariables.spacing[12]};
-
-  @keyframes signInUpWorkspaceActivationLogoPulse {
-    from {
-      opacity: 1;
-    }
-    to {
-      opacity: 0.4;
-    }
-  }
-
-  @media (prefers-reduced-motion: reduce) {
-    animation: none;
-    opacity: 1;
-  }
-`;
 
 const StyledStepsContainer = styled.div`
   height: ${STEPS_CONTAINER_HEIGHT_IN_PX}px;
@@ -65,7 +44,7 @@ export const SignInUpWorkspaceActivationV2 = ({
 
   return (
     <>
-      <StyledLogo src="/images/integrations/twenty-logo.svg" alt="" />
+      <OnboardingPulsingLogo />
       <StyledStepsContainer>
         {messages.map((message, index) => {
           const stepOffset = index - messageIndex;

--- a/packages/twenty-front/src/modules/auth/sign-in-up/hooks/useSignUpInNewWorkspace.ts
+++ b/packages/twenty-front/src/modules/auth/sign-in-up/hooks/useSignUpInNewWorkspace.ts
@@ -1,4 +1,5 @@
 import { useAuth } from '@/auth/hooks/useAuth';
+import { isOnboardingV2State } from '@/auth/states/isOnboardingV2State';
 import { isMultiWorkspaceEnabledState } from '@/client-config/states/isMultiWorkspaceEnabledState';
 import { useRedirectToWorkspaceDomain } from '@/domain-manager/hooks/useRedirectToWorkspaceDomain';
 import { useSnackBar } from '@/ui/feedback/snack-bar-manager/hooks/useSnackBar';
@@ -13,6 +14,7 @@ import {
 import { getWorkspaceUrl } from '~/utils/getWorkspaceUrl';
 import { assertIsDefinedOrThrow, isDefined } from 'twenty-shared/utils';
 import { useLingui } from '@lingui/react/macro';
+import { useStore } from 'jotai';
 
 export const useSignUpInNewWorkspace = () => {
   const { redirectToWorkspaceDomain } = useRedirectToWorkspaceDomain();
@@ -20,6 +22,7 @@ export const useSignUpInNewWorkspace = () => {
   const isMultiWorkspaceEnabled = useAtomStateValue(
     isMultiWorkspaceEnabledState,
   );
+  const store = useStore();
   const { enqueueErrorSnackBar } = useSnackBar();
   const { t } = useLingui();
 
@@ -73,9 +76,11 @@ export const useSignUpInNewWorkspace = () => {
         return true;
       }
 
+      const isOnboardingV2 = store.get(isOnboardingV2State.atom);
+
       await redirectToWorkspaceDomain(
         getWorkspaceUrl(data.signUpInNewWorkspace.workspace.workspaceUrls),
-        AppPath.Verify,
+        isOnboardingV2 ? AppPath.VerifyV2 : AppPath.Verify,
         { loginToken },
         '_self',
       );

--- a/packages/twenty-front/src/modules/captcha/constants/CaptchaProtectedPaths.ts
+++ b/packages/twenty-front/src/modules/captcha/constants/CaptchaProtectedPaths.ts
@@ -4,6 +4,7 @@ export const CAPTCHA_PROTECTED_PATHS: string[] = [
   AppPath.SignInUp,
   AppPath.SignInUpV2,
   AppPath.Verify,
+  AppPath.VerifyV2,
   AppPath.VerifyEmail,
   AppPath.ResetPassword,
   AppPath.Invite,

--- a/packages/twenty-front/src/modules/metadata-store/components/MinimalMetadataGater.tsx
+++ b/packages/twenty-front/src/modules/metadata-store/components/MinimalMetadataGater.tsx
@@ -17,6 +17,7 @@ export const MinimalMetadataGater = ({ children }: React.PropsWithChildren) => {
 
   const isOnExcludedPath =
     isMatchingLocation(location, AppPath.Verify) ||
+    isMatchingLocation(location, AppPath.VerifyV2) ||
     isMatchingLocation(location, AppPath.VerifyEmail) ||
     isMatchingLocation(location, AppPath.SignInUp) ||
     isMatchingLocation(location, AppPath.SignInUpV2) ||

--- a/packages/twenty-front/src/modules/onboarding/components/OnboardingPulsingLogo.tsx
+++ b/packages/twenty-front/src/modules/onboarding/components/OnboardingPulsingLogo.tsx
@@ -1,0 +1,27 @@
+import { styled } from '@linaria/react';
+import { themeCssVariables } from 'twenty-ui/theme-constants';
+
+const StyledLogo = styled.img`
+  animation: onboardingPulsingLogo 0.8s ease-in-out infinite alternate;
+  height: ${themeCssVariables.spacing[12]};
+  margin-bottom: ${themeCssVariables.spacing[8]};
+  width: ${themeCssVariables.spacing[12]};
+
+  @keyframes onboardingPulsingLogo {
+    from {
+      opacity: 1;
+    }
+    to {
+      opacity: 0.4;
+    }
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    animation: none;
+    opacity: 1;
+  }
+`;
+
+export const OnboardingPulsingLogo = () => (
+  <StyledLogo src="/images/integrations/twenty-logo.svg" alt="" />
+);

--- a/packages/twenty-front/src/pages/onboarding/VerifyV2.tsx
+++ b/packages/twenty-front/src/pages/onboarding/VerifyV2.tsx
@@ -1,0 +1,28 @@
+import { SubTitle } from '@/auth/components/SubTitle';
+import { VerifyLoginTokenEffect } from '@/auth/components/VerifyLoginTokenEffect';
+import { OnboardingPulsingLogo } from '@/onboarding/components/OnboardingPulsingLogo';
+import { styled } from '@linaria/react';
+import { useLingui } from '@lingui/react/macro';
+import { themeCssVariables } from 'twenty-ui/theme-constants';
+
+const StyledContainer = styled.div`
+  align-items: center;
+  background: ${themeCssVariables.background.primary};
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  justify-content: center;
+  width: 100%;
+`;
+
+export const VerifyV2 = () => {
+  const { t } = useLingui();
+
+  return (
+    <StyledContainer>
+      <VerifyLoginTokenEffect />
+      <OnboardingPulsingLogo />
+      <SubTitle>{t`Verifying your email`}</SubTitle>
+    </StyledContainer>
+  );
+};

--- a/packages/twenty-front/src/testing/constants/UntestedAppPaths.ts
+++ b/packages/twenty-front/src/testing/constants/UntestedAppPaths.ts
@@ -3,6 +3,7 @@ import { AppPath } from 'twenty-shared/types';
 export const UNTESTED_APP_PATHS = [
   AppPath.Settings,
   AppPath.Developers,
+  AppPath.VerifyV2,
   AppPath.WorkspaceActivationV2,
   AppPath.CreateProfileV2,
   AppPath.SyncEmailsV2,

--- a/packages/twenty-front/src/utils/title-utils.ts
+++ b/packages/twenty-front/src/utils/title-utils.ts
@@ -27,6 +27,7 @@ export const getPageTitleFromPath = (pathname: string): string => {
   const pathnameOrPrefix = getPathnameOrPrefix(pathname);
   switch (pathnameOrPrefix) {
     case AppPath.Verify:
+    case AppPath.VerifyV2:
       return t`Verify`;
     case AppPath.SignInUp:
     case AppPath.SignInUpV2:

--- a/packages/twenty-server/src/engine/core-modules/onboarding/onboarding.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/onboarding/onboarding.service.ts
@@ -64,14 +64,6 @@ export class OnboardingService {
       return null;
     }
 
-    if (
-      await this.billingService.isSubscriptionIncompleteOnboardingStatus(
-        workspace.id,
-      )
-    ) {
-      return OnboardingStatus.PLAN_REQUIRED;
-    }
-
     if (this.isWorkspaceActivationPending(workspace)) {
       return OnboardingStatus.WORKSPACE_ACTIVATION;
     }
@@ -106,6 +98,14 @@ export class OnboardingService {
 
     if (isInviteTeamPending) {
       return OnboardingStatus.INVITE_TEAM;
+    }
+
+    if (
+      await this.billingService.isSubscriptionIncompleteOnboardingStatus(
+        workspace.id,
+      )
+    ) {
+      return OnboardingStatus.PLAN_REQUIRED;
     }
 
     if (isBookOnboardingPending) {

--- a/packages/twenty-shared/src/types/AppPath.ts
+++ b/packages/twenty-shared/src/types/AppPath.ts
@@ -1,6 +1,7 @@
 export enum AppPath {
   // Not logged-in
   Verify = '/verify',
+  VerifyV2 = '/verify-v2',
   VerifyEmail = '/verify-email',
   SignInUp = '/welcome',
   SignInUpV2 = '/welcome-v2',


### PR DESCRIPTION
Stacked on `r--onboarding-v2-upgrade-free-trial` (which has the v2 plan/free-trial flow).

## What

In onboarding v2 the verify step rendered under the v1 `DefaultLayout`, flashing the `AuthModal` over the fake-app background before redirecting.

This adds a dedicated `/verify-v2` route under `BlankLayout` showing a clean "Verifying your email" screen (fading Twenty logo + text, matching `WorkspaceActivationV2`), so the transition into the rest of the v2 flow is seamless. The v2 sign-up redirect targets `/verify-v2`.

## Notes

- `isOnboardingV2` is read fresh from the Jotai store at redirect time (the form sets it just before `createWorkspace`).
- The pulsing logo is extracted to a shared `OnboardingPulsingLogo`, reused by the workspace-activation loader.
- `/verify-v2` joins the same exempt lists as `/verify` (ongoing-creation guard, metadata gater, apollo unauthenticated handler, captcha, page title, untested-paths) — intentionally not `useShowAuthModal`, which is what drops the modal.
- Also fixes a latent staleness in the Apollo `onUnauthenticatedError` handler: it captured `location` from the memoized client and now reads it via a ref, so the verify exemptions are correct after navigation.