### PR TITLE
feat(front): calendar layout for dashboard view widgets

### DIFF
--- a/packages/twenty-front/src/modules/context-store/types/ContextStoreViewType.ts
+++ b/packages/twenty-front/src/modules/context-store/types/ContextStoreViewType.ts
@@ -1,4 +1,5 @@
 export enum ContextStoreViewType {
   Table = 'table',
   Kanban = 'kanban',
+  Calendar = 'calendar',
 }

--- a/packages/twenty-front/src/modules/object-record/object-options-dropdown/components/ObjectOptionsDropdownCalendarEndFieldsContent.tsx
+++ b/packages/twenty-front/src/modules/object-record/object-options-dropdown/components/ObjectOptionsDropdownCalendarEndFieldsContent.tsx
@@ -1,13 +1,13 @@
+import { useSetAtomComponentState } from '@/ui/utilities/state/jotai/hooks/useSetAtomComponentState';
 import { type FieldMetadataItem } from '@/object-metadata/types/FieldMetadataItem';
 import { useObjectOptionsDropdown } from '@/object-record/object-options-dropdown/hooks/useObjectOptionsDropdown';
-import { recordIndexCalendarEndFieldMetadataIdState } from '@/object-record/record-index/states/recordIndexCalendarEndFieldMetadataIdState';
+import { recordIndexCalendarEndFieldMetadataIdComponentState } from '@/object-record/record-index/states/recordIndexCalendarEndFieldMetadataIdComponentState';
 import { DropdownContent } from '@/ui/layout/dropdown/components/DropdownContent';
 import { DropdownMenuHeader } from '@/ui/layout/dropdown/components/DropdownMenuHeader/DropdownMenuHeader';
 import { DropdownMenuHeaderLeftComponent } from '@/ui/layout/dropdown/components/DropdownMenuHeader/internal/DropdownMenuHeaderLeftComponent';
 import { DropdownMenuItemsContainer } from '@/ui/layout/dropdown/components/DropdownMenuItemsContainer';
 import { DropdownMenuSearchInput } from '@/ui/layout/dropdown/components/DropdownMenuSearchInput';
 import { DropdownMenuSeparator } from '@/ui/layout/dropdown/components/DropdownMenuSeparator';
-import { useSetAtomState } from '@/ui/utilities/state/jotai/hooks/useSetAtomState';
 import { useGetCurrentViewOnly } from '@/views/hooks/useGetCurrentViewOnly';
 import { useUpdateCurrentView } from '@/views/hooks/useUpdateCurrentView';
 import { useGetAvailableFieldsForCalendar } from '@/views/view-picker/hooks/useGetAvailableFieldsForCalendar';
