### PR TITLE
fix(workflow): retry workflow steps on transient infra errors

### DIFF
--- a/packages/twenty-server/src/modules/workflow/workflow-executor/utils/is-transient-workflow-error.util.ts
+++ b/packages/twenty-server/src/modules/workflow/workflow-executor/utils/is-transient-workflow-error.util.ts
@@ -1,0 +1,47 @@
+import { isDefined } from 'twenty-shared/utils';
+import { QueryFailedError } from 'typeorm';
+
+import { POSTGRESQL_ERROR_CODES } from 'src/engine/api/graphql/workspace-query-runner/constants/postgres-error-codes.constants';
+import {
+  TwentyORMException,
+  TwentyORMExceptionCode,
+} from 'src/engine/twenty-orm/exceptions/twenty-orm.exception';
+
+const TRANSIENT_ORM_EXCEPTION_CODES: TwentyORMExceptionCode[] = [
+  TwentyORMExceptionCode.QUERY_READ_TIMEOUT,
+];
+
+const TRANSIENT_POSTGRES_ERROR_CODES: string[] = [
+  POSTGRESQL_ERROR_CODES.CONNECTION_EXCEPTION,
+  POSTGRESQL_ERROR_CODES.CONNECTION_DOES_NOT_EXIST,
+  POSTGRESQL_ERROR_CODES.CONNECTION_FAILURE,
+  POSTGRESQL_ERROR_CODES.SERIALIZATION_FAILURE,
+  POSTGRESQL_ERROR_CODES.DEADLOCK_DETECTED,
+  POSTGRESQL_ERROR_CODES.TOO_MANY_CONNECTIONS,
+  POSTGRESQL_ERROR_CODES.LOCK_NOT_AVAILABLE,
+  POSTGRESQL_ERROR_CODES.QUERY_CANCELED,
+  POSTGRESQL_ERROR_CODES.CANNOT_CONNECT_NOW,
+];
+
+export const isTransientWorkflowError = (error: unknown): boolean => {
+  if (
+    error instanceof TwentyORMException &&
+    TRANSIENT_ORM_EXCEPTION_CODES.includes(error.code)
+  ) {
+    return true;
+  }
+
+  if (error instanceof QueryFailedError) {
+    const errorCode = (error as QueryFailedError & { code?: string }).code;
+
+    if (isDefined(errorCode) && TRANSIENT_POSTGRES_ERROR_CODES.includes(errorCode)) {
+      return true;
+    }
+  }
+
+  // The raw DB read-timeout surfaces as a message match before it is wrapped
+  // into a TwentyORMException, so match it here too.
+  return (
+    error instanceof Error && error.message.includes('Query read timeout')
+  );
+};

--- a/packages/twenty-server/src/modules/workflow/workflow-executor/workspace-services/workflow-executor.workspace-service.ts
+++ b/packages/twenty-server/src/modules/workflow/workflow-executor/workspace-services/workflow-executor.workspace-service.ts
@@ -36,6 +36,7 @@ import {
   type WorkflowBranchExecutorInput,
   type WorkflowExecutorInput,
 } from 'src/modules/workflow/workflow-executor/types/workflow-executor-input';
+import { isTransientWorkflowError } from 'src/modules/workflow/workflow-executor/utils/is-transient-workflow-error.util';
 import { shouldExecuteStep } from 'src/modules/workflow/workflow-executor/utils/should-execute-step.util';
 import { shouldFailSafely } from 'src/modules/workflow/workflow-executor/utils/should-fail-safely.util';
 import { shouldSkipStepExecution } from 'src/modules/workflow/workflow-executor/utils/should-skip-step-execution.util';
@@ -53,6 +54,10 @@ import { buildRunWorkflowJobOptions } from 'src/modules/workflow/workflow-runner
 import { WorkflowRunWorkspaceService } from 'src/modules/workflow/workflow-runner/workflow-run/workflow-run.workspace-service';
 
 const MAX_EXECUTED_STEPS_COUNT = 20;
+
+// A transient infra error (e.g. a DB read timeout) should not permanently
+// abandon a run. Retry the step a couple of times before failing it.
+const TRANSIENT_ERROR_RETRY_DELAYS_MS = [1000, 4000];
 
 @Injectable()
 export class WorkflowExecutorWorkspaceService {
@@ -460,38 +465,52 @@ export class WorkflowExecutorWorkspaceService {
       workspaceId,
     });
 
