### PR TITLE
Remove calendar week view feature flag from public flags

### DIFF
--- a/packages/twenty-server/src/engine/core-modules/feature-flag/constants/public-feature-flag.const.ts
+++ b/packages/twenty-server/src/engine/core-modules/feature-flag/constants/public-feature-flag.const.ts
@@ -13,14 +13,6 @@ export type PublicFeatureFlag = {
 
 export const PUBLIC_FEATURE_FLAGS: PublicFeatureFlag[] = [
   {
-    key: FeatureFlagKey.IS_CALENDAR_WEEK_VIEW_ENABLED,
-    metadata: {
-      label: 'Calendar Day and Week Views',
-      description:
-        'Display calendar records in daily or weekly layouts with optional end dates',
-    },
-  },
-  {
     key: FeatureFlagKey.IS_JUNCTION_RELATIONS_ENABLED,
     metadata: {
       label: 'Junction Relations',


### PR DESCRIPTION
## Summary
- Remove `IS_CALENDAR_WEEK_VIEW_ENABLED` from the public feature flag registry
- Keep the remaining public feature flags unchanged

## Note
Needs more polish before being released in the Lab

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/22950?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

