### PR TITLE
fix(security): validate OAuth propagator redirect origin explicitly in both workspace modes

### DIFF
--- a/packages/twenty-server/src/engine/core-modules/auth/controllers/__tests__/oauth-propagator.controller.spec.ts
+++ b/packages/twenty-server/src/engine/core-modules/auth/controllers/__tests__/oauth-propagator.controller.spec.ts
@@ -1,0 +1,253 @@
+import { Test, type TestingModule } from '@nestjs/testing';
+
+import { type Response } from 'express';
+
+import { BadRequestException, ForbiddenException } from '@nestjs/common';
+
+import { OAuthPropagatorController } from 'src/engine/core-modules/auth/controllers/oauth-propagator.controller';
+import { WorkspaceDomainsService } from 'src/engine/core-modules/domain/workspace-domains/services/workspace-domains.service';
+import { HttpExceptionHandlerService } from 'src/engine/core-modules/exception-handler/http-exception-handler.service';
+import { NodeEnvironment } from 'src/engine/core-modules/twenty-config/interfaces/node-environment.interface';
+import { TwentyConfigService } from 'src/engine/core-modules/twenty-config/twenty-config.service';
+
+describe('OAuthPropagatorController', () => {
+  let controller: OAuthPropagatorController;
+  let twentyConfigService: TwentyConfigService;
+  let workspaceDomainsService: WorkspaceDomainsService;
+
+  const buildConfigMock = (
+    overrides: Record<string, unknown> = {},
+  ): Record<string, unknown> => ({
+    NODE_ENV: NodeEnvironment.PRODUCTION,
+    IS_MULTIWORKSPACE_ENABLED: false,
+    FRONTEND_URL: 'https://app.twenty.com',
+    SERVER_URL: 'https://api.twenty.com',
+    ...overrides,
+  });
+
+  const buildResponse = () =>
+    ({
+      redirect: jest.fn(),
+    }) as unknown as Response;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [OAuthPropagatorController],
+      providers: [
+        {
+          provide: TwentyConfigService,
+          useValue: {
+            get: jest.fn(),
+          },
+        },
+        {
+          provide: WorkspaceDomainsService,
+          useValue: {
+            isRedirectUrlWithinResolvedWorkspaceDomains: jest.fn(),
+          },
+        },
+        {
+          provide: HttpExceptionHandlerService,
+          useValue: {
+            handleError: jest.fn(),
+          },
+        },
+      ],
+    }).compile();
+
+    controller = module.get(OAuthPropagatorController);
+    twentyConfigService = module.get(TwentyConfigService);
+    workspaceDomainsService = module.get(WorkspaceDomainsService);
+  });
+
+  const setupConfig = (config: Record<string, unknown>) => {
+    jest.spyOn(twentyConfigService, 'get').mockImplementation((key: string) => {
+      return config[key] as string | boolean | undefined;
+    });
+  };
+
+  const mockDomainDecision = (isValid: boolean) => {
+    jest
+      .spyOn(
+        workspaceDomainsService,
+        'isRedirectUrlWithinResolvedWorkspaceDomains',
+      )
+      .mockResolvedValue(isValid);
+  };
+
+  describe('propagateOAuthCallback', () => {
+    it('should throw BadRequestException when state is missing', async () => {
+      setupConfig(buildConfigMock());
+
+      await expect(
+        controller.propagateOAuthCallback(
+          undefined as unknown as string,
+          'code',
+          buildResponse(),
+        ),
+      ).rejects.toThrow(BadRequestException);
+    });
+
+    it('should throw BadRequestException when code is missing', async () => {
+      setupConfig(buildConfigMock());
+
+      await expect(
+        controller.propagateOAuthCallback(
+          'https://app.twenty.com/callback',
+          undefined as unknown as string,
+          buildResponse(),
+        ),
+      ).rejects.toThrow(BadRequestException);
+    });
+
+    it('should throw BadRequestException when state is not a valid URL', async () => {
+      setupConfig(buildConfigMock());
+
+      await expect(
+        controller.propagateOAuthCallback('not-a-url', 'code', buildResponse()),
+      ).rejects.toThrow(BadRequestException);
+    });
+
+    it('should throw BadRequestException when the redirect URI contains a fragment', async () => {
+      setupConfig(buildConfigMock());
+
+      await expect(
+        controller.propagateOAuthCallback(
+          encodeURIComponent('https://app.twenty.com/callback#fragment'),
+          'code',
+          buildResponse(),
+        ),
+      ).rejects.toThrow(BadRequestException);
+    });
+
+    it('should throw BadRequestException when the redirect URI is non-https and non-localhost', async () => {
+      setupConfig(buildConfigMock());
+
+      await expect(
+        controller.propagateOAuthCallback(
+          encodeURIComponent('http://app.twenty.com/callback'),
+          'code',
+          buildResponse(),
+        ),
+      ).rejects.toThrow(BadRequestException);
+    });
+
+    it('should redirect when the redirect origin is within workspace domains in single-workspace mode', async () => {
+      setupConfig(buildConfigMock());
+      mockDomainDecision(true);
+
+      const res = buildResponse();
+
+      await controller.propagateOAuthCallback(
+        encodeURIComponent('https://app.twenty.com/oauth/callback'),
+        'test-code',
+        res,
+      );
+
+      expect(res.redirect).toHaveBeenCalledWith(
+        302,
+        expect.stringContaining('https://app.twenty.com/oauth/callback'),
+      );
+      expect(res.redirect).toHaveBeenCalledWith(
+        302,
+        expect.stringContaining('code=test-code'),
+      );
+    });
+
+    it('should throw ForbiddenException for an attacker hostname in single-workspace mode (open redirect fix)', async () => {
+      setupConfig(buildConfigMock());
+      mockDomainDecision(false);
+
+      await expect(
+        controller.propagateOAuthCallback(
+          encodeURIComponent('https://attacker.example.com/phish'),
+          'STOLEN_CODE',
+          buildResponse(),
+        ),
+      ).rejects.toThrow(ForbiddenException);
+    });
+
+    it('should redirect when the redirect origin matches a workspace in multi-workspace mode', async () => {
+      setupConfig(buildConfigMock({ IS_MULTIWORKSPACE_ENABLED: true }));
+      mockDomainDecision(true);
+
+      const res = buildResponse();
+
+      await controller.propagateOAuthCallback(
+        encodeURIComponent('https://acme.twenty.com/oauth/callback'),
+        'test-code',
+        res,
+      );
+
+      expect(res.redirect).toHaveBeenCalledWith(
+        302,
+        expect.stringContaining('https://acme.twenty.com/oauth/callback'),
+      );
+    });
+
+    it('should throw ForbiddenException for an unregistered host in multi-workspace mode', async () => {
+      setupConfig(buildConfigMock({ IS_MULTIWORKSPACE_ENABLED: true }));
+      mockDomainDecision(false);
+
+      await expect(
+        controller.propagateOAuthCallback(
+          encodeURIComponent('https://unregistered.example.com/callback'),
+          'code',
+          buildResponse(),
+        ),
+      ).rejects.toThrow(ForbiddenException);
+    });
+
+    it('should allow any host in development mode without resolving workspace domains', async () => {
+      setupConfig(buildConfigMock({ NODE_ENV: NodeEnvironment.DEVELOPMENT }));
+
+      const res = buildResponse();
+
+      await controller.propagateOAuthCallback(
+        encodeURIComponent('https://attacker.example.com/callback'),
+        'test-code',
+        res,
+      );
+
+      expect(res.redirect).toHaveBeenCalledWith(
+        302,
+        expect.stringContaining('https://attacker.example.com/callback'),
+      );
+      expect(
+        workspaceDomainsService.isRedirectUrlWithinResolvedWorkspaceDomains,
+      ).not.toHaveBeenCalled();
+    });
+
+    it('should pass code and state as query params in the redirect', async () => {
+      setupConfig(buildConfigMock());
+      mockDomainDecision(true);
+
+      const res = buildResponse();
+      const state = encodeURIComponent('https://app.twenty.com/oauth/callback');
+
+      await controller.propagateOAuthCallback(state, 'my-auth-code', res);
+
+      const redirectCall = (res.redirect as jest.Mock).mock.calls[0];
+      const redirectUrl = redirectCall[1] as string;
+
+      expect(redirectUrl).toContain('code=my-auth-code');
+      expect(redirectUrl).toContain(`state=${encodeURIComponent(state)}`);
+    });
+
+    it('should handle URL-encoded state parameter correctly', async () => {
+      setupConfig(buildConfigMock());
+      mockDomainDecision(true);
+
+      const res = buildResponse();
+      const originalUrl = 'https://app.twenty.com/path/with%20space';
+      const state = encodeURIComponent(originalUrl);
+
+      await controller.propagateOAuthCallback(state, 'code', res);
+
+      const redirectCall = (res.redirect as jest.Mock).mock.calls[0];
+      const redirectUrl = redirectCall[1] as string;
+
+      expect(redirectUrl).toContain('https://app.twenty.com/path/with%20space');
+    });
+  });
+});

