### PR TITLE
fix(front): use valid Gmail/Outlook mailbox URLs on verification screen

### DIFF
--- a/packages/twenty-front/src/modules/auth/sign-in-up/components/EmailVerificationSent.tsx
+++ b/packages/twenty-front/src/modules/auth/sign-in-up/components/EmailVerificationSent.tsx
@@ -92,17 +92,19 @@ export const EmailVerificationSent = ({
     useHandleResendEmailVerificationToken();
 
   const handleOpenGmail = () => {
+    // /mail/u/{n}/ expects an account index (0, 1, …), not an email address.
+    // Use authuser so the correct inbox is selected when possible.
     const gmailUrl = email
-      ? `https://mail.google.com/mail/u/${email}/`
+      ? `https://mail.google.com/mail/?authuser=${encodeURIComponent(email)}`
       : 'https://mail.google.com/';
-    window.open(gmailUrl, '_blank');
+    window.open(gmailUrl, '_blank', 'noopener,noreferrer');
   };
 
   const handleOpenOutlook = () => {
     const outlookUrl = email
-      ? `https://outlook.live.com/mail/${email}/`
+      ? `https://outlook.live.com/mail/?login_hint=${encodeURIComponent(email)}`
       : 'https://outlook.live.com/';
-    window.open(outlookUrl, '_blank');
+    window.open(outlookUrl, '_blank', 'noopener,noreferrer');
   };
 
   const handleChangeEmail = () => {


### PR DESCRIPTION
﻿## Summary

Closes #23040.

### Fix
- Gmail: `?authuser=` instead of `/mail/u/{email}/`
- Outlook: `?login_hint=`
- `window.open(..., 'noopener,noreferrer')`

## Test plan
- [ ] Click Open Gmail with an address - Gmail opens with that account context
- [ ] Click Open Outlook - Outlook opens without a broken path


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/23041?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

