### PR TITLE
fix(server): preserve omitted EMAILS/LINKS subfields on partial updates

### DIFF
--- a/packages/twenty-server/src/engine/core-modules/record-transformer/utils/__tests__/transform-emails-value.util.spec.ts
+++ b/packages/twenty-server/src/engine/core-modules/record-transformer/utils/__tests__/transform-emails-value.util.spec.ts
@@ -46,14 +46,17 @@ describe('transformEmailsValue', () => {
     expect(result.primaryEmail).toBeNull();
   });
 
-  it('should return null for primaryEmail when it is undefined', () => {
+  it('should omit primaryEmail when it is not provided (partial update)', () => {
     const value = {
       additionalEmails: null,
     };
 
     const result = transformEmailsValue(value);
 
-    expect(result.primaryEmail).toBeNull();
+    expect(result).toEqual({
+      additionalEmails: null,
+    });
+    expect('primaryEmail' in result).toBe(false);
   });
 
   it('should convert additionalEmails array to lowercase JSON string', () => {
@@ -159,14 +162,37 @@ describe('transformEmailsValue', () => {
     });
   });
 
-  it('should handle empty value object', () => {
+  it('should handle empty value object without inventing subfields', () => {
     const value = {};
 
     const result = transformEmailsValue(value);
 
+    expect(result).toEqual({});
+  });
+
+  it('should not null out primaryEmail when only additionalEmails is updated', () => {
+    const value = {
+      additionalEmails: ['NEW@EXAMPLE.COM'],
+    };
+
+    const result = transformEmailsValue(value);
+
     expect(result).toEqual({
-      primaryEmail: null,
-      additionalEmails: undefined,
+      additionalEmails: '["new@example.com"]',
     });
+    expect('primaryEmail' in result).toBe(false);
+  });
+
+  it('should not null out additionalEmails when only primaryEmail is updated', () => {
+    const value = {
+      primaryEmail: 'NEW@EXAMPLE.COM',
+    };
+
+    const result = transformEmailsValue(value);
+
+    expect(result).toEqual({
+      primaryEmail: 'new@example.com',
+    });
+    expect('additionalEmails' in result).toBe(false);
   });
 });

--- a/packages/twenty-server/src/engine/core-modules/record-transformer/utils/__tests__/transform-links-value.util.spec.ts
+++ b/packages/twenty-server/src/engine/core-modules/record-transformer/utils/__tests__/transform-links-value.util.spec.ts
@@ -104,4 +104,34 @@ describe('transformLinksValue', () => {
       expect(transformLinksValue(input)).toEqual(expected);
     });
   });
+
+  describe('partial composite updates', () => {
+    it('should not null out primary link when only secondaryLinks is updated', () => {
+      const result = transformLinksValue({
+        secondaryLinks: JSON.stringify([
+          { url: 'HTTPS://SECONDARY.EXAMPLE.COM', label: 'Secondary' },
+        ]),
+      });
+
+      expect(result).toEqual({
+        secondaryLinks: JSON.stringify([
+          { url: 'https://secondary.example.com', label: 'Secondary' },
+        ]),
+      });
+      expect('primaryLinkUrl' in (result as object)).toBe(false);
+      expect('primaryLinkLabel' in (result as object)).toBe(false);
+    });
+
+    it('should not null out secondary links when only primaryLinkLabel is updated', () => {
+      const result = transformLinksValue({
+        primaryLinkLabel: 'Renamed',
+      });
+
+      expect(result).toEqual({
+        primaryLinkLabel: 'Renamed',
+      });
+      expect('primaryLinkUrl' in (result as object)).toBe(false);
+      expect('secondaryLinks' in (result as object)).toBe(false);
+    });
+  });
 });

--- a/packages/twenty-server/src/engine/core-modules/record-transformer/utils/transform-emails-value.util.ts
+++ b/packages/twenty-server/src/engine/core-modules/record-transformer/utils/transform-emails-value.util.ts
@@ -1,6 +1,9 @@
 import { isNonEmptyArray, isNonEmptyString } from '@sniptt/guards';
 import { isDefined } from 'class-validator';
 
