### PR TITLE
Fix shard 12 integration test failure: regenerate stale object metadata snapshot from #22594

### DIFF
--- a/packages/twenty-server/test/integration/metadata/suites/object-metadata/__snapshots__/failing-create-one-object-metadata-v2.integration-spec.ts.snap
+++ b/packages/twenty-server/test/integration/metadata/suites/object-metadata/__snapshots__/failing-create-one-object-metadata-v2.integration-spec.ts.snap
@@ -117,23 +117,6 @@ exports[`Object metadata creation should fail v2 when labelPlural contains only 
             },
           ],
           "flatEntityMinimalInformation": {
-            "name": "searchVector",
-            "objectMetadataUniversalIdentifier": Any<String>,
-            "universalIdentifier": Any<String>,
-          },
-          "metadataName": "fieldMetadata",
-          "status": "fail",
-          "type": "create",
-        },
-        {
-          "errors": [
-            {
-              "code": "OBJECT_METADATA_NOT_FOUND",
-              "message": "Object metadata not found",
-              "userFriendlyMessage": "Field to create related object not found",
-            },
-          ],
-          "flatEntityMinimalInformation": {
             "name": "updatedAt",
             "objectMetadataUniversalIdentifier": Any<String>,
             "universalIdentifier": Any<String>,
@@ -152,6 +135,23 @@ exports[`Object metadata creation should fail v2 when labelPlural contains only 
           ],
           "flatEntityMinimalInformation": {
             "name": "updatedBy",
+            "objectMetadataUniversalIdentifier": Any<String>,
+            "universalIdentifier": Any<String>,
+          },
+          "metadataName": "fieldMetadata",
+          "status": "fail",
+          "type": "create",
+        },
+        {
+          "errors": [
+            {
+              "code": "OBJECT_METADATA_NOT_FOUND",
+              "message": "Object metadata not found",
+              "userFriendlyMessage": "Field to create related object not found",
+            },
+          ],
+          "flatEntityMinimalInformation": {
+            "name": "searchVector",
             "objectMetadataUniversalIdentifier": Any<String>,
             "universalIdentifier": Any<String>,
           },
@@ -798,23 +798,6 @@ exports[`Object metadata creation should fail v2 when labelPlural exceeds maximu
             },
           ],
           "flatEntityMinimalInformation": {
-            "name": "searchVector",
-            "objectMetadataUniversalIdentifier": Any<String>,
-            "universalIdentifier": Any<String>,
-          },
-          "metadataName": "fieldMetadata",
-          "status": "fail",
-          "type": "create",
-        },
-        {
-          "errors": [
-            {
-              "code": "OBJECT_METADATA_NOT_FOUND",
-              "message": "Object metadata not found",
-              "userFriendlyMessage": "Field to create related object not found",
-            },
-          ],
-          "flatEntityMinimalInformation": {
             "name": "updatedAt",
             "objectMetadataUniversalIdentifier": Any<String>,
             "universalIdentifier": Any<String>,
@@ -833,6 +816,23 @@ exports[`Object metadata creation should fail v2 when labelPlural exceeds maximu
           ],
           "flatEntityMinimalInformation": {
             "name": "updatedBy",
+            "objectMetadataUniversalIdentifier": Any<String>,
+            "universalIdentifier": Any<String>,
+          },
+          "metadataName": "fieldMetadata",
+          "status": "fail",
+          "type": "create",
+        },
+        {
+          "errors": [
+            {
+              "code": "OBJECT_METADATA_NOT_FOUND",
+              "message": "Object metadata not found",
+              "userFriendlyMessage": "Field to create related object not found",
+            },
+          ],
+          "flatEntityMinimalInformation": {
+            "name": "searchVector",
             "objectMetadataUniversalIdentifier": Any<String>,
             "universalIdentifier": Any<String>,
           },
@@ -1490,23 +1490,6 @@ exports[`Object metadata creation should fail v2 when labelSingular contains onl
             },
           ],
           "flatEntityMinimalInformation": {
-            "name": "searchVector",
-            "objectMetadataUniversalIdentifier": Any<String>,
-            "universalIdentifier": Any<String>,
-          },
-          "metadataName": "fieldMetadata",
-          "status": "fail",
-          "type": "create",
-        },
-        {
-          "errors": [
-            {
-              "code": "OBJECT_METADATA_NOT_FOUND",
-              "message": "Object metadata not found",
-              "userFriendlyMessage": "Field to create related object not found",
-            },
-          ],
-          "flatEntityMinimalInformation": {
             "name": "updatedAt",
             "objectMetadataUniversalIdentifier": Any<String>,
             "universalIdentifier": Any<String>,
@@ -1525,6 +1508,23 @@ exports[`Object metadata creation should fail v2 when labelSingular contains onl
           ],
           "flatEntityMinimalInformation": {
             "name": "updatedBy",
+            "objectMetadataUniversalIdentifier": Any<String>,
+            "universalIdentifier": Any<String>,
+          },
+          "metadataName": "fieldMetadata",
+          "status": "fail",
+          "type": "create",
+        },
+        {
+          "errors": [
+            {
+              "code": "OBJECT_METADATA_NOT_FOUND",
+              "message": "Object metadata not found",
+              "userFriendlyMessage": "Field to create related object not found",
+            },
+          ],
+          "flatEntityMinimalInformation": {
+            "name": "searchVector",
             "objectMetadataUniversalIdentifier": Any<String>,
             "universalIdentifier": Any<String>,
           },
@@ -2171,23 +2171,6 @@ exports[`Object metadata creation should fail v2 when labelSingular exceeds maxi
             },
           ],
           "flatEntityMinimalInformation": {
-            "name": "searchVector",
-            "objectMetadataUniversalIdentifier": Any<String>,
-            "universalIdentifier": Any<String>,
-          },
-          "metadataName": "fieldMetadata",
-          "status": "fail",
-          "type": "create",
-        },
-        {
-          "errors": [
-            {
-              "code": "OBJECT_METADATA_NOT_FOUND",
-              "message": "Object metadata not found",
-              "userFriendlyMessage": "Field to create related object not found",
-            },
-          ],
-          "flatEntityMinimalInformation": {
             "name": "updatedAt",
             "objectMetadataUniversalIdentifier": Any<String>,
             "universalIdentifier": Any<String>,
@@ -2206,6 +2189,23 @@ exports[`Object metadata creation should fail v2 when labelSingular exceeds maxi
           ],
           "flatEntityMinimalInformation": {
             "name": "updatedBy",
+            "objectMetadataUniversalIdentifier": Any<String>,
+            "universalIdentifier": Any<String>,
+          },
+          "metadataName": "fieldMetadata",
+          "status": "fail",
+          "type": "create",
+        },
+        {
+          "errors": [
+            {
+              "code": "OBJECT_METADATA_NOT_FOUND",
+              "message": "Object metadata not found",
+              "userFriendlyMessage": "Field to create related object not found",
+            },
+          ],
+          "flatEntityMinimalInformation": {
+            "name": "searchVector",
             "objectMetadataUniversalIdentifier": Any<String>,
             "universalIdentifier": Any<String>,
           },
@@ -2863,23 +2863,6 @@ exports[`Object metadata creation should fail v2 when name exceeds maximum lengt
             },
           ],
           "flatEntityMinimalInformation": {
-            "name": "searchVector",
-            "objectMetadataUniversalIdentifier": Any<String>,
-            "universalIdentifier": Any<String>,
-          },
-          "metadataName": "fieldMetadata",
-          "status": "fail",
-          "type": "create",
-        },
-        {
-          "errors": [
-            {
-              "code": "OBJECT_METADATA_NOT_FOUND",
-              "message": "Object metadata not found",
-              "userFriendlyMessage": "Field to create related object not found",
-            },
-          ],
-          "flatEntityMinimalInformation": {
             "name": "updatedAt",
             "objectMetadataUniversalIdentifier": Any<String>,
             "universalIdentifier": Any<String>,
@@ -2898,6 +2881,23 @@ exports[`Object metadata creation should fail v2 when name exceeds maximum lengt
           ],
           "flatEntityMinimalInformation": {
             "name": "updatedBy",
+            "objectMetadataUniversalIdentifier": Any<String>,
+            "universalIdentifier": Any<String>,
+          },
+          "metadataName": "fieldMetadata",
+          "status": "fail",
+          "type": "create",
+        },
+        {
+          "errors": [
+            {
+              "code": "OBJECT_METADATA_NOT_FOUND",
+              "message": "Object metadata not found",
+              "userFriendlyMessage": "Field to create related object not found",
+            },
+          ],
+          "flatEntityMinimalInformation": {
+            "name": "searchVector",
             "objectMetadataUniversalIdentifier": Any<String>,
             "universalIdentifier": Any<String>,
           },
@@ -3568,23 +3568,6 @@ exports[`Object metadata creation should fail v2 when namePlural has invalid cha
             },
           ],
           "flatEntityMinimalInformation": {
-            "name": "searchVector",
-            "objectMetadataUniversalIdentifier": Any<String>,
-            "universalIdentifier": Any<String>,
-          },
-          "metadataName": "fieldMetadata",
-          "status": "fail",
-          "type": "create",
-        },
-        {
-          "errors": [
-            {
-              "code": "OBJECT_METADATA_NOT_FOUND",
-              "message": "Object metadata not found",
-              "userFriendlyMessage": "Field to create related object not found",
-            },
-          ],
-          "flatEntityMinimalInformation": {
             "name": "updatedAt",
             "objectMetadataUniversalIdentifier": Any<String>,
             "universalIdentifier": Any<String>,
@@ -3603,6 +3586,23 @@ exports[`Object metadata creation should fail v2 when namePlural has invalid cha
           ],
           "flatEntityMinimalInformation": {
             "name": "updatedBy",
+            "objectMetadataUniversalIdentifier": Any<String>,
+            "universalIdentifier": Any<String>,
+          },
+          "metadataName": "fieldMetadata",
+          "status": "fail",
+          "type": "create",
+        },
+        {
+          "errors": [
+            {
+              "code": "OBJECT_METADATA_NOT_FOUND",
+              "message": "Object metadata not found",
+              "userFriendlyMessage": "Field to create related object not found",
+            },
+          ],
+          "flatEntityMinimalInformation": {
+            "name": "searchVector",
             "objectMetadataUniversalIdentifier": Any<String>,
             "universalIdentifier": Any<String>,
           },
@@ -4249,23 +4249,6 @@ exports[`Object metadata creation should fail v2 when namePlural is a reserved k
             },
           ],
           "flatEntityMinimalInformation": {
-            "name": "searchVector",
-            "objectMetadataUniversalIdentifier": Any<String>,
-            "universalIdentifier": Any<String>,
-          },
-          "metadataName": "fieldMetadata",
-          "status": "fail",
-          "type": "create",
-        },
-        {
-          "errors": [
-            {
-              "code": "OBJECT_METADATA_NOT_FOUND",
-              "message": "Object metadata not found",
-              "userFriendlyMessage": "Field to create related object not found",
-            },
-          ],
-          "flatEntityMinimalInformation": {
             "name": "updatedAt",
             "objectMetadataUniversalIdentifier": Any<String>,
             "universalIdentifier": Any<String>,
@@ -4284,6 +4267,23 @@ exports[`Object metadata creation should fail v2 when namePlural is a reserved k
           ],
           "flatEntityMinimalInformation": {
             "name": "updatedBy",
+            "objectMetadataUniversalIdentifier": Any<String>,
+            "universalIdentifier": Any<String>,
+          },
+          "metadataName": "fieldMetadata",
+          "status": "fail",
+          "type": "create",
+        },
+        {
+          "errors": [
+            {
+              "code": "OBJECT_METADATA_NOT_FOUND",
+              "message": "Object metadata not found",
+              "userFriendlyMessage": "Field to create related object not found",
+            },
+          ],
+          "flatEntityMinimalInformation": {
+            "name": "searchVector",
             "objectMetadataUniversalIdentifier": Any<String>,
             "universalIdentifier": Any<String>,
           },
@@ -4941,23 +4941,6 @@ exports[`Object metadata creation should fail v2 when namePlural is not camelCas
             },
           ],
           "flatEntityMinimalInformation": {
-            "name": "searchVector",
-            "objectMetadataUniversalIdentifier": Any<String>,
-            "universalIdentifier": Any<String>,
-          },
-          "metadataName": "fieldMetadata",
-          "status": "fail",
-          "type": "create",
-        },
-        {
-          "errors": [
-            {
-              "code": "OBJECT_METADATA_NOT_FOUND",
-              "message": "Object metadata not found",
-              "userFriendlyMessage": "Field to create related object not found",
-            },
-          ],
-          "flatEntityMinimalInformation": {
             "name": "updatedAt",
             "objectMetadataUniversalIdentifier": Any<String>,
             "universalIdentifier": Any<String>,
@@ -4976,6 +4959,23 @@ exports[`Object metadata creation should fail v2 when namePlural is not camelCas
           ],
           "flatEntityMinimalInformation": {
             "name": "updatedBy",
+            "objectMetadataUniversalIdentifier": Any<String>,
+            "universalIdentifier": Any<String>,
+          },
+          "metadataName": "fieldMetadata",
+          "status": "fail",
+          "type": "create",
+        },
+        {
+          "errors": [
+            {
+              "code": "OBJECT_METADATA_NOT_FOUND",
+              "message": "Object metadata not found",
+              "userFriendlyMessage": "Field to create related object not found",
+            },
+          ],
+          "flatEntityMinimalInformation": {
+            "name": "searchVector",
             "objectMetadataUniversalIdentifier": Any<String>,
             "universalIdentifier": Any<String>,
           },
@@ -5622,23 +5622,6 @@ exports[`Object metadata creation should fail v2 when nameSingular contains only
             },
           ],
           "flatEntityMinimalInformation": {
-            "name": "searchVector",
-            "objectMetadataUniversalIdentifier": Any<String>,
-            "universalIdentifier": Any<String>,
-          },
-          "metadataName": "fieldMetadata",
-          "status": "fail",
-          "type": "create",
-        },
-        {
-          "errors": [
-            {
-              "code": "OBJECT_METADATA_NOT_FOUND",
-              "message": "Object metadata not found",
-              "userFriendlyMessage": "Field to create related object not found",
-            },
-          ],
-          "flatEntityMinimalInformation": {
             "name": "updatedAt",
             "objectMetadataUniversalIdentifier": Any<String>,
             "universalIdentifier": Any<String>,
@@ -5657,6 +5640,23 @@ exports[`Object metadata creation should fail v2 when nameSingular contains only
           ],
           "flatEntityMinimalInformation": {
             "name": "updatedBy",
+            "objectMetadataUniversalIdentifier": Any<String>,
+            "universalIdentifier": Any<String>,
+          },
+          "metadataName": "fieldMetadata",
+          "status": "fail",
+          "type": "create",
+        },
+        {
+          "errors": [
+            {
+              "code": "OBJECT_METADATA_NOT_FOUND",
+              "message": "Object metadata not found",
+              "userFriendlyMessage": "Field to create related object not found",
+            },
+          ],
+          "flatEntityMinimalInformation": {
+            "name": "searchVector",
             "objectMetadataUniversalIdentifier": Any<String>,
             "universalIdentifier": Any<String>,
           },
@@ -6327,23 +6327,6 @@ exports[`Object metadata creation should fail v2 when nameSingular contains only
             },
           ],
           "flatEntityMinimalInformation": {
-            "name": "searchVector",
-            "objectMetadataUniversalIdentifier": Any<String>,
-            "universalIdentifier": Any<String>,
-          },
-          "metadataName": "fieldMetadata",
-          "status": "fail",
-          "type": "create",
-        },
-        {
-          "errors": [
-            {
-              "code": "OBJECT_METADATA_NOT_FOUND",
-              "message": "Object metadata not found",
-              "userFriendlyMessage": "Field to create related object not found",
-            },
-          ],
-          "flatEntityMinimalInformation": {
             "name": "updatedAt",
             "objectMetadataUniversalIdentifier": Any<String>,
             "universalIdentifier": Any<String>,
@@ -6362,6 +6345,23 @@ exports[`Object metadata creation should fail v2 when nameSingular contains only
           ],
           "flatEntityMinimalInformation": {
             "name": "updatedBy",
+            "objectMetadataUniversalIdentifier": Any<String>,
+            "universalIdentifier": Any<String>,
+          },
+          "metadataName": "fieldMetadata",
+          "status": "fail",
+          "type": "create",
+        },
+        {
+          "errors": [
+            {
+              "code": "OBJECT_METADATA_NOT_FOUND",
+              "message": "Object metadata not found",
+              "userFriendlyMessage": "Field to create related object not found",
+            },
+          ],
+          "flatEntityMinimalInformation": {
+            "name": "searchVector",
             "objectMetadataUniversalIdentifier": Any<String>,
             "universalIdentifier": Any<String>,
           },
@@ -7014,23 +7014,6 @@ exports[`Object metadata creation should fail v2 when nameSingular has invalid c
             },
           ],
           "flatEntityMinimalInformation": {
-            "name": "searchVector",
-            "objectMetadataUniversalIdentifier": Any<String>,
-            "universalIdentifier": Any<String>,
-          },
-          "metadataName": "fieldMetadata",
-          "status": "fail",
-          "type": "create",
-        },
-        {
-          "errors": [
-            {
-              "code": "OBJECT_METADATA_NOT_FOUND",
-              "message": "Object metadata not found",
-              "userFriendlyMessage": "Field to create related object not found",
-            },
-          ],
-          "flatEntityMinimalInformation": {
             "name": "updatedAt",
             "objectMetadataUniversalIdentifier": Any<String>,
             "universalIdentifier": Any<String>,
@@ -7049,6 +7032,23 @@ exports[`Object metadata creation should fail v2 when nameSingular has invalid c
           ],
           "flatEntityMinimalInformation": {
             "name": "updatedBy",
+            "objectMetadataUniversalIdentifier": Any<String>,
+            "universalIdentifier": Any<String>,
+          },
+          "metadataName": "fieldMetadata",
+          "status": "fail",
+          "type": "create",
+        },
+        {
+          "errors": [
+            {
+              "code": "OBJECT_METADATA_NOT_FOUND",
+              "message": "Object metadata not found",
+              "userFriendlyMessage": "Field to create related object not found",
+            },
+          ],
+          "flatEntityMinimalInformation": {
+            "name": "searchVector",
             "objectMetadataUniversalIdentifier": Any<String>,
             "universalIdentifier": Any<String>,
           },
@@ -7719,23 +7719,6 @@ exports[`Object metadata creation should fail v2 when nameSingular is a reserved
             },
           ],
           "flatEntityMinimalInformation": {
-            "name": "searchVector",
-            "objectMetadataUniversalIdentifier": Any<String>,
-            "universalIdentifier": Any<String>,
-          },
-          "metadataName": "fieldMetadata",
-          "status": "fail",
-          "type": "create",
-        },
-        {
-          "errors": [
-            {
-              "code": "OBJECT_METADATA_NOT_FOUND",
-              "message": "Object metadata not found",
-              "userFriendlyMessage": "Field to create related object not found",
-            },
-          ],
-          "flatEntityMinimalInformation": {
             "name": "updatedAt",
             "objectMetadataUniversalIdentifier": Any<String>,
             "universalIdentifier": Any<String>,
@@ -7754,6 +7737,23 @@ exports[`Object metadata creation should fail v2 when nameSingular is a reserved
           ],
           "flatEntityMinimalInformation": {
             "name": "updatedBy",
+            "objectMetadataUniversalIdentifier": Any<String>,
+            "universalIdentifier": Any<String>,
+          },
+          "metadataName": "fieldMetadata",
+          "status": "fail",
+          "type": "create",
+        },
+        {
+          "errors": [
+            {
+              "code": "OBJECT_METADATA_NOT_FOUND",
+              "message": "Object metadata not found",
+              "userFriendlyMessage": "Field to create related object not found",
+            },
+          ],
+          "flatEntityMinimalInformation": {
+            "name": "searchVector",
             "objectMetadataUniversalIdentifier": Any<String>,
             "universalIdentifier": Any<String>,
           },
@@ -8411,23 +8411,6 @@ exports[`Object metadata creation should fail v2 when nameSingular is not camelC
             },
           ],
           "flatEntityMinimalInformation": {
-            "name": "searchVector",
-            "objectMetadataUniversalIdentifier": Any<String>,
-            "universalIdentifier": Any<String>,
-          },
-          "metadataName": "fieldMetadata",
-          "status": "fail",
-          "type": "create",
-        },
-        {
-          "errors": [
-            {
-              "code": "OBJECT_METADATA_NOT_FOUND",
-              "message": "Object metadata not found",
-              "userFriendlyMessage": "Field to create related object not found",
-            },
-          ],
-          "flatEntityMinimalInformation": {
             "name": "updatedAt",
             "objectMetadataUniversalIdentifier": Any<String>,
             "universalIdentifier": Any<String>,
@@ -8446,6 +8429,23 @@ exports[`Object metadata creation should fail v2 when nameSingular is not camelC
           ],
           "flatEntityMinimalInformation": {
             "name": "updatedBy",
+            "objectMetadataUniversalIdentifier": Any<String>,
+            "universalIdentifier": Any<String>,
+          },
+          "metadataName": "fieldMetadata",
+          "status": "fail",
+          "type": "create",
+        },
+        {
+          "errors": [
+            {
+              "code": "OBJECT_METADATA_NOT_FOUND",
+              "message": "Object metadata not found",
+              "userFriendlyMessage": "Field to create related object not found",
+            },
+          ],
+          "flatEntityMinimalInformation": {
+            "name": "searchVector",
             "objectMetadataUniversalIdentifier": Any<String>,
             "universalIdentifier": Any<String>,
           },
@@ -9116,23 +9116,6 @@ exports[`Object metadata creation should fail v2 when names are identical 1`] = 
             },
           ],
           "flatEntityMinimalInformation": {
-            "name": "searchVector",
-            "objectMetadataUniversalIdentifier": Any<String>,
-            "universalIdentifier": Any<String>,
-          },
-          "metadataName": "fieldMetadata",
-          "status": "fail",
-          "type": "create",
-        },
-        {
-          "errors": [
-            {
-              "code": "OBJECT_METADATA_NOT_FOUND",
-              "message": "Object metadata not found",
-              "userFriendlyMessage": "Field to create related object not found",
-            },
-          ],
-          "flatEntityMinimalInformation": {
             "name": "updatedAt",
             "objectMetadataUniversalIdentifier": Any<String>,
             "universalIdentifier": Any<String>,
@@ -9151,6 +9134,23 @@ exports[`Object metadata creation should fail v2 when names are identical 1`] = 
           ],
           "flatEntityMinimalInformation": {
             "name": "updatedBy",
+            "objectMetadataUniversalIdentifier": Any<String>,
+            "universalIdentifier": Any<String>,
+          },
+          "metadataName": "fieldMetadata",
+          "status": "fail",
+          "type": "create",
+        },
+        {
+          "errors": [
+            {
+              "code": "OBJECT_METADATA_NOT_FOUND",
+              "message": "Object metadata not found",
+              "userFriendlyMessage": "Field to create related object not found",
+            },
+          ],
+          "flatEntityMinimalInformation": {
+            "name": "searchVector",
             "objectMetadataUniversalIdentifier": Any<String>,
             "universalIdentifier": Any<String>,
           },
@@ -9797,23 +9797,6 @@ exports[`Object metadata creation should fail v2 when names with whitespaces res
             },
           ],
           "flatEntityMinimalInformation": {
-            "name": "searchVector",
-            "objectMetadataUniversalIdentifier": Any<String>,
-            "universalIdentifier": Any<String>,
-          },
-          "metadataName": "fieldMetadata",
-          "status": "fail",
-          "type": "create",
-        },
-        {
-          "errors": [
-            {
-              "code": "OBJECT_METADATA_NOT_FOUND",
-              "message": "Object metadata not found",
-              "userFriendlyMessage": "Field to create related object not found",
-            },
-          ],
-          "flatEntityMinimalInformation": {
             "name": "updatedAt",
             "objectMetadataUniversalIdentifier": Any<String>,
             "universalIdentifier": Any<String>,
@@ -9832,6 +9815,23 @@ exports[`Object metadata creation should fail v2 when names with whitespaces res
           ],
           "flatEntityMinimalInformation": {
             "name": "updatedBy",
+            "objectMetadataUniversalIdentifier": Any<String>,
+            "universalIdentifier": Any<String>,
+          },
+          "metadataName": "fieldMetadata",
+          "status": "fail",
+          "type": "create",
+        },
+        {
+          "errors": [
+            {
+              "code": "OBJECT_METADATA_NOT_FOUND",
+              "message": "Object metadata not found",
+              "userFriendlyMessage": "Field to create related object not found",
+            },
+          ],
+          "flatEntityMinimalInformation": {
+            "name": "searchVector",
             "objectMetadataUniversalIdentifier": Any<String>,
             "universalIdentifier": Any<String>,
           },


### PR DESCRIPTION
# Context

Since #22594 merged (July 9, 16:59 CET), `server-integration-test (12)` fails deterministically on every main-based branch. The failure is easy to misread as flakiness because nx truncates the failed task's replayed output before jest's `FAIL`/summary lines reach the CI log; the visible `timelineActivity` FK-violation errors are pre-existing noise also present in green runs.

Note: the flakiness PRs merged yesterday morning (#22699, #22701, #22702) are not the cause. The failure window starts with #22594.

# Root cause

#22594 moved `searchVector` provisioning out of the reserved-system-fields path into its own side-effect handler, registered after `ObjectSystemFieldsOnCreateSideEffectHandlerService` in `metadata-side-effect-handlers.module.ts`. The `searchVector` field entry therefore now appears after `updatedAt`/`updatedBy` in the create-object validation report. The snapshot for `failing-create-one-object-metadata-v2.integration-spec.ts` was rewritten in #22594 but kept the old `position -> searchVector -> updatedAt` ordering, so 15 of the 19 tests fail on a snapshot mismatch.

Reproduced locally on latest main: 15/19 fail, diff is exactly the three reordered name lines.

# Fix

Regenerated the snapshot with `jest -u` against a freshly reset database. Suite is 19/19 green afterwards. The sibling snapshot suites in the same directory (`failing-update-one-object-metadata`, `failing-update-one-standard-object-metadata`, `successful-update-one-standard-object-metadata`) were re-run and pass unchanged.

Pure block move: only the `searchVector`/`updatedAt`/`updatedBy` name lines relocate, 15 occurrences each (45+/45-), one file, no product code.

# Related

- #22757 is an earlier draft with the same snapshot regeneration.
- #22758 fixes the same suite by replacing the snapshot with per-case contract assertions (plus an msw catch-all). If that one merges first, this PR becomes unnecessary.

---
_Generated by [Claude Code](https://claude.ai/code/session_01NPSkHDBHNQw4c1iJzFTxoA)_

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/22768?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

