### PR TITLE
fix(front): activity target filter fails on renamed custom objects

### DIFF
--- a/packages/twenty-front/src/modules/activities/hooks/useActivityTargetsForTargetableObjects.ts
+++ b/packages/twenty-front/src/modules/activities/hooks/useActivityTargetsForTargetableObjects.ts
@@ -8,10 +8,12 @@ import { type ActivityTargetableObject } from '@/activities/types/ActivityTarget
 import { type NoteTarget } from '@/activities/types/NoteTarget';
 import { type TaskTarget } from '@/activities/types/TaskTarget';
 import { getActivityTargetsFilter } from '@/activities/utils/getActivityTargetsFilter';
+import { getJoinObjectNameSingular } from '@/activities/utils/getJoinObjectNameSingular';
 import { objectMetadataItemsSelector } from '@/object-metadata/states/objectMetadataItemsSelector';
 import { type EnrichedObjectMetadataItem } from '@/object-metadata/types/EnrichedObjectMetadataItem';
 import { useFindManyRecords } from '@/object-record/hooks/useFindManyRecords';
 import { useAtomStateValue } from '@/ui/utilities/state/jotai/hooks/useAtomStateValue';
+import { isDefined } from 'twenty-shared/utils';
 
 export const useActivityTargetsForTargetableObjects = ({
   objectNameSingular,
@@ -34,8 +36,23 @@ export const useActivityTargetsForTargetableObjects = ({
   const objectMetadataItems = useAtomStateValue<EnrichedObjectMetadataItem[]>(
     objectMetadataItemsSelector,
   );
+
+  const activityTargetObjectNameSingular =
+    getJoinObjectNameSingular(objectNameSingular);
+  const activityTargetObjectMetadataItem = objectMetadataItems.find(
+    (objectMetadataItem) =>
+      objectMetadataItem.nameSingular === activityTargetObjectNameSingular,
+  );
+
+  if (!isDefined(activityTargetObjectMetadataItem)) {
+    throw new Error(
+      `Cannot find activity target object metadata item for ${activityTargetObjectNameSingular}`,
+    );
+  }
+
   const activityTargetsFilter = getActivityTargetsFilter({
     targetableObjects,
+    activityTargetObjectMetadataItem,
   });
 
   const FIND_ACTIVITY_TARGETS_OPERATION_SIGNATURE =

--- a/packages/twenty-front/src/modules/activities/utils/__tests__/getActivityTargetsFilter.test.ts
+++ b/packages/twenty-front/src/modules/activities/utils/__tests__/getActivityTargetsFilter.test.ts
@@ -45,7 +45,9 @@ describe('getActivityTargetsFilter', () => {
     });
 
     const filter = getActivityTargetsFilter({
-      targetableObjects: [{ id: 'record-1', targetObjectNameSingular: 'ligacao' }],
+      targetableObjects: [
+        { id: 'record-1', targetObjectNameSingular: 'ligacao' },
+      ],
       activityTargetObjectMetadataItem,
     });
 

--- a/packages/twenty-front/src/modules/activities/utils/__tests__/getActivityTargetsFilter.test.ts
+++ b/packages/twenty-front/src/modules/activities/utils/__tests__/getActivityTargetsFilter.test.ts
@@ -1,0 +1,72 @@
+import { getActivityTargetsFilter } from '@/activities/utils/getActivityTargetsFilter';
+import { type EnrichedObjectMetadataItem } from '@/object-metadata/types/EnrichedObjectMetadataItem';
+import { FieldMetadataType, RelationType } from '~/generated-metadata/graphql';
+
+const buildNoteTargetMetadata = ({
+  fieldName,
+  joinColumnName,
+  targetNameSingular,
+}: {
+  fieldName: string;
+  joinColumnName: string;
+  targetNameSingular: string;
+}) =>
+  ({
+    nameSingular: 'noteTarget',
+    fields: [
+      {
+        name: fieldName,
+        type: FieldMetadataType.MORPH_RELATION,
+        settings: { joinColumnName },
+        morphRelations: [
+          {
+            type: RelationType.MANY_TO_ONE,
+            targetObjectMetadata: {
+              id: 'target-object-id',
+              nameSingular: targetNameSingular,
+              namePlural: `${targetNameSingular}s`,
+            },
+          },
+        ],
+      },
+    ],
+  }) as unknown as EnrichedObjectMetadataItem;
+
+describe('getActivityTargetsFilter', () => {
+  it('uses the stored join column even when the target object was renamed', () => {
+    // Object renamed from "pet" to "ligacao": the noteTarget field name and its
+    // join column stay frozen as targetPet/targetPetId while the object now
+    // reports nameSingular "ligacao". Deriving target<Name>Id would produce
+    // targetLigacaoId, which does not exist on noteTarget.
+    const activityTargetObjectMetadataItem = buildNoteTargetMetadata({
+      fieldName: 'targetPet',
+      joinColumnName: 'targetPetId',
+      targetNameSingular: 'ligacao',
+    });
+
+    const filter = getActivityTargetsFilter({
+      targetableObjects: [{ id: 'record-1', targetObjectNameSingular: 'ligacao' }],
+      activityTargetObjectMetadataItem,
+    });
+
+    expect(filter).toEqual({ targetPetId: { eq: 'record-1' } });
+    expect(filter).not.toHaveProperty('targetLigacaoId');
+  });
+
+  it('resolves the join column for a non-renamed object', () => {
+    const activityTargetObjectMetadataItem = buildNoteTargetMetadata({
+      fieldName: 'targetCompany',
+      joinColumnName: 'targetCompanyId',
+      targetNameSingular: 'company',
+    });
+
+    const filter = getActivityTargetsFilter({
+      targetableObjects: [
+        { id: 'record-2', targetObjectNameSingular: 'company' },
+      ],
+      activityTargetObjectMetadataItem,
+    });
+
+    expect(filter).toEqual({ targetCompanyId: { eq: 'record-2' } });
+  });
+});

--- a/packages/twenty-front/src/modules/activities/utils/__tests__/getActivityTargetsFilter.test.ts
+++ b/packages/twenty-front/src/modules/activities/utils/__tests__/getActivityTargetsFilter.test.ts
@@ -2,47 +2,47 @@ import { getActivityTargetsFilter } from '@/activities/utils/getActivityTargetsF
 import { type EnrichedObjectMetadataItem } from '@/object-metadata/types/EnrichedObjectMetadataItem';
 import { FieldMetadataType, RelationType } from '~/generated-metadata/graphql';
 
-const buildNoteTargetMetadata = ({
-  fieldName,
-  joinColumnName,
-  targetNameSingular,
-}: {
-  fieldName: string;
-  joinColumnName: string;
-  targetNameSingular: string;
-}) =>
+// The metadata API collapses the per-target join fields on noteTarget/taskTarget
+// into a single MORPH_RELATION field named "target" and strips the target-name
+// suffix from each morph relation's source field name. For a non-renamed target
+// the source field name is the base "target"; for a renamed target the suffix no
+// longer matches so it keeps the original (frozen) field name (e.g. "targetPet").
+const buildActivityTargetMetadata = (
+  morphTargets: { nameSingular: string; sourceFieldName: string }[],
+) =>
   ({
     nameSingular: 'noteTarget',
     fields: [
       {
-        name: fieldName,
+        name: 'target',
         type: FieldMetadataType.MORPH_RELATION,
-        settings: { joinColumnName },
-        morphRelations: [
-          {
+        morphRelations: morphTargets.map(
+          ({ nameSingular, sourceFieldName }) => ({
             type: RelationType.MANY_TO_ONE,
             targetObjectMetadata: {
-              id: 'target-object-id',
-              nameSingular: targetNameSingular,
-              namePlural: `${targetNameSingular}s`,
+              id: `${nameSingular}-object-id`,
+              nameSingular,
+              namePlural: `${nameSingular}s`,
             },
-          },
-        ],
+            sourceFieldMetadata: {
+              id: `${nameSingular}-field-id`,
+              name: sourceFieldName,
+            },
+          }),
+        ),
       },
     ],
   }) as unknown as EnrichedObjectMetadataItem;
 
 describe('getActivityTargetsFilter', () => {
-  it('uses the stored join column even when the target object was renamed', () => {
-    // Object renamed from "pet" to "ligacao": the noteTarget field name and its
-    // join column stay frozen as targetPet/targetPetId while the object now
-    // reports nameSingular "ligacao". Deriving target<Name>Id would produce
-    // targetLigacaoId, which does not exist on noteTarget.
-    const activityTargetObjectMetadataItem = buildNoteTargetMetadata({
-      fieldName: 'targetPet',
-      joinColumnName: 'targetPetId',
-      targetNameSingular: 'ligacao',
-    });
+  it('uses the frozen join column when the target object was renamed', () => {
+    // "pet" was renamed to "ligacao": the morph relation keeps the frozen source
+    // field name "targetPet", so the join column is targetPetId. Recomputing from
+    // the current name would produce targetLigacaoId, which does not exist.
+    const activityTargetObjectMetadataItem = buildActivityTargetMetadata([
+      { nameSingular: 'company', sourceFieldName: 'target' },
+      { nameSingular: 'ligacao', sourceFieldName: 'targetPet' },
+    ]);
 
     const filter = getActivityTargetsFilter({
       targetableObjects: [
@@ -56,11 +56,10 @@ describe('getActivityTargetsFilter', () => {
   });
 
   it('resolves the join column for a non-renamed object', () => {
-    const activityTargetObjectMetadataItem = buildNoteTargetMetadata({
-      fieldName: 'targetCompany',
-      joinColumnName: 'targetCompanyId',
-      targetNameSingular: 'company',
-    });
+    const activityTargetObjectMetadataItem = buildActivityTargetMetadata([
+      { nameSingular: 'company', sourceFieldName: 'target' },
+      { nameSingular: 'ligacao', sourceFieldName: 'targetPet' },
+    ]);
 
     const filter = getActivityTargetsFilter({
       targetableObjects: [

--- a/packages/twenty-front/src/modules/activities/utils/getActivityTargetJoinColumnName.ts
+++ b/packages/twenty-front/src/modules/activities/utils/getActivityTargetJoinColumnName.ts
@@ -1,0 +1,48 @@
+import { getActivityTargetObjectFieldIdName } from '@/activities/utils/getActivityTargetObjectFieldIdName';
+import { type EnrichedObjectMetadataItem } from '@/object-metadata/types/EnrichedObjectMetadataItem';
+import { type FieldRelationMetadataSettings } from '@/object-record/record-field/ui/types/FieldMetadata';
+import { FieldMetadataType } from 'twenty-shared/types';
+import { isDefined } from 'twenty-shared/utils';
+
+// Resolve the join column from the actual relation field metadata on
+// noteTarget/taskTarget so it stays correct after a target object is renamed.
+// The derived target<Name>Id no longer matches the frozen join column once
+// the object name changes.
+export const getActivityTargetJoinColumnName = ({
+  activityTargetObjectMetadataItem,
+  targetObjectNameSingular,
+}: {
+  activityTargetObjectMetadataItem: EnrichedObjectMetadataItem;
+  targetObjectNameSingular: string;
+}): string => {
+  const relationField = activityTargetObjectMetadataItem.fields.find(
+    (field) => {
+      if (
+        field.type === FieldMetadataType.MORPH_RELATION &&
+        isDefined(field.morphRelations)
+      ) {
+        return field.morphRelations.some(
+          (morphRelation) =>
+            morphRelation.targetObjectMetadata.nameSingular ===
+            targetObjectNameSingular,
+        );
+      }
+
+      return (
+        field.relation?.targetObjectMetadata.nameSingular ===
+        targetObjectNameSingular
+      );
+    },
+  );
+
+  const joinColumnName = (
+    relationField?.settings as FieldRelationMetadataSettings
+  )?.joinColumnName;
+
+  return (
+    joinColumnName ??
+    getActivityTargetObjectFieldIdName({
+      nameSingular: targetObjectNameSingular,
+    })
+  );
+};

--- a/packages/twenty-front/src/modules/activities/utils/getActivityTargetJoinColumnName.ts
+++ b/packages/twenty-front/src/modules/activities/utils/getActivityTargetJoinColumnName.ts
@@ -2,12 +2,8 @@ import { getActivityTargetObjectFieldIdName } from '@/activities/utils/getActivi
 import { type EnrichedObjectMetadataItem } from '@/object-metadata/types/EnrichedObjectMetadataItem';
 import { type FieldRelationMetadataSettings } from '@/object-record/record-field/ui/types/FieldMetadata';
 import { FieldMetadataType } from 'twenty-shared/types';
-import { isDefined } from 'twenty-shared/utils';
+import { capitalize, isDefined } from 'twenty-shared/utils';
 
-// Resolve the join column from the actual relation field metadata on
-// noteTarget/taskTarget so it stays correct after a target object is renamed.
-// The derived target<Name>Id no longer matches the frozen join column once
-// the object name changes.
 export const getActivityTargetJoinColumnName = ({
   activityTargetObjectMetadataItem,
   targetObjectNameSingular,
@@ -15,34 +11,40 @@ export const getActivityTargetJoinColumnName = ({
   activityTargetObjectMetadataItem: EnrichedObjectMetadataItem;
   targetObjectNameSingular: string;
 }): string => {
-  const relationField = activityTargetObjectMetadataItem.fields.find(
-    (field) => {
-      if (
-        field.type === FieldMetadataType.MORPH_RELATION &&
-        isDefined(field.morphRelations)
-      ) {
-        return field.morphRelations.some(
-          (morphRelation) =>
-            morphRelation.targetObjectMetadata.nameSingular ===
-            targetObjectNameSingular,
-        );
-      }
-
-      return (
-        field.relation?.targetObjectMetadata.nameSingular ===
-        targetObjectNameSingular
+  for (const field of activityTargetObjectMetadataItem.fields) {
+    if (
+      field.type === FieldMetadataType.MORPH_RELATION &&
+      isDefined(field.morphRelations)
+    ) {
+      const morphRelation = field.morphRelations.find(
+        (relation) =>
+          relation.targetObjectMetadata.nameSingular ===
+          targetObjectNameSingular,
       );
-    },
-  );
 
-  const joinColumnName = (
-    relationField?.settings as FieldRelationMetadataSettings
-  )?.joinColumnName;
+      if (isDefined(morphRelation)) {
+        const sourceFieldName = morphRelation.sourceFieldMetadata.name;
+        const joinFieldName =
+          sourceFieldName === field.name
+            ? `${field.name}${capitalize(targetObjectNameSingular)}`
+            : sourceFieldName;
 
-  return (
-    joinColumnName ??
-    getActivityTargetObjectFieldIdName({
-      nameSingular: targetObjectNameSingular,
-    })
-  );
+        return `${joinFieldName}Id`;
+      }
+    }
+
+    if (
+      field.relation?.targetObjectMetadata.nameSingular ===
+      targetObjectNameSingular
+    ) {
+      const joinColumnName = (field.settings as FieldRelationMetadataSettings)
+        ?.joinColumnName;
+
+      return joinColumnName ?? `${field.name}Id`;
+    }
+  }
+
+  return getActivityTargetObjectFieldIdName({
+    nameSingular: targetObjectNameSingular,
+  });
 };

--- a/packages/twenty-front/src/modules/activities/utils/getActivityTargetsFilter.ts
+++ b/packages/twenty-front/src/modules/activities/utils/getActivityTargetsFilter.ts
@@ -1,20 +1,24 @@
 import { type ActivityTargetableObject } from '@/activities/types/ActivityTargetableEntity';
-import { getActivityTargetObjectFieldIdName } from '@/activities/utils/getActivityTargetObjectFieldIdName';
+import { getActivityTargetJoinColumnName } from '@/activities/utils/getActivityTargetJoinColumnName';
+import { type EnrichedObjectMetadataItem } from '@/object-metadata/types/EnrichedObjectMetadataItem';
 import { isDefined } from 'twenty-shared/utils';
 
 export const getActivityTargetsFilter = ({
   targetableObjects,
+  activityTargetObjectMetadataItem,
 }: {
   targetableObjects: Pick<
     ActivityTargetableObject,
     'id' | 'targetObjectNameSingular'
   >[];
+  activityTargetObjectMetadataItem: EnrichedObjectMetadataItem;
 }) => {
   const findManyActivityTargetsQueryFilter = Object.fromEntries(
     targetableObjects
       .map((targetableObject) => {
-        const joinColumnName = getActivityTargetObjectFieldIdName({
-          nameSingular: targetableObject.targetObjectNameSingular,
+        const joinColumnName = getActivityTargetJoinColumnName({
+          activityTargetObjectMetadataItem,
+          targetObjectNameSingular: targetableObject.targetObjectNameSingular,
         });
 
         return [


### PR DESCRIPTION
## Problem

Adding a task or note to a custom object that has been **renamed** fails with:

> Invalid filter : noteTarget object doesn't have any 'targetLigacaoId' field.

(and the `taskTarget` equivalent). The record is fine; the frontend builds a filter join-column key that no longer exists on `noteTarget`/`taskTarget`.

Fixes #21164.

## Root cause

`getActivityTargetsFilter` built the filter join-column key by recomputing `target${capitalize(nameSingular)}Id` from the target object's **current** name (`getActivityTargetObjectFieldIdName`).

On `noteTarget`/`taskTarget`, the join column for each targetable object is frozen from the field name at creation time (e.g. `targetPetId`). When the object is renamed (pet -> ligacao) the join column stays `targetPetId`, but the frontend starts sending `targetLigacaoId`, which the backend filter validator rejects with `INVALID_ARGS_FILTER`.

## Fix

Derive the join column from the actual morph relation metadata instead of recomputing it from the current object name.

The metadata API collapses the per-target join fields into a single `MORPH_RELATION` field named `target` and strips the target-name suffix from each morph relation's `sourceFieldMetadata.name`:
- non-renamed target -> source field name is the base `target`, so the join column is `target` + `Capitalize(currentName)` + `Id` (e.g. `targetCompanyId`);
- renamed target -> the stripped suffix no longer matches, so the source field name is the original frozen name (e.g. `targetPet`), and the join column is that name + `Id` (e.g. `targetPetId`).

`getActivityTargetJoinColumnName` implements this and is used by `getActivityTargetsFilter`; `useActivityTargetsForTargetableObjects` resolves the `noteTarget`/`taskTarget` metadata and passes it down.

## Test

- Unit test `getActivityTargetsFilter.test.ts`: renamed target resolves to `targetPetId` (not `targetLigacaoId`); non-renamed target resolves to `targetCompanyId`.
- Verified live against a reconstructed legacy state (object renamed but join column left stale):
  - before the fix: `FindManyNoteTargets`/`FindManyTaskTargets` send `targetLigacaoId` and fail with `Object noteTarget doesn't have any "targetLigacaoId" field.`
  - after the fix: they send `targetPetId` and succeed; a non-renamed Company record still sends `targetCompanyId`.