### PR TITLE
fix(billing) - invalidate activationStatus after billing event

### DIFF
--- a/packages/twenty-server/src/engine/core-modules/billing-webhook/services/billing-webhook-subscription.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/billing-webhook/services/billing-webhook-subscription.service.ts
@@ -164,10 +164,7 @@ export class BillingWebhookSubscriptionService {
     } else if (
       workspace.activationStatus === WorkspaceActivationStatus.SUSPENDED
     ) {
-      await this.workspaceRepository.update(workspaceId, {
-        activationStatus: WorkspaceActivationStatus.ACTIVE,
-        suspendedAt: null,
-      });
+      await this.workspaceService.reactivateWorkspace(workspaceId);
 
       await this.messageQueueService.add<CleanWorkspaceDeletionWarningUserVarsJobData>(
         CleanWorkspaceDeletionWarningUserVarsJob.name,

--- a/packages/twenty-server/src/engine/core-modules/workspace/services/workspace.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/workspace/services/workspace.service.ts
@@ -484,6 +484,17 @@ export class WorkspaceService extends TypeOrmQueryService<WorkspaceEntity> {
       activationStatus: WorkspaceActivationStatus.SUSPENDED,
       suspendedAt: new Date(),
     });
+
+    await this.coreEntityCacheService.invalidate('workspaceEntity', id);
+  }
+
+  async reactivateWorkspace(id: string) {
+    await this.workspaceRepository.update(id, {
+      activationStatus: WorkspaceActivationStatus.ACTIVE,
+      suspendedAt: null,
+    });
+
+    await this.coreEntityCacheService.invalidate('workspaceEntity', id);
   }
 
   async deleteWorkspace(id: string, softDelete = false) {


### PR DESCRIPTION
Issue with workspaces still blocked after being re-activated

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/22414?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

