### PR TITLE
fix(admin): stop showing docker floating tag as latest version

### DIFF
--- a/packages/twenty-front/src/modules/settings/admin-panel/components/SettingsAdminVersionDisplay.tsx
+++ b/packages/twenty-front/src/modules/settings/admin-panel/components/SettingsAdminVersionDisplay.tsx
@@ -29,6 +29,25 @@ const StyledSpan = styled.span`
   font-weight: ${themeCssVariables.font.weight.regular};
 `;
 
+// Backend historically fell back to the docker tag name "latest" when it could
+// not resolve a real release version. Treat that placeholder (and empty values)
+// as "no version" so the admin panel never shows a useless "Latest" link.
+const isResolvableVersion = (
+  version: string | undefined | null,
+): version is string => {
+  if (!version) {
+    return false;
+  }
+
+  const normalizedVersion = version.trim().toLowerCase();
+
+  return (
+    normalizedVersion.length > 0 &&
+    normalizedVersion !== 'latest' &&
+    normalizedVersion !== 'unknown'
+  );
+};
+
 export const SettingsAdminVersionDisplay = ({
   version,
   loading,
@@ -38,7 +57,7 @@ export const SettingsAdminVersionDisplay = ({
     return <StyledSpan>{t`Loading...`}</StyledSpan>;
   }
 
-  if (!version) {
+  if (!isResolvableVersion(version)) {
     return <StyledSpan>{noVersionMessage}</StyledSpan>;
   }
 

--- a/packages/twenty-server/src/engine/core-modules/admin-panel/__tests__/admin-panel.service.spec.ts
+++ b/packages/twenty-server/src/engine/core-modules/admin-panel/__tests__/admin-panel.service.spec.ts
@@ -337,7 +337,7 @@ describe('AdminPanelVersionService', () => {
 
       expect(result).toEqual({
         currentVersion: '1.0.0',
-        latestVersion: 'latest',
+        latestVersion: null,
       });
     });
 
@@ -353,7 +353,7 @@ describe('AdminPanelVersionService', () => {
 
       expect(result).toEqual({
         currentVersion: '1.0.0',
-        latestVersion: 'latest',
+        latestVersion: null,
       });
     });
 
@@ -375,6 +375,28 @@ describe('AdminPanelVersionService', () => {
       expect(result).toEqual({
         currentVersion: '1.0.0',
         latestVersion: '2.0.0',
+      });
+    });
+
+    it('should resolve v-prefixed docker tags and ignore floating major/minor tags', async () => {
+      mockEnvironmentGet.mockReturnValue('2.20.0');
+      mockHttpClientGet.mockResolvedValue({
+        data: {
+          results: [
+            { name: 'latest' },
+            { name: 'v2' },
+            { name: 'v2.22' },
+            { name: 'v2.22.0' },
+            { name: 'v2.21.0' },
+          ],
+        },
+      });
+
+      const result = await versionService.getVersionInfo();
+
+      expect(result).toEqual({
+        currentVersion: '2.20.0',
+        latestVersion: '2.22.0',
       });
     });
   });

--- a/packages/twenty-server/src/engine/core-modules/admin-panel/dtos/version-info.dto.ts
+++ b/packages/twenty-server/src/engine/core-modules/admin-panel/dtos/version-info.dto.ts
@@ -5,6 +5,9 @@ export class VersionInfoDTO {
   @Field(() => String, { nullable: true })
   currentVersion?: string;
 
-  @Field(() => String)
-  latestVersion: string;
+  // Null when Docker Hub is unreachable or no numeric release tags are found.
+  // Never use the docker floating tag name "latest" here — the admin UI would
+  // display it as if it were a real version number.
+  @Field(() => String, { nullable: true })
+  latestVersion?: string | null;
 }

--- a/packages/twenty-server/src/engine/core-modules/admin-panel/services/admin-panel-version.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/admin-panel/services/admin-panel-version.service.ts
@@ -31,20 +31,23 @@ export class AdminPanelVersionService {
         })
         .parse(rawResponse);
 
+      // Prefer full x.y.z tags (docker publishes v-prefixed tags like v2.22.0).
+      // semver.clean accepts an optional leading "v"; floating tags (latest, v2,
+      // v2.22) clean to null and are excluded.
       const versions = response.data.results
-        .map((tag) => tag.name)
-        .filter((name) => name !== 'latest' && semver.valid(name));
+        .map((tag) => semver.clean(tag.name))
+        .filter((name): name is string => name !== null);
 
       if (versions.length === 0) {
-        return { currentVersion, latestVersion: 'latest' };
+        return { currentVersion, latestVersion: null };
       }
 
-      versions.sort((a, b) => semver.compare(b, a));
+      versions.sort((a, b) => semver.rcompare(a, b));
       const latestVersion = versions[0];
 
       return { currentVersion, latestVersion };
     } catch {
-      return { currentVersion, latestVersion: 'latest' };
+      return { currentVersion, latestVersion: null };
     }
   }
 }


### PR DESCRIPTION
﻿## Summary

Closes #22849.

### Problem
The admin panel "Latest version" row could show the string **latest** (Docker floating tag), which is useless for deciding whether an update is available. That happened when Docker Hub failed or when only non-semver tags were present.

### Fix
1. **Backend** (`AdminPanelVersionService`):
   - Resolve tags with `semver.clean` so `v2.22.0` works and floating tags (`latest`, `v2`, `v2.22`) are ignored
   - Sort with `semver.rcompare` and return the highest full version
   - On empty results / API errors return `null` (never the string `"latest"`)
   - Make `latestVersion` nullable in the GraphQL DTO
2. **Frontend** (`SettingsAdminVersionDisplay`):
   - Treat `latest` / `unknown` / empty as "no version" so the UI shows "No latest version found" even if an older server still returns the placeholder

Related open attempt: #22885 (backend-only null fallback). This PR also fixes v-prefixed tag resolution and adds frontend hardening.

## Test plan
- [x] Unit tests updated for API error / empty / v-prefixed tags
- [ ] Admin panel shows a real version when Docker Hub is reachable
- [ ] Admin panel shows "No latest version found" when Docker Hub is blocked


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/23022?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

