### PR TITLE
Fix email validation for over-length inline edits

### DIFF
--- a/packages/twenty-shared/src/utils/validation/emailSchema.ts
+++ b/packages/twenty-shared/src/utils/validation/emailSchema.ts
@@ -1,3 +1,3 @@
 import { z } from 'zod';
 
-export const emailSchema = z.email({ pattern: z.regexes.unicodeEmail });
+export const emailSchema = z.email({ pattern: z.regexes.unicodeEmail }).max(255);


### PR DESCRIPTION
Rebase of https://github.com/twentyhq/twenty/pull/22426
Add a client-side maximum length validation (255) to emailSchema so over-length email values are rejected before the GraphQL mutation is sent.

Rebased onto main: the schema moved from twenty-front record-field validation-schemas to twenty-shared utils/validation.

Closes to #22406.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/22655?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

