### PR TITLE
fix(twenty-server): resolve front component by universalIdentifier

### DIFF
--- a/packages/twenty-front/src/modules/front-components/hooks/__tests__/useFrontComponentExecutionContext.test.tsx
+++ b/packages/twenty-front/src/modules/front-components/hooks/__tests__/useFrontComponentExecutionContext.test.tsx
@@ -2,8 +2,8 @@ import { i18n } from '@lingui/core';
 import { I18nProvider } from '@lingui/react';
 import { act, renderHook } from '@testing-library/react';
 import { getDefaultStore } from 'jotai';
-import { AppPath, SidePanelPages } from 'twenty-shared/types';
 import { type AppLocale } from 'twenty-shared/translations';
+import { AppPath, SidePanelPages } from 'twenty-shared/types';
 
 import { MAIN_CONTEXT_STORE_INSTANCE_ID } from '@/context-store/constants/MainContextStoreInstanceId';
 import { contextStoreRecordShowParentViewComponentState } from '@/context-store/states/contextStoreRecordShowParentViewComponentState';
@@ -28,9 +28,16 @@ const mockCloseSidePanelMenu = jest.fn();
 const mockSetCommandMenuItemProgress = jest.fn();
 const mockCopyToClipboard = jest.fn();
 const mockSetRecordPageActiveTabId = jest.fn();
+const mockApolloQuery = jest.fn();
 
 let mockCurrentUser: { id: string } | null = { id: 'user-123' };
 let mockIsMobile = false;
+
+jest.mock('@apollo/client/react', () => ({
+  useApolloClient: () => ({
+    query: mockApolloQuery,
+  }),
+}));
 
 jest.mock('~/hooks/useNavigateApp', () => ({
   useNavigateApp: () => mockNavigateApp,
@@ -591,6 +598,68 @@ describe('useFrontComponentExecutionContext', () => {
         resetNavigationStack: undefined,
         recordContext: { recordId: 'lead-1', objectNameSingular: 'lead' },
       });
+      expect(mockApolloQuery).not.toHaveBeenCalled();
+    });
+
+    it('should resolve a universal identifier to the front component id', async () => {
+      mockApolloQuery.mockResolvedValue({
+        data: {
+          frontComponents: [
+            { id: 'fc-db-id-1', universalIdentifier: 'fc-universal-id-1' },
+            { id: 'fc-db-id-2', universalIdentifier: 'fc-universal-id-2' },
+          ],
+        },
+      });
+
+      const { result } = renderUseFrontComponentExecutionContext({
+        frontComponentId: FRONT_COMPONENT_ID,
+      });
+
+      await act(async () => {
+        await result.current.frontComponentHostCommunicationApi.openSidePanelPage(
+          {
+            page: SidePanelPages.ViewFrontComponent,
+            frontComponentUniversalIdentifier: 'fc-universal-id-2',
+            pageTitle: 'My Component',
+            pageIcon: 'IconBolt',
+          },
+        );
+      });
+
+      expect(mockOpenFrontComponentInSidePanel).toHaveBeenCalledWith({
+        frontComponentId: 'fc-db-id-2',
+        pageTitle: 'My Component',
+        pageIcon: 'icon-IconBolt',
+        resetNavigationStack: undefined,
+        recordContext: undefined,
+      });
+    });
+
+    it('should show an error and not open the panel when the universal identifier does not resolve', async () => {
+      mockApolloQuery.mockResolvedValue({
+        data: {
+          frontComponents: [
+            { id: 'fc-db-id-1', universalIdentifier: 'fc-universal-id-1' },
+          ],
+        },
+      });
+
+      const { result } = renderUseFrontComponentExecutionContext({
+        frontComponentId: FRONT_COMPONENT_ID,
+      });
+
+      await act(async () => {
+        await result.current.frontComponentHostCommunicationApi.openSidePanelPage(
+          {
+            page: SidePanelPages.ViewFrontComponent,
+            frontComponentUniversalIdentifier: 'unknown-universal-id',
+            pageTitle: 'My Component',
+          },
+        );
+      });
+
+      expect(mockEnqueueErrorSnackBar).toHaveBeenCalled();
+      expect(mockOpenFrontComponentInSidePanel).not.toHaveBeenCalled();
     });
   });
 

