### PR TITLE
chore(server): extract shared cursor pagination primitives to common-api

### DIFF
--- a/packages/twenty-server/src/engine/api/common/utils/cursor.util.ts
+++ b/packages/twenty-server/src/engine/api/common/utils/cursor.util.ts
@@ -1,0 +1,40 @@
+import {
+  CommonQueryRunnerException,
+  CommonQueryRunnerExceptionCode,
+} from 'src/engine/api/common/common-query-runners/errors/common-query-runner.exception';
+import { STANDARD_ERROR_MESSAGE } from 'src/engine/api/common/common-query-runners/errors/standard-error-message.constant';
+
+export interface CursorData {
+  // oxlint-disable-next-line typescript/no-explicit-any
+  [key: string]: any;
+}
+
+export const decodeCursor = <T = CursorData>(cursor: string): T => {
+  try {
+    return JSON.parse(Buffer.from(cursor, 'base64').toString());
+  } catch {
+    throw new CommonQueryRunnerException(
+      `Invalid cursor: ${cursor}`,
+      CommonQueryRunnerExceptionCode.INVALID_CURSOR,
+      { userFriendlyMessage: STANDARD_ERROR_MESSAGE },
+    );
+  }
+};
+
+export const encodeCursorData = (cursorData: CursorData) => {
+  return Buffer.from(JSON.stringify(cursorData)).toString('base64');
+};
+
+export const getPaginationInfo = <T>(
+  records: T[],
+  limit: number,
+  isForwardPagination: boolean,
+) => {
+  const hasMoreRecords = records.length > limit;
+
+  return {
+    hasNextPage: isForwardPagination && hasMoreRecords,
+    hasPreviousPage: !isForwardPagination && hasMoreRecords,
+    hasMoreRecords,
+  };
+};

--- a/packages/twenty-server/src/engine/api/common/utils/get-page-info.util.ts
+++ b/packages/twenty-server/src/engine/api/common/utils/get-page-info.util.ts
@@ -3,10 +3,8 @@ import { type ObjectRecord } from 'twenty-shared/types';
 import { type ObjectRecordOrderBy } from 'src/engine/api/graphql/workspace-query-builder/interfaces/object-record.interface';
 
 import { type CommonPageInfo } from 'src/engine/api/common/types/common-page-info.type';
-import {
-  encodeCursor,
-  getPaginationInfo,
-} from 'src/engine/api/graphql/graphql-query-runner/utils/cursors.util';
+import { getPaginationInfo } from 'src/engine/api/common/utils/cursor.util';
+import { encodeCursor } from 'src/engine/api/graphql/graphql-query-runner/utils/cursors.util';
 import { type FlatEntityMaps } from 'src/engine/metadata-modules/flat-entity/types/flat-entity-maps.type';
 import { type FlatFieldMetadata } from 'src/engine/metadata-modules/flat-field-metadata/types/flat-field-metadata.type';
 import { type FlatObjectMetadata } from 'src/engine/metadata-modules/flat-object-metadata/types/flat-object-metadata.type';

--- a/packages/twenty-server/src/engine/api/graphql/graphql-query-runner/utils/__tests__/cursors.util.spec.ts
+++ b/packages/twenty-server/src/engine/api/graphql/graphql-query-runner/utils/__tests__/cursors.util.spec.ts
@@ -5,7 +5,10 @@ import { type ObjectRecordOrderBy } from 'src/engine/api/graphql/workspace-query
 import { type FlatEntityMaps } from 'src/engine/metadata-modules/flat-entity/types/flat-entity-maps.type';
 import { type FlatFieldMetadata } from 'src/engine/metadata-modules/flat-field-metadata/types/flat-field-metadata.type';
 import { type FlatObjectMetadata } from 'src/engine/metadata-modules/flat-object-metadata/types/flat-object-metadata.type';
-import { decodeCursor, encodeCursor } from '../cursors.util';
+
+import { decodeCursor } from 'src/engine/api/common/utils/cursor.util';
+
+import { encodeCursor } from '../cursors.util';
 
 const buildMockField = (
   id: string,

--- a/packages/twenty-server/src/engine/api/graphql/graphql-query-runner/utils/cursors.util.ts
+++ b/packages/twenty-server/src/engine/api/graphql/graphql-query-runner/utils/cursors.util.ts
@@ -5,33 +5,16 @@ import { type ObjectRecordOrderBy } from 'src/engine/api/graphql/workspace-query
 import { type FindManyResolverArgs } from 'src/engine/api/graphql/workspace-resolver-builder/interfaces/workspace-resolvers-builder.interface';
 
 import {
-  CommonQueryRunnerException,
-  CommonQueryRunnerExceptionCode,
-} from 'src/engine/api/common/common-query-runners/errors/common-query-runner.exception';
-import { STANDARD_ERROR_MESSAGE } from 'src/engine/api/common/common-query-runners/errors/standard-error-message.constant';
+  type CursorData,
+  decodeCursor,
+  encodeCursorData,
+} from 'src/engine/api/common/utils/cursor.util';
 import { isCompositeFieldMetadataType } from 'src/engine/metadata-modules/field-metadata/utils/is-composite-field-metadata-type.util';
 import { type FlatEntityMaps } from 'src/engine/metadata-modules/flat-entity/types/flat-entity-maps.type';
 import { findFlatEntityByIdInFlatEntityMaps } from 'src/engine/metadata-modules/flat-entity/utils/find-flat-entity-by-id-in-flat-entity-maps.util';
 import { type FlatFieldMetadata } from 'src/engine/metadata-modules/flat-field-metadata/types/flat-field-metadata.type';
 import { buildFieldMapsFromFlatObjectMetadata } from 'src/engine/metadata-modules/flat-field-metadata/utils/build-field-maps-from-flat-object-metadata.util';
 import { type FlatObjectMetadata } from 'src/engine/metadata-modules/flat-object-metadata/types/flat-object-metadata.type';
