### PR TITLE
feat(workflow): read database-event triggers from core cache (flag-gated)

### DIFF
--- a/packages/twenty-server/src/modules/workflow/workflow-trigger/automated-trigger/automated-trigger.module.ts
+++ b/packages/twenty-server/src/modules/workflow/workflow-trigger/automated-trigger/automated-trigger.module.ts
@@ -3,7 +3,9 @@ import { TypeOrmModule } from '@nestjs/typeorm';
 
 import { CacheStorageModule } from 'src/engine/core-modules/cache-storage/cache-storage.module';
 import { CronModule } from 'src/engine/core-modules/cron/cron.module';
+import { FeatureFlagModule } from 'src/engine/core-modules/feature-flag/feature-flag.module';
 import { WorkspaceEntity } from 'src/engine/core-modules/workspace/workspace.entity';
+import { WorkspaceCacheModule } from 'src/engine/workspace-cache/workspace-cache.module';
 import { WorkspaceDataSourceModule } from 'src/engine/workspace-datasource/workspace-datasource.module';
 import { WorkflowCommonModule } from 'src/modules/workflow/common/workflow-common.module';
 import { AutomatedTriggerWorkspaceService } from 'src/modules/workflow/workflow-trigger/automated-trigger/automated-trigger.workspace-service';
@@ -16,7 +18,9 @@ import { WorkflowDatabaseEventTriggerListener } from 'src/modules/workflow/workf
     TypeOrmModule.forFeature([WorkspaceEntity]),
     CacheStorageModule,
     CronModule,
+    FeatureFlagModule,
     WorkflowCommonModule,
