### PR TITLE
Fix CI on app asset management PR

### DIFF
--- a/packages/twenty-apps/examples/document-generator/src/application-config.ts
+++ b/packages/twenty-apps/examples/document-generator/src/application-config.ts
@@ -12,8 +12,8 @@ export default defineApplication({
   universalIdentifier: APPLICATION_UNIVERSAL_IDENTIFIER,
   displayName: APP_DISPLAY_NAME,
   description: APP_DESCRIPTION,
-  logoUrl: 'public/document-generator.svg',
-  screenshots: [
+  logo: 'public/document-generator.svg',
+  galleryImages: [
     'public/gallery/01-template-editor.png',
     'public/gallery/02-command-menu.png',
     'public/gallery/03-documents.png',

--- a/packages/twenty-docs/developers/extend/apps/tutorials/document-generator/publishing.mdx
+++ b/packages/twenty-docs/developers/extend/apps/tutorials/document-generator/publishing.mdx
@@ -10,7 +10,7 @@ Your app works. The last step is to describe it for the marketplace and publish.
 
 The [application config](/developers/extend/apps/config/application) carries the
 identity that shows up in the marketplace: author, category, logo, and support
-links. Put a logo in `public/` and reference it with `logoUrl`.
+links. Put a logo in `public/` and reference it with `logo`.
 
 ```ts filename="src/application-config.ts"
 import { defineApplication } from 'twenty-sdk/define';
@@ -20,7 +20,7 @@ export default defineApplication({
   displayName: 'Document Generator',
   description:
     'Create reusable document templates and generate personalized documents from your CRM records.',
-  logoUrl: 'public/document-generator.svg',
+  logo: 'public/document-generator.svg',
   author: 'Twenty',
   category: 'Productivity',
   websiteUrl: 'https://docs.twenty.com/developers/extend/apps',
@@ -44,13 +44,13 @@ Also add the `twenty-app` keyword to `package.json` so the app is discoverable:
 ## Add gallery screenshots
 
 A marketplace listing sells itself with screenshots. Drop a few PNGs in
-`public/gallery/` and reference them with `screenshots` — they render as a gallery
-on the listing page.
+`public/gallery/` and reference them with `galleryImages` — they render as a
+gallery on the listing page, in array order.
 
 ```ts filename="src/application-config.ts"
 export default defineApplication({
   // ...identity from above
-  screenshots: [
+  galleryImages: [
     'public/gallery/01-generated-document.png',
     'public/gallery/02-command-menu.png',
     'public/gallery/03-template-editor.png',

--- a/packages/twenty-server/src/database/commands/upgrade-version-command/2-20/2-20-instance-command-fast-1783615890055-add-gallery-images-to-application-registration.ts
+++ b/packages/twenty-server/src/database/commands/upgrade-version-command/2-20/2-20-instance-command-fast-1783615890055-add-gallery-images-to-application-registration.ts
@@ -3,7 +3,7 @@ import { type QueryRunner } from 'typeorm';
 import { RegisteredInstanceCommand } from 'src/engine/core-modules/upgrade/decorators/registered-instance-command.decorator';
 import { type FastInstanceCommand } from 'src/engine/core-modules/upgrade/interfaces/fast-instance-command.interface';
 
-@RegisteredInstanceCommand('2.20.0', 1783592420699)
+@RegisteredInstanceCommand('2.20.0', 1783615890055)
 export class AddGalleryImagesToApplicationRegistrationFastInstanceCommand
   implements FastInstanceCommand
 {

--- a/packages/twenty-server/src/database/commands/upgrade-version-command/2-20/2-20-instance-command-slow-1783615890056-backfill-gallery-images-on-application-registration.ts
+++ b/packages/twenty-server/src/database/commands/upgrade-version-command/2-20/2-20-instance-command-slow-1783615890056-backfill-gallery-images-on-application-registration.ts
@@ -3,7 +3,7 @@ import { type DataSource, type QueryRunner } from 'typeorm';
 import { RegisteredInstanceCommand } from 'src/engine/core-modules/upgrade/decorators/registered-instance-command.decorator';
 import { type SlowInstanceCommand } from 'src/engine/core-modules/upgrade/interfaces/slow-instance-command.interface';
 
-@RegisteredInstanceCommand('2.20.0', 1783592420700, { type: 'slow' })
+@RegisteredInstanceCommand('2.20.0', 1783615890056, { type: 'slow' })
 export class BackfillGalleryImagesOnApplicationRegistrationSlowInstanceCommand
   implements SlowInstanceCommand
 {

--- a/packages/twenty-server/src/database/commands/upgrade-version-command/instance-commands.constant.ts
+++ b/packages/twenty-server/src/database/commands/upgrade-version-command/instance-commands.constant.ts
@@ -104,9 +104,9 @@ import { CreateWorkflowVersionCoreTableFastInstanceCommand } from './2-20/2-20-i
 import { BackfillNameFieldIsSystemSideEffectSlowInstanceCommand } from './2-20/2-20-instance-command-slow-1783529458168-backfill-name-field-is-system-side-effect';
 import { RenameIsFeaturedToIsVettedOnApplicationRegistrationFastInstanceCommand } from './2-20/2-20-instance-command-fast-1783527064000-rename-is-featured-to-is-vetted-on-application-registration';
 import { AddIsSystemSideEffectToSearchFieldMetadataFastInstanceCommand } from './2-20/2-20-instance-command-fast-1783580127637-add-is-system-side-effect-to-search-field-metadata';
-import { AddGalleryImagesToApplicationRegistrationFastInstanceCommand } from './2-20/2-20-instance-command-fast-1783592420699-add-gallery-images-to-application-registration';
-import { BackfillGalleryImagesOnApplicationRegistrationSlowInstanceCommand } from './2-20/2-20-instance-command-slow-1783592420700-backfill-gallery-images-on-application-registration';
 import { CreateWorkflowCoreTableFastInstanceCommand } from './2-20/2-20-instance-command-fast-1783603454479-create-workflow-core-table';
+import { AddGalleryImagesToApplicationRegistrationFastInstanceCommand } from './2-20/2-20-instance-command-fast-1783615890055-add-gallery-images-to-application-registration';
+import { BackfillGalleryImagesOnApplicationRegistrationSlowInstanceCommand } from './2-20/2-20-instance-command-slow-1783615890056-backfill-gallery-images-on-application-registration';
 
 export const INSTANCE_COMMANDS = [
   AddViewFieldGroupIdIndexOnViewFieldFastInstanceCommand,
@@ -213,7 +213,7 @@ export const INSTANCE_COMMANDS = [
   BackfillNameFieldIsSystemSideEffectSlowInstanceCommand,
   RenameIsFeaturedToIsVettedOnApplicationRegistrationFastInstanceCommand,
   AddIsSystemSideEffectToSearchFieldMetadataFastInstanceCommand,
+  CreateWorkflowCoreTableFastInstanceCommand,
   AddGalleryImagesToApplicationRegistrationFastInstanceCommand,
   BackfillGalleryImagesOnApplicationRegistrationSlowInstanceCommand,
-  CreateWorkflowCoreTableFastInstanceCommand,
 ];

--- a/packages/twenty-server/src/engine/core-modules/application/application-registration/application-registration.entity.ts
+++ b/packages/twenty-server/src/engine/core-modules/application/application-registration/application-registration.entity.ts
@@ -233,7 +233,7 @@ export class ApplicationRegistrationEntity {
   @Column({ type: 'jsonb', nullable: true })
   @WasIntroducedInUpgrade({
     upgradeCommandName:
-      '2.20.0_AddGalleryImagesToApplicationRegistrationFastInstanceCommand_1783592420699',
+      '2.20.0_AddGalleryImagesToApplicationRegistrationFastInstanceCommand_1783615890055',
   })
   galleryImages: ApplicationRegistrationGalleryImage[] | null;
 


### PR DESCRIPTION
Fixes the two failing checks on #22564:

**server-previous-version-upgrade-mutation-guard**: the two new 2-20 instance commands had timestamps (`1783592420699`/`700`) sorting before the existing max in the version directory (`1783603454479`, `create-workflow-core-table` merged from main). Re-slotted them to fresh timestamps `1783615890055`/`56`: renamed the files, updated the `@RegisteredInstanceCommand` timestamps, the registry imports, and the `@WasIntroducedInUpgrade` key on `ApplicationRegistrationEntity.galleryImages`.

**docs-drift-check**: the document-generator publishing tutorial still used the deprecated `logoUrl`/`screenshots` fields. Updated the tutorial (prose and code blocks) and the matching example app config at `packages/twenty-apps/examples/document-generator` to `logo`/`galleryImages`.

`nx typecheck twenty-server` passes.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Bbk4CGdotMASk1rQLn2zzj)_

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/22754?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

