### PR TITLE
fix(ai): tell members without billing permission why AI stopped at the usage cap

### DIFF
--- a/packages/twenty-front/src/modules/ai/components/AIChatNoMoreBillingCreditsBanner.tsx
+++ b/packages/twenty-front/src/modules/ai/components/AIChatNoMoreBillingCreditsBanner.tsx
@@ -47,7 +47,12 @@ export const AIChatNoMoreBillingCreditsBanner = () => {
   } = useCreditUpgradeAction();
 
   if (!hasPermissionToManageBilling) {
-    return null;
+    return (
+      <AiChatBanner
+        message={t`Your workspace hit its AI usage limit. Ask an admin to upgrade the plan.`}
+        variant="warning"
+      />
+    );
   }
 
   const message = isTrialing


### PR DESCRIPTION
## Rationale

When a workspace hits its AI usage cap, members **without** the `BILLING` permission flag get zero explanation: `AIChatNoMoreBillingCreditsBanner` returns `null` for them, and `AiChatErrorRenderer` also returns `null` for `BILLING_CREDITS_EXHAUSTED` (deliberately delegating to that same banner). Net effect — for most seats in a workspace, AI chat just silently stops working. Sentry shows the cap is hit constantly: 290 users / 90 days on `Billing Credits Exhausted`.

## Why this is the root cause, not a symptom patch

The permission gate exists to hide *billing actions* (upgrade/subscribe modals) from members who can't act on them — but it was written as "hide everything", conflating the action with the information. The fix keeps the gate exactly where it belongs (no upgrade button, no modals for non-billing members) and renders the information-only banner: "Your workspace hit its AI usage limit. Ask an admin to upgrade the plan." Fixing it in the error renderer instead would be the wrong altitude: the banner mounts *before* a send is attempted (gated on `hasReachedCurrentBillingPeriodCap`), so members are informed proactively rather than after a failed send.

## User impact

Non-admin members — the majority of seats — stop experiencing "AI is broken" and instead see what happened and who can fix it.

## Test plan

- [ ] CI green
- [ ] Manual: member without billing permission at cap → informational banner, no upgrade button; admin → unchanged upgrade flow

https://claude.ai/code/session_01Lyi6zTema2FMVVh8MD6c38

---
_Generated by [Claude Code](https://claude.ai/code/session_01Lyi6zTema2FMVVh8MD6c38)_

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/22487?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

