### PR TITLE
Fix signup visual regression in workspace selection layout

### DIFF
--- a/packages/twenty-front/src/modules/auth/sign-in-up/components/SignInUpGlobalScopeForm.tsx
+++ b/packages/twenty-front/src/modules/auth/sign-in-up/components/SignInUpGlobalScopeForm.tsx
@@ -38,7 +38,9 @@ import {
 import { getWorkspaceUrl } from '~/utils/getWorkspaceUrl';
 import { getAbsoluteImageUrl } from '~/utils/image/getAbsoluteImageUrl';
 
-const StyledContentContainer = styled(StyledOnboardingContentContainer)`
+const StyledWorkspaceSelectionContentContainer = styled(
+  StyledOnboardingContentContainer,
+)`
   max-width: 100%;
   width: ${ONBOARDING_CONTENT_BLOCK_WIDTH}px;
 `;
@@ -171,7 +173,7 @@ export const SignInUpGlobalScopeForm = () => {
   return (
     <>
       {signInUpStep === SignInUpStep.WorkspaceSelection && (
-        <StyledContentContainer>
+        <StyledWorkspaceSelectionContentContainer>
           <StyledWorkspaceContainer>
             {availableWorkspacesList.map((availableWorkspace, index) => (
               <OnboardingStepAnimatedItem
@@ -235,10 +237,10 @@ export const SignInUpGlobalScopeForm = () => {
               </OnboardingStepAnimatedItem>
             )}
           </StyledWorkspaceContainer>
-        </StyledContentContainer>
+        </StyledWorkspaceSelectionContentContainer>
       )}
       {signInUpStep !== SignInUpStep.WorkspaceSelection && (
-        <StyledContentContainer>
+        <StyledOnboardingContentContainer>
           {authProviders.google && (
             <SignInUpWithGoogle
               action="list-available-workspaces"
@@ -269,7 +271,7 @@ export const SignInUpGlobalScopeForm = () => {
               </ClickToActionLink>
             </StyledForgotPasswordLinkContainer>
           )}
-        </StyledContentContainer>
+        </StyledOnboardingContentContainer>
       )}
     </>
   );


### PR DESCRIPTION
## Summary
- Split the sign-in/up onboarding container styles so workspace selection can keep its wider layout without affecting the other auth states.
- Reuse the base onboarding container for the non-selection flow to restore the intended visual structure.

https://github.com/twentyhq/twenty/commit/566c3b662954de932677a3fefe69735a45fe55ae commit accidentally reused the 440px workspace-selection container for the global credential form

## Before
<img width="643" height="496" alt="Screenshot 2026-07-16 at 18 14 35" src="https://github.com/user-attachments/assets/abff0779-a236-424f-9503-9182dab5fa3f" />

## After
<img width="510" height="509" alt="Screenshot 2026-07-16 at 18 11 58" src="https://github.com/user-attachments/assets/8c4693b2-827f-4bc8-a9ce-10171bbb7d0b" />


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/22965?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

