### PR TITLE
fix: bump dompurify to 3.4.12 (Dependabot)

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -31071,14 +31071,14 @@ __metadata:
   linkType: hard
 
 "dompurify@npm:^3.4.11":
-  version: 3.4.11
-  resolution: "dompurify@npm:3.4.11"
+  version: 3.4.12
+  resolution: "dompurify@npm:3.4.12"
   dependencies:
     "@types/trusted-types": "npm:^2.0.7"
   dependenciesMeta:
     "@types/trusted-types":
       optional: true
-  checksum: 10c0/31439481c7e8fc3805d40c376936fd66936620fb1b1a31a2ec097f6165412c37f2d868e082c9ceba62bb37661c1ea132a5db4d5213434317e30df68d4aca9cc9
+  checksum: 10c0/127a13817353d4e20e75a991a9022a04c3af12af7479f68e2b8bee6dbc7330a96edfb8f4ebff96f4f0f24cd43e8dbba46214131f510c3aa87a843bd8b610d0ab
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Bumps **dompurify -> 3.4.12** (sole descriptor `^3.4.11`, caret already permits it; recursive `yarn up`, lockfile-only, no resolution). Clears [1801](https://github.com/twentyhq/twenty/security/dependabot/1801) (GHSA-c2j3-45gr-mqc4, low). `yarn install --immutable` passes. 3.4.12 published 2026-07-11, clears the age gate.
