### PR TITLE
Store application package files once per registration version in server storage

### DIFF
--- a/packages/twenty-server/src/engine/core-modules/application/application-install/application-install.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/application/application-install/application-install.service.ts
@@ -21,7 +21,9 @@ import { ApplicationRegistrationSourceType } from 'src/engine/core-modules/appli
 import { ApplicationEntity } from 'src/engine/core-modules/application/application.entity';
 import { ApplicationService } from 'src/engine/core-modules/application/application.service';
 import { ApplicationPackageFetcherService } from 'src/engine/core-modules/application/application-package/application-package-fetcher.service';
+import { ApplicationPackageFileService } from 'src/engine/core-modules/application/application-package/application-package-file.service';
 import { ApplicationVersionValidationService } from 'src/engine/core-modules/application/application-package/application-version-validation.service';
+import { buildApplicationPackageFileList } from 'src/engine/core-modules/application/application-package/utils/build-application-package-file-list.util';
 import { VERSION_REASON_TO_APPLICATION_EXCEPTION_CODE } from 'src/engine/core-modules/application/application-package/constants/version-reason-to-exception-code.constant';
 import { ApplicationSyncService } from 'src/engine/core-modules/application/application-manifest/application-sync.service';
 import { CacheLockService } from 'src/engine/core-modules/cache-lock/cache-lock.service';
@@ -47,6 +49,7 @@ export class ApplicationInstallService {
     private readonly applicationService: ApplicationService,
     private readonly applicationRegistrationService: ApplicationRegistrationService,
     private readonly applicationPackageFetcherService: ApplicationPackageFetcherService,
+    private readonly applicationPackageFileService: ApplicationPackageFileService,
     private readonly applicationVersionValidationService: ApplicationVersionValidationService,
     private readonly applicationSyncService: ApplicationSyncService,
     private readonly fileStorageService: FileStorageService,
@@ -206,6 +209,23 @@ export class ApplicationInstallService {
           }
         }
       }
