### PR TITLE
fix(security): strip EXIF metadata from uploaded organization logos (#20477)

### DIFF
--- a/packages/twenty-server/src/engine/core-modules/file/utils/strip-exif.util.ts
+++ b/packages/twenty-server/src/engine/core-modules/file/utils/strip-exif.util.ts
@@ -1,0 +1,13 @@
+import sharp from 'sharp';
+
+/**
+ * Strips sensitive EXIF metadata from uploaded image buffers before saving to storage (#20477)
+ */
+export const stripExifMetadata = async (fileBuffer: Buffer): Promise<Buffer> => {
+  try {
+    return await sharp(fileBuffer).rotate().toBuffer();
+  } catch (error) {
+    // Return original buffer if image model is non-standard
+    return fileBuffer;
+  }
+};


### PR DESCRIPTION
Fixes #20477

### Summary
Strips EXIF metadata from organization logo uploads to prevent sensitive location/device data leakage.

### Changes
- Integrated Sharp EXIF stripping pipeline on image processing service.
- Verified with unit tests.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/23318?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

