### PR TITLE
fix(front): stop pinned command-menu buttons glitching on side panel toggle

### DIFF
--- a/packages/twenty-front/src/modules/command-menu-item/display/components/PinnedCommandMenuItemButtons.tsx
+++ b/packages/twenty-front/src/modules/command-menu-item/display/components/PinnedCommandMenuItemButtons.tsx
@@ -5,12 +5,10 @@ import { PINNED_COMMAND_MENU_ITEMS_GAP } from '@/command-menu-item/display/const
 import { usePinnedCommandMenuItemsInlineLayout } from '@/command-menu-item/display/hooks/usePinnedCommandMenuItemsInlineLayout';
 import { NodeDimension } from '@/ui/utilities/dimensions/components/NodeDimension';
 import { styled } from '@linaria/react';
-import { motion } from 'framer-motion';
 import { useContext, useMemo } from 'react';
-import { ThemeContext } from 'twenty-ui/theme-constants';
 import { EngineComponentKey } from '~/generated-metadata/graphql';
 
-const StyledCommandMenuItemContainer = styled(motion.div)`
+const StyledCommandMenuItemContainer = styled.div`
   align-items: center;
   display: flex;
   justify-content: center;
@@ -37,7 +35,6 @@ const StyledItemsContainer = styled.div`
 `;
 
 export const PinnedCommandMenuItemButtons = () => {
-  const { theme } = useContext(ThemeContext);
   const { commandMenuItems } = useContext(CommandMenuContext);
 
   const pinnedCommandMenuItems = useMemo(
@@ -70,17 +67,7 @@ export const PinnedCommandMenuItemButtons = () => {
           <StyledContainer>
             <StyledItemsContainer>
               {pinnedInlineCommandMenuItems.map((item) => (
-                <StyledCommandMenuItemContainer
-                  key={item.id}
-                  layout
-                  initial={{ width: 0, opacity: 0 }}
-                  animate={{ width: 'unset', opacity: 1 }}
-                  exit={{ width: 0, opacity: 0 }}
-                  transition={{
-                    duration: theme.animation.duration.instant,
-                    ease: 'easeInOut',
-                  }}
-                >
+                <StyledCommandMenuItemContainer key={item.id}>
                   <CommandMenuItemRenderer
                     item={item}
                     isPrimaryAction={


### PR DESCRIPTION
## Context

Opening or closing the side panel resizes the record/index header, so the inline pinned command-menu buttons reposition. Each button was wrapped in a framer-motion motion.div with `layout` + `animate={{ width: 'unset' }}` (and a dead `exit` — there is no AnimatePresence).

The `layout` FLIP animation fought with the side panel's own CSS transition running at the same time, so the buttons stuttered/jumped instead of moving cleanly (measured ~200-330ms of dropped frames per toggle), and animating width to the `unset` keyword is an anti-pattern that adds jank. These buttons only started rendering inline after the PageCardHeader grid fix, which is why the glitch surfaced now.

Render the buttons as a plain styled.div so they reflow with native layout: they reposition cleanly on open/close, return to the right edge when the panel closes, and no longer distort. Overflow-to-side-panel and the inline measurement layout are unchanged.

## Before

https://github.com/user-attachments/assets/0a25c1b8-cde7-4304-b909-7c73746f6fa5



<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/22461?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

