### PR TITLE
fix(twenty-server,twenty-front): restore soft-deleted junction relation on re-add (#23305)

### DIFF
--- a/packages/twenty-front/src/modules/object-metadata/utils/generateCreateOneRecordMutation.ts
+++ b/packages/twenty-front/src/modules/object-metadata/utils/generateCreateOneRecordMutation.ts
@@ -1,13 +1,14 @@
-import { type EnrichedObjectMetadataItem } from '@/object-metadata/types/EnrichedObjectMetadataItem';
-import { mapObjectMetadataToGraphQLQuery } from '@/object-metadata/utils/mapObjectMetadataToGraphQLQuery';
-import { generateDepthRecordGqlFieldsFromObject } from '@/object-record/graphql/record-gql-fields/utils/generateDepthRecordGqlFieldsFromObject';
-import { getCreateOneRecordMutationResponseField } from '@/object-record/utils/getCreateOneRecordMutationResponseField';
 import { gql } from '@apollo/client';
 import {
   type ObjectPermissions,
   type RecordGqlOperationGqlRecordFields,
 } from 'twenty-shared/types';
 import { capitalize } from 'twenty-shared/utils';
+
+import { type EnrichedObjectMetadataItem } from '@/object-metadata/types/EnrichedObjectMetadataItem';
+import { mapObjectMetadataToGraphQLQuery } from '@/object-metadata/utils/mapObjectMetadataToGraphQLQuery';
+import { generateDepthRecordGqlFieldsFromObject } from '@/object-record/graphql/record-gql-fields/utils/generateDepthRecordGqlFieldsFromObject';
+import { getCreateOneRecordMutationResponseField } from '@/object-record/utils/getCreateOneRecordMutationResponseField';
 
 export const generateCreateOneRecordMutation = ({
   objectMetadataItem,
@@ -38,8 +39,8 @@ export const generateCreateOneRecordMutation = ({
   );
 
   const createOneRecordMutation = gql`
-    mutation CreateOne${capitalizedObjectName}($input: ${capitalizedObjectName}CreateInput!)  {
-      ${mutationResponseField}(data: $input) ${mapObjectMetadataToGraphQLQuery({
+    mutation CreateOne${capitalizedObjectName}($input: ${capitalizedObjectName}CreateInput!, $upsert: Boolean) {
+      ${mutationResponseField}(data: $input, upsert: $upsert) ${mapObjectMetadataToGraphQLQuery({
         objectMetadataItems,
         objectMetadataItem,
         recordGqlFields: appliedRecordGqlFields,

--- a/packages/twenty-front/src/modules/object-metadata/utils/generateCreateOneRecordMutation.ts
+++ b/packages/twenty-front/src/modules/object-metadata/utils/generateCreateOneRecordMutation.ts
@@ -39,7 +39,10 @@ export const generateCreateOneRecordMutation = ({
   );
 
   const createOneRecordMutation = gql`
-    mutation CreateOne${capitalizedObjectName}($input: ${capitalizedObjectName}CreateInput!, $upsert: Boolean) {
+    mutation CreateOne${capitalizedObjectName}(
+      $input: ${capitalizedObjectName}CreateInput!
+      $upsert: Boolean
+    ) {
       ${mutationResponseField}(data: $input, upsert: $upsert) ${mapObjectMetadataToGraphQLQuery({
         objectMetadataItems,
         objectMetadataItem,

--- a/packages/twenty-front/src/modules/object-record/hooks/useCreateOneRecord.ts
+++ b/packages/twenty-front/src/modules/object-record/hooks/useCreateOneRecord.ts
@@ -1,9 +1,15 @@
 import { useState } from 'react';
+import {
+  type ObjectRecord as ObjectRecordShared,
+  type RecordGqlOperationGqlRecordFields,
+} from 'twenty-shared/types';
+import { CustomError, isDefined } from 'twenty-shared/utils';
 import { v4 } from 'uuid';
 
 import { triggerCreateRecordsOptimisticEffect } from '@/apollo/optimistic-effect/utils/triggerCreateRecordsOptimisticEffect';
 import { triggerDestroyRecordsOptimisticEffect } from '@/apollo/optimistic-effect/utils/triggerDestroyRecordsOptimisticEffect';
 import { currentWorkspaceMemberState } from '@/auth/states/currentWorkspaceMemberState';
+import { dispatchObjectRecordOperationBrowserEvent } from '@/browser-event/utils/dispatchObjectRecordOperationBrowserEvent';
 import { useApolloCoreClient } from '@/object-metadata/hooks/useApolloCoreClient';
 import { useObjectMetadataItem } from '@/object-metadata/hooks/useObjectMetadataItem';
 import { useObjectMetadataItems } from '@/object-metadata/hooks/useObjectMetadataItems';
@@ -17,26 +23,20 @@ import { useCreateOneRecordMutation } from '@/object-record/hooks/useCreateOneRe
 import { useObjectPermissions } from '@/object-record/hooks/useObjectPermissions';
 import { useRefetchAggregateQueries } from '@/object-record/hooks/useRefetchAggregateQueries';
 import { useUpsertRecordsInStore } from '@/object-record/record-store/hooks/useUpsertRecordsInStore';
-import { type ObjectRecord } from '@/object-record/types/ObjectRecord';
-import {
-  type ObjectRecord as ObjectRecordShared,
-  type RecordGqlOperationGqlRecordFields,
-} from 'twenty-shared/types';
-
 import { type BaseObjectRecord } from '@/object-record/types/BaseObjectRecord';
+import { type ObjectRecord } from '@/object-record/types/ObjectRecord';
 import { computeOptimisticCreateRecordBaseRecordInput } from '@/object-record/utils/computeOptimisticCreateRecordBaseRecordInput';
 import { computeOptimisticRecordFromInput } from '@/object-record/utils/computeOptimisticRecordFromInput';
-import { dispatchObjectRecordOperationBrowserEvent } from '@/browser-event/utils/dispatchObjectRecordOperationBrowserEvent';
 import { getCreateOneRecordMutationResponseField } from '@/object-record/utils/getCreateOneRecordMutationResponseField';
 import { sanitizeRecordInput } from '@/object-record/utils/sanitizeRecordInput';
 import { useAtomStateValue } from '@/ui/utilities/state/jotai/hooks/useAtomStateValue';
-import { CustomError, isDefined } from 'twenty-shared/utils';
 
 type useCreateOneRecordProps = {
   objectNameSingular: string;
   recordGqlFields?: RecordGqlOperationGqlRecordFields;
   skipPostOptimisticEffect?: boolean;
   shouldMatchRootQueryFilter?: boolean;
+  upsert?: boolean;
 };
 
 export const useCreateOneRecord = <
@@ -46,6 +46,7 @@ export const useCreateOneRecord = <
   recordGqlFields,
   skipPostOptimisticEffect = false,
   shouldMatchRootQueryFilter,
+  upsert,
 }: useCreateOneRecordProps) => {
   const { upsertRecordsInStore } = useUpsertRecordsInStore();
   const apolloCoreClient = useApolloCoreClient();
@@ -141,6 +142,7 @@ export const useCreateOneRecord = <
         mutation: createOneRecordMutation,
         variables: {
           input: sanitizedInput,
+          upsert,
         },
         update: (cache, { data }) => {
           const record = data?.[mutationResponseField];

--- a/packages/twenty-front/src/modules/object-record/record-field/ui/hooks/useUpdateJunctionRelationFromCell.ts
+++ b/packages/twenty-front/src/modules/object-record/record-field/ui/hooks/useUpdateJunctionRelationFromCell.ts
@@ -1,5 +1,5 @@
-import { useCallback } from 'react';
 import { useStore } from 'jotai';
+import { useCallback } from 'react';
 import { isDefined } from 'twenty-shared/utils';
 import { v4 } from 'uuid';
 
@@ -61,6 +61,7 @@ export const useUpdateJunctionRelationFromCell = ({
   const { createOneRecord: createJunctionRecord } = useCreateOneRecord({
     objectNameSingular: junctionObjectNameSingular,
     skipPostOptimisticEffect: true,
+    upsert: true,
   });
 
   const { deleteOneRecord: deleteJunctionRecord } = useDeleteOneRecord({

--- a/packages/twenty-server/src/engine/api/common/common-query-runners/__tests__/common-create-one-query-runner.service.spec.ts
+++ b/packages/twenty-server/src/engine/api/common/common-query-runners/__tests__/common-create-one-query-runner.service.spec.ts
@@ -1,0 +1,36 @@
+import { CommonCreateOneQueryRunnerService } from 'src/engine/api/common/common-query-runners/common-create-one-query-runner.service';
+
+describe('CommonCreateOneQueryRunnerService', () => {
+  let service: CommonCreateOneQueryRunnerService;
+  let mockCommonCreateManyQueryRunnerService: { run: jest.Mock };
+
+  beforeEach(() => {
+    mockCommonCreateManyQueryRunnerService = {
+      run: jest.fn().mockResolvedValue([{ id: '1', name: 'Test Record' }]),
+    };
+
+    service = new CommonCreateOneQueryRunnerService(
+      mockCommonCreateManyQueryRunnerService as any,
+    );
+  });
+
+  it('should forward upsert flag to commonCreateManyQueryRunnerService.run', async () => {
+    const mockArgs = {
+      data: { name: 'Test Record' },
+      upsert: true,
+    };
+    const mockContext = {};
+
+    const result = await service.run(mockArgs as any, mockContext as any);
+
+    expect(mockCommonCreateManyQueryRunnerService.run).toHaveBeenCalledWith(
+      {
+        ...mockArgs,
+        data: [mockArgs.data],
+        upsert: true,
+      },
+      mockContext,
+    );
+    expect(result).toEqual({ id: '1', name: 'Test Record' });
+  });
+});

--- a/packages/twenty-server/src/engine/api/common/common-query-runners/__tests__/common-create-one-query-runner.service.spec.ts
+++ b/packages/twenty-server/src/engine/api/common/common-query-runners/__tests__/common-create-one-query-runner.service.spec.ts
@@ -3,34 +3,126 @@ import { CommonCreateOneQueryRunnerService } from 'src/engine/api/common/common-
 describe('CommonCreateOneQueryRunnerService', () => {
   let service: CommonCreateOneQueryRunnerService;
   let mockCommonCreateManyQueryRunnerService: { run: jest.Mock };
+  let mockDataArgProcessor: { process: jest.Mock };
 
   beforeEach(() => {
     mockCommonCreateManyQueryRunnerService = {
       run: jest.fn().mockResolvedValue([{ id: '1', name: 'Test Record' }]),
     };
 
+    mockDataArgProcessor = {
+      process: jest.fn().mockResolvedValue([{ id: '1', name: 'Test Record' }]),
+    };
+
     service = new CommonCreateOneQueryRunnerService(
       mockCommonCreateManyQueryRunnerService as any,
     );
+
+    (service as any).dataArgProcessor = mockDataArgProcessor;
   });
 
-  it('should forward upsert flag to commonCreateManyQueryRunnerService.run', async () => {
-    const mockArgs = {
-      data: { name: 'Test Record' },
-      upsert: true,
-    };
-    const mockContext = {};
-
-    const result = await service.run(mockArgs as any, mockContext as any);
-
-    expect(mockCommonCreateManyQueryRunnerService.run).toHaveBeenCalledWith(
-      {
-        ...mockArgs,
-        data: [mockArgs.data],
+  describe('run', () => {
+    it('should forward upsert: true flag to commonCreateManyQueryRunnerService.run', async () => {
+      const mockArgs = {
+        data: { name: 'Test Record' },
         upsert: true,
-      },
-      mockContext,
-    );
-    expect(result).toEqual({ id: '1', name: 'Test Record' });
+      };
+      const mockContext = {};
+
+      const result = await service.run(mockArgs as any, mockContext as any);
+
+      expect(mockCommonCreateManyQueryRunnerService.run).toHaveBeenCalledWith(
+        {
+          ...mockArgs,
+          data: [mockArgs.data],
+          upsert: true,
+        },
+        mockContext,
+      );
+      expect(result).toEqual({ id: '1', name: 'Test Record' });
+    });
+
+    it('should forward upsert: false flag to commonCreateManyQueryRunnerService.run', async () => {
+      const mockArgs = {
+        data: { name: 'Test Record' },
+        upsert: false,
+      };
+      const mockContext = {};
+
+      const result = await service.run(mockArgs as any, mockContext as any);
+
+      expect(mockCommonCreateManyQueryRunnerService.run).toHaveBeenCalledWith(
+        {
+          ...mockArgs,
+          data: [mockArgs.data],
+          upsert: false,
+        },
+        mockContext,
+      );
+      expect(result).toEqual({ id: '1', name: 'Test Record' });
+    });
+  });
+
+  describe('computeArgs', () => {
+    it('should pass shouldBackfillPositionIfUndefined: false when upsert is true', async () => {
+      const mockArgs = {
+        data: { name: 'Test Record' },
+        upsert: true,
+      };
+      const mockContext = {
+        authContext: {},
+        flatObjectMetadata: {},
+        flatFieldMetadataMaps: {},
+        flatObjectMetadataMaps: {},
+      };
+
+      const result = await service.computeArgs(
+        mockArgs as any,
+        mockContext as any,
+      );
+
+      expect(mockDataArgProcessor.process).toHaveBeenCalledWith({
+        partialRecordInputs: [mockArgs.data],
+        authContext: mockContext.authContext,
+        flatObjectMetadata: mockContext.flatObjectMetadata,
+        flatFieldMetadataMaps: mockContext.flatFieldMetadataMaps,
+        flatObjectMetadataMaps: mockContext.flatObjectMetadataMaps,
+        shouldBackfillPositionIfUndefined: false,
+      });
+      expect(result).toEqual({
+        ...mockArgs,
+        data: { id: '1', name: 'Test Record' },
+      });
+    });
+
+    it('should pass shouldBackfillPositionIfUndefined: true when upsert is false or undefined', async () => {
+      const mockArgs = {
+        data: { name: 'Test Record' },
+      };
+      const mockContext = {
+        authContext: {},
+        flatObjectMetadata: {},
+        flatFieldMetadataMaps: {},
+        flatObjectMetadataMaps: {},
+      };
+
+      const result = await service.computeArgs(
+        mockArgs as any,
+        mockContext as any,
+      );
+
+      expect(mockDataArgProcessor.process).toHaveBeenCalledWith({
+        partialRecordInputs: [mockArgs.data],
+        authContext: mockContext.authContext,
+        flatObjectMetadata: mockContext.flatObjectMetadata,
+        flatFieldMetadataMaps: mockContext.flatFieldMetadataMaps,
+        flatObjectMetadataMaps: mockContext.flatObjectMetadataMaps,
+        shouldBackfillPositionIfUndefined: true,
+      });
+      expect(result).toEqual({
+        ...mockArgs,
+        data: { id: '1', name: 'Test Record' },
+      });
+    });
   });
 });

--- a/packages/twenty-server/src/engine/api/common/common-query-runners/common-create-one-query-runner.service.ts
+++ b/packages/twenty-server/src/engine/api/common/common-query-runners/common-create-one-query-runner.service.ts
@@ -41,6 +41,7 @@ export class CommonCreateOneQueryRunnerService extends CommonBaseQueryRunnerServ
       {
         ...args,
         data: [args.data],
+        upsert: args.upsert,
       },
       queryRunnerContext,
     );


### PR DESCRIPTION
## Description
Fixes #23305.

When a junction relation (e.g., `PersonCompanyRelationship`) is removed, Twenty soft-deletes the intermediate junction record. Attempting to re-add the same relation previously failed with a PostgreSQL uniqueness error because the backend attempted to insert a new junction record instead of restoring the existing soft-deleted record.

This PR ensures that `upsert: true` is enabled when creating junction relation records, allowing `CommonCreateOneQueryRunnerService` to find and restore soft-deleted matching records (`deletedAt: null`).

## Changes Made
1. **`common-create-one-query-runner.service.ts`**: Forwarded `upsert: args.upsert` in `CommonCreateOneQueryRunnerService.run()`.
2. **`generateCreateOneRecordMutation.ts`**: Added `$upsert: Boolean` parameter support in Apollo CreateOne mutation definition.
3. **`useCreateOneRecord.ts`**: Added `upsert?: boolean` prop and passed `upsert` in mutation variables.
4. **`useUpdateJunctionRelationFromCell.ts`**: Set `upsert: true` when creating junction relation records.
5. **`common-create-one-query-runner.service.spec.ts`**: Added unit tests verifying `upsert` flag forwarding.

## Testing
- Added unit tests for `CommonCreateOneQueryRunnerService`.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/23365?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

