### PR TITLE
fix(front): render pinned command-menu buttons inline in page header

### DIFF
--- a/packages/twenty-front/src/modules/ui/layout/page/components/PageCardHeader.tsx
+++ b/packages/twenty-front/src/modules/ui/layout/page/components/PageCardHeader.tsx
@@ -31,7 +31,9 @@ const StyledHeader = styled.div<{ centerTitle?: boolean }>`
   column-gap: ${themeCssVariables.spacing[2]};
   display: grid;
   grid-template-columns: ${({ centerTitle }) =>
-    centerTitle ? 'minmax(0, 1fr) auto minmax(0, 1fr)' : 'minmax(0, 1fr) auto'};
+    centerTitle
+      ? 'minmax(0, 1fr) auto minmax(0, 1fr)'
+      : 'minmax(0, auto) minmax(0, 1fr)'};
   min-height: ${SIDE_PANEL_TOP_BAR_HEIGHT}px;
   padding: 0 ${themeCssVariables.spacing[3]};
   width: 100%;


### PR DESCRIPTION
## Context
Pinned command-menu items (isPinned: true) stopped appearing as inline buttons next to the command-menu/burger control and only showed up in the side panel's "Pinned" list.

Root cause: PR #21308 replaced the flex-based PageHeader with the grid-based PageCardHeader. The old header sized the title with `flex: 0 1 auto` (content width) and the action container with `flex: 1 1 0` (grows to fill), so the pinned-buttons wrapper — itself a `flex: 1 1 0` element that measures its own available width to decide how many buttons fit inline — had room to expand. PageCardHeader inverted this: it put the title in the flexible `minmax(0, 1fr)` track and the action area in the content-sized `auto` track. With the pinned wrapper empty on first paint, the `auto` track collapsed to zero, the measured container width was 0, and the "wait until measured" guard kept the visible inline count pinned at 0 forever — a deadlock where nothing ever rendered inline and every pinned item fell through to overflow.

Fix: give the non-centered header the same intent as the old flex layout — title track content-sized/shrinkable (`minmax(0, auto)`), action track flexible (`minmax(0, 1fr)`). The centered variant already placed the action area in a `1fr` track, so it is unchanged. Both tracks keep a 0 minimum, so long titles still clip without causing horizontal overflow.

## Before
<img width="1299" height="140" alt="Screenshot 2026-07-02 at 13 05 20" src="https://github.com/user-attachments/assets/948f5ded-1a9f-4329-825e-313924a829fe" />

## After
<img width="1296" height="238" alt="Screenshot 2026-07-02 at 13 05 11" src="https://github.com/user-attachments/assets/64edd5f2-b307-4119-9158-813e39f813aa" />
