### PR TITLE
feat(apps): plan/apply deploys with serial versioning and a destructive-change gate

### DIFF
--- a/packages/twenty-client-sdk/src/metadata/generated/schema.graphql
+++ b/packages/twenty-client-sdk/src/metadata/generated/schema.graphql
@@ -2410,6 +2410,34 @@ type UsageAnalytics {
   userDailyUsage: UsageUserDaily
 }
 
+type ApplicationSyncPlanAction {
+  type: String!
+  metadataName: String!
+  universalIdentifier: String
+  label: String
+  severity: String!
+  affectedRowCount: Int
+}
+
+type ApplicationSyncPlanSummary {
+  createCount: Int!
+  updateCount: Int!
+  deleteCount: Int!
+  breakingCount: Int!
+  destructiveCount: Int!
+  totalAffectedRows: Int!
+}
+
+type ApplicationSyncPlan {
+  applicationUniversalIdentifier: String!
+  actions: [ApplicationSyncPlanAction!]!
+  summary: ApplicationSyncPlanSummary!
+  currentVersion: String
+  proposedVersion: String!
+  isEmpty: Boolean!
+  hasDestructiveActions: Boolean!
+}
+
 type DevelopmentApplication {
   id: String!
   universalIdentifier: String!
@@ -3469,7 +3497,8 @@ type Mutation {
   syncMarketplaceCatalog: Boolean!
   createDevelopmentApplication(universalIdentifier: String!, name: String!): DevelopmentApplication!
   generateApplicationToken(applicationId: UUID!): ApplicationTokenPair!
-  syncApplication(manifest: JSON!, dryRun: Boolean): WorkspaceMigration!
+  planApplicationSync(manifest: JSON!, dryRun: Boolean, allowDestructive: Boolean): ApplicationSyncPlan!
+  syncApplication(manifest: JSON!, dryRun: Boolean, allowDestructive: Boolean): WorkspaceMigration!
   uploadApplicationFile(file: Upload!, applicationUniversalIdentifier: String!, fileFolder: FileFolder!, filePath: String!): File!
   upgradeApplication(appRegistrationId: String!, targetVersion: String!): Boolean!
   renewApplicationToken(applicationRefreshToken: String!): ApplicationTokenPair!

--- a/packages/twenty-client-sdk/src/metadata/generated/schema.ts
+++ b/packages/twenty-client-sdk/src/metadata/generated/schema.ts
@@ -2079,6 +2079,37 @@ export interface UsageAnalytics {
     __typename: 'UsageAnalytics'
 }
 
+export interface ApplicationSyncPlanAction {
+    type: Scalars['String']
+    metadataName: Scalars['String']
+    universalIdentifier?: Scalars['String']
+    label?: Scalars['String']
+    severity: Scalars['String']
+    affectedRowCount?: Scalars['Int']
+    __typename: 'ApplicationSyncPlanAction'
+}
+
+export interface ApplicationSyncPlanSummary {
+    createCount: Scalars['Int']
+    updateCount: Scalars['Int']
+    deleteCount: Scalars['Int']
+    breakingCount: Scalars['Int']
+    destructiveCount: Scalars['Int']
+    totalAffectedRows: Scalars['Int']
+    __typename: 'ApplicationSyncPlanSummary'
+}
+
+export interface ApplicationSyncPlan {
+    applicationUniversalIdentifier: Scalars['String']
+    actions: ApplicationSyncPlanAction[]
+    summary: ApplicationSyncPlanSummary
+    currentVersion?: Scalars['String']
+    proposedVersion: Scalars['String']
+    isEmpty: Scalars['Boolean']
+    hasDestructiveActions: Scalars['Boolean']
+    __typename: 'ApplicationSyncPlan'
+}
+
 export interface DevelopmentApplication {
     id: Scalars['String']
     universalIdentifier: Scalars['String']
@@ -2990,6 +3021,7 @@ export interface Mutation {
     syncMarketplaceCatalog: Scalars['Boolean']
     createDevelopmentApplication: DevelopmentApplication
     generateApplicationToken: ApplicationTokenPair
+    planApplicationSync: ApplicationSyncPlan
     syncApplication: WorkspaceMigration
     uploadApplicationFile: File
     upgradeApplication: Scalars['Boolean']
@@ -5207,6 +5239,40 @@ export interface UsageAnalyticsGenqlSelection{
     __scalar?: boolean | number
 }
 
+export interface ApplicationSyncPlanActionGenqlSelection{
+    type?: boolean | number
+    metadataName?: boolean | number
+    universalIdentifier?: boolean | number
+    label?: boolean | number
+    severity?: boolean | number
+    affectedRowCount?: boolean | number
+    __typename?: boolean | number
+    __scalar?: boolean | number
+}
+
+export interface ApplicationSyncPlanSummaryGenqlSelection{
+    createCount?: boolean | number
+    updateCount?: boolean | number
+    deleteCount?: boolean | number
+    breakingCount?: boolean | number
+    destructiveCount?: boolean | number
+    totalAffectedRows?: boolean | number
+    __typename?: boolean | number
+    __scalar?: boolean | number
+}
+
+export interface ApplicationSyncPlanGenqlSelection{
+    applicationUniversalIdentifier?: boolean | number
+    actions?: ApplicationSyncPlanActionGenqlSelection
+    summary?: ApplicationSyncPlanSummaryGenqlSelection
+    currentVersion?: boolean | number
+    proposedVersion?: boolean | number
+    isEmpty?: boolean | number
+    hasDestructiveActions?: boolean | number
+    __typename?: boolean | number
+    __scalar?: boolean | number
+}
+
 export interface DevelopmentApplicationGenqlSelection{
     id?: boolean | number
     universalIdentifier?: boolean | number
@@ -6189,7 +6255,8 @@ export interface MutationGenqlSelection{
     syncMarketplaceCatalog?: boolean | number
     createDevelopmentApplication?: (DevelopmentApplicationGenqlSelection & { __args: {universalIdentifier: Scalars['String'], name: Scalars['String']} })
     generateApplicationToken?: (ApplicationTokenPairGenqlSelection & { __args: {applicationId: Scalars['UUID']} })
-    syncApplication?: (WorkspaceMigrationGenqlSelection & { __args: {manifest: Scalars['JSON'], dryRun?: (Scalars['Boolean'] | null)} })
+    planApplicationSync?: (ApplicationSyncPlanGenqlSelection & { __args: {manifest: Scalars['JSON'], dryRun?: (Scalars['Boolean'] | null), allowDestructive?: (Scalars['Boolean'] | null)} })
+    syncApplication?: (WorkspaceMigrationGenqlSelection & { __args: {manifest: Scalars['JSON'], dryRun?: (Scalars['Boolean'] | null), allowDestructive?: (Scalars['Boolean'] | null)} })
     uploadApplicationFile?: (FileGenqlSelection & { __args: {file: Scalars['Upload'], applicationUniversalIdentifier: Scalars['String'], fileFolder: FileFolder, filePath: Scalars['String']} })
     upgradeApplication?: { __args: {appRegistrationId: Scalars['String'], targetVersion: Scalars['String']} }
     renewApplicationToken?: (ApplicationTokenPairGenqlSelection & { __args: {applicationRefreshToken: Scalars['String']} })
@@ -8159,6 +8226,30 @@ export interface LogicFunctionLogsInput {applicationId?: (Scalars['UUID'] | null
     export const isUsageAnalytics = (obj?: { __typename?: any } | null): obj is UsageAnalytics => {
       if (!obj?.__typename) throw new Error('__typename is missing in "isUsageAnalytics"')
       return UsageAnalytics_possibleTypes.includes(obj.__typename)
+    }
+    
+
+
+    const ApplicationSyncPlanAction_possibleTypes: string[] = ['ApplicationSyncPlanAction']
+    export const isApplicationSyncPlanAction = (obj?: { __typename?: any } | null): obj is ApplicationSyncPlanAction => {
+      if (!obj?.__typename) throw new Error('__typename is missing in "isApplicationSyncPlanAction"')
+      return ApplicationSyncPlanAction_possibleTypes.includes(obj.__typename)
+    }
+    
+
+
+    const ApplicationSyncPlanSummary_possibleTypes: string[] = ['ApplicationSyncPlanSummary']
+    export const isApplicationSyncPlanSummary = (obj?: { __typename?: any } | null): obj is ApplicationSyncPlanSummary => {
+      if (!obj?.__typename) throw new Error('__typename is missing in "isApplicationSyncPlanSummary"')
+      return ApplicationSyncPlanSummary_possibleTypes.includes(obj.__typename)
+    }
+    
+
+
+    const ApplicationSyncPlan_possibleTypes: string[] = ['ApplicationSyncPlan']
+    export const isApplicationSyncPlan = (obj?: { __typename?: any } | null): obj is ApplicationSyncPlan => {
+      if (!obj?.__typename) throw new Error('__typename is missing in "isApplicationSyncPlan"')
+      return ApplicationSyncPlan_possibleTypes.includes(obj.__typename)
     }
     
 

--- a/packages/twenty-client-sdk/src/metadata/generated/types.ts
+++ b/packages/twenty-client-sdk/src/metadata/generated/types.ts
@@ -62,27 +62,27 @@ export default {
         219,
         231,
         237,
-        273,
-        275,
         276,
-        277,
         278,
         279,
         280,
         281,
-        288,
-        327,
-        328,
-        329,
+        282,
+        283,
+        284,
+        291,
         330,
+        331,
         332,
-        334,
-        345,
-        352,
-        359,
-        442,
-        487,
-        496
+        333,
+        335,
+        337,
+        348,
+        355,
+        362,
+        445,
+        490,
+        499
     ],
     "types": {
         "BillingProductDTO": {
@@ -4733,6 +4733,78 @@ export default {
                 1
             ]
         },
+        "ApplicationSyncPlanAction": {
+            "type": [
+                1
+            ],
+            "metadataName": [
+                1
+            ],
+            "universalIdentifier": [
+                1
+            ],
+            "label": [
+                1
+            ],
+            "severity": [
+                1
+            ],
+            "affectedRowCount": [
+                21
+            ],
+            "__typename": [
+                1
+            ]
+        },
+        "ApplicationSyncPlanSummary": {
+            "createCount": [
+                21
+            ],
+            "updateCount": [
+                21
+            ],
+            "deleteCount": [
+                21
+            ],
+            "breakingCount": [
+                21
+            ],
+            "destructiveCount": [
+                21
+            ],
+            "totalAffectedRows": [
+                21
+            ],
+            "__typename": [
+                1
+            ]
+        },
+        "ApplicationSyncPlan": {
+            "applicationUniversalIdentifier": [
+                1
+            ],
+            "actions": [
+                265
+            ],
+            "summary": [
+                266
+            ],
+            "currentVersion": [
+                1
+            ],
+            "proposedVersion": [
+                1
+            ],
+            "isEmpty": [
+                6
+            ],
+            "hasDestructiveActions": [
+                6
+            ],
+            "__typename": [
+                1
+            ]
+        },
         "DevelopmentApplication": {
             "id": [
                 1
@@ -4884,10 +4956,10 @@ export default {
                 1
             ],
             "status": [
-                273
+                276
             ],
             "verificationRecords": [
-                271
+                274
             ],
             "verifiedAt": [
                 4
@@ -4902,22 +4974,22 @@ export default {
                 3
             ],
             "visibility": [
-                275
+                278
             ],
             "handle": [
                 1
             ],
             "type": [
-                276
+                279
             ],
             "isContactAutoCreationEnabled": [
                 6
             ],
             "contactAutoCreationPolicy": [
-                277
+                280
             ],
             "messageFolderImportPolicy": [
-                278
+                281
             ],
             "excludeNonProfessionalEmails": [
                 6
@@ -4926,7 +4998,7 @@ export default {
                 6
             ],
             "pendingGroupEmailsAction": [
-                279
+                282
             ],
             "isSyncEnabled": [
                 6
@@ -4935,10 +5007,10 @@ export default {
                 4
             ],
             "syncStatus": [
-                280
+                283
             ],
             "syncStage": [
-                281
+                284
             ],
             "syncStageStartedAt": [
                 4
@@ -4974,7 +5046,7 @@ export default {
         "MessageChannelSyncStage": {},
         "CreateEmailGroupChannelOutput": {
             "messageChannel": [
-                274
+                277
             ],
             "forwardingAddress": [
                 1
@@ -5036,7 +5108,7 @@ export default {
                 21
             ],
             "skipped": [
-                285
+                288
             ],
             "__typename": [
                 1
@@ -5059,7 +5131,7 @@ export default {
                 1
             ],
             "visibility": [
-                288
+                291
             ],
             "__typename": [
                 1
@@ -5105,7 +5177,7 @@ export default {
                 1
             ],
             "location": [
-                290
+                293
             ],
             "__typename": [
                 1
@@ -5130,13 +5202,13 @@ export default {
         },
         "ImapSmtpCaldavPublicConnectionParameters": {
             "IMAP": [
-                292
+                295
             ],
             "SMTP": [
-                292
+                295
             ],
             "CALDAV": [
-                292
+                295
             ],
             "__typename": [
                 1
@@ -5156,7 +5228,7 @@ export default {
                 3
             ],
             "connectionParameters": [
-                293
+                296
             ],
             "__typename": [
                 1
@@ -5378,7 +5450,7 @@ export default {
                 1
             ],
             "series": [
-                302
+                305
             ],
             "xAxisLabel": [
                 1
@@ -5427,7 +5499,7 @@ export default {
                 1
             ],
             "data": [
-                304
+                307
             ],
             "__typename": [
                 1
@@ -5435,7 +5507,7 @@ export default {
         },
         "LineChartData": {
             "series": [
-                305
+                308
             ],
             "xAxisLabel": [
                 1
@@ -5472,7 +5544,7 @@ export default {
         },
         "PieChartData": {
             "data": [
-                307
+                310
             ],
             "showLegend": [
                 6
@@ -5574,13 +5646,13 @@ export default {
         },
         "EventLogQueryResult": {
             "records": [
-                312
+                315
             ],
             "totalCount": [
                 21
             ],
             "pageInfo": [
-                313
+                316
             ],
             "__typename": [
                 1
@@ -5644,7 +5716,7 @@ export default {
                 1
             ],
             "parts": [
-                298
+                301
             ],
             "processedAt": [
                 4
@@ -5713,7 +5785,7 @@ export default {
         },
         "AiSystemPromptPreview": {
             "sections": [
-                318
+                321
             ],
             "estimatedTokenCount": [
                 21
@@ -5789,10 +5861,10 @@ export default {
                 3
             ],
             "evaluations": [
-                323
+                326
             ],
             "messages": [
-                316
+                319
             ],
             "createdAt": [
                 4
@@ -5823,19 +5895,19 @@ export default {
                 1
             ],
             "syncStatus": [
-                327
+                330
             ],
             "syncStage": [
-                328
+                331
             ],
             "visibility": [
-                329
+                332
             ],
             "isContactAutoCreationEnabled": [
                 6
             ],
             "contactAutoCreationPolicy": [
-                330
+                333
             ],
             "isSyncEnabled": [
                 6
@@ -5886,7 +5958,7 @@ export default {
                 1
             ],
             "pendingSyncAction": [
-                332
+                335
             ],
             "messageChannelId": [
                 3
@@ -5904,7 +5976,7 @@ export default {
         "MessageFolderPendingSyncAction": {},
         "CollectionHash": {
             "collectionName": [
-                334
+                337
             ],
             "hash": [
                 1
@@ -5968,13 +6040,13 @@ export default {
         },
         "MinimalMetadata": {
             "objectMetadataItems": [
-                335
+                338
             ],
             "views": [
-                336
+                339
             ],
             "collectionHashes": [
-                333
+                336
             ],
             "__typename": [
                 1
@@ -6127,7 +6199,7 @@ export default {
                 2,
                 {
                     "input": [
-                        339,
+                        342,
                         "GetApiKeyInput!"
                     ]
                 }
@@ -6230,7 +6302,7 @@ export default {
                 25,
                 {
                     "input": [
-                        340,
+                        343,
                         "AgentIdInput!"
                     ]
                 }
@@ -6286,7 +6358,7 @@ export default {
                 41,
                 {
                     "input": [
-                        341,
+                        344,
                         "LogicFunctionIdInput!"
                     ]
                 }
@@ -6298,7 +6370,7 @@ export default {
                 15,
                 {
                     "input": [
-                        341,
+                        344,
                         "LogicFunctionIdInput!"
                     ]
                 }
@@ -6307,7 +6379,7 @@ export default {
                 1,
                 {
                     "input": [
-                        341,
+                        344,
                         "LogicFunctionIdInput!"
                     ]
                 }
@@ -6470,22 +6542,22 @@ export default {
                 }
             ],
             "previewMessageCampaignAudience": [
-                283,
+                286,
                 {
                     "input": [
-                        342,
+                        345,
                         "PreviewMessageCampaignAudienceInput!"
                     ]
                 }
             ],
             "unsubscribeTopics": [
-                287
+                290
             ],
             "unsubscribePagePreviewUrl": [
                 1
             ],
             "myMessageChannels": [
-                274,
+                277,
                 {
                     "connectedAccountId": [
                         3
@@ -6493,13 +6565,13 @@ export default {
                 }
             ],
             "getEmailingDomains": [
-                272
+                275
             ],
             "myConnectedAccounts": [
                 239
             ],
             "getToolIndex": [
-                297
+                300
             ],
             "getToolInputSchema": [
                 15,
@@ -6511,10 +6583,10 @@ export default {
                 }
             ],
             "webhooks": [
-                296
+                299
             ],
             "webhook": [
-                296,
+                299,
                 {
                     "id": [
                         3,
@@ -6523,7 +6595,7 @@ export default {
                 }
             ],
             "myMessageFolders": [
-                331,
+                334,
                 {
                     "messageChannelId": [
                         3
@@ -6531,7 +6603,7 @@ export default {
                 }
             ],
             "myCalendarChannels": [
-                326,
+                329,
                 {
                     "connectedAccountId": [
                         3
@@ -6539,13 +6611,13 @@ export default {
                 }
             ],
             "minimalMetadata": [
-                337
+                340
             ],
             "appConnections": [
                 218,
                 {
                     "filter": [
-                        343
+                        346
                     ]
                 }
             ],
@@ -6559,13 +6631,13 @@ export default {
                 }
             ],
             "findWorkspaceAiStats": [
-                325
+                328
             ],
             "chatThreads": [
-                317
+                320
             ],
             "chatThread": [
-                317,
+                320,
                 {
                     "id": [
                         3,
@@ -6574,7 +6646,7 @@ export default {
                 }
             ],
             "chatMessages": [
-                316,
+                319,
                 {
                     "threadId": [
                         3,
@@ -6583,7 +6655,7 @@ export default {
                 }
             ],
             "chatStreamCatchupChunks": [
-                320,
+                323,
                 {
                     "threadId": [
                         3,
@@ -6592,13 +6664,13 @@ export default {
                 }
             ],
             "getAiSystemPromptPreview": [
-                319
+                322
             ],
             "skills": [
-                315
+                318
             ],
             "skill": [
-                315,
+                318,
                 {
                     "id": [
                         3,
@@ -6607,7 +6679,7 @@ export default {
                 }
             ],
             "agentTurns": [
-                324,
+                327,
                 {
                     "agentId": [
                         3,
@@ -6673,43 +6745,43 @@ export default {
                 224
             ],
             "eventLogs": [
-                314,
+                317,
                 {
                     "input": [
-                        344,
+                        347,
                         "EventLogQueryInput!"
                     ]
                 }
             ],
             "pieChartData": [
-                308,
+                311,
                 {
                     "input": [
-                        348,
+                        351,
                         "PieChartDataInput!"
                     ]
                 }
             ],
             "lineChartData": [
-                306,
+                309,
                 {
                     "input": [
-                        349,
+                        352,
                         "LineChartDataInput!"
                     ]
                 }
             ],
             "barChartData": [
-                303,
+                306,
                 {
                     "input": [
-                        350,
+                        353,
                         "BarChartDataInput!"
                     ]
                 }
             ],
             "getConnectedImapSmtpCaldavAccount": [
-                294,
+                297,
                 {
                     "id": [
                         3,
@@ -6718,7 +6790,7 @@ export default {
                 }
             ],
             "getAutoCompleteAddress": [
-                289,
+                292,
                 {
                     "address": [
                         1,
@@ -6737,7 +6809,7 @@ export default {
                 }
             ],
             "getAddressDetails": [
-                291,
+                294,
                 {
                     "placeId": [
                         1,
@@ -6753,18 +6825,18 @@ export default {
                 264,
                 {
                     "input": [
-                        351
+                        354
                     ]
                 }
             ],
             "findManyPublicDomains": [
-                270
+                273
             ],
             "findManyMarketplaceApps": [
-                268
+                271
             ],
             "findMarketplaceAppDetail": [
-                269,
+                272,
                 {
                     "universalIdentifier": [
                         1,
@@ -6827,10 +6899,10 @@ export default {
         },
         "EventLogQueryInput": {
             "table": [
-                345
+                348
             ],
             "filters": [
-                346
+                349
             ],
             "first": [
                 21
@@ -6851,7 +6923,7 @@ export default {
                 1
             ],
             "dateRange": [
-                347
+                350
             ],
             "recordId": [
                 1
@@ -6918,7 +6990,7 @@ export default {
                 1
             ],
             "operationTypes": [
-                352
+                355
             ],
             "__typename": [
                 1
@@ -6930,7 +7002,7 @@ export default {
                 6,
                 {
                     "input": [
-                        354,
+                        357,
                         "AddQuerySubscriptionInput!"
                     ]
                 }
@@ -6939,7 +7011,7 @@ export default {
                 6,
                 {
                     "input": [
-                        355,
+                        358,
                         "RemoveQueryFromEventStreamInput!"
                     ]
                 }
@@ -6948,7 +7020,7 @@ export default {
                 160,
                 {
                     "inputs": [
-                        356,
+                        359,
                         "[CreateNavigationMenuItemInput!]!"
                     ]
                 }
@@ -6957,7 +7029,7 @@ export default {
                 160,
                 {
                     "input": [
-                        356,
+                        359,
                         "CreateNavigationMenuItemInput!"
                     ]
                 }
@@ -6966,7 +7038,7 @@ export default {
                 160,
                 {
                     "inputs": [
-                        357,
+                        360,
                         "[UpdateOneNavigationMenuItemInput!]!"
                     ]
                 }
@@ -6975,7 +7047,7 @@ export default {
                 160,
                 {
                     "input": [
-                        357,
+                        360,
                         "UpdateOneNavigationMenuItemInput!"
                     ]
                 }
@@ -7002,7 +7074,7 @@ export default {
                 131,
                 {
                     "file": [
-                        359,
+                        362,
                         "Upload!"
                     ]
                 }
@@ -7023,7 +7095,7 @@ export default {
                 131,
                 {
                     "file": [
-                        359,
+                        362,
                         "Upload!"
                     ]
                 }
@@ -7032,7 +7104,7 @@ export default {
                 131,
                 {
                     "file": [
-                        359,
+                        362,
                         "Upload!"
                     ]
                 }
@@ -7041,7 +7113,7 @@ export default {
                 131,
                 {
                     "file": [
-                        359,
+                        362,
                         "Upload!"
                     ]
                 }
@@ -7050,7 +7122,7 @@ export default {
                 131,
                 {
                     "file": [
-                        359,
+                        362,
                         "Upload!"
                     ]
                 }
@@ -7059,7 +7131,7 @@ export default {
                 131,
                 {
                     "file": [
-                        359,
+                        362,
                         "Upload!"
                     ],
                     "fieldMetadataId": [
@@ -7072,7 +7144,7 @@ export default {
                 131,
                 {
                     "file": [
-                        359,
+                        362,
                         "Upload!"
                     ],
                     "fieldMetadataUniversalIdentifier": [
@@ -7085,7 +7157,7 @@ export default {
                 62,
                 {
                     "input": [
-                        360,
+                        363,
                         "CreateViewFilterGroupInput!"
                     ]
                 }
@@ -7098,7 +7170,7 @@ export default {
                         "String!"
                     ],
                     "input": [
-                        361,
+                        364,
                         "UpdateViewFilterGroupInput!"
                     ]
                 }
@@ -7125,7 +7197,7 @@ export default {
                 64,
                 {
                     "input": [
-                        362,
+                        365,
                         "CreateViewFilterInput!"
                     ]
                 }
@@ -7134,7 +7206,7 @@ export default {
                 64,
                 {
                     "input": [
-                        363,
+                        366,
                         "UpdateViewFilterInput!"
                     ]
                 }
@@ -7143,7 +7215,7 @@ export default {
                 64,
                 {
                     "input": [
-                        365,
+                        368,
                         "DeleteViewFilterInput!"
                     ]
                 }
@@ -7152,7 +7224,7 @@ export default {
                 64,
                 {
                     "input": [
-                        366,
+                        369,
                         "DestroyViewFilterInput!"
                     ]
                 }
@@ -7161,7 +7233,7 @@ export default {
                 70,
                 {
                     "input": [
-                        367,
+                        370,
                         "CreateViewInput!"
                     ]
                 }
@@ -7174,7 +7246,7 @@ export default {
                         "String!"
                     ],
                     "input": [
-                        368,
+                        371,
                         "UpdateViewInput!"
                     ]
                 }
@@ -7201,7 +7273,7 @@ export default {
                 70,
                 {
                     "input": [
-                        369,
+                        372,
                         "UpsertViewWidgetInput!"
                     ]
                 }
@@ -7210,7 +7282,7 @@ export default {
                 67,
                 {
                     "input": [
-                        374,
+                        377,
                         "CreateViewSortInput!"
                     ]
                 }
@@ -7219,7 +7291,7 @@ export default {
                 67,
                 {
                     "input": [
-                        375,
+                        378,
                         "UpdateViewSortInput!"
                     ]
                 }
@@ -7228,7 +7300,7 @@ export default {
                 6,
                 {
                     "input": [
-                        377,
+                        380,
                         "DeleteViewSortInput!"
                     ]
                 }
@@ -7237,7 +7309,7 @@ export default {
                 6,
                 {
                     "input": [
-                        378,
+                        381,
                         "DestroyViewSortInput!"
                     ]
                 }
@@ -7246,7 +7318,7 @@ export default {
                 60,
                 {
                     "input": [
-                        379,
+                        382,
                         "UpdateViewFieldInput!"
                     ]
                 }
@@ -7255,7 +7327,7 @@ export default {
                 60,
                 {
                     "input": [
-                        381,
+                        384,
                         "CreateViewFieldInput!"
                     ]
                 }
@@ -7264,7 +7336,7 @@ export default {
                 60,
                 {
                     "inputs": [
-                        381,
+                        384,
                         "[CreateViewFieldInput!]!"
                     ]
                 }
@@ -7273,7 +7345,7 @@ export default {
                 60,
                 {
                     "input": [
-                        382,
+                        385,
                         "DeleteViewFieldInput!"
                     ]
                 }
@@ -7282,7 +7354,7 @@ export default {
                 60,
                 {
                     "input": [
-                        383,
+                        386,
                         "DestroyViewFieldInput!"
                     ]
                 }
@@ -7291,7 +7363,7 @@ export default {
                 69,
                 {
                     "input": [
-                        384,
+                        387,
                         "UpdateViewFieldGroupInput!"
                     ]
                 }
@@ -7300,7 +7372,7 @@ export default {
                 69,
                 {
                     "input": [
-                        386,
+                        389,
                         "CreateViewFieldGroupInput!"
                     ]
                 }
@@ -7309,7 +7381,7 @@ export default {
                 69,
                 {
                     "inputs": [
-                        386,
+                        389,
                         "[CreateViewFieldGroupInput!]!"
                     ]
                 }
@@ -7318,7 +7390,7 @@ export default {
                 69,
                 {
                     "input": [
-                        387,
+                        390,
                         "DeleteViewFieldGroupInput!"
                     ]
                 }
@@ -7327,7 +7399,7 @@ export default {
                 69,
                 {
                     "input": [
-                        388,
+                        391,
                         "DestroyViewFieldGroupInput!"
                     ]
                 }
@@ -7336,7 +7408,7 @@ export default {
                 70,
                 {
                     "input": [
-                        389,
+                        392,
                         "UpsertFieldsWidgetInput!"
                     ]
                 }
@@ -7345,7 +7417,7 @@ export default {
                 2,
                 {
                     "input": [
-                        392,
+                        395,
                         "CreateApiKeyInput!"
                     ]
                 }
@@ -7354,7 +7426,7 @@ export default {
                 2,
                 {
                     "input": [
-                        393,
+                        396,
                         "UpdateApiKeyInput!"
                     ]
                 }
@@ -7363,7 +7435,7 @@ export default {
                 2,
                 {
                     "input": [
-                        394,
+                        397,
                         "RevokeApiKeyInput!"
                     ]
                 }
@@ -7512,7 +7584,7 @@ export default {
                 130,
                 {
                     "input": [
-                        395,
+                        398,
                         "CreateApprovedAccessDomainInput!"
                     ]
                 }
@@ -7521,7 +7593,7 @@ export default {
                 6,
                 {
                     "input": [
-                        396,
+                        399,
                         "DeleteApprovedAccessDomainInput!"
                     ]
                 }
@@ -7530,7 +7602,7 @@ export default {
                 130,
                 {
                     "input": [
-                        397,
+                        400,
                         "ValidateApprovedAccessDomainInput!"
                     ]
                 }
@@ -7539,7 +7611,7 @@ export default {
                 123,
                 {
                     "input": [
-                        398,
+                        401,
                         "CreatePageLayoutTabInput!"
                     ]
                 }
@@ -7552,7 +7624,7 @@ export default {
                         "String!"
                     ],
                     "input": [
-                        399,
+                        402,
                         "UpdatePageLayoutTabInput!"
                     ]
                 }
@@ -7570,7 +7642,7 @@ export default {
                 124,
                 {
                     "input": [
-                        400,
+                        403,
                         "CreatePageLayoutInput!"
                     ]
                 }
@@ -7583,7 +7655,7 @@ export default {
                         "String!"
                     ],
                     "input": [
-                        401,
+                        404,
                         "UpdatePageLayoutInput!"
                     ]
                 }
@@ -7605,7 +7677,7 @@ export default {
                         "String!"
                     ],
                     "input": [
-                        402,
+                        405,
                         "UpdatePageLayoutWithTabsInput!"
                     ]
                 }
@@ -7641,7 +7713,7 @@ export default {
                 85,
                 {
                     "input": [
-                        406,
+                        409,
                         "CreatePageLayoutWidgetInput!"
                     ]
                 }
@@ -7654,7 +7726,7 @@ export default {
                         "String!"
                     ],
                     "input": [
-                        407,
+                        410,
                         "UpdatePageLayoutWidgetInput!"
                     ]
                 }
@@ -7672,7 +7744,7 @@ export default {
                 25,
                 {
                     "input": [
-                        408,
+                        411,
                         "CreateAgentInput!"
                     ]
                 }
@@ -7681,7 +7753,7 @@ export default {
                 25,
                 {
                     "input": [
-                        409,
+                        412,
                         "UpdateAgentInput!"
                     ]
                 }
@@ -7690,7 +7762,7 @@ export default {
                 25,
                 {
                     "input": [
-                        340,
+                        343,
                         "AgentIdInput!"
                     ]
                 }
@@ -7699,7 +7771,7 @@ export default {
                 56,
                 {
                     "input": [
-                        410,
+                        413,
                         "CreateOneObjectInput!"
                     ]
                 }
@@ -7708,7 +7780,7 @@ export default {
                 56,
                 {
                     "input": [
-                        412,
+                        415,
                         "DeleteOneObjectInput!"
                     ]
                 }
@@ -7717,7 +7789,7 @@ export default {
                 56,
                 {
                     "input": [
-                        413,
+                        416,
                         "UpdateOneObjectInput!"
                     ]
                 }
@@ -7726,7 +7798,7 @@ export default {
                 47,
                 {
                     "input": [
-                        415,
+                        418,
                         "CreateOneIndexInput!"
                     ]
                 }
@@ -7735,7 +7807,7 @@ export default {
                 47,
                 {
                     "input": [
-                        418,
+                        421,
                         "DeleteOneIndexInput!"
                     ]
                 }
@@ -7744,7 +7816,7 @@ export default {
                 41,
                 {
                     "input": [
-                        341,
+                        344,
                         "LogicFunctionIdInput!"
                     ]
                 }
@@ -7753,7 +7825,7 @@ export default {
                 41,
                 {
                     "input": [
-                        419,
+                        422,
                         "CreateLogicFunctionFromSourceInput!"
                     ]
                 }
@@ -7762,7 +7834,7 @@ export default {
                 169,
                 {
                     "input": [
-                        420,
+                        423,
                         "ExecuteOneLogicFunctionInput!"
                     ]
                 }
@@ -7771,7 +7843,7 @@ export default {
                 6,
                 {
                     "input": [
-                        421,
+                        424,
                         "UpdateLogicFunctionFromSourceInput!"
                     ]
                 }
@@ -7780,7 +7852,7 @@ export default {
                 35,
                 {
                     "input": [
-                        423,
+                        426,
                         "CreateCommandMenuItemInput!"
                     ]
                 }
@@ -7789,7 +7861,7 @@ export default {
                 35,
                 {
                     "input": [
-                        424,
+                        427,
                         "UpdateCommandMenuItemInput!"
                     ]
                 }
@@ -7816,7 +7888,7 @@ export default {
                 34,
                 {
                     "input": [
-                        425,
+                        428,
                         "CreateFrontComponentInput!"
                     ]
                 }
@@ -7825,7 +7897,7 @@ export default {
                 34,
                 {
                     "input": [
-                        426,
+                        429,
                         "UpdateFrontComponentInput!"
                     ]
                 }
@@ -7843,7 +7915,7 @@ export default {
                 76,
                 {
                     "data": [
-                        428,
+                        431,
                         "ActivateWorkspaceInput!"
                     ]
                 }
@@ -7852,7 +7924,7 @@ export default {
                 76,
                 {
                     "data": [
-                        429,
+                        432,
                         "UpdateWorkspaceInput!"
                     ]
                 }
@@ -7867,7 +7939,7 @@ export default {
                 44,
                 {
                     "input": [
-                        430,
+                        433,
                         "CreateOneFieldMetadataInput!"
                     ]
                 }
@@ -7876,7 +7948,7 @@ export default {
                 44,
                 {
                     "input": [
-                        432,
+                        435,
                         "UpdateOneFieldMetadataInput!"
                     ]
                 }
@@ -7885,7 +7957,7 @@ export default {
                 44,
                 {
                     "input": [
-                        434,
+                        437,
                         "DeleteOneFieldInput!"
                     ]
                 }
@@ -7894,7 +7966,7 @@ export default {
                 66,
                 {
                     "input": [
-                        435,
+                        438,
                         "CreateViewGroupInput!"
                     ]
                 }
@@ -7903,7 +7975,7 @@ export default {
                 66,
                 {
                     "inputs": [
-                        435,
+                        438,
                         "[CreateViewGroupInput!]!"
                     ]
                 }
@@ -7912,7 +7984,7 @@ export default {
                 66,
                 {
                     "input": [
-                        436,
+                        439,
                         "UpdateViewGroupInput!"
                     ]
                 }
@@ -7921,7 +7993,7 @@ export default {
                 66,
                 {
                     "inputs": [
-                        436,
+                        439,
                         "[UpdateViewGroupInput!]!"
                     ]
                 }
@@ -7930,7 +8002,7 @@ export default {
                 66,
                 {
                     "input": [
-                        438,
+                        441,
                         "DeleteViewGroupInput!"
                     ]
                 }
@@ -7939,7 +8011,7 @@ export default {
                 66,
                 {
                     "input": [
-                        439,
+                        442,
                         "DestroyViewGroupInput!"
                     ]
                 }
@@ -7948,7 +8020,7 @@ export default {
                 6,
                 {
                     "workspaceMigration": [
-                        440,
+                        443,
                         "WorkspaceMigrationInput!"
                     ]
                 }
@@ -7979,7 +8051,7 @@ export default {
                 29,
                 {
                     "createRoleInput": [
-                        443,
+                        446,
                         "CreateRoleInput!"
                     ]
                 }
@@ -7988,7 +8060,7 @@ export default {
                 29,
                 {
                     "updateRoleInput": [
-                        444,
+                        447,
                         "UpdateRoleInput!"
                     ]
                 }
@@ -8006,7 +8078,7 @@ export default {
                 16,
                 {
                     "upsertObjectPermissionsInput": [
-                        446,
+                        449,
                         "UpsertObjectPermissionsInput!"
                     ]
                 }
@@ -8015,7 +8087,7 @@ export default {
                 27,
                 {
                     "upsertPermissionFlagsInput": [
-                        448,
+                        451,
                         "UpsertPermissionFlagsInput!"
                     ]
                 }
@@ -8024,7 +8096,7 @@ export default {
                 26,
                 {
                     "upsertFieldPermissionsInput": [
-                        449,
+                        452,
                         "UpsertFieldPermissionsInput!"
                     ]
                 }
@@ -8033,7 +8105,7 @@ export default {
                 234,
                 {
                     "input": [
-                        451,
+                        454,
                         "UpsertRowLevelPermissionPredicatesInput!"
                     ]
                 }
@@ -8064,7 +8136,7 @@ export default {
                 200,
                 {
                     "input": [
-                        454,
+                        457,
                         "CreateApplicationRegistrationInput!"
                     ]
                 }
@@ -8073,7 +8145,7 @@ export default {
                 7,
                 {
                     "input": [
-                        455,
+                        458,
                         "UpdateApplicationRegistrationInput!"
                     ]
                 }
@@ -8100,7 +8172,7 @@ export default {
                 5,
                 {
                     "input": [
-                        457,
+                        460,
                         "CreateApplicationRegistrationVariableInput!"
                     ]
                 }
@@ -8109,7 +8181,7 @@ export default {
                 5,
                 {
                     "input": [
-                        458,
+                        461,
                         "UpdateApplicationRegistrationVariableInput!"
                     ]
                 }
@@ -8127,7 +8199,7 @@ export default {
                 7,
                 {
                     "file": [
-                        359,
+                        362,
                         "Upload!"
                     ],
                     "universalIdentifier": [
@@ -8149,37 +8221,37 @@ export default {
                 }
             ],
             "sendEmailViaEmailingDomain": [
-                284,
+                287,
                 {
                     "input": [
-                        460,
+                        463,
                         "SendEmailViaDomainInput!"
                     ]
                 }
             ],
             "sendMessageCampaign": [
-                286,
+                289,
                 {
                     "input": [
-                        461,
+                        464,
                         "SendMessageCampaignInput!"
                     ]
                 }
             ],
             "createUnsubscribeTopic": [
-                287,
+                290,
                 {
                     "input": [
-                        462,
+                        465,
                         "CreateUnsubscribeTopicInput!"
                     ]
                 }
             ],
             "updateUnsubscribeTopic": [
-                287,
+                290,
                 {
                     "input": [
-                        463,
+                        466,
                         "UpdateUnsubscribeTopicInput!"
                     ]
                 }
@@ -8194,25 +8266,25 @@ export default {
                 }
             ],
             "updateMessageChannel": [
-                274,
+                277,
                 {
                     "input": [
-                        464,
+                        467,
                         "UpdateMessageChannelInput!"
                     ]
                 }
             ],
             "createEmailGroupChannel": [
-                282,
+                285,
                 {
                     "input": [
-                        466,
+                        469,
                         "CreateEmailGroupChannelInput!"
                     ]
                 }
             ],
             "deleteEmailGroupChannel": [
-                274,
+                277,
                 {
                     "id": [
                         3,
@@ -8221,10 +8293,10 @@ export default {
                 }
             ],
             "createEmailingDomain": [
-                272,
+                275,
                 {
                     "input": [
-                        467,
+                        470,
                         "CreateEmailingDomainInput!"
                     ]
                 }
@@ -8239,7 +8311,7 @@ export default {
                 }
             ],
             "verifyEmailingDomain": [
-                272,
+                275,
                 {
                     "id": [
                         1,
@@ -8257,34 +8329,34 @@ export default {
                 }
             ],
             "runAgent": [
-                299,
+                302,
                 {
                     "input": [
-                        468,
+                        471,
                         "RunAgentInput!"
                     ]
                 }
             ],
             "createWebhook": [
-                296,
+                299,
                 {
                     "input": [
-                        469,
+                        472,
                         "CreateWebhookInput!"
                     ]
                 }
             ],
             "updateWebhook": [
-                296,
+                299,
                 {
                     "input": [
-                        470,
+                        473,
                         "UpdateWebhookInput!"
                     ]
                 }
             ],
             "deleteWebhook": [
-                296,
+                299,
                 {
                     "id": [
                         3,
@@ -8293,37 +8365,37 @@ export default {
                 }
             ],
             "updateMessageFolder": [
-                331,
+                334,
                 {
                     "input": [
-                        472,
+                        475,
                         "UpdateMessageFolderInput!"
                     ]
                 }
             ],
             "updateMessageFolders": [
-                331,
+                334,
                 {
                     "input": [
-                        474,
+                        477,
                         "UpdateMessageFoldersInput!"
                     ]
                 }
             ],
             "updateCalendarChannel": [
-                326,
+                329,
                 {
                     "input": [
-                        475,
+                        478,
                         "UpdateCalendarChannelInput!"
                     ]
                 }
             ],
             "createChatThread": [
-                317
+                320
             ],
             "sendChatMessage": [
-                321,
+                324,
                 {
                     "threadId": [
                         3,
@@ -8344,7 +8416,7 @@ export default {
                         1
                     ],
                     "fileAttachments": [
-                        477,
+                        480,
                         "[FileAttachmentInput!]"
                     ]
                 }
@@ -8359,7 +8431,7 @@ export default {
                 }
             ],
             "renameChatThread": [
-                317,
+                320,
                 {
                     "id": [
                         3,
@@ -8372,7 +8444,7 @@ export default {
                 }
             ],
             "archiveChatThread": [
-                317,
+                320,
                 {
                     "id": [
                         3,
@@ -8381,7 +8453,7 @@ export default {
                 }
             ],
             "unarchiveChatThread": [
-                317,
+                320,
                 {
                     "id": [
                         3,
@@ -8408,25 +8480,25 @@ export default {
                 }
             ],
             "createSkill": [
-                315,
+                318,
                 {
                     "input": [
-                        478,
+                        481,
                         "CreateSkillInput!"
                     ]
                 }
             ],
             "updateSkill": [
-                315,
+                318,
                 {
                     "input": [
-                        479,
+                        482,
                         "UpdateSkillInput!"
                     ]
                 }
             ],
             "deleteSkill": [
-                315,
+                318,
                 {
                     "id": [
                         3,
@@ -8435,7 +8507,7 @@ export default {
                 }
             ],
             "activateSkill": [
-                315,
+                318,
                 {
                     "id": [
                         3,
@@ -8444,7 +8516,7 @@ export default {
                 }
             ],
             "deactivateSkill": [
-                315,
+                318,
                 {
                     "id": [
                         3,
@@ -8453,7 +8525,7 @@ export default {
                 }
             ],
             "evaluateAgentTurn": [
-                323,
+                326,
                 {
                     "turnId": [
                         3,
@@ -8462,7 +8534,7 @@ export default {
                 }
             ],
             "runEvaluationInput": [
-                324,
+                327,
                 {
                     "agentId": [
                         3,
@@ -8478,7 +8550,7 @@ export default {
                 247,
                 {
                     "input": [
-                        480,
+                        483,
                         "GetAuthorizationUrlForSSOInput!"
                     ]
                 }
@@ -8644,7 +8716,7 @@ export default {
                 250,
                 {
                     "input": [
-                        481
+                        484
                     ]
                 }
             ],
@@ -8656,7 +8728,7 @@ export default {
                         "String!"
                     ],
                     "file": [
-                        359,
+                        362,
                         "Upload!"
                     ]
                 }
@@ -8799,7 +8871,7 @@ export default {
                 6,
                 {
                     "input": [
-                        482,
+                        485,
                         "UpdateWorkspaceMemberSettingsInput!"
                     ]
                 }
@@ -8833,7 +8905,7 @@ export default {
                 225,
                 {
                     "input": [
-                        483,
+                        486,
                         "SetupOIDCSsoInput!"
                     ]
                 }
@@ -8842,7 +8914,7 @@ export default {
                 225,
                 {
                     "input": [
-                        484,
+                        487,
                         "SetupSAMLSsoInput!"
                     ]
                 }
@@ -8851,7 +8923,7 @@ export default {
                 221,
                 {
                     "input": [
-                        485,
+                        488,
                         "DeleteSsoInput!"
                     ]
                 }
@@ -8860,13 +8932,13 @@ export default {
                 222,
                 {
                     "input": [
-                        486,
+                        489,
                         "EditSsoInput!"
                     ]
                 }
             ],
             "createObjectEvent": [
-                311,
+                314,
                 {
                     "event": [
                         1,
@@ -8886,10 +8958,10 @@ export default {
                 }
             ],
             "trackAnalytics": [
-                311,
+                314,
                 {
                     "type": [
-                        487,
+                        490,
                         "AnalyticsType!"
                     ],
                     "name": [
@@ -8904,7 +8976,7 @@ export default {
                 }
             ],
             "duplicateDashboard": [
-                309,
+                312,
                 {
                     "id": [
                         3,
@@ -8926,25 +8998,25 @@ export default {
                 }
             ],
             "createCalendarEvent": [
-                301,
+                304,
                 {
                     "input": [
-                        488,
+                        491,
                         "CreateCalendarEventInput!"
                     ]
                 }
             ],
             "sendEmail": [
-                310,
+                313,
                 {
                     "input": [
-                        489,
+                        492,
                         "SendEmailInput!"
                     ]
                 }
             ],
             "startChannelSync": [
-                300,
+                303,
                 {
                     "connectedAccountId": [
                         3,
@@ -8953,14 +9025,14 @@ export default {
                 }
             ],
             "saveImapSmtpCaldavAccount": [
-                295,
+                298,
                 {
                     "handle": [
                         1,
                         "String!"
                     ],
                     "connectionParameters": [
-                        491,
+                        494,
                         "EmailAccountConnectionParameters!"
                     ],
                     "id": [
@@ -8972,13 +9044,13 @@ export default {
                 171,
                 {
                     "input": [
-                        493,
+                        496,
                         "UpdateLabPublicFeatureFlagInput!"
                     ]
                 }
             ],
             "createPublicDomain": [
-                270,
+                273,
                 {
                     "domain": [
                         1,
@@ -9012,7 +9084,7 @@ export default {
                 78,
                 {
                     "input": [
-                        494,
+                        497,
                         "CreateOneAppTokenInput!"
                     ]
                 }
@@ -9045,7 +9117,7 @@ export default {
                 6
             ],
             "createDevelopmentApplication": [
-                265,
+                268,
                 {
                     "universalIdentifier": [
                         1,
@@ -9066,8 +9138,8 @@ export default {
                     ]
                 }
             ],
-            "syncApplication": [
-                266,
+            "planApplicationSync": [
+                267,
                 {
                     "manifest": [
                         15,
@@ -9075,14 +9147,32 @@ export default {
                     ],
                     "dryRun": [
                         6
+                    ],
+                    "allowDestructive": [
+                        6
+                    ]
+                }
+            ],
+            "syncApplication": [
+                269,
+                {
+                    "manifest": [
+                        15,
+                        "JSON!"
+                    ],
+                    "dryRun": [
+                        6
+                    ],
+                    "allowDestructive": [
+                        6
                     ]
                 }
             ],
             "uploadApplicationFile": [
-                267,
+                270,
                 {
                     "file": [
-                        359,
+                        362,
                         "Upload!"
                     ],
                     "applicationUniversalIdentifier": [
@@ -9090,7 +9180,7 @@ export default {
                         "String!"
                     ],
                     "fileFolder": [
-                        496,
+                        499,
                         "FileFolder!"
                     ],
                     "filePath": [
@@ -9199,7 +9289,7 @@ export default {
                 3
             ],
             "update": [
-                358
+                361
             ],
             "__typename": [
                 1
@@ -9309,7 +9399,7 @@ export default {
                 3
             ],
             "update": [
-                364
+                367
             ],
             "__typename": [
                 1
@@ -9474,16 +9564,16 @@ export default {
                 3
             ],
             "viewFields": [
-                370
+                373
             ],
             "viewFilters": [
-                371
+                374
             ],
             "viewFilterGroups": [
-                372
+                375
             ],
             "viewSorts": [
-                373
+                376
             ],
             "__typename": [
                 1
@@ -9594,7 +9684,7 @@ export default {
                 3
             ],
             "update": [
-                376
+                379
             ],
             "__typename": [
                 1
@@ -9632,7 +9722,7 @@ export default {
                 3
             ],
             "update": [
-                380
+                383
             ],
             "__typename": [
                 1
@@ -9708,7 +9798,7 @@ export default {
                 3
             ],
             "update": [
-                385
+                388
             ],
             "__typename": [
                 1
@@ -9772,10 +9862,10 @@ export default {
                 3
             ],
             "groups": [
-                390
+                393
             ],
             "fields": [
-                391
+                394
             ],
             "__typename": [
                 1
@@ -9795,7 +9885,7 @@ export default {
                 6
             ],
             "fields": [
-                391
+                394
             ],
             "__typename": [
                 1
@@ -9963,7 +10053,7 @@ export default {
                 3
             ],
             "tabs": [
-                403
+                406
             ],
             "__typename": [
                 1
@@ -9986,7 +10076,7 @@ export default {
                 89
             ],
             "widgets": [
-                404
+                407
             ],
             "__typename": [
                 1
@@ -10009,7 +10099,7 @@ export default {
                 3
             ],
             "gridPosition": [
-                405
+                408
             ],
             "position": [
                 15
@@ -10058,7 +10148,7 @@ export default {
                 3
             ],
             "gridPosition": [
-                405
+                408
             ],
             "position": [
                 15
@@ -10084,7 +10174,7 @@ export default {
                 3
             ],
             "gridPosition": [
-                405
+                408
             ],
             "position": [
                 15
@@ -10177,7 +10267,7 @@ export default {
         },
         "CreateOneObjectInput": {
             "object": [
-                411
+                414
             ],
             "__typename": [
                 1
@@ -10237,7 +10327,7 @@ export default {
         },
         "UpdateOneObjectInput": {
             "update": [
-                414
+                417
             ],
             "id": [
                 3
@@ -10292,7 +10382,7 @@ export default {
         },
         "CreateOneIndexInput": {
             "index": [
-                416
+                419
             ],
             "__typename": [
                 1
@@ -10303,7 +10393,7 @@ export default {
                 3
             ],
             "fields": [
-                417
+                420
             ],
             "indexType": [
                 48
@@ -10388,7 +10478,7 @@ export default {
                 3
             ],
             "update": [
-                422
+                425
             ],
             "__typename": [
                 1
@@ -10548,7 +10638,7 @@ export default {
                 3
             ],
             "update": [
-                427
+                430
             ],
             "__typename": [
                 1
@@ -10652,7 +10742,7 @@ export default {
         },
         "CreateOneFieldMetadataInput": {
             "field": [
-                431
+                434
             ],
             "__typename": [
                 1
@@ -10725,7 +10815,7 @@ export default {
                 3
             ],
             "update": [
-                433
+                436
             ],
             "__typename": [
                 1
@@ -10820,7 +10910,7 @@ export default {
                 3
             ],
             "update": [
-                437
+                440
             ],
             "__typename": [
                 1
@@ -10861,7 +10951,7 @@ export default {
         },
         "WorkspaceMigrationInput": {
             "actions": [
-                441
+                444
             ],
             "__typename": [
                 1
@@ -10869,10 +10959,10 @@ export default {
         },
         "WorkspaceMigrationDeleteActionInput": {
             "type": [
-                442
+                445
             ],
             "metadataName": [
-                334
+                337
             ],
             "universalIdentifier": [
                 1
@@ -10928,7 +11018,7 @@ export default {
         },
         "UpdateRoleInput": {
             "update": [
-                445
+                448
             ],
             "id": [
                 3
@@ -10983,7 +11073,7 @@ export default {
                 3
             ],
             "objectPermissions": [
-                447
+                450
             ],
             "__typename": [
                 1
@@ -11025,7 +11115,7 @@ export default {
                 3
             ],
             "fieldPermissions": [
-                450
+                453
             ],
             "__typename": [
                 1
@@ -11056,10 +11146,10 @@ export default {
                 3
             ],
             "predicates": [
-                452
+                455
             ],
             "predicateGroups": [
-                453
+                456
             ],
             "__typename": [
                 1
@@ -11139,7 +11229,7 @@ export default {
                 1
             ],
             "update": [
-                456
+                459
             ],
             "__typename": [
                 1
@@ -11190,7 +11280,7 @@ export default {
                 1
             ],
             "update": [
-                459
+                462
             ],
             "__typename": [
                 1
@@ -11270,7 +11360,7 @@ export default {
                 1
             ],
             "visibility": [
-                288
+                291
             ],
             "__typename": [
                 1
@@ -11287,7 +11377,7 @@ export default {
                 1
             ],
             "visibility": [
-                288
+                291
             ],
             "__typename": [
                 1
@@ -11298,7 +11388,7 @@ export default {
                 3
             ],
             "update": [
-                465
+                468
             ],
             "__typename": [
                 1
@@ -11306,16 +11396,16 @@ export default {
         },
         "UpdateMessageChannelInputUpdates": {
             "visibility": [
-                275
+                278
             ],
             "isContactAutoCreationEnabled": [
                 6
             ],
             "contactAutoCreationPolicy": [
-                277
+                280
             ],
             "messageFolderImportPolicy": [
-                278
+                281
             ],
             "isSyncEnabled": [
                 6
@@ -11382,7 +11472,7 @@ export default {
                 3
             ],
             "update": [
-                471
+                474
             ],
             "__typename": [
                 1
@@ -11410,7 +11500,7 @@ export default {
                 3
             ],
             "update": [
-                473
+                476
             ],
             "__typename": [
                 1
@@ -11429,7 +11519,7 @@ export default {
                 3
             ],
             "update": [
-                473
+                476
             ],
             "__typename": [
                 1
@@ -11440,7 +11530,7 @@ export default {
                 3
             ],
             "update": [
-                476
+                479
             ],
             "__typename": [
                 1
@@ -11448,13 +11538,13 @@ export default {
         },
         "UpdateCalendarChannelInputUpdates": {
             "visibility": [
-                329
+                332
             ],
             "isContactAutoCreationEnabled": [
                 6
             ],
             "contactAutoCreationPolicy": [
-                330
+                333
             ],
             "isSyncEnabled": [
                 6
@@ -11677,7 +11767,7 @@ export default {
                 1
             ],
             "files": [
-                490
+                493
             ],
             "__typename": [
                 1
@@ -11696,13 +11786,13 @@ export default {
         },
         "EmailAccountConnectionParameters": {
             "IMAP": [
-                492
+                495
             ],
             "SMTP": [
-                492
+                495
             ],
             "CALDAV": [
-                492
+                495
             ],
             "__typename": [
                 1
@@ -11741,7 +11831,7 @@ export default {
         },
         "CreateOneAppTokenInput": {
             "appToken": [
-                495
+                498
             ],
             "__typename": [
                 1
@@ -11770,13 +11860,13 @@ export default {
                 235,
                 {
                     "input": [
-                        498,
+                        501,
                         "LogicFunctionLogsInput!"
                     ]
                 }
             ],
             "onAgentChatEvent": [
-                322,
+                325,
                 {
                     "threadId": [
                         3,
@@ -11785,10 +11875,10 @@ export default {
                 }
             ],
             "eventLogsLive": [
-                312,
+                315,
                 {
                     "table": [
-                        345,
+                        348,
                         "EventLogTable!"
                     ]
                 }

--- a/packages/twenty-front/src/generated-metadata/graphql.ts
+++ b/packages/twenty-front/src/generated-metadata/graphql.ts
@@ -394,6 +394,37 @@ export type ApplicationRegistrationVariableDto = {
   value?: Maybe<Scalars['String']['output']>;
 };
 
+export type ApplicationSyncPlan = {
+  __typename?: 'ApplicationSyncPlan';
+  actions: Array<ApplicationSyncPlanAction>;
+  applicationUniversalIdentifier: Scalars['String']['output'];
+  currentVersion?: Maybe<Scalars['String']['output']>;
+  hasDestructiveActions: Scalars['Boolean']['output'];
+  isEmpty: Scalars['Boolean']['output'];
+  proposedVersion: Scalars['String']['output'];
+  summary: ApplicationSyncPlanSummary;
+};
+
+export type ApplicationSyncPlanAction = {
+  __typename?: 'ApplicationSyncPlanAction';
+  affectedRowCount?: Maybe<Scalars['Int']['output']>;
+  label?: Maybe<Scalars['String']['output']>;
+  metadataName: Scalars['String']['output'];
+  severity: Scalars['String']['output'];
+  type: Scalars['String']['output'];
+  universalIdentifier?: Maybe<Scalars['String']['output']>;
+};
+
+export type ApplicationSyncPlanSummary = {
+  __typename?: 'ApplicationSyncPlanSummary';
+  breakingCount: Scalars['Int']['output'];
+  createCount: Scalars['Int']['output'];
+  deleteCount: Scalars['Int']['output'];
+  destructiveCount: Scalars['Int']['output'];
+  totalAffectedRows: Scalars['Int']['output'];
+  updateCount: Scalars['Int']['output'];
+};
+
 export type ApplicationTokenPair = {
   __typename?: 'ApplicationTokenPair';
   applicationAccessToken: AuthToken;
@@ -2595,6 +2626,7 @@ export type Mutation = {
   installApplication: Application;
   /** @deprecated Use installApplication instead */
   installMarketplaceApp: Scalars['Boolean']['output'];
+  planApplicationSync: ApplicationSyncPlan;
   refreshEnterpriseValidityToken: Scalars['Boolean']['output'];
   removeQueryFromEventStream: Scalars['Boolean']['output'];
   removeRoleFromAgent: Scalars['Boolean']['output'];
@@ -3272,6 +3304,13 @@ export type MutationInstallMarketplaceAppArgs = {
 };
 
 
+export type MutationPlanApplicationSyncArgs = {
+  allowDestructive?: InputMaybe<Scalars['Boolean']['input']>;
+  dryRun?: InputMaybe<Scalars['Boolean']['input']>;
+  manifest: Scalars['JSON']['input'];
+};
+
+
 export type MutationRemoveQueryFromEventStreamArgs = {
   input: RemoveQueryFromEventStreamInput;
 };
@@ -3449,6 +3488,7 @@ export type MutationStopAgentChatStreamArgs = {
 
 
 export type MutationSyncApplicationArgs = {
+  allowDestructive?: InputMaybe<Scalars['Boolean']['input']>;
   dryRun?: InputMaybe<Scalars['Boolean']['input']>;
   manifest: Scalars['JSON']['input'];
 };

--- a/packages/twenty-sdk/src/cli/commands/dev/dev-once.ts
+++ b/packages/twenty-sdk/src/cli/commands/dev/dev-once.ts
@@ -8,6 +8,7 @@ export type AppDevOnceCommandOptions = {
   appPath?: string;
   verbose?: boolean;
   dryRun?: boolean;
+  allowDestructive?: boolean;
 };
 
 export class AppDevOnceCommand {
@@ -29,6 +30,7 @@ export class AppDevOnceCommand {
       appPath,
       verbose: options.verbose,
       dryRun: options.dryRun,
+      allowDestructive: options.allowDestructive,
       onProgress: (message) => console.log(chalk.gray(message)),
     });
 

--- a/packages/twenty-sdk/src/cli/commands/dev/index.ts
+++ b/packages/twenty-sdk/src/cli/commands/dev/index.ts
@@ -28,6 +28,7 @@ export const registerDevCommands = (program: Command): void => {
       debug?: boolean;
       debounceMs?: string;
       dryRun?: boolean;
+      allowDestructive?: boolean;
     },
   ) => {
     if (options.dryRun && !options.once) {
@@ -50,6 +51,7 @@ export const registerDevCommands = (program: Command): void => {
       await devOnceCommand.execute({
         ...commonOptions,
         dryRun: options.dryRun,
+        allowDestructive: options.allowDestructive,
       });
 
       return;
@@ -68,6 +70,10 @@ export const registerDevCommands = (program: Command): void => {
     .option(
       '--dry-run',
       'Preview the metadata changes without applying them (requires --once)',
+    )
+    .option(
+      '--allow-destructive',
+      'Allow a --once deploy to apply destructive changes that permanently delete data',
     )
     .option('--debounceMs <ms>', 'Debounce in ms (default: 1 000)')
     .option('-v, --verbose', 'Show detailed logs')

--- a/packages/twenty-sdk/src/cli/operations/dev-once.ts
+++ b/packages/twenty-sdk/src/cli/operations/dev-once.ts
@@ -28,6 +28,7 @@ export type AppDevOnceOptions = {
   appPath: string;
   verbose?: boolean;
   dryRun?: boolean;
+  allowDestructive?: boolean;
   onProgress?: (message: string) => void;
 };
 
@@ -59,7 +60,7 @@ const appendRecoveryHint = (
 const innerAppDevOnce = async (
   options: AppDevOnceOptions,
 ): Promise<CommandResult<AppDevOnceResult>> => {
-  const { appPath, onProgress, verbose, dryRun } = options;
+  const { appPath, onProgress, verbose, dryRun, allowDestructive } = options;
 
   onProgress?.('Checking server...');
 
@@ -263,7 +264,9 @@ const innerAppDevOnce = async (
 
   onProgress?.('Syncing manifest...');
 
-  const syncResult = await apiService.syncApplication(manifest);
+  const syncResult = await apiService.syncApplication(manifest, {
+    allowDestructive,
+  });
 
   if (!syncResult.success) {
     const errorEvents = verbose

--- a/packages/twenty-sdk/src/cli/utilities/api/api-service.ts
+++ b/packages/twenty-sdk/src/cli/utilities/api/api-service.ts
@@ -78,7 +78,7 @@ export class ApiService {
 
   syncApplication(
     manifest: Manifest,
-    options?: { dryRun?: boolean },
+    options?: { dryRun?: boolean; allowDestructive?: boolean },
   ): Promise<
     ApiResponse<
       {

--- a/packages/twenty-sdk/src/cli/utilities/api/application-api.ts
+++ b/packages/twenty-sdk/src/cli/utilities/api/application-api.ts
@@ -258,7 +258,7 @@ export class ApplicationApi {
 
   async syncApplication(
     manifest: Manifest,
-    options?: { dryRun?: boolean },
+    options?: { dryRun?: boolean; allowDestructive?: boolean },
   ): Promise<
     ApiResponse<
       {
@@ -269,27 +269,28 @@ export class ApplicationApi {
     >
   > {
     try {
-      const isDryRun = options?.dryRun ?? false;
-
-      const mutation = isDryRun
-        ? `
-        mutation SyncApplication($manifest: JSON!, $dryRun: Boolean) {
-          syncApplication(manifest: $manifest, dryRun: $dryRun) {
-            applicationUniversalIdentifier
-            actions
-          }
-        }
-      `
-        : `
-        mutation SyncApplication($manifest: JSON!) {
-          syncApplication(manifest: $manifest) {
+      const mutation = `
+        mutation SyncApplication(
+          $manifest: JSON!
+          $dryRun: Boolean
+          $allowDestructive: Boolean
+        ) {
+          syncApplication(
+            manifest: $manifest
+            dryRun: $dryRun
+            allowDestructive: $allowDestructive
+          ) {
             applicationUniversalIdentifier
             actions
           }
         }
       `;
 
-      const variables = isDryRun ? { manifest, dryRun: true } : { manifest };
+      const variables = {
+        manifest,
+        dryRun: options?.dryRun ?? false,
+        allowDestructive: options?.allowDestructive ?? false,
+      };
 
       const response = await this.client.post(
         '/metadata',

--- a/packages/twenty-sdk/src/cli/utilities/dev/orchestrator/steps/sync-application-orchestrator-step.ts
+++ b/packages/twenty-sdk/src/cli/utilities/dev/orchestrator/steps/sync-application-orchestrator-step.ts
@@ -67,7 +67,9 @@ export class SyncApplicationOrchestratorStep {
     });
     events.push({ message: 'Syncing manifest', status: 'info' });
 
-    const syncResult = await this.apiService.syncApplication(manifest);
+    const syncResult = await this.apiService.syncApplication(manifest, {
+      allowDestructive: true,
+    });
 
     if (syncResult.success) {
       const syncData = syncResult.data;

--- a/packages/twenty-server/src/database/commands/upgrade-version-command/2-18/2-18-instance-command-fast-1801000110000-add-deploy-serial-to-application.ts
+++ b/packages/twenty-server/src/database/commands/upgrade-version-command/2-18/2-18-instance-command-fast-1801000110000-add-deploy-serial-to-application.ts
@@ -1,0 +1,21 @@
+import { type QueryRunner } from 'typeorm';
+
+import { RegisteredInstanceCommand } from 'src/engine/core-modules/upgrade/decorators/registered-instance-command.decorator';
+import { type FastInstanceCommand } from 'src/engine/core-modules/upgrade/interfaces/fast-instance-command.interface';
+
+@RegisteredInstanceCommand('2.18.0', 1801000110000)
+export class AddDeploySerialToApplicationFastInstanceCommand
+  implements FastInstanceCommand
+{
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      'ALTER TABLE "core"."application" ADD "deploySerial" integer',
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      'ALTER TABLE "core"."application" DROP COLUMN "deploySerial"',
+    );
+  }
+}

--- a/packages/twenty-server/src/database/commands/upgrade-version-command/instance-commands.constant.ts
+++ b/packages/twenty-server/src/database/commands/upgrade-version-command/instance-commands.constant.ts
@@ -82,6 +82,7 @@ import { MakePublicDomainApplicationIdNotNullSlowInstanceCommand } from 'src/dat
 import { AddServerTriggerSettingsToLogicFunctionFastInstanceCommand } from 'src/database/commands/upgrade-version-command/2-16/2-16-instance-command-fast-1782211913427-add-server-trigger-settings-to-logic-function';
 import { CreateDpaAgreementCoreTableFastInstanceCommand } from 'src/database/commands/upgrade-version-command/2-17/2-17-instance-command-fast-1801000020000-create-dpa-agreement-core-table';
 import { CreateApplicationTranslationCoreTableFastInstanceCommand } from 'src/database/commands/upgrade-version-command/2-17/2-17-instance-command-fast-1801000100000-create-application-translation-core-table';
+import { AddDeploySerialToApplicationFastInstanceCommand } from 'src/database/commands/upgrade-version-command/2-18/2-18-instance-command-fast-1801000110000-add-deploy-serial-to-application';
 
 export const INSTANCE_COMMANDS = [
   AddViewFieldGroupIdIndexOnViewFieldFastInstanceCommand,
@@ -166,4 +167,5 @@ export const INSTANCE_COMMANDS = [
   MakePublicDomainApplicationIdNotNullSlowInstanceCommand,
   CreateDpaAgreementCoreTableFastInstanceCommand,
   CreateApplicationTranslationCoreTableFastInstanceCommand,
+  AddDeploySerialToApplicationFastInstanceCommand,
 ];

--- a/packages/twenty-server/src/engine/core-modules/application/application-deploy/application-deploy-plan.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/application/application-deploy/application-deploy-plan.service.ts
@@ -95,18 +95,18 @@ export class ApplicationDeployPlanService {
     const isEmpty = actions.length === 0;
     const nextSerial = isEmpty ? currentSerial : currentSerial + 1;
 
+    const summary = this.buildSummary(actions);
+
     return {
       applicationUniversalIdentifier: manifest.application.universalIdentifier,
       actions,
-      summary: this.buildSummary(actions),
+      summary,
       currentVersion: isDefined(application.deploySerial)
         ? renderDeploySerial(application.deploySerial)
         : null,
       proposedVersion: renderDeploySerial(nextSerial),
       isEmpty,
-      hasDestructiveActions: actions.some(
-        (action) => action.severity === 'destructive',
-      ),
+      hasDestructiveActions: summary.destructiveCount > 0,
     };
   }
 
@@ -224,7 +224,7 @@ export class ApplicationDeployPlanService {
     });
 
     return this.runCount(
-      `SELECT count(*)::int AS count FROM "${schemaName}"."${tableName}"`,
+      `SELECT count(*)::bigint AS count FROM "${schemaName}"."${tableName}"`,
     );
   }
 
@@ -257,7 +257,7 @@ export class ApplicationDeployPlanService {
       .join(' OR ');
 
     return this.runCount(
-      `SELECT count(*)::int AS count FROM "${schemaName}"."${tableName}" WHERE ${notNullPredicate}`,
+      `SELECT count(*)::bigint AS count FROM "${schemaName}"."${tableName}" WHERE ${notNullPredicate}`,
     );
   }
 
@@ -280,19 +280,27 @@ export class ApplicationDeployPlanService {
   private buildSummary(
     actions: ApplicationSyncPlanActionDTO[],
   ): ApplicationSyncPlanSummaryDTO {
-    return {
-      createCount: actions.filter((action) => action.type === 'create').length,
-      updateCount: actions.filter((action) => action.type === 'update').length,
-      deleteCount: actions.filter((action) => action.type === 'delete').length,
-      breakingCount: actions.filter((action) => action.severity === 'breaking')
-        .length,
-      destructiveCount: actions.filter(
-        (action) => action.severity === 'destructive',
-      ).length,
-      totalAffectedRows: actions.reduce(
-        (total, action) => total + (action.affectedRowCount ?? 0),
-        0,
-      ),
-    };
+    return actions.reduce<ApplicationSyncPlanSummaryDTO>(
+      (summary, action) => ({
+        createCount: summary.createCount + (action.type === 'create' ? 1 : 0),
+        updateCount: summary.updateCount + (action.type === 'update' ? 1 : 0),
+        deleteCount: summary.deleteCount + (action.type === 'delete' ? 1 : 0),
+        breakingCount:
+          summary.breakingCount + (action.severity === 'breaking' ? 1 : 0),
+        destructiveCount:
+          summary.destructiveCount +
+          (action.severity === 'destructive' ? 1 : 0),
+        totalAffectedRows:
+          summary.totalAffectedRows + (action.affectedRowCount ?? 0),
+      }),
+      {
+        createCount: 0,
+        updateCount: 0,
+        deleteCount: 0,
+        breakingCount: 0,
+        destructiveCount: 0,
+        totalAffectedRows: 0,
+      },
+    );
   }
 }

--- a/packages/twenty-server/src/engine/core-modules/application/application-deploy/application-deploy-plan.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/application/application-deploy/application-deploy-plan.service.ts
@@ -1,0 +1,298 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { InjectDataSource } from '@nestjs/typeorm';
+
+import { type Manifest } from 'twenty-shared/application';
+import { DataSource } from 'typeorm';
+import { ALL_METADATA_NAME } from 'twenty-shared/metadata';
+import { isDefined } from 'twenty-shared/utils';
+
+import {
+  type ApplicationSyncPlanActionDTO,
+  type ApplicationSyncPlanDTO,
+  type ApplicationSyncPlanSummaryDTO,
+} from 'src/engine/core-modules/application/application-development/dtos/application-sync-plan.dto';
+import {
+  type ApplicationDeployActionSeverity,
+  classifyApplicationDeployActionSeverity,
+} from 'src/engine/core-modules/application/application-deploy/utils/classify-application-deploy-action-severity.util';
+import { ApplicationSyncService } from 'src/engine/core-modules/application/application-manifest/application-sync.service';
+import { ApplicationService } from 'src/engine/core-modules/application/application.service';
+import { findFlatEntityByUniversalIdentifier } from 'src/engine/metadata-modules/flat-entity/utils/find-flat-entity-by-universal-identifier.util';
+import { getMetadataFlatEntityMapsKey } from 'src/engine/metadata-modules/flat-entity/utils/get-metadata-flat-entity-maps-key.util';
+import { type FlatFieldMetadata } from 'src/engine/metadata-modules/flat-field-metadata/types/flat-field-metadata.type';
+import { type FlatObjectMetadata } from 'src/engine/metadata-modules/flat-object-metadata/types/flat-object-metadata.type';
+import { type UniversalFlatEntityMaps } from 'src/engine/workspace-manager/workspace-migration/universal-flat-entity/types/universal-flat-entity-maps.type';
+import { WorkspaceCacheService } from 'src/engine/workspace-cache/services/workspace-cache.service';
+import { type AllUniversalWorkspaceMigrationAction } from 'src/engine/workspace-manager/workspace-migration/workspace-migration-builder/types/workspace-migration-action-common';
+import { generateColumnDefinitions } from 'src/engine/workspace-manager/workspace-migration/workspace-migration-runner/utils/generate-column-definitions.util';
+import { getWorkspaceSchemaContextForMigration } from 'src/engine/workspace-manager/workspace-migration/workspace-migration-runner/utils/get-workspace-schema-context-for-migration.util';
+
+export const renderDeploySerial = (serial: number): string => `0.0.${serial}`;
+
+const getActionUniversalIdentifier = (
+  action: AllUniversalWorkspaceMigrationAction,
+): string =>
+  action.type === 'create'
+    ? action.flatEntity.universalIdentifier
+    : action.universalIdentifier;
+
+type DeployPlanMaps = {
+  flatFieldMetadataMaps: UniversalFlatEntityMaps<FlatFieldMetadata>;
+  flatObjectMetadataMaps: UniversalFlatEntityMaps<FlatObjectMetadata>;
+};
+
+@Injectable()
+export class ApplicationDeployPlanService {
+  private readonly logger = new Logger(ApplicationDeployPlanService.name);
+
+  constructor(
+    private readonly applicationService: ApplicationService,
+    private readonly applicationSyncService: ApplicationSyncService,
+    private readonly workspaceCacheService: WorkspaceCacheService,
+    @InjectDataSource()
+    private readonly coreDataSource: DataSource,
+  ) {}
+
+  public async computePlan({
+    workspaceId,
+    manifest,
+  }: {
+    workspaceId: string;
+    manifest: Manifest;
+  }): Promise<ApplicationSyncPlanDTO> {
+    const application = await this.applicationService.findOneApplicationOrThrow(
+      {
+        universalIdentifier: manifest.application.universalIdentifier,
+        workspaceId,
+      },
+    );
+
+    const { workspaceMigration } =
+      await this.applicationSyncService.synchronizeFromManifest({
+        workspaceId,
+        manifest,
+        dryRun: true,
+      });
+
+    const { flatFieldMetadataMaps, flatObjectMetadataMaps } =
+      await this.workspaceCacheService.getOrRecompute(workspaceId, [
+        getMetadataFlatEntityMapsKey(ALL_METADATA_NAME.fieldMetadata),
+        getMetadataFlatEntityMapsKey(ALL_METADATA_NAME.objectMetadata),
+      ]);
+
+    const maps: DeployPlanMaps = {
+      flatFieldMetadataMaps,
+      flatObjectMetadataMaps,
+    };
+
+    const actions = await Promise.all(
+      workspaceMigration.actions.map((action) =>
+        this.buildPlanAction({ action, workspaceId, maps }),
+      ),
+    );
+
+    const currentSerial = application.deploySerial ?? 0;
+    const isEmpty = actions.length === 0;
+    const nextSerial = isEmpty ? currentSerial : currentSerial + 1;
+
+    return {
+      applicationUniversalIdentifier: manifest.application.universalIdentifier,
+      actions,
+      summary: this.buildSummary(actions),
+      currentVersion: isDefined(application.deploySerial)
+        ? renderDeploySerial(application.deploySerial)
+        : null,
+      proposedVersion: renderDeploySerial(nextSerial),
+      isEmpty,
+      hasDestructiveActions: actions.some(
+        (action) => action.severity === 'destructive',
+      ),
+    };
+  }
+
+  private async buildPlanAction({
+    action,
+    workspaceId,
+    maps,
+  }: {
+    action: AllUniversalWorkspaceMigrationAction;
+    workspaceId: string;
+    maps: DeployPlanMaps;
+  }): Promise<ApplicationSyncPlanActionDTO> {
+    const universalIdentifier = getActionUniversalIdentifier(action);
+
+    const severity = classifyApplicationDeployActionSeverity({
+      action,
+      getCurrentEnumOptions: (fieldUniversalIdentifier) =>
+        findFlatEntityByUniversalIdentifier({
+          flatEntityMaps: maps.flatFieldMetadataMaps,
+          universalIdentifier: fieldUniversalIdentifier,
+        })?.options ?? null,
+    });
+
+    const { label, affectedRowCount } = await this.resolveLabelAndRowCount({
+      action,
+      universalIdentifier,
+      severity,
+      workspaceId,
+      maps,
+    });
+
+    return {
+      type: action.type,
+      metadataName: action.metadataName,
+      universalIdentifier,
+      label,
+      severity,
+      affectedRowCount,
+    };
+  }
+
+  private async resolveLabelAndRowCount({
+    action,
+    universalIdentifier,
+    severity,
+    workspaceId,
+    maps,
+  }: {
+    action: AllUniversalWorkspaceMigrationAction;
+    universalIdentifier: string;
+    severity: ApplicationDeployActionSeverity;
+    workspaceId: string;
+    maps: DeployPlanMaps;
+  }): Promise<{ label: string | null; affectedRowCount: number | null }> {
+    if (action.metadataName === ALL_METADATA_NAME.objectMetadata) {
+      const flatObjectMetadata = findFlatEntityByUniversalIdentifier({
+        flatEntityMaps: maps.flatObjectMetadataMaps,
+        universalIdentifier,
+      });
+
+      const label = flatObjectMetadata?.nameSingular ?? universalIdentifier;
+
+      const affectedRowCount =
+        action.type === 'delete' && isDefined(flatObjectMetadata)
+          ? await this.countObjectRows({ workspaceId, flatObjectMetadata })
+          : null;
+
+      return { label, affectedRowCount };
+    }
+
+    if (action.metadataName === ALL_METADATA_NAME.fieldMetadata) {
+      const flatFieldMetadata = findFlatEntityByUniversalIdentifier({
+        flatEntityMaps: maps.flatFieldMetadataMaps,
+        universalIdentifier,
+      });
+
+      const flatObjectMetadata = isDefined(flatFieldMetadata)
+        ? Object.values(maps.flatObjectMetadataMaps.byUniversalIdentifier).find(
+            (candidate) => candidate?.id === flatFieldMetadata.objectMetadataId,
+          )
+        : undefined;
+
+      const label = isDefined(flatFieldMetadata)
+        ? `${flatObjectMetadata?.nameSingular ?? '?'}.${flatFieldMetadata.name}`
+        : universalIdentifier;
+
+      const affectedRowCount =
+        severity === 'destructive' &&
+        action.type === 'delete' &&
+        isDefined(flatFieldMetadata) &&
+        isDefined(flatObjectMetadata)
+          ? await this.countFieldRows({
+              workspaceId,
+              flatFieldMetadata,
+              flatObjectMetadata,
+            })
+          : null;
+
+      return { label, affectedRowCount };
+    }
+
+    return { label: universalIdentifier, affectedRowCount: null };
+  }
+
+  private async countObjectRows({
+    workspaceId,
+    flatObjectMetadata,
+  }: {
+    workspaceId: string;
+    flatObjectMetadata: FlatObjectMetadata;
+  }): Promise<number | null> {
+    const { schemaName, tableName } = getWorkspaceSchemaContextForMigration({
+      workspaceId,
+      objectMetadata: flatObjectMetadata,
+    });
+
+    return this.runCount(
+      `SELECT count(*)::int AS count FROM "${schemaName}"."${tableName}"`,
+    );
+  }
+
+  private async countFieldRows({
+    workspaceId,
+    flatFieldMetadata,
+    flatObjectMetadata,
+  }: {
+    workspaceId: string;
+    flatFieldMetadata: FlatFieldMetadata;
+    flatObjectMetadata: FlatObjectMetadata;
+  }): Promise<number | null> {
+    const { schemaName, tableName } = getWorkspaceSchemaContextForMigration({
+      workspaceId,
+      objectMetadata: flatObjectMetadata,
+    });
+
+    const columnNames = generateColumnDefinitions({
+      flatFieldMetadata,
+      flatObjectMetadata,
+      workspaceId,
+    }).map((columnDefinition) => columnDefinition.name);
+
+    if (columnNames.length === 0) {
+      return null;
+    }
+
+    const notNullPredicate = columnNames
+      .map((columnName) => `"${columnName}" IS NOT NULL`)
+      .join(' OR ');
+
+    return this.runCount(
+      `SELECT count(*)::int AS count FROM "${schemaName}"."${tableName}" WHERE ${notNullPredicate}`,
+    );
+  }
+
+  private async runCount(query: string): Promise<number | null> {
+    try {
+      const result = await this.coreDataSource.query(query);
+
+      const count = Number(result?.[0]?.count);
+
+      return Number.isFinite(count) ? count : null;
+    } catch (error) {
+      this.logger.warn(
+        `Failed to count affected rows for deploy plan: ${error instanceof Error ? error.message : String(error)}`,
+      );
+
+      return null;
+    }
+  }
+
+  private buildSummary(
+    actions: ApplicationSyncPlanActionDTO[],
+  ): ApplicationSyncPlanSummaryDTO {
+    return {
+      createCount: actions.filter((action) => action.type === 'create').length,
+      updateCount: actions.filter((action) => action.type === 'update').length,
+      deleteCount: actions.filter((action) => action.type === 'delete').length,
+      breakingCount: actions.filter((action) => action.severity === 'breaking')
+        .length,
+      destructiveCount: actions.filter(
+        (action) => action.severity === 'destructive',
+      ).length,
+      totalAffectedRows: actions.reduce(
+        (total, action) => total + (action.affectedRowCount ?? 0),
+        0,
+      ),
+    };
+  }
+}

--- a/packages/twenty-server/src/engine/core-modules/application/application-deploy/utils/classify-application-deploy-action-severity.util.ts
+++ b/packages/twenty-server/src/engine/core-modules/application/application-deploy/utils/classify-application-deploy-action-severity.util.ts
@@ -64,10 +64,7 @@ export const classifyApplicationDeployActionSeverity = ({
       }
     }
 
-    if (
-      changedProperties.includes('name') ||
-      changedProperties.includes('type')
-    ) {
+    if (changedProperties.includes('name')) {
       return 'breaking';
     }
 

--- a/packages/twenty-server/src/engine/core-modules/application/application-deploy/utils/classify-application-deploy-action-severity.util.ts
+++ b/packages/twenty-server/src/engine/core-modules/application/application-deploy/utils/classify-application-deploy-action-severity.util.ts
@@ -1,0 +1,89 @@
+import { ALL_METADATA_NAME } from 'twenty-shared/metadata';
+import { isDefined } from 'twenty-shared/utils';
+
+import { type AllUniversalWorkspaceMigrationAction } from 'src/engine/workspace-manager/workspace-migration/workspace-migration-builder/types/workspace-migration-action-common';
+
+export type ApplicationDeployActionSeverity =
+  | 'safe'
+  | 'breaking'
+  | 'destructive';
+
+type DeployActionOption = { id?: string | null };
+
+type CurrentEnumOptionsResolver = (
+  universalIdentifier: string,
+) => DeployActionOption[] | null;
+
+const hasRemovedEnumOption = (
+  currentOptions: DeployActionOption[] | null,
+  nextOptions: DeployActionOption[] | null,
+): boolean => {
+  if (!isDefined(currentOptions) || !isDefined(nextOptions)) {
+    return false;
+  }
+
+  const nextOptionIds = new Set(
+    nextOptions.map((option) => option.id).filter(isDefined),
+  );
+
+  return currentOptions.some(
+    (option) => isDefined(option.id) && !nextOptionIds.has(option.id),
+  );
+};
+
+export const classifyApplicationDeployActionSeverity = ({
+  action,
+  getCurrentEnumOptions,
+}: {
+  action: AllUniversalWorkspaceMigrationAction;
+  getCurrentEnumOptions: CurrentEnumOptionsResolver;
+}): ApplicationDeployActionSeverity => {
+  const isFieldAction = action.metadataName === ALL_METADATA_NAME.fieldMetadata;
+  const isObjectAction =
+    action.metadataName === ALL_METADATA_NAME.objectMetadata;
+
+  if (action.type === 'delete') {
+    return isFieldAction || isObjectAction ? 'destructive' : 'safe';
+  }
+
+  if (action.type === 'create') {
+    return 'safe';
+  }
+
+  const changedProperties = Object.keys(action.update ?? {});
+
+  if (isFieldAction) {
+    if (changedProperties.includes('options')) {
+      const nextOptions =
+        (action.update as { options?: DeployActionOption[] | null }).options ??
+        null;
+      const currentOptions = getCurrentEnumOptions(action.universalIdentifier);
+
+      if (hasRemovedEnumOption(currentOptions, nextOptions)) {
+        return 'destructive';
+      }
+    }
+
+    if (
+      changedProperties.includes('name') ||
+      changedProperties.includes('type')
+    ) {
+      return 'breaking';
+    }
+
+    return 'safe';
+  }
+
+  if (isObjectAction) {
+    if (
+      changedProperties.includes('nameSingular') ||
+      changedProperties.includes('namePlural')
+    ) {
+      return 'breaking';
+    }
+
+    return 'safe';
+  }
+
+  return 'safe';
+};

--- a/packages/twenty-server/src/engine/core-modules/application/application-development/application-development.module.ts
+++ b/packages/twenty-server/src/engine/core-modules/application/application-development/application-development.module.ts
@@ -1,6 +1,7 @@
 import { Module } from '@nestjs/common';
 
 import { ApplicationRegistrationModule } from 'src/engine/core-modules/application/application-registration/application-registration.module';
+import { ApplicationDeployPlanService } from 'src/engine/core-modules/application/application-deploy/application-deploy-plan.service';
 import { ApplicationManifestModule } from 'src/engine/core-modules/application/application-manifest/application-manifest.module';
 import { ApplicationModule } from 'src/engine/core-modules/application/application.module';
 import { ApplicationDevelopmentResolver } from 'src/engine/core-modules/application/application-development/application-development.resolver';
@@ -11,6 +12,7 @@ import { FileStorageModule } from 'src/engine/core-modules/file-storage/file-sto
 import { ThrottlerModule } from 'src/engine/core-modules/throttler/throttler.module';
 import { SdkClientModule } from 'src/engine/core-modules/sdk-client/sdk-client.module';
 import { PermissionsModule } from 'src/engine/metadata-modules/permissions/permissions.module';
+import { WorkspaceCacheModule } from 'src/engine/workspace-cache/workspace-cache.module';
 import { WorkspaceMigrationGraphqlApiExceptionInterceptor } from 'src/engine/workspace-manager/workspace-migration/interceptors/workspace-migration-graphql-api-exception.interceptor';
 
 @Module({
@@ -25,9 +27,11 @@ import { WorkspaceMigrationGraphqlApiExceptionInterceptor } from 'src/engine/wor
     FileStorageModule,
     PermissionsModule,
     ThrottlerModule,
+    WorkspaceCacheModule,
   ],
   providers: [
     ApplicationDevelopmentResolver,
+    ApplicationDeployPlanService,
     WorkspaceMigrationGraphqlApiExceptionInterceptor,
   ],
 })

--- a/packages/twenty-server/src/engine/core-modules/application/application-development/application-development.resolver.ts
+++ b/packages/twenty-server/src/engine/core-modules/application/application-development/application-development.resolver.ts
@@ -1,4 +1,5 @@
 import {
+  Logger,
   UseFilters,
   UseGuards,
   UseInterceptors,
@@ -14,7 +15,12 @@ import { isDefined } from 'twenty-shared/utils';
 import type { FileUpload } from 'graphql-upload/processRequest.mjs';
 
 import { MetadataResolver } from 'src/engine/api/graphql/graphql-config/decorators/metadata-resolver.decorator';
+import {
+  ApplicationDeployPlanService,
+  renderDeploySerial,
+} from 'src/engine/core-modules/application/application-deploy/application-deploy-plan.service';
 import { ApplicationInput } from 'src/engine/core-modules/application/application-development/dtos/application.input';
+import { ApplicationSyncPlanDTO } from 'src/engine/core-modules/application/application-development/dtos/application-sync-plan.dto';
 import { CreateDevelopmentApplicationInput } from 'src/engine/core-modules/application/application-development/dtos/create-development-application.input';
 import { DevelopmentApplicationDTO } from 'src/engine/core-modules/application/application-development/dtos/development-application.dto';
 import { GenerateApplicationTokenInput } from 'src/engine/core-modules/application/application-development/dtos/generate-application-token.input';
@@ -64,6 +70,8 @@ const APP_SYNC_LOCK_OPTIONS = { ttl: 60_000, ms: 500, maxRetries: 120 };
   SettingsPermissionGuard(PermissionFlagType.APPLICATIONS),
 )
 export class ApplicationDevelopmentResolver {
+  private readonly logger = new Logger(ApplicationDevelopmentResolver.name);
+
   constructor(
     private readonly applicationTokenService: ApplicationTokenService,
     private readonly applicationService: ApplicationService,
@@ -75,6 +83,7 @@ export class ApplicationDevelopmentResolver {
     private readonly twentyConfigService: TwentyConfigService,
     private readonly throttlerService: ThrottlerService,
     private readonly cacheLockService: CacheLockService,
+    private readonly applicationDeployPlanService: ApplicationDeployPlanService,
   ) {}
 
   @Mutation(() => DevelopmentApplicationDTO)
@@ -131,10 +140,27 @@ export class ApplicationDevelopmentResolver {
     });
   }
 
+  @Mutation(() => ApplicationSyncPlanDTO)
+  async planApplicationSync(
+    @Args() { manifest }: ApplicationInput,
+    @AuthWorkspace() { id: workspaceId }: WorkspaceEntity,
+  ): Promise<ApplicationSyncPlanDTO> {
+    await this.throttlePerApplication(
+      manifest.application.universalIdentifier,
+      workspaceId,
+    );
+
+    return this.applicationDeployPlanService.computePlan({
+      workspaceId,
+      manifest,
+    });
+  }
+
   @Mutation(() => WorkspaceMigrationDTO)
   async syncApplication(
-    @Args() { manifest, dryRun }: ApplicationInput,
+    @Args() { manifest, dryRun, allowDestructive }: ApplicationInput,
     @AuthWorkspace() { id: workspaceId }: WorkspaceEntity,
+    @AuthUserWorkspaceId({ allowUndefined: true }) userWorkspaceId?: string,
   ): Promise<WorkspaceMigrationDTO> {
     await this.throttlePerApplication(
       manifest.application.universalIdentifier,
@@ -157,7 +183,13 @@ export class ApplicationDevelopmentResolver {
     }
 
     return this.cacheLockService.withLock(
-      () => this.applyManifestSync(manifest, workspaceId),
+      () =>
+        this.applyManifestSync(
+          manifest,
+          workspaceId,
+          allowDestructive === true,
+          userWorkspaceId,
+        ),
       `app-sync:${workspaceId}`,
       APP_SYNC_LOCK_OPTIONS,
     );
@@ -166,6 +198,8 @@ export class ApplicationDevelopmentResolver {
   private async applyManifestSync(
     manifest: ApplicationInput['manifest'],
     workspaceId: string,
+    allowDestructive: boolean,
+    actorUserWorkspaceId: string | undefined,
   ): Promise<WorkspaceMigrationDTO> {
     const applicationRegistrationId = await this.findApplicationRegistrationId(
       manifest.application.universalIdentifier,
@@ -182,6 +216,33 @@ export class ApplicationDevelopmentResolver {
       throw new ApplicationException(
         `Application "${manifest.application.universalIdentifier}" not found in workspace "${workspaceId}". Run createDevelopmentApplication first.`,
         ApplicationExceptionCode.APPLICATION_NOT_FOUND,
+      );
+    }
+
+    const plan = await this.applicationDeployPlanService.computePlan({
+      workspaceId,
+      manifest,
+    });
+
+    if (plan.isEmpty) {
+      await this.syncRegistrationMetadata(
+        applicationRegistrationId,
+        manifest,
+        workspaceId,
+        application.id,
+      );
+
+      return {
+        applicationUniversalIdentifier:
+          manifest.application.universalIdentifier,
+        actions: [],
+      };
+    }
+
+    if (plan.hasDestructiveActions && !allowDestructive) {
+      throw new ApplicationException(
+        this.buildDestructiveChangesMessage(plan),
+        ApplicationExceptionCode.DESTRUCTIVE_CHANGES_NOT_APPROVED,
       );
     }
 
@@ -210,11 +271,34 @@ export class ApplicationDevelopmentResolver {
       application.id,
     );
 
+    const nextSerial = (application.deploySerial ?? 0) + 1;
+
+    await this.applicationService.update(application.id, {
+      workspaceId,
+      version: renderDeploySerial(nextSerial),
+      deploySerial: nextSerial,
+    });
+
+    if (plan.hasDestructiveActions) {
+      this.logger.log(
+        `Destructive application deploy applied — application=${manifest.application.universalIdentifier} workspace=${workspaceId} actor=${actorUserWorkspaceId ?? 'unknown'} version=${renderDeploySerial(nextSerial)} destructiveActions=${plan.summary.destructiveCount} affectedRows=${plan.summary.totalAffectedRows}`,
+      );
+    }
+
     return {
       applicationUniversalIdentifier:
         workspaceMigration.applicationUniversalIdentifier,
       actions: workspaceMigration.actions,
     };
+  }
+
+  private buildDestructiveChangesMessage(plan: ApplicationSyncPlanDTO): string {
+    const destructiveLabels = plan.actions
+      .filter((action) => action.severity === 'destructive')
+      .map((action) => action.label ?? action.universalIdentifier)
+      .join(', ');
+
+    return `This deploy includes ${plan.summary.destructiveCount} destructive change(s) that permanently delete data (${destructiveLabels}). Re-run with allowDestructive set to true to proceed.`;
   }
 
   @Mutation(() => FileDTO)

--- a/packages/twenty-server/src/engine/core-modules/application/application-development/dtos/application-sync-plan.dto.ts
+++ b/packages/twenty-server/src/engine/core-modules/application/application-development/dtos/application-sync-plan.dto.ts
@@ -1,0 +1,67 @@
+import { Field, Int, ObjectType } from '@nestjs/graphql';
+
+@ObjectType('ApplicationSyncPlanAction')
+export class ApplicationSyncPlanActionDTO {
+  @Field(() => String)
+  type: 'create' | 'update' | 'delete';
+
+  @Field(() => String)
+  metadataName: string;
+
+  @Field(() => String, { nullable: true })
+  universalIdentifier: string | null;
+
+  @Field(() => String, { nullable: true })
+  label: string | null;
+
+  @Field(() => String)
+  severity: 'safe' | 'breaking' | 'destructive';
+
+  @Field(() => Int, { nullable: true })
+  affectedRowCount: number | null;
+}
+
+@ObjectType('ApplicationSyncPlanSummary')
+export class ApplicationSyncPlanSummaryDTO {
+  @Field(() => Int)
+  createCount: number;
+
+  @Field(() => Int)
+  updateCount: number;
+
+  @Field(() => Int)
+  deleteCount: number;
+
+  @Field(() => Int)
+  breakingCount: number;
+
+  @Field(() => Int)
+  destructiveCount: number;
+
+  @Field(() => Int)
+  totalAffectedRows: number;
+}
+
+@ObjectType('ApplicationSyncPlan')
+export class ApplicationSyncPlanDTO {
+  @Field(() => String)
+  applicationUniversalIdentifier: string;
+
+  @Field(() => [ApplicationSyncPlanActionDTO])
+  actions: ApplicationSyncPlanActionDTO[];
+
+  @Field(() => ApplicationSyncPlanSummaryDTO)
+  summary: ApplicationSyncPlanSummaryDTO;
+
+  @Field(() => String, { nullable: true })
+  currentVersion: string | null;
+
+  @Field(() => String)
+  proposedVersion: string;
+
+  @Field(() => Boolean)
+  isEmpty: boolean;
+
+  @Field(() => Boolean)
+  hasDestructiveActions: boolean;
+}

--- a/packages/twenty-server/src/engine/core-modules/application/application-development/dtos/application.input.ts
+++ b/packages/twenty-server/src/engine/core-modules/application/application-development/dtos/application.input.ts
@@ -10,4 +10,7 @@ export class ApplicationInput {
 
   @Field(() => Boolean, { nullable: true })
   dryRun?: boolean;
+
+  @Field(() => Boolean, { nullable: true })
+  allowDestructive?: boolean;
 }

--- a/packages/twenty-server/src/engine/core-modules/application/application-exception-filter.ts
+++ b/packages/twenty-server/src/engine/core-modules/application/application-exception-filter.ts
@@ -31,6 +31,7 @@ export class ApplicationExceptionFilter implements ExceptionFilter {
       case ApplicationExceptionCode.SOURCE_CHANNEL_MISMATCH:
       case ApplicationExceptionCode.APP_ALREADY_INSTALLED:
       case ApplicationExceptionCode.CANNOT_DOWNGRADE_APPLICATION:
+      case ApplicationExceptionCode.DESTRUCTIVE_CHANGES_NOT_APPROVED:
       case ApplicationExceptionCode.SERVER_VERSION_INCOMPATIBLE:
       case ApplicationExceptionCode.INVALID_APP_ENGINE_REQUIREMENT:
         throw new UserInputError(exception);

--- a/packages/twenty-server/src/engine/core-modules/application/application-rest-api-exception.filter.ts
+++ b/packages/twenty-server/src/engine/core-modules/application/application-rest-api-exception.filter.ts
@@ -33,6 +33,7 @@ const applicationExceptionCodeToHttpStatus = (
     case ApplicationExceptionCode.SOURCE_CHANNEL_MISMATCH:
     case ApplicationExceptionCode.APP_ALREADY_INSTALLED:
     case ApplicationExceptionCode.CANNOT_DOWNGRADE_APPLICATION:
+    case ApplicationExceptionCode.DESTRUCTIVE_CHANGES_NOT_APPROVED:
     case ApplicationExceptionCode.SERVER_VERSION_INCOMPATIBLE:
     case ApplicationExceptionCode.INVALID_APP_ENGINE_REQUIREMENT:
       return 400;

--- a/packages/twenty-server/src/engine/core-modules/application/application.entity.ts
+++ b/packages/twenty-server/src/engine/core-modules/application/application.entity.ts
@@ -64,6 +64,13 @@ export class ApplicationEntity extends WorkspaceRelatedEntity {
   @Column({ nullable: true, type: 'text' })
   version: string | null;
 
+  @Column({ nullable: true, type: 'integer' })
+  @WasIntroducedInUpgrade({
+    upgradeCommandName:
+      '2.18.0_AddDeploySerialToApplicationFastInstanceCommand_1801000110000',
+  })
+  deploySerial: number | null;
+
   @Column({ type: 'text', default: ApplicationRegistrationSourceType.LOCAL })
   sourceType: ApplicationRegistrationSourceType;
 

--- a/packages/twenty-server/src/engine/core-modules/application/application.exception.ts
+++ b/packages/twenty-server/src/engine/core-modules/application/application.exception.ts
@@ -22,6 +22,7 @@ export enum ApplicationExceptionCode {
   POST_INSTALL_ERROR = 'POST_INSTALL_ERROR',
   APP_ALREADY_INSTALLED = 'APP_ALREADY_INSTALLED',
   CANNOT_DOWNGRADE_APPLICATION = 'CANNOT_DOWNGRADE_APPLICATION',
+  DESTRUCTIVE_CHANGES_NOT_APPROVED = 'DESTRUCTIVE_CHANGES_NOT_APPROVED',
   SERVER_VERSION_INCOMPATIBLE = 'SERVER_VERSION_INCOMPATIBLE',
   INVALID_APP_ENGINE_REQUIREMENT = 'INVALID_APP_ENGINE_REQUIREMENT',
   INVALID_SERVER_VERSION = 'INVALID_SERVER_VERSION',
@@ -65,6 +66,8 @@ const getApplicationExceptionUserFriendlyMessage = (
       return msg`This version of the application is already installed in this workspace.`;
     case ApplicationExceptionCode.CANNOT_DOWNGRADE_APPLICATION:
       return msg`A higher version of this application is already installed. Downgrading is not allowed.`;
+    case ApplicationExceptionCode.DESTRUCTIVE_CHANGES_NOT_APPROVED:
+      return msg`This deploy permanently deletes data. Review the plan and confirm destructive changes to proceed.`;
     case ApplicationExceptionCode.SERVER_VERSION_INCOMPATIBLE:
       return msg`This app requires a newer version of the Twenty server. Please upgrade your server or use a compatible app version.`;
     case ApplicationExceptionCode.INVALID_APP_ENGINE_REQUIREMENT:

--- a/packages/twenty-server/src/engine/metadata-modules/flat-field-metadata/__tests__/morph-relation-from-create-field-input-to-flat-field-metadatas-to-create.spec.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/flat-field-metadata/__tests__/morph-relation-from-create-field-input-to-flat-field-metadatas-to-create.spec.ts
@@ -28,6 +28,7 @@ const MOCK_FLAT_APPLICATION: FlatApplication = {
   logo: null,
   workspaceId: 'workspace-id',
   version: null,
+  deploySerial: null,
   sourceType: ApplicationRegistrationSourceType.LOCAL,
   sourcePath: '',
   packageJsonChecksum: null,

--- a/packages/twenty-server/src/engine/metadata-modules/flat-field-metadata/utils/__tests__/generate-morph-or-relation-flat-field-metadata-pair.spec.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/flat-field-metadata/utils/__tests__/generate-morph-or-relation-flat-field-metadata-pair.spec.ts
@@ -22,6 +22,7 @@ const MOCK_FLAT_APPLICATION: FlatApplication = {
   description: null,
   logo: null,
   version: null,
+  deploySerial: null,
   workspaceId: 'workspace-id',
   sourceType: ApplicationRegistrationSourceType.LOCAL,
   sourcePath: '',

--- a/packages/twenty-server/test/integration/metadata/suites/application/application-deploy-plan-and-serial.integration-spec.ts
+++ b/packages/twenty-server/test/integration/metadata/suites/application/application-deploy-plan-and-serial.integration-spec.ts
@@ -1,0 +1,194 @@
+import { buildBaseManifest } from 'test/integration/metadata/suites/application/utils/build-base-manifest.util';
+import { buildDefaultObjectManifest } from 'test/integration/metadata/suites/application/utils/build-default-object-manifest.util';
+import { cleanupApplicationAndAppRegistration } from 'test/integration/metadata/suites/application/utils/cleanup-application-and-app-registration.util';
+import { planApplicationSync } from 'test/integration/metadata/suites/application/utils/plan-application-sync.util';
+import { setupApplicationForSync } from 'test/integration/metadata/suites/application/utils/setup-application-for-sync.util';
+import { syncApplication } from 'test/integration/metadata/suites/application/utils/sync-application.util';
+import { type Manifest } from 'twenty-shared/application';
+import { FieldMetadataType } from 'twenty-shared/types';
+import { v4 as uuidv4 } from 'uuid';
+
+import { SEED_APPLE_WORKSPACE_ID } from 'src/engine/workspace-manager/dev-seeder/core/constants/seeder-workspaces.constant';
+
+const TEST_APP_ID = uuidv4();
+const TEST_ROLE_ID = uuidv4();
+const LEGACY_FIELD_ID = uuidv4();
+
+const TICKET_OBJECT = buildDefaultObjectManifest({
+  nameSingular: 'deployPlanTicket',
+  namePlural: 'deployPlanTickets',
+  labelSingular: 'Deploy Plan Ticket',
+  labelPlural: 'Deploy Plan Tickets',
+  description: 'A support ticket',
+});
+
+const INVOICE_OBJECT = buildDefaultObjectManifest({
+  nameSingular: 'deployPlanInvoice',
+  namePlural: 'deployPlanInvoices',
+  labelSingular: 'Deploy Plan Invoice',
+  labelPlural: 'Deploy Plan Invoices',
+  description: 'A billing invoice',
+});
+
+const RECORD_OBJECT_WITH_LEGACY_FIELD = buildDefaultObjectManifest({
+  nameSingular: 'deployPlanRecord',
+  namePlural: 'deployPlanRecords',
+  labelSingular: 'Deploy Plan Record',
+  labelPlural: 'Deploy Plan Records',
+  description: 'A record carrying a removable field',
+  additionalFields: [
+    {
+      universalIdentifier: LEGACY_FIELD_ID,
+      type: FieldMetadataType.TEXT,
+      name: 'legacyNotes',
+      label: 'Legacy notes',
+    },
+  ],
+});
+
+const RECORD_OBJECT_WITHOUT_LEGACY_FIELD = {
+  ...RECORD_OBJECT_WITH_LEGACY_FIELD,
+  fields: RECORD_OBJECT_WITH_LEGACY_FIELD.fields.filter(
+    (field) => field.universalIdentifier !== LEGACY_FIELD_ID,
+  ),
+};
+
+const buildManifest = (overrides?: Partial<Manifest>) =>
+  buildBaseManifest({ appId: TEST_APP_ID, roleId: TEST_ROLE_ID, overrides });
+
+const readApplicationVersion = async (): Promise<{
+  version: string | null;
+  deploySerial: number | null;
+}> => {
+  const rows = await globalThis.testDataSource.query(
+    'SELECT version, "deploySerial" FROM core.application WHERE "universalIdentifier" = $1 AND "workspaceId" = $2',
+    [TEST_APP_ID, SEED_APPLE_WORKSPACE_ID],
+  );
+
+  return rows[0];
+};
+
+describe('Application deploy plan, serial versioning and destructive gate', () => {
+  beforeEach(async () => {
+    await setupApplicationForSync({
+      applicationUniversalIdentifier: TEST_APP_ID,
+      name: 'Deploy Plan Test Application',
+      description: 'App for testing the deploy plan and serial versioning',
+      sourcePath: 'application-deploy-plan-and-serial',
+    });
+  }, 60000);
+
+  afterEach(async () => {
+    await cleanupApplicationAndAppRegistration({
+      applicationUniversalIdentifier: TEST_APP_ID,
+    });
+  });
+
+  it('reports additive changes as safe with the next proposed serial', async () => {
+    const { data } = await planApplicationSync({
+      manifest: buildManifest({ objects: [TICKET_OBJECT] }),
+    });
+
+    const plan = data.planApplicationSync;
+
+    expect(plan.isEmpty).toBe(false);
+    expect(plan.hasDestructiveActions).toBe(false);
+    expect(plan.currentVersion).toBeNull();
+    expect(plan.proposedVersion).toBe('0.0.1');
+    expect(plan.summary.createCount).toBeGreaterThan(0);
+    expect(plan.summary.destructiveCount).toBe(0);
+    expect(plan.actions.every((action) => action.severity === 'safe')).toBe(
+      true,
+    );
+  }, 60000);
+
+  it('assigns a monotonic 0.0.N serial that advances on each non-empty deploy', async () => {
+    await syncApplication({
+      manifest: buildManifest({ objects: [TICKET_OBJECT] }),
+      expectToFail: false,
+    });
+
+    expect(await readApplicationVersion()).toEqual({
+      version: '0.0.1',
+      deploySerial: 1,
+    });
+
+    await syncApplication({
+      manifest: buildManifest({ objects: [TICKET_OBJECT, INVOICE_OBJECT] }),
+      expectToFail: false,
+    });
+
+    expect(await readApplicationVersion()).toEqual({
+      version: '0.0.2',
+      deploySerial: 2,
+    });
+  }, 60000);
+
+  it('treats an unchanged re-deploy as a no-op without advancing the serial', async () => {
+    const manifest = buildManifest({ objects: [TICKET_OBJECT] });
+
+    await syncApplication({ manifest, expectToFail: false });
+
+    const plan = (await planApplicationSync({ manifest })).data
+      .planApplicationSync;
+
+    expect(plan.isEmpty).toBe(true);
+    expect(plan.currentVersion).toBe('0.0.1');
+    expect(plan.proposedVersion).toBe('0.0.1');
+
+    await syncApplication({ manifest, expectToFail: false });
+
+    expect(await readApplicationVersion()).toEqual({
+      version: '0.0.1',
+      deploySerial: 1,
+    });
+  }, 60000);
+
+  it('flags field removal as destructive and blocks the deploy unless allowDestructive is set', async () => {
+    await syncApplication({
+      manifest: buildManifest({ objects: [RECORD_OBJECT_WITH_LEGACY_FIELD] }),
+      expectToFail: false,
+    });
+
+    const manifestWithoutLegacyField = buildManifest({
+      objects: [RECORD_OBJECT_WITHOUT_LEGACY_FIELD],
+    });
+
+    const plan = (
+      await planApplicationSync({ manifest: manifestWithoutLegacyField })
+    ).data.planApplicationSync;
+
+    expect(plan.hasDestructiveActions).toBe(true);
+    expect(plan.summary.destructiveCount).toBe(1);
+
+    const destructiveAction = plan.actions.find(
+      (action) => action.severity === 'destructive',
+    );
+
+    expect(destructiveAction).toBeDefined();
+    expect(destructiveAction?.type).toBe('delete');
+    expect(destructiveAction?.metadataName).toBe('fieldMetadata');
+    expect(destructiveAction?.affectedRowCount).toBe(0);
+
+    const blockedResponse = await syncApplication({
+      manifest: manifestWithoutLegacyField,
+      expectToFail: true,
+    });
+
+    expect(JSON.stringify(blockedResponse.errors).toLowerCase()).toContain(
+      'destructive',
+    );
+
+    await syncApplication({
+      manifest: manifestWithoutLegacyField,
+      allowDestructive: true,
+      expectToFail: false,
+    });
+
+    const planAfterApply = (
+      await planApplicationSync({ manifest: manifestWithoutLegacyField })
+    ).data.planApplicationSync;
+
+    expect(planAfterApply.isEmpty).toBe(true);
+  }, 60000);
+});

--- a/packages/twenty-server/test/integration/metadata/suites/application/failing-sync-application-object-system-fields.integration-spec.ts
+++ b/packages/twenty-server/test/integration/metadata/suites/application/failing-sync-application-object-system-fields.integration-spec.ts
@@ -376,6 +376,7 @@ describe('Sync application should fail due to object system fields integrity', (
 
     await syncApplication({
       manifest: validManifest,
+      allowDestructive: true,
       expectToFail: false,
     });
 

--- a/packages/twenty-server/test/integration/metadata/suites/application/successful-manifest-update-field.integration-spec.ts
+++ b/packages/twenty-server/test/integration/metadata/suites/application/successful-manifest-update-field.integration-spec.ts
@@ -223,6 +223,7 @@ describe('Manifest update - fields', () => {
           },
         ],
       }),
+      allowDestructive: true,
       expectToFail: false,
     });
 

--- a/packages/twenty-server/test/integration/metadata/suites/application/successful-manifest-update-object.integration-spec.ts
+++ b/packages/twenty-server/test/integration/metadata/suites/application/successful-manifest-update-object.integration-spec.ts
@@ -208,6 +208,7 @@ describe('Manifest update - objects', () => {
 
     await syncApplication({
       manifest: buildManifest({ objects: [ticketObject] }),
+      allowDestructive: true,
       expectToFail: false,
     });
 

--- a/packages/twenty-server/test/integration/metadata/suites/application/successful-sync-application-universal-identifier-reuse-cross-entity.integration-spec.ts
+++ b/packages/twenty-server/test/integration/metadata/suites/application/successful-sync-application-universal-identifier-reuse-cross-entity.integration-spec.ts
@@ -75,6 +75,7 @@ describe('Cross-entity universalIdentifier reuse across syncs', () => {
 
     await syncApplication({
       manifest: secondManifest,
+      allowDestructive: true,
       expectToFail: false,
     });
   }, 60000);

--- a/packages/twenty-server/test/integration/metadata/suites/application/successful-sync-application-workspace-migration.integration-spec.ts
+++ b/packages/twenty-server/test/integration/metadata/suites/application/successful-sync-application-workspace-migration.integration-spec.ts
@@ -220,6 +220,7 @@ describe('syncApplication', () => {
           ],
         },
       }),
+      allowDestructive: true,
       expectToFail: false,
     });
 

--- a/packages/twenty-server/test/integration/metadata/suites/application/utils/plan-application-sync-query-factory.util.ts
+++ b/packages/twenty-server/test/integration/metadata/suites/application/utils/plan-application-sync-query-factory.util.ts
@@ -1,0 +1,39 @@
+import gql from 'graphql-tag';
+import { type Manifest } from 'twenty-shared/application';
+
+export const planApplicationSyncQueryFactory = ({
+  manifest,
+}: {
+  manifest: Manifest;
+}) => ({
+  query: gql`
+    mutation PlanApplicationSync($manifest: JSON!) {
+      planApplicationSync(manifest: $manifest) {
+        applicationUniversalIdentifier
+        isEmpty
+        hasDestructiveActions
+        currentVersion
+        proposedVersion
+        summary {
+          createCount
+          updateCount
+          deleteCount
+          breakingCount
+          destructiveCount
+          totalAffectedRows
+        }
+        actions {
+          type
+          metadataName
+          universalIdentifier
+          label
+          severity
+          affectedRowCount
+        }
+      }
+    }
+  `,
+  variables: {
+    manifest,
+  },
+});

--- a/packages/twenty-server/test/integration/metadata/suites/application/utils/plan-application-sync.util.ts
+++ b/packages/twenty-server/test/integration/metadata/suites/application/utils/plan-application-sync.util.ts
@@ -1,0 +1,52 @@
+import { type Manifest } from 'twenty-shared/application';
+import { planApplicationSyncQueryFactory } from 'test/integration/metadata/suites/application/utils/plan-application-sync-query-factory.util';
+import { makeMetadataAPIRequest } from 'test/integration/metadata/suites/utils/make-metadata-api-request.util';
+import { type CommonResponseBody } from 'test/integration/metadata/types/common-response-body.type';
+import { warnIfErrorButNotExpectedToFail } from 'test/integration/metadata/utils/warn-if-error-but-not-expected-to-fail.util';
+
+type ApplicationSyncPlanAction = {
+  type: string;
+  metadataName: string;
+  universalIdentifier: string | null;
+  label: string | null;
+  severity: string;
+  affectedRowCount: number | null;
+};
+
+type ApplicationSyncPlan = {
+  applicationUniversalIdentifier: string;
+  isEmpty: boolean;
+  hasDestructiveActions: boolean;
+  currentVersion: string | null;
+  proposedVersion: string;
+  summary: {
+    createCount: number;
+    updateCount: number;
+    deleteCount: number;
+    breakingCount: number;
+    destructiveCount: number;
+    totalAffectedRows: number;
+  };
+  actions: ApplicationSyncPlanAction[];
+};
+
+export const planApplicationSync = async ({
+  manifest,
+  token,
+}: {
+  manifest: Manifest;
+  token?: string;
+}): CommonResponseBody<{
+  planApplicationSync: ApplicationSyncPlan;
+}> => {
+  const graphqlOperation = planApplicationSyncQueryFactory({ manifest });
+
+  const response = await makeMetadataAPIRequest(graphqlOperation, token);
+
+  warnIfErrorButNotExpectedToFail({
+    response,
+    errorMessage: 'Plan application sync has failed but should not',
+  });
+
+  return { data: response.body.data, errors: response.body.errors };
+};

--- a/packages/twenty-server/test/integration/metadata/suites/application/utils/sync-application-query-factory.util.ts
+++ b/packages/twenty-server/test/integration/metadata/suites/application/utils/sync-application-query-factory.util.ts
@@ -4,13 +4,23 @@ import { type Manifest } from 'twenty-shared/application';
 export const syncApplicationQueryFactory = ({
   manifest,
   dryRun,
+  allowDestructive,
 }: {
   manifest: Manifest;
   dryRun?: boolean;
+  allowDestructive?: boolean;
 }) => ({
   query: gql`
-    mutation SyncApplication($manifest: JSON!, $dryRun: Boolean) {
-      syncApplication(manifest: $manifest, dryRun: $dryRun) {
+    mutation SyncApplication(
+      $manifest: JSON!
+      $dryRun: Boolean
+      $allowDestructive: Boolean
+    ) {
+      syncApplication(
+        manifest: $manifest
+        dryRun: $dryRun
+        allowDestructive: $allowDestructive
+      ) {
         applicationUniversalIdentifier
         actions
       }
@@ -19,5 +29,6 @@ export const syncApplicationQueryFactory = ({
   variables: {
     manifest,
     dryRun,
+    allowDestructive,
   },
 });

--- a/packages/twenty-server/test/integration/metadata/suites/application/utils/sync-application.util.ts
+++ b/packages/twenty-server/test/integration/metadata/suites/application/utils/sync-application.util.ts
@@ -15,17 +15,20 @@ export const syncApplication = async ({
   expectToFail = false,
   token,
   dryRun,
+  allowDestructive,
 }: {
   manifest: Manifest;
   expectToFail?: boolean;
   token?: string;
   dryRun?: boolean;
+  allowDestructive?: boolean;
 }): CommonResponseBody<{
   syncApplication: WorkspaceMigration;
 }> => {
   const graphqlOperation = syncApplicationQueryFactory({
     manifest,
     dryRun,
+    allowDestructive,
   });
 
   const response = await makeMetadataAPIRequest(graphqlOperation, token);


### PR DESCRIPTION
## What & why

App developers hesitate to push changes to an installed app: a sync can silently drop columns and tables, there is no preview of what will change, and every deploy forces a manual semver bump. This adds a Terraform-style **plan → apply** flow with a server-assigned version serial and a server-enforced destructive-change gate.

## Changes

**Plan (`planApplicationSync`)** — a mutation that returns an `ApplicationSyncPlan`: every metadata change classified as `safe | breaking | destructive`, the number of rows a deletion would destroy, a summary, and the version this deploy would produce. Severity is computed server-side from the migration builder actions — field/object deletions and enum-option removals are `destructive` (the removal NULLs existing rows), option relabels/reorders are `safe`, field renames and type changes are `breaking`, and everything additive is `safe`.

**Serial versioning** — applications gain a `deploySerial` integer. The version is rendered as `0.0.N` and advances only on a non-empty deploy, so developers never bump versions by hand and an unchanged re-deploy is a friendly no-op (no serial bump, no SDK regeneration). This applies to the per-workspace local deploy path only; marketplace/npm installs keep their real semver.

**Destructive gate** — `syncApplication` gains `allowDestructive`. A deploy that destroys data is refused server-side (`DESTRUCTIVE_CHANGES_NOT_APPROVED`, HTTP 400) unless `allowDestructive` is set. The continuous `yarn twenty dev` watcher passes it automatically (local, throwaway data — stays frictionless); `yarn twenty dev --once` requires `--allow-destructive`. Destructive applies are logged with the actor, application, version, and affected-row count.

## Relationship to #22322

This supersedes the client-side `--version auto` timestamp synthesis: the server now assigns the serial, and it only advances on a real change, so no-op deploys no longer churn the version.

## Testing

Integration tests (`application-deploy-plan-and-serial.integration-spec.ts`) cover: an additive plan is `safe` with the next proposed serial; the serial advances `0.0.1 → 0.0.2` across deploys; an unchanged re-deploy is a no-op without a bump; a field removal is flagged `destructive` with an affected-row count, blocked without `allowDestructive`, and succeeds with it. Verified against a real Postgres test database (4/4 passing).

## Follow-ups (intentionally out of scope)

- Stored-plan-by-id + drift detection, so apply runs exactly the reviewed plan
- Soft-delete + retention so destructive ops become reversible (then "permanently deletes" copy becomes "recoverable for N days")
- A dedicated `DESTROY_APPLICATION_DATA` capability not subsumed by `canUpdateAllSettings`
- A durable destructive-deploy audit table (today it is a structured log line)
- Front-end plan-review modal in the upgrade flow


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/22333?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

