### PR TITLE
Avoid redundant Redis scan during view GraphQL queries cache invalidation

### DIFF
--- a/packages/twenty-server/src/engine/api/graphql/graphql-config/hooks/__tests__/use-cached-metadata.spec.ts
+++ b/packages/twenty-server/src/engine/api/graphql/graphql-config/hooks/__tests__/use-cached-metadata.spec.ts
@@ -1,0 +1,94 @@
+import { createHash } from 'crypto';
+
+import { type Request } from 'express';
+
+import { useCachedMetadata } from 'src/engine/api/graphql/graphql-config/hooks/use-cached-metadata';
+
+describe('useCachedMetadata', () => {
+  const query = 'query FindAllViews { views { id } }';
+  const queryHash = createHash('sha256').update(query).digest('hex');
+
+  const createRequest = (operationName = 'FindAllViews') =>
+    ({
+      body: { operationName, query },
+      locale: 'en',
+      userWorkspaceId: 'user-workspace-id',
+      workspace: { id: 'workspace-id', metadataVersion: 3 },
+    }) as Request;
+
+  it('includes the view cache version in FindAllViews cache keys', async () => {
+    const cacheGetter = jest.fn().mockResolvedValue(undefined);
+    const plugin = useCachedMetadata({
+      cacheGetter,
+      cacheSetter: jest.fn(),
+      findAllViewsCacheVersionGetter: jest
+        .fn()
+        .mockResolvedValue('view-version'),
+      operationsToCache: ['FindAllViews'],
+    });
+    const request = createRequest();
+
+    await plugin.onRequest?.({
+      endResponse: jest.fn(),
+      serverContext: { req: request },
+    } as never);
+
+    expect(cacheGetter).toHaveBeenCalledWith(
+      `graphql:operations:FindAllViews:workspace-id:3:view-version:user-workspace-id:${queryHash}`,
+    );
+  });
+
+  it('reuses the request version when caching the response', async () => {
+    const cacheGetter = jest.fn().mockResolvedValue(undefined);
+    const cacheSetter = jest.fn();
+    const findAllViewsCacheVersionGetter = jest
+      .fn()
+      .mockResolvedValueOnce('view-version-1')
+      .mockResolvedValueOnce('view-version-2');
+    const plugin = useCachedMetadata({
+      cacheGetter,
+      cacheSetter,
+      findAllViewsCacheVersionGetter,
+      operationsToCache: ['FindAllViews'],
+    });
+    const request = createRequest();
+    const serverContext = { req: request };
+
+    await plugin.onRequest?.({
+      endResponse: jest.fn(),
+      serverContext,
+    } as never);
+    await plugin.onResponse?.({
+      response: { json: jest.fn().mockResolvedValue({ data: { views: [] } }) },
+      serverContext,
+    } as never);
+
+    expect(findAllViewsCacheVersionGetter).toHaveBeenCalledTimes(1);
+    expect(cacheSetter).toHaveBeenCalledWith(
+      `graphql:operations:FindAllViews:workspace-id:3:view-version-1:user-workspace-id:${queryHash}`,
+      { data: { views: [] } },
+    );
+  });
+
+  it('does not load a view version for other metadata operations', async () => {
+    const cacheGetter = jest.fn().mockResolvedValue(undefined);
+    const findAllViewsCacheVersionGetter = jest.fn();
+    const plugin = useCachedMetadata({
+      cacheGetter,
+      cacheSetter: jest.fn(),
+      findAllViewsCacheVersionGetter,
+      operationsToCache: ['ObjectMetadataItems'],
+    });
+    const request = createRequest('ObjectMetadataItems');
+
+    await plugin.onRequest?.({
+      endResponse: jest.fn(),
+      serverContext: { req: request },
+    } as never);
+
+    expect(findAllViewsCacheVersionGetter).not.toHaveBeenCalled();
+    expect(cacheGetter).toHaveBeenCalledWith(
+      `graphql:operations:ObjectMetadataItems:workspace-id:3:en:${queryHash}`,
+    );
+  });
+});

