### PR TITLE
test: verify #build-companion thread creation (ignore — will close)

### DIFF
--- a/BUILD_COMPANION_THREAD_TEST.md
+++ b/BUILD_COMPANION_THREAD_TEST.md
@@ -1,0 +1,1 @@
+Temporary file to verify the #build-companion thread automation. Safe to delete.


### PR DESCRIPTION
Throwaway draft PR to verify the Twenty Eng Bot can create a thread on #build-companion review announcements. Will be closed immediately. Please ignore.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/22391?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

