### PR TITLE
Fix deterministic shard-12 integration failure: regenerate stale object-metadata snapshot from #22594

### DIFF
--- a/packages/twenty-server/test/integration/metadata/suites/object-metadata/__snapshots__/failing-create-one-object-metadata-v2.integration-spec.ts.snap
+++ b/packages/twenty-server/test/integration/metadata/suites/object-metadata/__snapshots__/failing-create-one-object-metadata-v2.integration-spec.ts.snap
@@ -117,23 +117,6 @@ exports[`Object metadata creation should fail v2 when labelPlural contains only 
             },
           ],
           "flatEntityMinimalInformation": {
-            "name": "searchVector",
-            "objectMetadataUniversalIdentifier": Any<String>,
-            "universalIdentifier": Any<String>,
-          },
-          "metadataName": "fieldMetadata",
-          "status": "fail",
-          "type": "create",
-        },
-        {
-          "errors": [
-            {
-              "code": "OBJECT_METADATA_NOT_FOUND",
-              "message": "Object metadata not found",
-              "userFriendlyMessage": "Field to create related object not found",
-            },
-          ],
-          "flatEntityMinimalInformation": {
             "name": "updatedAt",
             "objectMetadataUniversalIdentifier": Any<String>,
             "universalIdentifier": Any<String>,
@@ -152,6 +135,23 @@ exports[`Object metadata creation should fail v2 when labelPlural contains only 
           ],
           "flatEntityMinimalInformation": {
             "name": "updatedBy",
+            "objectMetadataUniversalIdentifier": Any<String>,
+            "universalIdentifier": Any<String>,
+          },
+          "metadataName": "fieldMetadata",
+          "status": "fail",
+          "type": "create",
+        },
+        {
+          "errors": [
+            {
+              "code": "OBJECT_METADATA_NOT_FOUND",
+              "message": "Object metadata not found",
+              "userFriendlyMessage": "Field to create related object not found",
+            },
+          ],
+          "flatEntityMinimalInformation": {
+            "name": "searchVector",
             "objectMetadataUniversalIdentifier": Any<String>,
             "universalIdentifier": Any<String>,
           },
@@ -798,23 +798,6 @@ exports[`Object metadata creation should fail v2 when labelPlural exceeds maximu
             },
           ],
           "flatEntityMinimalInformation": {
-            "name": "searchVector",
-            "objectMetadataUniversalIdentifier": Any<String>,
-            "universalIdentifier": Any<String>,
-          },
-          "metadataName": "fieldMetadata",
-          "status": "fail",
-          "type": "create",
-        },
-        {
-          "errors": [
-            {
-              "code": "OBJECT_METADATA_NOT_FOUND",
-              "message": "Object metadata not found",
-              "userFriendlyMessage": "Field to create related object not found",
-            },
-          ],
-          "flatEntityMinimalInformation": {
             "name": "updatedAt",
             "objectMetadataUniversalIdentifier": Any<String>,
             "universalIdentifier": Any<String>,
@@ -833,6 +816,23 @@ exports[`Object metadata creation should fail v2 when labelPlural exceeds maximu
           ],
           "flatEntityMinimalInformation": {
             "name": "updatedBy",
+            "objectMetadataUniversalIdentifier": Any<String>,
+            "universalIdentifier": Any<String>,
+          },
+          "metadataName": "fieldMetadata",
+          "status": "fail",
+          "type": "create",
+        },
+        {
+          "errors": [
+            {
+              "code": "OBJECT_METADATA_NOT_FOUND",
+              "message": "Object metadata not found",
+              "userFriendlyMessage": "Field to create related object not found",
+            },
+          ],
+          "flatEntityMinimalInformation": {
+            "name": "searchVector",
             "objectMetadataUniversalIdentifier": Any<String>,
             "universalIdentifier": Any<String>,
           },
@@ -1490,23 +1490,6 @@ exports[`Object metadata creation should fail v2 when labelSingular contains onl
             },
           ],
           "flatEntityMinimalInformation": {
-            "name": "searchVector",
-            "objectMetadataUniversalIdentifier": Any<String>,
-            "universalIdentifier": Any<String>,
-          },
-          "metadataName": "fieldMetadata",
-          "status": "fail",
-          "type": "create",
-        },
-        {
-          "errors": [
-            {
-              "code": "OBJECT_METADATA_NOT_FOUND",
-              "message": "Object metadata not found",
-              "userFriendlyMessage": "Field to create related object not found",
-            },
-          ],
-          "flatEntityMinimalInformation": {
             "name": "updatedAt",
             "objectMetadataUniversalIdentifier": Any<String>,
             "universalIdentifier": Any<String>,
@@ -1525,6 +1508,23 @@ exports[`Object metadata creation should fail v2 when labelSingular contains onl
           ],
           "flatEntityMinimalInformation": {
             "name": "updatedBy",
+            "objectMetadataUniversalIdentifier": Any<String>,
+            "universalIdentifier": Any<String>,
+          },
+          "metadataName": "fieldMetadata",
+          "status": "fail",
+          "type": "create",
+        },
+        {
+          "errors": [
+            {
+              "code": "OBJECT_METADATA_NOT_FOUND",
+              "message": "Object metadata not found",
+              "userFriendlyMessage": "Field to create related object not found",
+            },
+          ],
+          "flatEntityMinimalInformation": {
+            "name": "searchVector",
             "objectMetadataUniversalIdentifier": Any<String>,
             "universalIdentifier": Any<String>,
           },
@@ -2171,23 +2171,6 @@ exports[`Object metadata creation should fail v2 when labelSingular exceeds maxi
             },
           ],
           "flatEntityMinimalInformation": {
-            "name": "searchVector",
-            "objectMetadataUniversalIdentifier": Any<String>,
-            "universalIdentifier": Any<String>,
-          },
-          "metadataName": "fieldMetadata",
-          "status": "fail",
-          "type": "create",
-        },
-        {
-          "errors": [
-            {
-              "code": "OBJECT_METADATA_NOT_FOUND",
-              "message": "Object metadata not found",
-              "userFriendlyMessage": "Field to create related object not found",
-            },
-          ],
-          "flatEntityMinimalInformation": {
             "name": "updatedAt",
             "objectMetadataUniversalIdentifier": Any<String>,
             "universalIdentifier": Any<String>,
@@ -2206,6 +2189,23 @@ exports[`Object metadata creation should fail v2 when labelSingular exceeds maxi
           ],
           "flatEntityMinimalInformation": {
             "name": "updatedBy",
+            "objectMetadataUniversalIdentifier": Any<String>,
+            "universalIdentifier": Any<String>,
+          },
+          "metadataName": "fieldMetadata",
+          "status": "fail",
+          "type": "create",
+        },
+        {
+          "errors": [
+            {
+              "code": "OBJECT_METADATA_NOT_FOUND",
+              "message": "Object metadata not found",
+              "userFriendlyMessage": "Field to create related object not found",
+            },
+          ],
+          "flatEntityMinimalInformation": {
+            "name": "searchVector",
             "objectMetadataUniversalIdentifier": Any<String>,
             "universalIdentifier": Any<String>,
           },
@@ -2863,23 +2863,6 @@ exports[`Object metadata creation should fail v2 when name exceeds maximum lengt
             },
           ],
           "flatEntityMinimalInformation": {
-            "name": "searchVector",
-            "objectMetadataUniversalIdentifier": Any<String>,
-            "universalIdentifier": Any<String>,
-          },
-          "metadataName": "fieldMetadata",
-          "status": "fail",
-          "type": "create",
-        },
-        {
-          "errors": [
-            {
-              "code": "OBJECT_METADATA_NOT_FOUND",
-              "message": "Object metadata not found",
-              "userFriendlyMessage": "Field to create related object not found",
-            },
-          ],
-          "flatEntityMinimalInformation": {
             "name": "updatedAt",
             "objectMetadataUniversalIdentifier": Any<String>,
             "universalIdentifier": Any<String>,
@@ -2898,6 +2881,23 @@ exports[`Object metadata creation should fail v2 when name exceeds maximum lengt
           ],
           "flatEntityMinimalInformation": {
             "name": "updatedBy",
+            "objectMetadataUniversalIdentifier": Any<String>,
+            "universalIdentifier": Any<String>,
+          },
+          "metadataName": "fieldMetadata",
+          "status": "fail",
+          "type": "create",
+        },
+        {
+          "errors": [
+            {
+              "code": "OBJECT_METADATA_NOT_FOUND",
+              "message": "Object metadata not found",
+              "userFriendlyMessage": "Field to create related object not found",
+            },
+          ],
+          "flatEntityMinimalInformation": {
+            "name": "searchVector",
             "objectMetadataUniversalIdentifier": Any<String>,
             "universalIdentifier": Any<String>,
           },
@@ -3568,23 +3568,6 @@ exports[`Object metadata creation should fail v2 when namePlural has invalid cha
             },
           ],
           "flatEntityMinimalInformation": {
-            "name": "searchVector",
-            "objectMetadataUniversalIdentifier": Any<String>,
-            "universalIdentifier": Any<String>,
-          },
-          "metadataName": "fieldMetadata",
-          "status": "fail",
-          "type": "create",
-        },
-        {
-          "errors": [
-            {
-              "code": "OBJECT_METADATA_NOT_FOUND",
-              "message": "Object metadata not found",
-              "userFriendlyMessage": "Field to create related object not found",
-            },
-          ],
-          "flatEntityMinimalInformation": {
             "name": "updatedAt",
             "objectMetadataUniversalIdentifier": Any<String>,
             "universalIdentifier": Any<String>,
@@ -3603,6 +3586,23 @@ exports[`Object metadata creation should fail v2 when namePlural has invalid cha
           ],
           "flatEntityMinimalInformation": {
             "name": "updatedBy",
+            "objectMetadataUniversalIdentifier": Any<String>,
+            "universalIdentifier": Any<String>,
+          },
+          "metadataName": "fieldMetadata",
+          "status": "fail",
+          "type": "create",
+        },
+        {
+          "errors": [
+            {
+              "code": "OBJECT_METADATA_NOT_FOUND",
+              "message": "Object metadata not found",
+              "userFriendlyMessage": "Field to create related object not found",
+            },
+          ],
+          "flatEntityMinimalInformation": {
+            "name": "searchVector",
             "objectMetadataUniversalIdentifier": Any<String>,
             "universalIdentifier": Any<String>,
           },
@@ -4249,23 +4249,6 @@ exports[`Object metadata creation should fail v2 when namePlural is a reserved k
             },
           ],
           "flatEntityMinimalInformation": {
-            "name": "searchVector",
-            "objectMetadataUniversalIdentifier": Any<String>,
-            "universalIdentifier": Any<String>,
-          },
-          "metadataName": "fieldMetadata",
-          "status": "fail",
-          "type": "create",
-        },
-        {
-          "errors": [
-            {
-              "code": "OBJECT_METADATA_NOT_FOUND",
-              "message": "Object metadata not found",
-              "userFriendlyMessage": "Field to create related object not found",
-            },
-          ],
-          "flatEntityMinimalInformation": {
             "name": "updatedAt",
             "objectMetadataUniversalIdentifier": Any<String>,
             "universalIdentifier": Any<String>,
@@ -4284,6 +4267,23 @@ exports[`Object metadata creation should fail v2 when namePlural is a reserved k
           ],
           "flatEntityMinimalInformation": {
             "name": "updatedBy",
+            "objectMetadataUniversalIdentifier": Any<String>,
+            "universalIdentifier": Any<String>,
+          },
+          "metadataName": "fieldMetadata",
+          "status": "fail",
+          "type": "create",
+        },
+        {
+          "errors": [
+            {
+              "code": "OBJECT_METADATA_NOT_FOUND",
+              "message": "Object metadata not found",
+              "userFriendlyMessage": "Field to create related object not found",
+            },
+          ],
+          "flatEntityMinimalInformation": {
+            "name": "searchVector",
             "objectMetadataUniversalIdentifier": Any<String>,
             "universalIdentifier": Any<String>,
           },
@@ -4941,23 +4941,6 @@ exports[`Object metadata creation should fail v2 when namePlural is not camelCas
             },
           ],
           "flatEntityMinimalInformation": {
-            "name": "searchVector",
-            "objectMetadataUniversalIdentifier": Any<String>,
-            "universalIdentifier": Any<String>,
-          },
-          "metadataName": "fieldMetadata",
-          "status": "fail",
-          "type": "create",
-        },
-        {
-          "errors": [
-            {
-              "code": "OBJECT_METADATA_NOT_FOUND",
-              "message": "Object metadata not found",
-              "userFriendlyMessage": "Field to create related object not found",
-            },
-          ],
-          "flatEntityMinimalInformation": {
             "name": "updatedAt",
             "objectMetadataUniversalIdentifier": Any<String>,
             "universalIdentifier": Any<String>,
@@ -4976,6 +4959,23 @@ exports[`Object metadata creation should fail v2 when namePlural is not camelCas
           ],
           "flatEntityMinimalInformation": {
             "name": "updatedBy",
+            "objectMetadataUniversalIdentifier": Any<String>,
+            "universalIdentifier": Any<String>,
+          },
+          "metadataName": "fieldMetadata",
+          "status": "fail",
+          "type": "create",
+        },
+        {
+          "errors": [
+            {
+              "code": "OBJECT_METADATA_NOT_FOUND",
+              "message": "Object metadata not found",
+              "userFriendlyMessage": "Field to create related object not found",
+            },
+          ],
+          "flatEntityMinimalInformation": {
+            "name": "searchVector",
             "objectMetadataUniversalIdentifier": Any<String>,
             "universalIdentifier": Any<String>,
           },
@@ -5622,23 +5622,6 @@ exports[`Object metadata creation should fail v2 when nameSingular contains only
             },
           ],
           "flatEntityMinimalInformation": {
-            "name": "searchVector",
-            "objectMetadataUniversalIdentifier": Any<String>,
-            "universalIdentifier": Any<String>,
-          },
-          "metadataName": "fieldMetadata",
-          "status": "fail",
-          "type": "create",
-        },
-        {
-          "errors": [
-            {
-              "code": "OBJECT_METADATA_NOT_FOUND",
-              "message": "Object metadata not found",
-              "userFriendlyMessage": "Field to create related object not found",
-            },
-          ],
-          "flatEntityMinimalInformation": {
             "name": "updatedAt",
             "objectMetadataUniversalIdentifier": Any<String>,
             "universalIdentifier": Any<String>,
@@ -5657,6 +5640,23 @@ exports[`Object metadata creation should fail v2 when nameSingular contains only
           ],
           "flatEntityMinimalInformation": {
             "name": "updatedBy",
+            "objectMetadataUniversalIdentifier": Any<String>,
+            "universalIdentifier": Any<String>,
+          },
+          "metadataName": "fieldMetadata",
+          "status": "fail",
+          "type": "create",
+        },
+        {
+          "errors": [
+            {
+              "code": "OBJECT_METADATA_NOT_FOUND",
+              "message": "Object metadata not found",
+              "userFriendlyMessage": "Field to create related object not found",
+            },
+          ],
+          "flatEntityMinimalInformation": {
+            "name": "searchVector",
             "objectMetadataUniversalIdentifier": Any<String>,
             "universalIdentifier": Any<String>,
           },
@@ -6327,23 +6327,6 @@ exports[`Object metadata creation should fail v2 when nameSingular contains only
             },
           ],
           "flatEntityMinimalInformation": {
-            "name": "searchVector",
-            "objectMetadataUniversalIdentifier": Any<String>,
-            "universalIdentifier": Any<String>,
-          },
-          "metadataName": "fieldMetadata",
-          "status": "fail",
-          "type": "create",
-        },
-        {
-          "errors": [
-            {
-              "code": "OBJECT_METADATA_NOT_FOUND",
-              "message": "Object metadata not found",
-              "userFriendlyMessage": "Field to create related object not found",
-            },
-          ],
-          "flatEntityMinimalInformation": {
             "name": "updatedAt",
             "objectMetadataUniversalIdentifier": Any<String>,
             "universalIdentifier": Any<String>,
@@ -6362,6 +6345,23 @@ exports[`Object metadata creation should fail v2 when nameSingular contains only
           ],
           "flatEntityMinimalInformation": {
             "name": "updatedBy",
+            "objectMetadataUniversalIdentifier": Any<String>,
+            "universalIdentifier": Any<String>,
+          },
+          "metadataName": "fieldMetadata",
+          "status": "fail",
+          "type": "create",
+        },
+        {
+          "errors": [
+            {
+              "code": "OBJECT_METADATA_NOT_FOUND",
+              "message": "Object metadata not found",
+              "userFriendlyMessage": "Field to create related object not found",
+            },
+          ],
+          "flatEntityMinimalInformation": {
+            "name": "searchVector",
             "objectMetadataUniversalIdentifier": Any<String>,
             "universalIdentifier": Any<String>,
           },
@@ -7014,23 +7014,6 @@ exports[`Object metadata creation should fail v2 when nameSingular has invalid c
             },
           ],
           "flatEntityMinimalInformation": {
-            "name": "searchVector",
-            "objectMetadataUniversalIdentifier": Any<String>,
-            "universalIdentifier": Any<String>,
-          },
-          "metadataName": "fieldMetadata",
-          "status": "fail",
-          "type": "create",
-        },
-        {
-          "errors": [
-            {
-              "code": "OBJECT_METADATA_NOT_FOUND",
-              "message": "Object metadata not found",
-              "userFriendlyMessage": "Field to create related object not found",
-            },
-          ],
-          "flatEntityMinimalInformation": {
             "name": "updatedAt",
             "objectMetadataUniversalIdentifier": Any<String>,
             "universalIdentifier": Any<String>,
@@ -7049,6 +7032,23 @@ exports[`Object metadata creation should fail v2 when nameSingular has invalid c
           ],
           "flatEntityMinimalInformation": {
             "name": "updatedBy",
+            "objectMetadataUniversalIdentifier": Any<String>,
+            "universalIdentifier": Any<String>,
+          },
+          "metadataName": "fieldMetadata",
+          "status": "fail",
+          "type": "create",
+        },
+        {
+          "errors": [
+            {
+              "code": "OBJECT_METADATA_NOT_FOUND",
+              "message": "Object metadata not found",
+              "userFriendlyMessage": "Field to create related object not found",
+            },
+          ],
+          "flatEntityMinimalInformation": {
+            "name": "searchVector",
             "objectMetadataUniversalIdentifier": Any<String>,
             "universalIdentifier": Any<String>,
           },
@@ -7719,23 +7719,6 @@ exports[`Object metadata creation should fail v2 when nameSingular is a reserved
             },
           ],
           "flatEntityMinimalInformation": {
-            "name": "searchVector",
-            "objectMetadataUniversalIdentifier": Any<String>,
-            "universalIdentifier": Any<String>,
-          },
-          "metadataName": "fieldMetadata",
-          "status": "fail",
-          "type": "create",
-        },
-        {
-          "errors": [
-            {
-              "code": "OBJECT_METADATA_NOT_FOUND",
-              "message": "Object metadata not found",
-              "userFriendlyMessage": "Field to create related object not found",
-            },
-          ],
-          "flatEntityMinimalInformation": {
             "name": "updatedAt",
             "objectMetadataUniversalIdentifier": Any<String>,
             "universalIdentifier": Any<String>,
@@ -7754,6 +7737,23 @@ exports[`Object metadata creation should fail v2 when nameSingular is a reserved
           ],
           "flatEntityMinimalInformation": {
             "name": "updatedBy",
+            "objectMetadataUniversalIdentifier": Any<String>,
+            "universalIdentifier": Any<String>,
+          },
+          "metadataName": "fieldMetadata",
+          "status": "fail",
+          "type": "create",
+        },
+        {
+          "errors": [
+            {
+              "code": "OBJECT_METADATA_NOT_FOUND",
+              "message": "Object metadata not found",
+              "userFriendlyMessage": "Field to create related object not found",
+            },
+          ],
+          "flatEntityMinimalInformation": {
+            "name": "searchVector",
             "objectMetadataUniversalIdentifier": Any<String>,
             "universalIdentifier": Any<String>,
           },
@@ -8411,23 +8411,6 @@ exports[`Object metadata creation should fail v2 when nameSingular is not camelC
             },
           ],
           "flatEntityMinimalInformation": {
-            "name": "searchVector",
-            "objectMetadataUniversalIdentifier": Any<String>,
-            "universalIdentifier": Any<String>,
-          },
-          "metadataName": "fieldMetadata",
-          "status": "fail",
-          "type": "create",
-        },
-        {
-          "errors": [
-            {
-              "code": "OBJECT_METADATA_NOT_FOUND",
-              "message": "Object metadata not found",
-              "userFriendlyMessage": "Field to create related object not found",
-            },
-          ],
-          "flatEntityMinimalInformation": {
             "name": "updatedAt",
             "objectMetadataUniversalIdentifier": Any<String>,
             "universalIdentifier": Any<String>,
@@ -8446,6 +8429,23 @@ exports[`Object metadata creation should fail v2 when nameSingular is not camelC
           ],
           "flatEntityMinimalInformation": {
             "name": "updatedBy",
+            "objectMetadataUniversalIdentifier": Any<String>,
+            "universalIdentifier": Any<String>,
+          },
+          "metadataName": "fieldMetadata",
+          "status": "fail",
+          "type": "create",
+        },
+        {
+          "errors": [
+            {
+              "code": "OBJECT_METADATA_NOT_FOUND",
+              "message": "Object metadata not found",
+              "userFriendlyMessage": "Field to create related object not found",
+            },
+          ],
+          "flatEntityMinimalInformation": {
+            "name": "searchVector",
             "objectMetadataUniversalIdentifier": Any<String>,
             "universalIdentifier": Any<String>,
           },
@@ -9116,23 +9116,6 @@ exports[`Object metadata creation should fail v2 when names are identical 1`] = 
             },
           ],
           "flatEntityMinimalInformation": {
-            "name": "searchVector",
-            "objectMetadataUniversalIdentifier": Any<String>,
-            "universalIdentifier": Any<String>,
-          },
-          "metadataName": "fieldMetadata",
-          "status": "fail",
-          "type": "create",
-        },
-        {
-          "errors": [
-            {
-              "code": "OBJECT_METADATA_NOT_FOUND",
-              "message": "Object metadata not found",
-              "userFriendlyMessage": "Field to create related object not found",
-            },
-          ],
-          "flatEntityMinimalInformation": {
             "name": "updatedAt",
             "objectMetadataUniversalIdentifier": Any<String>,
             "universalIdentifier": Any<String>,
@@ -9151,6 +9134,23 @@ exports[`Object metadata creation should fail v2 when names are identical 1`] = 
           ],
           "flatEntityMinimalInformation": {
             "name": "updatedBy",
+            "objectMetadataUniversalIdentifier": Any<String>,
+            "universalIdentifier": Any<String>,
+          },
+          "metadataName": "fieldMetadata",
+          "status": "fail",
+          "type": "create",
+        },
+        {
+          "errors": [
+            {
+              "code": "OBJECT_METADATA_NOT_FOUND",
+              "message": "Object metadata not found",
+              "userFriendlyMessage": "Field to create related object not found",
+            },
+          ],
+          "flatEntityMinimalInformation": {
+            "name": "searchVector",
             "objectMetadataUniversalIdentifier": Any<String>,
             "universalIdentifier": Any<String>,
           },
@@ -9797,23 +9797,6 @@ exports[`Object metadata creation should fail v2 when names with whitespaces res
             },
           ],
           "flatEntityMinimalInformation": {
-            "name": "searchVector",
-            "objectMetadataUniversalIdentifier": Any<String>,
-            "universalIdentifier": Any<String>,
-          },
-          "metadataName": "fieldMetadata",
-          "status": "fail",
-          "type": "create",
-        },
-        {
-          "errors": [
-            {
-              "code": "OBJECT_METADATA_NOT_FOUND",
-              "message": "Object metadata not found",
-              "userFriendlyMessage": "Field to create related object not found",
-            },
-          ],
-          "flatEntityMinimalInformation": {
             "name": "updatedAt",
             "objectMetadataUniversalIdentifier": Any<String>,
             "universalIdentifier": Any<String>,
@@ -9832,6 +9815,23 @@ exports[`Object metadata creation should fail v2 when names with whitespaces res
           ],
           "flatEntityMinimalInformation": {
             "name": "updatedBy",
+            "objectMetadataUniversalIdentifier": Any<String>,
+            "universalIdentifier": Any<String>,
+          },
+          "metadataName": "fieldMetadata",
+          "status": "fail",
+          "type": "create",
+        },
+        {
+          "errors": [
+            {
+              "code": "OBJECT_METADATA_NOT_FOUND",
+              "message": "Object metadata not found",
+              "userFriendlyMessage": "Field to create related object not found",
+            },
+          ],
+          "flatEntityMinimalInformation": {
+            "name": "searchVector",
             "objectMetadataUniversalIdentifier": Any<String>,
             "universalIdentifier": Any<String>,
           },


### PR DESCRIPTION
# Context

Since #22594 merged, `server-integration-test (12)` fails **deterministically** on main-based branches (reproduced 2/2 in CI on twentyhq/twenty#22682's merge head and 2/2 locally). It's easy to misread as flakiness or a crash because nx truncates the failed task's replayed output (~190KB) before jest's `FAIL`/summary lines ever reach the CI log.

# Root cause

`failing-create-one-object-metadata-v2.integration-spec.ts` — 15 of 19 tests fail on a snapshot mismatch. #22594 moved `searchVector` provisioning out of the reserved-system-fields path into its own side-effect handler (`ObjectSearchVectorOnCreateSideEffectHandlerService`, registered after `ObjectSystemFieldsOnCreateSideEffectHandlerService`), so the `searchVector` field entry now appears **after** `updatedAt`/`updatedBy` in the create-object validation report. The `.snap` file was rewritten in #22594 but kept the pre-PR `position → searchVector → updatedAt` ordering — i.e. it was adjusted against an older handler order rather than re-recorded.

Note: the `timelineActivity` FK-violation errors visible in these failing job logs are a red herring — they are pre-existing benign noise, present in green runs too (fire-and-forget timeline jobs racing hard-deletes in the people-merge suites; single-attempt jobs, never fail a test).

# Fix

Regenerated the snapshot with `jest -u` against a freshly seeded database; suite goes 19/19 green. The diff is a pure block move: only the `searchVector` / `updatedAt` / `updatedBy` name lines relocate, 15 occurrences each (45+/45−, one file, zero product code).

---
_Generated by [Claude Code](https://claude.ai/code/session_01AtD2wWm3EthV6t3Hs31QyB)_

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/22757?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

