### PR TITLE
Add autofocus to 2FA OTP inputs

### DIFF
--- a/packages/twenty-front/src/modules/auth/sign-in-up/components/internal/SignInUpTwoFactorAuthenticationVerification.tsx
+++ b/packages/twenty-front/src/modules/auth/sign-in-up/components/internal/SignInUpTwoFactorAuthenticationVerification.tsx
@@ -233,6 +233,7 @@ export const SignInUpTOTPVerification = () => {
               onBlur={onBlur}
               onChange={onChange}
               value={value}
+              autoFocus
               render={({ slots }) => (
                 <StyledOTPContainer>
                   <StyledSlotGroup>

--- a/packages/twenty-front/src/modules/settings/admin-panel/components/SettingsAdminServerAdminAccess.tsx
+++ b/packages/twenty-front/src/modules/settings/admin-panel/components/SettingsAdminServerAdminAccess.tsx
@@ -239,6 +239,7 @@ export const SettingsAdminServerAdminAccess = ({
               maxLength={6}
               value={otp}
               onChange={setOtp}
+              autoFocus
               render={({ slots }) => (
                 <StyledOTPContainer>
                   {slots.slice(0, 3).map((slot, index) => (

--- a/packages/twenty-front/src/modules/settings/two-factor-authentication/components/TwoFactorAuthenticationVerificationForSettings.tsx
+++ b/packages/twenty-front/src/modules/settings/two-factor-authentication/components/TwoFactorAuthenticationVerificationForSettings.tsx
@@ -34,6 +34,7 @@ export const TwoFactorAuthenticationVerificationForSettings = () => {
           onBlur={onBlur}
           onChange={onChange}
           value={value}
+          autoFocus
           render={({ slots }) => (
             <StyledOTPContainer>
               {slots.slice(0, 3).map((slot, idx) => (


### PR DESCRIPTION
as title
<img width="854" height="533" alt="image" src="https://github.com/user-attachments/assets/777c2d83-8318-4337-865d-67aebc9186c2" />


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/23067?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

