### PR TITLE
ci(twenty-front): show only failing unit tests in CI

### DIFF
--- a/packages/twenty-front/jest-failures-only-reporter.cjs
+++ b/packages/twenty-front/jest-failures-only-reporter.cjs
@@ -1,0 +1,88 @@
+class JestFailuresOnlyReporter {
+  constructor() {
+    this._failures = [];
+  }
+
+  onTestResult(_test, testResult) {
+    if (testResult.numFailingTests === 0 && !testResult.testExecError) {
+      return;
+    }
+
+    const relativePath = testResult.testFilePath.replace(
+      process.cwd() + '/',
+      '',
+    );
+
+    process.stderr.write(`\n\x1b[31mFAIL\x1b[0m ${relativePath}\n`);
+
+    if (testResult.failureMessage) {
+      process.stderr.write(testResult.failureMessage + '\n');
+    }
+
+    if (testResult.testExecError) {
+      process.stderr.write(
+        `\n  Runtime error: ${testResult.testExecError.message}\n`,
+      );
+    }
+
+    this._failures.push({ path: relativePath, testResult });
+  }
+
+  onRunComplete(_testContexts, aggregatedResults) {
+    const {
+      numPassedTestSuites,
+      numFailedTestSuites,
+      numTotalTestSuites,
+      numPassedTests,
+      numFailedTests,
+      numTotalTests,
+    } = aggregatedResults;
+
+    process.stderr.write('\n');
+
+    if (this._failures.length > 0) {
+      process.stderr.write(
+        `\x1b[31m${'='.repeat(60)}\x1b[0m\n` +
+          `\x1b[31m FAILED TEST SUITES SUMMARY\x1b[0m\n` +
+          `\x1b[31m${'='.repeat(60)}\x1b[0m\n\n`,
+      );
+
+      for (const failure of this._failures) {
+        process.stderr.write(`  \x1b[31m✕\x1b[0m ${failure.path}\n`);
+
+        const failedTests = failure.testResult.testResults.filter(
+          (result) => result.status === 'failed',
+        );
+
+        for (const failedTest of failedTests) {
+          process.stderr.write(`    \x1b[31m→\x1b[0m ${failedTest.fullName}\n`);
+        }
+
+        process.stderr.write('\n');
+      }
+
+      process.stderr.write(`\x1b[31m${'='.repeat(60)}\x1b[0m\n\n`);
+    }
+
+    const suiteSummary =
+      `Test Suites: ` +
+      (numFailedTestSuites > 0
+        ? `\x1b[31m${numFailedTestSuites} failed\x1b[0m, `
+        : '') +
+      (numPassedTestSuites > 0
+        ? `\x1b[32m${numPassedTestSuites} passed\x1b[0m, `
+        : '') +
+      `${numTotalTestSuites} total`;
+
+    const testSummary =
+      `Tests:       ` +
+      (numFailedTests > 0 ? `\x1b[31m${numFailedTests} failed\x1b[0m, ` : '') +
+      (numPassedTests > 0 ? `\x1b[32m${numPassedTests} passed\x1b[0m, ` : '') +
+      `${numTotalTests} total`;
+
+    process.stderr.write(suiteSummary + '\n');
+    process.stderr.write(testSummary + '\n');
+  }
+}
+
+module.exports = JestFailuresOnlyReporter;

--- a/packages/twenty-front/jest.config.mjs
+++ b/packages/twenty-front/jest.config.mjs
@@ -9,6 +9,8 @@ const __dirname = dirname(__filename);
 const tsConfigPath = resolve(__dirname, './tsconfig.json');
 const tsConfig = JSON.parse(readFileSync(tsConfigPath, 'utf8'));
 
+const isCI = process.env.CI === 'true';
+
 // oxlint-disable-next-line no-undef
 process.env.TZ = 'GMT';
 // oxlint-disable-next-line no-undef
@@ -17,6 +19,7 @@ const jestConfig = {
   // For more information please have a look to official docs https://jestjs.io/docs/configuration/#prettierpath-string
   // Prettier v3 will should be supported in jest v30 https://github.com/jestjs/jest/releases/tag/v30.0.0-alpha.1
   prettierPath: null,
+  ...(isCI && { reporters: ['./jest-failures-only-reporter.cjs'] }),
   displayName: 'twenty-front',
   preset: '../../jest.preset.js',
   setupFilesAfterEnv: ['./setupTests.ts'],


### PR DESCRIPTION
## What

Adds a custom Jest reporter to **twenty-front** that, in CI, suppresses passing-test output and surfaces only failures — mirroring what we already do for **twenty-server**.

## How

- New `packages/twenty-front/jest-failures-only-reporter.cjs` — a verbatim port of `packages/twenty-server/jest-failures-only-reporter.js`. It prints a `FAIL` block per failing suite plus a final "FAILED TEST SUITES SUMMARY", and otherwise emits only the suite/test totals.
- Wired into `packages/twenty-front/jest.config.mjs` via `...(isCI && { reporters: ['./jest-failures-only-reporter.cjs'] })`, gated on `CI === 'true'` exactly like twenty-server.

### Note on the `.cjs` extension

twenty-front's `package.json` sets `"type": "module"`, so a `.js` reporter is parsed as ESM and `module.exports` throws. Renaming to `.cjs` keeps the file as CommonJS (Jest requires CJS reporters). twenty-server is not an ESM package, hence its `.js` extension.

## Testing

- Passing suite (`CI=true npx jest <file>`): output reduced to the totals summary only.
- Temporary failing suite: shows the `FAIL` block, failure message, and the failed-suites summary.

Local dev runs (no `CI` env) are unaffected — the default reporter is used.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/22345?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

