### PR TITLE
feat(apps): apply deploys by stored plan id with drift detection

### DIFF
--- a/packages/twenty-client-sdk/src/metadata/generated/schema.graphql
+++ b/packages/twenty-client-sdk/src/metadata/generated/schema.graphql
@@ -2430,6 +2430,8 @@ type ApplicationSyncPlanSummary {
 
 type ApplicationSyncPlan {
   applicationUniversalIdentifier: String!
+  planId: String
+  planDigest: String!
   actions: [ApplicationSyncPlanAction!]!
   summary: ApplicationSyncPlanSummary!
   currentVersion: String
@@ -3497,8 +3499,8 @@ type Mutation {
   syncMarketplaceCatalog: Boolean!
   createDevelopmentApplication(universalIdentifier: String!, name: String!): DevelopmentApplication!
   generateApplicationToken(applicationId: UUID!): ApplicationTokenPair!
-  planApplicationSync(manifest: JSON!, dryRun: Boolean, allowDestructive: Boolean): ApplicationSyncPlan!
-  syncApplication(manifest: JSON!, dryRun: Boolean, allowDestructive: Boolean): WorkspaceMigration!
+  planApplicationSync(manifest: JSON!, dryRun: Boolean, allowDestructive: Boolean, applyPlanId: String): ApplicationSyncPlan!
+  syncApplication(manifest: JSON!, dryRun: Boolean, allowDestructive: Boolean, applyPlanId: String): WorkspaceMigration!
   uploadApplicationFile(file: Upload!, applicationUniversalIdentifier: String!, fileFolder: FileFolder!, filePath: String!): File!
   upgradeApplication(appRegistrationId: String!, targetVersion: String!): Boolean!
   renewApplicationToken(applicationRefreshToken: String!): ApplicationTokenPair!

--- a/packages/twenty-client-sdk/src/metadata/generated/schema.ts
+++ b/packages/twenty-client-sdk/src/metadata/generated/schema.ts
@@ -2101,6 +2101,8 @@ export interface ApplicationSyncPlanSummary {
 
 export interface ApplicationSyncPlan {
     applicationUniversalIdentifier: Scalars['String']
+    planId?: Scalars['String']
+    planDigest: Scalars['String']
     actions: ApplicationSyncPlanAction[]
     summary: ApplicationSyncPlanSummary
     currentVersion?: Scalars['String']
@@ -5263,6 +5265,8 @@ export interface ApplicationSyncPlanSummaryGenqlSelection{
 
 export interface ApplicationSyncPlanGenqlSelection{
     applicationUniversalIdentifier?: boolean | number
+    planId?: boolean | number
+    planDigest?: boolean | number
     actions?: ApplicationSyncPlanActionGenqlSelection
     summary?: ApplicationSyncPlanSummaryGenqlSelection
     currentVersion?: boolean | number
@@ -6255,8 +6259,8 @@ export interface MutationGenqlSelection{
     syncMarketplaceCatalog?: boolean | number
     createDevelopmentApplication?: (DevelopmentApplicationGenqlSelection & { __args: {universalIdentifier: Scalars['String'], name: Scalars['String']} })
     generateApplicationToken?: (ApplicationTokenPairGenqlSelection & { __args: {applicationId: Scalars['UUID']} })
-    planApplicationSync?: (ApplicationSyncPlanGenqlSelection & { __args: {manifest: Scalars['JSON'], dryRun?: (Scalars['Boolean'] | null), allowDestructive?: (Scalars['Boolean'] | null)} })
-    syncApplication?: (WorkspaceMigrationGenqlSelection & { __args: {manifest: Scalars['JSON'], dryRun?: (Scalars['Boolean'] | null), allowDestructive?: (Scalars['Boolean'] | null)} })
+    planApplicationSync?: (ApplicationSyncPlanGenqlSelection & { __args: {manifest: Scalars['JSON'], dryRun?: (Scalars['Boolean'] | null), allowDestructive?: (Scalars['Boolean'] | null), applyPlanId?: (Scalars['String'] | null)} })
+    syncApplication?: (WorkspaceMigrationGenqlSelection & { __args: {manifest: Scalars['JSON'], dryRun?: (Scalars['Boolean'] | null), allowDestructive?: (Scalars['Boolean'] | null), applyPlanId?: (Scalars['String'] | null)} })
     uploadApplicationFile?: (FileGenqlSelection & { __args: {file: Scalars['Upload'], applicationUniversalIdentifier: Scalars['String'], fileFolder: FileFolder, filePath: Scalars['String']} })
     upgradeApplication?: { __args: {appRegistrationId: Scalars['String'], targetVersion: Scalars['String']} }
     renewApplicationToken?: (ApplicationTokenPairGenqlSelection & { __args: {applicationRefreshToken: Scalars['String']} })

--- a/packages/twenty-client-sdk/src/metadata/generated/types.ts
+++ b/packages/twenty-client-sdk/src/metadata/generated/types.ts
@@ -4783,6 +4783,12 @@ export default {
             "applicationUniversalIdentifier": [
                 1
             ],
+            "planId": [
+                1
+            ],
+            "planDigest": [
+                1
+            ],
             "actions": [
                 265
             ],
@@ -9150,6 +9156,9 @@ export default {
                     ],
                     "allowDestructive": [
                         6
+                    ],
+                    "applyPlanId": [
+                        1
                     ]
                 }
             ],
@@ -9165,6 +9174,9 @@ export default {
                     ],
                     "allowDestructive": [
                         6
+                    ],
+                    "applyPlanId": [
+                        1
                     ]
                 }
             ],

--- a/packages/twenty-front/src/generated-metadata/graphql.ts
+++ b/packages/twenty-front/src/generated-metadata/graphql.ts
@@ -401,6 +401,8 @@ export type ApplicationSyncPlan = {
   currentVersion?: Maybe<Scalars['String']['output']>;
   hasDestructiveActions: Scalars['Boolean']['output'];
   isEmpty: Scalars['Boolean']['output'];
+  planDigest: Scalars['String']['output'];
+  planId?: Maybe<Scalars['String']['output']>;
   proposedVersion: Scalars['String']['output'];
   summary: ApplicationSyncPlanSummary;
 };
@@ -3306,6 +3308,7 @@ export type MutationInstallMarketplaceAppArgs = {
 
 export type MutationPlanApplicationSyncArgs = {
   allowDestructive?: InputMaybe<Scalars['Boolean']['input']>;
+  applyPlanId?: InputMaybe<Scalars['String']['input']>;
   dryRun?: InputMaybe<Scalars['Boolean']['input']>;
   manifest: Scalars['JSON']['input'];
 };
@@ -3489,6 +3492,7 @@ export type MutationStopAgentChatStreamArgs = {
 
 export type MutationSyncApplicationArgs = {
   allowDestructive?: InputMaybe<Scalars['Boolean']['input']>;
+  applyPlanId?: InputMaybe<Scalars['String']['input']>;
   dryRun?: InputMaybe<Scalars['Boolean']['input']>;
   manifest: Scalars['JSON']['input'];
 };

--- a/packages/twenty-server/src/engine/core-modules/application/application-deploy/application-deploy-plan-store.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/application/application-deploy/application-deploy-plan-store.service.ts
@@ -1,0 +1,69 @@
+import { Injectable } from '@nestjs/common';
+
+import { randomUUID } from 'crypto';
+
+import { type Manifest } from 'twenty-shared/application';
+
+import { InjectCacheStorage } from 'src/engine/core-modules/cache-storage/decorators/cache-storage.decorator';
+import { CacheStorageService } from 'src/engine/core-modules/cache-storage/services/cache-storage.service';
+import { CacheStorageNamespace } from 'src/engine/core-modules/cache-storage/types/cache-storage-namespace.enum';
+
+const STORED_PLAN_TTL_MS = 30 * 60 * 1000;
+
+export type StoredDeployPlan = {
+  applicationUniversalIdentifier: string;
+  manifest: Manifest;
+  planDigest: string;
+};
+
+@Injectable()
+export class ApplicationDeployPlanStoreService {
+  constructor(
+    @InjectCacheStorage(CacheStorageNamespace.EngineApplicationDeployPlan)
+    private readonly cacheStorage: CacheStorageService,
+  ) {}
+
+  async store({
+    workspaceId,
+    plan,
+  }: {
+    workspaceId: string;
+    plan: StoredDeployPlan;
+  }): Promise<string> {
+    const planId = randomUUID();
+
+    await this.cacheStorage.set(
+      this.getKey(workspaceId, planId),
+      plan,
+      STORED_PLAN_TTL_MS,
+    );
+
+    return planId;
+  }
+
+  async get({
+    workspaceId,
+    planId,
+  }: {
+    workspaceId: string;
+    planId: string;
+  }): Promise<StoredDeployPlan | undefined> {
+    return this.cacheStorage.get<StoredDeployPlan>(
+      this.getKey(workspaceId, planId),
+    );
+  }
+
+  async consume({
+    workspaceId,
+    planId,
+  }: {
+    workspaceId: string;
+    planId: string;
+  }): Promise<void> {
+    await this.cacheStorage.del(this.getKey(workspaceId, planId));
+  }
+
+  private getKey(workspaceId: string, planId: string): string {
+    return `deploy-plan:${workspaceId}:${planId}`;
+  }
+}

--- a/packages/twenty-server/src/engine/core-modules/application/application-deploy/application-deploy-plan.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/application/application-deploy/application-deploy-plan.service.ts
@@ -1,6 +1,8 @@
 import { Injectable, Logger } from '@nestjs/common';
 import { InjectDataSource } from '@nestjs/typeorm';
 
+import { createHash } from 'crypto';
+
 import { type Manifest } from 'twenty-shared/application';
 import { DataSource } from 'typeorm';
 import { ALL_METADATA_NAME } from 'twenty-shared/metadata';
@@ -35,6 +37,28 @@ const getActionUniversalIdentifier = (
   action.type === 'create'
     ? action.flatEntity.universalIdentifier
     : action.universalIdentifier;
+
+const computePlanDigest = (
+  actions: ApplicationSyncPlanActionDTO[],
+  proposedVersion: string,
+): string => {
+  const normalizedActions = actions
+    .map((action) => ({
+      type: action.type,
+      metadataName: action.metadataName,
+      universalIdentifier: action.universalIdentifier,
+      severity: action.severity,
+    }))
+    .sort((a, b) =>
+      `${a.metadataName}:${a.universalIdentifier}:${a.type}`.localeCompare(
+        `${b.metadataName}:${b.universalIdentifier}:${b.type}`,
+      ),
+    );
+
+  return createHash('sha256')
+    .update(JSON.stringify({ actions: normalizedActions, proposedVersion }))
+    .digest('hex');
+};
 
 type DeployPlanMaps = {
   flatFieldMetadataMaps: UniversalFlatEntityMaps<FlatFieldMetadata>;
@@ -94,17 +118,20 @@ export class ApplicationDeployPlanService {
     const currentSerial = application.deploySerial ?? 0;
     const isEmpty = actions.length === 0;
     const nextSerial = isEmpty ? currentSerial : currentSerial + 1;
+    const proposedVersion = renderDeploySerial(nextSerial);
 
     const summary = this.buildSummary(actions);
 
     return {
       applicationUniversalIdentifier: manifest.application.universalIdentifier,
+      planId: null,
+      planDigest: computePlanDigest(actions, proposedVersion),
       actions,
       summary,
       currentVersion: isDefined(application.deploySerial)
         ? renderDeploySerial(application.deploySerial)
         : null,
-      proposedVersion: renderDeploySerial(nextSerial),
+      proposedVersion,
       isEmpty,
       hasDestructiveActions: summary.destructiveCount > 0,
     };

--- a/packages/twenty-server/src/engine/core-modules/application/application-development/application-development.module.ts
+++ b/packages/twenty-server/src/engine/core-modules/application/application-development/application-development.module.ts
@@ -2,6 +2,7 @@ import { Module } from '@nestjs/common';
 
 import { ApplicationRegistrationModule } from 'src/engine/core-modules/application/application-registration/application-registration.module';
 import { ApplicationDeployPlanService } from 'src/engine/core-modules/application/application-deploy/application-deploy-plan.service';
+import { ApplicationDeployPlanStoreService } from 'src/engine/core-modules/application/application-deploy/application-deploy-plan-store.service';
 import { ApplicationManifestModule } from 'src/engine/core-modules/application/application-manifest/application-manifest.module';
 import { ApplicationModule } from 'src/engine/core-modules/application/application.module';
 import { ApplicationDevelopmentResolver } from 'src/engine/core-modules/application/application-development/application-development.resolver';
@@ -32,6 +33,7 @@ import { WorkspaceMigrationGraphqlApiExceptionInterceptor } from 'src/engine/wor
   providers: [
     ApplicationDevelopmentResolver,
     ApplicationDeployPlanService,
+    ApplicationDeployPlanStoreService,
     WorkspaceMigrationGraphqlApiExceptionInterceptor,
   ],
 })

--- a/packages/twenty-server/src/engine/core-modules/application/application-development/application-development.resolver.ts
+++ b/packages/twenty-server/src/engine/core-modules/application/application-development/application-development.resolver.ts
@@ -238,6 +238,17 @@ export class ApplicationDevelopmentResolver {
       );
     }
 
+    if (
+      isDefined(storedPlan) &&
+      storedPlan.applicationUniversalIdentifier !==
+        manifest.application.universalIdentifier
+    ) {
+      throw new ApplicationException(
+        'The submitted application does not match the stored plan.',
+        ApplicationExceptionCode.DEPLOY_PLAN_DRIFTED,
+      );
+    }
+
     const effectiveManifest = storedPlan?.manifest ?? manifest;
 
     const applicationRegistrationId = await this.findApplicationRegistrationId(
@@ -303,6 +314,14 @@ export class ApplicationDevelopmentResolver {
         applicationRegistrationId,
       });
 
+    const nextSerial = (application.deploySerial ?? 0) + 1;
+
+    await this.applicationService.update(application.id, {
+      workspaceId,
+      version: renderDeploySerial(nextSerial),
+      deploySerial: nextSerial,
+    });
+
     if (isFirstSync || hasSchemaMetadataChanged) {
       await this.sdkClientGenerationService.generateSdkClientForApplication({
         workspaceId,
@@ -318,14 +337,6 @@ export class ApplicationDevelopmentResolver {
       workspaceId,
       application.id,
     );
-
-    const nextSerial = (application.deploySerial ?? 0) + 1;
-
-    await this.applicationService.update(application.id, {
-      workspaceId,
-      version: renderDeploySerial(nextSerial),
-      deploySerial: nextSerial,
-    });
 
     if (plan.hasDestructiveActions) {
       this.logger.log(

--- a/packages/twenty-server/src/engine/core-modules/application/application-development/application-development.resolver.ts
+++ b/packages/twenty-server/src/engine/core-modules/application/application-development/application-development.resolver.ts
@@ -19,6 +19,7 @@ import {
   ApplicationDeployPlanService,
   renderDeploySerial,
 } from 'src/engine/core-modules/application/application-deploy/application-deploy-plan.service';
+import { ApplicationDeployPlanStoreService } from 'src/engine/core-modules/application/application-deploy/application-deploy-plan-store.service';
 import { ApplicationInput } from 'src/engine/core-modules/application/application-development/dtos/application.input';
 import { ApplicationSyncPlanDTO } from 'src/engine/core-modules/application/application-development/dtos/application-sync-plan.dto';
 import { CreateDevelopmentApplicationInput } from 'src/engine/core-modules/application/application-development/dtos/create-development-application.input';
@@ -84,6 +85,7 @@ export class ApplicationDevelopmentResolver {
     private readonly throttlerService: ThrottlerService,
     private readonly cacheLockService: CacheLockService,
     private readonly applicationDeployPlanService: ApplicationDeployPlanService,
+    private readonly applicationDeployPlanStoreService: ApplicationDeployPlanStoreService,
   ) {}
 
   @Mutation(() => DevelopmentApplicationDTO)
@@ -150,15 +152,28 @@ export class ApplicationDevelopmentResolver {
       workspaceId,
     );
 
-    return this.applicationDeployPlanService.computePlan({
+    const plan = await this.applicationDeployPlanService.computePlan({
       workspaceId,
       manifest,
     });
+
+    const planId = await this.applicationDeployPlanStoreService.store({
+      workspaceId,
+      plan: {
+        applicationUniversalIdentifier:
+          manifest.application.universalIdentifier,
+        manifest,
+        planDigest: plan.planDigest,
+      },
+    });
+
+    return { ...plan, planId };
   }
 
   @Mutation(() => WorkspaceMigrationDTO)
   async syncApplication(
-    @Args() { manifest, dryRun, allowDestructive }: ApplicationInput,
+    @Args()
+    { manifest, dryRun, allowDestructive, applyPlanId }: ApplicationInput,
     @AuthWorkspace() { id: workspaceId }: WorkspaceEntity,
     @AuthUserWorkspaceId({ allowUndefined: true }) userWorkspaceId?: string,
   ): Promise<WorkspaceMigrationDTO> {
@@ -184,57 +199,90 @@ export class ApplicationDevelopmentResolver {
 
     return this.cacheLockService.withLock(
       () =>
-        this.applyManifestSync(
+        this.applyManifestSync({
           manifest,
           workspaceId,
-          allowDestructive === true,
-          userWorkspaceId,
-        ),
+          allowDestructive: allowDestructive === true,
+          actorUserWorkspaceId: userWorkspaceId,
+          applyPlanId,
+        }),
       `app-sync:${workspaceId}`,
       APP_SYNC_LOCK_OPTIONS,
     );
   }
 
-  private async applyManifestSync(
-    manifest: ApplicationInput['manifest'],
-    workspaceId: string,
-    allowDestructive: boolean,
-    actorUserWorkspaceId: string | undefined,
-  ): Promise<WorkspaceMigrationDTO> {
+  private async applyManifestSync({
+    manifest,
+    workspaceId,
+    allowDestructive,
+    actorUserWorkspaceId,
+    applyPlanId,
+  }: {
+    manifest: ApplicationInput['manifest'];
+    workspaceId: string;
+    allowDestructive: boolean;
+    actorUserWorkspaceId: string | undefined;
+    applyPlanId: string | undefined;
+  }): Promise<WorkspaceMigrationDTO> {
+    const storedPlan = isDefined(applyPlanId)
+      ? await this.applicationDeployPlanStoreService.get({
+          workspaceId,
+          planId: applyPlanId,
+        })
+      : undefined;
+
+    if (isDefined(applyPlanId) && !isDefined(storedPlan)) {
+      throw new ApplicationException(
+        'Deploy plan not found or already applied.',
+        ApplicationExceptionCode.DEPLOY_PLAN_NOT_FOUND,
+      );
+    }
+
+    const effectiveManifest = storedPlan?.manifest ?? manifest;
+
     const applicationRegistrationId = await this.findApplicationRegistrationId(
-      manifest.application.universalIdentifier,
+      effectiveManifest.application.universalIdentifier,
     );
 
     const application = await this.applicationService.findByUniversalIdentifier(
       {
-        universalIdentifier: manifest.application.universalIdentifier,
+        universalIdentifier: effectiveManifest.application.universalIdentifier,
         workspaceId,
       },
     );
 
     if (!isDefined(application)) {
       throw new ApplicationException(
-        `Application "${manifest.application.universalIdentifier}" not found in workspace "${workspaceId}". Run createDevelopmentApplication first.`,
+        `Application "${effectiveManifest.application.universalIdentifier}" not found in workspace "${workspaceId}". Run createDevelopmentApplication first.`,
         ApplicationExceptionCode.APPLICATION_NOT_FOUND,
       );
     }
 
     const plan = await this.applicationDeployPlanService.computePlan({
       workspaceId,
-      manifest,
+      manifest: effectiveManifest,
     });
+
+    if (isDefined(storedPlan) && plan.planDigest !== storedPlan.planDigest) {
+      throw new ApplicationException(
+        'The application changed since this plan was reviewed.',
+        ApplicationExceptionCode.DEPLOY_PLAN_DRIFTED,
+      );
+    }
 
     if (plan.isEmpty) {
       await this.syncRegistrationMetadata(
         applicationRegistrationId,
-        manifest,
+        effectiveManifest,
         workspaceId,
         application.id,
       );
 
+      await this.consumePlan(workspaceId, applyPlanId);
+
       return {
         applicationUniversalIdentifier:
-          manifest.application.universalIdentifier,
+          effectiveManifest.application.universalIdentifier,
         actions: [],
       };
     }
@@ -251,7 +299,7 @@ export class ApplicationDevelopmentResolver {
     const { workspaceMigration, hasSchemaMetadataChanged } =
       await this.applicationSyncService.synchronizeFromManifest({
         workspaceId,
-        manifest,
+        manifest: effectiveManifest,
         applicationRegistrationId,
       });
 
@@ -260,13 +308,13 @@ export class ApplicationDevelopmentResolver {
         workspaceId,
         applicationId: application.id,
         applicationUniversalIdentifier:
-          manifest.application.universalIdentifier,
+          effectiveManifest.application.universalIdentifier,
       });
     }
 
     await this.syncRegistrationMetadata(
       applicationRegistrationId,
-      manifest,
+      effectiveManifest,
       workspaceId,
       application.id,
     );
@@ -281,15 +329,29 @@ export class ApplicationDevelopmentResolver {
 
     if (plan.hasDestructiveActions) {
       this.logger.log(
-        `Destructive application deploy applied — application=${manifest.application.universalIdentifier} workspace=${workspaceId} actor=${actorUserWorkspaceId ?? 'unknown'} version=${renderDeploySerial(nextSerial)} destructiveActions=${plan.summary.destructiveCount} affectedRows=${plan.summary.totalAffectedRows}`,
+        `Destructive application deploy applied — application=${effectiveManifest.application.universalIdentifier} workspace=${workspaceId} actor=${actorUserWorkspaceId ?? 'unknown'} version=${renderDeploySerial(nextSerial)} destructiveActions=${plan.summary.destructiveCount} affectedRows=${plan.summary.totalAffectedRows}`,
       );
     }
+
+    await this.consumePlan(workspaceId, applyPlanId);
 
     return {
       applicationUniversalIdentifier:
         workspaceMigration.applicationUniversalIdentifier,
       actions: workspaceMigration.actions,
     };
+  }
+
+  private async consumePlan(
+    workspaceId: string,
+    applyPlanId: string | undefined,
+  ): Promise<void> {
+    if (isDefined(applyPlanId)) {
+      await this.applicationDeployPlanStoreService.consume({
+        workspaceId,
+        planId: applyPlanId,
+      });
+    }
   }
 
   private buildDestructiveChangesMessage(plan: ApplicationSyncPlanDTO): string {

--- a/packages/twenty-server/src/engine/core-modules/application/application-development/dtos/application-sync-plan.dto.ts
+++ b/packages/twenty-server/src/engine/core-modules/application/application-development/dtos/application-sync-plan.dto.ts
@@ -47,6 +47,12 @@ export class ApplicationSyncPlanDTO {
   @Field(() => String)
   applicationUniversalIdentifier: string;
 
+  @Field(() => String, { nullable: true })
+  planId: string | null;
+
+  @Field(() => String)
+  planDigest: string;
+
   @Field(() => [ApplicationSyncPlanActionDTO])
   actions: ApplicationSyncPlanActionDTO[];
 

--- a/packages/twenty-server/src/engine/core-modules/application/application-development/dtos/application.input.ts
+++ b/packages/twenty-server/src/engine/core-modules/application/application-development/dtos/application.input.ts
@@ -13,4 +13,7 @@ export class ApplicationInput {
 
   @Field(() => Boolean, { nullable: true })
   allowDestructive?: boolean;
+
+  @Field(() => String, { nullable: true })
+  applyPlanId?: string;
 }

--- a/packages/twenty-server/src/engine/core-modules/application/application-exception-filter.ts
+++ b/packages/twenty-server/src/engine/core-modules/application/application-exception-filter.ts
@@ -32,6 +32,8 @@ export class ApplicationExceptionFilter implements ExceptionFilter {
       case ApplicationExceptionCode.APP_ALREADY_INSTALLED:
       case ApplicationExceptionCode.CANNOT_DOWNGRADE_APPLICATION:
       case ApplicationExceptionCode.DESTRUCTIVE_CHANGES_NOT_APPROVED:
+      case ApplicationExceptionCode.DEPLOY_PLAN_NOT_FOUND:
+      case ApplicationExceptionCode.DEPLOY_PLAN_DRIFTED:
       case ApplicationExceptionCode.SERVER_VERSION_INCOMPATIBLE:
       case ApplicationExceptionCode.INVALID_APP_ENGINE_REQUIREMENT:
         throw new UserInputError(exception);

--- a/packages/twenty-server/src/engine/core-modules/application/application-rest-api-exception.filter.ts
+++ b/packages/twenty-server/src/engine/core-modules/application/application-rest-api-exception.filter.ts
@@ -34,6 +34,8 @@ const applicationExceptionCodeToHttpStatus = (
     case ApplicationExceptionCode.APP_ALREADY_INSTALLED:
     case ApplicationExceptionCode.CANNOT_DOWNGRADE_APPLICATION:
     case ApplicationExceptionCode.DESTRUCTIVE_CHANGES_NOT_APPROVED:
+    case ApplicationExceptionCode.DEPLOY_PLAN_NOT_FOUND:
+    case ApplicationExceptionCode.DEPLOY_PLAN_DRIFTED:
     case ApplicationExceptionCode.SERVER_VERSION_INCOMPATIBLE:
     case ApplicationExceptionCode.INVALID_APP_ENGINE_REQUIREMENT:
       return 400;

--- a/packages/twenty-server/src/engine/core-modules/application/application.exception.ts
+++ b/packages/twenty-server/src/engine/core-modules/application/application.exception.ts
@@ -23,6 +23,8 @@ export enum ApplicationExceptionCode {
   APP_ALREADY_INSTALLED = 'APP_ALREADY_INSTALLED',
   CANNOT_DOWNGRADE_APPLICATION = 'CANNOT_DOWNGRADE_APPLICATION',
   DESTRUCTIVE_CHANGES_NOT_APPROVED = 'DESTRUCTIVE_CHANGES_NOT_APPROVED',
+  DEPLOY_PLAN_NOT_FOUND = 'DEPLOY_PLAN_NOT_FOUND',
+  DEPLOY_PLAN_DRIFTED = 'DEPLOY_PLAN_DRIFTED',
   SERVER_VERSION_INCOMPATIBLE = 'SERVER_VERSION_INCOMPATIBLE',
   INVALID_APP_ENGINE_REQUIREMENT = 'INVALID_APP_ENGINE_REQUIREMENT',
   INVALID_SERVER_VERSION = 'INVALID_SERVER_VERSION',
@@ -68,6 +70,10 @@ const getApplicationExceptionUserFriendlyMessage = (
       return msg`A higher version of this application is already installed. Downgrading is not allowed.`;
     case ApplicationExceptionCode.DESTRUCTIVE_CHANGES_NOT_APPROVED:
       return msg`This deploy permanently deletes data. Review the plan and confirm destructive changes to proceed.`;
+    case ApplicationExceptionCode.DEPLOY_PLAN_NOT_FOUND:
+      return msg`This deploy plan has expired or was already applied. Re-run the plan and try again.`;
+    case ApplicationExceptionCode.DEPLOY_PLAN_DRIFTED:
+      return msg`The application changed since this plan was reviewed. Re-run the plan and try again.`;
     case ApplicationExceptionCode.SERVER_VERSION_INCOMPATIBLE:
       return msg`This app requires a newer version of the Twenty server. Please upgrade your server or use a compatible app version.`;
     case ApplicationExceptionCode.INVALID_APP_ENGINE_REQUIREMENT:

--- a/packages/twenty-server/src/engine/core-modules/cache-storage/types/cache-storage-namespace.enum.ts
+++ b/packages/twenty-server/src/engine/core-modules/cache-storage/types/cache-storage-namespace.enum.ts
@@ -10,5 +10,6 @@ export enum CacheStorageNamespace {
   EngineSubscriptions = 'engine:subscriptions',
   EngineBillingUsage = 'engine:billing-usage',
   EngineOnboardingInviteSuggestions = 'engine:onboarding-invite-suggestions',
+  EngineApplicationDeployPlan = 'engine:application-deploy-plan',
   IntegrationTests = 'integration-tests',
 }

--- a/packages/twenty-server/test/integration/metadata/suites/application/application-deploy-stored-plan.integration-spec.ts
+++ b/packages/twenty-server/test/integration/metadata/suites/application/application-deploy-stored-plan.integration-spec.ts
@@ -1,0 +1,151 @@
+import { buildBaseManifest } from 'test/integration/metadata/suites/application/utils/build-base-manifest.util';
+import { buildDefaultObjectManifest } from 'test/integration/metadata/suites/application/utils/build-default-object-manifest.util';
+import { cleanupApplicationAndAppRegistration } from 'test/integration/metadata/suites/application/utils/cleanup-application-and-app-registration.util';
+import { planApplicationSync } from 'test/integration/metadata/suites/application/utils/plan-application-sync.util';
+import { setupApplicationForSync } from 'test/integration/metadata/suites/application/utils/setup-application-for-sync.util';
+import { syncApplication } from 'test/integration/metadata/suites/application/utils/sync-application.util';
+import { findManyObjectMetadata } from 'test/integration/metadata/suites/object-metadata/utils/find-many-object-metadata.util';
+import { type Manifest } from 'twenty-shared/application';
+import { FieldMetadataType } from 'twenty-shared/types';
+import { v4 as uuidv4 } from 'uuid';
+
+const TEST_APP_ID = uuidv4();
+const TEST_ROLE_ID = uuidv4();
+const DRIFT_FIELD_ID = uuidv4();
+
+const PLANNED_OBJECT = buildDefaultObjectManifest({
+  nameSingular: 'storedPlanRecord',
+  namePlural: 'storedPlanRecords',
+  labelSingular: 'Stored Plan Record',
+  labelPlural: 'Stored Plan Records',
+  description: 'The object described by the stored plan',
+});
+
+const DECOY_OBJECT = buildDefaultObjectManifest({
+  nameSingular: 'storedPlanDecoy',
+  namePlural: 'storedPlanDecoys',
+  labelSingular: 'Stored Plan Decoy',
+  labelPlural: 'Stored Plan Decoys',
+  description: 'A decoy object that must be ignored when applying by plan id',
+});
+
+const DRIFT_OBJECT_WITH_FIELD = buildDefaultObjectManifest({
+  nameSingular: 'driftRecord',
+  namePlural: 'driftRecords',
+  labelSingular: 'Drift Record',
+  labelPlural: 'Drift Records',
+  description: 'Baseline object for the drift scenario',
+  additionalFields: [
+    {
+      universalIdentifier: DRIFT_FIELD_ID,
+      type: FieldMetadataType.TEXT,
+      name: 'extraNotes',
+      label: 'Extra notes',
+    },
+  ],
+});
+
+const DRIFT_OBJECT = {
+  ...DRIFT_OBJECT_WITH_FIELD,
+  fields: DRIFT_OBJECT_WITH_FIELD.fields.filter(
+    (field) => field.universalIdentifier !== DRIFT_FIELD_ID,
+  ),
+};
+
+const buildManifest = (overrides?: Partial<Manifest>) =>
+  buildBaseManifest({ appId: TEST_APP_ID, roleId: TEST_ROLE_ID, overrides });
+
+const findObjectNames = async (): Promise<string[]> => {
+  const { objects } = await findManyObjectMetadata({
+    input: { filter: {}, paging: { first: 100 } },
+    gqlFields: 'id nameSingular',
+    expectToFail: false,
+  });
+
+  return objects.map((object) => object.nameSingular);
+};
+
+describe('Application deploy — stored plan apply-by-id and drift', () => {
+  beforeEach(async () => {
+    await setupApplicationForSync({
+      applicationUniversalIdentifier: TEST_APP_ID,
+      name: 'Stored Plan Test Application',
+      description: 'App for testing apply-by-plan-id and drift detection',
+      sourcePath: 'application-deploy-stored-plan',
+    });
+  }, 60000);
+
+  afterEach(async () => {
+    await cleanupApplicationAndAppRegistration({
+      applicationUniversalIdentifier: TEST_APP_ID,
+    });
+  });
+
+  it('returns a planId and digest for a non-empty plan', async () => {
+    const plan = (
+      await planApplicationSync({
+        manifest: buildManifest({ objects: [PLANNED_OBJECT] }),
+      })
+    ).data.planApplicationSync;
+
+    expect(plan.planId).toEqual(expect.any(String));
+    expect(plan.planDigest.length).toBeGreaterThan(0);
+  }, 60000);
+
+  it('applies exactly the stored plan by id, ignoring the submitted manifest, then consumes it', async () => {
+    const plan = (
+      await planApplicationSync({
+        manifest: buildManifest({ objects: [PLANNED_OBJECT] }),
+      })
+    ).data.planApplicationSync;
+
+    const planId = plan.planId as string;
+
+    await syncApplication({
+      manifest: buildManifest({ objects: [DECOY_OBJECT] }),
+      applyPlanId: planId,
+      expectToFail: false,
+    });
+
+    const objectNames = await findObjectNames();
+
+    expect(objectNames).toContain('storedPlanRecord');
+    expect(objectNames).not.toContain('storedPlanDecoy');
+
+    const retry = await syncApplication({
+      manifest: buildManifest({ objects: [PLANNED_OBJECT] }),
+      applyPlanId: planId,
+      expectToFail: true,
+    });
+
+    expect(JSON.stringify(retry.errors)).toContain('DEPLOY_PLAN_NOT_FOUND');
+  }, 60000);
+
+  it('rejects a stored plan that drifted before apply', async () => {
+    await syncApplication({
+      manifest: buildManifest({ objects: [DRIFT_OBJECT] }),
+      expectToFail: false,
+    });
+
+    const plan = (
+      await planApplicationSync({
+        manifest: buildManifest({ objects: [DRIFT_OBJECT_WITH_FIELD] }),
+      })
+    ).data.planApplicationSync;
+
+    const planId = plan.planId as string;
+
+    await syncApplication({
+      manifest: buildManifest({ objects: [DRIFT_OBJECT_WITH_FIELD] }),
+      expectToFail: false,
+    });
+
+    const drifted = await syncApplication({
+      manifest: buildManifest({ objects: [DRIFT_OBJECT_WITH_FIELD] }),
+      applyPlanId: planId,
+      expectToFail: true,
+    });
+
+    expect(JSON.stringify(drifted.errors)).toContain('DEPLOY_PLAN_DRIFTED');
+  }, 60000);
+});

--- a/packages/twenty-server/test/integration/metadata/suites/application/utils/plan-application-sync-query-factory.util.ts
+++ b/packages/twenty-server/test/integration/metadata/suites/application/utils/plan-application-sync-query-factory.util.ts
@@ -10,6 +10,8 @@ export const planApplicationSyncQueryFactory = ({
     mutation PlanApplicationSync($manifest: JSON!) {
       planApplicationSync(manifest: $manifest) {
         applicationUniversalIdentifier
+        planId
+        planDigest
         isEmpty
         hasDestructiveActions
         currentVersion

--- a/packages/twenty-server/test/integration/metadata/suites/application/utils/plan-application-sync.util.ts
+++ b/packages/twenty-server/test/integration/metadata/suites/application/utils/plan-application-sync.util.ts
@@ -15,6 +15,8 @@ type ApplicationSyncPlanAction = {
 
 type ApplicationSyncPlan = {
   applicationUniversalIdentifier: string;
+  planId: string | null;
+  planDigest: string;
   isEmpty: boolean;
   hasDestructiveActions: boolean;
   currentVersion: string | null;

--- a/packages/twenty-server/test/integration/metadata/suites/application/utils/sync-application-query-factory.util.ts
+++ b/packages/twenty-server/test/integration/metadata/suites/application/utils/sync-application-query-factory.util.ts
@@ -5,21 +5,25 @@ export const syncApplicationQueryFactory = ({
   manifest,
   dryRun,
   allowDestructive,
+  applyPlanId,
 }: {
   manifest: Manifest;
   dryRun?: boolean;
   allowDestructive?: boolean;
+  applyPlanId?: string;
 }) => ({
   query: gql`
     mutation SyncApplication(
       $manifest: JSON!
       $dryRun: Boolean
       $allowDestructive: Boolean
+      $applyPlanId: String
     ) {
       syncApplication(
         manifest: $manifest
         dryRun: $dryRun
         allowDestructive: $allowDestructive
+        applyPlanId: $applyPlanId
       ) {
         applicationUniversalIdentifier
         actions
@@ -30,5 +34,6 @@ export const syncApplicationQueryFactory = ({
     manifest,
     dryRun,
     allowDestructive,
+    applyPlanId,
   },
 });

--- a/packages/twenty-server/test/integration/metadata/suites/application/utils/sync-application.util.ts
+++ b/packages/twenty-server/test/integration/metadata/suites/application/utils/sync-application.util.ts
@@ -16,12 +16,14 @@ export const syncApplication = async ({
   token,
   dryRun,
   allowDestructive,
+  applyPlanId,
 }: {
   manifest: Manifest;
   expectToFail?: boolean;
   token?: string;
   dryRun?: boolean;
   allowDestructive?: boolean;
+  applyPlanId?: string;
 }): CommonResponseBody<{
   syncApplication: WorkspaceMigration;
 }> => {
@@ -29,6 +31,7 @@ export const syncApplication = async ({
     manifest,
     dryRun,
     allowDestructive,
+    applyPlanId,
   });
 
   const response = await makeMetadataAPIRequest(graphqlOperation, token);


### PR DESCRIPTION
> Stacked on #22333 (base branch `feat/apps-deploy-plan-apply`). Review/merge that first.

## What & why

#22333 added a destructive gate bound to a freshly-recomputed plan, but `allowDestructive` was a bare flag and the apply re-read the client-submitted manifest — so a client could review one plan and apply a different manifest. This PR makes apply run **exactly the plan that was reviewed**.

## Changes

- **`planApplicationSync`** persists the computed plan in Redis (30-minute TTL, per-workspace key) and returns a **`planId`** plus a **`planDigest`** — a sha256 over the metadata change set (action type/identity/severity + proposed version, deliberately **excluding** row counts, which move with data).
- **`syncApplication` gains `applyPlanId`**: when set, the server loads the stored plan, applies **its** manifest (the submitted manifest is ignored), recomputes the plan **under the existing app-sync lock**, and refuses with **`DEPLOY_PLAN_DRIFTED`** if the recomputed digest no longer matches — i.e. the application changed since the plan was reviewed.
- The stored plan is **consumed on apply**, so a `planId` is single-use; reuse or expiry yields **`DEPLOY_PLAN_NOT_FOUND`**. Both new errors map to HTTP 400 / `BAD_USER_INPUT`.
- `applyPlanId` is optional, so the existing manifest-driven path (and the frictionless `yarn twenty dev` watcher) is unchanged.

## Testing

Integration tests (`application-deploy-stored-plan.integration-spec.ts`): a plan returns a `planId`/`planDigest`; apply-by-id applies the **stored** object while a decoy submitted manifest is ignored, then the consumed plan reuse fails `DEPLOY_PLAN_NOT_FOUND`; a plan whose change was applied by an intervening sync is rejected `DEPLOY_PLAN_DRIFTED`. Full application suite green (121 passing); schemas regenerated; typecheck/lint clean.

## Follow-ups (next in the stack)

Soft-delete + retention (makes destructive ops reversible and flips the "permanently deletes" copy), then the front-end plan-review modal.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/22339?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

