### PR TITLE
feat(ai-agent): progressive tool loading for workflow AI Agent nodes

### DIFF
--- a/packages/twenty-server/src/engine/core-modules/cache-storage/types/cache-storage-namespace.enum.ts
+++ b/packages/twenty-server/src/engine/core-modules/cache-storage/types/cache-storage-namespace.enum.ts
@@ -12,5 +12,6 @@ export enum CacheStorageNamespace {
   EngineSubscriptions = 'engine:subscriptions',
   EngineBillingUsage = 'engine:billing-usage',
   EngineOnboardingInviteSuggestions = 'engine:onboarding-invite-suggestions',
+  EngineAiAgentToolPreload = 'engine:ai-agent-tool-preload',
   IntegrationTests = 'integration-tests',
 }

--- a/packages/twenty-server/src/engine/core-modules/tool-provider/services/tool-registry.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/tool-provider/services/tool-registry.service.ts
@@ -1,6 +1,7 @@
 import { Inject, Injectable, Logger } from '@nestjs/common';
 
 import { type ToolSet, jsonSchema } from 'ai';
+import { type ToolCategory } from 'twenty-shared/ai';
 import { type APP_LOCALES } from 'twenty-shared/translations';
 
 import { type ToolProviderContext } from 'src/engine/core-modules/tool-provider/interfaces/tool-provider-context.type';
@@ -31,17 +32,28 @@ export class ToolRegistryService {
     private readonly toolOutputSpillService: ToolOutputSpillService,
   ) {}
 
