### PR TITLE
Curate signup-journey apps as vetted marketplace applications

### DIFF
--- a/packages/twenty-front/src/pages/settings/applications/SettingsApplications.tsx
+++ b/packages/twenty-front/src/pages/settings/applications/SettingsApplications.tsx
@@ -4,7 +4,6 @@ import { SettingsPageContainer } from '@/settings/components/SettingsPageContain
 import { SettingsPageLayout } from '@/settings/components/layout/SettingsPageLayout';
 import { SettingsTabBar } from '@/settings/components/layout/SettingsTabBar';
 import { useSettingsActiveTabId } from '@/settings/components/layout/useSettingsActiveTabId';
-import { useIsFeatureEnabled } from '@/workspace/hooks/useIsFeatureEnabled';
 import { useLingui } from '@lingui/react/macro';
 import { SettingsPath } from 'twenty-shared/types';
 import { getSettingsPath } from 'twenty-shared/utils';
@@ -12,10 +11,7 @@ import { IconApps, IconCode, IconDownload, IconPlug } from 'twenty-ui/icon';
 import { Section } from 'twenty-ui/layout';
 import coverDark from '~/pages/settings/applications/assets/cover-dark.png';
 import coverLight from '~/pages/settings/applications/assets/cover-light.png';
-import {
-  FeatureFlagKey,
-  PermissionFlagType,
-} from '~/generated-metadata/graphql';
+import { PermissionFlagType } from '~/generated-metadata/graphql';
 import { SettingsApplicationsAvailableTab } from '~/pages/settings/applications/tabs/SettingsApplicationsAvailableTab';
 import { SettingsApplicationsDeveloperTab } from '~/pages/settings/applications/tabs/SettingsApplicationsDeveloperTab';
 import { SettingsApplicationsInstalledTab } from '~/pages/settings/applications/tabs/SettingsApplicationsInstalledTab';
@@ -30,14 +26,8 @@ export const SettingsApplications = () => {
     PermissionFlagType.API_KEYS_AND_WEBHOOKS,
   );
 
