### PR TITLE
chore(twenty-exa): bump to 0.2.0, add marketplace metadata and Twenty version floor

### DIFF
--- a/packages/twenty-apps/public/twenty-exa/package.json
+++ b/packages/twenty-apps/public/twenty-exa/package.json
@@ -1,12 +1,13 @@
 {
   "name": "@twentyhq/twenty-exa",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Structured web search powered by Exa, exposed to Twenty AI agents as a tool.",
   "license": "MIT",
   "engines": {
     "node": "^24.5.0",
     "npm": "please-use-yarn",
-    "yarn": ">=4.0.2"
+    "yarn": ">=4.0.2",
+    "twenty": ">=2.19.0"
   },
   "keywords": [
     "twenty-app"

--- a/packages/twenty-apps/public/twenty-exa/src/application.config.ts
+++ b/packages/twenty-apps/public/twenty-exa/src/application.config.ts
@@ -11,7 +11,12 @@ export default defineApplication({
   description:
     'Structured web search powered by Exa. Surfaces entity-aware results (companies, people, research, news) to Twenty AI agents.',
   author: 'Twenty',
+  category: 'Search',
   logoUrl: 'public/exa-logomark.svg',
+  websiteUrl: 'https://docs.twenty.com/developers/extend/apps/getting-started',
+  termsUrl: 'https://www.twenty.com/terms',
+  emailSupport: 'contact@twenty.com',
+  issueReportUrl: 'https://github.com/twentyhq/twenty/issues',
   defaultRoleUniversalIdentifier: DEFAULT_ROLE_UNIVERSAL_IDENTIFIER,
   serverVariables: {
     EXA_API_KEY: {


### PR DESCRIPTION
## What

Prepares the Exa app (`@twentyhq/twenty-exa`) for a fresh npm release.

- Bump `version` `0.1.0` → `0.2.0`
- Add `engines.twenty: ">=2.19.0"` so older servers don't install an incompatible build
- Add marketplace metadata in `defineApplication()`: `category: 'Search'`, `websiteUrl`, `termsUrl`, `emailSupport`, `issueReportUrl` (matching the values used by the other `@twentyhq/*` apps)

## Why

The version currently published on npm is the **unscoped** `twenty-exa@0.1.0`, which predates several SDK breaking changes. The in-repo source has since migrated to `twenty-sdk@~2.16` and `exa-js` v2:

- `chargeCredits` now imported from `twenty-sdk/billing` (was a local util)
- logic function uses `toolTriggerSettings.inputSchema` (was `isTool` + `toolInputSchema`)
- schema type imported from `twenty-sdk/logic-function` (was `twenty-shared/logic-function`)
- `category` enum updated to the exa-js v2 union (removed `github`/`tweet`/`linkedin profile`, added `people`)

So the published build is effectively broken on current servers. This PR readies a `0.2.0` release under the standard scoped name `@twentyhq/twenty-exa`.

The app's `universalIdentifier` is unchanged (`2b7f4a2e-9c4b-4a11-b63c-2e5e7d3f5a9a`), so Twenty treats this as the **same app** and upgrades existing installs in place — the name change (unscoped → scoped) is only an npm-registry concern.

## Changes

- `packages/twenty-apps/public/twenty-exa/package.json`
- `packages/twenty-apps/public/twenty-exa/src/application.config.ts`

## Testing

- `yarn typecheck` — pass
- `yarn lint` — pass (0 errors)
- `yarn twenty dev:build` — builds a valid `@twentyhq/twenty-exa@0.2.0` tarball

## Follow-up (not in this PR — npm/ops, needs auth)

- Publish `@twentyhq/twenty-exa@0.2.0` to npm (`yarn twenty app:publish`)
- Deprecate + de-keyword the old unscoped `twenty-exa` so only one package feeds the shared `universalIdentifier` on catalog sync

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/23063?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

