### PR TITLE
Fix workflow filter crash on relation IS_NOT_NULL operand

### DIFF
--- a/packages/twenty-server/src/database/commands/upgrade-version-command/2-23/2-23-upgrade-version-command.module.ts
+++ b/packages/twenty-server/src/database/commands/upgrade-version-command/2-23/2-23-upgrade-version-command.module.ts
@@ -1,0 +1,18 @@
+import { Module } from '@nestjs/common';
+
+import { WorkspaceIteratorModule } from 'src/database/commands/command-runners/workspace-iterator.module';
+import { MigrateWorkflowFilterIsNotNullOperandCommand } from 'src/database/commands/upgrade-version-command/2-23/2-23-workspace-command-1784400000000-migrate-workflow-filter-is-not-null-operand.command';
+import { ApplicationModule } from 'src/engine/core-modules/application/application.module';
+import { WorkspaceCacheModule } from 'src/engine/workspace-cache/workspace-cache.module';
+import { WorkspaceMigrationModule } from 'src/engine/workspace-manager/workspace-migration/workspace-migration.module';
+
+@Module({
+  imports: [
+    ApplicationModule,
+    WorkspaceIteratorModule,
+    WorkspaceCacheModule,
+    WorkspaceMigrationModule,
+  ],
+  providers: [MigrateWorkflowFilterIsNotNullOperandCommand],
+})
+export class V2_23_UpgradeVersionCommandModule {}

--- a/packages/twenty-server/src/database/commands/upgrade-version-command/2-23/2-23-workspace-command-1784400000000-migrate-workflow-filter-is-not-null-operand.command.ts
+++ b/packages/twenty-server/src/database/commands/upgrade-version-command/2-23/2-23-workspace-command-1784400000000-migrate-workflow-filter-is-not-null-operand.command.ts
@@ -1,0 +1,94 @@
+import { Command } from 'nest-commander';
+import { STANDARD_OBJECTS } from 'twenty-shared/metadata';
+import { isDefined } from 'twenty-shared/utils';
+
+import { ProvisionedWorkspaceCommandRunner } from 'src/database/commands/command-runners/provisioned-workspace.command-runner';
+import { WorkspaceIteratorService } from 'src/database/commands/command-runners/workspace-iterator.service';
+import { type RunOnWorkspaceArgs } from 'src/database/commands/command-runners/workspace.command-runner';
+import { rewriteWorkflowFilterIsNotNullOperand } from 'src/database/commands/upgrade-version-command/2-23/utils/rewrite-workflow-filter-is-not-null-operand.util';
+import { RegisteredWorkspaceCommand } from 'src/engine/core-modules/upgrade/decorators/registered-workspace-command.decorator';
+import { findFlatEntityByUniversalIdentifier } from 'src/engine/metadata-modules/flat-entity/utils/find-flat-entity-by-universal-identifier.util';
+import { type FlatObjectMetadata } from 'src/engine/metadata-modules/flat-object-metadata/types/flat-object-metadata.type';
+import { GlobalWorkspaceOrmManager } from 'src/engine/twenty-orm/global-workspace-datasource/global-workspace-orm.manager';
+import { WorkspaceCacheService } from 'src/engine/workspace-cache/services/workspace-cache.service';
+import { type WorkflowVersionWorkspaceEntity } from 'src/modules/workflow/common/standard-objects/workflow-version.workspace-entity';
+
+@RegisteredWorkspaceCommand('2.23.0', 1784400000000)
+@Command({
+  name: 'upgrade:2-23:migrate-workflow-filter-is-not-null-operand',
+  description:
+    'Rewrite legacy isNotNull/IS_NOT_NULL workflow filter operands to IS_NOT_EMPTY',
+})
+export class MigrateWorkflowFilterIsNotNullOperandCommand extends ProvisionedWorkspaceCommandRunner {
+  constructor(
+    protected readonly workspaceIteratorService: WorkspaceIteratorService,
+    private readonly twentyORMGlobalManager: GlobalWorkspaceOrmManager,
+    private readonly workspaceCacheService: WorkspaceCacheService,
+  ) {
+    super(workspaceIteratorService);
+  }
+
+  override async runOnWorkspace({
+    workspaceId,
+    options,
+  }: RunOnWorkspaceArgs): Promise<void> {
+    const isDryRun = options.dryRun ?? false;
+
+    // Empty/partially-provisioned workspaces have no workflowVersion object;
+    // fetching the repository for a missing entity throws, so skip them.
+    const { flatObjectMetadataMaps } =
+      await this.workspaceCacheService.getOrRecompute(workspaceId, [
+        'flatObjectMetadataMaps',
+      ]);
+
+    const workflowVersionObject =
+      findFlatEntityByUniversalIdentifier<FlatObjectMetadata>({
+        flatEntityMaps: flatObjectMetadataMaps,
+        universalIdentifier:
+          STANDARD_OBJECTS.workflowVersion.universalIdentifier,
+      });
+
+    if (!isDefined(workflowVersionObject)) {
+      this.logger.log(
+        `workflowVersion object not found for workspace ${workspaceId}, skipping`,
+      );
+
+      return;
+    }
+
+    const workflowVersionRepository =
+      await this.twentyORMGlobalManager.getRepository<WorkflowVersionWorkspaceEntity>(
+        workspaceId,
+        'workflowVersion',
+        { shouldBypassPermissionChecks: true },
+      );
+
+    const allVersions = await workflowVersionRepository.find();
+
+    let updatedVersionCount = 0;
+
+    for (const version of allVersions) {
+      const migratedSteps = rewriteWorkflowFilterIsNotNullOperand(version.steps);
+
+      if (!migratedSteps.changed) {
+        continue;
+      }
+
+      updatedVersionCount++;
+
+      if (isDryRun) {
+        continue;
+      }
+
+      await workflowVersionRepository.update(version.id, {
+        steps: migratedSteps.value,
+      });
+    }
+
+    if (updatedVersionCount > 0) {
+      this.logger.log(
+        `${isDryRun ? '[DRY RUN] ' : ''}Migrated isNotNull filter operands in ${updatedVersionCount} workflow version(s) for workspace ${workspaceId}`,
+      );
+    }
+  }
+}

