### PR TITLE
Declare searchVector GIN index for searchable standard objects + backfill

### DIFF
--- a/packages/twenty-server/src/database/commands/upgrade-version-command/2-22/2-22-upgrade-version-command.module.ts
+++ b/packages/twenty-server/src/database/commands/upgrade-version-command/2-22/2-22-upgrade-version-command.module.ts
@@ -1,0 +1,20 @@
+import { Module } from '@nestjs/common';
+
+import { WorkspaceIteratorModule } from 'src/database/commands/command-runners/workspace-iterator.module';
+import { BackfillStandardSearchVectorGinIndexCommand } from 'src/database/commands/upgrade-version-command/2-22/2-22-workspace-command-1783950000000-backfill-standard-search-vector-gin-index.command';
+import { ApplicationModule } from 'src/engine/core-modules/application/application.module';
+import { WorkspaceMetadataVersionModule } from 'src/engine/metadata-modules/workspace-metadata-version/workspace-metadata-version.module';
+import { WorkspaceCacheModule } from 'src/engine/workspace-cache/workspace-cache.module';
+import { WorkspaceMigrationModule } from 'src/engine/workspace-manager/workspace-migration/workspace-migration.module';
+
+@Module({
+  imports: [
+    ApplicationModule,
+    WorkspaceCacheModule,
+    WorkspaceIteratorModule,
+    WorkspaceMetadataVersionModule,
+    WorkspaceMigrationModule,
+  ],
+  providers: [BackfillStandardSearchVectorGinIndexCommand],
+})
+export class V2_22_UpgradeVersionCommandModule {}

--- a/packages/twenty-server/src/database/commands/upgrade-version-command/2-22/2-22-workspace-command-1783950000000-backfill-standard-search-vector-gin-index.command.ts
+++ b/packages/twenty-server/src/database/commands/upgrade-version-command/2-22/2-22-workspace-command-1783950000000-backfill-standard-search-vector-gin-index.command.ts
@@ -1,0 +1,168 @@
+import { Command } from 'nest-commander';
+
+import { ActiveOrSuspendedWorkspaceCommandRunner } from 'src/database/commands/command-runners/active-or-suspended-workspace.command-runner';
+import { WorkspaceIteratorService } from 'src/database/commands/command-runners/workspace-iterator.service';
+import { type RunOnWorkspaceArgs } from 'src/database/commands/command-runners/workspace.command-runner';
+import { buildStandardSearchVectorGinIndexBackfillOperations } from 'src/database/commands/upgrade-version-command/2-22/utils/build-standard-search-vector-gin-index-backfill-operations.util';
+import { ApplicationService } from 'src/engine/core-modules/application/application.service';
+import { RegisteredWorkspaceCommand } from 'src/engine/core-modules/upgrade/decorators/registered-workspace-command.decorator';
+import { getMetadataFlatEntityMapsKey } from 'src/engine/metadata-modules/flat-entity/utils/get-metadata-flat-entity-maps-key.util';
+import { getMetadataRelatedMetadataNames } from 'src/engine/metadata-modules/flat-entity/utils/get-metadata-related-metadata-names.util';
+import { getMetadataSerializedRelationNames } from 'src/engine/metadata-modules/flat-entity/utils/get-metadata-serialized-relation-names.util';
+import { WorkspaceMetadataVersionService } from 'src/engine/metadata-modules/workspace-metadata-version/services/workspace-metadata-version.service';
+import { WorkspaceCacheService } from 'src/engine/workspace-cache/services/workspace-cache.service';
+import { type UniversalFlatIndexMetadata } from 'src/engine/workspace-manager/workspace-migration/universal-flat-entity/types/universal-flat-index-metadata.type';
+import { WorkspaceMigrationValidateBuildAndRunService } from 'src/engine/workspace-manager/workspace-migration/services/workspace-migration-validate-build-and-run-service';
+
+@RegisteredWorkspaceCommand('2.22.0', 1783950000000)
+@Command({
+  name: 'upgrade:2-22:backfill-standard-search-vector-gin-index',
+  description:
+    'Create the searchVector GIN index for twenty-standard searchable objects that declare it in the manifest but are missing it (the objects whose static declaration was only just added and previously relied on runtime side-effect creation). Idempotent.',
+})
+export class BackfillStandardSearchVectorGinIndexCommand extends ActiveOrSuspendedWorkspaceCommandRunner {
+  constructor(
+    protected readonly workspaceIteratorService: WorkspaceIteratorService,
+    private readonly applicationService: ApplicationService,
+    private readonly workspaceCacheService: WorkspaceCacheService,
+    private readonly workspaceMetadataVersionService: WorkspaceMetadataVersionService,
+    private readonly workspaceMigrationValidateBuildAndRunService: WorkspaceMigrationValidateBuildAndRunService,
+  ) {
+    super(workspaceIteratorService);
+  }
+
+  override async runOnWorkspace({
+    workspaceId,
+    options,
+  }: RunOnWorkspaceArgs): Promise<void> {
+    const isDryRun = options.dryRun ?? false;
+
+    const flatIndexesToCreateByApplicationUniversalIdentifier =
+      await this.computeOperations({ workspaceId });
+
+    const totalIndexesToBackfill = Object.values(
+      flatIndexesToCreateByApplicationUniversalIdentifier,
+    ).reduce((total, flatIndexes) => total + flatIndexes.length, 0);
+
+    if (totalIndexesToBackfill === 0) {
+      this.logger.log(
+        `No searchVector GIN index to backfill for workspace ${workspaceId}`,
+      );
+
+      return;
+    }
+
+    this.logger.log(
+      `${isDryRun ? '[DRY RUN] ' : ''}Backfilling ${totalIndexesToBackfill} missing searchVector GIN index(es) for workspace ${workspaceId}`,
+    );
+
+    if (isDryRun) {
+      return;
+    }
+
+    await this.applyBackfill({
+      workspaceId,
+      flatIndexesToCreateByApplicationUniversalIdentifier,
+    });
+
+    await this.flushIndexCacheAndBumpMetadataVersion(workspaceId);
+
+    this.logger.log(
+      `Backfilled searchVector GIN indexes for workspace ${workspaceId}`,
+    );
+  }
+
+  private async computeOperations({
+    workspaceId,
+  }: {
+    workspaceId: string;
+  }): Promise<Record<string, UniversalFlatIndexMetadata[]>> {
+    const { flatObjectMetadataMaps, flatFieldMetadataMaps, flatIndexMaps } =
+      await this.workspaceCacheService.getOrRecompute(workspaceId, [
+        'flatObjectMetadataMaps',
+        'flatFieldMetadataMaps',
+        'flatIndexMaps',
+      ]);
+
+    const { twentyStandardFlatApplication } =
+      await this.applicationService.findWorkspaceTwentyStandardAndCustomApplicationOrThrow(
+        { workspaceId },
+      );
+
+    return buildStandardSearchVectorGinIndexBackfillOperations({
+      flatObjectMetadataMaps,
+      flatFieldMetadataMaps,
+      flatIndexMaps,
+      twentyStandardApplicationId: twentyStandardFlatApplication.id,
+    });
+  }
+
+  private async applyBackfill({
+    workspaceId,
+    flatIndexesToCreateByApplicationUniversalIdentifier,
+  }: {
+    workspaceId: string;
+    flatIndexesToCreateByApplicationUniversalIdentifier: Record<
+      string,
+      UniversalFlatIndexMetadata[]
+    >;
+  }): Promise<void> {
+    for (const [
+      applicationUniversalIdentifier,
+      flatIndexesToCreate,
+    ] of Object.entries(flatIndexesToCreateByApplicationUniversalIdentifier)) {
+      if (flatIndexesToCreate.length === 0) {
+        continue;
+      }
+
+      const validateAndBuildResult =
+        await this.workspaceMigrationValidateBuildAndRunService.validateBuildAndRunWorkspaceMigration(
+          {
+            isSystemBuild: true,
+            allFlatEntityOperationByMetadataName: {
+              index: {
+                flatEntityToCreate: flatIndexesToCreate,
+                flatEntityToDelete: [],
+                flatEntityToUpdate: [],
+              },
+            },
+            workspaceId,
+            applicationUniversalIdentifier,
+          },
+        );
+
+      if (validateAndBuildResult.status === 'fail') {
+        this.logger.error(
+          `Failed to create searchVector GIN index(es) for application ${applicationUniversalIdentifier}:\n${JSON.stringify(
+            validateAndBuildResult,
+            null,
+            2,
+          )}`,
+        );
+
+        throw new Error(
+          `Failed to create searchVector GIN index(es) for workspace ${workspaceId}`,
+        );
+      }
+    }
+  }
+
+  private async flushIndexCacheAndBumpMetadataVersion(
+    workspaceId: string,
+  ): Promise<void> {
+    const indexRelatedMetadataNames = [
+      'index',
+      ...getMetadataRelatedMetadataNames('index'),
+      ...getMetadataSerializedRelationNames('index'),
+    ] as const;
+    const cacheKeysToFlush = [
+      ...new Set(indexRelatedMetadataNames.map(getMetadataFlatEntityMapsKey)),
+    ];
+
+    await this.workspaceCacheService.flush(workspaceId, cacheKeysToFlush);
+
+    await this.workspaceMetadataVersionService.incrementMetadataVersion(
+      workspaceId,
+    );
+  }
+}

