### PR TITLE
fix: bump brace-expansion 1.x/2.x lines (Dependabot)

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -27592,7 +27592,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"brace-expansion@npm:5.0.6, brace-expansion@npm:^5.0.2, brace-expansion@npm:^5.0.5":
+"brace-expansion@npm:5.0.6":
   version: 5.0.6
   resolution: "brace-expansion@npm:5.0.6"
   dependencies:
@@ -27602,21 +27602,30 @@ __metadata:
   linkType: hard
 
 "brace-expansion@npm:^1.1.7":
-  version: 1.1.15
-  resolution: "brace-expansion@npm:1.1.15"
+  version: 1.1.16
+  resolution: "brace-expansion@npm:1.1.16"
   dependencies:
     balanced-match: "npm:^1.0.0"
     concat-map: "npm:0.0.1"
-  checksum: 10c0/648e273f57cfa9ed67d8a77bdb15b408205465d33da9331808ee3c188d8b55674c9cdbf1f320b65bc562e485e1263360ae62ad355e128e0435891f6430e795d7
+  checksum: 10c0/b2a915bbedbf4e45840d1fb9a4d391bbf26a79475bd134714d3cee34f1f0edb0ce982738028843be5fbaf8039429f71fa487df8c915b6065ced542c83e58fae6
   languageName: node
   linkType: hard
 
 "brace-expansion@npm:^2.0.1, brace-expansion@npm:^2.0.2":
-  version: 2.1.1
-  resolution: "brace-expansion@npm:2.1.1"
+  version: 2.1.2
+  resolution: "brace-expansion@npm:2.1.2"
   dependencies:
     balanced-match: "npm:^1.0.0"
-  checksum: 10c0/63b5ddce608b70b50a76817c0526faf8ea67a9180073d88bb402f6bbc22a22da6b1dfac4f65efc53e5faa80222fb7d44bbf2fc638c3f55365975573f671d0ccb
+  checksum: 10c0/5442ecab84045d21826268bc56c81a6ef4215327ee1f5ee153f67928e93f7a915d130ecec9966623143277fa3cce036ebb50020024bcc4d78853cdd6af9a19f8
+  languageName: node
+  linkType: hard
+
+"brace-expansion@npm:^5.0.2, brace-expansion@npm:^5.0.5":
+  version: 5.0.7
+  resolution: "brace-expansion@npm:5.0.7"
+  dependencies:
+    balanced-match: "npm:^4.0.2"
+  checksum: 10c0/4769109c3c082de178e449a371bcad50d51ab468f644bce2dd9188efe0cf0a080ed102105d7fc8577382cedc45bad7e6443a91bf3d8102264ee8cf927dbaf205
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Bumps **brace-expansion 1.x -> 1.1.16** and **2.x -> 2.1.2** (caret consumer ranges permit both; recursive `yarn up`, lockfile-only, no resolution). Clears [1766](https://github.com/twentyhq/twenty/security/dependabot/1766) and [1767](https://github.com/twentyhq/twenty/security/dependabot/1767) for GHSA-3jxr-9vmj-r5cp (high, ReDoS).

**Deliberately not covered:** the 5.x line stays at 5.0.6 because `nx@22.7.5` pins it exact (minimatch's `^5.0.x` consumers do lift to 5.0.7, but the nx copy remains), so alert [1765](https://github.com/twentyhq/twenty/security/dependabot/1765) stays open. Same nx-exact-pin situation as axios; will be handled in the resolutions batch.

`yarn install --immutable` passes. 1.1.16 and 2.1.2 published 2026-07-08, clear the age gate.
