### PR TITLE
fix(server): enforce non-nullable application version entity column

### DIFF
--- a/packages/twenty-server/src/engine/core-modules/application/application-manifest/application-sync.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/application/application-manifest/application-sync.service.ts
@@ -155,7 +155,7 @@ export class ApplicationSyncService {
       description: manifest.application.description ?? null,
       logo: manifest.application.logo ?? manifest.application.logoUrl ?? null,
       logoFileId: null,
-      version: null,
+      version: '0.0.0',
       sourceType: ApplicationRegistrationSourceType.LOCAL,
       sourcePath: manifest.application.universalIdentifier,
       packageJsonChecksum: null,

--- a/packages/twenty-server/src/engine/core-modules/application/application.entity.ts
+++ b/packages/twenty-server/src/engine/core-modules/application/application.entity.ts
@@ -71,9 +71,8 @@ export class ApplicationEntity extends WorkspaceRelatedEntity {
   @JoinColumn({ name: 'logoFileId' })
   logoFile: Relation<FileEntity> | null;
 
-  // TODO should not be nullable
-  @Column({ nullable: true, type: 'text' })
-  version: string | null;
+  @Column({ nullable: false, type: 'text', default: '0.0.0' })
+  version: string;
 
   @Column({ type: 'text', default: ApplicationRegistrationSourceType.LOCAL })
   sourceType: ApplicationRegistrationSourceType;


### PR DESCRIPTION
## Summary
Resolves an open TODO regarding the application entity version column, enforcing non-nullability at the DB level.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/23334?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

