### PR TITLE
[2.19 patch, do not merge] fix workspaceDiscoverability upgrade with server-side fallback

### DIFF
--- a/packages/twenty-server/src/database/commands/upgrade-version-command/2-19/add-workspace-discoverability-to-workspace-upgrade-command-name.constant.ts
+++ b/packages/twenty-server/src/database/commands/upgrade-version-command/2-19/add-workspace-discoverability-to-workspace-upgrade-command-name.constant.ts
@@ -1,0 +1,4 @@
+// Referenced by @WasIntroducedInUpgrade on the workspace "workspaceDiscoverability"
+// column so pre-2.19 upgrade steps don't SELECT it before this command adds it.
+export const ADD_WORKSPACE_DISCOVERABILITY_TO_WORKSPACE_UPGRADE_COMMAND_NAME =
+  '2.19.0_AddWorkspaceDiscoverabilityToWorkspaceFastInstanceCommand_1783004140000';

--- a/packages/twenty-server/src/engine/core-modules/user-workspace/user-workspace.service.spec.ts
+++ b/packages/twenty-server/src/engine/core-modules/user-workspace/user-workspace.service.spec.ts
@@ -746,6 +746,46 @@ describe('UserWorkspaceService', () => {
         availableWorkspacesForSignUp: [{ workspace: workspace1 }],
       });
     });
