### PR TITLE
Count app install failures during package resolution

### DIFF
--- a/packages/twenty-server/src/engine/core-modules/application/application-install/application-install.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/application/application-install/application-install.service.ts
@@ -154,40 +154,22 @@ export class ApplicationInstallService {
       );
     }
 
-    const resolvedPackage =
-      await this.applicationPackageFetcherService.resolvePackage(
-        appRegistration,
-        { targetVersion: params.version },
-      );
-
-    if (!resolvedPackage) {
-      return true;
-    }
-
-    try {
-      const existingApplication =
-        await this.applicationService.findByUniversalIdentifier({
-          universalIdentifier: appRegistration.universalIdentifier,
-          workspaceId: params.workspaceId,
-        });
-
-      return await this.runInstallWithMetrics({
-        appRegistration,
-        params,
-        resolvedPackage,
-        existingApplication,
+    const existingApplication =
+      await this.applicationService.findByUniversalIdentifier({
+        universalIdentifier: appRegistration.universalIdentifier,
+        workspaceId: params.workspaceId,
       });
-    } finally {
-      await this.applicationPackageFetcherService.cleanupExtractedDir(
-        resolvedPackage.cleanupDir,
-      );
-    }
+
+    return await this.runInstallWithMetrics({
+      appRegistration,
+      params,
+      existingApplication,
+    });
   }
 
   private async runInstallWithMetrics({
     appRegistration,
     params,
-    resolvedPackage,
     existingApplication,
   }: {
     appRegistration: ApplicationRegistrationEntity;
@@ -196,19 +178,28 @@ export class ApplicationInstallService {
       workspaceId: string;
       skipWorkspaceCompatibilityCheck?: boolean;
     };
-    resolvedPackage: ResolvedPackage;
     existingApplication: ApplicationEntity | null;
   }): Promise<boolean> {
     const isVersionUpgrade = isDefined(existingApplication);
 
-    const attributes = {
-      universal_identifier: appRegistration.universalIdentifier,
-      app_name: resolvedPackage.manifest.application.displayName,
-      source_type: appRegistration.sourceType,
-      version: resolvedPackage.packageJson.version ?? 'unknown',
-    };
+    // Package resolution is inside the metrics scope: npm/tarball resolution can
+    // throw (fetch, extraction, manifest parsing) and those failures are real
+    // install failures that must be counted, not silently dropped.
+    let resolvedPackage: ResolvedPackage | null = null;
 
     try {
+      resolvedPackage =
+        await this.applicationPackageFetcherService.resolvePackage(
+          appRegistration,
+          { targetVersion: params.version },
+        );
+
+      // LOCAL and OAUTH_ONLY sources have no code artifacts to install, so
+      // there is nothing to meter.
+      if (!isDefined(resolvedPackage)) {
+        return true;
+      }
+
       const result = await this.runInstall({
         appRegistration,
         params,
@@ -221,7 +212,12 @@ export class ApplicationInstallService {
           ? MetricsKeys.AppUpgradeSucceeded
           : MetricsKeys.AppInstallSucceeded,
         amount: 1,
-        attributes,
+        attributes: {
+          universal_identifier: appRegistration.universalIdentifier,
+          app_name: resolvedPackage.manifest.application.displayName,
+          source_type: appRegistration.sourceType,
+          version: resolvedPackage.packageJson.version ?? 'unknown',
+        },
       });
 
       return result;
@@ -232,13 +228,24 @@ export class ApplicationInstallService {
           : MetricsKeys.AppInstallFailed,
         amount: 1,
         attributes: {
-          ...attributes,
+          universal_identifier: appRegistration.universalIdentifier,
+          app_name:
+            resolvedPackage?.manifest.application.displayName ?? 'unknown',
+          source_type: appRegistration.sourceType,
+          version:
+            resolvedPackage?.packageJson.version ?? params.version ?? 'unknown',
           error_code:
             error instanceof ApplicationException ? error.code : 'UNKNOWN',
         },
       });
 
       throw error;
+    } finally {
+      if (isDefined(resolvedPackage)) {
+        await this.applicationPackageFetcherService.cleanupExtractedDir(
+          resolvedPackage.cleanupDir,
+        );
+      }
     }
   }
 


### PR DESCRIPTION
## What

App install/upgrade metrics undercount because package resolution runs outside the metrics `try/catch`.

In `ApplicationInstallService`, `resolvePackage()` was called in `doInstallApplication()` before `runInstallWithMetrics()`, and the success/failure counters only wrapped `runInstall`. For NPM and TARBALL sources, resolution failures throw `ApplicationException` (registry fetch, tarball download/extraction, missing or invalid `manifest.json` / `package.json`). Those throws propagated up without ever incrementing `app-install/failed` or `app-upgrade/failed`, so any install that died during download/extract/parse was invisible in metrics: neither success nor failure was recorded, understating both the failure counter and total attempts.

## Changes

- Move package resolution inside the metrics scope in `runInstallWithMetrics`, so a resolution failure increments the failed counter with its `error_code`.
- When the package never resolved, the failure attributes fall back to the requested `params.version` and an `'unknown'` app name.
- `existingApplication` is looked up before resolution so install-vs-upgrade attribution is still correct on a resolution failure.
- LOCAL / OAUTH_ONLY sources still resolve to `null` and return early without emitting a counter (no code artifacts to install).
- Extracted-dir cleanup moved into the same block's `finally`, guarded so it only runs when a package actually resolved.

No metric keys or attribute names changed. Success-path behavior is unchanged.

## Notes

This closes the emission gap so `total attempts = successes + failures` for npm/tarball installs. Separately, when reading these metrics in Grafana, keep in mind that a large share of installs run in the worker process (onboarding and pre-installed-app backfill); that process must also be scraped by Prometheus (`METER_DRIVER` set, port `9464`) for those counters to appear. That is a deployment concern, not part of this change.

---
_Generated by [Claude Code](https://claude.ai/code/session_01RJVMoKXobv72o6ir3bLaeK)_

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/23265?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

