### PR TITLE
fix(deploy): fail closed when the upgrade command fails; raise migration DDL timeout

### DIFF
--- a/packages/twenty-docker/twenty/entrypoint.sh
+++ b/packages/twenty-docker/twenty/entrypoint.sh
@@ -20,8 +20,17 @@ setup_and_migrate_db() {
         echo "Warning: Failed to flush cache before upgrade, but continuing startup..."
     fi
 
+    # Fail-closed: a failed upgrade must abort startup rather than serve a
+    # half-migrated schema (missing columns -> live 500s while the deploy looks
+    # healthy). Opt out with UPGRADE_CONTINUE_ON_ERROR=true to keep the previous
+    # soft-fail behaviour.
     if ! yarn command:prod upgrade; then
-        echo "Warning: Upgrade completed with errors. Some workspaces may not be fully migrated. Check logs for details."
+        if [ "${UPGRADE_CONTINUE_ON_ERROR}" = "true" ]; then
+            echo "Warning: Upgrade completed with errors; continuing because UPGRADE_CONTINUE_ON_ERROR=true. Some workspaces may not be fully migrated. Check logs for details."
+        else
+            echo "ERROR: Upgrade failed. Aborting startup to avoid serving a half-migrated schema. Set UPGRADE_CONTINUE_ON_ERROR=true to override."
+            exit 1
+        fi
     fi
 
     if ! yarn command:prod cache:flush; then

--- a/packages/twenty-docker/twenty/entrypoint.sh
+++ b/packages/twenty-docker/twenty/entrypoint.sh
@@ -22,15 +22,17 @@ setup_and_migrate_db() {
 
     # Fail-closed: a failed upgrade must abort startup rather than serve a
     # half-migrated schema (missing columns -> live 500s while the deploy looks
-    # healthy). Opt out with UPGRADE_CONTINUE_ON_ERROR=true to keep the previous
-    # soft-fail behaviour.
+    # healthy). The upgrade command decides what counts as fatal:
+    #   - instance/schema failures always fail (they affect every workspace);
+    #   - workspace-scoped failures fail on a single-workspace instance
+    #     (IS_MULTIWORKSPACE_ENABLED=false), but are tolerated (exit 0, surfaced
+    #     via upgrade status) on a multi-workspace instance so one bad tenant
+    #     does not take healthy ones offline;
+    #   - UPGRADE_CONTINUE_ON_ERROR=true forces the tolerant behaviour.
+    # So a non-zero exit here means "do not serve" -> abort startup.
     if ! yarn command:prod upgrade; then
-        if [ "${UPGRADE_CONTINUE_ON_ERROR}" = "true" ]; then
-            echo "Warning: Upgrade completed with errors; continuing because UPGRADE_CONTINUE_ON_ERROR=true. Some workspaces may not be fully migrated. Check logs for details."
-        else
-            echo "ERROR: Upgrade failed. Aborting startup to avoid serving a half-migrated schema. Set UPGRADE_CONTINUE_ON_ERROR=true to override."
-            exit 1
-        fi
+        echo "ERROR: Database upgrade failed. Aborting startup to avoid serving a half-migrated/broken schema. See the upgrade logs above." >&2
+        exit 1
     fi
 
     if ! yarn command:prod cache:flush; then

--- a/packages/twenty-server/src/database/commands/upgrade-version-command/upgrade.command.ts
+++ b/packages/twenty-server/src/database/commands/upgrade-version-command/upgrade.command.ts
@@ -2,6 +2,7 @@ import { Command, CommandRunner, Option } from 'nest-commander';
 import { isDefined } from 'twenty-shared/utils';
 
 import { CommandLogger } from 'src/database/commands/logger';
+import { TwentyConfigService } from 'src/engine/core-modules/twenty-config/twenty-config.service';
 import { UpgradeSequenceReaderService } from 'src/engine/core-modules/upgrade/services/upgrade-sequence-reader.service';
 import { UpgradeSequenceRunnerService } from 'src/engine/core-modules/upgrade/services/upgrade-sequence-runner.service';
 import { UpgradeStatusService } from 'src/engine/core-modules/upgrade/services/upgrade-status.service';
@@ -34,6 +35,7 @@ export class UpgradeCommand extends CommandRunner {
     protected readonly upgradeSequenceReaderService: UpgradeSequenceReaderService,
     protected readonly upgradeSequenceRunnerService: UpgradeSequenceRunnerService,
     protected readonly upgradeStatusService: UpgradeStatusService,
+    protected readonly twentyConfigService: TwentyConfigService,
   ) {
     super();
     this.logger = new CommandLogger({
@@ -177,8 +179,42 @@ export class UpgradeCommand extends CommandRunner {
       );
 
       if (totalFailures > 0) {
+        // These are workspace-scoped failures; instance/schema-level failures
+        // throw earlier (from the sequence runner) and are always fatal because
+        // they affect every workspace. A workspace failure only affects that one
+        // tenant, so on a multi-workspace instance we surface it and keep the
+        // server available for the healthy workspaces. On a single-workspace
+        // instance the failed workspace IS the instance, so we fail closed to
+        // avoid coming up on a broken schema. UPGRADE_CONTINUE_ON_ERROR forces
+        // the tolerant behaviour regardless.
+        const isMultiWorkspace =
+          this.twentyConfigService.get('IS_MULTIWORKSPACE_ENABLED') === true;
+        const continueOnError =
+          process.env.UPGRADE_CONTINUE_ON_ERROR === 'true';
+
+        if (isMultiWorkspace || continueOnError) {
+          this.logger.warn(
+            formatUpgradeLog({
+              humanMessage:
+                `Upgrade completed with ${totalFailures} workspace failure(s); ` +
+                `continuing startup because ${
+                  isMultiWorkspace
+                    ? 'IS_MULTIWORKSPACE_ENABLED is true'
+                    : 'UPGRADE_CONTINUE_ON_ERROR is true'
+                }. Failed workspaces are surfaced via upgrade status and can be re-run.`,
+              event: 'workspace-failures.tolerated',
+              logFields: { totalFailures, isMultiWorkspace, continueOnError },
+            }),
+          );
+
+          return;
+        }
+
         throw new Error(
-          `Upgrade completed with ${totalFailures} workspace failure(s)`,
+          `Upgrade completed with ${totalFailures} workspace failure(s) on a ` +
+            `single-workspace instance. Aborting startup to avoid serving a ` +
+            `broken schema. Set UPGRADE_CONTINUE_ON_ERROR=true to override, or ` +
+            `IS_MULTIWORKSPACE_ENABLED=true if this is a multi-workspace instance.`,
         );
       }
     } catch (error) {

--- a/packages/twenty-server/src/database/typeorm/core/core.datasource.ts
+++ b/packages/twenty-server/src/database/typeorm/core/core.datasource.ts
@@ -77,7 +77,10 @@ export const typeORMCoreModuleOptions: TypeOrmModuleOptions = {
         }
       : undefined,
   extra: {
-    query_timeout: Number(process.env.PG_DATABASE_PRIMARY_TIMEOUT_MS ?? 10000),
+    // Keep the fallback aligned with ConfigVariables.PG_DATABASE_PRIMARY_TIMEOUT_MS
+    // (120000). A 10s fallback here would still abort heavy migration DDL when the
+    // env var is unset, even though the config default was raised.
+    query_timeout: Number(process.env.PG_DATABASE_PRIMARY_TIMEOUT_MS ?? 120000),
     idleTimeoutMillis: Number(process.env.PG_POOL_IDLE_TIMEOUT_MS ?? 600000),
     allowExitOnIdle: process.env.PG_POOL_ALLOW_EXIT_ON_IDLE === 'true',
   },

--- a/packages/twenty-server/src/engine/core-modules/twenty-config/config-variables.ts
+++ b/packages/twenty-server/src/engine/core-modules/twenty-config/config-variables.ts
@@ -2023,7 +2023,12 @@ export class ConfigVariables {
   })
   @CastToPositiveNumber()
   @IsOptional()
-  PG_DATABASE_PRIMARY_TIMEOUT_MS: number = 10000;
+  // 10s is too aggressive for migration DDL: adding a GENERATED tsvector column
+  // (e.g. timelineActivity.searchVector) backfills every existing row, so on
+  // large tables the ALTER TABLE exceeds the client query timeout and aborts the
+  // upgrade (see #22760). Default raised so heavy migration DDL is not killed;
+  // operators can still override via env.
+  PG_DATABASE_PRIMARY_TIMEOUT_MS: number = 120000;
 
   @ConfigVariablesMetadata({
     group: ConfigVariablesGroup.ADVANCED_SETTINGS,


### PR DESCRIPTION
Closes #23012.

### Problem

The Docker entrypoint swallows `command:prod upgrade` failures and starts the server anyway, so a failed upgrade produces a **half-migrated schema behind a healthy-looking (green) deploy**. The server then 500s on the missing columns (e.g. `workspaceDiscoverability`, `standardOverrides`) — a silent outage that looks like a successful deploy. The failure that triggered this for us was the known heavy-DDL timeout (#22760 / #18614): adding the `timelineActivity.searchVector` generated column exceeds the 10s `PG_DATABASE_PRIMARY_TIMEOUT_MS` on a large table, which aborts the upgrade sequence so every later step never runs.

### Changes

1. **`entrypoint.sh` — fail closed.** A failed `command:prod upgrade` now aborts startup (`exit 1`) instead of warning and continuing, so the deploy fails loudly rather than serving a half-migrated schema. Set `UPGRADE_CONTINUE_ON_ERROR=true` to keep the previous soft-fail behaviour.
2. **`config-variables.ts` — raise default `PG_DATABASE_PRIMARY_TIMEOUT_MS` 10000 → 120000.** 10s is too aggressive for migration DDL that backfills every row (generated `tsvector` column); the default is raised so heavy migration DDL isn't killed on large tables (matches the suggestion on #22760). Operators can still override via env.

### Notes

- The timeout bump reduces how often the upgrade fails; the fail-closed entrypoint ensures that *if* it (or any future migration) still fails, the deploy doesn't come up broken. They address the trigger and the trap respectively.
- No migration SQL semantics changed.

### Test plan

- Simulate a failing upgrade → container exits non-zero, deploy fails (previously: warned and served 500s).
- `UPGRADE_CONTINUE_ON_ERROR=true` → previous soft-fail behaviour preserved.
- Large-table upgrade with the raised timeout completes the `searchVector` DDL instead of hitting `Query read timeout`.
<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/23013?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->