### PR TITLE
fix: bump websocket-driver 0.7.4 -> 0.7.5 (Dependabot)

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -55716,13 +55716,13 @@ __metadata:
   linkType: hard
 
 "websocket-driver@npm:>=0.5.1, websocket-driver@npm:^0.7.4":
-  version: 0.7.4
-  resolution: "websocket-driver@npm:0.7.4"
+  version: 0.7.5
+  resolution: "websocket-driver@npm:0.7.5"
   dependencies:
     http-parser-js: "npm:>=0.5.1"
     safe-buffer: "npm:>=5.1.0"
     websocket-extensions: "npm:>=0.1.1"
-  checksum: 10c0/5f09547912b27bdc57bac17b7b6527d8993aa4ac8a2d10588bb74aebaf785fdcf64fea034aae0c359b7adff2044dd66f3d03866e4685571f81b13e548f9021f1
+  checksum: 10c0/843a3c9f529ce07f2721829f70f62986247525ab22625e857b69da13dc90967bacfe57b85e196801b565cd797e309ddd5b06fa8435732e34e8a8ab6201d7abed
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary

Bumps **websocket-driver 0.7.4 -> 0.7.5** to clear **2 Dependabot alerts** on the root `yarn.lock`, including the critical one from this week's advisory wave.

| Severity | Advisory | CVE | Alert |
|---|---|---|---|
| critical | GHSA-xv26-6w52-cph6 | CVE-2026-54466 | [1577](https://github.com/twentyhq/twenty/security/dependabot/1577) - message corruption via abuse of protocol length headers |
| medium | GHSA-mp7j-qc5w-4988 | CVE-2026-54490 | [1576](https://github.com/twentyhq/twenty/security/dependabot/1576) - resource limit bypass via message compression |

websocket-driver is transitive via **faye-websocket** (`>=0.5.1`) and **sockjs** (`^0.7.4`); both ranges already permit 0.7.5, so a recursive `yarn up -R websocket-driver` lifts it with no resolution and no `package.json` change.

## Verification

- `yarn install --immutable` passes.
- Diff is `yarn.lock` only; websocket-driver resolves to 0.7.5, no 0.7.4 remains.
- 0.7.5 published 2026-06-04, clears the 3-day npm age gate.
