### PR TITLE
fix(server): bound worker shutdown drain for all queues

### DIFF
--- a/packages/twenty-server/src/engine/core-modules/message-queue/drivers/bullmq.driver.ts
+++ b/packages/twenty-server/src/engine/core-modules/message-queue/drivers/bullmq.driver.ts
@@ -48,9 +48,6 @@ export class BullMQDriver
     MessageQueue,
     Worker
   >;
-  private workerOptionsMap: Partial<
-    Record<MessageQueue, MessageQueueWorkerOptions>
-  > = {};
 
   constructor(
     private options: BullMQDriverOptions,
@@ -138,14 +135,8 @@ export class BullMQDriver
     queueName: MessageQueue,
     worker: Worker,
   ): Promise<void> {
-    if (!this.workerOptionsMap[queueName]?.boundedShutdownDrain) {
-      await worker.close();
-
-      return;
-    }
-
     const shutdownTimeoutMs = this.twentyConfigService.get(
-      'AI_STREAM_SHUTDOWN_DRAIN_MS',
+      'WORKER_SHUTDOWN_DRAIN_MS',
     );
 
     const abortTimer = setTimeout(() => {
@@ -183,8 +174,6 @@ export class BullMQDriver
         collectInterval: 60000,
       },
     };
-
-    this.workerOptionsMap[queueName] = options;
 
     this.workerMap[queueName] = new Worker(
       queueName,

--- a/packages/twenty-server/src/engine/core-modules/message-queue/interfaces/message-queue-worker-options.interface.ts
+++ b/packages/twenty-server/src/engine/core-modules/message-queue/interfaces/message-queue-worker-options.interface.ts
@@ -2,5 +2,4 @@ export interface MessageQueueWorkerOptions {
   concurrency?: number;
   lockDuration?: number;
   maxStalledCount?: number;
-  boundedShutdownDrain?: boolean;
 }

--- a/packages/twenty-server/src/engine/core-modules/message-queue/message-queue-worker-options.constant.ts
+++ b/packages/twenty-server/src/engine/core-modules/message-queue/message-queue-worker-options.constant.ts
@@ -9,7 +9,6 @@ export const QUEUE_WORKER_OPTIONS: Partial<
     concurrency: 20,
     lockDuration: AI_STREAM_LOCK_DURATION_MS,
     maxStalledCount: 0,
-    boundedShutdownDrain: true,
   },
   [MessageQueue.logicFunctionQueue]: { concurrency: 10 },
 };

--- a/packages/twenty-server/src/engine/core-modules/twenty-config/config-variables.ts
+++ b/packages/twenty-server/src/engine/core-modules/twenty-config/config-variables.ts
@@ -1288,13 +1288,13 @@ export class ConfigVariables {
   @ConfigVariablesMetadata({
     group: ConfigVariablesGroup.SERVER_CONFIG,
     description:
-      'How long (ms) a worker shutdown waits for active AI chat stream jobs to finish before aborting them into a retryable interrupted state. Must be lower than the pod terminationGracePeriodSeconds so the abort and clean exit fit before SIGKILL (default: 300000)',
+      'How long (ms) a worker shutdown waits for active jobs on any queue to finish before aborting them into a retryable interrupted state. Must be lower than the pod terminationGracePeriodSeconds so the abort and clean exit fit before SIGKILL (default: 300000)',
     type: ConfigVariableType.NUMBER,
     isEnvOnly: true,
   })
   @CastToPositiveNumber()
   @IsOptional()
-  AI_STREAM_SHUTDOWN_DRAIN_MS = 300_000;
+  WORKER_SHUTDOWN_DRAIN_MS = 300_000;
 
   @ConfigVariablesMetadata({
     group: ConfigVariablesGroup.SERVER_CONFIG,


### PR DESCRIPTION
## Problem
Graceful SIGTERM drain (#22514) waits for in-flight jobs, but the abort-timer escape hatch (#22517) was opt-in via `boundedShutdownDrain` and only enabled on `aiStreamQueue`. Long queues (messaging, calendar) drained **unbounded** — a stuck Gmail fetch outlived the pod grace period and got SIGKILLed mid-job → orphaned job lock (`could not renew lock`, `Missing lock … moveToFinished`), `Premature close`, and accounts flipping to **Sync failed**.

Chronic since #22514/#22517 shipped; went from <10 errors/day to ~13k/day once a deploy rotated all worker pods.

## Fix
Make bounded drain the **default** for every queue instead of opt-in:
- `closeWorker` always arms the abort timer → stuck jobs are force-aborted cleanly (`cancelAllJobs`) before SIGKILL, releasing the lock and letting the job retry.
- Rename `AI_STREAM_SHUTDOWN_DRAIN_MS` → `WORKER_SHUTDOWN_DRAIN_MS` (env-only, default 300000, still < the 360s pod grace period).
- Drop the now-redundant `boundedShutdownDrain` flag + write-only `workerOptionsMap`.

−13 lines, 4 files.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/22669?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

