### PR TITLE
fix(twenty-server): support app-defined indexes on standard object fields (#23391)

### DIFF
--- a/packages/twenty-server/src/engine/core-modules/application/application-manifest/application-manifest-migration.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/application/application-manifest/application-manifest-migration.service.ts
@@ -112,6 +112,7 @@ export class ApplicationManifestMigrationService {
         ownerFlatApplication,
         now,
         workspaceId,
+        existingAllFlatEntityMaps,
       });
 
     const dependencyAllFlatEntityMaps = getApplicationSubAllFlatEntityMaps({
@@ -203,6 +204,7 @@ export class ApplicationManifestMigrationService {
         ownerFlatApplication,
         now,
         workspaceId,
+        existingAllFlatEntityMaps,
       });
 
     const allFlatEntityOperationRecordByMetadataName =

--- a/packages/twenty-server/src/engine/core-modules/application/application-manifest/services/compute-application-manifest-all-universal-flat-entity-maps.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/application/application-manifest/services/compute-application-manifest-all-universal-flat-entity-maps.service.ts
@@ -169,7 +169,7 @@ export class ComputeApplicationManifestAllUniversalFlatEntityMapsService {
         allUniversalFlatEntityMaps.flatObjectMetadataMaps.byUniversalIdentifier[
           indexManifest.objectUniversalIdentifier
         ] ??
-        (existingObjectCandidate?.isStandard
+        (isDefined(existingObjectCandidate) && !existingObjectCandidate.isCustom
           ? existingObjectCandidate
           : undefined);
 
@@ -200,11 +200,15 @@ export class ComputeApplicationManifestAllUniversalFlatEntityMapsService {
           flatObjectMetadata.universalIdentifier,
         ) ?? [];
 
-      const existingFieldsForObject = Object.values(
-        existingAllFlatEntityMaps?.flatFieldMetadataMaps
-          ?.byUniversalIdentifier ?? {},
+      const existingFieldsForObject = (
+        Object.values(
+          existingAllFlatEntityMaps?.flatFieldMetadataMaps
+            ?.byUniversalIdentifier ?? {},
+        ) as (UniversalFlatFieldMetadata | undefined)[]
       ).filter(
-        (field): field is UniversalFlatFieldMetadata =>
+        (
+          field: UniversalFlatFieldMetadata | undefined,
+        ): field is UniversalFlatFieldMetadata =>
           isDefined(field) &&
           field.objectMetadataUniversalIdentifier ===
             flatObjectMetadata.universalIdentifier,

--- a/packages/twenty-server/src/engine/core-modules/application/application-manifest/services/compute-application-manifest-all-universal-flat-entity-maps.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/application/application-manifest/services/compute-application-manifest-all-universal-flat-entity-maps.service.ts
@@ -71,11 +71,13 @@ export class ComputeApplicationManifestAllUniversalFlatEntityMapsService {
     ownerFlatApplication,
     now,
     workspaceId,
+    existingAllFlatEntityMaps,
   }: {
     manifest: Manifest;
     ownerFlatApplication: FlatApplication;
     now: string;
     workspaceId: string;
+    existingAllFlatEntityMaps?: AllFlatEntityMaps;
   }): AllFlatEntityMaps {
     const allUniversalFlatEntityMaps = createEmptyAllFlatEntityMaps();
 
@@ -162,6 +164,9 @@ export class ComputeApplicationManifestAllUniversalFlatEntityMapsService {
       const flatObjectMetadata =
         allUniversalFlatEntityMaps.flatObjectMetadataMaps.byUniversalIdentifier[
           indexManifest.objectUniversalIdentifier
+        ] ??
+        existingAllFlatEntityMaps?.flatObjectMetadataMaps?.byUniversalIdentifier[
+          indexManifest.objectUniversalIdentifier
         ];
 
       if (!isDefined(flatObjectMetadata)) {
@@ -186,14 +191,31 @@ export class ComputeApplicationManifestAllUniversalFlatEntityMapsService {
         nextCount,
       );
 
+      const appDefinedFields =
+        fieldsByObjectUniversalIdentifier.get(
+          flatObjectMetadata.universalIdentifier,
+        ) ?? [];
+
+      const existingFieldsForObject = Object.values(
+        existingAllFlatEntityMaps?.flatFieldMetadataMaps
+          ?.byUniversalIdentifier ?? {},
+      ).filter(
+        (field): field is UniversalFlatFieldMetadata =>
+          isDefined(field) &&
+          field.objectMetadataUniversalIdentifier ===
+            flatObjectMetadata.universalIdentifier,
+      );
+
+      const objectFlatFieldMetadatas = [
+        ...existingFieldsForObject,
+        ...appDefinedFields,
+      ];
+
       addUniversalFlatEntityToUniversalFlatEntityMapsThroughMutationOrThrow({
         universalFlatEntity: fromIndexManifestToUniversalFlatIndex({
           indexManifest,
           flatObjectMetadata,
-          objectFlatFieldMetadatas:
-            fieldsByObjectUniversalIdentifier.get(
-              flatObjectMetadata.universalIdentifier,
-            ) ?? [],
+          objectFlatFieldMetadatas,
           applicationUniversalIdentifier,
           now,
         }),

--- a/packages/twenty-server/src/engine/core-modules/application/application-manifest/services/compute-application-manifest-all-universal-flat-entity-maps.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/application/application-manifest/services/compute-application-manifest-all-universal-flat-entity-maps.service.ts
@@ -161,13 +161,17 @@ export class ComputeApplicationManifestAllUniversalFlatEntityMapsService {
     }
 
     for (const indexManifest of manifest.indexes ?? []) {
+      const existingObjectCandidate =
+        existingAllFlatEntityMaps?.flatObjectMetadataMaps
+          ?.byUniversalIdentifier[indexManifest.objectUniversalIdentifier];
+
       const flatObjectMetadata =
         allUniversalFlatEntityMaps.flatObjectMetadataMaps.byUniversalIdentifier[
           indexManifest.objectUniversalIdentifier
         ] ??
-        existingAllFlatEntityMaps?.flatObjectMetadataMaps?.byUniversalIdentifier[
-          indexManifest.objectUniversalIdentifier
-        ];
+        (existingObjectCandidate?.isStandard
+          ? existingObjectCandidate
+          : undefined);
 
       if (!isDefined(flatObjectMetadata)) {
         throw new Error(
@@ -207,8 +211,8 @@ export class ComputeApplicationManifestAllUniversalFlatEntityMapsService {
       );
 
       const objectFlatFieldMetadatas = [
-        ...existingFieldsForObject,
         ...appDefinedFields,
+        ...existingFieldsForObject,
       ];
 
       addUniversalFlatEntityToUniversalFlatEntityMapsThroughMutationOrThrow({


### PR DESCRIPTION
## Description
Fixes #23391.

When an app defines a new field on a standard object (e.g., `Company` or `Person`) using `defineField()` and attempts to create an index for that field using `defineIndex()`, synchronization previously failed with:
`INVALID_METADATA: Index "..." references unknown object 20202020-b374-4779-a561-80086cb2e17f`

This occurred because `ComputeApplicationManifestAllUniversalFlatEntityMapsService.compute()` looked up `flatObjectMetadata` strictly inside `allUniversalFlatEntityMaps.flatObjectMetadataMaps` (which only contains custom app objects) and did not include existing standard objects from `existingAllFlatEntityMaps`. Additionally, field resolution for standard object indexes omitted existing standard object fields.

This PR:
1. **Object Lookup**: Enables `ComputeApplicationManifestAllUniversalFlatEntityMapsService` to fall back to `existingAllFlatEntityMaps.flatObjectMetadataMaps` when resolving standard object metadata for `indexManifest`.
2. **Field Resolution**: Combines existing standard object fields with app-defined fields when building `objectFlatFieldMetadatas` for `fromIndexManifestToUniversalFlatIndex`.
3. **Migration Service**: Passes `existingAllFlatEntityMaps` to `compute()` in both pre-install and main sync phases.

## Testing
- Verified manifest entity map resolution for standard object app-extended indexes.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/23399?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

