### PR TITLE
fix: validation link for access-domains deeplinks to Invite tab

### DIFF
--- a/packages/twenty-server/src/engine/core-modules/approved-access-domain/services/approved-access-domain.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/approved-access-domain/services/approved-access-domain.service.ts
@@ -86,6 +86,7 @@ export class ApprovedAccessDomainService {
           workspaceId: workspace.id,
         }),
       },
+      hash: 'invite',
     });
 
     if (!isDefined(sender.userEmail)) {

--- a/packages/twenty-server/src/engine/core-modules/approved-access-domain/services/approved-access-domain.spec.ts
+++ b/packages/twenty-server/src/engine/core-modules/approved-access-domain/services/approved-access-domain.spec.ts
@@ -344,6 +344,7 @@ describe('ApprovedAccessDomainService', () => {
           wtdId: approvedAccessDomain.id,
           validationToken: 'signed.jwt.token',
         },
+        hash: 'invite',
       });
 
       expect(emailService.send).toHaveBeenCalledWith({

--- a/packages/twenty-server/src/engine/core-modules/domain/domain-server-config/utils/build-url-with-pathname-and-search-params.util.ts
+++ b/packages/twenty-server/src/engine/core-modules/domain/domain-server-config/utils/build-url-with-pathname-and-search-params.util.ts
@@ -4,12 +4,14 @@ type BuildUrlWithPathnameAndSearchParamsProps = {
   baseUrl: URL;
   pathname?: string;
   searchParams?: Record<string, string | number | boolean>;
+  hash?: string;
 };
 
 export const buildUrlWithPathnameAndSearchParams = ({
   baseUrl,
   pathname,
   searchParams,
+  hash,
 }: BuildUrlWithPathnameAndSearchParamsProps) => {
   const url = baseUrl;
 
@@ -19,6 +21,10 @@ export const buildUrlWithPathnameAndSearchParams = ({
 
   if (searchParams) {
     appendSearchParamsToUrl(url, searchParams);
+  }
+
+  if (hash) {
+    url.hash = hash;
   }
 
   return url;

--- a/packages/twenty-server/src/engine/core-modules/domain/workspace-domains/services/__test__/workspace-domains.service.spec.ts
+++ b/packages/twenty-server/src/engine/core-modules/domain/workspace-domains/services/__test__/workspace-domains.service.spec.ts
@@ -183,6 +183,38 @@ describe('WorkspaceDomainsService', () => {
       expect(result.searchParams.get('foo')).toBe('bar');
       expect(result.searchParams.get('baz')).toBe('123');
     });
+
+    it('should set the hash if provided', () => {
+      jest
+        .spyOn(twentyConfigService, 'get')
+        .mockImplementation((key: string) => {
+          const env = {
+            FRONTEND_URL: 'https://example.com',
+          };
+
+          // @ts-expect-error legacy noImplicitAny
+          return env[key];
+        });
+
+      const result = workspaceDomainsService.buildWorkspaceURL({
+        workspace: {
+          subdomain: 'test',
+          customDomain: null,
+          isCustomDomainEnabled: false,
+        },
+        pathname: '/settings/members',
+        searchParams: {
+          wtdId: 'domain-id',
+        },
+        hash: 'invite',
+      });
+
+      expect(result.hash).toBe('#invite');
+      expect(result.searchParams.get('wtdId')).toBe('domain-id');
+      expect(result.toString()).toBe(
+        'https://example.com/settings/members?wtdId=domain-id#invite',
+      );
+    });
   });
 
   describe('getWorkspaceByOriginOrDefaultWorkspace', () => {

--- a/packages/twenty-server/src/engine/core-modules/domain/workspace-domains/services/workspace-domains.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/domain/workspace-domains/services/workspace-domains.service.ts
@@ -31,10 +31,12 @@ export class WorkspaceDomainsService {
     workspace,
     pathname,
     searchParams,
+    hash,
   }: {
     workspace: WorkspaceDomainConfig;
     pathname?: string;
     searchParams?: Record<string, string | number | boolean>;
+    hash?: string;
   }) {
     const workspaceUrls = this.getWorkspaceUrls(workspace);
 
@@ -42,6 +44,7 @@ export class WorkspaceDomainsService {
       baseUrl: new URL(workspaceUrls.customUrl ?? workspaceUrls.subdomainUrl),
       pathname,
       searchParams,
+      hash,
     });
 
     return url;


### PR DESCRIPTION
The "validate domain" link sent in the email when adding an Access Domain wasn't working because the link didn't deep link to the Invite tab

URLs are now built to include the that hash property to deep link to the target tab.

Before:
```
https://example.com/settings/members?wtdId=<id>&validationToken=<token>
```

After:
```
https://example.com/settings/members?wtdId=<id>&validationToken=<token>#invite
```

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/22845?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

