### PR TITLE
Validate role scope when assigning a role to an API key

### DIFF
--- a/packages/twenty-server/src/engine/core-modules/api-key/api-key.resolver.ts
+++ b/packages/twenty-server/src/engine/core-modules/api-key/api-key.resolver.ts
@@ -14,10 +14,12 @@ import { RevokeApiKeyInput } from 'src/engine/core-modules/api-key/dtos/revoke-a
 import { UpdateApiKeyInput } from 'src/engine/core-modules/api-key/dtos/update-api-key.input';
 import { apiKeyGraphqlApiExceptionHandler } from 'src/engine/core-modules/api-key/utils/api-key-graphql-api-exception-handler.util';
 import { WorkspaceEntity } from 'src/engine/core-modules/workspace/workspace.entity';
+import { AuthUserWorkspaceId } from 'src/engine/decorators/auth/auth-user-workspace-id.decorator';
 import { AuthWorkspace } from 'src/engine/decorators/auth/auth-workspace.decorator';
 import { RequireAccessTokenGuard } from 'src/engine/guards/require-access-token.guard';
 import { SettingsPermissionGuard } from 'src/engine/guards/settings-permission.guard';
 import { WorkspaceAuthGuard } from 'src/engine/guards/workspace-auth.guard';
+import { PermissionsService } from 'src/engine/metadata-modules/permissions/permissions.service';
 import { PermissionsGraphqlApiExceptionFilter } from 'src/engine/metadata-modules/permissions/utils/permissions-graphql-api-exception.filter';
 import { RoleDTO } from 'src/engine/metadata-modules/role/dtos/role.dto';
 
