### PR TITLE
Fix "Go to roles settings" command

### DIFF
--- a/packages/twenty-server/src/database/commands/upgrade-version-command/2-23/2-23-upgrade-version-command.module.ts
+++ b/packages/twenty-server/src/database/commands/upgrade-version-command/2-23/2-23-upgrade-version-command.module.ts
@@ -4,6 +4,7 @@ import { TypeOrmModule } from '@nestjs/typeorm';
 import { WorkspaceIteratorModule } from 'src/database/commands/command-runners/workspace-iterator.module';
 import { AddWorkflowCoreSoftRefFieldCommand } from 'src/database/commands/upgrade-version-command/2-23/2-23-workspace-command-1784286706000-add-workflow-core-soft-ref-field.command';
 import { BackfillWorkflowCoreLinksCommand } from 'src/database/commands/upgrade-version-command/2-23/2-23-workspace-command-1784286707000-backfill-workflow-core-links.command';
+import { FixGoToRolesSettingsCommandMenuItemPathCommand } from 'src/database/commands/upgrade-version-command/2-23/2-23-workspace-command-1784566000000-fix-go-to-roles-settings-command-menu-item-path.command';
 import { ReconcileSystemRelationFieldUniversalIdentifierCommand } from 'src/database/commands/upgrade-version-command/2-23/2-23-workspace-command-1784565136000-reconcile-system-relation-field-universal-identifier.command';
 import { UpgradePeopleDataLabsApplicationCommand } from 'src/database/commands/upgrade-version-command/2-23/2-23-workspace-command-1784565137000-upgrade-people-data-labs-application.command';
 import { ApplicationUpgradeModule } from 'src/engine/core-modules/application/application-upgrade/application-upgrade.module';
@@ -27,6 +28,7 @@ import { WorkspaceMigrationModule } from 'src/engine/workspace-manager/workspace
   providers: [
     AddWorkflowCoreSoftRefFieldCommand,
     BackfillWorkflowCoreLinksCommand,
+    FixGoToRolesSettingsCommandMenuItemPathCommand,
     ReconcileSystemRelationFieldUniversalIdentifierCommand,
     UpgradePeopleDataLabsApplicationCommand,
   ],

--- a/packages/twenty-server/src/database/commands/upgrade-version-command/2-23/2-23-upgrade-version-command.module.ts
+++ b/packages/twenty-server/src/database/commands/upgrade-version-command/2-23/2-23-upgrade-version-command.module.ts
@@ -4,9 +4,9 @@ import { TypeOrmModule } from '@nestjs/typeorm';
 import { WorkspaceIteratorModule } from 'src/database/commands/command-runners/workspace-iterator.module';
 import { AddWorkflowCoreSoftRefFieldCommand } from 'src/database/commands/upgrade-version-command/2-23/2-23-workspace-command-1784286706000-add-workflow-core-soft-ref-field.command';
 import { BackfillWorkflowCoreLinksCommand } from 'src/database/commands/upgrade-version-command/2-23/2-23-workspace-command-1784286707000-backfill-workflow-core-links.command';
-import { FixGoToRolesSettingsCommandMenuItemPathCommand } from 'src/database/commands/upgrade-version-command/2-23/2-23-workspace-command-1784566000000-fix-go-to-roles-settings-command-menu-item-path.command';
 import { ReconcileSystemRelationFieldUniversalIdentifierCommand } from 'src/database/commands/upgrade-version-command/2-23/2-23-workspace-command-1784565136000-reconcile-system-relation-field-universal-identifier.command';
 import { UpgradePeopleDataLabsApplicationCommand } from 'src/database/commands/upgrade-version-command/2-23/2-23-workspace-command-1784565137000-upgrade-people-data-labs-application.command';
+import { FixGoToRolesSettingsCommandMenuItemPathCommand } from 'src/database/commands/upgrade-version-command/2-23/2-23-workspace-command-1784566000000-fix-go-to-roles-settings-command-menu-item-path.command';
 import { ApplicationUpgradeModule } from 'src/engine/core-modules/application/application-upgrade/application-upgrade.module';
 import { ApplicationEntity } from 'src/engine/core-modules/application/application.entity';
 import { ApplicationModule } from 'src/engine/core-modules/application/application.module';
@@ -28,9 +28,9 @@ import { WorkspaceMigrationModule } from 'src/engine/workspace-manager/workspace
   providers: [
     AddWorkflowCoreSoftRefFieldCommand,
     BackfillWorkflowCoreLinksCommand,
-    FixGoToRolesSettingsCommandMenuItemPathCommand,
     ReconcileSystemRelationFieldUniversalIdentifierCommand,
     UpgradePeopleDataLabsApplicationCommand,
+    FixGoToRolesSettingsCommandMenuItemPathCommand,
   ],
 })
 export class V2_23_UpgradeVersionCommandModule {}

