### PR TITLE
Allow workflow run control mutations to be called with API key auth

### DIFF
--- a/packages/twenty-server/src/engine/core-modules/workflow/resolvers/workflow-trigger.resolver.ts
+++ b/packages/twenty-server/src/engine/core-modules/workflow/resolvers/workflow-trigger.resolver.ts
@@ -48,7 +48,6 @@ export class WorkflowTriggerResolver {
   ) {}
 
   @Mutation(() => Boolean)
-  @UseGuards(UserAuthGuard)
   async activateWorkflowVersion(
     @AuthWorkspace() workspace: WorkspaceEntity,
     @Args('workflowVersionId', { type: () => UUIDScalarType })
@@ -61,7 +60,6 @@ export class WorkflowTriggerResolver {
   }
 
   @Mutation(() => Boolean)
-  @UseGuards(UserAuthGuard)
   async deactivateWorkflowVersion(
     @AuthWorkspace() workspace: WorkspaceEntity,
     @Args('workflowVersionId', { type: () => UUIDScalarType })
@@ -137,7 +135,6 @@ export class WorkflowTriggerResolver {
   }
 
   @Mutation(() => WorkflowRunDTO)
-  @UseGuards(UserAuthGuard)
   async retryWorkflowRun(
     @AuthWorkspace() workspace: WorkspaceEntity,
     @Args('workflowRunId', { type: () => UUIDScalarType })

--- a/packages/twenty-server/src/engine/core-modules/workflow/resolvers/workflow-trigger.resolver.ts
+++ b/packages/twenty-server/src/engine/core-modules/workflow/resolvers/workflow-trigger.resolver.ts
@@ -33,7 +33,6 @@ import { WorkspaceMemberWorkspaceEntity } from 'src/modules/workspace-member/sta
 @CoreResolver()
 @UseGuards(
   WorkspaceAuthGuard,
-  UserAuthGuard,
   SettingsPermissionGuard(PermissionFlagType.WORKFLOWS),
 )
 @UsePipes(ResolverValidationPipe)
@@ -49,6 +48,7 @@ export class WorkflowTriggerResolver {
   ) {}
 
   @Mutation(() => Boolean)
+  @UseGuards(UserAuthGuard)
   async activateWorkflowVersion(
     @AuthWorkspace() workspace: WorkspaceEntity,
     @Args('workflowVersionId', { type: () => UUIDScalarType })
@@ -61,6 +61,7 @@ export class WorkflowTriggerResolver {
   }
 
   @Mutation(() => Boolean)
+  @UseGuards(UserAuthGuard)
   async deactivateWorkflowVersion(
     @AuthWorkspace() workspace: WorkspaceEntity,
     @Args('workflowVersionId', { type: () => UUIDScalarType })
@@ -73,6 +74,7 @@ export class WorkflowTriggerResolver {
   }
 
   @Mutation(() => RunWorkflowVersionDTO)
+  @UseGuards(UserAuthGuard)
   async runWorkflowVersion(
     @AuthUser() user: AuthContextUser,
     @AuthWorkspace() workspace: WorkspaceEntity,
@@ -135,6 +137,7 @@ export class WorkflowTriggerResolver {
   }
 
   @Mutation(() => WorkflowRunDTO)
+  @UseGuards(UserAuthGuard)
   async retryWorkflowRun(
     @AuthWorkspace() workspace: WorkspaceEntity,
     @Args('workflowRunId', { type: () => UUIDScalarType })


### PR DESCRIPTION
## Context

A customer wants to control workflow runs from an external system / their own automation calling the API. Today the workflow mutations are gated by `UserAuthGuard`, which requires an interactive logged-in user (`request.user`). API-key requests set `request.workspace` but never `request.user`, so they can't call them.

## Change

`UserAuthGuard` was applied at the class level on `WorkflowTriggerResolver`, blanketing all five mutations even though only `runWorkflowVersion` actually consumes the user (it looks up the workspace member to stamp `createdBy`).

This drops `UserAuthGuard` from the class and keeps it only on `runWorkflowVersion`. As a result, these become callable with API-key auth:
- `stopWorkflowRun`
- `retryWorkflowRun`
- `activateWorkflowVersion`
- `deactivateWorkflowVersion`

None of these ever referenced the user, so no logic depends on it. `runWorkflowVersion` stays user-only because it needs a workspace member to attribute `createdBy`.

Permissioning is unchanged: `SettingsPermissionGuard(WORKFLOWS)` stays at the class level and already resolves the permission for API keys via `apiKeyId`, so a key still needs the WORKFLOWS permission.

## Notes / open questions

- No actor is recorded for these operations today (they only change run/version state), so exposing them to API keys doesn't drop any audit that existed. Attributing API-key-initiated actions would be a follow-up.
- If there's a deliberate product stance that workflow control should stay user-only, this is a policy change worth confirming.
