### PR TITLE
Label record table action buttons

### DIFF
--- a/packages/twenty-front/src/modules/object-record/record-table/record-table-cell/components/RecordTableCellButtons.tsx
+++ b/packages/twenty-front/src/modules/object-record/record-table/record-table-cell/components/RecordTableCellButtons.tsx
@@ -24,6 +24,7 @@ const StyledButtonContainer = styled.div`
 type RecordTableCellButtonsProps = {
   onClick?: () => void;
   Icon: IconComponent;
+  ariaLabel: string;
 }[];
 
 export const RecordTableCellButtons = ({

--- a/packages/twenty-front/src/modules/object-record/record-table/record-table-cell/components/RecordTableCellEditButton.tsx
+++ b/packages/twenty-front/src/modules/object-record/record-table/record-table-cell/components/RecordTableCellEditButton.tsx
@@ -6,6 +6,7 @@ import { RecordTableCellButtons } from '@/object-record/record-table/record-tabl
 import { useGetSecondaryRecordTableCellButton } from '@/object-record/record-table/record-table-cell/hooks/useGetSecondaryRecordTableCellButton';
 import { useOpenRecordTableCellFromCell } from '@/object-record/record-table/record-table-cell/hooks/useOpenRecordTableCellFromCell';
 import { useContext } from 'react';
+import { t } from '@lingui/core/macro';
 import { isDefined } from 'twenty-shared/utils';
 import { IconArrowUpRight, IconPencil } from 'twenty-ui/icon';
 
@@ -32,6 +33,9 @@ export const RecordTableCellEditButton = () => {
     }
   };
 
+  const mainButtonAriaLabel =
+    !isFieldInputOnly && isFirstColumn ? t`Open record` : t`Edit field`;
+
   return (
     <RecordTableCellButtons
       buttons={[
@@ -39,6 +43,7 @@ export const RecordTableCellEditButton = () => {
         {
           onClick: handleMainButtonClick,
           Icon: mainButtonIcon,
+          ariaLabel: mainButtonAriaLabel,
         },
       ]}
     />

--- a/packages/twenty-front/src/modules/object-record/record-table/record-table-cell/hooks/useGetSecondaryRecordTableCellButton.ts
+++ b/packages/twenty-front/src/modules/object-record/record-table/record-table-cell/hooks/useGetSecondaryRecordTableCellButton.ts
@@ -107,10 +107,17 @@ export const useGetSecondaryRecordTableCellButton = () => {
     [FieldMetadataSettingsOnClickAction.OPEN_IN_APP]: IconMail,
   };
 
+  const ariaLabelByAction = {
+    [FieldMetadataSettingsOnClickAction.OPEN_LINK]: t`Open link`,
+    [FieldMetadataSettingsOnClickAction.COPY]: t`Copy to clipboard`,
+    [FieldMetadataSettingsOnClickAction.OPEN_IN_APP]: t`Open email in app`,
+  };
+
   return [
     {
       onClick: onClickByAction[secondaryActionOnClick],
       Icon: iconByAction[secondaryActionOnClick],
+      ariaLabel: ariaLabelByAction[secondaryActionOnClick],
     },
   ];
 };


### PR DESCRIPTION
## What changed

- Require accessible labels on record-table action descriptors.
- Label the primary action as “Open record” or “Edit field” based on its behavior.
- Label secondary open-link, copy, and open-email actions.

## Why

These icon-only controls were rendered without visible text or an accessible name, so screen readers could not identify their purpose. Requiring `ariaLabel` at the local descriptor type also prevents new unlabeled actions in this path.

Closes #23127

## Validation

- `npx oxfmt --check` on all three changed files: passed.
- Type-aware `npx oxlint` on all three changed files: 0 warnings and 0 errors.
- The Nx frontend typecheck was attempted twice. Its dependency build first hit a sandbox IPC restriction, then stalled after cached UI builds. Direct `tsgo` could not resolve unbuilt `twenty-shared` workspace outputs, so no full typecheck result is claimed.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/23194?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

