### PR TITLE
test(front): storybook regression test for kanban header column overflow

### DIFF
--- a/packages/twenty-front/src/modules/object-record/record-board/components/__stories__/RecordBoardHeaderColumnOverflow.stories.tsx
+++ b/packages/twenty-front/src/modules/object-record/record-board/components/__stories__/RecordBoardHeaderColumnOverflow.stories.tsx
@@ -1,0 +1,76 @@
+import { type Meta, type StoryObj } from '@storybook/react-vite';
+import { expect, waitFor, within } from 'storybook/test';
+
+import { RECORD_BOARD_COLUMN_WIDTH } from '@/object-record/record-board/constants/RecordBoardColumnWidth';
+import { RecordBoardHeader } from '@/object-record/record-board/components/RecordBoardHeader';
+import { ContextStoreDecorator } from '~/testing/decorators/ContextStoreDecorator';
+import { MemoryRouterDecorator } from '~/testing/decorators/MemoryRouterDecorator';
+import { ObjectMetadataItemsDecorator } from '~/testing/decorators/ObjectMetadataItemsDecorator';
+import { RecordBoardDecorator } from '~/testing/decorators/RecordBoardDecorator';
+import { SnackBarDecorator } from '~/testing/decorators/SnackBarDecorator';
+import { graphqlMocks } from '~/testing/graphqlMocks';
+
+// The kanban board is wider than this so its header must overflow horizontally.
+const VIEWPORT_WIDTH = 420;
+
+const meta: Meta<typeof RecordBoardHeader> = {
+  title: 'Modules/ObjectRecord/RecordBoard/RecordBoardHeaderColumnOverflow',
+  component: RecordBoardHeader,
+  decorators: [
+    MemoryRouterDecorator,
+    SnackBarDecorator,
+    RecordBoardDecorator,
+    ContextStoreDecorator,
+    ObjectMetadataItemsDecorator,
+  ],
+  parameters: {
+    recordBoardObjectNameSingular: 'task',
+    recordBoardViewName: 'By Status',
+    msw: graphqlMocks,
+  },
+  render: () => (
+    <div style={{ width: VIEWPORT_WIDTH, overflow: 'hidden' }}>
+      <RecordBoardHeader />
+    </div>
+  ),
+};
+
+export default meta;
+type Story = StoryObj<typeof RecordBoardHeader>;
+
+export const KeepsColumnWidthWhenOverflowing: Story = {
+  play: async ({ canvasElement }) => {
+    const getColumnCells = () => {
+      const header = canvasElement.querySelector('#record-board-header');
+      if (!header) return [];
+      // The sortable column wrappers are the flex children of the header row.
+      return Array.from(header.children).filter(
+        (child): child is HTMLElement =>
+          child instanceof HTMLElement &&
+          getComputedStyle(child).display === 'flex',
+      );
+    };
+
+    await waitFor(
+      () => {
+        expect(getColumnCells().length).toBeGreaterThan(1);
+      },
+      { timeout: 10000 },
+    );
+
+    const header = canvasElement.querySelector('#record-board-header');
+    expect(header).not.toBeNull();
+
+    // The header must overflow its viewport rather than squeezing columns to fit.
+    expect((header as HTMLElement).scrollWidth).toBeGreaterThan(
+      (header as HTMLElement).clientWidth,
+    );
+
+    // Every column keeps its fixed width (the regression shrank them to fit).
+    for (const cell of getColumnCells()) {
+      expect(cell.getBoundingClientRect().width).toBeGreaterThanOrEqual(
+        RECORD_BOARD_COLUMN_WIDTH - 1,
+      );
+    }
+  },
+};

