### PR TITLE
Call recorder: unify outcome string literals into as-const constants

### DIFF
--- a/packages/twenty-apps/public/call-recorder/src/constants/generate-call-recording-summaries-outcome.ts
+++ b/packages/twenty-apps/public/call-recorder/src/constants/generate-call-recording-summaries-outcome.ts
@@ -1,0 +1,11 @@
+export const GenerateCallRecordingSummariesOutcome = {
+  PROCESSED: 'processed',
+  DISABLED: 'disabled',
+  NOTHING_SELECTED: 'nothing-selected',
+  NO_CALL_RECORDINGS_FOR_CALENDAR_EVENTS:
+    'no-call-recordings-for-calendar-events',
+  NOTHING_TO_SUMMARIZE: 'nothing-to-summarize',
+} as const;
+
+export type GenerateCallRecordingSummariesOutcome =
+  (typeof GenerateCallRecordingSummariesOutcome)[keyof typeof GenerateCallRecordingSummariesOutcome];

--- a/packages/twenty-apps/public/call-recorder/src/front-components/utils/request-call-recording-summary-generation.util.ts
+++ b/packages/twenty-apps/public/call-recorder/src/front-components/utils/request-call-recording-summary-generation.util.ts
@@ -3,6 +3,7 @@ import { RestApiClient } from 'twenty-client-sdk/rest';
 import { enqueueSnackbar } from 'twenty-sdk/front-component';
 
 import { GENERATE_CALL_RECORDING_SUMMARIES_ROUTE_PATH } from 'src/constants/generate-call-recording-summaries-route-path';
