### PR TITLE
refactor(schema): reorganize IndexField and related types

### DIFF
--- a/packages/twenty-client-sdk/src/metadata/generated/schema.graphql
+++ b/packages/twenty-client-sdk/src/metadata/generated/schema.graphql
@@ -529,15 +529,6 @@ enum FieldMetadataType {
   UUID
 }
 
-type IndexField {
-  id: UUID!
-  fieldMetadataId: UUID!
-  order: Float!
-  subFieldName: String
-  createdAt: DateTime!
-  updatedAt: DateTime!
-}
-
 type Index {
   id: UUID!
   name: String!
@@ -555,13 +546,6 @@ type Index {
     """Specify to filter the records returned."""
     filter: ObjectFilter! = {}
   ): IndexObjectMetadataConnection!
-  indexFieldMetadatas(
-    """Limit or page results."""
-    paging: CursorPaging! = {first: 10}
-
-    """Specify to filter the records returned."""
-    filter: IndexFieldFilter! = {}
-  ): IndexIndexFieldMetadatasConnection!
 }
 
 """Type of the index"""
@@ -620,13 +604,6 @@ input UUIDFilterComparison {
 input BooleanFieldComparison {
   is: Boolean
   isNot: Boolean
-}
-
-input IndexFieldFilter {
-  and: [IndexFieldFilter!]
-  or: [IndexFieldFilter!]
-  id: UUIDFilterComparison
-  fieldMetadataId: UUIDFilterComparison
 }
 
 type ObjectStandardOverrides {
@@ -2021,6 +1998,15 @@ enum RelationType {
   MANY_TO_ONE
 }
 
+type IndexField {
+  id: UUID!
+  fieldMetadataId: UUID!
+  order: Float!
+  subFieldName: String
+  createdAt: DateTime!
+  updatedAt: DateTime!
+}
+
 type IndexEdge {
   """The node containing the Index"""
   node: Index!
@@ -2049,22 +2035,6 @@ type IndexConnection {
 
   """Array of edges."""
   edges: [IndexEdge!]!
-}
-
-type IndexFieldEdge {
-  """The node containing the IndexField"""
-  node: IndexField!
-
-  """Cursor for this node."""
-  cursor: ConnectionCursor!
-}
-
-type IndexIndexFieldMetadatasConnection {
-  """Paging information"""
-  pageInfo: PageInfo!
-
-  """Array of edges."""
-  edges: [IndexFieldEdge!]!
 }
 
 type ObjectEdge {

--- a/packages/twenty-client-sdk/src/metadata/generated/schema.ts
+++ b/packages/twenty-client-sdk/src/metadata/generated/schema.ts
@@ -387,16 +387,6 @@ export interface Field {
 /** Type of the field */
 export type FieldMetadataType = 'ACTOR' | 'ADDRESS' | 'ARRAY' | 'BOOLEAN' | 'CURRENCY' | 'DATE' | 'DATE_TIME' | 'EMAILS' | 'FILES' | 'FULL_NAME' | 'LINKS' | 'MORPH_RELATION' | 'MULTI_SELECT' | 'NUMBER' | 'NUMERIC' | 'PHONES' | 'POSITION' | 'RATING' | 'RAW_JSON' | 'RELATION' | 'RICH_TEXT' | 'SELECT' | 'TEXT' | 'TS_VECTOR' | 'UUID'
 
-export interface IndexField {
-    id: Scalars['UUID']
-    fieldMetadataId: Scalars['UUID']
-    order: Scalars['Float']
-    subFieldName?: Scalars['String']
-    createdAt: Scalars['DateTime']
-    updatedAt: Scalars['DateTime']
-    __typename: 'IndexField'
-}
-
 export interface Index {
     id: Scalars['UUID']
     name: Scalars['String']
@@ -408,7 +398,6 @@ export interface Index {
     updatedAt: Scalars['DateTime']
     indexFieldMetadataList: IndexField[]
     objectMetadata: IndexObjectMetadataConnection
-    indexFieldMetadatas: IndexIndexFieldMetadatasConnection
     __typename: 'Index'
 }
 
@@ -1655,6 +1644,16 @@ export interface Relation {
 /** Relation type */
 export type RelationType = 'ONE_TO_MANY' | 'MANY_TO_ONE'
 
+export interface IndexField {
+    id: Scalars['UUID']
+    fieldMetadataId: Scalars['UUID']
+    order: Scalars['Float']
+    subFieldName?: Scalars['String']
+    createdAt: Scalars['DateTime']
+    updatedAt: Scalars['DateTime']
+    __typename: 'IndexField'
+}
+
 export interface IndexEdge {
     /** The node containing the Index */
     node: Index
@@ -1681,22 +1680,6 @@ export interface IndexConnection {
     /** Array of edges. */
     edges: IndexEdge[]
     __typename: 'IndexConnection'
-}
-
-export interface IndexFieldEdge {
-    /** The node containing the IndexField */
-    node: IndexField
-    /** Cursor for this node. */
-    cursor: Scalars['ConnectionCursor']
-    __typename: 'IndexFieldEdge'
-}
-
-export interface IndexIndexFieldMetadatasConnection {
-    /** Paging information */
-    pageInfo: PageInfo
-    /** Array of edges. */
-    edges: IndexFieldEdge[]
-    __typename: 'IndexIndexFieldMetadatasConnection'
 }
 
 export interface ObjectEdge {
@@ -3408,17 +3391,6 @@ export interface FieldGenqlSelection{
     __scalar?: boolean | number
 }
 
-export interface IndexFieldGenqlSelection{
-    id?: boolean | number
-    fieldMetadataId?: boolean | number
-    order?: boolean | number
-    subFieldName?: boolean | number
-    createdAt?: boolean | number
-    updatedAt?: boolean | number
-    __typename?: boolean | number
-    __scalar?: boolean | number
-}
-
 export interface IndexGenqlSelection{
     id?: boolean | number
     name?: boolean | number
@@ -3434,11 +3406,6 @@ export interface IndexGenqlSelection{
     paging: CursorPaging, 
     /** Specify to filter the records returned. */
     filter: ObjectFilter} })
-    indexFieldMetadatas?: (IndexIndexFieldMetadatasConnectionGenqlSelection & { __args: {
-    /** Limit or page results. */
-    paging: CursorPaging, 
-    /** Specify to filter the records returned. */
-    filter: IndexFieldFilter} })
     __typename?: boolean | number
     __scalar?: boolean | number
 }
@@ -3458,8 +3425,6 @@ export interface ObjectFilter {and?: (ObjectFilter[] | null),or?: (ObjectFilter[
 export interface UUIDFilterComparison {is?: (Scalars['Boolean'] | null),isNot?: (Scalars['Boolean'] | null),eq?: (Scalars['UUID'] | null),neq?: (Scalars['UUID'] | null),gt?: (Scalars['UUID'] | null),gte?: (Scalars['UUID'] | null),lt?: (Scalars['UUID'] | null),lte?: (Scalars['UUID'] | null),like?: (Scalars['UUID'] | null),notLike?: (Scalars['UUID'] | null),iLike?: (Scalars['UUID'] | null),notILike?: (Scalars['UUID'] | null),in?: (Scalars['UUID'][] | null),notIn?: (Scalars['UUID'][] | null)}
 
 export interface BooleanFieldComparison {is?: (Scalars['Boolean'] | null),isNot?: (Scalars['Boolean'] | null)}
-
-export interface IndexFieldFilter {and?: (IndexFieldFilter[] | null),or?: (IndexFieldFilter[] | null),id?: (UUIDFilterComparison | null),fieldMetadataId?: (UUIDFilterComparison | null)}
 
 export interface ObjectStandardOverridesGenqlSelection{
     labelSingular?: boolean | number
@@ -4744,6 +4709,17 @@ export interface RelationGenqlSelection{
     __scalar?: boolean | number
 }
 
+export interface IndexFieldGenqlSelection{
+    id?: boolean | number
+    fieldMetadataId?: boolean | number
+    order?: boolean | number
+    subFieldName?: boolean | number
+    createdAt?: boolean | number
+    updatedAt?: boolean | number
+    __typename?: boolean | number
+    __scalar?: boolean | number
+}
+
 export interface IndexEdgeGenqlSelection{
     /** The node containing the Index */
     node?: IndexGenqlSelection
@@ -4771,24 +4747,6 @@ export interface IndexConnectionGenqlSelection{
     pageInfo?: PageInfoGenqlSelection
     /** Array of edges. */
     edges?: IndexEdgeGenqlSelection
-    __typename?: boolean | number
-    __scalar?: boolean | number
-}
-
-export interface IndexFieldEdgeGenqlSelection{
-    /** The node containing the IndexField */
-    node?: IndexFieldGenqlSelection
-    /** Cursor for this node. */
-    cursor?: boolean | number
-    __typename?: boolean | number
-    __scalar?: boolean | number
-}
-
-export interface IndexIndexFieldMetadatasConnectionGenqlSelection{
-    /** Paging information */
-    pageInfo?: PageInfoGenqlSelection
-    /** Array of edges. */
-    edges?: IndexFieldEdgeGenqlSelection
     __typename?: boolean | number
     __scalar?: boolean | number
 }
@@ -6848,14 +6806,6 @@ export interface LogicFunctionLogsInput {applicationId?: (Scalars['UUID'] | null
     
 
 
-    const IndexField_possibleTypes: string[] = ['IndexField']
-    export const isIndexField = (obj?: { __typename?: any } | null): obj is IndexField => {
-      if (!obj?.__typename) throw new Error('__typename is missing in "isIndexField"')
-      return IndexField_possibleTypes.includes(obj.__typename)
-    }
-    
-
-
     const Index_possibleTypes: string[] = ['Index']
     export const isIndex = (obj?: { __typename?: any } | null): obj is Index => {
       if (!obj?.__typename) throw new Error('__typename is missing in "isIndex"')
@@ -7736,6 +7686,14 @@ export interface LogicFunctionLogsInput {applicationId?: (Scalars['UUID'] | null
     
 
 
+    const IndexField_possibleTypes: string[] = ['IndexField']
+    export const isIndexField = (obj?: { __typename?: any } | null): obj is IndexField => {
+      if (!obj?.__typename) throw new Error('__typename is missing in "isIndexField"')
+      return IndexField_possibleTypes.includes(obj.__typename)
+    }
+    
+
+
     const IndexEdge_possibleTypes: string[] = ['IndexEdge']
     export const isIndexEdge = (obj?: { __typename?: any } | null): obj is IndexEdge => {
       if (!obj?.__typename) throw new Error('__typename is missing in "isIndexEdge"')
@@ -7756,22 +7714,6 @@ export interface LogicFunctionLogsInput {applicationId?: (Scalars['UUID'] | null
     export const isIndexConnection = (obj?: { __typename?: any } | null): obj is IndexConnection => {
       if (!obj?.__typename) throw new Error('__typename is missing in "isIndexConnection"')
       return IndexConnection_possibleTypes.includes(obj.__typename)
-    }
-    
-
-
-    const IndexFieldEdge_possibleTypes: string[] = ['IndexFieldEdge']
-    export const isIndexFieldEdge = (obj?: { __typename?: any } | null): obj is IndexFieldEdge => {
-      if (!obj?.__typename) throw new Error('__typename is missing in "isIndexFieldEdge"')
-      return IndexFieldEdge_possibleTypes.includes(obj.__typename)
-    }
-    
-
-
-    const IndexIndexFieldMetadatasConnection_possibleTypes: string[] = ['IndexIndexFieldMetadatasConnection']
-    export const isIndexIndexFieldMetadatasConnection = (obj?: { __typename?: any } | null): obj is IndexIndexFieldMetadatasConnection => {
-      if (!obj?.__typename) throw new Error('__typename is missing in "isIndexIndexFieldMetadatasConnection"')
-      return IndexIndexFieldMetadatasConnection_possibleTypes.includes(obj.__typename)
     }
     
 

--- a/packages/twenty-client-sdk/src/metadata/generated/types.ts
+++ b/packages/twenty-client-sdk/src/metadata/generated/types.ts
@@ -18,71 +18,71 @@ export default {
         37,
         42,
         45,
-        48,
-        50,
+        47,
+        49,
+        59,
         61,
         63,
-        65,
-        68,
+        66,
+        69,
+        70,
         71,
         72,
         73,
-        74,
         75,
-        77,
-        80,
-        81,
-        86,
-        89,
-        94,
-        95,
-        98,
+        78,
+        79,
+        84,
+        87,
+        92,
+        93,
+        96,
+        97,
         99,
-        101,
-        104,
-        105,
-        111,
-        125,
+        102,
+        103,
+        109,
+        123,
+        133,
+        134,
         135,
-        136,
         137,
-        139,
-        148,
-        161,
+        146,
+        159,
+        162,
         164,
-        166,
+        168,
         170,
-        172,
-        179,
-        180,
-        187,
-        190,
-        193,
-        204,
-        220,
-        232,
-        238,
+        177,
+        178,
+        185,
+        188,
+        191,
+        202,
+        217,
+        229,
+        235,
+        271,
+        273,
         274,
+        275,
         276,
         277,
         278,
         279,
-        280,
-        281,
-        282,
-        289,
+        286,
+        325,
+        326,
+        327,
         328,
-        329,
         330,
-        331,
-        333,
-        335,
-        346,
-        353,
-        360,
-        443,
-        488,
-        497
+        332,
+        343,
+        350,
+        357,
+        440,
+        485,
+        494
     ],
     "types": {
         "BillingProductDTO": {
@@ -96,13 +96,13 @@ export default {
                 1
             ],
             "metadata": [
-                134
+                132
             ],
             "on_BillingLicensedProduct": [
-                143
+                141
             ],
             "on_BillingMeteredProduct": [
-                144
+                142
             ],
             "__typename": [
                 1
@@ -337,7 +337,7 @@ export default {
                 3
             ],
             "user": [
-                79
+                77
             ],
             "userId": [
                 3
@@ -959,42 +959,19 @@ export default {
                 3
             ],
             "relation": [
-                203
+                201
             ],
             "morphRelations": [
-                203
+                201
             ],
             "object": [
-                56
+                54
             ],
             "__typename": [
                 1
             ]
         },
         "FieldMetadataType": {},
-        "IndexField": {
-            "id": [
-                3
-            ],
-            "fieldMetadataId": [
-                3
-            ],
-            "order": [
-                11
-            ],
-            "subFieldName": [
-                1
-            ],
-            "createdAt": [
-                4
-            ],
-            "updatedAt": [
-                4
-            ],
-            "__typename": [
-                1
-            ]
-        },
         "Index": {
             "id": [
                 3
@@ -1012,7 +989,7 @@ export default {
                 1
             ],
             "indexType": [
-                48
+                47
             ],
             "createdAt": [
                 4
@@ -1021,31 +998,18 @@ export default {
                 4
             ],
             "indexFieldMetadataList": [
-                46
+                203
             ],
             "objectMetadata": [
-                211,
+                208,
                 {
                     "paging": [
-                        49,
+                        48,
                         "CursorPaging!"
                     ],
                     "filter": [
-                        51,
+                        50,
                         "ObjectFilter!"
-                    ]
-                }
-            ],
-            "indexFieldMetadatas": [
-                209,
-                {
-                    "paging": [
-                        49,
-                        "CursorPaging!"
-                    ],
-                    "filter": [
-                        54,
-                        "IndexFieldFilter!"
                     ]
                 }
             ],
@@ -1056,10 +1020,10 @@ export default {
         "IndexType": {},
         "CursorPaging": {
             "before": [
-                50
+                49
             ],
             "after": [
-                50
+                49
             ],
             "first": [
                 21
@@ -1074,34 +1038,34 @@ export default {
         "ConnectionCursor": {},
         "ObjectFilter": {
             "and": [
-                51
+                50
             ],
             "or": [
-                51
+                50
             ],
             "id": [
-                52
+                51
             ],
             "isRemote": [
-                53
+                52
             ],
             "isActive": [
-                53
+                52
             ],
             "isSystem": [
-                53
+                52
             ],
             "isUIEditable": [
-                53
+                52
             ],
             "isUICreatable": [
-                53
+                52
             ],
             "isUIReadOnly": [
-                53
+                52
             ],
             "isSearchable": [
-                53
+                52
             ],
             "__typename": [
                 1
@@ -1165,23 +1129,6 @@ export default {
                 1
             ]
         },
-        "IndexFieldFilter": {
-            "and": [
-                54
-            ],
-            "or": [
-                54
-            ],
-            "id": [
-                52
-            ],
-            "fieldMetadataId": [
-                52
-            ],
-            "__typename": [
-                1
-            ]
-        },
         "ObjectStandardOverrides": {
             "labelSingular": [
                 1
@@ -1231,7 +1178,7 @@ export default {
                 1
             ],
             "standardOverrides": [
-                55
+                53
             ],
             "shortcut": [
                 1
@@ -1285,33 +1232,33 @@ export default {
                 44
             ],
             "indexMetadataList": [
-                47
+                46
             ],
             "searchFieldMetadataList": [
-                213
+                210
             ],
             "fields": [
-                217,
+                214,
                 {
                     "paging": [
-                        49,
+                        48,
                         "CursorPaging!"
                     ],
                     "filter": [
-                        57,
+                        55,
                         "FieldFilter!"
                     ]
                 }
             ],
             "indexMetadatas": [
-                215,
+                212,
                 {
                     "paging": [
-                        49,
+                        48,
                         "CursorPaging!"
                     ],
                     "filter": [
-                        58,
+                        56,
                         "IndexFilter!"
                     ]
                 }
@@ -1322,28 +1269,28 @@ export default {
         },
         "FieldFilter": {
             "and": [
-                57
+                55
             ],
             "or": [
-                57
+                55
             ],
             "id": [
-                52
+                51
             ],
             "isActive": [
-                53
+                52
             ],
             "isSystem": [
-                53
+                52
             ],
             "isUIEditable": [
-                53
+                52
             ],
             "isUIReadOnly": [
-                53
+                52
             ],
             "objectMetadataId": [
-                52
+                51
             ],
             "__typename": [
                 1
@@ -1351,16 +1298,16 @@ export default {
         },
         "IndexFilter": {
             "and": [
-                58
+                56
             ],
             "or": [
-                58
+                56
             ],
             "id": [
-                52
+                51
             ],
             "isCustom": [
-                53
+                52
             ],
             "__typename": [
                 1
@@ -1428,7 +1375,7 @@ export default {
                 41
             ],
             "objects": [
-                56
+                54
             ],
             "applicationVariables": [
                 31
@@ -1457,7 +1404,7 @@ export default {
                 11
             ],
             "aggregateOperation": [
-                61
+                59
             ],
             "viewId": [
                 3
@@ -1496,7 +1443,7 @@ export default {
                 3
             ],
             "logicalOperator": [
-                63
+                61
             ],
             "positionInViewFilterGroup": [
                 11
@@ -1529,7 +1476,7 @@ export default {
                 3
             ],
             "operand": [
-                65
+                63
             ],
             "value": [
                 15
@@ -1606,7 +1553,7 @@ export default {
                 3
             ],
             "direction": [
-                68
+                66
             ],
             "subFieldName": [
                 1
@@ -1663,7 +1610,7 @@ export default {
                 4
             ],
             "viewFields": [
-                60
+                58
             ],
             "isOverridden": [
                 6
@@ -1683,10 +1630,10 @@ export default {
                 3
             ],
             "type": [
-                71
+                69
             ],
             "key": [
-                72
+                70
             ],
             "icon": [
                 1
@@ -1701,10 +1648,10 @@ export default {
                 6
             ],
             "openRecordIn": [
-                73
+                71
             ],
             "kanbanAggregateOperation": [
-                61
+                59
             ],
             "kanbanAggregateOperationFieldMetadataId": [
                 3
@@ -1728,7 +1675,7 @@ export default {
                 1
             ],
             "calendarLayout": [
-                74
+                72
             ],
             "createdAt": [
                 4
@@ -1740,25 +1687,25 @@ export default {
                 4
             ],
             "viewFields": [
-                60
+                58
             ],
             "viewFilters": [
-                64
-            ],
-            "viewFilterGroups": [
                 62
             ],
+            "viewFilterGroups": [
+                60
+            ],
             "viewSorts": [
-                67
+                65
             ],
             "viewGroups": [
-                66
+                64
             ],
             "viewFieldGroups": [
-                69
+                67
             ],
             "visibility": [
-                75
+                73
             ],
             "createdByUserWorkspaceId": [
                 3
@@ -1816,25 +1763,25 @@ export default {
                 11
             ],
             "activationStatus": [
-                77
+                75
             ],
             "views": [
-                70
+                68
             ],
             "viewFields": [
-                60
+                58
             ],
             "viewFilters": [
-                64
-            ],
-            "viewFilterGroups": [
                 62
             ],
+            "viewFilterGroups": [
+                60
+            ],
             "viewGroups": [
-                66
+                64
             ],
             "viewSorts": [
-                67
+                65
             ],
             "metadataVersion": [
                 11
@@ -1900,25 +1847,25 @@ export default {
                 1
             ],
             "workspaceCustomApplication": [
-                59
+                57
             ],
             "featureFlags": [
-                171
+                169
             ],
             "billingSubscriptions": [
-                147
+                145
             ],
             "installedApplications": [
-                59
+                57
             ],
             "currentBillingSubscription": [
-                147
+                145
             ],
             "billingCustomer": [
-                146
+                144
             ],
             "billingEntitlements": [
-                231
+                228
             ],
             "hasValidSignedEnterpriseKey": [
                 6
@@ -1927,7 +1874,7 @@ export default {
                 6
             ],
             "workspaceUrls": [
-                173
+                171
             ],
             "workspaceCustomApplicationId": [
                 1
@@ -2001,22 +1948,22 @@ export default {
                 17
             ],
             "onboardingStatus": [
-                80
+                78
             ],
             "currentWorkspace": [
-                76
+                74
             ],
             "currentUserWorkspace": [
                 17
             ],
             "userVars": [
-                81
+                79
             ],
             "workspaceMembers": [
                 20
             ],
             "deletedWorkspaceMembers": [
-                230
+                227
             ],
             "hasPassword": [
                 6
@@ -2028,7 +1975,7 @@ export default {
                 17
             ],
             "availableWorkspaces": [
-                229
+                226
             ],
             "__typename": [
                 1
@@ -2089,19 +2036,19 @@ export default {
                 1
             ],
             "type": [
-                86
+                84
             ],
             "objectMetadataId": [
                 3
             ],
             "gridPosition": [
-                84
+                82
             ],
             "position": [
-                87
+                85
             ],
             "configuration": [
-                92
+                90
             ],
             "conditionalDisplay": [
                 15
@@ -2131,13 +2078,13 @@ export default {
         "WidgetType": {},
         "PageLayoutWidgetPosition": {
             "on_PageLayoutWidgetGridPosition": [
-                88
+                86
             ],
             "on_PageLayoutWidgetVerticalListPosition": [
-                90
+                88
             ],
             "on_PageLayoutWidgetCanvasPosition": [
-                91
+                89
             ],
             "__typename": [
                 1
@@ -2145,7 +2092,7 @@ export default {
         },
         "PageLayoutWidgetGridPosition": {
             "layoutMode": [
-                89
+                87
             ],
             "row": [
                 21
@@ -2166,7 +2113,7 @@ export default {
         "PageLayoutTabLayoutMode": {},
         "PageLayoutWidgetVerticalListPosition": {
             "layoutMode": [
-                89
+                87
             ],
             "index": [
                 21
@@ -2177,7 +2124,7 @@ export default {
         },
         "PageLayoutWidgetCanvasPosition": {
             "layoutMode": [
-                89
+                87
             ],
             "__typename": [
                 1
@@ -2185,70 +2132,70 @@ export default {
         },
         "WidgetConfiguration": {
             "on_AggregateChartConfiguration": [
-                93
+                91
             ],
             "on_StandaloneRichTextConfiguration": [
-                96
+                94
             ],
             "on_PieChartConfiguration": [
-                97
+                95
             ],
             "on_LineChartConfiguration": [
-                100
+                98
             ],
             "on_IframeConfiguration": [
-                102
+                100
             ],
             "on_BarChartConfiguration": [
-                103
+                101
             ],
             "on_CalendarConfiguration": [
-                106
+                104
             ],
             "on_FrontComponentConfiguration": [
-                107
+                105
             ],
             "on_EmailsConfiguration": [
-                108
+                106
             ],
             "on_EmailThreadConfiguration": [
-                109
+                107
             ],
             "on_FieldConfiguration": [
-                110
+                108
             ],
             "on_FieldRichTextConfiguration": [
-                112
+                110
             ],
             "on_FieldsConfiguration": [
-                113
+                111
             ],
             "on_FilesConfiguration": [
-                114
+                112
             ],
             "on_NotesConfiguration": [
-                115
+                113
             ],
             "on_TasksConfiguration": [
-                116
+                114
             ],
             "on_TimelineConfiguration": [
-                117
+                115
             ],
             "on_ViewConfiguration": [
-                118
+                116
             ],
             "on_RecordTableConfiguration": [
-                119
+                117
             ],
             "on_WorkflowConfiguration": [
-                120
+                118
             ],
             "on_WorkflowRunConfiguration": [
-                121
+                119
             ],
             "on_WorkflowVersionConfiguration": [
-                122
+                120
             ],
             "__typename": [
                 1
@@ -2256,13 +2203,13 @@ export default {
         },
         "AggregateChartConfiguration": {
             "configurationType": [
-                94
+                92
             ],
             "aggregateFieldMetadataId": [
                 3
             ],
             "aggregateOperation": [
-                61
+                59
             ],
             "label": [
                 1
@@ -2271,7 +2218,7 @@ export default {
                 6
             ],
             "numberFormat": [
-                95
+                93
             ],
             "description": [
                 1
@@ -2292,7 +2239,7 @@ export default {
                 1
             ],
             "ratioAggregateConfig": [
-                82
+                80
             ],
             "__typename": [
                 1
@@ -2302,10 +2249,10 @@ export default {
         "ChartNumberFormat": {},
         "StandaloneRichTextConfiguration": {
             "configurationType": [
-                94
+                92
             ],
             "body": [
-                83
+                81
             ],
             "__typename": [
                 1
@@ -2313,13 +2260,13 @@ export default {
         },
         "PieChartConfiguration": {
             "configurationType": [
-                94
+                92
             ],
             "aggregateFieldMetadataId": [
                 3
             ],
             "aggregateOperation": [
-                61
+                59
             ],
             "groupByFieldMetadataId": [
                 3
@@ -2328,10 +2275,10 @@ export default {
                 1
             ],
             "dateGranularity": [
-                98
+                96
             ],
             "orderBy": [
-                99
+                97
             ],
             "manualSortOrder": [
                 1
@@ -2374,13 +2321,13 @@ export default {
         "GraphOrderBy": {},
         "LineChartConfiguration": {
             "configurationType": [
-                94
+                92
             ],
             "aggregateFieldMetadataId": [
                 3
             ],
             "aggregateOperation": [
-                61
+                59
             ],
             "primaryAxisGroupByFieldMetadataId": [
                 3
@@ -2389,10 +2336,10 @@ export default {
                 1
             ],
             "primaryAxisDateGranularity": [
-                98
+                96
             ],
             "primaryAxisOrderBy": [
-                99
+                97
             ],
             "primaryAxisManualSortOrder": [
                 1
@@ -2404,10 +2351,10 @@ export default {
                 1
             ],
             "secondaryAxisGroupByDateGranularity": [
-                98
+                96
             ],
             "secondaryAxisOrderBy": [
-                99
+                97
             ],
             "secondaryAxisManualSortOrder": [
                 1
@@ -2419,7 +2366,7 @@ export default {
                 6
             ],
             "axisNameDisplay": [
-                101
+                99
             ],
             "displayDataLabel": [
                 6
@@ -2461,7 +2408,7 @@ export default {
         "AxisNameDisplay": {},
         "IframeConfiguration": {
             "configurationType": [
-                94
+                92
             ],
             "url": [
                 1
@@ -2472,13 +2419,13 @@ export default {
         },
         "BarChartConfiguration": {
             "configurationType": [
-                94
+                92
             ],
             "aggregateFieldMetadataId": [
                 3
             ],
             "aggregateOperation": [
-                61
+                59
             ],
             "primaryAxisGroupByFieldMetadataId": [
                 3
@@ -2487,10 +2434,10 @@ export default {
                 1
             ],
             "primaryAxisDateGranularity": [
-                98
+                96
             ],
             "primaryAxisOrderBy": [
-                99
+                97
             ],
             "primaryAxisManualSortOrder": [
                 1
@@ -2502,10 +2449,10 @@ export default {
                 1
             ],
             "secondaryAxisGroupByDateGranularity": [
-                98
+                96
             ],
             "secondaryAxisOrderBy": [
-                99
+                97
             ],
             "secondaryAxisManualSortOrder": [
                 1
@@ -2517,7 +2464,7 @@ export default {
                 6
             ],
             "axisNameDisplay": [
-                101
+                99
             ],
             "displayDataLabel": [
                 6
@@ -2541,10 +2488,10 @@ export default {
                 15
             ],
             "groupMode": [
-                104
+                102
             ],
             "layout": [
-                105
+                103
             ],
             "isCumulative": [
                 6
@@ -2563,7 +2510,7 @@ export default {
         "BarChartLayout": {},
         "CalendarConfiguration": {
             "configurationType": [
-                94
+                92
             ],
             "__typename": [
                 1
@@ -2571,7 +2518,7 @@ export default {
         },
         "FrontComponentConfiguration": {
             "configurationType": [
-                94
+                92
             ],
             "frontComponentId": [
                 3
@@ -2582,7 +2529,7 @@ export default {
         },
         "EmailsConfiguration": {
             "configurationType": [
-                94
+                92
             ],
             "__typename": [
                 1
@@ -2590,7 +2537,7 @@ export default {
         },
         "EmailThreadConfiguration": {
             "configurationType": [
-                94
+                92
             ],
             "__typename": [
                 1
@@ -2598,13 +2545,13 @@ export default {
         },
         "FieldConfiguration": {
             "configurationType": [
-                94
+                92
             ],
             "fieldMetadataId": [
                 1
             ],
             "fieldDisplayMode": [
-                111
+                109
             ],
             "viewId": [
                 1
@@ -2616,7 +2563,7 @@ export default {
         "FieldDisplayMode": {},
         "FieldRichTextConfiguration": {
             "configurationType": [
-                94
+                92
             ],
             "__typename": [
                 1
@@ -2624,7 +2571,7 @@ export default {
         },
         "FieldsConfiguration": {
             "configurationType": [
-                94
+                92
             ],
             "viewId": [
                 1
@@ -2641,7 +2588,7 @@ export default {
         },
         "FilesConfiguration": {
             "configurationType": [
-                94
+                92
             ],
             "__typename": [
                 1
@@ -2649,7 +2596,7 @@ export default {
         },
         "NotesConfiguration": {
             "configurationType": [
-                94
+                92
             ],
             "__typename": [
                 1
@@ -2657,7 +2604,7 @@ export default {
         },
         "TasksConfiguration": {
             "configurationType": [
-                94
+                92
             ],
             "__typename": [
                 1
@@ -2665,7 +2612,7 @@ export default {
         },
         "TimelineConfiguration": {
             "configurationType": [
-                94
+                92
             ],
             "__typename": [
                 1
@@ -2673,7 +2620,7 @@ export default {
         },
         "ViewConfiguration": {
             "configurationType": [
-                94
+                92
             ],
             "__typename": [
                 1
@@ -2681,7 +2628,7 @@ export default {
         },
         "RecordTableConfiguration": {
             "configurationType": [
-                94
+                92
             ],
             "viewId": [
                 1
@@ -2695,7 +2642,7 @@ export default {
         },
         "WorkflowConfiguration": {
             "configurationType": [
-                94
+                92
             ],
             "__typename": [
                 1
@@ -2703,7 +2650,7 @@ export default {
         },
         "WorkflowRunConfiguration": {
             "configurationType": [
-                94
+                92
             ],
             "__typename": [
                 1
@@ -2711,7 +2658,7 @@ export default {
         },
         "WorkflowVersionConfiguration": {
             "configurationType": [
-                94
+                92
             ],
             "__typename": [
                 1
@@ -2734,13 +2681,13 @@ export default {
                 3
             ],
             "widgets": [
-                85
+                83
             ],
             "icon": [
                 1
             ],
             "layoutMode": [
-                89
+                87
             ],
             "createdAt": [
                 4
@@ -2769,13 +2716,13 @@ export default {
                 1
             ],
             "type": [
-                125
+                123
             ],
             "objectMetadataId": [
                 3
             ],
             "tabs": [
-                123
+                121
             ],
             "defaultTabToFocusOnMobileAndSidePanelId": [
                 3
@@ -2825,7 +2772,7 @@ export default {
                 1
             ],
             "oauth": [
-                126
+                124
             ],
             "__typename": [
                 1
@@ -2927,7 +2874,7 @@ export default {
                 11
             ],
             "items": [
-                132
+                130
             ],
             "__typename": [
                 1
@@ -2935,13 +2882,13 @@ export default {
         },
         "BillingProductMetadata": {
             "planKey": [
-                135
+                133
             ],
             "priceUsageBased": [
-                136
+                134
             ],
             "productKey": [
-                137
+                135
             ],
             "__typename": [
                 1
@@ -2952,7 +2899,7 @@ export default {
         "BillingProductKey": {},
         "BillingPriceLicensed": {
             "recurringInterval": [
-                139
+                137
             ],
             "unitAmount": [
                 11
@@ -2961,7 +2908,7 @@ export default {
                 1
             ],
             "priceUsageType": [
-                136
+                134
             ],
             "creditAmount": [
                 11
@@ -2987,16 +2934,16 @@ export default {
         },
         "BillingPriceMetered": {
             "tiers": [
-                140
+                138
             ],
             "recurringInterval": [
-                139
+                137
             ],
             "stripePriceId": [
                 1
             ],
             "priceUsageType": [
-                136
+                134
             ],
             "__typename": [
                 1
@@ -3013,7 +2960,7 @@ export default {
                 1
             ],
             "metadata": [
-                134
+                132
             ],
             "__typename": [
                 1
@@ -3030,10 +2977,10 @@ export default {
                 1
             ],
             "metadata": [
-                134
+                132
             ],
             "prices": [
-                138
+                136
             ],
             "__typename": [
                 1
@@ -3050,10 +2997,10 @@ export default {
                 1
             ],
             "metadata": [
-                134
+                132
             ],
             "prices": [
-                141
+                139
             ],
             "__typename": [
                 1
@@ -3095,13 +3042,13 @@ export default {
                 3
             ],
             "status": [
-                148
+                146
             ],
             "interval": [
-                139
+                137
             ],
             "billingSubscriptionItems": [
-                145
+                143
             ],
             "currentPeriodEnd": [
                 4
@@ -3110,7 +3057,7 @@ export default {
                 15
             ],
             "phases": [
-                133
+                131
             ],
             "cancelAt": [
                 4
@@ -3122,7 +3069,7 @@ export default {
         "SubscriptionStatus": {},
         "BillingEndTrialPeriod": {
             "status": [
-                148
+                146
             ],
             "hasPaymentMethod": [
                 6
@@ -3136,7 +3083,7 @@ export default {
         },
         "BillingResourceCreditUsage": {
             "productKey": [
-                137
+                135
             ],
             "periodStart": [
                 4
@@ -3165,16 +3112,16 @@ export default {
         },
         "BillingPlan": {
             "planKey": [
-                135
+                133
             ],
             "baseProducts": [
-                143
+                141
             ],
             "resourceCreditProducts": [
-                143
+                141
             ],
             "meteredProducts": [
-                144
+                142
             ],
             "__typename": [
                 1
@@ -3201,10 +3148,10 @@ export default {
         },
         "BillingUpdate": {
             "currentBillingSubscription": [
-                147
+                145
             ],
             "billingSubscriptions": [
-                147
+                145
             ],
             "__typename": [
                 1
@@ -3254,7 +3201,7 @@ export default {
                 1
             ],
             "result": [
-                157
+                155
             ],
             "__typename": [
                 1
@@ -3291,7 +3238,7 @@ export default {
                 3
             ],
             "type": [
-                161
+                159
             ],
             "name": [
                 1
@@ -3324,7 +3271,7 @@ export default {
                 4
             ],
             "targetRecordIdentifier": [
-                159
+                157
             ],
             "__typename": [
                 1
@@ -3350,7 +3297,7 @@ export default {
         },
         "MetadataEvent": {
             "type": [
-                164
+                162
             ],
             "metadataName": [
                 1
@@ -3359,7 +3306,7 @@ export default {
                 1
             ],
             "properties": [
-                162
+                160
             ],
             "updatedCollectionHash": [
                 1
@@ -3371,7 +3318,7 @@ export default {
         "MetadataEventAction": {},
         "ObjectRecordEvent": {
             "action": [
-                166
+                164
             ],
             "objectNameSingular": [
                 1
@@ -3386,7 +3333,7 @@ export default {
                 1
             ],
             "properties": [
-                162
+                160
             ],
             "__typename": [
                 1
@@ -3398,7 +3345,7 @@ export default {
                 1
             ],
             "objectRecordEvent": [
-                165
+                163
             ],
             "__typename": [
                 1
@@ -3409,10 +3356,10 @@ export default {
                 1
             ],
             "objectRecordEventsWithQueryIds": [
-                167
+                165
             ],
             "metadataEvents": [
-                163
+                161
             ],
             "__typename": [
                 1
@@ -3429,7 +3376,7 @@ export default {
                 11
             ],
             "status": [
-                170
+                168
             ],
             "error": [
                 15
@@ -3441,7 +3388,7 @@ export default {
         "LogicFunctionExecutionStatus": {},
         "FeatureFlag": {
             "key": [
-                172
+                170
             ],
             "value": [
                 6
@@ -3513,7 +3460,7 @@ export default {
                 1
             ],
             "versionDistribution": [
-                175
+                173
             ],
             "__typename": [
                 1
@@ -3538,10 +3485,10 @@ export default {
                 1
             ],
             "type": [
-                179
+                177
             ],
             "status": [
-                180
+                178
             ],
             "issuer": [
                 1
@@ -3554,7 +3501,7 @@ export default {
         "SSOIdentityProviderStatus": {},
         "AuthProviders": {
             "sso": [
-                178
+                176
             ],
             "google": [
                 6
@@ -3591,10 +3538,10 @@ export default {
                 3
             ],
             "authProviders": [
-                181
+                179
             ],
             "authBypassProviders": [
-                182
+                180
             ],
             "logo": [
                 1
@@ -3603,7 +3550,7 @@ export default {
                 1
             ],
             "workspaceUrls": [
-                173
+                171
             ],
             "__typename": [
                 1
@@ -3642,7 +3589,7 @@ export default {
                 1
             ],
             "modelFamily": [
-                187
+                185
             ],
             "modelFamilyLabel": [
                 1
@@ -3657,7 +3604,7 @@ export default {
                 11
             ],
             "nativeCapabilities": [
-                185
+                183
             ],
             "isDeprecated": [
                 6
@@ -3696,7 +3643,7 @@ export default {
                 1
             ],
             "trialPeriods": [
-                177
+                175
             ],
             "__typename": [
                 1
@@ -3704,7 +3651,7 @@ export default {
         },
         "Support": {
             "supportDriver": [
-                190
+                188
             ],
             "supportFrontChatId": [
                 1
@@ -3730,7 +3677,7 @@ export default {
         },
         "Captcha": {
             "provider": [
-                193
+                191
             ],
             "siteKey": [
                 1
@@ -3764,10 +3711,10 @@ export default {
         },
         "PublicFeatureFlag": {
             "key": [
-                172
+                170
             ],
             "metadata": [
-                195
+                193
             ],
             "__typename": [
                 1
@@ -3792,13 +3739,13 @@ export default {
                 1
             ],
             "authProviders": [
-                181
+                179
             ],
             "billing": [
-                188
+                186
             ],
             "aiModels": [
-                186
+                184
             ],
             "signInPrefilled": [
                 6
@@ -3822,25 +3769,25 @@ export default {
                 6
             ],
             "support": [
-                189
+                187
             ],
             "isAttachmentPreviewEnabled": [
                 6
             ],
             "sentry": [
-                191
+                189
             ],
             "captcha": [
-                192
+                190
             ],
             "api": [
-                194
+                192
             ],
             "canManageFeatureFlags": [
                 6
             ],
             "publicFeatureFlags": [
-                196
+                194
             ],
             "isMicrosoftMessagingEnabled": [
                 6
@@ -3879,7 +3826,7 @@ export default {
                 6
             ],
             "maintenance": [
-                197
+                195
             ],
             "__typename": [
                 1
@@ -3940,13 +3887,13 @@ export default {
         },
         "Relation": {
             "type": [
-                204
+                202
             ],
             "sourceObjectMetadata": [
-                56
+                54
             ],
             "targetObjectMetadata": [
-                56
+                54
             ],
             "sourceFieldMetadata": [
                 44
@@ -3959,12 +3906,35 @@ export default {
             ]
         },
         "RelationType": {},
+        "IndexField": {
+            "id": [
+                3
+            ],
+            "fieldMetadataId": [
+                3
+            ],
+            "order": [
+                11
+            ],
+            "subFieldName": [
+                1
+            ],
+            "createdAt": [
+                4
+            ],
+            "updatedAt": [
+                4
+            ],
+            "__typename": [
+                1
+            ]
+        },
         "IndexEdge": {
             "node": [
-                47
+                46
             ],
             "cursor": [
-                50
+                49
             ],
             "__typename": [
                 1
@@ -3978,10 +3948,10 @@ export default {
                 6
             ],
             "startCursor": [
-                50
+                49
             ],
             "endCursor": [
-                50
+                49
             ],
             "__typename": [
                 1
@@ -3989,32 +3959,10 @@ export default {
         },
         "IndexConnection": {
             "pageInfo": [
-                206
-            ],
-            "edges": [
                 205
             ],
-            "__typename": [
-                1
-            ]
-        },
-        "IndexFieldEdge": {
-            "node": [
-                46
-            ],
-            "cursor": [
-                50
-            ],
-            "__typename": [
-                1
-            ]
-        },
-        "IndexIndexFieldMetadatasConnection": {
-            "pageInfo": [
-                206
-            ],
             "edges": [
-                208
+                204
             ],
             "__typename": [
                 1
@@ -4022,10 +3970,10 @@ export default {
         },
         "ObjectEdge": {
             "node": [
-                56
+                54
             ],
             "cursor": [
-                50
+                49
             ],
             "__typename": [
                 1
@@ -4033,10 +3981,10 @@ export default {
         },
         "IndexObjectMetadataConnection": {
             "pageInfo": [
-                206
+                205
             ],
             "edges": [
-                210
+                207
             ],
             "__typename": [
                 1
@@ -4078,10 +4026,10 @@ export default {
         },
         "ObjectConnection": {
             "pageInfo": [
-                206
+                205
             ],
             "edges": [
-                210
+                207
             ],
             "__typename": [
                 1
@@ -4089,10 +4037,10 @@ export default {
         },
         "ObjectIndexMetadatasConnection": {
             "pageInfo": [
-                206
+                205
             ],
             "edges": [
-                205
+                204
             ],
             "__typename": [
                 1
@@ -4103,7 +4051,7 @@ export default {
                 44
             ],
             "cursor": [
-                50
+                49
             ],
             "__typename": [
                 1
@@ -4111,10 +4059,10 @@ export default {
         },
         "ObjectFieldsConnection": {
             "pageInfo": [
-                206
+                205
             ],
             "edges": [
-                216
+                213
             ],
             "__typename": [
                 1
@@ -4122,10 +4070,10 @@ export default {
         },
         "FieldConnection": {
             "pageInfo": [
-                206
+                205
             ],
             "edges": [
-                216
+                213
             ],
             "__typename": [
                 1
@@ -4133,7 +4081,7 @@ export default {
         },
         "AppConnection": {
             "id": [
-                220
+                217
             ],
             "providerName": [
                 1
@@ -4185,7 +4133,7 @@ export default {
                 3
             ],
             "type": [
-                179
+                177
             ],
             "issuer": [
                 1
@@ -4194,7 +4142,7 @@ export default {
                 1
             ],
             "status": [
-                180
+                178
             ],
             "__typename": [
                 1
@@ -4213,7 +4161,7 @@ export default {
         },
         "FindAvailableSSOIDP": {
             "type": [
-                179
+                177
             ],
             "id": [
                 3
@@ -4225,10 +4173,10 @@ export default {
                 1
             ],
             "status": [
-                180
+                178
             ],
             "workspace": [
-                224
+                221
             ],
             "__typename": [
                 1
@@ -4239,7 +4187,7 @@ export default {
                 3
             ],
             "type": [
-                179
+                177
             ],
             "issuer": [
                 1
@@ -4248,7 +4196,7 @@ export default {
                 1
             ],
             "status": [
-                180
+                178
             ],
             "__typename": [
                 1
@@ -4256,7 +4204,7 @@ export default {
         },
         "SSOConnection": {
             "type": [
-                179
+                177
             ],
             "id": [
                 3
@@ -4268,7 +4216,7 @@ export default {
                 1
             ],
             "status": [
-                180
+                178
             ],
             "__typename": [
                 1
@@ -4291,13 +4239,13 @@ export default {
                 1
             ],
             "workspaceUrls": [
-                173
+                171
             ],
             "logo": [
                 1
             ],
             "sso": [
-                227
+                224
             ],
             "__typename": [
                 1
@@ -4305,10 +4253,10 @@ export default {
         },
         "AvailableWorkspaces": {
             "availableWorkspacesForSignIn": [
-                228
+                225
             ],
             "availableWorkspacesForSignUp": [
-                228
+                225
             ],
             "__typename": [
                 1
@@ -4336,7 +4284,7 @@ export default {
         },
         "BillingEntitlement": {
             "key": [
-                232
+                229
             ],
             "value": [
                 6
@@ -4374,7 +4322,7 @@ export default {
                 1
             ],
             "records": [
-                233
+                230
             ],
             "isCustomDomainEnabled": [
                 6
@@ -4413,7 +4361,7 @@ export default {
                 1
             ],
             "connectionSecurity": [
-                238
+                235
             ],
             "__typename": [
                 1
@@ -4422,13 +4370,13 @@ export default {
         "EmailConnectionSecurity": {},
         "PublicImapSmtpCaldavConnectionParameters": {
             "IMAP": [
-                237
+                234
             ],
             "SMTP": [
-                237
+                234
             ],
             "CALDAV": [
-                237
+                234
             ],
             "__typename": [
                 1
@@ -4484,7 +4432,7 @@ export default {
                 4
             ],
             "connectionParameters": [
-                239
+                236
             ],
             "__typename": [
                 1
@@ -4535,10 +4483,10 @@ export default {
         },
         "AvailableWorkspacesAndAccessTokens": {
             "tokens": [
-                245
+                242
             ],
             "availableWorkspaces": [
-                229
+                226
             ],
             "__typename": [
                 1
@@ -4576,7 +4524,7 @@ export default {
         },
         "WorkspaceUrlsAndId": {
             "workspaceUrls": [
-                173
+                171
             ],
             "id": [
                 3
@@ -4590,7 +4538,7 @@ export default {
                 32
             ],
             "workspace": [
-                250
+                247
             ],
             "__typename": [
                 1
@@ -4623,7 +4571,7 @@ export default {
                 32
             ],
             "workspaceUrls": [
-                173
+                171
             ],
             "__typename": [
                 1
@@ -4667,7 +4615,7 @@ export default {
         },
         "AuthTokens": {
             "tokens": [
-                245
+                242
             ],
             "__typename": [
                 1
@@ -4708,7 +4656,7 @@ export default {
                 32
             ],
             "workspace": [
-                250
+                247
             ],
             "__typename": [
                 1
@@ -4730,7 +4678,7 @@ export default {
                 1
             ],
             "dailyUsage": [
-                263
+                260
             ],
             "__typename": [
                 1
@@ -4738,16 +4686,16 @@ export default {
         },
         "UsageAnalytics": {
             "usageByUser": [
-                199
+                197
             ],
             "usageByOperationType": [
-                199
+                197
             ],
             "usageByModel": [
-                199
+                197
             ],
             "timeSeries": [
-                263
+                260
             ],
             "periodStart": [
                 4
@@ -4756,7 +4704,7 @@ export default {
                 4
             ],
             "userDailyUsage": [
-                264
+                261
             ],
             "__typename": [
                 1
@@ -4913,10 +4861,10 @@ export default {
                 1
             ],
             "status": [
-                274
+                271
             ],
             "verificationRecords": [
-                272
+                269
             ],
             "verifiedAt": [
                 4
@@ -4931,22 +4879,22 @@ export default {
                 3
             ],
             "visibility": [
-                276
+                273
             ],
             "handle": [
                 1
             ],
             "type": [
-                277
+                274
             ],
             "isContactAutoCreationEnabled": [
                 6
             ],
             "contactAutoCreationPolicy": [
-                278
+                275
             ],
             "messageFolderImportPolicy": [
-                279
+                276
             ],
             "excludeNonProfessionalEmails": [
                 6
@@ -4955,7 +4903,7 @@ export default {
                 6
             ],
             "pendingGroupEmailsAction": [
-                280
+                277
             ],
             "isSyncEnabled": [
                 6
@@ -4964,10 +4912,10 @@ export default {
                 4
             ],
             "syncStatus": [
-                281
+                278
             ],
             "syncStage": [
-                282
+                279
             ],
             "syncStageStartedAt": [
                 4
@@ -4988,7 +4936,7 @@ export default {
                 4
             ],
             "connectedAccount": [
-                240
+                237
             ],
             "__typename": [
                 1
@@ -5003,7 +4951,7 @@ export default {
         "MessageChannelSyncStage": {},
         "CreateEmailGroupChannelOutput": {
             "messageChannel": [
-                275
+                272
             ],
             "forwardingAddress": [
                 1
@@ -5065,7 +5013,7 @@ export default {
                 21
             ],
             "skipped": [
-                286
+                283
             ],
             "__typename": [
                 1
@@ -5088,7 +5036,7 @@ export default {
                 1
             ],
             "visibility": [
-                289
+                286
             ],
             "__typename": [
                 1
@@ -5134,7 +5082,7 @@ export default {
                 1
             ],
             "location": [
-                291
+                288
             ],
             "__typename": [
                 1
@@ -5151,7 +5099,7 @@ export default {
                 1
             ],
             "connectionSecurity": [
-                238
+                235
             ],
             "__typename": [
                 1
@@ -5159,13 +5107,13 @@ export default {
         },
         "ImapSmtpCaldavPublicConnectionParameters": {
             "IMAP": [
-                293
+                290
             ],
             "SMTP": [
-                293
+                290
             ],
             "CALDAV": [
-                293
+                290
             ],
             "__typename": [
                 1
@@ -5185,7 +5133,7 @@ export default {
                 3
             ],
             "connectionParameters": [
-                294
+                291
             ],
             "__typename": [
                 1
@@ -5407,7 +5355,7 @@ export default {
                 1
             ],
             "series": [
-                303
+                300
             ],
             "xAxisLabel": [
                 1
@@ -5422,10 +5370,10 @@ export default {
                 6
             ],
             "layout": [
-                105
+                103
             ],
             "groupMode": [
-                104
+                102
             ],
             "hasTooManyGroups": [
                 6
@@ -5456,7 +5404,7 @@ export default {
                 1
             ],
             "data": [
-                305
+                302
             ],
             "__typename": [
                 1
@@ -5464,7 +5412,7 @@ export default {
         },
         "LineChartData": {
             "series": [
-                306
+                303
             ],
             "xAxisLabel": [
                 1
@@ -5501,7 +5449,7 @@ export default {
         },
         "PieChartData": {
             "data": [
-                308
+                305
             ],
             "showLegend": [
                 6
@@ -5606,13 +5554,13 @@ export default {
         },
         "EventLogQueryResult": {
             "records": [
-                313
+                310
             ],
             "totalCount": [
                 21
             ],
             "pageInfo": [
-                314
+                311
             ],
             "__typename": [
                 1
@@ -5676,7 +5624,7 @@ export default {
                 1
             ],
             "parts": [
-                299
+                296
             ],
             "processedAt": [
                 4
@@ -5690,7 +5638,7 @@ export default {
         },
         "AgentChatThread": {
             "id": [
-                220
+                217
             ],
             "title": [
                 1
@@ -5745,7 +5693,7 @@ export default {
         },
         "AiSystemPromptPreview": {
             "sections": [
-                319
+                316
             ],
             "estimatedTokenCount": [
                 21
@@ -5821,10 +5769,10 @@ export default {
                 3
             ],
             "evaluations": [
-                324
+                321
             ],
             "messages": [
-                317
+                314
             ],
             "createdAt": [
                 4
@@ -5855,19 +5803,19 @@ export default {
                 1
             ],
             "syncStatus": [
-                328
+                325
             ],
             "syncStage": [
-                329
+                326
             ],
             "visibility": [
-                330
+                327
             ],
             "isContactAutoCreationEnabled": [
                 6
             ],
             "contactAutoCreationPolicy": [
-                331
+                328
             ],
             "isSyncEnabled": [
                 6
@@ -5918,7 +5866,7 @@ export default {
                 1
             ],
             "pendingSyncAction": [
-                333
+                330
             ],
             "messageChannelId": [
                 3
@@ -5936,7 +5884,7 @@ export default {
         "MessageFolderPendingSyncAction": {},
         "CollectionHash": {
             "collectionName": [
-                335
+                332
             ],
             "hash": [
                 1
@@ -5986,10 +5934,10 @@ export default {
                 3
             ],
             "type": [
-                71
+                69
             ],
             "key": [
-                72
+                70
             ],
             "objectMetadataId": [
                 3
@@ -6000,13 +5948,13 @@ export default {
         },
         "MinimalMetadata": {
             "objectMetadataItems": [
-                336
+                333
             ],
             "views": [
-                337
+                334
             ],
             "collectionHashes": [
-                334
+                331
             ],
             "__typename": [
                 1
@@ -6014,10 +5962,10 @@ export default {
         },
         "Query": {
             "navigationMenuItems": [
-                160
+                158
             ],
             "navigationMenuItem": [
-                160,
+                158,
                 {
                     "id": [
                         3,
@@ -6042,10 +5990,10 @@ export default {
                 }
             ],
             "enterpriseSubscriptionStatus": [
-                129
+                127
             ],
             "getViewFilterGroups": [
-                62,
+                60,
                 {
                     "viewId": [
                         1
@@ -6053,7 +6001,7 @@ export default {
                 }
             ],
             "getViewFilterGroup": [
-                62,
+                60,
                 {
                     "id": [
                         1,
@@ -6062,7 +6010,7 @@ export default {
                 }
             ],
             "getViewFilters": [
-                64,
+                62,
                 {
                     "viewId": [
                         1
@@ -6070,7 +6018,7 @@ export default {
                 }
             ],
             "getViewFilter": [
-                64,
+                62,
                 {
                     "id": [
                         1,
@@ -6079,19 +6027,19 @@ export default {
                 }
             ],
             "getViews": [
-                70,
+                68,
                 {
                     "objectMetadataId": [
                         1
                     ],
                     "viewTypes": [
-                        71,
+                        69,
                         "[ViewType!]"
                     ]
                 }
             ],
             "getView": [
-                70,
+                68,
                 {
                     "id": [
                         1,
@@ -6100,7 +6048,7 @@ export default {
                 }
             ],
             "getViewSorts": [
-                67,
+                65,
                 {
                     "viewId": [
                         1
@@ -6108,7 +6056,7 @@ export default {
                 }
             ],
             "getViewSort": [
-                67,
+                65,
                 {
                     "id": [
                         1,
@@ -6117,7 +6065,7 @@ export default {
                 }
             ],
             "getViewFields": [
-                60,
+                58,
                 {
                     "viewId": [
                         1,
@@ -6126,7 +6074,7 @@ export default {
                 }
             ],
             "getViewField": [
-                60,
+                58,
                 {
                     "id": [
                         1,
@@ -6135,7 +6083,7 @@ export default {
                 }
             ],
             "getViewFieldGroups": [
-                69,
+                67,
                 {
                     "viewId": [
                         1,
@@ -6144,7 +6092,7 @@ export default {
                 }
             ],
             "getViewFieldGroup": [
-                69,
+                67,
                 {
                     "id": [
                         1,
@@ -6159,16 +6107,16 @@ export default {
                 2,
                 {
                     "input": [
-                        340,
+                        337,
                         "GetApiKeyInput!"
                     ]
                 }
             ],
             "getInviteSuggestions": [
-                155
+                153
             ],
             "applicationConnectionProviders": [
-                127,
+                125,
                 {
                     "applicationId": [
                         3,
@@ -6177,7 +6125,7 @@ export default {
                 }
             ],
             "billingPortalSession": [
-                153,
+                151,
                 {
                     "returnUrlPath": [
                         1
@@ -6188,19 +6136,19 @@ export default {
                 }
             ],
             "listPlans": [
-                151
+                149
             ],
             "getResourceCreditUsage": [
-                150
+                148
             ],
             "findWorkspaceInvitations": [
-                157
+                155
             ],
             "getApprovedAccessDomains": [
-                130
+                128
             ],
             "getPageLayoutTabs": [
-                123,
+                121,
                 {
                     "pageLayoutId": [
                         1,
@@ -6209,7 +6157,7 @@ export default {
                 }
             ],
             "getPageLayoutTab": [
-                123,
+                121,
                 {
                     "id": [
                         1,
@@ -6218,18 +6166,18 @@ export default {
                 }
             ],
             "getPageLayouts": [
-                124,
+                122,
                 {
                     "objectMetadataId": [
                         1
                     ],
                     "pageLayoutType": [
-                        125
+                        123
                     ]
                 }
             ],
             "getPageLayout": [
-                124,
+                122,
                 {
                     "id": [
                         1,
@@ -6238,7 +6186,7 @@ export default {
                 }
             ],
             "getPageLayoutWidgets": [
-                85,
+                83,
                 {
                     "pageLayoutTabId": [
                         1,
@@ -6247,7 +6195,7 @@ export default {
                 }
             ],
             "getPageLayoutWidget": [
-                85,
+                83,
                 {
                     "id": [
                         1,
@@ -6262,16 +6210,16 @@ export default {
                 25,
                 {
                     "input": [
-                        341,
+                        338,
                         "AgentIdInput!"
                     ]
                 }
             ],
             "objectRecordCounts": [
-                212
+                209
             ],
             "object": [
-                56,
+                54,
                 {
                     "id": [
                         3,
@@ -6280,20 +6228,20 @@ export default {
                 }
             ],
             "objects": [
-                214,
+                211,
                 {
                     "paging": [
-                        49,
+                        48,
                         "CursorPaging!"
                     ],
                     "filter": [
-                        51,
+                        50,
                         "ObjectFilter!"
                     ]
                 }
             ],
             "index": [
-                47,
+                46,
                 {
                     "id": [
                         3,
@@ -6302,14 +6250,14 @@ export default {
                 }
             ],
             "indexMetadatas": [
-                207,
+                206,
                 {
                     "paging": [
-                        49,
+                        48,
                         "CursorPaging!"
                     ],
                     "filter": [
-                        58,
+                        56,
                         "IndexFilter!"
                     ]
                 }
@@ -6318,7 +6266,7 @@ export default {
                 41,
                 {
                     "input": [
-                        342,
+                        339,
                         "LogicFunctionIdInput!"
                     ]
                 }
@@ -6330,7 +6278,7 @@ export default {
                 15,
                 {
                     "input": [
-                        342,
+                        339,
                         "LogicFunctionIdInput!"
                     ]
                 }
@@ -6339,7 +6287,7 @@ export default {
                 1,
                 {
                     "input": [
-                        342,
+                        339,
                         "LogicFunctionIdInput!"
                     ]
                 }
@@ -6369,10 +6317,10 @@ export default {
                 }
             ],
             "currentWorkspace": [
-                76
+                74
             ],
             "getPublicWorkspaceDataByDomain": [
-                183,
+                181,
                 {
                     "origin": [
                         1
@@ -6380,7 +6328,7 @@ export default {
                 }
             ],
             "getPublicWorkspaceDataById": [
-                184,
+                182,
                 {
                     "id": [
                         3,
@@ -6398,20 +6346,20 @@ export default {
                 }
             ],
             "fields": [
-                218,
+                215,
                 {
                     "paging": [
-                        49,
+                        48,
                         "CursorPaging!"
                     ],
                     "filter": [
-                        57,
+                        55,
                         "FieldFilter!"
                     ]
                 }
             ],
             "getViewGroups": [
-                66,
+                64,
                 {
                     "viewId": [
                         1
@@ -6419,7 +6367,7 @@ export default {
                 }
             ],
             "getViewGroup": [
-                66,
+                64,
                 {
                     "id": [
                         1,
@@ -6428,10 +6376,10 @@ export default {
                 }
             ],
             "findManyApplications": [
-                59
+                57
             ],
             "findOneApplication": [
-                59,
+                57,
                 {
                     "id": [
                         3
@@ -6445,7 +6393,7 @@ export default {
                 29
             ],
             "findApplicationRegistrationByClientId": [
-                201,
+                199,
                 {
                     "clientId": [
                         1,
@@ -6475,7 +6423,7 @@ export default {
                 }
             ],
             "findApplicationRegistrationStats": [
-                176,
+                174,
                 {
                     "id": [
                         1,
@@ -6484,7 +6432,7 @@ export default {
                 }
             ],
             "findApplicationRegistrationVariables": [
-                174,
+                172,
                 {
                     "applicationRegistrationId": [
                         1,
@@ -6502,22 +6450,22 @@ export default {
                 }
             ],
             "previewMessageCampaignAudience": [
-                284,
+                281,
                 {
                     "input": [
-                        343,
+                        340,
                         "PreviewMessageCampaignAudienceInput!"
                     ]
                 }
             ],
             "unsubscribeTopics": [
-                288
+                285
             ],
             "unsubscribePagePreviewUrl": [
                 1
             ],
             "myMessageChannels": [
-                275,
+                272,
                 {
                     "connectedAccountId": [
                         3
@@ -6525,13 +6473,13 @@ export default {
                 }
             ],
             "getEmailingDomains": [
-                273
+                270
             ],
             "myConnectedAccounts": [
-                240
+                237
             ],
             "getToolIndex": [
-                298
+                295
             ],
             "getToolInputSchema": [
                 15,
@@ -6543,10 +6491,10 @@ export default {
                 }
             ],
             "webhooks": [
-                297
+                294
             ],
             "webhook": [
-                297,
+                294,
                 {
                     "id": [
                         3,
@@ -6555,7 +6503,7 @@ export default {
                 }
             ],
             "myMessageFolders": [
-                332,
+                329,
                 {
                     "messageChannelId": [
                         3
@@ -6563,7 +6511,7 @@ export default {
                 }
             ],
             "myCalendarChannels": [
-                327,
+                324,
                 {
                     "connectedAccountId": [
                         3
@@ -6571,33 +6519,33 @@ export default {
                 }
             ],
             "minimalMetadata": [
-                338
+                335
             ],
             "appConnections": [
-                219,
+                216,
                 {
                     "filter": [
-                        344
+                        341
                     ]
                 }
             ],
             "appConnection": [
-                219,
+                216,
                 {
                     "id": [
-                        220,
+                        217,
                         "ID!"
                     ]
                 }
             ],
             "findWorkspaceAiStats": [
-                326
+                323
             ],
             "chatThreads": [
-                318
+                315
             ],
             "chatThread": [
-                318,
+                315,
                 {
                     "id": [
                         3,
@@ -6606,7 +6554,7 @@ export default {
                 }
             ],
             "chatMessages": [
-                317,
+                314,
                 {
                     "threadId": [
                         3,
@@ -6615,7 +6563,7 @@ export default {
                 }
             ],
             "chatStreamCatchupChunks": [
-                321,
+                318,
                 {
                     "threadId": [
                         3,
@@ -6624,13 +6572,13 @@ export default {
                 }
             ],
             "getAiSystemPromptPreview": [
-                320
+                317
             ],
             "skills": [
-                316
+                313
             ],
             "skill": [
-                316,
+                313,
                 {
                     "id": [
                         3,
@@ -6639,7 +6587,7 @@ export default {
                 }
             ],
             "agentTurns": [
-                325,
+                322,
                 {
                     "agentId": [
                         3,
@@ -6648,7 +6596,7 @@ export default {
                 }
             ],
             "checkUserExists": [
-                260,
+                257,
                 {
                     "email": [
                         1,
@@ -6660,7 +6608,7 @@ export default {
                 }
             ],
             "checkWorkspaceInviteHashIsValid": [
-                261,
+                258,
                 {
                     "inviteHash": [
                         1,
@@ -6669,7 +6617,7 @@ export default {
                 }
             ],
             "findWorkspaceFromInviteHash": [
-                76,
+                74,
                 {
                     "inviteHash": [
                         1,
@@ -6678,7 +6626,7 @@ export default {
                 }
             ],
             "checkWorkspaceSubdomainAvailability": [
-                255,
+                252,
                 {
                     "subdomain": [
                         1,
@@ -6687,10 +6635,10 @@ export default {
                 }
             ],
             "getWorkspaceCreationDefaults": [
-                256
+                253
             ],
             "validatePasswordResetToken": [
-                253,
+                250,
                 {
                     "passwordResetToken": [
                         1,
@@ -6699,49 +6647,49 @@ export default {
                 }
             ],
             "currentUser": [
-                79
+                77
             ],
             "getSSOIdentityProviders": [
-                225
+                222
             ],
             "eventLogs": [
-                315,
+                312,
                 {
                     "input": [
-                        345,
+                        342,
                         "EventLogQueryInput!"
                     ]
                 }
             ],
             "pieChartData": [
-                309,
+                306,
                 {
                     "input": [
-                        349,
+                        346,
                         "PieChartDataInput!"
                     ]
                 }
             ],
             "lineChartData": [
-                307,
+                304,
                 {
                     "input": [
-                        350,
+                        347,
                         "LineChartDataInput!"
                     ]
                 }
             ],
             "barChartData": [
-                304,
+                301,
                 {
                     "input": [
-                        351,
+                        348,
                         "BarChartDataInput!"
                     ]
                 }
             ],
             "getConnectedImapSmtpCaldavAccount": [
-                295,
+                292,
                 {
                     "id": [
                         3,
@@ -6750,7 +6698,7 @@ export default {
                 }
             ],
             "getAutoCompleteAddress": [
-                290,
+                287,
                 {
                     "address": [
                         1,
@@ -6769,7 +6717,7 @@ export default {
                 }
             ],
             "getAddressDetails": [
-                292,
+                289,
                 {
                     "placeId": [
                         1,
@@ -6782,21 +6730,21 @@ export default {
                 }
             ],
             "getUsageAnalytics": [
-                265,
+                262,
                 {
                     "input": [
-                        352
+                        349
                     ]
                 }
             ],
             "findManyPublicDomains": [
-                271
+                268
             ],
             "findManyMarketplaceApps": [
-                269
+                266
             ],
             "findMarketplaceAppDetail": [
-                270,
+                267,
                 {
                     "universalIdentifier": [
                         1,
@@ -6826,7 +6774,7 @@ export default {
         },
         "LogicFunctionIdInput": {
             "id": [
-                220
+                217
             ],
             "__typename": [
                 1
@@ -6859,10 +6807,10 @@ export default {
         },
         "EventLogQueryInput": {
             "table": [
-                346
+                343
             ],
             "filters": [
-                347
+                344
             ],
             "first": [
                 21
@@ -6883,7 +6831,7 @@ export default {
                 1
             ],
             "dateRange": [
-                348
+                345
             ],
             "recordId": [
                 1
@@ -6950,7 +6898,7 @@ export default {
                 1
             ],
             "operationTypes": [
-                353
+                350
             ],
             "__typename": [
                 1
@@ -6962,7 +6910,7 @@ export default {
                 6,
                 {
                     "input": [
-                        355,
+                        352,
                         "AddQuerySubscriptionInput!"
                     ]
                 }
@@ -6971,49 +6919,49 @@ export default {
                 6,
                 {
                     "input": [
-                        356,
+                        353,
                         "RemoveQueryFromEventStreamInput!"
                     ]
                 }
             ],
             "createManyNavigationMenuItems": [
-                160,
+                158,
                 {
                     "inputs": [
-                        357,
+                        354,
                         "[CreateNavigationMenuItemInput!]!"
                     ]
                 }
             ],
             "createNavigationMenuItem": [
-                160,
+                158,
                 {
                     "input": [
-                        357,
+                        354,
                         "CreateNavigationMenuItemInput!"
                     ]
                 }
             ],
             "updateManyNavigationMenuItems": [
-                160,
+                158,
                 {
                     "inputs": [
-                        358,
+                        355,
                         "[UpdateOneNavigationMenuItemInput!]!"
                     ]
                 }
             ],
             "updateNavigationMenuItem": [
-                160,
+                158,
                 {
                     "input": [
-                        358,
+                        355,
                         "UpdateOneNavigationMenuItemInput!"
                     ]
                 }
             ],
             "deleteManyNavigationMenuItems": [
-                160,
+                158,
                 {
                     "ids": [
                         3,
@@ -7022,7 +6970,7 @@ export default {
                 }
             ],
             "deleteNavigationMenuItem": [
-                160,
+                158,
                 {
                     "id": [
                         3,
@@ -7031,10 +6979,10 @@ export default {
                 }
             ],
             "uploadEmailAttachmentFile": [
-                131,
+                129,
                 {
                     "file": [
-                        360,
+                        357,
                         "Upload!"
                     ]
                 }
@@ -7043,7 +6991,7 @@ export default {
                 6
             ],
             "setEnterpriseKey": [
-                128,
+                126,
                 {
                     "enterpriseKey": [
                         1,
@@ -7052,46 +7000,46 @@ export default {
                 }
             ],
             "uploadAiChatFile": [
-                131,
+                129,
                 {
                     "file": [
-                        360,
+                        357,
                         "Upload!"
                     ]
                 }
             ],
             "uploadWorkflowFile": [
-                131,
+                129,
                 {
                     "file": [
-                        360,
+                        357,
                         "Upload!"
                     ]
                 }
             ],
             "uploadWorkspaceLogo": [
-                131,
+                129,
                 {
                     "file": [
-                        360,
+                        357,
                         "Upload!"
                     ]
                 }
             ],
             "uploadWorkspaceMemberProfilePicture": [
-                131,
+                129,
                 {
                     "file": [
-                        360,
+                        357,
                         "Upload!"
                     ]
                 }
             ],
             "uploadFilesFieldFile": [
-                131,
+                129,
                 {
                     "file": [
-                        360,
+                        357,
                         "Upload!"
                     ],
                     "fieldMetadataId": [
@@ -7101,10 +7049,10 @@ export default {
                 }
             ],
             "uploadFilesFieldFileByUniversalIdentifier": [
-                131,
+                129,
                 {
                     "file": [
-                        360,
+                        357,
                         "Upload!"
                     ],
                     "fieldMetadataUniversalIdentifier": [
@@ -7114,23 +7062,23 @@ export default {
                 }
             ],
             "createViewFilterGroup": [
-                62,
+                60,
                 {
                     "input": [
-                        361,
+                        358,
                         "CreateViewFilterGroupInput!"
                     ]
                 }
             ],
             "updateViewFilterGroup": [
-                62,
+                60,
                 {
                     "id": [
                         1,
                         "String!"
                     ],
                     "input": [
-                        362,
+                        359,
                         "UpdateViewFilterGroupInput!"
                     ]
                 }
@@ -7154,59 +7102,59 @@ export default {
                 }
             ],
             "createViewFilter": [
-                64,
+                62,
                 {
                     "input": [
-                        363,
+                        360,
                         "CreateViewFilterInput!"
                     ]
                 }
             ],
             "updateViewFilter": [
-                64,
+                62,
                 {
                     "input": [
-                        364,
+                        361,
                         "UpdateViewFilterInput!"
                     ]
                 }
             ],
             "deleteViewFilter": [
-                64,
+                62,
                 {
                     "input": [
-                        366,
+                        363,
                         "DeleteViewFilterInput!"
                     ]
                 }
             ],
             "destroyViewFilter": [
-                64,
+                62,
                 {
                     "input": [
-                        367,
+                        364,
                         "DestroyViewFilterInput!"
                     ]
                 }
             ],
             "createView": [
-                70,
+                68,
                 {
                     "input": [
-                        368,
+                        365,
                         "CreateViewInput!"
                     ]
                 }
             ],
             "updateView": [
-                70,
+                68,
                 {
                     "id": [
                         1,
                         "String!"
                     ],
                     "input": [
-                        369,
+                        366,
                         "UpdateViewInput!"
                     ]
                 }
@@ -7230,28 +7178,28 @@ export default {
                 }
             ],
             "upsertViewWidget": [
-                70,
+                68,
                 {
                     "input": [
-                        370,
+                        367,
                         "UpsertViewWidgetInput!"
                     ]
                 }
             ],
             "createViewSort": [
-                67,
+                65,
                 {
                     "input": [
-                        375,
+                        372,
                         "CreateViewSortInput!"
                     ]
                 }
             ],
             "updateViewSort": [
-                67,
+                65,
                 {
                     "input": [
-                        376,
+                        373,
                         "UpdateViewSortInput!"
                     ]
                 }
@@ -7260,7 +7208,7 @@ export default {
                 6,
                 {
                     "input": [
-                        378,
+                        375,
                         "DeleteViewSortInput!"
                     ]
                 }
@@ -7269,106 +7217,106 @@ export default {
                 6,
                 {
                     "input": [
-                        379,
+                        376,
                         "DestroyViewSortInput!"
                     ]
                 }
             ],
             "updateViewField": [
-                60,
+                58,
                 {
                     "input": [
-                        380,
+                        377,
                         "UpdateViewFieldInput!"
                     ]
                 }
             ],
             "createViewField": [
-                60,
+                58,
                 {
                     "input": [
-                        382,
+                        379,
                         "CreateViewFieldInput!"
                     ]
                 }
             ],
             "createManyViewFields": [
-                60,
+                58,
                 {
                     "inputs": [
-                        382,
+                        379,
                         "[CreateViewFieldInput!]!"
                     ]
                 }
             ],
             "deleteViewField": [
-                60,
+                58,
                 {
                     "input": [
-                        383,
+                        380,
                         "DeleteViewFieldInput!"
                     ]
                 }
             ],
             "destroyViewField": [
-                60,
+                58,
                 {
                     "input": [
-                        384,
+                        381,
                         "DestroyViewFieldInput!"
                     ]
                 }
             ],
             "updateViewFieldGroup": [
-                69,
+                67,
                 {
                     "input": [
-                        385,
+                        382,
                         "UpdateViewFieldGroupInput!"
                     ]
                 }
             ],
             "createViewFieldGroup": [
-                69,
+                67,
                 {
                     "input": [
-                        387,
+                        384,
                         "CreateViewFieldGroupInput!"
                     ]
                 }
             ],
             "createManyViewFieldGroups": [
-                69,
+                67,
                 {
                     "inputs": [
-                        387,
+                        384,
                         "[CreateViewFieldGroupInput!]!"
                     ]
                 }
             ],
             "deleteViewFieldGroup": [
-                69,
+                67,
                 {
                     "input": [
-                        388,
+                        385,
                         "DeleteViewFieldGroupInput!"
                     ]
                 }
             ],
             "destroyViewFieldGroup": [
-                69,
+                67,
                 {
                     "input": [
-                        389,
+                        386,
                         "DestroyViewFieldGroupInput!"
                     ]
                 }
             ],
             "upsertFieldsWidget": [
-                70,
+                68,
                 {
                     "input": [
-                        390,
+                        387,
                         "UpsertFieldsWidgetInput!"
                     ]
                 }
@@ -7377,7 +7325,7 @@ export default {
                 2,
                 {
                     "input": [
-                        393,
+                        390,
                         "CreateApiKeyInput!"
                     ]
                 }
@@ -7386,7 +7334,7 @@ export default {
                 2,
                 {
                     "input": [
-                        394,
+                        391,
                         "UpdateApiKeyInput!"
                     ]
                 }
@@ -7395,7 +7343,7 @@ export default {
                 2,
                 {
                     "input": [
-                        395,
+                        392,
                         "RevokeApiKeyInput!"
                     ]
                 }
@@ -7414,13 +7362,13 @@ export default {
                 }
             ],
             "skipSyncEmailOnboardingStep": [
-                156
+                154
             ],
             "skipBookOnboardingStep": [
-                156
+                154
             ],
             "triggerInstallAppsOnboardingStep": [
-                156,
+                154,
                 {
                     "universalIdentifiers": [
                         1,
@@ -7446,14 +7394,14 @@ export default {
                 }
             ],
             "checkoutSession": [
-                153,
+                151,
                 {
                     "recurringInterval": [
-                        139,
+                        137,
                         "SubscriptionInterval!"
                     ],
                     "plan": [
-                        135,
+                        133,
                         "BillingPlanKey!"
                     ],
                     "requirePaymentMethod": [
@@ -7466,14 +7414,14 @@ export default {
                 }
             ],
             "createSubscriptionPaymentIntent": [
-                152,
+                150,
                 {
                     "recurringInterval": [
-                        139,
+                        137,
                         "SubscriptionInterval!"
                     ],
                     "plan": [
-                        135,
+                        133,
                         "BillingPlanKey!"
                     ],
                     "requirePaymentMethod": [
@@ -7490,22 +7438,22 @@ export default {
                 }
             ],
             "createBillingPaymentMethodSetupIntent": [
-                152
+                150
             ],
             "switchSubscriptionInterval": [
-                154
+                152
             ],
             "switchBillingPlan": [
-                154
+                152
             ],
             "cancelSwitchBillingPlan": [
-                154
+                152
             ],
             "cancelSwitchBillingInterval": [
-                154
+                152
             ],
             "setResourceCreditSubscriptionPrice": [
-                154,
+                152,
                 {
                     "priceId": [
                         1,
@@ -7514,10 +7462,10 @@ export default {
                 }
             ],
             "endSubscriptionTrialPeriod": [
-                149
+                147
             ],
             "cancelSwitchResourceCreditPrice": [
-                154
+                152
             ],
             "deleteWorkspaceInvitation": [
                 1,
@@ -7529,7 +7477,7 @@ export default {
                 }
             ],
             "resendWorkspaceInvitation": [
-                158,
+                156,
                 {
                     "appTokenId": [
                         1,
@@ -7538,7 +7486,7 @@ export default {
                 }
             ],
             "sendInvitations": [
-                158,
+                156,
                 {
                     "emails": [
                         1,
@@ -7550,10 +7498,10 @@ export default {
                 }
             ],
             "createApprovedAccessDomain": [
-                130,
+                128,
                 {
                     "input": [
-                        396,
+                        393,
                         "CreateApprovedAccessDomainInput!"
                     ]
                 }
@@ -7562,38 +7510,38 @@ export default {
                 6,
                 {
                     "input": [
-                        397,
+                        394,
                         "DeleteApprovedAccessDomainInput!"
                     ]
                 }
             ],
             "validateApprovedAccessDomain": [
-                130,
+                128,
                 {
                     "input": [
-                        398,
+                        395,
                         "ValidateApprovedAccessDomainInput!"
                     ]
                 }
             ],
             "createPageLayoutTab": [
-                123,
+                121,
                 {
                     "input": [
-                        399,
+                        396,
                         "CreatePageLayoutTabInput!"
                     ]
                 }
             ],
             "updatePageLayoutTab": [
-                123,
+                121,
                 {
                     "id": [
                         1,
                         "String!"
                     ],
                     "input": [
-                        400,
+                        397,
                         "UpdatePageLayoutTabInput!"
                     ]
                 }
@@ -7608,23 +7556,23 @@ export default {
                 }
             ],
             "createPageLayout": [
-                124,
+                122,
                 {
                     "input": [
-                        401,
+                        398,
                         "CreatePageLayoutInput!"
                     ]
                 }
             ],
             "updatePageLayout": [
-                124,
+                122,
                 {
                     "id": [
                         1,
                         "String!"
                     ],
                     "input": [
-                        402,
+                        399,
                         "UpdatePageLayoutInput!"
                     ]
                 }
@@ -7639,20 +7587,20 @@ export default {
                 }
             ],
             "updatePageLayoutWithTabsAndWidgets": [
-                124,
+                122,
                 {
                     "id": [
                         1,
                         "String!"
                     ],
                     "input": [
-                        403,
+                        400,
                         "UpdatePageLayoutWithTabsInput!"
                     ]
                 }
             ],
             "resetPageLayoutToDefault": [
-                124,
+                122,
                 {
                     "id": [
                         1,
@@ -7661,7 +7609,7 @@ export default {
                 }
             ],
             "resetPageLayoutWidgetToDefault": [
-                85,
+                83,
                 {
                     "id": [
                         1,
@@ -7670,7 +7618,7 @@ export default {
                 }
             ],
             "resetPageLayoutTabToDefault": [
-                123,
+                121,
                 {
                     "id": [
                         1,
@@ -7679,23 +7627,23 @@ export default {
                 }
             ],
             "createPageLayoutWidget": [
-                85,
+                83,
                 {
                     "input": [
-                        407,
+                        404,
                         "CreatePageLayoutWidgetInput!"
                     ]
                 }
             ],
             "updatePageLayoutWidget": [
-                85,
+                83,
                 {
                     "id": [
                         1,
                         "String!"
                     ],
                     "input": [
-                        408,
+                        405,
                         "UpdatePageLayoutWidgetInput!"
                     ]
                 }
@@ -7713,7 +7661,7 @@ export default {
                 25,
                 {
                     "input": [
-                        409,
+                        406,
                         "CreateAgentInput!"
                     ]
                 }
@@ -7722,7 +7670,7 @@ export default {
                 25,
                 {
                     "input": [
-                        410,
+                        407,
                         "UpdateAgentInput!"
                     ]
                 }
@@ -7731,52 +7679,52 @@ export default {
                 25,
                 {
                     "input": [
-                        341,
+                        338,
                         "AgentIdInput!"
                     ]
                 }
             ],
             "createOneObject": [
-                56,
+                54,
                 {
                     "input": [
-                        411,
+                        408,
                         "CreateOneObjectInput!"
                     ]
                 }
             ],
             "deleteOneObject": [
-                56,
+                54,
                 {
                     "input": [
-                        413,
+                        410,
                         "DeleteOneObjectInput!"
                     ]
                 }
             ],
             "updateOneObject": [
-                56,
+                54,
                 {
                     "input": [
-                        414,
+                        411,
                         "UpdateOneObjectInput!"
                     ]
                 }
             ],
             "createOneIndex": [
-                47,
+                46,
                 {
                     "input": [
-                        416,
+                        413,
                         "CreateOneIndexInput!"
                     ]
                 }
             ],
             "deleteOneIndex": [
-                47,
+                46,
                 {
                     "input": [
-                        419,
+                        416,
                         "DeleteOneIndexInput!"
                     ]
                 }
@@ -7785,7 +7733,7 @@ export default {
                 41,
                 {
                     "input": [
-                        342,
+                        339,
                         "LogicFunctionIdInput!"
                     ]
                 }
@@ -7794,16 +7742,16 @@ export default {
                 41,
                 {
                     "input": [
-                        420,
+                        417,
                         "CreateLogicFunctionFromSourceInput!"
                     ]
                 }
             ],
             "executeOneLogicFunction": [
-                169,
+                167,
                 {
                     "input": [
-                        421,
+                        418,
                         "ExecuteOneLogicFunctionInput!"
                     ]
                 }
@@ -7812,7 +7760,7 @@ export default {
                 6,
                 {
                     "input": [
-                        422,
+                        419,
                         "UpdateLogicFunctionFromSourceInput!"
                     ]
                 }
@@ -7821,7 +7769,7 @@ export default {
                 35,
                 {
                     "input": [
-                        424,
+                        421,
                         "CreateCommandMenuItemInput!"
                     ]
                 }
@@ -7830,7 +7778,7 @@ export default {
                 35,
                 {
                     "input": [
-                        425,
+                        422,
                         "UpdateCommandMenuItemInput!"
                     ]
                 }
@@ -7857,7 +7805,7 @@ export default {
                 34,
                 {
                     "input": [
-                        426,
+                        423,
                         "CreateFrontComponentInput!"
                     ]
                 }
@@ -7866,7 +7814,7 @@ export default {
                 34,
                 {
                     "input": [
-                        427,
+                        424,
                         "UpdateFrontComponentInput!"
                     ]
                 }
@@ -7881,34 +7829,34 @@ export default {
                 }
             ],
             "activateWorkspace": [
-                76,
+                74,
                 {
                     "data": [
-                        429,
+                        426,
                         "ActivateWorkspaceInput!"
                     ]
                 }
             ],
             "updateWorkspace": [
-                76,
+                74,
                 {
                     "data": [
-                        430,
+                        427,
                         "UpdateWorkspaceInput!"
                     ]
                 }
             ],
             "deleteCurrentWorkspace": [
-                76
+                74
             ],
             "checkCustomDomainValidRecords": [
-                234
+                231
             ],
             "createOneField": [
                 44,
                 {
                     "input": [
-                        431,
+                        428,
                         "CreateOneFieldMetadataInput!"
                     ]
                 }
@@ -7917,7 +7865,7 @@ export default {
                 44,
                 {
                     "input": [
-                        433,
+                        430,
                         "UpdateOneFieldMetadataInput!"
                     ]
                 }
@@ -7926,61 +7874,61 @@ export default {
                 44,
                 {
                     "input": [
-                        435,
+                        432,
                         "DeleteOneFieldInput!"
                     ]
                 }
             ],
             "createViewGroup": [
-                66,
+                64,
                 {
                     "input": [
-                        436,
+                        433,
                         "CreateViewGroupInput!"
                     ]
                 }
             ],
             "createManyViewGroups": [
-                66,
+                64,
                 {
                     "inputs": [
-                        436,
+                        433,
                         "[CreateViewGroupInput!]!"
                     ]
                 }
             ],
             "updateViewGroup": [
-                66,
+                64,
                 {
                     "input": [
-                        437,
+                        434,
                         "UpdateViewGroupInput!"
                     ]
                 }
             ],
             "updateManyViewGroups": [
-                66,
+                64,
                 {
                     "inputs": [
-                        437,
+                        434,
                         "[UpdateViewGroupInput!]!"
                     ]
                 }
             ],
             "deleteViewGroup": [
-                66,
+                64,
                 {
                     "input": [
-                        439,
+                        436,
                         "DeleteViewGroupInput!"
                     ]
                 }
             ],
             "destroyViewGroup": [
-                66,
+                64,
                 {
                     "input": [
-                        440,
+                        437,
                         "DestroyViewGroupInput!"
                     ]
                 }
@@ -7989,7 +7937,7 @@ export default {
                 6,
                 {
                     "workspaceMigration": [
-                        441,
+                        438,
                         "WorkspaceMigrationInput!"
                     ]
                 }
@@ -8020,7 +7968,7 @@ export default {
                 29,
                 {
                     "createRoleInput": [
-                        444,
+                        441,
                         "CreateRoleInput!"
                     ]
                 }
@@ -8029,7 +7977,7 @@ export default {
                 29,
                 {
                     "updateRoleInput": [
-                        445,
+                        442,
                         "UpdateRoleInput!"
                     ]
                 }
@@ -8047,7 +7995,7 @@ export default {
                 16,
                 {
                     "upsertObjectPermissionsInput": [
-                        447,
+                        444,
                         "UpsertObjectPermissionsInput!"
                     ]
                 }
@@ -8056,7 +8004,7 @@ export default {
                 27,
                 {
                     "upsertPermissionFlagsInput": [
-                        449,
+                        446,
                         "UpsertPermissionFlagsInput!"
                     ]
                 }
@@ -8065,16 +8013,16 @@ export default {
                 26,
                 {
                     "upsertFieldPermissionsInput": [
-                        450,
+                        447,
                         "UpsertFieldPermissionsInput!"
                     ]
                 }
             ],
             "upsertRowLevelPermissionPredicates": [
-                235,
+                232,
                 {
                     "input": [
-                        452,
+                        449,
                         "UpsertRowLevelPermissionPredicatesInput!"
                     ]
                 }
@@ -8102,10 +8050,10 @@ export default {
                 }
             ],
             "createApplicationRegistration": [
-                200,
+                198,
                 {
                     "input": [
-                        455,
+                        452,
                         "CreateApplicationRegistrationInput!"
                     ]
                 }
@@ -8114,7 +8062,7 @@ export default {
                 7,
                 {
                     "input": [
-                        456,
+                        453,
                         "UpdateApplicationRegistrationInput!"
                     ]
                 }
@@ -8129,7 +8077,7 @@ export default {
                 }
             ],
             "rotateApplicationRegistrationClientSecret": [
-                202,
+                200,
                 {
                     "id": [
                         1,
@@ -8141,7 +8089,7 @@ export default {
                 5,
                 {
                     "input": [
-                        458,
+                        455,
                         "CreateApplicationRegistrationVariableInput!"
                     ]
                 }
@@ -8150,7 +8098,7 @@ export default {
                 5,
                 {
                     "input": [
-                        459,
+                        456,
                         "UpdateApplicationRegistrationVariableInput!"
                     ]
                 }
@@ -8168,7 +8116,7 @@ export default {
                 7,
                 {
                     "file": [
-                        360,
+                        357,
                         "Upload!"
                     ],
                     "universalIdentifier": [
@@ -8190,37 +8138,37 @@ export default {
                 }
             ],
             "sendEmailViaEmailingDomain": [
-                285,
+                282,
                 {
                     "input": [
-                        461,
+                        458,
                         "SendEmailViaDomainInput!"
                     ]
                 }
             ],
             "sendMessageCampaign": [
-                287,
+                284,
                 {
                     "input": [
-                        462,
+                        459,
                         "SendMessageCampaignInput!"
                     ]
                 }
             ],
             "createUnsubscribeTopic": [
-                288,
+                285,
                 {
                     "input": [
-                        463,
+                        460,
                         "CreateUnsubscribeTopicInput!"
                     ]
                 }
             ],
             "updateUnsubscribeTopic": [
-                288,
+                285,
                 {
                     "input": [
-                        464,
+                        461,
                         "UpdateUnsubscribeTopicInput!"
                     ]
                 }
@@ -8235,25 +8183,25 @@ export default {
                 }
             ],
             "updateMessageChannel": [
-                275,
+                272,
                 {
                     "input": [
-                        465,
+                        462,
                         "UpdateMessageChannelInput!"
                     ]
                 }
             ],
             "createEmailGroupChannel": [
-                283,
+                280,
                 {
                     "input": [
-                        467,
+                        464,
                         "CreateEmailGroupChannelInput!"
                     ]
                 }
             ],
             "deleteEmailGroupChannel": [
-                275,
+                272,
                 {
                     "id": [
                         3,
@@ -8262,10 +8210,10 @@ export default {
                 }
             ],
             "createEmailingDomain": [
-                273,
+                270,
                 {
                     "input": [
-                        468,
+                        465,
                         "CreateEmailingDomainInput!"
                     ]
                 }
@@ -8280,7 +8228,7 @@ export default {
                 }
             ],
             "verifyEmailingDomain": [
-                273,
+                270,
                 {
                     "id": [
                         1,
@@ -8289,7 +8237,7 @@ export default {
                 }
             ],
             "deleteConnectedAccount": [
-                240,
+                237,
                 {
                     "id": [
                         3,
@@ -8298,34 +8246,34 @@ export default {
                 }
             ],
             "runAgent": [
-                300,
+                297,
                 {
                     "input": [
-                        469,
+                        466,
                         "RunAgentInput!"
                     ]
                 }
             ],
             "createWebhook": [
-                297,
+                294,
                 {
                     "input": [
-                        470,
+                        467,
                         "CreateWebhookInput!"
                     ]
                 }
             ],
             "updateWebhook": [
-                297,
+                294,
                 {
                     "input": [
-                        471,
+                        468,
                         "UpdateWebhookInput!"
                     ]
                 }
             ],
             "deleteWebhook": [
-                297,
+                294,
                 {
                     "id": [
                         3,
@@ -8334,37 +8282,37 @@ export default {
                 }
             ],
             "updateMessageFolder": [
-                332,
+                329,
                 {
                     "input": [
-                        473,
+                        470,
                         "UpdateMessageFolderInput!"
                     ]
                 }
             ],
             "updateMessageFolders": [
-                332,
+                329,
                 {
                     "input": [
-                        475,
+                        472,
                         "UpdateMessageFoldersInput!"
                     ]
                 }
             ],
             "updateCalendarChannel": [
-                327,
+                324,
                 {
                     "input": [
-                        476,
+                        473,
                         "UpdateCalendarChannelInput!"
                     ]
                 }
             ],
             "createChatThread": [
-                318
+                315
             ],
             "sendChatMessage": [
-                322,
+                319,
                 {
                     "threadId": [
                         3,
@@ -8385,7 +8333,7 @@ export default {
                         1
                     ],
                     "fileAttachments": [
-                        478,
+                        475,
                         "[FileAttachmentInput!]"
                     ]
                 }
@@ -8400,7 +8348,7 @@ export default {
                 }
             ],
             "renameChatThread": [
-                318,
+                315,
                 {
                     "id": [
                         3,
@@ -8413,7 +8361,7 @@ export default {
                 }
             ],
             "archiveChatThread": [
-                318,
+                315,
                 {
                     "id": [
                         3,
@@ -8422,7 +8370,7 @@ export default {
                 }
             ],
             "unarchiveChatThread": [
-                318,
+                315,
                 {
                     "id": [
                         3,
@@ -8449,25 +8397,25 @@ export default {
                 }
             ],
             "createSkill": [
-                316,
+                313,
                 {
                     "input": [
-                        479,
+                        476,
                         "CreateSkillInput!"
                     ]
                 }
             ],
             "updateSkill": [
-                316,
+                313,
                 {
                     "input": [
-                        480,
+                        477,
                         "UpdateSkillInput!"
                     ]
                 }
             ],
             "deleteSkill": [
-                316,
+                313,
                 {
                     "id": [
                         3,
@@ -8476,7 +8424,7 @@ export default {
                 }
             ],
             "activateSkill": [
-                316,
+                313,
                 {
                     "id": [
                         3,
@@ -8485,7 +8433,7 @@ export default {
                 }
             ],
             "deactivateSkill": [
-                316,
+                313,
                 {
                     "id": [
                         3,
@@ -8494,7 +8442,7 @@ export default {
                 }
             ],
             "evaluateAgentTurn": [
-                324,
+                321,
                 {
                     "turnId": [
                         3,
@@ -8503,7 +8451,7 @@ export default {
                 }
             ],
             "runEvaluationInput": [
-                325,
+                322,
                 {
                     "agentId": [
                         3,
@@ -8516,16 +8464,16 @@ export default {
                 }
             ],
             "getAuthorizationUrlForSSO": [
-                248,
+                245,
                 {
                     "input": [
-                        481,
+                        478,
                         "GetAuthorizationUrlForSSOInput!"
                     ]
                 }
             ],
             "getLoginTokenFromCredentials": [
-                259,
+                256,
                 {
                     "email": [
                         1,
@@ -8551,7 +8499,7 @@ export default {
                 }
             ],
             "signIn": [
-                246,
+                243,
                 {
                     "email": [
                         1,
@@ -8573,7 +8521,7 @@ export default {
                 }
             ],
             "verifyEmailAndGetLoginToken": [
-                254,
+                251,
                 {
                     "emailVerificationToken": [
                         1,
@@ -8593,7 +8541,7 @@ export default {
                 }
             ],
             "verifyEmailAndGetWorkspaceAgnosticToken": [
-                246,
+                243,
                 {
                     "emailVerificationToken": [
                         1,
@@ -8609,7 +8557,7 @@ export default {
                 }
             ],
             "getAuthTokensFromOTP": [
-                258,
+                255,
                 {
                     "otp": [
                         1,
@@ -8629,7 +8577,7 @@ export default {
                 }
             ],
             "signUp": [
-                246,
+                243,
                 {
                     "email": [
                         1,
@@ -8651,7 +8599,7 @@ export default {
                 }
             ],
             "signUpInWorkspace": [
-                251,
+                248,
                 {
                     "email": [
                         1,
@@ -8682,31 +8630,31 @@ export default {
                 }
             ],
             "signUpInNewWorkspace": [
-                251,
+                248,
                 {
                     "input": [
-                        482
+                        479
                     ]
                 }
             ],
             "uploadNewWorkspaceLogo": [
-                131,
+                129,
                 {
                     "workspaceId": [
                         1,
                         "String!"
                     ],
                     "file": [
-                        360,
+                        357,
                         "Upload!"
                     ]
                 }
             ],
             "generateTransientToken": [
-                252
+                249
             ],
             "getAuthTokensFromLoginToken": [
-                258,
+                255,
                 {
                     "loginToken": [
                         1,
@@ -8719,7 +8667,7 @@ export default {
                 }
             ],
             "authorizeApp": [
-                244,
+                241,
                 {
                     "clientId": [
                         1,
@@ -8741,7 +8689,7 @@ export default {
                 }
             ],
             "renewToken": [
-                258,
+                255,
                 {
                     "appToken": [
                         1,
@@ -8750,7 +8698,7 @@ export default {
                 }
             ],
             "generateApiKeyToken": [
-                257,
+                254,
                 {
                     "apiKeyId": [
                         3,
@@ -8766,7 +8714,7 @@ export default {
                 32
             ],
             "emailPasswordResetLink": [
-                247,
+                244,
                 {
                     "email": [
                         1,
@@ -8778,7 +8726,7 @@ export default {
                 }
             ],
             "updatePasswordViaResetToken": [
-                249,
+                246,
                 {
                     "passwordResetToken": [
                         1,
@@ -8791,7 +8739,7 @@ export default {
                 }
             ],
             "initiateOTPProvisioning": [
-                242,
+                239,
                 {
                     "loginToken": [
                         1,
@@ -8804,10 +8752,10 @@ export default {
                 }
             ],
             "initiateOTPProvisioningForAuthenticatedUser": [
-                242
+                239
             ],
             "deleteTwoFactorAuthenticationMethod": [
-                241,
+                238,
                 {
                     "twoFactorAuthenticationMethodId": [
                         3,
@@ -8816,7 +8764,7 @@ export default {
                 }
             ],
             "verifyTwoFactorAuthenticationMethodForAuthenticatedUser": [
-                243,
+                240,
                 {
                     "otp": [
                         1,
@@ -8825,7 +8773,7 @@ export default {
                 }
             ],
             "deleteUser": [
-                79
+                77
             ],
             "deleteUserFromWorkspace": [
                 17,
@@ -8840,7 +8788,7 @@ export default {
                 6,
                 {
                     "input": [
-                        483,
+                        480,
                         "UpdateWorkspaceMemberSettingsInput!"
                     ]
                 }
@@ -8858,7 +8806,7 @@ export default {
                 }
             ],
             "resendEmailVerificationToken": [
-                221,
+                218,
                 {
                     "email": [
                         1,
@@ -8871,43 +8819,43 @@ export default {
                 }
             ],
             "createOIDCIdentityProvider": [
-                226,
+                223,
                 {
                     "input": [
-                        484,
+                        481,
                         "SetupOIDCSsoInput!"
                     ]
                 }
             ],
             "createSAMLIdentityProvider": [
-                226,
+                223,
                 {
                     "input": [
-                        485,
+                        482,
                         "SetupSAMLSsoInput!"
                     ]
                 }
             ],
             "deleteSSOIdentityProvider": [
-                222,
+                219,
                 {
                     "input": [
-                        486,
+                        483,
                         "DeleteSsoInput!"
                     ]
                 }
             ],
             "editSSOIdentityProvider": [
-                223,
+                220,
                 {
                     "input": [
-                        487,
+                        484,
                         "EditSsoInput!"
                     ]
                 }
             ],
             "createObjectEvent": [
-                312,
+                309,
                 {
                     "event": [
                         1,
@@ -8927,10 +8875,10 @@ export default {
                 }
             ],
             "trackAnalytics": [
-                312,
+                309,
                 {
                     "type": [
-                        488,
+                        485,
                         "AnalyticsType!"
                     ],
                     "name": [
@@ -8945,7 +8893,7 @@ export default {
                 }
             ],
             "duplicateDashboard": [
-                310,
+                307,
                 {
                     "id": [
                         3,
@@ -8954,7 +8902,7 @@ export default {
                 }
             ],
             "impersonate": [
-                262,
+                259,
                 {
                     "userId": [
                         3,
@@ -8967,25 +8915,25 @@ export default {
                 }
             ],
             "createCalendarEvent": [
-                302,
+                299,
                 {
                     "input": [
-                        489,
+                        486,
                         "CreateCalendarEventInput!"
                     ]
                 }
             ],
             "sendEmail": [
-                311,
+                308,
                 {
                     "input": [
-                        490,
+                        487,
                         "SendEmailInput!"
                     ]
                 }
             ],
             "startChannelSync": [
-                301,
+                298,
                 {
                     "connectedAccountId": [
                         3,
@@ -8994,14 +8942,14 @@ export default {
                 }
             ],
             "saveImapSmtpCaldavAccount": [
-                296,
+                293,
                 {
                     "handle": [
                         1,
                         "String!"
                     ],
                     "connectionParameters": [
-                        492,
+                        489,
                         "EmailAccountConnectionParameters!"
                     ],
                     "id": [
@@ -9010,16 +8958,16 @@ export default {
                 }
             ],
             "updateLabPublicFeatureFlag": [
-                171,
+                169,
                 {
                     "input": [
-                        494,
+                        491,
                         "UpdateLabPublicFeatureFlagInput!"
                     ]
                 }
             ],
             "createPublicDomain": [
-                271,
+                268,
                 {
                     "domain": [
                         1,
@@ -9041,7 +8989,7 @@ export default {
                 }
             ],
             "checkPublicDomainValidRecords": [
-                234,
+                231,
                 {
                     "domain": [
                         1,
@@ -9050,10 +8998,10 @@ export default {
                 }
             ],
             "createOneAppToken": [
-                78,
+                76,
                 {
                     "input": [
-                        495,
+                        492,
                         "CreateOneAppTokenInput!"
                     ]
                 }
@@ -9071,7 +9019,7 @@ export default {
                 }
             ],
             "installApplication": [
-                59,
+                57,
                 {
                     "universalIdentifier": [
                         1,
@@ -9086,7 +9034,7 @@ export default {
                 6
             ],
             "createDevelopmentApplication": [
-                266,
+                263,
                 {
                     "universalIdentifier": [
                         1,
@@ -9108,7 +9056,7 @@ export default {
                 }
             ],
             "syncApplication": [
-                267,
+                264,
                 {
                     "manifest": [
                         15,
@@ -9120,10 +9068,10 @@ export default {
                 }
             ],
             "uploadApplicationFile": [
-                268,
+                265,
                 {
                     "file": [
-                        360,
+                        357,
                         "Upload!"
                     ],
                     "applicationUniversalIdentifier": [
@@ -9131,7 +9079,7 @@ export default {
                         "String!"
                     ],
                     "fileFolder": [
-                        497,
+                        494,
                         "FileFolder!"
                     ],
                     "filePath": [
@@ -9208,7 +9156,7 @@ export default {
                 3
             ],
             "type": [
-                161
+                159
             ],
             "name": [
                 1
@@ -9240,7 +9188,7 @@ export default {
                 3
             ],
             "update": [
-                359
+                356
             ],
             "__typename": [
                 1
@@ -9281,7 +9229,7 @@ export default {
                 3
             ],
             "logicalOperator": [
-                63
+                61
             ],
             "positionInViewFilterGroup": [
                 11
@@ -9301,7 +9249,7 @@ export default {
                 3
             ],
             "logicalOperator": [
-                63
+                61
             ],
             "positionInViewFilterGroup": [
                 11
@@ -9321,7 +9269,7 @@ export default {
                 3
             ],
             "operand": [
-                65
+                63
             ],
             "value": [
                 15
@@ -9350,7 +9298,7 @@ export default {
                 3
             ],
             "update": [
-                365
+                362
             ],
             "__typename": [
                 1
@@ -9361,7 +9309,7 @@ export default {
                 3
             ],
             "operand": [
-                65
+                63
             ],
             "value": [
                 15
@@ -9409,10 +9357,10 @@ export default {
                 3
             ],
             "type": [
-                71
+                69
             ],
             "key": [
-                72
+                70
             ],
             "icon": [
                 1
@@ -9430,10 +9378,10 @@ export default {
                 21
             ],
             "openRecordIn": [
-                73
+                71
             ],
             "kanbanAggregateOperation": [
-                61
+                59
             ],
             "kanbanAggregateOperationFieldMetadataId": [
                 3
@@ -9442,7 +9390,7 @@ export default {
                 1
             ],
             "calendarLayout": [
-                74
+                72
             ],
             "calendarFieldMetadataId": [
                 3
@@ -9451,7 +9399,7 @@ export default {
                 3
             ],
             "visibility": [
-                75
+                73
             ],
             "__typename": [
                 1
@@ -9465,7 +9413,7 @@ export default {
                 1
             ],
             "type": [
-                71
+                69
             ],
             "icon": [
                 1
@@ -9477,10 +9425,10 @@ export default {
                 6
             ],
             "openRecordIn": [
-                73
+                71
             ],
             "kanbanAggregateOperation": [
-                61
+                59
             ],
             "kanbanAggregateOperationFieldMetadataId": [
                 3
@@ -9489,13 +9437,13 @@ export default {
                 1
             ],
             "calendarLayout": [
-                74
+                72
             ],
             "calendarFieldMetadataId": [
                 3
             ],
             "visibility": [
-                75
+                73
             ],
             "mainGroupByFieldMetadataId": [
                 3
@@ -9515,16 +9463,16 @@ export default {
                 3
             ],
             "viewFields": [
-                371
+                368
             ],
             "viewFilters": [
-                372
+                369
             ],
             "viewFilterGroups": [
-                373
+                370
             ],
             "viewSorts": [
-                374
+                371
             ],
             "__typename": [
                 1
@@ -9558,7 +9506,7 @@ export default {
                 3
             ],
             "operand": [
-                65
+                63
             ],
             "value": [
                 15
@@ -9587,7 +9535,7 @@ export default {
                 3
             ],
             "logicalOperator": [
-                63
+                61
             ],
             "positionInViewFilterGroup": [
                 11
@@ -9604,7 +9552,7 @@ export default {
                 3
             ],
             "direction": [
-                68
+                66
             ],
             "__typename": [
                 1
@@ -9618,7 +9566,7 @@ export default {
                 3
             ],
             "direction": [
-                68
+                66
             ],
             "subFieldName": [
                 1
@@ -9635,7 +9583,7 @@ export default {
                 3
             ],
             "update": [
-                377
+                374
             ],
             "__typename": [
                 1
@@ -9643,7 +9591,7 @@ export default {
         },
         "UpdateViewSortInputUpdates": {
             "direction": [
-                68
+                66
             ],
             "subFieldName": [
                 1
@@ -9673,7 +9621,7 @@ export default {
                 3
             ],
             "update": [
-                381
+                378
             ],
             "__typename": [
                 1
@@ -9690,7 +9638,7 @@ export default {
                 11
             ],
             "aggregateOperation": [
-                61
+                59
             ],
             "viewFieldGroupId": [
                 3
@@ -9719,7 +9667,7 @@ export default {
                 11
             ],
             "aggregateOperation": [
-                61
+                59
             ],
             "viewFieldGroupId": [
                 3
@@ -9749,7 +9697,7 @@ export default {
                 3
             ],
             "update": [
-                386
+                383
             ],
             "__typename": [
                 1
@@ -9813,10 +9761,10 @@ export default {
                 3
             ],
             "groups": [
-                391
+                388
             ],
             "fields": [
-                392
+                389
             ],
             "__typename": [
                 1
@@ -9836,7 +9784,7 @@ export default {
                 6
             ],
             "fields": [
-                392
+                389
             ],
             "__typename": [
                 1
@@ -9942,7 +9890,7 @@ export default {
                 3
             ],
             "layoutMode": [
-                89
+                87
             ],
             "__typename": [
                 1
@@ -9959,7 +9907,7 @@ export default {
                 1
             ],
             "layoutMode": [
-                89
+                87
             ],
             "__typename": [
                 1
@@ -9970,7 +9918,7 @@ export default {
                 1
             ],
             "type": [
-                125
+                123
             ],
             "objectMetadataId": [
                 3
@@ -9984,7 +9932,7 @@ export default {
                 1
             ],
             "type": [
-                125
+                123
             ],
             "objectMetadataId": [
                 3
@@ -9998,13 +9946,13 @@ export default {
                 1
             ],
             "type": [
-                125
+                123
             ],
             "objectMetadataId": [
                 3
             ],
             "tabs": [
-                404
+                401
             ],
             "__typename": [
                 1
@@ -10024,10 +9972,10 @@ export default {
                 1
             ],
             "layoutMode": [
-                89
+                87
             ],
             "widgets": [
-                405
+                402
             ],
             "__typename": [
                 1
@@ -10044,13 +9992,13 @@ export default {
                 1
             ],
             "type": [
-                86
+                84
             ],
             "objectMetadataId": [
                 3
             ],
             "gridPosition": [
-                406
+                403
             ],
             "position": [
                 15
@@ -10093,13 +10041,13 @@ export default {
                 1
             ],
             "type": [
-                86
+                84
             ],
             "objectMetadataId": [
                 3
             ],
             "gridPosition": [
-                406
+                403
             ],
             "position": [
                 15
@@ -10119,13 +10067,13 @@ export default {
                 1
             ],
             "type": [
-                86
+                84
             ],
             "objectMetadataId": [
                 3
             ],
             "gridPosition": [
-                406
+                403
             ],
             "position": [
                 15
@@ -10218,7 +10166,7 @@ export default {
         },
         "CreateOneObjectInput": {
             "object": [
-                412
+                409
             ],
             "__typename": [
                 1
@@ -10278,7 +10226,7 @@ export default {
         },
         "UpdateOneObjectInput": {
             "update": [
-                415
+                412
             ],
             "id": [
                 3
@@ -10333,7 +10281,7 @@ export default {
         },
         "CreateOneIndexInput": {
             "index": [
-                417
+                414
             ],
             "__typename": [
                 1
@@ -10344,10 +10292,10 @@ export default {
                 3
             ],
             "fields": [
-                418
+                415
             ],
             "indexType": [
-                48
+                47
             ],
             "__typename": [
                 1
@@ -10429,7 +10377,7 @@ export default {
                 3
             ],
             "update": [
-                423
+                420
             ],
             "__typename": [
                 1
@@ -10589,7 +10537,7 @@ export default {
                 3
             ],
             "update": [
-                428
+                425
             ],
             "__typename": [
                 1
@@ -10693,7 +10641,7 @@ export default {
         },
         "CreateOneFieldMetadataInput": {
             "field": [
-                432
+                429
             ],
             "__typename": [
                 1
@@ -10766,7 +10714,7 @@ export default {
                 3
             ],
             "update": [
-                434
+                431
             ],
             "__typename": [
                 1
@@ -10861,7 +10809,7 @@ export default {
                 3
             ],
             "update": [
-                438
+                435
             ],
             "__typename": [
                 1
@@ -10902,7 +10850,7 @@ export default {
         },
         "WorkspaceMigrationInput": {
             "actions": [
-                442
+                439
             ],
             "__typename": [
                 1
@@ -10910,10 +10858,10 @@ export default {
         },
         "WorkspaceMigrationDeleteActionInput": {
             "type": [
-                443
+                440
             ],
             "metadataName": [
-                335
+                332
             ],
             "universalIdentifier": [
                 1
@@ -10969,7 +10917,7 @@ export default {
         },
         "UpdateRoleInput": {
             "update": [
-                446
+                443
             ],
             "id": [
                 3
@@ -11024,7 +10972,7 @@ export default {
                 3
             ],
             "objectPermissions": [
-                448
+                445
             ],
             "__typename": [
                 1
@@ -11066,7 +11014,7 @@ export default {
                 3
             ],
             "fieldPermissions": [
-                451
+                448
             ],
             "__typename": [
                 1
@@ -11097,10 +11045,10 @@ export default {
                 3
             ],
             "predicates": [
-                453
+                450
             ],
             "predicateGroups": [
-                454
+                451
             ],
             "__typename": [
                 1
@@ -11180,7 +11128,7 @@ export default {
                 1
             ],
             "update": [
-                457
+                454
             ],
             "__typename": [
                 1
@@ -11231,7 +11179,7 @@ export default {
                 1
             ],
             "update": [
-                460
+                457
             ],
             "__typename": [
                 1
@@ -11311,7 +11259,7 @@ export default {
                 1
             ],
             "visibility": [
-                289
+                286
             ],
             "__typename": [
                 1
@@ -11328,7 +11276,7 @@ export default {
                 1
             ],
             "visibility": [
-                289
+                286
             ],
             "__typename": [
                 1
@@ -11339,7 +11287,7 @@ export default {
                 3
             ],
             "update": [
-                466
+                463
             ],
             "__typename": [
                 1
@@ -11347,16 +11295,16 @@ export default {
         },
         "UpdateMessageChannelInputUpdates": {
             "visibility": [
-                276
+                273
             ],
             "isContactAutoCreationEnabled": [
                 6
             ],
             "contactAutoCreationPolicy": [
-                278
+                275
             ],
             "messageFolderImportPolicy": [
-                279
+                276
             ],
             "isSyncEnabled": [
                 6
@@ -11423,7 +11371,7 @@ export default {
                 3
             ],
             "update": [
-                472
+                469
             ],
             "__typename": [
                 1
@@ -11451,7 +11399,7 @@ export default {
                 3
             ],
             "update": [
-                474
+                471
             ],
             "__typename": [
                 1
@@ -11470,7 +11418,7 @@ export default {
                 3
             ],
             "update": [
-                474
+                471
             ],
             "__typename": [
                 1
@@ -11481,7 +11429,7 @@ export default {
                 3
             ],
             "update": [
-                477
+                474
             ],
             "__typename": [
                 1
@@ -11489,13 +11437,13 @@ export default {
         },
         "UpdateCalendarChannelInputUpdates": {
             "visibility": [
-                330
+                327
             ],
             "isContactAutoCreationEnabled": [
                 6
             ],
             "contactAutoCreationPolicy": [
-                331
+                328
             ],
             "isSyncEnabled": [
                 6
@@ -11650,7 +11598,7 @@ export default {
                 3
             ],
             "status": [
-                180
+                178
             ],
             "__typename": [
                 1
@@ -11721,7 +11669,7 @@ export default {
                 1
             ],
             "files": [
-                491
+                488
             ],
             "__typename": [
                 1
@@ -11740,13 +11688,13 @@ export default {
         },
         "EmailAccountConnectionParameters": {
             "IMAP": [
-                493
+                490
             ],
             "SMTP": [
-                493
+                490
             ],
             "CALDAV": [
-                493
+                490
             ],
             "__typename": [
                 1
@@ -11766,7 +11714,7 @@ export default {
                 1
             ],
             "connectionSecurity": [
-                238
+                235
             ],
             "__typename": [
                 1
@@ -11785,7 +11733,7 @@ export default {
         },
         "CreateOneAppTokenInput": {
             "appToken": [
-                496
+                493
             ],
             "__typename": [
                 1
@@ -11802,7 +11750,7 @@ export default {
         "FileFolder": {},
         "Subscription": {
             "onEventSubscription": [
-                168,
+                166,
                 {
                     "eventStreamId": [
                         1,
@@ -11811,16 +11759,16 @@ export default {
                 }
             ],
             "logicFunctionLogs": [
-                236,
+                233,
                 {
                     "input": [
-                        499,
+                        496,
                         "LogicFunctionLogsInput!"
                     ]
                 }
             ],
             "onAgentChatEvent": [
-                323,
+                320,
                 {
                     "threadId": [
                         3,
@@ -11829,10 +11777,10 @@ export default {
                 }
             ],
             "eventLogsLive": [
-                313,
+                310,
                 {
                     "table": [
-                        346,
+                        343,
                         "EventLogTable!"
                     ]
                 }

--- a/packages/twenty-front/src/generated-metadata/graphql.ts
+++ b/packages/twenty-front/src/generated-metadata/graphql.ts
@@ -2050,7 +2050,6 @@ export type Index = {
   createdAt: Scalars['DateTime']['output'];
   id: Scalars['UUID']['output'];
   indexFieldMetadataList: Array<IndexField>;
-  indexFieldMetadatas: IndexIndexFieldMetadatasConnection;
   indexType: IndexType;
   indexWhereClause?: Maybe<Scalars['String']['output']>;
   isCustom?: Maybe<Scalars['Boolean']['output']>;
@@ -2058,12 +2057,6 @@ export type Index = {
   name: Scalars['String']['output'];
   objectMetadata: IndexObjectMetadataConnection;
   updatedAt: Scalars['DateTime']['output'];
-};
-
-
-export type IndexIndexFieldMetadatasArgs = {
-  filter?: IndexFieldFilter;
-  paging?: CursorPaging;
 };
 
 
@@ -2098,34 +2091,11 @@ export type IndexField = {
   updatedAt: Scalars['DateTime']['output'];
 };
 
-export type IndexFieldEdge = {
-  __typename?: 'IndexFieldEdge';
-  /** Cursor for this node. */
-  cursor: Scalars['ConnectionCursor']['output'];
-  /** The node containing the IndexField */
-  node: IndexField;
-};
-
-export type IndexFieldFilter = {
-  and?: InputMaybe<Array<IndexFieldFilter>>;
-  fieldMetadataId?: InputMaybe<UuidFilterComparison>;
-  id?: InputMaybe<UuidFilterComparison>;
-  or?: InputMaybe<Array<IndexFieldFilter>>;
-};
-
 export type IndexFilter = {
   and?: InputMaybe<Array<IndexFilter>>;
   id?: InputMaybe<UuidFilterComparison>;
   isCustom?: InputMaybe<BooleanFieldComparison>;
   or?: InputMaybe<Array<IndexFilter>>;
-};
-
-export type IndexIndexFieldMetadatasConnection = {
-  __typename?: 'IndexIndexFieldMetadatasConnection';
-  /** Array of edges. */
-  edges: Array<IndexFieldEdge>;
-  /** Paging information */
-  pageInfo: PageInfo;
 };
 
 export type IndexObjectMetadataConnection = {

--- a/packages/twenty-server/src/engine/metadata-modules/index-metadata/dtos/index-metadata.dto.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/index-metadata/dtos/index-metadata.dto.ts
@@ -24,7 +24,6 @@ import {
 
 import { UUIDScalarType } from 'src/engine/api/graphql/workspace-schema-builder/graphql-types/scalars';
 import { IsValidMetadataName } from 'src/engine/decorators/metadata/is-valid-metadata-name.decorator';
-import { IndexFieldMetadataDTO } from 'src/engine/metadata-modules/index-metadata/dtos/index-field-metadata.dto';
 import { IndexType } from 'src/engine/metadata-modules/index-metadata/types/indexType.types';
 import { ObjectMetadataDTO } from 'src/engine/metadata-modules/object-metadata/dtos/object-metadata.dto';
 
@@ -46,7 +45,6 @@ registerEnumType(IndexType, {
   maxResultsSize: 1000,
 })
 @CursorConnection('objectMetadata', () => ObjectMetadataDTO)
-@CursorConnection('indexFieldMetadatas', () => IndexFieldMetadataDTO)
 export class IndexMetadataDTO {
   @IsUUID()
   @IsNotEmpty()


### PR DESCRIPTION
## Summary

Querying `indexMetadatas { indexFieldMetadatas { ... } }` on the `/metadata` GraphQL endpoint fails with a 500:

> Nest could not find IndexFieldMetadataDTOAuthorizer element (this provider does not
> exist in the current context)

The `@CursorConnection('indexFieldMetadatas', ...)` decorator on `IndexMetadataDTO` makes nestjs-query auto-generate a relation resolver that injects an authorizer for `IndexFieldMetadataDTO`. That authorizer is never provided, because the DTO was never registered as a resolver in `IndexMetadataModule` — so the field has been broken since it was introduced in #7162.

Since the working, DataLoader-backed `indexFieldMetadataList` field already exposes the same data (and is what the frontend uses), this PR removes the dead connection instead of wiring up the authorizer.

## Changes

- Remove `@CursorConnection('indexFieldMetadatas', ...)` from `IndexMetadataDTO`
- Regenerate frontend metadata GraphQL types (`twenty-front/src/generated-metadata`)
- Regenerate client SDK metadata schema/types (`twenty-client-sdk/src/metadata/generated`)

## Notes

- Not a breaking change in practice: the removed field always threw, so no consumer can have been relying on it. Callers now get a standard GraphQL validation error suggesting `indexFieldMetadataList` instead of an internal server error.
- Verified locally: the failing query now returns `Cannot query field "indexFieldMetadatas" on type "Index". Did you mean "indexFieldMetadataList"?` and `indexFieldMetadataList` continues to work.

Fixes [sonarly issue #54098](https://sonarly.com/issue/54098?type=bug)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/22439?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

