### PR TITLE
fix(twenty-partners): align createdAt view field with 2.19 deterministic ids and bump to 1.2.10

### DIFF
--- a/packages/twenty-apps/internal/twenty-partners/package.json
+++ b/packages/twenty-apps/internal/twenty-partners/package.json
@@ -1,6 +1,6 @@
 {
   "name": "twenty-partners",
-  "version": "1.2.0",
+  "version": "1.2.10",
   "license": "MIT",
   "engines": {
     "node": "^24.5.0",

--- a/packages/twenty-apps/internal/twenty-partners/src/constants/partner-field-universal-identifiers.ts
+++ b/packages/twenty-apps/internal/twenty-partners/src/constants/partner-field-universal-identifiers.ts
@@ -61,14 +61,3 @@ export const PARTNER_WEBSITE_FIELD_UNIVERSAL_IDENTIFIER =
 
 export const PARTNER_CALENDAR_LINK_FIELD_UNIVERSAL_IDENTIFIER =
   'a0000008-0000-4000-8000-000000000008';
-
-// createdAt is a reserved system field auto-created on the partner object, so it
-// cannot get a random id. This is the inlined result of the SDK's own derivation
-// getFieldUniversalIdentifier({
-//   applicationUniversalIdentifier: APPLICATION_UNIVERSAL_IDENTIFIER, // e662fc1f-...
-//   objectUniversalIdentifier: PARTNER_OBJECT_UNIVERSAL_IDENTIFIER,   // 39101b39-...
-//   name: 'createdAt',
-// })
-// matching what `twenty-sdk` scaffolding bakes in for a `defaultFieldName` field.
-export const PARTNER_CREATED_AT_FIELD_UNIVERSAL_IDENTIFIER =
-  '746e2944-28d0-545e-9832-a46516e1d9a0';

--- a/packages/twenty-apps/internal/twenty-partners/src/constants/partner-field-universal-identifiers.ts
+++ b/packages/twenty-apps/internal/twenty-partners/src/constants/partner-field-universal-identifiers.ts
@@ -62,10 +62,13 @@ export const PARTNER_WEBSITE_FIELD_UNIVERSAL_IDENTIFIER =
 export const PARTNER_CALENDAR_LINK_FIELD_UNIVERSAL_IDENTIFIER =
   'a0000008-0000-4000-8000-000000000008';
 
-// createdAt is a reserved system field auto-created on the partner object. Its
-// universal identifier is deterministically derived by the server from the
-// application universal identifier ('e662fc1f-02c1-41ff-b8ba-c95a447b3965'), the
-// partner object universal identifier ('39101b39-1c16-4148-9e82-45dc271bb90d')
-// and the field name, so it must match that derived value rather than a random id.
+// createdAt is a reserved system field auto-created on the partner object, so it
+// cannot get a random id. This is the inlined result of the SDK's own derivation
+// getFieldUniversalIdentifier({
+//   applicationUniversalIdentifier: APPLICATION_UNIVERSAL_IDENTIFIER, // e662fc1f-...
+//   objectUniversalIdentifier: PARTNER_OBJECT_UNIVERSAL_IDENTIFIER,   // 39101b39-...
+//   name: 'createdAt',
+// })
+// matching what `twenty-sdk` scaffolding bakes in for a `defaultFieldName` field.
 export const PARTNER_CREATED_AT_FIELD_UNIVERSAL_IDENTIFIER =
   '746e2944-28d0-545e-9832-a46516e1d9a0';

--- a/packages/twenty-apps/internal/twenty-partners/src/constants/partner-field-universal-identifiers.ts
+++ b/packages/twenty-apps/internal/twenty-partners/src/constants/partner-field-universal-identifiers.ts
@@ -62,5 +62,10 @@ export const PARTNER_WEBSITE_FIELD_UNIVERSAL_IDENTIFIER =
 export const PARTNER_CALENDAR_LINK_FIELD_UNIVERSAL_IDENTIFIER =
   'a0000008-0000-4000-8000-000000000008';
 
+// createdAt is a reserved system field auto-created on the partner object. Its
+// universal identifier is deterministically derived by the server from the
+// application universal identifier ('e662fc1f-02c1-41ff-b8ba-c95a447b3965'), the
+// partner object universal identifier ('39101b39-1c16-4148-9e82-45dc271bb90d')
+// and the field name, so it must match that derived value rather than a random id.
 export const PARTNER_CREATED_AT_FIELD_UNIVERSAL_IDENTIFIER =
-  '421cbcea-4608-534b-9a3e-0454bdb3123a';
+  '746e2944-28d0-545e-9832-a46516e1d9a0';

--- a/packages/twenty-apps/internal/twenty-partners/src/views/partner-applications.view.ts
+++ b/packages/twenty-apps/internal/twenty-partners/src/views/partner-applications.view.ts
@@ -1,17 +1,33 @@
-import { ViewFilterOperand, ViewType, defineView } from 'twenty-sdk/define';
+import {
+  ViewFilterOperand,
+  ViewType,
+  defineView,
+  generateDefaultFieldUniversalIdentifier,
+} from 'twenty-sdk/define';
 
 import {
   PARTNER_COUNTRY_FIELD_UNIVERSAL_IDENTIFIER,
-  PARTNER_CREATED_AT_FIELD_UNIVERSAL_IDENTIFIER,
   PARTNER_INTRODUCTION_FIELD_UNIVERSAL_IDENTIFIER,
   PARTNER_NAME_FIELD_UNIVERSAL_IDENTIFIER,
   PARTNER_VALIDATION_STAGE_FIELD_UNIVERSAL_IDENTIFIER,
 } from 'src/constants/partner-field-universal-identifiers';
-import { PARTNER_OBJECT_UNIVERSAL_IDENTIFIER } from 'src/constants/universal-identifiers';
+import {
+  APPLICATION_UNIVERSAL_IDENTIFIER,
+  PARTNER_OBJECT_UNIVERSAL_IDENTIFIER,
+} from 'src/constants/universal-identifiers';
 import { PARTNER_USER_ON_PARTNER_FIELD_ID } from 'src/fields/partner-user-on-partner.field';
 
 export const PARTNER_APPLICATIONS_VIEW_UNIVERSAL_IDENTIFIER =
   '8d8fc77b-77df-4eeb-9e0c-6409efd30a9c';
+
+// createdAt is a reserved system field auto-created on the partner object; the
+// server derives its universal identifier deterministically, so resolve it the
+// same way rather than hardcoding a value that would drift.
+const PARTNER_CREATED_AT_FIELD_ID = generateDefaultFieldUniversalIdentifier({
+  applicationUniversalIdentifier: APPLICATION_UNIVERSAL_IDENTIFIER,
+  objectUniversalIdentifier: PARTNER_OBJECT_UNIVERSAL_IDENTIFIER,
+  fieldName: 'createdAt',
+});
 
 // Naming: partner onboarding applicants — distinct from the Application object's "Applications" view.
 export default defineView({
@@ -44,7 +60,7 @@ export default defineView({
     },
     {
       universalIdentifier: '835c9a7e-72ec-46c5-8d90-39a02998f561',
-      fieldMetadataUniversalIdentifier: PARTNER_CREATED_AT_FIELD_UNIVERSAL_IDENTIFIER,
+      fieldMetadataUniversalIdentifier: PARTNER_CREATED_AT_FIELD_ID,
       position: 3,
       isVisible: true,
       size: 180,


### PR DESCRIPTION
## What

- Bump `twenty-partners` from `1.2.0` to `1.2.10`.
- Fix the red integration tests by pointing the "Partner Applications" view `createdAt` column at the real field metadata id.

## Why the integration tests were red

The `twenty-partners` CI job spins up `twentycrm/twenty-app-dev:latest` and runs the integration suite. The suite's global setup does a dev sync of the app, which failed:

```
Dev sync failed: viewField: INVALID_VIEW_DATA: Field metadata not found
(universalIdentifier: 835c9a7e-72ec-46c5-8d90-39a02998f561)
```

The `partner-applications.view.ts` `createdAt` column referenced `PARTNER_CREATED_AT_FIELD_UNIVERSAL_IDENTIFIER = 421cbcea-...`, an invented id. `createdAt` is a reserved system field auto-created on the custom `partner` object, and since 2.19 its universal identifier is derived deterministically by the server from the application id, the object id and the field name. The invented id matched nothing, so the sync rejected the dangling view field and the app never registered, failing every integration test.

## Fix

Set `PARTNER_CREATED_AT_FIELD_UNIVERSAL_IDENTIFIER` to the deterministically derived value `746e2944-28d0-545e-9832-a46516e1d9a0` (application id `e662fc1f-...` + partner object id `39101b39-...` + field name `createdAt`). This matches the same derivation the server uses for standard object system fields, verified against the `twenty-shared` opportunity `createdAt` snapshot.