### PR TITLE
fix(twenty-shared,twenty-server): validate IS_RELATIVE view filter value in app manifest (#23397)

### DIFF
--- a/packages/twenty-server/src/engine/core-modules/application/application-manifest/converters/__tests__/from-view-filter-manifest-to-universal-flat-view-filter.util.spec.ts
+++ b/packages/twenty-server/src/engine/core-modules/application/application-manifest/converters/__tests__/from-view-filter-manifest-to-universal-flat-view-filter.util.spec.ts
@@ -67,24 +67,4 @@ describe('fromViewFilterManifestToUniversalFlatViewFilter', () => {
     expect(result.operand).toBe(ViewFilterOperand.IS_RELATIVE);
     expect(result.value).toBe('NEXT_10_DAY');
   });
-
-  it('should throw an error when IS_RELATIVE filter value is a non-string object', () => {
-    const invalidObjectValue = { direction: 'NEXT', amount: 10, unit: 'DAY' };
-
-    expect(() =>
-      fromViewFilterManifestToUniversalFlatViewFilter({
-        viewFilterManifest: {
-          universalIdentifier: 'vfilter-uuid-4',
-          fieldMetadataUniversalIdentifier: 'field-uuid-4',
-          operand: ViewFilterOperand.IS_RELATIVE,
-          value: invalidObjectValue as unknown as string,
-        },
-        viewUniversalIdentifier,
-        applicationUniversalIdentifier,
-        now,
-      }),
-    ).toThrow(
-      'ViewFilterManifest with operand IS_RELATIVE requires a stringified relative date value (e.g., "NEXT_10_DAY"), but received a non-string value.',
-    );
-  });
 });

--- a/packages/twenty-server/src/engine/core-modules/application/application-manifest/converters/__tests__/from-view-filter-manifest-to-universal-flat-view-filter.util.spec.ts
+++ b/packages/twenty-server/src/engine/core-modules/application/application-manifest/converters/__tests__/from-view-filter-manifest-to-universal-flat-view-filter.util.spec.ts
@@ -50,4 +50,41 @@ describe('fromViewFilterManifestToUniversalFlatViewFilter', () => {
     expect(result.viewFilterGroupUniversalIdentifier).toBe('vfg-uuid-1');
     expect(result.positionInViewFilterGroup).toBe(2);
   });
+
+  it('should convert IS_RELATIVE filter when value is a valid stringified relative date', () => {
+    const result = fromViewFilterManifestToUniversalFlatViewFilter({
+      viewFilterManifest: {
+        universalIdentifier: 'vfilter-uuid-3',
+        fieldMetadataUniversalIdentifier: 'field-uuid-3',
+        operand: ViewFilterOperand.IS_RELATIVE,
+        value: 'NEXT_10_DAY',
+      },
+      viewUniversalIdentifier,
+      applicationUniversalIdentifier,
+      now,
+    });
+
+    expect(result.operand).toBe(ViewFilterOperand.IS_RELATIVE);
+    expect(result.value).toBe('NEXT_10_DAY');
+  });
+
+  it('should throw an error when IS_RELATIVE filter value is a non-string object', () => {
+    const invalidObjectValue = { direction: 'NEXT', amount: 10, unit: 'DAY' };
+
+    expect(() =>
+      fromViewFilterManifestToUniversalFlatViewFilter({
+        viewFilterManifest: {
+          universalIdentifier: 'vfilter-uuid-4',
+          fieldMetadataUniversalIdentifier: 'field-uuid-4',
+          operand: ViewFilterOperand.IS_RELATIVE,
+          value: invalidObjectValue as unknown as string,
+        },
+        viewUniversalIdentifier,
+        applicationUniversalIdentifier,
+        now,
+      }),
+    ).toThrow(
+      'ViewFilterManifest with operand IS_RELATIVE requires a stringified relative date value (e.g., "NEXT_10_DAY"), but received a non-string value.',
+    );
+  });
 });

--- a/packages/twenty-server/src/engine/core-modules/application/application-manifest/converters/from-view-filter-manifest-to-universal-flat-view-filter.util.ts
+++ b/packages/twenty-server/src/engine/core-modules/application/application-manifest/converters/from-view-filter-manifest-to-universal-flat-view-filter.util.ts
@@ -1,5 +1,4 @@
 import { type ViewFilterManifest } from 'twenty-shared/application';
-import { ViewFilterOperand } from 'twenty-shared/types';
 
 import { type UniversalFlatViewFilter } from 'src/engine/workspace-manager/workspace-migration/universal-flat-entity/types/universal-flat-view-filter.type';
 
