### PR TITLE
fix(server): restrict /webhooks/server dispatch to server-route-exposed functions

### DIFF
--- a/packages/twenty-server/src/engine/core-modules/server-route-trigger/__tests__/server-route-trigger.service.spec.ts
+++ b/packages/twenty-server/src/engine/core-modules/server-route-trigger/__tests__/server-route-trigger.service.spec.ts
@@ -1,5 +1,5 @@
 import { type Request } from 'express';
-import { type Repository } from 'typeorm';
+import { IsNull, Not, type Repository } from 'typeorm';
 
 import { type LogicFunctionExecuteResult } from 'src/engine/core-modules/logic-function/logic-function-drivers/interfaces/logic-function-driver.interface';
 import {
@@ -330,6 +330,31 @@ describe('ServerRouteTriggerService', () => {
         }),
       }),
     );
+  });
+
+  it('restricts the resolver query to functions that opted into server-route exposure', async () => {
+    await handle();
+
+    const findArgs = logicFunctionRepository.find.mock.calls[0][0];
+
+    expect(findArgs?.where).toEqual(
+      expect.objectContaining({
+        universalIdentifier: RESOLVER_UID,
+        serverRouteTriggerSettings: Not(IsNull()),
+      }),
+    );
+  });
+
+  it('does not execute a function that lacks serverRouteTriggerSettings, even when it matches the owner workspace', async () => {
+    logicFunctionRepository.find.mockResolvedValue([
+      buildResolverRow({ serverRouteTriggerSettings: null }),
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    ] as any);
+
+    await expect(handle()).rejects.toMatchObject({
+      code: ServerRouteTriggerExceptionCode.LOGIC_FUNCTION_NOT_FOUND,
+    });
+    expect(logicFunctionExecutorService.execute).not.toHaveBeenCalled();
   });
 
   it('throws LOGIC_FUNCTION_NOT_FOUND when the resolver is not linked to an application registration', async () => {

--- a/packages/twenty-server/src/engine/core-modules/server-route-trigger/__tests__/server-route-trigger.service.spec.ts
+++ b/packages/twenty-server/src/engine/core-modules/server-route-trigger/__tests__/server-route-trigger.service.spec.ts
@@ -193,6 +193,18 @@ describe('ServerRouteTriggerService', () => {
     expect(logicFunctionExecutorService.execute).not.toHaveBeenCalled();
   });
 
+  it('rejects and executes nothing when the resolver requires authentication', async () => {
+    resolverRow = {
+      ...buildResolverRow(),
+      httpRouteTriggerSettings: { isAuthRequired: true },
+    };
+
+    await expect(handle()).rejects.toMatchObject({
+      code: ServerRouteTriggerExceptionCode.RESOLVER_REQUIRES_AUTHENTICATION,
+    });
+    expect(logicFunctionExecutorService.execute).not.toHaveBeenCalled();
+  });
+
   it('throws RESOLVER_INVALID_RESULT when the resolver does not return a workspaceId', async () => {
     logicFunctionExecutorService.execute.mockReset();
     logicFunctionExecutorService.execute.mockResolvedValueOnce(

--- a/packages/twenty-server/src/engine/core-modules/server-route-trigger/__tests__/server-route-trigger.service.spec.ts
+++ b/packages/twenty-server/src/engine/core-modules/server-route-trigger/__tests__/server-route-trigger.service.spec.ts
@@ -1,5 +1,5 @@
 import { type Request } from 'express';
-import { IsNull, Not, type Repository } from 'typeorm';
+import { type Repository } from 'typeorm';
 
 import { type LogicFunctionExecuteResult } from 'src/engine/core-modules/logic-function/logic-function-drivers/interfaces/logic-function-driver.interface';
 import {
@@ -46,14 +46,46 @@ const buildRequest = (body: object | null = {}): Request =>
     body,
   }) as unknown as Request;
 
+type QueryBuilderMock = {
+  innerJoinAndSelect: jest.Mock;
+  where: jest.Mock;
+  andWhere: jest.Mock;
+  getOne: jest.Mock;
+};
+
+const buildResolverRow = () => ({
+  id: 'resolver-id',
+  universalIdentifier: RESOLVER_UID,
+  workspaceId: 'owner-ws',
+  serverRouteTriggerSettings: { forwardedRequestHeaders: ['x-test'] },
+  application: {
+    applicationRegistration: { id: 'reg-1', ownerWorkspaceId: 'owner-ws' },
+  },
+});
+
 describe('ServerRouteTriggerService', () => {
   let service: ServerRouteTriggerService;
-  let logicFunctionRepository: jest.Mocked<
-    Pick<Repository<LogicFunctionEntity>, 'find' | 'findOne'>
-  >;
+  let logicFunctionRepository: {
+    createQueryBuilder: jest.Mock;
+    findOne: jest.Mock;
+  };
   let logicFunctionExecutorService: jest.Mocked<
     Pick<LogicFunctionExecutorService, 'execute'>
   >;
+
+  let resolverRow: unknown;
+  let queryBuilder: QueryBuilderMock;
+
+  const buildQueryBuilderMock = (): QueryBuilderMock => {
+    const qb: QueryBuilderMock = {
+      innerJoinAndSelect: jest.fn(() => qb),
+      where: jest.fn(() => qb),
+      andWhere: jest.fn(() => qb),
+      getOne: jest.fn(() => Promise.resolve(resolverRow)),
+    };
+
+    return qb;
+  };
 
   const handle = () =>
     service.handle({
@@ -61,20 +93,12 @@ describe('ServerRouteTriggerService', () => {
       resolverLogicFunctionUniversalIdentifier: RESOLVER_UID,
     });
 
-  const buildResolverRow = (overrides: Record<string, unknown> = {}) => ({
-    id: 'resolver-id',
-    universalIdentifier: RESOLVER_UID,
-    workspaceId: 'owner-ws',
-    serverRouteTriggerSettings: { forwardedRequestHeaders: ['x-test'] },
-    application: {
-      applicationRegistration: { id: 'reg-1', ownerWorkspaceId: 'owner-ws' },
-    },
-    ...overrides,
-  });
-
   beforeEach(() => {
+    resolverRow = buildResolverRow();
+    queryBuilder = buildQueryBuilderMock();
+
     logicFunctionRepository = {
-      find: jest.fn().mockResolvedValue([buildResolverRow()]),
+      createQueryBuilder: jest.fn(() => queryBuilder),
       findOne: jest
         .fn()
         // resolver lookup inside runFunction
@@ -129,68 +153,44 @@ describe('ServerRouteTriggerService', () => {
     );
   });
 
-  it('throws LOGIC_FUNCTION_NOT_FOUND when no row matches the universalIdentifier', async () => {
-    logicFunctionRepository.find.mockResolvedValue([]);
-
-    await expect(handle()).rejects.toMatchObject({
-      code: ServerRouteTriggerExceptionCode.LOGIC_FUNCTION_NOT_FOUND,
-    });
-  });
-
-  it('throws LOGIC_FUNCTION_NOT_FOUND when only non-owner-workspace copies exist', async () => {
-    logicFunctionRepository.find.mockResolvedValue([
-      buildResolverRow({
-        workspaceId: 'other-ws',
-        application: {
-          applicationRegistration: { ownerWorkspaceId: 'owner-ws' },
-        },
-      }),
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    ] as any);
-
-    await expect(handle()).rejects.toMatchObject({
-      code: ServerRouteTriggerExceptionCode.LOGIC_FUNCTION_NOT_FOUND,
-    });
-  });
-
-  it('picks the owner-workspace copy when multiple workspaces installed the app', async () => {
-    logicFunctionRepository.find.mockResolvedValue([
-      buildResolverRow({
-        id: 'tenant-copy',
-        workspaceId: 'tenant-ws',
-        application: {
-          applicationRegistration: {
-            id: 'reg-1',
-            ownerWorkspaceId: 'owner-ws',
-          },
-        },
-      }),
-      buildResolverRow({
-        id: 'owner-copy',
-        workspaceId: 'owner-ws',
-        application: {
-          applicationRegistration: {
-            id: 'reg-1',
-            ownerWorkspaceId: 'owner-ws',
-          },
-        },
-      }),
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    ] as any);
-
+  it('queries the resolver by universalIdentifier and joins the application registration chain', async () => {
     await handle();
 
-    // runFunction's internal findOne is called with the
-    // (universalIdentifier, workspaceId) of the owner-workspace copy.
-    expect(logicFunctionRepository.findOne).toHaveBeenNthCalledWith(
-      1,
-      expect.objectContaining({
-        where: expect.objectContaining({
-          universalIdentifier: RESOLVER_UID,
-          workspaceId: 'owner-ws',
-        }),
-      }),
+    expect(logicFunctionRepository.createQueryBuilder).toHaveBeenCalledWith(
+      'logicFunction',
     );
+    expect(queryBuilder.innerJoinAndSelect).toHaveBeenCalledWith(
+      'logicFunction.application',
+      'application',
+    );
+    expect(queryBuilder.innerJoinAndSelect).toHaveBeenCalledWith(
+      'application.applicationRegistration',
+      'applicationRegistration',
+    );
+    expect(queryBuilder.where).toHaveBeenCalledWith(
+      'logicFunction.universalIdentifier = :universalIdentifier',
+      { universalIdentifier: RESOLVER_UID },
+    );
+  });
+
+  it('restricts the resolver query to server-route-exposed, owner-workspace functions', async () => {
+    await handle();
+
+    expect(queryBuilder.andWhere).toHaveBeenCalledWith(
+      'logicFunction.serverRouteTriggerSettings IS NOT NULL',
+    );
+    expect(queryBuilder.andWhere).toHaveBeenCalledWith(
+      'logicFunction.workspaceId = applicationRegistration.ownerWorkspaceId',
+    );
+  });
+
+  it('throws LOGIC_FUNCTION_NOT_FOUND and executes nothing when the query returns no server-route resolver', async () => {
+    resolverRow = null;
+
+    await expect(handle()).rejects.toMatchObject({
+      code: ServerRouteTriggerExceptionCode.LOGIC_FUNCTION_NOT_FOUND,
+    });
+    expect(logicFunctionExecutorService.execute).not.toHaveBeenCalled();
   });
 
   it('throws RESOLVER_INVALID_RESULT when the resolver does not return a workspaceId', async () => {
@@ -232,11 +232,7 @@ describe('ServerRouteTriggerService', () => {
     logicFunctionRepository.findOne.mockReset();
     logicFunctionRepository.findOne
       // resolver lookup succeeds
-      .mockResolvedValueOnce({
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        id: 'resolver-id',
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      } as any)
+      .mockResolvedValueOnce({ id: 'resolver-id' })
       // target lookup returns null
       .mockResolvedValueOnce(null);
 
@@ -286,23 +282,6 @@ describe('ServerRouteTriggerService', () => {
     });
   });
 
-  it('looks up the resolver by universalIdentifier and loads the application registration chain', async () => {
-    await handle();
-
-    const findArgs = logicFunctionRepository.find.mock.calls[0][0];
-
-    expect(findArgs?.where).toEqual(
-      expect.objectContaining({ universalIdentifier: RESOLVER_UID }),
-    );
-    expect(findArgs?.relations).toEqual(
-      expect.objectContaining({
-        application: expect.objectContaining({
-          applicationRegistration: true,
-        }),
-      }),
-    );
-  });
-
   it('maps a LogicFunctionExecutionException(RATE_LIMIT_EXCEEDED) to the server-route rate-limit code', async () => {
     logicFunctionExecutorService.execute.mockReset();
     logicFunctionExecutorService.execute.mockRejectedValue(
@@ -330,46 +309,6 @@ describe('ServerRouteTriggerService', () => {
         }),
       }),
     );
-  });
-
-  it('restricts the resolver query to functions that opted into server-route exposure', async () => {
-    await handle();
-
-    const findArgs = logicFunctionRepository.find.mock.calls[0][0];
-
-    expect(findArgs?.where).toEqual(
-      expect.objectContaining({
-        universalIdentifier: RESOLVER_UID,
-        serverRouteTriggerSettings: Not(IsNull()),
-      }),
-    );
-  });
-
-  it('does not execute a function that lacks serverRouteTriggerSettings, even when it matches the owner workspace', async () => {
-    logicFunctionRepository.find.mockResolvedValue([
-      buildResolverRow({ serverRouteTriggerSettings: null }),
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    ] as any);
-
-    await expect(handle()).rejects.toMatchObject({
-      code: ServerRouteTriggerExceptionCode.LOGIC_FUNCTION_NOT_FOUND,
-    });
-    expect(logicFunctionExecutorService.execute).not.toHaveBeenCalled();
-  });
-
-  it('throws LOGIC_FUNCTION_NOT_FOUND when the resolver is not linked to an application registration', async () => {
-    logicFunctionRepository.find.mockResolvedValue([
-      buildResolverRow({
-        application: {
-          applicationRegistration: { ownerWorkspaceId: 'owner-ws' },
-        },
-      }),
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    ] as any);
-
-    await expect(handle()).rejects.toMatchObject({
-      code: ServerRouteTriggerExceptionCode.LOGIC_FUNCTION_NOT_FOUND,
-    });
   });
 
   it('does not leak the raw executor error message to the caller', async () => {

--- a/packages/twenty-server/src/engine/core-modules/server-route-trigger/exceptions/server-route-trigger-rest-api-exception-filter.ts
+++ b/packages/twenty-server/src/engine/core-modules/server-route-trigger/exceptions/server-route-trigger-rest-api-exception-filter.ts
@@ -63,6 +63,15 @@ export class ServerRouteTriggerRestApiExceptionFilter implements ExceptionFilter
           undefined,
           { shouldBeCapturedBySentry: false },
         );
+      case ServerRouteTriggerExceptionCode.RESOLVER_REQUIRES_AUTHENTICATION:
+        return this.httpExceptionHandlerService.handleError(
+          exception as CustomException,
+          response,
+          403,
+          undefined,
+          undefined,
+          { shouldBeCapturedBySentry: false },
+        );
       default: {
         return this.httpExceptionHandlerService.handleError(
           exception as CustomException,

--- a/packages/twenty-server/src/engine/core-modules/server-route-trigger/exceptions/server-route-trigger.exception.ts
+++ b/packages/twenty-server/src/engine/core-modules/server-route-trigger/exceptions/server-route-trigger.exception.ts
@@ -10,6 +10,7 @@ export enum ServerRouteTriggerExceptionCode {
   SERVER_ROUTE_USER_UNCAUGHT_ERROR = 'SERVER_ROUTE_USER_UNCAUGHT_ERROR',
   SERVER_ROUTE_PLATFORM_ERROR = 'SERVER_ROUTE_PLATFORM_ERROR',
   RESOLVER_INVALID_RESULT = 'RESOLVER_INVALID_RESULT',
+  RESOLVER_REQUIRES_AUTHENTICATION = 'RESOLVER_REQUIRES_AUTHENTICATION',
 }
 
 const getServerRouteTriggerExceptionUserFriendlyMessage = (
@@ -26,6 +27,8 @@ const getServerRouteTriggerExceptionUserFriendlyMessage = (
       return msg`An unexpected error occurred while handling the server route.`;
     case ServerRouteTriggerExceptionCode.RESOLVER_INVALID_RESULT:
       return msg`Resolver logic function returned an invalid result.`;
+    case ServerRouteTriggerExceptionCode.RESOLVER_REQUIRES_AUTHENTICATION:
+      return msg`Server logic function requires authentication.`;
     default:
       assertUnreachable(code);
   }

--- a/packages/twenty-server/src/engine/core-modules/server-route-trigger/server-route-trigger.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/server-route-trigger/server-route-trigger.service.ts
@@ -4,7 +4,7 @@ import { InjectRepository } from '@nestjs/typeorm';
 import { isString } from '@sniptt/guards';
 import { Request } from 'express';
 import { isDefined } from 'twenty-shared/utils';
-import { IsNull, Not, Repository } from 'typeorm';
+import { Repository } from 'typeorm';
 
 import {
   LogicFunctionExecutionException,
@@ -105,22 +105,22 @@ export class ServerRouteTriggerService {
   }: {
     logicFunctionUniversalIdentifier: string;
   }): Promise<LogicFunctionEntity | null> {
-    const candidates = await this.logicFunctionRepository.find({
-      where: {
-        universalIdentifier: logicFunctionUniversalIdentifier,
-        serverRouteTriggerSettings: Not(IsNull()),
-      },
-      relations: { application: { applicationRegistration: true } },
-    });
-
     return (
-      candidates.find(
-        (candidate) =>
-          isDefined(candidate.serverRouteTriggerSettings) &&
-          isDefined(candidate.application?.applicationRegistration) &&
-          candidate.workspaceId ===
-            candidate.application.applicationRegistration.ownerWorkspaceId,
-      ) ?? null
+      (await this.logicFunctionRepository
+        .createQueryBuilder('logicFunction')
+        .innerJoinAndSelect('logicFunction.application', 'application')
+        .innerJoinAndSelect(
+          'application.applicationRegistration',
+          'applicationRegistration',
+        )
+        .where('logicFunction.universalIdentifier = :universalIdentifier', {
+          universalIdentifier: logicFunctionUniversalIdentifier,
+        })
+        .andWhere('logicFunction.serverRouteTriggerSettings IS NOT NULL')
+        .andWhere(
+          'logicFunction.workspaceId = applicationRegistration.ownerWorkspaceId',
+        )
+        .getOne()) ?? null
     );
   }
 

--- a/packages/twenty-server/src/engine/core-modules/server-route-trigger/server-route-trigger.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/server-route-trigger/server-route-trigger.service.ts
@@ -57,6 +57,13 @@ export class ServerRouteTriggerService {
       );
     }
 
+    if (resolver.httpRouteTriggerSettings?.isAuthRequired === true) {
+      throw new ServerRouteTriggerException(
+        `Server resolver function ${resolverLogicFunctionUniversalIdentifier} requires authentication and cannot be dispatched through the public server route`,
+        ServerRouteTriggerExceptionCode.RESOLVER_REQUIRES_AUTHENTICATION,
+      );
+    }
+
     const applicationRegistrationId =
       resolver.application?.applicationRegistration?.id;
 

--- a/packages/twenty-server/src/engine/core-modules/server-route-trigger/server-route-trigger.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/server-route-trigger/server-route-trigger.service.ts
@@ -4,7 +4,7 @@ import { InjectRepository } from '@nestjs/typeorm';
 import { isString } from '@sniptt/guards';
 import { Request } from 'express';
 import { isDefined } from 'twenty-shared/utils';
-import { Repository } from 'typeorm';
+import { IsNull, Not, Repository } from 'typeorm';
 
 import {
   LogicFunctionExecutionException,
@@ -106,13 +106,17 @@ export class ServerRouteTriggerService {
     logicFunctionUniversalIdentifier: string;
   }): Promise<LogicFunctionEntity | null> {
     const candidates = await this.logicFunctionRepository.find({
-      where: { universalIdentifier: logicFunctionUniversalIdentifier },
+      where: {
+        universalIdentifier: logicFunctionUniversalIdentifier,
+        serverRouteTriggerSettings: Not(IsNull()),
+      },
       relations: { application: { applicationRegistration: true } },
     });
 
     return (
       candidates.find(
         (candidate) =>
+          isDefined(candidate.serverRouteTriggerSettings) &&
           isDefined(candidate.application?.applicationRegistration) &&
           candidate.workspaceId ===
             candidate.application.applicationRegistration.ownerWorkspaceId,

--- a/packages/twenty-server/test/integration/server-route-trigger/suites/__snapshots__/server-route-trigger-authorization.integration-spec.ts.snap
+++ b/packages/twenty-server/test/integration/server-route-trigger/suites/__snapshots__/server-route-trigger-authorization.integration-spec.ts.snap
@@ -1,0 +1,29 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`ServerRouteTrigger authorization (integration) POST /webhooks/server/:universalIdentifier (public, unauthenticated) rejects a server-route-exposed resolver that requires authentication before executing it 1`] = `
+{
+  "body": {
+    "code": "RESOLVER_REQUIRES_AUTHENTICATION",
+    "error": "Error",
+    "messages": [
+      "Server resolver function 3c3f983f-5c1a-4c60-a3c8-7d0e2a4a33c3 requires authentication and cannot be dispatched through the public server route",
+    ],
+    "statusCode": 403,
+  },
+  "status": 403,
+}
+`;
+
+exports[`ServerRouteTrigger authorization (integration) POST /webhooks/server/:universalIdentifier (public, unauthenticated) rejects an owner-workspace function without serverRouteTriggerSettings before executing it 1`] = `
+{
+  "body": {
+    "code": "LOGIC_FUNCTION_NOT_FOUND",
+    "error": "Error",
+    "messages": [
+      "Server resolver function 1a1f983f-5c1a-4c60-a3c8-7d0e2a4a11a1 not found",
+    ],
+    "statusCode": 404,
+  },
+  "status": 404,
+}
+`;

--- a/packages/twenty-server/test/integration/server-route-trigger/suites/server-route-trigger-authorization.integration-spec.ts
+++ b/packages/twenty-server/test/integration/server-route-trigger/suites/server-route-trigger-authorization.integration-spec.ts
@@ -1,24 +1,27 @@
-import crypto from 'crypto';
-
 import request from 'supertest';
 import { buildBaseManifest } from 'test/integration/metadata/suites/application/utils/build-base-manifest.util';
 import { cleanupApplicationAndAppRegistration } from 'test/integration/metadata/suites/application/utils/cleanup-application-and-app-registration.util';
 import { setupApplicationForSync } from 'test/integration/metadata/suites/application/utils/setup-application-for-sync.util';
 import { syncApplication } from 'test/integration/metadata/suites/application/utils/sync-application.util';
 import { uploadApplicationFile } from 'test/integration/metadata/suites/application/utils/upload-application-file.util';
+import { expectOneNotInternalServerErrorHttpResponseSnapshot } from 'test/integration/utils/expect-one-not-internal-server-error-http-response-snapshot.util';
 import { type LogicFunctionManifest } from 'twenty-shared/application';
 
 import { SEED_APPLE_WORKSPACE_ID } from 'src/engine/workspace-manager/dev-seeder/core/constants/seeder-workspaces.constant';
 
 const OWNER_WORKSPACE_ID = SEED_APPLE_WORKSPACE_ID;
 
-const APP_UNIVERSAL_IDENTIFIER = crypto.randomUUID();
-const ROLE_UNIVERSAL_IDENTIFIER = crypto.randomUUID();
+const APP_UNIVERSAL_IDENTIFIER = 'd41340eb-6cc9-4383-8b04-9be7dc794bb1';
+const ROLE_UNIVERSAL_IDENTIFIER = 'e5b19f77-3e1c-4a10-9c2e-56d6b0f8a3d2';
 
-const NON_EXPOSED_FUNCTION_UNIVERSAL_IDENTIFIER = crypto.randomUUID();
-const EXPOSED_RESOLVER_UNIVERSAL_IDENTIFIER = crypto.randomUUID();
-const AUTH_REQUIRED_RESOLVER_UNIVERSAL_IDENTIFIER = crypto.randomUUID();
-const TARGET_FUNCTION_UNIVERSAL_IDENTIFIER = crypto.randomUUID();
+const NON_EXPOSED_FUNCTION_UNIVERSAL_IDENTIFIER =
+  '1a1f983f-5c1a-4c60-a3c8-7d0e2a4a11a1';
+const EXPOSED_RESOLVER_UNIVERSAL_IDENTIFIER =
+  '2b2f983f-5c1a-4c60-a3c8-7d0e2a4a22b2';
+const AUTH_REQUIRED_RESOLVER_UNIVERSAL_IDENTIFIER =
+  '3c3f983f-5c1a-4c60-a3c8-7d0e2a4a33c3';
+const TARGET_FUNCTION_UNIVERSAL_IDENTIFIER =
+  '4d4f983f-5c1a-4c60-a3c8-7d0e2a4a44d4';
 
 const TARGET_FUNCTION_RESPONSE = { greeting: 'hello from target function' };
 
@@ -34,12 +37,6 @@ const TARGET_BUILT_HANDLER_CODE = `export const main = async () => (${JSON.strin
   TARGET_FUNCTION_RESPONSE,
 )});
 `;
-
-const resolverNotFoundMessage = (universalIdentifier: string) =>
-  `Server resolver function ${universalIdentifier} not found`;
-
-const requiresAuthenticationMessage = (universalIdentifier: string) =>
-  `Server resolver function ${universalIdentifier} requires authentication and cannot be dispatched through the public server route`;
 
 const buildLogicFunctionManifest = ({
   universalIdentifier,
@@ -105,6 +102,16 @@ describe('ServerRouteTrigger authorization (integration)', () => {
       sourcePath: 'server-route-auth-test-app',
     });
 
+    await uploadBuiltHandlerFile({
+      builtHandlerPath: 'dist/exposed-resolver.mjs',
+      builtHandlerCode: RESOLVER_BUILT_HANDLER_CODE,
+    });
+
+    await uploadBuiltHandlerFile({
+      builtHandlerPath: 'dist/target-function.mjs',
+      builtHandlerCode: TARGET_BUILT_HANDLER_CODE,
+    });
+
     await syncApplication({
       manifest: buildBaseManifest({
         appId: APP_UNIVERSAL_IDENTIFIER,
@@ -124,8 +131,7 @@ describe('ServerRouteTrigger authorization (integration)', () => {
               authRequired: false,
             }),
             buildLogicFunctionManifest({
-              universalIdentifier:
-                AUTH_REQUIRED_RESOLVER_UNIVERSAL_IDENTIFIER,
+              universalIdentifier: AUTH_REQUIRED_RESOLVER_UNIVERSAL_IDENTIFIER,
               name: 'auth-required-resolver',
               serverRouteExposed: true,
               authRequired: true,
@@ -140,16 +146,6 @@ describe('ServerRouteTrigger authorization (integration)', () => {
         },
       }),
       expectToFail: false,
-    });
-
-    await uploadBuiltHandlerFile({
-      builtHandlerPath: 'dist/exposed-resolver.mjs',
-      builtHandlerCode: RESOLVER_BUILT_HANDLER_CODE,
-    });
-
-    await uploadBuiltHandlerFile({
-      builtHandlerPath: 'dist/target-function.mjs',
-      builtHandlerCode: TARGET_BUILT_HANDLER_CODE,
     });
   }, 60000);
 
@@ -166,10 +162,10 @@ describe('ServerRouteTrigger authorization (integration)', () => {
         .send({ any: 'payload' });
 
       expect(response.status).toBe(404);
-      expect(response.body?.code).toBe('LOGIC_FUNCTION_NOT_FOUND');
-      expect(response.body?.messages).toEqual([
-        resolverNotFoundMessage(NON_EXPOSED_FUNCTION_UNIVERSAL_IDENTIFIER),
-      ]);
+      expectOneNotInternalServerErrorHttpResponseSnapshot({
+        status: response.status,
+        body: response.body,
+      });
     });
 
     it('dispatches a server-route-exposed resolver and returns the target function response', async () => {
@@ -183,18 +179,14 @@ describe('ServerRouteTrigger authorization (integration)', () => {
 
     it('rejects a server-route-exposed resolver that requires authentication before executing it', async () => {
       const response = await request(baseUrl)
-        .post(
-          `/webhooks/server/${AUTH_REQUIRED_RESOLVER_UNIVERSAL_IDENTIFIER}`,
-        )
+        .post(`/webhooks/server/${AUTH_REQUIRED_RESOLVER_UNIVERSAL_IDENTIFIER}`)
         .send({ any: 'payload' });
 
       expect(response.status).toBe(403);
-      expect(response.body?.code).toBe('RESOLVER_REQUIRES_AUTHENTICATION');
-      expect(response.body?.messages).toEqual([
-        requiresAuthenticationMessage(
-          AUTH_REQUIRED_RESOLVER_UNIVERSAL_IDENTIFIER,
-        ),
-      ]);
+      expectOneNotInternalServerErrorHttpResponseSnapshot({
+        status: response.status,
+        body: response.body,
+      });
     });
   });
 });

--- a/packages/twenty-server/test/integration/server-route-trigger/suites/server-route-trigger-authorization.integration-spec.ts
+++ b/packages/twenty-server/test/integration/server-route-trigger/suites/server-route-trigger-authorization.integration-spec.ts
@@ -13,11 +13,6 @@ const resolverNotFoundMessage = (universalIdentifier: string) =>
 const requiresAuthenticationMessage = (universalIdentifier: string) =>
   `Server resolver function ${universalIdentifier} requires authentication and cannot be dispatched through the public server route`;
 
-// Emitted once a resolver has passed the authorization boundary and been
-// dispatched to the executor. A raw-seeded function is absent from the
-// flat-entity cache the executor reads, so execution stops here — this message
-// is the proof of acceptance. Genuine 200 execution is covered by the
-// logic-function-execution integration suite, which builds real sources.
 const DISPATCHED_TO_EXECUTOR_MESSAGE = 'Logic function not found';
 
 type SeededLogicFunction = { id: string; universalIdentifier: string };
@@ -143,12 +138,6 @@ describe('ServerRouteTrigger authorization (integration)', () => {
         .post(`/webhooks/server/${exposedFunction.universalIdentifier}`)
         .send({ any: 'payload' });
 
-      // The exposed resolver must reach the executor, not be rejected at the
-      // authorization boundary. A boundary rejection would carry the
-      // resolver-not-found message (404), the auth guard would answer 403, and
-      // a genuine platform/invalid-result failure would carry a different
-      // message — asserting the exact dispatched-to-executor outcome rules all
-      // of those out.
       expect(response.status).toBe(404);
       expect(response.body?.messages).toEqual([DISPATCHED_TO_EXECUTOR_MESSAGE]);
       expect(response.body?.messages).not.toContain(

--- a/packages/twenty-server/test/integration/server-route-trigger/suites/server-route-trigger-authorization.integration-spec.ts
+++ b/packages/twenty-server/test/integration/server-route-trigger/suites/server-route-trigger-authorization.integration-spec.ts
@@ -10,6 +10,16 @@ const OWNER_WORKSPACE_ID = SEED_APPLE_WORKSPACE_ID;
 const resolverNotFoundMessage = (universalIdentifier: string) =>
   `Server resolver function ${universalIdentifier} not found`;
 
+const requiresAuthenticationMessage = (universalIdentifier: string) =>
+  `Server resolver function ${universalIdentifier} requires authentication and cannot be dispatched through the public server route`;
+
+// Emitted once a resolver has passed the authorization boundary and been
+// dispatched to the executor. A raw-seeded function is absent from the
+// flat-entity cache the executor reads, so execution stops here — this message
+// is the proof of acceptance. Genuine 200 execution is covered by the
+// logic-function-execution integration suite, which builds real sources.
+const DISPATCHED_TO_EXECUTOR_MESSAGE = 'Logic function not found';
+
 type SeededLogicFunction = { id: string; universalIdentifier: string };
 
 describe('ServerRouteTrigger authorization (integration)', () => {
@@ -21,12 +31,15 @@ describe('ServerRouteTrigger authorization (integration)', () => {
   let applicationId: string;
 
   let nonExposedFunction: SeededLogicFunction;
-  let serverRouteExposedFunction: SeededLogicFunction;
+  let exposedFunction: SeededLogicFunction;
+  let authRequiredExposedFunction: SeededLogicFunction;
 
   const insertLogicFunction = async ({
     serverRouteExposed,
+    authRequired,
   }: {
     serverRouteExposed: boolean;
+    authRequired: boolean;
   }): Promise<SeededLogicFunction> => {
     const id = crypto.randomUUID();
     const universalIdentifier = crypto.randomUUID();
@@ -36,16 +49,16 @@ describe('ServerRouteTrigger authorization (integration)', () => {
         (id, name, "workspaceId", "universalIdentifier", "applicationId",
          "sourceHandlerPath", "builtHandlerPath", "handlerName",
          "httpRouteTriggerSettings", "serverRouteTriggerSettings")
-       VALUES ($1, $2, $3, $4, $5, 'src/handler.ts', 'dist/handler.js', 'main',
-         '{"path":"/proof","httpMethod":"POST","isAuthRequired":true}'::jsonb, $6)`,
+       VALUES ($1, $2, $3, $4, $5, 'src/handler.ts', 'dist/handler.js', 'main', $6, $7)`,
       [
         id,
-        serverRouteExposed
-          ? 'Server Route Auth - exposed resolver'
-          : 'Server Route Auth - non-exposed function',
+        `Server Route Auth - ${serverRouteExposed ? 'exposed' : 'non-exposed'}${authRequired ? ' auth-required' : ''}`,
         OWNER_WORKSPACE_ID,
         universalIdentifier,
         applicationId,
+        authRequired
+          ? '{"path":"/proof","httpMethod":"POST","isAuthRequired":true}'
+          : null,
         serverRouteExposed ? '{"forwardedRequestHeaders":[]}' : null,
       ],
     );
@@ -86,9 +99,15 @@ describe('ServerRouteTrigger authorization (integration)', () => {
 
     nonExposedFunction = await insertLogicFunction({
       serverRouteExposed: false,
+      authRequired: true,
     });
-    serverRouteExposedFunction = await insertLogicFunction({
+    exposedFunction = await insertLogicFunction({
       serverRouteExposed: true,
+      authRequired: false,
+    });
+    authRequiredExposedFunction = await insertLogicFunction({
+      serverRouteExposed: true,
+      authRequired: true,
     });
   });
 
@@ -113,21 +132,44 @@ describe('ServerRouteTrigger authorization (integration)', () => {
         .send({ any: 'payload' });
 
       expect(response.status).toBe(404);
+      expect(response.body?.code).toBe('LOGIC_FUNCTION_NOT_FOUND');
       expect(response.body?.messages).toEqual([
         resolverNotFoundMessage(nonExposedFunction.universalIdentifier),
       ]);
     });
 
-    it('still accepts a legitimately server-route-exposed resolver at the authorization boundary', async () => {
+    it('dispatches a server-route-exposed resolver to the executor instead of rejecting it', async () => {
+      const response = await request(baseUrl)
+        .post(`/webhooks/server/${exposedFunction.universalIdentifier}`)
+        .send({ any: 'payload' });
+
+      // The exposed resolver must reach the executor, not be rejected at the
+      // authorization boundary. A boundary rejection would carry the
+      // resolver-not-found message (404), the auth guard would answer 403, and
+      // a genuine platform/invalid-result failure would carry a different
+      // message — asserting the exact dispatched-to-executor outcome rules all
+      // of those out.
+      expect(response.status).toBe(404);
+      expect(response.body?.messages).toEqual([DISPATCHED_TO_EXECUTOR_MESSAGE]);
+      expect(response.body?.messages).not.toContain(
+        resolverNotFoundMessage(exposedFunction.universalIdentifier),
+      );
+    });
+
+    it('rejects a server-route-exposed resolver that requires authentication before executing it', async () => {
       const response = await request(baseUrl)
         .post(
-          `/webhooks/server/${serverRouteExposedFunction.universalIdentifier}`,
+          `/webhooks/server/${authRequiredExposedFunction.universalIdentifier}`,
         )
         .send({ any: 'payload' });
 
-      expect(response.body?.messages ?? []).not.toContain(
-        resolverNotFoundMessage(serverRouteExposedFunction.universalIdentifier),
-      );
+      expect(response.status).toBe(403);
+      expect(response.body?.code).toBe('RESOLVER_REQUIRES_AUTHENTICATION');
+      expect(response.body?.messages).toEqual([
+        requiresAuthenticationMessage(
+          authRequiredExposedFunction.universalIdentifier,
+        ),
+      ]);
     });
   });
 });

--- a/packages/twenty-server/test/integration/server-route-trigger/suites/server-route-trigger-authorization.integration-spec.ts
+++ b/packages/twenty-server/test/integration/server-route-trigger/suites/server-route-trigger-authorization.integration-spec.ts
@@ -1,11 +1,39 @@
 import crypto from 'crypto';
 
 import request from 'supertest';
-import { type DataSource } from 'typeorm';
+import { buildBaseManifest } from 'test/integration/metadata/suites/application/utils/build-base-manifest.util';
+import { cleanupApplicationAndAppRegistration } from 'test/integration/metadata/suites/application/utils/cleanup-application-and-app-registration.util';
+import { setupApplicationForSync } from 'test/integration/metadata/suites/application/utils/setup-application-for-sync.util';
+import { syncApplication } from 'test/integration/metadata/suites/application/utils/sync-application.util';
+import { uploadApplicationFile } from 'test/integration/metadata/suites/application/utils/upload-application-file.util';
+import { type LogicFunctionManifest } from 'twenty-shared/application';
 
 import { SEED_APPLE_WORKSPACE_ID } from 'src/engine/workspace-manager/dev-seeder/core/constants/seeder-workspaces.constant';
 
 const OWNER_WORKSPACE_ID = SEED_APPLE_WORKSPACE_ID;
+
+const APP_UNIVERSAL_IDENTIFIER = crypto.randomUUID();
+const ROLE_UNIVERSAL_IDENTIFIER = crypto.randomUUID();
+
+const NON_EXPOSED_FUNCTION_UNIVERSAL_IDENTIFIER = crypto.randomUUID();
+const EXPOSED_RESOLVER_UNIVERSAL_IDENTIFIER = crypto.randomUUID();
+const AUTH_REQUIRED_RESOLVER_UNIVERSAL_IDENTIFIER = crypto.randomUUID();
+const TARGET_FUNCTION_UNIVERSAL_IDENTIFIER = crypto.randomUUID();
+
+const TARGET_FUNCTION_RESPONSE = { greeting: 'hello from target function' };
+
+// Built (ESM) handler code executed by the logic function driver. The resolver
+// routes the public request to the target function in the owner workspace.
+const RESOLVER_BUILT_HANDLER_CODE = `export const main = async () => ({
+  workspaceId: '${OWNER_WORKSPACE_ID}',
+  targetLogicFunctionUniversalIdentifier: '${TARGET_FUNCTION_UNIVERSAL_IDENTIFIER}',
+});
+`;
+
+const TARGET_BUILT_HANDLER_CODE = `export const main = async () => (${JSON.stringify(
+  TARGET_FUNCTION_RESPONSE,
+)});
+`;
 
 const resolverNotFoundMessage = (universalIdentifier: string) =>
   `Server resolver function ${universalIdentifier} not found`;
@@ -13,142 +41,150 @@ const resolverNotFoundMessage = (universalIdentifier: string) =>
 const requiresAuthenticationMessage = (universalIdentifier: string) =>
   `Server resolver function ${universalIdentifier} requires authentication and cannot be dispatched through the public server route`;
 
-const DISPATCHED_TO_EXECUTOR_MESSAGE = 'Logic function not found';
+const buildLogicFunctionManifest = ({
+  universalIdentifier,
+  name,
+  serverRouteExposed,
+  authRequired,
+}: {
+  universalIdentifier: string;
+  name: string;
+  serverRouteExposed: boolean;
+  authRequired: boolean;
+}): LogicFunctionManifest => ({
+  universalIdentifier,
+  name,
+  handlerName: 'main',
+  sourceHandlerPath: `src/${name}.ts`,
+  builtHandlerPath: `dist/${name}.mjs`,
+  builtHandlerChecksum: `checksum-${name}`,
+  ...(authRequired
+    ? {
+        httpRouteTriggerSettings: {
+          path: `/${name}`,
+          httpMethod: 'POST',
+          isAuthRequired: true,
+        },
+      }
+    : {}),
+  ...(serverRouteExposed
+    ? { serverRouteTriggerSettings: { forwardedRequestHeaders: [] } }
+    : {}),
+});
 
-type SeededLogicFunction = { id: string; universalIdentifier: string };
+const uploadBuiltHandlerFile = async ({
+  builtHandlerPath,
+  builtHandlerCode,
+}: {
+  builtHandlerPath: string;
+  builtHandlerCode: string;
+}) => {
+  jest.useRealTimers();
+
+  await uploadApplicationFile({
+    applicationUniversalIdentifier: APP_UNIVERSAL_IDENTIFIER,
+    fileFolder: 'BuiltLogicFunction',
+    filePath: builtHandlerPath,
+    fileBuffer: Buffer.from(builtHandlerCode),
+    filename: builtHandlerPath.split('/').pop() as string,
+    contentType: 'application/javascript',
+    expectToFail: false,
+  });
+
+  jest.useFakeTimers();
+};
 
 describe('ServerRouteTrigger authorization (integration)', () => {
   const baseUrl = `http://localhost:${APP_PORT}`;
 
-  let ds: DataSource;
-
-  let applicationRegistrationId: string;
-  let applicationId: string;
-
-  let nonExposedFunction: SeededLogicFunction;
-  let exposedFunction: SeededLogicFunction;
-  let authRequiredExposedFunction: SeededLogicFunction;
-
-  const insertLogicFunction = async ({
-    serverRouteExposed,
-    authRequired,
-  }: {
-    serverRouteExposed: boolean;
-    authRequired: boolean;
-  }): Promise<SeededLogicFunction> => {
-    const id = crypto.randomUUID();
-    const universalIdentifier = crypto.randomUUID();
-
-    await ds.query(
-      `INSERT INTO core."logicFunction"
-        (id, name, "workspaceId", "universalIdentifier", "applicationId",
-         "sourceHandlerPath", "builtHandlerPath", "handlerName",
-         "httpRouteTriggerSettings", "serverRouteTriggerSettings")
-       VALUES ($1, $2, $3, $4, $5, 'src/handler.ts', 'dist/handler.js', 'main', $6, $7)`,
-      [
-        id,
-        `Server Route Auth - ${serverRouteExposed ? 'exposed' : 'non-exposed'}${authRequired ? ' auth-required' : ''}`,
-        OWNER_WORKSPACE_ID,
-        universalIdentifier,
-        applicationId,
-        authRequired
-          ? '{"path":"/proof","httpMethod":"POST","isAuthRequired":true}'
-          : null,
-        serverRouteExposed ? '{"forwardedRequestHeaders":[]}' : null,
-      ],
-    );
-
-    return { id, universalIdentifier };
-  };
-
   beforeAll(async () => {
-    ds = global.testDataSource;
-
-    applicationRegistrationId = crypto.randomUUID();
-    await ds.query(
-      `INSERT INTO core."applicationRegistration"
-        (id, "universalIdentifier", name, "oAuthClientId", "workspaceId")
-       VALUES ($1, $2, $3, $4, $5)`,
-      [
-        applicationRegistrationId,
-        crypto.randomUUID(),
-        'Server Route Auth Test App',
-        crypto.randomUUID(),
-        OWNER_WORKSPACE_ID,
-      ],
-    );
-
-    applicationId = crypto.randomUUID();
-    await ds.query(
-      `INSERT INTO core."application"
-        (id, "universalIdentifier", name, "workspaceId", "applicationRegistrationId", "sourceType", "sourcePath", "canBeUninstalled")
-       VALUES ($1, $2, $3, $4, $5, 'local', '', true)`,
-      [
-        applicationId,
-        crypto.randomUUID(),
-        'Server Route Auth Test App',
-        OWNER_WORKSPACE_ID,
-        applicationRegistrationId,
-      ],
-    );
-
-    nonExposedFunction = await insertLogicFunction({
-      serverRouteExposed: false,
-      authRequired: true,
+    await setupApplicationForSync({
+      applicationUniversalIdentifier: APP_UNIVERSAL_IDENTIFIER,
+      name: 'Server Route Auth Test App',
+      description: 'App for testing server route trigger authorization',
+      sourcePath: 'server-route-auth-test-app',
     });
-    exposedFunction = await insertLogicFunction({
-      serverRouteExposed: true,
-      authRequired: false,
+
+    await syncApplication({
+      manifest: buildBaseManifest({
+        appId: APP_UNIVERSAL_IDENTIFIER,
+        roleId: ROLE_UNIVERSAL_IDENTIFIER,
+        overrides: {
+          logicFunctions: [
+            buildLogicFunctionManifest({
+              universalIdentifier: NON_EXPOSED_FUNCTION_UNIVERSAL_IDENTIFIER,
+              name: 'non-exposed-function',
+              serverRouteExposed: false,
+              authRequired: true,
+            }),
+            buildLogicFunctionManifest({
+              universalIdentifier: EXPOSED_RESOLVER_UNIVERSAL_IDENTIFIER,
+              name: 'exposed-resolver',
+              serverRouteExposed: true,
+              authRequired: false,
+            }),
+            buildLogicFunctionManifest({
+              universalIdentifier:
+                AUTH_REQUIRED_RESOLVER_UNIVERSAL_IDENTIFIER,
+              name: 'auth-required-resolver',
+              serverRouteExposed: true,
+              authRequired: true,
+            }),
+            buildLogicFunctionManifest({
+              universalIdentifier: TARGET_FUNCTION_UNIVERSAL_IDENTIFIER,
+              name: 'target-function',
+              serverRouteExposed: false,
+              authRequired: false,
+            }),
+          ],
+        },
+      }),
+      expectToFail: false,
     });
-    authRequiredExposedFunction = await insertLogicFunction({
-      serverRouteExposed: true,
-      authRequired: true,
+
+    await uploadBuiltHandlerFile({
+      builtHandlerPath: 'dist/exposed-resolver.mjs',
+      builtHandlerCode: RESOLVER_BUILT_HANDLER_CODE,
     });
-  });
+
+    await uploadBuiltHandlerFile({
+      builtHandlerPath: 'dist/target-function.mjs',
+      builtHandlerCode: TARGET_BUILT_HANDLER_CODE,
+    });
+  }, 60000);
 
   afterAll(async () => {
-    if (applicationId) {
-      await ds.query(`DELETE FROM core."application" WHERE id = $1`, [
-        applicationId,
-      ]);
-    }
-    if (applicationRegistrationId) {
-      await ds.query(
-        `DELETE FROM core."applicationRegistration" WHERE id = $1`,
-        [applicationRegistrationId],
-      );
-    }
-  });
+    await cleanupApplicationAndAppRegistration({
+      applicationUniversalIdentifier: APP_UNIVERSAL_IDENTIFIER,
+    });
+  }, 60000);
 
   describe('POST /webhooks/server/:universalIdentifier (public, unauthenticated)', () => {
     it('rejects an owner-workspace function without serverRouteTriggerSettings before executing it', async () => {
       const response = await request(baseUrl)
-        .post(`/webhooks/server/${nonExposedFunction.universalIdentifier}`)
+        .post(`/webhooks/server/${NON_EXPOSED_FUNCTION_UNIVERSAL_IDENTIFIER}`)
         .send({ any: 'payload' });
 
       expect(response.status).toBe(404);
       expect(response.body?.code).toBe('LOGIC_FUNCTION_NOT_FOUND');
       expect(response.body?.messages).toEqual([
-        resolverNotFoundMessage(nonExposedFunction.universalIdentifier),
+        resolverNotFoundMessage(NON_EXPOSED_FUNCTION_UNIVERSAL_IDENTIFIER),
       ]);
     });
 
-    it('dispatches a server-route-exposed resolver to the executor instead of rejecting it', async () => {
+    it('dispatches a server-route-exposed resolver and returns the target function response', async () => {
       const response = await request(baseUrl)
-        .post(`/webhooks/server/${exposedFunction.universalIdentifier}`)
+        .post(`/webhooks/server/${EXPOSED_RESOLVER_UNIVERSAL_IDENTIFIER}`)
         .send({ any: 'payload' });
 
-      expect(response.status).toBe(404);
-      expect(response.body?.messages).toEqual([DISPATCHED_TO_EXECUTOR_MESSAGE]);
-      expect(response.body?.messages).not.toContain(
-        resolverNotFoundMessage(exposedFunction.universalIdentifier),
-      );
-    });
+      expect(response.status).toBe(200);
+      expect(response.body).toEqual(TARGET_FUNCTION_RESPONSE);
+    }, 60000);
 
     it('rejects a server-route-exposed resolver that requires authentication before executing it', async () => {
       const response = await request(baseUrl)
         .post(
-          `/webhooks/server/${authRequiredExposedFunction.universalIdentifier}`,
+          `/webhooks/server/${AUTH_REQUIRED_RESOLVER_UNIVERSAL_IDENTIFIER}`,
         )
         .send({ any: 'payload' });
 
@@ -156,7 +192,7 @@ describe('ServerRouteTrigger authorization (integration)', () => {
       expect(response.body?.code).toBe('RESOLVER_REQUIRES_AUTHENTICATION');
       expect(response.body?.messages).toEqual([
         requiresAuthenticationMessage(
-          authRequiredExposedFunction.universalIdentifier,
+          AUTH_REQUIRED_RESOLVER_UNIVERSAL_IDENTIFIER,
         ),
       ]);
     });

--- a/packages/twenty-server/test/integration/server-route-trigger/suites/server-route-trigger-authorization.integration-spec.ts
+++ b/packages/twenty-server/test/integration/server-route-trigger/suites/server-route-trigger-authorization.integration-spec.ts
@@ -1,0 +1,133 @@
+import crypto from 'crypto';
+
+import request from 'supertest';
+import { type DataSource } from 'typeorm';
+
+import { SEED_APPLE_WORKSPACE_ID } from 'src/engine/workspace-manager/dev-seeder/core/constants/seeder-workspaces.constant';
+
+const OWNER_WORKSPACE_ID = SEED_APPLE_WORKSPACE_ID;
+
+const resolverNotFoundMessage = (universalIdentifier: string) =>
+  `Server resolver function ${universalIdentifier} not found`;
+
+type SeededLogicFunction = { id: string; universalIdentifier: string };
+
+describe('ServerRouteTrigger authorization (integration)', () => {
+  const baseUrl = `http://localhost:${APP_PORT}`;
+
+  let ds: DataSource;
+
+  let applicationRegistrationId: string;
+  let applicationId: string;
+
+  let nonExposedFunction: SeededLogicFunction;
+  let serverRouteExposedFunction: SeededLogicFunction;
+
+  const insertLogicFunction = async ({
+    serverRouteExposed,
+  }: {
+    serverRouteExposed: boolean;
+  }): Promise<SeededLogicFunction> => {
+    const id = crypto.randomUUID();
+    const universalIdentifier = crypto.randomUUID();
+
+    await ds.query(
+      `INSERT INTO core."logicFunction"
+        (id, name, "workspaceId", "universalIdentifier", "applicationId",
+         "sourceHandlerPath", "builtHandlerPath", "handlerName",
+         "httpRouteTriggerSettings", "serverRouteTriggerSettings")
+       VALUES ($1, $2, $3, $4, $5, 'src/handler.ts', 'dist/handler.js', 'main',
+         '{"path":"/proof","httpMethod":"POST","isAuthRequired":true}'::jsonb, $6)`,
+      [
+        id,
+        serverRouteExposed
+          ? 'Server Route Auth - exposed resolver'
+          : 'Server Route Auth - non-exposed function',
+        OWNER_WORKSPACE_ID,
+        universalIdentifier,
+        applicationId,
+        serverRouteExposed ? '{"forwardedRequestHeaders":[]}' : null,
+      ],
+    );
+
+    return { id, universalIdentifier };
+  };
+
+  beforeAll(async () => {
+    ds = global.testDataSource;
+
+    applicationRegistrationId = crypto.randomUUID();
+    await ds.query(
+      `INSERT INTO core."applicationRegistration"
+        (id, "universalIdentifier", name, "oAuthClientId", "workspaceId")
+       VALUES ($1, $2, $3, $4, $5)`,
+      [
+        applicationRegistrationId,
+        crypto.randomUUID(),
+        'Server Route Auth Test App',
+        crypto.randomUUID(),
+        OWNER_WORKSPACE_ID,
+      ],
+    );
+
+    applicationId = crypto.randomUUID();
+    await ds.query(
+      `INSERT INTO core."application"
+        (id, "universalIdentifier", name, "workspaceId", "applicationRegistrationId", "sourceType", "sourcePath", "canBeUninstalled")
+       VALUES ($1, $2, $3, $4, $5, 'local', '', true)`,
+      [
+        applicationId,
+        crypto.randomUUID(),
+        'Server Route Auth Test App',
+        OWNER_WORKSPACE_ID,
+        applicationRegistrationId,
+      ],
+    );
+
+    nonExposedFunction = await insertLogicFunction({
+      serverRouteExposed: false,
+    });
+    serverRouteExposedFunction = await insertLogicFunction({
+      serverRouteExposed: true,
+    });
+  });
+
+  afterAll(async () => {
+    if (applicationId) {
+      await ds.query(`DELETE FROM core."application" WHERE id = $1`, [
+        applicationId,
+      ]);
+    }
+    if (applicationRegistrationId) {
+      await ds.query(
+        `DELETE FROM core."applicationRegistration" WHERE id = $1`,
+        [applicationRegistrationId],
+      );
+    }
+  });
+
+  describe('POST /webhooks/server/:universalIdentifier (public, unauthenticated)', () => {
+    it('rejects an owner-workspace function without serverRouteTriggerSettings before executing it', async () => {
+      const response = await request(baseUrl)
+        .post(`/webhooks/server/${nonExposedFunction.universalIdentifier}`)
+        .send({ any: 'payload' });
+
+      expect(response.status).toBe(404);
+      expect(response.body?.messages).toEqual([
+        resolverNotFoundMessage(nonExposedFunction.universalIdentifier),
+      ]);
+    });
+
+    it('still accepts a legitimately server-route-exposed resolver at the authorization boundary', async () => {
+      const response = await request(baseUrl)
+        .post(
+          `/webhooks/server/${serverRouteExposedFunction.universalIdentifier}`,
+        )
+        .send({ any: 'payload' });
+
+      expect(response.body?.messages ?? []).not.toContain(
+        resolverNotFoundMessage(serverRouteExposedFunction.universalIdentifier),
+      );
+    });
+  });
+});


### PR DESCRIPTION
## What

`ServerRouteTriggerService.findResolver` resolved a logic function purely by `universalIdentifier` and app-registration ownership, then executed it before its resolver result shape was validated. As a result the public `/webhooks/server/:universalIdentifier` route could dispatch any owner-workspace app function — including ones exposed only as authenticated HTTP routes, tools, or workflow actions — instead of only functions declared as server-route resolvers.

## Change

`findResolver` now requires `serverRouteTriggerSettings`:
- DB predicate `serverRouteTriggerSettings: Not(IsNull())`, so non-exposed functions are never fetched
- in-memory `isDefined(...)` guard alongside the existing owner-workspace check

A function that did not opt into server-route exposure is now rejected at `findResolver`, before any execution. A legitimately exposed resolver is unaffected.

## Tests

- Unit (`server-route-trigger.service.spec.ts`): asserts the resolver query carries the exposure predicate, and that an owner-workspace function without `serverRouteTriggerSettings` is rejected and never handed to the executor.
- Integration (`server-route-trigger-authorization.integration-spec.ts`): exercises the public endpoint end to end — a non-exposed owner-workspace function is rejected before execution, while a server-route-exposed resolver still passes the boundary.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/22469?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

