### PR TITLE
Let server route resolvers answer the caller synchronously

### DIFF
--- a/packages/twenty-docs/developers/extend/apps/logic/logic-functions.mdx
+++ b/packages/twenty-docs/developers/extend/apps/logic/logic-functions.mdx
@@ -188,7 +188,7 @@ The trigger has two parts:
 ```ts src/logic-functions/resolve-server-route.logic-function.ts
 import { createHmac, timingSafeEqual } from 'crypto';
 import { defineLogicFunction } from 'twenty-sdk/define';
-import type { RoutePayload } from 'twenty-sdk/logic-function';
+import { Response, type RoutePayload } from 'twenty-sdk/logic-function';
 
 // Runs in the owner workspace. Verifies the request signature, picks
 // which target function should handle the event, and returns the
@@ -215,12 +215,25 @@ const handler = async (event: RoutePayload) => {
   }
 
   const body = (event.body ?? {}) as {
+    challenge?: string;
     metadata?: { twentyWorkspaceId?: string };
     type?: string;
   };
 
+  // Handshakes must be answered on this same response, so reply from the
+  // resolver instead of returning a dispatch target.
+  if (body.type === 'url_verification') {
+    return new Response({ challenge: body.challenge });
+  }
+
+  const workspaceId = body.metadata?.twentyWorkspaceId;
+
+  if (!workspaceId) {
+    throw new Error('event is not linked to a workspace');
+  }
+
   return {
-    workspaceId: body.metadata?.twentyWorkspaceId ?? '',
+    workspaceId,
     // Route different event types to different target functions.
     targetLogicFunctionUniversalIdentifier:
       body.type === 'invoice.paid'
@@ -269,13 +282,13 @@ The identifier is the resolver's `universalIdentifier` from your manifest. Regis
 **The application must be claimed and installed on its owner workspace.** Because the resolver runs in the **owner workspace** (the workspace that owns the application registration), a server route trigger only works once the application has been *claimed* — i.e. it has an owner workspace — **and** that application is **installed on the owner workspace**. Until both are true the resolver has nowhere to run, so the route cannot be dispatched. An application that exposes a `serverRouteTriggerSettings` logic function therefore cannot be listed in the marketplace until it is claimed and installed on its owner workspace.
 </Note>
 
-**Resolver contract.** The SDK's `LogicFunctionConfig` type enforces this at compile time: as soon as you set `serverRouteTriggerSettings`, your handler is constrained to return either a `Response`, or `{ workspaceId: string; targetLogicFunctionUniversalIdentifier: string; payload?: object }` (or a `Promise` of either). On the dispatch path, the `workspaceId` must be a workspace where the target function is installed, otherwise the request is rejected with `404`.
+**Resolver contract.** The SDK's `LogicFunctionConfig` type enforces this at compile time: as soon as you set `serverRouteTriggerSettings`, your handler is constrained to return either a `Response`, or `{ workspaceId: string; targetLogicFunctionUniversalIdentifier: string; payload?: object }` (or a `Promise` of either). On the dispatch path, both identifiers must be UUIDs and the `workspaceId` must be a workspace where the target function is installed, otherwise the request is rejected with `404`. A result that matches neither shape is rejected with `502`.
 
 | Field | Type | Notes |
 |-------|------|-------|
 | `workspaceId` | `string` | Workspace UUID where the target will run. |
 | `targetLogicFunctionUniversalIdentifier` | `string` | `universalIdentifier` of the logic function to invoke in that workspace. |
-| `payload` | `object` (optional) | If set, replaces the request body sent to the target. |
+| `payload` | `object` (optional) | If set, replaces the request body sent to the target. Must be a JSON object. |
 
 <Warning>
 **Signature verification is your responsibility — verify in the resolver.** The platform does not verify request signatures. The resolver is the recommended place to do it: it runs first, with access to `event.rawBody` and the headers you listed in `forwardedRequestHeaders`, and a thrown error (or any non-matching `workspaceId`) stops the dispatch before the target is invoked. If you instead push verification down into the target, the target must be careful not to lose `rawBody` and headers — i.e. the resolver must not return a `payload`. Always verify **before** any side effect and use a constant-time comparison.
@@ -296,7 +309,7 @@ The resolver example above already shows the GitHub HMAC-SHA256 flow — adapt t
 <Note>
 When the resolver returns a dispatch object, the route responds `202 { queued: true }` and the target runs on the worker queue — the caller never observes the target's latency, result, or failures (those are recorded in execution logs). This keeps sender redeliveries from amplifying processing slowdowns, which is what you want for webhook ingestion.
 
-When the caller must read the response body on the same request (challenge handshakes, interactive acknowledgements), return a `Response` from the **resolver** instead. The platform echoes it synchronously and skips the queue. Keep the resolver fast — some providers (e.g. Slack) time out in a few seconds. Because the resolver is reachable as a public endpoint, protect it with rate limiting at your edge.
+When the caller must read the response body on the same request (challenge handshakes, interactive acknowledgements), return a `Response` from the **resolver** instead. The platform echoes it synchronously and skips the queue; its headers go through the same allow-list as HTTP route responses. Keep the resolver fast — some providers (e.g. Slack) time out in a few seconds. Because the resolver is reachable as a public endpoint, protect it with rate limiting at your edge.
 </Note>
 
 #### Database event trigger payload

--- a/packages/twenty-docs/developers/extend/apps/logic/logic-functions.mdx
+++ b/packages/twenty-docs/developers/extend/apps/logic/logic-functions.mdx
@@ -282,13 +282,13 @@ The identifier is the resolver's `universalIdentifier` from your manifest. Regis
 **The application must be claimed and installed on its owner workspace.** Because the resolver runs in the **owner workspace** (the workspace that owns the application registration), a server route trigger only works once the application has been *claimed* — i.e. it has an owner workspace — **and** that application is **installed on the owner workspace**. Until both are true the resolver has nowhere to run, so the route cannot be dispatched. An application that exposes a `serverRouteTriggerSettings` logic function therefore cannot be listed in the marketplace until it is claimed and installed on its owner workspace.
 </Note>
 
-**Resolver contract.** The SDK's `LogicFunctionConfig` type enforces this at compile time: as soon as you set `serverRouteTriggerSettings`, your handler is constrained to return either a `Response`, or `{ workspaceId: string; targetLogicFunctionUniversalIdentifier: string; payload?: object }` (or a `Promise` of either). On the dispatch path, both identifiers must be UUIDs and the `workspaceId` must be a workspace where the target function is installed, otherwise the request is rejected with `404`. A result that matches neither shape is rejected with `502`.
+**Resolver contract.** The SDK's `LogicFunctionConfig` type enforces this at compile time: as soon as you set `serverRouteTriggerSettings`, your handler is constrained to return either a `Response`, or `{ workspaceId: string; targetLogicFunctionUniversalIdentifier: string; payload?: object }` (or a `Promise` of either). On the dispatch path, the `workspaceId` must be a workspace where the target function is installed, otherwise the request is rejected with `404`. A result that matches neither shape — including one whose identifiers are not UUIDs — is rejected with `502`.
 
 | Field | Type | Notes |
 |-------|------|-------|
 | `workspaceId` | `string` | Workspace UUID where the target will run. |
 | `targetLogicFunctionUniversalIdentifier` | `string` | `universalIdentifier` of the logic function to invoke in that workspace. |
-| `payload` | `object` (optional) | If set, replaces the request body sent to the target. Must be a JSON object. |
+| `payload` | `object` (optional) | If set, replaces the request body sent to the target. |
 
 <Warning>
 **Signature verification is your responsibility — verify in the resolver.** The platform does not verify request signatures. The resolver is the recommended place to do it: it runs first, with access to `event.rawBody` and the headers you listed in `forwardedRequestHeaders`, and a thrown error (or any non-matching `workspaceId`) stops the dispatch before the target is invoked. If you instead push verification down into the target, the target must be careful not to lose `rawBody` and headers — i.e. the resolver must not return a `payload`. Always verify **before** any side effect and use a constant-time comparison.

--- a/packages/twenty-docs/developers/extend/apps/logic/logic-functions.mdx
+++ b/packages/twenty-docs/developers/extend/apps/logic/logic-functions.mdx
@@ -59,7 +59,7 @@ To invoke a route-triggered logic function from a (headless) front component, se
 - **cron**: Runs your function on a schedule using a CRON expression.
 - **databaseEvent**: Runs on workspace object lifecycle events. When the event operation is `updated`, specific fields to listen to can be specified in the `updatedFields` array. If left undefined or empty, any update will trigger the function.
 > e.g. `person.updated`, `*.created`, `company.*`
-- **serverRoute**: Exposes a single registration-scoped HTTP route. A **resolver** function (declared with `serverRouteTriggerSettings`) runs in the owner workspace and returns the target workspace AND the target logic function to dispatch to; the platform acks with `202` and runs that **target** function on the worker queue. See [Server route trigger](#server-route-trigger).
+- **serverRoute**: Exposes a single registration-scoped HTTP route. A **resolver** function (declared with `serverRouteTriggerSettings`) runs in the owner workspace and either returns a sync `Response` or the target workspace AND logic function to enqueue; on the enqueue path the platform acks with `202` and runs that **target** on the worker queue. See [Server route trigger](#server-route-trigger).
 
 <Note>
 You can also manually execute a function using the CLI:
@@ -178,8 +178,12 @@ The status code must be a valid HTTP status code (between 100 and 599). Response
 
 The trigger has two parts:
 
-1. A **resolver** logic function — declared with `serverRouteTriggerSettings` — runs in your **owner workspace** (the workspace that owns the application registration). It inspects the incoming request and returns `{ workspaceId, targetLogicFunctionUniversalIdentifier, payload? }`, picking *both* the target workspace and the target function. The resolver is the single point of authorization — the URL only carries the resolver's identifier. **This is the preferred place to verify request signatures**: the resolver runs before any side effect, has access to the original `rawBody` and forwarded headers, and can reject without ever touching the target.
-2. A **target** logic function — a regular per-workspace logic function — then runs in the resolved workspace with the payload returned by the resolver (or the original request payload if the resolver didn't transform it). Its return value becomes the HTTP response.
+1. A **resolver** logic function — declared with `serverRouteTriggerSettings` — runs in your **owner workspace** (the workspace that owns the application registration). It inspects the incoming request and returns either:
+   - `{ workspaceId, targetLogicFunctionUniversalIdentifier, payload? }` — the platform enqueues that target in the resolved workspace and acks with `202 { queued: true }`, or
+   - a `Response` from `twenty-sdk/logic-function` — the platform echoes that HTTP response **synchronously** and does **not** enqueue a target (use this for challenge handshakes such as Slack `url_verification`).
+
+   The resolver is the single point of authorization — the URL only carries the resolver's identifier. **This is the preferred place to verify request signatures**: the resolver runs before any side effect, has access to the original `rawBody` and forwarded headers, and can reject without ever touching the target.
+2. A **target** logic function — a regular per-workspace logic function — then runs in the resolved workspace with the payload returned by the resolver (or the original request payload if the resolver didn't transform it). Its return value is **not** observed by the HTTP caller when the resolver chose the enqueue path.
 
 ```ts src/logic-functions/resolve-server-route.logic-function.ts
 import { createHmac, timingSafeEqual } from 'crypto';
