### PR TITLE
fix(ai): halt the queued-message flush when a stream fails

### DIFF
--- a/packages/twenty-server/src/engine/metadata-modules/ai/ai-chat/jobs/__tests__/stream-agent-chat.job.spec.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/ai/ai-chat/jobs/__tests__/stream-agent-chat.job.spec.ts
@@ -223,7 +223,12 @@ describe('StreamAgentChatJob', () => {
   });
 
   it('rejects, persists the error, and unblocks the thread when the model stream fails mid-stream', async () => {
-    const { job, publishedEvents, threadRepository } = buildJob({
+    const {
+      job,
+      publishedEvents,
+      threadRepository,
+      agentChatStreamingService,
+    } = buildJob({
       chatStream: createFakeChatStream({
         midStreamError: new Error('provider exploded'),
       }),
@@ -259,6 +264,9 @@ describe('StreamAgentChatJob', () => {
       { id: 'thread-id', activeStreamId: 'stream-id' },
       { activeStreamId: null },
     );
+    expect(
+      agentChatStreamingService.flushNextQueuedMessage,
+    ).not.toHaveBeenCalled();
   });
 
   it('rejects promptly when execution setup throws instead of hanging until the queue lock expires', async () => {
@@ -302,9 +310,12 @@ describe('StreamAgentChatJob', () => {
   });
 
   it('persists the error and unblocks the thread when the workspace is missing', async () => {
-    const { job, publishedEvents, threadRepository } = buildJob({
-      workspaceFound: false,
-    });
+    const {
+      job,
+      publishedEvents,
+      threadRepository,
+      agentChatStreamingService,
+    } = buildJob({ workspaceFound: false });
 
     await expect(job.handle(jobData)).rejects.toMatchObject({
       code: AiExceptionCode.WORKSPACE_NOT_FOUND,
@@ -328,6 +339,9 @@ describe('StreamAgentChatJob', () => {
       { id: 'thread-id', activeStreamId: 'stream-id' },
       { activeStreamId: null },
     );
+    expect(
+      agentChatStreamingService.flushNextQueuedMessage,
+    ).not.toHaveBeenCalled();
   });
 
   it('resolves without flushing the queue when the stream is cancelled', async () => {

--- a/packages/twenty-server/src/engine/metadata-modules/ai/ai-chat/jobs/stream-agent-chat.job.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/ai/ai-chat/jobs/stream-agent-chat.job.ts
@@ -96,8 +96,11 @@ export class StreamAgentChatJob {
       abortController.abort();
     });
 
+    let streamSucceeded = false;
+
     try {
       await this.executeStream(data, workspace, abortController.signal);
+      streamSucceeded = true;
     } catch (error) {
       this.logger.error(
         `Stream ${data.streamId} failed: ${error instanceof Error ? error.message : String(error)}`,
@@ -145,7 +148,7 @@ export class StreamAgentChatJob {
         )
         .catch(() => {});
 
-      if (!abortController.signal.aborted) {
+      if (streamSucceeded && !abortController.signal.aborted) {
         await this.agentChatStreamingService
           .flushNextQueuedMessage(
             data.threadId,


### PR DESCRIPTION
## Rationale

The job's `finally` flushes the next queued message guarded only on `!aborted`. After a **failed** turn, the queue drains anyway: the promoted message executes against the broken conversation, and its claim (`lastStreamError: null` reset) erases the error banner seconds after the user saw it — Retry loses its target mid-click. Maintainer decision from the chat-stack review: the queue should halt on failure/stop so the error stays visible and actionable.

## Why this is the root cause, not a symptom patch

The `finally` is the only place that runs after the claim is released on *every* exit path (success, throw, abort), and the flush's own claim requires `activeStreamId IS NULL` — so the gate belongs exactly here, expressed as what actually happened (`streamSucceeded`) rather than what didn't (`!aborted`). The alternative — a halt check inside `flushNextQueuedMessage` — immediately needs a bypass flag, because the resume path must deliberately drain *through* an existing error: sending with a backlog queues at the back and kicks the drain front-first (#22481), and retrying clears the error first. Halting is caller-context, not queue state.

No permanently-stuck-queue path exists: the backlog resumes on the next send (drain-kick) or Retry, both user-visible affordances rendered by the halted state itself.

## User impact

Today, a queued message silently converts your failed turn into a moving conversation — the error flashes and vanishes, and users lose both the failure context and the Retry. With this, a failure freezes the queue where it happened; the next intentional action resumes it.

## Stack

Based on #22482 (watchdog) — both edit the job's `finally`; sequenced to avoid conflicting hunks. Chain: #22481 → #22482 → this.

## Test plan

- [x] Covered by the harness assertions (#22479 pins success → flush, cancel → no flush); the failure-path `not.toHaveBeenCalled` assertions live in the harness file and will be pushed to this branch once the stack rebases over #22479/#22480 (tracked, I'm watching all of them)
- [ ] CI green

https://claude.ai/code/session_01Lyi6zTema2FMVVh8MD6c38

---
_Generated by [Claude Code](https://claude.ai/code/session_01Lyi6zTema2FMVVh8MD6c38)_

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/22483?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

