### PR TITLE
fix(server): unblock integration test shards stalled by 24h-delayed billing job

### DIFF
--- a/.github/workflows/ci-server.yaml
+++ b/.github/workflows/ci-server.yaml
@@ -478,6 +478,16 @@ jobs:
           tasks: 'test:integration'
           configuration: 'with-db-reset'
           args: --shard=${{ matrix.shard }}/${{ env.SHARD_COUNTER }}
+      # GitHub drops most of the buffered nx output when a shard fails with
+      # heavy logging, hiding the jest failure details; keep the full log.
+      - name: Upload integration test logs
+        if: failure()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: server-integration-test-logs-shard-${{ matrix.shard }}
+          path: |
+            packages/twenty-server/integration-test-logs.log
+            packages/twenty-server/reset-logs.log
 
   cross-version-upgrade:
     needs: [upgrade-changed-files-check, server-build]

--- a/packages/twenty-server/.gitignore
+++ b/packages/twenty-server/.gitignore
@@ -2,3 +2,4 @@ dist/*
 .local-storage
 logs/**/*
 *.log
+.jest-exit-code

--- a/packages/twenty-server/project.json
+++ b/packages/twenty-server/project.json
@@ -31,7 +31,7 @@
         "with-db-reset": {
           "cwd": "packages/twenty-server",
           "commands": [
-            "NODE_ENV=test NODE_OPTIONS=\"--max-old-space-size=12288 --import tsx/esm\" nx database:reset > reset-logs.log && NODE_ENV=test NODE_OPTIONS=\"--max-old-space-size=6144\" nx jest --config ./jest-integration.config.ts --logHeapUsage"
+            "NODE_ENV=test NODE_OPTIONS=\"--max-old-space-size=12288 --import tsx/esm\" nx database:reset > reset-logs.log && { NODE_ENV=test NODE_OPTIONS=\"--max-old-space-size=6144\" nx jest --config ./jest-integration.config.ts --logHeapUsage 2>&1; echo $? > .jest-exit-code; } | tee integration-test-logs.log; exit $(cat .jest-exit-code)"
           ]
         }
       }

--- a/packages/twenty-server/project.json
+++ b/packages/twenty-server/project.json
@@ -31,7 +31,7 @@
         "with-db-reset": {
           "cwd": "packages/twenty-server",
           "commands": [
-            "NODE_ENV=test NODE_OPTIONS=\"--max-old-space-size=12288 --import tsx/esm\" nx database:reset > reset-logs.log && { NODE_ENV=test NODE_OPTIONS=\"--max-old-space-size=6144\" nx jest --config ./jest-integration.config.ts --logHeapUsage 2>&1; echo $? > .jest-exit-code; } | tee integration-test-logs.log; exit $(cat .jest-exit-code)"
+            "rm -f .jest-exit-code && NODE_ENV=test NODE_OPTIONS=\"--max-old-space-size=12288 --import tsx/esm\" nx database:reset > reset-logs.log && { NODE_ENV=test NODE_OPTIONS=\"--max-old-space-size=6144\" nx jest --config ./jest-integration.config.ts --logHeapUsage 2>&1; echo $? > .jest-exit-code; } | tee integration-test-logs.log; exit $(cat .jest-exit-code 2>/dev/null || echo 1)"
           ]
         }
       }

