### PR TITLE
fix(front): hide Add New in relation picker for read-only objects

### DIFF
--- a/packages/twenty-front/src/modules/object-record/record-picker/multiple-record-picker/components/MultipleRecordPicker.tsx
+++ b/packages/twenty-front/src/modules/object-record/record-picker/multiple-record-picker/components/MultipleRecordPicker.tsx
@@ -3,6 +3,7 @@ import { useStore } from 'jotai';
 
 import { useObjectMetadataItems } from '@/object-metadata/hooks/useObjectMetadataItems';
 import { useObjectPermissionsForObject } from '@/object-record/hooks/useObjectPermissionsForObject';
+import { isObjectMetadataReadOnly } from '@/object-record/read-only/utils/isObjectMetadataReadOnly';
 import { canCreateRecordsForObjectMetadataItem } from '@/object-record/utils/canCreateRecordsForObjectMetadataItem';
 import { MultipleRecordPickerItemsDisplay } from '@/object-record/record-picker/multiple-record-picker/components/MultipleRecordPickerItemsDisplay';
 import { MultipleRecordPickerOnClickOutsideEffect } from '@/object-record/record-picker/multiple-record-picker/components/MultipleRecordPickerOnClickOutsideEffect';
@@ -120,6 +121,10 @@ export const MultipleRecordPicker = ({
   const canCreateRecordForCreate =
     isDefined(objectMetadataItemForCreate) &&
     canCreateRecordsForObjectMetadataItem({
+      objectPermissions: objectPermissionsForCreate,
+      objectMetadataItem: objectMetadataItemForCreate,
+    }) &&
+    !isObjectMetadataReadOnly({
       objectPermissions: objectPermissionsForCreate,
       objectMetadataItem: objectMetadataItemForCreate,
     });


### PR DESCRIPTION
## Problem

Fixes #21136. Read-only objects (e.g. Attachment) still exposed an "Add New" action in the multiple-record relation picker. Users could create records through it that were then immediately uneditable in the UI.

## Cause

`MultipleRecordPicker` gated the "Add New" button on create permission only (`canCreateRecordsForObjectMetadataItem`), with no check for whether the target object is read-only/system in the UI.

## Fix

Also require the target object to be editable in the UI before rendering "Add New", reusing the existing `isObjectMetadataReadOnly` helper with the permissions and metadata item the component already resolves:

```tsx
const canCreateRecordForCreate =
  isDefined(objectMetadataItemForCreate) &&
  canCreateRecordsForObjectMetadataItem({ ... }) &&
  !isObjectMetadataReadOnly({
    objectPermissions: objectPermissionsForCreate,
    objectMetadataItem: objectMetadataItemForCreate,
  });
```

`isObjectMetadataReadOnly` returns true for objects that are not UI-editable (system/read-only objects like Attachment), remote objects, or objects without update permission, so "Add New" no longer appears for any of them. This follows the reporter-preferred direction of disabling creation rather than making such records editable.

## Test

- oxlint + oxfmt pass on the changed file
- Type check clean for the changed file

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/23217?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

