### PR TITLE
fix: persist pageLayoutTab layoutMode updates and validate enum value (#23402)

### DIFF
--- a/packages/twenty-server/src/engine/metadata-modules/flat-entity/constant/__tests__/__snapshots__/all-universal-flat-entity-properties-to-compare-and-stringify.constant.spec.ts.snap
+++ b/packages/twenty-server/src/engine/metadata-modules/flat-entity/constant/__tests__/__snapshots__/all-universal-flat-entity-properties-to-compare-and-stringify.constant.spec.ts.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`ALL_UNIVERSAL_FLAT_ENTITY_PROPERTIES_TO_COMPARE_AND_STRINGIFY should match snapshot 1`] = `
 {
@@ -213,6 +213,7 @@ exports[`ALL_UNIVERSAL_FLAT_ENTITY_PROPERTIES_TO_COMPARE_AND_STRINGIFY should ma
       "position",
       "deletedAt",
       "icon",
+      "layoutMode",
       "isActive",
       "overrides",
     ],

--- a/packages/twenty-server/src/engine/metadata-modules/flat-entity/constant/all-entity-properties-configuration-by-metadata-name.constant.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/flat-entity/constant/all-entity-properties-configuration-by-metadata-name.constant.ts
@@ -1116,7 +1116,7 @@ export const ALL_ENTITY_PROPERTIES_CONFIGURATION_BY_METADATA_NAME = {
       universalProperty: 'pageLayoutUniversalIdentifier',
     },
     layoutMode: {
-      toCompare: false,
+      toCompare: true,
       toStringify: false,
       universalProperty: undefined,
     },

--- a/packages/twenty-server/src/engine/workspace-manager/workspace-migration/workspace-migration-builder/validators/services/flat-page-layout-tab-validator.service.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/workspace-migration/workspace-migration-builder/validators/services/flat-page-layout-tab-validator.service.ts
@@ -2,10 +2,12 @@ import { Injectable } from '@nestjs/common';
 
 import { msg, t } from '@lingui/core/macro';
 import { ALL_METADATA_NAME } from 'twenty-shared/metadata';
+import { PageLayoutTabLayoutMode } from 'twenty-shared/types';
 import { isDefined } from 'twenty-shared/utils';
 
 import { findFlatEntityByUniversalIdentifier } from 'src/engine/metadata-modules/flat-entity/utils/find-flat-entity-by-universal-identifier.util';
 import { PageLayoutExceptionCode } from 'src/engine/metadata-modules/page-layout/exceptions/page-layout.exception';
+import { PageLayoutTabExceptionCode } from 'src/engine/metadata-modules/page-layout-tab/exceptions/page-layout-tab.exception';
 import { type FailedFlatEntityValidation } from 'src/engine/workspace-manager/workspace-migration/workspace-migration-builder/builders/types/failed-flat-entity-validation.type';
 import { getEmptyFlatEntityValidationError } from 'src/engine/workspace-manager/workspace-migration/workspace-migration-builder/builders/utils/get-flat-entity-validation-error.util';
 import { type FlatEntityUpdateValidationArgs } from 'src/engine/workspace-manager/workspace-migration/workspace-migration-builder/types/universal-flat-entity-update-validation-args.type';
@@ -42,6 +44,19 @@ export class FlatPageLayoutTabValidatorService {
         code: PageLayoutExceptionCode.PAGE_LAYOUT_NOT_FOUND,
         message: t`Page layout not found`,
         userFriendlyMessage: msg`Page layout not found`,
+      });
+    }
+
+    if (
+      !isDefined(flatPageLayoutTab.layoutMode) ||
+      !Object.values(PageLayoutTabLayoutMode).includes(
+        flatPageLayoutTab.layoutMode,
+      )
+    ) {
+      validationResult.errors.push({
+        code: PageLayoutTabExceptionCode.INVALID_PAGE_LAYOUT_TAB_DATA,
+        message: t`Page layout tab with invalid layout mode`,
+        userFriendlyMessage: msg`Page layout tab layout mode is invalid`,
       });
     }
 
