### PR TITLE
Fix uneven padding in the onboarding trust badge

### DIFF
--- a/packages/twenty-front/src/modules/onboarding/components/import-contacts/OnboardingTrustBadges.tsx
+++ b/packages/twenty-front/src/modules/onboarding/components/import-contacts/OnboardingTrustBadges.tsx
@@ -37,9 +37,7 @@ const StyledBadge = styled.div<{ hasClusterLeading: boolean }>`
   overflow: hidden;
   padding: 0 10px 0
     ${({ hasClusterLeading }) =>
-      hasClusterLeading
-        ? themeCssVariables.spacing['0.5']
-        : themeCssVariables.spacing[1]};
+      hasClusterLeading ? '10px' : themeCssVariables.spacing[1]};
 `;
 
 const StyledSeal = styled.img`


### PR DESCRIPTION
The "+10k" trust badge on the onboarding import contacts step had 2px left padding vs 10px right, so the PwC logo hugged the left edge. The badge now has equal padding on both sides so its content is centered.
<img width="347" height="168" alt="image" src="https://github.com/user-attachments/assets/05e18541-827e-4ace-99ce-7e8c4201cd1b" />

