### PR TITLE
feat(server): derive localDataOnly cache bootstrap hashes from content

### DIFF
--- a/packages/twenty-server/src/engine/core-modules/user/services/workspace-flat-workspace-member-map-cache.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/user/services/workspace-flat-workspace-member-map-cache.service.ts
@@ -1,11 +1,15 @@
 import { Injectable } from '@nestjs/common';
 
-import { WorkspaceCacheProvider } from 'src/engine/workspace-cache/interfaces/workspace-cache-provider.service';
+import {
+  WorkspaceCacheProvider,
+  type WorkspaceCacheComputeResult,
+} from 'src/engine/workspace-cache/interfaces/workspace-cache-provider.service';
 
 import { FlatWorkspaceMemberMaps } from 'src/engine/core-modules/user/types/flat-workspace-member-maps.type';
 import { GlobalWorkspaceOrmManager } from 'src/engine/twenty-orm/global-workspace-datasource/global-workspace-orm.manager';
 import { buildSystemAuthContext } from 'src/engine/twenty-orm/utils/build-system-auth-context.util';
 import { WorkspaceCache } from 'src/engine/workspace-cache/decorators/workspace-cache.decorator';
+import { computeRowsContentHash } from 'src/engine/workspace-cache/utils/compute-rows-content-hash.util';
 import { WorkspaceMemberWorkspaceEntity } from 'src/modules/workspace-member/standard-objects/workspace-member.workspace-entity';
 
 @Injectable()
@@ -18,35 +22,45 @@ export class WorkspaceFlatWorkspaceMemberMapCacheService extends WorkspaceCacheP
   }
 
   async computeForCache(workspaceId: string): Promise<FlatWorkspaceMemberMaps> {
-    const flatWorkspaceMemberMaps =
-      await this.globalWorkspaceOrmManager.executeInWorkspaceContext(
-        async () => {
-          const workspaceMemberRepository =
-            await this.globalWorkspaceOrmManager.getRepository<WorkspaceMemberWorkspaceEntity>(
-              workspaceId,
-              'workspaceMember',
-              { shouldBypassPermissionChecks: true },
-            );
+    const { data } = await this.computeForCacheWithContentHash(workspaceId);
 
-          const flatWorkspaceMemberMaps: FlatWorkspaceMemberMaps = {
-            byId: {},
-            idByUserId: {},
-          };
-          const workspaceMembers = await workspaceMemberRepository.find({
-            withDeleted: true,
-          });
+    return data;
+  }
 
-          for (const workspaceMember of workspaceMembers) {
-            flatWorkspaceMemberMaps.byId[workspaceMember.id] = workspaceMember;
-            flatWorkspaceMemberMaps.idByUserId[workspaceMember.userId] =
-              workspaceMember.id;
-          }
+  override async computeForCacheWithContentHash(
+    workspaceId: string,
+  ): Promise<WorkspaceCacheComputeResult<FlatWorkspaceMemberMaps>> {
+    return this.globalWorkspaceOrmManager.executeInWorkspaceContext(
+      async () => {
+        const workspaceMemberRepository =
+          await this.globalWorkspaceOrmManager.getRepository<WorkspaceMemberWorkspaceEntity>(
+            workspaceId,
+            'workspaceMember',
+            { shouldBypassPermissionChecks: true },
+          );
 
-          return flatWorkspaceMemberMaps;
-        },
-        buildSystemAuthContext(workspaceId),
-      );
+        const flatWorkspaceMemberMaps: FlatWorkspaceMemberMaps = {
+          byId: {},
+          idByUserId: {},
+        };
+        const workspaceMembers = await workspaceMemberRepository.find({
+          withDeleted: true,
+        });
 
-    return flatWorkspaceMemberMaps;
+        for (const workspaceMember of workspaceMembers) {
+          flatWorkspaceMemberMaps.byId[workspaceMember.id] = workspaceMember;
+          flatWorkspaceMemberMaps.idByUserId[workspaceMember.userId] =
+            workspaceMember.id;
+        }
+
+        return {
+          data: flatWorkspaceMemberMaps,
+          contentHash: computeRowsContentHash({
+            workspaceMember: workspaceMembers,
+          }),
+        };
+      },
+      buildSystemAuthContext(workspaceId),
+    );
   }
 }

