### PR TITLE
perf(front-component): fingerprint built-JS URLs by path for CDN caching

### DIFF
--- a/packages/twenty-front/src/modules/front-components/utils/__tests__/getFrontComponentUrl.test.ts
+++ b/packages/twenty-front/src/modules/front-components/utils/__tests__/getFrontComponentUrl.test.ts
@@ -1,0 +1,21 @@
+import { REST_API_BASE_URL } from '@/apollo/constant/rest-api-base-url';
+import { getFrontComponentUrl } from '@/front-components/utils/getFrontComponentUrl';
+
+describe('getFrontComponentUrl', () => {
+  it('builds a checksum-fingerprinted path URL when a checksum is provided', () => {
+    expect(
+      getFrontComponentUrl({
+        frontComponentId: 'front-component-id',
+        checksum: 'abc123',
+      }),
+    ).toBe(
+      `${REST_API_BASE_URL}/front-components/front-component-id/abc123.js`,
+    );
+  });
+
+  it('falls back to the bare id URL when no checksum is provided', () => {
+    expect(
+      getFrontComponentUrl({ frontComponentId: 'front-component-id' }),
+    ).toBe(`${REST_API_BASE_URL}/front-components/front-component-id`);
+  });
+});

--- a/packages/twenty-front/src/modules/front-components/utils/getFrontComponentUrl.ts
+++ b/packages/twenty-front/src/modules/front-components/utils/getFrontComponentUrl.ts
@@ -9,6 +9,6 @@ export const getFrontComponentUrl = ({
   checksum?: string;
 }): string => {
   return isDefined(checksum)
-    ? `${REST_API_BASE_URL}/front-components/${frontComponentId}?checksum=${checksum}`
+    ? `${REST_API_BASE_URL}/front-components/${frontComponentId}/${checksum}.js`
     : `${REST_API_BASE_URL}/front-components/${frontComponentId}`;
 };

--- a/packages/twenty-server/src/engine/core-modules/file/controllers/file.controller.ts
+++ b/packages/twenty-server/src/engine/core-modules/file/controllers/file.controller.ts
@@ -92,7 +92,7 @@ export class FileController {
       return res.redirect(fileResponse.presignedUrl);
     }
 
