### PR TITLE
fix(Path flow) Windows path normalization in Twenty SDK manifest and upload payloads

### DIFF
--- a/packages/twenty-sdk/src/cli/utilities/api/file-api.ts
+++ b/packages/twenty-sdk/src/cli/utilities/api/file-api.ts
@@ -1,5 +1,6 @@
 import { type ApiResponse } from '@/cli/utilities/api/api-response-type';
 import { serializeError } from '@/cli/utilities/error/serialize-error';
+import { normalizePathSeparators } from '@/cli/utilities/file/normalize-path-separators';
 import axios, { type AxiosInstance, type AxiosResponse } from 'axios';
 import * as fs from 'fs';
 import * as path from 'path';
@@ -230,7 +231,7 @@ export class FileApi {
         variables: {
           file: null,
           applicationUniversalIdentifier,
-          filePath: builtHandlerPath,
+          filePath: normalizePathSeparators(builtHandlerPath),
           fileFolder: graphqlEnumFileFolder,
         },
       });

--- a/packages/twenty-sdk/src/cli/utilities/build/common/esbuild-result-processor.ts
+++ b/packages/twenty-sdk/src/cli/utilities/build/common/esbuild-result-processor.ts
@@ -3,6 +3,7 @@ import type * as esbuild from 'esbuild';
 import { readFile } from 'node:fs/promises';
 import path from 'path';
 import { type OnFileBuiltCallback } from '@/cli/utilities/build/common/restartable-watcher-interface';
+import { normalizePathSeparators } from '@/cli/utilities/file/normalize-path-separators';
 import { type FileFolder } from 'twenty-shared/types';
 
 const SDK_CLIENT_IMPORT_PREFIX = 'twenty-client-sdk';
