### PR TITLE
Suppress Claude session URL in generated PR bodies and commits

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -2,7 +2,8 @@
   "$schema": "https://json.schemastore.org/claude-code-settings.json",
   "attribution": {
     "commit": "",
-    "pr": ""
+    "pr": "",
+    "sessionUrl": false
   },
   "hooks": {
     "SessionStart": [
@@ -10,7 +11,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "cat <<'EOF'\nInstructions for this session:\n- Do NOT add any signature, footer, co-author tag, \"Generated with Claude\" or \"Co-Authored-By\" mention in commits, PRs, or files.\n- Be concise. Get to the point, no preamble or unnecessary recap.\n- Write like a human: natural, direct tone, no marketing language or overwrought phrasing.\n- No weird punctuation: never use em dashes, no emojis unless explicitly asked, standard punctuation only.\nEOF"
+            "command": "cat <<'EOF'\nInstructions for this session:\n- Do NOT add any signature, footer, co-author tag, session link, \"Generated with Claude\" or \"Co-Authored-By\" mention in commits, GitHub PR descriptions, PR or issue comments, reviews, or files.\n- Be concise. Get to the point, no preamble or unnecessary recap.\n- Write like a human: natural, direct tone, no marketing language or overwrought phrasing.\n- No weird punctuation: never use em dashes, no emojis unless explicitly asked, standard punctuation only.\n- Do NOT add code comments unless strictly necessary, such as TypeScript directives or a short \"why\" comment for non-obvious business logic. Code should be as self-explanatory as possible.\nEOF"
           }
         ]
       }


### PR DESCRIPTION
## Context

PRs generated by Claude Code web sessions (e.g. #22648) still carried a bare `claude.ai/code/session_...` link and a "Generated by Claude Code" footer, which do not comply with the project's committed Claude settings.

The existing `.claude/settings.json` already set `attribution.commit` and `attribution.pr` to empty strings, which suppresses the generic "Generated with Claude Code" footer. But the web session URL is a separate feature: web sessions add the session link to PR bodies and a `Claude-Session` git trailer to commits, controlled by `attribution.sessionUrl` (available from Claude Code v2.1.182), not by the `commit`/`pr` attribution text. Since that field was unset, the session link leaked through.

## Changes

- `.claude/settings.json`:
  - Add `"sessionUrl": false` to the `attribution` object so the session URL is omitted from both PR bodies and commit trailers.
  - Extend the `SessionStart` hook instructions to explicitly cover GitHub PR descriptions, PR/issue comments and reviews (not just commits and files), and to discourage code comments unless strictly necessary (TypeScript directives or short "why" comments for non-obvious business logic).

## Notes

The public schemastore schema referenced by `$schema` lags behind the CLI and does not yet list `sessionUrl`, so editors may show a harmless validation hint until it updates. The Claude Code parser supports the field, per the on-the-web docs.