### PR TITLE
Fix BlockNote placeholder alignment

### DIFF
--- a/packages/twenty-front/src/modules/blocknote-editor/components/BlockEditor.tsx
+++ b/packages/twenty-front/src/modules/blocknote-editor/components/BlockEditor.tsx
@@ -88,7 +88,8 @@ const StyledEditor = styled.div`
   }
 
   & .bn-inline-content {
-    width: 100%;
+    max-width: 100%;
+    min-width: 0;
   }
 
   & .bn-container .bn-suggestion-menu-item:hover {

--- a/packages/twenty-front/src/modules/page-layout/widgets/standalone-rich-text/components/DashboardsBlockEditor.tsx
+++ b/packages/twenty-front/src/modules/page-layout/widgets/standalone-rich-text/components/DashboardsBlockEditor.tsx
@@ -76,8 +76,18 @@ const StyledEditor = styled.div`
     padding-inline: 0px;
   }
 
+  & .bn-block-content {
+    min-width: 0;
+  }
+
+  & .bn-block-content,
   & .bn-inline-content {
-    width: 100%;
+    overflow-wrap: anywhere;
+  }
+
+  & .bn-inline-content {
+    max-width: 100%;
+    min-width: 0;
   }
 
   & .bn-container .bn-suggestion-menu-item:hover {


### PR DESCRIPTION
## Summary

- Keep BlockNote inline content from taking the full editor row so empty-block placeholders render at the caret position.
- Apply the same wrapping guard to dashboard rich-text widgets.

## Before/After