### PR TITLE
fix: set floating editor width to match reference element

### DIFF
--- a/packages/twenty-front/src/modules/object-record/record-inline-cell/components/RecordInlineCellEditMode.tsx
+++ b/packages/twenty-front/src/modules/object-record/record-inline-cell/components/RecordInlineCellEditMode.tsx
@@ -13,6 +13,7 @@ import {
   flip,
   offset,
   shift,
+  size,
   useFloating,
   type MiddlewareState,
 } from '@floating-ui/react';
@@ -84,6 +85,13 @@ export const RecordInlineCellEditMode = ({
             },
       ),
       shift({ padding: 8 }),
+      size({
+        apply({ rects, elements }) {
+          Object.assign(elements.floating.style, {
+            width: `${rects.reference.width}px`,
+          });
+        },
+      }),
       setFieldInputLayoutDirectionMiddleware,
     ],
     whileElementsMounted: autoUpdate,


### PR DESCRIPTION
## Summary

Fixes the text field display issue where the floating editor would have an incorrect width when clicking on a text field after manually resizing the right panel.

## Problem

When the right panel was manually resized, clicking on a text field would cause the floating inline editor to be too wide (or incorrectly sized), leading to a messy display.

## Root Cause

The `RecordInlineCellEditMode` component used Floating UI but didn't constrain the floating editor's width to match the reference cell's width, so the editor would expand to fit its content or other constraints instead of staying aligned with the original cell.

## Solution

Added Floating UI's `size` middleware to the `useFloating` call in `RecordInlineCellEditMode.tsx`, which sets the floating element's width to exactly match the reference element's width.

## Testing

- Open a record with a text field
- Manually resize the right panel
- Click the text field to edit it—verify the editor is the same width as the original cell

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/23048?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

