### PR TITLE
Reduce logic-function queue concurrency to limit production impact

### DIFF
--- a/packages/twenty-server/src/engine/core-modules/message-queue/message-queue-worker-options.constant.ts
+++ b/packages/twenty-server/src/engine/core-modules/message-queue/message-queue-worker-options.constant.ts
@@ -11,5 +11,9 @@ export const QUEUE_WORKER_OPTIONS: Partial<
     maxStalledCount: 0,
     boundedShutdownDrain: true,
   },
-  [MessageQueue.logicFunctionQueue]: { concurrency: 10 },
+  // Kept low because each job fans out to up to DATABASE_EVENT_JOBS_CHUNK_SIZE
+  // executions in parallel, and executions call back into the core API: with
+  // N worker pods the worst case is N * concurrency * chunkSize concurrent
+  // API calls competing with user traffic.
+  [MessageQueue.logicFunctionQueue]: { concurrency: 2 },
 };


### PR DESCRIPTION
## Context

Logic functions triggered by database events (notably call-recorder on `calendarEvent.*` and last-contact on `messageParticipant.updated`) call back into the core API via `CoreApiClient`, so every execution translates into several GraphQL requests hitting the same API pods and Postgres as user traffic.

The current fan-out with 3 worker pods:

- `logicFunctionQueue` worker concurrency: 10 per pod, so 30 jobs in flight cluster-wide
- Each job carries up to 20 payloads (`DATABASE_EVENT_JOBS_CHUNK_SIZE`) executed with `Promise.all`
- Worst case: 30 x 20 = **600 concurrent logic function executions**, each making ~4-8 API round trips

During message or calendar sync bursts this produces thousands of simultaneous API requests, which is consistent with the API latency degradation observed in production. The per-workspace throttle (1000 executions/min) does not meaningfully bound this since it is per workspace and the limit is high.

## Change

Lower `logicFunctionQueue` worker concurrency from 10 to 2.

New worst case with 3 pods: 3 x 2 x 20 = **120 concurrent executions** (5x reduction). Throughput stays sufficient to drain sync bursts since each job still processes 20 payloads in parallel; the backlog simply drains more gradually instead of stampeding the API.

## Notes

- `DATABASE_EVENT_JOBS_CHUNK_SIZE = 20` in `call-database-event-trigger-jobs.job.ts` is the other amplification knob. Reducing it (e.g. to 10) would halve the per-job burst and cap the worst case at 60 concurrent executions, at the cost of more queue jobs. Left unchanged here to keep this a single, easily revertable tuning change.
- If the queue starts lagging under normal load, 3 per pod is the next conservative step up.

---
_Generated by [Claude Code](https://claude.ai/code/session_018dWHK7zKwbgYPkrwgwdAMi)_

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/23201?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

