### PR TITLE
Make record chips open records natively on touch devices

### DIFF
--- a/packages/twenty-front/src/modules/object-record/components/RecordChip.tsx
+++ b/packages/twenty-front/src/modules/object-record/components/RecordChip.tsx
@@ -2,10 +2,8 @@ import { useOpenRecordInSidePanel } from '@/side-panel/hooks/useOpenRecordInSide
 import { CoreObjectNameSingular } from 'twenty-shared/types';
 import { getLinkToShowPage } from '@/object-metadata/utils/getLinkToShowPage';
 import { useRecordChipData } from '@/object-record/hooks/useRecordChipData';
-import { recordIndexOpenRecordInState } from '@/object-record/record-index/states/recordIndexOpenRecordInState';
+import { useResolveOpenRecordIn } from '@/object-record/record-index/hooks/useResolveOpenRecordIn';
 import { type ObjectRecord } from '@/object-record/types/ObjectRecord';
-import { canOpenObjectInSidePanel } from '@/object-record/utils/canOpenObjectInSidePanel';
-import { useAtomStateValue } from '@/ui/utilities/state/jotai/hooks/useAtomStateValue';
 import { ViewOpenRecordIn } from '~/generated-metadata/graphql';
 import { getAbsoluteImageUrl } from '~/utils/image/getAbsoluteImageUrl';
 import { t } from '@lingui/core/macro';
