### PR TITLE
Add drag and drop reordering for kanban columns

### DIFF
--- a/packages/twenty-front/src/modules/object-record/record-board/components/RecordBoardDragDropContext.tsx
+++ b/packages/twenty-front/src/modules/object-record/record-board/components/RecordBoardDragDropContext.tsx
@@ -1,4 +1,5 @@
 import { RecordBoardContext } from '@/object-record/record-board/contexts/RecordBoardContext';
+import { RECORD_BOARD_COLUMN_DND_TYPE } from '@/object-record/record-board/constants/RecordBoardColumnDndType';
 import { isRecordBoardDropProcessingComponentState } from '@/object-record/record-board/states/isRecordBoardDropProcessingComponentState';
 import { recordBoardSelectedRecordIdsComponentSelector } from '@/object-record/record-board/states/selectors/recordBoardSelectedRecordIdsComponentSelector';
 import { useEndRecordDrag } from '@/object-record/record-drag/hooks/useEndRecordDrag';
@@ -7,11 +8,15 @@ import { useStartRecordDrag } from '@/object-record/record-drag/hooks/useStartRe
 import { originalDragSelectionComponentState } from '@/object-record/record-drag/states/originalDragSelectionComponentState';
 
 import { RECORD_INDEX_REMOVE_SORTING_MODAL_ID } from '@/object-record/record-index/constants/RecordIndexRemoveSortingModalId';
+import { recordIndexRecordGroupSortComponentState } from '@/object-record/record-index/states/recordIndexRecordGroupSortComponentState';
 import { currentRecordSortsComponentState } from '@/object-record/record-sort/states/currentRecordSortsComponentState';
 import { getBoardCardDropBehavior } from '@/object-record/record-board/utils/getBoardCardDropBehavior';
+import { RecordGroupSort } from '@/object-record/record-group/types/RecordGroupSort';
+import { useReorderRecordGroups } from '@/object-record/record-group/hooks/useReorderRecordGroups';
 import { useModal } from '@/ui/layout/modal/hooks/useModal';
 import { useAtomComponentSelectorCallbackState } from '@/ui/utilities/state/jotai/hooks/useAtomComponentSelectorCallbackState';
 import { useAtomComponentStateCallbackState } from '@/ui/utilities/state/jotai/hooks/useAtomComponentStateCallbackState';
