### PR TITLE
Rebase schema staleness checks on metadata hashes

### DIFF
--- a/packages/twenty-front/src/modules/apollo/hooks/useApolloFactory.ts
+++ b/packages/twenty-front/src/modules/apollo/hooks/useApolloFactory.ts
@@ -1,5 +1,5 @@
 import { InMemoryCache } from '@apollo/client';
-import { useMemo, useRef } from 'react';
+import { useEffect, useMemo, useRef } from 'react';
 import { useLocation, useNavigate } from 'react-router-dom';
 
 import { ApolloFactory, type Options } from '@/apollo/services/apollo.factory';
@@ -12,8 +12,10 @@ import { returnToPathState } from '@/auth/states/returnToPathState';
 import { isValidReturnToPath } from '@/auth/utils/isValidReturnToPath';
 import { tokenPairState } from '@/auth/states/tokenPairState';
 import { appVersionState } from '@/client-config/states/appVersionState';
+import { metadataStoreState } from '@/metadata-store/states/metadataStoreState';
 import { useSnackBar } from '@/ui/feedback/snack-bar-manager/hooks/useSnackBar';
 import { useAtomState } from '@/ui/utilities/state/jotai/hooks/useAtomState';
+import { useAtomFamilyStateValue } from '@/ui/utilities/state/jotai/hooks/useAtomFamilyStateValue';
 import { useAtomStateValue } from '@/ui/utilities/state/jotai/hooks/useAtomStateValue';
 import { useSetAtomState } from '@/ui/utilities/state/jotai/hooks/useSetAtomState';
 import { AppPath } from 'twenty-shared/types';
@@ -32,6 +34,10 @@ export const useApolloFactory = (options: Partial<Options> = {}) => {
     currentWorkspaceState,
   );
   const appVersion = useAtomStateValue(appVersionState);
+  const { currentCollectionHash: objectMetadataCollectionHash } =
+    useAtomFamilyStateValue(metadataStoreState, 'objectMetadataItems');
+  const { currentCollectionHash: fieldMetadataCollectionHash } =
+    useAtomFamilyStateValue(metadataStoreState, 'fieldMetadataItems');
   const [currentWorkspaceMember, setCurrentWorkspaceMember] = useAtomState(
     currentWorkspaceMemberState,
   );
@@ -138,6 +144,18 @@ export const useApolloFactory = (options: Partial<Options> = {}) => {
       apolloRef.current.updateAppVersion(appVersion);
     }
   }, [appVersion]);
+
+  const metadataHashes =
+    isDefined(objectMetadataCollectionHash) &&
+    isDefined(fieldMetadataCollectionHash)
+      ? `${objectMetadataCollectionHash}.${fieldMetadataCollectionHash}`
+      : undefined;
+
+  useEffect(() => {
+    if (isDefined(apolloRef.current)) {
+      apolloRef.current.updateMetadataHashes(metadataHashes);
+    }
+  }, [metadataHashes]);
 
   return apolloClient;
 };

