### PR TITLE
feat(server): drain queue workers gracefully on SIGTERM

### DIFF
--- a/packages/twenty-server/src/engine/core-modules/message-queue/drivers/bullmq.driver.ts
+++ b/packages/twenty-server/src/engine/core-modules/message-queue/drivers/bullmq.driver.ts
@@ -98,8 +98,11 @@ export class BullMQDriver
       );
     }
 
-    await Promise.all(workers.map(([, worker]) => worker.close()));
-    await Promise.all(queues.map((queue) => queue.close()));
+    try {
+      await Promise.all(workers.map(([, worker]) => worker.close()));
+    } finally {
+      await Promise.all(queues.map((queue) => queue.close()));
+    }
 
     this.logger.log('Message queue shutdown complete');
   }

--- a/packages/twenty-server/src/engine/core-modules/message-queue/drivers/bullmq.driver.ts
+++ b/packages/twenty-server/src/engine/core-modules/message-queue/drivers/bullmq.driver.ts
@@ -98,8 +98,6 @@ export class BullMQDriver
       );
     }
 
-    // Workers close first so jobs finishing during the drain can still
-    // enqueue follow-up jobs through the queue instances
     await Promise.all(workers.map(([, worker]) => worker.close()));
     await Promise.all(queues.map((queue) => queue.close()));
 

--- a/packages/twenty-server/src/engine/core-modules/message-queue/drivers/bullmq.driver.ts
+++ b/packages/twenty-server/src/engine/core-modules/message-queue/drivers/bullmq.driver.ts
@@ -98,10 +98,28 @@ export class BullMQDriver
       );
     }
 
+    let workerCloseError: unknown;
+
     try {
       await Promise.all(workers.map(([, worker]) => worker.close()));
-    } finally {
+    } catch (error) {
+      workerCloseError = error;
+    }
+
+    try {
       await Promise.all(queues.map((queue) => queue.close()));
+    } catch (error) {
+      if (!isDefined(workerCloseError)) {
+        throw error;
+      }
+
+      this.logger.error(
+        `Failed to close queues during shutdown: ${error instanceof Error ? error.message : String(error)}`,
+      );
+    }
+
+    if (isDefined(workerCloseError)) {
+      throw workerCloseError;
     }
 
     this.logger.log('Message queue shutdown complete');