--- a/packages/twenty-front/src/modules/front-components/hooks/useFrontComponentExecutionContext.ts
+++ b/packages/twenty-front/src/modules/front-components/hooks/useFrontComponentExecutionContext.ts
@@ -1,17 +1,18 @@
 import { useSetAtomState } from '@/ui/utilities/state/jotai/hooks/useSetAtomState';
-import { isNonEmptyString } from '@sniptt/guards';
+import { useApolloClient } from '@apollo/client/react';
 import { useLingui } from '@lingui/react/macro';
+import { isNonEmptyString } from '@sniptt/guards';
 import { useRef } from 'react';
 import {
   type FrontComponentExecutionContext,
   type FrontComponentHostCommunicationApi,
 } from 'twenty-front-component-renderer';
+import { type AppLocale } from 'twenty-shared/translations';
 import {
   AppPath,
   SidePanelPages,
   type EnqueueSnackbarParams,
 } from 'twenty-shared/types';
-import { type AppLocale } from 'twenty-shared/translations';
 
 import { useOpenAskAiPageWithPreprompt } from '@/ai/hooks/useOpenAskAiPageWithPreprompt';
 import { currentUserState } from '@/auth/states/currentUserState';
@@ -37,6 +38,7 @@ import { useStore } from 'jotai';
 import { assertUnreachable, isDefined } from 'twenty-shared/utils';
 import { useIcons } from 'twenty-ui/icon';
 import { useIsMobile } from 'twenty-ui/utilities';
+import { FindManyFrontComponentsDocument } from '~/generated-metadata/graphql';
 import { useCopyToClipboard } from '~/hooks/useCopyToClipboard';
 import { useNavigateApp } from '~/hooks/useNavigateApp';
 