+
+    it('should treat workspaces as PUBLIC when workspaceDiscoverability is hidden during a cross-version upgrade', async () => {
+      const email = 'nonexistent@example.com';
+      // workspaceDiscoverability is undefined while the column is skipped by
+      // @WasIntroducedInUpgrade before the 2.19 command creates it.
+      const workspace1 = {
+        id: 'workspace-id-1',
+        displayName: 'Workspace 1',
+        logo: 'logo1.png',
+        workspaceSSOIdentityProviders: [],
+        workspaceDiscoverability: undefined,
+      } as unknown as WorkspaceEntity;
+
+      jest.spyOn(userRepository, 'findOne').mockResolvedValue(null);
+
+      jest
+        .spyOn(
+          approvedAccessDomainService,
+          'findValidatedApprovedAccessDomainWithWorkspacesAndSSOIdentityProvidersDomain',
+        )
+        .mockResolvedValueOnce([
+          {
+            id: 'domain-id-1',
+            workspaceId: workspace1.id,
+            workspace: workspace1,
+            isValidated: true,
+          } as unknown as ApprovedAccessDomainEntity,
+        ]);
+
+      jest
+        .spyOn(workspaceInvitationService, 'findInvitationsByEmail')
+        .mockResolvedValue([]);
+
+      const result = await service.findAvailableWorkspacesByEmail(email);
+
+      expect(result).toEqual({
+        availableWorkspacesForSignIn: [],
+        availableWorkspacesForSignUp: [{ workspace: workspace1 }],
+      });
+    });
   });
 
   describe('findFirstWorkspaceByUserId', () => {

--- a/packages/twenty-server/src/engine/core-modules/user-workspace/user-workspace.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/user-workspace/user-workspace.service.ts
@@ -374,6 +374,8 @@ export class UserWorkspaceService {
     );
 
     // Email-domain discovery is the only "listing" source: PUBLIC only.
+    // Defaults to PUBLIC while the workspaceDiscoverability column is still
+    // hidden by @WasIntroducedInUpgrade during a cross-version upgrade.
     const workspacesFromApprovedAccessDomain = (
       await this.approvedAccessDomainService.findValidatedApprovedAccessDomainWithWorkspacesAndSSOIdentityProvidersDomain(
         getDomainFromEmailOrThrow(email),
@@ -382,7 +384,8 @@ export class UserWorkspaceService {
       .filter(
         ({ workspace }) =>
           !alreadyMemberWorkspacesIds.includes(workspace.id) &&
-          workspace.workspaceDiscoverability ===
+          (workspace.workspaceDiscoverability ??
+            WorkspaceDiscoverability.PUBLIC) ===
             WorkspaceDiscoverability.PUBLIC,
       )
       .map(({ workspace }) => ({ workspace }));

--- a/packages/twenty-server/src/engine/core-modules/workspace/workspace.entity.ts
+++ b/packages/twenty-server/src/engine/core-modules/workspace/workspace.entity.ts
@@ -18,6 +18,7 @@ import {
   UpdateDateColumn,
 } from 'typeorm';
 
+import { ADD_WORKSPACE_DISCOVERABILITY_TO_WORKSPACE_UPGRADE_COMMAND_NAME } from 'src/database/commands/upgrade-version-command/2-19/add-workspace-discoverability-to-workspace-upgrade-command-name.constant';
 import { UUIDScalarType } from 'src/engine/api/graphql/workspace-schema-builder/graphql-types/scalars';
 import { ApiKeyEntity } from 'src/engine/core-modules/api-key/api-key.entity';
 import { AppTokenEntity } from 'src/engine/core-modules/app-token/app-token.entity';
@@ -30,6 +31,7 @@ import { FileEntity } from 'src/engine/core-modules/file/entities/file.entity';
 import { KeyValuePairEntity } from 'src/engine/core-modules/key-value-pair/key-value-pair.entity';
 import { PublicDomainEntity } from 'src/engine/core-modules/public-domain/public-domain.entity';
 import { WorkspaceSSOIdentityProviderEntity } from 'src/engine/core-modules/sso/workspace-sso-identity-provider.entity';
+import { WasIntroducedInUpgrade } from 'src/engine/core-modules/upgrade/decorators/was-introduced-in-upgrade.decorator';
 import { UserWorkspaceEntity } from 'src/engine/core-modules/user-workspace/user-workspace.entity';
 import { WorkspaceDiscoverability } from 'src/engine/core-modules/workspace/types/workspace-discoverability.type';
 import { AgentEntity } from 'src/engine/metadata-modules/ai/ai-agent/entities/agent.entity';
@@ -118,6 +120,10 @@ export class WorkspaceEntity {
   isPublicInviteLinkEnabled: boolean;
 
   @Field(() => WorkspaceDiscoverability)
+  @WasIntroducedInUpgrade({
+    upgradeCommandName:
+      ADD_WORKSPACE_DISCOVERABILITY_TO_WORKSPACE_UPGRADE_COMMAND_NAME,
+  })
   @Column({
     type: 'enum',
     enumName: 'workspace_discoverability_enum',

--- a/packages/twenty-server/src/engine/core-modules/workspace/workspace.resolver.ts
+++ b/packages/twenty-server/src/engine/core-modules/workspace/workspace.resolver.ts
@@ -45,6 +45,7 @@ import {
 import { UpdateWorkspaceInput } from 'src/engine/core-modules/workspace/dtos/update-workspace-input';
 import { WorkspaceUrlsDTO } from 'src/engine/core-modules/workspace/dtos/workspace-urls.dto';
 import { WorkspaceService } from 'src/engine/core-modules/workspace/services/workspace.service';
+import { WorkspaceDiscoverability } from 'src/engine/core-modules/workspace/types/workspace-discoverability.type';
 import { getAuthBypassProvidersByWorkspace } from 'src/engine/core-modules/workspace/utils/get-auth-bypass-providers-by-workspace.util';
 import { getAuthProvidersByWorkspace } from 'src/engine/core-modules/workspace/utils/get-auth-providers-by-workspace.util';
 import { workspaceGraphqlApiExceptionHandler } from 'src/engine/core-modules/workspace/utils/workspace-graphql-api-exception-handler.util';
@@ -210,6 +211,17 @@ export class WorkspaceResolver {
     return isDefined(defaultRoleEntity)
       ? fromRoleEntityToRoleDto(defaultRoleEntity)
       : null;
+  }
+
+  // Defaults to PUBLIC while the workspaceDiscoverability column is still
+  // hidden by @WasIntroducedInUpgrade during a cross-version upgrade.
+  @ResolveField(() => WorkspaceDiscoverability)
+  workspaceDiscoverability(
+    @Parent() workspace: WorkspaceEntity,
+  ): WorkspaceDiscoverability {
+    return (
+      workspace.workspaceDiscoverability ?? WorkspaceDiscoverability.PUBLIC
+    );
   }
 
   @ResolveField(() => String, { nullable: true })


### PR DESCRIPTION
## Do not merge

This PR exists only as a cherry-pick source for the **2.19** release branch. Cherry-pick the single commit (`c42a9235`) onto 2.19; do not merge this PR into `main`.

The `main` fix (non-nullable field, decorator only) is in #22818. This branch additionally carries the **server-side fallbacks** that we drop for the 2.20 merge, because 2.19 needs them: on 2.19, a workspace can still be served at login while the upgrade command that creates the column hasn't run.

## The single commit contains

- `@WasIntroducedInUpgrade` on `workspaceDiscoverability` (+ its upgrade-command-name constant) so the upgrade-aware ORM skips the column until the 2.19 command creates it, instead of failing workspace queries with `column workspaceDiscoverability does not exist` on login during a 2.18.x to 2.19 upgrade.
- A `workspaceDiscoverability` `@ResolveField` that falls back to `WorkspaceDiscoverability.PUBLIC` while the column is hidden, so the non-nullable GraphQL field never resolves to `null` (`Cannot return null for non-nullable field`) during the upgrade window.
- The same `PUBLIC` fallback in `findAvailableWorkspacesByEmail`, whose strict `=== PUBLIC` filter otherwise silently drops approved-access-domain workspaces from the root-domain sign-in picker while the column is hidden (+ a spec covering the upgrade window).

The GraphQL field stays non-nullable, so no generated-schema or frontend changes are needed.

## Context

Fixes #22662. Follow-up to #22423, which introduced `workspaceDiscoverability`.

## Test

- `typecheck` and lint pass for `twenty-server`.
- `validate-upgrade-aware-entity-decorators` / `resolve-entity-shape-at-upgrade-cursor` and the `upgrade-aware-repository.proxy` / `upgrade-aware-entity-metadata.adapter` specs pass (verified on the same change set in #22818).
- `user-workspace.service.spec.ts` passes (22 tests), including a new case asserting workspaces stay in the sign-up picker when `workspaceDiscoverability` is undefined during the upgrade window.
- Cherry-pick of the commit onto `twenty/v2.19.0` verified conflict-free with `git merge-tree`.
