### PR TITLE
Let the sign-in screen scroll when its content overflows the viewport

### DIFF
--- a/packages/twenty-front/src/pages/auth/SignInUpV2.tsx
+++ b/packages/twenty-front/src/pages/auth/SignInUpV2.tsx
@@ -51,6 +51,7 @@ const StyledBackground = styled.div`
   display: flex;
   flex-direction: column;
   height: 100dvh;
+  overflow-y: auto;
   width: 100%;
 `;
 


### PR DESCRIPTION
On the sign-in screen, when a step's content is taller than the viewport (e.g. many workspaces to choose from), it grew past the fixed-height background and overflowed the page.

Make the shared background scroll instead, so every sign-in step scrolls when its content overflows and stays centered when it fits.

## Before

https://github.com/user-attachments/assets/0226daee-0cd9-454c-9f4b-257cfab61bfb


## After

https://github.com/user-attachments/assets/7a535099-f0f0-431b-86ad-9fa8121638db


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/22397?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->
