### PR TITLE
Nav menu item styling

### DIFF
--- a/packages/twenty-front/src/modules/ui/navigation/navigation-drawer/components/NavigationDrawerItemBreadcrumb.tsx
+++ b/packages/twenty-front/src/modules/ui/navigation/navigation-drawer/components/NavigationDrawerItemBreadcrumb.tsx
@@ -13,6 +13,14 @@ const StyledNavigationDrawerItemBreadcrumbContainer = styled.div`
   margin-right: ${themeCssVariables.spacing[2]};
   width: 9px;
 
+  // Hide the tree connector while the item is being dragged so the floating
+  // preview only shows the icon and label instead of a dangling vertical bar.
+  // dnd-kit sets [data-dnd-dragging] on the moving clone, leaving the static
+  // placeholder and the other items in the list untouched.
+  [data-dnd-dragging] & {
+    display: none;
+  }
+
   @media (max-width: ${MOBILE_VIEWPORT}px) {
     height: ${themeCssVariables.spacing[8]};
   }


### PR DESCRIPTION
## What & why

When dragging a navigation menu **sub-item** (nested inside a folder / favorites), the sidebar uses dnd-kit with `feedback: 'clone'`, which clones the entire row as the floating drag preview. That clone included the vertical **tree-connector bar** on the left of the sub-item, so a dangling connector followed the cursor while dragging, which looked out of place.

The drag preview should show only the icon and label of the moving item.

## Change

A single scoped CSS rule in `NavigationDrawerItemBreadcrumb.tsx` hides the tree connector inside the moving clone:

```css
[data-dnd-dragging] & {
  display: none;
}
```

dnd-kit marks the moving clone with `data-dnd-dragging` on the sortable root (an ancestor of the breadcrumb) and leaves a static placeholder (`data-dnd-placeholder`) in the list. Scoping the rule to `[data-dnd-dragging]` therefore hides the connector **only in the floating preview** — the placeholder left in the list and every other item keep their connectors, so the list layout is unchanged during a drag.

Top-level items and folder headers use `indentationLevel === 1` and have no breadcrumb, so they are unaffected.
