### PR TITLE
feat(ai): show a pending-response indicator and enable Stop before the first streamed chunk

### DIFF
--- a/packages/twenty-front/src/modules/ai/components/AgentChatStreamSubscriptionEffect.tsx
+++ b/packages/twenty-front/src/modules/ai/components/AgentChatStreamSubscriptionEffect.tsx
@@ -9,6 +9,7 @@ import { useEnsureAgentChatThreadExistsForDraft } from '@/ai/hooks/useEnsureAgen
 import { useEnsureAgentChatThreadIdForSend } from '@/ai/hooks/useEnsureAgentChatThreadIdForSend';
 import { agentChatDisplayedThreadState } from '@/ai/states/agentChatDisplayedThreadState';
 import { agentChatFetchedMessagesComponentFamilyState } from '@/ai/states/agentChatFetchedMessagesComponentFamilyState';
+import { agentChatIsAwaitingFirstChunkComponentFamilyState } from '@/ai/states/agentChatIsAwaitingFirstChunkComponentFamilyState';
 import { agentChatIsAwaitingPersistedRefetchComponentFamilyState } from '@/ai/states/agentChatIsAwaitingPersistedRefetchComponentFamilyState';
 import { agentChatIsInitialScrollPendingOnThreadChangeState } from '@/ai/states/agentChatIsInitialScrollPendingOnThreadChangeState';
 import { agentChatIsLoadingState } from '@/ai/states/agentChatIsLoadingState';
@@ -68,6 +69,11 @@ export const AgentChatStreamSubscriptionEffect = () => {
     { threadId: currentAiChatThread },
   );
 
+  const agentChatIsAwaitingFirstChunk = useAtomComponentFamilyStateValue(
+    agentChatIsAwaitingFirstChunkComponentFamilyState,
+    { threadId: currentAiChatThread },
+  );
+
   const agentChatDisplayedThread = useAtomStateValue(
     agentChatDisplayedThreadState,
   );
