### PR TITLE
Use SDK calendarEventRecordPageFields identifiers in call-recorder

### DIFF
--- a/packages/twenty-apps/public/call-recorder/src/view-fields/call-recorder-preference-on-calendar-event.view-field.ts
+++ b/packages/twenty-apps/public/call-recorder/src/view-fields/call-recorder-preference-on-calendar-event.view-field.ts
@@ -1,24 +1,23 @@
-import { defineViewField } from 'twenty-sdk/define';
+import {
+  defineViewField,
+  STANDARD_OBJECT_UNIVERSAL_IDENTIFIERS,
+} from 'twenty-sdk/define';
 
 import { CALL_RECORDER_PREFERENCE_ON_CALENDAR_EVENT_FIELD_UNIVERSAL_IDENTIFIER } from 'src/constants/call-recorder-preference-on-calendar-event-field-universal-identifier';
 import { CALL_RECORDER_PREFERENCE_ON_CALENDAR_EVENT_VIEW_FIELD_UNIVERSAL_IDENTIFIER } from 'src/constants/call-recorder-preference-on-calendar-event-view-field-universal-identifier';
 
-// TODO: hardcoded because the published twenty-sdk (2.14.0) predates the
-// calendarEventRecordPageFields view. Replace both with
-// STANDARD_OBJECT_UNIVERSAL_IDENTIFIERS.calendarEvent.views.calendarEventRecordPageFields
-// once the SDK is republished with this view.
-const CALENDAR_EVENT_RECORD_PAGE_FIELDS_VIEW_UNIVERSAL_IDENTIFIER =
-  'c73668d1-022d-4eaf-b825-4e2548180db6';
-const CALENDAR_EVENT_RECORD_PAGE_FIELDS_GENERAL_GROUP_UNIVERSAL_IDENTIFIER =
-  'aeadeb9e-3673-4c0c-8845-f59cb1e6ca42';
+const CALENDAR_EVENT_RECORD_PAGE_FIELDS_VIEW =
+  STANDARD_OBJECT_UNIVERSAL_IDENTIFIERS.calendarEvent.views
+    .calendarEventRecordPageFields;
 
 export default defineViewField({
   universalIdentifier:
     CALL_RECORDER_PREFERENCE_ON_CALENDAR_EVENT_VIEW_FIELD_UNIVERSAL_IDENTIFIER,
   viewUniversalIdentifier:
-    CALENDAR_EVENT_RECORD_PAGE_FIELDS_VIEW_UNIVERSAL_IDENTIFIER,
+    CALENDAR_EVENT_RECORD_PAGE_FIELDS_VIEW.universalIdentifier,
   viewFieldGroupUniversalIdentifier:
-    CALENDAR_EVENT_RECORD_PAGE_FIELDS_GENERAL_GROUP_UNIVERSAL_IDENTIFIER,
+    CALENDAR_EVENT_RECORD_PAGE_FIELDS_VIEW.viewFieldGroups.general
+      .universalIdentifier,
   fieldMetadataUniversalIdentifier:
     CALL_RECORDER_PREFERENCE_ON_CALENDAR_EVENT_FIELD_UNIVERSAL_IDENTIFIER,
   position: 8,


### PR DESCRIPTION
Replaces the hardcoded calendarEventRecordPageFields view/group identifiers in the call-recorder preference view-field with `STANDARD_OBJECT_UNIVERSAL_IDENTIFIERS.calendarEvent.views.calendarEventRecordPageFields`, resolving the TODO. The published `twenty-sdk@2.18.0` (already pinned by the app) ships these identifiers with values matching the previously hardcoded ones.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/22618?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

