### PR TITLE
fix: add missing Expires field to security.txt per RFC 9116

### DIFF
--- a/packages/twenty-website/public/.well-known/security.txt
+++ b/packages/twenty-website/public/.well-known/security.txt
@@ -1,5 +1,6 @@
 Contact: https://github.com/twentyhq/twenty/issues/new
 Contact: security@twenty.com
+Expires: 2027-07-01T00:00:00.000Z
 Preferred-Languages: en
 Canonical: https://twenty.com/.well-known/security.txt
 Policy: https://github.com/twentyhq/twenty/security/policy


### PR DESCRIPTION
## Description

This PR adds the missing `Expires` field to `packages/twenty-website/public/.well-known/security.txt`.

RFC 9116 Section 2.5.5 defines the `Expires` field as mandatory and states: *"This field MUST always be present."* Without it, RFC 9116 validators and automated VDP-discovery tooling read the file as non-conformant.

## Changes

- Added `Expires: 2027-07-01T00:00:00.000Z` to `security.txt` (a date less than one year from now, suitable for regular rotation)

## Verification

The updated file now contains all mandatory fields per RFC 9116: `Contact` and `Expires`.

Closes #22866

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/22978?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

