### PR TITLE
fix(server): enforce non-nullable application version entity column (with backfill)

### DIFF
--- a/packages/twenty-server/src/database/commands/upgrade-version-command/2-25/2-25-instance-command-fast-1785151652795-backfill-application-version.ts
+++ b/packages/twenty-server/src/database/commands/upgrade-version-command/2-25/2-25-instance-command-fast-1785151652795-backfill-application-version.ts
@@ -1,0 +1,31 @@
+import { type QueryRunner } from 'typeorm';
+
+import { RegisteredInstanceCommand } from 'src/engine/core-modules/upgrade/decorators/registered-instance-command.decorator';
+import { type FastInstanceCommand } from 'src/engine/core-modules/upgrade/interfaces/fast-instance-command.interface';
+
+@RegisteredInstanceCommand('2.25.0', 1785151652795)
+export class BackfillApplicationVersionFastInstanceCommand implements FastInstanceCommand {
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+      UPDATE "core"."application"
+      SET "version" = '0.0.0'
+      WHERE "version" IS NULL
+    `);
+
+    await queryRunner.query(
+      `ALTER TABLE "core"."application" ALTER COLUMN "version" SET DEFAULT '0.0.0'`
+    );
+    await queryRunner.query(
+      `ALTER TABLE "core"."application" ALTER COLUMN "version" SET NOT NULL`
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "core"."application" ALTER COLUMN "version" DROP DEFAULT`
+    );
+    await queryRunner.query(
+      `ALTER TABLE "core"."application" ALTER COLUMN "version" DROP NOT NULL`
+    );
+  }
+}

--- a/packages/twenty-server/src/database/commands/upgrade-version-command/instance-commands.constant.ts
+++ b/packages/twenty-server/src/database/commands/upgrade-version-command/instance-commands.constant.ts
@@ -125,6 +125,7 @@ import { AddOnConnectLogicFunctionToConnectionProviderFastInstanceCommand } from
 import { RepairKeyValuePairApplicationIdFastInstanceCommand } from './2-24/2-24-instance-command-fast-1784897347051-repair-key-value-pair-application-id';
 import { AddAgentForeignKeyToRoleTargetFastInstanceCommand } from './2-25/2-25-instance-command-fast-1784820332810-add-agent-foreign-key-to-role-target';
 import { AddPageLayoutCascadeDeleteIndexesFastInstanceCommand } from './2-25/2-25-instance-command-fast-1784904030251-add-page-layout-cascade-delete-indexes';
+import { BackfillApplicationVersionFastInstanceCommand } from './2-25/2-25-instance-command-fast-1785151652795-backfill-application-version';
 
 export const INSTANCE_COMMANDS = [
   AddViewFieldGroupIdIndexOnViewFieldFastInstanceCommand,
@@ -252,4 +253,5 @@ export const INSTANCE_COMMANDS = [
   RepairKeyValuePairApplicationIdFastInstanceCommand,
   AddAgentForeignKeyToRoleTargetFastInstanceCommand,
   AddPageLayoutCascadeDeleteIndexesFastInstanceCommand,
+  BackfillApplicationVersionFastInstanceCommand,
 ];

--- a/packages/twenty-server/src/engine/core-modules/application/application-manifest/application-sync.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/application/application-manifest/application-sync.service.ts
@@ -155,7 +155,7 @@ export class ApplicationSyncService {
       description: manifest.application.description ?? null,
       logo: manifest.application.logo ?? manifest.application.logoUrl ?? null,
       logoFileId: null,
-      version: null,
+      version: '0.0.0',
       sourceType: ApplicationRegistrationSourceType.LOCAL,
       sourcePath: manifest.application.universalIdentifier,
       packageJsonChecksum: null,

--- a/packages/twenty-server/src/engine/core-modules/application/application.entity.ts
+++ b/packages/twenty-server/src/engine/core-modules/application/application.entity.ts
@@ -71,9 +71,8 @@ export class ApplicationEntity extends WorkspaceRelatedEntity {
   @JoinColumn({ name: 'logoFileId' })
   logoFile: Relation<FileEntity> | null;
 
-  // TODO should not be nullable
-  @Column({ nullable: true, type: 'text' })
-  version: string | null;
+  @Column({ nullable: false, type: 'text', default: '0.0.0' })
+  version: string;
 
   @Column({ type: 'text', default: ApplicationRegistrationSourceType.LOCAL })
   sourceType: ApplicationRegistrationSourceType;


### PR DESCRIPTION
Follow-up to PR #23334. This includes the Fast Instance Command requested by @thomtrp to backfill existing NULL values to '0.0.0' and safely apply the schema constraints.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/23355?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

