### PR TITLE
fix(workflow): create core mirror rows during workflow prefill

### DIFF
--- a/packages/twenty-server/src/engine/workspace-manager/standard-objects-prefill-data/utils/prefill-workflows.util.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/standard-objects-prefill-data/utils/prefill-workflows.util.ts
@@ -37,6 +37,38 @@ export const getWorkflowPrefillIds = (workspaceId: string) => ({
     `createCompanyAutomatedTrigger:${workspaceId}`,
     WORKFLOW_PREFILL_ID_NAMESPACE,
   ),
+  coreQuickLeadWorkflowId: v5(
+    `coreQuickLeadWorkflow:${workspaceId}`,
+    WORKFLOW_PREFILL_ID_NAMESPACE,
+  ),
+  coreCreateCompanyWorkflowId: v5(
+    `coreCreateCompanyWorkflow:${workspaceId}`,
+    WORKFLOW_PREFILL_ID_NAMESPACE,
+  ),
+  coreQuickLeadWorkflowVersionId: v5(
+    `coreQuickLeadWorkflowVersion:${workspaceId}`,
+    WORKFLOW_PREFILL_ID_NAMESPACE,
+  ),
+  coreCreateCompanyWorkflowVersionId: v5(
+    `coreCreateCompanyWorkflowVersion:${workspaceId}`,
+    WORKFLOW_PREFILL_ID_NAMESPACE,
+  ),
+  quickLeadWorkflowUniversalIdentifier: v5(
+    `quickLeadWorkflowUniversalIdentifier:${workspaceId}`,
+    WORKFLOW_PREFILL_ID_NAMESPACE,
+  ),
+  createCompanyWorkflowUniversalIdentifier: v5(
+    `createCompanyWorkflowUniversalIdentifier:${workspaceId}`,
+    WORKFLOW_PREFILL_ID_NAMESPACE,
+  ),
+  quickLeadWorkflowVersionUniversalIdentifier: v5(
+    `quickLeadWorkflowVersionUniversalIdentifier:${workspaceId}`,
+    WORKFLOW_PREFILL_ID_NAMESPACE,
+  ),
+  createCompanyWorkflowVersionUniversalIdentifier: v5(
+    `createCompanyWorkflowVersionUniversalIdentifier:${workspaceId}`,
+    WORKFLOW_PREFILL_ID_NAMESPACE,
+  ),
 });
 
 export const prefillWorkflows = async (
@@ -45,6 +77,7 @@ export const prefillWorkflows = async (
   schemaName: string,
   flatObjectMetadataMaps: FlatEntityMaps<FlatObjectMetadata>,
   flatFieldMetadataMaps: FlatEntityMaps<FlatFieldMetadata>,
+  applicationIdParam?: string,
 ) => {
   const {
     quickLeadWorkflowId,
@@ -52,7 +85,32 @@ export const prefillWorkflows = async (
     createCompanyWorkflowId,
     createCompanyWorkflowVersionId,
     createCompanyAutomatedTriggerId,
+    coreQuickLeadWorkflowId,
+    coreCreateCompanyWorkflowId,
+    coreQuickLeadWorkflowVersionId,
+    coreCreateCompanyWorkflowVersionId,
+    quickLeadWorkflowUniversalIdentifier,
+    createCompanyWorkflowUniversalIdentifier,
+    quickLeadWorkflowVersionUniversalIdentifier,
+    createCompanyWorkflowVersionUniversalIdentifier,
   } = getWorkflowPrefillIds(workspaceId);
+
+  let applicationId = applicationIdParam;
+
+  if (!isDefined(applicationId)) {
+    const [workspace] = await entityManager.query(
+      `SELECT "workspaceCustomApplicationId" FROM core."workspace" WHERE id = $1`,
+      [workspaceId],
+    );
+
+    applicationId = workspace?.workspaceCustomApplicationId;
+  }
+
+  if (!isDefined(applicationId)) {
+    throw new Error(
+      `Workspace custom application not found for workspace ${workspaceId}`,
+    );
+  }
 
   const {
     extractDomainLogicFunctionId,
@@ -132,6 +190,7 @@ export const prefillWorkflows = async (
       'updatedBySource',
       'updatedByWorkspaceMemberId',
       'updatedByName',
+      'coreWorkflowId',
     ])
     .orIgnore()
     .values([
@@ -148,6 +207,7 @@ export const prefillWorkflows = async (
         updatedBySource: FieldActorSource.SYSTEM,
         updatedByWorkspaceMemberId: null,
         updatedByName: 'System',
+        coreWorkflowId: coreQuickLeadWorkflowId,
       },
       {
         id: createCompanyWorkflowId,
@@ -162,10 +222,618 @@ export const prefillWorkflows = async (
         updatedBySource: FieldActorSource.SYSTEM,
         updatedByWorkspaceMemberId: null,
         updatedByName: 'System',
+        coreWorkflowId: coreCreateCompanyWorkflowId,
       },
     ])
     .returning('*')
     .execute();
+
+  await entityManager
+    .createQueryBuilder()
+    .insert()
+    .into('core.workflow', [
+      'id',
+      'workspaceId',
+      'universalIdentifier',
+      'applicationId',
+      'name',
+      'lastPublishedVersionId',
+    ])
+    .orIgnore()
+    .values([
+      {
+        id: coreQuickLeadWorkflowId,
+        workspaceId,
+        universalIdentifier: quickLeadWorkflowUniversalIdentifier,
+        applicationId,
+        name: 'Quick Lead',
+        lastPublishedVersionId: quickLeadWorkflowVersionId,
+      },
+      {
+        id: coreCreateCompanyWorkflowId,
+        workspaceId,
+        universalIdentifier: createCompanyWorkflowUniversalIdentifier,
+        applicationId,
+        name: 'Create company when adding a new person',
+        lastPublishedVersionId: createCompanyWorkflowVersionId,
+      },
+    ])
+    .execute();
+
+  const quickLeadTrigger = {
+    name: 'Launch manually',
+    type: 'MANUAL',
+    settings: {
+      outputSchema: {},
+      icon: 'IconUserPlus',
+      availability: { type: 'GLOBAL', locations: undefined },
+    },
+    nextStepIds: ['6e089bc9-aabd-435f-865f-f31c01c8f4a7'],
+  };
+
+  const createCompanyTrigger = {
+    name: 'Record is created or updated',
+    type: 'DATABASE_EVENT',
+    settings: {
+      eventName: 'person.upserted',
+      fields: ['emails'],
+      outputSchema: generateFakeObjectRecordEvent(
+        {
+          flatObjectMetadata: personObjectMetadata,
+          flatObjectMetadataMaps,
+          flatFieldMetadataMaps,
+        },
+        DatabaseEventAction.UPSERTED,
+      ),
+      filter: personSyncSourceFilter,
+    },
+    nextStepIds: ['c30d7cbe-00e0-4966-bc1a-99b0a11a2cca'],
+  };
+
+  const quickLeadSteps = JSON.stringify([
+    {
+      id: '6e089bc9-aabd-435f-865f-f31c01c8f4a7',
+      name: 'Quick Lead Form',
+      type: 'FORM',
+      valid: false,
+      settings: {
+        input: [
+          {
+            id: '14d669f0-5249-4fa4-b0bb-f8bd408328d5',
+            name: 'firstName',
+            type: 'TEXT',
+            label: 'First name',
+            placeholder: 'Tim',
+          },
+          {
+            id: '4eb6ce85-d231-4aef-9837-744490c026d0',
+            name: 'lastName',
+            type: 'TEXT',
+            label: 'Last Name',
+            placeholder: 'Apple',
+          },
+          {
+            id: 'adbf0e9f-1427-49be-b4fb-092b34d97350',
+            name: 'email',
+            type: 'TEXT',
+            label: 'Email',
+            placeholder: 'timapple@apple.com',
+          },
+          {
+            id: '4ffc7992-9e65-4a4d-9baf-b52e62f2c273',
+            name: 'jobTitle',
+            type: 'TEXT',
+            label: 'Job title',
+            placeholder: 'CEO',
+          },
+          {
+            id: '42f11926-04ea-4924-94a4-2293cc748362',
+            name: 'companyName',
+            type: 'TEXT',
+            label: 'Company name',
+            placeholder: 'Apple',
+          },
+          {
+            id: 'd6ca80ee-26cd-466d-91bf-984d7205451c',
+            name: 'companyDomain',
+            type: 'TEXT',
+            label: 'Company domain',
+            placeholder: 'https://www.apple.com',
+          },
+        ],
+        outputSchema: {
+          email: {
+            type: 'TEXT',
+            label: 'Email',
+            value: 'My text',
+            isLeaf: true,
+          },
+          jobTitle: {
+            type: 'TEXT',
+            label: 'Job title',
+            value: 'My text',
+            isLeaf: true,
+          },
+          lastName: {
+            type: 'TEXT',
+            label: 'Last Name',
+            value: 'My text',
+            isLeaf: true,
+          },
+          firstName: {
+            type: 'TEXT',
+            label: 'First name',
+            value: 'My text',
+            isLeaf: true,
+          },
+          companyName: {
+            type: 'TEXT',
+            label: 'Company name',
+            value: 'My text',
+            isLeaf: true,
+          },
+          companyDomain: {
+            type: 'TEXT',
+            label: 'Company domain',
+            value: 'My text',
+            isLeaf: true,
+          },
+        },
+        errorHandlingOptions: {
+          retryOnFailure: { value: false },
+          continueOnFailure: { value: false },
+        },
+      },
+      __typename: 'WorkflowAction',
+      nextStepIds: ['0715b6cd-7cc1-4b98-971b-00f54dfe643b'],
+    },
+    {
+      id: '0715b6cd-7cc1-4b98-971b-00f54dfe643b',
+      name: 'Create Company',
+      type: 'CREATE_RECORD',
+      valid: false,
+      settings: {
+        input: {
+          objectName: 'company',
+          objectRecord: {
+            name: '{{6e089bc9-aabd-435f-865f-f31c01c8f4a7.companyName}}',
+            domainName: {
+              primaryLinkUrl:
+                '{{6e089bc9-aabd-435f-865f-f31c01c8f4a7.companyDomain}}',
+              primaryLinkLabel: '',
+            },
+          },
+        },
+        outputSchema: {
+          object: {
+            icon: 'IconBuildingSkyscraper',
+            label: 'Company',
+            value: 'A company',
+            isLeaf: true,
+            fieldIdName: 'id',
+            nameSingular: 'company',
+          },
+          _outputSchemaType: 'RECORD',
+          fields: generateObjectRecordFields({
+            objectMetadataInfo: {
+              flatObjectMetadata: companyObjectMetadata,
+              flatObjectMetadataMaps,
+              flatFieldMetadataMaps,
+            },
+          }),
+        },
+        errorHandlingOptions: {
+          retryOnFailure: { value: false },
+          continueOnFailure: { value: false },
+        },
+      },
+      __typename: 'WorkflowAction',
+      nextStepIds: ['6f553ea7-b00e-4371-9d88-d8298568a246'],
+    },
+    {
+      id: '6f553ea7-b00e-4371-9d88-d8298568a246',
+      name: 'Create Person',
+      type: 'CREATE_RECORD',
+      valid: false,
+      settings: {
+        input: {
+          objectName: 'person',
+          objectRecord: {
+            name: {
+              lastName: '{{6e089bc9-aabd-435f-865f-f31c01c8f4a7.lastName}}',
+              firstName: '{{6e089bc9-aabd-435f-865f-f31c01c8f4a7.firstName}}',
+            },
+            emails: {
+              primaryEmail: '{{6e089bc9-aabd-435f-865f-f31c01c8f4a7.email}}',
+              additionalEmails: [],
+            },
+            companyId: '{{0715b6cd-7cc1-4b98-971b-00f54dfe643b.id}}',
+          },
+        },
+        outputSchema: {
+          fields: generateObjectRecordFields({
+            objectMetadataInfo: {
+              flatObjectMetadata: personObjectMetadata,
+              flatObjectMetadataMaps,
+              flatFieldMetadataMaps,
+            },
+          }),
+        },
+        errorHandlingOptions: {
+          retryOnFailure: { value: false },
+          continueOnFailure: { value: false },
+        },
+      },
+      __typename: 'WorkflowAction',
+      nextStepIds: null,
+    },
+  ]);
+
+  const createCompanySteps = JSON.stringify([
+    {
+      id: 'c30d7cbe-00e0-4966-bc1a-99b0a11a2cca',
+      name: 'Is this a personal email?',
+      type: 'CODE',
+      valid: false,
+      position: {
+        x: 227.25,
+        y: 130,
+      },
+      settings: {
+        input: {
+          logicFunctionId: isPersonalEmailLogicFunctionId,
+          logicFunctionInput: {
+            primaryEmail: '{{trigger.properties.after.emails.primaryEmail}}',
+          },
+        },
+        outputSchema: {
+          isPersonal: {
+            type: 'boolean',
+            label: 'isPersonal',
+            value: true,
+            isLeaf: true,
+          },
+        },
+        errorHandlingOptions: {
+          retryOnFailure: {
+            value: false,
+          },
+          continueOnFailure: {
+            value: false,
+          },
+        },
+      },
+      __typename: 'WorkflowAction',
+      nextStepIds: ['01f3db05-aae5-4e4b-b361-96684f09c704'],
+    },
+    {
+      id: '01f3db05-aae5-4e4b-b361-96684f09c704',
+      name: 'If business email',
+      type: 'FILTER',
+      valid: false,
+      position: {
+        x: 249.25,
+        y: 260,
+      },
+      settings: {
+        input: {
+          stepFilters: [
+            {
+              id: '0e595385-9e18-4869-abfd-cf72952b124c',
+              type: 'boolean',
+              value: 'false',
+              operand: 'IS',
+              isFullRecord: false,
+              stepOutputKey:
+                '{{c30d7cbe-00e0-4966-bc1a-99b0a11a2cca.isPersonal}}',
+              stepFilterGroupId: '5204d5f5-7b23-428c-9f84-c37971d497d3',
+              positionInStepFilterGroup: 0,
+            },
+          ],
+          stepFilterGroups: [
+            {
+              id: '5204d5f5-7b23-428c-9f84-c37971d497d3',
+              logicalOperator: 'AND',
+            },
+          ],
+        },
+        outputSchema: {},
+        errorHandlingOptions: {
+          retryOnFailure: {
+            value: false,
+          },
+          continueOnFailure: {
+            value: false,
+          },
+        },
+      },
+      __typename: 'WorkflowAction',
+      nextStepIds: ['1b01193b-8300-4d79-940b-44464bf45505'],
+    },
+    {
+      id: '1b01193b-8300-4d79-940b-44464bf45505',
+      name: 'Extract domain from email',
+      type: 'CODE',
+      valid: false,
+      position: {
+        x: 219.75,
+        y: 390,
+      },
+      settings: {
+        input: {
+          logicFunctionId: extractDomainLogicFunctionId,
+          logicFunctionInput: {
+            email: '{{trigger.properties.after.emails.primaryEmail}}',
+          },
+        },
+        outputSchema: {
+          url: {
+            icon: 'IconVariable',
+            type: 'string',
+            label: 'url',
+            value: 'https://twenty.com',
+            isLeaf: true,
+          },
+          domain: {
+            icon: 'IconVariable',
+            type: 'string',
+            label: 'domain',
+            value: 'twenty.com',
+            isLeaf: true,
+          },
+        },
+        errorHandlingOptions: {
+          retryOnFailure: {
+            value: false,
+          },
+          continueOnFailure: {
+            value: false,
+          },
+        },
+      },
+      __typename: 'WorkflowAction',
+      nextStepIds: ['becb3acf-79bb-4672-8a42-3696e94957b5'],
+    },
+    {
+      id: 'becb3acf-79bb-4672-8a42-3696e94957b5',
+      name: 'Search Company',
+      type: 'FIND_RECORDS',
+      valid: false,
+      position: {
+        x: 247.75,
+        y: 520,
+      },
+      settings: {
+        input: {
+          limit: 25,
+          filter: {
+            recordFilters: [
+              {
+                id: 'a9b917a0-5c4c-4e8f-bf91-160d0b888693',
+                type: 'LINKS',
+                label: 'Domain Name',
+                value: '{{1b01193b-8300-4d79-940b-44464bf45505.domain}}',
+                operand: 'CONTAINS',
+                displayValue: '{{1b01193b-8300-4d79-940b-44464bf45505.domain}}',
+                subFieldName: 'primaryLinkUrl',
+                fieldMetadataId: companyDomainNameFieldMetadata.id,
+                recordFilterGroupId: '194e151c-cf46-4e8f-a48b-649c36082dfa',
+              },
+            ],
+            recordFilterGroups: [
+              {
+                id: '194e151c-cf46-4e8f-a48b-649c36082dfa',
+                logicalOperator: 'AND',
+              },
+            ],
+          },
+          objectName: 'company',
+        },
+        outputSchema: {},
+        errorHandlingOptions: {
+          retryOnFailure: {
+            value: false,
+          },
+          continueOnFailure: {
+            value: false,
+          },
+        },
+      },
+      __typename: 'WorkflowAction',
+      nextStepIds: ['9d0b6ef2-aad2-4853-92e1-95f2abf10d5b'],
+    },
+    {
+      id: '9d0b6ef2-aad2-4853-92e1-95f2abf10d5b',
+      name: 'Find exact company match',
+      type: 'CODE',
+      valid: false,
+      position: {
+        x: 247.75,
+        y: 650,
+      },
+      settings: {
+        input: {
+          logicFunctionId: findMatchingCompanyByDomainLogicFunctionId,
+          logicFunctionInput: {
+            companies: '{{becb3acf-79bb-4672-8a42-3696e94957b5.all}}',
+            domain: '{{1b01193b-8300-4d79-940b-44464bf45505.domain}}',
+          },
+        },
+        outputSchema: {
+          companyId: {
+            type: 'string',
+            label: 'companyId',
+            value: '00000000-0000-0000-0000-000000000000',
+            isLeaf: true,
+          },
+          hasMatch: {
+            type: 'boolean',
+            label: 'hasMatch',
+            value: true,
+            isLeaf: true,
+          },
+        },
+        errorHandlingOptions: {
+          retryOnFailure: {
+            value: false,
+          },
+          continueOnFailure: {
+            value: false,
+          },
+        },
+      },
+      __typename: 'WorkflowAction',
+      nextStepIds: ['0c99a900-656a-40e8-977e-5a7357be33b9'],
+    },
+    {
+      id: '0c99a900-656a-40e8-977e-5a7357be33b9',
+      name: 'If a company already exists',
+      type: 'IF_ELSE',
+      valid: false,
+      position: {
+        x: 216.25,
+        y: 780,
+      },
+      settings: {
+        input: {
+          branches: [
+            {
+              id: '1344c151-15ff-40e2-a1a3-925fabaf5b1c',
+              nextStepIds: ['ffdd4271-75d4-4805-b1f8-2167a113c3b2'],
+              filterGroupId: 'f5c41047-2a6e-49fb-968a-fa7789a90ee5',
+            },
+            {
+              id: 'fe6dd152-1103-4324-af51-3ff994d1f8a7',
+              nextStepIds: ['ddafb9db-a94f-40b9-a5c9-becce857edf7'],
+            },
+          ],
+          stepFilters: [
+            {
+              id: '290cc6a3-08fd-4be5-b42e-966d0bb90ff7',
+              type: 'boolean',
+              value: 'true',
+              operand: 'IS',
+              isFullRecord: false,
+              stepOutputKey:
+                '{{9d0b6ef2-aad2-4853-92e1-95f2abf10d5b.hasMatch}}',
+              stepFilterGroupId: 'f5c41047-2a6e-49fb-968a-fa7789a90ee5',
+              positionInStepFilterGroup: 0,
+            },
+          ],
+          stepFilterGroups: [
+            {
+              id: 'f5c41047-2a6e-49fb-968a-fa7789a90ee5',
+              logicalOperator: 'AND',
+            },
+          ],
+        },
+        outputSchema: {},
+        errorHandlingOptions: {
+          retryOnFailure: {
+            value: false,
+          },
+          continueOnFailure: {
+            value: false,
+          },
+        },
+      },
+      __typename: 'WorkflowAction',
+    },
+    {
+      id: 'ffdd4271-75d4-4805-b1f8-2167a113c3b2',
+      name: 'Attach person to existing company',
+      type: 'UPDATE_RECORD',
+      valid: false,
+      position: {
+        x: 0,
+        y: 910,
+      },
+      settings: {
+        input: {
+          objectName: 'person',
+          objectRecord: {
+            companyId: '{{9d0b6ef2-aad2-4853-92e1-95f2abf10d5b.companyId}}',
+          },
+          fieldsToUpdate: ['companyId'],
+          objectRecordId: '{{trigger.properties.after.id}}',
+        },
+        outputSchema: {},
+        errorHandlingOptions: {
+          retryOnFailure: {
+            value: false,
+          },
+          continueOnFailure: {
+            value: false,
+          },
+        },
+      },
+      __typename: 'WorkflowAction',
+    },
+    {
+      id: 'ddafb9db-a94f-40b9-a5c9-becce857edf7',
+      name: 'Create a new company',
+      type: 'CREATE_RECORD',
+      valid: false,
+      position: {
+        x: 440,
+        y: 910,
+      },
+      settings: {
+        input: {
+          objectName: 'company',
+          objectRecord: {
+            name: '{{1b01193b-8300-4d79-940b-44464bf45505.domain}}',
+            domainName: {
+              primaryLinkUrl: '{{1b01193b-8300-4d79-940b-44464bf45505.url}}',
+              primaryLinkLabel:
+                '{{1b01193b-8300-4d79-940b-44464bf45505.domain}}',
+            },
+          },
+        },
+        outputSchema: {},
+        errorHandlingOptions: {
+          retryOnFailure: {
+            value: false,
+          },
+          continueOnFailure: {
+            value: false,
+          },
+        },
+      },
+      __typename: 'WorkflowAction',
+      nextStepIds: ['d5d5d6e1-391f-4142-83c1-670f7087f079'],
+    },
+    {
+      id: 'd5d5d6e1-391f-4142-83c1-670f7087f079',
+      name: 'Attach person to this company',
+      type: 'UPDATE_RECORD',
+      valid: false,
+      position: {
+        x: 420.5,
+        y: 1040,
+      },
+      settings: {
+        input: {
+          objectName: 'person',
+          objectRecord: {
+            companyId: '{{ddafb9db-a94f-40b9-a5c9-becce857edf7.id}}',
+          },
+          fieldsToUpdate: ['companyId'],
+          objectRecordId: '{{trigger.properties.after.id}}',
+        },
+        outputSchema: {},
+        errorHandlingOptions: {
+          retryOnFailure: {
+            value: false,
+          },
+          continueOnFailure: {
+            value: false,
+          },
+        },
+      },
+      __typename: 'WorkflowAction',
+    },
+  ]);
 
   await entityManager
     .createQueryBuilder()
@@ -178,604 +846,70 @@ export const prefillWorkflows = async (
       'status',
       'position',
       'workflowId',
+      'coreWorkflowVersionId',
     ])
     .orIgnore()
     .values([
       {
         id: quickLeadWorkflowVersionId,
         name: 'v1',
-        trigger: JSON.stringify({
-          name: 'Launch manually',
-          type: 'MANUAL',
-          settings: {
-            outputSchema: {},
-            icon: 'IconUserPlus',
-            availability: { type: 'GLOBAL', locations: undefined },
-          },
-          nextStepIds: ['6e089bc9-aabd-435f-865f-f31c01c8f4a7'],
-        }),
-        steps: JSON.stringify([
-          {
-            id: '6e089bc9-aabd-435f-865f-f31c01c8f4a7',
-            name: 'Quick Lead Form',
-            type: 'FORM',
-            valid: false,
-            settings: {
-              input: [
-                {
-                  id: '14d669f0-5249-4fa4-b0bb-f8bd408328d5',
-                  name: 'firstName',
-                  type: 'TEXT',
-                  label: 'First name',
-                  placeholder: 'Tim',
-                },
-                {
-                  id: '4eb6ce85-d231-4aef-9837-744490c026d0',
-                  name: 'lastName',
-                  type: 'TEXT',
-                  label: 'Last Name',
-                  placeholder: 'Apple',
-                },
-                {
-                  id: 'adbf0e9f-1427-49be-b4fb-092b34d97350',
-                  name: 'email',
-                  type: 'TEXT',
-                  label: 'Email',
-                  placeholder: 'timapple@apple.com',
-                },
-                {
-                  id: '4ffc7992-9e65-4a4d-9baf-b52e62f2c273',
-                  name: 'jobTitle',
-                  type: 'TEXT',
-                  label: 'Job title',
-                  placeholder: 'CEO',
-                },
-                {
-                  id: '42f11926-04ea-4924-94a4-2293cc748362',
-                  name: 'companyName',
-                  type: 'TEXT',
-                  label: 'Company name',
-                  placeholder: 'Apple',
-                },
-                {
-                  id: 'd6ca80ee-26cd-466d-91bf-984d7205451c',
-                  name: 'companyDomain',
-                  type: 'TEXT',
-                  label: 'Company domain',
-                  placeholder: 'https://www.apple.com',
-                },
-              ],
-              outputSchema: {
-                email: {
-                  type: 'TEXT',
-                  label: 'Email',
-                  value: 'My text',
-                  isLeaf: true,
-                },
-                jobTitle: {
-                  type: 'TEXT',
-                  label: 'Job title',
-                  value: 'My text',
-                  isLeaf: true,
-                },
-                lastName: {
-                  type: 'TEXT',
-                  label: 'Last Name',
-                  value: 'My text',
-                  isLeaf: true,
-                },
-                firstName: {
-                  type: 'TEXT',
-                  label: 'First name',
-                  value: 'My text',
-                  isLeaf: true,
-                },
-                companyName: {
-                  type: 'TEXT',
-                  label: 'Company name',
-                  value: 'My text',
-                  isLeaf: true,
-                },
-                companyDomain: {
-                  type: 'TEXT',
-                  label: 'Company domain',
-                  value: 'My text',
-                  isLeaf: true,
-                },
-              },
-              errorHandlingOptions: {
-                retryOnFailure: { value: false },
-                continueOnFailure: { value: false },
-              },
-            },
-            __typename: 'WorkflowAction',
-            nextStepIds: ['0715b6cd-7cc1-4b98-971b-00f54dfe643b'],
-          },
-          {
-            id: '0715b6cd-7cc1-4b98-971b-00f54dfe643b',
-            name: 'Create Company',
-            type: 'CREATE_RECORD',
-            valid: false,
-            settings: {
-              input: {
-                objectName: 'company',
-                objectRecord: {
-                  name: '{{6e089bc9-aabd-435f-865f-f31c01c8f4a7.companyName}}',
-                  domainName: {
-                    primaryLinkUrl:
-                      '{{6e089bc9-aabd-435f-865f-f31c01c8f4a7.companyDomain}}',
-                    primaryLinkLabel: '',
-                  },
-                },
-              },
-              outputSchema: {
-                object: {
-                  icon: 'IconBuildingSkyscraper',
-                  label: 'Company',
-                  value: 'A company',
-                  isLeaf: true,
-                  fieldIdName: 'id',
-                  nameSingular: 'company',
-                },
-                _outputSchemaType: 'RECORD',
-                fields: generateObjectRecordFields({
-                  objectMetadataInfo: {
-                    flatObjectMetadata: companyObjectMetadata,
-                    flatObjectMetadataMaps,
-                    flatFieldMetadataMaps,
-                  },
-                }),
-              },
-              errorHandlingOptions: {
-                retryOnFailure: { value: false },
-                continueOnFailure: { value: false },
-              },
-            },
-            __typename: 'WorkflowAction',
-            nextStepIds: ['6f553ea7-b00e-4371-9d88-d8298568a246'],
-          },
-          {
-            id: '6f553ea7-b00e-4371-9d88-d8298568a246',
-            name: 'Create Person',
-            type: 'CREATE_RECORD',
-            valid: false,
-            settings: {
-              input: {
-                objectName: 'person',
-                objectRecord: {
-                  name: {
-                    lastName:
-                      '{{6e089bc9-aabd-435f-865f-f31c01c8f4a7.lastName}}',
-                    firstName:
-                      '{{6e089bc9-aabd-435f-865f-f31c01c8f4a7.firstName}}',
-                  },
-                  emails: {
-                    primaryEmail:
-                      '{{6e089bc9-aabd-435f-865f-f31c01c8f4a7.email}}',
-                    additionalEmails: [],
-                  },
-                  companyId: '{{0715b6cd-7cc1-4b98-971b-00f54dfe643b.id}}',
-                },
-              },
-              outputSchema: {
-                fields: generateObjectRecordFields({
-                  objectMetadataInfo: {
-                    flatObjectMetadata: personObjectMetadata,
-                    flatObjectMetadataMaps,
-                    flatFieldMetadataMaps,
-                  },
-                }),
-              },
-              errorHandlingOptions: {
-                retryOnFailure: { value: false },
-                continueOnFailure: { value: false },
-              },
-            },
-            __typename: 'WorkflowAction',
-            nextStepIds: null,
-          },
-        ]),
+        trigger: JSON.stringify(quickLeadTrigger),
+        steps: quickLeadSteps,
         status: 'ACTIVE',
         position: 1,
         workflowId: quickLeadWorkflowId,
+        coreWorkflowVersionId: coreQuickLeadWorkflowVersionId,
       },
       {
         id: createCompanyWorkflowVersionId,
         name: 'v1',
-        trigger: JSON.stringify({
-          name: 'Record is created or updated',
-          type: 'DATABASE_EVENT',
-          settings: {
-            eventName: 'person.upserted',
-            fields: ['emails'],
-            outputSchema: generateFakeObjectRecordEvent(
-              {
-                flatObjectMetadata: personObjectMetadata,
-                flatObjectMetadataMaps,
-                flatFieldMetadataMaps,
-              },
-              DatabaseEventAction.UPSERTED,
-            ),
-            filter: personSyncSourceFilter,
-          },
-          nextStepIds: ['c30d7cbe-00e0-4966-bc1a-99b0a11a2cca'],
-        }),
-        steps: JSON.stringify([
-          {
-            id: 'c30d7cbe-00e0-4966-bc1a-99b0a11a2cca',
-            name: 'Is this a personal email?',
-            type: 'CODE',
-            valid: false,
-            position: {
-              x: 227.25,
-              y: 130,
-            },
-            settings: {
-              input: {
-                logicFunctionId: isPersonalEmailLogicFunctionId,
-                logicFunctionInput: {
-                  primaryEmail:
-                    '{{trigger.properties.after.emails.primaryEmail}}',
-                },
-              },
-              outputSchema: {
-                isPersonal: {
-                  type: 'boolean',
-                  label: 'isPersonal',
-                  value: true,
-                  isLeaf: true,
-                },
-              },
-              errorHandlingOptions: {
-                retryOnFailure: {
-                  value: false,
-                },
-                continueOnFailure: {
-                  value: false,
-                },
-              },
-            },
-            __typename: 'WorkflowAction',
-            nextStepIds: ['01f3db05-aae5-4e4b-b361-96684f09c704'],
-          },
-          {
-            id: '01f3db05-aae5-4e4b-b361-96684f09c704',
-            name: 'If business email',
-            type: 'FILTER',
-            valid: false,
-            position: {
-              x: 249.25,
-              y: 260,
-            },
-            settings: {
-              input: {
-                stepFilters: [
-                  {
-                    id: '0e595385-9e18-4869-abfd-cf72952b124c',
-                    type: 'boolean',
-                    value: 'false',
-                    operand: 'IS',
-                    isFullRecord: false,
-                    stepOutputKey:
-                      '{{c30d7cbe-00e0-4966-bc1a-99b0a11a2cca.isPersonal}}',
-                    stepFilterGroupId: '5204d5f5-7b23-428c-9f84-c37971d497d3',
-                    positionInStepFilterGroup: 0,
-                  },
-                ],
-                stepFilterGroups: [
-                  {
-                    id: '5204d5f5-7b23-428c-9f84-c37971d497d3',
-                    logicalOperator: 'AND',
-                  },
-                ],
-              },
-              outputSchema: {},
-              errorHandlingOptions: {
-                retryOnFailure: {
-                  value: false,
-                },
-                continueOnFailure: {
-                  value: false,
-                },
-              },
-            },
-            __typename: 'WorkflowAction',
-            nextStepIds: ['1b01193b-8300-4d79-940b-44464bf45505'],
-          },
-          {
-            id: '1b01193b-8300-4d79-940b-44464bf45505',
-            name: 'Extract domain from email',
-            type: 'CODE',
-            valid: false,
-            position: {
-              x: 219.75,
-              y: 390,
-            },
-            settings: {
-              input: {
-                logicFunctionId: extractDomainLogicFunctionId,
-                logicFunctionInput: {
-                  email: '{{trigger.properties.after.emails.primaryEmail}}',
-                },
-              },
-              outputSchema: {
-                url: {
-                  icon: 'IconVariable',
-                  type: 'string',
-                  label: 'url',
-                  value: 'https://twenty.com',
-                  isLeaf: true,
-                },
-                domain: {
-                  icon: 'IconVariable',
-                  type: 'string',
-                  label: 'domain',
-                  value: 'twenty.com',
-                  isLeaf: true,
-                },
-              },
-              errorHandlingOptions: {
-                retryOnFailure: {
-                  value: false,
-                },
-                continueOnFailure: {
-                  value: false,
-                },
-              },
-            },
-            __typename: 'WorkflowAction',
-            nextStepIds: ['becb3acf-79bb-4672-8a42-3696e94957b5'],
-          },
-          {
-            id: 'becb3acf-79bb-4672-8a42-3696e94957b5',
-            name: 'Search Company',
-            type: 'FIND_RECORDS',
-            valid: false,
-            position: {
-              x: 247.75,
-              y: 520,
-            },
-            settings: {
-              input: {
-                limit: 25,
-                filter: {
-                  recordFilters: [
-                    {
-                      id: 'a9b917a0-5c4c-4e8f-bf91-160d0b888693',
-                      type: 'LINKS',
-                      label: 'Domain Name',
-                      value: '{{1b01193b-8300-4d79-940b-44464bf45505.domain}}',
-                      operand: 'CONTAINS',
-                      displayValue:
-                        '{{1b01193b-8300-4d79-940b-44464bf45505.domain}}',
-                      subFieldName: 'primaryLinkUrl',
-                      fieldMetadataId: companyDomainNameFieldMetadata.id,
-                      recordFilterGroupId:
-                        '194e151c-cf46-4e8f-a48b-649c36082dfa',
-                    },
-                  ],
-                  recordFilterGroups: [
-                    {
-                      id: '194e151c-cf46-4e8f-a48b-649c36082dfa',
-                      logicalOperator: 'AND',
-                    },
-                  ],
-                },
-                objectName: 'company',
-              },
-              outputSchema: {},
-              errorHandlingOptions: {
-                retryOnFailure: {
-                  value: false,
-                },
-                continueOnFailure: {
-                  value: false,
-                },
-              },
-            },
-            __typename: 'WorkflowAction',
-            nextStepIds: ['9d0b6ef2-aad2-4853-92e1-95f2abf10d5b'],
-          },
-          {
-            id: '9d0b6ef2-aad2-4853-92e1-95f2abf10d5b',
-            name: 'Find exact company match',
-            type: 'CODE',
-            valid: false,
-            position: {
-              x: 247.75,
-              y: 650,
-            },
-            settings: {
-              input: {
-                logicFunctionId: findMatchingCompanyByDomainLogicFunctionId,
-                logicFunctionInput: {
-                  companies: '{{becb3acf-79bb-4672-8a42-3696e94957b5.all}}',
-                  domain: '{{1b01193b-8300-4d79-940b-44464bf45505.domain}}',
-                },
-              },
-              outputSchema: {
-                companyId: {
-                  type: 'string',
-                  label: 'companyId',
-                  value: '00000000-0000-0000-0000-000000000000',
-                  isLeaf: true,
-                },
-                hasMatch: {
-                  type: 'boolean',
-                  label: 'hasMatch',
-                  value: true,
-                  isLeaf: true,
-                },
-              },
-              errorHandlingOptions: {
-                retryOnFailure: {
-                  value: false,
-                },
-                continueOnFailure: {
-                  value: false,
-                },
-              },
-            },
-            __typename: 'WorkflowAction',
-            nextStepIds: ['0c99a900-656a-40e8-977e-5a7357be33b9'],
-          },
-          {
-            id: '0c99a900-656a-40e8-977e-5a7357be33b9',
-            name: 'If a company already exists',
-            type: 'IF_ELSE',
-            valid: false,
-            position: {
-              x: 216.25,
-              y: 780,
-            },
-            settings: {
-              input: {
-                branches: [
-                  {
-                    id: '1344c151-15ff-40e2-a1a3-925fabaf5b1c',
-                    nextStepIds: ['ffdd4271-75d4-4805-b1f8-2167a113c3b2'],
-                    filterGroupId: 'f5c41047-2a6e-49fb-968a-fa7789a90ee5',
-                  },
-                  {
-                    id: 'fe6dd152-1103-4324-af51-3ff994d1f8a7',
-                    nextStepIds: ['ddafb9db-a94f-40b9-a5c9-becce857edf7'],
-                  },
-                ],
-                stepFilters: [
-                  {
-                    id: '290cc6a3-08fd-4be5-b42e-966d0bb90ff7',
-                    type: 'boolean',
-                    value: 'true',
-                    operand: 'IS',
-                    isFullRecord: false,
-                    stepOutputKey:
-                      '{{9d0b6ef2-aad2-4853-92e1-95f2abf10d5b.hasMatch}}',
-                    stepFilterGroupId: 'f5c41047-2a6e-49fb-968a-fa7789a90ee5',
-                    positionInStepFilterGroup: 0,
-                  },
-                ],
-                stepFilterGroups: [
-                  {
-                    id: 'f5c41047-2a6e-49fb-968a-fa7789a90ee5',
-                    logicalOperator: 'AND',
-                  },
-                ],
-              },
-              outputSchema: {},
-              errorHandlingOptions: {
-                retryOnFailure: {
-                  value: false,
-                },
-                continueOnFailure: {
-                  value: false,
-                },
-              },
-            },
-            __typename: 'WorkflowAction',
-          },
-          {
-            id: 'ffdd4271-75d4-4805-b1f8-2167a113c3b2',
-            name: 'Attach person to existing company',
-            type: 'UPDATE_RECORD',
-            valid: false,
-            position: {
-              x: 0,
-              y: 910,
-            },
-            settings: {
-              input: {
-                objectName: 'person',
-                objectRecord: {
-                  companyId:
-                    '{{9d0b6ef2-aad2-4853-92e1-95f2abf10d5b.companyId}}',
-                },
-                fieldsToUpdate: ['companyId'],
-                objectRecordId: '{{trigger.properties.after.id}}',
-              },
-              outputSchema: {},
-              errorHandlingOptions: {
-                retryOnFailure: {
-                  value: false,
-                },
-                continueOnFailure: {
-                  value: false,
-                },
-              },
-            },
-            __typename: 'WorkflowAction',
-          },
-          {
-            id: 'ddafb9db-a94f-40b9-a5c9-becce857edf7',
-            name: 'Create a new company',
-            type: 'CREATE_RECORD',
-            valid: false,
-            position: {
-              x: 440,
-              y: 910,
-            },
-            settings: {
-              input: {
-                objectName: 'company',
-                objectRecord: {
-                  name: '{{1b01193b-8300-4d79-940b-44464bf45505.domain}}',
-                  domainName: {
-                    primaryLinkUrl:
-                      '{{1b01193b-8300-4d79-940b-44464bf45505.url}}',
-                    primaryLinkLabel:
-                      '{{1b01193b-8300-4d79-940b-44464bf45505.domain}}',
-                  },
-                },
-              },
-              outputSchema: {},
-              errorHandlingOptions: {
-                retryOnFailure: {
-                  value: false,
-                },
-                continueOnFailure: {
-                  value: false,
-                },
-              },
-            },
-            __typename: 'WorkflowAction',
-            nextStepIds: ['d5d5d6e1-391f-4142-83c1-670f7087f079'],
-          },
-          {
-            id: 'd5d5d6e1-391f-4142-83c1-670f7087f079',
-            name: 'Attach person to this company',
-            type: 'UPDATE_RECORD',
-            valid: false,
-            position: {
-              x: 420.5,
-              y: 1040,
-            },
-            settings: {
-              input: {
-                objectName: 'person',
-                objectRecord: {
-                  companyId: '{{ddafb9db-a94f-40b9-a5c9-becce857edf7.id}}',
-                },
-                fieldsToUpdate: ['companyId'],
-                objectRecordId: '{{trigger.properties.after.id}}',
-              },
-              outputSchema: {},
-              errorHandlingOptions: {
-                retryOnFailure: {
-                  value: false,
-                },
-                continueOnFailure: {
-                  value: false,
-                },
-              },
-            },
-            __typename: 'WorkflowAction',
-          },
-        ]),
+        trigger: JSON.stringify(createCompanyTrigger),
+        steps: createCompanySteps,
         status: 'ACTIVE',
         position: 2,
         workflowId: createCompanyWorkflowId,
+        coreWorkflowVersionId: coreCreateCompanyWorkflowVersionId,
       },
     ])
     .returning('*')
+    .execute();
+
+  await entityManager
+    .createQueryBuilder()
+    .insert()
+    .into('core.workflowVersion', [
+      'id',
+      'workspaceId',
+      'universalIdentifier',
+      'applicationId',
+      'triggers',
+      'steps',
+      'status',
+      'workflowId',
+    ])
+    .orIgnore()
+    .values([
+      {
+        id: coreQuickLeadWorkflowVersionId,
+        workspaceId,
+        universalIdentifier: quickLeadWorkflowVersionUniversalIdentifier,
+        applicationId,
+        triggers: [quickLeadTrigger],
+        steps: JSON.parse(quickLeadSteps),
+        status: 'ACTIVE',
+        workflowId: quickLeadWorkflowId,
+      },
+      {
+        id: coreCreateCompanyWorkflowVersionId,
+        workspaceId,
+        universalIdentifier: createCompanyWorkflowVersionUniversalIdentifier,
+        applicationId,
+        triggers: [createCompanyTrigger],
+        steps: JSON.parse(createCompanySteps),
+        status: 'ACTIVE',
+        workflowId: createCompanyWorkflowId,
+      },
+    ])
     .execute();
 
   await entityManager


### PR DESCRIPTION
## Problem
Seeded workflows are inserted during workspace activation (and dev seeding) via raw SQL in `prefill-workflows.util.ts`, which bypasses the ORM entirely. The async dual-write listener that mirrors `workflow` / `workflowVersion` into `core.workflow` / `core."workflowVersion"` never fires for these rows, so every newly activated workspace is born with:
- no core mirror rows, and
- NULL `coreWorkflowId` / `coreWorkflowVersionId` soft-refs.

This is permanent, growing drift. The core-consistency check reports every new workspace as 2 unlinked workflows + versions, and once trigger dispatch reads from core these seeded workflows would silently stop working.

## Change
Insert the `core.workflow` and `core."workflowVersion"` mirror rows and stamp the soft-refs inside the same prefill transaction. Field mapping mirrors the dual-write / backfill exactly:
- `core."workflowVersion".workflowId` = the workspace workflow id (what the trigger-map cache groups by)
- `triggers` = jsonb `[trigger]`
- `applicationId` = `workspace.workspaceCustomApplicationId` (throws if missing, same contract as the sync path)
- `core.workflow.lastPublishedVersionId` = the workspace version id
- one ACTIVE core version per workflow (satisfies the partial unique index)

Core ids are deterministic v5 (same helper/namespace as the existing prefill ids) so the existing `.orIgnore()` re-run guard stays idempotent — a re-run hits the PK conflict and is skipped instead of inserting duplicate orphan core rows.

The large diff is mostly re-indentation: the step/trigger arrays were extracted to consts so the same objects feed both the workspace and core inserts. The step/field UUID literals are unchanged from main.

## Verification
- `nx lint:diff-with-main twenty-server`: clean.
- Typecheck (isolated `tsc`): no errors in the changed file (`nx typecheck twenty-server` is blocked by a pre-existing `twenty-shared` build error on main, unrelated).
- Runtime: pending a `database:reset` + cross-schema parity query confirming zero drift on a freshly seeded workspace.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/23204?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

