### PR TITLE
fix(front): render AI chat record references with markdown-special titles

### DIFF
--- a/packages/twenty-front/src/modules/ai/components/LazyMarkdownRenderer.tsx
+++ b/packages/twenty-front/src/modules/ai/components/LazyMarkdownRenderer.tsx
@@ -1,9 +1,5 @@
 import { SKELETON_LOADER_HEIGHT_SIZES } from '@/activities/components/SkeletonLoader';
-import {
-  parseRecordReference,
-  RECORD_REFERENCE_REGEX,
-  RecordLink,
-} from '@/ai/components/RecordLink';
+import { RecordLink } from '@/ai/components/RecordLink';
 import {
   StyledMarkdownContainer,
   StyledParagraph,
@@ -11,45 +7,43 @@ import {
   StyledTableScrollContainer,
 } from '@/ai/components/LazyMarkdownRendererStyledComponents';
 import { MarkdownCodeBlock } from '@/ai/components/MarkdownCodeBlock';
-import { marked } from 'marked';
+import {
+  buildRecordReferenceToken,
+  extractRecordReferences,
+  RECORD_REFERENCE_PLACEHOLDER_REGEX,
+  type RecordReference,
+} from '@/ai/utils/extractRecordReferences';
 import {
   cloneElement,
+  createContext,
   isValidElement,
   lazy,
-  memo,
   Suspense,
   useContext,
-  useMemo,
 } from 'react';
 import Skeleton, { SkeletonTheme } from 'react-loading-skeleton';
 import { getSafeUrl, isDefined } from 'twenty-shared/utils';
 import { ThemeContext } from 'twenty-ui/theme-constants';
 
-const TextWithRecordLinks = ({ text }: { text: string }) => {
+const RecordReferencesContext = createContext<RecordReference[]>([]);
+
+const splitTextOnPlaceholders = (
+  text: string,
+  render: (referenceIndex: number, key: number) => React.ReactNode,
+): React.ReactNode[] => {
   const parts: React.ReactNode[] = [];
   let lastIndex = 0;
 
-  RECORD_REFERENCE_REGEX.lastIndex = 0;
+  RECORD_REFERENCE_PLACEHOLDER_REGEX.lastIndex = 0;
 
   let match;
 
-  while ((match = RECORD_REFERENCE_REGEX.exec(text)) !== null) {
+  while ((match = RECORD_REFERENCE_PLACEHOLDER_REGEX.exec(text)) !== null) {
     if (match.index > lastIndex) {
       parts.push(text.slice(lastIndex, match.index));
     }
 
-    const parsed = parseRecordReference(match[0]);
-
-    if (isDefined(parsed)) {
-      parts.push(
-        <RecordLink
-          key={match.index}
-          objectNameSingular={parsed.objectNameSingular}
-          recordId={parsed.recordId}
-          displayName={parsed.displayName}
-        />,
-      );
-    }
+    parts.push(render(Number(match[1]), match.index));
 
     lastIndex = match.index + match[0].length;
   }
@@ -57,6 +51,30 @@ const TextWithRecordLinks = ({ text }: { text: string }) => {
   if (lastIndex < text.length) {
     parts.push(text.slice(lastIndex));
   }
+
+  return parts;
+};
+
+// Prose: turn each placeholder into a clickable record chip.
+const TextWithRecordLinks = ({ text }: { text: string }) => {
+  const references = useContext(RecordReferencesContext);
+
+  const parts = splitTextOnPlaceholders(text, (referenceIndex, key) => {
+    const reference = references[referenceIndex];
+
+    if (!isDefined(reference)) {
+      return null;
+    }
+
+    return (
+      <RecordLink
+        key={key}
+        objectNameSingular={reference.objectNameSingular}
+        recordId={reference.recordId}
+        displayName={reference.displayName}
+      />
+    );
+  });
 
   return <>{parts}</>;
 };
@@ -85,6 +103,32 @@ const processChildrenForRecordLinks = (
   }
 
   return children;
+};
+
+// Code/pre: references never render as chips inside code, so restore the
+// original [[record:...]] text instead of leaking the placeholder sentinels.
+const CodeChildrenWithRestoredReferences = ({
+  children,
+}: {
+  children: React.ReactNode;
+}) => {
+  const references = useContext(RecordReferencesContext);
+
+  if (typeof children === 'string') {
+    return (
+      <>
+        {splitTextOnPlaceholders(children, (referenceIndex) => {
+          const reference = references[referenceIndex];
+
+          return isDefined(reference)
+            ? buildRecordReferenceToken(reference)
+            : '';
+        })}
+      </>
+    );
+  }
+
+  return <>{children}</>;
 };
 
 const MarkdownRenderer = lazy(async () => {
@@ -154,13 +198,31 @@ const MarkdownRenderer = lazy(async () => {
               {processChildrenForRecordLinks(children)}
             </a>
           ),
+          em: ({ children }) => (
+            <em>{processChildrenForRecordLinks(children)}</em>
+          ),
+          strong: ({ children }) => (
+            <strong>{processChildrenForRecordLinks(children)}</strong>
+          ),
+          del: ({ children }) => (
+            <del>{processChildrenForRecordLinks(children)}</del>
+          ),
+          blockquote: ({ children }) => (
+            <blockquote>{processChildrenForRecordLinks(children)}</blockquote>
+          ),
           code: ({
             className,
             children,
           }: {
             className?: string;
             children?: React.ReactNode;
-          }) => <code className={className}>{children}</code>,
+          }) => (
+            <code className={className}>
+              <CodeChildrenWithRestoredReferences>
+                {children}
+              </CodeChildrenWithRestoredReferences>
+            </code>
+          ),
           pre: ({ children }) => (
             <MarkdownCodeBlock>{children}</MarkdownCodeBlock>
           ),
@@ -206,34 +268,24 @@ const LoadingSkeleton = () => {
   );
 };
 
-const MemoizedMarkdownBlock = memo(
-  ({ blockText }: { blockText: string }) => (
-    <MarkdownRenderer
-      TableScrollContainer={StyledTableScrollContainer}
-      ParagraphComponent={StyledParagraph}
-    >
-      {blockText}
-    </MarkdownRenderer>
-  ),
-  (previousProps, nextProps) => previousProps.blockText === nextProps.blockText,
-);
-
 export const LazyMarkdownRenderer = ({ text }: { text: string }) => {
-  const markdownBlocks = useMemo(
-    () => marked.lexer(text).map((token) => token.raw),
-    [text],
-  );
+  const { sanitizedText, references } = extractRecordReferences(text);
 
   return (
     <StyledMarkdownContainer
       className="markdown-section"
       data-replay-ignore-mutations="true"
     >
-      <Suspense fallback={<LoadingSkeleton />}>
-        {markdownBlocks.map((blockText, blockIndex) => (
-          <MemoizedMarkdownBlock key={blockIndex} blockText={blockText} />
-        ))}
-      </Suspense>
+      <RecordReferencesContext.Provider value={references}>
+        <Suspense fallback={<LoadingSkeleton />}>
+          <MarkdownRenderer
+            TableScrollContainer={StyledTableScrollContainer}
+            ParagraphComponent={StyledParagraph}
+          >
+            {sanitizedText}
+          </MarkdownRenderer>
+        </Suspense>
+      </RecordReferencesContext.Provider>
     </StyledMarkdownContainer>
   );
 };

--- a/packages/twenty-front/src/modules/ai/components/LazyMarkdownRenderer.tsx
+++ b/packages/twenty-front/src/modules/ai/components/LazyMarkdownRenderer.tsx
@@ -55,7 +55,6 @@ const splitTextOnPlaceholders = (
   return parts;
 };
 
-// Prose: turn each placeholder into a clickable record chip.
 const TextWithRecordLinks = ({ text }: { text: string }) => {
   const references = useContext(RecordReferencesContext);
 
@@ -105,30 +104,33 @@ const processChildrenForRecordLinks = (
   return children;
 };
 
-// Code/pre: references never render as chips inside code, so restore the
-// original [[record:...]] text instead of leaking the placeholder sentinels.
-const CodeChildrenWithRestoredReferences = ({
+const restorePlaceholdersToTokens = (
+  text: string,
+  references: RecordReference[],
+): string =>
+  text.replace(RECORD_REFERENCE_PLACEHOLDER_REGEX, (_match, referenceIndex) => {
+    const reference = references[Number(referenceIndex)];
+
+    return isDefined(reference) ? buildRecordReferenceToken(reference) : '';
+  });
+
+// References never render as chips inside code; restore the original token as
+// plain text so the placeholder sentinels never reach the DOM or the clipboard.
+const CodeBlock = ({
+  className,
   children,
 }: {
-  children: React.ReactNode;
+  className?: string;
+  children?: React.ReactNode;
 }) => {
   const references = useContext(RecordReferencesContext);
 
-  if (typeof children === 'string') {
-    return (
-      <>
-        {splitTextOnPlaceholders(children, (referenceIndex) => {
-          const reference = references[referenceIndex];
+  const restoredChildren =
+    typeof children === 'string'
+      ? restorePlaceholdersToTokens(children, references)
+      : children;
 
-          return isDefined(reference)
-            ? buildRecordReferenceToken(reference)
-            : '';
-        })}
-      </>
-    );
-  }
-
-  return <>{children}</>;
+  return <code className={className}>{restoredChildren}</code>;
 };
 
 const MarkdownRenderer = lazy(async () => {
@@ -216,13 +218,7 @@ const MarkdownRenderer = lazy(async () => {
           }: {
             className?: string;
             children?: React.ReactNode;
-          }) => (
-            <code className={className}>
-              <CodeChildrenWithRestoredReferences>
-                {children}
-              </CodeChildrenWithRestoredReferences>
-            </code>
-          ),
+          }) => <CodeBlock className={className}>{children}</CodeBlock>,
           pre: ({ children }) => (
             <MarkdownCodeBlock>{children}</MarkdownCodeBlock>
           ),

--- a/packages/twenty-front/src/modules/ai/components/RecordLink.tsx
+++ b/packages/twenty-front/src/modules/ai/components/RecordLink.tsx
@@ -49,21 +49,3 @@ export const RecordLink = ({
     />
   );
 };
-
-export const RECORD_REFERENCE_REGEX =
-  /\[\[(?:record:)?([a-zA-Z]+):([a-f0-9-]+):([^\]]+)\]\]/g;
-
-export const parseRecordReference = (match: string) => {
-  const regex = /\[\[(?:record:)?([a-zA-Z]+):([a-f0-9-]+):([^\]]+)\]\]/;
-  const result = regex.exec(match);
-
-  if (!result) {
-    return null;
-  }
-
-  return {
-    objectNameSingular: result[1],
-    recordId: result[2],
-    displayName: result[3],
-  };
-};

--- a/packages/twenty-front/src/modules/ai/utils/__tests__/extractRecordReferences.test.ts
+++ b/packages/twenty-front/src/modules/ai/utils/__tests__/extractRecordReferences.test.ts
@@ -1,0 +1,89 @@
+import {
+  buildRecordReferenceToken,
+  extractRecordReferences,
+  RECORD_REFERENCE_PLACEHOLDER_REGEX,
+} from '@/ai/utils/extractRecordReferences';
+
+const countPlaceholders = (text: string) =>
+  text.match(RECORD_REFERENCE_PLACEHOLDER_REGEX)?.length ?? 0;
+
+const replacePlaceholdersWith = (text: string, token: string) =>
+  text.replace(RECORD_REFERENCE_PLACEHOLDER_REGEX, token);
+
+const hasNoRawTokens = (text: string) =>
+  expect(text).not.toContain('[[record:');
+
+describe('extractRecordReferences', () => {
+  it('extracts a simple reference and replaces it with a placeholder', () => {
+    const { sanitizedText, references } = extractRecordReferences(
+      'owned by [[record:engineer:cf1ca169-ac22-4f5f-afd5-18a11b48c133:ijreilly]] today',
+    );
+
+    expect(references).toEqual([
+      {
+        objectNameSingular: 'engineer',
+        recordId: 'cf1ca169-ac22-4f5f-afd5-18a11b48c133',
+        displayName: 'ijreilly',
+      },
+    ]);
+    hasNoRawTokens(sanitizedText);
+    expect(countPlaceholders(sanitizedText)).toBe(1);
+    expect(replacePlaceholdersWith(sanitizedText, 'X')).toBe(
+      'owned by X today',
+    );
+  });
+
+  it('keeps a display name that contains backticks in a single reference', () => {
+    const { references } = extractRecordReferences(
+      '[[record:issue:6cc5c91e-5b10-42ce-aed2-4abb05b89b42:Workflow DATABASE_EVENT trigger ignores watched fields on `upserted` events (logic-function path)]]',
+    );
+
+    expect(references).toHaveLength(1);
+    expect(references[0].displayName).toBe(
+      'Workflow DATABASE_EVENT trigger ignores watched fields on `upserted` events (logic-function path)',
+    );
+  });
+
+  it('keeps a display name that contains square brackets', () => {
+    const { references } = extractRecordReferences(
+      '[[record:issue:8c238767-941b-4f58-9246-0bf9833f7436:[Billing for Self-hosts] Tie enterprise key to serverId]]',
+    );
+
+    expect(references).toHaveLength(1);
+    expect(references[0].displayName).toBe(
+      '[Billing for Self-hosts] Tie enterprise key to serverId',
+    );
+  });
+
+  it('extracts every reference from the reported multi-reference message', () => {
+    const text =
+      "I don't see any active initiatives owned by [[record:engineer:cf1ca169-ac22-4f5f-afd5-18a11b48c133:ijreilly]], but I do see open assigned/authored issues. For the sync, should I frame next week's plan around finishing [[record:issue:6cc5c91e-5b10-42ce-aed2-4abb05b89b42:Workflow DATABASE_EVENT trigger ignores watched fields on `upserted` events (logic-function path)]], handling [[record:issue:42d9d653-ab2b-4a6b-b81c-40c19ce876ee:Attachments should not be creatable if they are not editable in the UI]], and continuing [[record:issue:8c238767-941b-4f58-9246-0bf9833f7436:[Billing for Self-hosts] Tie enterprise key to serverId]]?";
+
+    const { sanitizedText, references } = extractRecordReferences(text);
+
+    expect(references).toHaveLength(4);
+    hasNoRawTokens(sanitizedText);
+    expect(countPlaceholders(sanitizedText)).toBe(4);
+  });
+
+  it('leaves text without references untouched', () => {
+    const text =
+      'Just a normal answer with `code` and [a link](https://x.com).';
+    const { sanitizedText, references } = extractRecordReferences(text);
+
+    expect(references).toEqual([]);
+    expect(sanitizedText).toBe(text);
+  });
+
+  it('round-trips a reference back to its original token', () => {
+    const reference = {
+      objectNameSingular: 'issue',
+      recordId: '8c238767-941b-4f58-9246-0bf9833f7436',
+      displayName: '[Billing for Self-hosts] Tie enterprise key to serverId',
+    };
+
+    expect(buildRecordReferenceToken(reference)).toBe(
+      '[[record:issue:8c238767-941b-4f58-9246-0bf9833f7436:[Billing for Self-hosts] Tie enterprise key to serverId]]',
+    );
+  });
+});

--- a/packages/twenty-front/src/modules/ai/utils/__tests__/extractRecordReferences.test.ts
+++ b/packages/twenty-front/src/modules/ai/utils/__tests__/extractRecordReferences.test.ts
@@ -66,6 +66,21 @@ describe('extractRecordReferences', () => {
     expect(countPlaceholders(sanitizedText)).toBe(4);
   });
 
+  it('extracts a reference with an empty display name', () => {
+    const { sanitizedText, references } = extractRecordReferences(
+      'see [[record:person:cf1ca169-ac22-4f5f-afd5-18a11b48c133:]] here',
+    );
+
+    expect(references).toEqual([
+      {
+        objectNameSingular: 'person',
+        recordId: 'cf1ca169-ac22-4f5f-afd5-18a11b48c133',
+        displayName: '',
+      },
+    ]);
+    expect(countPlaceholders(sanitizedText)).toBe(1);
+  });
+
   it('leaves text without references untouched', () => {
     const text =
       'Just a normal answer with `code` and [a link](https://x.com).';

--- a/packages/twenty-front/src/modules/ai/utils/extractRecordReferences.ts
+++ b/packages/twenty-front/src/modules/ai/utils/extractRecordReferences.ts
@@ -4,16 +4,13 @@ export type RecordReference = {
   displayName: string;
 };
 
-// Display names come from real record titles and routinely contain markdown
-// special characters (backticks, brackets, pipes). Matching the display name
-// non-greedily up to the closing "]]" lets titles like "[Billing] Tie key"
-// survive, which "[^\]]+" would truncate at the first "]".
+// Non-greedy display name up to the closing "]]" so titles containing "]" (e.g.
+// "[Billing] Tie key") survive, unlike "[^\]]+" which stops at the first "]".
 const RECORD_REFERENCE_REGEX =
-  /\[\[(?:record:)?([a-zA-Z]+):([a-f0-9-]+):(.+?)\]\]/g;
+  /\[\[(?:record:)?([a-zA-Z]+):([a-f0-9-]+):(.*?)\]\]/g;
 
-// Private Use Area sentinels wrapping the reference index. They carry no
-// markdown meaning, so the parser keeps each placeholder inside a single text
-// node instead of fragmenting the original token on its special characters.
+// Private Use Area sentinels carry no markdown meaning, so the parser keeps each
+// placeholder in one text node instead of fragmenting the token on its content.
 const PLACEHOLDER_START = '\uE000';
 const PLACEHOLDER_END = '\uE001';
 

--- a/packages/twenty-front/src/modules/ai/utils/extractRecordReferences.ts
+++ b/packages/twenty-front/src/modules/ai/utils/extractRecordReferences.ts
@@ -1,0 +1,44 @@
+export type RecordReference = {
+  objectNameSingular: string;
+  recordId: string;
+  displayName: string;
+};
+
+// Display names come from real record titles and routinely contain markdown
+// special characters (backticks, brackets, pipes). Matching the display name
+// non-greedily up to the closing "]]" lets titles like "[Billing] Tie key"
+// survive, which "[^\]]+" would truncate at the first "]".
+const RECORD_REFERENCE_REGEX =
+  /\[\[(?:record:)?([a-zA-Z]+):([a-f0-9-]+):(.+?)\]\]/g;
+
+// Private Use Area sentinels wrapping the reference index. They carry no
+// markdown meaning, so the parser keeps each placeholder inside a single text
+// node instead of fragmenting the original token on its special characters.
+const PLACEHOLDER_START = '\uE000';
+const PLACEHOLDER_END = '\uE001';
+
+export const RECORD_REFERENCE_PLACEHOLDER_REGEX = /\uE000(\d+)\uE001/g;
+
+export const extractRecordReferences = (
+  text: string,
+): { sanitizedText: string; references: RecordReference[] } => {
+  const references: RecordReference[] = [];
+
+  const sanitizedText = text.replace(
+    RECORD_REFERENCE_REGEX,
+    (_match, objectNameSingular, recordId, displayName) => {
+      const index = references.length;
+      references.push({ objectNameSingular, recordId, displayName });
+      return `${PLACEHOLDER_START}${index}${PLACEHOLDER_END}`;
+    },
+  );
+
+  return { sanitizedText, references };
+};
+
+export const buildRecordReferenceToken = ({
+  objectNameSingular,
+  recordId,
+  displayName,
+}: RecordReference): string =>
+  `[[record:${objectNameSingular}:${recordId}:${displayName}]]`;


### PR DESCRIPTION
## Problem

Record references in AI chat replies (`[[record:object:id:name]]`) render as raw text instead of clickable chips when the referenced record's title contains markdown-special characters. Reported in Discord (quality-feedbacks) with issue titles like ``Workflow ... on `upserted` events`` and `[Billing for Self-hosts] Tie enterprise key`.

## Cause

`LazyMarkdownRenderer` parsed the message with `react-markdown` first, then scanned the resulting string nodes with a regex to turn tokens into chips. Titles routinely break that: backticks make the parser emit an inline `code` node that splits the token across siblings, and `]` in the title ends the `[^\]]+` capture early. The token then never matches.

## Fix

Extract references from the raw text **before** markdown parsing, replacing each with an inert Private-Use-Area placeholder the parser can't fragment, then re-inject `RecordLink` chips where the placeholders land. Code blocks restore the original token as plain text, so the sentinels never reach the DOM or the clipboard.

## Screenshots

Rendered from a harness using the real `react-markdown` + `remark-gfm` pipeline with the exact before/after logic (the reported message).

**Before** — titles with backticks / brackets fall back to raw `[[record:...]]` text:

![before](https://raw.githubusercontent.com/twentyhq/twenty/charles/pr-22996-screenshots/before.png)

**After** — every reference renders as a chip:

![after](https://raw.githubusercontent.com/twentyhq/twenty/charles/pr-22996-screenshots/after.png)

## Tests

`extractRecordReferences.test.ts` covers the reported titles (backticks, brackets), the full multi-reference message, empty titles, and no-reference passthrough.
