### PR TITLE
refactor(server): remove nestjs-query from key-value-pair module

### DIFF
--- a/packages/twenty-server/src/engine/core-modules/key-value-pair/key-value-pair.entity.ts
+++ b/packages/twenty-server/src/engine/core-modules/key-value-pair/key-value-pair.entity.ts
@@ -1,6 +1,5 @@
 import { Field, ObjectType } from '@nestjs/graphql';
 
-import { IDField } from '@ptc-org/nestjs-query-graphql';
 import {
   Column,
   CreateDateColumn,
@@ -56,7 +55,7 @@ export enum KeyValuePairType {
   },
 )
 export class KeyValuePairEntity {
-  @IDField(() => UUIDScalarType)
+  @Field(() => UUIDScalarType)
   @PrimaryGeneratedColumn('uuid')
   id: string;
 

--- a/packages/twenty-server/src/engine/core-modules/key-value-pair/key-value-pair.module.ts
+++ b/packages/twenty-server/src/engine/core-modules/key-value-pair/key-value-pair.module.ts
@@ -1,9 +1,9 @@
 import { Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
 
-import { KeyValuePairService } from 'src/engine/core-modules/key-value-pair/key-value-pair.service';
-import { KeyValuePairEntity } from 'src/engine/core-modules/key-value-pair/key-value-pair.entity';
 import { TypeORMModule } from 'src/database/typeorm/typeorm.module';
+import { KeyValuePairEntity } from 'src/engine/core-modules/key-value-pair/key-value-pair.entity';
+import { KeyValuePairService } from 'src/engine/core-modules/key-value-pair/key-value-pair.service';
 
 @Module({
   imports: [TypeOrmModule.forFeature([KeyValuePairEntity]), TypeORMModule],

--- a/packages/twenty-server/src/engine/core-modules/key-value-pair/key-value-pair.module.ts
+++ b/packages/twenty-server/src/engine/core-modules/key-value-pair/key-value-pair.module.ts
@@ -1,21 +1,12 @@
 import { Module } from '@nestjs/common';
-
-import { NestjsQueryGraphQLModule } from '@ptc-org/nestjs-query-graphql';
-import { NestjsQueryTypeOrmModule } from '@ptc-org/nestjs-query-typeorm';
+import { TypeOrmModule } from '@nestjs/typeorm';
 
 import { KeyValuePairService } from 'src/engine/core-modules/key-value-pair/key-value-pair.service';
 import { KeyValuePairEntity } from 'src/engine/core-modules/key-value-pair/key-value-pair.entity';
 import { TypeORMModule } from 'src/database/typeorm/typeorm.module';
 
 @Module({
-  imports: [
-    NestjsQueryGraphQLModule.forFeature({
-      imports: [
-        NestjsQueryTypeOrmModule.forFeature([KeyValuePairEntity]),
-        TypeORMModule,
-      ],
-    }),
-  ],
+  imports: [TypeOrmModule.forFeature([KeyValuePairEntity]), TypeORMModule],
   exports: [KeyValuePairService],
   providers: [KeyValuePairService],
 })


### PR DESCRIPTION
## Summary

First step toward removing `@ptc-org/nestjs-query` from the codebase (follow-up to the `indexFieldMetadatas` DI bug [discussion](https://github.com/twentyhq/twenty/pull/22439#issuecomment-4864265452)).

The `key-value-pair` module wrapped its entity in `NestjsQueryGraphQLModule.forFeature`, but registered **no resolvers** — the `KeyValuePair` type is exposed in no GraphQL schema, and `KeyValuePairService` only uses a plain TypeORM repository. The nestjs-query layer was doing nothing except registering that repository as a side effect.

## Changes

- Replace the empty `NestjsQueryGraphQLModule.forFeature({...})` wrapper with a plain
  `TypeOrmModule.forFeature([KeyValuePairEntity])`
- Swap the entity's `@IDField` (nestjs-query) for the standard `@Field` from `@nestjs/graphql`

`nestjs-query` is no longer referenced anywhere under `key-value-pair/`.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/22575?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

