### PR TITLE
Upgrade remaining official apps to 2.23 alpha

### DIFF
--- a/packages/twenty-apps/examples/postcard/package.json
+++ b/packages/twenty-apps/examples/postcard/package.json
@@ -1,12 +1,12 @@
 {
   "name": "postcard",
-  "version": "0.1.0",
+  "version": "0.1.2",
   "license": "MIT",
   "engines": {
     "node": "^24.5.0",
     "npm": "please-use-yarn",
     "yarn": ">=4.0.2",
-    "twenty": ">=2.19.0"
+    "twenty": ">=2.23.0"
   },
   "keywords": [
     "twenty-app"
@@ -29,8 +29,8 @@
     "playwright": "^1.60.0",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
-    "twenty-client-sdk": "2.19.0-alpha.1",
-    "twenty-sdk": "2.19.0-alpha.1",
+    "twenty-client-sdk": "2.23.0-alpha.1",
+    "twenty-sdk": "2.23.0-alpha.1",
     "typescript": "^5.9.3",
     "vitest": "^4.0.0"
   }

--- a/packages/twenty-apps/examples/postcard/yarn.lock
+++ b/packages/twenty-apps/examples/postcard/yarn.lock
@@ -2549,8 +2549,8 @@ __metadata:
     playwright: "npm:^1.60.0"
     react: "npm:^19.0.0"
     react-dom: "npm:^19.0.0"
-    twenty-client-sdk: "npm:2.19.0-alpha.1"
-    twenty-sdk: "npm:2.19.0-alpha.1"
+    twenty-client-sdk: "npm:2.23.0-alpha.1"
+    twenty-sdk: "npm:2.23.0-alpha.1"
     typescript: "npm:^5.9.3"
     vitest: "npm:^4.0.0"
   languageName: unknown
@@ -3090,22 +3090,22 @@ __metadata:
   languageName: node
   linkType: hard
 
-"twenty-client-sdk@npm:2.19.0-alpha.1":
-  version: 2.19.0-alpha.1
-  resolution: "twenty-client-sdk@npm:2.19.0-alpha.1"
+"twenty-client-sdk@npm:2.23.0-alpha.1":
+  version: 2.23.0-alpha.1
+  resolution: "twenty-client-sdk@npm:2.23.0-alpha.1"
   dependencies:
     "@genql/runtime": "npm:^2.10.0"
     esbuild: "npm:^0.28.1"
     graphql: "npm:^16.8.1"
     lodash: "npm:^4.17.21"
     prettier: "npm:^3.8.3"
-  checksum: 10c0/daeac1c1b439f2a5c6ecd5ac5a97b04e56832bdd2e5530f5269bf469fd776849c750ea103b6837910dab3378adc146d4703008f7374c44eb4263fae1e120eb7c
+  checksum: 10c0/b55c1e4eee7cdf24d68b9318924f428ad2d26a96052b5ed7d2a6da21a88bb216326fb979e8f7e99765e6495b9f98c0334ed6fb0452beb49a135f88bfb09c70cc
   languageName: node
   linkType: hard
 
-"twenty-sdk@npm:2.19.0-alpha.1":
-  version: 2.19.0-alpha.1
-  resolution: "twenty-sdk@npm:2.19.0-alpha.1"
+"twenty-sdk@npm:2.23.0-alpha.1":
+  version: 2.23.0-alpha.1
+  resolution: "twenty-sdk@npm:2.23.0-alpha.1"
   dependencies:
     "@sniptt/guards": "npm:^0.2.0"
     axios: "npm:^1.16.0"
@@ -3124,12 +3124,12 @@ __metadata:
     semver: "npm:7.6.3"
     sharp: "npm:^0.34.5"
     tinyglobby: "npm:^0.2.15"
-    twenty-client-sdk: "npm:2.19.0-alpha.1"
+    twenty-client-sdk: "npm:2.23.0-alpha.1"
     typescript: "npm:^5.9.3"
     uuid: "npm:^13.0.2"
   bin:
     twenty: dist/cli.cjs
-  checksum: 10c0/c36772f6e6193c24ff5c6ba7636f4ae3b6110fed5697bc94cfbd282ae290b8de10b0f1df2b86a2c38eaed8f5a57791222b1f49b0d46baef6bb4b12fd0622cc2f
+  checksum: 10c0/c11830007c6bbf3bc0447c9e7ba2df9d3d3eac9593cb9b0236757e92fbf94cb9f24eecc150b663e435e65dc0bee48baf1833ff2d06333e84845c8b47464bcdce
   languageName: node
   linkType: hard
 

--- a/packages/twenty-apps/public/call-recorder/package.json
+++ b/packages/twenty-apps/public/call-recorder/package.json
@@ -6,7 +6,7 @@
     "node": "^24.5.0",
     "npm": "please-use-yarn",
     "yarn": ">=4.0.2",
-    "twenty": ">=2.20.0"
+    "twenty": ">=2.23.0"
   },
   "keywords": [
     "twenty-app"
@@ -35,8 +35,8 @@
     "oxlint": "^0.16.0",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
-    "twenty-client-sdk": "2.20.0",
-    "twenty-sdk": "2.20.0",
+    "twenty-client-sdk": "2.23.0-alpha.1",
+    "twenty-sdk": "2.23.0-alpha.1",
     "twenty-ui": "^1.0.0-alpha.1",
     "typescript": "^5.9.3",
     "vite-tsconfig-paths": "^4.2.1",

--- a/packages/twenty-apps/public/call-recorder/yarn.lock
+++ b/packages/twenty-apps/public/call-recorder/yarn.lock
@@ -1376,8 +1376,8 @@ __metadata:
     react: "npm:^19.0.0"
     react-dom: "npm:^19.0.0"
     sharp: "npm:^0.34.5"
-    twenty-client-sdk: "npm:2.20.0"
-    twenty-sdk: "npm:2.20.0"
+    twenty-client-sdk: "npm:2.23.0-alpha.1"
+    twenty-sdk: "npm:2.23.0-alpha.1"
     twenty-ui: "npm:^1.0.0-alpha.1"
     typescript: "npm:^5.9.3"
     vite-tsconfig-paths: "npm:^4.2.1"
@@ -3588,22 +3588,22 @@ __metadata:
   languageName: node
   linkType: hard
 
-"twenty-client-sdk@npm:2.20.0":
-  version: 2.20.0
-  resolution: "twenty-client-sdk@npm:2.20.0"
+"twenty-client-sdk@npm:2.23.0-alpha.1":
+  version: 2.23.0-alpha.1
+  resolution: "twenty-client-sdk@npm:2.23.0-alpha.1"
   dependencies:
     "@genql/runtime": "npm:^2.10.0"
     esbuild: "npm:^0.28.1"
     graphql: "npm:^16.8.1"
     lodash: "npm:^4.17.21"
     prettier: "npm:^3.8.3"
-  checksum: 10c0/925a5ad99bbccb7290365536b6d7ded6a8d02a064b175a195b6439732db6848a0a3aaa762f5c30ad0b79f48921a6cbd203fe442a0b9f93d1d902812c0d83aa17
+  checksum: 10c0/b55c1e4eee7cdf24d68b9318924f428ad2d26a96052b5ed7d2a6da21a88bb216326fb979e8f7e99765e6495b9f98c0334ed6fb0452beb49a135f88bfb09c70cc
   languageName: node
   linkType: hard
 
-"twenty-sdk@npm:2.20.0":
-  version: 2.20.0
-  resolution: "twenty-sdk@npm:2.20.0"
+"twenty-sdk@npm:2.23.0-alpha.1":
+  version: 2.23.0-alpha.1
+  resolution: "twenty-sdk@npm:2.23.0-alpha.1"
   dependencies:
     "@sniptt/guards": "npm:^0.2.0"
     axios: "npm:^1.16.0"
@@ -3622,12 +3622,12 @@ __metadata:
     semver: "npm:7.6.3"
     sharp: "npm:^0.34.5"
     tinyglobby: "npm:^0.2.15"
-    twenty-client-sdk: "npm:2.20.0"
+    twenty-client-sdk: "npm:2.23.0-alpha.1"
     typescript: "npm:^5.9.3"
     uuid: "npm:^13.0.2"
   bin:
     twenty: dist/cli.cjs
-  checksum: 10c0/7fe50f229470e370473e7555f0eb284b59424cb51369ce0fa88723681bd6a662879268f953599b0e3c5fc97b73f1e756352df80605185ed6b4e9c85fa186feef
+  checksum: 10c0/c11830007c6bbf3bc0447c9e7ba2df9d3d3eac9593cb9b0236757e92fbf94cb9f24eecc150b663e435e65dc0bee48baf1833ff2d06333e84845c8b47464bcdce
   languageName: node
   linkType: hard
 

--- a/packages/twenty-apps/public/twenty-last-contact/package.json
+++ b/packages/twenty-apps/public/twenty-last-contact/package.json
@@ -6,7 +6,7 @@
     "node": "^24.5.0",
     "npm": "please-use-yarn",
     "yarn": ">=4.0.2",
-    "twenty": ">=2.20.0"
+    "twenty": ">=2.23.0"
   },
   "keywords": [
     "twenty-app"
@@ -28,8 +28,8 @@
     "oxlint": "^0.16.0",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
-    "twenty-client-sdk": "2.20.0",
-    "twenty-sdk": "2.20.0",
+    "twenty-client-sdk": "2.23.0-alpha.1",
+    "twenty-sdk": "2.23.0-alpha.1",
     "typescript": "^5.9.3",
     "vite-tsconfig-paths": "^4.2.1",
     "vitest": "^4.0.0"

--- a/packages/twenty-apps/public/twenty-last-contact/yarn.lock
+++ b/packages/twenty-apps/public/twenty-last-contact/yarn.lock
@@ -953,8 +953,8 @@ __metadata:
     oxlint: "npm:^0.16.0"
     react: "npm:^19.0.0"
     react-dom: "npm:^19.0.0"
-    twenty-client-sdk: "npm:2.20.0"
-    twenty-sdk: "npm:2.20.0"
+    twenty-client-sdk: "npm:2.23.0-alpha.1"
+    twenty-sdk: "npm:2.23.0-alpha.1"
     typescript: "npm:^5.9.3"
     vite-tsconfig-paths: "npm:^4.2.1"
     vitest: "npm:^4.0.0"
@@ -2833,22 +2833,22 @@ __metadata:
   languageName: node
   linkType: hard
 
-"twenty-client-sdk@npm:2.20.0":
-  version: 2.20.0
-  resolution: "twenty-client-sdk@npm:2.20.0"
+"twenty-client-sdk@npm:2.23.0-alpha.1":
+  version: 2.23.0-alpha.1
+  resolution: "twenty-client-sdk@npm:2.23.0-alpha.1"
   dependencies:
     "@genql/runtime": "npm:^2.10.0"
     esbuild: "npm:^0.28.1"
     graphql: "npm:^16.8.1"
     lodash: "npm:^4.17.21"
     prettier: "npm:^3.8.3"
-  checksum: 10c0/925a5ad99bbccb7290365536b6d7ded6a8d02a064b175a195b6439732db6848a0a3aaa762f5c30ad0b79f48921a6cbd203fe442a0b9f93d1d902812c0d83aa17
+  checksum: 10c0/b55c1e4eee7cdf24d68b9318924f428ad2d26a96052b5ed7d2a6da21a88bb216326fb979e8f7e99765e6495b9f98c0334ed6fb0452beb49a135f88bfb09c70cc
   languageName: node
   linkType: hard
 
-"twenty-sdk@npm:2.20.0":
-  version: 2.20.0
-  resolution: "twenty-sdk@npm:2.20.0"
+"twenty-sdk@npm:2.23.0-alpha.1":
+  version: 2.23.0-alpha.1
+  resolution: "twenty-sdk@npm:2.23.0-alpha.1"
   dependencies:
     "@sniptt/guards": "npm:^0.2.0"
     axios: "npm:^1.16.0"
@@ -2867,12 +2867,12 @@ __metadata:
     semver: "npm:7.6.3"
     sharp: "npm:^0.34.5"
     tinyglobby: "npm:^0.2.15"
-    twenty-client-sdk: "npm:2.20.0"
+    twenty-client-sdk: "npm:2.23.0-alpha.1"
     typescript: "npm:^5.9.3"
     uuid: "npm:^13.0.2"
   bin:
     twenty: dist/cli.cjs
-  checksum: 10c0/7fe50f229470e370473e7555f0eb284b59424cb51369ce0fa88723681bd6a662879268f953599b0e3c5fc97b73f1e756352df80605185ed6b4e9c85fa186feef
+  checksum: 10c0/c11830007c6bbf3bc0447c9e7ba2df9d3d3eac9593cb9b0236757e92fbf94cb9f24eecc150b663e435e65dc0bee48baf1833ff2d06333e84845c8b47464bcdce
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
The sdk does not provide system field anymore at all ( including relation ) if you don't upgrade you'll get a deterministic universal identifier collision from previously provision and now side effect resulting ones

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/23124?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

