### PR TITLE
Isolate front component origin storage from the host

### DIFF
--- a/packages/twenty-front-component-renderer/src/remote/worker/remote-worker.ts
+++ b/packages/twenty-front-component-renderer/src/remote/worker/remote-worker.ts
@@ -15,6 +15,7 @@ import { isDefined } from 'twenty-shared/utils';
 import { installStyleBridge } from '@/polyfills/installStyleBridge';
 import { installStylePropertyOnRemoteElements } from '@/remote/utils/installStylePropertyOnRemoteElements';
 import { patchRemoteElementSetAttribute } from '@/remote/utils/patchRemoteElementSetAttribute';
+import { installOriginStorageIsolation } from './utils/installOriginStorageIsolation';
 import { type FrontComponentExecutionContext } from 'twenty-sdk/front-component';
 import { frontComponentHostCommunicationApi } from '@/constants/frontComponentHostCommunicationApi';
 import { HTML_TAG_TO_CUSTOM_ELEMENT_TAG } from '@/constants/HtmlTagToRemoteComponent';
@@ -31,6 +32,7 @@ import { setWorkerEnv } from './utils/setWorkerEnv';
 
 installStylePropertyOnRemoteElements();
 patchRemoteElementSetAttribute();
+installOriginStorageIsolation();
 
 exposeGlobals({
   __HTML_TAG_TO_CUSTOM_ELEMENT_TAG__: HTML_TAG_TO_CUSTOM_ELEMENT_TAG,

--- a/packages/twenty-front-component-renderer/src/remote/worker/utils/__tests__/installOriginStorageIsolation.test.ts
+++ b/packages/twenty-front-component-renderer/src/remote/worker/utils/__tests__/installOriginStorageIsolation.test.ts
@@ -1,0 +1,96 @@
+import { installOriginStorageIsolation } from '../installOriginStorageIsolation';
+
+const PREFIX = 'front-component:';
+
+describe('installOriginStorageIsolation', () => {
+  describe('BroadcastChannel', () => {
+    it('should prefix channel names so host channels are unreachable', () => {
+      const constructedNames: string[] = [];
+      class FakeBroadcastChannel {
+        constructor(name: string) {
+          constructedNames.push(name);
+        }
+      }
+      const scope = { BroadcastChannel: FakeBroadcastChannel };
+
+      installOriginStorageIsolation(scope as never);
+      const channel = new scope.BroadcastChannel('twenty-sign-out');
+
+      expect(channel).toBeDefined();
+      expect(constructedNames).toEqual([`${PREFIX}twenty-sign-out`]);
+    });
+
+    it('should keep the namespaced channel an instanceof the original channel', () => {
+      class FakeBroadcastChannel {
+        constructor(public name: string) {}
+      }
+      const scope = { BroadcastChannel: FakeBroadcastChannel };
+
+      installOriginStorageIsolation(scope as never);
+      const channel = new scope.BroadcastChannel('my-channel');
+
+      expect(channel).toBeInstanceOf(scope.BroadcastChannel);
+      expect(channel).toBeInstanceOf(FakeBroadcastChannel);
+    });
+  });
+
+  describe('indexedDB', () => {
+    const createFakeIndexedDb = () => {
+      const openedNames: string[] = [];
+      const deletedNames: string[] = [];
+
+      return {
+        openedNames,
+        deletedNames,
+        factory: {
+          open: (name: string) => {
+            openedNames.push(name);
+            return { name };
+          },
+          deleteDatabase: (name: string) => {
+            deletedNames.push(name);
+          },
+          databases: async () => [
+            { name: `${PREFIX}mine`, version: 1 },
+            { name: 'twenty-front-metadata-store', version: 1 },
+          ],
+          cmp: () => 0,
+        },
+      };
+    };
+
+    it('should prefix opened database names', () => {
+      const { factory, openedNames } = createFakeIndexedDb();
+      const scope = { indexedDB: factory };
+
+      installOriginStorageIsolation(scope as never);
+      scope.indexedDB.open('twenty-front-metadata-store');
+
+      expect(openedNames).toEqual([`${PREFIX}twenty-front-metadata-store`]);
+    });
+
+    it('should prefix deleted database names', () => {
+      const { factory, deletedNames } = createFakeIndexedDb();
+      const scope = { indexedDB: factory };
+
+      installOriginStorageIsolation(scope as never);
+      scope.indexedDB.deleteDatabase('some-db');
+
+      expect(deletedNames).toEqual([`${PREFIX}some-db`]);
+    });
+
+    it('should only expose the component own databases with their unprefixed names', async () => {
+      const { factory } = createFakeIndexedDb();
+      const scope = { indexedDB: factory };
+
+      installOriginStorageIsolation(scope as never);
+      const databases = await scope.indexedDB.databases();
+
+      expect(databases).toEqual([{ name: 'mine', version: 1 }]);
+    });
+  });
+
+  it('should do nothing when the primitives are absent', () => {
+    expect(() => installOriginStorageIsolation({} as never)).not.toThrow();
+  });
+});

--- a/packages/twenty-front-component-renderer/src/remote/worker/utils/installOriginStorageIsolation.ts
+++ b/packages/twenty-front-component-renderer/src/remote/worker/utils/installOriginStorageIsolation.ts
@@ -1,0 +1,93 @@
+import { isDefined } from 'twenty-shared/utils';
+
+const FRONT_COMPONENT_ORIGIN_STORAGE_PREFIX = 'front-component:';
+
+type BroadcastChannelConstructor = new (name: string) => object;
+
+type IndexedDbDatabaseInfo = { name?: string; version?: number };
+
+type IndexedDbFactoryLike = {
+  open: (name: string, version?: number) => unknown;
+  deleteDatabase: (name: string) => unknown;
+  databases?: () => Promise<IndexedDbDatabaseInfo[]>;
+  cmp?: (first: unknown, second: unknown) => number;
+};
+
+type OriginStorageScope = {
+  BroadcastChannel?: BroadcastChannelConstructor;
+  indexedDB?: IndexedDbFactoryLike;
+};
+
+const defineGlobal = (scope: object, key: string, value: unknown): void => {
+  try {
+    Object.defineProperty(scope, key, {
+      value,
+      configurable: true,
+      writable: true,
+    });
+  } catch {}
+};
+
+const namespaceBroadcastChannel = (scope: OriginStorageScope): void => {
+  const OriginalBroadcastChannel = scope.BroadcastChannel;
+
+  if (!isDefined(OriginalBroadcastChannel)) {
+    return;
+  }
+
+  class NamespacedBroadcastChannel extends OriginalBroadcastChannel {
+    constructor(name: string) {
+      super(`${FRONT_COMPONENT_ORIGIN_STORAGE_PREFIX}${name}`);
+    }
+  }
+
+  defineGlobal(scope, 'BroadcastChannel', NamespacedBroadcastChannel);
+};
+
+const namespaceIndexedDb = (scope: OriginStorageScope): void => {
+  const originalIndexedDb = scope.indexedDB;
+
+  if (!isDefined(originalIndexedDb)) {
+    return;
+  }
+
+  const namespacedIndexedDb: IndexedDbFactoryLike = {
+    open: (name, version) =>
+      originalIndexedDb.open(
+        `${FRONT_COMPONENT_ORIGIN_STORAGE_PREFIX}${name}`,
+        version,
+      ),
+    deleteDatabase: (name) =>
+      originalIndexedDb.deleteDatabase(
+        `${FRONT_COMPONENT_ORIGIN_STORAGE_PREFIX}${name}`,
+      ),
+    databases: isDefined(originalIndexedDb.databases)
+      ? async () => {
+          const databases = await originalIndexedDb.databases!();
+
+          return databases
+            .filter((database) =>
+              database.name?.startsWith(FRONT_COMPONENT_ORIGIN_STORAGE_PREFIX),
+            )
+            .map((database) => ({
+              ...database,
+              name: database.name?.slice(
+                FRONT_COMPONENT_ORIGIN_STORAGE_PREFIX.length,
+              ),
+            }));
+        }
+      : undefined,
+    cmp: isDefined(originalIndexedDb.cmp)
+      ? (first, second) => originalIndexedDb.cmp!(first, second)
+      : undefined,
+  };
+
+  defineGlobal(scope, 'indexedDB', namespacedIndexedDb);
+};
+
+export const installOriginStorageIsolation = (
+  globalScope: OriginStorageScope = globalThis as unknown as OriginStorageScope,
+): void => {
+  namespaceBroadcastChannel(globalScope);
+  namespaceIndexedDb(globalScope);
+};


### PR DESCRIPTION
## What

Front components run in a Web Worker that shares the host page's origin, so today a component can reach the host's own `IndexedDB` and `BroadcastChannel`:

- `new BroadcastChannel('twenty-sign-out')` lets a component **force-log-out the user** in every tab.
- `indexedDB.open('twenty-front-metadata-store')` lets it **read or poison** the cached workspace metadata.

This adds `installOriginStorageIsolation` to the worker bootstrap, which transparently namespaces every worker-created channel and database name with a fixed `front-component:` prefix:

- `BroadcastChannel` is subclassed so channel names are prefixed (host channels become unreachable; `instanceof` still holds).
- `indexedDB` `open`/`deleteDatabase` prefix the database name, and `databases()` only lists the component's own (prefixed) databases, with the prefix stripped, so host databases can't be reached or even enumerated.

A component's own channels and databases keep working (they're just transparently renamed); it simply can no longer address the host's un-prefixed resources. Namespacing (rather than a denylist of host names) is future-proof — it doesn't depend on knowing the host's resource names.

## Why these APIs are reachable

Per the same-origin policy, browser storage and messaging APIs are scoped to the **origin**, not to the document or the worker. MDN lists `localStorage`, `indexedDB`, `BroadcastChannel`, and `SharedWorker` among the origin-checked APIs — so a worker that shares the host page's origin (as our inline blob worker does) sees the exact same `IndexedDB` databases and `BroadcastChannel`s as the host app. That is what this PR closes.

- [Same-origin policy (MDN)](https://developer.mozilla.org/en-US/docs/Web/Security/Same-origin_policy) — notes `localStorage`, `indexedDB`, `BroadcastChannel`, `SharedWorker` are origin-scoped
- [Broadcast Channel API (MDN)](https://developer.mozilla.org/en-US/docs/Web/API/Broadcast_Channel_API) — "communication between browsing contexts and workers on the same origin"
- [IndexedDB API (MDN)](https://developer.mozilla.org/en-US/docs/Web/API/IndexedDB_API)

## Scope

Worker-side only, no host/SDK/RPC changes. The prefix is fixed, so this isolates components from the **host**; per-application isolation (so two apps can't reach each other's storage, keyed by application id) is a follow-up. Existing apps don't use these primitives, so nothing regresses.