### PR TITLE
fix(front): constrain inline cell editor width to field anchor

### DIFF
--- a/packages/twenty-front/src/modules/object-record/record-inline-cell/components/RecordInlineCellEditMode.tsx
+++ b/packages/twenty-front/src/modules/object-record/record-inline-cell/components/RecordInlineCellEditMode.tsx
@@ -13,6 +13,7 @@ import {
   flip,
   offset,
   shift,
+  size,
   useFloating,
   type MiddlewareState,
 } from '@floating-ui/react';
@@ -84,6 +85,11 @@ export const RecordInlineCellEditMode = ({
             },
       ),
       shift({ padding: 8 }),
+      size({
+        apply: ({ rects, elements }) => {
+          elements.floating.style.width = `${rects.reference.width}px`;
+        },
+      }),
       setFieldInputLayoutDirectionMiddleware,
     ],
     whileElementsMounted: autoUpdate,


### PR DESCRIPTION
## Context

Fixes #22841

When the record right side panel is manually widened, clicking a text field opened an inline editor that rendered too wide and broke the layout.

## Root cause

`RecordInlineCellEditMode` builds its portaled editor position with `flip()`, `offset()`, `shift()` and a layout-direction middleware, but no `size()` middleware. The floating `OverlayContainer`'s width was therefore not constrained to the reference field anchor, so it grew past the field.

## Fix

Add Floating UI's `size()` middleware, applying the reference field anchor's measured width to the floating editor, while preserving `flip()`/`shift()` repositioning:

```tsx
size({
  apply: ({ rects, elements }) => {
    elements.floating.style.width = `${rects.reference.width}px`;
  },
}),
```

## Before / After

Inline cell editor opened on a field (shown with the Address field, whose wider content makes the difference visible; the same wrapper handles text fields).

| Before | After |
| --- | --- |
| ![before](https://raw.githubusercontent.com/twentyhq/twenty/tt-fix-22841-inline-cell-width-assets/before.png) | ![after](https://raw.githubusercontent.com/twentyhq/twenty/tt-fix-22841-inline-cell-width-assets/after.png) |

Before: the editor overflows past the fields column. After: the editor is constrained to the field anchor width.

## Verification

- Lint (`lint:diff-with-main`) and typecheck pass for the changed file.
- Runtime (local): with an inline cell editor open, the portaled editor's width tracks the reference field anchor exactly (measured `floating.style.width === rects.reference.width`).
