### PR TITLE
fix(server): finalize workflow runs stuck in STOPPING

### DIFF
--- a/packages/twenty-server/src/modules/workflow/workflow-runner/workflow-run-queue/command/workflow-handle-staled-runs.command.ts
+++ b/packages/twenty-server/src/modules/workflow/workflow-runner/workflow-run-queue/command/workflow-handle-staled-runs.command.ts
@@ -49,6 +49,10 @@ export class WorkflowHandleStaledRunsCommand extends CommandRunner {
         await this.workflowHandleStaledRunsWorkspaceService.handleStaledRunsForWorkspace(
           workspaceId,
         );
+
+        await this.workflowHandleStaledRunsWorkspaceService.handleStuckStoppingRunsForWorkspace(
+          workspaceId,
+        );
       } catch (error) {
         this.logger.error(
           `Failed to handle staled runs for workspace ${workspaceId}`,

--- a/packages/twenty-server/src/modules/workflow/workflow-runner/workflow-run-queue/command/workflow-handle-staled-runs.command.ts
+++ b/packages/twenty-server/src/modules/workflow/workflow-runner/workflow-run-queue/command/workflow-handle-staled-runs.command.ts
@@ -49,13 +49,20 @@ export class WorkflowHandleStaledRunsCommand extends CommandRunner {
         await this.workflowHandleStaledRunsWorkspaceService.handleStaledRunsForWorkspace(
           workspaceId,
         );
+      } catch (error) {
+        this.logger.error(
+          `Failed to handle staled runs for workspace ${workspaceId}`,
+          error instanceof Error ? error.stack : String(error),
+        );
+      }
 
+      try {
         await this.workflowHandleStaledRunsWorkspaceService.handleStuckStoppingRunsForWorkspace(
           workspaceId,
         );
       } catch (error) {
         this.logger.error(
-          `Failed to handle staled runs for workspace ${workspaceId}`,
+          `Failed to handle stuck stopping runs for workspace ${workspaceId}`,
           error instanceof Error ? error.stack : String(error),
         );
       }

--- a/packages/twenty-server/src/modules/workflow/workflow-runner/workflow-run-queue/command/workflow-handle-staled-runs.command.ts
+++ b/packages/twenty-server/src/modules/workflow/workflow-runner/workflow-run-queue/command/workflow-handle-staled-runs.command.ts
@@ -49,20 +49,13 @@ export class WorkflowHandleStaledRunsCommand extends CommandRunner {
         await this.workflowHandleStaledRunsWorkspaceService.handleStaledRunsForWorkspace(
           workspaceId,
         );
-      } catch (error) {
-        this.logger.error(
-          `Failed to handle staled runs for workspace ${workspaceId}`,
-          error instanceof Error ? error.stack : String(error),
-        );
-      }
 
-      try {
         await this.workflowHandleStaledRunsWorkspaceService.handleStuckStoppingRunsForWorkspace(
           workspaceId,
         );
       } catch (error) {
         this.logger.error(
-          `Failed to handle stuck stopping runs for workspace ${workspaceId}`,
+          `Failed to handle staled runs for workspace ${workspaceId}`,
           error instanceof Error ? error.stack : String(error),
         );
       }

--- a/packages/twenty-server/src/modules/workflow/workflow-runner/workflow-run-queue/constants/stuck-stopping-runs-threshold.ts
+++ b/packages/twenty-server/src/modules/workflow/workflow-runner/workflow-run-queue/constants/stuck-stopping-runs-threshold.ts
@@ -1,6 +1,1 @@
-// A run only stays in STOPPING while an in-flight worker execution finalizes it.
-// If no worker is executing it (worker crashed, or the step is awaiting an
-// external event that will never arrive), it never reaches STOPPED on its own.
-// The threshold must stay above the longest legitimate step execution so we
-// don't force-stop a run whose step is still genuinely running.
 export const STUCK_STOPPING_RUNS_THRESHOLD_MS = 60 * 60 * 1000; // 1 hour

--- a/packages/twenty-server/src/modules/workflow/workflow-runner/workflow-run-queue/constants/stuck-stopping-runs-threshold.ts
+++ b/packages/twenty-server/src/modules/workflow/workflow-runner/workflow-run-queue/constants/stuck-stopping-runs-threshold.ts
@@ -1,0 +1,6 @@
+// A run only stays in STOPPING while an in-flight worker execution finalizes it.
+// If no worker is executing it (worker crashed, or the step is awaiting an
+// external event that will never arrive), it never reaches STOPPED on its own.
+// The threshold must stay above the longest legitimate step execution so we
+// don't force-stop a run whose step is still genuinely running.
+export const STUCK_STOPPING_RUNS_THRESHOLD_MS = 60 * 60 * 1000; // 1 hour

--- a/packages/twenty-server/src/modules/workflow/workflow-runner/workflow-run-queue/cron/jobs/workflow-handle-staled-runs.cron.job.ts
+++ b/packages/twenty-server/src/modules/workflow/workflow-runner/workflow-run-queue/cron/jobs/workflow-handle-staled-runs.cron.job.ts
@@ -18,6 +18,7 @@ import { WorkspaceEntity } from 'src/engine/core-modules/workspace/workspace.ent
 import { getWorkspaceSchemaName } from 'src/engine/workspace-datasource/utils/get-workspace-schema-name.util';
 import { WorkflowRunStatus } from 'src/modules/workflow/common/standard-objects/workflow-run.workspace-entity';
 import { STALED_RUNS_THRESHOLD_MS } from 'src/modules/workflow/workflow-runner/workflow-run-queue/constants/staled-runs-threshold';
+import { STUCK_STOPPING_RUNS_THRESHOLD_MS } from 'src/modules/workflow/workflow-runner/workflow-run-queue/constants/stuck-stopping-runs-threshold';
 import {
   WorkflowHandleStaledRunsJob,
   WorkflowHandleStaledRunsJobData,
@@ -100,9 +101,12 @@ export class WorkflowHandleStaledRunsCronJob {
   }
 
   private async checkAndEnqueue(workspaceId: string): Promise<boolean> {
-    const hasStaledRuns = await this.hasStaledRuns(workspaceId);
+    const [hasStaledRuns, hasStuckStoppingRuns] = await Promise.all([
+      this.hasStaledRuns(workspaceId),
+      this.hasStuckStoppingRuns(workspaceId),
+    ]);
 
-    if (hasStaledRuns) {
+    if (hasStaledRuns || hasStuckStoppingRuns) {
       await this.messageQueueService.add<WorkflowHandleStaledRunsJobData>(
         WorkflowHandleStaledRunsJob.name,
         { workspaceId },
@@ -136,6 +140,20 @@ export class WorkflowHandleStaledRunsCronJob {
     const result = await this.coreDataSource.query(
       `SELECT 1 FROM ${schemaName}."workflowRun" WHERE "status" = $1 AND ("enqueuedAt" < $2 OR "enqueuedAt" IS NULL) LIMIT 1`,
       [WorkflowRunStatus.ENQUEUED, thresholdDate],
+    );
+
+    return result.length > 0;
+  }
+
+  private async hasStuckStoppingRuns(workspaceId: string): Promise<boolean> {
+    const schemaName = getWorkspaceSchemaName(workspaceId);
+    const thresholdDate = new Date(
+      Date.now() - STUCK_STOPPING_RUNS_THRESHOLD_MS,
+    );
+
+    const result = await this.coreDataSource.query(
+      `SELECT 1 FROM ${schemaName}."workflowRun" WHERE "status" = $1 AND "updatedAt" < $2 LIMIT 1`,
+      [WorkflowRunStatus.STOPPING, thresholdDate],
     );
 
     return result.length > 0;

--- a/packages/twenty-server/src/modules/workflow/workflow-runner/workflow-run-queue/jobs/workflow-handle-staled-runs.job.ts
+++ b/packages/twenty-server/src/modules/workflow/workflow-runner/workflow-run-queue/jobs/workflow-handle-staled-runs.job.ts
@@ -1,4 +1,4 @@
-import { Scope } from '@nestjs/common';
+import { Logger, Scope } from '@nestjs/common';
 
 import { Process } from 'src/engine/core-modules/message-queue/decorators/process.decorator';
 import { Processor } from 'src/engine/core-modules/message-queue/decorators/processor.decorator';
@@ -11,6 +11,8 @@ export type WorkflowHandleStaledRunsJobData = {
 
 @Processor({ queueName: MessageQueue.workflowQueue, scope: Scope.REQUEST })
 export class WorkflowHandleStaledRunsJob {
+  private readonly logger = new Logger(WorkflowHandleStaledRunsJob.name);
+
   constructor(
     private readonly workflowHandleStaledRunsWorkspaceService: WorkflowHandleStaledRunsWorkspaceService,
   ) {}
@@ -19,21 +21,26 @@ export class WorkflowHandleStaledRunsJob {
   async handle({
     workspaceId,
   }: WorkflowHandleStaledRunsJobData): Promise<void> {
-    const results = await Promise.allSettled([
-      this.workflowHandleStaledRunsWorkspaceService.handleStaledRunsForWorkspace(
+    try {
+      await this.workflowHandleStaledRunsWorkspaceService.handleStaledRunsForWorkspace(
         workspaceId,
-      ),
-      this.workflowHandleStaledRunsWorkspaceService.handleStuckStoppingRunsForWorkspace(
+      );
+    } catch (error) {
+      this.logger.error(
+        `Failed to handle staled runs for workspace ${workspaceId}`,
+        error,
+      );
+    }
+
+    try {
+      await this.workflowHandleStaledRunsWorkspaceService.handleStuckStoppingRunsForWorkspace(
         workspaceId,
-      ),
-    ]);
-
-    const rejection = results.find(
-      (result): result is PromiseRejectedResult => result.status === 'rejected',
-    );
-
-    if (rejection) {
-      throw rejection.reason;
+      );
+    } catch (error) {
+      this.logger.error(
+        `Failed to handle stuck stopping runs for workspace ${workspaceId}`,
+        error,
+      );
     }
   }
 }

--- a/packages/twenty-server/src/modules/workflow/workflow-runner/workflow-run-queue/jobs/workflow-handle-staled-runs.job.ts
+++ b/packages/twenty-server/src/modules/workflow/workflow-runner/workflow-run-queue/jobs/workflow-handle-staled-runs.job.ts
@@ -19,12 +19,21 @@ export class WorkflowHandleStaledRunsJob {
   async handle({
     workspaceId,
   }: WorkflowHandleStaledRunsJobData): Promise<void> {
-    await this.workflowHandleStaledRunsWorkspaceService.handleStaledRunsForWorkspace(
-      workspaceId,
+    const results = await Promise.allSettled([
+      this.workflowHandleStaledRunsWorkspaceService.handleStaledRunsForWorkspace(
+        workspaceId,
+      ),
+      this.workflowHandleStaledRunsWorkspaceService.handleStuckStoppingRunsForWorkspace(
+        workspaceId,
+      ),
+    ]);
+
+    const rejection = results.find(
+      (result): result is PromiseRejectedResult => result.status === 'rejected',
     );
 
-    await this.workflowHandleStaledRunsWorkspaceService.handleStuckStoppingRunsForWorkspace(
-      workspaceId,
-    );
+    if (rejection) {
+      throw rejection.reason;
+    }
   }
 }

--- a/packages/twenty-server/src/modules/workflow/workflow-runner/workflow-run-queue/jobs/workflow-handle-staled-runs.job.ts
+++ b/packages/twenty-server/src/modules/workflow/workflow-runner/workflow-run-queue/jobs/workflow-handle-staled-runs.job.ts
@@ -1,4 +1,4 @@
-import { Logger, Scope } from '@nestjs/common';
+import { Scope } from '@nestjs/common';
 
 import { Process } from 'src/engine/core-modules/message-queue/decorators/process.decorator';
 import { Processor } from 'src/engine/core-modules/message-queue/decorators/processor.decorator';
@@ -11,8 +11,6 @@ export type WorkflowHandleStaledRunsJobData = {
 
 @Processor({ queueName: MessageQueue.workflowQueue, scope: Scope.REQUEST })
 export class WorkflowHandleStaledRunsJob {
-  private readonly logger = new Logger(WorkflowHandleStaledRunsJob.name);
-
   constructor(
     private readonly workflowHandleStaledRunsWorkspaceService: WorkflowHandleStaledRunsWorkspaceService,
   ) {}
@@ -21,26 +19,12 @@ export class WorkflowHandleStaledRunsJob {
   async handle({
     workspaceId,
   }: WorkflowHandleStaledRunsJobData): Promise<void> {
-    try {
-      await this.workflowHandleStaledRunsWorkspaceService.handleStaledRunsForWorkspace(
-        workspaceId,
-      );
-    } catch (error) {
-      this.logger.error(
-        `Failed to handle staled runs for workspace ${workspaceId}`,
-        error,
-      );
-    }
+    await this.workflowHandleStaledRunsWorkspaceService.handleStaledRunsForWorkspace(
+      workspaceId,
+    );
 
-    try {
-      await this.workflowHandleStaledRunsWorkspaceService.handleStuckStoppingRunsForWorkspace(
-        workspaceId,
-      );
-    } catch (error) {
-      this.logger.error(
-        `Failed to handle stuck stopping runs for workspace ${workspaceId}`,
-        error,
-      );
-    }
+    await this.workflowHandleStaledRunsWorkspaceService.handleStuckStoppingRunsForWorkspace(
+      workspaceId,
+    );
   }
 }

--- a/packages/twenty-server/src/modules/workflow/workflow-runner/workflow-run-queue/jobs/workflow-handle-staled-runs.job.ts
+++ b/packages/twenty-server/src/modules/workflow/workflow-runner/workflow-run-queue/jobs/workflow-handle-staled-runs.job.ts
@@ -22,5 +22,9 @@ export class WorkflowHandleStaledRunsJob {
     await this.workflowHandleStaledRunsWorkspaceService.handleStaledRunsForWorkspace(
       workspaceId,
     );
+
+    await this.workflowHandleStaledRunsWorkspaceService.handleStuckStoppingRunsForWorkspace(
+      workspaceId,
+    );
   }
 }

--- a/packages/twenty-server/src/modules/workflow/workflow-runner/workflow-run-queue/jobs/workflow-handle-staled-runs.job.ts
+++ b/packages/twenty-server/src/modules/workflow/workflow-runner/workflow-run-queue/jobs/workflow-handle-staled-runs.job.ts
@@ -19,12 +19,13 @@ export class WorkflowHandleStaledRunsJob {
   async handle({
     workspaceId,
   }: WorkflowHandleStaledRunsJobData): Promise<void> {
-    await this.workflowHandleStaledRunsWorkspaceService.handleStaledRunsForWorkspace(
-      workspaceId,
-    );
-
-    await this.workflowHandleStaledRunsWorkspaceService.handleStuckStoppingRunsForWorkspace(
-      workspaceId,
-    );
+    await Promise.all([
+      this.workflowHandleStaledRunsWorkspaceService.handleStaledRunsForWorkspace(
+        workspaceId,
+      ),
+      this.workflowHandleStaledRunsWorkspaceService.handleStuckStoppingRunsForWorkspace(
+        workspaceId,
+      ),
+    ]);
   }
 }

--- a/packages/twenty-server/src/modules/workflow/workflow-runner/workflow-run-queue/utils/__tests__/get-stuck-stopping-runs-find-options.util.spec.ts
+++ b/packages/twenty-server/src/modules/workflow/workflow-runner/workflow-run-queue/utils/__tests__/get-stuck-stopping-runs-find-options.util.spec.ts
@@ -4,34 +4,10 @@ import { WorkflowRunStatus } from 'src/modules/workflow/common/standard-objects/
 import { getStuckStoppingRunsFindOptions } from 'src/modules/workflow/workflow-runner/workflow-run-queue/utils/get-stuck-stopping-runs-find-options.util';
 
 describe('getStuckStoppingRunsFindOptions', () => {
-  it('should match STOPPING runs past the threshold when no cursor is given', () => {
+  it('should match STOPPING runs older than the threshold', () => {
     const where = getStuckStoppingRunsFindOptions();
 
-    expect(Array.isArray(where)).toBe(false);
-    expect(where).toMatchObject({ status: WorkflowRunStatus.STOPPING });
-    expect(
-      (where as { updatedAt: FindOperator<string> }).updatedAt,
-    ).toBeInstanceOf(FindOperator);
-  });
-
-  it('should build a keyset OR condition when a cursor is given', () => {
-    const cursor = { createdAt: '2024-01-01T00:00:00.000Z', id: 'run-1' };
-
-    const where = getStuckStoppingRunsFindOptions(cursor);
-
-    expect(Array.isArray(where)).toBe(true);
-
-    const [afterCreatedAt, sameCreatedAtAfterId] = where as Array<
-      Record<string, unknown>
-    >;
-
-    // Strictly newer createdAt
-    expect(afterCreatedAt.status).toBe(WorkflowRunStatus.STOPPING);
-    expect(afterCreatedAt.createdAt).toBeInstanceOf(FindOperator);
-    expect(afterCreatedAt.id).toBeUndefined();
-
-    // Same createdAt, tie-broken by a greater id
-    expect(sameCreatedAtAfterId.createdAt).toBe(cursor.createdAt);
-    expect(sameCreatedAtAfterId.id).toBeInstanceOf(FindOperator);
+    expect(where.status).toBe(WorkflowRunStatus.STOPPING);
+    expect(where.updatedAt).toBeInstanceOf(FindOperator);
   });
 });

--- a/packages/twenty-server/src/modules/workflow/workflow-runner/workflow-run-queue/utils/__tests__/get-stuck-stopping-runs-find-options.util.spec.ts
+++ b/packages/twenty-server/src/modules/workflow/workflow-runner/workflow-run-queue/utils/__tests__/get-stuck-stopping-runs-find-options.util.spec.ts
@@ -1,0 +1,37 @@
+import { FindOperator } from 'typeorm';
+
+import { WorkflowRunStatus } from 'src/modules/workflow/common/standard-objects/workflow-run.workspace-entity';
+import { getStuckStoppingRunsFindOptions } from 'src/modules/workflow/workflow-runner/workflow-run-queue/utils/get-stuck-stopping-runs-find-options.util';
+
+describe('getStuckStoppingRunsFindOptions', () => {
+  it('should match STOPPING runs past the threshold when no cursor is given', () => {
+    const where = getStuckStoppingRunsFindOptions();
+
+    expect(Array.isArray(where)).toBe(false);
+    expect(where).toMatchObject({ status: WorkflowRunStatus.STOPPING });
+    expect(
+      (where as { updatedAt: FindOperator<string> }).updatedAt,
+    ).toBeInstanceOf(FindOperator);
+  });
+
+  it('should build a keyset OR condition when a cursor is given', () => {
+    const cursor = { createdAt: '2024-01-01T00:00:00.000Z', id: 'run-1' };
+
+    const where = getStuckStoppingRunsFindOptions(cursor);
+
+    expect(Array.isArray(where)).toBe(true);
+
+    const [afterCreatedAt, sameCreatedAtAfterId] = where as Array<
+      Record<string, unknown>
+    >;
+
+    // Strictly newer createdAt
+    expect(afterCreatedAt.status).toBe(WorkflowRunStatus.STOPPING);
+    expect(afterCreatedAt.createdAt).toBeInstanceOf(FindOperator);
+    expect(afterCreatedAt.id).toBeUndefined();
+
+    // Same createdAt, tie-broken by a greater id
+    expect(sameCreatedAtAfterId.createdAt).toBe(cursor.createdAt);
+    expect(sameCreatedAtAfterId.id).toBeInstanceOf(FindOperator);
+  });
+});

--- a/packages/twenty-server/src/modules/workflow/workflow-runner/workflow-run-queue/utils/get-stuck-stopping-runs-find-options.util.ts
+++ b/packages/twenty-server/src/modules/workflow/workflow-runner/workflow-run-queue/utils/get-stuck-stopping-runs-find-options.util.ts
@@ -1,0 +1,19 @@
+import { type FindOptionsWhere, LessThan } from 'typeorm';
+
+import {
+  WorkflowRunStatus,
+  type WorkflowRunWorkspaceEntity,
+} from 'src/modules/workflow/common/standard-objects/workflow-run.workspace-entity';
+import { STUCK_STOPPING_RUNS_THRESHOLD_MS } from 'src/modules/workflow/workflow-runner/workflow-run-queue/constants/stuck-stopping-runs-threshold';
+
+export const getStuckStoppingRunsFindOptions =
+  (): FindOptionsWhere<WorkflowRunWorkspaceEntity> => {
+    const thresholdDate = new Date(
+      Date.now() - STUCK_STOPPING_RUNS_THRESHOLD_MS,
+    );
+
+    return {
+      status: WorkflowRunStatus.STOPPING,
+      updatedAt: LessThan(thresholdDate.toISOString()),
+    };
+  };

--- a/packages/twenty-server/src/modules/workflow/workflow-runner/workflow-run-queue/utils/get-stuck-stopping-runs-find-options.util.ts
+++ b/packages/twenty-server/src/modules/workflow/workflow-runner/workflow-run-queue/utils/get-stuck-stopping-runs-find-options.util.ts
@@ -1,4 +1,4 @@
-import { type FindOptionsWhere, LessThan } from 'typeorm';
+import { type FindOptionsWhere, LessThan, MoreThan } from 'typeorm';
 
 import {
   WorkflowRunStatus,
@@ -6,14 +6,29 @@ import {
 } from 'src/modules/workflow/common/standard-objects/workflow-run.workspace-entity';
 import { STUCK_STOPPING_RUNS_THRESHOLD_MS } from 'src/modules/workflow/workflow-runner/workflow-run-queue/constants/stuck-stopping-runs-threshold';
 
-export const getStuckStoppingRunsFindOptions =
-  (): FindOptionsWhere<WorkflowRunWorkspaceEntity> => {
-    const thresholdDate = new Date(
-      Date.now() - STUCK_STOPPING_RUNS_THRESHOLD_MS,
-    );
+export type StuckStoppingRunsCursor = {
+  createdAt: string;
+  id: string;
+};
 
-    return {
-      status: WorkflowRunStatus.STOPPING,
-      updatedAt: LessThan(thresholdDate.toISOString()),
-    };
+export const getStuckStoppingRunsFindOptions = (
+  cursor?: StuckStoppingRunsCursor,
+):
+  | FindOptionsWhere<WorkflowRunWorkspaceEntity>
+  | FindOptionsWhere<WorkflowRunWorkspaceEntity>[] => {
+  const thresholdDate = new Date(Date.now() - STUCK_STOPPING_RUNS_THRESHOLD_MS);
+
+  const base: FindOptionsWhere<WorkflowRunWorkspaceEntity> = {
+    status: WorkflowRunStatus.STOPPING,
+    updatedAt: LessThan(thresholdDate.toISOString()),
   };
+
+  if (!cursor) {
+    return base;
+  }
+
+  return [
+    { ...base, createdAt: MoreThan(cursor.createdAt) },
+    { ...base, createdAt: cursor.createdAt, id: MoreThan(cursor.id) },
+  ];
+};

--- a/packages/twenty-server/src/modules/workflow/workflow-runner/workflow-run-queue/utils/get-stuck-stopping-runs-find-options.util.ts
+++ b/packages/twenty-server/src/modules/workflow/workflow-runner/workflow-run-queue/utils/get-stuck-stopping-runs-find-options.util.ts
@@ -1,4 +1,4 @@
-import { type FindOptionsWhere, LessThan, MoreThan } from 'typeorm';
+import { type FindOptionsWhere, LessThan } from 'typeorm';
 
 import {
   WorkflowRunStatus,
@@ -6,29 +6,14 @@ import {
 } from 'src/modules/workflow/common/standard-objects/workflow-run.workspace-entity';
 import { STUCK_STOPPING_RUNS_THRESHOLD_MS } from 'src/modules/workflow/workflow-runner/workflow-run-queue/constants/stuck-stopping-runs-threshold';
 
-export type StuckStoppingRunsCursor = {
-  createdAt: string;
-  id: string;
-};
+export const getStuckStoppingRunsFindOptions =
+  (): FindOptionsWhere<WorkflowRunWorkspaceEntity> => {
+    const thresholdDate = new Date(
+      Date.now() - STUCK_STOPPING_RUNS_THRESHOLD_MS,
+    );
 
-export const getStuckStoppingRunsFindOptions = (
-  cursor?: StuckStoppingRunsCursor,
-):
-  | FindOptionsWhere<WorkflowRunWorkspaceEntity>
-  | FindOptionsWhere<WorkflowRunWorkspaceEntity>[] => {
-  const thresholdDate = new Date(Date.now() - STUCK_STOPPING_RUNS_THRESHOLD_MS);
-
-  const base: FindOptionsWhere<WorkflowRunWorkspaceEntity> = {
-    status: WorkflowRunStatus.STOPPING,
-    updatedAt: LessThan(thresholdDate.toISOString()),
+    return {
+      status: WorkflowRunStatus.STOPPING,
+      updatedAt: LessThan(thresholdDate.toISOString()),
+    };
   };
-
-  if (!cursor) {
-    return base;
-  }
-
-  return [
-    { ...base, createdAt: MoreThan(cursor.createdAt) },
-    { ...base, createdAt: cursor.createdAt, id: MoreThan(cursor.id) },
-  ];
-};

--- a/packages/twenty-server/src/modules/workflow/workflow-runner/workflow-run-queue/workflow-run-queue.module.ts
+++ b/packages/twenty-server/src/modules/workflow/workflow-runner/workflow-run-queue/workflow-run-queue.module.ts
@@ -7,6 +7,7 @@ import { MetricsModule } from 'src/engine/core-modules/metrics/metrics.module';
 import { ThrottlerModule } from 'src/engine/core-modules/throttler/throttler.module';
 import { WorkspaceEntity } from 'src/engine/core-modules/workspace/workspace.entity';
 import { WorkspaceDataSourceModule } from 'src/engine/workspace-datasource/workspace-datasource.module';
+import { WorkflowRunModule } from 'src/modules/workflow/workflow-runner/workflow-run/workflow-run.module';
 import { WorkflowHandleStaledRunsCommand } from 'src/modules/workflow/workflow-runner/workflow-run-queue/command/workflow-handle-staled-runs.command';
 import { WorkflowCleanWorkflowRunsCronCommand } from 'src/modules/workflow/workflow-runner/workflow-run-queue/cron/command/workflow-clean-workflow-runs.cron.command';
 import { WorkflowHandleStaledRunsCronCommand } from 'src/modules/workflow/workflow-runner/workflow-run-queue/cron/command/workflow-handle-staled-runs.cron.command';
@@ -29,6 +30,7 @@ import { WorkflowThrottlingWorkspaceService } from 'src/modules/workflow/workflo
     WorkspaceDataSourceModule,
     MetricsModule,
     ThrottlerModule,
+    WorkflowRunModule,
   ],
   providers: [
     WorkflowThrottlingWorkspaceService,

--- a/packages/twenty-server/src/modules/workflow/workflow-runner/workflow-run-queue/workspace-services/__tests__/workflow-handle-staled-runs.workspace-service.spec.ts
+++ b/packages/twenty-server/src/modules/workflow/workflow-runner/workflow-run-queue/workspace-services/__tests__/workflow-handle-staled-runs.workspace-service.spec.ts
@@ -4,6 +4,7 @@ import { GlobalWorkspaceOrmManager } from 'src/engine/twenty-orm/global-workspac
 import { WorkflowRunStatus } from 'src/modules/workflow/common/standard-objects/workflow-run.workspace-entity';
 import { WorkflowHandleStaledRunsWorkspaceService } from 'src/modules/workflow/workflow-runner/workflow-run-queue/workspace-services/workflow-handle-staled-runs.workspace-service';
 import { WorkflowThrottlingWorkspaceService } from 'src/modules/workflow/workflow-runner/workflow-run-queue/workspace-services/workflow-throttling.workspace-service';
+import { WorkflowRunWorkspaceService } from 'src/modules/workflow/workflow-runner/workflow-run/workflow-run.workspace-service';
 
 const mockRepository = {
   count: jest.fn(),
@@ -21,6 +22,10 @@ const mockGlobalWorkspaceOrmManager = {
 
 const mockWorkflowThrottlingWorkspaceService = {
   recomputeWorkflowRunNotStartedCount: jest.fn().mockResolvedValue(undefined),
+};
+
+const mockWorkflowRunWorkspaceService = {
+  endWorkflowRun: jest.fn().mockResolvedValue(undefined),
 };
 
 // Mirrors QUERY_MAX_RECORDS, the per-batch cap the service applies. Kept as a
@@ -49,6 +54,10 @@ describe('WorkflowHandleStaledRunsWorkspaceService', () => {
         {
           provide: WorkflowThrottlingWorkspaceService,
           useValue: mockWorkflowThrottlingWorkspaceService,
+        },
+        {
+          provide: WorkflowRunWorkspaceService,
+          useValue: mockWorkflowRunWorkspaceService,
         },
       ],
     }).compile();
@@ -134,5 +143,47 @@ describe('WorkflowHandleStaledRunsWorkspaceService', () => {
     expect(
       mockWorkflowThrottlingWorkspaceService.recomputeWorkflowRunNotStartedCount,
     ).toHaveBeenCalledTimes(1);
+  });
+
+  describe('handleStuckStoppingRunsForWorkspace', () => {
+    it('should do nothing when there are no stuck stopping runs', async () => {
+      mockRepository.find.mockResolvedValueOnce([]);
+
+      await service.handleStuckStoppingRunsForWorkspace(workspaceId);
+
+      expect(
+        mockWorkflowRunWorkspaceService.endWorkflowRun,
+      ).not.toHaveBeenCalled();
+    });
+
+    it('should finalize each stuck stopping run to STOPPED', async () => {
+      mockRepository.find.mockResolvedValueOnce(buildStaledRuns(3));
+
+      await service.handleStuckStoppingRunsForWorkspace(workspaceId);
+
+      expect(
+        mockWorkflowRunWorkspaceService.endWorkflowRun,
+      ).toHaveBeenCalledTimes(3);
+      expect(
+        mockWorkflowRunWorkspaceService.endWorkflowRun,
+      ).toHaveBeenCalledWith({
+        workflowRunId: 'run-0',
+        workspaceId,
+        status: WorkflowRunStatus.STOPPED,
+      });
+    });
+
+    it('should keep finalizing remaining runs when one fails', async () => {
+      mockRepository.find.mockResolvedValueOnce(buildStaledRuns(3));
+      mockWorkflowRunWorkspaceService.endWorkflowRun
+        .mockRejectedValueOnce(new Error('boom'))
+        .mockResolvedValue(undefined);
+
+      await service.handleStuckStoppingRunsForWorkspace(workspaceId);
+
+      expect(
+        mockWorkflowRunWorkspaceService.endWorkflowRun,
+      ).toHaveBeenCalledTimes(3);
+    });
   });
 });

--- a/packages/twenty-server/src/modules/workflow/workflow-runner/workflow-run-queue/workspace-services/__tests__/workflow-handle-staled-runs.workspace-service.spec.ts
+++ b/packages/twenty-server/src/modules/workflow/workflow-runner/workflow-run-queue/workspace-services/__tests__/workflow-handle-staled-runs.workspace-service.spec.ts
@@ -147,16 +147,18 @@ describe('WorkflowHandleStaledRunsWorkspaceService', () => {
 
   describe('handleStuckStoppingRunsForWorkspace', () => {
     it('should do nothing when there are no stuck stopping runs', async () => {
-      mockRepository.find.mockResolvedValueOnce([]);
+      mockRepository.count.mockResolvedValueOnce(0);
 
       await service.handleStuckStoppingRunsForWorkspace(workspaceId);
 
+      expect(mockRepository.find).not.toHaveBeenCalled();
       expect(
         mockWorkflowRunWorkspaceService.endWorkflowRun,
       ).not.toHaveBeenCalled();
     });
 
     it('should finalize each stuck stopping run to STOPPED', async () => {
+      mockRepository.count.mockResolvedValueOnce(3);
       mockRepository.find.mockResolvedValueOnce(buildStaledRuns(3));
 
       await service.handleStuckStoppingRunsForWorkspace(workspaceId);
@@ -173,7 +175,27 @@ describe('WorkflowHandleStaledRunsWorkspaceService', () => {
       });
     });
 
+    it('should drain a multi-batch backlog based on the initial count', async () => {
+      // 450 stuck stopping runs => 3 batches (200, 200, 50)
+      mockRepository.count.mockResolvedValueOnce(450);
+      mockRepository.find
+        .mockResolvedValueOnce(buildStaledRuns(QUERY_MAX_RECORDS))
+        .mockResolvedValueOnce(buildStaledRuns(QUERY_MAX_RECORDS))
+        .mockResolvedValueOnce(buildStaledRuns(50));
+
+      await service.handleStuckStoppingRunsForWorkspace(workspaceId);
+
+      expect(mockRepository.find).toHaveBeenCalledTimes(3);
+      expect(mockRepository.find).toHaveBeenCalledWith(
+        expect.objectContaining({ take: QUERY_MAX_RECORDS }),
+      );
+      expect(
+        mockWorkflowRunWorkspaceService.endWorkflowRun,
+      ).toHaveBeenCalledTimes(450);
+    });
+
     it('should keep finalizing remaining runs when one fails', async () => {
+      mockRepository.count.mockResolvedValueOnce(3);
       mockRepository.find.mockResolvedValueOnce(buildStaledRuns(3));
       mockWorkflowRunWorkspaceService.endWorkflowRun
         .mockRejectedValueOnce(new Error('boom'))

--- a/packages/twenty-server/src/modules/workflow/workflow-runner/workflow-run-queue/workspace-services/__tests__/workflow-handle-staled-runs.workspace-service.spec.ts
+++ b/packages/twenty-server/src/modules/workflow/workflow-runner/workflow-run-queue/workspace-services/__tests__/workflow-handle-staled-runs.workspace-service.spec.ts
@@ -33,8 +33,11 @@ const mockWorkflowRunWorkspaceService = {
 // jest circular-init issue with config-variables loading the same barrel.
 const QUERY_MAX_RECORDS = 200;
 
-const buildStaledRuns = (count: number) =>
-  Array.from({ length: count }, (_, index) => ({ id: `run-${index}` }));
+const buildStaledRuns = (count: number, startIndex = 0) =>
+  Array.from({ length: count }, (_, index) => ({
+    id: `run-${startIndex + index}`,
+    createdAt: String(startIndex + index).padStart(6, '0'),
+  }));
 
 describe('WorkflowHandleStaledRunsWorkspaceService', () => {
   let service: WorkflowHandleStaledRunsWorkspaceService;
@@ -147,18 +150,16 @@ describe('WorkflowHandleStaledRunsWorkspaceService', () => {
 
   describe('handleStuckStoppingRunsForWorkspace', () => {
     it('should do nothing when there are no stuck stopping runs', async () => {
-      mockRepository.count.mockResolvedValueOnce(0);
+      mockRepository.find.mockResolvedValueOnce([]);
 
       await service.handleStuckStoppingRunsForWorkspace(workspaceId);
 
-      expect(mockRepository.find).not.toHaveBeenCalled();
       expect(
         mockWorkflowRunWorkspaceService.endWorkflowRun,
       ).not.toHaveBeenCalled();
     });
 
     it('should finalize each stuck stopping run to STOPPED', async () => {
-      mockRepository.count.mockResolvedValueOnce(3);
       mockRepository.find.mockResolvedValueOnce(buildStaledRuns(3));
 
       await service.handleStuckStoppingRunsForWorkspace(workspaceId);
@@ -175,12 +176,13 @@ describe('WorkflowHandleStaledRunsWorkspaceService', () => {
       });
     });
 
-    it('should drain a multi-batch backlog based on the initial count', async () => {
-      mockRepository.count.mockResolvedValueOnce(450);
+    it('should page through a multi-page backlog until a short page', async () => {
       mockRepository.find
         .mockResolvedValueOnce(buildStaledRuns(QUERY_MAX_RECORDS))
-        .mockResolvedValueOnce(buildStaledRuns(QUERY_MAX_RECORDS))
-        .mockResolvedValueOnce(buildStaledRuns(50));
+        .mockResolvedValueOnce(
+          buildStaledRuns(QUERY_MAX_RECORDS, QUERY_MAX_RECORDS),
+        )
+        .mockResolvedValueOnce(buildStaledRuns(50, 2 * QUERY_MAX_RECORDS));
 
       await service.handleStuckStoppingRunsForWorkspace(workspaceId);
 
@@ -190,11 +192,10 @@ describe('WorkflowHandleStaledRunsWorkspaceService', () => {
       );
       expect(
         mockWorkflowRunWorkspaceService.endWorkflowRun,
-      ).toHaveBeenCalledTimes(450);
+      ).toHaveBeenCalledTimes(2 * QUERY_MAX_RECORDS + 50);
     });
 
     it('should keep finalizing remaining runs when one fails', async () => {
-      mockRepository.count.mockResolvedValueOnce(3);
       mockRepository.find.mockResolvedValueOnce(buildStaledRuns(3));
       mockWorkflowRunWorkspaceService.endWorkflowRun
         .mockRejectedValueOnce(new Error('boom'))
@@ -205,6 +206,36 @@ describe('WorkflowHandleStaledRunsWorkspaceService', () => {
       expect(
         mockWorkflowRunWorkspaceService.endWorkflowRun,
       ).toHaveBeenCalledTimes(3);
+    });
+
+    it('should advance past a fully failed page instead of starving later runs', async () => {
+      mockRepository.find
+        .mockResolvedValueOnce(buildStaledRuns(QUERY_MAX_RECORDS))
+        .mockResolvedValueOnce(buildStaledRuns(50, QUERY_MAX_RECORDS));
+      // Whole first page fails, later runs still get finalized
+      mockWorkflowRunWorkspaceService.endWorkflowRun.mockImplementation(
+        ({ workflowRunId }: { workflowRunId: string }) => {
+          const index = Number(workflowRunId.replace('run-', ''));
+
+          return index < QUERY_MAX_RECORDS
+            ? Promise.reject(new Error('boom'))
+            : Promise.resolve(undefined);
+        },
+      );
+
+      await service.handleStuckStoppingRunsForWorkspace(workspaceId);
+
+      expect(mockRepository.find).toHaveBeenCalledTimes(2);
+      expect(
+        mockWorkflowRunWorkspaceService.endWorkflowRun,
+      ).toHaveBeenCalledTimes(QUERY_MAX_RECORDS + 50);
+      expect(
+        mockWorkflowRunWorkspaceService.endWorkflowRun,
+      ).toHaveBeenCalledWith({
+        workflowRunId: `run-${QUERY_MAX_RECORDS}`,
+        workspaceId,
+        status: WorkflowRunStatus.STOPPED,
+      });
     });
   });
 });

--- a/packages/twenty-server/src/modules/workflow/workflow-runner/workflow-run-queue/workspace-services/__tests__/workflow-handle-staled-runs.workspace-service.spec.ts
+++ b/packages/twenty-server/src/modules/workflow/workflow-runner/workflow-run-queue/workspace-services/__tests__/workflow-handle-staled-runs.workspace-service.spec.ts
@@ -176,7 +176,6 @@ describe('WorkflowHandleStaledRunsWorkspaceService', () => {
     });
 
     it('should drain a multi-batch backlog based on the initial count', async () => {
-      // 450 stuck stopping runs => 3 batches (200, 200, 50)
       mockRepository.count.mockResolvedValueOnce(450);
       mockRepository.find
         .mockResolvedValueOnce(buildStaledRuns(QUERY_MAX_RECORDS))

--- a/packages/twenty-server/src/modules/workflow/workflow-runner/workflow-run-queue/workspace-services/__tests__/workflow-handle-staled-runs.workspace-service.spec.ts
+++ b/packages/twenty-server/src/modules/workflow/workflow-runner/workflow-run-queue/workspace-services/__tests__/workflow-handle-staled-runs.workspace-service.spec.ts
@@ -36,7 +36,6 @@ const QUERY_MAX_RECORDS = 200;
 const buildStaledRuns = (count: number, startIndex = 0) =>
   Array.from({ length: count }, (_, index) => ({
     id: `run-${startIndex + index}`,
-    createdAt: String(startIndex + index).padStart(6, '0'),
   }));
 
 describe('WorkflowHandleStaledRunsWorkspaceService', () => {

--- a/packages/twenty-server/src/modules/workflow/workflow-runner/workflow-run-queue/workspace-services/workflow-handle-staled-runs.workspace-service.ts
+++ b/packages/twenty-server/src/modules/workflow/workflow-runner/workflow-run-queue/workspace-services/workflow-handle-staled-runs.workspace-service.ts
@@ -9,7 +9,10 @@ import {
   WorkflowRunWorkspaceEntity,
 } from 'src/modules/workflow/common/standard-objects/workflow-run.workspace-entity';
 import { getStaledRunsFindOptions } from 'src/modules/workflow/workflow-runner/workflow-run-queue/utils/get-staled-runs-find-options.util';
-import { getStuckStoppingRunsFindOptions } from 'src/modules/workflow/workflow-runner/workflow-run-queue/utils/get-stuck-stopping-runs-find-options.util';
+import {
+  getStuckStoppingRunsFindOptions,
+  type StuckStoppingRunsCursor,
+} from 'src/modules/workflow/workflow-runner/workflow-run-queue/utils/get-stuck-stopping-runs-find-options.util';
 import { WorkflowThrottlingWorkspaceService } from 'src/modules/workflow/workflow-runner/workflow-run-queue/workspace-services/workflow-throttling.workspace-service';
 import { WorkflowRunWorkspaceService } from 'src/modules/workflow/workflow-runner/workflow-run/workflow-run.workspace-service';
 
@@ -79,31 +82,10 @@ export class WorkflowHandleStaledRunsWorkspaceService {
   async handleStuckStoppingRunsForWorkspace(workspaceId: string) {
     const authContext = buildSystemAuthContext(workspaceId);
 
-    const stuckStoppingRunsCount =
-      await this.globalWorkspaceOrmManager.executeInWorkspaceContext(
-        async () => {
-          const workflowRunRepository =
-            await this.globalWorkspaceOrmManager.getRepository(
-              workspaceId,
-              WorkflowRunWorkspaceEntity,
-              { shouldBypassPermissionChecks: true },
-            );
+    let cursor: StuckStoppingRunsCursor | undefined;
 
-          return workflowRunRepository.count({
-            where: getStuckStoppingRunsFindOptions(),
-          });
-        },
-        authContext,
-      );
-
-    if (stuckStoppingRunsCount <= 0) {
-      return;
-    }
-
-    const batchCount = Math.ceil(stuckStoppingRunsCount / QUERY_MAX_RECORDS);
-
-    for (let batchIndex = 0; batchIndex < batchCount; batchIndex++) {
-      const stuckStoppingRunIds =
+    for (;;) {
+      const stuckStoppingRuns =
         await this.globalWorkspaceOrmManager.executeInWorkspaceContext(
           async () => {
             const workflowRunRepository =
@@ -113,27 +95,27 @@ export class WorkflowHandleStaledRunsWorkspaceService {
                 { shouldBypassPermissionChecks: true },
               );
 
-            const stuckStoppingRuns = await workflowRunRepository.find({
-              where: getStuckStoppingRunsFindOptions(),
+            return workflowRunRepository.find({
+              where: getStuckStoppingRunsFindOptions(cursor),
               select: {
                 id: true,
+                createdAt: true,
               },
               order: {
                 createdAt: 'ASC',
+                id: 'ASC',
               },
               take: QUERY_MAX_RECORDS,
             });
-
-            return stuckStoppingRuns.map((workflowRun) => workflowRun.id);
           },
           authContext,
         );
 
-      if (stuckStoppingRunIds.length === 0) {
+      if (stuckStoppingRuns.length === 0) {
         break;
       }
 
-      for (const workflowRunId of stuckStoppingRunIds) {
+      for (const { id: workflowRunId } of stuckStoppingRuns) {
         try {
           await this.workflowRunWorkspaceService.endWorkflowRun({
             workflowRunId,
@@ -147,6 +129,14 @@ export class WorkflowHandleStaledRunsWorkspaceService {
           );
         }
       }
+
+      if (stuckStoppingRuns.length < QUERY_MAX_RECORDS) {
+        break;
+      }
+
+      const lastRun = stuckStoppingRuns[stuckStoppingRuns.length - 1];
+
+      cursor = { createdAt: lastRun.createdAt, id: lastRun.id };
     }
   }
 }

--- a/packages/twenty-server/src/modules/workflow/workflow-runner/workflow-run-queue/workspace-services/workflow-handle-staled-runs.workspace-service.ts
+++ b/packages/twenty-server/src/modules/workflow/workflow-runner/workflow-run-queue/workspace-services/workflow-handle-staled-runs.workspace-service.ts
@@ -76,10 +76,6 @@ export class WorkflowHandleStaledRunsWorkspaceService {
     }, authContext);
   }
 
-  // Safety net for runs left in STOPPING: stopping only records intent, the
-  // STOPPING -> STOPPED transition is done by the in-flight worker execution.
-  // When no worker is executing the run (crash, or a step awaiting an event
-  // that never comes) it would stay STOPPING forever, so we finalize it here.
   async handleStuckStoppingRunsForWorkspace(workspaceId: string) {
     const authContext = buildSystemAuthContext(workspaceId);
 

--- a/packages/twenty-server/src/modules/workflow/workflow-runner/workflow-run-queue/workspace-services/workflow-handle-staled-runs.workspace-service.ts
+++ b/packages/twenty-server/src/modules/workflow/workflow-runner/workflow-run-queue/workspace-services/workflow-handle-staled-runs.workspace-service.ts
@@ -79,8 +79,6 @@ export class WorkflowHandleStaledRunsWorkspaceService {
   async handleStuckStoppingRunsForWorkspace(workspaceId: string) {
     const authContext = buildSystemAuthContext(workspaceId);
 
-    // Collect all the ids first, then finalize them. We don't finalize while
-    // paging so that a run whose finalization fails can't block the next page.
     const stuckStoppingRunIds =
       await this.globalWorkspaceOrmManager.executeInWorkspaceContext(
         async () => {

--- a/packages/twenty-server/src/modules/workflow/workflow-runner/workflow-run-queue/workspace-services/workflow-handle-staled-runs.workspace-service.ts
+++ b/packages/twenty-server/src/modules/workflow/workflow-runner/workflow-run-queue/workspace-services/workflow-handle-staled-runs.workspace-service.ts
@@ -89,12 +89,14 @@ export class WorkflowHandleStaledRunsWorkspaceService {
               { shouldBypassPermissionChecks: true },
             );
 
+          const findOptions = getStuckStoppingRunsFindOptions();
+
           const runIds: string[] = [];
           let page: WorkflowRunWorkspaceEntity[];
 
           do {
             page = await workflowRunRepository.find({
-              where: getStuckStoppingRunsFindOptions(),
+              where: findOptions,
               select: { id: true },
               order: { createdAt: 'ASC', id: 'ASC' },
               take: QUERY_MAX_RECORDS,

--- a/packages/twenty-server/src/modules/workflow/workflow-runner/workflow-run-queue/workspace-services/workflow-handle-staled-runs.workspace-service.ts
+++ b/packages/twenty-server/src/modules/workflow/workflow-runner/workflow-run-queue/workspace-services/workflow-handle-staled-runs.workspace-service.ts
@@ -96,7 +96,7 @@ export class WorkflowHandleStaledRunsWorkspaceService {
             page = await workflowRunRepository.find({
               where: getStuckStoppingRunsFindOptions(),
               select: { id: true },
-              order: { createdAt: 'ASC' },
+              order: { createdAt: 'ASC', id: 'ASC' },
               take: QUERY_MAX_RECORDS,
               skip: runIds.length,
             });

--- a/packages/twenty-server/src/modules/workflow/workflow-runner/workflow-run-queue/workspace-services/workflow-handle-staled-runs.workspace-service.ts
+++ b/packages/twenty-server/src/modules/workflow/workflow-runner/workflow-run-queue/workspace-services/workflow-handle-staled-runs.workspace-service.ts
@@ -9,10 +9,7 @@ import {
   WorkflowRunWorkspaceEntity,
 } from 'src/modules/workflow/common/standard-objects/workflow-run.workspace-entity';
 import { getStaledRunsFindOptions } from 'src/modules/workflow/workflow-runner/workflow-run-queue/utils/get-staled-runs-find-options.util';
-import {
-  getStuckStoppingRunsFindOptions,
-  type StuckStoppingRunsCursor,
-} from 'src/modules/workflow/workflow-runner/workflow-run-queue/utils/get-stuck-stopping-runs-find-options.util';
+import { getStuckStoppingRunsFindOptions } from 'src/modules/workflow/workflow-runner/workflow-run-queue/utils/get-stuck-stopping-runs-find-options.util';
 import { WorkflowThrottlingWorkspaceService } from 'src/modules/workflow/workflow-runner/workflow-run-queue/workspace-services/workflow-throttling.workspace-service';
 import { WorkflowRunWorkspaceService } from 'src/modules/workflow/workflow-runner/workflow-run/workflow-run.workspace-service';
 
@@ -82,61 +79,51 @@ export class WorkflowHandleStaledRunsWorkspaceService {
   async handleStuckStoppingRunsForWorkspace(workspaceId: string) {
     const authContext = buildSystemAuthContext(workspaceId);
 
-    let cursor: StuckStoppingRunsCursor | undefined;
+    // Collect all the ids first, then finalize them. We don't finalize while
+    // paging so that a run whose finalization fails can't block the next page.
+    const stuckStoppingRunIds =
+      await this.globalWorkspaceOrmManager.executeInWorkspaceContext(
+        async () => {
+          const workflowRunRepository =
+            await this.globalWorkspaceOrmManager.getRepository(
+              workspaceId,
+              WorkflowRunWorkspaceEntity,
+              { shouldBypassPermissionChecks: true },
+            );
 
-    for (;;) {
-      const stuckStoppingRuns =
-        await this.globalWorkspaceOrmManager.executeInWorkspaceContext(
-          async () => {
-            const workflowRunRepository =
-              await this.globalWorkspaceOrmManager.getRepository(
-                workspaceId,
-                WorkflowRunWorkspaceEntity,
-                { shouldBypassPermissionChecks: true },
-              );
+          const runIds: string[] = [];
+          let page: WorkflowRunWorkspaceEntity[];
 
-            return workflowRunRepository.find({
-              where: getStuckStoppingRunsFindOptions(cursor),
-              select: {
-                id: true,
-                createdAt: true,
-              },
-              order: {
-                createdAt: 'ASC',
-                id: 'ASC',
-              },
+          do {
+            page = await workflowRunRepository.find({
+              where: getStuckStoppingRunsFindOptions(),
+              select: { id: true },
+              order: { createdAt: 'ASC' },
               take: QUERY_MAX_RECORDS,
+              skip: runIds.length,
             });
-          },
-          authContext,
+
+            runIds.push(...page.map((workflowRun) => workflowRun.id));
+          } while (page.length === QUERY_MAX_RECORDS);
+
+          return runIds;
+        },
+        authContext,
+      );
+
+    for (const workflowRunId of stuckStoppingRunIds) {
+      try {
+        await this.workflowRunWorkspaceService.endWorkflowRun({
+          workflowRunId,
+          workspaceId,
+          status: WorkflowRunStatus.STOPPED,
+        });
+      } catch (error) {
+        this.logger.error(
+          `Failed to finalize stuck stopping workflow run ${workflowRunId} for workspace ${workspaceId}`,
+          error,
         );
-
-      if (stuckStoppingRuns.length === 0) {
-        break;
       }
-
-      for (const { id: workflowRunId } of stuckStoppingRuns) {
-        try {
-          await this.workflowRunWorkspaceService.endWorkflowRun({
-            workflowRunId,
-            workspaceId,
-            status: WorkflowRunStatus.STOPPED,
-          });
-        } catch (error) {
-          this.logger.error(
-            `Failed to finalize stuck stopping workflow run ${workflowRunId} for workspace ${workspaceId}`,
-            error,
-          );
-        }
-      }
-
-      if (stuckStoppingRuns.length < QUERY_MAX_RECORDS) {
-        break;
-      }
-
-      const lastRun = stuckStoppingRuns[stuckStoppingRuns.length - 1];
-
-      cursor = { createdAt: lastRun.createdAt, id: lastRun.id };
     }
   }
 }

--- a/packages/twenty-server/src/modules/workflow/workflow-runner/workflow-run-queue/workspace-services/workflow-handle-staled-runs.workspace-service.ts
+++ b/packages/twenty-server/src/modules/workflow/workflow-runner/workflow-run-queue/workspace-services/workflow-handle-staled-runs.workspace-service.ts
@@ -83,7 +83,7 @@ export class WorkflowHandleStaledRunsWorkspaceService {
   async handleStuckStoppingRunsForWorkspace(workspaceId: string) {
     const authContext = buildSystemAuthContext(workspaceId);
 
-    const stuckStoppingRunIds =
+    const stuckStoppingRunsCount =
       await this.globalWorkspaceOrmManager.executeInWorkspaceContext(
         async () => {
           const workflowRunRepository =
@@ -93,34 +93,63 @@ export class WorkflowHandleStaledRunsWorkspaceService {
               { shouldBypassPermissionChecks: true },
             );
 
-          const stuckStoppingRuns = await workflowRunRepository.find({
+          return workflowRunRepository.count({
             where: getStuckStoppingRunsFindOptions(),
-            select: {
-              id: true,
-            },
-            order: {
-              createdAt: 'ASC',
-            },
-            take: QUERY_MAX_RECORDS,
           });
-
-          return stuckStoppingRuns.map((workflowRun) => workflowRun.id);
         },
         authContext,
       );
 
-    for (const workflowRunId of stuckStoppingRunIds) {
-      try {
-        await this.workflowRunWorkspaceService.endWorkflowRun({
-          workflowRunId,
-          workspaceId,
-          status: WorkflowRunStatus.STOPPED,
-        });
-      } catch (error) {
-        this.logger.error(
-          `Failed to finalize stuck stopping workflow run ${workflowRunId} for workspace ${workspaceId}`,
-          error,
+    if (stuckStoppingRunsCount <= 0) {
+      return;
+    }
+
+    const batchCount = Math.ceil(stuckStoppingRunsCount / QUERY_MAX_RECORDS);
+
+    for (let batchIndex = 0; batchIndex < batchCount; batchIndex++) {
+      const stuckStoppingRunIds =
+        await this.globalWorkspaceOrmManager.executeInWorkspaceContext(
+          async () => {
+            const workflowRunRepository =
+              await this.globalWorkspaceOrmManager.getRepository(
+                workspaceId,
+                WorkflowRunWorkspaceEntity,
+                { shouldBypassPermissionChecks: true },
+              );
+
+            const stuckStoppingRuns = await workflowRunRepository.find({
+              where: getStuckStoppingRunsFindOptions(),
+              select: {
+                id: true,
+              },
+              order: {
+                createdAt: 'ASC',
+              },
+              take: QUERY_MAX_RECORDS,
+            });
+
+            return stuckStoppingRuns.map((workflowRun) => workflowRun.id);
+          },
+          authContext,
         );
+
+      if (stuckStoppingRunIds.length === 0) {
+        break;
+      }
+
+      for (const workflowRunId of stuckStoppingRunIds) {
+        try {
+          await this.workflowRunWorkspaceService.endWorkflowRun({
+            workflowRunId,
+            workspaceId,
+            status: WorkflowRunStatus.STOPPED,
+          });
+        } catch (error) {
+          this.logger.error(
+            `Failed to finalize stuck stopping workflow run ${workflowRunId} for workspace ${workspaceId}`,
+            error,
+          );
+        }
       }
     }
   }

--- a/packages/twenty-server/src/modules/workflow/workflow-runner/workflow-run-queue/workspace-services/workflow-handle-staled-runs.workspace-service.ts
+++ b/packages/twenty-server/src/modules/workflow/workflow-runner/workflow-run-queue/workspace-services/workflow-handle-staled-runs.workspace-service.ts
@@ -9,7 +9,9 @@ import {
   WorkflowRunWorkspaceEntity,
 } from 'src/modules/workflow/common/standard-objects/workflow-run.workspace-entity';
 import { getStaledRunsFindOptions } from 'src/modules/workflow/workflow-runner/workflow-run-queue/utils/get-staled-runs-find-options.util';
+import { getStuckStoppingRunsFindOptions } from 'src/modules/workflow/workflow-runner/workflow-run-queue/utils/get-stuck-stopping-runs-find-options.util';
 import { WorkflowThrottlingWorkspaceService } from 'src/modules/workflow/workflow-runner/workflow-run-queue/workspace-services/workflow-throttling.workspace-service';
+import { WorkflowRunWorkspaceService } from 'src/modules/workflow/workflow-runner/workflow-run/workflow-run.workspace-service';
 
 @Injectable()
 export class WorkflowHandleStaledRunsWorkspaceService {
@@ -19,6 +21,7 @@ export class WorkflowHandleStaledRunsWorkspaceService {
   constructor(
     private readonly globalWorkspaceOrmManager: GlobalWorkspaceOrmManager,
     private readonly workflowThrottlingWorkspaceService: WorkflowThrottlingWorkspaceService,
+    private readonly workflowRunWorkspaceService: WorkflowRunWorkspaceService,
   ) {}
 
   async handleStaledRunsForWorkspace(workspaceId: string) {
@@ -71,5 +74,54 @@ export class WorkflowHandleStaledRunsWorkspaceService {
         workspaceId,
       );
     }, authContext);
+  }
+
+  // Safety net for runs left in STOPPING: stopping only records intent, the
+  // STOPPING -> STOPPED transition is done by the in-flight worker execution.
+  // When no worker is executing the run (crash, or a step awaiting an event
+  // that never comes) it would stay STOPPING forever, so we finalize it here.
+  async handleStuckStoppingRunsForWorkspace(workspaceId: string) {
+    const authContext = buildSystemAuthContext(workspaceId);
+
+    const stuckStoppingRunIds =
+      await this.globalWorkspaceOrmManager.executeInWorkspaceContext(
+        async () => {
+          const workflowRunRepository =
+            await this.globalWorkspaceOrmManager.getRepository(
+              workspaceId,
+              WorkflowRunWorkspaceEntity,
+              { shouldBypassPermissionChecks: true },
+            );
+
+          const stuckStoppingRuns = await workflowRunRepository.find({
+            where: getStuckStoppingRunsFindOptions(),
+            select: {
+              id: true,
+            },
+            order: {
+              createdAt: 'ASC',
+            },
+            take: QUERY_MAX_RECORDS,
+          });
+
+          return stuckStoppingRuns.map((workflowRun) => workflowRun.id);
+        },
+        authContext,
+      );
+
+    for (const workflowRunId of stuckStoppingRunIds) {
+      try {
+        await this.workflowRunWorkspaceService.endWorkflowRun({
+          workflowRunId,
+          workspaceId,
+          status: WorkflowRunStatus.STOPPED,
+        });
+      } catch (error) {
+        this.logger.error(
+          `Failed to finalize stuck stopping workflow run ${workflowRunId} for workspace ${workspaceId}`,
+          error,
+        );
+      }
+    }
   }
 }


### PR DESCRIPTION
## Context

A workflow run only reaches STOPPED via the in-flight worker execution: `stopWorkflowRun` just flips a RUNNING run to `STOPPING` (records intent), and the `STOPPING -> STOPPED` transition is done later inside `computeWorkflowRunStatus`, which only runs while a worker is executing the run's steps.

If no worker is executing the run at that point, nothing ever finalizes it:
- the worker that owned the run crashed / was killed mid-step (e.g. under heavy load), or
- a step legitimately sits in RUNNING awaiting an external event that never arrives (the user stopped it).

Only `ENQUEUED` runs had a staleness sweep, so `STOPPING` (and `RUNNING`) had no recovery path and would stay stuck indefinitely. This has been observed in production (~150 runs stuck in `STOPPING` after manual stops during a migration).

## Change

Extend the existing staled-runs machinery to also finalize runs left in `STOPPING`:
- New `stuck-stopping-runs-threshold` (1h) + `getStuckStoppingRunsFindOptions` matching `status = STOPPING AND updatedAt < now - 1h`. `updatedAt` is a TypeORM update-date column, so it reliably marks when the run entered `STOPPING`, and 1h stays above any legitimate in-flight step.
- `handleStuckStoppingRunsForWorkspace` finalizes each match to `STOPPED` via `endWorkflowRun`, so `endedAt`, step infos and the `WorkflowRunStopped` metric stay consistent. It pages the backlog with keyset pagination on `(createdAt, id)`, so a page whose finalizations all fail can't stay at the front of the query and starve later runs (failed ones are retried on the next sweep).
- Wired into the same cron (`WorkflowHandleStaledRunsCronJob`, every 10 min), per-workspace job, and the manual `workflow:handle-staled-runs` command — so ops can also clear an existing backlog immediately. The staled-ENQUEUED and stuck-STOPPING handlers run independently (`Promise.allSettled` in the job, separate try/catch in the command), so a failure in one doesn't block the other.

Stop remains manual and unchanged; this only guarantees a stopped run eventually reaches `STOPPED`.

## Notes / scope

- No schema change (reuses `updatedAt`), so no migration.
- `RUNNING` runs orphaned by a worker crash have the same missing-net problem; left out of scope here (this covers the user-triggered STOPPING case).
- The new detection query scans `status`/`updatedAt` like the existing ENQUEUED sweep; at very high `workflowRun` volumes an index on `(status, updatedAt)` would help — same pre-existing consideration as the ENQUEUED path.

## Tests

Unit tests for `handleStuckStoppingRunsForWorkspace`: no-op when none, finalizes each match to STOPPED, pages through a multi-page backlog, and advances past a fully-failed page instead of starving later runs. Plus a unit test for the `(createdAt, id)` keyset condition in `getStuckStoppingRunsFindOptions`. Full suite green, lint + typecheck clean on changed files.

Manually verified on a real instance (Postgres): seeded a `STOPPING` run aged 2h and ran `workflow:handle-staled-runs` -> transitioned to `STOPPED` with `endedAt` set; a freshly-`STOPPING` run (updatedAt now) was correctly left untouched by the 1h threshold.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/22900?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->
