### PR TITLE
chore: upgrade call-recorder, last-contact, people-data-labs to twenty-sdk 2.20

### DIFF
--- a/packages/twenty-apps/public/call-recorder/package.json
+++ b/packages/twenty-apps/public/call-recorder/package.json
@@ -1,12 +1,12 @@
 {
   "name": "@twentyhq/call-recorder",
-  "version": "1.0.10",
+  "version": "1.0.11",
   "license": "MIT",
   "engines": {
     "node": "^24.5.0",
     "npm": "please-use-yarn",
     "yarn": ">=4.0.2",
-    "twenty": ">=2.19.0"
+    "twenty": ">=2.20.0"
   },
   "keywords": [
     "twenty-app"
@@ -35,8 +35,8 @@
     "oxlint": "^0.16.0",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
-    "twenty-client-sdk": "2.19.0",
-    "twenty-sdk": "2.19.0",
+    "twenty-client-sdk": "2.20.0",
+    "twenty-sdk": "2.20.0",
     "twenty-ui": "^1.0.0-alpha.1",
     "typescript": "^5.9.3",
     "vite-tsconfig-paths": "^4.2.1",

--- a/packages/twenty-apps/public/call-recorder/yarn.lock
+++ b/packages/twenty-apps/public/call-recorder/yarn.lock
@@ -1376,8 +1376,8 @@ __metadata:
     react: "npm:^19.0.0"
     react-dom: "npm:^19.0.0"
     sharp: "npm:^0.34.5"
-    twenty-client-sdk: "npm:2.19.0"
-    twenty-sdk: "npm:2.19.0"
+    twenty-client-sdk: "npm:2.20.0"
+    twenty-sdk: "npm:2.20.0"
     twenty-ui: "npm:^1.0.0-alpha.1"
     typescript: "npm:^5.9.3"
     vite-tsconfig-paths: "npm:^4.2.1"
@@ -3588,22 +3588,22 @@ __metadata:
   languageName: node
   linkType: hard
 
-"twenty-client-sdk@npm:2.19.0":
-  version: 2.19.0
-  resolution: "twenty-client-sdk@npm:2.19.0"
+"twenty-client-sdk@npm:2.20.0":
+  version: 2.20.0
+  resolution: "twenty-client-sdk@npm:2.20.0"
   dependencies:
     "@genql/runtime": "npm:^2.10.0"
     esbuild: "npm:^0.28.1"
     graphql: "npm:^16.8.1"
     lodash: "npm:^4.17.21"
     prettier: "npm:^3.8.3"
-  checksum: 10c0/647922bda96a98fa163bed50b1e9065e9fc6f624e7ee40abcbe99a4c4bbfdd9a54b19fd2b774e06e6f758dd63a63724daf5ee34d716d7fe1740c04f120d266c0
+  checksum: 10c0/925a5ad99bbccb7290365536b6d7ded6a8d02a064b175a195b6439732db6848a0a3aaa762f5c30ad0b79f48921a6cbd203fe442a0b9f93d1d902812c0d83aa17
   languageName: node
   linkType: hard
 
-"twenty-sdk@npm:2.19.0":
-  version: 2.19.0
-  resolution: "twenty-sdk@npm:2.19.0"
+"twenty-sdk@npm:2.20.0":
+  version: 2.20.0
+  resolution: "twenty-sdk@npm:2.20.0"
   dependencies:
     "@sniptt/guards": "npm:^0.2.0"
     axios: "npm:^1.16.0"
@@ -3622,12 +3622,12 @@ __metadata:
     semver: "npm:7.6.3"
     sharp: "npm:^0.34.5"
     tinyglobby: "npm:^0.2.15"
-    twenty-client-sdk: "npm:2.19.0"
+    twenty-client-sdk: "npm:2.20.0"
     typescript: "npm:^5.9.3"
     uuid: "npm:^13.0.2"
   bin:
     twenty: dist/cli.cjs
-  checksum: 10c0/d5d4126997510112008116ae807f0cbbe46f7a46ca7c061ae91363edc0f009eb159a92fdeaaf16b6f636f2faffc43dd9355ddfeb6ec3506c440fb8f1f39fe9e2
+  checksum: 10c0/7fe50f229470e370473e7555f0eb284b59424cb51369ce0fa88723681bd6a662879268f953599b0e3c5fc97b73f1e756352df80605185ed6b4e9c85fa186feef
   languageName: node
   linkType: hard
 

--- a/packages/twenty-apps/public/people-data-labs/package.json
+++ b/packages/twenty-apps/public/people-data-labs/package.json
@@ -1,13 +1,13 @@
 {
   "name": "@twentyhq/people-data-labs",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "description": "People Data Labs enrichment app for Twenty",
   "license": "MIT",
   "engines": {
     "node": "^24.5.0",
     "npm": "please-use-yarn",
     "yarn": ">=4.0.2",
-    "twenty": ">=2.19.0"
+    "twenty": ">=2.20.0"
   },
   "keywords": [
     "twenty-app"
@@ -29,8 +29,8 @@
     "oxlint": "^0.16.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
-    "twenty-client-sdk": "2.19.0-alpha.1",
-    "twenty-sdk": "2.19.0-alpha.1",
+    "twenty-client-sdk": "2.20.0",
+    "twenty-sdk": "2.20.0",
     "typescript": "^5.9.3",
     "vite-tsconfig-paths": "^4.2.1",
     "vitest": "^4.0.0"

--- a/packages/twenty-apps/public/people-data-labs/yarn.lock
+++ b/packages/twenty-apps/public/people-data-labs/yarn.lock
@@ -953,8 +953,8 @@ __metadata:
     oxlint: "npm:^0.16.0"
     react: "npm:^18.2.0"
     react-dom: "npm:^18.2.0"
-    twenty-client-sdk: "npm:2.19.0-alpha.1"
-    twenty-sdk: "npm:2.19.0-alpha.1"
+    twenty-client-sdk: "npm:2.20.0"
+    twenty-sdk: "npm:2.20.0"
     typescript: "npm:^5.9.3"
     vite-tsconfig-paths: "npm:^4.2.1"
     vitest: "npm:^4.0.0"
@@ -2871,22 +2871,22 @@ __metadata:
   languageName: node
   linkType: hard
 
-"twenty-client-sdk@npm:2.19.0-alpha.1":
-  version: 2.19.0-alpha.1
-  resolution: "twenty-client-sdk@npm:2.19.0-alpha.1"
+"twenty-client-sdk@npm:2.20.0":
+  version: 2.20.0
+  resolution: "twenty-client-sdk@npm:2.20.0"
   dependencies:
     "@genql/runtime": "npm:^2.10.0"
     esbuild: "npm:^0.28.1"
     graphql: "npm:^16.8.1"
     lodash: "npm:^4.17.21"
     prettier: "npm:^3.8.3"
-  checksum: 10c0/daeac1c1b439f2a5c6ecd5ac5a97b04e56832bdd2e5530f5269bf469fd776849c750ea103b6837910dab3378adc146d4703008f7374c44eb4263fae1e120eb7c
+  checksum: 10c0/925a5ad99bbccb7290365536b6d7ded6a8d02a064b175a195b6439732db6848a0a3aaa762f5c30ad0b79f48921a6cbd203fe442a0b9f93d1d902812c0d83aa17
   languageName: node
   linkType: hard
 
-"twenty-sdk@npm:2.19.0-alpha.1":
-  version: 2.19.0-alpha.1
-  resolution: "twenty-sdk@npm:2.19.0-alpha.1"
+"twenty-sdk@npm:2.20.0":
+  version: 2.20.0
+  resolution: "twenty-sdk@npm:2.20.0"
   dependencies:
     "@sniptt/guards": "npm:^0.2.0"
     axios: "npm:^1.16.0"
@@ -2905,12 +2905,12 @@ __metadata:
     semver: "npm:7.6.3"
     sharp: "npm:^0.34.5"
     tinyglobby: "npm:^0.2.15"
-    twenty-client-sdk: "npm:2.19.0-alpha.1"
+    twenty-client-sdk: "npm:2.20.0"
     typescript: "npm:^5.9.3"
     uuid: "npm:^13.0.2"
   bin:
     twenty: dist/cli.cjs
-  checksum: 10c0/c36772f6e6193c24ff5c6ba7636f4ae3b6110fed5697bc94cfbd282ae290b8de10b0f1df2b86a2c38eaed8f5a57791222b1f49b0d46baef6bb4b12fd0622cc2f
+  checksum: 10c0/7fe50f229470e370473e7555f0eb284b59424cb51369ce0fa88723681bd6a662879268f953599b0e3c5fc97b73f1e756352df80605185ed6b4e9c85fa186feef
   languageName: node
   linkType: hard
 

--- a/packages/twenty-apps/public/twenty-last-contact/package.json
+++ b/packages/twenty-apps/public/twenty-last-contact/package.json
@@ -1,12 +1,12 @@
 {
   "name": "@twentyhq/last-contact",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "license": "MIT",
   "engines": {
     "node": "^24.5.0",
     "npm": "please-use-yarn",
     "yarn": ">=4.0.2",
-    "twenty": ">=2.19.0"
+    "twenty": ">=2.20.0"
   },
   "keywords": [
     "twenty-app"
@@ -28,8 +28,8 @@
     "oxlint": "^0.16.0",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
-    "twenty-client-sdk": "2.19.0-alpha.1",
-    "twenty-sdk": "2.19.0-alpha.1",
+    "twenty-client-sdk": "2.20.0",
+    "twenty-sdk": "2.20.0",
     "typescript": "^5.9.3",
     "vite-tsconfig-paths": "^4.2.1",
     "vitest": "^4.0.0"

--- a/packages/twenty-apps/public/twenty-last-contact/yarn.lock
+++ b/packages/twenty-apps/public/twenty-last-contact/yarn.lock
@@ -953,8 +953,8 @@ __metadata:
     oxlint: "npm:^0.16.0"
     react: "npm:^19.0.0"
     react-dom: "npm:^19.0.0"
-    twenty-client-sdk: "npm:2.19.0-alpha.1"
-    twenty-sdk: "npm:2.19.0-alpha.1"
+    twenty-client-sdk: "npm:2.20.0"
+    twenty-sdk: "npm:2.20.0"
     typescript: "npm:^5.9.3"
     vite-tsconfig-paths: "npm:^4.2.1"
     vitest: "npm:^4.0.0"
@@ -2833,22 +2833,22 @@ __metadata:
   languageName: node
   linkType: hard
 
-"twenty-client-sdk@npm:2.19.0-alpha.1":
-  version: 2.19.0-alpha.1
-  resolution: "twenty-client-sdk@npm:2.19.0-alpha.1"
+"twenty-client-sdk@npm:2.20.0":
+  version: 2.20.0
+  resolution: "twenty-client-sdk@npm:2.20.0"
   dependencies:
     "@genql/runtime": "npm:^2.10.0"
     esbuild: "npm:^0.28.1"
     graphql: "npm:^16.8.1"
     lodash: "npm:^4.17.21"
     prettier: "npm:^3.8.3"
-  checksum: 10c0/daeac1c1b439f2a5c6ecd5ac5a97b04e56832bdd2e5530f5269bf469fd776849c750ea103b6837910dab3378adc146d4703008f7374c44eb4263fae1e120eb7c
+  checksum: 10c0/925a5ad99bbccb7290365536b6d7ded6a8d02a064b175a195b6439732db6848a0a3aaa762f5c30ad0b79f48921a6cbd203fe442a0b9f93d1d902812c0d83aa17
   languageName: node
   linkType: hard
 
-"twenty-sdk@npm:2.19.0-alpha.1":
-  version: 2.19.0-alpha.1
-  resolution: "twenty-sdk@npm:2.19.0-alpha.1"
+"twenty-sdk@npm:2.20.0":
+  version: 2.20.0
+  resolution: "twenty-sdk@npm:2.20.0"
   dependencies:
     "@sniptt/guards": "npm:^0.2.0"
     axios: "npm:^1.16.0"
@@ -2867,12 +2867,12 @@ __metadata:
     semver: "npm:7.6.3"
     sharp: "npm:^0.34.5"
     tinyglobby: "npm:^0.2.15"
-    twenty-client-sdk: "npm:2.19.0-alpha.1"
+    twenty-client-sdk: "npm:2.20.0"
     typescript: "npm:^5.9.3"
     uuid: "npm:^13.0.2"
   bin:
     twenty: dist/cli.cjs
-  checksum: 10c0/c36772f6e6193c24ff5c6ba7636f4ae3b6110fed5697bc94cfbd282ae290b8de10b0f1df2b86a2c38eaed8f5a57791222b1f49b0d46baef6bb4b12fd0622cc2f
+  checksum: 10c0/7fe50f229470e370473e7555f0eb284b59424cb51369ce0fa88723681bd6a662879268f953599b0e3c5fc97b73f1e756352df80605185ed6b4e9c85fa186feef
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## What

Upgrades three public apps to `twenty-sdk` 2.20.

For each app, bumped `twenty-sdk` and `twenty-client-sdk` to `2.20.0`, raised the `engines.twenty` floor to `>=2.20.0`, and regenerated `yarn.lock`:

- **call-recorder**: `2.19.0` -> `2.20.0`
- **last-contact** (`@twentyhq/last-contact`): `2.19.0-alpha.1` -> `2.20.0`
- **people-data-labs**: `2.19.0-alpha.1` -> `2.20.0`

## Verification

- Lockfile diffs are version/checksum-only; the SDK's transitive dependency set is unchanged between 2.19 and 2.20, so no new packages were introduced.
- `yarn typecheck` passes cleanly for all three apps against 2.20, confirming no breaking API changes to adapt to.

---
_Generated by [Claude Code](https://claude.ai/code/session_01YWiC3qAbBcE1kvBMWvaxba)_

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/22852?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

