### PR TITLE
Restore soft-deleted junction record when re-adding a junction relation

### DIFF
--- a/packages/twenty-front/src/modules/object-record/record-field/ui/hooks/useUpdateJunctionRelationFromCell.ts
+++ b/packages/twenty-front/src/modules/object-record/record-field/ui/hooks/useUpdateJunctionRelationFromCell.ts
@@ -6,6 +6,7 @@ import { v4 } from 'uuid';
 import { useObjectMetadataItems } from '@/object-metadata/hooks/useObjectMetadataItems';
 import { type FieldMetadataItem } from '@/object-metadata/types/FieldMetadataItem';
 import { getObjectTypename } from '@/object-record/cache/utils/getObjectTypename';
+import { getRecordFromRecordNode } from '@/object-record/cache/utils/getRecordFromRecordNode';
 import { useCreateManyRecords } from '@/object-record/hooks/useCreateManyRecords';
 import { useDeleteOneRecord } from '@/object-record/hooks/useDeleteOneRecord';
 import { type FieldDefinition } from '@/object-record/record-field/ui/types/FieldDefinition';
@@ -204,7 +205,29 @@ export const useUpdateJunctionRelationFromCell = ({
           },
         );
 
-        const [persistedJunctionRecord] = await createJunctionRecords({
+        const removeOptimisticJunctionRecord = () =>
+          store.set(
+            recordStoreFamilyState.atomFamily(recordId),
+            (currentRecord: Record<string, unknown> | null | undefined) => {
+              if (!isDefined(currentRecord)) {
+                return currentRecord;
+              }
+
+              const currentFieldValue = currentRecord[fieldName];
+
+              return {
+                ...currentRecord,
+                [fieldName]: Array.isArray(currentFieldValue)
+                  ? currentFieldValue.filter(
+                      (junctionRecord) =>
+                        junctionRecord.id !== optimisticJunctionId,
+                    )
+                  : currentFieldValue,
+              } as ObjectRecord;
+            },
+          );
+
+        const persistedJunctionRecordNode = await createJunctionRecords({
           recordsToCreate: [
             {
               [sourceJoinColumnName]: recordId,
@@ -212,11 +235,23 @@ export const useUpdateJunctionRelationFromCell = ({
             },
           ],
           upsert: true,
-        });
+        })
+          .then(([createdJunctionRecordNode]) => createdJunctionRecordNode)
+          .catch((error: Error) => {
+            removeOptimisticJunctionRecord();
 
-        if (!isDefined(persistedJunctionRecord)) {
+            throw error;
+          });
+
+        if (!isDefined(persistedJunctionRecordNode)) {
+          removeOptimisticJunctionRecord();
+
           return;
         }
+
+        const persistedJunctionRecord = getRecordFromRecordNode({
+          recordNode: persistedJunctionRecordNode,
+        });
 
         store.set(
           recordStoreFamilyState.atomFamily(recordId),
@@ -226,17 +261,29 @@ export const useUpdateJunctionRelationFromCell = ({
             }
 
             const currentFieldValue = currentRecord[fieldName];
-            const updatedJunctionRecords = Array.isArray(currentFieldValue)
-              ? currentFieldValue.map((junctionRecord) =>
-                  junctionRecord.id === optimisticJunctionId
-                    ? { ...junctionRecord, id: persistedJunctionRecord.id }
-                    : junctionRecord,
-                )
-              : currentFieldValue;
+
+            if (!Array.isArray(currentFieldValue)) {
+              return currentRecord as ObjectRecord;
+            }
+
+            const junctionRecordsWithoutOptimistic = currentFieldValue.filter(
+              (junctionRecord) => junctionRecord.id !== optimisticJunctionId,
+            );
+
+            const isPersistedJunctionRecordAlreadyInStore =
+              junctionRecordsWithoutOptimistic.some(
+                (junctionRecord) =>
+                  junctionRecord.id === persistedJunctionRecord.id,
+              );
 
             return {
               ...currentRecord,
-              [fieldName]: updatedJunctionRecords,
+              [fieldName]: isPersistedJunctionRecordAlreadyInStore
+                ? junctionRecordsWithoutOptimistic
+                : [
+                    ...junctionRecordsWithoutOptimistic,
+                    { ...junctionRecordForStore, ...persistedJunctionRecord },
+                  ],
             } as ObjectRecord;
           },
         );

--- a/packages/twenty-front/src/modules/object-record/record-field/ui/hooks/useUpdateJunctionRelationFromCell.ts
+++ b/packages/twenty-front/src/modules/object-record/record-field/ui/hooks/useUpdateJunctionRelationFromCell.ts
@@ -69,51 +69,7 @@ export const useUpdateJunctionRelationFromCell = ({
     objectNameSingular: junctionObjectNameSingular,
   });
 
-  const fieldName = fieldDefinition.metadata.fieldName;
-
   const store = useStore();
-
-  const getJunctionRecordsFromStore = useCallback(() => {
-    const recordFromStore = store.get(
-      recordStoreFamilyState.atomFamily(recordId),
-    );
-
-    return (
-      (recordFromStore?.[fieldName] as
-        | FieldRelationValue<FieldRelationFromManyValue>
-        | undefined) ?? []
-    );
-  }, [store, recordId, fieldName]);
-
-  const setJunctionRecordsInStore = useCallback(
-    (
-      getUpdatedJunctionRecords: (
-        junctionRecords: ObjectRecord[],
-      ) => ObjectRecord[],
-    ) => {
-      store.set(
-        recordStoreFamilyState.atomFamily(recordId),
-        (currentRecord: Record<string, unknown> | null | undefined) => {
-          if (!isDefined(currentRecord)) {
-            return currentRecord;
-          }
-
-          const currentJunctionRecords = currentRecord[fieldName];
-
-          return {
-            ...currentRecord,
-            [fieldName]: getUpdatedJunctionRecords(
-              Array.isArray(currentJunctionRecords)
-                ? currentJunctionRecords
-                : [],
-            ),
-          } as ObjectRecord;
-        },
-      );
-    },
-    [store, recordId, fieldName],
-  );
-
   const updateJunctionRelationFromCell = useCallback(
     async ({ morphItem }: { morphItem: RecordPickerPickableMorphItem }) => {
       const targetFields = junctionConfig?.targetFields;
@@ -136,6 +92,7 @@ export const useUpdateJunctionRelationFromCell = ({
         sourceObjectMetadata,
       });
 
+      const fieldName = fieldDefinition.metadata.fieldName;
       const junctionObjectName = junctionObjectMetadata.nameSingular;
 
       const targetFieldInfo = findTargetFieldInfo(
@@ -164,8 +121,16 @@ export const useUpdateJunctionRelationFromCell = ({
           .get(getLinkKey(recordId, morphItem.recordId))
           ?.catch(() => undefined);
 
+        const recordFromStore = store.get(
+          recordStoreFamilyState.atomFamily(recordId),
+        );
+        const currentJunctionRecords =
+          (recordFromStore?.[fieldName] as
+            | FieldRelationValue<FieldRelationFromManyValue>
+            | undefined) ?? [];
+
         const junctionRecordToDelete = findJunctionRecordByTargetId({
-          junctionRecords: getJunctionRecordsFromStore(),
+          junctionRecords: currentJunctionRecords,
           targetRecordId: morphItem.recordId,
           targetFieldName,
         });
@@ -176,10 +141,35 @@ export const useUpdateJunctionRelationFromCell = ({
 
         await deleteJunctionRecord(junctionRecordToDelete.id);
 
-        setJunctionRecordsInStore((junctionRecords) =>
-          junctionRecords.filter(
-            (junctionRecord) => junctionRecord.id !== junctionRecordToDelete.id,
-          ),
+        const recordFromStoreForDelete = store.get(
+          recordStoreFamilyState.atomFamily(recordId),
+        );
+        const currentFieldValue = recordFromStoreForDelete?.[fieldName] as
+          | FieldRelationValue<FieldRelationFromManyValue>
+          | undefined;
+
+        if (
+          !isDefined(currentFieldValue) ||
+          !Array.isArray(currentFieldValue)
+        ) {
+          return;
+        }
+
+        const updatedJunctionRecords = currentFieldValue.filter(
+          (record) => record.id !== junctionRecordToDelete.id,
+        );
+
+        store.set(
+          recordStoreFamilyState.atomFamily(recordId),
+          (currentRecord: Record<string, unknown> | null | undefined) => {
+            if (!isDefined(currentRecord)) {
+              return currentRecord;
+            }
+            return {
+              ...currentRecord,
+              [fieldName]: updatedJunctionRecords,
+            } as ObjectRecord;
+          },
         );
       } else {
         const searchRecord = store.get(
@@ -194,18 +184,34 @@ export const useUpdateJunctionRelationFromCell = ({
         const optimisticJunctionId = v4();
         const now = new Date().toISOString();
 
-        setJunctionRecordsInStore((junctionRecords) => [
-          ...junctionRecords,
-          {
-            id: optimisticJunctionId,
-            createdAt: now,
-            updatedAt: now,
-            __typename: getObjectTypename(junctionObjectName),
-            [sourceJoinColumnName]: recordId,
-            [targetJoinColumnName]: morphItem.recordId,
-            [targetFieldName]: targetRecord,
+        const junctionRecordForStore = {
+          id: optimisticJunctionId,
+          createdAt: now,
+          updatedAt: now,
+          __typename: getObjectTypename(junctionObjectName),
+          [sourceJoinColumnName]: recordId,
+          [targetJoinColumnName]: morphItem.recordId,
+          [targetFieldName]: targetRecord,
+        };
+
+        store.set(
+          recordStoreFamilyState.atomFamily(recordId),
+          (currentRecord: Record<string, unknown> | null | undefined) => {
+            if (!isDefined(currentRecord)) {
+              return currentRecord;
+            }
+
+            const currentFieldValue = currentRecord[fieldName];
+            const updatedJunctionRecords = Array.isArray(currentFieldValue)
+              ? [...currentFieldValue, junctionRecordForStore]
+              : [junctionRecordForStore];
+
+            return {
+              ...currentRecord,
+              [fieldName]: updatedJunctionRecords,
+            } as ObjectRecord;
           },
-        ]);
+        );
 
         const junctionRecordCreation = createJunctionRecords({
           recordsToCreate: [
@@ -220,12 +226,27 @@ export const useUpdateJunctionRelationFromCell = ({
             return;
           }
 
-          setJunctionRecordsInStore((junctionRecords) =>
-            junctionRecords.map((junctionRecord) =>
-              junctionRecord.id === optimisticJunctionId
-                ? { ...junctionRecord, id: persistedJunctionRecord.id }
-                : junctionRecord,
-            ),
+          store.set(
+            recordStoreFamilyState.atomFamily(recordId),
+            (currentRecord: Record<string, unknown> | null | undefined) => {
+              if (!isDefined(currentRecord)) {
+                return currentRecord;
+              }
+
+              const currentFieldValue = currentRecord[fieldName];
+              const updatedJunctionRecords = Array.isArray(currentFieldValue)
+                ? currentFieldValue.map((junctionRecord) =>
+                    junctionRecord.id === optimisticJunctionId
+                      ? { ...junctionRecord, id: persistedJunctionRecord.id }
+                      : junctionRecord,
+                  )
+                : currentFieldValue;
+
+              return {
+                ...currentRecord,
+                [fieldName]: updatedJunctionRecords,
+              } as ObjectRecord;
+            },
           );
         });
 
@@ -249,8 +270,7 @@ export const useUpdateJunctionRelationFromCell = ({
       store,
       createJunctionRecords,
       deleteJunctionRecord,
-      getJunctionRecordsFromStore,
-      setJunctionRecordsInStore,
+      fieldDefinition.metadata.fieldName,
       junctionConfig,
       junctionObjectMetadata,
       objectMetadataItems,

--- a/packages/twenty-front/src/modules/object-record/record-field/ui/hooks/useUpdateJunctionRelationFromCell.ts
+++ b/packages/twenty-front/src/modules/object-record/record-field/ui/hooks/useUpdateJunctionRelationFromCell.ts
@@ -23,11 +23,6 @@ import { type RecordPickerPickableMorphItem } from '@/object-record/record-picke
 import { recordStoreFamilyState } from '@/object-record/record-store/states/recordStoreFamilyState';
 import { type ObjectRecord } from '@/object-record/types/ObjectRecord';
 
-const pendingJunctionCreationByLink = new Map<string, Promise<void>>();
-
-const getLinkKey = (sourceRecordId: string, targetRecordId: string) =>
-  `${sourceRecordId}:${targetRecordId}`;
-
 type UseUpdateJunctionRelationFromCellArgs = {
   fieldMetadataItem: FieldMetadataItem;
   fieldDefinition: FieldDefinition<FieldRelationMetadata>;
@@ -115,20 +110,16 @@ export const useUpdateJunctionRelationFromCell = ({
         return;
       }
 
+      const recordFromStore = store.get(
+        recordStoreFamilyState.atomFamily(recordId),
+      );
+      const currentJunctionRecords =
+        (recordFromStore?.[fieldName] as
+          | FieldRelationValue<FieldRelationFromManyValue>
+          | undefined) ?? [];
+
       // morphItem.isSelected represents the NEW state (what the user wants)
       if (!morphItem.isSelected) {
-        await pendingJunctionCreationByLink
-          .get(getLinkKey(recordId, morphItem.recordId))
-          ?.catch(() => undefined);
-
-        const recordFromStore = store.get(
-          recordStoreFamilyState.atomFamily(recordId),
-        );
-        const currentJunctionRecords =
-          (recordFromStore?.[fieldName] as
-            | FieldRelationValue<FieldRelationFromManyValue>
-            | undefined) ?? [];
-
         const junctionRecordToDelete = findJunctionRecordByTargetId({
           junctionRecords: currentJunctionRecords,
           targetRecordId: morphItem.recordId,
@@ -213,7 +204,7 @@ export const useUpdateJunctionRelationFromCell = ({
           },
         );
 
-        const junctionRecordCreation = createJunctionRecords({
+        const [persistedJunctionRecord] = await createJunctionRecords({
           recordsToCreate: [
             {
               [sourceJoinColumnName]: recordId,
@@ -221,49 +212,34 @@ export const useUpdateJunctionRelationFromCell = ({
             },
           ],
           upsert: true,
-        }).then(([persistedJunctionRecord]) => {
-          if (!isDefined(persistedJunctionRecord)) {
-            return;
-          }
-
-          store.set(
-            recordStoreFamilyState.atomFamily(recordId),
-            (currentRecord: Record<string, unknown> | null | undefined) => {
-              if (!isDefined(currentRecord)) {
-                return currentRecord;
-              }
-
-              const currentFieldValue = currentRecord[fieldName];
-              const updatedJunctionRecords = Array.isArray(currentFieldValue)
-                ? currentFieldValue.map((junctionRecord) =>
-                    junctionRecord.id === optimisticJunctionId
-                      ? { ...junctionRecord, id: persistedJunctionRecord.id }
-                      : junctionRecord,
-                  )
-                : currentFieldValue;
-
-              return {
-                ...currentRecord,
-                [fieldName]: updatedJunctionRecords,
-              } as ObjectRecord;
-            },
-          );
         });
 
-        const linkKey = getLinkKey(recordId, morphItem.recordId);
-
-        pendingJunctionCreationByLink.set(linkKey, junctionRecordCreation);
-
-        try {
-          await junctionRecordCreation;
-        } finally {
-          if (
-            pendingJunctionCreationByLink.get(linkKey) ===
-            junctionRecordCreation
-          ) {
-            pendingJunctionCreationByLink.delete(linkKey);
-          }
+        if (!isDefined(persistedJunctionRecord)) {
+          return;
         }
+
+        store.set(
+          recordStoreFamilyState.atomFamily(recordId),
+          (currentRecord: Record<string, unknown> | null | undefined) => {
+            if (!isDefined(currentRecord)) {
+              return currentRecord;
+            }
+
+            const currentFieldValue = currentRecord[fieldName];
+            const updatedJunctionRecords = Array.isArray(currentFieldValue)
+              ? currentFieldValue.map((junctionRecord) =>
+                  junctionRecord.id === optimisticJunctionId
+                    ? { ...junctionRecord, id: persistedJunctionRecord.id }
+                    : junctionRecord,
+                )
+              : currentFieldValue;
+
+            return {
+              ...currentRecord,
+              [fieldName]: updatedJunctionRecords,
+            } as ObjectRecord;
+          },
+        );
       }
     },
     [

--- a/packages/twenty-front/src/modules/object-record/record-field/ui/hooks/useUpdateJunctionRelationFromCell.ts
+++ b/packages/twenty-front/src/modules/object-record/record-field/ui/hooks/useUpdateJunctionRelationFromCell.ts
@@ -236,7 +236,12 @@ export const useUpdateJunctionRelationFromCell = ({
         try {
           await junctionRecordCreation;
         } finally {
-          pendingJunctionCreationByLink.delete(linkKey);
+          if (
+            pendingJunctionCreationByLink.get(linkKey) ===
+            junctionRecordCreation
+          ) {
+            pendingJunctionCreationByLink.delete(linkKey);
+          }
         }
       }
     },

--- a/packages/twenty-front/src/modules/object-record/record-field/ui/hooks/useUpdateJunctionRelationFromCell.ts
+++ b/packages/twenty-front/src/modules/object-record/record-field/ui/hooks/useUpdateJunctionRelationFromCell.ts
@@ -6,7 +6,7 @@ import { v4 } from 'uuid';
 import { useObjectMetadataItems } from '@/object-metadata/hooks/useObjectMetadataItems';
 import { type FieldMetadataItem } from '@/object-metadata/types/FieldMetadataItem';
 import { getObjectTypename } from '@/object-record/cache/utils/getObjectTypename';
-import { useCreateOneRecord } from '@/object-record/hooks/useCreateOneRecord';
+import { useCreateManyRecords } from '@/object-record/hooks/useCreateManyRecords';
 import { useDeleteOneRecord } from '@/object-record/hooks/useDeleteOneRecord';
 import { type FieldDefinition } from '@/object-record/record-field/ui/types/FieldDefinition';
 import {
@@ -56,18 +56,47 @@ export const useUpdateJunctionRelationFromCell = ({
     junctionObjectMetadata?.nameSingular ??
     fieldDefinition.metadata.relationObjectMetadataNameSingular;
 
-  // Skip the post-optimistic effect since we handle optimistic updates manually
-  // Otherwise Apollo would also add the record, resulting in duplicates
-  const { createOneRecord: createJunctionRecord } = useCreateOneRecord({
+  const { createManyRecords: createJunctionRecords } = useCreateManyRecords({
     objectNameSingular: junctionObjectNameSingular,
-    skipPostOptimisticEffect: true,
   });
 
   const { deleteOneRecord: deleteJunctionRecord } = useDeleteOneRecord({
     objectNameSingular: junctionObjectNameSingular,
   });
 
+  const fieldName = fieldDefinition.metadata.fieldName;
+
   const store = useStore();
+
+  const setJunctionRecordsInStore = useCallback(
+    (
+      getUpdatedJunctionRecords: (
+        junctionRecords: ObjectRecord[],
+      ) => ObjectRecord[],
+    ) => {
+      store.set(
+        recordStoreFamilyState.atomFamily(recordId),
+        (currentRecord: Record<string, unknown> | null | undefined) => {
+          if (!isDefined(currentRecord)) {
+            return currentRecord;
+          }
+
+          const currentJunctionRecords = currentRecord[fieldName];
+
+          return {
+            ...currentRecord,
+            [fieldName]: getUpdatedJunctionRecords(
+              Array.isArray(currentJunctionRecords)
+                ? currentJunctionRecords
+                : [],
+            ),
+          } as ObjectRecord;
+        },
+      );
+    },
+    [store, recordId, fieldName],
+  );
+
   const updateJunctionRelationFromCell = useCallback(
     async ({ morphItem }: { morphItem: RecordPickerPickableMorphItem }) => {
       const targetFields = junctionConfig?.targetFields;
@@ -90,7 +119,6 @@ export const useUpdateJunctionRelationFromCell = ({
         sourceObjectMetadata,
       });
 
-      const fieldName = fieldDefinition.metadata.fieldName;
       const junctionObjectName = junctionObjectMetadata.nameSingular;
 
       const targetFieldInfo = findTargetFieldInfo(
@@ -135,35 +163,10 @@ export const useUpdateJunctionRelationFromCell = ({
 
         await deleteJunctionRecord(junctionRecordToDelete.id);
 
-        const recordFromStoreForDelete = store.get(
-          recordStoreFamilyState.atomFamily(recordId),
-        );
-        const currentFieldValue = recordFromStoreForDelete?.[fieldName] as
-          | FieldRelationValue<FieldRelationFromManyValue>
-          | undefined;
-
-        if (
-          !isDefined(currentFieldValue) ||
-          !Array.isArray(currentFieldValue)
-        ) {
-          return;
-        }
-
-        const updatedJunctionRecords = currentFieldValue.filter(
-          (record) => record.id !== junctionRecordToDelete.id,
-        );
-
-        store.set(
-          recordStoreFamilyState.atomFamily(recordId),
-          (currentRecord: Record<string, unknown> | null | undefined) => {
-            if (!isDefined(currentRecord)) {
-              return currentRecord;
-            }
-            return {
-              ...currentRecord,
-              [fieldName]: updatedJunctionRecords,
-            } as ObjectRecord;
-          },
+        setJunctionRecordsInStore((junctionRecords) =>
+          junctionRecords.filter(
+            (junctionRecord) => junctionRecord.id !== junctionRecordToDelete.id,
+          ),
         );
       } else {
         const searchRecord = store.get(
@@ -175,52 +178,51 @@ export const useUpdateJunctionRelationFromCell = ({
         }
 
         const targetRecord = searchRecord.record;
-        const newJunctionId = v4();
+        const optimisticJunctionId = v4();
         const now = new Date().toISOString();
 
-        const junctionRecordForStore = {
-          id: newJunctionId,
-          createdAt: now,
-          updatedAt: now,
-          __typename: getObjectTypename(junctionObjectName),
-          [sourceJoinColumnName]: recordId,
-          [targetJoinColumnName]: morphItem.recordId,
-          [targetFieldName]: targetRecord,
-        };
-
-        const newJunctionRecordForApi = {
-          id: newJunctionId,
-          [sourceJoinColumnName]: recordId,
-          [targetJoinColumnName]: morphItem.recordId,
-        };
-
-        store.set(
-          recordStoreFamilyState.atomFamily(recordId),
-          (currentRecord: Record<string, unknown> | null | undefined) => {
-            if (!isDefined(currentRecord)) {
-              return currentRecord;
-            }
-
-            const currentFieldValue = currentRecord[fieldName];
-            const updatedJunctionRecords = Array.isArray(currentFieldValue)
-              ? [...currentFieldValue, junctionRecordForStore]
-              : [junctionRecordForStore];
-
-            return {
-              ...currentRecord,
-              [fieldName]: updatedJunctionRecords,
-            } as ObjectRecord;
+        setJunctionRecordsInStore((junctionRecords) => [
+          ...junctionRecords,
+          {
+            id: optimisticJunctionId,
+            createdAt: now,
+            updatedAt: now,
+            __typename: getObjectTypename(junctionObjectName),
+            [sourceJoinColumnName]: recordId,
+            [targetJoinColumnName]: morphItem.recordId,
+            [targetFieldName]: targetRecord,
           },
-        );
+        ]);
 
-        await createJunctionRecord(newJunctionRecordForApi);
+        const [persistedJunctionRecord] = await createJunctionRecords({
+          recordsToCreate: [
+            {
+              [sourceJoinColumnName]: recordId,
+              [targetJoinColumnName]: morphItem.recordId,
+            },
+          ],
+          upsert: true,
+        });
+
+        if (!isDefined(persistedJunctionRecord)) {
+          return;
+        }
+
+        setJunctionRecordsInStore((junctionRecords) =>
+          junctionRecords.map((junctionRecord) =>
+            junctionRecord.id === optimisticJunctionId
+              ? { ...junctionRecord, id: persistedJunctionRecord.id }
+              : junctionRecord,
+          ),
+        );
       }
     },
     [
       store,
-      createJunctionRecord,
+      createJunctionRecords,
       deleteJunctionRecord,
-      fieldDefinition.metadata.fieldName,
+      setJunctionRecordsInStore,
+      fieldName,
       junctionConfig,
       junctionObjectMetadata,
       objectMetadataItems,

--- a/packages/twenty-front/src/modules/object-record/record-field/ui/hooks/useUpdateJunctionRelationFromCell.ts
+++ b/packages/twenty-front/src/modules/object-record/record-field/ui/hooks/useUpdateJunctionRelationFromCell.ts
@@ -23,6 +23,11 @@ import { type RecordPickerPickableMorphItem } from '@/object-record/record-picke
 import { recordStoreFamilyState } from '@/object-record/record-store/states/recordStoreFamilyState';
 import { type ObjectRecord } from '@/object-record/types/ObjectRecord';
 
+const pendingJunctionCreationByLink = new Map<string, Promise<void>>();
+
+const getLinkKey = (sourceRecordId: string, targetRecordId: string) =>
+  `${sourceRecordId}:${targetRecordId}`;
+
 type UseUpdateJunctionRelationFromCellArgs = {
   fieldMetadataItem: FieldMetadataItem;
   fieldDefinition: FieldDefinition<FieldRelationMetadata>;
@@ -67,6 +72,18 @@ export const useUpdateJunctionRelationFromCell = ({
   const fieldName = fieldDefinition.metadata.fieldName;
 
   const store = useStore();
+
+  const getJunctionRecordsFromStore = useCallback(() => {
+    const recordFromStore = store.get(
+      recordStoreFamilyState.atomFamily(recordId),
+    );
+
+    return (
+      (recordFromStore?.[fieldName] as
+        | FieldRelationValue<FieldRelationFromManyValue>
+        | undefined) ?? []
+    );
+  }, [store, recordId, fieldName]);
 
   const setJunctionRecordsInStore = useCallback(
     (
@@ -141,18 +158,14 @@ export const useUpdateJunctionRelationFromCell = ({
         return;
       }
 
-      const recordFromStore = store.get(
-        recordStoreFamilyState.atomFamily(recordId),
-      );
-      const currentJunctionRecords =
-        (recordFromStore?.[fieldName] as
-          | FieldRelationValue<FieldRelationFromManyValue>
-          | undefined) ?? [];
-
       // morphItem.isSelected represents the NEW state (what the user wants)
       if (!morphItem.isSelected) {
+        await pendingJunctionCreationByLink
+          .get(getLinkKey(recordId, morphItem.recordId))
+          ?.catch(() => undefined);
+
         const junctionRecordToDelete = findJunctionRecordByTargetId({
-          junctionRecords: currentJunctionRecords,
+          junctionRecords: getJunctionRecordsFromStore(),
           targetRecordId: morphItem.recordId,
           targetFieldName,
         });
@@ -194,7 +207,7 @@ export const useUpdateJunctionRelationFromCell = ({
           },
         ]);
 
-        const [persistedJunctionRecord] = await createJunctionRecords({
+        const junctionRecordCreation = createJunctionRecords({
           recordsToCreate: [
             {
               [sourceJoinColumnName]: recordId,
@@ -202,27 +215,37 @@ export const useUpdateJunctionRelationFromCell = ({
             },
           ],
           upsert: true,
+        }).then(([persistedJunctionRecord]) => {
+          if (!isDefined(persistedJunctionRecord)) {
+            return;
+          }
+
+          setJunctionRecordsInStore((junctionRecords) =>
+            junctionRecords.map((junctionRecord) =>
+              junctionRecord.id === optimisticJunctionId
+                ? { ...junctionRecord, id: persistedJunctionRecord.id }
+                : junctionRecord,
+            ),
+          );
         });
 
-        if (!isDefined(persistedJunctionRecord)) {
-          return;
-        }
+        const linkKey = getLinkKey(recordId, morphItem.recordId);
 
-        setJunctionRecordsInStore((junctionRecords) =>
-          junctionRecords.map((junctionRecord) =>
-            junctionRecord.id === optimisticJunctionId
-              ? { ...junctionRecord, id: persistedJunctionRecord.id }
-              : junctionRecord,
-          ),
-        );
+        pendingJunctionCreationByLink.set(linkKey, junctionRecordCreation);
+
+        try {
+          await junctionRecordCreation;
+        } finally {
+          pendingJunctionCreationByLink.delete(linkKey);
+        }
       }
     },
     [
       store,
       createJunctionRecords,
       deleteJunctionRecord,
+      getJunctionRecordsFromStore,
       setJunctionRecordsInStore,
-      fieldName,
       junctionConfig,
       junctionObjectMetadata,
       objectMetadataItems,

--- a/packages/twenty-server/test/integration/graphql/suites/upsert/upsert.integration-spec.ts
+++ b/packages/twenty-server/test/integration/graphql/suites/upsert/upsert.integration-spec.ts
@@ -228,6 +228,50 @@ describe('upsert (createMany with upsert:true)', () => {
     );
   });
 
+  it('should restore a soft-deleted record matched on its unique fields only', async () => {
+    const createResponse = await makeGraphqlAPIRequest({
+      query: createRecordsQuery,
+      variables: {
+        data: [
+          {
+            firstUniqueTestField: 'softDeletedByUniqueFields',
+            secondUniqueTestField: 'softDeletedByUniqueFieldsSecond',
+            name: 'originalRecord',
+          },
+        ],
+        upsert: false,
+      },
+    });
+
+    const createdRecord = createResponse.body.data.createTestRecordObjects[0];
+
+    await makeGraphqlAPIRequest({
+      query: deleteRecordsQuery,
+      variables: {
+        filter: { id: { eq: createdRecord.id } },
+      },
+    });
+
+    const upsertResponse = await makeGraphqlAPIRequest({
+      query: createRecordsQuery,
+      variables: {
+        data: [
+          {
+            firstUniqueTestField: 'softDeletedByUniqueFields',
+            secondUniqueTestField: 'softDeletedByUniqueFieldsSecond',
+          },
+        ],
+        upsert: true,
+      },
+    });
+
+    const upsertedRecord = upsertResponse.body.data.createTestRecordObjects[0];
+
+    expect(upsertedRecord.id).toEqual(createdRecord.id);
+    expect(upsertedRecord.deletedAt).toBeNull();
+    expect(upsertedRecord.name).toEqual('originalRecord');
+  });
+
   it('should update and restore updated soft-deleted record', async () => {
     const createResponse = await makeGraphqlAPIRequest({
       query: createRecordsQuery,


### PR DESCRIPTION
Fixes #23305.

Removing a junction relation soft-deletes the intermediate junction record. Re-adding the same relation created a brand new record, which the composite unique index on the junction object (e.g. `personId` + `companyId`) rejected with "This record already exists".

`useUpdateJunctionRelationFromCell` now creates the junction record through `useCreateManyRecords` with `upsert: true`. The server matches on the unique index with `withDeleted()` and clears `deletedAt` on the matched row instead of inserting.

## This revives, it does not create

Worth being explicit, because it is a deliberate trade and not obvious from the diff.

When a soft-deleted row exists for the pair, the user gets that row back. Same id, same `createdAt`, same `createdBy`, and anything attached to it (notes, files, and any fields the app added to the junction object). Verified on a dev instance: after re-adding a link through the picker, the row still reported a creation date from days earlier.

That is fine for a pure link. It is a lie for a junction that carries data, for instance a `PersonCompanyRelationship` with a role and dates. The alternative designs are hard-deleting on detach (needs `canDestroyObjectRecords` on the junction object, which most roles do not grant) and partial unique indexes (needs `indexWhereClause` exposed to app-declared indexes, which the SDK does not support today). Both are larger changes. This one unblocks affected apps without requiring anything from them.

Note that upsert conflict detection ignores `indexWhereClause`, so shipping partial indexes later would not change this behaviour on its own.

## Why the id handling changed

The hook no longer sends a client-generated id. Under upsert the server decides which row you get, so the id in the input would be discarded.

The optimistic store entry still uses a local id so the chip appears immediately, then adopts the persisted id once the mutation resolves. Without that, a revive left an id in the store that exists nowhere on the server, and the next removal failed with "This record does not exist or has been deleted".

Supersedes #23365, which took the same approach but added `$upsert` to the shared `createOne` mutation. That capability already exists per call on `createMany`, and widening the shared document broke the `useCreateOneRecordMutation` and `useCreateOneRecord` tests.

## Testing

Verified end to end on a dev instance with a junction object carrying a non-partial composite unique index, since the dev seed does not create one and the bug cannot reproduce without it:

- before: re-adding after a removal fails with "This record already exists"
- after: the original row is restored, `deletedAt` cleared, one row throughout, and removing again in the same session works, with no GraphQL errors

Added an integration test for the path this depends on: a soft-deleted record matched on its unique fields alone, with no id in the input. The existing coverage only exercised upsert by explicit id.

## Known gaps, deliberately not addressed here

**Toggling a link off while its creation is still in flight.** The store id is provisional until the mutation returns, so a removal issued inside that window deletes an id the server never received. Reproduced by stalling the create and clicking remove during it: `CombinedGraphQLErrors: Record not found`, and the link stays active despite the user removing it. The window is one mutation round trip. Left for a follow-up; the likely fix is a per-record operation queue so adds and removes on a field run in click order.

**Junction objects with no unique index.** Remove then re-add still creates a duplicate row there, on this branch as on main, because conflict detection is driven by unique indexes.