### PR TITLE
Publish apps to npm with public access

### DIFF
--- a/packages/twenty-apps/public/discord/package.json
+++ b/packages/twenty-apps/public/discord/package.json
@@ -3,6 +3,9 @@
   "version": "0.1.0",
   "description": "Discord workflow connector for Twenty",
   "license": "MIT",
+  "publishConfig": {
+    "access": "public"
+  },
   "engines": {
     "node": "^24.5.0",
     "npm": "please-use-yarn",

--- a/packages/twenty-apps/public/exa/package.json
+++ b/packages/twenty-apps/public/exa/package.json
@@ -3,6 +3,9 @@
   "version": "0.2.0",
   "description": "Structured web search powered by Exa, exposed to Twenty AI agents as a tool.",
   "license": "MIT",
+  "publishConfig": {
+    "access": "public"
+  },
   "engines": {
     "node": "^24.5.0",
     "npm": "please-use-yarn",

--- a/packages/twenty-apps/public/linear/package.json
+++ b/packages/twenty-apps/public/linear/package.json
@@ -3,6 +3,9 @@
   "version": "0.1.0",
   "description": "Linear integration for Twenty. Connect a user's Linear account and create issues from logic functions.",
   "license": "MIT",
+  "publishConfig": {
+    "access": "public"
+  },
   "engines": {
     "node": "^24.5.0",
     "npm": "please-use-yarn",

--- a/packages/twenty-apps/public/twenty-slack/package.json
+++ b/packages/twenty-apps/public/twenty-slack/package.json
@@ -3,6 +3,9 @@
   "version": "0.1.0",
   "description": "Slack workflow connector for Twenty",
   "license": "MIT",
+  "publishConfig": {
+    "access": "public"
+  },
   "engines": {
     "node": "^24.5.0",
     "npm": "please-use-yarn",


### PR DESCRIPTION
## Context

`yarn twenty app:publish` from `packages/twenty-apps/public/exa` fails on the first publish:

```
npm error code E402
npm error 402 Payment Required - PUT https://registry.npmjs.org/@twentyhq%2fexa - You must sign up for private packages
```

`@twentyhq/exa` has never been published, so this is a create request. npm defaults scoped packages to `restricted` access, which requires a paid plan, hence the 402.

`twenty-sdk` passes `--access public` to `npm publish`, but only since 2.23.0. Four apps still pin `twenty-sdk@2.16.0` in their lockfiles, and that build runs a bare `npm publish`:

| app | twenty-sdk | on npm |
| --- | --- | --- |
| exa | 2.16.0 | no |
| discord | 2.16.0 | no |
| linear | 2.16.0 | no |
| twenty-slack | 2.16.0 | no |

## Changes

Add `publishConfig: { access: "public" }` to those four manifests. The build copies each app's `package.json` verbatim into `.twenty/output`, which is the cwd of the `npm publish` call, so npm picks the setting up regardless of which SDK version the app pins.

Apps already on `twenty-sdk` 2.23.0-alpha.2 (call-recorder, fireflies, last-contact, people-data-labs) get `--access public` from the CLI and are left alone.

## Verification

`npm publish --dry-run` against the built `exa` package.json:

- with `publishConfig`: `Publishing to https://registry.npmjs.org/ with tag latest and public access`
- without it: `... with tag latest and default access`

## Note

These four apps are still a full minor behind the rest on `twenty-sdk`. Worth bumping them separately, at which point this field becomes redundant.
