### PR TITLE
feat(server): promote registration display fields to first-class columns

### DIFF
--- a/packages/twenty-server/src/database/commands/upgrade-version-command/2-19/2-19-instance-command-fast-1783073776590-add-display-fields-to-application-registration.ts
+++ b/packages/twenty-server/src/database/commands/upgrade-version-command/2-19/2-19-instance-command-fast-1783073776590-add-display-fields-to-application-registration.ts
@@ -1,0 +1,69 @@
+import { QueryRunner } from 'typeorm';
+
+import { RegisteredInstanceCommand } from 'src/engine/core-modules/upgrade/decorators/registered-instance-command.decorator';
+import { FastInstanceCommand } from 'src/engine/core-modules/upgrade/interfaces/fast-instance-command.interface';
+
+@RegisteredInstanceCommand('2.19.0', 1783073776590)
+export class AddDisplayFieldsToApplicationRegistrationFastInstanceCommand
+  implements FastInstanceCommand
+{
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      'ALTER TABLE "core"."applicationRegistration" ADD COLUMN IF NOT EXISTS "description" text',
+    );
+    await queryRunner.query(
+      'ALTER TABLE "core"."applicationRegistration" ADD COLUMN IF NOT EXISTS "author" text',
+    );
+    await queryRunner.query(
+      'ALTER TABLE "core"."applicationRegistration" ADD COLUMN IF NOT EXISTS "category" text',
+    );
+    await queryRunner.query(
+      'ALTER TABLE "core"."applicationRegistration" ADD COLUMN IF NOT EXISTS "websiteUrl" text',
+    );
+    await queryRunner.query(
+      'ALTER TABLE "core"."applicationRegistration" ADD COLUMN IF NOT EXISTS "aboutDescription" text',
+    );
+    await queryRunner.query(
+      'ALTER TABLE "core"."applicationRegistration" ADD COLUMN IF NOT EXISTS "termsUrl" text',
+    );
+    await queryRunner.query(
+      'ALTER TABLE "core"."applicationRegistration" ADD COLUMN IF NOT EXISTS "emailSupport" text',
+    );
+    await queryRunner.query(
+      'ALTER TABLE "core"."applicationRegistration" ADD COLUMN IF NOT EXISTS "issueReportUrl" text',
+    );
+    await queryRunner.query(
+      `ALTER TABLE "core"."applicationRegistration" ADD COLUMN IF NOT EXISTS "screenshots" text array NOT NULL DEFAULT '{}'`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      'ALTER TABLE "core"."applicationRegistration" DROP COLUMN "description"',
+    );
+    await queryRunner.query(
+      'ALTER TABLE "core"."applicationRegistration" DROP COLUMN "author"',
+    );
+    await queryRunner.query(
+      'ALTER TABLE "core"."applicationRegistration" DROP COLUMN "category"',
+    );
+    await queryRunner.query(
+      'ALTER TABLE "core"."applicationRegistration" DROP COLUMN "websiteUrl"',
+    );
+    await queryRunner.query(
+      'ALTER TABLE "core"."applicationRegistration" DROP COLUMN "aboutDescription"',
+    );
+    await queryRunner.query(
+      'ALTER TABLE "core"."applicationRegistration" DROP COLUMN "termsUrl"',
+    );
+    await queryRunner.query(
+      'ALTER TABLE "core"."applicationRegistration" DROP COLUMN "emailSupport"',
+    );
+    await queryRunner.query(
+      'ALTER TABLE "core"."applicationRegistration" DROP COLUMN "issueReportUrl"',
+    );
+    await queryRunner.query(
+      'ALTER TABLE "core"."applicationRegistration" DROP COLUMN "screenshots"',
+    );
+  }
+}

