### PR TITLE
Remove queue retries for logic function and workflow trigger jobs

### DIFF
--- a/packages/twenty-server/src/engine/core-modules/application/application-install/application-install.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/application/application-install/application-install.service.ts
@@ -566,7 +566,6 @@ export class ApplicationInstallService {
             payload,
           },
         ],
-        { retryLimit: 3 },
       );
       return;
     }

--- a/packages/twenty-server/src/engine/core-modules/application/connection-provider/__tests__/connection-provider-oauth-flow.service.spec.ts
+++ b/packages/twenty-server/src/engine/core-modules/application/connection-provider/__tests__/connection-provider-oauth-flow.service.spec.ts
@@ -512,7 +512,6 @@ describe('ConnectionProviderOAuthFlowService', () => {
               },
             },
           ],
-          { retryLimit: 3 },
         );
       });
 

--- a/packages/twenty-server/src/engine/core-modules/application/connection-provider/connection-provider-oauth-flow.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/application/connection-provider/connection-provider-oauth-flow.service.ts
@@ -265,7 +265,6 @@ export class ConnectionProviderOAuthFlowService {
             },
           },
         ],
-        { retryLimit: 3 },
       );
     } catch (error) {
       this.exceptionHandlerService.captureExceptions([error], {

--- a/packages/twenty-server/src/engine/core-modules/logic-function/logic-function-trigger/triggers/cron/cron-trigger.cron.job.ts
+++ b/packages/twenty-server/src/engine/core-modules/logic-function/logic-function-trigger/triggers/cron/cron-trigger.cron.job.ts
@@ -94,7 +94,6 @@ export class CronTriggerCronJob {
                 payload: {},
               },
             ],
-            { retryLimit: 10 },
           );
         }
       } catch (error) {

--- a/packages/twenty-server/src/engine/core-modules/logic-function/logic-function-trigger/triggers/database-event/call-database-event-trigger-jobs.job.ts
+++ b/packages/twenty-server/src/engine/core-modules/logic-function/logic-function-trigger/triggers/database-event/call-database-event-trigger-jobs.job.ts
@@ -72,7 +72,6 @@ export class CallDatabaseEventTriggerJobsJob {
       await this.messageQueueService.add<LogicFunctionTriggerJobData[]>(
         LogicFunctionTriggerJob.name,
         logicFunctionPayloadsChunk,
-        { retryLimit: 3 },
       );
     }
   }

--- a/packages/twenty-server/src/engine/core-modules/server-route-trigger/__tests__/server-route-trigger.service.spec.ts
+++ b/packages/twenty-server/src/engine/core-modules/server-route-trigger/__tests__/server-route-trigger.service.spec.ts
@@ -153,7 +153,6 @@ describe('ServerRouteTriggerService', () => {
           payload: { from: 'resolver' },
         },
       ],
-      { retryLimit: 3 },
     );
     expect(result).toEqual(
       expect.objectContaining({

--- a/packages/twenty-server/src/engine/core-modules/server-route-trigger/server-route-trigger.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/server-route-trigger/server-route-trigger.service.ts
@@ -36,8 +36,6 @@ type ResolverResult = {
   payload?: object;
 };
 
-const QUEUED_TARGET_RETRY_LIMIT = 3;
-
 @Injectable()
 export class ServerRouteTriggerService {
   private readonly logger = new Logger(ServerRouteTriggerService.name);
@@ -198,7 +196,6 @@ export class ServerRouteTriggerService {
           payload,
         },
       ],
-      { retryLimit: QUEUED_TARGET_RETRY_LIMIT },
     );
 
     return { statusCode: 202, headers: {}, body: { queued: true } };

--- a/packages/twenty-server/src/modules/workflow/workflow-trigger/automated-trigger/crons/jobs/__tests__/workflow-cron-trigger-cron.job.spec.ts
+++ b/packages/twenty-server/src/modules/workflow/workflow-trigger/automated-trigger/crons/jobs/__tests__/workflow-cron-trigger-cron.job.spec.ts
@@ -123,7 +123,6 @@ describe('WorkflowCronTriggerCronJob', () => {
           workflowId: 'workflow-1',
           payload: {},
         },
-        { retryLimit: 3 },
       );
     });
 
@@ -287,7 +286,6 @@ describe('WorkflowCronTriggerCronJob', () => {
           workflowId: 'workflow-1',
           payload: {},
         },
-        { retryLimit: 3 },
       );
     });
 
@@ -321,7 +319,6 @@ describe('WorkflowCronTriggerCronJob', () => {
           workflowId: 'workflow-1',
           payload: {},
         },
-        { retryLimit: 3 },
       );
     });
   });

--- a/packages/twenty-server/src/modules/workflow/workflow-trigger/automated-trigger/crons/jobs/workflow-cron-trigger-cron.job.ts
+++ b/packages/twenty-server/src/modules/workflow/workflow-trigger/automated-trigger/crons/jobs/workflow-cron-trigger-cron.job.ts
@@ -105,7 +105,6 @@ export class WorkflowCronTriggerCronJob {
             workflowId: trigger.workflowId,
             payload: {},
           },