--- a/packages/twenty-server/src/database/commands/upgrade-version-command/2-23/utils/__tests__/rewrite-workflow-filter-is-not-null-operand.util.spec.ts
+++ b/packages/twenty-server/src/database/commands/upgrade-version-command/2-23/utils/__tests__/rewrite-workflow-filter-is-not-null-operand.util.spec.ts
@@ -1,0 +1,104 @@
+import { ViewFilterOperand } from 'twenty-shared/types';
+import { WorkflowActionType } from 'twenty-shared/workflow';
+
+import { rewriteWorkflowFilterIsNotNullOperand } from 'src/database/commands/upgrade-version-command/2-23/utils/rewrite-workflow-filter-is-not-null-operand.util';
+import { type WorkflowAction } from 'src/modules/workflow/workflow-executor/workflow-actions/types/workflow-action.type';
+
+const createFilterStep = (operands: string[]): WorkflowAction =>
+  ({
+    id: 'step-1',
+    name: 'Filter',
+    type: WorkflowActionType.FILTER,
+    valid: true,
+    settings: {
+      input: {
+        stepFilters: operands.map((operand, index) => ({
+          id: `filter-${index}`,
+          type: 'RELATION',
+          operand,
+          value: '',
+          stepOutputKey: 'trigger.record',
+          stepFilterGroupId: 'group-1',
+        })),
+        stepFilterGroups: [],
+      },
+      outputSchema: {},
+      errorHandlingOptions: {
+        retryOnFailure: { value: false },
+        continueOnFailure: { value: false },
+      },
+    },
+  }) as unknown as WorkflowAction;
+
+const getOperands = (steps: WorkflowAction[] | null): (string | undefined)[] =>
+  (steps?.[0] as WorkflowAction & { settings: { input: { stepFilters: { operand: string }[] } } }).settings.input.stepFilters.map(
+    (filter) => filter.operand,
+  );
+
+describe('rewriteWorkflowFilterIsNotNullOperand', () => {
+  it('rewrites the deprecated camelCase isNotNull operand to IS_NOT_EMPTY', () => {
+    const result = rewriteWorkflowFilterIsNotNullOperand([
+      createFilterStep(['isNotNull']),
+    ]);
+
+    expect(result.changed).toBe(true);
+    expect(getOperands(result.value)).toEqual([ViewFilterOperand.IS_NOT_EMPTY]);
+  });
+
+  it('rewrites the normalized IS_NOT_NULL operand to IS_NOT_EMPTY', () => {
+    const result = rewriteWorkflowFilterIsNotNullOperand([
+      createFilterStep(['IS_NOT_NULL']),
+    ]);
+
+    expect(result.changed).toBe(true);
+    expect(getOperands(result.value)).toEqual([ViewFilterOperand.IS_NOT_EMPTY]);
+  });
+
+  it('leaves supported operands untouched', () => {
+    const result = rewriteWorkflowFilterIsNotNullOperand([
+      createFilterStep([
+        ViewFilterOperand.IS,
+        ViewFilterOperand.IS_NOT_EMPTY,
+        ViewFilterOperand.IS_EMPTY,
+      ]),
+    ]);
+
+    expect(result.changed).toBe(false);
+    expect(getOperands(result.value)).toEqual([
+      ViewFilterOperand.IS,
+      ViewFilterOperand.IS_NOT_EMPTY,
+      ViewFilterOperand.IS_EMPTY,
+    ]);
+  });
+
+  it('only rewrites the affected operands within a mixed filter set', () => {
+    const result = rewriteWorkflowFilterIsNotNullOperand([
+      createFilterStep([ViewFilterOperand.IS, 'IS_NOT_NULL']),
+    ]);
+
+    expect(result.changed).toBe(true);
+    expect(getOperands(result.value)).toEqual([
+      ViewFilterOperand.IS,
+      ViewFilterOperand.IS_NOT_EMPTY,
+    ]);
+  });
+
+  it('ignores non-filter steps', () => {
+    const otherStep = {
+      id: 'step-1',
+      type: WorkflowActionType.CODE,
+      settings: { input: {} },
+    } as unknown as WorkflowAction;
+
+    const result = rewriteWorkflowFilterIsNotNullOperand([otherStep]);
+
+    expect(result.changed).toBe(false);
+  });
+
+  it('handles null steps', () => {
+    const result = rewriteWorkflowFilterIsNotNullOperand(null);
+
+    expect(result.changed).toBe(false);
+    expect(result.value).toBeNull();
+  });
+});