-  const isMarketplaceSettingTabVisible = useIsFeatureEnabled(
-    FeatureFlagKey.IS_MARKETPLACE_SETTING_TAB_VISIBLE,
-  );
-
   const tabs = [
-    ...(isMarketplaceSettingTabVisible
-      ? [{ id: 'marketplace', title: t`Marketplace`, Icon: IconDownload }]
-      : []),
+    { id: 'marketplace', title: t`Marketplace`, Icon: IconDownload },
     { id: 'installed', title: t`Installed`, Icon: IconApps },
     ...(hasDeveloperAccess
       ? [{ id: 'developer', title: t`Developer`, Icon: IconCode }]
@@ -58,11 +48,7 @@ export const SettingsApplications = () => {
       case 'developer':
         return <SettingsApplicationsDeveloperTab />;
       default:
-        return isMarketplaceSettingTabVisible ? (
-          <SettingsApplicationsAvailableTab />
-        ) : (
-          <SettingsApplicationsInstalledTab />
-        );
+        return <SettingsApplicationsAvailableTab />;
     }
   };
 

--- a/packages/twenty-front/src/pages/settings/applications/tabs/SettingsApplicationsAvailableTab.tsx
+++ b/packages/twenty-front/src/pages/settings/applications/tabs/SettingsApplicationsAvailableTab.tsx
@@ -1,14 +1,9 @@
 import { SettingsEmptyPlaceholder } from '@/settings/components/SettingsEmptyPlaceholder';
-import { Dropdown } from '@/ui/layout/dropdown/components/Dropdown';
-import { DropdownContent } from '@/ui/layout/dropdown/components/DropdownContent';
-import { DropdownMenuItemsContainer } from '@/ui/layout/dropdown/components/DropdownMenuItemsContainer';
 import { styled } from '@linaria/react';
 import { useLingui } from '@lingui/react/macro';
-import { type ReactNode, useState } from 'react';
-import { IconSparkles } from 'twenty-ui/icon';
+import { useState } from 'react';
 import { SearchInput } from 'twenty-ui/input';
 import { Section } from 'twenty-ui/layout';
-import { MenuItemToggle } from 'twenty-ui/navigation';
 import { themeCssVariables } from 'twenty-ui/theme-constants';
 import { useMarketplaceApps } from '~/modules/marketplace/hooks/useMarketplaceApps';
 import { SettingsAvailableApplicationCard } from '~/pages/settings/applications/components/SettingsAvailableApplicationCard';
@@ -27,25 +22,19 @@ const StyledCardsGrid = styled.div`
   }
 `;
 
-const StyledHintLink = styled.button`
-  background: none;
-  border: none;
-  color: ${themeCssVariables.color.blue};
-  cursor: pointer;
-  font-size: inherit;
-  padding: 0;
-  text-decoration: underline;
-`;
-
 export const SettingsApplicationsAvailableTab = () => {
   const { t } = useLingui();
   const [searchTerm, setSearchTerm] = useState('');
-  const [showFeaturedOnly, setShowFeaturedOnly] = useState(true);
 
   const { data: marketplaceApps, isLoading } = useMarketplaceApps();
 
-  const textFilteredApplications = searchTerm
-    ? marketplaceApps.filter((application) => {
+  // Only vetted (featured) applications are exposed on the marketplace tab.
+  const vettedApplications = marketplaceApps.filter(
+    (application) => application.isFeatured,
+  );
+
+  const filteredApplications = searchTerm
+    ? vettedApplications.filter((application) => {
         const lowerSearch = searchTerm.toLowerCase();
 
         return (
@@ -54,16 +43,7 @@ export const SettingsApplicationsAvailableTab = () => {
           application.author.toLowerCase().includes(lowerSearch)
         );
       })
-    : marketplaceApps;
-
-  const filteredApplications = showFeaturedOnly
-    ? textFilteredApplications.filter((application) => application.isFeatured)
-    : textFilteredApplications;
-
-  const nonFeaturedCount = showFeaturedOnly
-    ? textFilteredApplications.filter((application) => !application.isFeatured)
-        .length
-    : 0;
+    : vettedApplications;
 
   if (isLoading) {
     return (
@@ -73,9 +53,6 @@ export const SettingsApplicationsAvailableTab = () => {
     );
   }
 
-  const showNonFeaturedHint =
-    filteredApplications.length === 0 && nonFeaturedCount > 0;
-
   return (
     <Section>
       <StyledSearchInputContainer>
@@ -83,42 +60,12 @@ export const SettingsApplicationsAvailableTab = () => {
           placeholder={t`Search an application`}
           value={searchTerm}
           onChange={setSearchTerm}
-          filterDropdown={(filterButton: ReactNode) => (
-            <Dropdown
-              dropdownId="marketplace-filter-dropdown"
-              dropdownPlacement="bottom-end"
-              dropdownOffset={{ x: 0, y: 8 }}
-              clickableComponent={filterButton}
-              dropdownComponents={
-                <DropdownContent>
-                  <DropdownMenuItemsContainer>
-                    <MenuItemToggle
-                      LeftIcon={IconSparkles}
-                      onToggleChange={() =>
-                        setShowFeaturedOnly(!showFeaturedOnly)
-                      }
-                      toggled={showFeaturedOnly}
-                      text={t`Featured only`}
-                      toggleSize="small"
-                    />
-                  </DropdownMenuItemsContainer>
-                </DropdownContent>
-              }
-            />
-          )}
         />
       </StyledSearchInputContainer>
 
       {filteredApplications.length === 0 ? (
         <SettingsEmptyPlaceholder padding="4">
-          {showNonFeaturedHint
-            ? t`No featured applications found. ${nonFeaturedCount} non-featured result(s) available — `
-            : t`No applications available`}
-          {showNonFeaturedHint && (
-            <StyledHintLink onClick={() => setShowFeaturedOnly(false)}>
-              {t`show all`}
-            </StyledHintLink>
-          )}
+          {t`No applications available`}
         </SettingsEmptyPlaceholder>
       ) : (
         <StyledCardsGrid>

--- a/packages/twenty-front/src/pages/settings/applications/tabs/SettingsApplicationsDeveloperTab.tsx
+++ b/packages/twenty-front/src/pages/settings/applications/tabs/SettingsApplicationsDeveloperTab.tsx
@@ -1,26 +1,18 @@
 import { currentWorkspaceMemberState } from '@/auth/states/currentWorkspaceMemberState';
-import { SettingsEmptyPlaceholder } from '@/settings/components/SettingsEmptyPlaceholder';
-import {
-  StyledActionTableCell,
-  StyledNameTableCell,
-} from '@/settings/data-model/object-details/components/SettingsObjectItemTableRowStyledComponents';
 import { getDocumentationUrl } from '@/support/utils/getDocumentationUrl';
 import { Table } from '@/ui/layout/table/components/Table';
-import { TableCell } from '@/ui/layout/table/components/TableCell';
 import { TableHeader } from '@/ui/layout/table/components/TableHeader';
 import { TableRow } from '@/ui/layout/table/components/TableRow';
 import { useAtomStateValue } from '@/ui/utilities/state/jotai/hooks/useAtomStateValue';
 import { useQuery } from '@apollo/client/react';
 import { styled } from '@linaria/react';
 import { useLingui } from '@lingui/react/macro';
-import { useContext, useMemo, useState } from 'react';
+import { useContext, useState } from 'react';
 import { ThemeContext, themeCssVariables } from 'twenty-ui/theme-constants';
-import { FeatureFlagKey, SettingsPath } from 'twenty-shared/types';
+import { SettingsPath } from 'twenty-shared/types';
 import { getSettingsPath } from 'twenty-shared/utils';
 import { CommandBlock } from 'twenty-ui/data-display';
-import { InlineBanner } from 'twenty-ui/feedback';
 import { IconArrowUpRight, IconChevronRight, IconCopy } from 'twenty-ui/icon';
-import { OverflowingTextWithTooltip } from 'twenty-ui/surfaces';
 import { H2Title } from 'twenty-ui/typography';
 import { Button, SearchInput } from 'twenty-ui/input';
 import { Section } from 'twenty-ui/layout';
@@ -29,14 +21,10 @@ import {
   FindManyApplicationRegistrationsDocument,
 } from '~/generated-metadata/graphql';
 import { useCopyToClipboard } from '~/hooks/useCopyToClipboard';
-import { useMarketplaceApps } from '~/modules/marketplace/hooks/useMarketplaceApps';
 import {
   APPLICATION_TABLE_ROW_GRID_TEMPLATE_COLUMNS,
   SettingsApplicationTableRow,
 } from '~/pages/settings/applications/components/SettingsApplicationTableRow';
-import { getApplicationDescriptionSummary } from '~/pages/settings/applications/utils/getApplicationDescriptionSummary';
-import { ApplicationDisplay } from '@/applications/components/ApplicationDisplay';
-import { useIsFeatureEnabled } from '@/workspace/hooks/useIsFeatureEnabled';
 
 const StyledButtonContainer = styled.div`
   display: flex;
@@ -53,42 +41,16 @@ const StyledTableRowsContainer = styled.div`
   padding: ${themeCssVariables.spacing[2]} 0;
 `;
 
-const NPM_PACKAGES_GRID_COLUMNS = '200px 1fr 36px';
-
 export const SettingsApplicationsDeveloperTab = () => {
   const { t } = useLingui();
   const { theme } = useContext(ThemeContext);
   const currentWorkspaceMember = useAtomStateValue(currentWorkspaceMemberState);
 
-  const [displayNotVettedApps, setDisplayNotVettedApps] = useState(false);
-
   const { copyToClipboard } = useCopyToClipboard();
 
   const { data } = useQuery(FindManyApplicationRegistrationsDocument);
 
-  const isMarketplaceSettingTabVisible = useIsFeatureEnabled(
-    FeatureFlagKey.IS_MARKETPLACE_SETTING_TAB_VISIBLE,
-  );
-
-  const [marketplaceAppSearchTerm, setMarketplaceAppSearchTerm] = useState('');
-
   const [myAppsSearchTerm, setMyAppsSearchTerm] = useState('');
-
-  const { data: marketplaceApps } = useMarketplaceApps();
-
-  const filteredMarketplaceApps = useMemo(() => {
-    if (!marketplaceAppSearchTerm) {
-      return marketplaceApps;
-    }
-
-    const lowerSearch = marketplaceAppSearchTerm.toLowerCase();
-
-    return marketplaceApps.filter(
-      (application) =>
-        application.name.toLowerCase().includes(lowerSearch) ||
-        application.description.toLowerCase().includes(lowerSearch),
-    );
-  }, [marketplaceApps, marketplaceAppSearchTerm]);
 
   const registrations: ApplicationRegistrationListItemFragment[] =
     data?.findManyApplicationRegistrations ?? [];
@@ -189,82 +151,6 @@ export const SettingsApplicationsDeveloperTab = () => {
               })}
             </StyledTableRowsContainer>
           </Table>
-        </Section>
-      )}
-
-      {!isMarketplaceSettingTabVisible && (
-        <Section>
-          <H2Title
-            title={t`NPM packages`}
-            description={t`Apps made by other developers published on npm`}
-          />
-          <InlineBanner
-            color={'danger'}
-            message={t`These apps are not vetted. Use at your own risk.`}
-            button={{
-              title: t`Access`,
-              hidden: displayNotVettedApps,
-              onClick: () => setDisplayNotVettedApps(true),
-            }}
-          />
-          {displayNotVettedApps && (
-            <>
-              <StyledSearchInputContainer>
-                <SearchInput
-                  placeholder={t`Search an application`}
-                  value={marketplaceAppSearchTerm}
-                  onChange={setMarketplaceAppSearchTerm}
-                />
-              </StyledSearchInputContainer>
-              {filteredMarketplaceApps.length === 0 ? (
-                <SettingsEmptyPlaceholder>{t`No application found`}</SettingsEmptyPlaceholder>
-              ) : (
-                <Table>
-                  <TableRow gridAutoColumns={NPM_PACKAGES_GRID_COLUMNS}>
-                    <TableHeader>{t`Name`}</TableHeader>
-                    <TableHeader>{t`Description`}</TableHeader>
-                    <TableHeader />
-                  </TableRow>
-                  <StyledTableRowsContainer>
-                    {filteredMarketplaceApps.map((application) => (
-                      <TableRow
-                        key={application.id}
-                        gridAutoColumns={NPM_PACKAGES_GRID_COLUMNS}
-                        to={getSettingsPath(
-                          SettingsPath.AvailableApplicationDetail,
-                          {
-                            availableApplicationId: application.id,
-                          },
-                        )}
-                      >
-                        <StyledNameTableCell>
-                          <ApplicationDisplay application={application} />
-                        </StyledNameTableCell>
-                        <TableCell
-                          overflow="hidden"
-                          textOverflow="ellipsis"
-                          whiteSpace="nowrap"
-                        >
-                          <OverflowingTextWithTooltip
-                            text={getApplicationDescriptionSummary(
-                              application.description,
-                            )}
-                          />
-                        </TableCell>
-                        <StyledActionTableCell>
-                          <IconChevronRight
-                            size={theme.icon.size.md}
-                            stroke={theme.icon.stroke.sm}
-                            color={theme.font.color.light}
-                          />
-                        </StyledActionTableCell>
-                      </TableRow>
-                    ))}
-                  </StyledTableRowsContainer>
-                </Table>
-              )}
-            </>
-          )}
         </Section>
       )}
     </>

--- a/packages/twenty-server/src/engine/core-modules/application/application-marketplace/constants/marketplace-curated-applications.constant.ts
+++ b/packages/twenty-server/src/engine/core-modules/application/application-marketplace/constants/marketplace-curated-applications.constant.ts
@@ -1,4 +1,23 @@
+// Applications proposed to install in the signup journey. Listing them here
+// marks their registrations as featured (vetted) and sets their category.
 export const MARKETPLACE_CURATED_APPLICATIONS: {
   universalIdentifier: string;
+  category: string;
   position?: number;
-}[] = [];
+}[] = [
+  {
+    universalIdentifier: '8da4b8b5-5edf-4880-b51f-ab6e679ec617',
+    category: 'Communication',
+    position: 1,
+  },
+  {
+    universalIdentifier: '4a1178c1-3535-4a47-b592-231d3216b36f',
+    category: 'Enrichment',
+    position: 2,
+  },
+  {
+    universalIdentifier: '66a504cc-0a75-410e-a43f-cdeae1db1522',
+    category: 'Data',
+    position: 3,
+  },
+];

--- a/packages/twenty-server/src/engine/core-modules/application/application-registration/application-registration.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/application/application-registration/application-registration.service.ts
@@ -383,13 +383,17 @@ export class ApplicationRegistrationService {
       params.universalIdentifier,
     );
 
-    const curatedIdentifiers = new Set(
-      MARKETPLACE_CURATED_APPLICATIONS.map(
-        (entry) => entry.universalIdentifier,
-      ),
+    const curatedApplication = MARKETPLACE_CURATED_APPLICATIONS.find(
+      (entry) => entry.universalIdentifier === params.universalIdentifier,
     );
 
-    const isFeatured = curatedIdentifiers.has(params.universalIdentifier);
+    const isFeatured = isDefined(curatedApplication);
+
+    // Curated applications carry a vetted category that takes precedence over
+    // whatever the manifest declares.
+    const curatedCategoryOverride = isDefined(curatedApplication)
+      ? { category: curatedApplication.category }
+      : {};
 
     if (isDefined(existing)) {
       await this.applicationRegistrationRepository.save({
@@ -400,6 +404,7 @@ export class ApplicationRegistrationService {
         latestAvailableVersion: params.latestAvailableVersion,
         manifest: params.manifest,
         ...fromManifestApplicationToDisplayFields(params.manifest?.application),
+        ...curatedCategoryOverride,
         isFeatured,
       });
     } else {
@@ -413,6 +418,7 @@ export class ApplicationRegistrationService {
         isFeatured,
         manifest: params.manifest,
         ...fromManifestApplicationToDisplayFields(params.manifest?.application),
+        ...curatedCategoryOverride,
         oAuthClientId: v4(),
         oAuthRedirectUris: [],
         oAuthScopes: [],


### PR DESCRIPTION
## What

Curates the applications we propose during the signup journey as vetted marketplace apps, always exposes the Marketplace tab, and restricts that tab to vetted apps only.

### Applications proposed in the signup journey

These are the three apps offered during onboarding (`ONBOARDING_INSTALLABLE_APPS`), now added to `MARKETPLACE_CURATED_APPLICATIONS` with a category:

| App | Universal identifier | Category |
| --- | --- | --- |
| Call recorder | `8da4b8b5-5edf-4880-b51f-ab6e679ec617` | `Communication` |
| Enrichment (People Data Labs) | `4a1178c1-3535-4a47-b592-231d3216b36f` | `Enrichment` |
| Last contact | `66a504cc-0a75-410e-a43f-cdeae1db1522` | `Data` |

Categories are plain strings for now, taken from the set we plan to formalize in `applicationCategoryType.ts` (`Communication`, `Productivity`, `Product management`, `Sales`, `Marketing`, `Enrichment`, `Data`, `Search`, `Other`).

## Changes

- **`marketplace-curated-applications.constant.ts`**: list the three signup apps with a `category` string and `position`.
- **`application-registration.service.ts`** (`upsertFromCatalog`): a listed app that matches a curated entry is marked `isFeatured`, and its curated category takes precedence over the manifest category.
- **`SettingsApplications.tsx`**: drop the `IS_MARKETPLACE_SETTING_TAB_VISIBLE` feature-flag gating so the Marketplace tab is always visible (flag treated as true).
- **`SettingsApplicationsAvailableTab.tsx`**: the Marketplace tab now shows only vetted (featured) applications; removed the "Featured only" toggle and the non-featured fallback.
- **`SettingsApplicationsDeveloperTab.tsx`**: removed the now-dead non-vetted "NPM packages" section (it only rendered when the flag was false) and its unused imports/state.

## Notes

The `IS_MARKETPLACE_SETTING_TAB_VISIBLE` flag definition and its dev seed are left in place; only the gating that consumed it was removed. Typecheck, lint, and format pass on the changed files.

https://claude.ai/code/session_01KzjTKQik724MwcfbbFAqsr

---
_Generated by [Claude Code](https://claude.ai/code/session_01KzjTKQik724MwcfbbFAqsr)_

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/22631?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

