### PR TITLE
Fireflies: upgrade to twenty-sdk 2.23

### DIFF
--- a/packages/twenty-apps/public/twenty-fireflies/package.json
+++ b/packages/twenty-apps/public/twenty-fireflies/package.json
@@ -6,7 +6,8 @@
   "engines": {
     "node": "^24.5.0",
     "npm": "please-use-yarn",
-    "yarn": ">=4.0.2"
+    "yarn": ">=4.0.2",
+    "twenty": ">=2.23.0"
   },
   "keywords": [
     "twenty-app"
@@ -33,8 +34,8 @@
     "oxlint": "^0.16.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
-    "twenty-client-sdk": "^2.18.0",
-    "twenty-sdk": "^2.18.0",
+    "twenty-client-sdk": "2.23.0-alpha.2",
+    "twenty-sdk": "2.23.0-alpha.2",
     "twenty-ui": "^1.0.0-alpha.1",
     "typescript": "^5.9.3",
     "vite-tsconfig-paths": "^4.2.1",

--- a/packages/twenty-apps/public/twenty-fireflies/yarn.lock
+++ b/packages/twenty-apps/public/twenty-fireflies/yarn.lock
@@ -1375,8 +1375,8 @@ __metadata:
     oxlint: "npm:^0.16.0"
     react: "npm:^18.2.0"
     react-dom: "npm:^18.2.0"
-    twenty-client-sdk: "npm:^2.18.0"
-    twenty-sdk: "npm:^2.18.0"
+    twenty-client-sdk: "npm:2.23.0-alpha.2"
+    twenty-sdk: "npm:2.23.0-alpha.2"
     twenty-ui: "npm:^1.0.0-alpha.1"
     typescript: "npm:^5.9.3"
     vite-tsconfig-paths: "npm:^4.2.1"
@@ -3642,22 +3642,22 @@ __metadata:
   languageName: node
   linkType: hard
 
-"twenty-client-sdk@npm:2.18.0, twenty-client-sdk@npm:^2.18.0":
-  version: 2.18.0
-  resolution: "twenty-client-sdk@npm:2.18.0"
+"twenty-client-sdk@npm:2.23.0-alpha.2":
+  version: 2.23.0-alpha.2
+  resolution: "twenty-client-sdk@npm:2.23.0-alpha.2"
   dependencies:
     "@genql/runtime": "npm:^2.10.0"
     esbuild: "npm:^0.28.1"
     graphql: "npm:^16.8.1"
     lodash: "npm:^4.17.21"
     prettier: "npm:^3.8.3"
-  checksum: 10c0/3b7d6ca4e7b59c04cd2348af0f2ba8de153e70d565b4a38c2744b44998dfcc6c2bdb84ba6315cec208953d8c6fa7573ab33c17355f971f279299d470c57be06e
+  checksum: 10c0/9bdee21c07c3a3369199289e16860213c9dde995e62bbdbce20ad0aa4490d8a664cd3c9a1c654bc6291189c8941616dda38df359828472330b15efdf9f4c089f
   languageName: node
   linkType: hard
 
-"twenty-sdk@npm:^2.18.0":
-  version: 2.18.0
-  resolution: "twenty-sdk@npm:2.18.0"
+"twenty-sdk@npm:2.23.0-alpha.2":
+  version: 2.23.0-alpha.2
+  resolution: "twenty-sdk@npm:2.23.0-alpha.2"
   dependencies:
     "@sniptt/guards": "npm:^0.2.0"
     axios: "npm:^1.16.0"
@@ -3676,12 +3676,12 @@ __metadata:
     semver: "npm:7.6.3"
     sharp: "npm:^0.34.5"
     tinyglobby: "npm:^0.2.15"
-    twenty-client-sdk: "npm:2.18.0"
+    twenty-client-sdk: "npm:2.23.0-alpha.2"
     typescript: "npm:^5.9.3"
     uuid: "npm:^13.0.2"
   bin:
     twenty: dist/cli.cjs
-  checksum: 10c0/7e6d300894c427029e4124047614b55988671c914332613acb38f830cee11ecc480ff2a586b6153756aab1b7fa7f4520cf072c9db1428cd9ce9b9f7a62dfcd64
+  checksum: 10c0/82f820a23bc84fb45b6ca06e237b02d71cb9c5fddc98bcdaa4838e1268a7c687242ff89f429ae7c5b30c211325de8f8d349d57f18acdb8130c1d2f677c1db913
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Fireflies was skipped by both SDK bump sweeps (#23124, #23165) and sat on `twenty-sdk ^2.18.0` with no `engines.twenty` floor, while the rest of the published set moved to `2.23.0-alpha.2`.

- `twenty-sdk` / `twenty-client-sdk` `^2.18.0` -> `2.23.0-alpha.2`
- adds `engines.twenty: ">=2.23.0"`

No source changes needed: the 2.19 identifier migration (#22601) only affected apps referencing a standard object's system-field identifier, defining a relation into a standard object, or calling the field-UID derivation helper. Fireflies does none of those.

The `engines.twenty` floor means the app integration job needs a server image at 2.23+, so it may fail on version mismatch rather than an app defect, as in #22601.