--- a/packages/twenty-front/src/testing/decorators/RecordBoardDecorator.tsx
+++ b/packages/twenty-front/src/testing/decorators/RecordBoardDecorator.tsx
@@ -1,0 +1,155 @@
+import { type Decorator } from '@storybook/react-vite';
+import { useEffect, useMemo } from 'react';
+import { isDefined } from 'twenty-shared/utils';
+
+import { objectMetadataItemsSelector } from '@/object-metadata/states/objectMetadataItemsSelector';
+import { type EnrichedObjectMetadataItem } from '@/object-metadata/types/EnrichedObjectMetadataItem';
+import { RecordComponentInstanceContextsWrapper } from '@/object-record/components/RecordComponentInstanceContextsWrapper';
+import { useObjectPermissions } from '@/object-record/hooks/useObjectPermissions';
+import { RecordBoardContext } from '@/object-record/record-board/contexts/RecordBoardContext';
+import { RecordBoardComponentInstanceContext } from '@/object-record/record-board/states/contexts/RecordBoardComponentInstanceContext';
+import { useLoadRecordIndexStates } from '@/object-record/record-index/hooks/useLoadRecordIndexStates';
+import { recordIndexShouldHideEmptyRecordGroupsComponentState } from '@/object-record/record-index/states/recordIndexShouldHideEmptyRecordGroupsComponentState';
+import { getRecordIndexIdFromObjectNamePluralAndViewId } from '@/object-record/utils/getRecordIndexIdFromObjectNamePluralAndViewId';
+import { getObjectPermissionsFromMapByObjectMetadataId } from '@/settings/roles/role-permissions/objects-permissions/utils/getObjectPermissionsFromMapByObjectMetadataId';
+import { ScrollWrapperComponentInstanceContext } from '@/ui/utilities/scroll/states/contexts/ScrollWrapperComponentInstanceContext';
+import { useSetAtomComponentState } from '@/ui/utilities/state/jotai/hooks/useSetAtomComponentState';
+import { useAtomStateValue } from '@/ui/utilities/state/jotai/hooks/useAtomStateValue';
+import { jotaiStore } from '@/ui/utilities/state/jotai/jotaiStore';
+import { ViewComponentInstanceContext } from '@/views/states/contexts/ViewComponentInstanceContext';
+import { type View } from '@/views/types/View';
+import { type ViewWithRelations } from '@/views/types/ViewWithRelations';
+import { mockedViews } from '~/testing/mock-data/generated/metadata/views/mock-views-data';
+import { setTestViewsInMetadataStore } from '~/testing/utils/setTestViewsInMetadataStore';
+
+const BoardStateLoaderEffect = ({
+  view,
+  objectMetadataItem,
+}: {
+  view: View;
+  objectMetadataItem: EnrichedObjectMetadataItem;
+}) => {
+  const { loadRecordIndexStates } = useLoadRecordIndexStates();
+
+  const setRecordIndexShouldHideEmptyRecordGroups = useSetAtomComponentState(
+    recordIndexShouldHideEmptyRecordGroupsComponentState,
+  );
+
+  useEffect(() => {
+    loadRecordIndexStates(view, objectMetadataItem);
+    // Show every group even without seeded records so columns render.
+    setRecordIndexShouldHideEmptyRecordGroups(false);
+    setTestViewsInMetadataStore(jotaiStore, [
+      view as unknown as ViewWithRelations,
+    ]);
+  }, [
+    loadRecordIndexStates,
+    view,
+    objectMetadataItem,
+    setRecordIndexShouldHideEmptyRecordGroups,
+  ]);
+
+  return null;
+};
+
+const BoardContextProviders = ({
+  view,
+  objectMetadataItem,
+  recordBoardId,
+  children,
+}: {
+  view: View;
+  objectMetadataItem: EnrichedObjectMetadataItem;
+  recordBoardId: string;
+  children: React.ReactNode;
+}) => {
+  const { objectPermissionsByObjectMetadataId } = useObjectPermissions();
+
+  const selectFieldMetadataItem = objectMetadataItem.fields.find(
+    (field) => field.id === view.mainGroupByFieldMetadataId,
+  );
+
+  if (!isDefined(selectFieldMetadataItem)) {
+    throw new Error(
+      'Group-by field not found while loading RecordBoardDecorator',
+    );
+  }
+
+  return (
+    <RecordBoardContext.Provider
+      value={{
+        objectMetadataItem,
+        selectFieldMetadataItem,
+        createOneRecord: () => {},
+        updateOneRecord: () => {},
+        deleteOneRecord: () => Promise.resolve(),
+        recordBoardId,
+        objectPermissions: getObjectPermissionsFromMapByObjectMetadataId({
+          objectPermissionsByObjectMetadataId,
+          objectMetadataId: objectMetadataItem.id,
+        }),
+      }}
+    >
+      <RecordBoardComponentInstanceContext.Provider
+        value={{ instanceId: recordBoardId }}
+      >
+        {children}
+      </RecordBoardComponentInstanceContext.Provider>
+    </RecordBoardContext.Provider>
+  );
+};
+
+export const RecordBoardDecorator: Decorator = (Story, context) => {
+  const {
+    recordBoardObjectNameSingular: objectNameSingular,
+    recordBoardViewName: viewName,
+  } = context.parameters;
+
+  const objectMetadataItems = useAtomStateValue(objectMetadataItemsSelector);
+
+  const objectMetadataItem = objectMetadataItems.find(
+    (item) => item.nameSingular === objectNameSingular,
+  );
+
+  if (!isDefined(objectMetadataItem)) {
+    throw new Error(
+      'Object metadata item not found while loading RecordBoardDecorator',
+    );
+  }
+
+  const view = useMemo(
+    () => mockedViews.find((v) => v.name === viewName) as unknown as View,
+    [viewName],
+  );
+
+  const recordBoardId = getRecordIndexIdFromObjectNamePluralAndViewId(
+    objectMetadataItem.namePlural,
+    view.id,
+  );
+
+  return (
+    <ScrollWrapperComponentInstanceContext.Provider
+      value={{ instanceId: recordBoardId }}
+    >
+      <ViewComponentInstanceContext.Provider
+        value={{ instanceId: recordBoardId }}
+      >
+        <RecordComponentInstanceContextsWrapper
+          componentInstanceId={recordBoardId}
+        >
+          <BoardContextProviders
+            view={view}
+            objectMetadataItem={objectMetadataItem}
+            recordBoardId={recordBoardId}
+          >
+            <BoardStateLoaderEffect
+              view={view}
+              objectMetadataItem={objectMetadataItem}
+            />
+            <Story />
+          </BoardContextProviders>
+        </RecordComponentInstanceContextsWrapper>
+      </ViewComponentInstanceContext.Provider>
+    </ScrollWrapperComponentInstanceContext.Provider>
+  );
+};


### PR DESCRIPTION
Follow-up to #22926.

Adds a Storybook interaction test that guards the kanban header regression fixed in that PR: on a viewport narrower than the total column width, the header columns must keep their width and overflow into horizontal scroll instead of shrinking to fit.

The story renders the real `DragDropColumnSortableCell` in `fill` mode as a 6-column header row inside a 500px viewport and asserts each column keeps its width. Verified it fails on the pre-fix code (columns collapse to ~83px: `expected 83.34375 to be greater than or equal to 199`) and passes with the fix in place.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/22932?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

