### PR TITLE
fix: preserve inline editor width when editing text fields

### DIFF
--- a/packages/twenty-front/src/modules/object-record/record-inline-cell/components/RecordInlineCellEditMode.tsx
+++ b/packages/twenty-front/src/modules/object-record/record-inline-cell/components/RecordInlineCellEditMode.tsx
@@ -7,15 +7,16 @@ import { OverlayContainer } from '@/ui/layout/overlay/components/OverlayContaine
 import { useAvailableComponentInstanceIdOrThrow } from '@/ui/utilities/state/component-state/hooks/useAvailableComponentInstanceIdOrThrow';
 import { useAtomComponentStateValue } from '@/ui/utilities/state/jotai/hooks/useAtomComponentStateValue';
 import { useSetAtomComponentState } from '@/ui/utilities/state/jotai/hooks/useSetAtomComponentState';
-import { styled } from '@linaria/react';
 import {
   autoUpdate,
   flip,
   offset,
   shift,
+  size,
   useFloating,
   type MiddlewareState,
 } from '@floating-ui/react';
+import { styled } from '@linaria/react';
 import { useContext } from 'react';
 import { createPortal } from 'react-dom';
 
@@ -83,6 +84,11 @@ export const RecordInlineCellEditMode = ({
               crossAxis: -5,
             },
       ),
+      size({
+        apply({ rects, elements }) {
+          elements.floating.style.width = `${rects.reference.width}px`;
+        },
+      }),
       shift({ padding: 8 }),
       setFieldInputLayoutDirectionMiddleware,
     ],

--- a/packages/twenty-front/src/modules/ui/field/input/components/TextAreaInput.tsx
+++ b/packages/twenty-front/src/modules/ui/field/input/components/TextAreaInput.tsx
@@ -53,7 +53,7 @@ const StyledTextAreaContainer = styled.div`
     padding: ${themeCssVariables.spacing[0]} ${themeCssVariables.spacing[2]};
     resize: none;
 
-    width: 100%;
+    width: calc(100% - ${themeCssVariables.spacing[7]});
   }
 `;
 

--- a/packages/twenty-front/src/modules/ui/field/input/components/TextAreaInput.tsx
+++ b/packages/twenty-front/src/modules/ui/field/input/components/TextAreaInput.tsx
@@ -5,8 +5,8 @@ import TextareaAutosize from 'react-textarea-autosize';
 import { LightCopyIconButton } from '@/object-record/record-field/ui/components/LightCopyIconButton';
 import { useRegisterInputEvents } from '@/object-record/record-field/ui/meta-types/input/hooks/useRegisterInputEvents';
 import { isDefined } from 'twenty-shared/utils';
-import { turnIntoEmptyStringIfWhitespacesOnly } from '~/utils/string/turnIntoEmptyStringIfWhitespacesOnly';
 import { themeCssVariables } from 'twenty-ui/theme-constants';
+import { turnIntoEmptyStringIfWhitespacesOnly } from '~/utils/string/turnIntoEmptyStringIfWhitespacesOnly';
 
 export type TextAreaInputProps = {
   instanceId: string;
@@ -26,6 +26,9 @@ export type TextAreaInputProps = {
 };
 
 const StyledTextAreaContainer = styled.div`
+  flex: 1;
+  width: 100%;
+
   > textarea {
     align-items: center;
     background-color: transparent;
@@ -50,7 +53,7 @@ const StyledTextAreaContainer = styled.div`
     padding: ${themeCssVariables.spacing[0]} ${themeCssVariables.spacing[2]};
     resize: none;
 
-    width: calc(100% - ${themeCssVariables.spacing[7]});
+    width: 100%;
   }
 `;
 


### PR DESCRIPTION
Fixes #22841

## Context

When the right-side panel is manually widened, entering edit mode on a text field causes the inline editor to render with a narrower width than the available space. This causes long text to wrap prematurely instead of using the available editing space.

## Changes

- Match the floating inline editor width to the reference element using Floating UI's `size` middleware.
- Allow the textarea container to grow and occupy the available width.
- Update the textarea width to fill its container, preventing unnecessary wrapping.

## Test

- Reproduced the issue by manually widening the right-side panel.
- Verified that the inline text editor matches the available width when entering edit mode.
- Tested with long text values to confirm wrapping behaves as expected.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/22847?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