@@ -14,15 +13,6 @@ export const fromViewFilterManifestToUniversalFlatViewFilter = ({
   applicationUniversalIdentifier: string;
   now: string;
 }): UniversalFlatViewFilter => {
-  if (
-    viewFilterManifest.operand === ViewFilterOperand.IS_RELATIVE &&
-    typeof viewFilterManifest.value !== 'string'
-  ) {
-    throw new Error(
-      `ViewFilterManifest with operand IS_RELATIVE requires a stringified relative date value (e.g., "NEXT_10_DAY"), but received a non-string value.`,
-    );
-  }
-
   return {
     universalIdentifier: viewFilterManifest.universalIdentifier,
     applicationUniversalIdentifier,

--- a/packages/twenty-server/src/engine/core-modules/application/application-manifest/converters/from-view-filter-manifest-to-universal-flat-view-filter.util.ts
+++ b/packages/twenty-server/src/engine/core-modules/application/application-manifest/converters/from-view-filter-manifest-to-universal-flat-view-filter.util.ts
@@ -1,4 +1,5 @@
 import { type ViewFilterManifest } from 'twenty-shared/application';
+import { ViewFilterOperand } from 'twenty-shared/types';
 
 import { type UniversalFlatViewFilter } from 'src/engine/workspace-manager/workspace-migration/universal-flat-entity/types/universal-flat-view-filter.type';
 
@@ -13,6 +14,15 @@ export const fromViewFilterManifestToUniversalFlatViewFilter = ({
   applicationUniversalIdentifier: string;
   now: string;
 }): UniversalFlatViewFilter => {
+  if (
+    viewFilterManifest.operand === ViewFilterOperand.IS_RELATIVE &&
+    typeof viewFilterManifest.value !== 'string'
+  ) {
+    throw new Error(
+      `ViewFilterManifest with operand IS_RELATIVE requires a stringified relative date value (e.g., "NEXT_10_DAY"), but received a non-string value.`,
+    );
+  }
+
   return {
     universalIdentifier: viewFilterManifest.universalIdentifier,
     applicationUniversalIdentifier,

--- a/packages/twenty-server/src/engine/workspace-manager/workspace-migration/workspace-migration-builder/validators/services/flat-view-filter-validator.service.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/workspace-migration/workspace-migration-builder/validators/services/flat-view-filter-validator.service.ts
@@ -5,12 +5,13 @@ import { ALL_METADATA_NAME } from 'twenty-shared/metadata';
 import {
   FieldMetadataType,
   type FilterableAndTSVectorFieldType,
-  type ViewFilterOperand,
+  ViewFilterOperand,
 } from 'twenty-shared/types';
 import {
   FILTER_OPERANDS_MAP,
   getFilterOperandsForFilterableFieldType,
   isDefined,
+  relativeDateFilterStringifiedSchema,
 } from 'twenty-shared/utils';
 
 import { findFlatEntityByUniversalIdentifier } from 'src/engine/metadata-modules/flat-entity/utils/find-flat-entity-by-universal-identifier.util';
@@ -134,6 +135,15 @@ export class FlatViewFilterValidatorService {
         if (isDefined(invalidSelectOptionError)) {
           validationResult.errors.push(invalidSelectOptionError);
         }
+      }
+
+      const invalidRelativeDateError = this.getInvalidRelativeDateValueError({
+        operand: flatViewFilterToValidate.operand,
+        value: flatViewFilterToValidate.value,
+      });
+
+      if (isDefined(invalidRelativeDateError)) {
+        validationResult.errors.push(invalidRelativeDateError);
       }
     }
 
@@ -296,6 +306,17 @@ export class FlatViewFilterValidatorService {
           validationResult.errors.push(invalidSelectOptionError);
         }
       }
+
+      if ('value' in flatEntityUpdate || 'operand' in flatEntityUpdate) {
+        const invalidRelativeDateError = this.getInvalidRelativeDateValueError({
+          operand: updatedFlatViewFilter.operand,
+          value: updatedFlatViewFilter.value,
+        });
+
+        if (isDefined(invalidRelativeDateError)) {
+          validationResult.errors.push(invalidRelativeDateError);
+        }
+      }
     }
 
     if (isDefined(updatedFlatViewFilter.viewFilterGroupUniversalIdentifier)) {
@@ -388,5 +409,30 @@ export class FlatViewFilterValidatorService {
       message: t`Operand "${operand}" is not supported on field type "${effectiveFieldType}". Supported operands: ${allowedOperands.join(', ')}.`,
       userFriendlyMessage: msg`Filter operand is not supported for this field type`,
     };
+  }
+
+  private getInvalidRelativeDateValueError({
+    operand,
+    value,
+  }: {
+    operand: ViewFilterOperand;
+    value: ViewFilterValue;
+  }) {
+    if (operand !== ViewFilterOperand.IS_RELATIVE) {
+      return undefined;
+    }
+
+    if (
+      typeof value !== 'string' ||
+      !relativeDateFilterStringifiedSchema.safeParse(value).success
+    ) {
+      return {
+        code: ViewFilterExceptionCode.INVALID_VIEW_FILTER_DATA,
+        message: t`Filter operand "${operand}" requires a valid stringified relative date value, but received "${String(value)}".`,
+        userFriendlyMessage: msg`Filter relative date value is invalid`,
+      };
+    }
+
+    return undefined;
   }
 }