@@ -85,6 +100,7 @@ export class FlatPageLayoutTabValidatorService {
 
   public validateFlatPageLayoutTabUpdate({
     universalIdentifier,
+    flatEntityUpdate,
     optimisticFlatEntityMapsAndRelatedFlatEntityMaps: {
       flatPageLayoutTabMaps: optimisticFlatPageLayoutTabMaps,
     },
@@ -112,6 +128,19 @@ export class FlatPageLayoutTabValidatorService {
       });
 
       return validationResult;
+    }
+
+    if (
+      isDefined(flatEntityUpdate.layoutMode) &&
+      !Object.values(PageLayoutTabLayoutMode).includes(
+        flatEntityUpdate.layoutMode,
+      )
+    ) {
+      validationResult.errors.push({
+        code: PageLayoutTabExceptionCode.INVALID_PAGE_LAYOUT_TAB_DATA,
+        message: t`Page layout tab with invalid layout mode`,
+        userFriendlyMessage: msg`Page layout tab layout mode is invalid`,
+      });
     }
 
     return validationResult;

--- a/packages/twenty-server/test/integration/metadata/suites/application/manifest-sync-page-layout-tab-layout-mode.integration-spec.ts
+++ b/packages/twenty-server/test/integration/metadata/suites/application/manifest-sync-page-layout-tab-layout-mode.integration-spec.ts
@@ -1,0 +1,199 @@
+import { buildBaseManifest } from 'test/integration/metadata/suites/application/utils/build-base-manifest.util';
+import { cleanupApplicationAndAppRegistration } from 'test/integration/metadata/suites/application/utils/cleanup-application-and-app-registration.util';
+import { setupApplicationForSync } from 'test/integration/metadata/suites/application/utils/setup-application-for-sync.util';
+import { syncApplication } from 'test/integration/metadata/suites/application/utils/sync-application.util';
+import { findPageLayoutTabs } from 'test/integration/metadata/suites/page-layout-tab/utils/find-page-layout-tabs.util';
+import { type Manifest } from 'twenty-shared/application';
+import { PageLayoutTabLayoutMode } from 'twenty-shared/types';
+import { v4 as uuidv4 } from 'uuid';
+
+const TEST_APP_ID = uuidv4();
+const TEST_ROLE_ID = uuidv4();
+const TEST_TAB_ID = uuidv4();
+
+const STANDARD_PERSON_PAGE_LAYOUT_UNIVERSAL_ID =
+  '20202020-a102-4002-8002-ae0a1ea11002';
+
+const PAGE_LAYOUT_TAB_GQL_FIELDS = `
+  id
+  title
+  position
+  layoutMode
+  pageLayoutId
+  applicationId
+`;
+
+let testApplicationId: string;
+let standardPersonPageLayoutId: string;
+
+const buildManifest = (overrides?: Partial<Pick<Manifest, 'pageLayoutTabs'>>) =>
+  buildBaseManifest({
+    appId: TEST_APP_ID,
+    roleId: TEST_ROLE_ID,
+    overrides,
+  });
+
+const buildTabManifest = ({
+  title,
+  layoutMode,
+}: {
+  title: string;
+  layoutMode: PageLayoutTabLayoutMode;
+}) => ({
+  universalIdentifier: TEST_TAB_ID,
+  pageLayoutUniversalIdentifier: STANDARD_PERSON_PAGE_LAYOUT_UNIVERSAL_ID,
+  title,
+  position: 1000,
+  layoutMode,
+});
+
+const findStandardPersonPageLayoutTabs = async () => {
+  const { data } = await findPageLayoutTabs({
+    gqlFields: PAGE_LAYOUT_TAB_GQL_FIELDS,
+    expectToFail: false,
+    input: { pageLayoutId: standardPersonPageLayoutId },
+  });
+
+  return data.getPageLayoutTabs.filter(
+    (tab) => tab.applicationId === testApplicationId,
+  );
+};
+
+describe('Manifest sync - page layout tab layoutMode', () => {
+  beforeEach(async () => {
+    await setupApplicationForSync({
+      applicationUniversalIdentifier: TEST_APP_ID,
+      name: 'Test Application',
+      description: 'App for testing page layout tab layoutMode manifest sync',
+      sourcePath: 'test-manifest-sync-page-layout-tab-layout-mode',
+    });
+
+    const applicationRow = await globalThis.testDataSource.query(
+      `SELECT id FROM core."application" WHERE "universalIdentifier" = $1`,
+      [TEST_APP_ID],
+    );
+
+    testApplicationId = applicationRow[0].id;
+
+    const pageLayoutRow = await globalThis.testDataSource.query(
+      `SELECT id FROM core."pageLayout" WHERE "universalIdentifier" = $1`,
+      [STANDARD_PERSON_PAGE_LAYOUT_UNIVERSAL_ID],
+    );
+
+    standardPersonPageLayoutId = pageLayoutRow[0].id;
+  }, 60000);
+
+  afterEach(async () => {
+    await cleanupApplicationAndAppRegistration({
+      applicationUniversalIdentifier: TEST_APP_ID,
+    });
+  });
+
+  it('should persist layoutMode on tab creation', async () => {
+    await syncApplication({
+      manifest: buildManifest({
+        pageLayoutTabs: [
+          buildTabManifest({
+            title: 'Insights',
+            layoutMode: PageLayoutTabLayoutMode.VERTICAL_LIST,
+          }),
+        ],
+      }),
+      expectToFail: false,
+    });
+
+    const tabs = await findStandardPersonPageLayoutTabs();
+
+    expect(tabs).toHaveLength(1);
+    expect(tabs[0]).toMatchObject({
+      title: 'Insights',
+      layoutMode: PageLayoutTabLayoutMode.VERTICAL_LIST,
+    });
+  }, 60000);
+
+  // Documents https://github.com/twentyhq/twenty/issues/23402: layoutMode has
+  // toCompare: false in ALL_ENTITY_PROPERTIES_CONFIGURATION_BY_METADATA_NAME,
+  // so the migration builder never emits an update for it. Marked as failing:
+  // these tests assert the desired behavior and start passing once fixed.
+  it.failing(
+    'should update layoutMode when it is the only changed property on second sync',
+    async () => {
+      await syncApplication({
+        manifest: buildManifest({
+          pageLayoutTabs: [
+            buildTabManifest({
+              title: 'Insights',
+              layoutMode: PageLayoutTabLayoutMode.GRID,
+            }),
+          ],
+        }),
+        expectToFail: false,
+      });
+
+      const tabsAfterFirstSync = await findStandardPersonPageLayoutTabs();
+
+      expect(tabsAfterFirstSync).toHaveLength(1);
+      expect(tabsAfterFirstSync[0].layoutMode).toBe(
+        PageLayoutTabLayoutMode.GRID,
+      );
+
+      await syncApplication({
+        manifest: buildManifest({
+          pageLayoutTabs: [
+            buildTabManifest({
+              title: 'Insights',
+              layoutMode: PageLayoutTabLayoutMode.VERTICAL_LIST,
+            }),
+          ],
+        }),
+        expectToFail: false,
+      });
+
+      const tabsAfterSecondSync = await findStandardPersonPageLayoutTabs();
+
+      expect(tabsAfterSecondSync).toHaveLength(1);
+      expect(tabsAfterSecondSync[0].layoutMode).toBe(
+        PageLayoutTabLayoutMode.VERTICAL_LIST,
+      );
+    },
+    60000,
+  );
+
+  it.failing(
+    'should update layoutMode alongside another changed property on second sync',
+    async () => {
+      await syncApplication({
+        manifest: buildManifest({
+          pageLayoutTabs: [
+            buildTabManifest({
+              title: 'Insights',
+              layoutMode: PageLayoutTabLayoutMode.GRID,
+            }),
+          ],
+        }),
+        expectToFail: false,
+      });
+
+      await syncApplication({
+        manifest: buildManifest({
+          pageLayoutTabs: [
+            buildTabManifest({
+              title: 'Renamed Insights',
+              layoutMode: PageLayoutTabLayoutMode.VERTICAL_LIST,
+            }),
+          ],
+        }),
+        expectToFail: false,
+      });
+
+      const tabsAfterSecondSync = await findStandardPersonPageLayoutTabs();
+
+      expect(tabsAfterSecondSync).toHaveLength(1);
+      expect(tabsAfterSecondSync[0]).toMatchObject({
+        title: 'Renamed Insights',
+        layoutMode: PageLayoutTabLayoutMode.VERTICAL_LIST,
+      });
+    },
+    60000,
+  );
+});

--- a/packages/twenty-server/test/integration/metadata/suites/application/manifest-sync-page-layout-tab-layout-mode.integration-spec.ts
+++ b/packages/twenty-server/test/integration/metadata/suites/application/manifest-sync-page-layout-tab-layout-mode.integration-spec.ts
@@ -111,89 +111,130 @@ describe('Manifest sync - page layout tab layoutMode', () => {
     });
   }, 60000);
 