-    try {
-      return await workflowAction.execute({
-        currentStepId: stepId,
-        steps,
-        context: getWorkflowRunContext(stepInfos),
-        runInfo: {
-          workflowRunId,
-          workspaceId,
-        },
-      });
-    } catch (error) {
-      const isUserError =
-        error instanceof WorkflowStepExecutorException &&
-        (error.code === WorkflowStepExecutorExceptionCode.INVALID_STEP_TYPE ||
-          error.code === WorkflowStepExecutorExceptionCode.INVALID_STEP_INPUT ||
-          error.code === WorkflowStepExecutorExceptionCode.STEP_NOT_FOUND);
-
-      if (!isUserError) {
-        this.exceptionHandlerService.captureExceptions([error], {
-          workspace: { id: workspaceId },
+    for (let attempt = 0; ; attempt++) {
+      try {
+        return await workflowAction.execute({
+          currentStepId: stepId,
+          steps,
+          context: getWorkflowRunContext(stepInfos),
+          runInfo: {
+            workflowRunId,
+            workspaceId,
+          },
         });
+      } catch (error) {
+        if (
+          isTransientWorkflowError(error) &&
+          attempt < TRANSIENT_ERROR_RETRY_DELAYS_MS.length
+        ) {
+          await new Promise((resolve) =>
+            setTimeout(resolve, TRANSIENT_ERROR_RETRY_DELAYS_MS[attempt]),
+          );
 
-        await this.metricsService.incrementCounterForEvent({
-          key: MetricsKeys.WorkflowRunSystemError,
-          eventId: workflowRunId,
-          debugLog: `[Workflow Run System Error] Workflow run ${workflowRunId} in workspace ${workspaceId} ended with system error`,
-        });
+          continue;
+        }
+
+        const isUserError =
+          error instanceof WorkflowStepExecutorException &&
+          (error.code === WorkflowStepExecutorExceptionCode.INVALID_STEP_TYPE ||
+            error.code ===
+              WorkflowStepExecutorExceptionCode.INVALID_STEP_INPUT ||
+            error.code === WorkflowStepExecutorExceptionCode.STEP_NOT_FOUND);
+
+        if (!isUserError) {
+          this.exceptionHandlerService.captureExceptions([error], {
+            workspace: { id: workspaceId },
+          });
+
+          await this.metricsService.incrementCounterForEvent({
+            key: MetricsKeys.WorkflowRunSystemError,
+            eventId: workflowRunId,
+            debugLog: `[Workflow Run System Error] Workflow run ${workflowRunId} in workspace ${workspaceId} ended with system error`,
+          });
+        }
+
+        return {
+          error: error.message ?? 'Execution result error, no data or error',
+        };
       }
-
-      return {
-        error: error.message ?? 'Execution result error, no data or error',
-      };
     }
   }
 


### PR DESCRIPTION
## Context

Closes part of #23046.

A workflow run failed mid-execution on a CODE step because of a transient DB read timeout. Since the step had `retryOnFailure: false` / `continueOnFailure: false`, the whole run was abandoned: the step was marked `FAILED`, `computeWorkflowRunStatus` ended the run, and every downstream step stayed `NOT_STARTED`. Other runs of the same workflow succeeded before and after, so this was a one-off transient infra blip, not a logic error.

Today the executor catches the step error and immediately turns it into a terminal `FAILED`. There is no retry boundary for transient infra errors, and the queue-level retry never sees the exception because it is swallowed first.

## Change

Add an automatic retry for **transient infrastructure errors only**, independent of the per-step `retryOnFailure` opt-in.

- New `isTransientWorkflowError` util classifies an error as transient: `TwentyORMException` with `QUERY_READ_TIMEOUT`, a `QueryFailedError` carrying a transient Postgres code (connection loss, serialization/deadlock, lock-not-available, too-many-connections, query canceled, cannot-connect-now), or a raw `Query read timeout` message.
- `executeStep` wraps `workflowAction.execute()` in a retry loop. On a transient error it waits (1s, then 4s) and retries, up to 2 times, before falling through to the existing capture-exception / metrics / fail path. Non-transient errors fail immediately, exactly as before.

This scopes retries to blips that are actually worth retrying, and leaves genuine logic failures fast-failing.

## Out of scope

The issue also asks for platform-level alerting on `FAILED` runs. That is a separate, larger piece and is not addressed here.

## Notes

Retries are synchronous within the worker (max ~5s of added latency on a failing step). A re-enqueue-with-delay approach would free the worker and allow longer backoffs, at the cost of a step-info attempt counter and job plumbing. Happy to switch if preferred.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/23079?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