--- a/packages/twenty-server/src/engine/core-modules/auth/controllers/oauth-propagator.controller.ts
+++ b/packages/twenty-server/src/engine/core-modules/auth/controllers/oauth-propagator.controller.ts
@@ -15,7 +15,7 @@ import { isDefined } from 'twenty-shared/utils';
 import { NodeEnvironment } from 'src/engine/core-modules/twenty-config/interfaces/node-environment.interface';
 
 import { AuthRestApiExceptionFilter } from 'src/engine/core-modules/auth/filters/auth-rest-api-exception.filter';
-import { DomainServerConfigService } from 'src/engine/core-modules/domain/domain-server-config/services/domain-server-config.service';
+import { validateRedirectUri } from 'src/engine/core-modules/auth/utils/validate-redirect-uri.util';
 import { WorkspaceDomainsService } from 'src/engine/core-modules/domain/workspace-domains/services/workspace-domains.service';
 import { TwentyConfigService } from 'src/engine/core-modules/twenty-config/twenty-config.service';
 import { NoPermissionGuard } from 'src/engine/guards/no-permission.guard';
@@ -25,7 +25,6 @@ import { PublicEndpointGuard } from 'src/engine/guards/public-endpoint.guard';
 @UseFilters(AuthRestApiExceptionFilter)
 export class OAuthPropagatorController {
   constructor(
-    private readonly domainServerConfigService: DomainServerConfigService,
     private readonly twentyConfigService: TwentyConfigService,
     private readonly workspaceDomainsService: WorkspaceDomainsService,
   ) {}
@@ -47,15 +46,22 @@ export class OAuthPropagatorController {
 
     const decodedRedirectUri = decodeURIComponent(state);
 
-    let redirectUrl: URL;
+    const redirectUriValidation = validateRedirectUri(decodedRedirectUri);
 
-    try {
-      redirectUrl = new URL(decodedRedirectUri);
-    } catch {
-      throw new BadRequestException('Invalid redirect URI in state');
+    if (!redirectUriValidation.valid) {
+      throw new BadRequestException(redirectUriValidation.reason);
     }
 
-    const isValidDomain = await this.isValidDomain(redirectUrl);
+    const redirectUrl = redirectUriValidation.parsed;
+
+    const isDevelopment =
+      this.twentyConfigService.get('NODE_ENV') === NodeEnvironment.DEVELOPMENT;
+
+    const isValidDomain =
+      isDevelopment ||
+      (await this.workspaceDomainsService.isRedirectUrlWithinResolvedWorkspaceDomains(
+        redirectUrl,
+      ));
 
     if (!isValidDomain) {
       throw new ForbiddenException(
@@ -67,20 +73,5 @@ export class OAuthPropagatorController {
     redirectUrl.searchParams.set('state', state);
 
     return res.redirect(302, redirectUrl.toString());
-  }
-
-  private async isValidDomain(url: URL): Promise<boolean> {
-    if (
-      this.twentyConfigService.get('NODE_ENV') === NodeEnvironment.DEVELOPMENT
-    ) {
-      return true;
-    }
-
-    const workspace =
-      await this.workspaceDomainsService.getWorkspaceByOriginOrDefaultWorkspace(
-        url.href,
-      );
-
-    return isDefined(workspace);
   }
 }

--- a/packages/twenty-server/src/engine/core-modules/domain/workspace-domains/services/__test__/workspace-domains.service.spec.ts
+++ b/packages/twenty-server/src/engine/core-modules/domain/workspace-domains/services/__test__/workspace-domains.service.spec.ts
@@ -382,4 +382,190 @@ describe('WorkspaceDomainsService', () => {
       expect(result).toEqual(undefined);
     });
   });
+
+  describe('isRedirectUrlWithinResolvedWorkspaceDomains', () => {
+    const setupConfig = (config: Record<string, unknown>) => {
+      jest
+        .spyOn(twentyConfigService, 'get')
+        // @ts-expect-error legacy noImplicitAny
+        .mockImplementation((key: string) => config[key]);
+    };
+
+    const mockResolvedWorkspace = (resolved: {
+      workspace?: Partial<WorkspaceEntity>;
+      publicDomain?: Partial<PublicDomainEntity> | null;
+    }) => {
+      jest
+        .spyOn(workspaceDomainsService, 'resolveWorkspaceAndPublicDomain')
+        .mockResolvedValue({
+          workspace: resolved.workspace as WorkspaceEntity | undefined,
+          publicDomain: (resolved.publicDomain ??
+            null) as PublicDomainEntity | null,
+          isIsolatedOrigin: false,
+        });
+    };
+
+    it('should return false when no workspace is resolved', async () => {
+      setupConfig({
+        FRONTEND_URL: 'https://app.twenty.com',
+        IS_MULTIWORKSPACE_ENABLED: false,
+      });
+      mockResolvedWorkspace({ workspace: undefined });
+
+      const result =
+        await workspaceDomainsService.isRedirectUrlWithinResolvedWorkspaceDomains(
+          new URL('https://app.twenty.com/callback'),
+        );
+
+      expect(result).toBe(false);
+    });
+
+    it('should allow a redirect matching the subdomain origin in single-workspace mode', async () => {
+      setupConfig({
+        FRONTEND_URL: 'https://app.twenty.com',
+        IS_MULTIWORKSPACE_ENABLED: false,
+      });
+      mockResolvedWorkspace({
+        workspace: {
+          subdomain: 'acme',
+          customDomain: null,
+          isCustomDomainEnabled: false,
+        },
+      });
+
+      const result =
+        await workspaceDomainsService.isRedirectUrlWithinResolvedWorkspaceDomains(
+          new URL('https://app.twenty.com/callback'),
+        );
+
+      expect(result).toBe(true);
+    });
+
+    it('should allow a redirect matching the subdomain origin in multi-workspace mode', async () => {
+      setupConfig({
+        FRONTEND_URL: 'https://app.twenty.com',
+        IS_MULTIWORKSPACE_ENABLED: true,
+      });
+      mockResolvedWorkspace({
+        workspace: {
+          subdomain: 'acme',
+          customDomain: null,
+          isCustomDomainEnabled: false,
+        },
+      });
+
+      const result =
+        await workspaceDomainsService.isRedirectUrlWithinResolvedWorkspaceDomains(
+          new URL('https://acme.app.twenty.com/callback'),
+        );
+
+      expect(result).toBe(true);
+    });
+
+    it('should reject an http origin when the allowed origin is https', async () => {
+      setupConfig({
+        FRONTEND_URL: 'https://app.twenty.com',
+        IS_MULTIWORKSPACE_ENABLED: false,
+      });
+      mockResolvedWorkspace({
+        workspace: {
+          subdomain: 'acme',
+          customDomain: null,
+          isCustomDomainEnabled: false,
+        },
+      });
+
+      const result =
+        await workspaceDomainsService.isRedirectUrlWithinResolvedWorkspaceDomains(
+          new URL('http://app.twenty.com/callback'),
+        );
+
+      expect(result).toBe(false);
+    });
+
+    it('should reject an origin with a mismatched port', async () => {
+      setupConfig({
+        FRONTEND_URL: 'https://app.twenty.com',
+        IS_MULTIWORKSPACE_ENABLED: false,
+      });
+      mockResolvedWorkspace({
+        workspace: {
+          subdomain: 'acme',
+          customDomain: null,
+          isCustomDomainEnabled: false,
+        },
+      });
+
+      const result =
+        await workspaceDomainsService.isRedirectUrlWithinResolvedWorkspaceDomains(
+          new URL('https://app.twenty.com:8080/callback'),
+        );
+
+      expect(result).toBe(false);
+    });
+
+    it('should allow the custom domain origin when isCustomDomainEnabled is true', async () => {
+      setupConfig({
+        FRONTEND_URL: 'https://app.twenty.com',
+        IS_MULTIWORKSPACE_ENABLED: false,
+      });
+      mockResolvedWorkspace({
+        workspace: {
+          subdomain: 'acme',
+          customDomain: 'custom.example.com',
+          isCustomDomainEnabled: true,
+        },
+      });
+
+      const result =
+        await workspaceDomainsService.isRedirectUrlWithinResolvedWorkspaceDomains(
+          new URL('https://custom.example.com/callback'),
+        );
+
+      expect(result).toBe(true);
+    });
+
+    it('should reject the custom domain origin when isCustomDomainEnabled is false', async () => {
+      setupConfig({
+        FRONTEND_URL: 'https://app.twenty.com',
+        IS_MULTIWORKSPACE_ENABLED: false,
+      });
+      mockResolvedWorkspace({
+        workspace: {
+          subdomain: 'acme',
+          customDomain: 'custom.example.com',
+          isCustomDomainEnabled: false,
+        },
+      });
+
+      const result =
+        await workspaceDomainsService.isRedirectUrlWithinResolvedWorkspaceDomains(
+          new URL('https://custom.example.com/callback'),
+        );
+
+      expect(result).toBe(false);
+    });
+
+    it('should allow the resolved public domain origin', async () => {
+      setupConfig({
+        FRONTEND_URL: 'https://app.twenty.com',
+        IS_MULTIWORKSPACE_ENABLED: false,
+      });
+      mockResolvedWorkspace({
+        workspace: {
+          subdomain: 'acme',
+          customDomain: null,
+          isCustomDomainEnabled: false,
+        },
+        publicDomain: { domain: 'public.example.com' },
+      });
+
+      const result =
+        await workspaceDomainsService.isRedirectUrlWithinResolvedWorkspaceDomains(
+          new URL('https://public.example.com/callback'),
+        );
+
+      expect(result).toBe(true);
+    });
+  });
 });

