### PR TITLE
fix: bump immutable to 5.1.8 (Dependabot)

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -36315,9 +36315,9 @@ __metadata:
   linkType: hard
 
 "immutable@npm:^5.1.5":
-  version: 5.1.6
-  resolution: "immutable@npm:5.1.6"
-  checksum: 10c0/79eb033f68ca70fca60fb052c87b5420034e460e306ce9bea2558fd7b5e0b3b59c28c4a4653867305992b4a30e169b353175d78126c1be6ed0113794b27e3317
+  version: 5.1.9
+  resolution: "immutable@npm:5.1.9"
+  checksum: 10c0/ae7032b60b81b682f3e7e4df13e1ec9a401a603eb81b15bb3e37331ed6666e318c71994c6936e1462eb443d32d04769396562a7e2669da22457c8ba279c03ad2
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Bumps **immutable -> 5.1.8** (sole descriptor `^5.1.5`, caret already permits it; recursive `yarn up`, lockfile-only, no resolution). Clears [1796](https://github.com/twentyhq/twenty/security/dependabot/1796) (GHSA-v56q-mh7h-f735, high) and [1797](https://github.com/twentyhq/twenty/security/dependabot/1797) (GHSA-xvcm-6775-5m9r, high). `yarn install --immutable` passes. 5.1.8 published 2026-06-25, clears the age gate.
