### PR TITLE
fix(website): add RFC 9116 mandatory Expires field to security.txt

### DIFF
--- a/packages/twenty-website/public/.well-known/security.txt
+++ b/packages/twenty-website/public/.well-known/security.txt
@@ -1,5 +1,6 @@
-Contact: https://github.com/twentyhq/twenty/issues/new
+﻿Contact: https://github.com/twentyhq/twenty/issues/new
 Contact: security@twenty.com
+Expires: 2027-07-19T00:00:00.000Z
 Preferred-Languages: en
 Canonical: https://twenty.com/.well-known/security.txt
 Policy: https://github.com/twentyhq/twenty/security/policy


### PR DESCRIPTION
## Summary

Closes #22866.

Adds the RFC 9116-required `Expires` field to `packages/twenty-website/public/.well-known/security.txt` so the file is conformant for VDP discovery tooling.

## Test plan

- [x] `Expires` present and within one year of publication
- [ ] File still served at `https://twenty.com/.well-known/security.txt` after deploy

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/23018?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

