### PR TITLE
Use record pickers for People Data Labs enrichment workflow inputs

### DIFF
--- a/packages/twenty-apps/public/people-data-labs/src/logic-functions/enrich-companies.function.ts
+++ b/packages/twenty-apps/public/people-data-labs/src/logic-functions/enrich-companies.function.ts
@@ -1,4 +1,4 @@
-import { defineLogicFunction } from 'twenty-sdk/define';
+import { defineLogicFunction, STANDARD_OBJECT_UNIVERSAL_IDENTIFIERS } from 'twenty-sdk/define';
 
 import { UPDATE_FIELDS_OPTION_VALUES } from 'src/constants/update-fields-option-values';
 import { PDL_LOGIC_FUNCTION_CONSTANTS } from 'src/constants/universal-identifiers';
@@ -28,8 +28,9 @@ export default defineLogicFunction({
         type: 'object',
         properties: {
           records: {
-            type: 'array',
-            items: { type: 'object' },
+            type: 'records',
+            objectUniversalIdentifier:
+              STANDARD_OBJECT_UNIVERSAL_IDENTIFIERS.company.universalIdentifier,
             label: 'Records',
           },
           updateFields: {

--- a/packages/twenty-apps/public/people-data-labs/src/logic-functions/enrich-company.function.ts
+++ b/packages/twenty-apps/public/people-data-labs/src/logic-functions/enrich-company.function.ts
@@ -1,4 +1,4 @@
-import { defineLogicFunction } from 'twenty-sdk/define';
+import { defineLogicFunction, STANDARD_OBJECT_UNIVERSAL_IDENTIFIERS } from 'twenty-sdk/define';
 
 import { UPDATE_FIELDS_OPTION_VALUES } from 'src/constants/update-fields-option-values';
 import { PDL_LOGIC_FUNCTION_CONSTANTS } from 'src/constants/universal-identifiers';
@@ -22,7 +22,9 @@ export default defineLogicFunction({
         type: 'object',
         properties: {
           recordId: {
-            type: 'string',
+            type: 'record',
+            objectUniversalIdentifier:
+              STANDARD_OBJECT_UNIVERSAL_IDENTIFIERS.company.universalIdentifier,
             label: 'Record',
           },
           updateFields: {

--- a/packages/twenty-apps/public/people-data-labs/src/logic-functions/enrich-people.function.ts
+++ b/packages/twenty-apps/public/people-data-labs/src/logic-functions/enrich-people.function.ts
@@ -1,4 +1,4 @@
-import { defineLogicFunction } from 'twenty-sdk/define';
+import { defineLogicFunction, STANDARD_OBJECT_UNIVERSAL_IDENTIFIERS } from 'twenty-sdk/define';
 
 import { UPDATE_FIELDS_OPTION_VALUES } from 'src/constants/update-fields-option-values';
 import { PDL_LOGIC_FUNCTION_CONSTANTS } from 'src/constants/universal-identifiers';
@@ -28,8 +28,9 @@ export default defineLogicFunction({
         type: 'object',
         properties: {
           records: {
-            type: 'array',
-            items: { type: 'object' },
+            type: 'records',
+            objectUniversalIdentifier:
+              STANDARD_OBJECT_UNIVERSAL_IDENTIFIERS.person.universalIdentifier,
             label: 'Records',
           },
           updateFields: {

--- a/packages/twenty-apps/public/people-data-labs/src/logic-functions/enrich-person.function.ts
+++ b/packages/twenty-apps/public/people-data-labs/src/logic-functions/enrich-person.function.ts
@@ -1,4 +1,4 @@
-import { defineLogicFunction } from 'twenty-sdk/define';
+import { defineLogicFunction, STANDARD_OBJECT_UNIVERSAL_IDENTIFIERS } from 'twenty-sdk/define';
 
 import { UPDATE_FIELDS_OPTION_VALUES } from 'src/constants/update-fields-option-values';
 import { PDL_LOGIC_FUNCTION_CONSTANTS } from 'src/constants/universal-identifiers';
@@ -22,7 +22,9 @@ export default defineLogicFunction({
         type: 'object',
         properties: {
           recordId: {
-            type: 'string',
+            type: 'record',
+            objectUniversalIdentifier:
+              STANDARD_OBJECT_UNIVERSAL_IDENTIFIERS.person.universalIdentifier,
             label: 'Record',
           },
           updateFields: {


### PR DESCRIPTION
Follow-up to #21494, which added record-typed logic function workflow inputs but deferred the People Data Labs migration until the SDK release.

twenty-sdk 2.16.0 (published) now includes the `record`/`records` input schema support, so this types the enrichment inputs accordingly: `records` on enrich-people/enrich-companies and `recordId` on enrich-person/enrich-company render as record pickers bound to Person/Company.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/22596?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

