### PR TITLE
`[FIX_TYPECHECK_ON_MAIN]` Add missing inviteTeamMaxCreditsReward to OnboardingConfig type

### DIFF
--- a/packages/twenty-front/src/modules/client-config/types/OnboardingConfig.ts
+++ b/packages/twenty-front/src/modules/client-config/types/OnboardingConfig.ts
@@ -1,5 +1,6 @@
 export type OnboardingConfig = {
   importContactsCreditsReward: number;
+  inviteTeamMaxCreditsReward: number;
   inviteTeamCreditsRewardPerUser: number;
   upgradeCreditsReward: number;
 };

--- a/packages/twenty-front/src/testing/mock-data/config.ts
+++ b/packages/twenty-front/src/testing/mock-data/config.ts
@@ -46,6 +46,7 @@ export const mockedClientConfig: ClientConfig = {
   api: { mutationMaximumAffectedRecords: 100 },
   onboarding: {
     importContactsCreditsReward: 2,
+    inviteTeamMaxCreditsReward: 9,
     inviteTeamCreditsRewardPerUser: 3,
     upgradeCreditsReward: 5,
   },


### PR DESCRIPTION
## Context

The `twenty-front` typecheck is broken on `main`:

```
src/modules/onboarding/hooks/useInviteTeam.ts:154:27 - error TS2551: Property 'inviteTeamMaxCreditsReward' does not exist on type 'OnboardingConfig'.
```

This is a merge race: one PR started consuming `onboardingConfig.inviteTeamMaxCreditsReward` in `useInviteTeam.ts`, while the frontend `OnboardingConfig` type only declared `inviteTeamCreditsRewardPerUser`. The backend already returns both fields (`client-config.entity.ts` declares `inviteTeamMaxCreditsReward` and the service populates it), so this is purely a missing frontend type field.

## Changes

- Add `inviteTeamMaxCreditsReward: number` to the frontend `OnboardingConfig` type.
- Add the field to the config mock so `mock-data/config.ts` satisfies the type.

## Test

`npx nx typecheck twenty-front` passes.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/22370?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

