### PR TITLE
Ratchet ui-module isolation: boundary lint rule, shrink-only baseline, first two inversions

### DIFF
--- a/packages/twenty-front/.oxlintrc.json
+++ b/packages/twenty-front/.oxlintrc.json
@@ -137,6 +137,10 @@
           }
         ]
       }
+    ],
+    "twenty/no-feature-imports-in-ui": [
+      "error",
+      { "baselinePath": ".ui-boundary-baseline.json" }
     ]
   },
   "overrides": [

--- a/packages/twenty-front/.ui-boundary-baseline.json
+++ b/packages/twenty-front/.ui-boundary-baseline.json
@@ -327,14 +327,7 @@
     ],
     "src/modules/ui/theme/hooks/useColorScheme.ts": [
       "@/auth/states/currentWorkspaceMemberState",
-      "@/settings/profile/hooks/useUpdateWorkspaceMemberSettings",
-      "@/workspace-member/types/WorkspaceMember"
-    ],
-    "src/modules/ui/theme/hooks/useSystemColorScheme.ts": [
-      "@/workspace-member/types/WorkspaceMember"
-    ],
-    "src/modules/ui/theme/states/persistedColorSchemeState.ts": [
-      "@/workspace-member/types/WorkspaceMember"
+      "@/settings/profile/hooks/useUpdateWorkspaceMemberSettings"
     ],
     "src/modules/ui/utilities/page-favicon/components/PageFavicon.tsx": [
       "@/auth/states/workspacePublicDataState"

--- a/packages/twenty-front/.ui-boundary-baseline.json
+++ b/packages/twenty-front/.ui-boundary-baseline.json
@@ -1,0 +1,346 @@
+{
+  "entries": {
+    "src/modules/ui/feedback/snack-bar-manager/hooks/useSnackBar.ts": [
+      "@apollo/client"
+    ],
+    "src/modules/ui/feedback/snack-bar-manager/utils/buildErrorAction.ts": [
+      "@apollo/client"
+    ],
+    "src/modules/ui/field/display/components/ActorDisplay.tsx": [
+      "@/object-record/record-field/ui/types/FieldMetadata"
+    ],
+    "src/modules/ui/field/display/components/ArrayDisplay.tsx": [
+      "@/object-record/record-field/ui/types/FieldMetadata"
+    ],
+    "src/modules/ui/field/display/components/CurrencyDisplay.tsx": [
+      "@/localization/hooks/useNumberFormat",
+      "@/object-record/record-field/ui/types/FieldDefinition",
+      "@/object-record/record-field/ui/types/FieldMetadata",
+      "@/settings/data-model/constants/SettingsFieldCurrencyCodes"
+    ],
+    "src/modules/ui/field/display/components/DateDisplay.tsx": [
+      "@/object-record/record-field/ui/types/FieldMetadata",
+      "@/users/contexts/UserContext"
+    ],
+    "src/modules/ui/field/display/components/DateTimeDisplay.tsx": [
+      "@/object-record/record-field/ui/types/FieldMetadata",
+      "@/users/contexts/UserContext"
+    ],
+    "src/modules/ui/field/display/components/EmailsDisplay.tsx": [
+      "@/object-record/record-field/ui/types/FieldMetadata"
+    ],
+    "src/modules/ui/field/display/components/FileChip.tsx": [
+      "@/file/components/FileIcon",
+      "@/object-record/record-field/ui/types/FieldMetadata",
+      "@/object-record/record-field/ui/utils/getFileCategoryFromExtension"
+    ],
+    "src/modules/ui/field/display/components/FilesDisplay.tsx": [
+      "@/activities/files/utils/downloadFile",
+      "@/client-config/states/isAttachmentPreviewEnabledState",
+      "@/object-record/record-field/ui/types/FieldMetadata"
+    ],
+    "src/modules/ui/field/display/components/GlobalFilePreviewModal.tsx": [
+      "@/activities/files/components/DocumentViewer",
+      "@/activities/files/utils/downloadFile"
+    ],
+    "src/modules/ui/field/display/components/LinksDisplay.tsx": [
+      "@/object-record/record-field/ui/meta-types/input/utils/getFieldLinkDefinedLinks",
+      "@/object-record/record-field/ui/types/FieldMetadata"
+    ],
+    "src/modules/ui/field/display/components/MoneyDisplay.tsx": [
+      "@/localization/hooks/useNumberFormat"
+    ],
+    "src/modules/ui/field/display/components/MultiSelectDisplay.tsx": [
+      "@/object-record/record-field/ui/types/FieldMetadata"
+    ],
+    "src/modules/ui/field/display/components/PhonesDisplay.tsx": [
+      "@/object-record/record-field/ui/types/FieldMetadata"
+    ],
+    "src/modules/ui/field/display/states/filePreviewState.ts": [
+      "@/object-record/record-field/ui/types/FieldMetadata"
+    ],
+    "src/modules/ui/field/input/components/AddressInput.tsx": [
+      "@/geo-map/components/PlaceAutocompleteSelect",
+      "@/geo-map/constants/SelectAutocompleteListDropDownId",
+      "@/object-record/record-field/ui/meta-types/input/hooks/useRegisterInputEvents",
+      "@/object-record/record-field/ui/types/FieldInputDraftValue",
+      "@/object-record/record-field/ui/types/FieldMetadata"
+    ],
+    "src/modules/ui/field/input/components/CurrencyInput.tsx": [
+      "@/localization/hooks/useNumberFormat",
+      "@/object-record/record-field/ui/meta-types/input/hooks/useRegisterInputEvents",
+      "@/settings/data-model/constants/Currencies"
+    ],
+    "src/modules/ui/field/input/components/DateInput.tsx": [
+      "@/object-record/record-field/ui/meta-types/input/hooks/useRegisterInputEvents"
+    ],
+    "src/modules/ui/field/input/components/DateTimeInput.tsx": [
+      "@/object-record/record-field/ui/meta-types/input/hooks/useRegisterInputEvents"
+    ],
+    "src/modules/ui/field/input/components/DoubleTextInput.tsx": [
+      "@/object-record/record-field/ui/types/FieldDoubleText"
+    ],
+    "src/modules/ui/field/input/components/MultiSelectInput.tsx": [
+      "@/object-record/record-field/ui/types/FieldMetadata",
+      "@/settings/data-model/fields/forms/select/components/AddSelectOptionMenuItem"
+    ],
+    "src/modules/ui/field/input/components/RatingInput.tsx": [
+      "@/object-record/record-field/ui/hooks/useClearField"
+    ],
+    "src/modules/ui/field/input/components/TextAreaInput.tsx": [
+      "@/object-record/record-field/ui/components/LightCopyIconButton",
+      "@/object-record/record-field/ui/meta-types/input/hooks/useRegisterInputEvents"
+    ],
+    "src/modules/ui/field/input/components/TextInput.tsx": [
+      "@/object-record/record-field/ui/components/LightCopyIconButton",
+      "@/object-record/record-field/ui/meta-types/input/hooks/useRegisterInputEvents"
+    ],
+    "src/modules/ui/field/input/hooks/useAddressAutocomplete.ts": [
+      "@/geo-map/constants/SelectAutocompleteListDropDownId",
+      "@/geo-map/hooks/useGetPlaceApiData",
+      "@/geo-map/types/placeApi",
+      "@/object-record/record-field/ui/types/FieldInputDraftValue"
+    ],
+    "src/modules/ui/field/input/hooks/useFocusManagement.ts": [
+      "@/object-record/record-field/ui/types/FieldInputDraftValue"
+    ],
+    "src/modules/ui/input/components/internal/currency/components/CurrencyPickerDropdownButton.tsx": [
+      "@/settings/data-model/constants/Currencies"
+    ],
+    "src/modules/ui/input/components/internal/currency/components/CurrencyPickerDropdownSelect.tsx": [
+      "@/settings/data-model/constants/Currencies"
+    ],
+    "src/modules/ui/input/components/internal/date/components/DatePicker.tsx": [
+      "@/activities/components/SkeletonLoader",
+      "@/auth/states/currentWorkspaceMemberState",
+      "@/localization/utils/detection/detectCalendarStartDay"
+    ],
+    "src/modules/ui/input/components/internal/date/components/DatePickerHeader.tsx": [
+      "@/auth/states/currentWorkspaceMemberState"
+    ],
+    "src/modules/ui/input/components/internal/date/components/DatePickerInput.tsx": [
+      "@/localization/hooks/useDateTimeFormat"
+    ],
+    "src/modules/ui/input/components/internal/date/components/DatePickerWithoutCalendar.tsx": [
+      "@/activities/components/SkeletonLoader",
+      "@/auth/states/currentWorkspaceMemberState",
+      "@/localization/utils/detection/detectCalendarStartDay"
+    ],
+    "src/modules/ui/input/components/internal/date/components/DateTimePicker.tsx": [
+      "@/activities/components/SkeletonLoader"
+    ],
+    "src/modules/ui/input/components/internal/date/components/DateTimePickerHeader.tsx": [
+      "@/auth/states/currentWorkspaceMemberState",
+      "@/localization/hooks/useDateTimeFormat"
+    ],
+    "src/modules/ui/input/components/internal/date/components/DateTimePickerInput.tsx": [
+      "@/localization/hooks/useDateTimeFormat"
+    ],
+    "src/modules/ui/input/components/internal/date/components/RelativeDatePickerCalendarNavigation.tsx": [
+      "@/auth/states/currentWorkspaceMemberState"
+    ],
+    "src/modules/ui/input/components/internal/date/components/RelativeDateTimeRangeText.tsx": [
+      "@/auth/states/currentWorkspaceMemberState"
+    ],
+    "src/modules/ui/input/components/internal/date/hooks/useParseDateInputStringToJSDate.ts": [
+      "@/localization/hooks/useDateTimeFormat"
+    ],
+    "src/modules/ui/input/components/internal/date/hooks/useParseDateInputStringToPlainDate.ts": [
+      "@/localization/hooks/useDateTimeFormat"
+    ],
+    "src/modules/ui/input/components/internal/date/hooks/useParseDateTimeInputStringToJSDate.ts": [
+      "@/localization/hooks/useDateTimeFormat"
+    ],
+    "src/modules/ui/input/components/internal/date/hooks/useParseJSDateToIMaskDateInputString.ts": [
+      "@/localization/hooks/useDateTimeFormat"
+    ],
+    "src/modules/ui/input/components/internal/date/hooks/useParseJSDateToIMaskDateTimeInputString.ts": [
+      "@/localization/hooks/useDateTimeFormat"
+    ],
+    "src/modules/ui/input/components/internal/date/hooks/useParsePlainDateToDateInputString.ts": [
+      "@/localization/hooks/useDateTimeFormat"
+    ],
+    "src/modules/ui/input/components/internal/date/hooks/useParseZonedDateTimeToIMaskDateTimeInputString.ts": [
+      "@/localization/constants/DateFormat",
+      "@/localization/hooks/useDateTimeFormat"
+    ],
+    "src/modules/ui/input/components/internal/date/hooks/useTimeInput.ts": [
+      "@/localization/constants/TimeFormat"
+    ],
+    "src/modules/ui/input/components/internal/date/hooks/useUserDateFormat.ts": [
+      "@/auth/states/currentWorkspaceMemberState",
+      "~/generated-metadata/graphql"
+    ],
+    "src/modules/ui/input/components/internal/date/hooks/useUserFirstDayOfTheWeek.ts": [
+      "@/auth/states/currentWorkspaceMemberState",
+      "@/localization/utils/detection/detectCalendarStartDay"
+    ],
+    "src/modules/ui/input/components/internal/date/hooks/useUserTimeFormat.ts": [
+      "@/auth/states/currentWorkspaceMemberState",
+      "~/generated-metadata/graphql"
+    ],
+    "src/modules/ui/input/components/internal/date/hooks/useUserTimezone.ts": [
+      "@/auth/states/currentWorkspaceMemberState"
+    ],
+    "src/modules/ui/input/components/internal/date/utils/getDateTimeMask.ts": [
+      "@/localization/constants/DateFormat",
+      "@/localization/constants/TimeFormat"
+    ],
+    "src/modules/ui/input/components/internal/date/utils/getTimeBlocks.ts": [
+      "@/localization/constants/TimeFormat"
+    ],
+    "src/modules/ui/input/components/internal/date/utils/getTimeMask.ts": [
+      "@/localization/constants/TimeFormat"
+    ],
+    "src/modules/ui/input/components/SelectInput.tsx": [
+      "@/settings/data-model/fields/forms/select/components/AddSelectOptionMenuItem"
+    ],
+    "src/modules/ui/input/components/TitleInput.tsx": [
+      "@/object-record/record-field/ui/meta-types/input/hooks/useRegisterInputEvents"
+    ],
+    "src/modules/ui/input/relation-picker/components/skeletons/DropdownMenuSkeletonItem.tsx": [
+      "@/activities/components/SkeletonLoader"
+    ],
+    "src/modules/ui/layout/contexts/LayoutRenderingContext.tsx": [
+      "~/generated-metadata/graphql"
+    ],
+    "src/modules/ui/layout/contexts/TargetRecordIdentifier.ts": [
+      "@/activities/types/ActivityTargetableEntity"
+    ],
+    "src/modules/ui/layout/dropdown/components/DropdownMenuInput.tsx": [
+      "@/object-record/record-field/ui/meta-types/input/hooks/useRegisterInputEvents"
+    ],
+    "src/modules/ui/layout/dropdown/components/OptionsDropdownMenu.tsx": [
+      "@/side-panel/constants/SidePanelFocusId"
+    ],
+    "src/modules/ui/layout/page/components/DefaultLayout.tsx": [
+      "@/error-handler/components/AppErrorBoundary",
+      "@/error-handler/components/AppFullScreenErrorFallback",
+      "@/error-handler/components/AppPageErrorFallback",
+      "@/file-upload/components/FileUploadProvider",
+      "@/information-banner/components/impersonate/InformationBannerIsImpersonating",
+      "@/keyboard-shortcut-menu/components/KeyboardShortcutMenu",
+      "@/layout-customization/components/LayoutCustomizationBar",
+      "@/navigation-menu-item/display/dnd/providers/PageDragDropProvider",
+      "@/navigation/components/AppNavigationDrawer",
+      "@/navigation/components/MobileNavigationBar"
+    ],
+    "src/modules/ui/layout/page/components/MainAppLayoutWithSidePanel.tsx": [
+      "@/command-menu/components/CommandMenuForMobile",
+      "@/command-menu/hooks/useCommandMenuHotKeys",
+      "@/side-panel/components/SidePanelForDesktop"
+    ],
+    "src/modules/ui/layout/page/components/PageCardHeader.tsx": [
+      "@/navigation/hooks/useNavigationDrawerExpanded",
+      "@/side-panel/constants/SidePanelTopBarHeight"
+    ],
+    "src/modules/ui/layout/page/components/PageCardLayout.tsx": [
+      "@/information-banner/components/InformationBannerWrapper"
+    ],
+    "src/modules/ui/layout/page/components/PageHeader.tsx": [
+      "@/navigation/hooks/useIsSettingsPage",
+      "@/navigation/hooks/useNavigationDrawerExpanded"
+    ],
+    "src/modules/ui/layout/show-page/components/FieldRichTextCard.tsx": [
+      "@/activities/components/ActivityRichTextEditor",
+      "@/activities/components/SkeletonLoader",
+      "@/object-record/record-store/states/selectors/recordStoreFamilySelector"
+    ],
+    "src/modules/ui/layout/show-page/components/ShowPageSummaryCard.tsx": [
+      "@/activities/components/SkeletonLoader"
+    ],
+    "src/modules/ui/navigation/bread-crumb/components/MobileBreadcrumb.tsx": [
+      "@/navigation/hooks/useIsSettingsPage"
+    ],
+    "src/modules/ui/navigation/navigation-drawer/components/MultiWorkspaceDropdown/internal/components/AvailableWorkspaceItem.tsx": [
+      "@/auth/utils/availableWorkspacesUtils",
+      "@/domain-manager/hooks/useBuildWorkspaceUrl",
+      "@/domain-manager/hooks/useRedirectToWorkspaceDomain",
+      "~/generated-metadata/graphql"
+    ],
+    "src/modules/ui/navigation/navigation-drawer/components/MultiWorkspaceDropdown/internal/components/WorkspacesForSignIn.tsx": [
+      "@/auth/states/availableWorkspacesState",
+      "@/auth/states/currentWorkspaceState"
+    ],
+    "src/modules/ui/navigation/navigation-drawer/components/MultiWorkspaceDropdown/internal/components/WorkspacesForSignUp.tsx": [
+      "@/auth/states/availableWorkspacesState",
+      "@/auth/states/currentWorkspaceState"
+    ],
+    "src/modules/ui/navigation/navigation-drawer/components/MultiWorkspaceDropdown/internal/MultiWorkspaceDropdownClickableComponent.tsx": [
+      "@/auth/states/currentWorkspaceState"
+    ],
+    "src/modules/ui/navigation/navigation-drawer/components/MultiWorkspaceDropdown/internal/MultiWorkspaceDropdownDefaultComponents.tsx": [
+      "@/auth/hooks/useAuth",
+      "@/auth/states/availableWorkspacesState",
+      "@/auth/states/currentWorkspaceState",
+      "@/auth/utils/availableWorkspacesUtils",
+      "@/client-config/states/isMultiWorkspaceEnabledState",
+      "@/client-config/states/supportChatState",
+      "@/domain-manager/hooks/useBuildWorkspaceUrl",
+      "@/domain-manager/hooks/useRedirectToDefaultDomain",
+      "@/domain-manager/hooks/useRedirectToWorkspaceDomain",
+      "@/navigation/hooks/useOpenSettings",
+      "~/generated-metadata/graphql"
+    ],
+    "src/modules/ui/navigation/navigation-drawer/components/MultiWorkspaceDropdown/internal/MultiWorkspaceDropdownWorkspacesListComponents.tsx": [
+      "@/auth/states/availableWorkspacesState"
+    ],
+    "src/modules/ui/navigation/navigation-drawer/components/MultiWorkspaceDropdown/MultiWorkspaceDropdownButton.tsx": [
+      "@/layout-customization/states/isLayoutCustomizationModeEnabledState"
+    ],
+    "src/modules/ui/navigation/navigation-drawer/components/NavigationDrawer.tsx": [
+      "@/navigation/hooks/useIsSettingsDrawer",
+      "@/navigation/hooks/useNavigationDrawerExpanded",
+      "@/object-record/record-table/states/tableWidthResizeIsActivedState"
+    ],
+    "src/modules/ui/navigation/navigation-drawer/components/NavigationDrawerAnimatedCollapseWrapper.tsx": [
+      "@/navigation/hooks/useIsSettingsPage"
+    ],
+    "src/modules/ui/navigation/navigation-drawer/components/NavigationDrawerBackButton.tsx": [
+      "@/navigation/states/currentMobileNavigationDrawerState",
+      "@/workspace/hooks/useIsWorkspaceActivationStatusEqualsTo"
+    ],
+    "src/modules/ui/navigation/navigation-drawer/components/NavigationDrawerHeader.tsx": [
+      "@/side-panel/hooks/useOpenRecordsSearchPageInSidePanel"
+    ],
+    "src/modules/ui/navigation/navigation-drawer/components/NavigationDrawerItem.tsx": [
+      "@/navigation/hooks/useNavigationDrawerExpanded"
+    ],
+    "src/modules/ui/navigation/navigation-drawer/components/NavigationDrawerItemsCollapsableContainer.tsx": [
+      "@/navigation/hooks/useIsSettingsPage"
+    ],
+    "src/modules/ui/navigation/navigation-drawer/components/NavigationDrawerScrollableContent.tsx": [
+      "@/navigation/hooks/useIsSettingsDrawer"
+    ],
+    "src/modules/ui/navigation/navigation-drawer/components/NavigationDrawerSection.tsx": [
+      "@/navigation/hooks/useIsSettingsDrawer"
+    ],
+    "src/modules/ui/navigation/navigation-drawer/components/NavigationDrawerSectionTitle.tsx": [
+      "@/navigation/hooks/useIsSettingsPage"
+    ],
+    "src/modules/ui/navigation/navigation-drawer/components/NavigationDrawerSectionTitleSkeletonLoader.tsx": [
+      "@/activities/components/SkeletonLoader"
+    ],
+    "src/modules/ui/navigation/navigation-drawer/hooks/useFilteredAvailableWorkspaces.ts": [
+      "@/auth/states/currentWorkspaceState",
+      "~/generated-metadata/graphql"
+    ],
+    "src/modules/ui/theme/hooks/useColorScheme.ts": [
+      "@/auth/states/currentWorkspaceMemberState",
+      "@/settings/profile/hooks/useUpdateWorkspaceMemberSettings",
+      "@/workspace-member/types/WorkspaceMember"
+    ],
+    "src/modules/ui/theme/hooks/useSystemColorScheme.ts": [
+      "@/workspace-member/types/WorkspaceMember"
+    ],
+    "src/modules/ui/theme/states/persistedColorSchemeState.ts": [
+      "@/workspace-member/types/WorkspaceMember"
+    ],
+    "src/modules/ui/utilities/page-favicon/components/PageFavicon.tsx": [
+      "@/auth/states/workspacePublicDataState"
+    ],
+    "src/modules/ui/utilities/state/jotai/jotaiStore.ts": [
+      "@/auth/utils/clearAllSessionLocalStorageKeys"
+    ]
+  }
+}

--- a/packages/twenty-front/.ui-boundary-baseline.json
+++ b/packages/twenty-front/.ui-boundary-baseline.json
@@ -290,8 +290,7 @@
     ],
     "src/modules/ui/navigation/navigation-drawer/components/NavigationDrawer.tsx": [
       "@/navigation/hooks/useIsSettingsDrawer",
-      "@/navigation/hooks/useNavigationDrawerExpanded",
-      "@/object-record/record-table/states/tableWidthResizeIsActivedState"
+      "@/navigation/hooks/useNavigationDrawerExpanded"
     ],
     "src/modules/ui/navigation/navigation-drawer/components/NavigationDrawerAnimatedCollapseWrapper.tsx": [
       "@/navigation/hooks/useIsSettingsPage"

--- a/packages/twenty-front/project.json
+++ b/packages/twenty-front/project.json
@@ -59,11 +59,13 @@
         "{projectRoot}/tsconfig*.json",
         "{workspaceRoot}/tsconfig.base.json",
         "{projectRoot}/.oxlintrc.json",
+        "{projectRoot}/.ui-boundary-baseline.json",
+        "{projectRoot}/scripts/ui-boundary-baseline.mjs",
         "{workspaceRoot}/packages/twenty-oxlint-rules/dist/oxlint-plugin.mjs"
       ],
       "options": {
         "cwd": "{projectRoot}",
-        "command": "npx oxlint --type-aware -c .oxlintrc.json src/ && (npx oxfmt --check src/ || (echo 'ERROR: oxfmt formatting check failed! Fix with: npx nx lint twenty-front --configuration=fix' && false))"
+        "command": "node scripts/ui-boundary-baseline.mjs --check && npx oxlint --type-aware -c .oxlintrc.json src/ && (npx oxfmt --check src/ || (echo 'ERROR: oxfmt formatting check failed! Fix with: npx nx lint twenty-front --configuration=fix' && false))"
       },
       "configurations": {
         "fix": {

--- a/packages/twenty-front/scripts/ui-boundary-baseline.mjs
+++ b/packages/twenty-front/scripts/ui-boundary-baseline.mjs
@@ -1,0 +1,153 @@
+#!/usr/bin/env node
+// Keep in sync with packages/twenty-oxlint-rules/rules/no-feature-imports-in-ui.ts.
+import { readdirSync, readFileSync, statSync, writeFileSync } from 'fs';
+import { join, relative } from 'path';
+import { fileURLToPath } from 'url';
+
+const packageRoot = join(fileURLToPath(import.meta.url), '..', '..');
+const uiRoot = join(packageRoot, 'src', 'modules', 'ui');
+const baselinePath = join(packageRoot, '.ui-boundary-baseline.json');
+
+const EXEMPT_FILE_MARKERS = [
+  '.test.',
+  '.spec.',
+  '.stories.',
+  '/__tests__/',
+  '/__mocks__/',
+  '/__stories__/',
+];
+
+const isBannedImport = (importSource) => {
+  if (importSource.startsWith('@/') && !importSource.startsWith('@/ui/')) {
+    return true;
+  }
+
+  if (
+    importSource === '@apollo/client' ||
+    importSource.startsWith('@apollo/client/')
+  ) {
+    return true;
+  }
+
+  if (importSource.startsWith('~/generated')) {
+    return true;
+  }
+
+  return false;
+};
+
+const listSourceFiles = (dir) => {
+  const files = [];
+
+  for (const entry of readdirSync(dir)) {
+    const fullPath = join(dir, entry);
+
+    if (statSync(fullPath).isDirectory()) {
+      files.push(...listSourceFiles(fullPath));
+      continue;
+    }
+
+    if (/\.(ts|tsx)$/.test(entry)) {
+      files.push(fullPath);
+    }
+  }
+
+  return files;
+};
+
+const IMPORT_SOURCE_PATTERN =
+  /(?:from\s+|import\s*\(\s*|import\s+)['"]([^'"]+)['"]/g;
+
+const scanViolations = () => {
+  const entries = {};
+
+  for (const filePath of listSourceFiles(uiRoot)) {
+    const normalizedPath = filePath.replace(/\\/g, '/');
+
+    if (EXEMPT_FILE_MARKERS.some((marker) => normalizedPath.includes(marker))) {
+      continue;
+    }
+
+    const source = readFileSync(filePath, 'utf8');
+    const violations = new Set();
+
+    for (const match of source.matchAll(IMPORT_SOURCE_PATTERN)) {
+      if (isBannedImport(match[1])) {
+        violations.add(match[1]);
+      }
+    }
+
+    if (violations.size > 0) {
+      const key = relative(packageRoot, filePath).replace(/\\/g, '/');
+
+      entries[key] = [...violations].sort();
+    }
+  }
+
+  return Object.fromEntries(
+    Object.entries(entries).sort(([a], [b]) => a.localeCompare(b)),
+  );
+};
+
+const currentEntries = scanViolations();
+
+if (process.argv.includes('--check')) {
+  let committed = {};
+
+  try {
+    committed = JSON.parse(readFileSync(baselinePath, 'utf8')).entries ?? {};
+  } catch {
+    console.error(
+      `ui-boundary-baseline: missing or unreadable ${baselinePath}`,
+    );
+    process.exit(1);
+  }
+
+  const stale = [];
+  const missing = [];
+
+  for (const [file, specifiers] of Object.entries(committed)) {
+    for (const specifier of specifiers) {
+      if (!(currentEntries[file] ?? []).includes(specifier)) {
+        stale.push(`${file} -> ${specifier}`);
+      }
+    }
+  }
+
+  for (const [file, specifiers] of Object.entries(currentEntries)) {
+    for (const specifier of specifiers) {
+      if (!(committed[file] ?? []).includes(specifier)) {
+        missing.push(`${file} -> ${specifier}`);
+      }
+    }
+  }
+
+  if (stale.length > 0) {
+    console.error(
+      'ui-boundary-baseline: stale entries (violation fixed — remove from .ui-boundary-baseline.json; the baseline only shrinks):',
+    );
+    stale.forEach((line) => console.error(`  ${line}`));
+  }
+
+  if (missing.length > 0) {
+    console.error(
+      'ui-boundary-baseline: new violations not in the baseline (fix the import — src/modules/ui must not depend on feature modules):',
+    );
+    missing.forEach((line) => console.error(`  ${line}`));
+  }
+
+  if (stale.length > 0 || missing.length > 0) {
+    process.exit(1);
+  }
+
+  console.log('ui-boundary-baseline: OK');
+  process.exit(0);
+}
+
+writeFileSync(
+  baselinePath,
+  `${JSON.stringify({ entries: currentEntries }, null, 2)}\n`,
+);
+console.log(
+  `ui-boundary-baseline: wrote ${Object.values(currentEntries).flat().length} entries across ${Object.keys(currentEntries).length} files`,
+);

--- a/packages/twenty-front/scripts/ui-boundary-baseline.mjs
+++ b/packages/twenty-front/scripts/ui-boundary-baseline.mjs
@@ -1,5 +1,6 @@
 #!/usr/bin/env node
 // Keep in sync with packages/twenty-oxlint-rules/rules/no-feature-imports-in-ui.ts.
+import { execFileSync } from 'child_process';
 import { readdirSync, readFileSync, statSync, writeFileSync } from 'fs';
 import { join, relative } from 'path';
 import { fileURLToPath } from 'url';
@@ -18,8 +19,12 @@ const EXEMPT_FILE_MARKERS = [
 ];
 
 const isBannedImport = (importSource) => {
-  if (importSource.startsWith('@/') && !importSource.startsWith('@/ui/')) {
-    return true;
+  if (importSource.startsWith('@/')) {
+    if (importSource.includes('/../') || importSource.endsWith('/..')) {
+      return true;
+    }
+
+    return importSource !== '@/ui' && !importSource.startsWith('@/ui/');
   }
 
   if (
@@ -56,7 +61,7 @@ const listSourceFiles = (dir) => {
 };
 
 const IMPORT_SOURCE_PATTERN =
-  /(?:from\s+|import\s*\(\s*|import\s+)['"]([^'"]+)['"]/g;
+  /(?:from\s+|import\s*\(\s*|import\s+)[`'"]([^`'"]+)[`'"]/g;
 
 const scanViolations = () => {
   const entries = {};
@@ -72,7 +77,7 @@ const scanViolations = () => {
     const violations = new Set();
 
     for (const match of source.matchAll(IMPORT_SOURCE_PATTERN)) {
-      if (isBannedImport(match[1])) {
+      if (!match[1].includes('${') && isBannedImport(match[1])) {
         violations.add(match[1]);
       }
     }
@@ -87,6 +92,30 @@ const scanViolations = () => {
   return Object.fromEntries(
     Object.entries(entries).sort(([a], [b]) => a.localeCompare(b)),
   );
+};
+
+const readBranchPointBaseline = () => {
+  try {
+    const mergeBase = execFileSync(
+      'git',
+      ['merge-base', 'HEAD', 'origin/main'],
+      { cwd: packageRoot, encoding: 'utf8', stdio: ['ignore', 'pipe', 'pipe'] },
+    ).trim();
+    const repoPrefix = execFileSync('git', ['rev-parse', '--show-prefix'], {
+      cwd: packageRoot,
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'pipe'],
+    }).trim();
+    const blob = execFileSync(
+      'git',
+      ['show', `${mergeBase}:${repoPrefix}.ui-boundary-baseline.json`],
+      { cwd: packageRoot, encoding: 'utf8', stdio: ['ignore', 'pipe', 'pipe'] },
+    );
+
+    return JSON.parse(blob).entries ?? {};
+  } catch {
+    return null;
+  }
 };
 
 const currentEntries = scanViolations();
@@ -136,7 +165,27 @@ if (process.argv.includes('--check')) {
     missing.forEach((line) => console.error(`  ${line}`));
   }
 
-  if (stale.length > 0 || missing.length > 0) {
+  const branchPointEntries = readBranchPointBaseline();
+  const grown = [];
+
+  if (branchPointEntries !== null) {
+    for (const [file, specifiers] of Object.entries(committed)) {
+      for (const specifier of specifiers) {
+        if (!(branchPointEntries[file] ?? []).includes(specifier)) {
+          grown.push(`${file} -> ${specifier}`);
+        }
+      }
+    }
+
+    if (grown.length > 0) {
+      console.error(
+        'ui-boundary-baseline: baseline grew relative to the branch point (the baseline only shrinks — fix the import instead of baselining it):',
+      );
+      grown.forEach((line) => console.error(`  ${line}`));
+    }
+  }
+
+  if (stale.length > 0 || missing.length > 0 || grown.length > 0) {
     process.exit(1);
   }
 

--- a/packages/twenty-front/src/modules/metadata-store/effect-components/UserMetadataProviderInitialEffect.tsx
+++ b/packages/twenty-front/src/modules/metadata-store/effect-components/UserMetadataProviderInitialEffect.tsx
@@ -10,7 +10,7 @@ import { isCurrentUserLoadedState } from '@/auth/states/isCurrentUserLoadedState
 import { useInitializeFormatPreferences } from '@/localization/hooks/useInitializeFormatPreferences';
 import { getDateFnsLocale } from '@/ui/field/display/utils/getDateFnsLocale';
 import { useSetAtomState } from '@/ui/utilities/state/jotai/hooks/useSetAtomState';
-import { type ColorScheme } from '@/workspace-member/types/WorkspaceMember';
+import { type ColorScheme } from 'twenty-ui/input';
 import { enUS } from 'date-fns/locale';
 import { useStore } from 'jotai';
 import { useCallback, useEffect, useState } from 'react';

--- a/packages/twenty-front/src/modules/object-record/record-table/components/RecordTableWidthEffect.tsx
+++ b/packages/twenty-front/src/modules/object-record/record-table/components/RecordTableWidthEffect.tsx
@@ -1,5 +1,5 @@
 import { recordTableWidthComponentState } from '@/object-record/record-table/states/recordTableWidthComponentState';
-import { tableWidthResizeIsActiveState } from '@/object-record/record-table/states/tableWidthResizeIsActivedState';
+import { panelResizeIsSettledState } from '@/ui/layout/resizable-panel/states/panelResizeIsSettledState';
 import { useScrollWrapperHTMLElement } from '@/ui/utilities/scroll/hooks/useScrollWrapperHTMLElement';
 import { useSetAtomComponentState } from '@/ui/utilities/state/jotai/hooks/useSetAtomComponentState';
 import { useAtomStateValue } from '@/ui/utilities/state/jotai/hooks/useAtomStateValue';
@@ -12,16 +12,14 @@ export const RecordTableWidthEffect = () => {
     recordTableWidthComponentState,
   );
 
-  const tableWidthResizeIsActive = useAtomStateValue(
-    tableWidthResizeIsActiveState,
-  );
+  const panelResizeIsSettled = useAtomStateValue(panelResizeIsSettledState);
 
   const { scrollWrapperHTMLElement } = useScrollWrapperHTMLElement();
 
   useEffect(() => {
     const tableWidth = scrollWrapperHTMLElement?.clientWidth ?? 0;
 
-    if (tableWidthResizeIsActive) {
+    if (panelResizeIsSettled) {
       if (tableWidth > 0) {
         setRecordTableWidth(tableWidth);
       }
@@ -43,7 +41,7 @@ export const RecordTableWidthEffect = () => {
         tableResizeObserver.disconnect();
       };
     }
-  }, [setRecordTableWidth, scrollWrapperHTMLElement, tableWidthResizeIsActive]);
+  }, [setRecordTableWidth, scrollWrapperHTMLElement, panelResizeIsSettled]);
 
   return null;
 };

--- a/packages/twenty-front/src/modules/object-record/record-table/states/tableWidthResizeIsActivedState.ts
+++ b/packages/twenty-front/src/modules/object-record/record-table/states/tableWidthResizeIsActivedState.ts
@@ -1,6 +1,0 @@
-import { createAtomState } from '@/ui/utilities/state/jotai/utils/createAtomState';
-
-export const tableWidthResizeIsActiveState = createAtomState<boolean>({
-  key: 'tableWidthResizeIsActiveState',
-  defaultValue: true,
-});

--- a/packages/twenty-front/src/modules/object-record/record-table/utils/__tests__/buildValueFromFilter.spec.ts
+++ b/packages/twenty-front/src/modules/object-record/record-table/utils/__tests__/buildValueFromFilter.spec.ts
@@ -1,7 +1,7 @@
 import { type FieldMetadataItemOption } from '@/object-metadata/types/FieldMetadataItem';
 import { type RecordFilter } from '@/object-record/record-filter/types/RecordFilter';
 import { buildValueFromFilter } from '@/object-record/record-table/utils/buildValueFromFilter';
-import { type ColorScheme } from '@/workspace-member/types/WorkspaceMember';
+import { type ColorScheme } from 'twenty-ui/input';
 import {
   type FilterableFieldType,
   ViewFilterOperand,

--- a/packages/twenty-front/src/modules/settings/profile/utils/mergeWorkspaceMemberSettingsIntoCurrent.ts
+++ b/packages/twenty-front/src/modules/settings/profile/utils/mergeWorkspaceMemberSettingsIntoCurrent.ts
@@ -1,7 +1,7 @@
 import { isNull, isNumber, isString } from '@sniptt/guards';
 
 import { type CurrentWorkspaceMember } from '@/auth/states/currentWorkspaceMemberState';
-import { type ColorScheme } from '@/workspace-member/types/WorkspaceMember';
+import { type ColorScheme } from 'twenty-ui/input';
 import { isDefined, isPlainObject } from 'twenty-shared/utils';
 import {
   WorkspaceMemberDateFormatEnum,

--- a/packages/twenty-front/src/modules/side-panel/components/SidePanelForDesktop.tsx
+++ b/packages/twenty-front/src/modules/side-panel/components/SidePanelForDesktop.tsx
@@ -1,4 +1,4 @@
-import { tableWidthResizeIsActiveState } from '@/object-record/record-table/states/tableWidthResizeIsActivedState';
+import { panelResizeIsSettledState } from '@/ui/layout/resizable-panel/states/panelResizeIsSettledState';
 import { SidePanelRouter } from '@/side-panel/components/SidePanelRouter';
 import { SidePanelWidthEffect } from '@/side-panel/components/SidePanelWidthEffect';
 import { SIDE_PANEL_CLICK_OUTSIDE_ID } from '@/side-panel/constants/SidePanelClickOutsideId';
@@ -72,9 +72,7 @@ export const SidePanelForDesktop = () => {
   const [shouldRenderContent, setShouldRenderContent] =
     useState(isSidePanelOpened);
 
-  const setTableWidthResizeIsActive = useSetAtomState(
-    tableWidthResizeIsActiveState,
-  );
+  const setPanelResizeIsSettled = useSetAtomState(panelResizeIsSettledState);
 
   const shouldShowContent = isSidePanelOpened || shouldRenderContent;
 
@@ -102,21 +100,21 @@ export const SidePanelForDesktop = () => {
     (width: number) => {
       setSidePanelWidth(width);
       setIsResizing(false);
-      setTableWidthResizeIsActive(true);
+      setPanelResizeIsSettled(true);
     },
-    [setSidePanelWidth, setTableWidthResizeIsActive],
+    [setSidePanelWidth, setPanelResizeIsSettled],
   );
 
   const handleResizeStart = useCallback(() => {
     setIsResizing(true);
-    setTableWidthResizeIsActive(false);
-  }, [setTableWidthResizeIsActive]);
+    setPanelResizeIsSettled(false);
+  }, [setPanelResizeIsSettled]);
 
   const handleCollapse = useCallback(() => {
     closeSidePanelMenu();
     setIsResizing(false);
-    setTableWidthResizeIsActive(true);
-  }, [closeSidePanelMenu, setTableWidthResizeIsActive]);
+    setPanelResizeIsSettled(true);
+  }, [closeSidePanelMenu, setPanelResizeIsSettled]);
 
   return (
     <>

--- a/packages/twenty-front/src/modules/ui/layout/resizable-panel/states/panelResizeIsSettledState.ts
+++ b/packages/twenty-front/src/modules/ui/layout/resizable-panel/states/panelResizeIsSettledState.ts
@@ -1,7 +1,5 @@
 import { createAtomState } from '@/ui/utilities/state/jotai/utils/createAtomState';
 
-// True while no horizontal panel edge (navigation drawer, side panel) is being
-// dragged. Width-dependent layouts subscribe to recompute once a drag settles.
 export const panelResizeIsSettledState = createAtomState<boolean>({
   key: 'panelResizeIsSettledState',
   defaultValue: true,

--- a/packages/twenty-front/src/modules/ui/layout/resizable-panel/states/panelResizeIsSettledState.ts
+++ b/packages/twenty-front/src/modules/ui/layout/resizable-panel/states/panelResizeIsSettledState.ts
@@ -1,0 +1,8 @@
+import { createAtomState } from '@/ui/utilities/state/jotai/utils/createAtomState';
+
+// True while no horizontal panel edge (navigation drawer, side panel) is being
+// dragged. Width-dependent layouts subscribe to recompute once a drag settles.
+export const panelResizeIsSettledState = createAtomState<boolean>({
+  key: 'panelResizeIsSettledState',
+  defaultValue: true,
+});

--- a/packages/twenty-front/src/modules/ui/navigation/navigation-drawer/components/NavigationDrawer.tsx
+++ b/packages/twenty-front/src/modules/ui/navigation/navigation-drawer/components/NavigationDrawer.tsx
@@ -3,10 +3,10 @@ import { type ReactNode, useState } from 'react';
 
 import { useNavigationDrawerExpanded } from '@/navigation/hooks/useNavigationDrawerExpanded';
 import { useIsSettingsDrawer } from '@/navigation/hooks/useIsSettingsDrawer';
-import { tableWidthResizeIsActiveState } from '@/object-record/record-table/states/tableWidthResizeIsActivedState';
 import { ResizablePanelEdge } from '@/ui/layout/resizable-panel/components/ResizablePanelEdge';
 import { NAVIGATION_DRAWER_COLLAPSED_WIDTH } from '@/ui/layout/resizable-panel/constants/NavigationDrawerCollapsedWidth';
 import { NAVIGATION_DRAWER_CONSTRAINTS } from '@/ui/layout/resizable-panel/constants/NavigationDrawerConstraints';
+import { panelResizeIsSettledState } from '@/ui/layout/resizable-panel/states/panelResizeIsSettledState';
 import { NavigationDrawerWidthEffect } from '@/ui/navigation/components/NavigationDrawerWidthEffect';
 import { NAVIGATION_DRAWER_CLICK_OUTSIDE_ID } from '@/ui/navigation/navigation-drawer/constants/NavigationDrawerClickOutsideId';
 import { isNavigationDrawerExpandedState } from '@/ui/navigation/states/isNavigationDrawerExpanded';
@@ -89,26 +89,24 @@ export const NavigationDrawer = ({
   const setNavigationDrawerActiveTab = useSetAtomState(
     navigationDrawerActiveTabState,
   );
-  const setTableWidthResizeIsActive = useSetAtomState(
-    tableWidthResizeIsActiveState,
-  );
+  const setPanelResizeIsSettled = useSetAtomState(panelResizeIsSettledState);
 
   const handleCollapse = () => {
     setIsNavigationDrawerExpanded(false);
     setNavigationDrawerActiveTab(NAVIGATION_DRAWER_TABS.NAVIGATION_MENU);
     setIsResizing(false);
-    setTableWidthResizeIsActive(true);
+    setPanelResizeIsSettled(true);
   };
 
   const handleWidthChange = (width: number) => {
     setNavigationDrawerWidth(width);
     setIsResizing(false);
-    setTableWidthResizeIsActive(true);
+    setPanelResizeIsSettled(true);
   };
 
   const handleResizeStart = () => {
     setIsResizing(true);
-    setTableWidthResizeIsActive(false);
+    setPanelResizeIsSettled(false);
   };
 
   return (

--- a/packages/twenty-front/src/modules/ui/theme/hooks/useColorScheme.ts
+++ b/packages/twenty-front/src/modules/ui/theme/hooks/useColorScheme.ts
@@ -4,13 +4,13 @@ import { useAtomState } from '@/ui/utilities/state/jotai/hooks/useAtomState';
 import { useCallback } from 'react';
 import { persistedColorSchemeState } from '@/ui/theme/states/persistedColorSchemeState';
 import { useSetAtomState } from '@/ui/utilities/state/jotai/hooks/useSetAtomState';
-import { type ColorScheme } from '@/workspace-member/types/WorkspaceMember';
 import {
   type IconComponent,
   IconMoon,
   IconSun,
   IconSunMoon,
 } from 'twenty-ui/icon';
+import { type ColorScheme } from 'twenty-ui/input';
 
 export const useColorScheme = () => {
   const [currentWorkspaceMember, setCurrentWorkspaceMember] = useAtomState(

--- a/packages/twenty-front/src/modules/ui/theme/hooks/useSystemColorScheme.ts
+++ b/packages/twenty-front/src/modules/ui/theme/hooks/useSystemColorScheme.ts
@@ -1,6 +1,7 @@
 import { useEffect, useMemo, useState } from 'react';
 
-import { type ColorScheme } from '@/workspace-member/types/WorkspaceMember';
+import { type ColorScheme } from 'twenty-ui/input';
+
 import { isUndefinedOrNull } from '~/utils/isUndefinedOrNull';
 
 export const useSystemColorScheme = (): ColorScheme => {

--- a/packages/twenty-front/src/modules/ui/theme/states/persistedColorSchemeState.ts
+++ b/packages/twenty-front/src/modules/ui/theme/states/persistedColorSchemeState.ts
@@ -1,5 +1,5 @@
-import { type ColorScheme } from '@/workspace-member/types/WorkspaceMember';
 import { createAtomState } from '@/ui/utilities/state/jotai/utils/createAtomState';
+import { type ColorScheme } from 'twenty-ui/input';
 
 export const persistedColorSchemeState = createAtomState<ColorScheme>({
   key: 'persistedColorSchemeState',

--- a/packages/twenty-front/src/modules/workspace-member/types/WorkspaceMember.ts
+++ b/packages/twenty-front/src/modules/workspace-member/types/WorkspaceMember.ts
@@ -1,10 +1,10 @@
+import { type ColorScheme } from 'twenty-ui/input';
+
 import {
   type WorkspaceMemberDateFormatEnum,
   type WorkspaceMemberNumberFormatEnum,
   type WorkspaceMemberTimeFormatEnum,
 } from '~/generated-metadata/graphql';
-
-export type ColorScheme = 'Dark' | 'Light' | 'System';
 
 export type WorkspaceMember = {
   __typename: 'WorkspaceMember';

--- a/packages/twenty-oxlint-rules/oxlint-plugin.ts
+++ b/packages/twenty-oxlint-rules/oxlint-plugin.ts
@@ -41,6 +41,10 @@ import {
   RULE_NAME as noDirectAtomFamilyInSelectorName,
 } from './rules/no-direct-atom-family-in-selector';
 import {
+  rule as noFeatureImportsInUi,
+  RULE_NAME as noFeatureImportsInUiName,
+} from './rules/no-feature-imports-in-ui';
+import {
   rule as noHardcodedColors,
   RULE_NAME as noHardcodedColorsName,
 } from './rules/no-hardcoded-colors';
@@ -95,6 +99,7 @@ export default definePlugin({
     [noDataMutationInFastInstanceCommandName]:
       noDataMutationInFastInstanceCommand,
     [noDirectAtomFamilyInSelectorName]: noDirectAtomFamilyInSelector,
+    [noFeatureImportsInUiName]: noFeatureImportsInUi,
     [noHardcodedColorsName]: noHardcodedColors,
     [noJotaiStoreInSelectorName]: noJotaiStoreInSelector,
     [noNavigatePreferLinkName]: noNavigatePreferLink,

--- a/packages/twenty-oxlint-rules/rules/no-feature-imports-in-ui.baseline.fixture.json
+++ b/packages/twenty-oxlint-rules/rules/no-feature-imports-in-ui.baseline.fixture.json
@@ -1,0 +1,7 @@
+{
+  "entries": {
+    "src/modules/ui/navigation/navigation-drawer/components/NavigationDrawer.tsx": [
+      "@/object-record/record-table/states/tableWidthResizeIsActivedState"
+    ]
+  }
+}

--- a/packages/twenty-oxlint-rules/rules/no-feature-imports-in-ui.spec.ts
+++ b/packages/twenty-oxlint-rules/rules/no-feature-imports-in-ui.spec.ts
@@ -36,6 +36,10 @@ ruleTester.run(RULE_NAME, rule, {
       filename: UI_FILE,
     },
     {
+      code: "import { Button } from '@/ui';",
+      filename: UI_FILE,
+    },
+    {
       code: "import { recordStoreFamilyState } from '@/object-record/record-store/states/recordStoreFamilyState';",
       filename:
         '/project/packages/twenty-front/src/modules/object-record/record-table/components/RecordTable.tsx',
@@ -73,6 +77,16 @@ ruleTester.run(RULE_NAME, rule, {
     },
     {
       code: "const load = () => import('@/views/components/ViewBar');",
+      filename: UI_FILE,
+      errors: [{ messageId: 'featureImportInUi' }],
+    },
+    {
+      code: 'const load = () => import(`@/views/components/ViewBar`);',
+      filename: UI_FILE,
+      errors: [{ messageId: 'featureImportInUi' }],
+    },
+    {
+      code: "import { formatRecord } from '@/ui/../object-record/utils/formatRecord';",
       filename: UI_FILE,
       errors: [{ messageId: 'featureImportInUi' }],
     },

--- a/packages/twenty-oxlint-rules/rules/no-feature-imports-in-ui.spec.ts
+++ b/packages/twenty-oxlint-rules/rules/no-feature-imports-in-ui.spec.ts
@@ -1,0 +1,95 @@
+import { fileURLToPath } from 'url';
+
+import { RuleTester } from 'oxlint/plugins-dev';
+
+import { rule, RULE_NAME } from './no-feature-imports-in-ui';
+
+const UI_FILE =
+  '/project/packages/twenty-front/src/modules/ui/navigation/navigation-drawer/components/NavigationDrawer.tsx';
+
+const BASELINE_FIXTURE_PATH = fileURLToPath(
+  new URL('./no-feature-imports-in-ui.baseline.fixture.json', import.meta.url),
+);
+
+const ruleTester = new RuleTester();
+
+ruleTester.run(RULE_NAME, rule, {
+  valid: [
+    {
+      code: "import { useDropdown } from '@/ui/layout/dropdown/hooks/useDropdown';",
+      filename: UI_FILE,
+    },
+    {
+      code: "import { THEME_LIGHT } from 'twenty-ui/theme';",
+      filename: UI_FILE,
+    },
+    {
+      code: "import { isDefined } from 'twenty-shared/utils';",
+      filename: UI_FILE,
+    },
+    {
+      code: "import { useState } from 'react';",
+      filename: UI_FILE,
+    },
+    {
+      code: "import { NavigationDrawerHeader } from './NavigationDrawerHeader';",
+      filename: UI_FILE,
+    },
+    {
+      code: "import { recordStoreFamilyState } from '@/object-record/record-store/states/recordStoreFamilyState';",
+      filename:
+        '/project/packages/twenty-front/src/modules/object-record/record-table/components/RecordTable.tsx',
+    },
+    {
+      code: "import { getMockRecord } from '@/object-record/testing/mocks';",
+      filename:
+        '/project/packages/twenty-front/src/modules/ui/field/display/components/__stories__/ChipDisplay.stories.tsx',
+    },
+    {
+      code: "import { tableWidthResizeIsActiveState } from '@/object-record/record-table/states/tableWidthResizeIsActivedState';",
+      filename: UI_FILE,
+      options: [
+        {
+          baselinePath: BASELINE_FIXTURE_PATH,
+        },
+      ],
+    },
+  ],
+  invalid: [
+    {
+      code: "import { workspaceState } from '@/workspace/states/workspaceState';",
+      filename: UI_FILE,
+      errors: [{ messageId: 'featureImportInUi' }],
+    },
+    {
+      code: "import { useQuery } from '@apollo/client';",
+      filename: UI_FILE,
+      errors: [{ messageId: 'featureImportInUi' }],
+    },
+    {
+      code: "import { SearchRecordsDocument } from '~/generated/graphql';",
+      filename: UI_FILE,
+      errors: [{ messageId: 'featureImportInUi' }],
+    },
+    {
+      code: "const load = () => import('@/views/components/ViewBar');",
+      filename: UI_FILE,
+      errors: [{ messageId: 'featureImportInUi' }],
+    },
+    {
+      code: "export { formatRecord } from '@/object-record/utils/formatRecord';",
+      filename: UI_FILE,
+      errors: [{ messageId: 'featureImportInUi' }],
+    },
+    {
+      code: "import { workspaceState } from '@/workspace/states/workspaceState';",
+      filename: UI_FILE,
+      options: [
+        {
+          baselinePath: BASELINE_FIXTURE_PATH,
+        },
+      ],
+      errors: [{ messageId: 'featureImportInUi' }],
+    },
+  ],
+});

--- a/packages/twenty-oxlint-rules/rules/no-feature-imports-in-ui.ts
+++ b/packages/twenty-oxlint-rules/rules/no-feature-imports-in-ui.ts
@@ -1,0 +1,167 @@
+import { readFileSync } from 'fs';
+import { resolve } from 'path';
+
+import { defineRule } from '@oxlint/plugins';
+
+export const RULE_NAME = 'no-feature-imports-in-ui';
+
+const UI_PATH_SEGMENT = '/src/modules/ui/';
+
+const EXEMPT_FILE_MARKERS = [
+  '.test.',
+  '.spec.',
+  '.stories.',
+  '/__tests__/',
+  '/__mocks__/',
+  '/__stories__/',
+];
+
+// Keep in sync with packages/twenty-front/scripts/ui-boundary-baseline.mjs.
+const isBannedImport = (importSource: string): boolean => {
+  if (importSource.startsWith('@/') && !importSource.startsWith('@/ui/')) {
+    return true;
+  }
+
+  if (
+    importSource === '@apollo/client' ||
+    importSource.startsWith('@apollo/client/')
+  ) {
+    return true;
+  }
+
+  if (importSource.startsWith('~/generated')) {
+    return true;
+  }
+
+  return false;
+};
+
+const toBaselineKey = (filename: string): string | null => {
+  const normalized = filename.replace(/\\/g, '/');
+  const index = normalized.indexOf(UI_PATH_SEGMENT);
+
+  if (index === -1) {
+    return null;
+  }
+
+  return normalized.slice(index + 1);
+};
+
+type Baseline = Record<string, string[]>;
+
+const baselineCache = new Map<string, Baseline>();
+
+const loadBaseline = (baselinePath: string): Baseline => {
+  const resolvedPath = resolve(process.cwd(), baselinePath);
+  const cached = baselineCache.get(resolvedPath);
+
+  if (cached !== undefined) {
+    return cached;
+  }
+
+  let baseline: Baseline = {};
+
+  try {
+    const parsed = JSON.parse(readFileSync(resolvedPath, 'utf8')) as {
+      entries?: Baseline;
+    };
+
+    baseline = parsed.entries ?? {};
+  } catch {
+    baseline = {};
+  }
+
+  baselineCache.set(resolvedPath, baseline);
+
+  return baseline;
+};
+
+const checkImport = (
+  node: any,
+  context: any,
+  baseline: Baseline,
+  baselineKey: string | null,
+) => {
+  const sourceNode = node.source;
+  const importSource = sourceNode?.value;
+
+  if (!importSource || typeof importSource !== 'string') {
+    return;
+  }
+
+  if (!isBannedImport(importSource)) {
+    return;
+  }
+
+  if (
+    baselineKey !== null &&
+    (baseline[baselineKey] ?? []).includes(importSource)
+  ) {
+    return;
+  }
+
+  context.report({
+    node: sourceNode,
+    messageId: 'featureImportInUi',
+    data: { importSource },
+  });
+};
+
+export const rule = defineRule({
+  meta: {
+    type: 'problem',
+    docs: {
+      description:
+        'src/modules/ui is the presentation layer: it must not import feature modules, Apollo, or generated GraphQL. Declare a context/hook interface inside the ui module and inject the implementation from the feature.',
+    },
+    schema: [
+      {
+        type: 'object',
+        properties: {
+          baselinePath: { type: 'string' },
+        },
+      },
+    ],
+    messages: {
+      featureImportInUi:
+        "ui module imports '{{ importSource }}': src/modules/ui must not depend on feature modules. Invert the dependency (declare a context/hook interface in the ui module; inject the implementation from the feature). The pre-existing debt baseline (.ui-boundary-baseline.json) only shrinks.",
+    },
+  },
+  create: (context) => {
+    const filename: string = context.filename ?? '';
+
+    if (!filename.includes(UI_PATH_SEGMENT)) {
+      return {};
+    }
+
+    if (EXEMPT_FILE_MARKERS.some((marker) => filename.includes(marker))) {
+      return {};
+    }
+
+    const options = (context.options as [{ baselinePath?: string }])?.[0];
+    const baseline =
+      options?.baselinePath === undefined
+        ? {}
+        : loadBaseline(options.baselinePath);
+    const baselineKey = toBaselineKey(filename);
+
+    return {
+      ImportDeclaration: (node: any) => {
+        checkImport(node, context, baseline, baselineKey);
+      },
+      ImportExpression: (node: any) => {
+        if (node.source?.type === 'Literal') {
+          checkImport(node, context, baseline, baselineKey);
+        }
+      },
+      ExportNamedDeclaration: (node: any) => {
+        if (node.source) {
+          checkImport(node, context, baseline, baselineKey);
+        }
+      },
+      ExportAllDeclaration: (node: any) => {
+        checkImport(node, context, baseline, baselineKey);
+      },
+    };
+  },
+});

--- a/packages/twenty-oxlint-rules/rules/no-feature-imports-in-ui.ts
+++ b/packages/twenty-oxlint-rules/rules/no-feature-imports-in-ui.ts
@@ -18,8 +18,12 @@ const EXEMPT_FILE_MARKERS = [
 
 // Keep in sync with packages/twenty-front/scripts/ui-boundary-baseline.mjs.
 const isBannedImport = (importSource: string): boolean => {
-  if (importSource.startsWith('@/') && !importSource.startsWith('@/ui/')) {
-    return true;
+  if (importSource.startsWith('@/')) {
+    if (importSource.includes('/../') || importSource.endsWith('/..')) {
+      return true;
+    }
+
+    return importSource !== '@/ui' && !importSource.startsWith('@/ui/');
   }
 
   if (
@@ -36,15 +40,30 @@ const isBannedImport = (importSource: string): boolean => {
   return false;
 };
 
+const getStaticImportSource = (sourceNode: any): string | null => {
+  if (sourceNode?.type === 'Literal' && typeof sourceNode.value === 'string') {
+    return sourceNode.value;
+  }
+
+  if (
+    sourceNode?.type === 'TemplateLiteral' &&
+    sourceNode.expressions?.length === 0 &&
+    sourceNode.quasis?.length === 1
+  ) {
+    return sourceNode.quasis[0]?.value?.cooked ?? null;
+  }
+
+  return null;
+};
+
 const toBaselineKey = (filename: string): string | null => {
-  const normalized = filename.replace(/\\/g, '/');
-  const index = normalized.indexOf(UI_PATH_SEGMENT);
+  const index = filename.indexOf(UI_PATH_SEGMENT);
 
   if (index === -1) {
     return null;
   }
 
-  return normalized.slice(index + 1);
+  return filename.slice(index + 1);
 };
 
 type Baseline = Record<string, string[]>;
@@ -83,9 +102,9 @@ const checkImport = (
   baselineKey: string | null,
 ) => {
   const sourceNode = node.source;
-  const importSource = sourceNode?.value;
+  const importSource = getStaticImportSource(sourceNode);
 
-  if (!importSource || typeof importSource !== 'string') {
+  if (importSource === null) {
     return;
   }
 
@@ -128,7 +147,7 @@ export const rule = defineRule({
     },
   },
   create: (context) => {
-    const filename: string = context.filename ?? '';
+    const filename: string = (context.filename ?? '').replace(/\\/g, '/');
 
     if (!filename.includes(UI_PATH_SEGMENT)) {
       return {};
@@ -150,9 +169,7 @@ export const rule = defineRule({
         checkImport(node, context, baseline, baselineKey);
       },
       ImportExpression: (node: any) => {
-        if (node.source?.type === 'Literal') {
-          checkImport(node, context, baseline, baselineKey);
-        }
+        checkImport(node, context, baseline, baselineKey);
       },
       ExportNamedDeclaration: (node: any) => {
         if (node.source) {


### PR DESCRIPTION
This PR starts a campaign rather than finishing a feature, so a few words on the idea before the mechanics.

We want src/modules/ui to become a genuine presentation layer: components that own their markup, styling and interaction, declare the data they need through their own types, hooks and contexts, and receive implementations from the features that use them. Today that boundary leaks. ui components import feature state, feature types, Apollo and generated GraphQL directly, which means they only work inside the app, storybook needs a heavy decorator stack to compensate, and nothing under ui can graduate into twenty-ui where other consumers (the website, the admin panel, front components from apps) could reuse it. The direction we are chasing is dependency inversion for the view layer: features may import ui, ui may never import features. Where ui needs data, it declares an interface and the feature injects the implementation. Long term, modules that reach zero feature imports move into twenty-ui as a proper library.

Doing that in one refactor would be madness, so the first commit installs a ratchet instead. A new oxlint rule, twenty/no-feature-imports-in-ui, forbids imports in src/modules/ui of anything under @/ outside @/ui, plus @apollo/client and generated GraphQL. The 160 pre-existing violations across 91 files are recorded in .ui-boundary-baseline.json and stay allowed for now. Any new violation fails lint immediately. A small script runs before oxlint and fails when the baseline contains an entry whose violation no longer exists, so fixing an import forces you to delete its baseline line. The baseline can never grow and every refactor shrinks it. The file doubles as the campaign backlog: field has 26 offending files, input 17, navigation 11, layout 5, and the rest are stragglers in feedback, utilities and theme.

The other two commits are worked examples of the two violation classes we will encounter, so reviews of later PRs have a precedent to point at.

The ColorScheme commit shows the type coupling class. ui/theme imported the ColorScheme type from the workspace-member feature, while twenty-ui/input already declared the identical union. Color scheme is a presentation concept, so the library copy is the real one. All importers, including the WorkspaceMember type itself, now use it and the duplicate declaration is gone. Three baseline lines deleted.

The panel resize commit shows the state coupling class, and a nastier smell: NavigationDrawer, a ui component, was writing record-table state (tableWidthResizeIsActiveState), so the arrow did not just point the wrong way, ui was mutating a feature. The signal it carries ("no horizontal panel edge is being dragged right now, width-dependent layouts may recompute") belongs to the resizable panel system both writers already wrap. It now lives in ui/layout/resizable-panel as panelResizeIsSettledState, named for what it actually stores; the old name said resize-is-active but stored the opposite. The drawer and the side panel write their own layer's state and record-table subscribes to it. Feature depends on ui, never the reverse. One baseline line deleted, behavior identical.

Verification: typecheck green, lint green (which now includes the baseline check), the oxlint-rules package passes its 258 rule tests including 14 new ones for this rule, and 323 jest tests across the touched surfaces (navigation drawer, side panel, record table components, theme) pass. The rule was also negative-tested by injecting a violation (errors as expected) and by removing a live baseline entry (errors as expected).

Nothing user-facing changes in this PR. What changes is that the ui boundary can only get cleaner from here.


One obligation this PR creates, written down here so it does not become debt: the baseline machinery is scaffolding, not architecture. The day .ui-boundary-baseline.json reaches zero entries, the whole apparatus comes out in the same PR that removes the last entry: the baseline file itself, the baselinePath option and baseline loading inside the rule, the baseline cases and their fixture json in the rule's spec, scripts/ui-boundary-baseline.mjs, and the check invocation plus the two input entries wired into twenty-front's lint target. The rule itself stays forever, it just stops carrying a baseline.