### PR TITLE
[Twenty-front][Fix]: One to many relations field creating duplicates

### DIFF
--- a/packages/twenty-front/src/modules/object-record/record-picker/multiple-record-picker/components/MultipleRecordPickerMenuItems.tsx
+++ b/packages/twenty-front/src/modules/object-record/record-picker/multiple-record-picker/components/MultipleRecordPickerMenuItems.tsx
@@ -57,6 +57,17 @@ export const MultipleRecordPickerMenuItems = ({
         (item) => item.recordId === morphItem.recordId,
       );
 
+      if (existingMorphItemIndex !== -1) {
+        const existingMorphItem = previousMorphItems[existingMorphItemIndex];
+
+        if (
+          existingMorphItem?.isSelected === morphItem.isSelected &&
+          existingMorphItem.objectMetadataId === morphItem.objectMetadataId
+        ) {
+          return false;
+        }
+      }
+
       const newMorphItems = [...previousMorphItems];
 
       if (existingMorphItemIndex === -1) {
@@ -66,6 +77,7 @@ export const MultipleRecordPickerMenuItems = ({
       }
 
       store.set(multipleRecordPickerPickableMorphItems, newMorphItems);
+      return true;
     },
     [multipleRecordPickerPickableMorphItems, store],
   );
@@ -101,7 +113,9 @@ export const MultipleRecordPickerMenuItems = ({
                 key={recordId}
                 recordId={recordId}
                 onChange={(morphItem) => {
-                  handleChange(morphItem);
+                  const hasChanged = handleChange(morphItem);
+                  if (!hasChanged) return;
+
                   onChange?.(morphItem);
                 }}
               />


### PR DESCRIPTION
Fixes #22395


https://github.com/user-attachments/assets/ff33f8a9-63bc-468e-ae54-5bcf60c335c6



<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/22451?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

