### PR TITLE
feat(apps): preview and destructive-gate marketplace upgrades

### DIFF
--- a/packages/twenty-client-sdk/src/metadata/generated/schema.graphql
+++ b/packages/twenty-client-sdk/src/metadata/generated/schema.graphql
@@ -3195,6 +3195,7 @@ type Query {
   findManyPublicDomains: [PublicDomain!]!
   findManyMarketplaceApps: [MarketplaceApp!]!
   findMarketplaceAppDetail(universalIdentifier: String!): MarketplaceAppDetail!
+  planApplicationUpgrade(appRegistrationId: String!, targetVersion: String!): ApplicationSyncPlan!
 }
 
 input GetApiKeyInput {
@@ -3495,14 +3496,14 @@ type Mutation {
   checkPublicDomainValidRecords(domain: String!): DomainValidRecords
   createOneAppToken(input: CreateOneAppTokenInput!): AppToken!
   installMarketplaceApp(universalIdentifier: String!, version: String): Boolean! @deprecated(reason: "Use installApplication instead")
-  installApplication(universalIdentifier: String!, version: String): Application!
+  installApplication(universalIdentifier: String!, version: String, allowDestructive: Boolean): Application!
   syncMarketplaceCatalog: Boolean!
   createDevelopmentApplication(universalIdentifier: String!, name: String!): DevelopmentApplication!
   generateApplicationToken(applicationId: UUID!): ApplicationTokenPair!
   planApplicationSync(manifest: JSON!, dryRun: Boolean, allowDestructive: Boolean, applyPlanId: String): ApplicationSyncPlan!
   syncApplication(manifest: JSON!, dryRun: Boolean, allowDestructive: Boolean, applyPlanId: String): WorkspaceMigration!
   uploadApplicationFile(file: Upload!, applicationUniversalIdentifier: String!, fileFolder: FileFolder!, filePath: String!): File!
-  upgradeApplication(appRegistrationId: String!, targetVersion: String!): Boolean!
+  upgradeApplication(appRegistrationId: String!, targetVersion: String!, allowDestructive: Boolean): Boolean!
   renewApplicationToken(applicationRefreshToken: String!): ApplicationTokenPair!
 }
 

--- a/packages/twenty-client-sdk/src/metadata/generated/schema.ts
+++ b/packages/twenty-client-sdk/src/metadata/generated/schema.ts
@@ -2797,6 +2797,7 @@ export interface Query {
     findManyPublicDomains: PublicDomain[]
     findManyMarketplaceApps: MarketplaceApp[]
     findMarketplaceAppDetail: MarketplaceAppDetail
+    planApplicationUpgrade: ApplicationSyncPlan
     __typename: 'Query'
 }
 
@@ -6008,6 +6009,7 @@ export interface QueryGenqlSelection{
     findManyPublicDomains?: PublicDomainGenqlSelection
     findManyMarketplaceApps?: MarketplaceAppGenqlSelection
     findMarketplaceAppDetail?: (MarketplaceAppDetailGenqlSelection & { __args: {universalIdentifier: Scalars['String']} })
+    planApplicationUpgrade?: (ApplicationSyncPlanGenqlSelection & { __args: {appRegistrationId: Scalars['String'], targetVersion: Scalars['String']} })
     __typename?: boolean | number
     __scalar?: boolean | number
 }
@@ -6255,14 +6257,14 @@ export interface MutationGenqlSelection{
     createOneAppToken?: (AppTokenGenqlSelection & { __args: {input: CreateOneAppTokenInput} })
     /** @deprecated Use installApplication instead */
     installMarketplaceApp?: { __args: {universalIdentifier: Scalars['String'], version?: (Scalars['String'] | null)} }
-    installApplication?: (ApplicationGenqlSelection & { __args: {universalIdentifier: Scalars['String'], version?: (Scalars['String'] | null)} })
+    installApplication?: (ApplicationGenqlSelection & { __args: {universalIdentifier: Scalars['String'], version?: (Scalars['String'] | null), allowDestructive?: (Scalars['Boolean'] | null)} })
     syncMarketplaceCatalog?: boolean | number
     createDevelopmentApplication?: (DevelopmentApplicationGenqlSelection & { __args: {universalIdentifier: Scalars['String'], name: Scalars['String']} })
     generateApplicationToken?: (ApplicationTokenPairGenqlSelection & { __args: {applicationId: Scalars['UUID']} })
     planApplicationSync?: (ApplicationSyncPlanGenqlSelection & { __args: {manifest: Scalars['JSON'], dryRun?: (Scalars['Boolean'] | null), allowDestructive?: (Scalars['Boolean'] | null), applyPlanId?: (Scalars['String'] | null)} })
     syncApplication?: (WorkspaceMigrationGenqlSelection & { __args: {manifest: Scalars['JSON'], dryRun?: (Scalars['Boolean'] | null), allowDestructive?: (Scalars['Boolean'] | null), applyPlanId?: (Scalars['String'] | null)} })
     uploadApplicationFile?: (FileGenqlSelection & { __args: {file: Scalars['Upload'], applicationUniversalIdentifier: Scalars['String'], fileFolder: FileFolder, filePath: Scalars['String']} })
-    upgradeApplication?: { __args: {appRegistrationId: Scalars['String'], targetVersion: Scalars['String']} }
+    upgradeApplication?: { __args: {appRegistrationId: Scalars['String'], targetVersion: Scalars['String'], allowDestructive?: (Scalars['Boolean'] | null)} }
     renewApplicationToken?: (ApplicationTokenPairGenqlSelection & { __args: {applicationRefreshToken: Scalars['String']} })
     __typename?: boolean | number
     __scalar?: boolean | number

--- a/packages/twenty-client-sdk/src/metadata/generated/types.ts
+++ b/packages/twenty-client-sdk/src/metadata/generated/types.ts
@@ -6850,6 +6850,19 @@ export default {
                     ]
                 }
             ],