--- a/packages/twenty-server/src/database/commands/upgrade-version-command/2-22/utils/__tests__/build-standard-search-vector-gin-index-backfill-operations.util.spec.ts
+++ b/packages/twenty-server/src/database/commands/upgrade-version-command/2-22/utils/__tests__/build-standard-search-vector-gin-index-backfill-operations.util.spec.ts
@@ -1,0 +1,267 @@
+import { STANDARD_OBJECTS } from 'twenty-shared/metadata';
+import { FieldMetadataType } from 'twenty-shared/types';
+
+import { buildStandardSearchVectorGinIndexBackfillOperations } from 'src/database/commands/upgrade-version-command/2-22/utils/build-standard-search-vector-gin-index-backfill-operations.util';
+import { type FlatEntityMaps } from 'src/engine/metadata-modules/flat-entity/types/flat-entity-maps.type';
+import { getFlatFieldMetadataMock } from 'src/engine/metadata-modules/flat-field-metadata/__mocks__/get-flat-field-metadata.mock';
+import { type FlatFieldMetadata } from 'src/engine/metadata-modules/flat-field-metadata/types/flat-field-metadata.type';
+import { getFlatIndexMetadataMock } from 'src/engine/metadata-modules/flat-index-metadata/__mocks__/get-flat-index-metadata.mock';
+import {
+  type FlatIndexFieldMetadata,
+  type FlatIndexMetadata,
+} from 'src/engine/metadata-modules/flat-index-metadata/types/flat-index-metadata.type';
+import { getFlatObjectMetadataMock } from 'src/engine/metadata-modules/flat-object-metadata/__mocks__/get-flat-object-metadata.mock';
+import { type FlatObjectMetadata } from 'src/engine/metadata-modules/flat-object-metadata/types/flat-object-metadata.type';
+import { IndexType } from 'src/engine/metadata-modules/index-metadata/types/indexType.types';
+import { SEARCH_VECTOR_FIELD } from 'src/engine/metadata-modules/search-field-metadata/constants/search-vector-field.constants';
+
+const STANDARD_APPLICATION_ID = 'standard-application-id';
+const INSTALLED_APPLICATION_ID = 'installed-application-id';
+// Application universal identifiers must be valid UUIDs: they are used as the v5
+// namespace by the deterministic identifier helpers.
+const STANDARD_APPLICATION_UID = '11111111-1111-4111-8111-111111111111';
+const INSTALLED_APPLICATION_UID = '33333333-3333-4333-8333-333333333333';
+
+const buildFlatObjectMetadataMaps = (
+  flatObjectMetadatas: FlatObjectMetadata[],
+): FlatEntityMaps<FlatObjectMetadata> => ({
+  byUniversalIdentifier: Object.fromEntries(
+    flatObjectMetadatas.map((flatObjectMetadata) => [
+      flatObjectMetadata.universalIdentifier,
+      flatObjectMetadata,
+    ]),
+  ),
+  universalIdentifierById: Object.fromEntries(
+    flatObjectMetadatas.map((flatObjectMetadata) => [
+      flatObjectMetadata.id,
+      flatObjectMetadata.universalIdentifier,
+    ]),
+  ),
+  universalIdentifiersByApplicationId: {},
+});
+
+const buildFlatFieldMetadataMaps = (
+  flatFieldMetadatas: FlatFieldMetadata[],
+): FlatEntityMaps<FlatFieldMetadata> => ({
+  byUniversalIdentifier: Object.fromEntries(
+    flatFieldMetadatas.map((flatFieldMetadata) => [
+      flatFieldMetadata.universalIdentifier,
+      flatFieldMetadata,
+    ]),
+  ),
+  universalIdentifierById: Object.fromEntries(
+    flatFieldMetadatas.map((flatFieldMetadata) => [
+      flatFieldMetadata.id,
+      flatFieldMetadata.universalIdentifier,
+    ]),
+  ),
+  universalIdentifiersByApplicationId: {},
+});
+
+const buildFlatIndexMaps = (
+  flatIndexMetadatas: FlatIndexMetadata[],
+): FlatEntityMaps<FlatIndexMetadata> => ({
+  byUniversalIdentifier: Object.fromEntries(
+    flatIndexMetadatas.map((flatIndexMetadata) => [
+      flatIndexMetadata.universalIdentifier,
+      flatIndexMetadata,
+    ]),
+  ),
+  universalIdentifierById: Object.fromEntries(
+    flatIndexMetadatas.map((flatIndexMetadata) => [
+      flatIndexMetadata.id,
+      flatIndexMetadata.universalIdentifier,
+    ]),
+  ),
+  universalIdentifiersByApplicationId: {},
+});
+
+const buildFlatIndexFieldMetadata = ({
+  fieldMetadataId,
+}: {
+  fieldMetadataId: string;
+}): FlatIndexFieldMetadata => {
+  const createdAt = '2024-01-01T00:00:00.000Z';
+
+  return {
+    id: `${fieldMetadataId}-index-field-id`,
+    workspaceId: 'workspace-id',
+    indexMetadataId: 'index-metadata-id',
+    fieldMetadataId,
+    order: 0,
+    subFieldName: null,
+    createdAt,
+    updatedAt: createdAt,
+  };
+};
+
+const buildSearchableObjectFixture = ({
+  objectId,
+  objectUniversalIdentifier,
+  applicationId,
+  applicationUniversalIdentifier,
+}: {
+  objectId: string;
+  objectUniversalIdentifier: string;
+  applicationId: string;
+  applicationUniversalIdentifier: string;
+}) => {
+  const searchVectorFlatFieldMetadata = getFlatFieldMetadataMock({
+    id: `${objectId}-search-vector-field-id`,
+    universalIdentifier: `${objectUniversalIdentifier}-search-vector-field-uid`,
+    objectMetadataId: objectId,
+    objectMetadataUniversalIdentifier: objectUniversalIdentifier,
+    type: FieldMetadataType.TS_VECTOR,
+    name: SEARCH_VECTOR_FIELD.name,
+    applicationId,
+    applicationUniversalIdentifier,
+  });
+
+  const flatObjectMetadata = getFlatObjectMetadataMock({
+    id: objectId,
+    universalIdentifier: objectUniversalIdentifier,
+    isSearchable: true,
+    applicationId,
+    applicationUniversalIdentifier,
+    fieldUniversalIdentifiers: [
+      searchVectorFlatFieldMetadata.universalIdentifier,
+    ],
+  });
+
+  return { flatObjectMetadata, searchVectorFlatFieldMetadata };
+};
+
+describe('buildStandardSearchVectorGinIndexBackfillOperations', () => {
+  it('creates a GIN searchVector index for a manifest-declared twenty-standard object that has none, grouped under its application', () => {
+    const { flatObjectMetadata, searchVectorFlatFieldMetadata } =
+      buildSearchableObjectFixture({
+        objectId: 'standard-object-id',
+        objectUniversalIdentifier:
+          STANDARD_OBJECTS.attachment.universalIdentifier,
+        applicationId: STANDARD_APPLICATION_ID,
+        applicationUniversalIdentifier: STANDARD_APPLICATION_UID,
+      });
+
+    const flatIndexesToCreateByApplicationUniversalIdentifier =
+      buildStandardSearchVectorGinIndexBackfillOperations({
+        flatObjectMetadataMaps: buildFlatObjectMetadataMaps([
+          flatObjectMetadata,
+        ]),
+        flatFieldMetadataMaps: buildFlatFieldMetadataMaps([
+          searchVectorFlatFieldMetadata,
+        ]),
+        flatIndexMaps: buildFlatIndexMaps([]),
+        twentyStandardApplicationId: STANDARD_APPLICATION_ID,
+      });
+
+    const createdIndexes =
+      flatIndexesToCreateByApplicationUniversalIdentifier[
+        STANDARD_APPLICATION_UID
+      ];
+
+    expect(createdIndexes).toHaveLength(1);
+    expect(createdIndexes?.[0].indexType).toBe(IndexType.GIN);
+    expect(createdIndexes?.[0].objectMetadataUniversalIdentifier).toBe(
+      flatObjectMetadata.universalIdentifier,
+    );
+    expect(createdIndexes?.[0].applicationUniversalIdentifier).toBe(
+      STANDARD_APPLICATION_UID,
+    );
+  });
+
+  it('does not create an index for a non twenty-standard object that has none', () => {
+    const { flatObjectMetadata, searchVectorFlatFieldMetadata } =
+      buildSearchableObjectFixture({
+        objectId: 'installed-object-id',
+        objectUniversalIdentifier: 'installed-object-uid',
+        applicationId: INSTALLED_APPLICATION_ID,
+        applicationUniversalIdentifier: INSTALLED_APPLICATION_UID,
+      });
+
+    const flatIndexesToCreateByApplicationUniversalIdentifier =
+      buildStandardSearchVectorGinIndexBackfillOperations({
+        flatObjectMetadataMaps: buildFlatObjectMetadataMaps([
+          flatObjectMetadata,
+        ]),
+        flatFieldMetadataMaps: buildFlatFieldMetadataMaps([
+          searchVectorFlatFieldMetadata,
+        ]),
+        flatIndexMaps: buildFlatIndexMaps([]),
+        twentyStandardApplicationId: STANDARD_APPLICATION_ID,
+      });
+
+    expect(
+      Object.keys(flatIndexesToCreateByApplicationUniversalIdentifier),
+    ).toHaveLength(0);
+  });
+
+  it('does not create an index for a twenty-standard object that does not declare a searchVector GIN index in the manifest (borderline objects)', () => {
+    const { flatObjectMetadata, searchVectorFlatFieldMetadata } =
+      buildSearchableObjectFixture({
+        objectId: 'note-target-object-id',
+        objectUniversalIdentifier:
+          STANDARD_OBJECTS.noteTarget.universalIdentifier,
+        applicationId: STANDARD_APPLICATION_ID,
+        applicationUniversalIdentifier: STANDARD_APPLICATION_UID,
+      });
+
+    const flatIndexesToCreateByApplicationUniversalIdentifier =
+      buildStandardSearchVectorGinIndexBackfillOperations({
+        flatObjectMetadataMaps: buildFlatObjectMetadataMaps([
+          flatObjectMetadata,
+        ]),
+        flatFieldMetadataMaps: buildFlatFieldMetadataMaps([
+          searchVectorFlatFieldMetadata,
+        ]),
+        flatIndexMaps: buildFlatIndexMaps([]),
+        twentyStandardApplicationId: STANDARD_APPLICATION_ID,
+      });
+
+    expect(
+      Object.keys(flatIndexesToCreateByApplicationUniversalIdentifier),
+    ).toHaveLength(0);
+  });
+
+  it('is idempotent: no create when the twenty-standard object already has a GIN searchVector index', () => {
+    const { flatObjectMetadata, searchVectorFlatFieldMetadata } =
+      buildSearchableObjectFixture({
+        objectId: 'standard-object-id',
+        objectUniversalIdentifier:
+          STANDARD_OBJECTS.attachment.universalIdentifier,
+        applicationId: STANDARD_APPLICATION_ID,
+        applicationUniversalIdentifier: STANDARD_APPLICATION_UID,
+      });
+
+    const ginIndex = getFlatIndexMetadataMock({
+      id: 'standard-gin-index-id',
+      universalIdentifier: 'standard-gin-index-uid',
+      objectMetadataId: flatObjectMetadata.id,
+      objectMetadataUniversalIdentifier: flatObjectMetadata.universalIdentifier,
+      applicationId: STANDARD_APPLICATION_ID,
+      applicationUniversalIdentifier: STANDARD_APPLICATION_UID,
+      name: 'IDX_SEARCH_VECTOR_STANDARD',
+      indexType: IndexType.GIN,
+      flatIndexFieldMetadatas: [
+        buildFlatIndexFieldMetadata({
+          fieldMetadataId: searchVectorFlatFieldMetadata.id,
+        }),
+      ],
+    });
+
+    const flatIndexesToCreateByApplicationUniversalIdentifier =
+      buildStandardSearchVectorGinIndexBackfillOperations({
+        flatObjectMetadataMaps: buildFlatObjectMetadataMaps([
+          flatObjectMetadata,
+        ]),
+        flatFieldMetadataMaps: buildFlatFieldMetadataMaps([
+          searchVectorFlatFieldMetadata,
+        ]),
+        flatIndexMaps: buildFlatIndexMaps([ginIndex]),
+        twentyStandardApplicationId: STANDARD_APPLICATION_ID,
+      });
+
+    expect(
+      Object.keys(flatIndexesToCreateByApplicationUniversalIdentifier),
+    ).toHaveLength(0);
+  });
+});

