### PR TITLE
fix(security): add required Expires field to security.txt (RFC 9116)

### DIFF
--- a/packages/twenty-website/public/.well-known/security.txt
+++ b/packages/twenty-website/public/.well-known/security.txt
@@ -1,6 +1,6 @@
 Contact: https://github.com/twentyhq/twenty/issues/new
 Contact: security@twenty.com
-Expires: 2027-07-13T00:00:00.000Z
+Expires: 2027-01-13T00:00:00.000Z
 Preferred-Languages: en
 Canonical: https://twenty.com/.well-known/security.txt
 Policy: https://github.com/twentyhq/twenty/security/policy

--- a/packages/twenty-website/public/.well-known/security.txt
+++ b/packages/twenty-website/public/.well-known/security.txt
@@ -1,5 +1,6 @@
 Contact: https://github.com/twentyhq/twenty/issues/new
 Contact: security@twenty.com
+Expires: 2027-07-13T00:00:00.000Z
 Preferred-Languages: en
 Canonical: https://twenty.com/.well-known/security.txt
 Policy: https://github.com/twentyhq/twenty/security/policy


### PR DESCRIPTION
### Summary

Adds the required `Expires` field to `packages/twenty-website/public/.well-known/security.txt`.

Closes #22866.

### Why

[RFC 9116 §2.5.5](https://www.rfc-editor.org/rfc/rfc9116#section-2.5.5) makes `Expires` **mandatory**:

> The "Expires" field … MUST always be present.

The current file (and the live one at `https://twenty.com/.well-known/security.txt`) has no `Expires`
line, so RFC-9116 validators (e.g. securitytxt.org) flag the file as invalid, and a researcher can't
tell whether the listed contacts are still maintained. Twenty's own Sonarly analysis on #22866 reached
the same conclusion.

### What changed

One line added:

```
Expires: 2027-07-13T00:00:00.000Z
```

- Set to one year out. RFC 9116 recommends less than a year, so **please adjust the date to match
  whatever refresh cadence suits your process** — I used a sensible default.
- No other fields changed.

### Notes

Thanks to @dankgarlic1 for the friendly nudge on the issue. Happy to tweak the value or placement if
you'd prefer.

<sub>AI-assisted; I verified the RFC requirement and the live file myself, and I own this change.</sub>


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/22871?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

