### PR TITLE
Finish #23071: edge-case tests for resolveDropTarget

### DIFF
--- a/packages/twenty-front/src/modules/ui/utilities/drag-and-drop/utils/__tests__/resolveDropTarget.test.ts
+++ b/packages/twenty-front/src/modules/ui/utilities/drag-and-drop/utils/__tests__/resolveDropTarget.test.ts
@@ -32,4 +32,24 @@ describe('resolveDropTarget', () => {
 
     expect(result.dropTargetIndex).toBe(3);
   });
+
+  it('should target the card position when the pointer is above the card top', () => {
+    const result = resolveDropTarget({
+      pointerY: 80,
+      cardPosition: 2,
+      cardShape,
+    });
+
+    expect(result.dropTargetIndex).toBe(2);
+  });
+
+  it('should target the slot after the card when the pointer is below the card bottom', () => {
+    const result = resolveDropTarget({
+      pointerY: 180,
+      cardPosition: 2,
+      cardShape,
+    });
+
+    expect(result.dropTargetIndex).toBe(3);
+  });
 });


### PR DESCRIPTION
Stacked on #23071 (`git-init-priyanshu:record-board/drag-drop-dnd-kit-rewrite`). The base branch here mirrors that PR's head (`7fc6c0aa`), so this diff is only the finishing change.

## What
Adds the two edge-case tests cubic asked for on #23071 (`resolveDropTarget.test.ts`): `pointerY` above the card top and below the card bottom — the positions a real drag enters and exits a card through.

## Why
This is the only outstanding review item left on #23071. For context, everything else on that PR is already handled:
- The single-card drag duplicate fix landed (`d52691512`).
- The contributor's follow-up `e8e70d01` generalizes the source-card dimming to single + multi drag and moves the multi-drag stack/scale to render only on the drag overlay — which resolves the multi-primary duplicate cleanly.
- `main` is merged in (`7fc6c0aa`); conflicts are gone and CI is green.

## To land
Cherry-pick this commit onto the #23071 branch (same way the single-drag fix landed), then that PR's last open thread is addressed and it's ready to merge. Verified locally: `resolveDropTarget` suite green (5/5), oxlint + oxfmt clean.

---
_Generated by [Claude Code](https://claude.ai/code/session_01XKRCzzu8oGyocXZtFp7VEG)_

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/23140?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

