### PR TITLE
chore(apps): patch bump public apps moved to sdk 2.19.0-alpha.1

### DIFF
--- a/packages/twenty-apps/public/call-recorder/package.json
+++ b/packages/twenty-apps/public/call-recorder/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@twentyhq/call-recorder",
-  "version": "1.0.6",
+  "version": "1.0.7",
   "license": "MIT",
   "engines": {
     "node": "^24.5.0",

--- a/packages/twenty-apps/public/people-data-labs/package.json
+++ b/packages/twenty-apps/public/people-data-labs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@twentyhq/people-data-labs",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "description": "People Data Labs enrichment app for Twenty",
   "license": "MIT",
   "engines": {

--- a/packages/twenty-apps/public/twenty-last-contact/package.json
+++ b/packages/twenty-apps/public/twenty-last-contact/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@twentyhq/last-contact",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "license": "MIT",
   "engines": {
     "node": "^24.5.0",


### PR DESCRIPTION
## Summary

Bumps the `version` field (patch) of the public apps that were moved to `twenty-sdk@2.19.0-alpha.1` in #22601. That PR intentionally left `version` untouched ("they'll be bumped at publish time") — this is that follow-up bump.

| App | Before | After |
|---|---|---|
| `@twentyhq/call-recorder` | 1.0.6 | 1.0.7 |
| `@twentyhq/people-data-labs` | 1.0.3 | 1.0.4 |
| `@twentyhq/last-contact` | 1.0.1 | 1.0.2 |

## Notes

- `twenty-partners`, `postcard` and `self-hosting` are intentionally **not** bumped.