### PR TITLE
fix(docker): bump node base to 24.18.0 (all 24.17.0 CVE fixes + http.Agent premature-close fix)

### DIFF
--- a/packages/twenty-docker/twenty/Dockerfile
+++ b/packages/twenty-docker/twenty/Dockerfile
@@ -2,7 +2,7 @@
 # Dependency stages
 # ===========================================================================
 
-FROM node:24.16.0-alpine3.23@sha256:2bdb65ed1dab192432bc31c95f94155ca5ad7fc1392fb7eb7526ab682fa5bf14 AS front-deps
+FROM node:24.18.0-alpine3.23@sha256:595398b0081eacda8e1c4c5b97b76cd1020e4d58a8ebcb4843b9bca1e79e7436 AS front-deps
 
 WORKDIR /app
 
@@ -20,7 +20,7 @@ COPY ./packages/twenty-client-sdk/package.json /app/packages/twenty-client-sdk/
 RUN yarn workspaces focus twenty twenty-front twenty-front-component-renderer twenty-ui twenty-shared twenty-sdk twenty-client-sdk && yarn cache clean && npx nx reset
 
 
-FROM node:24.16.0-alpine3.23@sha256:2bdb65ed1dab192432bc31c95f94155ca5ad7fc1392fb7eb7526ab682fa5bf14 AS server-deps
+FROM node:24.18.0-alpine3.23@sha256:595398b0081eacda8e1c4c5b97b76cd1020e4d58a8ebcb4843b9bca1e79e7436 AS server-deps
 
 WORKDIR /app
 
@@ -84,7 +84,7 @@ RUN if [ -d /app/packages/twenty-front/build ]; then \
 #   docker build --target twenty-server -f packages/twenty-docker/twenty/Dockerfile .
 # ===========================================================================
 
-FROM node:24.16.0-alpine3.23@sha256:2bdb65ed1dab192432bc31c95f94155ca5ad7fc1392fb7eb7526ab682fa5bf14 AS twenty-server
+FROM node:24.18.0-alpine3.23@sha256:595398b0081eacda8e1c4c5b97b76cd1020e4d58a8ebcb4843b9bca1e79e7436 AS twenty-server
 
 # Force the patched Alpine OpenSSL libs (base bakes 3.5.6-r0; repo ships
 # 3.5.7-r0). Node bundles its own OpenSSL, but psql/curl link these system
@@ -137,13 +137,12 @@ LABEL org.opencontainers.image.description="Twenty server image (no frontend)."
 #  - the Node dev headers: only node-gyp needs them and native addons are
 #    compiled in the build stages; their vendored openssl/opensslv.h is what
 #    scanners fingerprint whenever OpenSSL patches ahead of Node releases.
-# TODO(2026-07-08): the base is deliberately pinned back to node:24.16.0-alpine.
-# 24.17.0's http.Agent/llhttp security patches cause a flood of mid-body
-# "Premature close" failures on keep-alive fetches in prod (Gmail/Calendar sync,
-# Cloudflare API — see #22671). Trade-off: 24.16.0 statically links OpenSSL 3.5.6,
-# so the scanner will re-flag CVE-2026-48930 (TLS embedded-nul hostname authority
-# rebinding, CVSS 9.8) on the node binary until we re-bump. Re-bump to the next
-# 24.x once the premature-close regression is fixed upstream (nodejs/node).
+# The pinned node:24.18.0-alpine base carries every 24.17.0 security fix
+# (OpenSSL 3.5.7, CVE-2026-48930) plus the fix for the http.Agent keep-alive
+# regression (nodejs/node#64004) that flooded prod with false "Premature close"
+# fetch failures on 24.17.0 (see #22671/#22673). Do not pin 24.17.0 again.
+# Keep the base current when Node ships 24.x security releases — the scanner
+# flags the statically-linked node binary itself.
 RUN rm -rf /usr/local/lib/node_modules/npm /usr/local/bin/npm /usr/local/bin/npx \
       /usr/local/include/node && \
     find /app/node_modules -type d -name example -prune -exec rm -rf {} +
@@ -218,7 +217,7 @@ RUN S6_ARCH=$(cat /tmp/s6arch) && \
     echo "$NOARCH_SUM  s6-overlay-noarch.tar.xz" | sha256sum -c - && \
     echo "$ARCH_SUM  s6-overlay-arch.tar.xz" | sha256sum -c -
 
-FROM node:24.16.0-alpine3.23@sha256:2bdb65ed1dab192432bc31c95f94155ca5ad7fc1392fb7eb7526ab682fa5bf14 AS twenty-app-dev
+FROM node:24.18.0-alpine3.23@sha256:595398b0081eacda8e1c4c5b97b76cd1020e4d58a8ebcb4843b9bca1e79e7436 AS twenty-app-dev
 
 # s6-overlay
 COPY --from=s6-fetch /tmp/s6-overlay-noarch.tar.xz /tmp/


### PR DESCRIPTION
## Context

Follow-up to #22673, which pinned the base image back to `node:24.16.0-alpine` to stop the prod flood of `Invalid response body while trying to fetch …: Premature close` failures on Gmail/Calendar sync and Cloudflare checks introduced by the 24.17.0 bump (#22529).

The regression is confirmed upstream: 24.17.0's response-queue-poisoning fix (CVE-2026-48931) attaches a public `'data'` listener on idle keep-alive sockets in the `http.Agent` pool, which false-triggers node-fetch@2's premature-close detection whenever a server abruptly resets a keep-alive socket right after a **complete** response — standard behavior for Google's front end. Reported the day 24.17.0 shipped (nodejs/node#63989, #64098) and fixed by nodejs/node#64004, released in **Node 24.18.0 (2026-06-23)**.

## What this PR does

Bumps all four stages to `node:24.18.0-alpine3.23` (digest-pinned). 24.18.0 is the current 24 LTS and contains:
- everything from 24.17.0: OpenSSL 3.5.7, CVE-2026-48930 (CVSS 9.8), and the response-queue-poisoning guard itself — reimplemented via the socket's internal `onread` hook instead of a public stream listener (nodejs/node#64004)
- so we get the full security posture back **and** the regression fix.

## Verification

Deterministic repro (complete chunked response over keep-alive, then abrupt socket destroy — per nodejs/node#64098), run against all three images with node-fetch v2 and v3:

| Node | node-fetch@2 | node-fetch@3 |
|------|--------------|--------------|
| 24.16.0 | OK | OK |
| 24.17.0 | **`ERR_STREAM_PREMATURE_CLOSE: Invalid response body … Premature close`** (byte-for-byte the prod Sentry error) | OK |
| 24.18.0 | OK | OK |

node-fetch@2 is what the Gmail batch layer (`@jrmdayn/googleapis-batcher`) and the Cloudflare client resolve to, matching the affected prod paths.

## Related

- #22673 — interim rollback to 24.16.0 (shipped as twenty/v2.19.1); this PR supersedes it
- #22671 — classifies `ERR_STREAM_PREMATURE_CLOSE` as a transient retryable network error; still worth landing since servers legitimately reset keep-alive sockets

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/22677?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

