### PR TITLE
chore(server): remove nestjs-query from user-workspace module

### DIFF
--- a/packages/twenty-server/src/engine/core-modules/user-workspace/user-workspace.entity.ts
+++ b/packages/twenty-server/src/engine/core-modules/user-workspace/user-workspace.entity.ts
@@ -1,6 +1,5 @@
 import { Field, ObjectType, registerEnumType } from '@nestjs/graphql';
 
-import { IDField } from '@ptc-org/nestjs-query-graphql';
 import {
   PermissionFlagType,
   PermissionsOnAllObjectRecords,
@@ -48,7 +47,7 @@ registerEnumType(PermissionsOnAllObjectRecords, {
 @Index('IDX_USER_WORKSPACE_USER_ID', ['userId'])
 @Index('IDX_USER_WORKSPACE_WORKSPACE_ID', ['workspaceId'])
 export class UserWorkspaceEntity extends WorkspaceRelatedEntity {
-  @IDField(() => UUIDScalarType)
+  @Field(() => UUIDScalarType)
   @PrimaryGeneratedColumn('uuid')
   id: string;
 

--- a/packages/twenty-server/src/engine/core-modules/user-workspace/user-workspace.module.ts
+++ b/packages/twenty-server/src/engine/core-modules/user-workspace/user-workspace.module.ts
@@ -1,7 +1,5 @@
 import { Module } from '@nestjs/common';
-
-import { NestjsQueryGraphQLModule } from '@ptc-org/nestjs-query-graphql';
-import { NestjsQueryTypeOrmModule } from '@ptc-org/nestjs-query-typeorm';
+import { TypeOrmModule } from '@nestjs/typeorm';
 
 import { TypeORMModule } from 'src/database/typeorm/typeorm.module';
 import { CoreEntityCacheModule } from 'src/engine/core-entity-cache/core-entity-cache.module';
@@ -29,34 +27,29 @@ import { WorkspaceDataSourceModule } from 'src/engine/workspace-datasource/works
 
 @Module({
   imports: [
-    NestjsQueryGraphQLModule.forFeature({
-      imports: [
-        NestjsQueryTypeOrmModule.forFeature([
-          UserEntity,
-          UserWorkspaceEntity,
-          WorkspaceEntity,
-          RoleTargetEntity,
-          RoleEntity,
-        ]),
-        RoleValidationModule,
-        NestjsQueryTypeOrmModule.forFeature([ObjectMetadataEntity]),
-        TypeORMModule,
-        WorkspaceDataSourceModule,
-        ApprovedAccessDomainModule,
-        WorkspaceInvitationModule,
-        WorkspaceDomainsModule,
-        TwentyORMModule,
-        UserRoleModule,
-        FileModule,
-        TokenModule,
-        PermissionsModule,
-        OnboardingModule,
-        EnterpriseModule,
-        FeatureFlagModule,
-        CoreEntityCacheModule,
-      ],
-      services: [UserWorkspaceService],
-    }),
+    TypeOrmModule.forFeature([
+      UserEntity,
+      UserWorkspaceEntity,
+      WorkspaceEntity,
+      RoleTargetEntity,
+      RoleEntity,
+      ObjectMetadataEntity,
+    ]),
+    RoleValidationModule,
+    TypeORMModule,
+    WorkspaceDataSourceModule,
+    ApprovedAccessDomainModule,
+    WorkspaceInvitationModule,
+    WorkspaceDomainsModule,
+    TwentyORMModule,
+    UserRoleModule,
+    FileModule,
+    TokenModule,
+    PermissionsModule,
+    OnboardingModule,
+    EnterpriseModule,
+    FeatureFlagModule,
+    CoreEntityCacheModule,
   ],
   exports: [UserWorkspaceService],
   providers: [UserWorkspaceService, UserWorkspaceEntityCacheProviderService],

--- a/packages/twenty-server/src/engine/core-modules/user-workspace/user-workspace.module.ts
+++ b/packages/twenty-server/src/engine/core-modules/user-workspace/user-workspace.module.ts
@@ -15,11 +15,8 @@ import { UserWorkspaceEntity } from 'src/engine/core-modules/user-workspace/user
 import { UserWorkspaceService } from 'src/engine/core-modules/user-workspace/user-workspace.service';
 import { UserEntity } from 'src/engine/core-modules/user/user.entity';
 import { WorkspaceInvitationModule } from 'src/engine/core-modules/workspace-invitation/workspace-invitation.module';
-import { WorkspaceEntity } from 'src/engine/core-modules/workspace/workspace.entity';
-import { ObjectMetadataEntity } from 'src/engine/metadata-modules/object-metadata/object-metadata.entity';
 import { PermissionsModule } from 'src/engine/metadata-modules/permissions/permissions.module';
 import { RoleTargetEntity } from 'src/engine/metadata-modules/role-target/role-target.entity';
-import { RoleEntity } from 'src/engine/metadata-modules/role/role.entity';
 import { RoleValidationModule } from 'src/engine/metadata-modules/role-validation/role-validation.module';
 import { UserRoleModule } from 'src/engine/metadata-modules/user-role/user-role.module';
 import { TwentyORMModule } from 'src/engine/twenty-orm/twenty-orm.module';
@@ -28,12 +25,9 @@ import { WorkspaceDataSourceModule } from 'src/engine/workspace-datasource/works
 @Module({
   imports: [
     TypeOrmModule.forFeature([
-      UserEntity,
       UserWorkspaceEntity,
-      WorkspaceEntity,
+      UserEntity,
       RoleTargetEntity,
-      RoleEntity,
-      ObjectMetadataEntity,
     ]),
     RoleValidationModule,
     TypeORMModule,

--- a/packages/twenty-server/src/engine/core-modules/user-workspace/user-workspace.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/user-workspace/user-workspace.service.ts
@@ -1,7 +1,6 @@
 import { Logger } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 
-import { TypeOrmQueryService } from '@ptc-org/nestjs-query-typeorm';
 import { type APP_LOCALES, SOURCE_LOCALE } from 'twenty-shared/translations';
 import { FileFolder } from 'twenty-shared/types';
 import { assertIsDefinedOrThrow, isDefined } from 'twenty-shared/utils';
@@ -44,7 +43,7 @@ import { type WorkspaceMemberWorkspaceEntity } from 'src/modules/workspace-membe
 import { assert } from 'src/utils/assert';
 import { getDomainFromEmailOrThrow } from 'src/utils/get-domain-from-email-or-throw';
 
-export class UserWorkspaceService extends TypeOrmQueryService<UserWorkspaceEntity> {
+export class UserWorkspaceService {
   private readonly logger = new Logger(UserWorkspaceService.name);
 
   constructor(
@@ -67,8 +66,10 @@ export class UserWorkspaceService extends TypeOrmQueryService<UserWorkspaceEntit
     private readonly fileUrlService: FileUrlService,
     private readonly onboardingService: OnboardingService,
     private readonly coreEntityCacheService: CoreEntityCacheService,
-  ) {
-    super(userWorkspaceRepository);
+  ) {}
+
+  async findById(id: string): Promise<UserWorkspaceEntity | null> {
+    return this.userWorkspaceRepository.findOne({ where: { id } });
   }
 
   async updateUserWorkspaceLocaleForUserWorkspace({


### PR DESCRIPTION
## Summary
Continues the incremental removal of `@ptc-org/nestjs-query`. Migrates the `user-workspace` module to plain NestJS/TypeORM. This module registered no resolvers, so `nestjs-query` was only acting as module wiring and providing the service's inherited query methods — no public API behavior depended on it.

## Changes
- `user-workspace.module.ts`: replaced `NestjsQueryGraphQLModule.forFeature`   with plain `TypeOrmModule.forFeature`; kept all module imports and the service provider unchanged.
- `user-workspace.service.ts`: dropped `extends TypeOrmQueryService` and the `super()` call; added an explicit `findById` (the only inherited method used externally, by `agent-actor-context.service.ts`).
- `user-workspace.entity.ts`: swapped `@IDField` for the standard `@Field` on `id` (renders identically as `UUID!`).


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/22591?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

