### PR TITLE
fix(connected-account): stop retrying webhook subscriptions on dead credentials

### DIFF
--- a/packages/twenty-server/src/modules/connected-account/connected-account.module.ts
+++ b/packages/twenty-server/src/modules/connected-account/connected-account.module.ts
@@ -6,13 +6,18 @@ import { UserVarsModule } from 'src/engine/core-modules/user/user-vars/user-vars
 import { ConnectedAccountEntity } from 'src/engine/metadata-modules/connected-account/entities/connected-account.entity';
 import { ConnectedAccountListener } from 'src/modules/connected-account/listeners/connected-account.listener';
 import { AccountsToReconnectService } from 'src/modules/connected-account/services/accounts-to-reconnect.service';
+import { ConnectedAccountAuthFailureService } from 'src/modules/connected-account/services/connected-account-auth-failure.service';
 
 @Module({
   imports: [
     TypeOrmModule.forFeature([ConnectedAccountEntity, UserWorkspaceEntity]),
     UserVarsModule,
   ],
-  providers: [AccountsToReconnectService, ConnectedAccountListener],
-  exports: [AccountsToReconnectService],
+  providers: [
+    AccountsToReconnectService,
+    ConnectedAccountAuthFailureService,
+    ConnectedAccountListener,
+  ],
+  exports: [AccountsToReconnectService, ConnectedAccountAuthFailureService],
 })
 export class ConnectedAccountModule {}

--- a/packages/twenty-server/src/modules/connected-account/refresh-tokens-manager/drivers/microsoft/utils/parse-msal-error.util.ts
+++ b/packages/twenty-server/src/modules/connected-account/refresh-tokens-manager/drivers/microsoft/utils/parse-msal-error.util.ts
@@ -3,6 +3,7 @@ import {
   InteractionRequiredAuthError,
   ServerError,
 } from '@azure/msal-node';
