### PR TITLE
docs: add AGENTS.md with Cursor Cloud dev environment setup notes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,58 @@
+# AGENTS.md
+
+Twenty is an open-source CRM built as an Nx monorepo managed with Yarn 4.
+See `CLAUDE.md` and `README.md` for the full command reference (dev, test,
+lint, build, database, GraphQL). This file only captures durable,
+non-obvious guidance for agents working in the Cursor Cloud environment.
+
+## Cursor Cloud specific instructions
+
+### Services (Twenty CRM)
+The core product is `twenty-front` (React UI, http://localhost:3001) +
+`twenty-server` (NestJS API/GraphQL, http://localhost:3000) + the server
+`worker` (BullMQ background jobs), backed by **PostgreSQL 16** and **Redis**
+(both required). ClickHouse, SMTP, OAuth, Stripe and AI providers are optional.
+
+- Start everything: `yarn start` (runs front + server + worker concurrently).
+- One-time / idempotent env setup (Postgres+Redis, `.env` files, DB migrations):
+  `bash packages/twenty-utils/setup-dev-env.sh`. Seed dev data with
+  `npx nx database:reset twenty-server`.
+- Postgres and Redis run as **local system services** (installed via apt), not
+  Docker. `setup-dev-env.sh` auto-detects and starts the local cluster
+  (`pg_ctlcluster 16 main start`, `service redis-server start`). Docker is not
+  installed in this environment.
+- Login (dev): `SIGN_IN_PREFILLED=true`, so click "Continue with Email" — the
+  credentials are prefilled. Default account is `tim@apple.dev` /
+  `tim@apple.dev` (workspace "Apple").
+
+### Node version (must use Node 24)
+The repo requires Node `^24.5.0` (`.nvmrc` pins `24.16.0`). Node 24 is installed
+via nvm and set as the default. The cloud image injects `/exec-daemon/node`
+(v22) at the front of `PATH`, which would otherwise shadow it, so `~/.bashrc`
+prepends the Node 24 bin dir. **Always run commands in a login bash shell**
+(e.g. `bash -lc '...'`) so the correct Node and `yarn` (via corepack) are used.
+
+### Critical gotcha: nx hangs unless `NODE_NO_WARNINGS=1` is set
+nx forces `FORCE_COLOR=true` on child processes, but the cloud image sets
+`NO_COLOR=1` globally. On Node 24 this conflict makes Node emit a process
+warning *inside a worker thread* (`@prettier/sync`, used by
+`twenty-shared/scripts/generateBarrels.ts`) that **deadlocks the worker and
+hangs the task forever**. This blocks `nx build`, `nx database:init`,
+`setup-dev-env.sh`, and `yarn start` (the server build depends on
+`twenty-shared`'s `generateBarrels`).
+
+The fix is `export NODE_NO_WARNINGS=1`, which is set in `~/.bashrc` and picked
+up by any login shell (`~/.profile` sources `~/.bashrc`, which has no
+interactive guard). If you ever see a build/`database:init` step sit at
+`> tsx packages/twenty-shared/scripts/generateBarrels.ts` with no progress,
+confirm `NODE_NO_WARNINGS=1` is set in the running shell.
+
+### nx daemon
+The nx daemon caches the environment from when it first started. If you change
+env vars (e.g. the color/warning vars above) and tasks still misbehave, run
+`npx nx reset` to restart the daemon so it picks up the new environment.
+
+### Lint / test / build
+Use the standard nx commands (documented in `CLAUDE.md`), e.g.
+`npx nx lint <project>`, `npx nx test <project>`, `npx nx build <project>`.
+`twenty-shared` must be built before `twenty-front` / `twenty-server`.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Sets up the Twenty CRM development environment for Cursor Cloud agents and documents the durable, non-obvious gotchas discovered during setup.

The only code change is a new root `AGENTS.md` with a `## Cursor Cloud specific instructions` section. Environment/dependency work (Node 24, PostgreSQL 16, Redis, `yarn install`, DB migrations + seed) was done on the VM and captured via the startup update script (`yarn install`) and a one-time `~/.bashrc` edit.

## What was set up
- **Node 24.16.0** (repo requires `^24.5.0`, `.nvmrc` pins `24.16.0`) via nvm, plus Yarn 4.13.0 via corepack. `~/.bashrc` prepends the Node 24 bin dir because the cloud image injects an older `/exec-daemon/node` (v22) ahead of it.
- **PostgreSQL 16** and **Redis** installed as local system services (Docker is not installed; `setup-dev-env.sh` auto-detects the local cluster).
- `yarn install`, `bash packages/twenty-utils/setup-dev-env.sh`, and `npx nx database:reset twenty-server` (migrations + seed).

## Key gotcha documented in AGENTS.md
nx forces `FORCE_COLOR=true` on child processes while the cloud image sets `NO_COLOR=1` globally. On Node 24 this conflict makes Node emit a process warning inside a worker thread (`@prettier/sync`, used by `twenty-shared/scripts/generateBarrels.ts`) that deadlocks and hangs `nx build`, `nx database:init`, `setup-dev-env.sh`, and `yarn start`. The fix is `export NODE_NO_WARNINGS=1` (set in `~/.bashrc`, picked up by login shells).

## Verification
- Frontend (`:3001`) and backend (`:3000`, `/healthz` = 200) and BullMQ worker all running via `yarn start`.
- Lint: `npx nx lint twenty-shared` — 0 warnings/errors.
- Tests: `npx nx test twenty-shared` — 1644 passed.
- Build: `npx nx build twenty-shared` — dist produced.
- Hello-world: logged in as `tim@apple.dev` and created a company record `Cursor Cloud Agent Inc` (`cursor.com`), verified persisted in the database.

[twenty_crm_create_company_record.mp4](https://cursor.com/agents/bc-b66462ed-e22b-4f93-a753-d54417f8bcb6/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Ftwenty_crm_create_company_record.mp4)
[Created company record](https://cursor.com/agents/bc-b66462ed-e22b-4f93-a753-d54417f8bcb6/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Ftwenty_crm_company_created.webp)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b66462ed-e22b-4f93-a753-d54417f8bcb6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b66462ed-e22b-4f93-a753-d54417f8bcb6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/22883?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

