### PR TITLE
Seed CHANGELOG.md and SETUP.md in create-twenty-app scaffold

### DIFF
--- a/packages/create-twenty-app/src/constants/template/CHANGELOG.md
+++ b/packages/create-twenty-app/src/constants/template/CHANGELOG.md
@@ -1,0 +1,7 @@
+# Changelog
+
+All notable changes to this application are documented in this file.
+
+## 0.1.0
+
+- Initial application scaffolded with [`create-twenty-app`](https://www.npmjs.com/package/create-twenty-app)

--- a/packages/create-twenty-app/src/constants/template/README.md
+++ b/packages/create-twenty-app/src/constants/template/README.md
@@ -1,24 +1,32 @@
-This is a [Twenty](https://twenty.com) application bootstrapped with [`create-twenty-app`](https://www.npmjs.com/package/create-twenty-app).
+# My Twenty App
 
-## Getting Started
+Describe your app in one or two sentences: what it does and why someone would install it. This README is the first thing people see, so lead with the value your app provides, not the tooling behind it.
 
-This app was scaffolded with a local Twenty server running at [http://localhost:2020](http://localhost:2020).
+Built on [Twenty](https://twenty.com) with [`create-twenty-app`](https://www.npmjs.com/package/create-twenty-app).
 
-Login with the default development credentials: `tim@apple.dev` / `tim@apple.dev`.
+## Features
+
+List the top things your app does, for example:
+
+- Feature one
+- Feature two
+- Feature three
+
+## Getting started
+
+Setup instructions live in [SETUP.md](SETUP.md). Once set up, start developing with:
+
+```bash
+yarn twenty dev
+```
 
 Run `yarn twenty help` to list all available commands.
 
-## Useful Commands
+## Changelog
 
-- `yarn twenty dev` - Start the development server and sync your app
-- `yarn twenty docker:status` - Check the local Twenty server status
-- `yarn twenty docker:start` - Start the local Twenty server
-- `yarn lint` - Lint the project with oxlint
-- `yarn typecheck` - Type-check the project
-- `yarn test:unit` - Run unit tests
-- `yarn test` - Run integration tests
+Notable changes are documented in [CHANGELOG.md](CHANGELOG.md).
 
-## Learn More
+## Learn more
 
 - [Twenty Apps documentation](https://docs.twenty.com/developers/extend/apps/getting-started/quick-start)
 - [twenty-sdk CLI reference](https://www.npmjs.com/package/twenty-sdk)

--- a/packages/create-twenty-app/src/constants/template/README.md
+++ b/packages/create-twenty-app/src/constants/template/README.md
@@ -1,8 +1,6 @@
 # My Twenty App
 
-Describe your app in one or two sentences: what it does and why someone would install it. This README is the first thing people see, so lead with the value your app provides, not the tooling behind it.
-
-Built on [Twenty](https://twenty.com) with [`create-twenty-app`](https://www.npmjs.com/package/create-twenty-app).
+Describe your app in one or two sentences.
 
 ## Features
 
@@ -14,13 +12,7 @@ List the top things your app does, for example:
 
 ## Getting started
 
-Setup instructions live in [SETUP.md](SETUP.md). Once set up, start developing with:
-
-```bash
-yarn twenty dev
-```
-
-Run `yarn twenty help` to list all available commands.
+Setup instructions live in [SETUP.md](SETUP.md).
 
 ## Changelog
 

--- a/packages/create-twenty-app/src/constants/template/SETUP.md
+++ b/packages/create-twenty-app/src/constants/template/SETUP.md
@@ -1,0 +1,44 @@
+# Setup
+
+Follow these steps to get your app running locally.
+
+## Prerequisites
+
+- Node.js (version specified in `.nvmrc`)
+- Yarn 4
+- Docker (to run the local Twenty server)
+
+## Steps
+
+1. Install dependencies:
+
+   ```bash
+   yarn install
+   ```
+
+2. Start the local Twenty server:
+
+   ```bash
+   yarn twenty docker:start
+   ```
+
+   Check the server status at any time with `yarn twenty docker:status`.
+
+3. Start the development server and sync your app:
+
+   ```bash
+   yarn twenty dev
+   ```
+
+4. Open [http://localhost:2020](http://localhost:2020) and log in with the default development credentials: `tim@apple.dev` / `tim@apple.dev`.
+
+## Verifying your setup
+
+- `yarn lint` - Lint the project with oxlint
+- `yarn typecheck` - Type-check the project
+- `yarn test:unit` - Run unit tests
+- `yarn test` - Run integration tests
+
+## Troubleshooting
+
+See the [troubleshooting guide](https://docs.twenty.com/developers/extend/apps/getting-started/troubleshooting) or ask on [Discord](https://discord.gg/cx5n4Jzs57).

--- a/packages/create-twenty-app/src/utils/__tests__/app-template.spec.ts
+++ b/packages/create-twenty-app/src/utils/__tests__/app-template.spec.ts
@@ -212,6 +212,23 @@ describe('copyBaseApplicationProject', () => {
     expect(content).toContain("APP_DESCRIPTION = ''");
   });
 
+  it.each(['CHANGELOG.md', 'SETUP.md'])(
+    'should seed %s in the base template',
+    async (seedFileName) => {
+      const templateDirectory = join(
+        __dirname,
+        '..',
+        '..',
+        'constants',
+        'template',
+      );
+
+      expect(await fs.pathExists(join(templateDirectory, seedFileName))).toBe(
+        true,
+      );
+    },
+  );
+
   it('should generate unique UUIDs across different scaffolds', async () => {
     const firstAppDir = join(testAppDirectory, 'app1');
     await fs.ensureDir(join(firstAppDir, 'src', 'constants'));

--- a/packages/twenty-docs/developers/extend/apps/getting-started/project-structure.mdx
+++ b/packages/twenty-docs/developers/extend/apps/getting-started/project-structure.mdx
@@ -33,7 +33,7 @@ my-twenty-app/
   vitest.unit.config.ts                     # Unit test runner config
   tsconfig.json, tsconfig.spec.json
   .nvmrc, .yarnrc.yml, .oxlintrc.json
-  README.md, AGENTS.md, CLAUDE.md
+  README.md, AGENTS.md, CLAUDE.md, CHANGELOG.md, SETUP.md
 ```
 
 ## Key files

--- a/packages/twenty-docs/developers/extend/apps/getting-started/project-structure.mdx
+++ b/packages/twenty-docs/developers/extend/apps/getting-started/project-structure.mdx
@@ -47,6 +47,7 @@ my-twenty-app/
 | `src/__tests__/` | A unit test plus an integration test (with its global setup) that syncs the app against a real server. |
 | `public/` | Static assets (images, fonts) served with your app. |
 | `AGENTS.md` / `CLAUDE.md` | Guidance for AI coding agents working on the app. |
+| `CHANGELOG.md` / `SETUP.md` | Changelog of notable changes and setup instructions for local development. |
 
 <Note>
 **File organization is up to you.** The folders above are conventions — the SDK detects entities via AST analysis on `export default defineEntity(...)` calls regardless of where the file lives.


### PR DESCRIPTION
Projects scaffolded with `create-twenty-app` now include two additional seed files:

- `CHANGELOG.md` with an initial `0.1.0` entry matching the template's package version
- `SETUP.md` with step-by-step local setup instructions (prerequisites, install, local server, dev sync, verification commands)

Both files live in `src/constants/template/`, so they flow through the existing `fs.copy` scaffolding and the vite `copy-assets` build step with no code changes. Verified `dist/constants/template/` contains both files after `nx build create-twenty-app`.

The scaffolded `README.md` was also simplified into a marketable front page for the app being built: a pitch placeholder, a features section, and links to `SETUP.md` for setup instructions and `CHANGELOG.md` for history, instead of duplicating dev commands.

Also:

- Adds a regression test asserting the template directory contains both seed files
- Updates `project-structure.mdx` docs to list the new files in the scaffold directory tree