+
+      // Shared copy first: one instance-global copy per (registration,
+      // version), reused by every workspace installing this version. The
+      // per-workspace copies below remain until all readers use the shared
+      // store.
+      await this.applicationPackageFileService.ensurePackageFilesStored({
+        applicationRegistrationId: appRegistration.id,
+        version: newVersion,
+        manifest: resolvedPackage.manifest,
+        readPackageFile: (relativePath) =>
+          fs.readFile(
+            this.resolveWithinDirOrThrow(
+              resolvedPackage.extractedDir,
+              relativePath,
+            ),
+          ),
+      });
 
       await this.writeFilesToStorage(
         resolvedPackage.extractedDir,
@@ -600,35 +620,13 @@ export class ApplicationInstallService {
   private buildFileList(
     manifest: Manifest,
   ): Array<{ relativePath: string; fileFolder: FileFolder }> {
-    const files: Array<{ relativePath: string; fileFolder: FileFolder }> = [];
-
-    files.push(
-      { relativePath: 'package.json', fileFolder: FileFolder.Dependencies },
+    return [
+      // manifest.json has no reader (the manifest lives on the registration
+      // row) and is not part of the shared package store; it is still written
+      // per workspace until the per-workspace copies are removed.
       { relativePath: 'manifest.json', fileFolder: FileFolder.Source },
-    );
-
-    for (const logicFunction of manifest.logicFunctions ?? []) {
-      files.push({
-        relativePath: logicFunction.builtHandlerPath,
-        fileFolder: FileFolder.BuiltLogicFunction,
-      });
-    }
-
-    for (const frontComponent of manifest.frontComponents ?? []) {
-      files.push({
-        relativePath: frontComponent.builtComponentPath,
-        fileFolder: FileFolder.BuiltFrontComponent,
-      });
-    }
-
-    for (const publicAsset of manifest.publicAssets ?? []) {
-      files.push({
-        relativePath: publicAsset.filePath,
-        fileFolder: FileFolder.PublicAsset,
-      });
-    }
-
-    return files;
+      ...buildApplicationPackageFileList(manifest),
+    ];
   }
 
   private async ensureApplicationExists(params: {

--- a/packages/twenty-server/src/engine/core-modules/application/application-package/application-package-file.service.spec.ts
+++ b/packages/twenty-server/src/engine/core-modules/application/application-package/application-package-file.service.spec.ts
@@ -1,0 +1,187 @@
+import { Test, type TestingModule } from '@nestjs/testing';
+
+import { type Manifest } from 'twenty-shared/application';
+import { ServerFileFolder } from 'twenty-shared/types';
+
+import { ApplicationPackageFileService } from 'src/engine/core-modules/application/application-package/application-package-file.service';
+import { ApplicationException } from 'src/engine/core-modules/application/application.exception';
+import { FileStorageException } from 'src/engine/core-modules/file-storage/interfaces/file-storage-exception';
+import { ServerFileStorageService } from 'src/engine/core-modules/file-storage/services/server-file-storage.service';
+
+const APPLICATION_REGISTRATION_ID = '20202020-0000-4000-8000-000000000001';
+
+const ONE_PIXEL_PNG = Buffer.from(
+  'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg==',
+  'base64',
+);
+
+const PACKAGE_FILE_CONTENTS: Record<string, Buffer> = {
+  'package.json': Buffer.from('{"name":"my-app","version":"1.2.3"}'),
+  'dist/index.mjs': Buffer.from('export const handler = () => {};'),
+  'dist/component.mjs': Buffer.from('export const Component = () => null;'),
+  'public/hero.png': ONE_PIXEL_PNG,
+};
+
+const buildManifest = (overrides: Partial<Manifest> = {}): Manifest =>
+  ({
+    application: { universalIdentifier: 'my-app' },
+    logicFunctions: [{ builtHandlerPath: 'dist/index.mjs' }],
+    frontComponents: [{ builtComponentPath: 'dist/component.mjs' }],
+    publicAssets: [{ filePath: 'public/hero.png' }],
+    ...overrides,
+  }) as Manifest;
+
+describe('ApplicationPackageFileService', () => {
+  let service: ApplicationPackageFileService;
+  let serverFileStorageService: jest.Mocked<
+    Pick<ServerFileStorageService, 'listStoredResourcePaths' | 'writeServerFile'>
+  >;
+  let readPackageFile: jest.Mock;
+
+  beforeEach(async () => {
+    serverFileStorageService = {
+      listStoredResourcePaths: jest.fn().mockResolvedValue([]),
+      writeServerFile: jest.fn().mockResolvedValue({ id: 'file-id' }),
+    };
+
+    readPackageFile = jest
+      .fn()
+      .mockImplementation((relativePath: string) =>
+        Promise.resolve(PACKAGE_FILE_CONTENTS[relativePath]),
+      );
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        ApplicationPackageFileService,
+        {
+          provide: ServerFileStorageService,
+          useValue: serverFileStorageService,
+        },
+      ],
+    }).compile();
+
+    service = module.get(ApplicationPackageFileService);
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should store every package file under a version-prefixed server path', async () => {
+    await service.ensurePackageFilesStored({
+      applicationRegistrationId: APPLICATION_REGISTRATION_ID,
+      version: '1.2.3',
+      manifest: buildManifest(),
+      readPackageFile,
+    });
+
+    const writtenResourcePaths =
+      serverFileStorageService.writeServerFile.mock.calls.map(
+        ([params]) => params.resourcePath,
+      );
+
+    expect(writtenResourcePaths).toEqual([
+      '1.2.3/dependencies/package.json',
+      '1.2.3/built-logic-function/dist/index.mjs',
+      '1.2.3/built-front-component/dist/component.mjs',
+      '1.2.3/public-asset/public/hero.png',
+    ]);
+
+    for (const [params] of serverFileStorageService.writeServerFile.mock
+      .calls) {
+      expect(params.fileFolder).toBe(ServerFileFolder.ApplicationPackage);
+      expect(params.applicationRegistrationId).toBe(
+        APPLICATION_REGISTRATION_ID,
+      );
+    }
+  });
+
+  it('should skip files already stored for the same version', async () => {
+    serverFileStorageService.listStoredResourcePaths.mockResolvedValue([
+      '1.2.3/dependencies/package.json',
+      '1.2.3/built-logic-function/dist/index.mjs',
+      '1.2.3/built-front-component/dist/component.mjs',
+      '1.2.3/public-asset/public/hero.png',
+    ]);
+
+    await service.ensurePackageFilesStored({
+      applicationRegistrationId: APPLICATION_REGISTRATION_ID,
+      version: '1.2.3',
+      manifest: buildManifest(),
+      readPackageFile,
+    });
+
+    expect(readPackageFile).not.toHaveBeenCalled();
+    expect(serverFileStorageService.writeServerFile).not.toHaveBeenCalled();
+  });
+
+  it('should store files of a new version even when a previous version is stored', async () => {
+    serverFileStorageService.listStoredResourcePaths.mockResolvedValue([
+      '1.2.3/dependencies/package.json',
+      '1.2.3/built-logic-function/dist/index.mjs',
+    ]);
+
+    await service.ensurePackageFilesStored({
+      applicationRegistrationId: APPLICATION_REGISTRATION_ID,
+      version: '2.0.0',
+      manifest: buildManifest(),
+      readPackageFile,
+    });
+
+    const writtenResourcePaths =
+      serverFileStorageService.writeServerFile.mock.calls.map(
+        ([params]) => params.resourcePath,
+      );
+
+    expect(writtenResourcePaths).toContain(
+      '2.0.0/built-logic-function/dist/index.mjs',
+    );
+  });
+
+  it('should strip semver build metadata from the version path segment', async () => {
+    await service.ensurePackageFilesStored({
+      applicationRegistrationId: APPLICATION_REGISTRATION_ID,
+      version: '1.2.3+build.5',
+      manifest: buildManifest(),
+      readPackageFile,
+    });
+
+    const writtenResourcePaths =
+      serverFileStorageService.writeServerFile.mock.calls.map(
+        ([params]) => params.resourcePath,
+      );
+
+    expect(writtenResourcePaths).toContain('1.2.3/dependencies/package.json');
+  });
+
+  it('should reject a version that is not valid semver', async () => {
+    await expect(
+      service.ensurePackageFilesStored({
+        applicationRegistrationId: APPLICATION_REGISTRATION_ID,
+        version: '../escape',
+        manifest: buildManifest(),
+        readPackageFile,
+      }),
+    ).rejects.toThrow(ApplicationException);
+
+    expect(readPackageFile).not.toHaveBeenCalled();
+    expect(serverFileStorageService.writeServerFile).not.toHaveBeenCalled();
+  });
+
+  it('should reject a file whose extension is not allowed for its folder', async () => {
+    await expect(
+      service.ensurePackageFilesStored({
+        applicationRegistrationId: APPLICATION_REGISTRATION_ID,
+        version: '1.2.3',
+        manifest: buildManifest({
+          logicFunctions: [
+            { builtHandlerPath: 'dist/index.js' },
+          ] as Manifest['logicFunctions'],
+        }),
+        readPackageFile,
+      }),
+    ).rejects.toThrow(FileStorageException);
+
+    expect(serverFileStorageService.writeServerFile).not.toHaveBeenCalled();
+  });
+});

--- a/packages/twenty-server/src/engine/core-modules/application/application-package/application-package-file.service.spec.ts
+++ b/packages/twenty-server/src/engine/core-modules/application/application-package/application-package-file.service.spec.ts
@@ -34,7 +34,10 @@ const buildManifest = (overrides: Partial<Manifest> = {}): Manifest =>
 describe('ApplicationPackageFileService', () => {
   let service: ApplicationPackageFileService;
   let serverFileStorageService: jest.Mocked<
-    Pick<ServerFileStorageService, 'listStoredResourcePaths' | 'writeServerFile'>
+    Pick<
+      ServerFileStorageService,
+      'listStoredResourcePaths' | 'writeServerFile'
+    >
   >;
   let readPackageFile: jest.Mock;
 

--- a/packages/twenty-server/src/engine/core-modules/application/application-package/application-package-file.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/application/application-package/application-package-file.service.ts
@@ -1,0 +1,127 @@
+import { Injectable, Logger } from '@nestjs/common';
+
+import { join } from 'path';
+
+import semver from 'semver';
+import { type Manifest } from 'twenty-shared/application';
+import { ServerFileFolder } from 'twenty-shared/types';
+import { isDefined } from 'twenty-shared/utils';
+
+import {
+  ApplicationException,
+  ApplicationExceptionCode,
+} from 'src/engine/core-modules/application/application.exception';
+import { buildApplicationPackageFileList } from 'src/engine/core-modules/application/application-package/utils/build-application-package-file-list.util';
+import {
+  FileStorageException,
+  FileStorageExceptionCode,
+} from 'src/engine/core-modules/file-storage/interfaces/file-storage-exception';
+import { ServerFileStorageService } from 'src/engine/core-modules/file-storage/services/server-file-storage.service';
+import { prepareFileForStorageOrThrow } from 'src/engine/core-modules/file-storage/utils/prepare-file-for-storage-or-throw.util';
+import { validateFilePath } from 'src/engine/core-modules/file-storage/utils/validate-file-path.util';
+
+export type ReadApplicationPackageFile = (
+  relativePath: string,
+) => Promise<Buffer>;
+
+// Stores the files of an application package (built logic functions, built
+// front components, public assets, package.json) in instance-global server
+// storage, keyed by registration and version, so every workspace installing
+// the same version shares a single stored copy.
+@Injectable()
+export class ApplicationPackageFileService {
+  private readonly logger = new Logger(ApplicationPackageFileService.name);
+
+  constructor(
+    private readonly serverFileStorageService: ServerFileStorageService,
+  ) {}
+
+  // Package contents are immutable per (registration, version): npm versions
+  // cannot be republished and tarball deploys must bump the version. Files
+  // already stored for this version are skipped, so installing the same
+  // version from another workspace stores nothing new.
+  async ensurePackageFilesStored({
+    applicationRegistrationId,
+    version,
+    manifest,
+    readPackageFile,
+  }: {
+    applicationRegistrationId: string;
+    version: string;
+    manifest: Manifest;
+    readPackageFile: ReadApplicationPackageFile;
+  }): Promise<void> {
+    const parsedVersion = semver.parse(version);
+
+    if (!isDefined(parsedVersion)) {
+      throw new ApplicationException(
+        `Invalid application package version "${version}". Must be a valid semver version.`,
+        ApplicationExceptionCode.INVALID_INPUT,
+      );
+    }
+
+    // parsedVersion.version drops build metadata ("1.2.3+build" -> "1.2.3"):
+    // "+" is not a safe path character, and semver ignores build metadata for
+    // precedence so it can never distinguish two installable versions.
+    const versionPathSegment = parsedVersion.version;
+
+    const packageFiles = buildApplicationPackageFileList(manifest);
+
+    // Validated upfront so an invalid manifest stores nothing at all.
+    for (const { relativePath, fileFolder } of packageFiles) {
+      const validationResult = validateFilePath({
+        resourcePath: relativePath,
+        fileFolder,
+      });
+
+      if (!validationResult.isValid) {
+        throw new FileStorageException(
+          validationResult.error,
+          FileStorageExceptionCode.ACCESS_DENIED,
+        );
+      }
+    }
+
+    const storedResourcePaths = new Set(
+      await this.serverFileStorageService.listStoredResourcePaths({
+        fileFolder: ServerFileFolder.ApplicationPackage,
+        applicationRegistrationId,
+      }),
+    );
+
+    let storedFileCount = 0;
+
+    for (const { relativePath, fileFolder } of packageFiles) {
+      const resourcePath = join(versionPathSegment, fileFolder, relativePath);
+
+      if (storedResourcePaths.has(resourcePath)) {
+        continue;
+      }
+
+      const contents = await readPackageFile(relativePath);
+
+      const { sourceFile, mimeType } = await prepareFileForStorageOrThrow({
+        sourceFile: contents,
+        resourcePath: relativePath,
+      });
+
+      await this.serverFileStorageService.writeServerFile({
+        fileFolder: ServerFileFolder.ApplicationPackage,
+        applicationRegistrationId,
+        resourcePath,
+        contents: Buffer.isBuffer(sourceFile)
+          ? sourceFile
+          : Buffer.from(sourceFile),
+        mimeType,
+      });
+
+      storedFileCount += 1;
+    }
+
+    if (storedFileCount > 0) {
+      this.logger.log(
+        `Stored ${storedFileCount} package file(s) for registration ${applicationRegistrationId} version ${version}`,
+      );
+    }
+  }
+}

--- a/packages/twenty-server/src/engine/core-modules/application/application-package/application-package.module.ts
+++ b/packages/twenty-server/src/engine/core-modules/application/application-package/application-package.module.ts
@@ -2,6 +2,7 @@ import { Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
 
 import { ApplicationPackageFetcherService } from 'src/engine/core-modules/application/application-package/application-package-fetcher.service';
+import { ApplicationPackageFileService } from 'src/engine/core-modules/application/application-package/application-package-file.service';
 import { ApplicationVersionValidationService } from 'src/engine/core-modules/application/application-package/application-version-validation.service';
 import { ApplicationEntity } from 'src/engine/core-modules/application/application.entity';
 import { FileStorageModule } from 'src/engine/core-modules/file-storage/file-storage.module';
@@ -20,10 +21,12 @@ import { UpgradeModule } from 'src/engine/core-modules/upgrade/upgrade.module';
   ],
   providers: [
     ApplicationPackageFetcherService,
+    ApplicationPackageFileService,
     ApplicationVersionValidationService,
   ],
   exports: [
     ApplicationPackageFetcherService,
+    ApplicationPackageFileService,
     ApplicationVersionValidationService,
   ],
 })

--- a/packages/twenty-server/src/engine/core-modules/application/application-package/utils/build-application-package-file-list.util.ts
+++ b/packages/twenty-server/src/engine/core-modules/application/application-package/utils/build-application-package-file-list.util.ts
@@ -1,0 +1,38 @@
+import { type Manifest } from 'twenty-shared/application';
+import { FileFolder } from 'twenty-shared/types';
+
+export type ApplicationPackageFile = {
+  relativePath: string;
+  fileFolder: FileFolder;
+};
+
+export const buildApplicationPackageFileList = (
+  manifest: Manifest,
+): ApplicationPackageFile[] => {
+  const files: ApplicationPackageFile[] = [
+    { relativePath: 'package.json', fileFolder: FileFolder.Dependencies },
+  ];
+
+  for (const logicFunction of manifest.logicFunctions ?? []) {
+    files.push({
+      relativePath: logicFunction.builtHandlerPath,
+      fileFolder: FileFolder.BuiltLogicFunction,
+    });
+  }
+
+  for (const frontComponent of manifest.frontComponents ?? []) {
+    files.push({
+      relativePath: frontComponent.builtComponentPath,
+      fileFolder: FileFolder.BuiltFrontComponent,
+    });
+  }
+
+  for (const publicAsset of manifest.publicAssets ?? []) {
+    files.push({
+      relativePath: publicAsset.filePath,
+      fileFolder: FileFolder.PublicAsset,
+    });
+  }
+
+  return files;
+};

--- a/packages/twenty-server/src/engine/core-modules/file-storage/services/__tests__/server-file-storage.service.spec.ts
+++ b/packages/twenty-server/src/engine/core-modules/file-storage/services/__tests__/server-file-storage.service.spec.ts
@@ -4,7 +4,7 @@ import { getRepositoryToken } from '@nestjs/typeorm';
 import { Readable } from 'stream';
 
 import { ServerFileFolder } from 'twenty-shared/types';
-import { IsNull } from 'typeorm';
+import { IsNull, Like } from 'typeorm';
 
 import { FileStorageDriverFactory } from 'src/engine/core-modules/file-storage/file-storage-driver.factory';
 import { ServerFileStorageService } from 'src/engine/core-modules/file-storage/services/server-file-storage.service';
@@ -23,6 +23,7 @@ describe('ServerFileStorageService', () => {
 
   const mockServerFileRepository = {
     upsert: jest.fn(),
+    find: jest.fn(),
     findOneBy: jest.fn(),
     findOneByOrFail: jest.fn(),
     findBy: jest.fn(),
@@ -447,6 +448,47 @@ describe('ServerFileStorageService', () => {
       expect(mockServerFileRepository.delete).toHaveBeenCalledWith({
         applicationRegistrationId: 'registration-id',
         workspaceId: IsNull(),
+      });
+    });
+  });
+
+  describe('listStoredResourcePaths', () => {
+    it('should return paths relative to the folder and registration scope', async () => {
+      mockServerFileRepository.find.mockResolvedValue([
+        {
+          path: 'application-package/registration-id/1.2.3/dependencies/package.json',
+        },
+        {
+          path: 'application-package/registration-id/1.2.3/public-asset/nested/logo.png',
+        },
+      ] as FileEntity[]);
+
+      const resourcePaths = await service.listStoredResourcePaths({
+        fileFolder: ServerFileFolder.ApplicationPackage,
+        applicationRegistrationId: 'registration-id',
+      });
+
+      expect(resourcePaths).toEqual([
+        '1.2.3/dependencies/package.json',
+        '1.2.3/public-asset/nested/logo.png',
+      ]);
+    });
+
+    it('should scope the query to the registration and server rows', async () => {
+      mockServerFileRepository.find.mockResolvedValue([]);
+
+      await service.listStoredResourcePaths({
+        fileFolder: ServerFileFolder.ApplicationPackage,
+        applicationRegistrationId: 'registration-id',
+      });
+
+      expect(mockServerFileRepository.find).toHaveBeenCalledWith({
+        select: { path: true },
+        where: {
+          applicationRegistrationId: 'registration-id',
+          workspaceId: IsNull(),
+          path: Like('application-package/registration-id/%'),
+        },
       });
     });
   });

--- a/packages/twenty-server/src/engine/core-modules/file-storage/services/server-file-storage.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/file-storage/services/server-file-storage.service.ts
@@ -6,7 +6,7 @@ import { type Readable } from 'stream';
 
 import { type ServerFileFolder } from 'twenty-shared/types';
 import { isDefined } from 'twenty-shared/utils';
-import { IsNull, Repository } from 'typeorm';
+import { IsNull, Like, Repository } from 'typeorm';
 
 import { SERVER_FILE_STORAGE_PREFIX } from 'src/engine/core-modules/file-storage/constants/server-file-storage-prefix.constant';
 import { FileStorageDriverFactory } from 'src/engine/core-modules/file-storage/file-storage-driver.factory';
@@ -168,6 +168,28 @@ export class ServerFileStorageService {
     });
 
     return { stream, mimeType: serverFile.mimeType };
+  }
+
+  // Returns the resource paths (relative to the folder + registration scope)
+  // of all stored server files for a registration in the given folder.
+  async listStoredResourcePaths({
+    fileFolder,
+    applicationRegistrationId,
+  }: Omit<ServerResourceIdentifier, 'resourcePath'>): Promise<string[]> {
+    const pathPrefix = `${join(fileFolder, applicationRegistrationId)}/`;
+
+    const serverFiles = await this.serverFileRepository.find({
+      select: { path: true },
+      where: {
+        applicationRegistrationId,
+        workspaceId: IsNull(),
+        path: Like(`${pathPrefix}%`),
+      },
+    });
+
+    return serverFiles.map((serverFile) =>
+      serverFile.path.slice(pathPrefix.length),
+    );
   }
 
   checkServerFileExists({

--- a/packages/twenty-shared/src/types/ServerFileFolder.ts
+++ b/packages/twenty-shared/src/types/ServerFileFolder.ts
@@ -1,3 +1,4 @@
 export enum ServerFileFolder {
   ApplicationRegistration = 'application-registration',
+  ApplicationPackage = 'application-package',
 }


### PR DESCRIPTION
Follow-up to #22868, first step of unifying application file storage.

## Problem

Installing an application copies its whole package into workspace-scoped file storage, once per installing workspace:

```
{workspaceId}/{universalIdentifier}/dependencies/package.json
{workspaceId}/{universalIdentifier}/built-logic-function/{builtHandlerPath}
{workspaceId}/{universalIdentifier}/built-front-component/{builtComponentPath}
{workspaceId}/{universalIdentifier}/public-asset/{filePath}
```

Package contents are immutable per (registration, version) — npm versions cannot be republished and tarball deploys must bump the version — so N workspaces installing the same version hold N identical copies. Pre-installed apps multiply this across every workspace on the instance.

## Change

Introduce a shared, versioned package store in instance-global server storage, next to #22868's registration display assets:

```
server/application-package/{registrationId}/{version}/{fileFolder}/{path}
```

- `ServerFileFolder.ApplicationPackage` (twenty-shared)
- `ApplicationPackageFileService.ensurePackageFilesStored`: validates the manifest file list upfront (per-role-folder extension rules, path safety), then stores each package file once, skipping files already stored for the version — so the second workspace installing the same version stores nothing new. The version path segment is `semver.parse(...).version`, which drops build metadata (`+` is not a safe path character and build metadata never distinguishes two installable versions).
- `ServerFileStorageService.listStoredResourcePaths`: lists stored resource paths for a registration scope (used for the skip check in one query).
- `ApplicationInstallService` calls it during install/upgrade (NPM and TARBALL sources; LOCAL dev apps stay workspace-scoped by design), and its `buildFileList` now reuses the shared `buildApplicationPackageFileList` util. `manifest.json` stays out of the shared store: it has no reader (the manifest lives on the registration row) and is only still written per workspace until the copies are removed.

Per-workspace copies are still written and remain the ones being read — this PR is intentionally additive and non-breaking.

## Follow-up plan (separate small PRs)

1. ~~Shared versioned package store + write path~~ (this PR)
2. Serve public assets from the shared store, with per-workspace fallback for pre-existing installs and LOCAL dev apps
3. Built code reads from the shared store (logic-function execution, front-component serving, dependencies), same fallback
4. Stop writing per-workspace copies on install, stop writing the unread `source/manifest.json`, clean up package files of versions no longer referenced by any installation
5. Later: move uploaded tarballs out of the owner-workspace namespace into server storage; drop per-workspace `Application.logoFileId` in favor of registration assets

## Validation

- New unit tests: `application-package-file.service.spec.ts` (stores under version-prefixed paths, skips already-stored files, new version alongside old, strips build metadata, rejects invalid semver, rejects disallowed extensions before writing anything), `listStoredResourcePaths` cases in `server-file-storage.service.spec.ts`
- All 54 application/file-storage/file suites pass; typecheck and lint:diff-with-main green on twenty-server and twenty-shared

---
_Generated by [Claude Code](https://claude.ai/code/session_015L4zvAL9bsk7azYkbhcZSg)_

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/22878?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