+            "planApplicationUpgrade": [
+                267,
+                {
+                    "appRegistrationId": [
+                        1,
+                        "String!"
+                    ],
+                    "targetVersion": [
+                        1,
+                        "String!"
+                    ]
+                }
+            ],
             "__typename": [
                 1
             ]
@@ -9116,6 +9129,9 @@ export default {
                     ],
                     "version": [
                         1
+                    ],
+                    "allowDestructive": [
+                        6
                     ]
                 }
             ],
@@ -9211,6 +9227,9 @@ export default {
                     "targetVersion": [
                         1,
                         "String!"
+                    ],
+                    "allowDestructive": [
+                        6
                     ]
                 }
             ],

--- a/packages/twenty-front/src/generated-metadata/graphql.ts
+++ b/packages/twenty-front/src/generated-metadata/graphql.ts
@@ -3295,6 +3295,7 @@ export type MutationInitiateOtpProvisioningArgs = {
 
 
 export type MutationInstallApplicationArgs = {
+  allowDestructive?: InputMaybe<Scalars['Boolean']['input']>;
   universalIdentifier: Scalars['String']['input'];
   version?: InputMaybe<Scalars['String']['input']>;
 };
@@ -3724,6 +3725,7 @@ export type MutationUpdateWorkspaceMemberSettingsArgs = {
 
 
 export type MutationUpgradeApplicationArgs = {
+  allowDestructive?: InputMaybe<Scalars['Boolean']['input']>;
   appRegistrationId: Scalars['String']['input'];
   targetVersion: Scalars['String']['input'];
 };
@@ -4429,6 +4431,7 @@ export type Query = {
   objectRecordCounts: Array<ObjectRecordCount>;
   objects: ObjectConnection;
   pieChartData: PieChartData;
+  planApplicationUpgrade: ApplicationSyncPlan;
   previewMessageCampaignAudience: CampaignAudiencePreviewDto;
   skill?: Maybe<Skill>;
   skills: Array<Skill>;
@@ -4799,6 +4802,12 @@ export type QueryObjectsArgs = {
 
 export type QueryPieChartDataArgs = {
   input: PieChartDataInput;
+};
+
+
+export type QueryPlanApplicationUpgradeArgs = {
+  appRegistrationId: Scalars['String']['input'];
+  targetVersion: Scalars['String']['input'];
 };
 
 

--- a/packages/twenty-server/src/engine/core-modules/application/application-deploy/application-deploy.module.ts
+++ b/packages/twenty-server/src/engine/core-modules/application/application-deploy/application-deploy.module.ts
@@ -1,0 +1,14 @@
+import { Module } from '@nestjs/common';
+
+import { ApplicationDeployPlanService } from 'src/engine/core-modules/application/application-deploy/application-deploy-plan.service';
+import { ApplicationDeployPlanStoreService } from 'src/engine/core-modules/application/application-deploy/application-deploy-plan-store.service';
+import { ApplicationManifestModule } from 'src/engine/core-modules/application/application-manifest/application-manifest.module';
+import { ApplicationModule } from 'src/engine/core-modules/application/application.module';
+import { WorkspaceCacheModule } from 'src/engine/workspace-cache/workspace-cache.module';
+
+@Module({
+  imports: [ApplicationModule, ApplicationManifestModule, WorkspaceCacheModule],
+  providers: [ApplicationDeployPlanService, ApplicationDeployPlanStoreService],
+  exports: [ApplicationDeployPlanService, ApplicationDeployPlanStoreService],
+})
+export class ApplicationDeployModule {}

--- a/packages/twenty-server/src/engine/core-modules/application/application-deploy/utils/build-destructive-changes-message.util.ts
+++ b/packages/twenty-server/src/engine/core-modules/application/application-deploy/utils/build-destructive-changes-message.util.ts
@@ -1,0 +1,12 @@
+import { type ApplicationSyncPlanDTO } from 'src/engine/core-modules/application/application-development/dtos/application-sync-plan.dto';
+
+export const buildDestructiveChangesMessage = (
+  plan: ApplicationSyncPlanDTO,
+): string => {
+  const destructiveLabels = plan.actions
+    .filter((action) => action.severity === 'destructive')
+    .map((action) => action.label ?? action.universalIdentifier)
+    .join(', ');
+
+  return `This deploy includes ${plan.summary.destructiveCount} destructive change(s) that permanently delete data (${destructiveLabels}). Re-run with allowDestructive set to true to proceed.`;
+};

--- a/packages/twenty-server/src/engine/core-modules/application/application-development/application-development.module.ts
+++ b/packages/twenty-server/src/engine/core-modules/application/application-development/application-development.module.ts
@@ -1,8 +1,7 @@
 import { Module } from '@nestjs/common';
 
 import { ApplicationRegistrationModule } from 'src/engine/core-modules/application/application-registration/application-registration.module';
-import { ApplicationDeployPlanService } from 'src/engine/core-modules/application/application-deploy/application-deploy-plan.service';
-import { ApplicationDeployPlanStoreService } from 'src/engine/core-modules/application/application-deploy/application-deploy-plan-store.service';
+import { ApplicationDeployModule } from 'src/engine/core-modules/application/application-deploy/application-deploy.module';
 import { ApplicationManifestModule } from 'src/engine/core-modules/application/application-manifest/application-manifest.module';
 import { ApplicationModule } from 'src/engine/core-modules/application/application.module';
 import { ApplicationDevelopmentResolver } from 'src/engine/core-modules/application/application-development/application-development.resolver';
@@ -21,6 +20,7 @@ import { WorkspaceMigrationGraphqlApiExceptionInterceptor } from 'src/engine/wor
     ApplicationModule,
     ApplicationManifestModule,
     ApplicationRegistrationModule,
+    ApplicationDeployModule,
     CacheLockModule,
     FeatureFlagModule,
     SdkClientModule,
@@ -32,8 +32,6 @@ import { WorkspaceMigrationGraphqlApiExceptionInterceptor } from 'src/engine/wor
   ],
   providers: [
     ApplicationDevelopmentResolver,
-    ApplicationDeployPlanService,
-    ApplicationDeployPlanStoreService,
     WorkspaceMigrationGraphqlApiExceptionInterceptor,
   ],
 })

--- a/packages/twenty-server/src/engine/core-modules/application/application-development/application-development.resolver.ts
+++ b/packages/twenty-server/src/engine/core-modules/application/application-development/application-development.resolver.ts
@@ -20,6 +20,7 @@ import {
   renderDeploySerial,
 } from 'src/engine/core-modules/application/application-deploy/application-deploy-plan.service';
 import { ApplicationDeployPlanStoreService } from 'src/engine/core-modules/application/application-deploy/application-deploy-plan-store.service';
+import { buildDestructiveChangesMessage } from 'src/engine/core-modules/application/application-deploy/utils/build-destructive-changes-message.util';
 import { ApplicationInput } from 'src/engine/core-modules/application/application-development/dtos/application.input';
 import { ApplicationSyncPlanDTO } from 'src/engine/core-modules/application/application-development/dtos/application-sync-plan.dto';
 import { CreateDevelopmentApplicationInput } from 'src/engine/core-modules/application/application-development/dtos/create-development-application.input';
@@ -300,7 +301,7 @@ export class ApplicationDevelopmentResolver {
 
     if (plan.hasDestructiveActions && !allowDestructive) {
       throw new ApplicationException(
-        this.buildDestructiveChangesMessage(plan),
+        buildDestructiveChangesMessage(plan),
         ApplicationExceptionCode.DESTRUCTIVE_CHANGES_NOT_APPROVED,
       );
     }
@@ -363,15 +364,6 @@ export class ApplicationDevelopmentResolver {
         planId: applyPlanId,
       });
     }
