### PR TITLE
Mitigate synchronized Call Recorder cron load

### DIFF
--- a/packages/twenty-server/src/engine/core-modules/logic-function/logic-function-trigger/triggers/cron/__tests__/cron-trigger.cron.job.spec.ts
+++ b/packages/twenty-server/src/engine/core-modules/logic-function/logic-function-trigger/triggers/cron/__tests__/cron-trigger.cron.job.spec.ts
@@ -1,0 +1,96 @@
+import { LogicFunctionTriggerJob } from 'src/engine/core-modules/logic-function/logic-function-trigger/jobs/logic-function-trigger.job';
+import { CronTriggerCronJob } from 'src/engine/core-modules/logic-function/logic-function-trigger/triggers/cron/cron-trigger.cron.job';
+
+jest.mock(
+  'src/engine/core-modules/logic-function/logic-function-trigger/jobs/logic-function-trigger.job',
+  () => ({ LogicFunctionTriggerJob: class LogicFunctionTriggerJob {} }),
+);
+
+const WORKSPACE_ID = 'workspace-id';
+const LOGIC_FUNCTION_ID = 'logic-function-id';
+const CALL_RECORDER_APPLICATION_UNIVERSAL_IDENTIFIER =
+  '8da4b8b5-5edf-4880-b51f-ab6e679ec617';
+const LOGIC_FUNCTION_UNIVERSAL_IDENTIFIER =
+  'd7d1170f-abb1-4c9b-8258-13219a611b03';
+
+describe('CronTriggerCronJob', () => {
+  const messageQueueService = { add: jest.fn() };
+  const workspaceRepository = { find: jest.fn() };
+  const workspaceCacheService = { getOrRecompute: jest.fn() };
+  const exceptionHandlerService = { captureExceptions: jest.fn() };
+  const cronTriggerDeduplicationService = { shouldDispatch: jest.fn() };
+
+  const job = new CronTriggerCronJob(
+    messageQueueService as never,
+    workspaceRepository as never,
+    workspaceCacheService as never,
+    exceptionHandlerService as never,
+    cronTriggerDeduplicationService as never,
+  );
+
+  const setLogicFunction = ({
+    applicationUniversalIdentifier = CALL_RECORDER_APPLICATION_UNIVERSAL_IDENTIFIER,
+    cronPattern = '*/15 * * * *',
+  }: {
+    applicationUniversalIdentifier?: string;
+    cronPattern?: string;
+  } = {}) => {
+    workspaceCacheService.getOrRecompute.mockResolvedValue({
+      flatLogicFunctionMaps: {
+        byUniversalIdentifier: {
+          [LOGIC_FUNCTION_UNIVERSAL_IDENTIFIER]: {
+            id: LOGIC_FUNCTION_ID,
+            universalIdentifier: LOGIC_FUNCTION_UNIVERSAL_IDENTIFIER,
+            applicationUniversalIdentifier,
+            deletedAt: null,
+            cronTriggerSettings: { pattern: cronPattern },
+          },
+        },
+      },
+    });
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    workspaceRepository.find.mockResolvedValue([{ id: WORKSPACE_ID }]);
+    cronTriggerDeduplicationService.shouldDispatch.mockResolvedValue(true);
+  });
+
+  it('spreads an installed Call Recorder cron by workspace', async () => {
+    setLogicFunction();
+
+    await job.handle();
+
+    expect(messageQueueService.add).toHaveBeenCalledWith(
+      LogicFunctionTriggerJob.name,
+      [
+        {
+          logicFunctionId: LOGIC_FUNCTION_ID,
+          workspaceId: WORKSPACE_ID,
+          payload: {},
+        },
+      ],
+      { retryLimit: 3, delay: 49_026 },
+    );
+  });
+
+  it('dispatches unrelated cron triggers without delay', async () => {
+    setLogicFunction({
+      applicationUniversalIdentifier: 'another-application',
+    });
+
+    await job.handle();
+
+    expect(messageQueueService.add).toHaveBeenCalledWith(
+      LogicFunctionTriggerJob.name,
+      [
+        {
+          logicFunctionId: LOGIC_FUNCTION_ID,
+          workspaceId: WORKSPACE_ID,
+          payload: {},
+        },
+      ],
+      { retryLimit: 3 },
+    );
+  });
+});

--- a/packages/twenty-server/src/engine/core-modules/logic-function/logic-function-trigger/triggers/cron/constants/call-recorder-cron-trigger-spread.constant.ts
+++ b/packages/twenty-server/src/engine/core-modules/logic-function/logic-function-trigger/triggers/cron/constants/call-recorder-cron-trigger-spread.constant.ts
@@ -1,0 +1,14 @@
+// Remove once deployed Call Recorder manifests no longer synchronize these jobs.
+export const CALL_RECORDER_APPLICATION_UNIVERSAL_IDENTIFIER =
+  '8da4b8b5-5edf-4880-b51f-ab6e679ec617';
+
+export const CALL_RECORDER_SPREAD_LOGIC_FUNCTION_UNIVERSAL_IDENTIFIERS =
+  new Set([
+    'd7d1170f-abb1-4c9b-8258-13219a611b03',
+    'e362aa9b-52c6-4b7e-bb20-927e0e8d7cbe',
+  ]);
+
+export const CALL_RECORDER_CRON_SPREAD_SECONDS_BY_PATTERN = new Map([
+  ['*/5 * * * *', 4 * 60],
+  ['*/15 * * * *', 14 * 60],
+]);