-  // Documents https://github.com/twentyhq/twenty/issues/23402: layoutMode has
-  // toCompare: false in ALL_ENTITY_PROPERTIES_CONFIGURATION_BY_METADATA_NAME,
-  // so the migration builder never emits an update for it. Marked as failing:
-  // these tests assert the desired behavior and start passing once fixed.
-  it.failing(
-    'should update layoutMode when it is the only changed property on second sync',
-    async () => {
-      await syncApplication({
-        manifest: buildManifest({
-          pageLayoutTabs: [
-            buildTabManifest({
-              title: 'Insights',
-              layoutMode: PageLayoutTabLayoutMode.GRID,
-            }),
-          ],
-        }),
-        expectToFail: false,
-      });
+  // Regression tests for https://github.com/twentyhq/twenty/issues/23402:
+  // layoutMode updates were silently discarded by the migration builder
+  it('should update layoutMode when it is the only changed property on second sync', async () => {
+    await syncApplication({
+      manifest: buildManifest({
+        pageLayoutTabs: [
+          buildTabManifest({
+            title: 'Insights',
+            layoutMode: PageLayoutTabLayoutMode.GRID,
+          }),
+        ],
+      }),
+      expectToFail: false,
+    });
 
-      const tabsAfterFirstSync = await findStandardPersonPageLayoutTabs();
+    const tabsAfterFirstSync = await findStandardPersonPageLayoutTabs();
 
-      expect(tabsAfterFirstSync).toHaveLength(1);
-      expect(tabsAfterFirstSync[0].layoutMode).toBe(
-        PageLayoutTabLayoutMode.GRID,
-      );
+    expect(tabsAfterFirstSync).toHaveLength(1);
+    expect(tabsAfterFirstSync[0].layoutMode).toBe(PageLayoutTabLayoutMode.GRID);
 
-      await syncApplication({
-        manifest: buildManifest({
-          pageLayoutTabs: [
-            buildTabManifest({
-              title: 'Insights',
-              layoutMode: PageLayoutTabLayoutMode.VERTICAL_LIST,
-            }),
-          ],
-        }),
-        expectToFail: false,
-      });
+    await syncApplication({
+      manifest: buildManifest({
+        pageLayoutTabs: [
+          buildTabManifest({
+            title: 'Insights',
+            layoutMode: PageLayoutTabLayoutMode.VERTICAL_LIST,
+          }),
+        ],
+      }),
+      expectToFail: false,
+    });
 
-      const tabsAfterSecondSync = await findStandardPersonPageLayoutTabs();
+    const tabsAfterSecondSync = await findStandardPersonPageLayoutTabs();
 
-      expect(tabsAfterSecondSync).toHaveLength(1);
-      expect(tabsAfterSecondSync[0].layoutMode).toBe(
-        PageLayoutTabLayoutMode.VERTICAL_LIST,
-      );
-    },
-    60000,
-  );
+    expect(tabsAfterSecondSync).toHaveLength(1);
+    expect(tabsAfterSecondSync[0].layoutMode).toBe(
+      PageLayoutTabLayoutMode.VERTICAL_LIST,
+    );
+  }, 60000);
 