@@ -265,7 +269,7 @@ The identifier is the resolver's `universalIdentifier` from your manifest. Regis
 **The application must be claimed and installed on its owner workspace.** Because the resolver runs in the **owner workspace** (the workspace that owns the application registration), a server route trigger only works once the application has been *claimed* — i.e. it has an owner workspace — **and** that application is **installed on the owner workspace**. Until both are true the resolver has nowhere to run, so the route cannot be dispatched. An application that exposes a `serverRouteTriggerSettings` logic function therefore cannot be listed in the marketplace until it is claimed and installed on its owner workspace.
 </Note>
 
-**Resolver contract.** The SDK's `LogicFunctionConfig` type enforces this at compile time: as soon as you set `serverRouteTriggerSettings`, your handler is constrained to return `{ workspaceId: string; targetLogicFunctionUniversalIdentifier: string; payload?: object }` (or a `Promise` of it). The `workspaceId` must be a workspace where the target function is installed, otherwise the request is rejected with `404`.
+**Resolver contract.** The SDK's `LogicFunctionConfig` type enforces this at compile time: as soon as you set `serverRouteTriggerSettings`, your handler is constrained to return either a `Response`, or `{ workspaceId: string; targetLogicFunctionUniversalIdentifier: string; payload?: object }` (or a `Promise` of either). On the dispatch path, the `workspaceId` must be a workspace where the target function is installed, otherwise the request is rejected with `404`.
 
 | Field | Type | Notes |
 |-------|------|-------|
