### PR TITLE
fix: recognize mixed-case http(s) schemes in ensureAbsoluteUrl

### DIFF
--- a/packages/twenty-shared/src/utils/url/__tests__/ensureAbsoluteUrl.test.ts
+++ b/packages/twenty-shared/src/utils/url/__tests__/ensureAbsoluteUrl.test.ts
@@ -21,6 +21,22 @@ describe('ensureAbsoluteUrl', () => {
     expect(ensureAbsoluteUrl('HTTP://example.com')).toBe('HTTP://example.com');
   });
 
+  it('should return mixed-case scheme URL as-is when it is already absolute', () => {
+    expect(ensureAbsoluteUrl('Https://example.com')).toBe(
+      'Https://example.com',
+    );
+    expect(ensureAbsoluteUrl('Http://example.com')).toBe('Http://example.com');
+    expect(ensureAbsoluteUrl('HttpS://example.com')).toBe(
+      'HttpS://example.com',
+    );
+  });
+
+  it('should not prepend https:// to a mixed-case absolute URL', () => {
+    expect(ensureAbsoluteUrl('Https://example.com')).not.toContain(
+      'https://Https://',
+    );
+  });
+
   it('should prepend https:// to bare domains', () => {
     expect(ensureAbsoluteUrl('example.com')).toBe('https://example.com');
   });

--- a/packages/twenty-shared/src/utils/url/ensureAbsoluteUrl.ts
+++ b/packages/twenty-shared/src/utils/url/ensureAbsoluteUrl.ts
@@ -1,12 +1,9 @@
 export const ensureAbsoluteUrl = (value: string): string => {
   const trimmedValue = value.trim();
 
-  if (
-    trimmedValue.startsWith('http://') ||
-    trimmedValue.startsWith('https://') ||
-    trimmedValue.startsWith('HTTPS://') ||
-    trimmedValue.startsWith('HTTP://')
-  ) {
+  // URL schemes are case-insensitive, so match any casing (e.g. mobile
+  // keyboards auto-capitalize the first letter into "Https://")
+  if (/^https?:\/\//i.test(trimmedValue)) {
     return trimmedValue;
   }
 


### PR DESCRIPTION
Closes #22773

### What

`ensureAbsoluteUrl` decides whether a value is already absolute by checking for the exact prefixes `http://`, `https://`, `HTTP://` and `HTTPS://`.

URL schemes are case-insensitive, so any *other* casing of the scheme fails all four checks. A very common source of this is mobile keyboards, which auto-capitalize the first typed letter — so a user typing a link produces `Https://example.com`. The function then treats it as relative and prepends a second scheme:

```ts
ensureAbsoluteUrl('Https://example.com'); // => 'https://Https://example.com'  ❌
```

This affects any user-entered link that flows through `ensureAbsoluteUrl`, including record link fields, navigation-menu item links, webhook URLs, and `normalizeUrl`.

### How

Replace the four exact-case prefix checks with a single case-insensitive regex (`/^https?:\/\//i`).

All existing behavior is preserved:
- lowercase / all-caps schemes are still returned as-is,
- bare domains still get `https://` prepended,
- surrounding whitespace is still trimmed.

```ts
ensureAbsoluteUrl('Https://example.com'); // => 'Https://example.com'  ✅
```

### Tests

Added regression tests to `ensureAbsoluteUrl.test.ts` covering mixed-case schemes (`Https://`, `Http://`, `HttpS://`).

```
cd packages/twenty-shared && npx jest ensureAbsoluteUrl
# 8 passed, 8 total
```
