### PR TITLE
fix(server): normalize invitation emails to lowercase

### DIFF
--- a/packages/twenty-server/src/engine/core-modules/workspace-invitation/services/workspace-invitation.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/workspace-invitation/services/workspace-invitation.service.ts
@@ -77,7 +77,13 @@ export class WorkspaceInvitationService {
         throw new Error('Invalid invitation token');
       }
 
-      if (!appToken.context?.email || appToken.context?.email !== email) {
+      const invitationEmail =
+        typeof appToken.context?.email === 'string'
+          ? appToken.context.email.toLowerCase().trim()
+          : undefined;
+      const normalizedEmail = email.toLowerCase().trim();
+
+      if (!invitationEmail || invitationEmail !== normalizedEmail) {
         throw new Error('Email does not match the invitation');
       }
 
@@ -162,14 +168,18 @@ export class WorkspaceInvitationService {
     roleId?: string,
     isOnboardingInvitation = false,
   ) {
+    // Users are stored lowercased; invitations must use the same form so
+    // duplicate invites and "already in workspace" checks cannot miss on case.
+    const normalizedEmail = email.toLowerCase().trim();
+
     const maybeWorkspaceInvitation = await this.getOneWorkspaceInvitation(
       workspace.id,
-      email.toLowerCase(),
+      normalizedEmail,
     );
 
     if (maybeWorkspaceInvitation) {
       throw new WorkspaceInvitationException(
-        `${email} already invited`,
+        `${normalizedEmail} already invited`,
         WorkspaceInvitationExceptionCode.INVITATION_ALREADY_EXIST,
       );
     }
@@ -178,7 +188,7 @@ export class WorkspaceInvitationService {
       where: {
         workspaceId: workspace.id,
         user: {
-          email,
+          email: normalizedEmail,
         },
       },
       relations: {
@@ -188,14 +198,14 @@ export class WorkspaceInvitationService {
 
     if (isUserAlreadyInWorkspace) {
       throw new WorkspaceInvitationException(
-        `${email} is already in the workspace`,
+        `${normalizedEmail} is already in the workspace`,
         WorkspaceInvitationExceptionCode.USER_ALREADY_EXIST,
       );
     }
 
     return this.generateInvitationToken(
       workspace.id,
-      email,
+      normalizedEmail,
       roleId,
       isOnboardingInvitation,
     );


### PR DESCRIPTION
﻿## Summary

Closes #23036.

Invitation create/accept mixed raw and lowercased emails, so:
- `User@X.com` and `user@x.com` could create two invites
- Accept with different casing failed with "Email does not match"
- "Already in workspace" could miss existing members

### Fix
Normalize with `toLowerCase().trim()` at create (storage + lookups) and at validate (compare).

## Test plan
- [ ] Invite `User@Example.com` then `user@example.com` → already invited
- [ ] Accept with either casing → success


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/23037?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

