### PR TITLE
fix(server): prevent OAuth propagator open redirect in single-workspace mode

### DIFF
--- a/packages/twenty-server/src/engine/core-modules/auth/controllers/__tests__/oauth-propagator.controller.spec.ts
+++ b/packages/twenty-server/src/engine/core-modules/auth/controllers/__tests__/oauth-propagator.controller.spec.ts
@@ -1,0 +1,158 @@
+import { ForbiddenException } from '@nestjs/common';
+
+import { OAuthPropagatorController } from 'src/engine/core-modules/auth/controllers/oauth-propagator.controller';
+import { NodeEnvironment } from 'src/engine/core-modules/twenty-config/interfaces/node-environment.interface';
+
+describe('OAuthPropagatorController', () => {
+  const createController = ({
+    isMultiWorkspaceEnabled = false,
+    nodeEnv = NodeEnvironment.PRODUCTION,
+    frontHostname = 'app.example.com',
+    findByCustomDomainResult = null as { id: string } | null,
+    publicDomainResult = null as { domain: string } | null,
+    workspaceByOriginResult = null as { id: string } | null,
+  } = {}) => {
+    const domainServerConfigService = {
+      getFrontUrl: jest.fn(() => new URL(`https://${frontHostname}`)),
+    };
+    const twentyConfigService = {
+      get: jest.fn((key: string) => {
+        if (key === 'NODE_ENV') {
+          return nodeEnv;
+        }
+        if (key === 'IS_MULTIWORKSPACE_ENABLED') {
+          return isMultiWorkspaceEnabled;
+        }
+
+        return undefined;
+      }),
+    };
+    const workspaceDomainsService = {
+      findByCustomDomain: jest.fn(async () => findByCustomDomainResult),
+      resolveWorkspaceAndPublicDomain: jest.fn(async () => ({
+        workspace: undefined,
+        publicDomain: publicDomainResult,
+        isIsolatedOrigin: publicDomainResult !== null,
+      })),
+      getWorkspaceByOriginOrDefaultWorkspace: jest.fn(
+        async () => workspaceByOriginResult,
+      ),
+    };
+
+    const controller = new OAuthPropagatorController(
+      domainServerConfigService as never,
+      twentyConfigService as never,
+      workspaceDomainsService as never,
+    );
+
+    return { controller, workspaceDomainsService };
+  };
+
+  const callPropagate = async (
+    controller: OAuthPropagatorController,
+    state: string,
+  ) => {
+    const res = {
+      redirect: jest.fn(),
+    };
+
+    await controller.propagateOAuthCallback(state, 'oauth-code', res as never);
+
+    return res;
+  };
+
+  it('should reject attacker hostnames in single-workspace production mode', async () => {
+    const { controller } = createController();
+
+    await expect(
+      callPropagate(
+        controller,
+        encodeURIComponent('https://attacker.example.com/phish'),
+      ),
+    ).rejects.toBeInstanceOf(ForbiddenException);
+  });
+
+  it('should allow the configured front hostname', async () => {
+    const { controller } = createController();
+
+    const res = await callPropagate(
+      controller,
+      encodeURIComponent('https://app.example.com/auth/callback'),
+    );
+
+    expect(res.redirect).toHaveBeenCalledWith(
+      302,
+      expect.stringContaining('https://app.example.com/auth/callback'),
+    );
+    expect(res.redirect).toHaveBeenCalledWith(
+      302,
+      expect.stringContaining('code=oauth-code'),
+    );
+  });
+
+  it('should allow a registered custom domain', async () => {
+    const { controller } = createController({
+      findByCustomDomainResult: { id: 'workspace-1' },
+    });
+
+    const res = await callPropagate(
+      controller,
+      encodeURIComponent('https://crm.customer.com/auth/callback'),
+    );
+
+    expect(res.redirect).toHaveBeenCalledWith(
+      302,
+      expect.stringContaining('https://crm.customer.com/auth/callback'),
+    );
+  });
+
+  it('should allow a registered public domain', async () => {
+    const { controller } = createController({
+      publicDomainResult: { domain: 'public.customer.com' },
+    });
+
+    const res = await callPropagate(
+      controller,
+      encodeURIComponent('https://public.customer.com/auth/callback'),
+    );
+
+    expect(res.redirect).toHaveBeenCalledWith(
+      302,
+      expect.stringContaining('https://public.customer.com/auth/callback'),
+    );
+  });
+
+  it('should allow multi-workspace subdomains only when a workspace resolves', async () => {
+    const { controller, workspaceDomainsService } = createController({
+      isMultiWorkspaceEnabled: true,
+      workspaceByOriginResult: { id: 'workspace-2' },
+    });
+
+    const res = await callPropagate(
+      controller,
+      encodeURIComponent('https://acme.app.example.com/auth/callback'),
+    );
+
+    expect(
+      workspaceDomainsService.getWorkspaceByOriginOrDefaultWorkspace,
+    ).toHaveBeenCalled();
+    expect(res.redirect).toHaveBeenCalledWith(
+      302,
+      expect.stringContaining('https://acme.app.example.com/auth/callback'),
+    );
+  });
+
+  it('should reject multi-workspace subdomains when no workspace resolves', async () => {
+    const { controller } = createController({
+      isMultiWorkspaceEnabled: true,
+      workspaceByOriginResult: null,
+    });
+
+    await expect(
+      callPropagate(
+        controller,
+        encodeURIComponent('https://unknown.app.example.com/auth/callback'),
+      ),
+    ).rejects.toBeInstanceOf(ForbiddenException);
+  });
+});

