### PR TITLE
fix: bump svgo to 3.3.4 (Dependabot)

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -51499,8 +51499,8 @@ __metadata:
   linkType: hard
 
 "svgo@npm:^3.0.2":
-  version: 3.3.3
-  resolution: "svgo@npm:3.3.3"
+  version: 3.3.4
+  resolution: "svgo@npm:3.3.4"
   dependencies:
     commander: "npm:^7.2.0"
     css-select: "npm:^5.1.0"
@@ -51511,7 +51511,7 @@ __metadata:
     sax: "npm:^1.5.0"
   bin:
     svgo: ./bin/svgo
-  checksum: 10c0/06568c6b0430f96748c557f0b17dc7de79b19fa16d13d7523527ede0ec727fc6d8e6a10e13ff106dc4372d2e6063a1dca7c455c495efb1b83857480425f9b965
+  checksum: 10c0/4aeb29f2dc1923e4332ad3b702aca901c0a55692b9e3884fc932ca1d76b7db0dc8ce4b2f493bbf79b16a961c288fa720628fc78bb91915645967dcaa8f92d499
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Bumps **svgo -> 3.3.4** (sole descriptor `^3.0.2`, caret already permits it; recursive `yarn up`, lockfile-only, no resolution). Clears [1802](https://github.com/twentyhq/twenty/security/dependabot/1802) (GHSA-2p49-hgcm-8545, high). `yarn install --immutable` passes. 3.3.4 published 2026-07-11, clears the age gate.