--- a/packages/twenty-front/src/modules/apollo/hooks/useApolloFactory.ts
+++ b/packages/twenty-front/src/modules/apollo/hooks/useApolloFactory.ts
@@ -72,6 +72,7 @@ export const useApolloFactory = (options: Partial<Options> = {}) => {
       currentWorkspaceMember: currentWorkspaceMember,
       currentWorkspace: currentWorkspace,
       appVersion,
+      metadataHashes,
       onTokenPairChange: (tokenPair) => {
         setTokenPair(tokenPair);
       },

--- a/packages/twenty-front/src/modules/apollo/services/apollo.factory.ts
+++ b/packages/twenty-front/src/modules/apollo/services/apollo.factory.ts
@@ -79,6 +79,7 @@ export interface Options {
   extraLinks?: ApolloLink[];
   isDebugMode?: boolean;
   appVersion?: string;
+  metadataHashes?: string;
 }
 
 export class ApolloFactory implements ApolloManager {
@@ -106,11 +107,13 @@ export class ApolloFactory implements ApolloManager {
       extraLinks,
       isDebugMode,
       appVersion,
+      metadataHashes,
     } = opts;
 
     this.currentWorkspaceMember = currentWorkspaceMember;
     this.currentWorkspace = currentWorkspace;
     this.appVersion = appVersion;
+    this.metadataHashes = metadataHashes;
 
     const buildApolloLink = (): ApolloLink => {
       const uploadLink = new UploadHttpLink({

--- a/packages/twenty-front/src/modules/apollo/services/apollo.factory.ts
+++ b/packages/twenty-front/src/modules/apollo/services/apollo.factory.ts
@@ -86,6 +86,7 @@ export class ApolloFactory implements ApolloManager {
   private currentWorkspaceMember: CurrentWorkspaceMember | null = null;
   private currentWorkspace: CurrentWorkspace | null = null;
   private appVersion?: string;
+  private metadataHashes?: string;
 
   constructor(opts: Options) {
     const {
@@ -147,6 +148,9 @@ export class ApolloFactory implements ApolloManager {
             ...optionHeaders,
             authorization: token ? `Bearer ${token}` : '',
             'x-locale': locale,
+            ...(isDefined(this.metadataHashes) && {
+              'X-Metadata-Hashes': this.metadataHashes,
+            }),
             ...(this.appVersion && { 'X-App-Version': this.appVersion }),
           },
         };
@@ -423,6 +427,10 @@ export class ApolloFactory implements ApolloManager {
 
   updateAppVersion(appVersion?: string) {
     this.appVersion = appVersion;
+  }
+
+  updateMetadataHashes(metadataHashes: string | undefined) {
+    this.metadataHashes = metadataHashes;
   }
 
   getClient() {

--- a/packages/twenty-front/src/modules/metadata-store/hooks/useUpdateMetadataStoreDraft.ts
+++ b/packages/twenty-front/src/modules/metadata-store/hooks/useUpdateMetadataStoreDraft.ts
@@ -71,6 +71,20 @@ export const useUpdateMetadataStoreDraft = () => {
         currentEntry.status === 'up-to-date' &&
         isDeeplyEqual(currentEntry.current, data)
       ) {
+        const deliveredCollectionHash =
+          collectionHash ?? currentEntry.draftCollectionHash;
+
+        if (
+          isDefined(deliveredCollectionHash) &&
+          deliveredCollectionHash !== currentEntry.currentCollectionHash
+        ) {
+          store.set(metadataStoreState.atomFamily(key), (prev) => ({
+            ...prev,
+            currentCollectionHash: deliveredCollectionHash,
+            draftCollectionHash: undefined,
+          }));
+        }
+
         return;
       }
 

--- a/packages/twenty-server/@types/express.d.ts
+++ b/packages/twenty-server/@types/express.d.ts
@@ -19,7 +19,6 @@ declare module 'express-serve-static-core' {
     locale: keyof typeof APP_LOCALES;
     workspace?: FlatWorkspace;
     workspaceId?: string;
-    workspaceMetadataVersion?: number;
     workspaceMemberId?: string;
     workspaceMember?: WorkspaceMemberWorkspaceEntity;
     userWorkspaceId?: string;

--- a/packages/twenty-server/src/engine/api/graphql/admin-panel-graphql-api.module.ts
+++ b/packages/twenty-server/src/engine/api/graphql/admin-panel-graphql-api.module.ts
@@ -9,6 +9,8 @@ import { AdminPanelModule } from 'src/engine/core-modules/admin-panel/admin-pane
 import { ExceptionHandlerService } from 'src/engine/core-modules/exception-handler/exception-handler.service';
 import { I18nModule } from 'src/engine/core-modules/i18n/i18n.module';
 import { I18nService } from 'src/engine/core-modules/i18n/i18n.service';
+import { WorkspaceCacheService } from 'src/engine/workspace-cache/services/workspace-cache.service';
+import { WorkspaceCacheModule } from 'src/engine/workspace-cache/workspace-cache.module';
 import { MetricsModule } from 'src/engine/core-modules/metrics/metrics.module';
 import { MetricsService } from 'src/engine/core-modules/metrics/metrics.service';
 import { TwentyConfigService } from 'src/engine/core-modules/twenty-config/twenty-config.service';
@@ -25,6 +27,7 @@ import { DataloaderService } from 'src/engine/dataloaders/dataloader.service';
         DataloaderModule,
         MetricsModule,
         I18nModule,
+        WorkspaceCacheModule,
       ],
       inject: [
         TwentyConfigService,
@@ -32,6 +35,7 @@ import { DataloaderService } from 'src/engine/dataloaders/dataloader.service';
         DataloaderService,
         MetricsService,
         I18nService,
+        WorkspaceCacheService,
       ],
     }),
     AdminPanelModule,

--- a/packages/twenty-server/src/engine/api/graphql/admin-panel.module-factory.ts
+++ b/packages/twenty-server/src/engine/api/graphql/admin-panel.module-factory.ts
@@ -13,8 +13,10 @@ import { useValidateGraphqlQueryComplexity } from 'src/engine/core-modules/graph
 import { type I18nService } from 'src/engine/core-modules/i18n/i18n.service';
 import { type MetricsService } from 'src/engine/core-modules/metrics/metrics.service';
 import { type TwentyConfigService } from 'src/engine/core-modules/twenty-config/twenty-config.service';
+import { buildSchemaMetadataHashesGetter } from 'src/engine/api/graphql/graphql-config/utils/build-schema-metadata-hashes-getter.util';
 import { type DataloaderService } from 'src/engine/dataloaders/dataloader.service';
 import { renderApolloPlayground } from 'src/engine/utils/render-apollo-playground.util';
+import { type WorkspaceCacheService } from 'src/engine/workspace-cache/services/workspace-cache.service';
 
 export const adminPanelModuleFactory = async (
   twentyConfigService: TwentyConfigService,
@@ -22,6 +24,7 @@ export const adminPanelModuleFactory = async (
   dataloaderService: DataloaderService,
   metricsService: MetricsService,
   i18nService: I18nService,
+  workspaceCacheService: WorkspaceCacheService,
 ): Promise<YogaDriverConfig> => {
   const config: YogaDriverConfig = {
     autoSchemaFile: true,
@@ -39,6 +42,9 @@ export const adminPanelModuleFactory = async (
         exceptionHandlerService,
         i18nService,
         twentyConfigService,
+        schemaMetadataHashesGetter: buildSchemaMetadataHashesGetter(
+          workspaceCacheService,
+        ),
       }),
       useDisableIntrospectionAndSuggestionsForUnauthenticatedUsers(
         twentyConfigService.get('NODE_ENV') === NodeEnvironment.PRODUCTION,

--- a/packages/twenty-server/src/engine/api/graphql/graphql-config/graphql-config.module.ts
+++ b/packages/twenty-server/src/engine/api/graphql/graphql-config/graphql-config.module.ts
@@ -1,11 +1,12 @@
 import { Module } from '@nestjs/common';
 
+import { WorkspaceCacheModule } from 'src/engine/workspace-cache/workspace-cache.module';
 import { DirectExecutionModule } from 'src/engine/api/graphql/direct-execution/direct-execution.module';
 import { CoreEngineModule } from 'src/engine/core-modules/core-engine.module';
 
 @Module({
-  imports: [CoreEngineModule, DirectExecutionModule],
+  imports: [CoreEngineModule, DirectExecutionModule, WorkspaceCacheModule],
   providers: [],
-  exports: [CoreEngineModule, DirectExecutionModule],
+  exports: [CoreEngineModule, DirectExecutionModule, WorkspaceCacheModule],
 })
 export class GraphQLConfigModule {}

--- a/packages/twenty-server/src/engine/api/graphql/graphql-config/graphql-config.service.ts
+++ b/packages/twenty-server/src/engine/api/graphql/graphql-config/graphql-config.service.ts
@@ -19,6 +19,7 @@ import { ExceptionHandlerService } from 'src/engine/core-modules/exception-handl
 import { useSentryTracing } from 'src/engine/core-modules/exception-handler/hooks/use-sentry-tracing';
 import { FeatureFlagService } from 'src/engine/core-modules/feature-flag/services/feature-flag.service';
 import { useDisableIntrospectionAndSuggestionsForUnauthenticatedUsers } from 'src/engine/core-modules/graphql/hooks/use-disable-introspection-and-suggestions-for-unauthenticated-users.hook';
+import { buildSchemaMetadataHashesGetter } from 'src/engine/api/graphql/graphql-config/utils/build-schema-metadata-hashes-getter.util';
 import { useGraphQLErrorHandlerHook } from 'src/engine/core-modules/graphql/hooks/use-graphql-error-handler.hook';
 import { useValidateGraphqlQueryComplexity } from 'src/engine/core-modules/graphql/hooks/use-validate-graphql-query-complexity.hook';
 import { I18nService } from 'src/engine/core-modules/i18n/i18n.service';
@@ -27,6 +28,7 @@ import { TwentyConfigService } from 'src/engine/core-modules/twenty-config/twent
 import { type FlatWorkspace } from 'src/engine/core-modules/workspace/types/flat-workspace.type';
 import { DataloaderService } from 'src/engine/dataloaders/dataloader.service';
 import { renderApolloPlayground } from 'src/engine/utils/render-apollo-playground.util';
+import { WorkspaceCacheService } from 'src/engine/workspace-cache/services/workspace-cache.service';
 
 export interface GraphQLContext extends YogaDriverServerContext<'express'> {
   user?: FlatAuthContextUser;
@@ -46,6 +48,7 @@ export class GraphQLConfigService implements GqlOptionsFactory<
     private readonly i18nService: I18nService,
     private readonly directExecutionService: DirectExecutionService,
     private readonly featureFlagService: FeatureFlagService,
+    private readonly workspaceCacheService: WorkspaceCacheService,
   ) {}
 
   createGqlOptions(): YogaDriverConfig {
@@ -61,6 +64,9 @@ export class GraphQLConfigService implements GqlOptionsFactory<
         exceptionHandlerService: this.exceptionHandlerService,
         i18nService: this.i18nService,
         twentyConfigService: this.twentyConfigService,
+        schemaMetadataHashesGetter: buildSchemaMetadataHashesGetter(
+          this.workspaceCacheService,
+        ),
       }),
       useDisableIntrospectionAndSuggestionsForUnauthenticatedUsers(
         this.twentyConfigService.get('NODE_ENV') === NodeEnvironment.PRODUCTION,

--- a/packages/twenty-server/src/engine/api/graphql/graphql-config/utils/build-schema-metadata-hashes-getter.util.ts
+++ b/packages/twenty-server/src/engine/api/graphql/graphql-config/utils/build-schema-metadata-hashes-getter.util.ts
@@ -1,0 +1,25 @@
+import { isDefined } from 'twenty-shared/utils';
+
+import { type WorkspaceCacheService } from 'src/engine/workspace-cache/services/workspace-cache.service';
+
+const SCHEMA_METADATA_CACHE_DEPENDENCIES = [
+  'flatObjectMetadataMaps',
+  'flatFieldMetadataMaps',
+] as const;
+
+export const buildSchemaMetadataHashesGetter =
+  (workspaceCacheService: WorkspaceCacheService) =>
+  (workspaceId: string): string | undefined => {
+    const localHashes = workspaceCacheService.peekLocalHashes(workspaceId, [
+      ...SCHEMA_METADATA_CACHE_DEPENDENCIES,
+    ]);
+    const orderedHashes = SCHEMA_METADATA_CACHE_DEPENDENCIES.map(
+      (cacheKeyName) => localHashes[cacheKeyName],
+    );
+
+    if (!orderedHashes.every(isDefined)) {
+      return undefined;
+    }
+
+    return orderedHashes.join('.');
+  };

--- a/packages/twenty-server/src/engine/api/graphql/metadata.module-factory.ts
+++ b/packages/twenty-server/src/engine/api/graphql/metadata.module-factory.ts
@@ -5,6 +5,7 @@ import GraphQLJSON from 'graphql-type-json';
 import { NodeEnvironment } from 'src/engine/core-modules/twenty-config/interfaces/node-environment.interface';
 
 import { METADATA_GRAPHQL_OPERATIONS_TO_CACHE } from 'src/engine/api/graphql/graphql-config/constants/metadata-graphql-operations-to-cache.constant';
+import { buildSchemaMetadataHashesGetter } from 'src/engine/api/graphql/graphql-config/utils/build-schema-metadata-hashes-getter.util';
 import { useCachedMetadata } from 'src/engine/api/graphql/graphql-config/hooks/use-cached-metadata';
 import { MetadataGraphQLApiModule } from 'src/engine/api/graphql/metadata-graphql-api.module';
 import { type CacheStorageService } from 'src/engine/core-modules/cache-storage/services/cache-storage.service';
@@ -50,6 +51,9 @@ export const metadataModuleFactory = async (
         exceptionHandlerService,
         i18nService,
         twentyConfigService,
+        schemaMetadataHashesGetter: buildSchemaMetadataHashesGetter(
+          workspaceCacheService,
+        ),
       }),
       useCachedMetadata({
         cacheGetter: cacheStorageService.get.bind(cacheStorageService),

--- a/packages/twenty-server/src/engine/api/mcp/mcp.module.ts
+++ b/packages/twenty-server/src/engine/api/mcp/mcp.module.ts
@@ -15,7 +15,6 @@ import { WorkspaceAuthGuard } from 'src/engine/guards/workspace-auth.guard';
 import { WorkspaceManyOrAllFlatEntityMapsCacheModule } from 'src/engine/metadata-modules/flat-entity/services/workspace-many-or-all-flat-entity-maps-cache.module';
 import { SkillModule } from 'src/engine/metadata-modules/skill/skill.module';
 import { UserRoleModule } from 'src/engine/metadata-modules/user-role/user-role.module';
-import { WorkspaceCacheStorageModule } from 'src/engine/workspace-cache-storage/workspace-cache-storage.module';
 
 import { WorkspaceCacheModule } from 'src/engine/workspace-cache/workspace-cache.module';
 
@@ -24,7 +23,6 @@ import { WorkspaceCacheModule } from 'src/engine/workspace-cache/workspace-cache
     ApiKeyModule,
     MetricsModule,
     TokenModule,
-    WorkspaceCacheStorageModule,
     WorkspaceManyOrAllFlatEntityMapsCacheModule,
     UserRoleModule,
     ToolProviderModule,

--- a/packages/twenty-server/src/engine/api/rest/core/handlers/rest-api-base.handler.ts
+++ b/packages/twenty-server/src/engine/api/rest/core/handlers/rest-api-base.handler.ts
@@ -190,22 +190,6 @@ export abstract class RestApiBaseHandler {
 
     assertIsDefinedOrThrow(workspace, WorkspaceNotFoundDefaultError);
 
-    const currentCacheVersion =
-      await this.workspaceCacheStorageService.getMetadataVersion(workspace.id);
-
-    if (currentCacheVersion === undefined) {
-      if (isDefined(workspace.metadataVersion)) {
-        await this.workspaceCacheStorageService.setMetadataVersion(
-          workspace.id,
-          workspace.metadataVersion,
-        );
-      } else {
-        throw new BadRequestException(
-          'Workspace metadata version not found in database',
-        );
-      }
-    }
-
     const { flatObjectMetadataMaps, flatFieldMetadataMaps, flatIndexMaps } =
       await this.workspaceManyOrAllFlatEntityMapsCacheService.getOrRecomputeManyOrAllFlatEntityMaps(
         {

--- a/packages/twenty-server/src/engine/api/rest/core/handlers/rest-api-base.handler.ts
+++ b/packages/twenty-server/src/engine/api/rest/core/handlers/rest-api-base.handler.ts
@@ -36,7 +36,6 @@ import {
   PermissionsExceptionMessage,
 } from 'src/engine/metadata-modules/permissions/permissions.exception';
 import { UserRoleService } from 'src/engine/metadata-modules/user-role/user-role.service';
-import { WorkspaceCacheStorageService } from 'src/engine/workspace-cache-storage/workspace-cache-storage.service';
 import { WorkspaceCacheService } from 'src/engine/workspace-cache/services/workspace-cache.service';
 import { isApplicationAuthContext } from 'src/engine/core-modules/auth/guards/is-application-auth-context.guard';
 
@@ -60,8 +59,6 @@ export abstract class RestApiBaseHandler {
   protected readonly workspaceCacheService: WorkspaceCacheService;
   @Inject()
   protected readonly actorFromAuthContextService: ActorFromAuthContextService;
-  @Inject()
-  protected readonly workspaceCacheStorageService: WorkspaceCacheStorageService;
   @Inject()
   protected readonly workspaceManyOrAllFlatEntityMapsCacheService: WorkspaceManyOrAllFlatEntityMapsCacheService;
   @Inject()

--- a/packages/twenty-server/src/engine/core-modules/application/connection-provider/connections/application-connections.module.ts
+++ b/packages/twenty-server/src/engine/core-modules/application/connection-provider/connections/application-connections.module.ts
@@ -8,13 +8,12 @@ import { ApplicationConnectionsListService } from 'src/engine/core-modules/appli
 import { TokenModule } from 'src/engine/core-modules/auth/token/token.module';
 import { ConnectedAccountEntity } from 'src/engine/metadata-modules/connected-account/entities/connected-account.entity';
 import { ConnectedAccountTokenEncryptionModule } from 'src/engine/metadata-modules/connected-account/services/connected-account-token-encryption.module';
-import { WorkspaceCacheStorageModule } from 'src/engine/workspace-cache-storage/workspace-cache-storage.module';
 import { RefreshTokensManagerModule } from 'src/modules/connected-account/refresh-tokens-manager/connected-account-refresh-tokens-manager.module';
 
 // Top-level consumer: depends on RefreshTokensManagerModule (which itself
 // imports the engine-side AppOAuthRefreshModule). Kept separate from
-// ConnectionProviderModule to avoid the import cycle. TokenModule +
-// WorkspaceCacheStorageModule are pulled in for the controller's JwtAuthGuard.
+// ConnectionProviderModule to avoid the import cycle. TokenModule is
+// pulled in for the controller's JwtAuthGuard.
 @Module({
   imports: [
     TypeOrmModule.forFeature([
@@ -22,7 +21,6 @@ import { RefreshTokensManagerModule } from 'src/modules/connected-account/refres
       ConnectionProviderEntity,
     ]),
     TokenModule,
-    WorkspaceCacheStorageModule,
     RefreshTokensManagerModule,
     ConnectedAccountTokenEncryptionModule,
   ],

--- a/packages/twenty-server/src/engine/core-modules/auth/strategies/google.auth.strategy.ts
+++ b/packages/twenty-server/src/engine/core-modules/auth/strategies/google.auth.strategy.ts
@@ -18,10 +18,7 @@ import { type SocialSSOSignInUpActionType } from 'src/engine/core-modules/auth/t
 import { type SocialSSOState } from 'src/engine/core-modules/auth/types/social-sso-state.type';
 import { TwentyConfigService } from 'src/engine/core-modules/twenty-config/twenty-config.service';
 
-export type GoogleRequest = Omit<
-  Request,
-  'user' | 'workspace' | 'workspaceMetadataVersion'
-> & {
+export type GoogleRequest = Omit<Request, 'user' | 'workspace'> & {
   user: {
     firstName?: string | null;
     lastName?: string | null;

--- a/packages/twenty-server/src/engine/core-modules/auth/strategies/microsoft.auth.strategy.ts
+++ b/packages/twenty-server/src/engine/core-modules/auth/strategies/microsoft.auth.strategy.ts
@@ -16,10 +16,7 @@ import { type SocialSSOSignInUpActionType } from 'src/engine/core-modules/auth/t
 import { type SocialSSOState } from 'src/engine/core-modules/auth/types/social-sso-state.type';
 import { type TwentyConfigService } from 'src/engine/core-modules/twenty-config/twenty-config.service';
 
-export type MicrosoftRequest = Omit<
-  Request,
-  'user' | 'workspace' | 'workspaceMetadataVersion'
-> & {
+export type MicrosoftRequest = Omit<Request, 'user' | 'workspace'> & {
   user: {
     firstName?: string | null;
     lastName?: string | null;

--- a/packages/twenty-server/src/engine/core-modules/auth/strategies/oidc.auth.strategy.ts
+++ b/packages/twenty-server/src/engine/core-modules/auth/strategies/oidc.auth.strategy.ts
@@ -11,10 +11,7 @@ import {
   AuthExceptionCode,
 } from 'src/engine/core-modules/auth/auth.exception';
 
-export type OIDCRequest = Omit<
-  Request,
-  'user' | 'workspace' | 'workspaceMetadataVersion'
-> & {
+export type OIDCRequest = Omit<Request, 'user' | 'workspace'> & {
   user: {
     identityProviderId: string;
     email: string;

--- a/packages/twenty-server/src/engine/core-modules/auth/strategies/saml.auth.strategy.ts
+++ b/packages/twenty-server/src/engine/core-modules/auth/strategies/saml.auth.strategy.ts
@@ -39,10 +39,7 @@ const RELAY_STATE_BODY_SCHEMA = z.object({
     .pipe(WORKSPACE_INVITE_HASH_PAYLOAD_SCHEMA),
 });
 
-export type SAMLRequest = Omit<
-  Request,
-  'user' | 'workspace' | 'workspaceMetadataVersion'
-> & {
+export type SAMLRequest = Omit<Request, 'user' | 'workspace'> & {
   user: {
     identityProviderId: string;
     workspaceInviteHash?: string;

--- a/packages/twenty-server/src/engine/core-modules/auth/types/apis-oauth-request.type.ts
+++ b/packages/twenty-server/src/engine/core-modules/auth/types/apis-oauth-request.type.ts
@@ -7,10 +7,7 @@ import {
 
 import { type PlaintextString } from 'src/engine/core-modules/secret-encryption/branded-strings/plaintext-string.type';
 
-export type APIsOAuthRequest = Omit<
-  Request,
-  'user' | 'workspace' | 'workspaceMetadataVersion'
-> & {
+export type APIsOAuthRequest = Omit<Request, 'user' | 'workspace'> & {
   user: {
     firstName?: string | null;
     lastName?: string | null;

--- a/packages/twenty-server/src/engine/core-modules/graphql/hooks/use-graphql-error-handler.hook.ts
+++ b/packages/twenty-server/src/engine/core-modules/graphql/hooks/use-graphql-error-handler.hook.ts
@@ -35,7 +35,7 @@ import {
 import { translateUserFriendlyMessageDescriptors } from 'src/engine/core-modules/i18n/utils/translate-user-friendly-message-descriptors.util';
 
 const DEFAULT_EVENT_ID_KEY = 'exceptionEventId';
-const SCHEMA_VERSION_HEADER = 'x-schema-version';
+const METADATA_HASHES_HEADER = 'x-metadata-hashes';
 const SCHEMA_MISMATCH_ERROR = 'Schema version mismatch.';
 const APP_VERSION_HEADER = 'x-app-version';
 const APP_VERSION_MISMATCH_ERROR = 'App version mismatch.';
@@ -52,6 +52,8 @@ type GraphQLErrorHandlerHookOptions = {
   i18nService: I18nService;
 
   twentyConfigService: TwentyConfigService;
+
+  schemaMetadataHashesGetter: (workspaceId: string) => string | undefined;
   /**
    * The key of the event id in the error's extension. `null` to disable.
    * @default exceptionEventId
@@ -267,8 +269,14 @@ export const useGraphQLErrorHandlerHook = <
 
       if (Array.isArray(errors) && errors.length > 0) {
         const headers = context.req.headers;
-        const currentMetadataVersion = context.req.workspaceMetadataVersion;
-        const requestMetadataVersion = headers[SCHEMA_VERSION_HEADER];
+        const metadataHashesHeaderValue = headers[METADATA_HASHES_HEADER];
+        const requestMetadataHashes = Array.isArray(metadataHashesHeaderValue)
+          ? metadataHashesHeaderValue[0]
+          : metadataHashesHeaderValue;
+        const workspaceId = context.req.workspace?.id;
+        const currentMetadataHashes = isDefined(workspaceId)
+          ? options.schemaMetadataHashesGetter(workspaceId)
+          : undefined;
         const backendAppVersion =
           options.twentyConfigService.get('APP_VERSION');
         const appVersionHeaderValue = headers[APP_VERSION_HEADER];
@@ -278,12 +286,12 @@ export const useGraphQLErrorHandlerHook = <
             : appVersionHeaderValue;
 
         if (
-          requestMetadataVersion &&
-          isDefined(currentMetadataVersion) &&
-          requestMetadataVersion !== `${currentMetadataVersion}`
+          isDefined(requestMetadataHashes) &&
+          isDefined(currentMetadataHashes) &&
+          requestMetadataHashes !== currentMetadataHashes
         ) {
           void options.metricsService.incrementCounterForEvent({
-            key: MetricsKeys.SchemaVersionMismatch,
+            key: MetricsKeys.MetadataHashMismatch,
           });
 
           throw new GraphQLError(SCHEMA_MISMATCH_ERROR, {

--- a/packages/twenty-server/src/engine/core-modules/metrics/types/metrics-keys.type.ts
+++ b/packages/twenty-server/src/engine/core-modules/metrics/types/metrics-keys.type.ts
@@ -44,7 +44,7 @@ export enum MetricsKeys {
   AiChatOutputTokens = 'ai-chat/output-tokens',
   AiChatCacheReadTokens = 'ai-chat/cache-read-tokens',
   AiChatCacheWriteTokens = 'ai-chat/cache-write-tokens',
-  SchemaVersionMismatch = 'schema-version/mismatch',
+  MetadataHashMismatch = 'metadata-hash/mismatch',
   AppVersionMismatch = 'app-version/mismatch',
   AppInstallSucceeded = 'app-install/succeeded',
   AppInstallFailed = 'app-install/failed',

--- a/packages/twenty-server/src/engine/guards/jwt-auth.guard.ts
+++ b/packages/twenty-server/src/engine/guards/jwt-auth.guard.ts
@@ -9,16 +9,12 @@ import { isDefined } from 'twenty-shared/utils';
 
 import { AccessTokenService } from 'src/engine/core-modules/auth/token/services/access-token.service';
 import { bindDataToRequestObject } from 'src/engine/utils/bind-data-to-request-object.util';
-import { WorkspaceCacheStorageService } from 'src/engine/workspace-cache-storage/workspace-cache-storage.service';
 
 @Injectable()
 export class JwtAuthGuard implements CanActivate {
   private readonly logger = new Logger(JwtAuthGuard.name);
 
-  constructor(
-    private readonly accessTokenService: AccessTokenService,
-    private readonly workspaceStorageCacheService: WorkspaceCacheStorageService,
-  ) {}
+  constructor(private readonly accessTokenService: AccessTokenService) {}
 
   async canActivate(context: ExecutionContext): Promise<boolean> {
     const request = context.switchToHttp().getRequest();
@@ -26,11 +22,6 @@ export class JwtAuthGuard implements CanActivate {
     try {
       const data =
         await this.accessTokenService.validateTokenByRequest(request);
-      const metadataVersion = data.workspace
-        ? await this.workspaceStorageCacheService.getMetadataVersion(
-            data.workspace.id,
-          )
-        : undefined;
 
       if (
         !isDefined(data.apiKey) &&
@@ -44,7 +35,7 @@ export class JwtAuthGuard implements CanActivate {
         return false;
       }
 
-      bindDataToRequestObject(data, request, metadataVersion);
+      bindDataToRequestObject(data, request);
 
       return true;
     } catch (error) {

--- a/packages/twenty-server/src/engine/metadata-modules/workspace-metadata-version/services/workspace-metadata-version.service.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/workspace-metadata-version/services/workspace-metadata-version.service.ts
@@ -4,13 +4,11 @@ import { InjectRepository } from '@nestjs/typeorm';
 import { isDefined } from 'twenty-shared/utils';
 import { Repository } from 'typeorm';
 
-import { CoreEntityCacheService } from 'src/engine/core-entity-cache/services/core-entity-cache.service';
 import { WorkspaceEntity } from 'src/engine/core-modules/workspace/workspace.entity';
 import {
   WorkspaceMetadataVersionException,
   WorkspaceMetadataVersionExceptionCode,
 } from 'src/engine/metadata-modules/workspace-metadata-version/exceptions/workspace-metadata-version.exception';
-import { WorkspaceCacheStorageService } from 'src/engine/workspace-cache-storage/workspace-cache-storage.service';
 
 @Injectable()
 export class WorkspaceMetadataVersionService {
@@ -19,8 +17,6 @@ export class WorkspaceMetadataVersionService {
   constructor(
     @InjectRepository(WorkspaceEntity)
     private readonly workspaceRepository: Repository<WorkspaceEntity>,
-    private readonly workspaceCacheStorageService: WorkspaceCacheStorageService,
-    private readonly coreEntityCacheService: CoreEntityCacheService,
   ) {}
 
   async incrementMetadataVersion(workspaceId: string): Promise<void> {
@@ -44,16 +40,6 @@ export class WorkspaceMetadataVersionService {
     await this.workspaceRepository.update(
       { id: workspaceId },
       { metadataVersion: newMetadataVersion },
-    );
-
-    await this.workspaceCacheStorageService.setMetadataVersion(
-      workspaceId,
-      newMetadataVersion,
-    );
-
-    await this.coreEntityCacheService.invalidate(
-      'workspaceEntity',
-      workspaceId,
     );
   }
 }

--- a/packages/twenty-server/src/engine/metadata-modules/workspace-metadata-version/workspace-metadata-version.module.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/workspace-metadata-version/workspace-metadata-version.module.ts
@@ -1,17 +1,13 @@
 import { Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
 
-import { CoreEntityCacheModule } from 'src/engine/core-entity-cache/core-entity-cache.module';
 import { WorkspaceEntity } from 'src/engine/core-modules/workspace/workspace.entity';
 import { WorkspaceManyOrAllFlatEntityMapsCacheModule } from 'src/engine/metadata-modules/flat-entity/services/workspace-many-or-all-flat-entity-maps-cache.module';
 import { WorkspaceMetadataVersionService } from 'src/engine/metadata-modules/workspace-metadata-version/services/workspace-metadata-version.service';
-import { WorkspaceCacheStorageModule } from 'src/engine/workspace-cache-storage/workspace-cache-storage.module';
 
 @Module({
   imports: [
     TypeOrmModule.forFeature([WorkspaceEntity]),
-    CoreEntityCacheModule,
-    WorkspaceCacheStorageModule,
     WorkspaceManyOrAllFlatEntityMapsCacheModule,
   ],
   exports: [WorkspaceMetadataVersionService],

--- a/packages/twenty-server/src/engine/middlewares/middleware.module.ts
+++ b/packages/twenty-server/src/engine/middlewares/middleware.module.ts
@@ -4,11 +4,9 @@ import { TokenModule } from 'src/engine/core-modules/auth/token/token.module';
 import { JwtModule } from 'src/engine/core-modules/jwt/jwt.module';
 import { WorkspaceManyOrAllFlatEntityMapsCacheModule } from 'src/engine/metadata-modules/flat-entity/services/workspace-many-or-all-flat-entity-maps-cache.module';
 import { MiddlewareService } from 'src/engine/middlewares/middleware.service';
-import { WorkspaceCacheStorageModule } from 'src/engine/workspace-cache-storage/workspace-cache-storage.module';
 
 @Module({
   imports: [
-    WorkspaceCacheStorageModule,
     WorkspaceManyOrAllFlatEntityMapsCacheModule,
     TokenModule,
     JwtModule,

--- a/packages/twenty-server/src/engine/middlewares/middleware.service.ts
+++ b/packages/twenty-server/src/engine/middlewares/middleware.service.ts
@@ -12,7 +12,6 @@ import { getAuthExceptionRestStatus } from 'src/engine/core-modules/auth/utils/g
 import { ExceptionHandlerService } from 'src/engine/core-modules/exception-handler/exception-handler.service';
 import { ErrorCode } from 'src/engine/core-modules/graphql/utils/graphql-errors.util';
 import { JwtWrapperService } from 'src/engine/core-modules/jwt/services/jwt-wrapper.service';
-import { type FlatWorkspace } from 'src/engine/core-modules/workspace/types/flat-workspace.type';
 import { WorkspaceManyOrAllFlatEntityMapsCacheService } from 'src/engine/metadata-modules/flat-entity/services/workspace-many-or-all-flat-entity-maps-cache.service';
 import { INTERNAL_SERVER_ERROR } from 'src/engine/middlewares/constants/default-error-message.constant';
 import { bindDataToRequestObject } from 'src/engine/utils/bind-data-to-request-object.util';
@@ -20,14 +19,12 @@ import {
   handleException,
   handleExceptionAndConvertToGraphQLError,
 } from 'src/engine/utils/global-exception-handler.util';
-import { WorkspaceCacheStorageService } from 'src/engine/workspace-cache-storage/workspace-cache-storage.service';
 import { type CustomException } from 'src/utils/custom-exception';
 
 @Injectable()
 export class MiddlewareService {
   constructor(
     private readonly accessTokenService: AccessTokenService,
-    private readonly workspaceStorageCacheService: WorkspaceCacheStorageService,
     private readonly flatEntityMapsCacheService: WorkspaceManyOrAllFlatEntityMapsCacheService,
     private readonly exceptionHandlerService: ExceptionHandlerService,
     private readonly jwtWrapperService: JwtWrapperService,
@@ -100,9 +97,6 @@ export class MiddlewareService {
 
   public async hydrateRestRequest(request: Request) {
     const data = await this.accessTokenService.validateTokenByRequest(request);
-    const metadataVersion = data.workspace
-      ? await this.getOrSeedMetadataVersion(data.workspace)
-      : undefined;
 
     if (!data.workspace) {
       throw new Error('No data sources found');
@@ -112,7 +106,7 @@ export class MiddlewareService {
       throw new Error('No data sources found');
     }
 
-    bindDataToRequestObject(data, request, metadataVersion);
+    bindDataToRequestObject(data, request);
   }
 
   public async hydrateGraphqlRequest(request: Request) {
@@ -125,31 +119,8 @@ export class MiddlewareService {
     }
 
     const data = await this.accessTokenService.validateTokenByRequest(request);
-    const metadataVersion = data.workspace
-      ? await this.getOrSeedMetadataVersion(data.workspace)
-      : undefined;
 
-    bindDataToRequestObject(data, request, metadataVersion);
-  }
-
-  private async getOrSeedMetadataVersion(
-    workspace: Pick<FlatWorkspace, 'id' | 'metadataVersion'>,
-  ): Promise<number | undefined> {
-    const cachedMetadataVersion =
-      await this.workspaceStorageCacheService.getMetadataVersion(workspace.id);
-
-    if (isDefined(cachedMetadataVersion)) {
-      return cachedMetadataVersion;
-    }
-
-    if (isDefined(workspace.metadataVersion)) {
-      await this.workspaceStorageCacheService.setMetadataVersion(
-        workspace.id,
-        workspace.metadataVersion,
-      );
-    }
-
-    return workspace.metadataVersion;
+    bindDataToRequestObject(data, request);
   }
 
   private hasErrorStatus(error: unknown): error is { status: number } {

--- a/packages/twenty-server/src/engine/utils/bind-data-to-request-object.util.ts
+++ b/packages/twenty-server/src/engine/utils/bind-data-to-request-object.util.ts
@@ -6,7 +6,6 @@ import { type RawAuthContext } from 'src/engine/core-modules/auth/types/raw-auth
 export const bindDataToRequestObject = (
   data: RawAuthContext,
   request: Request,
-  metadataVersion: number | undefined,
 ) => {
   request.user = data.user;
   request.apiKey = data.apiKey;
@@ -14,7 +13,6 @@ export const bindDataToRequestObject = (
   request.userWorkspace = data.userWorkspace;
   request.workspace = data.workspace;
   request.workspaceId = data.workspace?.id;
-  request.workspaceMetadataVersion = metadataVersion;
   request.workspaceMemberId = data.workspaceMemberId;
   request.workspaceMember = data.workspaceMember;
   request.userWorkspaceId = data.userWorkspaceId;

--- a/packages/twenty-server/src/engine/workspace-cache-storage/workspace-cache-storage.service.ts
+++ b/packages/twenty-server/src/engine/workspace-cache-storage/workspace-cache-storage.service.ts
@@ -13,7 +13,6 @@ export const HASH_KEYED_WORKSPACE_CACHE_KEYS = {
   GraphQLUsedScalarNames: 'graphql:used-scalar-names',
 } as const;
 export const WORKSPACE_CACHE_KEYS = {
-  MetadataVersion: 'metadata:workspace-metadata-version',
   GraphQLOperations: 'graphql:operations',
   GraphQLFeatureFlag: 'graphql:feature-flag',
   FeatureFlagMap: 'feature-flag:feature-flag-map',
@@ -38,23 +37,6 @@ export class WorkspaceCacheStorageService {
     @InjectCacheStorage(CacheStorageNamespace.EngineWorkspace)
     private readonly cacheStorageService: CacheStorageService,
   ) {}
-
-  setMetadataVersion(
-    workspaceId: string,
-    metadataVersion: number,
-  ): Promise<void> {
-    return this.cacheStorageService.set<number>(
-      `${WORKSPACE_CACHE_KEYS.MetadataVersion}:${workspaceId}`,
-      metadataVersion,
-      TTL_ONE_WEEK,
-    );
-  }
-
-  getMetadataVersion(workspaceId: string): Promise<number | undefined> {
-    return this.cacheStorageService.get<number>(
-      `${WORKSPACE_CACHE_KEYS.MetadataVersion}:${workspaceId}`,
-    );
-  }
 
   setGraphQLTypeDefs(
     workspaceId: string,

--- a/packages/twenty-server/src/engine/workspace-cache/services/workspace-cache.service.ts
+++ b/packages/twenty-server/src/engine/workspace-cache/services/workspace-cache.service.ts
@@ -41,6 +41,7 @@ const STALE_VERSION_TTL_MS = 5_000; // 5 seconds
 const MAX_LOCAL_STALE_VERSIONS = 5; // 5 stale versions
 // Sized against 4 GiB pods (--max-old-space-size=3500): 7,500 sat at the heap ceiling
 const MAX_LOCAL_CACHE_ENTRIES = 6_000;
+const PEEK_LOCAL_HASHES_MAX_AGE_MS = 10_000;
 const MIN_EVICT_KEYS = 100;
 
 type CacheDataType = WorkspaceCacheDataMap[WorkspaceCacheKeyName];
@@ -212,7 +213,11 @@ export class WorkspaceCacheService implements OnModuleInit {
         this.buildCacheKey(workspaceId, cacheKeyName),
       );
 
-      if (isDefined(entry) && entry.latestHash !== '') {
+      if (
+        isDefined(entry) &&
+        entry.latestHash !== '' &&
+        Date.now() - entry.lastHashCheckedAt < PEEK_LOCAL_HASHES_MAX_AGE_MS
+      ) {
         hashes[cacheKeyName] = entry.latestHash;
       }
     }

--- a/packages/twenty-server/src/engine/workspace-cache/services/workspace-cache.service.ts
+++ b/packages/twenty-server/src/engine/workspace-cache/services/workspace-cache.service.ts
@@ -201,6 +201,25 @@ export class WorkspaceCacheService implements OnModuleInit {
     return result as WorkspaceCacheResultWithHashes<K>;
   }
 
+  public peekLocalHashes(
+    workspaceId: string,
+    cacheKeyNames: WorkspaceCacheKeyName[],
+  ): Partial<Record<WorkspaceCacheKeyName, string>> {
+    const hashes: Partial<Record<WorkspaceCacheKeyName, string>> = {};
+
+    for (const cacheKeyName of cacheKeyNames) {
+      const entry = this.localCache.get(
+        this.buildCacheKey(workspaceId, cacheKeyName),
+      );
+
+      if (isDefined(entry) && entry.latestHash !== '') {
+        hashes[cacheKeyName] = entry.latestHash;
+      }
+    }
+
+    return hashes;
+  }
+
   public async getOrRecomputeCombinedHash(
     workspaceId: string,
     cacheKeyNames: WorkspaceCacheKeyName[],


### PR DESCRIPTION
## Summary
- Replace workspace metadata-version checks with object and field metadata hashes
- Send metadata hashes from Apollo clients and validate them in GraphQL requests
- Remove legacy metadata-version cache and request handling
- Track metadata hash mismatches with updated metrics


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/23218?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