-  it.failing(
-    'should update layoutMode alongside another changed property on second sync',
-    async () => {
-      await syncApplication({
-        manifest: buildManifest({
-          pageLayoutTabs: [
-            buildTabManifest({
-              title: 'Insights',
-              layoutMode: PageLayoutTabLayoutMode.GRID,
-            }),
-          ],
-        }),
-        expectToFail: false,
-      });
+  it('should update layoutMode alongside another changed property on second sync', async () => {
+    await syncApplication({
+      manifest: buildManifest({
+        pageLayoutTabs: [
+          buildTabManifest({
+            title: 'Insights',
+            layoutMode: PageLayoutTabLayoutMode.GRID,
+          }),
+        ],
+      }),
+      expectToFail: false,
+    });
 
-      await syncApplication({
-        manifest: buildManifest({
-          pageLayoutTabs: [
-            buildTabManifest({
-              title: 'Renamed Insights',
-              layoutMode: PageLayoutTabLayoutMode.VERTICAL_LIST,
-            }),
-          ],
-        }),
-        expectToFail: false,
-      });
+    await syncApplication({
+      manifest: buildManifest({
+        pageLayoutTabs: [
+          buildTabManifest({
+            title: 'Renamed Insights',
+            layoutMode: PageLayoutTabLayoutMode.VERTICAL_LIST,
+          }),
+        ],
+      }),
+      expectToFail: false,
+    });
 
-      const tabsAfterSecondSync = await findStandardPersonPageLayoutTabs();
+    const tabsAfterSecondSync = await findStandardPersonPageLayoutTabs();
 
-      expect(tabsAfterSecondSync).toHaveLength(1);
-      expect(tabsAfterSecondSync[0]).toMatchObject({
-        title: 'Renamed Insights',
-        layoutMode: PageLayoutTabLayoutMode.VERTICAL_LIST,
-      });
-    },
-    60000,
-  );
+    expect(tabsAfterSecondSync).toHaveLength(1);
+    expect(tabsAfterSecondSync[0]).toMatchObject({
+      title: 'Renamed Insights',
+      layoutMode: PageLayoutTabLayoutMode.VERTICAL_LIST,
+    });
+  }, 60000);
+
+  it('should fail to sync when layoutMode is not a valid enum value', async () => {
+    const { errors } = await syncApplication({
+      manifest: buildManifest({
+        pageLayoutTabs: [
+          buildTabManifest({
+            title: 'Insights',
+            layoutMode: 'DIAGONAL' as PageLayoutTabLayoutMode,
+          }),
+        ],
+      }),
+      expectToFail: true,
+    });
+
+    expect(errors).toBeDefined();
+    expect(errors?.length).toBeGreaterThan(0);
+  }, 60000);
+
+  it('should fail to sync when layoutMode is updated to an invalid enum value', async () => {
+    await syncApplication({
+      manifest: buildManifest({
+        pageLayoutTabs: [
+          buildTabManifest({
+            title: 'Insights',
+            layoutMode: PageLayoutTabLayoutMode.GRID,
+          }),
+        ],
+      }),
+      expectToFail: false,
+    });
+
+    const { errors } = await syncApplication({
+      manifest: buildManifest({
+        pageLayoutTabs: [
+          buildTabManifest({
+            title: 'Insights',
+            layoutMode: 'DIAGONAL' as PageLayoutTabLayoutMode,
+          }),
+        ],
+      }),
+      expectToFail: true,
+    });
+
+    expect(errors).toBeDefined();
+    expect(errors?.length).toBeGreaterThan(0);
+
+    const tabsAfterFailedSync = await findStandardPersonPageLayoutTabs();
+
+    expect(tabsAfterFailedSync).toHaveLength(1);
+    expect(tabsAfterFailedSync[0].layoutMode).toBe(
+      PageLayoutTabLayoutMode.GRID,
+    );
+  }, 60000);
 });