--- a/packages/twenty-server/src/engine/twenty-orm/global-workspace-datasource/workspace-orm-entity-metadatas-cache.service.ts
+++ b/packages/twenty-server/src/engine/twenty-orm/global-workspace-datasource/workspace-orm-entity-metadatas-cache.service.ts
@@ -7,7 +7,10 @@ import { type EntityMetadata, EntitySchema, Repository } from 'typeorm';
 import { EntitySchemaTransformer } from 'typeorm/entity-schema/EntitySchemaTransformer';
 import { EntityMetadataBuilder } from 'typeorm/metadata-builder/EntityMetadataBuilder';
 
-import { WorkspaceCacheProvider } from 'src/engine/workspace-cache/interfaces/workspace-cache-provider.service';
+import {
+  WorkspaceCacheProvider,
+  type WorkspaceCacheComputeResult,
+} from 'src/engine/workspace-cache/interfaces/workspace-cache-provider.service';
 
 import { ApplicationEntity } from 'src/engine/core-modules/application/application.entity';
 import { FieldMetadataEntity } from 'src/engine/metadata-modules/field-metadata/field-metadata.entity';
@@ -16,6 +19,7 @@ import { EntitySchemaFactory } from 'src/engine/twenty-orm/factories/entity-sche
 import { GlobalWorkspaceOrmManager } from 'src/engine/twenty-orm/global-workspace-datasource/global-workspace-orm.manager';
 import { buildEntitySchemaMetadataMaps } from 'src/engine/twenty-orm/global-workspace-datasource/types/entity-schema-metadata.type';
 import { WorkspaceCache } from 'src/engine/workspace-cache/decorators/workspace-cache.decorator';
+import { computeRowsContentHash } from 'src/engine/workspace-cache/utils/compute-rows-content-hash.util';
 
 @Injectable()
 @WorkspaceCache('ORMEntityMetadatas', { localDataOnly: true })
@@ -36,6 +40,14 @@ export class WorkspaceORMEntityMetadatasCacheService extends WorkspaceCacheProvi
   }
 
   async computeForCache(workspaceId: string): Promise<EntityMetadata[]> {
+    const { data } = await this.computeForCacheWithContentHash(workspaceId);
+
+    return data;
+  }
+
+  override async computeForCacheWithContentHash(
+    workspaceId: string,
+  ): Promise<WorkspaceCacheComputeResult<EntityMetadata[]>> {
     const [objectMetadatas, fieldMetadatas, twentyStandardApplication] =
       await Promise.all([
         this.objectMetadataRepository.find({
@@ -54,6 +66,14 @@ export class WorkspaceORMEntityMetadatasCacheService extends WorkspaceCacheProvi
           },
         }),
       ]);
