### PR TITLE
feat(twenty-for-twenty): bump to SDK 2.18 with local UI components

### DIFF
--- a/packages/twenty-apps/internal/twenty-for-twenty/package.json
+++ b/packages/twenty-apps/internal/twenty-for-twenty/package.json
@@ -1,6 +1,6 @@
 {
   "name": "twenty-for-twenty",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "license": "MIT",
   "engines": {
     "node": "^24.5.0",
@@ -30,8 +30,8 @@
     "oxlint": "^0.16.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
-    "twenty-client-sdk": "^2.14.0",
-    "twenty-sdk": "^2.14.0",
+    "twenty-client-sdk": "^2.18.0",
+    "twenty-sdk": "^2.18.0",
     "typescript": "^5.9.3",
     "vite-tsconfig-paths": "^4.2.1",
     "vitest": "^4.0.0"

--- a/packages/twenty-apps/internal/twenty-for-twenty/src/modules/resend/email-stats/front-components/PersonResendEmailStats.front-component.tsx
+++ b/packages/twenty-apps/internal/twenty-for-twenty/src/modules/resend/email-stats/front-components/PersonResendEmailStats.front-component.tsx
@@ -5,7 +5,7 @@ import {
   IconAlertCircle,
   IconMail,
   IconRefresh,
-} from 'twenty-sdk/ui';
+} from '@ui';
 
 import { isDefined } from '@utils/is-defined';
 

--- a/packages/twenty-apps/internal/twenty-for-twenty/src/modules/resend/html-viewer/components/RecordHtmlViewer.tsx
+++ b/packages/twenty-apps/internal/twenty-for-twenty/src/modules/resend/html-viewer/components/RecordHtmlViewer.tsx
@@ -1,5 +1,5 @@
 import { isDefined } from '@utils/is-defined';
-import { Callout, IconAlertCircle } from 'twenty-sdk/ui';
+import { Callout, IconAlertCircle } from '@ui';
 
 import { HtmlPreview } from '@modules/resend/html-viewer/components/HtmlPreview';
 import { useRecordHtml } from '@modules/resend/html-viewer/hooks/useRecordHtml';

--- a/packages/twenty-apps/internal/twenty-for-twenty/src/modules/resend/html-viewer/front-components/EmailBroadcastHtmlViewer.front-component.tsx
+++ b/packages/twenty-apps/internal/twenty-for-twenty/src/modules/resend/html-viewer/front-components/EmailBroadcastHtmlViewer.front-component.tsx
@@ -1,6 +1,6 @@
 import { isDefined } from '@utils/is-defined';
 import { defineFrontComponent } from 'twenty-sdk/define';
-import { Callout, IconAlertCircle, IconInfoCircle } from 'twenty-sdk/ui';
+import { Callout, IconAlertCircle, IconInfoCircle } from '@ui';
 
 import { EMAIL_BROADCAST_HTML_VIEWER_FRONT_COMPONENT_UNIVERSAL_IDENTIFIER } from '@modules/resend/constants/universal-identifiers';
 import { HtmlPreview } from '@modules/resend/html-viewer/components/HtmlPreview';

--- a/packages/twenty-apps/internal/twenty-for-twenty/src/modules/resend/manual-sync/components/ResendSyncStatus.tsx
+++ b/packages/twenty-apps/internal/twenty-for-twenty/src/modules/resend/manual-sync/components/ResendSyncStatus.tsx
@@ -7,7 +7,7 @@ import {
   IconAlertCircle,
   IconRefresh,
   Status,
-} from 'twenty-sdk/ui';
+} from '@ui';
 
 import { extractConnection } from '@modules/resend/shared/utils/typed-client';
 import { RESEND_SYNC_CURSOR_STEPS } from '@modules/resend/sync/cursor/constants/resend-sync-cursor-steps';

