### PR TITLE
Fix WebKit blank-page crash on legacy IANA timezone aliases (CET/MET/WET/EET)

### DIFF
--- a/packages/twenty-front/src/modules/command-menu-item/engine-command/utils/buildHeadlessCommandContextApi.ts
+++ b/packages/twenty-front/src/modules/command-menu-item/engine-command/utils/buildHeadlessCommandContextApi.ts
@@ -9,6 +9,8 @@ import { contextStoreFilterGroupsComponentState } from '@/context-store/states/c
 import { contextStoreFiltersComponentState } from '@/context-store/states/contextStoreFiltersComponentState';
 import { contextStoreTargetedRecordsRuleComponentState } from '@/context-store/states/contextStoreTargetedRecordsRuleComponentState';
 import { computeContextStoreFilters } from '@/context-store/utils/computeContextStoreFilters';
+import { detectTimeZone } from '@/localization/utils/detection/detectTimeZone';
+import { normalizeTimeZone } from '@/localization/utils/normalizeTimeZone';
 import { flattenedFieldMetadataItemsSelector } from '@/object-metadata/states/flattenedFieldMetadataItemsSelector';
 import { objectMetadataItemsSelector } from '@/object-metadata/states/objectMetadataItemsSelector';
 import { type EnrichedObjectMetadataItem } from '@/object-metadata/types/EnrichedObjectMetadataItem';
@@ -85,11 +87,11 @@ export const buildHeadlessCommandContextApi = ({
 
   const currentWorkspaceMember = store.get(currentWorkspaceMemberState.atom);
 
-  const systemTimeZone = Intl.DateTimeFormat().resolvedOptions().timeZone;
+  const systemTimeZone = detectTimeZone();
 
   const userTimezone =
     currentWorkspaceMember?.timeZone !== 'system'
-      ? (currentWorkspaceMember?.timeZone ?? systemTimeZone)
+      ? normalizeTimeZone(currentWorkspaceMember?.timeZone ?? systemTimeZone)
       : systemTimeZone;
 
   const flattenedFieldMetadataItems = store.get(

--- a/packages/twenty-front/src/modules/localization/utils/__tests__/formatDateISOStringToCustomUnicodeFormat.test.ts
+++ b/packages/twenty-front/src/modules/localization/utils/__tests__/formatDateISOStringToCustomUnicodeFormat.test.ts
@@ -98,7 +98,9 @@ describe('formatDateISOStringToCustomUnicodeFormat', () => {
       expect(result).toBe('2022-01-02 07:00');
     });
 
-    it('should return the fallback string for an unknown timezone', () => {
+    it('should format in a fallback zone instead of erroring for an unknown timezone', () => {
+      // Normalization falls back to the detected zone (UTC in jsdom) so the
+      // value still renders instead of surfacing an error string.
       const result = formatDateISOStringToCustomUnicodeFormat({
         date: '2022-01-01T12:00:00Z',
         timeZone: 'Mars/Olympus',
@@ -106,7 +108,7 @@ describe('formatDateISOStringToCustomUnicodeFormat', () => {
         localeCatalog: enUS,
       });
 
-      expect(result).toBe('Invalid format string');
+      expect(result).toBe('2022-01-01');
     });
   });
 });

--- a/packages/twenty-front/src/modules/localization/utils/__tests__/formatTimeZoneLabel.test.ts
+++ b/packages/twenty-front/src/modules/localization/utils/__tests__/formatTimeZoneLabel.test.ts
@@ -20,9 +20,29 @@ describe('formatTimeZoneLabel', () => {
     expect(formattedLabel).toEqual(expectedLabel);
   });
 
-  it('should format a legacy alias as its canonical zone instead of throwing', () => {
+  it('should format a legacy alias as its canonical zone when the engine rejects it', () => {
+    // Simulate WebKit, whose ICU rejects the alias that V8 accepts.
+    const originalDateTimeFormat = global.Intl.DateTimeFormat;
+    function webKitLikeDateTimeFormat(
+      this: unknown,
+      locales?: Intl.LocalesArgument,
+      options?: Intl.DateTimeFormatOptions,
+    ) {
+      if (options?.timeZone === 'CET') {
+        throw new RangeError('Invalid time zone specified: CET');
+      }
+
+      return new originalDateTimeFormat(locales, options);
+    }
+    webKitLikeDateTimeFormat.supportedLocalesOf =
+      originalDateTimeFormat.supportedLocalesOf;
+    global.Intl.DateTimeFormat =
+      webKitLikeDateTimeFormat as unknown as typeof Intl.DateTimeFormat;
+
     expect(formatTimeZoneLabel('CET')).toEqual(
       formatTimeZoneLabel('Europe/Paris'),
     );
+
+    global.Intl.DateTimeFormat = originalDateTimeFormat;
   });
 });

--- a/packages/twenty-front/src/modules/localization/utils/__tests__/formatTimeZoneLabel.test.ts
+++ b/packages/twenty-front/src/modules/localization/utils/__tests__/formatTimeZoneLabel.test.ts
@@ -19,4 +19,10 @@ describe('formatTimeZoneLabel', () => {
 
     expect(formattedLabel).toEqual(expectedLabel);
   });
+
+  it('should format a legacy alias as its canonical zone instead of throwing', () => {
+    expect(formatTimeZoneLabel('CET')).toEqual(
+      formatTimeZoneLabel('Europe/Paris'),
+    );
+  });
 });

--- a/packages/twenty-front/src/modules/localization/utils/__tests__/isTimeZoneSupported.test.ts
+++ b/packages/twenty-front/src/modules/localization/utils/__tests__/isTimeZoneSupported.test.ts
@@ -1,0 +1,11 @@
+import { isTimeZoneSupported } from '@/localization/utils/isTimeZoneSupported';
+
+describe('isTimeZoneSupported', () => {
+  it('should return true for a canonical IANA time zone', () => {
+    expect(isTimeZoneSupported('Europe/Paris')).toBe(true);
+  });
+
+  it('should return false for an unknown time zone', () => {
+    expect(isTimeZoneSupported('Mars/Olympus')).toBe(false);
+  });
+});

--- a/packages/twenty-front/src/modules/localization/utils/__tests__/normalizeTimeZone.test.ts
+++ b/packages/twenty-front/src/modules/localization/utils/__tests__/normalizeTimeZone.test.ts
@@ -1,0 +1,65 @@
+import { isTimeZoneSupported } from '@/localization/utils/isTimeZoneSupported';
+import { normalizeTimeZone } from '@/localization/utils/normalizeTimeZone';
+
+jest.mock('@/localization/utils/isTimeZoneSupported');
+
+const mockIsTimeZoneSupported = jest.mocked(isTimeZoneSupported);
+
+const originalDateTimeFormat = global.Intl.DateTimeFormat;
+
+const mockDetectedTimeZone = (timeZone: string) => {
+  // @ts-expect-error - Mocking for test
+  global.Intl.DateTimeFormat = jest.fn().mockImplementation(() => ({
+    resolvedOptions: () => ({ timeZone }),
+  }));
+};
+
+describe('normalizeTimeZone', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockDetectedTimeZone('America/New_York');
+  });
+
+  afterAll(() => {
+    global.Intl.DateTimeFormat = originalDateTimeFormat;
+  });
+
+  it('should return a supported time zone unchanged', () => {
+    mockIsTimeZoneSupported.mockReturnValue(true);
+
+    expect(normalizeTimeZone('Europe/Paris')).toBe('Europe/Paris');
+  });
+
+  it('should remap a legacy alias to its canonical IANA zone on every engine', () => {
+    mockIsTimeZoneSupported.mockReturnValue(true);
+
+    expect(normalizeTimeZone('CET')).toBe('Europe/Paris');
+    expect(normalizeTimeZone('MET')).toBe('Europe/Berlin');
+    expect(normalizeTimeZone('WET')).toBe('Europe/Lisbon');
+    expect(normalizeTimeZone('EET')).toBe('Europe/Bucharest');
+  });
+
+  it('should fall back to the detected time zone for an unsupported unknown zone', () => {
+    mockIsTimeZoneSupported.mockImplementation(
+      (timeZone) => timeZone === 'America/New_York',
+    );
+
+    expect(normalizeTimeZone('Mars/Olympus')).toBe('America/New_York');
+  });
+
+  it('should canonicalize the detected time zone when it is itself a legacy alias', () => {
+    // Simulate WebKit detecting the host zone as `CET` while rejecting it.
+    mockDetectedTimeZone('CET');
+    mockIsTimeZoneSupported.mockImplementation(
+      (timeZone) => timeZone !== 'CET' && timeZone !== 'Mars/Olympus',
+    );
+
+    expect(normalizeTimeZone('Mars/Olympus')).toBe('Europe/Paris');
+  });
+
+  it('should fall back to UTC when even the detected zone is unsupported', () => {
+    mockIsTimeZoneSupported.mockReturnValue(false);
+
+    expect(normalizeTimeZone('Mars/Olympus')).toBe('UTC');
+  });
+});

