### PR TITLE
fix: enable saving inline-created select options

### DIFF
--- a/packages/twenty-front/src/modules/settings/data-model/fields/forms/select/components/SettingsDataModelFieldSelectForm.tsx
+++ b/packages/twenty-front/src/modules/settings/data-model/fields/forms/select/components/SettingsDataModelFieldSelectForm.tsx
@@ -203,11 +203,7 @@ export const SettingsDataModelFieldSelectForm = ({
   useEffect(() => {
     const newOptionValue = searchParams.get('newOption');
 
-    if (
-      isFormMounted &&
-      isDefined(newOptionValue) &&
-      !hasAppliedNewOption
-    ) {
+    if (isFormMounted && isDefined(newOptionValue) && !hasAppliedNewOption) {
       const newOption = generateNewSelectOption(initialOptions, newOptionValue);
 
       const optionsWithNew = [...initialOptions, newOption];

--- a/packages/twenty-front/src/modules/settings/data-model/fields/forms/select/components/SettingsDataModelFieldSelectForm.tsx
+++ b/packages/twenty-front/src/modules/settings/data-model/fields/forms/select/components/SettingsDataModelFieldSelectForm.tsx
@@ -167,7 +167,7 @@ export const SettingsDataModelFieldSelectForm = ({
   disabled = false,
 }: SettingsDataModelFieldSelectFormProps) => {
   const { theme } = useContext(ThemeContext);
-  const { initialDefaultValue, initialOptions } =
+  const { initialDefaultValue, initialOptions, resetOptionsField } =
     useSelectSettingsFormInitialValues({
       fieldMetadataId: existingFieldMetadataId,
     });
@@ -203,10 +203,17 @@ export const SettingsDataModelFieldSelectForm = ({
 
       const optionsWithNew = [...initialOptions, newOption];
 
+      resetOptionsField();
       setFormValue('options', optionsWithNew, { shouldDirty: true });
       setHasAppliedNewOption(true);
     }
-  }, [searchParams, hasAppliedNewOption, initialOptions, setFormValue]);
+  }, [
+    searchParams,
+    hasAppliedNewOption,
+    initialOptions,
+    resetOptionsField,
+    setFormValue,
+  ]);
 
   const handleDragEnd = (
     values: FieldMetadataItemOption[],

--- a/packages/twenty-front/src/modules/settings/data-model/fields/forms/select/components/SettingsDataModelFieldSelectForm.tsx
+++ b/packages/twenty-front/src/modules/settings/data-model/fields/forms/select/components/SettingsDataModelFieldSelectForm.tsx
@@ -167,7 +167,7 @@ export const SettingsDataModelFieldSelectForm = ({
   disabled = false,
 }: SettingsDataModelFieldSelectFormProps) => {
   const { theme } = useContext(ThemeContext);
-  const { initialDefaultValue, initialOptions, resetOptionsField } =
+  const { initialDefaultValue, initialOptions } =
     useSelectSettingsFormInitialValues({
       fieldMetadataId: existingFieldMetadataId,
     });
@@ -188,6 +188,7 @@ export const SettingsDataModelFieldSelectForm = ({
   } = useFormContext<SettingsDataModelFieldSelectFormValues>();
 
   const [hasAppliedNewOption, setHasAppliedNewOption] = useState(false);
+  const [isFormMounted, setIsFormMounted] = useState(false);
   const [isBulkInputMode, setIsBulkInputMode] = useState(false);
   const [bulkInputText, setBulkInputText] = useState('');
 
@@ -196,22 +197,29 @@ export const SettingsDataModelFieldSelectForm = ({
   const { closeDropdown: closeOptionsDropdown } = useCloseDropdown();
 
   useEffect(() => {
+    setIsFormMounted(true);
+  }, []);
+
+  useEffect(() => {
     const newOptionValue = searchParams.get('newOption');
 
-    if (isDefined(newOptionValue) && !hasAppliedNewOption) {
+    if (
+      isFormMounted &&
+      isDefined(newOptionValue) &&
+      !hasAppliedNewOption
+    ) {
       const newOption = generateNewSelectOption(initialOptions, newOptionValue);
 
       const optionsWithNew = [...initialOptions, newOption];
 
-      resetOptionsField();
       setFormValue('options', optionsWithNew, { shouldDirty: true });
       setHasAppliedNewOption(true);
     }
   }, [
     searchParams,
+    isFormMounted,
     hasAppliedNewOption,
     initialOptions,
-    resetOptionsField,
     setFormValue,
   ]);
 

--- a/packages/twenty-front/src/modules/settings/data-model/fields/forms/select/hooks/useSelectSettingsFormInitialValues.ts
+++ b/packages/twenty-front/src/modules/settings/data-model/fields/forms/select/hooks/useSelectSettingsFormInitialValues.ts
@@ -47,13 +47,9 @@ export const useSelectSettingsFormInitialValues = ({
   const resetDefaultValueField = () =>
     resetField('defaultValue', { defaultValue: initialDefaultValue });
 
-  const resetOptionsField = () =>
-    resetField('options', { defaultValue: initialOptions });
-
   return {
     initialDefaultValue,
     initialOptions,
     resetDefaultValueField,
-    resetOptionsField,
   };
 };

--- a/packages/twenty-front/src/modules/settings/data-model/fields/forms/select/hooks/useSelectSettingsFormInitialValues.ts
+++ b/packages/twenty-front/src/modules/settings/data-model/fields/forms/select/hooks/useSelectSettingsFormInitialValues.ts
@@ -47,9 +47,13 @@ export const useSelectSettingsFormInitialValues = ({
   const resetDefaultValueField = () =>
     resetField('defaultValue', { defaultValue: initialDefaultValue });
 
+  const resetOptionsField = () =>
+    resetField('options', { defaultValue: initialOptions });
+
   return {
     initialDefaultValue,
     initialOptions,
     resetDefaultValueField,
+    resetOptionsField,
   };
 };


### PR DESCRIPTION
## Summary

Fixes #23487.

When creating a select or multi-select option from the record UI, the data model editor now immediately recognizes the injected option as an unsaved change and enables the Save button.

## Changes

- Reset the options field’s form baseline to the existing options.
- Apply the URL-provided new option and mark the field dirty.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/23488?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

