### PR TITLE
Fix missing translations in data model field creation form

### DIFF
--- a/packages/twenty-front/src/modules/object-record/object-filter-dropdown/utils/getFieldMetadataTypeLabel.ts
+++ b/packages/twenty-front/src/modules/object-record/object-filter-dropdown/utils/getFieldMetadataTypeLabel.ts
@@ -2,6 +2,8 @@ import { isCompositeFieldType } from '@/object-record/object-filter-dropdown/uti
 import { isNonCompositeField } from '@/object-record/object-filter-dropdown/utils/isNonCompositeField';
 import { SETTINGS_COMPOSITE_FIELD_TYPE_CONFIGS } from '@/settings/data-model/constants/SettingsCompositeFieldTypeConfigs';
 import { SETTINGS_NON_COMPOSITE_FIELD_TYPE_CONFIGS } from '@/settings/data-model/constants/SettingsNonCompositeFieldTypeConfigs';
+import { i18n } from '@lingui/core';
+import { isDefined } from 'twenty-shared/utils';
 import { FieldMetadataType } from '~/generated-metadata/graphql';
 
 export const getFieldMetadataTypeLabel = (fieldType: FieldMetadataType) => {
@@ -9,11 +11,18 @@ export const getFieldMetadataTypeLabel = (fieldType: FieldMetadataType) => {
   if (
     isNonCompositeField(fieldType) ||
     fieldType === FieldMetadataType.RELATION
-  )
-    return SETTINGS_NON_COMPOSITE_FIELD_TYPE_CONFIGS[
-      fieldType as keyof typeof SETTINGS_NON_COMPOSITE_FIELD_TYPE_CONFIGS
-    ]?.label;
+  ) {
+    const label =
+      SETTINGS_NON_COMPOSITE_FIELD_TYPE_CONFIGS[
+        fieldType as keyof typeof SETTINGS_NON_COMPOSITE_FIELD_TYPE_CONFIGS
+      ]?.label;
 
-  if (isCompositeFieldType(fieldType))
-    return SETTINGS_COMPOSITE_FIELD_TYPE_CONFIGS[fieldType]?.label;
+    return isDefined(label) ? i18n._(label) : undefined;
+  }
+
+  if (isCompositeFieldType(fieldType)) {
+    const label = SETTINGS_COMPOSITE_FIELD_TYPE_CONFIGS[fieldType]?.label;
+
+    return isDefined(label) ? i18n._(label) : undefined;
+  }
 };