--- a/packages/twenty-apps/internal/twenty-for-twenty/src/ui/Callout.tsx
+++ b/packages/twenty-apps/internal/twenty-for-twenty/src/ui/Callout.tsx
@@ -1,0 +1,140 @@
+import { IconHelp, type IconComponent } from '@ui/icons';
+
+// Inline reimplementation of twenty-ui's `Callout`, styled with the Twenty
+// theme's `--t-*` CSS variables (injected by the front-component host). Only
+// the subset the app uses is kept: variant, title, description and Icon.
+export type CalloutVariant =
+  | 'info'
+  | 'warning'
+  | 'error'
+  | 'neutral'
+  | 'success';
+
+type CalloutVariantColors = {
+  background: string;
+  border: string;
+  icon: string;
+};
+
+const VARIANT_COLORS: Record<CalloutVariant, CalloutVariantColors> = {
+  info: {
+    background: 'var(--t-accent-accent1)',
+    border: 'var(--t-accent-accent6)',
+    icon: 'var(--t-accent-accent9)',
+  },
+  warning: {
+    background: 'var(--t-color-orange1)',
+    border: 'var(--t-color-orange6)',
+    icon: 'var(--t-color-orange9)',
+  },
+  success: {
+    background: 'var(--t-color-turquoise1)',
+    border: 'var(--t-color-turquoise6)',
+    icon: 'var(--t-color-turquoise9)',
+  },
+  error: {
+    background: 'var(--t-color-red1)',
+    border: 'var(--t-color-red6)',
+    icon: 'var(--t-color-red9)',
+  },
+  neutral: {
+    background: 'var(--t-color-gray1)',
+    border: 'var(--t-color-gray6)',
+    icon: 'var(--t-color-gray9)',
+  },
+};
+
+export type CalloutProps = {
+  variant: CalloutVariant;
+  title: string;
+  description: string;
+  Icon?: IconComponent;
+};
+
+export const Callout = ({
+  variant,
+  title,
+  description,
+  Icon = IconHelp,
+}: CalloutProps) => {
+  const colors = VARIANT_COLORS[variant];
+
+  return (
+    <div
+      style={{
+        boxSizing: 'border-box',
+        display: 'flex',
+        flexDirection: 'column',
+        alignItems: 'flex-start',
+        gap: 'var(--t-spacing-2)',
+        width: '100%',
+        maxWidth: '512px',
+        padding: 'var(--t-spacing-3) var(--t-spacing-3) var(--t-spacing-2)',
+        border: `1px solid ${colors.border}`,
+        borderRadius: 'var(--t-border-radius-md)',
+        background: colors.background,
+        fontFamily: 'var(--t-font-family)',
+      }}
+    >
+      <div
+        style={{
+          display: 'flex',
+          flexDirection: 'row',
+          alignItems: 'center',
+          alignSelf: 'stretch',
+          gap: 'var(--t-spacing-2)',
+          minHeight: 'var(--t-spacing-6)',
+        }}
+      >
+        <div
+          style={{
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+            flexShrink: 0,
+            height: 'var(--t-spacing-4)',
+            width: 'var(--t-spacing-4)',
+            color: colors.icon,
+          }}
+        >
+          <Icon size={16} />
+        </div>
+        <div
+          style={{
+            flex: 1,
+            color: 'var(--t-font-color-primary)',
+            fontSize: 'var(--t-font-size-md)',
+            fontWeight: 'var(--t-font-weight-medium)' as React.CSSProperties['fontWeight'],
+            lineHeight: 1.4,
+            overflow: 'hidden',
+            textOverflow: 'ellipsis',
+            whiteSpace: 'nowrap',
+          }}
+        >
+          {title}
+        </div>
+      </div>
+      <div
+        style={{
+          display: 'flex',
+          alignItems: 'center',
+          alignSelf: 'stretch',
+          paddingLeft: 'var(--t-spacing-6)',
+          paddingBottom: 'var(--t-spacing-2)',
+        }}
+      >
+        <div
+          style={{
+            flex: 1,
+            color: 'var(--t-font-color-tertiary)',
+            fontSize: 'var(--t-font-size-sm)',
+            fontWeight: 'var(--t-font-weight-regular)' as React.CSSProperties['fontWeight'],
+            lineHeight: 1.4,
+          }}
+        >
+          {description}
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/packages/twenty-apps/internal/twenty-for-twenty/src/ui/H2Title.tsx
+++ b/packages/twenty-apps/internal/twenty-for-twenty/src/ui/H2Title.tsx
@@ -1,0 +1,39 @@
+// Inline reimplementation of twenty-ui's `H2Title` (title-only usage), styled
+// with the Twenty theme's `--t-*` CSS variables. The `margin-bottom` is kept
+// identical to twenty-ui so the callers' negative-margin layout hack still lines up.
+export type H2TitleProps = {
+  title: string;
+  className?: string;
+};
+
+export const H2Title = ({ title }: H2TitleProps) => {
+  return (
+    <div
+      style={{
+        display: 'flex',
+        flexDirection: 'column',
+        marginBottom: 'var(--t-spacing-4)',
+      }}
+    >
+      <div
+        style={{
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'space-between',
+        }}
+      >
+        <h2
+          style={{
+            margin: 0,
+            color: 'var(--t-font-color-primary)',
+            fontSize: 'var(--t-font-size-md)',
+            fontWeight:
+              'var(--t-font-weight-semi-bold)' as React.CSSProperties['fontWeight'],
+          }}
+        >
+          {title}
+        </h2>
+      </div>
+    </div>
+  );
+};

--- a/packages/twenty-apps/internal/twenty-for-twenty/src/ui/Status.tsx
+++ b/packages/twenty-apps/internal/twenty-for-twenty/src/ui/Status.tsx
@@ -1,0 +1,81 @@
+import { type ThemeColor } from '@ui/theme-color';
+
+// Inline reimplementation of twenty-ui's `Status` pill, styled with the Twenty
+// theme's `--t-tag-*` CSS variables. The leading dot (twenty-ui renders it as a
+// `::before`) is an explicit element here, and the loader is a self-contained
+// SMIL-animated SVG so no `@keyframes` injection is required in front-components.
+export type StatusProps = {
+  color: ThemeColor;
+  text: string;
+  isLoaderVisible?: boolean;
+};
+
+const StatusLoader = ({ colorVar }: { colorVar: string }) => (
+  <svg width="14" height="14" viewBox="0 0 24 24" fill="none" aria-hidden="true">
+    <circle
+      cx="12"
+      cy="12"
+      r="9"
+      stroke={colorVar}
+      strokeOpacity="0.25"
+      strokeWidth="3"
+    />
+    <path d="M21 12a9 9 0 0 0 -9 -9" stroke={colorVar} strokeWidth="3" strokeLinecap="round">
+      <animateTransform
+        attributeName="transform"
+        type="rotate"
+        from="0 12 12"
+        to="360 12 12"
+        dur="0.8s"
+        repeatCount="indefinite"
+      />
+    </path>
+  </svg>
+);
+
+export const Status = ({ color, text, isLoaderVisible = false }: StatusProps) => {
+  const backgroundVar = `var(--t-tag-background-${color})`;
+  const textColorVar = `var(--t-tag-text-${color})`;
+
+  return (
+    <h3
+      style={{
+        display: 'inline-flex',
+        alignItems: 'center',
+        gap: 'var(--t-spacing-1)',
+        height: 'var(--t-spacing-5)',
+        margin: 0,
+        padding: isLoaderVisible
+          ? '0 var(--t-spacing-1) 0 var(--t-spacing-2)'
+          : '0 var(--t-spacing-2)',
+        borderRadius: 'var(--t-border-radius-pill)',
+        background: backgroundVar,
+        color: textColorVar,
+        fontSize: 'var(--t-font-size-md)',
+        fontWeight: 'var(--t-font-weight-regular)' as React.CSSProperties['fontWeight'],
+        fontStyle: 'normal',
+        overflow: 'hidden',
+      }}
+    >
+      <span
+        style={{
+          flexShrink: 0,
+          height: 'var(--t-spacing-1)',
+          width: 'var(--t-spacing-1)',
+          borderRadius: 'var(--t-border-radius-rounded)',
+          background: textColorVar,
+        }}
+      />
+      <span
+        style={{
+          overflow: 'hidden',
+          textOverflow: 'ellipsis',
+          whiteSpace: 'nowrap',
+        }}
+      >
+        {text}
+      </span>
+      {isLoaderVisible ? <StatusLoader colorVar={textColorVar} /> : null}
+    </h3>
+  );
+};

--- a/packages/twenty-apps/internal/twenty-for-twenty/src/ui/icons.tsx
+++ b/packages/twenty-apps/internal/twenty-for-twenty/src/ui/icons.tsx
@@ -1,0 +1,74 @@
+// Self-contained Tabler-style icons.
+// Replaces the icons that used to come from `twenty-sdk/ui`, which stopped
+// re-exporting `twenty-ui` in twenty-sdk 2.18. Paths mirror the outline
+// variants of `@tabler/icons` so front-components keep the same visuals
+// without depending on the (React 19 only) `twenty-ui` package.
+
+export type IconComponentProps = {
+  size?: number;
+  color?: string;
+  stroke?: number;
+  className?: string;
+  style?: React.CSSProperties;
+};
+
+export type IconComponent = (props: IconComponentProps) => React.ReactElement;
+
+const createIcon =
+  (children: React.ReactNode): IconComponent =>
+  ({ size = 24, color = 'currentColor', stroke = 2, className, style }) => (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      width={size}
+      height={size}
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke={color}
+      strokeWidth={stroke}
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      className={className}
+      style={style}
+      aria-hidden="true"
+    >
+      {children}
+    </svg>
+  );
+
+export const IconAlertCircle = createIcon(
+  <>
+    <path d="M3 12a9 9 0 1 0 18 0a9 9 0 0 0 -18 0" />
+    <path d="M12 8v4" />
+    <path d="M12 16h.01" />
+  </>,
+);
+
+export const IconInfoCircle = createIcon(
+  <>
+    <path d="M3 12a9 9 0 1 0 18 0a9 9 0 0 0 -18 0" />
+    <path d="M12 9h.01" />
+    <path d="M11 12h1v4h1" />
+  </>,
+);
+
+export const IconMail = createIcon(
+  <>
+    <path d="M3 7a2 2 0 0 1 2 -2h14a2 2 0 0 1 2 2v10a2 2 0 0 1 -2 2h-14a2 2 0 0 1 -2 -2v-10" />
+    <path d="M3 7l9 6l9 -6" />
+  </>,
+);
+
+export const IconRefresh = createIcon(
+  <>
+    <path d="M20 11a8.1 8.1 0 0 0 -15.5 -2m-.5 -4v4h4" />
+    <path d="M4 13a8.1 8.1 0 0 0 15.5 2m.5 4v-4h-4" />
+  </>,
+);
+
+export const IconHelp = createIcon(
+  <>
+    <path d="M3 12a9 9 0 1 0 18 0a9 9 0 0 0 -18 0" />
+    <path d="M12 17l0 .01" />
+    <path d="M12 13.5a1.5 1.5 0 0 1 1 -1.5a2.6 2.6 0 1 0 -3 -4" />
+  </>,
+);

--- a/packages/twenty-apps/internal/twenty-for-twenty/src/ui/index.ts
+++ b/packages/twenty-apps/internal/twenty-for-twenty/src/ui/index.ts
@@ -1,0 +1,16 @@
+// Local, self-contained replacements for the primitives that used to be
+// imported from `twenty-sdk/ui` (removed in twenty-sdk 2.18). See the
+// individual files for details.
+export { Callout, type CalloutProps, type CalloutVariant } from '@ui/Callout';
+export { H2Title, type H2TitleProps } from '@ui/H2Title';
+export { Status, type StatusProps } from '@ui/Status';
+export { type ThemeColor } from '@ui/theme-color';
+export {
+  IconAlertCircle,
+  IconInfoCircle,
+  IconMail,
+  IconRefresh,
+  IconHelp,
+  type IconComponent,
+  type IconComponentProps,
+} from '@ui/icons';

--- a/packages/twenty-apps/internal/twenty-for-twenty/src/ui/theme-color.ts
+++ b/packages/twenty-apps/internal/twenty-for-twenty/src/ui/theme-color.ts
@@ -1,0 +1,28 @@
+// Tag color palette exposed by the Twenty theme as `--t-tag-{background,text}-{color}`
+// CSS variables. Mirrors twenty-ui's `ThemeColor` so components can key into it.
+export type ThemeColor =
+  | 'red'
+  | 'ruby'
+  | 'crimson'
+  | 'tomato'
+  | 'orange'
+  | 'amber'
+  | 'yellow'
+  | 'lime'
+  | 'grass'
+  | 'green'
+  | 'jade'
+  | 'mint'
+  | 'turquoise'
+  | 'cyan'
+  | 'sky'
+  | 'blue'
+  | 'iris'
+  | 'violet'
+  | 'purple'
+  | 'plum'
+  | 'pink'
+  | 'bronze'
+  | 'gold'
+  | 'brown'
+  | 'gray';

--- a/packages/twenty-apps/internal/twenty-for-twenty/tsconfig.json
+++ b/packages/twenty-apps/internal/twenty-for-twenty/tsconfig.json
@@ -27,7 +27,9 @@
       "~/*": ["./*"],
       "@utils/*": ["./src/utils/*"],
       "@constants/*": ["./src/constants/*"],
-      "@modules/*": ["./src/modules/*"]
+      "@modules/*": ["./src/modules/*"],
+      "@ui": ["./src/ui/index.ts"],
+      "@ui/*": ["./src/ui/*"]
     }
   },
   "exclude": [

--- a/packages/twenty-apps/internal/twenty-for-twenty/yarn.lock
+++ b/packages/twenty-apps/internal/twenty-for-twenty/yarn.lock
@@ -34,6 +34,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@emnapi/runtime@npm:^1.7.0":
+  version: 1.11.1
+  resolution: "@emnapi/runtime@npm:1.11.1"
+  dependencies:
+    tslib: "npm:^2.4.0"
+  checksum: 10c0/04332fb62076afc440aa23316c04bec42f584ca8b074e5507d08e2b33a47cbe0493b1aadb8f3c1057b64ae1e17f5bde1a7bc37f7facc9d0bc25c18197cbd366f
+  languageName: node
+  linkType: hard
+
 "@emnapi/wasi-threads@npm:1.2.1":
   version: 1.2.1
   resolution: "@emnapi/wasi-threads@npm:1.2.1"
@@ -249,6 +258,233 @@ __metadata:
   peerDependencies:
     graphql: "*"
   checksum: 10c0/e2a886c2469c933681e2b0ddd6a5b7f4cb12932251ba460e3cf2db4246817da79313ea4ba9769ec7cbe53ab9c1cb81ad8fcce6a969cd241185b79398d2a4f3c6
+  languageName: node
+  linkType: hard
+
+"@img/colour@npm:^1.0.0":
+  version: 1.1.0
+  resolution: "@img/colour@npm:1.1.0"
+  checksum: 10c0/2ebea2c0bbaee73b99badcefa04e1e71d83f36e5369337d3121dca841f4569533c4e2faddda6d62dd247f0d5cca143711f9446c59bcce81e427ba433a7a94a17
+  languageName: node
+  linkType: hard
+
+"@img/sharp-darwin-arm64@npm:0.34.5":
+  version: 0.34.5
+  resolution: "@img/sharp-darwin-arm64@npm:0.34.5"
+  dependencies:
+    "@img/sharp-libvips-darwin-arm64": "npm:1.2.4"
+  dependenciesMeta:
+    "@img/sharp-libvips-darwin-arm64":
+      optional: true
+  conditions: os=darwin & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@img/sharp-darwin-x64@npm:0.34.5":
+  version: 0.34.5
+  resolution: "@img/sharp-darwin-x64@npm:0.34.5"
+  dependencies:
+    "@img/sharp-libvips-darwin-x64": "npm:1.2.4"
+  dependenciesMeta:
+    "@img/sharp-libvips-darwin-x64":
+      optional: true
+  conditions: os=darwin & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@img/sharp-libvips-darwin-arm64@npm:1.2.4":
+  version: 1.2.4
+  resolution: "@img/sharp-libvips-darwin-arm64@npm:1.2.4"
+  conditions: os=darwin & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@img/sharp-libvips-darwin-x64@npm:1.2.4":
+  version: 1.2.4
+  resolution: "@img/sharp-libvips-darwin-x64@npm:1.2.4"
+  conditions: os=darwin & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@img/sharp-libvips-linux-arm64@npm:1.2.4":
+  version: 1.2.4
+  resolution: "@img/sharp-libvips-linux-arm64@npm:1.2.4"
+  conditions: os=linux & cpu=arm64 & libc=glibc
+  languageName: node
+  linkType: hard
+
+"@img/sharp-libvips-linux-arm@npm:1.2.4":
+  version: 1.2.4
+  resolution: "@img/sharp-libvips-linux-arm@npm:1.2.4"
+  conditions: os=linux & cpu=arm & libc=glibc
+  languageName: node
+  linkType: hard
+
+"@img/sharp-libvips-linux-ppc64@npm:1.2.4":
+  version: 1.2.4
+  resolution: "@img/sharp-libvips-linux-ppc64@npm:1.2.4"
+  conditions: os=linux & cpu=ppc64 & libc=glibc
+  languageName: node
+  linkType: hard
+
+"@img/sharp-libvips-linux-riscv64@npm:1.2.4":
+  version: 1.2.4
+  resolution: "@img/sharp-libvips-linux-riscv64@npm:1.2.4"
+  conditions: os=linux & cpu=riscv64 & libc=glibc
+  languageName: node
+  linkType: hard
+
+"@img/sharp-libvips-linux-s390x@npm:1.2.4":
+  version: 1.2.4
+  resolution: "@img/sharp-libvips-linux-s390x@npm:1.2.4"
+  conditions: os=linux & cpu=s390x & libc=glibc
+  languageName: node
+  linkType: hard
+
+"@img/sharp-libvips-linux-x64@npm:1.2.4":
+  version: 1.2.4
+  resolution: "@img/sharp-libvips-linux-x64@npm:1.2.4"
+  conditions: os=linux & cpu=x64 & libc=glibc
+  languageName: node
+  linkType: hard
+
+"@img/sharp-libvips-linuxmusl-arm64@npm:1.2.4":
+  version: 1.2.4
+  resolution: "@img/sharp-libvips-linuxmusl-arm64@npm:1.2.4"
+  conditions: os=linux & cpu=arm64 & libc=musl
+  languageName: node
+  linkType: hard
+
+"@img/sharp-libvips-linuxmusl-x64@npm:1.2.4":
+  version: 1.2.4
+  resolution: "@img/sharp-libvips-linuxmusl-x64@npm:1.2.4"
+  conditions: os=linux & cpu=x64 & libc=musl
+  languageName: node
+  linkType: hard
+
+"@img/sharp-linux-arm64@npm:0.34.5":
+  version: 0.34.5
+  resolution: "@img/sharp-linux-arm64@npm:0.34.5"
+  dependencies:
+    "@img/sharp-libvips-linux-arm64": "npm:1.2.4"
+  dependenciesMeta:
+    "@img/sharp-libvips-linux-arm64":
+      optional: true
+  conditions: os=linux & cpu=arm64 & libc=glibc
+  languageName: node
+  linkType: hard
+
+"@img/sharp-linux-arm@npm:0.34.5":
+  version: 0.34.5
+  resolution: "@img/sharp-linux-arm@npm:0.34.5"
+  dependencies:
+    "@img/sharp-libvips-linux-arm": "npm:1.2.4"
+  dependenciesMeta:
+    "@img/sharp-libvips-linux-arm":
+      optional: true
+  conditions: os=linux & cpu=arm & libc=glibc
+  languageName: node
+  linkType: hard
+
+"@img/sharp-linux-ppc64@npm:0.34.5":
+  version: 0.34.5
+  resolution: "@img/sharp-linux-ppc64@npm:0.34.5"
+  dependencies:
+    "@img/sharp-libvips-linux-ppc64": "npm:1.2.4"
+  dependenciesMeta:
+    "@img/sharp-libvips-linux-ppc64":
+      optional: true
+  conditions: os=linux & cpu=ppc64 & libc=glibc
+  languageName: node
+  linkType: hard
+
+"@img/sharp-linux-riscv64@npm:0.34.5":
+  version: 0.34.5
+  resolution: "@img/sharp-linux-riscv64@npm:0.34.5"
+  dependencies:
+    "@img/sharp-libvips-linux-riscv64": "npm:1.2.4"
+  dependenciesMeta:
+    "@img/sharp-libvips-linux-riscv64":
+      optional: true
+  conditions: os=linux & cpu=riscv64 & libc=glibc
+  languageName: node
+  linkType: hard
+
+"@img/sharp-linux-s390x@npm:0.34.5":
+  version: 0.34.5
+  resolution: "@img/sharp-linux-s390x@npm:0.34.5"
+  dependencies:
+    "@img/sharp-libvips-linux-s390x": "npm:1.2.4"
+  dependenciesMeta:
+    "@img/sharp-libvips-linux-s390x":
+      optional: true
+  conditions: os=linux & cpu=s390x & libc=glibc
+  languageName: node
+  linkType: hard
+
+"@img/sharp-linux-x64@npm:0.34.5":
+  version: 0.34.5
+  resolution: "@img/sharp-linux-x64@npm:0.34.5"
+  dependencies:
+    "@img/sharp-libvips-linux-x64": "npm:1.2.4"
+  dependenciesMeta:
+    "@img/sharp-libvips-linux-x64":
+      optional: true
+  conditions: os=linux & cpu=x64 & libc=glibc
+  languageName: node
+  linkType: hard
+
+"@img/sharp-linuxmusl-arm64@npm:0.34.5":
+  version: 0.34.5
+  resolution: "@img/sharp-linuxmusl-arm64@npm:0.34.5"
+  dependencies:
+    "@img/sharp-libvips-linuxmusl-arm64": "npm:1.2.4"
+  dependenciesMeta:
+    "@img/sharp-libvips-linuxmusl-arm64":
+      optional: true
+  conditions: os=linux & cpu=arm64 & libc=musl
+  languageName: node
+  linkType: hard
+
+"@img/sharp-linuxmusl-x64@npm:0.34.5":
+  version: 0.34.5
+  resolution: "@img/sharp-linuxmusl-x64@npm:0.34.5"
+  dependencies:
+    "@img/sharp-libvips-linuxmusl-x64": "npm:1.2.4"
+  dependenciesMeta:
+    "@img/sharp-libvips-linuxmusl-x64":
+      optional: true
+  conditions: os=linux & cpu=x64 & libc=musl
+  languageName: node
+  linkType: hard
+
+"@img/sharp-wasm32@npm:0.34.5":
+  version: 0.34.5
+  resolution: "@img/sharp-wasm32@npm:0.34.5"
+  dependencies:
+    "@emnapi/runtime": "npm:^1.7.0"
+  conditions: cpu=wasm32
+  languageName: node
+  linkType: hard
+
+"@img/sharp-win32-arm64@npm:0.34.5":
+  version: 0.34.5
+  resolution: "@img/sharp-win32-arm64@npm:0.34.5"
+  conditions: os=win32 & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@img/sharp-win32-ia32@npm:0.34.5":
+  version: 0.34.5
+  resolution: "@img/sharp-win32-ia32@npm:0.34.5"
+  conditions: os=win32 & cpu=ia32
+  languageName: node
+  linkType: hard
+
+"@img/sharp-win32-x64@npm:0.34.5":
+  version: 0.34.5
+  resolution: "@img/sharp-win32-x64@npm:0.34.5"
+  conditions: os=win32 & cpu=x64
   languageName: node
   linkType: hard
 
@@ -1283,7 +1519,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"detect-libc@npm:^2.0.3":
+"detect-libc@npm:^2.0.3, detect-libc@npm:^2.1.2":
   version: 2.1.2
   resolution: "detect-libc@npm:2.1.2"
   checksum: 10c0/acc675c29a5649fa1fb6e255f993b8ee829e510b6b56b0910666949c80c364738833417d0edb5f90e4e46be17228b0f2b66a010513984e18b15deeeac49369c4
@@ -2594,12 +2830,114 @@ __metadata:
   languageName: node
   linkType: hard
 
+"semver@npm:7.6.3":
+  version: 7.6.3
+  resolution: "semver@npm:7.6.3"
+  bin:
+    semver: bin/semver.js
+  checksum: 10c0/88f33e148b210c153873cb08cfe1e281d518aaa9a666d4d148add6560db5cd3c582f3a08ccb91f38d5f379ead256da9931234ed122057f40bb5766e65e58adaf
+  languageName: node
+  linkType: hard
+
 "semver@npm:^7.3.5":
   version: 7.7.4
   resolution: "semver@npm:7.7.4"
   bin:
     semver: bin/semver.js
   checksum: 10c0/5215ad0234e2845d4ea5bb9d836d42b03499546ddafb12075566899fc617f68794bb6f146076b6881d755de17d6c6cc73372555879ec7dce2c2feee947866ad2
+  languageName: node
+  linkType: hard
+
+"semver@npm:^7.7.3":
+  version: 7.8.5
+  resolution: "semver@npm:7.8.5"
+  bin:
+    semver: bin/semver.js
+  checksum: 10c0/b1f3127a5be8125a94f37188b361c212466c292c6910adce3ec106cff5dc211ccaedc4739c11bb70fda59d6fc1f040a9bca289f4e093451521a2372e5231fe0c
+  languageName: node
+  linkType: hard
+
+"sharp@npm:^0.34.5":
+  version: 0.34.5
+  resolution: "sharp@npm:0.34.5"
+  dependencies:
+    "@img/colour": "npm:^1.0.0"
+    "@img/sharp-darwin-arm64": "npm:0.34.5"
+    "@img/sharp-darwin-x64": "npm:0.34.5"
+    "@img/sharp-libvips-darwin-arm64": "npm:1.2.4"
+    "@img/sharp-libvips-darwin-x64": "npm:1.2.4"
+    "@img/sharp-libvips-linux-arm": "npm:1.2.4"
+    "@img/sharp-libvips-linux-arm64": "npm:1.2.4"
+    "@img/sharp-libvips-linux-ppc64": "npm:1.2.4"
+    "@img/sharp-libvips-linux-riscv64": "npm:1.2.4"
+    "@img/sharp-libvips-linux-s390x": "npm:1.2.4"
+    "@img/sharp-libvips-linux-x64": "npm:1.2.4"
+    "@img/sharp-libvips-linuxmusl-arm64": "npm:1.2.4"
+    "@img/sharp-libvips-linuxmusl-x64": "npm:1.2.4"
+    "@img/sharp-linux-arm": "npm:0.34.5"
+    "@img/sharp-linux-arm64": "npm:0.34.5"
+    "@img/sharp-linux-ppc64": "npm:0.34.5"
+    "@img/sharp-linux-riscv64": "npm:0.34.5"
+    "@img/sharp-linux-s390x": "npm:0.34.5"
+    "@img/sharp-linux-x64": "npm:0.34.5"
+    "@img/sharp-linuxmusl-arm64": "npm:0.34.5"
+    "@img/sharp-linuxmusl-x64": "npm:0.34.5"
+    "@img/sharp-wasm32": "npm:0.34.5"
+    "@img/sharp-win32-arm64": "npm:0.34.5"
+    "@img/sharp-win32-ia32": "npm:0.34.5"
+    "@img/sharp-win32-x64": "npm:0.34.5"
+    detect-libc: "npm:^2.1.2"
+    semver: "npm:^7.7.3"
+  dependenciesMeta:
+    "@img/sharp-darwin-arm64":
+      optional: true
+    "@img/sharp-darwin-x64":
+      optional: true
+    "@img/sharp-libvips-darwin-arm64":
+      optional: true
+    "@img/sharp-libvips-darwin-x64":
+      optional: true
+    "@img/sharp-libvips-linux-arm":
+      optional: true
+    "@img/sharp-libvips-linux-arm64":
+      optional: true
+    "@img/sharp-libvips-linux-ppc64":
+      optional: true
+    "@img/sharp-libvips-linux-riscv64":
+      optional: true
+    "@img/sharp-libvips-linux-s390x":
+      optional: true
+    "@img/sharp-libvips-linux-x64":
+      optional: true
+    "@img/sharp-libvips-linuxmusl-arm64":
+      optional: true
+    "@img/sharp-libvips-linuxmusl-x64":
+      optional: true
+    "@img/sharp-linux-arm":
+      optional: true
+    "@img/sharp-linux-arm64":
+      optional: true
+    "@img/sharp-linux-ppc64":
+      optional: true
+    "@img/sharp-linux-riscv64":
+      optional: true
+    "@img/sharp-linux-s390x":
+      optional: true
+    "@img/sharp-linux-x64":
+      optional: true
+    "@img/sharp-linuxmusl-arm64":
+      optional: true
+    "@img/sharp-linuxmusl-x64":
+      optional: true
+    "@img/sharp-wasm32":
+      optional: true
+    "@img/sharp-win32-arm64":
+      optional: true
+    "@img/sharp-win32-ia32":
+      optional: true
+    "@img/sharp-win32-x64":
+      optional: true
+  checksum: 10c0/fd79e29df0597a7d5704b8461c51f944ead91a5243691697be6e8243b966402beda53ddc6f0a53b96ea3cb8221f0b244aa588114d3ebf8734fb4aefd41ab802f
   languageName: node
   linkType: hard
 
@@ -2866,16 +3204,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"twenty-client-sdk@npm:2.14.0, twenty-client-sdk@npm:^2.14.0":
-  version: 2.14.0
-  resolution: "twenty-client-sdk@npm:2.14.0"
+"twenty-client-sdk@npm:2.18.0, twenty-client-sdk@npm:^2.18.0":
+  version: 2.18.0
+  resolution: "twenty-client-sdk@npm:2.18.0"
   dependencies:
     "@genql/runtime": "npm:^2.10.0"
     esbuild: "npm:^0.28.1"
     graphql: "npm:^16.8.1"
     lodash: "npm:^4.17.21"
     prettier: "npm:^3.8.3"
-  checksum: 10c0/eb222a726e21fc98f3a624f9acac7d47f0c769b989911889036665dac7c7c88698ec99beb844bf51a42e1696ea0a067bae8cf47fd751965af52a3720835242f0
+  checksum: 10c0/3b7d6ca4e7b59c04cd2348af0f2ba8de153e70d565b4a38c2744b44998dfcc6c2bdb84ba6315cec208953d8c6fa7573ab33c17355f971f279299d470c57be06e
   languageName: node
   linkType: hard
 
@@ -2890,17 +3228,17 @@ __metadata:
     react: "npm:^18.2.0"
     react-dom: "npm:^18.2.0"
     resend: "npm:^6.12.0"
-    twenty-client-sdk: "npm:^2.14.0"
-    twenty-sdk: "npm:^2.14.0"
+    twenty-client-sdk: "npm:^2.18.0"
+    twenty-sdk: "npm:^2.18.0"
     typescript: "npm:^5.9.3"
     vite-tsconfig-paths: "npm:^4.2.1"
     vitest: "npm:^4.0.0"
   languageName: unknown
   linkType: soft
 
-"twenty-sdk@npm:^2.14.0":
-  version: 2.14.0
-  resolution: "twenty-sdk@npm:2.14.0"
+"twenty-sdk@npm:^2.18.0":
+  version: 2.18.0
+  resolution: "twenty-sdk@npm:2.18.0"
   dependencies:
     "@sniptt/guards": "npm:^0.2.0"
     axios: "npm:^1.16.0"
@@ -2916,13 +3254,15 @@ __metadata:
     preact: "npm:^10.28.3"
     react: "npm:^19.2.0"
     react-dom: "npm:^19.2.0"
+    semver: "npm:7.6.3"
+    sharp: "npm:^0.34.5"
     tinyglobby: "npm:^0.2.15"
-    twenty-client-sdk: "npm:2.14.0"
+    twenty-client-sdk: "npm:2.18.0"
     typescript: "npm:^5.9.3"
     uuid: "npm:^13.0.2"
   bin:
     twenty: dist/cli.cjs
-  checksum: 10c0/c4211772f8dd2ba81074a74be5f616c4c264d6bf8a174c5724be6d1c9a8cb3ca68a2674653bb58c059dae4bf1b0f43f91991e73d6a01395807206f0ac44afb08
+  checksum: 10c0/7e6d300894c427029e4124047614b55988671c914332613acb38f830cee11ecc480ff2a586b6153756aab1b7fa7f4520cf072c9db1428cd9ce9b9f7a62dfcd64
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## What & why

Bumps the **Twenty for Twenty** internal app to the current SDK line and serves it on the matching `twenty-app-dev` image.

- `twenty-sdk` / `twenty-client-sdk`: `^2.14.0` → **`^2.18.0`** (npm latest)
- Runs against `twentycrm/twenty-app-dev:v2.18.5` (same 2.18 line)
- App version `0.1.0` → **`0.2.0`**

### The `twenty-sdk/ui` break

twenty-sdk 2.18 **removed the `twenty-sdk/ui` subpath** (#22326, "Remove twenty-ui reexport from the SDK"). The intended replacement — `twenty-ui@1.0.0-alpha.1` subpaths — requires **React 19 + a monaco-editor peer** that this React-18 app can't adopt, so the app no longer builds against 2.18 as-is.

Instead of migrating to twenty-ui, this replaces the four `twenty-sdk/ui` consumers with **self-contained local components** under `src/ui/`, imported via a new `@ui` alias:

- `Callout`, `H2Title`, `Status`
- Tabler-style inline-SVG icons (`IconAlertCircle`, `IconInfoCircle`, `IconMail`, `IconRefresh`, `IconHelp`)
- a `ThemeColor` type

They mirror the twenty-ui components 1:1 using the `--t-*` theme CSS variables the front-component host injects (the same inline-style pattern the app already used for theme tokens) — no new runtime deps, no React 19 requirement.

## Test plan

- `twenty dev:build` ✓, `yarn typecheck` ✓, `yarn lint` ✓
- Synced into a local `twenty-app-dev:v2.18.5` container (`twenty dev --once`) — objects/fields/views/app install applied cleanly
- Verified rendering live: Sync Status page (`H2Title` headings + `Status` "Not synced" pills) and all three `Callout` variants (error/info/neutral) with correct colors + icons

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/22542?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

