### PR TITLE
fix(ai-chat): stop rendering "Ran undefined" for execute_tool calls

### DIFF
--- a/packages/twenty-front/src/modules/ai/utils/tool-display/__tests__/unwrap-tool-input.util.test.ts
+++ b/packages/twenty-front/src/modules/ai/utils/tool-display/__tests__/unwrap-tool-input.util.test.ts
@@ -1,0 +1,60 @@
+import { unwrapToolInput } from '@/ai/utils/tool-display/unwrap-tool-input.util';
+
+describe('unwrapToolInput', () => {
+  it('should leave non-execute_tool tools untouched', () => {
+    const input = { limit: 10 };
+
+    expect(unwrapToolInput({ input, toolName: 'find_many_companies' })).toEqual({
+      toolInput: input,
+      toolName: 'find_many_companies',
+    });
+  });
+
+  it('should unwrap the inner tool name and arguments', () => {
+    expect(
+      unwrapToolInput({
+        input: { toolName: 'find_many_companies', arguments: { limit: 10 } },
+        toolName: 'execute_tool',
+      }),
+    ).toEqual({
+      toolInput: { limit: 10 },
+      toolName: 'find_many_companies',
+    });
+  });
+
+  it('should fall back to execute_tool when the inner tool name is missing', () => {
+    const input = { arguments: { limit: 10 } };
+
+    expect(unwrapToolInput({ input, toolName: 'execute_tool' })).toEqual({
+      toolInput: input,
+      toolName: 'execute_tool',
+    });
+  });
+
+  it('should fall back to execute_tool when the inner tool name is empty', () => {
+    const input = { toolName: '', arguments: {} };
+
+    expect(unwrapToolInput({ input, toolName: 'execute_tool' })).toEqual({
+      toolInput: input,
+      toolName: 'execute_tool',
+    });
+  });
+
+  it('should fall back to execute_tool when the inner tool name is not a string', () => {
+    const input = { toolName: 42, arguments: {} };
+
+    expect(unwrapToolInput({ input, toolName: 'execute_tool' })).toEqual({
+      toolInput: input,
+      toolName: 'execute_tool',
+    });
+  });
+
+  it('should fall back to execute_tool when the input is empty', () => {
+    const input = {};
+
+    expect(unwrapToolInput({ input, toolName: 'execute_tool' })).toEqual({
+      toolInput: input,
+      toolName: 'execute_tool',
+    });
+  });
+});

--- a/packages/twenty-front/src/modules/ai/utils/tool-display/unwrap-tool-input.util.ts
+++ b/packages/twenty-front/src/modules/ai/utils/tool-display/unwrap-tool-input.util.ts
@@ -3,7 +3,7 @@ import { z } from 'zod';
 import { type ToolInput } from '@/ai/types/ToolInput';
 
 const ExecuteToolSchema = z.object({
-  toolName: z.coerce.string(),
+  toolName: z.string().min(1),
   arguments: z.unknown(),
 });
 


### PR DESCRIPTION
## Problem

In the AI chat, tool calls sometimes render as **"Ran undefined"** instead of a real label.

`unwrapToolInput` validates `execute_tool`'s input with `z.coerce.string()`:

```ts
const ExecuteToolSchema = z.object({
  toolName: z.coerce.string(),
  arguments: z.unknown(),
});
```

`z.coerce.string()` applies `String(input)` *before* validating, and `String(undefined)` is the
literal string `"undefined"`. So when `toolName` is missing, the parse **succeeds** and yields
`"undefined"` as the tool name. That flows through `buildToolStatusMessageByCategory`, which
matches no category and falls back to `` label = labelByName.get(toolName) ?? toolName ``, producing
`` t`Ran ${label}` `` → **"Ran undefined"**.

The `?? toolName` fallback was meant to degrade to the real tool name, but coercion had already
replaced it with a valid-looking string, so the fallback never fires.

This shows up whenever a tool call reaches the UI without a parseable `toolName` — most visibly
with providers whose streamed tool-call arguments arrive malformed, where the affected calls render
as "Ran undefined" while well-formed ones in the same message render correctly.

## Fix

Use `z.string().min(1)` so invalid input fails validation and the existing fallback path does its
job, reporting `execute_tool` rather than a fabricated name.

Behaviour on zod 4.1.11 (the version in this repo):

| `input` | before | after |
| --- | --- | --- |
| `{ toolName: 'find_many_companies', arguments: {...} }` | `"find_many_companies"` | `"find_many_companies"` |
| `{ arguments: {...} }` | `"undefined"` | `"execute_tool"` |
| `{ toolName: '', arguments: {} }` | `""` (renders `Ran `) | `"execute_tool"` |
| `{ toolName: 42, arguments: {} }` | `"42"` | `"execute_tool"` |
| `{}` | `"undefined"` | `"execute_tool"` |

The happy path and partially-streamed names (e.g. `find_many_p`) are unchanged — coercion only ever
altered input that was already invalid, so nothing that previously produced a correct label regresses.

## Tests

Adds `__tests__/unwrap-tool-input.util.test.ts` covering the passthrough case, the successful unwrap,
and each fallback (missing, empty, non-string, empty object).

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/23110?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

