### PR TITLE
feat(website): send the referring partner with a client brief

### DIFF
--- a/packages/twenty-website/src/app/[locale]/(focused)/partners/brief/ClientBriefPageContent.tsx
+++ b/packages/twenty-website/src/app/[locale]/(focused)/partners/brief/ClientBriefPageContent.tsx
@@ -25,11 +25,15 @@ const BriefContainer = styled.div`
   }
 `;
 
-export function ClientBriefPageContent() {
+export function ClientBriefPageContent({
+  partnerSlug,
+}: {
+  partnerSlug?: string;
+}) {
   return (
     <BriefBackground data-scheme="dark">
       <BriefContainer>
-        <ClientBriefWizard />
+        <ClientBriefWizard partnerSlug={partnerSlug} />
       </BriefContainer>
     </BriefBackground>
   );

--- a/packages/twenty-website/src/app/[locale]/(focused)/partners/brief/page.tsx
+++ b/packages/twenty-website/src/app/[locale]/(focused)/partners/brief/page.tsx
@@ -1,3 +1,4 @@
+import { normalizePartnerSlug } from '@/client-brief/normalize-partner-slug';
 import {
   getRouteI18n,
   type LocaleRouteParams,
@@ -10,10 +11,19 @@ export const generateMetadata = buildRouteMetadata('partnersBrief');
 
 export default async function ClientBriefPage({
   params,
+  searchParams,
 }: {
   params: Promise<LocaleRouteParams>;
+  searchParams: Promise<{ partner?: string | string[] }>;
 }) {
-  await getRouteI18n(params);
+  const [, resolvedSearchParams] = await Promise.all([
+    getRouteI18n(params),
+    searchParams,
+  ]);
 
-  return <ClientBriefPageContent />;
+  return (
+    <ClientBriefPageContent
+      partnerSlug={normalizePartnerSlug(resolvedSearchParams.partner)}
+    />
+  );
 }

--- a/packages/twenty-website/src/app/[locale]/(focused)/partners/brief/page.tsx
+++ b/packages/twenty-website/src/app/[locale]/(focused)/partners/brief/page.tsx
@@ -16,14 +16,8 @@ export default async function ClientBriefPage({
   params: Promise<LocaleRouteParams>;
   searchParams: Promise<{ partner?: string | string[] }>;
 }) {
-  const [, resolvedSearchParams] = await Promise.all([
-    getRouteI18n(params),
-    searchParams,
-  ]);
+  await getRouteI18n(params);
+  const { partner } = await searchParams;
 
-  return (
-    <ClientBriefPageContent
-      partnerSlug={normalizePartnerSlug(resolvedSearchParams.partner)}
-    />
-  );
+  return <ClientBriefPageContent partnerSlug={normalizePartnerSlug(partner)} />;
 }

--- a/packages/twenty-website/src/client-brief/build-client-brief-request-body.test.ts
+++ b/packages/twenty-website/src/client-brief/build-client-brief-request-body.test.ts
@@ -1,0 +1,23 @@
+import { buildClientBriefRequestBody } from './build-client-brief-request-body';
+import { INITIAL_CLIENT_BRIEF_STATE } from './client-brief-state';
+
+const state = {
+  ...INITIAL_CLIENT_BRIEF_STATE,
+  firstName: 'Jane',
+  lastName: 'Smith',
+  email: 'jane@acme.com',
+  companyName: 'Acme Real Estate',
+  need: 'Migrate from HubSpot',
+};
+
+describe('buildClientBriefRequestBody', () => {
+  it('puts the referring partner slug on the wire', () => {
+    expect(
+      buildClientBriefRequestBody(state, 'acme-consulting').partnerSlug,
+    ).toBe('acme-consulting');
+  });
+
+  it('omits the key entirely when no slug is given', () => {
+    expect('partnerSlug' in buildClientBriefRequestBody(state)).toBe(false);
+  });
+});

--- a/packages/twenty-website/src/client-brief/build-client-brief-request-body.ts
+++ b/packages/twenty-website/src/client-brief/build-client-brief-request-body.ts
@@ -10,6 +10,7 @@ function splitLanguages(value: string): string[] {
 
 export function buildClientBriefRequestBody(
   state: ClientBriefState,
+  partnerSlug?: string,
 ): ClientBriefRequest {
   const body: ClientBriefRequest = {
     firstName: state.firstName.trim(),
@@ -27,6 +28,7 @@ export function buildClientBriefRequestBody(
   if (state.seatCount.trim()) body.seatCount = state.seatCount.trim();
   if (state.timeline.trim()) body.timeline = state.timeline.trim();
   if (state.budgetRange.trim()) body.budgetRange = state.budgetRange.trim();
+  if (partnerSlug !== undefined) body.partnerSlug = partnerSlug;
 
   return body;
 }

--- a/packages/twenty-website/src/client-brief/build-client-brief-request-body.ts
+++ b/packages/twenty-website/src/client-brief/build-client-brief-request-body.ts
@@ -28,7 +28,7 @@ export function buildClientBriefRequestBody(
   if (state.seatCount.trim()) body.seatCount = state.seatCount.trim();
   if (state.timeline.trim()) body.timeline = state.timeline.trim();
   if (state.budgetRange.trim()) body.budgetRange = state.budgetRange.trim();
-  if (partnerSlug !== undefined) body.partnerSlug = partnerSlug;
+  if (partnerSlug) body.partnerSlug = partnerSlug;
 
   return body;
 }

--- a/packages/twenty-website/src/client-brief/client-brief-request-schema.test.ts
+++ b/packages/twenty-website/src/client-brief/client-brief-request-schema.test.ts
@@ -68,4 +68,22 @@ describe('clientBriefRequestSchema', () => {
         .success,
     ).toBe(false);
   });
+
+  it('accepts a payload carrying a referring partner slug', () => {
+    expect(
+      clientBriefRequestSchema.safeParse({
+        ...minimalValid,
+        partnerSlug: 'acme-consulting',
+      }).success,
+    ).toBe(true);
+  });
+
+  it('rejects a malformed partner slug', () => {
+    expect(
+      clientBriefRequestSchema.safeParse({
+        ...minimalValid,
+        partnerSlug: 'Acme Consulting!',
+      }).success,
+    ).toBe(false);
+  });
 });

--- a/packages/twenty-website/src/client-brief/client-brief-request-schema.ts
+++ b/packages/twenty-website/src/client-brief/client-brief-request-schema.ts
@@ -3,16 +3,9 @@ import { z } from 'zod';
 import { emailFieldSchema } from '@/partner-application/email-field-schema';
 
 import { CLIENT_BRIEF_HOSTING_TYPES } from './data/hosting-type-values';
+import { partnerSlugSchema } from './partner-slug-schema';
 
 const optionalNonEmptyString = z.string().trim().min(1).optional();
-
-// Mirrors the backend `slugify` output; shared with normalizePartnerSlug so the
-// rule has one owner.
-export const partnerSlugSchema = z
-  .string()
-  .trim()
-  .regex(/^[a-z0-9-]+$/)
-  .max(100);
 
 export const clientBriefRequestSchema = z.strictObject({
   firstName: z.string().trim().min(1, { error: 'First name is required.' }),

--- a/packages/twenty-website/src/client-brief/client-brief-request-schema.ts
+++ b/packages/twenty-website/src/client-brief/client-brief-request-schema.ts
@@ -19,6 +19,12 @@ export const clientBriefRequestSchema = z.strictObject({
   seatCount: optionalNonEmptyString,
   timeline: optionalNonEmptyString,
   budgetRange: optionalNonEmptyString,
+  partnerSlug: z
+    .string()
+    .trim()
+    .regex(/^[a-z0-9-]+$/)
+    .max(100)
+    .optional(),
 });
 
 export type ClientBriefRequest = z.infer<typeof clientBriefRequestSchema>;

--- a/packages/twenty-website/src/client-brief/client-brief-request-schema.ts
+++ b/packages/twenty-website/src/client-brief/client-brief-request-schema.ts
@@ -6,6 +6,14 @@ import { CLIENT_BRIEF_HOSTING_TYPES } from './data/hosting-type-values';
 
 const optionalNonEmptyString = z.string().trim().min(1).optional();
 
+// Mirrors the backend `slugify` output; shared with normalizePartnerSlug so the
+// rule has one owner.
+export const partnerSlugSchema = z
+  .string()
+  .trim()
+  .regex(/^[a-z0-9-]+$/)
+  .max(100);
+
 export const clientBriefRequestSchema = z.strictObject({
   firstName: z.string().trim().min(1, { error: 'First name is required.' }),
   lastName: z.string(),
@@ -19,12 +27,7 @@ export const clientBriefRequestSchema = z.strictObject({
   seatCount: optionalNonEmptyString,
   timeline: optionalNonEmptyString,
   budgetRange: optionalNonEmptyString,
-  partnerSlug: z
-    .string()
-    .trim()
-    .regex(/^[a-z0-9-]+$/)
-    .max(100)
-    .optional(),
+  partnerSlug: partnerSlugSchema.optional(),
 });
 
 export type ClientBriefRequest = z.infer<typeof clientBriefRequestSchema>;

--- a/packages/twenty-website/src/client-brief/normalize-partner-slug.test.ts
+++ b/packages/twenty-website/src/client-brief/normalize-partner-slug.test.ts
@@ -1,0 +1,29 @@
+import { normalizePartnerSlug } from './normalize-partner-slug';
+
+describe('normalizePartnerSlug', () => {
+  it('returns a well-formed slug unchanged', () => {
+    expect(normalizePartnerSlug('acme-consulting')).toBe('acme-consulting');
+  });
+
+  it('returns undefined when the param is absent', () => {
+    expect(normalizePartnerSlug(undefined)).toBeUndefined();
+  });
+
+  it('returns undefined for an empty string', () => {
+    expect(normalizePartnerSlug('')).toBeUndefined();
+  });
+
+  it('drops a slug with unsupported characters instead of forwarding it', () => {
+    expect(normalizePartnerSlug('Acme Consulting!')).toBeUndefined();
+  });
+
+  it('drops an over-long slug', () => {
+    expect(normalizePartnerSlug('a'.repeat(101))).toBeUndefined();
+  });
+
+  it('takes the first value when the param is repeated', () => {
+    expect(normalizePartnerSlug(['acme-consulting', 'other'])).toBe(
+      'acme-consulting',
+    );
+  });
+});

--- a/packages/twenty-website/src/client-brief/normalize-partner-slug.ts
+++ b/packages/twenty-website/src/client-brief/normalize-partner-slug.ts
@@ -1,0 +1,12 @@
+const PARTNER_SLUG_PATTERN = /^[a-z0-9-]{1,100}$/;
+
+// The API schema is strict, so a malformed value must be dropped here rather
+// than forwarded and rejected — that would fail the whole brief submission.
+export function normalizePartnerSlug(
+  raw: string | string[] | undefined,
+): string | undefined {
+  const value = Array.isArray(raw) ? raw[0] : raw;
+  if (value === undefined) return undefined;
+  const trimmed = value.trim();
+  return PARTNER_SLUG_PATTERN.test(trimmed) ? trimmed : undefined;
+}

--- a/packages/twenty-website/src/client-brief/normalize-partner-slug.ts
+++ b/packages/twenty-website/src/client-brief/normalize-partner-slug.ts
@@ -1,11 +1,9 @@
-import { clientBriefRequestSchema } from './client-brief-request-schema';
+import { partnerSlugSchema } from './client-brief-request-schema';
 
 // The API schema is strict: a malformed value must be dropped here, not
 // forwarded, or it fails the whole brief submission.
 export function normalizePartnerSlug(
   raw: string | string[] | undefined,
 ): string | undefined {
-  return clientBriefRequestSchema.shape.partnerSlug.safeParse(
-    Array.isArray(raw) ? raw[0] : raw,
-  ).data;
+  return partnerSlugSchema.safeParse(Array.isArray(raw) ? raw[0] : raw).data;
 }

--- a/packages/twenty-website/src/client-brief/normalize-partner-slug.ts
+++ b/packages/twenty-website/src/client-brief/normalize-partner-slug.ts
@@ -1,12 +1,11 @@
-const PARTNER_SLUG_PATTERN = /^[a-z0-9-]{1,100}$/;
+import { clientBriefRequestSchema } from './client-brief-request-schema';
 
-// The API schema is strict, so a malformed value must be dropped here rather
-// than forwarded and rejected — that would fail the whole brief submission.
+// The API schema is strict: a malformed value must be dropped here, not
+// forwarded, or it fails the whole brief submission.
 export function normalizePartnerSlug(
   raw: string | string[] | undefined,
 ): string | undefined {
-  const value = Array.isArray(raw) ? raw[0] : raw;
-  if (value === undefined) return undefined;
-  const trimmed = value.trim();
-  return PARTNER_SLUG_PATTERN.test(trimmed) ? trimmed : undefined;
+  return clientBriefRequestSchema.shape.partnerSlug.safeParse(
+    Array.isArray(raw) ? raw[0] : raw,
+  ).data;
 }

--- a/packages/twenty-website/src/client-brief/normalize-partner-slug.ts
+++ b/packages/twenty-website/src/client-brief/normalize-partner-slug.ts
@@ -1,4 +1,4 @@
-import { partnerSlugSchema } from './client-brief-request-schema';
+import { partnerSlugSchema } from './partner-slug-schema';
 
 // The API schema is strict: a malformed value must be dropped here, not
 // forwarded, or it fails the whole brief submission.

--- a/packages/twenty-website/src/client-brief/partner-slug-schema.ts
+++ b/packages/twenty-website/src/client-brief/partner-slug-schema.ts
@@ -1,0 +1,9 @@
+import { z } from 'zod';
+
+// Mirrors the backend `slugify` output. Shared by the request schema and
+// normalizePartnerSlug so the rule has one owner.
+export const partnerSlugSchema = z
+  .string()
+  .trim()
+  .regex(/^[a-z0-9-]+$/)
+  .max(100);

--- a/packages/twenty-website/src/client-brief/wizard/ClientBriefWizard.tsx
+++ b/packages/twenty-website/src/client-brief/wizard/ClientBriefWizard.tsx
@@ -135,7 +135,7 @@ function StepRenderer({ controller }: { controller: ClientBriefController }) {
   }
 }
 
-export function ClientBriefWizard() {
+export function ClientBriefWizard({ partnerSlug }: { partnerSlug?: string }) {
   const { i18n } = useLingui();
   const controller = useClientBriefState();
   const {
@@ -176,7 +176,7 @@ export function ClientBriefWizard() {
         return;
       }
 
-      const payload = buildClientBriefRequestBody(state);
+      const payload = buildClientBriefRequestBody(state, partnerSlug);
       setSubmitting(true);
       try {
         const response = await fetch('/api/client-brief', {
@@ -199,6 +199,7 @@ export function ClientBriefWizard() {
       goNext,
       i18n,
       isLastStep,
+      partnerSlug,
       setFieldErrors,
       setSubmitError,
       setSubmitted,

--- a/packages/twenty-website/src/partners-marketplace/PartnerProfile.tsx
+++ b/packages/twenty-website/src/partners-marketplace/PartnerProfile.tsx
@@ -144,6 +144,7 @@ export function PartnerProfile({ partner }: { partner: MarketplacePartner }) {
               calendarLink={partner.calendarLink}
               links={partner.links}
               linkUrls={partner.linkUrls}
+              slug={partner.slug}
             />
             <PartnerRatesPanel
               hourlyRateUsd={partner.hourlyRateUsd}

--- a/packages/twenty-website/src/partners-marketplace/PartnerProfileCtas.tsx
+++ b/packages/twenty-website/src/partners-marketplace/PartnerProfileCtas.tsx
@@ -118,10 +118,12 @@ export function PartnerProfileCtas({
   calendarLink,
   links,
   linkUrls,
+  slug,
 }: {
   calendarLink: string;
   links: PartnerLinks;
   linkUrls?: readonly string[];
+  slug: string;
 }) {
   const { i18n } = useLingui();
   const calendarHref = isSafeHttpUrl(calendarLink) ? calendarLink : null;
@@ -178,7 +180,7 @@ export function PartnerProfileCtas({
         )}
         <PrimaryAction>
           <Button
-            href="/partners/brief"
+            href={`/partners/brief?partner=${encodeURIComponent(slug)}`}
             label={i18n._(msg`Submit a brief`)}
             variant="outlined"
           />


### PR DESCRIPTION
**Pairs with #23344** (`twenty-partners` v1.4.1), which adds the `referredByPartner` relation and the Discord notification. This PR is the sender; that one is the receiver.

**Merge #23344 first.** Its schema is a non-strict `z.object`, so an unknown `partnerSlug` is stripped rather than rejected — shipping this one first degrades silently (attribution dropped) rather than breaking, but there is no reason to. Until #23344 is deployed, this field goes nowhere.

No dependency in the other direction and no shared files: #23344 is entirely inside `packages/twenty-apps`, this is entirely inside `packages/twenty-website`.

## What this does

A visitor can reach the client brief form from two places: the marketplace listing page, or a specific partner's profile. Until now both produced an identical payload, so the partner whose page drove the lead was lost.

This sends the partner's slug along with the brief when the form was opened from a profile page. #23344 resolves it to a Partner record and links it to the created Opportunity.

## How it flows

`PartnerProfileCtas` links to `/partners/brief?partner=<slug>` → `page.tsx` reads and normalizes the param → prop threaded through `ClientBriefPageContent` → `ClientBriefWizard` → `buildClientBriefRequestBody`.

The slug is inert context, never a form field, so the wizard reducer and `ClientBriefState` are untouched.

The three CTAs on `/partners/list` (`MarketplaceHeader`, `MarketplaceMatchCard`, `MarketplaceBriefPrompt`) stay bare — a brief from the listing page has no referring partner, and the notification labels it "Marketplace listing".

## Why `normalizePartnerSlug` exists

`clientBriefRequestSchema` is a `z.strictObject`. Forwarding a malformed `?partner=` value straight into the body would fail validation for the **entire request** and lose the brief — a bad trade for an attribution field the visitor never saw.

So the param is normalized at the boundary: array-valued params take the first entry, and anything not matching `[a-z0-9-]{1,100}` is dropped to `undefined` rather than passed on. The charset mirrors the app's `slugify` helper, which is what produced the slugs in the first place.

## Testing

8 new cases — 6 for the normalizer (well-formed, absent, empty, bad charset, over-long, repeated param) and 2 for the schema. Suite: 456 passing, up exactly 8 from a 448 baseline. `oxlint` and `oxfmt --check` clean; `next build` compiles with no type errors.

Verified in a browser rather than asserted: opening a partner profile, clicking "Submit a brief", and completing the wizard produces

```json
{"firstName":"Jane","lastName":"","email":"…","companyName":"NetZero Test Co","need":"…","partnerSlug":"netzero-systems"}
```

on `POST /api/client-brief` → 200. `LocalizedLink` preserves the query string across locale prefixing (`localize-href.test.ts:20` already covers this; confirmed live on the FR route).

## Deliberately not included

- **CTA-level attribution.** Which of the three listing-page CTAs was used is not tracked. That is click analytics, a different concern from partner attribution.
- **Length bounds on the other brief fields.** `country`, `seatCount`, `timeline`, `budgetRange` and `companyName` remain unbounded, as they were before this PR. Worth tightening, but pre-existing and out of scope here.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/23351?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