+    WorkspaceCacheModule,
     WorkspaceDataSourceModule,
   ],
   providers: [

--- a/packages/twenty-server/src/modules/workflow/workflow-trigger/automated-trigger/listeners/__tests__/workflow-database-event-trigger.listener.spec.ts
+++ b/packages/twenty-server/src/modules/workflow/workflow-trigger/automated-trigger/listeners/__tests__/workflow-database-event-trigger.listener.spec.ts
@@ -1,8 +1,10 @@
 import { Test, type TestingModule } from '@nestjs/testing';
 
+import { FeatureFlagService } from 'src/engine/core-modules/feature-flag/services/feature-flag.service';
 import { MessageQueueService } from 'src/engine/core-modules/message-queue/services/message-queue.service';
 import { type FlatObjectMetadata } from 'src/engine/metadata-modules/flat-object-metadata/types/flat-object-metadata.type';
 import { GlobalWorkspaceOrmManager } from 'src/engine/twenty-orm/global-workspace-datasource/global-workspace-orm.manager';
+import { WorkspaceCacheService } from 'src/engine/workspace-cache/services/workspace-cache.service';
 import { type WorkspaceEventBatch } from 'src/engine/workspace-event-emitter/types/workspace-event-batch.type';
 import { AutomatedTriggerType } from 'src/modules/workflow/common/standard-objects/workflow-automated-trigger.workspace-entity';
 import { WorkflowCommonWorkspaceService } from 'src/modules/workflow/common/workspace-services/workflow-common.workspace-service';
@@ -13,6 +15,8 @@ describe('WorkflowDatabaseEventTriggerListener', () => {
   let listener: WorkflowDatabaseEventTriggerListener;
   let globalWorkspaceOrmManager: jest.Mocked<GlobalWorkspaceOrmManager>;
   let messageQueueService: jest.Mocked<MessageQueueService>;
+  let featureFlagService: jest.Mocked<FeatureFlagService>;
+  let workspaceCacheService: jest.Mocked<WorkspaceCacheService>;
 
   const mockRepository = {
     find: jest.fn(),
@@ -58,6 +62,14 @@ describe('WorkflowDatabaseEventTriggerListener', () => {
       add: jest.fn(),
     } as any;
 
+    featureFlagService = {
+      isFeatureEnabled: jest.fn().mockResolvedValue(false),
+    } as any;
+
+    workspaceCacheService = {
+      getOrRecompute: jest.fn(),
+    } as any;
+
     const module: TestingModule = await Test.createTestingModule({
       providers: [
         WorkflowDatabaseEventTriggerListener,
@@ -72,6 +84,14 @@ describe('WorkflowDatabaseEventTriggerListener', () => {
         {
           provide: 'MESSAGE_QUEUE_workflow-queue',
           useValue: messageQueueService,
+        },
+        {
+          provide: FeatureFlagService,
+          useValue: featureFlagService,
+        },
+        {
+          provide: WorkspaceCacheService,
+          useValue: workspaceCacheService,
         },
         {
           provide: WorkflowCommonWorkspaceService,
@@ -446,6 +466,78 @@ describe('WorkflowDatabaseEventTriggerListener', () => {
       ]);
 
       await listener.handleObjectRecordUpdateEvent(positionOnlyPayload);
+
+      expect(messageQueueService.add).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('core read switch (IS_WORKFLOW_VERSION_IN_CORE_ENABLED)', () => {
+    const workspaceId = 'test-workspace';
+    const databaseEventName = 'testEvent';
+    const workflowId = 'test-workflow';
+
+    const mockPayload: WorkspaceEventBatch<any> = {
+      workspaceId,
+      name: databaseEventName,
+      objectMetadata: createMockFlatObjectMetadata({}),
+      events: [
+        {
+          recordId: 'test-record',
+          properties: {
+            updatedFields: ['field1'],
+            before: { field1: 'old' },
+            after: { field1: 'new' },
+          },
+        },
+      ],
+    };
+
+    beforeEach(() => {
+      featureFlagService.isFeatureEnabled.mockResolvedValue(true);
+      workspaceCacheService.getOrRecompute.mockResolvedValue({
+        workflowAutomatedTriggerMaps: {
+          byWorkflowId: {
+            [workflowId]: {
+              type: AutomatedTriggerType.DATABASE_EVENT,
+              workflowId,
+              workflowVersionId: 'test-version',
+              settings: { eventName: databaseEventName, fields: ['field1'] },
+            },
+          },
+        },
+      } as any);
+    });
+
+    it('dispatches from the core cache without reading the workspace table', async () => {
+      await listener.handleObjectRecordUpdateEvent(mockPayload);
+
+      expect(workspaceCacheService.getOrRecompute).toHaveBeenCalledWith(
+        workspaceId,
+        ['workflowAutomatedTriggerMaps'],
+      );
+      expect(mockRepository.find).not.toHaveBeenCalled();
+      expect(messageQueueService.add).toHaveBeenCalledWith(
+        WorkflowTriggerJob.name,
+        { workspaceId, workflowId, payload: mockPayload.events[0] },
+        { retryLimit: 3 },
+      );
+    });
+
+    it('ignores core triggers whose eventName does not match', async () => {
+      workspaceCacheService.getOrRecompute.mockResolvedValue({
+        workflowAutomatedTriggerMaps: {
+          byWorkflowId: {
+            [workflowId]: {
+              type: AutomatedTriggerType.DATABASE_EVENT,
+              workflowId,
+              workflowVersionId: 'test-version',
+              settings: { eventName: 'otherEvent', fields: [] },
+            },
+          },
+        },
+      } as any);
+
+      await listener.handleObjectRecordUpdateEvent(mockPayload);
 
       expect(messageQueueService.add).not.toHaveBeenCalled();
     });

--- a/packages/twenty-server/src/modules/workflow/workflow-trigger/automated-trigger/listeners/workflow-database-event-trigger.listener.ts
+++ b/packages/twenty-server/src/modules/workflow/workflow-trigger/automated-trigger/listeners/workflow-database-event-trigger.listener.ts
@@ -8,13 +8,14 @@ import {
   type ObjectRecordUpdateEvent,
   type ObjectRecordUpsertEvent,
 } from 'twenty-shared/database-events';
-import { type ObjectRecord } from 'twenty-shared/types';
+import { FeatureFlagKey, type ObjectRecord } from 'twenty-shared/types';
 import { isDefined, isNonEmptyArray } from 'twenty-shared/utils';
 import { TRIGGER_STEP_ID } from 'twenty-shared/workflow';
 import { In, Raw } from 'typeorm';
 
 import { OnDatabaseBatchEvent } from 'src/engine/api/graphql/graphql-query-runner/decorators/on-database-batch-event.decorator';
 import { DatabaseEventAction } from 'src/engine/api/graphql/graphql-query-runner/enums/database-event-action';
+import { FeatureFlagService } from 'src/engine/core-modules/feature-flag/services/feature-flag.service';
 import { InjectMessageQueue } from 'src/engine/core-modules/message-queue/decorators/message-queue.decorator';
 import { MessageQueue } from 'src/engine/core-modules/message-queue/message-queue.constants';
 import { MessageQueueService } from 'src/engine/core-modules/message-queue/services/message-queue.service';
@@ -26,6 +27,7 @@ import { buildFieldMapsFromFlatObjectMetadata } from 'src/engine/metadata-module
 import { type FlatObjectMetadata } from 'src/engine/metadata-modules/flat-object-metadata/types/flat-object-metadata.type';
 import { GlobalWorkspaceOrmManager } from 'src/engine/twenty-orm/global-workspace-datasource/global-workspace-orm.manager';
 import { buildSystemAuthContext } from 'src/engine/twenty-orm/utils/build-system-auth-context.util';
+import { WorkspaceCacheService } from 'src/engine/workspace-cache/services/workspace-cache.service';
 import { type WorkspaceEventBatch } from 'src/engine/workspace-event-emitter/types/workspace-event-batch.type';
 import {
   AutomatedTriggerType,
@@ -42,9 +44,14 @@ import {
   type WorkflowTriggerJobData,
 } from 'src/modules/workflow/workflow-trigger/jobs/workflow-trigger.job';
 
+type WorkflowAutomatedTriggerEventListener = Pick<
+  WorkflowAutomatedTriggerWorkspaceEntity,
+  'settings' | 'workflowId'
+>;
+
 type TriggerEvaluationArgs = {
   eventPayload: ObjectRecordEvent;
-  eventListener: WorkflowAutomatedTriggerWorkspaceEntity;
+  eventListener: WorkflowAutomatedTriggerEventListener;
   action: DatabaseEventAction;
 };
 
@@ -59,6 +66,8 @@ export class WorkflowDatabaseEventTriggerListener {
     @InjectMessageQueue(MessageQueue.workflowQueue)
     private readonly messageQueueService: MessageQueueService,
     private readonly workflowCommonWorkspaceService: WorkflowCommonWorkspaceService,
+    private readonly workspaceCacheService: WorkspaceCacheService,
+    private readonly featureFlagService: FeatureFlagService,
   ) {}
 
   @OnDatabaseBatchEvent('*', DatabaseEventAction.CREATED)
@@ -343,11 +352,83 @@ export class WorkflowDatabaseEventTriggerListener {
   }) {
     const workspaceId = payload.workspaceId;
     const databaseEventName = payload.name;
-    const automatedTriggerTableName = 'workflowAutomatedTrigger';
 
+    const eventListeners = await this.getDatabaseEventListeners(
+      workspaceId,
+      databaseEventName,
+    );
+
+    for (const eventListener of eventListeners) {
+      for (const eventPayload of payload.events) {
+        const shouldTriggerJob = this.shouldTriggerJob({
+          eventPayload,
+          eventListener,
+          action,
+        });
+
+        if (shouldTriggerJob) {
+          await this.messageQueueService.add<WorkflowTriggerJobData>(
+            WorkflowTriggerJob.name,
+            {
+              workspaceId,
+              workflowId: eventListener.workflowId,
+              payload: eventPayload,
+            },
+            { retryLimit: 3 },
+          );
+        }
+      }
+    }
+  }
+
+  private async getDatabaseEventListeners(
+    workspaceId: string,
+    databaseEventName: string,
+  ): Promise<WorkflowAutomatedTriggerEventListener[]> {
+    const isWorkflowVersionInCoreEnabled =
+      await this.featureFlagService.isFeatureEnabled(
+        FeatureFlagKey.IS_WORKFLOW_VERSION_IN_CORE_ENABLED,
+        workspaceId,
+      );
+
+    if (isWorkflowVersionInCoreEnabled) {
+      return this.getDatabaseEventListenersFromCore(
+        workspaceId,
+        databaseEventName,
+      );
+    }
+
+    return this.getDatabaseEventListenersFromWorkspace(
+      workspaceId,
+      databaseEventName,
+    );
+  }
+
+  private async getDatabaseEventListenersFromCore(
+    workspaceId: string,
+    databaseEventName: string,
+  ): Promise<WorkflowAutomatedTriggerEventListener[]> {
+    const { workflowAutomatedTriggerMaps } =
+      await this.workspaceCacheService.getOrRecompute(workspaceId, [
+        'workflowAutomatedTriggerMaps',
+      ]);
+
+    return Object.values(workflowAutomatedTriggerMaps.byWorkflowId).filter(
+      (automatedTrigger) =>
+        automatedTrigger.type === AutomatedTriggerType.DATABASE_EVENT &&
+        (automatedTrigger.settings as BaseDatabaseEventTriggerSettings)
+          .eventName === databaseEventName,
+    );
+  }
+
+  private async getDatabaseEventListenersFromWorkspace(
+    workspaceId: string,
+    databaseEventName: string,
+  ): Promise<WorkflowAutomatedTriggerEventListener[]> {
+    const automatedTriggerTableName = 'workflowAutomatedTrigger';
     const authContext = buildSystemAuthContext(workspaceId);
 
-    await this.globalWorkspaceOrmManager.executeInWorkspaceContext(async () => {
+    return this.globalWorkspaceOrmManager.executeInWorkspaceContext(async () => {
       const workflowAutomatedTriggerRepository =
         await this.globalWorkspaceOrmManager.getRepository<WorkflowAutomatedTriggerWorkspaceEntity>(
           workspaceId,
@@ -355,7 +436,7 @@ export class WorkflowDatabaseEventTriggerListener {
           { shouldBypassPermissionChecks: true },
         );
 
-      const eventListeners = await workflowAutomatedTriggerRepository.find({
+      return workflowAutomatedTriggerRepository.find({
         where: {
           type: AutomatedTriggerType.DATABASE_EVENT,
           settings: Raw(
@@ -365,28 +446,6 @@ export class WorkflowDatabaseEventTriggerListener {
           ),
         },
       });
-
-      for (const eventListener of eventListeners) {
-        for (const eventPayload of payload.events) {
-          const shouldTriggerJob = this.shouldTriggerJob({
-            eventPayload,
-            eventListener,
-            action,
-          });
-
-          if (shouldTriggerJob) {
-            await this.messageQueueService.add<WorkflowTriggerJobData>(
-              WorkflowTriggerJob.name,
-              {
-                workspaceId,
-                workflowId: eventListener.workflowId,
-                payload: eventPayload,
-              },
-              { retryLimit: 3 },
-            );
-          }
-        }
-      }
     }, authContext);
   }
 


### PR DESCRIPTION
## What

Phase B, first slice: the database-event dispatch path reads its active triggers from the core-derived \`workflowAutomatedTriggerMaps\` cache (built from active core workflow versions) instead of querying the workspace \`workflowAutomatedTrigger\` table.

Gated per-workspace by \`IS_WORKFLOW_VERSION_IN_CORE_ENABLED\` (**off by default**), so behavior is unchanged until the flag is flipped. Implemented as an additive branch in \`WorkflowDatabaseEventTriggerListener\`: \`getDatabaseEventListeners\` picks the core cache (flag on) or the existing workspace-table query (flag off). The dispatch/filter logic (\`shouldTriggerJob\`) is untouched and shared by both paths.

## Not included: the cron path

The cron trigger job (\`WorkflowCronTriggerCronJob\`) also reads the table, but it has a global Redis cache spanning all workspaces. Partitioning that by a per-workspace flag risks double-dispatch (a flag-on workspace being dispatched by both the core path and the still-populated table/Redis path, since table writes aren't removed until Phase C). Switching it cleanly needs a deliberate redesign of that cache, so it's a separate follow-up rather than a rushed change here.

## Test

- 11 existing table-path tests still pass (flag defaults to off).
- 2 new tests for the core path: dispatches from the cache without touching the workspace table, and ignores cached triggers whose \`eventName\` doesn't match.
- typecheck + lint clean.

Flag-off = zero behavior change. Full live dispatch correctness (activate a DATABASE_EVENT workflow with the flag on, confirm it fires from core) should be integration-tested before flipping the flag in any environment.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/22786?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

