### PR TITLE
Remove dead code from legacy metadataVersion cache mechanism

### DIFF
--- a/packages/twenty-server/src/engine/core-modules/auth/types/workspace-auth-context.type.ts
+++ b/packages/twenty-server/src/engine/core-modules/auth/types/workspace-auth-context.type.ts
@@ -10,7 +10,6 @@ export type WorkspaceAuthContextType =
 interface BaseWorkspaceAuthContext {
   type: WorkspaceAuthContextType;
   workspace: NonNullable<RawAuthContext['workspace']>;
-  workspaceMetadataVersion?: string;
 }
 
 export interface ApiKeyWorkspaceAuthContext extends BaseWorkspaceAuthContext {

--- a/packages/twenty-server/src/engine/core-modules/auth/utils/build-api-key-auth-context.util.ts
+++ b/packages/twenty-server/src/engine/core-modules/auth/utils/build-api-key-auth-context.util.ts
@@ -4,7 +4,6 @@ import { type ApiKeyWorkspaceAuthContext } from 'src/engine/core-modules/auth/ty
 type ApiKeyAuthContextInput = {
   workspace: NonNullable<RawAuthContext['workspace']>;
   apiKey: NonNullable<RawAuthContext['apiKey']>;
-  workspaceMetadataVersion?: string;
 };
 
 export const buildApiKeyAuthContext = (
@@ -14,6 +13,5 @@ export const buildApiKeyAuthContext = (
     type: 'apiKey',
     workspace: input.workspace,
     apiKey: input.apiKey,
-    workspaceMetadataVersion: input.workspaceMetadataVersion,
   };
 };

--- a/packages/twenty-server/src/engine/core-modules/auth/utils/build-application-auth-context.util.ts
+++ b/packages/twenty-server/src/engine/core-modules/auth/utils/build-application-auth-context.util.ts
@@ -4,7 +4,6 @@ import { type ApplicationWorkspaceAuthContext } from 'src/engine/core-modules/au
 type ApplicationAuthContextInput = {
   workspace: NonNullable<RawAuthContext['workspace']>;
   application: NonNullable<RawAuthContext['application']>;
-  workspaceMetadataVersion?: string;
 };
 
 export const buildApplicationAuthContext = (
@@ -14,6 +13,5 @@ export const buildApplicationAuthContext = (
     type: 'application',
     workspace: input.workspace,
     application: input.application,
-    workspaceMetadataVersion: input.workspaceMetadataVersion,
   };
 };

--- a/packages/twenty-server/src/engine/core-modules/auth/utils/build-pending-activation-user-auth-context.util.ts
+++ b/packages/twenty-server/src/engine/core-modules/auth/utils/build-pending-activation-user-auth-context.util.ts
@@ -5,7 +5,6 @@ type PendingActivationUserAuthContextInput = {
   workspace: NonNullable<RawAuthContext['workspace']>;
   userWorkspaceId: NonNullable<RawAuthContext['userWorkspaceId']>;
   user: NonNullable<RawAuthContext['user']>;
-  workspaceMetadataVersion?: string;
 };
 
 export const buildPendingActivationUserAuthContext = (
@@ -16,6 +15,5 @@ export const buildPendingActivationUserAuthContext = (
     workspace: input.workspace,
     userWorkspaceId: input.userWorkspaceId,
     user: input.user,
-    workspaceMetadataVersion: input.workspaceMetadataVersion,
   };
 };

--- a/packages/twenty-server/src/engine/core-modules/auth/utils/build-system-auth-context.util.ts
+++ b/packages/twenty-server/src/engine/core-modules/auth/utils/build-system-auth-context.util.ts
@@ -3,7 +3,6 @@ import { type SystemWorkspaceAuthContext } from 'src/engine/core-modules/auth/ty
 
 type SystemAuthContextInput = {
   workspace: NonNullable<RawAuthContext['workspace']>;
-  workspaceMetadataVersion?: string;
 };
 
 export const buildSystemAuthContext = (
@@ -12,6 +11,5 @@ export const buildSystemAuthContext = (
   return {
     type: 'system',
     workspace: input.workspace,
-    workspaceMetadataVersion: input.workspaceMetadataVersion,
   };
 };

--- a/packages/twenty-server/src/engine/core-modules/auth/utils/build-user-auth-context.util.ts
+++ b/packages/twenty-server/src/engine/core-modules/auth/utils/build-user-auth-context.util.ts
@@ -7,7 +7,6 @@ type UserAuthContextInput = {
   user: NonNullable<RawAuthContext['user']>;
   workspaceMemberId: NonNullable<RawAuthContext['workspaceMemberId']>;
   workspaceMember: NonNullable<RawAuthContext['workspaceMember']>;
-  workspaceMetadataVersion?: string;
 };
 
 export const buildUserAuthContext = (
@@ -20,6 +19,5 @@ export const buildUserAuthContext = (
     user: input.user,
     workspaceMemberId: input.workspaceMemberId,
     workspaceMember: input.workspaceMember,
-    workspaceMetadataVersion: input.workspaceMetadataVersion,
   };
 };

--- a/packages/twenty-server/src/engine/metadata-modules/field-metadata/field-metadata.module.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/field-metadata/field-metadata.module.ts
@@ -30,7 +30,6 @@ import { ViewFieldModule } from 'src/engine/metadata-modules/view-field/view-fie
 import { ViewFilterModule } from 'src/engine/metadata-modules/view-filter/view-filter.module';
 import { ViewGroupModule } from 'src/engine/metadata-modules/view-group/view-group.module';
 import { ViewModule } from 'src/engine/metadata-modules/view/view.module';
-import { WorkspaceMetadataVersionModule } from 'src/engine/metadata-modules/workspace-metadata-version/workspace-metadata-version.module';
 import { WorkspaceCacheStorageModule } from 'src/engine/workspace-cache-storage/workspace-cache-storage.module';
 import { WorkspaceMigrationModule } from 'src/engine/workspace-manager/workspace-migration/workspace-migration.module';
 import { WorkspaceCacheModule } from 'src/engine/workspace-cache/workspace-cache.module';
@@ -54,7 +53,6 @@ import { UpdateFieldInput } from './dtos/update-field.input';
           FieldMetadataEntity,
           ObjectMetadataEntity,
         ]),
