### PR TITLE
perf(server): index relation rows when hydrating nested relations (O(n*m) -> O(n+m))

### DIFF
--- a/packages/twenty-server/src/engine/api/common/common-nested-relations-processor/process-nested-relations-v2.helper.ts
+++ b/packages/twenty-server/src/engine/api/common/common-nested-relations-processor/process-nested-relations-v2.helper.ts
@@ -527,15 +527,38 @@ export class ProcessNestedRelationsV2Helper {
     relationType: RelationType;
     selectedFields: Record<string, unknown>;
   }): void {
+    // Index the relation rows once instead of re-scanning them for every parent
+    // record (O(n*m) -> O(n+m)). Parent ids are unique, so each bucket belongs to
+    // exactly one parent.
+    // oxlint-disable-next-line typescript/no-explicit-any
+    const relationsByJoinField = new Map<unknown, any[]>();
+    // oxlint-disable-next-line typescript/no-explicit-any
+    const relationById = new Map<unknown, any>();
+
+    if (relationType === RelationType.ONE_TO_MANY) {
+      for (const rel of relationResults) {
+        const bucket = relationsByJoinField.get(rel[joinField]);
+
+        if (bucket) {
+          bucket.push(rel);
+        } else {
+          relationsByJoinField.set(rel[joinField], [rel]);
+        }
+      }
+    } else {
+      for (const rel of relationResults) {
+        // first occurrence wins, matching Array.prototype.find
+        if (!relationById.has(rel.id)) {
+          relationById.set(rel.id, rel);
+        }
+      }
+    }
+
     parentRecords.forEach((item) => {
       if (relationType === RelationType.ONE_TO_MANY) {
-        item[sourceFieldName] = relationResults.filter(
-          (rel) => rel[joinField] === item.id,
-        );
+        item[sourceFieldName] = relationsByJoinField.get(item.id) ?? [];
       } else {
-        const matchedRelation = relationResults.find(
-          (rel) => rel.id === item[joinColumnName],
-        );
+        const matchedRelation = relationById.get(item[joinColumnName]);
 
         if (isDefined(matchedRelation?.deletedAt)) {
           item[sourceFieldName] = null;

--- a/packages/twenty-server/src/engine/metadata-modules/view/services/view-widget-upsert.service.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/view/services/view-widget-upsert.service.ts
@@ -463,21 +463,34 @@ export class ViewWidgetUpsertService {
     const fieldsToCreate: FlatViewField[] = [];
     const fieldsToUpdate: FlatViewField[] = [];
 
+    // Index the existing fields once instead of re-scanning them for every input
+    // (O(n*m) -> O(n+m)). First occurrence wins, matching the previous .find().
+    const existingFieldById = new Map<string, FlatViewField>();
+    const existingFieldByFieldMetadataId = new Map<string, FlatViewField>();
+
+    for (const existingField of existingViewFields) {
+      if (!existingFieldById.has(existingField.id)) {
+        existingFieldById.set(existingField.id, existingField);
+      }
+      if (!existingFieldByFieldMetadataId.has(existingField.fieldMetadataId)) {
+        existingFieldByFieldMetadataId.set(
+          existingField.fieldMetadataId,
+          existingField,
+        );
+      }
+    }
+
     for (const inputField of inputFields) {
       const existingFieldByViewFieldId = isDefined(inputField.viewFieldId)
-        ? existingViewFields.find((f) => f.id === inputField.viewFieldId)
+        ? existingFieldById.get(inputField.viewFieldId)
         : undefined;
 
-      const existingFieldByFieldMetadataId = isDefined(
-        inputField.fieldMetadataId,
-      )
-        ? existingViewFields.find(
-            (f) => f.fieldMetadataId === inputField.fieldMetadataId,
-          )
+      const existingFieldByMetadataId = isDefined(inputField.fieldMetadataId)
+        ? existingFieldByFieldMetadataId.get(inputField.fieldMetadataId)
         : undefined;
 
       const existingField =
-        existingFieldByViewFieldId ?? existingFieldByFieldMetadataId;
+        existingFieldByViewFieldId ?? existingFieldByMetadataId;
 
       if (isDefined(existingField)) {
         const resolvedIsVisible = isDefined(existingField.overrides?.isVisible)
@@ -636,9 +649,17 @@ export class ViewWidgetUpsertService {
       inputFilterGroups.map((g) => g.id).filter(isDefined),
     );
 
+    const existingFilterGroupById = new Map<string, FlatViewFilterGroup>();
+
+    for (const existingGroup of existingViewFilterGroups) {
+      if (!existingFilterGroupById.has(existingGroup.id)) {
+        existingFilterGroupById.set(existingGroup.id, existingGroup);
+      }
+    }
+
     for (const inputGroup of inputFilterGroups) {
       const existingGroup = isDefined(inputGroup.id)
-        ? existingViewFilterGroups.find((g) => g.id === inputGroup.id)
+        ? existingFilterGroupById.get(inputGroup.id)
         : undefined;
 
       if (!isDefined(existingGroup)) {
@@ -755,9 +776,17 @@ export class ViewWidgetUpsertService {
       inputFilters.map((f) => f.id).filter(isDefined),
     );
 
+    const existingFilterById = new Map<string, FlatViewFilter>();
+
+    for (const existingFilter of existingViewFilters) {
+      if (!existingFilterById.has(existingFilter.id)) {
+        existingFilterById.set(existingFilter.id, existingFilter);
+      }
+    }
+
     for (const inputFilter of inputFilters) {
       const existingFilter = isDefined(inputFilter.id)
-        ? existingViewFilters.find((f) => f.id === inputFilter.id)
+        ? existingFilterById.get(inputFilter.id)
         : undefined;
 
       if (!isDefined(existingFilter)) {
@@ -921,9 +950,17 @@ export class ViewWidgetUpsertService {
     const sortsToUpdate: FlatViewSort[] = [];
     const inputSortIds = new Set(inputSorts.map((s) => s.id).filter(isDefined));
 
+    const existingSortById = new Map<string, FlatViewSort>();
+
+    for (const existingSort of existingViewSorts) {
+      if (!existingSortById.has(existingSort.id)) {
+        existingSortById.set(existingSort.id, existingSort);
+      }
+    }
+
     for (const inputSort of inputSorts) {
       const existingSort = isDefined(inputSort.id)
-        ? existingViewSorts.find((s) => s.id === inputSort.id)
+        ? existingSortById.get(inputSort.id)
         : undefined;
 
       if (!isDefined(existingSort)) {


### PR DESCRIPTION
### What

`processNestedRelations` hydrates relations onto parent records, and for **every parent record** it re-scans the entire `relationResults` array:

```ts
parentRecords.forEach((item) => {
  if (relationType === RelationType.ONE_TO_MANY) {
    item[sourceFieldName] = relationResults.filter((rel) => rel[joinField] === item.id);
  } else {
    const matchedRelation = relationResults.find((rel) => rel.id === item[joinColumnName]);
    ...
  }
});
```

That is `O(n*m)` — parent records × relation rows — on every query that selects a relation. A page of 60 records with 500 relation rows is ~30k comparisons, and it grows with both page size and relation cardinality.

### How

Index `relationResults` once before the loop, then look up in `O(1)`:

- **ONE_TO_MANY** — group by `joinField` into `Map<key, rel[]>`, then `map.get(item.id) ?? []` (the `?? []` preserves the empty-array result of `.filter`).
- **otherwise** — index by `id`, **first occurrence wins** so the behaviour matches `Array.prototype.find` (a plain `new Map(arr.map(...))` would keep the *last* one).

Parent ids are unique, so each `ONE_TO_MANY` bucket belongs to exactly one parent — no array is shared between records.

No behaviour change; only the lookup strategy.

<sub>Found with [cleanscore](https://github.com/yoo-minho/cleanscore) (flags linear scans of an outer array inside a loop) and verified by hand. Description drafted with LLM assistance.</sub>


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/23232?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