-  }
-
-  private buildDestructiveChangesMessage(plan: ApplicationSyncPlanDTO): string {
-    const destructiveLabels = plan.actions
-      .filter((action) => action.severity === 'destructive')
-      .map((action) => action.label ?? action.universalIdentifier)
-      .join(', ');
-
-    return `This deploy includes ${plan.summary.destructiveCount} destructive change(s) that permanently delete data (${destructiveLabels}). Re-run with allowDestructive set to true to proceed.`;
   }
 
   @Mutation(() => FileDTO)

--- a/packages/twenty-server/src/engine/core-modules/application/application-install/application-install.module.ts
+++ b/packages/twenty-server/src/engine/core-modules/application/application-install/application-install.module.ts
@@ -4,6 +4,7 @@ import { TypeOrmModule } from '@nestjs/typeorm';
 import { CacheLockModule } from 'src/engine/core-modules/cache-lock/cache-lock.module';
 import { FeatureFlagModule } from 'src/engine/core-modules/feature-flag/feature-flag.module';
 import { ApplicationRegistrationEntity } from 'src/engine/core-modules/application/application-registration/application-registration.entity';
+import { ApplicationDeployModule } from 'src/engine/core-modules/application/application-deploy/application-deploy.module';
 import { ApplicationModule } from 'src/engine/core-modules/application/application.module';
 import { ApplicationManifestModule } from 'src/engine/core-modules/application/application-manifest/application-manifest.module';
 import { ApplicationPackageModule } from 'src/engine/core-modules/application/application-package/application-package.module';
@@ -21,6 +22,7 @@ import { WorkspaceCacheModule } from 'src/engine/workspace-cache/workspace-cache
     ApplicationModule,
     ApplicationManifestModule,
     ApplicationPackageModule,
+    ApplicationDeployModule,
     CacheLockModule,
     FeatureFlagModule,
     LogicFunctionModule,

--- a/packages/twenty-server/src/engine/core-modules/application/application-install/application-install.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/application/application-install/application-install.service.ts
@@ -23,6 +23,9 @@ import {
   ApplicationVersionValidationService,
   type VersionValidationFailureReason,
 } from 'src/engine/core-modules/application/application-package/application-version-validation.service';
