### PR TITLE
fix(server): list marketplace apps with server routes before install

### DIFF
--- a/packages/twenty-server/src/engine/core-modules/application/application-registration-variable/application-registration-variable.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/application/application-registration-variable/application-registration-variable.service.ts
@@ -174,27 +174,13 @@ export class ApplicationRegistrationVariableService {
   async isConfiguredBatch(
     applicationRegistrationIds: string[],
   ): Promise<Map<string, boolean>> {
-    const [variables, registrations, installedApps] = await Promise.all([
-      this.variableRepository.find({
-        where: { applicationRegistrationId: In(applicationRegistrationIds) },
-      }),
-      this.applicationRegistrationRepository.find({
-        where: { id: In(applicationRegistrationIds) },
-        select: { id: true, manifest: true, ownerWorkspaceId: true },
-      }),
-      this.applicationRepository.find({
-        where: { applicationRegistrationId: In(applicationRegistrationIds) },
-        select: { applicationRegistrationId: true, workspaceId: true },
-      }),
-    ]);
+    const variables = await this.variableRepository.find({
+      where: { applicationRegistrationId: In(applicationRegistrationIds) },
+    });
 
     const result = new Map<string, boolean>();
 
     for (const id of applicationRegistrationIds) {
-      const registration = registrations.find(
-        (registration) => registration.id === id,
-      );
-
       const areVariablesConfigured = variables
         .filter(
           (variable) =>
@@ -202,41 +188,14 @@ export class ApplicationRegistrationVariableService {
         )
         .every((variable) => variable.isFilled);
 
-      const isInstalledOnOwnerWorkspace = installedApps.some(
-        (app) =>
-          app.applicationRegistrationId === id &&
-          app.workspaceId === registration?.ownerWorkspaceId,
-      );
-
-      result.set(
-        id,
-        areVariablesConfigured &&
-          this.isServerRouteConfigured(
-            registration,
-            isInstalledOnOwnerWorkspace,
-          ),
-      );
+      // Server-route apps must remain listable before install. Requiring the
+      // app to already be installed on the owner workspace hid those apps
+      // from the marketplace forever (chicken-and-egg, #22707). Server-route
+      // readiness is enforced at install/runtime, not catalog visibility.
+      result.set(id, areVariablesConfigured);
     }
 
     return result;
-  }
-
-  private isServerRouteConfigured(
-    registration: ApplicationRegistrationEntity | undefined,
-    isInstalledOnOwnerWorkspace: boolean,
-  ): boolean {
-    const hasServerRouteFunction =
-      registration?.manifest?.logicFunctions?.some((logicFunction) =>
-        isDefined(logicFunction.serverRouteTriggerSettings),
-      ) ?? false;
-
-    if (!hasServerRouteFunction) {
-      return true;
-    }
-
-    return (
-      isDefined(registration?.ownerWorkspaceId) && isInstalledOnOwnerWorkspace
-    );
   }
 
   private async findVariableOrThrow(


### PR DESCRIPTION
﻿## Summary

Closes #22707.

Marketplace catalog filtering required apps with `serverRouteTriggerSettings` to already be installed on the owner workspace. That is a chicken-and-egg: the app cannot appear until installed, and cannot be installed until it appears.

### Fix
`isConfiguredBatch` only checks required variables for catalog visibility. Server-route readiness stays an install/runtime concern.

## Test plan
- [ ] Marketplace lists apps that declare server routes and are not yet installed
- [ ] Apps missing required variables still stay hidden until configured


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/23044?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