--- a/packages/twenty-server/test/integration/metadata/suites/page-layout-tab/__snapshots__/successful-page-layout-tab-update.integration-spec.ts.snap
+++ b/packages/twenty-server/test/integration/metadata/suites/page-layout-tab/__snapshots__/successful-page-layout-tab-update.integration-spec.ts.snap
@@ -1,10 +1,24 @@
 // Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
+exports[`Page layout tab update should succeed should update page layout tab layout mode 1`] = `
+{
+  "createdAt": Any<String>,
+  "deletedAt": null,
+  "id": Any<String>,
+  "layoutMode": "VERTICAL_LIST",
+  "pageLayoutId": Any<String>,
+  "position": 0,
+  "title": "Original Tab Title",
+  "updatedAt": Any<String>,
+}
+`;
+
 exports[`Page layout tab update should succeed should update page layout tab position 1`] = `
 {
   "createdAt": Any<String>,
   "deletedAt": null,
   "id": Any<String>,
+  "layoutMode": "GRID",
   "pageLayoutId": Any<String>,
   "position": 10,
   "title": "Original Tab Title",
@@ -17,6 +31,7 @@ exports[`Page layout tab update should succeed should update page layout tab tit
   "createdAt": Any<String>,
   "deletedAt": null,
   "id": Any<String>,
