### PR TITLE
fix: corrected grammar in approved domain message

### DIFF
--- a/packages/twenty-front/src/pages/settings/security/SettingsSecurityApprovedAccessDomain.tsx
+++ b/packages/twenty-front/src/pages/settings/security/SettingsSecurityApprovedAccessDomain.tsx
@@ -132,7 +132,7 @@ export const SettingsSecurityApprovedAccessDomain = () => {
           <Section>
             <H2Title
               title={t`Email verification`}
-              description={t`We will send your a link to verify domain ownership`}
+              description={t`We will send you a link to verify domain ownership`}
             />
             <Controller
               name="email"


### PR DESCRIPTION
title says it all- quick grammar fix in the workspace approved access domains form

<img width="1484" height="610" alt="image" src="https://github.com/user-attachments/assets/bb4ce7a5-6ba4-40a7-a1f9-57c3e8d2dde0" />


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/22646?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

