### PR TITLE
feat(server): on-connect logic function hook for connection providers

### DIFF
--- a/packages/twenty-client-sdk/src/metadata/generated/schema.graphql
+++ b/packages/twenty-client-sdk/src/metadata/generated/schema.graphql
@@ -1382,44 +1382,6 @@ type ApplicationConnectionProvider {
   oauth: ApplicationConnectionProviderOAuthConfig
 }
 
-type EnterpriseLicenseInfoDTO {
-  isValid: Boolean!
-  licensee: String
-  expiresAt: DateTime
-  subscriptionId: String
-}
-
-type EnterpriseSubscriptionStatusDTO {
-  status: String!
-  licensee: String
-  expiresAt: DateTime
-  cancelAt: DateTime
-  currentPeriodEnd: DateTime
-  isCancellationScheduled: Boolean!
-}
-
-type ApprovedAccessDomain {
-  id: UUID!
-  domain: String!
-  isValidated: Boolean!
-  createdAt: DateTime!
-}
-
-type FileWithSignedUrl {
-  id: UUID!
-  path: String!
-  size: Float!
-  createdAt: DateTime!
-  url: String!
-}
-
-type FileUploadTarget {
-  fileId: UUID!
-  uploadUrl: String!
-  contentType: String!
-  expiresAt: DateTime!
-}
-
 type BillingSubscriptionSchedulePhaseItem {
   price: String!
   quantity: Float
@@ -1511,11 +1473,6 @@ type BillingSubscriptionItem {
   billingProduct: BillingProductDTO!
 }
 
-type BillingCustomer {
-  id: UUID!
-  hasPaymentMethod: Boolean
-}
-
 type BillingSubscription {
   id: UUID!
   status: SubscriptionStatus!
@@ -1536,6 +1493,73 @@ enum SubscriptionStatus {
   Paused
   Trialing
   Unpaid
+}
+
+type BillingCustomer {
+  id: UUID!
+  hasPaymentMethod: Boolean
+}
+
+type LogicFunctionExecutionResult {
+  """Execution result in JSON format"""
+  data: JSON
+
+  """Execution Logs"""
+  logs: String!
+
+  """Execution duration in milliseconds"""
+  duration: Float!
+
+  """Execution status"""
+  status: LogicFunctionExecutionStatus!
+
+  """Execution error in JSON format"""
+  error: JSON
+}
+
+"""Status of the logic function execution"""
+enum LogicFunctionExecutionStatus {
+  IDLE
+  SUCCESS
+  ERROR
+}
+
+type EnterpriseLicenseInfoDTO {
+  isValid: Boolean!
+  licensee: String
+  expiresAt: DateTime
+  subscriptionId: String
+}
+
+type EnterpriseSubscriptionStatusDTO {
+  status: String!
+  licensee: String
+  expiresAt: DateTime
+  cancelAt: DateTime
+  currentPeriodEnd: DateTime
+  isCancellationScheduled: Boolean!
+}
+
+type ApprovedAccessDomain {
+  id: UUID!
+  domain: String!
+  isValidated: Boolean!
+  createdAt: DateTime!
+}
+
+type FileWithSignedUrl {
+  id: UUID!
+  path: String!
+  size: Float!
+  createdAt: DateTime!
+  url: String!
+}
+
+type FileUploadTarget {
+  fileId: UUID!
+  uploadUrl: String!
+  contentType: String!
+  expiresAt: DateTime!
 }
 
 type BillingEndTrialPeriod {
@@ -1695,30 +1719,6 @@ type EventSubscription {
   eventStreamId: String!
   objectRecordEventsWithQueryIds: [ObjectRecordEventWithQueryIds!]!
   metadataEvents: [MetadataEvent!]!
-}
-
-type LogicFunctionExecutionResult {
-  """Execution result in JSON format"""
-  data: JSON
-
-  """Execution Logs"""
-  logs: String!
-
-  """Execution duration in milliseconds"""
-  duration: Float!
-
-  """Execution status"""
-  status: LogicFunctionExecutionStatus!
-
-  """Execution error in JSON format"""
-  error: JSON
-}
-
-"""Status of the logic function execution"""
-enum LogicFunctionExecutionStatus {
-  IDLE
-  SUCCESS
-  ERROR
 }
 
 type FeatureFlag {

--- a/packages/twenty-client-sdk/src/metadata/generated/schema.ts
+++ b/packages/twenty-client-sdk/src/metadata/generated/schema.ts
@@ -1057,49 +1057,6 @@ export interface ApplicationConnectionProvider {
     __typename: 'ApplicationConnectionProvider'
 }
 
-export interface EnterpriseLicenseInfoDTO {
-    isValid: Scalars['Boolean']
-    licensee?: Scalars['String']
-    expiresAt?: Scalars['DateTime']
-    subscriptionId?: Scalars['String']
-    __typename: 'EnterpriseLicenseInfoDTO'
-}
-
-export interface EnterpriseSubscriptionStatusDTO {
-    status: Scalars['String']
-    licensee?: Scalars['String']
-    expiresAt?: Scalars['DateTime']
-    cancelAt?: Scalars['DateTime']
-    currentPeriodEnd?: Scalars['DateTime']
-    isCancellationScheduled: Scalars['Boolean']
-    __typename: 'EnterpriseSubscriptionStatusDTO'
-}
-
-export interface ApprovedAccessDomain {
-    id: Scalars['UUID']
-    domain: Scalars['String']
-    isValidated: Scalars['Boolean']
-    createdAt: Scalars['DateTime']
-    __typename: 'ApprovedAccessDomain'
-}
-
-export interface FileWithSignedUrl {
-    id: Scalars['UUID']
-    path: Scalars['String']
-    size: Scalars['Float']
-    createdAt: Scalars['DateTime']
-    url: Scalars['String']
-    __typename: 'FileWithSignedUrl'
-}
-
-export interface FileUploadTarget {
-    fileId: Scalars['UUID']
-    uploadUrl: Scalars['String']
-    contentType: Scalars['String']
-    expiresAt: Scalars['DateTime']
-    __typename: 'FileUploadTarget'
-}
-
 export interface BillingSubscriptionSchedulePhaseItem {
     price: Scalars['String']
     quantity?: Scalars['Float']
@@ -1191,12 +1148,6 @@ export interface BillingSubscriptionItem {
     __typename: 'BillingSubscriptionItem'
 }
 
-export interface BillingCustomer {
-    id: Scalars['UUID']
-    hasPaymentMethod?: Scalars['Boolean']
-    __typename: 'BillingCustomer'
-}
-
 export interface BillingSubscription {
     id: Scalars['UUID']
     status: SubscriptionStatus
@@ -1210,6 +1161,73 @@ export interface BillingSubscription {
 }
 
 export type SubscriptionStatus = 'Active' | 'Canceled' | 'Incomplete' | 'IncompleteExpired' | 'PastDue' | 'Paused' | 'Trialing' | 'Unpaid'
+
+export interface BillingCustomer {
+    id: Scalars['UUID']
+    hasPaymentMethod?: Scalars['Boolean']
+    __typename: 'BillingCustomer'
+}
+
+export interface LogicFunctionExecutionResult {
+    /** Execution result in JSON format */
+    data?: Scalars['JSON']
+    /** Execution Logs */
+    logs: Scalars['String']
+    /** Execution duration in milliseconds */
+    duration: Scalars['Float']
+    /** Execution status */
+    status: LogicFunctionExecutionStatus
+    /** Execution error in JSON format */
+    error?: Scalars['JSON']
+    __typename: 'LogicFunctionExecutionResult'
+}
+
+
+/** Status of the logic function execution */
+export type LogicFunctionExecutionStatus = 'IDLE' | 'SUCCESS' | 'ERROR'
+
+export interface EnterpriseLicenseInfoDTO {
+    isValid: Scalars['Boolean']
+    licensee?: Scalars['String']
+    expiresAt?: Scalars['DateTime']
+    subscriptionId?: Scalars['String']
+    __typename: 'EnterpriseLicenseInfoDTO'
+}
+
+export interface EnterpriseSubscriptionStatusDTO {
+    status: Scalars['String']
+    licensee?: Scalars['String']
+    expiresAt?: Scalars['DateTime']
+    cancelAt?: Scalars['DateTime']
+    currentPeriodEnd?: Scalars['DateTime']
+    isCancellationScheduled: Scalars['Boolean']
+    __typename: 'EnterpriseSubscriptionStatusDTO'
+}
+
+export interface ApprovedAccessDomain {
+    id: Scalars['UUID']
+    domain: Scalars['String']
+    isValidated: Scalars['Boolean']
+    createdAt: Scalars['DateTime']
+    __typename: 'ApprovedAccessDomain'
+}
+
+export interface FileWithSignedUrl {
+    id: Scalars['UUID']
+    path: Scalars['String']
+    size: Scalars['Float']
+    createdAt: Scalars['DateTime']
+    url: Scalars['String']
+    __typename: 'FileWithSignedUrl'
+}
+
+export interface FileUploadTarget {
+    fileId: Scalars['UUID']
+    uploadUrl: Scalars['String']
+    contentType: Scalars['String']
+    expiresAt: Scalars['DateTime']
+    __typename: 'FileUploadTarget'
+}
 
 export interface BillingEndTrialPeriod {
     /** Updated subscription status */
@@ -1365,24 +1383,6 @@ export interface EventSubscription {
     metadataEvents: MetadataEvent[]
     __typename: 'EventSubscription'
 }
-
-export interface LogicFunctionExecutionResult {
-    /** Execution result in JSON format */
-    data?: Scalars['JSON']
-    /** Execution Logs */
-    logs: Scalars['String']
-    /** Execution duration in milliseconds */
-    duration: Scalars['Float']
-    /** Execution status */
-    status: LogicFunctionExecutionStatus
-    /** Execution error in JSON format */
-    error?: Scalars['JSON']
-    __typename: 'LogicFunctionExecutionResult'
-}
-
-
-/** Status of the logic function execution */
-export type LogicFunctionExecutionStatus = 'IDLE' | 'SUCCESS' | 'ERROR'
 
 export interface FeatureFlag {
     key: FeatureFlagKey
@@ -4148,54 +4148,6 @@ export interface ApplicationConnectionProviderGenqlSelection{
     __scalar?: boolean | number
 }
 
-export interface EnterpriseLicenseInfoDTOGenqlSelection{
-    isValid?: boolean | number
-    licensee?: boolean | number
-    expiresAt?: boolean | number
-    subscriptionId?: boolean | number
-    __typename?: boolean | number
-    __scalar?: boolean | number
-}
-
-export interface EnterpriseSubscriptionStatusDTOGenqlSelection{
-    status?: boolean | number
-    licensee?: boolean | number
-    expiresAt?: boolean | number
-    cancelAt?: boolean | number
-    currentPeriodEnd?: boolean | number
-    isCancellationScheduled?: boolean | number
-    __typename?: boolean | number
-    __scalar?: boolean | number
-}
-
-export interface ApprovedAccessDomainGenqlSelection{
-    id?: boolean | number
-    domain?: boolean | number
-    isValidated?: boolean | number
-    createdAt?: boolean | number
-    __typename?: boolean | number
-    __scalar?: boolean | number
-}
-
-export interface FileWithSignedUrlGenqlSelection{
-    id?: boolean | number
-    path?: boolean | number
-    size?: boolean | number
-    createdAt?: boolean | number
-    url?: boolean | number
-    __typename?: boolean | number
-    __scalar?: boolean | number
-}
-
-export interface FileUploadTargetGenqlSelection{
-    fileId?: boolean | number
-    uploadUrl?: boolean | number
-    contentType?: boolean | number
-    expiresAt?: boolean | number
-    __typename?: boolean | number
-    __scalar?: boolean | number
-}
-
 export interface BillingSubscriptionSchedulePhaseItemGenqlSelection{
     price?: boolean | number
     quantity?: boolean | number
@@ -4285,13 +4237,6 @@ export interface BillingSubscriptionItemGenqlSelection{
     __scalar?: boolean | number
 }
 
-export interface BillingCustomerGenqlSelection{
-    id?: boolean | number
-    hasPaymentMethod?: boolean | number
-    __typename?: boolean | number
-    __scalar?: boolean | number
-}
-
 export interface BillingSubscriptionGenqlSelection{
     id?: boolean | number
     status?: boolean | number
@@ -4301,6 +4246,76 @@ export interface BillingSubscriptionGenqlSelection{
     metadata?: boolean | number
     phases?: BillingSubscriptionSchedulePhaseGenqlSelection
     cancelAt?: boolean | number
+    __typename?: boolean | number
+    __scalar?: boolean | number
+}
+
+export interface BillingCustomerGenqlSelection{
+    id?: boolean | number
+    hasPaymentMethod?: boolean | number
+    __typename?: boolean | number
+    __scalar?: boolean | number
+}
+
+export interface LogicFunctionExecutionResultGenqlSelection{
+    /** Execution result in JSON format */
+    data?: boolean | number
+    /** Execution Logs */
+    logs?: boolean | number
+    /** Execution duration in milliseconds */
+    duration?: boolean | number
+    /** Execution status */
+    status?: boolean | number
+    /** Execution error in JSON format */
+    error?: boolean | number
+    __typename?: boolean | number
+    __scalar?: boolean | number
+}
+
+export interface EnterpriseLicenseInfoDTOGenqlSelection{
+    isValid?: boolean | number
+    licensee?: boolean | number
+    expiresAt?: boolean | number
+    subscriptionId?: boolean | number
+    __typename?: boolean | number
+    __scalar?: boolean | number
+}
+
+export interface EnterpriseSubscriptionStatusDTOGenqlSelection{
+    status?: boolean | number
+    licensee?: boolean | number
+    expiresAt?: boolean | number
+    cancelAt?: boolean | number
+    currentPeriodEnd?: boolean | number
+    isCancellationScheduled?: boolean | number
+    __typename?: boolean | number
+    __scalar?: boolean | number
+}
+
+export interface ApprovedAccessDomainGenqlSelection{
+    id?: boolean | number
+    domain?: boolean | number
+    isValidated?: boolean | number
+    createdAt?: boolean | number
+    __typename?: boolean | number
+    __scalar?: boolean | number
+}
+
+export interface FileWithSignedUrlGenqlSelection{
+    id?: boolean | number
+    path?: boolean | number
+    size?: boolean | number
+    createdAt?: boolean | number
+    url?: boolean | number
+    __typename?: boolean | number
+    __scalar?: boolean | number
+}
+
+export interface FileUploadTargetGenqlSelection{
+    fileId?: boolean | number
+    uploadUrl?: boolean | number
+    contentType?: boolean | number
+    expiresAt?: boolean | number
     __typename?: boolean | number
     __scalar?: boolean | number
 }
@@ -4463,21 +4478,6 @@ export interface EventSubscriptionGenqlSelection{
     eventStreamId?: boolean | number
     objectRecordEventsWithQueryIds?: ObjectRecordEventWithQueryIdsGenqlSelection
     metadataEvents?: MetadataEventGenqlSelection
-    __typename?: boolean | number
-    __scalar?: boolean | number
-}
-
-export interface LogicFunctionExecutionResultGenqlSelection{
-    /** Execution result in JSON format */
-    data?: boolean | number
-    /** Execution Logs */
-    logs?: boolean | number
-    /** Execution duration in milliseconds */
-    duration?: boolean | number
-    /** Execution status */
-    status?: boolean | number
-    /** Execution error in JSON format */
-    error?: boolean | number
     __typename?: boolean | number
     __scalar?: boolean | number
 }
@@ -7267,46 +7267,6 @@ export interface LogicFunctionLogsInput {applicationId?: (Scalars['UUID'] | null
     
 
 
-    const EnterpriseLicenseInfoDTO_possibleTypes: string[] = ['EnterpriseLicenseInfoDTO']
-    export const isEnterpriseLicenseInfoDTO = (obj?: { __typename?: any } | null): obj is EnterpriseLicenseInfoDTO => {
-      if (!obj?.__typename) throw new Error('__typename is missing in "isEnterpriseLicenseInfoDTO"')
-      return EnterpriseLicenseInfoDTO_possibleTypes.includes(obj.__typename)
-    }
-    
-
-
-    const EnterpriseSubscriptionStatusDTO_possibleTypes: string[] = ['EnterpriseSubscriptionStatusDTO']
-    export const isEnterpriseSubscriptionStatusDTO = (obj?: { __typename?: any } | null): obj is EnterpriseSubscriptionStatusDTO => {
-      if (!obj?.__typename) throw new Error('__typename is missing in "isEnterpriseSubscriptionStatusDTO"')
-      return EnterpriseSubscriptionStatusDTO_possibleTypes.includes(obj.__typename)
-    }
-    
-
-
-    const ApprovedAccessDomain_possibleTypes: string[] = ['ApprovedAccessDomain']
-    export const isApprovedAccessDomain = (obj?: { __typename?: any } | null): obj is ApprovedAccessDomain => {
-      if (!obj?.__typename) throw new Error('__typename is missing in "isApprovedAccessDomain"')
-      return ApprovedAccessDomain_possibleTypes.includes(obj.__typename)
-    }
-    
-
-
-    const FileWithSignedUrl_possibleTypes: string[] = ['FileWithSignedUrl']
-    export const isFileWithSignedUrl = (obj?: { __typename?: any } | null): obj is FileWithSignedUrl => {
-      if (!obj?.__typename) throw new Error('__typename is missing in "isFileWithSignedUrl"')
-      return FileWithSignedUrl_possibleTypes.includes(obj.__typename)
-    }
-    
-
-
-    const FileUploadTarget_possibleTypes: string[] = ['FileUploadTarget']
-    export const isFileUploadTarget = (obj?: { __typename?: any } | null): obj is FileUploadTarget => {
-      if (!obj?.__typename) throw new Error('__typename is missing in "isFileUploadTarget"')
-      return FileUploadTarget_possibleTypes.includes(obj.__typename)
-    }
-    
-
-
     const BillingSubscriptionSchedulePhaseItem_possibleTypes: string[] = ['BillingSubscriptionSchedulePhaseItem']
     export const isBillingSubscriptionSchedulePhaseItem = (obj?: { __typename?: any } | null): obj is BillingSubscriptionSchedulePhaseItem => {
       if (!obj?.__typename) throw new Error('__typename is missing in "isBillingSubscriptionSchedulePhaseItem"')
@@ -7387,6 +7347,14 @@ export interface LogicFunctionLogsInput {applicationId?: (Scalars['UUID'] | null
     
 
 
+    const BillingSubscription_possibleTypes: string[] = ['BillingSubscription']
+    export const isBillingSubscription = (obj?: { __typename?: any } | null): obj is BillingSubscription => {
+      if (!obj?.__typename) throw new Error('__typename is missing in "isBillingSubscription"')
+      return BillingSubscription_possibleTypes.includes(obj.__typename)
+    }
+    
+
+
     const BillingCustomer_possibleTypes: string[] = ['BillingCustomer']
     export const isBillingCustomer = (obj?: { __typename?: any } | null): obj is BillingCustomer => {
       if (!obj?.__typename) throw new Error('__typename is missing in "isBillingCustomer"')
@@ -7395,10 +7363,50 @@ export interface LogicFunctionLogsInput {applicationId?: (Scalars['UUID'] | null
     
 
 
-    const BillingSubscription_possibleTypes: string[] = ['BillingSubscription']
-    export const isBillingSubscription = (obj?: { __typename?: any } | null): obj is BillingSubscription => {
-      if (!obj?.__typename) throw new Error('__typename is missing in "isBillingSubscription"')
-      return BillingSubscription_possibleTypes.includes(obj.__typename)
+    const LogicFunctionExecutionResult_possibleTypes: string[] = ['LogicFunctionExecutionResult']
+    export const isLogicFunctionExecutionResult = (obj?: { __typename?: any } | null): obj is LogicFunctionExecutionResult => {
+      if (!obj?.__typename) throw new Error('__typename is missing in "isLogicFunctionExecutionResult"')
+      return LogicFunctionExecutionResult_possibleTypes.includes(obj.__typename)
+    }
+    
+
+
+    const EnterpriseLicenseInfoDTO_possibleTypes: string[] = ['EnterpriseLicenseInfoDTO']
+    export const isEnterpriseLicenseInfoDTO = (obj?: { __typename?: any } | null): obj is EnterpriseLicenseInfoDTO => {
+      if (!obj?.__typename) throw new Error('__typename is missing in "isEnterpriseLicenseInfoDTO"')
+      return EnterpriseLicenseInfoDTO_possibleTypes.includes(obj.__typename)
+    }
+    
+
+
+    const EnterpriseSubscriptionStatusDTO_possibleTypes: string[] = ['EnterpriseSubscriptionStatusDTO']
+    export const isEnterpriseSubscriptionStatusDTO = (obj?: { __typename?: any } | null): obj is EnterpriseSubscriptionStatusDTO => {
+      if (!obj?.__typename) throw new Error('__typename is missing in "isEnterpriseSubscriptionStatusDTO"')
+      return EnterpriseSubscriptionStatusDTO_possibleTypes.includes(obj.__typename)
+    }
+    
+
+
+    const ApprovedAccessDomain_possibleTypes: string[] = ['ApprovedAccessDomain']
+    export const isApprovedAccessDomain = (obj?: { __typename?: any } | null): obj is ApprovedAccessDomain => {
+      if (!obj?.__typename) throw new Error('__typename is missing in "isApprovedAccessDomain"')
+      return ApprovedAccessDomain_possibleTypes.includes(obj.__typename)
+    }
+    
+
+
+    const FileWithSignedUrl_possibleTypes: string[] = ['FileWithSignedUrl']
+    export const isFileWithSignedUrl = (obj?: { __typename?: any } | null): obj is FileWithSignedUrl => {
+      if (!obj?.__typename) throw new Error('__typename is missing in "isFileWithSignedUrl"')
+      return FileWithSignedUrl_possibleTypes.includes(obj.__typename)
+    }
+    
+
+
+    const FileUploadTarget_possibleTypes: string[] = ['FileUploadTarget']
+    export const isFileUploadTarget = (obj?: { __typename?: any } | null): obj is FileUploadTarget => {
+      if (!obj?.__typename) throw new Error('__typename is missing in "isFileUploadTarget"')
+      return FileUploadTarget_possibleTypes.includes(obj.__typename)
     }
     
 
@@ -7535,14 +7543,6 @@ export interface LogicFunctionLogsInput {applicationId?: (Scalars['UUID'] | null
     export const isEventSubscription = (obj?: { __typename?: any } | null): obj is EventSubscription => {
       if (!obj?.__typename) throw new Error('__typename is missing in "isEventSubscription"')
       return EventSubscription_possibleTypes.includes(obj.__typename)
-    }
-    
-
-
-    const LogicFunctionExecutionResult_possibleTypes: string[] = ['LogicFunctionExecutionResult']
-    export const isLogicFunctionExecutionResult = (obj?: { __typename?: any } | null): obj is LogicFunctionExecutionResult => {
-      if (!obj?.__typename) throw new Error('__typename is missing in "isLogicFunctionExecutionResult"')
-      return LogicFunctionExecutionResult_possibleTypes.includes(obj.__typename)
     }
     
 
@@ -9168,6 +9168,12 @@ export const enumSubscriptionStatus = {
    Unpaid: 'Unpaid' as const
 }
 
+export const enumLogicFunctionExecutionStatus = {
+   IDLE: 'IDLE' as const,
+   SUCCESS: 'SUCCESS' as const,
+   ERROR: 'ERROR' as const
+}
+
 export const enumNavigationMenuItemType = {
    VIEW: 'VIEW' as const,
    FOLDER: 'FOLDER' as const,
@@ -9190,12 +9196,6 @@ export const enumDatabaseEventAction = {
    DESTROYED: 'DESTROYED' as const,
    RESTORED: 'RESTORED' as const,
    UPSERTED: 'UPSERTED' as const
-}
-
-export const enumLogicFunctionExecutionStatus = {
-   IDLE: 'IDLE' as const,
-   SUCCESS: 'SUCCESS' as const,
-   ERROR: 'ERROR' as const
 }
 
 export const enumFeatureFlagKey = {

--- a/packages/twenty-client-sdk/src/metadata/generated/types.ts
+++ b/packages/twenty-client-sdk/src/metadata/generated/types.ts
@@ -44,15 +44,15 @@ export default {
         100,
         106,
         120,
-        131,
-        132,
-        133,
-        135,
-        144,
-        157,
-        160,
+        126,
+        127,
+        128,
+        130,
+        138,
+        141,
+        159,
         162,
-        166,
+        164,
         168,
         175,
         176,
@@ -96,13 +96,13 @@ export default {
                 1
             ],
             "metadata": [
-                130
+                125
             ],
             "on_BillingLicensedProduct": [
-                139
+                134
             ],
             "on_BillingMeteredProduct": [
-                140
+                135
             ],
             "__typename": [
                 1
@@ -1789,16 +1789,16 @@ export default {
                 167
             ],
             "billingSubscriptions": [
-                143
+                137
             ],
             "installedApplications": [
                 54
             ],
             "currentBillingSubscription": [
-                143
+                137
             ],
             "billingCustomer": [
-                142
+                139
             ],
             "billingEntitlements": [
                 230
@@ -2695,6 +2695,239 @@ export default {
                 1
             ]
         },
+        "BillingSubscriptionSchedulePhaseItem": {
+            "price": [
+                1
+            ],
+            "quantity": [
+                12
+            ],
+            "__typename": [
+                1
+            ]
+        },
+        "BillingSubscriptionSchedulePhase": {
+            "start_date": [
+                12
+            ],
+            "end_date": [
+                12
+            ],
+            "items": [
+                123
+            ],
+            "__typename": [
+                1
+            ]
+        },
+        "BillingProductMetadata": {
+            "planKey": [
+                126
+            ],
+            "priceUsageBased": [
+                127
+            ],
+            "productKey": [
+                128
+            ],
+            "__typename": [
+                1
+            ]
+        },
+        "BillingPlanKey": {},
+        "BillingUsageType": {},
+        "BillingProductKey": {},
+        "BillingPriceLicensed": {
+            "recurringInterval": [
+                130
+            ],
+            "unitAmount": [
+                12
+            ],
+            "stripePriceId": [
+                1
+            ],
+            "priceUsageType": [
+                127
+            ],
+            "creditAmount": [
+                12
+            ],
+            "__typename": [
+                1
+            ]
+        },
+        "SubscriptionInterval": {},
+        "BillingPriceTier": {
+            "upTo": [
+                12
+            ],
+            "flatAmount": [
+                12
+            ],
+            "unitAmount": [
+                12
+            ],
+            "__typename": [
+                1
+            ]
+        },
+        "BillingPriceMetered": {
+            "tiers": [
+                131
+            ],
+            "recurringInterval": [
+                130
+            ],
+            "stripePriceId": [
+                1
+            ],
+            "priceUsageType": [
+                127
+            ],
+            "__typename": [
+                1
+            ]
+        },
+        "BillingProduct": {
+            "name": [
+                1
+            ],
+            "description": [
+                1
+            ],
+            "images": [
+                1
+            ],
+            "metadata": [
+                125
+            ],
+            "__typename": [
+                1
+            ]
+        },
+        "BillingLicensedProduct": {
+            "name": [
+                1
+            ],
+            "description": [
+                1
+            ],
+            "images": [
+                1
+            ],
+            "metadata": [
+                125
+            ],
+            "prices": [
+                129
+            ],
+            "__typename": [
+                1
+            ]
+        },
+        "BillingMeteredProduct": {
+            "name": [
+                1
+            ],
+            "description": [
+                1
+            ],
+            "images": [
+                1
+            ],
+            "metadata": [
+                125
+            ],
+            "prices": [
+                132
+            ],
+            "__typename": [
+                1
+            ]
+        },
+        "BillingSubscriptionItem": {
+            "id": [
+                3
+            ],
+            "hasReachedCurrentPeriodCap": [
+                6
+            ],
+            "quantity": [
+                12
+            ],
+            "stripePriceId": [
+                1
+            ],
+            "billingProduct": [
+                0
+            ],
+            "__typename": [
+                1
+            ]
+        },
+        "BillingSubscription": {
+            "id": [
+                3
+            ],
+            "status": [
+                138
+            ],
+            "interval": [
+                130
+            ],
+            "billingSubscriptionItems": [
+                136
+            ],
+            "currentPeriodEnd": [
+                4
+            ],
+            "metadata": [
+                7
+            ],
+            "phases": [
+                124
+            ],
+            "cancelAt": [
+                4
+            ],
+            "__typename": [
+                1
+            ]
+        },
+        "SubscriptionStatus": {},
+        "BillingCustomer": {
+            "id": [
+                3
+            ],
+            "hasPaymentMethod": [
+                6
+            ],
+            "__typename": [
+                1
+            ]
+        },
+        "LogicFunctionExecutionResult": {
+            "data": [
+                7
+            ],
+            "logs": [
+                1
+            ],
+            "duration": [
+                12
+            ],
+            "status": [
+                141
+            ],
+            "error": [
+                7
+            ],
+            "__typename": [
+                1
+            ]
+        },
+        "LogicFunctionExecutionStatus": {},
         "EnterpriseLicenseInfoDTO": {
             "isValid": [
                 6
@@ -2789,221 +3022,9 @@ export default {
                 1
             ]
         },
-        "BillingSubscriptionSchedulePhaseItem": {
-            "price": [
-                1
-            ],
-            "quantity": [
-                12
-            ],
-            "__typename": [
-                1
-            ]
-        },
-        "BillingSubscriptionSchedulePhase": {
-            "start_date": [
-                12
-            ],
-            "end_date": [
-                12
-            ],
-            "items": [
-                128
-            ],
-            "__typename": [
-                1
-            ]
-        },
-        "BillingProductMetadata": {
-            "planKey": [
-                131
-            ],
-            "priceUsageBased": [
-                132
-            ],
-            "productKey": [
-                133
-            ],
-            "__typename": [
-                1
-            ]
-        },
-        "BillingPlanKey": {},
-        "BillingUsageType": {},
-        "BillingProductKey": {},
-        "BillingPriceLicensed": {
-            "recurringInterval": [
-                135
-            ],
-            "unitAmount": [
-                12
-            ],
-            "stripePriceId": [
-                1
-            ],
-            "priceUsageType": [
-                132
-            ],
-            "creditAmount": [
-                12
-            ],
-            "__typename": [
-                1
-            ]
-        },
-        "SubscriptionInterval": {},
-        "BillingPriceTier": {
-            "upTo": [
-                12
-            ],
-            "flatAmount": [
-                12
-            ],
-            "unitAmount": [
-                12
-            ],
-            "__typename": [
-                1
-            ]
-        },
-        "BillingPriceMetered": {
-            "tiers": [
-                136
-            ],
-            "recurringInterval": [
-                135
-            ],
-            "stripePriceId": [
-                1
-            ],
-            "priceUsageType": [
-                132
-            ],
-            "__typename": [
-                1
-            ]
-        },
-        "BillingProduct": {
-            "name": [
-                1
-            ],
-            "description": [
-                1
-            ],
-            "images": [
-                1
-            ],
-            "metadata": [
-                130
-            ],
-            "__typename": [
-                1
-            ]
-        },
-        "BillingLicensedProduct": {
-            "name": [
-                1
-            ],
-            "description": [
-                1
-            ],
-            "images": [
-                1
-            ],
-            "metadata": [
-                130
-            ],
-            "prices": [
-                134
-            ],
-            "__typename": [
-                1
-            ]
-        },
-        "BillingMeteredProduct": {
-            "name": [
-                1
-            ],
-            "description": [
-                1
-            ],
-            "images": [
-                1
-            ],
-            "metadata": [
-                130
-            ],
-            "prices": [
-                137
-            ],
-            "__typename": [
-                1
-            ]
-        },
-        "BillingSubscriptionItem": {
-            "id": [
-                3
-            ],
-            "hasReachedCurrentPeriodCap": [
-                6
-            ],
-            "quantity": [
-                12
-            ],
-            "stripePriceId": [
-                1
-            ],
-            "billingProduct": [
-                0
-            ],
-            "__typename": [
-                1
-            ]
-        },
-        "BillingCustomer": {
-            "id": [
-                3
-            ],
-            "hasPaymentMethod": [
-                6
-            ],
-            "__typename": [
-                1
-            ]
-        },
-        "BillingSubscription": {
-            "id": [
-                3
-            ],
-            "status": [
-                144
-            ],
-            "interval": [
-                135
-            ],
-            "billingSubscriptionItems": [
-                141
-            ],
-            "currentPeriodEnd": [
-                4
-            ],
-            "metadata": [
-                7
-            ],
-            "phases": [
-                129
-            ],
-            "cancelAt": [
-                4
-            ],
-            "__typename": [
-                1
-            ]
-        },
-        "SubscriptionStatus": {},
         "BillingEndTrialPeriod": {
             "status": [
-                144
+                138
             ],
             "hasPaymentMethod": [
                 6
@@ -3017,7 +3038,7 @@ export default {
         },
         "BillingResourceCreditUsage": {
             "productKey": [
-                133
+                128
             ],
             "periodStart": [
                 4
@@ -3046,16 +3067,16 @@ export default {
         },
         "BillingPlan": {
             "planKey": [
-                131
+                126
             ],
             "baseProducts": [
-                139
+                134
             ],
             "resourceCreditProducts": [
-                139
+                134
             ],
             "meteredProducts": [
-                140
+                135
             ],
             "__typename": [
                 1
@@ -3082,10 +3103,10 @@ export default {
         },
         "BillingUpdate": {
             "currentBillingSubscription": [
-                143
+                137
             ],
             "billingSubscriptions": [
-                143
+                137
             ],
             "__typename": [
                 1
@@ -3135,7 +3156,7 @@ export default {
                 1
             ],
             "result": [
-                153
+                155
             ],
             "__typename": [
                 1
@@ -3172,7 +3193,7 @@ export default {
                 3
             ],
             "type": [
-                157
+                159
             ],
             "name": [
                 1
@@ -3205,7 +3226,7 @@ export default {
                 4
             ],
             "targetRecordIdentifier": [
-                155
+                157
             ],
             "__typename": [
                 1
@@ -3231,7 +3252,7 @@ export default {
         },
         "MetadataEvent": {
             "type": [
-                160
+                162
             ],
             "metadataName": [
                 1
@@ -3240,7 +3261,7 @@ export default {
                 1
             ],
             "properties": [
-                158
+                160
             ],
             "updatedCollectionHash": [
                 1
@@ -3252,7 +3273,7 @@ export default {
         "MetadataEventAction": {},
         "ObjectRecordEvent": {
             "action": [
-                162
+                164
             ],
             "objectNameSingular": [
                 1
@@ -3267,7 +3288,7 @@ export default {
                 1
             ],
             "properties": [
-                158
+                160
             ],
             "__typename": [
                 1
@@ -3279,7 +3300,7 @@ export default {
                 1
             ],
             "objectRecordEvent": [
-                161
+                163
             ],
             "__typename": [
                 1
@@ -3290,36 +3311,15 @@ export default {
                 1
             ],
             "objectRecordEventsWithQueryIds": [
-                163
+                165
             ],
             "metadataEvents": [
-                159
+                161
             ],
             "__typename": [
                 1
             ]
         },
-        "LogicFunctionExecutionResult": {
-            "data": [
-                7
-            ],
-            "logs": [
-                1
-            ],
-            "duration": [
-                12
-            ],
-            "status": [
-                166
-            ],
-            "error": [
-                7
-            ],
-            "__typename": [
-                1
-            ]
-        },
-        "LogicFunctionExecutionStatus": {},
         "FeatureFlag": {
             "key": [
                 168
@@ -6058,10 +6058,10 @@ export default {
         },
         "Query": {
             "navigationMenuItems": [
-                156
+                158
             ],
             "navigationMenuItem": [
-                156,
+                158,
                 {
                     "id": [
                         3,
@@ -6086,7 +6086,7 @@ export default {
                 }
             ],
             "enterpriseSubscriptionStatus": [
-                124
+                143
             ],
             "getViewFilterGroups": [
                 57,
@@ -6209,7 +6209,7 @@ export default {
                 }
             ],
             "getInviteSuggestions": [
-                151
+                153
             ],
             "applicationConnectionProviders": [
                 122,
@@ -6221,7 +6221,7 @@ export default {
                 }
             ],
             "billingPortalSession": [
-                149,
+                151,
                 {
                     "returnUrlPath": [
                         1
@@ -6232,16 +6232,16 @@ export default {
                 }
             ],
             "listPlans": [
-                147
+                149
             ],
             "getResourceCreditUsage": [
-                146
+                148
             ],
             "findWorkspaceInvitations": [
-                153
+                155
             ],
             "getApprovedAccessDomains": [
-                125
+                144
             ],
             "getPageLayoutTabs": [
                 118,
@@ -7087,7 +7087,7 @@ export default {
                 }
             ],
             "createManyNavigationMenuItems": [
-                156,
+                158,
                 {
                     "inputs": [
                         356,
@@ -7096,7 +7096,7 @@ export default {
                 }
             ],
             "createNavigationMenuItem": [
-                156,
+                158,
                 {
                     "input": [
                         356,
@@ -7105,7 +7105,7 @@ export default {
                 }
             ],
             "updateManyNavigationMenuItems": [
-                156,
+                158,
                 {
                     "inputs": [
                         357,
@@ -7114,7 +7114,7 @@ export default {
                 }
             ],
             "updateNavigationMenuItem": [
-                156,
+                158,
                 {
                     "input": [
                         357,
@@ -7123,7 +7123,7 @@ export default {
                 }
             ],
             "deleteManyNavigationMenuItems": [
-                156,
+                158,
                 {
                     "ids": [
                         3,
@@ -7132,7 +7132,7 @@ export default {
                 }
             ],
             "deleteNavigationMenuItem": [
-                156,
+                158,
                 {
                     "id": [
                         3,
@@ -7141,7 +7141,7 @@ export default {
                 }
             ],
             "createFileUpload": [
-                127,
+                146,
                 {
                     "filename": [
                         1,
@@ -7164,7 +7164,7 @@ export default {
                 }
             ],
             "completeFileUpload": [
-                126,
+                145,
                 {
                     "fileId": [
                         1,
@@ -7176,10 +7176,10 @@ export default {
                 6
             ],
             "releaseEnterpriseServerBinding": [
-                123
+                142
             ],
             "setEnterpriseKey": [
-                123,
+                142,
                 {
                     "enterpriseKey": [
                         1,
@@ -7188,7 +7188,7 @@ export default {
                 }
             ],
             "uploadEmailAttachmentFile": [
-                126,
+                145,
                 {
                     "file": [
                         360,
@@ -7197,7 +7197,7 @@ export default {
                 }
             ],
             "uploadAiChatFile": [
-                126,
+                145,
                 {
                     "file": [
                         360,
@@ -7206,7 +7206,7 @@ export default {
                 }
             ],
             "uploadWorkflowFile": [
-                126,
+                145,
                 {
                     "file": [
                         360,
@@ -7215,7 +7215,7 @@ export default {
                 }
             ],
             "uploadWorkspaceLogo": [
-                126,
+                145,
                 {
                     "file": [
                         360,
@@ -7224,7 +7224,7 @@ export default {
                 }
             ],
             "uploadWorkspaceMemberProfilePicture": [
-                126,
+                145,
                 {
                     "file": [
                         360,
@@ -7233,7 +7233,7 @@ export default {
                 }
             ],
             "uploadFilesFieldFile": [
-                126,
+                145,
                 {
                     "file": [
                         360,
@@ -7246,7 +7246,7 @@ export default {
                 }
             ],
             "uploadFilesFieldFileByUniversalIdentifier": [
-                126,
+                145,
                 {
                     "file": [
                         360,
@@ -7559,10 +7559,10 @@ export default {
                 }
             ],
             "skipSyncEmailOnboardingStep": [
-                152
+                154
             ],
             "triggerInstallAppsOnboardingStep": [
-                152,
+                154,
                 {
                     "universalIdentifiers": [
                         1,
@@ -7588,14 +7588,14 @@ export default {
                 }
             ],
             "checkoutSession": [
-                149,
+                151,
                 {
                     "recurringInterval": [
-                        135,
+                        130,
                         "SubscriptionInterval!"
                     ],
                     "plan": [
-                        131,
+                        126,
                         "BillingPlanKey!"
                     ],
                     "requirePaymentMethod": [
@@ -7608,14 +7608,14 @@ export default {
                 }
             ],
             "createSubscriptionPaymentIntent": [
-                148,
+                150,
                 {
                     "recurringInterval": [
-                        135,
+                        130,
                         "SubscriptionInterval!"
                     ],
                     "plan": [
-                        131,
+                        126,
                         "BillingPlanKey!"
                     ],
                     "requirePaymentMethod": [
@@ -7632,22 +7632,22 @@ export default {
                 }
             ],
             "createBillingPaymentMethodSetupIntent": [
-                148
+                150
             ],
             "switchSubscriptionInterval": [
-                150
+                152
             ],
             "switchBillingPlan": [
-                150
+                152
             ],
             "cancelSwitchBillingPlan": [
-                150
+                152
             ],
             "cancelSwitchBillingInterval": [
-                150
+                152
             ],
             "setResourceCreditSubscriptionPrice": [
-                150,
+                152,
                 {
                     "priceId": [
                         1,
@@ -7656,10 +7656,10 @@ export default {
                 }
             ],
             "endSubscriptionTrialPeriod": [
-                145
+                147
             ],
             "cancelSwitchResourceCreditPrice": [
-                150
+                152
             ],
             "deleteWorkspaceInvitation": [
                 1,
@@ -7671,7 +7671,7 @@ export default {
                 }
             ],
             "resendWorkspaceInvitation": [
-                154,
+                156,
                 {
                     "appTokenId": [
                         1,
@@ -7680,7 +7680,7 @@ export default {
                 }
             ],
             "sendInvitations": [
-                154,
+                156,
                 {
                     "emails": [
                         1,
@@ -7692,7 +7692,7 @@ export default {
                 }
             ],
             "createApprovedAccessDomain": [
-                125,
+                144,
                 {
                     "input": [
                         396,
@@ -7710,7 +7710,7 @@ export default {
                 }
             ],
             "validateApprovedAccessDomain": [
-                125,
+                144,
                 {
                     "input": [
                         398,
@@ -7942,7 +7942,7 @@ export default {
                 }
             ],
             "executeOneLogicFunction": [
-                165,
+                140,
                 {
                     "input": [
                         421,
@@ -8917,7 +8917,7 @@ export default {
                 }
             ],
             "uploadNewWorkspaceLogo": [
-                126,
+                145,
                 {
                     "workspaceId": [
                         1,
@@ -9386,7 +9386,7 @@ export default {
                 3
             ],
             "type": [
-                157
+                159
             ],
             "name": [
                 1
@@ -11978,7 +11978,7 @@ export default {
         },
         "Subscription": {
             "onEventSubscription": [
-                164,
+                166,
                 {
                     "eventStreamId": [
                         1,

--- a/packages/twenty-docs/developers/extend/apps/logic/connections.mdx
+++ b/packages/twenty-docs/developers/extend/apps/logic/connections.mdx
@@ -87,6 +87,61 @@ https://<your-twenty-server>/auth/apps/callback
 
 </Accordion>
 
+<Accordion title="React to a new connection" description="Run a logic function after OAuth succeeds">
+
+Declare `onConnectLogicFunctionUniversalIdentifier` on the connection provider to run one of your app's logic functions right after a user completes the OAuth consent screen (it also runs on reconnect):
+
+```ts src/connection-providers/slack-connection.ts
+export default defineConnectionProvider({
+  universalIdentifier: '9c7d1f5e-6a0b-4d44-be0c-3f8b5a9d4e6f',
+  name: 'slack',
+  displayName: 'Slack',
+  type: 'oauth',
+  oauth: { /* ... */ },
+  // universalIdentifier of a logic function declared in this app
+  onConnectLogicFunctionUniversalIdentifier:
+    '5f0a2b1c-8d3e-4f6a-9b7c-1d2e3f4a5b6c',
+});
+```
+
+The function is enqueued asynchronously — a failure never blocks the user's OAuth redirect — and receives the new connection as its payload:
+
+```ts src/logic-functions/on-slack-connected.logic-function.ts
+import { defineLogicFunction } from 'twenty-sdk/define';
+import { getConnection } from 'twenty-sdk/logic-function';
+
+type OnConnectPayload = {
+  connectionId: string;
+  connectionProviderName: string;
+  workspaceId: string;
+  userWorkspaceId: string;
+  isReconnection: boolean;
+};
+
+const handler = async (payload: OnConnectPayload) => {
+  const connection = await getConnection(payload.connectionId);
+
+  // Use the fresh token for provider-specific bookkeeping, e.g. asking
+  // Slack which team was just connected.
+  const response = await fetch('https://slack.com/api/auth.test', {
+    method: 'POST',
+    headers: { Authorization: `Bearer ${connection.accessToken}` },
+  });
+  const { team_id } = (await response.json()) as { team_id: string };
+
+  // e.g. persist it for later webhook routing
+  // await kv.set(`slack:team:${team_id}`, undefined, { scope: 'GLOBAL' });
+};
+
+export default defineLogicFunction({
+  universalIdentifier: '5f0a2b1c-8d3e-4f6a-9b7c-1d2e3f4a5b6c',
+  name: 'on-slack-connected',
+  handler,
+});
+```
+
+</Accordion>
+
 <Accordion title="listConnections / getConnection" description="Use connections from a logic function">
 
 Inside a logic function handler, `listConnections({ providerName })` returns this app's `ConnectedAccount` rows for the given provider, with refreshed access tokens.

--- a/packages/twenty-sdk/src/sdk/define/connection-providers/__tests__/define-connection-provider.spec.ts
+++ b/packages/twenty-sdk/src/sdk/define/connection-providers/__tests__/define-connection-provider.spec.ts
@@ -24,6 +24,29 @@ describe('defineConnectionProvider', () => {
     expect(result.errors).toEqual([]);
   });
 
+  it('accepts a UUID onConnectLogicFunctionUniversalIdentifier', () => {
+    const result = defineConnectionProvider({
+      ...baseValidConfig,
+      onConnectLogicFunctionUniversalIdentifier:
+        '11111111-1111-4111-8111-111111111111',
+    });
+
+    expect(result.success).toBe(true);
+    expect(result.errors).toEqual([]);
+  });
+
+  it('rejects a non-UUID onConnectLogicFunctionUniversalIdentifier', () => {
+    const result = defineConnectionProvider({
+      ...baseValidConfig,
+      onConnectLogicFunctionUniversalIdentifier: 'my-hook',
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.errors).toContain(
+      'Connection provider onConnectLogicFunctionUniversalIdentifier "my-hook" must be the UUID universalIdentifier of a logic function of this application',
+    );
+  });
+
   it('reports a missing universalIdentifier', () => {
     const result = defineConnectionProvider({
       ...baseValidConfig,

--- a/packages/twenty-sdk/src/sdk/define/connection-providers/define-connection-provider.ts
+++ b/packages/twenty-sdk/src/sdk/define/connection-providers/define-connection-provider.ts
@@ -44,6 +44,15 @@ export const defineConnectionProvider: DefineEntity<
     );
   }
 
+  if (
+    config.onConnectLogicFunctionUniversalIdentifier !== undefined &&
+    !UUID_PATTERN.test(config.onConnectLogicFunctionUniversalIdentifier)
+  ) {
+    errors.push(
+      `Connection provider onConnectLogicFunctionUniversalIdentifier "${config.onConnectLogicFunctionUniversalIdentifier}" must be the UUID universalIdentifier of a logic function of this application`,
+    );
+  }
+
   if (config.type === 'oauth') {
     const oauth = config.oauth;
 

--- a/packages/twenty-server/src/engine/core-modules/application/application-manifest/converters/__tests__/from-connection-provider-manifest-to-universal-flat-connection-provider.util.spec.ts
+++ b/packages/twenty-server/src/engine/core-modules/application/application-manifest/converters/__tests__/from-connection-provider-manifest-to-universal-flat-connection-provider.util.spec.ts
@@ -49,10 +49,27 @@ describe('fromConnectionProviderManifestToUniversalFlatConnectionProvider', () =
         authorizationParams: null,
         tokenRequestContentType: 'json',
         usePkce: true,
+        onConnectLogicFunctionUniversalIdentifier: null,
       },
       createdAt: NOW,
       updatedAt: NOW,
     });
+  });
+
+  it('passes through the on-connect logic function universal identifier', () => {
+    const result =
+      fromConnectionProviderManifestToUniversalFlatConnectionProvider({
+        connectionProviderManifest: buildManifest({
+          onConnectLogicFunctionUniversalIdentifier:
+            '11111111-1111-4111-8111-111111111111',
+        }),
+        applicationUniversalIdentifier: APP_UID,
+        now: NOW,
+      });
+
+    expect(result.oauthConfig?.onConnectLogicFunctionUniversalIdentifier).toBe(
+      '11111111-1111-4111-8111-111111111111',
+    );
   });
 
   it('passes through optional oauth config when provided', () => {

--- a/packages/twenty-server/src/engine/core-modules/application/application-manifest/converters/from-connection-provider-manifest-to-universal-flat-connection-provider.util.ts
+++ b/packages/twenty-server/src/engine/core-modules/application/application-manifest/converters/from-connection-provider-manifest-to-universal-flat-connection-provider.util.ts
@@ -33,6 +33,9 @@ export const fromConnectionProviderManifestToUniversalFlatConnectionProvider =
               connectionProviderManifest.oauth.tokenRequestContentType ??
               'json',
             usePkce: connectionProviderManifest.oauth.usePkce ?? true,
+            onConnectLogicFunctionUniversalIdentifier:
+              connectionProviderManifest.onConnectLogicFunctionUniversalIdentifier ??
+              null,
           }
         : null;
 

--- a/packages/twenty-server/src/engine/core-modules/application/connection-provider/__tests__/connection-provider-oauth-flow.service.spec.ts
+++ b/packages/twenty-server/src/engine/core-modules/application/connection-provider/__tests__/connection-provider-oauth-flow.service.spec.ts
@@ -23,8 +23,11 @@ import { JwtWrapperService } from 'src/engine/core-modules/jwt/services/jwt-wrap
 import { SecureHttpClientService } from 'src/engine/core-modules/secure-http-client/secure-http-client.service';
 import { TwentyConfigService } from 'src/engine/core-modules/twenty-config/twenty-config.service';
 import { SECRET_ENCRYPTION_ENVELOPE_V2_PREFIX } from 'src/engine/core-modules/secret-encryption/constants/secret-encryption.constant';
+import { MessageQueue } from 'src/engine/core-modules/message-queue/message-queue.constants';
+import { getQueueToken } from 'src/engine/core-modules/message-queue/utils/get-queue-token.util';
 import { ConnectedAccountEntity } from 'src/engine/metadata-modules/connected-account/entities/connected-account.entity';
 import { ConnectedAccountTokenEncryptionService } from 'src/engine/metadata-modules/connected-account/services/connected-account-token-encryption.service';
+import { WorkspaceCacheService } from 'src/engine/workspace-cache/services/workspace-cache.service';
 
 const FAKE_CIPHER_PREFIX = `${SECRET_ENCRYPTION_ENVELOPE_V2_PREFIX}keyid:`;
 
@@ -47,6 +50,8 @@ describe('ConnectionProviderOAuthFlowService', () => {
     findOne: jest.Mock;
     findOneByOrFail: jest.Mock;
   };
+  let workspaceCacheService: { getOrRecompute: jest.Mock };
+  let messageQueueService: { add: jest.Mock };
 
   const baseProvider: ConnectionProviderEntity = {
     id: 'provider-1',
@@ -66,6 +71,7 @@ describe('ConnectionProviderOAuthFlowService', () => {
       authorizationParams: null,
       tokenRequestContentType: 'form-urlencoded',
       usePkce: false,
+      onConnectLogicFunctionUniversalIdentifier: null,
     },
     createdAt: new Date(),
     updatedAt: new Date(),
@@ -95,6 +101,12 @@ describe('ConnectionProviderOAuthFlowService', () => {
         provider: ConnectedAccountProvider.APP,
       })),
     };
+    workspaceCacheService = {
+      getOrRecompute: jest.fn(async () => ({
+        flatLogicFunctionMaps: { byUniversalIdentifier: {} },
+      })),
+    };
+    messageQueueService = { add: jest.fn() };
 
     const module: TestingModule = await Test.createTestingModule({
       providers: [
@@ -135,6 +147,11 @@ describe('ConnectionProviderOAuthFlowService', () => {
               }),
             ),
           },
+        },
+        { provide: WorkspaceCacheService, useValue: workspaceCacheService },
+        {
+          provide: getQueueToken(MessageQueue.logicFunctionQueue),
+          useValue: messageQueueService,
         },
       ],
     }).compile();
@@ -436,6 +453,103 @@ describe('ConnectionProviderOAuthFlowService', () => {
           state: 'bad-state',
         }),
       ).rejects.toThrow(/state/);
+    });
+
+    describe('on-connect logic function', () => {
+      const HOOK_UID = '11111111-1111-4111-8111-111111111111';
+
+      const providerWithHook = {
+        ...baseProvider,
+        oauthConfig: {
+          ...baseProvider.oauthConfig,
+          onConnectLogicFunctionUniversalIdentifier: HOOK_UID,
+        },
+      } as unknown as ConnectionProviderEntity;
+
+      it('does not touch the queue when the provider declares no hook', async () => {
+        await service.completeAuthorizationFlow({
+          code: 'auth_code',
+          state: 'signed-state',
+        });
+
+        expect(workspaceCacheService.getOrRecompute).not.toHaveBeenCalled();
+        expect(messageQueueService.add).not.toHaveBeenCalled();
+      });
+
+      it('enqueues the hook with the connection payload after a successful connect', async () => {
+        connectionProviderService.findOneByIdOrThrow.mockResolvedValue(
+          providerWithHook,
+        );
+        workspaceCacheService.getOrRecompute.mockResolvedValue({
+          flatLogicFunctionMaps: {
+            byUniversalIdentifier: {
+              [HOOK_UID]: { id: 'logic-function-1', applicationId: 'app-1' },
+            },
+          },
+        });
+
+        await service.completeAuthorizationFlow({
+          code: 'auth_code',
+          state: 'signed-state',
+        });
+
+        expect(messageQueueService.add).toHaveBeenCalledWith(
+          'LogicFunctionTriggerJob',
+          [
+            {
+              logicFunctionId: 'logic-function-1',
+              workspaceId: 'workspace-1',
+              userId: 'user-1',
+              userWorkspaceId: 'uws-1',
+              payload: {
+                connectionId: 'new-account-id',
+                connectionProviderName: 'linear',
+                workspaceId: 'workspace-1',
+                userWorkspaceId: 'uws-1',
+                isReconnection: false,
+              },
+            },
+          ],
+          { retryLimit: 3 },
+        );
+      });
+
+      it('skips a hook whose logic function belongs to another application', async () => {
+        connectionProviderService.findOneByIdOrThrow.mockResolvedValue(
+          providerWithHook,
+        );
+        workspaceCacheService.getOrRecompute.mockResolvedValue({
+          flatLogicFunctionMaps: {
+            byUniversalIdentifier: {
+              [HOOK_UID]: { id: 'logic-function-1', applicationId: 'app-2' },
+            },
+          },
+        });
+
+        await service.completeAuthorizationFlow({
+          code: 'auth_code',
+          state: 'signed-state',
+        });
+
+        expect(messageQueueService.add).not.toHaveBeenCalled();
+      });
+
+      it('still completes the OAuth flow when enqueueing the hook fails', async () => {
+        connectionProviderService.findOneByIdOrThrow.mockResolvedValue(
+          providerWithHook,
+        );
+        workspaceCacheService.getOrRecompute.mockRejectedValue(
+          new Error('cache unavailable'),
+        );
+
+        const result = await service.completeAuthorizationFlow({
+          code: 'auth_code',
+          state: 'signed-state',
+        });
+
+        expect(result.connectedAccountId).toBe('new-account-id');
+        expect(messageQueueService.add).not.toHaveBeenCalled();
+      });
     });
   });
 });

--- a/packages/twenty-server/src/engine/core-modules/application/connection-provider/connection-provider-oauth-flow.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/application/connection-provider/connection-provider-oauth-flow.service.ts
@@ -22,10 +22,18 @@ import { generatePkceVerifier } from 'src/engine/core-modules/application/connec
 import { type AppOAuthStateJwtPayload } from 'src/engine/core-modules/auth/types/app-oauth-state-jwt-payload.type';
 import { JwtTokenTypeEnum } from 'src/engine/core-modules/auth/types/jwt-token-type.enum';
 import { JwtWrapperService } from 'src/engine/core-modules/jwt/services/jwt-wrapper.service';
+import {
+  LogicFunctionTriggerJob,
+  type LogicFunctionTriggerJobData,
+} from 'src/engine/core-modules/logic-function/logic-function-trigger/jobs/logic-function-trigger.job';
+import { InjectMessageQueue } from 'src/engine/core-modules/message-queue/decorators/message-queue.decorator';
+import { MessageQueue } from 'src/engine/core-modules/message-queue/message-queue.constants';
+import { MessageQueueService } from 'src/engine/core-modules/message-queue/services/message-queue.service';
 import { SecureHttpClientService } from 'src/engine/core-modules/secure-http-client/secure-http-client.service';
 import { TwentyConfigService } from 'src/engine/core-modules/twenty-config/twenty-config.service';
 import { ConnectedAccountEntity } from 'src/engine/metadata-modules/connected-account/entities/connected-account.entity';
 import { ConnectedAccountTokenEncryptionService } from 'src/engine/metadata-modules/connected-account/services/connected-account-token-encryption.service';
+import { WorkspaceCacheService } from 'src/engine/workspace-cache/services/workspace-cache.service';
 
 const STATE_JWT_EXPIRES_IN = '10m';
 
@@ -63,6 +71,9 @@ export class ConnectionProviderOAuthFlowService {
     private readonly connectedAccountTokenEncryptionService: ConnectedAccountTokenEncryptionService,
     @InjectRepository(ConnectedAccountEntity)
     private readonly connectedAccountRepository: Repository<ConnectedAccountEntity>,
+    private readonly workspaceCacheService: WorkspaceCacheService,
+    @InjectMessageQueue(MessageQueue.logicFunctionQueue)
+    private readonly messageQueueService: MessageQueueService,
   ) {}
 
   async startAuthorizationFlow(
@@ -186,12 +197,93 @@ export class ConnectionProviderOAuthFlowService {
         statePayload.reconnectingConnectedAccountId,
     });
 
+    await this.enqueueOnConnectLogicFunction({
+      provider,
+      connectionId: connectedAccount.id,
+      workspaceId: statePayload.workspaceId,
+      userId: statePayload.userId,
+      userWorkspaceId: statePayload.userWorkspaceId,
+      isReconnection: isDefined(statePayload.reconnectingConnectedAccountId),
+    });
+
     return {
       connectedAccountId: connectedAccount.id,
       workspaceId: statePayload.workspaceId,
       applicationId: provider.applicationId,
       redirectLocation: statePayload.redirectLocation,
     };
+  }
+
+  // Fire-and-forget: a failing hook must never fail the OAuth redirect the
+  // user is waiting on, so errors are logged and swallowed.
+  private async enqueueOnConnectLogicFunction({
+    provider,
+    connectionId,
+    workspaceId,
+    userId,
+    userWorkspaceId,
+    isReconnection,
+  }: {
+    provider: OAuthConnectionProvider;
+    connectionId: string;
+    workspaceId: string;
+    userId: string;
+    userWorkspaceId: string;
+    isReconnection: boolean;
+  }): Promise<void> {
+    const onConnectLogicFunctionUniversalIdentifier =
+      provider.oauthConfig.onConnectLogicFunctionUniversalIdentifier;
+
+    if (!isDefined(onConnectLogicFunctionUniversalIdentifier)) {
+      return;
+    }
+
+    try {
+      const { flatLogicFunctionMaps } =
+        await this.workspaceCacheService.getOrRecompute(workspaceId, [
+          'flatLogicFunctionMaps',
+        ]);
+
+      const flatLogicFunction =
+        flatLogicFunctionMaps.byUniversalIdentifier[
+          onConnectLogicFunctionUniversalIdentifier
+        ];
+
+      if (
+        !isDefined(flatLogicFunction) ||
+        flatLogicFunction.applicationId !== provider.applicationId
+      ) {
+        this.logger.error(
+          `On-connect logic function "${onConnectLogicFunctionUniversalIdentifier}" not found for provider ${provider.id} in workspace ${workspaceId}`,
+        );
+
+        return;
+      }
+
+      await this.messageQueueService.add<LogicFunctionTriggerJobData[]>(
+        LogicFunctionTriggerJob.name,
+        [
+          {
+            logicFunctionId: flatLogicFunction.id,
+            workspaceId,
+            userId,
+            userWorkspaceId,
+            payload: {
+              connectionId,
+              connectionProviderName: provider.name,
+              workspaceId,
+              userWorkspaceId,
+              isReconnection,
+            },
+          },
+        ],
+        { retryLimit: 3 },
+      );
+    } catch (error) {
+      this.logger.error(
+        `Failed to enqueue on-connect logic function for provider ${provider.id}: ${(error as Error).message}`,
+      );
+    }
   }
 
   private async signState(payload: AppOAuthStateJwtPayload): Promise<string> {

--- a/packages/twenty-server/src/engine/core-modules/application/connection-provider/connection-provider.module.ts
+++ b/packages/twenty-server/src/engine/core-modules/application/connection-provider/connection-provider.module.ts
@@ -14,6 +14,7 @@ import { TwentyConfigModule } from 'src/engine/core-modules/twenty-config/twenty
 import { ConnectedAccountEntity } from 'src/engine/metadata-modules/connected-account/entities/connected-account.entity';
 import { ConnectedAccountTokenEncryptionModule } from 'src/engine/metadata-modules/connected-account/services/connected-account-token-encryption.module';
 import { FlatConnectionProviderModule } from 'src/engine/metadata-modules/flat-connection-provider/flat-connection-provider.module';
+import { WorkspaceCacheModule } from 'src/engine/workspace-cache/workspace-cache.module';
 
 @Module({
   imports: [
@@ -29,6 +30,7 @@ import { FlatConnectionProviderModule } from 'src/engine/metadata-modules/flat-c
     TwentyConfigModule,
     FlatConnectionProviderModule,
     ConnectedAccountTokenEncryptionModule,
+    WorkspaceCacheModule,
   ],
   providers: [
     ConnectionProviderService,

--- a/packages/twenty-shared/src/application/connectionProviderManifestType.ts
+++ b/packages/twenty-shared/src/application/connectionProviderManifestType.ts
@@ -6,4 +6,7 @@ export type ConnectionProviderManifest = SyncableEntityOptions & {
   displayName: string;
   type: 'oauth';
   oauth: OAuthConnectionProviderConfig;
+  // universalIdentifier of a logic function of the same application, enqueued
+  // after each successful OAuth connect (and reconnect) of this provider.
+  onConnectLogicFunctionUniversalIdentifier?: string;
 };

--- a/packages/twenty-shared/src/application/storedOAuthConnectionProviderConfigType.ts
+++ b/packages/twenty-shared/src/application/storedOAuthConnectionProviderConfigType.ts
@@ -13,4 +13,5 @@ export type StoredOAuthConnectionProviderConfig = {
   authorizationParams: Record<string, string> | null;
   tokenRequestContentType: OAuthProviderTokenRequestContentType;
   usePkce: boolean;
+  onConnectLogicFunctionUniversalIdentifier: string | null;
 };


### PR DESCRIPTION
## What

Lets an application run one of its own logic functions right after a user completes (or redoes) the OAuth flow of one of the app's connection providers:

```ts
export default defineConnectionProvider({
  // ...
  onConnectLogicFunctionUniversalIdentifier: '<logic function universalIdentifier>',
});
```

The function is enqueued on the logic function queue with payload `{ connectionId, connectionProviderName, workspaceId, userWorkspaceId, isReconnection }`, so the app can do provider-specific bookkeeping with the fresh token — e.g. the Slack app calling `auth.test` to learn the `team_id` behind the new connection and persisting it for webhook routing (the GLOBAL claim from #23089).

## How

- `ConnectionProviderManifest` gains an optional `onConnectLogicFunctionUniversalIdentifier`; it is stored in the existing `connectionProvider.oauthConfig` JSONB (no schema migration) and mapped by the manifest converter
- `ConnectionProviderOAuthFlowService.completeAuthorizationFlow` enqueues the hook after `persistConnectedAccount`; fire-and-forget — a missing function, foreign-application function, or queue failure is logged and never breaks the user's OAuth redirect
- The referenced logic function must belong to the same application as the provider (checked at fire time) and be a UUID (validated at SDK build time in `defineConnectionProvider`)
- Docs: new "React to a new connection" section on the Connections page

## Tests

- `connection-provider-oauth-flow.service.spec.ts`: no-hook, happy path payload/queue assertions, foreign-application skip, flow survives enqueue failure
- `from-connection-provider-manifest-to-universal-flat-connection-provider.util.spec.ts`: identifier pass-through and null default
- `define-connection-provider.spec.ts`: UUID validation of the new field

All three suites pass locally; `typecheck` and `lint` clean for twenty-server, twenty-sdk, twenty-shared.

---
_Generated by [Claude Code](https://claude.ai/code/session_01MphoFiRLfEjeQXAx6YAkr3)_

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/23158?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

