### PR TITLE
chore(server): migrate 5 modules off NestjsQueryTypeOrmModule wiring

### DIFF
--- a/packages/twenty-server/src/engine/core-modules/application/application-variable/application-variable.module.ts
+++ b/packages/twenty-server/src/engine/core-modules/application/application-variable/application-variable.module.ts
@@ -1,8 +1,6 @@
 import { Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
 
-import { NestjsQueryTypeOrmModule } from '@ptc-org/nestjs-query-typeorm';
-
 import { ApplicationEntity } from 'src/engine/core-modules/application/application.entity';
 import { ApplicationVariableEntity } from 'src/engine/core-modules/application/application-variable/application-variable.entity';
 import { ApplicationVariableEntityResolver } from 'src/engine/core-modules/application/application-variable/application-variable.resolver';
@@ -15,7 +13,6 @@ import { WorkspaceCacheModule } from 'src/engine/workspace-cache/workspace-cache
 
 @Module({
   imports: [
-    NestjsQueryTypeOrmModule.forFeature([ApplicationVariableEntity]),
     TypeOrmModule.forFeature([ApplicationVariableEntity, ApplicationEntity]),
     PermissionsModule,
     WorkspaceCacheModule,

--- a/packages/twenty-server/src/engine/core-modules/approved-access-domain/approved-access-domain.module.ts
+++ b/packages/twenty-server/src/engine/core-modules/approved-access-domain/approved-access-domain.module.ts
@@ -1,6 +1,5 @@
 import { Module } from '@nestjs/common';
-
-import { NestjsQueryTypeOrmModule } from '@ptc-org/nestjs-query-typeorm';
+import { TypeOrmModule } from '@nestjs/typeorm';
 
 import { ApprovedAccessDomainEntity } from 'src/engine/core-modules/approved-access-domain/approved-access-domain.entity';
 import { ApprovedAccessDomainResolver } from 'src/engine/core-modules/approved-access-domain/approved-access-domain.resolver';
@@ -15,7 +14,7 @@ import { provideWorkspaceScopedRepository } from 'src/engine/twenty-orm/workspac
     WorkspaceDomainsModule,
     FileModule,
     JwtModule,
-    NestjsQueryTypeOrmModule.forFeature([ApprovedAccessDomainEntity]),
+    TypeOrmModule.forFeature([ApprovedAccessDomainEntity]),
     PermissionsModule,
   ],
   exports: [ApprovedAccessDomainService],

--- a/packages/twenty-server/src/engine/core-modules/emailing-domain/emailing-domain.module.ts
+++ b/packages/twenty-server/src/engine/core-modules/emailing-domain/emailing-domain.module.ts
@@ -1,8 +1,6 @@
 import { Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
 
-import { NestjsQueryTypeOrmModule } from '@ptc-org/nestjs-query-typeorm';
-
 import { TypeORMModule } from 'src/database/typeorm/typeorm.module';
 import { BillingModule } from 'src/engine/core-modules/billing/billing.module';
 import { DnsManagerModule } from 'src/engine/core-modules/dns-manager/dns-manager.module';
@@ -32,8 +30,7 @@ import { provideWorkspaceScopedRepository } from 'src/engine/twenty-orm/workspac
 @Module({
   imports: [
     TypeORMModule,
-    TypeOrmModule.forFeature([WorkspaceEntity]),
-    NestjsQueryTypeOrmModule.forFeature([EmailingDomainEntity]),
+    TypeOrmModule.forFeature([WorkspaceEntity, EmailingDomainEntity]),
     FeatureFlagModule,
     PermissionsModule,
     DnsManagerModule,

--- a/packages/twenty-server/src/engine/core-modules/public-domain/public-domain.module.ts
+++ b/packages/twenty-server/src/engine/core-modules/public-domain/public-domain.module.ts
@@ -1,6 +1,5 @@
 import { Module } from '@nestjs/common';
-
-import { NestjsQueryTypeOrmModule } from '@ptc-org/nestjs-query-typeorm';
+import { TypeOrmModule } from '@nestjs/typeorm';
 
 import { ApplicationEntity } from 'src/engine/core-modules/application/application.entity';
 import { PublicDomainService } from 'src/engine/core-modules/public-domain/public-domain.service';
@@ -14,7 +13,7 @@ import { PermissionsModule } from 'src/engine/metadata-modules/permissions/permi
 import { provideWorkspaceScopedRepository } from 'src/engine/twenty-orm/workspace-scoped-repository/provide-workspace-scoped-repository';
 @Module({
   imports: [
-    NestjsQueryTypeOrmModule.forFeature([
+    TypeOrmModule.forFeature([
       PublicDomainEntity,
       WorkspaceEntity,
       ApplicationEntity,

--- a/packages/twenty-server/src/engine/core-modules/workspace-invitation/workspace-invitation.module.ts
+++ b/packages/twenty-server/src/engine/core-modules/workspace-invitation/workspace-invitation.module.ts
@@ -1,6 +1,5 @@
 import { Module } from '@nestjs/common';
-
-import { NestjsQueryTypeOrmModule } from '@ptc-org/nestjs-query-typeorm';
+import { TypeOrmModule } from '@nestjs/typeorm';
 
 import { AppTokenEntity } from 'src/engine/core-modules/app-token/app-token.entity';
 import { WorkspaceDomainsModule } from 'src/engine/core-modules/domain/workspace-domains/workspace-domains.module';
@@ -11,18 +10,13 @@ import { ThrottlerModule } from 'src/engine/core-modules/throttler/throttler.mod
 import { UserWorkspaceEntity } from 'src/engine/core-modules/user-workspace/user-workspace.entity';
 import { WorkspaceInvitationService } from 'src/engine/core-modules/workspace-invitation/services/workspace-invitation.service';
 import { WorkspaceInvitationResolver } from 'src/engine/core-modules/workspace-invitation/workspace-invitation.resolver';
-import { WorkspaceEntity } from 'src/engine/core-modules/workspace/workspace.entity';
 import { PermissionsModule } from 'src/engine/metadata-modules/permissions/permissions.module';
 import { RoleValidationModule } from 'src/engine/metadata-modules/role-validation/role-validation.module';
 
 @Module({
   imports: [
     WorkspaceDomainsModule,
-    NestjsQueryTypeOrmModule.forFeature([
-      AppTokenEntity,
-      UserWorkspaceEntity,
-      WorkspaceEntity,
-    ]),
+    TypeOrmModule.forFeature([AppTokenEntity, UserWorkspaceEntity]),
     RoleValidationModule,
     FileModule,
     OnboardingModule,


### PR DESCRIPTION
## Summary
Continues the incremental removal of `@ptc-org/nestjs-query`. Migrates five core modules from `NestjsQueryTypeOrmModule.forFeature` to the standard `TypeOrmModule.forFeature`. These modules only used `nestjs-query` for repository registration — their resolvers are hand-written and registered as normal providers — so this is a pure module-wiring swap with no behavior or schema change.



<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/22595?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

