### PR TITLE
Fireflies: stamp applicationId and stop stranding recordings in PROCESSING

### DIFF
--- a/packages/twenty-apps/public/twenty-fireflies/package.json
+++ b/packages/twenty-apps/public/twenty-fireflies/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@twentyhq/twenty-fireflies",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Fireflies call-transcript connector for Twenty",
   "license": "MIT",
   "engines": {

--- a/packages/twenty-apps/public/twenty-fireflies/src/logic-functions/constants/call-recording-status.ts
+++ b/packages/twenty-apps/public/twenty-fireflies/src/logic-functions/constants/call-recording-status.ts
@@ -4,6 +4,12 @@ export const CALL_RECORDING_STATUS = {
   COMPLETED: 'COMPLETED',
 } as const;
 
+export type CallRecordingStatus =
+  (typeof CALL_RECORDING_STATUS)[keyof typeof CALL_RECORDING_STATUS];
+
 export const CALL_RECORDING_REQUEST_STATUS = {
   REQUESTED: 'REQUESTED',
 } as const;
+
+export type CallRecordingRequestStatus =
+  (typeof CALL_RECORDING_REQUEST_STATUS)[keyof typeof CALL_RECORDING_REQUEST_STATUS];

--- a/packages/twenty-apps/public/twenty-fireflies/src/logic-functions/utils/sync-fireflies-call-to-call-recording.ts
+++ b/packages/twenty-apps/public/twenty-fireflies/src/logic-functions/utils/sync-fireflies-call-to-call-recording.ts
@@ -112,7 +112,8 @@ export const syncFirefliesCallToCallRecording = async ({
       createFields: {
         ...sharedFields,
         recordingRequestStatus: CALL_RECORDING_REQUEST_STATUS.REQUESTED,
-        status: sharedFields.status ?? CALL_RECORDING_STATUS.PROCESSING,
+        // Fireflies only surfaces calls that already ended.
+        status: CALL_RECORDING_STATUS.COMPLETED,
       },
       updateFields: sharedFields,
     });
@@ -159,10 +160,7 @@ const buildFieldUpdate = ({
 
     return {
       empty: false,
-      fields: {
-        transcript: entries,
-        status: CALL_RECORDING_STATUS.COMPLETED,
-      },
+      fields: { transcript: entries },
     };
   }
 

--- a/packages/twenty-apps/public/twenty-fireflies/src/logic-functions/utils/upsert-call-recording.ts
+++ b/packages/twenty-apps/public/twenty-fireflies/src/logic-functions/utils/upsert-call-recording.ts
@@ -1,16 +1,25 @@
 import { type CoreApiClient } from 'twenty-client-sdk/core';
 import { isDefined } from 'src/utils/is-defined';
 
+import { APPLICATION_UNIVERSAL_IDENTIFIER } from 'src/constants/universal-identifiers';
+import {
+  type CallRecordingRequestStatus,
+  type CallRecordingStatus,
+} from 'src/logic-functions/constants/call-recording-status';
+
 export type CallRecordingWriteFields = {
   title?: string;
-  status?: string;
-  recordingRequestStatus?: string;
   externalRecordingId?: string;
   startedAt?: string;
   endedAt?: string;
   transcript?: unknown;
   summary?: { markdown: string; blocknote: null };
   calendarEventId?: string;
+};
+
+export type CallRecordingCreateFields = CallRecordingWriteFields & {
+  status: CallRecordingStatus;
+  recordingRequestStatus: CallRecordingRequestStatus;
 };
 
 type UpsertCallRecordingResult = {
@@ -60,7 +69,7 @@ export const upsertCallRecording = async (
     updateFields,
   }: {
     id: string;
-    createFields: CallRecordingWriteFields;
+    createFields: CallRecordingCreateFields;
     updateFields: CallRecordingWriteFields;
   },
 ): Promise<UpsertCallRecordingResult> => {
@@ -75,7 +84,13 @@ export const upsertCallRecording = async (
   try {
     await client.mutation({
       createCallRecording: {
-        __args: { data: { id, ...createFields } },
+        __args: {
+          data: {
+            id,
+            ...createFields,
+            applicationId: APPLICATION_UNIVERSAL_IDENTIFIER,
+          },
+        },
         id: true,
       },
     });


### PR DESCRIPTION
Three fixes to what the app writes to `CallRecording`.

**Stamp `applicationId`.** App-created rows carried provenance only through the `createdBy` actor name. The create path now sets `applicationId`; updates leave it alone.

**Recordings no longer strand in `PROCESSING`.** Only the transcript path set `status: COMPLETED`. The summary path set none, so creates fell back to `PROCESSING`. For a call Fireflies summarized but produced no sentences for, the summary webhook created the row at `PROCESSING` and the transcript sync skipped without writing, leaving nothing to move it. Fireflies only ever hands us calls that already ended, so creates are now unconditionally `COMPLETED`.

**Type status writes.** `CallRecordingWriteFields` typed `status` and `recordingRequestStatus` as `string`. The published SDK ships `type CoreSchema = {}`, so that passes locally but not against a schema generated from a running server. Create-only fields split into `CallRecordingCreateFields`, typed off the existing mirrored constants like call-recorder does.

The mirrored constants keep `PROCESSING` — they mirror core's select options and the integration test guards them against the live schema.

