### PR TITLE
fix(server): allow REST restore-one path /rest/restore/{object}/{id}

### DIFF
--- a/packages/twenty-server/src/engine/api/rest/input-request-parsers/path-parser-utils/__tests__/parse-core-path.utils.spec.ts
+++ b/packages/twenty-server/src/engine/api/rest/input-request-parsers/path-parser-utils/__tests__/parse-core-path.utils.spec.ts
@@ -73,4 +73,41 @@ describe('parseCorePath', () => {
       id: undefined,
     });
   });
+
+  it('should parse restore many object from request path', () => {
+    const request: any = { path: '/rest/restore/companies' };
+
+    expect(parseCorePath(request)).toEqual({
+      object: 'companies',
+      id: undefined,
+    });
+  });
+
+  it('should parse restore one object from request path', () => {
+    const request: any = { path: `/rest/restore/companies/${testUUID}` };
+
+    expect(parseCorePath(request)).toEqual({
+      object: 'companies',
+      id: testUUID,
+    });
+  });
+
+  it('should throw for malformed uuid in restore one request', () => {
+    const malformedUUID = 'malformed-uuid';
+    const request: any = { path: `/rest/restore/companies/${malformedUUID}` };
+
+    expect(() => parseCorePath(request)).toThrow(
+      `'${malformedUUID}' is not a valid UUID`,
+    );
+  });
+
+  it('should throw for restore path with too many segments', () => {
+    const request: any = {
+      path: `/rest/restore/companies/${testUUID}/extra`,
+    };
+
+    expect(() => parseCorePath(request)).toThrow(
+      `Query path '/rest/restore/companies/${testUUID}/extra' invalid`,
+    );
+  });
 });

--- a/packages/twenty-server/src/engine/api/rest/input-request-parsers/path-parser-utils/parse-core-path.utils.ts
+++ b/packages/twenty-server/src/engine/api/rest/input-request-parsers/path-parser-utils/parse-core-path.utils.ts
@@ -12,18 +12,21 @@ export const parseCorePath = (
     .split('/')
     .filter(Boolean);
 
-  if (
-    queryAction.length > 2 ||
-    (queryAction.length > 3 && queryAction[0] === 'restore')
-  ) {
+  // /rest/restore/{object} (length 2) and /rest/restore/{object}/{id} (length 3)
+  // must be accepted. The previous check used (length > 3 && restore) which is
+  // never true when length is already > 2, so restore-one was always rejected.
+  const isRestorePath = queryAction[0] === 'restore';
+  const maxPathSegments = isRestorePath ? 3 : 2;
+
+  if (queryAction.length > maxPathSegments) {
     throw new BadRequestException(
-      `Query path '${request.path}' invalid. Valid examples: /rest/companies/id or /rest/companies or /rest/batch/companies`,
+      `Query path '${request.path}' invalid. Valid examples: /rest/companies/id or /rest/companies or /rest/batch/companies or /rest/restore/companies/id`,
     );
   }
 
   if (queryAction.length === 0) {
     throw new BadRequestException(
-      `Query path '${request.path}' invalid. Valid examples: /rest/companies/id or /rest/companies or /rest/batch/companies`,
+      `Query path '${request.path}' invalid. Valid examples: /rest/companies/id or /rest/companies or /rest/batch/companies or /rest/restore/companies/id`,
     );
   }
 
@@ -43,7 +46,7 @@ export const parseCorePath = (
     return { object: queryAction[0] };
   }
 
-  if (queryAction[0] === 'restore') {
+  if (isRestorePath) {
     const recordId = queryAction[2];
 
     if (isDefined(recordId) && !isValidUuid(recordId)) {


### PR DESCRIPTION
﻿## Summary

Closes #23034.

`PATCH /rest/restore/{object}/{id}` was always rejected because `parseCorePath` threw on any path longer than 2 segments before the restore branch could run.

### Fix
- Allow up to 3 segments when the first segment is `restore`
- Keep max 2 segments for normal object paths
- Add unit tests for restore-many, restore-one, bad UUID, too many segments

## Test plan
- [x] Unit tests for restore paths
- [x] Existing path parser tests still pass


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/23035?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

