### PR TITLE
fix(metadata): resync metadata store via collection hashes on SSE reconnect

### DIFF
--- a/packages/twenty-front/src/modules/metadata-store/hooks/useResyncMetadataStore.ts
+++ b/packages/twenty-front/src/modules/metadata-store/hooks/useResyncMetadataStore.ts
@@ -1,0 +1,16 @@
+import { metadataLoadedVersionState } from '@/metadata-store/states/metadataLoadedVersionState';
+import { useStore } from 'jotai';
+import { useCallback } from 'react';
+
+// Re-runs the minimal metadata load without clearing collection hashes, so the
+// hash comparison only refetches collections that actually changed. Unlike
+// useInvalidateMetadataStore, this does not force a full refetch of every collection.
+export const useResyncMetadataStore = () => {
+  const store = useStore();
+
+  const resyncMetadataStore = useCallback(() => {
+    store.set(metadataLoadedVersionState.atom, (prev) => prev + 1);
+  }, [store]);
+
+  return { resyncMetadataStore };
+};

--- a/packages/twenty-front/src/modules/metadata-store/hooks/useResyncMetadataStore.ts
+++ b/packages/twenty-front/src/modules/metadata-store/hooks/useResyncMetadataStore.ts
@@ -2,9 +2,6 @@ import { metadataLoadedVersionState } from '@/metadata-store/states/metadataLoad
 import { useStore } from 'jotai';
 import { useCallback } from 'react';
 
-// Re-runs the minimal metadata load without clearing collection hashes, so the
-// hash comparison only refetches collections that actually changed. Unlike
-// useInvalidateMetadataStore, this does not force a full refetch of every collection.
 export const useResyncMetadataStore = () => {
   const store = useStore();
 

--- a/packages/twenty-front/src/modules/sse-db-event/components/SSEClientEffect.tsx
+++ b/packages/twenty-front/src/modules/sse-db-event/components/SSEClientEffect.tsx
@@ -1,7 +1,7 @@
 import { useHasAccessTokenPair } from '@/auth/hooks/useHasAccessTokenPair';
 import { tokenPairState } from '@/auth/states/tokenPairState';
 import { dispatchBrowserEvent } from '@/browser-event/utils/dispatchBrowserEvent';
-import { useInvalidateMetadataStore } from '@/metadata-store/hooks/useInvalidateMetadataStore';
+import { useResyncMetadataStore } from '@/metadata-store/hooks/useResyncMetadataStore';
 import { SSE_CLIENT_RECONNECTED_EVENT_NAME } from '@/sse-db-event/constants/SseClientReconnectedEventName';
 import { useHandleSseClientConnectionRetry } from '@/sse-db-event/hooks/useHandleSseClientConnectionRetry';
 import { activeQueryListenersState } from '@/sse-db-event/states/activeQueryListenersState';
@@ -20,7 +20,7 @@ export const SSEClientEffect = () => {
   const hasAccessTokenPair = useHasAccessTokenPair();
   const [sseClient, setSseClient] = useAtomState(sseClientState);
   const tokenPair = useAtomStateValue(tokenPairState);
-  const { invalidateMetadataStore } = useInvalidateMetadataStore();
+  const { resyncMetadataStore } = useResyncMetadataStore();
 
   const handleSSEClientConnected = useCallback(
     (reconnected: boolean) => {
@@ -33,11 +33,11 @@ export const SSEClientEffect = () => {
       }
 
       if (reconnected) {
-        invalidateMetadataStore();
+        resyncMetadataStore();
         dispatchBrowserEvent(SSE_CLIENT_RECONNECTED_EVENT_NAME);
       }
     },
-    [store, invalidateMetadataStore],
+    [store, resyncMetadataStore],
   );
 
   const { handleSseClientConnectionRetry } =


### PR DESCRIPTION
## Context

Follow-up to #22562 (merged), which fixed the SSE-gap durability hole from #22504 by calling `invalidateMetadataStore()` on SSE reconnect.

In review, @Weiko and a second reviewer flagged a performance concern: firing a full invalidation on every reconnect can spam the backend, and reconnect frequency is unbounded (`retryAttempts: Infinity`). The steer was to lean on the per-collection hashes that `FindMinimalMetadata` already returns and refetch only what actually changed.

## Problem

`invalidateMetadataStore()` sets `currentCollectionHash: undefined` for every entity key. The staleness check in `useLoadMinimalMetadata` is `entry.currentCollectionHash !== hash`, so nulling the hash makes **every** collection compare as stale. Result: each reconnect forces a full refetch of every metadata collection (objects, fields, views, ...), even when nothing changed during the gap. That defeats the collection-hash mechanism built to avoid exactly this.

## Change

Add `useResyncMetadataStore`, which only bumps `metadataLoadedVersionState` without clearing collection hashes. `MinimalMetadataLoadEffect` already re-runs on a version change, so this triggers one `FindMinimalMetadata` query; the existing hash comparison then marks only genuinely-changed collections stale.

`SSEClientEffect` now calls `resyncMetadataStore()` instead of `invalidateMetadataStore()` on reconnect.

Net: same durability guarantee (changes missed during a disconnect are caught on reconnect), but cost per reconnect drops from "refetch everything" to "one lightweight hash query + refetch only what changed."

## Testing

1. Open a record page in a workspace.
2. Create a field / page-layout tab via the metadata API while the SSE stream is dropped (background the tab, kill the network briefly, or restart the server).
3. On reconnect the new metadata appears without a manual reload.
4. Reconnect with no metadata change triggers only a `FindMinimalMetadata` query and no collection refetch.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/22956?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

