### PR TITLE
docs(skills): use 'twenty apply' in codex-plugin skills (dev --once deprecated)

### DIFF
--- a/packages/twenty-codex-plugin/skills/create-app/SKILL.md
+++ b/packages/twenty-codex-plugin/skills/create-app/SKILL.md
@@ -75,7 +75,7 @@ Supported create-time options are `--name`, `--display-name`, `--description`, `
 
 When the scaffolder completes, the app is fully created, synced, and installed. The job is done.
 
-Do not run any follow-up validation commands after scaffolding unless the user asks for them. Do not run `yarn twenty dev --once`, `yarn test`, `yarn lint`, or other validation just to prove the scaffold worked; the scaffolder already performed the initial sync. If the user asks to run tests later, switch to `develop-app` or `manage-app` guidance and run the full suite against the isolated test instance with `TWENTY_API_URL=http://localhost:2021`.
+Do not run any follow-up validation commands after scaffolding unless the user asks for them. Do not run `yarn twenty apply`, `yarn test`, `yarn lint`, or other validation just to prove the scaffold worked; the scaffolder already performed the initial sync. If the user asks to run tests later, switch to `develop-app` or `manage-app` guidance and run the full suite against the isolated test instance with `TWENTY_API_URL=http://localhost:2021`.
 
 Report to the user that the app was created successfully and is ready for development. Then stop. Wait for the user to ask for the next action.
 
@@ -95,4 +95,4 @@ Only proceed to these when the user explicitly asks:
 
 - Use `develop-app` when the user wants to add objects, fields, logic functions, roles, views, navigation, page layouts, skills, agents, or front component registrations.
 - Use `references/design/front-component-ui.md` when the user wants to design or improve the UI of a Twenty front component.
-- When the user later makes changes to app entities, use `yarn twenty dev --once` to sync those changes. See the `manage-app` skill for sync workflow.
+- When the user later makes changes to app entities, use `yarn twenty apply` to sync those changes. See the `manage-app` skill for sync workflow.

--- a/packages/twenty-codex-plugin/skills/develop-app/SKILL.md
+++ b/packages/twenty-codex-plugin/skills/develop-app/SKILL.md
@@ -86,10 +86,10 @@ Once all edits for the change are complete, run lint and typecheck once at the e
 ```bash
 yarn twenty dev:typecheck
 yarn lint
-yarn twenty dev --once
+yarn twenty apply
 ```
 
-`yarn twenty dev:typecheck` checks generated app types, `yarn lint` checks local lint rules, and `yarn twenty dev --once` syncs entity definitions to the active remote. Run all three a single time once every edit is done, not repeatedly after each step. When the user explicitly asks to run tests, follow `../../references/develop-app/tests.md`.
+`yarn twenty dev:typecheck` checks generated app types, `yarn lint` checks local lint rules, and `yarn twenty apply` syncs entity definitions to the active remote. Run all three a single time once every edit is done, not repeatedly after each step. When the user explicitly asks to run tests, follow `../../references/develop-app/tests.md`.
 
 Use the official Twenty docs or local SDK source when exact entity fields, imports, or configuration shapes matter.
 

--- a/packages/twenty-codex-plugin/skills/manage-app/SKILL.md
+++ b/packages/twenty-codex-plugin/skills/manage-app/SKILL.md
@@ -91,10 +91,10 @@ When the user says "prod", "production", or "workspace de prod", identify the ta
 Always use one-shot sync to synchronize app changes with the active remote:
 
 ```bash
-yarn twenty dev --once
+yarn twenty apply
 ```
 
-Do not use bare `yarn twenty dev` (watch mode). Run `yarn twenty dev --once` each time changes need to be synced.
+Do not use bare `yarn twenty dev` (watch mode). Run `yarn twenty apply` each time changes need to be synced.
 
 One-shot sync requires an authenticated remote. If authentication fails, re-add or switch the remote before retrying.
 
@@ -115,7 +115,7 @@ Collect the minimum useful context before changing configuration:
 sed -n '1,220p' package.json
 sed -n '1,220p' src/application-config.ts
 yarn twenty remote:list
-yarn twenty dev --once --verbose
+yarn twenty apply --verbose
 ```
 
 For remote or authentication issues:
@@ -127,7 +127,7 @@ For remote or authentication issues:
 
 For sync issues:
 
-- Prefer `yarn twenty dev --once --verbose` to get a bounded failure.
+- Prefer `yarn twenty apply --verbose` to get a bounded failure.
 - Check generated type or schema errors before editing app entities.
 - If the app depends on a changed data model, use `$develop-app` to fix the entity definitions.
 


### PR DESCRIPTION
The `twenty` CLI deprecated `yarn twenty dev --once` in favour of `yarn twenty apply` (added in #22372). The developer docs were updated in #22688, but the codex-plugin skills still tell agents to run the deprecated command. This swaps `yarn twenty dev --once` -> `yarn twenty apply` (including the `--verbose` variants) in the create-app, develop-app and manage-app skills so agent guidance matches the current CLI.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/22880?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

