### PR TITLE
fix(workflow): valid JSON for HTTP request body variables + logic function input inference

### DIFF
--- a/packages/twenty-front/src/modules/workflow/workflow-steps/workflow-actions/http-request-action/hooks/useTestHttpRequest.ts
+++ b/packages/twenty-front/src/modules/workflow/workflow-steps/workflow-actions/http-request-action/hooks/useTestHttpRequest.ts
@@ -11,7 +11,13 @@ import { useMutation } from '@apollo/client/react';
 import { t } from '@lingui/core/macro';
 import { isObject, isString } from '@sniptt/guards';
 import { useState } from 'react';
-import { isDefined, parseJson, resolveInput } from 'twenty-shared/utils';
+import {
+  isDefined,
+  parseJson,
+  resolveInput,
+  resolveJsonBodyVariables,
+} from 'twenty-shared/utils';
+import { CONTENT_TYPE_VALUES_HTTP_REQUEST } from 'twenty-shared/workflow';
 import {
   type TestHttpRequestInput,
   type TestHttpRequestMutation,
@@ -76,10 +82,17 @@ export const useTestHttpRequest = (actionId: string) => {
         httpRequestFormData.headers,
         nestedVariableContext,
       );
-      const substitutedBodyRaw = resolveInput(
-        httpRequestFormData.body,
-        nestedVariableContext,
-      );
+      const isJsonBody =
+        isString(httpRequestFormData.body) &&
+        httpRequestFormData.headers?.['content-type'] ===
+          CONTENT_TYPE_VALUES_HTTP_REQUEST.rawJson;
+
+      const substitutedBodyRaw = isJsonBody
+        ? resolveJsonBodyVariables(
+            httpRequestFormData.body as string,
+            nestedVariableContext,
+          )
+        : resolveInput(httpRequestFormData.body, nestedVariableContext);
 
       const substitutedBody: HttpRequestBody | string | undefined =
         isString(substitutedBodyRaw) ||

--- a/packages/twenty-server/src/modules/workflow/workflow-executor/workflow-actions/http-request/__tests__/http-request.workflow-action.spec.ts
+++ b/packages/twenty-server/src/modules/workflow/workflow-executor/workflow-actions/http-request/__tests__/http-request.workflow-action.spec.ts
@@ -78,6 +78,34 @@ describe('HttpRequestWorkflowAction', () => {
     );
   });
 
