### PR TITLE
fix(server): honor OIDC issuer id_token signing algorithms

### DIFF
--- a/packages/twenty-server/src/engine/core-modules/sso/services/sso.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/sso/services/sso.service.ts
@@ -194,11 +194,28 @@ export class SSOService {
       );
     }
 
+    // openid-client defaults to expecting an RS256-signed id_token and rejects
+    // anything else ("unexpected JWT alg received, expected RS256, got: ...").
+    // Align the client with the algorithm the issuer actually advertises so
+    // IdPs signing with EC/EdDSA algorithms (e.g. Logto uses ES384) work too.
+    // Prefer a commonly supported RSA alg when the issuer lists several, then
+    // fall back to the first advertised value, then RS256.
+    const supportedIdTokenAlgs = issuer.metadata
+      .id_token_signing_alg_values_supported as string[] | undefined;
+    const preferredIdTokenAlgs = ['RS256', 'ES256', 'ES384', 'ES512', 'EdDSA'];
+    const idTokenSignedResponseAlg =
+      preferredIdTokenAlgs.find((algorithm) =>
+        supportedIdTokenAlgs?.includes(algorithm),
+      ) ??
+      supportedIdTokenAlgs?.[0] ??
+      'RS256';
+
     return new issuer.Client({
       client_id: identityProvider.clientID,
       client_secret: identityProvider.clientSecret,
       redirect_uris: [this.buildCallbackUrl(identityProvider)],
       response_types: [OIDCResponseType.CODE],
+      id_token_signed_response_alg: idTokenSignedResponseAlg,
     });
   }
 


### PR DESCRIPTION
﻿## Summary

Closes #22780.

OIDC SSO failed for identity providers that sign ID tokens with non-RS256 algorithms (e.g. Logto ES384). `openid-client` defaults `id_token_signed_response_alg` to `RS256` when unset, so `client.callback()` threw `unexpected JWT alg received`.

### Fix
Set `id_token_signed_response_alg` from the issuer discovery document (`id_token_signing_alg_values_supported`), preferring `RS256` / common EC / EdDSA algs, then the first advertised value, then `RS256`.

## Test plan
- [ ] Configure OIDC IdP with ES384-only id_token signing (e.g. Logto)
- [ ] SSO login completes instead of redirecting to Unauthorized
- [ ] RS256-only IdPs still work


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/23020?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

