### PR TITLE
fix(front): validate nextPath after email verification to prevent open redirect

### DIFF
--- a/packages/twenty-front/src/hooks/usePageChangeEffectNavigateLocation.ts
+++ b/packages/twenty-front/src/hooks/usePageChangeEffectNavigateLocation.ts
@@ -99,7 +99,8 @@ export const usePageChangeEffectNavigateLocation = () => {
   ) {
     if (
       isMatchingLocation(location, AppPath.VerifyEmail) &&
-      isDefined(verifyEmailRedirectPath)
+      isDefined(verifyEmailRedirectPath) &&
+      isValidReturnToPath(verifyEmailRedirectPath)
     ) {
       return verifyEmailRedirectPath;
     }

--- a/packages/twenty-front/src/modules/auth/components/VerifyEmailEffect.tsx
+++ b/packages/twenty-front/src/modules/auth/components/VerifyEmailEffect.tsx
@@ -1,6 +1,7 @@
 import { verifyEmailRedirectPathState } from '@/app/states/verifyEmailRedirectPathState';
 import { useAuth } from '@/auth/hooks/useAuth';
 import { useVerifyLogin } from '@/auth/hooks/useVerifyLogin';
+import { isValidReturnToPath } from '@/auth/utils/isValidReturnToPath';
 import { clientConfigApiStatusState } from '@/client-config/states/clientConfigApiStatusState';
 import { useIsCurrentLocationOnAWorkspace } from '@/domain-manager/hooks/useIsCurrentLocationOnAWorkspace';
 import { useRedirectToWorkspaceDomain } from '@/domain-manager/hooks/useRedirectToWorkspaceDomain';
@@ -91,7 +92,12 @@ export const VerifyEmailEffect = ({ onError }: VerifyEmailEffectProps) => {
           });
         }
 
-        if (isDefined(verifyEmailRedirectPath)) {
+        // nextPath must use the same allowlist as returnToPath or it becomes
+        // an open-redirect (//evil.com, protocol-relative, etc.).
+        if (
+          isDefined(verifyEmailRedirectPath) &&
+          isValidReturnToPath(verifyEmailRedirectPath)
+        ) {
           setVerifyEmailRedirectPath(verifyEmailRedirectPath);
         }
 


### PR DESCRIPTION
﻿## Summary

Closes #23038.

`nextPath` on the email-verification success flow was set and later navigated to without the same allowlist as `returnToPath`, enabling open redirects (`//evil.com`, etc.).

### Fix
Apply `isValidReturnToPath` when setting `verifyEmailRedirectPath` and before navigating to it.

## Test plan
- [ ] Valid `/objects/people` nextPath still works
- [ ] `//evil.com` nextPath is ignored


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/23039?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