-  async getCatalog(context: ToolProviderContext): Promise<ToolIndexEntry[]> {
-    const results = await Promise.all(
-      this.providers.map(async (provider) => {
-        if (await provider.isAvailable(context)) {
-          return provider.generateDescriptors(context, {
-            includeSchemas: false,
-          });
-        }
+  async getCatalog(
+    context: ToolProviderContext,
+    options?: { categories?: ToolCategory[] },
+  ): Promise<ToolIndexEntry[]> {
+    const categorySet = options?.categories
+      ? new Set(options.categories)
+      : undefined;
 
-        return [];
-      }),
+    const results = await Promise.all(
+      this.providers
+        .filter(
+          (provider) => !categorySet || categorySet.has(provider.category),
+        )
+        .map(async (provider) => {
+          if (await provider.isAvailable(context)) {
+            return provider.generateDescriptors(context, {
+              includeSchemas: false,
+            });
+          }
+
+          return [];
+        }),
     );
 
     return results.flat();

--- a/packages/twenty-server/src/engine/metadata-modules/ai/ai-agent-execution/ai-agent-execution.module.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/ai/ai-agent-execution/ai-agent-execution.module.ts
@@ -27,6 +27,7 @@ import { AgentRunResolver } from './resolvers/agent-run.resolver';
 import { AgentActorContextService } from './services/agent-actor-context.service';
 import { AgentAsyncExecutorService } from './services/agent-async-executor.service';
 import { AgentRunService } from './services/agent-run.service';
+import { AgentToolPreloadService } from './services/agent-tool-preload.service';
 
 @Module({
   imports: [
@@ -58,6 +59,7 @@ import { AgentRunService } from './services/agent-run.service';
     AgentMessagePartResolver,
     AgentRunResolver,
     AgentRunService,
+    AgentToolPreloadService,
     provideWorkspaceScopedRepository(RoleTargetEntity),
     provideWorkspaceScopedRepository(AgentEntity),
   ],

--- a/packages/twenty-server/src/engine/metadata-modules/ai/ai-agent-execution/constants/workflow-agent-excluded-tool-names.const.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/ai/ai-agent-execution/constants/workflow-agent-excluded-tool-names.const.ts
@@ -1,0 +1,7 @@
+import { OUTPUT_NAVIGATION_TOOL_NAMES } from 'src/engine/core-modules/tool/tools/output-navigation-tool/constants/output-navigation-tool-names.constant';
+
+export const WORKFLOW_AGENT_EXCLUDED_TOOL_NAMES = [
+  ...OUTPUT_NAVIGATION_TOOL_NAMES,
+  'navigate_app',
+  'search_help_center',
+] as const;

--- a/packages/twenty-server/src/engine/metadata-modules/ai/ai-agent-execution/services/__tests__/agent-tool-preload.service.spec.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/ai/ai-agent-execution/services/__tests__/agent-tool-preload.service.spec.ts
@@ -1,0 +1,93 @@
+import { type CacheStorageService } from 'src/engine/core-modules/cache-storage/services/cache-storage.service';
+import { AgentToolPreloadService } from 'src/engine/metadata-modules/ai/ai-agent-execution/services/agent-tool-preload.service';
+
+const AGENT = {
+  id: 'agent-1',
+  updatedAt: new Date('2026-01-01T00:00:00.000Z'),
+};
+const EXPECTED_KEY = `agent-1:${AGENT.updatedAt.getTime()}`;
+const TTL_MS = 1000 * 60 * 5;
+
+describe('AgentToolPreloadService', () => {
+  let service: AgentToolPreloadService;
+  let cacheStorageService: { get: jest.Mock; set: jest.Mock };
+
+  beforeEach(() => {
+    cacheStorageService = { get: jest.fn(), set: jest.fn() };
+    service = new AgentToolPreloadService(
+      cacheStorageService as unknown as CacheStorageService,
+    );
+  });
+
+  describe('getPreloadToolNames', () => {
+    it('returns an empty array and does not slide when nothing is cached', async () => {
+      cacheStorageService.get.mockResolvedValue(undefined);
+
+      const result = await service.getPreloadToolNames(AGENT);
+
+      expect(result).toEqual([]);
+      expect(cacheStorageService.get).toHaveBeenCalledWith(EXPECTED_KEY);
+      expect(cacheStorageService.set).not.toHaveBeenCalled();
+    });
+
+    it('returns the cached set and slides the TTL, keyed by updatedAt', async () => {
+      cacheStorageService.get.mockResolvedValue(['find_many_customers']);
+
+      const result = await service.getPreloadToolNames(AGENT);
+
+      expect(result).toEqual(['find_many_customers']);
+      expect(cacheStorageService.set).toHaveBeenCalledWith(
+        EXPECTED_KEY,
+        ['find_many_customers'],
+        TTL_MS,
+      );
+    });
+  });
+
+  describe('recordToolUsage', () => {
+    it('does nothing when there are no usable tool names', async () => {
+      await service.recordToolUsage(AGENT, ['', '']);
+
+      expect(cacheStorageService.get).not.toHaveBeenCalled();
+      expect(cacheStorageService.set).not.toHaveBeenCalled();
+    });
+
+    it('merges with the existing set, dedupes and sorts', async () => {
+      cacheStorageService.get.mockResolvedValue([
+        'update_one_sales_call',
+        'find_many_customers',
+      ]);
+
+      await service.recordToolUsage(AGENT, [
+        'create_many_customers',
+        'find_many_customers',
+      ]);
+
+      expect(cacheStorageService.set).toHaveBeenLastCalledWith(
+        EXPECTED_KEY,
+        [
+          'create_many_customers',
+          'find_many_customers',
+          'update_one_sales_call',
+        ],
+        TTL_MS,
+      );
+    });
+
+    it('caps the stored set to the maximum', async () => {
+      cacheStorageService.get.mockResolvedValue([]);
+
+      const manyToolNames = Array.from(
+        { length: 20 },
+        (_, index) => `tool_${String(index).padStart(2, '0')}`,
+      );
+
+      await service.recordToolUsage(AGENT, manyToolNames);
+
+      const setCalls = cacheStorageService.set.mock.calls;
+      const storedToolNames = setCalls[setCalls.length - 1]?.[1];
+
+      expect(storedToolNames).toHaveLength(12);
+    });
+  });
+});

--- a/packages/twenty-server/src/engine/metadata-modules/ai/ai-agent-execution/services/__tests__/agent-tool-preload.service.spec.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/ai/ai-agent-execution/services/__tests__/agent-tool-preload.service.spec.ts
@@ -5,7 +5,8 @@ const AGENT = {
   id: 'agent-1',
   updatedAt: new Date('2026-01-01T00:00:00.000Z'),
 };
-const EXPECTED_KEY = `agent-1:${AGENT.updatedAt.getTime()}`;
+const STEP_ID = 'step-1';
+const EXPECTED_KEY = `agent-1:${AGENT.updatedAt.getTime()}:${STEP_ID}`;
 const TTL_MS = 1000 * 60 * 5;
 
 describe('AgentToolPreloadService', () => {
@@ -23,19 +24,20 @@ describe('AgentToolPreloadService', () => {
     it('returns an empty array and does not slide when nothing is cached', async () => {
       cacheStorageService.get.mockResolvedValue(undefined);
 
-      const result = await service.getPreloadToolNames(AGENT);
+      const result = await service.getPreloadToolNames(AGENT, STEP_ID);
 
       expect(result).toEqual([]);
       expect(cacheStorageService.get).toHaveBeenCalledWith(EXPECTED_KEY);
       expect(cacheStorageService.set).not.toHaveBeenCalled();
     });
 
-    it('returns the cached set and slides the TTL, keyed by updatedAt', async () => {
+    it('returns the cached set and slides the TTL, keyed by updatedAt and stepId', async () => {
       cacheStorageService.get.mockResolvedValue(['find_many_customers']);
 
-      const result = await service.getPreloadToolNames(AGENT);
+      const result = await service.getPreloadToolNames(AGENT, STEP_ID);
 
       expect(result).toEqual(['find_many_customers']);
+      expect(cacheStorageService.get).toHaveBeenCalledWith(EXPECTED_KEY);
       expect(cacheStorageService.set).toHaveBeenCalledWith(
         EXPECTED_KEY,
         ['find_many_customers'],
@@ -46,7 +48,7 @@ describe('AgentToolPreloadService', () => {
 
   describe('recordToolUsage', () => {
     it('does nothing when there are no usable tool names', async () => {
-      await service.recordToolUsage(AGENT, ['', '']);
+      await service.recordToolUsage(AGENT, ['', ''], STEP_ID);
 
       expect(cacheStorageService.get).not.toHaveBeenCalled();
       expect(cacheStorageService.set).not.toHaveBeenCalled();
@@ -58,10 +60,11 @@ describe('AgentToolPreloadService', () => {
         'find_many_customers',
       ]);
 
-      await service.recordToolUsage(AGENT, [
-        'create_many_customers',
-        'find_many_customers',
-      ]);
+      await service.recordToolUsage(
+        AGENT,
+        ['create_many_customers', 'find_many_customers'],
+        STEP_ID,
+      );
 
       expect(cacheStorageService.set).toHaveBeenLastCalledWith(
         EXPECTED_KEY,
@@ -82,7 +85,7 @@ describe('AgentToolPreloadService', () => {
         (_, index) => `tool_${String(index).padStart(2, '0')}`,
       );
 
-      await service.recordToolUsage(AGENT, manyToolNames);
+      await service.recordToolUsage(AGENT, manyToolNames, STEP_ID);
 
       const setCalls = cacheStorageService.set.mock.calls;
       const storedToolNames = setCalls[setCalls.length - 1]?.[1];

--- a/packages/twenty-server/src/engine/metadata-modules/ai/ai-agent-execution/services/agent-async-executor.service.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/ai/ai-agent-execution/services/agent-async-executor.service.ts
@@ -24,9 +24,17 @@ import { MetricsService } from 'src/engine/core-modules/metrics/metrics.service'
 import { MetricsKeys } from 'src/engine/core-modules/metrics/types/metrics-keys.type';
 import { type ToolProviderContext } from 'src/engine/core-modules/tool-provider/interfaces/tool-provider-context.type';
 import { ToolRegistryService } from 'src/engine/core-modules/tool-provider/services/tool-registry.service';
+import {
+  createExecuteToolTool,
+  createLearnToolsTool,
+  EXECUTE_TOOL_TOOL_NAME,
+  LEARN_TOOLS_TOOL_NAME,
+} from 'src/engine/core-modules/tool-provider/tools';
+import { type ToolContext } from 'src/engine/core-modules/tool-provider/types/tool-context.type';
 import { estimateToolOutputTokens } from 'src/engine/core-modules/tool-provider/utils/estimate-tool-output-tokens.util';
 import { getToolMetricName } from 'src/engine/core-modules/tool-provider/utils/get-tool-metric-name.util';
 import { isToolOutputSuccessful } from 'src/engine/core-modules/tool-provider/utils/is-tool-output-successful.util';
+import { resolveToolName } from 'src/engine/core-modules/tool-provider/utils/resolve-tool-name.util';
 import { OUTPUT_NAVIGATION_TOOL_NAMES } from 'src/engine/core-modules/tool/tools/output-navigation-tool/constants/output-navigation-tool-names.constant';
 import { UsageOperationType } from 'src/engine/core-modules/usage/enums/usage-operation-type.enum';
 import { WorkspaceEntity } from 'src/engine/core-modules/workspace/workspace.entity';
@@ -35,6 +43,7 @@ import { type AgentExecutionResult } from 'src/engine/metadata-modules/ai/ai-age
 import { AGENT_CONFIG } from 'src/engine/metadata-modules/ai/ai-agent/constants/agent-config.const';
 import { WORKFLOW_SYSTEM_PROMPTS } from 'src/engine/metadata-modules/ai/ai-agent/constants/agent-system-prompts.const';
 import { type AgentEntity } from 'src/engine/metadata-modules/ai/ai-agent/entities/agent.entity';
+import { buildWorkflowAgentToolCatalogSection } from 'src/engine/metadata-modules/ai/ai-agent/utils/build-workflow-agent-tool-catalog-section.util';
 import { repairToolCall } from 'src/engine/metadata-modules/ai/ai-agent/utils/repair-tool-call.util';
 import { NATIVE_WEB_SEARCH_COST_PER_CALL_DOLLARS } from 'src/engine/metadata-modules/ai/ai-billing/constants/native-web-search-cost-per-call-dollars';
 import { AiBillingService } from 'src/engine/metadata-modules/ai/ai-billing/services/ai-billing.service';
@@ -152,6 +161,9 @@ export class AgentAsyncExecutorService {
         await this.aiModelRegistryService.resolveModelForAgent(agent);
 
       let tools: ToolSet = {};
+      let systemPrompt = `${WORKFLOW_SYSTEM_PROMPTS.BASE}\n\n${
+        agent ? agent.prompt : ''
+      }`;
       let providerOptions = getCallLevelProviderOptions({
         sdkPackage: registeredModel.sdkPackage,
         providerOptions: undefined,
@@ -170,11 +182,31 @@ export class AgentAsyncExecutorService {
             agent.modelConfiguration?.twitterSearch?.enabled === true,
         };
 
+        const nativeTools = this.nativeToolBinder.bind(
+          registeredModel,
+          nativeModelToolOptions,
+        );
+
         let registryTools: ToolSet = {};
 
         // Workflow agent registry tools are scoped exclusively by the agent
         // permission-tab role. No role means no registry tools.
+        //
+        // Tools use progressive disclosure: the model sees a lightweight
+        // catalog (names + descriptions) in the system prompt and pulls a
+        // tool's input schema on demand via learn_tools/execute_tool. This
+        // avoids eagerly serializing every CRUD schema for every object the
+        // role can access, which otherwise dominates the prompt token cost.
         if (isDefined(agentRoleId)) {
+          const userId =
+            isDefined(authContext) && isUserAuthContext(authContext)
+              ? authContext.user.id
+              : undefined;
+          const userWorkspaceId =
+            isDefined(authContext) && isUserAuthContext(authContext)
+              ? authContext.userWorkspaceId
+              : undefined;
+
           const agentRolePermissionConfig: RolePermissionConfig = {
             unionOf: [agentRoleId],
           };
@@ -185,30 +217,51 @@ export class AgentAsyncExecutorService {
             rolePermissionConfig: agentRolePermissionConfig,
             authContext,
             actorContext,
-            userId:
-              isDefined(authContext) && isUserAuthContext(authContext)
-                ? authContext.user.id
-                : undefined,
-            userWorkspaceId:
-              isDefined(authContext) && isUserAuthContext(authContext)
-                ? authContext.userWorkspaceId
-                : undefined,
+            userId,
+            userWorkspaceId,
           };
 
-          registryTools = await this.toolRegistry.getToolsByCategories(
-            toolProviderContext,
-            {
-              categories: WORKFLOW_AGENT_REGISTRY_TOOL_CATEGORIES,
-              excludeTools: [...OUTPUT_NAVIGATION_TOOL_NAMES],
-              wrapWithErrorContext: false,
-            },
-          );
-        }
+          const toolContext: ToolContext = {
+            workspaceId: agent.workspaceId,
+            roleId: agentRoleId,
+            authContext,
+            actorContext,
+            userId,
+            userWorkspaceId,
+          };
 
-        const nativeTools = this.nativeToolBinder.bind(
-          registeredModel,
-          nativeModelToolOptions,
-        );
+          const excludedToolNames = new Set<string>(
+            OUTPUT_NAVIGATION_TOOL_NAMES,
+          );
+
+          const toolCatalog = (
+            await this.toolRegistry.getCatalog(toolProviderContext, {
+              categories: WORKFLOW_AGENT_REGISTRY_TOOL_CATEGORIES,
+            })
+          ).filter((entry) => !excludedToolNames.has(entry.name));
+
+          registryTools = {
+            [LEARN_TOOLS_TOOL_NAME]: createLearnToolsTool(
+              this.toolRegistry,
+              toolContext,
+              excludedToolNames,
+            ),
+            [EXECUTE_TOOL_TOOL_NAME]: createExecuteToolTool(
+              this.toolRegistry,
+              toolContext,
+              {
+                excludeTools: excludedToolNames,
+                compactOutput: true,
+                spillLargeOutput: true,
+              },
+            ),
+          };
+
+          systemPrompt = `${systemPrompt}\n\n${buildWorkflowAgentToolCatalogSection(
+            toolCatalog,
+            [],
+          )}`;
+        }
 
         tools = {
           ...registryTools,
@@ -230,7 +283,7 @@ export class AgentAsyncExecutorService {
       let hasNoMoreAvailableCredits = false;
 
       const textResponse = await generateText({
-        system: `${WORKFLOW_SYSTEM_PROMPTS.BASE}\n\n${agent ? agent.prompt : ''}`,
+        system: systemPrompt,
         tools,
         model: registeredModel.model,
         prompt: userPrompt,
@@ -246,7 +299,7 @@ export class AgentAsyncExecutorService {
             unit: 'ms',
             attributes: {
               model: registeredModel.modelId,
-              tool: getToolMetricName(event.toolCall.toolName),
+              tool: getToolMetricName(resolveToolName(event.toolCall)),
             },
             bucketBoundaries: TOOL_EXECUTION_DURATION_MS_BUCKET_BOUNDARIES,
           });
@@ -279,7 +332,7 @@ export class AgentAsyncExecutorService {
 
             const toolAttributes = {
               model: registeredModel.modelId,
-              tool: getToolMetricName(part.toolName),
+              tool: getToolMetricName(resolveToolName(part)),
             };
 
             this.metricsService.incrementCounterBy({

--- a/packages/twenty-server/src/engine/metadata-modules/ai/ai-agent-execution/services/agent-async-executor.service.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/ai/ai-agent-execution/services/agent-async-executor.service.ts
@@ -39,7 +39,9 @@ import { OUTPUT_NAVIGATION_TOOL_NAMES } from 'src/engine/core-modules/tool/tools
 import { UsageOperationType } from 'src/engine/core-modules/usage/enums/usage-operation-type.enum';
 import { WorkspaceEntity } from 'src/engine/core-modules/workspace/workspace.entity';
 import { WORKFLOW_AGENT_REGISTRY_TOOL_CATEGORIES } from 'src/engine/metadata-modules/ai/ai-agent-execution/constants/workflow-agent-registry-tool-categories.const';
+import { AgentToolPreloadService } from 'src/engine/metadata-modules/ai/ai-agent-execution/services/agent-tool-preload.service';
 import { type AgentExecutionResult } from 'src/engine/metadata-modules/ai/ai-agent-execution/types/agent-execution-result.type';
+import { extractExecutedRegistryToolNames } from 'src/engine/metadata-modules/ai/ai-agent-execution/utils/extract-executed-registry-tool-names.util';
 import { AGENT_CONFIG } from 'src/engine/metadata-modules/ai/ai-agent/constants/agent-config.const';
 import { WORKFLOW_SYSTEM_PROMPTS } from 'src/engine/metadata-modules/ai/ai-agent/constants/agent-system-prompts.const';
 import { type AgentEntity } from 'src/engine/metadata-modules/ai/ai-agent/entities/agent.entity';
@@ -99,6 +101,7 @@ export class AgentAsyncExecutorService {
     private readonly aiBillingService: AiBillingService,
     private readonly billingUsageService: BillingUsageService,
     private readonly metricsService: MetricsService,
+    private readonly agentToolPreloadService: AgentToolPreloadService,
     @InjectWorkspaceScopedRepository(RoleTargetEntity)
     private readonly roleTargetRepository: WorkspaceScopedRepository<RoleTargetEntity>,
     @InjectRepository(WorkspaceEntity)
@@ -164,6 +167,9 @@ export class AgentAsyncExecutorService {
       let systemPrompt = `${WORKFLOW_SYSTEM_PROMPTS.BASE}\n\n${
         agent ? agent.prompt : ''
       }`;
+      // Registry tool names available this run, used after execution to record
+      // which tools were actually called for the next run's preload set.
+      let recordableToolNames: Set<string> | null = null;
       let providerOptions = getCallLevelProviderOptions({
         sdkPackage: registeredModel.sdkPackage,
         providerOptions: undefined,
@@ -240,7 +246,32 @@ export class AgentAsyncExecutorService {
             })
           ).filter((entry) => !excludedToolNames.has(entry.name));
 
+          const catalogToolNames = new Set(
+            toolCatalog.map((entry) => entry.name),
+          );
+
+          recordableToolNames = catalogToolNames;
+
+          // Preload the schemas of tools this agent used in recent runs so the
+          // common path skips the learn_tools round-trip. Names no longer in the
+          // catalog (permissions or metadata changed) are dropped.
+          const historicalToolNames =
+            await this.agentToolPreloadService.getPreloadToolNames(agent);
+          const preloadToolNames = historicalToolNames.filter((name) =>
+            catalogToolNames.has(name),
+          );
+
+          const preloadedTools =
+            preloadToolNames.length > 0
+              ? await this.toolRegistry.getToolsByName(
+                  preloadToolNames,
+                  toolContext,
+                  { compactOutput: true, spillLargeOutput: true },
+                )
+              : {};
+
           registryTools = {
+            ...preloadedTools,
             [LEARN_TOOLS_TOOL_NAME]: createLearnToolsTool(
               this.toolRegistry,
               toolContext,
@@ -259,7 +290,7 @@ export class AgentAsyncExecutorService {
 
           systemPrompt = `${systemPrompt}\n\n${buildWorkflowAgentToolCatalogSection(
             toolCatalog,
-            [],
+            Object.keys(preloadedTools),
           )}`;
         }
 
@@ -378,6 +409,24 @@ export class AgentAsyncExecutorService {
         textResponse.steps,
       );
       executionSteps = textResponse.steps;
+
+      if (agent && isDefined(recordableToolNames)) {
+        try {
+          await this.agentToolPreloadService.recordToolUsage(
+            agent,
+            extractExecutedRegistryToolNames(
+              textResponse.steps,
+              recordableToolNames,
+            ),
+          );
+        } catch (error) {
+          this.logger.warn(
+            `Failed to record agent tool usage for preload: ${
+              error instanceof Error ? error.message : String(error)
+            }`,
+          );
+        }
+      }
 
       const agentSchema =
         agent?.responseFormat?.type === 'json'

--- a/packages/twenty-server/src/engine/metadata-modules/ai/ai-agent-execution/services/agent-async-executor.service.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/ai/ai-agent-execution/services/agent-async-executor.service.ts
@@ -35,9 +35,9 @@ import { estimateToolOutputTokens } from 'src/engine/core-modules/tool-provider/
 import { getToolMetricName } from 'src/engine/core-modules/tool-provider/utils/get-tool-metric-name.util';
 import { isToolOutputSuccessful } from 'src/engine/core-modules/tool-provider/utils/is-tool-output-successful.util';
 import { resolveToolName } from 'src/engine/core-modules/tool-provider/utils/resolve-tool-name.util';
-import { OUTPUT_NAVIGATION_TOOL_NAMES } from 'src/engine/core-modules/tool/tools/output-navigation-tool/constants/output-navigation-tool-names.constant';
 import { UsageOperationType } from 'src/engine/core-modules/usage/enums/usage-operation-type.enum';
 import { WorkspaceEntity } from 'src/engine/core-modules/workspace/workspace.entity';
+import { WORKFLOW_AGENT_EXCLUDED_TOOL_NAMES } from 'src/engine/metadata-modules/ai/ai-agent-execution/constants/workflow-agent-excluded-tool-names.const';
 import { WORKFLOW_AGENT_REGISTRY_TOOL_CATEGORIES } from 'src/engine/metadata-modules/ai/ai-agent-execution/constants/workflow-agent-registry-tool-categories.const';
 import { AgentToolPreloadService } from 'src/engine/metadata-modules/ai/ai-agent-execution/services/agent-tool-preload.service';
 import { type AgentExecutionResult } from 'src/engine/metadata-modules/ai/ai-agent-execution/types/agent-execution-result.type';
@@ -129,6 +129,7 @@ export class AgentAsyncExecutorService {
     authContext,
     workspaceId,
     userWorkspaceId,
+    stepId,
     operationType = UsageOperationType.AI_WORKFLOW_TOKEN,
   }: {
     agent: AgentEntity | null;
@@ -137,6 +138,7 @@ export class AgentAsyncExecutorService {
     authContext?: WorkspaceAuthContext;
     workspaceId: string;
     userWorkspaceId?: string | null;
+    stepId?: string;
     operationType?: UsageOperationType;
   }): Promise<AgentExecutionResult> {
     await this.billingUsageService.hasAvailableCreditsOrThrow(workspaceId);
@@ -167,13 +169,18 @@ export class AgentAsyncExecutorService {
       let systemPrompt = `${WORKFLOW_SYSTEM_PROMPTS.BASE}\n\n${
         agent ? agent.prompt : ''
       }`;
-      // Registry tool names available this run, used after execution to record
-      // which tools were actually called for the next run's preload set.
+
       let recordableToolNames: Set<string> | null = null;
+
+      const promptCacheKey =
+        isDefined(agent) && isDefined(stepId)
+          ? `${agent.id}:${stepId}`
+          : agent?.id;
+
       let providerOptions = getCallLevelProviderOptions({
         sdkPackage: registeredModel.sdkPackage,
         providerOptions: undefined,
-        promptCacheKey: agent?.id,
+        promptCacheKey,
       });
 
       if (agent) {
@@ -195,14 +202,6 @@ export class AgentAsyncExecutorService {
 
         let registryTools: ToolSet = {};
 
-        // Workflow agent registry tools are scoped exclusively by the agent
-        // permission-tab role. No role means no registry tools.
-        //
-        // Tools use progressive disclosure: the model sees a lightweight
-        // catalog (names + descriptions) in the system prompt and pulls a
-        // tool's input schema on demand via learn_tools/execute_tool. This
-        // avoids eagerly serializing every CRUD schema for every object the
-        // role can access, which otherwise dominates the prompt token cost.
         if (isDefined(agentRoleId)) {
           const userId =
             isDefined(authContext) && isUserAuthContext(authContext)
@@ -237,7 +236,7 @@ export class AgentAsyncExecutorService {
           };
 
           const excludedToolNames = new Set<string>(
-            OUTPUT_NAVIGATION_TOOL_NAMES,
+            WORKFLOW_AGENT_EXCLUDED_TOOL_NAMES,
           );
 
           const toolCatalog = (
@@ -252,11 +251,12 @@ export class AgentAsyncExecutorService {
 
           recordableToolNames = catalogToolNames;
 
-          // Preload the schemas of tools this agent used in recent runs so the
-          // common path skips the learn_tools round-trip. Names no longer in the
-          // catalog (permissions or metadata changed) are dropped.
-          const historicalToolNames =
-            await this.agentToolPreloadService.getPreloadToolNames(agent);
+          const historicalToolNames = isDefined(stepId)
+            ? await this.agentToolPreloadService.getPreloadToolNames(
+                agent,
+                stepId,
+              )
+            : [];
           const preloadToolNames = historicalToolNames.filter((name) =>
             catalogToolNames.has(name),
           );
@@ -266,7 +266,7 @@ export class AgentAsyncExecutorService {
               ? await this.toolRegistry.getToolsByName(
                   preloadToolNames,
                   toolContext,
-                  { compactOutput: true, spillLargeOutput: true },
+                  { compactOutput: true },
                 )
               : {};
 
@@ -283,7 +283,6 @@ export class AgentAsyncExecutorService {
               {
                 excludeTools: excludedToolNames,
                 compactOutput: true,
-                spillLargeOutput: true,
               },
             ),
           };
@@ -305,7 +304,7 @@ export class AgentAsyncExecutorService {
             this.aiModelConfigService.getReasoningProviderOptions(
               registeredModel,
             ),
-          promptCacheKey: agent?.id,
+          promptCacheKey,
         });
       }
 
@@ -410,7 +409,7 @@ export class AgentAsyncExecutorService {
       );
       executionSteps = textResponse.steps;
 
-      if (agent && isDefined(recordableToolNames)) {
+      if (agent && isDefined(recordableToolNames) && isDefined(stepId)) {
         try {
           await this.agentToolPreloadService.recordToolUsage(
             agent,
@@ -418,6 +417,7 @@ export class AgentAsyncExecutorService {
               textResponse.steps,
               recordableToolNames,
             ),
+            stepId,
           );
         } catch (error) {
           this.logger.warn(
@@ -448,7 +448,7 @@ export class AgentAsyncExecutorService {
           providerOptions: getCallLevelProviderOptions({
             sdkPackage: registeredModel.sdkPackage,
             providerOptions: undefined,
-            promptCacheKey: agent?.id,
+            promptCacheKey,
           }),
           experimental_telemetry: AI_TELEMETRY_CONFIG,
           onStepFinish: async (step) => {

--- a/packages/twenty-server/src/engine/metadata-modules/ai/ai-agent-execution/services/agent-tool-preload.service.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/ai/ai-agent-execution/services/agent-tool-preload.service.ts
@@ -1,0 +1,63 @@
+import { Injectable } from '@nestjs/common';
+
+import { isNonEmptyString } from 'twenty-shared/utils';
+
+import { InjectCacheStorage } from 'src/engine/core-modules/cache-storage/decorators/cache-storage.decorator';
+import { CacheStorageService } from 'src/engine/core-modules/cache-storage/services/cache-storage.service';
+import { CacheStorageNamespace } from 'src/engine/core-modules/cache-storage/types/cache-storage-namespace.enum';
+import { type AgentEntity } from 'src/engine/metadata-modules/ai/ai-agent/entities/agent.entity';
+
+const MAX_PRELOAD_TOOL_NAMES = 12;
+const AGENT_TOOL_PRELOAD_TTL_MS = 1000 * 60 * 60 * 24;
+
+type AgentToolPreloadKey = Pick<AgentEntity, 'id' | 'updatedAt'>;
+
+// Remembers which registry tools a workflow agent actually used, so future runs
+// can preload their schemas directly instead of paying a learn_tools round-trip
+// for the tools the agent relies on every time.
+@Injectable()
+export class AgentToolPreloadService {
+  constructor(
+    @InjectCacheStorage(CacheStorageNamespace.EngineAiAgentToolPreload)
+    private readonly cacheStorageService: CacheStorageService,
+  ) {}
+
+  async getPreloadToolNames(agent: AgentToolPreloadKey): Promise<string[]> {
+    const storedToolNames = await this.cacheStorageService.get<string[]>(
+      this.buildCacheKey(agent),
+    );
+
+    return storedToolNames ?? [];
+  }
+
+  async recordToolUsage(
+    agent: AgentToolPreloadKey,
+    usedToolNames: string[],
+  ): Promise<void> {
+    const normalizedToolNames = usedToolNames.filter(isNonEmptyString);
+
+    if (normalizedToolNames.length === 0) {
+      return;
+    }
+
+    const existingToolNames = await this.getPreloadToolNames(agent);
+
+    // Sorted so the preloaded set serializes to stable bytes across runs, which
+    // keeps the model's prompt cache warm.
+    const mergedToolNames = [
+      ...new Set([...existingToolNames, ...normalizedToolNames]),
+    ]
+      .sort()
+      .slice(0, MAX_PRELOAD_TOOL_NAMES);
+
+    await this.cacheStorageService.set(
+      this.buildCacheKey(agent),
+      mergedToolNames,
+      AGENT_TOOL_PRELOAD_TTL_MS,
+    );
+  }
+
+  private buildCacheKey(agent: AgentToolPreloadKey): string {
+    return agent.id;
+  }
+}

--- a/packages/twenty-server/src/engine/metadata-modules/ai/ai-agent-execution/services/agent-tool-preload.service.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/ai/ai-agent-execution/services/agent-tool-preload.service.ts
@@ -1,6 +1,7 @@
 import { Injectable } from '@nestjs/common';
 
-import { isNonEmptyString } from 'twenty-shared/utils';
+import { isNonEmptyString } from '@sniptt/guards';
+import { isDefined } from 'twenty-shared/utils';
 
 import { InjectCacheStorage } from 'src/engine/core-modules/cache-storage/decorators/cache-storage.decorator';
 import { CacheStorageService } from 'src/engine/core-modules/cache-storage/services/cache-storage.service';
@@ -8,7 +9,9 @@ import { CacheStorageNamespace } from 'src/engine/core-modules/cache-storage/typ
 import { type AgentEntity } from 'src/engine/metadata-modules/ai/ai-agent/entities/agent.entity';
 
 const MAX_PRELOAD_TOOL_NAMES = 12;
-const AGENT_TOOL_PRELOAD_TTL_MS = 1000 * 60 * 60 * 24;
+// Aligned with the model's ephemeral prompt-cache window and slid on each read,
+// so a frequently-run agent keeps a stable warm set while an idle one expires.
+const AGENT_TOOL_PRELOAD_TTL_MS = 1000 * 60 * 5;
 
 type AgentToolPreloadKey = Pick<AgentEntity, 'id' | 'updatedAt'>;
 
@@ -23,11 +26,23 @@ export class AgentToolPreloadService {
   ) {}
 
   async getPreloadToolNames(agent: AgentToolPreloadKey): Promise<string[]> {
-    const storedToolNames = await this.cacheStorageService.get<string[]>(
-      this.buildCacheKey(agent),
+    const cacheKey = this.buildCacheKey(agent);
+    const storedToolNames =
+      await this.cacheStorageService.get<string[]>(cacheKey);
+
+    if (!isDefined(storedToolNames)) {
+      return [];
+    }
+
+    // Slide the TTL: consuming the set keeps it (and the model's prompt cache)
+    // alive for agents that run within the window.
+    await this.cacheStorageService.set(
+      cacheKey,
+      storedToolNames,
+      AGENT_TOOL_PRELOAD_TTL_MS,
     );
 
-    return storedToolNames ?? [];
+    return storedToolNames;
   }
 
   async recordToolUsage(
@@ -57,7 +72,9 @@ export class AgentToolPreloadService {
     );
   }
 
+  // Keyed by updatedAt so editing the agent (prompt, permissions, config)
+  // abandons the old learned set and relearns from scratch.
   private buildCacheKey(agent: AgentToolPreloadKey): string {
-    return agent.id;
+    return `${agent.id}:${new Date(agent.updatedAt).getTime()}`;
   }
 }

--- a/packages/twenty-server/src/engine/metadata-modules/ai/ai-agent-execution/services/agent-tool-preload.service.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/ai/ai-agent-execution/services/agent-tool-preload.service.ts
@@ -15,9 +15,6 @@ const AGENT_TOOL_PRELOAD_TTL_MS = 1000 * 60 * 5;
 
 type AgentToolPreloadKey = Pick<AgentEntity, 'id' | 'updatedAt'>;
 
-// Remembers which registry tools a workflow agent actually used, so future runs
-// can preload their schemas directly instead of paying a learn_tools round-trip
-// for the tools the agent relies on every time.
 @Injectable()
 export class AgentToolPreloadService {
   constructor(
@@ -25,8 +22,11 @@ export class AgentToolPreloadService {
     private readonly cacheStorageService: CacheStorageService,
   ) {}
 
-  async getPreloadToolNames(agent: AgentToolPreloadKey): Promise<string[]> {
-    const cacheKey = this.buildCacheKey(agent);
+  async getPreloadToolNames(
+    agent: AgentToolPreloadKey,
+    stepId: string,
+  ): Promise<string[]> {
+    const cacheKey = this.buildCacheKey(agent, stepId);
     const storedToolNames =
       await this.cacheStorageService.get<string[]>(cacheKey);
 
@@ -48,6 +48,7 @@ export class AgentToolPreloadService {
   async recordToolUsage(
     agent: AgentToolPreloadKey,
     usedToolNames: string[],
+    stepId: string,
   ): Promise<void> {
     const normalizedToolNames = usedToolNames.filter(isNonEmptyString);
 
@@ -55,7 +56,7 @@ export class AgentToolPreloadService {
       return;
     }
 
-    const existingToolNames = await this.getPreloadToolNames(agent);
+    const existingToolNames = await this.getPreloadToolNames(agent, stepId);
 
     // Sorted so the preloaded set serializes to stable bytes across runs, which
     // keeps the model's prompt cache warm.
@@ -66,15 +67,13 @@ export class AgentToolPreloadService {
       .slice(0, MAX_PRELOAD_TOOL_NAMES);
 
     await this.cacheStorageService.set(
-      this.buildCacheKey(agent),
+      this.buildCacheKey(agent, stepId),
       mergedToolNames,
       AGENT_TOOL_PRELOAD_TTL_MS,
     );
   }
 
-  // Keyed by updatedAt so editing the agent (prompt, permissions, config)
-  // abandons the old learned set and relearns from scratch.
-  private buildCacheKey(agent: AgentToolPreloadKey): string {
-    return `${agent.id}:${new Date(agent.updatedAt).getTime()}`;
+  private buildCacheKey(agent: AgentToolPreloadKey, stepId: string): string {
+    return `${agent.id}:${new Date(agent.updatedAt).getTime()}:${stepId}`;
   }
 }

--- a/packages/twenty-server/src/engine/metadata-modules/ai/ai-agent-execution/utils/extract-executed-registry-tool-names.util.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/ai/ai-agent-execution/utils/extract-executed-registry-tool-names.util.ts
@@ -1,0 +1,29 @@
+import { type StepResult, type ToolSet } from 'ai';
+
+import { resolveToolName } from 'src/engine/core-modules/tool-provider/utils/resolve-tool-name.util';
+
+// Collects the registry tool names a workflow agent actually called during a
+// run (execute_tool calls unwrapped to their underlying tool). Restricted to
+// allowedToolNames so meta-tools (learn_tools) and native tools are ignored.
+export const extractExecutedRegistryToolNames = (
+  steps: StepResult<ToolSet>[],
+  allowedToolNames: Set<string>,
+): string[] => {
+  const executedToolNames = new Set<string>();
+
+  for (const step of steps) {
+    for (const part of step.content) {
+      if (part.type !== 'tool-call') {
+        continue;
+      }
+
+      const toolName = resolveToolName(part);
+
+      if (allowedToolNames.has(toolName)) {
+        executedToolNames.add(toolName);
+      }
+    }
+  }
+
+  return [...executedToolNames];
+};

--- a/packages/twenty-server/src/engine/metadata-modules/ai/ai-agent-execution/utils/map-ai-steps-to-tool-call-logs.util.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/ai/ai-agent-execution/utils/map-ai-steps-to-tool-call-logs.util.ts
@@ -2,6 +2,7 @@ import { type StepResult, type ToolSet } from 'ai';
 
 import { type AiToolCallLog } from 'twenty-shared/workflow';
 
+import { resolveToolName } from 'src/engine/core-modules/tool-provider/utils/resolve-tool-name.util';
 import {
   TRUNCATION_SENTINEL,
   truncateStringToUtf8ByteBudget,
@@ -98,7 +99,9 @@ export const mapAiStepsToToolCallLogs = (
 
       if (part.type === 'tool-call') {
         const entry: AiToolCallLog = {
-          toolName: part.toolName,
+          // Unwrap execute_tool calls to the underlying tool name so progressive
+          // disclosure keeps the run log readable (e.g. find_many_customers).
+          toolName: resolveToolName(part),
           toolCallId: part.toolCallId,
           input: truncateUnknownForLog(part.input, maxToolInputBytes),
           state: 'started',

--- a/packages/twenty-server/src/engine/metadata-modules/ai/ai-agent/utils/build-workflow-agent-tool-catalog-section.util.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/ai/ai-agent/utils/build-workflow-agent-tool-catalog-section.util.ts
@@ -1,0 +1,126 @@
+import { ToolCategory } from 'twenty-shared/ai';
+
+import {
+  EXECUTE_TOOL_TOOL_NAME,
+  LEARN_TOOLS_TOOL_NAME,
+} from 'src/engine/core-modules/tool-provider/tools';
+import { type ToolIndexEntry } from 'src/engine/core-modules/tool-provider/types/tool-index-entry.type';
+
+const CATEGORY_LABELS: Partial<Record<ToolCategory, string>> = {
+  [ToolCategory.DATABASE_CRUD]: 'Database Tools (CRUD operations)',
+  [ToolCategory.ACTION]: 'Action Tools (HTTP, Email, etc.)',
+};
+
+const buildDatabaseCrudSection = (
+  tools: ToolIndexEntry[],
+  label: string,
+): string => {
+  const operationOrder: string[] = [];
+  const seenOperations = new Set<string>();
+  const objectNames = new Set<string>();
+  const standaloneToolNames: string[] = [];
+
+  for (const tool of tools) {
+    if (tool.objectName && tool.operation) {
+      objectNames.add(tool.objectName);
+
+      if (!seenOperations.has(tool.operation)) {
+        seenOperations.add(tool.operation);
+        operationOrder.push(tool.operation);
+      }
+    } else {
+      standaloneToolNames.push(tool.name);
+    }
+  }
+
+  const lines: string[] = [`### ${label} (${tools.length} tools)`];
+
+  if (objectNames.size > 0) {
+    const sortedObjectNames = [...objectNames].sort();
+    const findManyExample = tools.find(
+      (tool) => tool.operation === 'find_many',
+    );
+    const findOneExample = tools.find(
+      (tool) =>
+        tool.operation === 'find_one' &&
+        tool.objectName === findManyExample?.objectName,
+    );
+    const example =
+      findManyExample && findOneExample
+        ? ` e.g. \`${findManyExample.name}\` / \`${findOneExample.name}\``
+        : '';
+
+    lines.push('Operations per object:');
+    lines.push(
+      ...operationOrder.map((operation) => `- \`${operation}_{object}\``),
+    );
+    lines.push(`\nObjects (${sortedObjectNames.length}):`);
+    lines.push(...sortedObjectNames.map((name) => `- \`${name}\``));
+    lines.push(
+      `\nTool name = operation + object name. \`*_many_*\` operations use the plural form, \`*_one_*\` use the singular form.${example}`,
+    );
+  }
+
+  for (const toolName of standaloneToolNames.sort()) {
+    lines.push(`- \`${toolName}\``);
+  }
+
+  return lines.join('\n');
+};
+
+// Renders the workflow agent's tool catalog (names only, no schemas) into a
+// compact system-prompt section. Schemas are fetched on demand via learn_tools,
+// which is what keeps the agent's context small.
+export const buildWorkflowAgentToolCatalogSection = (
+  toolCatalog: ToolIndexEntry[],
+  preloadedToolNames: string[],
+): string => {
+  if (toolCatalog.length === 0) {
+    return '';
+  }
+
+  const toolsByCategory = new Map<ToolCategory, ToolIndexEntry[]>();
+
+  for (const tool of toolCatalog) {
+    const existing = toolsByCategory.get(tool.category) ?? [];
+
+    existing.push(tool);
+    toolsByCategory.set(tool.category, existing);
+  }
+
+  const sections: string[] = [
+    `## Available Tools
+
+You can access ${toolCatalog.length} tools, discovered on demand to keep this prompt small. Before calling a tool you have not loaded yet, call \`${LEARN_TOOLS_TOOL_NAME}({ toolNames: [...] })\` to get its input schema, then call \`${EXECUTE_TOOL_TOOL_NAME}({ toolName, arguments })\` to run it. Pass every tool you need in a single \`${LEARN_TOOLS_TOOL_NAME}\` call.`,
+  ];
+
+  if (preloadedToolNames.length > 0) {
+    sections.push(
+      `### Ready to use now (call directly, no ${LEARN_TOOLS_TOOL_NAME} needed)\n${preloadedToolNames
+        .map((name) => `- \`${name}\` ✓`)
+        .join('\n')}`,
+    );
+  }
+
+  for (const category of Object.values(ToolCategory)) {
+    const tools = toolsByCategory.get(category);
+
+    if (!tools || tools.length === 0) {
+      continue;
+    }
+
+    const label = CATEGORY_LABELS[category] ?? category;
+
+    if (category === ToolCategory.DATABASE_CRUD) {
+      sections.push(buildDatabaseCrudSection(tools, label));
+    } else {
+      sections.push(
+        `### ${label} (${tools.length} tools)\n${tools
+          .map((tool) => `- \`${tool.name}\``)
+          .join('\n')}`,
+      );
+    }
+  }
+
+  return sections.join('\n\n');
+};

--- a/packages/twenty-server/src/modules/workflow/workflow-executor/workflow-actions/ai-agent/ai-agent.workflow-action.ts
+++ b/packages/twenty-server/src/modules/workflow/workflow-executor/workflow-actions/ai-agent/ai-agent.workflow-action.ts
@@ -90,6 +90,7 @@ export class AiAgentWorkflowAction implements WorkflowAction {
       authContext: executionContext.authContext,
       workspaceId,
       userWorkspaceId,
+      stepId: currentStepId,
       operationType: UsageOperationType.AI_WORKFLOW_TOKEN,
     });
 


### PR DESCRIPTION
## Context

The AI Agent workflow node sends its full tool payload on every run regardless of the task. On a run doing 4 tool calls (find customers, update 2 sales calls, create customers) the node billed **426.2k tokens / $1.46** with only **863 output tokens** — the input was **212,654** (209,448 served from cache, 212,652 cache-creation). More than 99% of the tokens are static tool definitions, not the actual work.

Root cause: the workflow agent eager-loads the full JSON schema of every CRUD tool (find/create/update/delete/group_by/upsert, up to 10 per object) for every object the agent's role can access, via `getToolsByCategories({ includeSchemas: true })`. The `find_many` filter schema alone enumerates every field with every operator. The AI chat path already avoids this with a lightweight catalog + `learn_tools`; the workflow path did not.

## What changed

**Progressive disclosure.** Mirror the AI chat path: expose a lightweight
catalog (names + descriptions) in the system prompt and let the model pull a
tool's input schema on demand via `learn_tools` / `execute_tool`. `getCatalog`
now accepts a category filter so the workflow agent stays scoped to
`DATABASE_CRUD` + `ACTION`. Run logs and tool metrics unwrap `execute_tool` to
the underlying tool name so they stay readable.

**Preload from run history.** Remember which registry tools an agent actually
used and preload their schemas directly on the next run, so the tools an agent
relies on skip the `learn_tools` round trip.

**Sliding TTL cache.** The learned set is cached per agent (keyed by
`updatedAt`, so editing the agent relearns from scratch) with a 5 min TTL slid
on each read, aligned to the model's ephemeral prompt-cache window. A
frequently-run agent keeps a stable warm set while an idle one expires.

**Preload is workflow-step-only.** The preload set is scoped by `stepId`, so an
agent reused across workflow steps keeps a separate warm set per step, matching
the per-step provider prompt-cache key. Non-workflow executions (evaluation
jobs, direct agent runs) have no step and skip preload entirely, falling back to
pure progressive disclosure.

**Exclude interactive-only tools.** `navigate_app` and `search_help_center` are
dropped from the workflow agent catalog. Navigation emits a client-side action a
headless workflow run cannot act on, and help-center search is end-user support
surface, not workflow tooling.

**Disable large-output spill.** Spilling offloads a large tool output and points
the agent at `extract_json_paths` / `search_output` to read it back, but those
are excluded from the workflow agent catalog, so a spilled output would be
unrecoverable. Outputs stay inline (still compacted).

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/23358?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

