### PR TITLE
drop nestjs-query IDField from standalone DTOs/entities

### DIFF
--- a/packages/twenty-server/src/engine/core-modules/api-key/api-key.entity.ts
+++ b/packages/twenty-server/src/engine/core-modules/api-key/api-key.entity.ts
@@ -1,6 +1,4 @@
 import { Field, ObjectType } from '@nestjs/graphql';
-
-import { IDField } from '@ptc-org/nestjs-query-graphql';
 import {
   Column,
   CreateDateColumn,
@@ -17,7 +15,7 @@ import { WorkspaceRelatedEntity } from 'src/engine/workspace-manager/types/works
 @Entity({ name: 'apiKey', schema: 'core' })
 @ObjectType('ApiKey')
 export class ApiKeyEntity extends WorkspaceRelatedEntity {
-  @IDField(() => UUIDScalarType)
+  @Field(() => UUIDScalarType)
   @PrimaryGeneratedColumn('uuid')
   id: string;
 

--- a/packages/twenty-server/src/engine/core-modules/application/application-registration-variable/application-registration-variable.entity.ts
+++ b/packages/twenty-server/src/engine/core-modules/application/application-registration-variable/application-registration-variable.entity.ts
@@ -1,6 +1,4 @@
 import { Field, ObjectType } from '@nestjs/graphql';
-
-import { IDField } from '@ptc-org/nestjs-query-graphql';
 import {
   Check,
   Column,
@@ -41,7 +39,7 @@ import { type EncryptedString } from 'src/engine/core-modules/secret-encryption/
   `"encryptedValue" = '' OR "encryptedValue" LIKE 'enc:v2:%'`,
 )
 export class ApplicationRegistrationVariableEntity {
-  @IDField(() => UUIDScalarType)
+  @Field(() => UUIDScalarType)
   @PrimaryGeneratedColumn('uuid')
   id: string;
 

--- a/packages/twenty-server/src/engine/core-modules/application/application-registration-variable/dtos/application-registration-variable.dto.ts
+++ b/packages/twenty-server/src/engine/core-modules/application/application-registration-variable/dtos/application-registration-variable.dto.ts
@@ -1,13 +1,12 @@
 import { Field, ObjectType } from '@nestjs/graphql';
 import { UUIDScalarType } from 'src/engine/api/graphql/workspace-schema-builder/graphql-types/scalars';
 import { IsBoolean, IsOptional, IsString } from 'class-validator';
-import { IDField } from '@ptc-org/nestjs-query-graphql';
 import { GraphQLJSON } from 'graphql-type-json';
 import { type ApplicationVariableOption } from 'twenty-shared/application';
 
 @ObjectType()
 export class ApplicationRegistrationVariableDTO {
-  @IDField(() => UUIDScalarType)
+  @Field(() => UUIDScalarType)
   id: string;
 
   @IsString()

--- a/packages/twenty-server/src/engine/core-modules/application/application-registration/application-registration.entity.ts
+++ b/packages/twenty-server/src/engine/core-modules/application/application-registration/application-registration.entity.ts
@@ -1,6 +1,4 @@
 import { Field, ObjectType } from '@nestjs/graphql';
-
-import { IDField } from '@ptc-org/nestjs-query-graphql';
 import {
   Check,
   Column,
@@ -53,7 +51,7 @@ import { WorkspaceEntity } from 'src/engine/core-modules/workspace/workspace.ent
   `"sourceType" <> 'npm' OR "sourcePackage" IS NOT NULL`,
 )
 export class ApplicationRegistrationEntity {
-  @IDField(() => UUIDScalarType)
+  @Field(() => UUIDScalarType)
   @PrimaryGeneratedColumn('uuid')
   id: string;
 

--- a/packages/twenty-server/src/engine/core-modules/application/application-variable/application-variable.entity.ts
+++ b/packages/twenty-server/src/engine/core-modules/application/application-variable/application-variable.entity.ts
@@ -1,6 +1,4 @@
-import { ObjectType } from '@nestjs/graphql';
-
-import { IDField } from '@ptc-org/nestjs-query-graphql';
+import { Field, ObjectType } from '@nestjs/graphql';
 import {
   Check,
   Column,
@@ -34,7 +32,7 @@ import { SyncableEntity } from 'src/engine/workspace-manager/types/syncable-enti
   `"value" = '' OR "value" LIKE 'enc:v2:%'`,
 )
 export class ApplicationVariableEntity extends SyncableEntity {
-  @IDField(() => UUIDScalarType)
+  @Field(() => UUIDScalarType)
   @PrimaryGeneratedColumn('uuid')
   id: string;
 

--- a/packages/twenty-server/src/engine/core-modules/application/application-variable/dtos/application-variable.dto.ts
+++ b/packages/twenty-server/src/engine/core-modules/application/application-variable/dtos/application-variable.dto.ts
@@ -2,14 +2,13 @@ import { Field, ObjectType } from '@nestjs/graphql';
 
 import { IsBoolean, IsOptional, IsString } from 'class-validator';
 import { GraphQLJSON } from 'graphql-type-json';
-import { IDField } from '@ptc-org/nestjs-query-graphql';
 import { type ApplicationVariableOption } from 'twenty-shared/application';
 
 import { UUIDScalarType } from 'src/engine/api/graphql/workspace-schema-builder/graphql-types/scalars';
 
 @ObjectType('ApplicationVariable')
 export class ApplicationVariableEntityDTO {
-  @IDField(() => UUIDScalarType)
+  @Field(() => UUIDScalarType)
   id: string;
 
   @IsString()

--- a/packages/twenty-server/src/engine/core-modules/application/connection-provider/dtos/application-connection-provider.dto.ts
+++ b/packages/twenty-server/src/engine/core-modules/application/connection-provider/dtos/application-connection-provider.dto.ts
@@ -1,7 +1,5 @@
 import { Field, ObjectType } from '@nestjs/graphql';
 
-import { IDField } from '@ptc-org/nestjs-query-graphql';
-
 import { type ConnectionProviderType } from 'twenty-shared/application';
 
 import { UUIDScalarType } from 'src/engine/api/graphql/workspace-schema-builder/graphql-types/scalars';
@@ -20,7 +18,7 @@ export class ApplicationConnectionProviderOAuthConfigDTO {
 
 @ObjectType('ApplicationConnectionProvider')
 export class ApplicationConnectionProviderDTO {
-  @IDField(() => UUIDScalarType)
+  @Field(() => UUIDScalarType)
   id: string;
 
   @Field()

--- a/packages/twenty-server/src/engine/core-modules/approved-access-domain/dtos/approved-access-domain.dto.ts
+++ b/packages/twenty-server/src/engine/core-modules/approved-access-domain/dtos/approved-access-domain.dto.ts
@@ -1,12 +1,10 @@
 import { Field, ObjectType } from '@nestjs/graphql';
 
-import { IDField } from '@ptc-org/nestjs-query-graphql';
-
 import { UUIDScalarType } from 'src/engine/api/graphql/workspace-schema-builder/graphql-types/scalars';
 
 @ObjectType('ApprovedAccessDomain')
 export class ApprovedAccessDomainDTO {
-  @IDField(() => UUIDScalarType)
+  @Field(() => UUIDScalarType)
   id: string;
 
   @Field({ nullable: false })

--- a/packages/twenty-server/src/engine/core-modules/billing/dtos/billing-subscription-item.dto.ts
+++ b/packages/twenty-server/src/engine/core-modules/billing/dtos/billing-subscription-item.dto.ts
@@ -2,14 +2,12 @@
 
 import { Field, ObjectType } from '@nestjs/graphql';
 
-import { IDField } from '@ptc-org/nestjs-query-graphql';
-
 import { UUIDScalarType } from 'src/engine/api/graphql/workspace-schema-builder/graphql-types/scalars';
 import { BillingProductDTO } from 'src/engine/core-modules/billing/dtos/billing-product.dto';
 
 @ObjectType('BillingSubscriptionItem')
 export class BillingSubscriptionItemDTO {
-  @IDField(() => UUIDScalarType)
+  @Field(() => UUIDScalarType)
   id: string;
 
   @Field(() => Boolean)

--- a/packages/twenty-server/src/engine/core-modules/billing/entities/billing-customer.entity.ts
+++ b/packages/twenty-server/src/engine/core-modules/billing/entities/billing-customer.entity.ts
@@ -1,8 +1,6 @@
 /* @license Enterprise */
 
 import { Field, ObjectType } from '@nestjs/graphql';
-
-import { IDField } from '@ptc-org/nestjs-query-graphql';
 import {
   Column,
   CreateDateColumn,
@@ -25,7 +23,7 @@ import { WorkspaceRelatedEntity } from 'src/engine/workspace-manager/types/works
   unique: true,
 })
 export class BillingCustomerEntity extends WorkspaceRelatedEntity {
-  @IDField(() => UUIDScalarType)
+  @Field(() => UUIDScalarType)
   @PrimaryGeneratedColumn('uuid')
   id: string;
 

--- a/packages/twenty-server/src/engine/core-modules/billing/entities/billing-entitlement.entity.ts
+++ b/packages/twenty-server/src/engine/core-modules/billing/entities/billing-entitlement.entity.ts
@@ -1,8 +1,6 @@
 /* @license Enterprise */
 
 import { Field, ObjectType } from '@nestjs/graphql';
-
-import { IDField } from '@ptc-org/nestjs-query-graphql';
 import {
   Column,
   CreateDateColumn,
@@ -27,7 +25,7 @@ import { WorkspaceRelatedEntity } from 'src/engine/workspace-manager/types/works
   'workspaceId',
 ])
 export class BillingEntitlementEntity extends WorkspaceRelatedEntity {
-  @IDField(() => UUIDScalarType)
+  @Field(() => UUIDScalarType)
   @PrimaryGeneratedColumn('uuid')
   id: string;
 

--- a/packages/twenty-server/src/engine/core-modules/billing/entities/billing-subscription.entity.ts
+++ b/packages/twenty-server/src/engine/core-modules/billing/entities/billing-subscription.entity.ts
@@ -1,8 +1,6 @@
 /* @license Enterprise */
 
 import { Field, ObjectType, registerEnumType } from '@nestjs/graphql';
-
-import { IDField } from '@ptc-org/nestjs-query-graphql';
 import graphqlTypeJson from 'graphql-type-json';
 import {
   Column,
@@ -56,7 +54,7 @@ registerEnumType(SubscriptionInterval, { name: 'SubscriptionInterval' });
 })
 @ObjectType('BillingSubscription')
 export class BillingSubscriptionEntity extends WorkspaceRelatedEntity {
-  @IDField(() => UUIDScalarType)
+  @Field(() => UUIDScalarType)
   @PrimaryGeneratedColumn('uuid')
   id: string;
 

--- a/packages/twenty-server/src/engine/core-modules/dpa/entities/dpa-agreement.entity.ts
+++ b/packages/twenty-server/src/engine/core-modules/dpa/entities/dpa-agreement.entity.ts
@@ -1,6 +1,4 @@
 import { Field, ObjectType, registerEnumType } from '@nestjs/graphql';
-
-import { IDField } from '@ptc-org/nestjs-query-graphql';
 import {
   Column,
   CreateDateColumn,
@@ -29,7 +27,7 @@ registerEnumType(DpaRegion, { name: 'DpaRegion' });
 @Index('IDX_DPA_AGREEMENT_WORKSPACE_ID', ['workspaceId'])
 @ObjectType('DpaAgreement')
 export class DpaAgreementEntity {
-  @IDField(() => UUIDScalarType)
+  @Field(() => UUIDScalarType)
   @PrimaryGeneratedColumn('uuid')
   id: string;
 

--- a/packages/twenty-server/src/engine/core-modules/emailing-domain/dtos/emailing-domain.dto.ts
+++ b/packages/twenty-server/src/engine/core-modules/emailing-domain/dtos/emailing-domain.dto.ts
@@ -1,7 +1,5 @@
 import { Field, ObjectType, registerEnumType } from '@nestjs/graphql';
 
-import { IDField } from '@ptc-org/nestjs-query-graphql';
-
 import { UUIDScalarType } from 'src/engine/api/graphql/workspace-schema-builder/graphql-types/scalars';
 import { EmailingDomainStatus } from 'src/engine/core-modules/emailing-domain/drivers/types/emailing-domain-status.type';
 import { VerificationRecordDTO } from 'src/engine/core-modules/emailing-domain/dtos/verification-record.dto';
@@ -12,7 +10,7 @@ registerEnumType(EmailingDomainStatus, {
 
 @ObjectType('EmailingDomain')
 export class EmailingDomainDTO {
-  @IDField(() => UUIDScalarType)
+  @Field(() => UUIDScalarType)
   id: string;
 
   @Field(() => Date)

--- a/packages/twenty-server/src/engine/core-modules/emailing-domain/dtos/unsubscribe-topic.dto.ts
+++ b/packages/twenty-server/src/engine/core-modules/emailing-domain/dtos/unsubscribe-topic.dto.ts
@@ -1,7 +1,5 @@
 import { Field, ObjectType, registerEnumType } from '@nestjs/graphql';
 
-import { IDField } from '@ptc-org/nestjs-query-graphql';
-
 import { UUIDScalarType } from 'src/engine/api/graphql/workspace-schema-builder/graphql-types/scalars';
 import { UnsubscribeTopicVisibility } from 'src/engine/core-modules/emailing-domain/types/unsubscribe-topic-visibility.type';
 
@@ -11,7 +9,7 @@ registerEnumType(UnsubscribeTopicVisibility, {
 
 @ObjectType('UnsubscribeTopic')
 export class UnsubscribeTopicDTO {
-  @IDField(() => UUIDScalarType)
+  @Field(() => UUIDScalarType)
   id: string;
 
   @Field(() => Date)

--- a/packages/twenty-server/src/engine/core-modules/public-domain/dtos/public-domain.dto.ts
+++ b/packages/twenty-server/src/engine/core-modules/public-domain/dtos/public-domain.dto.ts
@@ -1,12 +1,10 @@
 import { Field, ObjectType } from '@nestjs/graphql';
 
-import { IDField } from '@ptc-org/nestjs-query-graphql';
-
 import { UUIDScalarType } from 'src/engine/api/graphql/workspace-schema-builder/graphql-types/scalars';
 
 @ObjectType('PublicDomain')
 export class PublicDomainDTO {
-  @IDField(() => UUIDScalarType)
+  @Field(() => UUIDScalarType)
   id: string;
 
   @Field({ nullable: false })

--- a/packages/twenty-server/src/engine/core-modules/sso/workspace-sso-identity-provider.entity.ts
+++ b/packages/twenty-server/src/engine/core-modules/sso/workspace-sso-identity-provider.entity.ts
@@ -1,8 +1,6 @@
 /* @license Enterprise */
 
-import { ObjectType, registerEnumType } from '@nestjs/graphql';
-
-import { IDField } from '@ptc-org/nestjs-query-graphql';
+import { Field, ObjectType, registerEnumType } from '@nestjs/graphql';
 import {
   Column,
   CreateDateColumn,
@@ -45,7 +43,7 @@ registerEnumType(SSOIdentityProviderStatus, {
 @ObjectType('WorkspaceSSOIdentityProvider')
 export class WorkspaceSSOIdentityProviderEntity extends WorkspaceRelatedEntity {
   // COMMON
-  @IDField(() => UUIDScalarType)
+  @Field(() => UUIDScalarType)
   @PrimaryGeneratedColumn('uuid')
   id: string;
 

--- a/packages/twenty-server/src/engine/core-modules/user/dtos/deleted-workspace-member.dto.ts
+++ b/packages/twenty-server/src/engine/core-modules/user/dtos/deleted-workspace-member.dto.ts
@@ -1,13 +1,11 @@
 import { Field, ObjectType } from '@nestjs/graphql';
 
-import { IDField } from '@ptc-org/nestjs-query-graphql';
-
 import { UUIDScalarType } from 'src/engine/api/graphql/workspace-schema-builder/graphql-types/scalars';
 import { FullNameDTO } from 'src/engine/core-modules/user/dtos/workspace-member.dto';
 
 @ObjectType('DeletedWorkspaceMember')
 export class DeletedWorkspaceMemberDTO {
-  @IDField(() => UUIDScalarType)
+  @Field(() => UUIDScalarType)
   id: string;
 
   @Field(() => FullNameDTO)

--- a/packages/twenty-server/src/engine/core-modules/user/dtos/workspace-member.dto.ts
+++ b/packages/twenty-server/src/engine/core-modules/user/dtos/workspace-member.dto.ts
@@ -1,6 +1,4 @@
 import { Field, Int, ObjectType } from '@nestjs/graphql';
-
-import { IDField } from '@ptc-org/nestjs-query-graphql';
 import { Max, Min } from 'class-validator';
 
 import { UUIDScalarType } from 'src/engine/api/graphql/workspace-schema-builder/graphql-types/scalars';
@@ -22,7 +20,7 @@ export class FullNameDTO {
 
 @ObjectType('WorkspaceMember')
 export class WorkspaceMemberDTO {
-  @IDField(() => UUIDScalarType)
+  @Field(() => UUIDScalarType)
   id: string;
 
   @Field(() => FullNameDTO)

--- a/packages/twenty-server/src/engine/core-modules/workspace-invitation/dtos/workspace-invitation.dto.ts
+++ b/packages/twenty-server/src/engine/core-modules/workspace-invitation/dtos/workspace-invitation.dto.ts
@@ -1,12 +1,10 @@
 import { Field, ObjectType } from '@nestjs/graphql';
 
-import { IDField } from '@ptc-org/nestjs-query-graphql';
-
 import { UUIDScalarType } from 'src/engine/api/graphql/workspace-schema-builder/graphql-types/scalars';
 
 @ObjectType('WorkspaceInvitation')
 export class WorkspaceInvitation {
-  @IDField(() => UUIDScalarType)
+  @Field(() => UUIDScalarType)
   id: string;
 
   @Field({ nullable: false })

--- a/packages/twenty-server/src/engine/metadata-modules/field-metadata/dtos/delete-field.input.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/field-metadata/dtos/delete-field.input.ts
@@ -1,13 +1,11 @@
-import { InputType } from '@nestjs/graphql';
-
-import { IDField } from '@ptc-org/nestjs-query-graphql';
+import { Field, InputType } from '@nestjs/graphql';
 import { IsUUID } from 'class-validator';
 
 import { UUIDScalarType } from 'src/engine/api/graphql/workspace-schema-builder/graphql-types/scalars';
 
 @InputType()
 export class DeleteOneFieldInput {
-  @IDField(() => UUIDScalarType, {
+  @Field(() => UUIDScalarType, {
     description: 'The id of the field to delete.',
   })
   @IsUUID()

--- a/packages/twenty-server/src/engine/metadata-modules/index-metadata/dtos/delete-index.input.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/index-metadata/dtos/delete-index.input.ts
@@ -1,13 +1,11 @@
-import { InputType } from '@nestjs/graphql';
-
-import { IDField } from '@ptc-org/nestjs-query-graphql';
+import { Field, InputType } from '@nestjs/graphql';
 import { IsUUID } from 'class-validator';
 
 import { UUIDScalarType } from 'src/engine/api/graphql/workspace-schema-builder/graphql-types/scalars';
 
 @InputType()
 export class DeleteOneIndexInput {
-  @IDField(() => UUIDScalarType, {
+  @Field(() => UUIDScalarType, {
     description: 'The id of the custom index to delete.',
   })
   @IsUUID()

--- a/packages/twenty-server/src/engine/metadata-modules/logic-function/dtos/logic-function-id.input.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/logic-function/dtos/logic-function-id.input.ts
@@ -1,9 +1,7 @@
-import { ID, InputType } from '@nestjs/graphql';
-
-import { IDField } from '@ptc-org/nestjs-query-graphql';
+import { Field, ID, InputType } from '@nestjs/graphql';
 
 @InputType()
 export class LogicFunctionIdInput {
-  @IDField(() => ID, { description: 'The id of the function.' })
+  @Field(() => ID, { description: 'The id of the function.' })
   id!: string;
 }

--- a/packages/twenty-server/src/engine/metadata-modules/minimal-metadata/dtos/minimal-object-metadata.dto.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/minimal-metadata/dtos/minimal-object-metadata.dto.ts
@@ -1,12 +1,10 @@
 import { Field, ObjectType } from '@nestjs/graphql';
 
-import { IDField } from '@ptc-org/nestjs-query-graphql';
-
 import { UUIDScalarType } from 'src/engine/api/graphql/workspace-schema-builder/graphql-types/scalars';
 
 @ObjectType('MinimalObjectMetadata')
 export class MinimalObjectMetadataDTO {
-  @IDField(() => UUIDScalarType)
+  @Field(() => UUIDScalarType)
   id: string;
 
   @Field()

--- a/packages/twenty-server/src/engine/metadata-modules/minimal-metadata/dtos/minimal-view.dto.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/minimal-metadata/dtos/minimal-view.dto.ts
@@ -1,13 +1,11 @@
 import { Field, ObjectType } from '@nestjs/graphql';
-
-import { IDField } from '@ptc-org/nestjs-query-graphql';
 import { ViewKey, ViewType } from 'twenty-shared/types';
 
 import { UUIDScalarType } from 'src/engine/api/graphql/workspace-schema-builder/graphql-types/scalars';
 
 @ObjectType('MinimalView')
 export class MinimalViewDTO {
-  @IDField(() => UUIDScalarType)
+  @Field(() => UUIDScalarType)
   id: string;
 
   @Field(() => ViewType)

--- a/packages/twenty-server/src/engine/metadata-modules/object-metadata/dtos/delete-object.input.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/object-metadata/dtos/delete-object.input.ts
@@ -1,13 +1,11 @@
-import { InputType } from '@nestjs/graphql';
-
-import { IDField } from '@ptc-org/nestjs-query-graphql';
+import { Field, InputType } from '@nestjs/graphql';
 import { IsUUID } from 'class-validator';
 
 import { UUIDScalarType } from 'src/engine/api/graphql/workspace-schema-builder/graphql-types/scalars';
 
 @InputType()
 export class DeleteOneObjectInput {
-  @IDField(() => UUIDScalarType, {
+  @Field(() => UUIDScalarType, {
     description: 'The id of the record to delete.',
   })
   @IsUUID()

--- a/packages/twenty-server/src/engine/metadata-modules/page-layout-tab/dtos/page-layout-tab.dto.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/page-layout-tab/dtos/page-layout-tab.dto.ts
@@ -5,8 +5,6 @@ import {
   ObjectType,
   registerEnumType,
 } from '@nestjs/graphql';
-
-import { IDField } from '@ptc-org/nestjs-query-graphql';
 import { PageLayoutTabLayoutMode } from 'twenty-shared/types';
 
 import { UUIDScalarType } from 'src/engine/api/graphql/workspace-schema-builder/graphql-types/scalars';
@@ -19,7 +17,7 @@ registerEnumType(PageLayoutTabLayoutMode, {
 
 @ObjectType('PageLayoutTab')
 export class PageLayoutTabDTO {
-  @IDField(() => UUIDScalarType)
+  @Field(() => UUIDScalarType)
   id: string;
 
   @Field(() => UUIDScalarType, { nullable: false })

--- a/packages/twenty-server/src/engine/metadata-modules/page-layout-widget/dtos/page-layout-widget.dto.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/page-layout-widget/dtos/page-layout-widget.dto.ts
@@ -4,8 +4,6 @@ import {
   ObjectType,
   registerEnumType,
 } from '@nestjs/graphql';
-
-import { IDField } from '@ptc-org/nestjs-query-graphql';
 import GraphQLJSON from 'graphql-type-json';
 import {
   PageLayoutWidgetConditionalDisplay,
@@ -38,7 +36,7 @@ export class GridPositionDTO {
 
 @ObjectType('PageLayoutWidget')
 export class PageLayoutWidgetDTO {
-  @IDField(() => UUIDScalarType)
+  @Field(() => UUIDScalarType)
   id: string;
 
   @Field(() => UUIDScalarType, { nullable: false })

--- a/packages/twenty-server/src/engine/metadata-modules/page-layout/dtos/page-layout.dto.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/page-layout/dtos/page-layout.dto.ts
@@ -1,6 +1,4 @@
 import { Field, ObjectType, registerEnumType } from '@nestjs/graphql';
-
-import { IDField } from '@ptc-org/nestjs-query-graphql';
 import { SerializedRelation } from 'twenty-shared/types';
 
 import { UUIDScalarType } from 'src/engine/api/graphql/workspace-schema-builder/graphql-types/scalars';
@@ -11,7 +9,7 @@ registerEnumType(PageLayoutType, { name: 'PageLayoutType' });
 
 @ObjectType('PageLayout')
 export class PageLayoutDTO {
-  @IDField(() => UUIDScalarType)
+  @Field(() => UUIDScalarType)
   id: string;
 
   @Field({ nullable: false })

--- a/packages/twenty-server/src/engine/metadata-modules/view-field-group/dtos/inputs/delete-view-field-group.input.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/view-field-group/dtos/inputs/delete-view-field-group.input.ts
@@ -1,13 +1,11 @@
-import { InputType } from '@nestjs/graphql';
-
-import { IDField } from '@ptc-org/nestjs-query-graphql';
+import { Field, InputType } from '@nestjs/graphql';
 import { IsUUID } from 'class-validator';
 
 import { UUIDScalarType } from 'src/engine/api/graphql/workspace-schema-builder/graphql-types/scalars';
 
 @InputType()
 export class DeleteViewFieldGroupInput {
-  @IDField(() => UUIDScalarType, {
+  @Field(() => UUIDScalarType, {
     description: 'The id of the view field group to delete.',
   })
   @IsUUID()

--- a/packages/twenty-server/src/engine/metadata-modules/view-field-group/dtos/inputs/destroy-view-field-group.input.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/view-field-group/dtos/inputs/destroy-view-field-group.input.ts
@@ -1,13 +1,11 @@
-import { InputType } from '@nestjs/graphql';
-
-import { IDField } from '@ptc-org/nestjs-query-graphql';
+import { Field, InputType } from '@nestjs/graphql';
 import { IsUUID } from 'class-validator';
 
 import { UUIDScalarType } from 'src/engine/api/graphql/workspace-schema-builder/graphql-types/scalars';
 
 @InputType()
 export class DestroyViewFieldGroupInput {
-  @IDField(() => UUIDScalarType, {
+  @Field(() => UUIDScalarType, {
     description: 'The id of the view field group to destroy.',
   })
   @IsUUID()

--- a/packages/twenty-server/src/engine/metadata-modules/view-field-group/dtos/view-field-group.dto.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/view-field-group/dtos/view-field-group.dto.ts
@@ -1,14 +1,12 @@
 import { Field, HideField, ObjectType } from '@nestjs/graphql';
 
-import { IDField } from '@ptc-org/nestjs-query-graphql';
-
 import { UUIDScalarType } from 'src/engine/api/graphql/workspace-schema-builder/graphql-types/scalars';
 import { type ViewFieldGroupOverrides } from 'src/engine/metadata-modules/view-field-group/entities/view-field-group.entity';
 import { ViewFieldDTO } from 'src/engine/metadata-modules/view-field/dtos/view-field.dto';
 
 @ObjectType('ViewFieldGroup')
 export class ViewFieldGroupDTO {
-  @IDField(() => UUIDScalarType)
+  @Field(() => UUIDScalarType)
   id: string;
 
   @Field({ nullable: false })

--- a/packages/twenty-server/src/engine/metadata-modules/view-field/dtos/inputs/delete-view-field.input.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/view-field/dtos/inputs/delete-view-field.input.ts
@@ -1,13 +1,11 @@
-import { InputType } from '@nestjs/graphql';
-
-import { IDField } from '@ptc-org/nestjs-query-graphql';
+import { Field, InputType } from '@nestjs/graphql';
 import { IsUUID } from 'class-validator';
 
 import { UUIDScalarType } from 'src/engine/api/graphql/workspace-schema-builder/graphql-types/scalars';
 
 @InputType()
 export class DeleteViewFieldInput {
-  @IDField(() => UUIDScalarType, {
+  @Field(() => UUIDScalarType, {
     description: 'The id of the view field to delete.',
   })
   @IsUUID()

--- a/packages/twenty-server/src/engine/metadata-modules/view-field/dtos/inputs/destroy-view-field.input.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/view-field/dtos/inputs/destroy-view-field.input.ts
@@ -1,13 +1,11 @@
-import { InputType } from '@nestjs/graphql';
-
-import { IDField } from '@ptc-org/nestjs-query-graphql';
+import { Field, InputType } from '@nestjs/graphql';
 import { IsUUID } from 'class-validator';
 
 import { UUIDScalarType } from 'src/engine/api/graphql/workspace-schema-builder/graphql-types/scalars';
 
 @InputType()
 export class DestroyViewFieldInput {
-  @IDField(() => UUIDScalarType, {
+  @Field(() => UUIDScalarType, {
     description: 'The id of the view field to destroy.',
   })
   @IsUUID()

--- a/packages/twenty-server/src/engine/metadata-modules/view-field/dtos/view-field.dto.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/view-field/dtos/view-field.dto.ts
@@ -4,8 +4,6 @@ import {
   ObjectType,
   registerEnumType,
 } from '@nestjs/graphql';
-
-import { IDField } from '@ptc-org/nestjs-query-graphql';
 import { AggregateOperations } from 'twenty-shared/types';
 
 import { UUIDScalarType } from 'src/engine/api/graphql/workspace-schema-builder/graphql-types/scalars';
@@ -15,7 +13,7 @@ registerEnumType(AggregateOperations, { name: 'AggregateOperations' });
 
 @ObjectType('ViewField')
 export class ViewFieldDTO {
-  @IDField(() => UUIDScalarType)
+  @Field(() => UUIDScalarType)
   id: string;
 
   @Field(() => UUIDScalarType, { nullable: false })

--- a/packages/twenty-server/src/engine/metadata-modules/view-filter-group/dtos/inputs/delete-view-filter-group.input.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/view-filter-group/dtos/inputs/delete-view-filter-group.input.ts
@@ -1,13 +1,11 @@
-import { InputType } from '@nestjs/graphql';
-
-import { IDField } from '@ptc-org/nestjs-query-graphql';
+import { Field, InputType } from '@nestjs/graphql';
 import { IsUUID } from 'class-validator';
 
 import { UUIDScalarType } from 'src/engine/api/graphql/workspace-schema-builder/graphql-types/scalars';
 
 @InputType()
 export class DeleteViewFilterGroupInput {
-  @IDField(() => UUIDScalarType, {
+  @Field(() => UUIDScalarType, {
     description: 'The id of the view filter group to delete.',
   })
   @IsUUID()

--- a/packages/twenty-server/src/engine/metadata-modules/view-filter-group/dtos/inputs/destroy-view-filter-group.input.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/view-filter-group/dtos/inputs/destroy-view-filter-group.input.ts
@@ -1,13 +1,11 @@
-import { InputType } from '@nestjs/graphql';
-
-import { IDField } from '@ptc-org/nestjs-query-graphql';
+import { Field, InputType } from '@nestjs/graphql';
 import { IsUUID } from 'class-validator';
 
 import { UUIDScalarType } from 'src/engine/api/graphql/workspace-schema-builder/graphql-types/scalars';
 
 @InputType()
 export class DestroyViewFilterGroupInput {
-  @IDField(() => UUIDScalarType, {
+  @Field(() => UUIDScalarType, {
     description: 'The id of the view filter group to destroy.',
   })
   @IsUUID()

--- a/packages/twenty-server/src/engine/metadata-modules/view-filter-group/dtos/view-filter-group.dto.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/view-filter-group/dtos/view-filter-group.dto.ts
@@ -1,6 +1,4 @@
 import { Field, ObjectType, registerEnumType } from '@nestjs/graphql';
-
-import { IDField } from '@ptc-org/nestjs-query-graphql';
 import { ViewFilterGroupLogicalOperator } from 'twenty-shared/types';
 
 import { UUIDScalarType } from 'src/engine/api/graphql/workspace-schema-builder/graphql-types/scalars';
@@ -11,7 +9,7 @@ registerEnumType(ViewFilterGroupLogicalOperator, {
 
 @ObjectType('ViewFilterGroup')
 export class ViewFilterGroupDTO {
-  @IDField(() => UUIDScalarType)
+  @Field(() => UUIDScalarType)
   id: string;
 
   @Field(() => UUIDScalarType, { nullable: true })

--- a/packages/twenty-server/src/engine/metadata-modules/view-filter/dtos/inputs/delete-view-filter.input.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/view-filter/dtos/inputs/delete-view-filter.input.ts
@@ -1,13 +1,11 @@
-import { InputType } from '@nestjs/graphql';
-
-import { IDField } from '@ptc-org/nestjs-query-graphql';
+import { Field, InputType } from '@nestjs/graphql';
 import { IsUUID } from 'class-validator';
 
 import { UUIDScalarType } from 'src/engine/api/graphql/workspace-schema-builder/graphql-types/scalars';
 
 @InputType()
 export class DeleteViewFilterInput {
-  @IDField(() => UUIDScalarType, {
+  @Field(() => UUIDScalarType, {
     description: 'The id of the view filter to delete.',
   })
   @IsUUID()

--- a/packages/twenty-server/src/engine/metadata-modules/view-filter/dtos/inputs/destroy-view-filter.input.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/view-filter/dtos/inputs/destroy-view-filter.input.ts
@@ -1,13 +1,11 @@
-import { InputType } from '@nestjs/graphql';
-
-import { IDField } from '@ptc-org/nestjs-query-graphql';
+import { Field, InputType } from '@nestjs/graphql';
 import { IsUUID } from 'class-validator';
 
 import { UUIDScalarType } from 'src/engine/api/graphql/workspace-schema-builder/graphql-types/scalars';
 
 @InputType()
 export class DestroyViewFilterInput {
-  @IDField(() => UUIDScalarType, {
+  @Field(() => UUIDScalarType, {
     description: 'The id of the view filter to destroy.',
   })
   @IsUUID()

--- a/packages/twenty-server/src/engine/metadata-modules/view-filter/dtos/view-filter.dto.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/view-filter/dtos/view-filter.dto.ts
@@ -1,6 +1,4 @@
 import { Field, ObjectType, registerEnumType } from '@nestjs/graphql';
-
-import { IDField } from '@ptc-org/nestjs-query-graphql';
 import GraphQLJSON from 'graphql-type-json';
 import { ViewFilterOperand } from 'twenty-shared/types';
 
@@ -13,7 +11,7 @@ registerEnumType(ViewFilterOperand, {
 
 @ObjectType('ViewFilter')
 export class ViewFilterDTO {
-  @IDField(() => UUIDScalarType)
+  @Field(() => UUIDScalarType)
   id: string;
 
   @Field(() => UUIDScalarType, { nullable: false })

--- a/packages/twenty-server/src/engine/metadata-modules/view-group/dtos/inputs/delete-view-group.input.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/view-group/dtos/inputs/delete-view-group.input.ts
@@ -1,13 +1,11 @@
-import { InputType } from '@nestjs/graphql';
-
-import { IDField } from '@ptc-org/nestjs-query-graphql';
+import { Field, InputType } from '@nestjs/graphql';
 import { IsUUID } from 'class-validator';
 
 import { UUIDScalarType } from 'src/engine/api/graphql/workspace-schema-builder/graphql-types/scalars';
 
 @InputType()
 export class DeleteViewGroupInput {
-  @IDField(() => UUIDScalarType, {
+  @Field(() => UUIDScalarType, {
     description: 'The id of the view group to delete.',
   })
   @IsUUID()

--- a/packages/twenty-server/src/engine/metadata-modules/view-group/dtos/inputs/destroy-view-group.input.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/view-group/dtos/inputs/destroy-view-group.input.ts
@@ -1,13 +1,11 @@
-import { InputType } from '@nestjs/graphql';
-
-import { IDField } from '@ptc-org/nestjs-query-graphql';
+import { Field, InputType } from '@nestjs/graphql';
 import { IsUUID } from 'class-validator';
 
 import { UUIDScalarType } from 'src/engine/api/graphql/workspace-schema-builder/graphql-types/scalars';
 
 @InputType()
 export class DestroyViewGroupInput {
-  @IDField(() => UUIDScalarType, {
+  @Field(() => UUIDScalarType, {
     description: 'The id of the view group to destroy.',
   })
   @IsUUID()

--- a/packages/twenty-server/src/engine/metadata-modules/view-group/dtos/view-group.dto.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/view-group/dtos/view-group.dto.ts
@@ -1,12 +1,10 @@
 import { Field, ObjectType } from '@nestjs/graphql';
 
-import { IDField } from '@ptc-org/nestjs-query-graphql';
-
 import { UUIDScalarType } from 'src/engine/api/graphql/workspace-schema-builder/graphql-types/scalars';
 
 @ObjectType('ViewGroup')
 export class ViewGroupDTO {
-  @IDField(() => UUIDScalarType)
+  @Field(() => UUIDScalarType)
   id: string;
 
   @Field({ nullable: false, defaultValue: true })

--- a/packages/twenty-server/src/engine/metadata-modules/view-sort/dtos/inputs/delete-view-sort.input.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/view-sort/dtos/inputs/delete-view-sort.input.ts
@@ -1,13 +1,11 @@
-import { InputType } from '@nestjs/graphql';
-
-import { IDField } from '@ptc-org/nestjs-query-graphql';
+import { Field, InputType } from '@nestjs/graphql';
 import { IsUUID } from 'class-validator';
 
 import { UUIDScalarType } from 'src/engine/api/graphql/workspace-schema-builder/graphql-types/scalars';
 
 @InputType()
 export class DeleteViewSortInput {
-  @IDField(() => UUIDScalarType, {
+  @Field(() => UUIDScalarType, {
     description: 'The id of the view sort to delete.',
   })
   @IsUUID()

--- a/packages/twenty-server/src/engine/metadata-modules/view-sort/dtos/inputs/destroy-view-sort.input.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/view-sort/dtos/inputs/destroy-view-sort.input.ts
@@ -1,13 +1,11 @@
-import { InputType } from '@nestjs/graphql';
-
-import { IDField } from '@ptc-org/nestjs-query-graphql';
+import { Field, InputType } from '@nestjs/graphql';
 import { IsUUID } from 'class-validator';
 
 import { UUIDScalarType } from 'src/engine/api/graphql/workspace-schema-builder/graphql-types/scalars';
 
 @InputType()
 export class DestroyViewSortInput {
-  @IDField(() => UUIDScalarType, {
+  @Field(() => UUIDScalarType, {
     description: 'The id of the view sort to destroy.',
   })
   @IsUUID()

--- a/packages/twenty-server/src/engine/metadata-modules/view-sort/dtos/view-sort.dto.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/view-sort/dtos/view-sort.dto.ts
@@ -1,7 +1,5 @@
 import { Field, ObjectType, registerEnumType } from '@nestjs/graphql';
 
-import { IDField } from '@ptc-org/nestjs-query-graphql';
-
 import { UUIDScalarType } from 'src/engine/api/graphql/workspace-schema-builder/graphql-types/scalars';
 import { ViewSortDirection } from 'twenty-shared/types';
 
@@ -9,7 +7,7 @@ registerEnumType(ViewSortDirection, { name: 'ViewSortDirection' });
 
 @ObjectType('ViewSort')
 export class ViewSortDTO {
-  @IDField(() => UUIDScalarType)
+  @Field(() => UUIDScalarType)
   id: string;
 
   @Field(() => UUIDScalarType, { nullable: false })

--- a/packages/twenty-server/src/engine/metadata-modules/view/dtos/inputs/delete-view.input.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/view/dtos/inputs/delete-view.input.ts
@@ -1,13 +1,11 @@
-import { InputType } from '@nestjs/graphql';
-
-import { IDField } from '@ptc-org/nestjs-query-graphql';
+import { Field, InputType } from '@nestjs/graphql';
 import { IsUUID } from 'class-validator';
 
 import { UUIDScalarType } from 'src/engine/api/graphql/workspace-schema-builder/graphql-types/scalars';
 
 @InputType()
 export class DeleteViewInput {
-  @IDField(() => UUIDScalarType, {
+  @Field(() => UUIDScalarType, {
     description: 'The id of the view to delete.',
   })
   @IsUUID()

--- a/packages/twenty-server/src/engine/metadata-modules/view/dtos/inputs/destroy-view.input.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/view/dtos/inputs/destroy-view.input.ts
@@ -1,13 +1,11 @@
-import { InputType } from '@nestjs/graphql';
-
-import { IDField } from '@ptc-org/nestjs-query-graphql';
+import { Field, InputType } from '@nestjs/graphql';
 import { IsUUID } from 'class-validator';
 
 import { UUIDScalarType } from 'src/engine/api/graphql/workspace-schema-builder/graphql-types/scalars';
 
 @InputType()
 export class DestroyViewInput {
-  @IDField(() => UUIDScalarType, {
+  @Field(() => UUIDScalarType, {
     description: 'The id of the view to destroy.',
   })
   @IsUUID()

--- a/packages/twenty-server/src/engine/metadata-modules/view/dtos/view.dto.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/view/dtos/view.dto.ts
@@ -5,8 +5,6 @@ import {
   ObjectType,
   registerEnumType,
 } from '@nestjs/graphql';
-
-import { IDField } from '@ptc-org/nestjs-query-graphql';
 import {
   AggregateOperations,
   ViewCalendarLayout,
@@ -33,7 +31,7 @@ registerEnumType(ViewVisibility, { name: 'ViewVisibility' });
 
 @ObjectType('View')
 export class ViewDTO {
-  @IDField(() => UUIDScalarType)
+  @Field(() => UUIDScalarType)
   id: string;
 
   @Field({ nullable: false })


### PR DESCRIPTION
## What

Replaces `@IDField(() => UUIDScalarType)` from `@ptc-org/nestjs-query-graphql` with the native `@Field(() => UUIDScalarType)` (`@nestjs/graphql`) across 50 DTOs and entities that are **not** wired to a nestjs-query auto-resolver.

This continues the incremental migration off `@ptc-org/nestjs-query`.

## Why

These 50 types only used `IDField` to type their `id` column as a UUID scalar. Since none of them are attached to a `NestjsQueryGraphQLModule.forFeature` resolver, `IDField` carries no extra behavior here — it's a plain field decorator.

