### PR TITLE
chore: add permissions allowlist to claude settings

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -5,6 +5,24 @@
     "pr": "",
     "sessionUrl": false
   },
+  "permissions": {
+    "allow": [
+      "Bash(npx nx lint:*)",
+      "Bash(npx nx typecheck:*)",
+      "Bash(npx nx test:*)",
+      "Bash(npx nx run:*)",
+      "Bash(npx nx build:*)",
+      "Bash(npx nx fmt:*)",
+      "Bash(npx nx storybook:*)",
+      "Bash(npx nx graphql:*)",
+      "Bash(npx jest:*)",
+      "Bash(yarn install)",
+      "Bash(git status:*)",
+      "Bash(git diff:*)",
+      "Bash(git log:*)",
+      "Bash(git fetch:*)"
+    ]
+  },
   "hooks": {
     "SessionStart": [
       {


### PR DESCRIPTION
DO NOT MERGE THIS

## What

Adds a `permissions.allow` list to `.claude/settings.json` covering the common safe dev commands already documented in `CLAUDE.md`:

- nx tasks: `lint`, `typecheck`, `test`, `run`, `build`, `fmt`, `storybook`, `graphql`
- `npx jest`
- `yarn install`
- read-only git: `status`, `diff`, `log`, `fetch`

## Why

These are the day-to-day commands from the repo's own workflow docs. Allowlisting them cuts down repetitive permission prompts during Claude Code sessions without granting anything destructive (no writes, resets, or pushes). Everything else still prompts as before.

---
_Generated by [Claude Code](https://claude.ai/code/session_01R9JsKJKnL2Y42e28Woij84)_

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/22653?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