-        WorkspaceMetadataVersionModule,
         WorkspaceCacheStorageModule,
         ObjectMetadataModule,
         TypeORMModule,

--- a/packages/twenty-server/src/engine/metadata-modules/object-metadata/object-metadata.module.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/object-metadata/object-metadata.module.ts
@@ -35,7 +35,6 @@ import { PermissionsGraphqlApiExceptionFilter } from 'src/engine/metadata-module
 import { ViewFieldModule } from 'src/engine/metadata-modules/view-field/view-field.module';
 import { ViewEntity } from 'src/engine/metadata-modules/view/entities/view.entity';
 import { ViewModule } from 'src/engine/metadata-modules/view/view.module';
-import { WorkspaceMetadataVersionModule } from 'src/engine/metadata-modules/workspace-metadata-version/workspace-metadata-version.module';
 import { WorkspaceCacheStorageModule } from 'src/engine/workspace-cache-storage/workspace-cache-storage.module';
 import { WorkspaceCacheModule } from 'src/engine/workspace-cache/workspace-cache.module';
 import { WorkspaceDataSourceModule } from 'src/engine/workspace-datasource/workspace-datasource.module';
@@ -59,7 +58,6 @@ import { WorkspaceMigrationModule } from 'src/engine/workspace-manager/workspace
         ]),
         TypeOrmModule.forFeature([FeatureFlagEntity, ViewEntity]),
         ApplicationModule,
-        WorkspaceMetadataVersionModule,
         IndexMetadataModule,
         PermissionsModule,
         WorkspaceCacheStorageModule,

