### PR TITLE
feat(workflow): provision coreWorkflowVersionId on existing workspaces and link them

### DIFF
--- a/packages/twenty-server/src/database/commands/upgrade-version-command/2-22/2-22-upgrade-version-command.module.ts
+++ b/packages/twenty-server/src/database/commands/upgrade-version-command/2-22/2-22-upgrade-version-command.module.ts
@@ -3,9 +3,12 @@ import { Module } from '@nestjs/common';
 import { WorkspaceIteratorModule } from 'src/database/commands/command-runners/workspace-iterator.module';
 import { BackfillCompanyPersonImageIdentifierFieldMetadataIdCommand } from 'src/database/commands/upgrade-version-command/2-22/2-22-workspace-command-1783959648000-backfill-company-person-image-identifier-field-metadata-id.command';
 import { MigratePersonAvatarUrlToAvatarFileCommand } from 'src/database/commands/upgrade-version-command/2-22/2-22-workspace-command-1783960128000-migrate-person-avatar-url-to-avatar-file.command';
+import { AddWorkflowVersionCoreSoftRefFieldCommand } from 'src/database/commands/upgrade-version-command/2-22/2-22-workspace-command-1784193206000-add-workflow-version-core-soft-ref-field.command';
+import { BackfillWorkflowVersionCoreLinksCommand } from 'src/database/commands/upgrade-version-command/2-22/2-22-workspace-command-1784193207000-backfill-workflow-version-core-links.command';
 import { ApplicationModule } from 'src/engine/core-modules/application/application.module';
 import { FilesFieldModule } from 'src/engine/core-modules/file/files-field/files-field.module';
 import { SecureHttpClientModule } from 'src/engine/core-modules/secure-http-client/secure-http-client.module';
+import { WorkflowVersionCoreModule } from 'src/engine/core-modules/workflow/workflow-version-core.module';
 import { WorkspaceCacheModule } from 'src/engine/workspace-cache/workspace-cache.module';
 import { WorkspaceMigrationModule } from 'src/engine/workspace-manager/workspace-migration/workspace-migration.module';
 
@@ -14,6 +17,7 @@ import { WorkspaceMigrationModule } from 'src/engine/workspace-manager/workspace
     ApplicationModule,
     FilesFieldModule,
     SecureHttpClientModule,
+    WorkflowVersionCoreModule,
     WorkspaceCacheModule,
     WorkspaceMigrationModule,
     WorkspaceIteratorModule,
@@ -21,6 +25,8 @@ import { WorkspaceMigrationModule } from 'src/engine/workspace-manager/workspace
   providers: [
     BackfillCompanyPersonImageIdentifierFieldMetadataIdCommand,
     MigratePersonAvatarUrlToAvatarFileCommand,
+    AddWorkflowVersionCoreSoftRefFieldCommand,
+    BackfillWorkflowVersionCoreLinksCommand,
   ],
 })
 export class V2_22_UpgradeVersionCommandModule {}

--- a/packages/twenty-server/src/database/commands/upgrade-version-command/2-22/2-22-workspace-command-1784193206000-add-workflow-version-core-soft-ref-field.command.ts
+++ b/packages/twenty-server/src/database/commands/upgrade-version-command/2-22/2-22-workspace-command-1784193206000-add-workflow-version-core-soft-ref-field.command.ts
@@ -103,8 +103,14 @@ export class AddWorkflowVersionCoreSoftRefFieldCommand extends ProvisionedWorksp
       return;
     }
 
+    const flatFieldMetadataToCreate: FlatFieldMetadata = {
+      ...standardField,
+      viewFieldIds: [],
+      viewFieldUniversalIdentifiers: [],
+    };
+
     const result =
