### PR TITLE
feat(front): view widget with kanban and calendar layouts on record page layouts

### DIFF
--- a/packages/twenty-front/src/modules/page-layout/utils/createDefaultRecordTableWidget.ts
+++ b/packages/twenty-front/src/modules/page-layout/utils/createDefaultRecordTableWidget.ts
@@ -11,12 +11,14 @@ export const createDefaultRecordTableWidget = ({
   pageLayoutTabId,
   title,
   gridPosition,
+  verticalListPositionIndex,
   objectMetadataId,
 }: {
   id: string;
   pageLayoutTabId: string;
   title: string;
   gridPosition: GridPosition;
+  verticalListPositionIndex?: number;
   objectMetadataId?: string;
 }): PageLayoutWidget => {
   return {
@@ -31,14 +33,21 @@ export const createDefaultRecordTableWidget = ({
       configurationType: WidgetConfigurationType.RECORD_TABLE,
     },
     gridPosition,
-    position: {
-      __typename: 'PageLayoutWidgetGridPosition',
-      layoutMode: PageLayoutTabLayoutMode.GRID,
-      row: gridPosition.row,
-      column: gridPosition.column,
-      rowSpan: gridPosition.rowSpan,
-      columnSpan: gridPosition.columnSpan,
-    },
+    position:
+      verticalListPositionIndex !== undefined
+        ? {
+            __typename: 'PageLayoutWidgetVerticalListPosition',
+            layoutMode: PageLayoutTabLayoutMode.VERTICAL_LIST,
+            index: verticalListPositionIndex,
+          }
+        : {
+            __typename: 'PageLayoutWidgetGridPosition',
+            layoutMode: PageLayoutTabLayoutMode.GRID,
+            row: gridPosition.row,
+            column: gridPosition.column,
+            rowSpan: gridPosition.rowSpan,
+            columnSpan: gridPosition.columnSpan,
+          },
     objectMetadataId: objectMetadataId ?? null,
     isOverridden: false,
     createdAt: new Date().toISOString(),

--- a/packages/twenty-front/src/modules/side-panel/hooks/useOpenWidgetSettingsInSidePanel.ts
+++ b/packages/twenty-front/src/modules/side-panel/hooks/useOpenWidgetSettingsInSidePanel.ts
@@ -109,10 +109,6 @@ export const useOpenWidgetSettingsInSidePanel = (
       }
 
       if (widgetType === WidgetType.RECORD_TABLE) {
-        if (!isDashboardPageLayout) {
-          return;
-        }
-
         navigatePageLayoutSidePanel({
           sidePanelPage: SidePanelPages.DashboardRecordTableSettings,
           pageTitle: t`Edit Record Table`,

--- a/packages/twenty-front/src/modules/side-panel/pages/page-layout/components/SidePanelPageLayoutRecordPageWidgetTypeSelect.tsx
+++ b/packages/twenty-front/src/modules/side-panel/pages/page-layout/components/SidePanelPageLayoutRecordPageWidgetTypeSelect.tsx
@@ -10,9 +10,11 @@ import { type PageLayoutWidget } from '@/page-layout/types/PageLayoutWidget';
 import { addWidgetToTab } from '@/page-layout/utils/addWidgetToTab';
 import { createDefaultFieldWidget } from '@/page-layout/utils/createDefaultFieldWidget';
 import { createDefaultFieldsWidget } from '@/page-layout/utils/createDefaultFieldsWidget';
+import { createDefaultRecordTableWidget } from '@/page-layout/utils/createDefaultRecordTableWidget';
 import { isVerticalListPosition } from '@/page-layout/utils/isVerticalListPosition';
 import { removeWidgetFromTab } from '@/page-layout/utils/removeWidgetFromTab';
 import { useFieldWidgetEligibleFields } from '@/page-layout/widgets/field/hooks/useFieldWidgetEligibleFields';
+import { useAddDraftViewForRecordTableWidget } from '@/page-layout/widgets/record-table/hooks/useAddDraftViewForRecordTableWidget';
 import { getFieldWidgetDefaultDisplayMode } from '@/page-layout/widgets/field/utils/getFieldWidgetDisplayModeConfig';
 import { SidePanelGroup } from '@/side-panel/components/SidePanelGroup';
 import { SidePanelList } from '@/side-panel/components/SidePanelList';
@@ -31,7 +33,7 @@ import { useStore } from 'jotai';
 import { useCallback } from 'react';
 import { SidePanelPages } from 'twenty-shared/types';
 import { isDefined } from 'twenty-shared/utils';
-import { IconApps, IconList } from 'twenty-ui/icon';
+import { IconApps, IconList, IconTable } from 'twenty-ui/icon';
 import { v4 as uuidv4 } from 'uuid';
 import {
   type FrontComponent,
@@ -78,6 +80,9 @@ export const SidePanelPageLayoutRecordPageWidgetTypeSelect = () => {
 
   const { insertCreatedWidgetAtContext } =
     useInsertCreatedWidgetAtContext(pageLayoutId);
+
+  const { addDraftViewForRecordTableWidget } =
+    useAddDraftViewForRecordTableWidget(pageLayoutId);
 
   const { objectMetadataItem } = useObjectMetadataItem({
     objectNameSingular: targetObjectNameSingular,
@@ -264,6 +269,56 @@ export const SidePanelPageLayoutRecordPageWidgetTypeSelect = () => {
     tabId,
   ]);
 
+  const handleCreateViewWidget = useCallback(() => {
+    const replacePositionIndex = getExistingWidgetPositionIndex();
+    removeExistingWidgetIfReplacing();
+
+    const updatedPageLayout = store.get(pageLayoutDraftState);
+    const activeTab = updatedPageLayout.tabs.find((tab) => tab.id === tabId);
+    const positionIndex =
+      replacePositionIndex ?? activeTab?.widgets.length ?? 0;
+    const widgetId = uuidv4();
+
+    const newWidget = createDefaultRecordTableWidget({
+      id: widgetId,
+      pageLayoutTabId: tabId,
+      title: objectMetadataItem.labelPlural,
+      gridPosition: {
+        row: 0,
+        column: 0,
+        rowSpan: 6,
+        columnSpan: 12,
+      },
+      verticalListPositionIndex: positionIndex,
+      objectMetadataId: objectMetadataItem.id,
+    });
+
+    store.set(pageLayoutDraftState, (prev) => ({
+      ...prev,
+      tabs: addWidgetToTab(prev.tabs, tabId, newWidget),
+    }));
+
+    setPageLayoutEditingWidgetId(widgetId);
+    insertCreatedWidgetAtContext(widgetId);
+    addDraftViewForRecordTableWidget(widgetId, objectMetadataItem);
+
+    navigatePageLayoutSidePanel({
+      sidePanelPage: SidePanelPages.DashboardRecordTableSettings,
+      resetNavigationStack: true,
+    });
+  }, [
+    addDraftViewForRecordTableWidget,
+    getExistingWidgetPositionIndex,
+    insertCreatedWidgetAtContext,
+    navigatePageLayoutSidePanel,
+    objectMetadataItem,
+    pageLayoutDraftState,
+    removeExistingWidgetIfReplacing,
+    setPageLayoutEditingWidgetId,
+    store,
+    tabId,
+  ]);
+
   const handleCreateFrontComponentWidget = useCallback(
     (frontComponent: FrontComponent) => {
       const replacePositionIndex = getExistingWidgetPositionIndex();
@@ -331,6 +386,7 @@ export const SidePanelPageLayoutRecordPageWidgetTypeSelect = () => {
   const selectableItemIds = [
     'fields',
     'field',
+    'view',
     ...frontComponentsWithSelectItemId.map(({ selectItemId }) => selectItemId),
   ];
 
@@ -351,6 +407,14 @@ export const SidePanelPageLayoutRecordPageWidgetTypeSelect = () => {
             label={t`Field`}
             id="field"
             onClick={handleCreateFieldWidget}
+          />
+        </SelectableListItem>
+        <SelectableListItem itemId="view" onEnter={handleCreateViewWidget}>
+          <CommandMenuItem
+            Icon={IconTable}
+            label={t`View`}
+            id="view"
+            onClick={handleCreateViewWidget}
           />
         </SelectableListItem>
       </SidePanelGroup>


### PR DESCRIPTION
## Context

Stacked on #22963. Brings the **View widget** — table, grouped table, kanban, and calendar — to **record page layouts**, so a record page can host e.g. an opportunities board next to the timeline.

The renderer, settings panel, and save pipeline from #22963 were already layout-type-agnostic: the widget content switch branches on widget type only, `useSaveLayoutCustomization` (the record-page save) already ran `createPendingRecordTableWidgetViews` and `saveRecordTableWidgetViews`, and the server never gated widget persistence by layout type. The restriction to dashboards was two front-end decision points, which is the whole diff:

## What this does

- **Add-widget menu.** The record page widget-type menu (`SidePanelPageLayoutRecordPageWidgetTypeSelect`) gains a *View* item. It creates a `RECORD_TABLE` widget with a vertical-list position (record page tabs are vertical lists, not grids), defaults the source to the page's own object, seeds the draft view through the same `useAddDraftViewForRecordTableWidget` flow dashboards use, and opens the existing settings panel.
- **`createDefaultRecordTableWidget`** accepts an optional `verticalListPositionIndex` so the same util serves both tab layout modes.
- **Widget settings on click.** `useOpenWidgetSettingsInSidePanel` no longer early-returns for `RECORD_TABLE` outside dashboards — clicking a view widget on a record page opens the same settings panel (Layout / Source / Group by / Date field / Fields / Filter / Sort).

No server changes; no changes to the widget renderer or persistence.

## Scope

- The widget shows **all records of the source object** (same as on dashboards). Scoping a record-page view widget to records related to the current record (e.g. "this company's opportunities") is a natural follow-up: the injection pattern already exists in `FieldWidgetRelationTable` (`RecordFilterValueDependenciesContext` + relation-scoped view), and needs a settings row to pick the relation.
- The settings panel keeps its `SidePanelPages.DashboardRecordTableSettings` name; renaming it now that it serves both layout types is deliberate follow-up cleanup, kept out of this diff.

## Test

- Browser-verified end-to-end on a seeded workspace: opportunity record page → Edit Layout → More widgets → **View** → Layout: Kanban → board renders grouped by Stage in the edit preview → Save (`upsertViewWidget` returned the server-generated view groups) → reload → the board persists and renders on the record page. Layout restored afterwards.
- `twenty-front` typecheck, oxlint, and unit tests green (197 suites / 1308 tests across page-layout + side-panel).

https://claude.ai/code/session_01E5N87kwwZWhDtEQaP72cMf

---
_Generated by [Claude Code](https://claude.ai/code/session_01E5N87kwwZWhDtEQaP72cMf)_

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/23003?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

