### PR TITLE
Dedupe common result handlers

### DIFF
--- a/packages/twenty-server/src/engine/api/common/common-result-getters/__tests__/common-result-getters.service.spec.ts
+++ b/packages/twenty-server/src/engine/api/common/common-result-getters/__tests__/common-result-getters.service.spec.ts
@@ -80,6 +80,7 @@ describe('CommonResultGettersService', () => {
     const flatObjectMetadataMaps =
       createEmptyFlatEntityMaps() as FlatEntityMaps<FlatObjectMetadata>;
     const record: ObjectRecord = {
+      id: 'document-id',
       files: [
         {
           fileId: 'file-id',

--- a/packages/twenty-server/src/engine/api/common/common-result-getters/__tests__/common-result-getters.service.spec.ts
+++ b/packages/twenty-server/src/engine/api/common/common-result-getters/__tests__/common-result-getters.service.spec.ts
@@ -1,0 +1,119 @@
+import {
+  FieldMetadataType,
+  FileFolder,
+  type ObjectRecord,
+} from 'twenty-shared/types';
+
+import { CommonResultGettersService } from 'src/engine/api/common/common-result-getters/common-result-getters.service';
+import { type FileUrlService } from 'src/engine/core-modules/file/file-url/file-url.service';
+import { createEmptyFlatEntityMaps } from 'src/engine/metadata-modules/flat-entity/constant/create-empty-flat-entity-maps.constant';
+import { type FlatEntityMaps } from 'src/engine/metadata-modules/flat-entity/types/flat-entity-maps.type';
+import { addFlatEntityToFlatEntityMapsOrThrow } from 'src/engine/metadata-modules/flat-entity/utils/add-flat-entity-to-flat-entity-maps-or-throw.util';
+import { getFlatFieldMetadataMock } from 'src/engine/metadata-modules/flat-field-metadata/__mocks__/get-flat-field-metadata.mock';
+import { type FlatFieldMetadata } from 'src/engine/metadata-modules/flat-field-metadata/types/flat-field-metadata.type';
+import { getFlatObjectMetadataMock } from 'src/engine/metadata-modules/flat-object-metadata/__mocks__/get-flat-object-metadata.mock';
+import { type FlatObjectMetadata } from 'src/engine/metadata-modules/flat-object-metadata/types/flat-object-metadata.type';
+
+const createField = ({
+  id,
+  objectMetadataId,
+  ...overrides
+}: Pick<FlatFieldMetadata, 'id' | 'name' | 'objectMetadataId' | 'type'> &
+  Partial<FlatFieldMetadata>): FlatFieldMetadata =>
+  getFlatFieldMetadataMock({
+    id,
+    universalIdentifier: `${id}-universal-identifier`,
+    objectMetadataId,
+    objectMetadataUniversalIdentifier: `${objectMetadataId}-universal-identifier`,
+    ...overrides,
+  });
+
+const buildFlatFieldMetadataMaps = (
+  fields: FlatFieldMetadata[],
+): FlatEntityMaps<FlatFieldMetadata> =>
+  fields.reduce(
+    (maps, field) =>
+      addFlatEntityToFlatEntityMapsOrThrow({
+        flatEntity: field,
+        flatEntityMaps: maps,
+      }),
+    createEmptyFlatEntityMaps() as FlatEntityMaps<FlatFieldMetadata>,
+  );
+
+describe('CommonResultGettersService', () => {
+  const signFileByIdUrl = jest.fn(
+    async ({ fileId }: { fileId: string }) => `signed-${fileId}`,
+  );
+  const service = new CommonResultGettersService({
+    signFileByIdUrl,
+  } as unknown as FileUrlService);
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('runs a field handler once when multiple record fields share its type', async () => {
+    const objectMetadataId = 'document-object-id';
+    const filesField = createField({
+      id: 'document-files-field-id',
+      name: 'files',
+      objectMetadataId,
+      type: FieldMetadataType.FILES,
+    });
+    const attachmentsField = createField({
+      id: 'document-attachments-field-id',
+      name: 'attachments',
+      objectMetadataId,
+      type: FieldMetadataType.FILES,
+    });
+    const objectMetadata = getFlatObjectMetadataMock({
+      id: objectMetadataId,
+      universalIdentifier: 'document-object-universal-identifier',
+      nameSingular: 'document',
+      namePlural: 'documents',
+      fieldIds: [filesField.id, attachmentsField.id],
+    });
+    const flatFieldMetadataMaps = buildFlatFieldMetadataMaps([
+      filesField,
+      attachmentsField,
+    ]);
+    const flatObjectMetadataMaps =
+      createEmptyFlatEntityMaps() as FlatEntityMaps<FlatObjectMetadata>;
+    const record: ObjectRecord = {
+      files: [
+        {
+          fileId: 'file-id',
+          label: 'document',
+          extension: 'pdf',
+        },
+      ],
+      attachments: [
+        {
+          fileId: 'attachment-id',
+          label: 'attachment',
+          extension: 'pdf',
+        },
+      ],
+    };
+
+    await service.processRecord(
+      record,
+      objectMetadata,
+      flatObjectMetadataMaps,
+      flatFieldMetadataMaps,
+      'workspace-id',
+    );
+
+    expect(signFileByIdUrl).toHaveBeenCalledTimes(2);
+    expect(signFileByIdUrl).toHaveBeenCalledWith({
+      fileId: 'file-id',
+      workspaceId: 'workspace-id',
+      fileFolder: FileFolder.FilesField,
+    });
+    expect(signFileByIdUrl).toHaveBeenCalledWith({
+      fileId: 'attachment-id',
+      workspaceId: 'workspace-id',
+      fileFolder: FileFolder.FilesField,
+    });
+  });
+});

--- a/packages/twenty-server/src/engine/api/common/common-result-getters/common-result-getters.service.ts
+++ b/packages/twenty-server/src/engine/api/common/common-result-getters/common-result-getters.service.ts
@@ -110,9 +110,8 @@ export class CommonResultGettersService {
 
     const { fieldIdByName } = fieldMaps;
 
-    const handlers = [
-      this.getObjectHandler(flatObjectMetadata.nameSingular),
-      ...Object.keys(record)
+    const fieldHandlers = new Set(
+      Object.keys(record)
         .map((recordFieldName) =>
           findFlatEntityByIdInFlatEntityMaps({
             flatEntityId: fieldIdByName[recordFieldName],
@@ -122,6 +121,11 @@ export class CommonResultGettersService {
         .filter(isDefined)
         .map((fieldMetadata) => this.fieldHandlers.get(fieldMetadata.type))
         .filter(isDefined),
+    );
+
+    const handlers = [
+      this.getObjectHandler(flatObjectMetadata.nameSingular),
+      ...fieldHandlers,
     ];
 
     const relationFields = Object.keys(record)


### PR DESCRIPTION
## Context

`CommonResultGettersService` selects field handlers by mapping every returned record field to the handler registered for its metadata type.

Handlers are shared instances, and each handler already receives the complete field metadata list. This means that when multiple fields have the same handled type, the same handler is added and executed multiple times.

For example, a record with two `FILES` fields previously produced this execution list:

```text
[objectHandler, filesHandler, filesHandler]
```

Each `filesHandler` execution processes both `FILES` fields. As a result, both file URLs were signed twice. With several fields of the same type, this can make the work grow quadratically.

The same duplication can affect rich-text processing, including JSON parsing, serialization, and embedded file URL signing.

## What changed

Field handler instances are collected in an insertion-ordered `Set` before execution:

```text
[objectHandler, filesHandler]
```

Each distinct field handler now runs once per record and continues to process every matching field.

## Why this is safe

- The object-specific handler still runs first.
- Different field-handler types keep their first-seen order.
- No field is skipped, handlers still receive the complete field metadata list.
- Requests with zero or one field for a handled type are unchanged.
- No cache or cross-request state is introduced.

## Expected impact

This removes repeated synchronous file-token signing and repeated rich-text transformations for records with multiple fields of the same handled type. It also reduces event-loop blocking when large result sets contain several file or rich-text fields.

## Tests

Added a regression test with two `FILES` fields. It verifies that both fields are processed while `signFileByIdUrl` is called exactly once per file, two calls instead of the previous four.

Validated with:

```bash
yarn nx jest twenty-server --runInBand --runTestsByPath src/engine/api/common/common-result-getters/__tests__/common-result-getters.service.spec.ts
```

Touched files also pass type-aware Oxlint and Oxfmt.
