### PR TITLE
perf(front): lazy-mount below-fold dashboard view widgets

### DIFF
--- a/packages/twenty-front/src/modules/page-layout/widgets/record-table/components/RecordTableWidgetRenderer.tsx
+++ b/packages/twenty-front/src/modules/page-layout/widgets/record-table/components/RecordTableWidgetRenderer.tsx
@@ -5,7 +5,7 @@ import { RecordTableWidgetRendererContent } from '@/page-layout/widgets/record-t
 import { useHasEnteredViewport } from '@/ui/utilities/viewport/hooks/useHasEnteredViewport';
 import { useAtomComponentStateValue } from '@/ui/utilities/state/jotai/hooks/useAtomComponentStateValue';
 import { styled } from '@linaria/react';
-import { useEffect, useRef, useState } from 'react';
+import { useEffect, useState } from 'react';
 import { isDefined } from 'twenty-shared/utils';
 import { WidgetConfigurationType } from '~/generated-metadata/graphql';
 
@@ -26,8 +26,7 @@ export const RecordTableWidgetRenderer = ({
 }: RecordTableWidgetRendererProps) => {
   const { configuration } = widget;
 
-  const containerRef = useRef<HTMLDivElement>(null);
-  const hasEnteredViewport = useHasEnteredViewport(containerRef);
+  const { elementRef, hasEnteredViewport } = useHasEnteredViewport();
 
   const pageLayoutEditingWidgetId = useAtomComponentStateValue(
     pageLayoutEditingWidgetIdComponentState,
@@ -66,7 +65,7 @@ export const RecordTableWidgetRenderer = ({
   }
 
   return (
-    <StyledLazyMountContainer ref={containerRef}>
+    <StyledLazyMountContainer ref={elementRef}>
       {shouldMountContent || hasMountedContentOnce ? (
         <RecordTableWidgetRendererContent
           objectMetadataId={widget.objectMetadataId}

--- a/packages/twenty-front/src/modules/page-layout/widgets/record-table/components/RecordTableWidgetRenderer.tsx
+++ b/packages/twenty-front/src/modules/page-layout/widgets/record-table/components/RecordTableWidgetRenderer.tsx
@@ -1,7 +1,21 @@
+import { pageLayoutEditingWidgetIdComponentState } from '@/page-layout/states/pageLayoutEditingWidgetIdComponentState';
 import { type PageLayoutWidget } from '@/page-layout/types/PageLayoutWidget';
+import { WidgetSkeletonLoader } from '@/page-layout/widgets/components/WidgetSkeletonLoader';
 import { RecordTableWidgetRendererContent } from '@/page-layout/widgets/record-table/components/RecordTableWidgetRendererContent';
+import { useHasEnteredViewport } from '@/ui/utilities/viewport/hooks/useHasEnteredViewport';
+import { useAtomComponentStateValue } from '@/ui/utilities/state/jotai/hooks/useAtomComponentStateValue';
+import { styled } from '@linaria/react';
+import { useEffect, useRef, useState } from 'react';
 import { isDefined } from 'twenty-shared/utils';
 import { WidgetConfigurationType } from '~/generated-metadata/graphql';
+
+const StyledLazyMountContainer = styled.div`
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  min-height: 0;
+  width: 100%;
+`;
 
 type RecordTableWidgetRendererProps = {
   widget: PageLayoutWidget;
@@ -11,6 +25,28 @@ export const RecordTableWidgetRenderer = ({
   widget,
 }: RecordTableWidgetRendererProps) => {
   const { configuration } = widget;
+
+  const containerRef = useRef<HTMLDivElement>(null);
+  const hasEnteredViewport = useHasEnteredViewport(containerRef);
+
+  const pageLayoutEditingWidgetId = useAtomComponentStateValue(
+    pageLayoutEditingWidgetIdComponentState,
+  );
+  const isWidgetInEditMode = pageLayoutEditingWidgetId === widget.id;
+
+  // View widgets fire their own record queries (and one aggregate per
+  // group on kanban/grouped layouts), so below-fold widgets stay
+  // unmounted until they first become visible. Mounting is sticky and
+  // the widget under edit always mounts so its side panel preview works.
+  const shouldMountContent = hasEnteredViewport || isWidgetInEditMode;
+
+  const [hasMountedContentOnce, setHasMountedContentOnce] = useState(false);
+
+  useEffect(() => {
+    if (shouldMountContent) {
+      setHasMountedContentOnce(true);
+    }
+  }, [shouldMountContent]);
 
   const isRecordTableConfiguration =
     configuration.configurationType === WidgetConfigurationType.RECORD_TABLE;
@@ -30,12 +66,18 @@ export const RecordTableWidgetRenderer = ({
   }
 
   return (
-    <RecordTableWidgetRendererContent
-      objectMetadataId={widget.objectMetadataId}
-      viewId={viewId}
-      widgetId={widget.id}
-      isEmptyStateHidden
-      recordLimit={recordLimit}
-    />
+    <StyledLazyMountContainer ref={containerRef}>
+      {shouldMountContent || hasMountedContentOnce ? (
+        <RecordTableWidgetRendererContent
+          objectMetadataId={widget.objectMetadataId}
+          viewId={viewId}
+          widgetId={widget.id}
+          isEmptyStateHidden
+          recordLimit={recordLimit}
+        />
+      ) : (
+        <WidgetSkeletonLoader />
+      )}
+    </StyledLazyMountContainer>
   );
 };

--- a/packages/twenty-front/src/modules/ui/utilities/viewport/hooks/__tests__/useHasEnteredViewport.test.ts
+++ b/packages/twenty-front/src/modules/ui/utilities/viewport/hooks/__tests__/useHasEnteredViewport.test.ts
@@ -1,0 +1,88 @@
+import { act, renderHook } from '@testing-library/react';
+
+import { useHasEnteredViewport } from '@/ui/utilities/viewport/hooks/useHasEnteredViewport';
+
+describe('useHasEnteredViewport', () => {
+  const originalIntersectionObserver = (
+    globalThis as { IntersectionObserver?: unknown }
+  ).IntersectionObserver;
+
+  afterEach(() => {
+    (globalThis as { IntersectionObserver?: unknown }).IntersectionObserver =
+      originalIntersectionObserver;
+  });
+
+  it('latches to true immediately when IntersectionObserver is unavailable', () => {
+    delete (globalThis as { IntersectionObserver?: unknown })
+      .IntersectionObserver;
+
+    const elementRef = { current: document.createElement('div') };
+
+    const { result } = renderHook(() => useHasEnteredViewport(elementRef));
+
+    expect(result.current).toBe(true);
+  });
+
+  it('stays false until the element intersects, then latches to true', () => {
+    let observerCallback: IntersectionObserverCallback = () => {};
+    const observe = jest.fn();
+    const disconnect = jest.fn();
+
+    class MockIntersectionObserver {
+      constructor(callback: IntersectionObserverCallback) {
+        observerCallback = callback;
+      }
+
+      observe = observe;
+      disconnect = disconnect;
+    }
+
+    (globalThis as { IntersectionObserver?: unknown }).IntersectionObserver =
+      MockIntersectionObserver;
+
+    const elementRef = { current: document.createElement('div') };
+
+    const { result } = renderHook(() => useHasEnteredViewport(elementRef));
+
+    expect(result.current).toBe(false);
+    expect(observe).toHaveBeenCalledWith(elementRef.current);
+
+    act(() => {
+      observerCallback(
+        [{ isIntersecting: false } as IntersectionObserverEntry],
+        {} as IntersectionObserver,
+      );
+    });
+
+    expect(result.current).toBe(false);
+
+    act(() => {
+      observerCallback(
+        [{ isIntersecting: true } as IntersectionObserverEntry],
+        {} as IntersectionObserver,
+      );
+    });
+
+    expect(result.current).toBe(true);
+    expect(disconnect).toHaveBeenCalled();
+  });
+
+  it('does nothing when the element ref is empty', () => {
+    const observe = jest.fn();
+
+    class MockIntersectionObserver {
+      observe = observe;
+      disconnect = jest.fn();
+    }
+
+    (globalThis as { IntersectionObserver?: unknown }).IntersectionObserver =
+      MockIntersectionObserver;
+
+    const elementRef = { current: null };
+
+    const { result } = renderHook(() => useHasEnteredViewport(elementRef));
+
+    expect(result.current).toBe(false);
+    expect(observe).not.toHaveBeenCalled();
+  });
+});

--- a/packages/twenty-front/src/modules/ui/utilities/viewport/hooks/__tests__/useHasEnteredViewport.test.ts
+++ b/packages/twenty-front/src/modules/ui/utilities/viewport/hooks/__tests__/useHasEnteredViewport.test.ts
@@ -16,11 +16,13 @@ describe('useHasEnteredViewport', () => {
     delete (globalThis as { IntersectionObserver?: unknown })
       .IntersectionObserver;
 
-    const elementRef = { current: document.createElement('div') };
+    const { result } = renderHook(() => useHasEnteredViewport());
 
-    const { result } = renderHook(() => useHasEnteredViewport(elementRef));
+    act(() => {
+      result.current.elementRef(document.createElement('div'));
+    });
 
-    expect(result.current).toBe(true);
+    expect(result.current.hasEnteredViewport).toBe(true);
   });
 
   it('stays false until the element intersects, then latches to true', () => {
@@ -40,12 +42,16 @@ describe('useHasEnteredViewport', () => {
     (globalThis as { IntersectionObserver?: unknown }).IntersectionObserver =
       MockIntersectionObserver;
 
-    const elementRef = { current: document.createElement('div') };
+    const element = document.createElement('div');
 
-    const { result } = renderHook(() => useHasEnteredViewport(elementRef));
+    const { result } = renderHook(() => useHasEnteredViewport());
 
-    expect(result.current).toBe(false);
-    expect(observe).toHaveBeenCalledWith(elementRef.current);
+    act(() => {
+      result.current.elementRef(element);
+    });
+
+    expect(result.current.hasEnteredViewport).toBe(false);
+    expect(observe).toHaveBeenCalledWith(element);
 
     act(() => {
       observerCallback(
@@ -54,7 +60,7 @@ describe('useHasEnteredViewport', () => {
       );
     });
 
-    expect(result.current).toBe(false);
+    expect(result.current.hasEnteredViewport).toBe(false);
 
     act(() => {
       observerCallback(
@@ -63,11 +69,11 @@ describe('useHasEnteredViewport', () => {
       );
     });
 
-    expect(result.current).toBe(true);
+    expect(result.current.hasEnteredViewport).toBe(true);
     expect(disconnect).toHaveBeenCalled();
   });
 
-  it('does nothing when the element ref is empty', () => {
+  it('does nothing while no element is attached', () => {
     const observe = jest.fn();
 
     class MockIntersectionObserver {
@@ -78,11 +84,47 @@ describe('useHasEnteredViewport', () => {
     (globalThis as { IntersectionObserver?: unknown }).IntersectionObserver =
       MockIntersectionObserver;
 
-    const elementRef = { current: null };
+    const { result } = renderHook(() => useHasEnteredViewport());
 
-    const { result } = renderHook(() => useHasEnteredViewport(elementRef));
-
-    expect(result.current).toBe(false);
+    expect(result.current.hasEnteredViewport).toBe(false);
     expect(observe).not.toHaveBeenCalled();
+  });
+
+  it('starts observing when the element appears after the first render', () => {
+    let observerCallback: IntersectionObserverCallback = () => {};
+    const observe = jest.fn();
+
+    class MockIntersectionObserver {
+      constructor(callback: IntersectionObserverCallback) {
+        observerCallback = callback;
+      }
+
+      observe = observe;
+      disconnect = jest.fn();
+    }
+
+    (globalThis as { IntersectionObserver?: unknown }).IntersectionObserver =
+      MockIntersectionObserver;
+
+    const { result } = renderHook(() => useHasEnteredViewport());
+
+    expect(observe).not.toHaveBeenCalled();
+
+    const lateElement = document.createElement('div');
+
+    act(() => {
+      result.current.elementRef(lateElement);
+    });
+
+    expect(observe).toHaveBeenCalledWith(lateElement);
+
+    act(() => {
+      observerCallback(
+        [{ isIntersecting: true } as IntersectionObserverEntry],
+        {} as IntersectionObserver,
+      );
+    });
+
+    expect(result.current.hasEnteredViewport).toBe(true);
   });
 });

--- a/packages/twenty-front/src/modules/ui/utilities/viewport/hooks/useHasEnteredViewport.ts
+++ b/packages/twenty-front/src/modules/ui/utilities/viewport/hooks/useHasEnteredViewport.ts
@@ -1,0 +1,45 @@
+import { type RefObject, useEffect, useState } from 'react';
+
+const VIEWPORT_PRELOAD_MARGIN = '200px';
+
+// Latches to true the first time the element intersects the viewport
+// (clipping ancestors like scroll containers are accounted for) and
+// never resets, so consumers can safely mount-once on visibility.
+export const useHasEnteredViewport = (
+  elementRef: RefObject<HTMLElement | null>,
+) => {
+  const [hasEnteredViewport, setHasEnteredViewport] = useState(false);
+
+  useEffect(() => {
+    if (hasEnteredViewport) {
+      return;
+    }
+
+    const element = elementRef.current;
+
+    if (element === null) {
+      return;
+    }
+
+    if (typeof IntersectionObserver === 'undefined') {
+      setHasEnteredViewport(true);
+
+      return;
+    }
+
+    const observer = new IntersectionObserver(
+      (entries) => {
+        if (entries.some((entry) => entry.isIntersecting)) {
+          setHasEnteredViewport(true);
+        }
+      },
+      { rootMargin: VIEWPORT_PRELOAD_MARGIN },
+    );
+
+    observer.observe(element);
+
+    return () => observer.disconnect();
+  }, [hasEnteredViewport, elementRef]);
+
+  return hasEnteredViewport;
+};

--- a/packages/twenty-front/src/modules/ui/utilities/viewport/hooks/useHasEnteredViewport.ts
+++ b/packages/twenty-front/src/modules/ui/utilities/viewport/hooks/useHasEnteredViewport.ts
@@ -1,23 +1,19 @@
-import { type RefObject, useEffect, useState } from 'react';
+import { useEffect, useState } from 'react';
 
 const VIEWPORT_PRELOAD_MARGIN = '200px';
 
-// Latches to true the first time the element intersects the viewport
-// (clipping ancestors like scroll containers are accounted for) and
-// never resets, so consumers can safely mount-once on visibility.
-export const useHasEnteredViewport = (
-  elementRef: RefObject<HTMLElement | null>,
-) => {
+// Latches to true the first time the observed element intersects the
+// viewport (clipping ancestors like scroll containers are accounted
+// for) and never resets, so consumers can safely mount-once on
+// visibility. Attach the returned elementRef as the element's ref —
+// it is state-backed, so observation starts (or re-arms) whenever the
+// element appears, even if it was absent on first render.
+export const useHasEnteredViewport = () => {
+  const [element, setElement] = useState<HTMLElement | null>(null);
   const [hasEnteredViewport, setHasEnteredViewport] = useState(false);
 
   useEffect(() => {
-    if (hasEnteredViewport) {
-      return;
-    }
-
-    const element = elementRef.current;
-
-    if (element === null) {
+    if (hasEnteredViewport || element === null) {
       return;
     }
 
@@ -39,7 +35,7 @@ export const useHasEnteredViewport = (
     observer.observe(element);
 
     return () => observer.disconnect();
-  }, [hasEnteredViewport, elementRef]);
+  }, [hasEnteredViewport, element]);
 
-  return hasEnteredViewport;
+  return { elementRef: setElement, hasEnteredViewport };
 };


### PR DESCRIPTION
# Lazy-mount below-fold dashboard view widgets (5/5)

Final part of the dashboard view-layouts stack ([#22963](https://github.com/twentyhq/twenty/pull/22963) → [#22966](https://github.com/twentyhq/twenty/pull/22966) → [#22967](https://github.com/twentyhq/twenty/pull/22967) → [#22968](https://github.com/twentyhq/twenty/pull/22968) → this).

## Why

Every view widget on a dashboard fires its own record queries — a find-many for tables, plus **one aggregate query per group** for grouped tables and kanbans, plus the date-range query for calendars. A dashboard with many view widgets fans all of that out on first paint, even for widgets the user hasn't scrolled to.

## What this does

- `RecordTableWidgetRenderer` renders a lightweight skeleton (`WidgetSkeletonLoader`) instead of the widget content until the widget card first becomes visible, using a new `useHasEnteredViewport` hook (IntersectionObserver, 200px preload margin, latches on first intersection — scrolling away never unmounts).
- Two safety rules:
  - **Mounting is sticky** — once content mounts it stays mounted, so no state thrash when scrolling.
  - **The widget being edited always mounts** (`pageLayoutEditingWidgetIdComponentState`), so the side-panel preview and draft flow work even for a below-fold widget.
- The draft-init effect moving behind the gate is safe: `useSaveRecordTableWidgetViews` already skips widgets whose draft snapshot was never seeded, so saving a dashboard with unscrolled widgets works unchanged.
- Environments without `IntersectionObserver` (jsdom) mount immediately.

Only `RECORD_TABLE`-type widgets (table/kanban/calendar views) are gated — graph and other widget types are untouched.

## Test

- Unit tests for `useHasEnteredViewport` (unavailable-IO fallback, intersect-then-latch, empty ref, late-appearing element).
- Browser-verified on a dashboard holding all three layouts (grouped table + kanban + calendar): with a short viewport, the below-fold calendar widget renders a skeleton and issues no calendar queries; scrolling down mounts it and the month grid appears. Save/reload flows unchanged.
- `twenty-front` typecheck, lint, and unit tests green locally.

https://claude.ai/code/session_01E5N87kwwZWhDtEQaP72cMf