### PR TITLE
Fix app object nameSingular rename breaking sync on default relation …

### DIFF
--- a/packages/twenty-server/src/engine/core-modules/application/application-manifest/application-manifest-migration.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/application/application-manifest/application-manifest-migration.service.ts
@@ -1,12 +1,18 @@
 import { Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
 
 import { type Manifest } from 'twenty-shared/application';
 import { ALL_METADATA_NAME } from 'twenty-shared/metadata';
 import { isDefined } from 'twenty-shared/utils';
+import { Repository } from 'typeorm';
 
 import { ComputeApplicationManifestAllUniversalFlatEntityMapsService } from 'src/engine/core-modules/application/application-manifest/services/compute-application-manifest-all-universal-flat-entity-maps.service';
 import { buildAllFlatEntityOperationRecordByMetadataNameFromFromTo } from 'src/engine/core-modules/application/application-manifest/utils/build-all-flat-entity-operation-record-by-metadata-name-from-from-to.util';
 import { buildFromToAllUniversalFlatEntityMaps } from 'src/engine/core-modules/application/application-manifest/utils/build-from-to-all-universal-flat-entity-maps.util';
+import {
+  computeDefaultRelationFieldUniversalIdentifierTakeovers,
+  type FieldUniversalIdentifierTakeover,
+} from 'src/engine/core-modules/application/application-manifest/utils/compute-default-relation-field-universal-identifier-takeovers.util';
 import { getApplicationSubAllFlatEntityMaps } from 'src/engine/core-modules/application/application-manifest/utils/get-application-sub-all-flat-entity-maps.util';
 import {
   ApplicationException,
@@ -15,22 +21,31 @@ import {
 import { ApplicationService } from 'src/engine/core-modules/application/application.service';
 import { type FlatApplication } from 'src/engine/core-modules/application/types/flat-application.type';
 import { LoggerService } from 'src/engine/core-modules/logger/logger.service';
+import { FieldMetadataEntity } from 'src/engine/metadata-modules/field-metadata/field-metadata.entity';
+import { type AllFlatEntityMaps } from 'src/engine/metadata-modules/flat-entity/types/all-flat-entity-maps.type';
 import { findFlatEntityByUniversalIdentifier } from 'src/engine/metadata-modules/flat-entity/utils/find-flat-entity-by-universal-identifier.util';
 import { getMetadataFlatEntityMapsKey } from 'src/engine/metadata-modules/flat-entity/utils/get-metadata-flat-entity-maps-key.util';
+import { getMetadataRelatedMetadataNames } from 'src/engine/metadata-modules/flat-entity/utils/get-metadata-related-metadata-names.util';
+import { getMetadataSerializedRelationNames } from 'src/engine/metadata-modules/flat-entity/utils/get-metadata-serialized-relation-names.util';
 import { WorkspaceCacheService } from 'src/engine/workspace-cache/services/workspace-cache.service';
 import { TWENTY_STANDARD_APPLICATION } from 'src/engine/workspace-manager/twenty-standard-application/constants/twenty-standard-applications';
 import { WorkspaceMigrationBuilderException } from 'src/engine/workspace-manager/workspace-migration/exceptions/workspace-migration-builder-exception';
 import { WorkspaceMigrationValidateBuildAndRunService } from 'src/engine/workspace-manager/workspace-migration/services/workspace-migration-validate-build-and-run-service';
+import { type MetadataUniversalFlatEntityMaps } from 'src/engine/workspace-manager/workspace-migration/universal-flat-entity/types/metadata-universal-flat-entity-maps.type';
 import { WorkspaceMigration } from 'src/engine/workspace-manager/workspace-migration/workspace-migration-builder/types/workspace-migration.type';
+import { WorkspaceMigrationRunnerService } from 'src/engine/workspace-manager/workspace-migration/workspace-migration-runner/services/workspace-migration-runner.service';
 
 @Injectable()
 export class ApplicationManifestMigrationService {
   constructor(
     private readonly workspaceCacheService: WorkspaceCacheService,
     private readonly workspaceMigrationValidateBuildAndRunService: WorkspaceMigrationValidateBuildAndRunService,
+    private readonly workspaceMigrationRunnerService: WorkspaceMigrationRunnerService,
     private readonly applicationService: ApplicationService,
     private readonly computeManifestFlatEntityMapsService: ComputeApplicationManifestAllUniversalFlatEntityMapsService,
     private readonly logger: LoggerService,
+    @InjectRepository(FieldMetadataEntity)
+    private readonly fieldMetadataRepository: Repository<FieldMetadataEntity>,
   ) {}
 
   async syncPreInstallLogicFunctionFromManifest({
@@ -192,7 +207,7 @@ export class ApplicationManifestMigrationService {
     const { featureFlagsMap: _featureFlagsMap, ...existingAllFlatEntityMaps } =
       cacheResult;
 
-    const fromAllFlatEntityMaps = getApplicationSubAllFlatEntityMaps({
+    let fromAllFlatEntityMaps = getApplicationSubAllFlatEntityMaps({
       applicationIds: [ownerFlatApplication.id],
       fromAllFlatEntityMaps: existingAllFlatEntityMaps,
     });
@@ -204,6 +219,24 @@ export class ApplicationManifestMigrationService {
         now,
         workspaceId,
       });
+
+    const fieldUniversalIdentifierTakeovers =
+      computeDefaultRelationFieldUniversalIdentifierTakeovers({
+        fromFlatFieldMetadataMaps: fromAllFlatEntityMaps.flatFieldMetadataMaps,
+        // Manifest-derived maps hold universal flat entities behind the
+        // AllFlatEntityMaps type, same cast as the operation record builder.
+        toUniversalFlatFieldMetadataMaps:
+          toAllUniversalFlatEntityMaps.flatFieldMetadataMaps as unknown as MetadataUniversalFlatEntityMaps<'fieldMetadata'>,
+      });
+
+    if (fieldUniversalIdentifierTakeovers.length > 0) {
+      fromAllFlatEntityMaps =
+        await this.takeOverDefaultRelationFieldUniversalIdentifiers({
+          workspaceId,
+          ownerFlatApplication,
+          takeovers: fieldUniversalIdentifierTakeovers,
+        });
+    }
 
     const allFlatEntityOperationRecordByMetadataName =
       buildAllFlatEntityOperationRecordByMetadataNameFromFromTo({
@@ -260,6 +293,69 @@ export class ApplicationManifestMigrationService {
       workspaceMigration: validateAndBuildResult.workspaceMigration,
       hasSchemaMetadataChanged: validateAndBuildResult.hasSchemaMetadataChanged,
     };
+  }
+
+  // Reassigns the universal identifier of installed auto-provisioned reverse
+  // default relation fields to the derivation the manifest now uses, so an
+  // object rename converges through in-place field renames instead of a
+  // destroy/create pair that relation validation rejects. This runs before
+  // the migration build (dry run included) because the whole migration engine
+  // matches entities by universal identifier against the workspace cache: the
+  // reassignment is identifier bookkeeping only, changes no schema or data,
+  // and is idempotent.
+  private async takeOverDefaultRelationFieldUniversalIdentifiers({
+    workspaceId,
+    ownerFlatApplication,
+    takeovers,
+  }: {
+    workspaceId: string;
+    ownerFlatApplication: FlatApplication;
+    takeovers: FieldUniversalIdentifierTakeover[];
+  }): Promise<AllFlatEntityMaps> {
+    this.logger.log(
+      `Taking over ${takeovers.length} default relation field universal identifier(s) for application ${ownerFlatApplication.universalIdentifier}`,
+      ApplicationManifestMigrationService.name,
+    );
+
+    await this.fieldMetadataRepository.manager.transaction(
+      async (entityManager) => {
+        const transactionalFieldMetadataRepository =
+          entityManager.getRepository(FieldMetadataEntity);
+
+        for (const { fieldMetadataId, toUniversalIdentifier } of takeovers) {
+          await transactionalFieldMetadataRepository.update(
+            { id: fieldMetadataId, workspaceId },
+            { universalIdentifier: toUniversalIdentifier },
+          );
+        }
+      },
+    );
+
+    const fieldMetadataRelatedNames = [
+      'fieldMetadata',
+      ...getMetadataRelatedMetadataNames('fieldMetadata'),
+      ...getMetadataSerializedRelationNames('fieldMetadata'),
+      'index',
+    ] as const;
+    const allFlatEntityMapsKeys = [
+      ...new Set(fieldMetadataRelatedNames.map(getMetadataFlatEntityMapsKey)),
+    ];
+
+    await this.workspaceMigrationRunnerService.invalidateCache({
+      allFlatEntityMapsKeys,
+      workspaceId,
+    });
+
+    const refreshedCacheResult =
+      await this.workspaceCacheService.getOrRecompute(
+        workspaceId,
+        Object.values(ALL_METADATA_NAME).map(getMetadataFlatEntityMapsKey),
+      );
+
+    return getApplicationSubAllFlatEntityMaps({
+      applicationIds: [ownerFlatApplication.id],
+      fromAllFlatEntityMaps: refreshedCacheResult,
+    });
   }
 
   private async syncDefaultRole({

--- a/packages/twenty-server/src/engine/core-modules/application/application-manifest/application-manifest.module.ts
+++ b/packages/twenty-server/src/engine/core-modules/application/application-manifest/application-manifest.module.ts
@@ -1,4 +1,5 @@
 import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
 
 import { ApplicationModule } from 'src/engine/core-modules/application/application.module';
 import { ApplicationManifestMigrationService } from 'src/engine/core-modules/application/application-manifest/application-manifest-migration.service';
@@ -9,9 +10,11 @@ import { ApplicationVariableEntityModule } from 'src/engine/core-modules/applica
 import { FeatureFlagModule } from 'src/engine/core-modules/feature-flag/feature-flag.module';
 import { FileStorageModule } from 'src/engine/core-modules/file-storage/file-storage.module';
 import { SecretEncryptionModule } from 'src/engine/core-modules/secret-encryption/secret-encryption.module';
+import { FieldMetadataEntity } from 'src/engine/metadata-modules/field-metadata/field-metadata.entity';
 import { PermissionsModule } from 'src/engine/metadata-modules/permissions/permissions.module';
 import { WorkspaceCacheModule } from 'src/engine/workspace-cache/workspace-cache.module';
 import { WorkspaceMigrationModule } from 'src/engine/workspace-manager/workspace-migration/workspace-migration.module';
+import { WorkspaceMigrationRunnerModule } from 'src/engine/workspace-manager/workspace-migration/workspace-migration-runner/workspace-migration-runner.module';
 
 @Module({
   imports: [
@@ -22,8 +25,10 @@ import { WorkspaceMigrationModule } from 'src/engine/workspace-manager/workspace
     FileStorageModule,
     PermissionsModule,
     SecretEncryptionModule,
+    TypeOrmModule.forFeature([FieldMetadataEntity]),
     WorkspaceCacheModule,
     WorkspaceMigrationModule,
+    WorkspaceMigrationRunnerModule,
   ],
   providers: [
     ApplicationManifestMigrationService,

--- a/packages/twenty-server/src/engine/core-modules/application/application-manifest/utils/__tests__/compute-default-relation-field-universal-identifier-takeovers.util.spec.ts
+++ b/packages/twenty-server/src/engine/core-modules/application/application-manifest/utils/__tests__/compute-default-relation-field-universal-identifier-takeovers.util.spec.ts
@@ -1,0 +1,307 @@
+import { getFieldUniversalIdentifier } from 'twenty-shared/application';
+import { STANDARD_OBJECTS } from 'twenty-shared/metadata';
+import { FieldMetadataType } from 'twenty-shared/types';
+
+import { computeDefaultRelationFieldUniversalIdentifierTakeovers } from 'src/engine/core-modules/application/application-manifest/utils/compute-default-relation-field-universal-identifier-takeovers.util';
+import { type AllFlatEntityMaps } from 'src/engine/metadata-modules/flat-entity/types/all-flat-entity-maps.type';
+import { getFlatFieldMetadataMock } from 'src/engine/metadata-modules/flat-field-metadata/__mocks__/get-flat-field-metadata.mock';
+import { type FlatFieldMetadata } from 'src/engine/metadata-modules/flat-field-metadata/types/flat-field-metadata.type';
+import { type MetadataUniversalFlatEntityMaps } from 'src/engine/workspace-manager/workspace-migration/universal-flat-entity/types/metadata-universal-flat-entity-maps.type';
+
+const APPLICATION_UNIVERSAL_IDENTIFIER = '3f5b7b8e-8a6a-4b3e-9c1d-2e4f6a8b0c1d';
+const OBJECT_UNIVERSAL_IDENTIFIER = '7d9e1f2a-3b4c-4d5e-8f6a-1b2c3d4e5f6a';
+const ATTACHMENT_UNIVERSAL_IDENTIFIER =
+  STANDARD_OBJECTS.attachment.universalIdentifier;
+const REVERSE_FIELD_METADATA_ID = '9a8b7c6d-5e4f-4a3b-8c2d-1e0f9a8b7c6d';
+
+const deriveFieldUniversalIdentifier = ({
+  objectUniversalIdentifier,
+  name,
+}: {
+  objectUniversalIdentifier: string;
+  name: string;
+}) =>
+  getFieldUniversalIdentifier({
+    applicationUniversalIdentifier: APPLICATION_UNIVERSAL_IDENTIFIER,
+    objectUniversalIdentifier,
+    name,
+  });
+
+const FORWARD_FIELD_UNIVERSAL_IDENTIFIER = deriveFieldUniversalIdentifier({
+  objectUniversalIdentifier: OBJECT_UNIVERSAL_IDENTIFIER,
+  name: 'attachments',
+});
+const OLD_REVERSE_FIELD_UNIVERSAL_IDENTIFIER = deriveFieldUniversalIdentifier({
+  objectUniversalIdentifier: ATTACHMENT_UNIVERSAL_IDENTIFIER,
+  name: 'targetInitiative',
+});
+const NEW_REVERSE_FIELD_UNIVERSAL_IDENTIFIER = deriveFieldUniversalIdentifier({
+  objectUniversalIdentifier: ATTACHMENT_UNIVERSAL_IDENTIFIER,
+  name: 'targetProject',
+});
+
+const buildForwardField = ({
+  reverseFieldUniversalIdentifier,
+}: {
+  reverseFieldUniversalIdentifier: string;
+}) =>
+  getFlatFieldMetadataMock({
+    universalIdentifier: FORWARD_FIELD_UNIVERSAL_IDENTIFIER,
+    objectMetadataId: 'unused',
+    type: FieldMetadataType.RELATION,
+    name: 'attachments',
+    applicationUniversalIdentifier: APPLICATION_UNIVERSAL_IDENTIFIER,
+    objectMetadataUniversalIdentifier: OBJECT_UNIVERSAL_IDENTIFIER,
+    relationTargetFieldMetadataUniversalIdentifier:
+      reverseFieldUniversalIdentifier,
+    relationTargetObjectMetadataUniversalIdentifier:
+      ATTACHMENT_UNIVERSAL_IDENTIFIER,
+  });
+
+const buildReverseField = ({
+  universalIdentifier,
+  name,
+}: {
+  universalIdentifier: string;
+  name: string;
+}) =>
+  getFlatFieldMetadataMock({
+    id: REVERSE_FIELD_METADATA_ID,
+    universalIdentifier,
+    objectMetadataId: 'unused',
+    type: FieldMetadataType.MORPH_RELATION,
+    name,
+    applicationUniversalIdentifier: APPLICATION_UNIVERSAL_IDENTIFIER,
+    objectMetadataUniversalIdentifier: ATTACHMENT_UNIVERSAL_IDENTIFIER,
+    relationTargetFieldMetadataUniversalIdentifier:
+      FORWARD_FIELD_UNIVERSAL_IDENTIFIER,
+    relationTargetObjectMetadataUniversalIdentifier:
+      OBJECT_UNIVERSAL_IDENTIFIER,
+  });
+
+const buildFromMaps = (
+  fields: FlatFieldMetadata[],
+): AllFlatEntityMaps['flatFieldMetadataMaps'] => ({
+  byUniversalIdentifier: Object.fromEntries(
+    fields.map((field) => [field.universalIdentifier, field]),
+  ),
+  universalIdentifierById: Object.fromEntries(
+    fields.map((field) => [field.id, field.universalIdentifier]),
+  ),
+  universalIdentifiersByApplicationId: {},
+});
+
+const buildToMaps = (
+  fields: FlatFieldMetadata[],
+): MetadataUniversalFlatEntityMaps<'fieldMetadata'> =>
+  ({
+    byUniversalIdentifier: Object.fromEntries(
+      fields.map((field) => [field.universalIdentifier, field]),
+    ),
+  }) as unknown as MetadataUniversalFlatEntityMaps<'fieldMetadata'>;
+
+describe('computeDefaultRelationFieldUniversalIdentifierTakeovers', () => {
+  it('should pair the installed reverse field with the renamed manifest reverse field', () => {
+    const takeovers = computeDefaultRelationFieldUniversalIdentifierTakeovers({
+      fromFlatFieldMetadataMaps: buildFromMaps([
+        buildForwardField({
+          reverseFieldUniversalIdentifier:
+            OLD_REVERSE_FIELD_UNIVERSAL_IDENTIFIER,
+        }),
+        buildReverseField({
+          universalIdentifier: OLD_REVERSE_FIELD_UNIVERSAL_IDENTIFIER,
+          name: 'targetInitiative',
+        }),
+      ]),
+      toUniversalFlatFieldMetadataMaps: buildToMaps([
+        buildForwardField({
+          reverseFieldUniversalIdentifier:
+            NEW_REVERSE_FIELD_UNIVERSAL_IDENTIFIER,
+        }),
+        buildReverseField({
+          universalIdentifier: NEW_REVERSE_FIELD_UNIVERSAL_IDENTIFIER,
+          name: 'targetProject',
+        }),
+      ]),
+    });
+
+    expect(takeovers).toEqual([
+      {
+        fieldMetadataId: REVERSE_FIELD_METADATA_ID,
+        fromUniversalIdentifier: OLD_REVERSE_FIELD_UNIVERSAL_IDENTIFIER,
+        toUniversalIdentifier: NEW_REVERSE_FIELD_UNIVERSAL_IDENTIFIER,
+      },
+    ]);
+  });
+
+  it('should return nothing when identifiers already match', () => {
+    const fields = [
+      buildForwardField({
+        reverseFieldUniversalIdentifier: OLD_REVERSE_FIELD_UNIVERSAL_IDENTIFIER,
+      }),
+      buildReverseField({
+        universalIdentifier: OLD_REVERSE_FIELD_UNIVERSAL_IDENTIFIER,
+        name: 'targetInitiative',
+      }),
+    ];
+
+    expect(
+      computeDefaultRelationFieldUniversalIdentifierTakeovers({
+        fromFlatFieldMetadataMaps: buildFromMaps(fields),
+        toUniversalFlatFieldMetadataMaps: buildToMaps(fields),
+      }),
+    ).toEqual([]);
+  });
+
+  it('should skip reverse fields with an author-provided universal identifier', () => {
+    const authorProvidedUniversalIdentifier =
+      'aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeeeee';
+
+    expect(
+      computeDefaultRelationFieldUniversalIdentifierTakeovers({
+        fromFlatFieldMetadataMaps: buildFromMaps([
+          buildForwardField({
+            reverseFieldUniversalIdentifier:
+              OLD_REVERSE_FIELD_UNIVERSAL_IDENTIFIER,
+          }),
+          buildReverseField({
+            universalIdentifier: OLD_REVERSE_FIELD_UNIVERSAL_IDENTIFIER,
+            name: 'targetInitiative',
+          }),
+        ]),
+        toUniversalFlatFieldMetadataMaps: buildToMaps([
+          buildForwardField({
+            reverseFieldUniversalIdentifier: authorProvidedUniversalIdentifier,
+          }),
+          buildReverseField({
+            universalIdentifier: authorProvidedUniversalIdentifier,
+            name: 'targetProject',
+          }),
+        ]),
+      }),
+    ).toEqual([]);
+  });
+
+  it('should skip when the manifest still declares the installed reverse field', () => {
+    expect(
+      computeDefaultRelationFieldUniversalIdentifierTakeovers({
+        fromFlatFieldMetadataMaps: buildFromMaps([
+          buildForwardField({
+            reverseFieldUniversalIdentifier:
+              OLD_REVERSE_FIELD_UNIVERSAL_IDENTIFIER,
+          }),
+          buildReverseField({
+            universalIdentifier: OLD_REVERSE_FIELD_UNIVERSAL_IDENTIFIER,
+            name: 'targetInitiative',
+          }),
+        ]),
+        toUniversalFlatFieldMetadataMaps: buildToMaps([
+          buildForwardField({
+            reverseFieldUniversalIdentifier:
+              NEW_REVERSE_FIELD_UNIVERSAL_IDENTIFIER,
+          }),
+          buildReverseField({
+            universalIdentifier: OLD_REVERSE_FIELD_UNIVERSAL_IDENTIFIER,
+            name: 'targetInitiative',
+          }),
+          buildReverseField({
+            universalIdentifier: NEW_REVERSE_FIELD_UNIVERSAL_IDENTIFIER,
+            name: 'targetProject',
+          }),
+        ]),
+      }),
+    ).toEqual([]);
+  });
+
+  it('should skip relation fields that do not target a default relation standard object', () => {
+    const otherObjectUniversalIdentifier =
+      '1a2b3c4d-5e6f-4a7b-8c9d-0e1f2a3b4c5d';
+    const forwardUniversalIdentifier = deriveFieldUniversalIdentifier({
+      objectUniversalIdentifier: OBJECT_UNIVERSAL_IDENTIFIER,
+      name: 'children',
+    });
+    const buildCustomReverseField = (name: string) =>
+      getFlatFieldMetadataMock({
+        id: REVERSE_FIELD_METADATA_ID,
+        universalIdentifier: deriveFieldUniversalIdentifier({
+          objectUniversalIdentifier: otherObjectUniversalIdentifier,
+          name,
+        }),
+        objectMetadataId: 'unused',
+        type: FieldMetadataType.RELATION,
+        name,
+        applicationUniversalIdentifier: APPLICATION_UNIVERSAL_IDENTIFIER,
+        objectMetadataUniversalIdentifier: otherObjectUniversalIdentifier,
+        relationTargetFieldMetadataUniversalIdentifier:
+          forwardUniversalIdentifier,
+        relationTargetObjectMetadataUniversalIdentifier:
+          OBJECT_UNIVERSAL_IDENTIFIER,
+      });
+    const buildCustomForwardField = (reverseUniversalIdentifier: string) =>
+      getFlatFieldMetadataMock({
+        universalIdentifier: forwardUniversalIdentifier,
+        objectMetadataId: 'unused',
+        type: FieldMetadataType.RELATION,
+        name: 'children',
+        applicationUniversalIdentifier: APPLICATION_UNIVERSAL_IDENTIFIER,
+        objectMetadataUniversalIdentifier: OBJECT_UNIVERSAL_IDENTIFIER,
+        relationTargetFieldMetadataUniversalIdentifier:
+          reverseUniversalIdentifier,
+        relationTargetObjectMetadataUniversalIdentifier:
+          otherObjectUniversalIdentifier,
+      });
+
+    expect(
+      computeDefaultRelationFieldUniversalIdentifierTakeovers({
+        fromFlatFieldMetadataMaps: buildFromMaps([
+          buildCustomForwardField(
+            buildCustomReverseField('parentInitiative').universalIdentifier,
+          ),
+          buildCustomReverseField('parentInitiative'),
+        ]),
+        toUniversalFlatFieldMetadataMaps: buildToMaps([
+          buildCustomForwardField(
+            buildCustomReverseField('parentProject').universalIdentifier,
+          ),
+          buildCustomReverseField('parentProject'),
+        ]),
+      }),
+    ).toEqual([]);
+  });
+
+  it('should pair structurally when the installed identifier no longer matches its own name derivation', () => {
+    // State left by a takeover whose follow-up migration did not complete:
+    // the row still carries the old name but already holds the identifier
+    // derived from the new one. Reverting the manifest must converge back.
+    const takeovers = computeDefaultRelationFieldUniversalIdentifierTakeovers({
+      fromFlatFieldMetadataMaps: buildFromMaps([
+        buildForwardField({
+          reverseFieldUniversalIdentifier:
+            NEW_REVERSE_FIELD_UNIVERSAL_IDENTIFIER,
+        }),
+        buildReverseField({
+          universalIdentifier: NEW_REVERSE_FIELD_UNIVERSAL_IDENTIFIER,
+          name: 'targetInitiative',
+        }),
+      ]),
+      toUniversalFlatFieldMetadataMaps: buildToMaps([
+        buildForwardField({
+          reverseFieldUniversalIdentifier:
+            OLD_REVERSE_FIELD_UNIVERSAL_IDENTIFIER,
+        }),
+        buildReverseField({
+          universalIdentifier: OLD_REVERSE_FIELD_UNIVERSAL_IDENTIFIER,
+          name: 'targetInitiative',
+        }),
+      ]),
+    });
+
+    expect(takeovers).toEqual([
+      {
+        fieldMetadataId: REVERSE_FIELD_METADATA_ID,
+        fromUniversalIdentifier: NEW_REVERSE_FIELD_UNIVERSAL_IDENTIFIER,
+        toUniversalIdentifier: OLD_REVERSE_FIELD_UNIVERSAL_IDENTIFIER,
+      },
+    ]);
+  });
+});

--- a/packages/twenty-server/src/engine/core-modules/application/application-manifest/utils/compute-default-relation-field-universal-identifier-takeovers.util.ts
+++ b/packages/twenty-server/src/engine/core-modules/application/application-manifest/utils/compute-default-relation-field-universal-identifier-takeovers.util.ts
@@ -1,0 +1,181 @@
+import { getFieldUniversalIdentifier } from 'twenty-shared/application';
+import { STANDARD_OBJECTS } from 'twenty-shared/metadata';
+import { isDefined } from 'twenty-shared/utils';
+
+import { type AllFlatEntityMaps } from 'src/engine/metadata-modules/flat-entity/types/all-flat-entity-maps.type';
+import { isMorphOrRelationFieldMetadataType } from 'src/engine/utils/is-morph-or-relation-field-metadata-type.util';
+import { type MetadataUniversalFlatEntityMaps } from 'src/engine/workspace-manager/workspace-migration/universal-flat-entity/types/metadata-universal-flat-entity-maps.type';
+
+export type FieldUniversalIdentifierTakeover = {
+  fieldMetadataId: string;
+  fromUniversalIdentifier: string;
+  toUniversalIdentifier: string;
+};
+
+// Reverse default relation fields (target<NameSingular> on the four standard
+// relation objects) are auto-provisioned by the SDK with a universal
+// identifier derived from their name. Renaming an object therefore renames
+// those fields AND changes their derived identifiers, so identifier-based
+// matching alone would destroy/create them instead of renaming in place.
+const DEFAULT_RELATION_FORWARD_FIELD_NAME_BY_STANDARD_OBJECT_UNIVERSAL_IDENTIFIER: Record<
+  string,
+  string
+> = {
+  [STANDARD_OBJECTS.timelineActivity.universalIdentifier]: 'timelineActivities',
+  [STANDARD_OBJECTS.attachment.universalIdentifier]: 'attachments',
+  [STANDARD_OBJECTS.noteTarget.universalIdentifier]: 'noteTargets',
+  [STANDARD_OBJECTS.taskTarget.universalIdentifier]: 'taskTargets',
+};
+
+// Detects manifest reverse default relation fields whose universal identifier
+// changed only because the owning object was renamed, and pairs them with the
+// installed row they logically are. The pairing is structural: both sides must
+// hang off the same auto-provisioned forward field (whose identifier is
+// derived from the object universal identifier and a constant name, hence
+// stable across renames). The matched installed rows can then take over the
+// new derived identifier so the sync converges through an in-place rename
+// instead of a destroy/create that validation rejects.
+export const computeDefaultRelationFieldUniversalIdentifierTakeovers = ({
+  fromFlatFieldMetadataMaps,
+  toUniversalFlatFieldMetadataMaps,
+}: {
+  fromFlatFieldMetadataMaps: AllFlatEntityMaps['flatFieldMetadataMaps'];
+  toUniversalFlatFieldMetadataMaps: MetadataUniversalFlatEntityMaps<'fieldMetadata'>;
+}): FieldUniversalIdentifierTakeover[] => {
+  const takeovers: FieldUniversalIdentifierTakeover[] = [];
+
+  for (const toField of Object.values(
+    toUniversalFlatFieldMetadataMaps.byUniversalIdentifier,
+  )) {
+    if (!isDefined(toField)) {
+      continue;
+    }
+
+    // Already matched by universal identifier: regular update flow applies.
+    if (
+      isDefined(
+        fromFlatFieldMetadataMaps.byUniversalIdentifier[
+          toField.universalIdentifier
+        ],
+      )
+    ) {
+      continue;
+    }
+
+    if (!isMorphOrRelationFieldMetadataType(toField.type)) {
+      continue;
+    }
+
+    const expectedForwardFieldName =
+      DEFAULT_RELATION_FORWARD_FIELD_NAME_BY_STANDARD_OBJECT_UNIVERSAL_IDENTIFIER[
+        toField.objectMetadataUniversalIdentifier
+      ];
+
+    if (!isDefined(expectedForwardFieldName)) {
+      continue;
+    }
+
+    // Only auto-provisioned reverse fields are taken over: their identifier
+    // must be the deterministic derivation from their own name. An
+    // author-provided identifier keeps the regular destroy/create semantics.
+    const derivedToUniversalIdentifier = getFieldUniversalIdentifier({
+      applicationUniversalIdentifier: toField.applicationUniversalIdentifier,
+      objectUniversalIdentifier: toField.objectMetadataUniversalIdentifier,
+      name: toField.name,
+    });
+
+    if (toField.universalIdentifier !== derivedToUniversalIdentifier) {
+      continue;
+    }
+
+    const forwardFieldUniversalIdentifier =
+      toField.relationTargetFieldMetadataUniversalIdentifier;
+
+    if (!isDefined(forwardFieldUniversalIdentifier)) {
+      continue;
+    }
+
+    const toForwardField =
+      toUniversalFlatFieldMetadataMaps.byUniversalIdentifier[
+        forwardFieldUniversalIdentifier
+      ];
+    const fromForwardField =
+      fromFlatFieldMetadataMaps.byUniversalIdentifier[
+        forwardFieldUniversalIdentifier
+      ];
+
+    // The forward field exists on both sides under the same identifier, which
+    // is derived from the object universal identifier: this proves the object
+    // itself kept its identity and only its name changed.
+    if (!isDefined(toForwardField) || !isDefined(fromForwardField)) {
+      continue;
+    }
+
+    if (
+      toForwardField.name !== expectedForwardFieldName ||
+      fromForwardField.name !== expectedForwardFieldName
+    ) {
+      continue;
+    }
+
+    const derivedForwardUniversalIdentifier = getFieldUniversalIdentifier({
+      applicationUniversalIdentifier:
+        toForwardField.applicationUniversalIdentifier,
+      objectUniversalIdentifier:
+        toForwardField.objectMetadataUniversalIdentifier,
+      name: toForwardField.name,
+    });
+
+    if (forwardFieldUniversalIdentifier !== derivedForwardUniversalIdentifier) {
+      continue;
+    }
+
+    // The installed counterpart is whichever field the installed forward
+    // field still points back to, whatever identifier it currently carries.
+    const fromReverseFieldUniversalIdentifier =
+      fromForwardField.relationTargetFieldMetadataUniversalIdentifier;
+
+    if (!isDefined(fromReverseFieldUniversalIdentifier)) {
+      continue;
+    }
+
+    const fromReverseField =
+      fromFlatFieldMetadataMaps.byUniversalIdentifier[
+        fromReverseFieldUniversalIdentifier
+      ];
+
+    if (!isDefined(fromReverseField)) {
+      continue;
+    }
+
+    // Still declared by the manifest under its current identifier: not a
+    // rename of that field.
+    if (
+      isDefined(
+        toUniversalFlatFieldMetadataMaps.byUniversalIdentifier[
+          fromReverseFieldUniversalIdentifier
+        ],
+      )
+    ) {
+      continue;
+    }
+
+    if (
+      fromReverseField.type !== toField.type ||
+      fromReverseField.objectMetadataUniversalIdentifier !==
+        toField.objectMetadataUniversalIdentifier ||
+      fromReverseField.relationTargetFieldMetadataUniversalIdentifier !==
+        forwardFieldUniversalIdentifier
+    ) {
+      continue;
+    }
+
+    takeovers.push({
+      fieldMetadataId: fromReverseField.id,
+      fromUniversalIdentifier: fromReverseFieldUniversalIdentifier,
+      toUniversalIdentifier: toField.universalIdentifier,
+    });
+  }
+
+  return takeovers;
+};

--- a/packages/twenty-server/test/integration/metadata/suites/application/successful-sync-application-object-rename-default-relations.integration-spec.ts
+++ b/packages/twenty-server/test/integration/metadata/suites/application/successful-sync-application-object-rename-default-relations.integration-spec.ts
@@ -1,0 +1,328 @@
+import { buildBaseManifest } from 'test/integration/metadata/suites/application/utils/build-base-manifest.util';
+import { buildDefaultObjectManifest } from 'test/integration/metadata/suites/application/utils/build-default-object-manifest.util';
+import { cleanupApplicationAndAppRegistration } from 'test/integration/metadata/suites/application/utils/cleanup-application-and-app-registration.util';
+import { setupApplicationForSync } from 'test/integration/metadata/suites/application/utils/setup-application-for-sync.util';
+import { syncApplication } from 'test/integration/metadata/suites/application/utils/sync-application.util';
+import { findManyFieldsMetadata } from 'test/integration/metadata/suites/field-metadata/utils/find-many-fields-metadata.util';
+import { findManyObjectMetadata } from 'test/integration/metadata/suites/object-metadata/utils/find-many-object-metadata.util';
+import {
+  getFieldUniversalIdentifier,
+  type FieldManifest,
+  type Manifest,
+  type ObjectFieldManifest,
+} from 'twenty-shared/application';
+import { STANDARD_OBJECTS } from 'twenty-shared/metadata';
+import {
+  FieldMetadataType,
+  RelationOnDeleteAction,
+  RelationType,
+} from 'twenty-shared/types';
+import { capitalize } from 'twenty-shared/utils';
+import { v4 as uuidv4 } from 'uuid';
+
+const TEST_APP_ID = uuidv4();
+const TEST_ROLE_ID = uuidv4();
+const TEST_OBJECT_UNIVERSAL_IDENTIFIER = uuidv4();
+
+// Mirrors the SDK's default standard-relation provisioning
+// (packages/twenty-sdk/src/cli/utilities/build/manifest/utils/get-default-relation-object-fields.ts):
+// forward fields keep constant names while reverse field names and their
+// derived universal identifiers depend on the object nameSingular.
+const DEFAULT_RELATION_CONFIGS = [
+  {
+    fieldName: 'timelineActivities',
+    label: 'Timeline Activities',
+    standardObjectKey: 'timelineActivity',
+  },
+  {
+    fieldName: 'attachments',
+    label: 'Attachments',
+    standardObjectKey: 'attachment',
+  },
+  {
+    fieldName: 'noteTargets',
+    label: 'Note Targets',
+    standardObjectKey: 'noteTarget',
+  },
+  {
+    fieldName: 'taskTargets',
+    label: 'Task Targets',
+    standardObjectKey: 'taskTarget',
+  },
+] as const;
+
+const computeReverseFieldUniversalIdentifier = ({
+  standardObjectKey,
+  nameSingular,
+}: {
+  standardObjectKey: (typeof DEFAULT_RELATION_CONFIGS)[number]['standardObjectKey'];
+  nameSingular: string;
+}) =>
+  getFieldUniversalIdentifier({
+    applicationUniversalIdentifier: TEST_APP_ID,
+    objectUniversalIdentifier:
+      STANDARD_OBJECTS[standardObjectKey].universalIdentifier,
+    name: `target${capitalize(nameSingular)}`,
+  });
+
+const buildDefaultRelationManifestFields = (
+  nameSingular: string,
+): { objectFields: ObjectFieldManifest[]; fields: FieldManifest[] } => {
+  const objectFields: ObjectFieldManifest[] = [];
+  const fields: FieldManifest[] = [];
+
+  for (const config of DEFAULT_RELATION_CONFIGS) {
+    const standardObject = STANDARD_OBJECTS[config.standardObjectKey];
+    const targetFieldName = `target${capitalize(nameSingular)}`;
+
+    const forwardFieldUniversalIdentifier = getFieldUniversalIdentifier({
+      applicationUniversalIdentifier: TEST_APP_ID,
+      objectUniversalIdentifier: TEST_OBJECT_UNIVERSAL_IDENTIFIER,
+      name: config.fieldName,
+    });
+
+    const reverseFieldUniversalIdentifier =
+      computeReverseFieldUniversalIdentifier({
+        standardObjectKey: config.standardObjectKey,
+        nameSingular,
+      });
+
+    objectFields.push({
+      universalIdentifier: forwardFieldUniversalIdentifier,
+      type: FieldMetadataType.RELATION,
+      name: config.fieldName,
+      label: config.label,
+      icon: 'IconBuildingSkyscraper',
+      isNullable: true,
+      universalSettings: { relationType: RelationType.ONE_TO_MANY },
+      relationTargetFieldMetadataUniversalIdentifier:
+        reverseFieldUniversalIdentifier,
+      relationTargetObjectMetadataUniversalIdentifier:
+        standardObject.universalIdentifier,
+    });
+
+    fields.push({
+      universalIdentifier: reverseFieldUniversalIdentifier,
+      type: FieldMetadataType.MORPH_RELATION,
+      name: targetFieldName,
+      label: capitalize(nameSingular),
+      icon: 'IconBuildingSkyscraper',
+      isNullable: true,
+      morphId: standardObject.morphIds.targetMorphId.morphId,
+      universalSettings: {
+        relationType: RelationType.MANY_TO_ONE,
+        onDelete: RelationOnDeleteAction.SET_NULL,
+        joinColumnName: `target${capitalize(nameSingular)}Id`,
+      },
+      objectUniversalIdentifier: standardObject.universalIdentifier,
+      relationTargetFieldMetadataUniversalIdentifier:
+        forwardFieldUniversalIdentifier,
+      relationTargetObjectMetadataUniversalIdentifier:
+        TEST_OBJECT_UNIVERSAL_IDENTIFIER,
+    });
+  }
+
+  return { objectFields, fields };
+};
+
+const buildManifestForNameSingular = (nameSingular: string): Manifest => {
+  const { objectFields, fields } =
+    buildDefaultRelationManifestFields(nameSingular);
+
+  const objectManifest = buildDefaultObjectManifest({
+    applicationUniversalIdentifier: TEST_APP_ID,
+    universalIdentifier: TEST_OBJECT_UNIVERSAL_IDENTIFIER,
+    nameSingular,
+    namePlural: `${nameSingular}s`,
+    labelSingular: capitalize(nameSingular),
+    labelPlural: `${capitalize(nameSingular)}s`,
+    description: 'Object used to test renames with default relations',
+    icon: 'IconTag',
+    additionalFields: objectFields,
+  });
+
+  return buildBaseManifest({
+    appId: TEST_APP_ID,
+    roleId: TEST_ROLE_ID,
+    overrides: { objects: [objectManifest], fields },
+  });
+};
+
+type FetchedField = {
+  id: string;
+  name: string;
+  universalIdentifier: string;
+};
+
+const standardObjectIdByUniversalIdentifier = new Map<string, string>();
+
+const findStandardObjectFields = async (
+  objectUniversalIdentifier: string,
+): Promise<FetchedField[]> => {
+  if (standardObjectIdByUniversalIdentifier.size === 0) {
+    const { objects } = await findManyObjectMetadata({
+      input: {
+        filter: {},
+        paging: { first: 1000 },
+      },
+      gqlFields: 'id universalIdentifier',
+      expectToFail: false,
+    });
+
+    for (const object of objects) {
+      standardObjectIdByUniversalIdentifier.set(
+        object.universalIdentifier,
+        object.id,
+      );
+    }
+  }
+
+  const objectMetadataId = standardObjectIdByUniversalIdentifier.get(
+    objectUniversalIdentifier,
+  );
+
+  expect(objectMetadataId).toBeDefined();
+
+  const { fields } = await findManyFieldsMetadata({
+    input: {
+      filter: { objectMetadataId: { eq: objectMetadataId } },
+      paging: { first: 1000 },
+    },
+    gqlFields: 'id name universalIdentifier',
+    expectToFail: false,
+  });
+
+  return fields.map((edge: { node: FetchedField }) => edge.node);
+};
+
+describe('Sync application object rename with default relations', () => {
+  beforeEach(async () => {
+    await setupApplicationForSync({
+      applicationUniversalIdentifier: TEST_APP_ID,
+      name: 'Object Rename App',
+      description: 'App for testing object rename with default relations',
+      sourcePath: 'test-object-rename-default-relations',
+    });
+  }, 60000);
+
+  afterEach(async () => {
+    await cleanupApplicationAndAppRegistration({
+      applicationUniversalIdentifier: TEST_APP_ID,
+    });
+  });
+
+  it('should rename the reverse default relation fields in place when the object nameSingular changes', async () => {
+    await syncApplication({
+      manifest: buildManifestForNameSingular('initiative'),
+      expectToFail: false,
+    });
+
+    const reverseFieldIdsBeforeRename: Record<string, string> = {};
+
+    for (const config of DEFAULT_RELATION_CONFIGS) {
+      const standardObjectFields = await findStandardObjectFields(
+        STANDARD_OBJECTS[config.standardObjectKey].universalIdentifier,
+      );
+
+      const reverseField = standardObjectFields.find(
+        (field) => field.name === 'targetInitiative',
+      );
+
+      expect(reverseField).toBeDefined();
+      expect(reverseField?.universalIdentifier).toBe(
+        computeReverseFieldUniversalIdentifier({
+          standardObjectKey: config.standardObjectKey,
+          nameSingular: 'initiative',
+        }),
+      );
+
+      reverseFieldIdsBeforeRename[config.standardObjectKey] = reverseField!.id;
+    }
+
+    await syncApplication({
+      manifest: buildManifestForNameSingular('project'),
+      expectToFail: false,
+    });
+
+    for (const config of DEFAULT_RELATION_CONFIGS) {
+      const standardObjectFields = await findStandardObjectFields(
+        STANDARD_OBJECTS[config.standardObjectKey].universalIdentifier,
+      );
+
+      const renamedReverseField = standardObjectFields.find(
+        (field) => field.name === 'targetProject',
+      );
+
+      expect(renamedReverseField).toBeDefined();
+      // The same metadata id proves the reverse field was renamed in place
+      // and took over the new derived identifier, not dropped and recreated.
+      expect(renamedReverseField?.id).toBe(
+        reverseFieldIdsBeforeRename[config.standardObjectKey],
+      );
+      expect(renamedReverseField?.universalIdentifier).toBe(
+        computeReverseFieldUniversalIdentifier({
+          standardObjectKey: config.standardObjectKey,
+          nameSingular: 'project',
+        }),
+      );
+
+      expect(
+        standardObjectFields.find((field) => field.name === 'targetInitiative'),
+      ).toBeUndefined();
+    }
+  }, 120000);
+
+  it('should compute a rename plan on dry run without touching the reverse default relation fields', async () => {
+    await syncApplication({
+      manifest: buildManifestForNameSingular('initiative'),
+      expectToFail: false,
+    });
+
+    const { data } = await syncApplication({
+      manifest: buildManifestForNameSingular('project'),
+      dryRun: true,
+      expectToFail: false,
+    });
+
+    const actions = data?.syncApplication.actions as {
+      type: string;
+      metadataName: string;
+    }[];
+
+    expect(actions).toBeDefined();
+    expect(
+      actions.filter(
+        (action) =>
+          action.metadataName === 'fieldMetadata' &&
+          (action.type === 'create' || action.type === 'delete'),
+      ),
+    ).toEqual([]);
+
+    // The dry run must leave the installed reverse fields readable under the
+    // old name so the subsequent real sync still converges.
+    for (const config of DEFAULT_RELATION_CONFIGS) {
+      const standardObjectFields = await findStandardObjectFields(
+        STANDARD_OBJECTS[config.standardObjectKey].universalIdentifier,
+      );
+
+      expect(
+        standardObjectFields.find((field) => field.name === 'targetInitiative'),
+      ).toBeDefined();
+    }
+
+    await syncApplication({
+      manifest: buildManifestForNameSingular('project'),
+      expectToFail: false,
+    });
+
+    for (const config of DEFAULT_RELATION_CONFIGS) {
+      const standardObjectFields = await findStandardObjectFields(
+        STANDARD_OBJECTS[config.standardObjectKey].universalIdentifier,
+      );
+
+      expect(
+        standardObjectFields.find((field) => field.name === 'targetProject'),
+      ).toBeDefined();
+    }
+  }, 120000);
+});


### PR DESCRIPTION
…fields

Since deterministic field universal identifiers (#22565), the SDK derives the reverse default relation field identifiers (target<NameSingular> on attachment, noteTarget, taskTarget and timelineActivity) from the field name. Renaming an object's nameSingular changes both the reverse field names and their derived identifiers, so identifier-based sync matching tried to create the new pairs alongside the orphaned installed ones and relation validation rejected the migration (INVALID_FIELD_INPUT / FIELD_METADATA_NOT_FOUND), making the rename effectively unsupported.

Manifest sync now pairs those reverse fields structurally through their auto-provisioned forward field (attachments, noteTargets, taskTargets, timelineActivities), whose identifier is derived from the object universal identifier and a constant name and is therefore stable across renames. When the object kept its universal identifier, the installed reverse rows take over the newly derived identifiers (same ownership model as the 2.19 backfill) before the migration is built, so the sync converges through in-place renames instead of a destroy/create pair.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/22740?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

