### PR TITLE
fix(twenty-server): make page layout type required

### DIFF
--- a/packages/twenty-sdk/src/cli/utilities/entity/__tests__/get-page-layout-base-file.spec.ts
+++ b/packages/twenty-sdk/src/cli/utilities/entity/__tests__/get-page-layout-base-file.spec.ts
@@ -11,6 +11,7 @@ describe('getPageLayoutBaseFile', () => {
     );
     expect(result).toContain('export default definePageLayout({');
     expect(result).toContain("name: 'my-layout'");
+    expect(result).toContain("type: 'STANDALONE_PAGE'");
     expect(result).toContain("title: 'Overview'");
     expect(result).toContain('widgets: []');
     expect(result).toContain('tabs: [');

--- a/packages/twenty-sdk/src/cli/utilities/entity/entity-page-layout-template.ts
+++ b/packages/twenty-sdk/src/cli/utilities/entity/entity-page-layout-template.ts
@@ -6,6 +6,7 @@ export const getPageLayoutBaseFile = ({ name }: { name: string }) => {
 export default definePageLayout({
   universalIdentifier: '${uuidv4()}',
   name: '${name}',
+  type: 'STANDALONE_PAGE',
   tabs: [
     {
       universalIdentifier: '${uuidv4()}',

--- a/packages/twenty-sdk/src/sdk/define/page-layouts/define-page-layout.ts
+++ b/packages/twenty-sdk/src/sdk/define/page-layouts/define-page-layout.ts
@@ -13,6 +13,10 @@ export const definePageLayout: DefineEntity<PageLayoutConfig> = (config) => {
     errors.push('PageLayout must have a name');
   }
 
+  if (!config.type) {
+    errors.push('PageLayout must have a type');
+  }
+
   if (config.tabs) {
     for (const tab of config.tabs) {
       if (!tab.universalIdentifier) {

--- a/packages/twenty-server/src/engine/core-modules/application/application-manifest/converters/__tests__/from-page-layout-manifest-to-universal-flat-page-layout.util.spec.ts
+++ b/packages/twenty-server/src/engine/core-modules/application/application-manifest/converters/__tests__/from-page-layout-manifest-to-universal-flat-page-layout.util.spec.ts
@@ -10,6 +10,7 @@ describe('fromPageLayoutManifestToUniversalFlatPageLayout', () => {
       pageLayoutManifest: {
         universalIdentifier: 'pl-uuid-1',
         name: 'My Page Layout',
+        type: PageLayoutType.RECORD_PAGE,
       },
       applicationUniversalIdentifier,
       now,

--- a/packages/twenty-server/src/engine/core-modules/application/application-manifest/converters/from-page-layout-manifest-to-universal-flat-page-layout.util.ts
+++ b/packages/twenty-server/src/engine/core-modules/application/application-manifest/converters/from-page-layout-manifest-to-universal-flat-page-layout.util.ts
@@ -16,8 +16,7 @@ export const fromPageLayoutManifestToUniversalFlatPageLayout = ({
     universalIdentifier: pageLayoutManifest.universalIdentifier,
     applicationUniversalIdentifier,
     name: pageLayoutManifest.name,
-    type:
-      (pageLayoutManifest.type as PageLayoutType) ?? PageLayoutType.RECORD_PAGE,
+    type: pageLayoutManifest.type as PageLayoutType,
     objectMetadataUniversalIdentifier:
       pageLayoutManifest.objectUniversalIdentifier ?? null,
     defaultTabToFocusOnMobileAndSidePanelUniversalIdentifier:

--- a/packages/twenty-shared/src/application/pageLayoutManifestType.ts
+++ b/packages/twenty-shared/src/application/pageLayoutManifestType.ts
@@ -26,7 +26,7 @@ export type PageLayoutTabManifest = SyncableEntityOptions & {
 
 export type PageLayoutManifest = SyncableEntityOptions & {
   name: string;
-  type?: string;
+  type: string;
   objectUniversalIdentifier?: string;
   defaultTabToFocusOnMobileAndSidePanelUniversalIdentifier?: string;
   tabs?: PageLayoutTabManifest[];


### PR DESCRIPTION
Fixes #22251 (Replaces closed PR #22255)

Following up on the feedback from @etiennejouan and @bosiraphael in #22255, this PR drops the fallback inference strategy for missing page layout types. Instead, it makes the type field strictly required in the application manifest, enforcing correctness at the type level and via SDK validation.

This ensures that developers explicitly declare whether a layout is a RECORD_PAGE or a STANDALONE_PAGE, preventing the SPA router 404 "Off track" errors that occur when the frontend route guard blocks layouts with missing types.

Changes Made
Manifest Updates: Made the type property required on PageLayoutManifest (in twenty-shared/src/application/pageLayoutManifestType.ts).
SDK Validation: Added validation in definePageLayout to ensure a type is always provided when defining a page layout.
Removed Fallbacks: Removed the implicit type fallback logic from fromPageLayoutManifestToUniversalFlatPageLayout so it respects the explicitly declared type.
Templates: Updated the CLI generator templates (entity-page-layout-template.ts) to include a default type: 'STANDALONE_PAGE' (or RECORD_PAGE where appropriate) when scaffolding new layouts.

Tests: Updated existing server and SDK tests to provide the now-required type field and assert on its behavior.
Validation
✅ Verified yarn nx test twenty-server tests pass.
✅ Verified yarn nx test twenty-sdk tests pass.
✅ TypeScript correctly catches any missing type fields in layout configurations.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/22543?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

