### PR TITLE
feat(workspace-migration): report divergences on non-updatable flat entity properties

### DIFF
--- a/packages/twenty-server/src/engine/core-modules/application/application-manifest/utils/build-all-flat-entity-operation-record-by-metadata-name-from-from-to.util.ts
+++ b/packages/twenty-server/src/engine/core-modules/application/application-manifest/utils/build-all-flat-entity-operation-record-by-metadata-name-from-from-to.util.ts
@@ -78,13 +78,13 @@ const buildFlatEntityOperationRecordForMetadata = <T extends AllMetadataName>({
         return undefined;
       }
 
-      const update = compareTwoFlatEntity({
+      const comparisonResult = compareTwoFlatEntity({
         fromUniversalFlatEntity: fromFlatEntity,
         toUniversalFlatEntity: toFlatEntity,
         metadataName,
       });
 
-      return isDefined(update) ? toFlatEntity : undefined;
+      return isDefined(comparisonResult) ? toFlatEntity : undefined;
     })
     .filter(isDefined);
 

--- a/packages/twenty-server/src/engine/metadata-modules/flat-entity/constant/__tests__/__snapshots__/all-universal-flat-entity-properties-to-compare-and-stringify.constant.spec.ts.snap
+++ b/packages/twenty-server/src/engine/metadata-modules/flat-entity/constant/__tests__/__snapshots__/all-universal-flat-entity-properties-to-compare-and-stringify.constant.spec.ts.snap
@@ -14,6 +14,7 @@ exports[`ALL_UNIVERSAL_FLAT_ENTITY_PROPERTIES_TO_COMPARE_AND_STRINGIFY should ma
       "modelConfiguration",
       "evaluationInputs",
     ],
+    "propertiesToReportDivergence": [],
     "propertiesToStringify": [
       "responseFormat",
       "modelConfiguration",
@@ -28,6 +29,7 @@ exports[`ALL_UNIVERSAL_FLAT_ENTITY_PROPERTIES_TO_COMPARE_AND_STRINGIFY should ma
       "type",
       "options",
     ],
+    "propertiesToReportDivergence": [],
     "propertiesToStringify": [
       "options",
     ],
@@ -48,6 +50,9 @@ exports[`ALL_UNIVERSAL_FLAT_ENTITY_PROPERTIES_TO_COMPARE_AND_STRINGIFY should ma
       "isActive",
       "universalOverrides",
     ],
+    "propertiesToReportDivergence": [
+      "pageLayoutUniversalIdentifier",
+    ],
     "propertiesToStringify": [
       "payload",
       "hotKeys",
@@ -62,6 +67,7 @@ exports[`ALL_UNIVERSAL_FLAT_ENTITY_PROPERTIES_TO_COMPARE_AND_STRINGIFY should ma
       "oauthConfig",
       "onConnectLogicFunctionUniversalIdentifier",
     ],
+    "propertiesToReportDivergence": [],
     "propertiesToStringify": [
       "oauthConfig",
     ],
@@ -82,6 +88,7 @@ exports[`ALL_UNIVERSAL_FLAT_ENTITY_PROPERTIES_TO_COMPARE_AND_STRINGIFY should ma
       "isUIEditable",
       "isNullable",
     ],
+    "propertiesToReportDivergence": [],
     "propertiesToStringify": [
       "defaultValue",
       "options",
@@ -97,6 +104,7 @@ exports[`ALL_UNIVERSAL_FLAT_ENTITY_PROPERTIES_TO_COMPARE_AND_STRINGIFY should ma
       "canReadFieldValue",
       "canUpdateFieldValue",
     ],
+    "propertiesToReportDivergence": [],
     "propertiesToStringify": [],
   },
   "frontComponent": {
@@ -110,6 +118,7 @@ exports[`ALL_UNIVERSAL_FLAT_ENTITY_PROPERTIES_TO_COMPARE_AND_STRINGIFY should ma
       "isHeadless",
       "usesSdkClient",
     ],
+    "propertiesToReportDivergence": [],
     "propertiesToStringify": [],
   },
   "index": {
@@ -120,6 +129,7 @@ exports[`ALL_UNIVERSAL_FLAT_ENTITY_PROPERTIES_TO_COMPARE_AND_STRINGIFY should ma
       "name",
       "universalFlatIndexFieldMetadatas",
     ],
+    "propertiesToReportDivergence": [],
     "propertiesToStringify": [
       "universalFlatIndexFieldMetadatas",
     ],
@@ -143,6 +153,7 @@ exports[`ALL_UNIVERSAL_FLAT_ENTITY_PROPERTIES_TO_COMPARE_AND_STRINGIFY should ma
       "workflowActionTriggerSettings",
       "builtHandlerPath",
     ],
+    "propertiesToReportDivergence": [],
     "propertiesToStringify": [
       "cronTriggerSettings",
       "databaseEventTriggerSettings",
@@ -161,6 +172,9 @@ exports[`ALL_UNIVERSAL_FLAT_ENTITY_PROPERTIES_TO_COMPARE_AND_STRINGIFY should ma
       "link",
       "icon",
       "color",
+    ],
+    "propertiesToReportDivergence": [
+      "pageLayoutUniversalIdentifier",
     ],
     "propertiesToStringify": [],
   },
@@ -182,6 +196,7 @@ exports[`ALL_UNIVERSAL_FLAT_ENTITY_PROPERTIES_TO_COMPARE_AND_STRINGIFY should ma
       "isSearchable",
       "imageIdentifierFieldMetadataUniversalIdentifier",
     ],
+    "propertiesToReportDivergence": [],
     "propertiesToStringify": [
       "overrides",
     ],
@@ -195,6 +210,7 @@ exports[`ALL_UNIVERSAL_FLAT_ENTITY_PROPERTIES_TO_COMPARE_AND_STRINGIFY should ma
       "canSoftDeleteObjectRecords",
       "canDestroyObjectRecords",
     ],