@@ -290,7 +294,9 @@ For request signatures, most providers sign with HMAC-SHA256; the parts that dif
 The resolver example above already shows the GitHub HMAC-SHA256 flow — adapt the header name, digest encoding, and signed-payload string per the provider you're integrating.
 
 <Note>
-The route responds `202 { queued: true }` right after the resolver returns and the target runs on the worker queue — the caller never observes the target's latency, result, or failures (those are recorded in execution logs). This keeps sender redeliveries from amplifying processing slowdowns, which is what you want for webhook ingestion. For endpoints whose caller must read the response body (challenge handshakes, Slack commands), use an `httpRouteTriggerSettings` route instead. Keep the resolver fast — some providers (e.g. Slack) time out in a few seconds. Because the resolver is reachable as a public endpoint, protect it with rate limiting at your edge.
+When the resolver returns a dispatch object, the route responds `202 { queued: true }` and the target runs on the worker queue — the caller never observes the target's latency, result, or failures (those are recorded in execution logs). This keeps sender redeliveries from amplifying processing slowdowns, which is what you want for webhook ingestion.
+
+When the caller must read the response body on the same request (challenge handshakes, interactive acknowledgements), return a `Response` from the **resolver** instead. The platform echoes it synchronously and skips the queue. Keep the resolver fast — some providers (e.g. Slack) time out in a few seconds. Because the resolver is reachable as a public endpoint, protect it with rate limiting at your edge.
 </Note>
 
 #### Database event trigger payload

