### PR TITLE
fix(server): exclude expired API keys from findActiveByWorkspaceId

### DIFF
--- a/packages/twenty-server/src/engine/core-modules/api-key/services/__tests__/api-key.service.spec.ts
+++ b/packages/twenty-server/src/engine/core-modules/api-key/services/__tests__/api-key.service.spec.ts
@@ -245,16 +245,22 @@ describe('ApiKeyService', () => {
   });
 
   describe('findActiveByWorkspaceId', () => {
-    it('should find only active (non-revoked) API keys', async () => {
+    it('should find only active (non-revoked, non-expired) API keys', async () => {
       const activeApiKeys = [mockApiKey];
 
       mockApiKeyRepository.find.mockResolvedValue(activeApiKeys);
 
       const result = await service.findActiveByWorkspaceId(mockWorkspaceId);
 
-      expect(mockApiKeyRepository.find).toHaveBeenCalledWith(mockWorkspaceId, {
-        where: { revokedAt: IsNull() },
-      });
+      expect(mockApiKeyRepository.find).toHaveBeenCalledWith(
+        mockWorkspaceId,
+        expect.objectContaining({
+          where: expect.objectContaining({
+            revokedAt: IsNull(),
+            expiresAt: expect.anything(),
+          }),
+        }),
+      );
       expect(result).toEqual(activeApiKeys);
     });
   });

--- a/packages/twenty-server/src/engine/core-modules/api-key/services/api-key.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/api-key/services/api-key.service.ts
@@ -1,7 +1,7 @@
 import { Injectable } from '@nestjs/common';
 
 import { msg } from '@lingui/core/macro';
-import { IsNull } from 'typeorm';
+import { IsNull, MoreThan } from 'typeorm';
 import { type QueryDeepPartialEntity } from 'typeorm/query-builder/QueryPartialEntity';
 
 import { ApiKeyEntity } from 'src/engine/core-modules/api-key/api-key.entity';
@@ -69,8 +69,13 @@ export class ApiKeyService {
   }
 
   async findActiveByWorkspaceId(workspaceId: string): Promise<ApiKeyEntity[]> {
+    // Auth rejects keys with expiresAt < now; the "active" list must match so
+    // expired non-revoked keys are not shown as usable.
     return this.apiKeyRepository.find(workspaceId, {
-      where: { revokedAt: IsNull() },
+      where: {
+        revokedAt: IsNull(),
+        expiresAt: MoreThan(new Date()),
+      },
     });
   }
 


### PR DESCRIPTION
﻿## Summary

Closes #23042.

### Fix
`findActiveByWorkspaceId` now requires `revokedAt IS NULL` and `expiresAt > now`, matching auth validation.

## Test plan
- [x] Unit expectation updated
- [ ] Expired key no longer listed as active in Settings


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/23043?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