--- a/packages/twenty-server/src/engine/twenty-orm/exceptions/twenty-orm.exception.ts
+++ b/packages/twenty-server/src/engine/twenty-orm/exceptions/twenty-orm.exception.ts
@@ -6,7 +6,6 @@ import { STANDARD_ERROR_MESSAGE } from 'src/engine/api/common/common-query-runne
 import { CustomException } from 'src/utils/custom-exception';
 
 export enum TwentyORMExceptionCode {
-  METADATA_VERSION_MISMATCH = 'METADATA_VERSION_MISMATCH',
   WORKSPACE_SCHEMA_NOT_FOUND = 'WORKSPACE_SCHEMA_NOT_FOUND',
   ROLES_PERMISSIONS_VERSION_NOT_FOUND = 'ROLES_PERMISSIONS_VERSION_NOT_FOUND',
   FEATURE_FLAG_MAP_VERSION_NOT_FOUND = 'FEATURE_FLAG_MAP_VERSION_NOT_FOUND',
@@ -33,8 +32,6 @@ const getTwentyORMExceptionUserFriendlyMessage = (
   code: TwentyORMExceptionCode,
 ) => {
   switch (code) {
-    case TwentyORMExceptionCode.METADATA_VERSION_MISMATCH:
-      return msg`Data version mismatch. Please refresh and try again.`;
     case TwentyORMExceptionCode.WORKSPACE_SCHEMA_NOT_FOUND:
       return msg`Workspace schema not found.`;
     case TwentyORMExceptionCode.ROLES_PERMISSIONS_VERSION_NOT_FOUND:

--- a/packages/twenty-server/src/engine/workspace-cache-storage/workspace-cache-storage.service.ts
+++ b/packages/twenty-server/src/engine/workspace-cache-storage/workspace-cache-storage.service.ts
@@ -3,7 +3,6 @@ import { Injectable } from '@nestjs/common';
 import crypto from 'crypto';
 
 import { isDefined } from 'twenty-shared/utils';
-import { type EntitySchemaOptions } from 'typeorm';
 
 import { type FeatureFlagMap } from 'src/engine/core-modules/feature-flag/interfaces/feature-flag-map.interface';
 
@@ -14,7 +13,6 @@ import { CacheStorageNamespace } from 'src/engine/core-modules/cache-storage/typ
 export const METADATA_VERSIONED_WORKSPACE_CACHE_KEY = {
   GraphQLTypeDefs: 'graphql:type-defs',
   MetadataVersion: 'metadata:workspace-metadata-version',
-  MetadataObjectMetadataMaps: 'metadata:object-metadata-maps',
   GraphQLUsedScalarNames: 'graphql:used-scalar-names',
   ORMEntitySchemas: 'orm:entity-schemas',
 } as const;
@@ -43,31 +41,6 @@ export class WorkspaceCacheStorageService {
     @InjectCacheStorage(CacheStorageNamespace.EngineWorkspace)
     private readonly cacheStorageService: CacheStorageService,
   ) {}
-
-  setORMEntitySchema(
-    workspaceId: string,
-    metadataVersion: number,
-    // oxlint-disable-next-line typescript/no-explicit-any
-    entitySchemas: EntitySchemaOptions<any>[],
-  ) {
-    // oxlint-disable-next-line typescript/no-explicit-any
-    return this.cacheStorageService.set<EntitySchemaOptions<any>[]>(
-      `${METADATA_VERSIONED_WORKSPACE_CACHE_KEY.ORMEntitySchemas}:${workspaceId}:${metadataVersion}`,
-      entitySchemas,
-      TTL_ONE_WEEK,
-    );
-  }
-
-  getORMEntitySchema(
-    workspaceId: string,
-    metadataVersion: number,
-    // oxlint-disable-next-line typescript/no-explicit-any
-  ): Promise<EntitySchemaOptions<any>[] | undefined> {
-    // oxlint-disable-next-line typescript/no-explicit-any
-    return this.cacheStorageService.get<EntitySchemaOptions<any>[]>(
-      `${METADATA_VERSIONED_WORKSPACE_CACHE_KEY.ORMEntitySchemas}:${workspaceId}:${metadataVersion}`,
-    );
-  }
 
   setMetadataVersion(
     workspaceId: string,


### PR DESCRIPTION
- Drop unused setORMEntitySchema/getORMEntitySchema from WorkspaceCacheStorageService
- Drop MetadataObjectMetadataMaps cache key, only referenced by the flush loop
- Drop never-populated workspaceMetadataVersion field from workspace auth context type and builders
- Drop unthrown TwentyORMExceptionCode.METADATA_VERSION_MISMATCH
- Drop unused WorkspaceMetadataVersionModule imports in field-metadata and object-metadata modules

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/23122?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