+import { ViewType } from '@/views/types/ViewType';
 import {
   DragDropContext,
   type DragStart,
@@ -25,8 +30,18 @@ export const RecordBoardDragDropContext = ({
 }: React.PropsWithChildren) => {
   const { recordBoardId } = useContext(RecordBoardContext);
 
+  const { reorderRecordGroups } = useReorderRecordGroups({
+    recordIndexId: recordBoardId,
+    viewType: ViewType.KANBAN,
+  });
+
   const currentRecordSorts = useAtomComponentStateCallbackState(
     currentRecordSortsComponentState,
+    recordBoardId,
+  );
+
+  const recordIndexRecordGroupSort = useAtomComponentStateCallbackState(
+    recordIndexRecordGroupSortComponentState,
     recordBoardId,
   );
 
@@ -56,6 +71,10 @@ export const RecordBoardDragDropContext = ({
 
   const handleDragStart = useCallback(
     (start: DragStart) => {
+      if (start.type === RECORD_BOARD_COLUMN_DND_TYPE) {
+        return;
+      }
+
       const currentSelectedRecordIds = store.get(recordBoardSelectedRecordIds);
 
       store.set(isRecordBoardDropProcessingCallbackState, true);
@@ -72,6 +91,21 @@ export const RecordBoardDragDropContext = ({
 
   const handleDragEnd: OnDragEndResponder = useCallback(
     (result) => {
+      if (result.type === RECORD_BOARD_COLUMN_DND_TYPE) {
+        if (!result.destination) {
+          return;
+        }
+
+        reorderRecordGroups({
+          fromIndex: result.source.index,
+          toIndex: result.destination.index,
+        });
+
+        store.set(recordIndexRecordGroupSort, RecordGroupSort.Manual);
+
+        return;
+      }
+
       const originalDragSelection = store.get(
         originalDragSelectionCallbackState,
       );
@@ -118,6 +152,8 @@ export const RecordBoardDragDropContext = ({
       store,
       originalDragSelectionCallbackState,
       isRecordBoardDropProcessingCallbackState,
+      recordIndexRecordGroupSort,
+      reorderRecordGroups,
     ],
   );
 

--- a/packages/twenty-front/src/modules/object-record/record-board/components/RecordBoardHeader.tsx
+++ b/packages/twenty-front/src/modules/object-record/record-board/components/RecordBoardHeader.tsx
@@ -1,9 +1,13 @@
+import { Draggable, Droppable } from '@hello-pangea/dnd';
 import { RecordBoardAddGroupColumn } from '@/object-record/record-board/components/RecordBoardAddGroupColumn';
+import { RECORD_BOARD_COLUMN_DND_TYPE } from '@/object-record/record-board/constants/RecordBoardColumnDndType';
+import { RECORD_BOARD_COLUMN_DROPPABLE_ID } from '@/object-record/record-board/constants/RecordBoardColumnDroppableId';
 import { RecordBoardColumnHeaderWrapper } from '@/object-record/record-board/record-board-column/components/RecordBoardColumnHeaderWrapper';
 import { RecordGroupContext } from '@/object-record/record-group/states/context/RecordGroupContext';
 import { visibleRecordGroupIdsComponentFamilySelector } from '@/object-record/record-group/states/selectors/visibleRecordGroupIdsComponentFamilySelector';
 import { RecordIndexGroupAggregatesDataLoader } from '@/object-record/record-index/components/RecordIndexGroupAggregatesDataLoader';
 import { useAtomComponentFamilySelectorValue } from '@/ui/utilities/state/jotai/hooks/useAtomComponentFamilySelectorValue';
+import { getCssCompatibleDraggableProps } from '@/ui/layout/draggable-list/utils/getCssCompatibleDraggableProps';
 import { ViewType } from '@/views/types/ViewType';
 import { styled } from '@linaria/react';
 import { themeCssVariables } from 'twenty-ui/theme-constants';
@@ -34,20 +38,49 @@ export const RecordBoardHeader = () => {
   );
 
   return (
-    <StyledHeaderContainer id="record-board-header">
-      {visibleRecordGroupIds.map((recordGroupId, index) => (
-        <RecordGroupContext.Provider
-          key={recordGroupId}
-          value={{ recordGroupId }}
+    <Droppable
+      direction="horizontal"
+      droppableId={RECORD_BOARD_COLUMN_DROPPABLE_ID}
+      type={RECORD_BOARD_COLUMN_DND_TYPE}
+    >
+      {(droppableProvided) => (
+        <StyledHeaderContainer
+          id="record-board-header"
+          ref={droppableProvided.innerRef}
+          // oxlint-disable-next-line react/jsx-props-no-spreading
+          {...droppableProvided.droppableProps}
         >
-          <RecordBoardColumnHeaderWrapper
-            columnId={recordGroupId}
-            columnIndex={index}
-          />
-        </RecordGroupContext.Provider>
-      ))}
-      <RecordBoardAddGroupColumn />
-      <RecordIndexGroupAggregatesDataLoader />
-    </StyledHeaderContainer>
+          {visibleRecordGroupIds.map((recordGroupId, index) => (
+            <Draggable
+              draggableId={recordGroupId}
+              index={index}
+              key={recordGroupId}
+            >
+              {(draggableProvided, draggableSnapshot) => (
+                <div
+                  ref={draggableProvided.innerRef}
+                  // oxlint-disable-next-line react/jsx-props-no-spreading
+                  {...getCssCompatibleDraggableProps(
+                    draggableProvided.draggableProps,
+                  )}
+                >
+                  <RecordGroupContext.Provider value={{ recordGroupId }}>
+                    <RecordBoardColumnHeaderWrapper
+                      columnId={recordGroupId}
+                      columnIndex={index}
+                      dragHandleProps={draggableProvided.dragHandleProps}
+                      isDragging={draggableSnapshot.isDragging}
+                    />
+                  </RecordGroupContext.Provider>
+                </div>
+              )}
+            </Draggable>
+          ))}
+          {droppableProvided.placeholder}
+          <RecordBoardAddGroupColumn />
+          <RecordIndexGroupAggregatesDataLoader />
+        </StyledHeaderContainer>
+      )}
+    </Droppable>
   );
 };

--- a/packages/twenty-front/src/modules/object-record/record-board/constants/RecordBoardColumnDndType.ts
+++ b/packages/twenty-front/src/modules/object-record/record-board/constants/RecordBoardColumnDndType.ts
@@ -1,0 +1,1 @@
+export const RECORD_BOARD_COLUMN_DND_TYPE = 'record-board-column';

--- a/packages/twenty-front/src/modules/object-record/record-board/constants/RecordBoardColumnDroppableId.ts
+++ b/packages/twenty-front/src/modules/object-record/record-board/constants/RecordBoardColumnDroppableId.ts
@@ -1,0 +1,1 @@
+export const RECORD_BOARD_COLUMN_DROPPABLE_ID = 'record-board-columns';

--- a/packages/twenty-front/src/modules/object-record/record-board/record-board-column/components/RecordBoardColumnHeader.tsx
+++ b/packages/twenty-front/src/modules/object-record/record-board/record-board-column/components/RecordBoardColumnHeader.tsx
@@ -1,3 +1,4 @@
+import { type DraggableProvidedDragHandleProps } from '@hello-pangea/dnd';
 import { styled } from '@linaria/react';
 import { useContext, useState } from 'react';
 import { themeCssVariables } from 'twenty-ui/theme-constants';
@@ -23,7 +24,7 @@ import { useToggleDropdown } from '@/ui/layout/dropdown/hooks/useToggleDropdown'
 import { useAtomComponentFamilyStateValue } from '@/ui/utilities/state/jotai/hooks/useAtomComponentFamilyStateValue';
 import { useAtomComponentSelectorValue } from '@/ui/utilities/state/jotai/hooks/useAtomComponentSelectorValue';
 import { useAtomComponentStateValue } from '@/ui/utilities/state/jotai/hooks/useAtomComponentStateValue';
-import { IconDotsVertical, IconPlus } from 'twenty-ui/icon';
+import { IconDotsVertical, IconGripVertical, IconPlus } from 'twenty-ui/icon';
 import { LightIconButton } from 'twenty-ui/input';
 
 const StyledHeader = styled.div`
@@ -51,6 +52,7 @@ const StyledLeftContainer = styled.div`
   align-items: center;
   display: flex;
   gap: ${themeCssVariables.spacing[1]};
+  min-width: 0;
   overflow: hidden;
 `;
 
@@ -59,8 +61,10 @@ const StyledRightContainer = styled.div`
   display: flex;
 `;
 
-const StyledColumn = styled.div`
+const StyledColumn = styled.div<{ $isDragging: boolean }>`
   background-color: ${themeCssVariables.background.primary};
+  box-shadow: ${({ $isDragging }) =>
+    $isDragging ? themeCssVariables.boxShadow.strong : 'none'};
   display: flex;
   flex-direction: column;
   max-width: var(
@@ -75,6 +79,7 @@ const StyledColumn = styled.div`
   padding: ${themeCssVariables.spacing[2]};
 
   position: relative;
+  transition: box-shadow 120ms ease;
 `;
 
 const StyledTagContainer = styled.div`
@@ -88,7 +93,47 @@ const StyledDropdownContainer = styled.div`
   overflow: hidden;
 `;
 
-export const RecordBoardColumnHeader = () => {
+const StyledDragHandle = styled.div`
+  align-items: center;
+  border-radius: ${themeCssVariables.border.radius.sm};
+  color: ${themeCssVariables.font.color.tertiary};
+  cursor: grab;
+  display: flex;
+  flex-shrink: 0;
+  height: 20px;
+  justify-content: center;
+  opacity: 0;
+  outline: none;
+  transition:
+    background-color 120ms ease,
+    color 120ms ease,
+    opacity 120ms ease;
+  width: 16px;
+
+  ${StyledHeader}:hover &,
+  &:focus-visible {
+    opacity: 1;
+  }
+
+  &:hover {
+    background-color: ${themeCssVariables.background.transparent.light};
+    color: ${themeCssVariables.font.color.secondary};
+  }
+
+  &:active {
+    cursor: grabbing;
+  }
+`;
+
+type RecordBoardColumnHeaderProps = {
+  dragHandleProps?: DraggableProvidedDragHandleProps | null;
+  isDragging?: boolean;
+};
+
+export const RecordBoardColumnHeader = ({
+  dragHandleProps,
+  isDragging = false,
+}: RecordBoardColumnHeaderProps) => {
   const { columnDefinition } = useContext(RecordBoardColumnContext);
 
   const [isHeaderHovered, setIsHeaderHovered] = useState(false);
@@ -136,13 +181,20 @@ export const RecordBoardColumnHeader = () => {
   };
 
   return (
-    <StyledColumn>
+    <StyledColumn $isDragging={isDragging}>
       <StyledHeader
         onMouseEnter={() => setIsHeaderHovered(true)}
         onMouseLeave={() => setIsHeaderHovered(false)}
       >
         <StyledHeaderContainer>
           <StyledLeftContainer>
+            <StyledDragHandle
+              aria-label="Drag column"
+              // oxlint-disable-next-line react/jsx-props-no-spreading
+              {...(dragHandleProps ?? {})}
+            >
+              <IconGripVertical size={themeCssVariables.icon.size.md} />
+            </StyledDragHandle>
             <StyledDropdownContainer>
               <Dropdown
                 dropdownId={dropdownId}

--- a/packages/twenty-front/src/modules/object-record/record-board/record-board-column/components/RecordBoardColumnHeaderWrapper.tsx
+++ b/packages/twenty-front/src/modules/object-record/record-board/record-board-column/components/RecordBoardColumnHeaderWrapper.tsx
@@ -1,3 +1,4 @@
+import { type DraggableProvidedDragHandleProps } from '@hello-pangea/dnd';
 import { RecordBoardColumnHeader } from '@/object-record/record-board/record-board-column/components/RecordBoardColumnHeader';
 import { RecordBoardColumnContext } from '@/object-record/record-board/record-board-column/contexts/RecordBoardColumnContext';
 import { useShouldHideRecordGroup } from '@/object-record/record-group/hooks/useShouldHideRecordGroup';
@@ -10,11 +11,15 @@ import { isDefined } from 'twenty-shared/utils';
 type RecordBoardColumnHeaderWrapperProps = {
   columnId: string;
   columnIndex: number;
+  dragHandleProps?: DraggableProvidedDragHandleProps | null;
+  isDragging?: boolean;
 };
 
 export const RecordBoardColumnHeaderWrapper = ({
   columnId,
   columnIndex,
+  dragHandleProps,
+  isDragging = false,
 }: RecordBoardColumnHeaderWrapperProps) => {
   const recordGroupDefinition = useAtomFamilyStateValue(
     recordGroupDefinitionFamilyState,
@@ -45,7 +50,10 @@ export const RecordBoardColumnHeaderWrapper = ({
         columnIndex,
       }}
     >
-      <RecordBoardColumnHeader />
+      <RecordBoardColumnHeader
+        dragHandleProps={dragHandleProps}
+        isDragging={isDragging}
+      />
     </RecordBoardColumnContext.Provider>
   );
 };


### PR DESCRIPTION
## Summary
- Add horizontal drag-and-drop support to Record Board column headers
- Reuse the existing record group reorder flow so view group positions are persisted
- Add a subtle column drag handle without changing card drag-and-drop behavior

## Testing
- git diff --check
- Not run: twenty-front lint/typecheck because this checkout has no node_modules and Yarn is not available on PATH

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/22495?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