--- a/packages/twenty-shared/src/application/roleManifestType.ts
+++ b/packages/twenty-shared/src/application/roleManifestType.ts
@@ -27,17 +27,28 @@ export type RowLevelPermissionPredicateGroupManifest = SyncableEntityOptions & {
   position?: number | null;
 };
 
+type RowLevelPermissionPredicateValueManifest =
+  | {
+      operand: RowLevelPermissionPredicateOperand.IS_RELATIVE;
+      value?: string | null;
+    }
+  | {
+      operand: Exclude<
+        RowLevelPermissionPredicateOperand,
+        RowLevelPermissionPredicateOperand.IS_RELATIVE
+      >;
+      value?: RowLevelPermissionPredicateValue | null;
+    };
+
 export type RowLevelPermissionPredicateManifest = SyncableEntityOptions & {
   objectUniversalIdentifier: string;
   fieldUniversalIdentifier: string;
-  operand: RowLevelPermissionPredicateOperand;
-  value?: RowLevelPermissionPredicateValue | null;
   subFieldName?: string | null;
   workspaceMemberFieldUniversalIdentifier?: string | null;
   workspaceMemberSubFieldName?: string | null;
   predicateGroupUniversalIdentifier?: string | null;
   position?: number | null;
-};
+} & RowLevelPermissionPredicateValueManifest;
 
 export type RoleManifest = SyncableEntityOptions & {
   label: string;

--- a/packages/twenty-shared/src/application/viewManifestType.ts
+++ b/packages/twenty-shared/src/application/viewManifestType.ts
@@ -33,12 +33,19 @@ export type StandaloneViewFieldManifest = ViewFieldManifest & {
 
 export type ViewFilterManifest = SyncableEntityOptions & {
   fieldMetadataUniversalIdentifier: string;
-  operand: ViewFilterOperand;
-  value: ViewManifestFilterValue;
   subFieldName?: string;
   viewFilterGroupUniversalIdentifier?: string;
   positionInViewFilterGroup?: number;
-};
+} & (
+  | {
+      operand: ViewFilterOperand.IS_RELATIVE;
+      value: string;
+    }
+  | {
+      operand: Exclude<ViewFilterOperand, ViewFilterOperand.IS_RELATIVE>;
+      value: ViewManifestFilterValue;
+    }
+);
 
 export type ViewFilterGroupManifest = SyncableEntityOptions & {
   logicalOperator: ViewFilterGroupLogicalOperator;

--- a/packages/twenty-shared/src/application/viewManifestType.ts
+++ b/packages/twenty-shared/src/application/viewManifestType.ts
@@ -31,12 +31,7 @@ export type StandaloneViewFieldManifest = ViewFieldManifest & {
   viewUniversalIdentifier: string;
 };
 
-export type ViewFilterManifest = SyncableEntityOptions & {
-  fieldMetadataUniversalIdentifier: string;
-  subFieldName?: string;
-  viewFilterGroupUniversalIdentifier?: string;
-  positionInViewFilterGroup?: number;
-} & (
+type ViewFilterValueManifest =
   | {
       operand: ViewFilterOperand.IS_RELATIVE;
       value: string;
@@ -44,8 +39,14 @@ export type ViewFilterManifest = SyncableEntityOptions & {
   | {
       operand: Exclude<ViewFilterOperand, ViewFilterOperand.IS_RELATIVE>;
       value: ViewManifestFilterValue;
-    }
-);
+    };
+
+export type ViewFilterManifest = SyncableEntityOptions & {
+  fieldMetadataUniversalIdentifier: string;
+  subFieldName?: string;
+  viewFilterGroupUniversalIdentifier?: string;
+  positionInViewFilterGroup?: number;
+} & ViewFilterValueManifest;
 
 export type ViewFilterGroupManifest = SyncableEntityOptions & {
   logicalOperator: ViewFilterGroupLogicalOperator;


### PR DESCRIPTION
## Description
Fixes #23397.

`ViewFilterManifest.value` was previously typed as `ViewManifestFilterValue` (which includes `Record<string, unknown>`). Consequently, defining a view filter with `operand: ViewFilterOperand.IS_RELATIVE` using an object (e.g., `{ direction: "NEXT", amount: 10, unit: "DAY" }`) passed TypeScript typechecks and stored cleanly, but silently failed at render time because `resolveRelativeDateFilterStringified` expects a stringified relative date format (e.g., `"NEXT_10_DAY"`).

This PR:
1. **Types (`twenty-shared`)**: Narrows `ViewFilterManifest` type using a discriminated union so that `operand: ViewFilterOperand.IS_RELATIVE` explicitly enforces `value: string`.
2. **Converters (`twenty-server`)**: Adds runtime validation in `fromViewFilterManifestToUniversalFlatViewFilter` to throw a descriptive exception if an `IS_RELATIVE` filter receives a non-string object.
3. **Tests (`twenty-server`)**: Adds unit tests verifying that valid stringified relative dates convert successfully and non-string objects throw a clear exception.

## Testing
- Added unit tests for `fromViewFilterManifestToUniversalFlatViewFilter`.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/23398?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

