### PR TITLE
Scope relation table queries to the host record

### DIFF
--- a/packages/twenty-front/src/modules/object-record/record-filter/contexts/RecordFilterValueDependenciesContext.ts
+++ b/packages/twenty-front/src/modules/object-record/record-filter/contexts/RecordFilterValueDependenciesContext.ts
@@ -1,10 +1,15 @@
 import { createContext } from 'react';
-import { type RecordFilterValueDependencies } from 'twenty-shared/types';
+import {
+  type RecordFilterValueDependencies,
+  type RecordGqlOperationFilter,
+} from 'twenty-shared/types';
 
 export type RecordFilterValueDependenciesContextValue = Pick<
   RecordFilterValueDependencies,
   'currentRecord'
->;
+> & {
+  relationTableFilter?: RecordGqlOperationFilter;
+};
 
 export const RecordFilterValueDependenciesContext =
   createContext<RecordFilterValueDependenciesContextValue>({});

--- a/packages/twenty-front/src/modules/object-record/record-index/hooks/useFindManyRecordIndexTableParams.ts
+++ b/packages/twenty-front/src/modules/object-record/record-index/hooks/useFindManyRecordIndexTableParams.ts
@@ -3,6 +3,7 @@ import { useObjectMetadataItems } from '@/object-metadata/hooks/useObjectMetadat
 import { flattenedFieldMetadataItemsSelector } from '@/object-metadata/states/flattenedFieldMetadataItemsSelector';
 import { turnSortsIntoOrderBy } from '@/object-record/object-sort-dropdown/utils/turnSortsIntoOrderBy';
 import { currentRecordFilterGroupsComponentState } from '@/object-record/record-filter-group/states/currentRecordFilterGroupsComponentState';
+import { RecordFilterValueDependenciesContext } from '@/object-record/record-filter/contexts/RecordFilterValueDependenciesContext';
 import { useFilterValueDependencies } from '@/object-record/record-filter/hooks/useFilterValueDependencies';
 import { anyFieldFilterValueComponentState } from '@/object-record/record-filter/states/anyFieldFilterValueComponentState';
 import { currentRecordFiltersComponentState } from '@/object-record/record-filter/states/currentRecordFiltersComponentState';
@@ -11,9 +12,11 @@ import { useRecordGroupFilter } from '@/object-record/record-group/hooks/useReco
 import { currentRecordSortsComponentState } from '@/object-record/record-sort/states/currentRecordSortsComponentState';
 import { useAtomComponentStateValue } from '@/ui/utilities/state/jotai/hooks/useAtomComponentStateValue';
 import { useAtomStateValue } from '@/ui/utilities/state/jotai/hooks/useAtomStateValue';
+import { useContext } from 'react';
 import {
   combineFilters,
   computeRecordGqlOperationFilter,
+  isDefined,
   turnAnyFieldFilterIntoRecordGqlFilter,
 } from 'twenty-shared/utils';
 