--- a/packages/twenty-front/src/modules/localization/utils/__tests__/normalizeTimeZone.test.ts
+++ b/packages/twenty-front/src/modules/localization/utils/__tests__/normalizeTimeZone.test.ts
@@ -30,8 +30,18 @@ describe('normalizeTimeZone', () => {
     expect(normalizeTimeZone('Europe/Paris')).toBe('Europe/Paris');
   });
 
-  it('should remap a legacy alias to its canonical IANA zone on every engine', () => {
+  it('should return a legacy alias unchanged when the engine supports it', () => {
+    // V8 accepts the alias; keeping it preserves historical-date rendering.
     mockIsTimeZoneSupported.mockReturnValue(true);
+
+    expect(normalizeTimeZone('CET')).toBe('CET');
+  });
+
+  it('should remap a legacy alias to its canonical zone when the engine rejects it', () => {
+    // Simulate WebKit: aliases unsupported, region zones supported.
+    mockIsTimeZoneSupported.mockImplementation(
+      (timeZone) => !['CET', 'MET', 'WET', 'EET'].includes(timeZone),
+    );
 
     expect(normalizeTimeZone('CET')).toBe('Europe/Paris');
     expect(normalizeTimeZone('MET')).toBe('Europe/Berlin');
@@ -47,7 +57,7 @@ describe('normalizeTimeZone', () => {
     expect(normalizeTimeZone('Mars/Olympus')).toBe('America/New_York');
   });
 
-  it('should canonicalize the detected time zone when it is itself a legacy alias', () => {
+  it('should canonicalize the detected time zone when it is itself a rejected legacy alias', () => {
     // Simulate WebKit detecting the host zone as `CET` while rejecting it.
     mockDetectedTimeZone('CET');
     mockIsTimeZoneSupported.mockImplementation(

--- a/packages/twenty-front/src/modules/localization/utils/detection/__tests__/detectTimeZone.test.ts
+++ b/packages/twenty-front/src/modules/localization/utils/detection/__tests__/detectTimeZone.test.ts
@@ -42,14 +42,25 @@ describe('detectTimeZone', () => {
     global.Intl.DateTimeFormat = originalDateTimeFormat;
   });
 
-  it('should normalize a detected legacy alias to its canonical zone', () => {
+  it('should normalize a detected legacy alias its own engine rejects', () => {
     // WebKit on Linux can resolve the host zone as `CET`, an alias its own ICU
-    // rejects when passed back into a formatter.
+    // then rejects when passed back into a formatter.
     const originalDateTimeFormat = global.Intl.DateTimeFormat;
     // @ts-expect-error - Mocking for test
-    global.Intl.DateTimeFormat = jest.fn().mockImplementation(() => ({
-      resolvedOptions: () => ({ timeZone: 'CET' }),
-    }));
+    global.Intl.DateTimeFormat = jest
+      .fn()
+      .mockImplementation(
+        (
+          _locales?: Intl.LocalesArgument,
+          options?: Intl.DateTimeFormatOptions,
+        ) => {
+          if (options?.timeZone === 'CET') {
+            throw new RangeError('Invalid time zone specified: CET');
+          }
+
+          return { resolvedOptions: () => ({ timeZone: 'CET' }) };
+        },
+      );
 
     expect(detectTimeZone()).toBe('Europe/Paris');
     global.Intl.DateTimeFormat = originalDateTimeFormat;

--- a/packages/twenty-front/src/modules/localization/utils/detection/__tests__/detectTimeZone.test.ts
+++ b/packages/twenty-front/src/modules/localization/utils/detection/__tests__/detectTimeZone.test.ts
@@ -41,4 +41,17 @@ describe('detectTimeZone', () => {
     expect(detectTimeZone()).toBe('America/New_York');
     global.Intl.DateTimeFormat = originalDateTimeFormat;
   });
+
+  it('should normalize a detected legacy alias to its canonical zone', () => {
+    // WebKit on Linux can resolve the host zone as `CET`, an alias its own ICU
+    // rejects when passed back into a formatter.
+    const originalDateTimeFormat = global.Intl.DateTimeFormat;
+    // @ts-expect-error - Mocking for test
+    global.Intl.DateTimeFormat = jest.fn().mockImplementation(() => ({
+      resolvedOptions: () => ({ timeZone: 'CET' }),
+    }));
+
+    expect(detectTimeZone()).toBe('Europe/Paris');
+    global.Intl.DateTimeFormat = originalDateTimeFormat;
+  });
 });

--- a/packages/twenty-front/src/modules/localization/utils/detection/detectTimeZone.ts
+++ b/packages/twenty-front/src/modules/localization/utils/detection/detectTimeZone.ts
@@ -1,10 +1,15 @@
+import { normalizeTimeZone } from '@/localization/utils/normalizeTimeZone';
+
 /**
  * Detects the user's time zone.
- * @returns a IANA time zone
+ * @returns a IANA time zone the current engine can format. Detection can yield
+ * legacy alias zones (e.g. WebKit resolving `CET`) that the same engine then
+ * rejects when passed back to Intl or date-fns-tz, so the raw value is
+ * normalized before being handed to any formatting path.
  */
 export const detectTimeZone = (): string => {
   try {
-    return Intl.DateTimeFormat().resolvedOptions().timeZone;
+    return normalizeTimeZone(Intl.DateTimeFormat().resolvedOptions().timeZone);
   } catch {
     return 'UTC';
   }

--- a/packages/twenty-front/src/modules/localization/utils/format-preferences/getTimeZoneFromWorkspaceMember.ts
+++ b/packages/twenty-front/src/modules/localization/utils/format-preferences/getTimeZoneFromWorkspaceMember.ts
@@ -1,11 +1,15 @@
 import { type CurrentWorkspaceMember } from '@/auth/states/currentWorkspaceMemberState';
 import { detectTimeZone } from '@/localization/utils/detection/detectTimeZone';
+import { normalizeTimeZone } from '@/localization/utils/normalizeTimeZone';
 import { type WorkspaceMember } from '@/workspace-member/types/WorkspaceMember';
 
 export const getTimeZoneFromWorkspaceMember = (
   workspaceMember: WorkspaceMember | CurrentWorkspaceMember,
 ): string => {
+  // The stored value is normalized because the backend accepts any string for
+  // `timeZone`, so legacy aliases (e.g. `CET`) can be persisted and would crash
+  // WebKit's date formatting.
   return workspaceMember.timeZone === 'system' || !workspaceMember.timeZone
     ? detectTimeZone()
-    : workspaceMember.timeZone;
+    : normalizeTimeZone(workspaceMember.timeZone);
 };

--- a/packages/twenty-front/src/modules/localization/utils/formatDateISOStringToCustomUnicodeFormat.ts
+++ b/packages/twenty-front/src/modules/localization/utils/formatDateISOStringToCustomUnicodeFormat.ts
@@ -1,4 +1,5 @@
 import { formatPlainDateISOString } from '@/localization/utils/formatPlainDateISOString';
+import { normalizeTimeZone } from '@/localization/utils/normalizeTimeZone';
 import { type Locale } from 'date-fns';
 import { formatInTimeZone } from 'date-fns-tz';
 import { isDateWithoutTime } from 'twenty-shared/utils';
@@ -19,9 +20,14 @@ export const formatDateISOStringToCustomUnicodeFormat = ({
       return formatPlainDateISOString({ date, dateFormat, localeCatalog });
     }
 
-    return formatInTimeZone(new Date(date), timeZone, dateFormat, {
-      locale: localeCatalog,
-    });
+    return formatInTimeZone(
+      new Date(date),
+      normalizeTimeZone(timeZone),
+      dateFormat,
+      {
+        locale: localeCatalog,
+      },
+    );
   } catch {
     return 'Invalid format string';
   }

--- a/packages/twenty-front/src/modules/localization/utils/formatDateISOStringToDate.ts
+++ b/packages/twenty-front/src/modules/localization/utils/formatDateISOStringToDate.ts
@@ -1,5 +1,6 @@
 import { type DateFormat } from '@/localization/constants/DateFormat';
 import { formatPlainDateISOString } from '@/localization/utils/formatPlainDateISOString';
+import { normalizeTimeZone } from '@/localization/utils/normalizeTimeZone';
 import { type Locale } from 'date-fns';
 import { formatInTimeZone } from 'date-fns-tz';
 import { isDateWithoutTime } from 'twenty-shared/utils';
@@ -19,7 +20,12 @@ export const formatDateISOStringToDate = ({
     return formatPlainDateISOString({ date, dateFormat, localeCatalog });
   }
 
-  return formatInTimeZone(new Date(date), timeZone, dateFormat, {
-    locale: localeCatalog,
-  });
+  return formatInTimeZone(
+    new Date(date),
+    normalizeTimeZone(timeZone),
+    dateFormat,
+    {
+      locale: localeCatalog,
+    },
+  );
 };

--- a/packages/twenty-front/src/modules/localization/utils/formatDateISOStringToDateTime.ts
+++ b/packages/twenty-front/src/modules/localization/utils/formatDateISOStringToDateTime.ts
@@ -1,5 +1,6 @@
 import { type DateFormat } from '@/localization/constants/DateFormat';
 import { type TimeFormat } from '@/localization/constants/TimeFormat';
+import { normalizeTimeZone } from '@/localization/utils/normalizeTimeZone';
 import { isValid, type Locale } from 'date-fns';
 import { formatInTimeZone } from 'date-fns-tz';
 
@@ -24,7 +25,12 @@ export const formatDateISOStringToDateTime = ({
 
   // TODO: replace this with shiftPointInTimeToFromTimezoneDifference to remove date-fns-tz, which formatInTimeZone is doig under the hood :
   // https://github.com/marnusw/date-fns-tz/blob/4f3383b26a5907a73b14512a2701f3dfd8cf1579/src/toZonedTime/index.ts#L36C9-L36C27
-  return formatInTimeZone(parsedDate, timeZone, `${dateFormat} ${timeFormat}`, {
-    locale: localeCatalog,
-  });
+  return formatInTimeZone(
+    parsedDate,
+    normalizeTimeZone(timeZone),
+    `${dateFormat} ${timeFormat}`,
+    {
+      locale: localeCatalog,
+    },
+  );
 };

--- a/packages/twenty-front/src/modules/localization/utils/formatDateISOStringToDateTimeSimplified.ts
+++ b/packages/twenty-front/src/modules/localization/utils/formatDateISOStringToDateTimeSimplified.ts
@@ -1,6 +1,7 @@
 import { DATE_FORMAT_WITHOUT_YEAR } from '@/localization/constants/DateFormatWithoutYear';
 import { type TimeFormat } from '@/localization/constants/TimeFormat';
 import { detectDateFormat } from '@/localization/utils/detection/detectDateFormat';
+import { normalizeTimeZone } from '@/localization/utils/normalizeTimeZone';
 import { formatInTimeZone } from 'date-fns-tz';
 
 export const formatDateISOStringToDateTimeSimplified = (
@@ -12,7 +13,7 @@ export const formatDateISOStringToDateTimeSimplified = (
 
   return formatInTimeZone(
     date,
-    timeZone,
+    normalizeTimeZone(timeZone),
     `${simplifiedDateFormat} · ${timeFormat}`,
   );
 };

--- a/packages/twenty-front/src/modules/localization/utils/formatTimeZoneLabel.ts
+++ b/packages/twenty-front/src/modules/localization/utils/formatTimeZoneLabel.ts
@@ -1,6 +1,8 @@
 import { formatInTimeZone } from 'date-fns-tz';
 import { enUS as defaultLocale } from 'date-fns/locale/en-US';
 
+import { normalizeTimeZone } from '@/localization/utils/normalizeTimeZone';
+
 /**
  * Formats a IANA time zone to a select option label.
  * @param ianaTimeZone IANA time zone
@@ -8,13 +10,17 @@ import { enUS as defaultLocale } from 'date-fns/locale/en-US';
  * @example 'Europe/Paris' => '(GMT+01:00) Central European Time - Paris'
  */
 export const formatTimeZoneLabel = (ianaTimeZone: string) => {
+  // Normalized so a legacy alias (e.g. a stored `CET` preference) resolves to
+  // the label of its canonical zone instead of throwing on engines whose ICU
+  // rejects the alias (WebKit).
+  const supportedTimeZone = normalizeTimeZone(ianaTimeZone);
   const timeZoneWithGmtOffset = formatInTimeZone(
     Date.now(),
-    ianaTimeZone,
+    supportedTimeZone,
     `(OOOO) zzzz`,
     { locale: defaultLocale },
   );
-  const ianaTimeZoneParts = ianaTimeZone.split('/');
+  const ianaTimeZoneParts = supportedTimeZone.split('/');
   const location =
     ianaTimeZoneParts.length > 1
       ? ianaTimeZoneParts.slice(-1)[0].replaceAll('_', ' ')

--- a/packages/twenty-front/src/modules/localization/utils/isTimeZoneSupported.ts
+++ b/packages/twenty-front/src/modules/localization/utils/isTimeZoneSupported.ts
@@ -1,0 +1,29 @@
+import { isDefined } from 'twenty-shared/utils';
+
+// Whether the current JS engine's Intl/ICU knows the given time zone.
+// V8 (Chrome/Node) accepts legacy IANA abbreviation zones such as `CET`, while
+// WebKit/JavaScriptCore rejects them with a RangeError. Probing here lets us
+// fall back before that error reaches a render path and crashes the page.
+//
+// Support is static for a given engine, and this runs on hot render paths (date
+// cells), so results are memoized.
+const timeZoneSupportByName = new Map<string, boolean>();
+
+export const isTimeZoneSupported = (timeZone: string): boolean => {
+  const cachedResult = timeZoneSupportByName.get(timeZone);
+  if (isDefined(cachedResult)) {
+    return cachedResult;
+  }
+
+  let isSupported: boolean;
+  try {
+    Intl.DateTimeFormat(undefined, { timeZone });
+    isSupported = true;
+  } catch {
+    isSupported = false;
+  }
+
+  timeZoneSupportByName.set(timeZone, isSupported);
+
+  return isSupported;
+};

--- a/packages/twenty-front/src/modules/localization/utils/normalizeTimeZone.ts
+++ b/packages/twenty-front/src/modules/localization/utils/normalizeTimeZone.ts
@@ -1,0 +1,48 @@
+import { isDefined } from 'twenty-shared/utils';
+
+import { isTimeZoneSupported } from '@/localization/utils/isTimeZoneSupported';
+
+// Legacy IANA abbreviation zones that V8 (Chrome/Node) accepts but WebKit's ICU
+// rejects with a RangeError. Each maps to a canonical region zone with the same
+// UTC offset and DST rules, so a stored preference like `CET` keeps working on
+// Safari instead of crashing the render tree, and renders identically on V8.
+export const LEGACY_TIME_ZONE_TO_IANA: Record<string, string> = {
+  CET: 'Europe/Paris',
+  MET: 'Europe/Berlin',
+  WET: 'Europe/Lisbon',
+  EET: 'Europe/Bucharest',
+};
+
+// Raw engine detection, without the normalization `detectTimeZone` applies on
+// top of it (kept here so `detectTimeZone` can depend on this module without an
+// import cycle).
+const detectRawTimeZone = (): string | undefined => {
+  try {
+    return Intl.DateTimeFormat().resolvedOptions().timeZone;
+  } catch {
+    return undefined;
+  }
+};
+
+// Returns a time zone the current engine can format. Legacy aliases are mapped
+// to their canonical region zone on every engine (same rendering, valid on the
+// server); other supported zones pass through unchanged; anything the engine
+// rejects falls back to the detected zone, then UTC, guaranteeing the result
+// never throws downstream.
+export const normalizeTimeZone = (timeZone: string): string => {
+  const canonicalTimeZone = LEGACY_TIME_ZONE_TO_IANA[timeZone] ?? timeZone;
+  if (isTimeZoneSupported(canonicalTimeZone)) {
+    return canonicalTimeZone;
+  }
+
+  const detectedTimeZone = detectRawTimeZone();
+  if (isDefined(detectedTimeZone)) {
+    const canonicalDetectedTimeZone =
+      LEGACY_TIME_ZONE_TO_IANA[detectedTimeZone] ?? detectedTimeZone;
+    if (isTimeZoneSupported(canonicalDetectedTimeZone)) {
+      return canonicalDetectedTimeZone;
+    }
+  }
+
+  return 'UTC';
+};

--- a/packages/twenty-front/src/modules/localization/utils/normalizeTimeZone.ts
+++ b/packages/twenty-front/src/modules/localization/utils/normalizeTimeZone.ts
@@ -1,16 +1,7 @@
+import { LEGACY_TIME_ZONE_TO_IANA } from 'twenty-shared/constants';
 import { isDefined } from 'twenty-shared/utils';
 
 import { isTimeZoneSupported } from '@/localization/utils/isTimeZoneSupported';
-
-// Legacy IANA abbreviation zones that V8 (Chrome/Node) accepts but WebKit's ICU
-// rejects with a RangeError. Each maps to a canonical region zone with the same
-// current UTC offset and DST rules.
-export const LEGACY_TIME_ZONE_TO_IANA: Record<string, string> = {
-  CET: 'Europe/Paris',
-  MET: 'Europe/Berlin',
-  WET: 'Europe/Lisbon',
-  EET: 'Europe/Bucharest',
-};
 
 // Supported zones pass through unchanged so rendering never changes on engines
 // that accept the zone (the region mappings only match the alias rules for

--- a/packages/twenty-front/src/modules/localization/utils/normalizeTimeZone.ts
+++ b/packages/twenty-front/src/modules/localization/utils/normalizeTimeZone.ts
@@ -4,13 +4,29 @@ import { isTimeZoneSupported } from '@/localization/utils/isTimeZoneSupported';
 
 // Legacy IANA abbreviation zones that V8 (Chrome/Node) accepts but WebKit's ICU
 // rejects with a RangeError. Each maps to a canonical region zone with the same
-// UTC offset and DST rules, so a stored preference like `CET` keeps working on
-// Safari instead of crashing the render tree, and renders identically on V8.
+// current UTC offset and DST rules.
 export const LEGACY_TIME_ZONE_TO_IANA: Record<string, string> = {
   CET: 'Europe/Paris',
   MET: 'Europe/Berlin',
   WET: 'Europe/Lisbon',
   EET: 'Europe/Bucharest',
+};
+
+// Supported zones pass through unchanged so rendering never changes on engines
+// that accept the zone (the region mappings only match the alias rules for
+// modern dates, not all historical timestamps). The remap only fires on engines
+// that reject the alias (WebKit), where the alternative is a formatting crash.
+const toSupportedTimeZone = (timeZone: string): string | undefined => {
+  if (isTimeZoneSupported(timeZone)) {
+    return timeZone;
+  }
+
+  const mappedTimeZone = LEGACY_TIME_ZONE_TO_IANA[timeZone];
+  if (isDefined(mappedTimeZone) && isTimeZoneSupported(mappedTimeZone)) {
+    return mappedTimeZone;
+  }
+
+  return undefined;
 };
 
 // Raw engine detection, without the normalization `detectTimeZone` applies on
@@ -24,23 +40,20 @@ const detectRawTimeZone = (): string | undefined => {
   }
 };
 
-// Returns a time zone the current engine can format. Legacy aliases are mapped
-// to their canonical region zone on every engine (same rendering, valid on the
-// server); other supported zones pass through unchanged; anything the engine
-// rejects falls back to the detected zone, then UTC, guaranteeing the result
-// never throws downstream.
+// Returns a time zone the current engine can format: the zone itself when
+// supported, its canonical equivalent for a rejected legacy alias, then the
+// detected zone, then UTC, guaranteeing the result never throws downstream.
 export const normalizeTimeZone = (timeZone: string): string => {
-  const canonicalTimeZone = LEGACY_TIME_ZONE_TO_IANA[timeZone] ?? timeZone;
-  if (isTimeZoneSupported(canonicalTimeZone)) {
-    return canonicalTimeZone;
+  const supportedTimeZone = toSupportedTimeZone(timeZone);
+  if (isDefined(supportedTimeZone)) {
+    return supportedTimeZone;
   }
 
   const detectedTimeZone = detectRawTimeZone();
   if (isDefined(detectedTimeZone)) {
-    const canonicalDetectedTimeZone =
-      LEGACY_TIME_ZONE_TO_IANA[detectedTimeZone] ?? detectedTimeZone;
-    if (isTimeZoneSupported(canonicalDetectedTimeZone)) {
-      return canonicalDetectedTimeZone;
+    const supportedDetectedTimeZone = toSupportedTimeZone(detectedTimeZone);
+    if (isDefined(supportedDetectedTimeZone)) {
+      return supportedDetectedTimeZone;
     }
   }
 

--- a/packages/twenty-front/src/modules/settings/experience/constants/AvailableTimezoneOptionsByLabel.ts
+++ b/packages/twenty-front/src/modules/settings/experience/constants/AvailableTimezoneOptionsByLabel.ts
@@ -1,30 +1,7 @@
-import { IANA_TIME_ZONES } from 'twenty-shared/constants';
-import { formatTimeZoneLabel } from '@/localization/utils/formatTimeZoneLabel';
-import { type SelectOption } from 'twenty-ui/input';
+import { buildAvailableTimeZoneOptionsByLabel } from '@/settings/experience/utils/buildAvailableTimeZoneOptionsByLabel';
 
 const { AVAILABLE_TIME_ZONE_OPTIONS_BY_LABEL } = {
-  AVAILABLE_TIME_ZONE_OPTIONS_BY_LABEL: IANA_TIME_ZONES.reduce<
-    Record<string, SelectOption>
-  >((result, ianaTimeZone) => {
-    // Skip time zones with GMT, UTC, or UCT in their name,
-    // and duplicates.
-    if (
-      formatTimeZoneLabel(ianaTimeZone).slice(11).includes('GMT') ||
-      formatTimeZoneLabel(ianaTimeZone).slice(11).includes('UTC') ||
-      formatTimeZoneLabel(ianaTimeZone).slice(11).includes('UCT') ||
-      formatTimeZoneLabel(ianaTimeZone) in result
-    ) {
-      return result;
-    }
-
-    return {
-      ...result,
-      [formatTimeZoneLabel(ianaTimeZone)]: {
-        label: formatTimeZoneLabel(ianaTimeZone),
-        value: ianaTimeZone,
-      },
-    };
-  }, {}),
+  AVAILABLE_TIME_ZONE_OPTIONS_BY_LABEL: buildAvailableTimeZoneOptionsByLabel(),
 };
 
 export { AVAILABLE_TIME_ZONE_OPTIONS_BY_LABEL };

--- a/packages/twenty-front/src/modules/settings/experience/constants/__tests__/AvailableTimezoneOptionsByLabel.test.ts
+++ b/packages/twenty-front/src/modules/settings/experience/constants/__tests__/AvailableTimezoneOptionsByLabel.test.ts
@@ -1,0 +1,68 @@
+const LEGACY_TIME_ZONE_ALIASES = ['CET', 'MET', 'WET', 'EET'];
+
+const originalDateTimeFormat = global.Intl.DateTimeFormat;
+
+// Simulates WebKit/JavaScriptCore, whose ICU rejects legacy IANA alias zones
+// that V8 accepts. The options map is built at module init, so it must be
+// required inside an isolated module registry after the mock is installed.
+const mockWebKitDateTimeFormat = () => {
+  function webKitDateTimeFormat(
+    this: unknown,
+    locales?: Intl.LocalesArgument,
+    options?: Intl.DateTimeFormatOptions,
+  ) {
+    if (
+      typeof options?.timeZone === 'string' &&
+      LEGACY_TIME_ZONE_ALIASES.includes(options.timeZone)
+    ) {
+      throw new RangeError(`Invalid time zone specified: ${options.timeZone}`);
+    }
+
+    return new originalDateTimeFormat(locales, options);
+  }
+  webKitDateTimeFormat.supportedLocalesOf =
+    originalDateTimeFormat.supportedLocalesOf;
+
+  global.Intl.DateTimeFormat =
+    webKitDateTimeFormat as unknown as typeof Intl.DateTimeFormat;
+};
+
+const requireAvailableTimeZoneOptionsByLabel = () => {
+  let options: Record<string, { label: string; value: string }> = {};
+  jest.isolateModules(() => {
+    ({ AVAILABLE_TIME_ZONE_OPTIONS_BY_LABEL: options } =
+      // eslint-disable-next-line @typescript-eslint/no-require-imports
+      require('@/settings/experience/constants/AvailableTimezoneOptionsByLabel'));
+  });
+
+  return options;
+};
+
+describe('AVAILABLE_TIME_ZONE_OPTIONS_BY_LABEL', () => {
+  afterEach(() => {
+    global.Intl.DateTimeFormat = originalDateTimeFormat;
+  });
+
+  it('should not offer legacy alias zones as option values', () => {
+    const options = requireAvailableTimeZoneOptionsByLabel();
+    const optionValues = Object.values(options).map((option) => option.value);
+
+    expect(optionValues.length).toBeGreaterThan(0);
+    for (const legacyAlias of LEGACY_TIME_ZONE_ALIASES) {
+      expect(optionValues).not.toContain(legacyAlias);
+    }
+  });
+
+  it('should build without throwing on engines whose ICU rejects legacy alias zones', () => {
+    mockWebKitDateTimeFormat();
+
+    const options = requireAvailableTimeZoneOptionsByLabel();
+    const optionValues = Object.values(options).map((option) => option.value);
+
+    expect(optionValues.length).toBeGreaterThan(0);
+    expect(optionValues).toContain('Europe/Paris');
+    for (const legacyAlias of LEGACY_TIME_ZONE_ALIASES) {
+      expect(optionValues).not.toContain(legacyAlias);
+    }
+  });
+});

--- a/packages/twenty-front/src/modules/settings/experience/utils/buildAvailableTimeZoneOptionsByLabel.ts
+++ b/packages/twenty-front/src/modules/settings/experience/utils/buildAvailableTimeZoneOptionsByLabel.ts
@@ -1,7 +1,9 @@
-import { IANA_TIME_ZONES } from 'twenty-shared/constants';
+import {
+  IANA_TIME_ZONES,
+  LEGACY_TIME_ZONE_TO_IANA,
+} from 'twenty-shared/constants';
 import { formatTimeZoneLabel } from '@/localization/utils/formatTimeZoneLabel';
 import { isTimeZoneSupported } from '@/localization/utils/isTimeZoneSupported';
-import { LEGACY_TIME_ZONE_TO_IANA } from '@/localization/utils/normalizeTimeZone';
 import { type SelectOption } from 'twenty-ui/input';
 
 export const buildAvailableTimeZoneOptionsByLabel = (): Record<

--- a/packages/twenty-front/src/modules/settings/experience/utils/buildAvailableTimeZoneOptionsByLabel.ts
+++ b/packages/twenty-front/src/modules/settings/experience/utils/buildAvailableTimeZoneOptionsByLabel.ts
@@ -1,0 +1,44 @@
+import { IANA_TIME_ZONES } from 'twenty-shared/constants';
+import { formatTimeZoneLabel } from '@/localization/utils/formatTimeZoneLabel';
+import { normalizeTimeZone } from '@/localization/utils/normalizeTimeZone';
+import { type SelectOption } from 'twenty-ui/input';
+
+export const buildAvailableTimeZoneOptionsByLabel = (): Record<
+  string,
+  SelectOption
+> =>
+  IANA_TIME_ZONES.reduce<Record<string, SelectOption>>(
+    (result, ianaTimeZone) => {
+      // Skip zones that don't survive normalization: legacy aliases (CET, MET,
+      // WET, EET) crash WebKit's ICU and duplicate their canonical region zone,
+      // and zones unknown to the running engine can't be formatted at all.
+      // Offering only pass-through zones keeps persisted preferences safe on
+      // every engine. This runs at module init, so any throw here would blank
+      // the whole app on engines rejecting one of the listed zones.
+      if (normalizeTimeZone(ianaTimeZone) !== ianaTimeZone) {
+        return result;
+      }
+
+      const timeZoneLabel = formatTimeZoneLabel(ianaTimeZone);
+
+      // Skip time zones with GMT, UTC, or UCT in their name,
+      // and duplicates.
+      if (
+        timeZoneLabel.slice(11).includes('GMT') ||
+        timeZoneLabel.slice(11).includes('UTC') ||
+        timeZoneLabel.slice(11).includes('UCT') ||
+        timeZoneLabel in result
+      ) {
+        return result;
+      }
+
+      return {
+        ...result,
+        [timeZoneLabel]: {
+          label: timeZoneLabel,
+          value: ianaTimeZone,
+        },
+      };
+    },
+    {},
+  );

--- a/packages/twenty-front/src/modules/settings/experience/utils/buildAvailableTimeZoneOptionsByLabel.ts
+++ b/packages/twenty-front/src/modules/settings/experience/utils/buildAvailableTimeZoneOptionsByLabel.ts
@@ -1,6 +1,7 @@
 import { IANA_TIME_ZONES } from 'twenty-shared/constants';
 import { formatTimeZoneLabel } from '@/localization/utils/formatTimeZoneLabel';
-import { normalizeTimeZone } from '@/localization/utils/normalizeTimeZone';
+import { isTimeZoneSupported } from '@/localization/utils/isTimeZoneSupported';
+import { LEGACY_TIME_ZONE_TO_IANA } from '@/localization/utils/normalizeTimeZone';
 import { type SelectOption } from 'twenty-ui/input';
 
 export const buildAvailableTimeZoneOptionsByLabel = (): Record<
@@ -9,13 +10,15 @@ export const buildAvailableTimeZoneOptionsByLabel = (): Record<
 > =>
   IANA_TIME_ZONES.reduce<Record<string, SelectOption>>(
     (result, ianaTimeZone) => {
-      // Skip zones that don't survive normalization: legacy aliases (CET, MET,
-      // WET, EET) crash WebKit's ICU and duplicate their canonical region zone,
-      // and zones unknown to the running engine can't be formatted at all.
-      // Offering only pass-through zones keeps persisted preferences safe on
-      // every engine. This runs at module init, so any throw here would blank
+      // Skip legacy aliases (CET, MET, WET, EET) on every engine: picking one
+      // persists a zone that crashes WebKit's ICU, and their canonical region
+      // zones are already in the list. Also skip zones the running engine
+      // can't format. This runs at module init, so any throw here would blank
       // the whole app on engines rejecting one of the listed zones.
-      if (normalizeTimeZone(ianaTimeZone) !== ianaTimeZone) {
+      if (
+        ianaTimeZone in LEGACY_TIME_ZONE_TO_IANA ||
+        !isTimeZoneSupported(ianaTimeZone)
+      ) {
         return result;
       }
 

--- a/packages/twenty-front/src/modules/ui/input/components/internal/date/hooks/useUserTimezone.ts
+++ b/packages/twenty-front/src/modules/ui/input/components/internal/date/hooks/useUserTimezone.ts
@@ -1,13 +1,17 @@
 import { currentWorkspaceMemberState } from '@/auth/states/currentWorkspaceMemberState';
+import { detectTimeZone } from '@/localization/utils/detection/detectTimeZone';
+import { normalizeTimeZone } from '@/localization/utils/normalizeTimeZone';
 import { useAtomStateValue } from '@/ui/utilities/state/jotai/hooks/useAtomStateValue';
 
 export const useUserTimezone = () => {
   const currentWorkspaceMember = useAtomStateValue(currentWorkspaceMemberState);
-  const systemTimeZone = Intl.DateTimeFormat().resolvedOptions().timeZone;
+  const systemTimeZone = detectTimeZone();
 
+  // Normalized because the stored value can be a legacy alias (e.g. `CET`)
+  // that WebKit's Intl/Temporal rejects.
   const userTimezone =
     currentWorkspaceMember?.timeZone !== 'system'
-      ? (currentWorkspaceMember?.timeZone ?? systemTimeZone)
+      ? normalizeTimeZone(currentWorkspaceMember?.timeZone ?? systemTimeZone)
       : systemTimeZone;
 
   const isSystemTimezone = userTimezone === systemTimeZone;

--- a/packages/twenty-server/src/database/commands/upgrade-version-command/2-20/2-20-upgrade-version-command.module.ts
+++ b/packages/twenty-server/src/database/commands/upgrade-version-command/2-20/2-20-upgrade-version-command.module.ts
@@ -9,6 +9,7 @@ import { BackfillWorkflowVersionToCoreCommand } from 'src/database/commands/upgr
 import { ReconcileSearchVectorGinIndexUniversalIdentifierCommand } from 'src/database/commands/upgrade-version-command/2-20/2-20-workspace-command-1783529458169-reconcile-search-vector-gin-index-universal-identifier.command';
 import { ReconcileSearchFieldMetadataCommand } from 'src/database/commands/upgrade-version-command/2-20/2-20-workspace-command-1783529458170-reconcile-search-field-metadata.command';
 import { RebuildInstalledAppSearchVectorsCommand } from 'src/database/commands/upgrade-version-command/2-20/2-20-workspace-command-1783529458171-rebuild-installed-app-search-vectors.command';
+import { NormalizeWorkspaceMemberTimeZonesCommand } from 'src/database/commands/upgrade-version-command/2-20/2-20-workspace-command-1783685009260-normalize-workspace-member-time-zones.command';
 import { ApplicationModule } from 'src/engine/core-modules/application/application.module';
 import { WorkflowVersionCoreModule } from 'src/engine/core-modules/workflow/workflow-version-core.module';
 import { IndexMetadataEntity } from 'src/engine/metadata-modules/index-metadata/index-metadata.entity';
@@ -39,6 +40,7 @@ import { WorkspaceMigrationModule } from 'src/engine/workspace-manager/workspace
     ReconcileSearchVectorGinIndexUniversalIdentifierCommand,
     ReconcileSearchFieldMetadataCommand,
     RebuildInstalledAppSearchVectorsCommand,
+    NormalizeWorkspaceMemberTimeZonesCommand,
   ],
 })
 export class V2_20_UpgradeVersionCommandModule {}

--- a/packages/twenty-server/src/database/commands/upgrade-version-command/2-20/2-20-workspace-command-1783685009260-normalize-workspace-member-time-zones.command.ts
+++ b/packages/twenty-server/src/database/commands/upgrade-version-command/2-20/2-20-workspace-command-1783685009260-normalize-workspace-member-time-zones.command.ts
@@ -1,0 +1,96 @@
+import { Command } from 'nest-commander';
+import {
+  IANA_TIME_ZONES,
+  LEGACY_TIME_ZONE_TO_IANA,
+} from 'twenty-shared/constants';
+import { isDefined } from 'twenty-shared/utils';
+
+import { ActiveOrSuspendedWorkspaceCommandRunner } from 'src/database/commands/command-runners/active-or-suspended-workspace.command-runner';
+import { WorkspaceIteratorService } from 'src/database/commands/command-runners/workspace-iterator.service';
+import { type RunOnWorkspaceArgs } from 'src/database/commands/command-runners/workspace.command-runner';
+import { RegisteredWorkspaceCommand } from 'src/engine/core-modules/upgrade/decorators/registered-workspace-command.decorator';
+import { getWorkspaceSchemaName } from 'src/engine/workspace-datasource/utils/get-workspace-schema-name.util';
+
+@RegisteredWorkspaceCommand('2.20.0', 1783685009260)
+@Command({
+  name: 'upgrade:2-20:normalize-workspace-member-time-zones',
+  description:
+    'Rewrite stored workspaceMember.timeZone values: legacy IANA aliases (CET/MET/WET/EET, rejected by WebKit and crashing its date rendering) to their canonical region zone, and any value outside the supported list to system.',
+})
+export class NormalizeWorkspaceMemberTimeZonesCommand extends ActiveOrSuspendedWorkspaceCommandRunner {
+  constructor(
+    protected readonly workspaceIteratorService: WorkspaceIteratorService,
+  ) {
+    super(workspaceIteratorService);
+  }
+
+  override async runOnWorkspace({
+    workspaceId,
+    dataSource,
+    options,
+  }: RunOnWorkspaceArgs): Promise<void> {
+    if (!isDefined(dataSource)) {
+      this.logger.log(`No data source for workspace ${workspaceId}, skipping`);
+
+      return;
+    }
+
+    const schemaName = getWorkspaceSchemaName(workspaceId);
+    const validTimeZones = [...IANA_TIME_ZONES, 'system'];
+
+    const [{ count: invalidCount }]: { count: number }[] =
+      await dataSource.query(
+        `SELECT count(*)::int AS count
+         FROM "${schemaName}"."workspaceMember"
+         WHERE "timeZone" IS NOT NULL
+           AND NOT ("timeZone" = ANY($1))`,
+        [validTimeZones],
+      );
+
+    const legacyAliases = Object.keys(LEGACY_TIME_ZONE_TO_IANA);
+    const [{ count: legacyAliasCount }]: { count: number }[] =
+      await dataSource.query(
+        `SELECT count(*)::int AS count
+         FROM "${schemaName}"."workspaceMember"
+         WHERE "timeZone" = ANY($1)`,
+        [legacyAliases],
+      );
+
+    if (invalidCount === 0 && legacyAliasCount === 0) {
+      return;
+    }
+
+    if (options.dryRun) {
+      this.logger.log(
+        `[DRY RUN] Would remap ${legacyAliasCount} legacy alias time zone(s) and reset ${invalidCount} unsupported time zone(s) to 'system' in workspace ${workspaceId}`,
+      );
+
+      return;
+    }
+
+    // The keys and values interpolated below come from constants, not user
+    // input.
+    const aliasCaseBranches = Object.entries(LEGACY_TIME_ZONE_TO_IANA)
+      .map(([alias, canonical]) => `WHEN '${alias}' THEN '${canonical}'`)
+      .join(' ');
+
+    await dataSource.query(
+      `UPDATE "${schemaName}"."workspaceMember"
+       SET "timeZone" = CASE "timeZone" ${aliasCaseBranches} END
+       WHERE "timeZone" = ANY($1)`,
+      [legacyAliases],
+    );
+
+    await dataSource.query(
+      `UPDATE "${schemaName}"."workspaceMember"
+       SET "timeZone" = 'system'
+       WHERE "timeZone" IS NOT NULL
+         AND NOT ("timeZone" = ANY($1))`,
+      [validTimeZones],
+    );
+
+    this.logger.log(
+      `Remapped ${legacyAliasCount} legacy alias time zone(s) and reset ${invalidCount} unsupported time zone(s) to 'system' in workspace ${workspaceId}`,
+    );
+  }
+}

--- a/packages/twenty-server/src/engine/api/common/common-query-runners/utils/get-group-by-expression.util.ts
+++ b/packages/twenty-server/src/engine/api/common/common-query-runners/utils/get-group-by-expression.util.ts
@@ -18,7 +18,7 @@ import { type GroupByField } from 'src/engine/api/common/common-query-runners/ty
 import { isGroupByDateField } from 'src/engine/api/common/common-query-runners/utils/is-group-by-date-field.util';
 import { isGroupByRelationField } from 'src/engine/api/common/common-query-runners/utils/is-group-by-relation-field.util';
 
-const VALID_IANA_TIMEZONES = new Set(IANA_TIME_ZONES);
+const VALID_IANA_TIMEZONES = new Set<string>(IANA_TIME_ZONES);
 
 export const getGroupByExpression = ({
   groupByField,

--- a/packages/twenty-server/src/modules/workspace-member/query-hooks/__tests__/workspace-member-update-one.pre-query.hook.spec.ts
+++ b/packages/twenty-server/src/modules/workspace-member/query-hooks/__tests__/workspace-member-update-one.pre-query.hook.spec.ts
@@ -1,0 +1,56 @@
+import { type UpdateOneResolverArgs } from 'src/engine/api/graphql/workspace-resolver-builder/interfaces/workspace-resolvers-builder.interface';
+import { type WorkspaceAuthContext } from 'src/engine/core-modules/auth/types/workspace-auth-context.type';
+import { WorkspaceMemberUpdateOnePreQueryHook } from 'src/modules/workspace-member/query-hooks/workspace-member-update-one.pre-query.hook';
+import { type WorkspaceMemberWorkspaceEntity } from 'src/modules/workspace-member/standard-objects/workspace-member.workspace-entity';
+
+describe('WorkspaceMemberUpdateOnePreQueryHook', () => {
+  const hook = new WorkspaceMemberUpdateOnePreQueryHook();
+  const authContext = {} as WorkspaceAuthContext;
+
+  const buildPayload = (
+    data: Partial<WorkspaceMemberWorkspaceEntity>,
+  ): UpdateOneResolverArgs<Partial<WorkspaceMemberWorkspaceEntity>> => ({
+    id: 'workspace-member-id',
+    data,
+  });
+
+  it('should pass through when timeZone is not updated', async () => {
+    const payload = buildPayload({ colorScheme: 'Light' });
+
+    await expect(
+      hook.execute(authContext, 'workspaceMember', payload),
+    ).resolves.toEqual(payload);
+  });
+
+  it('should pass through the system time zone', async () => {
+    const payload = buildPayload({ timeZone: 'system' });
+
+    await expect(
+      hook.execute(authContext, 'workspaceMember', payload),
+    ).resolves.toEqual(payload);
+  });
+
+  it('should pass through a supported IANA time zone', async () => {
+    const payload = buildPayload({ timeZone: 'Europe/Paris' });
+
+    await expect(
+      hook.execute(authContext, 'workspaceMember', payload),
+    ).resolves.toEqual(payload);
+  });
+
+  it('should canonicalize a legacy alias time zone', async () => {
+    const payload = buildPayload({ timeZone: 'CET' });
+
+    await expect(
+      hook.execute(authContext, 'workspaceMember', payload),
+    ).resolves.toEqual(buildPayload({ timeZone: 'Europe/Paris' }));
+  });
+
+  it('should reject an unknown time zone', async () => {
+    const payload = buildPayload({ timeZone: 'Mars/Olympus' });
+
+    await expect(
+      hook.execute(authContext, 'workspaceMember', payload),
+    ).rejects.toThrow('Invalid time zone: Mars/Olympus');
+  });
+});

--- a/packages/twenty-server/src/modules/workspace-member/query-hooks/workspace-member-query-hook.module.ts
+++ b/packages/twenty-server/src/modules/workspace-member/query-hooks/workspace-member-query-hook.module.ts
@@ -15,6 +15,7 @@ import { WorkspaceMemberDestroyOnePreQueryHook } from 'src/modules/workspace-mem
 import { WorkspaceMemberRestoreManyPreQueryHook } from 'src/modules/workspace-member/query-hooks/workspace-member-restore-many.pre-query.hook';
 import { WorkspaceMemberRestoreOnePreQueryHook } from 'src/modules/workspace-member/query-hooks/workspace-member-restore-one.pre-query.hook';
 import { WorkspaceMemberUpdateManyPreQueryHook } from 'src/modules/workspace-member/query-hooks/workspace-member-update-many.pre-query.hook';
+import { WorkspaceMemberUpdateOnePreQueryHook } from 'src/modules/workspace-member/query-hooks/workspace-member-update-one.pre-query.hook';
 
 @Module({
   providers: [
@@ -28,6 +29,7 @@ import { WorkspaceMemberUpdateManyPreQueryHook } from 'src/modules/workspace-mem
     WorkspaceMemberRestoreOnePreQueryHook,
     WorkspaceMemberRestoreManyPreQueryHook,
     WorkspaceMemberUpdateManyPreQueryHook,
+    WorkspaceMemberUpdateOnePreQueryHook,
   ],
   imports: [
     CoreEntityCacheModule,

--- a/packages/twenty-server/src/modules/workspace-member/query-hooks/workspace-member-update-one.pre-query.hook.ts
+++ b/packages/twenty-server/src/modules/workspace-member/query-hooks/workspace-member-update-one.pre-query.hook.ts
@@ -1,0 +1,53 @@
+import { msg } from '@lingui/core/macro';
+import { isNonEmptyString } from '@sniptt/guards';
+import {
+  IANA_TIME_ZONES,
+  LEGACY_TIME_ZONE_TO_IANA,
+} from 'twenty-shared/constants';
+
+import { type WorkspacePreQueryHookInstance } from 'src/engine/api/graphql/workspace-query-runner/workspace-query-hook/interfaces/workspace-query-hook.interface';
+import { type UpdateOneResolverArgs } from 'src/engine/api/graphql/workspace-resolver-builder/interfaces/workspace-resolvers-builder.interface';
+
+import {
+  CommonQueryRunnerException,
+  CommonQueryRunnerExceptionCode,
+} from 'src/engine/api/common/common-query-runners/errors/common-query-runner.exception';
+import { WorkspaceQueryHook } from 'src/engine/api/graphql/workspace-query-runner/workspace-query-hook/decorators/workspace-query-hook.decorator';
+import { type WorkspaceAuthContext } from 'src/engine/core-modules/auth/types/workspace-auth-context.type';
+import { type WorkspaceMemberWorkspaceEntity } from 'src/modules/workspace-member/standard-objects/workspace-member.workspace-entity';
+
+const VALID_TIME_ZONES = new Set<string>(IANA_TIME_ZONES);
+
+@WorkspaceQueryHook(`workspaceMember.updateOne`)
+export class WorkspaceMemberUpdateOnePreQueryHook implements WorkspacePreQueryHookInstance {
+  async execute(
+    _authContext: WorkspaceAuthContext,
+    _objectName: string,
+    payload: UpdateOneResolverArgs<Partial<WorkspaceMemberWorkspaceEntity>>,
+  ): Promise<UpdateOneResolverArgs<Partial<WorkspaceMemberWorkspaceEntity>>> {
+    const timeZone = payload.data?.timeZone;
+
+    if (!isNonEmptyString(timeZone) || timeZone === 'system') {
+      return payload;
+    }
+
+    // The column is plain text, so this is the only guard against persisting a
+    // zone that crashes date rendering on engines rejecting it (WebKit throws
+    // on legacy aliases such as CET). Aliases are canonicalized rather than
+    // rejected so older clients keep working.
+    const canonicalTimeZone = LEGACY_TIME_ZONE_TO_IANA[timeZone] ?? timeZone;
+
+    if (!VALID_TIME_ZONES.has(canonicalTimeZone)) {
+      throw new CommonQueryRunnerException(
+        `Invalid time zone: ${timeZone}`,
+        CommonQueryRunnerExceptionCode.BAD_REQUEST,
+        { userFriendlyMessage: msg`Invalid time zone.` },
+      );
+    }
+
+    return {
+      ...payload,
+      data: { ...payload.data, timeZone: canonicalTimeZone },
+    };
+  }
+}

--- a/packages/twenty-server/src/modules/workspace-member/query-hooks/workspace-member-update-one.pre-query.hook.ts
+++ b/packages/twenty-server/src/modules/workspace-member/query-hooks/workspace-member-update-one.pre-query.hook.ts
@@ -3,6 +3,7 @@ import { isNonEmptyString } from '@sniptt/guards';
 import {
   IANA_TIME_ZONES,
   LEGACY_TIME_ZONE_TO_IANA,
+  type IanaTimeZone,
 } from 'twenty-shared/constants';
 
 import { type WorkspacePreQueryHookInstance } from 'src/engine/api/graphql/workspace-query-runner/workspace-query-hook/interfaces/workspace-query-hook.interface';
@@ -18,6 +19,9 @@ import { type WorkspaceMemberWorkspaceEntity } from 'src/modules/workspace-membe
 
 const VALID_TIME_ZONES = new Set<string>(IANA_TIME_ZONES);
 
+const isIanaTimeZone = (value: string): value is IanaTimeZone =>
+  VALID_TIME_ZONES.has(value);
+
 @WorkspaceQueryHook(`workspaceMember.updateOne`)
 export class WorkspaceMemberUpdateOnePreQueryHook implements WorkspacePreQueryHookInstance {
   async execute(
@@ -25,19 +29,21 @@ export class WorkspaceMemberUpdateOnePreQueryHook implements WorkspacePreQueryHo
     _objectName: string,
     payload: UpdateOneResolverArgs<Partial<WorkspaceMemberWorkspaceEntity>>,
   ): Promise<UpdateOneResolverArgs<Partial<WorkspaceMemberWorkspaceEntity>>> {
-    const timeZone = payload.data?.timeZone;
+    // The entity types timeZone as IanaTimeZone | 'system', but the GraphQL
+    // input is an unvalidated string at runtime — this hook is what upholds
+    // the type.
+    const timeZone: string | undefined = payload.data?.timeZone;
 
     if (!isNonEmptyString(timeZone) || timeZone === 'system') {
       return payload;
     }
 
-    // The column is plain text, so this is the only guard against persisting a
-    // zone that crashes date rendering on engines rejecting it (WebKit throws
-    // on legacy aliases such as CET). Aliases are canonicalized rather than
-    // rejected so older clients keep working.
+    // Legacy aliases (e.g. CET) crash date rendering on engines rejecting
+    // them (WebKit), so they are canonicalized rather than rejected to keep
+    // older clients working.
     const canonicalTimeZone = LEGACY_TIME_ZONE_TO_IANA[timeZone] ?? timeZone;
 
-    if (!VALID_TIME_ZONES.has(canonicalTimeZone)) {
+    if (!isIanaTimeZone(canonicalTimeZone)) {
       throw new CommonQueryRunnerException(
         `Invalid time zone: ${timeZone}`,
         CommonQueryRunnerExceptionCode.BAD_REQUEST,

--- a/packages/twenty-server/src/modules/workspace-member/standard-objects/workspace-member.workspace-entity.ts
+++ b/packages/twenty-server/src/modules/workspace-member/standard-objects/workspace-member.workspace-entity.ts
@@ -61,6 +61,10 @@ export class WorkspaceMemberWorkspaceEntity extends BaseWorkspaceEntity {
   jobTitle: string | null;
   calendarStartDay: number;
   userId: string;
+  // Not typed as `IanaTimeZone | 'system'`: the 594-literal union makes
+  // TypeORM's QueryDeepPartialEntity/DeepPartial computations exceed
+  // TypeScript's union size limit (TS2590). The updateOne pre-query hook is
+  // the enforcement point instead.
   timeZone: string;
   dateFormat: string;
   timeFormat: string;

--- a/packages/twenty-shared/src/constants/IanaTimeZones.ts
+++ b/packages/twenty-shared/src/constants/IanaTimeZones.ts
@@ -595,4 +595,6 @@ export const IANA_TIME_ZONES = [
   'W-SU',
   'WET',
   'Zulu',
-];
+] as const;
+
+export type IanaTimeZone = (typeof IANA_TIME_ZONES)[number];

--- a/packages/twenty-shared/src/constants/LegacyTimeZoneToIana.ts
+++ b/packages/twenty-shared/src/constants/LegacyTimeZoneToIana.ts
@@ -1,0 +1,9 @@
+// Legacy IANA abbreviation zones that V8 (Chrome/Node) accepts but WebKit's ICU
+// rejects with a RangeError. Each maps to a canonical region zone with the same
+// current UTC offset and DST rules.
+export const LEGACY_TIME_ZONE_TO_IANA: Record<string, string> = {
+  CET: 'Europe/Paris',
+  MET: 'Europe/Berlin',
+  WET: 'Europe/Lisbon',
+  EET: 'Europe/Bucharest',
+};

--- a/packages/twenty-shared/src/constants/LegacyTimeZoneToIana.ts
+++ b/packages/twenty-shared/src/constants/LegacyTimeZoneToIana.ts
@@ -1,7 +1,9 @@
+import { type IanaTimeZone } from './IanaTimeZones';
+
 // Legacy IANA abbreviation zones that V8 (Chrome/Node) accepts but WebKit's ICU
 // rejects with a RangeError. Each maps to a canonical region zone with the same
 // current UTC offset and DST rules.
-export const LEGACY_TIME_ZONE_TO_IANA: Record<string, string> = {
+export const LEGACY_TIME_ZONE_TO_IANA: Record<string, IanaTimeZone> = {
   CET: 'Europe/Paris',
   MET: 'Europe/Berlin',
   WET: 'Europe/Lisbon',

--- a/packages/twenty-shared/src/constants/index.ts
+++ b/packages/twenty-shared/src/constants/index.ts
@@ -39,6 +39,7 @@ export { FIELD_RESTRICTED_ADDITIONAL_PERMISSIONS_REQUIRED } from './FieldRestric
 export { FILES_FIELD_MAX_NUMBER_OF_VALUES } from './FilesFieldMaxNumberOfValues';
 export { GIN_COMPATIBLE_FIELD_TYPES } from './GinCompatibleFieldTypes';
 export { GROUP_BY_DATE_GRANULARITY_THAT_REQUIRE_TIME_ZONE } from './GroupByDateGranularityThatRequireTimeZone';
+export type { IanaTimeZone } from './IanaTimeZones';
 export { IANA_TIME_ZONES } from './IanaTimeZones';
 export { LABEL_IDENTIFIER_FIELD_METADATA_TYPES } from './LabelIdentifierFieldMetadataTypes';
 export { LEGACY_TIME_ZONE_TO_IANA } from './LegacyTimeZoneToIana';

--- a/packages/twenty-shared/src/constants/index.ts
+++ b/packages/twenty-shared/src/constants/index.ts
@@ -41,6 +41,7 @@ export { GIN_COMPATIBLE_FIELD_TYPES } from './GinCompatibleFieldTypes';
 export { GROUP_BY_DATE_GRANULARITY_THAT_REQUIRE_TIME_ZONE } from './GroupByDateGranularityThatRequireTimeZone';
 export { IANA_TIME_ZONES } from './IanaTimeZones';
 export { LABEL_IDENTIFIER_FIELD_METADATA_TYPES } from './LabelIdentifierFieldMetadataTypes';
+export { LEGACY_TIME_ZONE_TO_IANA } from './LegacyTimeZoneToIana';
 export { MAX_CUSTOM_INDEXES_PER_OBJECT } from './MaxCustomIndexesPerObject';
 export { MAX_EMAIL_RECIPIENTS } from './MaxEmailRecipients';
 export { MULTI_ITEM_FIELD_DEFAULT_MAX_VALUES } from './MultiItemFieldDefaultMaxValues';


### PR DESCRIPTION
Fixes the Safari failure of the `app-prod-parity-e2e` check and the underlying Safari blank-page bug, and cleans up the stored data that triggers it.

Related issue: twentyhq/core-team-issues#2664

## Root cause

Not the workspace member timezone, and not browser timezone detection. `IANA_TIME_ZONES` in `twenty-shared` contains the legacy alias zones `CET`, `EET`, `MET` and `WET`. `AVAILABLE_TIME_ZONE_OPTIONS_BY_LABEL` formats every entry of that list **at module init** through `formatTimeZoneLabel` -> `formatInTimeZone(date, zone, '(OOOO) zzzz')`. The `O`/`z` tokens make date-fns-tz probe the zone with `new Intl.DateTimeFormat(undefined, { timeZone })`; WebKit's ICU rejects the aliases (V8 accepts them), so evaluating that chunk on Safari throws `RangeError: Invalid time zone specified: CET` and unmounts the whole app. `CET` is the first alias in the list, which is why the error always names CET.

This is why none of the environment-level mitigations worked (runner `/etc/localtime` pin, `TZ` env, Playwright `timezoneId`), and why the previous normalization attempt (reverted from #22672, commits `bf20ba9b3f9`/`f368cf2df51`) still failed CI with the identical stack (`formatInTimeZone-*.js:1:3552`): it normalized user-timezone resolution points, but the throw happens while enumerating the static options list.

A second product bug falls out of the same list: the picker offers options whose values are the legacy aliases themselves, so a user can persist a zone that blanks their whole workspace on Safari — and the backend column is plain `text` with no validation, so any API client can do the same.

## Changes

### Frontend: never crash on a legacy alias

- `buildAvailableTimeZoneOptionsByLabel`: skip the legacy aliases on every engine (their canonical region zones are already in the list) and any zone the running engine can't format; compute each label once instead of five times per zone.
- New `normalizeTimeZone` + `isTimeZoneSupported` (re-landing the reverted utils): a supported zone passes through unchanged — so rendering never changes on engines that accept it, historical dates included — and a rejected legacy alias is remapped to its canonical zone (`CET` -> `Europe/Paris`, ...), falling back to the detected zone, then UTC. `isTimeZoneSupported` is memoized since it runs on hot render paths.
- Normalization wired at the source and the sinks so a persisted legacy alias keeps rendering on WebKit: `detectTimeZone()` (WebKit can detect a zone its own ICU then rejects), `formatTimeZoneLabel`, all four `formatDateISOStringTo*` utils (including `formatDateISOStringToCustomUnicodeFormat`, which the previous attempt missed), `useUserTimezone` and `buildHeadlessCommandContextApi`.

### Backend: validate on write, backfill stored data

- `LEGACY_TIME_ZONE_TO_IANA` moved to `twenty-shared` so both sides share the mapping.
- New `workspaceMember.updateOne` pre-query hook (the only open generic write path — create/updateMany are permission-denied): canonicalizes legacy aliases and rejects any zone outside `IANA_TIME_ZONES` with a BAD_REQUEST, so invalid zones can no longer be persisted.
- New 2.20 workspace upgrade command `upgrade:2-20:normalize-workspace-member-time-zones`: per-workspace backfill rewriting stored `timeZone` values — legacy aliases to their canonical region zone, anything unsupported to `'system'`. Supports `--dry-run` with counts.
- `IANA_TIME_ZONES` itself is left untouched: it doubles as the group-by validation whitelist, and older clients may still send alias values until they pick up this build.

Behavior change: an unknown/unsupported stored zone now renders values in the fallback zone instead of returning the `'Invalid format string'` error string (test updated accordingly).

## Testing

- New regression test imports the options module under a WebKit-simulated `Intl` (throws on the aliases) and asserts it builds without throwing and never offers an alias as an option value.
- Unit tests for `normalizeTimeZone`, `isTimeZoneSupported`, `detectTimeZone` (detected `CET` -> `Europe/Paris` when rejected), `formatTimeZoneLabel`, and the new `workspaceMember.updateOne` hook (pass-through, canonicalization, rejection).
- Affected front + server suites pass; `typecheck` and `lint:diff-with-main` green on both packages.
- Verified end-to-end in the real failing environment: the `App Prod-Parity E2E` workflow (webkit spec included) passed against this fix — https://github.com/twentyhq/ci-privileged/actions/runs/29088930806. A run against the current head is dispatched and posts the `app-prod-parity-e2e` status on this PR.