### PR TITLE
fix(sdk): report the connected server's real version in dev version check

### DIFF
--- a/packages/twenty-sdk/src/cli/utilities/version/__tests__/get-server-version-from-api.test.ts
+++ b/packages/twenty-sdk/src/cli/utilities/version/__tests__/get-server-version-from-api.test.ts
@@ -21,6 +21,8 @@ const mockFetch = (
 };
 
 describe('getServerVersionFromApi', () => {
+  const originalFetch = global.fetch;
+
   beforeEach(() => {
     vi.clearAllMocks();
     mockedGetConfig.mockResolvedValue({ apiUrl: 'http://localhost:2020' });
@@ -28,6 +30,7 @@ describe('getServerVersionFromApi', () => {
 
   afterEach(() => {
     vi.restoreAllMocks();
+    global.fetch = originalFetch;
   });
 
   it('returns the version reported by the server card endpoint', async () => {

--- a/packages/twenty-sdk/src/cli/utilities/version/__tests__/get-server-version-from-api.test.ts
+++ b/packages/twenty-sdk/src/cli/utilities/version/__tests__/get-server-version-from-api.test.ts
@@ -1,0 +1,105 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { getServerVersionFromApi } from '@/cli/utilities/version/get-server-version-from-api';
+
+const { mockedGetConfig } = vi.hoisted(() => ({
+  mockedGetConfig: vi.fn(),
+}));
+
+vi.mock('@/cli/utilities/config/config-service', () => ({
+  ConfigService: class {
+    getConfig = mockedGetConfig;
+  },
+}));
+
+const mockFetch = (
+  impl: (
+    input: string,
+  ) => Promise<{ ok: boolean; json: () => Promise<unknown> }>,
+) => {
+  global.fetch = vi.fn(impl as unknown as typeof fetch);
+};
+
+describe('getServerVersionFromApi', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockedGetConfig.mockResolvedValue({ apiUrl: 'http://localhost:2020' });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('returns the version reported by the server card endpoint', async () => {
+    mockFetch(async () => ({
+      ok: true,
+      json: async () => ({ version: '2.16.1' }),
+    }));
+
+    expect(await getServerVersionFromApi()).toBe('2.16.1');
+    expect(global.fetch).toHaveBeenCalledWith(
+      'http://localhost:2020/.well-known/mcp/server-card.json',
+      expect.anything(),
+    );
+  });
+
+  it('uses the provided apiUrl over the config, stripping a trailing slash', async () => {
+    mockFetch(async () => ({
+      ok: true,
+      json: async () => ({ version: 'v2.19.0' }),
+    }));
+
+    expect(await getServerVersionFromApi('http://example.com/')).toBe('2.19.0');
+    expect(mockedGetConfig).not.toHaveBeenCalled();
+    expect(global.fetch).toHaveBeenCalledWith(
+      'http://example.com/.well-known/mcp/server-card.json',
+      expect.anything(),
+    );
+  });
+
+  it('returns null for the 0.0.0 fallback version', async () => {
+    mockFetch(async () => ({
+      ok: true,
+      json: async () => ({ version: '0.0.0' }),
+    }));
+
+    expect(await getServerVersionFromApi()).toBeNull();
+  });
+
+  it('returns null for a non-semver version', async () => {
+    mockFetch(async () => ({
+      ok: true,
+      json: async () => ({ version: 'latest' }),
+    }));
+
+    expect(await getServerVersionFromApi()).toBeNull();
+  });
+
+  it('returns null when the version field is missing', async () => {
+    mockFetch(async () => ({ ok: true, json: async () => ({}) }));
+
+    expect(await getServerVersionFromApi()).toBeNull();
+  });
+
+  it('returns null on a non-ok response', async () => {
+    mockFetch(async () => ({ ok: false, json: async () => ({}) }));
+
+    expect(await getServerVersionFromApi()).toBeNull();
+  });
+
+  it('returns null when the request throws', async () => {
+    global.fetch = vi.fn(async () => {
+      throw new Error('network error');
+    }) as unknown as typeof fetch;
+
+    expect(await getServerVersionFromApi()).toBeNull();
+  });
+
+  it('returns null when no apiUrl is configured', async () => {
+    mockedGetConfig.mockResolvedValue({ apiUrl: '' });
+    global.fetch = vi.fn() as unknown as typeof fetch;
+
+    expect(await getServerVersionFromApi()).toBeNull();
+    expect(global.fetch).not.toHaveBeenCalled();
+  });
+});

--- a/packages/twenty-sdk/src/cli/utilities/version/get-server-version-from-api.ts
+++ b/packages/twenty-sdk/src/cli/utilities/version/get-server-version-from-api.ts
@@ -1,0 +1,47 @@
+import { ConfigService } from '@/cli/utilities/config/config-service';
+import { parseSemver } from '@/cli/utilities/version/parse-semver';
+
+const SERVER_CARD_PATH = '/.well-known/mcp/server-card.json';
+const FETCH_TIMEOUT_MS = 3000;
+
+export const getServerVersionFromApi = async (
+  apiUrl?: string,
+): Promise<string | null> => {
+  const baseUrl = apiUrl ?? (await new ConfigService().getConfig()).apiUrl;
+
+  if (!baseUrl) {
+    return null;
+  }
+
+  const controller = new AbortController();
+  const timeoutId = setTimeout(() => controller.abort(), FETCH_TIMEOUT_MS);
+
+  try {
+    const response = await fetch(
+      `${baseUrl.replace(/\/$/, '')}${SERVER_CARD_PATH}`,
+      { signal: controller.signal },
+    );
+
+    if (!response.ok) {
+      return null;
+    }
+
+    const body = (await response.json()) as { version?: unknown };
+
+    if (typeof body.version !== 'string') {
+      return null;
+    }
+
+    const version = body.version.trim().replace(/^v/, '');
+
+    if (version === '0.0.0' || parseSemver(version) === null) {
+      return null;
+    }
+
+    return version;
+  } catch {
+    return null;
+  } finally {
+    clearTimeout(timeoutId);
+  }
+};

--- a/packages/twenty-sdk/src/cli/utilities/version/get-version-info.ts
+++ b/packages/twenty-sdk/src/cli/utilities/version/get-version-info.ts
@@ -14,12 +14,7 @@ import sdkPackageJson from '../../../../package.json';
 
 const LOCAL_REMOTE_NAME = 'local';
 
-const LOOPBACK_HOSTS = new Set([
-  'localhost',
-  '127.0.0.1',
-  '[::1]',
-  '0.0.0.0',
-]);
+const LOOPBACK_HOSTS = new Set(['localhost', '127.0.0.1', '[::1]', '0.0.0.0']);
 
 const isLoopbackHost = (hostname: string): boolean =>
   LOOPBACK_HOSTS.has(hostname);

--- a/packages/twenty-sdk/src/cli/utilities/version/get-version-info.ts
+++ b/packages/twenty-sdk/src/cli/utilities/version/get-version-info.ts
@@ -2,6 +2,7 @@ import { CONTAINER_NAME } from '@/cli/utilities/server/docker-container';
 import { compareSemver } from '@/cli/utilities/version/compare-semver';
 import { getLocalServerVersion } from '@/cli/utilities/version/get-local-server-version';
 import { getPublishedServerVersions } from '@/cli/utilities/version/get-published-server-versions';
+import { getServerVersionFromApi } from '@/cli/utilities/version/get-server-version-from-api';
 import { parseSemver } from '@/cli/utilities/version/parse-semver';
 import { type VersionInfo } from '@/cli/utilities/version/version-info';
 import sdkPackageJson from '../../../../package.json';
@@ -17,10 +18,13 @@ export const getVersionInfo = async (
   containerName: string = CONTAINER_NAME,
 ): Promise<VersionInfo> => {
   const cliVersion = sdkPackageJson.version;
-  const [localServerVersion, publishedVersions] = await Promise.all([
-    getLocalServerVersion(containerName),
+
+  const [apiServerVersion, publishedVersions] = await Promise.all([
+    getServerVersionFromApi(),
     getPublishedServerVersions(),
   ]);
+  const localServerVersion =
+    apiServerVersion ?? (await getLocalServerVersion(containerName));
   const latestServerVersion = publishedVersions[0]?.name ?? null;
 
   const localParsed = localServerVersion

--- a/packages/twenty-sdk/src/cli/utilities/version/get-version-info.ts
+++ b/packages/twenty-sdk/src/cli/utilities/version/get-version-info.ts
@@ -1,4 +1,9 @@
-import { CONTAINER_NAME } from '@/cli/utilities/server/docker-container';
+import { ConfigService } from '@/cli/utilities/config/config-service';
+import {
+  CONTAINER_NAME,
+  getContainerPort,
+  isContainerRunning,
+} from '@/cli/utilities/server/docker-container';
 import { compareSemver } from '@/cli/utilities/version/compare-semver';
 import { getLocalServerVersion } from '@/cli/utilities/version/get-local-server-version';
 import { getPublishedServerVersions } from '@/cli/utilities/version/get-published-server-versions';
@@ -6,6 +11,56 @@ import { getServerVersionFromApi } from '@/cli/utilities/version/get-server-vers
 import { parseSemver } from '@/cli/utilities/version/parse-semver';
 import { type VersionInfo } from '@/cli/utilities/version/version-info';
 import sdkPackageJson from '../../../../package.json';
+
+const LOCAL_REMOTE_NAME = 'local';
+
+// Cheap, network-free check: is the CLI-managed container the one actually
+// serving the configured apiUrl? If it's running and bound to the same port,
+// its baked-in APP_VERSION is authoritative (two processes can't share a port),
+// so we can read it locally instead of paying the API fetch timeout.
+const isContainerServingApiUrl = async (
+  containerName: string,
+): Promise<boolean> => {
+  if (ConfigService.getActiveRemote() !== LOCAL_REMOTE_NAME) {
+    return false;
+  }
+
+  if (!isContainerRunning(containerName)) {
+    return false;
+  }
+
+  try {
+    const { apiUrl } = await new ConfigService().getConfig();
+    const apiPort = new URL(apiUrl).port;
+
+    return (
+      apiPort !== '' && String(getContainerPort(containerName)) === apiPort
+    );
+  } catch {
+    return false;
+  }
+};
+
+// Resolves the version of the server the CLI is connected to. Prefers a local
+// Docker read when the CLI-managed container is the server (fast, no network),
+// otherwise asks the connected server over HTTP and only falls back to Docker
+// inspection when it can't be reached.
+const resolveLocalServerVersion = async (
+  containerName: string,
+): Promise<string | null> => {
+  if (await isContainerServingApiUrl(containerName)) {
+    const dockerVersion = await getLocalServerVersion(containerName);
+
+    if (dockerVersion !== null) {
+      return dockerVersion;
+    }
+  }
+
+  return (
+    (await getServerVersionFromApi()) ??
+    (await getLocalServerVersion(containerName))
+  );
+};
 
 const MS_PER_DAY = 24 * 60 * 60 * 1000;
 
@@ -19,12 +74,10 @@ export const getVersionInfo = async (
 ): Promise<VersionInfo> => {
   const cliVersion = sdkPackageJson.version;
 
-  const [apiServerVersion, publishedVersions] = await Promise.all([
-    getServerVersionFromApi(),
+  const [localServerVersion, publishedVersions] = await Promise.all([
+    resolveLocalServerVersion(containerName),
     getPublishedServerVersions(),
   ]);
-  const localServerVersion =
-    apiServerVersion ?? (await getLocalServerVersion(containerName));
   const latestServerVersion = publishedVersions[0]?.name ?? null;
 
   const localParsed = localServerVersion

--- a/packages/twenty-sdk/src/cli/utilities/version/get-version-info.ts
+++ b/packages/twenty-sdk/src/cli/utilities/version/get-version-info.ts
@@ -14,10 +14,6 @@ import sdkPackageJson from '../../../../package.json';
 
 const LOCAL_REMOTE_NAME = 'local';
 
-// Cheap, network-free check: is the CLI-managed container the one actually
-// serving the configured apiUrl? If it's running and bound to the same port,
-// its baked-in APP_VERSION is authoritative (two processes can't share a port),
-// so we can read it locally instead of paying the API fetch timeout.
 const isContainerServingApiUrl = async (
   containerName: string,
 ): Promise<boolean> => {
@@ -41,10 +37,6 @@ const isContainerServingApiUrl = async (
   }
 };
 
-// Resolves the version of the server the CLI is connected to. Prefers a local
-// Docker read when the CLI-managed container is the server (fast, no network),
-// otherwise asks the connected server over HTTP and only falls back to Docker
-// inspection when it can't be reached.
 const resolveLocalServerVersion = async (
   containerName: string,
 ): Promise<string | null> => {

--- a/packages/twenty-sdk/src/cli/utilities/version/get-version-info.ts
+++ b/packages/twenty-sdk/src/cli/utilities/version/get-version-info.ts
@@ -14,6 +14,16 @@ import sdkPackageJson from '../../../../package.json';
 
 const LOCAL_REMOTE_NAME = 'local';
 
+const LOOPBACK_HOSTS = new Set([
+  'localhost',
+  '127.0.0.1',
+  '[::1]',
+  '0.0.0.0',
+]);
+
+const isLoopbackHost = (hostname: string): boolean =>
+  LOOPBACK_HOSTS.has(hostname);
+
 const isContainerServingApiUrl = async (
   containerName: string,
 ): Promise<boolean> => {
@@ -27,10 +37,12 @@ const isContainerServingApiUrl = async (
 
   try {
     const { apiUrl } = await new ConfigService().getConfig();
-    const apiPort = new URL(apiUrl).port;
+    const { hostname, port: apiPort } = new URL(apiUrl);
 
     return (
-      apiPort !== '' && String(getContainerPort(containerName)) === apiPort
+      isLoopbackHost(hostname) &&
+      apiPort !== '' &&
+      String(getContainerPort(containerName)) === apiPort
     );
   } catch {
     return false;


### PR DESCRIPTION
## Summary

The `yarn twenty app dev` version row was reading the "local server" version from the `twenty-app-dev` Docker container's baked-in `APP_VERSION` env var. When the CLI is actually pointed at a separately running instance (or a stale `twenty-app-dev` container is lying around), this reported a version unrelated to the server serving requests — e.g. showing `Server v2.5.3` and a bogus "days behind" warning while the real instance was on `2.16.1`.

This changes the version resolution to ask the server the CLI is connected to for its real version over HTTP, falling back to Docker inspection only when the server can't be reached.

- Add `getServerVersionFromApi`, which reads the version from the public, no-auth `/.well-known/mcp/server-card.json` endpoint (its `version` is the server's `APP_VERSION`). Returns `null` gracefully on timeout, non-OK responses, or missing/`0.0.0`/non-semver values.
- `getVersionInfo` now uses `getServerVersionFromApi() ?? getLocalServerVersion(containerName)`, running the API call in parallel with the Docker Hub published-versions fetch. All downstream logic (`isMinorOrMajorBehind`, `daysBehind`, the dev UI row, and the headless warning) now operates on the real version.