### PR TITLE
feat(website): add Product to menu + footer nav, move Why into Resources dropdown

### DIFF
--- a/packages/twenty-website/src/sections/footer/footer.data.ts
+++ b/packages/twenty-website/src/sections/footer/footer.data.ts
@@ -38,8 +38,6 @@ export type FooterSocialLink = {
   icon: IconComponent;
 };
 
-// Sitemap includes Customers — it exists in the nav but was missing from the
-// old footer.
 export const FOOTER: {
   navGroups: readonly FooterNavGroup[];
   socialLinks: readonly FooterSocialLink[];
@@ -50,6 +48,7 @@ export const FOOTER: {
       title: msg`Sitemap`,
       links: [
         { label: msg`Home`, href: '/' },
+        { label: msg`Product`, href: '/product' },
         { label: msg`Pricing`, href: '/pricing' },
         { label: msg`Customers`, href: '/customers' },
         { label: msg`Partners`, href: '/partners' },

--- a/packages/twenty-website/src/sections/menu/data/menu.ts
+++ b/packages/twenty-website/src/sections/menu/data/menu.ts
@@ -3,6 +3,7 @@ import {
   IconBook,
   IconBrandLinkedin,
   IconBrandX,
+  IconBulb,
   IconCode,
   IconTag,
   IconUsers,
@@ -22,10 +23,23 @@ export const MENU: {
 } = {
   appUrl: SITE_URLS.appWelcome,
   navItems: [
-    { href: '/why-twenty', label: msg`Why` },
+    { href: '/product', label: msg`Product` },
     {
       label: msg`Resources`,
       children: [
+        {
+          label: msg`Why`,
+          description: msg`The story behind Twenty`,
+          href: '/why-twenty',
+          icon: IconBulb,
+          preview: {
+            image: '/images/menu/why.webp',
+            imageAlt: msg`Why Twenty illustration`,
+            imagePosition: 'center',
+            title: msg`Why teams choose Twenty`,
+            description: msg`The principles and product philosophy behind the open source CRM.`,
+          },
+        },
         {
           label: msg`User Guide`,
           description: msg`Learn how to use Twenty`,


### PR DESCRIPTION
## What

Restores the **Product** link to the site nav (removed in #21794), reversing that commit's nav-structure change:

- **Menu** — Product is the first top-level item (in place of Why); **Why** moves back into the **Resources** dropdown with its `why.webp` preview (`IconBulb`, "Why teams choose Twenty").
- **Footer** — Product added to the **Sitemap** group (after Home).

The `/product` and `/why-twenty` routes already exist and are in the sitemap; only the nav data changed. The rest of #21794 (dropdown frame height, preview assets, current-page highlight) is untouched.

## Notes

- New `msg` strings (`Product`, and Why's restored strings) are left to CI / the i18n bot to extract + translate — no catalog changes here.

## Testing

- `nx lint twenty-website` ✓ (check-conventions + oxlint + oxfmt)
- `nx typecheck twenty-website` ✓