-      await this.workspaceMigrationValidateBuildAndRunService.validateBuildAndRunWorkspaceMigration(
+      await this.workspaceMigrationValidateBuildAndRunService.validateBuildAndRunLegacyWorkspaceMigration(
         {
           isSystemBuild: true,
           workspaceId,
@@ -112,7 +118,7 @@ export class AddWorkflowVersionCoreSoftRefFieldCommand extends ProvisionedWorksp
             twentyStandardFlatApplication.universalIdentifier,
           allFlatEntityOperationByMetadataName: {
             fieldMetadata: {
-              flatEntityToCreate: [standardField],
+              flatEntityToCreate: [flatFieldMetadataToCreate],
               flatEntityToDelete: [],
               flatEntityToUpdate: [],
             },

--- a/packages/twenty-server/src/database/commands/upgrade-version-command/2-22/2-22-workspace-command-1784193206000-add-workflow-version-core-soft-ref-field.command.ts
+++ b/packages/twenty-server/src/database/commands/upgrade-version-command/2-22/2-22-workspace-command-1784193206000-add-workflow-version-core-soft-ref-field.command.ts
@@ -1,0 +1,137 @@
+import { Command } from 'nest-commander';
+import { STANDARD_OBJECTS } from 'twenty-shared/metadata';
+import { isDefined } from 'twenty-shared/utils';
+
+import { ProvisionedWorkspaceCommandRunner } from 'src/database/commands/command-runners/provisioned-workspace.command-runner';
+import { WorkspaceIteratorService } from 'src/database/commands/command-runners/workspace-iterator.service';
+import { type RunOnWorkspaceArgs } from 'src/database/commands/command-runners/workspace.command-runner';
+import { ApplicationService } from 'src/engine/core-modules/application/application.service';
+import { RegisteredWorkspaceCommand } from 'src/engine/core-modules/upgrade/decorators/registered-workspace-command.decorator';
+import { findFlatEntityByUniversalIdentifier } from 'src/engine/metadata-modules/flat-entity/utils/find-flat-entity-by-universal-identifier.util';
+import { type FlatFieldMetadata } from 'src/engine/metadata-modules/flat-field-metadata/types/flat-field-metadata.type';
+import { type FlatObjectMetadata } from 'src/engine/metadata-modules/flat-object-metadata/types/flat-object-metadata.type';
+import { computeTwentyStandardApplicationAllFlatEntityMaps } from 'src/engine/workspace-manager/twenty-standard-application/utils/twenty-standard-application-all-flat-entity-maps.constant';
+import { WorkspaceCacheService } from 'src/engine/workspace-cache/services/workspace-cache.service';
+import { WorkspaceMigrationValidateBuildAndRunService } from 'src/engine/workspace-manager/workspace-migration/services/workspace-migration-validate-build-and-run-service';
+
+const WORKFLOW_VERSION = STANDARD_OBJECTS.workflowVersion;
+const CORE_WORKFLOW_VERSION_ID_FIELD_UNIVERSAL_IDENTIFIER =
+  WORKFLOW_VERSION.fields.coreWorkflowVersionId.universalIdentifier;
+
+@RegisteredWorkspaceCommand('2.22.0', 1784193206000)
+@Command({
+  name: 'upgrade:2-22:add-workflow-version-core-soft-ref-field',
+  description:
+    'Add the workflowVersion.coreWorkflowVersionId system field on existing workspaces that predate it',
+})
+export class AddWorkflowVersionCoreSoftRefFieldCommand extends ProvisionedWorkspaceCommandRunner {
+  constructor(
+    protected readonly workspaceIteratorService: WorkspaceIteratorService,
+    private readonly applicationService: ApplicationService,
+    private readonly workspaceCacheService: WorkspaceCacheService,
+    private readonly workspaceMigrationValidateBuildAndRunService: WorkspaceMigrationValidateBuildAndRunService,
+  ) {
+    super(workspaceIteratorService);
+  }
+
+  override async runOnWorkspace({
+    workspaceId,
+    options,
+  }: RunOnWorkspaceArgs): Promise<void> {
+    const isDryRun = options.dryRun ?? false;
+
+    const { flatFieldMetadataMaps, flatObjectMetadataMaps } =
+      await this.workspaceCacheService.getOrRecompute(workspaceId, [
+        'flatFieldMetadataMaps',
+        'flatObjectMetadataMaps',
+      ]);
+
+    const workflowVersionObjectMetadata =
+      findFlatEntityByUniversalIdentifier<FlatObjectMetadata>({
+        flatEntityMaps: flatObjectMetadataMaps,
+        universalIdentifier: WORKFLOW_VERSION.universalIdentifier,
+      });
+
+    if (!isDefined(workflowVersionObjectMetadata)) {
+      this.logger.log(
+        `workflowVersion object does not exist for workspace ${workspaceId}, skipping`,
+      );
+
+      return;
+    }
+
+    if (
+      isDefined(
+        flatFieldMetadataMaps.byUniversalIdentifier[
+          CORE_WORKFLOW_VERSION_ID_FIELD_UNIVERSAL_IDENTIFIER
+        ],
+      )
+    ) {
+      return;
+    }
+
+    const { twentyStandardFlatApplication } =
+      await this.applicationService.findWorkspaceTwentyStandardAndCustomApplicationOrThrow(
+        { workspaceId },
+      );
+
+    const { allFlatEntityMaps: standardAllFlatEntityMaps } =
+      computeTwentyStandardApplicationAllFlatEntityMaps({
+        now: new Date().toISOString(),
+        workspaceId,
+        twentyStandardApplicationId: twentyStandardFlatApplication.id,
+      });
+
+    const standardField = findFlatEntityByUniversalIdentifier<FlatFieldMetadata>(
+      {
+        flatEntityMaps: standardAllFlatEntityMaps.flatFieldMetadataMaps,
+        universalIdentifier: CORE_WORKFLOW_VERSION_ID_FIELD_UNIVERSAL_IDENTIFIER,
+      },
+    );
+
+    if (!isDefined(standardField)) {
+      throw new Error(
+        'Standard application is missing workflowVersion field coreWorkflowVersionId',
+      );
+    }
+
+    if (isDryRun) {
+      this.logger.log(
+        `[DRY RUN] Would add coreWorkflowVersionId field for workspace ${workspaceId}`,
+      );
+
+      return;
+    }
+
+    const result =
+      await this.workspaceMigrationValidateBuildAndRunService.validateBuildAndRunWorkspaceMigration(
+        {
+          isSystemBuild: true,
+          workspaceId,
+          applicationUniversalIdentifier:
+            twentyStandardFlatApplication.universalIdentifier,
+          allFlatEntityOperationByMetadataName: {
+            fieldMetadata: {
+              flatEntityToCreate: [standardField],
+              flatEntityToDelete: [],
+              flatEntityToUpdate: [],
+            },
+          },
+        },
+      );
+
+    if (result.status === 'fail') {
+      this.logger.error(
+        `Failed to add coreWorkflowVersionId field:\n${JSON.stringify(result, null, 2)}`,
+      );
+
+      throw new Error(
+        `Failed to add coreWorkflowVersionId field for workspace ${workspaceId}`,
+      );
+    }
+
+    this.logger.log(
+      `Added coreWorkflowVersionId field for workspace ${workspaceId}`,
+    );
+  }
+}

--- a/packages/twenty-server/src/database/commands/upgrade-version-command/2-22/2-22-workspace-command-1784193207000-backfill-workflow-version-core-links.command.ts
+++ b/packages/twenty-server/src/database/commands/upgrade-version-command/2-22/2-22-workspace-command-1784193207000-backfill-workflow-version-core-links.command.ts
@@ -1,4 +1,5 @@
 import { Command } from 'nest-commander';
+import { isDefined } from 'twenty-shared/utils';
 import { EntityMetadataNotFoundError } from 'typeorm/error/EntityMetadataNotFoundError';
 
 import { ProvisionedWorkspaceCommandRunner } from 'src/database/commands/command-runners/provisioned-workspace.command-runner';
@@ -6,8 +7,6 @@ import { WorkspaceIteratorService } from 'src/database/commands/command-runners/
 import { type RunOnWorkspaceArgs } from 'src/database/commands/command-runners/workspace.command-runner';
 import { RegisteredWorkspaceCommand } from 'src/engine/core-modules/upgrade/decorators/registered-workspace-command.decorator';
 import { WorkflowVersionCoreSyncService } from 'src/engine/core-modules/workflow/services/workflow-version-core-sync.service';
-import { GlobalWorkspaceOrmManager } from 'src/engine/twenty-orm/global-workspace-datasource/global-workspace-orm.manager';
-import { buildSystemAuthContext } from 'src/engine/twenty-orm/utils/build-system-auth-context.util';
 import { type WorkflowVersionWorkspaceEntity } from 'src/modules/workflow/common/standard-objects/workflow-version.workspace-entity';
 
 // One-time migration to the soft-ref model after coreWorkflowVersionId is
@@ -23,7 +22,6 @@ import { type WorkflowVersionWorkspaceEntity } from 'src/modules/workflow/common
 export class BackfillWorkflowVersionCoreLinksCommand extends ProvisionedWorkspaceCommandRunner {
   constructor(
     protected readonly workspaceIteratorService: WorkspaceIteratorService,
-    private readonly globalWorkspaceOrmManager: GlobalWorkspaceOrmManager,
     private readonly workflowVersionCoreSyncService: WorkflowVersionCoreSyncService,
   ) {
     super(workspaceIteratorService);
@@ -32,24 +30,26 @@ export class BackfillWorkflowVersionCoreLinksCommand extends ProvisionedWorkspac
   override async runOnWorkspace({
     workspaceId,
     options,
+    dataSource,
   }: RunOnWorkspaceArgs): Promise<void> {
+    if (!isDefined(dataSource)) {
+      this.logger.log(
+        `No workspace data source for workspace ${workspaceId}, skipping`,
+      );
+
+      return;
+    }
+
     let workspaceWorkflowVersions: WorkflowVersionWorkspaceEntity[];
 
     try {
-      workspaceWorkflowVersions =
-        await this.globalWorkspaceOrmManager.executeInWorkspaceContext(
-          async () => {
-            const workflowVersionRepository =
-              await this.globalWorkspaceOrmManager.getRepository<WorkflowVersionWorkspaceEntity>(
-                workspaceId,
-                'workflowVersion',
-                { shouldBypassPermissionChecks: true },
-              );
-
-            return workflowVersionRepository.find();
-          },
-          buildSystemAuthContext(workspaceId),
+      const workflowVersionRepository =
+        dataSource.getRepository<WorkflowVersionWorkspaceEntity>(
+          'workflowVersion',
+          { shouldBypassPermissionChecks: true },
         );
+
+      workspaceWorkflowVersions = await workflowVersionRepository.find();
     } catch (error) {
       if (error instanceof EntityMetadataNotFoundError) {
         this.logger.log(

--- a/packages/twenty-server/src/database/commands/upgrade-version-command/2-22/2-22-workspace-command-1784193207000-backfill-workflow-version-core-links.command.ts
+++ b/packages/twenty-server/src/database/commands/upgrade-version-command/2-22/2-22-workspace-command-1784193207000-backfill-workflow-version-core-links.command.ts
@@ -1,0 +1,82 @@
+import { Command } from 'nest-commander';
+import { EntityMetadataNotFoundError } from 'typeorm/error/EntityMetadataNotFoundError';
+
+import { ProvisionedWorkspaceCommandRunner } from 'src/database/commands/command-runners/provisioned-workspace.command-runner';
+import { WorkspaceIteratorService } from 'src/database/commands/command-runners/workspace-iterator.service';
+import { type RunOnWorkspaceArgs } from 'src/database/commands/command-runners/workspace.command-runner';
+import { RegisteredWorkspaceCommand } from 'src/engine/core-modules/upgrade/decorators/registered-workspace-command.decorator';
+import { WorkflowVersionCoreSyncService } from 'src/engine/core-modules/workflow/services/workflow-version-core-sync.service';
+import { GlobalWorkspaceOrmManager } from 'src/engine/twenty-orm/global-workspace-datasource/global-workspace-orm.manager';
+import { buildSystemAuthContext } from 'src/engine/twenty-orm/utils/build-system-auth-context.util';
+import { type WorkflowVersionWorkspaceEntity } from 'src/modules/workflow/common/standard-objects/workflow-version.workspace-entity';
+
+// One-time migration to the soft-ref model after coreWorkflowVersionId is
+// provisioned. Re-runs the sync: upsertToCore purges each legacy shared-id
+// core row (id === record id) and rebuilds a deterministic own-id row, then
+// links the workspace record.
+@RegisteredWorkspaceCommand('2.22.0', 1784193207000)
+@Command({
+  name: 'upgrade:2-22:backfill-workflow-version-core-links',
+  description:
+    'Re-run the workflowVersion core sync so workspaces newly provisioned with coreWorkflowVersionId get linked',
+})
+export class BackfillWorkflowVersionCoreLinksCommand extends ProvisionedWorkspaceCommandRunner {
+  constructor(
+    protected readonly workspaceIteratorService: WorkspaceIteratorService,
+    private readonly globalWorkspaceOrmManager: GlobalWorkspaceOrmManager,
+    private readonly workflowVersionCoreSyncService: WorkflowVersionCoreSyncService,
+  ) {
+    super(workspaceIteratorService);
+  }
+
+  override async runOnWorkspace({
+    workspaceId,
+    options,
+  }: RunOnWorkspaceArgs): Promise<void> {
+    let workspaceWorkflowVersions: WorkflowVersionWorkspaceEntity[];
+
+    try {
+      workspaceWorkflowVersions =
+        await this.globalWorkspaceOrmManager.executeInWorkspaceContext(
+          async () => {
+            const workflowVersionRepository =
+              await this.globalWorkspaceOrmManager.getRepository<WorkflowVersionWorkspaceEntity>(
+                workspaceId,
+                'workflowVersion',
+                { shouldBypassPermissionChecks: true },
+              );
+
+            return workflowVersionRepository.find();
+          },
+          buildSystemAuthContext(workspaceId),
+        );
+    } catch (error) {
+      if (error instanceof EntityMetadataNotFoundError) {
+        this.logger.log(
+          `workflowVersion object does not exist for workspace ${workspaceId}, skipping`,
+        );
+
+        return;
+      }
+
+      throw error;
+    }
+
+    if (options.dryRun === true) {
+      this.logger.log(
+        `[DRY RUN] Would re-sync ${workspaceWorkflowVersions.length} workflowVersion row(s) for workspace ${workspaceId}`,
+      );
+
+      return;
+    }
+
+    await this.workflowVersionCoreSyncService.upsertToCore(
+      workspaceId,
+      workspaceWorkflowVersions,
+    );
+
+    this.logger.log(
+      `Linked ${workspaceWorkflowVersions.length} workflowVersion row(s) for workspace ${workspaceId}`,
+    );
+  }
+}

--- a/packages/twenty-server/src/engine/core-modules/workflow/services/workflow-version-core-sync.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/workflow/services/workflow-version-core-sync.service.ts
@@ -30,7 +30,7 @@ export class WorkflowVersionCoreSyncService {
 
   constructor(
     @InjectWorkspaceScopedRepository(WorkflowVersionEntity)
-    private readonly workflowVersionRepository: WorkspaceScopedRepository<WorkflowVersionEntity>,
+    private readonly coreWorkflowVersionRepository: WorkspaceScopedRepository<WorkflowVersionEntity>,
     @InjectRepository(WorkspaceEntity)
     private readonly workspaceRepository: Repository<WorkspaceEntity>,
     private readonly globalWorkspaceOrmManager: GlobalWorkspaceOrmManager,
@@ -82,7 +82,9 @@ export class WorkflowVersionCoreSyncService {
       Array.from(coreVersionIdByWorkspaceRecordId.keys()),
     );
 
-    await this.workflowVersionRepository.upsert(workspaceId, coreRows, ['id']);
+    await this.coreWorkflowVersionRepository.upsert(workspaceId, coreRows, [
+      'id',
+    ]);
 
     await this.writeBackCoreVersionIds(
       workspaceId,
@@ -100,7 +102,7 @@ export class WorkflowVersionCoreSyncService {
       return;
     }
 
-    await this.workflowVersionRepository.delete(workspaceId, {
+    await this.coreWorkflowVersionRepository.delete(workspaceId, {
       id: In(coreWorkflowVersionIds),
     });
 
@@ -118,7 +120,7 @@ export class WorkflowVersionCoreSyncService {
       return;
     }
 
-    await this.workflowVersionRepository.delete(workspaceId, {
+    await this.coreWorkflowVersionRepository.delete(workspaceId, {
       id: In(workspaceRecordIds),
     });
   }
@@ -140,7 +142,7 @@ export class WorkflowVersionCoreSyncService {
     }
 
     await this.globalWorkspaceOrmManager.executeInWorkspaceContext(async () => {
-      const workflowVersionRepository =
+      const workspaceWorkflowVersionRepository =
         await this.globalWorkspaceOrmManager.getRepository<WorkflowVersionWorkspaceEntity>(
           workspaceId,
           'workflowVersion',
@@ -151,7 +153,7 @@ export class WorkflowVersionCoreSyncService {
         workspaceRecordId,
         coreWorkflowVersionId,
       ] of coreVersionIdByWorkspaceRecordId) {
-        await workflowVersionRepository.update(workspaceRecordId, {
+        await workspaceWorkflowVersionRepository.update(workspaceRecordId, {
           coreWorkflowVersionId,
         });
       }


### PR DESCRIPTION
Stacked on the write-back guard hotfix (#22940). Completes the version soft-ref for workspaces that predate the `coreWorkflowVersionId` field.

## Why
New standard fields aren't auto-synced to existing workspaces; they're only built at workspace creation or added by an explicit upgrade command. Deployed 2.20/2.21 instances also carry **legacy core rows with `id = record.id`** (the pre-soft-ref shared-UUID model, from the already-run #22663 backfill). The original backfill has already run there and won't re-run (tracking is by command name), so the migration to soft-ref has to be **new appended commands**.

## What (two appended 2-22 workspace commands)
1. `add-workflow-version-core-soft-ref-field` (`1784193206000`): adds the `coreWorkflowVersionId` system field to existing workspaces missing it (flat-entity migration, `add-message-campaign-stat-fields` pattern). Idempotent, dry-run aware, skips workspaces without the `workflowVersion` object.
2. `backfill-workflow-version-core-links` (`1784193207000`): re-runs the sync (`upsertToCore`). For each version, `upsertToCore` **purges the legacy shared-id core row** (`id === record id`) then upserts a deterministic own-id row and writes the link back onto the workspace record. Targeted per-id delete — it does not wipe unrelated core rows.

Ordering: both run after the original 2-20 backfill. On instances that run 2-20 fresh (e.g. 2.19 → 2.22) that backfill creates core rows and — via the hotfix guard — skips the write-back until the field exists; command 1 provisions the field; command 2 purges + relinks. On already-migrated 2.21 instances the 2-20 backfill won't re-run, so command 2 is what clears their shared-id rows.

The same per-id purge in `upsertToCore` also covers the dual-write path: between the 2.22 deploy and command 2 running, an edited version would otherwise collide with its shared-id row on the one-active-per-workflow index.

Scope: version side only. The workflow-side equivalent (`coreWorkflowId`) ships with the workflow-side sync PR; `core.workflow` was never backfilled in prod, so it has no legacy shared-id rows.

## Test
- Unit: guard skips write-back when the field is absent; runs it when present.
- Happy path (fresh reset): original backfill → add-field no-op → link → 4/4 linked, own ids, 0 duplicates.
- Deployed migration (simulated 2.21: shared-id ACTIVE core rows + field removed): add-field re-provisions → link purges the shared-id rows and rebuilds → records linked to own-id rows, 0 duplicates, exactly one ACTIVE core version per workflow (index intact), no collision.
- Idempotent re-run: still 4 core rows, links resolve.
- Typecheck + lint + oxfmt clean.
