### PR TITLE
fix(workflow): scope one-active-per-workflow index to workspace

### DIFF
--- a/packages/twenty-server/src/database/commands/upgrade-version-command/2-20/2-20-instance-command-fast-1783512000000-create-workflow-version-core-table.ts
+++ b/packages/twenty-server/src/database/commands/upgrade-version-command/2-20/2-20-instance-command-fast-1783512000000-create-workflow-version-core-table.ts
@@ -31,7 +31,7 @@ export class CreateWorkflowVersionCoreTableFastInstanceCommand
     );
     await queryRunner.query(
       `CREATE UNIQUE INDEX IF NOT EXISTS "IDX_WORKFLOW_VERSION_ONE_ACTIVE_PER_WORKFLOW"
-        ON "core"."workflowVersion" ("workflowId")
+        ON "core"."workflowVersion" ("workspaceId", "workflowId")
         WHERE "status" = 'ACTIVE'`,
     );
   }

--- a/packages/twenty-server/src/engine/core-modules/workflow/entities/workflow-version.entity.ts
+++ b/packages/twenty-server/src/engine/core-modules/workflow/entities/workflow-version.entity.ts
@@ -25,10 +25,14 @@ export enum WorkflowVersionStatus {
   upgradeCommandName: CREATE_WORKFLOW_VERSION_CORE_TABLE_UPGRADE_COMMAND_NAME,
 })
 @Index('IDX_WORKFLOW_VERSION_WORKSPACE_ID', ['workspaceId'])
-@Index('IDX_WORKFLOW_VERSION_ONE_ACTIVE_PER_WORKFLOW', ['workflowId'], {
-  unique: true,
-  where: `"status" = 'ACTIVE'`,
-})
+@Index(
+  'IDX_WORKFLOW_VERSION_ONE_ACTIVE_PER_WORKFLOW',
+  ['workspaceId', 'workflowId'],
+  {
+    unique: true,
+    where: `"status" = 'ACTIVE'`,
+  },
+)
 @Index('IDX_WORKFLOW_VERSION_APPLICATION_ID', ['applicationId'])
 export class WorkflowVersionEntity extends SyncableEntity {
   @PrimaryGeneratedColumn('uuid')


### PR DESCRIPTION
## Problem

The Phase 0 core index \`IDX_WORKFLOW_VERSION_ONE_ACTIVE_PER_WORKFLOW\` is on \`(workflowId) WHERE status='ACTIVE'\`, with **no \`workspaceId\`**. But \`core.workflowVersion\` is a shared multi-tenant table, so this enforces "one active version per workflowId **globally across all workspaces**" instead of per workspace.

The version backfill fails on staging with:
\`\`\`
duplicate key value violates unique constraint "IDX_WORKFLOW_VERSION_ONE_ACTIVE_PER_WORKFLOW"
Detail: Key ("workflowId")=(8b213cac-...) already exists.
\`\`\`
across several different workspaces that share the same workflowId (seeded/cloned data): workspace A's active version claims the workflowId, and every other workspace's insert collides. Every other index on this table includes \`workspaceId\`; this one dropped it when copied from the per-tenant workspace entity.

## Fix

Index becomes \`(workspaceId, workflowId) WHERE status='ACTIVE'\` — one active version per workflow **per workspace**, matching the table's multi-tenant design and the intended invariant. New 2-20 fast instance command drops and recreates the index (Phase 0's command is merged/append-only).

## Test

Reset + reproduce the exact scenario against the fixed index:
- two workspaces with the same workflowId, both ACTIVE → **insert succeeds** (previously collided)
- a second ACTIVE version for the same workflow within one workspace → **still blocked** (invariant preserved)

Zero \`migrate:generate\` drift, typecheck + lint clean. After this deploys, re-run \`upgrade:2-20:backfill-workflow-version-to-core\`.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/22795?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