--- a/packages/twenty-server/src/database/commands/upgrade-version-command/2-23/2-23-workspace-command-1784566000000-fix-go-to-roles-settings-command-menu-item-path.command.ts
+++ b/packages/twenty-server/src/database/commands/upgrade-version-command/2-23/2-23-workspace-command-1784566000000-fix-go-to-roles-settings-command-menu-item-path.command.ts
@@ -1,0 +1,96 @@
+import { Command } from 'nest-commander';
+
+import { ProvisionedWorkspaceCommandRunner } from 'src/database/commands/command-runners/provisioned-workspace.command-runner';
+import { WorkspaceIteratorService } from 'src/database/commands/command-runners/workspace-iterator.service';
+import { type RunOnWorkspaceArgs } from 'src/database/commands/command-runners/workspace.command-runner';
+import { buildFixGoToRolesSettingsCommandMenuItemPathSyncOperations } from 'src/database/commands/upgrade-version-command/2-23/utils/build-fix-go-to-roles-settings-command-menu-item-path-sync-operations.util';
+import { ApplicationService } from 'src/engine/core-modules/application/application.service';
+import { RegisteredWorkspaceCommand } from 'src/engine/core-modules/upgrade/decorators/registered-workspace-command.decorator';
+import { WorkspaceCacheService } from 'src/engine/workspace-cache/services/workspace-cache.service';
+import { WorkspaceMigrationValidateBuildAndRunService } from 'src/engine/workspace-manager/workspace-migration/services/workspace-migration-validate-build-and-run-service';
+
+@RegisteredWorkspaceCommand('2.23.0', 1784566000000)
+@Command({
+  name: 'upgrade:2-23:fix-go-to-roles-settings-command-menu-item-path',
+  description:
+    'Point the "Go to Roles Settings" navigation command menu item at /settings/members#roles for existing workspaces',
+})
+export class FixGoToRolesSettingsCommandMenuItemPathCommand extends ProvisionedWorkspaceCommandRunner {
+  constructor(
+    protected readonly workspaceIteratorService: WorkspaceIteratorService,
+    private readonly applicationService: ApplicationService,
+    private readonly workspaceCacheService: WorkspaceCacheService,
+    private readonly workspaceMigrationValidateBuildAndRunService: WorkspaceMigrationValidateBuildAndRunService,
+  ) {
+    super(workspaceIteratorService);
+  }
+
+  override async runOnWorkspace({
+    workspaceId,
+    options,
+  }: RunOnWorkspaceArgs): Promise<void> {
+    const isDryRun = options.dryRun ?? false;
+
+    const { flatCommandMenuItemMaps } =
+      await this.workspaceCacheService.getOrRecompute(workspaceId, [
+        'flatCommandMenuItemMaps',
+      ]);
+
+    const commandMenuItemOperations =
+      buildFixGoToRolesSettingsCommandMenuItemPathSyncOperations({
+        existingFlatCommandMenuItemMaps: flatCommandMenuItemMaps,
+        now: new Date().toISOString(),
+      });
+
+    const commandMenuItemsToUpdate =
+      commandMenuItemOperations.flatEntityToUpdate;
+
+    if (commandMenuItemsToUpdate.length === 0) {
+      this.logger.log(
+        `"Go to Roles Settings" command menu item path already synced for workspace ${workspaceId}, skipping`,
+      );
+
+      return;
+    }
+
+    this.logger.log(
+      `${isDryRun ? '[DRY RUN] ' : ''}Fixing "Go to Roles Settings" command menu item path for workspace ${workspaceId}`,
+    );
+
+    if (isDryRun) {
+      return;
+    }
+
+    const { twentyStandardFlatApplication } =
+      await this.applicationService.findWorkspaceTwentyStandardAndCustomApplicationOrThrow(
+        { workspaceId },
+      );
+
+    const validateAndBuildResult =
+      await this.workspaceMigrationValidateBuildAndRunService.validateBuildAndRunWorkspaceMigration(
+        {
+          isSystemBuild: true,
+          workspaceId,
+          applicationUniversalIdentifier:
+            twentyStandardFlatApplication.universalIdentifier,
+          allFlatEntityOperationByMetadataName: {
+            commandMenuItem: commandMenuItemOperations,
+          },
+        },
+      );
+
+    if (validateAndBuildResult.status === 'fail') {
+      this.logger.error(
+        `Failed to fix "Go to Roles Settings" command menu item path:\n${JSON.stringify(validateAndBuildResult, null, 2)}`,
+      );
+
+      throw new Error(
+        `Failed to fix "Go to Roles Settings" command menu item path for workspace ${workspaceId}`,
+      );
+    }
+
+    this.logger.log(
+      `Successfully fixed "Go to Roles Settings" command menu item path for workspace ${workspaceId}`,
+    );
+  }
+}

