### PR TITLE
fix: bump fast-uri to 3.1.4 (Dependabot)

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -33075,9 +33075,9 @@ __metadata:
   linkType: hard
 
 "fast-uri@npm:^3.0.1":
-  version: 3.1.2
-  resolution: "fast-uri@npm:3.1.2"
-  checksum: 10c0/5b35641895959f3f7ab7a7b1b5542bded159346f25ec9f256817b206d50b64eda5828e90d605a2e2fc645c90519a7259c2bab2c942ee728c88b88e5be21b090d
+  version: 3.1.4
+  resolution: "fast-uri@npm:3.1.4"
+  checksum: 10c0/f90948821ceb49980f64f89b8216ba498f5957f26035be813526a55b6145d26cbd63ef5618d5205a3292b31edc9c08589749350cd72bd86c7095eb434dceb757
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Bumps **fast-uri -> 3.1.4** (sole descriptor `^3.0.1`, caret already permits it; recursive `yarn up`, lockfile-only, no resolution). Clears [1798](https://github.com/twentyhq/twenty/security/dependabot/1798) (GHSA-4c8g-83qw-93j6, high) and [1805](https://github.com/twentyhq/twenty/security/dependabot/1805) (GHSA-v2hh-gcrm-f6hx, high). `yarn install --immutable` passes. 3.1.4 published 2026-07-19, clears the 3-day age gate.
