### PR TITLE
fix: resolve nested interactive controls in filter chips

### DIFF
--- a/packages/twenty-front/src/modules/ui/layout/dropdown/components/Dropdown.tsx
+++ b/packages/twenty-front/src/modules/ui/layout/dropdown/components/Dropdown.tsx
@@ -199,10 +199,6 @@ export const Dropdown = ({
         <StyledClickableComponent
           ref={refs.setReference}
           onClick={handleClickableComponentClick}
-          aria-controls={`${dropdownId}-options`}
-          aria-expanded={isDropdownOpen}
-          aria-haspopup={true}
-          role="button"
           width={clickableComponentWidth}
         >
           {clickableComponent}

--- a/packages/twenty-front/src/modules/views/components/SortOrFilterChip.tsx
+++ b/packages/twenty-front/src/modules/views/components/SortOrFilterChip.tsx
@@ -38,7 +38,6 @@ const StyledChip = styled.div<{ variant: SortOrFilterChipVariant }>`
   }};
   column-gap: ${themeCssVariables.spacing[1]};
   corner-shape: round;
-  cursor: pointer;
   display: flex;
   flex-direction: row;
   flex-shrink: 0;
@@ -49,6 +48,19 @@ const StyledChip = styled.div<{ variant: SortOrFilterChipVariant }>`
   padding-left: ${themeCssVariables.spacing[1]};
   user-select: none;
   white-space: nowrap;
+`;
+
+const StyledChipLabel = styled.button`
+  align-items: center;
+  background: none;
+  border: none;
+  color: inherit;
+  column-gap: ${themeCssVariables.spacing[1]};
+  cursor: pointer;
+  display: flex;
+  font: inherit;
+  margin: 0;
+  padding: 0;
 `;
 
 const StyledIcon = styled.div`
@@ -147,29 +159,33 @@ export const SortOrFilterChip = ({
   };
 
   return (
-    <StyledChip onClick={onClick} variant={variant}>
-      {Icon && (
-        <StyledIcon>
-          <Icon size={theme.icon.size.sm} />
-        </StyledIcon>
-      )}
-      <StyledKeyLabelContainer>
-        {labelKey && <StyledLabelKey>{labelKey}</StyledLabelKey>}
-        {type === 'sort' ? (
-          <StyledSortValue>{labelValue}</StyledSortValue>
-        ) : (
-          <StyledFilterValue>{labelValue}</StyledFilterValue>
+    <StyledChip variant={variant}>
+      <StyledChipLabel type="button" onClick={onClick}>
+        {Icon && (
+          <StyledIcon>
+            <Icon size={theme.icon.size.sm} />
+          </StyledIcon>
         )}
-        {isDefined(labelSubField) && (
-          <>
-            <StyledSubFieldSeparator>·</StyledSubFieldSeparator>
-            <StyledSubFieldValue>{labelSubField}</StyledSubFieldValue>
-          </>
-        )}
-      </StyledKeyLabelContainer>
+        <StyledKeyLabelContainer>
+          {labelKey && <StyledLabelKey>{labelKey}</StyledLabelKey>}
+          {type === 'sort' ? (
+            <StyledSortValue>{labelValue}</StyledSortValue>
+          ) : (
+            <StyledFilterValue>{labelValue}</StyledFilterValue>
+          )}
+          {isDefined(labelSubField) && (
+            <>
+              <StyledSubFieldSeparator>·</StyledSubFieldSeparator>
+              <StyledSubFieldValue>{labelSubField}</StyledSubFieldValue>
+            </>
+          )}
+        </StyledKeyLabelContainer>
+      </StyledChipLabel>
       <StyledDelete
+        type="button"
         variant={variant}
         onClick={handleDeleteClick}
+        aria-label={type === 'sort' ? 'Remove sort' : 'Remove filter'}
         data-testid={'remove-icon-' + testId}
       >
         <IconX size={theme.icon.size.sm} stroke={theme.icon.stroke.sm} />


### PR DESCRIPTION
## Summary
- Fixes WCAG 4.1.2 nested-interactive on view filter chips (#23132)
- Stops exposing the Dropdown clickable wrapper as a button
- Splits SortOrFilterChip into sibling label and remove buttons

## Test plan
- [ ] Open Companies, apply a filter, confirm chip opens dropdown on click
- [ ] Confirm X removes the filter without opening the dropdown
- [ ] Keyboard: Tab to chip label → Enter opens; Tab to X → Enter removes
- [ ] Re-run axe / Accessibility Insights and confirm nested-interactive is gone on filter chips
- [ ] Confirm Filter / Sort header buttons still open their dropdowns


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/23197?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