--- a/packages/twenty-server/src/engine/core-modules/domain/workspace-domains/services/workspace-domains.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/domain/workspace-domains/services/workspace-domains.service.ts
@@ -100,6 +100,35 @@ export class WorkspaceDomainsService {
     return workspace;
   }
 
+  async isRedirectUrlWithinResolvedWorkspaceDomains(
+    url: URL,
+  ): Promise<boolean> {
+    const { workspace, publicDomain } =
+      await this.resolveWorkspaceAndPublicDomain(url.href);
+
+    if (!isDefined(workspace)) {
+      return false;
+    }
+
+    const { customUrl, subdomainUrl } = this.getWorkspaceUrls({
+      subdomain: workspace.subdomain,
+      customDomain: workspace.customDomain,
+      isCustomDomainEnabled: workspace.isCustomDomainEnabled,
+    });
+
+    const allowedOrigins = new Set<string>([new URL(subdomainUrl).origin]);
+
+    if (isDefined(customUrl)) {
+      allowedOrigins.add(new URL(customUrl).origin);
+    }
+
+    if (isDefined(publicDomain)) {
+      allowedOrigins.add(`https://${publicDomain.domain}`);
+    }
+
+    return allowedOrigins.has(url.origin);
+  }
+
   async resolveWorkspaceAndPublicDomain(origin: string): Promise<{
     workspace: WorkspaceEntity | undefined;
     publicDomain: PublicDomainEntity | null;


### PR DESCRIPTION
## Summary

Hardens the open-redirect fix for `/auth/oauth-propagator/callback` (relates to #22109 / PR #22381) so the redirect target is validated explicitly and uniformly, instead of relying on `isDefined(workspace)` being trustworthy in multi-workspace mode.

The endpoint takes an attacker-controllable `state` (a raw redirect URL), validates it, then 302-redirects to it with the OAuth `code` appended. In single-workspace mode (`IS_MULTIWORKSPACE_ENABLED=false`, the default) the workspace resolver always returns the default workspace regardless of hostname, so a workspace-presence check alone was an open redirect. Multi-workspace mode relied on the resolver returning `undefined` for unknown hosts, which is implicit and easy to regress.

## Changes

- **`WorkspaceDomainsService.isRedirectUrlWithinResolvedWorkspaceDomains(url)`**: single, testable method that resolves the workspace from the URL and confirms the URL's **origin** (not just hostname, so protocol/port variants can't bypass) is one of that workspace's legitimate origins. Reuses `getWorkspaceUrls()` (which already encodes the single- vs multi-workspace difference) and includes the resolved public domain.
- **`OAuthPropagatorController`**: runs the decoded `state` through the existing `validateRedirectUri()` util first (absolute URL, https except localhost, no fragments), keeps the development bypass, then delegates the domain decision to the new service method. Removes the old two-branch private `isValidDomain()` and the now-unused `DomainServerConfigService` injection.

## Tests

- Controller spec covers both workspace modes (allowed origin vs rejected host, 403), format hardening (fragment and non-https rejected with 400), the development bypass, missing state/code, and `code`+`state` passthrough.
- New service-method tests cover origin strictness (`http://` and `:port` variants rejected), custom domain allowed only when `isCustomDomainEnabled`, public-domain origin allowed, and undefined workspace rejected.

## Verification

- `nx typecheck twenty-server` passes
- oxlint / oxfmt clean on the changed files
- 32 unit tests pass across the two specs

---
_Generated by [Claude Code](https://claude.ai/code/session_01Jupb9Rb6PeZZ6qTX4TcXfs)_

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/23072?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

