### PR TITLE
fix(ai): apply stream chunks in exact server seq order via a client-side sequencer

### DIFF
--- a/packages/twenty-front/src/modules/ai/components/AgentChatMessagesFetchEffect.tsx
+++ b/packages/twenty-front/src/modules/ai/components/AgentChatMessagesFetchEffect.tsx
@@ -111,20 +111,13 @@ export const AgentChatMessagesFetchEffect = () => {
       const firstLiveSeq = store.get(firstLiveSeqFamilyCallback(familyKey));
 
       for (let index = 0; index < catchup.chunks.length; index++) {
-        const chunkSeq = index + 1;
-
-        if (firstLiveSeq !== null && chunkSeq >= firstLiveSeq) {
-          break;
-        }
-
         handleEvent({
           type: 'stream-chunk',
           chunk: catchup.chunks[index],
-          seq: chunkSeq,
+          seq: index + 1,
         } as AgentChatSubscriptionEvent);
       }
 
-      // Never replay a persisted error into an active live stream.
       if (isDefined(catchup.error) && firstLiveSeq === null) {
         handleEvent({
           type: 'stream-error',
@@ -178,7 +171,6 @@ export const AgentChatMessagesFetchEffect = () => {
     onBrowserEvent: handleRefetchMessages,
   });
 
-  // Replay events missed while the SSE connection was down.
   useListenToBrowserEvent({
     eventName: SSE_CLIENT_RECONNECTED_EVENT_NAME,
     onBrowserEvent: handleRefetchMessages,

--- a/packages/twenty-front/src/modules/ai/components/AgentChatStreamSubscriptionEffect.tsx
+++ b/packages/twenty-front/src/modules/ai/components/AgentChatStreamSubscriptionEffect.tsx
@@ -9,6 +9,7 @@ import { useEnsureAgentChatThreadExistsForDraft } from '@/ai/hooks/useEnsureAgen
 import { useEnsureAgentChatThreadIdForSend } from '@/ai/hooks/useEnsureAgentChatThreadIdForSend';
 import { agentChatDisplayedThreadState } from '@/ai/states/agentChatDisplayedThreadState';
 import { agentChatFetchedMessagesComponentFamilyState } from '@/ai/states/agentChatFetchedMessagesComponentFamilyState';
+import { agentChatIsAwaitingFirstChunkComponentFamilyState } from '@/ai/states/agentChatIsAwaitingFirstChunkComponentFamilyState';
 import { agentChatIsAwaitingPersistedRefetchComponentFamilyState } from '@/ai/states/agentChatIsAwaitingPersistedRefetchComponentFamilyState';
 import { agentChatIsInitialScrollPendingOnThreadChangeState } from '@/ai/states/agentChatIsInitialScrollPendingOnThreadChangeState';
 import { agentChatIsLoadingState } from '@/ai/states/agentChatIsLoadingState';
@@ -68,6 +69,11 @@ export const AgentChatStreamSubscriptionEffect = () => {
     { threadId: currentAiChatThread },
   );
 
+  const agentChatIsAwaitingFirstChunk = useAtomComponentFamilyStateValue(
+    agentChatIsAwaitingFirstChunkComponentFamilyState,
+    { threadId: currentAiChatThread },
+  );
+
   const agentChatDisplayedThread = useAtomStateValue(
     agentChatDisplayedThreadState,
   );
@@ -87,7 +93,19 @@ export const AgentChatStreamSubscriptionEffect = () => {
 
     const isThreadSwitch = currentAiChatThread !== agentChatDisplayedThread;
 
-    if (!isThreadSwitch && agentChatIsAwaitingPersistedRefetch) {
+    if (
+      !isThreadSwitch &&
+      (agentChatIsAwaitingPersistedRefetch || agentChatIsAwaitingFirstChunk)
+    ) {
+      return;
+    }
+
+    if (isThreadSwitch && agentChatIsAwaitingFirstChunk) {
+      if (agentChatFetchedMessages.length > 0) {
+        setAgentChatIsInitialScrollPendingOnThreadChange(true);
+      }
+      setAgentChatDisplayedThread(currentAiChatThread);
+
       return;
     }
 
@@ -103,6 +121,7 @@ export const AgentChatStreamSubscriptionEffect = () => {
     agentChatFetchedMessages,
     agentChatIsStreaming,
     agentChatIsAwaitingPersistedRefetch,
+    agentChatIsAwaitingFirstChunk,
     setAgentChatMessages,
     currentAiChatThread,
     agentChatDisplayedThread,

--- a/packages/twenty-front/src/modules/ai/components/AiChatAssistantMessageRenderer.tsx
+++ b/packages/twenty-front/src/modules/ai/components/AiChatAssistantMessageRenderer.tsx
@@ -1,8 +1,8 @@
 import { AiChatCompactionIndicator } from '@/ai/components/AiChatCompactionIndicator';
+import { AiChatInitialLoadingIndicator } from '@/ai/components/AiChatInitialLoadingIndicator';
 import { CodeExecutionDisplay } from '@/ai/components/CodeExecutionDisplay';
 import { RoutingStatusDisplay } from '@/ai/components/RoutingStatusDisplay';
 import { ThinkingStepsDisplay } from '@/ai/components/ThinkingStepsDisplay';
-import { IconDotsVertical } from 'twenty-ui/icon';
 
 import { AiChatQuestionStatusRenderer } from '@/ai/components/AiChatQuestionStatusRenderer';
 import { LazyMarkdownRenderer } from '@/ai/components/LazyMarkdownRenderer';
@@ -15,41 +15,13 @@ import {
   ASK_QUESTIONS_TOOL_NAME,
   type ExtendedUIMessagePart,
 } from 'twenty-shared/ai';
-import { useContext } from 'react';
-import { ThemeContext, themeCssVariables } from 'twenty-ui/theme-constants';
+import { themeCssVariables } from 'twenty-ui/theme-constants';
 
 const StyledMessagePartsContainer = styled.div`
   display: flex;
   flex-direction: column;
   gap: ${themeCssVariables.spacing[1]};
 `;
-
-const StyledLoadingIconContainer = styled.div`
-  align-items: center;
-  border: 1px solid ${themeCssVariables.border.color.light};
-  border-radius: ${themeCssVariables.border.radius.md};
-  display: flex;
-  justify-content: center;
-  padding-inline: ${themeCssVariables.spacing[1]};
-`;
-
-const StyledLoadingIconWrapper = styled.span`
-  color: ${themeCssVariables.font.color.light};
-  display: flex;
-  transform: rotate(90deg);
-`;
-
-const InitialLoadingIndicator = () => {
-  const { theme } = useContext(ThemeContext);
-
-  return (
-    <StyledLoadingIconContainer>
-      <StyledLoadingIconWrapper>
-        <IconDotsVertical size={theme.icon.size.xl} />
-      </StyledLoadingIconWrapper>
-    </StyledLoadingIconContainer>
-  );
-};
 
 const MessagePartRenderer = ({
   part,
@@ -115,7 +87,7 @@ export const AiChatAssistantMessageRenderer = ({
   const renderItems = groupContiguousThinkingStepParts(filteredParts);
 
   if (!renderItems.length && !hasError) {
-    return <InitialLoadingIndicator />;
+    return <AiChatInitialLoadingIndicator />;
   }
 
   return (

--- a/packages/twenty-front/src/modules/ai/components/AiChatInitialLoadingIndicator.tsx
+++ b/packages/twenty-front/src/modules/ai/components/AiChatInitialLoadingIndicator.tsx
@@ -1,0 +1,31 @@
+import { styled } from '@linaria/react';
+import { useContext } from 'react';
+import { IconDotsVertical } from 'twenty-ui/icon';
+import { ThemeContext, themeCssVariables } from 'twenty-ui/theme-constants';
+
+const StyledLoadingIconContainer = styled.div`
+  align-items: center;
+  border: 1px solid ${themeCssVariables.border.color.light};
+  border-radius: ${themeCssVariables.border.radius.md};
+  display: flex;
+  justify-content: center;
+  padding-inline: ${themeCssVariables.spacing[1]};
+`;
+
+const StyledLoadingIconWrapper = styled.span`
+  color: ${themeCssVariables.font.color.light};
+  display: flex;
+  transform: rotate(90deg);
+`;
+
+export const AiChatInitialLoadingIndicator = () => {
+  const { theme } = useContext(ThemeContext);
+
+  return (
+    <StyledLoadingIconContainer>
+      <StyledLoadingIconWrapper>
+        <IconDotsVertical size={theme.icon.size.xl} />
+      </StyledLoadingIconWrapper>
+    </StyledLoadingIconContainer>
+  );
+};

--- a/packages/twenty-front/src/modules/ai/components/AiChatPendingResponseIndicator.tsx
+++ b/packages/twenty-front/src/modules/ai/components/AiChatPendingResponseIndicator.tsx
@@ -1,0 +1,49 @@
+import { styled } from '@linaria/react';
+import { isDefined } from 'twenty-shared/utils';
+
+import { AiChatInitialLoadingIndicator } from '@/ai/components/AiChatInitialLoadingIndicator';
+import { agentChatDisplayedThreadState } from '@/ai/states/agentChatDisplayedThreadState';
+import { agentChatErrorComponentFamilyState } from '@/ai/states/agentChatErrorComponentFamilyState';
+import { agentChatIsAwaitingFirstChunkComponentFamilyState } from '@/ai/states/agentChatIsAwaitingFirstChunkComponentFamilyState';
+import { agentChatIsStreamingComponentFamilyState } from '@/ai/states/agentChatIsStreamingComponentFamilyState';
+import { useAtomComponentFamilyStateValue } from '@/ui/utilities/state/jotai/hooks/useAtomComponentFamilyStateValue';
+import { useAtomStateValue } from '@/ui/utilities/state/jotai/hooks/useAtomStateValue';
+
+const StyledPendingResponseWrapper = styled.div`
+  align-items: flex-start;
+  display: flex;
+  width: 100%;
+`;
+
+export const AiChatPendingResponseIndicator = () => {
+  const agentChatDisplayedThread = useAtomStateValue(
+    agentChatDisplayedThreadState,
+  );
+  const agentChatIsAwaitingFirstChunk = useAtomComponentFamilyStateValue(
+    agentChatIsAwaitingFirstChunkComponentFamilyState,
+    { threadId: agentChatDisplayedThread },
+  );
+  const agentChatIsStreaming = useAtomComponentFamilyStateValue(
+    agentChatIsStreamingComponentFamilyState,
+    { threadId: agentChatDisplayedThread },
+  );
+  const agentChatError = useAtomComponentFamilyStateValue(
+    agentChatErrorComponentFamilyState,
+    { threadId: agentChatDisplayedThread },
+  );
+
+  const shouldRender =
+    agentChatIsAwaitingFirstChunk &&
+    !agentChatIsStreaming &&
+    !isDefined(agentChatError);
+
+  if (!shouldRender) {
+    return null;
+  }
+
+  return (
+    <StyledPendingResponseWrapper>
+      <AiChatInitialLoadingIndicator />
+    </StyledPendingResponseWrapper>
+  );
+};

--- a/packages/twenty-front/src/modules/ai/components/AiChatTabMessageList.tsx
+++ b/packages/twenty-front/src/modules/ai/components/AiChatTabMessageList.tsx
@@ -1,6 +1,7 @@
 import { AiChatErrorUnderMessageList } from '@/ai/components/AiChatErrorUnderMessageList';
 import { AiChatLastMessageWithStreamingState } from '@/ai/components/AiChatLastMessageWithStreamingState';
 import { AiChatNonLastMessageIdsList } from '@/ai/components/AiChatNonLastMessageIdsList';
+import { AiChatPendingResponseIndicator } from '@/ai/components/AiChatPendingResponseIndicator';
 import { AiChatScrollToBottomButton } from '@/ai/components/AiChatScrollToBottomButton';
 import { AgentChatScrollToBottomOnDisplayedThreadChangeLayoutEffect } from '@/ai/components/AgentChatScrollToBottomOnDisplayedThreadChangeLayoutEffect';
 import { AgentChatScrollToBottomOnMountLayoutEffect } from '@/ai/components/AgentChatScrollToBottomOnMountLayoutEffect';
@@ -54,6 +55,7 @@ export const AiChatTabMessageList = () => {
         <StyledMessageListContent>
           <AiChatNonLastMessageIdsList />
           <AiChatLastMessageWithStreamingState />
+          <AiChatPendingResponseIndicator />
           <AiChatErrorUnderMessageList />
         </StyledMessageListContent>
         <AgentChatScrollToBottomOnDisplayedThreadChangeLayoutEffect />

--- a/packages/twenty-front/src/modules/ai/components/internal/SendMessageButton.tsx
+++ b/packages/twenty-front/src/modules/ai/components/internal/SendMessageButton.tsx
@@ -1,5 +1,6 @@
 import { AGENT_CHAT_STOP_EVENT_NAME } from '@/ai/constants/AgentChatStopEventName';
 import { agentChatInputIsEmptySelector } from '@/ai/states/selectors/agentChatInputIsEmptySelector';
+import { agentChatIsAwaitingFirstChunkComponentFamilyState } from '@/ai/states/agentChatIsAwaitingFirstChunkComponentFamilyState';
 import { agentChatIsLoadingState } from '@/ai/states/agentChatIsLoadingState';
 import { agentChatIsStreamingComponentFamilyState } from '@/ai/states/agentChatIsStreamingComponentFamilyState';
 import { currentAiChatThreadState } from '@/ai/states/currentAiChatThreadState';
@@ -29,12 +30,16 @@ export const SendMessageButton = ({
     agentChatIsStreamingComponentFamilyState,
     { threadId: currentAiChatThread },
   );
+  const agentChatIsAwaitingFirstChunk = useAtomComponentFamilyStateValue(
+    agentChatIsAwaitingFirstChunkComponentFamilyState,
+    { threadId: currentAiChatThread },
+  );
 
   const handleStopClick = () => {
     dispatchBrowserEvent(AGENT_CHAT_STOP_EVENT_NAME);
   };
 
-  if (agentChatIsStreaming) {
+  if (agentChatIsStreaming || agentChatIsAwaitingFirstChunk) {
     return (
       <RoundedIconButton
         Icon={IconPlayerStop}

--- a/packages/twenty-front/src/modules/ai/hooks/useAgentChat.ts
+++ b/packages/twenty-front/src/modules/ai/hooks/useAgentChat.ts
@@ -24,6 +24,7 @@ import {
 } from '@/ai/states/agentChatDraftsByThreadIdState';
 import { agentChatErrorComponentFamilyState } from '@/ai/states/agentChatErrorComponentFamilyState';
 import { agentChatInputState } from '@/ai/states/agentChatInputState';
+import { agentChatIsAwaitingFirstChunkComponentFamilyState } from '@/ai/states/agentChatIsAwaitingFirstChunkComponentFamilyState';
 import { agentChatLastSentBrowsingContextFamilyState } from '@/ai/states/agentChatLastSentBrowsingContextFamilyState';
 import { agentChatMessagesComponentFamilyState } from '@/ai/states/agentChatMessagesComponentFamilyState';
 import { agentChatSelectedFilesState } from '@/ai/states/agentChatSelectedFilesState';
@@ -145,11 +146,17 @@ export const useAgentChat = (
       instanceId: AGENT_CHAT_INSTANCE_ID,
       familyKey: { threadId },
     });
+    const isAwaitingFirstChunkAtom =
+      agentChatIsAwaitingFirstChunkComponentFamilyState.atomFamily({
+        instanceId: AGENT_CHAT_INSTANCE_ID,
+        familyKey: { threadId },
+      });
 
     const currentMessages = store.get(messagesAtom);
 
     store.set(messagesAtom, [...currentMessages, optimisticUserMessage]);
     store.set(errorAtom, null);
+    store.set(isAwaitingFirstChunkAtom, true);
 
     const fileAttachments = agentChatUploadedFiles.map((file) => ({
       id: file.fileId,
@@ -190,6 +197,7 @@ export const useAgentChat = (
           messagesAtom,
           latestMessages.filter((message) => message.id !== messageId),
         );
+        store.set(isAwaitingFirstChunkAtom, false);
       }
 
       dispatchBrowserEvent(AGENT_CHAT_REFETCH_MESSAGES_EVENT_NAME);
@@ -216,6 +224,7 @@ export const useAgentChat = (
         latestMessages.filter((message) => message.id !== messageId),
       );
 
+      store.set(isAwaitingFirstChunkAtom, false);
       store.set(
         errorAtom,
         CombinedGraphQLErrors.is(error) || error instanceof Error
@@ -254,6 +263,14 @@ export const useAgentChat = (
     if (!isDefined(threadId) || !isValidUuid(threadId)) {
       return;
     }
+
+    store.set(
+      agentChatIsAwaitingFirstChunkComponentFamilyState.atomFamily({
+        instanceId: AGENT_CHAT_INSTANCE_ID,
+        familyKey: { threadId },
+      }),
+      false,
+    );
 
     try {
       await apolloClient.mutate({

--- a/packages/twenty-front/src/modules/ai/hooks/useAgentChatSubscription.ts
+++ b/packages/twenty-front/src/modules/ai/hooks/useAgentChatSubscription.ts
@@ -15,6 +15,7 @@ import { ON_AGENT_CHAT_EVENT } from '@/ai/graphql/subscriptions/OnAgentChatEvent
 import { agentChatErrorComponentFamilyState } from '@/ai/states/agentChatErrorComponentFamilyState';
 import { agentChatFirstLiveSeqComponentFamilyState } from '@/ai/states/agentChatFirstLiveSeqComponentFamilyState';
 import { agentChatHandleEventCallbackComponentFamilyState } from '@/ai/states/agentChatHandleEventCallbackComponentFamilyState';
+import { agentChatIsAwaitingFirstChunkComponentFamilyState } from '@/ai/states/agentChatIsAwaitingFirstChunkComponentFamilyState';
 import { agentChatIsAwaitingPersistedRefetchComponentFamilyState } from '@/ai/states/agentChatIsAwaitingPersistedRefetchComponentFamilyState';
 import { agentChatIsStreamingComponentFamilyState } from '@/ai/states/agentChatIsStreamingComponentFamilyState';
 import { agentChatMessagesComponentFamilyState } from '@/ai/states/agentChatMessagesComponentFamilyState';
@@ -113,6 +114,10 @@ export const useAgentChatSubscription = (threadId: string | null) => {
   const isStreamingFamilyCallback = useAtomComponentFamilyStateCallbackState(
     agentChatIsStreamingComponentFamilyState,
   );
+  const isAwaitingFirstChunkFamilyCallback =
+    useAtomComponentFamilyStateCallbackState(
+      agentChatIsAwaitingFirstChunkComponentFamilyState,
+    );
   const firstLiveSeqFamilyCallback = useAtomComponentFamilyStateCallbackState(
     agentChatFirstLiveSeqComponentFamilyState,
   );
@@ -143,6 +148,8 @@ export const useAgentChatSubscription = (threadId: string | null) => {
 
     const errorAtom = errorFamilyCallback(familyKey);
     const isStreamingAtom = isStreamingFamilyCallback(familyKey);
+    const isAwaitingFirstChunkAtom =
+      isAwaitingFirstChunkFamilyCallback(familyKey);
     const firstLiveSeqAtom = firstLiveSeqFamilyCallback(familyKey);
     const isAwaitingPersistedRefetchAtom =
       isAwaitingPersistedRefetchFamilyCallback(familyKey);
@@ -318,6 +325,7 @@ export const useAgentChatSubscription = (threadId: string | null) => {
     const resetStreamProcessing = () => {
       chunkSequencer.reset();
       closeWriter();
+      store.set(isAwaitingFirstChunkAtom, false);
     };
 
     const handleEvent = (event: AgentChatSubscriptionEvent) => {
@@ -325,6 +333,10 @@ export const useAgentChatSubscription = (threadId: string | null) => {
         case 'stream-chunk': {
           if (isDefined(event.seq) && store.get(firstLiveSeqAtom) === null) {
             store.set(firstLiveSeqAtom, event.seq);
+          }
+
+          if (store.get(isAwaitingFirstChunkAtom)) {
+            store.set(isAwaitingFirstChunkAtom, false);
           }
 
           chunkSequencer.push(event.chunk as UIMessageChunk, event.seq);
@@ -436,6 +448,7 @@ export const useAgentChatSubscription = (threadId: string | null) => {
     return () => {
       disposed = true;
       chunkSequencer.reset();
+      store.set(isAwaitingFirstChunkAtom, false);
       store.set(handleEventCallbackAtom, null);
       if (isDefined(throttleTimer)) {
         clearTimeout(throttleTimer);
@@ -450,6 +463,7 @@ export const useAgentChatSubscription = (threadId: string | null) => {
     store,
     errorFamilyCallback,
     isStreamingFamilyCallback,
+    isAwaitingFirstChunkFamilyCallback,
     firstLiveSeqFamilyCallback,
     isAwaitingPersistedRefetchFamilyCallback,
     handleEventCallbackFamilyCallback,

--- a/packages/twenty-front/src/modules/ai/hooks/useAgentChatSubscription.ts
+++ b/packages/twenty-front/src/modules/ai/hooks/useAgentChatSubscription.ts
@@ -23,6 +23,8 @@ import { agentChatStreamResubscribeNonceState } from '@/ai/states/agentChatStrea
 import { agentChatUsageComponentFamilyState } from '@/ai/states/agentChatUsageComponentFamilyState';
 import { currentAiChatThreadTitleComponentFamilyState } from '@/ai/states/currentAiChatThreadTitleComponentFamilyState';
 import { AiChatErrorCode } from '@/ai/utils/aiChatErrorCode';
+import { createAiChatCodedError } from '@/ai/utils/createAiChatCodedError';
+import { createStreamChunkSequencer } from '@/ai/utils/createStreamChunkSequencer';
 import { currentWorkspaceState } from '@/auth/states/currentWorkspaceState';
 import { dispatchBrowserEvent } from '@/browser-event/utils/dispatchBrowserEvent';
 import { sseClientState } from '@/sse-db-event/states/sseClientState';
@@ -283,6 +285,41 @@ export const useAgentChatSubscription = (threadId: string | null) => {
       }
     };
 
+    const applyChunk = (chunk: UIMessageChunk) => {
+      if (!store.get(isStreamingAtom)) {
+        store.set(isStreamingAtom, true);
+        store.set(errorAtom, null);
+
+        bridge = new TransformStream<UIMessageChunk>();
+        writer = bridge.writable.getWriter();
+
+        const adaptedReadable = bridge.readable.pipeThrough(
+          createMidStreamAdapter(),
+        );
+
+        startReadLoop(adaptedReadable).catch(() => {
+          if (!disposed) {
+            store.set(isStreamingAtom, false);
+          }
+        });
+      }
+
+      if (isDefined(writer)) {
+        writer.write(chunk).catch(() => {});
+      }
+    };
+
+    const chunkSequencer = createStreamChunkSequencer({
+      onApply: applyChunk,
+      onGapStalled: () =>
+        dispatchBrowserEvent(AGENT_CHAT_REFETCH_MESSAGES_EVENT_NAME),
+    });
+
+    const resetStreamProcessing = () => {
+      chunkSequencer.reset();
+      closeWriter();
+    };
+
     const handleEvent = (event: AgentChatSubscriptionEvent) => {
       switch (event.type) {
         case 'stream-chunk': {
@@ -290,32 +327,12 @@ export const useAgentChatSubscription = (threadId: string | null) => {
             store.set(firstLiveSeqAtom, event.seq);
           }
 
-          if (!store.get(isStreamingAtom)) {
-            store.set(isStreamingAtom, true);
-            store.set(errorAtom, null);
-
-            bridge = new TransformStream<UIMessageChunk>();
-            writer = bridge.writable.getWriter();
-
-            const adaptedReadable = bridge.readable.pipeThrough(
-              createMidStreamAdapter(),
-            );
-
-            startReadLoop(adaptedReadable).catch(() => {
-              if (!disposed) {
-                store.set(isStreamingAtom, false);
-              }
-            });
-          }
-
-          if (isDefined(writer)) {
-            writer.write(event.chunk as UIMessageChunk).catch(() => {});
-          }
+          chunkSequencer.push(event.chunk as UIMessageChunk, event.seq);
           break;
         }
 
         case 'message-persisted': {
-          closeWriter();
+          resetStreamProcessing();
           store.set(isAwaitingPersistedRefetchAtom, true);
           dispatchBrowserEvent(AGENT_CHAT_REFETCH_MESSAGES_EVENT_NAME);
           break;
@@ -331,14 +348,12 @@ export const useAgentChatSubscription = (threadId: string | null) => {
         }
 
         case 'stream-error': {
-          const streamError = new Error(event.message) as Error & {
-            code?: string;
-          };
+          store.set(
+            errorAtom,
+            createAiChatCodedError(event.message, event.code),
+          );
 
-          streamError.code = event.code;
-          store.set(errorAtom, streamError);
-
-          closeWriter();
+          resetStreamProcessing();
           store.set(isStreamingAtom, false);
           break;
         }
@@ -373,14 +388,15 @@ export const useAgentChatSubscription = (threadId: string | null) => {
             };
           });
 
-          const noMoreCreditsError = new Error(
-            'Chat stopped: no more available credits.',
-          ) as Error & { code?: string };
+          store.set(
+            errorAtom,
+            createAiChatCodedError(
+              'Chat stopped: no more available credits.',
+              AiChatErrorCode.BILLING_CREDITS_EXHAUSTED,
+            ),
+          );
 
-          noMoreCreditsError.code = AiChatErrorCode.BILLING_CREDITS_EXHAUSTED;
-          store.set(errorAtom, noMoreCreditsError);
-
-          closeWriter();
+          resetStreamProcessing();
           store.set(isAwaitingPersistedRefetchAtom, true);
           dispatchBrowserEvent(AGENT_CHAT_REFETCH_MESSAGES_EVENT_NAME);
           store.set(isStreamingAtom, false);
@@ -419,6 +435,7 @@ export const useAgentChatSubscription = (threadId: string | null) => {
 
     return () => {
       disposed = true;
+      chunkSequencer.reset();
       store.set(handleEventCallbackAtom, null);
       if (isDefined(throttleTimer)) {
         clearTimeout(throttleTimer);

--- a/packages/twenty-front/src/modules/ai/hooks/useRetryChatMessage.ts
+++ b/packages/twenty-front/src/modules/ai/hooks/useRetryChatMessage.ts
@@ -9,6 +9,7 @@ import { RETRY_CHAT_MESSAGE } from '@/ai/graphql/mutations/retryChatMessage';
 import { useAgentChatModelId } from '@/ai/hooks/useAgentChatModelId';
 import { agentChatDisplayedThreadState } from '@/ai/states/agentChatDisplayedThreadState';
 import { agentChatErrorComponentFamilyState } from '@/ai/states/agentChatErrorComponentFamilyState';
+import { agentChatIsAwaitingFirstChunkComponentFamilyState } from '@/ai/states/agentChatIsAwaitingFirstChunkComponentFamilyState';
 import { dispatchBrowserEvent } from '@/browser-event/utils/dispatchBrowserEvent';
 
 export const useRetryChatMessage = () => {
@@ -27,9 +28,15 @@ export const useRetryChatMessage = () => {
       instanceId: AGENT_CHAT_INSTANCE_ID,
       familyKey: { threadId },
     });
+    const isAwaitingFirstChunkAtom =
+      agentChatIsAwaitingFirstChunkComponentFamilyState.atomFamily({
+        instanceId: AGENT_CHAT_INSTANCE_ID,
+        familyKey: { threadId },
+      });
     const previousError = store.get(errorAtom);
 
     store.set(errorAtom, null);
+    store.set(isAwaitingFirstChunkAtom, true);
 
     try {
       await apolloClient.mutate({
@@ -42,6 +49,7 @@ export const useRetryChatMessage = () => {
 
       dispatchBrowserEvent(AGENT_CHAT_REFETCH_MESSAGES_EVENT_NAME);
     } catch (retryError) {
+      store.set(isAwaitingFirstChunkAtom, false);
       store.set(
         errorAtom,
         retryError instanceof Error ? retryError : previousError,

--- a/packages/twenty-front/src/modules/ai/hooks/useSubmitQuestionAnswer.ts
+++ b/packages/twenty-front/src/modules/ai/hooks/useSubmitQuestionAnswer.ts
@@ -10,6 +10,7 @@ import { AGENT_CHAT_REFETCH_MESSAGES_EVENT_NAME } from '@/ai/constants/AgentChat
 import { ANSWER_AGENT_CHAT_QUESTION } from '@/ai/graphql/mutations/answerAgentChatQuestion';
 import { useAgentChatModelId } from '@/ai/hooks/useAgentChatModelId';
 import { agentChatDisplayedThreadState } from '@/ai/states/agentChatDisplayedThreadState';
+import { agentChatIsAwaitingFirstChunkComponentFamilyState } from '@/ai/states/agentChatIsAwaitingFirstChunkComponentFamilyState';
 import { agentChatMessagesComponentFamilyState } from '@/ai/states/agentChatMessagesComponentFamilyState';
 import { markQuestionAnswered } from '@/ai/utils/markQuestionAnswered';
 import { markQuestionPending } from '@/ai/utils/markQuestionPending';
@@ -42,12 +43,18 @@ export const useSubmitQuestionAnswer = () => {
         instanceId: AGENT_CHAT_INSTANCE_ID,
         familyKey: { threadId },
       });
+      const isAwaitingFirstChunkAtom =
+        agentChatIsAwaitingFirstChunkComponentFamilyState.atomFamily({
+          instanceId: AGENT_CHAT_INSTANCE_ID,
+          familyKey: { threadId },
+        });
       const previousMessages = store.get(messagesAtom);
 
       store.set(
         messagesAtom,
         markQuestionAnswered(previousMessages, messageId, toolCallId, answers),
       );
+      store.set(isAwaitingFirstChunkAtom, true);
 
       try {
         await apolloClient.mutate({
@@ -64,6 +71,7 @@ export const useSubmitQuestionAnswer = () => {
       } catch (error) {
         const currentMessages = store.get(messagesAtom);
 
+        store.set(isAwaitingFirstChunkAtom, false);
         store.set(
           messagesAtom,
           markQuestionPending(currentMessages, messageId, toolCallId),

--- a/packages/twenty-front/src/modules/ai/states/agentChatIsAwaitingFirstChunkComponentFamilyState.ts
+++ b/packages/twenty-front/src/modules/ai/states/agentChatIsAwaitingFirstChunkComponentFamilyState.ts
@@ -1,0 +1,9 @@
+import { AgentChatComponentInstanceContext } from '@/ai/contexts/AgentChatComponentInstanceContext';
+import { createAtomComponentFamilyState } from '@/ui/utilities/state/jotai/utils/createAtomComponentFamilyState';
+
+export const agentChatIsAwaitingFirstChunkComponentFamilyState =
+  createAtomComponentFamilyState<boolean, { threadId: string | null }>({
+    key: 'agentChatIsAwaitingFirstChunkComponentFamilyState',
+    defaultValue: false,
+    componentInstanceContext: AgentChatComponentInstanceContext,
+  });

--- a/packages/twenty-front/src/modules/ai/utils/__tests__/createStreamChunkSequencer.test.ts
+++ b/packages/twenty-front/src/modules/ai/utils/__tests__/createStreamChunkSequencer.test.ts
@@ -1,0 +1,123 @@
+import { type UIMessageChunk } from 'ai';
+
+import { createStreamChunkSequencer } from '@/ai/utils/createStreamChunkSequencer';
+
+const chunk = (text: string) =>
+  ({ type: 'text-delta', id: 'text-1', delta: text }) as UIMessageChunk;
+
+describe('createStreamChunkSequencer', () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  const build = () => {
+    const applied: string[] = [];
+    const onGapStalled = jest.fn();
+    const sequencer = createStreamChunkSequencer({
+      onApply: (appliedChunk) =>
+        applied.push((appliedChunk as { delta: string }).delta),
+      onGapStalled,
+    });
+
+    return { sequencer, applied, onGapStalled };
+  };
+
+  it('applies in-order chunks immediately', () => {
+    const { sequencer, applied } = build();
+
+    sequencer.push(chunk('a'), 1);
+    sequencer.push(chunk('b'), 2);
+
+    expect(applied).toEqual(['a', 'b']);
+  });
+
+  it('buffers early arrivals until the gap is filled, then drains in order', () => {
+    const { sequencer, applied } = build();
+
+    sequencer.push(chunk('c'), 3);
+    sequencer.push(chunk('d'), 4);
+    expect(applied).toEqual([]);
+
+    sequencer.push(chunk('a'), 1);
+    sequencer.push(chunk('b'), 2);
+
+    expect(applied).toEqual(['a', 'b', 'c', 'd']);
+  });
+
+  it('drops duplicates from overlapping catchup replay', () => {
+    const { sequencer, applied } = build();
+
+    sequencer.push(chunk('a'), 1);
+    sequencer.push(chunk('b'), 2);
+    sequencer.push(chunk('a'), 1);
+    sequencer.push(chunk('b'), 2);
+    sequencer.push(chunk('c'), 3);
+
+    expect(applied).toEqual(['a', 'b', 'c']);
+  });
+
+  it('signals a stalled gap once so the caller can refetch', () => {
+    const { sequencer, applied, onGapStalled } = build();
+
+    sequencer.push(chunk('e'), 5);
+    expect(onGapStalled).not.toHaveBeenCalled();
+
+    jest.advanceTimersByTime(2_100);
+    expect(onGapStalled).toHaveBeenCalledTimes(1);
+    expect(applied).toEqual([]);
+
+    [1, 2, 3, 4].forEach((seq) => sequencer.push(chunk(`s${seq}`), seq));
+    expect(applied).toEqual(['s1', 's2', 's3', 's4', 'e']);
+  });
+
+  it('does not signal a gap that got filled before the stall timeout', () => {
+    const { sequencer, onGapStalled } = build();
+
+    sequencer.push(chunk('b'), 2);
+    sequencer.push(chunk('a'), 1);
+
+    jest.advanceTimersByTime(3_000);
+    expect(onGapStalled).not.toHaveBeenCalled();
+  });
+
+  it('starts a fresh epoch after reset so the next turn applies from seq 1', () => {
+    const { sequencer, applied } = build();
+
+    sequencer.push(chunk('a'), 1);
+    sequencer.push(chunk('b'), 2);
+    sequencer.reset();
+
+    sequencer.push(chunk('x'), 1);
+    expect(applied).toEqual(['a', 'b', 'x']);
+  });
+
+  it('degrades to an in-order flush when the gap survives a second stall', () => {
+    const { sequencer, applied, onGapStalled } = build();
+
+    sequencer.push(chunk('d'), 4);
+    sequencer.push(chunk('c'), 3);
+
+    jest.advanceTimersByTime(2_100);
+    expect(onGapStalled).toHaveBeenCalledTimes(1);
+    expect(applied).toEqual([]);
+
+    jest.advanceTimersByTime(2_100);
+    expect(applied).toEqual(['c', 'd']);
+
+    sequencer.push(chunk('e'), 5);
+    expect(applied).toEqual(['c', 'd', 'e']);
+  });
+
+  it('applies seq-less chunks immediately without affecting ordering', () => {
+    const { sequencer, applied } = build();
+
+    sequencer.push(chunk('legacy'), undefined);
+    sequencer.push(chunk('a'), 1);
+
+    expect(applied).toEqual(['legacy', 'a']);
+  });
+});

--- a/packages/twenty-front/src/modules/ai/utils/createAiChatCodedError.ts
+++ b/packages/twenty-front/src/modules/ai/utils/createAiChatCodedError.ts
@@ -1,0 +1,10 @@
+export const createAiChatCodedError = (
+  message: string,
+  code: string,
+): Error & { code?: string } => {
+  const codedError = new Error(message) as Error & { code?: string };
+
+  codedError.code = code;
+
+  return codedError;
+};

--- a/packages/twenty-front/src/modules/ai/utils/createStreamChunkSequencer.ts
+++ b/packages/twenty-front/src/modules/ai/utils/createStreamChunkSequencer.ts
@@ -1,0 +1,122 @@
+import { type UIMessageChunk } from 'ai';
+
+type StreamChunkSequencer = {
+  push: (chunk: UIMessageChunk, seq: number | undefined) => void;
+  reset: () => void;
+};
+
+const GAP_STALL_TIMEOUT_IN_MS = 2_000;
+
+export const createStreamChunkSequencer = ({
+  onApply,
+  onGapStalled,
+  gapStallTimeoutInMs = GAP_STALL_TIMEOUT_IN_MS,
+}: {
+  onApply: (chunk: UIMessageChunk) => void;
+  onGapStalled: () => void;
+  gapStallTimeoutInMs?: number;
+}): StreamChunkSequencer => {
+  let lastAppliedSeq = 0;
+  let gapStallCount = 0;
+  const pendingBySeq = new Map<number, UIMessageChunk>();
+  let gapTimer: ReturnType<typeof setTimeout> | null = null;
+
+  const clearGapTimer = () => {
+    if (gapTimer !== null) {
+      clearTimeout(gapTimer);
+      gapTimer = null;
+    }
+  };
+
+  const drainPending = () => {
+    let nextChunk = pendingBySeq.get(lastAppliedSeq + 1);
+
+    while (nextChunk !== undefined) {
+      pendingBySeq.delete(lastAppliedSeq + 1);
+      lastAppliedSeq += 1;
+      onApply(nextChunk);
+      nextChunk = pendingBySeq.get(lastAppliedSeq + 1);
+    }
+
+    if (pendingBySeq.size === 0) {
+      clearGapTimer();
+      gapStallCount = 0;
+    }
+  };
+
+  const flushPending = () => {
+    const orderedSeqs = [...pendingBySeq.keys()].sort(
+      (seqA, seqB) => seqA - seqB,
+    );
+
+    for (const seq of orderedSeqs) {
+      const pendingChunk = pendingBySeq.get(seq);
+
+      pendingBySeq.delete(seq);
+      lastAppliedSeq = seq;
+
+      if (pendingChunk !== undefined) {
+        onApply(pendingChunk);
+      }
+    }
+
+    clearGapTimer();
+    gapStallCount = 0;
+  };
+
+  const handleGapStall = () => {
+    gapTimer = null;
+
+    if (pendingBySeq.size === 0) {
+      return;
+    }
+
+    gapStallCount += 1;
+
+    if (gapStallCount === 1) {
+      onGapStalled();
+      armGapTimer();
+
+      return;
+    }
+
+    flushPending();
+  };
+
+  const armGapTimer = () => {
+    if (gapTimer === null) {
+      gapTimer = setTimeout(handleGapStall, gapStallTimeoutInMs);
+    }
+  };
+
+  return {
+    push: (chunk, seq) => {
+      if (seq === undefined) {
+        onApply(chunk);
+
+        return;
+      }
+
+      if (seq <= lastAppliedSeq) {
+        return;
+      }
+
+      if (seq === lastAppliedSeq + 1) {
+        lastAppliedSeq = seq;
+        onApply(chunk);
+        drainPending();
+
+        return;
+      }
+
+      pendingBySeq.set(seq, chunk);
+      armGapTimer();
+    },
+    reset: () => {
+      lastAppliedSeq = 0;
+      gapStallCount = 0;
+      pendingBySeq.clear();
+      clearGapTimer();
+    },
+  };
+};


### PR DESCRIPTION
## Rationale

Stream chunks reach the client on two unsynchronized paths: live SSE events and the catchup replay (fired on reload, refetch, SSE reconnect, and keep-alive recovery). The server already stamps every chunk with an authoritative `seq` (Redis `RPUSH` length), but the client applies chunks in **arrival order**. Reload mid-stream and the two paths interleave: duplicated text deltas, or lower-seq catchup chunks applied after higher-seq live ones — the streaming answer visibly garbles until the persist-refetch repaints it.

Main's existing guard (`seq < firstLiveSeq` bound on catchup) only prevents duplication in one direction (live-before-catchup); it does nothing for catchup-during-live overlap, and it *creates* a dropped-chunk window when chunks land between the catchup snapshot and the first live event.

## Why this is the root cause, not a symptom patch

The defect is a joining problem between two ordered sources, and the join point is the client — the server can't fix it without a protocol change (per-subscriber cursor resume), because Redis pub/sub fan-out has no per-subscriber replay. Given the transport, the correct fix is to make the reducer's input **seq-exact**: apply strictly in server order, dedup anything already applied, buffer early arrivals until the gap fills. Escalation is bounded and degrades gracefully: a stalled gap triggers one refetch (the full-list catchup replay doubles as gap-fill, no new endpoint), a second stall flushes the buffer in order — so even an expired chunk list degrades to slightly-lossy instead of wedging. The catchup path now replays the full list (the sequencer dedups overlap), which also closes the dropped-chunk window.

Server-side cursor resume remains the nicer long-term protocol (would simplify this client), but it's a subscription protocol change; this fixes the user-facing defect with zero server change and is forward-compatible with it.

## User impact

Reloading (or losing the connection) mid-answer currently scrambles or duplicates the streaming text until the turn completes. With this, the answer renders identically no matter when you reload or how the two delivery paths race.

## Test plan

- [x] Sequencer unit suite (fake timers): in-order apply, out-of-order buffering, catchup/live overlap dedup, gap-fill via replay, stall→refetch escalation, second-stall in-order flush, high-water-mark continuation, reset
- [ ] CI green
- [ ] Manual: reload mid-stream repeatedly; text never reorders

https://claude.ai/code/session_01Lyi6zTema2FMVVh8MD6c38

---
_Generated by [Claude Code](https://claude.ai/code/session_01Lyi6zTema2FMVVh8MD6c38)_

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/22484?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