+    "propertiesToReportDivergence": [],
     "propertiesToStringify": [],
   },
   "pageLayout": {
@@ -205,6 +221,7 @@ exports[`ALL_UNIVERSAL_FLAT_ENTITY_PROPERTIES_TO_COMPARE_AND_STRINGIFY should ma
       "defaultTabToFocusOnMobileAndSidePanelUniversalIdentifier",
       "deletedAt",
     ],
+    "propertiesToReportDivergence": [],
     "propertiesToStringify": [],
   },
   "pageLayoutTab": {
@@ -215,6 +232,10 @@ exports[`ALL_UNIVERSAL_FLAT_ENTITY_PROPERTIES_TO_COMPARE_AND_STRINGIFY should ma
       "icon",
       "isActive",
       "overrides",
+    ],
+    "propertiesToReportDivergence": [
+      "pageLayoutUniversalIdentifier",
+      "layoutMode",
     ],
     "propertiesToStringify": [
       "overrides",
@@ -235,6 +256,7 @@ exports[`ALL_UNIVERSAL_FLAT_ENTITY_PROPERTIES_TO_COMPARE_AND_STRINGIFY should ma
       "isActive",
       "universalOverrides",
     ],
+    "propertiesToReportDivergence": [],
     "propertiesToStringify": [
       "gridPosition",
       "position",
@@ -251,6 +273,7 @@ exports[`ALL_UNIVERSAL_FLAT_ENTITY_PROPERTIES_TO_COMPARE_AND_STRINGIFY should ma
       "icon",
       "permissionType",
     ],
+    "propertiesToReportDivergence": [],
     "propertiesToStringify": [],
   },
   "role": {
@@ -268,6 +291,7 @@ exports[`ALL_UNIVERSAL_FLAT_ENTITY_PROPERTIES_TO_COMPARE_AND_STRINGIFY should ma
       "canBeAssignedToAgents",
       "canBeAssignedToApiKeys",
     ],
+    "propertiesToReportDivergence": [],
     "propertiesToStringify": [],
   },
   "rolePermissionFlag": {
@@ -275,6 +299,7 @@ exports[`ALL_UNIVERSAL_FLAT_ENTITY_PROPERTIES_TO_COMPARE_AND_STRINGIFY should ma
       "permissionFlagUniversalIdentifier",
       "roleUniversalIdentifier",
     ],
+    "propertiesToReportDivergence": [],
     "propertiesToStringify": [],
   },
   "roleTarget": {
@@ -284,6 +309,7 @@ exports[`ALL_UNIVERSAL_FLAT_ENTITY_PROPERTIES_TO_COMPARE_AND_STRINGIFY should ma
       "apiKeyId",
       "agentUniversalIdentifier",
     ],
+    "propertiesToReportDivergence": [],
     "propertiesToStringify": [],
   },
   "rowLevelPermissionPredicate": {
@@ -298,6 +324,7 @@ exports[`ALL_UNIVERSAL_FLAT_ENTITY_PROPERTIES_TO_COMPARE_AND_STRINGIFY should ma
       "workspaceMemberSubFieldName",
       "deletedAt",
     ],
+    "propertiesToReportDivergence": [],
     "propertiesToStringify": [
       "value",
     ],
@@ -309,12 +336,14 @@ exports[`ALL_UNIVERSAL_FLAT_ENTITY_PROPERTIES_TO_COMPARE_AND_STRINGIFY should ma
       "parentRowLevelPermissionPredicateGroupUniversalIdentifier",
       "deletedAt",
     ],
+    "propertiesToReportDivergence": [],
     "propertiesToStringify": [],
   },
   "searchFieldMetadata": {
     "propertiesToCompare": [
       "position",
     ],
+    "propertiesToReportDivergence": [],
     "propertiesToStringify": [],
   },
   "skill": {
@@ -326,6 +355,7 @@ exports[`ALL_UNIVERSAL_FLAT_ENTITY_PROPERTIES_TO_COMPARE_AND_STRINGIFY should ma
       "content",
       "isActive",
     ],
+    "propertiesToReportDivergence": [],
     "propertiesToStringify": [],
   },
   "view": {
@@ -352,6 +382,7 @@ exports[`ALL_UNIVERSAL_FLAT_ENTITY_PROPERTIES_TO_COMPARE_AND_STRINGIFY should ma
       "isActive",
       "universalOverrides",
     ],
+    "propertiesToReportDivergence": [],
     "propertiesToStringify": [
       "universalOverrides",
     ],
@@ -368,6 +399,7 @@ exports[`ALL_UNIVERSAL_FLAT_ENTITY_PROPERTIES_TO_COMPARE_AND_STRINGIFY should ma
       "isActive",
       "universalOverrides",
     ],
+    "propertiesToReportDivergence": [],
     "propertiesToStringify": [
       "universalOverrides",
     ],
@@ -382,6 +414,7 @@ exports[`ALL_UNIVERSAL_FLAT_ENTITY_PROPERTIES_TO_COMPARE_AND_STRINGIFY should ma
       "viewUniversalIdentifier",
       "overrides",
     ],
+    "propertiesToReportDivergence": [],
     "propertiesToStringify": [
       "overrides",
     ],
@@ -398,6 +431,7 @@ exports[`ALL_UNIVERSAL_FLAT_ENTITY_PROPERTIES_TO_COMPARE_AND_STRINGIFY should ma
       "subFieldName",
       "relationTargetFieldMetadataUniversalIdentifier",
     ],
+    "propertiesToReportDivergence": [],
     "propertiesToStringify": [
       "value",
     ],
@@ -410,6 +444,7 @@ exports[`ALL_UNIVERSAL_FLAT_ENTITY_PROPERTIES_TO_COMPARE_AND_STRINGIFY should ma
       "logicalOperator",
       "positionInViewFilterGroup",
     ],
+    "propertiesToReportDivergence": [],
     "propertiesToStringify": [],
   },
   "viewGroup": {
@@ -420,6 +455,7 @@ exports[`ALL_UNIVERSAL_FLAT_ENTITY_PROPERTIES_TO_COMPARE_AND_STRINGIFY should ma
       "deletedAt",
       "viewUniversalIdentifier",
     ],
+    "propertiesToReportDivergence": [],
     "propertiesToStringify": [],
   },
   "viewSort": {
@@ -430,6 +466,7 @@ exports[`ALL_UNIVERSAL_FLAT_ENTITY_PROPERTIES_TO_COMPARE_AND_STRINGIFY should ma
       "viewUniversalIdentifier",
       "deletedAt",
     ],
+    "propertiesToReportDivergence": [],
     "propertiesToStringify": [],
   },
   "webhook": {
@@ -439,6 +476,7 @@ exports[`ALL_UNIVERSAL_FLAT_ENTITY_PROPERTIES_TO_COMPARE_AND_STRINGIFY should ma
       "description",
       "secret",
     ],
+    "propertiesToReportDivergence": [],
     "propertiesToStringify": [
       "operations",
     ],

--- a/packages/twenty-server/src/engine/metadata-modules/flat-entity/constant/all-entity-properties-configuration-by-metadata-name.constant.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/flat-entity/constant/all-entity-properties-configuration-by-metadata-name.constant.ts
@@ -38,10 +38,17 @@ type MetadataEntityPropertyConfiguration<
               UnwrapWasRemovedInUpgrade<MetadataEntity<TMetadataName>[K]>
             >
         : boolean;
-    toCompare: boolean;
     isOverridable?: boolean;
     translatable?: boolean;
-  };
+  } & (
+    | { toCompare: true }
+    // toReportDivergence guards non-comparable properties that input surfaces
+    // (DTO editable properties, manifest shapes) still accept: instead of the
+    // builder silently stripping a changed value, the update fails validation.
+    // Non-comparable properties without it keep diverging silently, as many
+    // sync converters emit placeholder values for them by design.
+    | { toCompare: false; toReportDivergence?: true }
+  );
 };
 
 export const ALL_ENTITY_PROPERTIES_CONFIGURATION_BY_METADATA_NAME = {
@@ -1112,11 +1119,13 @@ export const ALL_ENTITY_PROPERTIES_CONFIGURATION_BY_METADATA_NAME = {
     },
     pageLayoutId: {
       toCompare: false,
+      toReportDivergence: true,
       toStringify: false,
       universalProperty: 'pageLayoutUniversalIdentifier',
     },
     layoutMode: {
       toCompare: false,
+      toReportDivergence: true,
       toStringify: false,
       universalProperty: undefined,
     },
@@ -1263,6 +1272,7 @@ export const ALL_ENTITY_PROPERTIES_CONFIGURATION_BY_METADATA_NAME = {
     },
     pageLayoutId: {
       toCompare: false,
+      toReportDivergence: true,
       toStringify: false,
       universalProperty: 'pageLayoutUniversalIdentifier',
       isOverridable: true,
@@ -1335,6 +1345,7 @@ export const ALL_ENTITY_PROPERTIES_CONFIGURATION_BY_METADATA_NAME = {
     },
     pageLayoutId: {
       toCompare: false,
+      toReportDivergence: true,
       toStringify: false,
       universalProperty: 'pageLayoutUniversalIdentifier',
     },
@@ -1888,3 +1899,18 @@ export type MetadataEntityTranslatablePropertyName<T extends AllMetadataName> =
   FilterTranslatableKeys<
     (typeof ALL_ENTITY_PROPERTIES_CONFIGURATION_BY_METADATA_NAME)[T]
   >;
+
+type FilterDivergenceReportedKeys<TConfig> = {
+  [P in keyof TConfig]: TConfig[P] extends {
+    toCompare: false;
+    toReportDivergence: true;
+  }
+    ? P
+    : never;
+}[keyof TConfig];
+
+export type MetadataEntityDivergenceReportedPropertyName<
+  T extends AllMetadataName,
+> = FilterDivergenceReportedKeys<
+  (typeof ALL_ENTITY_PROPERTIES_CONFIGURATION_BY_METADATA_NAME)[T]
+>;

--- a/packages/twenty-server/src/engine/metadata-modules/flat-entity/constant/all-universal-flat-entity-properties-to-compare-and-stringify.constant.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/flat-entity/constant/all-universal-flat-entity-properties-to-compare-and-stringify.constant.ts
@@ -6,12 +6,14 @@ import {
 import { ALL_ENTITY_PROPERTIES_CONFIGURATION_BY_METADATA_NAME } from 'src/engine/metadata-modules/flat-entity/constant/all-entity-properties-configuration-by-metadata-name.constant';
 import { type MetadataFlatEntity } from 'src/engine/metadata-modules/flat-entity/types/metadata-flat-entity.type';
 import { type MetadataUniversalFlatEntityPropertiesToCompare } from 'src/engine/workspace-manager/workspace-migration/universal-flat-entity/types/metadata-universal-flat-entity-properties-to-compare.type';
+import { type MetadataUniversalFlatEntityPropertiesToReportDivergence } from 'src/engine/workspace-manager/workspace-migration/universal-flat-entity/types/metadata-universal-flat-entity-properties-to-report-divergence.type';
 import { type MetadataUniversalFlatEntityPropertiesToStringify } from 'src/engine/workspace-manager/workspace-migration/universal-flat-entity/types/metadata-universal-flat-entity-properties-to-stringify.type';
 
 type PropertyConfiguration = {
   universalProperty: string | undefined;
   toStringify: boolean;
   toCompare: boolean;
+  toReportDivergence?: boolean;
 };
 
 // TODO remove once https://github.com/twentyhq/core-team-issues/issues/2227 has been resolved
@@ -34,6 +36,7 @@ type UniversalFlatEntityPropertiesToCompareAndStringify<
 > = {
   propertiesToCompare: MetadataUniversalFlatEntityPropertiesToCompare<T>[];
   propertiesToStringify: MetadataUniversalFlatEntityPropertiesToStringify<T>[];
+  propertiesToReportDivergence: MetadataUniversalFlatEntityPropertiesToReportDivergence<T>[];
 };
 const computeUniversalFlatEntityPropertiesToCompareAndStringify = <
   T extends AllMetadataName,
@@ -50,10 +53,17 @@ const computeUniversalFlatEntityPropertiesToCompareAndStringify = <
   const accumulator: UniversalFlatEntityPropertiesToCompareAndStringify<T> = {
     propertiesToCompare: [],
     propertiesToStringify: [],
+    propertiesToReportDivergence: [],
   };
 
   for (const [property, configuration] of entries) {
     if (!configuration.toCompare) {
+      if (configuration.toReportDivergence === true) {
+        accumulator.propertiesToReportDivergence.push(
+          (configuration.universalProperty ??
+            property) as MetadataUniversalFlatEntityPropertiesToReportDivergence<T>,
+        );
+      }
       continue;
     }
 

--- a/packages/twenty-server/src/engine/workspace-manager/workspace-migration/universal-flat-entity/types/metadata-universal-flat-entity-properties-to-report-divergence.type.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/workspace-migration/universal-flat-entity/types/metadata-universal-flat-entity-properties-to-report-divergence.type.ts
@@ -1,0 +1,25 @@
+import { type AllMetadataName } from 'twenty-shared/metadata';
+
+import {
+  type ALL_ENTITY_PROPERTIES_CONFIGURATION_BY_METADATA_NAME,
+  type MetadataEntityDivergenceReportedPropertyName,
+} from 'src/engine/metadata-modules/flat-entity/constant/all-entity-properties-configuration-by-metadata-name.constant';
+import { type MetadataUniversalFlatEntity } from 'src/engine/metadata-modules/flat-entity/types/metadata-universal-flat-entity.type';
+
+type ExtractUniversalProperty<
+  MetadataConfig,
+  P extends keyof MetadataConfig,
+> = MetadataConfig[P] extends { universalProperty: string }
+  ? MetadataConfig[P]['universalProperty']
+  : P;
+
+export type MetadataUniversalFlatEntityPropertiesToReportDivergence<
+  T extends AllMetadataName,
+  MetadataConfig =
+    (typeof ALL_ENTITY_PROPERTIES_CONFIGURATION_BY_METADATA_NAME)[T],
+  TDivergenceReportedKeys extends keyof MetadataConfig =
+    MetadataEntityDivergenceReportedPropertyName<T> & keyof MetadataConfig,
+> = {
+  [P in TDivergenceReportedKeys]: ExtractUniversalProperty<MetadataConfig, P>;
+}[TDivergenceReportedKeys] &
+  keyof MetadataUniversalFlatEntity<T>;

--- a/packages/twenty-server/src/engine/workspace-manager/workspace-migration/universal-flat-entity/types/universal-flat-entity-property-divergence.type.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/workspace-migration/universal-flat-entity/types/universal-flat-entity-property-divergence.type.ts
@@ -1,0 +1,8 @@
+import { type AllMetadataName } from 'twenty-shared/metadata';
+import { type FromTo } from 'twenty-shared/types';
+
+import { type MetadataUniversalFlatEntityPropertiesToReportDivergence } from 'src/engine/workspace-manager/workspace-migration/universal-flat-entity/types/metadata-universal-flat-entity-properties-to-report-divergence.type';
+
+export type UniversalFlatEntityPropertyDivergence<T extends AllMetadataName> = {
+  property: MetadataUniversalFlatEntityPropertiesToReportDivergence<T>;
+} & FromTo<unknown, 'value'>;

--- a/packages/twenty-server/src/engine/workspace-manager/workspace-migration/universal-flat-entity/utils/__tests__/__snapshots__/compare-two-universal-flat-entity.util.spec.ts.snap
+++ b/packages/twenty-server/src/engine/workspace-manager/workspace-migration/universal-flat-entity/utils/__tests__/__snapshots__/compare-two-universal-flat-entity.util.spec.ts.snap
@@ -1,13 +1,19 @@
-// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
+// Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`compareTwoFlatEntity It should detect flat field metadata isActive diff from true to false 1`] = `
 {
-  "isActive": false,
+  "nonUpdatablePropertyDivergences": [],
+  "update": {
+    "isActive": false,
+  },
 }
 `;
 
 exports[`compareTwoFlatEntity It should detect flat field metadata isActive diff from true to false 2`] = `
 {
-  "isActive": true,
+  "nonUpdatablePropertyDivergences": [],
+  "update": {
+    "isActive": true,
+  },
 }
 `;

--- a/packages/twenty-server/src/engine/workspace-manager/workspace-migration/universal-flat-entity/utils/__tests__/__snapshots__/universal-flat-entity-deleted-created-updated-matrix-dispatcher.util.spec.ts.snap
+++ b/packages/twenty-server/src/engine/workspace-manager/workspace-migration/universal-flat-entity/utils/__tests__/__snapshots__/universal-flat-entity-deleted-created-updated-matrix-dispatcher.util.spec.ts.snap
@@ -143,6 +143,7 @@ exports[`flatEntityDeletedCreatedUpdatedMatrixDispatcher It should detect an upd
   "updatedFlatEntityMaps": {
     "byUniversalIdentifier": {
       "universal-identifier-1": {
+        "nonUpdatablePropertyDivergences": [],
         "update": {
           "isActive": true,
         },
@@ -267,6 +268,7 @@ exports[`flatEntityDeletedCreatedUpdatedMatrixDispatcher It should detect create
   "updatedFlatEntityMaps": {
     "byUniversalIdentifier": {
       "universal-identifier-1": {
+        "nonUpdatablePropertyDivergences": [],
         "update": {
           "isActive": false,
         },

--- a/packages/twenty-server/src/engine/workspace-manager/workspace-migration/universal-flat-entity/utils/__tests__/compare-two-universal-flat-entity.util.spec.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/workspace-migration/universal-flat-entity/utils/__tests__/compare-two-universal-flat-entity.util.spec.ts
@@ -4,11 +4,36 @@ import {
   eachTestingContextFilter,
   type EachTestingContext,
 } from 'twenty-shared/testing';
-import { FieldMetadataType, type FromTo } from 'twenty-shared/types';
+import {
+  FieldMetadataType,
+  type FromTo,
+  PageLayoutTabLayoutMode,
+} from 'twenty-shared/types';
 
 import { type MetadataUniversalFlatEntity } from 'src/engine/metadata-modules/flat-entity/types/metadata-universal-flat-entity.type';
 import { getFlatFieldMetadataMock } from 'src/engine/metadata-modules/flat-field-metadata/__mocks__/get-flat-field-metadata.mock';
+import { type UniversalFlatPageLayoutTab } from 'src/engine/workspace-manager/workspace-migration/universal-flat-entity/types/universal-flat-page-layout-tab.type';
 import { compareTwoFlatEntity } from 'src/engine/workspace-manager/workspace-migration/universal-flat-entity/utils/compare-two-universal-flat-entity.util';
+
+const getUniversalFlatPageLayoutTabMock = (
+  overrides: Partial<UniversalFlatPageLayoutTab>,
+): UniversalFlatPageLayoutTab => ({
+  universalIdentifier: 'page-layout-tab-universal-identifier',
+  applicationUniversalIdentifier: 'application-universal-identifier',
+  title: 'Tab title',
+  position: 0,
+  pageLayoutUniversalIdentifier: 'page-layout-universal-identifier',
+  icon: null,
+  layoutMode: PageLayoutTabLayoutMode.GRID,
+  isActive: true,
+  isSystemSideEffect: false,
+  widgetUniversalIdentifiers: [],
+  createdAt: '2024-01-01T00:00:00.000Z',
+  updatedAt: '2024-01-01T00:00:00.000Z',
+  deletedAt: null,
+  overrides: null,
+  ...overrides,
+});
 
 type TestContext<T extends AllMetadataName = AllMetadataName> = FromTo<
   MetadataUniversalFlatEntity<T>,
@@ -73,4 +98,100 @@ describe('compareTwoFlatEntity', () => {
       );
     },
   );
+
+  describe('non updatable property divergence reporting', () => {
+    it('should report a divergence when only layoutMode differs on pageLayoutTab', () => {
+      const result = compareTwoFlatEntity({
+        fromUniversalFlatEntity: getUniversalFlatPageLayoutTabMock({}),
+        toUniversalFlatEntity: getUniversalFlatPageLayoutTabMock({
+          layoutMode: PageLayoutTabLayoutMode.VERTICAL_LIST,
+        }),
+        metadataName: 'pageLayoutTab',
+      });
+
+      expect(result).toEqual({
+        update: {},
+        nonUpdatablePropertyDivergences: [
+          {
+            property: 'layoutMode',
+            fromValue: PageLayoutTabLayoutMode.GRID,
+            toValue: PageLayoutTabLayoutMode.VERTICAL_LIST,
+          },
+        ],
+      });
+    });
+
+    it('should report a divergence alongside a comparable property update', () => {
+      const result = compareTwoFlatEntity({
+        fromUniversalFlatEntity: getUniversalFlatPageLayoutTabMock({}),
+        toUniversalFlatEntity: getUniversalFlatPageLayoutTabMock({
+          title: 'Renamed tab title',
+          layoutMode: PageLayoutTabLayoutMode.VERTICAL_LIST,
+        }),
+        metadataName: 'pageLayoutTab',
+      });
+
+      expect(result).toEqual({
+        update: { title: 'Renamed tab title' },
+        nonUpdatablePropertyDivergences: [
+          {
+            property: 'layoutMode',
+            fromValue: PageLayoutTabLayoutMode.GRID,
+            toValue: PageLayoutTabLayoutMode.VERTICAL_LIST,
+          },
+        ],
+      });
+    });
+
+    it('should report a divergence when pageLayoutUniversalIdentifier differs on pageLayoutTab', () => {
+      const result = compareTwoFlatEntity({
+        fromUniversalFlatEntity: getUniversalFlatPageLayoutTabMock({}),
+        toUniversalFlatEntity: getUniversalFlatPageLayoutTabMock({
+          pageLayoutUniversalIdentifier:
+            'another-page-layout-universal-identifier',
+        }),
+        metadataName: 'pageLayoutTab',
+      });
+
+      expect(result).toEqual({
+        update: {},
+        nonUpdatablePropertyDivergences: [
+          {
+            property: 'pageLayoutUniversalIdentifier',
+            fromValue: 'page-layout-universal-identifier',
+            toValue: 'another-page-layout-universal-identifier',
+          },
+        ],
+      });
+    });
+
+    it('should return undefined when only silently ignored non-comparable properties differ', () => {
+      const result = compareTwoFlatEntity({
+        fromUniversalFlatEntity: getUniversalFlatPageLayoutTabMock({}),
+        toUniversalFlatEntity: getUniversalFlatPageLayoutTabMock({
+          createdAt: '2025-01-01T00:00:00.000Z',
+          updatedAt: '2025-01-01T00:00:00.000Z',
+          isSystemSideEffect: true,
+        }),
+        metadataName: 'pageLayoutTab',
+      });
+
+      expect(result).toBeUndefined();
+    });
+
+    it('should not report any divergence when only comparable properties differ', () => {
+      const result = compareTwoFlatEntity({
+        fromUniversalFlatEntity: getUniversalFlatPageLayoutTabMock({}),
+        toUniversalFlatEntity: getUniversalFlatPageLayoutTabMock({
+          title: 'Renamed tab title',
+        }),
+        metadataName: 'pageLayoutTab',
+      });
+
+      expect(result).toEqual({
+        update: { title: 'Renamed tab title' },
+        nonUpdatablePropertyDivergences: [],
+      });
+    });
+  });
 });

--- a/packages/twenty-server/src/engine/workspace-manager/workspace-migration/universal-flat-entity/utils/compare-two-universal-flat-entity.util.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/workspace-migration/universal-flat-entity/utils/compare-two-universal-flat-entity.util.ts
@@ -5,7 +5,9 @@ import { parseJson } from 'twenty-shared/utils';
 
 import { ALL_UNIVERSAL_FLAT_ENTITY_PROPERTIES_TO_COMPARE_AND_STRINGIFY } from 'src/engine/metadata-modules/flat-entity/constant/all-universal-flat-entity-properties-to-compare-and-stringify.constant';
 import { type MetadataUniversalFlatEntity } from 'src/engine/metadata-modules/flat-entity/types/metadata-universal-flat-entity.type';
+import { orderObjectProperties } from 'src/engine/metadata-modules/flat-entity/utils/order-object-properties.util';
 import { type MetadataUniversalFlatEntityPropertiesToStringify } from 'src/engine/workspace-manager/workspace-migration/universal-flat-entity/types/metadata-universal-flat-entity-properties-to-stringify.type';
+import { type UniversalFlatEntityPropertyDivergence } from 'src/engine/workspace-manager/workspace-migration/universal-flat-entity/types/universal-flat-entity-property-divergence.type';
 import { type UniversalFlatEntityUpdate } from 'src/engine/workspace-manager/workspace-migration/universal-flat-entity/types/universal-flat-entity-update.type';
 import { transformUniversalFlatEntityForComparison } from 'src/engine/workspace-manager/workspace-migration/universal-flat-entity/utils/transform-universal-flat-entity-for-comparison.util';
 
@@ -14,14 +16,28 @@ type CompareTwoUniversalFlatEntityArgs<T extends AllMetadataName> = FromTo<
   'universalFlatEntity'
 > & { metadataName: T };
 
+export type CompareTwoUniversalFlatEntityResult<T extends AllMetadataName> = {
+  update: UniversalFlatEntityUpdate<T>;
+  nonUpdatablePropertyDivergences: UniversalFlatEntityPropertyDivergence<T>[];
+};
+
+const normalizeValueForComparison = (value: unknown): unknown =>
+  typeof value === 'object' && value !== null
+    ? JSON.stringify(orderObjectProperties(value))
+    : value;
+
 export const compareTwoFlatEntity = <T extends AllMetadataName>({
   fromUniversalFlatEntity,
   toUniversalFlatEntity,
   metadataName,
 }: CompareTwoUniversalFlatEntityArgs<T>):
-  | UniversalFlatEntityUpdate<T>
+  | CompareTwoUniversalFlatEntityResult<T>
   | undefined => {
-  const { propertiesToStringify, propertiesToCompare } =
+  const {
+    propertiesToStringify,
+    propertiesToCompare,
+    propertiesToReportDivergence,
+  } =
     ALL_UNIVERSAL_FLAT_ENTITY_PROPERTIES_TO_COMPARE_AND_STRINGIFY[metadataName];
 
   const [transformedFromUniversalFlatEntity, transformedToUniversalFlatEntity] =
@@ -40,13 +56,32 @@ export const compareTwoFlatEntity = <T extends AllMetadataName>({
     transformedToUniversalFlatEntity,
   );
 
-  if (flatEntityDifferences.length === 0) {
+  const nonUpdatablePropertyDivergences = propertiesToReportDivergence.flatMap<
+    UniversalFlatEntityPropertyDivergence<T>
+  >((property) => {
+    const fromValue = fromUniversalFlatEntity[property];
+    const toValue = toUniversalFlatEntity[property];
+
+    if (
+      normalizeValueForComparison(fromValue) ===
+      normalizeValueForComparison(toValue)
+    ) {
+      return [];
+    }
+
+    return [{ property, fromValue, toValue }];
+  });
+
+  if (
+    flatEntityDifferences.length === 0 &&
+    nonUpdatablePropertyDivergences.length === 0
+  ) {
     return undefined;
   }
 
   const initialAccumulator: UniversalFlatEntityUpdate<T> = {};
 
-  return flatEntityDifferences.reduce((accumulator, difference) => {
+  const update = flatEntityDifferences.reduce((accumulator, difference) => {
     switch (difference.type) {
       case 'CHANGE': {
         const { path, value } = difference;
@@ -75,4 +110,6 @@ export const compareTwoFlatEntity = <T extends AllMetadataName>({
       }
     }
   }, initialAccumulator);
+
+  return { update, nonUpdatablePropertyDivergences };
 };

--- a/packages/twenty-server/src/engine/workspace-manager/workspace-migration/universal-flat-entity/utils/universal-flat-entity-deleted-created-updated-matrix-dispatcher.util.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/workspace-migration/universal-flat-entity/utils/universal-flat-entity-deleted-created-updated-matrix-dispatcher.util.ts
@@ -4,8 +4,10 @@ import { isDefined } from 'twenty-shared/utils';
 
 import { type MetadataUniversalFlatEntity } from 'src/engine/metadata-modules/flat-entity/types/metadata-universal-flat-entity.type';
 import { type MetadataUniversalFlatEntityMaps } from 'src/engine/workspace-manager/workspace-migration/universal-flat-entity/types/metadata-universal-flat-entity-maps.type';
-import { type UniversalFlatEntityUpdate } from 'src/engine/workspace-manager/workspace-migration/universal-flat-entity/types/universal-flat-entity-update.type';
-import { compareTwoFlatEntity } from 'src/engine/workspace-manager/workspace-migration/universal-flat-entity/utils/compare-two-universal-flat-entity.util';
+import {
+  compareTwoFlatEntity,
+  type CompareTwoUniversalFlatEntityResult,
+} from 'src/engine/workspace-manager/workspace-migration/universal-flat-entity/utils/compare-two-universal-flat-entity.util';
 import { addUniversalFlatEntityToUniversalFlatEntityMapsThroughMutationOrThrow } from 'src/engine/workspace-manager/workspace-migration/utils/add-universal-flat-entity-to-universal-flat-entity-maps-through-mutation-or-throw.util';
 import { shouldInferDeletionFromMissingEntities } from 'src/engine/workspace-manager/workspace-migration/utils/should-infer-deletion-from-missing-entities.util';
 import { type WorkspaceMigrationBuilderOptions } from 'src/engine/workspace-manager/workspace-migration/workspace-migration-builder/types/workspace-migration-builder-options.type';
@@ -16,9 +18,7 @@ export type DeletedCreatedUpdatedMatrix<T extends AllMetadataName> = {
   updatedFlatEntityMaps: {
     byUniversalIdentifier: Record<
       string,
-      {
-        update: UniversalFlatEntityUpdate<T>;
-      }
+      CompareTwoUniversalFlatEntityResult<T>
     >;
   };
 };
@@ -81,21 +81,19 @@ export const flatEntityDeletedCreatedUpdatedMatrixDispatcher = <
     if (!isDefined(toUniversalFlatEntity)) {
       continue;
     }
-    const update = compareTwoFlatEntity({
+    const comparisonResult = compareTwoFlatEntity({
       fromUniversalFlatEntity,
       toUniversalFlatEntity,
       metadataName,
     });
 
-    if (!isDefined(update)) {
+    if (!isDefined(comparisonResult)) {
       continue;
     }
 
     initialDispatcher.updatedFlatEntityMaps.byUniversalIdentifier[
       fromUniversalFlatEntity.universalIdentifier
-    ] = {
-      update,
-    };
+    ] = comparisonResult;
   }
 
   return initialDispatcher;

--- a/packages/twenty-server/src/engine/workspace-manager/workspace-migration/workspace-migration-builder/services/workspace-entity-migration-builder.service.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/workspace-migration/workspace-migration-builder/services/workspace-entity-migration-builder.service.ts
@@ -1,5 +1,6 @@
 import { Inject } from '@nestjs/common';
 
+import { msg } from '@lingui/core/macro';
 import { type AllMetadataName } from 'twenty-shared/metadata';
 import { type FromTo } from 'twenty-shared/types';
 import { isDefined } from 'twenty-shared/utils';
@@ -31,7 +32,12 @@ import { flatEntityDeletedCreatedUpdatedMatrixDispatcher } from 'src/engine/work
 import { getMetadataEmptyWorkspaceMigrationActionRecord } from 'src/engine/workspace-manager/workspace-migration/utils/get-metadata-empty-workspace-migration-action-record.util';
 import { shouldInferDeletionFromMissingEntities } from 'src/engine/workspace-manager/workspace-migration/utils/should-infer-deletion-from-missing-entities.util';
 import { topologicallySortUniversalFlatEntitiesForSelfReferentialFks } from 'src/engine/workspace-manager/workspace-migration/utils/topologically-sort-universal-flat-entities-for-self-referential-fks.util';
-import { FlatEntityValidationError } from 'src/engine/workspace-manager/workspace-migration/workspace-migration-builder/builders/types/failed-flat-entity-validation.type';
+import { UniversalFlatEntityPropertyDivergence } from 'src/engine/workspace-manager/workspace-migration/universal-flat-entity/types/universal-flat-entity-property-divergence.type';
+import {
+  FailedFlatEntityValidation,
+  FlatEntityValidationError,
+} from 'src/engine/workspace-manager/workspace-migration/workspace-migration-builder/builders/types/failed-flat-entity-validation.type';
+import { getEmptyFlatEntityValidationError } from 'src/engine/workspace-manager/workspace-migration/workspace-migration-builder/builders/utils/get-flat-entity-validation-error.util';
 import { FailedFlatEntityValidateAndBuild } from 'src/engine/workspace-manager/workspace-migration/workspace-migration-builder/types/failed-flat-entity-validate-and-build.type';
 import { SuccessfulFlatEntityValidateAndBuild } from 'src/engine/workspace-manager/workspace-migration/workspace-migration-builder/types/successful-flat-entity-validate-and-build.type';
 import { FlatEntityUpdateValidationArgs } from 'src/engine/workspace-manager/workspace-migration/workspace-migration-builder/types/universal-flat-entity-update-validation-args.type';
@@ -288,6 +294,17 @@ export abstract class WorkspaceEntityMigrationBuilderService<
         );
       }
 
+      if (flatEntityUpdate.nonUpdatablePropertyDivergences.length > 0) {
+        allValidationResult.push(
+          this.buildNonUpdatablePropertyDivergenceValidationError({
+            universalIdentifier: flatEntityToUpdateUniversalIdentifier,
+            nonUpdatablePropertyDivergences:
+              flatEntityUpdate.nonUpdatablePropertyDivergences,
+          }),
+        );
+        continue;
+      }
+
       const validationResult = await this.validateFlatEntityUpdate({
         flatEntityUpdate: flatEntityUpdate.update,
         optimisticFlatEntityMapsAndRelatedFlatEntityMaps,
@@ -378,6 +395,33 @@ export abstract class WorkspaceEntityMigrationBuilderService<
       status: 'success',
       actions: actionsResult,
     };
+  }
+
+  private buildNonUpdatablePropertyDivergenceValidationError({
+    universalIdentifier,
+    nonUpdatablePropertyDivergences,
+  }: {
+    universalIdentifier: string;
+    nonUpdatablePropertyDivergences: UniversalFlatEntityPropertyDivergence<T>[];
+  }): FailedFlatEntityValidation<T, 'update'> {
+    const validationError = getEmptyFlatEntityValidationError({
+      metadataName: this.metadataName,
+      flatEntityMinimalInformation: {
+        universalIdentifier,
+      } as Partial<MetadataFlatEntity<T>>,
+      type: 'update',
+    });
+
+    validationError.errors = nonUpdatablePropertyDivergences.map(
+      ({ property, fromValue, toValue }) => ({
+        code: 'NON_UPDATABLE_PROPERTY_DIVERGENCE',
+        message: `Property "${String(property)}" of ${this.metadataName} "${universalIdentifier}" cannot be updated`,
+        userFriendlyMessage: msg`Property "${String(property)}" cannot be updated`,
+        value: { fromValue, toValue },
+      }),
+    );
+
+    return validationError;
   }
 
   private validateUniversalIdentifier({


### PR DESCRIPTION
Addresses twentyhq/core-team-issues#2738: the migration builder silently stripped changes to non-comparable properties that input surfaces still accept, so mutations and manifest syncs reported success while returning stale data (e.g. `updatePageLayoutTab` with `layoutMode`, see #23402 and the regression evidence in #23406).

## Why not "compare all keys" as the issue proposes

Auditing the sync paths shows the blanket rule is not implementable: converters emit placeholder values for non-comparable properties by design. Manifest converters stamp `createdAt`/`updatedAt` with `now` on every sync and hardcode `isSystemSideEffect: false`; the objectMetadata converter emits `targetTableName: 'DEPRECATED'` and `isSystem: false`; `applicationVariable.value` is the manifest default while the DB holds the user-set encrypted value; standard-app builders hardcode `pageLayoutUniversalIdentifier: null` on command menu items. Raising on any non-comparable divergence would hard-fail every manifest sync and workspace upgrade.

## What this does instead

- Adds a `toReportDivergence` flag to `ALL_ENTITY_PROPERTIES_CONFIGURATION_BY_METADATA_NAME`, type-restricted so it can only be set on `toCompare: false` properties.
- `compareTwoFlatEntity` now also diffs flagged properties and returns `{ update, nonUpdatablePropertyDivergences }` (still `undefined` when nothing differs). Divergence-only changes flow through the matrix dispatcher and the manifest from-to operation-record util as update candidates.
- The generic `WorkspaceEntityMigrationBuilderService` update loop fails validation with one `NON_UPDATABLE_PROPERTY_DIVERGENCE` error per diverged property before emitting any action, so the contract is enforced centrally for every metadata type, on both the API mutation path and manifest sync.

## Flagged properties

Intersecting all 19 `FLAT_*_EDITABLE_PROPERTIES` allowlists with the non-comparable configuration yields exactly these misalignments, now flagged:

- `pageLayoutTab.layoutMode`
- `pageLayoutTab.pageLayoutId` (expressible via manifest)
- `commandMenuItem.pageLayoutId`
- `navigationMenuItem.pageLayoutId`

Unflagged non-comparable properties keep today's silent behavior. Note the complementary alternative for `layoutMode`: if it should genuinely be updatable, flip it to `toCompare: true` (the approach of the closed #23406) and drop the flag.

## Tests

- New explicit cases in `compare-two-universal-flat-entity.util.spec.ts`: layoutMode-only divergence, divergence alongside a comparable update, parent layout divergence, ignored timestamp/`isSystemSideEffect` drift, and no divergence on comparable-only changes.
- Regenerated snapshots (compare util, matrix dispatcher, compare-and-stringify constant, which now lists `propertiesToReportDivergence` per metadata type).
- `workspace-migration`, `flat-entity`, `application`, and page-layout-tab/command-menu-item module suites pass; `lint:diff-with-main` clean; typecheck's only error is pre-existing on main in an unrelated AI agent spec.

---
_Generated by [Claude Code](https://claude.ai/code/session_01U2tjDMvZeGsFFkQ5B5NtJC)_

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/23436?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

