### PR TITLE
Fix flaky "Message queues stalled" false positives in integration tests

### DIFF
--- a/packages/twenty-server/test/integration/utils/wait-for-all-jobs-to-finish.util.ts
+++ b/packages/twenty-server/test/integration/utils/wait-for-all-jobs-to-finish.util.ts
@@ -1,11 +1,14 @@
-import { Queue } from 'bullmq';
+import { type Job, Queue } from 'bullmq';
 import IORedis from 'ioredis';
 
 import { MessageQueue } from 'src/engine/core-modules/message-queue/message-queue.constants';
 
-const POLL_INTERVAL_MS = 25;
+const QUIET_POLL_INTERVAL_MS = 25;
+const BUSY_POLL_INTERVAL_MS = 250;
 const REQUIRED_CONSECUTIVE_QUIET_CHECKS = 2;
-const STALL_TIMEOUT_MS = 15_000;
+// The workflow worker runs at concurrency 1 on a loaded 2-core runner, so a
+// single slow job plus a queued one is normal; 15s produced false stalls.
+const STALL_TIMEOUT_MS = 45_000;
 const HARD_TIMEOUT_MS = 120_000;
 const PENDING_JOB_STATES = [
   'waiting',
@@ -34,40 +37,89 @@ const getQueues = (): Queue[] => {
   return queues;
 };
 
-const getPendingJobCountsByQueue = async (): Promise<
-  Record<string, number>
-> => {
-  const countsByQueue = await Promise.all(
-    getQueues().map(async (queue) => {
+// Jobs scheduled further out than the stall window (e.g. billing's 24h
+// UpdateSubscriptionQuantityJob) will never run during the test run; waiting
+// on them can only produce false stalls.
+const isBlockingJob = (job: Job): boolean => {
+  if (!job.delay) {
+    return true;
+  }
+
+  const remainingDelayMs = job.timestamp + job.delay - Date.now();
+
+  return remainingDelayMs <= STALL_TIMEOUT_MS;
+};
+
+type QueueSnapshot = {
+  blockingJobsByQueue: Record<string, Job[]>;
+  blockingTotal: number;
+  fingerprint: string;
+};
+
+const getQueueSnapshot = async (): Promise<QueueSnapshot> => {
+  const jobsByQueue: Array<[string, Job[]]> = await Promise.all(
+    getQueues().map(async (queue): Promise<[string, Job[]]> => {
       const jobCounts = await queue.getJobCounts(...PENDING_JOB_STATES);
       const pendingCount = Object.values(jobCounts).reduce(
         (sum, count) => sum + count,
         0,
       );
 
-      return [queue.name, pendingCount] as const;
+      if (pendingCount === 0) {
+        return [queue.name, []];
+      }
+
+      const jobs = await queue.getJobs([...PENDING_JOB_STATES], 0, 100);
+
+      return [
+        queue.name,
+        jobs.filter((job): job is Job => Boolean(job)).filter(isBlockingJob),
+      ];
     }),
   );
 
-  return Object.fromEntries(
-    countsByQueue.filter(([, pendingCount]) => pendingCount > 0),
+  const blockingJobsByQueue: Record<string, Job[]> = Object.fromEntries(
+    jobsByQueue.filter(([, jobs]) => jobs.length > 0),
   );
+
+  const blockingTotal = Object.values(blockingJobsByQueue).reduce(
+    (sum, jobs) => sum + jobs.length,
+    0,
+  );
+
+  // Retries keep their job id but increment attemptsMade, so a churning
+  // queue registers as progress while a genuinely frozen one does not.
+  const fingerprint = Object.entries(blockingJobsByQueue)
+    .map(
+      ([queueName, jobs]) =>
+        `${queueName}:${jobs
+          .map(
+            (job) =>
+              `${job.name}#${job.id}@${job.attemptsMade}:${job.delay ?? 0}`,
+          )
+          .sort()
+          .join(',')}`,
+    )
+    .sort()
+    .join('|');
+
+  return { blockingJobsByQueue, blockingTotal, fingerprint };
 };
 
-const getActiveJobsFingerprint = async (
-  busyQueueNames: string[],
-): Promise<string> => {
-  const activeJobIdsByQueue = await Promise.all(
-    getQueues()
-      .filter((queue) => busyQueueNames.includes(queue.name))
-      .map(async (queue) => {
-        const activeJobs = await queue.getActive(0, 50);
-
-        return `${queue.name}:${activeJobs.map((job) => job.id).join(',')}`;
-      }),
-  );
-
-  return activeJobIdsByQueue.join('|');
+const describeBlockingJobs = (
+  blockingJobsByQueue: Record<string, Job[]>,
+): string => {
+  return Object.entries(blockingJobsByQueue)
+    .map(
+      ([queueName, jobs]) =>
+        `${queueName}: ${jobs
+          .map(
+            (job) =>
+              `${job.name}(id=${job.id}, attemptsMade=${job.attemptsMade}, delay=${job.delay ?? 0})`,
+          )
+          .join(', ')}`,
+    )
+    .join('; ');
 };
 
 export const waitForAllJobsToFinish = async (): Promise<void> => {
@@ -75,45 +127,49 @@ export const waitForAllJobsToFinish = async (): Promise<void> => {
   let lastProgressAt = startedAt;
   let lastBusyFingerprint = '';
   let consecutiveQuietChecks = 0;
+  let busy = false;
 
   while (consecutiveQuietChecks < REQUIRED_CONSECUTIVE_QUIET_CHECKS) {
-    const pendingJobCountsByQueue = await getPendingJobCountsByQueue();
-    const pendingTotal = Object.values(pendingJobCountsByQueue).reduce(
-      (sum, count) => sum + count,
-      0,
-    );
+    const { blockingJobsByQueue, blockingTotal, fingerprint } =
+      await getQueueSnapshot();
 
-    if (pendingTotal === 0) {
+    if (blockingTotal === 0) {
+      busy = false;
       consecutiveQuietChecks += 1;
     } else {
+      busy = true;
       consecutiveQuietChecks = 0;
       const now = Date.now();
 
-      const activeJobsFingerprint = await getActiveJobsFingerprint(
-        Object.keys(pendingJobCountsByQueue),
-      );
-      const busyFingerprint = `${pendingTotal}|${activeJobsFingerprint}`;
-
-      if (busyFingerprint !== lastBusyFingerprint) {
-        lastBusyFingerprint = busyFingerprint;
+      if (fingerprint !== lastBusyFingerprint) {
+        lastBusyFingerprint = fingerprint;
         lastProgressAt = now;
       }
 
       if (now - lastProgressAt > STALL_TIMEOUT_MS) {
         throw new Error(
-          `Message queues stalled, no progress for ${STALL_TIMEOUT_MS}ms, pending jobs: ${JSON.stringify(pendingJobCountsByQueue)}`,
+          `Message queues stalled, no progress for ${STALL_TIMEOUT_MS}ms, pending jobs: ${describeBlockingJobs(
+            blockingJobsByQueue,
+          )}`,
         );
       }
 
       if (now - startedAt > HARD_TIMEOUT_MS) {
         throw new Error(
-          `Message queues still busy after ${HARD_TIMEOUT_MS}ms, pending jobs: ${JSON.stringify(pendingJobCountsByQueue)}`,
+          `Message queues still busy after ${HARD_TIMEOUT_MS}ms, pending jobs: ${describeBlockingJobs(
+            blockingJobsByQueue,
+          )}`,
         );
       }
     }
 
     if (consecutiveQuietChecks < REQUIRED_CONSECUTIVE_QUIET_CHECKS) {
-      await new Promise((resolve) => setTimeout(resolve, POLL_INTERVAL_MS));
+      await new Promise((resolve) =>
+        setTimeout(
+          resolve,
+          busy ? BUSY_POLL_INTERVAL_MS : QUIET_POLL_INTERVAL_MS,
+        ),
+      );
     }
   }
 };


### PR DESCRIPTION
# Context

Part of a CI flakiness sweep. Integration shards intermittently fail in unrelated suites' `afterEach` with:

```
Message queues stalled, no progress for 15000ms, pending jobs: {"workflow-queue":2}
```

(example: run 28945426764, shard 7, `delete-one-object-records-permissions` — a suite that never touches workflows; the jobs are `WorkflowTriggerJob`s enqueued by plain record CRUD because a previous workflow suite in the same shard left an active `workflowAutomatedTrigger` on the shared workspace).

# Root cause

`waitForAllJobsToFinish`'s stall detection was structurally prone to false positives:

- The progress fingerprint only sampled **active** job ids. Every driver enqueue lands in `prioritized` (the driver sets a queue priority), which the fingerprint can't see, and the workflow worker runs at **concurrency 1** — so one slow job plus one queued job legitimately shows a constant fingerprint for a while on a loaded 2-core runner that is also hosting Postgres, Redis, ClickHouse and jest. 15s was too aggressive for that topology.
- Latent guaranteed false stall (found during adversarial review): with `IS_BILLING_ENABLED=true` (all 16 shards), any suite creating/deleting a workspace member enqueues `UpdateSubscriptionQuantityJob` with a **24-hour** delay — a pending job the watchdog would wait on forever.

# Fix (test util only)

- Fingerprint **all** pending jobs as `name#id@attemptsMade:delay`, so retries and queue turnover count as progress while a genuinely frozen queue still has a constant fingerprint and stalls out.
- Exclude jobs delayed beyond the stall window from the blocking set (fixes the 24h billing job false stall without executing anything early — an earlier draft used `queue.promoteJobs()`, which adversarial review rejected because it would run the billing job mid-suite).
- Stall timeout 15s → 45s; hard cap unchanged at 120s; poll at 250ms while busy (instead of 25ms) to keep Redis load bounded.
- Both error messages now include job names/ids/attempts/delays, so any future stall identifies the offending jobs directly instead of just `{"workflow-queue":2}`.

True-deadlock detection is preserved: a stuck job has a constant fingerprint (same id, same attemptsMade) → stall at 45s; an infinite churn loop is impossible (no backoff configured, retries exhaust in ms and move to `failed`, leaving the pending set), and the 120s hard cap bounds everything else.

1 file, test infrastructure only.

---
_Generated by [Claude Code](https://claude.ai/code/session_01AtD2wWm3EthV6t3Hs31QyB)_

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/22703?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

