### PR TITLE
Disable install button in app install onboarding when no app is selected

### DIFF
--- a/packages/twenty-front/src/pages/onboarding/InstallAppsContent.tsx
+++ b/packages/twenty-front/src/pages/onboarding/InstallAppsContent.tsx
@@ -204,7 +204,9 @@ export const InstallAppsContent = ({
               <MainButton
                 title={t`Install`}
                 onClick={onInstall}
-                disabled={isCompleting}
+                disabled={
+                  isCompleting || !isNonEmptyArray(selectedUniversalIdentifiers)
+                }
                 fullWidth
               />
             </StyledInstallButton>


### PR DESCRIPTION
In the app installation onboarding step, the Install button was always clickable, even with no app selected. Clicking it with an empty selection ran the completion flow with zero apps, which is equivalent to skipping.

Now the button is disabled until at least one app is selected (in addition to staying disabled while completing). The Skip button remains available for users who don't want to install anything.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/22822?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

