### PR TITLE
fix(website): center the User Guide nav preview image

### DIFF
--- a/packages/twenty-website/src/sections/menu/data/menu.ts
+++ b/packages/twenty-website/src/sections/menu/data/menu.ts
@@ -49,6 +49,7 @@ export const MENU: {
           preview: {
             image: '/images/menu/user-guide.webp',
             imageAlt: msg`Twenty user guide preview`,
+            imagePosition: 'center',
             title: msg`Master every corner of Twenty`,
             description: msg`Step-by-step guides and playbooks to help your team get the most out of their workspace.`,
           },


### PR DESCRIPTION
## What

The **User Guide** item in the Resources dropdown rendered its preview image off-center (anchored top-left with a gap below the halftone).

## Fix

Set `imagePosition: 'center'` on the User Guide preview so the halftone book is centered and fills to the bottom of the frame, matching the others.

## Testing

- `nx lint twenty-website` ✓ (check-conventions + oxlint + oxfmt)
- `nx typecheck twenty-website` ✓