### PR TITLE
fix(dashboard): skip widgets orphaned by deleted app/object

### DIFF
--- a/packages/twenty-server/src/engine/metadata-modules/flat-page-layout-widget/services/workspace-flat-page-layout-widget-map-cache.service.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/flat-page-layout-widget/services/workspace-flat-page-layout-widget-map-cache.service.ts
@@ -1,6 +1,7 @@
 import { Injectable } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 
+import { isDefined } from 'twenty-shared/utils';
 import { Repository } from 'typeorm';
 
 import { WorkspaceCacheProvider } from 'src/engine/workspace-cache/interfaces/workspace-cache-provider.service';
@@ -107,6 +108,30 @@ export class WorkspaceFlatPageLayoutWidgetMapCacheService extends WorkspaceCache
     const flatPageLayoutWidgetMaps = createEmptyFlatEntityMaps();
 
     for (const pageLayoutWidgetEntity of existingPageLayoutWidgets) {
+      // Skip widgets orphaned by a deleted app/object/tab so the whole
+      // dashboard map still builds instead of throwing FlatEntityMapsException.
+      const isApplicationMissing =
+        !applicationIdToUniversalIdentifierMap.has(
+          pageLayoutWidgetEntity.applicationId,
+        );
+      const isPageLayoutTabMissing =
+        !pageLayoutTabIdToUniversalIdentifierMap.has(
+          pageLayoutWidgetEntity.pageLayoutTabId,
+        );
+      const isObjectMetadataMissing =
+        isDefined(pageLayoutWidgetEntity.objectMetadataId) &&
+        !objectMetadataIdToUniversalIdentifierMap.has(
+          pageLayoutWidgetEntity.objectMetadataId,
+        );
+
+      if (
+        isApplicationMissing ||
+        isPageLayoutTabMissing ||
+        isObjectMetadataMissing
+      ) {
+        continue;
+      }
+
       const flatPageLayoutWidget =
         fromPageLayoutWidgetEntityToFlatPageLayoutWidget({
           entity: pageLayoutWidgetEntity,


### PR DESCRIPTION
## Problem

Opening a dashboard that contains a widget whose parent app (or its object metadata) has been deleted throws an unhandled `FlatEntityMapsException`, breaking the whole dashboard instead of degrading the single orphaned widget.

Reproduction (from #20768): create a dashboard with widgets from an app, then delete the app.

## Root cause

`WorkspaceFlatPageLayoutWidgetMapCacheService.computeForCache()` converts every widget through `fromPageLayoutWidgetEntityToFlatPageLayoutWidget`, which resolves the widget's many-to-one relations via `resolveManyToOneRelationIdsToUniversalIdentifiers`. That resolver throws `FlatEntityMapsException` when a widget's `applicationId` / `pageLayoutTabId` / `objectMetadataId` is absent from the preloaded lookup maps. A single orphaned widget aborts the entire map build, so `getPageLayout` fails for the whole dashboard.

Note: the widget config conversion path already degrades gracefully (`shouldThrowOnMissingIdentifier` defaults to `false`), so the relation resolver was the only hard-throwing path.

## Fix

Skip orphaned widgets in the caller before conversion: if the widget's application, page layout tab, or (non-null) object metadata id is missing from its lookup map, `continue`. The rest of the dashboard builds normally and the missing widget is simply absent.

Closes #20768

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/22638?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