--- a/packages/twenty-server/src/database/commands/upgrade-version-command/2-23/utils/rewrite-workflow-filter-is-not-null-operand.util.ts
+++ b/packages/twenty-server/src/database/commands/upgrade-version-command/2-23/utils/rewrite-workflow-filter-is-not-null-operand.util.ts
@@ -1,0 +1,54 @@
+import { ViewFilterOperand } from 'twenty-shared/types';
+import { isDefined } from 'twenty-shared/utils';
+import { WorkflowActionType } from 'twenty-shared/workflow';
+
+import { type WorkflowAction } from 'src/modules/workflow/workflow-executor/workflow-actions/types/workflow-action.type';
+
+// isNotNull was the legacy relation "is set" operand, retired in mid-2024 in
+// favor of IS_NOT_EMPTY. Old workflow filter steps still store it (as the
+// deprecated camelCase value or its normalized IS_NOT_NULL form), and no
+// evaluator supports it, so running those steps throws. Rewrite it to the
+// equivalent IS_NOT_EMPTY.
+const DEPRECATED_IS_NOT_NULL_OPERANDS = new Set(['isNotNull', 'IS_NOT_NULL']);
+
+export const rewriteWorkflowFilterIsNotNullOperand = (
+  steps: WorkflowAction[] | null,
+): { changed: boolean; value: WorkflowAction[] | null } => {
+  if (!isDefined(steps)) {
+    return { changed: false, value: steps };
+  }
+
+  let changed = false;
+
+  const value = steps.map((step) => {
+    if (step.type !== WorkflowActionType.FILTER) {
+      return step;
+    }
+
+    const stepFilters = step.settings?.input?.stepFilters;
+
+    if (!isDefined(stepFilters)) {
+      return step;
+    }
+
+    const rewrittenStepFilters = stepFilters.map((stepFilter) => {
+      if (!DEPRECATED_IS_NOT_NULL_OPERANDS.has(stepFilter.operand)) {
+        return stepFilter;
+      }
+
+      changed = true;
+
+      return { ...stepFilter, operand: ViewFilterOperand.IS_NOT_EMPTY };
+    });
+
+    return {
+      ...step,
+      settings: {
+        ...step.settings,
+        input: { ...step.settings.input, stepFilters: rewrittenStepFilters },
+      },
+    };
+  });
+
+  return { changed, value };
+};

