### PR TITLE
feat(files): content-verify direct uploads and pin pending files to octet-stream

### DIFF
--- a/packages/twenty-server/src/database/commands/upgrade-version-command/2-19/2-19-instance-command-fast-1783094691548-add-pending-mime-check-to-file.ts
+++ b/packages/twenty-server/src/database/commands/upgrade-version-command/2-19/2-19-instance-command-fast-1783094691548-add-pending-mime-check-to-file.ts
@@ -1,0 +1,35 @@
+import { QueryRunner } from 'typeorm';
+
+import { RegisteredInstanceCommand } from 'src/engine/core-modules/upgrade/decorators/registered-instance-command.decorator';
+import { FastInstanceCommand } from 'src/engine/core-modules/upgrade/interfaces/fast-instance-command.interface';
+
+@RegisteredInstanceCommand('2.19.0', 1783094691548)
+export class AddPendingMimeCheckToFileFastInstanceCommand
+  implements FastInstanceCommand
+{
+  // A PENDING file is a direct upload whose bytes have not been content-sniffed
+  // yet, so its declared mime type is untrusted. Forcing PENDING rows to
+  // 'application/octet-stream' guarantees the real mime type is only ever set
+  // from server-side detection at completeFileUpload time.
+  //
+  // Added NOT VALID on purpose: PR that shipped the PENDING status set the mime
+  // from the filename extension, so a freshly-upgraded instance may still hold
+  // PENDING rows that predate this rule. NOT VALID enforces the invariant on
+  // every new and updated row without scanning (and failing on) that legacy
+  // backlog — those rows either get overwritten to octet-stream when completed
+  // (status flips to UPLOADED, so the check passes) or reaped while pending.
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "core"."file" DROP CONSTRAINT IF EXISTS "CHK_FILE_PENDING_MIME_OCTET_STREAM"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "core"."file" ADD CONSTRAINT "CHK_FILE_PENDING_MIME_OCTET_STREAM" CHECK ("status" != 'PENDING' OR "mimeType" = 'application/octet-stream') NOT VALID`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "core"."file" DROP CONSTRAINT IF EXISTS "CHK_FILE_PENDING_MIME_OCTET_STREAM"`,
+    );
+  }
+}