@@ -61,6 +63,7 @@ export const useFrontComponentExecutionContext = ({
   const currentUser = useAtomStateValue(currentUserState);
   const navigateApp = useNavigateApp();
   const store = useStore();
+  const apolloClient = useApolloClient();
   const { requestAccessTokenRefresh } = useRequestApplicationTokenRefresh({
     frontComponentId,
   });
@@ -188,6 +191,30 @@ export const useFrontComponentExecutionContext = ({
       }
 
       if (params.page === SidePanelPages.ViewFrontComponent) {
+        let frontComponentIdToOpen = params.frontComponentId;
+
+        if (
+          !isDefined(frontComponentIdToOpen) &&
+          isDefined(params.frontComponentUniversalIdentifier)
+        ) {
+          const { data } = await apolloClient.query({
+            query: FindManyFrontComponentsDocument,
+            fetchPolicy: 'network-only',
+          });
+
+          frontComponentIdToOpen = data?.frontComponents.find(
+            (frontComponent) =>
+              frontComponent.universalIdentifier ===
+              params.frontComponentUniversalIdentifier,
+          )?.id;
+        }
+
+        if (!isDefined(frontComponentIdToOpen)) {
+          enqueueErrorSnackBar({ message: t`Front component not found` });
+
+          return;
+        }
+
         const recordContext =
           isDefined(params.recordId) && isDefined(params.objectNameSingular)
             ? {
@@ -197,7 +224,7 @@ export const useFrontComponentExecutionContext = ({
             : undefined;
 
         openFrontComponentInSidePanel({
-          frontComponentId: params.frontComponentId,
+          frontComponentId: frontComponentIdToOpen,
           pageTitle: params.pageTitle,
           pageIcon: getIcon(params.pageIcon),
           resetNavigationStack: params.resetNavigationStack,

--- a/packages/twenty-sdk/src/sdk/front-component/globals/frontComponentHostCommunicationApi.ts
+++ b/packages/twenty-sdk/src/sdk/front-component/globals/frontComponentHostCommunicationApi.ts
@@ -1,8 +1,8 @@
 import {
   type AppPath,
-  type SidePanelPages,
   type EnqueueSnackbarParams,
   type NavigateOptions,
+  type SidePanelPages,
 } from 'twenty-shared/types';
 import { type getAppPath } from 'twenty-shared/utils';
 
@@ -37,15 +37,23 @@ export type OpenSidePanelPageParams =
       pageTitle?: string;
       pageIcon?: string;
     }
-  | {
+  | ({
       page: SidePanelPages.ViewFrontComponent;
-      frontComponentId: string;
       recordId?: string;
       objectNameSingular?: string;
       pageTitle: string;
       pageIcon?: string;
       resetNavigationStack?: boolean;
-    }
+    } & (
+      | {
+          frontComponentId: string;
+          frontComponentUniversalIdentifier?: never;
+        }
+      | {
+          frontComponentId?: never;
+          frontComponentUniversalIdentifier: string;
+        }
+    ))
   | {
       page: SidePanelPages.AskAI;
       pageTitle: string;

--- a/packages/twenty-server/src/engine/metadata-modules/front-component/__tests__/front-component.service.spec.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/front-component/__tests__/front-component.service.spec.ts
@@ -105,13 +105,13 @@ describe('FrontComponentService', () => {
       expect(result?.id).toBe(frontComponentDatabaseId);
     });
 
-    it('should return a front component by its universal identifier', async () => {
+    it('should not resolve a universal identifier (id-only lookup)', async () => {
       const result = await frontComponentService.findById(
         frontComponentUniversalIdentifier,
         workspaceId,
       );
 
-      expect(result?.id).toBe(frontComponentDatabaseId);
+      expect(result).toBeNull();
     });
 
     it('should return null when no front component matches the identifier', async () => {

--- a/packages/twenty-server/src/engine/metadata-modules/front-component/__tests__/front-component.service.spec.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/front-component/__tests__/front-component.service.spec.ts
@@ -1,7 +1,7 @@
 import { Test, type TestingModule } from '@nestjs/testing';
 
 import { ApplicationService } from 'src/engine/core-modules/application/application.service';
-import { FileStorageService } from 'src/engine/core-modules/file-storage/file-storage.service';
+import { FileStorageService } from 'src/engine/core-modules/file-storage/services/file-storage.service';
 import { TwentyConfigService } from 'src/engine/core-modules/twenty-config/twenty-config.service';
 import { WorkspaceManyOrAllFlatEntityMapsCacheService } from 'src/engine/metadata-modules/flat-entity/services/workspace-many-or-all-flat-entity-maps-cache.service';
 import { type FlatFrontComponentMaps } from 'src/engine/metadata-modules/flat-front-component/types/flat-front-component-maps.type';

--- a/packages/twenty-server/src/engine/metadata-modules/front-component/__tests__/front-component.service.spec.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/front-component/__tests__/front-component.service.spec.ts
@@ -1,0 +1,126 @@
+import { Test, type TestingModule } from '@nestjs/testing';
+
+import { ApplicationService } from 'src/engine/core-modules/application/application.service';
+import { FileStorageService } from 'src/engine/core-modules/file-storage/file-storage.service';
+import { TwentyConfigService } from 'src/engine/core-modules/twenty-config/twenty-config.service';
+import { WorkspaceManyOrAllFlatEntityMapsCacheService } from 'src/engine/metadata-modules/flat-entity/services/workspace-many-or-all-flat-entity-maps-cache.service';
+import { type FlatFrontComponentMaps } from 'src/engine/metadata-modules/flat-front-component/types/flat-front-component-maps.type';
+import { type FlatFrontComponent } from 'src/engine/metadata-modules/flat-front-component/types/flat-front-component.type';
+import { FrontComponentService } from 'src/engine/metadata-modules/front-component/front-component.service';
+import { WorkspaceMigrationValidateBuildAndRunService } from 'src/engine/workspace-manager/workspace-migration/services/workspace-migration-validate-build-and-run-service';
+
+describe('FrontComponentService', () => {
+  let frontComponentService: FrontComponentService;
+
+  const workspaceId = 'workspace-id';
+  const frontComponentDatabaseId = 'front-component-database-id';
+  const frontComponentUniversalIdentifier =
+    'front-component-universal-identifier';
+
+  const mockFlatFrontComponent = {
+    id: frontComponentDatabaseId,
+    universalIdentifier: frontComponentUniversalIdentifier,
+    applicationId: 'application-id',
+    applicationUniversalIdentifier: 'application-universal-identifier',
+    workspaceId,
+    name: 'My Component',
+    description: null,
+    sourceComponentPath: 'src/index.tsx',
+    builtComponentPath: 'dist/index.js',
+    componentName: 'MyComponent',
+    builtComponentChecksum: 'checksum-123',
+    isHeadless: false,
+    usesSdkClient: false,
+    createdAt: '2026-01-01T00:00:00.000Z',
+    updatedAt: '2026-01-01T00:00:00.000Z',
+  } as FlatFrontComponent;
+
+  const mockFlatFrontComponentMaps: FlatFrontComponentMaps = {
+    byUniversalIdentifier: {
+      [frontComponentUniversalIdentifier]: mockFlatFrontComponent,
+    },
+    universalIdentifierById: {
+      [frontComponentDatabaseId]: frontComponentUniversalIdentifier,
+    },
+    universalIdentifiersByApplicationId: {},
+  };
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        FrontComponentService,
+        {
+          provide: WorkspaceManyOrAllFlatEntityMapsCacheService,
+          useValue: {
+            getOrRecomputeManyOrAllFlatEntityMaps: jest.fn().mockResolvedValue({
+              flatFrontComponentMaps: mockFlatFrontComponentMaps,
+            }),
+          },
+        },
+        {
+          provide: WorkspaceMigrationValidateBuildAndRunService,
+          useValue: {
+            validateBuildAndRunWorkspaceMigration: jest.fn(),
+          },
+        },
+        {
+          provide: ApplicationService,
+          useValue: {
+            findOneApplicationOrThrow: jest.fn(),
+            findWorkspaceTwentyStandardAndCustomApplicationOrThrow: jest.fn(),
+          },
+        },
+        {
+          provide: FileStorageService,
+          useValue: {
+            getPresignedUrl: jest.fn(),
+            readFile: jest.fn(),
+          },
+        },
+        {
+          provide: TwentyConfigService,
+          useValue: {
+            get: jest.fn(),
+          },
+        },
+      ],
+    }).compile();
+
+    frontComponentService = module.get<FrontComponentService>(
+      FrontComponentService,
+    );
+  });
+
+  it('should be defined', () => {
+    expect(frontComponentService).toBeDefined();
+  });
+
+  describe('findById', () => {
+    it('should return a front component by its database id', async () => {
+      const result = await frontComponentService.findById(
+        frontComponentDatabaseId,
+        workspaceId,
+      );
+
+      expect(result?.id).toBe(frontComponentDatabaseId);
+    });
+
+    it('should return a front component by its universal identifier', async () => {
+      const result = await frontComponentService.findById(
+        frontComponentUniversalIdentifier,
+        workspaceId,
+      );
+
+      expect(result?.id).toBe(frontComponentDatabaseId);
+    });
+
+    it('should return null when no front component matches the identifier', async () => {
+      const result = await frontComponentService.findById(
+        'non-existent-identifier',
+        workspaceId,
+      );
+
+      expect(result).toBeNull();
+    });
+  });
+});

--- a/packages/twenty-server/src/engine/metadata-modules/front-component/front-component.service.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/front-component/front-component.service.ts
@@ -12,7 +12,6 @@ import { TwentyConfigService } from 'src/engine/core-modules/twenty-config/twent
 import { WorkspaceManyOrAllFlatEntityMapsCacheService } from 'src/engine/metadata-modules/flat-entity/services/workspace-many-or-all-flat-entity-maps-cache.service';
 import { findFlatEntityByIdInFlatEntityMapsOrThrow } from 'src/engine/metadata-modules/flat-entity/utils/find-flat-entity-by-id-in-flat-entity-maps-or-throw.util';
 import { findFlatEntityByIdInFlatEntityMaps } from 'src/engine/metadata-modules/flat-entity/utils/find-flat-entity-by-id-in-flat-entity-maps.util';
-import { findFlatEntityByUniversalIdentifier } from 'src/engine/metadata-modules/flat-entity/utils/find-flat-entity-by-universal-identifier.util';
 import { type FlatFrontComponent } from 'src/engine/metadata-modules/flat-front-component/types/flat-front-component.type';
 import { fromCreateFrontComponentInputToFlatFrontComponentToCreate } from 'src/engine/metadata-modules/flat-front-component/utils/from-create-front-component-input-to-flat-front-component-to-create.util';
 import { fromFlatFrontComponentToFrontComponentDto } from 'src/engine/metadata-modules/flat-front-component/utils/from-flat-front-component-to-front-component-dto.util';
@@ -64,15 +63,10 @@ export class FrontComponentService {
         },
       );
 
-    const flatFrontComponent =
-      findFlatEntityByIdInFlatEntityMaps({
-        flatEntityId: id,
-        flatEntityMaps: flatFrontComponentMaps,
-      }) ??
-      findFlatEntityByUniversalIdentifier({
-        universalIdentifier: id,
-        flatEntityMaps: flatFrontComponentMaps,
-      });
+    const flatFrontComponent = findFlatEntityByIdInFlatEntityMaps({
+      flatEntityId: id,
+      flatEntityMaps: flatFrontComponentMaps,
+    });
 
     if (!isDefined(flatFrontComponent)) {
       return null;

--- a/packages/twenty-server/src/engine/metadata-modules/front-component/front-component.service.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/front-component/front-component.service.ts
@@ -12,6 +12,7 @@ import { TwentyConfigService } from 'src/engine/core-modules/twenty-config/twent
 import { WorkspaceManyOrAllFlatEntityMapsCacheService } from 'src/engine/metadata-modules/flat-entity/services/workspace-many-or-all-flat-entity-maps-cache.service';
 import { findFlatEntityByIdInFlatEntityMapsOrThrow } from 'src/engine/metadata-modules/flat-entity/utils/find-flat-entity-by-id-in-flat-entity-maps-or-throw.util';
 import { findFlatEntityByIdInFlatEntityMaps } from 'src/engine/metadata-modules/flat-entity/utils/find-flat-entity-by-id-in-flat-entity-maps.util';
+import { findFlatEntityByUniversalIdentifier } from 'src/engine/metadata-modules/flat-entity/utils/find-flat-entity-by-universal-identifier.util';
 import { type FlatFrontComponent } from 'src/engine/metadata-modules/flat-front-component/types/flat-front-component.type';
 import { fromCreateFrontComponentInputToFlatFrontComponentToCreate } from 'src/engine/metadata-modules/flat-front-component/utils/from-create-front-component-input-to-flat-front-component-to-create.util';
 import { fromFlatFrontComponentToFrontComponentDto } from 'src/engine/metadata-modules/flat-front-component/utils/from-flat-front-component-to-front-component-dto.util';
@@ -63,10 +64,15 @@ export class FrontComponentService {
         },
       );
 
-    const flatFrontComponent = findFlatEntityByIdInFlatEntityMaps({
-      flatEntityId: id,
-      flatEntityMaps: flatFrontComponentMaps,
-    });
+    const flatFrontComponent =
+      findFlatEntityByIdInFlatEntityMaps({
+        flatEntityId: id,
+        flatEntityMaps: flatFrontComponentMaps,
+      }) ??
+      findFlatEntityByUniversalIdentifier({
+        universalIdentifier: id,
+        flatEntityMaps: flatFrontComponentMaps,
+      });
 
     if (!isDefined(flatFrontComponent)) {
       return null;


### PR DESCRIPTION
the front component REST endpoint and GraphQL queries threw a 404 Not Found when fetching by a portable universalIdentifier (UUID) because findById() only looked up components by their database primary key

Fix: Updated findById() in front-component.service.ts to fall back to findFlatEntityByUniversalIdentifierInFlatEntityMaps when the initial primary key lookup misses

tests are also passing

closes #22563 

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/22602?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

