### PR TITLE
[e2e probe — do not merge] Run e2e suite on Safari (WebKit)

### DIFF
--- a/packages/twenty-apps/examples/postcard/playwright.config.ts
+++ b/packages/twenty-apps/examples/postcard/playwright.config.ts
@@ -36,5 +36,13 @@ export default defineConfig({
       },
       dependencies: ['setup'],
     },
+    {
+      name: 'webkit',
+      use: {
+        ...devices['Desktop Safari'],
+        storageState: path.resolve(__dirname, 'e2e/.auth/user.json'),
+      },
+      dependencies: ['setup'],
+    },
   ],
 });

--- a/packages/twenty-e2e-testing/playwright.config.ts
+++ b/packages/twenty-e2e-testing/playwright.config.ts
@@ -55,10 +55,14 @@ export default defineConfig({
       dependencies: ['setup'],
     },
 
-    //{
-    //  name: 'webkit',
-    //  use: { ...devices['Desktop Safari'] },
-    //},
+    {
+      name: 'safari',
+      use: {
+        ...devices['Desktop Safari'],
+        storageState: path.resolve(__dirname, '.auth', 'user.json'),
+      },
+      dependencies: ['setup'],
+    },
 
     /* Test against mobile viewports. */
     // {


### PR DESCRIPTION
## Purpose

**Probe / do not merge.** Branched off `main` with a single change — adds a `safari` (WebKit) Playwright project mirroring the existing `chrome` project — so the prod-parity e2e suite runs against WebKit and we can see which specs (if any) actually fail on Safari, independent of the front-component changes in #22672.

Carrying the `run-e2e-apps-prod-parity-tests` label to trigger the run.

## Notes

- The `safari` project omits the `clipboard-read` / `clipboard-write` permissions the `chrome` project sets, because those permission names are Chromium-only and WebKit rejects them. `signup_invite_email.spec.ts` reads `navigator.clipboard`, so that spec is the prime candidate to fail under WebKit — this run will confirm.
- Requires the WebKit browser binary + system deps in the e2e job (`playwright install webkit --with-deps`). If the job doesn't provision WebKit, the run will error at browser launch rather than at a spec.

Findings feed back into #22672 (whether to scope the Safari project down to front-component specs or make clipboard-dependent tests WebKit-aware).

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/22717?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