--- a/packages/twenty-server/src/database/commands/upgrade-version-command/2-22/utils/build-standard-search-vector-gin-index-backfill-operations.util.ts
+++ b/packages/twenty-server/src/database/commands/upgrade-version-command/2-22/utils/build-standard-search-vector-gin-index-backfill-operations.util.ts
@@ -1,0 +1,104 @@
+import { STANDARD_OBJECTS } from 'twenty-shared/metadata';
+import { fromArrayToValuesByKeyRecord, isDefined } from 'twenty-shared/utils';
+
+import { isSearchVectorGinFlatIndexMetadata } from 'src/database/commands/upgrade-version-command/2-20/utils/is-search-vector-gin-flat-index-metadata.util';
+import { type FlatEntityMaps } from 'src/engine/metadata-modules/flat-entity/types/flat-entity-maps.type';
+import { type FlatFieldMetadata } from 'src/engine/metadata-modules/flat-field-metadata/types/flat-field-metadata.type';
+import { type FlatIndexMetadata } from 'src/engine/metadata-modules/flat-index-metadata/types/flat-index-metadata.type';
+import { type FlatObjectMetadata } from 'src/engine/metadata-modules/flat-object-metadata/types/flat-object-metadata.type';
+import { findTsVectorFlatFieldMetadataForObject } from 'src/engine/metadata-modules/flat-search-field-metadata/utils/find-ts-vector-flat-field-metadata-for-object.util';
+import { buildSearchVectorGinIndexForCustomObject } from 'src/engine/metadata-modules/object-metadata/utils/build-search-vector-gin-index-for-custom-object.util';
+import { type UniversalFlatIndexMetadata } from 'src/engine/workspace-manager/workspace-migration/universal-flat-entity/types/universal-flat-index-metadata.type';
+
+// Object universal identifiers of the twenty-standard objects that declare a searchVector
+// GIN index in the manifest. Restricting the backfill to these excludes objects whose
+// searchVector is intentionally left without a GIN index (e.g. the borderline UUID-only
+// searchable objects and non-searchable objects), so the backfill only creates indexes the
+// manifest actually declares.
+const STANDARD_OBJECT_UNIVERSAL_IDENTIFIERS_DECLARING_SEARCH_VECTOR_GIN_INDEX =
+  new Set<string>(
+    Object.values(STANDARD_OBJECTS)
+      .filter((standardObject) =>
+        Object.keys(standardObject.indexes).includes('searchVectorGinIndex'),
+      )
+      .map((standardObject) => standardObject.universalIdentifier),
+  );
+
+type BuildStandardSearchVectorGinIndexBackfillOperationsArgs = {
+  flatObjectMetadataMaps: FlatEntityMaps<FlatObjectMetadata>;
+  flatFieldMetadataMaps: FlatEntityMaps<FlatFieldMetadata>;
+  flatIndexMaps: FlatEntityMaps<FlatIndexMetadata>;
+  twentyStandardApplicationId: string;
+};
+
+// Backfills the searchVector GIN index for twenty-standard objects that declare it in the
+// manifest but are still missing it in existing workspaces (the objects whose declaration
+// was only just added and previously relied on runtime side-effect creation). The 2-20
+// backfill deliberately skips twenty-standard, so this covers that gap. Grouped by
+// application universal identifier for the per-application migration run.
+export const buildStandardSearchVectorGinIndexBackfillOperations = ({
+  flatObjectMetadataMaps,
+  flatFieldMetadataMaps,
+  flatIndexMaps,
+  twentyStandardApplicationId,
+}: BuildStandardSearchVectorGinIndexBackfillOperationsArgs): Record<
+  string,
+  UniversalFlatIndexMetadata[]
+> => {
+  const objectMetadataIdsWithSearchVectorGinIndex = new Set<string>();
+
+  for (const flatIndexMetadata of Object.values(
+    flatIndexMaps.byUniversalIdentifier,
+  ).filter(isDefined)) {
+    if (
+      isSearchVectorGinFlatIndexMetadata({
+        flatIndexMetadata,
+        flatFieldMetadataMaps,
+      })
+    ) {
+      objectMetadataIdsWithSearchVectorGinIndex.add(
+        flatIndexMetadata.objectMetadataId,
+      );
+    }
+  }
+
+  const flatIndexesToCreate: UniversalFlatIndexMetadata[] = [];
+
+  for (const flatObjectMetadata of Object.values(
+    flatObjectMetadataMaps.byUniversalIdentifier,
+  ).filter(isDefined)) {
+    if (
+      flatObjectMetadata.applicationId !== twentyStandardApplicationId ||
+      !STANDARD_OBJECT_UNIVERSAL_IDENTIFIERS_DECLARING_SEARCH_VECTOR_GIN_INDEX.has(
+        flatObjectMetadata.universalIdentifier,
+      )
+    ) {
+      continue;
+    }
+
+    if (objectMetadataIdsWithSearchVectorGinIndex.has(flatObjectMetadata.id)) {
+      continue;
+    }
+
+    const tsVectorFlatFieldMetadata = findTsVectorFlatFieldMetadataForObject({
+      fieldUniversalIdentifiers: flatObjectMetadata.fieldUniversalIdentifiers,
+      flatFieldMetadataMaps,
+    });
+
+    if (!isDefined(tsVectorFlatFieldMetadata)) {
+      continue;
+    }
+
+    flatIndexesToCreate.push(
+      buildSearchVectorGinIndexForCustomObject({
+        flatObjectMetadata,
+        searchVectorFlatFieldMetadata: tsVectorFlatFieldMetadata,
+      }),
+    );
+  }
+
+  return fromArrayToValuesByKeyRecord({
+    array: flatIndexesToCreate,
+    key: 'applicationUniversalIdentifier',
+  });
+};

