### PR TITLE
Update claude session settings for a proper PR behavior

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -3,5 +3,17 @@
   "attribution": {
     "commit": "",
     "pr": ""
+  },
+  "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "cat <<'EOF'\nInstructions for this session:\n- Do NOT add any signature, footer, co-author tag, \"Generated with Claude\" or \"Co-Authored-By\" mention in commits, PRs, or files.\n- Be concise. Get to the point, no preamble or unnecessary recap.\n- Write like a human: natural, direct tone, no marketing language or overwrought phrasing.\n- No weird punctuation: never use em dashes, no emojis unless explicitly asked, standard punctuation only.\nEOF"
+          }
+        ]
+      }
+    ]
   }
 }


### PR DESCRIPTION
required so it is taken into account by claude in Cloud claude sessions

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/22619?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

