### PR TITLE
Catch Cursor's "Made with" attribution footer in blocked contributors check

### DIFF
--- a/packages/twenty-server/scripts/check-blocked-contributors.ts
+++ b/packages/twenty-server/scripts/check-blocked-contributors.ts
@@ -8,7 +8,7 @@ const IDENTITY_PATTERNS = [
 const SIGNATURE_PATTERNS = [
   /Generated with \[Claude Code\]\(/i,
   /Co-Authored-By:[^\n]*<[^>]*@anthropic\.com>/i,
-  /Generated with \[Cursor( Agent)?\]\(/i,
+  /(Generated|Made|Built) with \[Cursor( Agent)?\]\(/i,
   /Co-Authored-By:[^\n]*cursoragent/i,
 ];
 


### PR DESCRIPTION
## Summary

PR #22785 merged with a Cursor attribution (05afc49e) even though the `check-blocked-contributors` job ran and passed. The PR's commits were clean, but the description ended with Cursor's attribution footer, which starts with "Made with" followed by a markdown link to cursor.com, while the script only matched the "Generated with" wording. Since the repo squash-merges, the PR description became the merged commit message, carrying the footer (plus the co-author trailer GitHub appends at squash time) into main's history.

This broadens the signature pattern in `scripts/check-blocked-contributors.ts` to also cover the "Made"/"Built" wordings.

Note: this description intentionally avoids quoting the banned strings verbatim, since the check scans it too (and it would become the squash commit message).

## Test plan

Verified the new pattern against:
- The exact footer from the PR #22785 description - now caught
- The co-author trailer from the merged squash commit - caught by existing patterns
- The "Generated with" and "Built with" wordings, with and without the "Agent" suffix in the link label - caught
- Negative cases: prose mentioning the word cursor and a plain markdown link to cursor.com - not flagged