### PR TITLE
docs: surface the self-serve partner marketplace on high-intent pages

### DIFF
--- a/packages/twenty-docs/user-guide/data-migration/how-tos/migrating-from-other-crms.mdx
+++ b/packages/twenty-docs/user-guide/data-migration/how-tos/migrating-from-other-crms.mdx
@@ -269,8 +269,9 @@ See [How to Fix Import Errors](/user-guide/data-migration/how-tos/fix-import-err
 
 ## Need Help?
 
-For complex migrations or large datasets:
-- **Guided setup:** Book a 4-hour onboarding pack
-- **Full migration service:** Our partners can handle the entire migration
+<Tip>
+  Want help with your migration?
 
-Contact [contact@twenty.com](mailto:contact@twenty.com) or explore our [Implementation Services](/user-guide/getting-started/capabilities/implementation-services).
+  - **Done for you:** [find a certified Twenty partner](https://twenty.com/partners/list?categories=SOLUTIONING&ref=docs-migrate-crm) to move your data, pipelines, and users end-to-end.
+  - **Onboarding pack:** a 4-hour guided setup with our team — [contact@twenty.com](mailto:contact@twenty.com).
+</Tip>

--- a/packages/twenty-docs/user-guide/data-migration/how-tos/migrating-from-self-hosted-to-cloud.mdx
+++ b/packages/twenty-docs/user-guide/data-migration/how-tos/migrating-from-self-hosted-to-cloud.mdx
@@ -161,5 +161,7 @@ After importing data, manually recreate:
 
 ## Need Help?
 
-For complex migrations or large datasets, contact us at [contact@twenty.com](mailto:contact@twenty.com) or explore our [Implementation Services](/user-guide/getting-started/capabilities/implementation-services).
+<Tip>
+  Migrating a large or complex workspace? [Get a certified Twenty partner](https://twenty.com/partners/list?categories=HOSTING&ref=docs-migrate-cloud) to handle the move end-to-end. *(Or loop in our team: [contact@twenty.com](mailto:contact@twenty.com).)*
+</Tip>
 

--- a/packages/twenty-docs/user-guide/getting-started/capabilities/implementation-services.mdx
+++ b/packages/twenty-docs/user-guide/getting-started/capabilities/implementation-services.mdx
@@ -13,4 +13,13 @@ Get help from our core team to set up your Twenty workspace with our 4-hour Onbo
 
 ## Implementation Partners
 
-Work with certified Twenty partners for more advanced customizations and integrations. Reach out to our team via [contact@twenty.com](mailto:contact@twenty.com) to be matched with our partners.
+Work with certified Twenty partners for advanced customizations, integrations, and dedicated implementation support.
+
+<CardGroup cols={2}>
+  <Card title="Browse certified partners" icon="magnifying-glass" href="https://twenty.com/partners/list?ref=docs-implementation-services">
+    Find a partner and reach out directly — filter by region, language, and expertise.
+  </Card>
+  <Card title="Get matched by Twenty" icon="envelope" href="mailto:contact@twenty.com">
+    Tell us what you need and we'll connect you with the right partner.
+  </Card>
+</CardGroup>

--- a/packages/twenty-docs/user-guide/permissions-access/capabilities/sso-configuration.mdx
+++ b/packages/twenty-docs/user-guide/permissions-access/capabilities/sso-configuration.mdx
@@ -103,3 +103,7 @@ If you encounter issues, contact support with:
 - Error messages received
 - Identity provider being used
 - Configuration details (without sensitive data)
+
+<Tip>
+  Need SSO configured for your organization? [Find a certified Twenty partner](https://twenty.com/partners/list?categories=SOLUTIONING&ref=docs-sso) who specializes in SSO and identity setup. *(Prefer to loop in Twenty directly? [contact@twenty.com](mailto:contact@twenty.com).)*
+</Tip>


### PR DESCRIPTION
## Summary

Adds partner-marketplace CTAs to four high-intent docs pages (enterprise + migration), routing readers to the **self-serve** partner directory (`twenty.com/partners/list`) while keeping `contact@twenty.com` as a secondary option. This upgrades pages that previously only offered the old "email us to be matched" path (or no partner path at all).

Rendered with Mintlify-native components — `<Tip>` callouts, plus a `<CardGroup>` on the Implementation Services page. No new snippet; no `docs.json`, navigation, or translation (`l/`) changes.

## Pages changed — screenshots (one per page)

> Preview locally with `npx nx run twenty-docs:dev` (localhost:3000), or use the Mintlify PR preview once it posts on this PR. Paths below are under `docs.twenty.com`.

### 1. `/user-guide/permissions-access/capabilities/sso-configuration`
`<Tip>` callout → *Find a certified Twenty partner* (Solutioning), `contact@twenty.com` as a secondary aside.

_screenshot:_
<img width="712" height="616" alt="Screenshot 2026-07-09 at 12 14 05" src="https://github.com/user-attachments/assets/e6521634-7783-466f-bfae-a4a49f64d941" />


### 2. `/user-guide/data-migration/how-tos/migrating-from-self-hosted-to-cloud`
`<Tip>` callout → *Get a certified Twenty partner* (Hosting), contact fallback.

_screenshot:_
<img width="665" height="193" alt="Screenshot 2026-07-09 at 12 14 23" src="https://github.com/user-attachments/assets/30ecb4d2-fb7e-4e0f-9355-491713290f90" />


### 3. `/user-guide/data-migration/how-tos/migrating-from-other-crms`
`<Tip>` callout → **Done for you** (partner) vs **Onboarding pack** (Twenty team).

_screenshot:_
<img width="659" height="273" alt="Screenshot 2026-07-09 at 12 14 35" src="https://github.com/user-attachments/assets/9cc5bb3e-c8be-4734-9e03-dc5b536eeeb7" />


### 4. `/user-guide/getting-started/capabilities/implementation-services`
`<CardGroup>` → **Browse certified partners** / **Get matched by Twenty**.

_screenshot:_
<img width="706" height="766" alt="Screenshot 2026-07-09 at 12 14 47" src="https://github.com/user-attachments/assets/01b69197-0f47-46fe-a40e-92c11286827e" />


## Notes for reviewers

- Links deep-link the directory via `?categories=<scope>` (verified live) and carry a `?ref=docs-*` tag.
- **Attribution caveat:** twenty.com's analytics (Cloudflare Web Analytics) is path-based, so `?ref=` is not measurable yet.
- `contact@twenty.com` intentionally kept as a secondary option.
- `mintlify validate` passes.

Opened as a draft.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/22719?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

