### PR TITLE
Fix editing records in Select-sorted paginated views

### DIFF
--- a/packages/twenty-shared/src/types/RecordGqlOperationFilter.ts
+++ b/packages/twenty-shared/src/types/RecordGqlOperationFilter.ts
@@ -130,6 +130,10 @@ export type SelectFilter = {
   in?: string[];
   eq?: string;
   neq?: string;
+  gt?: string;
+  gte?: string;
+  lt?: string;
+  lte?: string;
 };
 
 export type MultiSelectFilter = {

--- a/packages/twenty-shared/src/utils/filter/utils/__tests__/isMatchingSelectFilter.test.ts
+++ b/packages/twenty-shared/src/utils/filter/utils/__tests__/isMatchingSelectFilter.test.ts
@@ -72,6 +72,27 @@ describe('isMatchingSelectFilter', () => {
     });
   });
 
+  describe('comparison operators', () => {
+    it.each([
+      { selectFilter: { gt: 'ACTIVE' }, value: 'PENDING', expected: true },
+      { selectFilter: { gt: 'PENDING' }, value: 'ACTIVE', expected: false },
+      { selectFilter: { gte: 'ACTIVE' }, value: 'ACTIVE', expected: true },
+      { selectFilter: { lt: 'PENDING' }, value: 'ACTIVE', expected: true },
+      { selectFilter: { lt: 'ACTIVE' }, value: 'PENDING', expected: false },
+      { selectFilter: { lte: 'ACTIVE' }, value: 'ACTIVE', expected: true },
+    ])(
+      'should return $expected for $selectFilter and $value',
+      ({ selectFilter, value, expected }) => {
+        expect(
+          isMatchingSelectFilter({
+            selectFilter,
+            value,
+          }),
+        ).toBe(expected);
+      },
+    );
+  });
+
   describe('default', () => {
     it('should throw for unexpected filter', () => {
       expect(() =>

--- a/packages/twenty-shared/src/utils/filter/utils/isMatchingSelectFilter.ts
+++ b/packages/twenty-shared/src/utils/filter/utils/isMatchingSelectFilter.ts
@@ -24,6 +24,18 @@ export const isMatchingSelectFilter = ({
     case selectFilter.neq !== undefined: {
       return value !== selectFilter.neq;
     }
+    case selectFilter.gt !== undefined: {
+      return value > selectFilter.gt;
+    }
+    case selectFilter.gte !== undefined: {
+      return value >= selectFilter.gte;
+    }
+    case selectFilter.lt !== undefined: {
+      return value < selectFilter.lt;
+    }
+    case selectFilter.lte !== undefined: {
+      return value <= selectFilter.lte;
+    }
     default: {
       throw new Error(
         `Unexpected value for select filter : ${JSON.stringify(selectFilter)}`,


### PR DESCRIPTION
## What changed

- add ordered comparison operators to `SelectFilter`
- handle `gt`, `gte`, `lt`, and `lte` in `isMatchingSelectFilter`
- cover ordered Select matching with regression tests

## Why

Cursor pagination creates ordered filters for sorted fields. When a table was sorted by a Select field, optimistic record updates replayed a cursor filter such as `{ lt: "NEW" }`, but the Select matcher threw instead of evaluating it. The synchronous exception prevented the mutation from being sent.

This keeps optimistic matching consistent with the ordered filters used by cursor pagination, so edits in paginated Select-sorted views can be saved normally.

Fixes #23468.

## Validation

- `nx test twenty-shared` — 211 suites, 1,678 tests passed
- `nx lint twenty-shared`
- `nx typecheck twenty-shared`
- `nx fmt twenty-shared`


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/23469?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

