### PR TITLE
fix(front): do not throw on relative rich-text image URLs during save

### DIFF
--- a/packages/twenty-front/src/modules/blocknote-editor/utils/__tests__/prepareBodyWithSignedUrls.test.ts
+++ b/packages/twenty-front/src/modules/blocknote-editor/utils/__tests__/prepareBodyWithSignedUrls.test.ts
@@ -43,4 +43,28 @@ describe('prepareBodyWithSignedUrls', () => {
     expect(result[0].type).toBe('image');
     expect(result[0].props.url).toContain('example.com');
   });
+
+  it('should leave relative image URLs unchanged without throwing', () => {
+    const input = JSON.stringify([
+      { type: 'image', props: { url: '/files/workspace/image.png' } },
+      { type: 'paragraph', content: 'still saved' },
+    ]);
+
+    expect(() => prepareBodyWithSignedUrls(input)).not.toThrow();
+
+    const result = JSON.parse(prepareBodyWithSignedUrls(input));
+    expect(result[0].props.url).toBe('/files/workspace/image.png');
+    expect(result[1].content).toBe('still saved');
+  });
+
+  it('should leave invalid image URLs unchanged without throwing', () => {
+    const input = JSON.stringify([
+      { type: 'image', props: { url: 'not a url' } },
+    ]);
+
+    expect(() => prepareBodyWithSignedUrls(input)).not.toThrow();
+
+    const result = JSON.parse(prepareBodyWithSignedUrls(input));
+    expect(result[0].props.url).toBe('not a url');
+  });
 });

--- a/packages/twenty-front/src/modules/blocknote-editor/utils/prepareBodyWithSignedUrls.ts
+++ b/packages/twenty-front/src/modules/blocknote-editor/utils/prepareBodyWithSignedUrls.ts
@@ -17,15 +17,23 @@ export const prepareBodyWithSignedUrls = (
     }
 
     const imageUrl = block.props.url;
-    const parsedImageUrl = new URL(imageUrl);
 
-    return {
-      ...block,
-      props: {
-        ...block.props,
-        url: parsedImageUrl.toString(),
-      },
-    };
+    // Relative or malformed URLs must not throw — that aborts debounced rich
+    // text persistence (see #23028). Leave the original URL unchanged when
+    // it cannot be parsed as an absolute URL.
+    try {
+      const parsedImageUrl = new URL(imageUrl);
+
+      return {
+        ...block,
+        props: {
+          ...block.props,
+          url: parsedImageUrl.toString(),
+        },
+      };
+    } catch {
+      return block;
+    }
   });
 
   return JSON.stringify(bodyWithSignedPayload);


### PR DESCRIPTION
﻿## Summary

Closes #23028.

`prepareBodyWithSignedUrls` (used on every debounced rich-text save) called `new URL(imageUrl)` with no try/catch. Relative paths like `/files/...` threw and aborted the save.

### Fix
Catch URL parse failures and leave the original image URL unchanged so persistence continues. Absolute URLs still normalize as before.

## Test plan
- [x] Relative URL does not throw; URL preserved
- [x] Invalid URL does not throw
- [x] Absolute HTTPS URL still processed


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/23033?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