@@ -34,6 +36,7 @@ export class ApiKeyResolver {
   constructor(
     private readonly apiKeyService: ApiKeyService,
     private readonly apiKeyRoleService: ApiKeyRoleService,
+    private readonly permissionsService: PermissionsService,
   ) {}
 
   @Query(() => [ApiKeyEntity])
@@ -68,8 +71,15 @@ export class ApiKeyResolver {
   @Mutation(() => ApiKeyEntity)
   async createApiKey(
     @AuthWorkspace() workspace: WorkspaceEntity,
+    @AuthUserWorkspaceId() userWorkspaceId: string,
     @Args('input') input: CreateApiKeyInput,
   ): Promise<ApiKeyEntity> {
+    await this.permissionsService.validateUserWorkspaceCanAssignRoleOrThrow({
+      userWorkspaceId,
+      workspaceId: workspace.id,
+      roleId: input.roleId,
+    });
+
     return this.apiKeyService.create({
       name: input.name,
       expiresAt: new Date(input.expiresAt),
@@ -110,10 +120,17 @@ export class ApiKeyResolver {
   @Mutation(() => Boolean)
   async assignRoleToApiKey(
     @AuthWorkspace() workspace: WorkspaceEntity,
+    @AuthUserWorkspaceId() userWorkspaceId: string,
     @Args('apiKeyId', { type: () => UUIDScalarType }) apiKeyId: string,
     @Args('roleId', { type: () => UUIDScalarType }) roleId: string,
   ): Promise<boolean> {
     try {
+      await this.permissionsService.validateUserWorkspaceCanAssignRoleOrThrow({
+        userWorkspaceId,
+        workspaceId: workspace.id,
+        roleId,
+      });
+
       await this.apiKeyRoleService.assignRoleToApiKey({
         apiKeyId,
         roleId,

--- a/packages/twenty-server/src/engine/metadata-modules/permissions/permissions.service.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/permissions/permissions.service.ts
@@ -238,6 +238,90 @@ export class PermissionsService {
     );
   }
 
+  public async validateUserWorkspaceCanAssignRoleOrThrow({
+    userWorkspaceId,
+    workspaceId,
+    roleId,
+  }: {
+    userWorkspaceId: string;
+    workspaceId: string;
+    roleId: string;
+  }): Promise<void> {
+    const roleToAssign = await this.roleRepository.findOne(workspaceId, {
+      where: { id: roleId },
+      relations: ['rolePermissionFlags', 'rolePermissionFlags.permissionFlag'],
+    });
+
+    if (!isDefined(roleToAssign)) {
+      throw new PermissionsException(
+        PermissionsExceptionMessage.ROLE_NOT_FOUND,
+        PermissionsExceptionCode.ROLE_NOT_FOUND,
+      );
+    }
+
+    const callerRoles = await this.userRoleService
+      .getRolesByUserWorkspaces({
+        userWorkspaceIds: [userWorkspaceId],
+        workspaceId,
+      })
+      .then(
+        (rolesByUserWorkspace) =>
+          rolesByUserWorkspace.get(userWorkspaceId) ?? [],
+      );
+
+    if (callerRoles.length === 0) {
+      throw new PermissionsException(
+        PermissionsExceptionMessage.NO_ROLE_FOUND_FOR_USER_WORKSPACE,
+        PermissionsExceptionCode.NO_ROLE_FOUND_FOR_USER_WORKSPACE,
+      );
+    }
+
+    if (!this.callerRolesCoverRolePermissions({ callerRoles, roleToAssign })) {
+      throw new PermissionsException(
+        PermissionsExceptionMessage.PERMISSION_DENIED,
+        PermissionsExceptionCode.PERMISSION_DENIED,
+      );
+    }
+  }
+
+  private callerRolesCoverRolePermissions({
+    callerRoles,
+    roleToAssign,
+  }: {
+    callerRoles: RoleEntity[];
+    roleToAssign: RoleEntity;
+  }): boolean {
+    // canUpdateAllSettings / canAccessAllTools are intentionally omitted here:
+    // they are fully expanded into the per-flag check below (a role with
+    // canUpdateAllSettings grants every settings flag).
+    const objectRecordPermissions = [
+      'canReadAllObjectRecords',
+      'canUpdateAllObjectRecords',
+      'canSoftDeleteAllObjectRecords',
+      'canDestroyAllObjectRecords',
+    ] as const;
+
+    const callerCoversObjectRecordPermissions = objectRecordPermissions.every(
+      (objectRecordPermission) =>
+        !roleToAssign[objectRecordPermission] ||
+        callerRoles.some((callerRole) => callerRole[objectRecordPermission]),
+    );
+
+    if (!callerCoversObjectRecordPermissions) {
+      return false;
+    }
+
+    return Object.values(PermissionFlagType).every((flag) => {
+      if (!this.checkRolePermissions(roleToAssign, flag)) {
+        return true;
+      }
+
+      return callerRoles.some((callerRole) =>
+        this.checkRolePermissions(callerRole, flag),
+      );
+    });
+  }
+
   public checkRolePermissions(
     role: RoleEntity,
     setting: PermissionFlagType,

--- a/packages/twenty-server/test/integration/graphql/suites/settings-permissions/api-key-role-assignment-scope.integration-spec.ts
+++ b/packages/twenty-server/test/integration/graphql/suites/settings-permissions/api-key-role-assignment-scope.integration-spec.ts
@@ -12,11 +12,10 @@ import { WORKSPACE_MEMBER_DATA_SEED_IDS } from 'src/engine/workspace-manager/dev
 
 const client = request(`http://localhost:${APP_PORT}`);
 
-// A workspace member whose role only carries the API_KEYS_AND_WEBHOOKS flag must
-// not be able to mint (or re-assign) an API key bound to a role that grants more
-// permissions than the member itself holds. Otherwise the member could escalate
-// to Admin through the API key token.
-describe('API key role privilege escalation', () => {
+// The role bound to an API key must stay within the caller's own permission
+// scope: a member can bind a role equal to or narrower than what they hold, but
+// not one that grants more permissions than they have.
+describe('API key role assignment scope', () => {
   let customRoleId: string;
   let originalMemberRoleId: string;
   let adminRoleId: string;
@@ -118,7 +117,7 @@ describe('API key role privilege escalation', () => {
     it('should deny minting an API key bound to a role that exceeds the caller permissions', async () => {
       const { data, errors } = await createApiKey({
         input: {
-          name: 'escalation-key',
+          name: 'above-scope-key',
           expiresAt: '2027-01-01T00:00:00.000Z',
           roleId: adminRoleId,
         },
@@ -166,7 +165,7 @@ describe('API key role privilege escalation', () => {
     it('should deny re-assigning an API key to a role that exceeds the caller permissions', async () => {
       const { data: createData } = await createApiKey({
         input: {
-          name: 'assign-escalation-key',
+          name: 'above-scope-reassign-key',
           expiresAt: '2027-01-01T00:00:00.000Z',
           roleId: customRoleId,
         },

--- a/packages/twenty-server/test/integration/graphql/suites/settings-permissions/api-key-role-privilege-escalation.integration-spec.ts
+++ b/packages/twenty-server/test/integration/graphql/suites/settings-permissions/api-key-role-privilege-escalation.integration-spec.ts
@@ -1,5 +1,7 @@
 import request from 'supertest';
 import { deleteOneRoleOperationFactory } from 'test/integration/graphql/utils/delete-one-role-operation-factory.util';
+import { assignRoleToApiKey } from 'test/integration/metadata/suites/developers/utils/assign-role-to-api-key.util';
+import { createApiKey } from 'test/integration/metadata/suites/developers/utils/create-api-key.util';
 import { findOneRoleByLabel } from 'test/integration/metadata/suites/role/utils/find-one-role-by-label.util';
 import { updateWorkspaceMemberRole } from 'test/integration/metadata/suites/role/utils/update-workspace-member-role.util';
 import { PermissionFlagType } from 'twenty-shared/constants';
@@ -114,118 +116,84 @@ describe('API key role privilege escalation', () => {
 
   describe('createApiKey', () => {
     it('should deny minting an API key bound to a role that exceeds the caller permissions', async () => {
-      const createApiKeyQuery = {
-        query: `
-          mutation CreateApiKey {
-            createApiKey(input: {
-              name: "escalation-key"
-              expiresAt: "2027-01-01T00:00:00.000Z"
-              roleId: "${adminRoleId}"
-            }) {
-              id
-            }
-          }
-        `,
-      };
+      const { data, errors } = await createApiKey({
+        input: {
+          name: 'escalation-key',
+          expiresAt: '2027-01-01T00:00:00.000Z',
+          roleId: adminRoleId,
+        },
+        gqlFields: 'id',
+        expectToFail: true,
+        token: APPLE_JONY_MEMBER_ACCESS_TOKEN,
+      });
 
-      const response = await client
-        .post('/metadata')
-        .set('Authorization', `Bearer ${APPLE_JONY_MEMBER_ACCESS_TOKEN}`)
-        .send(createApiKeyQuery);
-
-      if (response.body?.data?.createApiKey?.id) {
-        createdApiKeyIds.push(response.body.data.createApiKey.id);
+      if (data?.createApiKey?.id) {
+        createdApiKeyIds.push(data.createApiKey.id);
       }
 
-      expect(response.status).toBe(200);
-      expect(response.body.data).toBeNull();
-      expect(response.body.errors).toBeDefined();
-      expect(response.body.errors[0].message).toBe(
+      expect(data).toBeNull();
+      expect(errors).toBeDefined();
+      expect(errors[0].message).toBe(
         PermissionsExceptionMessage.PERMISSION_DENIED,
       );
-      expect(response.body.errors[0].extensions.code).toBe(ErrorCode.FORBIDDEN);
+      expect(errors[0].extensions.code).toBe(ErrorCode.FORBIDDEN);
     });
 
     it('should allow minting an API key bound to a role within the caller permissions', async () => {
-      const createApiKeyQuery = {
-        query: `
-          mutation CreateApiKey {
-            createApiKey(input: {
-              name: "legit-key"
-              expiresAt: "2027-01-01T00:00:00.000Z"
-              roleId: "${customRoleId}"
-            }) {
-              id
-            }
-          }
-        `,
-      };
+      const { data, errors } = await createApiKey({
+        input: {
+          name: 'legit-key',
+          expiresAt: '2027-01-01T00:00:00.000Z',
+          roleId: customRoleId,
+        },
+        gqlFields: 'id',
+        expectToFail: false,
+        token: APPLE_JONY_MEMBER_ACCESS_TOKEN,
+      });
 
-      const response = await client
-        .post('/metadata')
-        .set('Authorization', `Bearer ${APPLE_JONY_MEMBER_ACCESS_TOKEN}`)
-        .send(createApiKeyQuery);
-
-      const createdApiKeyId = response.body?.data?.createApiKey?.id;
+      const createdApiKeyId = data?.createApiKey?.id;
 
       if (createdApiKeyId) {
         createdApiKeyIds.push(createdApiKeyId);
       }
 
-      expect(response.status).toBe(200);
-      expect(response.body.errors).toBeUndefined();
+      expect(errors).toBeUndefined();
       expect(createdApiKeyId).toBeDefined();
     });
   });
 
   describe('assignRoleToApiKey', () => {
     it('should deny re-assigning an API key to a role that exceeds the caller permissions', async () => {
-      const createApiKeyQuery = {
-        query: `
-          mutation CreateApiKey {
-            createApiKey(input: {
-              name: "assign-escalation-key"
-              expiresAt: "2027-01-01T00:00:00.000Z"
-              roleId: "${customRoleId}"
-            }) {
-              id
-            }
-          }
-        `,
-      };
+      const { data: createData } = await createApiKey({
+        input: {
+          name: 'assign-escalation-key',
+          expiresAt: '2027-01-01T00:00:00.000Z',
+          roleId: customRoleId,
+        },
+        gqlFields: 'id',
+        expectToFail: false,
+        token: APPLE_JONY_MEMBER_ACCESS_TOKEN,
+      });
 
-      const createResponse = await client
-        .post('/metadata')
-        .set('Authorization', `Bearer ${APPLE_JONY_MEMBER_ACCESS_TOKEN}`)
-        .send(createApiKeyQuery);
-
-      const apiKeyId = createResponse.body.data.createApiKey.id;
+      const apiKeyId = createData.createApiKey.id;
 
       createdApiKeyIds.push(apiKeyId);
 
-      const assignRoleQuery = {
-        query: `
-          mutation AssignRoleToApiKey {
-            assignRoleToApiKey(
-              apiKeyId: "${apiKeyId}"
-              roleId: "${adminRoleId}"
-            )
-          }
-        `,
-      };
+      const { data, errors } = await assignRoleToApiKey({
+        input: {
+          apiKeyId,
+          roleId: adminRoleId,
+        },
+        expectToFail: true,
+        token: APPLE_JONY_MEMBER_ACCESS_TOKEN,
+      });
 
-      const response = await client
-        .post('/metadata')
-        .set('Authorization', `Bearer ${APPLE_JONY_MEMBER_ACCESS_TOKEN}`)
-        .send(assignRoleQuery);
-
-      expect(response.status).toBe(200);
-      expect(response.body.data).toBeNull();
-      expect(response.body.errors).toBeDefined();
-      expect(response.body.errors[0].message).toBe(
+      expect(data).toBeNull();
+      expect(errors).toBeDefined();
+      expect(errors[0].message).toBe(
         PermissionsExceptionMessage.PERMISSION_DENIED,
       );
-      expect(response.body.errors[0].extensions.code).toBe(ErrorCode.FORBIDDEN);
+      expect(errors[0].extensions.code).toBe(ErrorCode.FORBIDDEN);
     });
   });
 });

--- a/packages/twenty-server/test/integration/graphql/suites/settings-permissions/api-key-role-privilege-escalation.integration-spec.ts
+++ b/packages/twenty-server/test/integration/graphql/suites/settings-permissions/api-key-role-privilege-escalation.integration-spec.ts
@@ -1,0 +1,231 @@
+import request from 'supertest';
+import { deleteOneRoleOperationFactory } from 'test/integration/graphql/utils/delete-one-role-operation-factory.util';
+import { findOneRoleByLabel } from 'test/integration/metadata/suites/role/utils/find-one-role-by-label.util';
+import { updateWorkspaceMemberRole } from 'test/integration/metadata/suites/role/utils/update-workspace-member-role.util';
+import { PermissionFlagType } from 'twenty-shared/constants';
+
+import { ErrorCode } from 'src/engine/core-modules/graphql/utils/graphql-errors.util';
+import { PermissionsExceptionMessage } from 'src/engine/metadata-modules/permissions/permissions.exception';
+import { WORKSPACE_MEMBER_DATA_SEED_IDS } from 'src/engine/workspace-manager/dev-seeder/data/constants/workspace-member-data-seeds.constant';
+
+const client = request(`http://localhost:${APP_PORT}`);
+
+// A workspace member whose role only carries the API_KEYS_AND_WEBHOOKS flag must
+// not be able to mint (or re-assign) an API key bound to a role that grants more
+// permissions than the member itself holds. Otherwise the member could escalate
+// to Admin through the API key token.
+describe('API key role privilege escalation', () => {
+  let customRoleId: string;
+  let originalMemberRoleId: string;
+  let adminRoleId: string;
+  const createdApiKeyIds: string[] = [];
+
+  beforeAll(async () => {
+    const memberRole = await findOneRoleByLabel({ label: 'Member' });
+
+    originalMemberRoleId = memberRole.id;
+
+    const adminRole = await findOneRoleByLabel({ label: 'Admin' });
+
+    adminRoleId = adminRole.id;
+
+    const createRoleQuery = {
+      query: `
+        mutation CreateOneRole {
+          createOneRole(createRoleInput: {
+            label: "Api Key Escalation Test Role"
+            description: "Role that only holds API_KEYS_AND_WEBHOOKS"
+            canUpdateAllSettings: false
+            canReadAllObjectRecords: true
+            canUpdateAllObjectRecords: true
+            canSoftDeleteAllObjectRecords: false
+            canDestroyAllObjectRecords: false
+          }) {
+            id
+          }
+        }
+      `,
+    };
+
+    const createRoleResponse = await client
+      .post('/metadata')
+      .set('Authorization', `Bearer ${APPLE_JANE_ADMIN_ACCESS_TOKEN}`)
+      .send(createRoleQuery);
+
+    customRoleId = createRoleResponse.body.data.createOneRole.id;
+
+    const upsertPermissionFlagsQuery = {
+      query: `
+        mutation UpsertPermissionFlags {
+          upsertPermissionFlags(upsertPermissionFlagsInput: {
+            roleId: "${customRoleId}"
+            permissionFlagKeys: ["${PermissionFlagType.API_KEYS_AND_WEBHOOKS}"]
+          }) {
+            id
+          }
+        }
+      `,
+    };
+
+    await client
+      .post('/metadata')
+      .set('Authorization', `Bearer ${APPLE_JANE_ADMIN_ACCESS_TOKEN}`)
+      .send(upsertPermissionFlagsQuery);
+
+    await updateWorkspaceMemberRole({
+      input: {
+        roleId: customRoleId,
+        workspaceMemberId: WORKSPACE_MEMBER_DATA_SEED_IDS.JONY,
+      },
+      expectToFail: false,
+    });
+  });
+
+  afterAll(async () => {
+    await updateWorkspaceMemberRole({
+      input: {
+        workspaceMemberId: WORKSPACE_MEMBER_DATA_SEED_IDS.JONY,
+        roleId: originalMemberRoleId,
+      },
+      expectToFail: false,
+    });
+
+    // Remove role targets first: deleting an apiKey row does not cascade to its
+    // roleTarget, and a lingering roleTarget would block the role deletion.
+    await testDataSource
+      .query('DELETE FROM core."roleTarget" WHERE "roleId" = $1', [
+        customRoleId,
+      ])
+      .catch(() => {});
+
+    for (const apiKeyId of createdApiKeyIds) {
+      await testDataSource
+        .query('DELETE FROM core."apiKey" WHERE id = $1', [apiKeyId])
+        .catch(() => {});
+    }
+
+    const deleteRoleQuery = deleteOneRoleOperationFactory(customRoleId);
+
+    await client
+      .post('/metadata')
+      .set('Authorization', `Bearer ${APPLE_JANE_ADMIN_ACCESS_TOKEN}`)
+      .send(deleteRoleQuery);
+  });
+
+  describe('createApiKey', () => {
+    it('should deny minting an API key bound to a role that exceeds the caller permissions', async () => {
+      const createApiKeyQuery = {
+        query: `
+          mutation CreateApiKey {
+            createApiKey(input: {
+              name: "escalation-key"
+              expiresAt: "2027-01-01T00:00:00.000Z"
+              roleId: "${adminRoleId}"
+            }) {
+              id
+            }
+          }
+        `,
+      };
+
+      const response = await client
+        .post('/metadata')
+        .set('Authorization', `Bearer ${APPLE_JONY_MEMBER_ACCESS_TOKEN}`)
+        .send(createApiKeyQuery);
+
+      if (response.body?.data?.createApiKey?.id) {
+        createdApiKeyIds.push(response.body.data.createApiKey.id);
+      }
+
+      expect(response.status).toBe(200);
+      expect(response.body.data).toBeNull();
+      expect(response.body.errors).toBeDefined();
+      expect(response.body.errors[0].message).toBe(
+        PermissionsExceptionMessage.PERMISSION_DENIED,
+      );
+      expect(response.body.errors[0].extensions.code).toBe(ErrorCode.FORBIDDEN);
+    });
+
+    it('should allow minting an API key bound to a role within the caller permissions', async () => {
+      const createApiKeyQuery = {
+        query: `
+          mutation CreateApiKey {
+            createApiKey(input: {
+              name: "legit-key"
+              expiresAt: "2027-01-01T00:00:00.000Z"
+              roleId: "${customRoleId}"
+            }) {
+              id
+            }
+          }
+        `,
+      };
+
+      const response = await client
+        .post('/metadata')
+        .set('Authorization', `Bearer ${APPLE_JONY_MEMBER_ACCESS_TOKEN}`)
+        .send(createApiKeyQuery);
+
+      const createdApiKeyId = response.body?.data?.createApiKey?.id;
+
+      if (createdApiKeyId) {
+        createdApiKeyIds.push(createdApiKeyId);
+      }
+
+      expect(response.status).toBe(200);
+      expect(response.body.errors).toBeUndefined();
+      expect(createdApiKeyId).toBeDefined();
+    });
+  });
+
+  describe('assignRoleToApiKey', () => {
+    it('should deny re-assigning an API key to a role that exceeds the caller permissions', async () => {
+      const createApiKeyQuery = {
+        query: `
+          mutation CreateApiKey {
+            createApiKey(input: {
+              name: "assign-escalation-key"
+              expiresAt: "2027-01-01T00:00:00.000Z"
+              roleId: "${customRoleId}"
+            }) {
+              id
+            }
+          }
+        `,
+      };
+
+      const createResponse = await client
+        .post('/metadata')
+        .set('Authorization', `Bearer ${APPLE_JONY_MEMBER_ACCESS_TOKEN}`)
+        .send(createApiKeyQuery);
+
+      const apiKeyId = createResponse.body.data.createApiKey.id;
+
+      createdApiKeyIds.push(apiKeyId);
+
+      const assignRoleQuery = {
+        query: `
+          mutation AssignRoleToApiKey {
+            assignRoleToApiKey(
+              apiKeyId: "${apiKeyId}"
+              roleId: "${adminRoleId}"
+            )
+          }
+        `,
+      };
+
+      const response = await client
+        .post('/metadata')
+        .set('Authorization', `Bearer ${APPLE_JONY_MEMBER_ACCESS_TOKEN}`)
+        .send(assignRoleQuery);
+
+      expect(response.status).toBe(200);
+      expect(response.body.data).toBeNull();
+      expect(response.body.errors).toBeDefined();
+      expect(response.body.errors[0].message).toBe(
+        PermissionsExceptionMessage.PERMISSION_DENIED,
+      );
+      expect(response.body.errors[0].extensions.code).toBe(ErrorCode.FORBIDDEN);
+    });
+  });
+});

--- a/packages/twenty-server/test/integration/metadata/suites/developers/utils/assign-role-to-api-key-query-factory.util.ts
+++ b/packages/twenty-server/test/integration/metadata/suites/developers/utils/assign-role-to-api-key-query-factory.util.ts
@@ -1,0 +1,22 @@
+import gql from 'graphql-tag';
+
+export type AssignRoleToApiKeyInput = {
+  apiKeyId: string;
+  roleId: string;
+};
+
+export const assignRoleToApiKeyQueryFactory = ({
+  input,
+}: {
+  input: AssignRoleToApiKeyInput;
+}) => ({
+  query: gql`
+    mutation AssignRoleToApiKey($apiKeyId: UUID!, $roleId: UUID!) {
+      assignRoleToApiKey(apiKeyId: $apiKeyId, roleId: $roleId)
+    }
+  `,
+  variables: {
+    apiKeyId: input.apiKeyId,
+    roleId: input.roleId,
+  },
+});

--- a/packages/twenty-server/test/integration/metadata/suites/developers/utils/assign-role-to-api-key.util.ts
+++ b/packages/twenty-server/test/integration/metadata/suites/developers/utils/assign-role-to-api-key.util.ts
@@ -1,0 +1,40 @@
+import {
+  type AssignRoleToApiKeyInput,
+  assignRoleToApiKeyQueryFactory,
+} from 'test/integration/metadata/suites/developers/utils/assign-role-to-api-key-query-factory.util';
+import { makeMetadataAPIRequest } from 'test/integration/metadata/suites/utils/make-metadata-api-request.util';
+import { type CommonResponseBody } from 'test/integration/metadata/types/common-response-body.type';
+import { warnIfErrorButNotExpectedToFail } from 'test/integration/metadata/utils/warn-if-error-but-not-expected-to-fail.util';
+import { warnIfNoErrorButExpectedToFail } from 'test/integration/metadata/utils/warn-if-no-error-but-expected-to-fail.util';
+
+export const assignRoleToApiKey = async ({
+  input,
+  expectToFail = false,
+  token,
+}: {
+  input: AssignRoleToApiKeyInput;
+  expectToFail?: boolean;
+  token?: string;
+}): CommonResponseBody<{
+  assignRoleToApiKey: boolean;
+}> => {
+  const graphqlOperation = assignRoleToApiKeyQueryFactory({ input });
+
+  const response = await makeMetadataAPIRequest(graphqlOperation, token);
+
+  if (expectToFail === true) {
+    warnIfNoErrorButExpectedToFail({
+      response,
+      errorMessage: 'API key role assignment should have failed but did not',
+    });
+  }
+
+  if (expectToFail === false) {
+    warnIfErrorButNotExpectedToFail({
+      response,
+      errorMessage: 'API key role assignment has failed but should not',
+    });
+  }
+
+  return { data: response.body.data, errors: response.body.errors };
+};

--- a/packages/twenty-server/test/integration/metadata/suites/developers/utils/create-api-key-query-factory.util.ts
+++ b/packages/twenty-server/test/integration/metadata/suites/developers/utils/create-api-key-query-factory.util.ts
@@ -1,0 +1,38 @@
+import gql from 'graphql-tag';
+
+export type CreateApiKeyInput = {
+  name: string;
+  expiresAt: string;
+  roleId: string;
+  revokedAt?: string;
+};
+
+const DEFAULT_API_KEY_GQL_FIELDS = `
+  id
+  name
+  expiresAt
+  revokedAt
+  role {
+    id
+    label
+  }
+`;
+
+export const createApiKeyQueryFactory = ({
+  input,
+  gqlFields = DEFAULT_API_KEY_GQL_FIELDS,
+}: {
+  input: CreateApiKeyInput;
+  gqlFields?: string;
+}) => ({
+  query: gql`
+    mutation CreateApiKey($input: CreateApiKeyInput!) {
+      createApiKey(input: $input) {
+        ${gqlFields}
+      }
+    }
+  `,
+  variables: {
+    input,
+  },
+});

--- a/packages/twenty-server/test/integration/metadata/suites/developers/utils/create-api-key.util.ts
+++ b/packages/twenty-server/test/integration/metadata/suites/developers/utils/create-api-key.util.ts
@@ -1,0 +1,47 @@
+import {
+  type CreateApiKeyInput,
+  createApiKeyQueryFactory,
+} from 'test/integration/metadata/suites/developers/utils/create-api-key-query-factory.util';
+import { makeMetadataAPIRequest } from 'test/integration/metadata/suites/utils/make-metadata-api-request.util';
+import { type CommonResponseBody } from 'test/integration/metadata/types/common-response-body.type';
+import { warnIfErrorButNotExpectedToFail } from 'test/integration/metadata/utils/warn-if-error-but-not-expected-to-fail.util';
+import { warnIfNoErrorButExpectedToFail } from 'test/integration/metadata/utils/warn-if-no-error-but-expected-to-fail.util';
+
+import { type ApiKeyEntity } from 'src/engine/core-modules/api-key/api-key.entity';
+
+export const createApiKey = async ({
+  input,
+  gqlFields,
+  expectToFail = false,
+  token,
+}: {
+  input: CreateApiKeyInput;
+  gqlFields?: string;
+  expectToFail?: boolean;
+  token?: string;
+}): CommonResponseBody<{
+  createApiKey: ApiKeyEntity;
+}> => {
+  const graphqlOperation = createApiKeyQueryFactory({
+    input,
+    gqlFields,
+  });
+
+  const response = await makeMetadataAPIRequest(graphqlOperation, token);
+
+  if (expectToFail === true) {
+    warnIfNoErrorButExpectedToFail({
+      response,
+      errorMessage: 'API key creation should have failed but did not',
+    });
+  }
+
+  if (expectToFail === false) {
+    warnIfErrorButNotExpectedToFail({
+      response,
+      errorMessage: 'API key creation has failed but should not',
+    });
+  }
+
+  return { data: response.body.data, errors: response.body.errors };
+};


### PR DESCRIPTION
## Context

When creating an API key (`createApiKey`) or re-assigning its role (`assignRoleToApiKey`), the bound role was accepted without comparing it to the caller's own permissions. This means the role attached to a key could grant more than the person creating it holds.

This PR makes the role assignment respect the caller's permission scope.

## What changed

- Added `validateUserWorkspaceCanAssignRoleOrThrow` in `PermissionsService`. The role being bound must be **equal to or a subset of** the caller's own permission scope — evaluated as the union across the caller's role(s), so it scales cleanly if a user ever holds several roles. The comparison covers all `PermissionFlagType` flags (with `canUpdateAllSettings` / `canAccessAllTools` expanded into their underlying flags) plus the object-record capability booleans.
- Wired the check into `createApiKey` and `assignRoleToApiKey` in `ApiKeyResolver`, using the caller's `userWorkspaceId`.
- Added integration coverage and two reusable test utils (`createApiKey`, `assignRoleToApiKey`) following the existing query-factory + wrapper convention.

## Behaviour

- A user can bind a role equal to or narrower than their own scope. ✅
- Binding a role that exceeds the caller's scope is rejected with a permission error (`FORBIDDEN`). ⛔️
- Admin flows are unchanged (admin covers every scope).

## Tests

`api-key-role-assignment-scope.integration-spec.ts` — denies an out-of-scope role on both create and re-assign, allows an in-scope role. Existing `api-keys`, `api-key-webhooks`, and `granular-settings-permissions` suites still pass.

## Notes / follow-ups

- The scope comparison currently covers permission flags + object-record booleans, which is sufficient for the settings/roles surface. Extending it to per-object / field / row-level permissions would make it a complete "no more access than me" guarantee and could be a separate hardening step.
- `updateWorkspaceMemberRole` (assigning a role to a member) is gated by the `ROLES` flag but does not yet apply this same scope check; aligning it would make the rule uniform across every role-binding path.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/22528?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

