### PR TITLE
docs: document Node ^24.5.0 prerequisite in CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -202,6 +202,8 @@ IMPORTANT: Use Context7 for code generation, setup or configuration steps, or li
 
 ## Dev Environment Setup
 
+**Prerequisite: Node `^24.5.0`** (`.nvmrc` pins the exact version). Check `node --version` BEFORE installing dependencies — cloud sandboxes and CI images often default to Node 20–22, and `yarn install` on an older Node fails only at the post-install engines check, after minutes of wasted work. If the version is too old, run `nvm install` (reads `.nvmrc`) first.
+
 All dev environments (Claude Code web, Cursor, local) use one script:
 
 ```bash


### PR DESCRIPTION
## What

Adds an explicit Node `^24.5.0` prerequisite to the **Dev Environment Setup** section of CLAUDE.md, with the instruction to check `node --version` before installing dependencies and to run `nvm install` (which reads `.nvmrc`) when the version is too old.

## Why

The Node requirement currently lives only in `package.json` `engines` and `.nvmrc`, so coding agents (Claude Code web sandboxes, cloud agents, CI-like environments) that default to Node 20–22 discover it the expensive way: `yarn install` runs for ~4 minutes and only then fails at the post-install engines check.

Observed in practice: a cloud agent session on a fresh Ubuntu 22.04 sandbox (Node 22 default) lost ~4 minutes on a doomed install before diagnosing the engines mismatch and installing Node 24. CLAUDE.md is the first thing these agents read, so documenting the prerequisite there prevents the wasted cycle for every agent-driven environment.

## Test

Doc-only change — no code affected.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/22566?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