+import { ApplicationDeployPlanService } from 'src/engine/core-modules/application/application-deploy/application-deploy-plan.service';
+import { buildDestructiveChangesMessage } from 'src/engine/core-modules/application/application-deploy/utils/build-destructive-changes-message.util';
+import { type ApplicationSyncPlanDTO } from 'src/engine/core-modules/application/application-development/dtos/application-sync-plan.dto';
 import { ApplicationSyncService } from 'src/engine/core-modules/application/application-manifest/application-sync.service';
 import { CacheLockService } from 'src/engine/core-modules/cache-lock/cache-lock.service';
 import { FileStorageService } from 'src/engine/core-modules/file-storage/file-storage.service';
@@ -58,6 +61,7 @@ export class ApplicationInstallService {
     private readonly applicationPackageFetcherService: ApplicationPackageFetcherService,
     private readonly applicationVersionValidationService: ApplicationVersionValidationService,
     private readonly applicationSyncService: ApplicationSyncService,
+    private readonly applicationDeployPlanService: ApplicationDeployPlanService,
     private readonly fileStorageService: FileStorageService,
     private readonly logicFunctionExecutorService: LogicFunctionExecutorService,
     private readonly cacheLockService: CacheLockService,
@@ -71,6 +75,7 @@ export class ApplicationInstallService {
     appRegistrationId: string;
     version?: string;
     workspaceId: string;
+    allowDestructive?: boolean;
   }): Promise<boolean> {
     const appRegistration = await this.appRegistrationRepository.findOne({
       where: { id: params.appRegistrationId },
@@ -111,6 +116,7 @@ export class ApplicationInstallService {
         this.doInstallApplication(appRegistration, {
           version: params.version,
           workspaceId: params.workspaceId,
+          allowDestructive: params.allowDestructive === true,
         }),
       lockKey,
       { ttl: 60_000, ms: 500, maxRetries: 120 },
@@ -119,7 +125,11 @@ export class ApplicationInstallService {
 
   private async doInstallApplication(
     appRegistration: ApplicationRegistrationEntity,
-    params: { version?: string; workspaceId: string },
+    params: {
+      version?: string;
+      workspaceId: string;
+      allowDestructive: boolean;
+    },
   ): Promise<boolean> {
     const resolvedPackage =
       await this.applicationPackageFetcherService.resolvePackage(
@@ -215,6 +225,13 @@ export class ApplicationInstallService {
         }
       }
 
+      await this.assertUpgradeIsNotUnexpectedlyDestructive({
+        isVersionUpgrade,
+        allowDestructive: params.allowDestructive,
+        workspaceId: params.workspaceId,
+        manifest: resolvedPackage.manifest,
+      });
+
       await this.writeFilesToStorage(
         resolvedPackage.extractedDir,
         resolvedPackage.manifest,
@@ -280,6 +297,70 @@ export class ApplicationInstallService {
           resolvedPackage.cleanupDir,
         );
       }
+    }
+  }
+
+  async planUpgrade(params: {
+    appRegistrationId: string;
+    targetVersion?: string;
+    workspaceId: string;
+  }): Promise<ApplicationSyncPlanDTO> {
+    const appRegistration = await this.appRegistrationRepository.findOne({
+      where: { id: params.appRegistrationId },
+    });
+
+    if (!appRegistration) {
+      throw new ApplicationException(
+        `Application registration with id ${params.appRegistrationId} not found`,
+        ApplicationExceptionCode.APPLICATION_NOT_FOUND,
+      );
+    }
+
+    const resolvedPackage =
+      await this.applicationPackageFetcherService.resolvePackage(
+        appRegistration,
+        { targetVersion: params.targetVersion },
+      );
+
+    if (!resolvedPackage) {
+      throw new ApplicationException(
+        `Cannot resolve a package to plan for "${appRegistration.universalIdentifier}".`,
+        ApplicationExceptionCode.PACKAGE_RESOLUTION_FAILED,
+      );
+    }
+
+    try {
+      return await this.applicationDeployPlanService.computePlan({
+        workspaceId: params.workspaceId,
+        manifest: resolvedPackage.manifest,
+      });
+    } finally {
+      await this.applicationPackageFetcherService.cleanupExtractedDir(
+        resolvedPackage.cleanupDir,
+      );
+    }
+  }
+
+  private async assertUpgradeIsNotUnexpectedlyDestructive(params: {
+    isVersionUpgrade: boolean;
+    allowDestructive: boolean;
+    workspaceId: string;
+    manifest: Manifest;
+  }): Promise<void> {
+    if (!params.isVersionUpgrade || params.allowDestructive) {
+      return;
+    }
+
+    const plan = await this.applicationDeployPlanService.computePlan({
+      workspaceId: params.workspaceId,
+      manifest: params.manifest,
+    });
+
+    if (plan.hasDestructiveActions) {
+      throw new ApplicationException(
+        buildDestructiveChangesMessage(plan),
+        ApplicationExceptionCode.DESTRUCTIVE_CHANGES_NOT_APPROVED,
+      );
     }
   }
 

--- a/packages/twenty-server/src/engine/core-modules/application/application-marketplace/marketplace.resolver.ts
+++ b/packages/twenty-server/src/engine/core-modules/application/application-marketplace/marketplace.resolver.ts
@@ -3,6 +3,7 @@ import { Args, Mutation, Query } from '@nestjs/graphql';
 
 import { PermissionFlagType } from 'twenty-shared/constants';
 import { MetadataResolver } from 'src/engine/api/graphql/graphql-config/decorators/metadata-resolver.decorator';
+import { ApplicationExceptionFilter } from 'src/engine/core-modules/application/application-exception-filter';
 import { ApplicationRegistrationExceptionFilter } from 'src/engine/core-modules/application/application-registration/application-registration-exception-filter';
 import { ApplicationInstallService } from 'src/engine/core-modules/application/application-install/application-install.service';
 import { ApplicationService } from 'src/engine/core-modules/application/application.service';
@@ -22,7 +23,7 @@ import { MessageQueue } from 'src/engine/core-modules/message-queue/message-queu
 import { MessageQueueService } from 'src/engine/core-modules/message-queue/services/message-queue.service';
 
 @MetadataResolver()
-@UseFilters(ApplicationRegistrationExceptionFilter)
+@UseFilters(ApplicationRegistrationExceptionFilter, ApplicationExceptionFilter)
 @UseInterceptors(WorkspaceMigrationGraphqlApiExceptionInterceptor)
 @UseGuards(WorkspaceAuthGuard, NoPermissionGuard)
 export class MarketplaceResolver {
@@ -78,6 +79,8 @@ export class MarketplaceResolver {
     @Args('universalIdentifier') universalIdentifier: string,
     @Args('version', { type: () => String, nullable: true })
     version: string | undefined,
+    @Args('allowDestructive', { type: () => Boolean, nullable: true })
+    allowDestructive: boolean | undefined,
     @AuthWorkspace() workspace: WorkspaceEntity,
   ) {
     const registration =
@@ -89,6 +92,7 @@ export class MarketplaceResolver {
       appRegistrationId: registration.id,
       version,
       workspaceId: workspace.id,
+      allowDestructive,
     });
 
     return this.applicationService.findOneApplicationOrThrow({

--- a/packages/twenty-server/src/engine/core-modules/application/application-upgrade/application-upgrade.resolver.ts
+++ b/packages/twenty-server/src/engine/core-modules/application/application-upgrade/application-upgrade.resolver.ts
@@ -1,8 +1,9 @@
 import { UseFilters, UseGuards } from '@nestjs/common';
-import { Args, Mutation } from '@nestjs/graphql';
+import { Args, Mutation, Query } from '@nestjs/graphql';
 
 import { PermissionFlagType } from 'twenty-shared/constants';
 import { MetadataResolver } from 'src/engine/api/graphql/graphql-config/decorators/metadata-resolver.decorator';
+import { ApplicationSyncPlanDTO } from 'src/engine/core-modules/application/application-development/dtos/application-sync-plan.dto';
 import { ApplicationExceptionFilter } from 'src/engine/core-modules/application/application-exception-filter';
 import { ApplicationUpgradeService } from 'src/engine/core-modules/application/application-upgrade/application-upgrade.service';
 import { WorkspaceEntity } from 'src/engine/core-modules/workspace/workspace.entity';
@@ -20,17 +21,34 @@ export class ApplicationUpgradeResolver {
     private readonly applicationUpgradeService: ApplicationUpgradeService,
   ) {}
 
+  @Query(() => ApplicationSyncPlanDTO)
+  @UseGuards(SettingsPermissionGuard(PermissionFlagType.MARKETPLACE_APPS))
+  async planApplicationUpgrade(
+    @Args('appRegistrationId') appRegistrationId: string,
+    @Args('targetVersion') targetVersion: string,
+    @AuthWorkspace() workspace: WorkspaceEntity,
+  ): Promise<ApplicationSyncPlanDTO> {
+    return this.applicationUpgradeService.planUpgrade({
+      appRegistrationId,
+      targetVersion,
+      workspaceId: workspace.id,
+    });
+  }
+
   @Mutation(() => Boolean)
   @UseGuards(SettingsPermissionGuard(PermissionFlagType.MARKETPLACE_APPS))
   async upgradeApplication(
     @Args('appRegistrationId') appRegistrationId: string,
     @Args('targetVersion') targetVersion: string,
+    @Args('allowDestructive', { type: () => Boolean, nullable: true })
+    allowDestructive: boolean | undefined,
     @AuthWorkspace() workspace: WorkspaceEntity,
   ): Promise<boolean> {
     return this.applicationUpgradeService.upgradeApplication({
       appRegistrationId,
       targetVersion,
       workspaceId: workspace.id,
+      allowDestructive,
     });
   }
 }

--- a/packages/twenty-server/src/engine/core-modules/application/application-upgrade/application-upgrade.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/application/application-upgrade/application-upgrade.service.ts
@@ -5,6 +5,7 @@ import axios from 'axios';
 import { Repository } from 'typeorm';
 import { z } from 'zod';
 
+import { type ApplicationSyncPlanDTO } from 'src/engine/core-modules/application/application-development/dtos/application-sync-plan.dto';
 import { ApplicationInstallService } from 'src/engine/core-modules/application/application-install/application-install.service';
 import { ApplicationRegistrationEntity } from 'src/engine/core-modules/application/application-registration/application-registration.entity';
 import { ApplicationRegistrationSourceType } from 'src/engine/core-modules/application/application-registration/enums/application-registration-source-type.enum';
@@ -90,10 +91,19 @@ export class ApplicationUpgradeService {
     }
   }
 
+  async planUpgrade(params: {
+    appRegistrationId: string;
+    targetVersion: string;
+    workspaceId: string;
+  }): Promise<ApplicationSyncPlanDTO> {
+    return this.applicationInstallService.planUpgrade(params);
+  }
+
   async upgradeApplication(params: {
     appRegistrationId: string;
     targetVersion: string;
     workspaceId: string;
+    allowDestructive?: boolean;
   }): Promise<boolean> {
     const appRegistration = await this.appRegistrationRepository.findOneOrFail({
       where: { id: params.appRegistrationId },
@@ -117,6 +127,7 @@ export class ApplicationUpgradeService {
         appRegistrationId: params.appRegistrationId,
         version: params.targetVersion,
         workspaceId: params.workspaceId,
+        allowDestructive: params.allowDestructive,
       });
     } catch (error) {
       const appName =

--- a/packages/twenty-server/test/integration/metadata/suites/application/app-distribution.integration-spec.ts
+++ b/packages/twenty-server/test/integration/metadata/suites/application/app-distribution.integration-spec.ts
@@ -1,52 +1,13 @@
 import crypto from 'crypto';
-import { promises as fs } from 'fs';
-import { join } from 'path';
-import { tmpdir } from 'os';
 
 import request from 'supertest';
-import * as tar from 'tar';
 import { type DataSource } from 'typeorm';
+import { createTestTarball } from 'test/integration/metadata/suites/application/utils/create-test-tarball.util';
 import { uploadAppTarball } from 'test/integration/metadata/suites/application/utils/upload-app-tarball.util';
 
 import { SEED_APPLE_WORKSPACE_ID } from 'src/engine/workspace-manager/dev-seeder/core/constants/seeder-workspaces.constant';
 
 const TEST_WORKSPACE_ID = SEED_APPLE_WORKSPACE_ID;
-
-const createTestTarball = async (
-  files: Record<string, string>,
-): Promise<Buffer> => {
-  const tempId = crypto.randomUUID();
-  const sourceDir = join(tmpdir(), `test-tarball-src-${tempId}`);
-  const tarballPath = join(tmpdir(), `test-tarball-${tempId}.tar.gz`);
-
-  await fs.mkdir(sourceDir, { recursive: true });
-
-  for (const [name, content] of Object.entries(files)) {
-    const filePath = join(sourceDir, name);
-    const dir = filePath.substring(0, filePath.lastIndexOf('/'));
-
-    if (dir !== sourceDir) {
-      await fs.mkdir(dir, { recursive: true });
-    }
-    await fs.writeFile(filePath, content);
-  }
-
-  await tar.create(
-    {
-      file: tarballPath,
-      gzip: true,
-      cwd: sourceDir,
-    },
-    Object.keys(files),
-  );
-
-  const buffer = await fs.readFile(tarballPath);
-
-  await fs.rm(sourceDir, { recursive: true, force: true });
-  await fs.rm(tarballPath, { force: true });
-
-  return buffer;
-};
 
 const createValidManifest = (universalIdentifier: string) =>
   JSON.stringify({

--- a/packages/twenty-server/test/integration/metadata/suites/application/application-upgrade-plan-and-gate.integration-spec.ts
+++ b/packages/twenty-server/test/integration/metadata/suites/application/application-upgrade-plan-and-gate.integration-spec.ts
@@ -1,0 +1,132 @@
+import { buildBaseManifest } from 'test/integration/metadata/suites/application/utils/build-base-manifest.util';
+import { buildDefaultObjectManifest } from 'test/integration/metadata/suites/application/utils/build-default-object-manifest.util';
+import { cleanupApplicationAndAppRegistration } from 'test/integration/metadata/suites/application/utils/cleanup-application-and-app-registration.util';
+import { createTestTarball } from 'test/integration/metadata/suites/application/utils/create-test-tarball.util';
+import { installApplication } from 'test/integration/metadata/suites/application/utils/install-application.util';
+import { planApplicationUpgrade } from 'test/integration/metadata/suites/application/utils/plan-application-upgrade.util';
+import { uploadAppTarball } from 'test/integration/metadata/suites/application/utils/upload-app-tarball.util';
+import { findManyObjectMetadata } from 'test/integration/metadata/suites/object-metadata/utils/find-many-object-metadata.util';
+import { FieldMetadataType } from 'twenty-shared/types';
+import { v4 as uuidv4 } from 'uuid';
+
+const TEST_APP_ID = uuidv4();
+const TEST_ROLE_ID = uuidv4();
+const REMOVABLE_FIELD_ID = uuidv4();
+
+const OBJECT_WITH_FIELD = buildDefaultObjectManifest({
+  nameSingular: 'upgradeGateRecord',
+  namePlural: 'upgradeGateRecords',
+  labelSingular: 'Upgrade Gate Record',
+  labelPlural: 'Upgrade Gate Records',
+  description: 'Object for the upgrade destructive-gate test',
+  additionalFields: [
+    {
+      universalIdentifier: REMOVABLE_FIELD_ID,
+      type: FieldMetadataType.TEXT,
+      name: 'removableNotes',
+      label: 'Removable notes',
+    },
+  ],
+});
+
+const OBJECT_WITHOUT_FIELD = {
+  ...OBJECT_WITH_FIELD,
+  fields: OBJECT_WITH_FIELD.fields.filter(
+    (field) => field.universalIdentifier !== REMOVABLE_FIELD_ID,
+  ),
+};
+
+const buildTarball = async (params: {
+  withField: boolean;
+  version: string;
+}): Promise<Buffer> => {
+  const manifest = buildBaseManifest({
+    appId: TEST_APP_ID,
+    roleId: TEST_ROLE_ID,
+    overrides: {
+      objects: [params.withField ? OBJECT_WITH_FIELD : OBJECT_WITHOUT_FIELD],
+    },
+  });
+
+  return createTestTarball({
+    'manifest.json': JSON.stringify(manifest),
+    'package.json': JSON.stringify({
+      name: 'upgrade-gate-app',
+      version: params.version,
+    }),
+  });
+};
+
+const findObjectNames = async (): Promise<string[]> => {
+  const { objects } = await findManyObjectMetadata({
+    input: { filter: {}, paging: { first: 100 } },
+    gqlFields: 'id nameSingular',
+    expectToFail: false,
+  });
+
+  return objects.map((object) => object.nameSingular);
+};
+
+describe('Application upgrade — plan preview and destructive gate', () => {
+  let appRegistrationId: string;
+
+  beforeAll(async () => {
+    jest.useRealTimers();
+
+    const upload = await uploadAppTarball({
+      tarballBuffer: await buildTarball({ withField: true, version: '1.0.0' }),
+      universalIdentifier: TEST_APP_ID,
+    });
+
+    appRegistrationId = upload.data!.uploadAppTarball.id;
+
+    await installApplication({
+      input: { universalIdentifier: TEST_APP_ID, version: '1.0.0' },
+      expectToFail: false,
+    });
+  }, 90000);
+
+  afterAll(async () => {
+    await cleanupApplicationAndAppRegistration({
+      applicationUniversalIdentifier: TEST_APP_ID,
+    });
+    jest.useFakeTimers();
+  });
+
+  it('previews a destructive upgrade and refuses it unless allowDestructive is set', async () => {
+    expect(await findObjectNames()).toContain('upgradeGateRecord');
+
+    await uploadAppTarball({
+      tarballBuffer: await buildTarball({ withField: false, version: '2.0.0' }),
+      universalIdentifier: TEST_APP_ID,
+    });
+
+    const plan = (
+      await planApplicationUpgrade({
+        appRegistrationId,
+        targetVersion: '2.0.0',
+      })
+    ).data.planApplicationUpgrade;
+
+    expect(plan.hasDestructiveActions).toBe(true);
+    expect(plan.summary.destructiveCount).toBeGreaterThanOrEqual(1);
+
+    const blocked = await installApplication({
+      input: { universalIdentifier: TEST_APP_ID, version: '2.0.0' },
+      expectToFail: true,
+    });
+
+    expect(JSON.stringify(blocked.errors)).toContain(
+      'DESTRUCTIVE_CHANGES_NOT_APPROVED',
+    );
+
+    await installApplication({
+      input: {
+        universalIdentifier: TEST_APP_ID,
+        version: '2.0.0',
+        allowDestructive: true,
+      },
+      expectToFail: false,
+    });
+  }, 90000);
+});

--- a/packages/twenty-server/test/integration/metadata/suites/application/utils/create-test-tarball.util.ts
+++ b/packages/twenty-server/test/integration/metadata/suites/application/utils/create-test-tarball.util.ts
@@ -1,7 +1,7 @@
 import crypto from 'crypto';
 import { promises as fs } from 'fs';
 import { tmpdir } from 'os';
-import { join } from 'path';
+import { dirname, join } from 'path';
 
 import * as tar from 'tar';
 
@@ -16,7 +16,7 @@ export const createTestTarball = async (
 
   for (const [name, content] of Object.entries(files)) {
     const filePath = join(sourceDir, name);
-    const dir = filePath.substring(0, filePath.lastIndexOf('/'));
+    const dir = dirname(filePath);
 
     if (dir !== sourceDir) {
       await fs.mkdir(dir, { recursive: true });

--- a/packages/twenty-server/test/integration/metadata/suites/application/utils/create-test-tarball.util.ts
+++ b/packages/twenty-server/test/integration/metadata/suites/application/utils/create-test-tarball.util.ts
@@ -1,0 +1,42 @@
+import crypto from 'crypto';
+import { promises as fs } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+
+import * as tar from 'tar';
+
+export const createTestTarball = async (
+  files: Record<string, string>,
+): Promise<Buffer> => {
+  const tempId = crypto.randomUUID();
+  const sourceDir = join(tmpdir(), `test-tarball-src-${tempId}`);
+  const tarballPath = join(tmpdir(), `test-tarball-${tempId}.tar.gz`);
+
+  await fs.mkdir(sourceDir, { recursive: true });
+
+  for (const [name, content] of Object.entries(files)) {
+    const filePath = join(sourceDir, name);
+    const dir = filePath.substring(0, filePath.lastIndexOf('/'));
+
+    if (dir !== sourceDir) {
+      await fs.mkdir(dir, { recursive: true });
+    }
+    await fs.writeFile(filePath, content);
+  }
+
+  await tar.create(
+    {
+      file: tarballPath,
+      gzip: true,
+      cwd: sourceDir,
+    },
+    Object.keys(files),
+  );
+
+  const buffer = await fs.readFile(tarballPath);
+
+  await fs.rm(sourceDir, { recursive: true, force: true });
+  await fs.rm(tarballPath, { force: true });
+
+  return buffer;
+};

--- a/packages/twenty-server/test/integration/metadata/suites/application/utils/install-application-query-factory.util.ts
+++ b/packages/twenty-server/test/integration/metadata/suites/application/utils/install-application-query-factory.util.ts
@@ -3,6 +3,7 @@ import gql from 'graphql-tag';
 export type InstallApplicationFactoryInput = {
   universalIdentifier: string;
   version?: string;
+  allowDestructive?: boolean;
 };
 
 export const installApplicationQueryFactory = ({
@@ -14,10 +15,12 @@ export const installApplicationQueryFactory = ({
     mutation InstallApplication(
       $universalIdentifier: String!
       $version: String
+      $allowDestructive: Boolean
     ) {
       installApplication(
         universalIdentifier: $universalIdentifier
         version: $version
+        allowDestructive: $allowDestructive
       ) {
         id
       }
@@ -26,5 +29,6 @@ export const installApplicationQueryFactory = ({
   variables: {
     universalIdentifier: input.universalIdentifier,
     version: input.version,
+    allowDestructive: input.allowDestructive,
   },
 });

--- a/packages/twenty-server/test/integration/metadata/suites/application/utils/plan-application-upgrade.util.ts
+++ b/packages/twenty-server/test/integration/metadata/suites/application/utils/plan-application-upgrade.util.ts
@@ -1,0 +1,58 @@
+import gql from 'graphql-tag';
+import { makeMetadataAPIRequest } from 'test/integration/metadata/suites/utils/make-metadata-api-request.util';
+import { type CommonResponseBody } from 'test/integration/metadata/types/common-response-body.type';
+import { warnIfErrorButNotExpectedToFail } from 'test/integration/metadata/utils/warn-if-error-but-not-expected-to-fail.util';
+
+type ApplicationSyncPlan = {
+  applicationUniversalIdentifier: string;
+  hasDestructiveActions: boolean;
+  summary: { destructiveCount: number };
+  actions: Array<{ type: string; metadataName: string; severity: string }>;
+};
+
+export const planApplicationUpgrade = async ({
+  appRegistrationId,
+  targetVersion,
+  token,
+}: {
+  appRegistrationId: string;
+  targetVersion: string;
+  token?: string;
+}): CommonResponseBody<{
+  planApplicationUpgrade: ApplicationSyncPlan;
+}> => {
+  const graphqlOperation = {
+    query: gql`
+      query PlanApplicationUpgrade(
+        $appRegistrationId: String!
+        $targetVersion: String!
+      ) {
+        planApplicationUpgrade(
+          appRegistrationId: $appRegistrationId
+          targetVersion: $targetVersion
+        ) {
+          applicationUniversalIdentifier
+          hasDestructiveActions
+          summary {
+            destructiveCount
+          }
+          actions {
+            type
+            metadataName
+            severity
+          }
+        }
+      }
+    `,
+    variables: { appRegistrationId, targetVersion },
+  };
+
+  const response = await makeMetadataAPIRequest(graphqlOperation, token);
+
+  warnIfErrorButNotExpectedToFail({
+    response,
+    errorMessage: 'Plan application upgrade has failed but should not',
+  });
+
+  return { data: response.body.data, errors: response.body.errors };
+};


### PR DESCRIPTION
> Stacked on #22339 → #22333 (base branch `feat/apps-deploy-stored-plan`). Review/merge those first.

## What & why

The plan/apply safety work so far (#22333, #22339) covered the CLI deploy path (`syncApplication`). The **marketplace install/upgrade path** (`installApplication` / `upgradeApplication`) is separate: it resolved a target version's package and applied its manifest via `synchronizeFromManifest` with **no preview and no protection against data loss**. This PR brings the same plan + destructive gate to that path — the server prerequisite for a front-end plan-review modal in the upgrade UI.

## Changes

- **`planApplicationUpgrade(appRegistrationId, targetVersion)`** (query) — resolves the target version's manifest and returns the same `ApplicationSyncPlan` as the CLI deploy (severity, affected-row counts, proposed version), so an upgrade can be reviewed before it's applied. Cleans up the extracted package afterwards.
- **Destructive gate on upgrades** — `doInstallApplication` now computes the plan for a *version upgrade* and refuses it (`DESTRUCTIVE_CHANGES_NOT_APPROVED`, HTTP 400) unless `allowDestructive` is set; threaded through `installApplication` and `upgradeApplication`. A fresh install is never gated (nothing to destroy).
- **Reuse / cleanup** — extracted `ApplicationDeployModule` so the plan service is shared by the dev and install paths (no duplication); a single `buildDestructiveChangesMessage` util is now used by both gates; the marketplace resolver maps `ApplicationException` to a typed 400 (it previously surfaced as a 500).

## Testing

Integration test (`application-upgrade-plan-and-gate.integration-spec.ts`): installs a tarball app with a field, previews the v2 upgrade that removes the field (`planApplicationUpgrade` → `hasDestructiveActions`), confirms the upgrade is blocked without `allowDestructive` and succeeds with it. Full application suite green (122 passing); the existing `app-distribution` test was refactored onto the shared `createTestTarball` util and still passes; schemas regenerated; typecheck/lint clean.

## Follow-ups (next in the stack)

The front-end plan-review modal (now unblocked by `planApplicationUpgrade`), then soft-delete + retention (a dedicated `deletedAt` marker distinct from `isActive`, with a retention cron — pending your sign-off).


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/22340?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

