### PR TITLE
fix(deploy): fail closed on upgrade failure to avoid half-migrated schema

### DIFF
--- a/packages/twenty-docker/twenty/entrypoint.sh
+++ b/packages/twenty-docker/twenty/entrypoint.sh
@@ -20,8 +20,19 @@ setup_and_migrate_db() {
         echo "Warning: Failed to flush cache before upgrade, but continuing startup..."
     fi
 
+    # Fail-closed: a failed upgrade must abort startup rather than serve a
+    # half-migrated schema (missing columns -> live 500s while the deploy looks
+    # healthy). The upgrade command decides what counts as fatal:
+    #   - instance/schema failures always fail (they affect every workspace);
+    #   - workspace-scoped failures fail on a single-workspace instance
+    #     (IS_MULTIWORKSPACE_ENABLED=false), but are tolerated (exit 0, surfaced
+    #     via upgrade status) on a multi-workspace instance so one bad tenant
+    #     does not take healthy ones offline;
+    #   - UPGRADE_CONTINUE_ON_ERROR=true forces the tolerant behaviour.
+    # So a non-zero exit here means "do not serve" -> abort startup.
     if ! yarn command:prod upgrade; then
-        echo "Warning: Upgrade completed with errors. Some workspaces may not be fully migrated. Check logs for details."
+        echo "ERROR: Database upgrade failed. Aborting startup to avoid serving a half-migrated/broken schema. See the upgrade logs above." >&2
+        exit 1
     fi
 
     if ! yarn command:prod cache:flush; then

--- a/packages/twenty-server/src/database/commands/upgrade-version-command/upgrade.command.ts
+++ b/packages/twenty-server/src/database/commands/upgrade-version-command/upgrade.command.ts
@@ -2,6 +2,8 @@ import { Command, CommandRunner, Option } from 'nest-commander';
 import { isDefined } from 'twenty-shared/utils';
 
 import { CommandLogger } from 'src/database/commands/logger';
+import { shouldTolerateUpgradeWorkspaceFailures } from 'src/database/commands/upgrade-version-command/utils/should-tolerate-upgrade-workspace-failures.util';
+import { TwentyConfigService } from 'src/engine/core-modules/twenty-config/twenty-config.service';
 import { UpgradeSequenceReaderService } from 'src/engine/core-modules/upgrade/services/upgrade-sequence-reader.service';
 import { UpgradeSequenceRunnerService } from 'src/engine/core-modules/upgrade/services/upgrade-sequence-runner.service';
 import { UpgradeStatusService } from 'src/engine/core-modules/upgrade/services/upgrade-status.service';
@@ -34,6 +36,7 @@ export class UpgradeCommand extends CommandRunner {
     protected readonly upgradeSequenceReaderService: UpgradeSequenceReaderService,
     protected readonly upgradeSequenceRunnerService: UpgradeSequenceRunnerService,
     protected readonly upgradeStatusService: UpgradeStatusService,
+    protected readonly twentyConfigService: TwentyConfigService,
   ) {
     super();
     this.logger = new CommandLogger({
@@ -177,8 +180,51 @@ export class UpgradeCommand extends CommandRunner {
       );
 
       if (totalFailures > 0) {
+        // These are workspace-scoped failures; instance/schema-level failures
+        // throw earlier (from the sequence runner) and are always fatal because
+        // they affect every workspace. A workspace failure only affects that one
+        // tenant, so on a multi-workspace instance we surface it and keep the
+        // server available for the healthy workspaces. On a single-workspace
+        // instance the failed workspace IS the instance, so we fail closed to
+        // avoid coming up on a broken schema. UPGRADE_CONTINUE_ON_ERROR forces
+        // the tolerant behaviour regardless.
+        const isMultiWorkspaceEnabled =
+          this.twentyConfigService.get('IS_MULTIWORKSPACE_ENABLED') === true;
+        const continueOnError =
+          process.env.UPGRADE_CONTINUE_ON_ERROR === 'true';
+
+        if (
+          shouldTolerateUpgradeWorkspaceFailures({
+            isMultiWorkspaceEnabled,
+            continueOnError,
+          })
+        ) {
+          this.logger.warn(
+            formatUpgradeLog({
+              humanMessage:
+                `Upgrade completed with ${totalFailures} workspace failure(s); ` +
+                `continuing startup because ${
+                  isMultiWorkspaceEnabled
+                    ? 'IS_MULTIWORKSPACE_ENABLED is true'
+                    : 'UPGRADE_CONTINUE_ON_ERROR is true'
+                }. Failed workspaces are surfaced via upgrade status and can be re-run.`,
+              event: 'workspace-failures.tolerated',
+              logFields: {
+                totalFailures,
+                isMultiWorkspaceEnabled,
+                continueOnError,
+              },
+            }),
+          );
+
+          return;
+        }
+
         throw new Error(
-          `Upgrade completed with ${totalFailures} workspace failure(s)`,
+          `Upgrade completed with ${totalFailures} workspace failure(s) on a ` +
+            `single-workspace instance. Aborting startup to avoid serving a ` +
+            `broken schema. Set UPGRADE_CONTINUE_ON_ERROR=true to override, or ` +
+            `IS_MULTIWORKSPACE_ENABLED=true if this is a multi-workspace instance.`,
         );
       }
     } catch (error) {

--- a/packages/twenty-server/src/database/commands/upgrade-version-command/utils/__tests__/should-tolerate-upgrade-workspace-failures.util.spec.ts
+++ b/packages/twenty-server/src/database/commands/upgrade-version-command/utils/__tests__/should-tolerate-upgrade-workspace-failures.util.spec.ts
@@ -1,0 +1,39 @@
+import { shouldTolerateUpgradeWorkspaceFailures } from 'src/database/commands/upgrade-version-command/utils/should-tolerate-upgrade-workspace-failures.util';
+
+describe('shouldTolerateUpgradeWorkspaceFailures', () => {
+  it('should fail closed on a single-workspace instance without override', () => {
+    expect(
+      shouldTolerateUpgradeWorkspaceFailures({
+        isMultiWorkspaceEnabled: false,
+        continueOnError: false,
+      }),
+    ).toBe(false);
+  });
+
+  it('should tolerate workspace failures when multi-workspace is enabled', () => {
+    expect(
+      shouldTolerateUpgradeWorkspaceFailures({
+        isMultiWorkspaceEnabled: true,
+        continueOnError: false,
+      }),
+    ).toBe(true);
+  });
+
+  it('should tolerate workspace failures when UPGRADE_CONTINUE_ON_ERROR is set', () => {
+    expect(
+      shouldTolerateUpgradeWorkspaceFailures({
+        isMultiWorkspaceEnabled: false,
+        continueOnError: true,
+      }),
+    ).toBe(true);
+  });
+
+  it('should tolerate when both multi-workspace and continue-on-error are set', () => {
+    expect(
+      shouldTolerateUpgradeWorkspaceFailures({
+        isMultiWorkspaceEnabled: true,
+        continueOnError: true,
+      }),
+    ).toBe(true);
+  });
+});

--- a/packages/twenty-server/src/database/commands/upgrade-version-command/utils/should-tolerate-upgrade-workspace-failures.util.ts
+++ b/packages/twenty-server/src/database/commands/upgrade-version-command/utils/should-tolerate-upgrade-workspace-failures.util.ts
@@ -1,0 +1,14 @@
+// Workspace-scoped upgrade failures only affect the failed tenant.
+// Instance/schema-level failures throw earlier and are always fatal.
+//
+// On a single-workspace instance the failed workspace is the product, so
+// continuing would serve a half-migrated schema (live 500s behind a green
+// deploy). On multi-workspace, or when explicitly opted out, tolerate the
+// failure so healthy tenants stay available and re-run later via upgrade status.
+export const shouldTolerateUpgradeWorkspaceFailures = ({
+  isMultiWorkspaceEnabled,
+  continueOnError,
+}: {
+  isMultiWorkspaceEnabled: boolean;
+  continueOnError: boolean;
+}): boolean => isMultiWorkspaceEnabled || continueOnError;

--- a/packages/twenty-server/src/database/typeorm/core/core.datasource.ts
+++ b/packages/twenty-server/src/database/typeorm/core/core.datasource.ts
@@ -77,7 +77,10 @@ export const typeORMCoreModuleOptions: TypeOrmModuleOptions = {
         }
       : undefined,
   extra: {
-    query_timeout: Number(process.env.PG_DATABASE_PRIMARY_TIMEOUT_MS ?? 10000),
+    // Keep the fallback aligned with ConfigVariables.PG_DATABASE_PRIMARY_TIMEOUT_MS
+    // (120000). A 10s fallback here would still abort heavy migration DDL when the
+    // env var is unset, even though the config default was raised.
+    query_timeout: Number(process.env.PG_DATABASE_PRIMARY_TIMEOUT_MS ?? 120000),
     idleTimeoutMillis: Number(process.env.PG_POOL_IDLE_TIMEOUT_MS ?? 600000),
     allowExitOnIdle: process.env.PG_POOL_ALLOW_EXIT_ON_IDLE === 'true',
   },

--- a/packages/twenty-server/src/engine/core-modules/twenty-config/config-variables.ts
+++ b/packages/twenty-server/src/engine/core-modules/twenty-config/config-variables.ts
@@ -2023,7 +2023,12 @@ export class ConfigVariables {
   })
   @CastToPositiveNumber()
   @IsOptional()
-  PG_DATABASE_PRIMARY_TIMEOUT_MS: number = 10000;
+  // 10s is too aggressive for migration DDL: adding a GENERATED tsvector column
+  // (e.g. timelineActivity.searchVector) backfills every existing row, so on
+  // large tables the ALTER TABLE exceeds the client query timeout and aborts the
+  // upgrade (see #22760). Default raised so heavy migration DDL is not killed;
+  // operators can still override via env.
+  PG_DATABASE_PRIMARY_TIMEOUT_MS: number = 120000;
 
   @ConfigVariablesMetadata({
     group: ConfigVariablesGroup.ADVANCED_SETTINGS,


### PR DESCRIPTION
## Problem

Closes #23012.

On self-hosted Docker deployments, when `yarn command:prod upgrade` fails, `packages/twenty-docker/twenty/entrypoint.sh` **swallows the error and starts the server anyway**. The container comes up, `/healthz` returns 200, and the deployment platform marks the deploy **successful** — while the database is only **partially migrated**. The result is a live outage (core queries `500` with `column ... does not exist`) that looks like a green deploy.

This was previously attempted in #23013 (closed unmerged). This PR incorporates that review feedback:
1. Fail-closed entrypoint
2. Multi-tenant-safe workspace failure tolerance
3. Align `core.datasource.ts` fallback with the raised config default (not just config-variables)

## Changes

1. **`entrypoint.sh` — fail closed.** A failed `command:prod upgrade` now aborts startup (`exit 1`) instead of warning and continuing, so the deploy fails loudly rather than serving a half-migrated schema.

2. **`upgrade.command.ts` — multi-tenant-aware failure policy.**
   - Instance/schema-level failures still throw (always fatal).
   - Workspace-scoped failures (`totalFailures > 0`):
     - **Fail closed** on single-workspace instances (default self-hosted).
     - **Tolerate** when `IS_MULTIWORKSPACE_ENABLED=true` (one bad tenant must not take healthy ones offline).
     - **Tolerate** when `UPGRADE_CONTINUE_ON_ERROR=true` (explicit opt-out).
   - Policy is extracted to a pure util with unit tests covering edge cases.

3. **`PG_DATABASE_PRIMARY_TIMEOUT_MS` default `10000` → `120000`** in config-variables **and** the `core.datasource.ts` env fallback (so unset env still gets 120s for heavy migration DDL like `timelineActivity.searchVector`).

## Edge cases covered

| Scenario | Behavior |
|---|---|
| Upgrade fails, single-workspace | Container exits non-zero; deploy fails |
| Upgrade fails, multi-workspace | Server starts; failures logged + upgrade status |
| `UPGRADE_CONTINUE_ON_ERROR=true` | Soft-fail preserved (ops override) |
| Instance/schema failure | Always fatal (throws before workspace tally) |
| Heavy DDL on large tables | Less likely to hit 10s client timeout mid-sequence |

## Test plan

- [x] Unit tests for `shouldTolerateUpgradeWorkspaceFailures` (4 cases pass)
- [ ] Simulate failing upgrade on single-workspace → container exits non-zero
- [ ] `UPGRADE_CONTINUE_ON_ERROR=true` → previous soft-fail behaviour preserved
- [ ] Multi-workspace with one failed tenant → server still starts
- [ ] Large-table upgrade with raised timeout can complete generated-column DDL

## Notes

- No migration SQL semantics changed.
- Related: #22760, #18614, #18657, prior attempt #23013.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/23017?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

