### PR TITLE
fix(front): hide sub-item tree connector in navigation drag preview

### DIFF
--- a/packages/twenty-front/src/modules/ui/navigation/navigation-drawer/components/NavigationDrawerItemBreadcrumb.tsx
+++ b/packages/twenty-front/src/modules/ui/navigation/navigation-drawer/components/NavigationDrawerItemBreadcrumb.tsx
@@ -13,6 +13,10 @@ const StyledNavigationDrawerItemBreadcrumbContainer = styled.div`
   margin-right: ${themeCssVariables.spacing[2]};
   width: 9px;
 
+  [data-dnd-dragging] & {
+    display: none;
+  }
+
   @media (max-width: ${MOBILE_VIEWPORT}px) {
     height: ${themeCssVariables.spacing[8]};
   }


### PR DESCRIPTION
## Context

Dragging a navigation menu sub-item cloned the whole row as the floating drag preview, which included the vertical tree-connector bar on the left. Hide that connector inside the moving clone (marked by dnd-kit with [data-dnd-dragging]) so the preview shows only the icon and label. The static placeholder left in the list and the other items keep their connectors, so the list layout is unchanged.

## Before


https://github.com/user-attachments/assets/8fc04a28-e1d2-49e0-88c1-ef03f89475c2


## After

https://github.com/user-attachments/assets/dbcd3cc5-8a51-40a3-98de-a8ea3d440774


