### PR TITLE
fix(docker): bump node base to 24.17.0 for CVE-2026-48930 (critical)

### DIFF
--- a/packages/twenty-docker/twenty/Dockerfile
+++ b/packages/twenty-docker/twenty/Dockerfile
@@ -2,7 +2,7 @@
 # Dependency stages
 # ===========================================================================
 
-FROM node:24.16.0-alpine3.23@sha256:2bdb65ed1dab192432bc31c95f94155ca5ad7fc1392fb7eb7526ab682fa5bf14 AS front-deps
+FROM node:24.17.0-alpine3.23@sha256:7c70d1235c0b4c2bc9eeed5393d19f1bbdde6885ba0d58ba62bb385d7b0f3ff1 AS front-deps
 
 WORKDIR /app
 
@@ -20,7 +20,7 @@ COPY ./packages/twenty-client-sdk/package.json /app/packages/twenty-client-sdk/
 RUN yarn workspaces focus twenty twenty-front twenty-front-component-renderer twenty-ui twenty-shared twenty-sdk twenty-client-sdk && yarn cache clean && npx nx reset
 
 
-FROM node:24.16.0-alpine3.23@sha256:2bdb65ed1dab192432bc31c95f94155ca5ad7fc1392fb7eb7526ab682fa5bf14 AS server-deps
+FROM node:24.17.0-alpine3.23@sha256:7c70d1235c0b4c2bc9eeed5393d19f1bbdde6885ba0d58ba62bb385d7b0f3ff1 AS server-deps
 
 WORKDIR /app
 
@@ -84,7 +84,7 @@ RUN if [ -d /app/packages/twenty-front/build ]; then \
 #   docker build --target twenty-server -f packages/twenty-docker/twenty/Dockerfile .
 # ===========================================================================
 
-FROM node:24.16.0-alpine3.23@sha256:2bdb65ed1dab192432bc31c95f94155ca5ad7fc1392fb7eb7526ab682fa5bf14 AS twenty-server
+FROM node:24.17.0-alpine3.23@sha256:7c70d1235c0b4c2bc9eeed5393d19f1bbdde6885ba0d58ba62bb385d7b0f3ff1 AS twenty-server
 
 # Force the patched Alpine OpenSSL libs (base bakes 3.5.6-r0; repo ships
 # 3.5.7-r0). Node bundles its own OpenSSL, but psql/curl link these system
@@ -137,10 +137,10 @@ LABEL org.opencontainers.image.description="Twenty server image (no frontend)."
 #  - the Node dev headers: only node-gyp needs them and native addons are
 #    compiled in the build stages; their vendored openssl/opensslv.h is what
 #    scanners fingerprint whenever OpenSSL patches ahead of Node releases.
-# TODO(2026-06-17): the node binary statically links OpenSSL 3.5.6 (June 9
-# OpenSSL advisory fixed in 3.5.7). Bump the pinned node:24-alpine base once
-# the announced June 17, 2026 Node security release ships a 24.x linking
-# OpenSSL >= 3.5.7 — check deps/openssl/openssl/VERSION.dat on the release tag.
+# The pinned node:24.17.0-alpine base (June 18, 2026 security release) statically
+# links OpenSSL 3.5.7 and fixes CVE-2026-48930 (TLS embedded-nul hostname
+# authority rebinding, CVSS 9.8). Keep the base current when Node ships 24.x
+# security releases — the scanner flags the statically-linked node binary itself.
 RUN rm -rf /usr/local/lib/node_modules/npm /usr/local/bin/npm /usr/local/bin/npx \
       /usr/local/include/node && \
     find /app/node_modules -type d -name example -prune -exec rm -rf {} +
@@ -215,7 +215,7 @@ RUN S6_ARCH=$(cat /tmp/s6arch) && \
     echo "$NOARCH_SUM  s6-overlay-noarch.tar.xz" | sha256sum -c - && \
     echo "$ARCH_SUM  s6-overlay-arch.tar.xz" | sha256sum -c -
 
-FROM node:24.16.0-alpine3.23@sha256:2bdb65ed1dab192432bc31c95f94155ca5ad7fc1392fb7eb7526ab682fa5bf14 AS twenty-app-dev
+FROM node:24.17.0-alpine3.23@sha256:7c70d1235c0b4c2bc9eeed5393d19f1bbdde6885ba0d58ba62bb385d7b0f3ff1 AS twenty-app-dev
 
 # s6-overlay
 COPY --from=s6-fetch /tmp/s6-overlay-noarch.tar.xz /tmp/


### PR DESCRIPTION
## Problem

The `prod-twenty` ECR image is flagged **CRITICAL** by Inspector/Oneleet — currently ~99 active findings, all the same CVE, across every recent per-arch digest.

- **CVE-2026-48930** (CVSS **9.8**) — a flaw in Node.js TLS hostname handling: embedded-nul hostnames can lead to silent authority rebinding due to c-string truncation in resolver bindings. Affects all supported lines (22/24/26).
- The finding is on the statically-linked node binary (`/usr/local/bin/node`), which is **24.16.0** — the version pinned across all four stages of the Dockerfile. Every build, including the latest, is affected; this does not age out on its own.
- Fixed in the [June 18, 2026 Node security release](https://nodejs.org/en/blog/vulnerability/june-2026-security-releases) → **24.17.0**.

## Fix

Bump all four base-image stages to `node:24.17.0-alpine3.23` (digest-pinned).

This also statically links **OpenSSL 3.5.7**, which resolves the pending `TODO(2026-06-17)` OpenSSL 3.5.6 → 3.5.7 note in the same Dockerfile — so the comment is updated to reflect the current state instead of a stale TODO.

The nearby `apk` `libcrypto3/libssl3 >= 3.5.7-r0` constraints (Alpine system libs, separate from Node's bundled OpenSSL) remain correct.

## Verification

- Fixed version confirmed against the Node.js June 2026 security release blog and the Inspector finding (`fixedInVersion` for the 24.x line).
- New base digest resolved directly from Docker Hub for `node:24.17.0-alpine3.23`.
- Once merged and the image rebuilds, the new digests scan clean and Inspector auto-closes the stale findings as no image references the old digests.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/22529?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

