### PR TITLE
fix(api): keep record queries on a single metadata generation

### DIFF
--- a/packages/twenty-server/src/engine/api/common/common-query-runners/common-base-query-runner.service.ts
+++ b/packages/twenty-server/src/engine/api/common/common-query-runners/common-base-query-runner.service.ts
@@ -17,6 +17,7 @@ import {
 } from 'src/engine/api/common/common-query-runners/errors/common-query-runner.exception';
 import { STANDARD_ERROR_MESSAGE } from 'src/engine/api/common/common-query-runners/errors/standard-error-message.constant';
 import { CommonResultGettersService } from 'src/engine/api/common/common-result-getters/common-result-getters.service';
+import { alignQueryRunnerContextWithWorkspaceContext } from 'src/engine/api/common/common-query-runners/utils/align-query-runner-context-with-workspace-context.util';
 import { CommonBaseQueryRunnerContext } from 'src/engine/api/common/types/common-base-query-runner-context.type';
 import { CommonExtendedQueryRunnerContext } from 'src/engine/api/common/types/common-extended-query-runner-context.type';
 import {
@@ -102,62 +103,71 @@ export abstract class CommonBaseQueryRunnerService<
 
   public async execute(
     args: CommonInput<Args>,
-    queryRunnerContext: CommonBaseQueryRunnerContext,
+    callerQueryRunnerContext: CommonBaseQueryRunnerContext,
   ): Promise<CommonQueryExecutionResult<Output, Args>> {
-    const {
-      authContext,
-      flatObjectMetadata,
-      flatObjectMetadataMaps,
-      flatFieldMetadataMaps,
-    } = queryRunnerContext;
+    const { authContext } = callerQueryRunnerContext;
 
     await this.throttleQueryExecution(authContext);
 
-    await this.validate(args, queryRunnerContext);
+    return await this.globalWorkspaceOrmManager.executeInWorkspaceContext(
+      async () => {
+        const queryRunnerContext = alignQueryRunnerContextWithWorkspaceContext(
+          callerQueryRunnerContext,
+        );
 
-    if (flatObjectMetadata.isSystem === true) {
-      await this.validateSettingsPermissionsOnObjectOrThrow(
-        authContext,
-        queryRunnerContext,
-      );
-    }
+        const {
+          flatObjectMetadata,
+          flatObjectMetadataMaps,
+          flatFieldMetadataMaps,
+        } = queryRunnerContext;
 
-    const commonQueryParser = new GraphqlQueryParser(
-      flatObjectMetadata,
-      flatObjectMetadataMaps,
-      flatFieldMetadataMaps,
-    );
+        await this.validate(args, queryRunnerContext);
 
-    const selectedFieldsResult = commonQueryParser.parseSelectedFields(
-      args.selectedFields,
-    );
-
-    const processedArgs = {
-      ...(await this.processArgs(args, queryRunnerContext, this.operationName)),
-      selectedFieldsResult,
-    } as CommonExtendedInput<Args>;
-
-    this.validateQueryComplexity(
-      selectedFieldsResult,
-      processedArgs,
-      queryRunnerContext,
-    );
-
-    const results =
-      await this.globalWorkspaceOrmManager.executeInWorkspaceContext(
-        async () =>
-          this.executeQueryAndEnrichResults(
-            processedArgs,
+        if (flatObjectMetadata.isSystem === true) {
+          await this.validateSettingsPermissionsOnObjectOrThrow(
+            authContext,
             queryRunnerContext,
-            commonQueryParser,
-          ),
-        authContext,
-      );
+          );
+        }
 
-    return {
-      results,
-      args: processedArgs,
-    };
+        const commonQueryParser = new GraphqlQueryParser(
+          flatObjectMetadata,
+          flatObjectMetadataMaps,
+          flatFieldMetadataMaps,
+        );
+
+        const selectedFieldsResult = commonQueryParser.parseSelectedFields(
+          args.selectedFields,
+        );
+
+        const processedArgs = {
+          ...(await this.processArgs(
+            args,
+            queryRunnerContext,
+            this.operationName,
+          )),
+          selectedFieldsResult,
+        } as CommonExtendedInput<Args>;
+
+        this.validateQueryComplexity(
+          selectedFieldsResult,
+          processedArgs,
+          queryRunnerContext,
+        );
+
+        const results = await this.executeQueryAndEnrichResults(
+          processedArgs,
+          queryRunnerContext,
+          commonQueryParser,
+        );
+
+        return {
+          results,
+          args: processedArgs,
+        };
+      },
+      authContext,
+    );
   }
 
   protected abstract run(

--- a/packages/twenty-server/src/engine/api/common/common-query-runners/utils/__tests__/align-query-runner-context-with-workspace-context.util.spec.ts
+++ b/packages/twenty-server/src/engine/api/common/common-query-runners/utils/__tests__/align-query-runner-context-with-workspace-context.util.spec.ts
@@ -1,0 +1,119 @@
+import { CommonQueryRunnerException } from 'src/engine/api/common/common-query-runners/errors/common-query-runner.exception';
+import { alignQueryRunnerContextWithWorkspaceContext } from 'src/engine/api/common/common-query-runners/utils/align-query-runner-context-with-workspace-context.util';
+import { type CommonBaseQueryRunnerContext } from 'src/engine/api/common/types/common-base-query-runner-context.type';
+import { type FlatObjectMetadata } from 'src/engine/metadata-modules/flat-object-metadata/types/flat-object-metadata.type';
+import {
+  workspaceContextStorage,
+  type ORMWorkspaceContext,
+} from 'src/engine/twenty-orm/storage/orm-workspace-context.storage';
+
+const COMPANY_UNIVERSAL_IDENTIFIER = 'company-universal-identifier';
+
+const buildFlatObjectMetadata = (
+  overrides: Partial<FlatObjectMetadata> = {},
+): FlatObjectMetadata =>
+  ({
+    id: 'company-id',
+    universalIdentifier: COMPANY_UNIVERSAL_IDENTIFIER,
+    nameSingular: 'company',
+    fieldIds: [],
+    ...overrides,
+  }) as FlatObjectMetadata;
+
+const buildFlatEntityMaps = (byUniversalIdentifier: object) =>
+  ({
+    byUniversalIdentifier,
+    universalIdentifierById: {},
+    universalIdentifiersByApplicationId: {},
+  }) as never;
+
+const buildCallerContext = (
+  flatObjectMetadata: FlatObjectMetadata,
+): CommonBaseQueryRunnerContext =>
+  ({
+    authContext: { workspace: { id: 'workspace-id' } },
+    flatObjectMetadata,
+    flatObjectMetadataMaps: buildFlatEntityMaps({
+      [COMPANY_UNIVERSAL_IDENTIFIER]: flatObjectMetadata,
+    }),
+    flatFieldMetadataMaps: buildFlatEntityMaps({ caller: true }),
+    flatIndexMaps: buildFlatEntityMaps({ caller: true }),
+    objectIdByNameSingular: { company: 'company-id' },
+    rolePermissionConfig: { roleId: 'role-id' },
+  }) as unknown as CommonBaseQueryRunnerContext;
+
+const buildWorkspaceContext = (
+  flatObjectMetadata?: FlatObjectMetadata,
+): ORMWorkspaceContext =>
+  ({
+    flatObjectMetadataMaps: buildFlatEntityMaps(
+      flatObjectMetadata
+        ? { [COMPANY_UNIVERSAL_IDENTIFIER]: flatObjectMetadata }
+        : {},
+    ),
+    flatFieldMetadataMaps: buildFlatEntityMaps({ workspaceContext: true }),
+    flatIndexMaps: buildFlatEntityMaps({ workspaceContext: true }),
+    objectIdByNameSingular: { company: 'company-id' },
+  }) as unknown as ORMWorkspaceContext;
+
+const alignInWorkspaceContext = (
+  workspaceContext: ORMWorkspaceContext,
+  queryRunnerContext: CommonBaseQueryRunnerContext,
+) =>
+  workspaceContextStorage.run(workspaceContext, () =>
+    alignQueryRunnerContextWithWorkspaceContext(queryRunnerContext),
+  );
+
+describe('alignQueryRunnerContextWithWorkspaceContext', () => {
+  it('should replace the caller metadata maps with the ones from the workspace context', () => {
+    const callerContext = buildCallerContext(
+      buildFlatObjectMetadata({ fieldIds: ['stale-field-id'] }),
+    );
+    const workspaceContextObjectMetadata = buildFlatObjectMetadata({
+      fieldIds: ['stale-field-id', 'last-contact-at-field-id'],
+    });
+    const workspaceContext = buildWorkspaceContext(
+      workspaceContextObjectMetadata,
+    );
+
+    const alignedContext = alignInWorkspaceContext(
+      workspaceContext,
+      callerContext,
+    );
+
+    expect(alignedContext.flatObjectMetadata).toBe(
+      workspaceContextObjectMetadata,
+    );
+    expect(alignedContext.flatObjectMetadataMaps).toBe(
+      workspaceContext.flatObjectMetadataMaps,
+    );
+    expect(alignedContext.flatFieldMetadataMaps).toBe(
+      workspaceContext.flatFieldMetadataMaps,
+    );
+    expect(alignedContext.flatIndexMaps).toBe(workspaceContext.flatIndexMaps);
+  });
+
+  it('should keep the caller properties that are not metadata related', () => {
+    const callerContext = buildCallerContext(buildFlatObjectMetadata());
+    const workspaceContext = buildWorkspaceContext(buildFlatObjectMetadata());
+
+    const alignedContext = alignInWorkspaceContext(
+      workspaceContext,
+      callerContext,
+    );
+
+    expect(alignedContext.authContext).toBe(callerContext.authContext);
+    expect(alignedContext.rolePermissionConfig).toBe(
+      callerContext.rolePermissionConfig,
+    );
+  });
+
+  it('should throw when the object is missing from the workspace context', () => {
+    const callerContext = buildCallerContext(buildFlatObjectMetadata());
+    const workspaceContext = buildWorkspaceContext();
+
+    expect(() =>
+      alignInWorkspaceContext(workspaceContext, callerContext),
+    ).toThrow(CommonQueryRunnerException);
+  });
+});

--- a/packages/twenty-server/src/engine/api/common/common-query-runners/utils/align-query-runner-context-with-workspace-context.util.ts
+++ b/packages/twenty-server/src/engine/api/common/common-query-runners/utils/align-query-runner-context-with-workspace-context.util.ts
@@ -1,0 +1,51 @@
+import { msg } from '@lingui/core/macro';
+import { isDefined } from 'twenty-shared/utils';
+
+import {
+  CommonQueryRunnerException,
+  CommonQueryRunnerExceptionCode,
+} from 'src/engine/api/common/common-query-runners/errors/common-query-runner.exception';
+import { type CommonBaseQueryRunnerContext } from 'src/engine/api/common/types/common-base-query-runner-context.type';
+import { getWorkspaceContext } from 'src/engine/twenty-orm/storage/orm-workspace-context.storage';
+
+// API layers resolve object and field metadata from their own workspace cache
+// snapshot, which can be a generation ahead of the ORM entity metadata loaded
+// when entering the workspace context. Selecting a column from the newer
+// snapshot then fails in the ORM, so the context is re-derived here to keep the
+// columns a query selects and the entity metadata resolving them on the same
+// generation.
+export const alignQueryRunnerContextWithWorkspaceContext = (
+  queryRunnerContext: CommonBaseQueryRunnerContext,
+): CommonBaseQueryRunnerContext => {
+  const {
+    flatObjectMetadataMaps,
+    flatFieldMetadataMaps,
+    flatIndexMaps,
+    objectIdByNameSingular,
+  } = getWorkspaceContext();
+
+  const { universalIdentifier, nameSingular } =
+    queryRunnerContext.flatObjectMetadata;
+
+  const flatObjectMetadata =
+    flatObjectMetadataMaps.byUniversalIdentifier[universalIdentifier];
+
+  if (!isDefined(flatObjectMetadata)) {
+    throw new CommonQueryRunnerException(
+      `Object metadata not found for ${nameSingular} in the workspace context`,
+      CommonQueryRunnerExceptionCode.INTERNAL_SERVER_ERROR,
+      {
+        userFriendlyMessage: msg`This object is being updated, please try again in a moment.`,
+      },
+    );
+  }
+
+  return {
+    ...queryRunnerContext,
+    flatObjectMetadata,
+    flatObjectMetadataMaps,
+    flatFieldMetadataMaps,
+    flatIndexMaps,
+    objectIdByNameSingular,
+  };
+};

--- a/packages/twenty-server/src/engine/workspace-cache/services/__tests__/workspace-cache.service.spec.ts
+++ b/packages/twenty-server/src/engine/workspace-cache/services/__tests__/workspace-cache.service.spec.ts
@@ -280,6 +280,50 @@ describe('WorkspaceCacheService', () => {
       // Total: 4 mget calls (2 per getOrRecompute)
       expect(cacheStorageService.mget).toHaveBeenCalledTimes(4);
     });
+
+    it('should revalidate every requested key when one of them is due, so a set cannot mix generations', async () => {
+      const secondMockProvider = new MockRolesPermissionsCacheProvider();
+
+      discoveryService.getProviders.mockReturnValue([
+        { instance: mockProvider },
+        { instance: secondMockProvider },
+      ] as any);
+
+      reflector.get.mockImplementation((key, target) => {
+        if (key === WORKSPACE_CACHE_KEY) {
+          if (target === MockFeatureFlagsCacheProvider) {
+            return 'featureFlagsMap';
+          }
+          if (target === MockRolesPermissionsCacheProvider) {
+            return 'rolesPermissions';
+          }
+        }
+
+        return undefined;
+      });
+
+      await service.onModuleInit();
+
+      cacheStorageService.mget.mockResolvedValue([undefined, undefined]);
+      cacheStorageService.mset.mockResolvedValue(undefined);
+
+      await service.getOrRecompute(WORKSPACE_ID, ['featureFlagsMap']);
+
+      jest.advanceTimersByTime(50);
+      cacheStorageService.mget.mockClear();
+
+      await service.getOrRecompute(WORKSPACE_ID, [
+        'featureFlagsMap',
+        'rolesPermissions',
+      ]);
+
+      // featureFlagsMap is still within its local TTL but rolesPermissions is
+      // not, so both hashes must be revalidated against the same redis read
+      expect(cacheStorageService.mget).toHaveBeenNthCalledWith(1, [
+        'feature-flag:feature-flags-map:20202020-0000-4000-8000-000000000000:hash',
+        'metadata:permissions:roles-permissions:20202020-0000-4000-8000-000000000000:hash',
+      ]);
+    });
   });
 
   describe('invalidateAndRecompute', () => {

--- a/packages/twenty-server/src/engine/workspace-cache/services/workspace-cache.service.ts
+++ b/packages/twenty-server/src/engine/workspace-cache/services/workspace-cache.service.ts
@@ -303,26 +303,29 @@ export class WorkspaceCacheService implements OnModuleInit {
     }
   }
 
+  // Keys requested together are kept on the same generation: their local TTLs
+  // are refreshed at different times by callers asking for different key sets,
+  // so validating only the expired ones would mix a revalidated key with a
+  // locally fresh one from the previous generation. Callers combining several
+  // keys rely on them describing the same metadata state, so the whole set is
+  // revalidated as soon as one key is due.
   private checkLocalTTL<K extends WorkspaceCacheKeyName>(
     workspaceId: string,
     cacheKeyNames: readonly K[],
   ): { freshKeys: K[]; staleKeys: K[] } {
-    const freshKeys: K[] = [];
-    const staleKeys: K[] = [];
     const now = Date.now();
 
-    for (const keyName of cacheKeyNames) {
-      const localKey = this.buildCacheKey(workspaceId, keyName);
-      const cached = this.localCache.get(localKey);
+    const areAllKeysFresh = cacheKeyNames.every((keyName) => {
+      const cached = this.localCache.get(
+        this.buildCacheKey(workspaceId, keyName),
+      );
 
-      if (isDefined(cached) && now - cached.lastHashCheckedAt < LOCAL_TTL_MS) {
-        freshKeys.push(keyName);
-      } else {
-        staleKeys.push(keyName);
-      }
-    }
+      return isDefined(cached) && now - cached.lastHashCheckedAt < LOCAL_TTL_MS;
+    });
 
-    return { freshKeys, staleKeys };
+    return areAllKeysFresh
+      ? { freshKeys: [...cacheKeyNames], staleKeys: [] }
+      : { freshKeys: [], staleKeys: [...cacheKeyNames] };
   }
 
   private async validateLocalHashAgainstRedisHash(


### PR DESCRIPTION
## Problem

Signing up and opting into an app during onboarding surfaces a red snackbar on the first record page:

```
Property "lastContactAt" was not found in "company". Make sure your query is correct.
```

That message is TypeORM's `EntityPropertyNotFoundError`, not a GraphQL validation error. Workspace queries bypass the GraphQL schema entirely (`useDirectExecution`), so a field the server accepts for selection but cannot resolve in the ORM fails hard at query build time.

It is not a front/back desync: the selected-fields parser only keeps columns present in the server's `flatObjectMetadata.fieldIds`, so a field the front knows about and the server does not is silently dropped. For the column to reach TypeORM, the server's own field metadata already had it. The skew is server-internal.

## Root cause

A record query reads workspace metadata twice, through two different cache key sets:

1. `DirectExecutionService.executeWorkspaceQuery` (and the REST/MCP equivalents) loads `flatObjectMetadataMaps` / `flatFieldMetadataMaps` — this decides which columns are selected.
2. `GlobalWorkspaceOrmManager.loadWorkspaceContext` loads `ORMEntityMetadatas` — this resolves those columns.

Both go through `WorkspaceCacheService`, but the memoizer key is `${workspaceId}-${sortedKeyNames}`, so each key set is memoized separately for 10s, and `checkLocalTTL` refreshes each key's local TTL independently. The two reads can therefore sit on different generations, and the memoizer is only cleared in the process that performed the invalidation — API pods never see the worker's eviction.

App installs make the bad direction easy to hit: the migration runs on the worker, the browser is told about the new fields over SSE and re-queries immediately, and the API pod serving that query is still on the previous generation for `ORMEntityMetadatas` while already on the new one for the field maps.

## Changes

- `alignQueryRunnerContextWithWorkspaceContext` re-derives the query runner context (object metadata, field maps, index maps, `objectIdByNameSingular`) from the workspace context that also carries `entityMetadatas`. `CommonBaseQueryRunnerService.execute` now enters the workspace context first and runs validation, selection parsing and execution against that single snapshot, so the selected columns and the entity metadata resolving them always come from the same load. This covers GraphQL, REST and MCP, which all funnel through this runner.
- `WorkspaceCacheService.checkLocalTTL` now revalidates a whole requested key set as soon as one of its keys is due, instead of mixing a revalidated key with a locally fresh one from the previous generation. The hashes were already fetched in a single `mget`, so this adds no extra round trip.

The residual 10s staleness of the memoizer is unchanged and out of scope here — it now degrades to "the whole request is one generation behind" instead of a hard error.

## Tests

- New unit tests for `alignQueryRunnerContextWithWorkspaceContext` (map replacement, caller properties preserved, missing object throws).
- New unit test asserting a mixed-freshness key set is revalidated as a whole.
- Full `twenty-server` unit suite passes (860 suites, 7066 tests), plus typecheck and lint on the changed files.


---
_Generated by [Claude Code](https://claude.ai/code/session_01XNqdAfKRosqvR7gDtvyApH)_

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/23442?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

