### PR TITLE
docs: set correct credit cost for workflow steps and app logic functions

### DIFF
--- a/packages/twenty-docs/user-guide/billing/capabilities/credits.mdx
+++ b/packages/twenty-docs/user-guide/billing/capabilities/credits.mdx
@@ -15,15 +15,18 @@ Cost scales with the work. Everyday automation and quick AI messages cost a tiny
 
 | What you do | Roughly costs | What that means |
 |-------------|---------------|-----------------|
-| Run a standard workflow step (search, create, update records) | ~$0.0001 | About **10,000 steps per credit** |
+| Run a standard workflow step (search, create, update records) or trigger an app's logic function | $0.0001 | **10,000 runs per credit** |
 | Call an external API or run a code node | A small fraction of a credit | Thousands per credit |
 | Send a quick AI chat message or simple AI step | A fraction of a cent | Hundreds per credit |
 | Run a large AI agent task (e.g. "configure 10 workspace objects") | Can run to **~$1 or more** | A few per credit |
 | Run an AI web search | A fixed per-search cost | Hundreds of searches per credit |
-| Trigger app's logic function | A small fraction of a credit | Thousands per credit |
 
 <Note>
 For most teams, standard automations are effectively free — you'll only make a noticeable dent in your balance when you lean on AI features or run heavy code nodes. That's by design: the included credits are meant to let you build without watching a meter.
+</Note>
+
+<Note>
+Not every app charges for its runs. Call Recorder and Last contact react to every email and calendar event imported into your workspace, so their logic function runs are free. You are still charged for the metered work they do, such as recorded call minutes.
 </Note>
 
 ## How AI usage is metered


### PR DESCRIPTION
The Credits page listed the app logic function row as "A small fraction of a credit / Thousands per credit", which understates the rate.

A workflow step and a logic function run each cost a flat 100 micro-credits (`workflow-executor.workspace-service.ts:353`, `logic-function-executor.service.ts:536`), i.e. $0.0001, or 10,000 runs per credit. Since the two rows carried the same rate stated twice, they're merged into one.

Also adds a note that Call Recorder and Last contact don't consume credits for their logic function runs. They're in `MARKETPLACE_BILLING_EXEMPT_UNIVERSAL_IDENTIFIERS`, which is 2 of the 3 apps currently in `MARKETPLACE_VETTED_APPLICATIONS`. The note is explicit that the exemption covers only the per-run charge, since those apps still bill metered work (recorded call minutes) through `chargeCredits`.

## Test plan

Docs-only change. Rates cross-checked against `workflow-executor.workspace-service.ts` and `logic-function-executor.service.ts`; the exempt list against `marketplace-billing-exempt-applications.constant.ts` and `marketplace-vetted-applications.constant.ts`.