### PR TITLE
fix(ai-agent): lazy-load tools in agent executor to cut Slack assistant latency

### DIFF
--- a/packages/twenty-server/src/engine/core-modules/tool-provider/utils/build-tool-catalog-section.util.ts
+++ b/packages/twenty-server/src/engine/core-modules/tool-provider/utils/build-tool-catalog-section.util.ts
@@ -1,0 +1,166 @@
+import { ToolCategory } from 'twenty-shared/ai';
+import { assertUnreachable } from 'twenty-shared/utils';
+
+import {
+  EXECUTE_TOOL_TOOL_NAME,
+  LEARN_TOOLS_TOOL_NAME,
+} from 'src/engine/core-modules/tool-provider/tools';
+import { type ToolIndexEntry } from 'src/engine/core-modules/tool-provider/types/tool-index-entry.type';
+
+const getCategoryLabel = (category: ToolCategory): string => {
+  switch (category) {
+    case ToolCategory.DATABASE_CRUD:
+      return 'Database Tools (CRUD operations)';
+    case ToolCategory.ACTION:
+      return 'Action Tools (HTTP, Email, etc.)';
+    case ToolCategory.WORKFLOW:
+      return 'Workflow Tools (create/manage workflows)';
+    case ToolCategory.METADATA:
+      return 'Metadata Tools (schema management)';
+    case ToolCategory.VIEW:
+      return 'View Tools (manage views, fields, filters, and sorts)';
+    case ToolCategory.DASHBOARD:
+      return 'Dashboard Tools (create/manage dashboards)';
+    case ToolCategory.LOGIC_FUNCTION:
+      return 'Logic Functions (custom tools)';
+    case ToolCategory.NAVIGATION_MENU_ITEM:
+      return 'Navigation Menu Item Tools (sidebar entries, folders, and user favorites)';
+    case ToolCategory.WEBHOOK:
+      return 'Webhook Tools (outgoing webhooks)';
+    default:
+      return assertUnreachable(category);
+  }
+};
+
+const buildDatabaseCrudCatalogSection = (
+  tools: ToolIndexEntry[],
+  preloadedSet: Set<string>,
+  categoryLabel: string,
+): string => {
+  const operationOrder: string[] = [];
+  const seenOps = new Set<string>();
+
+  const objectToolsMap = new Map<string, string[]>();
+  const standaloneTools: ToolIndexEntry[] = [];
+
+  for (const tool of tools) {
+    if (tool.objectName && tool.operation) {
+      const ops = objectToolsMap.get(tool.objectName) ?? [];
+
+      ops.push(tool.operation);
+      objectToolsMap.set(tool.objectName, ops);
+
+      if (!seenOps.has(tool.operation)) {
+        seenOps.add(tool.operation);
+        operationOrder.push(tool.operation);
+      }
+    } else {
+      standaloneTools.push(tool);
+    }
+  }
+
+  const lines: string[] = [`\n#### ${categoryLabel} (${tools.length} tools)`];
+
+  if (objectToolsMap.size > 0) {
+    const objectNames = [...objectToolsMap.keys()].sort();
+
+    lines.push(`Operations per object:`);
+    lines.push(...operationOrder.map((op) => `- \`${op}_{object}\``));
+
+    lines.push(`\nObjects (${objectNames.length}):`);
+    lines.push(...objectNames.map((name) => `- \`${name}\``));
+
+    const findManyExample = tools.find((t) => t.operation === 'find_many');
+    const findOneExample = tools.find(
+      (t) =>
+        t.operation === 'find_one' &&
+        t.objectName === findManyExample?.objectName,
+    );
+    const examplePart =
+      findManyExample && findOneExample
+        ? ` e.g. \`${findManyExample.name}\` / \`${findOneExample.name}\``
+        : '';
+
+    lines.push(
+      `\nTool name = operation + object name. *_many_* operations use the plural form, *_one_* use the singular form.${examplePart}`,
+    );
+  }
+
+  for (const tool of standaloneTools) {
+    const status = preloadedSet.has(tool.name) ? ' ✓' : '';
+
+    lines.push(`- \`${tool.name}\`${status}`);
+  }
+
+  return lines.join('\n');
+};
+
+export const buildToolCatalogSection = (
+  toolCatalog: ToolIndexEntry[],
+  preloadedTools: string[],
+): string => {
+  const preloadedSet = new Set(preloadedTools);
+
+  const toolsByCategory = new Map<string, ToolIndexEntry[]>();
+
+  for (const tool of toolCatalog) {
+    const category = tool.category;
+    const existing = toolsByCategory.get(category) ?? [];
+
+    existing.push(tool);
+    toolsByCategory.set(category, existing);
+  }
+
+  const sections: string[] = [];
+
+  const preloadedList =
+    preloadedTools.length > 0
+      ? preloadedTools.map((toolName) => `- \`${toolName}\` ✓`).join('\n')
+      : '(none)';
+
+  sections.push(`
+## Available Tools
+
+You have access to ${toolCatalog.length} tools. Some are pre-loaded and ready to use immediately.
+To use any other tool, first call \`${LEARN_TOOLS_TOOL_NAME}\` to learn its schema, then call \`${EXECUTE_TOOL_TOOL_NAME}\` to run it.
+
+### Pre-loaded Tools (ready to use now)
+${preloadedList}
+
+### Tool Catalog by Category`);
+
+  const categoryOrder = Object.values(ToolCategory);
+
+  for (const category of categoryOrder) {
+    const tools = toolsByCategory.get(category);
+
+    if (!tools || tools.length === 0) {
+      continue;
+    }
+
+    const categoryLabel = getCategoryLabel(category);
+
+    if (category === ToolCategory.DATABASE_CRUD) {
+      sections.push(
+        buildDatabaseCrudCatalogSection(tools, preloadedSet, categoryLabel),
+      );
+    } else {
+      sections.push(`
+#### ${categoryLabel} (${tools.length} tools)
+${tools
+  .map((tool) => {
+    const status = preloadedSet.has(tool.name) ? ' ✓' : '';
+
+    return `- \`${tool.name}\`${status}`;
+  })
+  .join('\n')}`);
+    }
+  }
+
+  sections.push(`
+### How to Use Tools
+1. **Pre-loaded tools** (marked with ✓): Use directly
+2. **Other tools**: First call \`${LEARN_TOOLS_TOOL_NAME}({toolNames: ["tool_name"]})\` to learn the schema, then call \`${EXECUTE_TOOL_TOOL_NAME}({toolName: "tool_name", arguments: {...}})\` to run it`);
+
+  return sections.join('\n');
+};