@@ -34,8 +34,8 @@ export const ObjectOptionsDropdownCalendarEndFieldsContent = () => {
   const { updateCurrentView } = useUpdateCurrentView();
   const { availableFieldsForCalendar } = useGetAvailableFieldsForCalendar();
 
-  const setRecordIndexCalendarEndFieldMetadataId = useSetAtomState(
-    recordIndexCalendarEndFieldMetadataIdState,
+  const setRecordIndexCalendarEndFieldMetadataId = useSetAtomComponentState(
+    recordIndexCalendarEndFieldMetadataIdComponentState,
   );
 
   const availableCalendarEndFieldMetadataItems =

--- a/packages/twenty-front/src/modules/object-record/object-options-dropdown/components/ObjectOptionsDropdownCalendarFieldsContent.tsx
+++ b/packages/twenty-front/src/modules/object-record/object-options-dropdown/components/ObjectOptionsDropdownCalendarFieldsContent.tsx
@@ -1,7 +1,8 @@
+import { useSetAtomComponentState } from '@/ui/utilities/state/jotai/hooks/useSetAtomComponentState';
 import { type FieldMetadataItem } from '@/object-metadata/types/FieldMetadataItem';
 import { useObjectOptionsDropdown } from '@/object-record/object-options-dropdown/hooks/useObjectOptionsDropdown';
-import { recordIndexCalendarEndFieldMetadataIdState } from '@/object-record/record-index/states/recordIndexCalendarEndFieldMetadataIdState';
-import { recordIndexCalendarFieldMetadataIdState } from '@/object-record/record-index/states/recordIndexCalendarFieldMetadataIdState';
+import { recordIndexCalendarEndFieldMetadataIdComponentState } from '@/object-record/record-index/states/recordIndexCalendarEndFieldMetadataIdComponentState';
+import { recordIndexCalendarFieldMetadataIdComponentState } from '@/object-record/record-index/states/recordIndexCalendarFieldMetadataIdComponentState';
 import { DropdownContent } from '@/ui/layout/dropdown/components/DropdownContent';
 import { DropdownMenuHeader } from '@/ui/layout/dropdown/components/DropdownMenuHeader/DropdownMenuHeader';
 import { DropdownMenuHeaderLeftComponent } from '@/ui/layout/dropdown/components/DropdownMenuHeader/internal/DropdownMenuHeaderLeftComponent';
@@ -11,7 +12,6 @@ import { DropdownMenuSeparator } from '@/ui/layout/dropdown/components/DropdownM
 import { useGetCurrentViewOnly } from '@/views/hooks/useGetCurrentViewOnly';
 import { useUpdateCurrentView } from '@/views/hooks/useUpdateCurrentView';
 import { useGetAvailableFieldsForCalendar } from '@/views/view-picker/hooks/useGetAvailableFieldsForCalendar';
-import { useSetAtomState } from '@/ui/utilities/state/jotai/hooks/useSetAtomState';
 import { useLingui } from '@lingui/react/macro';
 import { useState } from 'react';
 import { isDefined } from 'twenty-shared/utils';
@@ -31,11 +31,11 @@ export const ObjectOptionsDropdownCalendarFieldsContent = () => {
   const { availableFieldsForCalendar, navigateToDateFieldSettings } =
     useGetAvailableFieldsForCalendar();
 
-  const setRecordIndexCalendarFieldMetadataId = useSetAtomState(
-    recordIndexCalendarFieldMetadataIdState,
+  const setRecordIndexCalendarFieldMetadataId = useSetAtomComponentState(
+    recordIndexCalendarFieldMetadataIdComponentState,
   );
-  const setRecordIndexCalendarEndFieldMetadataId = useSetAtomState(
-    recordIndexCalendarEndFieldMetadataIdState,
+  const setRecordIndexCalendarEndFieldMetadataId = useSetAtomComponentState(
+    recordIndexCalendarEndFieldMetadataIdComponentState,
   );
 
   const calendarFieldMetadata = currentView?.calendarFieldMetadataId

--- a/packages/twenty-front/src/modules/object-record/object-options-dropdown/components/ObjectOptionsDropdownCalendarViewContent.tsx
+++ b/packages/twenty-front/src/modules/object-record/object-options-dropdown/components/ObjectOptionsDropdownCalendarViewContent.tsx
@@ -1,7 +1,8 @@
+import { useSetAtomComponentState } from '@/ui/utilities/state/jotai/hooks/useSetAtomComponentState';
 import { OBJECT_OPTIONS_DROPDOWN_ID } from '@/object-record/object-options-dropdown/constants/ObjectOptionsDropdownId';
 import { useObjectOptionsDropdown } from '@/object-record/object-options-dropdown/hooks/useObjectOptionsDropdown';
 import { getSupportedRecordCalendarLayout } from '@/object-record/record-calendar/utils/getSupportedRecordCalendarLayout';
-import { recordIndexCalendarLayoutState } from '@/object-record/record-index/states/recordIndexCalendarLayoutState';
+import { recordIndexCalendarLayoutComponentState } from '@/object-record/record-index/states/recordIndexCalendarLayoutComponentState';
 import { DropdownContent } from '@/ui/layout/dropdown/components/DropdownContent';
 import { DropdownMenuHeader } from '@/ui/layout/dropdown/components/DropdownMenuHeader/DropdownMenuHeader';
 import { DropdownMenuHeaderLeftComponent } from '@/ui/layout/dropdown/components/DropdownMenuHeader/internal/DropdownMenuHeaderLeftComponent';
@@ -10,8 +11,6 @@ import { SelectableList } from '@/ui/layout/selectable-list/components/Selectabl
 import { SelectableListItem } from '@/ui/layout/selectable-list/components/SelectableListItem';
 import { selectedItemIdComponentState } from '@/ui/layout/selectable-list/states/selectedItemIdComponentState';
 import { useAtomComponentStateValue } from '@/ui/utilities/state/jotai/hooks/useAtomComponentStateValue';
-import { useAtomStateValue } from '@/ui/utilities/state/jotai/hooks/useAtomStateValue';
-import { useSetAtomState } from '@/ui/utilities/state/jotai/hooks/useSetAtomState';
 import { useUpdateCurrentView } from '@/views/hooks/useUpdateCurrentView';
 import { useIsFeatureEnabled } from '@/workspace/hooks/useIsFeatureEnabled';
 import { t } from '@lingui/core/macro';
@@ -33,8 +32,8 @@ const RECORD_CALENDAR_TIMELINE_VIEW_ID = 'record-calendar-timeline-view';
 
 export const ObjectOptionsDropdownCalendarViewContent = () => {
   const { resetContent } = useObjectOptionsDropdown();
-  const recordIndexCalendarLayout = useAtomStateValue(
-    recordIndexCalendarLayoutState,
+  const recordIndexCalendarLayout = useAtomComponentStateValue(
+    recordIndexCalendarLayoutComponentState,
   );
   const isCalendarWeekViewEnabled = useIsFeatureEnabled(
     FeatureFlagKey.IS_CALENDAR_WEEK_VIEW_ENABLED,
@@ -43,8 +42,8 @@ export const ObjectOptionsDropdownCalendarViewContent = () => {
     calendarLayout: recordIndexCalendarLayout,
     isCalendarWeekViewEnabled,
   });
-  const setRecordIndexCalendarLayout = useSetAtomState(
-    recordIndexCalendarLayoutState,
+  const setRecordIndexCalendarLayout = useSetAtomComponentState(
+    recordIndexCalendarLayoutComponentState,
   );
   const { updateCurrentView } = useUpdateCurrentView();
 

--- a/packages/twenty-front/src/modules/object-record/object-options-dropdown/components/ObjectOptionsDropdownCustomView.tsx
+++ b/packages/twenty-front/src/modules/object-record/object-options-dropdown/components/ObjectOptionsDropdownCustomView.tsx
@@ -3,7 +3,7 @@ import { OBJECT_OPTIONS_DROPDOWN_ID } from '@/object-record/object-options-dropd
 import { useObjectOptionsDropdown } from '@/object-record/object-options-dropdown/hooks/useObjectOptionsDropdown';
 import { useObjectOptionsForBoard } from '@/object-record/object-options-dropdown/hooks/useObjectOptionsForBoard';
 import { getSupportedRecordCalendarLayout } from '@/object-record/record-calendar/utils/getSupportedRecordCalendarLayout';
-import { recordIndexCalendarLayoutState } from '@/object-record/record-index/states/recordIndexCalendarLayoutState';
+import { recordIndexCalendarLayoutComponentState } from '@/object-record/record-index/states/recordIndexCalendarLayoutComponentState';
 import { recordIndexGroupFieldMetadataItemComponentState } from '@/object-record/record-index/states/recordIndexGroupFieldMetadataComponentState';
 import { DropdownContent } from '@/ui/layout/dropdown/components/DropdownContent';
 import { DropdownMenuItemsContainer } from '@/ui/layout/dropdown/components/DropdownMenuItemsContainer';
@@ -25,7 +25,6 @@ import {
 import { useDestroyViewFromCurrentState } from '@/views/view-picker/hooks/useDestroyViewFromCurrentState';
 import { useIsFeatureEnabled } from '@/workspace/hooks/useIsFeatureEnabled';
 import { viewPickerReferenceViewIdComponentState } from '@/views/view-picker/states/viewPickerReferenceViewIdComponentState';
-import { useAtomStateValue } from '@/ui/utilities/state/jotai/hooks/useAtomStateValue';
 import { useAtomFamilySelectorValue } from '@/ui/utilities/state/jotai/hooks/useAtomFamilySelectorValue';
 import { useLingui } from '@lingui/react/macro';
 import { isDefined } from 'twenty-shared/utils';
@@ -89,8 +88,8 @@ export const ObjectOptionsDropdownCustomView = ({
   const isDefaultView = currentView?.key === ViewKey.INDEX;
   const isLastView = viewsOnCurrentObject.length <= 1;
 
-  const recordIndexCalendarLayout = useAtomStateValue(
-    recordIndexCalendarLayoutState,
+  const recordIndexCalendarLayout = useAtomComponentStateValue(
+    recordIndexCalendarLayoutComponentState,
   );
   const isCalendarWeekViewEnabled = useIsFeatureEnabled(
     FeatureFlagKey.IS_CALENDAR_WEEK_VIEW_ENABLED,

--- a/packages/twenty-front/src/modules/object-record/object-options-dropdown/components/ObjectOptionsDropdownLayoutContent.tsx
+++ b/packages/twenty-front/src/modules/object-record/object-options-dropdown/components/ObjectOptionsDropdownLayoutContent.tsx
@@ -2,7 +2,7 @@ import { OBJECT_OPTIONS_DROPDOWN_ID } from '@/object-record/object-options-dropd
 import { useObjectOptionsDropdown } from '@/object-record/object-options-dropdown/hooks/useObjectOptionsDropdown';
 import { useSetViewTypeFromLayoutOptionsMenu } from '@/object-record/object-options-dropdown/hooks/useSetViewTypeFromLayoutOptionsMenu';
 import { getSupportedRecordCalendarLayout } from '@/object-record/record-calendar/utils/getSupportedRecordCalendarLayout';
-import { recordIndexCalendarLayoutState } from '@/object-record/record-index/states/recordIndexCalendarLayoutState';
+import { recordIndexCalendarLayoutComponentState } from '@/object-record/record-index/states/recordIndexCalendarLayoutComponentState';
 import { recordIndexGroupFieldMetadataItemComponentState } from '@/object-record/record-index/states/recordIndexGroupFieldMetadataComponentState';
 import { recordIndexOpenRecordInState } from '@/object-record/record-index/states/recordIndexOpenRecordInState';
 import { DropdownContent } from '@/ui/layout/dropdown/components/DropdownContent';
@@ -72,8 +72,8 @@ export const ObjectOptionsDropdownLayoutContent = () => {
   const recordIndexOpenRecordIn = useAtomStateValue(
     recordIndexOpenRecordInState,
   );
-  const recordIndexCalendarLayout = useAtomStateValue(
-    recordIndexCalendarLayoutState,
+  const recordIndexCalendarLayout = useAtomComponentStateValue(
+    recordIndexCalendarLayoutComponentState,
   );
   const isCalendarWeekViewEnabled = useIsFeatureEnabled(
     FeatureFlagKey.IS_CALENDAR_WEEK_VIEW_ENABLED,

--- a/packages/twenty-front/src/modules/object-record/object-options-dropdown/components/__tests__/ObjectOptionsDropdownCalendarViewContent.test.tsx
+++ b/packages/twenty-front/src/modules/object-record/object-options-dropdown/components/__tests__/ObjectOptionsDropdownCalendarViewContent.test.tsx
@@ -8,7 +8,7 @@ const mockResetContent = jest.fn();
 const mockSetRecordIndexCalendarLayout = jest.fn();
 const mockUpdateCurrentView = jest.fn();
 const mockUseIsFeatureEnabled = jest.fn();
-const mockUseAtomStateValue = jest.fn();
+const mockUseCalendarLayoutValue = jest.fn();
 
 jest.mock(
   '@/object-record/object-options-dropdown/hooks/useObjectOptionsDropdown',
@@ -45,13 +45,20 @@ jest.mock('@/ui/layout/selectable-list/components/SelectableListItem', () => ({
 }));
 jest.mock(
   '@/ui/utilities/state/jotai/hooks/useAtomComponentStateValue',
-  () => ({ useAtomComponentStateValue: jest.fn(() => null) }),
+  () => ({
+    useAtomComponentStateValue: (state: unknown) => {
+      const { recordIndexCalendarLayoutComponentState } = jest.requireActual(
+        '@/object-record/record-index/states/recordIndexCalendarLayoutComponentState',
+      );
+
+      return state === recordIndexCalendarLayoutComponentState
+        ? mockUseCalendarLayoutValue()
+        : null;
+    },
+  }),
 );
-jest.mock('@/ui/utilities/state/jotai/hooks/useAtomStateValue', () => ({
-  useAtomStateValue: (...args: unknown[]) => mockUseAtomStateValue(...args),
-}));
-jest.mock('@/ui/utilities/state/jotai/hooks/useSetAtomState', () => ({
-  useSetAtomState: jest.fn(() => mockSetRecordIndexCalendarLayout),
+jest.mock('@/ui/utilities/state/jotai/hooks/useSetAtomComponentState', () => ({
+  useSetAtomComponentState: jest.fn(() => mockSetRecordIndexCalendarLayout),
 }));
 jest.mock('@/views/hooks/useUpdateCurrentView', () => ({
   useUpdateCurrentView: jest.fn(() => ({
@@ -88,7 +95,7 @@ jest.mock('twenty-ui/navigation', () => ({
 describe('ObjectOptionsDropdownCalendarViewContent', () => {
   beforeEach(() => {
     jest.clearAllMocks();
-    mockUseAtomStateValue.mockReturnValue(ViewCalendarLayout.MONTH);
+    mockUseCalendarLayoutValue.mockReturnValue(ViewCalendarLayout.MONTH);
     mockUseIsFeatureEnabled.mockReturnValue(true);
     mockUpdateCurrentView.mockResolvedValue(undefined);
   });

--- a/packages/twenty-front/src/modules/object-record/record-board-widget/components/RecordBoardWidgetViewSettingsReadOnlyEffect.tsx
+++ b/packages/twenty-front/src/modules/object-record/record-board-widget/components/RecordBoardWidgetViewSettingsReadOnlyEffect.tsx
@@ -1,6 +1,6 @@
 import { isRecordBoardViewSettingsReadOnlyComponentState } from '@/object-record/record-board/states/isRecordBoardViewSettingsReadOnlyComponentState';
 import { useSetAtomComponentState } from '@/ui/utilities/state/jotai/hooks/useSetAtomComponentState';
-import { useEffect } from 'react';
+import { useLayoutEffect } from 'react';
 
 type RecordBoardWidgetViewSettingsReadOnlyEffectProps = {
   recordBoardId: string;
@@ -16,7 +16,9 @@ export const RecordBoardWidgetViewSettingsReadOnlyEffect = ({
     recordBoardId,
   );
 
-  useEffect(() => {
+  // Synchronized before paint so read-only widgets never flash (or
+  // briefly accept interaction on) their editable controls.
+  useLayoutEffect(() => {
     setIsRecordBoardViewSettingsReadOnly(isViewSettingsReadOnly);
 
     // Reset to the default on unmount so the flag cannot outlive the

--- a/packages/twenty-front/src/modules/object-record/record-calendar-widget/components/RecordCalendarWidget.tsx
+++ b/packages/twenty-front/src/modules/object-record/record-calendar-widget/components/RecordCalendarWidget.tsx
@@ -1,0 +1,79 @@
+import { useObjectMetadataItem } from '@/object-metadata/hooks/useObjectMetadataItem';
+import { useObjectPermissionsForObject } from '@/object-record/hooks/useObjectPermissionsForObject';
+import { RecordCalendar } from '@/object-record/record-calendar/components/RecordCalendar';
+import { RecordCalendarSSESubscribeEffect } from '@/object-record/record-calendar/components/RecordCalendarSSESubscribeEffect';
+import { RecordIndexCalendarDataLoaderEffect } from '@/object-record/record-calendar/components/RecordIndexCalendarDataLoaderEffect';
+import { RecordIndexCalendarSelectedDateInitEffect } from '@/object-record/record-calendar/components/RecordIndexCalendarSelectedDateInitEffect';
+import { RecordCalendarContextProvider } from '@/object-record/record-calendar/contexts/RecordCalendarContext';
+import { RecordCalendarWidgetReadOnlyEffect } from '@/object-record/record-calendar-widget/components/RecordCalendarWidgetReadOnlyEffect';
+import { recordIndexCalendarFieldMetadataIdComponentState } from '@/object-record/record-index/states/recordIndexCalendarFieldMetadataIdComponentState';
+import { useRecordIndexContextOrThrow } from '@/object-record/record-index/contexts/RecordIndexContext';
+import { useAtomComponentStateValue } from '@/ui/utilities/state/jotai/hooks/useAtomComponentStateValue';
+import { styled } from '@linaria/react';
+import { isDefined } from 'twenty-shared/utils';
+import { themeCssVariables } from 'twenty-ui/theme-constants';
+
+const StyledCalendarContainer = styled.div`
+  border: 1px solid ${themeCssVariables.border.color.light};
+  border-radius: ${themeCssVariables.border.radius.sm};
+  display: flex;
+  flex: 1;
+  flex-direction: column;
+  min-height: 0;
+  overflow: hidden;
+`;
+
+type RecordCalendarWidgetProps = {
+  isReadOnly?: boolean;
+};
+
+export const RecordCalendarWidget = ({
+  isReadOnly = true,
+}: RecordCalendarWidgetProps) => {
+  const { objectNameSingular, recordIndexId, viewBarInstanceId } =
+    useRecordIndexContextOrThrow();
+
+  const { objectMetadataItem } = useObjectMetadataItem({
+    objectNameSingular,
+  });
+
+  const objectPermissions = useObjectPermissionsForObject(
+    objectMetadataItem.id,
+  );
+
+  // Hydrated per widget instance from the backing view (draft or persisted)
+  // by the widget view load effect, so edit-mode previews work before save.
+  const recordIndexCalendarFieldMetadataId = useAtomComponentStateValue(
+    recordIndexCalendarFieldMetadataIdComponentState,
+    recordIndexId,
+  );
+
+  if (!isDefined(recordIndexCalendarFieldMetadataId)) {
+    return null;
+  }
+
+  return (
+    <>
+      <RecordCalendarWidgetReadOnlyEffect
+        recordCalendarId={recordIndexId}
+        isReadOnly={isReadOnly}
+      />
+      <StyledCalendarContainer>
+        <RecordCalendarContextProvider
+          value={{
+            viewBarInstanceId,
+            objectNameSingular,
+            visibleRecordFields: [],
+            objectMetadataItem,
+            objectPermissions,
+          }}
+        >
+          <RecordCalendar />
+          <RecordCalendarSSESubscribeEffect />
+          <RecordIndexCalendarDataLoaderEffect />
+          <RecordIndexCalendarSelectedDateInitEffect />
+        </RecordCalendarContextProvider>
+      </StyledCalendarContainer>
+    </>
+  );
+};

--- a/packages/twenty-front/src/modules/object-record/record-calendar-widget/components/RecordCalendarWidgetReadOnlyEffect.tsx
+++ b/packages/twenty-front/src/modules/object-record/record-calendar-widget/components/RecordCalendarWidgetReadOnlyEffect.tsx
@@ -1,0 +1,24 @@
+import { isRecordCalendarReadOnlyComponentState } from '@/object-record/record-calendar/states/isRecordCalendarReadOnlyComponentState';
+import { useSetAtomComponentState } from '@/ui/utilities/state/jotai/hooks/useSetAtomComponentState';
+import { useEffect } from 'react';
+
+type RecordCalendarWidgetReadOnlyEffectProps = {
+  recordCalendarId: string;
+  isReadOnly: boolean;
+};
+
+export const RecordCalendarWidgetReadOnlyEffect = ({
+  recordCalendarId,
+  isReadOnly,
+}: RecordCalendarWidgetReadOnlyEffectProps) => {
+  const setIsRecordCalendarReadOnly = useSetAtomComponentState(
+    isRecordCalendarReadOnlyComponentState,
+    recordCalendarId,
+  );
+
+  useEffect(() => {
+    setIsRecordCalendarReadOnly(isReadOnly);
+  }, [isReadOnly, setIsRecordCalendarReadOnly]);
+
+  return null;
+};

--- a/packages/twenty-front/src/modules/object-record/record-calendar-widget/components/RecordCalendarWidgetReadOnlyEffect.tsx
+++ b/packages/twenty-front/src/modules/object-record/record-calendar-widget/components/RecordCalendarWidgetReadOnlyEffect.tsx
@@ -20,6 +20,12 @@ export const RecordCalendarWidgetReadOnlyEffect = ({
   // briefly accept interaction on) their editable controls.
   useLayoutEffect(() => {
     setIsRecordCalendarReadOnly(isReadOnly);
+
+    // Reset to the default on unmount so the flag cannot outlive the
+    // widget and leak into a later calendar mounted on the same instance id.
+    return () => {
+      setIsRecordCalendarReadOnly(false);
+    };
   }, [isReadOnly, setIsRecordCalendarReadOnly]);
 
   return null;

--- a/packages/twenty-front/src/modules/object-record/record-calendar-widget/components/RecordCalendarWidgetReadOnlyEffect.tsx
+++ b/packages/twenty-front/src/modules/object-record/record-calendar-widget/components/RecordCalendarWidgetReadOnlyEffect.tsx
@@ -1,6 +1,6 @@
 import { isRecordCalendarReadOnlyComponentState } from '@/object-record/record-calendar/states/isRecordCalendarReadOnlyComponentState';
 import { useSetAtomComponentState } from '@/ui/utilities/state/jotai/hooks/useSetAtomComponentState';
-import { useEffect } from 'react';
+import { useLayoutEffect } from 'react';
 
 type RecordCalendarWidgetReadOnlyEffectProps = {
   recordCalendarId: string;
@@ -16,7 +16,9 @@ export const RecordCalendarWidgetReadOnlyEffect = ({
     recordCalendarId,
   );
 
-  useEffect(() => {
+  // Synchronized before paint so read-only widgets never flash (or
+  // briefly accept interaction on) their editable controls.
+  useLayoutEffect(() => {
     setIsRecordCalendarReadOnly(isReadOnly);
   }, [isReadOnly, setIsRecordCalendarReadOnly]);
 

--- a/packages/twenty-front/src/modules/object-record/record-calendar/components/RecordCalendar.tsx
+++ b/packages/twenty-front/src/modules/object-record/record-calendar/components/RecordCalendar.tsx
@@ -1,3 +1,4 @@
+import { useAtomComponentStateValue } from '@/ui/utilities/state/jotai/hooks/useAtomComponentStateValue';
 import { styled } from '@linaria/react';
 
 import { COMMAND_MENU_DROPDOWN_CLICK_OUTSIDE_ID } from '@/command-menu-item/constants/CommandMenuDropdownClickOutsideId';
@@ -8,7 +9,7 @@ import { RecordCalendarDay } from '@/object-record/record-calendar/day/component
 import { RecordCalendarMonth } from '@/object-record/record-calendar/month/components/RecordCalendarMonth';
 import { RecordCalendarWeek } from '@/object-record/record-calendar/week/components/RecordCalendarWeek';
 import { RECORD_CALENDAR_CARD_CLICK_OUTSIDE_ID } from '@/object-record/record-calendar/record-calendar-card/constants/RecordCalendarCardClickOutsideId';
-import { recordIndexCalendarLayoutState } from '@/object-record/record-index/states/recordIndexCalendarLayoutState';
+import { recordIndexCalendarLayoutComponentState } from '@/object-record/record-index/states/recordIndexCalendarLayoutComponentState';
 import { RecordCalendarComponentInstanceContext } from '@/object-record/record-calendar/states/contexts/RecordCalendarComponentInstanceContext';
 import { useRecordCalendarSelection } from '@/object-record/record-calendar/states/selectors/useRecordCalendarSelection';
 import { getSupportedRecordCalendarLayout } from '@/object-record/record-calendar/utils/getSupportedRecordCalendarLayout';
@@ -17,7 +18,6 @@ import { PAGE_ACTION_CONTAINER_CLICK_OUTSIDE_ID } from '@/ui/layout/page/constan
 import { useListenClickOutside } from '@/ui/utilities/pointer-event/hooks/useListenClickOutside';
 import { ScrollWrapper } from '@/ui/utilities/scroll/components/ScrollWrapper';
 import { useAvailableComponentInstanceIdOrThrow } from '@/ui/utilities/state/component-state/hooks/useAvailableComponentInstanceIdOrThrow';
-import { useAtomStateValue } from '@/ui/utilities/state/jotai/hooks/useAtomStateValue';
 import { useIsFeatureEnabled } from '@/workspace/hooks/useIsFeatureEnabled';
 import { useEffect } from 'react';
 import { LINK_CHIP_CLICK_OUTSIDE_ID } from 'twenty-ui/data-display';
@@ -44,8 +44,8 @@ export const RecordCalendar = () => {
 
   const { resetRecordSelection } = useRecordCalendarSelection(recordCalendarId);
 
-  const recordIndexCalendarLayout = useAtomStateValue(
-    recordIndexCalendarLayoutState,
+  const recordIndexCalendarLayout = useAtomComponentStateValue(
+    recordIndexCalendarLayoutComponentState,
   );
   const isCalendarWeekViewEnabled = useIsFeatureEnabled(
     FeatureFlagKey.IS_CALENDAR_WEEK_VIEW_ENABLED,

--- a/packages/twenty-front/src/modules/object-record/record-calendar/components/RecordCalendarAddNew.tsx
+++ b/packages/twenty-front/src/modules/object-record/record-calendar/components/RecordCalendarAddNew.tsx
@@ -1,14 +1,15 @@
+import { useAtomComponentStateValue } from '@/ui/utilities/state/jotai/hooks/useAtomComponentStateValue';
 import { useObjectPermissionsForObject } from '@/object-record/hooks/useObjectPermissionsForObject';
 import { isFieldMetadataReadOnlyByPermissions } from '@/object-record/read-only/utils/internal/isFieldMetadataReadOnlyByPermissions';
 import { useRecordCalendarContextOrThrow } from '@/object-record/record-calendar/contexts/RecordCalendarContext';
+import { isRecordCalendarReadOnlyComponentState } from '@/object-record/record-calendar/states/isRecordCalendarReadOnlyComponentState';
 import { hasAnySoftDeleteFilterOnViewComponentSelector } from '@/object-record/record-filter/states/hasAnySoftDeleteFilterOnView';
-import { recordIndexCalendarEndFieldMetadataIdState } from '@/object-record/record-index/states/recordIndexCalendarEndFieldMetadataIdState';
-import { recordIndexCalendarFieldMetadataIdState } from '@/object-record/record-index/states/recordIndexCalendarFieldMetadataIdState';
+import { recordIndexCalendarEndFieldMetadataIdComponentState } from '@/object-record/record-index/states/recordIndexCalendarEndFieldMetadataIdComponentState';
+import { recordIndexCalendarFieldMetadataIdComponentState } from '@/object-record/record-index/states/recordIndexCalendarFieldMetadataIdComponentState';
 import { useCreateNewIndexRecord } from '@/object-record/record-table/hooks/useCreateNewIndexRecord';
 import { canCreateRecordsForObjectMetadataItem } from '@/object-record/utils/canCreateRecordsForObjectMetadataItem';
 import { useUserTimezone } from '@/ui/input/components/internal/date/hooks/useUserTimezone';
 import { useAtomComponentSelectorValue } from '@/ui/utilities/state/jotai/hooks/useAtomComponentSelectorValue';
-import { useAtomStateValue } from '@/ui/utilities/state/jotai/hooks/useAtomStateValue';
 import { styled } from '@linaria/react';
 import { t } from '@lingui/core/macro';
 import { useContext } from 'react';
@@ -35,6 +36,10 @@ export const RecordCalendarAddNew = ({
   cardTime,
   compact = false,
 }: RecordCalendarAddNewProps) => {
+  const isRecordCalendarReadOnly = useAtomComponentStateValue(
+    isRecordCalendarReadOnlyComponentState,
+  );
+
   const { theme } = useContext(ThemeContext);
   const { userTimezone } = useUserTimezone();
   const { objectMetadataItem } = useRecordCalendarContextOrThrow();
@@ -50,11 +55,11 @@ export const RecordCalendarAddNew = ({
     hasAnySoftDeleteFilterOnViewComponentSelector,
   );
 
-  const recordIndexCalendarFieldMetadataId = useAtomStateValue(
-    recordIndexCalendarFieldMetadataIdState,
+  const recordIndexCalendarFieldMetadataId = useAtomComponentStateValue(
+    recordIndexCalendarFieldMetadataIdComponentState,
   );
-  const recordIndexCalendarEndFieldMetadataId = useAtomStateValue(
-    recordIndexCalendarEndFieldMetadataIdState,
+  const recordIndexCalendarEndFieldMetadataId = useAtomComponentStateValue(
+    recordIndexCalendarEndFieldMetadataIdComponentState,
   );
 
   const calendarFieldMetadataItem = objectMetadataItem.fields.find(
@@ -81,6 +86,7 @@ export const RecordCalendarAddNew = ({
     : false;
 
   if (
+    isRecordCalendarReadOnly ||
     hasAnySoftDeleteFilterOnView === true ||
     !canCreateRecordsForObjectMetadataItem({
       objectPermissions,

--- a/packages/twenty-front/src/modules/object-record/record-calendar/components/RecordCalendarTopBar.tsx
+++ b/packages/twenty-front/src/modules/object-record/record-calendar/components/RecordCalendarTopBar.tsx
@@ -1,10 +1,11 @@
 import { useDateTimeFormat } from '@/localization/hooks/useDateTimeFormat';
 import { RecordCalendarComponentInstanceContext } from '@/object-record/record-calendar/states/contexts/RecordCalendarComponentInstanceContext';
+import { isRecordCalendarReadOnlyComponentState } from '@/object-record/record-calendar/states/isRecordCalendarReadOnlyComponentState';
 import { recordCalendarSelectedDateComponentState } from '@/object-record/record-calendar/states/recordCalendarSelectedDateComponentState';
 import { getSupportedRecordCalendarLayout } from '@/object-record/record-calendar/utils/getSupportedRecordCalendarLayout';
 import { useRecordCalendarWeekDaysRange } from '@/object-record/record-calendar/week/hooks/useRecordCalendarWeekDaysRange';
 import { formatRecordCalendarWeekRange } from '@/object-record/record-calendar/week/utils/formatRecordCalendarWeekRange';
-import { recordIndexCalendarLayoutState } from '@/object-record/record-index/states/recordIndexCalendarLayoutState';
+import { recordIndexCalendarLayoutComponentState } from '@/object-record/record-index/states/recordIndexCalendarLayoutComponentState';
 import { DatePickerWithoutCalendar } from '@/ui/input/components/internal/date/components/DatePickerWithoutCalendar';
 import { TimeZoneAbbreviation } from '@/ui/input/components/internal/date/components/TimeZoneAbbreviation';
 import { Select } from '@/ui/input/components/Select';
@@ -14,8 +15,8 @@ import { DropdownContent } from '@/ui/layout/dropdown/components/DropdownContent
 import { useCloseDropdown } from '@/ui/layout/dropdown/hooks/useCloseDropdown';
 import { type DropdownOffset } from '@/ui/layout/dropdown/types/DropdownOffset';
 import { useAvailableComponentInstanceIdOrThrow } from '@/ui/utilities/state/component-state/hooks/useAvailableComponentInstanceIdOrThrow';
+import { useAtomComponentStateValue } from '@/ui/utilities/state/jotai/hooks/useAtomComponentStateValue';
 import { useAtomComponentState } from '@/ui/utilities/state/jotai/hooks/useAtomComponentState';
-import { useAtomState } from '@/ui/utilities/state/jotai/hooks/useAtomState';
 import { useAtomStateValue } from '@/ui/utilities/state/jotai/hooks/useAtomStateValue';
 import { useUpdateCurrentView } from '@/views/hooks/useUpdateCurrentView';
 import { useIsFeatureEnabled } from '@/workspace/hooks/useIsFeatureEnabled';
@@ -70,8 +71,12 @@ export const RecordCalendarTopBar = () => {
   const [recordCalendarSelectedDate, setRecordCalendarSelectedDate] =
     useAtomComponentState(recordCalendarSelectedDateComponentState);
 
+  const isRecordCalendarReadOnly = useAtomComponentStateValue(
+    isRecordCalendarReadOnlyComponentState,
+  );
+
   const [recordIndexCalendarLayout, setRecordIndexCalendarLayout] =
-    useAtomState(recordIndexCalendarLayoutState);
+    useAtomComponentState(recordIndexCalendarLayoutComponentState);
   const isCalendarWeekViewEnabled = useIsFeatureEnabled(
     FeatureFlagKey.IS_CALENDAR_WEEK_VIEW_ENABLED,
   );
@@ -161,7 +166,7 @@ export const RecordCalendarTopBar = () => {
   return (
     <StyledContainer>
       <StyledLeftSection>
-        {isCalendarWeekViewEnabled && (
+        {isCalendarWeekViewEnabled && !isRecordCalendarReadOnly && (
           <Select
             dropdownId={`record-calendar-layout-${recordCalendarId}`}
             value={supportedCalendarLayout}

--- a/packages/twenty-front/src/modules/object-record/record-calendar/components/__tests__/RecordCalendar.test.tsx
+++ b/packages/twenty-front/src/modules/object-record/record-calendar/components/__tests__/RecordCalendar.test.tsx
@@ -50,16 +50,19 @@ jest.mock(
 jest.mock('@/ui/utilities/pointer-event/hooks/useListenClickOutside', () => ({
   useListenClickOutside: jest.fn(),
 }));
-jest.mock('@/ui/utilities/state/jotai/hooks/useAtomStateValue', () => ({
-  useAtomStateValue: jest.fn(),
-}));
+jest.mock(
+  '@/ui/utilities/state/jotai/hooks/useAtomComponentStateValue',
+  () => ({
+    useAtomComponentStateValue: jest.fn(),
+  }),
+);
 jest.mock('@/workspace/hooks/useIsFeatureEnabled', () => ({
   useIsFeatureEnabled: jest.fn(),
 }));
 
-const useAtomStateValueMock = jest.requireMock(
-  '@/ui/utilities/state/jotai/hooks/useAtomStateValue',
-).useAtomStateValue;
+const useAtomComponentStateValueMock = jest.requireMock(
+  '@/ui/utilities/state/jotai/hooks/useAtomComponentStateValue',
+).useAtomComponentStateValue;
 const useIsFeatureEnabledMock = jest.requireMock(
   '@/workspace/hooks/useIsFeatureEnabled',
 ).useIsFeatureEnabled;
@@ -67,13 +70,13 @@ const useIsFeatureEnabledMock = jest.requireMock(
 describe('RecordCalendar', () => {
   beforeEach(() => {
     jest.clearAllMocks();
-    useAtomStateValueMock.mockReturnValue(ViewCalendarLayout.WEEK);
+    useAtomComponentStateValueMock.mockReturnValue(ViewCalendarLayout.WEEK);
   });
 
   it.each([ViewCalendarLayout.DAY, ViewCalendarLayout.WEEK])(
     'renders month when a persisted %s layout is disabled',
     (calendarLayout) => {
-      useAtomStateValueMock.mockReturnValue(calendarLayout);
+      useAtomComponentStateValueMock.mockReturnValue(calendarLayout);
       useIsFeatureEnabledMock.mockReturnValue(false);
 
       render(<RecordCalendar />);
@@ -88,7 +91,7 @@ describe('RecordCalendar', () => {
   );
 
   it('renders day when the day layout is enabled', () => {
-    useAtomStateValueMock.mockReturnValue(ViewCalendarLayout.DAY);
+    useAtomComponentStateValueMock.mockReturnValue(ViewCalendarLayout.DAY);
     useIsFeatureEnabledMock.mockReturnValue(true);
 
     render(<RecordCalendar />);

--- a/packages/twenty-front/src/modules/object-record/record-calendar/components/__tests__/RecordCalendarTopBar.test.tsx
+++ b/packages/twenty-front/src/modules/object-record/record-calendar/components/__tests__/RecordCalendarTopBar.test.tsx
@@ -3,13 +3,14 @@ import { enUS } from 'date-fns/locale';
 import { Temporal } from 'temporal-polyfill';
 
 import { RecordCalendarTopBar } from '@/object-record/record-calendar/components/RecordCalendarTopBar';
+import { recordCalendarSelectedDateComponentState } from '@/object-record/record-calendar/states/recordCalendarSelectedDateComponentState';
+import { recordIndexCalendarLayoutComponentState } from '@/object-record/record-index/states/recordIndexCalendarLayoutComponentState';
 import { ViewCalendarLayout } from '~/generated-metadata/graphql';
 
 const mockSetRecordCalendarSelectedDate = jest.fn();
 const mockSetRecordIndexCalendarLayout = jest.fn();
 const mockUpdateCurrentView = jest.fn();
 const mockUseAtomComponentState = jest.fn();
-const mockUseAtomState = jest.fn();
 const mockUseAtomStateValue = jest.fn();
 const mockUseRecordCalendarWeekDaysRange = jest.fn();
 
@@ -68,9 +69,6 @@ jest.mock('@/ui/utilities/state/jotai/hooks/useAtomComponentState', () => ({
   useAtomComponentState: (...args: unknown[]) =>
     mockUseAtomComponentState(...args),
 }));
-jest.mock('@/ui/utilities/state/jotai/hooks/useAtomState', () => ({
-  useAtomState: (...args: unknown[]) => mockUseAtomState(...args),
-}));
 jest.mock('@/ui/utilities/state/jotai/hooks/useAtomStateValue', () => ({
   useAtomStateValue: (...args: unknown[]) => mockUseAtomStateValue(...args),
 }));
@@ -101,14 +99,20 @@ jest.mock('twenty-ui/input', () => ({
 describe('RecordCalendarTopBar', () => {
   beforeEach(() => {
     jest.clearAllMocks();
-    mockUseAtomComponentState.mockReturnValue([
-      Temporal.PlainDate.from('2026-07-15'),
-      mockSetRecordCalendarSelectedDate,
-    ]);
-    mockUseAtomState.mockReturnValue([
-      ViewCalendarLayout.DAY,
-      mockSetRecordIndexCalendarLayout,
-    ]);
+    mockUseAtomComponentState.mockImplementation((state: unknown) => {
+      if (state === recordIndexCalendarLayoutComponentState) {
+        return [ViewCalendarLayout.DAY, mockSetRecordIndexCalendarLayout];
+      }
+
+      if (state === recordCalendarSelectedDateComponentState) {
+        return [
+          Temporal.PlainDate.from('2026-07-15'),
+          mockSetRecordCalendarSelectedDate,
+        ];
+      }
+
+      return [undefined, jest.fn()];
+    });
     mockUseAtomStateValue.mockReturnValue({
       locale: 'en-US',
       localeCatalog: enUS,

--- a/packages/twenty-front/src/modules/object-record/record-calendar/hooks/useRecordCalendarGroupByRecords.ts
+++ b/packages/twenty-front/src/modules/object-record/record-calendar/hooks/useRecordCalendarGroupByRecords.ts
@@ -1,3 +1,4 @@
+import { useAtomComponentStateValue } from '@/ui/utilities/state/jotai/hooks/useAtomComponentStateValue';
 import { useApolloCoreClient } from '@/object-metadata/hooks/useApolloCoreClient';
 import { hasObjectMetadataItemPositionField } from '@/object-metadata/utils/hasObjectMetadataItemPositionField';
 import { getRecordsFromRecordConnection } from '@/object-record/cache/utils/getRecordsFromRecordConnection';
@@ -5,12 +6,11 @@ import { useGroupByRecordsQuery } from '@/object-record/hooks/useGroupByRecordsQ
 import { useRecordCalendarContextOrThrow } from '@/object-record/record-calendar/contexts/RecordCalendarContext';
 import { useRecordCalendarQueryDateRangeFilter } from '@/object-record/record-calendar/month/hooks/useRecordCalendarQueryDateRangeFilter';
 import { useRelevantRecordsGqlFields } from '@/object-record/record-field/hooks/useRelevantRecordsGqlFields';
-import { recordIndexCalendarEndFieldMetadataIdState } from '@/object-record/record-index/states/recordIndexCalendarEndFieldMetadataIdState';
-import { recordIndexCalendarFieldMetadataIdState } from '@/object-record/record-index/states/recordIndexCalendarFieldMetadataIdState';
+import { recordIndexCalendarEndFieldMetadataIdComponentState } from '@/object-record/record-index/states/recordIndexCalendarEndFieldMetadataIdComponentState';
+import { recordIndexCalendarFieldMetadataIdComponentState } from '@/object-record/record-index/states/recordIndexCalendarFieldMetadataIdComponentState';
 import { type ObjectRecord } from '@/object-record/types/ObjectRecord';
 import { buildGroupByFieldObject } from '@/page-layout/widgets/graph/utils/buildGroupByFieldObject';
 import { useUserTimezone } from '@/ui/input/components/internal/date/hooks/useUserTimezone';
-import { useAtomStateValue } from '@/ui/utilities/state/jotai/hooks/useAtomStateValue';
 import { useQuery } from '@apollo/client/react';
 import { useMemo } from 'react';
 import { type Temporal } from 'temporal-polyfill';
@@ -27,11 +27,11 @@ export const useRecordCalendarGroupByRecords = (
 
   const { userTimezone } = useUserTimezone();
 
-  const recordIndexCalendarFieldMetadataId = useAtomStateValue(
-    recordIndexCalendarFieldMetadataIdState,
+  const recordIndexCalendarFieldMetadataId = useAtomComponentStateValue(
+    recordIndexCalendarFieldMetadataIdComponentState,
   );
-  const recordIndexCalendarEndFieldMetadataId = useAtomStateValue(
-    recordIndexCalendarEndFieldMetadataIdState,
+  const recordIndexCalendarEndFieldMetadataId = useAtomComponentStateValue(
+    recordIndexCalendarEndFieldMetadataIdComponentState,
   );
 
   const recordGqlFields = useRelevantRecordsGqlFields({

--- a/packages/twenty-front/src/modules/object-record/record-calendar/month/hooks/useRecordCalendarQueryDateRangeFilter.tsx
+++ b/packages/twenty-front/src/modules/object-record/record-calendar/month/hooks/useRecordCalendarQueryDateRangeFilter.tsx
@@ -2,7 +2,7 @@ import { flattenedFieldMetadataItemsSelector } from '@/object-metadata/states/fl
 import { useRecordCalendarContextOrThrow } from '@/object-record/record-calendar/contexts/RecordCalendarContext';
 import { useRecordCalendarMonthDaysRange } from '@/object-record/record-calendar/month/hooks/useRecordCalendarMonthDaysRange';
 import { getRecordCalendarDateRangeOverlapFilter } from '@/object-record/record-calendar/month/utils/getRecordCalendarDateRangeOverlapFilter';
-import { recordIndexCalendarEndFieldMetadataIdState } from '@/object-record/record-index/states/recordIndexCalendarEndFieldMetadataIdState';
+import { recordIndexCalendarEndFieldMetadataIdComponentState } from '@/object-record/record-index/states/recordIndexCalendarEndFieldMetadataIdComponentState';
 import { currentRecordFilterGroupsComponentState } from '@/object-record/record-filter-group/states/currentRecordFilterGroupsComponentState';
 import { useFilterValueDependencies } from '@/object-record/record-filter/hooks/useFilterValueDependencies';
 import { anyFieldFilterValueComponentState } from '@/object-record/record-filter/states/anyFieldFilterValueComponentState';
@@ -54,8 +54,8 @@ export const useRecordCalendarQueryDateRangeFilter = (
   const flattenedFieldMetadataItems = useAtomStateValue(
     flattenedFieldMetadataItemsSelector,
   );
-  const recordIndexCalendarEndFieldMetadataId = useAtomStateValue(
-    recordIndexCalendarEndFieldMetadataIdState,
+  const recordIndexCalendarEndFieldMetadataId = useAtomComponentStateValue(
+    recordIndexCalendarEndFieldMetadataIdComponentState,
   );
 
   const anyFieldFilterValue = useAtomComponentStateValue(

--- a/packages/twenty-front/src/modules/object-record/record-calendar/month/hooks/useRecordCalendarQueryDateRangeFilter.tsx
+++ b/packages/twenty-front/src/modules/object-record/record-calendar/month/hooks/useRecordCalendarQueryDateRangeFilter.tsx
@@ -3,6 +3,7 @@ import { useRecordCalendarContextOrThrow } from '@/object-record/record-calendar
 import { useRecordCalendarMonthDaysRange } from '@/object-record/record-calendar/month/hooks/useRecordCalendarMonthDaysRange';
 import { getRecordCalendarDateRangeOverlapFilter } from '@/object-record/record-calendar/month/utils/getRecordCalendarDateRangeOverlapFilter';
 import { recordIndexCalendarEndFieldMetadataIdComponentState } from '@/object-record/record-index/states/recordIndexCalendarEndFieldMetadataIdComponentState';
+import { recordIndexCalendarFieldMetadataIdComponentState } from '@/object-record/record-index/states/recordIndexCalendarFieldMetadataIdComponentState';
 import { currentRecordFilterGroupsComponentState } from '@/object-record/record-filter-group/states/currentRecordFilterGroupsComponentState';
 import { useFilterValueDependencies } from '@/object-record/record-filter/hooks/useFilterValueDependencies';
 import { anyFieldFilterValueComponentState } from '@/object-record/record-filter/states/anyFieldFilterValueComponentState';
@@ -12,7 +13,6 @@ import { RecordFilterOperand } from '@/object-record/record-filter/types/RecordF
 import { useUserTimezone } from '@/ui/input/components/internal/date/hooks/useUserTimezone';
 import { useAtomComponentStateValue } from '@/ui/utilities/state/jotai/hooks/useAtomComponentStateValue';
 import { useAtomStateValue } from '@/ui/utilities/state/jotai/hooks/useAtomStateValue';
-import { useGetCurrentViewOnly } from '@/views/hooks/useGetCurrentViewOnly';
 import { t } from '@lingui/core/macro';
 import { type Temporal } from 'temporal-polyfill';
 import {
@@ -37,8 +37,6 @@ export const useRecordCalendarQueryDateRangeFilter = (
 
   const { userTimezone } = useUserTimezone();
 
-  const { currentView } = useGetCurrentViewOnly();
-
   const currentRecordFilterGroups = useAtomComponentStateValue(
     currentRecordFilterGroupsComponentState,
     viewBarInstanceId,
@@ -54,6 +52,12 @@ export const useRecordCalendarQueryDateRangeFilter = (
   const flattenedFieldMetadataItems = useAtomStateValue(
     flattenedFieldMetadataItemsSelector,
   );
+  // Read per calendar instance (hydrated from the draft view in widget
+  // edit mode, from the persisted view elsewhere) instead of the current
+  // view store: a widget's pending view only exists after dashboard save.
+  const recordIndexCalendarFieldMetadataId = useAtomComponentStateValue(
+    recordIndexCalendarFieldMetadataIdComponentState,
+  );
   const recordIndexCalendarEndFieldMetadataId = useAtomComponentStateValue(
     recordIndexCalendarEndFieldMetadataIdComponentState,
   );
@@ -63,10 +67,7 @@ export const useRecordCalendarQueryDateRangeFilter = (
     viewBarInstanceId,
   );
 
-  if (
-    !isDefined(currentView) ||
-    !isDefined(currentView.calendarFieldMetadataId)
-  ) {
+  if (!isDefined(recordIndexCalendarFieldMetadataId)) {
     return {
       dateRangeFilter: {},
     };
@@ -84,11 +85,11 @@ export const useRecordCalendarQueryDateRangeFilter = (
       userTimezone,
     );
 
-  const dateRangeFilterFieldMetadataId = currentView.calendarFieldMetadataId;
+  const dateRangeFilterFieldMetadataId = recordIndexCalendarFieldMetadataId;
 
   const calendarFieldMetadataItem = objectMetadataItem.fields.find(
     (fieldMetadataItem) =>
-      fieldMetadataItem.id === currentView.calendarFieldMetadataId,
+      fieldMetadataItem.id === recordIndexCalendarFieldMetadataId,
   );
 
   const calendarEndFieldMetadataItem = objectMetadataItem.fields.find(

--- a/packages/twenty-front/src/modules/object-record/record-calendar/record-calendar-card/hooks/useIsRecordCalendarCardDragDisabled.ts
+++ b/packages/twenty-front/src/modules/object-record/record-calendar/record-calendar-card/hooks/useIsRecordCalendarCardDragDisabled.ts
@@ -1,10 +1,11 @@
+import { useAtomComponentStateValue } from '@/ui/utilities/state/jotai/hooks/useAtomComponentStateValue';
 import { useObjectPermissionsForObject } from '@/object-record/hooks/useObjectPermissionsForObject';
 import { useIsRecordReadOnly } from '@/object-record/read-only/hooks/useIsRecordReadOnly';
 import { isFieldMetadataReadOnlyByPermissions } from '@/object-record/read-only/utils/internal/isFieldMetadataReadOnlyByPermissions';
 import { useRecordCalendarContextOrThrow } from '@/object-record/record-calendar/contexts/RecordCalendarContext';
-import { recordIndexCalendarEndFieldMetadataIdState } from '@/object-record/record-index/states/recordIndexCalendarEndFieldMetadataIdState';
-import { recordIndexCalendarFieldMetadataIdState } from '@/object-record/record-index/states/recordIndexCalendarFieldMetadataIdState';
-import { useAtomStateValue } from '@/ui/utilities/state/jotai/hooks/useAtomStateValue';
+import { isRecordCalendarReadOnlyComponentState } from '@/object-record/record-calendar/states/isRecordCalendarReadOnlyComponentState';
+import { recordIndexCalendarEndFieldMetadataIdComponentState } from '@/object-record/record-index/states/recordIndexCalendarEndFieldMetadataIdComponentState';
+import { recordIndexCalendarFieldMetadataIdComponentState } from '@/object-record/record-index/states/recordIndexCalendarFieldMetadataIdComponentState';
 import { isDefined } from 'twenty-shared/utils';
 
 export const useIsRecordCalendarCardDragDisabled = (recordId: string) => {
@@ -16,11 +17,15 @@ export const useIsRecordCalendarCardDragDisabled = (recordId: string) => {
   const objectPermissions = useObjectPermissionsForObject(
     objectMetadataItem.id,
   );
-  const recordIndexCalendarFieldMetadataId = useAtomStateValue(
-    recordIndexCalendarFieldMetadataIdState,
+  const isRecordCalendarReadOnly = useAtomComponentStateValue(
+    isRecordCalendarReadOnlyComponentState,
   );
-  const recordIndexCalendarEndFieldMetadataId = useAtomStateValue(
-    recordIndexCalendarEndFieldMetadataIdState,
+
+  const recordIndexCalendarFieldMetadataId = useAtomComponentStateValue(
+    recordIndexCalendarFieldMetadataIdComponentState,
+  );
+  const recordIndexCalendarEndFieldMetadataId = useAtomComponentStateValue(
+    recordIndexCalendarEndFieldMetadataIdComponentState,
   );
 
   const calendarFieldMetadataItem = objectMetadataItem.fields.find(
@@ -46,6 +51,9 @@ export const useIsRecordCalendarCardDragDisabled = (recordId: string) => {
       }));
 
   return (
-    recordIsReadOnly || calendarFieldIsReadOnly || calendarEndFieldIsReadOnly
+    isRecordCalendarReadOnly ||
+    recordIsReadOnly ||
+    calendarFieldIsReadOnly ||
+    calendarEndFieldIsReadOnly
   );
 };

--- a/packages/twenty-front/src/modules/object-record/record-calendar/states/isRecordCalendarReadOnlyComponentState.ts
+++ b/packages/twenty-front/src/modules/object-record/record-calendar/states/isRecordCalendarReadOnlyComponentState.ts
@@ -1,0 +1,9 @@
+import { RecordCalendarComponentInstanceContext } from '@/object-record/record-calendar/states/contexts/RecordCalendarComponentInstanceContext';
+import { createAtomComponentState } from '@/ui/utilities/state/jotai/utils/createAtomComponentState';
+
+export const isRecordCalendarReadOnlyComponentState =
+  createAtomComponentState<boolean>({
+    key: 'isRecordCalendarReadOnlyComponentState',
+    defaultValue: false,
+    componentInstanceContext: RecordCalendarComponentInstanceContext,
+  });

--- a/packages/twenty-front/src/modules/object-record/record-calendar/states/selectors/calendarDayRecordsComponentFamilySelector.ts
+++ b/packages/twenty-front/src/modules/object-record/record-calendar/states/selectors/calendarDayRecordsComponentFamilySelector.ts
@@ -5,8 +5,8 @@ import { RecordCalendarComponentInstanceContext } from '@/object-record/record-c
 import { recordCalendarRecordIdsComponentState } from '@/object-record/record-calendar/states/recordCalendarRecordIdsComponentState';
 import { isRecordCalendarDayInDateRange } from '@/object-record/record-calendar/utils/isRecordCalendarDayInDateRange';
 import { isRecordCalendarDayInDateTimeRange } from '@/object-record/record-calendar/utils/isRecordCalendarDayInDateTimeRange';
-import { recordIndexCalendarEndFieldMetadataIdState } from '@/object-record/record-index/states/recordIndexCalendarEndFieldMetadataIdState';
-import { recordIndexCalendarFieldMetadataIdState } from '@/object-record/record-index/states/recordIndexCalendarFieldMetadataIdState';
+import { recordIndexCalendarEndFieldMetadataIdComponentState } from '@/object-record/record-index/states/recordIndexCalendarEndFieldMetadataIdComponentState';
+import { recordIndexCalendarFieldMetadataIdComponentState } from '@/object-record/record-index/states/recordIndexCalendarFieldMetadataIdComponentState';
 import { recordStoreFamilyState } from '@/object-record/record-store/states/recordStoreFamilyState';
 import { createAtomComponentFamilySelector } from '@/ui/utilities/state/jotai/utils/createAtomComponentFamilySelector';
 import { isNonEmptyString } from '@sniptt/guards';
@@ -26,10 +26,12 @@ export const calendarDayRecordIdsComponentFamilySelector =
       ({ instanceId, familyKey: { day, timeZone } }) =>
       ({ get }) => {
         const calendarFieldMetadataId = get(
-          recordIndexCalendarFieldMetadataIdState,
+          recordIndexCalendarFieldMetadataIdComponentState,
+          { instanceId },
         );
         const calendarEndFieldMetadataId = get(
-          recordIndexCalendarEndFieldMetadataIdState,
+          recordIndexCalendarEndFieldMetadataIdComponentState,
+          { instanceId },
         );
 
         const objectMetadataItems = get(objectMetadataItemsSelector);

--- a/packages/twenty-front/src/modules/object-record/record-calendar/time-grid/components/RecordCalendarTimeGrid.tsx
+++ b/packages/twenty-front/src/modules/object-record/record-calendar/time-grid/components/RecordCalendarTimeGrid.tsx
@@ -1,3 +1,4 @@
+import { useAtomComponentStateValue } from '@/ui/utilities/state/jotai/hooks/useAtomComponentStateValue';
 import { useDateTimeFormat } from '@/localization/hooks/useDateTimeFormat';
 import { RecordCalendarAddNew } from '@/object-record/record-calendar/components/RecordCalendarAddNew';
 import { useRecordCalendarContextOrThrow } from '@/object-record/record-calendar/contexts/RecordCalendarContext';
@@ -14,12 +15,11 @@ import {
   type RecordCalendarWeekSlotInteractionMode,
   updateRecordCalendarWeekActiveSlot,
 } from '@/object-record/record-calendar/week/utils/updateRecordCalendarWeekActiveSlot';
-import { recordIndexCalendarEndFieldMetadataIdState } from '@/object-record/record-index/states/recordIndexCalendarEndFieldMetadataIdState';
-import { recordIndexCalendarFieldMetadataIdState } from '@/object-record/record-index/states/recordIndexCalendarFieldMetadataIdState';
+import { recordIndexCalendarEndFieldMetadataIdComponentState } from '@/object-record/record-index/states/recordIndexCalendarEndFieldMetadataIdComponentState';
+import { recordIndexCalendarFieldMetadataIdComponentState } from '@/object-record/record-index/states/recordIndexCalendarFieldMetadataIdComponentState';
 import { recordStoreFamilyState } from '@/object-record/record-store/states/recordStoreFamilyState';
 import { TimeZoneAbbreviation } from '@/ui/input/components/internal/date/components/TimeZoneAbbreviation';
 import { useAtomComponentFamilySelectorValue } from '@/ui/utilities/state/jotai/hooks/useAtomComponentFamilySelectorValue';
-import { useAtomStateValue } from '@/ui/utilities/state/jotai/hooks/useAtomStateValue';
 import { styled } from '@linaria/react';
 import { t } from '@lingui/core/macro';
 import { format } from 'date-fns';
@@ -441,11 +441,11 @@ export const RecordCalendarTimeGrid = ({
 }: RecordCalendarTimeGridProps) => {
   const { objectMetadataItem } = useRecordCalendarContextOrThrow();
   const { timeFormat, timeZone } = useDateTimeFormat();
-  const recordIndexCalendarFieldMetadataId = useAtomStateValue(
-    recordIndexCalendarFieldMetadataIdState,
+  const recordIndexCalendarFieldMetadataId = useAtomComponentStateValue(
+    recordIndexCalendarFieldMetadataIdComponentState,
   );
-  const recordIndexCalendarEndFieldMetadataId = useAtomStateValue(
-    recordIndexCalendarEndFieldMetadataIdState,
+  const recordIndexCalendarEndFieldMetadataId = useAtomComponentStateValue(
+    recordIndexCalendarEndFieldMetadataIdComponentState,
   );
   const scrollAnchorRef = useRef<HTMLDivElement>(null);
   const gridRef = useRef<HTMLDivElement>(null);

--- a/packages/twenty-front/src/modules/object-record/record-calendar/utils/isFieldMetadataItemAvailableAsCalendarField.ts
+++ b/packages/twenty-front/src/modules/object-record/record-calendar/utils/isFieldMetadataItemAvailableAsCalendarField.ts
@@ -4,10 +4,10 @@ import {
   isFieldMetadataSupportedInGroupBy,
 } from 'twenty-shared/utils';
 
-// Mirrors useGetAvailableFieldsForCalendar so widget calendar settings
-// offer the same date fields as the record index calendar view picker
-// (excluding system fields like deletedAt).
-export const isFieldMetadataItemAvailableAsWidgetCalendarField = (
+// Single availability rule for calendar date fields, shared by the
+// record index calendar picker and dashboard widget calendar settings:
+// active date fields, excluding system ones like deletedAt.
+export const isFieldMetadataItemAvailableAsCalendarField = (
   fieldMetadataItem: FieldMetadataItem,
 ) =>
   fieldMetadataItem.isActive === true &&

--- a/packages/twenty-front/src/modules/object-record/record-drag/hooks/useProcessCalendarCardDrop.ts
+++ b/packages/twenty-front/src/modules/object-record/record-drag/hooks/useProcessCalendarCardDrop.ts
@@ -1,3 +1,4 @@
+import { useAtomComponentStateValue } from '@/ui/utilities/state/jotai/hooks/useAtomComponentStateValue';
 import { type DropResult } from '@hello-pangea/dnd';
 import { useCallback } from 'react';
 import { useStore } from 'jotai';
@@ -9,12 +10,11 @@ import { getRecordIdFromRecordCalendarCardDraggableId } from '@/object-record/re
 
 import { extractRecordPositions } from '@/object-record/record-drag/utils/extractRecordPositions';
 import { getShiftedRecordCalendarDateTime } from '@/object-record/record-drag/utils/getShiftedRecordCalendarDateTime';
-import { recordIndexCalendarEndFieldMetadataIdState } from '@/object-record/record-index/states/recordIndexCalendarEndFieldMetadataIdState';
+import { recordIndexCalendarEndFieldMetadataIdComponentState } from '@/object-record/record-index/states/recordIndexCalendarEndFieldMetadataIdComponentState';
 import { recordStoreFamilyState } from '@/object-record/record-store/states/recordStoreFamilyState';
 import { computeNewPositionOfDraggedRecord } from '@/object-record/utils/computeNewPositionOfDraggedRecord';
 import { useUserTimezone } from '@/ui/input/components/internal/date/hooks/useUserTimezone';
 import { useAtomComponentFamilySelectorCallbackState } from '@/ui/utilities/state/jotai/hooks/useAtomComponentFamilySelectorCallbackState';
-import { useAtomStateValue } from '@/ui/utilities/state/jotai/hooks/useAtomStateValue';
 import { useGetCurrentViewOnly } from '@/views/hooks/useGetCurrentViewOnly';
 import { Temporal } from 'temporal-polyfill';
 import { FieldMetadataType } from 'twenty-shared/types';
@@ -25,8 +25,8 @@ export const useProcessCalendarCardDrop = () => {
   const { objectMetadataItem } = useRecordCalendarContextOrThrow();
   const { currentView } = useGetCurrentViewOnly();
   const { updateOneRecord } = useUpdateOneRecord();
-  const recordIndexCalendarEndFieldMetadataId = useAtomStateValue(
-    recordIndexCalendarEndFieldMetadataIdState,
+  const recordIndexCalendarEndFieldMetadataId = useAtomComponentStateValue(
+    recordIndexCalendarEndFieldMetadataIdComponentState,
   );
 
   const { userTimezone } = useUserTimezone();

--- a/packages/twenty-front/src/modules/object-record/record-index/hooks/useLoadRecordIndexStates.ts
+++ b/packages/twenty-front/src/modules/object-record/record-index/hooks/useLoadRecordIndexStates.ts
@@ -13,12 +13,12 @@ import { currentRecordFiltersComponentState } from '@/object-record/record-filte
 import { useSetRecordGroups } from '@/object-record/record-group/hooks/useSetRecordGroups';
 import { getSupportedRecordCalendarLayout } from '@/object-record/record-calendar/utils/getSupportedRecordCalendarLayout';
 import { getEffectiveRecordCalendarEndFieldMetadataId } from '@/object-record/record-calendar/utils/getEffectiveRecordCalendarEndFieldMetadataId';
-import { recordIndexCalendarEndFieldMetadataIdState } from '@/object-record/record-index/states/recordIndexCalendarEndFieldMetadataIdState';
+import { recordIndexCalendarEndFieldMetadataIdComponentState } from '@/object-record/record-index/states/recordIndexCalendarEndFieldMetadataIdComponentState';
 import { recordIndexGroupFieldMetadataItemComponentState } from '@/object-record/record-index/states/recordIndexGroupFieldMetadataComponentState';
 import { currentRecordSortsComponentState } from '@/object-record/record-sort/states/currentRecordSortsComponentState';
 
-import { recordIndexCalendarFieldMetadataIdState } from '@/object-record/record-index/states/recordIndexCalendarFieldMetadataIdState';
-import { recordIndexCalendarLayoutState } from '@/object-record/record-index/states/recordIndexCalendarLayoutState';
+import { recordIndexCalendarFieldMetadataIdComponentState } from '@/object-record/record-index/states/recordIndexCalendarFieldMetadataIdComponentState';
+import { recordIndexCalendarLayoutComponentState } from '@/object-record/record-index/states/recordIndexCalendarLayoutComponentState';
 import { RECORD_BOARD_COLUMN_WIDTH } from '@/object-record/record-board/constants/RecordBoardColumnWidth';
 import { clampRecordBoardColumnWidth } from '@/object-record/record-board/utils/clampRecordBoardColumnWidth';
 import { recordIndexFieldDefinitionsState } from '@/object-record/record-index/states/recordIndexFieldDefinitionsState';
@@ -33,6 +33,8 @@ import { type ColumnDefinition } from '@/object-record/record-table/types/Column
 import { convertAggregateOperationToExtendedAggregateOperation } from '@/object-record/utils/convertAggregateOperationToExtendedAggregateOperation';
 import { filterAvailableTableColumns } from '@/object-record/utils/filterAvailableTableColumns';
 import { getRecordIndexIdFromObjectNamePluralAndViewId } from '@/object-record/utils/getRecordIndexIdFromObjectNamePluralAndViewId';
+import { useAvailableComponentInstanceId } from '@/ui/utilities/state/component-state/hooks/useAvailableComponentInstanceId';
+import { ViewComponentInstanceContext } from '@/views/states/contexts/ViewComponentInstanceContext';
 import { useAtomComponentStateCallbackState } from '@/ui/utilities/state/jotai/hooks/useAtomComponentStateCallbackState';
 import { hasInitializedCurrentRecordFieldsComponentFamilyState } from '@/views/states/hasInitializedCurrentRecordFieldsComponentFamilyState';
 import { hasInitializedCurrentRecordFiltersComponentFamilyState } from '@/views/states/hasInitializedCurrentRecordFiltersComponentFamilyState';
@@ -82,6 +84,10 @@ export const useLoadRecordIndexStates = () => {
 
   const recordIndexKanbanColumnWidthAtom = useAtomComponentStateCallbackState(
     recordIndexKanbanColumnWidthComponentState,
+  );
+
+  const ambientViewInstanceId = useAvailableComponentInstanceId(
+    ViewComponentInstanceContext,
   );
 
   const { getFieldMetadataItemByIdOrThrow } =
@@ -327,20 +333,31 @@ export const useLoadRecordIndexStates = () => {
           if (!skipGlobalIndexStates) {
             batchSet(recordIndexViewTypeState.atom, view.type);
             batchSet(recordIndexOpenRecordInState.atom, view.openRecordIn);
+          }
 
+          const recordCalendarInstanceId =
+            options?.recordIndexId ?? ambientViewInstanceId;
+
+          if (isDefined(recordCalendarInstanceId)) {
             batchSet(
-              recordIndexCalendarFieldMetadataIdState.atom,
+              recordIndexCalendarFieldMetadataIdComponentState.atomFamily({
+                instanceId: recordCalendarInstanceId,
+              }),
               view.calendarFieldMetadataId ?? null,
             );
             batchSet(
-              recordIndexCalendarEndFieldMetadataIdState.atom,
+              recordIndexCalendarEndFieldMetadataIdComponentState.atomFamily({
+                instanceId: recordCalendarInstanceId,
+              }),
               getEffectiveRecordCalendarEndFieldMetadataId({
                 calendarEndFieldMetadataId: view.calendarEndFieldMetadataId,
                 isCalendarWeekViewEnabled,
               }),
             );
             batchSet(
-              recordIndexCalendarLayoutState.atom,
+              recordIndexCalendarLayoutComponentState.atomFamily({
+                instanceId: recordCalendarInstanceId,
+              }),
               getSupportedRecordCalendarLayout({
                 calendarLayout: view.calendarLayout,
                 isCalendarWeekViewEnabled,
@@ -393,6 +410,7 @@ export const useLoadRecordIndexStates = () => {
     },
     [
       store,
+      ambientViewInstanceId,
       contextStoreTargetedRecordsRuleAtom,
       recordIndexGroupFieldMetadataItemAtom,
       recordIndexGroupAggregateOperationAtom,

--- a/packages/twenty-front/src/modules/object-record/record-index/states/recordIndexCalendarEndFieldMetadataIdComponentState.ts
+++ b/packages/twenty-front/src/modules/object-record/record-index/states/recordIndexCalendarEndFieldMetadataIdComponentState.ts
@@ -1,0 +1,9 @@
+import { RecordCalendarComponentInstanceContext } from '@/object-record/record-calendar/states/contexts/RecordCalendarComponentInstanceContext';
+import { createAtomComponentState } from '@/ui/utilities/state/jotai/utils/createAtomComponentState';
+
+export const recordIndexCalendarEndFieldMetadataIdComponentState =
+  createAtomComponentState<string | null>({
+    key: 'recordIndexCalendarEndFieldMetadataIdComponentState',
+    defaultValue: null,
+    componentInstanceContext: RecordCalendarComponentInstanceContext,
+  });

--- a/packages/twenty-front/src/modules/object-record/record-index/states/recordIndexCalendarEndFieldMetadataIdState.ts
+++ b/packages/twenty-front/src/modules/object-record/record-index/states/recordIndexCalendarEndFieldMetadataIdState.ts
@@ -1,8 +1,0 @@
-import { createAtomState } from '@/ui/utilities/state/jotai/utils/createAtomState';
-
-export const recordIndexCalendarEndFieldMetadataIdState = createAtomState<
-  string | null
->({
-  key: 'recordIndexCalendarEndFieldMetadataIdState',
-  defaultValue: null,
-});

--- a/packages/twenty-front/src/modules/object-record/record-index/states/recordIndexCalendarFieldMetadataIdComponentState.ts
+++ b/packages/twenty-front/src/modules/object-record/record-index/states/recordIndexCalendarFieldMetadataIdComponentState.ts
@@ -1,0 +1,9 @@
+import { RecordCalendarComponentInstanceContext } from '@/object-record/record-calendar/states/contexts/RecordCalendarComponentInstanceContext';
+import { createAtomComponentState } from '@/ui/utilities/state/jotai/utils/createAtomComponentState';
+
+export const recordIndexCalendarFieldMetadataIdComponentState =
+  createAtomComponentState<string | null>({
+    key: 'recordIndexCalendarFieldMetadataIdComponentState',
+    defaultValue: null,
+    componentInstanceContext: RecordCalendarComponentInstanceContext,
+  });

--- a/packages/twenty-front/src/modules/object-record/record-index/states/recordIndexCalendarFieldMetadataIdState.ts
+++ b/packages/twenty-front/src/modules/object-record/record-index/states/recordIndexCalendarFieldMetadataIdState.ts
@@ -1,8 +1,0 @@
-import { createAtomState } from '@/ui/utilities/state/jotai/utils/createAtomState';
-
-export const recordIndexCalendarFieldMetadataIdState = createAtomState<
-  string | null
->({
-  key: 'recordIndexCalendarFieldMetadataIdState',
-  defaultValue: null,
-});

--- a/packages/twenty-front/src/modules/object-record/record-index/states/recordIndexCalendarLayoutComponentState.ts
+++ b/packages/twenty-front/src/modules/object-record/record-index/states/recordIndexCalendarLayoutComponentState.ts
@@ -1,0 +1,10 @@
+import { RecordCalendarComponentInstanceContext } from '@/object-record/record-calendar/states/contexts/RecordCalendarComponentInstanceContext';
+import { createAtomComponentState } from '@/ui/utilities/state/jotai/utils/createAtomComponentState';
+import { ViewCalendarLayout } from '~/generated-metadata/graphql';
+
+export const recordIndexCalendarLayoutComponentState =
+  createAtomComponentState<ViewCalendarLayout>({
+    key: 'recordIndexCalendarLayoutComponentState',
+    defaultValue: ViewCalendarLayout.MONTH,
+    componentInstanceContext: RecordCalendarComponentInstanceContext,
+  });

--- a/packages/twenty-front/src/modules/object-record/record-index/states/recordIndexCalendarLayoutState.ts
+++ b/packages/twenty-front/src/modules/object-record/record-index/states/recordIndexCalendarLayoutState.ts
@@ -1,8 +1,0 @@
-import { createAtomState } from '@/ui/utilities/state/jotai/utils/createAtomState';
-import { ViewCalendarLayout } from '~/generated-metadata/graphql';
-
-export const recordIndexCalendarLayoutState =
-  createAtomState<ViewCalendarLayout>({
-    key: 'recordIndexCalendarLayoutState',
-    defaultValue: ViewCalendarLayout.MONTH,
-  });

--- a/packages/twenty-front/src/modules/page-layout/widgets/record-table/components/RecordTableWidgetRendererContent.tsx
+++ b/packages/twenty-front/src/modules/page-layout/widgets/record-table/components/RecordTableWidgetRendererContent.tsx
@@ -1,6 +1,7 @@
 import { ContextStoreViewType } from '@/context-store/types/ContextStoreViewType';
 import { useObjectMetadataItemById } from '@/object-metadata/hooks/useObjectMetadataItemById';
 import { RecordBoardWidget } from '@/object-record/record-board-widget/components/RecordBoardWidget';
+import { RecordCalendarWidget } from '@/object-record/record-calendar-widget/components/RecordCalendarWidget';
 import { RecordTableWidget } from '@/object-record/record-table-widget/components/RecordTableWidget';
 import { RecordTableWidgetProvider } from '@/object-record/record-table-widget/components/RecordTableWidgetProvider';
 import { useIsPageLayoutInEditMode } from '@/page-layout/hooks/useIsPageLayoutInEditMode';
@@ -54,6 +55,7 @@ export const RecordTableWidgetRendererContent = ({
   );
 
   const isKanbanLayout = widgetViewLayout === ViewType.KANBAN;
+  const isCalendarLayout = widgetViewLayout === ViewType.CALENDAR;
 
   return (
     <>
@@ -70,11 +72,15 @@ export const RecordTableWidgetRendererContent = ({
         contextStoreViewType={
           isKanbanLayout
             ? ContextStoreViewType.Kanban
-            : ContextStoreViewType.Table
+            : isCalendarLayout
+              ? ContextStoreViewType.Calendar
+              : ContextStoreViewType.Table
         }
       >
         {isKanbanLayout ? (
           <RecordBoardWidget isReadOnly={isReadOnly} />
+        ) : isCalendarLayout ? (
+          <RecordCalendarWidget isReadOnly={isReadOnly} />
         ) : (
           <RecordTableWidget
             isReadOnly={isReadOnly}

--- a/packages/twenty-front/src/modules/page-layout/widgets/record-table/hooks/useRecordTableWidgetLayoutCallbacks.ts
+++ b/packages/twenty-front/src/modules/page-layout/widgets/record-table/hooks/useRecordTableWidgetLayoutCallbacks.ts
@@ -4,11 +4,12 @@ import { buildDraftViewGroupsForFieldMetadataItem } from '@/page-layout/widgets/
 import { useAtomComponentStateCallbackState } from '@/ui/utilities/state/jotai/hooks/useAtomComponentStateCallbackState';
 import { useStore } from 'jotai';
 import { isDefined } from 'twenty-shared/utils';
-import { ViewType } from '~/generated-metadata/graphql';
+import { ViewCalendarLayout, ViewType } from '~/generated-metadata/graphql';
 
 export type RecordTableWidgetLayoutViewType =
   | ViewType.TABLE_WIDGET
-  | ViewType.KANBAN_WIDGET;
+  | ViewType.KANBAN_WIDGET
+  | ViewType.CALENDAR_WIDGET;
 
 type UseRecordTableWidgetLayoutCallbacksParams = {
   pageLayoutId: string;
@@ -58,9 +59,11 @@ export const useRecordTableWidgetLayoutCallbacks = ({
   const handleLayoutChange = ({
     targetViewType,
     defaultGroupByFieldMetadataItem,
+    defaultCalendarFieldMetadataItem,
   }: {
     targetViewType: RecordTableWidgetLayoutViewType;
     defaultGroupByFieldMetadataItem: FieldMetadataItem | null;
+    defaultCalendarFieldMetadataItem?: FieldMetadataItem | null;
   }) => {
     store.set(recordTableWidgetViewDraftState, (prev) => {
       const widgetViewDraft = prev[widgetId];
@@ -100,6 +103,32 @@ export const useRecordTableWidgetLayoutCallbacks = ({
         };
       }
 
+      if (targetViewType === ViewType.CALENDAR_WIDGET) {
+        const hasCalendarField = isDefined(
+          widgetViewDraft.view.calendarFieldMetadataId,
+        );
+
+        if (!hasCalendarField && !isDefined(defaultCalendarFieldMetadataItem)) {
+          return prev;
+        }
+
+        return {
+          ...prev,
+          [widgetId]: {
+            ...widgetViewDraft,
+            view: {
+              ...widgetViewDraft.view,
+              type: targetViewType,
+              calendarLayout:
+                widgetViewDraft.view.calendarLayout ?? ViewCalendarLayout.MONTH,
+              calendarFieldMetadataId: hasCalendarField
+                ? widgetViewDraft.view.calendarFieldMetadataId
+                : defaultCalendarFieldMetadataItem?.id,
+            },
+          },
+        };
+      }
+
       return {
         ...prev,
         [widgetId]: {
@@ -107,6 +136,29 @@ export const useRecordTableWidgetLayoutCallbacks = ({
           view: {
             ...widgetViewDraft.view,
             type: targetViewType,
+          },
+        },
+      };
+    });
+  };
+
+  const handleCalendarFieldChange = (fieldMetadataItem: FieldMetadataItem) => {
+    store.set(recordTableWidgetViewDraftState, (prev) => {
+      const widgetViewDraft = prev[widgetId];
+
+      if (!isDefined(widgetViewDraft)) {
+        return prev;
+      }
+
+      return {
+        ...prev,
+        [widgetId]: {
+          ...widgetViewDraft,
+          view: {
+            ...widgetViewDraft.view,
+            calendarFieldMetadataId: fieldMetadataItem.id,
+            calendarLayout:
+              widgetViewDraft.view.calendarLayout ?? ViewCalendarLayout.MONTH,
           },
         },
       };
@@ -137,6 +189,7 @@ export const useRecordTableWidgetLayoutCallbacks = ({
   };
 
   return {
+    handleCalendarFieldChange,
     handleGroupByFieldChange,
     handleLayoutChange,
     handleShouldHideEmptyGroupsChange,

--- a/packages/twenty-front/src/modules/page-layout/widgets/record-table/hooks/useRecordTableWidgetLayoutCallbacks.ts
+++ b/packages/twenty-front/src/modules/page-layout/widgets/record-table/hooks/useRecordTableWidgetLayoutCallbacks.ts
@@ -1,5 +1,6 @@
 import { type FieldMetadataItem } from '@/object-metadata/types/FieldMetadataItem';
 import { recordTableWidgetViewDraftComponentState } from '@/page-layout/states/recordTableWidgetViewDraftComponentState';
+import { type RecordTableWidgetViewSnapshot } from '@/page-layout/widgets/record-table/types/RecordTableWidgetViewSnapshot';
 import { buildDraftViewGroupsForFieldMetadataItem } from '@/page-layout/widgets/record-table/utils/buildDraftViewGroupsForFieldMetadataItem';
 import { useAtomComponentStateCallbackState } from '@/ui/utilities/state/jotai/hooks/useAtomComponentStateCallbackState';
 import { useStore } from 'jotai';
@@ -27,8 +28,12 @@ export const useRecordTableWidgetLayoutCallbacks = ({
 
   const store = useStore();
 
-  const handleGroupByFieldChange = (
-    fieldMetadataItem: FieldMetadataItem | null,
+  // Returning the received snapshot unchanged from the updater leaves the
+  // whole draft map untouched (no state update is published).
+  const setWidgetViewDraft = (
+    updater: (
+      widgetViewDraft: RecordTableWidgetViewSnapshot,
+    ) => RecordTableWidgetViewSnapshot,
   ) => {
     store.set(recordTableWidgetViewDraftState, (prev) => {
       const widgetViewDraft = prev[widgetId];
@@ -37,23 +42,35 @@ export const useRecordTableWidgetLayoutCallbacks = ({
         return prev;
       }
 
+      const updatedWidgetViewDraft = updater(widgetViewDraft);
+
+      if (updatedWidgetViewDraft === widgetViewDraft) {
+        return prev;
+      }
+
       return {
         ...prev,
-        [widgetId]: {
-          ...widgetViewDraft,
-          view: {
-            ...widgetViewDraft.view,
-            mainGroupByFieldMetadataId: fieldMetadataItem?.id ?? null,
-          },
-          viewGroups: isDefined(fieldMetadataItem)
-            ? buildDraftViewGroupsForFieldMetadataItem({
-                viewId: widgetViewDraft.view.id,
-                fieldMetadataItem,
-              })
-            : [],
-        },
+        [widgetId]: updatedWidgetViewDraft,
       };
     });
+  };
+
+  const handleGroupByFieldChange = (
+    fieldMetadataItem: FieldMetadataItem | null,
+  ) => {
+    setWidgetViewDraft((widgetViewDraft) => ({
+      ...widgetViewDraft,
+      view: {
+        ...widgetViewDraft.view,
+        mainGroupByFieldMetadataId: fieldMetadataItem?.id ?? null,
+      },
+      viewGroups: isDefined(fieldMetadataItem)
+        ? buildDraftViewGroupsForFieldMetadataItem({
+            viewId: widgetViewDraft.view.id,
+            fieldMetadataItem,
+          })
+        : [],
+    }));
   };
 
   const handleLayoutChange = ({
@@ -65,41 +82,32 @@ export const useRecordTableWidgetLayoutCallbacks = ({
     defaultGroupByFieldMetadataItem: FieldMetadataItem | null;
     defaultCalendarFieldMetadataItem?: FieldMetadataItem | null;
   }) => {
-    store.set(recordTableWidgetViewDraftState, (prev) => {
-      const widgetViewDraft = prev[widgetId];
-
-      if (!isDefined(widgetViewDraft)) {
-        return prev;
-      }
-
+    setWidgetViewDraft((widgetViewDraft) => {
       if (targetViewType === ViewType.KANBAN_WIDGET) {
         const hasGroupBy = isDefined(
           widgetViewDraft.view.mainGroupByFieldMetadataId,
         );
 
         if (!hasGroupBy && !isDefined(defaultGroupByFieldMetadataItem)) {
-          return prev;
+          return widgetViewDraft;
         }
 
         return {
-          ...prev,
-          [widgetId]: {
-            ...widgetViewDraft,
-            view: {
-              ...widgetViewDraft.view,
-              type: targetViewType,
-              mainGroupByFieldMetadataId: hasGroupBy
-                ? widgetViewDraft.view.mainGroupByFieldMetadataId
-                : defaultGroupByFieldMetadataItem?.id,
-            },
-            viewGroups:
-              hasGroupBy || !isDefined(defaultGroupByFieldMetadataItem)
-                ? widgetViewDraft.viewGroups
-                : buildDraftViewGroupsForFieldMetadataItem({
-                    viewId: widgetViewDraft.view.id,
-                    fieldMetadataItem: defaultGroupByFieldMetadataItem,
-                  }),
+          ...widgetViewDraft,
+          view: {
+            ...widgetViewDraft.view,
+            type: targetViewType,
+            mainGroupByFieldMetadataId: hasGroupBy
+              ? widgetViewDraft.view.mainGroupByFieldMetadataId
+              : defaultGroupByFieldMetadataItem?.id,
           },
+          viewGroups:
+            hasGroupBy || !isDefined(defaultGroupByFieldMetadataItem)
+              ? widgetViewDraft.viewGroups
+              : buildDraftViewGroupsForFieldMetadataItem({
+                  viewId: widgetViewDraft.view.id,
+                  fieldMetadataItem: defaultGroupByFieldMetadataItem,
+                }),
         };
       }
 
@@ -109,84 +117,56 @@ export const useRecordTableWidgetLayoutCallbacks = ({
         );
 
         if (!hasCalendarField && !isDefined(defaultCalendarFieldMetadataItem)) {
-          return prev;
+          return widgetViewDraft;
         }
 
         return {
-          ...prev,
-          [widgetId]: {
-            ...widgetViewDraft,
-            view: {
-              ...widgetViewDraft.view,
-              type: targetViewType,
-              // Widget calendars are month-only for now, so switching to
-              // the calendar layout always normalizes to MONTH.
-              calendarLayout: ViewCalendarLayout.MONTH,
-              calendarFieldMetadataId: hasCalendarField
-                ? widgetViewDraft.view.calendarFieldMetadataId
-                : defaultCalendarFieldMetadataItem?.id,
-            },
+          ...widgetViewDraft,
+          view: {
+            ...widgetViewDraft.view,
+            type: targetViewType,
+            // Widget calendars are month-only for now, so switching to
+            // the calendar layout always normalizes to MONTH.
+            calendarLayout: ViewCalendarLayout.MONTH,
+            calendarFieldMetadataId: hasCalendarField
+              ? widgetViewDraft.view.calendarFieldMetadataId
+              : defaultCalendarFieldMetadataItem?.id,
           },
         };
       }
 
       return {
-        ...prev,
-        [widgetId]: {
-          ...widgetViewDraft,
-          view: {
-            ...widgetViewDraft.view,
-            type: targetViewType,
-          },
+        ...widgetViewDraft,
+        view: {
+          ...widgetViewDraft.view,
+          type: targetViewType,
         },
       };
     });
   };
 
   const handleCalendarFieldChange = (fieldMetadataItem: FieldMetadataItem) => {
-    store.set(recordTableWidgetViewDraftState, (prev) => {
-      const widgetViewDraft = prev[widgetId];
-
-      if (!isDefined(widgetViewDraft)) {
-        return prev;
-      }
-
-      return {
-        ...prev,
-        [widgetId]: {
-          ...widgetViewDraft,
-          view: {
-            ...widgetViewDraft.view,
-            calendarFieldMetadataId: fieldMetadataItem.id,
-            calendarLayout:
-              widgetViewDraft.view.calendarLayout ?? ViewCalendarLayout.MONTH,
-          },
-        },
-      };
-    });
+    setWidgetViewDraft((widgetViewDraft) => ({
+      ...widgetViewDraft,
+      view: {
+        ...widgetViewDraft.view,
+        calendarFieldMetadataId: fieldMetadataItem.id,
+        calendarLayout:
+          widgetViewDraft.view.calendarLayout ?? ViewCalendarLayout.MONTH,
+      },
+    }));
   };
 
   const handleShouldHideEmptyGroupsChange = (
     shouldHideEmptyGroups: boolean,
   ) => {
-    store.set(recordTableWidgetViewDraftState, (prev) => {
-      const widgetViewDraft = prev[widgetId];
-
-      if (!isDefined(widgetViewDraft)) {
-        return prev;
-      }
-
-      return {
-        ...prev,
-        [widgetId]: {
-          ...widgetViewDraft,
-          view: {
-            ...widgetViewDraft.view,
-            shouldHideEmptyGroups,
-          },
-        },
-      };
-    });
+    setWidgetViewDraft((widgetViewDraft) => ({
+      ...widgetViewDraft,
+      view: {
+        ...widgetViewDraft.view,
+        shouldHideEmptyGroups,
+      },
+    }));
   };
 
   return {

--- a/packages/twenty-front/src/modules/page-layout/widgets/record-table/hooks/useRecordTableWidgetLayoutCallbacks.ts
+++ b/packages/twenty-front/src/modules/page-layout/widgets/record-table/hooks/useRecordTableWidgetLayoutCallbacks.ts
@@ -119,8 +119,9 @@ export const useRecordTableWidgetLayoutCallbacks = ({
             view: {
               ...widgetViewDraft.view,
               type: targetViewType,
-              calendarLayout:
-                widgetViewDraft.view.calendarLayout ?? ViewCalendarLayout.MONTH,
+              // Widget calendars are month-only for now, so switching to
+              // the calendar layout always normalizes to MONTH.
+              calendarLayout: ViewCalendarLayout.MONTH,
               calendarFieldMetadataId: hasCalendarField
                 ? widgetViewDraft.view.calendarFieldMetadataId
                 : defaultCalendarFieldMetadataItem?.id,

--- a/packages/twenty-front/src/modules/page-layout/widgets/record-table/utils/isFieldMetadataItemAvailableAsWidgetCalendarField.ts
+++ b/packages/twenty-front/src/modules/page-layout/widgets/record-table/utils/isFieldMetadataItemAvailableAsWidgetCalendarField.ts
@@ -1,0 +1,19 @@
+import { type FieldMetadataItem } from '@/object-metadata/types/FieldMetadataItem';
+import {
+  isFieldMetadataDateKind,
+  isFieldMetadataSupportedInGroupBy,
+} from 'twenty-shared/utils';
+
+// Mirrors useGetAvailableFieldsForCalendar so widget calendar settings
+// offer the same date fields as the record index calendar view picker
+// (excluding system fields like deletedAt).
+export const isFieldMetadataItemAvailableAsWidgetCalendarField = (
+  fieldMetadataItem: FieldMetadataItem,
+) =>
+  fieldMetadataItem.isActive === true &&
+  isFieldMetadataDateKind(fieldMetadataItem.type) &&
+  isFieldMetadataSupportedInGroupBy({
+    type: fieldMetadataItem.type,
+    name: fieldMetadataItem.name,
+    isSystem: fieldMetadataItem.isSystem ?? false,
+  });

--- a/packages/twenty-front/src/modules/page-layout/widgets/record-table/utils/isFieldMetadataItemAvailableAsWidgetGroupByField.ts
+++ b/packages/twenty-front/src/modules/page-layout/widgets/record-table/utils/isFieldMetadataItemAvailableAsWidgetGroupByField.ts
@@ -1,0 +1,13 @@
+import { type FieldMetadataItem } from '@/object-metadata/types/FieldMetadataItem';
+import { canGroupRecordsByFieldMetadataItem } from '@/object-record/record-group/utils/canGroupRecordsByFieldMetadataItem';
+import { FieldMetadataType } from 'twenty-shared/types';
+
+// Widgets only offer select-field grouping: the server auto-generates
+// view groups from select options, and widgets have no per-record
+// add-group flow like the record index page.
+export const isFieldMetadataItemAvailableAsWidgetGroupByField = (
+  fieldMetadataItem: FieldMetadataItem,
+) =>
+  fieldMetadataItem.isActive === true &&
+  fieldMetadataItem.type === FieldMetadataType.SELECT &&
+  canGroupRecordsByFieldMetadataItem(fieldMetadataItem);

--- a/packages/twenty-front/src/modules/side-panel/pages/page-layout/components/dashboard/SidePanelDashboardRecordTableSettings.tsx
+++ b/packages/twenty-front/src/modules/side-panel/pages/page-layout/components/dashboard/SidePanelDashboardRecordTableSettings.tsx
@@ -13,6 +13,7 @@ import { useSidePanelSubPageHistory } from '@/side-panel/hooks/useSidePanelSubPa
 import { RecordTableDataSourceDropdownContent } from '@/side-panel/pages/page-layout/components/record-table-settings/RecordTableDataSourceDropdownContent';
 import { RecordTableFieldsDropdownContent } from '@/side-panel/pages/page-layout/components/record-table-settings/RecordTableFieldsDropdownContent';
 import { RecordTableGroupByDropdownContent } from '@/side-panel/pages/page-layout/components/record-table-settings/RecordTableGroupByDropdownContent';
+import { RecordTableCalendarFieldDropdownContent } from '@/side-panel/pages/page-layout/components/record-table-settings/RecordTableCalendarFieldDropdownContent';
 import { RecordTableLayoutDropdownContent } from '@/side-panel/pages/page-layout/components/record-table-settings/RecordTableLayoutDropdownContent';
 import { WidgetSettingsFooter } from '@/side-panel/pages/page-layout/components/WidgetSettingsFooter';
 import { usePageLayoutIdFromContextStore } from '@/side-panel/pages/page-layout/hooks/usePageLayoutIdFromContextStore';
@@ -29,6 +30,8 @@ import {
   IconArrowBarToDownDashed,
   IconArrowsSort,
   IconBox,
+  IconCalendar,
+  IconCalendarEvent,
   IconEyeOff,
   IconFilter,
   IconLayoutKanban,
@@ -125,9 +128,14 @@ export const SidePanelDashboardRecordTableSettings = () => {
   const shouldHideEmptyGroups = widgetView?.shouldHideEmptyGroups ?? false;
 
   const isKanbanLayout = widgetView?.type === ViewType.KANBAN_WIDGET;
+  const isCalendarLayout = widgetView?.type === ViewType.CALENDAR_WIDGET;
   const currentLayoutViewType = isKanbanLayout
     ? ViewType.KANBAN_WIDGET
-    : ViewType.TABLE_WIDGET;
+    : isCalendarLayout
+      ? ViewType.CALENDAR_WIDGET
+      : ViewType.TABLE_WIDGET;
+
+  const calendarFieldMetadataId = widgetView?.calendarFieldMetadataId ?? null;
 
   const { objectMetadataItems } = useObjectMetadataItems();
   const objectMetadataItem = objectMetadataItems.find(
@@ -139,6 +147,12 @@ export const SidePanelDashboardRecordTableSettings = () => {
     ? (objectMetadataItem?.fields.find(
         (fieldMetadataItem) =>
           fieldMetadataItem.id === mainGroupByFieldMetadataId,
+      )?.label ?? t`None`)
+    : t`None`;
+
+  const calendarFieldLabel = isDefined(calendarFieldMetadataId)
+    ? (objectMetadataItem?.fields.find(
+        (fieldMetadataItem) => fieldMetadataItem.id === calendarFieldMetadataId,
       )?.label ?? t`None`)
     : t`None`;
 
@@ -156,9 +170,13 @@ export const SidePanelDashboardRecordTableSettings = () => {
           'record-table-fields',
           'record-table-filter',
           'record-table-sort',
-          'record-table-group-by',
-          ...(hasGroupBy ? ['record-table-hide-empty-groups'] : []),
-          ...(hasGroupBy ? [] : ['record-table-limit']),
+          ...(isCalendarLayout
+            ? ['record-table-calendar-field']
+            : ['record-table-group-by']),
+          ...(!isCalendarLayout && hasGroupBy
+            ? ['record-table-hide-empty-groups']
+            : []),
+          ...(!isCalendarLayout && !hasGroupBy ? ['record-table-limit'] : []),
         ]
       : []),
   ];
@@ -181,7 +199,13 @@ export const SidePanelDashboardRecordTableSettings = () => {
             <SidePanelGroup heading={t`Settings`}>
               <SelectableListItem itemId="object-view-layout">
                 <CommandMenuItemDropdown
-                  Icon={isKanbanLayout ? IconLayoutKanban : IconTable}
+                  Icon={
+                    isKanbanLayout
+                      ? IconLayoutKanban
+                      : isCalendarLayout
+                        ? IconCalendar
+                        : IconTable
+                  }
                   label={t`Layout`}
                   id="object-view-layout"
                   dropdownId="object-view-layout"
@@ -201,7 +225,13 @@ export const SidePanelDashboardRecordTableSettings = () => {
                   }
                   dropdownPlacement="bottom-end"
                   hasSubMenu={hasViewId}
-                  description={isKanbanLayout ? t`Kanban` : t`Table`}
+                  description={
+                    isKanbanLayout
+                      ? t`Kanban`
+                      : isCalendarLayout
+                        ? t`Calendar`
+                        : t`Table`
+                  }
                   disabled={!hasViewId}
                   contextualTextPosition="right"
                 />
@@ -273,34 +303,64 @@ export const SidePanelDashboardRecordTableSettings = () => {
                       contextualTextPosition="right"
                     />
                   </SelectableListItem>
-                  <SelectableListItem itemId="record-table-group-by">
-                    <CommandMenuItemDropdown
-                      Icon={IconLayoutList}
-                      label={t`Group by`}
-                      id="record-table-group-by"
-                      dropdownId="record-table-group-by"
-                      dropdownComponents={
-                        <DropdownContent>
-                          <RecordTableGroupByDropdownContent
-                            pageLayoutId={pageLayoutId}
-                            widgetId={widgetInEditMode.id}
-                            objectMetadataId={
-                              widgetInEditMode.objectMetadataId!
-                            }
-                            currentMainGroupByFieldMetadataId={
-                              mainGroupByFieldMetadataId
-                            }
-                            isClearable={!isKanbanLayout}
-                          />
-                        </DropdownContent>
-                      }
-                      dropdownPlacement="bottom-end"
-                      hasSubMenu
-                      description={mainGroupByFieldLabel}
-                      contextualTextPosition="right"
-                    />
-                  </SelectableListItem>
-                  {hasGroupBy && (
+                  {isCalendarLayout && (
+                    <SelectableListItem itemId="record-table-calendar-field">
+                      <CommandMenuItemDropdown
+                        Icon={IconCalendarEvent}
+                        label={t`Date field`}
+                        id="record-table-calendar-field"
+                        dropdownId="record-table-calendar-field"
+                        dropdownComponents={
+                          <DropdownContent>
+                            <RecordTableCalendarFieldDropdownContent
+                              pageLayoutId={pageLayoutId}
+                              widgetId={widgetInEditMode.id}
+                              objectMetadataId={
+                                widgetInEditMode.objectMetadataId!
+                              }
+                              currentCalendarFieldMetadataId={
+                                calendarFieldMetadataId
+                              }
+                            />
+                          </DropdownContent>
+                        }
+                        dropdownPlacement="bottom-end"
+                        hasSubMenu
+                        description={calendarFieldLabel}
+                        contextualTextPosition="right"
+                      />
+                    </SelectableListItem>
+                  )}
+                  {!isCalendarLayout && (
+                    <SelectableListItem itemId="record-table-group-by">
+                      <CommandMenuItemDropdown
+                        Icon={IconLayoutList}
+                        label={t`Group by`}
+                        id="record-table-group-by"
+                        dropdownId="record-table-group-by"
+                        dropdownComponents={
+                          <DropdownContent>
+                            <RecordTableGroupByDropdownContent
+                              pageLayoutId={pageLayoutId}
+                              widgetId={widgetInEditMode.id}
+                              objectMetadataId={
+                                widgetInEditMode.objectMetadataId!
+                              }
+                              currentMainGroupByFieldMetadataId={
+                                mainGroupByFieldMetadataId
+                              }
+                              isClearable={!isKanbanLayout}
+                            />
+                          </DropdownContent>
+                        }
+                        dropdownPlacement="bottom-end"
+                        hasSubMenu
+                        description={mainGroupByFieldLabel}
+                        contextualTextPosition="right"
+                      />
+                    </SelectableListItem>
+                  )}
+                  {!isCalendarLayout && hasGroupBy && (
                     <SelectableListItem itemId="record-table-hide-empty-groups">
                       <CommandMenuItemToggle
                         LeftIcon={IconEyeOff}
@@ -311,7 +371,7 @@ export const SidePanelDashboardRecordTableSettings = () => {
                       />
                     </SelectableListItem>
                   )}
-                  {!hasGroupBy && (
+                  {!isCalendarLayout && !hasGroupBy && (
                     <SelectableListItem itemId="record-table-limit">
                       <CommandMenuItemNumberInput
                         id="record-table-limit"

--- a/packages/twenty-front/src/modules/side-panel/pages/page-layout/components/record-table-settings/RecordTableCalendarFieldDropdownContent.tsx
+++ b/packages/twenty-front/src/modules/side-panel/pages/page-layout/components/record-table-settings/RecordTableCalendarFieldDropdownContent.tsx
@@ -1,5 +1,6 @@
 import { useObjectMetadataItems } from '@/object-metadata/hooks/useObjectMetadataItems';
 import { useRecordTableWidgetLayoutCallbacks } from '@/page-layout/widgets/record-table/hooks/useRecordTableWidgetLayoutCallbacks';
+import { isFieldMetadataItemAvailableAsWidgetCalendarField } from '@/page-layout/widgets/record-table/utils/isFieldMetadataItemAvailableAsWidgetCalendarField';
 import { DropdownMenuItemsContainer } from '@/ui/layout/dropdown/components/DropdownMenuItemsContainer';
 import { DropdownComponentInstanceContext } from '@/ui/layout/dropdown/contexts/DropdownComponentInstanceContext';
 import { useCloseDropdown } from '@/ui/layout/dropdown/hooks/useCloseDropdown';
@@ -8,7 +9,6 @@ import { SelectableListItem } from '@/ui/layout/selectable-list/components/Selec
 import { selectedItemIdComponentState } from '@/ui/layout/selectable-list/states/selectedItemIdComponentState';
 import { useAvailableComponentInstanceIdOrThrow } from '@/ui/utilities/state/component-state/hooks/useAvailableComponentInstanceIdOrThrow';
 import { useAtomComponentStateValue } from '@/ui/utilities/state/jotai/hooks/useAtomComponentStateValue';
-import { FieldMetadataType } from 'twenty-shared/types';
 import { useIcons } from 'twenty-ui/icon';
 import { MenuItemSelect } from 'twenty-ui/navigation';
 
@@ -50,10 +50,7 @@ export const RecordTableCalendarFieldDropdownContent = ({
   });
 
   const dateFields = (objectMetadataItem?.readableFields ?? []).filter(
-    (fieldMetadataItem) =>
-      fieldMetadataItem.isActive === true &&
-      (fieldMetadataItem.type === FieldMetadataType.DATE ||
-        fieldMetadataItem.type === FieldMetadataType.DATE_TIME),
+    isFieldMetadataItemAvailableAsWidgetCalendarField,
   );
 
   return (

--- a/packages/twenty-front/src/modules/side-panel/pages/page-layout/components/record-table-settings/RecordTableCalendarFieldDropdownContent.tsx
+++ b/packages/twenty-front/src/modules/side-panel/pages/page-layout/components/record-table-settings/RecordTableCalendarFieldDropdownContent.tsx
@@ -1,6 +1,6 @@
 import { useObjectMetadataItems } from '@/object-metadata/hooks/useObjectMetadataItems';
 import { useRecordTableWidgetLayoutCallbacks } from '@/page-layout/widgets/record-table/hooks/useRecordTableWidgetLayoutCallbacks';
-import { isFieldMetadataItemAvailableAsWidgetCalendarField } from '@/page-layout/widgets/record-table/utils/isFieldMetadataItemAvailableAsWidgetCalendarField';
+import { isFieldMetadataItemAvailableAsCalendarField } from '@/object-record/record-calendar/utils/isFieldMetadataItemAvailableAsCalendarField';
 import { DropdownMenuItemsContainer } from '@/ui/layout/dropdown/components/DropdownMenuItemsContainer';
 import { DropdownComponentInstanceContext } from '@/ui/layout/dropdown/contexts/DropdownComponentInstanceContext';
 import { useCloseDropdown } from '@/ui/layout/dropdown/hooks/useCloseDropdown';
@@ -50,7 +50,7 @@ export const RecordTableCalendarFieldDropdownContent = ({
   });
 
   const dateFields = (objectMetadataItem?.readableFields ?? []).filter(
-    isFieldMetadataItemAvailableAsWidgetCalendarField,
+    isFieldMetadataItemAvailableAsCalendarField,
   );
 
   return (

--- a/packages/twenty-front/src/modules/side-panel/pages/page-layout/components/record-table-settings/RecordTableCalendarFieldDropdownContent.tsx
+++ b/packages/twenty-front/src/modules/side-panel/pages/page-layout/components/record-table-settings/RecordTableCalendarFieldDropdownContent.tsx
@@ -1,0 +1,92 @@
+import { useObjectMetadataItems } from '@/object-metadata/hooks/useObjectMetadataItems';
+import { useRecordTableWidgetLayoutCallbacks } from '@/page-layout/widgets/record-table/hooks/useRecordTableWidgetLayoutCallbacks';
+import { DropdownMenuItemsContainer } from '@/ui/layout/dropdown/components/DropdownMenuItemsContainer';
+import { DropdownComponentInstanceContext } from '@/ui/layout/dropdown/contexts/DropdownComponentInstanceContext';
+import { useCloseDropdown } from '@/ui/layout/dropdown/hooks/useCloseDropdown';
+import { SelectableList } from '@/ui/layout/selectable-list/components/SelectableList';
+import { SelectableListItem } from '@/ui/layout/selectable-list/components/SelectableListItem';
+import { selectedItemIdComponentState } from '@/ui/layout/selectable-list/states/selectedItemIdComponentState';
+import { useAvailableComponentInstanceIdOrThrow } from '@/ui/utilities/state/component-state/hooks/useAvailableComponentInstanceIdOrThrow';
+import { useAtomComponentStateValue } from '@/ui/utilities/state/jotai/hooks/useAtomComponentStateValue';
+import { FieldMetadataType } from 'twenty-shared/types';
+import { useIcons } from 'twenty-ui/icon';
+import { MenuItemSelect } from 'twenty-ui/navigation';
+
+type RecordTableCalendarFieldDropdownContentProps = {
+  pageLayoutId: string;
+  widgetId: string;
+  objectMetadataId: string;
+  currentCalendarFieldMetadataId: string | null;
+};
+
+export const RecordTableCalendarFieldDropdownContent = ({
+  pageLayoutId,
+  widgetId,
+  objectMetadataId,
+  currentCalendarFieldMetadataId,
+}: RecordTableCalendarFieldDropdownContentProps) => {
+  const { getIcon } = useIcons();
+
+  const { objectMetadataItems } = useObjectMetadataItems();
+  const objectMetadataItem = objectMetadataItems.find(
+    (objectMetadataItemToFind) =>
+      objectMetadataItemToFind.id === objectMetadataId,
+  );
+
+  const dropdownId = useAvailableComponentInstanceIdOrThrow(
+    DropdownComponentInstanceContext,
+  );
+
+  const selectedItemId = useAtomComponentStateValue(
+    selectedItemIdComponentState,
+    dropdownId,
+  );
+
+  const { closeDropdown } = useCloseDropdown();
+
+  const { handleCalendarFieldChange } = useRecordTableWidgetLayoutCallbacks({
+    pageLayoutId,
+    widgetId,
+  });
+
+  const dateFields = (objectMetadataItem?.readableFields ?? []).filter(
+    (fieldMetadataItem) =>
+      fieldMetadataItem.isActive === true &&
+      (fieldMetadataItem.type === FieldMetadataType.DATE ||
+        fieldMetadataItem.type === FieldMetadataType.DATE_TIME),
+  );
+
+  return (
+    <DropdownMenuItemsContainer hasMaxHeight>
+      <SelectableList
+        selectableListInstanceId={dropdownId}
+        selectableItemIdArray={dateFields.map(
+          (fieldMetadataItem) => fieldMetadataItem.id,
+        )}
+        focusId={dropdownId}
+      >
+        {dateFields.map((fieldMetadataItem) => (
+          <SelectableListItem
+            key={fieldMetadataItem.id}
+            itemId={fieldMetadataItem.id}
+            onEnter={() => {
+              handleCalendarFieldChange(fieldMetadataItem);
+              closeDropdown();
+            }}
+          >
+            <MenuItemSelect
+              text={fieldMetadataItem.label}
+              LeftIcon={getIcon(fieldMetadataItem.icon)}
+              selected={currentCalendarFieldMetadataId === fieldMetadataItem.id}
+              focused={selectedItemId === fieldMetadataItem.id}
+              onClick={() => {
+                handleCalendarFieldChange(fieldMetadataItem);
+                closeDropdown();
+              }}
+            />
+          </SelectableListItem>
+        ))}
+      </SelectableList>
+    </DropdownMenuItemsContainer>
+  );
+};

--- a/packages/twenty-front/src/modules/side-panel/pages/page-layout/components/record-table-settings/RecordTableGroupByDropdownContent.tsx
+++ b/packages/twenty-front/src/modules/side-panel/pages/page-layout/components/record-table-settings/RecordTableGroupByDropdownContent.tsx
@@ -1,6 +1,6 @@
 import { useObjectMetadataItems } from '@/object-metadata/hooks/useObjectMetadataItems';
-import { canGroupRecordsByFieldMetadataItem } from '@/object-record/record-group/utils/canGroupRecordsByFieldMetadataItem';
 import { useRecordTableWidgetLayoutCallbacks } from '@/page-layout/widgets/record-table/hooks/useRecordTableWidgetLayoutCallbacks';
+import { isFieldMetadataItemAvailableAsWidgetGroupByField } from '@/page-layout/widgets/record-table/utils/isFieldMetadataItemAvailableAsWidgetGroupByField';
 import { DropdownMenuItemsContainer } from '@/ui/layout/dropdown/components/DropdownMenuItemsContainer';
 import { DropdownMenuSearchInput } from '@/ui/layout/dropdown/components/DropdownMenuSearchInput';
 import { DropdownMenuSeparator } from '@/ui/layout/dropdown/components/DropdownMenuSeparator';
@@ -13,7 +13,6 @@ import { useAvailableComponentInstanceIdOrThrow } from '@/ui/utilities/state/com
 import { useAtomComponentStateValue } from '@/ui/utilities/state/jotai/hooks/useAtomComponentStateValue';
 import { t } from '@lingui/core/macro';
 import { useState } from 'react';
-import { FieldMetadataType } from 'twenty-shared/types';
 import { isDefined } from 'twenty-shared/utils';
 import { useIcons } from 'twenty-ui/icon';
 import { MenuItemSelect } from 'twenty-ui/navigation';
@@ -61,14 +60,8 @@ export const RecordTableGroupByDropdownContent = ({
     widgetId,
   });
 
-  // Relation group-by is not offered on widgets for now: the server only
-  // auto-generates view groups from select options, and widgets have no
-  // add-group-per-record flow like the record index page.
   const groupableFields = (objectMetadataItem?.readableFields ?? []).filter(
-    (fieldMetadataItem) =>
-      fieldMetadataItem.isActive === true &&
-      fieldMetadataItem.type === FieldMetadataType.SELECT &&
-      canGroupRecordsByFieldMetadataItem(fieldMetadataItem),
+    isFieldMetadataItemAvailableAsWidgetGroupByField,
   );
 
   const filteredFields = filterBySearchQuery({

--- a/packages/twenty-front/src/modules/side-panel/pages/page-layout/components/record-table-settings/RecordTableLayoutDropdownContent.tsx
+++ b/packages/twenty-front/src/modules/side-panel/pages/page-layout/components/record-table-settings/RecordTableLayoutDropdownContent.tsx
@@ -15,7 +15,7 @@ import { useAtomComponentStateValue } from '@/ui/utilities/state/jotai/hooks/use
 import { t } from '@lingui/core/macro';
 import { FieldMetadataType } from 'twenty-shared/types';
 import { isDefined } from 'twenty-shared/utils';
-import { IconLayoutKanban, IconTable } from 'twenty-ui/icon';
+import { IconCalendar, IconLayoutKanban, IconTable } from 'twenty-ui/icon';
 import { MenuItemSelect } from 'twenty-ui/navigation';
 import { ViewType } from '~/generated-metadata/graphql';
 
@@ -62,7 +62,16 @@ export const RecordTableLayoutDropdownContent = ({
         canGroupRecordsByFieldMetadataItem(fieldMetadataItem),
     ) ?? null;
 
+  const defaultCalendarFieldMetadataItem =
+    (objectMetadataItem?.readableFields ?? []).find(
+      (fieldMetadataItem) =>
+        fieldMetadataItem.isActive === true &&
+        (fieldMetadataItem.type === FieldMetadataType.DATE ||
+          fieldMetadataItem.type === FieldMetadataType.DATE_TIME),
+    ) ?? null;
+
   const isKanbanAvailable = isDefined(defaultGroupByFieldMetadataItem);
+  const isCalendarAvailable = isDefined(defaultCalendarFieldMetadataItem);
 
   const handleSelectLayout = (
     targetViewType: RecordTableWidgetLayoutViewType,
@@ -70,6 +79,7 @@ export const RecordTableLayoutDropdownContent = ({
     handleLayoutChange({
       targetViewType,
       defaultGroupByFieldMetadataItem,
+      defaultCalendarFieldMetadataItem,
     });
     closeDropdown();
   };
@@ -81,6 +91,7 @@ export const RecordTableLayoutDropdownContent = ({
         selectableItemIdArray={[
           ViewType.TABLE_WIDGET,
           ...(isKanbanAvailable ? [ViewType.KANBAN_WIDGET] : []),
+          ...(isCalendarAvailable ? [ViewType.CALENDAR_WIDGET] : []),
         ]}
         focusId={dropdownId}
       >
@@ -107,6 +118,20 @@ export const RecordTableLayoutDropdownContent = ({
               selected={currentLayoutViewType === ViewType.KANBAN_WIDGET}
               focused={selectedItemId === ViewType.KANBAN_WIDGET}
               onClick={() => handleSelectLayout(ViewType.KANBAN_WIDGET)}
+            />
+          </SelectableListItem>
+        )}
+        {isCalendarAvailable && (
+          <SelectableListItem
+            itemId={ViewType.CALENDAR_WIDGET}
+            onEnter={() => handleSelectLayout(ViewType.CALENDAR_WIDGET)}
+          >
+            <MenuItemSelect
+              text={t`Calendar`}
+              LeftIcon={IconCalendar}
+              selected={currentLayoutViewType === ViewType.CALENDAR_WIDGET}
+              focused={selectedItemId === ViewType.CALENDAR_WIDGET}
+              onClick={() => handleSelectLayout(ViewType.CALENDAR_WIDGET)}
             />
           </SelectableListItem>
         )}

--- a/packages/twenty-front/src/modules/side-panel/pages/page-layout/components/record-table-settings/RecordTableLayoutDropdownContent.tsx
+++ b/packages/twenty-front/src/modules/side-panel/pages/page-layout/components/record-table-settings/RecordTableLayoutDropdownContent.tsx
@@ -4,6 +4,7 @@ import {
   type RecordTableWidgetLayoutViewType,
   useRecordTableWidgetLayoutCallbacks,
 } from '@/page-layout/widgets/record-table/hooks/useRecordTableWidgetLayoutCallbacks';
+import { isFieldMetadataItemAvailableAsWidgetCalendarField } from '@/page-layout/widgets/record-table/utils/isFieldMetadataItemAvailableAsWidgetCalendarField';
 import { DropdownMenuItemsContainer } from '@/ui/layout/dropdown/components/DropdownMenuItemsContainer';
 import { useCloseDropdown } from '@/ui/layout/dropdown/hooks/useCloseDropdown';
 import { SelectableList } from '@/ui/layout/selectable-list/components/SelectableList';
@@ -64,10 +65,7 @@ export const RecordTableLayoutDropdownContent = ({
 
   const defaultCalendarFieldMetadataItem =
     (objectMetadataItem?.readableFields ?? []).find(
-      (fieldMetadataItem) =>
-        fieldMetadataItem.isActive === true &&
-        (fieldMetadataItem.type === FieldMetadataType.DATE ||
-          fieldMetadataItem.type === FieldMetadataType.DATE_TIME),
+      isFieldMetadataItemAvailableAsWidgetCalendarField,
     ) ?? null;
 
   const isKanbanAvailable = isDefined(defaultGroupByFieldMetadataItem);

--- a/packages/twenty-front/src/modules/side-panel/pages/page-layout/components/record-table-settings/RecordTableLayoutDropdownContent.tsx
+++ b/packages/twenty-front/src/modules/side-panel/pages/page-layout/components/record-table-settings/RecordTableLayoutDropdownContent.tsx
@@ -1,10 +1,10 @@
 import { useObjectMetadataItems } from '@/object-metadata/hooks/useObjectMetadataItems';
-import { canGroupRecordsByFieldMetadataItem } from '@/object-record/record-group/utils/canGroupRecordsByFieldMetadataItem';
+import { isFieldMetadataItemAvailableAsCalendarField } from '@/object-record/record-calendar/utils/isFieldMetadataItemAvailableAsCalendarField';
 import {
   type RecordTableWidgetLayoutViewType,
   useRecordTableWidgetLayoutCallbacks,
 } from '@/page-layout/widgets/record-table/hooks/useRecordTableWidgetLayoutCallbacks';
-import { isFieldMetadataItemAvailableAsCalendarField } from '@/object-record/record-calendar/utils/isFieldMetadataItemAvailableAsCalendarField';
+import { isFieldMetadataItemAvailableAsWidgetGroupByField } from '@/page-layout/widgets/record-table/utils/isFieldMetadataItemAvailableAsWidgetGroupByField';
 import { DropdownMenuItemsContainer } from '@/ui/layout/dropdown/components/DropdownMenuItemsContainer';
 import { useCloseDropdown } from '@/ui/layout/dropdown/hooks/useCloseDropdown';
 import { SelectableList } from '@/ui/layout/selectable-list/components/SelectableList';
@@ -14,7 +14,6 @@ import { DropdownComponentInstanceContext } from '@/ui/layout/dropdown/contexts/
 import { useAvailableComponentInstanceIdOrThrow } from '@/ui/utilities/state/component-state/hooks/useAvailableComponentInstanceIdOrThrow';
 import { useAtomComponentStateValue } from '@/ui/utilities/state/jotai/hooks/useAtomComponentStateValue';
 import { t } from '@lingui/core/macro';
-import { FieldMetadataType } from 'twenty-shared/types';
 import { isDefined } from 'twenty-shared/utils';
 import { IconCalendar, IconLayoutKanban, IconTable } from 'twenty-ui/icon';
 import { MenuItemSelect } from 'twenty-ui/navigation';
@@ -57,10 +56,7 @@ export const RecordTableLayoutDropdownContent = ({
 
   const defaultGroupByFieldMetadataItem =
     (objectMetadataItem?.readableFields ?? []).find(
-      (fieldMetadataItem) =>
-        fieldMetadataItem.isActive === true &&
-        fieldMetadataItem.type === FieldMetadataType.SELECT &&
-        canGroupRecordsByFieldMetadataItem(fieldMetadataItem),
+      isFieldMetadataItemAvailableAsWidgetGroupByField,
     ) ?? null;
 
   const defaultCalendarFieldMetadataItem =

--- a/packages/twenty-front/src/modules/side-panel/pages/page-layout/components/record-table-settings/RecordTableLayoutDropdownContent.tsx
+++ b/packages/twenty-front/src/modules/side-panel/pages/page-layout/components/record-table-settings/RecordTableLayoutDropdownContent.tsx
@@ -4,7 +4,7 @@ import {
   type RecordTableWidgetLayoutViewType,
   useRecordTableWidgetLayoutCallbacks,
 } from '@/page-layout/widgets/record-table/hooks/useRecordTableWidgetLayoutCallbacks';
-import { isFieldMetadataItemAvailableAsWidgetCalendarField } from '@/page-layout/widgets/record-table/utils/isFieldMetadataItemAvailableAsWidgetCalendarField';
+import { isFieldMetadataItemAvailableAsCalendarField } from '@/object-record/record-calendar/utils/isFieldMetadataItemAvailableAsCalendarField';
 import { DropdownMenuItemsContainer } from '@/ui/layout/dropdown/components/DropdownMenuItemsContainer';
 import { useCloseDropdown } from '@/ui/layout/dropdown/hooks/useCloseDropdown';
 import { SelectableList } from '@/ui/layout/selectable-list/components/SelectableList';
@@ -65,7 +65,7 @@ export const RecordTableLayoutDropdownContent = ({
 
   const defaultCalendarFieldMetadataItem =
     (objectMetadataItem?.readableFields ?? []).find(
-      isFieldMetadataItemAvailableAsWidgetCalendarField,
+      isFieldMetadataItemAvailableAsCalendarField,
     ) ?? null;
 
   const isKanbanAvailable = isDefined(defaultGroupByFieldMetadataItem);

--- a/packages/twenty-front/src/modules/views/view-picker/hooks/useGetAvailableFieldsForCalendar.ts
+++ b/packages/twenty-front/src/modules/views/view-picker/hooks/useGetAvailableFieldsForCalendar.ts
@@ -2,17 +2,14 @@ import { useCallback } from 'react';
 import { useLocation } from 'react-router-dom';
 
 import { objectMetadataItemsSelector } from '@/object-metadata/states/objectMetadataItemsSelector';
+import { isFieldMetadataItemAvailableAsCalendarField } from '@/object-record/record-calendar/utils/isFieldMetadataItemAvailableAsCalendarField';
 import { navigationMemorizedUrlState } from '@/ui/navigation/states/navigationMemorizedUrlState';
 import { useSetAtomState } from '@/ui/utilities/state/jotai/hooks/useSetAtomState';
 import { useAtomComponentStateValue } from '@/ui/utilities/state/jotai/hooks/useAtomComponentStateValue';
 import { useAtomStateValue } from '@/ui/utilities/state/jotai/hooks/useAtomStateValue';
 import { viewObjectMetadataIdComponentState } from '@/views/states/viewObjectMetadataIdComponentState';
 import { FieldMetadataType, SettingsPath } from 'twenty-shared/types';
-import {
-  isDefined,
-  isFieldMetadataDateKind,
-  isFieldMetadataSupportedInGroupBy,
-} from 'twenty-shared/utils';
+import { isDefined } from 'twenty-shared/utils';
 import { useNavigateSettings } from '~/hooks/useNavigateSettings';
 
 export const useGetAvailableFieldsForCalendar = () => {
@@ -31,13 +28,7 @@ export const useGetAvailableFieldsForCalendar = () => {
 
   const availableFieldsForCalendar =
     objectMetadataItem?.readableFields.filter(
-      (field) =>
-        isFieldMetadataDateKind(field.type) &&
-        isFieldMetadataSupportedInGroupBy({
-          type: field.type,
-          name: field.name,
-          isSystem: field.isSystem ?? false,
-        }),
+      isFieldMetadataItemAvailableAsCalendarField,
     ) ?? [];
 
   const navigate = useNavigateSettings();


### PR DESCRIPTION
# Calendar layout for dashboard view widgets (4/4)

Part 4 of the dashboard view-layouts stack ([#22963](https://github.com/twentyhq/twenty/pull/22963) → [#22966](https://github.com/twentyhq/twenty/pull/22966) → [#22967](https://github.com/twentyhq/twenty/pull/22967) → this).

Dashboards can now render **Calendar** view widgets: pick a View widget, set Layout → Calendar, choose the date field, save. The widget shows a read-only month calendar of the source object, backed by a real `CALENDAR_WIDGET` view (server support shipped in #22963).

## What this does

- **Calendar widget rendering** — `RecordTableWidgetRendererContent` now branches to a new `RecordCalendarWidget` when the backing view&#39;s layout resolves to Calendar (`getViewLayoutFromViewType`). The widget mounts the existing `RecordCalendar` month grid inside the per-widget component-instance sandbox, with SSE subscribe / data loader / selected-date init effects.
- **Settings panel** — the Layout dropdown gains a *Calendar* option (offered when the source object has at least one `DATE`/`DATE_TIME` field). Selecting it defaults the draft view to `MONTH` layout + the first date field. A new *Date field* row replaces *Group by* while the calendar layout is active.
- **Read-only in widgets** — new `isRecordCalendarReadOnlyComponentState` disables card dragging, hides the per-day add-new button, and hides the layout selector in the calendar top bar. Dashboard widgets set it via `RecordCalendarWidgetReadOnlyEffect`; index pages are unaffected (defaults to `false`).

## Prerequisite refactor: calendar state componentization

The calendar module previously kept its three settings in **global** jotai atoms (`recordIndexCalendarFieldMetadataIdState`, `recordIndexCalendarEndFieldMetadataIdState`, `recordIndexCalendarLayoutState`) — fine when one calendar exists per page, wrong once a dashboard can host several calendar widgets next to a record-index page in the same app shell.

- The three atoms become component states keyed on `RecordCalendarComponentInstanceContext` (`*ComponentState`), following the same pattern the record-board module uses.
- All readers (top bar, month/week/day grids, group-by query hook, date-range filter, drag-drop) resolve the ambient calendar instance; the existing calendar unit tests were updated to mock the componentized hooks.
- `useLoadRecordIndexStates` writes them against `options.recordIndexId ?? ambient view instance id`, so per-widget hydration (`skipGlobalIndexStates: true`) and index-page hydration each target their own instance — a widget&#39;s date field can no longer leak into the Companies calendar page or vice versa.

## Scope

- **Month layout only** for widgets in v1 — week/day remain index-page features (the layout selector is hidden in widgets).
- Widget calendars are **read-only**: no card drag, no record create from the grid. Cards still open the record in the side panel.

## Test

- Browser-verified end-to-end on a seeded workspace: create dashboard → add View widget (Opportunities) → Layout → Calendar → month grid renders in edit preview → Save → reload → widget persists and renders the saved view. Also re-verified the Companies index-page calendar (layout switcher, drag, add-new all intact).
- `twenty-front` typecheck, lint, and unit tests green locally.

https://claude.ai/code/session_01E5N87kwwZWhDtEQaP72cMf