### PR TITLE
test(postcard): verify app prod-parity e2e pipeline (intentional failure)

### DIFF
--- a/packages/twenty-apps/examples/postcard/e2e/card-front-component.spec.ts
+++ b/packages/twenty-apps/examples/postcard/e2e/card-front-component.spec.ts
@@ -64,10 +64,16 @@ test.describe('Postcard card front component', () => {
     await page.goto(`${resolveWorkspaceUrl()}/object/postCard/${RECORD_ID}`);
 
     const card = page.getByTestId(CARD_TEST_IDS.root);
-    // INTENTIONAL FAILURE — asserts no postcard record was created post-install.
-    // Used only to verify the app prod-parity e2e pipeline surfaces failures.
-    // Revert to `toBeVisible()` before merging.
-    await expect(card).not.toBeVisible();
+    await expect(card).toBeVisible();
+
+    // INTENTIONAL FAILURE — asserts the "Record not found" fallback is shown,
+    // i.e. that no postcard record was created post-install. The post-install
+    // hook DOES seed records, so the card renders and this assertion fails after
+    // the expect timeout. A positive (retrying) assertion is required here: a
+    // negated `not.toBeVisible()` would pass trivially at t=0 before the
+    // remote-dom card has had time to render. Used only to verify the app
+    // prod-parity e2e pipeline surfaces failing runs. Delete before merging.
+    await expect(page.getByText('Record not found', { exact: false })).toBeVisible();
 
     const cardName = card.getByTestId(CARD_TEST_IDS.name);
     const cardStatus = card.getByTestId(CARD_TEST_IDS.status);

--- a/packages/twenty-apps/examples/postcard/e2e/card-front-component.spec.ts
+++ b/packages/twenty-apps/examples/postcard/e2e/card-front-component.spec.ts
@@ -64,7 +64,10 @@ test.describe('Postcard card front component', () => {
     await page.goto(`${resolveWorkspaceUrl()}/object/postCard/${RECORD_ID}`);
 
     const card = page.getByTestId(CARD_TEST_IDS.root);
-    await expect(card).toBeVisible();
+    // INTENTIONAL FAILURE — asserts no postcard record was created post-install.
+    // Used only to verify the app prod-parity e2e pipeline surfaces failures.
+    // Revert to `toBeVisible()` before merging.
+    await expect(card).not.toBeVisible();
 
     const cardName = card.getByTestId(CARD_TEST_IDS.name);
     const cardStatus = card.getByTestId(CARD_TEST_IDS.status);


### PR DESCRIPTION
## Purpose

Verify that the **app prod-parity e2e** pipeline (`.github/workflows/app-prod-parity-e2e-dispatch.yaml`, which dispatches to `twentyhq/ci-privileged`) correctly surfaces a failing e2e run back onto the PR status check.

This is a **throwaway / do-not-merge** PR. It intentionally makes the postcard app e2e fail.

## Change

In `packages/twenty-apps/examples/postcard/e2e/card-front-component.spec.ts`, the seeded-record assertion is inverted so the test expects **no** postcard record to exist after install:

```diff
-    await expect(card).toBeVisible();
+    await expect(card).not.toBeVisible();
```

Since the app's `post-install` logic function seeds postcard records, the card *is* rendered, so this assertion fails on purpose.

## Expectations

- The `run-e2e-apps-prod-parity-tests` label is applied, and because this PR is from a branch in the main repo (not a fork), the dispatch job runs and forwards the head SHA to `twentyhq/ci-privileged`.
- The prod-parity e2e run should **fail** and report a failing `app-prod-parity-e2e` status back on this PR.

## Before merging

Do not merge. If kept, revert the assertion back to `toBeVisible()`.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/22444?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

