### PR TITLE
feat(call-recorder): explain why a call summary is unavailable

### DIFF
--- a/packages/twenty-apps/public/call-recorder/package.json
+++ b/packages/twenty-apps/public/call-recorder/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@twentyhq/call-recorder",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "license": "MIT",
   "engines": {
     "node": "^24.5.0",

--- a/packages/twenty-apps/public/call-recorder/src/front-components/components/CalendarEventSummaryBody.tsx
+++ b/packages/twenty-apps/public/call-recorder/src/front-components/components/CalendarEventSummaryBody.tsx
@@ -19,12 +19,14 @@ const StyledCenteredState = styled.div`
 
 type CalendarEventSummaryBodyProps = {
   summaryMarkdown: string | undefined;
+  summaryUnavailableReason: string | undefined;
   isCalendarEventSummaryQueryLoading: boolean;
   errorMessage: string | undefined;
 };
 
 export const CalendarEventSummaryBody = ({
   summaryMarkdown,
+  summaryUnavailableReason,
   isCalendarEventSummaryQueryLoading,
   errorMessage,
 }: CalendarEventSummaryBodyProps) => {
@@ -44,7 +46,7 @@ export const CalendarEventSummaryBody = ({
   if (isUndefined(summaryMarkdown)) {
     return (
       <StyledCenteredState>
-        No summary for this calendar event yet.
+        {summaryUnavailableReason ?? 'No summary for this calendar event yet.'}
       </StyledCenteredState>
     );
   }

--- a/packages/twenty-apps/public/call-recorder/src/front-components/components/CalendarEventSummaryContent.tsx
+++ b/packages/twenty-apps/public/call-recorder/src/front-components/components/CalendarEventSummaryContent.tsx
@@ -53,8 +53,12 @@ type CalendarEventSummaryContentProps = {
 export const CalendarEventSummaryContent = ({
   calendarEventId,
 }: CalendarEventSummaryContentProps) => {
-  const { summaryMarkdown, isCalendarEventSummaryQueryLoading, errorMessage } =
-    useCalendarEventSummary(calendarEventId);
+  const {
+    summaryMarkdown,
+    summaryUnavailableReason,
+    isCalendarEventSummaryQueryLoading,
+    errorMessage,
+  } = useCalendarEventSummary(calendarEventId);
 
   return (
     <StyledSummaryShell>
@@ -65,6 +69,7 @@ export const CalendarEventSummaryContent = ({
         <StyledSummaryContentFrame>
           <CalendarEventSummaryBody
             summaryMarkdown={summaryMarkdown}
+            summaryUnavailableReason={summaryUnavailableReason}
             isCalendarEventSummaryQueryLoading={
               isCalendarEventSummaryQueryLoading
             }

--- a/packages/twenty-apps/public/call-recorder/src/front-components/hooks/use-calendar-event-summary.ts
+++ b/packages/twenty-apps/public/call-recorder/src/front-components/hooks/use-calendar-event-summary.ts
@@ -2,16 +2,20 @@ import { isUndefined } from '@sniptt/guards';
 import { useEffect, useState } from 'react';
 import { CoreApiClient } from 'twenty-client-sdk/core';
 
+import { getSummaryUnavailableReason } from 'src/front-components/utils/get-summary-unavailable-reason.util';
 import { isNonEmptyString } from 'src/logic-functions/utils/is-non-empty-string.util';
 
 type CalendarEventSummaryState = {
   summaryMarkdown: string | undefined;
+  summaryUnavailableReason: string | undefined;
   isCalendarEventSummaryQueryLoading: boolean;
   errorMessage: string | undefined;
 };
 
 type CalendarEventSummaryCallRecordingNode = {
   id: string;
+  status: string | null;
+  callRecorderFailureReason: string | null;
   summary: { markdown: string | null } | null;
 };
 
@@ -37,6 +41,7 @@ export const useCalendarEventSummary = (
 ): CalendarEventSummaryState => {
   const [state, setState] = useState<CalendarEventSummaryState>({
     summaryMarkdown: undefined,
+    summaryUnavailableReason: undefined,
     isCalendarEventSummaryQueryLoading: !isUndefined(calendarEventId),
     errorMessage: undefined,
   });
@@ -45,6 +50,7 @@ export const useCalendarEventSummary = (
     if (isUndefined(calendarEventId)) {
       setState({
         summaryMarkdown: undefined,
+        summaryUnavailableReason: undefined,
         isCalendarEventSummaryQueryLoading: false,
         errorMessage: undefined,
       });
@@ -56,6 +62,7 @@ export const useCalendarEventSummary = (
     const fetchSummary = async () => {
       setState({
         summaryMarkdown: undefined,
+        summaryUnavailableReason: undefined,
         isCalendarEventSummaryQueryLoading: true,
         errorMessage: undefined,
       });
@@ -72,6 +79,8 @@ export const useCalendarEventSummary = (
             edges: {
               node: {
                 id: true,
+                status: true,
+                callRecorderFailureReason: true,
                 summary: { markdown: true },
               },
             },
@@ -87,9 +96,13 @@ export const useCalendarEventSummary = (
         const callRecordingNodes = callRecordingEdges.map(
           (callRecordingEdge) => callRecordingEdge.node,
         );
+        const summaryMarkdown = selectSummaryMarkdown(callRecordingNodes);
 
         setState({
-          summaryMarkdown: selectSummaryMarkdown(callRecordingNodes),
+          summaryMarkdown,
+          summaryUnavailableReason: isUndefined(summaryMarkdown)
+            ? getSummaryUnavailableReason(callRecordingNodes)
+            : undefined,
           isCalendarEventSummaryQueryLoading: false,
           errorMessage: undefined,
         });
@@ -100,6 +113,7 @@ export const useCalendarEventSummary = (
 
         setState({
           summaryMarkdown: undefined,
+          summaryUnavailableReason: undefined,
           isCalendarEventSummaryQueryLoading: false,
           errorMessage: CALENDAR_EVENT_SUMMARY_ERROR_MESSAGE,
         });

--- a/packages/twenty-apps/public/call-recorder/src/front-components/utils/__tests__/get-summary-unavailable-reason.test.ts
+++ b/packages/twenty-apps/public/call-recorder/src/front-components/utils/__tests__/get-summary-unavailable-reason.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, it } from 'vitest';
+
+import { getSummaryUnavailableReason } from 'src/front-components/utils/get-summary-unavailable-reason.util';
+
+describe('getSummaryUnavailableReason', () => {
+  it('returns undefined when there are no call recordings', () => {
+    expect(getSummaryUnavailableReason([])).toBeUndefined();
+  });
+
+  it('returns undefined when the recording is completed without a summary', () => {
+    expect(
+      getSummaryUnavailableReason([
+        { status: 'COMPLETED', callRecorderFailureReason: null },
+      ]),
+    ).toBeUndefined();
+  });
+
+  it('explains that the recording is still being processed', () => {
+    expect(
+      getSummaryUnavailableReason([
+        { status: 'PROCESSING', callRecorderFailureReason: null },
+      ]),
+    ).toBe(
+      'The recording is still being processed. The summary will appear here once it is ready.',
+    );
+  });
+
+  it('explains that the recording is in progress while recording', () => {
+    expect(
+      getSummaryUnavailableReason([
+        { status: 'RECORDING', callRecorderFailureReason: null },
+      ]),
+    ).toBe(
+      'The recording is in progress. The summary will be available once the call ends.',
+    );
+  });
+
+  it('explains that the recording is in progress while joining', () => {
+    expect(
+      getSummaryUnavailableReason([
+        { status: 'JOINING', callRecorderFailureReason: null },
+      ]),
+    ).toBe(
+      'The recording is in progress. The summary will be available once the call ends.',
+    );
+  });
+
+  it('explains that the recording is scheduled', () => {
+    expect(
+      getSummaryUnavailableReason([
+        { status: 'SCHEDULED', callRecorderFailureReason: null },
+      ]),
+    ).toBe(
+      'The recording is scheduled. The summary will be available once the call has been recorded.',
+    );
+  });
+
+  it('explains that the recording failed without a provider reason', () => {
+    expect(
+      getSummaryUnavailableReason([
+        { status: 'FAILED', callRecorderFailureReason: null },
+      ]),
+    ).toBe('The recording failed, so no summary could be generated.');
+  });
+
+  it('includes the provider failure reason when the recording failed', () => {
+    expect(
+      getSummaryUnavailableReason([
+        {
+          status: 'FAILED',
+          callRecorderFailureReason: '  video_file_too_large  ',
+        },
+      ]),
+    ).toBe(
+      'The recording failed, so no summary could be generated. Reason: video_file_too_large',
+    );
+  });
+
+  it('prioritizes an in-progress retry over an earlier failed attempt', () => {
+    expect(
+      getSummaryUnavailableReason([
+        { status: 'FAILED', callRecorderFailureReason: 'left_waiting_room' },
+        { status: 'RECORDING', callRecorderFailureReason: null },
+      ]),
+    ).toBe(
+      'The recording is in progress. The summary will be available once the call ends.',
+    );
+  });
+});

--- a/packages/twenty-apps/public/call-recorder/src/front-components/utils/get-summary-unavailable-reason.util.ts
+++ b/packages/twenty-apps/public/call-recorder/src/front-components/utils/get-summary-unavailable-reason.util.ts
@@ -1,0 +1,60 @@
+import { isUndefined } from '@sniptt/guards';
+
+import { CallRecordingStatus } from 'src/logic-functions/constants/call-recording-status';
+import { isNonEmptyString } from 'src/logic-functions/utils/is-non-empty-string.util';
+
+export type SummaryUnavailableCallRecording = {
+  status: string | null;
+  callRecorderFailureReason: string | null;
+};
+
+const RECORDING_PROCESSING_REASON =
+  'The recording is still being processed. The summary will appear here once it is ready.';
+const RECORDING_IN_PROGRESS_REASON =
+  'The recording is in progress. The summary will be available once the call ends.';
+const RECORDING_SCHEDULED_REASON =
+  'The recording is scheduled. The summary will be available once the call has been recorded.';
+const RECORDING_FAILED_REASON =
+  'The recording failed, so no summary could be generated.';
+
+const hasStatus = (
+  callRecordings: SummaryUnavailableCallRecording[],
+  status: CallRecordingStatus,
+): boolean =>
+  callRecordings.some((callRecording) => callRecording.status === status);
+
+// Explains why no summary is available, derived from the call recordings' lifecycle.
+// In-progress states take precedence over a failed attempt (a retry may be under way).
+// Returns undefined when the reason is unknown, so the caller keeps the default empty state.
+export const getSummaryUnavailableReason = (
+  callRecordings: SummaryUnavailableCallRecording[],
+): string | undefined => {
+  if (hasStatus(callRecordings, CallRecordingStatus.PROCESSING)) {
+    return RECORDING_PROCESSING_REASON;
+  }
+
+  if (
+    hasStatus(callRecordings, CallRecordingStatus.RECORDING) ||
+    hasStatus(callRecordings, CallRecordingStatus.JOINING)
+  ) {
+    return RECORDING_IN_PROGRESS_REASON;
+  }
+
+  if (hasStatus(callRecordings, CallRecordingStatus.SCHEDULED)) {
+    return RECORDING_SCHEDULED_REASON;
+  }
+
+  const failedCallRecording = callRecordings.find(
+    (callRecording) => callRecording.status === CallRecordingStatus.FAILED,
+  );
+
+  if (!isUndefined(failedCallRecording)) {
+    const failureReason = failedCallRecording.callRecorderFailureReason;
+
+    return isNonEmptyString(failureReason)
+      ? `${RECORDING_FAILED_REASON} Reason: ${failureReason.trim()}`
+      : RECORDING_FAILED_REASON;
+  }
+
+  return undefined;
+};


### PR DESCRIPTION
## What

When a call recording summary is not available, the calendar event **Summary** front component (in the `call-recorder` app) previously always showed a generic `No summary for this calendar event yet.` — leaving the user with no idea why.

This PR surfaces the reason directly in the summary empty state:

- **Processing** → _"The recording is still being processed. The summary will appear here once it is ready."_
- **Recording / Joining** → _"The recording is in progress. The summary will be available once the call ends."_
- **Scheduled** → _"The recording is scheduled. The summary will be available once the call has been recorded."_
- **Failed** → _"The recording failed, so no summary could be generated."_, appending the provider-specific `callRecorderFailureReason` when present.
- **Unknown** (e.g. completed with no summary, or no recording) → keeps the current generic message, as requested in the ticket.

In-progress states take precedence over an earlier failed attempt, since a retry may already be under way.

## How

- New pure util `get-summary-unavailable-reason.util.ts` that maps the call recordings' lifecycle (`status` + `callRecorderFailureReason`) to a human-readable reason, returning `undefined` when unknown.
- `use-calendar-event-summary` hook now also fetches `status` and `callRecorderFailureReason`, and computes `summaryUnavailableReason` when no summary markdown is found.
- `CalendarEventSummaryContent` threads the reason to `CalendarEventSummaryBody`, which renders it in the existing centered empty state (unchanged design when the reason is unknown).
- Bumped the app version `1.3.0` → `1.3.1`.

## Tests

- Added unit tests for the new util covering every lifecycle state, the failure reason passthrough/trimming, the retry-precedence rule, and the unknown → `undefined` fallback.
- Full app unit suite green (497 tests), typecheck and lint clean.

Closes twentyhq/core-team-issues#2700


---
_Generated by [Claude Code](https://claude.ai/code/session_01LzjzLPbfB9CcSXewGjjWSN)_

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/23051?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

