### PR TITLE
Cap upgrade batch size and fix batch size input parsing

### DIFF
--- a/packages/twenty-front/src/pages/settings/applications/components/SettingsApplicationRegistrationGeneralStats.tsx
+++ b/packages/twenty-front/src/pages/settings/applications/components/SettingsApplicationRegistrationGeneralStats.tsx
@@ -51,11 +51,11 @@ export const SettingsApplicationRegistrationGeneralStats = ({
     { client: apolloAdminClient },
   );
 
-  const parsedBatchSize = Number.parseInt(batchSizeInput, 10);
+  const parsedBatchSize = Number(batchSizeInput);
   const batchSize =
-    Number.isNaN(parsedBatchSize) || parsedBatchSize < 1
-      ? DEFAULT_UPGRADE_BATCH_SIZE
-      : parsedBatchSize;
+    Number.isInteger(parsedBatchSize) && parsedBatchSize > 0
+      ? parsedBatchSize
+      : DEFAULT_UPGRADE_BATCH_SIZE;
 
   const handleUpgrade = async () => {
     setIsUpgrading(true);

--- a/packages/twenty-server/src/engine/core-modules/application/application-upgrade/application-upgrade.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/application/application-upgrade/application-upgrade.service.ts
@@ -22,6 +22,7 @@ const npmPackageMetadataSchema = z.object({
 });
 
 const UPGRADE_APPLICATIONS_DEFAULT_BATCH_SIZE = 5;
+const UPGRADE_APPLICATIONS_MAX_BATCH_SIZE = 50;
 
 @Injectable()
 export class ApplicationUpgradeService {
@@ -141,7 +142,10 @@ export class ApplicationUpgradeService {
       (application) => application.version !== targetVersion,
     );
 
-    const sanitizedBatchSize = Math.max(1, Math.floor(batchSize));
+    const sanitizedBatchSize = Math.min(
+      Math.max(1, Math.floor(batchSize)),
+      UPGRADE_APPLICATIONS_MAX_BATCH_SIZE,
+    );
 
     for (
       let batchStart = 0;


### PR DESCRIPTION
Follow-up to #23101, addressing the two review-bot findings that landed after it merged:

- `ApplicationUpgradeService` now clamps the batch size to `UPGRADE_APPLICATIONS_MAX_BATCH_SIZE = 50`, so an arbitrarily large admin-supplied value can no longer turn the per-batch `Promise.all` into unbounded concurrency across all workspaces.
- The batch size input in the admin confirmation modal is parsed with `Number` and validated with `Number.isInteger` instead of `Number.parseInt`, so values like `1e3` are no longer silently truncated to `1` (they now parse to `1000`, which the server clamps to 50).

---
_Generated by [Claude Code](https://claude.ai/code/session_0128uEtaXvdPoAB8btAr5v9V)_

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/23115?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