--- a/packages/twenty-server/src/database/commands/upgrade-version-command/2-19/2-19-instance-command-slow-1783073776591-backfill-display-fields-on-application-registration.ts
+++ b/packages/twenty-server/src/database/commands/upgrade-version-command/2-19/2-19-instance-command-slow-1783073776591-backfill-display-fields-on-application-registration.ts
@@ -1,0 +1,44 @@
+import { DataSource, QueryRunner } from 'typeorm';
+
+import { RegisteredInstanceCommand } from 'src/engine/core-modules/upgrade/decorators/registered-instance-command.decorator';
+import { SlowInstanceCommand } from 'src/engine/core-modules/upgrade/interfaces/slow-instance-command.interface';
+
+@RegisteredInstanceCommand('2.19.0', 1783073776591, { type: 'slow' })
+export class BackfillDisplayFieldsOnApplicationRegistrationSlowInstanceCommand
+  implements SlowInstanceCommand
+{
+  async runDataMigration(dataSource: DataSource): Promise<void> {
+    await dataSource.query(
+      `UPDATE "core"."applicationRegistration"
+       SET
+         "description" = "manifest"->'application'->>'description',
+         "author" = "manifest"->'application'->>'author',
+         "category" = "manifest"->'application'->>'category',
+         "websiteUrl" = "manifest"->'application'->>'websiteUrl',
+         "aboutDescription" = "manifest"->'application'->>'aboutDescription',
+         "termsUrl" = "manifest"->'application'->>'termsUrl',
+         "emailSupport" = "manifest"->'application'->>'emailSupport',
+         "issueReportUrl" = "manifest"->'application'->>'issueReportUrl',
+         "screenshots" = COALESCE(ARRAY(SELECT jsonb_array_elements_text("manifest"->'application'->'screenshots')), '{}')
+       WHERE "manifest" IS NOT NULL`,
+    );
+  }
+
+  public async up(_queryRunner: QueryRunner): Promise<void> {}
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `UPDATE "core"."applicationRegistration"
+       SET
+         "description" = NULL,
+         "author" = NULL,
+         "category" = NULL,
+         "websiteUrl" = NULL,
+         "aboutDescription" = NULL,
+         "termsUrl" = NULL,
+         "emailSupport" = NULL,
+         "issueReportUrl" = NULL,
+         "screenshots" = '{}'`,
+    );
+  }
+}

--- a/packages/twenty-server/src/database/commands/upgrade-version-command/instance-commands.constant.ts
+++ b/packages/twenty-server/src/database/commands/upgrade-version-command/instance-commands.constant.ts
@@ -94,6 +94,8 @@ import { AddWorkspaceDiscoverabilityToWorkspaceFastInstanceCommand } from './2-1
 import { DropMetadataStandardOverridesColumnFastInstanceCommand } from './2-20/2-20-instance-command-fast-1825000000000-drop-metadata-standard-overrides-column';
 import { AddLogoToApplicationRegistrationFastInstanceCommand } from './2-19/2-19-instance-command-fast-1783069672191-add-logo-to-application-registration';
 import { BackfillLogoOnApplicationRegistrationSlowInstanceCommand } from './2-19/2-19-instance-command-slow-1783069673191-backfill-logo-on-application-registration';
