### PR TITLE
Fix workflow step mutations unreachable via workspace API keys

### DIFF
--- a/packages/twenty-server/src/engine/core-modules/workflow/resolvers/workflow-builder.resolver.ts
+++ b/packages/twenty-server/src/engine/core-modules/workflow/resolvers/workflow-builder.resolver.ts
@@ -12,7 +12,6 @@ import { WorkflowTriggerGraphqlApiExceptionFilter } from 'src/engine/core-module
 import { WorkspaceEntity } from 'src/engine/core-modules/workspace/workspace.entity';
 import { AuthWorkspace } from 'src/engine/decorators/auth/auth-workspace.decorator';
 import { SettingsPermissionGuard } from 'src/engine/guards/settings-permission.guard';
-import { UserAuthGuard } from 'src/engine/guards/user-auth.guard';
 import { WorkspaceAuthGuard } from 'src/engine/guards/workspace-auth.guard';
 import { PermissionsGraphqlApiExceptionFilter } from 'src/engine/metadata-modules/permissions/utils/permissions-graphql-api-exception.filter';
 import { type OutputSchema } from 'src/modules/workflow/workflow-builder/workflow-schema/types/output-schema.type';
@@ -21,7 +20,6 @@ import { WorkflowSchemaWorkspaceService } from 'src/modules/workflow/workflow-bu
 @CoreResolver()
 @UseGuards(
   WorkspaceAuthGuard,
-  UserAuthGuard,
   SettingsPermissionGuard(PermissionFlagType.WORKFLOWS),
 )
 @UsePipes(ResolverValidationPipe)

--- a/packages/twenty-server/src/engine/core-modules/workflow/resolvers/workflow-trigger.resolver.ts
+++ b/packages/twenty-server/src/engine/core-modules/workflow/resolvers/workflow-trigger.resolver.ts
@@ -33,7 +33,6 @@ import { WorkspaceMemberWorkspaceEntity } from 'src/modules/workspace-member/sta
 @CoreResolver()
 @UseGuards(
   WorkspaceAuthGuard,
-  UserAuthGuard,
   SettingsPermissionGuard(PermissionFlagType.WORKFLOWS),
 )
 @UsePipes(ResolverValidationPipe)
@@ -73,6 +72,7 @@ export class WorkflowTriggerResolver {
   }
 
   @Mutation(() => RunWorkflowVersionDTO)
