### PR TITLE
Show agent names on real estate dashboard charts

### DIFF
--- a/packages/twenty-apps/internal/real-estate/src/page-layouts/agency-dashboard.page-layout.ts
+++ b/packages/twenty-apps/internal/real-estate/src/page-layouts/agency-dashboard.page-layout.ts
@@ -169,6 +169,7 @@ export default definePageLayout({
             aggregateOperation: AggregateOperations.COUNT,
             primaryAxisGroupByFieldMetadataUniversalIdentifier:
               LISTING_AGENT_ON_PROPERTY_ID,
+            primaryAxisGroupBySubFieldName: 'name.firstName',
             ...BAR,
             primaryAxisOrderBy: 'VALUE_DESC',
           },
@@ -186,6 +187,7 @@ export default definePageLayout({
             aggregateOperation: AggregateOperations.COUNT,
             primaryAxisGroupByFieldMetadataUniversalIdentifier:
               AGENT_ON_SHOWING_ID,
+            primaryAxisGroupBySubFieldName: 'name.firstName',
             ...BAR,
             primaryAxisOrderBy: 'VALUE_DESC',
           },


### PR DESCRIPTION
Follow-up to the real estate demo app: the Agency Overview dashboard's "Listings by agent" and "Showings by agent" bar charts grouped by the agent relation, which rendered the agent's UUID on the axis.

Adding `primaryAxisGroupBySubFieldName: 'name.firstName'` groups by the agent's first name instead, so the charts show agent names (Emma, Lucas, Chloe, Louis).


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/23146?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

