### PR TITLE
fix: make scrollbar corner transparent in DefaultLayout

### DIFF
--- a/packages/twenty-front/src/modules/ui/layout/page/components/DefaultLayout.tsx
+++ b/packages/twenty-front/src/modules/ui/layout/page/components/DefaultLayout.tsx
@@ -24,6 +24,10 @@ const StyledLayout = styled.div`
   scrollbar-width: 4px;
   width: 100%;
 
+  *::-webkit-scrollbar-corner {
+    background-color: transparent;
+  }
+
   *::-webkit-scrollbar-thumb {
     border-radius: ${themeCssVariables.border.radius.md};
   }


### PR DESCRIPTION
## Problem

In dark mode, a blank square appears in the bottom-right corner when both scrollbars are visible
(e.g. on the Companies page when the list is long enough to show a vertical scrollbar alongside a
horizontal one).

This was reported in #23128. That tracking issue was auto-closed shortly after filing, but the bug
still reproduces on `main`. so this is a small fix for it. Happy to close this PR if it's intentionally
being left as-is.

## Cause

`StyledLayout` in `DefaultLayout.tsx` defines the app-wide custom scrollbar styling. It styles
`::-webkit-scrollbar-thumb` (and sets `scrollbar-color`/`scrollbar-width`), but it never styles
`::-webkit-scrollbar-corner`. Where the horizontal and vertical scrollbars meet, WebKit renders the
corner with its default background color, which is visible as a blank square against the dark theme.

The Storybook config already accounts for this — `packages/twenty-front/.storybook/preview-head.html`
sets `*::-webkit-scrollbar-corner { background-color: transparent; }` — which is why the issue never
appears in Storybook, only in the app.

## Fix

Add the same transparent `*::-webkit-scrollbar-corner` rule to `StyledLayout`, so the corner matches
the rest of the (transparent) scrollbar track in both light and dark mode.

```css
*::-webkit-scrollbar-corner {
  background-color: transparent;
}
```

CSS-only change, consistent with the existing Storybook rule and the adjacent `::-webkit-scrollbar-thumb`
styling.

Ref #23128


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/23138?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