@@ -87,7 +93,16 @@ export const AgentChatStreamSubscriptionEffect = () => {
 
     const isThreadSwitch = currentAiChatThread !== agentChatDisplayedThread;
 
-    if (!isThreadSwitch && agentChatIsAwaitingPersistedRefetch) {
+    if (
+      !isThreadSwitch &&
+      (agentChatIsAwaitingPersistedRefetch || agentChatIsAwaitingFirstChunk)
+    ) {
+      return;
+    }
+
+    if (isThreadSwitch && agentChatIsAwaitingFirstChunk) {
+      setAgentChatDisplayedThread(currentAiChatThread);
+
       return;
     }
 
@@ -103,6 +118,7 @@ export const AgentChatStreamSubscriptionEffect = () => {
     agentChatFetchedMessages,
     agentChatIsStreaming,
     agentChatIsAwaitingPersistedRefetch,
+    agentChatIsAwaitingFirstChunk,
     setAgentChatMessages,
     currentAiChatThread,
     agentChatDisplayedThread,

--- a/packages/twenty-front/src/modules/ai/components/AgentChatStreamSubscriptionEffect.tsx
+++ b/packages/twenty-front/src/modules/ai/components/AgentChatStreamSubscriptionEffect.tsx
@@ -101,6 +101,9 @@ export const AgentChatStreamSubscriptionEffect = () => {
     }
 
     if (isThreadSwitch && agentChatIsAwaitingFirstChunk) {
+      if (agentChatFetchedMessages.length > 0) {
+        setAgentChatIsInitialScrollPendingOnThreadChange(true);
+      }
       setAgentChatDisplayedThread(currentAiChatThread);
 
       return;

--- a/packages/twenty-front/src/modules/ai/components/AiChatAssistantMessageRenderer.tsx
+++ b/packages/twenty-front/src/modules/ai/components/AiChatAssistantMessageRenderer.tsx
@@ -1,8 +1,8 @@
 import { AiChatCompactionIndicator } from '@/ai/components/AiChatCompactionIndicator';
+import { AiChatInitialLoadingIndicator } from '@/ai/components/AiChatInitialLoadingIndicator';
 import { CodeExecutionDisplay } from '@/ai/components/CodeExecutionDisplay';
 import { RoutingStatusDisplay } from '@/ai/components/RoutingStatusDisplay';
 import { ThinkingStepsDisplay } from '@/ai/components/ThinkingStepsDisplay';
-import { IconDotsVertical } from 'twenty-ui/icon';
 
 import { AiChatQuestionStatusRenderer } from '@/ai/components/AiChatQuestionStatusRenderer';
 import { LazyMarkdownRenderer } from '@/ai/components/LazyMarkdownRenderer';
@@ -15,41 +15,13 @@ import {
   ASK_QUESTIONS_TOOL_NAME,
   type ExtendedUIMessagePart,
 } from 'twenty-shared/ai';
-import { useContext } from 'react';
-import { ThemeContext, themeCssVariables } from 'twenty-ui/theme-constants';
+import { themeCssVariables } from 'twenty-ui/theme-constants';
 
 const StyledMessagePartsContainer = styled.div`
   display: flex;
   flex-direction: column;
   gap: ${themeCssVariables.spacing[1]};
 `;
-
-const StyledLoadingIconContainer = styled.div`
-  align-items: center;
-  border: 1px solid ${themeCssVariables.border.color.light};
-  border-radius: ${themeCssVariables.border.radius.md};
-  display: flex;
-  justify-content: center;
-  padding-inline: ${themeCssVariables.spacing[1]};
-`;
-
-const StyledLoadingIconWrapper = styled.span`
-  color: ${themeCssVariables.font.color.light};
-  display: flex;
-  transform: rotate(90deg);
-`;
-
-const InitialLoadingIndicator = () => {
-  const { theme } = useContext(ThemeContext);
-
-  return (
-    <StyledLoadingIconContainer>
-      <StyledLoadingIconWrapper>
-        <IconDotsVertical size={theme.icon.size.xl} />
-      </StyledLoadingIconWrapper>
-    </StyledLoadingIconContainer>
-  );
-};
 
 const MessagePartRenderer = ({
   part,
@@ -115,7 +87,7 @@ export const AiChatAssistantMessageRenderer = ({
   const renderItems = groupContiguousThinkingStepParts(filteredParts);
 
   if (!renderItems.length && !hasError) {
-    return <InitialLoadingIndicator />;
+    return <AiChatInitialLoadingIndicator />;
   }
 
   return (

--- a/packages/twenty-front/src/modules/ai/components/AiChatInitialLoadingIndicator.tsx
+++ b/packages/twenty-front/src/modules/ai/components/AiChatInitialLoadingIndicator.tsx
@@ -1,0 +1,31 @@
+import { styled } from '@linaria/react';
+import { useContext } from 'react';
+import { IconDotsVertical } from 'twenty-ui/icon';
+import { ThemeContext, themeCssVariables } from 'twenty-ui/theme-constants';
+
+const StyledLoadingIconContainer = styled.div`
+  align-items: center;
+  border: 1px solid ${themeCssVariables.border.color.light};
+  border-radius: ${themeCssVariables.border.radius.md};
+  display: flex;
+  justify-content: center;
+  padding-inline: ${themeCssVariables.spacing[1]};
+`;
+
+const StyledLoadingIconWrapper = styled.span`
+  color: ${themeCssVariables.font.color.light};
+  display: flex;
+  transform: rotate(90deg);
+`;
+
+export const AiChatInitialLoadingIndicator = () => {
+  const { theme } = useContext(ThemeContext);
+
+  return (
+    <StyledLoadingIconContainer>
+      <StyledLoadingIconWrapper>
+        <IconDotsVertical size={theme.icon.size.xl} />
+      </StyledLoadingIconWrapper>
+    </StyledLoadingIconContainer>
+  );
+};

--- a/packages/twenty-front/src/modules/ai/components/AiChatPendingResponseIndicator.tsx
+++ b/packages/twenty-front/src/modules/ai/components/AiChatPendingResponseIndicator.tsx
@@ -1,0 +1,49 @@
+import { styled } from '@linaria/react';
+import { isDefined } from 'twenty-shared/utils';
+
+import { AiChatInitialLoadingIndicator } from '@/ai/components/AiChatInitialLoadingIndicator';
+import { agentChatDisplayedThreadState } from '@/ai/states/agentChatDisplayedThreadState';
+import { agentChatErrorComponentFamilyState } from '@/ai/states/agentChatErrorComponentFamilyState';
+import { agentChatIsAwaitingFirstChunkComponentFamilyState } from '@/ai/states/agentChatIsAwaitingFirstChunkComponentFamilyState';
+import { agentChatIsStreamingComponentFamilyState } from '@/ai/states/agentChatIsStreamingComponentFamilyState';
+import { useAtomComponentFamilyStateValue } from '@/ui/utilities/state/jotai/hooks/useAtomComponentFamilyStateValue';
+import { useAtomStateValue } from '@/ui/utilities/state/jotai/hooks/useAtomStateValue';
+
+const StyledPendingResponseWrapper = styled.div`
+  align-items: flex-start;
+  display: flex;
+  width: 100%;
+`;
+
+export const AiChatPendingResponseIndicator = () => {
+  const agentChatDisplayedThread = useAtomStateValue(
+    agentChatDisplayedThreadState,
+  );
+  const agentChatIsAwaitingFirstChunk = useAtomComponentFamilyStateValue(
+    agentChatIsAwaitingFirstChunkComponentFamilyState,
+    { threadId: agentChatDisplayedThread },
+  );
+  const agentChatIsStreaming = useAtomComponentFamilyStateValue(
+    agentChatIsStreamingComponentFamilyState,
+    { threadId: agentChatDisplayedThread },
+  );
+  const agentChatError = useAtomComponentFamilyStateValue(
+    agentChatErrorComponentFamilyState,
+    { threadId: agentChatDisplayedThread },
+  );
+
+  const shouldRender =
+    agentChatIsAwaitingFirstChunk &&
+    !agentChatIsStreaming &&
+    !isDefined(agentChatError);
+
+  if (!shouldRender) {
+    return null;
+  }
+
+  return (
+    <StyledPendingResponseWrapper>
+      <AiChatInitialLoadingIndicator />
+    </StyledPendingResponseWrapper>
+  );
+};

--- a/packages/twenty-front/src/modules/ai/components/AiChatTabMessageList.tsx
+++ b/packages/twenty-front/src/modules/ai/components/AiChatTabMessageList.tsx
@@ -1,6 +1,7 @@
 import { AiChatErrorUnderMessageList } from '@/ai/components/AiChatErrorUnderMessageList';
 import { AiChatLastMessageWithStreamingState } from '@/ai/components/AiChatLastMessageWithStreamingState';
 import { AiChatNonLastMessageIdsList } from '@/ai/components/AiChatNonLastMessageIdsList';
+import { AiChatPendingResponseIndicator } from '@/ai/components/AiChatPendingResponseIndicator';
 import { AiChatScrollToBottomButton } from '@/ai/components/AiChatScrollToBottomButton';
 import { AgentChatScrollToBottomOnDisplayedThreadChangeLayoutEffect } from '@/ai/components/AgentChatScrollToBottomOnDisplayedThreadChangeLayoutEffect';
 import { AgentChatScrollToBottomOnMountLayoutEffect } from '@/ai/components/AgentChatScrollToBottomOnMountLayoutEffect';
@@ -54,6 +55,7 @@ export const AiChatTabMessageList = () => {
         <StyledMessageListContent>
           <AiChatNonLastMessageIdsList />
           <AiChatLastMessageWithStreamingState />
+          <AiChatPendingResponseIndicator />
           <AiChatErrorUnderMessageList />
         </StyledMessageListContent>
         <AgentChatScrollToBottomOnDisplayedThreadChangeLayoutEffect />

--- a/packages/twenty-front/src/modules/ai/components/internal/SendMessageButton.tsx
+++ b/packages/twenty-front/src/modules/ai/components/internal/SendMessageButton.tsx
@@ -1,5 +1,6 @@
 import { AGENT_CHAT_STOP_EVENT_NAME } from '@/ai/constants/AgentChatStopEventName';
 import { agentChatInputIsEmptySelector } from '@/ai/states/selectors/agentChatInputIsEmptySelector';
+import { agentChatIsAwaitingFirstChunkComponentFamilyState } from '@/ai/states/agentChatIsAwaitingFirstChunkComponentFamilyState';
 import { agentChatIsLoadingState } from '@/ai/states/agentChatIsLoadingState';
 import { agentChatIsStreamingComponentFamilyState } from '@/ai/states/agentChatIsStreamingComponentFamilyState';
 import { currentAiChatThreadState } from '@/ai/states/currentAiChatThreadState';
@@ -29,12 +30,16 @@ export const SendMessageButton = ({
     agentChatIsStreamingComponentFamilyState,
     { threadId: currentAiChatThread },
   );
+  const agentChatIsAwaitingFirstChunk = useAtomComponentFamilyStateValue(
+    agentChatIsAwaitingFirstChunkComponentFamilyState,
+    { threadId: currentAiChatThread },
+  );
 
   const handleStopClick = () => {
     dispatchBrowserEvent(AGENT_CHAT_STOP_EVENT_NAME);
   };
 
-  if (agentChatIsStreaming) {
+  if (agentChatIsStreaming || agentChatIsAwaitingFirstChunk) {
     return (
       <RoundedIconButton
         Icon={IconPlayerStop}

--- a/packages/twenty-front/src/modules/ai/hooks/useAgentChat.ts
+++ b/packages/twenty-front/src/modules/ai/hooks/useAgentChat.ts
@@ -24,6 +24,7 @@ import {
 } from '@/ai/states/agentChatDraftsByThreadIdState';
 import { agentChatErrorComponentFamilyState } from '@/ai/states/agentChatErrorComponentFamilyState';
 import { agentChatInputState } from '@/ai/states/agentChatInputState';
+import { agentChatIsAwaitingFirstChunkComponentFamilyState } from '@/ai/states/agentChatIsAwaitingFirstChunkComponentFamilyState';
 import { agentChatLastSentBrowsingContextFamilyState } from '@/ai/states/agentChatLastSentBrowsingContextFamilyState';
 import { agentChatMessagesComponentFamilyState } from '@/ai/states/agentChatMessagesComponentFamilyState';
 import { agentChatSelectedFilesState } from '@/ai/states/agentChatSelectedFilesState';
@@ -145,11 +146,17 @@ export const useAgentChat = (
       instanceId: AGENT_CHAT_INSTANCE_ID,
       familyKey: { threadId },
     });
+    const isAwaitingFirstChunkAtom =
+      agentChatIsAwaitingFirstChunkComponentFamilyState.atomFamily({
+        instanceId: AGENT_CHAT_INSTANCE_ID,
+        familyKey: { threadId },
+      });
 
     const currentMessages = store.get(messagesAtom);
 
     store.set(messagesAtom, [...currentMessages, optimisticUserMessage]);
     store.set(errorAtom, null);
+    store.set(isAwaitingFirstChunkAtom, true);
 
     const fileAttachments = agentChatUploadedFiles.map((file) => ({
       id: file.fileId,
@@ -190,6 +197,7 @@ export const useAgentChat = (
           messagesAtom,
           latestMessages.filter((message) => message.id !== messageId),
         );
+        store.set(isAwaitingFirstChunkAtom, false);
       }
 
       dispatchBrowserEvent(AGENT_CHAT_REFETCH_MESSAGES_EVENT_NAME);
@@ -216,6 +224,7 @@ export const useAgentChat = (
         latestMessages.filter((message) => message.id !== messageId),
       );
 
+      store.set(isAwaitingFirstChunkAtom, false);
       store.set(
         errorAtom,
         CombinedGraphQLErrors.is(error) || error instanceof Error
@@ -254,6 +263,14 @@ export const useAgentChat = (
     if (!isDefined(threadId) || !isValidUuid(threadId)) {
       return;
     }
+
+    store.set(
+      agentChatIsAwaitingFirstChunkComponentFamilyState.atomFamily({
+        instanceId: AGENT_CHAT_INSTANCE_ID,
+        familyKey: { threadId },
+      }),
+      false,
+    );
 
     try {
       await apolloClient.mutate({

--- a/packages/twenty-front/src/modules/ai/hooks/useAgentChatSubscription.ts
+++ b/packages/twenty-front/src/modules/ai/hooks/useAgentChatSubscription.ts
@@ -15,6 +15,7 @@ import { ON_AGENT_CHAT_EVENT } from '@/ai/graphql/subscriptions/OnAgentChatEvent
 import { agentChatErrorComponentFamilyState } from '@/ai/states/agentChatErrorComponentFamilyState';
 import { agentChatFirstLiveSeqComponentFamilyState } from '@/ai/states/agentChatFirstLiveSeqComponentFamilyState';
 import { agentChatHandleEventCallbackComponentFamilyState } from '@/ai/states/agentChatHandleEventCallbackComponentFamilyState';
+import { agentChatIsAwaitingFirstChunkComponentFamilyState } from '@/ai/states/agentChatIsAwaitingFirstChunkComponentFamilyState';
 import { agentChatIsAwaitingPersistedRefetchComponentFamilyState } from '@/ai/states/agentChatIsAwaitingPersistedRefetchComponentFamilyState';
 import { agentChatIsStreamingComponentFamilyState } from '@/ai/states/agentChatIsStreamingComponentFamilyState';
 import { agentChatMessagesComponentFamilyState } from '@/ai/states/agentChatMessagesComponentFamilyState';
@@ -113,6 +114,10 @@ export const useAgentChatSubscription = (threadId: string | null) => {
   const isStreamingFamilyCallback = useAtomComponentFamilyStateCallbackState(
     agentChatIsStreamingComponentFamilyState,
   );
+  const isAwaitingFirstChunkFamilyCallback =
+    useAtomComponentFamilyStateCallbackState(
+      agentChatIsAwaitingFirstChunkComponentFamilyState,
+    );
   const firstLiveSeqFamilyCallback = useAtomComponentFamilyStateCallbackState(
     agentChatFirstLiveSeqComponentFamilyState,
   );
@@ -143,6 +148,8 @@ export const useAgentChatSubscription = (threadId: string | null) => {
 
     const errorAtom = errorFamilyCallback(familyKey);
     const isStreamingAtom = isStreamingFamilyCallback(familyKey);
+    const isAwaitingFirstChunkAtom =
+      isAwaitingFirstChunkFamilyCallback(familyKey);
     const firstLiveSeqAtom = firstLiveSeqFamilyCallback(familyKey);
     const isAwaitingPersistedRefetchAtom =
       isAwaitingPersistedRefetchFamilyCallback(familyKey);
@@ -318,6 +325,7 @@ export const useAgentChatSubscription = (threadId: string | null) => {
     const resetStreamProcessing = () => {
       chunkSequencer.reset();
       closeWriter();
+      store.set(isAwaitingFirstChunkAtom, false);
     };
 
     const handleEvent = (event: AgentChatSubscriptionEvent) => {
@@ -325,6 +333,10 @@ export const useAgentChatSubscription = (threadId: string | null) => {
         case 'stream-chunk': {
           if (isDefined(event.seq) && store.get(firstLiveSeqAtom) === null) {
             store.set(firstLiveSeqAtom, event.seq);
+          }
+
+          if (store.get(isAwaitingFirstChunkAtom)) {
+            store.set(isAwaitingFirstChunkAtom, false);
           }
 
           chunkSequencer.push(event.chunk as UIMessageChunk, event.seq);
@@ -450,6 +462,7 @@ export const useAgentChatSubscription = (threadId: string | null) => {
     store,
     errorFamilyCallback,
     isStreamingFamilyCallback,
+    isAwaitingFirstChunkFamilyCallback,
     firstLiveSeqFamilyCallback,
     isAwaitingPersistedRefetchFamilyCallback,
     handleEventCallbackFamilyCallback,

--- a/packages/twenty-front/src/modules/ai/hooks/useAgentChatSubscription.ts
+++ b/packages/twenty-front/src/modules/ai/hooks/useAgentChatSubscription.ts
@@ -448,6 +448,7 @@ export const useAgentChatSubscription = (threadId: string | null) => {
     return () => {
       disposed = true;
       chunkSequencer.reset();
+      store.set(isAwaitingFirstChunkAtom, false);
       store.set(handleEventCallbackAtom, null);
       if (isDefined(throttleTimer)) {
         clearTimeout(throttleTimer);

--- a/packages/twenty-front/src/modules/ai/hooks/useRetryChatMessage.ts
+++ b/packages/twenty-front/src/modules/ai/hooks/useRetryChatMessage.ts
@@ -9,6 +9,7 @@ import { RETRY_CHAT_MESSAGE } from '@/ai/graphql/mutations/retryChatMessage';
 import { useAgentChatModelId } from '@/ai/hooks/useAgentChatModelId';
 import { agentChatDisplayedThreadState } from '@/ai/states/agentChatDisplayedThreadState';
 import { agentChatErrorComponentFamilyState } from '@/ai/states/agentChatErrorComponentFamilyState';
+import { agentChatIsAwaitingFirstChunkComponentFamilyState } from '@/ai/states/agentChatIsAwaitingFirstChunkComponentFamilyState';
 import { dispatchBrowserEvent } from '@/browser-event/utils/dispatchBrowserEvent';
 
 export const useRetryChatMessage = () => {
@@ -27,9 +28,15 @@ export const useRetryChatMessage = () => {
       instanceId: AGENT_CHAT_INSTANCE_ID,
       familyKey: { threadId },
     });
+    const isAwaitingFirstChunkAtom =
+      agentChatIsAwaitingFirstChunkComponentFamilyState.atomFamily({
+        instanceId: AGENT_CHAT_INSTANCE_ID,
+        familyKey: { threadId },
+      });
     const previousError = store.get(errorAtom);
 
     store.set(errorAtom, null);
+    store.set(isAwaitingFirstChunkAtom, true);
 
     try {
       await apolloClient.mutate({
@@ -42,6 +49,7 @@ export const useRetryChatMessage = () => {
 
       dispatchBrowserEvent(AGENT_CHAT_REFETCH_MESSAGES_EVENT_NAME);
     } catch (retryError) {
+      store.set(isAwaitingFirstChunkAtom, false);
       store.set(
         errorAtom,
         retryError instanceof Error ? retryError : previousError,

--- a/packages/twenty-front/src/modules/ai/hooks/useSubmitQuestionAnswer.ts
+++ b/packages/twenty-front/src/modules/ai/hooks/useSubmitQuestionAnswer.ts
@@ -10,6 +10,7 @@ import { AGENT_CHAT_REFETCH_MESSAGES_EVENT_NAME } from '@/ai/constants/AgentChat
 import { ANSWER_AGENT_CHAT_QUESTION } from '@/ai/graphql/mutations/answerAgentChatQuestion';
 import { useAgentChatModelId } from '@/ai/hooks/useAgentChatModelId';
 import { agentChatDisplayedThreadState } from '@/ai/states/agentChatDisplayedThreadState';
+import { agentChatIsAwaitingFirstChunkComponentFamilyState } from '@/ai/states/agentChatIsAwaitingFirstChunkComponentFamilyState';
 import { agentChatMessagesComponentFamilyState } from '@/ai/states/agentChatMessagesComponentFamilyState';
 import { markQuestionAnswered } from '@/ai/utils/markQuestionAnswered';
 import { markQuestionPending } from '@/ai/utils/markQuestionPending';
@@ -42,12 +43,18 @@ export const useSubmitQuestionAnswer = () => {
         instanceId: AGENT_CHAT_INSTANCE_ID,
         familyKey: { threadId },
       });
+      const isAwaitingFirstChunkAtom =
+        agentChatIsAwaitingFirstChunkComponentFamilyState.atomFamily({
+          instanceId: AGENT_CHAT_INSTANCE_ID,
+          familyKey: { threadId },
+        });
       const previousMessages = store.get(messagesAtom);
 
       store.set(
         messagesAtom,
         markQuestionAnswered(previousMessages, messageId, toolCallId, answers),
       );
+      store.set(isAwaitingFirstChunkAtom, true);
 
       try {
         await apolloClient.mutate({
@@ -64,6 +71,7 @@ export const useSubmitQuestionAnswer = () => {
       } catch (error) {
         const currentMessages = store.get(messagesAtom);
 
+        store.set(isAwaitingFirstChunkAtom, false);
         store.set(
           messagesAtom,
           markQuestionPending(currentMessages, messageId, toolCallId),

--- a/packages/twenty-front/src/modules/ai/states/agentChatIsAwaitingFirstChunkComponentFamilyState.ts
+++ b/packages/twenty-front/src/modules/ai/states/agentChatIsAwaitingFirstChunkComponentFamilyState.ts
@@ -1,0 +1,9 @@
+import { AgentChatComponentInstanceContext } from '@/ai/contexts/AgentChatComponentInstanceContext';
+import { createAtomComponentFamilyState } from '@/ui/utilities/state/jotai/utils/createAtomComponentFamilyState';
+
+export const agentChatIsAwaitingFirstChunkComponentFamilyState =
+  createAtomComponentFamilyState<boolean, { threadId: string | null }>({
+    key: 'agentChatIsAwaitingFirstChunkComponentFamilyState',
+    defaultValue: false,
+    componentInstanceContext: AgentChatComponentInstanceContext,
+  });


### PR DESCRIPTION
## Rationale

`agentChatIsStreaming` only flips true on the **first chunk**, so the entire send→first-token window — queue wait, model warm-up, tool-heavy first step — renders nothing: no indicator, no Stop (the button reverts to Send), and worst of all the fetched-messages sync can overwrite the messages state with a stale fetch, making the user's just-sent text **visibly vanish** for a beat. That window is exactly where perceived latency lives, and Sentry shows it's also where real failures concentrate (`AI_NoOutputGeneratedError`: 126 users/30d produce no first token at all).

## Why this is the root cause, not a symptom patch

The gap is a missing state, not a missing spinner: the client conflates "no stream yet" with "idle". This adds the missing per-thread state (`agentChatIsAwaitingFirstChunk`) with a complete lifecycle — set by send/retry/question-answer, cleared by the first live chunk, every terminal event, stop, and send-failure — then derives the UX from it (indicator, Stop availability, deferred fetched-sync). Client-local state is the only mechanism that can show feedback *synchronously on click*; a server-derived flag lags a round-trip and can't distinguish pre-first-chunk from mid-stream. A follow-up could additionally seed the state from `activeStreamId` on reload for multi-tab fidelity — additive, not a replacement.

## User impact

Sending a message now gives immediate, truthful feedback ("working on it") instead of a dead pause; impatient double-sends drop; slow-to-first-token turns can be cancelled without waiting for tokens that may never come; and the optimistic message never flickers out.

## Stack

Based on #22484 (sequencer) — both rewire `useAgentChatSubscription`; sequenced to avoid conflicting hunks.

## Test plan

- [ ] CI green (indicator component + state covered by front unit/storybook pipelines)
- [ ] Manual: send with a slow model — indicator until first token, Stop works throughout, optimistic message never disappears

https://claude.ai/code/session_01Lyi6zTema2FMVVh8MD6c38

---
_Generated by [Claude Code](https://claude.ai/code/session_01Lyi6zTema2FMVVh8MD6c38)_

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/22485?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

