### PR TITLE
chore(twenty-partners): upgrade to twenty-sdk 2.21

### DIFF
--- a/packages/twenty-apps/internal/twenty-partners/package.json
+++ b/packages/twenty-apps/internal/twenty-partners/package.json
@@ -25,8 +25,8 @@
     "rls:configure:prod": "ENV_FILE=.env.prod tsx src/scripts/configure-partner-rls.ts"
   },
   "dependencies": {
-    "twenty-client-sdk": "2.19.0-alpha.1",
-    "twenty-sdk": "2.19.0-alpha.1",
+    "twenty-client-sdk": "2.21.0",
+    "twenty-sdk": "2.21.0",
     "zod": "^4.1.11"
   },
   "devDependencies": {

--- a/packages/twenty-apps/internal/twenty-partners/src/views/partner-applications.view.ts
+++ b/packages/twenty-apps/internal/twenty-partners/src/views/partner-applications.view.ts
@@ -2,7 +2,7 @@ import {
   ViewFilterOperand,
   ViewType,
   defineView,
-  generateDefaultFieldUniversalIdentifier,
+  getFieldUniversalIdentifier,
 } from 'twenty-sdk/define';
 
 import {
@@ -23,10 +23,10 @@ export const PARTNER_APPLICATIONS_VIEW_UNIVERSAL_IDENTIFIER =
 // createdAt is a reserved system field auto-created on the partner object; the
 // server derives its universal identifier deterministically, so resolve it the
 // same way rather than hardcoding a value that would drift.
-const PARTNER_CREATED_AT_FIELD_ID = generateDefaultFieldUniversalIdentifier({
+const PARTNER_CREATED_AT_FIELD_ID = getFieldUniversalIdentifier({
   applicationUniversalIdentifier: APPLICATION_UNIVERSAL_IDENTIFIER,
   objectUniversalIdentifier: PARTNER_OBJECT_UNIVERSAL_IDENTIFIER,
-  fieldName: 'createdAt',
+  name: 'createdAt',
 });
 
 // Naming: partner onboarding applicants — distinct from the Application object's "Applications" view.

--- a/packages/twenty-apps/internal/twenty-partners/yarn.lock
+++ b/packages/twenty-apps/internal/twenty-partners/yarn.lock
@@ -2773,16 +2773,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"twenty-client-sdk@npm:2.19.0-alpha.1":
-  version: 2.19.0-alpha.1
-  resolution: "twenty-client-sdk@npm:2.19.0-alpha.1"
+"twenty-client-sdk@npm:2.21.0":
+  version: 2.21.0
+  resolution: "twenty-client-sdk@npm:2.21.0"
   dependencies:
     "@genql/runtime": "npm:^2.10.0"
     esbuild: "npm:^0.28.1"
     graphql: "npm:^16.8.1"
     lodash: "npm:^4.17.21"
     prettier: "npm:^3.8.3"
-  checksum: 10c0/daeac1c1b439f2a5c6ecd5ac5a97b04e56832bdd2e5530f5269bf469fd776849c750ea103b6837910dab3378adc146d4703008f7374c44eb4263fae1e120eb7c
+  checksum: 10c0/b411ce14c606830f63df27e7fa8efff6bc82968baabfbb0d6d5725cd6f6b023862102a22ce8baed4ae5c99ac5a50c10915e4f983c97e0fb138db9837c76be80a
   languageName: node
   linkType: hard
 
@@ -2797,8 +2797,8 @@ __metadata:
     react: "npm:^19.0.0"
     react-dom: "npm:^19.0.0"
     tsx: "npm:^4.0.0"
-    twenty-client-sdk: "npm:2.19.0-alpha.1"
-    twenty-sdk: "npm:2.19.0-alpha.1"
+    twenty-client-sdk: "npm:2.21.0"
+    twenty-sdk: "npm:2.21.0"
     typescript: "npm:^5.9.3"
     vite-tsconfig-paths: "npm:^4.2.1"
     vitest: "npm:^4.0.0"
@@ -2806,9 +2806,9 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"twenty-sdk@npm:2.19.0-alpha.1":
-  version: 2.19.0-alpha.1
-  resolution: "twenty-sdk@npm:2.19.0-alpha.1"
+"twenty-sdk@npm:2.21.0":
+  version: 2.21.0
+  resolution: "twenty-sdk@npm:2.21.0"
   dependencies:
     "@sniptt/guards": "npm:^0.2.0"
     axios: "npm:^1.16.0"
@@ -2827,12 +2827,12 @@ __metadata:
     semver: "npm:7.6.3"
     sharp: "npm:^0.34.5"
     tinyglobby: "npm:^0.2.15"
-    twenty-client-sdk: "npm:2.19.0-alpha.1"
+    twenty-client-sdk: "npm:2.21.0"
     typescript: "npm:^5.9.3"
     uuid: "npm:^13.0.2"
   bin:
     twenty: dist/cli.cjs
-  checksum: 10c0/c36772f6e6193c24ff5c6ba7636f4ae3b6110fed5697bc94cfbd282ae290b8de10b0f1df2b86a2c38eaed8f5a57791222b1f49b0d46baef6bb4b12fd0622cc2f
+  checksum: 10c0/ea03d59ca549054b1c065feb0800a103eb707c1755cb250356bbe5c59e7af576ce9f8480c1f658637ded8d3930b110bac7b57305255ff9ce02f8a587963e140c
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## What

Upgrades the `twenty-partners` internal app to consume twenty-sdk 2.21.

- Bump `twenty-sdk` and `twenty-client-sdk` from `2.19.0-alpha.1` to `2.21.0` (`package.json` + `yarn.lock`).
- Replace the removed `generateDefaultFieldUniversalIdentifier` helper with `getFieldUniversalIdentifier` in `partner-applications.view.ts`, renaming the `fieldName` argument to `name`.

## Why

`generateDefaultFieldUniversalIdentifier` was removed from the SDK and replaced by `getFieldUniversalIdentifier`. Both compute the same deterministic uuid-v5 (`fieldMetadata:objectUID:name` under the app universal identifier), so the resolved `createdAt` field identifier is unchanged; this is the only code change required to build against 2.21.

## Verified

- Install resolves to 2.21.0; runtime check confirms `getFieldUniversalIdentifier` is exported and `generateDefaultFieldUniversalIdentifier` is gone.
- Type check: no real errors.
- `oxlint`: 0 warnings, 0 errors.

---
_Generated by [Claude Code](https://claude.ai/code/session_01RUQ2yyfZcyKWqG57HbUYxx)_

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/22869?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