+  @UseGuards(UserAuthGuard)
   async runWorkflowVersion(
     @AuthUser() user: AuthContextUser,
     @AuthWorkspace() workspace: WorkspaceEntity,

--- a/packages/twenty-server/src/engine/core-modules/workflow/resolvers/workflow-trigger.resolver.ts
+++ b/packages/twenty-server/src/engine/core-modules/workflow/resolvers/workflow-trigger.resolver.ts
@@ -11,11 +11,11 @@ import {
 import { CoreResolver } from 'src/engine/api/graphql/graphql-config/decorators/core-resolver.decorator';
 import { UUIDScalarType } from 'src/engine/api/graphql/workspace-schema-builder/graphql-types/scalars';
 import { buildCreatedByFromFullNameMetadata } from 'src/engine/core-modules/actor/utils/build-created-by-from-full-name-metadata.util';
+import { type AuthContextUser } from 'src/engine/core-modules/auth/types/auth-context.type';
 import { PreventNestToAutoLogGraphqlErrorsFilter } from 'src/engine/core-modules/graphql/filters/prevent-nest-to-auto-log-graphql-errors.filter';
 import { ResolverValidationPipe } from 'src/engine/core-modules/graphql/pipes/resolver-validation.pipe';
-import { type AuthContextUser } from 'src/engine/core-modules/auth/types/auth-context.type';
-import { RunWorkflowVersionInput } from 'src/engine/core-modules/workflow/dtos/run-workflow-version.input';
 import { RunWorkflowVersionDTO } from 'src/engine/core-modules/workflow/dtos/run-workflow-version.dto';
+import { RunWorkflowVersionInput } from 'src/engine/core-modules/workflow/dtos/run-workflow-version.input';
 import { WorkflowRunDTO } from 'src/engine/core-modules/workflow/dtos/workflow-run.dto';
 import { WorkflowTriggerGraphqlApiExceptionFilter } from 'src/engine/core-modules/workflow/filters/workflow-trigger-graphql-api-exception.filter';
 import { WorkspaceEntity } from 'src/engine/core-modules/workspace/workspace.entity';

--- a/packages/twenty-server/src/engine/core-modules/workflow/resolvers/workflow-version-edge.resolver.ts
+++ b/packages/twenty-server/src/engine/core-modules/workflow/resolvers/workflow-version-edge.resolver.ts
@@ -12,7 +12,6 @@ import { WorkflowVersionEdgeGraphqlApiExceptionFilter } from 'src/engine/core-mo
 import { WorkspaceEntity } from 'src/engine/core-modules/workspace/workspace.entity';
 import { AuthWorkspace } from 'src/engine/decorators/auth/auth-workspace.decorator';
 import { SettingsPermissionGuard } from 'src/engine/guards/settings-permission.guard';
-import { UserAuthGuard } from 'src/engine/guards/user-auth.guard';
 import { WorkspaceAuthGuard } from 'src/engine/guards/workspace-auth.guard';
 import { PermissionsGraphqlApiExceptionFilter } from 'src/engine/metadata-modules/permissions/utils/permissions-graphql-api-exception.filter';
 import { WorkflowVersionEdgeWorkspaceService } from 'src/modules/workflow/workflow-builder/workflow-version-edge/workflow-version-edge.workspace-service';
@@ -21,7 +20,6 @@ import { WorkflowVersionEdgeWorkspaceService } from 'src/modules/workflow/workfl
 @UsePipes(ResolverValidationPipe)
 @UseGuards(
   WorkspaceAuthGuard,
-  UserAuthGuard,
   SettingsPermissionGuard(PermissionFlagType.WORKFLOWS),
 )
 @UseFilters(

--- a/packages/twenty-server/src/engine/core-modules/workflow/resolvers/workflow-version-step.resolver.ts
+++ b/packages/twenty-server/src/engine/core-modules/workflow/resolvers/workflow-version-step.resolver.ts
@@ -22,7 +22,6 @@ import { WorkflowVersionStepGraphqlApiExceptionFilter } from 'src/engine/core-mo
 import { WorkspaceEntity } from 'src/engine/core-modules/workspace/workspace.entity';
 import { AuthWorkspace } from 'src/engine/decorators/auth/auth-workspace.decorator';
 import { SettingsPermissionGuard } from 'src/engine/guards/settings-permission.guard';
-import { UserAuthGuard } from 'src/engine/guards/user-auth.guard';
 import { WorkspaceAuthGuard } from 'src/engine/guards/workspace-auth.guard';
 import { ConnectedAccountMetadataService } from 'src/engine/metadata-modules/connected-account/connected-account-metadata.service';
 import { ConnectedAccountHandleDTO } from 'src/engine/metadata-modules/connected-account/dtos/connected-account-handle.dto';
@@ -35,7 +34,6 @@ import { WorkflowRunnerWorkspaceService } from 'src/modules/workflow/workflow-ru
 @UsePipes(ResolverValidationPipe)
 @UseGuards(
   WorkspaceAuthGuard,
-  UserAuthGuard,
   SettingsPermissionGuard(PermissionFlagType.WORKFLOWS),
 )
 @UseFilters(

--- a/packages/twenty-server/src/engine/core-modules/workflow/resolvers/workflow-version-step.resolver.ts
+++ b/packages/twenty-server/src/engine/core-modules/workflow/resolvers/workflow-version-step.resolver.ts
@@ -22,6 +22,7 @@ import { WorkflowVersionStepGraphqlApiExceptionFilter } from 'src/engine/core-mo
 import { WorkspaceEntity } from 'src/engine/core-modules/workspace/workspace.entity';
 import { AuthWorkspace } from 'src/engine/decorators/auth/auth-workspace.decorator';
 import { SettingsPermissionGuard } from 'src/engine/guards/settings-permission.guard';
+import { UserAuthGuard } from 'src/engine/guards/user-auth.guard';
 import { WorkspaceAuthGuard } from 'src/engine/guards/workspace-auth.guard';
 import { ConnectedAccountMetadataService } from 'src/engine/metadata-modules/connected-account/connected-account-metadata.service';
 import { ConnectedAccountHandleDTO } from 'src/engine/metadata-modules/connected-account/dtos/connected-account-handle.dto';
@@ -157,6 +158,7 @@ export class WorkflowVersionStepResolver {
   }
 
   @Mutation(() => TestHttpRequestDTO)
+  @UseGuards(UserAuthGuard)
   async testHttpRequest(
     @AuthWorkspace() workspace: WorkspaceEntity,
     @Args('input')

--- a/packages/twenty-server/src/engine/core-modules/workflow/resolvers/workflow-version-step.resolver.ts
+++ b/packages/twenty-server/src/engine/core-modules/workflow/resolvers/workflow-version-step.resolver.ts
@@ -12,8 +12,8 @@ import { CreateWorkflowVersionStepInput } from 'src/engine/core-modules/workflow
 import { DeleteWorkflowVersionStepInput } from 'src/engine/core-modules/workflow/dtos/delete-workflow-version-step.input';
 import { DuplicateWorkflowVersionStepInput } from 'src/engine/core-modules/workflow/dtos/duplicate-workflow-version-step.input';
 import { SubmitFormStepInput } from 'src/engine/core-modules/workflow/dtos/submit-form-step.input';
-import { TestHttpRequestInput } from 'src/engine/core-modules/workflow/dtos/test-http-request.input';
 import { TestHttpRequestDTO } from 'src/engine/core-modules/workflow/dtos/test-http-request.dto';
+import { TestHttpRequestInput } from 'src/engine/core-modules/workflow/dtos/test-http-request.input';
 import { UpdateWorkflowRunStepInput } from 'src/engine/core-modules/workflow/dtos/update-workflow-run-step.input';
 import { UpdateWorkflowVersionStepInput } from 'src/engine/core-modules/workflow/dtos/update-workflow-version-step.input';
 import { WorkflowActionDTO } from 'src/engine/core-modules/workflow/dtos/workflow-action.dto';

--- a/packages/twenty-server/src/engine/core-modules/workflow/resolvers/workflow-version.resolver.ts
+++ b/packages/twenty-server/src/engine/core-modules/workflow/resolvers/workflow-version.resolver.ts
@@ -13,7 +13,6 @@ import { WorkflowVersionDTO } from 'src/engine/core-modules/workflow/dtos/workfl
 import { WorkspaceEntity } from 'src/engine/core-modules/workspace/workspace.entity';
 import { AuthWorkspace } from 'src/engine/decorators/auth/auth-workspace.decorator';
 import { SettingsPermissionGuard } from 'src/engine/guards/settings-permission.guard';
-import { UserAuthGuard } from 'src/engine/guards/user-auth.guard';
 import { WorkspaceAuthGuard } from 'src/engine/guards/workspace-auth.guard';
 import { PermissionsGraphqlApiExceptionFilter } from 'src/engine/metadata-modules/permissions/utils/permissions-graphql-api-exception.filter';
 import { WorkflowVersionWorkspaceService } from 'src/modules/workflow/workflow-builder/workflow-version/workflow-version.workspace-service';
@@ -22,7 +21,6 @@ import { WorkflowVersionWorkspaceService } from 'src/modules/workflow/workflow-b
 @UsePipes(ResolverValidationPipe)
 @UseGuards(
   WorkspaceAuthGuard,
-  UserAuthGuard,
   SettingsPermissionGuard(PermissionFlagType.WORKFLOWS),
 )
 @UseFilters(

--- a/packages/twenty-server/test/integration/graphql/suites/workflow/workflow-version-step-api-key.integration-spec.ts
+++ b/packages/twenty-server/test/integration/graphql/suites/workflow/workflow-version-step-api-key.integration-spec.ts
@@ -53,7 +53,7 @@ describe('workflowVersionStep API key access', () => {
       getWorkflowResponse.body.data.workflow.versions.edges[0].node.id;
 
     // Set up a trigger on the draft version so steps can be added
-    await client
+    const triggerResponse = await client
       .post('/graphql')
       .set('Authorization', `Bearer ${APPLE_JANE_ADMIN_ACCESS_TOKEN}`)
       .send({
@@ -77,6 +77,8 @@ describe('workflowVersionStep API key access', () => {
           },
         },
       });
+
+    expect(triggerResponse.body.errors).toBeUndefined();
   });
 
   afterAll(async () => {
@@ -173,7 +175,8 @@ describe('workflowVersionStep API key access', () => {
 
       expect(getVersionResponse.body.errors).toBeUndefined();
 
-      const steps = getVersionResponse.body.data.workflowVersion.steps as Array<{
+      const steps = getVersionResponse.body.data.workflowVersion
+        .steps as Array<{
         id: string;
         type: string;
       }>;
@@ -184,7 +187,7 @@ describe('workflowVersionStep API key access', () => {
     });
 
     it('should succeed with an admin API key', async () => {
-      expect(stepIdToDelete).toBeDefined();
+      expect(stepIdToDelete).toBeTruthy();
 
       const response = await client
         .post('/graphql')

--- a/packages/twenty-server/test/integration/graphql/suites/workflow/workflow-version-step-api-key.integration-spec.ts
+++ b/packages/twenty-server/test/integration/graphql/suites/workflow/workflow-version-step-api-key.integration-spec.ts
@@ -299,8 +299,8 @@ describe('workflowVersionStep API key access', () => {
           query: `
             mutation TestHttpRequest($input: TestHttpRequestInput!) {
               testHttpRequest(input: $input) {
+                success
                 status
-                body
               }
             }
           `,

--- a/packages/twenty-server/test/integration/graphql/suites/workflow/workflow-version-step-api-key.integration-spec.ts
+++ b/packages/twenty-server/test/integration/graphql/suites/workflow/workflow-version-step-api-key.integration-spec.ts
@@ -1,0 +1,281 @@
+import request from 'supertest';
+
+const client = request(`http://localhost:${APP_PORT}`);
+
+describe('workflowVersionStep API key access', () => {
+  let workflowId: string;
+  let workflowVersionId: string;
+
+  beforeAll(async () => {
+    // Create a workflow with admin user session
+    const createWorkflowResponse = await client
+      .post('/graphql')
+      .set('Authorization', `Bearer ${APPLE_JANE_ADMIN_ACCESS_TOKEN}`)
+      .send({
+        query: `
+          mutation CreateOneWorkflow {
+            createWorkflow(data: { name: "API Key Test Workflow" }) {
+              id
+              versions {
+                edges {
+                  node {
+                    id
+                  }
+                }
+              }
+            }
+          }
+        `,
+      });
+
+    expect(createWorkflowResponse.body.errors).toBeUndefined();
+
+    workflowId = createWorkflowResponse.body.data.createWorkflow.id;
+    workflowVersionId =
+      createWorkflowResponse.body.data.createWorkflow.versions.edges[0].node.id;
+
+    // Set up a trigger on the draft version so steps can be added
+    await client
+      .post('/graphql')
+      .set('Authorization', `Bearer ${APPLE_JANE_ADMIN_ACCESS_TOKEN}`)
+      .send({
+        query: `
+          mutation UpdateWorkflowVersion($id: UUID!, $data: WorkflowVersionUpdateInput!) {
+            updateWorkflowVersion(id: $id, data: $data) {
+              id
+            }
+          }
+        `,
+        variables: {
+          id: workflowVersionId,
+          data: {
+            trigger: {
+              name: 'Manual Trigger',
+              type: 'MANUAL',
+              settings: { outputSchema: {} },
+              nextStepIds: [],
+              position: { x: 0, y: 0 },
+            },
+          },
+        },
+      });
+  });
+
+  afterAll(async () => {
+    if (workflowId) {
+      await client
+        .post('/graphql')
+        .set('Authorization', `Bearer ${APPLE_JANE_ADMIN_ACCESS_TOKEN}`)
+        .send({
+          query: `
+            mutation DestroyOneWorkflow($id: UUID!) {
+              destroyWorkflow(id: $id) { id }
+            }
+          `,
+          variables: { id: workflowId },
+        });
+    }
+  });
+
+  describe('createWorkflowVersionStep', () => {
+    it('should succeed with an admin API key', async () => {
+      const response = await client
+        .post('/graphql')
+        .set('Authorization', `Bearer ${API_KEY_ACCESS_TOKEN}`)
+        .send({
+          query: `
+            mutation CreateWorkflowVersionStep($input: CreateWorkflowVersionStepInput!) {
+              createWorkflowVersionStep(input: $input) {
+                stepsDiff
+              }
+            }
+          `,
+          variables: {
+            input: {
+              workflowVersionId,
+              stepType: 'CODE',
+              parentStepId: 'trigger',
+              position: { x: 200, y: 0 },
+            },
+          },
+        });
+
+      expect(response.status).toBe(200);
+      expect(response.body.errors).toBeUndefined();
+      expect(response.body.data.createWorkflowVersionStep).toBeDefined();
+      expect(
+        response.body.data.createWorkflowVersionStep.stepsDiff,
+      ).toBeDefined();
+    });
+  });
+
+  describe('deleteWorkflowVersionStep', () => {
+    let stepIdToDelete: string;
+
+    beforeAll(async () => {
+      // Create a step to delete (using API key)
+      const createResponse = await client
+        .post('/graphql')
+        .set('Authorization', `Bearer ${API_KEY_ACCESS_TOKEN}`)
+        .send({
+          query: `
+            mutation CreateWorkflowVersionStep($input: CreateWorkflowVersionStepInput!) {
+              createWorkflowVersionStep(input: $input) {
+                stepsDiff
+              }
+            }
+          `,
+          variables: {
+            input: {
+              workflowVersionId,
+              stepType: 'CODE',
+              parentStepId: 'trigger',
+              position: { x: 400, y: 0 },
+            },
+          },
+        });
+
+      // Extract the created step ID from stepsDiff
+      const stepsDiff = createResponse.body.data.createWorkflowVersionStep
+        .stepsDiff as Record<string, unknown>[];
+
+      const createdEntry = stepsDiff.find(
+        (diff: Record<string, unknown>) => diff.type === 'create',
+      ) as Record<string, unknown> | undefined;
+
+      stepIdToDelete = (createdEntry?.step as Record<string, unknown>)
+        ?.id as string;
+    });
+
+    it('should succeed with an admin API key', async () => {
+      expect(stepIdToDelete).toBeDefined();
+
+      const response = await client
+        .post('/graphql')
+        .set('Authorization', `Bearer ${API_KEY_ACCESS_TOKEN}`)
+        .send({
+          query: `
+            mutation DeleteWorkflowVersionStep($input: DeleteWorkflowVersionStepInput!) {
+              deleteWorkflowVersionStep(input: $input) {
+                stepsDiff
+              }
+            }
+          `,
+          variables: {
+            input: {
+              workflowVersionId,
+              stepId: stepIdToDelete,
+            },
+          },
+        });
+
+      expect(response.status).toBe(200);
+      expect(response.body.errors).toBeUndefined();
+      expect(response.body.data.deleteWorkflowVersionStep).toBeDefined();
+    });
+  });
+
+  describe('runWorkflowVersion', () => {
+    it('should be rejected with an API key (requires user session)', async () => {
+      const response = await client
+        .post('/graphql')
+        .set('Authorization', `Bearer ${API_KEY_ACCESS_TOKEN}`)
+        .send({
+          query: `
+            mutation RunWorkflowVersion($input: RunWorkflowVersionInput!) {
+              runWorkflowVersion(input: $input) {
+                workflowRunId
+              }
+            }
+          `,
+          variables: {
+            input: {
+              workflowVersionId,
+            },
+          },
+        });
+
+      expect(response.status).toBe(200);
+      expect(response.body.errors).toBeDefined();
+      expect(response.body.errors[0].message).toBe('Forbidden resource');
+    });
+
+    it('should succeed with a user session token', async () => {
+      // First activate the version so it can be run
+      await client
+        .post('/graphql')
+        .set('Authorization', `Bearer ${APPLE_JANE_ADMIN_ACCESS_TOKEN}`)
+        .send({
+          query: `
+            mutation ActivateWorkflowVersion($workflowVersionId: UUID!) {
+              activateWorkflowVersion(workflowVersionId: $workflowVersionId)
+            }
+          `,
+          variables: { workflowVersionId },
+        });
+
+      const response = await client
+        .post('/graphql')
+        .set('Authorization', `Bearer ${APPLE_JANE_ADMIN_ACCESS_TOKEN}`)
+        .send({
+          query: `
+            mutation RunWorkflowVersion($input: RunWorkflowVersionInput!) {
+              runWorkflowVersion(input: $input) {
+                workflowRunId
+              }
+            }
+          `,
+          variables: {
+            input: {
+              workflowVersionId,
+            },
+          },
+        });
+
+      expect(response.status).toBe(200);
+      expect(response.body.errors).toBeUndefined();
+      expect(response.body.data.runWorkflowVersion.workflowRunId).toBeDefined();
+
+      // Clean up: deactivate the version
+      await client
+        .post('/graphql')
+        .set('Authorization', `Bearer ${APPLE_JANE_ADMIN_ACCESS_TOKEN}`)
+        .send({
+          query: `
+            mutation DeactivateWorkflowVersion($workflowVersionId: UUID!) {
+              deactivateWorkflowVersion(workflowVersionId: $workflowVersionId)
+            }
+          `,
+          variables: { workflowVersionId },
+        });
+    });
+  });
+
+  describe('testHttpRequest', () => {
+    it('should be rejected with an API key (requires user session)', async () => {
+      const response = await client
+        .post('/graphql')
+        .set('Authorization', `Bearer ${API_KEY_ACCESS_TOKEN}`)
+        .send({
+          query: `
+            mutation TestHttpRequest($input: TestHttpRequestInput!) {
+              testHttpRequest(input: $input) {
+                statusCode
+                body
+              }
+            }
+          `,
+          variables: {
+            input: {
+              url: 'https://httpbin.org/get',
+              method: 'GET',
+            },
+          },
+        });
+
+      expect(response.status).toBe(200);
+      expect(response.body.errors).toBeDefined();
+      expect(response.body.errors[0].message).toBe('Forbidden resource');
+    });
+  });
+});

--- a/packages/twenty-server/test/integration/graphql/suites/workflow/workflow-version-step-api-key.integration-spec.ts
+++ b/packages/twenty-server/test/integration/graphql/suites/workflow/workflow-version-step-api-key.integration-spec.ts
@@ -299,7 +299,7 @@ describe('workflowVersionStep API key access', () => {
           query: `
             mutation TestHttpRequest($input: TestHttpRequestInput!) {
               testHttpRequest(input: $input) {
-                statusCode
+                status
                 body
               }
             }

--- a/packages/twenty-server/test/integration/graphql/suites/workflow/workflow-version-step-api-key.integration-spec.ts
+++ b/packages/twenty-server/test/integration/graphql/suites/workflow/workflow-version-step-api-key.integration-spec.ts
@@ -16,6 +16,24 @@ describe('workflowVersionStep API key access', () => {
           mutation CreateOneWorkflow {
             createWorkflow(data: { name: "API Key Test Workflow" }) {
               id
+            }
+          }
+        `,
+      });
+
+    expect(createWorkflowResponse.body.errors).toBeUndefined();
+
+    workflowId = createWorkflowResponse.body.data.createWorkflow.id;
+
+    // Fetch the auto-created draft version
+    const getWorkflowResponse = await client
+      .post('/graphql')
+      .set('Authorization', `Bearer ${APPLE_JANE_ADMIN_ACCESS_TOKEN}`)
+      .send({
+        query: `
+          query GetWorkflow($id: UUID!) {
+            workflow(filter: { id: { eq: $id } }) {
+              id
               versions {
                 edges {
                   node {
@@ -26,13 +44,13 @@ describe('workflowVersionStep API key access', () => {
             }
           }
         `,
+        variables: { id: workflowId },
       });
 
-    expect(createWorkflowResponse.body.errors).toBeUndefined();
+    expect(getWorkflowResponse.body.errors).toBeUndefined();
 
-    workflowId = createWorkflowResponse.body.data.createWorkflow.id;
     workflowVersionId =
-      createWorkflowResponse.body.data.createWorkflow.versions.edges[0].node.id;
+      getWorkflowResponse.body.data.workflow.versions.edges[0].node.id;
 
     // Set up a trigger on the draft version so steps can be added
     await client
@@ -135,16 +153,34 @@ describe('workflowVersionStep API key access', () => {
           },
         });
 
-      // Extract the created step ID from stepsDiff
-      const stepsDiff = createResponse.body.data.createWorkflowVersionStep
-        .stepsDiff as Record<string, unknown>[];
+      expect(createResponse.body.errors).toBeUndefined();
 
-      const createdEntry = stepsDiff.find(
-        (diff: Record<string, unknown>) => diff.type === 'create',
-      ) as Record<string, unknown> | undefined;
+      // Fetch the step ID from the workflow version
+      const getVersionResponse = await client
+        .post('/graphql')
+        .set('Authorization', `Bearer ${APPLE_JANE_ADMIN_ACCESS_TOKEN}`)
+        .send({
+          query: `
+            query GetWorkflowVersion($id: UUID!) {
+              workflowVersion(filter: { id: { eq: $id } }) {
+                id
+                steps
+              }
+            }
+          `,
+          variables: { id: workflowVersionId },
+        });
 
-      stepIdToDelete = (createdEntry?.step as Record<string, unknown>)
-        ?.id as string;
+      expect(getVersionResponse.body.errors).toBeUndefined();
+
+      const steps = getVersionResponse.body.data.workflowVersion.steps as Array<{
+        id: string;
+        type: string;
+      }>;
+
+      const codeStep = steps.find((step) => step.type === 'CODE');
+
+      stepIdToDelete = codeStep?.id ?? '';
     });
 
     it('should succeed with an admin API key', async () => {


### PR DESCRIPTION
Fixes #21714


### The issue :
`UserAuthGuard `blocks API key access across all workflow resolvers. It checks `request.user !== undefined` but API keys only set `request.workspace`, not `request.user.` The `SettingsPermissionGuard `already handles API key permission checks properly (via `apiKeyId`), so `UserAuthGuard `is an unnecessary extra barrier.


### The fix: 
Remove `UserAuthGuard `from all workflow resolvers that don't need a user, and move it to method-level for the one method (`runWorkflowVersion`) that actually uses `@AuthUser()`.



<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/22379?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