@@ -49,6 +52,10 @@ export const useFindManyRecordIndexTableParams = (
 
   const { filterValueDependencies } = useFilterValueDependencies();
 
+  const { relationTableFilter } = useContext(
+    RecordFilterValueDependenciesContext,
+  );
+
   const flattenedFieldMetadataItems = useAtomStateValue(
     flattenedFieldMetadataItemsSelector,
   );
@@ -81,6 +88,7 @@ export const useFindManyRecordIndexTableParams = (
     currentFilters,
     recordGroupFilter,
     anyFieldFilter,
+    ...(isDefined(relationTableFilter) ? [relationTableFilter] : []),
   ]);
 
   return {

--- a/packages/twenty-front/src/modules/object-record/record-table/record-table-footer/hooks/useAggregateRecordsForRecordTableColumnFooter.tsx
+++ b/packages/twenty-front/src/modules/object-record/record-table/record-table-footer/hooks/useAggregateRecordsForRecordTableColumnFooter.tsx
@@ -5,6 +5,7 @@ import { transformAggregateRawValueIntoAggregateDisplayValue } from '@/object-re
 import { getAggregateOperationLabel } from '@/object-record/record-board/record-board-column/utils/getAggregateOperationLabel';
 
 import { currentRecordFilterGroupsComponentState } from '@/object-record/record-filter-group/states/currentRecordFilterGroupsComponentState';
+import { RecordFilterValueDependenciesContext } from '@/object-record/record-filter/contexts/RecordFilterValueDependenciesContext';
 import { useFilterValueDependencies } from '@/object-record/record-filter/hooks/useFilterValueDependencies';
 import { anyFieldFilterValueComponentState } from '@/object-record/record-filter/states/anyFieldFilterValueComponentState';
 import { currentRecordFiltersComponentState } from '@/object-record/record-filter/states/currentRecordFiltersComponentState';
@@ -23,6 +24,7 @@ import { UserContext } from '@/users/contexts/UserContext';
 import { useContext } from 'react';
 import { FIELD_FOR_TOTAL_COUNT_AGGREGATE_OPERATION } from 'twenty-shared/constants';
 import {
+  combineFilters,
   computeRecordGqlOperationFilter,
   findById,
   isDefined,
@@ -114,14 +116,19 @@ export const useAggregateRecordsForRecordTableColumnFooter = (
       filterValue: anyFieldFilterValue,
     });
 
+  const { relationTableFilter } = useContext(
+    RecordFilterValueDependenciesContext,
+  );
+
   const { data, loading } = useAggregateRecords({
     objectNameSingular: objectMetadataItem.nameSingular,
     recordGqlFieldsAggregate,
-    filter: {
-      ...requestFilters,
-      ...recordGroupFilter,
-      ...anyFieldFilter,
-    },
+    filter: combineFilters([
+      requestFilters,
+      recordGroupFilter,
+      anyFieldFilter,
+      ...(isDefined(relationTableFilter) ? [relationTableFilter] : []),
+    ]),
     skip: !isDefined(aggregateOperationForViewField),
   });
 

--- a/packages/twenty-front/src/modules/page-layout/widgets/field/components/FieldWidgetRelationTable.tsx
+++ b/packages/twenty-front/src/modules/page-layout/widgets/field/components/FieldWidgetRelationTable.tsx
@@ -4,6 +4,7 @@ import { type FieldRelationMetadata } from '@/object-record/record-field/ui/type
 import { RECORD_TABLE_ROW_HEIGHT } from '@/object-record/record-table/constants/RecordTableRowHeight';
 import { useIsPageLayoutInEditMode } from '@/page-layout/hooks/useIsPageLayoutInEditMode';
 import { RecordTableWidgetRendererContent } from '@/page-layout/widgets/record-table/components/RecordTableWidgetRendererContent';
+import { getRelationTableFilter } from '@/page-layout/widgets/field/utils/getRelationTableFilter';
 import { isFieldWidget } from '@/page-layout/widgets/field/utils/isFieldWidget';
 import { useCurrentWidget } from '@/page-layout/widgets/hooks/useCurrentWidget';
 import { useLayoutRenderingContext } from '@/ui/layout/contexts/LayoutRenderingContext';
@@ -42,10 +43,39 @@ export const FieldWidgetRelationTable = ({
     ? widget.configuration.viewId
     : undefined;
 
-  const relationObjectMetadataId =
-    fieldDefinition.metadata.relationObjectMetadataId;
+  const {
+    relationFieldMetadataId,
+    relationObjectMetadataNameSingular,
+    relationObjectMetadataId,
+    relationType,
+    objectMetadataNameSingular,
+  } = fieldDefinition.metadata;
   const recordPageObjectMetadataNameSingular =
     fieldDefinition.metadata.objectMetadataNameSingular;
+
+  const { objectMetadataItem: relationObjectMetadataItem } =
+    useObjectMetadataItem({
+      objectNameSingular: relationObjectMetadataNameSingular,
+    });
+
+  const { objectMetadataItems } = useObjectMetadataItems();
+
+  const recordObjectMetadataItem = objectMetadataItems.find(
+    ({ nameSingular }) => nameSingular === objectMetadataNameSingular,
+  );
+
+  const inverseRelationFieldMetadataItem =
+    relationObjectMetadataItem.fields.find(
+      ({ id }) => id === relationFieldMetadataId,
+    );
+
+  const relationTableFilter = getRelationTableFilter({
+    recordId,
+    relationType,
+    inverseRelationFieldMetadataItem,
+    recordObjectMetadataNameSingular: recordObjectMetadataItem?.nameSingular,
+    recordObjectMetadataNamePlural: recordObjectMetadataItem?.namePlural,
+  });
 
   if (
     !isDefined(viewId) ||
@@ -62,6 +92,7 @@ export const FieldWidgetRelationTable = ({
           id: recordId,
           objectMetadataNameSingular: recordPageObjectMetadataNameSingular,
         },
+        relationTableFilter,
       }}
     >
       <StyledContainer>
@@ -77,3 +108,5 @@ export const FieldWidgetRelationTable = ({
     </RecordFilterValueDependenciesContext.Provider>
   );
 };
+import { useObjectMetadataItem } from '@/object-metadata/hooks/useObjectMetadataItem';
+import { useObjectMetadataItems } from '@/object-metadata/hooks/useObjectMetadataItems';

--- a/packages/twenty-front/src/modules/page-layout/widgets/field/utils/__tests__/getRelationTableFilter.test.ts
+++ b/packages/twenty-front/src/modules/page-layout/widgets/field/utils/__tests__/getRelationTableFilter.test.ts
@@ -1,0 +1,30 @@
+import { type FieldMetadataItem } from '@/object-metadata/types/FieldMetadataItem';
+import { getRelationTableFilter } from '@/page-layout/widgets/field/utils/getRelationTableFilter';
+import { FieldMetadataType } from 'twenty-shared/types';
+import { RelationType } from '~/generated-metadata/graphql';
+
+const RECORD_ID = '20202020-1111-2222-3333-444444444444';
+
+const buildInverseRelationField = (
+  overrides: Partial<
+    Pick<FieldMetadataItem, 'name' | 'type' | 'settings'>
+  > = {},
+): Pick<FieldMetadataItem, 'name' | 'type' | 'settings'> => ({
+  name: 'meeting',
+  type: FieldMetadataType.RELATION,
+  ...overrides,
+});
+
+describe('getRelationTableFilter', () => {
+  it('scopes a one-to-many relation table to its host record', () => {
+    expect(
+      getRelationTableFilter({
+        recordId: RECORD_ID,
+        relationType: RelationType.ONE_TO_MANY,
+        inverseRelationFieldMetadataItem: buildInverseRelationField(),
+        recordObjectMetadataNameSingular: 'teamSyncMeeting',
+        recordObjectMetadataNamePlural: 'teamSyncMeetings',
+      }),
+    ).toEqual({ meetingId: { in: [RECORD_ID] } });
+  });
+});

--- a/packages/twenty-front/src/modules/page-layout/widgets/field/utils/getRelationTableFilter.ts
+++ b/packages/twenty-front/src/modules/page-layout/widgets/field/utils/getRelationTableFilter.ts
@@ -1,0 +1,76 @@
+import { type FieldMetadataItem } from '@/object-metadata/types/FieldMetadataItem';
+import {
+  FieldMetadataType,
+  type RecordGqlOperationFilter,
+} from 'twenty-shared/types';
+import {
+  computeMorphRelationGqlFieldName,
+  isDefined,
+} from 'twenty-shared/utils';
+import { RelationType } from '~/generated-metadata/graphql';
+
+type GetRelationTableFilterArgs = {
+  recordId: string;
+  relationType: RelationType | undefined;
+  inverseRelationFieldMetadataItem:
+    | Pick<FieldMetadataItem, 'name' | 'type' | 'settings'>
+    | undefined;
+  recordObjectMetadataNameSingular: string | undefined;
+  recordObjectMetadataNamePlural: string | undefined;
+};
+
+const resolveInverseRelationGqlFieldName = ({
+  inverseRelationFieldMetadataItem,
+  recordObjectMetadataNameSingular,
+  recordObjectMetadataNamePlural,
+}: Omit<GetRelationTableFilterArgs, 'recordId' | 'relationType'>) => {
+  if (
+    !isDefined(inverseRelationFieldMetadataItem) ||
+    inverseRelationFieldMetadataItem.type !== FieldMetadataType.MORPH_RELATION
+  ) {
+    return inverseRelationFieldMetadataItem?.name;
+  }
+
+  const morphRelationType =
+    isDefined(inverseRelationFieldMetadataItem.settings) &&
+    'relationType' in inverseRelationFieldMetadataItem.settings
+      ? inverseRelationFieldMetadataItem.settings.relationType
+      : undefined;
+
+  if (
+    !isDefined(morphRelationType) ||
+    !isDefined(recordObjectMetadataNameSingular) ||
+    !isDefined(recordObjectMetadataNamePlural)
+  ) {
+    return undefined;
+  }
+
+  return computeMorphRelationGqlFieldName({
+    fieldName: inverseRelationFieldMetadataItem.name,
+    relationType: morphRelationType,
+    targetObjectMetadataNameSingular: recordObjectMetadataNameSingular,
+    targetObjectMetadataNamePlural: recordObjectMetadataNamePlural,
+  });
+};
+
+export const getRelationTableFilter = ({
+  recordId,
+  relationType,
+  inverseRelationFieldMetadataItem,
+  recordObjectMetadataNameSingular,
+  recordObjectMetadataNamePlural,
+}: GetRelationTableFilterArgs): RecordGqlOperationFilter | undefined => {
+  if (relationType !== RelationType.ONE_TO_MANY) {
+    return undefined;
+  }
+
+  const gqlFieldName = resolveInverseRelationGqlFieldName({
+    inverseRelationFieldMetadataItem,
+    recordObjectMetadataNameSingular,
+    recordObjectMetadataNamePlural,
+  });
+
+  return isDefined(gqlFieldName)
+    ? { [`${gqlFieldName}Id`]: { in: [recordId] } }
+    : undefined;
+};


### PR DESCRIPTION
## Summary
- Add a relation-table filter to the record filter dependencies context so related widgets can reuse it downstream.
- Compute a host-record-scoped filter for one-to-many relation tables and pass it into the table widget.
- Merge that filter into table query and aggregate query parameters so relation tables only show records tied to the current page record.

Regression from PR [#21965](https://github.com/twentyhq/twenty/pull/21965), commit b1ada79d725bccd5860438d89853066c48f6b3e6.
That PR removed the explicit relationTableFilter, assuming every widget view always carried an equivalent isCurrentRecordSelected filter. 


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/22948?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

