### PR TITLE
docs: partner CTAs on high-traffic pages (workflows, data-model, docker-compose)

### DIFF
--- a/packages/twenty-docs/developers/self-host/capabilities/docker-compose.mdx
+++ b/packages/twenty-docs/developers/self-host/capabilities/docker-compose.mdx
@@ -241,3 +241,9 @@ docker compose up -d
 
 If you encounter any problem, check [Troubleshooting](/developers/self-host/capabilities/troubleshooting) for solutions.
 
+## Managed Hosting
+
+<Tip>
+  Prefer not to run and maintain Twenty yourself? [Find a certified Twenty hosting partner](https://twenty.com/partners/list?categories=HOSTING&ref=docs-docker-compose) to deploy, host, and manage your instance end-to-end. *(Or reach our team: [contact@twenty.com](mailto:contact@twenty.com).)*
+</Tip>
+

--- a/packages/twenty-docs/user-guide/data-model/overview.mdx
+++ b/packages/twenty-docs/user-guide/data-model/overview.mdx
@@ -161,4 +161,9 @@ Once you've planned your data model:
 
 ## Need Help?
 
-Our team can help you design and create the data model you need. Discover our [Implementation Services](/user-guide/getting-started/capabilities/implementation-services).
+<Tip>
+  Want help designing your data model?
+
+  - **Done for you:** [find a certified Twenty partner](https://twenty.com/partners/list?categories=SOLUTIONING&ref=docs-data-model) to design and build your objects, fields, and relationships.
+  - **Onboarding pack:** a 4-hour guided Data Model Design session with our team — [contact@twenty.com](mailto:contact@twenty.com). See [Implementation Services](/user-guide/getting-started/capabilities/implementation-services).
+</Tip>

--- a/packages/twenty-docs/user-guide/workflows/overview.mdx
+++ b/packages/twenty-docs/user-guide/workflows/overview.mdx
@@ -69,3 +69,12 @@ After your trigger, add one or more actions:
 - [Workflow Triggers](/user-guide/workflows/capabilities/workflow-triggers)
 - [Workflow Actions](/user-guide/workflows/capabilities/workflow-actions)
 - [CRM Automations](/user-guide/workflows/how-tos/crm-automations/closed-won-automations)
+
+## Need Help?
+
+<Tip>
+  Want help automating your workflows?
+
+  - **Done for you:** [find a certified Twenty partner](https://twenty.com/partners/list?categories=SOLUTIONING&ref=docs-workflows) to design and build your automations end-to-end.
+  - **Onboarding pack:** a 4-hour guided Workflow Creation session with our team — [contact@twenty.com](mailto:contact@twenty.com).
+</Tip>


### PR DESCRIPTION
## Summary

Follow-up to #22719 (merged), which added partner-marketplace CTAs to four **high-intent, low-traffic** docs pages (SSO, both migration guides, implementation services).

Reviewing the docs' **top-visited pages** showed none of those four rank in the top ~20 — they're the high-intent tail, which is correct, but small reach. This PR extends the same pattern to three **high-traffic pages that also carry buying intent**, without touching the pure top-of-funnel intros/quickstarts (volume without intent → a CTA there is just noise).

Same conventions as #22719: Mintlify-native `<Tip>` callouts, partner-first with `contact@twenty.com` secondary, directory deep-linked via `?categories=<scope>` and tagged with `?ref=docs-*`. No new snippet; no `docs.json`, navigation, or translation (`l/`) changes.

## Pages changed — screenshots (one per page)

> Preview locally with `npx mintlify dev` from `packages/twenty-docs`, or use the Mintlify PR preview once it posts. Paths below are under `docs.twenty.com`.

### 1. `/user-guide/workflows/overview` (~593 views)
New `## Need Help?` two-bullet `<Tip>` → **Done for you** (Solutioning partner) / **Onboarding pack** (Workflow Creation). Maps 1:1 to the named onboarding service.

_screenshot:_
<img width="1440" height="818" alt="Screenshot 2026-07-10 at 14 34 32" src="https://github.com/user-attachments/assets/231f681d-b5be-4b1e-9b6a-a4947a9fca37" />


### 2. `/user-guide/data-model/overview` (~954 views)
Replaced the plain "Need Help?" line with a two-bullet `<Tip>` → **Done for you** (Solutioning partner) / **Onboarding pack** (Data Model Design). Keeps the existing Implementation Services link.

_screenshot:_
<img width="1436" height="817" alt="Screenshot 2026-07-10 at 14 34 14" src="https://github.com/user-attachments/assets/c0fe1064-1030-4062-91c7-24644ac31654" />


### 3. `/developers/self-host/capabilities/docker-compose` (~2421 views)
New `## Managed Hosting` single-line `<Tip>` → *find a certified Twenty hosting partner* (Hosting), contact fallback. Framed as a lighter "prefer not to run it yourself?" alternative — deliberately low-pressure for the DIY self-host audience.

_screenshot:_
<img width="1437" height="815" alt="Screenshot 2026-07-10 at 14 33 39" src="https://github.com/user-attachments/assets/a37207cd-2aaa-4aba-848d-cbf06a1e1321" />

## Notes for reviewers

- Page-selection rationale: intent × volume. Kept the four intent-tail pages from #22719; added the highest-traffic pages that also carry a natural partner-buying moment (self-host → Hosting; workflows / data-model → Solutioning). Intros/quickstarts/contribute pages intentionally left untouched.
- **Attribution caveat (unchanged from #22719):** twenty.com's analytics (Cloudflare Web Analytics) is path-based, so `?ref=` is not measurable yet. Per-page measurement via a `/go/*` redirect Worker remains a planned, separate follow-up (out of scope here).
- `mintlify validate` passes.

Opened as a draft.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/22808?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

