### PR TITLE
Fix email validation for over-length inline edits

### DIFF
--- a/packages/twenty-shared/src/utils/validation/emailSchema.ts
+++ b/packages/twenty-shared/src/utils/validation/emailSchema.ts
@@ -1,3 +1,5 @@
 import { z } from 'zod';
 
-export const emailSchema = z.email({ pattern: z.regexes.unicodeEmail });
+export const emailSchema = z
+  .email({ pattern: z.regexes.unicodeEmail })
+  .max(255);


### PR DESCRIPTION
## Summary

This PR addresses the inconsistency reported in #22406 where over-length email values were accepted by the inline editor, optimistically shown as saved, and then rejected by the backend.

### Changes

- Await `updateOneRecord` before updating the local record store, so the UI is only updated after a successful mutation. This prevents the optimistic state from showing values that failed to persist.
- Add a client-side maximum length validation (`255`) to `emailSchema` so over-length email values are rejected before the GraphQL mutation is sent.
- Propagate the client-side validation message through `MultiItemFieldInput` so validation failures are surfaced immediately instead of silently preventing the save.

### Verification

- Valid email addresses continue to save successfully.
- Over-length email values are rejected on the client without sending a GraphQL request.

Related to #22406.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/22426?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