--- a/packages/twenty-front/src/modules/object-record/object-options-dropdown/components/ObjectOptionsDropdownCalendarEndFieldsContent.tsx
+++ b/packages/twenty-front/src/modules/object-record/object-options-dropdown/components/ObjectOptionsDropdownCalendarEndFieldsContent.tsx
@@ -21,7 +21,7 @@ import { MenuItemSelect } from 'twenty-ui/navigation';
 import { FeatureFlagKey } from '~/generated-metadata/graphql';
 
 export const ObjectOptionsDropdownCalendarEndFieldsContent = () => {
-  const { t } = useLingui();
+  const { i18n, t } = useLingui();
   const { getIcon } = useIcons();
   const [searchInput, setSearchInput] = useState('');
   const isCalendarWeekViewEnabled = useIsFeatureEnabled(
@@ -46,7 +46,7 @@ export const ObjectOptionsDropdownCalendarEndFieldsContent = () => {
 
   const filteredCalendarEndFields =
     availableCalendarEndFieldMetadataItems.filter((field) =>
-      field.label.toLowerCase().includes(searchInput.toLowerCase()),
+      i18n._(field.label).toLowerCase().includes(searchInput.toLowerCase()),
     );
 
   const handleCalendarEndFieldChange = async (
@@ -100,7 +100,7 @@ export const ObjectOptionsDropdownCalendarEndFieldsContent = () => {
             }
             onClick={() => handleCalendarEndFieldChange(fieldMetadataItem)}
             LeftIcon={getIcon(fieldMetadataItem.icon)}
-            text={fieldMetadataItem.label}
+            text={i18n._(fieldMetadataItem.label)}
           />
         ))}
       </DropdownMenuItemsContainer>

--- a/packages/twenty-front/src/modules/object-record/object-options-dropdown/components/ObjectOptionsDropdownCalendarFieldsContent.tsx
+++ b/packages/twenty-front/src/modules/object-record/object-options-dropdown/components/ObjectOptionsDropdownCalendarFieldsContent.tsx
@@ -19,7 +19,7 @@ import { IconChevronLeft, IconSettings, useIcons } from 'twenty-ui/icon';
 import { MenuItem, MenuItemSelect } from 'twenty-ui/navigation';
 
 export const ObjectOptionsDropdownCalendarFieldsContent = () => {
-  const { t } = useLingui();
+  const { i18n, t } = useLingui();
   const { getIcon } = useIcons();
   const [searchInput, setSearchInput] = useState('');
 
@@ -51,7 +51,7 @@ export const ObjectOptionsDropdownCalendarFieldsContent = () => {
     : undefined;
 
   const filteredCalendarFields = availableFieldsForCalendar.filter((field) =>
-    field.label.toLowerCase().includes(searchInput.toLowerCase()),
+    i18n._(field.label).toLowerCase().includes(searchInput.toLowerCase()),
   );
 
   const handleCalendarFieldChange = async (
@@ -103,7 +103,7 @@ export const ObjectOptionsDropdownCalendarFieldsContent = () => {
             selected={fieldMetadataItem.id === calendarFieldMetadata?.id}
             onClick={() => handleCalendarFieldChange(fieldMetadataItem)}
             LeftIcon={getIcon(fieldMetadataItem.icon)}
-            text={fieldMetadataItem.label}
+            text={i18n._(fieldMetadataItem.label)}
           />
         ))}
       </DropdownMenuItemsContainer>

--- a/packages/twenty-front/src/modules/settings/data-model/constants/SettingsCompositeFieldTypeConfigs.ts
+++ b/packages/twenty-front/src/modules/settings/data-model/constants/SettingsCompositeFieldTypeConfigs.ts
@@ -11,6 +11,7 @@ import {
 import { COMPOSITE_FIELD_SUB_FIELD_LABELS } from '@/settings/data-model/constants/CompositeFieldSubFieldLabel';
 import { type SettingsFieldTypeConfig } from '@/settings/data-model/constants/SettingsNonCompositeFieldTypeConfigs';
 import { type CompositeFieldType } from '@/settings/data-model/types/CompositeFieldType';
+import { msg } from '@lingui/core/macro';
 import {
   COMPOSITE_FIELD_TYPE_SUB_FIELDS_NAMES,
   CurrencyCode,
@@ -50,7 +51,7 @@ type SettingsCompositeFieldTypeConfigArray = Record<
 
 export const SETTINGS_COMPOSITE_FIELD_TYPE_CONFIGS = {
   [FieldMetadataType.CURRENCY]: {
-    label: 'Currency',
+    label: msg`Currency`,
     Icon: IllustrationIconCurrency,
     subFields: [
       {
@@ -93,7 +94,7 @@ export const SETTINGS_COMPOSITE_FIELD_TYPE_CONFIGS = {
     category: 'Basic',
   } as const satisfies SettingsCompositeFieldTypeConfig<FieldCurrencyValue>,
   [FieldMetadataType.EMAILS]: {
-    label: 'Emails',
+    label: msg`Emails`,
     Icon: IllustrationIconMail,
     subFields: [
       {
@@ -140,7 +141,7 @@ export const SETTINGS_COMPOSITE_FIELD_TYPE_CONFIGS = {
     category: 'Basic',
   } as const satisfies SettingsCompositeFieldTypeConfig<FieldEmailsValue>,
   [FieldMetadataType.LINKS]: {
-    label: 'Links',
+    label: msg`Links`,
     Icon: IllustrationIconLink,
     subFields: [
       {
@@ -197,7 +198,7 @@ export const SETTINGS_COMPOSITE_FIELD_TYPE_CONFIGS = {
     category: 'Basic',
   } as const satisfies SettingsCompositeFieldTypeConfig<FieldLinksValue>,
   [FieldMetadataType.PHONES]: {
-    label: 'Phones',
+    label: msg`Phones`,
     Icon: IllustrationIconPhone,
     subFields: [
       {
@@ -273,7 +274,7 @@ export const SETTINGS_COMPOSITE_FIELD_TYPE_CONFIGS = {
     category: 'Basic',
   } as const satisfies SettingsCompositeFieldTypeConfig<FieldPhonesValue>,
   [FieldMetadataType.FULL_NAME]: {
-    label: 'Full Name',
+    label: msg`Full Name`,
     Icon: IllustrationIconUser,
     subFields: [
       {
@@ -307,7 +308,7 @@ export const SETTINGS_COMPOSITE_FIELD_TYPE_CONFIGS = {
     category: 'Basic',
   } as const satisfies SettingsCompositeFieldTypeConfig<FieldFullNameValue>,
   [FieldMetadataType.ADDRESS]: {
-    label: 'Address',
+    label: msg`Address`,
     Icon: IllustrationIconMap,
     subFields: [
       {
@@ -434,7 +435,7 @@ export const SETTINGS_COMPOSITE_FIELD_TYPE_CONFIGS = {
     category: 'Basic',
   } as const satisfies SettingsCompositeFieldTypeConfig<FieldAddressValue>,
   [FieldMetadataType.ACTOR]: {
-    label: 'Actor',
+    label: msg`Actor`,
     Icon: IllustrationIconSetting,
     category: 'Basic',
     subFields: [
@@ -500,7 +501,7 @@ export const SETTINGS_COMPOSITE_FIELD_TYPE_CONFIGS = {
     ],
   } as const satisfies SettingsCompositeFieldTypeConfig<FieldActorValue>,
   [FieldMetadataType.RICH_TEXT]: {
-    label: 'Rich Text',
+    label: msg`Rich Text`,
     Icon: IllustrationIconText,
     category: 'Basic',
     subFields: [

--- a/packages/twenty-front/src/modules/settings/data-model/constants/SettingsFieldTypeCategoryLabels.ts
+++ b/packages/twenty-front/src/modules/settings/data-model/constants/SettingsFieldTypeCategoryLabels.ts
@@ -2,11 +2,11 @@ import { type SettingsFieldTypeCategoryType } from '@/settings/data-model/types/
 import { type MessageDescriptor } from '@lingui/core';
 import { msg } from '@lingui/core/macro';
 
-export const SETTINGS_FIELD_TYPE_CATEGORY_DESCRIPTIONS: Record<
+export const SETTINGS_FIELD_TYPE_CATEGORY_LABELS: Record<
   SettingsFieldTypeCategoryType,
   MessageDescriptor
 > = {
-  Basic: msg`All the basic field types you need to start`,
-  Advanced: msg`More advanced fields for advanced projects`,
-  Relation: msg`Create a relation with other objects`,
+  Basic: msg`Basic`,
+  Advanced: msg`Advanced`,
+  Relation: msg`Relation`,
 };

--- a/packages/twenty-front/src/modules/settings/data-model/constants/SettingsNonCompositeFieldTypeConfigs.ts
+++ b/packages/twenty-front/src/modules/settings/data-model/constants/SettingsNonCompositeFieldTypeConfigs.ts
@@ -15,6 +15,8 @@ import {
 import { DEFAULT_DATE_VALUE } from '@/settings/data-model/constants/DefaultDateValue';
 import { type SettingsFieldTypeCategoryType } from '@/settings/data-model/types/SettingsFieldTypeCategoryType';
 import { type SettingsNonCompositeFieldType } from '@/settings/data-model/types/SettingsNonCompositeFieldType';
+import { type MessageDescriptor } from '@lingui/core';
+import { msg } from '@lingui/core/macro';
 import { FILE_CATEGORIES, type FieldRatingValue } from 'twenty-shared/types';
 import {
   IllustrationIconArray,
@@ -37,7 +39,7 @@ import { FieldMetadataType } from '~/generated-metadata/graphql';
 DEFAULT_DATE_VALUE.setFullYear(DEFAULT_DATE_VALUE.getFullYear() + 2);
 
 export type SettingsFieldTypeConfig<T> = {
-  label: string;
+  label: MessageDescriptor;
   Icon: IconComponent;
   exampleValues?: [T, T, T];
   category: SettingsFieldTypeCategoryType;
@@ -52,7 +54,7 @@ type SettingsNonCompositeFieldTypeConfigArray = Record<
 export const SETTINGS_NON_COMPOSITE_FIELD_TYPE_CONFIGS: SettingsNonCompositeFieldTypeConfigArray =
   {
     [FieldMetadataType.UUID]: {
-      label: 'Unique ID',
+      label: msg`Unique ID`,
       Icon: IllustrationIconUid,
       exampleValues: [
         '00000000-0000-4000-8000-000000000000',
@@ -62,7 +64,7 @@ export const SETTINGS_NON_COMPOSITE_FIELD_TYPE_CONFIGS: SettingsNonCompositeFiel
       category: 'Advanced',
     } as const satisfies SettingsFieldTypeConfig<FieldUUidValue>,
     [FieldMetadataType.TEXT]: {
-      label: 'Text',
+      label: msg`Text`,
       Icon: IllustrationIconText,
       exampleValues: [
         'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vestibulum magna enim, dapibus non enim in, lacinia faucibus nunc. Sed interdum ante sed felis facilisis, eget ultricies neque molestie. Mauris auctor, justo eu volutpat cursus, libero erat tempus nulla, non sodales lorem lacus a est.',
@@ -72,19 +74,19 @@ export const SETTINGS_NON_COMPOSITE_FIELD_TYPE_CONFIGS: SettingsNonCompositeFiel
       category: 'Basic',
     } as const satisfies SettingsFieldTypeConfig<FieldTextValue>,
     [FieldMetadataType.NUMBER]: {
-      label: 'Number',
+      label: msg`Number`,
       Icon: IllustrationIconNumbers,
       exampleValues: [2000, 3000, 4000],
       category: 'Basic',
     } as const satisfies SettingsFieldTypeConfig<FieldNumberValue>,
     [FieldMetadataType.BOOLEAN]: {
-      label: 'True/False',
+      label: msg`True/False`,
       Icon: IllustrationIconToggle,
       exampleValues: [true, false, true],
       category: 'Basic',
     } as const satisfies SettingsFieldTypeConfig<FieldBooleanValue>,
     [FieldMetadataType.DATE_TIME]: {
-      label: 'Date and Time',
+      label: msg`Date and Time`,
       Icon: IllustrationIconCalendarTime,
       exampleValues: [
         DEFAULT_DATE_VALUE.toISOString(),
@@ -94,7 +96,7 @@ export const SETTINGS_NON_COMPOSITE_FIELD_TYPE_CONFIGS: SettingsNonCompositeFiel
       category: 'Basic',
     } as const satisfies SettingsFieldTypeConfig<FieldDateTimeValue>,
     [FieldMetadataType.DATE]: {
-      label: 'Date',
+      label: msg`Date`,
       Icon: IllustrationIconCalendarEvent,
       exampleValues: [
         DEFAULT_DATE_VALUE.toISOString(),
@@ -104,45 +106,45 @@ export const SETTINGS_NON_COMPOSITE_FIELD_TYPE_CONFIGS: SettingsNonCompositeFiel
       category: 'Basic',
     } as const satisfies SettingsFieldTypeConfig<FieldDateValue>,
     [FieldMetadataType.SELECT]: {
-      label: 'Select',
+      label: msg`Select`,
       Icon: IllustrationIconTag,
       category: 'Basic',
     } as const satisfies SettingsFieldTypeConfig<FieldSelectValue>,
     [FieldMetadataType.MULTI_SELECT]: {
-      label: 'Multi-select',
+      label: msg`Multi-select`,
       Icon: IllustrationIconTags,
       category: 'Basic',
     } as const satisfies SettingsFieldTypeConfig<FieldMultiSelectValue>,
     [FieldMetadataType.RELATION]: {
-      label: 'Relation',
+      label: msg`Relation`,
       Icon: IllustrationIconOneToMany,
       category: 'Relation',
     } as const satisfies SettingsFieldTypeConfig<FieldRelationValue<any>>,
     [FieldMetadataType.MORPH_RELATION]: {
-      label: 'Morph Relation',
+      label: msg`Morph Relation`,
       Icon: IllustrationIconOneToMany,
       category: 'Relation',
     } as const satisfies SettingsFieldTypeConfig<FieldRelationValue<any>>,
     [FieldMetadataType.RATING]: {
-      label: 'Rating',
+      label: msg`Rating`,
       Icon: IllustrationIconStar,
       exampleValues: ['RATING_3', 'RATING_4', 'RATING_5'],
       category: 'Basic',
     } as const satisfies SettingsFieldTypeConfig<FieldRatingValue>,
     [FieldMetadataType.RAW_JSON]: {
-      label: 'JSON',
+      label: msg`JSON`,
       Icon: IllustrationIconJson,
       exampleValues: [{ key: 'value1' }, { key: 'value2', key2: 'value2' }, {}],
       category: 'Advanced',
     } as const satisfies SettingsFieldTypeConfig<FieldJsonValue>,
     [FieldMetadataType.ARRAY]: {
-      label: 'Array',
+      label: msg`Array`,
       Icon: IllustrationIconArray,
       category: 'Advanced',
       exampleValues: [['value1', 'value2'], ['value3'], []],
     } as const satisfies SettingsFieldTypeConfig<FieldArrayValue>,
     [FieldMetadataType.FILES]: {
-      label: 'Files',
+      label: msg`Files`,
       Icon: IllustrationIconFile,
       category: 'Basic',
       exampleValues: [

--- a/packages/twenty-front/src/modules/settings/data-model/fields/forms/components/SettingsObjectNewFieldSelector.tsx
+++ b/packages/twenty-front/src/modules/settings/data-model/fields/forms/components/SettingsObjectNewFieldSelector.tsx
@@ -2,6 +2,7 @@ import { type FieldMetadataItem } from '@/object-metadata/types/FieldMetadataIte
 import { SettingsCard } from '@/settings/components/SettingsCard';
 import { SETTINGS_FIELD_TYPE_CATEGORIES } from '@/settings/data-model/constants/SettingsFieldTypeCategories';
 import { SETTINGS_FIELD_TYPE_CATEGORY_DESCRIPTIONS } from '@/settings/data-model/constants/SettingsFieldTypeCategoryDescriptions';
+import { SETTINGS_FIELD_TYPE_CATEGORY_LABELS } from '@/settings/data-model/constants/SettingsFieldTypeCategoryLabels';
 import { SETTINGS_FIELD_TYPE_CONFIGS } from '@/settings/data-model/constants/SettingsFieldTypeConfigs';
 import { type SettingsFieldTypeConfig } from '@/settings/data-model/constants/SettingsNonCompositeFieldTypeConfigs';
 import { useBooleanSettingsFormInitialValues } from '@/settings/data-model/fields/forms/boolean/hooks/useBooleanSettingsFormInitialValues';
@@ -11,7 +12,8 @@ import { type FieldType } from '@/settings/data-model/types/FieldType';
 import { type SettingsFieldType } from '@/settings/data-model/types/SettingsFieldType';
 import { SettingsTextInput } from '@/ui/input/components/SettingsTextInput';
 import { styled } from '@linaria/react';
-import { t } from '@lingui/core/macro';
+import { msg } from '@lingui/core/macro';
+import { useLingui } from '@lingui/react/macro';
 import { Section } from 'twenty-ui/layout';
 import { useContext, useState } from 'react';
 import { Controller, useFormContext } from 'react-hook-form';
@@ -70,6 +72,7 @@ export const SettingsObjectNewFieldSelector = ({
   excludedFieldTypes = [],
   objectNamePlural,
 }: SettingsObjectNewFieldSelectorProps) => {
+  const { t } = useLingui();
   const { theme } = useContext(ThemeContext);
   const { control, setValue } =
     useFormContext<SettingsDataModelFieldTypeFormValues>();
@@ -79,7 +82,7 @@ export const SettingsObjectNewFieldSelector = ({
   ).filter(
     ([key, config]) =>
       !excludedFieldTypes.includes(key as SettingsFieldType) &&
-      config.label.toLowerCase().includes(searchQuery.toLowerCase()),
+      t(config.label).toLowerCase().includes(searchQuery.toLowerCase()),
   );
 
   const { resetDefaultValueField: resetBooleanDefaultValueField } =
@@ -132,10 +135,10 @@ export const SettingsObjectNewFieldSelector = ({
             {SETTINGS_FIELD_TYPE_CATEGORIES.map((category) => (
               <Section key={category}>
                 <H2Title
-                  title={category}
-                  description={
-                    SETTINGS_FIELD_TYPE_CATEGORY_DESCRIPTIONS[category]
-                  }
+                  title={t(SETTINGS_FIELD_TYPE_CATEGORY_LABELS[category])}
+                  description={t(
+                    SETTINGS_FIELD_TYPE_CATEGORY_DESCRIPTIONS[category],
+                  )}
                 />
                 <StyledContainer>
                   {fieldTypeConfigs
@@ -146,7 +149,7 @@ export const SettingsObjectNewFieldSelector = ({
                         [
                           key,
                           key === FieldMetadataType.MORPH_RELATION
-                            ? { ...config, label: t`Relation` }
+                            ? { ...config, label: msg`Relation` }
                             : config,
                         ] as [string, SettingsFieldTypeConfig<any>],
                     )
@@ -174,7 +177,7 @@ export const SettingsObjectNewFieldSelector = ({
                                 />
                               </StyledFieldTypeIconContainer>
                             }
-                            title={config.label}
+                            title={t(config.label)}
                           />
                         </UndecoratedLink>
                       </StyledCardContainer>

--- a/packages/twenty-front/src/modules/settings/data-model/object-details/components/SettingsObjectFieldDataType.tsx
+++ b/packages/twenty-front/src/modules/settings/data-model/object-details/components/SettingsObjectFieldDataType.tsx
@@ -3,8 +3,10 @@ import { Link } from 'react-router-dom';
 
 import { type SettingsFieldType } from '@/settings/data-model/types/SettingsFieldType';
 import { getSettingsFieldTypeConfig } from '@/settings/data-model/utils/getSettingsFieldTypeConfig';
+import { useLingui } from '@lingui/react/macro';
 import { type IconComponent, IconTwentyStar } from 'twenty-ui/icon';
 import { useContext } from 'react';
+import { isDefined } from 'twenty-shared/utils';
 import { ThemeContext, themeCssVariables } from 'twenty-ui/theme-constants';
 
 type SettingsObjectFieldDataTypeProps = {
@@ -66,11 +68,14 @@ export const SettingsObjectFieldDataType = ({
   labelDetail,
   onClick,
 }: SettingsObjectFieldDataTypeProps) => {
+  const { t } = useLingui();
   const { theme } = useContext(ThemeContext);
   const fieldTypeConfig = getSettingsFieldTypeConfig(value);
   const Icon: IconComponent =
     IconFromProps ?? fieldTypeConfig?.Icon ?? IconTwentyStar;
-  const label = labelFromProps ?? fieldTypeConfig?.label;
+  const label =
+    labelFromProps ??
+    (isDefined(fieldTypeConfig?.label) ? t(fieldTypeConfig.label) : undefined);
 
   return (
     <StyledDataType

--- a/packages/twenty-front/src/pages/settings/data-model/hooks/useMapFieldMetadataItemToSettingsObjectDetailTableItem.ts
+++ b/packages/twenty-front/src/pages/settings/data-model/hooks/useMapFieldMetadataItemToSettingsObjectDetailTableItem.ts
@@ -11,10 +11,12 @@ import { isFieldTypeSupportedInSettings } from '@/settings/data-model/utils/isFi
 import { type SettingsObjectDetailTableItem } from '~/pages/settings/data-model/types/SettingsObjectDetailTableItem';
 import { getSettingsObjectFieldType } from '~/pages/settings/data-model/utils/getSettingsObjectFieldType';
 import { useAtomStateValue } from '@/ui/utilities/state/jotai/hooks/useAtomStateValue';
+import { useLingui } from '@lingui/react/macro';
 
 export const useMapFieldMetadataItemToSettingsObjectDetailTableItem = (
   objectMetadataItem: EnrichedObjectMetadataItem,
 ) => {
+  const { t } = useLingui();
   const getRelationMetadata = useGetRelationMetadata();
 
   const currentWorkspace = useAtomStateValue(currentWorkspaceState);
@@ -42,14 +44,18 @@ export const useMapFieldMetadataItemToSettingsObjectDetailTableItem = (
 
     const fieldMetadataType = fieldMetadataItem.type as FieldType;
 
+    const fieldTypeConfigLabel = getSettingsFieldTypeConfig(
+      fieldMetadataType as SettingsFieldType,
+    )?.label;
+
     return {
       fieldMetadataItem,
       fieldType: fieldType ?? '',
       dataType:
-        isDefined(relationObjectMetadataItem?.labelPlural) ||
-        isFieldTypeSupportedInSettings(fieldMetadataType)
-          ? getSettingsFieldTypeConfig(fieldMetadataType as SettingsFieldType)
-              ?.label
+        (isDefined(relationObjectMetadataItem?.labelPlural) ||
+          isFieldTypeSupportedInSettings(fieldMetadataType)) &&
+        isDefined(fieldTypeConfigLabel)
+          ? t(fieldTypeConfigLabel)
           : '',
       label: fieldMetadataItem.label,
       identifierType: identifierType,


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/23491?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

