### PR TITLE
chore: fix validation error message to reference pageLayoutUniversalIdentifiers

### DIFF
--- a/packages/twenty-server/src/engine/workspace-manager/workspace-migration/workspace-migration-builder/validators/services/flat-navigation-menu-item-validator.service.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/workspace-migration/workspace-migration-builder/validators/services/flat-navigation-menu-item-validator.service.ts
@@ -102,8 +102,8 @@ export class FlatNavigationMenuItemValidatorService {
         if (!hasPageLayoutId) {
           errors.push({
             code: NavigationMenuItemExceptionCode.INVALID_NAVIGATION_MENU_ITEM_INPUT,
-            message: t`pageLayoutId is required for PAGE_LAYOUT type`,
-            userFriendlyMessage: msg`pageLayoutId is required for PAGE_LAYOUT type`,
+            message: t`pageLayoutUniversalIdentifier is required for PAGE_LAYOUT type`,
+            userFriendlyMessage: msg`pageLayoutUniversalIdentifier is required for PAGE_LAYOUT type`,
           });
         }
         break;


### PR DESCRIPTION
Fixes #23484

This pull request updates an error message in the `FlatNavigationMenuItemValidatorService` to clarify the required field for PAGE_LAYOUT type navigation menu items.

Validation message update:

* Updated the error messages to refer to `pageLayoutUniversalIdentifier` instead of `pageLayoutId` when validating PAGE_LAYOUT type navigation menu items in `flat-navigation-menu-item-validator.service.ts`.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/23485?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