-
-export interface CursorData {
-  // oxlint-disable-next-line typescript/no-explicit-any
-  [key: string]: any;
-}
-
-export const decodeCursor = <T = CursorData>(cursor: string): T => {
-  try {
-    return JSON.parse(Buffer.from(cursor, 'base64').toString());
-  } catch {
-    throw new CommonQueryRunnerException(
-      `Invalid cursor: ${cursor}`,
-      CommonQueryRunnerExceptionCode.INVALID_CURSOR,
-      { userFriendlyMessage: STANDARD_ERROR_MESSAGE },
-    );
-  }
-};
 
 export const encodeCursor = <T extends ObjectRecord = ObjectRecord>({
   objectRecord,
@@ -98,10 +81,6 @@ export const encodeCursor = <T extends ObjectRecord = ObjectRecord>({
   return encodeCursorData(cursorData);
 };
 
-export const encodeCursorData = (cursorData: CursorData) => {
-  return Buffer.from(JSON.stringify(cursorData)).toString('base64');
-};
-
 export const getCursor = (
   // oxlint-disable-next-line typescript/no-explicit-any
   args: FindManyResolverArgs<any, any>,
@@ -111,18 +90,4 @@ export const getCursor = (
   if (args.before) return decodeCursor(args.before);
 
   return undefined;
-};
-
-export const getPaginationInfo = (
-  objectRecords: ObjectRecord[],
-  limit: number,
-  isForwardPagination: boolean,
-) => {
-  const hasMoreRecords = objectRecords.length > limit;
-
-  return {
-    hasNextPage: isForwardPagination && hasMoreRecords,
-    hasPreviousPage: !isForwardPagination && hasMoreRecords,
-    hasMoreRecords,
-  };
 };

--- a/packages/twenty-server/src/engine/core-modules/search/__tests__/search.service.spec.ts
+++ b/packages/twenty-server/src/engine/core-modules/search/__tests__/search.service.spec.ts
@@ -1,6 +1,6 @@
 import { Test, type TestingModule } from '@nestjs/testing';
 
-import { encodeCursorData } from 'src/engine/api/graphql/graphql-query-runner/utils/cursors.util';
+import { encodeCursorData } from 'src/engine/api/common/utils/cursor.util';
 import {
   mockFlatFieldMetadataMaps,
   mockFlatObjectMetadatas,

--- a/packages/twenty-server/src/engine/core-modules/search/services/search.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/search/services/search.service.ts
@@ -18,11 +18,11 @@ import { Brackets, type ObjectLiteral } from 'typeorm';
 import { type ObjectRecordFilter } from 'src/engine/api/graphql/workspace-query-builder/interfaces/object-record.interface';
 
 import { FileOutput } from 'src/engine/api/common/common-args-processors/data-arg-processor/types/file-item.type';
-import { GraphqlQueryParser } from 'src/engine/api/graphql/graphql-query-runner/graphql-query-parsers/graphql-query.parser';
 import {
   decodeCursor,
   encodeCursorData,
-} from 'src/engine/api/graphql/graphql-query-runner/utils/cursors.util';
+} from 'src/engine/api/common/utils/cursor.util';
+import { GraphqlQueryParser } from 'src/engine/api/graphql/graphql-query-runner/graphql-query-parsers/graphql-query.parser';
 import { isQueryCanceledError } from 'src/engine/api/graphql/workspace-query-runner/utils/is-query-canceled-error.util';
 import { FileUrlService } from 'src/engine/core-modules/file/file-url/file-url.service';
 import { extractFileIdFromUrl } from 'src/engine/core-modules/file/files-field/utils/extract-file-id-from-url.util';


### PR DESCRIPTION
## Summary

Extracts the record-agnostic cursor/pagination primitives out of the dynamic-schema (companies, people, …) `graphql-query-runner` cursors util into a neutral `common-api` util, so they can be reused outside the object-record pipeline — e.g. by upcoming hand-written metadata resolvers as part of the `@ptc-org/nestjs-query` removal effort.

- New `engine/api/common/utils/cursor.util.ts` now owns the generic primitives:
  - `decodeCursor` / `encodeCursorData` — opaque base64-JSON cursor codec
  - `getPaginationInfo` — generic `hasNextPage` / `hasPreviousPage` / `hasMoreRecords` (now generic `<T>`, no longer tied to `ObjectRecord`)
- The record-specific `encodeCursor` / `getCursor` connection logic stays in `graphql-query-runner/utils/cursors.util.ts` and now imports the shared primitives.
- All importers re-pointed at the new location (no re-export shim): dynamic-schema cursors util, `get-page-info.util.ts`, and `search.service.ts` (+ specs).

This is a pure move + re-point — **no behavior change and no GraphQL schema change**.

## Test plan

- [x] `cursors.util.spec.ts` and `search.service.spec.ts` pass (23 tests)
- [x] `nx lint:diff-with-main twenty-server` clean (lint + format) on all 6 files
- [ ] CI green

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/22830?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

