### PR TITLE
fix: raise dev-mode heap limit for twenty-server to prevent OOM crash

### DIFF
--- a/packages/twenty-server/project.json
+++ b/packages/twenty-server/project.json
@@ -54,7 +54,7 @@
       "dependsOn": ["^build"],
       "options": {
         "cwd": "packages/twenty-server",
-        "command": "rimraf dist && NODE_ENV=development nest start --watch"
+        "command": "rimraf dist && NODE_ENV=development NODE_OPTIONS=--max-old-space-size=12288 nest start --watch"
       }
     },
     "start:ci": {
@@ -77,7 +77,7 @@
       "dependsOn": ["^build"],
       "options": {
         "cwd": "packages/twenty-server",
-        "command": "rimraf dist && NODE_ENV=development nest start --watch --debug"
+        "command": "rimraf dist && NODE_ENV=development NODE_OPTIONS=--max-old-space-size=12288 nest start --watch --debug"
       }
     },
     "reset:env": {
@@ -120,7 +120,7 @@
       "dependsOn": ["^build"],
       "options": {
         "cwd": "packages/twenty-server",
-        "command": "NODE_ENV=development nest start --watch --entryFile queue-worker/queue-worker"
+        "command": "NODE_ENV=development NODE_OPTIONS=--max-old-space-size=12288 nest start --watch --entryFile queue-worker/queue-worker"
       }
     },
     "ts-node": {


### PR DESCRIPTION
## Context

Closes twentyhq/core-team-issues#2601

Dev mode was crashing with a Node.js out-of-memory error:

```
FATAL ERROR: Reached heap limit Allocation failed - JavaScript heap out of memory
```

The crash occurred at ~4119 MB, which is Node's **default** heap ceiling on typical dev machines.

## Root cause

`yarn start` runs `nx run-many -t start -p twenty-server twenty-front` plus `twenty-server:worker`. The three twenty-server dev targets — `start`, `start:debug`, and `worker` — ran `nest start --watch` **without** setting `--max-old-space-size`, so the long-running NestJS watch process used Node's default heap limit and eventually OOM-crashed in development.

Notably, `.vscode/launch.json` and `.vscode/tasks.json` already set `--max-old-space-size=12288` for server runs, so the CLI dev path was simply missing the same headroom.

## Change

Add `NODE_OPTIONS=--max-old-space-size=12288` to the twenty-server `start`, `start:debug`, and `worker` targets in `packages/twenty-server/project.json`, matching the value already used in the VS Code configs.

Raising the ceiling does not pre-allocate memory — it only lets the dev process grow past ~4 GB before Node aborts, which prevents the crash.

## Test

- `yarn start` no longer aborts with the heap-limit fatal error during a normal dev session.
- No behavioral/schema changes; config-only.


---
_Generated by [Claude Code](https://claude.ai/code/session_011zE5E1MNotK4YnoewP18tQ)_

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/22430?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