--- a/packages/twenty-server/src/database/commands/upgrade-version-command/workspace-command-provider.module.ts
+++ b/packages/twenty-server/src/database/commands/upgrade-version-command/workspace-command-provider.module.ts
@@ -23,6 +23,7 @@ import { V2_19_UpgradeVersionCommandModule } from 'src/database/commands/upgrade
 import { V2_20_UpgradeVersionCommandModule } from 'src/database/commands/upgrade-version-command/2-20/2-20-upgrade-version-command.module';
 import { V2_21_UpgradeVersionCommandModule } from 'src/database/commands/upgrade-version-command/2-21/2-21-upgrade-version-command.module';
 import { V2_22_UpgradeVersionCommandModule } from 'src/database/commands/upgrade-version-command/2-22/2-22-upgrade-version-command.module';
+import { V2_23_UpgradeVersionCommandModule } from 'src/database/commands/upgrade-version-command/2-23/2-23-upgrade-version-command.module';
 
 @Module({
   imports: [
@@ -49,6 +50,7 @@ import { V2_22_UpgradeVersionCommandModule } from 'src/database/commands/upgrade
     V2_20_UpgradeVersionCommandModule,
     V2_21_UpgradeVersionCommandModule,
     V2_22_UpgradeVersionCommandModule,
+    V2_23_UpgradeVersionCommandModule,
   ],
 })
 export class WorkspaceCommandProviderModule {}

--- a/packages/twenty-server/src/modules/workflow/workflow-executor/workflow-actions/filter/filter.workflow-action.ts
+++ b/packages/twenty-server/src/modules/workflow/workflow-executor/workflow-actions/filter/filter.workflow-action.ts
@@ -39,11 +39,23 @@ export class FilterWorkflowAction implements WorkflowAction {
       };
     }
 
-    const matchesFilter = evaluateStepFilters({
-      stepFilters,
-      stepFilterGroups,
-      context,
-    });
+    let matchesFilter: boolean;
+
+    try {
+      matchesFilter = evaluateStepFilters({
+        stepFilters,
+        stepFilterGroups,
+        context,
+      });
+    } catch (error) {
+      // Filter evaluation only fails on invalid filter configuration (e.g. a
+      // legacy operand no evaluator supports). Surface it as a user error so
+      // the run fails without being reported as a Twenty system error.
+      throw new WorkflowStepExecutorException(
+        error instanceof Error ? error.message : 'Failed to evaluate filter',
+        WorkflowStepExecutorExceptionCode.INVALID_STEP_INPUT,
+      );
+    }
 
     return {
       result: {


### PR DESCRIPTION
## Context

Sentry [TWENTY-SERVER-GDM](https://twenty-v7.sentry.io/issues/7449525293?project=4507072499810304): `Error: Operand IS_NOT_NULL not supported for relation filter`, thrown from `evaluateRelationFilter`. 1123 occurrences, `handled`.

## Root cause

`IS_NOT_NULL` (originally the camelCase `isNotNull`) was historically the relation filter operand meaning "the relation is set". Old workflow filter steps on relation fields were saved with `isNotNull`; #14837 added `convertViewFilterOperandToCoreOperand` which normalizes it to `IS_NOT_NULL` before dispatch, but `evaluateRelationFilter` only handled `IS`, `IS_NOT`, `IS_EMPTY`, `IS_NOT_EMPTY`, so these legacy filters fell through to the `default` throw and crashed the workflow run.

Only legacy saved workflows hit this (the current relation UI uses `IS_EMPTY`/`IS_NOT_EMPTY`), which matches the signal: many occurrences but only 2 workspaces impacted.

## Fix

Treat `IS_NOT_NULL` as an alias of `IS_NOT_EMPTY` ("relation is set", no value expected) in `evaluateRelationFilter`. This also covers the `ACTOR` `workspaceMemberId` path, which routes through the same function.

A follow-up data migration to rewrite stored `isNotNull`/`IS_NOT_NULL` relation operands to `IS_NOT_EMPTY` would let this legacy alias eventually be removed.

## Testing

- Added regression tests for relation `IS_NOT_NULL`/`IS_NOT_EMPTY` (set and empty) and the raw deprecated `isNotNull` string. Full spec passes (99/99).
- Reproduced the exact crash in the server runtime against unmodified code, then confirmed the fixed code returns correct booleans (set -> true, empty -> false, deprecated `isNotNull` -> true).

Fixes TWENTY-SERVER-GDM

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/22992?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