--- a/packages/twenty-server/src/engine/core-modules/message-queue/drivers/bullmq.driver.ts
+++ b/packages/twenty-server/src/engine/core-modules/message-queue/drivers/bullmq.driver.ts
@@ -89,13 +89,21 @@ export class BullMQDriver
   }
 
   async onModuleDestroy() {
-    const workers = Object.values(this.workerMap);
+    const workers = Object.entries(this.workerMap);
     const queues = Object.values(this.queueMap);
 
-    await Promise.all([
-      ...queues.map((q) => q.close()),
-      ...workers.map((w) => w.close()),
-    ]);
+    if (workers.length > 0) {
+      this.logger.log(
+        `Draining active jobs on queues: ${workers.map(([queueName]) => queueName).join(', ')}`,
+      );
+    }
+
+    // Workers close first so jobs finishing during the drain can still
+    // enqueue follow-up jobs through the queue instances
+    await Promise.all(workers.map(([, worker]) => worker.close()));
+    await Promise.all(queues.map((queue) => queue.close()));
+
+    this.logger.log('Message queue shutdown complete');
   }
 
   work<T>(

--- a/packages/twenty-server/src/main.ts
+++ b/packages/twenty-server/src/main.ts
@@ -35,6 +35,9 @@ const bootstrap = async () => {
     // resource_metadata pointer on 401. Required by MCP authorization spec.
     cors: { exposedHeaders: ['WWW-Authenticate'] },
     bufferLogs: process.env.LOGGER_IS_BUFFER_ENABLED === 'true',
+    // Long-lived connections (subscriptions, SSE) would otherwise hold
+    // close() open until the pod is force-killed
+    forceCloseConnections: true,
     rawBody: true,
     snapshot: process.env.NODE_ENV === NodeEnvironment.DEVELOPMENT,
     ...(process.env.SSL_KEY_PATH && process.env.SSL_CERT_PATH
@@ -112,6 +115,8 @@ const bootstrap = async () => {
 
   httpServer.keepAliveTimeout = keepAliveTimeout;
   httpServer.headersTimeout = keepAliveTimeout + 1000;
+
+  app.enableShutdownHooks();
 
   await app.listen(twentyConfigService.get('NODE_PORT'));
 };

--- a/packages/twenty-server/src/main.ts
+++ b/packages/twenty-server/src/main.ts
@@ -35,7 +35,6 @@ const bootstrap = async () => {
     // resource_metadata pointer on 401. Required by MCP authorization spec.
     cors: { exposedHeaders: ['WWW-Authenticate'] },
     bufferLogs: process.env.LOGGER_IS_BUFFER_ENABLED === 'true',
-    forceCloseConnections: true,
     rawBody: true,
     snapshot: process.env.NODE_ENV === NodeEnvironment.DEVELOPMENT,
     ...(process.env.SSL_KEY_PATH && process.env.SSL_CERT_PATH
@@ -113,8 +112,6 @@ const bootstrap = async () => {
 
   httpServer.keepAliveTimeout = keepAliveTimeout;
   httpServer.headersTimeout = keepAliveTimeout + 1000;
-
-  app.enableShutdownHooks();
 
   await app.listen(twentyConfigService.get('NODE_PORT'));
 };

--- a/packages/twenty-server/src/main.ts
+++ b/packages/twenty-server/src/main.ts
@@ -35,8 +35,6 @@ const bootstrap = async () => {
     // resource_metadata pointer on 401. Required by MCP authorization spec.
     cors: { exposedHeaders: ['WWW-Authenticate'] },
     bufferLogs: process.env.LOGGER_IS_BUFFER_ENABLED === 'true',
-    // Long-lived connections (subscriptions, SSE) would otherwise hold
-    // close() open until the pod is force-killed
     forceCloseConnections: true,
     rawBody: true,
     snapshot: process.env.NODE_ENV === NodeEnvironment.DEVELOPMENT,

--- a/packages/twenty-server/src/queue-worker/queue-worker.ts
+++ b/packages/twenty-server/src/queue-worker/queue-worker.ts
@@ -21,7 +21,6 @@ async function bootstrap() {
     // Inject our logger
     app.useLogger(loggerService ?? false);
 
-    // SIGTERM triggers onModuleDestroy so the queue driver drains active jobs
     app.enableShutdownHooks();
   } catch (err) {
     loggerService?.error(err?.message, err?.name);

--- a/packages/twenty-server/src/queue-worker/queue-worker.ts
+++ b/packages/twenty-server/src/queue-worker/queue-worker.ts
@@ -20,6 +20,9 @@ async function bootstrap() {
 
     // Inject our logger
     app.useLogger(loggerService ?? false);
+
+    // SIGTERM triggers onModuleDestroy so the queue driver drains active jobs
+    app.enableShutdownHooks();
   } catch (err) {
     loggerService?.error(err?.message, err?.name);
 


### PR DESCRIPTION
## Why

Deploys kill workers mid-job: neither the queue worker nor the API server ever calls `enableShutdownHooks()`, so NestJS never listens for SIGTERM and the graceful close in `BullMQDriver.onModuleDestroy` is dead code. On every rollout a worker dies instantly — an in-flight 10-minute AI stream freezes for the watching user, and BullMQ silently re-runs the half-executed job on another worker ~10 minutes later.

This is the root cause, not a symptom: the correct drain semantics already exist in the driver (`worker.close()` waits for active jobs and stops picking new ones, per the BullMQ graceful-shutdown docs) — the process just never received the signal.

## What

- `queue-worker.ts` + `main.ts`: enable shutdown hooks. SIGTERM now runs `onModuleDestroy` across providers: the BullMQ driver drains active jobs, `RedisClientService` and the AI cancel subscriber quit their Redis connections, TypeORM closes its pools, then the process exits on its own.
- BullMQ close order: workers drain before queues close, so a job finishing during the drain can still enqueue follow-ups (e.g. the AI queue flushing the next queued message).
- API server: `forceCloseConnections` so long-lived subscription sockets don't hold `close()` open until the pod is force-killed. They were dropped abruptly on every deploy before this PR too — clients already recover.
- Drain start/completion logs so pod terminations are debuggable.

## User impact

Deploys stop corrupting in-flight background work. Follow-ups build on this: bounded drain-then-abort for AI stream jobs, and eliminating the stalled-job zombie re-run.

## Validation

- Local: SIGTERM'd a running worker mid-job — drain log appears, the active job completes, "Message queue shutdown complete" is logged, process exits by itself. (Also verified with `LOGGER_IS_BUFFER_ENABLED=true` that final logs are not swallowed.)
- The k8s side (termination grace period ≥ drain budget, exec'ing `node` directly so PID 1 receives SIGTERM) lands separately in twenty-infra.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/22514?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

