### PR TITLE
feat(apps): retention window for app-removed metadata (deferred drop)

### DIFF
--- a/packages/twenty-oxlint-rules/rules/prefer-workspace-scoped-repository.ts
+++ b/packages/twenty-oxlint-rules/rules/prefer-workspace-scoped-repository.ts
@@ -25,6 +25,7 @@ const STRUCTURAL_EXEMPTIONS = new Set<string>([
   'FrontComponentEntity',
   'LogicFunctionEntity',
   'MessageFolderEntity',
+  'PendingMetadataDropEntity',
   'RolePermissionFlagEntity',
   'SigningKeyEntity',
   'UserEntity',

--- a/packages/twenty-server/src/database/commands/cron-register-all.command.ts
+++ b/packages/twenty-server/src/database/commands/cron-register-all.command.ts
@@ -14,6 +14,7 @@ import { CronTriggerCronCommand } from 'src/engine/core-modules/logic-function/l
 import { CheckPublicDomainsValidRecordsCronCommand } from 'src/engine/core-modules/public-domain/crons/commands/check-public-domains-valid-records.cron.command';
 import { TwentyConfigService } from 'src/engine/core-modules/twenty-config/twenty-config.service';
 import { CheckCustomDomainValidRecordsCronCommand } from 'src/engine/core-modules/workspace/crons/commands/check-custom-domain-valid-records.cron.command';
+import { MetadataRemovalRetentionCronCommand } from 'src/engine/core-modules/metadata-removal-retention/commands/metadata-removal-retention.cron.command';
 import { TrashCleanupCronCommand } from 'src/engine/trash-cleanup/commands/trash-cleanup.cron.command';
 import { CleanOnboardingWorkspacesCronCommand } from 'src/engine/workspace-manager/workspace-cleaner/commands/clean-onboarding-workspaces.cron.command';
 import { CleanSuspendedWorkspacesCronCommand } from 'src/engine/workspace-manager/workspace-cleaner/commands/clean-suspended-workspaces.cron.command';
@@ -59,6 +60,7 @@ export class CronRegisterAllCommand extends CommandRunner {
     private readonly cleanSuspendedWorkspacesCronCommand: CleanSuspendedWorkspacesCronCommand,
     private readonly cleanOnboardingWorkspacesCronCommand: CleanOnboardingWorkspacesCronCommand,
     private readonly trashCleanupCronCommand: TrashCleanupCronCommand,
+    private readonly metadataRemovalRetentionCronCommand: MetadataRemovalRetentionCronCommand,
     private readonly eventLogCleanupCronCommand: EventLogCleanupCronCommand,
     private readonly enterpriseKeyValidationCronCommand: EnterpriseKeyValidationCronCommand,
     private readonly rotateSigningKeysCronCommand: RotateSigningKeysCronCommand,
@@ -156,6 +158,10 @@ export class CronRegisterAllCommand extends CommandRunner {
       {
         name: 'TrashCleanup',
         command: this.trashCleanupCronCommand,
+      },
+      {
+        name: 'MetadataRemovalRetention',
+        command: this.metadataRemovalRetentionCronCommand,
       },
       {
         name: 'EventLogCleanup',

--- a/packages/twenty-server/src/database/commands/database-command.module.ts
+++ b/packages/twenty-server/src/database/commands/database-command.module.ts
@@ -40,6 +40,7 @@ import { ObjectMetadataModule } from 'src/engine/metadata-modules/object-metadat
 import { RoleEntity } from 'src/engine/metadata-modules/role/role.entity';
 import { provideWorkspaceScopedRepository } from 'src/engine/twenty-orm/workspace-scoped-repository/provide-workspace-scoped-repository';
 import { CodeInterpreterSessionCleanupModule } from 'src/engine/core-modules/code-interpreter/crons/code-interpreter-session-cleanup.module';
+import { MetadataRemovalRetentionModule } from 'src/engine/core-modules/metadata-removal-retention/metadata-removal-retention.module';
 import { TrashCleanupModule } from 'src/engine/trash-cleanup/trash-cleanup.module';
 import { WorkspaceCacheStorageModule } from 'src/engine/workspace-cache-storage/workspace-cache-storage.module';
 import { WorkspaceCacheModule } from 'src/engine/workspace-cache/workspace-cache.module';
@@ -77,6 +78,7 @@ import { AutomatedTriggerModule } from 'src/modules/workflow/workflow-trigger/au
     WorkspaceCleanerModule,
     WorkspaceMigrationModule,
     TrashCleanupModule,
+    MetadataRemovalRetentionModule,
     BillingReminderModule,
     CodeInterpreterSessionCleanupModule,
     PublicDomainModule,

--- a/packages/twenty-server/src/database/commands/upgrade-version-command/2-18/2-18-instance-command-fast-1801000120000-create-pending-metadata-drop-core-table.ts
+++ b/packages/twenty-server/src/database/commands/upgrade-version-command/2-18/2-18-instance-command-fast-1801000120000-create-pending-metadata-drop-core-table.ts
@@ -1,0 +1,47 @@
+import { type QueryRunner } from 'typeorm';
+
+import { RegisteredInstanceCommand } from 'src/engine/core-modules/upgrade/decorators/registered-instance-command.decorator';
+import { type FastInstanceCommand } from 'src/engine/core-modules/upgrade/interfaces/fast-instance-command.interface';
+
+@RegisteredInstanceCommand('2.18.0', 1801000120000)
+export class CreatePendingMetadataDropCoreTableFastInstanceCommand
+  implements FastInstanceCommand
+{
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `CREATE TABLE IF NOT EXISTS "core"."pendingMetadataDrop" (
+        "id" uuid NOT NULL DEFAULT uuid_generate_v4(),
+        "kind" character varying NOT NULL,
+        "schemaName" character varying NOT NULL,
+        "tableName" character varying NOT NULL,
+        "columnNames" jsonb NOT NULL,
+        "enumNames" jsonb NOT NULL,
+        "columnDefinitions" jsonb,
+        "applicationId" uuid,
+        "removedAt" TIMESTAMP WITH TIME ZONE NOT NULL,
+        "scheduledDropAt" TIMESTAMP WITH TIME ZONE NOT NULL,
+        "createdAt" TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(),
+        "workspaceId" uuid NOT NULL,
+        CONSTRAINT "PK_pendingMetadataDrop_id" PRIMARY KEY ("id")
+      )`,
+    );
+    await queryRunner.query(
+      `CREATE INDEX IF NOT EXISTS "IDX_PENDING_METADATA_DROP_WORKSPACE_ID"
+        ON "core"."pendingMetadataDrop" ("workspaceId")`,
+    );
+    await queryRunner.query(
+      `CREATE INDEX IF NOT EXISTS "IDX_PENDING_METADATA_DROP_SCHEDULED_DROP_AT"
+        ON "core"."pendingMetadataDrop" ("scheduledDropAt")`,
+    );
+    await queryRunner.query(
+      `CREATE INDEX IF NOT EXISTS "IDX_PENDING_METADATA_DROP_TARGET"
+        ON "core"."pendingMetadataDrop" ("workspaceId", "schemaName", "tableName")`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `DROP TABLE IF EXISTS "core"."pendingMetadataDrop"`,
+    );
+  }
+}

--- a/packages/twenty-server/src/database/commands/upgrade-version-command/instance-commands.constant.ts
+++ b/packages/twenty-server/src/database/commands/upgrade-version-command/instance-commands.constant.ts
@@ -83,6 +83,7 @@ import { AddServerTriggerSettingsToLogicFunctionFastInstanceCommand } from 'src/
 import { CreateDpaAgreementCoreTableFastInstanceCommand } from 'src/database/commands/upgrade-version-command/2-17/2-17-instance-command-fast-1801000020000-create-dpa-agreement-core-table';
 import { CreateApplicationTranslationCoreTableFastInstanceCommand } from 'src/database/commands/upgrade-version-command/2-17/2-17-instance-command-fast-1801000100000-create-application-translation-core-table';
 import { AddDeploySerialToApplicationFastInstanceCommand } from 'src/database/commands/upgrade-version-command/2-18/2-18-instance-command-fast-1801000110000-add-deploy-serial-to-application';
+import { CreatePendingMetadataDropCoreTableFastInstanceCommand } from 'src/database/commands/upgrade-version-command/2-18/2-18-instance-command-fast-1801000120000-create-pending-metadata-drop-core-table';
 
 export const INSTANCE_COMMANDS = [
   AddViewFieldGroupIdIndexOnViewFieldFastInstanceCommand,
@@ -168,4 +169,5 @@ export const INSTANCE_COMMANDS = [
   CreateDpaAgreementCoreTableFastInstanceCommand,
   CreateApplicationTranslationCoreTableFastInstanceCommand,
   AddDeploySerialToApplicationFastInstanceCommand,
+  CreatePendingMetadataDropCoreTableFastInstanceCommand,
 ];

--- a/packages/twenty-server/src/engine/core-modules/core-engine.module.ts
+++ b/packages/twenty-server/src/engine/core-modules/core-engine.module.ts
@@ -72,6 +72,7 @@ import { RoleModule } from 'src/engine/metadata-modules/role/role.module';
 import { RowLevelPermissionModule } from 'src/engine/metadata-modules/row-level-permission-predicate/row-level-permission.module';
 import { SubscriptionsModule } from 'src/engine/subscriptions/subscriptions.module';
 import { CodeInterpreterSessionCleanupModule } from 'src/engine/core-modules/code-interpreter/crons/code-interpreter-session-cleanup.module';
+import { MetadataRemovalRetentionModule } from 'src/engine/core-modules/metadata-removal-retention/metadata-removal-retention.module';
 import { TrashCleanupModule } from 'src/engine/trash-cleanup/trash-cleanup.module';
 import { WorkspaceEventEmitterModule } from 'src/engine/workspace-event-emitter/workspace-event-emitter.module';
 import { ChannelSyncModule } from 'src/modules/connected-account/channel-sync/channel-sync.module';
@@ -163,6 +164,7 @@ import { FileModule } from './file/file.module';
     PageLayoutModule,
     ImpersonationModule,
     TrashCleanupModule,
+    MetadataRemovalRetentionModule,
     CodeInterpreterSessionCleanupModule,
     DashboardModule,
     EventLogsViewerModule,

--- a/packages/twenty-server/src/engine/core-modules/metadata-removal-retention/__tests__/pending-metadata-drop.service.spec.ts
+++ b/packages/twenty-server/src/engine/core-modules/metadata-removal-retention/__tests__/pending-metadata-drop.service.spec.ts
@@ -27,6 +27,7 @@ const buildColumnEntry = (
 describe('PendingMetadataDropService', () => {
   let service: PendingMetadataDropService;
   let scopedRepository: {
+    find: jest.Mock;
     findOne: jest.Mock;
     delete: jest.Mock;
     insert: jest.Mock;
@@ -46,6 +47,7 @@ describe('PendingMetadataDropService', () => {
 
   beforeEach(async () => {
     scopedRepository = {
+      find: jest.fn(),
       findOne: jest.fn(),
       delete: jest.fn(),
       insert: jest.fn(),
@@ -118,7 +120,7 @@ describe('PendingMetadataDropService', () => {
 
   describe('reclaimColumns', () => {
     it('returns none and drops nothing when there is no pending entry', async () => {
-      scopedRepository.findOne.mockResolvedValue(null);
+      scopedRepository.find.mockResolvedValue([]);
 
       const outcome = await service.reclaimColumns({
         queryRunner: queryRunner as never,
@@ -135,7 +137,7 @@ describe('PendingMetadataDropService', () => {
     });
 
     it('reuses the retained column and cancels the drop when the definition is identical', async () => {
-      scopedRepository.findOne.mockResolvedValue(buildColumnEntry());
+      scopedRepository.find.mockResolvedValue([buildColumnEntry()]);
 
       const outcome = await service.reclaimColumns({
         queryRunner: queryRunner as never,
@@ -152,11 +154,11 @@ describe('PendingMetadataDropService', () => {
     });
 
     it('reuses the column when the stored definition only differs by key order', async () => {
-      scopedRepository.findOne.mockResolvedValue(
+      scopedRepository.find.mockResolvedValue([
         buildColumnEntry({
           columnDefinitions: [{ type: 'text', name: 'amount' } as never],
         }),
-      );
+      ]);
 
       const outcome = await service.reclaimColumns({
         queryRunner: queryRunner as never,
@@ -172,7 +174,7 @@ describe('PendingMetadataDropService', () => {
     });
 
     it('drops the stale column when the re-added definition differs', async () => {
-      scopedRepository.findOne.mockResolvedValue(buildColumnEntry());
+      scopedRepository.find.mockResolvedValue([buildColumnEntry()]);
 
       const outcome = await service.reclaimColumns({
         queryRunner: queryRunner as never,
@@ -192,9 +194,9 @@ describe('PendingMetadataDropService', () => {
     });
 
     it('returns none when a pending entry targets different columns', async () => {
-      scopedRepository.findOne.mockResolvedValue(
+      scopedRepository.find.mockResolvedValue([
         buildColumnEntry({ columnNames: ['other'] }),
-      );
+      ]);
 
       const outcome = await service.reclaimColumns({
         queryRunner: queryRunner as never,
@@ -240,14 +242,17 @@ describe('PendingMetadataDropService', () => {
     });
 
     it('drops each due column and table then removes the ledger row in its own transaction', async () => {
-      rootRepository.find.mockResolvedValue([
-        buildColumnEntry({ id: 'col-entry' }),
-        buildColumnEntry({
-          id: 'table-entry',
-          kind: 'TABLE',
-          columnNames: [],
-        }),
-      ]);
+      const columnEntry = buildColumnEntry({ id: 'col-entry' });
+      const tableEntry = buildColumnEntry({
+        id: 'table-entry',
+        kind: 'TABLE',
+        columnNames: [],
+      });
+
+      rootRepository.find.mockResolvedValue([columnEntry, tableEntry]);
+      scopedRepository.findOne
+        .mockResolvedValueOnce(columnEntry)
+        .mockResolvedValueOnce(tableEntry);
 
       await service.dropDueForWorkspace({
         workspaceId: 'workspace-id',
@@ -262,8 +267,23 @@ describe('PendingMetadataDropService', () => {
       expect(queryRunner.release).toHaveBeenCalledTimes(1);
     });
 
+    it('skips the drop and commits when the ledger row was reclaimed concurrently', async () => {
+      rootRepository.find.mockResolvedValue([buildColumnEntry()]);
+      scopedRepository.findOne.mockResolvedValue(null);
+
+      await service.dropDueForWorkspace({
+        workspaceId: 'workspace-id',
+        now: new Date('2026-06-30T00:00:00.000Z'),
+      });
+
+      expect(columnManager.dropColumns).not.toHaveBeenCalled();
+      expect(scopedRepository.delete).not.toHaveBeenCalled();
+      expect(queryRunner.commitTransaction).toHaveBeenCalledTimes(1);
+    });
+
     it('rolls back and keeps the ledger row when a drop fails', async () => {
       rootRepository.find.mockResolvedValue([buildColumnEntry()]);
+      scopedRepository.findOne.mockResolvedValue(buildColumnEntry());
       columnManager.dropColumns.mockRejectedValue(new Error('boom'));
 
       await service.dropDueForWorkspace({

--- a/packages/twenty-server/src/engine/core-modules/metadata-removal-retention/__tests__/pending-metadata-drop.service.spec.ts
+++ b/packages/twenty-server/src/engine/core-modules/metadata-removal-retention/__tests__/pending-metadata-drop.service.spec.ts
@@ -1,0 +1,280 @@
+import { getDataSourceToken, getRepositoryToken } from '@nestjs/typeorm';
+import { Test, type TestingModule } from '@nestjs/testing';
+
+import { PendingMetadataDropEntity } from 'src/engine/core-modules/metadata-removal-retention/pending-metadata-drop.entity';
+import { PendingMetadataDropService } from 'src/engine/core-modules/metadata-removal-retention/pending-metadata-drop.service';
+import { WorkspaceSchemaManagerService } from 'src/engine/twenty-orm/workspace-schema-manager/workspace-schema-manager.service';
+
+const buildColumnEntry = (
+  overrides: Partial<PendingMetadataDropEntity> = {},
+): PendingMetadataDropEntity =>
+  ({
+    id: 'entry-id',
+    kind: 'COLUMN',
+    schemaName: 'workspace_1',
+    tableName: '_invoice',
+    columnNames: ['amount'],
+    enumNames: ['workspace_1._invoice_amount_enum'],
+    columnDefinitions: [{ name: 'amount', type: 'text' }],
+    applicationId: null,
+    removedAt: new Date('2026-06-01T00:00:00.000Z'),
+    scheduledDropAt: new Date('2026-06-08T00:00:00.000Z'),
+    createdAt: new Date('2026-06-01T00:00:00.000Z'),
+    workspaceId: 'workspace-id',
+    ...overrides,
+  }) as PendingMetadataDropEntity;
+
+describe('PendingMetadataDropService', () => {
+  let service: PendingMetadataDropService;
+  let scopedRepository: {
+    findOne: jest.Mock;
+    delete: jest.Mock;
+    insert: jest.Mock;
+  };
+  let rootRepository: { find: jest.Mock };
+  let columnManager: { dropColumns: jest.Mock };
+  let tableManager: { dropTable: jest.Mock };
+  let enumManager: { dropEnum: jest.Mock };
+  let queryRunner: {
+    manager: { getRepository: jest.Mock };
+    connect: jest.Mock;
+    startTransaction: jest.Mock;
+    commitTransaction: jest.Mock;
+    rollbackTransaction: jest.Mock;
+    release: jest.Mock;
+  };
+
+  beforeEach(async () => {
+    scopedRepository = {
+      findOne: jest.fn(),
+      delete: jest.fn(),
+      insert: jest.fn(),
+    };
+    rootRepository = { find: jest.fn() };
+    columnManager = { dropColumns: jest.fn() };
+    tableManager = { dropTable: jest.fn() };
+    enumManager = { dropEnum: jest.fn() };
+    queryRunner = {
+      manager: { getRepository: jest.fn().mockReturnValue(scopedRepository) },
+      connect: jest.fn(),
+      startTransaction: jest.fn(),
+      commitTransaction: jest.fn(),
+      rollbackTransaction: jest.fn(),
+      release: jest.fn(),
+    };
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        PendingMetadataDropService,
+        {
+          provide: getRepositoryToken(PendingMetadataDropEntity),
+          useValue: rootRepository,
+        },
+        {
+          provide: WorkspaceSchemaManagerService,
+          useValue: { columnManager, tableManager, enumManager },
+        },
+        {
+          provide: getDataSourceToken(),
+          useValue: { createQueryRunner: () => queryRunner },
+        },
+      ],
+    }).compile();
+
+    service = module.get(PendingMetadataDropService);
+  });
+
+  describe('recordColumnDrop', () => {
+    it('schedules the drop retentionDays after removal and stores it in the migration transaction', async () => {
+      await service.recordColumnDrop({
+        queryRunner: queryRunner as never,
+        workspaceId: 'workspace-id',
+        applicationId: 'app-id',
+        schemaName: 'workspace_1',
+        tableName: '_invoice',
+        columnNames: ['amount'],
+        enumNames: [],
+        columnDefinitions: [{ name: 'amount', type: 'text' }],
+        retentionDays: 7,
+      });
+
+      expect(queryRunner.manager.getRepository).toHaveBeenCalledWith(
+        PendingMetadataDropEntity,
+      );
+      expect(scopedRepository.insert).toHaveBeenCalledTimes(1);
+
+      const inserted = scopedRepository.insert.mock.calls[0][0];
+
+      expect(inserted.kind).toBe('COLUMN');
+      expect(inserted.columnNames).toEqual(['amount']);
+
+      const elapsedDays =
+        (inserted.scheduledDropAt.getTime() - inserted.removedAt.getTime()) /
+        (24 * 60 * 60 * 1000);
+
+      expect(elapsedDays).toBe(7);
+    });
+  });
+
+  describe('reclaimColumns', () => {
+    it('returns none and drops nothing when there is no pending entry', async () => {
+      scopedRepository.findOne.mockResolvedValue(null);
+
+      const outcome = await service.reclaimColumns({
+        queryRunner: queryRunner as never,
+        workspaceId: 'workspace-id',
+        schemaName: 'workspace_1',
+        tableName: '_invoice',
+        columnNames: ['amount'],
+        columnDefinitions: [{ name: 'amount', type: 'text' }],
+      });
+
+      expect(outcome).toBe('none');
+      expect(columnManager.dropColumns).not.toHaveBeenCalled();
+      expect(scopedRepository.delete).not.toHaveBeenCalled();
+    });
+
+    it('reuses the retained column and cancels the drop when the definition is identical', async () => {
+      scopedRepository.findOne.mockResolvedValue(buildColumnEntry());
+
+      const outcome = await service.reclaimColumns({
+        queryRunner: queryRunner as never,
+        workspaceId: 'workspace-id',
+        schemaName: 'workspace_1',
+        tableName: '_invoice',
+        columnNames: ['amount'],
+        columnDefinitions: [{ name: 'amount', type: 'text' }],
+      });
+
+      expect(outcome).toBe('reused');
+      expect(columnManager.dropColumns).not.toHaveBeenCalled();
+      expect(scopedRepository.delete).toHaveBeenCalledWith('entry-id');
+    });
+
+    it('reuses the column when the stored definition only differs by key order', async () => {
+      scopedRepository.findOne.mockResolvedValue(
+        buildColumnEntry({
+          columnDefinitions: [{ type: 'text', name: 'amount' } as never],
+        }),
+      );
+
+      const outcome = await service.reclaimColumns({
+        queryRunner: queryRunner as never,
+        workspaceId: 'workspace-id',
+        schemaName: 'workspace_1',
+        tableName: '_invoice',
+        columnNames: ['amount'],
+        columnDefinitions: [{ name: 'amount', type: 'text' }],
+      });
+
+      expect(outcome).toBe('reused');
+      expect(columnManager.dropColumns).not.toHaveBeenCalled();
+    });
+
+    it('drops the stale column when the re-added definition differs', async () => {
+      scopedRepository.findOne.mockResolvedValue(buildColumnEntry());
+
+      const outcome = await service.reclaimColumns({
+        queryRunner: queryRunner as never,
+        workspaceId: 'workspace-id',
+        schemaName: 'workspace_1',
+        tableName: '_invoice',
+        columnNames: ['amount'],
+        columnDefinitions: [{ name: 'amount', type: 'numeric' }],
+      });
+
+      expect(outcome).toBe('dropped');
+      expect(columnManager.dropColumns).toHaveBeenCalledWith(
+        expect.objectContaining({ columnNames: ['amount'], cascade: true }),
+      );
+      expect(enumManager.dropEnum).toHaveBeenCalledTimes(1);
+      expect(scopedRepository.delete).toHaveBeenCalledWith('entry-id');
+    });
+
+    it('returns none when a pending entry targets different columns', async () => {
+      scopedRepository.findOne.mockResolvedValue(
+        buildColumnEntry({ columnNames: ['other'] }),
+      );
+
+      const outcome = await service.reclaimColumns({
+        queryRunner: queryRunner as never,
+        workspaceId: 'workspace-id',
+        schemaName: 'workspace_1',
+        tableName: '_invoice',
+        columnNames: ['amount'],
+        columnDefinitions: [{ name: 'amount', type: 'text' }],
+      });
+
+      expect(outcome).toBe('none');
+      expect(columnManager.dropColumns).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('findWorkspaceIdsWithDueDrops', () => {
+    it('returns the distinct workspace ids with due drops', async () => {
+      rootRepository.find.mockResolvedValue([
+        { workspaceId: 'a' },
+        { workspaceId: 'a' },
+        { workspaceId: 'b' },
+      ]);
+
+      const workspaceIds = await service.findWorkspaceIdsWithDueDrops(
+        new Date('2026-06-30T00:00:00.000Z'),
+      );
+
+      expect(workspaceIds).toEqual(['a', 'b']);
+    });
+  });
+
+  describe('dropDueForWorkspace', () => {
+    it('does nothing when there are no due drops', async () => {
+      rootRepository.find.mockResolvedValue([]);
+
+      await service.dropDueForWorkspace({
+        workspaceId: 'workspace-id',
+        now: new Date('2026-06-30T00:00:00.000Z'),
+      });
+
+      expect(queryRunner.connect).not.toHaveBeenCalled();
+      expect(columnManager.dropColumns).not.toHaveBeenCalled();
+    });
+
+    it('drops each due column and table then removes the ledger row in its own transaction', async () => {
+      rootRepository.find.mockResolvedValue([
+        buildColumnEntry({ id: 'col-entry' }),
+        buildColumnEntry({
+          id: 'table-entry',
+          kind: 'TABLE',
+          columnNames: [],
+        }),
+      ]);
+
+      await service.dropDueForWorkspace({
+        workspaceId: 'workspace-id',
+        now: new Date('2026-06-30T00:00:00.000Z'),
+      });
+
+      expect(columnManager.dropColumns).toHaveBeenCalledTimes(1);
+      expect(tableManager.dropTable).toHaveBeenCalledTimes(1);
+      expect(scopedRepository.delete).toHaveBeenCalledWith('col-entry');
+      expect(scopedRepository.delete).toHaveBeenCalledWith('table-entry');
+      expect(queryRunner.commitTransaction).toHaveBeenCalledTimes(2);
+      expect(queryRunner.release).toHaveBeenCalledTimes(1);
+    });
+
+    it('rolls back and keeps the ledger row when a drop fails', async () => {
+      rootRepository.find.mockResolvedValue([buildColumnEntry()]);
+      columnManager.dropColumns.mockRejectedValue(new Error('boom'));
+
+      await service.dropDueForWorkspace({
+        workspaceId: 'workspace-id',
+        now: new Date('2026-06-30T00:00:00.000Z'),
+      });
+
+      expect(queryRunner.rollbackTransaction).toHaveBeenCalledTimes(1);
+      expect(queryRunner.commitTransaction).not.toHaveBeenCalled();
+      expect(scopedRepository.delete).not.toHaveBeenCalled();
+      expect(queryRunner.release).toHaveBeenCalledTimes(1);
+    });
+  });
+});

--- a/packages/twenty-server/src/engine/core-modules/metadata-removal-retention/commands/metadata-removal-retention.cron.command.ts
+++ b/packages/twenty-server/src/engine/core-modules/metadata-removal-retention/commands/metadata-removal-retention.cron.command.ts
@@ -1,0 +1,33 @@
+import { Command, CommandRunner } from 'nest-commander';
+
+import { InjectMessageQueue } from 'src/engine/core-modules/message-queue/decorators/message-queue.decorator';
+import { MessageQueue } from 'src/engine/core-modules/message-queue/message-queue.constants';
+import { MessageQueueService } from 'src/engine/core-modules/message-queue/services/message-queue.service';
+import { METADATA_REMOVAL_RETENTION_CRON_PATTERN } from 'src/engine/core-modules/metadata-removal-retention/constants/metadata-removal-retention-cron-pattern.constant';
+import { MetadataRemovalRetentionCronJob } from 'src/engine/core-modules/metadata-removal-retention/crons/metadata-removal-retention.cron.job';
+
+@Command({
+  name: 'cron:metadata-removal-retention',
+  description:
+    'Starts a cron job to permanently drop columns and tables removed by application deploys once their retention period has elapsed',
+})
+export class MetadataRemovalRetentionCronCommand extends CommandRunner {
+  constructor(
+    @InjectMessageQueue(MessageQueue.cronQueue)
+    private readonly messageQueueService: MessageQueueService,
+  ) {
+    super();
+  }
+
+  async run(): Promise<void> {
+    await this.messageQueueService.addCron<undefined>({
+      jobName: MetadataRemovalRetentionCronJob.name,
+      data: undefined,
+      options: {
+        repeat: {
+          pattern: METADATA_REMOVAL_RETENTION_CRON_PATTERN,
+        },
+      },
+    });
+  }
+}

--- a/packages/twenty-server/src/engine/core-modules/metadata-removal-retention/constants/metadata-removal-retention-cron-pattern.constant.ts
+++ b/packages/twenty-server/src/engine/core-modules/metadata-removal-retention/constants/metadata-removal-retention-cron-pattern.constant.ts
@@ -1,0 +1,1 @@
+export const METADATA_REMOVAL_RETENTION_CRON_PATTERN = '20 0 * * *';

--- a/packages/twenty-server/src/engine/core-modules/metadata-removal-retention/crons/metadata-removal-retention.cron.job.ts
+++ b/packages/twenty-server/src/engine/core-modules/metadata-removal-retention/crons/metadata-removal-retention.cron.job.ts
@@ -1,0 +1,61 @@
+import { Injectable, Logger } from '@nestjs/common';
+
+import { SentryCronMonitor } from 'src/engine/core-modules/cron/sentry-cron-monitor.decorator';
+import { ExceptionHandlerService } from 'src/engine/core-modules/exception-handler/exception-handler.service';
+import { InjectMessageQueue } from 'src/engine/core-modules/message-queue/decorators/message-queue.decorator';
+import { Process } from 'src/engine/core-modules/message-queue/decorators/process.decorator';
+import { Processor } from 'src/engine/core-modules/message-queue/decorators/processor.decorator';
+import { MessageQueue } from 'src/engine/core-modules/message-queue/message-queue.constants';
+import { MessageQueueService } from 'src/engine/core-modules/message-queue/services/message-queue.service';
+import { METADATA_REMOVAL_RETENTION_CRON_PATTERN } from 'src/engine/core-modules/metadata-removal-retention/constants/metadata-removal-retention-cron-pattern.constant';
+import {
+  MetadataRemovalRetentionJob,
+  type MetadataRemovalRetentionJobData,
+} from 'src/engine/core-modules/metadata-removal-retention/jobs/metadata-removal-retention.job';
+import { PendingMetadataDropService } from 'src/engine/core-modules/metadata-removal-retention/pending-metadata-drop.service';
+
+@Injectable()
+@Processor(MessageQueue.cronQueue)
+export class MetadataRemovalRetentionCronJob {
+  private readonly logger = new Logger(MetadataRemovalRetentionCronJob.name);
+
+  constructor(
+    private readonly pendingMetadataDropService: PendingMetadataDropService,
+    @InjectMessageQueue(MessageQueue.workspaceQueue)
+    private readonly messageQueueService: MessageQueueService,
+    private readonly exceptionHandlerService: ExceptionHandlerService,
+  ) {}
+
+  @Process(MetadataRemovalRetentionCronJob.name)
+  @SentryCronMonitor(
+    MetadataRemovalRetentionCronJob.name,
+    METADATA_REMOVAL_RETENTION_CRON_PATTERN,
+  )
+  async handle(): Promise<void> {
+    const workspaceIds =
+      await this.pendingMetadataDropService.findWorkspaceIdsWithDueDrops(
+        new Date(),
+      );
+
+    if (workspaceIds.length === 0) {
+      return;
+    }
+
+    this.logger.log(
+      `Enqueuing metadata removal retention jobs for ${workspaceIds.length} workspace(s)`,
+    );
+
+    for (const workspaceId of workspaceIds) {
+      try {
+        await this.messageQueueService.add<MetadataRemovalRetentionJobData>(
+          MetadataRemovalRetentionJob.name,
+          { workspaceId },
+        );
+      } catch (error) {
+        this.exceptionHandlerService.captureExceptions([error], {
+          workspace: { id: workspaceId },
+        });
+      }
+    }
+  }
+}

--- a/packages/twenty-server/src/engine/core-modules/metadata-removal-retention/jobs/metadata-removal-retention.job.ts
+++ b/packages/twenty-server/src/engine/core-modules/metadata-removal-retention/jobs/metadata-removal-retention.job.ts
@@ -1,0 +1,36 @@
+import { Injectable, Logger } from '@nestjs/common';
+
+import { Process } from 'src/engine/core-modules/message-queue/decorators/process.decorator';
+import { Processor } from 'src/engine/core-modules/message-queue/decorators/processor.decorator';
+import { MessageQueue } from 'src/engine/core-modules/message-queue/message-queue.constants';
+import { PendingMetadataDropService } from 'src/engine/core-modules/metadata-removal-retention/pending-metadata-drop.service';
+
+export type MetadataRemovalRetentionJobData = {
+  workspaceId: string;
+};
+
+@Injectable()
+@Processor(MessageQueue.workspaceQueue)
+export class MetadataRemovalRetentionJob {
+  private readonly logger = new Logger(MetadataRemovalRetentionJob.name);
+
+  constructor(
+    private readonly pendingMetadataDropService: PendingMetadataDropService,
+  ) {}
+
+  @Process(MetadataRemovalRetentionJob.name)
+  async handle(data: MetadataRemovalRetentionJobData): Promise<void> {
+    try {
+      await this.pendingMetadataDropService.dropDueForWorkspace({
+        workspaceId: data.workspaceId,
+        now: new Date(),
+      });
+    } catch (error) {
+      this.logger.error(
+        `Metadata removal retention failed for workspace ${data.workspaceId}`,
+        error instanceof Error ? error.stack : String(error),
+      );
+      throw error;
+    }
+  }
+}

--- a/packages/twenty-server/src/engine/core-modules/metadata-removal-retention/metadata-removal-retention.module.ts
+++ b/packages/twenty-server/src/engine/core-modules/metadata-removal-retention/metadata-removal-retention.module.ts
@@ -1,0 +1,24 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+
+import { MetadataRemovalRetentionCronCommand } from 'src/engine/core-modules/metadata-removal-retention/commands/metadata-removal-retention.cron.command';
+import { MetadataRemovalRetentionCronJob } from 'src/engine/core-modules/metadata-removal-retention/crons/metadata-removal-retention.cron.job';
+import { MetadataRemovalRetentionJob } from 'src/engine/core-modules/metadata-removal-retention/jobs/metadata-removal-retention.job';
+import { PendingMetadataDropEntity } from 'src/engine/core-modules/metadata-removal-retention/pending-metadata-drop.entity';
+import { PendingMetadataDropService } from 'src/engine/core-modules/metadata-removal-retention/pending-metadata-drop.service';
+import { WorkspaceSchemaManagerModule } from 'src/engine/twenty-orm/workspace-schema-manager/workspace-schema-manager.module';
+
+@Module({
+  imports: [
+    TypeOrmModule.forFeature([PendingMetadataDropEntity]),
+    WorkspaceSchemaManagerModule,
+  ],
+  providers: [
+    PendingMetadataDropService,
+    MetadataRemovalRetentionJob,
+    MetadataRemovalRetentionCronJob,
+    MetadataRemovalRetentionCronCommand,
+  ],
+  exports: [PendingMetadataDropService, MetadataRemovalRetentionCronCommand],
+})
+export class MetadataRemovalRetentionModule {}

--- a/packages/twenty-server/src/engine/core-modules/metadata-removal-retention/pending-metadata-drop.entity.ts
+++ b/packages/twenty-server/src/engine/core-modules/metadata-removal-retention/pending-metadata-drop.entity.ts
@@ -1,0 +1,57 @@
+import {
+  Column,
+  CreateDateColumn,
+  Entity,
+  Index,
+  PrimaryGeneratedColumn,
+} from 'typeorm';
+
+import { type WorkspaceSchemaColumnDefinition } from 'src/engine/twenty-orm/workspace-schema-manager/types/workspace-schema-column-definition.type';
+
+export type PendingMetadataDropKind = 'COLUMN' | 'TABLE';
+
+@Entity({ name: 'pendingMetadataDrop', schema: 'core' })
+@Index('IDX_PENDING_METADATA_DROP_WORKSPACE_ID', ['workspaceId'])
+@Index('IDX_PENDING_METADATA_DROP_SCHEDULED_DROP_AT', ['scheduledDropAt'])
+@Index('IDX_PENDING_METADATA_DROP_TARGET', [
+  'workspaceId',
+  'schemaName',
+  'tableName',
+])
+export class PendingMetadataDropEntity {
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  @Column({ type: 'varchar' })
+  kind: PendingMetadataDropKind;
+
+  @Column({ type: 'varchar' })
+  schemaName: string;
+
+  @Column({ type: 'varchar' })
+  tableName: string;
+
+  @Column({ type: 'jsonb' })
+  columnNames: string[];
+
+  @Column({ type: 'jsonb' })
+  enumNames: string[];
+
+  @Column({ type: 'jsonb', nullable: true })
+  columnDefinitions: WorkspaceSchemaColumnDefinition[] | null;
+
+  @Column({ type: 'uuid', nullable: true })
+  applicationId: string | null;
+
+  @Column({ type: 'timestamptz' })
+  removedAt: Date;
+
+  @Column({ type: 'timestamptz' })
+  scheduledDropAt: Date;
+
+  @CreateDateColumn({ type: 'timestamptz' })
+  createdAt: Date;
+
+  @Column({ type: 'uuid' })
+  workspaceId: string;
+}

--- a/packages/twenty-server/src/engine/core-modules/metadata-removal-retention/pending-metadata-drop.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/metadata-removal-retention/pending-metadata-drop.service.ts
@@ -1,0 +1,293 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { InjectDataSource, InjectRepository } from '@nestjs/typeorm';
+
+import {
+  DataSource,
+  LessThanOrEqual,
+  type QueryRunner,
+  Repository,
+} from 'typeorm';
+
+import { PendingMetadataDropEntity } from 'src/engine/core-modules/metadata-removal-retention/pending-metadata-drop.entity';
+import { type WorkspaceSchemaColumnDefinition } from 'src/engine/twenty-orm/workspace-schema-manager/types/workspace-schema-column-definition.type';
+import { WorkspaceSchemaManagerService } from 'src/engine/twenty-orm/workspace-schema-manager/workspace-schema-manager.service';
+
+const MILLISECONDS_PER_DAY = 24 * 60 * 60 * 1000;
+
+export type ReclaimOutcome = 'reused' | 'dropped' | 'none';
+
+@Injectable()
+export class PendingMetadataDropService {
+  private readonly logger = new Logger(PendingMetadataDropService.name);
+
+  constructor(
+    @InjectRepository(PendingMetadataDropEntity)
+    private readonly pendingMetadataDropRepository: Repository<PendingMetadataDropEntity>,
+    private readonly workspaceSchemaManagerService: WorkspaceSchemaManagerService,
+    @InjectDataSource()
+    private readonly coreDataSource: DataSource,
+  ) {}
+
+  async recordColumnDrop(params: {
+    queryRunner: QueryRunner;
+    workspaceId: string;
+    applicationId: string | null;
+    schemaName: string;
+    tableName: string;
+    columnNames: string[];
+    enumNames: string[];
+    columnDefinitions: WorkspaceSchemaColumnDefinition[];
+    retentionDays: number;
+  }): Promise<void> {
+    const removedAt = new Date();
+
+    await params.queryRunner.manager
+      .getRepository(PendingMetadataDropEntity)
+      .insert({
+        kind: 'COLUMN',
+        workspaceId: params.workspaceId,
+        applicationId: params.applicationId,
+        schemaName: params.schemaName,
+        tableName: params.tableName,
+        columnNames: params.columnNames,
+        enumNames: params.enumNames,
+        columnDefinitions: params.columnDefinitions,
+        removedAt,
+        scheduledDropAt: new Date(
+          removedAt.getTime() + params.retentionDays * MILLISECONDS_PER_DAY,
+        ),
+      });
+  }
+
+  async recordTableDrop(params: {
+    queryRunner: QueryRunner;
+    workspaceId: string;
+    applicationId: string | null;
+    schemaName: string;
+    tableName: string;
+    enumNames: string[];
+    columnDefinitions: WorkspaceSchemaColumnDefinition[];
+    retentionDays: number;
+  }): Promise<void> {
+    const removedAt = new Date();
+
+    await params.queryRunner.manager
+      .getRepository(PendingMetadataDropEntity)
+      .insert({
+        kind: 'TABLE',
+        workspaceId: params.workspaceId,
+        applicationId: params.applicationId,
+        schemaName: params.schemaName,
+        tableName: params.tableName,
+        columnNames: [],
+        enumNames: params.enumNames,
+        columnDefinitions: params.columnDefinitions,
+        removedAt,
+        scheduledDropAt: new Date(
+          removedAt.getTime() + params.retentionDays * MILLISECONDS_PER_DAY,
+        ),
+      });
+  }
+
+  async reclaimColumns(params: {
+    queryRunner: QueryRunner;
+    workspaceId: string;
+    schemaName: string;
+    tableName: string;
+    columnNames: string[];
+    columnDefinitions: WorkspaceSchemaColumnDefinition[];
+  }): Promise<ReclaimOutcome> {
+    const repository = params.queryRunner.manager.getRepository(
+      PendingMetadataDropEntity,
+    );
+
+    const entry = await repository.findOne({
+      where: {
+        kind: 'COLUMN',
+        workspaceId: params.workspaceId,
+        schemaName: params.schemaName,
+        tableName: params.tableName,
+      },
+      order: { removedAt: 'DESC' },
+    });
+
+    if (
+      entry === null ||
+      !this.columnNamesMatch(entry.columnNames, params.columnNames)
+    ) {
+      return 'none';
+    }
+
+    if (
+      this.definitionsMatch(entry.columnDefinitions, params.columnDefinitions)
+    ) {
+      await repository.delete(entry.id);
+
+      return 'reused';
+    }
+
+    await this.executeDeferredDrop({ entry, queryRunner: params.queryRunner });
+    await repository.delete(entry.id);
+
+    return 'dropped';
+  }
+
+  async reclaimTable(params: {
+    queryRunner: QueryRunner;
+    workspaceId: string;
+    schemaName: string;
+    tableName: string;
+    columnDefinitions: WorkspaceSchemaColumnDefinition[];
+  }): Promise<ReclaimOutcome> {
+    const repository = params.queryRunner.manager.getRepository(
+      PendingMetadataDropEntity,
+    );
+
+    const entry = await repository.findOne({
+      where: {
+        kind: 'TABLE',
+        workspaceId: params.workspaceId,
+        schemaName: params.schemaName,
+        tableName: params.tableName,
+      },
+      order: { removedAt: 'DESC' },
+    });
+
+    if (entry === null) {
+      return 'none';
+    }
+
+    if (
+      this.definitionsMatch(entry.columnDefinitions, params.columnDefinitions)
+    ) {
+      await repository.delete(entry.id);
+
+      return 'reused';
+    }
+
+    await this.executeDeferredDrop({ entry, queryRunner: params.queryRunner });
+    await repository.delete(entry.id);
+
+    return 'dropped';
+  }
+
+  async findWorkspaceIdsWithDueDrops(now: Date): Promise<string[]> {
+    const dueDrops = await this.pendingMetadataDropRepository.find({
+      where: { scheduledDropAt: LessThanOrEqual(now) },
+      select: { workspaceId: true },
+    });
+
+    return [...new Set(dueDrops.map((drop) => drop.workspaceId))];
+  }
+
+  async dropDueForWorkspace(params: {
+    workspaceId: string;
+    now: Date;
+  }): Promise<void> {
+    const dueDrops = await this.pendingMetadataDropRepository.find({
+      where: {
+        workspaceId: params.workspaceId,
+        scheduledDropAt: LessThanOrEqual(params.now),
+      },
+    });
+
+    if (dueDrops.length === 0) {
+      return;
+    }
+
+    const queryRunner = this.coreDataSource.createQueryRunner();
+
+    await queryRunner.connect();
+
+    try {
+      for (const entry of dueDrops) {
+        await queryRunner.startTransaction();
+
+        try {
+          await this.executeDeferredDrop({ entry, queryRunner });
+          await queryRunner.manager
+            .getRepository(PendingMetadataDropEntity)
+            .delete(entry.id);
+          await queryRunner.commitTransaction();
+        } catch (error) {
+          await queryRunner.rollbackTransaction();
+
+          this.logger.error(
+            `Failed to drop retained ${entry.kind.toLowerCase()} ${entry.schemaName}.${entry.tableName} (${entry.id})`,
+            error instanceof Error ? error.stack : String(error),
+          );
+        }
+      }
+    } finally {
+      await queryRunner.release();
+    }
+  }
+
+  private async executeDeferredDrop(params: {
+    entry: PendingMetadataDropEntity;
+    queryRunner: QueryRunner;
+  }): Promise<void> {
+    const { entry, queryRunner } = params;
+
+    if (entry.kind === 'COLUMN') {
+      await this.workspaceSchemaManagerService.columnManager.dropColumns({
+        queryRunner,
+        schemaName: entry.schemaName,
+        tableName: entry.tableName,
+        columnNames: entry.columnNames,
+        cascade: true,
+      });
+    } else {
+      await this.workspaceSchemaManagerService.tableManager.dropTable({
+        queryRunner,
+        schemaName: entry.schemaName,
+        tableName: entry.tableName,
+        cascade: true,
+      });
+    }
+
+    for (const enumName of entry.enumNames) {
+      await this.workspaceSchemaManagerService.enumManager.dropEnum({
+        queryRunner,
+        schemaName: entry.schemaName,
+        enumName,
+      });
+    }
+  }
+
+  private columnNamesMatch(left: string[], right: string[]): boolean {
+    return (
+      left.length === right.length &&
+      [...left].sort().join(',') === [...right].sort().join(',')
+    );
+  }
+
+  private definitionsMatch(
+    left: WorkspaceSchemaColumnDefinition[] | null,
+    right: WorkspaceSchemaColumnDefinition[],
+  ): boolean {
+    if (left === null) {
+      return false;
+    }
+
+    return this.normalizeDefinitions(left) === this.normalizeDefinitions(right);
+  }
+
+  private normalizeDefinitions(
+    definitions: WorkspaceSchemaColumnDefinition[],
+  ): string {
+    const canonicalDefinitions = definitions
+      .map((definition) =>
+        Object.fromEntries(
+          Object.entries(definition).sort(([leftKey], [rightKey]) =>
+            leftKey.localeCompare(rightKey),
+          ),
+        ),
+      )
+      .sort((left, right) =>
+        String(left.name).localeCompare(String(right.name)),
+      );
+
+    return JSON.stringify(canonicalDefinitions);
+  }
+}

--- a/packages/twenty-server/src/engine/core-modules/metadata-removal-retention/pending-metadata-drop.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/metadata-removal-retention/pending-metadata-drop.service.ts
@@ -8,7 +8,10 @@ import {
   Repository,
 } from 'typeorm';
 
-import { PendingMetadataDropEntity } from 'src/engine/core-modules/metadata-removal-retention/pending-metadata-drop.entity';
+import {
+  PendingMetadataDropEntity,
+  type PendingMetadataDropKind,
+} from 'src/engine/core-modules/metadata-removal-retention/pending-metadata-drop.entity';
 import { type WorkspaceSchemaColumnDefinition } from 'src/engine/twenty-orm/workspace-schema-manager/types/workspace-schema-column-definition.type';
 import { WorkspaceSchemaManagerService } from 'src/engine/twenty-orm/workspace-schema-manager/workspace-schema-manager.service';
 
@@ -97,39 +100,7 @@ export class PendingMetadataDropService {
     columnNames: string[];
     columnDefinitions: WorkspaceSchemaColumnDefinition[];
   }): Promise<ReclaimOutcome> {
-    const repository = params.queryRunner.manager.getRepository(
-      PendingMetadataDropEntity,
-    );
-
-    const entry = await repository.findOne({
-      where: {
-        kind: 'COLUMN',
-        workspaceId: params.workspaceId,
-        schemaName: params.schemaName,
-        tableName: params.tableName,
-      },
-      order: { removedAt: 'DESC' },
-    });
-
-    if (
-      entry === null ||
-      !this.columnNamesMatch(entry.columnNames, params.columnNames)
-    ) {
-      return 'none';
-    }
-
-    if (
-      this.definitionsMatch(entry.columnDefinitions, params.columnDefinitions)
-    ) {
-      await repository.delete(entry.id);
-
-      return 'reused';
-    }
-
-    await this.executeDeferredDrop({ entry, queryRunner: params.queryRunner });
-    await repository.delete(entry.id);
-
-    return 'dropped';
+    return this.reclaim({ ...params, kind: 'COLUMN' });
   }
 
   async reclaimTable(params: {
@@ -139,19 +110,41 @@ export class PendingMetadataDropService {
     tableName: string;
     columnDefinitions: WorkspaceSchemaColumnDefinition[];
   }): Promise<ReclaimOutcome> {
+    return this.reclaim({ ...params, kind: 'TABLE', columnNames: null });
+  }
+
+  private async reclaim(params: {
+    queryRunner: QueryRunner;
+    kind: PendingMetadataDropKind;
+    workspaceId: string;
+    schemaName: string;
+    tableName: string;
+    columnNames: string[] | null;
+    columnDefinitions: WorkspaceSchemaColumnDefinition[];
+  }): Promise<ReclaimOutcome> {
     const repository = params.queryRunner.manager.getRepository(
       PendingMetadataDropEntity,
     );
 
-    const entry = await repository.findOne({
+    const candidates = await repository.find({
       where: {
-        kind: 'TABLE',
+        kind: params.kind,
         workspaceId: params.workspaceId,
         schemaName: params.schemaName,
         tableName: params.tableName,
       },
       order: { removedAt: 'DESC' },
+      lock: { mode: 'pessimistic_write' },
     });
+
+    const requestedColumnNames = params.columnNames;
+
+    const entry =
+      requestedColumnNames === null
+        ? (candidates[0] ?? null)
+        : (candidates.find((candidate) =>
+            this.columnNamesMatch(candidate.columnNames, requestedColumnNames),
+          ) ?? null);
 
     if (entry === null) {
       return 'none';
@@ -189,6 +182,7 @@ export class PendingMetadataDropService {
         workspaceId: params.workspaceId,
         scheduledDropAt: LessThanOrEqual(params.now),
       },
+      select: { id: true },
     });
 
     if (dueDrops.length === 0) {
@@ -200,20 +194,33 @@ export class PendingMetadataDropService {
     await queryRunner.connect();
 
     try {
-      for (const entry of dueDrops) {
+      for (const { id } of dueDrops) {
         await queryRunner.startTransaction();
 
         try {
-          await this.executeDeferredDrop({ entry, queryRunner });
-          await queryRunner.manager
-            .getRepository(PendingMetadataDropEntity)
-            .delete(entry.id);
+          const repository = queryRunner.manager.getRepository(
+            PendingMetadataDropEntity,
+          );
+
+          const entry = await repository.findOne({
+            where: {
+              id,
+              scheduledDropAt: LessThanOrEqual(params.now),
+            },
+            lock: { mode: 'pessimistic_write' },
+          });
+
+          if (entry !== null) {
+            await this.executeDeferredDrop({ entry, queryRunner });
+            await repository.delete(entry.id);
+          }
+
           await queryRunner.commitTransaction();
         } catch (error) {
           await queryRunner.rollbackTransaction();
 
           this.logger.error(
-            `Failed to drop retained ${entry.kind.toLowerCase()} ${entry.schemaName}.${entry.tableName} (${entry.id})`,
+            `Failed to drop retained metadata ledger entry ${id}`,
             error instanceof Error ? error.stack : String(error),
           );
         }

--- a/packages/twenty-server/src/engine/core-modules/twenty-config/config-variables.ts
+++ b/packages/twenty-server/src/engine/core-modules/twenty-config/config-variables.ts
@@ -1696,6 +1696,15 @@ export class ConfigVariables {
   @ConfigVariablesMetadata({
     group: ConfigVariablesGroup.ADVANCED_SETTINGS,
     description:
+      'Number of days a column or table removed by an application deploy is retained before the retention cron permanently drops it. 0 drops immediately, on apply, with no recovery window.',
+    type: ConfigVariableType.NUMBER,
+  })
+  @CastToPositiveNumber()
+  METADATA_REMOVAL_RETENTION_DAYS = 0;
+
+  @ConfigVariablesMetadata({
+    group: ConfigVariablesGroup.ADVANCED_SETTINGS,
+    description:
       'Maximum number of workspaces that can be deleted in a single execution',
     type: ConfigVariableType.NUMBER,
   })

--- a/packages/twenty-server/src/engine/workspace-manager/workspace-migration/workspace-migration-runner/action-handlers/field/services/create-field-action-handler.service.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/workspace-migration/workspace-migration-runner/action-handlers/field/services/create-field-action-handler.service.ts
@@ -5,6 +5,8 @@ import { isDefined } from 'twenty-shared/utils';
 import { type QueryRunner } from 'typeorm';
 import { v4 } from 'uuid';
 
+import { PendingMetadataDropService } from 'src/engine/core-modules/metadata-removal-retention/pending-metadata-drop.service';
+import { TwentyConfigService } from 'src/engine/core-modules/twenty-config/twenty-config.service';
 import { computeMorphOrRelationFieldJoinColumnName } from 'src/engine/metadata-modules/field-metadata/utils/compute-morph-or-relation-field-join-column-name.util';
 import { WorkspaceMigrationRunnerActionHandler } from 'src/engine/workspace-manager/workspace-migration/workspace-migration-runner/interfaces/workspace-migration-runner-action-handler-service.interface';
 
@@ -40,6 +42,8 @@ export class CreateFieldActionHandlerService extends WorkspaceMigrationRunnerAct
 ) {
   constructor(
     private readonly workspaceSchemaManagerService: WorkspaceSchemaManagerService,
+    private readonly pendingMetadataDropService: PendingMetadataDropService,
+    private readonly twentyConfigService: TwentyConfigService,
   ) {
     super();
   }
@@ -188,16 +192,37 @@ export class CreateFieldActionHandlerService extends WorkspaceMigrationRunnerAct
     tableName: string;
     workspaceId: string;
   }): Promise<void> {
-    const enumOperations = collectEnumOperationsForField({
-      flatFieldMetadata,
-      tableName,
-      operation: EnumOperation.CREATE,
-    });
-
     const columnDefinitions = generateColumnDefinitions({
       flatFieldMetadata,
       flatObjectMetadata,
       workspaceId,
+    });
+
+    const retentionEnabled =
+      this.twentyConfigService.get('METADATA_REMOVAL_RETENTION_DAYS') > 0;
+
+    if (retentionEnabled) {
+      const reclaimOutcome =
+        await this.pendingMetadataDropService.reclaimColumns({
+          queryRunner,
+          workspaceId,
+          schemaName,
+          tableName,
+          columnNames: columnDefinitions.map(
+            (columnDefinition) => columnDefinition.name,
+          ),
+          columnDefinitions,
+        });
+
+      if (reclaimOutcome === 'reused') {
+        return;
+      }
+    }
+
+    const enumOperations = collectEnumOperationsForField({
+      flatFieldMetadata,
+      tableName,
+      operation: EnumOperation.CREATE,
     });
 
     await executeBatchEnumOperations({

--- a/packages/twenty-server/src/engine/workspace-manager/workspace-migration/workspace-migration-runner/action-handlers/field/services/delete-field-action-handler.service.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/workspace-migration/workspace-migration-runner/action-handlers/field/services/delete-field-action-handler.service.ts
@@ -2,6 +2,8 @@ import { Injectable } from '@nestjs/common';
 
 import { WorkspaceMigrationRunnerActionHandler } from 'src/engine/workspace-manager/workspace-migration/workspace-migration-runner/interfaces/workspace-migration-runner-action-handler-service.interface';
 
+import { PendingMetadataDropService } from 'src/engine/core-modules/metadata-removal-retention/pending-metadata-drop.service';
+import { TwentyConfigService } from 'src/engine/core-modules/twenty-config/twenty-config.service';
 import { FieldMetadataEntity } from 'src/engine/metadata-modules/field-metadata/field-metadata.entity';
 import { findFlatEntityByIdInFlatEntityMapsOrThrow } from 'src/engine/metadata-modules/flat-entity/utils/find-flat-entity-by-id-in-flat-entity-maps-or-throw.util';
 import { WorkspaceSchemaManagerService } from 'src/engine/twenty-orm/workspace-schema-manager/workspace-schema-manager.service';
@@ -16,6 +18,7 @@ import {
 import { generateColumnDefinitions } from 'src/engine/workspace-manager/workspace-migration/workspace-migration-runner/utils/generate-column-definitions.util';
 import { getWorkspaceSchemaContextForMigration } from 'src/engine/workspace-manager/workspace-migration/workspace-migration-runner/utils/get-workspace-schema-context-for-migration.util';
 import {
+  collectEnumNamesFromDropOperations,
   collectEnumOperationsForField,
   EnumOperation,
   executeBatchEnumOperations,
@@ -28,6 +31,8 @@ export class DeleteFieldActionHandlerService extends WorkspaceMigrationRunnerAct
 ) {
   constructor(
     private readonly workspaceSchemaManagerService: WorkspaceSchemaManagerService,
+    private readonly pendingMetadataDropService: PendingMetadataDropService,
+    private readonly twentyConfigService: TwentyConfigService,
   ) {
     super();
   }
@@ -62,6 +67,7 @@ export class DeleteFieldActionHandlerService extends WorkspaceMigrationRunnerAct
       queryRunner,
       allFlatEntityMaps: { flatObjectMetadataMaps, flatFieldMetadataMaps },
       workspaceId,
+      flatApplication,
     } = context;
 
     const flatFieldMetadata = findFlatEntityByIdInFlatEntityMapsOrThrow({
@@ -86,18 +92,38 @@ export class DeleteFieldActionHandlerService extends WorkspaceMigrationRunnerAct
     });
     const columnNamesToDrop = columnDefinitions.map((def) => def.name);
 
+    const enumOperations = collectEnumOperationsForField({
+      flatFieldMetadata,
+      tableName,
+      operation: EnumOperation.DROP,
+    });
+
+    const retentionDays = this.twentyConfigService.get(
+      'METADATA_REMOVAL_RETENTION_DAYS',
+    );
+
+    if (retentionDays > 0) {
+      await this.pendingMetadataDropService.recordColumnDrop({
+        queryRunner,
+        workspaceId,
+        applicationId: flatApplication.id,
+        schemaName,
+        tableName,
+        columnNames: columnNamesToDrop,
+        enumNames: collectEnumNamesFromDropOperations(enumOperations),
+        columnDefinitions,
+        retentionDays,
+      });
+
+      return;
+    }
+
     await this.workspaceSchemaManagerService.columnManager.dropColumns({
       queryRunner,
       schemaName,
       tableName,
       columnNames: columnNamesToDrop,
       cascade: true,
-    });
-
-    const enumOperations = collectEnumOperationsForField({
-      flatFieldMetadata,
-      tableName,
-      operation: EnumOperation.DROP,
     });
 
     await executeBatchEnumOperations({

--- a/packages/twenty-server/src/engine/workspace-manager/workspace-migration/workspace-migration-runner/action-handlers/object/services/create-object-action-handler.service.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/workspace-migration/workspace-migration-runner/action-handlers/object/services/create-object-action-handler.service.ts
@@ -4,6 +4,8 @@ import { v4 } from 'uuid';
 
 import { WorkspaceMigrationRunnerActionHandler } from 'src/engine/workspace-manager/workspace-migration/workspace-migration-runner/interfaces/workspace-migration-runner-action-handler-service.interface';
 
+import { PendingMetadataDropService } from 'src/engine/core-modules/metadata-removal-retention/pending-metadata-drop.service';
+import { TwentyConfigService } from 'src/engine/core-modules/twenty-config/twenty-config.service';
 import { ALL_METADATA_ENTITY_BY_METADATA_NAME } from 'src/engine/metadata-modules/flat-entity/constant/all-metadata-entity-by-metadata-name.constant';
 import { isCompositeFlatFieldMetadata } from 'src/engine/metadata-modules/flat-field-metadata/utils/is-composite-flat-field-metadata.util';
 import { isEnumFlatFieldMetadata } from 'src/engine/metadata-modules/flat-field-metadata/utils/is-enum-flat-field-metadata.util';
@@ -34,6 +36,8 @@ export class CreateObjectActionHandlerService extends WorkspaceMigrationRunnerAc
 ) {
   constructor(
     private readonly workspaceSchemaManagerService: WorkspaceSchemaManagerService,
+    private readonly pendingMetadataDropService: PendingMetadataDropService,
+    private readonly twentyConfigService: TwentyConfigService,
   ) {
     super();
   }
@@ -132,6 +136,25 @@ export class CreateObjectActionHandlerService extends WorkspaceMigrationRunnerAc
         workspaceId,
       }),
     );
+
+    const retentionEnabled =
+      this.twentyConfigService.get('METADATA_REMOVAL_RETENTION_DAYS') > 0;
+
+    if (retentionEnabled) {
+      const reclaimOutcome = await this.pendingMetadataDropService.reclaimTable(
+        {
+          queryRunner,
+          workspaceId,
+          schemaName,
+          tableName,
+          columnDefinitions,
+        },
+      );
+
+      if (reclaimOutcome === 'reused') {
+        return;
+      }
+    }
 
     const enumOrCompositeFlatFieldMetadatas = flatFieldMetadatas.filter(
       (flatFieldMetadata) =>

--- a/packages/twenty-server/src/engine/workspace-manager/workspace-migration/workspace-migration-runner/action-handlers/object/services/delete-object-action-handler.service.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/workspace-migration/workspace-migration-runner/action-handlers/object/services/delete-object-action-handler.service.ts
@@ -2,6 +2,8 @@ import { Injectable } from '@nestjs/common';
 
 import { WorkspaceMigrationRunnerActionHandler } from 'src/engine/workspace-manager/workspace-migration/workspace-migration-runner/interfaces/workspace-migration-runner-action-handler-service.interface';
 
+import { PendingMetadataDropService } from 'src/engine/core-modules/metadata-removal-retention/pending-metadata-drop.service';
+import { TwentyConfigService } from 'src/engine/core-modules/twenty-config/twenty-config.service';
 import { findFlatEntityByIdInFlatEntityMapsOrThrow } from 'src/engine/metadata-modules/flat-entity/utils/find-flat-entity-by-id-in-flat-entity-maps-or-throw.util';
 import { findFlatEntityByUniversalIdentifierOrThrow } from 'src/engine/metadata-modules/flat-entity/utils/find-flat-entity-by-universal-identifier-or-throw.util';
 import { findManyFlatEntityByIdInFlatEntityMapsOrThrow } from 'src/engine/metadata-modules/flat-entity/utils/find-many-flat-entity-by-id-in-flat-entity-maps-or-throw.util';
@@ -9,6 +11,7 @@ import { isCompositeFlatFieldMetadata } from 'src/engine/metadata-modules/flat-f
 import { isEnumFlatFieldMetadata } from 'src/engine/metadata-modules/flat-field-metadata/utils/is-enum-flat-field-metadata.util';
 import { ObjectMetadataEntity } from 'src/engine/metadata-modules/object-metadata/object-metadata.entity';
 import { WorkspaceSchemaManagerService } from 'src/engine/twenty-orm/workspace-schema-manager/workspace-schema-manager.service';
+import { generateColumnDefinitions } from 'src/engine/workspace-manager/workspace-migration/workspace-migration-runner/utils/generate-column-definitions.util';
 import {
   type FlatDeleteObjectAction,
   type UniversalDeleteObjectAction,
@@ -19,6 +22,7 @@ import {
 } from 'src/engine/workspace-manager/workspace-migration/workspace-migration-runner/types/workspace-migration-action-runner-args.type';
 import { getWorkspaceSchemaContextForMigration } from 'src/engine/workspace-manager/workspace-migration/workspace-migration-runner/utils/get-workspace-schema-context-for-migration.util';
 import {
+  collectEnumNamesFromDropOperations,
   collectEnumOperationsForObject,
   EnumOperation,
   executeBatchEnumOperations,
@@ -31,6 +35,8 @@ export class DeleteObjectActionHandlerService extends WorkspaceMigrationRunnerAc
 ) {
   constructor(
     private readonly workspaceSchemaManagerService: WorkspaceSchemaManagerService,
+    private readonly pendingMetadataDropService: PendingMetadataDropService,
+    private readonly twentyConfigService: TwentyConfigService,
   ) {
     super();
   }
@@ -73,6 +79,7 @@ export class DeleteObjectActionHandlerService extends WorkspaceMigrationRunnerAc
       queryRunner,
       allFlatEntityMaps: { flatObjectMetadataMaps, flatFieldMetadataMaps },
       workspaceId,
+      flatApplication,
     } = context;
 
     const flatObjectMetadata = findFlatEntityByIdInFlatEntityMapsOrThrow({
@@ -85,18 +92,20 @@ export class DeleteObjectActionHandlerService extends WorkspaceMigrationRunnerAc
       objectMetadata: flatObjectMetadata,
     });
 
-    await this.workspaceSchemaManagerService.tableManager.dropTable({
-      queryRunner,
-      schemaName,
-      tableName,
-      cascade: true,
-    });
-
     const objectFlatFieldMetadatas =
       findManyFlatEntityByIdInFlatEntityMapsOrThrow({
         flatEntityMaps: flatFieldMetadataMaps,
         flatEntityIds: flatObjectMetadata.fieldIds,
       });
+
+    const columnDefinitions = objectFlatFieldMetadatas.flatMap(
+      (flatFieldMetadata) =>
+        generateColumnDefinitions({
+          flatFieldMetadata,
+          flatObjectMetadata,
+          workspaceId,
+        }),
+    );
 
     const enumOrCompositeFlatFieldMetadatas = objectFlatFieldMetadatas.filter(
       (flatFieldMetadata) =>
@@ -108,6 +117,32 @@ export class DeleteObjectActionHandlerService extends WorkspaceMigrationRunnerAc
       flatFieldMetadatas: enumOrCompositeFlatFieldMetadatas,
       tableName,
       operation: EnumOperation.DROP,
+    });
+
+    const retentionDays = this.twentyConfigService.get(
+      'METADATA_REMOVAL_RETENTION_DAYS',
+    );
+
+    if (retentionDays > 0) {
+      await this.pendingMetadataDropService.recordTableDrop({
+        queryRunner,
+        workspaceId,
+        applicationId: flatApplication.id,
+        schemaName,
+        tableName,
+        enumNames: collectEnumNamesFromDropOperations(enumOperations),
+        columnDefinitions,
+        retentionDays,
+      });
+
+      return;
+    }
+
+    await this.workspaceSchemaManagerService.tableManager.dropTable({
+      queryRunner,
+      schemaName,
+      tableName,
+      cascade: true,
     });
 
     await executeBatchEnumOperations({

--- a/packages/twenty-server/src/engine/workspace-manager/workspace-migration/workspace-migration-runner/action-handlers/workspace-schema-migration-runner-action-handlers.module.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/workspace-migration/workspace-migration-runner/action-handlers/workspace-schema-migration-runner-action-handlers.module.ts
@@ -2,6 +2,7 @@ import { Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
 
 import { ApplicationEntity } from 'src/engine/core-modules/application/application.entity';
+import { MetadataRemovalRetentionModule } from 'src/engine/core-modules/metadata-removal-retention/metadata-removal-retention.module';
 import { SecretEncryptionModule } from 'src/engine/core-modules/secret-encryption/secret-encryption.module';
 import { WorkspaceSchemaManagerModule } from 'src/engine/twenty-orm/workspace-schema-manager/workspace-schema-manager.module';
 import { CreateAgentActionHandlerService } from 'src/engine/workspace-manager/workspace-migration/workspace-migration-runner/action-handlers/agent/services/create-agent-action-handler.service';
@@ -103,6 +104,7 @@ import { UpdateSearchFieldMetadataActionHandlerService } from 'src/engine/worksp
     TypeOrmModule.forFeature([ApplicationEntity]),
     WorkspaceSchemaManagerModule,
     SecretEncryptionModule,
+    MetadataRemovalRetentionModule,
   ],
   providers: [
     CreateFieldActionHandlerService,

--- a/packages/twenty-server/src/engine/workspace-manager/workspace-migration/workspace-migration-runner/utils/workspace-schema-enum-operations.util.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/workspace-migration/workspace-migration-runner/utils/workspace-schema-enum-operations.util.ts
@@ -44,6 +44,16 @@ export enum EnumOperation {
   RENAME = 'rename',
 }
 
+export const collectEnumNamesFromDropOperations = (
+  enumOperations: EnumOperationSpec[],
+): string[] =>
+  enumOperations
+    .filter(
+      (enumOperation): enumOperation is DropEnumOperationSpec =>
+        enumOperation.operation === EnumOperation.DROP,
+    )
+    .map((enumOperation) => enumOperation.enumName);
+
 const collectEnumOperationsForBasicEnumField = ({
   flatFieldMetadata,
   tableName,

--- a/packages/twenty-server/test/integration/metadata/suites/metadata-removal-retention/metadata-removal-retention.integration-spec.ts
+++ b/packages/twenty-server/test/integration/metadata/suites/metadata-removal-retention/metadata-removal-retention.integration-spec.ts
@@ -1,0 +1,143 @@
+import { createOneFieldMetadata } from 'test/integration/metadata/suites/field-metadata/utils/create-one-field-metadata.util';
+import { deleteOneFieldMetadata } from 'test/integration/metadata/suites/field-metadata/utils/delete-one-field-metadata.util';
+import { updateOneFieldMetadata } from 'test/integration/metadata/suites/field-metadata/utils/update-one-field-metadata.util';
+import { createOneObjectMetadata } from 'test/integration/metadata/suites/object-metadata/utils/create-one-object-metadata.util';
+import { deleteOneObjectMetadata } from 'test/integration/metadata/suites/object-metadata/utils/delete-one-object-metadata.util';
+import { updateOneObjectMetadata } from 'test/integration/metadata/suites/object-metadata/utils/update-one-object-metadata.util';
+import { updateConfigVariable } from 'test/integration/twenty-config/utils/update-config-variable.util';
+import { FieldMetadataType } from 'twenty-shared/types';
+
+import { SEED_APPLE_WORKSPACE_ID } from 'src/engine/workspace-manager/dev-seeder/core/constants/seeder-workspaces.constant';
+import { getWorkspaceSchemaName } from 'src/engine/workspace-datasource/utils/get-workspace-schema-name.util';
+
+const SCHEMA_NAME = getWorkspaceSchemaName(SEED_APPLE_WORKSPACE_ID);
+const TABLE_NAME = '_softDeleteRetentionTest';
+const COLUMN_NAME = 'retainedField';
+const RETAIN_MARKER = 'softdelete-retain-marker';
+
+let objectMetadataId = '';
+
+const columnExists = async (): Promise<boolean> => {
+  const rows = await globalThis.testDataSource.query(
+    `SELECT 1 FROM information_schema.columns WHERE table_schema = $1 AND table_name = $2 AND column_name = $3`,
+    [SCHEMA_NAME, TABLE_NAME, COLUMN_NAME],
+  );
+
+  return rows.length > 0;
+};
+
+const columnComment = async (): Promise<string | null> => {
+  const rows = await globalThis.testDataSource.query(
+    `SELECT pg_catalog.col_description(c.oid, a.attnum) AS comment
+     FROM pg_class c
+     JOIN pg_namespace n ON n.oid = c.relnamespace
+     JOIN pg_attribute a ON a.attrelid = c.oid
+     WHERE n.nspname = $1 AND c.relname = $2 AND a.attname = $3`,
+    [SCHEMA_NAME, TABLE_NAME, COLUMN_NAME],
+  );
+
+  return rows[0]?.comment ?? null;
+};
+
+const pendingDropCount = async (): Promise<number> => {
+  const rows = await globalThis.testDataSource.query(
+    `SELECT id FROM core."pendingMetadataDrop" WHERE "workspaceId" = $1 AND "tableName" = $2 AND "kind" = 'COLUMN' AND "columnNames" @> $3::jsonb`,
+    [SEED_APPLE_WORKSPACE_ID, TABLE_NAME, JSON.stringify([COLUMN_NAME])],
+  );
+
+  return rows.length;
+};
+
+const createRetainedField = async (): Promise<string> => {
+  const { data } = await createOneFieldMetadata({
+    input: {
+      name: COLUMN_NAME,
+      label: 'Retained Field',
+      type: FieldMetadataType.TEXT,
+      objectMetadataId,
+      isLabelSyncedWithName: false,
+    },
+    gqlFields: 'id name',
+  });
+
+  return data.createOneField.id;
+};
+
+const deactivateAndDeleteField = async (fieldId: string): Promise<void> => {
+  await updateOneFieldMetadata({
+    expectToFail: false,
+    input: { idToUpdate: fieldId, updatePayload: { isActive: false } },
+  });
+
+  await deleteOneFieldMetadata({
+    expectToFail: false,
+    input: { idToDelete: fieldId },
+  });
+};
+
+describe('Metadata removal retention — deferred drop and reclaim', () => {
+  beforeAll(async () => {
+    await updateConfigVariable({
+      input: { key: 'METADATA_REMOVAL_RETENTION_DAYS', value: 7 },
+    });
+
+    const { data } = await createOneObjectMetadata({
+      input: {
+        nameSingular: 'softDeleteRetentionTest',
+        namePlural: 'softDeleteRetentionTests',
+        labelSingular: 'Soft Delete Retention Test',
+        labelPlural: 'Soft Delete Retention Tests',
+        icon: 'IconTrash',
+      },
+    });
+
+    objectMetadataId = data.createOneObject.id;
+  }, 90000);
+
+  afterAll(async () => {
+    await updateConfigVariable({
+      input: { key: 'METADATA_REMOVAL_RETENTION_DAYS', value: 0 },
+    });
+
+    await updateOneObjectMetadata({
+      expectToFail: false,
+      input: {
+        idToUpdate: objectMetadataId,
+        updatePayload: { isActive: false },
+      },
+    });
+
+    await deleteOneObjectMetadata({
+      input: { idToDelete: objectMetadataId },
+    });
+
+    await globalThis.testDataSource.query(
+      `DELETE FROM core."pendingMetadataDrop" WHERE "workspaceId" = $1 AND "tableName" = $2`,
+      [SEED_APPLE_WORKSPACE_ID, TABLE_NAME],
+    );
+  }, 90000);
+
+  it('retains a removed column for the retention window, then reclaims it with data intact on re-add', async () => {
+    const fieldId = await createRetainedField();
+
+    expect(await columnExists()).toBe(true);
+
+    await globalThis.testDataSource.query(
+      `COMMENT ON COLUMN "${SCHEMA_NAME}"."${TABLE_NAME}"."${COLUMN_NAME}" IS '${RETAIN_MARKER}'`,
+    );
+
+    expect(await columnComment()).toBe(RETAIN_MARKER);
+
+    await deactivateAndDeleteField(fieldId);
+
+    expect(await columnExists()).toBe(true);
+    expect(await columnComment()).toBe(RETAIN_MARKER);
+    expect(await pendingDropCount()).toBe(1);
+
+    await createRetainedField();
+
+    expect(await columnExists()).toBe(true);
+    expect(await columnComment()).toBe(RETAIN_MARKER);
+    expect(await pendingDropCount()).toBe(0);
+  }, 90000);
+});


### PR DESCRIPTION
> Stacked on #22341 → #22340 → #22339 → #22333 (base branch `feat/apps-deploy-plan-modal`). Review/merge those first.

## What & why

The plan/gate work (#22333–#22341) lets app developers **see** a destructive change and confirm it. This PR adds the other half of "unafraid to deploy": a **retention window** so a removed field or object is recoverable instead of instantly gone.

When an app deploy (or any metadata change) removes a field/object, the workspace migration runner immediately `DROP`s the column/table. With retention enabled, the drop is **deferred**: the column/table is kept, the removal is recorded in a `core.pendingMetadataDrop` ledger, and a daily cron performs the real `DROP` only after the retention period elapses. Re-adding the same field/object within the window **reclaims the retained column with its data intact**.

This is the deferred-drop-ledger design chosen over a soft-delete marker specifically because it leaves the GraphQL-schema generation path untouched — the metadata row is still deleted, so the schema stays correct with zero changes to the schema hot path.

## Safety: off by default

Gated by a new config var **`METADATA_REMOVAL_RETENTION_DAYS` (default `0`)**. At `0` the behavior is byte-for-byte today's immediate drop, so this PR is **inert until an operator enables it** — no behavior change, no regression risk. The reclaim path in the create handlers is a no-op until a ledger entry exists.

## How it works

- **Deferral** — `DeleteFieldActionHandlerService` / `DeleteObjectActionHandlerService`: when `retentionDays > 0`, record the column/table (+ enum types, + the exact column definitions) in the ledger and skip the physical drop. The ledger write happens inside the migration's `queryRunner` transaction, so a rolled-back migration never leaves an orphan drop.
- **Reclaim** — `CreateFieldActionHandlerService` / `CreateObjectActionHandlerService`: before adding a column/table, check the ledger. An identical definition → cancel the pending drop and reuse the retained column (data intact). A changed definition → execute the deferred drop now, then create fresh. No entry → normal create.
- **Retention sweep** — `MetadataRemovalRetentionCronJob` (daily) fans out per workspace to `MetadataRemovalRetentionJob`, which drops everything past its `scheduledDropAt` in its own transaction (a failed drop is logged and retried next run, never blocking others).
- New `core.pendingMetadataDrop` entity + fast instance command; `PendingMetadataDropEntity` added to the workspace-scoped-repository lint exemptions (it is core bookkeeping, like `WorkspaceEntity`).

## Testing

- **Integration** (`metadata-removal-retention.integration-spec.ts`): with retention on, create a field, mark its column, delete the field → asserts the column **and its marker survive** plus a ledger row exists; re-add the field → asserts the **same physical column is reused** (marker still present, proving data is intact) and the ledger row is consumed. This caught a real bug — `jsonb` does not preserve key order, so the stored vs freshly-generated column-definition comparison needed canonicalization.
- **Unit** (`pending-metadata-drop.service.spec.ts`): reclaim outcomes (reuse / drop-stale / none / key-order-insensitive), `scheduledDropAt` math, and the cron sweep including the rollback-on-failure path.
- Object-metadata and application integration suites pass unchanged with retention off (the default), confirming no regression to normal create/delete.

## Follow-up

With retention enabled, the destructive-gate copy ("permanently deletes data") could be softened to "recoverable for N days". Left out here to keep this PR's blast radius tight and because the copy is correct at the default (`0`).


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/22344?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

