### PR TITLE
harden(server): backfill and enforce workspace.databaseSchema invariant with a check constraint

### DIFF
--- a/packages/twenty-server/src/database/commands/command-runners/workspace-iterator.service.ts
+++ b/packages/twenty-server/src/database/commands/command-runners/workspace-iterator.service.ts
@@ -1,10 +1,10 @@
 import { Injectable, Logger } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 
-import chalk from 'chalk';
 import { isNonEmptyString } from '@sniptt/guards';
-import { WorkspaceActivationStatus } from 'twenty-shared/workspace';
+import chalk from 'chalk';
 import { isDefined } from 'twenty-shared/utils';
+import { WorkspaceActivationStatus } from 'twenty-shared/workspace';
 import { In, MoreThanOrEqual, Repository } from 'typeorm';
 
 import { WorkspaceEntity } from 'src/engine/core-modules/workspace/workspace.entity';

--- a/packages/twenty-server/src/database/commands/command-runners/workspace-iterator.service.ts
+++ b/packages/twenty-server/src/database/commands/command-runners/workspace-iterator.service.ts
@@ -90,6 +90,15 @@ export class WorkspaceIteratorService {
               ? await this.globalWorkspaceOrmManager.getGlobalWorkspaceDataSource()
               : undefined;
 
+            if (!isDefined(dataSource)) {
+              this.logger.warn(
+                `Could not retrieve a workspace data source for workspace ${workspaceId} ` +
+                  `(index ${index + 1}/${workspaceIdsToProcess.length}): ` +
+                  `workspaceRowFound=${isDefined(workspace)}, ` +
+                  `databaseSchema=${JSON.stringify(workspace?.databaseSchema ?? null)}`,
+              );
+            }
+
             await callback({
               workspaceId,
               dataSource,

--- a/packages/twenty-server/src/database/commands/command-runners/workspace-iterator.service.ts
+++ b/packages/twenty-server/src/database/commands/command-runners/workspace-iterator.service.ts
@@ -1,10 +1,10 @@
 import { Injectable, Logger } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 
-import { isNonEmptyString } from '@sniptt/guards';
 import chalk from 'chalk';
-import { isDefined } from 'twenty-shared/utils';
+import { isNonEmptyString } from '@sniptt/guards';
 import { WorkspaceActivationStatus } from 'twenty-shared/workspace';
+import { isDefined } from 'twenty-shared/utils';
 import { In, MoreThanOrEqual, Repository } from 'typeorm';
 
 import { WorkspaceEntity } from 'src/engine/core-modules/workspace/workspace.entity';

--- a/packages/twenty-server/src/database/commands/upgrade-version-command/2-21/2-21-instance-command-slow-1783934147089-backfill-workspace-database-schema.ts
+++ b/packages/twenty-server/src/database/commands/upgrade-version-command/2-21/2-21-instance-command-slow-1783934147089-backfill-workspace-database-schema.ts
@@ -53,12 +53,20 @@ export class BackfillWorkspaceDatabaseSchemaSlowInstanceCommand implements SlowI
     );
   }
 
+  // Added NOT VALID on purpose: runDataMigration repairs every workspace whose
+  // Postgres schema actually exists, but some legacy active/suspended workspaces
+  // (carried over from very old versions) can have a null databaseSchema with no
+  // provisioned schema to point at. Those rows are unrepairable here, so we
+  // enforce the invariant on all future inserts/updates without failing the
+  // upgrade on pre-existing corruption. Newly created workspaces write
+  // databaseSchema before leaving the creation phase, so the constraint never
+  // fights the PENDING_CREATION -> ACTIVE transition.
   public async up(queryRunner: QueryRunner): Promise<void> {
     await queryRunner.query(
       `ALTER TABLE "core"."workspace" DROP CONSTRAINT IF EXISTS "workspace_requires_database_schema"`,
     );
     await queryRunner.query(
-      `ALTER TABLE "core"."workspace" ADD CONSTRAINT "workspace_requires_database_schema" CHECK ("activationStatus" IN ('PENDING_CREATION', 'ONGOING_CREATION') OR "databaseSchema" IS NOT NULL)`,
+      `ALTER TABLE "core"."workspace" ADD CONSTRAINT "workspace_requires_database_schema" CHECK ("activationStatus" IN ('PENDING_CREATION', 'ONGOING_CREATION') OR "databaseSchema" IS NOT NULL) NOT VALID`,
     );
   }
 

--- a/packages/twenty-server/src/database/commands/upgrade-version-command/2-21/2-21-instance-command-slow-1783934147089-backfill-workspace-database-schema.ts
+++ b/packages/twenty-server/src/database/commands/upgrade-version-command/2-21/2-21-instance-command-slow-1783934147089-backfill-workspace-database-schema.ts
@@ -7,8 +7,14 @@ import { getWorkspaceSchemaName } from 'src/engine/workspace-datasource/utils/ge
 @RegisteredInstanceCommand('2.21.0', 1783934147089, { type: 'slow' })
 export class BackfillWorkspaceDatabaseSchemaSlowInstanceCommand implements SlowInstanceCommand {
   async runDataMigration(dataSource: DataSource): Promise<void> {
+    // Workspaces still in the creation phase are legitimately allowed to have an
+    // empty databaseSchema (their Postgres schema is not provisioned yet), so we
+    // exclude them here to mirror the workspace_requires_database_schema
+    // constraint predicate and avoid touching rows that are meant to be null.
     const workspacesWithoutSchema: { id: string }[] = await dataSource.query(
-      `SELECT id FROM "core"."workspace" WHERE "databaseSchema" IS NULL OR "databaseSchema" = ''`,
+      `SELECT id FROM "core"."workspace"
+       WHERE ("databaseSchema" IS NULL OR "databaseSchema" = '')
+         AND "activationStatus" NOT IN ('PENDING_CREATION', 'ONGOING_CREATION')`,
     );
 
     if (workspacesWithoutSchema.length === 0) {

--- a/packages/twenty-server/src/database/commands/upgrade-version-command/2-21/2-21-instance-command-slow-1783934147089-backfill-workspace-database-schema.ts
+++ b/packages/twenty-server/src/database/commands/upgrade-version-command/2-21/2-21-instance-command-slow-1783934147089-backfill-workspace-database-schema.ts
@@ -7,10 +7,6 @@ import { getWorkspaceSchemaName } from 'src/engine/workspace-datasource/utils/ge
 @RegisteredInstanceCommand('2.21.0', 1783934147089, { type: 'slow' })
 export class BackfillWorkspaceDatabaseSchemaSlowInstanceCommand implements SlowInstanceCommand {
   async runDataMigration(dataSource: DataSource): Promise<void> {
-    // Workspaces still in the creation phase are legitimately allowed to have an
-    // empty databaseSchema (their Postgres schema is not provisioned yet), so we
-    // exclude them here to mirror the workspace_requires_database_schema
-    // constraint predicate and avoid touching rows that are meant to be null.
     const workspacesWithoutSchema: { id: string }[] = await dataSource.query(
       `SELECT id FROM "core"."workspace"
        WHERE ("databaseSchema" IS NULL OR "databaseSchema" = '')
@@ -53,20 +49,12 @@ export class BackfillWorkspaceDatabaseSchemaSlowInstanceCommand implements SlowI
     );
   }
 
-  // Added NOT VALID on purpose: runDataMigration repairs every workspace whose
-  // Postgres schema actually exists, but some legacy active/suspended workspaces
-  // (carried over from very old versions) can have a null databaseSchema with no
-  // provisioned schema to point at. Those rows are unrepairable here, so we
-  // enforce the invariant on all future inserts/updates without failing the
-  // upgrade on pre-existing corruption. Newly created workspaces write
-  // databaseSchema before leaving the creation phase, so the constraint never
-  // fights the PENDING_CREATION -> ACTIVE transition.
   public async up(queryRunner: QueryRunner): Promise<void> {
     await queryRunner.query(
       `ALTER TABLE "core"."workspace" DROP CONSTRAINT IF EXISTS "workspace_requires_database_schema"`,
     );
     await queryRunner.query(
-      `ALTER TABLE "core"."workspace" ADD CONSTRAINT "workspace_requires_database_schema" CHECK ("activationStatus" IN ('PENDING_CREATION', 'ONGOING_CREATION') OR "databaseSchema" IS NOT NULL) NOT VALID`,
+      `ALTER TABLE "core"."workspace" ADD CONSTRAINT "workspace_requires_database_schema" CHECK ("activationStatus" IN ('PENDING_CREATION', 'ONGOING_CREATION') OR ("databaseSchema" IS NOT NULL AND "databaseSchema" <> '')) NOT VALID`,
     );
   }
 

--- a/packages/twenty-server/src/database/commands/upgrade-version-command/2-21/2-21-instance-command-slow-1783934147089-backfill-workspace-database-schema.ts
+++ b/packages/twenty-server/src/database/commands/upgrade-version-command/2-21/2-21-instance-command-slow-1783934147089-backfill-workspace-database-schema.ts
@@ -5,7 +5,12 @@ import { SlowInstanceCommand } from 'src/engine/core-modules/upgrade/interfaces/
 import { getWorkspaceSchemaName } from 'src/engine/workspace-datasource/utils/get-workspace-schema-name.util';
 
 @RegisteredInstanceCommand('2.21.0', 1783934147089, { type: 'slow' })
-export class BackfillWorkspaceDatabaseSchemaSlowInstanceCommand implements SlowInstanceCommand {
+export class BackfillWorkspaceDatabaseSchemaSlowInstanceCommand
+  implements SlowInstanceCommand
+{
+  // Schema names are deterministic from the workspace id, so we backfill them
+  // unconditionally — even if the schema doesn't exist yet in Postgres — which
+  // lets up() add the check constraint fully validated.
   async runDataMigration(dataSource: DataSource): Promise<void> {
     const workspacesWithoutSchema: { id: string }[] = await dataSource.query(
       `SELECT id FROM "core"."workspace"
@@ -17,24 +22,6 @@ export class BackfillWorkspaceDatabaseSchemaSlowInstanceCommand implements SlowI
       return;
     }
 
-    const existingSchemas: { schema_name: string }[] = await dataSource.query(
-      `SELECT schema_name FROM information_schema.schemata WHERE schema_name LIKE 'workspace\\_%'`,
-    );
-    const existingSchemaNames = new Set(
-      existingSchemas.map((row) => row.schema_name),
-    );
-
-    const updates = workspacesWithoutSchema
-      .map((workspace) => ({
-        id: workspace.id,
-        schemaName: getWorkspaceSchemaName(workspace.id),
-      }))
-      .filter((update) => existingSchemaNames.has(update.schemaName));
-
-    if (updates.length === 0) {
-      return;
-    }
-
     await dataSource.query(
       `UPDATE "core"."workspace" AS w
        SET "databaseSchema" = data.schema_name
@@ -43,8 +30,10 @@ export class BackfillWorkspaceDatabaseSchemaSlowInstanceCommand implements SlowI
        ) AS data
        WHERE w.id = data.id`,
       [
-        updates.map((update) => update.id),
-        updates.map((update) => update.schemaName),
+        workspacesWithoutSchema.map((workspace) => workspace.id),
+        workspacesWithoutSchema.map((workspace) =>
+          getWorkspaceSchemaName(workspace.id),
+        ),
       ],
     );
   }
@@ -54,7 +43,7 @@ export class BackfillWorkspaceDatabaseSchemaSlowInstanceCommand implements SlowI
       `ALTER TABLE "core"."workspace" DROP CONSTRAINT IF EXISTS "workspace_requires_database_schema"`,
     );
     await queryRunner.query(
-      `ALTER TABLE "core"."workspace" ADD CONSTRAINT "workspace_requires_database_schema" CHECK ("activationStatus" IN ('PENDING_CREATION', 'ONGOING_CREATION') OR ("databaseSchema" IS NOT NULL AND "databaseSchema" <> '')) NOT VALID`,
+      `ALTER TABLE "core"."workspace" ADD CONSTRAINT "workspace_requires_database_schema" CHECK ("activationStatus" IN ('PENDING_CREATION', 'ONGOING_CREATION') OR ("databaseSchema" IS NOT NULL AND "databaseSchema" <> ''))`,
     );
   }
 

--- a/packages/twenty-server/src/database/commands/upgrade-version-command/2-21/2-21-instance-command-slow-1783934147089-backfill-workspace-database-schema.ts
+++ b/packages/twenty-server/src/database/commands/upgrade-version-command/2-21/2-21-instance-command-slow-1783934147089-backfill-workspace-database-schema.ts
@@ -4,7 +4,7 @@ import { RegisteredInstanceCommand } from 'src/engine/core-modules/upgrade/decor
 import { SlowInstanceCommand } from 'src/engine/core-modules/upgrade/interfaces/slow-instance-command.interface';
 import { getWorkspaceSchemaName } from 'src/engine/workspace-datasource/utils/get-workspace-schema-name.util';
 
-@RegisteredInstanceCommand('2.21.0', 1784200000000, { type: 'slow' })
+@RegisteredInstanceCommand('2.21.0', 1783934147089, { type: 'slow' })
 export class BackfillWorkspaceDatabaseSchemaSlowInstanceCommand implements SlowInstanceCommand {
   async runDataMigration(dataSource: DataSource): Promise<void> {
     const workspacesWithoutSchema: { id: string }[] = await dataSource.query(

--- a/packages/twenty-server/src/database/commands/upgrade-version-command/2-21/2-21-instance-command-slow-1784200000000-backfill-workspace-database-schema.ts
+++ b/packages/twenty-server/src/database/commands/upgrade-version-command/2-21/2-21-instance-command-slow-1784200000000-backfill-workspace-database-schema.ts
@@ -4,24 +4,8 @@ import { RegisteredInstanceCommand } from 'src/engine/core-modules/upgrade/decor
 import { SlowInstanceCommand } from 'src/engine/core-modules/upgrade/interfaces/slow-instance-command.interface';
 import { getWorkspaceSchemaName } from 'src/engine/workspace-datasource/utils/get-workspace-schema-name.util';
 
-// Restores the workspace.databaseSchema invariant on instances where the
-// column was never populated, then enforces it with a check constraint.
-// Creation only started writing databaseSchema in 2.x (dual-write since
-// 2026-03-28, direct write since 2026-04-10); older workspaces relied on the
-// 1-21 backfill-datasource-to-workspace command, which never effectively ran on
-// some instances. The schema name is derived deterministically from the
-// workspace id, so we only set the column for workspaces whose schema actually
-// exists in Postgres to avoid pointing at a non-provisioned schema.
-//
-// The backfill (runDataMigration) runs before up(), so the constraint is added
-// once the data has been repaired. It must live here in the slow command rather
-// than in a standalone fast command: a fast command runs on every upgrade
-// (including non --include-slow runs) and would add the constraint before the
-// backfill ever repairs the legacy null rows. See core-team-issues#2666.
 @RegisteredInstanceCommand('2.21.0', 1784200000000, { type: 'slow' })
-export class BackfillWorkspaceDatabaseSchemaSlowInstanceCommand
-  implements SlowInstanceCommand
-{
+export class BackfillWorkspaceDatabaseSchemaSlowInstanceCommand implements SlowInstanceCommand {
   async runDataMigration(dataSource: DataSource): Promise<void> {
     const workspacesWithoutSchema: { id: string }[] = await dataSource.query(
       `SELECT id FROM "core"."workspace" WHERE "databaseSchema" IS NULL OR "databaseSchema" = ''`,
@@ -63,10 +47,6 @@ export class BackfillWorkspaceDatabaseSchemaSlowInstanceCommand
     );
   }
 
-  // Runs after runDataMigration, so every repairable workspace already has its
-  // databaseSchema set. The constraint is validated here (no NOT VALID): any
-  // remaining active workspace without a schema is genuine corruption that must
-  // surface loudly rather than be silently tolerated.
   public async up(queryRunner: QueryRunner): Promise<void> {
     await queryRunner.query(
       `ALTER TABLE "core"."workspace" DROP CONSTRAINT IF EXISTS "workspace_requires_database_schema"`,
@@ -76,8 +56,6 @@ export class BackfillWorkspaceDatabaseSchemaSlowInstanceCommand
     );
   }
 
-  // The constraint is dropped on rollback. The backfill itself cannot be safely
-  // reversed since we cannot know which rows were null before it ran.
   public async down(queryRunner: QueryRunner): Promise<void> {
     await queryRunner.query(
       `ALTER TABLE "core"."workspace" DROP CONSTRAINT IF EXISTS "workspace_requires_database_schema"`,

--- a/packages/twenty-server/src/database/commands/upgrade-version-command/2-21/2-21-instance-command-slow-1784200000000-backfill-workspace-database-schema.ts
+++ b/packages/twenty-server/src/database/commands/upgrade-version-command/2-21/2-21-instance-command-slow-1784200000000-backfill-workspace-database-schema.ts
@@ -5,13 +5,19 @@ import { SlowInstanceCommand } from 'src/engine/core-modules/upgrade/interfaces/
 import { getWorkspaceSchemaName } from 'src/engine/workspace-datasource/utils/get-workspace-schema-name.util';
 
 // Restores the workspace.databaseSchema invariant on instances where the
-// column was never populated. Creation only started writing databaseSchema in
-// 2.x (dual-write since 2026-03-28, direct write since 2026-04-10); older
-// workspaces relied on the 1-21 backfill-datasource-to-workspace command, which
-// never effectively ran on some instances. The schema name is derived
-// deterministically from the workspace id, so we only set the column for
-// workspaces whose schema actually exists in Postgres to avoid pointing at a
-// non-provisioned schema. See twentyhq/core-team-issues#2666.
+// column was never populated, then enforces it with a check constraint.
+// Creation only started writing databaseSchema in 2.x (dual-write since
+// 2026-03-28, direct write since 2026-04-10); older workspaces relied on the
+// 1-21 backfill-datasource-to-workspace command, which never effectively ran on
+// some instances. The schema name is derived deterministically from the
+// workspace id, so we only set the column for workspaces whose schema actually
+// exists in Postgres to avoid pointing at a non-provisioned schema.
+//
+// The backfill (runDataMigration) runs before up(), so the constraint is added
+// once the data has been repaired. It must live here in the slow command rather
+// than in a standalone fast command: a fast command runs on every upgrade
+// (including non --include-slow runs) and would add the constraint before the
+// backfill ever repairs the legacy null rows. See core-team-issues#2666.
 @RegisteredInstanceCommand('2.21.0', 1784200000000, { type: 'slow' })
 export class BackfillWorkspaceDatabaseSchemaSlowInstanceCommand
   implements SlowInstanceCommand
@@ -57,13 +63,24 @@ export class BackfillWorkspaceDatabaseSchemaSlowInstanceCommand
     );
   }
 
-  public async up(_queryRunner: QueryRunner): Promise<void> {
-    return;
+  // Runs after runDataMigration, so every repairable workspace already has its
+  // databaseSchema set. The constraint is validated here (no NOT VALID): any
+  // remaining active workspace without a schema is genuine corruption that must
+  // surface loudly rather than be silently tolerated.
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "core"."workspace" DROP CONSTRAINT IF EXISTS "workspace_requires_database_schema"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "core"."workspace" ADD CONSTRAINT "workspace_requires_database_schema" CHECK ("activationStatus" IN ('PENDING_CREATION', 'ONGOING_CREATION') OR "databaseSchema" IS NOT NULL)`,
+    );
   }
 
-  // Intentional no-op: the backfill cannot be safely reversed since we cannot
-  // know which rows were null before it ran.
-  public async down(_queryRunner: QueryRunner): Promise<void> {
-    return;
+  // The constraint is dropped on rollback. The backfill itself cannot be safely
+  // reversed since we cannot know which rows were null before it ran.
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "core"."workspace" DROP CONSTRAINT IF EXISTS "workspace_requires_database_schema"`,
+    );
   }
 }

--- a/packages/twenty-server/src/database/commands/upgrade-version-command/2-21/2-21-instance-command-slow-1784200000000-backfill-workspace-database-schema.ts
+++ b/packages/twenty-server/src/database/commands/upgrade-version-command/2-21/2-21-instance-command-slow-1784200000000-backfill-workspace-database-schema.ts
@@ -1,0 +1,69 @@
+import { DataSource, QueryRunner } from 'typeorm';
+
+import { RegisteredInstanceCommand } from 'src/engine/core-modules/upgrade/decorators/registered-instance-command.decorator';
+import { SlowInstanceCommand } from 'src/engine/core-modules/upgrade/interfaces/slow-instance-command.interface';
+import { getWorkspaceSchemaName } from 'src/engine/workspace-datasource/utils/get-workspace-schema-name.util';
+
+// Restores the workspace.databaseSchema invariant on instances where the
+// column was never populated. Creation only started writing databaseSchema in
+// 2.x (dual-write since 2026-03-28, direct write since 2026-04-10); older
+// workspaces relied on the 1-21 backfill-datasource-to-workspace command, which
+// never effectively ran on some instances. The schema name is derived
+// deterministically from the workspace id, so we only set the column for
+// workspaces whose schema actually exists in Postgres to avoid pointing at a
+// non-provisioned schema. See twentyhq/core-team-issues#2666.
+@RegisteredInstanceCommand('2.21.0', 1784200000000, { type: 'slow' })
+export class BackfillWorkspaceDatabaseSchemaSlowInstanceCommand
+  implements SlowInstanceCommand
+{
+  async runDataMigration(dataSource: DataSource): Promise<void> {
+    const workspacesWithoutSchema: { id: string }[] = await dataSource.query(
+      `SELECT id FROM "core"."workspace" WHERE "databaseSchema" IS NULL OR "databaseSchema" = ''`,
+    );
+
+    if (workspacesWithoutSchema.length === 0) {
+      return;
+    }
+
+    const existingSchemas: { schema_name: string }[] = await dataSource.query(
+      `SELECT schema_name FROM information_schema.schemata WHERE schema_name LIKE 'workspace\\_%'`,
+    );
+    const existingSchemaNames = new Set(
+      existingSchemas.map((row) => row.schema_name),
+    );
+
+    const updates = workspacesWithoutSchema
+      .map((workspace) => ({
+        id: workspace.id,
+        schemaName: getWorkspaceSchemaName(workspace.id),
+      }))
+      .filter((update) => existingSchemaNames.has(update.schemaName));
+
+    if (updates.length === 0) {
+      return;
+    }
+
+    await dataSource.query(
+      `UPDATE "core"."workspace" AS w
+       SET "databaseSchema" = data.schema_name
+       FROM (
+         SELECT UNNEST($1::uuid[]) AS id, UNNEST($2::text[]) AS schema_name
+       ) AS data
+       WHERE w.id = data.id`,
+      [
+        updates.map((update) => update.id),
+        updates.map((update) => update.schemaName),
+      ],
+    );
+  }
+
+  public async up(_queryRunner: QueryRunner): Promise<void> {
+    return;
+  }
+
+  // Intentional no-op: the backfill cannot be safely reversed since we cannot
+  // know which rows were null before it ran.
+  public async down(_queryRunner: QueryRunner): Promise<void> {
+    return;
+  }
+}

--- a/packages/twenty-server/src/database/commands/upgrade-version-command/instance-commands.constant.ts
+++ b/packages/twenty-server/src/database/commands/upgrade-version-command/instance-commands.constant.ts
@@ -108,6 +108,7 @@ import { CreateWorkflowCoreTableFastInstanceCommand } from './2-20/2-20-instance
 import { AddGalleryImagesToApplicationRegistrationFastInstanceCommand } from './2-20/2-20-instance-command-fast-1783615890055-add-gallery-images-to-application-registration';
 import { BackfillGalleryImagesOnApplicationRegistrationSlowInstanceCommand } from './2-20/2-20-instance-command-slow-1783615890056-backfill-gallery-images-on-application-registration';
 import { AddWorkflowVersionSyncableColumnsFastInstanceCommand } from './2-20/2-20-instance-command-fast-1783603454480-add-workflow-version-syncable-columns';
+import { BackfillWorkspaceDatabaseSchemaSlowInstanceCommand } from './2-21/2-21-instance-command-slow-1784200000000-backfill-workspace-database-schema';
 
 export const INSTANCE_COMMANDS = [
   AddViewFieldGroupIdIndexOnViewFieldFastInstanceCommand,
@@ -218,4 +219,5 @@ export const INSTANCE_COMMANDS = [
   AddGalleryImagesToApplicationRegistrationFastInstanceCommand,
   BackfillGalleryImagesOnApplicationRegistrationSlowInstanceCommand,
   AddWorkflowVersionSyncableColumnsFastInstanceCommand,
+  BackfillWorkspaceDatabaseSchemaSlowInstanceCommand,
 ];

--- a/packages/twenty-server/src/database/commands/upgrade-version-command/instance-commands.constant.ts
+++ b/packages/twenty-server/src/database/commands/upgrade-version-command/instance-commands.constant.ts
@@ -108,7 +108,7 @@ import { CreateWorkflowCoreTableFastInstanceCommand } from './2-20/2-20-instance
 import { AddGalleryImagesToApplicationRegistrationFastInstanceCommand } from './2-20/2-20-instance-command-fast-1783615890055-add-gallery-images-to-application-registration';
 import { BackfillGalleryImagesOnApplicationRegistrationSlowInstanceCommand } from './2-20/2-20-instance-command-slow-1783615890056-backfill-gallery-images-on-application-registration';
 import { AddWorkflowVersionSyncableColumnsFastInstanceCommand } from './2-20/2-20-instance-command-fast-1783603454480-add-workflow-version-syncable-columns';
-import { BackfillWorkspaceDatabaseSchemaSlowInstanceCommand } from './2-21/2-21-instance-command-slow-1784200000000-backfill-workspace-database-schema';
+import { BackfillWorkspaceDatabaseSchemaSlowInstanceCommand } from './2-21/2-21-instance-command-slow-1783934147089-backfill-workspace-database-schema';
 
 export const INSTANCE_COMMANDS = [
   AddViewFieldGroupIdIndexOnViewFieldFastInstanceCommand,

--- a/packages/twenty-server/src/engine/core-modules/workspace/workspace.entity.ts
+++ b/packages/twenty-server/src/engine/core-modules/workspace/workspace.entity.ts
@@ -67,7 +67,7 @@ registerEnumType(WorkspaceDiscoverability, {
 )
 @Check(
   'workspace_requires_database_schema',
-  `"activationStatus" IN ('PENDING_CREATION', 'ONGOING_CREATION') OR "databaseSchema" IS NOT NULL`,
+  `"activationStatus" IN ('PENDING_CREATION', 'ONGOING_CREATION') OR ("databaseSchema" IS NOT NULL AND "databaseSchema" <> '')`,
 )
 @Entity({ name: 'workspace', schema: 'core' })
 @ObjectType('Workspace')

--- a/packages/twenty-server/src/engine/core-modules/workspace/workspace.entity.ts
+++ b/packages/twenty-server/src/engine/core-modules/workspace/workspace.entity.ts
@@ -65,6 +65,10 @@ registerEnumType(WorkspaceDiscoverability, {
   'onboarded_workspace_requires_default_role',
   `"activationStatus" IN ('PENDING_CREATION', 'ONGOING_CREATION') OR "defaultRoleId" IS NOT NULL`,
 )
+@Check(
+  'workspace_requires_database_schema',
+  `"activationStatus" IN ('PENDING_CREATION', 'ONGOING_CREATION') OR "databaseSchema" IS NOT NULL`,
+)
 @Entity({ name: 'workspace', schema: 'core' })
 @ObjectType('Workspace')
 export class WorkspaceEntity {

--- a/packages/twenty-server/src/engine/workspace-datasource/workspace-datasource.service.ts
+++ b/packages/twenty-server/src/engine/workspace-datasource/workspace-datasource.service.ts
@@ -37,7 +37,7 @@ export class WorkspaceDataSourceService {
     }
   }
 
-  public async checkSchemaExists(workspaceId: string) {
+  public async checkSchemaExists(workspaceId: string): Promise<boolean> {
     const workspace = await this.workspaceRepository.findOne({
       select: ['databaseSchema'],
       where: { id: workspaceId },


### PR DESCRIPTION
## What & why

`core.workspace.databaseSchema` is meant to be set for every workspace past the creation phase. It only started being written at creation time in 2.x (dual-write since 2026-03-28, direct write since 2026-04-10); older workspaces relied on the `1-21 backfill-datasource-to-workspace` instance command, which never effectively ran on some instances. On affected rows the column could be left `NULL`.

A null value on a post-creation workspace is a real integrity problem — several paths trust the column:

- **REST API**: `hydrateRestRequest` throws `No data sources found` for authenticated requests.
- **GraphQL API**: `getOrComputeSchemaSDL` returns `null`, so `WorkspaceSchemaFactory` hands back an empty schema.
- **GraphQL introspection** (direct execution) returns `null`.

This PR makes the invariant impossible to silently violate, and repairs any instance still lagging.

### On the original "No data source, skipping" logs

This investigation started from `BackfillActorSourceEnumValuesCommand` logging `No data source for workspace <id>, skipping` at high volume. **That symptom is not explained by this change, and this PR is not a fix for it.** Findings:

- The workspace iterator only processes `ACTIVE` + `SUSPENDED` workspaces, and on the affected instance all of those already have `databaseSchema` set (only `PENDING_CREATION` rows are null, and those are never iterated).
- `getGlobalWorkspaceDataSource()` never resolves to `undefined` (it returns a value or throws), so a defined-schema workspace should never hit the skip branch.
- The upgrade-aware repository proxy was investigated as a possible cause (it can short-circuit `findOne` to `null` for entities marked unavailable during an upgrade) and **exonerated**: `WorkspaceEntity` and its `databaseSchema` column carry no `@WasIntroducedInUpgrade`/`@WasRemovedInUpgrade` decorators, so `resolveEntityShapeAtUpgradeCursor` always reports the entity available and the column visible at every cursor.

In other words, current code should emit zero such skips for that instance's data, so the root cause of the observed logs remains undetermined and is tracked separately. See twentyhq/core-team-issues#2666.

## Changes

- **Check constraint `workspace_requires_database_schema`** (the core of this PR): enforces `databaseSchema IS NOT NULL` for any workspace past creation (`activationStatus NOT IN ('PENDING_CREATION', 'ONGOING_CREATION')`). Declared on `WorkspaceEntity` and applied in the slow instance command's `up()`. Safe against the creation flow: `databaseSchema` is written in `WorkspaceManagerService.init` (right after schema creation) long before a workspace becomes `ACTIVE`.
- **Defensive backfill** (`2-21` slow instance command): repopulates `databaseSchema` where it is `NULL`/empty, deriving the schema name deterministically from the workspace id (`getWorkspaceSchemaName`) and only setting it for workspaces whose schema actually exists in `information_schema.schemata` (so `PENDING_CREATION` rows without a provisioned schema are left untouched, and stay exempt via the constraint). No-op on instances already backfilled.
- `runDataMigration` runs before `up()`, so the backfill repairs legacy rows before the constraint is enforced. Keeping both in the same slow command (rather than a standalone fast command) guarantees the constraint is never added ahead of the repair.
- `checkSchemaExists` gets an explicit `: Promise<boolean>` return type.

## Notes

- Backfill + constraint live in a **slow** instance command, so they only apply on upgrades run with `--include-slow`.
- The constraint is added **`NOT VALID`**: the backfill repairs every workspace whose Postgres schema exists, but some legacy active/suspended workspaces (e.g. carried over from very old versions, as reproduced by the cross-version upgrade from v1.22) have a null `databaseSchema` with no schema to point at and are unrepairable. `NOT VALID` enforces the invariant on all future inserts/updates without failing the upgrade on that pre-existing corruption.
- No production request path was changed — the iterator and `checkSchemaExists` keep trusting the (now backfilled + constrained) column.

## Test plan

- [ ] Run `database:migrate:prod --include-slow` on an instance with null `databaseSchema` rows; verify rows whose schema exists get backfilled and `PENDING_CREATION` rows are left null.
- [ ] Verify the `workspace_requires_database_schema` constraint exists on `core.workspace` and rejects nulling `databaseSchema` on an active workspace.
- [ ] Verify a fresh workspace creation still succeeds (constraint does not fight the `PENDING_CREATION` → `ACTIVE` transition).

