### PR TITLE
Fix side panel open/close animation glitches in the page header and panel content

### DIFF
--- a/packages/twenty-front/src/modules/command-menu-item/display/components/PinnedCommandMenuItemButtons.tsx
+++ b/packages/twenty-front/src/modules/command-menu-item/display/components/PinnedCommandMenuItemButtons.tsx
@@ -73,7 +73,6 @@ export const PinnedCommandMenuItemButtons = () => {
               {pinnedInlineCommandMenuItems.map((item) => (
                 <StyledCommandMenuItemContainer
                   key={item.id}
-                  layout
                   initial={{ width: 0, opacity: 0 }}
                   animate={{ width: 'unset', opacity: 1 }}
                   exit={{ width: 0, opacity: 0 }}

--- a/packages/twenty-front/src/modules/side-panel/components/SidePanelForDesktop.tsx
+++ b/packages/twenty-front/src/modules/side-panel/components/SidePanelForDesktop.tsx
@@ -44,7 +44,7 @@ const StyledSidePanel = styled.aside`
   height: 100%;
   overflow: hidden;
   position: relative;
-  width: 100%;
+  width: var(${SIDE_PANEL_WIDTH_VAR});
 `;
 
 const StyledModalContainer = styled.div`


### PR DESCRIPTION
When the side panel opens or closes, the pinned header button (e.g. New Company) was flat-clipped for the whole 300ms animation: the ⋮ toggle mounts instantly and shifts the button's slot, framer's `layout` prop compensates with a transform that the surrounding `overflow: hidden` containers don't follow, and the ResizeObserver-driven rerenders re-seed that transform every frame. Removing `layout` lets the button follow plain reflow, which cannot clip.

The panel content also squeezed during the animation (labels re-truncating at every intermediate width) because the inner panel was `width: 100%` of the width-animating wrapper. Pinning it to `var(--side-panel-width)` turns the animation into a rigid drawer slide; drag-resize is unaffected since it writes the same CSS variable.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/22598?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