@@ -28,10 +29,14 @@ export const processEsbuildResult = async ({
 
   for (const outputFile of outputFiles) {
     const absoluteBuiltFile = path.resolve(outputFile);
-    const relativeBuiltPath = path.relative(appPath, absoluteBuiltFile);
+    const relativeBuiltPath = normalizePathSeparators(
+      path.relative(appPath, absoluteBuiltFile),
+    );
     const absoluteSourcePath =
       result.metafile?.outputs?.[outputFile]?.entryPoint || '';
-    const relativeSourcePath = path.relative(appPath, absoluteSourcePath);
+    const relativeSourcePath = normalizePathSeparators(
+      path.relative(appPath, absoluteSourcePath),
+    );
 
     const content = await readFile(absoluteBuiltFile);
     const checksum = crypto.createHash('md5').update(content).digest('hex');

--- a/packages/twenty-sdk/src/cli/utilities/build/common/file-upload-watcher.ts
+++ b/packages/twenty-sdk/src/cli/utilities/build/common/file-upload-watcher.ts
@@ -11,6 +11,7 @@ import {
   pathExists,
   remove,
 } from '@/cli/utilities/file/fs-utils';
+import { normalizePathSeparators } from '@/cli/utilities/file/normalize-path-separators';
 
 export type AssetWatcherOptions = {
   appPath: string;
@@ -80,8 +81,10 @@ export class FileUploadWatcher {
   }
 
   private async copyAndNotify(absoluteFilePath: string): Promise<void> {
-    const sourcePath = relative(this.appPath, absoluteFilePath);
-    const outputPath = join(OUTPUT_DIR, sourcePath);
+    const sourcePath = normalizePathSeparators(
+      relative(this.appPath, absoluteFilePath),
+    );
+    const outputPath = normalizePathSeparators(join(OUTPUT_DIR, sourcePath));
     const absoluteOutputPath = join(this.appPath, outputPath);
 
     await ensureDir(dirname(absoluteOutputPath));
@@ -99,8 +102,10 @@ export class FileUploadWatcher {
   }
 
   private async handleUnlink(absoluteFilePath: string): Promise<void> {
-    const sourcePath = relative(this.appPath, absoluteFilePath);
-    const builtPath = join(OUTPUT_DIR, sourcePath);
+    const sourcePath = normalizePathSeparators(
+      relative(this.appPath, absoluteFilePath),
+    );
+    const builtPath = normalizePathSeparators(join(OUTPUT_DIR, sourcePath));
     const absoluteBuiltPath = join(this.appPath, builtPath);
 
     await remove(absoluteBuiltPath);

--- a/packages/twenty-sdk/src/cli/utilities/build/manifest/manifest-build.ts
+++ b/packages/twenty-sdk/src/cli/utilities/build/manifest/manifest-build.ts
@@ -54,6 +54,7 @@ import {
   jsonSchemaToInputSchema,
 } from 'twenty-shared/logic-function';
 import { assertUnreachable } from 'twenty-shared/utils';
+import { normalizePathSeparators } from '@/cli/utilities/file/normalize-path-separators';
 
 const loadSources = async (appPath: string): Promise<string[]> => {
   return await glob(['**/*.ts', '**/*.tsx'], {
@@ -139,7 +140,7 @@ export const buildManifest = async (
 
   for (const filePath of filePaths) {
     const fileContent = await readFile(filePath, 'utf-8');
-    const relativePath = relative(appPath, filePath);
+    const relativePath = normalizePathSeparators(relative(appPath, filePath));
 
     errors.push(
       ...validateConditionalAvailabilityUsage(fileContent, relativePath),
@@ -374,7 +375,9 @@ export const buildManifest = async (
 
         const { component, ...rest } = extract.config;
 
-        const relativeFilePath = relative(appPath, filePath);
+        const relativeFilePath = normalizePathSeparators(
+          relative(appPath, filePath),
+        );
 
         const config: FrontComponentManifest = {
           ...rest,
@@ -506,7 +509,7 @@ export const buildManifest = async (
   const assetFiles = await loadAssets(appPath);
 
   for (const assetFile of assetFiles) {
-    const relativePath = relative(appPath, assetFile);
+    const relativePath = normalizePathSeparators(relative(appPath, assetFile));
     publicAssets.push({
       filePath: relativePath,
       fileName: basename(assetFile),

--- a/packages/twenty-sdk/src/cli/utilities/build/manifest/manifest-update-checksums.ts
+++ b/packages/twenty-sdk/src/cli/utilities/build/manifest/manifest-update-checksums.ts
@@ -3,6 +3,7 @@ import { type Manifest, OUTPUT_DIR } from 'twenty-shared/application';
 import { FileFolder } from 'twenty-shared/types';
 
 import type { EntityFilePaths } from '@/cli/utilities/build/manifest/manifest-extract-config';
+import { normalizePathSeparators } from '@/cli/utilities/file/normalize-path-separators';
 
 export type ManifestBuildResult = {
   manifest: Manifest | null;
@@ -32,7 +33,9 @@ export const manifestUpdateChecksums = ({
     builtPath,
     { fileFolder, checksum },
   ] of builtFileInfos.entries()) {
-    const rootBuiltPath = relative(OUTPUT_DIR, builtPath);
+    const rootBuiltPath = normalizePathSeparators(
+      relative(OUTPUT_DIR, builtPath),
+    );
     if (fileFolder === FileFolder.BuiltLogicFunction) {
       const logicFunctions = result.logicFunctions;
       const fnIndex = logicFunctions.findIndex(

--- a/packages/twenty-sdk/src/cli/utilities/file/file-uploader.ts
+++ b/packages/twenty-sdk/src/cli/utilities/file/file-uploader.ts
@@ -1,4 +1,5 @@
 import { ApiService } from '@/cli/utilities/api/api-service';
+import { normalizePathSeparators } from '@/cli/utilities/file/normalize-path-separators';
 import path, { relative } from 'path';
 import { type FileFolder } from 'twenty-shared/types';
 import { OUTPUT_DIR } from 'twenty-shared/application';
@@ -24,7 +25,9 @@ export class FileUploader {
     builtPath: string;
     fileFolder: FileFolder;
   }) {
-    const builtHandlerPath = relative(OUTPUT_DIR, builtPath);
+    const builtHandlerPath = normalizePathSeparators(
+      relative(OUTPUT_DIR, builtPath),
+    );
 
     return await this.apiService.uploadFile({
       filePath: path.join(this.appPath, builtPath),

--- a/packages/twenty-sdk/src/cli/utilities/file/normalize-path-separators.ts
+++ b/packages/twenty-sdk/src/cli/utilities/file/normalize-path-separators.ts
@@ -1,0 +1,2 @@
+export const normalizePathSeparators = (filePath: string): string =>
+  filePath.replace(/\\/g, '/');


### PR DESCRIPTION
## Description
Fixes #22539 
This PR fixes Windows backslash path handling in the Twenty SDK so manifest entries and upload payloads consistently use forward slashes before reaching the server.

The change normalizes paths at the SDK boundaries that matter for remote communication and manifest storage:

* Manifest generation for logic functions and front components.
* Checksum matching against built artifacts.
* File upload payloads sent through `UploadApplicationFile`.
* Watcher/build pipeline outputs that feed those payloads.

## Resolves

This resolves the Windows failures described in the linked issue:

* `yarn twenty dev --once` no longer sends unsafe backslash paths in upload requests.
* `yarn twenty app:install` no longer stores backslash paths in the manifest, so installed packages resolve correctly.

## Validation

Tested locally using:

```bash
npx nx typecheck twenty-sdk


