### PR TITLE
fix: bump tar 7.5.16 -> 7.5.20 (Dependabot)

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -51740,15 +51740,15 @@ __metadata:
   linkType: hard
 
 "tar@npm:^7.4.0, tar@npm:^7.4.3, tar@npm:^7.5.11, tar@npm:^7.5.16, tar@npm:^7.5.4, tar@npm:^7.5.9":
-  version: 7.5.16
-  resolution: "tar@npm:7.5.16"
+  version: 7.5.20
+  resolution: "tar@npm:7.5.20"
   dependencies:
     "@isaacs/fs-minipass": "npm:^4.0.0"
     chownr: "npm:^3.0.0"
     minipass: "npm:^7.1.2"
     minizlib: "npm:^3.1.0"
     yallist: "npm:^5.0.0"
-  checksum: 10c0/4f37f3c4bd2ca2755fd736a5df1d573c1a868ec1b1e893346aeafa95ac510f9e2fd1469420bd866cc7904799e5bd4ac62b5d4f03fe27747d6e1e373b44505c5c
+  checksum: 10c0/4df4335c6d958b76adf1eaced55889dec3ca1c51f450658a074af80694bb0d9c154a8e93fdf4da617372d1575b121295379993961bbe4cd4b0867c0e5689846a
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary

Bumps **tar 7.5.16 -> 7.5.20** on the root `yarn.lock` to clear **4 Dependabot alerts** from this week's node-tar advisory chain, including the critical one.

| Severity | Advisory | Vulnerable | Fixed | Alert |
|---|---|---|---|---|
| critical | GHSA-23hp-3jrh-7fpw | <= 7.5.18 | 7.5.19 | [1772](https://github.com/twentyhq/twenty/security/dependabot/1772) |
| high | GHSA-8x88-c5mf-7j5w | <= 7.5.17 | 7.5.18 | [1771](https://github.com/twentyhq/twenty/security/dependabot/1771) |
| medium | GHSA-w8wr-v893-vjvp | <= 7.5.17 | 7.5.18 | [1773](https://github.com/twentyhq/twenty/security/dependabot/1773) |
| medium | GHSA-gvwx-54wh-qm9j | <= 7.5.16 | 7.5.17 | [1770](https://github.com/twentyhq/twenty/security/dependabot/1770) |

The root lockfile has a single tar entry with all-caret consumer ranges (`^7.4.0` ... `^7.5.16`), so a recursive `yarn up -R tar` lifts it to the latest patch (7.5.20, published 2026-07-12, clears the 3-day age gate). The existing scoped tar resolutions (`npm:^7.5.16` for the @electron/rebuild toolchain and @mintlify/previewing) are caret ranges and permit it unchanged, so no `package.json` edit.

Note: the remaining 52 tar alerts live in the twenty-apps and seed-dependencies mini-lockfiles and will be handled separately.

## Verification

- `yarn install --immutable` passes.
- Diff is `yarn.lock` only; single tar entry now 7.5.20, nothing below remains.
