### PR TITLE
Fix(Twenty-front): Junction field unable to display as table

### DIFF
--- a/packages/twenty-front/src/modules/page-layout/widgets/field/components/FieldWidget.tsx
+++ b/packages/twenty-front/src/modules/page-layout/widgets/field/components/FieldWidget.tsx
@@ -136,6 +136,15 @@ export const FieldWidget = ({ widget }: FieldWidgetProps) => {
         );
       }
 
+      if (fieldDisplayMode === FieldDisplayMode.TABLE) {
+        return (
+          <FieldWidgetRelationTable
+            fieldDefinition={fieldDefinition}
+            recordId={targetRecord.id}
+          />
+        );
+      }
+
       return (
         <FieldWidgetJunctionRelationField
           fieldDefinition={fieldDefinition}


### PR DESCRIPTION
Fixes: #22783 

The junction field can now be displayed as a table.
<img width="1911" height="961" alt="image" src="https://github.com/user-attachments/assets/2aad15af-baca-4563-85eb-ef0826008a7d" />