--- a/packages/twenty-server/src/engine/core-modules/billing/stripe/stripe-sdk/mocks/stripe-sdk.mock.ts
+++ b/packages/twenty-server/src/engine/core-modules/billing/stripe/stripe-sdk/mocks/stripe-sdk.mock.ts
@@ -6,6 +6,12 @@ export class StripeSDKMock {
   constructor(private readonly _apiKey: string) {}
 
   customers = {
+    create: (params?: Stripe.CustomerCreateParams) => {
+      return {
+        id: `cus_mock_${crypto.randomUUID()}`,
+        ...params,
+      };
+    },
     update: (_id: string, _params?: Stripe.CustomerUpdateParams) => {
       return;
     },

--- a/packages/twenty-server/test/integration/google/mocks/google-webhook-subscription-handlers.util.ts
+++ b/packages/twenty-server/test/integration/google/mocks/google-webhook-subscription-handlers.util.ts
@@ -1,0 +1,30 @@
+import { type calendar_v3 } from 'googleapis';
+import { http, HttpResponse } from 'msw';
+
+import { GOOGLE_CALENDAR_EVENTS_URL } from 'test/integration/google/mocks/google-calendar-events-url.constant';
+import { type MswHandler } from 'test/integration/utils/http-mock.util';
+
+const ONE_DAY_MS = 24 * 60 * 60 * 1000;
+
+// Connecting an account enqueues CreateWebhookSubscriptionJob in the
+// background, which calls these endpoints. Without handlers, msw's "error"
+// unhandled-request strategy leaves the request pending forever, so the job
+// stays active and blocks waitForAllJobsToFinish and app shutdown.
+export const googleWebhookSubscriptionHandlers = (): MswHandler[] => [
+  http.post(`${GOOGLE_CALENDAR_EVENTS_URL}/watch`, () =>
+    HttpResponse.json<calendar_v3.Schema$Channel>({
+      resourceId: 'mock-calendar-watch-resource-id',
+      expiration: String(Date.now() + ONE_DAY_MS),
+    }),
+  ),
+  http.post('https://www.googleapis.com/calendar/v3/channels/stop', () =>
+    HttpResponse.json({}),
+  ),
+  http.post('*/gmail/v1/users/me/watch', () =>
+    HttpResponse.json({
+      historyId: 'mock-history-id',
+      expiration: String(Date.now() + ONE_DAY_MS),
+    }),
+  ),
+  http.post('*/gmail/v1/users/me/stop', () => HttpResponse.json({})),
+];

--- a/packages/twenty-server/test/integration/google/mocks/setup-google-mock.util.ts
+++ b/packages/twenty-server/test/integration/google/mocks/setup-google-mock.util.ts
@@ -11,6 +11,7 @@ import {
   GOOGLE_TOKEN_URLS,
   googleTokenHandlers,
 } from 'test/integration/google/mocks/google-token-handlers.util';
+import { googleWebhookSubscriptionHandlers } from 'test/integration/google/mocks/google-webhook-subscription-handlers.util';
 import { setupHttpMock } from 'test/integration/utils/http-mock.util';
 import {
   createMockEntityStore,
@@ -51,6 +52,7 @@ export const setupGoogleMock = ({
     ...googleTokenHandlers(),
     ...googleIdentityHandlers(handle),
     ...googleCalendarEventsHandlers([], 'mock-calendar-sync-token'),
+    ...googleWebhookSubscriptionHandlers(),
     ...gmailMailboxHandlers(inbox, labelStore),
   );
 

--- a/packages/twenty-server/test/integration/microsoft/mocks/microsoft-webhook-subscription-handlers.util.ts
+++ b/packages/twenty-server/test/integration/microsoft/mocks/microsoft-webhook-subscription-handlers.util.ts
@@ -1,0 +1,31 @@
+import { http, HttpResponse } from 'msw';
+import { v4 } from 'uuid';
+
+import { type MswHandler } from 'test/integration/utils/http-mock.util';
+
+const ONE_DAY_MS = 24 * 60 * 60 * 1000;
+
+// Connecting an account enqueues CreateWebhookSubscriptionJob in the
+// background, which calls these endpoints. Without handlers, msw's "error"
+// unhandled-request strategy leaves the request pending forever, so the job
+// stays active and blocks waitForAllJobsToFinish and app shutdown.
+export const microsoftWebhookSubscriptionHandlers = (): MswHandler[] => [
+  http.post('https://graph.microsoft.com/v1.0/subscriptions', () =>
+    HttpResponse.json({
+      id: v4(),
+      expirationDateTime: new Date(Date.now() + ONE_DAY_MS).toISOString(),
+    }),
+  ),
+  http.patch(
+    'https://graph.microsoft.com/v1.0/subscriptions/:subscriptionId',
+    ({ params }) =>
+      HttpResponse.json({
+        id: params.subscriptionId,
+        expirationDateTime: new Date(Date.now() + ONE_DAY_MS).toISOString(),
+      }),
+  ),
+  http.delete(
+    'https://graph.microsoft.com/v1.0/subscriptions/:subscriptionId',
+    () => new HttpResponse(null, { status: 204 }),
+  ),
+];

--- a/packages/twenty-server/test/integration/microsoft/mocks/setup-microsoft-mock.util.ts
+++ b/packages/twenty-server/test/integration/microsoft/mocks/setup-microsoft-mock.util.ts
@@ -4,6 +4,7 @@ import { setupHttpMock } from 'test/integration/utils/http-mock.util';
 import { microsoftAuthHandlers } from 'test/integration/microsoft/mocks/microsoft-auth-handlers.util';
 import { microsoftCalendarEventsHandlers } from 'test/integration/microsoft/mocks/microsoft-calendar-events-handlers.util';
 import { microsoftMailboxHandlers } from 'test/integration/microsoft/mocks/microsoft-mailbox-handlers.util';
+import { microsoftWebhookSubscriptionHandlers } from 'test/integration/microsoft/mocks/microsoft-webhook-subscription-handlers.util';
 import {
   createMockEntityStore,
   type MockEntityStore,
@@ -36,6 +37,7 @@ export const setupMicrosoftMock = ({
 
   const httpMock = setupHttpMock(
     ...microsoftAuthHandlers(handle),
+    ...microsoftWebhookSubscriptionHandlers(),
     ...microsoftMailboxHandlers(folderStore),
   );
 

--- a/packages/twenty-server/test/integration/utils/teardown-test.ts
+++ b/packages/twenty-server/test/integration/utils/teardown-test.ts
@@ -1,6 +1,31 @@
 import 'tsconfig-paths/register';
 
+// app.close() waits for in-flight queue jobs; a job stuck on a request that
+// never settles would otherwise hang teardown until the CI job timeout kills
+// the runner 30 minutes later, with all jest output lost.
+const APP_CLOSE_TIMEOUT_MS = 60_000;
+
 export default async () => {
-  await global.app.close();
+  let closeTimeout: NodeJS.Timeout | undefined;
+
+  const timedOut = await Promise.race([
+    global.app.close().then(() => false),
+    new Promise<boolean>((resolve) => {
+      closeTimeout = setTimeout(() => resolve(true), APP_CLOSE_TIMEOUT_MS);
+      closeTimeout.unref();
+    }),
+  ]);
+
+  if (closeTimeout) {
+    clearTimeout(closeTimeout);
+  }
+
+  if (timedOut) {
+    console.error(
+      `[teardown] app.close() did not finish within ${APP_CLOSE_TIMEOUT_MS}ms, likely a queue job stuck on a request that never settles; forcing exit`,
+    );
+    process.exit(1);
+  }
+
   await global.testDataSource.destroy();
 };

--- a/packages/twenty-server/test/integration/utils/wait-for-all-jobs-to-finish.util.ts
+++ b/packages/twenty-server/test/integration/utils/wait-for-all-jobs-to-finish.util.ts
@@ -7,12 +7,16 @@ const POLL_INTERVAL_MS = 25;
 const REQUIRED_CONSECUTIVE_QUIET_CHECKS = 2;
 const STALL_TIMEOUT_MS = 15_000;
 const HARD_TIMEOUT_MS = 120_000;
+// Delayed jobs due later than this are intentionally scheduled for the far
+// future (e.g. the 24h billing seats settling job) and would otherwise make
+// every subsequent hook fail with a stall error; they are not in-flight work,
+// so they don't count as pending.
+const DELAYED_JOB_DUE_SOON_HORIZON_MS = STALL_TIMEOUT_MS;
 const PENDING_JOB_STATES = [
   'waiting',
   'active',
   'prioritized',
   'waiting-children',
-  'delayed',
 ] as const;
 
 let redisConnection: IORedis | null = null;
@@ -34,16 +38,24 @@ const getQueues = (): Queue[] => {
   return queues;
 };
 
+const getDueSoonDelayedJobCount = async (queue: Queue): Promise<number> => {
+  const delayedJobs = await queue.getDelayed();
+  const dueSoonThreshold = Date.now() + DELAYED_JOB_DUE_SOON_HORIZON_MS;
+
+  return delayedJobs.filter(
+    (job) => job.timestamp + (job.delay ?? 0) <= dueSoonThreshold,
+  ).length;
+};
+
 const getPendingJobCountsByQueue = async (): Promise<
   Record<string, number>
 > => {
   const countsByQueue = await Promise.all(
     getQueues().map(async (queue) => {
       const jobCounts = await queue.getJobCounts(...PENDING_JOB_STATES);
-      const pendingCount = Object.values(jobCounts).reduce(
-        (sum, count) => sum + count,
-        0,
-      );
+      const pendingCount =
+        Object.values(jobCounts).reduce((sum, count) => sum + count, 0) +
+        (await getDueSoonDelayedJobCount(queue));
 
       return [queue.name, pendingCount] as const;
     }),

--- a/packages/twenty-server/test/integration/utils/wait-for-all-jobs-to-finish.util.ts
+++ b/packages/twenty-server/test/integration/utils/wait-for-all-jobs-to-finish.util.ts
@@ -38,13 +38,17 @@ const getQueues = (): Queue[] => {
   return queues;
 };
 
-const getDueSoonDelayedJobCount = async (queue: Queue): Promise<number> => {
-  const delayedJobs = await queue.getDelayed();
-  const dueSoonThreshold = Date.now() + DELAYED_JOB_DUE_SOON_HORIZON_MS;
+// BullMQ stores delayed jobs in a zset scored with the due timestamp shifted
+// 12 bits left (see bullmq's getDelayedScore.lua), so the score is the source
+// of truth for when a job actually runs, including retry/backoff reschedules.
+const DELAYED_SCORE_PER_MS = 0x1000;
 
-  return delayedJobs.filter(
-    (job) => job.timestamp + (job.delay ?? 0) <= dueSoonThreshold,
-  ).length;
+const getDueSoonDelayedJobCount = async (queue: Queue): Promise<number> => {
+  const client = await queue.client;
+  const dueSoonThreshold = Date.now() + DELAYED_JOB_DUE_SOON_HORIZON_MS;
+  const maxScore = (dueSoonThreshold + 1) * DELAYED_SCORE_PER_MS - 1;
+
+  return client.zcount(queue.toKey('delayed'), 0, maxScore);
 };
 
 const getPendingJobCountsByQueue = async (): Promise<

--- a/packages/twenty-server/test/integration/utils/wait-for-all-jobs-to-finish.util.ts
+++ b/packages/twenty-server/test/integration/utils/wait-for-all-jobs-to-finish.util.ts
@@ -44,11 +44,14 @@ const getQueues = (): Queue[] => {
 const DELAYED_SCORE_PER_MS = 0x1000;
 
 const getDueSoonDelayedJobCount = async (queue: Queue): Promise<number> => {
-  const client = await queue.client;
+  if (!redisConnection) {
+    return 0;
+  }
+
   const dueSoonThreshold = Date.now() + DELAYED_JOB_DUE_SOON_HORIZON_MS;
   const maxScore = (dueSoonThreshold + 1) * DELAYED_SCORE_PER_MS - 1;
 
-  return client.zcount(queue.toKey('delayed'), 0, maxScore);
+  return redisConnection.zcount(queue.toKey('delayed'), 0, maxScore);
 };
 
 const getPendingJobCountsByQueue = async (): Promise<


### PR DESCRIPTION
# Context

`server-integration-test` shards have been hanging silently until the 30-minute job timeout kills them (e.g. shard 3 on #22727, three times in a row, and shard 3/12 on this PR's first run). The shard shows zero jest output because Nx only flushes a task's output when it completes.

Local reproduction of the affected shards surfaced three independent problems:

1. **Stuck webhook subscription job (the 30-minute silent hang).** Connecting an account in an integration test (e.g. `google/messaging/folder-discovery`, `google/messaging/sync-failure-lifecycle`) enqueues `CreateWebhookSubscriptionJob` in the in-process worker. Its Google Calendar `events/watch` call has no msw handler, and msw's `onUnhandledRequest: 'error'` strategy leaves the intercepted request pending forever (`InternalError: Cannot bypass a request when using the "error" strategy`). The job stays `active` indefinitely, so every later suite fails its 15s stall check in `waitForAllJobsToFinish`, and `app.close()` in globalTeardown blocks on the active job until the CI runner is killed.
2. **Harness stall on far-future delayed jobs.** `BillingWorkspaceMemberListener` enqueues `UpdateSubscriptionQuantityJob` with a 24h settling delay on workspace-member create/delete. The wait helper counted `delayed` jobs as pending, so once a test deleted a workspace member (e.g. `user.integration-spec.ts`), every subsequent hook burned 15s and threw `Message queues stalled`.
3. **Missing Stripe mock method.** `BillingService.ensureBillingCustomer` calls `stripe.customers.create`, which `StripeSDKMock` didn't implement, failing every test that creates a workspace when `IS_BILLING_ENABLED=true` (as in CI).

# Changes

- Mock the webhook subscription endpoints in the shared http mocks: Google Calendar `events/watch` + `channels/stop`, Gmail `users/watch` + `users/stop`, and Microsoft Graph `subscriptions` (create/renew/delete).
- Bound `app.close()` in globalTeardown (60s): if a stuck job is holding the worker, fail loudly with a diagnostic message instead of hanging until the CI timeout with all jest output lost.
- `waitForAllJobsToFinish`: only count delayed jobs as pending when they are due within the stall window, reading the due time from BullMQ's delayed-set score (authoritative, stays correct for retry/backoff reschedules) rather than `job.timestamp + job.delay`.
- `StripeSDKMock`: implement `customers.create`.

# Verification

- Before: the CI shard-3 file set hangs locally exactly as in CI (`folder-discovery` leaves a permanently-active `CreateWebhookSubscriptionJob`, every later suite fails with `Message queues stalled ... {"webhook-queue":1}`, teardown never returns).
- After: `folder-discovery` passes in 8s with the queue drained and a clean process exit; `user.integration-spec.ts` passes in 7s (billing stall gone); full shard-3 run green locally.
- `npx nx typecheck twenty-server` passes.