+
+    const contentHash = computeRowsContentHash({
+      objectMetadata: objectMetadatas,
+      fieldMetadata: fieldMetadatas,
+      application: isDefined(twentyStandardApplication)
+        ? [twentyStandardApplication]
+        : [],
+    });
 
     const { objectMetadataMaps, fieldMetadataMaps } =
       buildEntitySchemaMetadataMaps(
@@ -75,7 +95,7 @@ export class WorkspaceORMEntityMetadatasCacheService extends WorkspaceCacheProvi
 
     const entityMetadatas = await this.buildEntityMetadatas(entitySchemas);
 
-    return entityMetadatas;
+    return { data: entityMetadatas, contentHash };
   }
 
   private async buildEntityMetadatas(

--- a/packages/twenty-server/src/engine/workspace-cache/interfaces/workspace-cache-provider.service.ts
+++ b/packages/twenty-server/src/engine/workspace-cache/interfaces/workspace-cache-provider.service.ts
@@ -7,9 +7,23 @@ import {
 
 type WorkspaceCacheDataType = WorkspaceCacheDataMap[WorkspaceCacheKeyName];
 
+export type WorkspaceCacheComputeResult<T> = {
+  data: T;
+  contentHash: string | null;
+};
+
 @Injectable()
 export abstract class WorkspaceCacheProvider<
   T extends WorkspaceCacheDataType = WorkspaceCacheDataType,
 > {
   abstract computeForCache(workspaceId: string): Promise<T>;
+
+  async computeForCacheWithContentHash(
+    workspaceId: string,
+  ): Promise<WorkspaceCacheComputeResult<T>> {
+    return {
+      data: await this.computeForCache(workspaceId),
+      contentHash: null,
+    };
+  }
 }

--- a/packages/twenty-server/src/engine/workspace-cache/services/__tests__/workspace-cache.service.spec.ts
+++ b/packages/twenty-server/src/engine/workspace-cache/services/__tests__/workspace-cache.service.spec.ts
@@ -39,6 +39,21 @@ class MockOrmEntityMetadatasCacheProvider extends WorkspaceCacheProvider<{
   }
 }
 
+class MockContentHashedOrmEntityMetadatasCacheProvider extends WorkspaceCacheProvider<{
+  testData: string;
+}> {
+  async computeForCache(_workspaceId: string) {
+    return { testData: 'orm-computed-value' };
+  }
+
+  override async computeForCacheWithContentHash(_workspaceId: string) {
+    return {
+      data: { testData: 'orm-computed-value' },
+      contentHash: 'content-hash-abc',
+    };
+  }
+}
+
 describe('WorkspaceCacheService', () => {
   let service: WorkspaceCacheService;
   let cacheStorageService: jest.Mocked<CacheStorageService>;
@@ -668,6 +683,109 @@ describe('WorkspaceCacheService', () => {
       expect(cacheStorageService.mset).toHaveBeenCalledWith([
         { key: ormHashKey, value: expect.any(String) },
       ]);
+    });
+  });
+
+  describe('localDataOnly content hash', () => {
+    let contentHashedProvider: MockContentHashedOrmEntityMetadatasCacheProvider;
+    const ormHashKey = `orm:entity-metadatas:${WORKSPACE_ID}:hash`;
+
+    beforeEach(async () => {
+      contentHashedProvider =
+        new MockContentHashedOrmEntityMetadatasCacheProvider();
+
+      discoveryService.getProviders.mockReturnValue([
+        { instance: contentHashedProvider },
+      ] as any);
+
+      reflector.get.mockImplementation((key, target) => {
+        if (target !== MockContentHashedOrmEntityMetadatasCacheProvider) {
+          return undefined;
+        }
+
+        if (key === WORKSPACE_CACHE_KEY) {
+          return 'ORMEntityMetadatas';
+        }
+
+        if (key === WORKSPACE_CACHE_OPTIONS) {
+          return { localDataOnly: true };
+        }
+
+        return undefined;
+      });
+
+      await service.onModuleInit();
+    });
+
+    it('should persist the content hash only if still absent when redis has none', async () => {
+      cacheStorageService.mget.mockResolvedValue([undefined]);
+      cacheStorageService.setIfAbsent.mockResolvedValue(true);
+
+      await service.getOrRecompute(WORKSPACE_ID, ['ORMEntityMetadatas']);
+
+      expect(cacheStorageService.setIfAbsent).toHaveBeenCalledWith(
+        ormHashKey,
+        'content-hash-abc',
+        604800000,
+      );
+      expect(cacheStorageService.mset).not.toHaveBeenCalled();
+    });
+
+    it('should validate against the persisted content hash without recomputing', async () => {
+      cacheStorageService.mget.mockResolvedValue([undefined]);
+      cacheStorageService.mset.mockResolvedValue(undefined);
+
+      const computeSpy = jest.spyOn(
+        contentHashedProvider,
+        'computeForCacheWithContentHash',
+      );
+
+      await service.getOrRecompute(WORKSPACE_ID, ['ORMEntityMetadatas']);
+
+      jest.advanceTimersByTime(15_000);
+
+      cacheStorageService.mget.mockResolvedValue(['content-hash-abc']);
+
+      await service.getOrRecompute(WORKSPACE_ID, ['ORMEntityMetadatas']);
+
+      expect(computeSpy).toHaveBeenCalledTimes(1);
+    });
+
+    it('should prefer adopting the redis hash over the content hash', async () => {
+      cacheStorageService.mget.mockResolvedValue(['hash-from-another-pod']);
+      cacheStorageService.mset.mockResolvedValue(undefined);
+
+      const computeSpy = jest.spyOn(
+        contentHashedProvider,
+        'computeForCacheWithContentHash',
+      );
+
+      await service.getOrRecompute(WORKSPACE_ID, ['ORMEntityMetadatas']);
+
+      jest.advanceTimersByTime(15_000);
+
+      await service.getOrRecompute(WORKSPACE_ID, ['ORMEntityMetadatas']);
+
+      expect(computeSpy).toHaveBeenCalledTimes(1);
+      expect(cacheStorageService.mset).not.toHaveBeenCalled();
+    });
+
+    it('should mint a random hash instead of the content hash on invalidateAndRecompute', async () => {
+      cacheStorageService.mdel.mockResolvedValue(undefined);
+      cacheStorageService.mset.mockResolvedValue(undefined);
+
+      await service.invalidateAndRecompute(WORKSPACE_ID, [
+        'ORMEntityMetadatas',
+      ]);
+
+      expect(cacheStorageService.mset).toHaveBeenCalledWith([
+        { key: ormHashKey, value: expect.any(String) },
+      ]);
+
+      const persistedEntries = cacheStorageService.mset.mock
+        .calls[0][0] as Array<{ key: string; value: string }>;
+
+      expect(persistedEntries[0].value).not.toBe('content-hash-abc');
     });
   });
 });