-    setFileResponseHeaders(res, fileResponse.mimeType);
+    setFileResponseHeaders(res, fileResponse.mimeType, FileFolder.PublicAsset);
 
     try {
       await pipeline(fileResponse.stream, res);

--- a/packages/twenty-server/src/engine/core-modules/file/interfaces/file-folder.interface.ts
+++ b/packages/twenty-server/src/engine/core-modules/file/interfaces/file-folder.interface.ts
@@ -8,62 +8,64 @@ registerEnumType(FileFolder, {
 
 export type FileFolderConfig = {
   ignoreExpirationToken: boolean;
-  immutable: boolean;
+  cacheControl: string | null;
 };
 
 export const IMMUTABLE_FILE_CACHE_CONTROL = 'private, max-age=86400, immutable';
 
+export const PUBLIC_ASSET_CACHE_CONTROL = 'public, max-age=3600';
+
 export const fileFolderConfigs: Record<FileFolder, FileFolderConfig> = {
   [FileFolder.CorePicture]: {
     ignoreExpirationToken: true,
-    immutable: true,
+    cacheControl: IMMUTABLE_FILE_CACHE_CONTROL,
   },
   [FileFolder.AgentChat]: {
     ignoreExpirationToken: false,
-    immutable: true,
+    cacheControl: IMMUTABLE_FILE_CACHE_CONTROL,
   },
   [FileFolder.BuiltLogicFunction]: {
     ignoreExpirationToken: false,
-    immutable: false,
+    cacheControl: null,
   },
   [FileFolder.BuiltFrontComponent]: {
     ignoreExpirationToken: false,
-    immutable: false,
+    cacheControl: IMMUTABLE_FILE_CACHE_CONTROL,
   },
   [FileFolder.PublicAsset]: {
     ignoreExpirationToken: true,
-    immutable: false,
+    cacheControl: PUBLIC_ASSET_CACHE_CONTROL,
   },
   [FileFolder.Source]: {
     ignoreExpirationToken: false,
-    immutable: false,
+    cacheControl: null,
   },
   [FileFolder.FilesField]: {
     ignoreExpirationToken: false,
-    immutable: true,
+    cacheControl: IMMUTABLE_FILE_CACHE_CONTROL,
   },
   [FileFolder.Dependencies]: {
     ignoreExpirationToken: false,
-    immutable: false,
+    cacheControl: null,
   },
   [FileFolder.Workflow]: {
     ignoreExpirationToken: false,
-    immutable: true,
+    cacheControl: IMMUTABLE_FILE_CACHE_CONTROL,
   },
   [FileFolder.EmailAttachment]: {
     ignoreExpirationToken: false,
-    immutable: true,
+    cacheControl: IMMUTABLE_FILE_CACHE_CONTROL,
   },
   [FileFolder.AppTarball]: {
     ignoreExpirationToken: false,
-    immutable: false,
+    cacheControl: null,
   },
   [FileFolder.GeneratedSdkClient]: {
     ignoreExpirationToken: false,
-    immutable: false,
+    cacheControl: null,
   },
   [FileFolder.Dpa]: {
     ignoreExpirationToken: false,
-    immutable: true,
+    cacheControl: IMMUTABLE_FILE_CACHE_CONTROL,
   },
 };

--- a/packages/twenty-server/src/engine/core-modules/file/services/file.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/file/services/file.service.ts
@@ -13,10 +13,7 @@ import {
   FileStorageExceptionCode,
 } from 'src/engine/core-modules/file-storage/interfaces/file-storage-exception';
 import { FileEntity } from 'src/engine/core-modules/file/entities/file.entity';
-import {
-  fileFolderConfigs,
-  IMMUTABLE_FILE_CACHE_CONTROL,
-} from 'src/engine/core-modules/file/interfaces/file-folder.interface';
+import { fileFolderConfigs } from 'src/engine/core-modules/file/interfaces/file-folder.interface';
 import { type FileResponse } from 'src/engine/core-modules/file/types/file-response.type';
 import { getContentDisposition } from 'src/engine/core-modules/file/utils/get-content-disposition.utils';
 import { removeFileFolderFromFileEntityPath } from 'src/engine/core-modules/file/utils/remove-file-folder-from-file-entity-path.utils';
@@ -213,9 +210,8 @@ export class FileService {
       ),
       responseContentType: mimeType,
       responseContentDisposition: getContentDisposition(mimeType),
-      responseCacheControl: fileFolderConfigs[fileFolder].immutable
-        ? IMMUTABLE_FILE_CACHE_CONTROL
-        : undefined,
+      responseCacheControl:
+        fileFolderConfigs[fileFolder].cacheControl ?? undefined,
     });
 
     if (presignedUrl) {

--- a/packages/twenty-server/src/engine/core-modules/file/utils/__tests__/set-file-response-headers.utils.spec.ts
+++ b/packages/twenty-server/src/engine/core-modules/file/utils/__tests__/set-file-response-headers.utils.spec.ts
@@ -124,16 +124,20 @@ describe('setFileResponseHeaders', () => {
     FileFolder.Source,
     FileFolder.BuiltLogicFunction,
     FileFolder.Dependencies,
-  ])('should not set Cache-Control for mutable folder %s', (fileFolder) => {
-    const res = createMockResponse();
+    FileFolder.GeneratedSdkClient,
+  ])(
+    'should not set Cache-Control for non-cacheable folder %s',
+    (fileFolder) => {
+      const res = createMockResponse();
 
-    setFileResponseHeaders(res as any, 'image/png', fileFolder);
+      setFileResponseHeaders(res as any, 'image/png', fileFolder);
 
-    expect(res.setHeader).not.toHaveBeenCalledWith(
-      'Cache-Control',
-      expect.anything(),
-    );
-  });
+      expect(res.setHeader).not.toHaveBeenCalledWith(
+        'Cache-Control',
+        expect.anything(),
+      );
+    },
+  );
 });
 
 describe('getContentDisposition', () => {

--- a/packages/twenty-server/src/engine/core-modules/file/utils/__tests__/set-file-response-headers.utils.spec.ts
+++ b/packages/twenty-server/src/engine/core-modules/file/utils/__tests__/set-file-response-headers.utils.spec.ts
@@ -93,6 +93,7 @@ describe('setFileResponseHeaders', () => {
     FileFolder.AgentChat,
     FileFolder.EmailAttachment,
     FileFolder.Dpa,
+    FileFolder.BuiltFrontComponent,
   ])(
     'should set an immutable Cache-Control for immutable folder %s',
     (fileFolder) => {
@@ -107,11 +108,22 @@ describe('setFileResponseHeaders', () => {
     },
   );
 
+  it('should set a bounded public Cache-Control for the PublicAsset folder', () => {
+    const res = createMockResponse();
+
+    setFileResponseHeaders(res as any, 'image/png', FileFolder.PublicAsset);
+
+    expect(res.setHeader).toHaveBeenCalledWith(
+      'Cache-Control',
+      'public, max-age=3600',
+    );
+  });
+
   it.each([
-    FileFolder.PublicAsset,
     FileFolder.AppTarball,
     FileFolder.Source,
-    FileFolder.BuiltFrontComponent,
+    FileFolder.BuiltLogicFunction,
+    FileFolder.Dependencies,
   ])('should not set Cache-Control for mutable folder %s', (fileFolder) => {
     const res = createMockResponse();
 

--- a/packages/twenty-server/src/engine/core-modules/file/utils/set-file-response-headers.utils.ts
+++ b/packages/twenty-server/src/engine/core-modules/file/utils/set-file-response-headers.utils.ts
@@ -3,10 +3,7 @@ import { type Response } from 'express';
 import { FileFolder } from 'twenty-shared/types';
 import { isDefined } from 'twenty-shared/utils';
 
-import {
-  fileFolderConfigs,
-  IMMUTABLE_FILE_CACHE_CONTROL,
-} from 'src/engine/core-modules/file/interfaces/file-folder.interface';
+import { fileFolderConfigs } from 'src/engine/core-modules/file/interfaces/file-folder.interface';
 import { getContentDisposition } from 'src/engine/core-modules/file/utils/get-content-disposition.utils';
 
 export const setFileResponseHeaders = (
@@ -20,7 +17,11 @@ export const setFileResponseHeaders = (
   res.setHeader('X-Content-Type-Options', 'nosniff');
   res.setHeader('Content-Disposition', getContentDisposition(contentType));
 
-  if (isDefined(fileFolder) && fileFolderConfigs[fileFolder].immutable) {
-    res.setHeader('Cache-Control', IMMUTABLE_FILE_CACHE_CONTROL);
+  const cacheControl = isDefined(fileFolder)
+    ? fileFolderConfigs[fileFolder].cacheControl
+    : null;
+
+  if (isDefined(cacheControl)) {
+    res.setHeader('Cache-Control', cacheControl);
   }
 };

--- a/packages/twenty-server/src/engine/metadata-modules/front-component/controllers/front-component.controller.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/front-component/controllers/front-component.controller.ts
@@ -11,6 +11,7 @@ import {
 import { pipeline } from 'stream/promises';
 
 import { Response } from 'express';
+import { FileFolder } from 'twenty-shared/types';
 
 import {
   FileStorageException,
@@ -87,7 +88,11 @@ export class FrontComponentController {
       return res.redirect(fileResponse.presignedUrl);
     }
 
-    setFileResponseHeaders(res, fileResponse.mimeType);
+    setFileResponseHeaders(
+      res,
+      fileResponse.mimeType,
+      FileFolder.BuiltFrontComponent,
+    );
 
     try {
       await pipeline(fileResponse.stream, res);

--- a/packages/twenty-server/src/engine/metadata-modules/front-component/controllers/front-component.controller.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/front-component/controllers/front-component.controller.ts
@@ -46,7 +46,7 @@ export class FrontComponentController {
 
   constructor(private readonly frontComponentService: FrontComponentService) {}
 
-  @Get(':frontComponentId')
+  @Get([':frontComponentId', ':frontComponentId/:cacheKey'])
   @UseGuards(NoPermissionGuard)
   async getBuiltJs(
     @Res() res: Response,

--- a/packages/twenty-server/src/engine/metadata-modules/front-component/front-component.service.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/front-component/front-component.service.ts
@@ -6,6 +6,7 @@ import { isDefined } from 'twenty-shared/utils';
 import { ApplicationService } from 'src/engine/core-modules/application/application.service';
 import { type FlatApplication } from 'src/engine/core-modules/application/types/flat-application.type';
 import { FileStorageService } from 'src/engine/core-modules/file-storage/file-storage.service';
+import { fileFolderConfigs } from 'src/engine/core-modules/file/interfaces/file-folder.interface';
 import { type FileResponse } from 'src/engine/core-modules/file/types/file-response.type';
 import { getContentDisposition } from 'src/engine/core-modules/file/utils/get-content-disposition.utils';
 import { TwentyConfigService } from 'src/engine/core-modules/twenty-config/twenty-config.service';
@@ -332,6 +333,9 @@ export class FrontComponentService {
       ),
       responseContentType: mimeType,
       responseContentDisposition: getContentDisposition(mimeType),
+      responseCacheControl:
+        fileFolderConfigs[FileFolder.BuiltFrontComponent].cacheControl ??
+        undefined,
     });
 
     if (presignedUrl) {

--- a/packages/twenty-server/test/integration/rest/suites/front-component-built-js.integration-spec.ts
+++ b/packages/twenty-server/test/integration/rest/suites/front-component-built-js.integration-spec.ts
@@ -55,6 +55,20 @@ describe('Front component built JS endpoint', () => {
       });
   });
 
+  it('should serve the built JS from the checksum-fingerprinted path with an immutable cache header', async () => {
+    await makeRestAPIRequest({
+      method: 'get',
+      path: `/front-components/${frontComponentId}/test-checksum-123.js`,
+      bearer: APPLE_JANE_ADMIN_ACCESS_TOKEN,
+    })
+      .expect(200)
+      .expect('Content-Type', /application\/javascript/)
+      .expect('Cache-Control', 'private, max-age=86400, immutable')
+      .expect((res) => {
+        expect(res.text).toBe('dummy built component content');
+      });
+  });
+
   it('should return 404 for a non-existent front component ID', async () => {
     const nonExistentId = '00000000-0000-0000-0000-000000000000';
 


### PR DESCRIPTION
**Stacked on #22523** — base is that branch, so the diff shows only this commit. GitHub will retarget it to `main` automatically once #22523 merges.

Follows up on @FelixMalfait's question on #22523: move the BuiltFrontComponent cache key from a query string into the path so it plays well with Cloudflare cache rules.

## What

- URL: `/rest/front-components/:id?checksum=<c>` → `/rest/front-components/:id/<c>.js` (`getFrontComponentUrl`).
- Route: the controller now accepts `[':frontComponentId', ':frontComponentId/:cacheKey']`. `:cacheKey` is a pure cache-buster the server **ignores** — it still resolves by `:frontComponentId`, exactly as the query param did.

## Why a path segment (not `:id-<checksum>.js`)

A path-based, extension-bearing URL is matched by Cloudflare's **default** static-asset caching and by trivial `*.js` path cache rules, and it's immune to any "ignore query string" cache setting that would otherwise collapse `?checksum=` to one entry and serve stale JS.

I used a path **segment** (`/:id/:checksum.js`) rather than the literal `:id-<checksum>.js` you sketched because the id is a **UUID — which itself contains hyphens** — so a `-` separator is ambiguous to parse. A segment is unambiguous and equally CDN-friendly (still ends in `.js`).

## Backward compatibility

The bare `:frontComponentId` route is kept, so URLs minted before this deploys (query-string form, or in-flight pages) still resolve. It can be dropped in a later release once no client mints the old form. No data migration — the URL is computed at render time from `frontComponentId` + `builtComponentChecksum`.

## ⚠️ Decision for you: this alone does not edge-cache — `private` vs `public`

BFC is served behind `WorkspaceAuthGuard` and #22523 set its header to **`private`**, max-age, immutable. `private` means shared caches (Cloudflare) **won't** store it — so today this is browser-cache only, and the path change just makes it *ready* for edge caching + clean cache rules.

To actually get **edge** caching you'd additionally either flip BFC to `public` or add a Cloudflare rule that overrides cache-control — which means **accepting that the `id`+`checksum` URL becomes the access capability** (a cache hit is served without re-checking origin auth). The cache key is unique per component+build so there's no cross-workspace mixup, but the built JS effectively becomes public-by-URL (same posture PublicAsset already has). I've **left it `private`** here; flipping to `public` is your call and can be a one-line follow-up.

## Tests

- `getFrontComponentUrl` unit test: fingerprinted path when a checksum is present, bare fallback otherwise.
- Integration test: the `/front-components/:id/:checksum.js` path serves the built JS with `Content-Type: application/javascript` and `Cache-Control: private, max-age=86400, immutable`. Existing bare-route tests remain and still pass.

https://claude.ai/code/session_01AKwhTxYFDhWhCZ4b7sf35W

---
_Generated by [Claude Code](https://claude.ai/code/session_01AKwhTxYFDhWhCZ4b7sf35W)_

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/22530?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