+  "layoutMode": "GRID",
   "pageLayoutId": Any<String>,
   "position": 0,
   "title": "Updated Tab Title",

--- a/packages/twenty-server/test/integration/metadata/suites/page-layout-tab/successful-page-layout-tab-update.integration-spec.ts
+++ b/packages/twenty-server/test/integration/metadata/suites/page-layout-tab/successful-page-layout-tab-update.integration-spec.ts
@@ -1,5 +1,6 @@
 import { createOnePageLayoutTab } from 'test/integration/metadata/suites/page-layout-tab/utils/create-one-page-layout-tab.util';
 import { destroyOnePageLayoutTab } from 'test/integration/metadata/suites/page-layout-tab/utils/destroy-one-page-layout-tab.util';
+import { findPageLayoutTabs } from 'test/integration/metadata/suites/page-layout-tab/utils/find-page-layout-tabs.util';
 import { updateOnePageLayoutTab } from 'test/integration/metadata/suites/page-layout-tab/utils/update-one-page-layout-tab.util';
 import { createOnePageLayout } from 'test/integration/metadata/suites/page-layout/utils/create-one-page-layout.util';
 import { destroyOnePageLayout } from 'test/integration/metadata/suites/page-layout/utils/destroy-one-page-layout.util';
@@ -8,11 +9,13 @@ import {
   type EachTestingContext,
   eachTestingContextFilter,
 } from 'twenty-shared/testing';
+import { PageLayoutTabLayoutMode } from 'twenty-shared/types';
 
 type TestContext = {
   input: {
     title?: string;
     position?: number;
+    layoutMode?: PageLayoutTabLayoutMode;
   };
 };
 
@@ -30,6 +33,14 @@ const SUCCESSFUL_TEST_CASES: EachTestingContext<TestContext>[] = [
     context: {
       input: {
         position: 10,
+      },
+    },
+  },
+  {
+    title: 'update page layout tab layout mode',
+    context: {
+      input: {
+        layoutMode: PageLayoutTabLayoutMode.VERTICAL_LIST,
       },
     },
   },
@@ -90,4 +101,28 @@ describe('Page layout tab update should succeed', () => {
       );
     },
   );
