### PR TITLE
fix(docker): bump curl pin to 8.20.0-r0 (2 high + 6 medium CVEs)

### DIFF
--- a/packages/twenty-docker/twenty/Dockerfile
+++ b/packages/twenty-docker/twenty/Dockerfile
@@ -90,7 +90,7 @@ FROM node:24.18.0-alpine3.23@sha256:595398b0081eacda8e1c4c5b97b76cd1020e4d58a8eb
 # 3.5.7-r0). Node bundles its own OpenSSL, but psql/curl link these system
 # libs, so the upgrade hardens runtime TLS and clears the scanner.
 RUN apk add --no-cache \
-    'curl>=8.19.0-r0' \
+    'curl>=8.20.0-r0' \
     'nghttp2-libs>=1.69.0-r0' \
     'libcrypto3>=3.5.7-r0' \
     'libssl3>=3.5.7-r0' \
@@ -233,7 +233,7 @@ RUN apk add --no-cache \
     redis \
     'libcrypto3>=3.5.7-r0' \
     'libssl3>=3.5.7-r0' \
-    curl jq su-exec
+    'curl>=8.20.0-r0' jq su-exec
 
 # Workspace root config
 COPY --from=twenty-server-build /app/package.json /app/yarn.lock /app/.yarnrc.yml /app/


### PR DESCRIPTION
## Context

AWS Inspector flags `curl 8.19.0` in every `prod-twenty` image, including current builds, with 2 high and 6 medium findings:

- **High**: CVE-2026-6276, CVE-2026-5773
- **Medium**: CVE-2026-4873, CVE-2026-5545, CVE-2026-6253, CVE-2026-6429, CVE-2026-7009, CVE-2026-7168

These drive the Oneleet monitor "AWS ECR repository image vulnerabilities are remediated" (high severity SLA window currently open).

## Fix

All 8 CVEs are fixed in Alpine 3.23's `curl 8.20.0-r0`, now available in the v3.23 main repository:

- `twenty-server` runtime stage: raise the pin from `curl>=8.19.0-r0` to `curl>=8.20.0-r0`
- `twenty-app-dev` stage: pin the previously unpinned `curl` to the same floor

## Verification

Built the runtime apk layer locally against the pinned `node:24.18.0-alpine3.23` base:

```
curl-8.20.0-r0
libcurl-8.20.0-r0
curl 8.20.0 (aarch64-alpine-linux-musl) libcurl/8.20.0 OpenSSL/3.5.7 ...
```

Next deployed image will carry the patched curl, and the remaining findings on old images age out via the 14-day ECR lifecycle.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/22994?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