--- a/packages/twenty-sdk/src/sdk/define/index.ts
+++ b/packages/twenty-sdk/src/sdk/define/index.ts
@@ -92,7 +92,9 @@ export type {
 export type {
   LogicFunctionConfig,
   LogicFunctionHandler,
+  ServerRouteResolverResult,
 } from '@/sdk/define/logic-functions/logic-function-config';
+export type { ServerRouteDispatchResult } from 'twenty-shared/application';
 export type { CronPayload } from '@/sdk/define/logic-functions/triggers/cron-payload-type';
 export type {
   DatabaseEventPayload,

--- a/packages/twenty-sdk/src/sdk/define/logic-functions/logic-function-config.ts
+++ b/packages/twenty-sdk/src/sdk/define/logic-functions/logic-function-config.ts
@@ -7,8 +7,8 @@ import { type LogicFunctionHttpResponse } from 'twenty-shared/types';
 export type LogicFunctionHandler = (...args: any[]) => any | Promise<any>;
 
 // A resolver function attached to `serverRouteTriggerSettings` runs in the
-// owner workspace and must return BOTH the target workspace and the target
-// logic function to dispatch to. The server contract is
+// owner workspace and returns either a sync `Response`, or BOTH the target
+// workspace and the target logic function to enqueue. The dispatch contract is
 // `{ workspaceId: string; targetLogicFunctionUniversalIdentifier: string;
 // payload?: object }`. The resolver is the single point of authorization —
 // the URL only carries the resolver's universalIdentifier.

--- a/packages/twenty-sdk/src/sdk/define/logic-functions/logic-function-config.ts
+++ b/packages/twenty-sdk/src/sdk/define/logic-functions/logic-function-config.ts
@@ -1,25 +1,16 @@
 import {
   type LogicFunctionManifest,
+  type ServerRouteDispatchResult,
   type ServerRouteTriggerSettings,
 } from 'twenty-shared/application';
 import { type LogicFunctionHttpResponse } from 'twenty-shared/types';
 
 export type LogicFunctionHandler = (...args: any[]) => any | Promise<any>;
 
-// A resolver function attached to `serverRouteTriggerSettings` runs in the
-// owner workspace and returns either a sync `Response`, or BOTH the target
-// workspace and the target logic function to enqueue. The dispatch contract is
-// `{ workspaceId: string; targetLogicFunctionUniversalIdentifier: string;
-// payload?: object }`. The resolver is the single point of authorization —
-// the URL only carries the resolver's universalIdentifier.
-export type ServerRouteDispatchResult = {
-  workspaceId: string;
-  targetLogicFunctionUniversalIdentifier: string;
-  payload?: object;
-};
-
-// Returning a `Response` instead answers the caller synchronously and skips the
-// dispatch, for providers whose webhook URL requires a handshake reply.
+// A resolver attached to `serverRouteTriggerSettings` runs in the owner workspace and is the single
+// point of authorization: the URL only carries the resolver's universalIdentifier. Returning a
+// dispatch result enqueues the target, returning a `Response` answers the caller synchronously
+// instead, for providers whose webhook URL requires a handshake reply.
 export type ServerRouteResolverResult =
   | ServerRouteDispatchResult
   | LogicFunctionHttpResponse;

--- a/packages/twenty-sdk/src/sdk/define/logic-functions/logic-function-config.ts
+++ b/packages/twenty-sdk/src/sdk/define/logic-functions/logic-function-config.ts
@@ -2,6 +2,7 @@ import {
   type LogicFunctionManifest,
   type ServerRouteTriggerSettings,
 } from 'twenty-shared/application';
+import { type LogicFunctionHttpResponse } from 'twenty-shared/types';
 
 export type LogicFunctionHandler = (...args: any[]) => any | Promise<any>;
 
@@ -11,11 +12,17 @@ export type LogicFunctionHandler = (...args: any[]) => any | Promise<any>;
 // `{ workspaceId: string; targetLogicFunctionUniversalIdentifier: string;
 // payload?: object }`. The resolver is the single point of authorization —
 // the URL only carries the resolver's universalIdentifier.
-export type ServerRouteResolverResult = {
+export type ServerRouteDispatchResult = {
   workspaceId: string;
   targetLogicFunctionUniversalIdentifier: string;
   payload?: object;
 };
+
+// Returning a `Response` instead answers the caller synchronously and skips the
+// dispatch, for providers whose webhook URL requires a handshake reply.
+export type ServerRouteResolverResult =
+  | ServerRouteDispatchResult
+  | LogicFunctionHttpResponse;
 
 export type ServerRouteResolverHandler = (
   ...args: any[]

--- a/packages/twenty-sdk/src/sdk/logic-function/index.ts
+++ b/packages/twenty-sdk/src/sdk/logic-function/index.ts
@@ -13,7 +13,9 @@
 export type {
   LogicFunctionConfig,
   LogicFunctionHandler,
+  ServerRouteResolverResult,
 } from '@/sdk/define/logic-functions/logic-function-config';
+export type { ServerRouteDispatchResult } from 'twenty-shared/application';
 
 export type {
   InstallHandler,

--- a/packages/twenty-server/src/engine/core-modules/server-route-trigger/__tests__/server-route-trigger.service.spec.ts
+++ b/packages/twenty-server/src/engine/core-modules/server-route-trigger/__tests__/server-route-trigger.service.spec.ts
@@ -1,4 +1,5 @@
 import { type Request } from 'express';
+import { LOGIC_FUNCTION_HTTP_RESPONSE_MARKER } from 'twenty-shared/types';
 import { type Repository } from 'typeorm';
 
 import { type LogicFunctionExecuteResult } from 'src/engine/core-modules/logic-function/logic-function-drivers/interfaces/logic-function-driver.interface';
@@ -227,6 +228,26 @@ describe('ServerRouteTriggerService', () => {
       code: ServerRouteTriggerExceptionCode.RESOLVER_REQUIRES_AUTHENTICATION,
     });
     expect(logicFunctionExecutorService.execute).not.toHaveBeenCalled();
+  });
+
+  it('answers the caller directly and enqueues nothing when the resolver returns an http response', async () => {
+    logicFunctionExecutorService.execute.mockReset();
+    logicFunctionExecutorService.execute.mockResolvedValueOnce(
+      buildExecuteResult({
+        [LOGIC_FUNCTION_HTTP_RESPONSE_MARKER]: true,
+        status: 200,
+        body: { challenge: 'abc123' },
+      }),
+    );
+
+    const result = await handle();
+
+    expect(result).toEqual({
+      statusCode: 200,
+      headers: {},
+      body: { challenge: 'abc123' },
+    });
+    expect(messageQueueService.add).not.toHaveBeenCalled();
   });
 
   it('throws RESOLVER_INVALID_RESULT when the resolver does not return a workspaceId', async () => {

--- a/packages/twenty-server/src/engine/core-modules/server-route-trigger/__tests__/server-route-trigger.service.spec.ts
+++ b/packages/twenty-server/src/engine/core-modules/server-route-trigger/__tests__/server-route-trigger.service.spec.ts
@@ -19,8 +19,9 @@ import {
 } from 'src/engine/metadata-modules/logic-function/logic-function.exception';
 import { LogicFunctionExecutionStatus } from 'src/engine/metadata-modules/logic-function/dtos/logic-function-execution-result.dto';
 
-const RESOLVER_UID = 'resolver-uid';
-const TARGET_UID = 'target-uid';
+const RESOLVER_UID = 'b3c2f0a1-7d4e-4c9a-9f2b-2e1d6a4c8e10';
+const TARGET_UID = 'c4e2a9b1-7d4e-4c9a-9f2b-2e1d6a4c8e10';
+const TARGET_WORKSPACE_ID = '20202020-1c25-4d02-bf25-6aeccf7ea419';
 
 const buildExecuteResult = (
   data: object | null,
@@ -117,7 +118,7 @@ describe('ServerRouteTriggerService', () => {
     logicFunctionExecutorService = {
       execute: jest.fn().mockResolvedValueOnce(
         buildExecuteResult({
-          workspaceId: 'target-ws',
+          workspaceId: TARGET_WORKSPACE_ID,
           targetLogicFunctionUniversalIdentifier: TARGET_UID,
           payload: { from: 'resolver' },
         }),
@@ -149,7 +150,7 @@ describe('ServerRouteTriggerService', () => {
       LogicFunctionTriggerJob.name,
       {
         logicFunctionId: 'target-id',
-        workspaceId: 'target-ws',
+        workspaceId: TARGET_WORKSPACE_ID,
         payload: { from: 'resolver' },
       },
       { retryLimit: 3 },
@@ -201,7 +202,7 @@ describe('ServerRouteTriggerService', () => {
       expect.objectContaining({
         where: expect.objectContaining({
           universalIdentifier: TARGET_UID,
-          workspaceId: 'target-ws',
+          workspaceId: TARGET_WORKSPACE_ID,
           application: { applicationRegistrationId: 'reg-1' },
         }),
       }),
@@ -266,7 +267,7 @@ describe('ServerRouteTriggerService', () => {
   it('throws RESOLVER_INVALID_RESULT when the resolver does not return a targetLogicFunctionUniversalIdentifier', async () => {
     logicFunctionExecutorService.execute.mockReset();
     logicFunctionExecutorService.execute.mockResolvedValueOnce(
-      buildExecuteResult({ workspaceId: 'target-ws' }),
+      buildExecuteResult({ workspaceId: TARGET_WORKSPACE_ID }),
     );
 
     await expect(handle()).rejects.toMatchObject({

--- a/packages/twenty-server/src/engine/core-modules/server-route-trigger/server-route-trigger.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/server-route-trigger/server-route-trigger.service.ts
@@ -3,6 +3,7 @@ import { InjectRepository } from '@nestjs/typeorm';
 
 import { isString } from '@sniptt/guards';
 import { Request } from 'express';
+import { isLogicFunctionHttpResponse } from 'twenty-shared/types';
 import { isDefined } from 'twenty-shared/utils';
 import { Repository } from 'typeorm';
 
@@ -19,7 +20,10 @@ import { buildLogicFunctionEvent } from 'src/engine/core-modules/logic-function/
 import { InjectMessageQueue } from 'src/engine/core-modules/message-queue/decorators/message-queue.decorator';
 import { MessageQueue } from 'src/engine/core-modules/message-queue/message-queue.constants';
 import { MessageQueueService } from 'src/engine/core-modules/message-queue/services/message-queue.service';
-import { type RouteTriggerResponse } from 'src/engine/core-modules/logic-function/logic-function-trigger/triggers/route/utils/route-trigger-response.util';
+import {
+  buildRouteTriggerResponse,
+  type RouteTriggerResponse,
+} from 'src/engine/core-modules/logic-function/logic-function-trigger/triggers/route/utils/route-trigger-response.util';
 import {
   ServerRouteTriggerException,
   ServerRouteTriggerExceptionCode,
@@ -99,7 +103,22 @@ export class ServerRouteTriggerService {
       workspaceId: resolver.workspaceId,
       payload: event,
     });
-    const resolved = this.parseResolverResult(resolverResult);
+
+    if (isDefined(resolverResult.error)) {
+      throw new ServerRouteTriggerException(
+        resolverResult.error.errorMessage,
+        ServerRouteTriggerExceptionCode.SERVER_ROUTE_USER_UNCAUGHT_ERROR,
+      );
+    }
+
+    // Providers that require a synchronous handshake on the webhook URL (Slack
+    // Events API url_verification) need the resolver to answer the caller itself
+    // instead of dispatching to a queued target function.
+    if (isLogicFunctionHttpResponse(resolverResult.data)) {
+      return buildRouteTriggerResponse(resolverResult.data);
+    }
+
+    const resolved = this.parseResolverResult(resolverResult.data);
 
     return await this.enqueueTargetFunction({
       logicFunctionUniversalIdentifier:
@@ -134,18 +153,8 @@ export class ServerRouteTriggerService {
     );
   }
 
-  private parseResolverResult(result: {
-    data: object | null;
-    error?: { errorMessage: string };
-  }): ResolverResult {
-    if (isDefined(result.error)) {
-      throw new ServerRouteTriggerException(
-        result.error.errorMessage,
-        ServerRouteTriggerExceptionCode.SERVER_ROUTE_USER_UNCAUGHT_ERROR,
-      );
-    }
-
-    const data = result.data as {
+  private parseResolverResult(resolverData: object | null): ResolverResult {
+    const data = resolverData as {
       workspaceId?: unknown;
       targetLogicFunctionUniversalIdentifier?: unknown;
       payload?: unknown;

--- a/packages/twenty-server/src/engine/core-modules/server-route-trigger/server-route-trigger.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/server-route-trigger/server-route-trigger.service.ts
@@ -34,7 +34,7 @@ import {
   LogicFunctionExceptionCode,
 } from 'src/engine/metadata-modules/logic-function/logic-function.exception';
 
-type ResolverResult = {
+type ResolverDispatchResult = {
   workspaceId: string;
   targetLogicFunctionUniversalIdentifier: string;
   payload?: object;
@@ -111,14 +111,11 @@ export class ServerRouteTriggerService {
       );
     }
 
-    // Providers that require a synchronous handshake on the webhook URL (Slack
-    // Events API url_verification) need the resolver to answer the caller itself
-    // instead of dispatching to a queued target function.
     if (isLogicFunctionHttpResponse(resolverResult.data)) {
       return buildRouteTriggerResponse(resolverResult.data);
     }
 
-    const resolved = this.parseResolverResult(resolverResult.data);
+    const resolved = this.parseResolverDispatchResult(resolverResult.data);
 
     return await this.enqueueTargetFunction({
       logicFunctionUniversalIdentifier:
@@ -153,30 +150,33 @@ export class ServerRouteTriggerService {
     );
   }
 
-  private parseResolverResult(resolverData: object | null): ResolverResult {
-    const data = resolverData as {
+  private parseResolverDispatchResult(
+    data: object | null,
+  ): ResolverDispatchResult {
+    const dispatchData = data as {
       workspaceId?: unknown;
       targetLogicFunctionUniversalIdentifier?: unknown;
       payload?: unknown;
     };
 
     if (
-      !isString(data?.workspaceId) ||
-      !isString(data?.targetLogicFunctionUniversalIdentifier)
+      !isString(dispatchData?.workspaceId) ||
+      !isString(dispatchData?.targetLogicFunctionUniversalIdentifier)
     ) {
       throw new ServerRouteTriggerException(
-        'Resolver logic function must return { workspaceId: string; targetLogicFunctionUniversalIdentifier: string; payload?: object }',
+        'Resolver logic function must return either a Response, or { workspaceId: string; targetLogicFunctionUniversalIdentifier: string; payload?: object }',
         ServerRouteTriggerExceptionCode.RESOLVER_INVALID_RESULT,
       );
     }
 
     return {
-      workspaceId: data.workspaceId,
+      workspaceId: dispatchData.workspaceId,
       targetLogicFunctionUniversalIdentifier:
-        data.targetLogicFunctionUniversalIdentifier,
+        dispatchData.targetLogicFunctionUniversalIdentifier,
       payload:
-        typeof data.payload === 'object' && data.payload !== null
-          ? (data.payload as object)
+        typeof dispatchData.payload === 'object' &&
+        dispatchData.payload !== null
+          ? (dispatchData.payload as object)
           : undefined,
     };
   }

--- a/packages/twenty-server/src/engine/core-modules/server-route-trigger/server-route-trigger.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/server-route-trigger/server-route-trigger.service.ts
@@ -1,7 +1,6 @@
 import { Injectable, Logger } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 
-import { isString } from '@sniptt/guards';
 import { Request } from 'express';
 import { isLogicFunctionHttpResponse } from 'twenty-shared/types';
 import { isDefined } from 'twenty-shared/utils';
@@ -28,17 +27,12 @@ import {
   ServerRouteTriggerException,
   ServerRouteTriggerExceptionCode,
 } from 'src/engine/core-modules/server-route-trigger/exceptions/server-route-trigger.exception';
+import { parseResolverDispatchResultOrThrow } from 'src/engine/core-modules/server-route-trigger/utils/parse-resolver-dispatch-result-or-throw.util';
 import { LogicFunctionEntity } from 'src/engine/metadata-modules/logic-function/logic-function.entity';
 import {
   LogicFunctionException,
   LogicFunctionExceptionCode,
 } from 'src/engine/metadata-modules/logic-function/logic-function.exception';
-
-type ResolverDispatchResult = {
-  workspaceId: string;
-  targetLogicFunctionUniversalIdentifier: string;
-  payload?: object;
-};
 
 const QUEUED_TARGET_RETRY_LIMIT = 3;
 
@@ -115,13 +109,15 @@ export class ServerRouteTriggerService {
       return buildRouteTriggerResponse(resolverResult.data);
     }
 
-    const resolved = this.parseResolverDispatchResult(resolverResult.data);
+    const dispatchResult = parseResolverDispatchResultOrThrow(
+      resolverResult.data,
+    );
 
     return await this.enqueueTargetFunction({
       logicFunctionUniversalIdentifier:
-        resolved.targetLogicFunctionUniversalIdentifier,
-      workspaceId: resolved.workspaceId,
-      payload: resolved.payload ?? event,
+        dispatchResult.targetLogicFunctionUniversalIdentifier,
+      workspaceId: dispatchResult.workspaceId,
+      payload: dispatchResult.payload ?? event,
       applicationRegistrationId,
     });
   }
@@ -148,37 +144,6 @@ export class ServerRouteTriggerService {
         )
         .getOne()) ?? null
     );
-  }
-
-  private parseResolverDispatchResult(
-    data: object | null,
-  ): ResolverDispatchResult {
-    const dispatchData = data as {
-      workspaceId?: unknown;
-      targetLogicFunctionUniversalIdentifier?: unknown;
-      payload?: unknown;
-    };
-
-    if (
-      !isString(dispatchData?.workspaceId) ||
-      !isString(dispatchData?.targetLogicFunctionUniversalIdentifier)
-    ) {
-      throw new ServerRouteTriggerException(
-        'Resolver logic function must return either a Response, or { workspaceId: string; targetLogicFunctionUniversalIdentifier: string; payload?: object }',
-        ServerRouteTriggerExceptionCode.RESOLVER_INVALID_RESULT,
-      );
-    }
-
-    return {
-      workspaceId: dispatchData.workspaceId,
-      targetLogicFunctionUniversalIdentifier:
-        dispatchData.targetLogicFunctionUniversalIdentifier,
-      payload:
-        typeof dispatchData.payload === 'object' &&
-        dispatchData.payload !== null
-          ? (dispatchData.payload as object)
-          : undefined,
-    };
   }
 
   private async enqueueTargetFunction({

--- a/packages/twenty-server/src/engine/core-modules/server-route-trigger/utils/__tests__/parse-resolver-dispatch-result-or-throw.util.spec.ts
+++ b/packages/twenty-server/src/engine/core-modules/server-route-trigger/utils/__tests__/parse-resolver-dispatch-result-or-throw.util.spec.ts
@@ -1,0 +1,83 @@
+import { ServerRouteTriggerExceptionCode } from 'src/engine/core-modules/server-route-trigger/exceptions/server-route-trigger.exception';
+import { parseResolverDispatchResultOrThrow } from 'src/engine/core-modules/server-route-trigger/utils/parse-resolver-dispatch-result-or-throw.util';
+
+const WORKSPACE_ID = '20202020-1c25-4d02-bf25-6aeccf7ea419';
+const TARGET_UNIVERSAL_IDENTIFIER = 'c4e2a9b1-7d4e-4c9a-9f2b-2e1d6a4c8e10';
+
+const expectInvalidResult = (data: unknown) =>
+  expect(() => parseResolverDispatchResultOrThrow(data)).toThrow(
+    expect.objectContaining({
+      code: ServerRouteTriggerExceptionCode.RESOLVER_INVALID_RESULT,
+    }),
+  );
+
+describe('parseResolverDispatchResultOrThrow', () => {
+  it('should return the dispatch target when the resolver returns one', () => {
+    expect(
+      parseResolverDispatchResultOrThrow({
+        workspaceId: WORKSPACE_ID,
+        targetLogicFunctionUniversalIdentifier: TARGET_UNIVERSAL_IDENTIFIER,
+      }),
+    ).toEqual({
+      workspaceId: WORKSPACE_ID,
+      targetLogicFunctionUniversalIdentifier: TARGET_UNIVERSAL_IDENTIFIER,
+    });
+  });
+
+  it('should keep the payload when the resolver transforms it', () => {
+    expect(
+      parseResolverDispatchResultOrThrow({
+        workspaceId: WORKSPACE_ID,
+        targetLogicFunctionUniversalIdentifier: TARGET_UNIVERSAL_IDENTIFIER,
+        payload: { event: 'invoice.paid' },
+      }).payload,
+    ).toEqual({ event: 'invoice.paid' });
+  });
+
+  it('should drop keys that are not part of the dispatch contract', () => {
+    expect(
+      parseResolverDispatchResultOrThrow({
+        workspaceId: WORKSPACE_ID,
+        targetLogicFunctionUniversalIdentifier: TARGET_UNIVERSAL_IDENTIFIER,
+        applicationRegistrationId: 'smuggled',
+      }),
+    ).toEqual({
+      workspaceId: WORKSPACE_ID,
+      targetLogicFunctionUniversalIdentifier: TARGET_UNIVERSAL_IDENTIFIER,
+    });
+  });
+
+  it('should throw RESOLVER_INVALID_RESULT when the workspaceId is missing', () => {
+    expectInvalidResult({
+      targetLogicFunctionUniversalIdentifier: TARGET_UNIVERSAL_IDENTIFIER,
+    });
+  });
+
+  it('should throw RESOLVER_INVALID_RESULT when the target identifier is missing', () => {
+    expectInvalidResult({ workspaceId: WORKSPACE_ID });
+  });
+
+  it('should throw RESOLVER_INVALID_RESULT when an identifier is not a uuid', () => {
+    expectInvalidResult({
+      workspaceId: '',
+      targetLogicFunctionUniversalIdentifier: TARGET_UNIVERSAL_IDENTIFIER,
+    });
+    expectInvalidResult({
+      workspaceId: WORKSPACE_ID,
+      targetLogicFunctionUniversalIdentifier: 'handle-invoice-paid',
+    });
+  });
+
+  it('should throw RESOLVER_INVALID_RESULT when the payload is not an object', () => {
+    expectInvalidResult({
+      workspaceId: WORKSPACE_ID,
+      targetLogicFunctionUniversalIdentifier: TARGET_UNIVERSAL_IDENTIFIER,
+      payload: 'not-an-object',
+    });
+  });
+
+  it('should throw RESOLVER_INVALID_RESULT when the resolver returns nothing', () => {
+    expectInvalidResult(null);
+    expectInvalidResult(undefined);
+  });
+});

--- a/packages/twenty-server/src/engine/core-modules/server-route-trigger/utils/__tests__/parse-resolver-dispatch-result-or-throw.util.spec.ts
+++ b/packages/twenty-server/src/engine/core-modules/server-route-trigger/utils/__tests__/parse-resolver-dispatch-result-or-throw.util.spec.ts
@@ -34,6 +34,16 @@ describe('parseResolverDispatchResultOrThrow', () => {
     ).toEqual({ event: 'invoice.paid' });
   });
 
+  it('should accept any object as a payload', () => {
+    expect(
+      parseResolverDispatchResultOrThrow({
+        workspaceId: WORKSPACE_ID,
+        targetLogicFunctionUniversalIdentifier: TARGET_UNIVERSAL_IDENTIFIER,
+        payload: [{ event: 'invoice.paid' }],
+      }).payload,
+    ).toEqual([{ event: 'invoice.paid' }]);
+  });
+
   it('should drop keys that are not part of the dispatch contract', () => {
     expect(
       parseResolverDispatchResultOrThrow({

--- a/packages/twenty-server/src/engine/core-modules/server-route-trigger/utils/parse-resolver-dispatch-result-or-throw.util.ts
+++ b/packages/twenty-server/src/engine/core-modules/server-route-trigger/utils/parse-resolver-dispatch-result-or-throw.util.ts
@@ -1,0 +1,30 @@
+import { type ServerRouteDispatchResult } from 'twenty-shared/application';
+import { z } from 'zod';
+
+import {
+  ServerRouteTriggerException,
+  ServerRouteTriggerExceptionCode,
+} from 'src/engine/core-modules/server-route-trigger/exceptions/server-route-trigger.exception';
+
+// workspaceId and targetLogicFunctionUniversalIdentifier are uuid columns: rejecting non-uuids here
+// keeps a malformed resolver result from reaching the database as an invalid query.
+const resolverDispatchResultSchema = z.object({
+  workspaceId: z.uuid(),
+  targetLogicFunctionUniversalIdentifier: z.uuid(),
+  payload: z.record(z.string(), z.unknown()).optional(),
+});
+
+export const parseResolverDispatchResultOrThrow = (
+  data: unknown,
+): ServerRouteDispatchResult => {
+  const parsedDispatchResult = resolverDispatchResultSchema.safeParse(data);
+
+  if (!parsedDispatchResult.success) {
+    throw new ServerRouteTriggerException(
+      'Resolver logic function must return either a Response, or { workspaceId: string; targetLogicFunctionUniversalIdentifier: string; payload?: object }',
+      ServerRouteTriggerExceptionCode.RESOLVER_INVALID_RESULT,
+    );
+  }
+
+  return parsedDispatchResult.data;
+};

--- a/packages/twenty-server/src/engine/core-modules/server-route-trigger/utils/parse-resolver-dispatch-result-or-throw.util.ts
+++ b/packages/twenty-server/src/engine/core-modules/server-route-trigger/utils/parse-resolver-dispatch-result-or-throw.util.ts
@@ -6,8 +6,6 @@ import {
   ServerRouteTriggerExceptionCode,
 } from 'src/engine/core-modules/server-route-trigger/exceptions/server-route-trigger.exception';
 
-// workspaceId and targetLogicFunctionUniversalIdentifier are uuid columns: rejecting non-uuids here
-// keeps a malformed resolver result from reaching the database as an invalid query.
 const resolverDispatchResultSchema = z.object({
   workspaceId: z.uuid(),
   targetLogicFunctionUniversalIdentifier: z.uuid(),

--- a/packages/twenty-server/src/engine/core-modules/server-route-trigger/utils/parse-resolver-dispatch-result-or-throw.util.ts
+++ b/packages/twenty-server/src/engine/core-modules/server-route-trigger/utils/parse-resolver-dispatch-result-or-throw.util.ts
@@ -1,3 +1,4 @@
+import { isObject } from '@sniptt/guards';
 import { type ServerRouteDispatchResult } from 'twenty-shared/application';
 import { z } from 'zod';
 
@@ -9,7 +10,7 @@ import {
 const resolverDispatchResultSchema = z.object({
   workspaceId: z.uuid(),
   targetLogicFunctionUniversalIdentifier: z.uuid(),
-  payload: z.record(z.string(), z.unknown()).optional(),
+  payload: z.custom<object>((value) => isObject(value)).optional(),
 });
 
 export const parseResolverDispatchResultOrThrow = (

--- a/packages/twenty-server/test/integration/server-route-trigger/suites/server-route-trigger-authorization.integration-spec.ts
+++ b/packages/twenty-server/test/integration/server-route-trigger/suites/server-route-trigger-authorization.integration-spec.ts
@@ -36,7 +36,6 @@ const RESOLVER_BUILT_HANDLER_CODE = `export const main = async () => ({
 });
 `;
 
-// What `new Response(...)` from twenty-sdk/logic-function serializes to.
 const HANDSHAKE_RESOLVER_BUILT_HANDLER_CODE = `export const main = async (event) => ({
   ${LOGIC_FUNCTION_HTTP_RESPONSE_MARKER}: true,
   status: 200,

--- a/packages/twenty-server/test/integration/server-route-trigger/suites/server-route-trigger-authorization.integration-spec.ts
+++ b/packages/twenty-server/test/integration/server-route-trigger/suites/server-route-trigger-authorization.integration-spec.ts
@@ -6,6 +6,7 @@ import { syncApplication } from 'test/integration/metadata/suites/application/ut
 import { uploadApplicationFile } from 'test/integration/metadata/suites/application/utils/upload-application-file.util';
 import { expectOneNotInternalServerErrorHttpResponseSnapshot } from 'test/integration/utils/expect-one-not-internal-server-error-http-response-snapshot.util';
 import { type LogicFunctionManifest } from 'twenty-shared/application';
+import { LOGIC_FUNCTION_HTTP_RESPONSE_MARKER } from 'twenty-shared/types';
 
 import { SEED_APPLE_WORKSPACE_ID } from 'src/engine/workspace-manager/dev-seeder/core/constants/seeder-workspaces.constant';
 
@@ -22,6 +23,8 @@ const AUTH_REQUIRED_RESOLVER_UNIVERSAL_IDENTIFIER =
   '3c3f983f-5c1a-4c60-a3c8-7d0e2a4a33c3';
 const TARGET_FUNCTION_UNIVERSAL_IDENTIFIER =
   '4d4f983f-5c1a-4c60-a3c8-7d0e2a4a44d4';
+const HANDSHAKE_RESOLVER_UNIVERSAL_IDENTIFIER =
+  '5e5f983f-5c1a-4c60-a3c8-7d0e2a4a55e5';
 
 const TARGET_FUNCTION_RESPONSE = { greeting: 'hello from target function' };
 
@@ -30,6 +33,14 @@ const TARGET_FUNCTION_RESPONSE = { greeting: 'hello from target function' };
 const RESOLVER_BUILT_HANDLER_CODE = `export const main = async () => ({
   workspaceId: '${OWNER_WORKSPACE_ID}',
   targetLogicFunctionUniversalIdentifier: '${TARGET_FUNCTION_UNIVERSAL_IDENTIFIER}',
+});
+`;
+
+// What `new Response(...)` from twenty-sdk/logic-function serializes to.
+const HANDSHAKE_RESOLVER_BUILT_HANDLER_CODE = `export const main = async (event) => ({
+  ${LOGIC_FUNCTION_HTTP_RESPONSE_MARKER}: true,
+  status: 200,
+  body: { challenge: event.body.challenge },
 });
 `;
 
@@ -108,6 +119,11 @@ describe('ServerRouteTrigger authorization (integration)', () => {
     });
 
     await uploadBuiltHandlerFile({
+      builtHandlerPath: 'dist/handshake-resolver.mjs',
+      builtHandlerCode: HANDSHAKE_RESOLVER_BUILT_HANDLER_CODE,
+    });
+
+    await uploadBuiltHandlerFile({
       builtHandlerPath: 'dist/target-function.mjs',
       builtHandlerCode: TARGET_BUILT_HANDLER_CODE,
     });
@@ -135,6 +151,12 @@ describe('ServerRouteTrigger authorization (integration)', () => {
               name: 'auth-required-resolver',
               serverRouteExposed: true,
               authRequired: true,
+            }),
+            buildLogicFunctionManifest({
+              universalIdentifier: HANDSHAKE_RESOLVER_UNIVERSAL_IDENTIFIER,
+              name: 'handshake-resolver',
+              serverRouteExposed: true,
+              authRequired: false,
             }),
             buildLogicFunctionManifest({
               universalIdentifier: TARGET_FUNCTION_UNIVERSAL_IDENTIFIER,
@@ -175,6 +197,15 @@ describe('ServerRouteTrigger authorization (integration)', () => {
 
       expect(response.status).toBe(202);
       expect(response.body).toEqual({ queued: true });
+    }, 60000);
+
+    it('answers the caller with the response returned by the resolver', async () => {
+      const response = await request(baseUrl)
+        .post(`/webhooks/server/${HANDSHAKE_RESOLVER_UNIVERSAL_IDENTIFIER}`)
+        .send({ type: 'url_verification', challenge: 'abc123' });
+
+      expect(response.status).toBe(200);
+      expect(response.body).toEqual({ challenge: 'abc123' });
     }, 60000);
 
     it('rejects a server-route-exposed resolver that requires authentication before executing it', async () => {

--- a/packages/twenty-shared/src/application/index.ts
+++ b/packages/twenty-shared/src/application/index.ts
@@ -133,6 +133,7 @@ export type {
 } from './roleManifestType';
 export type { RunAgentInput, RunAgentResult } from './runAgentType';
 export type { ServerVariables } from './server-variables.type';
+export type { ServerRouteDispatchResult } from './serverRouteDispatchResultType';
 export type { ServerRouteTriggerSettings } from './serverRouteTriggerSettingsType';
 export type { SkillManifest } from './skillManifestType';
 export type { StoredOAuthConnectionProviderConfig } from './storedOAuthConnectionProviderConfigType';

--- a/packages/twenty-shared/src/application/serverRouteDispatchResultType.ts
+++ b/packages/twenty-shared/src/application/serverRouteDispatchResultType.ts
@@ -1,0 +1,5 @@
+export type ServerRouteDispatchResult = {
+  workspaceId: string;
+  targetLogicFunctionUniversalIdentifier: string;
+  payload?: object;
+};


### PR DESCRIPTION
## Problem

A server route resolver can only return a dispatch target (`{ workspaceId, targetLogicFunctionUniversalIdentifier, payload }`), and `ServerRouteTriggerService` always acks `202 {queued:true}`. The target function runs off the queue, after the response has been sent, so its return value can never reach the caller.

That makes it impossible to integrate a provider whose webhook URL has to be proven with a handshake on the same response. Slack's Events API is the case that surfaced it: `url_verification` sends `{ type, challenge }` and will not accept the Request URL unless the challenge comes back on that POST.

## Change

A resolver may now return a `Response` (the existing `LogicFunctionHttpResponse`) instead of a dispatch target. The route sends it as-is via `buildRouteTriggerResponse` and enqueues nothing.

- Reuses the marker and builder that HTTP route triggers already use, so there is no new response shape.
- Dispatch results behave exactly as before; the resolver error path is unchanged, just hoisted out of `parseResolverResult` so it runs before the branch.
- SDK: `ServerRouteResolverResult` becomes `ServerRouteDispatchResult | LogicFunctionHttpResponse`.

Additive: a resolver that returns a dispatch target sees no behavior change. Previously, returning this shape threw `RESOLVER_INVALID_RESULT`.

## Testing

`server-route-trigger.service.spec.ts` gains a case asserting the resolver's response is sent verbatim and nothing is enqueued. 15/15 pass.

## Context

Split out of #22984 (Slack conversational assistant), which needs this to complete the Slack Events URL verification. That PR depends on this one merging first.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/23233?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