+import { AddDisplayFieldsToApplicationRegistrationFastInstanceCommand } from './2-19/2-19-instance-command-fast-1783073776590-add-display-fields-to-application-registration';
+import { BackfillDisplayFieldsOnApplicationRegistrationSlowInstanceCommand } from './2-19/2-19-instance-command-slow-1783073776591-backfill-display-fields-on-application-registration';
 
 export const INSTANCE_COMMANDS = [
   AddViewFieldGroupIdIndexOnViewFieldFastInstanceCommand,
@@ -190,4 +192,6 @@ export const INSTANCE_COMMANDS = [
   AddTypeAndOptionsToApplicationVariablesFastInstanceCommand,
   AddLogoToApplicationRegistrationFastInstanceCommand,
   BackfillLogoOnApplicationRegistrationSlowInstanceCommand,
+  AddDisplayFieldsToApplicationRegistrationFastInstanceCommand,
+  BackfillDisplayFieldsOnApplicationRegistrationSlowInstanceCommand,
 ];

--- a/packages/twenty-server/src/engine/core-modules/application/application-marketplace/marketplace-query.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/application/application-marketplace/marketplace-query.service.ts
@@ -93,7 +93,7 @@ export class MarketplaceQueryService {
   ): MarketplaceAppDTO {
     return {
       id: catalogCard.universalIdentifier,
-      name: catalogCard.displayName ?? catalogCard.name,
+      name: catalogCard.name,
       description: catalogCard.description ?? '',
       author: catalogCard.author ?? 'Unknown',
       category: catalogCard.category ?? '',

--- a/packages/twenty-server/src/engine/core-modules/application/application-registration/application-registration.entity.ts
+++ b/packages/twenty-server/src/engine/core-modules/application/application-registration/application-registration.entity.ts
@@ -141,6 +141,69 @@ export class ApplicationRegistrationEntity {
   })
   logo: string | null;
 
+  @Column({ nullable: true, type: 'text' })
+  @WasIntroducedInUpgrade({
+    upgradeCommandName:
+      '2.19.0_AddDisplayFieldsToApplicationRegistrationFastInstanceCommand_1783073776590',
+  })
+  description: string | null;
+
+  @Column({ nullable: true, type: 'text' })
+  @WasIntroducedInUpgrade({
+    upgradeCommandName:
+      '2.19.0_AddDisplayFieldsToApplicationRegistrationFastInstanceCommand_1783073776590',
+  })
+  author: string | null;
+
+  @Column({ nullable: true, type: 'text' })
+  @WasIntroducedInUpgrade({
+    upgradeCommandName:
+      '2.19.0_AddDisplayFieldsToApplicationRegistrationFastInstanceCommand_1783073776590',
+  })
+  category: string | null;
+
+  @Column({ nullable: true, type: 'text' })
+  @WasIntroducedInUpgrade({
+    upgradeCommandName:
+      '2.19.0_AddDisplayFieldsToApplicationRegistrationFastInstanceCommand_1783073776590',
+  })
+  websiteUrl: string | null;
+
+  @Column({ nullable: true, type: 'text' })
+  @WasIntroducedInUpgrade({
+    upgradeCommandName:
+      '2.19.0_AddDisplayFieldsToApplicationRegistrationFastInstanceCommand_1783073776590',
+  })
+  aboutDescription: string | null;
+
+  @Column({ nullable: true, type: 'text' })
+  @WasIntroducedInUpgrade({
+    upgradeCommandName:
+      '2.19.0_AddDisplayFieldsToApplicationRegistrationFastInstanceCommand_1783073776590',
+  })
+  termsUrl: string | null;
+
+  @Column({ nullable: true, type: 'text' })
+  @WasIntroducedInUpgrade({
+    upgradeCommandName:
+      '2.19.0_AddDisplayFieldsToApplicationRegistrationFastInstanceCommand_1783073776590',
+  })
+  emailSupport: string | null;
+
+  @Column({ nullable: true, type: 'text' })
+  @WasIntroducedInUpgrade({
+    upgradeCommandName:
+      '2.19.0_AddDisplayFieldsToApplicationRegistrationFastInstanceCommand_1783073776590',
+  })
+  issueReportUrl: string | null;
+
+  @Column({ type: 'text', array: true, default: '{}' })
+  @WasIntroducedInUpgrade({
+    upgradeCommandName:
+      '2.19.0_AddDisplayFieldsToApplicationRegistrationFastInstanceCommand_1783073776590',
+  })
+  screenshots: string[];
+
   @Field(() => String, { nullable: true })
   get logoUrl(): string | null {
     return this.logo ?? this.manifest?.application?.logoUrl ?? null;

--- a/packages/twenty-server/src/engine/core-modules/application/application-registration/application-registration.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/application/application-registration/application-registration.service.ts
@@ -25,6 +25,7 @@ import {
   type UpdateApplicationRegistrationPayload,
 } from 'src/engine/core-modules/application/application-registration/dtos/update-application-registration.input';
 import { ApplicationRegistrationSourceType } from 'src/engine/core-modules/application/application-registration/enums/application-registration-source-type.enum';
+import { fromManifestApplicationToDisplayFields } from 'src/engine/core-modules/application/application-registration/utils/from-manifest-application-to-display-fields.util';
 import { ApplicationEntity } from 'src/engine/core-modules/application/application.entity';
 import { validateRedirectUri } from 'src/engine/core-modules/auth/utils/validate-redirect-uri.util';
 import { WorkspaceEntity } from 'src/engine/core-modules/workspace/workspace.entity';
@@ -298,16 +299,7 @@ export class ApplicationRegistrationService {
       ...existing,
       name: manifest.application.displayName,
       manifest,
-      logo: manifest.application.logoUrl ?? null,
-      description: manifest.application.description ?? null,
-      author: manifest.application.author ?? null,
-      category: manifest.application.category ?? null,
-      websiteUrl: manifest.application.websiteUrl ?? null,
-      aboutDescription: manifest.application.aboutDescription ?? null,
-      termsUrl: manifest.application.termsUrl ?? null,
-      emailSupport: manifest.application.emailSupport ?? null,
-      issueReportUrl: manifest.application.issueReportUrl ?? null,
-      screenshots: manifest.application.screenshots ?? [],
+      ...fromManifestApplicationToDisplayFields(manifest.application),
       ...(sourceType !== undefined && { sourceType }),
     });
   }
@@ -377,17 +369,7 @@ export class ApplicationRegistrationService {
         sourcePackage: params.sourcePackage,
         latestAvailableVersion: params.latestAvailableVersion,
         manifest: params.manifest,
-        logo: params.manifest?.application?.logoUrl ?? null,
-        description: params.manifest?.application?.description ?? null,
-        author: params.manifest?.application?.author ?? null,
-        category: params.manifest?.application?.category ?? null,
-        websiteUrl: params.manifest?.application?.websiteUrl ?? null,
-        aboutDescription:
-          params.manifest?.application?.aboutDescription ?? null,
-        termsUrl: params.manifest?.application?.termsUrl ?? null,
-        emailSupport: params.manifest?.application?.emailSupport ?? null,
-        issueReportUrl: params.manifest?.application?.issueReportUrl ?? null,
-        screenshots: params.manifest?.application?.screenshots ?? [],
+        ...fromManifestApplicationToDisplayFields(params.manifest?.application),
         isFeatured,
       });
     } else {
@@ -400,17 +382,7 @@ export class ApplicationRegistrationService {
         isListed: true,
         isFeatured,
         manifest: params.manifest,
-        logo: params.manifest?.application?.logoUrl ?? null,
-        description: params.manifest?.application?.description ?? null,
-        author: params.manifest?.application?.author ?? null,
-        category: params.manifest?.application?.category ?? null,
-        websiteUrl: params.manifest?.application?.websiteUrl ?? null,
-        aboutDescription:
-          params.manifest?.application?.aboutDescription ?? null,
-        termsUrl: params.manifest?.application?.termsUrl ?? null,
-        emailSupport: params.manifest?.application?.emailSupport ?? null,
-        issueReportUrl: params.manifest?.application?.issueReportUrl ?? null,
-        screenshots: params.manifest?.application?.screenshots ?? [],
+        ...fromManifestApplicationToDisplayFields(params.manifest?.application),
         oAuthClientId: v4(),
         oAuthRedirectUris: [],
         oAuthScopes: [],

--- a/packages/twenty-server/src/engine/core-modules/application/application-registration/application-registration.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/application/application-registration/application-registration.service.ts
@@ -51,6 +51,15 @@ const APPLICATION_REGISTRATION_WITHOUT_MANIFEST_SELECT: (keyof ApplicationRegist
     'isFeatured',
     'isPreInstalled',
     'logo',
+    'description',
+    'author',
+    'category',
+    'websiteUrl',
+    'aboutDescription',
+    'termsUrl',
+    'emailSupport',
+    'issueReportUrl',
+    'screenshots',
     'createdAt',
     'updatedAt',
   ];
@@ -61,7 +70,6 @@ export type ApplicationRegistrationCatalogCard = {
   name: string;
   sourcePackage: string | null;
   isFeatured: boolean;
-  displayName: string | null;
   description: string | null;
   author: string | null;
   category: string | null;
@@ -147,7 +155,7 @@ export class ApplicationRegistrationService {
   ): Promise<PublicApplicationRegistrationDTO | null> {
     const registration = await this.applicationRegistrationRepository.findOne({
       where: { oAuthClientId: clientId },
-      select: ['id', 'name', 'manifest', 'oAuthScopes'],
+      select: ['id', 'name', 'logo', 'websiteUrl', 'oAuthScopes'],
     });
 
     if (!registration) {
@@ -157,8 +165,8 @@ export class ApplicationRegistrationService {
     return {
       id: registration.id,
       name: registration.name,
-      logoUrl: registration.manifest?.application?.logoUrl ?? null,
-      websiteUrl: registration.manifest?.application?.websiteUrl ?? null,
+      logoUrl: registration.logo,
+      websiteUrl: registration.websiteUrl,
       oAuthScopes: registration.oAuthScopes,
     };
   }
@@ -291,6 +299,15 @@ export class ApplicationRegistrationService {
       name: manifest.application.displayName,
       manifest,
       logo: manifest.application.logoUrl ?? null,
+      description: manifest.application.description ?? null,
+      author: manifest.application.author ?? null,
+      category: manifest.application.category ?? null,
+      websiteUrl: manifest.application.websiteUrl ?? null,
+      aboutDescription: manifest.application.aboutDescription ?? null,
+      termsUrl: manifest.application.termsUrl ?? null,
+      emailSupport: manifest.application.emailSupport ?? null,
+      issueReportUrl: manifest.application.issueReportUrl ?? null,
+      screenshots: manifest.application.screenshots ?? [],
       ...(sourceType !== undefined && { sourceType }),
     });
   }
@@ -361,6 +378,16 @@ export class ApplicationRegistrationService {
         latestAvailableVersion: params.latestAvailableVersion,
         manifest: params.manifest,
         logo: params.manifest?.application?.logoUrl ?? null,
+        description: params.manifest?.application?.description ?? null,
+        author: params.manifest?.application?.author ?? null,
+        category: params.manifest?.application?.category ?? null,
+        websiteUrl: params.manifest?.application?.websiteUrl ?? null,
+        aboutDescription:
+          params.manifest?.application?.aboutDescription ?? null,
+        termsUrl: params.manifest?.application?.termsUrl ?? null,
+        emailSupport: params.manifest?.application?.emailSupport ?? null,
+        issueReportUrl: params.manifest?.application?.issueReportUrl ?? null,
+        screenshots: params.manifest?.application?.screenshots ?? [],
         isFeatured,
       });
     } else {
@@ -374,6 +401,16 @@ export class ApplicationRegistrationService {
         isFeatured,
         manifest: params.manifest,
         logo: params.manifest?.application?.logoUrl ?? null,
+        description: params.manifest?.application?.description ?? null,
+        author: params.manifest?.application?.author ?? null,
+        category: params.manifest?.application?.category ?? null,
+        websiteUrl: params.manifest?.application?.websiteUrl ?? null,
+        aboutDescription:
+          params.manifest?.application?.aboutDescription ?? null,
+        termsUrl: params.manifest?.application?.termsUrl ?? null,
+        emailSupport: params.manifest?.application?.emailSupport ?? null,
+        issueReportUrl: params.manifest?.application?.issueReportUrl ?? null,
+        screenshots: params.manifest?.application?.screenshots ?? [],
         oAuthClientId: v4(),
         oAuthRedirectUris: [],
         oAuthScopes: [],
@@ -430,6 +467,17 @@ export class ApplicationRegistrationService {
     ApplicationRegistrationCatalogCard[]
   > {
     const registrations = await this.applicationRegistrationRepository.find({
+      select: [
+        'id',
+        'universalIdentifier',
+        'name',
+        'sourcePackage',
+        'isFeatured',
+        'logo',
+        'description',
+        'author',
+        'category',
+      ],
       where: {
         isListed: true,
         sourceType: ApplicationRegistrationSourceType.NPM,
@@ -442,14 +490,10 @@ export class ApplicationRegistrationService {
       name: registration.name,
       sourcePackage: registration.sourcePackage,
       isFeatured: registration.isFeatured,
-      displayName: registration.manifest?.application?.displayName ?? null,
-      description: registration.manifest?.application?.description ?? null,
-      author: registration.manifest?.application?.author ?? null,
-      category: registration.manifest?.application?.category ?? null,
-      logoUrl:
-        registration.logo ??
-        registration.manifest?.application?.logoUrl ??
-        null,
+      description: registration.description,
+      author: registration.author,
+      category: registration.category,
+      logoUrl: registration.logo,
     }));
   }
 

--- a/packages/twenty-server/src/engine/core-modules/application/application-registration/application-tarball.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/application/application-registration/application-tarball.service.ts
@@ -18,6 +18,7 @@ import {
   ApplicationRegistrationExceptionCode,
 } from 'src/engine/core-modules/application/application-registration/application-registration.exception';
 import { ApplicationRegistrationSourceType } from 'src/engine/core-modules/application/application-registration/enums/application-registration-source-type.enum';
+import { fromManifestApplicationToDisplayFields } from 'src/engine/core-modules/application/application-registration/utils/from-manifest-application-to-display-fields.util';
 import { extractTarballSecurely } from 'src/engine/core-modules/application/application-package/utils/extract-tarball-securely.util';
 import { readJsonFile } from 'src/engine/core-modules/application/application-package/utils/read-json-file.util';
 import { resolvePackageContentDir } from 'src/engine/core-modules/application/application-package/utils/tarball-utils';
@@ -170,6 +171,7 @@ export class ApplicationTarballService {
           name: manifest.application?.displayName ?? 'Unknown App',
           sourceType: ApplicationRegistrationSourceType.TARBALL,
           manifest,
+          ...fromManifestApplicationToDisplayFields(manifest.application),
           latestAvailableVersion: packageJson?.version ?? null,
           isListed: false,
           isFeatured: false,
@@ -207,6 +209,7 @@ export class ApplicationTarballService {
         tarballFileId: savedFile.id,
         name: manifest.application?.displayName ?? 'Unknown App',
         manifest,
+        ...fromManifestApplicationToDisplayFields(manifest.application),
         latestAvailableVersion: packageJson?.version ?? null,
         isListed: false,
         isFeatured: false,

--- a/packages/twenty-server/src/engine/core-modules/application/application-registration/utils/from-manifest-application-to-display-fields.util.ts
+++ b/packages/twenty-server/src/engine/core-modules/application/application-registration/utils/from-manifest-application-to-display-fields.util.ts
@@ -1,0 +1,16 @@
+import { type ApplicationManifest } from 'twenty-shared/application';
+
+export const fromManifestApplicationToDisplayFields = (
+  application: ApplicationManifest | undefined,
+) => ({
+  logo: application?.logoUrl ?? null,
+  description: application?.description ?? null,
+  author: application?.author ?? null,
+  category: application?.category ?? null,
+  websiteUrl: application?.websiteUrl ?? null,
+  aboutDescription: application?.aboutDescription ?? null,
+  termsUrl: application?.termsUrl ?? null,
+  emailSupport: application?.emailSupport ?? null,
+  issueReportUrl: application?.issueReportUrl ?? null,
+  screenshots: application?.screenshots ?? [],
+});

--- a/packages/twenty-server/test/integration/metadata/suites/application/marketplace-catalog-sync.integration-spec.ts
+++ b/packages/twenty-server/test/integration/metadata/suites/application/marketplace-catalog-sync.integration-spec.ts
@@ -68,6 +68,7 @@ describe('Marketplace Catalog Sync (integration)', () => {
     sourcePackage: string;
     latestAvailableVersion?: string;
     manifest?: Record<string, unknown>;
+    category?: string;
   }): Promise<string> => {
     const id = crypto.randomUUID();
     const oAuthClientId = crypto.randomUUID();
@@ -77,8 +78,8 @@ describe('Marketplace Catalog Sync (integration)', () => {
         (id, "universalIdentifier", name, "oAuthClientId",
          "oAuthRedirectUris", "oAuthScopes", "workspaceId",
          "sourceType", "sourcePackage", "latestAvailableVersion",
-         "manifest", "isListed")
-       VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12)`,
+         "manifest", "isListed", "category")
+       VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13)`,
       [
         id,
         params.universalIdentifier,
@@ -92,6 +93,7 @@ describe('Marketplace Catalog Sync (integration)', () => {
         params.latestAvailableVersion ?? '1.0.0',
         params.manifest ? JSON.stringify(params.manifest) : null,
         true,
+        params.category ?? null,
       ],
     );
 
@@ -146,6 +148,7 @@ describe('Marketplace Catalog Sync (integration)', () => {
             category: 'Data',
           },
         },
+        category: 'Data',
       });
     });
 


### PR DESCRIPTION
Part of the application settings architecture work: https://github.com/twentyhq/core-team-issues/issues/2456 — follow-up to #22453, delivering the promised removal of the temporary manifest load.

Display data (description, author, category, websiteUrl, aboutDescription, termsUrl, emailSupport, issueReportUrl, screenshots) only existed inside the `manifest` jsonb, forcing hot paths to load it. This PR:

- Promotes those 9 fields to first-class columns on `applicationRegistration`, populated at every ingestion point (`updateFromManifest`, both `upsertFromCatalog` branches) — fast command creates the columns at deploy, slow command backfills them from the manifest.
- `findManyListedCatalogCards()` (marketplace list) now selects only scalar columns — the manifest jsonb is no longer loaded there.
- `findPublicByClientId()` (OAuth consent page) now selects `id, name, logo, websiteUrl, oAuthScopes` — no manifest.
- The narrow select used by `findMany`/`findAll`/`findOneById`/`findOneByIdGlobal` includes the new columns.
- GraphQL surface unchanged (no new fields); the marketplace detail endpoint still reads the manifest and is slimmed in the next PR.

Verified: migration applied via the real runner (both commands recorded completed), backfill SQL exercised against live rows (full + minimal manifests), migration generator reports no pending schema changes, typecheck, lint, unit suites (application-registration + marketplace 15/15).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011sST4rPLU1Koi2oVGi84ei

---
_Generated by [Claude Code](https://claude.ai/code/session_011sST4rPLU1Koi2oVGi84ei)_

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/22513?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