-          { retryLimit: 3 },
         );
       } catch (error) {
         this.logger.error(`Error processing cached trigger: ${error}`);
@@ -205,7 +204,6 @@ export class WorkflowCronTriggerCronJob {
               workflowId: trigger.workflowId,
               payload: {},
             },
-            { retryLimit: 3 },
           );
         }
       }

--- a/packages/twenty-server/src/modules/workflow/workflow-trigger/automated-trigger/listeners/__tests__/workflow-database-event-trigger.listener.spec.ts
+++ b/packages/twenty-server/src/modules/workflow/workflow-trigger/automated-trigger/listeners/__tests__/workflow-database-event-trigger.listener.spec.ts
@@ -136,7 +136,6 @@ describe('WorkflowDatabaseEventTriggerListener', () => {
           workflowId,
           payload: mockPayload.events[0],
         },
-        { retryLimit: 3 },
       );
     });
 
@@ -221,7 +220,6 @@ describe('WorkflowDatabaseEventTriggerListener', () => {
           workflowId,
           payload: createPayload.events[0],
         },
-        { retryLimit: 3 },
       );
     });
 
@@ -258,7 +256,6 @@ describe('WorkflowDatabaseEventTriggerListener', () => {
           workflowId,
           payload: deletePayload.events[0],
         },
-        { retryLimit: 3 },
       );
     });
 
@@ -295,7 +292,6 @@ describe('WorkflowDatabaseEventTriggerListener', () => {
           workflowId,
           payload: destroyPayload.events[0],
         },
-        { retryLimit: 3 },
       );
     });
 
@@ -338,7 +334,6 @@ describe('WorkflowDatabaseEventTriggerListener', () => {
           workflowId,
           payload: batchPayload.events[0],
         },
-        { retryLimit: 3 },
       );
       expect(messageQueueService.add).toHaveBeenNthCalledWith(
         2,
@@ -348,7 +343,6 @@ describe('WorkflowDatabaseEventTriggerListener', () => {
           workflowId,
           payload: batchPayload.events[1],
         },
-        { retryLimit: 3 },
       );
     });
 
@@ -386,7 +380,6 @@ describe('WorkflowDatabaseEventTriggerListener', () => {
           workflowId,
           payload: positionOnlyPayload.events[0],
         },
-        { retryLimit: 3 },
       );
     });
 

--- a/packages/twenty-server/src/modules/workflow/workflow-trigger/automated-trigger/listeners/workflow-database-event-trigger.listener.ts
+++ b/packages/twenty-server/src/modules/workflow/workflow-trigger/automated-trigger/listeners/workflow-database-event-trigger.listener.ts
@@ -382,7 +382,6 @@ export class WorkflowDatabaseEventTriggerListener {
                 workflowId: eventListener.workflowId,
                 payload: eventPayload,
               },
-              { retryLimit: 3 },
             );
           }
         }


### PR DESCRIPTION
## Context

All `LogicFunctionTriggerJob` and `WorkflowTriggerJob` enqueue sites set a `retryLimit` (3 on most, 10 on the logic function cron). These retries provide little value and can cause harm:

- User-code failures never throw: the logic function driver returns a `{ status, error }` result, and `WorkflowTriggerJob` swallows its permanent failure cases (workflow not found, unpublished, inactive). Queue retries only ever fired on rate-limit and infra errors.
- The BullMQ driver configures no `backoff`, so retries fire immediately. An immediate retry into a still-empty token bucket or a still-down driver accomplishes nothing.
- Retries can duplicate user-facing executions: on the batched database-event path for logic functions, one failing payload made the retry re-run every function in the chunk that had already succeeded (duplicating side effects and billing 100 credits per re-invocation), and a `WorkflowTriggerJob` retry after `workflowRunnerWorkspaceService.run` partially completed creates a duplicate workflow run.

## Changes

Removed `retryLimit` from all `LogicFunctionTriggerJob` enqueue sites:

- `call-database-event-trigger-jobs.job.ts` (was 3)
- `cron-trigger.cron.job.ts` (was 10)
- `server-route-trigger.service.ts` (was 3, also dropped the now-unused `QUEUED_TARGET_RETRY_LIMIT` constant)
- `application-install.service.ts` post-install hook (was 3)
- `connection-provider-oauth-flow.service.ts` on-connect hook (was 3)

And from all `WorkflowTriggerJob` enqueue sites:

- `workflow-database-event-trigger.listener.ts` (was 3)
- `workflow-cron-trigger-cron.job.ts` (was 3, two sites)

Updated the specs asserting on the enqueue options. Infra queues keep their retries (webhook delivery, email, event-to-db persistence, SDK client generation, webhook subscription renewal): those jobs are idempotent or duplicate-tolerant and benefit from retrying transient failures.

## Test

- `server-route-trigger.service.spec.ts`, `connection-provider-oauth-flow.service.spec.ts`, `workflow-database-event-trigger.listener.spec.ts`, and `workflow-cron-trigger-cron.job.spec.ts` pass (50 tests)
- `nx lint:diff-with-main twenty-server` and `nx typecheck twenty-server` pass