### PR TITLE
added a counter to fix the workflow run stuck

### DIFF
--- a/packages/twenty-server/src/modules/workflow/workflow-runner/workflow-run-queue/workspace-services/workflow-run-enqueue.workspace-service.ts
+++ b/packages/twenty-server/src/modules/workflow/workflow-runner/workflow-run-queue/workspace-services/workflow-run-enqueue.workspace-service.ts
@@ -110,18 +110,31 @@ export class WorkflowRunEnqueueWorkspaceService {
               status: WorkflowRunStatus.ENQUEUED,
             });
 
+            const failedRunIds: string[] = [];
+
             for (const workflowRunId of batchIds) {
-              await this.messageQueueService.add<RunWorkflowJobData>(
-                RunWorkflowJob.name,
-                {
-                  workflowRunId,
-                  workspaceId,
-                },
-              );
+              try {
+                await this.messageQueueService.add<RunWorkflowJobData>(
+                  RunWorkflowJob.name,
+                  {
+                    workflowRunId,
+                    workspaceId,
+                  },
+                );
+              } catch {
+                failedRunIds.push(workflowRunId);
+              }
             }
 
-            totalEnqueuedCount += batchRuns.length;
-            remainingWorkflowRunToEnqueueCount -= batchRuns.length;
+            if (failedRunIds.length > 0) {
+              await workflowRunRepository.update(failedRunIds, {
+                enqueuedAt: null,
+                status: WorkflowRunStatus.NOT_STARTED,
+              });
+            }
+
+            totalEnqueuedCount += batchRuns.length - failedRunIds.length;
+            remainingWorkflowRunToEnqueueCount -= batchRuns.length - failedRunIds.length;
           }
 
           if (totalEnqueuedCount === 0) {

--- a/packages/twenty-server/src/modules/workflow/workflow-runner/workflow-run-queue/workspace-services/workflow-run-enqueue.workspace-service.ts
+++ b/packages/twenty-server/src/modules/workflow/workflow-runner/workflow-run-queue/workspace-services/workflow-run-enqueue.workspace-service.ts
@@ -134,8 +134,7 @@ export class WorkflowRunEnqueueWorkspaceService {
             }
 
             totalEnqueuedCount += batchRuns.length - failedRunIds.length;
-            remainingWorkflowRunToEnqueueCount -=
-              batchRuns.length - failedRunIds.length;
+            remainingWorkflowRunToEnqueueCount -= batchRuns.length;
           }
 
           if (totalEnqueuedCount === 0) {

--- a/packages/twenty-server/src/modules/workflow/workflow-runner/workflow-run-queue/workspace-services/workflow-run-enqueue.workspace-service.ts
+++ b/packages/twenty-server/src/modules/workflow/workflow-runner/workflow-run-queue/workspace-services/workflow-run-enqueue.workspace-service.ts
@@ -134,7 +134,8 @@ export class WorkflowRunEnqueueWorkspaceService {
             }
 
             totalEnqueuedCount += batchRuns.length - failedRunIds.length;
-            remainingWorkflowRunToEnqueueCount -= batchRuns.length - failedRunIds.length;
+            remainingWorkflowRunToEnqueueCount -=
+              batchRuns.length - failedRunIds.length;
           }
 
           if (totalEnqueuedCount === 0) {


### PR DESCRIPTION
closes #22082 

The fix wraps each messageQueueService.add() call in a per-run try-catch. Any run that fails to publish is immediately reverted from ENQUEUED back to NOT_STARTED with enqueuedAt: null, and only successfully published runs count toward throttle/cache bookkeeping. This eliminates the terminal "stuck ENQUEUED" state where the DB says a job is queued but no BullMQ job exists, making failed publishes automatically retryable in the next enqueue cycle. 

if a publish fails, the cause is almost certainly systemic (Redis down, misconfigured queue, etc.). Retrying in the same tight loop is wasteful and can generate a lot of DB writes (ENQUEUED → revert → ENQUEUED → revert...) in seconds. Waiting ~1 minute for the next cron cycle is a natural backoff.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/22895?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

