### PR TITLE
fix: add SettingsRolesQueryEffect to invite tab

### DIFF
--- a/packages/twenty-front/src/pages/settings/members/tabs/SettingsWorkspaceMembersInviteTab.tsx
+++ b/packages/twenty-front/src/pages/settings/members/tabs/SettingsWorkspaceMembersInviteTab.tsx
@@ -6,6 +6,8 @@ import { isNonEmptyArray } from '@sniptt/guards';
 import { formatDistanceToNow } from 'date-fns';
 import { useContext, useMemo } from 'react';
 
+import { SettingsRolesQueryEffect } from '@/settings/roles/components/SettingsRolesQueryEffect';
+
 import { useSnackBarOnQueryError } from '@/apollo/hooks/useSnackBarOnQueryError';
 import { currentWorkspaceState } from '@/auth/states/currentWorkspaceState';
 import { useSettingsAllRoles } from '@/settings/roles/hooks/useSettingsAllRoles';
@@ -123,6 +125,7 @@ export const SettingsWorkspaceMembersInviteTab = () => {
 
   return (
     <>
+      <SettingsRolesQueryEffect />
       {currentWorkspace?.inviteHash &&
         currentWorkspace?.isPublicInviteLinkEnabled && (
           <Section>


### PR DESCRIPTION
Fixes #23302

## Problem
The role select in the user invite form was only interactive after navigating to the roles tab because the roles data wasn't being fetched on the invite page.

## Solution
Add SettingsRolesQueryEffect to SettingsWorkspaceMembersInviteTab to ensure roles are loaded regardless of which settings page the user visits.

## Changes
Added SettingsRolesQueryEffect import and render in the component tree.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/23320?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