--- a/packages/twenty-server/src/engine/core-modules/auth/controllers/oauth-propagator.controller.ts
+++ b/packages/twenty-server/src/engine/core-modules/auth/controllers/oauth-propagator.controller.ts
@@ -69,6 +69,9 @@ export class OAuthPropagatorController {
     return res.redirect(302, redirectUrl.toString());
   }
 
+  // Do not use getWorkspaceByOriginOrDefaultWorkspace here: in single-workspace
+  // mode it always returns the default workspace for any origin, which turned
+  // this check into a no-op and allowed open redirects of OAuth codes (#22109).
   private async isValidDomain(url: URL): Promise<boolean> {
     if (
       this.twentyConfigService.get('NODE_ENV') === NodeEnvironment.DEVELOPMENT
@@ -76,11 +79,36 @@ export class OAuthPropagatorController {
       return true;
     }
 
-    const workspace =
-      await this.workspaceDomainsService.getWorkspaceByOriginOrDefaultWorkspace(
+    const frontHostname = this.domainServerConfigService.getFrontUrl().hostname;
+
+    if (url.hostname === frontHostname) {
+      return true;
+    }
+
+    if (
+      this.twentyConfigService.get('IS_MULTIWORKSPACE_ENABLED') &&
+      url.hostname.endsWith(`.${frontHostname}`)
+    ) {
+      const workspace =
+        await this.workspaceDomainsService.getWorkspaceByOriginOrDefaultWorkspace(
+          url.href,
+        );
+
+      return isDefined(workspace);
+    }
+
+    const workspaceByCustomDomain =
+      await this.workspaceDomainsService.findByCustomDomain(url.hostname);
+
+    if (isDefined(workspaceByCustomDomain)) {
+      return true;
+    }
+
+    const { publicDomain } =
+      await this.workspaceDomainsService.resolveWorkspaceAndPublicDomain(
         url.href,
       );
 
-    return isDefined(workspace);
+    return isDefined(publicDomain);
   }
 }


### PR DESCRIPTION
﻿## Summary

Closes #22109.

### Problem
`/auth/oauth-propagator/callback` treated `state` as a redirect URL and validated it via `getWorkspaceByOriginOrDefaultWorkspace`. In single-workspace mode (the default), that helper **always** returns the default workspace for any origin — so the domain check was a no-op.

Attacker PoC:

```
GET /auth/oauth-propagator/callback?state=https://attacker.example.com/phish&code=STOLEN_CODE
→ 302 Location: https://attacker.example.com/phish?code=STOLEN_CODE&...
```

### Fix
Replace the fallthrough check with explicit hostname allowlisting:
1. Configured front hostname (`FRONTEND_URL` / `SERVER_URL`)
2. Registered workspace custom domains
3. Registered public domains
4. Multi-workspace subdomains only when a workspace actually resolves

### Edge cases
- Custom domain workspaces still work
- Public domain origins still work
- Multi-workspace unknown subdomains are rejected
- Attacker hosts are rejected in single-workspace production

## Test plan
- [x] Unit tests for reject attacker / allow front / custom / public / multi-ws match & miss
- [ ] Manual: single-workspace `state=https://evil.com` → 403
- [ ] Manual: `state=<FRONTEND_URL>/...` → 302 with code


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/23021?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