--- a/packages/twenty-server/src/database/commands/upgrade-version-command/2-19/2-19-instance-command-fast-1783094691548-add-pending-mime-check-to-file.ts
+++ b/packages/twenty-server/src/database/commands/upgrade-version-command/2-19/2-19-instance-command-fast-1783094691548-add-pending-mime-check-to-file.ts
@@ -7,17 +7,6 @@ import { FastInstanceCommand } from 'src/engine/core-modules/upgrade/interfaces/
 export class AddPendingMimeCheckToFileFastInstanceCommand
   implements FastInstanceCommand
 {
-  // A PENDING file is a direct upload whose bytes have not been content-sniffed
-  // yet, so its declared mime type is untrusted. Forcing PENDING rows to
-  // 'application/octet-stream' guarantees the real mime type is only ever set
-  // from server-side detection at completeFileUpload time.
-  //
-  // Added NOT VALID on purpose: PR that shipped the PENDING status set the mime
-  // from the filename extension, so a freshly-upgraded instance may still hold
-  // PENDING rows that predate this rule. NOT VALID enforces the invariant on
-  // every new and updated row without scanning (and failing on) that legacy
-  // backlog — those rows either get overwritten to octet-stream when completed
-  // (status flips to UPLOADED, so the check passes) or reaped while pending.
   public async up(queryRunner: QueryRunner): Promise<void> {
     await queryRunner.query(
       `ALTER TABLE "core"."file" DROP CONSTRAINT IF EXISTS "CHK_FILE_PENDING_MIME_OCTET_STREAM"`,

--- a/packages/twenty-server/src/database/commands/upgrade-version-command/instance-commands.constant.ts
+++ b/packages/twenty-server/src/database/commands/upgrade-version-command/instance-commands.constant.ts
@@ -92,6 +92,7 @@ import { AddViewKanbanColumnWidthFastInstanceCommand } from './2-15/2-15-instanc
 import { AddPendingQuestionMessageIdToAgentChatThreadFastInstanceCommand } from 'src/database/commands/upgrade-version-command/2-19/2-19-instance-command-fast-1782999138000-add-pending-question-to-agent-chat-thread';
 import { AddWorkspaceDiscoverabilityToWorkspaceFastInstanceCommand } from './2-19/2-19-instance-command-fast-1783004140000-add-workspace-discoverability-to-workspace';
 import { AddStatusToFileFastInstanceCommand } from './2-19/2-19-instance-command-fast-1783082964705-add-status-to-file';
+import { AddPendingMimeCheckToFileFastInstanceCommand } from './2-19/2-19-instance-command-fast-1783094691548-add-pending-mime-check-to-file';
 import { DropMetadataStandardOverridesColumnFastInstanceCommand } from './2-20/2-20-instance-command-fast-1825000000000-drop-metadata-standard-overrides-column';
 import { AddLogoToApplicationRegistrationFastInstanceCommand } from './2-19/2-19-instance-command-fast-1783069672191-add-logo-to-application-registration';
 import { BackfillLogoOnApplicationRegistrationSlowInstanceCommand } from './2-19/2-19-instance-command-slow-1783069673191-backfill-logo-on-application-registration';
@@ -196,4 +197,5 @@ export const INSTANCE_COMMANDS = [
   AddDisplayFieldsToApplicationRegistrationFastInstanceCommand,
   BackfillDisplayFieldsOnApplicationRegistrationSlowInstanceCommand,
   AddStatusToFileFastInstanceCommand,
+  AddPendingMimeCheckToFileFastInstanceCommand,
 ];

--- a/packages/twenty-server/src/engine/core-modules/file/entities/file.entity.ts
+++ b/packages/twenty-server/src/engine/core-modules/file/entities/file.entity.ts
@@ -24,9 +24,6 @@ import { WasIntroducedInUpgrade } from 'src/engine/core-modules/upgrade/decorato
 import { WorkspaceRelatedEntity } from 'src/engine/workspace-manager/types/workspace-related-entity';
 
 @Entity('file')
-// A PENDING file's bytes have not been content-verified yet, so its mime type
-// is untrusted and pinned to octet-stream. The real mime type is only ever set
-// from server-side sniffing when the upload is completed (status -> UPLOADED).
 @Check(
   'CHK_FILE_PENDING_MIME_OCTET_STREAM',
   `"status" != 'PENDING' OR "mimeType" = 'application/octet-stream'`,

--- a/packages/twenty-server/src/engine/core-modules/file/entities/file.entity.ts
+++ b/packages/twenty-server/src/engine/core-modules/file/entities/file.entity.ts
@@ -1,4 +1,5 @@
 import {
+  Check,
   Column,
   CreateDateColumn,
   DeleteDateColumn,
@@ -23,6 +24,13 @@ import { WasIntroducedInUpgrade } from 'src/engine/core-modules/upgrade/decorato
 import { WorkspaceRelatedEntity } from 'src/engine/workspace-manager/types/workspace-related-entity';
 
 @Entity('file')
+// A PENDING file's bytes have not been content-verified yet, so its mime type
+// is untrusted and pinned to octet-stream. The real mime type is only ever set
+// from server-side sniffing when the upload is completed (status -> UPLOADED).
+@Check(
+  'CHK_FILE_PENDING_MIME_OCTET_STREAM',
+  `"status" != 'PENDING' OR "mimeType" = 'application/octet-stream'`,
+)
 @Index('IDX_FILE_WORKSPACE_ID', ['workspaceId'])
 @Index('IDX_FILE_STATUS', ['status'])
 @Unique('IDX_APPLICATION_PATH_WORKSPACE_ID_APPLICATION_ID_UNIQUE', [

--- a/packages/twenty-server/src/engine/core-modules/file/file-upload/constants/file-content-sniff.constant.ts
+++ b/packages/twenty-server/src/engine/core-modules/file/file-upload/constants/file-content-sniff.constant.ts
@@ -1,5 +1,1 @@
-// Number of leading bytes read from a completed upload to detect its real
-// content type. Magic-byte signatures live at the very start of a file, so a
-// bounded prefix is enough to identify the type without ever buffering a
-// large object into memory.
 export const FILE_CONTENT_SNIFF_BYTE_COUNT = 64 * 1024;

--- a/packages/twenty-server/src/engine/core-modules/file/file-upload/constants/file-content-sniff.constant.ts
+++ b/packages/twenty-server/src/engine/core-modules/file/file-upload/constants/file-content-sniff.constant.ts
@@ -1,0 +1,5 @@
+// Number of leading bytes read from a completed upload to detect its real
+// content type. Magic-byte signatures live at the very start of a file, so a
+// bounded prefix is enough to identify the type without ever buffering a
+// large object into memory.
+export const FILE_CONTENT_SNIFF_BYTE_COUNT = 64 * 1024;

--- a/packages/twenty-server/src/engine/core-modules/file/file-upload/services/file-upload.service.spec.ts
+++ b/packages/twenty-server/src/engine/core-modules/file/file-upload/services/file-upload.service.spec.ts
@@ -1,3 +1,5 @@
+import { Readable } from 'stream';
+
 import { Test, type TestingModule } from '@nestjs/testing';
 import { getRepositoryToken } from '@nestjs/typeorm';
 
@@ -31,6 +33,7 @@ describe('FileUploadService', () => {
     getPresignedUploadUrl: jest.fn(),
     getFileMetadata: jest.fn(),
     writeFileStream: jest.fn(),
+    readFile: jest.fn(),
   };
 
   const fileUrlService = {
@@ -153,13 +156,14 @@ describe('FileUploadService', () => {
         expect.objectContaining({
           fileId: 'mocked-file-id',
           size: 1024,
-          mimeType: 'application/pdf',
+          // A pending file is opaque until its content is sniffed at completion.
+          mimeType: 'application/octet-stream',
           resourcePath: 'field-metadata-uid/mocked-file-id.pdf',
           settings: { isTemporaryFile: true, toDelete: false },
         }),
       );
       expect(result.uploadUrl).toBe('https://bucket/presigned-put');
-      expect(result.contentType).toBe('application/pdf');
+      expect(result.contentType).toBe('application/octet-stream');
       expect(result.fileId).toBe('mocked-file-id');
     });
 
@@ -193,11 +197,21 @@ describe('FileUploadService', () => {
       path: 'files-field/field-metadata-uid/file-id.pdf',
       size: 1024,
       applicationId: 'application-id',
-      mimeType: 'application/pdf',
+      // A pending file is always octet-stream until its content is sniffed.
+      mimeType: 'application/octet-stream',
       status: FILE_STATUS.PENDING,
       settings: { isTemporaryFile: true, toDelete: false },
       createdAt: new Date(),
     };
+
+    // Real magic-byte samples so the content sniffer resolves a concrete type.
+    const PDF_BYTES = Buffer.from('%PDF-1.4\n%\xE2\xE3\xCF\xD3\n', 'latin1');
+    // A complete 1x1 transparent PNG (the sniffer seeks past the signature to
+    // rule out APNG, so a full image is needed rather than just the header).
+    const PNG_BYTES = Buffer.from(
+      'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg==',
+      'base64',
+    );
 
     it('should throw when the file record does not exist', async () => {
       fileRepository.findOne.mockResolvedValueOnce(null);
@@ -240,11 +254,45 @@ describe('FileUploadService', () => {
       expect(fileRepository.update).not.toHaveBeenCalled();
     });
 
-    it('should flip the file to UPLOADED when the stored size matches', async () => {
+    it('should sniff the content, set the detected mime and flip to UPLOADED', async () => {
       fileRepository.findOne.mockResolvedValueOnce(pendingFile);
       fileStorageService.getFileMetadata.mockResolvedValueOnce({ size: 1024 });
+      fileStorageService.readFile.mockResolvedValueOnce(
+        Readable.from(PDF_BYTES),
+      );
 
       const result = await service.completeFileUpload({
+        workspaceId: 'workspace-id',
+        fileId: 'file-id',
+      });
+
+      expect(fileStorageService.readFile).toHaveBeenCalledWith(
+        expect.objectContaining({
+          fileFolder: FileFolder.FilesField,
+          resourcePath: 'field-metadata-uid/file-id.pdf',
+          workspaceId: 'workspace-id',
+        }),
+      );
+      expect(fileRepository.update).toHaveBeenCalledWith(
+        'workspace-id',
+        { id: 'file-id' },
+        { status: FILE_STATUS.UPLOADED, mimeType: 'application/pdf' },
+      );
+      expect(result.url).toBe('https://signed-url');
+    });
+
+    it('should override a spoofed extension with the detected content type', async () => {
+      fileRepository.findOne.mockResolvedValueOnce({
+        ...pendingFile,
+        path: 'files-field/field-metadata-uid/file-id.pdf',
+      });
+      fileStorageService.getFileMetadata.mockResolvedValueOnce({ size: 1024 });
+      // A .pdf file whose bytes are actually a PNG: the sniffer wins.
+      fileStorageService.readFile.mockResolvedValueOnce(
+        Readable.from(PNG_BYTES),
+      );
+
+      await service.completeFileUpload({
         workspaceId: 'workspace-id',
         fileId: 'file-id',
       });
@@ -252,9 +300,28 @@ describe('FileUploadService', () => {
       expect(fileRepository.update).toHaveBeenCalledWith(
         'workspace-id',
         { id: 'file-id' },
-        { status: FILE_STATUS.UPLOADED },
+        { status: FILE_STATUS.UPLOADED, mimeType: 'image/png' },
       );
-      expect(result.url).toBe('https://signed-url');
+    });
+
+    it('should reject when the content cannot be matched to the declared extension', async () => {
+      fileRepository.findOne.mockResolvedValueOnce({
+        ...pendingFile,
+        path: 'files-field/field-metadata-uid/file-id.png',
+      });
+      fileStorageService.getFileMetadata.mockResolvedValueOnce({ size: 1024 });
+      // Undetectable bytes under a .png extension: content does not match.
+      fileStorageService.readFile.mockResolvedValueOnce(
+        Readable.from(Buffer.from('not-an-image-just-text')),
+      );
+
+      await expect(
+        service.completeFileUpload({
+          workspaceId: 'workspace-id',
+          fileId: 'file-id',
+        }),
+      ).rejects.toThrow();
+      expect(fileRepository.update).not.toHaveBeenCalled();
     });
 
     it('should be idempotent when the file is already UPLOADED', async () => {

--- a/packages/twenty-server/src/engine/core-modules/file/file-upload/services/file-upload.service.spec.ts
+++ b/packages/twenty-server/src/engine/core-modules/file/file-upload/services/file-upload.service.spec.ts
@@ -156,7 +156,6 @@ describe('FileUploadService', () => {
         expect.objectContaining({
           fileId: 'mocked-file-id',
           size: 1024,
-          // A pending file is opaque until its content is sniffed at completion.
           mimeType: 'application/octet-stream',
           resourcePath: 'field-metadata-uid/mocked-file-id.pdf',
           settings: { isTemporaryFile: true, toDelete: false },
@@ -197,17 +196,13 @@ describe('FileUploadService', () => {
       path: 'files-field/field-metadata-uid/file-id.pdf',
       size: 1024,
       applicationId: 'application-id',
-      // A pending file is always octet-stream until its content is sniffed.
       mimeType: 'application/octet-stream',
       status: FILE_STATUS.PENDING,
       settings: { isTemporaryFile: true, toDelete: false },
       createdAt: new Date(),
     };
 
-    // Real magic-byte samples so the content sniffer resolves a concrete type.
     const PDF_BYTES = Buffer.from('%PDF-1.4\n%\xE2\xE3\xCF\xD3\n', 'latin1');
-    // A complete 1x1 transparent PNG (the sniffer seeks past the signature to
-    // rule out APNG, so a full image is needed rather than just the header).
     const PNG_BYTES = Buffer.from(
       'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg==',
       'base64',
@@ -287,7 +282,6 @@ describe('FileUploadService', () => {
         path: 'files-field/field-metadata-uid/file-id.pdf',
       });
       fileStorageService.getFileMetadata.mockResolvedValueOnce({ size: 1024 });
-      // A .pdf file whose bytes are actually a PNG: the sniffer wins.
       fileStorageService.readFile.mockResolvedValueOnce(
         Readable.from(PNG_BYTES),
       );
@@ -310,7 +304,6 @@ describe('FileUploadService', () => {
         path: 'files-field/field-metadata-uid/file-id.png',
       });
       fileStorageService.getFileMetadata.mockResolvedValueOnce({ size: 1024 });
-      // Undetectable bytes under a .png extension: content does not match.
       fileStorageService.readFile.mockResolvedValueOnce(
         Readable.from(Buffer.from('not-an-image-just-text')),
       );

--- a/packages/twenty-server/src/engine/core-modules/file/file-upload/services/file-upload.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/file/file-upload/services/file-upload.service.ts
@@ -101,12 +101,6 @@ export class FileUploadService {
     }
 
     const { ext } = buildFileInfo(filename);
-    // A pending file is opaque: its bytes have not been content-sniffed yet, so
-    // the mime type stays octet-stream (enforced by the
-    // CHK_FILE_PENDING_MIME_OCTET_STREAM constraint). The real mime type is only
-    // set from server-side detection at completeFileUpload time. The extension
-    // is still kept on the stored object name so that detection can validate the
-    // content against the declared extension.
     const mimeType = 'application/octet-stream';
 
     const fileId = v4();
@@ -361,11 +355,6 @@ export class FileUploadService {
       );
     }
 
-    // The bytes are only trustworthy now that they are in storage. Sniff a
-    // bounded prefix to detect the real mime type and reject any file whose
-    // content does not match its declared extension. Until this succeeds the
-    // record stays PENDING (octet-stream), so it can never be served or
-    // attached, and gets reaped by the pending-file cleanup cron.
     const mimeType = await this.detectUploadedMimeTypeOrThrow({
       fileFolder: fileFolder as FileFolder,
       applicationUniversalIdentifier: application.universalIdentifier,
@@ -387,9 +376,6 @@ export class FileUploadService {
     });
   }
 
-  // Reads a bounded prefix of the stored object and derives its mime type from
-  // the content (falling back to the declared extension). Throws when the
-  // content contradicts the extension.
   private async detectUploadedMimeTypeOrThrow({
     fileFolder,
     applicationUniversalIdentifier,

--- a/packages/twenty-server/src/engine/core-modules/file/file-upload/services/file-upload.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/file/file-upload/services/file-upload.service.ts
@@ -7,7 +7,6 @@ import { pipeline } from 'stream/promises';
 import { msg } from '@lingui/core/macro';
 import { isNonEmptyString } from '@sniptt/guards';
 import bytes from 'bytes';
-import { lookup } from 'mrmime';
 import { FileFolder } from 'twenty-shared/types';
 import { isDefined } from 'twenty-shared/utils';
 import { Repository } from 'typeorm';
@@ -19,9 +18,9 @@ import { ApplicationService } from 'src/engine/core-modules/application/applicat
 import { FileUploadTokenJwtPayload } from 'src/engine/core-modules/auth/types/file-upload-token-jwt-payload.type';
 import { JwtTokenTypeEnum } from 'src/engine/core-modules/auth/types/jwt-token-type.enum';
 import { FileStorageService } from 'src/engine/core-modules/file-storage/file-storage.service';
-import { TWENTY_MIME_POLICY } from 'src/engine/core-modules/file/constants/twenty-mime-policy.constant';
 import { FileWithSignedUrlDTO } from 'src/engine/core-modules/file/dtos/file-with-sign-url.dto';
 import { FileEntity } from 'src/engine/core-modules/file/entities/file.entity';
+import { FILE_CONTENT_SNIFF_BYTE_COUNT } from 'src/engine/core-modules/file/file-upload/constants/file-content-sniff.constant';
 import { FileUploadTargetDTO } from 'src/engine/core-modules/file/file-upload/dtos/file-upload-target.dto';
 import {
   FileUploadException,
@@ -30,12 +29,14 @@ import {
 import { FileUrlService } from 'src/engine/core-modules/file/file-url/file-url.service';
 import { FILE_STATUS } from 'src/engine/core-modules/file/types/file-status.types';
 import { buildFileInfo } from 'src/engine/core-modules/file/utils/build-file-info.utils';
+import { extractFileInfoOrThrow } from 'src/engine/core-modules/file/utils/extract-file-info-or-throw.utils';
 import { removeFileFolderFromFileEntityPath } from 'src/engine/core-modules/file/utils/remove-file-folder-from-file-entity-path.utils';
 import { JwtWrapperService } from 'src/engine/core-modules/jwt/services/jwt-wrapper.service';
 import { TwentyConfigService } from 'src/engine/core-modules/twenty-config/twenty-config.service';
 import { FieldMetadataEntity } from 'src/engine/metadata-modules/field-metadata/field-metadata.entity';
 import { InjectWorkspaceScopedRepository } from 'src/engine/twenty-orm/workspace-scoped-repository/inject-workspace-scoped-repository.decorator';
 import { WorkspaceScopedRepository } from 'src/engine/twenty-orm/workspace-scoped-repository/workspace-scoped-repository';
+import { readReadablePrefix } from 'src/utils/read-readable-prefix';
 
 export const DIRECT_UPLOAD_FILE_FOLDERS = [
   FileFolder.FilesField,
@@ -100,14 +101,13 @@ export class FileUploadService {
     }
 
     const { ext } = buildFileInfo(filename);
-    // The file content cannot be sniffed before it reaches storage, so the
-    // mime type is derived from the extension only. Anything unknown is
-    // stored as octet-stream, and the serving path already forces
-    // Content-Disposition: attachment for non-inline-safe mime types.
-    const mimeType =
-      TWENTY_MIME_POLICY[ext] ??
-      (isNonEmptyString(ext) ? lookup(ext) : undefined) ??
-      'application/octet-stream';
+    // A pending file is opaque: its bytes have not been content-sniffed yet, so
+    // the mime type stays octet-stream (enforced by the
+    // CHK_FILE_PENDING_MIME_OCTET_STREAM constraint). The real mime type is only
+    // set from server-side detection at completeFileUpload time. The extension
+    // is still kept on the stored object name so that detection can validate the
+    // content against the declared extension.
+    const mimeType = 'application/octet-stream';
 
     const fileId = v4();
     const name = `${fileId}${isNonEmptyString(ext) ? `.${ext}` : ''}`;
@@ -361,17 +361,66 @@ export class FileUploadService {
       );
     }
 
+    // The bytes are only trustworthy now that they are in storage. Sniff a
+    // bounded prefix to detect the real mime type and reject any file whose
+    // content does not match its declared extension. Until this succeeds the
+    // record stays PENDING (octet-stream), so it can never be served or
+    // attached, and gets reaped by the pending-file cleanup cron.
+    const mimeType = await this.detectUploadedMimeTypeOrThrow({
+      fileFolder: fileFolder as FileFolder,
+      applicationUniversalIdentifier: application.universalIdentifier,
+      workspaceId,
+      resourcePath,
+      filename: file.path,
+    });
+
     await this.fileRepository.update(
       workspaceId,
       { id: fileId },
-      { status: FILE_STATUS.UPLOADED },
+      { status: FILE_STATUS.UPLOADED, mimeType },
     );
 
     return this.toFileWithSignedUrl({
-      file: { ...file, status: FILE_STATUS.UPLOADED },
+      file: { ...file, status: FILE_STATUS.UPLOADED, mimeType },
       fileFolder: fileFolder as FileFolder,
       workspaceId,
     });
+  }
+
+  // Reads a bounded prefix of the stored object and derives its mime type from
+  // the content (falling back to the declared extension). Throws when the
+  // content contradicts the extension.
+  private async detectUploadedMimeTypeOrThrow({
+    fileFolder,
+    applicationUniversalIdentifier,
+    workspaceId,
+    resourcePath,
+    filename,
+  }: {
+    fileFolder: FileFolder;
+    applicationUniversalIdentifier: string;
+    workspaceId: string;
+    resourcePath: string;
+    filename: string;
+  }): Promise<string> {
+    const stream = await this.fileStorageService.readFile({
+      fileFolder,
+      applicationUniversalIdentifier,
+      workspaceId,
+      resourcePath,
+    });
+
+    const prefix = await readReadablePrefix(
+      stream,
+      FILE_CONTENT_SNIFF_BYTE_COUNT,
+    );
+
+    const { mimeType } = await extractFileInfoOrThrow({
+      file: prefix,
+      filename,
+    });
+
+    return mimeType;
   }
 
   private async resolveUploadLocation({

--- a/packages/twenty-server/src/utils/__tests__/read-readable-prefix.spec.ts
+++ b/packages/twenty-server/src/utils/__tests__/read-readable-prefix.spec.ts
@@ -17,7 +17,6 @@ describe('readReadablePrefix', () => {
 
     const stream = new Readable({
       read() {
-        // Keep emitting 1 KiB chunks; the reader must tear us down early.
         producedBytes += 1024;
         this.push(Buffer.alloc(1024, 0x61));
 
@@ -31,7 +30,6 @@ describe('readReadablePrefix', () => {
 
     expect(prefix.length).toBe(4096);
     expect(stream.destroyed).toBe(true);
-    // The reader stopped well before draining the 1 MiB source.
     expect(producedBytes).toBeLessThan(1024 * 1024);
   });
 

--- a/packages/twenty-server/src/utils/__tests__/read-readable-prefix.spec.ts
+++ b/packages/twenty-server/src/utils/__tests__/read-readable-prefix.spec.ts
@@ -1,0 +1,55 @@
+import { Readable } from 'stream';
+
+import { readReadablePrefix } from 'src/utils/read-readable-prefix';
+
+describe('readReadablePrefix', () => {
+  it('should return the whole content when it is shorter than the limit', async () => {
+    const prefix = await readReadablePrefix(
+      Readable.from(Buffer.from('hello')),
+      1024,
+    );
+
+    expect(prefix.toString()).toBe('hello');
+  });
+
+  it('should stop at the limit and not buffer the rest of a large source', async () => {
+    let producedBytes = 0;
+
+    const stream = new Readable({
+      read() {
+        // Keep emitting 1 KiB chunks; the reader must tear us down early.
+        producedBytes += 1024;
+        this.push(Buffer.alloc(1024, 0x61));
+
+        if (producedBytes >= 1024 * 1024) {
+          this.push(null);
+        }
+      },
+    });
+
+    const prefix = await readReadablePrefix(stream, 4096);
+
+    expect(prefix.length).toBe(4096);
+    expect(stream.destroyed).toBe(true);
+    // The reader stopped well before draining the 1 MiB source.
+    expect(producedBytes).toBeLessThan(1024 * 1024);
+  });
+
+  it('should reject when the stream errors before the limit', async () => {
+    const stream = new Readable({
+      read() {
+        this.destroy(new Error('storage exploded'));
+      },
+    });
+
+    await expect(readReadablePrefix(stream, 4096)).rejects.toThrow(
+      'storage exploded',
+    );
+  });
+
+  it('should return an empty buffer for an empty stream', async () => {
+    const prefix = await readReadablePrefix(Readable.from([]), 4096);
+
+    expect(prefix.length).toBe(0);
+  });
+});

--- a/packages/twenty-server/src/utils/__tests__/read-readable-prefix.spec.ts
+++ b/packages/twenty-server/src/utils/__tests__/read-readable-prefix.spec.ts
@@ -33,6 +33,15 @@ describe('readReadablePrefix', () => {
     expect(producedBytes).toBeLessThan(1024 * 1024);
   });
 
+  it('should bound the buffer to maxBytes even when a single chunk overshoots', async () => {
+    const prefix = await readReadablePrefix(
+      Readable.from(Buffer.alloc(64 * 1024, 0x61)),
+      4096,
+    );
+
+    expect(prefix.length).toBe(4096);
+  });
+
   it('should reject when the stream errors before the limit', async () => {
     const stream = new Readable({
       read() {

--- a/packages/twenty-server/src/utils/read-readable-prefix.ts
+++ b/packages/twenty-server/src/utils/read-readable-prefix.ts
@@ -1,0 +1,57 @@
+import { type Readable } from 'stream';
+
+// Reads at most `maxBytes` from the start of a Readable, then stops and tears
+// the stream down. Unlike streamToBuffer this never rejects on a large source:
+// it is meant to sample a bounded prefix (e.g. to sniff a content type) without
+// buffering the whole object into memory.
+export const readReadablePrefix = async (
+  stream: Readable,
+  maxBytes: number,
+): Promise<Buffer> => {
+  const chunks: Buffer[] = [];
+  let collected = 0;
+  let settled = false;
+
+  return new Promise((resolve, reject) => {
+    const onData = (chunk: Buffer) => {
+      if (settled) {
+        return;
+      }
+
+      chunks.push(chunk);
+      collected += chunk.length;
+
+      if (collected >= maxBytes) {
+        settled = true;
+        stream.off('data', onData);
+        stream.off('end', onEnd);
+        // The error listener stays attached so the destroy() teardown below
+        // never surfaces as an unhandled 'error' event.
+        stream.destroy();
+        resolve(Buffer.concat(chunks).subarray(0, maxBytes));
+      }
+    };
+
+    const onEnd = () => {
+      if (settled) {
+        return;
+      }
+
+      settled = true;
+      resolve(Buffer.concat(chunks));
+    };
+
+    const onError = (error: Error) => {
+      if (settled) {
+        return;
+      }
+
+      settled = true;
+      reject(error);
+    };
+
+    stream.on('data', onData);
+    stream.on('end', onEnd);
+    stream.on('error', onError);
+  });
+};

--- a/packages/twenty-server/src/utils/read-readable-prefix.ts
+++ b/packages/twenty-server/src/utils/read-readable-prefix.ts
@@ -14,15 +14,19 @@ export const readReadablePrefix = async (
         return;
       }
 
-      chunks.push(chunk);
-      collected += chunk.length;
+      const remaining = maxBytes - collected;
+      const boundedChunk =
+        chunk.length > remaining ? chunk.subarray(0, remaining) : chunk;
+
+      chunks.push(boundedChunk);
+      collected += boundedChunk.length;
 
       if (collected >= maxBytes) {
         settled = true;
         stream.off('data', onData);
         stream.off('end', onEnd);
         stream.destroy();
-        resolve(Buffer.concat(chunks).subarray(0, maxBytes));
+        resolve(Buffer.concat(chunks));
       }
     };
 

--- a/packages/twenty-server/src/utils/read-readable-prefix.ts
+++ b/packages/twenty-server/src/utils/read-readable-prefix.ts
@@ -1,9 +1,5 @@
 import { type Readable } from 'stream';
 
-// Reads at most `maxBytes` from the start of a Readable, then stops and tears
-// the stream down. Unlike streamToBuffer this never rejects on a large source:
-// it is meant to sample a bounded prefix (e.g. to sniff a content type) without
-// buffering the whole object into memory.
 export const readReadablePrefix = async (
   stream: Readable,
   maxBytes: number,
@@ -25,8 +21,6 @@ export const readReadablePrefix = async (
         settled = true;
         stream.off('data', onData);
         stream.off('end', onEnd);
-        // The error listener stays attached so the destroy() teardown below
-        // never surfaces as an unhandled 'error' event.
         stream.destroy();
         resolve(Buffer.concat(chunks).subarray(0, maxBytes));
       }

--- a/packages/twenty-server/test/integration/graphql/suites/file-upload/direct-file-upload.integration-spec.ts
+++ b/packages/twenty-server/test/integration/graphql/suites/file-upload/direct-file-upload.integration-spec.ts
@@ -228,6 +228,36 @@ describe('direct file upload (createFileUpload / completeFileUpload)', () => {
     );
   });
 
+  it('should reject completing an upload whose content contradicts its extension', async () => {
+    // A .png name but plain-text bytes: the content sniff at completion must
+    // reject it, and the record must stay PENDING (never become downloadable).
+    const spoofedContent = Buffer.from('this is not really a png image');
+
+    const createResponse = await createFileUpload({
+      filename: 'actually-text.png',
+      size: spoofedContent.length,
+      fileFolder: 'FilesField',
+      fieldMetadataId: createdFieldMetadataId,
+    });
+
+    const uploadTarget = createResponse.body.data.createFileUpload;
+
+    uploadedFileIds.push(uploadTarget.fileId);
+
+    const putResponse = await putFileToUploadUrl(
+      uploadTarget.uploadUrl,
+      uploadTarget.contentType,
+      spoofedContent,
+    );
+
+    expect(putResponse.status).toBe(204);
+
+    const completeResponse = await completeFileUpload(uploadTarget.fileId);
+
+    expect(completeResponse.body.errors).toBeDefined();
+    expect(completeResponse.body.errors[0].message).toContain('match');
+  });
+
   it('should refuse a PUT larger than the declared size', async () => {
     const declaredSize = 10;
     const oversizedContent = Buffer.from(

--- a/packages/twenty-server/test/integration/graphql/suites/file-upload/direct-file-upload.integration-spec.ts
+++ b/packages/twenty-server/test/integration/graphql/suites/file-upload/direct-file-upload.integration-spec.ts
@@ -229,8 +229,6 @@ describe('direct file upload (createFileUpload / completeFileUpload)', () => {
   });
 
   it('should reject completing an upload whose content contradicts its extension', async () => {
-    // A .png name but plain-text bytes: the content sniff at completion must
-    // reject it, and the record must stay PENDING (never become downloadable).
     const spoofedContent = Buffer.from('this is not really a png image');
 
     const createResponse = await createFileUpload({

--- a/packages/twenty-server/test/integration/graphql/suites/file-upload/direct-file-upload.integration-spec.ts
+++ b/packages/twenty-server/test/integration/graphql/suites/file-upload/direct-file-upload.integration-spec.ts
@@ -253,7 +253,14 @@ describe('direct file upload (createFileUpload / completeFileUpload)', () => {
     const completeResponse = await completeFileUpload(uploadTarget.fileId);
 
     expect(completeResponse.body.errors).toBeDefined();
-    expect(completeResponse.body.errors[0].message).toContain('match');
+    expect(completeResponse.body.errors[0].message).toContain(
+      'does not match its extension',
+    );
+
+    const retryResponse = await completeFileUpload(uploadTarget.fileId);
+
+    expect(retryResponse.body.errors).toBeDefined();
+    expect(retryResponse.body.data?.completeFileUpload ?? null).toBeNull();
   });
 
   it('should refuse a PUT larger than the declared size', async () => {


### PR DESCRIPTION
## Context

Follow-up to #22449 (direct-to-storage upload endpoints). In that flow `createFileUpload` inserts a `PENDING` file record before any bytes exist, and until now it guessed the mime type from the **filename extension** — an untrusted, client-controlled value. This PR makes a pending file opaque and only trusts a mime type that was verified against the actual stored bytes.

## What this does

**1. A pending file is always `application/octet-stream`.**
`createFileUpload` records the pending file — and signs the presigned PUT — as `application/octet-stream`. The extension is still kept on the stored object name so the content can be checked against it later.

**2. Content verification at completion.**
`completeFileUpload`, after the existing size check, reads a **bounded prefix** of the stored object (`readReadablePrefix`, capped at 64 KiB — a large object is never buffered in full) and runs the existing `extractFileInfoOrThrow` util to detect the real mime type from the content. It:
- writes the detected type alongside `status = UPLOADED`, and
- rejects a file whose bytes don't match its declared extension (the record stays `PENDING`, so it can never be served or attached, and is reaped by the pending-file cleanup cron).

Serving already overrides `Content-Type` from the DB record, so storing the object as octet-stream is fine.

**3. A database constraint as backstop.**
`CHK_FILE_PENDING_MIME_OCTET_STREAM` — `"status" != 'PENDING' OR "mimeType" = 'application/octet-stream'` — added to `FileEntity` and applied by a fast instance command (`2-19`). It is added `NOT VALID` on purpose: an instance freshly upgraded past #22449 may still hold `PENDING` rows whose mime came from the old extension-guess path, and `NOT VALID` enforces the invariant on every new/updated row without failing on that legacy backlog (those rows get overwritten to octet-stream when completed — `status` flips to `UPLOADED`, so the check passes — or are reaped while pending).

## Tests

- `read-readable-prefix.spec.ts` — prefix reader: short source, early stop on a large source (asserts it tears the stream down without draining it), error propagation, empty stream.
- `file-upload.service.spec.ts` — create records octet-stream; complete sniffs and sets the detected type, overrides a spoofed extension with the real content type, and rejects content that can't be matched to the declared extension.
- `direct-file-upload.integration-spec.ts` — end-to-end case rejecting a `.png` upload whose bytes are plain text.

## Verification

`typecheck` green, `lint:diff-with-main` clean, unit suites pass (17 tests). No GraphQL schema change, so no codegen drift.

## Scope

Server-only, part of the incremental direct-upload rollout being split into small PRs. Independent of the reaper-cron PR (#22531).

https://claude.ai/code/session_015UH8KWmsB9zdYaog8MFG1d

---
_Generated by [Claude Code](https://claude.ai/code/session_015UH8KWmsB9zdYaog8MFG1d)_

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/22533?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

