### PR TITLE
feat(ai): optionally preselect fast or smart model when opening Ask AI

### DIFF
--- a/packages/twenty-front/src/modules/ai/hooks/useOpenAskAiPageWithPreprompt.ts
+++ b/packages/twenty-front/src/modules/ai/hooks/useOpenAskAiPageWithPreprompt.ts
@@ -1,3 +1,5 @@
+import { isDefined } from 'twenty-shared/utils';
+
 import { useSwitchToNewAiChat } from '@/ai/hooks/useSwitchToNewAiChat';
 import {
   AGENT_CHAT_NEW_THREAD_DRAFT_KEY,
@@ -7,23 +9,43 @@ import {
   type AgentChatPrepromptMode,
   agentChatPrepromptState,
 } from '@/ai/states/agentChatPrepromptState';
+import { agentChatUserSelectedModelState } from '@/ai/states/agentChatUserSelectedModelState';
+import { currentWorkspaceState } from '@/auth/states/currentWorkspaceState';
+import { useAtomStateValue } from '@/ui/utilities/state/jotai/hooks/useAtomStateValue';
 import { useSetAtomState } from '@/ui/utilities/state/jotai/hooks/useSetAtomState';
+
+export type AgentChatModelPreselection = 'FAST' | 'SMART';
 
 export const useOpenAskAiPageWithPreprompt = () => {
   const { switchToNewChat } = useSwitchToNewAiChat();
+  const currentWorkspace = useAtomStateValue(currentWorkspaceState);
   const setAgentChatDraftsByThreadId = useSetAtomState(
     agentChatDraftsByThreadIdState,
   );
   const setAgentChatPreprompt = useSetAtomState(agentChatPrepromptState);
+  const setAgentChatUserSelectedModel = useSetAtomState(
+    agentChatUserSelectedModelState,
+  );
 
   const openAskAiPageWithPreprompt = ({
     text,
     mode = 'PREFILL',
+    model,
   }: {
     text: string;
     mode?: AgentChatPrepromptMode;
+    model?: AgentChatModelPreselection;
   }) => {
     switchToNewChat();
+
+    if (isDefined(model)) {
+      const fastModelId = currentWorkspace?.fastModel;
+
+      setAgentChatUserSelectedModel(
+        model === 'FAST' && isDefined(fastModelId) ? fastModelId : null,
+      );
+    }
+
     setAgentChatDraftsByThreadId((prev) => ({
       ...prev,
       [AGENT_CHAT_NEW_THREAD_DRAFT_KEY]: text,

--- a/packages/twenty-front/src/modules/front-components/hooks/useFrontComponentExecutionContext.ts
+++ b/packages/twenty-front/src/modules/front-components/hooks/useFrontComponentExecutionContext.ts
@@ -203,6 +203,7 @@ export const useFrontComponentExecutionContext = ({
         openAskAiPageWithPreprompt({
           text: params.preprompt.text,
           mode: params.preprompt.mode,
+          model: params.preprompt.model,
         });
 
         if (params.shouldResetSearchState === true) {

--- a/packages/twenty-sdk/src/sdk/front-component/globals/frontComponentHostCommunicationApi.ts
+++ b/packages/twenty-sdk/src/sdk/front-component/globals/frontComponentHostCommunicationApi.ts
@@ -53,6 +53,7 @@ export type OpenSidePanelPageParams =
       preprompt?: {
         text: string;
         mode?: 'PREFILL' | 'SEND';
+        model?: 'FAST' | 'SMART';
       };
     }
   | {


### PR DESCRIPTION
Allow front components to preselect the AI model when opening the Ask AI
side panel with a preprompt.

- Add an optional `model: 'FAST' | 'SMART'` to the preprompt in the
  openSidePanelPage AskAI params of the front-component SDK.
- openAskAiPageWithPreprompt resolves FAST to the workspace fast model
  and SMART to the workspace default (null selection = pinned default
  model), writing to agentChatUserSelectedModelState.