### PR TITLE
Install app logic functions in PREBUILT mode when the prebuilt flag is enabled

### DIFF
--- a/packages/twenty-server/src/engine/core-modules/application/application-manifest/application-manifest-migration.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/application/application-manifest/application-manifest-migration.service.ts
@@ -2,6 +2,7 @@ import { Injectable } from '@nestjs/common';
 
 import { type Manifest } from 'twenty-shared/application';
 import { ALL_METADATA_NAME } from 'twenty-shared/metadata';
+import { FeatureFlagKey } from 'twenty-shared/types';
 import { isDefined } from 'twenty-shared/utils';
 
 import { ComputeApplicationManifestAllUniversalFlatEntityMapsService } from 'src/engine/core-modules/application/application-manifest/services/compute-application-manifest-all-universal-flat-entity-maps.service';
@@ -112,6 +113,10 @@ export class ApplicationManifestMigrationService {
         ownerFlatApplication,
         now,
         workspaceId,
+        isLogicFunctionPrebuiltModeEnabled:
+          featureFlagsMap[
+            FeatureFlagKey.IS_LOGIC_FUNCTION_PREBUILT_MODE_ENABLED
+          ] === true,
       });
 
     const dependencyAllFlatEntityMaps = getApplicationSubAllFlatEntityMaps({
@@ -189,8 +194,7 @@ export class ApplicationManifestMigrationService {
       ApplicationManifestMigrationService.name,
     );
 
-    const { featureFlagsMap: _featureFlagsMap, ...existingAllFlatEntityMaps } =
-      cacheResult;
+    const { featureFlagsMap, ...existingAllFlatEntityMaps } = cacheResult;
 
     const fromAllFlatEntityMaps = getApplicationSubAllFlatEntityMaps({
       applicationIds: [ownerFlatApplication.id],
@@ -203,6 +207,10 @@ export class ApplicationManifestMigrationService {
         ownerFlatApplication,
         now,
         workspaceId,
+        isLogicFunctionPrebuiltModeEnabled:
+          featureFlagsMap[
+            FeatureFlagKey.IS_LOGIC_FUNCTION_PREBUILT_MODE_ENABLED
+          ] === true,
       });
 
     const allFlatEntityOperationRecordByMetadataName =

--- a/packages/twenty-server/src/engine/core-modules/application/application-manifest/converters/__tests__/from-logic-function-manifest-to-universal-flat-logic-function.util.spec.ts
+++ b/packages/twenty-server/src/engine/core-modules/application/application-manifest/converters/__tests__/from-logic-function-manifest-to-universal-flat-logic-function.util.spec.ts
@@ -1,0 +1,68 @@
+import { type LogicFunctionManifest } from 'twenty-shared/application';
+
+import { fromLogicFunctionManifestToUniversalFlatLogicFunction } from 'src/engine/core-modules/application/application-manifest/converters/from-logic-function-manifest-to-universal-flat-logic-function.util';
+import { LogicFunctionExecutionMode } from 'src/engine/metadata-modules/logic-function/logic-function.entity';
+
+const APP_UID = 'a8a8a8a8-a8a8-4a8a-a8a8-a8a8a8a8a8a8';
+const LOGIC_FUNCTION_UID = '3f0a55dd-1f6b-4a63-9a10-52ac6b7f0bbb';
+const NOW = '2026-05-04T00:00:00.000Z';
+
+const buildManifest = (
+  overrides: Partial<LogicFunctionManifest> = {},
+): LogicFunctionManifest => ({
+  universalIdentifier: LOGIC_FUNCTION_UID,
+  name: 'sync-contacts',
+  sourceHandlerPath: 'functions/sync-contacts/index.ts',
+  builtHandlerPath: 'functions/sync-contacts/index.mjs',
+  builtHandlerChecksum: 'checksum-123',
+  handlerName: 'main',
+  ...overrides,
+});
+
+describe('fromLogicFunctionManifestToUniversalFlatLogicFunction', () => {
+  it('keeps LIVE execution mode when prebuilt mode is disabled', () => {
+    const result = fromLogicFunctionManifestToUniversalFlatLogicFunction({
+      logicFunctionManifest: buildManifest(),
+      applicationUniversalIdentifier: APP_UID,
+      now: NOW,
+      isLogicFunctionPrebuiltModeEnabled: false,
+    });
+
+    expect(result.executionMode).toBe(LogicFunctionExecutionMode.LIVE);
+  });
+
+  it('uses PREBUILT execution mode when prebuilt mode is enabled', () => {
+    const result = fromLogicFunctionManifestToUniversalFlatLogicFunction({
+      logicFunctionManifest: buildManifest(),
+      applicationUniversalIdentifier: APP_UID,
+      now: NOW,
+      isLogicFunctionPrebuiltModeEnabled: true,
+    });
+
+    expect(result.executionMode).toBe(LogicFunctionExecutionMode.PREBUILT);
+    expect(result.isBuildUpToDate).toBe(true);
+    expect(result.checksum).toBe('checksum-123');
+  });
+
+  it('maps manifest fields onto the universal flat logic function', () => {
+    const result = fromLogicFunctionManifestToUniversalFlatLogicFunction({
+      logicFunctionManifest: buildManifest({ name: undefined }),
+      applicationUniversalIdentifier: APP_UID,
+      now: NOW,
+      isLogicFunctionPrebuiltModeEnabled: true,
+    });
+
+    expect(result).toMatchObject({
+      universalIdentifier: LOGIC_FUNCTION_UID,
+      applicationUniversalIdentifier: APP_UID,
+      name: 'main',
+      sourceHandlerPath: 'functions/sync-contacts/index.ts',
+      builtHandlerPath: 'functions/sync-contacts/index.mjs',
+      handlerName: 'main',
+      checksum: 'checksum-123',
+      createdAt: NOW,
+      updatedAt: NOW,
+      deletedAt: null,
+    });
+  });
+});

--- a/packages/twenty-server/src/engine/core-modules/application/application-manifest/converters/from-logic-function-manifest-to-universal-flat-logic-function.util.ts
+++ b/packages/twenty-server/src/engine/core-modules/application/application-manifest/converters/from-logic-function-manifest-to-universal-flat-logic-function.util.ts
@@ -12,10 +12,12 @@ export const fromLogicFunctionManifestToUniversalFlatLogicFunction = ({
   logicFunctionManifest,
   applicationUniversalIdentifier,
   now,
+  isLogicFunctionPrebuiltModeEnabled,
 }: {
   logicFunctionManifest: LogicFunctionManifest;
   applicationUniversalIdentifier: string;
   now: string;
+  isLogicFunctionPrebuiltModeEnabled: boolean;
 }): UniversalFlatLogicFunction => {
   const name =
     logicFunctionManifest.name ?? parse(logicFunctionManifest.handlerName).name;
@@ -42,7 +44,9 @@ export const fromLogicFunctionManifestToUniversalFlatLogicFunction = ({
     workflowActionTriggerSettings:
       logicFunctionManifest.workflowActionTriggerSettings ?? null,
     isBuildUpToDate: true,
-    executionMode: LogicFunctionExecutionMode.LIVE,
+    executionMode: isLogicFunctionPrebuiltModeEnabled
+      ? LogicFunctionExecutionMode.PREBUILT
+      : LogicFunctionExecutionMode.LIVE,
     createdAt: now,
     updatedAt: now,
     deletedAt: null,

--- a/packages/twenty-server/src/engine/core-modules/application/application-manifest/services/compute-application-manifest-all-universal-flat-entity-maps.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/application/application-manifest/services/compute-application-manifest-all-universal-flat-entity-maps.service.ts
@@ -70,11 +70,13 @@ export class ComputeApplicationManifestAllUniversalFlatEntityMapsService {
     ownerFlatApplication,
     now,
     workspaceId,
+    isLogicFunctionPrebuiltModeEnabled,
   }: {
     manifest: Manifest;
     ownerFlatApplication: FlatApplication;
     now: string;
     workspaceId: string;
+    isLogicFunctionPrebuiltModeEnabled: boolean;
   }): AllFlatEntityMaps {
     const allUniversalFlatEntityMaps = createEmptyAllFlatEntityMaps();
 
@@ -208,6 +210,7 @@ export class ComputeApplicationManifestAllUniversalFlatEntityMapsService {
             logicFunctionManifest,
             applicationUniversalIdentifier,
             now,
+            isLogicFunctionPrebuiltModeEnabled,
           }),
         universalFlatEntityMapsToMutate:
           allUniversalFlatEntityMaps.flatLogicFunctionMaps,


### PR DESCRIPTION
## Context

Manifest-installed logic functions (marketplace, tarball, npm, dev-sync) are always created in `LIVE` execution mode, so every execution rebuilds the runtime bundle even though apps ship a built artifact with a checksum in their manifest. The PREBUILT machinery already exists end to end: the create/update workspace-migration action handlers install the bundle, the executor asserts and uses it, and workflow code steps already flip to PREBUILT after build behind `IS_LOGIC_FUNCTION_PREBUILT_MODE_ENABLED`.

## What this does

When `IS_LOGIC_FUNCTION_PREBUILT_MODE_ENABLED` is on for the workspace, the manifest sync now creates and updates app logic functions in `PREBUILT` mode:

- `fromLogicFunctionManifestToUniversalFlatLogicFunction` takes an `isLogicFunctionPrebuiltModeEnabled` flag and sets `executionMode` accordingly (manifests always carry `builtHandlerChecksum` and `isBuildUpToDate: true`, so PREBUILT validation passes).
- `ComputeApplicationManifestAllUniversalFlatEntityMapsService.compute` threads the flag through.
- `ApplicationManifestMigrationService` resolves it from the `featureFlagsMap` already fetched from the workspace cache (no extra query), for both the pre-install function sync and the full metadata sync.

The existing create action handler then installs the prebuilt bundle at app install, and the update handler reinstalls on checksum change or mode flip. Executions reuse the installed bundle instead of assembling it per run.

## Behavior

- Flag off: unchanged, functions stay `LIVE`.
- Flag on: new installs create functions in `PREBUILT`; already-installed apps flip on their next sync or upgrade since `executionMode` is a compared property in the migration diff.
- Turning the flag off later is safe: the executor resolves the effective mode from the flag first and falls back to `LIVE`, and built files are still written to storage at install.

## Tests

Unit spec for the converter covering both flag states and the field mapping.

---
_Generated by [Claude Code](https://claude.ai/code/session_015L4zvAL9bsk7azYkbhcZSg)_

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/22993?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

