### PR TITLE
fix(server): fail closed and return transformed DTOs in ResolverValidationPipe

### DIFF
--- a/packages/twenty-server/src/engine/core-modules/graphql/pipes/__tests__/resolver-validation.pipe.spec.ts
+++ b/packages/twenty-server/src/engine/core-modules/graphql/pipes/__tests__/resolver-validation.pipe.spec.ts
@@ -1,0 +1,46 @@
+import { IsString, ValidateNested } from 'class-validator';
+import { Type } from 'class-transformer';
+
+import { ResolverValidationPipe } from 'src/engine/core-modules/graphql/pipes/resolver-validation.pipe';
+import { UserInputError } from 'src/engine/core-modules/graphql/utils/graphql-errors.util';
+
+class NestedDto {
+  @IsString()
+  name!: string;
+}
+
+class ParentDto {
+  @ValidateNested()
+  @Type(() => NestedDto)
+  nested!: NestedDto;
+}
+
+describe('ResolverValidationPipe', () => {
+  const pipe = new ResolverValidationPipe();
+
+  it('should return transformed class instances on success', async () => {
+    const result = (await pipe.transform(
+      { nested: { name: 'ok' } },
+      { type: 'body', metatype: ParentDto, data: '' },
+    )) as ParentDto;
+
+    expect(result).toBeInstanceOf(ParentDto);
+    expect(result.nested).toBeInstanceOf(NestedDto);
+    expect(result.nested.name).toBe('ok');
+  });
+
+  it('should throw UserInputError when validation constraints fail', async () => {
+    await expect(
+      pipe.transform(
+        { nested: { name: 123 } },
+        { type: 'body', metatype: ParentDto, data: '' },
+      ),
+    ).rejects.toBeInstanceOf(UserInputError);
+  });
+
+  it('should pass through primitive metatypes unchanged', async () => {
+    await expect(
+      pipe.transform('hello', { type: 'body', metatype: String, data: '' }),
+    ).resolves.toBe('hello');
+  });
+});

--- a/packages/twenty-server/src/engine/core-modules/graphql/pipes/resolver-validation.pipe.ts
+++ b/packages/twenty-server/src/engine/core-modules/graphql/pipes/resolver-validation.pipe.ts
@@ -10,16 +10,6 @@ import { type ValidationError, validate } from 'class-validator';
 
 import { UserInputError } from 'src/engine/core-modules/graphql/utils/graphql-errors.util';
 
-const safeClassValidatorValidateWrapper = async (
-  object: object,
-): Promise<ValidationError[]> => {
-  try {
-    return await validate(object);
-  } catch {
-    return [];
-  }
-};
-
 @Injectable()
 export class ResolverValidationPipe implements PipeTransform {
   async transform(value: unknown, metadata: ArgumentMetadata) {
@@ -30,11 +20,24 @@ export class ResolverValidationPipe implements PipeTransform {
     }
 
     const object = plainToInstance(metatype, value);
-    const errors = await safeClassValidatorValidateWrapper(object);
+
+    let errors: ValidationError[];
+
+    try {
+      errors = await validate(object);
+    } catch (error) {
+      // Fail closed: infrastructure / custom-validator throws must not
+      // silently accept the payload (previous behaviour returned []).
+      const message =
+        error instanceof Error ? error.message : 'Validation failed';
+
+      throw new UserInputError(message);
+    }
 
     if (errors.length === 0) {
-      // TODO shouldn't we return the object here ? As transpilation could bring mutations
-      return value;
+      // Return the transformed instance so @Type() / class-transformer
+      // mutations apply (Nest ValidationPipe behaviour).
+      return object;
     }
 
     const errorMessage = this.formatErrorMessage(errors);


### PR DESCRIPTION
﻿## Summary

Closes #23027.

`ResolverValidationPipe` had two bugs:
1. `validate()` exceptions were caught and treated as zero errors (fail-open).
2. On success it returned the original plain `value`, discarding `plainToInstance` / `@Type()` transforms.

### Fix
- Re-throw validation infrastructure failures as `UserInputError`.
- Return the transformed `object` on success (Nest `ValidationPipe` behaviour).

## Test plan
- [x] Unit tests for transformed instance, constraint failure, primitive passthrough


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/23032?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