--- a/packages/twenty-server/src/database/commands/upgrade-version-command/workspace-command-provider.module.ts
+++ b/packages/twenty-server/src/database/commands/upgrade-version-command/workspace-command-provider.module.ts
@@ -22,6 +22,7 @@ import { V2_18_UpgradeVersionCommandModule } from 'src/database/commands/upgrade
 import { V2_19_UpgradeVersionCommandModule } from 'src/database/commands/upgrade-version-command/2-19/2-19-upgrade-version-command.module';
 import { V2_20_UpgradeVersionCommandModule } from 'src/database/commands/upgrade-version-command/2-20/2-20-upgrade-version-command.module';
 import { V2_21_UpgradeVersionCommandModule } from 'src/database/commands/upgrade-version-command/2-21/2-21-upgrade-version-command.module';
+import { V2_22_UpgradeVersionCommandModule } from 'src/database/commands/upgrade-version-command/2-22/2-22-upgrade-version-command.module';
 
 @Module({
   imports: [
@@ -47,6 +48,7 @@ import { V2_21_UpgradeVersionCommandModule } from 'src/database/commands/upgrade
     V2_19_UpgradeVersionCommandModule,
     V2_20_UpgradeVersionCommandModule,
     V2_21_UpgradeVersionCommandModule,
+    V2_22_UpgradeVersionCommandModule,
   ],
 })
 export class WorkspaceCommandProviderModule {}

--- a/packages/twenty-server/src/engine/workspace-manager/twenty-standard-application/utils/index/build-standard-flat-index-metadata-maps.util.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/twenty-standard-application/utils/index/build-standard-flat-index-metadata-maps.util.ts
@@ -7,6 +7,7 @@ import { buildAttachmentStandardFlatIndexMetadatas } from 'src/engine/workspace-
 import { buildBlocklistStandardFlatIndexMetadatas } from 'src/engine/workspace-manager/twenty-standard-application/utils/index/compute-blocklist-standard-flat-index-metadata.util';
 import { buildCalendarChannelEventAssociationStandardFlatIndexMetadatas } from 'src/engine/workspace-manager/twenty-standard-application/utils/index/compute-calendar-channel-event-association-standard-flat-index-metadata.util';
 import { buildCalendarEventParticipantStandardFlatIndexMetadatas } from 'src/engine/workspace-manager/twenty-standard-application/utils/index/compute-calendar-event-participant-standard-flat-index-metadata.util';
+import { buildCalendarEventStandardFlatIndexMetadatas } from 'src/engine/workspace-manager/twenty-standard-application/utils/index/compute-calendar-event-standard-flat-index-metadata.util';
 import { buildCallRecordingStandardFlatIndexMetadatas } from 'src/engine/workspace-manager/twenty-standard-application/utils/index/compute-call-recording-standard-flat-index-metadata.util';
 import { buildCompanyStandardFlatIndexMetadatas } from 'src/engine/workspace-manager/twenty-standard-application/utils/index/compute-company-standard-flat-index-metadata.util';
 import { buildDashboardStandardFlatIndexMetadatas } from 'src/engine/workspace-manager/twenty-standard-application/utils/index/compute-dashboard-standard-flat-index-metadata.util';