@@ -58,18 +56,11 @@ export const RecordChip = ({
 
   const { openRecordInSidePanel } = useOpenRecordInSidePanel();
 
-  const recordIndexOpenRecordIn = useAtomStateValue(
-    recordIndexOpenRecordInState,
-  );
-  const canOpenInSidePanel = canOpenObjectInSidePanel(objectNameSingular);
-
-  const isSidePanelViewOpenRecordIn =
-    recordIndexOpenRecordIn === ViewOpenRecordIn.SIDE_PANEL &&
-    canOpenInSidePanel;
+  const openRecordIn = useResolveOpenRecordIn(objectNameSingular);
 
   const handleCustomClick = isDefined(onClick)
     ? onClick
-    : isSidePanelViewOpenRecordIn
+    : openRecordIn === ViewOpenRecordIn.SIDE_PANEL
       ? (_event: MouseEvent<HTMLElement>) => {
           openRecordInSidePanel({
             recordId: record.id,

--- a/packages/twenty-front/src/modules/object-record/record-board/record-board-card/components/RecordBoardCardHeader.tsx
+++ b/packages/twenty-front/src/modules/object-record/record-board/record-board-card/components/RecordBoardCardHeader.tsx
@@ -10,12 +10,11 @@ import { StopPropagationContainer } from '@/object-record/record-board/record-bo
 import { recordBoardCardIsExpandedComponentState } from '@/object-record/record-board/record-board-card/states/recordBoardCardIsExpandedComponentState';
 import { RecordCardHeaderContainer } from '@/object-record/record-card/components/RecordCardHeaderContainer';
 import { useOpenRecordFromIndexView } from '@/object-record/record-index/hooks/useOpenRecordFromIndexView';
-import { recordIndexOpenRecordInState } from '@/object-record/record-index/states/recordIndexOpenRecordInState';
+import { useResolveOpenRecordIn } from '@/object-record/record-index/hooks/useResolveOpenRecordIn';
 import { recordStoreFamilyState } from '@/object-record/record-store/states/recordStoreFamilyState';
 import { useAtomComponentFamilyState } from '@/ui/utilities/state/jotai/hooks/useAtomComponentFamilyState';
 import { useAtomComponentState } from '@/ui/utilities/state/jotai/hooks/useAtomComponentState';
 import { useAtomFamilyStateValue } from '@/ui/utilities/state/jotai/hooks/useAtomFamilyStateValue';
-import { useAtomStateValue } from '@/ui/utilities/state/jotai/hooks/useAtomStateValue';
 import { useGetCurrentViewOnly } from '@/views/hooks/useGetCurrentViewOnly';
 import { ViewOpenRecordIn } from '~/generated-metadata/graphql';
 import { styled } from '@linaria/react';
@@ -25,6 +24,7 @@ import { isDefined } from 'twenty-shared/utils';
 import { ChipVariant } from 'twenty-ui/data-display';
 import { IconEye, IconEyeOff } from 'twenty-ui/icon';
 import { Checkbox, CheckboxVariant, LightIconButton } from 'twenty-ui/input';
+import { useIsTouchDevice } from 'twenty-ui/utilities';
 
 const StyledCompactIconContainer = styled.div`
   align-items: center;
@@ -69,14 +69,14 @@ export const RecordBoardCardHeader = () => {
 
   const { openRecordFromIndexView } = useOpenRecordFromIndexView();
 
-  const recordIndexOpenRecordIn = useAtomStateValue(
-    recordIndexOpenRecordInState,
-  );
+  const openRecordIn = useResolveOpenRecordIn(objectMetadataItem.nameSingular);
+
+  const isTouchDevice = useIsTouchDevice();
 
   const recordStore = useAtomFamilyStateValue(recordStoreFamilyState, recordId);
 
   const triggerEvent =
-    recordIndexOpenRecordIn === ViewOpenRecordIn.SIDE_PANEL
+    openRecordIn === ViewOpenRecordIn.SIDE_PANEL || isTouchDevice
       ? 'CLICK'
       : 'MOUSE_DOWN';
 

--- a/packages/twenty-front/src/modules/object-record/record-index/hooks/useGetOpenRecordIn.ts
+++ b/packages/twenty-front/src/modules/object-record/record-index/hooks/useGetOpenRecordIn.ts
@@ -1,0 +1,23 @@
+import { recordIndexOpenRecordInState } from '@/object-record/record-index/states/recordIndexOpenRecordInState';
+import { resolveOpenRecordIn } from '@/object-record/record-index/utils/resolveOpenRecordIn';
+import { useStore } from 'jotai';
+import { useCallback } from 'react';
+import { useIsMobile } from 'twenty-ui/utilities';
+
+export const useGetOpenRecordIn = () => {
+  const store = useStore();
+
+  const isMobile = useIsMobile();
+
+  const getOpenRecordIn = useCallback(
+    (objectNameSingular: string) =>
+      resolveOpenRecordIn({
+        openRecordInViewSetting: store.get(recordIndexOpenRecordInState.atom),
+        objectNameSingular,
+        canDisplaySidePanel: !isMobile,
+      }),
+    [isMobile, store],
+  );
+
+  return { getOpenRecordIn };
+};

--- a/packages/twenty-front/src/modules/object-record/record-index/hooks/useOpenRecordFromIndexView.ts
+++ b/packages/twenty-front/src/modules/object-record/record-index/hooks/useOpenRecordFromIndexView.ts
@@ -6,15 +6,13 @@ import { contextStoreRecordShowParentViewComponentState } from '@/context-store/
 import { currentRecordFilterGroupsComponentState } from '@/object-record/record-filter-group/states/currentRecordFilterGroupsComponentState';
 import { currentRecordFiltersComponentState } from '@/object-record/record-filter/states/currentRecordFiltersComponentState';
 import { useRecordIndexContextOrThrow } from '@/object-record/record-index/contexts/RecordIndexContext';
-import { recordIndexOpenRecordInState } from '@/object-record/record-index/states/recordIndexOpenRecordInState';
+import { useGetOpenRecordIn } from '@/object-record/record-index/hooks/useGetOpenRecordIn';
 import { currentRecordSortsComponentState } from '@/object-record/record-sort/states/currentRecordSortsComponentState';
-import { canOpenObjectInSidePanel } from '@/object-record/utils/canOpenObjectInSidePanel';
 import { useAtomComponentStateCallbackState } from '@/ui/utilities/state/jotai/hooks/useAtomComponentStateCallbackState';
 import { ViewOpenRecordIn } from '~/generated-metadata/graphql';
 import { useStore } from 'jotai';
 import { useCallback } from 'react';
 import { AppPath, SidePanelPages } from 'twenty-shared/types';
-import { useIsMobile } from 'twenty-ui/utilities';
 import { useNavigateApp } from '~/hooks/useNavigateApp';
 
 export const useOpenRecordFromIndexView = () => {
@@ -25,7 +23,7 @@ export const useOpenRecordFromIndexView = () => {
   const navigate = useNavigateApp();
   const { openRecordInSidePanel } = useOpenRecordInSidePanel();
 
-  const isMobile = useIsMobile();
+  const { getOpenRecordIn } = useGetOpenRecordIn();
 
   const currentRecordFilters = useAtomComponentStateCallbackState(
     currentRecordFiltersComponentState,
@@ -48,10 +46,6 @@ export const useOpenRecordFromIndexView = () => {
 
   const openRecordFromIndexView = useCallback(
     ({ recordId }: { recordId: string }) => {
-      const recordIndexOpenRecordIn = store.get(
-        recordIndexOpenRecordInState.atom,
-      );
-
       const parentViewFilters = store.get(currentRecordFilters);
 
       const parentViewSorts = store.get(currentRecordSorts);
@@ -71,11 +65,7 @@ export const useOpenRecordFromIndexView = () => {
         },
       );
 
-      if (
-        !isMobile &&
-        recordIndexOpenRecordIn === ViewOpenRecordIn.SIDE_PANEL &&
-        canOpenObjectInSidePanel(objectNameSingular)
-      ) {
+      if (getOpenRecordIn(objectNameSingular) === ViewOpenRecordIn.SIDE_PANEL) {
         openRecordInSidePanel({
           recordId,
           objectNameSingular,
@@ -103,7 +93,7 @@ export const useOpenRecordFromIndexView = () => {
       objectNameSingular,
       navigate,
       openRecordInSidePanel,
-      isMobile,
+      getOpenRecordIn,
       closeSidePanelMenu,
       store,
     ],

--- a/packages/twenty-front/src/modules/object-record/record-index/hooks/useResolveOpenRecordIn.ts
+++ b/packages/twenty-front/src/modules/object-record/record-index/hooks/useResolveOpenRecordIn.ts
@@ -1,0 +1,18 @@
+import { recordIndexOpenRecordInState } from '@/object-record/record-index/states/recordIndexOpenRecordInState';
+import { resolveOpenRecordIn } from '@/object-record/record-index/utils/resolveOpenRecordIn';
+import { useAtomStateValue } from '@/ui/utilities/state/jotai/hooks/useAtomStateValue';
+import { useIsMobile } from 'twenty-ui/utilities';
+
+export const useResolveOpenRecordIn = (objectNameSingular: string) => {
+  const recordIndexOpenRecordIn = useAtomStateValue(
+    recordIndexOpenRecordInState,
+  );
+
+  const isMobile = useIsMobile();
+
+  return resolveOpenRecordIn({
+    openRecordInViewSetting: recordIndexOpenRecordIn,
+    objectNameSingular,
+    canDisplaySidePanel: !isMobile,
+  });
+};

--- a/packages/twenty-front/src/modules/object-record/record-index/utils/__tests__/resolveOpenRecordIn.test.ts
+++ b/packages/twenty-front/src/modules/object-record/record-index/utils/__tests__/resolveOpenRecordIn.test.ts
@@ -1,0 +1,44 @@
+import { resolveOpenRecordIn } from '@/object-record/record-index/utils/resolveOpenRecordIn';
+import { ViewOpenRecordIn } from '~/generated-metadata/graphql';
+
+describe('resolveOpenRecordIn', () => {
+  it('opens in the side panel when the view asks for it and it can be displayed', () => {
+    expect(
+      resolveOpenRecordIn({
+        openRecordInViewSetting: ViewOpenRecordIn.SIDE_PANEL,
+        objectNameSingular: 'company',
+        canDisplaySidePanel: true,
+      }),
+    ).toBe(ViewOpenRecordIn.SIDE_PANEL);
+  });
+
+  it('falls back to the record page when there is no room for a side panel', () => {
+    expect(
+      resolveOpenRecordIn({
+        openRecordInViewSetting: ViewOpenRecordIn.SIDE_PANEL,
+        objectNameSingular: 'company',
+        canDisplaySidePanel: false,
+      }),
+    ).toBe(ViewOpenRecordIn.RECORD_PAGE);
+  });
+
+  it('falls back to the record page for objects without a side panel', () => {
+    expect(
+      resolveOpenRecordIn({
+        openRecordInViewSetting: ViewOpenRecordIn.SIDE_PANEL,
+        objectNameSingular: 'workflow',
+        canDisplaySidePanel: true,
+      }),
+    ).toBe(ViewOpenRecordIn.RECORD_PAGE);
+  });
+
+  it('keeps the record page when the view asks for it', () => {
+    expect(
+      resolveOpenRecordIn({
+        openRecordInViewSetting: ViewOpenRecordIn.RECORD_PAGE,
+        objectNameSingular: 'company',
+        canDisplaySidePanel: true,
+      }),
+    ).toBe(ViewOpenRecordIn.RECORD_PAGE);
+  });
+});

--- a/packages/twenty-front/src/modules/object-record/record-index/utils/resolveOpenRecordIn.ts
+++ b/packages/twenty-front/src/modules/object-record/record-index/utils/resolveOpenRecordIn.ts
@@ -1,0 +1,22 @@
+import { canOpenObjectInSidePanel } from '@/object-record/utils/canOpenObjectInSidePanel';
+import { ViewOpenRecordIn } from '~/generated-metadata/graphql';
+
+type ResolveOpenRecordInArgs = {
+  openRecordInViewSetting: ViewOpenRecordIn;
+  objectNameSingular: string;
+  canDisplaySidePanel: boolean;
+};
+
+// The view setting is an intent, not a decision: the side panel is only a real
+// destination when there is room to display it next to the record list, and
+// when the object has a side panel to display at all.
+export const resolveOpenRecordIn = ({
+  openRecordInViewSetting,
+  objectNameSingular,
+  canDisplaySidePanel,
+}: ResolveOpenRecordInArgs): ViewOpenRecordIn =>
+  openRecordInViewSetting === ViewOpenRecordIn.SIDE_PANEL &&
+  canDisplaySidePanel &&
+  canOpenObjectInSidePanel(objectNameSingular)
+    ? ViewOpenRecordIn.SIDE_PANEL
+    : ViewOpenRecordIn.RECORD_PAGE;

--- a/packages/twenty-front/src/modules/object-record/record-table/components/RecordTableContent.tsx
+++ b/packages/twenty-front/src/modules/object-record/record-table/components/RecordTableContent.tsx
@@ -12,6 +12,7 @@ import { useRecordTableContextOrThrow } from '@/object-record/record-table/conte
 import { RecordTableNoRecordGroupBody } from '@/object-record/record-table/record-table-body/components/RecordTableNoRecordGroupBody';
 import { RecordTableRecordGroupsBody } from '@/object-record/record-table/record-table-body/components/RecordTableRecordGroupsBody';
 import { RecordTableHeader } from '@/object-record/record-table/record-table-header/components/RecordTableHeader';
+import { useMoveHoverToCurrentCell } from '@/object-record/record-table/record-table-cell/hooks/useMoveHoverToCurrentCell';
 import { isRowSelectedComponentFamilyState } from '@/object-record/record-table/record-table-row/states/isRowSelectedComponentFamilyState';
 import { recordTableHoverPositionComponentState } from '@/object-record/record-table/states/recordTableHoverPositionComponentState';
 import { isSomeCellInEditModeComponentSelector } from '@/object-record/record-table/states/selectors/isSomeCellInEditModeComponentSelector';
@@ -99,12 +100,10 @@ export const RecordTableContent = ({
     }
   }, [store, isSomeCellInEditMode, recordTableHoverPositionCallbackState]);
 
+  const { moveHoverToCurrentCell } = useMoveHoverToCurrentCell(recordTableId);
+
   const handleDelegatedMouseMove = useCallback(
     (event: React.MouseEvent) => {
-      if (store.get(isSomeCellInEditMode)) {
-        return;
-      }
-
       const target = event.target as HTMLElement;
       const cellElement = target.closest<HTMLElement>(
         '[data-record-table-col]',
@@ -121,15 +120,9 @@ export const RecordTableContent = ({
         return;
       }
 
-      const lastPosition = store.get(recordTableHoverPositionCallbackState);
-
-      if (lastPosition?.column === column && lastPosition?.row === row) {
-        return;
-      }
-
-      store.set(recordTableHoverPositionCallbackState, { column, row });
+      moveHoverToCurrentCell({ column, row });
     },
-    [store, isSomeCellInEditMode, recordTableHoverPositionCallbackState],
+    [moveHoverToCurrentCell],
   );
 
   const isRecordTableDragColumnHidden = useAtomComponentStateValue(

--- a/packages/twenty-front/src/modules/object-record/record-table/components/RecordTableContextProvider.tsx
+++ b/packages/twenty-front/src/modules/object-record/record-table/components/RecordTableContextProvider.tsx
@@ -9,12 +9,12 @@ import { useUpdateOneRecord } from '@/object-record/hooks/useUpdateOneRecord';
 import { RecordFieldsScopeContextProvider } from '@/object-record/record-field-list/contexts/RecordFieldsScopeContext';
 import { visibleRecordFieldsComponentSelector } from '@/object-record/record-field/states/visibleRecordFieldsComponentSelector';
 import { type RecordUpdateHookParams } from '@/object-record/record-field/ui/contexts/FieldContext';
-import { recordIndexOpenRecordInState } from '@/object-record/record-index/states/recordIndexOpenRecordInState';
+import { useResolveOpenRecordIn } from '@/object-record/record-index/hooks/useResolveOpenRecordIn';
 import { RECORD_TABLE_CELL_INPUT_ID_PREFIX } from '@/object-record/record-table/constants/RecordTableCellInputIdPrefix';
 import { RECORD_TABLE_COLUMN_MIN_WIDTH } from '@/object-record/record-table/constants/RecordTableColumnMinWidth';
 import { RecordTableUpdateContext } from '@/object-record/record-table/contexts/RecordTableUpdateContext';
 import { useAtomComponentSelectorValue } from '@/ui/utilities/state/jotai/hooks/useAtomComponentSelectorValue';
-import { useAtomStateValue } from '@/ui/utilities/state/jotai/hooks/useAtomStateValue';
+import { useIsTouchDevice } from 'twenty-ui/utilities';
 import { ViewOpenRecordIn } from '~/generated-metadata/graphql';
 
 type RecordTableContextProviderProps = {
@@ -59,11 +59,14 @@ export const RecordTableContextProvider = ({
     [objectNameSingular, updateOneRecord],
   );
 
-  const recordIndexOpenRecordIn = useAtomStateValue(
-    recordIndexOpenRecordInState,
-  );
+  const openRecordIn = useResolveOpenRecordIn(objectNameSingular);
+
+  const isTouchDevice = useIsTouchDevice();
+
+  // Navigating on mouse down only buys a frame on a real pointer: a tap
+  // synthesises its mouse events after the finger is already gone.
   const triggerEvent =
-    recordIndexOpenRecordIn === ViewOpenRecordIn.SIDE_PANEL
+    openRecordIn === ViewOpenRecordIn.SIDE_PANEL || isTouchDevice
       ? 'CLICK'
       : 'MOUSE_DOWN';
 

--- a/packages/twenty-front/src/modules/object-record/record-table/hooks/useCreateNewIndexRecord.ts
+++ b/packages/twenty-front/src/modules/object-record/record-table/hooks/useCreateNewIndexRecord.ts
@@ -5,12 +5,11 @@ import { useCreateOneRecord } from '@/object-record/hooks/useCreateOneRecord';
 import { recordGroupDefinitionsComponentSelector } from '@/object-record/record-group/states/selectors/recordGroupDefinitionsComponentSelector';
 import { getFieldMetadataItemGqlFieldName } from '@/object-metadata/utils/getFieldMetadataItemGqlFieldName';
 import { recordIndexGroupFieldMetadataItemComponentState } from '@/object-record/record-index/states/recordIndexGroupFieldMetadataComponentState';
-import { recordIndexOpenRecordInState } from '@/object-record/record-index/states/recordIndexOpenRecordInState';
+import { useGetOpenRecordIn } from '@/object-record/record-index/hooks/useGetOpenRecordIn';
 import { recordIndexRecordIdsByGroupComponentFamilyState } from '@/object-record/record-index/states/recordIndexRecordIdsByGroupComponentFamilyState';
 import { useUpsertRecordsInStore } from '@/object-record/record-store/hooks/useUpsertRecordsInStore';
 import { useBuildRecordInputFromFilters } from '@/object-record/record-table/hooks/useBuildRecordInputFromFilters';
 import { type ObjectRecord } from '@/object-record/types/ObjectRecord';
-import { canOpenObjectInSidePanel } from '@/object-record/utils/canOpenObjectInSidePanel';
 import { useOpenRecordInSidePanel } from '@/side-panel/hooks/useOpenRecordInSidePanel';
 import { useSidePanelMenu } from '@/side-panel/hooks/useSidePanelMenu';
 import { useAtomComponentFamilyStateCallbackState } from '@/ui/utilities/state/jotai/hooks/useAtomComponentFamilyStateCallbackState';
@@ -52,6 +51,8 @@ export const useCreateNewIndexRecord = ({
 
   const { openRecordInSidePanel } = useOpenRecordInSidePanel();
 
+  const { getOpenRecordIn } = useGetOpenRecordIn();
+
   const { closeSidePanelMenu } = useSidePanelMenu();
 
   const { createOneRecord } = useCreateOneRecord({
@@ -85,18 +86,14 @@ export const useCreateNewIndexRecord = ({
         ...recordInput,
       };
 
-      const recordIndexOpenRecordIn = store.get(
-        recordIndexOpenRecordInState.atom,
-      );
-
       const createdRecord = await createOneRecord({
         id: recordId,
         ...mergedRecordInput,
       });
 
       if (
-        recordIndexOpenRecordIn === ViewOpenRecordIn.SIDE_PANEL &&
-        canOpenObjectInSidePanel(objectMetadataItem.nameSingular)
+        getOpenRecordIn(objectMetadataItem.nameSingular) ===
+        ViewOpenRecordIn.SIDE_PANEL
       ) {
         openRecordInSidePanel({
           recordId,
@@ -172,6 +169,7 @@ export const useCreateNewIndexRecord = ({
       navigate,
       objectMetadataItem,
       openRecordInSidePanel,
+      getOpenRecordIn,
       recordGroupDefinitions,
       recordIndexGroupFieldMetadataItem,
       recordIndexRecordIdsByGroupCallbackState,

--- a/packages/twenty-front/src/modules/object-record/record-table/record-table-cell/components/RecordTableCellBaseContainer.tsx
+++ b/packages/twenty-front/src/modules/object-record/record-table/record-table-cell/components/RecordTableCellBaseContainer.tsx
@@ -25,22 +25,24 @@ const StyledBaseContainer = styled.div<{
 
   user-select: none;
 
-  &:hover {
-    background-color: ${({ isReadOnly, backgroundColorSecondary }) =>
-      isReadOnly ? backgroundColorSecondary : 'unset'};
-    border-radius: ${({ isReadOnly }) => (isReadOnly ? '0px' : 'unset')};
-    color: ${({ isReadOnly, fontColorSecondary }) =>
-      isReadOnly ? fontColorSecondary : 'unset'};
-    outline: ${({ isReadOnly, fontColorMedium }) =>
-      isReadOnly ? `1px solid ${fontColorMedium}` : 'unset'};
-
-    svg {
+  @media (hover: hover) {
+    &:hover {
+      background-color: ${({ isReadOnly, backgroundColorSecondary }) =>
+        isReadOnly ? backgroundColorSecondary : 'unset'};
+      border-radius: ${({ isReadOnly }) => (isReadOnly ? '0px' : 'unset')};
       color: ${({ isReadOnly, fontColorSecondary }) =>
         isReadOnly ? fontColorSecondary : 'unset'};
-    }
+      outline: ${({ isReadOnly, fontColorMedium }) =>
+        isReadOnly ? `1px solid ${fontColorMedium}` : 'unset'};
 
-    img {
-      opacity: ${({ isReadOnly }) => (isReadOnly ? '0.64' : 'unset')};
+      svg {
+        color: ${({ isReadOnly, fontColorSecondary }) =>
+          isReadOnly ? fontColorSecondary : 'unset'};
+      }
+
+      img {
+        opacity: ${({ isReadOnly }) => (isReadOnly ? '0.64' : 'unset')};
+      }
     }
   }
 `;

--- a/packages/twenty-front/src/modules/object-record/record-table/record-table-cell/components/RecordTableCellDragAndDrop.tsx
+++ b/packages/twenty-front/src/modules/object-record/record-table/record-table-cell/components/RecordTableCellDragAndDrop.tsx
@@ -16,8 +16,10 @@ const StyledContainer = styled.div`
   display: flex;
   height: ${RECORD_TABLE_ROW_HEIGHT}px;
 
-  &:hover .icon {
-    opacity: 1;
+  @media (hover: hover) {
+    &:hover .icon {
+      opacity: 1;
+    }
   }
 
   z-index: ${TABLE_Z_INDEX.columnGrip};

--- a/packages/twenty-front/src/modules/object-record/record-table/record-table-cell/hooks/__tests__/useMoveHoverToCurrentCell.test.tsx
+++ b/packages/twenty-front/src/modules/object-record/record-table/record-table-cell/hooks/__tests__/useMoveHoverToCurrentCell.test.tsx
@@ -15,44 +15,65 @@ import {
 import { useMoveHoverToCurrentCell } from '@/object-record/record-table/record-table-cell/hooks/useMoveHoverToCurrentCell';
 import { recordTableHoverPositionComponentState } from '@/object-record/record-table/states/recordTableHoverPositionComponentState';
 
-const Wrapper = ({ children }: { children: React.ReactNode }) => (
-  <JotaiProvider store={jotaiStore}>
-    <RecordTableComponentInstance recordTableId="test-record-table-instance-id">
-      <RecordTableRowContextProvider value={recordTableRowContextValue}>
-        <RecordTableRowDraggableContextProvider
-          value={recordTableRowDraggableContextValue}
-        >
-          <RecordTableCellContext.Provider value={recordTableCellContextValue}>
-            {children}
-          </RecordTableCellContext.Provider>
-        </RecordTableRowDraggableContextProvider>
-      </RecordTableRowContextProvider>
-    </RecordTableComponentInstance>
-  </JotaiProvider>
-);
+jest.mock('react-responsive', () => ({
+  useMediaQuery: jest.fn(),
+}));
+
+const mockUseMediaQuery = jest.requireMock('react-responsive')
+  .useMediaQuery as jest.Mock;
+
+const mockIsTouchDevice = (isTouchDevice: boolean) => {
+  mockUseMediaQuery.mockImplementation(({ query }: { query: string }) =>
+    query.includes('hover: none') ? isTouchDevice : false,
+  );
+};
+
+const createWrapper =
+  (recordTableId: string) =>
+  ({ children }: { children: React.ReactNode }) => (
+    <JotaiProvider store={jotaiStore}>
+      <RecordTableComponentInstance recordTableId={recordTableId}>
+        <RecordTableRowContextProvider value={recordTableRowContextValue}>
+          <RecordTableRowDraggableContextProvider
+            value={recordTableRowDraggableContextValue}
+          >
+            <RecordTableCellContext.Provider
+              value={recordTableCellContextValue}
+            >
+              {children}
+            </RecordTableCellContext.Provider>
+          </RecordTableRowDraggableContextProvider>
+        </RecordTableRowContextProvider>
+      </RecordTableComponentInstance>
+    </JotaiProvider>
+  );
+
+const renderMoveHoverToCurrentCell = (recordTableId: string) =>
+  renderHook(
+    () => {
+      const recordTableHoverPosition = useAtomValue(
+        recordTableHoverPositionComponentState.atomFamily({
+          instanceId: recordTableId,
+        }),
+      );
+      const { moveHoverToCurrentCell } =
+        useMoveHoverToCurrentCell(recordTableId);
+
+      return {
+        moveHoverToCurrentCell,
+        recordTableHoverPosition,
+      };
+    },
+    {
+      wrapper: createWrapper(recordTableId),
+    },
+  );
 
 describe('useMoveHoverToCurrentCell', () => {
   it('should work as expected', () => {
-    const { result } = renderHook(
-      () => {
-        const recordTableHoverPosition = useAtomValue(
-          recordTableHoverPositionComponentState.atomFamily({
-            instanceId: 'test-record-table-instance-id',
-          }),
-        );
-        const { moveHoverToCurrentCell } = useMoveHoverToCurrentCell(
-          'test-record-table-instance-id',
-        );
+    mockIsTouchDevice(false);
 
-        return {
-          moveHoverToCurrentCell,
-          recordTableHoverPosition,
-        };
-      },
-      {
-        wrapper: Wrapper,
-      },
-    );
+    const { result } = renderMoveHoverToCurrentCell('test-pointer-fine');
 
     act(() => {
       result.current.moveHoverToCurrentCell({
@@ -65,5 +86,20 @@ describe('useMoveHoverToCurrentCell', () => {
       column: 3,
       row: 2,
     });
+  });
+
+  it('should not track hover on touch devices', () => {
+    mockIsTouchDevice(true);
+
+    const { result } = renderMoveHoverToCurrentCell('test-pointer-coarse');
+
+    act(() => {
+      result.current.moveHoverToCurrentCell({
+        column: 1,
+        row: 1,
+      });
+    });
+
+    expect(result.current.recordTableHoverPosition).toBeNull();
   });
 });

--- a/packages/twenty-front/src/modules/object-record/record-table/record-table-cell/hooks/useMoveHoverToCurrentCell.ts
+++ b/packages/twenty-front/src/modules/object-record/record-table/record-table-cell/hooks/useMoveHoverToCurrentCell.ts
@@ -6,10 +6,11 @@ import { useStore } from 'jotai';
 import { recordTableHoverPositionComponentState } from '@/object-record/record-table/states/recordTableHoverPositionComponentState';
 import { isSomeCellInEditModeComponentSelector } from '@/object-record/record-table/states/selectors/isSomeCellInEditModeComponentSelector';
 import { useAtomComponentSelectorCallbackState } from '@/ui/utilities/state/jotai/hooks/useAtomComponentSelectorCallbackState';
-import { useSetAtomComponentState } from '@/ui/utilities/state/jotai/hooks/useSetAtomComponentState';
+import { useAtomComponentStateCallbackState } from '@/ui/utilities/state/jotai/hooks/useAtomComponentStateCallbackState';
+import { useIsTouchDevice } from 'twenty-ui/utilities';
 
 export const useMoveHoverToCurrentCell = (recordTableId: string) => {
-  const setRecordTableHoverPosition = useSetAtomComponentState(
+  const recordTableHoverPosition = useAtomComponentStateCallbackState(
     recordTableHoverPositionComponentState,
     recordTableId,
   );
@@ -19,17 +20,31 @@ export const useMoveHoverToCurrentCell = (recordTableId: string) => {
     recordTableId,
   );
 
+  const isTouchDevice = useIsTouchDevice();
+
   const store = useStore();
 
   const moveHoverToCurrentCell = useCallback(
     (cellPosition: TableCellPosition) => {
-      const cellInEditMode = store.get(isSomeCellInEditMode);
-
-      if (!cellInEditMode) {
-        setRecordTableHoverPosition(cellPosition);
+      // A tap synthesises a mousemove before its mousedown. Hovering on it
+      // would mount the hover portal under the finger, and the click that
+      // follows would hit that new subtree instead of what the user aimed at.
+      if (isTouchDevice || store.get(isSomeCellInEditMode)) {
+        return;
       }
+
+      const lastPosition = store.get(recordTableHoverPosition);
+
+      if (
+        lastPosition?.column === cellPosition.column &&
+        lastPosition?.row === cellPosition.row
+      ) {
+        return;
+      }
+
+      store.set(recordTableHoverPosition, cellPosition);
     },
-    [store, isSomeCellInEditMode, setRecordTableHoverPosition],
+    [isTouchDevice, store, isSomeCellInEditMode, recordTableHoverPosition],
   );
 
   return { moveHoverToCurrentCell };

--- a/packages/twenty-front/src/modules/object-record/record-table/record-table-cell/hooks/useOpenRecordTableCell.ts
+++ b/packages/twenty-front/src/modules/object-record/record-table/record-table-cell/hooks/useOpenRecordTableCell.ts
@@ -10,7 +10,6 @@ import { type TableCellPosition } from '@/object-record/record-table/types/Table
 import { useDragSelect } from '@/ui/utilities/drag-select/hooks/useDragSelect';
 import { useClickOutsideListener } from '@/ui/utilities/pointer-event/hooks/useClickOutsideListener';
 import { useOpenFieldInputEditMode } from '@/object-record/record-field/ui/hooks/useOpenFieldInputEditMode';
-import { recordIndexOpenRecordInState } from '@/object-record/record-index/states/recordIndexOpenRecordInState';
 import { RECORD_TABLE_CLICK_OUTSIDE_LISTENER_ID } from '@/object-record/record-table/constants/RecordTableClickOutsideListenerId';
 import { recordTableCellEditModePositionComponentState } from '@/object-record/record-table/states/recordTableCellEditModePositionComponentState';
 import { getDropdownFocusIdForRecordField } from '@/object-record/utils/getDropdownFocusIdForRecordField';
@@ -18,6 +17,8 @@ import { getRecordFieldInputInstanceId } from '@/object-record/utils/getRecordFi
 import { useSetActiveDropdownFocusIdAndMemorizePrevious } from '@/ui/layout/dropdown/hooks/useSetFocusedDropdownIdAndMemorizePrevious';
 
 import { useRecordFieldsScopeContextOrThrow } from '@/object-record/record-field-list/contexts/RecordFieldsScopeContext';
+import { useRecordIndexContextOrThrow } from '@/object-record/record-index/contexts/RecordIndexContext';
+import { useGetOpenRecordIn } from '@/object-record/record-index/hooks/useGetOpenRecordIn';
 import { useOpenRecordFromIndexView } from '@/object-record/record-index/hooks/useOpenRecordFromIndexView';
 import { useActiveRecordTableRow } from '@/object-record/record-table/hooks/useActiveRecordTableRow';
 import { useFocusedRecordTableRow } from '@/object-record/record-table/hooks/useFocusedRecordTableRow';
@@ -84,6 +85,10 @@ export const useOpenRecordTableCell = (recordTableId: string) => {
 
   const { openRecordFromIndexView } = useOpenRecordFromIndexView();
 
+  const { getOpenRecordIn } = useGetOpenRecordIn();
+
+  const { objectNameSingular } = useRecordIndexContextOrThrow();
+
   const openTableCell = useCallback(
     ({
       initialValue,
@@ -117,9 +122,9 @@ export const useOpenRecordTableCell = (recordTableId: string) => {
       if ((isFirstColumnCell && !isEmpty) || isNavigating) {
         leaveTableFocus();
 
-        const openRecordIn = store.get(recordIndexOpenRecordInState.atom);
-
-        if (openRecordIn === ViewOpenRecordIn.SIDE_PANEL) {
+        if (
+          getOpenRecordIn(objectNameSingular) === ViewOpenRecordIn.SIDE_PANEL
+        ) {
           activateRecordTableRow(cellPosition.row);
           unfocusRecordTableRow();
         }
@@ -194,6 +199,8 @@ export const useOpenRecordTableCell = (recordTableId: string) => {
       scopeInstanceId,
       leaveTableFocus,
       openRecordFromIndexView,
+      getOpenRecordIn,
+      objectNameSingular,
       activateRecordTableRow,
       unfocusRecordTableRow,
       store,

--- a/packages/twenty-front/src/modules/object-record/record-table/record-table-footer/components/RecordTableAggregateFooterCell.tsx
+++ b/packages/twenty-front/src/modules/object-record/record-table/record-table-footer/components/RecordTableAggregateFooterCell.tsx
@@ -41,11 +41,13 @@ const StyledColumnFooterCell = styled.div<{
       ? `calc(var(${RECORD_TABLE_DRAG_DROP_WIDTH_CSS_VAR}) + var(${RECORD_TABLE_CHECKBOX_WIDTH_CSS_VAR}))`
       : 'auto'};
 
-  &:hover {
-    background: ${({ isReadOnly }) =>
-      isReadOnly
-        ? themeCssVariables.background.primary
-        : themeCssVariables.background.secondary};
+  @media (hover: hover) {
+    &:hover {
+      background: ${({ isReadOnly }) =>
+        isReadOnly
+          ? themeCssVariables.background.primary
+          : themeCssVariables.background.secondary};
+    }
   }
 
   min-width: ${({ columnWidth }) => columnWidth}px;

--- a/packages/twenty-front/src/modules/object-record/record-table/record-table-header/components/RecordTableHeaderAddColumnButton.tsx
+++ b/packages/twenty-front/src/modules/object-record/record-table/record-table-header/components/RecordTableHeaderAddColumnButton.tsx
@@ -41,8 +41,10 @@ const StyledPlusIconHeaderCell = styled.div<{
   width: ${RECORD_TABLE_COLUMN_ADD_COLUMN_BUTTON_WIDTH}px;
   z-index: 1;
 
-  &:hover {
-    background: ${themeCssVariables.background.secondary};
+  @media (hover: hover) {
+    &:hover {
+      background: ${themeCssVariables.background.secondary};
+    }
   }
 `;
 

--- a/packages/twenty-front/src/modules/object-record/record-table/record-table-header/components/RecordTableHeaderCellContainer.tsx
+++ b/packages/twenty-front/src/modules/object-record/record-table/record-table-header/components/RecordTableHeaderCellContainer.tsx
@@ -28,11 +28,13 @@ const StyledHeaderCell = styled.div<{
 
   text-align: left;
 
-  &:hover {
-    background: ${({ isResizing, isReadOnly }) =>
-      isReadOnly || isResizing
-        ? themeCssVariables.background.primary
-        : themeCssVariables.background.secondary};
+  @media (hover: hover) {
+    &:hover {
+      background: ${({ isResizing, isReadOnly }) =>
+        isReadOnly || isResizing
+          ? themeCssVariables.background.primary
+          : themeCssVariables.background.secondary};
+    }
   }
 
   &:active {

--- a/packages/twenty-front/src/modules/object-record/record-table/record-table-row/components/RecordTableActionRow.tsx
+++ b/packages/twenty-front/src/modules/object-record/record-table/record-table-row/components/RecordTableActionRow.tsx
@@ -36,9 +36,11 @@ const StyledRecordTableDraggableTr = styled.div`
   display: flex;
   flex-direction: row;
 
-  &:hover {
-    div:not(:first-of-type) {
-      background-color: ${themeCssVariables.background.secondary};
+  @media (hover: hover) {
+    &:hover {
+      div:not(:first-of-type) {
+        background-color: ${themeCssVariables.background.secondary};
+      }
     }
   }
 

--- a/packages/twenty-ui/src/data-display/Avatar/Avatar.module.scss
+++ b/packages/twenty-ui/src/data-display/Avatar/Avatar.module.scss
@@ -25,8 +25,10 @@
     cursor: pointer;
   }
 
-  &[data-clickable]:hover {
-    box-shadow: 0 0 0 4px var(--t-background-transparent-light);
+  @include hover-capable {
+    &[data-clickable]:hover {
+      box-shadow: 0 0 0 4px var(--t-background-transparent-light);
+    }
   }
 }
 

--- a/packages/twenty-ui/src/data-display/Chip/Chip.module.scss
+++ b/packages/twenty-ui/src/data-display/Chip/Chip.module.scss
@@ -61,8 +61,10 @@
 .backgroundHighlighted {
   background-color: var(--t-background-transparent-light);
 
-  &:hover {
-    background-color: var(--t-background-transparent-medium);
+  @include hover-capable {
+    &:hover {
+      background-color: var(--t-background-transparent-medium);
+    }
   }
 
   &:active {
@@ -84,8 +86,10 @@
 
 // Applied only when variant is regular, clickable and not disabled.
 .interactiveRegular {
-  &:hover {
-    background-color: var(--t-background-transparent-light);
+  @include hover-capable {
+    &:hover {
+      background-color: var(--t-background-transparent-light);
+    }
   }
 
   &:active {

--- a/packages/twenty-ui/src/styles/abstracts/_mixins.scss
+++ b/packages/twenty-ui/src/styles/abstracts/_mixins.scss
@@ -4,3 +4,12 @@
     outline-offset: 1px;
   }
 }
+
+// A tap leaves :hover applied until the next tap lands elsewhere, so anything
+// that paints on hover has to be limited to pointers that can actually hover.
+// Mirrors useIsTouchDevice.
+@mixin hover-capable {
+  @media (hover: hover) {
+    @content;
+  }
+}

--- a/packages/twenty-ui/src/utilities/index.ts
+++ b/packages/twenty-ui/src/utilities/index.ts
@@ -22,6 +22,7 @@ export { useResetLocationHash } from './navigation/hooks/useResetLocationHash';
 export { isNavigationModifierPressed } from './navigation/isNavigationModifierPressed';
 export type { TriggerEventType } from './navigation/types/trigger-event.type';
 export { useIsMobile } from './responsive/hooks/useIsMobile';
+export { useIsTouchDevice } from './responsive/hooks/useIsTouchDevice';
 export { useScreenSize } from './screen-size/hooks/useScreenSize';
 export type { ClickOutsideAttributes } from './types/ClickOutsideAttributes';
 export type { Nullable } from './types/Nullable';

--- a/packages/twenty-ui/src/utilities/responsive/hooks/useIsTouchDevice.ts
+++ b/packages/twenty-ui/src/utilities/responsive/hooks/useIsTouchDevice.ts
@@ -1,0 +1,8 @@
+import { useMediaQuery } from 'react-responsive';
+
+// Viewport width tells us how much room we have to lay things out, not how the
+// user points at them: a narrow window on a desktop still hovers, a tablet in
+// landscape never does. Interaction behaviour must branch on this, not on
+// useIsMobile.
+export const useIsTouchDevice = () =>
+  useMediaQuery({ query: '(hover: none) and (pointer: coarse)' });


### PR DESCRIPTION
Two mobile problems in the record table: tapping a chip in the first column takes two taps, and chips in every other column open a side panel where a full page is wanted. #23422 is stacked on this branch.

## Two taps to open a record

The table's interactive layer lives in a hover portal mounted from `onMouseMove` on the table wrapper. Touch has no hover, so the browser fakes one, and the synthesised `mousemove` arrives *before* the `mousedown`. React commits the portal in the microtask between them, so the whole tap is hit-tested against a subtree that did not exist when the user aimed.

Confirmed in Chromium with real touch input (`page.tap`, Pixel 5 emulation), mounting an overlay from the mousemove handler:

```
mousemove target=chip
>>> overlay mounted          <- the hover portal
mousedown target=portalChip  <- a node that did not exist when the finger went down
mouseup   target=portalChip
click     target=portalChip
```

The same test also ruled out `preventDefault` on the compat `mousedown` as a cause, and showed a `setTimeout`-deferred mount does *not* retarget — it is specifically React's sync flush timing that does.

So hover state is now only tracked on hover-capable pointers. `useMoveHoverToCurrentCell` becomes the single writer and absorbs the deduplication `RecordTableContent` was duplicating inline.

The interaction/layout split matters here: `useIsMobile` is a 768px width query, which answers "how much room is there to lay out", not "how does this person point". The new `useIsTouchDevice` uses `(hover: none) and (pointer: coarse)`. Layout keeps using width; interaction uses capability.

## Side panel on mobile

"Where does a record open" was computed independently in six places and only `useOpenRecordFromIndexView` knew about mobile. `RecordChip` — every chip outside the first column, plus board cards and relation fields — had its own copy without that check. On mobile the side panel animates to `fullScreen`, so it is a full-page view with no URL and no back button.

That decision now lives in one `resolveOpenRecordIn`: the view setting is an intent, and the side panel is only a real destination when there is room for it and the object supports it.

Also here: `MOUSE_DOWN` navigation downgrades to `CLICK` on touch. It only buys a frame on a real pointer, since a tap synthesises its mouse events after the finger is already gone.

## Hover styling

Separate layer, same root cause. A tap leaves CSS `:hover` applied until the next tap lands elsewhere, so a row you came back from keeps reading as selected. Nine `:hover` blocks across the record table, `Chip` and `Avatar` are now fenced behind `(hover: hover)` — the same media feature `useIsTouchDevice` branches on, via a new `hover-capable` SCSS mixin on the twenty-ui side and inline media queries in the Linaria components.

Desktop rendering is unchanged, since Chrome matches `hover: hover`. Verified the built CSS emits the wrapper correctly, and checked the nested form through stylis directly for the Linaria side.

## Testing

- New unit tests for `resolveOpenRecordIn` and for hover not being tracked on touch devices.
- Full frontend suite: 951 suites, 5598 tests passing. Typecheck and lint clean.
- Not observed end to end in a running app: no database in this environment, and the `RecordIndexPage` story renders an empty table under its msw mocks. The browser-level mechanism is verified and the fix removes the mid-gesture DOM change, but it is worth one pass on a real device before merge.

## Follow-ups not in this PR

- The whole first cell navigates but only the chip-sized part of it gives tap feedback, and `isRecordTableRowActive` is only set on the side panel path — setting it on the navigate path too would keep the row lit while the page loads.
- Rows are 32px against a 44px minimum touch target.
- Giving the side panel a URL would make "panel vs page" a rendering decision on the same location, rather than something each call site has to branch on.


---
_Generated by [Claude Code](https://claude.ai/code/session_019cDWPgWESbdRUhGxGb66j8)_

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/23424?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