+// Only transform subfields that are present on the input. Omitted keys stay
+// undefined so partial updates (e.g. additionalEmails only) do not null out
+// stored primaryEmail — same contract as ADDRESS / FULL_NAME transformers.
 export const transformEmailsValue = (
   // oxlint-disable-next-line typescript/no-explicit-any
   value: any,
@@ -10,29 +13,36 @@ export const transformEmailsValue = (
     return value;
   }
 
-  let additionalEmails: string | null = value?.additionalEmails;
-  const primaryEmail = isNonEmptyString(value?.primaryEmail)
-    ? value.primaryEmail.toLowerCase()
-    : null;
+  // oxlint-disable-next-line typescript/no-explicit-any
+  const result: Record<string, any> = {};
 
-  if (additionalEmails) {
-    try {
-      const emailArray = (
-        isNonEmptyString(additionalEmails)
-          ? JSON.parse(additionalEmails)
-          : additionalEmails
-      ) as string[];
-
-      additionalEmails = isNonEmptyArray(emailArray)
-        ? JSON.stringify(emailArray.map((email) => email.toLowerCase()))
-        : null;
-    } catch {
-      /* empty */
-    }
+  if ('primaryEmail' in value) {
+    result.primaryEmail = isNonEmptyString(value.primaryEmail)
+      ? value.primaryEmail.toLowerCase()
+      : null;
   }
 
-  return {
-    primaryEmail,
-    additionalEmails,
-  };
+  if ('additionalEmails' in value) {
+    let additionalEmails = value.additionalEmails;
+
+    if (additionalEmails) {
+      try {
+        const emailArray = (
+          isNonEmptyString(additionalEmails)
+            ? JSON.parse(additionalEmails)
+            : additionalEmails
+        ) as string[];
+
+        additionalEmails = isNonEmptyArray(emailArray)
+          ? JSON.stringify(emailArray.map((email) => email.toLowerCase()))
+          : null;
+      } catch {
+        /* empty */
+      }
+    }
+
+    result.additionalEmails = additionalEmails;
+  }
+
+  return result;
 };

--- a/packages/twenty-server/src/engine/core-modules/record-transformer/utils/transform-links-value.util.ts
+++ b/packages/twenty-server/src/engine/core-modules/record-transformer/utils/transform-links-value.util.ts
@@ -14,7 +14,10 @@ export type LinksFieldGraphQLInput =
   | null
   | undefined;
 
-// TODO refactor this function handle partial composite field update
+// Full composite writes (all three subfields present, or empty object used as
+// clear) still run removeEmptyLinks so invalid/empty links are consolidated.
+// Partial writes only transform the provided keys so omitted subfields are not
+// null-written over stored values.
 export const transformLinksValue = (
   value: LinksFieldGraphQLInput,
 ): LinksFieldGraphQLInput => {
@@ -22,35 +25,80 @@ export const transformLinksValue = (
     return value;
   }
 
-  const primaryLinkUrlRaw = value.primaryLinkUrl as string | null;
-  const primaryLinkLabelRaw = value.primaryLinkLabel as string | null;
-  const secondaryLinksRaw = value.secondaryLinks as string | null;
+  const hasPrimaryLinkUrl = 'primaryLinkUrl' in value;
+  const hasPrimaryLinkLabel = 'primaryLinkLabel' in value;
+  const hasSecondaryLinks = 'secondaryLinks' in value;
+  const isFullCompositeWrite =
+    (hasPrimaryLinkUrl && hasPrimaryLinkLabel && hasSecondaryLinks) ||
+    (!hasPrimaryLinkUrl && !hasPrimaryLinkLabel && !hasSecondaryLinks);
 
-  const secondaryLinksArray = isNonEmptyString(secondaryLinksRaw)
-    ? parseJson<LinkMetadataNullable[]>(secondaryLinksRaw)
-    : secondaryLinksRaw;
+  if (isFullCompositeWrite) {
+    const primaryLinkUrlRaw = (value.primaryLinkUrl ?? null) as string | null;
+    const primaryLinkLabelRaw = (value.primaryLinkLabel ??
+      null) as string | null;
+    const secondaryLinksRaw = (value.secondaryLinks ?? null) as string | null;
 
-  const { primaryLinkLabel, primaryLinkUrl, secondaryLinks } = removeEmptyLinks(
-    {
-      primaryLinkUrl: primaryLinkUrlRaw,
-      primaryLinkLabel: primaryLinkLabelRaw,
-      secondaryLinks: secondaryLinksArray,
-    },
-  );
+    const secondaryLinksArray = isNonEmptyString(secondaryLinksRaw)
+      ? parseJson<LinkMetadataNullable[]>(secondaryLinksRaw)
+      : secondaryLinksRaw;
 
-  const processedSecondaryLinks = secondaryLinks?.map((link) => ({
-    ...link,
-    url: isDefined(link.url) ? normalizeUrlOrigin(link.url) : link.url,
-  }));
+    const { primaryLinkLabel, primaryLinkUrl, secondaryLinks } =
+      removeEmptyLinks({
+        primaryLinkUrl: primaryLinkUrlRaw,
+        primaryLinkLabel: primaryLinkLabelRaw,
+        secondaryLinks: secondaryLinksArray,
+      });
 
-  return {
-    ...value,
-    primaryLinkUrl: isDefined(primaryLinkUrl)
-      ? normalizeUrlOrigin(primaryLinkUrl)
-      : primaryLinkUrl,
-    primaryLinkLabel,
-    secondaryLinks: isEmpty(processedSecondaryLinks)
-      ? null
-      : JSON.stringify(processedSecondaryLinks),
-  };
+    const processedSecondaryLinks = secondaryLinks?.map((link) => ({
+      ...link,
+      url: isDefined(link.url) ? normalizeUrlOrigin(link.url) : link.url,
+    }));
+
+    return {
+      primaryLinkUrl: isDefined(primaryLinkUrl)
+        ? normalizeUrlOrigin(primaryLinkUrl)
+        : primaryLinkUrl,
+      primaryLinkLabel,
+      secondaryLinks: isEmpty(processedSecondaryLinks)
+        ? null
+        : JSON.stringify(processedSecondaryLinks),
+    };
+  }
+
+  const result: LinksFieldGraphQLInput = {};
+
+  if (hasPrimaryLinkUrl) {
+    result.primaryLinkUrl = isNonEmptyString(value.primaryLinkUrl)
+      ? normalizeUrlOrigin(value.primaryLinkUrl)
+      : value.primaryLinkUrl;
+  }
+
+  if (hasPrimaryLinkLabel) {
+    result.primaryLinkLabel = value.primaryLinkLabel;
+  }
+
+  if (hasSecondaryLinks) {
+    const secondaryLinksRaw = value.secondaryLinks;
+
+    if (!isDefined(secondaryLinksRaw) || secondaryLinksRaw === null) {
+      result.secondaryLinks = null;
+    } else {
+      const secondaryLinksArray = isNonEmptyString(secondaryLinksRaw)
+        ? parseJson<LinkMetadataNullable[]>(secondaryLinksRaw)
+        : (secondaryLinksRaw as unknown as LinkMetadataNullable[]);
+
+      const processedSecondaryLinks = (secondaryLinksArray ?? [])
+        .filter((link) => isDefined(link) && isNonEmptyString(link.url))
+        .map((link) => ({
+          ...link,
+          url: isDefined(link.url) ? normalizeUrlOrigin(link.url) : link.url,
+        }));
+
+      result.secondaryLinks = isEmpty(processedSecondaryLinks)
+        ? null
+        : JSON.stringify(processedSecondaryLinks);
+    }
+  }
+
+  return result;
 };


### PR DESCRIPTION
﻿## Summary

Closes #23024.

Partial EMAILS/LINKS composite updates forced omitted subfields to `null`, which `formatData` then persisted — wiping stored `primaryEmail` / primary links when only secondary values were updated.

### Fix
- **EMAILS**: only transform keys present on the input (`in` check).
- **LINKS**: full three-field writes still use `removeEmptyLinks`; partial writes only touch provided keys.

## Test plan
- [x] Unit tests for partial EMAILS (additional-only / primary-only)
- [x] Unit tests for partial LINKS
- [x] Existing full-write tests kept


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/23029?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

