### PR TITLE
fix(server): stop leaking account state from resendEmailVerificationToken

### DIFF
--- a/packages/twenty-server/src/engine/core-modules/email-verification/services/email-verification.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/email-verification/services/email-verification.service.ts
@@ -9,7 +9,7 @@ import ms from 'ms';
 import { SendEmailVerificationLinkEmail } from 'twenty-emails';
 import { type APP_LOCALES } from 'twenty-shared/translations';
 import { AppPath } from 'twenty-shared/types';
-import { assertIsDefinedOrThrow, isDefined } from 'twenty-shared/utils';
+import { isDefined } from 'twenty-shared/utils';
 import { Repository } from 'typeorm';
 
 import {

--- a/packages/twenty-server/src/engine/core-modules/email-verification/services/email-verification.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/email-verification/services/email-verification.service.ts
@@ -163,20 +163,18 @@ export class EmailVerificationService {
       );
     }
 
-    // TODO: Remove the dependency on querying user altogether when the endpoint is authenticated.
+    // Public endpoint: always return the same success payload for missing,
+    // verified, and rate-limited accounts so callers cannot enumerate users
+    // or verification state. Only send mail for real unverified users outside
+    // the resend cooldown window.
     const user = await this.userRepository.findOne({
       where: {
         email,
       },
     });
 
-    assertIsDefinedOrThrow(user);
-
-    if (user.isEmailVerified) {
-      throw new EmailVerificationException(
-        'Email already verified',
-        EmailVerificationExceptionCode.EMAIL_ALREADY_VERIFIED,
-      );
+    if (!isDefined(user) || user.isEmailVerified) {
+      return { success: true };
     }
 
     const existingToken = await this.appTokenRepository.findOne({
@@ -194,10 +192,7 @@ export class EmailVerificationService {
       );
 
       if (timeToWaitMs > 0) {
-        throw new EmailVerificationException(
-          `Please wait ${ms(timeToWaitMs, { long: true })} before requesting another verification email`,
-          EmailVerificationExceptionCode.RATE_LIMIT_EXCEEDED,
-        );
+        return { success: true };
       }
 
       await this.appTokenRepository.delete(existingToken.id);


### PR DESCRIPTION
﻿## Summary

Closes #23026.

`resendEmailVerificationToken` is public. Distinct failures for unknown / verified / rate-limited emails leaked account existence and verification state, and confirmed that mail could be triggered.

### Fix
Always return `{ success: true }` for:
- unknown email
- already verified email
- still inside resend cooldown

Only send a verification email for a real unverified user outside cooldown. Config-level `EMAIL_VERIFICATION_NOT_REQUIRED` still errors (server policy, not user enumeration).

## Test plan
- [ ] Unknown email → success, no mail
- [ ] Verified email → success, no mail
- [ ] Unverified + cooldown → success, no second mail
- [ ] Unverified outside cooldown → success + mail


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/23031?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