+import { GenerateCallRecordingSummariesOutcome } from 'src/constants/generate-call-recording-summaries-outcome';
 import { TWENTY_FUNCTIONS_URL_ENV_VAR_NAME } from 'src/constants/twenty-functions-url-env-var-name';
 
 type GenerateSummariesResponse = {
@@ -21,14 +22,17 @@ const buildSnackbarForResponse = (
     (response.failedCallRecordingIds ?? []).length +
     (response.erroredCallRecordingIds ?? []).length;
 
-  if (response.outcome === 'disabled') {
+  if (response.outcome === GenerateCallRecordingSummariesOutcome.DISABLED) {
     return {
       message: 'Call summaries are disabled for this workspace.',
       variant: 'error',
     };
   }
 
-  if (response.outcome === 'no-call-recordings-for-calendar-events') {
+  if (
+    response.outcome ===
+    GenerateCallRecordingSummariesOutcome.NO_CALL_RECORDINGS_FOR_CALENDAR_EVENTS
+  ) {
     return {
       message: 'No call recording found for this event.',
       variant: 'error',

--- a/packages/twenty-apps/public/call-recorder/src/logic-functions/constants/call-recorder-reconciliation-action.ts
+++ b/packages/twenty-apps/public/call-recorder/src/logic-functions/constants/call-recorder-reconciliation-action.ts
@@ -1,0 +1,10 @@
+export const CallRecorderReconciliationAction = {
+  CREATED: 'CREATED',
+  UPDATED: 'UPDATED',
+  CANCELED: 'CANCELED',
+  SKIPPED: 'SKIPPED',
+  FAILED: 'FAILED',
+} as const;
+
+export type CallRecorderReconciliationAction =
+  (typeof CallRecorderReconciliationAction)[keyof typeof CallRecorderReconciliationAction];

--- a/packages/twenty-apps/public/call-recorder/src/logic-functions/constants/call-recording-media-ingestion-outcome.ts
+++ b/packages/twenty-apps/public/call-recorder/src/logic-functions/constants/call-recording-media-ingestion-outcome.ts
@@ -1,0 +1,8 @@
+export const CallRecordingMediaIngestionOutcome = {
+  INGESTED: 'ingested',
+  TOO_LARGE: 'too-large',
+  FAILED: 'failed',
+} as const;
+
+export type CallRecordingMediaIngestionOutcome =
+  (typeof CallRecordingMediaIngestionOutcome)[keyof typeof CallRecordingMediaIngestionOutcome];

--- a/packages/twenty-apps/public/call-recorder/src/logic-functions/constants/call-recording-summary-generation-outcome.ts
+++ b/packages/twenty-apps/public/call-recorder/src/logic-functions/constants/call-recording-summary-generation-outcome.ts
@@ -1,0 +1,11 @@
+export const CallRecordingSummaryGenerationOutcome = {
+  DISABLED: 'disabled',
+  NO_TRANSCRIPT: 'no-transcript',
+  NOT_APP_RECORDING: 'not-app-recording',
+  ALREADY_SUMMARIZED: 'already-summarized',
+  EMPTY_SUMMARY: 'empty-summary',
+  GENERATED: 'generated',
+} as const;
+
+export type CallRecordingSummaryGenerationOutcome =
+  (typeof CallRecordingSummaryGenerationOutcome)[keyof typeof CallRecordingSummaryGenerationOutcome];

--- a/packages/twenty-apps/public/call-recorder/src/logic-functions/constants/transcript-download-outcome.ts
+++ b/packages/twenty-apps/public/call-recorder/src/logic-functions/constants/transcript-download-outcome.ts
@@ -1,0 +1,9 @@
+export const TranscriptDownloadOutcome = {
+  FILLED: 'filled',
+  FAILED: 'failed',
+  PENDING: 'pending',
+  ERROR: 'error',
+} as const;
+
+export type TranscriptDownloadOutcome =
+  (typeof TranscriptDownloadOutcome)[keyof typeof TranscriptDownloadOutcome];

--- a/packages/twenty-apps/public/call-recorder/src/logic-functions/flows/download-transcript.util.ts
+++ b/packages/twenty-apps/public/call-recorder/src/logic-functions/flows/download-transcript.util.ts
@@ -1,14 +1,21 @@
 import { isUndefined } from '@sniptt/guards';
 
+import { TranscriptDownloadOutcome } from 'src/logic-functions/constants/transcript-download-outcome';
 import { retrieveRecallTranscript } from 'src/logic-functions/recall-api/retrieve-recall-transcript.util';
 
 const TRANSCRIPT_DOWNLOAD_TIMEOUT_MS = 20_000;
 
 export type DownloadTranscriptResult =
-  | { outcome: 'filled'; content: unknown }
-  | { outcome: 'failed'; subCode: string | null }
-  | { outcome: 'pending' }
-  | { outcome: 'error'; errorMessage: string };
+  | { outcome: typeof TranscriptDownloadOutcome.FILLED; content: unknown }
+  | {
+      outcome: typeof TranscriptDownloadOutcome.FAILED;
+      subCode: string | null;
+    }
+  | { outcome: typeof TranscriptDownloadOutcome.PENDING }
+  | {
+      outcome: typeof TranscriptDownloadOutcome.ERROR;
+      errorMessage: string;
+    };
 
 export const downloadTranscript = async ({
   transcriptId,
@@ -18,7 +25,10 @@ export const downloadTranscript = async ({
   const retrieveResult = await retrieveRecallTranscript({ transcriptId });
 
   if (!retrieveResult.ok) {
-    return { outcome: 'error', errorMessage: retrieveResult.errorMessage };
+    return {
+      outcome: TranscriptDownloadOutcome.ERROR,
+      errorMessage: retrieveResult.errorMessage,
+    };
   }
 
   const { downloadUrl, statusCode, statusSubCode } = retrieveResult.transcript;
@@ -28,10 +38,13 @@ export const downloadTranscript = async ({
   }
 
   if (statusCode === 'error' || statusCode === 'failed') {
-    return { outcome: 'failed', subCode: statusSubCode ?? null };
+    return {
+      outcome: TranscriptDownloadOutcome.FAILED,
+      subCode: statusSubCode ?? null,
+    };
   }
 
-  return { outcome: 'pending' };
+  return { outcome: TranscriptDownloadOutcome.PENDING };
 };
 
 const downloadTranscriptContent = async (
@@ -48,19 +61,22 @@ const downloadTranscriptContent = async (
       );
 
       return {
-        outcome: 'error',
+        outcome: TranscriptDownloadOutcome.ERROR,
         errorMessage: 'transcript download failed',
       };
     }
 
-    return { outcome: 'filled', content: await response.json() };
+    return {
+      outcome: TranscriptDownloadOutcome.FILLED,
+      content: await response.json(),
+    };
   } catch (error) {
     console.warn(
       `[call-recorder] transcript download failed: ${error instanceof Error ? error.message : String(error)}`,
     );
 
     return {
-      outcome: 'error',
+      outcome: TranscriptDownloadOutcome.ERROR,
       errorMessage: 'transcript download failed',
     };
   }

--- a/packages/twenty-apps/public/call-recorder/src/logic-functions/flows/generate-call-recording-summary-result.type.ts
+++ b/packages/twenty-apps/public/call-recorder/src/logic-functions/flows/generate-call-recording-summary-result.type.ts
@@ -1,9 +1,5 @@
+import { type CallRecordingSummaryGenerationOutcome } from 'src/logic-functions/constants/call-recording-summary-generation-outcome';
+
 export type GenerateCallRecordingSummaryResult = {
-  outcome:
-    | 'disabled'
-    | 'no-transcript'
-    | 'not-app-recording'
-    | 'already-summarized'
-    | 'empty-summary'
-    | 'generated';
+  outcome: CallRecordingSummaryGenerationOutcome;
 };

--- a/packages/twenty-apps/public/call-recorder/src/logic-functions/flows/generate-call-recording-summary.util.ts
+++ b/packages/twenty-apps/public/call-recorder/src/logic-functions/flows/generate-call-recording-summary.util.ts
@@ -2,6 +2,7 @@ import { type CoreApiClient } from 'twenty-client-sdk/core';
 import { runAgent } from 'twenty-sdk/logic-function';
 
 import { CALL_RECORDING_SUMMARIZER_AGENT_UNIVERSAL_IDENTIFIER } from 'src/constants/call-recording-summarizer-agent-universal-identifier';
+import { CallRecordingSummaryGenerationOutcome } from 'src/logic-functions/constants/call-recording-summary-generation-outcome';
 import { findCallRecordingForSummary } from 'src/logic-functions/data/find-call-recording-for-summary.util';
 import { updateCallRecording } from 'src/logic-functions/data/update-call-recording.util';
 import { buildCallRecordingSummaryPrompt } from 'src/logic-functions/domain/build-call-recording-summary-prompt.util';
@@ -20,7 +21,7 @@ export const generateCallRecordingSummary = async (
   }: { callRecordingId: string; requireCreatedByCallRecorder?: boolean },
 ): Promise<GenerateCallRecordingSummaryResult> => {
   if (!isCallRecordingSummaryEnabled()) {
-    return { outcome: 'disabled' };
+    return { outcome: CallRecordingSummaryGenerationOutcome.DISABLED };
   }
 
   const callRecording = await findCallRecordingForSummary(client, {
@@ -31,18 +32,22 @@ export const generateCallRecordingSummary = async (
     callRecording === undefined ||
     !isRealTranscript(callRecording.transcript)
   ) {
-    return { outcome: 'no-transcript' };
+    return { outcome: CallRecordingSummaryGenerationOutcome.NO_TRANSCRIPT };
   }
 
   if (
     requireCreatedByCallRecorder &&
     !isCallRecordingCreatedByCallRecorder(callRecording.createdBy)
   ) {
-    return { outcome: 'not-app-recording' };
+    return {
+      outcome: CallRecordingSummaryGenerationOutcome.NOT_APP_RECORDING,
+    };
   }
 
   if (callRecording.summaryMarkdown !== undefined) {
-    return { outcome: 'already-summarized' };
+    return {
+      outcome: CallRecordingSummaryGenerationOutcome.ALREADY_SUMMARIZED,
+    };
   }
 
   const prompt = buildCallRecordingSummaryPrompt({
@@ -52,7 +57,7 @@ export const generateCallRecordingSummary = async (
   });
 
   if (prompt === undefined) {
-    return { outcome: 'no-transcript' };
+    return { outcome: CallRecordingSummaryGenerationOutcome.NO_TRANSCRIPT };
   }
 
   const agentResult = await runAgent({
@@ -64,7 +69,7 @@ export const generateCallRecordingSummary = async (
   const markdown = extractCallRecordingSummaryMarkdown(agentResult);
 
   if (markdown === undefined) {
-    return { outcome: 'empty-summary' };
+    return { outcome: CallRecordingSummaryGenerationOutcome.EMPTY_SUMMARY };
   }
 
   await updateCallRecording(client, {
@@ -72,5 +77,5 @@ export const generateCallRecordingSummary = async (
     data: { summary: { blocknote: null, markdown } },
   });
 
-  return { outcome: 'generated' };
+  return { outcome: CallRecordingSummaryGenerationOutcome.GENERATED };
 };

--- a/packages/twenty-apps/public/call-recorder/src/logic-functions/flows/generate-missing-call-recording-summaries.util.ts
+++ b/packages/twenty-apps/public/call-recorder/src/logic-functions/flows/generate-missing-call-recording-summaries.util.ts
@@ -1,5 +1,6 @@
 import { type CoreApiClient } from 'twenty-client-sdk/core';
 
+import { CallRecordingSummaryGenerationOutcome } from 'src/logic-functions/constants/call-recording-summary-generation-outcome';
 import { requestCallRecordingSummariesContinuation } from 'src/logic-functions/data/request-call-recording-summaries-continuation.util';
 import { generateCallRecordingSummary } from 'src/logic-functions/flows/generate-call-recording-summary.util';
 import { type GenerateCallRecordingSummaryResult } from 'src/logic-functions/flows/generate-call-recording-summary-result.type';
@@ -47,7 +48,7 @@ export const generateMissingCallRecordingSummaries = async ({
     remainingCallRecordingIds.shift();
     slowestItemMs = Math.max(slowestItemMs, getNowMs() - itemStartedAtMs);
 
-    if (outcome === 'disabled') {
+    if (outcome === CallRecordingSummaryGenerationOutcome.DISABLED) {
       // The workspace toggle turned off mid-run; stop spending immediately.
       return {
         generatedCallRecordingIds,
@@ -59,9 +60,11 @@ export const generateMissingCallRecordingSummaries = async ({
       };
     }
 
-    if (outcome === 'generated') {
+    if (outcome === CallRecordingSummaryGenerationOutcome.GENERATED) {
       generatedCallRecordingIds.push(callRecordingId);
-    } else if (outcome === 'empty-summary') {
+    } else if (
+      outcome === CallRecordingSummaryGenerationOutcome.EMPTY_SUMMARY
+    ) {
       failedCallRecordingIds.push(callRecordingId);
     } else if (outcome === 'generation-error') {
       erroredCallRecordingIds.push(callRecordingId);

--- a/packages/twenty-apps/public/call-recorder/src/logic-functions/flows/handle-recall-webhook.util.ts
+++ b/packages/twenty-apps/public/call-recorder/src/logic-functions/flows/handle-recall-webhook.util.ts
@@ -2,6 +2,7 @@ import { isNonEmptyArray, isNull, isUndefined } from '@sniptt/guards';
 import { type CoreApiClient } from 'twenty-client-sdk/core';
 
 import { CallRecordingStatus } from 'src/logic-functions/constants/call-recording-status';
+import { TranscriptDownloadOutcome } from 'src/logic-functions/constants/transcript-download-outcome';
 import { type FilesFieldValue } from 'src/logic-functions/types/files-field-value.type';
 import { buildFailedTranscriptMarker } from 'src/logic-functions/domain/build-failed-transcript-marker.util';
 import { buildTranscriptFailureReason } from 'src/logic-functions/domain/build-transcript-failure-reason.util';
@@ -692,7 +693,7 @@ const handleRecallTranscriptEvent = async ({
   const downloadResult = await downloadTranscript({ transcriptId });
 
   switch (downloadResult.outcome) {
-    case 'filled': {
+    case TranscriptDownloadOutcome.FILLED: {
       const updateData: CallRecordingUpdateFields = {
         transcript: downloadResult.content as Record<string, unknown>,
         ...(isUndefined(callRecording.externalRecordingId)
@@ -713,7 +714,7 @@ const handleRecallTranscriptEvent = async ({
         transcriptOutcome: 'FILLED',
       };
     }
-    case 'failed':
+    case TranscriptDownloadOutcome.FAILED:
       return applyTranscriptFailure({
         client,
         callRecording,
@@ -721,11 +722,11 @@ const handleRecallTranscriptEvent = async ({
         transcriptId,
         subCode: downloadResult.subCode,
       });
-    case 'pending':
-    case 'error': {
+    case TranscriptDownloadOutcome.PENDING:
+    case TranscriptDownloadOutcome.ERROR: {
       // 200-acked either way, Svix never redelivers; the cron re-check retries this.
       const reason =
-        downloadResult.outcome === 'pending'
+        downloadResult.outcome === TranscriptDownloadOutcome.PENDING
           ? 'transcript not downloadable yet'
           : downloadResult.errorMessage;
 

--- a/packages/twenty-apps/public/call-recorder/src/logic-functions/flows/ingest-call-recording-media.util.ts
+++ b/packages/twenty-apps/public/call-recorder/src/logic-functions/flows/ingest-call-recording-media.util.ts
@@ -3,6 +3,7 @@ import { MetadataApiClient } from 'twenty-client-sdk/metadata';
 
 import { CALL_RECORDING_AUDIO_FIELD_UNIVERSAL_IDENTIFIER } from 'src/constants/call-recording-audio-field-universal-identifier';
 import { CALL_RECORDING_VIDEO_FIELD_UNIVERSAL_IDENTIFIER } from 'src/constants/call-recording-video-field-universal-identifier';
+import { CallRecordingMediaIngestionOutcome } from 'src/logic-functions/constants/call-recording-media-ingestion-outcome';
 import { getMaxMediaFileSizeBytes } from 'src/logic-functions/constants/get-max-media-file-size-bytes';
 import {
   AUDIO_FILE_TOO_LARGE_FAILURE_REASON,
@@ -20,13 +21,19 @@ type CallRecordingMediaUpdateFields = Pick<
 >;
 
 type IngestMediaArtifactResult =
-  | { outcome: 'ingested'; files: CallRecordingMediaFile[] }
-  | { outcome: 'too-large' }
-  | { outcome: 'failed' };
+  | {
+      outcome: typeof CallRecordingMediaIngestionOutcome.INGESTED;
+      files: CallRecordingMediaFile[];
+    }
+  | { outcome: typeof CallRecordingMediaIngestionOutcome.TOO_LARGE }
+  | { outcome: typeof CallRecordingMediaIngestionOutcome.FAILED };
 
 type DownloadMediaFileResult =
   | { outcome: 'downloaded'; buffer: Buffer; contentType: string }
-  | { outcome: 'too-large'; sizeBytes: number | undefined };
+  | {
+      outcome: typeof CallRecordingMediaIngestionOutcome.TOO_LARGE;
+      sizeBytes: number | undefined;
+    };
 
 const MEDIA_DOWNLOAD_TIMEOUT_MS = 120_000;
 
@@ -73,11 +80,11 @@ export const ingestCallRecordingMedia = async ({
       maxMediaFileSizeBytes,
     });
 
-    if (video.outcome === 'ingested') {
+    if (video.outcome === CallRecordingMediaIngestionOutcome.INGESTED) {
       updateFields.video = video.files;
     }
 
-    if (video.outcome === 'too-large') {
+    if (video.outcome === CallRecordingMediaIngestionOutcome.TOO_LARGE) {
       tooLargeFailureReasons.push(VIDEO_FILE_TOO_LARGE_FAILURE_REASON);
     }
   }
@@ -93,11 +100,11 @@ export const ingestCallRecordingMedia = async ({
       maxMediaFileSizeBytes,
     });
 
-    if (audio.outcome === 'ingested') {
+    if (audio.outcome === CallRecordingMediaIngestionOutcome.INGESTED) {
       updateFields.audio = audio.files;
     }
 
-    if (audio.outcome === 'too-large') {
+    if (audio.outcome === CallRecordingMediaIngestionOutcome.TOO_LARGE) {
       tooLargeFailureReasons.push(AUDIO_FILE_TOO_LARGE_FAILURE_REASON);
     }
   }
@@ -132,12 +139,14 @@ const ingestMediaArtifact = async ({
       maxMediaFileSizeBytes,
     });
 
-    if (downloadResult.outcome === 'too-large') {
+    if (
+      downloadResult.outcome === CallRecordingMediaIngestionOutcome.TOO_LARGE
+    ) {
       console.warn(
         `[call-recorder] media-ingestion phase=artifact-too-large callRecordingId=${callRecordingId} fileName=${fileName} sizeBytes=${downloadResult.sizeBytes ?? 'unknown'} maxMediaFileSizeBytes=${maxMediaFileSizeBytes}`,
       );
 
-      return { outcome: 'too-large' };
+      return { outcome: CallRecordingMediaIngestionOutcome.TOO_LARGE };
     }
 
     const { buffer, contentType } = downloadResult;
@@ -154,7 +163,7 @@ const ingestMediaArtifact = async ({
     );
 
     return {
-      outcome: 'ingested',
+      outcome: CallRecordingMediaIngestionOutcome.INGESTED,
       files: [{ fileId: uploadedFile.id, label: fileName }],
     };
   } catch (error) {
@@ -162,7 +171,7 @@ const ingestMediaArtifact = async ({
       `[call-recorder] failed to ingest ${fileName} for call recording ${callRecordingId}: ${error instanceof Error ? error.message : String(error)}`,
     );
 
-    return { outcome: 'failed' };
+    return { outcome: CallRecordingMediaIngestionOutcome.FAILED };
   }
 };
 
@@ -200,7 +209,10 @@ const downloadMediaFile = async ({
   ) {
     await response.body?.cancel();
 
-    return { outcome: 'too-large', sizeBytes: contentLengthBytes };
+    return {
+      outcome: CallRecordingMediaIngestionOutcome.TOO_LARGE,
+      sizeBytes: contentLengthBytes,
+    };
   }
 
   if (isNull(response.body)) {
@@ -239,7 +251,10 @@ const readBodyWithinSizeCap = async ({
     if (downloadedBytes > maxMediaFileSizeBytes) {
       await reader.cancel();
 
-      return { outcome: 'too-large', sizeBytes: undefined };
+      return {
+        outcome: CallRecordingMediaIngestionOutcome.TOO_LARGE,
+        sizeBytes: undefined,
+      };
     }
 
     chunks.push(value);

--- a/packages/twenty-apps/public/call-recorder/src/logic-functions/flows/reconcile-call-recorder.util.ts
+++ b/packages/twenty-apps/public/call-recorder/src/logic-functions/flows/reconcile-call-recorder.util.ts
@@ -1,6 +1,7 @@
 import { isUndefined } from '@sniptt/guards';
 import { type CoreApiClient } from 'twenty-client-sdk/core';
 
+import { CallRecorderReconciliationAction } from 'src/logic-functions/constants/call-recorder-reconciliation-action';
 import { CallRecordingRequestStatus } from 'src/logic-functions/constants/call-recording-request-status';
 import { CallRecordingStatus } from 'src/logic-functions/constants/call-recording-status';
 import { type CalendarEventRecord } from 'src/logic-functions/types/calendar-event-record.type';
@@ -202,7 +203,7 @@ const reconcileCallRecorderForMeetingOccurrences = async ({
         `[call-recorder] reconciliation failed for meeting ${meetingPolicyResult.realMeetingKey}: ${errorMessage}`,
       );
       reconciliationResults.push({
-        action: 'FAILED',
+        action: CallRecorderReconciliationAction.FAILED,
         realMeetingKey: meetingPolicyResult.realMeetingKey,
         errorMessage,
       });
@@ -261,7 +262,7 @@ const reconcileActiveMeeting = async ({
 
   if (!isUndefined(manualOpenCallRecording)) {
     return {
-      action: 'SKIPPED',
+      action: CallRecorderReconciliationAction.SKIPPED,
       realMeetingKey: meetingPolicyResult.realMeetingKey,
       callRecordingId: manualOpenCallRecording.id,
     };
@@ -299,7 +300,7 @@ const updatePolicyManagedCallRecording = async ({
   });
 
   return {
-    action: 'UPDATED',
+    action: CallRecorderReconciliationAction.UPDATED,
     realMeetingKey,
     callRecordingId: existingCallRecording.id,
   };
@@ -354,7 +355,7 @@ const createPolicyManagedCallRecording = async ({
   });
 
   return {
-    action: 'CREATED',
+    action: CallRecorderReconciliationAction.CREATED,
     realMeetingKey,
     callRecordingId,
   };
@@ -424,7 +425,7 @@ const reconcileCanceledMeeting = async ({
   }
 
   return {
-    action: 'CANCELED',
+    action: CallRecorderReconciliationAction.CANCELED,
     realMeetingKey: meetingPolicyResult.realMeetingKey,
     callRecordingId: cancellableCallRecordings[0].id,
   };
@@ -489,7 +490,7 @@ const buildRemovedCalendarEventIdsByMeetingKey = (
 const buildSkippedResult = (
   realMeetingKey: string,
 ): CallRecorderReconciliationResult => ({
-  action: 'SKIPPED',
+  action: CallRecorderReconciliationAction.SKIPPED,
   realMeetingKey,
   callRecordingId: null,
 });

--- a/packages/twenty-apps/public/call-recorder/src/logic-functions/flows/reconcile-call-recording-transcript-artifact.util.ts
+++ b/packages/twenty-apps/public/call-recorder/src/logic-functions/flows/reconcile-call-recording-transcript-artifact.util.ts
@@ -1,6 +1,7 @@
 import { isNull, isUndefined } from '@sniptt/guards';
 
 import { CallRecordingStatus } from 'src/logic-functions/constants/call-recording-status';
+import { TranscriptDownloadOutcome } from 'src/logic-functions/constants/transcript-download-outcome';
 import { buildFailedTranscriptMarker } from 'src/logic-functions/domain/build-failed-transcript-marker.util';
 import { buildPendingTranscriptMarker } from 'src/logic-functions/domain/build-pending-transcript-marker.util';
 import { buildTranscriptFailureReason } from 'src/logic-functions/domain/build-transcript-failure-reason.util';
@@ -119,7 +120,7 @@ export const reconcileCallRecordingTranscriptArtifact = async ({
     transcriptId: transcriptIdToDownload,
   });
 
-  if (downloadResult.outcome === 'filled') {
+  if (downloadResult.outcome === TranscriptDownloadOutcome.FILLED) {
     return {
       updateData: {
         transcript: downloadResult.content as Record<string, unknown>,
@@ -128,7 +129,7 @@ export const reconcileCallRecordingTranscriptArtifact = async ({
     };
   }
 
-  if (downloadResult.outcome === 'failed') {
+  if (downloadResult.outcome === TranscriptDownloadOutcome.FAILED) {
     return {
       updateData: buildTranscriptFailureUpdate({
         currentStatus,
@@ -139,7 +140,7 @@ export const reconcileCallRecordingTranscriptArtifact = async ({
     };
   }
 
-  if (downloadResult.outcome === 'error') {
+  if (downloadResult.outcome === TranscriptDownloadOutcome.ERROR) {
     console.warn(
       `[call-recorder] could not fill transcript for call recording ${callRecordingId}: ${downloadResult.errorMessage}`,
     );

--- a/packages/twenty-apps/public/call-recorder/src/logic-functions/flows/reconcile-upcoming-calendar-event-batches.util.ts
+++ b/packages/twenty-apps/public/call-recorder/src/logic-functions/flows/reconcile-upcoming-calendar-event-batches.util.ts
@@ -1,5 +1,6 @@
 import { type CoreApiClient } from 'twenty-client-sdk/core';
 
+import { CallRecorderReconciliationAction } from 'src/logic-functions/constants/call-recorder-reconciliation-action';
 import { UPCOMING_CALENDAR_EVENT_RECONCILIATION_BATCH_SIZE } from 'src/logic-functions/constants/upcoming-calendar-event-reconciliation-batch-size';
 import { requestUpcomingCalendarEventsReconciliation } from 'src/logic-functions/data/request-upcoming-calendar-events-reconciliation.util';
 import { reconcileCallRecorderForCalendarEventIds } from 'src/logic-functions/flows/reconcile-call-recorder.util';
@@ -12,11 +13,11 @@ import { type CallRecorderReconciliationResult } from 'src/logic-functions/types
 const ACTION_COUNT_KEY_BY_ACTION: {
   [Action in CallRecorderReconciliationResult['action']]: Lowercase<Action>;
 } = {
-  CREATED: 'created',
-  UPDATED: 'updated',
-  CANCELED: 'canceled',
-  SKIPPED: 'skipped',
-  FAILED: 'failed',
+  [CallRecorderReconciliationAction.CREATED]: 'created',
+  [CallRecorderReconciliationAction.UPDATED]: 'updated',
+  [CallRecorderReconciliationAction.CANCELED]: 'canceled',
+  [CallRecorderReconciliationAction.SKIPPED]: 'skipped',
+  [CallRecorderReconciliationAction.FAILED]: 'failed',
 };
 
 export const reconcileUpcomingCalendarEventBatches = async ({

--- a/packages/twenty-apps/public/call-recorder/src/logic-functions/generate-call-recording-summaries.ts
+++ b/packages/twenty-apps/public/call-recorder/src/logic-functions/generate-call-recording-summaries.ts
@@ -3,9 +3,11 @@ import { defineLogicFunction, type RoutePayload } from 'twenty-sdk/define';
 
 import { GENERATE_CALL_RECORDING_SUMMARIES_LOGIC_FUNCTION_UNIVERSAL_IDENTIFIER } from 'src/constants/generate-call-recording-summaries-logic-function-universal-identifier';
 import { GENERATE_CALL_RECORDING_SUMMARIES_ROUTE_PATH } from 'src/constants/generate-call-recording-summaries-route-path';
+import { GenerateCallRecordingSummariesOutcome } from 'src/constants/generate-call-recording-summaries-outcome';
 import { findCallRecordingIdsForCalendarEvents } from 'src/logic-functions/data/find-call-recording-ids-for-calendar-events.util';
 import { findCallRecordingIdsMissingSummary } from 'src/logic-functions/data/find-call-recording-ids-missing-summary.util';
 import { generateMissingCallRecordingSummaries } from 'src/logic-functions/flows/generate-missing-call-recording-summaries.util';
+import { type GenerateMissingCallRecordingSummariesResult } from 'src/logic-functions/flows/generate-missing-call-recording-summaries-result.type';
 import { isCallRecordingSummaryEnabled } from 'src/logic-functions/utils/is-call-recording-summary-enabled.util';
 import { isNonEmptyString } from 'src/logic-functions/utils/is-non-empty-string.util';
 
@@ -16,6 +18,18 @@ type GenerateCallRecordingSummariesRouteBody = {
   callRecordingIds?: string[];
   calendarEventIds?: string[];
 };
+
+type GenerateCallRecordingSummariesRouteResult =
+  | {
+      outcome:
+        | typeof GenerateCallRecordingSummariesOutcome.DISABLED
+        | typeof GenerateCallRecordingSummariesOutcome.NOTHING_SELECTED
+        | typeof GenerateCallRecordingSummariesOutcome.NO_CALL_RECORDINGS_FOR_CALENDAR_EVENTS
+        | typeof GenerateCallRecordingSummariesOutcome.NOTHING_TO_SUMMARIZE;
+    }
+  | ({
+      outcome: typeof GenerateCallRecordingSummariesOutcome.PROCESSED;
+    } & GenerateMissingCallRecordingSummariesResult);
 
 const hasOwnProperty = <T extends object>(
   object: T | null | undefined,
@@ -30,9 +44,9 @@ const toIdList = (value: unknown): string[] =>
 
 export const generateCallRecordingSummariesHandler = async (
   payload: RoutePayload<GenerateCallRecordingSummariesRouteBody>,
-): Promise<object> => {
+): Promise<GenerateCallRecordingSummariesRouteResult> => {
   if (!isCallRecordingSummaryEnabled()) {
-    return { outcome: 'disabled' };
+    return { outcome: GenerateCallRecordingSummariesOutcome.DISABLED };
   }
 
   const startedAtMs = Date.now();
@@ -58,7 +72,7 @@ export const generateCallRecordingSummariesHandler = async (
     requestedCallRecordingIds.length === 0 &&
     requestedCalendarEventIds.length === 0
   ) {
-    return { outcome: 'nothing-selected' };
+    return { outcome: GenerateCallRecordingSummariesOutcome.NOTHING_SELECTED };
   }
 
   if (callRecordingIds.length === 0 && requestedCalendarEventIds.length > 0) {
@@ -67,7 +81,10 @@ export const generateCallRecordingSummariesHandler = async (
     });
 
     if (callRecordingIds.length === 0) {
-      return { outcome: 'no-call-recordings-for-calendar-events' };
+      return {
+        outcome:
+          GenerateCallRecordingSummariesOutcome.NO_CALL_RECORDINGS_FOR_CALENDAR_EVENTS,
+      };
     }
   }
 
@@ -77,7 +94,9 @@ export const generateCallRecordingSummariesHandler = async (
     callRecordingIds = await findCallRecordingIdsMissingSummary(client);
 
     if (callRecordingIds.length === 0) {
-      return { outcome: 'nothing-to-summarize' };
+      return {
+        outcome: GenerateCallRecordingSummariesOutcome.NOTHING_TO_SUMMARIZE,
+      };
     }
   }
 
@@ -88,7 +107,10 @@ export const generateCallRecordingSummariesHandler = async (
       startedAtMs + TIMEOUT_SECONDS * 1000 - CONTINUATION_RESERVE_MS,
   });
 
-  return { outcome: 'processed', ...result };
+  return {
+    outcome: GenerateCallRecordingSummariesOutcome.PROCESSED,
+    ...result,
+  };
 };
 
 export default defineLogicFunction({

--- a/packages/twenty-apps/public/call-recorder/src/logic-functions/types/call-recorder-reconciliation-result.type.ts
+++ b/packages/twenty-apps/public/call-recorder/src/logic-functions/types/call-recorder-reconciliation-result.type.ts
@@ -1,16 +1,21 @@
+import { type CallRecorderReconciliationAction } from 'src/logic-functions/constants/call-recorder-reconciliation-action';
+
 export type CallRecorderReconciliationResult =
   | {
-      action: 'CREATED' | 'UPDATED' | 'CANCELED';
+      action:
+        | typeof CallRecorderReconciliationAction.CREATED
+        | typeof CallRecorderReconciliationAction.UPDATED
+        | typeof CallRecorderReconciliationAction.CANCELED;
       realMeetingKey: string;
       callRecordingId: string;
     }
   | {
-      action: 'SKIPPED';
+      action: typeof CallRecorderReconciliationAction.SKIPPED;
       realMeetingKey: string;
       callRecordingId: string | null;
     }
   | {
-      action: 'FAILED';
+      action: typeof CallRecorderReconciliationAction.FAILED;
       realMeetingKey: string;
       errorMessage: string;
     };


### PR DESCRIPTION
## Context

Stacked on #22552, which introduced `as const` outcome constants for the code it added. This PR extends the same pattern to the rest of the Call Recorder app, per the repo's string-literals-over-enums guideline. Pure refactor: every wire value is byte-identical, and no test assertion changed — existing tests keep asserting the raw strings, pinning the contract.

## What changed

**5 new constant files**, all `as const` objects with derived union types (no enums):

| Constant | Location | Values |
| --- | --- | --- |
| `GenerateCallRecordingSummariesOutcome` | `src/constants/` | `processed`, `disabled`, `nothing-selected`, `no-call-recordings-for-calendar-events`, `nothing-to-summarize` |
| `CallRecorderReconciliationAction` | `logic-functions/constants/` | `CREATED`, `UPDATED`, `CANCELED`, `SKIPPED`, `FAILED` |
| `CallRecordingSummaryGenerationOutcome` | `logic-functions/constants/` | `disabled`, `no-transcript`, `not-app-recording`, `already-summarized`, `empty-summary`, `generated` |
| `CallRecordingMediaIngestionOutcome` | `logic-functions/constants/` | `ingested`, `too-large`, `failed` |
| `TranscriptDownloadOutcome` | `logic-functions/constants/` | `filled`, `failed`, `pending`, `error` |

**Highlights:**

- `GenerateCallRecordingSummariesOutcome` lives in `src/constants/` because it crosses the logic-function/front-component boundary: the front component was string-matching `'disabled'` / `'no-call-recordings-for-calendar-events'` against the route's responses across two separately-built bundles — a silent-drift risk that a shared constant removes. The summaries route handler is also retyped from `Promise<object>` to a discriminated result union, mirroring the sweep route.
- `CallRecorderReconciliationAction` now backs the reconciliation result's discriminated union and all its producers; the `ACTION_COUNT_KEY_BY_ACTION` map in the sweep batch flow keeps its mapped-type exhaustiveness guarantee with computed constant keys.
- The three flow-level constants back the internal result unions (media ingestion, transcript download, summary generation) and every cross-file comparison of them.

**Deliberately left as literals:** Recall API transcript status codes (`statusCode === 'error'`), transcript markers, the webhook handler's separate uppercase `transcriptOutcome` field, file-private unions that never leave their module, error-message prose, and the three existing enums (`CallRecordingStatus`, `CallRecordingRequestStatus`, `CallRecorderPreference`) which mirror core SELECT options and fall under the GraphQL-enum exception.

## Test plan

- `yarn test:unit`: 379 tests across 61 files pass with zero test modifications — the strongest evidence no wire value moved.
- `yarn typecheck`, `yarn lint`, `yarn twenty dev:build` (manifest build) all pass.

---
_Generated by [Claude Code](https://claude.ai/code/session_011pC36ysPtanzbfCSc9Ge4y)_

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/22553?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

