### PR TITLE
fix(front): align group-by optimistic keys with backend wire format

### DIFF
--- a/packages/twenty-front/src/modules/apollo/optimistic-effect/group-by/utils/__tests__/normalizeGroupByDimensionValue.test.ts
+++ b/packages/twenty-front/src/modules/apollo/optimistic-effect/group-by/utils/__tests__/normalizeGroupByDimensionValue.test.ts
@@ -11,26 +11,68 @@ describe('normalizeGroupByDimensionValue', () => {
     expect(result).toBe('123');
   });
 
-  it('should handle date with DAY granularity', () => {
+  it('should handle date with DAY granularity as YYYY-MM-DD', () => {
     const date = new Date('2024-01-15T10:30:00Z');
     const result = normalizeGroupByDimensionValue(date, { granularity: 'DAY' });
     expect(result).toBe('2024-01-15');
   });
 
-  it('should handle date with MONTH granularity', () => {
+  it('should handle date with MONTH granularity as first day YYYY-MM-DD', () => {
     const date = new Date('2024-01-15T10:30:00Z');
     const result = normalizeGroupByDimensionValue(date, {
       granularity: 'MONTH',
     });
-    expect(result).toBe('2024-01');
+    expect(result).toBe('2024-01-01');
   });
 
-  it('should handle date with YEAR granularity', () => {
+  it('should handle date with YEAR granularity as Jan 1 YYYY-MM-DD', () => {
     const date = new Date('2024-01-15T10:30:00Z');
     const result = normalizeGroupByDimensionValue(date, {
       granularity: 'YEAR',
     });
-    expect(result).toBe('2024');
+    expect(result).toBe('2024-01-01');
+  });
+
+  it('should handle date with QUARTER granularity as quarter start YYYY-MM-DD', () => {
+    const date = new Date('2024-05-15T10:30:00Z');
+    const result = normalizeGroupByDimensionValue(date, {
+      granularity: 'QUARTER',
+    });
+    expect(result).toBe('2024-04-01');
+  });
+
+  it('should handle DAY_OF_THE_WEEK as English day name matching backend TMDay', () => {
+    // 2024-01-15 is a Monday
+    const date = new Date('2024-01-15T10:30:00Z');
+    const result = normalizeGroupByDimensionValue(date, {
+      granularity: 'DAY_OF_THE_WEEK',
+    });
+    expect(result).toBe('Monday');
+  });
+
+  it('should handle MONTH_OF_THE_YEAR as English month name matching backend TMMonth', () => {
+    const date = new Date('2024-01-15T10:30:00Z');
+    const result = normalizeGroupByDimensionValue(date, {
+      granularity: 'MONTH_OF_THE_YEAR',
+    });
+    expect(result).toBe('January');
+  });
+
+  it('should handle QUARTER_OF_THE_YEAR as Qn', () => {
+    const date = new Date('2024-05-15T10:30:00Z');
+    const result = normalizeGroupByDimensionValue(date, {
+      granularity: 'QUARTER_OF_THE_YEAR',
+    });
+    expect(result).toBe('Q2');
+  });
+
+  it('should handle WEEK as Monday-start YYYY-MM-DD', () => {
+    // 2024-01-17 is Wednesday → week starts Monday 2024-01-15
+    const date = new Date('2024-01-17T10:30:00Z');
+    const result = normalizeGroupByDimensionValue(date, {
+      granularity: 'WEEK',
+    });
+    expect(result).toBe('2024-01-15');
   });
 
   it('should handle object with id', () => {

--- a/packages/twenty-front/src/modules/apollo/optimistic-effect/group-by/utils/normalizeGroupByDimensionValue.ts
+++ b/packages/twenty-front/src/modules/apollo/optimistic-effect/group-by/utils/normalizeGroupByDimensionValue.ts
@@ -1,5 +1,53 @@
 import { isDefined } from 'twenty-shared/utils';
 
+// Must match backend wire format from get-group-by-expression.util.ts:
+// - DAY / MONTH / QUARTER / YEAR / WEEK → TO_CHAR(..., 'YYYY-MM-DD') after DATE_TRUNC
+// - DAY_OF_THE_WEEK → TO_CHAR(..., 'TMDay') → English full day name
+// - MONTH_OF_THE_YEAR → TO_CHAR(..., 'TMMonth') → English full month name
+// - QUARTER_OF_THE_YEAR → TO_CHAR(..., '"Q"Q') → Q1..Q4
+const ENGLISH_DAY_NAMES = [
+  'Sunday',
+  'Monday',
+  'Tuesday',
+  'Wednesday',
+  'Thursday',
+  'Friday',
+  'Saturday',
+] as const;
+
+const ENGLISH_MONTH_NAMES = [
+  'January',
+  'February',
+  'March',
+  'April',
+  'May',
+  'June',
+  'July',
+  'August',
+  'September',
+  'October',
+  'November',
+  'December',
+] as const;
+
+const toUtcDateParts = (dateValue: Date) => ({
+  year: dateValue.getUTCFullYear(),
+  month: dateValue.getUTCMonth(),
+  day: dateValue.getUTCDate(),
+  dayOfWeek: dateValue.getUTCDay(),
+});
+
+const formatUtcYyyyMmDd = (
+  year: number,
+  monthIndex: number,
+  day: number,
+): string => {
+  const month = String(monthIndex + 1).padStart(2, '0');
+  const dayOfMonth = String(day).padStart(2, '0');
+
+  return `${year}-${month}-${dayOfMonth}`;
+};
+
 export const normalizeGroupByDimensionValue = (
   value: any,
   fieldConfig: boolean | Record<string, string> | undefined,
@@ -7,19 +55,44 @@ export const normalizeGroupByDimensionValue = (
   if (typeof fieldConfig === 'object' && isDefined(fieldConfig.granularity)) {
     const dateValue = new Date(value);
     const granularity = fieldConfig.granularity;
+    const { year, month, day, dayOfWeek } = toUtcDateParts(dateValue);
 
-    // TODO: to remove once backend properly returns DATE without time
+    // TODO: prefer the groupBy query timezone once available on fieldConfig
+    // (backend DATE_TRUNC uses IANA timezone for DATE_TIME fields).
     switch (granularity) {
       case 'DAY':
-        return dateValue.toISOString().split('T')[0];
+        return formatUtcYyyyMmDd(year, month, day);
       case 'MONTH':
-        return dateValue.toISOString().substring(0, 7);
+        // DATE_TRUNC('month') → first day of month as YYYY-MM-DD
+        return formatUtcYyyyMmDd(year, month, 1);
+      case 'QUARTER': {
+        const quarterStartMonth = Math.floor(month / 3) * 3;
+
+        return formatUtcYyyyMmDd(year, quarterStartMonth, 1);
+      }
       case 'YEAR':
-        return dateValue.getFullYear().toString();
+        // DATE_TRUNC('year') → Jan 1 as YYYY-MM-DD
+        return formatUtcYyyyMmDd(year, 0, 1);
+      case 'WEEK': {
+        // Align with Postgres DATE_TRUNC('week') default (Monday start, ISO-like).
+        // dayOfWeek: 0=Sun .. 6=Sat; days since Monday:
+        const daysSinceMonday = (dayOfWeek + 6) % 7;
+        const weekStart = new Date(
+          Date.UTC(year, month, day - daysSinceMonday),
+        );
+
+        return formatUtcYyyyMmDd(
+          weekStart.getUTCFullYear(),
+          weekStart.getUTCMonth(),
+          weekStart.getUTCDate(),
+        );
+      }
       case 'DAY_OF_THE_WEEK':
-        return dateValue.getDay().toString();
+        return ENGLISH_DAY_NAMES[dayOfWeek];
       case 'MONTH_OF_THE_YEAR':
-        return (dateValue.getMonth() + 1).toString();
+        return ENGLISH_MONTH_NAMES[month];
+      case 'QUARTER_OF_THE_YEAR':
+        return `Q${Math.floor(month / 3) + 1}`;
       default:
         return String(value);
     }


### PR DESCRIPTION
﻿## Summary

Closes #23025.

Frontend optimistic group-by keys did not match backend SQL dimension values:
- `DAY_OF_THE_WEEK`: client used `"0"`–`"6"`, server uses `"Monday"`, …
- `MONTH_OF_THE_YEAR`: client used `"1"`–`"12"`, server uses `"January"`, …
- `MONTH` / `YEAR`: client used `YYYY-MM` / year number, server uses truncated `YYYY-MM-DD`

### Fix
`normalizeGroupByDimensionValue` now emits the same wire format as `get-group-by-expression.util.ts` (UTC baseline; timezone still a follow-up).

## Test plan
- [x] Unit tests for DAY/MONTH/YEAR/QUARTER/WEEK/DAY_OF_THE_WEEK/MONTH_OF_THE_YEAR/QUARTER_OF_THE_YEAR


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/23030?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

