### PR TITLE
fix(front): mark stale AnimatePresence exit page inert so it can't intercept clicks

### DIFF
--- a/packages/twenty-front/src/modules/ui/layout/page/components/MainAppLayoutWithSidePanel.tsx
+++ b/packages/twenty-front/src/modules/ui/layout/page/components/MainAppLayoutWithSidePanel.tsx
@@ -4,8 +4,12 @@ import { SidePanelForDesktop } from '@/side-panel/components/SidePanelForDesktop
 import { useIsMobile } from '@/ui/utilities/responsive/hooks/useIsMobile';
 import { styled } from '@linaria/react';
 import { AnimatePresence, motion } from 'framer-motion';
+import { useEffect, useState } from 'react';
 import { useLocation, useOutlet } from 'react-router-dom';
 import { AppPath } from 'twenty-shared/types';
+import { isDefined } from 'twenty-shared/utils';
+
+const ROUTE_SECTION_DATA_ATTRIBUTE = 'data-main-app-route-section';
 
 const APP_TO_SETTINGS_TRANSITION_DURATION_IN_SECONDS = 0.3;
 
@@ -53,17 +57,30 @@ const MainAppLayoutOutlet = () => {
   const { pathname } = useLocation();
   const outlet = useOutlet();
   const routeSection = getMainAppLayoutRouteSection(pathname);
+  const [containerElement, setContainerElement] =
+    useState<HTMLDivElement | null>(null);
+
+  useEffect(() => {
+    if (!isDefined(containerElement)) {
+      return;
+    }
+
+    Array.from(containerElement.children).forEach((child) => {
+      if (child instanceof HTMLElement) {
+        child.inert =
+          child.getAttribute(ROUTE_SECTION_DATA_ATTRIBUTE) !== routeSection;
+      }
+    });
+  }, [containerElement, routeSection]);
 
   return (
-    <StyledContentTransitionContainer>
+    <StyledContentTransitionContainer ref={setContainerElement}>
       <AnimatePresence initial={false}>
         <StyledContentTransitionPage
           key={routeSection}
+          {...{ [ROUTE_SECTION_DATA_ATTRIBUTE]: routeSection }}
           initial={{ opacity: 0, y: 4 }}
           animate={{ opacity: 1, y: 0 }}
-          // The outgoing page shares this grid cell with the incoming one, so it
-          // must not capture pointer/scroll events — including when AnimatePresence
-          // leaves a stale exit node mounted on top of the active page.
           exit={{ opacity: 0, y: -4, pointerEvents: 'none' }}
           transition={{
             duration: APP_TO_SETTINGS_TRANSITION_DURATION_IN_SECONDS,


### PR DESCRIPTION
## Context
When navigating between the app and settings sections, MainAppLayoutOutlet keeps the outgoing page mounted during the AnimatePresence exit transition, and can leave a stale exit node behind the active page, notably when the page hosts an app front component whose Web Worker teardown blocks React from removing it. 
The leftover page is invisible (opacity 0) but still captures pointer events on top of the active route, so e.g. front-component buttons stay clickable through the settings screen.

The existing `exit={{ pointerEvents: 'none' }}` mitigation is defeated by descendants that set pointer-events explicitly (the front-component container uses pointer-events: auto). Tag each transition page with its route section and mark every non-active one `inert`, which descendants cannot override, so any stale page is fully non-interactive.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/22328?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