@@ -17,6 +18,7 @@ import { buildMessageChannelMessageAssociationMessageFolderStandardFlatIndexMeta
 import { buildMessageChannelMessageAssociationStandardFlatIndexMetadatas } from 'src/engine/workspace-manager/twenty-standard-application/utils/index/compute-message-channel-message-association-standard-flat-index-metadata.util';
 import { buildMessageParticipantStandardFlatIndexMetadatas } from 'src/engine/workspace-manager/twenty-standard-application/utils/index/compute-message-participant-standard-flat-index-metadata.util';
 import { buildMessageStandardFlatIndexMetadatas } from 'src/engine/workspace-manager/twenty-standard-application/utils/index/compute-message-standard-flat-index-metadata.util';
+import { buildMessageThreadStandardFlatIndexMetadatas } from 'src/engine/workspace-manager/twenty-standard-application/utils/index/compute-message-thread-standard-flat-index-metadata.util';
 import { buildNoteStandardFlatIndexMetadatas } from 'src/engine/workspace-manager/twenty-standard-application/utils/index/compute-note-standard-flat-index-metadata.util';
 import { buildNoteTargetStandardFlatIndexMetadatas } from 'src/engine/workspace-manager/twenty-standard-application/utils/index/compute-note-target-standard-flat-index-metadata.util';
 import { buildOpportunityStandardFlatIndexMetadatas } from 'src/engine/workspace-manager/twenty-standard-application/utils/index/compute-opportunity-standard-flat-index-metadata.util';
@@ -42,6 +44,7 @@ const STANDARD_FLAT_INDEX_METADATA_BUILDERS_BY_OBJECT_NAME = {
     buildCalendarChannelEventAssociationStandardFlatIndexMetadatas,
   calendarEventParticipant:
     buildCalendarEventParticipantStandardFlatIndexMetadatas,
+  calendarEvent: buildCalendarEventStandardFlatIndexMetadatas,
   callRecording: buildCallRecordingStandardFlatIndexMetadatas,
   company: buildCompanyStandardFlatIndexMetadatas,
   dashboard: buildDashboardStandardFlatIndexMetadatas,
@@ -54,6 +57,7 @@ const STANDARD_FLAT_INDEX_METADATA_BUILDERS_BY_OBJECT_NAME = {
   messageChannelMessageAssociationMessageFolder:
     buildMessageChannelMessageAssociationMessageFolderStandardFlatIndexMetadatas,
   messageParticipant: buildMessageParticipantStandardFlatIndexMetadatas,
+  messageThread: buildMessageThreadStandardFlatIndexMetadatas,
   note: buildNoteStandardFlatIndexMetadatas,
   noteTarget: buildNoteTargetStandardFlatIndexMetadatas,
   opportunity: buildOpportunityStandardFlatIndexMetadatas,

--- a/packages/twenty-server/src/engine/workspace-manager/twenty-standard-application/utils/index/compute-attachment-standard-flat-index-metadata.util.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/twenty-standard-application/utils/index/compute-attachment-standard-flat-index-metadata.util.ts
@@ -1,4 +1,5 @@
 import { type FlatIndexMetadata } from 'src/engine/metadata-modules/flat-index-metadata/types/flat-index-metadata.type';
+import { IndexType } from 'src/engine/metadata-modules/index-metadata/types/indexType.types';
 import { type AllStandardObjectIndexName } from 'src/engine/workspace-manager/twenty-standard-application/types/all-standard-object-index-name.type';
 import {
   type CreateStandardIndexArgs,
@@ -94,6 +95,20 @@ export const buildAttachmentStandardFlatIndexMetadatas = ({
     context: {
       indexName: 'workflowIdIndex',
       relatedFieldNames: ['targetWorkflow'],
+    },
+    standardObjectMetadataRelatedEntityIds,
+    dependencyFlatEntityMaps,
+    twentyStandardApplicationId,
+    now,
+  }),
+  searchVectorGinIndex: createStandardIndexFlatMetadata({
+    objectName,
+    workspaceId,
+    context: {
+      indexName: 'searchVectorGinIndex',
+      relatedFieldNames: ['searchVector'],
+      indexType: IndexType.GIN,
+      hasDeterministicUniversalIdentifier: true,
     },
     standardObjectMetadataRelatedEntityIds,
     dependencyFlatEntityMaps,

--- a/packages/twenty-server/src/engine/workspace-manager/twenty-standard-application/utils/index/compute-blocklist-standard-flat-index-metadata.util.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/twenty-standard-application/utils/index/compute-blocklist-standard-flat-index-metadata.util.ts
@@ -1,4 +1,5 @@
 import { type FlatIndexMetadata } from 'src/engine/metadata-modules/flat-index-metadata/types/flat-index-metadata.type';
+import { IndexType } from 'src/engine/metadata-modules/index-metadata/types/indexType.types';
 import { type AllStandardObjectIndexName } from 'src/engine/workspace-manager/twenty-standard-application/types/all-standard-object-index-name.type';
 import {
   type CreateStandardIndexArgs,
@@ -22,6 +23,20 @@ export const buildBlocklistStandardFlatIndexMetadatas = ({
     context: {
       indexName: 'workspaceMemberIdIndex',
       relatedFieldNames: ['workspaceMember'],
+    },
+    standardObjectMetadataRelatedEntityIds,
+    dependencyFlatEntityMaps,
+    twentyStandardApplicationId,
+    now,
+  }),
+  searchVectorGinIndex: createStandardIndexFlatMetadata({
+    objectName,
+    workspaceId,
+    context: {
+      indexName: 'searchVectorGinIndex',
+      relatedFieldNames: ['searchVector'],
+      indexType: IndexType.GIN,
+      hasDeterministicUniversalIdentifier: true,
     },
     standardObjectMetadataRelatedEntityIds,
     dependencyFlatEntityMaps,

--- a/packages/twenty-server/src/engine/workspace-manager/twenty-standard-application/utils/index/compute-calendar-channel-event-association-standard-flat-index-metadata.util.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/twenty-standard-application/utils/index/compute-calendar-channel-event-association-standard-flat-index-metadata.util.ts
@@ -1,4 +1,5 @@
 import { type FlatIndexMetadata } from 'src/engine/metadata-modules/flat-index-metadata/types/flat-index-metadata.type';
+import { IndexType } from 'src/engine/metadata-modules/index-metadata/types/indexType.types';
 import { type AllStandardObjectIndexName } from 'src/engine/workspace-manager/twenty-standard-application/types/all-standard-object-index-name.type';
 import {
   type CreateStandardIndexArgs,
@@ -37,6 +38,20 @@ export const buildCalendarChannelEventAssociationStandardFlatIndexMetadatas = ({
     context: {
       indexName: 'calendarEventIdIndex',
       relatedFieldNames: ['calendarEvent'],
+    },
+    standardObjectMetadataRelatedEntityIds,
+    dependencyFlatEntityMaps,
+    twentyStandardApplicationId,
+    now,
+  }),
+  searchVectorGinIndex: createStandardIndexFlatMetadata({
+    objectName,
+    workspaceId,
+    context: {
+      indexName: 'searchVectorGinIndex',
+      relatedFieldNames: ['searchVector'],
+      indexType: IndexType.GIN,
+      hasDeterministicUniversalIdentifier: true,
     },
     standardObjectMetadataRelatedEntityIds,
     dependencyFlatEntityMaps,

--- a/packages/twenty-server/src/engine/workspace-manager/twenty-standard-application/utils/index/compute-calendar-event-participant-standard-flat-index-metadata.util.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/twenty-standard-application/utils/index/compute-calendar-event-participant-standard-flat-index-metadata.util.ts
@@ -1,4 +1,5 @@
 import { type FlatIndexMetadata } from 'src/engine/metadata-modules/flat-index-metadata/types/flat-index-metadata.type';
+import { IndexType } from 'src/engine/metadata-modules/index-metadata/types/indexType.types';
 import { type AllStandardObjectIndexName } from 'src/engine/workspace-manager/twenty-standard-application/types/all-standard-object-index-name.type';
 import {
   type CreateStandardIndexArgs,
@@ -49,6 +50,20 @@ export const buildCalendarEventParticipantStandardFlatIndexMetadatas = ({
     context: {
       indexName: 'workspaceMemberIdIndex',
       relatedFieldNames: ['workspaceMember'],
+    },
+    standardObjectMetadataRelatedEntityIds,
+    dependencyFlatEntityMaps,
+    twentyStandardApplicationId,
+    now,
+  }),
+  searchVectorGinIndex: createStandardIndexFlatMetadata({
+    objectName,
+    workspaceId,
+    context: {
+      indexName: 'searchVectorGinIndex',
+      relatedFieldNames: ['searchVector'],
+      indexType: IndexType.GIN,
+      hasDeterministicUniversalIdentifier: true,
     },
     standardObjectMetadataRelatedEntityIds,
     dependencyFlatEntityMaps,

--- a/packages/twenty-server/src/engine/workspace-manager/twenty-standard-application/utils/index/compute-calendar-event-standard-flat-index-metadata.util.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/twenty-standard-application/utils/index/compute-calendar-event-standard-flat-index-metadata.util.ts
@@ -6,29 +6,17 @@ import {
   createStandardIndexFlatMetadata,
 } from 'src/engine/workspace-manager/twenty-standard-application/utils/index/create-standard-index-flat-metadata.util';
 
-export const buildCallRecordingStandardFlatIndexMetadatas = ({
+export const buildCalendarEventStandardFlatIndexMetadatas = ({
   now,
   objectName,
   workspaceId,
   standardObjectMetadataRelatedEntityIds,
   dependencyFlatEntityMaps,
   twentyStandardApplicationId,
-}: Omit<CreateStandardIndexArgs<'callRecording'>, 'context'>): Record<
-  AllStandardObjectIndexName<'callRecording'>,
+}: Omit<CreateStandardIndexArgs<'calendarEvent'>, 'context'>): Record<
+  AllStandardObjectIndexName<'calendarEvent'>,
   FlatIndexMetadata
 > => ({
-  calendarEventIdIndex: createStandardIndexFlatMetadata({
-    objectName,
-    workspaceId,
-    context: {
-      indexName: 'calendarEventIdIndex',
-      relatedFieldNames: ['calendarEvent'],
-    },
-    standardObjectMetadataRelatedEntityIds,
-    dependencyFlatEntityMaps,
-    twentyStandardApplicationId,
-    now,
-  }),
   searchVectorGinIndex: createStandardIndexFlatMetadata({
     objectName,
     workspaceId,

--- a/packages/twenty-server/src/engine/workspace-manager/twenty-standard-application/utils/index/compute-message-channel-message-association-standard-flat-index-metadata.util.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/twenty-standard-application/utils/index/compute-message-channel-message-association-standard-flat-index-metadata.util.ts
@@ -1,4 +1,5 @@
 import { type FlatIndexMetadata } from 'src/engine/metadata-modules/flat-index-metadata/types/flat-index-metadata.type';
+import { IndexType } from 'src/engine/metadata-modules/index-metadata/types/indexType.types';
 import { type AllStandardObjectIndexName } from 'src/engine/workspace-manager/twenty-standard-application/types/all-standard-object-index-name.type';
 import {
   type CreateStandardIndexArgs,
@@ -52,6 +53,20 @@ export const buildMessageChannelMessageAssociationStandardFlatIndexMetadatas =
         relatedFieldNames: ['messageChannelId', 'message'],
         isUnique: true,
         indexWhereClause: '"deletedAt" IS NULL',
+      },
+      standardObjectMetadataRelatedEntityIds,
+      dependencyFlatEntityMaps,
+      twentyStandardApplicationId,
+      now,
+    }),
+    searchVectorGinIndex: createStandardIndexFlatMetadata({
+      objectName,
+      workspaceId,
+      context: {
+        indexName: 'searchVectorGinIndex',
+        relatedFieldNames: ['searchVector'],
+        indexType: IndexType.GIN,
+        hasDeterministicUniversalIdentifier: true,
       },
       standardObjectMetadataRelatedEntityIds,
       dependencyFlatEntityMaps,

--- a/packages/twenty-server/src/engine/workspace-manager/twenty-standard-application/utils/index/compute-message-participant-standard-flat-index-metadata.util.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/twenty-standard-application/utils/index/compute-message-participant-standard-flat-index-metadata.util.ts
@@ -1,4 +1,5 @@
 import { type FlatIndexMetadata } from 'src/engine/metadata-modules/flat-index-metadata/types/flat-index-metadata.type';
+import { IndexType } from 'src/engine/metadata-modules/index-metadata/types/indexType.types';
 import { type AllStandardObjectIndexName } from 'src/engine/workspace-manager/twenty-standard-application/types/all-standard-object-index-name.type';
 import {
   type CreateStandardIndexArgs,
@@ -58,6 +59,20 @@ export const buildMessageParticipantStandardFlatIndexMetadatas = ({
     context: {
       indexName: 'messageCampaignIdIndex',
       relatedFieldNames: ['messageCampaign'],
+    },
+    standardObjectMetadataRelatedEntityIds,
+    dependencyFlatEntityMaps,
+    twentyStandardApplicationId,
+    now,
+  }),
+  searchVectorGinIndex: createStandardIndexFlatMetadata({
+    objectName,
+    workspaceId,
+    context: {
+      indexName: 'searchVectorGinIndex',
+      relatedFieldNames: ['searchVector'],
+      indexType: IndexType.GIN,
+      hasDeterministicUniversalIdentifier: true,
     },
     standardObjectMetadataRelatedEntityIds,
     dependencyFlatEntityMaps,

--- a/packages/twenty-server/src/engine/workspace-manager/twenty-standard-application/utils/index/compute-message-standard-flat-index-metadata.util.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/twenty-standard-application/utils/index/compute-message-standard-flat-index-metadata.util.ts
@@ -1,4 +1,5 @@
 import { type FlatIndexMetadata } from 'src/engine/metadata-modules/flat-index-metadata/types/flat-index-metadata.type';
+import { IndexType } from 'src/engine/metadata-modules/index-metadata/types/indexType.types';
 import { type AllStandardObjectIndexName } from 'src/engine/workspace-manager/twenty-standard-application/types/all-standard-object-index-name.type';
 import {
   type CreateStandardIndexArgs,
@@ -34,6 +35,20 @@ export const buildMessageStandardFlatIndexMetadatas = ({
     context: {
       indexName: 'messageCampaignIdIndex',
       relatedFieldNames: ['messageCampaign'],
+    },
+    standardObjectMetadataRelatedEntityIds,
+    dependencyFlatEntityMaps,
+    twentyStandardApplicationId,
+    now,
+  }),
+  searchVectorGinIndex: createStandardIndexFlatMetadata({
+    objectName,
+    workspaceId,
+    context: {
+      indexName: 'searchVectorGinIndex',
+      relatedFieldNames: ['searchVector'],
+      indexType: IndexType.GIN,
+      hasDeterministicUniversalIdentifier: true,
     },
     standardObjectMetadataRelatedEntityIds,
     dependencyFlatEntityMaps,

--- a/packages/twenty-server/src/engine/workspace-manager/twenty-standard-application/utils/index/compute-message-thread-standard-flat-index-metadata.util.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/twenty-standard-application/utils/index/compute-message-thread-standard-flat-index-metadata.util.ts
@@ -6,29 +6,17 @@ import {
   createStandardIndexFlatMetadata,
 } from 'src/engine/workspace-manager/twenty-standard-application/utils/index/create-standard-index-flat-metadata.util';
 
-export const buildCallRecordingStandardFlatIndexMetadatas = ({
+export const buildMessageThreadStandardFlatIndexMetadatas = ({
   now,
   objectName,
   workspaceId,
   standardObjectMetadataRelatedEntityIds,
   dependencyFlatEntityMaps,
   twentyStandardApplicationId,
-}: Omit<CreateStandardIndexArgs<'callRecording'>, 'context'>): Record<
-  AllStandardObjectIndexName<'callRecording'>,
+}: Omit<CreateStandardIndexArgs<'messageThread'>, 'context'>): Record<
+  AllStandardObjectIndexName<'messageThread'>,
   FlatIndexMetadata
 > => ({
-  calendarEventIdIndex: createStandardIndexFlatMetadata({
-    objectName,
-    workspaceId,
-    context: {
-      indexName: 'calendarEventIdIndex',
-      relatedFieldNames: ['calendarEvent'],
-    },
-    standardObjectMetadataRelatedEntityIds,
-    dependencyFlatEntityMaps,
-    twentyStandardApplicationId,
-    now,
-  }),
   searchVectorGinIndex: createStandardIndexFlatMetadata({
     objectName,
     workspaceId,

--- a/packages/twenty-server/src/engine/workspace-manager/twenty-standard-application/utils/index/compute-timeline-activity-standard-flat-index-metadata.util.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/twenty-standard-application/utils/index/compute-timeline-activity-standard-flat-index-metadata.util.ts
@@ -1,4 +1,5 @@
 import { type FlatIndexMetadata } from 'src/engine/metadata-modules/flat-index-metadata/types/flat-index-metadata.type';
+import { IndexType } from 'src/engine/metadata-modules/index-metadata/types/indexType.types';
 import { type AllStandardObjectIndexName } from 'src/engine/workspace-manager/twenty-standard-application/types/all-standard-object-index-name.type';
 import {
   type CreateStandardIndexArgs,
@@ -130,6 +131,20 @@ export const buildTimelineActivityStandardFlatIndexMetadatas = ({
     context: {
       indexName: 'dashboardIdIndex',
       relatedFieldNames: ['targetDashboard'],
+    },
+    standardObjectMetadataRelatedEntityIds,
+    dependencyFlatEntityMaps,
+    twentyStandardApplicationId,
+    now,
+  }),
+  searchVectorGinIndex: createStandardIndexFlatMetadata({
+    objectName,
+    workspaceId,
+    context: {
+      indexName: 'searchVectorGinIndex',
+      relatedFieldNames: ['searchVector'],
+      indexType: IndexType.GIN,
+      hasDeterministicUniversalIdentifier: true,
     },
     standardObjectMetadataRelatedEntityIds,
     dependencyFlatEntityMaps,

--- a/packages/twenty-shared/src/metadata/__tests__/__snapshots__/standardObjectUniversalIdentifiers.test.ts.snap
+++ b/packages/twenty-shared/src/metadata/__tests__/__snapshots__/standardObjectUniversalIdentifiers.test.ts.snap
@@ -78,6 +78,9 @@ exports[`STANDARD_OBJECTS universal identifiers should never change without an e
       "personIdIndex": {
         "universalIdentifier": "55637a5a-1edc-4351-8d76-d40020bf8944",
       },
+      "searchVectorGinIndex": {
+        "universalIdentifier": "68d93786-4909-4883-bdee-721f4dc087d2",
+      },
       "taskIdIndex": {
         "universalIdentifier": "b8d4f9a3-0c25-4e7b-9f6a-2d3e4c5b6f70",
       },
@@ -166,6 +169,9 @@ exports[`STANDARD_OBJECTS universal identifiers should never change without an e
       },
     },
     "indexes": {
+      "searchVectorGinIndex": {
+        "universalIdentifier": "273d6a6f-d3cf-410a-a162-56cca11d21e6",
+      },
       "workspaceMemberIdIndex": {
         "universalIdentifier": "4daf320e-74d0-4f24-a45a-af3a09d741cb",
       },
@@ -255,6 +261,9 @@ exports[`STANDARD_OBJECTS universal identifiers should never change without an e
       },
       "calendarEventIdIndex": {
         "universalIdentifier": "47a3c8d2-9f14-4b6e-8c5d-1a2b3f4e5c69",
+      },
+      "searchVectorGinIndex": {
+        "universalIdentifier": "b9f1b0bc-43e9-41f4-b7d7-5ba9be56fd74",
       },
     },
     "universalIdentifier": "20202020-491b-4aaa-9825-afd1bae6ae00",
@@ -378,7 +387,11 @@ exports[`STANDARD_OBJECTS universal identifiers should never change without an e
         "universalIdentifier": "ace17dae-1488-50eb-849e-02f409627627",
       },
     },
-    "indexes": {},
+    "indexes": {
+      "searchVectorGinIndex": {
+        "universalIdentifier": "a9774ff0-f3f5-482e-98a4-af49804b1628",
+      },
+    },
     "universalIdentifier": "20202020-8f1d-4eef-9f85-0d1965e27221",
     "views": {
       "allCalendarEvents": {
@@ -515,6 +528,9 @@ exports[`STANDARD_OBJECTS universal identifiers should never change without an e
       },
       "personIdIndex": {
         "universalIdentifier": "30e9b75a-881f-4a85-aaf1-f2d2464be1cf",
+      },
+      "searchVectorGinIndex": {
+        "universalIdentifier": "3864f144-0848-4478-aaf7-3e85daad1b11",
       },
       "workspaceMemberIdIndex": {
         "universalIdentifier": "898aa202-428f-4a7a-a3b3-8f0a17a6658e",
@@ -662,6 +678,9 @@ exports[`STANDARD_OBJECTS universal identifiers should never change without an e
     "indexes": {
       "calendarEventIdIndex": {
         "universalIdentifier": "8be3cc47-9352-4a1b-ad19-bb186bc0865d",
+      },
+      "searchVectorGinIndex": {
+        "universalIdentifier": "2e59eb58-003c-41f1-9299-0b53d6c20d4f",
       },
     },
     "universalIdentifier": "ce19efb9-710f-45b2-b141-473abbeea60b",
@@ -1019,6 +1038,9 @@ exports[`STANDARD_OBJECTS universal identifiers should never change without an e
       "messageThreadIdIndex": {
         "universalIdentifier": "7a05b45e-7aa6-4a7e-9bbc-299cbed53c96",
       },
+      "searchVectorGinIndex": {
+        "universalIdentifier": "ef468949-5df6-43d0-9933-bda0009883fe",
+      },
     },
     "universalIdentifier": "20202020-3f6b-4425-80ab-e468899ab4b2",
     "views": {
@@ -1229,6 +1251,9 @@ exports[`STANDARD_OBJECTS universal identifiers should never change without an e
       },
       "messageIdIndex": {
         "universalIdentifier": "9bb24d40-60dd-4beb-8c64-a74e8c67f9ee",
+      },
+      "searchVectorGinIndex": {
+        "universalIdentifier": "438011c0-1273-43d1-985a-9a4cc4764fe8",
       },
     },
     "universalIdentifier": "20202020-ad1e-4127-bccb-d83ae04d2ccb",
@@ -1539,6 +1564,9 @@ exports[`STANDARD_OBJECTS universal identifiers should never change without an e
       "personIdIndex": {
         "universalIdentifier": "df805c2e-3bfe-4d51-8309-75e5eb4052fe",
       },
+      "searchVectorGinIndex": {
+        "universalIdentifier": "1067429e-5d82-48eb-8008-b54efa3f6888",
+      },
       "workspaceMemberIdIndex": {
         "universalIdentifier": "ce1e3a9e-afe9-439d-abb7-6cc98a6fa405",
       },
@@ -1643,7 +1671,11 @@ exports[`STANDARD_OBJECTS universal identifiers should never change without an e
         "universalIdentifier": "0c9b48d9-795f-50f7-aa44-8f286660199c",
       },
     },
-    "indexes": {},
+    "indexes": {
+      "searchVectorGinIndex": {
+        "universalIdentifier": "efebaaf5-03f6-439d-86df-36aa66be68ca",
+      },
+    },
     "universalIdentifier": "20202020-849a-4c3e-84f5-a25a7d802271",
     "views": {
       "allMessageThreads": {
@@ -2638,6 +2670,9 @@ exports[`STANDARD_OBJECTS universal identifiers should never change without an e
       },
       "personIdIndex": {
         "universalIdentifier": "3e89a914-7bec-47bd-9cf9-743c6b83d001",
+      },
+      "searchVectorGinIndex": {
+        "universalIdentifier": "0c97ba73-a022-4584-b500-8437adf269fd",
       },
       "taskIdIndex": {
         "universalIdentifier": "609cf622-86ef-48d1-812b-e1cab610a46c",

--- a/packages/twenty-shared/src/metadata/constants/standard-object.constant.ts
+++ b/packages/twenty-shared/src/metadata/constants/standard-object.constant.ts
@@ -71,6 +71,9 @@ export const STANDARD_OBJECTS = {
       workflowIdIndex: {
         universalIdentifier: 'fadeab4b-79ee-4173-af79-72c51fbad888',
       },
+      searchVectorGinIndex: {
+        universalIdentifier: '68d93786-4909-4883-bdee-721f4dc087d2',
+      },
     },
     views: {
       allAttachments: {
@@ -127,6 +130,9 @@ export const STANDARD_OBJECTS = {
     indexes: {
       workspaceMemberIdIndex: {
         universalIdentifier: '4daf320e-74d0-4f24-a45a-af3a09d741cb',
+      },
+      searchVectorGinIndex: {
+        universalIdentifier: '273d6a6f-d3cf-410a-a162-56cca11d21e6',
       },
     },
     views: {
@@ -193,6 +199,9 @@ export const STANDARD_OBJECTS = {
       },
       calendarEventIdIndex: {
         universalIdentifier: '47a3c8d2-9f14-4b6e-8c5d-1a2b3f4e5c69',
+      },
+      searchVectorGinIndex: {
+        universalIdentifier: 'b9f1b0bc-43e9-41f4-b7d7-5ba9be56fd74',
       },
     },
     views: {
@@ -280,6 +289,9 @@ export const STANDARD_OBJECTS = {
       },
       workspaceMemberIdIndex: {
         universalIdentifier: '898aa202-428f-4a7a-a3b3-8f0a17a6658e',
+      },
+      searchVectorGinIndex: {
+        universalIdentifier: '3864f144-0848-4478-aaf7-3e85daad1b11',
       },
     },
     views: {
@@ -402,7 +414,11 @@ export const STANDARD_OBJECTS = {
         universalIdentifier: '48d6d151-18e2-4111-b405-d85fb9d860d8',
       },
     },
-    indexes: {},
+    indexes: {
+      searchVectorGinIndex: {
+        universalIdentifier: 'a9774ff0-f3f5-482e-98a4-af49804b1628',
+      },
+    },
     views: {
       allCalendarEvents: {
         universalIdentifier: '20202020-c001-4c01-8c01-ca1ebe0ca001',
@@ -533,6 +549,9 @@ export const STANDARD_OBJECTS = {
     indexes: {
       calendarEventIdIndex: {
         universalIdentifier: '8be3cc47-9352-4a1b-ad19-bb186bc0865d',
+      },
+      searchVectorGinIndex: {
+        universalIdentifier: '2e59eb58-003c-41f1-9299-0b53d6c20d4f',
       },
     },
     views: {
@@ -966,6 +985,9 @@ export const STANDARD_OBJECTS = {
       messageChannelIdMessageIdUniqueIndex: {
         universalIdentifier: '1b86ece8-7ce3-4df3-8771-fd4b5d45b2f2',
       },
+      searchVectorGinIndex: {
+        universalIdentifier: '438011c0-1273-43d1-985a-9a4cc4764fe8',
+      },
     },
     views: {
       allMessageChannelMessageAssociations: {
@@ -1128,6 +1150,9 @@ export const STANDARD_OBJECTS = {
       messageCampaignIdIndex: {
         universalIdentifier: 'e9bcdd77-cc8b-4532-833c-124dfdc8e5ff',
       },
+      searchVectorGinIndex: {
+        universalIdentifier: '1067429e-5d82-48eb-8008-b54efa3f6888',
+      },
     },
     views: {
       allMessageParticipants: {
@@ -1208,7 +1233,11 @@ export const STANDARD_OBJECTS = {
         universalIdentifier: 'a8ddbf8c-1137-45d1-b89e-5ffbd83f67c8',
       },
     },
-    indexes: {},
+    indexes: {
+      searchVectorGinIndex: {
+        universalIdentifier: 'efebaaf5-03f6-439d-86df-36aa66be68ca',
+      },
+    },
     views: {
       allMessageThreads: {
         universalIdentifier: '20202020-d002-4d02-8d02-ae55a9ba2002',
@@ -1268,6 +1297,9 @@ export const STANDARD_OBJECTS = {
       },
       messageCampaignIdIndex: {
         universalIdentifier: '79e777ca-7008-46c5-b3a6-3108b7c7dfb6',
+      },
+      searchVectorGinIndex: {
+        universalIdentifier: 'ef468949-5df6-43d0-9933-bda0009883fe',
       },
     },
     views: {
@@ -2100,6 +2132,9 @@ export const STANDARD_OBJECTS = {
       },
       dashboardIdIndex: {
         universalIdentifier: 'e8821da9-728d-470a-bf5b-5a981fff7880',
+      },
+      searchVectorGinIndex: {
+        universalIdentifier: '0c97ba73-a022-4584-b500-8437adf269fd',
       },
     },
     views: {


### PR DESCRIPTION
## Context

Only 12 of the searchable standard objects declared their `searchVectorGinIndex` statically; the rest relied entirely on runtime injection by the metadata side-effect engine. This closes that gap for the text-searchable objects (see twentyhq/core-team-issues#2672).

## Changes

- **Static declarations (11 text-searchable objects):** added `searchVectorGinIndex` to `STANDARD_OBJECTS` and to each per-object index builder for `attachment`, `blocklist`, `calendarEvent`, `calendarEventParticipant`, `callRecording`, `message`, `messageThread`, `messageParticipant`, `timelineActivity`, `calendarChannelEventAssociation` and `messageChannelMessageAssociation`.
  - `calendarEvent` and `messageThread` had no index builder before (empty `indexes`), so new builder files were added and registered in `build-standard-flat-index-metadata-maps.util.ts`.
- **Backfill command:** `upgrade:2-22:backfill-standard-search-vector-gin-index` creates the GIN index for twenty-standard searchable objects that declare it in the manifest but are still missing it in existing workspaces. It reuses the side-effect validate-build-and-run path and is idempotent. The candidate set is restricted to objects that declare `searchVectorGinIndex` in `STANDARD_OBJECTS`, so the borderline UUID-only searchable objects (`messageListMember`, `noteTarget`, `taskTarget`, `workflowAutomatedTrigger`) and non-searchable objects are excluded.

## Scope notes

- No previously-shipped upgrade command files are modified. Routing the `2-10` call-recording sync through the legacy validate-build path (so it explicitly owns the now-declared GIN index) is handled separately in #22884.

## Test plan

- `nx typecheck twenty-server` and `nx typecheck twenty-shared` pass.
- `standardObjectUniversalIdentifiers` snapshot updated (23 declared indexes = 12 existing + 11 new).
- twenty-standard-application build specs pass (the full manifest builds with the new indexes).
- New unit spec for the backfill util (creates for a declared object, skips non-standard, skips borderline undeclared, idempotent).
- oxlint + oxfmt clean on changed files.