### PR TITLE
fix(front): redirect workspace-less sessions instead of hanging the root domain

### DIFF
--- a/packages/twenty-front/src/modules/app/components/AppRouterProviders.tsx
+++ b/packages/twenty-front/src/modules/app/components/AppRouterProviders.tsx
@@ -32,6 +32,7 @@ import { BaseThemeProvider } from '@/ui/theme/components/BaseThemeProvider';
 import { UserThemeProviderEffect } from '@/ui/theme/components/UserThemeProviderEffect';
 import { PageFavicon } from '@/ui/utilities/page-favicon/components/PageFavicon';
 import { PageTitle } from '@/ui/utilities/page-title/components/PageTitle';
+import { WorkspacelessSessionRedirectEffect } from '@/app/effect-components/WorkspacelessSessionRedirectEffect';
 import { WorkspaceProviderEffect } from '@/workspace/components/WorkspaceProviderEffect';
 import { StrictMode } from 'react';
 import { Outlet, useLocation } from 'react-router-dom';
@@ -49,6 +50,7 @@ export const AppRouterProviders = () => {
         <MinimalMetadataLoadEffect />
         <IsMinimalMetadataReadyEffect />
         <WorkspaceProviderEffect />
+        <WorkspacelessSessionRedirectEffect />
         <ClientConfigProvider>
           <CaptchaProvider>
             <MinimalMetadataGater>

--- a/packages/twenty-front/src/modules/app/effect-components/WorkspacelessSessionRedirectEffect.tsx
+++ b/packages/twenty-front/src/modules/app/effect-components/WorkspacelessSessionRedirectEffect.tsx
@@ -1,0 +1,62 @@
+import { useEffect } from 'react';
+import { useLocation, useNavigate } from 'react-router-dom';
+import { AppPath } from 'twenty-shared/types';
+import { isWorkspaceActiveOrSuspended } from 'twenty-shared/workspace';
+
+import { ONBOARDING_PATHS } from '@/auth/constants/OnboardingPaths';
+import { ONGOING_USER_CREATION_PATHS } from '@/auth/constants/OngoingUserCreationPaths';
+import { useHasAccessTokenPair } from '@/auth/hooks/useHasAccessTokenPair';
+import { currentWorkspaceState } from '@/auth/states/currentWorkspaceState';
+import { isCurrentUserLoadedState } from '@/auth/states/isCurrentUserLoadedState';
+import { useAtomStateValue } from '@/ui/utilities/state/jotai/hooks/useAtomStateValue';
+import { isMatchingLocation } from '~/utils/isMatchingLocation';
+
+// An authenticated session with no active workspace — e.g. a workspace-agnostic
+// token on the multi-workspace root domain — can never satisfy MinimalMetadataLoadEffect
+// (which requires an active workspace), so MinimalMetadataGater would show its loader
+// forever. This runs above the gater and routes such sessions to SignInUp, which on the
+// root domain resolves to the workspace picker, instead of hanging on the loader.
+const REDIRECT_EXCLUDED_PATHS = [
+  ...ONGOING_USER_CREATION_PATHS,
+  ...ONBOARDING_PATHS,
+  AppPath.ResetPassword,
+  AppPath.Authorize,
+];
+
+export const WorkspacelessSessionRedirectEffect = () => {
+  const hasAccessTokenPair = useHasAccessTokenPair();
+  const isCurrentUserLoaded = useAtomStateValue(isCurrentUserLoadedState);
+  const currentWorkspace = useAtomStateValue(currentWorkspaceState);
+  const location = useLocation();
+  const navigate = useNavigate();
+
+  useEffect(() => {
+    // Wait for the current-user load to resolve so we don't redirect a valid
+    // workspace session during the window before currentWorkspace is populated.
+    if (!hasAccessTokenPair || !isCurrentUserLoaded) {
+      return;
+    }
+
+    if (isWorkspaceActiveOrSuspended(currentWorkspace)) {
+      return;
+    }
+
+    const isOnExcludedPath = REDIRECT_EXCLUDED_PATHS.some((appPath) =>
+      isMatchingLocation(location, appPath),
+    );
+
+    if (isOnExcludedPath) {
+      return;
+    }
+
+    navigate(AppPath.SignInUp);
+  }, [
+    hasAccessTokenPair,
+    isCurrentUserLoaded,
+    currentWorkspace,
+    location,
+    navigate,
+  ]);
+
+  return null;
+};

--- a/packages/twenty-front/src/modules/app/effect-components/__tests__/WorkspacelessSessionRedirectEffect.test.tsx
+++ b/packages/twenty-front/src/modules/app/effect-components/__tests__/WorkspacelessSessionRedirectEffect.test.tsx
@@ -1,0 +1,89 @@
+import { render, waitFor } from '@testing-library/react';
+import { Provider as JotaiProvider } from 'jotai';
+import { MemoryRouter } from 'react-router-dom';
+import { AppPath } from 'twenty-shared/types';
+import { WorkspaceActivationStatus } from 'twenty-shared/workspace';
+
+import { WorkspacelessSessionRedirectEffect } from '@/app/effect-components/WorkspacelessSessionRedirectEffect';
+import {
+  type CurrentWorkspace,
+  currentWorkspaceState,
+} from '@/auth/states/currentWorkspaceState';
+import { isCurrentUserLoadedState } from '@/auth/states/isCurrentUserLoadedState';
+import {
+  jotaiStore,
+  resetJotaiStore,
+} from '@/ui/utilities/state/jotai/jotaiStore';
+
+const navigateMock = jest.fn();
+let hasAccessTokenPairValue = true;
+
+jest.mock('@/auth/hooks/useHasAccessTokenPair', () => ({
+  useHasAccessTokenPair: () => hasAccessTokenPairValue,
+}));
+
+jest.mock('react-router-dom', () => ({
+  ...jest.requireActual('react-router-dom'),
+  useNavigate: () => navigateMock,
+}));
+
+const activeWorkspace = {
+  activationStatus: WorkspaceActivationStatus.ACTIVE,
+} as CurrentWorkspace;
+
+const renderEffect = (initialEntry: string) =>
+  render(
+    <JotaiProvider store={jotaiStore}>
+      <MemoryRouter initialEntries={[initialEntry]}>
+        <WorkspacelessSessionRedirectEffect />
+      </MemoryRouter>
+    </JotaiProvider>,
+  );
+
+describe('WorkspacelessSessionRedirectEffect', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    resetJotaiStore();
+    hasAccessTokenPairValue = true;
+    jotaiStore.set(isCurrentUserLoadedState.atom, true);
+    jotaiStore.set(currentWorkspaceState.atom, null);
+  });
+
+  it('redirects an authenticated workspace-less session to SignInUp', async () => {
+    renderEffect('/');
+
+    await waitFor(() => {
+      expect(navigateMock).toHaveBeenCalledWith(AppPath.SignInUp);
+    });
+  });
+
+  it('does not redirect a session that has an active workspace', () => {
+    jotaiStore.set(currentWorkspaceState.atom, activeWorkspace);
+
+    renderEffect('/');
+
+    expect(navigateMock).not.toHaveBeenCalled();
+  });
+
+  it('does not redirect before the current user has finished loading', () => {
+    jotaiStore.set(isCurrentUserLoadedState.atom, false);
+
+    renderEffect('/');
+
+    expect(navigateMock).not.toHaveBeenCalled();
+  });
+
+  it('does not redirect an unauthenticated session', () => {
+    hasAccessTokenPairValue = false;
+
+    renderEffect('/');
+
+    expect(navigateMock).not.toHaveBeenCalled();
+  });
+
+  it('does not redirect when already on the SignInUp page', () => {
+    renderEffect(AppPath.SignInUp);
+
+    expect(navigateMock).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Problem

On the multi-workspace root domain (app.twenty.com), a persisted **workspace-agnostic** token (JWT type `WORKSPACE_AGNOSTIC`, no `workspaceId`) leaves the app **loading forever**:

- `MinimalMetadataLoadEffect` only loads metadata when `hasAccessTokenPair && isActiveWorkspace`. With no active workspace, `isMinimalMetadataReady` never flips true.
- `MinimalMetadataGater` therefore renders `<UserOrMetadataLoader />` indefinitely.
- `PageChangeEffect` — the redirect engine that would route a workspace-less session onward — is a **child of that gater**, so it never mounts, and the app can't escape the loader. No backend calls, no error, just an infinite skeleton.

Diagnosed live on app.twenty.com: backend + GraphQL are healthy; a logged-out load works fine; the hang is purely this frontend gating.

## Fix

Add `WorkspacelessSessionRedirectEffect`, mounted **above** the gater in `AppRouterProviders`. When a session is authenticated, the current-user load has resolved, and there is **no active workspace**, it navigates to `SignInUp` — which on the root domain resolves to the workspace picker (`SignInUpGlobalScopeForm`) — instead of hanging.

- Guarded on `isCurrentUserLoaded` so a valid workspace session is **never** redirected during the initial load window (before `currentWorkspace` populates).
- Excludes auth/onboarding paths (`ONGOING_USER_CREATION_PATHS`, `ONBOARDING_PATHS`, `ResetPassword`, `Authorize`) so it can't loop or interrupt those flows.
- Precedence is unchanged: `WorkspaceProviderEffect` still redirects returning users to their `lastAuthenticatedWorkspaceDomain` first; this only catches the case where no such redirect applies.

Unit tests cover: redirects the hang state; does **not** redirect a session with an active workspace, a session still loading, an unauthenticated session, or one already on `SignInUp`.

## Scope note

This is the **targeted, verifiable** fix for the production hang. The larger entry-app / workspace-app split behind a domain resolver (the multi-region decoupling) was designed and adversarially reviewed separately; it touches SSO/impersonation/onboarding/billing cross-domain flows and is best landed as a **staged follow-up** rather than folded in here. This change is a clean foundation for it.

## Stacking

Opened against `r--remove-v1-onboarding` (#22398) per the original plan, but it only touches `AppRouterProviders.tsx` (which #22398 doesn't) plus a new file, so it has no real dependency on #22398 and can be retargeted to `main` if preferred.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/22425?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

