### PR TITLE
Resolve route-trigger workspace from bearer token on bare hosts

### DIFF
--- a/packages/twenty-server/src/engine/core-modules/logic-function/logic-function-trigger/triggers/route/__tests__/route-trigger.service.spec.ts
+++ b/packages/twenty-server/src/engine/core-modules/logic-function/logic-function-trigger/triggers/route/__tests__/route-trigger.service.spec.ts
@@ -13,6 +13,7 @@ import { RouteTriggerExceptionCode } from 'src/engine/core-modules/logic-functio
 import { RouteTriggerService } from 'src/engine/core-modules/logic-function/logic-function-trigger/triggers/route/route-trigger.service';
 import { buildRouteTriggerResponse } from 'src/engine/core-modules/logic-function/logic-function-trigger/triggers/route/utils/route-trigger-response.util';
 import { type TwentyConfigService } from 'src/engine/core-modules/twenty-config/twenty-config.service';
+import { type WorkspaceEntity } from 'src/engine/core-modules/workspace/workspace.entity';
 import { type LogicFunctionEntity } from 'src/engine/metadata-modules/logic-function/logic-function.entity';
 
 describe('buildRouteTriggerResponse', () => {
@@ -64,19 +65,23 @@ describe('buildRouteTriggerResponse', () => {
 describe('RouteTriggerService', () => {
   const resolveWorkspaceAndPublicDomain = jest.fn();
   const find = jest.fn();
+  const validateTokenByRequest = jest.fn();
+  const findOneBy = jest.fn();
 
   const service = new RouteTriggerService(
-    {} as unknown as AccessTokenService,
+    { validateTokenByRequest } as unknown as AccessTokenService,
     {} as unknown as LogicFunctionTriggerService,
     { resolveWorkspaceAndPublicDomain } as unknown as WorkspaceDomainsService,
     { get: jest.fn() } as unknown as TwentyConfigService,
     { find } as unknown as Repository<LogicFunctionEntity>,
+    { findOneBy } as unknown as Repository<WorkspaceEntity>,
   );
 
   const request = {
     protocol: 'https',
     get: () => 'acme.twenty.com',
     path: '/s/webhook',
+    headers: {},
   } as unknown as Request;
 
   afterEach(() => {
@@ -125,5 +130,103 @@ describe('RouteTriggerService', () => {
         httpRouteTriggerSettings: expect.anything(),
       },
     });
+  });
+
+  it('should reject with WORKSPACE_NOT_FOUND when the host resolves no workspace and no token is sent', async () => {
+    resolveWorkspaceAndPublicDomain.mockResolvedValue({
+      workspace: undefined,
+      publicDomain: null,
+      isIsolatedOrigin: false,
+    });
+
+    await expect(
+      service.handle({ request, httpMethod: HTTPMethod.GET }),
+    ).rejects.toMatchObject({
+      code: RouteTriggerExceptionCode.WORKSPACE_NOT_FOUND,
+    });
+
+    expect(validateTokenByRequest).not.toHaveBeenCalled();
+  });
+
+  it('should resolve the workspace from the token when the host resolves none', async () => {
+    resolveWorkspaceAndPublicDomain.mockResolvedValue({
+      workspace: undefined,
+      publicDomain: null,
+      isIsolatedOrigin: false,
+    });
+    validateTokenByRequest.mockResolvedValue({
+      workspace: { id: 'token-workspace-id' },
+    });
+    findOneBy.mockResolvedValue({
+      id: 'token-workspace-id',
+      activationStatus: WorkspaceActivationStatus.ACTIVE,
+    });
+    find.mockResolvedValue([]);
+
+    const authedRequest = {
+      ...request,
+      headers: { authorization: 'Bearer app-token' },
+    } as unknown as Request;
+
+    await expect(
+      service.handle({ request: authedRequest, httpMethod: HTTPMethod.GET }),
+    ).rejects.toMatchObject({
+      code: RouteTriggerExceptionCode.TRIGGER_NOT_FOUND,
+    });
+
+    expect(findOneBy).toHaveBeenCalledWith({ id: 'token-workspace-id' });
+    expect(find).toHaveBeenCalledWith({
+      where: {
+        workspaceId: 'token-workspace-id',
+        httpRouteTriggerSettings: expect.anything(),
+      },
+    });
+  });
+
+  it('should reject with WORKSPACE_NOT_FOUND when the host resolves no workspace and the token is invalid', async () => {
+    resolveWorkspaceAndPublicDomain.mockResolvedValue({
+      workspace: undefined,
+      publicDomain: null,
+      isIsolatedOrigin: false,
+    });
+    validateTokenByRequest.mockRejectedValue(new Error('invalid token'));
+
+    const authedRequest = {
+      ...request,
+      headers: { authorization: 'Bearer expired-token' },
+    } as unknown as Request;
+
+    await expect(
+      service.handle({ request: authedRequest, httpMethod: HTTPMethod.GET }),
+    ).rejects.toMatchObject({
+      code: RouteTriggerExceptionCode.WORKSPACE_NOT_FOUND,
+    });
+
+    expect(find).not.toHaveBeenCalled();
+  });
+
+  it('should keep the host workspace when the host resolves one', async () => {
+    resolveWorkspaceAndPublicDomain.mockResolvedValue({
+      workspace: {
+        id: 'workspace-id',
+        activationStatus: WorkspaceActivationStatus.ACTIVE,
+      },
+      publicDomain: null,
+      isIsolatedOrigin: false,
+    });
+    find.mockResolvedValue([]);
+
+    const authedRequest = {
+      ...request,
+      headers: { authorization: 'Bearer other-workspace-token' },
+    } as unknown as Request;
+
+    await expect(
+      service.handle({ request: authedRequest, httpMethod: HTTPMethod.GET }),
+    ).rejects.toMatchObject({
+      code: RouteTriggerExceptionCode.TRIGGER_NOT_FOUND,
+    });
+
+    expect(validateTokenByRequest).not.toHaveBeenCalled();
   });
 });

--- a/packages/twenty-server/src/engine/core-modules/logic-function/logic-function-trigger/triggers/route/__tests__/route-trigger.service.spec.ts
+++ b/packages/twenty-server/src/engine/core-modules/logic-function/logic-function-trigger/triggers/route/__tests__/route-trigger.service.spec.ts
@@ -13,7 +13,6 @@ import { RouteTriggerExceptionCode } from 'src/engine/core-modules/logic-functio
 import { RouteTriggerService } from 'src/engine/core-modules/logic-function/logic-function-trigger/triggers/route/route-trigger.service';
 import { buildRouteTriggerResponse } from 'src/engine/core-modules/logic-function/logic-function-trigger/triggers/route/utils/route-trigger-response.util';
 import { type TwentyConfigService } from 'src/engine/core-modules/twenty-config/twenty-config.service';
-import { type WorkspaceEntity } from 'src/engine/core-modules/workspace/workspace.entity';
 import { type LogicFunctionEntity } from 'src/engine/metadata-modules/logic-function/logic-function.entity';
 
 describe('buildRouteTriggerResponse', () => {
@@ -65,23 +64,19 @@ describe('buildRouteTriggerResponse', () => {
 describe('RouteTriggerService', () => {
   const resolveWorkspaceAndPublicDomain = jest.fn();
   const find = jest.fn();
-  const validateTokenByRequest = jest.fn();
-  const findOneBy = jest.fn();
 
   const service = new RouteTriggerService(
-    { validateTokenByRequest } as unknown as AccessTokenService,
+    {} as unknown as AccessTokenService,
     {} as unknown as LogicFunctionTriggerService,
     { resolveWorkspaceAndPublicDomain } as unknown as WorkspaceDomainsService,
     { get: jest.fn() } as unknown as TwentyConfigService,
     { find } as unknown as Repository<LogicFunctionEntity>,
-    { findOneBy } as unknown as Repository<WorkspaceEntity>,
   );
 
   const request = {
     protocol: 'https',
     get: () => 'acme.twenty.com',
     path: '/s/webhook',
-    headers: {},
   } as unknown as Request;
 
   afterEach(() => {
@@ -130,103 +125,5 @@ describe('RouteTriggerService', () => {
         httpRouteTriggerSettings: expect.anything(),
       },
     });
-  });
-
-  it('should reject with WORKSPACE_NOT_FOUND when the host resolves no workspace and no token is sent', async () => {
-    resolveWorkspaceAndPublicDomain.mockResolvedValue({
-      workspace: undefined,
-      publicDomain: null,
-      isIsolatedOrigin: false,
-    });
-
-    await expect(
-      service.handle({ request, httpMethod: HTTPMethod.GET }),
-    ).rejects.toMatchObject({
-      code: RouteTriggerExceptionCode.WORKSPACE_NOT_FOUND,
-    });
-
-    expect(validateTokenByRequest).not.toHaveBeenCalled();
-  });
-
-  it('should resolve the workspace from the token when the host resolves none', async () => {
-    resolveWorkspaceAndPublicDomain.mockResolvedValue({
-      workspace: undefined,
-      publicDomain: null,
-      isIsolatedOrigin: false,
-    });
-    validateTokenByRequest.mockResolvedValue({
-      workspace: { id: 'token-workspace-id' },
-    });
-    findOneBy.mockResolvedValue({
-      id: 'token-workspace-id',
-      activationStatus: WorkspaceActivationStatus.ACTIVE,
-    });
-    find.mockResolvedValue([]);
-
-    const authedRequest = {
-      ...request,
-      headers: { authorization: 'Bearer app-token' },
-    } as unknown as Request;
-
-    await expect(
-      service.handle({ request: authedRequest, httpMethod: HTTPMethod.GET }),
-    ).rejects.toMatchObject({
-      code: RouteTriggerExceptionCode.TRIGGER_NOT_FOUND,
-    });
-
-    expect(findOneBy).toHaveBeenCalledWith({ id: 'token-workspace-id' });
-    expect(find).toHaveBeenCalledWith({
-      where: {
-        workspaceId: 'token-workspace-id',
-        httpRouteTriggerSettings: expect.anything(),
-      },
-    });
-  });
-
-  it('should reject with WORKSPACE_NOT_FOUND when the host resolves no workspace and the token is invalid', async () => {
-    resolveWorkspaceAndPublicDomain.mockResolvedValue({
-      workspace: undefined,
-      publicDomain: null,
-      isIsolatedOrigin: false,
-    });
-    validateTokenByRequest.mockRejectedValue(new Error('invalid token'));
-
-    const authedRequest = {
-      ...request,
-      headers: { authorization: 'Bearer expired-token' },
-    } as unknown as Request;
-
-    await expect(
-      service.handle({ request: authedRequest, httpMethod: HTTPMethod.GET }),
-    ).rejects.toMatchObject({
-      code: RouteTriggerExceptionCode.WORKSPACE_NOT_FOUND,
-    });
-
-    expect(find).not.toHaveBeenCalled();
-  });
-
-  it('should keep the host workspace when the host resolves one', async () => {
-    resolveWorkspaceAndPublicDomain.mockResolvedValue({
-      workspace: {
-        id: 'workspace-id',
-        activationStatus: WorkspaceActivationStatus.ACTIVE,
-      },
-      publicDomain: null,
-      isIsolatedOrigin: false,
-    });
-    find.mockResolvedValue([]);
-
-    const authedRequest = {
-      ...request,
-      headers: { authorization: 'Bearer other-workspace-token' },
-    } as unknown as Request;
-
-    await expect(
-      service.handle({ request: authedRequest, httpMethod: HTTPMethod.GET }),
-    ).rejects.toMatchObject({
-      code: RouteTriggerExceptionCode.TRIGGER_NOT_FOUND,
-    });
-
-    expect(validateTokenByRequest).not.toHaveBeenCalled();
   });
 });

--- a/packages/twenty-server/src/engine/core-modules/logic-function/logic-function-trigger/triggers/route/route-trigger.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/logic-function/logic-function-trigger/triggers/route/route-trigger.service.ts
@@ -22,6 +22,7 @@ import {
 } from 'src/engine/core-modules/logic-function/logic-function-trigger/triggers/route/exceptions/route-trigger.exception';
 import { LogicFunctionTriggerService } from 'src/engine/core-modules/logic-function/logic-function-trigger/logic-function-trigger.service';
 import { type RouteTriggerResponse } from 'src/engine/core-modules/logic-function/logic-function-trigger/triggers/route/utils/route-trigger-response.util';
+import { sanitizeRouteTriggerPath } from 'src/engine/core-modules/logic-function/logic-function-trigger/triggers/route/utils/sanitize-route-trigger-path.util';
 import {
   LogicFunctionException,
   LogicFunctionExceptionCode,
@@ -271,7 +272,7 @@ export class RouteTriggerService {
       this.findLogicFunctionWithPathParamsOrFail({
         httpMethod,
         logicFunctionsWithHttpRouteTrigger,
-        requestPath: request.path.replace(/^\/s\//, '/'),
+        requestPath: sanitizeRouteTriggerPath(request.path),
       });
 
     this.assertLegacyRouteIsServableOrThrow({

--- a/packages/twenty-server/src/engine/core-modules/logic-function/logic-function-trigger/triggers/route/route-trigger.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/logic-function/logic-function-trigger/triggers/route/route-trigger.service.ts
@@ -10,9 +10,11 @@ import { IsNull, Not, Repository } from 'typeorm';
 import { HTTPMethod } from 'twenty-shared/types';
 import { WorkspaceActivationStatus } from 'twenty-shared/workspace';
 
+import { AuthException } from 'src/engine/core-modules/auth/auth.exception';
 import { AccessTokenService } from 'src/engine/core-modules/auth/token/services/access-token.service';
+import { type AuthContext } from 'src/engine/core-modules/auth/types/auth-context.type';
 import { WorkspaceDomainsService } from 'src/engine/core-modules/domain/workspace-domains/services/workspace-domains.service';
-import { WorkspaceEntity } from 'src/engine/core-modules/workspace/workspace.entity';
+import { type WorkspaceEntity } from 'src/engine/core-modules/workspace/workspace.entity';
 import { TwentyConfigService } from 'src/engine/core-modules/twenty-config/twenty-config.service';
 import {
   RouteTriggerException,
@@ -31,6 +33,11 @@ import {
 } from 'src/engine/core-modules/logic-function/logic-function-executor/logic-function-executor.service';
 import { CustomException } from 'src/utils/custom-exception';
 
+type RouteTriggerWorkspace = Pick<
+  WorkspaceEntity,
+  'activationStatus' | 'id' | 'subdomain'
+>;
+
 @Injectable()
 export class RouteTriggerService {
   private readonly logger = new Logger(RouteTriggerService.name);
@@ -42,8 +49,6 @@ export class RouteTriggerService {
     private readonly twentyConfigService: TwentyConfigService,
     @InjectRepository(LogicFunctionEntity)
     private readonly logicFunctionRepository: Repository<LogicFunctionEntity>,
-    @InjectRepository(WorkspaceEntity)
-    private readonly workspaceRepository: Repository<WorkspaceEntity>,
   ) {}
 
   private async getLogicFunctionWithPathParamsOrFail({
@@ -56,14 +61,23 @@ export class RouteTriggerService {
     logicFunction: LogicFunctionEntity;
     pathParams: Partial<Record<string, string | string[]>>;
     isIsolatedOrigin: boolean;
+    authenticationContext: AuthContext | undefined;
   }> {
     const host = `${request.protocol}://${request.get('host')}`;
 
-    const { workspace: workspaceFromHost, publicDomain, isIsolatedOrigin } =
-      await this.workspaceDomainsService.resolveWorkspaceAndPublicDomain(host);
+    const {
+      workspace: workspaceFromHost,
+      publicDomain,
+      isIsolatedOrigin,
+    } = await this.workspaceDomainsService.resolveWorkspaceAndPublicDomain(
+      host,
+    );
 
-    const workspace =
-      workspaceFromHost ?? (await this.resolveWorkspaceFromToken(request));
+    const authenticationContext = isDefined(workspaceFromHost)
+      ? undefined
+      : await this.resolveAuthenticationContextFromBearerToken(request);
+
+    const workspace = workspaceFromHost ?? authenticationContext?.workspace;
 
     assertIsDefinedOrThrow(
       workspace,
@@ -120,6 +134,7 @@ export class RouteTriggerService {
           logicFunction,
           pathParams: routeMatched.params,
           isIsolatedOrigin,
+          authenticationContext,
         };
       }
     }
@@ -136,7 +151,7 @@ export class RouteTriggerService {
     isIsolatedOrigin,
   }: {
     logicFunction: LogicFunctionEntity;
-    workspace: WorkspaceEntity;
+    workspace: RouteTriggerWorkspace;
     isIsolatedOrigin: boolean;
   }) {
     if (isIsolatedOrigin) {
@@ -185,54 +200,48 @@ export class RouteTriggerService {
   private async validateWorkspaceFromRequest({
     request,
     workspaceId,
+    authenticationContext,
   }: {
     request: Request;
     workspaceId: string;
+    authenticationContext: AuthContext | undefined;
   }) {
-    const authContext =
-      await this.accessTokenService.validateTokenByRequest(request);
+    const resolvedAuthenticationContext =
+      authenticationContext ??
+      (await this.accessTokenService.validateTokenByRequest(request));
 
-    if (!isDefined(authContext.workspace)) {
+    if (!isDefined(resolvedAuthenticationContext.workspace)) {
       throw new RouteTriggerException(
         'Workspace not found',
         RouteTriggerExceptionCode.WORKSPACE_NOT_FOUND,
       );
     }
 
-    if (authContext.workspace.id !== workspaceId) {
+    if (resolvedAuthenticationContext.workspace.id !== workspaceId) {
       throw new RouteTriggerException(
         'You are not authorized',
         RouteTriggerExceptionCode.FORBIDDEN_EXCEPTION,
       );
     }
 
-    return authContext;
+    return resolvedAuthenticationContext;
   }
 
-  // Invalid tokens resolve to undefined, not throw: public-route callers on an
-  // unresolvable host must keep getting WORKSPACE_NOT_FOUND, not an auth error.
-  private async resolveWorkspaceFromToken(
+  private async resolveAuthenticationContextFromBearerToken(
     request: Request,
-  ): Promise<WorkspaceEntity | undefined> {
+  ): Promise<AuthContext | undefined> {
     if (!isNonEmptyString(request.headers.authorization)) {
       return undefined;
     }
 
     try {
-      const authContext =
-        await this.accessTokenService.validateTokenByRequest(request);
-
-      if (!isDefined(authContext.workspace)) {
+      return await this.accessTokenService.validateTokenByRequest(request);
+    } catch (error) {
+      if (error instanceof AuthException) {
         return undefined;
       }
 
-      return (
-        (await this.workspaceRepository.findOneBy({
-          id: authContext.workspace.id,
-        })) ?? undefined
-      );
-    } catch {
-      return undefined;
+      throw error;
     }
   }
 
@@ -267,11 +276,15 @@ export class RouteTriggerService {
     request: Request;
     httpMethod: HTTPMethod;
   }): Promise<{ response: RouteTriggerResponse; isIsolatedOrigin: boolean }> {
-    const { logicFunction, pathParams, isIsolatedOrigin } =
-      await this.getLogicFunctionWithPathParamsOrFail({
-        request,
-        httpMethod,
-      });
+    const {
+      logicFunction,
+      pathParams,
+      isIsolatedOrigin,
+      authenticationContext,
+    } = await this.getLogicFunctionWithPathParamsOrFail({
+      request,
+      httpMethod,
+    });
 
     const httpRouteSettings = logicFunction.httpRouteTriggerSettings;
 
@@ -282,6 +295,7 @@ export class RouteTriggerService {
       const authContext = await this.validateWorkspaceFromRequest({
         request,
         workspaceId: logicFunction.workspaceId,
+        authenticationContext,
       });
 
       userWorkspaceId = authContext.userWorkspaceId ?? null;

--- a/packages/twenty-server/src/engine/core-modules/logic-function/logic-function-trigger/triggers/route/route-trigger.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/logic-function/logic-function-trigger/triggers/route/route-trigger.service.ts
@@ -42,6 +42,8 @@ export class RouteTriggerService {
     private readonly twentyConfigService: TwentyConfigService,
     @InjectRepository(LogicFunctionEntity)
     private readonly logicFunctionRepository: Repository<LogicFunctionEntity>,
+    @InjectRepository(WorkspaceEntity)
+    private readonly workspaceRepository: Repository<WorkspaceEntity>,
   ) {}
 
   private async getLogicFunctionWithPathParamsOrFail({
@@ -57,8 +59,11 @@ export class RouteTriggerService {
   }> {
     const host = `${request.protocol}://${request.get('host')}`;
 
-    const { workspace, publicDomain, isIsolatedOrigin } =
+    const { workspace: workspaceFromHost, publicDomain, isIsolatedOrigin } =
       await this.workspaceDomainsService.resolveWorkspaceAndPublicDomain(host);
+
+    const workspace =
+      workspaceFromHost ?? (await this.resolveWorkspaceFromToken(request));
 
     assertIsDefinedOrThrow(
       workspace,
@@ -202,6 +207,33 @@ export class RouteTriggerService {
     }
 
     return authContext;
+  }
+
+  // Invalid tokens resolve to undefined, not throw: public-route callers on an
+  // unresolvable host must keep getting WORKSPACE_NOT_FOUND, not an auth error.
+  private async resolveWorkspaceFromToken(
+    request: Request,
+  ): Promise<WorkspaceEntity | undefined> {
+    if (!isNonEmptyString(request.headers.authorization)) {
+      return undefined;
+    }
+
+    try {
+      const authContext =
+        await this.accessTokenService.validateTokenByRequest(request);
+
+      if (!isDefined(authContext.workspace)) {
+        return undefined;
+      }
+
+      return (
+        (await this.workspaceRepository.findOneBy({
+          id: authContext.workspace.id,
+        })) ?? undefined
+      );
+    } catch {
+      return undefined;
+    }
   }
 
   private mapErrorToRouteTriggerCode(

--- a/packages/twenty-server/src/engine/core-modules/logic-function/logic-function-trigger/triggers/route/route-trigger.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/logic-function/logic-function-trigger/triggers/route/route-trigger.service.ts
@@ -38,6 +38,13 @@ type RouteTriggerWorkspace = Pick<
   'activationStatus' | 'id' | 'subdomain'
 >;
 
+type RouteTriggerRequestContext = {
+  workspace: RouteTriggerWorkspace;
+  applicationId: string | null;
+  isIsolatedOrigin: boolean;
+  authenticationContext: AuthContext | undefined;
+};
+
 @Injectable()
 export class RouteTriggerService {
   private readonly logger = new Logger(RouteTriggerService.name);
@@ -51,18 +58,34 @@ export class RouteTriggerService {
     private readonly logicFunctionRepository: Repository<LogicFunctionEntity>,
   ) {}
 
-  private async getLogicFunctionWithPathParamsOrFail({
+  private async resolveAuthenticationContextForWorkspaceFallback({
     request,
-    httpMethod,
+    workspaceFromHost,
   }: {
     request: Request;
-    httpMethod: HTTPMethod;
-  }): Promise<{
-    logicFunction: LogicFunctionEntity;
-    pathParams: Partial<Record<string, string | string[]>>;
-    isIsolatedOrigin: boolean;
-    authenticationContext: AuthContext | undefined;
-  }> {
+    workspaceFromHost: RouteTriggerWorkspace | undefined;
+  }): Promise<AuthContext | undefined> {
+    if (
+      isDefined(workspaceFromHost) ||
+      !isNonEmptyString(request.headers.authorization)
+    ) {
+      return undefined;
+    }
+
+    try {
+      return await this.accessTokenService.validateTokenByRequest(request);
+    } catch (error) {
+      if (error instanceof AuthException) {
+        return undefined;
+      }
+
+      throw error;
+    }
+  }
+
+  private async resolveRouteTriggerRequestContextOrFail(
+    request: Request,
+  ): Promise<RouteTriggerRequestContext> {
     const host = `${request.protocol}://${request.get('host')}`;
 
     const {
@@ -73,9 +96,11 @@ export class RouteTriggerService {
       host,
     );
 
-    const authenticationContext = isDefined(workspaceFromHost)
-      ? undefined
-      : await this.resolveAuthenticationContextFromBearerToken(request);
+    const authenticationContext =
+      await this.resolveAuthenticationContextForWorkspaceFallback({
+        request,
+        workspaceFromHost,
+      });
 
     const workspace = workspaceFromHost ?? authenticationContext?.workspace;
 
@@ -94,20 +119,26 @@ export class RouteTriggerService {
       );
     }
 
-    // App-scoped public domain → restrict matches to that app's logic functions.
-    const applicationId = publicDomain?.applicationId ?? null;
+    return {
+      workspace,
+      applicationId: publicDomain?.applicationId ?? null,
+      isIsolatedOrigin,
+      authenticationContext,
+    };
+  }
 
-    const logicFunctionsWithHttpRouteTrigger =
-      await this.logicFunctionRepository.find({
-        where: {
-          workspaceId: workspace.id,
-          httpRouteTriggerSettings: Not(IsNull()),
-          ...(isDefined(applicationId) ? { applicationId } : {}),
-        },
-      });
-
-    const requestPath = request.path.replace(/^\/s\//, '/');
-
+  private findLogicFunctionWithPathParamsOrFail({
+    httpMethod,
+    logicFunctionsWithHttpRouteTrigger,
+    requestPath,
+  }: {
+    httpMethod: HTTPMethod;
+    logicFunctionsWithHttpRouteTrigger: LogicFunctionEntity[];
+    requestPath: string;
+  }): {
+    logicFunction: LogicFunctionEntity;
+    pathParams: Partial<Record<string, string | string[]>>;
+  } {
     for (const logicFunction of logicFunctionsWithHttpRouteTrigger) {
       const httpRouteSettings = logicFunction.httpRouteTriggerSettings;
 
@@ -124,17 +155,9 @@ export class RouteTriggerService {
       const routeMatched = routeMatcher(requestPath);
 
       if (routeMatched) {
-        this.assertLegacyRouteIsServableOrThrow({
-          logicFunction,
-          workspace,
-          isIsolatedOrigin,
-        });
-
         return {
           logicFunction,
           pathParams: routeMatched.params,
-          isIsolatedOrigin,
-          authenticationContext,
         };
       }
     }
@@ -197,54 +220,6 @@ export class RouteTriggerService {
     }
   }
 
-  private async validateWorkspaceFromRequest({
-    request,
-    workspaceId,
-    authenticationContext,
-  }: {
-    request: Request;
-    workspaceId: string;
-    authenticationContext: AuthContext | undefined;
-  }) {
-    const resolvedAuthenticationContext =
-      authenticationContext ??
-      (await this.accessTokenService.validateTokenByRequest(request));
-
-    if (!isDefined(resolvedAuthenticationContext.workspace)) {
-      throw new RouteTriggerException(
-        'Workspace not found',
-        RouteTriggerExceptionCode.WORKSPACE_NOT_FOUND,
-      );
-    }
-
-    if (resolvedAuthenticationContext.workspace.id !== workspaceId) {
-      throw new RouteTriggerException(
-        'You are not authorized',
-        RouteTriggerExceptionCode.FORBIDDEN_EXCEPTION,
-      );
-    }
-
-    return resolvedAuthenticationContext;
-  }
-
-  private async resolveAuthenticationContextFromBearerToken(
-    request: Request,
-  ): Promise<AuthContext | undefined> {
-    if (!isNonEmptyString(request.headers.authorization)) {
-      return undefined;
-    }
-
-    try {
-      return await this.accessTokenService.validateTokenByRequest(request);
-    } catch (error) {
-      if (error instanceof AuthException) {
-        return undefined;
-      }
-
-      throw error;
-    }
-  }
-
   private mapErrorToRouteTriggerCode(
     error: unknown,
   ): RouteTriggerExceptionCode {
@@ -277,13 +252,32 @@ export class RouteTriggerService {
     httpMethod: HTTPMethod;
   }): Promise<{ response: RouteTriggerResponse; isIsolatedOrigin: boolean }> {
     const {
-      logicFunction,
-      pathParams,
+      workspace,
+      applicationId,
       isIsolatedOrigin,
       authenticationContext,
-    } = await this.getLogicFunctionWithPathParamsOrFail({
-      request,
-      httpMethod,
+    } = await this.resolveRouteTriggerRequestContextOrFail(request);
+
+    const logicFunctionsWithHttpRouteTrigger =
+      await this.logicFunctionRepository.find({
+        where: {
+          workspaceId: workspace.id,
+          httpRouteTriggerSettings: Not(IsNull()),
+          ...(isDefined(applicationId) ? { applicationId } : {}),
+        },
+      });
+
+    const { logicFunction, pathParams } =
+      this.findLogicFunctionWithPathParamsOrFail({
+        httpMethod,
+        logicFunctionsWithHttpRouteTrigger,
+        requestPath: request.path.replace(/^\/s\//, '/'),
+      });
+
+    this.assertLegacyRouteIsServableOrThrow({
+      logicFunction,
+      workspace,
+      isIsolatedOrigin,
     });
 
     const httpRouteSettings = logicFunction.httpRouteTriggerSettings;
@@ -292,14 +286,26 @@ export class RouteTriggerService {
     let userId: string | null = null;
 
     if (httpRouteSettings?.isAuthRequired) {
-      const authContext = await this.validateWorkspaceFromRequest({
-        request,
-        workspaceId: logicFunction.workspaceId,
-        authenticationContext,
-      });
+      const routeAuthenticationContext =
+        authenticationContext ??
+        (await this.accessTokenService.validateTokenByRequest(request));
 
-      userWorkspaceId = authContext.userWorkspaceId ?? null;
-      userId = authContext.user?.id ?? null;
+      if (!isDefined(routeAuthenticationContext.workspace)) {
+        throw new RouteTriggerException(
+          'Workspace not found',
+          RouteTriggerExceptionCode.WORKSPACE_NOT_FOUND,
+        );
+      }
+
+      if (routeAuthenticationContext.workspace.id !== workspace.id) {
+        throw new RouteTriggerException(
+          'You are not authorized',
+          RouteTriggerExceptionCode.FORBIDDEN_EXCEPTION,
+        );
+      }
+
+      userWorkspaceId = routeAuthenticationContext.userWorkspaceId ?? null;
+      userId = routeAuthenticationContext.user?.id ?? null;
     }
 
     let outcome;

--- a/packages/twenty-server/src/engine/core-modules/logic-function/logic-function-trigger/triggers/route/utils/sanitize-route-trigger-path.util.ts
+++ b/packages/twenty-server/src/engine/core-modules/logic-function/logic-function-trigger/triggers/route/utils/sanitize-route-trigger-path.util.ts
@@ -1,0 +1,2 @@
+export const sanitizeRouteTriggerPath = (requestPath: string): string =>
+  requestPath.replace(/^\/s\//, '/');

--- a/packages/twenty-server/test/integration/route-trigger/suites/route-trigger-suspended-workspace.integration-spec.ts
+++ b/packages/twenty-server/test/integration/route-trigger/suites/route-trigger-suspended-workspace.integration-spec.ts
@@ -18,6 +18,8 @@ const APP_UNIVERSAL_IDENTIFIER = '6a6f983f-5c1a-4c60-a3c8-7d0e2a4a66a6';
 const ROLE_UNIVERSAL_IDENTIFIER = '7b7f983f-5c1a-4c60-a3c8-7d0e2a4a77b7';
 const ROUTE_FUNCTION_UNIVERSAL_IDENTIFIER =
   '8c8f983f-5c1a-4c60-a3c8-7d0e2a4a88c8';
+const AUTHENTICATED_ROUTE_FUNCTION_UNIVERSAL_IDENTIFIER =
+  '9d9f983f-5c1a-4c60-a3c8-7d0e2a4a99d9';
 
 const ROUTE_FUNCTION_RESPONSE = { greeting: 'hello from route function' };
 
@@ -57,6 +59,20 @@ const routeFunctionManifest: LogicFunctionManifest = {
     path: '/suspended-workspace-route',
     httpMethod: 'GET',
     isAuthRequired: false,
+  },
+};
+
+const authenticatedRouteFunctionManifest: LogicFunctionManifest = {
+  universalIdentifier: AUTHENTICATED_ROUTE_FUNCTION_UNIVERSAL_IDENTIFIER,
+  name: 'authenticated-workspace-route',
+  handlerName: 'main',
+  sourceHandlerPath: 'src/authenticated-workspace-route.ts',
+  builtHandlerPath: 'dist/authenticated-workspace-route.mjs',
+  builtHandlerChecksum: 'checksum-authenticated-workspace-route',
+  httpRouteTriggerSettings: {
+    path: '/authenticated-workspace-route',
+    httpMethod: 'GET',
+    isAuthRequired: true,
   },
 };
 
@@ -101,12 +117,20 @@ describe('RouteTrigger suspended workspace (integration)', () => {
       builtHandlerCode: ROUTE_BUILT_HANDLER_CODE,
     });
 
+    await uploadBuiltHandlerFile({
+      builtHandlerPath: 'dist/authenticated-workspace-route.mjs',
+      builtHandlerCode: ROUTE_BUILT_HANDLER_CODE,
+    });
+
     await syncApplication({
       manifest: buildBaseManifest({
         appId: APP_UNIVERSAL_IDENTIFIER,
         roleId: ROLE_UNIVERSAL_IDENTIFIER,
         overrides: {
-          logicFunctions: [routeFunctionManifest],
+          logicFunctions: [
+            routeFunctionManifest,
+            authenticatedRouteFunctionManifest,
+          ],
         },
       }),
       expectToFail: false,
@@ -147,6 +171,18 @@ describe('RouteTrigger suspended workspace (integration)', () => {
       applicationUniversalIdentifier: APP_UNIVERSAL_IDENTIFIER,
     });
   }, 60000);
+
+  describe('GET /s/authenticated-workspace-route', () => {
+    it('should serve an authenticated route when the bearer token resolves the workspace', async () => {
+      const response = await request(baseUrl)
+        .get('/s/authenticated-workspace-route')
+        .set('Host', bareHost)
+        .set('Authorization', `Bearer ${applicationAccessToken}`);
+
+      expect(response.status).toBe(200);
+      expect(response.body).toEqual(ROUTE_FUNCTION_RESPONSE);
+    }, 60000);
+  });
 
   describe('GET /s/suspended-workspace-route', () => {
     it('should return WORKSPACE_NOT_FOUND when neither host nor token identifies a workspace', async () => {

--- a/packages/twenty-server/test/integration/route-trigger/suites/route-trigger-suspended-workspace.integration-spec.ts
+++ b/packages/twenty-server/test/integration/route-trigger/suites/route-trigger-suspended-workspace.integration-spec.ts
@@ -1,6 +1,8 @@
 import request from 'supertest';
+import { findManyApplications } from 'test/integration/graphql/utils/find-many-applications.util';
 import { buildBaseManifest } from 'test/integration/metadata/suites/application/utils/build-base-manifest.util';
 import { cleanupApplicationAndAppRegistration } from 'test/integration/metadata/suites/application/utils/cleanup-application-and-app-registration.util';
+import { generateApplicationToken } from 'test/integration/metadata/suites/application/utils/generate-application-token.util';
 import { setupApplicationForSync } from 'test/integration/metadata/suites/application/utils/setup-application-for-sync.util';
 import { syncApplication } from 'test/integration/metadata/suites/application/utils/sync-application.util';
 import { uploadApplicationFile } from 'test/integration/metadata/suites/application/utils/upload-application-file.util';
@@ -82,7 +84,9 @@ const uploadBuiltHandlerFile = async ({
 
 describe('RouteTrigger suspended workspace (integration)', () => {
   const baseUrl = `http://localhost:${APP_PORT}`;
+  const bareHost = `localhost:${APP_PORT}`;
   const workspaceHost = `apple.localhost:${APP_PORT}`;
+  let applicationAccessToken: string;
 
   beforeAll(async () => {
     await setupApplicationForSync({
@@ -108,6 +112,25 @@ describe('RouteTrigger suspended workspace (integration)', () => {
       expectToFail: false,
     });
 
+    const { data: applicationsData } = await findManyApplications({
+      expectToFail: false,
+    });
+    const routeTriggerApplication = applicationsData.findManyApplications.find(
+      (application) =>
+        application.universalIdentifier === APP_UNIVERSAL_IDENTIFIER,
+    );
+
+    expect(routeTriggerApplication).toBeDefined();
+
+    const { data: applicationTokenData } = await generateApplicationToken({
+      applicationId: routeTriggerApplication!.id,
+      expectToFail: false,
+    });
+
+    applicationAccessToken =
+      applicationTokenData.generateApplicationToken.applicationAccessToken
+        .token;
+
     jest.useRealTimers();
   }, 60000);
 
@@ -126,6 +149,35 @@ describe('RouteTrigger suspended workspace (integration)', () => {
   }, 60000);
 
   describe('GET /s/suspended-workspace-route', () => {
+    it('should return WORKSPACE_NOT_FOUND when neither host nor token identifies a workspace', async () => {
+      const response = await request(baseUrl)
+        .get('/s/suspended-workspace-route')
+        .set('Host', bareHost);
+
+      expect(response.status).toBe(404);
+      expect(response.body.code).toBe('WORKSPACE_NOT_FOUND');
+    }, 60000);
+
+    it('should return WORKSPACE_NOT_FOUND when the bearer token is invalid on an unresolved host', async () => {
+      const response = await request(baseUrl)
+        .get('/s/suspended-workspace-route')
+        .set('Host', bareHost)
+        .set('Authorization', 'Bearer invalid-token');
+
+      expect(response.status).toBe(404);
+      expect(response.body.code).toBe('WORKSPACE_NOT_FOUND');
+    }, 60000);
+
+    it('should resolve the workspace from the bearer token when the host names none', async () => {
+      const response = await request(baseUrl)
+        .get('/s/suspended-workspace-route')
+        .set('Host', bareHost)
+        .set('Authorization', `Bearer ${applicationAccessToken}`);
+
+      expect(response.status).toBe(200);
+      expect(response.body).toEqual(ROUTE_FUNCTION_RESPONSE);
+    }, 60000);
+
     it('serves the route trigger while the workspace is active', async () => {
       const response = await request(baseUrl)
         .get('/s/suspended-workspace-route')


### PR DESCRIPTION
When a request reaches the `/s` route on a host that names no workspace (bare `SERVER_URL` on a multiworkspace instance), resolve the workspace from the bearer token — the same source `/graphql` uses — instead of failing with `WORKSPACE_NOT_FOUND`. Hosts that do name a workspace keep host resolution unchanged, and requests without a token are unaffected.

This makes the client SDK's same-site `${apiBase}/s` fallback work on multiworkspace instances without a configured public domain: app logic functions calling their own HTTP routes (e.g. call-recorder artifact import) currently 404 there, because `TWENTY_FUNCTIONS_URL` is injected empty and the bare server host carries no workspace identity. Cloud (workspace public origin injected) and single-workspace self-host (host resolves the default workspace) never hit this path.

Note: this also allows public routes to be reached through a bare host when a valid token identifies the workspace. It does not change route authorization; the token is used only for workspace resolution.