### PR TITLE
fix(mcp): stop advertising get_tool_catalog

### DIFF
--- a/packages/twenty-server/src/engine/api/mcp/services/__tests__/mcp-protocol.service.spec.ts
+++ b/packages/twenty-server/src/engine/api/mcp/services/__tests__/mcp-protocol.service.spec.ts
@@ -299,17 +299,15 @@ describe('McpProtocolService', () => {
 
       expect(mcpToolExecutorService.handleToolCall).toHaveBeenCalledWith(
         '123',
-        expect.objectContaining(
-          Object.fromEntries(
-            EXPECTED_MCP_TOOL_NAMES.map((name) => [
-              name,
-              expect.objectContaining({
-                description: expect.any(String),
-                annotations: EXPECTED_MCP_TOOL_ANNOTATIONS[name],
-                execute: expect.any(Function),
-              }),
-            ]),
-          ),
+        Object.fromEntries(
+          EXPECTED_MCP_TOOL_NAMES.map((name) => [
+            name,
+            expect.objectContaining({
+              description: expect.any(String),
+              annotations: EXPECTED_MCP_TOOL_ANNOTATIONS[name],
+              execute: expect.any(Function),
+            }),
+          ]),
         ),
         mockRequest.params,
         undefined,
@@ -339,16 +337,14 @@ describe('McpProtocolService', () => {
 
       expect(mcpToolExecutorService.handleToolsListing).toHaveBeenCalledWith(
         '123',
-        expect.objectContaining(
-          Object.fromEntries(
-            EXPECTED_MCP_TOOL_NAMES.map((name) => [
-              name,
-              expect.objectContaining({
-                description: expect.any(String),
-                annotations: EXPECTED_MCP_TOOL_ANNOTATIONS[name],
-              }),
-            ]),
-          ),
+        Object.fromEntries(
+          EXPECTED_MCP_TOOL_NAMES.map((name) => [
+            name,
+            expect.objectContaining({
+              description: expect.any(String),
+              annotations: EXPECTED_MCP_TOOL_ANNOTATIONS[name],
+            }),
+          ]),
         ),
       );
     });

--- a/packages/twenty-server/src/engine/api/mcp/services/mcp-protocol.service.ts
+++ b/packages/twenty-server/src/engine/api/mcp/services/mcp-protocol.service.ts
@@ -43,11 +43,6 @@ import {
   executeToolInputSchema,
 } from 'src/engine/core-modules/tool-provider/tools/execute-tool.tool';
 import {
-  createGetToolCatalogTool,
-  GET_TOOL_CATALOG_TOOL_NAME,
-  getToolCatalogInputSchema,
-} from 'src/engine/core-modules/tool-provider/tools/get-tool-catalog.tool';
-import {
   createLoadSkillTool,
   LOAD_SKILL_TOOL_NAME,
   loadSkillInputSchema,
@@ -223,15 +218,6 @@ export class McpProtocolService {
 
     return {
       ...annotatePreloadedMcpTools(preloadedTools),
-      [GET_TOOL_CATALOG_TOOL_NAME]: {
-        ...createGetToolCatalogTool(this.toolRegistry, workspace.id, roleId, {
-          userId: options?.userId,
-          userWorkspaceId: options?.userWorkspaceId,
-          excludeTools: MCP_EXCLUDED_TOOL_NAMES,
-        }),
-        inputSchema: zodSchema(getToolCatalogInputSchema),
-        annotations: MCP_CLOSED_WORLD_READ_ONLY_TOOL_ANNOTATIONS,
-      } as McpAnnotatedTool,
       [EXECUTE_TOOL_TOOL_NAME]: {
         ...createExecuteToolTool(this.toolRegistry, toolContext, {
           excludeTools: MCP_EXCLUDED_TOOL_NAMES,


### PR DESCRIPTION
## Summary

- stop advertising `get_tool_catalog` in the MCP top-level tool set
- make the existing six-tool unit assertions reject unexpected extra tools

## Why

#21183 moved MCP discovery to the workspace-aware initialization instructions and the `learn_tools` → `execute_tool` workflow, but the old `get_tool_catalog` registration remained in `McpProtocolService`. As a result, `tools/list` still exposed a deprecated seventh tool whose description contradicted the server instructions.

The tests described the tool set as "exactly 6 tools", but their outer `expect.objectContaining` matcher allowed extra keys, so the stale registration was not caught.

## Impact

MCP clients will now see the six intended top-level tools and receive a consistent discovery workflow from both initialization instructions and `tools/list`.

## Validation

- focused `mcp-protocol.service.spec.ts`: 17 tests passed
- type-aware lint and formatting checks on both changed files
- `nx typecheck twenty-server`
- `git diff --check`

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/22875?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

