### PR TITLE
fix(server): apply watched-fields filter on upserted database events

### DIFF
--- a/packages/twenty-server/src/engine/core-modules/logic-function/logic-function-trigger/triggers/database-event/utils/__tests__/transform-event-batch-to-event-payloads.spec.ts
+++ b/packages/twenty-server/src/engine/core-modules/logic-function/logic-function-trigger/triggers/database-event/utils/__tests__/transform-event-batch-to-event-payloads.spec.ts
@@ -424,6 +424,104 @@ describe('transformEventBatchToEventPayloads', () => {
     });
   });
 
+  describe('upserted updatedFields filtering', () => {
+    it('should filter upserted events to only those matching watched fields', () => {
+      const workspaceEventBatch = createMockWorkspaceEventBatch({
+        name: 'company.upserted',
+        events: [
+          createMockEvent({
+            recordId: 'record-1',
+            properties: { after: {}, updatedFields: ['name'] },
+          }),
+          createMockEvent({
+            recordId: 'record-2',
+            properties: { after: {}, updatedFields: ['address'] },
+          }),
+        ],
+      });
+      const logicFunctions = [
+        createMockLogicFunction({
+          databaseEventTriggerSettings: {
+            eventName: 'company.upserted',
+            updatedFields: ['name'],
+          },
+        }),
+      ];
+
+      const result = transformEventBatchToEventPayloads({
+        workspaceEventBatch,
+        logicFunctions,
+      });
+
+      expect(result).toHaveLength(1);
+      expect((result[0].payload as ObjectRecordEvent).recordId).toBe(
+        'record-1',
+      );
+    });
+
+    it('should keep pure-create upserts with no updatedFields when a watch list is set', () => {
+      const workspaceEventBatch = createMockWorkspaceEventBatch({
+        name: 'company.upserted',
+        events: [
+          createMockEvent({
+            recordId: 'record-create',
+            properties: { after: {} },
+          }),
+          createMockEvent({
+            recordId: 'record-update-other-field',
+            properties: { after: {}, updatedFields: ['address'] },
+          }),
+        ],
+      });
+      const logicFunctions = [
+        createMockLogicFunction({
+          databaseEventTriggerSettings: {
+            eventName: 'company.upserted',
+            updatedFields: ['name'],
+          },
+        }),
+      ];
+
+      const result = transformEventBatchToEventPayloads({
+        workspaceEventBatch,
+        logicFunctions,
+      });
+
+      expect(result).toHaveLength(1);
+      expect((result[0].payload as ObjectRecordEvent).recordId).toBe(
+        'record-create',
+      );
+    });
+
+    it('should include all upserted events when no updatedFields filter is configured', () => {
+      const workspaceEventBatch = createMockWorkspaceEventBatch({
+        name: 'company.upserted',
+        events: [
+          createMockEvent({
+            recordId: 'record-1',
+            properties: { after: {}, updatedFields: ['name'] },
+          }),
+          createMockEvent({
+            recordId: 'record-2',
+            properties: { after: {}, updatedFields: ['address'] },
+          }),
+        ],
+      });
+      const logicFunctions = [
+        createMockLogicFunction({
+          databaseEventTriggerSettings: { eventName: 'company.upserted' },
+        }),
+      ];
+
+      const result = transformEventBatchToEventPayloads({
+        workspaceEventBatch,
+        logicFunctions,
+      });
+
+      expect(result).toHaveLength(2);
+    });
+  });
+
   describe('edge cases', () => {
     it('should return empty array when no logic functions provided', () => {
       const workspaceEventBatch = createMockWorkspaceEventBatch();

--- a/packages/twenty-server/src/engine/core-modules/logic-function/logic-function-trigger/triggers/database-event/utils/transform-event-batch-to-event-payloads.ts
+++ b/packages/twenty-server/src/engine/core-modules/logic-function/logic-function-trigger/triggers/database-event/utils/transform-event-batch-to-event-payloads.ts
@@ -44,6 +44,14 @@ export const transformEventBatchToEventPayloads = ({
   return result;
 };
 
+const isFieldFilterableDatabaseEventOperation = (
+  operation: string,
+): boolean => operation === 'updated' || operation === 'upserted';
+
+// Aligns with the classic workflow listener: field-scope both `updated` and
+// `upserted`. Pure-create upserts (no before-record / empty updatedFields) still
+// pass so first-time processing is not dropped; update-path upserts whose
+// changed fields do not intersect the watched set are filtered out.
 const filterEventsByUpdatedFields = ({
   events,
   operation,
@@ -53,7 +61,7 @@ const filterEventsByUpdatedFields = ({
   operation: string;
   triggerUpdatedFields?: string[];
 }): ObjectRecordEvent[] => {
-  if (operation !== 'updated') {
+  if (!isFieldFilterableDatabaseEventOperation(operation)) {
     return events;
   }
 
@@ -67,7 +75,9 @@ const filterEventsByUpdatedFields = ({
     )?.updatedFields;
 
     if (!isDefined(eventUpdatedFields) || eventUpdatedFields.length === 0) {
-      return false;
+      // Pure create path of an upsert has no field diff — keep it.
+      // For plain `updated`, empty updatedFields means nothing to match.
+      return operation === 'upserted';
     }
 
     return eventUpdatedFields.some((fieldName: string) =>


### PR DESCRIPTION
﻿## Summary

Closes #22876.

Logic-function database-event triggers only field-scoped `updated` events. `upserted` bypassed the filter entirely, so workflows with "Fields to watch" still fired on every upsert — including self-write loops from enrichment actions.

### Fix
- Apply the same watched-fields filter for `updated` and `upserted` (matches the classic workflow listener).
- Pure-create upserts (no `updatedFields`) still pass so first-time processing is not dropped.
- Update-path upserts that only change non-watched fields are filtered out.

## Test plan
- [x] Unit tests for upserted filter match / miss / pure-create / no filter
- [x] Existing updated-field tests still pass


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/23019?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