--- a/packages/twenty-server/src/engine/api/graphql/graphql-config/hooks/__tests__/use-cached-metadata.spec.ts
+++ b/packages/twenty-server/src/engine/api/graphql/graphql-config/hooks/__tests__/use-cached-metadata.spec.ts
@@ -1,55 +1,142 @@
-import { createHash } from 'crypto';
-
 import { type Request } from 'express';
 
 import { useCachedMetadata } from 'src/engine/api/graphql/graphql-config/hooks/use-cached-metadata';
 
 describe('useCachedMetadata', () => {
-  const query = 'query FindAllViews { views { id } }';
-  const queryHash = createHash('sha256').update(query).digest('hex');
-
-  const createRequest = (operationName = 'FindAllViews') =>
+  const createRequest = (
+    overrides: Partial<
+      Pick<Request, 'body' | 'locale' | 'userWorkspaceId' | 'workspace'>
+    > = {},
+  ) =>
     ({
-      body: { operationName, query },
+      body: {
+        operationName: 'FindAllViews',
+        query: 'query FindAllViews { views { id } }',
+        variables: { objectMetadataId: 'object-id' },
+      },
       locale: 'en',
       userWorkspaceId: 'user-workspace-id',
       workspace: { id: 'workspace-id', metadataVersion: 3 },
+      ...overrides,
     }) as Request;
 
-  it('includes the view cache version in FindAllViews cache keys', async () => {
-    const cacheGetter = jest.fn().mockResolvedValue(undefined);
-    const plugin = useCachedMetadata({
+  const createPlugin = ({
+    cacheGetter = jest.fn().mockResolvedValue(undefined),
+    cacheSetter = jest.fn(),
+    dependencyVersionGetter = jest.fn().mockResolvedValue('dependencies-1'),
+  } = {}) =>
+    useCachedMetadata({
       cacheGetter,
-      cacheSetter: jest.fn(),
-      findAllViewsCacheVersionGetter: jest
-        .fn()
-        .mockResolvedValue('view-version'),
+      cacheSetter,
+      dependencyVersionGetters: {
+        FindAllViews: dependencyVersionGetter,
+      },
       operationsToCache: ['FindAllViews'],
     });
-    const request = createRequest();
 
+  const runOnRequest = async ({
+    plugin,
+    request,
+    endResponse = jest.fn(),
+  }: {
+    plugin: ReturnType<typeof createPlugin>;
+    request: Request;
+    endResponse?: jest.Mock;
+  }) => {
     await plugin.onRequest?.({
-      endResponse: jest.fn(),
+      endResponse,
       serverContext: { req: request },
     } as never);
+  };
 
-    expect(cacheGetter).toHaveBeenCalledWith(
-      `graphql:operations:FindAllViews:workspace-id:3:view-version:user-workspace-id:${queryHash}`,
+  it('returns a cached response for the same dependencies and request identity', async () => {
+    const cachedResponse = { data: { views: [{ id: 'view-id' }] } };
+    const cacheGetter = jest
+      .fn()
+      .mockResolvedValueOnce(undefined)
+      .mockResolvedValueOnce(cachedResponse);
+    const endResponse = jest.fn();
+    const plugin = createPlugin({ cacheGetter });
+
+    await runOnRequest({ plugin, request: createRequest() });
+    await runOnRequest({ plugin, request: createRequest(), endResponse });
+
+    expect(cacheGetter.mock.calls[0][0]).toBe(cacheGetter.mock.calls[1][0]);
+    expect(endResponse).toHaveBeenCalledWith(
+      expect.objectContaining({ status: 200 }),
     );
   });
 
-  it('reuses the request version when caching the response', async () => {
+  it('uses different keys when the dependency version changes', async () => {
+    const cacheGetter = jest.fn().mockResolvedValue(undefined);
+    const dependencyVersionGetter = jest
+      .fn()
+      .mockResolvedValueOnce('dependencies-1')
+      .mockResolvedValueOnce('dependencies-2');
+    const plugin = createPlugin({ cacheGetter, dependencyVersionGetter });
+
+    await runOnRequest({ plugin, request: createRequest() });
+    await runOnRequest({ plugin, request: createRequest() });
+
+    expect(cacheGetter.mock.calls[0][0]).not.toBe(cacheGetter.mock.calls[1][0]);
+  });
+
+  it.each([
+    ['user workspace', { userWorkspaceId: 'other-user-workspace-id' }],
+    ['locale', { locale: 'fr' }],
+    [
+      'variables',
+      {
+        body: {
+          operationName: 'FindAllViews',
+          query: 'query FindAllViews { views { id } }',
+          variables: { objectMetadataId: 'other-object-id' },
+        },
+      },
+    ],
+    [
+      'query',
+      {
+        body: {
+          operationName: 'FindAllViews',
+          query: 'query FindAllViews { views { name } }',
+          variables: { objectMetadataId: 'object-id' },
+        },
+      },
+    ],
+    [
+      'metadata version',
+      { workspace: { id: 'workspace-id', metadataVersion: 4 } },
+    ],
+  ] as const)(
+    'does not collide when %s changes',
+    async (_identityPart, requestOverrides) => {
+      const cacheGetter = jest.fn().mockResolvedValue(undefined);
+      const plugin = createPlugin({ cacheGetter });
+
+      await runOnRequest({ plugin, request: createRequest() });
+      await runOnRequest({
+        plugin,
+        request: createRequest(requestOverrides as never),
+      });
+
+      expect(cacheGetter.mock.calls[0][0]).not.toBe(
+        cacheGetter.mock.calls[1][0],
+      );
+    },
+  );
+
+  it('reuses the dependency version resolved at request start', async () => {
     const cacheGetter = jest.fn().mockResolvedValue(undefined);
     const cacheSetter = jest.fn();
-    const findAllViewsCacheVersionGetter = jest
+    const dependencyVersionGetter = jest
       .fn()
-      .mockResolvedValueOnce('view-version-1')
-      .mockResolvedValueOnce('view-version-2');
-    const plugin = useCachedMetadata({
+      .mockResolvedValueOnce('dependencies-1')
+      .mockResolvedValueOnce('dependencies-2');
+    const plugin = createPlugin({
       cacheGetter,
       cacheSetter,
-      findAllViewsCacheVersionGetter,
-      operationsToCache: ['FindAllViews'],
+      dependencyVersionGetter,
     });
     const request = createRequest();
     const serverContext = { req: request };
@@ -63,32 +150,32 @@ describe('useCachedMetadata', () => {
       serverContext,
     } as never);
 
-    expect(findAllViewsCacheVersionGetter).toHaveBeenCalledTimes(1);
-    expect(cacheSetter).toHaveBeenCalledWith(
-      `graphql:operations:FindAllViews:workspace-id:3:view-version-1:user-workspace-id:${queryHash}`,
-      { data: { views: [] } },
-    );
+    expect(dependencyVersionGetter).toHaveBeenCalledTimes(1);
+    expect(cacheSetter.mock.calls[0][0]).toContain(':dependencies-1:');
+    expect(cacheSetter.mock.calls[0][0]).not.toContain(':dependencies-2:');
   });
 
-  it('does not load a view version for other metadata operations', async () => {
-    const cacheGetter = jest.fn().mockResolvedValue(undefined);
-    const findAllViewsCacheVersionGetter = jest.fn();
-    const plugin = useCachedMetadata({
+  it('bypasses caching when dependency hashes remain unavailable', async () => {
+    const cacheGetter = jest.fn();
+    const cacheSetter = jest.fn();
+    const plugin = createPlugin({
       cacheGetter,
-      cacheSetter: jest.fn(),
-      findAllViewsCacheVersionGetter,
-      operationsToCache: ['ObjectMetadataItems'],
+      cacheSetter,
+      dependencyVersionGetter: jest.fn().mockResolvedValue(undefined),
     });
-    const request = createRequest('ObjectMetadataItems');
+    const request = createRequest();
+    const serverContext = { req: request };
 
     await plugin.onRequest?.({
       endResponse: jest.fn(),
-      serverContext: { req: request },
+      serverContext,
+    } as never);
+    await plugin.onResponse?.({
+      response: { json: jest.fn() },
+      serverContext,
     } as never);
 
-    expect(findAllViewsCacheVersionGetter).not.toHaveBeenCalled();
-    expect(cacheGetter).toHaveBeenCalledWith(
-      `graphql:operations:ObjectMetadataItems:workspace-id:3:en:${queryHash}`,
-    );
+    expect(cacheGetter).not.toHaveBeenCalled();
+    expect(cacheSetter).not.toHaveBeenCalled();
   });
 });

--- a/packages/twenty-server/src/engine/api/graphql/graphql-config/hooks/use-cached-metadata.ts
+++ b/packages/twenty-server/src/engine/api/graphql/graphql-config/hooks/use-cached-metadata.ts
@@ -11,17 +11,20 @@ export type CacheMetadataPluginConfig = {
   cacheGetter: (key: string) => any;
   // oxlint-disable-next-line typescript/no-explicit-any
   cacheSetter: (key: string, value: any) => void;
+  findAllViewsCacheVersionGetter: (
+    workspaceId: string,
+  ) => Promise<string | undefined>;
   operationsToCache: string[];
 };
 
 export function useCachedMetadata(config: CacheMetadataPluginConfig): Plugin {
-  const computeCacheKey = ({
+  const computeCacheKey = async ({
     operationName,
     request,
   }: {
     operationName: string;
     request: Pick<Request, 'workspace' | 'locale' | 'body' | 'userWorkspaceId'>;
-  }) => {
+  }): Promise<string> => {
     const workspace = request.workspace;
 
     if (!isDefined(workspace)) {
@@ -35,7 +38,10 @@ export function useCachedMetadata(config: CacheMetadataPluginConfig): Plugin {
       .digest('hex');
 
     if (operationName === 'FindAllViews') {
-      return `graphql:operations:${operationName}:${workspace.id}:${workspaceMetadataVersion}:${request.userWorkspaceId}:${queryHash}`;
+      const findAllViewsCacheVersion =
+        (await config.findAllViewsCacheVersionGetter(workspace.id)) ?? '0';
+
+      return `graphql:operations:${operationName}:${workspace.id}:${workspaceMetadataVersion}:${findAllViewsCacheVersion}:${request.userWorkspaceId}:${queryHash}`;
     }
 
     return `graphql:operations:${operationName}:${workspace.id}:${workspaceMetadataVersion}:${locale}:${queryHash}`;
@@ -44,6 +50,28 @@ export function useCachedMetadata(config: CacheMetadataPluginConfig): Plugin {
   // oxlint-disable-next-line typescript/no-explicit-any
   const getOperationName = (serverContext: any) =>
     serverContext?.req?.body?.operationName;
+
+  const cacheKeyByRequest = new WeakMap<object, string>();
+
+  const getCacheKey = async ({
+    operationName,
+    request,
+  }: {
+    operationName: string;
+    request: Pick<Request, 'workspace' | 'locale' | 'body' | 'userWorkspaceId'>;
+  }): Promise<string> => {
+    const existingCacheKey = cacheKeyByRequest.get(request);
+
+    if (existingCacheKey) {
+      return existingCacheKey;
+    }
+
+    const cacheKey = await computeCacheKey({ operationName, request });
+
+    cacheKeyByRequest.set(request, cacheKey);
+
+    return cacheKey;
+  };
 
   return {
     onRequest: async ({ endResponse, serverContext }) => {
@@ -58,7 +86,7 @@ export function useCachedMetadata(config: CacheMetadataPluginConfig): Plugin {
         return;
       }
 
-      const cacheKey = computeCacheKey({
+      const cacheKey = await getCacheKey({
         operationName: getOperationName(serverContext),
         request,
       });
@@ -81,7 +109,7 @@ export function useCachedMetadata(config: CacheMetadataPluginConfig): Plugin {
         return;
       }
 
-      const cacheKey = computeCacheKey({
+      const cacheKey = await getCacheKey({
         operationName: getOperationName(serverContext),
         request,
       });

--- a/packages/twenty-server/src/engine/api/graphql/graphql-config/hooks/use-cached-metadata.ts
+++ b/packages/twenty-server/src/engine/api/graphql/graphql-config/hooks/use-cached-metadata.ts
@@ -11,9 +11,9 @@ export type CacheMetadataPluginConfig = {
   cacheGetter: (key: string) => any;
   // oxlint-disable-next-line typescript/no-explicit-any
   cacheSetter: (key: string, value: any) => void;
-  findAllViewsCacheVersionGetter: (
-    workspaceId: string,
-  ) => Promise<string | undefined>;
+  dependencyVersionGetters?: Partial<
+    Record<string, (workspaceId: string) => Promise<string | undefined>>
+  >;
   operationsToCache: string[];
 };
 
@@ -24,7 +24,7 @@ export function useCachedMetadata(config: CacheMetadataPluginConfig): Plugin {
   }: {
     operationName: string;
     request: Pick<Request, 'workspace' | 'locale' | 'body' | 'userWorkspaceId'>;
-  }): Promise<string> => {
+  }): Promise<string | undefined> => {
     const workspace = request.workspace;
 
     if (!isDefined(workspace)) {
@@ -33,40 +33,49 @@ export function useCachedMetadata(config: CacheMetadataPluginConfig): Plugin {
 
     const workspaceMetadataVersion = workspace.metadataVersion ?? '0';
     const locale = request.locale;
-    const queryHash = createHash('sha256')
-      .update(request.body.query)
+    const requestHash = createHash('sha256')
+      .update(
+        JSON.stringify({
+          query: request.body.query,
+          variables: request.body.variables ?? null,
+        }),
+      )
       .digest('hex');
+    const dependencyVersionGetter =
+      config.dependencyVersionGetters?.[operationName];
+    const dependencyVersion = await dependencyVersionGetter?.(workspace.id);
 
-    if (operationName === 'FindAllViews') {
-      const findAllViewsCacheVersion =
-        (await config.findAllViewsCacheVersionGetter(workspace.id)) ?? '0';
-
-      return `graphql:operations:${operationName}:${workspace.id}:${workspaceMetadataVersion}:${findAllViewsCacheVersion}:${request.userWorkspaceId}:${queryHash}`;
+    if (isDefined(dependencyVersionGetter) && !isDefined(dependencyVersion)) {
+      return undefined;
     }
 
-    return `graphql:operations:${operationName}:${workspace.id}:${workspaceMetadataVersion}:${locale}:${queryHash}`;
+    if (operationName === 'FindAllViews') {
+      return `graphql:operations:${operationName}:${workspace.id}:${workspaceMetadataVersion}:${dependencyVersion}:${request.userWorkspaceId}:${locale}:${requestHash}`;
+    }
+
+    return `graphql:operations:${operationName}:${workspace.id}:${workspaceMetadataVersion}:${locale}:${requestHash}`;
   };
 
   // oxlint-disable-next-line typescript/no-explicit-any
   const getOperationName = (serverContext: any) =>
     serverContext?.req?.body?.operationName;
 
-  const cacheKeyByRequest = new WeakMap<object, string>();
+  const cacheKeyByRequest = new WeakMap<object, Promise<string | undefined>>();
 
-  const getCacheKey = async ({
+  const getCacheKey = ({
     operationName,
     request,
   }: {
     operationName: string;
     request: Pick<Request, 'workspace' | 'locale' | 'body' | 'userWorkspaceId'>;
-  }): Promise<string> => {
-    const existingCacheKey = cacheKeyByRequest.get(request);
+  }): Promise<string | undefined> => {
+    const cachedKey = cacheKeyByRequest.get(request);
 
-    if (existingCacheKey) {
-      return existingCacheKey;
+    if (isDefined(cachedKey)) {
+      return cachedKey;
     }
 
-    const cacheKey = await computeCacheKey({ operationName, request });
+    const cacheKey = computeCacheKey({ operationName, request });
 
     cacheKeyByRequest.set(request, cacheKey);
 
@@ -90,6 +99,11 @@ export function useCachedMetadata(config: CacheMetadataPluginConfig): Plugin {
         operationName: getOperationName(serverContext),
         request,
       });
+
+      if (!isDefined(cacheKey)) {
+        return;
+      }
+
       const cachedResponse = await config.cacheGetter(cacheKey);
 
       if (cachedResponse) {
@@ -113,6 +127,10 @@ export function useCachedMetadata(config: CacheMetadataPluginConfig): Plugin {
         operationName: getOperationName(serverContext),
         request,
       });
+
+      if (!isDefined(cacheKey)) {
+        return;
+      }
 
       const cachedResponse = await config.cacheGetter(cacheKey);
 

--- a/packages/twenty-server/src/engine/api/graphql/graphql-config/utils/__tests__/get-find-all-views-cache-dependency-version.util.spec.ts
+++ b/packages/twenty-server/src/engine/api/graphql/graphql-config/utils/__tests__/get-find-all-views-cache-dependency-version.util.spec.ts
@@ -1,0 +1,75 @@
+import {
+  FIND_ALL_VIEWS_CACHE_DEPENDENCIES,
+  getFindAllViewsCacheDependencyVersion,
+} from 'src/engine/api/graphql/graphql-config/utils/get-find-all-views-cache-dependency-version.util';
+
+describe('getFindAllViewsCacheDependencyVersion', () => {
+  const workspaceId = 'workspace-id';
+  const hashes = Object.fromEntries(
+    FIND_ALL_VIEWS_CACHE_DEPENDENCIES.map((dependency, index) => [
+      dependency,
+      `hash-${index}`,
+    ]),
+  );
+
+  const getVersion = async ({
+    getCacheHashes = jest.fn().mockResolvedValue(hashes),
+    getOrRecompute = jest.fn(),
+  } = {}) =>
+    getFindAllViewsCacheDependencyVersion({
+      workspaceCacheService: {
+        getCacheHashes,
+        getOrRecompute,
+      } as never,
+      workspaceId,
+    });
+
+  it('returns the same version for the same ordered dependency hashes', async () => {
+    const firstVersion = await getVersion();
+    const secondVersion = await getVersion();
+
+    expect(firstVersion).toBe(secondVersion);
+  });
+
+  it.each(FIND_ALL_VIEWS_CACHE_DEPENDENCIES)(
+    'changes the version when %s changes',
+    async (changedDependency) => {
+      const initialVersion = await getVersion();
+      const changedVersion = await getVersion({
+        getCacheHashes: jest.fn().mockResolvedValue({
+          ...hashes,
+          [changedDependency]: 'changed-hash',
+        }),
+      });
+
+      expect(changedVersion).not.toBe(initialVersion);
+    },
+  );
+
+  it('recomputes only missing dependencies before deriving the version', async () => {
+    const { flatViewSortMaps: _missingHash, ...coldHashes } = hashes;
+    const getCacheHashes = jest
+      .fn()
+      .mockResolvedValueOnce(coldHashes)
+      .mockResolvedValueOnce(hashes);
+    const getOrRecompute = jest.fn().mockResolvedValue(undefined);
+
+    const version = await getVersion({ getCacheHashes, getOrRecompute });
+
+    expect(getOrRecompute).toHaveBeenCalledWith(workspaceId, [
+      'flatViewSortMaps',
+    ]);
+    expect(version).toBeDefined();
+  });
+
+  it('returns undefined when hashes remain unavailable after recomputation', async () => {
+    const { flatViewSortMaps: _missingHash, ...incompleteHashes } = hashes;
+    const getCacheHashes = jest.fn().mockResolvedValue(incompleteHashes);
+    const getOrRecompute = jest.fn().mockResolvedValue(undefined);
+
+    const version = await getVersion({ getCacheHashes, getOrRecompute });
+
+    expect(getCacheHashes).toHaveBeenCalledTimes(2);
+    expect(version).toBeUndefined();
+  });
+});

--- a/packages/twenty-server/src/engine/api/graphql/graphql-config/utils/get-find-all-views-cache-dependency-version.util.ts
+++ b/packages/twenty-server/src/engine/api/graphql/graphql-config/utils/get-find-all-views-cache-dependency-version.util.ts
@@ -1,0 +1,54 @@
+import { createHash } from 'crypto';
+
+import { isDefined } from 'twenty-shared/utils';
+
+import { type WorkspaceCacheService } from 'src/engine/workspace-cache/services/workspace-cache.service';
+import { type WorkspaceCacheKeyName } from 'src/engine/workspace-cache/types/workspace-cache-key.type';
+
+export const FIND_ALL_VIEWS_CACHE_DEPENDENCIES = [
+  'flatViewMaps',
+  'flatViewFieldMaps',
+  'flatViewFieldGroupMaps',
+  'flatViewGroupMaps',
+  'flatViewSortMaps',
+  'flatViewFilterMaps',
+  'flatViewFilterGroupMaps',
+] as const satisfies readonly WorkspaceCacheKeyName[];
+
+export const getFindAllViewsCacheDependencyVersion = async ({
+  workspaceCacheService,
+  workspaceId,
+}: {
+  workspaceCacheService: WorkspaceCacheService;
+  workspaceId: string;
+}): Promise<string | undefined> => {
+  let cacheHashes = await workspaceCacheService.getCacheHashes(workspaceId, [
+    ...FIND_ALL_VIEWS_CACHE_DEPENDENCIES,
+  ]);
+  const missingDependencies = FIND_ALL_VIEWS_CACHE_DEPENDENCIES.filter(
+    (dependency) => !isDefined(cacheHashes[dependency]),
+  );
+
+  if (missingDependencies.length > 0) {
+    await workspaceCacheService.getOrRecompute(workspaceId, [
+      ...missingDependencies,
+    ]);
+    cacheHashes = await workspaceCacheService.getCacheHashes(workspaceId, [
+      ...FIND_ALL_VIEWS_CACHE_DEPENDENCIES,
+    ]);
+  }
+
+  const dependencyValues: string[] = [];
+
+  for (const dependency of FIND_ALL_VIEWS_CACHE_DEPENDENCIES) {
+    const cacheHash = cacheHashes[dependency];
+
+    if (!isDefined(cacheHash)) {
+      return undefined;
+    }
+
+    dependencyValues.push(`${dependency}:${cacheHash}`);
+  }
+
+  return createHash('sha256').update(dependencyValues.join('|')).digest('hex');
+};

--- a/packages/twenty-server/src/engine/api/graphql/metadata-graphql-api.module.ts
+++ b/packages/twenty-server/src/engine/api/graphql/metadata-graphql-api.module.ts
@@ -16,8 +16,8 @@ import { TwentyConfigService } from 'src/engine/core-modules/twenty-config/twent
 import { DataloaderModule } from 'src/engine/dataloaders/dataloader.module';
 import { DataloaderService } from 'src/engine/dataloaders/dataloader.service';
 import { MetadataEngineModule } from 'src/engine/metadata-modules/metadata-engine.module';
-import { WorkspaceCacheStorageModule } from 'src/engine/workspace-cache-storage/workspace-cache-storage.module';
-import { WorkspaceCacheStorageService } from 'src/engine/workspace-cache-storage/workspace-cache-storage.service';
+import { WorkspaceCacheModule } from 'src/engine/workspace-cache/workspace-cache.module';
+import { WorkspaceCacheService } from 'src/engine/workspace-cache/services/workspace-cache.service';
 
 @Module({
   imports: [
@@ -29,14 +29,14 @@ import { WorkspaceCacheStorageService } from 'src/engine/workspace-cache-storage
         DataloaderModule,
         MetricsModule,
         I18nModule,
-        WorkspaceCacheStorageModule,
+        WorkspaceCacheModule,
       ],
       inject: [
         TwentyConfigService,
         ExceptionHandlerService,
         DataloaderService,
         CacheStorageNamespace.EngineWorkspace,
-        WorkspaceCacheStorageService,
+        WorkspaceCacheService,
         MetricsService,
         I18nService,
         FeatureFlagService,

--- a/packages/twenty-server/src/engine/api/graphql/metadata-graphql-api.module.ts
+++ b/packages/twenty-server/src/engine/api/graphql/metadata-graphql-api.module.ts
@@ -16,6 +16,8 @@ import { TwentyConfigService } from 'src/engine/core-modules/twenty-config/twent
 import { DataloaderModule } from 'src/engine/dataloaders/dataloader.module';
 import { DataloaderService } from 'src/engine/dataloaders/dataloader.service';
 import { MetadataEngineModule } from 'src/engine/metadata-modules/metadata-engine.module';
+import { WorkspaceCacheStorageModule } from 'src/engine/workspace-cache-storage/workspace-cache-storage.module';
+import { WorkspaceCacheStorageService } from 'src/engine/workspace-cache-storage/workspace-cache-storage.service';
 
 @Module({
   imports: [
@@ -27,12 +29,14 @@ import { MetadataEngineModule } from 'src/engine/metadata-modules/metadata-engin
         DataloaderModule,
         MetricsModule,
         I18nModule,
+        WorkspaceCacheStorageModule,
       ],
       inject: [
         TwentyConfigService,
         ExceptionHandlerService,
         DataloaderService,
         CacheStorageNamespace.EngineWorkspace,
+        WorkspaceCacheStorageService,
         MetricsService,
         I18nService,
         FeatureFlagService,

--- a/packages/twenty-server/src/engine/api/graphql/metadata.module-factory.ts
+++ b/packages/twenty-server/src/engine/api/graphql/metadata.module-factory.ts
@@ -5,6 +5,7 @@ import GraphQLJSON from 'graphql-type-json';
 import { NodeEnvironment } from 'src/engine/core-modules/twenty-config/interfaces/node-environment.interface';
 
 import { useCachedMetadata } from 'src/engine/api/graphql/graphql-config/hooks/use-cached-metadata';
+import { getFindAllViewsCacheDependencyVersion } from 'src/engine/api/graphql/graphql-config/utils/get-find-all-views-cache-dependency-version.util';
 import { MetadataGraphQLApiModule } from 'src/engine/api/graphql/metadata-graphql-api.module';
 import { type CacheStorageService } from 'src/engine/core-modules/cache-storage/services/cache-storage.service';
 import { ClientConfig } from 'src/engine/core-modules/client-config/client-config.entity';
@@ -19,14 +20,14 @@ import { type MetricsService } from 'src/engine/core-modules/metrics/metrics.ser
 import { type TwentyConfigService } from 'src/engine/core-modules/twenty-config/twenty-config.service';
 import { type DataloaderService } from 'src/engine/dataloaders/dataloader.service';
 import { renderApolloPlayground } from 'src/engine/utils/render-apollo-playground.util';
-import { type WorkspaceCacheStorageService } from 'src/engine/workspace-cache-storage/workspace-cache-storage.service';
+import { type WorkspaceCacheService } from 'src/engine/workspace-cache/services/workspace-cache.service';
 
 export const metadataModuleFactory = async (
   twentyConfigService: TwentyConfigService,
   exceptionHandlerService: ExceptionHandlerService,
   dataloaderService: DataloaderService,
   cacheStorageService: CacheStorageService,
-  workspaceCacheStorageService: WorkspaceCacheStorageService,
+  workspaceCacheService: WorkspaceCacheService,
   metricsService: MetricsService,
   i18nService: I18nService,
   _featureFlagService: FeatureFlagService,
@@ -53,10 +54,13 @@ export const metadataModuleFactory = async (
       useCachedMetadata({
         cacheGetter: cacheStorageService.get.bind(cacheStorageService),
         cacheSetter: cacheStorageService.set.bind(cacheStorageService),
-        findAllViewsCacheVersionGetter:
-          workspaceCacheStorageService.getFindAllViewsCacheVersion.bind(
-            workspaceCacheStorageService,
-          ),
+        dependencyVersionGetters: {
+          FindAllViews: (workspaceId) =>
+            getFindAllViewsCacheDependencyVersion({
+              workspaceCacheService,
+              workspaceId,
+            }),
+        },
         operationsToCache: ['ObjectMetadataItems', 'FindAllViews'],
       }),
       useDisableIntrospectionAndSuggestionsForUnauthenticatedUsers(

--- a/packages/twenty-server/src/engine/api/graphql/metadata.module-factory.ts
+++ b/packages/twenty-server/src/engine/api/graphql/metadata.module-factory.ts
@@ -19,12 +19,14 @@ import { type MetricsService } from 'src/engine/core-modules/metrics/metrics.ser
 import { type TwentyConfigService } from 'src/engine/core-modules/twenty-config/twenty-config.service';
 import { type DataloaderService } from 'src/engine/dataloaders/dataloader.service';
 import { renderApolloPlayground } from 'src/engine/utils/render-apollo-playground.util';
+import { type WorkspaceCacheStorageService } from 'src/engine/workspace-cache-storage/workspace-cache-storage.service';
 
 export const metadataModuleFactory = async (
   twentyConfigService: TwentyConfigService,
   exceptionHandlerService: ExceptionHandlerService,
   dataloaderService: DataloaderService,
   cacheStorageService: CacheStorageService,
+  workspaceCacheStorageService: WorkspaceCacheStorageService,
   metricsService: MetricsService,
   i18nService: I18nService,
   _featureFlagService: FeatureFlagService,
@@ -51,6 +53,10 @@ export const metadataModuleFactory = async (
       useCachedMetadata({
         cacheGetter: cacheStorageService.get.bind(cacheStorageService),
         cacheSetter: cacheStorageService.set.bind(cacheStorageService),
+        findAllViewsCacheVersionGetter:
+          workspaceCacheStorageService.getFindAllViewsCacheVersion.bind(
+            workspaceCacheStorageService,
+          ),
         operationsToCache: ['ObjectMetadataItems', 'FindAllViews'],
       }),
       useDisableIntrospectionAndSuggestionsForUnauthenticatedUsers(

--- a/packages/twenty-server/src/engine/workspace-cache-storage/workspace-cache-storage.service.ts
+++ b/packages/twenty-server/src/engine/workspace-cache-storage/workspace-cache-storage.service.ts
@@ -20,6 +20,7 @@ export const METADATA_VERSIONED_WORKSPACE_CACHE_KEY = {
 } as const;
 export const WORKSPACE_CACHE_KEYS = {
   GraphQLOperations: 'graphql:operations',
+  FindAllViewsCacheVersion: 'graphql:find-all-views-cache-version',
   GraphQLFeatureFlag: 'graphql:feature-flag',
   FeatureFlagMap: 'feature-flag:feature-flag-map',
   FeatureFlagMapVersion: 'feature-flag:feature-flag-map-version',
@@ -184,15 +185,21 @@ export class WorkspaceCacheStorageService {
     );
   }
 
-  async flushGraphQLOperation({
-    operationName,
-    workspaceId,
-  }: {
-    operationName: string;
-    workspaceId: string;
-  }): Promise<void> {
-    await this.cacheStorageService.flushByPattern(
-      `${WORKSPACE_CACHE_KEYS.GraphQLOperations}:${operationName}:${workspaceId}:*`,
+  getFindAllViewsCacheVersion(
+    workspaceId: string,
+  ): Promise<string | undefined> {
+    return this.cacheStorageService.get<string>(
+      `${WORKSPACE_CACHE_KEYS.FindAllViewsCacheVersion}:${workspaceId}`,
+    );
+  }
+
+  async setFindAllViewsCacheVersion(workspaceId: string): Promise<void> {
+    const version = crypto.randomUUID();
+
+    await this.cacheStorageService.set<string>(
+      `${WORKSPACE_CACHE_KEYS.FindAllViewsCacheVersion}:${workspaceId}`,
+      version,
+      TTL_ONE_WEEK,
     );
   }
 

--- a/packages/twenty-server/src/engine/workspace-cache-storage/workspace-cache-storage.service.ts
+++ b/packages/twenty-server/src/engine/workspace-cache-storage/workspace-cache-storage.service.ts
@@ -19,8 +19,6 @@ export const METADATA_VERSIONED_WORKSPACE_CACHE_KEY = {
   ORMEntitySchemas: 'orm:entity-schemas',
 } as const;
 export const WORKSPACE_CACHE_KEYS = {
-  GraphQLOperations: 'graphql:operations',
-  FindAllViewsCacheVersion: 'graphql:find-all-views-cache-version',
   GraphQLFeatureFlag: 'graphql:feature-flag',
   FeatureFlagMap: 'feature-flag:feature-flag-map',
   FeatureFlagMapVersion: 'feature-flag:feature-flag-map-version',
@@ -182,24 +180,6 @@ export class WorkspaceCacheStorageService {
   getFeatureFlagsMap(workspaceId: string): Promise<FeatureFlagMap | undefined> {
     return this.cacheStorageService.get<FeatureFlagMap>(
       `${WORKSPACE_CACHE_KEYS.FeatureFlagMap}:${workspaceId}`,
-    );
-  }
-
-  getFindAllViewsCacheVersion(
-    workspaceId: string,
-  ): Promise<string | undefined> {
-    return this.cacheStorageService.get<string>(
-      `${WORKSPACE_CACHE_KEYS.FindAllViewsCacheVersion}:${workspaceId}`,
-    );
-  }
-
-  async setFindAllViewsCacheVersion(workspaceId: string): Promise<void> {
-    const version = crypto.randomUUID();
-
-    await this.cacheStorageService.set<string>(
-      `${WORKSPACE_CACHE_KEYS.FindAllViewsCacheVersion}:${workspaceId}`,
-      version,
-      TTL_ONE_WEEK,
     );
   }
 

--- a/packages/twenty-server/src/engine/workspace-manager/workspace-migration/workspace-migration-runner/services/__tests__/workspace-migration-runner.service.spec.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/workspace-migration/workspace-migration-runner/services/__tests__/workspace-migration-runner.service.spec.ts
@@ -1,0 +1,74 @@
+import { FIND_ALL_VIEWS_GRAPHQL_OPERATION } from 'src/engine/metadata-modules/view/constants/find-all-views-graphql-operation.constant';
+import { WorkspaceMigrationRunnerService } from 'src/engine/workspace-manager/workspace-migration/workspace-migration-runner/services/workspace-migration-runner.service';
+
+describe('WorkspaceMigrationRunnerService', () => {
+  const workspaceId = 'workspace-id';
+
+  let service: WorkspaceMigrationRunnerService;
+  let invalidateFlatEntityMaps: jest.Mock;
+  let incrementMetadataVersion: jest.Mock;
+  let flushGraphQLOperation: jest.Mock;
+  let invalidateAndRecompute: jest.Mock;
+
+  beforeEach(() => {
+    invalidateFlatEntityMaps = jest.fn().mockResolvedValue(undefined);
+    incrementMetadataVersion = jest.fn().mockResolvedValue(undefined);
+    flushGraphQLOperation = jest.fn().mockResolvedValue(undefined);
+    invalidateAndRecompute = jest.fn().mockResolvedValue(undefined);
+
+    service = new WorkspaceMigrationRunnerService(
+      { invalidateFlatEntityMaps } as never,
+      {} as never,
+      {} as never,
+      { incrementMetadataVersion } as never,
+      { flushGraphQLOperation } as never,
+      { invalidateAndRecompute } as never,
+      {
+        perfTime: jest.fn(),
+        perfTimeEnd: jest.fn(),
+        error: jest.fn(),
+      } as never,
+      {} as never,
+    );
+  });
+
+  it.each(['flatObjectMetadataMaps', 'flatFieldMetadataMaps'] as const)(
+    'invalidates versioned GraphQL caches without scanning for %s',
+    async (flatMapsKey) => {
+      await service.invalidateCache({
+        allFlatEntityMapsKeys: [flatMapsKey],
+        workspaceId,
+      });
+
+      expect(incrementMetadataVersion).toHaveBeenCalledWith(workspaceId);
+      expect(flushGraphQLOperation).not.toHaveBeenCalled();
+      expect(invalidateAndRecompute).toHaveBeenCalledWith(workspaceId, [
+        'ORMEntityMetadatas',
+        'graphQLResolverNameMap',
+      ]);
+    },
+  );
+
+  it('keeps pattern invalidation for view-only changes', async () => {
+    await service.invalidateCache({
+      allFlatEntityMapsKeys: ['flatViewMaps'],
+      workspaceId,
+    });
+
+    expect(incrementMetadataVersion).not.toHaveBeenCalled();
+    expect(flushGraphQLOperation).toHaveBeenCalledWith({
+      operationName: FIND_ALL_VIEWS_GRAPHQL_OPERATION,
+      workspaceId,
+    });
+  });
+
+  it('uses the metadata version when metadata and views change together', async () => {
+    await service.invalidateCache({
+      allFlatEntityMapsKeys: ['flatObjectMetadataMaps', 'flatViewMaps'],
+      workspaceId,
+    });
+
+    expect(incrementMetadataVersion).toHaveBeenCalledWith(workspaceId);
+    expect(flushGraphQLOperation).not.toHaveBeenCalled();
+  });
+});

--- a/packages/twenty-server/src/engine/workspace-manager/workspace-migration/workspace-migration-runner/services/__tests__/workspace-migration-runner.service.spec.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/workspace-migration/workspace-migration-runner/services/__tests__/workspace-migration-runner.service.spec.ts
@@ -1,4 +1,3 @@
-import { FIND_ALL_VIEWS_GRAPHQL_OPERATION } from 'src/engine/metadata-modules/view/constants/find-all-views-graphql-operation.constant';
 import { WorkspaceMigrationRunnerService } from 'src/engine/workspace-manager/workspace-migration/workspace-migration-runner/services/workspace-migration-runner.service';
 
 describe('WorkspaceMigrationRunnerService', () => {
@@ -7,13 +6,13 @@ describe('WorkspaceMigrationRunnerService', () => {
   let service: WorkspaceMigrationRunnerService;
   let invalidateFlatEntityMaps: jest.Mock;
   let incrementMetadataVersion: jest.Mock;
-  let flushGraphQLOperation: jest.Mock;
+  let setFindAllViewsCacheVersion: jest.Mock;
   let invalidateAndRecompute: jest.Mock;
 
   beforeEach(() => {
     invalidateFlatEntityMaps = jest.fn().mockResolvedValue(undefined);
     incrementMetadataVersion = jest.fn().mockResolvedValue(undefined);
-    flushGraphQLOperation = jest.fn().mockResolvedValue(undefined);
+    setFindAllViewsCacheVersion = jest.fn().mockResolvedValue(undefined);
     invalidateAndRecompute = jest.fn().mockResolvedValue(undefined);
 
     service = new WorkspaceMigrationRunnerService(
@@ -21,7 +20,7 @@ describe('WorkspaceMigrationRunnerService', () => {
       {} as never,
       {} as never,
       { incrementMetadataVersion } as never,
-      { flushGraphQLOperation } as never,
+      { setFindAllViewsCacheVersion } as never,
       { invalidateAndRecompute } as never,
       {
         perfTime: jest.fn(),
@@ -41,7 +40,7 @@ describe('WorkspaceMigrationRunnerService', () => {
       });
 
       expect(incrementMetadataVersion).toHaveBeenCalledWith(workspaceId);
-      expect(flushGraphQLOperation).not.toHaveBeenCalled();
+      expect(setFindAllViewsCacheVersion).not.toHaveBeenCalled();
       expect(invalidateAndRecompute).toHaveBeenCalledWith(workspaceId, [
         'ORMEntityMetadatas',
         'graphQLResolverNameMap',
@@ -49,17 +48,14 @@ describe('WorkspaceMigrationRunnerService', () => {
     },
   );
 
-  it('keeps pattern invalidation for view-only changes', async () => {
+  it('increments the view cache version for view-only changes', async () => {
     await service.invalidateCache({
       allFlatEntityMapsKeys: ['flatViewMaps'],
       workspaceId,
     });
 
     expect(incrementMetadataVersion).not.toHaveBeenCalled();
-    expect(flushGraphQLOperation).toHaveBeenCalledWith({
-      operationName: FIND_ALL_VIEWS_GRAPHQL_OPERATION,
-      workspaceId,
-    });
+    expect(setFindAllViewsCacheVersion).toHaveBeenCalledWith(workspaceId);
   });
 
   it('uses the metadata version when metadata and views change together', async () => {
@@ -69,6 +65,6 @@ describe('WorkspaceMigrationRunnerService', () => {
     });
 
     expect(incrementMetadataVersion).toHaveBeenCalledWith(workspaceId);
-    expect(flushGraphQLOperation).not.toHaveBeenCalled();
+    expect(setFindAllViewsCacheVersion).not.toHaveBeenCalled();
   });
 });

--- a/packages/twenty-server/src/engine/workspace-manager/workspace-migration/workspace-migration-runner/services/__tests__/workspace-migration-runner.service.spec.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/workspace-migration/workspace-migration-runner/services/__tests__/workspace-migration-runner.service.spec.ts
@@ -6,13 +6,11 @@ describe('WorkspaceMigrationRunnerService', () => {
   let service: WorkspaceMigrationRunnerService;
   let invalidateFlatEntityMaps: jest.Mock;
   let incrementMetadataVersion: jest.Mock;
-  let setFindAllViewsCacheVersion: jest.Mock;
   let invalidateAndRecompute: jest.Mock;
 
   beforeEach(() => {
     invalidateFlatEntityMaps = jest.fn().mockResolvedValue(undefined);
     incrementMetadataVersion = jest.fn().mockResolvedValue(undefined);
-    setFindAllViewsCacheVersion = jest.fn().mockResolvedValue(undefined);
     invalidateAndRecompute = jest.fn().mockResolvedValue(undefined);
 
     service = new WorkspaceMigrationRunnerService(
@@ -20,7 +18,6 @@ describe('WorkspaceMigrationRunnerService', () => {
       {} as never,
       {} as never,
       { incrementMetadataVersion } as never,
-      { setFindAllViewsCacheVersion } as never,
       { invalidateAndRecompute } as never,
       {
         perfTime: jest.fn(),
@@ -40,7 +37,6 @@ describe('WorkspaceMigrationRunnerService', () => {
       });
 
       expect(incrementMetadataVersion).toHaveBeenCalledWith(workspaceId);
-      expect(setFindAllViewsCacheVersion).not.toHaveBeenCalled();
       expect(invalidateAndRecompute).toHaveBeenCalledWith(workspaceId, [
         'ORMEntityMetadatas',
         'graphQLResolverNameMap',
@@ -48,14 +44,18 @@ describe('WorkspaceMigrationRunnerService', () => {
     },
   );
 
-  it('increments the view cache version for view-only changes', async () => {
+  it('rotates view flat-map hashes without incrementing metadata version', async () => {
     await service.invalidateCache({
       allFlatEntityMapsKeys: ['flatViewMaps'],
       workspaceId,
     });
 
+    expect(invalidateFlatEntityMaps).toHaveBeenCalledWith({
+      flatMapsKeys: ['flatViewMaps'],
+      workspaceId,
+    });
     expect(incrementMetadataVersion).not.toHaveBeenCalled();
-    expect(setFindAllViewsCacheVersion).toHaveBeenCalledWith(workspaceId);
+    expect(invalidateAndRecompute).not.toHaveBeenCalled();
   });
 
   it('uses the metadata version when metadata and views change together', async () => {
@@ -65,6 +65,9 @@ describe('WorkspaceMigrationRunnerService', () => {
     });
 
     expect(incrementMetadataVersion).toHaveBeenCalledWith(workspaceId);
-    expect(setFindAllViewsCacheVersion).not.toHaveBeenCalled();
+    expect(invalidateAndRecompute).toHaveBeenCalledWith(workspaceId, [
+      'ORMEntityMetadatas',
+      'graphQLResolverNameMap',
+    ]);
   });
 });

--- a/packages/twenty-server/src/engine/workspace-manager/workspace-migration/workspace-migration-runner/services/workspace-migration-runner.service.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/workspace-migration/workspace-migration-runner/services/workspace-migration-runner.service.ts
@@ -16,7 +16,6 @@ import { getMetadataRelatedMetadataNames } from 'src/engine/metadata-modules/fla
 import { getMetadataSerializedRelationNames } from 'src/engine/metadata-modules/flat-entity/utils/get-metadata-serialized-relation-names.util';
 import { createSearchFieldMetadatasByTsVectorFieldIdAccessor } from 'src/engine/metadata-modules/flat-search-field-metadata/utils/create-search-field-metadatas-by-ts-vector-field-id-accessor.util';
 import { WorkspaceMetadataVersionService } from 'src/engine/metadata-modules/workspace-metadata-version/services/workspace-metadata-version.service';
-import { WorkspaceCacheStorageService } from 'src/engine/workspace-cache-storage/workspace-cache-storage.service';
 import { WorkspaceCacheService } from 'src/engine/workspace-cache/services/workspace-cache.service';
 import { WorkspaceMigration } from 'src/engine/workspace-manager/workspace-migration/workspace-migration-builder/types/workspace-migration.type';
 import {
@@ -36,7 +35,6 @@ export class WorkspaceMigrationRunnerService {
     private readonly coreDataSource: DataSource,
     private readonly workspaceMigrationRunnerActionHandlerRegistry: WorkspaceMigrationRunnerActionHandlerRegistryService,
     private readonly workspaceMetadataVersionService: WorkspaceMetadataVersionService,
-    private readonly workspaceCacheStorageService: WorkspaceCacheStorageService,
     private readonly workspaceCacheService: WorkspaceCacheService,
     private readonly logger: LoggerService,
     private readonly twentyConfigService: TwentyConfigService,
@@ -59,27 +57,6 @@ export class WorkspaceMigrationRunnerService {
     if (shouldIncrementMetadataGraphqlSchemaVersion) {
       asyncOperations.push(
         this.workspaceMetadataVersionService.incrementMetadataVersion(
-          workspaceId,
-        ),
-      );
-    }
-
-    const viewRelatedFlatMapsKeys: (keyof AllFlatEntityMaps)[] = [
-      'flatViewMaps',
-      'flatViewFilterMaps',
-      'flatViewGroupMaps',
-      'flatViewFieldMaps',
-      'flatViewFilterGroupMaps',
-    ];
-    const shouldInvalidateFindViewsGraphqlCacheOperation =
-      viewRelatedFlatMapsKeys.some((key) => flatMapsKeysSet.has(key));
-
-    if (
-      shouldInvalidateFindViewsGraphqlCacheOperation &&
-      !shouldIncrementMetadataGraphqlSchemaVersion
-    ) {
-      asyncOperations.push(
-        this.workspaceCacheStorageService.setFindAllViewsCacheVersion(
           workspaceId,
         ),
       );

--- a/packages/twenty-server/src/engine/workspace-manager/workspace-migration/workspace-migration-runner/services/workspace-migration-runner.service.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/workspace-migration/workspace-migration-runner/services/workspace-migration-runner.service.ts
@@ -75,9 +75,11 @@ export class WorkspaceMigrationRunnerService {
     const shouldInvalidateFindViewsGraphqlCacheOperation =
       viewRelatedFlatMapsKeys.some((key) => flatMapsKeysSet.has(key));
 
+    // Metadata changes already invalidate versioned GraphQL operation keys.
+    // Avoid a redundant pattern flush, which scans the full Redis keyspace.
     if (
-      shouldInvalidateFindViewsGraphqlCacheOperation ||
-      shouldIncrementMetadataGraphqlSchemaVersion
+      shouldInvalidateFindViewsGraphqlCacheOperation &&
+      !shouldIncrementMetadataGraphqlSchemaVersion
     ) {
       asyncOperations.push(
         this.workspaceCacheStorageService.flushGraphQLOperation({

--- a/packages/twenty-server/src/engine/workspace-manager/workspace-migration/workspace-migration-runner/services/workspace-migration-runner.service.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/workspace-migration/workspace-migration-runner/services/workspace-migration-runner.service.ts
@@ -15,7 +15,6 @@ import { getMetadataRelatedMetadataNamesForValidation } from 'src/engine/metadat
 import { getMetadataRelatedMetadataNames } from 'src/engine/metadata-modules/flat-entity/utils/get-metadata-related-metadata-names.util';
 import { getMetadataSerializedRelationNames } from 'src/engine/metadata-modules/flat-entity/utils/get-metadata-serialized-relation-names.util';
 import { createSearchFieldMetadatasByTsVectorFieldIdAccessor } from 'src/engine/metadata-modules/flat-search-field-metadata/utils/create-search-field-metadatas-by-ts-vector-field-id-accessor.util';
-import { FIND_ALL_VIEWS_GRAPHQL_OPERATION } from 'src/engine/metadata-modules/view/constants/find-all-views-graphql-operation.constant';
 import { WorkspaceMetadataVersionService } from 'src/engine/metadata-modules/workspace-metadata-version/services/workspace-metadata-version.service';
 import { WorkspaceCacheStorageService } from 'src/engine/workspace-cache-storage/workspace-cache-storage.service';
 import { WorkspaceCacheService } from 'src/engine/workspace-cache/services/workspace-cache.service';
@@ -75,17 +74,14 @@ export class WorkspaceMigrationRunnerService {
     const shouldInvalidateFindViewsGraphqlCacheOperation =
       viewRelatedFlatMapsKeys.some((key) => flatMapsKeysSet.has(key));
 
-    // Metadata changes already invalidate versioned GraphQL operation keys.
-    // Avoid a redundant pattern flush, which scans the full Redis keyspace.
     if (
       shouldInvalidateFindViewsGraphqlCacheOperation &&
       !shouldIncrementMetadataGraphqlSchemaVersion
     ) {
       asyncOperations.push(
-        this.workspaceCacheStorageService.flushGraphQLOperation({
-          operationName: FIND_ALL_VIEWS_GRAPHQL_OPERATION,
+        this.workspaceCacheStorageService.setFindAllViewsCacheVersion(
           workspaceId,
-        }),
+        ),
       );
     }
 


### PR DESCRIPTION
## Context

Workspace upgrades invalidated the `FindAllViews` response cache using Redis `SCAN MATCH`.

Because `SCAN` traverses the shared Redis keyspace, its cost grew with both workspace count and total cache size. With a large amount of workspaces, upgrades generated hundreds of millions of `SCAN` calls and could take several hours. The slowdown was cumulative, not tied to one migration command.

## Changes

Replace pattern-based invalidation with dependency-based cache keys.

`FindAllViews` now depends on the hashes of:

- `flatViewMaps`
- `flatViewFieldMaps`
- `flatViewFieldGroupMaps`
- `flatViewGroupMaps`
- `flatViewSortMaps`
- `flatViewFilterMaps`
- `flatViewFilterGroupMaps`

The dependency hashes are loaded with one batched lookup and combined into the response-cache key. Missing hashes are recomputed on cold cache. If they remain unavailable, response caching is bypassed.

The cache identity also includes:

- Workspace metadata version
- User-workspace ID
- Locale
- GraphQL query
- Variables

The resolved key is memoized for the request lifetime. If a view changes while a request is running, the response is stored under the old dependency version and cannot become visible through the new key.

This also removes:

- Per-workspace pattern scanning
- `flushGraphQLOperation`
- Experimental `FindAllViews` version state
- View-specific migration-runner cache wiring

Object and field metadata changes continue incrementing the workspace metadata version. View-only changes rely on their existing flat-map hash rotation.
