### PR TITLE
Reduce call-recorder recovery crons to daily to relieve production

### DIFF
--- a/packages/twenty-apps/public/call-recorder/package.json
+++ b/packages/twenty-apps/public/call-recorder/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@twentyhq/call-recorder",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "license": "MIT",
   "engines": {
     "node": "^24.5.0",

--- a/packages/twenty-apps/public/call-recorder/src/logic-functions/constants/pending-call-recording-requests-cron-pattern.ts
+++ b/packages/twenty-apps/public/call-recorder/src/logic-functions/constants/pending-call-recording-requests-cron-pattern.ts
@@ -1,3 +1,3 @@
 // The callRecording.updated trigger resumes most stuck rows within seconds;
 // this cron is the backstop for crashed creations and missed events.
-export const PENDING_CALL_RECORDING_REQUESTS_CRON_PATTERN = '*/15 * * * *';
+export const PENDING_CALL_RECORDING_REQUESTS_CRON_PATTERN = '0 3 * * *';

--- a/packages/twenty-apps/public/call-recorder/src/logic-functions/constants/stale-bot-state-cron-pattern.ts
+++ b/packages/twenty-apps/public/call-recorder/src/logic-functions/constants/stale-bot-state-cron-pattern.ts
@@ -1,1 +1,1 @@
-export const STALE_BOT_STATE_CRON_PATTERN = '*/15 * * * *';
+export const STALE_BOT_STATE_CRON_PATTERN = '30 3 * * *';


### PR DESCRIPTION
## Context

Call Recorder is installed on 700+ workspaces and its two recovery crons run every 15 minutes with the same pattern in every workspace, so all executions land on the same minute boundaries and impact production. The `callRecording.updated` event trigger (#23014) now covers the fast path within seconds; these crons are only backstops for crashed creations and missed webhooks.

## What changed

Pattern updates only, no logic changes:

- `process-pending-call-recording-requests`: `*/15 * * * *` -> `0 3 * * *`
- `reconcile-stale-bot-state`: `*/15 * * * *` -> `30 3 * * *`

The daily times are staggered half an hour apart from the existing daily crons (04:00 upcoming-events sweep, 04:30 orphaned-bots cleanup) so the four daily jobs never coincide.

## Notes

- Recovery latency for rows missed by the event trigger becomes up to 24h instead of 15min, which is acceptable for backstops (the 7-day convergence lookback is unaffected).
- Cron patterns live in installed manifests, so existing installations pick this up on app upgrade only.
- The daily herd across workspaces at 03:00/03:30 remains synchronized until generic cron spreading lands server-side (#23088 covers only the `*/5` and `*/15` patterns).