--- a/packages/twenty-server/src/engine/core-modules/logic-function/logic-function-trigger/triggers/cron/cron-trigger.cron.job.ts
+++ b/packages/twenty-server/src/engine/core-modules/logic-function/logic-function-trigger/triggers/cron/cron-trigger.cron.job.ts
@@ -18,6 +18,7 @@ import {
   LogicFunctionTriggerJob,
   LogicFunctionTriggerJobData,
 } from 'src/engine/core-modules/logic-function/logic-function-trigger/jobs/logic-function-trigger.job';
+import { computeLogicFunctionCronTriggerSpreadDelay } from 'src/engine/core-modules/logic-function/logic-function-trigger/triggers/cron/utils/compute-logic-function-cron-trigger-spread-delay.util';
 import { WorkspaceCacheService } from 'src/engine/workspace-cache/services/workspace-cache.service';
 
 export const CRON_TRIGGER_CRON_PATTERN = '* * * * *';
@@ -85,6 +86,14 @@ export class CronTriggerCronJob {
             continue;
           }
 
+          const spreadDelay = computeLogicFunctionCronTriggerSpreadDelay({
+            workspaceId: activeWorkspace.id,
+            applicationUniversalIdentifier:
+              logicFunction.applicationUniversalIdentifier,
+            logicFunctionUniversalIdentifier: logicFunction.universalIdentifier,
+            cronPattern: cronSettings.pattern,
+          });
+
           await this.messageQueueService.add<LogicFunctionTriggerJobData[]>(
             LogicFunctionTriggerJob.name,
             [
@@ -94,7 +103,10 @@ export class CronTriggerCronJob {
                 payload: {},
               },
             ],
-            { retryLimit: 3 },
+            {
+              retryLimit: 3,
+              ...(spreadDelay > 0 ? { delay: spreadDelay } : {}),
+            },
           );
         }
       } catch (error) {

--- a/packages/twenty-server/src/engine/core-modules/logic-function/logic-function-trigger/triggers/cron/utils/__tests__/compute-logic-function-cron-trigger-spread-delay.util.spec.ts
+++ b/packages/twenty-server/src/engine/core-modules/logic-function/logic-function-trigger/triggers/cron/utils/__tests__/compute-logic-function-cron-trigger-spread-delay.util.spec.ts
@@ -1,0 +1,65 @@
+import { computeLogicFunctionCronTriggerSpreadDelay } from 'src/engine/core-modules/logic-function/logic-function-trigger/triggers/cron/utils/compute-logic-function-cron-trigger-spread-delay.util';
+
+const CALL_RECORDER_APPLICATION_UNIVERSAL_IDENTIFIER =
+  '8da4b8b5-5edf-4880-b51f-ab6e679ec617';
+const PENDING_REQUESTS_LOGIC_FUNCTION_UNIVERSAL_IDENTIFIER =
+  'd7d1170f-abb1-4c9b-8258-13219a611b03';
+const STALE_BOT_STATE_LOGIC_FUNCTION_UNIVERSAL_IDENTIFIER =
+  'e362aa9b-52c6-4b7e-bb20-927e0e8d7cbe';
+
+describe('computeLogicFunctionCronTriggerSpreadDelay', () => {
+  const input = {
+    workspaceId: 'workspace-id',
+    applicationUniversalIdentifier:
+      CALL_RECORDER_APPLICATION_UNIVERSAL_IDENTIFIER,
+    logicFunctionUniversalIdentifier:
+      PENDING_REQUESTS_LOGIC_FUNCTION_UNIVERSAL_IDENTIFIER,
+    cronPattern: '*/15 * * * *',
+  };
+
+  it('returns a stable delay within the Call Recorder cron interval', () => {
+    const delay = computeLogicFunctionCronTriggerSpreadDelay(input);
+
+    expect(delay).toBe(49_026);
+    expect(computeLogicFunctionCronTriggerSpreadDelay(input)).toBe(delay);
+    expect(delay).toBeLessThan(14 * 60 * 1000);
+    expect(
+      computeLogicFunctionCronTriggerSpreadDelay({
+        ...input,
+        workspaceId: 'another-workspace',
+      }),
+    ).not.toBe(delay);
+  });
+
+  it('spreads stale bot reconciliation independently', () => {
+    const delay = computeLogicFunctionCronTriggerSpreadDelay({
+      ...input,
+      logicFunctionUniversalIdentifier:
+        STALE_BOT_STATE_LOGIC_FUNCTION_UNIVERSAL_IDENTIFIER,
+    });
+
+    expect(delay).toBeGreaterThan(0);
+    expect(delay).toBeLessThan(14 * 60 * 1000);
+    expect(delay).not.toBe(computeLogicFunctionCronTriggerSpreadDelay(input));
+  });
+
+  it('supports installed versions that still run every five minutes', () => {
+    const delay = computeLogicFunctionCronTriggerSpreadDelay({
+      ...input,
+      cronPattern: '*/5 * * * *',
+    });
+
+    expect(delay).toBeGreaterThan(0);
+    expect(delay).toBeLessThan(4 * 60 * 1000);
+  });
+
+  it.each([
+    { applicationUniversalIdentifier: 'another-application' },
+    { logicFunctionUniversalIdentifier: 'another-logic-function' },
+    { cronPattern: '0 4 * * *' },
+  ])('does not spread unrelated cron triggers', (override) => {
+    expect(
+      computeLogicFunctionCronTriggerSpreadDelay({ ...input, ...override }),
+    ).toBe(0);
+  });
+});

--- a/packages/twenty-server/src/engine/core-modules/logic-function/logic-function-trigger/triggers/cron/utils/compute-logic-function-cron-trigger-spread-delay.util.ts
+++ b/packages/twenty-server/src/engine/core-modules/logic-function/logic-function-trigger/triggers/cron/utils/compute-logic-function-cron-trigger-spread-delay.util.ts
@@ -1,0 +1,46 @@
+import { createHash } from 'crypto';
+
+import {
+  CALL_RECORDER_APPLICATION_UNIVERSAL_IDENTIFIER,
+  CALL_RECORDER_CRON_SPREAD_SECONDS_BY_PATTERN,
+  CALL_RECORDER_SPREAD_LOGIC_FUNCTION_UNIVERSAL_IDENTIFIERS,
+} from 'src/engine/core-modules/logic-function/logic-function-trigger/triggers/cron/constants/call-recorder-cron-trigger-spread.constant';
+
+const MILLISECONDS_PER_SECOND = 1000;
+
+export const computeLogicFunctionCronTriggerSpreadDelay = ({
+  workspaceId,
+  applicationUniversalIdentifier,
+  logicFunctionUniversalIdentifier,
+  cronPattern,
+}: {
+  workspaceId: string;
+  applicationUniversalIdentifier: string;
+  logicFunctionUniversalIdentifier: string;
+  cronPattern: string;
+}): number => {
+  if (
+    applicationUniversalIdentifier !==
+      CALL_RECORDER_APPLICATION_UNIVERSAL_IDENTIFIER ||
+    !CALL_RECORDER_SPREAD_LOGIC_FUNCTION_UNIVERSAL_IDENTIFIERS.has(
+      logicFunctionUniversalIdentifier,
+    )
+  ) {
+    return 0;
+  }
+
+  const spreadSeconds =
+    CALL_RECORDER_CRON_SPREAD_SECONDS_BY_PATTERN.get(cronPattern);
+
+  if (spreadSeconds === undefined) {
+    return 0;
+  }
+
+  const spreadMilliseconds = spreadSeconds * MILLISECONDS_PER_SECOND;
+  const hash = createHash('sha256')
+    .update(`${workspaceId}:${logicFunctionUniversalIdentifier}`)
+    .digest()
+    .readUIntBE(0, 6);
+
+  return hash % spreadMilliseconds;
+};


### PR DESCRIPTION
## Context

Logic-function cron triggers using the same pattern are dispatched at the same instant for every workspace. Call Recorder has two maintenance functions using frequent shared patterns, so their executions can create a thundering herd against the application queue and API.

This PR is a targeted load-shaping mitigation for those synchronized executions. It does not reduce the amount of work performed by the maintenance functions.

## What changed

- Match only the Call Recorder application and its pending-request and stale-bot-state maintenance functions by universal identifier.
- Deterministically spread each workspace/function pair across the available cron interval:
  - `*/5`: delay within the first four minutes.
  - `*/15`: delay within the first fourteen minutes.
- Leave a one-minute buffer before the next scheduled occurrence.
- Pass the computed delay to the logic-function queue while preserving execution count and cadence.
- Keep every unrelated logic-function cron unchanged.

The delay is derived from the workspace and logic-function universal identifiers, so it remains stable across scheduler runs while distributing different workspaces and functions independently.

## Why this is server-side

Changing the Call Recorder manifest would require upgrading every existing app installation before the new schedules took effect. The server-side compatibility policy allows existing installations to receive the mitigation without an app upgrade.

No Call Recorder app manifest or version is changed by this PR.

## What this does not fix

- It does not reduce the number or cost of API calls made by the maintenance functions.
- It does not add generic backpressure or spreading for other logic-function crons.
- It does not optimize the Call Recorder maintenance scans themselves.

Addressing the underlying workload requires a Call Recorder change and app upgrade. Addressing the platform-wide scheduling behavior requires a separate, explicit timing/backpressure contract for logic-function crons rather than an application-specific policy.

The compatibility policy in this PR should be removed once one of those longer-term fixes is deployed to existing installations.

## Test

- Focused server Jest tests: 8 passed.
- `twenty-server` typecheck.
- Oxlint and formatting checks on changed files.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/23088?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->