+  it('escapes special characters when resolving variables in a JSON body', async () => {
+    await action.execute({
+      currentStepId: 'step-1',
+      steps: [
+        buildHttpRequestStep({
+          url: 'https://api.example.com/inbound',
+          method: 'POST',
+          headers: { 'content-type': 'application/json' },
+          body: '{\n  "subject": "{{trigger.subject}}",\n  "body": "{{trigger.text}}"\n}',
+        }),
+      ],
+      context: {
+        trigger: {
+          subject: 'Say "hello"',
+          text: 'line 1\nline 2',
+        },
+      },
+      runInfo: { workspaceId: 'workspace-1', workflowRunId: 'run-1' },
+    });
+
+    const forwardedBody = mockHttpTool.execute.mock.calls[0][0].body as string;
+
+    expect(JSON.parse(forwardedBody)).toEqual({
+      subject: 'Say "hello"',
+      body: 'line 1\nline 2',
+    });
+  });
+
   it('persists an HTTP_REQUEST step log', async () => {
     await action.execute({
       currentStepId: 'step-1',

--- a/packages/twenty-server/src/modules/workflow/workflow-executor/workflow-actions/http-request/http-request.workflow-action.ts
+++ b/packages/twenty-server/src/modules/workflow/workflow-executor/workflow-actions/http-request/http-request.workflow-action.ts
@@ -1,6 +1,10 @@
 import { Injectable } from '@nestjs/common';
 
-import { type WorkflowRunStepLog } from 'twenty-shared/workflow';
+import { resolveJsonBodyVariables } from 'twenty-shared/utils';
+import {
+  CONTENT_TYPE_VALUES_HTTP_REQUEST,
+  type WorkflowRunStepLog,
+} from 'twenty-shared/workflow';
 
 import { HttpTool } from 'src/engine/core-modules/tool/tools/http-tool/http-tool';
 import { type ToolOutput } from 'src/engine/core-modules/tool/types/tool-output.type';
@@ -27,6 +31,24 @@ export class HttpRequestWorkflowAction extends ToolBackedWorkflowAction<Workflow
 
   protected getTool(): Tool {
     return this.httpTool;
+  }
+
+  protected override async preprocessInput(
+    rawInput: WorkflowHttpRequestActionInput,
+    context: Record<string, unknown>,
+  ): Promise<WorkflowHttpRequestActionInput> {
+    if (
+      typeof rawInput.body !== 'string' ||
+      rawInput.headers?.['content-type'] !==
+        CONTENT_TYPE_VALUES_HTTP_REQUEST.rawJson
+    ) {
+      return rawInput;
+    }
+
+    return {
+      ...rawInput,
+      body: resolveJsonBodyVariables(rawInput.body, context),
+    };
   }
 
   protected assertStep(step: WorkflowAction): void {

--- a/packages/twenty-shared/src/logic-function/__tests__/get-function-input-schema.test.ts
+++ b/packages/twenty-shared/src/logic-function/__tests__/get-function-input-schema.test.ts
@@ -159,6 +159,53 @@ describe('getFunctionInputSchema', () => {
     ]);
   });
 
+  it('should extract properties from an untyped object destructuring parameter', () => {
+    const fileContent = `
+        export const main = async ({
+          toAddress,
+          subject,
+          body,
+          messageId,
+          messageThreadId,
+        }) => {
+          return {};
+        };
+      `;
+    const result = getFunctionInputSchema(fileContent);
+
+    expect(result).toEqual([
+      {
+        type: 'object',
+        properties: {
+          toAddress: {},
+          subject: {},
+          body: {},
+          messageId: {},
+          messageThreadId: {},
+        },
+      },
+    ]);
+  });
+
+  it('should use the source property name and skip rest elements when destructuring', () => {
+    const fileContent = `
+        export const main = async ({ a: renamedA, b, ...rest }) => {
+          return {};
+        };
+      `;
+    const result = getFunctionInputSchema(fileContent);
+
+    expect(result).toEqual([
+      {
+        type: 'object',
+        properties: {
+          a: {},
+          b: {},
+        },
+      },
+    ]);
+  });
+
   it('should analyze a complex function correctly', () => {
     const fileContent = `
         function testFunction(

--- a/packages/twenty-shared/src/logic-function/get-function-input-schema.ts
+++ b/packages/twenty-shared/src/logic-function/get-function-input-schema.ts
@@ -1,12 +1,14 @@
 import {
   type ArrayTypeNode,
   type ArrowFunction,
+  type BindingElement,
   createSourceFile,
   type FunctionDeclaration,
   type FunctionLikeDeclaration,
   type Identifier,
   type LiteralTypeNode,
   type Node,
+  type ObjectBindingPattern,
   type PropertySignature,
   ScriptTarget,
   type StringLiteral,
@@ -130,6 +132,26 @@ const getTypeString = (typeNode: TypeNode): InputJsonSchema => {
   }
 };
 
+const getObjectBindingPatternSchema = (
+  bindingPattern: ObjectBindingPattern,
+): InputJsonSchema => {
+  const properties: InputJsonSchema['properties'] = {};
+
+  bindingPattern.elements.forEach((element: BindingElement) => {
+    if (isDefined(element.dotDotDotToken)) {
+      return;
+    }
+
+    const propertyNameNode = element.propertyName ?? element.name;
+
+    if (propertyNameNode.kind === SyntaxKind.Identifier) {
+      properties[(propertyNameNode as Identifier).text] = {};
+    }
+  });
+
+  return { type: 'object', properties };
+};
+
 const computeFunctionParameters = (
   funcNode: FunctionDeclaration | FunctionLikeDeclaration | ArrowFunction,
   schema: InputJsonSchema[],
@@ -141,9 +163,16 @@ const computeFunctionParameters = (
 
     if (isDefined(typeNode)) {
       return [...updatedSchema, getTypeString(typeNode)];
-    } else {
-      return [...updatedSchema, {}];
     }
+
+    if (param.name.kind === SyntaxKind.ObjectBindingPattern) {
+      return [
+        ...updatedSchema,
+        getObjectBindingPatternSchema(param.name as ObjectBindingPattern),
+      ];
+    }
+
+    return [...updatedSchema, {}];
   }, schema);
 };
 

--- a/packages/twenty-shared/src/utils/__tests__/json-body-variable-resolver.test.ts
+++ b/packages/twenty-shared/src/utils/__tests__/json-body-variable-resolver.test.ts
@@ -54,6 +54,45 @@ describe('resolveJsonBodyVariables', () => {
     expect(JSON.parse(result)).toEqual({ path: 'C:\\Users\\john' });
   });
 
+  it('should escape tabs and control characters coming from resolved values', () => {
+    const contextWithControlChars = {
+      trigger: { text: 'col1\tcol2\r\nrow2' },
+    };
+
+    const body = '{"text":"{{trigger.text}}"}';
+
+    const result = resolveJsonBodyVariables(body, contextWithControlChars);
+
+    expect(JSON.parse(result)).toEqual({ text: 'col1\tcol2\r\nrow2' });
+  });
+
+  it('should preserve values byte-for-byte after a JSON round-trip', () => {
+    const contextWithMixedSpecialChars = {
+      trigger: { text: 'Quote " tab \t newline \n backslash \\ end' },
+    };
+
+    const body = '{"text":"{{trigger.text}}"}';
+
+    const result = resolveJsonBodyVariables(body, contextWithMixedSpecialChars);
+
+    expect(JSON.parse(result).text).toBe(
+      'Quote " tab \t newline \n backslash \\ end',
+    );
+  });
+
+  it('should preserve boolean type when used outside of a string literal', () => {
+    const contextWithBoolean = {
+      trigger: { active: true },
+    };
+
+    const body = '{"active":{{trigger.active}}}';
+
+    const result = resolveJsonBodyVariables(body, contextWithBoolean);
+
+    expect(result).toBe('{"active":true}');
+    expect(JSON.parse(result)).toEqual({ active: true });
+  });
+
   it('should keep the JSON valid for multiline pretty-printed bodies', () => {
     const contextWithSpecialChars = {
       trigger: {

--- a/packages/twenty-shared/src/utils/__tests__/json-body-variable-resolver.test.ts
+++ b/packages/twenty-shared/src/utils/__tests__/json-body-variable-resolver.test.ts
@@ -1,0 +1,139 @@
+import { resolveJsonBodyVariables } from '../json-body-variable-resolver';
+
+describe('resolveJsonBodyVariables', () => {
+  const context = {
+    trigger: {
+      handle: 'john@example.com',
+      subject: 'Hello',
+      count: 42,
+    },
+  };
+
+  it('should resolve variables inside JSON string values', () => {
+    const body = '{"toAddress":"{{trigger.handle}}"}';
+
+    const result = resolveJsonBodyVariables(body, context);
+
+    expect(result).toBe('{"toAddress":"john@example.com"}');
+    expect(JSON.parse(result)).toEqual({ toAddress: 'john@example.com' });
+  });
+
+  it('should escape double quotes coming from resolved values', () => {
+    const contextWithQuotes = {
+      trigger: { subject: 'Say "hello" now' },
+    };
+
+    const body = '{"subject":"{{trigger.subject}}"}';
+
+    const result = resolveJsonBodyVariables(body, contextWithQuotes);
+
+    expect(JSON.parse(result)).toEqual({ subject: 'Say "hello" now' });
+  });
+
+  it('should escape newlines coming from resolved values', () => {
+    const contextWithNewlines = {
+      trigger: { text: 'line 1\nline 2' },
+    };
+
+    const body = '{"body":"{{trigger.text}}"}';
+
+    const result = resolveJsonBodyVariables(body, contextWithNewlines);
+
+    expect(JSON.parse(result)).toEqual({ body: 'line 1\nline 2' });
+  });
+
+  it('should escape backslashes coming from resolved values', () => {
+    const contextWithBackslash = {
+      trigger: { path: 'C:\\Users\\john' },
+    };
+
+    const body = '{"path":"{{trigger.path}}"}';
+
+    const result = resolveJsonBodyVariables(body, contextWithBackslash);
+
+    expect(JSON.parse(result)).toEqual({ path: 'C:\\Users\\john' });
+  });
+
+  it('should keep the JSON valid for multiline pretty-printed bodies', () => {
+    const contextWithSpecialChars = {
+      trigger: {
+        handle: 'john@example.com',
+        subject: 'Contains "quotes" and \\ backslash',
+        text: 'Multi\nline\nbody',
+      },
+    };
+
+    const body = `{
+  "toAddress": "{{trigger.handle}}",
+  "subject": "{{trigger.subject}}",
+  "body": "{{trigger.text}}"
+}`;
+
+    const result = resolveJsonBodyVariables(body, contextWithSpecialChars);
+
+    expect(JSON.parse(result)).toEqual({
+      toAddress: 'john@example.com',
+      subject: 'Contains "quotes" and \\ backslash',
+      body: 'Multi\nline\nbody',
+    });
+  });
+
+  it('should encode numbers as JSON when used outside of a string literal', () => {
+    const body = '{"count":{{trigger.count}}}';
+
+    const result = resolveJsonBodyVariables(body, context);
+
+    expect(result).toBe('{"count":42}');
+    expect(JSON.parse(result)).toEqual({ count: 42 });
+  });
+
+  it('should stringify numbers when used inside a string literal', () => {
+    const body = '{"count":"{{trigger.count}}"}';
+
+    const result = resolveJsonBodyVariables(body, context);
+
+    expect(JSON.parse(result)).toEqual({ count: '42' });
+  });
+
+  it('should serialize object values as JSON inside a string literal', () => {
+    const contextWithObject = {
+      trigger: { payload: { foo: 'bar', count: 1 } },
+    };
+
+    const body = '{"payload":"{{trigger.payload}}"}';
+
+    const result = resolveJsonBodyVariables(body, contextWithObject);
+
+    expect(JSON.parse(result)).toEqual({
+      payload: '{"foo":"bar","count":1}',
+    });
+  });
+
+  it('should serialize object values as JSON outside of a string literal', () => {
+    const contextWithObject = {
+      trigger: { payload: { foo: 'bar' } },
+    };
+
+    const body = '{"payload":{{trigger.payload}}}';
+
+    const result = resolveJsonBodyVariables(body, contextWithObject);
+
+    expect(JSON.parse(result)).toEqual({ payload: { foo: 'bar' } });
+  });
+
+  it('should replace unresolved variables with an empty string inside a string literal', () => {
+    const body = '{"toAddress":"{{trigger.unknown}}"}';
+
+    const result = resolveJsonBodyVariables(body, context);
+
+    expect(JSON.parse(result)).toEqual({ toAddress: '' });
+  });
+
+  it('should not modify bodies without variables', () => {
+    const body = '{"static":"value"}';
+
+    const result = resolveJsonBodyVariables(body, context);
+
+    expect(result).toBe(body);
+  });
+});

--- a/packages/twenty-shared/src/utils/index.ts
+++ b/packages/twenty-shared/src/utils/index.ts
@@ -173,13 +173,13 @@ export {
 } from './image/getLogoUrlFromDomainName';
 export { getUniqueConstraintsFields } from './indexMetadata/getUniqueConstraintsFields';
 export { isAutoSelectModelId } from './isAutoSelectModelId';
+export { resolveJsonBodyVariables } from './json-body-variable-resolver';
 export { fastDeepEqual } from './json/fast-deep-equal';
 export { getAppPath } from './navigation/getAppPath';
 export { getSettingsPath } from './navigation/getSettingsPath';
 export { parseJson } from './parseJson';
 export { removePropertiesFromRecord } from './removePropertiesFromRecord';
 export { removeUndefinedFields } from './removeUndefinedFields';
-export { resolveJsonBodyVariables } from './json-body-variable-resolver';
 export { resolveRichTextVariables } from './rich-text-variable-resolver';
 export { safeParseRelativeDateFilterJsonStringified } from './safeParseRelativeDateFilterJsonStringified';
 export { getGenericOperationName } from './sentry/getGenericOperationName';

--- a/packages/twenty-shared/src/utils/index.ts
+++ b/packages/twenty-shared/src/utils/index.ts
@@ -179,6 +179,7 @@ export { getSettingsPath } from './navigation/getSettingsPath';
 export { parseJson } from './parseJson';
 export { removePropertiesFromRecord } from './removePropertiesFromRecord';
 export { removeUndefinedFields } from './removeUndefinedFields';
+export { resolveJsonBodyVariables } from './json-body-variable-resolver';
 export { resolveRichTextVariables } from './rich-text-variable-resolver';
 export { safeParseRelativeDateFilterJsonStringified } from './safeParseRelativeDateFilterJsonStringified';
 export { getGenericOperationName } from './sentry/getGenericOperationName';

--- a/packages/twenty-shared/src/utils/json-body-variable-resolver.ts
+++ b/packages/twenty-shared/src/utils/json-body-variable-resolver.ts
@@ -31,11 +31,6 @@ const encodeResolvedValue = (value: unknown, insideString: boolean): string => {
   return JSON.stringify(isDefined(value) ? value : null);
 };
 
-// Resolves {{variables}} inside a raw JSON body while keeping the result valid
-// JSON. Values injected inside a JSON string literal are escaped so that
-// quotes, backslashes or newlines coming from the resolved value don't break
-// the surrounding JSON. Values injected outside of a string literal are encoded
-// as JSON so numbers, booleans and objects keep their type.
 export const resolveJsonBodyVariables = (
   jsonBody: string,
   context: Record<string, unknown>,

--- a/packages/twenty-shared/src/utils/json-body-variable-resolver.ts
+++ b/packages/twenty-shared/src/utils/json-body-variable-resolver.ts
@@ -1,0 +1,72 @@
+import { evalFromContext } from '@/utils/evalFromContext';
+import { isDefined } from '@/utils/validation';
+
+const escapeJsonStringContent = (text: string): string => {
+  return JSON.stringify(text).slice(1, -1);
+};
+
+const isEscapedQuote = (text: string, quoteIndex: number): boolean => {
+  let backslashCount = 0;
+  let cursor = quoteIndex - 1;
+
+  while (cursor >= 0 && text[cursor] === '\\') {
+    backslashCount += 1;
+    cursor -= 1;
+  }
+
+  return backslashCount % 2 === 1;
+};
+
+const encodeResolvedValue = (value: unknown, insideString: boolean): string => {
+  if (insideString) {
+    const textValue = !isDefined(value)
+      ? ''
+      : typeof value === 'object'
+        ? JSON.stringify(value)
+        : String(value);
+
+    return escapeJsonStringContent(textValue);
+  }
+
+  return JSON.stringify(isDefined(value) ? value : null);
+};
+
+// Resolves {{variables}} inside a raw JSON body while keeping the result valid
+// JSON. Values injected inside a JSON string literal are escaped so that
+// quotes, backslashes or newlines coming from the resolved value don't break
+// the surrounding JSON. Values injected outside of a string literal are encoded
+// as JSON so numbers, booleans and objects keep their type.
+export const resolveJsonBodyVariables = (
+  jsonBody: string,
+  context: Record<string, unknown>,
+): string => {
+  let result = '';
+  let insideString = false;
+  let index = 0;
+
+  while (index < jsonBody.length) {
+    if (jsonBody.startsWith('{{', index)) {
+      const closingIndex = jsonBody.indexOf('}}', index + 2);
+
+      if (closingIndex !== -1) {
+        const token = jsonBody.slice(index, closingIndex + 2);
+        const resolvedValue = evalFromContext(token, context);
+
+        result += encodeResolvedValue(resolvedValue, insideString);
+        index = closingIndex + 2;
+        continue;
+      }
+    }
+
+    const character = jsonBody[index];
+
+    if (character === '"' && !isEscapedQuote(jsonBody, index)) {
+      insideString = !insideString;
+    }
+
+    result += character;
+    index += 1;
+  }
+
+  return result;
+};


### PR DESCRIPTION
Fixes two workflow editor bugs.

## 1. HTTP Request action: raw JSON body produced invalid JSON

When an HTTP Request action uses a Raw JSON body with variables (e.g. `"body": "{{message.text}}"`), the resolved values were injected into the JSON string without escaping. As soon as a value contained a `"`, newline, tab or `\` (very common in email subjects/bodies) the resulting body became **invalid JSON**.

Axios then double-encodes an invalid-JSON string body through its `stringifySafely` transform (`JSON.parse` fails, so it falls back to `JSON.stringify`), wrapping the whole body in quotes. The receiver gets a quoted string instead of an object and rejects it:

```
Unexpected token '"', ""{\n  \"to"... is not valid JSON
```

### Fix

Resolve raw JSON bodies with a dedicated JSON-aware resolver (`resolveJsonBodyVariables`) instead of the generic string resolver. It tracks whether each `{{variable}}` sits inside a JSON string literal and:

- inside a string literal → escapes the resolved value (`JSON.stringify(value).slice(1, -1)`), so quotes/newlines/tabs/backslashes stay valid;
- outside a string literal → JSON-encodes the value, so numbers, booleans and objects keep their type.

This mirrors the existing `resolveRichTextVariables` used for email bodies. Applied in both paths: backend run (`HttpRequestWorkflowAction.preprocessInput`, only when `content-type` is `application/json`) and the frontend "Test" tab (`useTestHttpRequest`).

## 2. Logic Function action: input fields disappeared for untyped destructured params

The logic function editor derived its parameter input fields only from a parameter's type annotation (`getFunctionInputSchema`). A handler using an untyped object-destructuring parameter, such as:

```js
export const main = async ({ toAddress, subject, body, messageId, messageThreadId }) => { ... }
```

produced an empty schema, so the parameter input fields vanished after pasting.

### Fix

When a parameter has no type annotation but is an object binding pattern, extract the property names from the binding pattern (using the source property name, skipping rest elements). The fields reappear as generic inputs. Typed handlers are unchanged.

## Tests

- `resolveJsonBodyVariables` unit tests: quotes, newlines, tabs, control chars, backslashes, byte-for-byte round-trip, number/boolean/object type in string vs bare context, unresolved variables.
- `HttpRequestWorkflowAction` spec: forwarded body stays valid JSON when a variable value contains special characters.
- `getFunctionInputSchema` tests: untyped object destructuring, renamed properties and rest elements.
