### PR TITLE
fix: move message list member backfill command to 2.25

### DIFF
--- a/packages/twenty-server/src/database/commands/upgrade-version-command/2-25/2-25-upgrade-version-command.module.ts
+++ b/packages/twenty-server/src/database/commands/upgrade-version-command/2-25/2-25-upgrade-version-command.module.ts
@@ -2,7 +2,7 @@ import { Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
 
 import { WorkspaceIteratorModule } from 'src/database/commands/command-runners/workspace-iterator.module';
-import { BackfillMessageListMembersJunctionTargetCommand } from 'src/database/commands/upgrade-version-command/2-24/2-24-workspace-command-1784567000000-backfill-message-list-members-junction-target.command';
+import { BackfillMessageListMembersJunctionTargetCommand } from 'src/database/commands/upgrade-version-command/2-25/2-25-workspace-command-1784567000000-backfill-message-list-members-junction-target.command';
 import { FieldMetadataEntity } from 'src/engine/metadata-modules/field-metadata/field-metadata.entity';
 import { WorkspaceCacheModule } from 'src/engine/workspace-cache/workspace-cache.module';
 import { WorkspaceMigrationRunnerModule } from 'src/engine/workspace-manager/workspace-migration/workspace-migration-runner/workspace-migration-runner.module';
@@ -16,4 +16,4 @@ import { WorkspaceMigrationRunnerModule } from 'src/engine/workspace-manager/wor
   ],
   providers: [BackfillMessageListMembersJunctionTargetCommand],
 })
-export class V2_24_UpgradeVersionCommandModule {}
+export class V2_25_UpgradeVersionCommandModule {}

--- a/packages/twenty-server/src/database/commands/upgrade-version-command/2-25/2-25-workspace-command-1784567000000-backfill-message-list-members-junction-target.command.ts
+++ b/packages/twenty-server/src/database/commands/upgrade-version-command/2-25/2-25-workspace-command-1784567000000-backfill-message-list-members-junction-target.command.ts
@@ -26,7 +26,7 @@ const PERSON_FIELD_UNIVERSAL_IDENTIFIER =
 
 @RegisteredWorkspaceCommand('2.25.0', 1784567000000)
 @Command({
-  name: 'upgrade:2-24:backfill-message-list-members-junction-target',
+  name: 'upgrade:2-25:backfill-message-list-members-junction-target',
   description:
     'Backfill the junction target field id on messageList.members for workspaces provisioned before it was declared, so the record page renders the members junction picker.',
 })

--- a/packages/twenty-server/src/database/commands/upgrade-version-command/2-25/2-25-workspace-command-1784567000000-backfill-message-list-members-junction-target.command.ts
+++ b/packages/twenty-server/src/database/commands/upgrade-version-command/2-25/2-25-workspace-command-1784567000000-backfill-message-list-members-junction-target.command.ts
@@ -24,7 +24,7 @@ const MEMBERS_FIELD_UNIVERSAL_IDENTIFIER =
 const PERSON_FIELD_UNIVERSAL_IDENTIFIER =
   STANDARD_OBJECTS.messageListMember.fields.person.universalIdentifier;
 
-@RegisteredWorkspaceCommand('2.24.0', 1784567000000)
+@RegisteredWorkspaceCommand('2.25.0', 1784567000000)
 @Command({
   name: 'upgrade:2-24:backfill-message-list-members-junction-target',
   description:

--- a/packages/twenty-server/src/database/commands/upgrade-version-command/workspace-command-provider.module.ts
+++ b/packages/twenty-server/src/database/commands/upgrade-version-command/workspace-command-provider.module.ts
@@ -24,7 +24,7 @@ import { V2_20_UpgradeVersionCommandModule } from 'src/database/commands/upgrade
 import { V2_21_UpgradeVersionCommandModule } from 'src/database/commands/upgrade-version-command/2-21/2-21-upgrade-version-command.module';
 import { V2_22_UpgradeVersionCommandModule } from 'src/database/commands/upgrade-version-command/2-22/2-22-upgrade-version-command.module';
 import { V2_23_UpgradeVersionCommandModule } from 'src/database/commands/upgrade-version-command/2-23/2-23-upgrade-version-command.module';
-import { V2_24_UpgradeVersionCommandModule } from 'src/database/commands/upgrade-version-command/2-24/2-24-upgrade-version-command.module';
+import { V2_25_UpgradeVersionCommandModule } from 'src/database/commands/upgrade-version-command/2-25/2-25-upgrade-version-command.module';
 
 @Module({
   imports: [
@@ -52,7 +52,7 @@ import { V2_24_UpgradeVersionCommandModule } from 'src/database/commands/upgrade
     V2_21_UpgradeVersionCommandModule,
     V2_22_UpgradeVersionCommandModule,
     V2_23_UpgradeVersionCommandModule,
-    V2_24_UpgradeVersionCommandModule,
+    V2_25_UpgradeVersionCommandModule,
   ],
 })
 export class WorkspaceCommandProviderModule {}


### PR DESCRIPTION
## What

Moves the `backfill-message-list-members-junction-target` workspace upgrade command from `2.24.0` to `2.25.0`.

Introduced in #23176 (commit 59eead23), the command was registered under version `2.24.0`. Since `TWENTY_CURRENT_VERSION` is now `2.25.0`, `2.24.0` is an already-released version, so its upgrade commands do not re-run and the backfill would never execute on upgrade.

## Changes

- Moved the command and its module from `upgrade-version-command/2-24/` to a new `2-25/` directory.
- Updated the decorator from `@RegisteredWorkspaceCommand('2.24.0', ...)` to `('2.25.0', ...)`.
- Renamed `V2_24_UpgradeVersionCommandModule` to `V2_25_UpgradeVersionCommandModule` and updated its registration in `workspace-command-provider.module.ts`. The `2-24` module only ever provided this single command.

The timestamp (`1784567000000`) and command logic are unchanged.

---
_Generated by [Claude Code](https://claude.ai/code/session_01549NK3QrcEgFsdi8UgXk1u)_

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/23271?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