--- a/packages/twenty-server/src/engine/workspace-cache/services/workspace-cache.service.ts
+++ b/packages/twenty-server/src/engine/workspace-cache/services/workspace-cache.service.ts
@@ -366,7 +366,8 @@ export class WorkspaceCacheService implements OnModuleInit {
 
     const computePromises = cacheKeyNames.map(async (keyName) => {
       const provider = this.getProviderOrThrow(keyName);
-      const data = await provider.computeForCache(workspaceId);
+      const { data, contentHash } =
+        await provider.computeForCacheWithContentHash(workspaceId);
 
       if (hashResolution.strategy === 'mint') {
         return { keyName, data, hash: crypto.randomUUID(), isAdopted: false };
@@ -377,7 +378,7 @@ export class WorkspaceCacheService implements OnModuleInit {
       return {
         keyName,
         data,
-        hash: adoptableHash ?? crypto.randomUUID(),
+        hash: adoptableHash ?? contentHash ?? crypto.randomUUID(),
         isAdopted: isDefined(adoptableHash),
       };
     });

--- a/packages/twenty-server/src/engine/workspace-cache/utils/__tests__/compute-rows-content-hash.util.spec.ts
+++ b/packages/twenty-server/src/engine/workspace-cache/utils/__tests__/compute-rows-content-hash.util.spec.ts
@@ -1,0 +1,66 @@
+import { computeRowsContentHash } from 'src/engine/workspace-cache/utils/compute-rows-content-hash.util';
+
+describe('computeRowsContentHash', () => {
+  const rowA = {
+    id: 'a',
+    updatedAt: '2026-01-01T00:00:00.000Z',
+    deletedAt: null,
+  };
+  const rowB = {
+    id: 'b',
+    updatedAt: '2026-01-02T00:00:00.000Z',
+    deletedAt: null,
+  };
+
+  it('should be stable across row ordering', () => {
+    expect(computeRowsContentHash({ section: [rowA, rowB] })).toBe(
+      computeRowsContentHash({ section: [rowB, rowA] }),
+    );
+  });
+
+  it('should be stable across section insertion order', () => {
+    expect(computeRowsContentHash({ alpha: [rowA], beta: [rowB] })).toBe(
+      computeRowsContentHash({ beta: [rowB], alpha: [rowA] }),
+    );
+  });
+
+  it('should treat dates and their ISO string form identically', () => {
+    expect(
+      computeRowsContentHash({
+        section: [{ id: 'a', updatedAt: new Date('2026-01-01T00:00:00.000Z') }],
+      }),
+    ).toBe(
+      computeRowsContentHash({
+        section: [{ id: 'a', updatedAt: '2026-01-01T00:00:00.000Z' }],
+      }),
+    );
+  });
+
+  it('should change when a row is updated', () => {
+    expect(
+      computeRowsContentHash({
+        section: [{ ...rowA, updatedAt: '2026-01-03T00:00:00.000Z' }],
+      }),
+    ).not.toBe(computeRowsContentHash({ section: [rowA] }));
+  });
+
+  it('should change when a row is soft deleted', () => {
+    expect(
+      computeRowsContentHash({
+        section: [{ ...rowA, deletedAt: '2026-01-03T00:00:00.000Z' }],
+      }),
+    ).not.toBe(computeRowsContentHash({ section: [rowA] }));
+  });
+
+  it('should change when a row is added', () => {
+    expect(computeRowsContentHash({ section: [rowA, rowB] })).not.toBe(
+      computeRowsContentHash({ section: [rowA] }),
+    );
+  });
+
+  it('should distinguish which section a row belongs to', () => {
+    expect(computeRowsContentHash({ alpha: [rowA], beta: [] })).not.toBe(
+      computeRowsContentHash({ alpha: [], beta: [rowA] }),
+    );
+  });
+});

--- a/packages/twenty-server/src/engine/workspace-cache/utils/compute-rows-content-hash.util.ts
+++ b/packages/twenty-server/src/engine/workspace-cache/utils/compute-rows-content-hash.util.ts
@@ -1,0 +1,35 @@
+import crypto from 'crypto';
+
+import { isDefined } from 'twenty-shared/utils';
+
+type ContentHashableRow = {
+  id: string;
+  updatedAt: Date | string;
+  deletedAt?: Date | string | null;
+};
+
+const serializeRowDate = (value: Date | string | null | undefined): string => {
+  if (!isDefined(value)) {
+    return '';
+  }
+
+  return typeof value === 'string' ? value : value.toISOString();
+};
+
+export const computeRowsContentHash = (
+  rowSections: Record<string, ContentHashableRow[]>,
+): string => {
+  const parts: string[] = [];
+
+  for (const sectionName of Object.keys(rowSections).sort()) {
+    for (const row of rowSections[sectionName]) {
+      parts.push(
+        `${sectionName}:${row.id}:${serializeRowDate(row.updatedAt)}:${serializeRowDate(row.deletedAt)}`,
+      );
+    }
+  }
+
+  parts.sort();
+
+  return crypto.createHash('sha256').update(parts.join('|')).digest('hex');
+};


### PR DESCRIPTION
## Context

Stacked on #22980 (base branch is set to its head; GitHub will retarget to `main` once #22980 merges and its branch is deleted). Review only the last commit here.

After #22980, the remaining churn window for `localDataOnly` keys is the bootstrap case where Redis has no validation hash: post-invalidation flush window, hash TTL expiry (`CACHE_STORAGE_TTL`, 7 days), and cold start after a deploy. In that window every recomputing pod minted its own random hash, so concurrent bootstrappers invalidated each other until one hash won; a fleet-wide deploy makes this a cold-start cascade across all warm workspaces.

## What this does

- `WorkspaceCacheProvider` gains an overridable `computeForCacheWithContentHash` (default delegates to `computeForCache` with a null hash).
- The two `localDataOnly` providers (`ORMEntityMetadatas`, `flatWorkspaceMemberMaps`) derive a content hash from the source rows they already fetch: sorted `section:id:updatedAt:deletedAt` tuples, sha256 (`computeRowsContentHash`). Identical data yields the identical hash on every pod, so concurrent bootstrap recomputes converge immediately, with zero invalidation of each other.
- The content hash is used **only** on the recovery path when Redis has no hash (still written via SET NX from #22980). `invalidateAndRecompute` keeps minting random hashes on purpose: explicit invalidations must always propagate, including for changes that do not bump `updatedAt` (raw SQL migrations).

## Cost

Benchmarked on synthetic fieldMetadata-shaped rows: 1.3ms at 1.5k rows, 3.4ms at 4k rows, 12ms at 10k rows, per recompute. The recompute it accompanies already spends ~220ms in Postgres plus `EntityMetadataBuilder.build`. The digest hashes only `(id, updatedAt, deletedAt)` tuples, not full row payloads, which is why it stays in single-digit milliseconds.

---
_Generated by [Claude Code](https://claude.ai/code/session_01T3JUHwXJHPmZDZTrv6YTDi)_

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/22982?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

