### PR TITLE
[Billing for self hosts] Add info in description

### DIFF
--- a/packages/twenty-front/src/pages/settings/enterprise/SettingsEnterprise.tsx
+++ b/packages/twenty-front/src/pages/settings/enterprise/SettingsEnterprise.tsx
@@ -575,7 +575,7 @@ export const SettingsEnterprise = ({
         description={
           instanceType === ENTERPRISE_INSTANCE_TYPE.DEVELOPMENT
             ? t`This server is registered as a development instance and is not billed additionally. A subscription can have a single development instance in addition to its production one. Switching it back to a production instance will make its seats count toward billing.`
-            : t`One subscription provides one enterprise key powers one production instance and one potential staging or test instance. To run a staging or test environment, install Twenty on a second server, activate it with this same enterprise key, then register that server as a development instance. Development instances unlock enterprise features without extra billing and do not count toward your production seats.`
+            : t`One subscription provides one enterprise key that powers one production instance and one potential staging or test instance. To run a staging or test environment, install Twenty on a second server, activate it with this same enterprise key, then register that server as a development instance. Development instances unlock enterprise features without extra billing and do not count toward your production seats.`
         }
       />
       {instanceType === ENTERPRISE_INSTANCE_TYPE.DEVELOPMENT ? (

--- a/packages/twenty-front/src/pages/settings/enterprise/SettingsEnterprise.tsx
+++ b/packages/twenty-front/src/pages/settings/enterprise/SettingsEnterprise.tsx
@@ -563,7 +563,7 @@ export const SettingsEnterprise = ({
     <Section>
       <H2Title
         title={t`Your enterprise key`}
-        description={t`Your enterprise key is safely stored on this server, so you do not need to re-enter it here. Make sure you keep a copy of it somewhere safe: you will need the same key to activate a development instance or to move your license to a replacement server. If you lose it, contact support to recover it.`}
+        description={t`Your enterprise key is safely stored on this server. Make sure you keep a copy of it somewhere safe: you need the same key to activate a development instance or to move your license to a replacement server. If you lose it, contact support to recover it.`}
       />
     </Section>
   );
@@ -575,7 +575,7 @@ export const SettingsEnterprise = ({
         description={
           instanceType === ENTERPRISE_INSTANCE_TYPE.DEVELOPMENT
             ? t`This server is registered as a development instance and is not billed additionally. A subscription can have a single development instance in addition to its production one. Switching it back to a production instance will make its seats count toward billing.`
-            : t`One enterprise key powers all of your instances. To run a staging or test environment, install Twenty on a second server, activate it with this same enterprise key, then register that server as a development instance. Development instances unlock enterprise features without extra billing and do not count toward your production seats. Each subscription can have one development instance alongside its production one, as long as the production instance stays active.`
+            : t`One subscription provides one enterprise key powers one production instance and one potential staging or test instance. To run a staging or test environment, install Twenty on a second server, activate it with this same enterprise key, then register that server as a development instance. Development instances unlock enterprise features without extra billing and do not count toward your production seats.`
         }
       />
       {instanceType === ENTERPRISE_INSTANCE_TYPE.DEVELOPMENT ? (

--- a/packages/twenty-front/src/pages/settings/enterprise/SettingsEnterprise.tsx
+++ b/packages/twenty-front/src/pages/settings/enterprise/SettingsEnterprise.tsx
@@ -563,7 +563,7 @@ export const SettingsEnterprise = ({
     <Section>
       <H2Title
         title={t`Your enterprise key`}
-        description={t`Your enterprise key is safely stored on this server. Make sure you keep a copy of it somewhere safe: you need the same key to activate a development instance or to move your license to a replacement server. If you lose it, contact support to recover it.`}
+        description={t`This server has an enterprise key configured. Make sure you keep a copy of it somewhere safe: you need the same key to activate a development instance or to move your license to a replacement server. If you no longer have access to your key, contact support.`}
       />
     </Section>
   );

--- a/packages/twenty-front/src/pages/settings/enterprise/SettingsEnterprise.tsx
+++ b/packages/twenty-front/src/pages/settings/enterprise/SettingsEnterprise.tsx
@@ -510,7 +510,7 @@ export const SettingsEnterprise = ({
     <Section>
       <H2Title
         title={t`Activate Enterprise Key`}
-        description={t`Paste your enterprise key below to activate`}
+        description={t`Paste your enterprise key below to activate. Keep a copy of this key somewhere safe: the same key is reused to set up a development instance or to move your license to a replacement server.`}
       />
       <StyledInputContainer>
         <StyledInputWrapper>
@@ -559,14 +559,23 @@ export const SettingsEnterprise = ({
     </Section>
   );
 
+  const enterpriseKeyInfoSection = (
+    <Section>
+      <H2Title
+        title={t`Your enterprise key`}
+        description={t`Your enterprise key is safely stored on this server, so you do not need to re-enter it here. Make sure you keep a copy of it somewhere safe: you will need the same key to activate a development instance or to move your license to a replacement server. If you lose it, contact support to recover it.`}
+      />
+    </Section>
+  );
+
   const instanceTypeSection = (
     <Section>
       <H2Title
         title={t`Development instance`}
         description={
           instanceType === ENTERPRISE_INSTANCE_TYPE.DEVELOPMENT
-            ? t`This instance is registered as a development instance and is not billed. A subscription can have a single free development instance in addition to its production one.`
-            : t`Register this server as a free development instance (for a staging or test environment). Development instances unlock enterprise features without being billed, and do not affect your production seat count.`
+            ? t`This server is registered as a development instance and is not billed additionally. A subscription can have a single development instance in addition to its production one. Switching it back to a production instance will make its seats count toward billing.`
+            : t`One enterprise key powers all of your instances. To run a staging or test environment, install Twenty on a second server, activate it with this same enterprise key, then register that server as a development instance. Development instances unlock enterprise features without extra billing and do not count toward your production seats. Each subscription can have one development instance alongside its production one, as long as the production instance stays active.`
         }
       />
       {instanceType === ENTERPRISE_INSTANCE_TYPE.DEVELOPMENT ? (
@@ -955,6 +964,7 @@ export const SettingsEnterprise = ({
         onConfirmClick={handleReleaseBinding}
       />
       {renderContent()}
+      {hasSignedEnterpriseKey && enterpriseKeyInfoSection}
       {hasEnterpriseLicense && instanceTypeSection}
     </>
   );


### PR DESCRIPTION
Clarify how the same enterprise key is reused for one prod + one dev instance. 
Suggest to save / store enterprise key in clear somewhere.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/22660?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