+
+  // Regression test for https://github.com/twentyhq/twenty/issues/23402:
+  // layoutMode updates were silently discarded while the mutation reported success
+  it('should persist layout mode update', async () => {
+    await updateOnePageLayoutTab({
+      expectToFail: false,
+      input: {
+        id: testPageLayoutTabId,
+        layoutMode: PageLayoutTabLayoutMode.VERTICAL_LIST,
+      },
+    });
+
+    const { data } = await findPageLayoutTabs({
+      expectToFail: false,
+      gqlFields: `id layoutMode`,
+      input: { pageLayoutId: testPageLayoutId },
+    });
+
+    const updatedTab = data.getPageLayoutTabs.find(
+      (tab) => tab.id === testPageLayoutTabId,
+    );
+
+    expect(updatedTab?.layoutMode).toBe(PageLayoutTabLayoutMode.VERTICAL_LIST);
+  });
 });

--- a/packages/twenty-server/test/integration/metadata/suites/page-layout-tab/utils/update-one-page-layout-tab-query-factory.util.ts
+++ b/packages/twenty-server/test/integration/metadata/suites/page-layout-tab/utils/update-one-page-layout-tab-query-factory.util.ts
@@ -11,6 +11,7 @@ const DEFAULT_PAGE_LAYOUT_TAB_GQL_FIELDS = `
   id
   title
   position
+  layoutMode
   pageLayoutId
   createdAt
   updatedAt
@@ -34,6 +35,7 @@ export const updateOnePageLayoutTabQueryFactory = ({
       title: input.title,
       position: input.position,
       icon: input.icon,
+      layoutMode: input.layoutMode,
     },
   },
 });


### PR DESCRIPTION
Fixes #23402: `updatePageLayoutTab` silently ignored `layoutMode`.

## Root cause (confirmed by integration test)

`layoutMode` is accepted at the API boundary (`FLAT_PAGE_LAYOUT_TAB_EDITABLE_PROPERTIES`, manifest tab shape) but had `toCompare: false` in `ALL_ENTITY_PROPERTIES_CONFIGURATION_BY_METADATA_NAME`. It therefore never entered `propertiesToCompare` for `pageLayoutTab`, so:

- `compareTwoFlatEntity` produced no update action for a `layoutMode`-only change, and
- `sanitizeUniversalFlatEntityUpdate` stripped `layoutMode` even when it changed alongside another property.

Both the `updatePageLayoutTab` mutation and application manifest sync go through this pipeline, so both dropped the value silently while reporting success. First confirmed on this branch with an integration test whose broken cases were initially committed as `it.failing`:

```
✕ should update layoutMode when it is the only changed property on second sync
    Expected: "VERTICAL_LIST"
    Received: "GRID"
✕ should update layoutMode alongside another changed property on second sync
    - "layoutMode": "VERTICAL_LIST",
    + "layoutMode": "GRID",
      "title": "Renamed Insights",   <- title did update
```

## Fix

- Flip `layoutMode` to `toCompare: true` for `pageLayoutTab` (+ snapshot update), so it participates in comparison and update sanitization.
- Validate `layoutMode` against the `PageLayoutTabLayoutMode` enum in `FlatPageLayoutTabValidatorService` on both creation and update. Manifest input has no runtime validation (the manifest type is compile-time only), so an invalid string previously flowed straight to the DB enum; it now fails migration validation with an explicit error instead.

## Tests

Integration (all run locally against a live server + DB, green):

- `manifest-sync-page-layout-tab-layout-mode.integration-spec.ts`: layoutMode persists on creation; layoutMode-only re-sync persists; layoutMode + title re-sync persists both (the two former `it.failing` cases, now plain); invalid enum value rejected on first sync and on re-sync (persisted value untouched after failed sync).
- `successful-page-layout-tab-update.integration-spec.ts`: new `layoutMode` case in the mutation test matrix plus an explicit persistence check that re-queries after `updatePageLayoutTab` (the exact repro from the issue).

Unit: regenerated `all-universal-flat-entity-properties-to-compare-and-stringify` snapshot (`layoutMode` now listed for `pageLayoutTab`); full `workspace-migration` unit suite passes. Also ran the `page-layout-tab`, `page-layout`, existing manifest tab update, and dry-run manifest sync integration suites: all green.

Note: `PageLayoutTabLayoutMode.CANVAS` is deprecated but remains a valid enum member, so existing manifests using it keep syncing; validation only rejects values outside the enum.