+import { isNonEmptyString } from '@sniptt/guards';
 
 import {
   ConnectedAccountRefreshAccessTokenException,
@@ -34,8 +35,10 @@ export const parseMsalError = (
   error: unknown,
 ): ConnectedAccountRefreshAccessTokenException => {
   if (error instanceof InteractionRequiredAuthError) {
+    // The AADSTS code carried by errorMessage/subError is what tells apart a
+    // revoked consent from an expired token or a conditional access policy.
     return new ConnectedAccountRefreshAccessTokenException(
-      `Microsoft token refresh requires re-authentication: ${error.errorCode}`,
+      `Microsoft token refresh requires re-authentication: ${error.errorCode}${isNonEmptyString(error.subError) ? ` (${error.subError})` : ''} - ${error.errorMessage}`,
       ConnectedAccountRefreshAccessTokenExceptionCode.INVALID_REFRESH_TOKEN,
     );
   }

--- a/packages/twenty-server/src/modules/connected-account/services/connected-account-auth-failure.service.ts
+++ b/packages/twenty-server/src/modules/connected-account/services/connected-account-auth-failure.service.ts
@@ -1,0 +1,65 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+
+import { isDefined } from 'twenty-shared/utils';
+import { Repository } from 'typeorm';
+
+import { UserWorkspaceEntity } from 'src/engine/core-modules/user-workspace/user-workspace.entity';
+import { ConnectedAccountEntity } from 'src/engine/metadata-modules/connected-account/entities/connected-account.entity';
+import { AccountsToReconnectService } from 'src/modules/connected-account/services/accounts-to-reconnect.service';
+import { AccountsToReconnectKeys } from 'src/modules/connected-account/types/accounts-to-reconnect-key-value.type';
+
+@Injectable()
+export class ConnectedAccountAuthFailureService {
+  private readonly logger = new Logger(ConnectedAccountAuthFailureService.name);
+
+  constructor(
+    @InjectRepository(ConnectedAccountEntity)
+    private readonly connectedAccountRepository: Repository<ConnectedAccountEntity>,
+    @InjectRepository(UserWorkspaceEntity)
+    private readonly userWorkspaceRepository: Repository<UserWorkspaceEntity>,
+    private readonly accountsToReconnectService: AccountsToReconnectService,
+  ) {}
+
+  async markAuthFailed({
+    connectedAccountId,
+    workspaceId,
+  }: {
+    connectedAccountId: string;
+    workspaceId: string;
+  }): Promise<void> {
+    const connectedAccount = await this.connectedAccountRepository.findOne({
+      where: { id: connectedAccountId, workspaceId },
+      select: ['id', 'userWorkspaceId'],
+    });
+
+    if (!isDefined(connectedAccount)) {
+      return;
+    }
+
+    await this.connectedAccountRepository.update(
+      { id: connectedAccount.id, workspaceId },
+      { authFailedAt: new Date() },
+    );
+
+    const userWorkspace = await this.userWorkspaceRepository.findOne({
+      where: { id: connectedAccount.userWorkspaceId },
+      select: ['userId'],
+    });
+
+    if (!isDefined(userWorkspace)) {
+      return;
+    }
+
+    await this.accountsToReconnectService.addAccountToReconnectByKey(
+      AccountsToReconnectKeys.ACCOUNTS_TO_RECONNECT_INSUFFICIENT_PERMISSIONS,
+      userWorkspace.userId,
+      workspaceId,
+      connectedAccount.id,
+    );
+
+    this.logger.warn(
+      `Connected account ${connectedAccount.id} in workspace ${workspaceId} requires re-authentication`,
+    );
+  }
+}

--- a/packages/twenty-server/src/modules/connected-account/utils/is-connected-account-reauthentication-required-exception.util.ts
+++ b/packages/twenty-server/src/modules/connected-account/utils/is-connected-account-reauthentication-required-exception.util.ts
@@ -1,0 +1,17 @@
+import {
+  ConnectedAccountRefreshAccessTokenException,
+  ConnectedAccountRefreshAccessTokenExceptionCode,
+} from 'src/engine/metadata-modules/connected-account/exceptions/connected-account-refresh-tokens.exception';
+
+// Those codes mean the stored credentials are dead until the user reconnects
+// the account, so retrying the operation can never succeed.
+const REAUTHENTICATION_REQUIRED_CODES: string[] = [
+  ConnectedAccountRefreshAccessTokenExceptionCode.INVALID_REFRESH_TOKEN,
+  ConnectedAccountRefreshAccessTokenExceptionCode.REFRESH_TOKEN_NOT_FOUND,
+];
+
+export const isConnectedAccountReauthenticationRequiredException = (
+  error: unknown,
+): error is ConnectedAccountRefreshAccessTokenException =>
+  error instanceof ConnectedAccountRefreshAccessTokenException &&
+  REAUTHENTICATION_REQUIRED_CODES.includes(error.code);

--- a/packages/twenty-server/src/modules/connected-account/webhook-subscription-manager/crons/jobs/webhook-subscription-renewal.cron.job.ts
+++ b/packages/twenty-server/src/modules/connected-account/webhook-subscription-manager/crons/jobs/webhook-subscription-renewal.cron.job.ts
@@ -6,7 +6,13 @@ import {
   WebhookSubscriptionStatus,
 } from 'twenty-shared/types';
 import { WorkspaceActivationStatus } from 'twenty-shared/workspace';
-import { type FindManyOptions, In, LessThanOrEqual, Repository } from 'typeorm';
+import {
+  type FindManyOptions,
+  In,
+  IsNull,
+  LessThanOrEqual,
+  Repository,
+} from 'typeorm';
 
 import { SentryCronMonitor } from 'src/engine/core-modules/cron/sentry-cron-monitor.decorator';
 import { InjectMessageQueue } from 'src/engine/core-modules/message-queue/decorators/message-queue.decorator';
@@ -94,10 +100,16 @@ export class WebhookSubscriptionRenewalCronJob {
     repository: Repository<TChannel>,
     activeWorkspaceIds: string[],
   ): Promise<StaleChannel[]> {
-    const workspaceScope = { workspaceId: In(activeWorkspaceIds) };
     const renewalThreshold = new Date(
       Date.now() + WEBHOOK_SUBSCRIPTION_RENEWAL_BUFFER_MS,
     );
+
+    // Accounts whose credentials are dead can only be recovered by the user
+    // reconnecting them, so renewing their subscriptions can never succeed.
+    const workspaceScope = {
+      workspaceId: In(activeWorkspaceIds),
+      connectedAccount: { authFailedAt: IsNull() },
+    };
 
     const options: FindManyOptions<WebhookSubscribableChannel> = {
       where: [

--- a/packages/twenty-server/src/modules/connected-account/webhook-subscription-manager/services/__tests__/calendar-webhook-subscription.service.spec.ts
+++ b/packages/twenty-server/src/modules/connected-account/webhook-subscription-manager/services/__tests__/calendar-webhook-subscription.service.spec.ts
@@ -1,0 +1,139 @@
+import { Test, type TestingModule } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+
+import {
+  ConnectedAccountProvider,
+  WebhookSubscriptionStatus,
+} from 'twenty-shared/types';
+
+import { ExceptionHandlerService } from 'src/engine/core-modules/exception-handler/exception-handler.service';
+import { CalendarChannelEntity } from 'src/engine/metadata-modules/calendar-channel/entities/calendar-channel.entity';
+import { ConnectedAccountEntity } from 'src/engine/metadata-modules/connected-account/entities/connected-account.entity';
+import {
+  ConnectedAccountRefreshAccessTokenException,
+  ConnectedAccountRefreshAccessTokenExceptionCode,
+} from 'src/engine/metadata-modules/connected-account/exceptions/connected-account-refresh-tokens.exception';
+import { ConnectedAccountAuthFailureService } from 'src/modules/connected-account/services/connected-account-auth-failure.service';
+import { CalendarWebhookSubscriptionService } from 'src/modules/connected-account/webhook-subscription-manager/services/calendar-webhook-subscription.service';
+import { WebhookSubscriptionDriverFactory } from 'src/modules/connected-account/webhook-subscription-manager/services/webhook-subscription-driver-factory.service';
+
+describe('CalendarWebhookSubscriptionService', () => {
+  let service: CalendarWebhookSubscriptionService;
+  let calendarChannelRepository: { findOne: jest.Mock; update: jest.Mock };
+  let driver: { renewSubscription: jest.Mock; deleteSubscription: jest.Mock };
+  let exceptionHandlerService: { captureExceptions: jest.Mock };
+  let connectedAccountAuthFailureService: { markAuthFailed: jest.Mock };
+
+  const workspaceId = 'workspace-1';
+  const calendarChannelId = 'calendar-channel-1';
+  const connectedAccountId = 'connected-account-1';
+
+  const activeCalendarChannel = {
+    id: calendarChannelId,
+    workspaceId,
+    connectedAccountId,
+    webhookSubscriptionStatus: WebhookSubscriptionStatus.ACTIVE,
+    webhookSubscriptionExternalId: 'external-1',
+    webhookSubscriptionExternalResourceId: null,
+    webhookSubscriptionClientState: 'client-state-1',
+    connectedAccount: {
+      id: connectedAccountId,
+      provider: ConnectedAccountProvider.MICROSOFT,
+    },
+  } as unknown as CalendarChannelEntity;
+
+  beforeEach(async () => {
+    calendarChannelRepository = {
+      findOne: jest.fn().mockResolvedValue(activeCalendarChannel),
+      update: jest.fn().mockResolvedValue(undefined),
+    };
+
+    driver = {
+      renewSubscription: jest.fn(),
+      deleteSubscription: jest.fn().mockResolvedValue(undefined),
+    };
+
+    exceptionHandlerService = { captureExceptions: jest.fn() };
+    connectedAccountAuthFailureService = {
+      markAuthFailed: jest.fn().mockResolvedValue(undefined),
+    };
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        CalendarWebhookSubscriptionService,
+        {
+          provide: getRepositoryToken(CalendarChannelEntity),
+          useValue: calendarChannelRepository,
+        },
+        {
+          provide: getRepositoryToken(ConnectedAccountEntity),
+          useValue: { findOne: jest.fn() },
+        },
+        {
+          provide: WebhookSubscriptionDriverFactory,
+          useValue: {
+            getDriver: jest.fn().mockReturnValue(driver),
+            isProviderSupported: jest.fn().mockReturnValue(true),
+          },
+        },
+        {
+          provide: ExceptionHandlerService,
+          useValue: exceptionHandlerService,
+        },
+        {
+          provide: ConnectedAccountAuthFailureService,
+          useValue: connectedAccountAuthFailureService,
+        },
+      ],
+    }).compile();
+
+    service = module.get(CalendarWebhookSubscriptionService);
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should flag the account for reconnection and stop retrying when the refresh token is invalid', async () => {
+    driver.renewSubscription.mockRejectedValue(
+      new ConnectedAccountRefreshAccessTokenException(
+        'Microsoft token refresh requires re-authentication: invalid_grant',
+        ConnectedAccountRefreshAccessTokenExceptionCode.INVALID_REFRESH_TOKEN,
+      ),
+    );
+
+    await expect(
+      service.renewSubscription({ calendarChannelId, workspaceId }),
+    ).resolves.toBeUndefined();
+
+    expect(calendarChannelRepository.update).toHaveBeenCalledWith(
+      calendarChannelId,
+      { webhookSubscriptionStatus: WebhookSubscriptionStatus.FAILED },
+    );
+    expect(
+      connectedAccountAuthFailureService.markAuthFailed,
+    ).toHaveBeenCalledWith({ connectedAccountId, workspaceId });
+    expect(exceptionHandlerService.captureExceptions).not.toHaveBeenCalled();
+  });
+
+  it('should capture and rethrow when the failure is not an authentication failure', async () => {
+    const error = new Error('Microsoft Graph is unavailable');
+
+    driver.renewSubscription.mockRejectedValue(error);
+
+    await expect(
+      service.renewSubscription({ calendarChannelId, workspaceId }),
+    ).rejects.toThrow(error);
+
+    expect(
+      connectedAccountAuthFailureService.markAuthFailed,
+    ).not.toHaveBeenCalled();
+    expect(exceptionHandlerService.captureExceptions).toHaveBeenCalledWith(
+      [error],
+      {
+        workspace: { id: workspaceId },
+        additionalData: { connectedAccountId, calendarChannelId },
+      },
+    );
+  });
+});

--- a/packages/twenty-server/src/modules/connected-account/webhook-subscription-manager/services/calendar-webhook-subscription.service.ts
+++ b/packages/twenty-server/src/modules/connected-account/webhook-subscription-manager/services/calendar-webhook-subscription.service.ts
@@ -12,6 +12,8 @@ import { v4 } from 'uuid';
 import { ExceptionHandlerService } from 'src/engine/core-modules/exception-handler/exception-handler.service';
 import { CalendarChannelEntity } from 'src/engine/metadata-modules/calendar-channel/entities/calendar-channel.entity';
 import { ConnectedAccountEntity } from 'src/engine/metadata-modules/connected-account/entities/connected-account.entity';
+import { ConnectedAccountAuthFailureService } from 'src/modules/connected-account/services/connected-account-auth-failure.service';
+import { isConnectedAccountReauthenticationRequiredException } from 'src/modules/connected-account/utils/is-connected-account-reauthentication-required-exception.util';
 import { WebhookSubscriptionDriverFactory } from 'src/modules/connected-account/webhook-subscription-manager/services/webhook-subscription-driver-factory.service';
 import { type WebhookSubscriptionContext } from 'src/modules/connected-account/webhook-subscription-manager/types/webhook-subscription-driver.type';
 
@@ -24,6 +26,7 @@ export class CalendarWebhookSubscriptionService {
     private readonly calendarChannelRepository: Repository<CalendarChannelEntity>,
     private readonly webhookSubscriptionDriverFactory: WebhookSubscriptionDriverFactory,
     private readonly exceptionHandlerService: ExceptionHandlerService,
+    private readonly connectedAccountAuthFailureService: ConnectedAccountAuthFailureService,
   ) {}
 
   async createSubscription(
@@ -89,11 +92,14 @@ export class CalendarWebhookSubscriptionService {
         webhookSubscriptionExpiresAt: null,
       });
 
-      this.exceptionHandlerService.captureExceptions([error], {
-        workspace: { id: workspaceId },
+      await this.handleSubscriptionError({
+        error,
+        connectedAccountId: calendarChannel.connectedAccountId,
+        calendarChannelId: calendarChannel.id,
+        workspaceId,
       });
 
-      throw error;
+      return;
     }
 
     if (isDefined(previousSubscription)) {
@@ -154,11 +160,12 @@ export class CalendarWebhookSubscriptionService {
         webhookSubscriptionStatus: WebhookSubscriptionStatus.FAILED,
       });
 
-      this.exceptionHandlerService.captureExceptions([error], {
-        workspace: { id: calendarChannel.workspaceId },
+      await this.handleSubscriptionError({
+        error,
+        connectedAccountId: calendarChannel.connectedAccountId,
+        calendarChannelId: calendarChannel.id,
+        workspaceId: calendarChannel.workspaceId,
       });
-
-      throw error;
     }
   }
 
@@ -192,10 +199,48 @@ export class CalendarWebhookSubscriptionService {
     try {
       await driver.deleteSubscription(this.toContext(calendarChannel));
     } catch (error) {
+      if (isConnectedAccountReauthenticationRequiredException(error)) {
+        return;
+      }
+
       this.exceptionHandlerService.captureExceptions([error], {
         workspace: { id: calendarChannel.workspaceId },
+        additionalData: {
+          connectedAccountId: calendarChannel.connectedAccountId,
+          calendarChannelId: calendarChannel.id,
+        },
       });
     }
+  }
+
+  // A dead refresh token cannot be recovered by retrying: flag the account for
+  // reconnection and swallow the error so the renewal cron stops looping on it.
+  private async handleSubscriptionError({
+    error,
+    connectedAccountId,
+    calendarChannelId,
+    workspaceId,
+  }: {
+    error: unknown;
+    connectedAccountId: string;
+    calendarChannelId: string;
+    workspaceId: string;
+  }): Promise<void> {
+    if (isConnectedAccountReauthenticationRequiredException(error)) {
+      await this.connectedAccountAuthFailureService.markAuthFailed({
+        connectedAccountId,
+        workspaceId,
+      });
+
+      return;
+    }
+
+    this.exceptionHandlerService.captureExceptions([error], {
+      workspace: { id: workspaceId },
+      additionalData: { connectedAccountId, calendarChannelId },
+    });
+
+    throw error;
   }
 
   private toContext(

--- a/packages/twenty-server/src/modules/connected-account/webhook-subscription-manager/services/messaging-webhook-subscription.service.ts
+++ b/packages/twenty-server/src/modules/connected-account/webhook-subscription-manager/services/messaging-webhook-subscription.service.ts
@@ -12,6 +12,8 @@ import { v4 } from 'uuid';
 import { ExceptionHandlerService } from 'src/engine/core-modules/exception-handler/exception-handler.service';
 import { ConnectedAccountEntity } from 'src/engine/metadata-modules/connected-account/entities/connected-account.entity';
 import { MessageChannelEntity } from 'src/engine/metadata-modules/message-channel/entities/message-channel.entity';
+import { ConnectedAccountAuthFailureService } from 'src/modules/connected-account/services/connected-account-auth-failure.service';
+import { isConnectedAccountReauthenticationRequiredException } from 'src/modules/connected-account/utils/is-connected-account-reauthentication-required-exception.util';
 import { WebhookSubscriptionDriverFactory } from 'src/modules/connected-account/webhook-subscription-manager/services/webhook-subscription-driver-factory.service';
 import { type WebhookSubscriptionContext } from 'src/modules/connected-account/webhook-subscription-manager/types/webhook-subscription-driver.type';
 
@@ -24,6 +26,7 @@ export class MessagingWebhookSubscriptionService {
     private readonly messageChannelRepository: Repository<MessageChannelEntity>,
     private readonly webhookSubscriptionDriverFactory: WebhookSubscriptionDriverFactory,
     private readonly exceptionHandlerService: ExceptionHandlerService,
+    private readonly connectedAccountAuthFailureService: ConnectedAccountAuthFailureService,
   ) {}
 
   async createSubscription(
@@ -88,11 +91,14 @@ export class MessagingWebhookSubscriptionService {
         webhookSubscriptionExpiresAt: null,
       });
 
-      this.exceptionHandlerService.captureExceptions([error], {
-        workspace: { id: workspaceId },
+      await this.handleSubscriptionError({
+        error,
+        connectedAccountId: messageChannel.connectedAccountId,
+        messageChannelId: messageChannel.id,
+        workspaceId,
       });
 
-      throw error;
+      return;
     }
 
     if (isDefined(previousSubscription)) {
@@ -152,11 +158,12 @@ export class MessagingWebhookSubscriptionService {
         webhookSubscriptionStatus: WebhookSubscriptionStatus.FAILED,
       });
 
-      this.exceptionHandlerService.captureExceptions([error], {
-        workspace: { id: messageChannel.workspaceId },
+      await this.handleSubscriptionError({
+        error,
+        connectedAccountId: messageChannel.connectedAccountId,
+        messageChannelId: messageChannel.id,
+        workspaceId: messageChannel.workspaceId,
       });
-
-      throw error;
     }
   }
 
@@ -190,10 +197,48 @@ export class MessagingWebhookSubscriptionService {
     try {
       await driver.deleteSubscription(this.toContext(messageChannel));
     } catch (error) {
+      if (isConnectedAccountReauthenticationRequiredException(error)) {
+        return;
+      }
+
       this.exceptionHandlerService.captureExceptions([error], {
         workspace: { id: messageChannel.workspaceId },
+        additionalData: {
+          connectedAccountId: messageChannel.connectedAccountId,
+          messageChannelId: messageChannel.id,
+        },
       });
     }
+  }
+
+  // A dead refresh token cannot be recovered by retrying: flag the account for
+  // reconnection and swallow the error so the renewal cron stops looping on it.
+  private async handleSubscriptionError({
+    error,
+    connectedAccountId,
+    messageChannelId,
+    workspaceId,
+  }: {
+    error: unknown;
+    connectedAccountId: string;
+    messageChannelId: string;
+    workspaceId: string;
+  }): Promise<void> {
+    if (isConnectedAccountReauthenticationRequiredException(error)) {
+      await this.connectedAccountAuthFailureService.markAuthFailed({
+        connectedAccountId,
+        workspaceId,
+      });
+
+      return;
+    }
+
+    this.exceptionHandlerService.captureExceptions([error], {
+      workspace: { id: workspaceId },
+      additionalData: { connectedAccountId, messageChannelId },
+    });
+
+    throw error;
   }
 
   private toContext(

--- a/packages/twenty-server/src/modules/connected-account/webhook-subscription-manager/webhook-subscription.module.ts
+++ b/packages/twenty-server/src/modules/connected-account/webhook-subscription-manager/webhook-subscription.module.ts
@@ -7,6 +7,7 @@ import { WorkspaceEntity } from 'src/engine/core-modules/workspace/workspace.ent
 import { ConnectedAccountEntity } from 'src/engine/metadata-modules/connected-account/entities/connected-account.entity';
 import { CalendarChannelEntity } from 'src/engine/metadata-modules/calendar-channel/entities/calendar-channel.entity';
 import { MessageChannelEntity } from 'src/engine/metadata-modules/message-channel/entities/message-channel.entity';
+import { ConnectedAccountModule } from 'src/modules/connected-account/connected-account.module';
 import { CreateWebhookSubscriptionForConnectedAccountCommand } from 'src/modules/connected-account/webhook-subscription-manager/commands/create-webhook-subscription-for-connected-account.command';
 import { WebhookSubscriptionRenewalCronCommand } from 'src/modules/connected-account/webhook-subscription-manager/crons/commands/webhook-subscription-renewal.cron.command';
 import { CreateWebhookSubscriptionJob } from 'src/modules/connected-account/webhook-subscription-manager/jobs/create-webhook-subscription.job';
@@ -20,6 +21,7 @@ import { WebhookSubscriptionManagerModule } from 'src/modules/connected-account/
 @Module({
   imports: [
     WebhookSubscriptionManagerModule,
+    ConnectedAccountModule,
     FeatureFlagModule,
     WorkspaceIteratorModule,
     TypeOrmModule.forFeature([


### PR DESCRIPTION
## Context

Production workers log this on repeat:

```
Error: Microsoft token refresh requires re-authentication: invalid_grant
    at parseMsalError (.../parse-msal-error.util.js:32:16)
    ...
    at async CalendarWebhookSubscriptionService.renewSubscription
    at async RenewWebhookSubscriptionJob.handle
```

`invalid_grant` means the stored refresh token is dead at Entra ID (password change, revoked consent, 90 days of inactivity, a conditional access policy, or a lost rotated token), so it can only be recovered by the user reconnecting the account.

The renewal path treated it as retryable: `createSubscription`/`renewSubscription` marked the channel `FAILED`, captured the exception and rethrew, the job retried 3 times (`retryLimit: 3`), and the hourly cron re-selected the same `FAILED` channel on every run. One broken account therefore produced the same Sentry error ~4 times an hour, forever, and nothing ever told the user to reconnect. The import path already handles this case (`CalendarEventImportErrorHandlerService` flags `authFailedAt` + accounts to reconnect); the webhook path did not.

## Changes

- `ConnectedAccountAuthFailureService`: sets `authFailedAt` on the connected account and adds it to `ACCOUNTS_TO_RECONNECT_INSUFFICIENT_PERMISSIONS` so the user is prompted to reconnect.
- Calendar and messaging webhook subscription services: `INVALID_REFRESH_TOKEN` / `REFRESH_TOKEN_NOT_FOUND` are now terminal. The channel is still marked `FAILED`, the account is flagged, and the error is swallowed instead of being captured and rethrown, so the job does not retry. Every other failure keeps the previous capture-and-rethrow behavior.
- `WebhookSubscriptionRenewalCronJob` skips channels whose connected account has `authFailedAt` set. Reconnecting clears `authFailedAt`, so renewals resume on their own.
- `parseMsalError` keeps `errorMessage` and `subError` on the `InteractionRequiredAuthError` branch, so the AADSTS code that distinguishes a revoked consent from an expired token reaches Sentry.
- Sentry captures from the webhook path now carry `connectedAccountId` and the channel id.

Not addressed here: `ConnectedAccountRefreshTokensService` has no per-account lock, so concurrent refreshes of the same account can race on Microsoft's rotating refresh tokens (single-use for personal accounts). That is likely producing some of these `invalid_grant`s rather than only reporting them, and deserves its own PR.

## Test

- New unit test on `CalendarWebhookSubscriptionService.renewSubscription`: an invalid refresh token flags the account and resolves without capturing; any other error is still captured and rethrown.
- `npx jest src/modules/connected-account` passes (9 suites, 54 tests).
- `npx nx typecheck twenty-server` reports only a pre-existing failure in `agent-async-executor.service.spec.ts`, unrelated to this change.
- oxlint + oxfmt clean on the changed files.

---
_Generated by [Claude Code](https://claude.ai/code/session_0178YJig4KvDMQ2k98DngTZx)_

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/23427?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

