### PR TITLE
fix: reconcile metadata store after object creation so activity targets on new custom objects link correctly

### DIFF
--- a/packages/twenty-front/src/modules/object-metadata/hooks/useCreateOneObjectMetadataItem.ts
+++ b/packages/twenty-front/src/modules/object-metadata/hooks/useCreateOneObjectMetadataItem.ts
@@ -7,6 +7,7 @@ import {
   FindManyViewsDocument,
 } from '~/generated-metadata/graphql';
 
+import { useInvalidateMetadataStore } from '@/metadata-store/hooks/useInvalidateMetadataStore';
 import { useMetadataErrorHandler } from '@/metadata-error-handler/hooks/useMetadataErrorHandler';
 import { useUpdateMetadataStoreDraft } from '@/metadata-store/hooks/useUpdateMetadataStoreDraft';
 import { type FlatFieldMetadataItem } from '@/metadata-store/types/FlatFieldMetadataItem';
@@ -30,6 +31,7 @@ export const useCreateOneObjectMetadataItem = () => {
   const { enqueueErrorSnackBar } = useSnackBar();
   const { addToDraft, replaceDraft, applyChanges } =
     useUpdateMetadataStoreDraft();
+  const { invalidateMetadataStore } = useInvalidateMetadataStore();
   const { loadCurrentUser } = useLoadCurrentUser();
 
   const createOneObjectMetadataItem = async (
@@ -123,6 +125,8 @@ export const useCreateOneObjectMetadataItem = () => {
         applyChanges();
 
         await loadCurrentUser();
+
+        invalidateMetadataStore();
       }
 
       return {


### PR DESCRIPTION
## Summary

Creating a Task or Note on a record of a newly-created custom object failed to link them, and the console showed `Missing field 'targetTest…' while writing result` for `TaskTarget`/`NoteTarget`.

After creating a custom object, the front-end metadata store was left with an inconsistent morph relation group on the default-relation objects (`taskTarget`, `noteTarget`, `attachment`, `timelineActivity`). This reconciles the store from the server after creation so the morph fields are rebuilt correctly.

## Context / root cause

The DB and server are correct: the new object adds a single member (e.g. `targetTest`) to the existing `target` morph group (shared `morphId`), and the server's `objects` query collapses + renames the group to one `target` field with a full `morphRelations` array.

On the client, though, the metadata store is updated incrementally after creation:
- The bulk `objects` query stores morph fields already collapsed (`target` + `morphRelations`).
- The new reciprocal morph member arrives via SSE/mutation as a raw, un-collapsed field row (`targetTest`, without `morphRelations`), which `objectMetadataItemsWithFieldsSelector` simply joins in.

This leaves two morph fields on `taskTarget`/`noteTarget` (`target` with stale members + an un-normalized `targetTest`). `mapFieldMetadataToGraphQLQuery` then fans `targetTest` out into non-existent fields (`targetTestCompany`, `targetTestPerson`, …), which the server omits, breaking the optimistic cache write (`writeFragment`) and leaving the activity target unlinked in the UI.

This is a regression from the metadata-store incremental-sync refactor (the create path stopped reconciling reciprocal morph fields on existing objects).

## Fix

In `useCreateOneObjectMetadataItem`, after the incremental store updates, call `invalidateMetadataStore()` so the objects/field metadata is refetched from the server and the morph groups are rebuilt in their correct collapsed form. This mirrors the existing pattern in `useDeleteOneObjectMetadataItem`.

## Test plan

- [ ] Create a new custom object.
- [ ] Open a record of that object and create a Task and a Note from it.
- [ ] Verify no `Missing field 'target…'` error in the console and the task/note is linked (visible in the record's Tasks/Notes and on the activity target).
- [ ] Confirm existing standard objects (Company/Person/Opportunity) still link tasks/notes correctly.
- [ ] Confirm object creation still updates the left nav / views as before.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/22331?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