--- a/packages/twenty-server/src/engine/metadata-modules/ai/ai-agent-execution/services/__tests__/agent-async-executor.service.spec.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/ai/ai-agent-execution/services/__tests__/agent-async-executor.service.spec.ts
@@ -42,7 +42,7 @@ const generateTextMock = generateText as jest.MockedFunction<
 
 describe('AgentAsyncExecutorService — workflow agent role-scoped tool resolution', () => {
   let service: AgentAsyncExecutorService;
-  let toolRegistry: { getToolsByCategories: jest.Mock };
+  let toolRegistry: { buildToolIndex: jest.Mock };
   let roleTargetRepository: { findOne: jest.Mock };
   let aiBillingService: {
     decrementAndCheckAvailableCredits: jest.Mock;
@@ -65,7 +65,7 @@ describe('AgentAsyncExecutorService — workflow agent role-scoped tool resoluti
     }) as AgentEntity;
 
   beforeEach(async () => {
-    toolRegistry = { getToolsByCategories: jest.fn().mockResolvedValue({}) };
+    toolRegistry = { buildToolIndex: jest.fn().mockResolvedValue([]) };
     roleTargetRepository = { findOne: jest.fn() };
     aiBillingService = {
       decrementAndCheckAvailableCredits: jest
@@ -132,7 +132,7 @@ describe('AgentAsyncExecutorService — workflow agent role-scoped tool resoluti
     service = module.get<AgentAsyncExecutorService>(AgentAsyncExecutorService);
   });
 
-  it('passes intersectionOf: [agentRoleId] when the agent has a role assigned', async () => {
+  it('builds the lazy tool catalog scoped to the agent role when one is assigned', async () => {
     roleTargetRepository.findOne.mockResolvedValueOnce({ roleId: agentRoleId });
 
     await service.executeAgent({
@@ -141,14 +141,11 @@ describe('AgentAsyncExecutorService — workflow agent role-scoped tool resoluti
       workspaceId,
     });
 
-    expect(toolRegistry.getToolsByCategories).toHaveBeenCalledTimes(1);
-    expect(toolRegistry.getToolsByCategories).toHaveBeenCalledWith(
-      expect.objectContaining({
-        roleId: agentRoleId,
-        rolePermissionConfig: { intersectionOf: [agentRoleId] },
-        workspaceId,
-      }),
-      expect.objectContaining({ wrapWithErrorContext: false }),
+    expect(toolRegistry.buildToolIndex).toHaveBeenCalledTimes(1);
+    expect(toolRegistry.buildToolIndex).toHaveBeenCalledWith(
+      workspaceId,
+      agentRoleId,
+      expect.any(Object),
     );
   });
 
@@ -161,7 +158,7 @@ describe('AgentAsyncExecutorService — workflow agent role-scoped tool resoluti
       workspaceId,
     });
 
-    expect(toolRegistry.getToolsByCategories).not.toHaveBeenCalled();
+    expect(toolRegistry.buildToolIndex).not.toHaveBeenCalled();
   });
 
   describe('cost folding', () => {

--- a/packages/twenty-server/src/engine/metadata-modules/ai/ai-agent-execution/services/agent-async-executor.service.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/ai/ai-agent-execution/services/agent-async-executor.service.ts
@@ -22,8 +22,15 @@ import { TOOL_EXECUTION_DURATION_MS_BUCKET_BOUNDARIES } from 'src/engine/core-mo
 import { TOOL_OUTPUT_TOKENS_BUCKET_BOUNDARIES } from 'src/engine/core-modules/metrics/constants/tool-output-tokens-bucket-boundaries.constant';
 import { MetricsService } from 'src/engine/core-modules/metrics/metrics.service';
 import { MetricsKeys } from 'src/engine/core-modules/metrics/types/metrics-keys.type';
-import { type ToolProviderContext } from 'src/engine/core-modules/tool-provider/interfaces/tool-provider-context.type';
 import { ToolRegistryService } from 'src/engine/core-modules/tool-provider/services/tool-registry.service';
+import {
+  createExecuteToolTool,
+  createLearnToolsTool,
+  EXECUTE_TOOL_TOOL_NAME,
+  LEARN_TOOLS_TOOL_NAME,
+} from 'src/engine/core-modules/tool-provider/tools';
+import { type ToolContext } from 'src/engine/core-modules/tool-provider/types/tool-context.type';
+import { buildToolCatalogSection } from 'src/engine/core-modules/tool-provider/utils/build-tool-catalog-section.util';
 import { estimateToolOutputTokens } from 'src/engine/core-modules/tool-provider/utils/estimate-tool-output-tokens.util';
 import { getToolMetricName } from 'src/engine/core-modules/tool-provider/utils/get-tool-metric-name.util';
 import { isToolOutputSuccessful } from 'src/engine/core-modules/tool-provider/utils/is-tool-output-successful.util';
@@ -56,7 +63,6 @@ import {
   AiExceptionCode,
 } from 'src/engine/metadata-modules/ai/ai.exception';
 import { RoleTargetEntity } from 'src/engine/metadata-modules/role-target/role-target.entity';
-import { type RolePermissionConfig } from 'src/engine/twenty-orm/types/role-permission-config';
 import { InjectWorkspaceScopedRepository } from 'src/engine/twenty-orm/workspace-scoped-repository/inject-workspace-scoped-repository.decorator';
 import { WorkspaceScopedRepository } from 'src/engine/twenty-orm/workspace-scoped-repository/workspace-scoped-repository';
 
@@ -152,6 +158,7 @@ export class AgentAsyncExecutorService {
         await this.aiModelRegistryService.resolveModelForAgent(agent);
 
       let tools: ToolSet = {};
+      let toolCatalogSection = '';
       let providerOptions = getCallLevelProviderOptions({
         sdkPackage: registeredModel.sdkPackage,
         providerOptions: undefined,
@@ -172,37 +179,65 @@ export class AgentAsyncExecutorService {
 
         let registryTools: ToolSet = {};
 
-        // Workflow agent registry tools are scoped exclusively by the agent
-        // permission-tab role. No role means no registry tools.
         if (isDefined(agentRoleId)) {
-          const agentRolePermissionConfig: RolePermissionConfig = {
-            intersectionOf: [agentRoleId],
-          };
+          const userId =
+            isDefined(authContext) && isUserAuthContext(authContext)
+              ? authContext.user.id
+              : undefined;
+          const userWorkspaceId =
+            isDefined(authContext) && isUserAuthContext(authContext)
+              ? authContext.userWorkspaceId
+              : undefined;
 
-          const toolProviderContext: ToolProviderContext = {
+          const toolContext: ToolContext = {
             workspaceId: agent.workspaceId,
             roleId: agentRoleId,
-            rolePermissionConfig: agentRolePermissionConfig,
             authContext,
             actorContext,
-            userId:
-              isDefined(authContext) && isUserAuthContext(authContext)
-                ? authContext.user.id
-                : undefined,
-            userWorkspaceId:
-              isDefined(authContext) && isUserAuthContext(authContext)
-                ? authContext.userWorkspaceId
-                : undefined,
+            userId,
+            userWorkspaceId,
           };
 
-          registryTools = await this.toolRegistry.getToolsByCategories(
-            toolProviderContext,
-            {
-              categories: WORKFLOW_AGENT_REGISTRY_TOOL_CATEGORIES,
-              excludeTools: [...OUTPUT_NAVIGATION_TOOL_NAMES],
-              wrapWithErrorContext: false,
-            },
+          const fullCatalog = await this.toolRegistry.buildToolIndex(
+            agent.workspaceId,
+            agentRoleId,
+            { userId, userWorkspaceId },
           );
+
+          const allowedCategories = new Set(
+            WORKFLOW_AGENT_REGISTRY_TOOL_CATEGORIES,
+          );
+          const outputNavigationTools = new Set<string>(
+            OUTPUT_NAVIGATION_TOOL_NAMES,
+          );
+
+          const catalog = fullCatalog.filter(
+            (entry) =>
+              allowedCategories.has(entry.category) &&
+              !outputNavigationTools.has(entry.name),
+          );
+
+          const allowedNames = new Set(catalog.map((entry) => entry.name));
+          const excludeTools = new Set(
+            fullCatalog
+              .map((entry) => entry.name)
+              .filter((name) => !allowedNames.has(name)),
+          );
+
+          toolCatalogSection = buildToolCatalogSection(catalog, []);
+
+          registryTools = {
+            [LEARN_TOOLS_TOOL_NAME]: createLearnToolsTool(
+              this.toolRegistry,
+              toolContext,
+              { excludeTools, spillLargeOutput: true },
+            ),
+            [EXECUTE_TOOL_TOOL_NAME]: createExecuteToolTool(
+              this.toolRegistry,
+              toolContext,
+              { excludeTools, compactOutput: true, spillLargeOutput: true },
+            ),
+          };
         }
 
         const nativeTools = this.nativeToolBinder.bind(
@@ -230,7 +265,7 @@ export class AgentAsyncExecutorService {
       let hasNoMoreAvailableCredits = false;
 
       const textResponse = await generateText({
-        system: `${WORKFLOW_SYSTEM_PROMPTS.BASE}\n\n${agent ? agent.prompt : ''}`,
+        system: `${WORKFLOW_SYSTEM_PROMPTS.BASE}\n\n${agent ? agent.prompt : ''}${toolCatalogSection}`,
         tools,
         model: registeredModel.model,
         prompt: userPrompt,

--- a/packages/twenty-server/src/engine/metadata-modules/ai/ai-chat/services/system-prompt-builder.service.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/ai/ai-chat/services/system-prompt-builder.service.ts
@@ -1,19 +1,12 @@
 import { Injectable } from '@nestjs/common';
 
-import {
-  assertUnreachable,
-  getValidTimeZoneOrUndefined,
-} from 'twenty-shared/utils';
+import { getValidTimeZoneOrUndefined } from 'twenty-shared/utils';
 
 import { COMMON_PRELOAD_TOOLS } from 'src/engine/core-modules/tool-provider/constants/common-preload-tools.const';
-import { ToolCategory } from 'twenty-shared/ai';
 import { ToolRegistryService } from 'src/engine/core-modules/tool-provider/services/tool-registry.service';
-import {
-  EXECUTE_TOOL_TOOL_NAME,
-  LEARN_TOOLS_TOOL_NAME,
-  LOAD_SKILL_TOOL_NAME,
-} from 'src/engine/core-modules/tool-provider/tools';
+import { LOAD_SKILL_TOOL_NAME } from 'src/engine/core-modules/tool-provider/tools';
 import { type ToolIndexEntry } from 'src/engine/core-modules/tool-provider/types/tool-index-entry.type';
+import { buildToolCatalogSection } from 'src/engine/core-modules/tool-provider/utils/build-tool-catalog-section.util';
 import {
   AgentActorContextService,
   type UserContext,
@@ -103,7 +96,7 @@ export class SystemPromptBuilderService {
       });
     }
 
-    const toolSection = this.buildToolCatalogSection(
+    const toolSection = buildToolCatalogSection(
       toolCatalog,
       COMMON_PRELOAD_TOOLS,
     );
@@ -160,7 +153,7 @@ export class SystemPromptBuilderService {
       parts.push(this.buildUserContextSection(userContext));
     }
 
-    parts.push(this.buildToolCatalogSection(toolCatalog, preloadedTools));
+    parts.push(buildToolCatalogSection(toolCatalog, preloadedTools));
     parts.push(this.buildSkillCatalogSection(skillCatalog));
 
     if (storedFiles && storedFiles.length > 0) {
@@ -251,167 +244,5 @@ Skills provide detailed expertise for specialized tasks. Load a skill before att
 To load a skill, call \`${LOAD_SKILL_TOOL_NAME}\` with the skill name(s).
 
 ${skillsList}`;
-  }
-
-  buildToolCatalogSection(
-    toolCatalog: ToolIndexEntry[],
-    preloadedTools: string[],
-  ): string {
-    const preloadedSet = new Set(preloadedTools);
-
-    const toolsByCategory = new Map<string, ToolIndexEntry[]>();
-
-    for (const tool of toolCatalog) {
-      const category = tool.category;
-      const existing = toolsByCategory.get(category) ?? [];
-
-      existing.push(tool);
-      toolsByCategory.set(category, existing);
-    }
-
-    const sections: string[] = [];
-
-    const preloadedList =
-      preloadedTools.length > 0
-        ? preloadedTools.map((toolName) => `- \`${toolName}\` ✓`).join('\n')
-        : '(none)';
-
-    sections.push(`
-## Available Tools
-
-You have access to ${toolCatalog.length} tools. Some are pre-loaded and ready to use immediately.
-To use any other tool, first call \`${LEARN_TOOLS_TOOL_NAME}\` to learn its schema, then call \`${EXECUTE_TOOL_TOOL_NAME}\` to run it.
-
-### Pre-loaded Tools (ready to use now)
-${preloadedList}
-
-### Tool Catalog by Category`);
-
-    const categoryOrder = Object.values(ToolCategory);
-
-    for (const category of categoryOrder) {
-      const tools = toolsByCategory.get(category);
-
-      if (!tools || tools.length === 0) {
-        continue;
-      }
-
-      const categoryLabel = this.getCategoryLabel(category);
-
-      if (category === ToolCategory.DATABASE_CRUD) {
-        sections.push(
-          this.buildDatabaseCrudCatalogSection(
-            tools,
-            preloadedSet,
-            categoryLabel,
-          ),
-        );
-      } else {
-        sections.push(`
-#### ${categoryLabel} (${tools.length} tools)
-${tools
-  .map((tool) => {
-    const status = preloadedSet.has(tool.name) ? ' ✓' : '';
-
-    return `- \`${tool.name}\`${status}`;
-  })
-  .join('\n')}`);
-      }
-    }
-
-    sections.push(`
-### How to Use Tools
-1. **Pre-loaded tools** (marked with ✓): Use directly
-2. **Other tools**: First call \`${LEARN_TOOLS_TOOL_NAME}({toolNames: ["tool_name"]})\` to learn the schema, then call \`${EXECUTE_TOOL_TOOL_NAME}({toolName: "tool_name", arguments: {...}})\` to run it`);
-
-    return sections.join('\n');
-  }
-
-  private buildDatabaseCrudCatalogSection(
-    tools: ToolIndexEntry[],
-    preloadedSet: Set<string>,
-    categoryLabel: string,
-  ): string {
-    const operationOrder: string[] = [];
-    const seenOps = new Set<string>();
-
-    const objectToolsMap = new Map<string, string[]>();
-    const standaloneTools: ToolIndexEntry[] = [];
-
-    for (const tool of tools) {
-      if (tool.objectName && tool.operation) {
-        const ops = objectToolsMap.get(tool.objectName) ?? [];
-
-        ops.push(tool.operation);
-        objectToolsMap.set(tool.objectName, ops);
-
-        if (!seenOps.has(tool.operation)) {
-          seenOps.add(tool.operation);
-          operationOrder.push(tool.operation);
-        }
-      } else {
-        standaloneTools.push(tool);
-      }
-    }
-
-    const lines: string[] = [`\n#### ${categoryLabel} (${tools.length} tools)`];
-
-    if (objectToolsMap.size > 0) {
-      const objectNames = [...objectToolsMap.keys()].sort();
-
-      lines.push(`Operations per object:`);
-      lines.push(...operationOrder.map((op) => `- \`${op}_{object}\``));
-
-      lines.push(`\nObjects (${objectNames.length}):`);
-      lines.push(...objectNames.map((name) => `- \`${name}\``));
-
-      const findManyExample = tools.find((t) => t.operation === 'find_many');
-      const findOneExample = tools.find(
-        (t) =>
-          t.operation === 'find_one' &&
-          t.objectName === findManyExample?.objectName,
-      );
-      const examplePart =
-        findManyExample && findOneExample
-          ? ` e.g. \`${findManyExample.name}\` / \`${findOneExample.name}\``
-          : '';
-
-      lines.push(
-        `\nTool name = operation + object name. *_many_* operations use the plural form, *_one_* use the singular form.${examplePart}`,
-      );
-    }
-
-    for (const tool of standaloneTools) {
-      const status = preloadedSet.has(tool.name) ? ' ✓' : '';
-
-      lines.push(`- \`${tool.name}\`${status}`);
-    }
-
-    return lines.join('\n');
-  }
-
-  private getCategoryLabel(category: ToolCategory): string {
-    switch (category) {
-      case ToolCategory.DATABASE_CRUD:
-        return 'Database Tools (CRUD operations)';
-      case ToolCategory.ACTION:
-        return 'Action Tools (HTTP, Email, etc.)';
-      case ToolCategory.WORKFLOW:
-        return 'Workflow Tools (create/manage workflows)';
-      case ToolCategory.METADATA:
-        return 'Metadata Tools (schema management)';
-      case ToolCategory.VIEW:
-        return 'View Tools (manage views, fields, filters, and sorts)';
-      case ToolCategory.DASHBOARD:
-        return 'Dashboard Tools (create/manage dashboards)';
-      case ToolCategory.LOGIC_FUNCTION:
-        return 'Logic Functions (custom tools)';
-      case ToolCategory.NAVIGATION_MENU_ITEM:
-        return 'Navigation Menu Item Tools (sidebar entries, folders, and user favorites)';
-      case ToolCategory.WEBHOOK:
-        return 'Webhook Tools (outgoing webhooks)';
-      default:
-        return assertUnreachable(category);
-    }
   }
 }


### PR DESCRIPTION
## Context

The codebase has two agent execution paths that diverged over time: `ChatExecutionService` ("Ask AI") and `AgentAsyncExecutorService` (`runAgent`, workflow AI-agent actions, evals). For the same prompt, Ask AI answers in seconds while the Slack assistant took 3-4 minutes.

The difference was tool loading, not the model. Ask AI already uses lazy tool discovery (a compact catalog + `learn_tools` / `execute_tool`), so it ships a few tools' worth of schema per step. The agent executor eagerly loaded every `DATABASE_CRUD` and `ACTION` tool with full JSON schemas and re-sent that whole payload on every step. In a real workspace that is hundreds of fully-schema'd tools, which dominated per-step latency. The lazy layer was built on the chat path and never backported; this PR closes that gap.

## What

Switch `AgentAsyncExecutorService` to the same lazy model the chat path uses: a compact tool catalog (names + descriptions, no schemas) goes into the system prompt, and the model resolves the one schema it needs on demand via
`learn_tools` / `execute_tool`.

## How

- Replace the eager `getToolsByCategories(..., includeSchemas: true)` call with `buildToolIndex` + the `learn_tools` / `execute_tool` meta-tools.
- Deny the meta-tools any tool outside the shown catalog, preserving the guard that keeps workflow tools out of agent execution (recursion safety).
- Extract the catalog formatter out of `SystemPromptBuilderService` into a shared `tool-provider` util so both executors format the catalog identically.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/23393?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