--- a/packages/twenty-server/src/database/commands/upgrade-version-command/2-23/utils/build-fix-go-to-roles-settings-command-menu-item-path-sync-operations.util.ts
+++ b/packages/twenty-server/src/database/commands/upgrade-version-command/2-23/utils/build-fix-go-to-roles-settings-command-menu-item-path-sync-operations.util.ts
@@ -1,0 +1,55 @@
+import { isDefined } from 'twenty-shared/utils';
+
+import { type FlatCommandMenuItem } from 'src/engine/metadata-modules/flat-command-menu-item/types/flat-command-menu-item.type';
+import { type FlatEntityMaps } from 'src/engine/metadata-modules/flat-entity/types/flat-entity-maps.type';
+import { type FlatEntityToCreateDeleteUpdate } from 'src/engine/metadata-modules/flat-entity/types/flat-entity-to-create-delete-update.type';
+import { STANDARD_COMMAND_MENU_ITEMS } from 'src/engine/workspace-manager/twenty-standard-application/constants/standard-command-menu-item.constant';
+
+export const LEGACY_GO_TO_ROLES_SETTINGS_PATH = '/settings/roles';
+
+export const GO_TO_ROLES_SETTINGS_PATH = '/settings/members#roles';
+
+const GO_TO_ROLES_SETTINGS_COMMAND_MENU_ITEM_UNIVERSAL_IDENTIFIER =
+  STANDARD_COMMAND_MENU_ITEMS.goToSettingsRoles.universalIdentifier;
+
+export const buildFixGoToRolesSettingsCommandMenuItemPathSyncOperations = ({
+  existingFlatCommandMenuItemMaps,
+  now,
+}: {
+  existingFlatCommandMenuItemMaps: FlatEntityMaps<FlatCommandMenuItem>;
+  now: string;
+}): FlatEntityToCreateDeleteUpdate<'commandMenuItem'> => {
+  const existingGoToRolesSettingsCommandMenuItem =
+    existingFlatCommandMenuItemMaps.byUniversalIdentifier[
+      GO_TO_ROLES_SETTINGS_COMMAND_MENU_ITEM_UNIVERSAL_IDENTIFIER
+    ];
+
+  const existingPath =
+    existingGoToRolesSettingsCommandMenuItem?.payload &&
+    'path' in existingGoToRolesSettingsCommandMenuItem.payload
+      ? existingGoToRolesSettingsCommandMenuItem.payload.path
+      : undefined;
+
+  if (
+    !isDefined(existingGoToRolesSettingsCommandMenuItem) ||
+    existingPath !== LEGACY_GO_TO_ROLES_SETTINGS_PATH
+  ) {
+    return {
+      flatEntityToCreate: [],
+      flatEntityToDelete: [],
+      flatEntityToUpdate: [],
+    };
+  }
+
+  return {
+    flatEntityToCreate: [],
+    flatEntityToDelete: [],
+    flatEntityToUpdate: [
+      {
+        ...existingGoToRolesSettingsCommandMenuItem,
+        payload: { path: GO_TO_ROLES_SETTINGS_PATH },
+        updatedAt: now,
+      },
+    ],
+  };
+};

--- a/packages/twenty-server/src/engine/workspace-manager/twenty-standard-application/constants/standard-command-menu-item.constant.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/twenty-standard-application/constants/standard-command-menu-item.constant.ts
@@ -872,7 +872,7 @@ export const STANDARD_COMMAND_MENU_ITEMS = {
     frontComponentUniversalIdentifier: null,
     engineComponentKey: EngineComponentKey.NAVIGATION,
     hotKeys: null,
-    payload: { path: '/settings/roles' },
+    payload: { path: '/settings/members#roles' },
   },
   goToSettingsDomains: {
     universalIdentifier: '2d071684-fb5e-4222-b560-4c7ab2597fb4',


### PR DESCRIPTION
**Fix the "Go to Roles Settings" command** — it pointed at the non-existent `/settings/roles` route and now navigates to `/settings/members#roles`.

**Backfill existing workspaces** — added the `upgrade:2-23:fix-go-to-roles-settings-command-menu-item-path` workspace command, which rewrites the seeded command menu item payload for existing workspaces. It is idempotent and only touches workspaces still holding the legacy path.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/23105?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

