### PR TITLE
Replace the mobile bottom bar with a dynamic island

### DIFF
--- a/packages/twenty-front/src/modules/navigation/components/MobileNavigationIsland.tsx
+++ b/packages/twenty-front/src/modules/navigation/components/MobileNavigationIsland.tsx
@@ -11,28 +11,29 @@ import { useHasPermissionFlag } from '@/settings/roles/hooks/useHasPermissionFla
 import { useOpenRecordsSearchPageInSidePanel } from '@/side-panel/hooks/useOpenRecordsSearchPageInSidePanel';
 import { useSidePanelMenu } from '@/side-panel/hooks/useSidePanelMenu';
 import { isSidePanelOpenedState } from '@/side-panel/states/isSidePanelOpenedState';
+import { sidePanelPageState } from '@/side-panel/states/sidePanelPageState';
 import { isNavigationDrawerExpandedState } from '@/ui/navigation/states/isNavigationDrawerExpanded';
 import { navigationMemorizedUrlState } from '@/ui/navigation/states/navigationMemorizedUrlState';
-import { useSetAtomComponentState } from '@/ui/utilities/state/jotai/hooks/useSetAtomComponentState';
 import { useAtomState } from '@/ui/utilities/state/jotai/hooks/useAtomState';
 import { useAtomStateValue } from '@/ui/utilities/state/jotai/hooks/useAtomStateValue';
+import { useSetAtomComponentState } from '@/ui/utilities/state/jotai/hooks/useSetAtomComponentState';
 import { useNavigate } from 'react-router-dom';
+import { SidePanelPages } from 'twenty-shared/types';
+import { IconList, IconMessageCirclePlus, IconSearch } from 'twenty-ui/icon';
 import {
-  type IconComponent,
-  IconList,
-  IconMessageCirclePlus,
-  IconSearch,
-} from 'twenty-ui/icon';
-import { NavigationBar } from 'twenty-ui/navigation';
+  NavigationIsland,
+  type NavigationIslandItem,
+} from 'twenty-ui/navigation';
 import { PermissionFlagType } from '~/generated-metadata/graphql';
 
-type NavigationBarItemName = 'main' | 'search' | 'newAiChat';
+type NavigationIslandItemName = 'main' | 'search' | 'newAiChat';
 
