### PR TITLE
fix(create-twenty-app): working docs URL in final message, complete dev:add table in AGENTS.md

### DIFF
--- a/packages/create-twenty-app/src/constants/template/AGENTS.md
+++ b/packages/create-twenty-app/src/constants/template/AGENTS.md
@@ -63,5 +63,9 @@ It's highly recommended to create new app entities using `yarn twenty dev:add`. 
 | View                 | `yarn twenty dev:add view`               | `src/views/<name>.ts`                 |
 | Navigation menu item | `yarn twenty dev:add navigationMenuItem` | `src/navigation-menu-items/<name>.ts` |
 | Page layout          | `yarn twenty dev:add pageLayout`         | `src/page-layouts/<name>.ts`          |
+| Page layout tab      | `yarn twenty dev:add pageLayoutTab`      | `src/page-layout-tabs/<name>.ts`      |
+| Command menu item    | `yarn twenty dev:add commandMenuItem`    | `src/command-menu-items/<name>.ts`    |
+| View field           | `yarn twenty dev:add viewField`          | `src/view-fields/<name>.ts`           |
+| Connection provider  | `yarn twenty dev:add connectionProvider` | `src/connection-providers/<name>.ts`  |
 
 This helps automatically generate required IDs etc.

--- a/packages/create-twenty-app/src/create-app.command.ts
+++ b/packages/create-twenty-app/src/create-app.command.ts
@@ -668,7 +668,7 @@ export class CreateAppCommand {
 
     console.log(
       chalk.gray(
-        '  Documentation: https://docs.twenty.com/developers/extend/capabilities/apps',
+        '  Documentation: https://docs.twenty.com/developers/extend/apps/getting-started/quick-start',
       ),
     );
   }


### PR DESCRIPTION
Part 7 of the app-docs audit series — two small fixes in the scaffolder itself, found while testing it end-to-end.

- The `Documentation:` link printed at the end of `npx create-twenty-app` points to `https://docs.twenty.com/developers/extend/capabilities/apps`, which 404s (the apps docs live under `/developers/extend/apps/...`). Now points at the quick start.
- The generated `AGENTS.md` (mirrored to `CLAUDE.md`) recommends `yarn twenty dev:add` but its entity table lists only 10 of the 14 supported entity types — AI agents working from that file can't discover `pageLayoutTab`, `commandMenuItem`, `viewField`, or `connectionProvider`. Added the missing rows (paths follow the CLI's `kebabCase(entity)s` convention).

---
_Generated by [Claude Code](https://claude.ai/code/session_01ExboyDAT19khDuKXaYXETT)_

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/22695?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

