### PR TITLE
Dispatch app routes on the explicit /s/ path prefix

### DIFF
--- a/packages/twenty-apps/examples/document-generator/src/front-components/document-viewer.front-component.tsx
+++ b/packages/twenty-apps/examples/document-generator/src/front-components/document-viewer.front-component.tsx
@@ -93,7 +93,9 @@ const DocumentViewer = () => {
     return <div style={styles.empty}>{loading ? 'Loading…' : 'Open a document to preview it here.'}</div>;
   }
 
-  const webUrl = `${process.env.TWENTY_FUNCTIONS_URL}/documents/view?id=${recordId}`;
+  const functionsBaseUrl =
+    process.env.TWENTY_FUNCTIONS_URL || `${process.env.TWENTY_API_URL ?? ''}/s`;
+  const webUrl = `${functionsBaseUrl}/documents/view?id=${recordId}`;
 
   return (
     <div style={styles.scroll}>

--- a/packages/twenty-apps/examples/document-generator/src/front-components/document-viewer.front-component.tsx
+++ b/packages/twenty-apps/examples/document-generator/src/front-components/document-viewer.front-component.tsx
@@ -1,5 +1,6 @@
 import { type CSSProperties, useEffect, useState } from 'react';
 import { CoreApiClient } from 'twenty-client-sdk/core';
+import { RestApiClient } from 'twenty-client-sdk/rest';
 import { defineFrontComponent } from 'twenty-sdk/define';
 import { useFrontComponentExecutionContext } from 'twenty-sdk/front-component';
 
@@ -93,9 +94,9 @@ const DocumentViewer = () => {
     return <div style={styles.empty}>{loading ? 'Loading…' : 'Open a document to preview it here.'}</div>;
   }
 
-  const functionsBaseUrl =
-    process.env.TWENTY_FUNCTIONS_URL || `${process.env.TWENTY_API_URL ?? ''}/s`;
-  const webUrl = `${functionsBaseUrl}/documents/view?id=${recordId}`;
+  const webUrl = new RestApiClient().resolveUrl('/s/documents/view', {
+    query: { id: recordId },
+  });
 
   return (
     <div style={styles.scroll}>

--- a/packages/twenty-apps/examples/document-generator/src/front-components/generate-document-form.front-component.tsx
+++ b/packages/twenty-apps/examples/document-generator/src/front-components/generate-document-form.front-component.tsx
@@ -203,7 +203,7 @@ const GenerateDocumentForm = () => {
 
     try {
       const result = await new RestApiClient().post<GenerateResponse>(
-        '/documents/generate',
+        '/s/documents/generate',
         { templateId, recordId },
       );
 

--- a/packages/twenty-apps/public/call-recorder/src/front-components/utils/__tests__/request-call-recording-summary-generation.test.ts
+++ b/packages/twenty-apps/public/call-recorder/src/front-components/utils/__tests__/request-call-recording-summary-generation.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { GENERATE_CALL_RECORDING_SUMMARIES_ROUTE_PATH } from 'src/constants/generate-call-recording-summaries-route-path';
 import { requestCallRecordingSummaryGeneration } from 'src/front-components/utils/request-call-recording-summary-generation.util';
@@ -29,12 +29,20 @@ describe('requestCallRecordingSummaryGeneration', () => {
     });
   });
 
-  it('posts the route path and lets the client resolve the functions url', async () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it('posts to the injected functions origin without the legacy prefix', async () => {
+    vi.stubEnv('TWENTY_FUNCTIONS_URL', 'https://acme.functions.example.com');
+
     await requestCallRecordingSummaryGeneration({
       calendarEventIds: ['calendar-event-1'],
     });
 
-    expect(restApiClientMock).toHaveBeenCalledWith();
+    expect(restApiClientMock).toHaveBeenCalledWith({
+      baseUrl: 'https://acme.functions.example.com',
+    });
     expect(postMock).toHaveBeenCalledWith(
       GENERATE_CALL_RECORDING_SUMMARIES_ROUTE_PATH,
       { calendarEventIds: ['calendar-event-1'] },
@@ -61,7 +69,7 @@ describe('requestCallRecordingSummaryGeneration', () => {
     });
 
     expect(postMock).toHaveBeenCalledWith(
-      GENERATE_CALL_RECORDING_SUMMARIES_ROUTE_PATH,
+      `/s${GENERATE_CALL_RECORDING_SUMMARIES_ROUTE_PATH}`,
       { calendarEventIds: ['calendar-event-1', 'calendar-event-2'] },
     );
     expect(enqueueSnackbarMock).toHaveBeenCalledWith({

--- a/packages/twenty-apps/public/call-recorder/src/front-components/utils/__tests__/request-call-recording-summary-generation.test.ts
+++ b/packages/twenty-apps/public/call-recorder/src/front-components/utils/__tests__/request-call-recording-summary-generation.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { GENERATE_CALL_RECORDING_SUMMARIES_ROUTE_PATH } from 'src/constants/generate-call-recording-summaries-route-path';
 import { requestCallRecordingSummaryGeneration } from 'src/front-components/utils/request-call-recording-summary-generation.util';
@@ -29,22 +29,14 @@ describe('requestCallRecordingSummaryGeneration', () => {
     });
   });
 
-  afterEach(() => {
-    vi.unstubAllEnvs();
-  });
-
-  it('posts to the injected functions origin without the legacy prefix', async () => {
-    vi.stubEnv('TWENTY_FUNCTIONS_URL', 'https://acme.functions.example.com');
-
+  it('posts the /s-prefixed route path and lets the client resolve the url', async () => {
     await requestCallRecordingSummaryGeneration({
       calendarEventIds: ['calendar-event-1'],
     });
 
-    expect(restApiClientMock).toHaveBeenCalledWith({
-      baseUrl: 'https://acme.functions.example.com',
-    });
+    expect(restApiClientMock).toHaveBeenCalledWith();
     expect(postMock).toHaveBeenCalledWith(
-      GENERATE_CALL_RECORDING_SUMMARIES_ROUTE_PATH,
+      `/s${GENERATE_CALL_RECORDING_SUMMARIES_ROUTE_PATH}`,
       { calendarEventIds: ['calendar-event-1'] },
     );
   });

--- a/packages/twenty-apps/public/call-recorder/src/front-components/utils/request-call-recording-summary-generation.util.ts
+++ b/packages/twenty-apps/public/call-recorder/src/front-components/utils/request-call-recording-summary-generation.util.ts
@@ -1,9 +1,7 @@
-import { isNonEmptyString } from '@sniptt/guards';
 import { RestApiClient } from 'twenty-client-sdk/rest';
 import { enqueueSnackbar } from 'twenty-sdk/front-component';
 
 import { GENERATE_CALL_RECORDING_SUMMARIES_ROUTE_PATH } from 'src/constants/generate-call-recording-summaries-route-path';
-import { TWENTY_FUNCTIONS_URL_ENV_VAR_NAME } from 'src/constants/twenty-functions-url-env-var-name';
 
 type GenerateSummariesResponse = {
   outcome?: string;
@@ -66,17 +64,8 @@ export const requestCallRecordingSummaryGeneration = async ({
   }
 
   try {
-    // The host injects the isolated functions origin; the legacy /s route
-    // 410s post-cutoff functions and only remains for self-hosting.
-    const functionsBaseUrl = process.env[TWENTY_FUNCTIONS_URL_ENV_VAR_NAME];
-    const client = isNonEmptyString(functionsBaseUrl)
-      ? new RestApiClient({ baseUrl: functionsBaseUrl })
-      : new RestApiClient();
-
-    const response = await client.post<GenerateSummariesResponse>(
-      isNonEmptyString(functionsBaseUrl)
-        ? GENERATE_CALL_RECORDING_SUMMARIES_ROUTE_PATH
-        : `/s${GENERATE_CALL_RECORDING_SUMMARIES_ROUTE_PATH}`,
+    const response = await new RestApiClient().post<GenerateSummariesResponse>(
+      `/s${GENERATE_CALL_RECORDING_SUMMARIES_ROUTE_PATH}`,
       { calendarEventIds },
     );
 

--- a/packages/twenty-apps/public/call-recorder/src/front-components/utils/request-call-recording-summary-generation.util.ts
+++ b/packages/twenty-apps/public/call-recorder/src/front-components/utils/request-call-recording-summary-generation.util.ts
@@ -1,7 +1,9 @@
+import { isNonEmptyString } from '@sniptt/guards';
 import { RestApiClient } from 'twenty-client-sdk/rest';
 import { enqueueSnackbar } from 'twenty-sdk/front-component';
 
 import { GENERATE_CALL_RECORDING_SUMMARIES_ROUTE_PATH } from 'src/constants/generate-call-recording-summaries-route-path';
+import { TWENTY_FUNCTIONS_URL_ENV_VAR_NAME } from 'src/constants/twenty-functions-url-env-var-name';
 
 type GenerateSummariesResponse = {
   outcome?: string;
@@ -64,10 +66,17 @@ export const requestCallRecordingSummaryGeneration = async ({
   }
 
   try {
-    const client = new RestApiClient();
+    // The host injects the isolated functions origin; the legacy /s route
+    // 410s post-cutoff functions and only remains for self-hosting.
+    const functionsBaseUrl = process.env[TWENTY_FUNCTIONS_URL_ENV_VAR_NAME];
+    const client = isNonEmptyString(functionsBaseUrl)
+      ? new RestApiClient({ baseUrl: functionsBaseUrl })
+      : new RestApiClient();
 
     const response = await client.post<GenerateSummariesResponse>(
-      GENERATE_CALL_RECORDING_SUMMARIES_ROUTE_PATH,
+      isNonEmptyString(functionsBaseUrl)
+        ? GENERATE_CALL_RECORDING_SUMMARIES_ROUTE_PATH
+        : `/s${GENERATE_CALL_RECORDING_SUMMARIES_ROUTE_PATH}`,
       { calendarEventIds },
     );
 

--- a/packages/twenty-apps/public/people-data-labs/src/front-components/utils/call-enrich-logic-function.utils.ts
+++ b/packages/twenty-apps/public/people-data-labs/src/front-components/utils/call-enrich-logic-function.utils.ts
@@ -6,7 +6,7 @@ export const execute = async ({path, recordIds}:{ path: string; recordIds: strin
     const client = new RestApiClient();
 
 
-    await client.post(path, { recordIds });
+    await client.post(`/s${path}`, { recordIds });
 
     await enqueueSnackbar({
       message: `Enriched ${recordIds.length > 1 ? 'records.' : 'record.'}`,

--- a/packages/twenty-client-sdk/src/rest/__tests__/RestApiClient.test.ts
+++ b/packages/twenty-client-sdk/src/rest/__tests__/RestApiClient.test.ts
@@ -125,7 +125,7 @@ describe('RestApiClient', () => {
   });
 
   describe('app route paths', () => {
-    it('should send non-rest paths to an isolated-domain functions url at the root', async () => {
+    it('should strip the /s prefix and send app route paths to an isolated-domain functions url at the root', async () => {
       (globalThis as Record<string, unknown>).process = {
         env: {
           TWENTY_API_URL: 'https://api.twenty.test',
@@ -137,7 +137,7 @@ describe('RestApiClient', () => {
 
       const client = new RestApiClient({ fetch: fetchMock });
 
-      await client.post('/my-app/my-route', { remainingIds: ['a'] });
+      await client.post('/s/my-app/my-route', { remainingIds: ['a'] });
 
       const [url, requestInit] = fetchMock.mock.calls[0];
       expect(url).toBe('https://acme.functions.twenty.test/my-app/my-route');
@@ -156,7 +156,7 @@ describe('RestApiClient', () => {
 
       const client = new RestApiClient({ fetch: fetchMock });
 
-      await client.post('/my-app/my-route');
+      await client.post('/s/my-app/my-route');
 
       const [url] = fetchMock.mock.calls[0];
       expect(url).toBe('https://api.twenty.test/s/my-app/my-route');
@@ -167,7 +167,7 @@ describe('RestApiClient', () => {
 
       const client = new RestApiClient({ fetch: fetchMock });
 
-      await client.post('/my-app/my-route');
+      await client.post('/s/my-app/my-route');
 
       const [url] = fetchMock.mock.calls[0];
       expect(url).toBe('https://api.twenty.test/s/my-app/my-route');
@@ -185,7 +185,7 @@ describe('RestApiClient', () => {
 
       const client = new RestApiClient({ fetch: fetchMock });
 
-      await client.post('/my-app/my-route');
+      await client.post('/s/my-app/my-route');
 
       const [url] = fetchMock.mock.calls[0];
       expect(url).toBe('https://api.twenty.test/s/my-app/my-route');
@@ -209,7 +209,25 @@ describe('RestApiClient', () => {
       expect(url).toBe('https://api.twenty.test/rest/companies');
     });
 
-    it('should prefer an explicit baseUrl over the functions url', async () => {
+    it('should keep unprefixed paths on the api url when a functions url is injected', async () => {
+      (globalThis as Record<string, unknown>).process = {
+        env: {
+          TWENTY_API_URL: 'https://api.twenty.test',
+          TWENTY_FUNCTIONS_URL: 'https://acme.functions.twenty.test',
+          TWENTY_APP_ACCESS_TOKEN: 'app-access-token',
+        },
+      };
+      const fetchMock = vi.fn().mockResolvedValue(buildResponse('{}'));
+
+      const client = new RestApiClient({ fetch: fetchMock });
+
+      await client.post('/my-app/my-route');
+
+      const [url] = fetchMock.mock.calls[0];
+      expect(url).toBe('https://api.twenty.test/my-app/my-route');
+    });
+
+    it('should prefer an explicit baseUrl over the functions url and keep the path untouched', async () => {
       (globalThis as Record<string, unknown>).process = {
         env: {
           TWENTY_API_URL: 'https://api.twenty.test',
@@ -224,10 +242,10 @@ describe('RestApiClient', () => {
         fetch: fetchMock,
       });
 
-      await client.post('/my-app/my-route');
+      await client.post('/s/my-app/my-route');
 
       const [url] = fetchMock.mock.calls[0];
-      expect(url).toBe('https://explicit.twenty.test/my-app/my-route');
+      expect(url).toBe('https://explicit.twenty.test/s/my-app/my-route');
     });
   });
 

--- a/packages/twenty-client-sdk/src/rest/__tests__/RestApiClient.test.ts
+++ b/packages/twenty-client-sdk/src/rest/__tests__/RestApiClient.test.ts
@@ -247,6 +247,39 @@ describe('RestApiClient', () => {
       const [url] = fetchMock.mock.calls[0];
       expect(url).toBe('https://explicit.twenty.test/s/my-app/my-route');
     });
+
+    it('should resolve an app route url without sending a request', () => {
+      (globalThis as Record<string, unknown>).process = {
+        env: {
+          TWENTY_API_URL: 'https://api.twenty.test',
+          TWENTY_FUNCTIONS_URL: 'https://acme.functions.twenty.test',
+          TWENTY_APP_ACCESS_TOKEN: 'app-access-token',
+        },
+      };
+      const fetchMock = vi.fn();
+
+      const client = new RestApiClient({ fetch: fetchMock });
+
+      const url = client.resolveUrl('/s/documents/view', {
+        query: { id: 'record-1' },
+      });
+
+      expect(url).toBe(
+        'https://acme.functions.twenty.test/documents/view?id=record-1',
+      );
+      expect(fetchMock).not.toHaveBeenCalled();
+    });
+
+    it('should resolve a rest url on the api base without sending a request', () => {
+      const fetchMock = vi.fn();
+
+      const client = new RestApiClient({ fetch: fetchMock });
+
+      const url = client.resolveUrl('/rest/companies');
+
+      expect(url).toBe('https://api.twenty.test/rest/companies');
+      expect(fetchMock).not.toHaveBeenCalled();
+    });
   });
 
   it('should refresh the access token once on a 401 and retry the request', async () => {

--- a/packages/twenty-client-sdk/src/rest/index.ts
+++ b/packages/twenty-client-sdk/src/rest/index.ts
@@ -54,7 +54,12 @@ const getProcessEnvironment = (): ProcessEnvironment => {
   return processObject?.env ?? {};
 };
 
-const isRestApiPath = (path: string): boolean => /^\/?rest\//.test(path);
+const isAppRoutePath = (path: string): boolean => /^\/?s\//.test(path);
+
+// The server serves app routes under /s/; isolated functions domains serve
+// them at the root, so the marker prefix is stripped before joining.
+const stripAppRoutePrefix = (path: string): string =>
+  path.replace(/^(\/?)s\//, '$1');
 
 const buildRequestUrl = (
   baseUrl: string,
@@ -166,13 +171,18 @@ export class RestApiClient {
     return functionsBaseUrl.trim().replace(/\/+$/, '');
   }
 
-  private resolveTargetBaseUrl(path: string): string {
-    if (isDefined(this.baseUrl) || isRestApiPath(path)) {
-      return this.resolveBaseUrl();
+  private resolveTarget(path: string): { baseUrl: string; path: string } {
+    if (isDefined(this.baseUrl) || !isAppRoutePath(path)) {
+      return { baseUrl: this.resolveBaseUrl(), path };
     }
 
-    // App routes use TWENTY_FUNCTIONS_URL, falling back to the API's /s route.
-    return this.resolveFunctionsBaseUrl() ?? `${this.resolveBaseUrl()}/s`;
+    // /s/ marks an app HTTP route. TWENTY_FUNCTIONS_URL is a complete base
+    // URL (isolated domains serve routes at the root, self-host bakes /s in);
+    // fall back to the same-site /s route when it is not injected.
+    return {
+      baseUrl: this.resolveFunctionsBaseUrl() ?? `${this.resolveBaseUrl()}/s`,
+      path: stripAppRoutePrefix(path),
+    };
   }
 
   private resolveToken(): string {
@@ -327,9 +337,10 @@ export class RestApiClient {
     body: unknown,
     requestOptions?: RestApiRequestOptions,
   ): Promise<TResponse> {
+    const target = this.resolveTarget(path);
     const url = buildRequestUrl(
-      this.resolveTargetBaseUrl(path),
-      path,
+      target.baseUrl,
+      target.path,
       requestOptions?.query,
     );
     const token = this.resolveToken();

--- a/packages/twenty-client-sdk/src/rest/index.ts
+++ b/packages/twenty-client-sdk/src/rest/index.ts
@@ -119,6 +119,15 @@ export class RestApiClient {
     return this.execute<TResponse>('GET', path, undefined, options);
   }
 
+  resolveUrl(
+    path: string,
+    requestOptions?: Pick<RestApiRequestOptions, 'query'>,
+  ): string {
+    const target = this.resolveTarget(path);
+
+    return buildRequestUrl(target.baseUrl, target.path, requestOptions?.query);
+  }
+
   post<TResponse = unknown>(
     path: string,
     body?: unknown,

--- a/packages/twenty-docs/developers/extend/apps/layout/front-components.mdx
+++ b/packages/twenty-docs/developers/extend/apps/layout/front-components.mdx
@@ -198,7 +198,7 @@ export default defineFrontComponent({
 
 Front components run browser-side in a Web Worker sandboxed inside an opaque-origin iframe, while [logic functions](/developers/extend/apps/logic/logic-functions) run server-side. There is no direct in-process call between the two — instead, a front component reaches a logic function over HTTP.
 
-A logic function declared with `httpRouteTriggerSettings` is reachable over HTTP at its route path. `RestApiClient` routes non-`/rest/` paths to the injected `TWENTY_FUNCTIONS_URL` and authenticates them with `TWENTY_APP_ACCESS_TOKEN`.
+A logic function declared with `httpRouteTriggerSettings` is reachable over HTTP at its route path. `RestApiClient` routes paths starting with `/s/` to the injected `TWENTY_FUNCTIONS_URL` (stripping the `/s` prefix) and authenticates them with `TWENTY_APP_ACCESS_TOKEN`.
 
 > **On Twenty Cloud, HTTP-triggered logic functions are served on a dedicated per-workspace domain** at `https://<your-workspace-subdomain>.withtwenty.com<path>` — this is exactly what `TWENTY_FUNCTIONS_URL` resolves to. For external callers, copy the exact URL from the function's **HTTP trigger** settings or the application's **Settings** tab.
 
@@ -215,7 +215,7 @@ import { Command } from 'twenty-sdk/front-component';
 
 const SyncPrs = () => {
   const execute = async () => {
-    await new RestApiClient().post('/github/fetch-prs', {
+    await new RestApiClient().post('/s/github/fetch-prs', {
       owner: 'twentyhq',
       repo: 'twenty',
     });
@@ -233,7 +233,7 @@ export default defineFrontComponent({
 });
 ```
 
-The path passed to `RestApiClient` is the logic function's `httpRouteTriggerSettings.path`. Keep `isAuthRequired: true`; the `TWENTY_APP_ACCESS_TOKEN` Twenty mints for your component authenticates the request:
+The path passed to `RestApiClient` is the logic function's `httpRouteTriggerSettings.path`, prefixed with `/s`. Keep `isAuthRequired: true`; the `TWENTY_APP_ACCESS_TOKEN` Twenty mints for your component authenticates the request:
 
 ```ts src/logic-functions/fetch-prs.logic-function.ts
 import { defineLogicFunction } from 'twenty-sdk/define';
@@ -263,7 +263,7 @@ export default defineLogicFunction({
 
 ### Calling the Twenty REST API
 
-To call app HTTP routes or read and write Twenty records from a front component, use `RestApiClient` from `twenty-client-sdk/rest`. It sends `/rest/...` paths to `TWENTY_API_URL` and other paths to `TWENTY_FUNCTIONS_URL`.
+To call app HTTP routes or read and write Twenty records from a front component, use `RestApiClient` from `twenty-client-sdk/rest`. It sends `/s/...` paths to `TWENTY_FUNCTIONS_URL` and every other path, including `/rest/...`, to `TWENTY_API_URL`.
 
 | Method | Description |
 |--------|-------------|

--- a/packages/twenty-docs/developers/extend/apps/layout/front-components.mdx
+++ b/packages/twenty-docs/developers/extend/apps/layout/front-components.mdx
@@ -273,6 +273,7 @@ To call app HTTP routes or read and write Twenty records from a front component,
 | `patch(path, body?, options?)` | Sends a `PATCH` request |
 | `delete(path, options?)` | Sends a `DELETE` request |
 | `request(method, path, options?)` | Generic request with any HTTP method |
+| `resolveUrl(path, options?)` | Resolves a path to its full URL without sending a request (for links) |
 
 `options` accepts `headers`, `query` (a record of query-string params; nullish values are skipped), and an `AbortSignal` via `signal`. A non-`FormData` object `body` is JSON-serialized automatically. On a `401`, the client refreshes the access token once through the host and retries the request.
 

--- a/packages/twenty-docs/developers/extend/apps/tutorials/document-generator/building-the-ui.mdx
+++ b/packages/twenty-docs/developers/extend/apps/tutorials/document-generator/building-the-ui.mdx
@@ -93,7 +93,7 @@ const GenerateDocumentForm = () => {
 
   const generate = async () => {
     const res = await new RestApiClient().post<{ success: boolean }>(
-      '/documents/generate',
+      '/s/documents/generate',
       { templateId, recordId },
     );
     await enqueueSnackbar({
@@ -184,7 +184,9 @@ const DocumentViewer = () => {
   const recordId = useFrontComponentExecutionContext((c) => c.recordId ?? null);
   // ...load { content, file } for recordId, then derive the links:
   const pdfUrl = document.file?.[0]?.url;
-  const webUrl = `${process.env.TWENTY_FUNCTIONS_URL}/documents/view?id=${recordId}`;
+  const functionsBaseUrl =
+    process.env.TWENTY_FUNCTIONS_URL || `${process.env.TWENTY_API_URL ?? ''}/s`;
+  const webUrl = `${functionsBaseUrl}/documents/view?id=${recordId}`;
 
   // Render the template body, plus quick links to the web page and the PDF.
   // Links open in a new tab so they don't navigate the embedded component.

--- a/packages/twenty-docs/developers/extend/apps/tutorials/document-generator/building-the-ui.mdx
+++ b/packages/twenty-docs/developers/extend/apps/tutorials/document-generator/building-the-ui.mdx
@@ -176,6 +176,7 @@ helper.
 
 ```tsx filename="src/front-components/document-viewer.front-component.tsx"
 import { CoreApiClient } from 'twenty-client-sdk/core';
+import { RestApiClient } from 'twenty-client-sdk/rest';
 import { defineFrontComponent } from 'twenty-sdk/define';
 import { useFrontComponentExecutionContext } from 'twenty-sdk/front-component';
 import { Markdown } from 'src/utils/markdown-to-react';
@@ -184,9 +185,9 @@ const DocumentViewer = () => {
   const recordId = useFrontComponentExecutionContext((c) => c.recordId ?? null);
   // ...load { content, file } for recordId, then derive the links:
   const pdfUrl = document.file?.[0]?.url;
-  const functionsBaseUrl =
-    process.env.TWENTY_FUNCTIONS_URL || `${process.env.TWENTY_API_URL ?? ''}/s`;
-  const webUrl = `${functionsBaseUrl}/documents/view?id=${recordId}`;
+  const webUrl = new RestApiClient().resolveUrl('/s/documents/view', {
+    query: { id: recordId },
+  });
 
   // Render the template body, plus quick links to the web page and the PDF.
   // Links open in a new tab so they don't navigate the embedded component.


### PR DESCRIPTION
Implements the dispatch rule requested in https://github.com/twentyhq/twenty/pull/22863#issuecomment-4981407903, targeting the #22863 branch.

**Dispatch rule in `RestApiClient`**
- Paths starting with `/s/` are app HTTP routes: the prefix is stripped and the path is resolved against the injected `TWENTY_FUNCTIONS_URL`, falling back to `TWENTY_API_URL/s` when it is not injected (so the resulting URL is identical to what the caller wrote).
- Every other path, including `/rest/...`, goes to `TWENTY_API_URL` unchanged, so a typo'd path fails loudly at the API instead of being silently sent to the functions domain.
- An explicit `baseUrl` still bypasses dispatch entirely and leaves the path untouched.

**Reverted call-site changes that dropped the prefix**
- `call-recorder` summary-generation util and its test are restored to main (they keep working unchanged once the SDK ships, since `/s`-prefixed calls resolve to the same URLs).
- `people-data-labs` enrich util is restored to `client.post(`/s${path}`)`.
- The document-generator example keeps the `RestApiClient` migration but posts to `/s/documents/generate` (same URL with current published SDKs), and the viewer's `webUrl` restores the `TWENTY_API_URL/s` fallback.

**Docs**
- `front-components.mdx` and `building-the-ui.mdx` keep the `RestApiClient` examples but with `/s/`-prefixed paths, and the prose now describes the `/s/` marker rule instead of the non-`/rest/` heuristic.

**Tests**: the app-route suite now exercises `/s/`-prefixed paths (isolated domain, same-site `/s`, missing/empty `TWENTY_FUNCTIONS_URL`, explicit `baseUrl`) plus a new case asserting unprefixed non-rest paths stay on `TWENTY_API_URL`. All 14 SDK tests, 414 call-recorder unit tests, and the document-generator lint/unit tests pass.

---
_Generated by [Claude Code](https://claude.ai/code/session_0131knKpoZ5VGw61KZrwsi5E)_

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/22914?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