-export const MobileNavigationBar = () => {
+export const MobileNavigationIsland = () => {
   const { t } = useLingui();
   const navigate = useNavigate();
   const { defaultHomePagePath } = useDefaultHomePagePath();
   const isSidePanelOpened = useAtomStateValue(isSidePanelOpenedState);
+  const sidePanelPage = useAtomStateValue(sidePanelPageState);
   const navigationMemorizedUrl = useAtomStateValue(navigationMemorizedUrlState);
   const { closeSidePanelMenu } = useSidePanelMenu();
   const { openRecordsSearchPage } = useOpenRecordsSearchPageInSidePanel();
@@ -51,21 +52,23 @@ export const MobileNavigationBar = () => {
     MAIN_CONTEXT_STORE_INSTANCE_ID,
   );
 
+  const isAiChatOpenedInSidePanel =
+    isSidePanelOpened &&
+    (sidePanelPage === SidePanelPages.AskAI ||
+      sidePanelPage === SidePanelPages.ViewPreviousAiChats);
+
   const activeItemName = isNavigationDrawerExpanded
     ? currentMobileNavigationDrawer
-    : isSidePanelOpened
-      ? 'search'
-      : 'main';
+    : isAiChatOpenedInSidePanel
+      ? 'newAiChat'
+      : isSidePanelOpened
+        ? 'search'
+        : 'main';
 
-  const items: {
-    name: NavigationBarItemName;
-    label: string;
-    Icon: IconComponent;
-    onClick: () => void;
-  }[] = [
+  const items: (NavigationIslandItem & { name: NavigationIslandItemName })[] = [
     {
       name: 'main',
-      label: t`Main navigation`,
+      label: t`Menu`,
       Icon: IconList,
       onClick: () => {
         closeSidePanelMenu();
@@ -108,7 +111,7 @@ export const MobileNavigationBar = () => {
       ? [
           {
             name: 'newAiChat' as const,
-            label: t`New AI chat`,
+            label: t`AI chat`,
             Icon: IconMessageCirclePlus,
             onClick: () => {
               setIsNavigationDrawerExpanded(false);
@@ -120,5 +123,5 @@ export const MobileNavigationBar = () => {
       : []),
   ];
 
-  return <NavigationBar activeItemName={activeItemName} items={items} />;
+  return <NavigationIsland activeItemName={activeItemName} items={items} />;
 };

--- a/packages/twenty-front/src/modules/object-record/record-table/record-table-footer/components/RecordTableAggregateFooter.tsx
+++ b/packages/twenty-front/src/modules/object-record/record-table/record-table-footer/components/RecordTableAggregateFooter.tsx
@@ -10,6 +10,7 @@ import { TABLE_Z_INDEX } from '@/object-record/record-table/constants/TableZInde
 import { useRecordTableContextOrThrow } from '@/object-record/record-table/contexts/RecordTableContext';
 import { RecordTableAggregateFooterCell } from '@/object-record/record-table/record-table-footer/components/RecordTableAggregateFooterCell';
 import { RecordTableColumnAggregateFooterCellContext } from '@/object-record/record-table/record-table-footer/components/RecordTableColumnAggregateFooterCellContext';
+import { useIsMobile } from '@/ui/utilities/responsive/hooks/useIsMobile';
 import { themeCssVariables } from 'twenty-ui/theme-constants';
 
 const StyledPlaceholderDragAndDropFooterCell = styled.div`
@@ -53,6 +54,13 @@ export const RecordTableAggregateFooter = ({
   currentRecordGroupId?: string;
 }) => {
   const { visibleRecordFields } = useRecordTableContextOrThrow();
+  const isMobile = useIsMobile();
+
+  // The navigation island floats over the bottom of the page, so aggregates
+  // would sit underneath it and stay out of reach on mobile.
+  if (isMobile) {
+    return null;
+  }
 
   return (
     <StyledAggregateFooterContainer>

--- a/packages/twenty-front/src/modules/ui/layout/page/components/DefaultLayout.tsx
+++ b/packages/twenty-front/src/modules/ui/layout/page/components/DefaultLayout.tsx
@@ -6,7 +6,7 @@ import { InformationBannerIsImpersonating } from '@/information-banner/component
 import { KeyboardShortcutMenu } from '@/keyboard-shortcut-menu/components/KeyboardShortcutMenu';
 import { LayoutCustomizationBar } from '@/layout-customization/components/LayoutCustomizationBar';
 import { AppNavigationDrawer } from '@/navigation/components/AppNavigationDrawer';
-import { MobileNavigationBar } from '@/navigation/components/MobileNavigationBar';
+import { MobileNavigationIsland } from '@/navigation/components/MobileNavigationIsland';
 import { PageDragDropProvider } from '@/navigation-menu-item/display/dnd/providers/PageDragDropProvider';
 import { useShowFullscreen } from '@/ui/layout/fullscreen/hooks/useShowFullscreen';
 import { useIsMobile } from '@/ui/utilities/responsive/hooks/useIsMobile';
@@ -59,6 +59,19 @@ const StyledNavigationDrawerWrapper = styled.div`
   }
 `;
 
+// The island floats above the page, so the layout gives back most of its
+// footprint and lets it overlap the page card by a few pixels only.
+const StyledNavigationIslandSpacer = styled.div`
+  flex-shrink: 0;
+  height: calc(
+    ${themeCssVariables.spacing[14]} + env(safe-area-inset-bottom, 0px)
+  );
+
+  @media print {
+    display: none;
+  }
+`;
+
 const StyledMainContainer = styled.div`
   display: flex;
   flex: 0 1 100%;
@@ -98,7 +111,12 @@ export const DefaultLayout = () => {
                 </StyledMainContainer>
               </PageDragDropProvider>
             </StyledPageContainer>
-            {isMobile && <MobileNavigationBar />}
+            {isMobile && (
+              <>
+                <StyledNavigationIslandSpacer />
+                <MobileNavigationIsland />
+              </>
+            )}
           </AppErrorBoundary>
         </StyledLayout>
       </FileUploadProvider>

--- a/packages/twenty-ui/src/navigation/NavigationIsland/NavigationIsland.module.scss
+++ b/packages/twenty-ui/src/navigation/NavigationIsland/NavigationIsland.module.scss
@@ -1,0 +1,174 @@
+// Spring sampled as a linear() easing so the capsule morphs the way the iOS
+// Dynamic Island does: a slight overshoot, then a quick settle.
+$morph-easing: linear(
+  0,
+  0.0181,
+  0.0653,
+  0.1325,
+  0.2121,
+  0.2982,
+  0.3862,
+  0.4726,
+  0.5547,
+  0.6308,
+  0.7,
+  0.7615,
+  0.8153,
+  0.8616,
+  0.9006,
+  0.9329,
+  0.9592,
+  0.98,
+  0.9962,
+  1.0083,
+  1.0169,
+  1.0228,
+  1.0263,
+  1.028,
+  1.0283,
+  1.0276,
+  1.0261,
+  1.0241,
+  1.0218,
+  1.0193,
+  1.0168,
+  1.0144,
+  1.0121,
+  1.01,
+  1.0081,
+  1.0064,
+  1.0049,
+  1.0036,
+  1.0026,
+  1.0017,
+  1
+);
+$morph-duration: 420ms;
+
+.viewport {
+  bottom: calc(var(--t-spacing-3) + env(safe-area-inset-bottom, 0px));
+  display: flex;
+  justify-content: center;
+  left: 0;
+  // Only the capsule itself is interactive, the rest of the strip stays
+  // transparent to taps so the page underneath keeps working.
+  pointer-events: none;
+  position: fixed;
+  right: 0;
+  // Above the page and the mobile navigation drawer, but still below portalled
+  // overlays such as dropdowns, modals and the command menu.
+  z-index: 1001;
+
+  @media print {
+    display: none;
+  }
+}
+
+.island {
+  align-items: center;
+  backdrop-filter: var(--t-blur-strong);
+  // Inverted surface, like tooltips: the capsule always contrasts with the page
+  // it floats over instead of dissolving into it. The last 10% of transparency
+  // is what lets the blurred page show through.
+  background-color: color-mix(
+    in srgb,
+    var(--t-background-inverted-primary) 90%,
+    transparent
+  );
+  border: 1px solid
+    color-mix(in srgb, var(--t-gray-scale-gray1) 12%, transparent);
+  border-radius: var(--t-border-radius-pill);
+  box-shadow: var(--t-box-shadow-strong), var(--t-box-shadow-super-heavy);
+  color: var(--t-gray-scale-gray1);
+  // A capsule reads as a capsule whether or not squircles are supported.
+  corner-shape: round;
+  display: flex;
+  gap: var(--t-spacing-1);
+  max-width: calc(100dvw - var(--t-spacing-8));
+  padding: var(--t-spacing-1);
+  pointer-events: auto;
+}
+
+.item {
+  align-items: center;
+  appearance: none;
+  background-color: transparent;
+  border: none;
+  border-radius: var(--t-border-radius-pill);
+  color: inherit;
+  corner-shape: round;
+  cursor: pointer;
+  display: flex;
+  font: inherit;
+  gap: 0;
+  height: var(--t-spacing-11);
+  justify-content: center;
+  min-width: var(--t-spacing-11);
+  opacity: 0.55;
+  padding: 0 var(--t-spacing-2);
+  transition:
+    background-color duration(normal) $morph-easing,
+    gap $morph-duration $morph-easing,
+    opacity duration(fast) ease-out,
+    padding $morph-duration $morph-easing,
+    transform duration(instant) ease-out;
+
+  &[data-active] {
+    background-color: color-mix(
+      in srgb,
+      var(--t-gray-scale-gray1) 16%,
+      transparent
+    );
+    gap: var(--t-spacing-1);
+    opacity: 1;
+    padding: 0 var(--t-spacing-3) 0 var(--t-spacing-2);
+  }
+
+  &:active {
+    transform: scale(0.94);
+  }
+
+  @include hover-capable {
+    &:hover:not([data-active]) {
+      opacity: 0.8;
+    }
+  }
+
+  @include focus-ring;
+}
+
+.itemIcon {
+  flex-shrink: 0;
+}
+
+.itemLabel {
+  filter: blur(4px);
+  font-size: var(--t-font-size-sm);
+  font-weight: var(--t-font-weight-medium);
+  // The label is what makes the capsule breathe: it unrolls from zero width and
+  // the island resizes around it, since the island's width is content-driven.
+  max-width: 0;
+  opacity: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  transition:
+    max-width $morph-duration $morph-easing,
+    opacity duration(fast) ease-out,
+    filter duration(normal) ease-out;
+  white-space: nowrap;
+
+  .item[data-active] & {
+    filter: blur(0);
+    max-width: var(--t-spacing-30);
+    opacity: 1;
+    // The label only fades in once the capsule has started to make room for it.
+    transition-delay: 0s, 60ms, 60ms;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .item,
+  .itemLabel {
+    transition-duration: 1ms;
+  }
+}

--- a/packages/twenty-ui/src/navigation/NavigationIsland/NavigationIsland.module.scss.d.ts
+++ b/packages/twenty-ui/src/navigation/NavigationIsland/NavigationIsland.module.scss.d.ts
@@ -1,0 +1,8 @@
+declare const classNames: {
+  readonly viewport: 'viewport';
+  readonly island: 'island';
+  readonly item: 'item';
+  readonly itemIcon: 'itemIcon';
+  readonly itemLabel: 'itemLabel';
+};
+export default classNames;

--- a/packages/twenty-ui/src/navigation/NavigationIsland/NavigationIsland.tsx
+++ b/packages/twenty-ui/src/navigation/NavigationIsland/NavigationIsland.tsx
@@ -1,0 +1,54 @@
+import { type IconComponent } from '@ui/icon/types/IconComponent';
+import { useTheme } from '@ui/theme-constants';
+
+import styles from './NavigationIsland.module.scss';
+
+export type NavigationIslandItem = {
+  name: string;
+  label: string;
+  Icon: IconComponent;
+  onClick: () => void;
+};
+
+type NavigationIslandProps = {
+  activeItemName: string;
+  items: NavigationIslandItem[];
+};
+
+export const NavigationIsland = ({
+  activeItemName,
+  items,
+}: NavigationIslandProps) => {
+  const theme = useTheme();
+
+  return (
+    <div className={styles.viewport}>
+      <nav className={styles.island}>
+        {items.map(({ Icon, name, label, onClick }) => {
+          const isActive = activeItemName === name;
+
+          return (
+            <button
+              key={name}
+              type="button"
+              className={styles.item}
+              data-active={isActive ? '' : undefined}
+              aria-label={label}
+              aria-pressed={isActive}
+              onClick={onClick}
+            >
+              <Icon
+                className={styles.itemIcon}
+                size={theme.icon.size.lg}
+                aria-hidden
+              />
+              <span className={styles.itemLabel} aria-hidden>
+                {label}
+              </span>
+            </button>
+          );
+        })}
+      </nav>
+    </div>
+  );
+};

--- a/packages/twenty-ui/src/navigation/NavigationIsland/__stories__/NavigationIsland.stories.tsx
+++ b/packages/twenty-ui/src/navigation/NavigationIsland/__stories__/NavigationIsland.stories.tsx
@@ -1,0 +1,42 @@
+import { type Meta, type StoryObj } from '@storybook/react-vite';
+import { IconList, IconMessageCirclePlus, IconSearch } from '@ui/icon';
+import { ComponentDecorator } from '@ui/testing';
+
+import { NavigationIsland } from '@ui/navigation/NavigationIsland/NavigationIsland';
+
+const meta: Meta<typeof NavigationIsland> = {
+  title: 'UI/Navigation/NavigationIsland/NavigationIsland',
+  component: NavigationIsland,
+  decorators: [ComponentDecorator],
+  args: {
+    activeItemName: 'menu',
+    items: [
+      { name: 'menu', label: 'Menu', Icon: IconList, onClick: () => {} },
+      { name: 'search', label: 'Search', Icon: IconSearch, onClick: () => {} },
+      {
+        name: 'newAiChat',
+        label: 'AI chat',
+        Icon: IconMessageCirclePlus,
+        onClick: () => {},
+      },
+    ],
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof NavigationIsland>;
+
+export const Default: Story = {};
+
+export const SearchActive: Story = {
+  args: { activeItemName: 'search' },
+};
+
+export const WithoutAi: Story = {
+  args: {
+    items: [
+      { name: 'menu', label: 'Menu', Icon: IconList, onClick: () => {} },
+      { name: 'search', label: 'Search', Icon: IconSearch, onClick: () => {} },
+    ],
+  },
+};

--- a/packages/twenty-ui/src/navigation/index.ts
+++ b/packages/twenty-ui/src/navigation/index.ts
@@ -52,6 +52,8 @@ export type { MenuPickerProps } from './MenuPicker/MenuPicker';
 export { MenuPicker } from './MenuPicker/MenuPicker';
 export { NavigationBar } from './NavigationBar/NavigationBar';
 export { NavigationBarItem } from './NavigationBarItem/NavigationBarItem';
+export type { NavigationIslandItem } from './NavigationIsland/NavigationIsland';
+export { NavigationIsland } from './NavigationIsland/NavigationIsland';
 export { RawLink } from './RawLink/RawLink';
 export { RoundedLink } from './RoundedLink/RoundedLink';
 export { LinkType } from './SocialLink/LinkType';


### PR DESCRIPTION
Replaces the full-width mobile bottom bar with a floating, morphing capsule inspired by the Dynamic Island.

## What changed

**`NavigationIsland` (twenty-ui)** — a new design-system component that replaces `NavigationBar` at the app level:

- Fixed, centered capsule floating above the page, `env(safe-area-inset-bottom)` aware
- Inverted surface (`--t-background-inverted-primary` at 90%) plus `--t-blur-strong`, so it is a dark capsule in light mode and a light one in dark mode, always contrasting with whatever it floats over
- The active item grows a label; the capsule resizes around it because its width is content-driven. Tapping another destination shrinks one lozenge and grows the other, which is the fluid morph rather than a sliding indicator
- The morph runs on a spring sampled as a `linear()` easing (~420ms, slight overshoot). The label unrolls from zero width and fades in from a 4px blur, 60ms behind the capsule so it never leads the resize
- `transform: scale(0.94)` press feedback, `prefers-reduced-motion` collapses every transition
- `z-index: 1001` matching the old bar, so portalled dropdowns, modals and the command menu still stack above it

**Layout** — `DefaultLayout` keeps a spacer of the island's footprint, so the island overlaps the page card by ~10px instead of covering content.

**Aggregate footer** — `RecordTableAggregateFooter` returns `null` on mobile. It used to sit at the bottom of the table card, which is exactly where the island now floats, so its dropdown would open into the island and be unreachable.

**Active state fix** — opening the AI chat used to light up the search item, because both go through the side panel. The island now reads `sidePanelPageState` and marks the AI item active for `AskAI` / `ViewPreviousAiChats`.

## Notes

- `NavigationBar` / `NavigationBarItem` stay in twenty-ui (they are still referenced by the component gallery); only the app-level `MobileNavigationBar` is replaced.
- Storybook stories cover the compact, search-active and no-AI-permission states.

## Testing

Verified with Playwright at 390x844 and 320x568, light and dark, on the record index, an expanded navigation drawer, the search side panel, a record page, and the table scrolled to its last row. Typecheck and lint pass for both packages.


---
_Generated by [Claude Code](https://claude.ai/code/session_018gcsCQbuTMsyFWv874p25Q)_

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/23465?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

