### PR TITLE
`[Upgrade]` Add a detached-run wrapper for the `upgrade` command

### DIFF
--- a/packages/twenty-docker/twenty/Dockerfile
+++ b/packages/twenty-docker/twenty/Dockerfile
@@ -117,6 +117,9 @@ COPY --chown=1000 --from=twenty-server-build /app/packages/twenty-server/dist /a
 COPY --chown=1000 --from=twenty-server-build /app/packages/twenty-server/patches /app/packages/twenty-server/patches
 # Shell entrypoints referenced by package.json scripts (upgrade:background*)
 COPY --chown=1000 --from=twenty-server-build /app/packages/twenty-server/scripts /app/packages/twenty-server/scripts
+# COPY preserves the committed mode, but the scripts are also invoked directly
+# and not only through yarn, so do not let a dropped exec bit reach the pod
+RUN chmod +x /app/packages/twenty-server/scripts/upgrade-background.sh
 
 # Workspace packages (dist + package.json; node_modules symlinks resolve to these)
 COPY --chown=1000 --from=twenty-server-build /app/packages/twenty-shared/package.json /app/packages/twenty-shared/

--- a/packages/twenty-docker/twenty/Dockerfile
+++ b/packages/twenty-docker/twenty/Dockerfile
@@ -115,6 +115,8 @@ COPY --chown=1000 --from=twenty-server-build /app/node_modules /app/node_modules
 COPY --chown=1000 --from=twenty-server-build /app/packages/twenty-server/package.json /app/packages/twenty-server/
 COPY --chown=1000 --from=twenty-server-build /app/packages/twenty-server/dist /app/packages/twenty-server/dist
 COPY --chown=1000 --from=twenty-server-build /app/packages/twenty-server/patches /app/packages/twenty-server/patches
+# Shell entrypoints referenced by package.json scripts (upgrade:background*)
+COPY --chown=1000 --from=twenty-server-build /app/packages/twenty-server/scripts /app/packages/twenty-server/scripts
 
 # Workspace packages (dist + package.json; node_modules symlinks resolve to these)
 COPY --chown=1000 --from=twenty-server-build /app/packages/twenty-shared/package.json /app/packages/twenty-shared/

--- a/packages/twenty-server/docs/UPGRADE_COMMANDS.md
+++ b/packages/twenty-server/docs/UPGRADE_COMMANDS.md
@@ -197,6 +197,8 @@ Ctrl+C cannot reach a detached run at all: it has its own session and no control
 
 The log and PID files live in `/tmp` inside the container (override with `TWENTY_UPGRADE_LOG_FILE` and `TWENTY_UPGRADE_PID_FILE`). Both are lost if the pod is replaced, along with the run itself.
 
+Detaching needs `setsid`, which is what puts the run in its own session. The runtime image has it (busybox provides the applet) and so does any Linux host, but macOS does not ship it, so `upgrade:background` refuses to start there and points you at the foreground command. That is no real loss, since a local run has no connection to drop in the first place.
+
 Kubernetes cannot stop a detached run gracefully either, and `terminationGracePeriodSeconds` is not the lever it looks like. PID 1 in the command-runner pod is `tail -f /dev/null`, so on pod deletion it exits immediately and the detached node process is torn down without ever receiving `SIGTERM`, however long the grace period is. Graceful shutdown on eviction only applies when node is the container's main process, which is the foreground case, not this one.
 
 ## Shipping a command for a future version (deferred drops)

--- a/packages/twenty-server/docs/UPGRADE_COMMANDS.md
+++ b/packages/twenty-server/docs/UPGRADE_COMMANDS.md
@@ -174,6 +174,8 @@ It exits `0` while a run is alive and `1` once none is. Note that `1` means "not
 | `stop --now` | two spaced `SIGTERM`s | immediate exit, step in progress left unfinished |
 | `stop --force` | `SIGKILL` | no graceful boundary, a multi-transaction command may leave partial work |
 
+Every tier prints the tail of the log after signalling, so you can see which workspace and step the run was on without a second command. The plain `stop` waits a moment first, long enough for the runner's "finishing the step in progress" acknowledgement to reach the log, which is the confirmation that the signal was received and is being honoured rather than ignored.
+
 Only the node process is signalled, never the process group. A group signal would also hit the wrapper shell, killing the process that records the exit code and tearing down node's parent while it is trying to finish its segment.
 
 #### Reading the outcome

--- a/packages/twenty-server/docs/UPGRADE_COMMANDS.md
+++ b/packages/twenty-server/docs/UPGRADE_COMMANDS.md
@@ -154,7 +154,19 @@ yarn upgrade:background:logs     # re-attach from another shell
 yarn upgrade:background:stop     # graceful stop; --now for immediate, --force for SIGKILL
 ```
 
-`upgrade:background` refuses to start when a run is already in flight, and forwards any extra arguments (`--include-slow`, workspace filters) to `upgrade`. Ctrl+C on the log stream detaches the stream only, the run keeps going, and `logs` supports any number of concurrent readers.
+`upgrade:background` refuses to start when a run is already in flight. Ctrl+C on the log stream detaches the stream only, the run keeps going, and `logs` supports any number of concurrent readers.
+
+Everything after `upgrade:background` is forwarded verbatim to `upgrade`, so it takes that command's options and no others:
+
+| Option | Effect |
+| --- | --- |
+| `-d`, `--dry-run` | simulate without making changes |
+| `-v`, `--verbose` | verbose output |
+| `-w`, `--workspace-id <id>` | restrict to a workspace, repeatable; all provisioned workspaces if omitted |
+| `--start-from-workspace-id <id>` | resume from a workspace, ascending id order |
+| `--workspace-count-limit <n>` | process at most n workspaces, ascending id order |
+
+`-w` and `--start-from-workspace-id` are mutually exclusive and `upgrade` rejects the combination. Note that `--include-slow` is **not** one of these: it belongs to `run-instance-commands`, which the upgrade pipeline invokes itself.
 
 `logs` is the only one you need to check on a run, because it reports what it found before streaming. If a run is alive it announces the pid and follows the log. If none is alive it prints how the last one ended and dumps the tail instead of following, so it always terminates rather than waiting on a log that will never grow again. That distinction cannot be made from the log alone: a workspace segment can run for many minutes without printing anything, so a silent log looks identical whether the run is grinding through a slow segment or was killed twenty minutes ago. Only the recorded pid answers it.
 

--- a/packages/twenty-server/docs/UPGRADE_COMMANDS.md
+++ b/packages/twenty-server/docs/UPGRADE_COMMANDS.md
@@ -151,21 +151,20 @@ Use it for any long upgrade started over `kubectl exec` or SSH. A foreground run
 ```bash
 yarn upgrade:background [args]   # start detached, then stream the log
 yarn upgrade:background:logs     # re-attach from another shell
-yarn upgrade:background:status   # one-shot check, for scripts
 yarn upgrade:background:stop     # graceful stop; --now for immediate, --force for SIGKILL
 ```
 
 `upgrade:background` refuses to start when a run is already in flight, and forwards any extra arguments (`--include-slow`, workspace filters) to `upgrade`. Ctrl+C on the log stream detaches the stream only, the run keeps going, and `logs` supports any number of concurrent readers.
 
-`logs` is the one to reach for interactively, because it reports what it found before streaming. If a run is alive it announces the pid and follows the log. If none is alive it prints how the last one ended and dumps the tail instead of following, so it always terminates rather than waiting on a log that will never grow again. That distinction cannot be made from the log alone: a workspace segment can run for many minutes without printing anything, so a silent log looks identical whether the run is grinding through a slow segment or was killed twenty minutes ago. Only the recorded pid answers it.
+`logs` is the only one you need to check on a run, because it reports what it found before streaming. If a run is alive it announces the pid and follows the log. If none is alive it prints how the last one ended and dumps the tail instead of following, so it always terminates rather than waiting on a log that will never grow again. That distinction cannot be made from the log alone: a workspace segment can run for many minutes without printing anything, so a silent log looks identical whether the run is grinding through a slow segment or was killed twenty minutes ago. Only the recorded pid answers it.
 
-`status` answers the same question in one line and exits, for scripts rather than people. It exits `0` while a run is alive and `1` once none is, so a wait loop reads as:
+The script also takes a `status` subcommand, which gives the same verdict in one line and exits. It has no yarn entry point because it is meant for scripts rather than people, and calling the script directly avoids both yarn's startup cost per poll and its requirement to be run from the package directory:
 
 ```bash
-until ! yarn upgrade:background:status > /dev/null; do sleep 30; done
+until ! /app/packages/twenty-server/scripts/upgrade-background.sh status > /dev/null; do sleep 30; done
 ```
 
-Note that `1` means "not running", not "failed": a run that completed cleanly still exits `1`, because the code answers liveness and the outcome is in the text.
+It exits `0` while a run is alive and `1` once none is. Note that `1` means "not running", not "failed": a run that completed cleanly still exits `1`, because the code answers liveness and the outcome is in the text.
 
 The three `stop` tiers map onto the signal behavior above, as three explicit invocations with no timed escalation between them: a single workspace segment can take many minutes, and a timer would defeat the graceful path entirely.
 

--- a/packages/twenty-server/docs/UPGRADE_COMMANDS.md
+++ b/packages/twenty-server/docs/UPGRADE_COMMANDS.md
@@ -170,14 +170,6 @@ Everything after `upgrade:background` is forwarded verbatim to `upgrade`, so it 
 
 `logs` is the only one you need to check on a run, because it reports what it found before streaming. If a run is alive it announces the pid and follows the log. If none is alive it prints how the last one ended and dumps the tail instead of following, so it always terminates rather than waiting on a log that will never grow again. That distinction cannot be made from the log alone: a workspace segment can run for many minutes without printing anything, so a silent log looks identical whether the run is grinding through a slow segment or was killed twenty minutes ago. Only the recorded pid answers it.
 
-The script also takes a `status` subcommand, which gives the same verdict in one line and exits. It has no yarn entry point because it is meant for scripts rather than people, and calling the script directly avoids both yarn's startup cost per poll and its requirement to be run from the package directory:
-
-```bash
-until ! /app/packages/twenty-server/scripts/upgrade-background.sh status > /dev/null; do sleep 30; done
-```
-
-It exits `0` while a run is alive and `1` once none is. Note that `1` means "not running", not "failed": a run that completed cleanly still exits `1`, because the code answers liveness and the outcome is in the text.
-
 `stop` has three tiers, deliberately three explicit invocations with no timed escalation between them: a single workspace segment can take many minutes, so a timer that escalated to `SIGKILL` on its own would defeat the graceful path entirely.
 
 | Invocation | Signal | Effect |

--- a/packages/twenty-server/docs/UPGRADE_COMMANDS.md
+++ b/packages/twenty-server/docs/UPGRADE_COMMANDS.md
@@ -142,6 +142,54 @@ Rerun the command to resume. Nothing is rolled back, and the run picks up from t
 
 Expect the first Ctrl+C to look like it did nothing while a long step is running: it takes effect once the step ends.
 
+### Running detached
+
+A foreground `upgrade` is a child of the shell it was started from, so anything that drops that shell kills the run: a `kubectl exec` session losing its SSM tunnel, a closed laptop, an expired VPN. `scripts/upgrade-background.sh` puts the run in its own session with no controlling terminal and streams its output from a log file instead, so the run survives the disconnect and can be re-attached from a new shell.
+
+Use it for any long upgrade started over `kubectl exec` or SSH. A foreground run is still the right thing locally, or in CI where the parent process is stable.
+
+```bash
+yarn upgrade:background [args]   # start detached, then stream the log
+yarn upgrade:background:logs     # re-attach to the log from another shell
+yarn upgrade:background:status   # is it running, and how did it end
+yarn upgrade:background:stop     # graceful stop; --now for immediate, --force for SIGKILL
+```
+
+`upgrade:background` refuses to start when a run is already in flight, and forwards any extra arguments (`--include-slow`, workspace filters) to `upgrade`. Ctrl+C on the log stream detaches the stream only, the run keeps going, and `logs` supports any number of concurrent readers.
+
+The three `stop` tiers map onto the signal behavior above, as three explicit invocations with no timed escalation between them: a single workspace segment can take many minutes, and a timer would defeat the graceful path entirely.
+
+| Invocation | Signal | Effect |
+| --- | --- | --- |
+| `stop` | one `SIGTERM` | stops at the next boundary, exit `143` |
+| `stop --now` | two spaced `SIGTERM`s | immediate exit, step in progress left unfinished |
+| `stop --force` | `SIGKILL` | no graceful boundary, a multi-transaction command may leave partial work |
+
+Only the node process is signalled, never the process group. A group signal would also hit the wrapper shell, killing the process that records the exit code and tearing down node's parent while it is trying to finish its segment.
+
+#### Reading the outcome
+
+The wrapper outlives node and appends an `EXIT=<code>` line to the log, which is what `status` reports on:
+
+| Log | Meaning |
+| --- | --- |
+| `EXIT=0` | completed |
+| `EXIT=130` | graceful stop on `SIGINT` |
+| `EXIT=143` | graceful stop on `SIGTERM`, what `stop` and `stop --now` produce |
+| `EXIT=137` | `SIGKILL`ed, what `stop --force` produces |
+| any other `EXIT=` | the upgrade failed, `status` prints the tail of the log |
+| no `EXIT=` line | the wrapper died too, so the run was killed without any graceful stop (pod replaced, container restarted, host lost) |
+
+A graceful stop is always safe to rerun: nothing is rolled back, and the rerun resumes from the last command recorded in `upgradeMigration`, with each workspace either fully done with its segment or untouched. Rerunning after a forced kill or a lost pod is safe too, but only because upgrade commands are idempotent, since a command interrupted mid-flight may have left partial work.
+
+#### Limits of this mode
+
+Ctrl+C cannot reach a detached run at all: it has its own session and no controlling terminal, so no terminal can send it `SIGINT`. `upgrade:background:stop` is the only graceful entry point here, and the `130` exit code only ever shows up on foreground runs.
+
+The log and PID files live in `/tmp` inside the container (override with `TWENTY_UPGRADE_LOG_FILE` and `TWENTY_UPGRADE_PID_FILE`). Both are lost if the pod is replaced, along with the run itself.
+
+`terminationGracePeriodSeconds` does not protect a detached run. PID 1 in the command-runner pod is `tail -f /dev/null`, so on pod deletion it exits immediately and the detached node process is torn down without ever receiving `SIGTERM`. The graceful path on eviction only applies when node is the container's main process.
+
 ## Shipping a command for a future version (deferred drops)
 
 You can write a command for a version listed in `TWENTY_NEXT_VERSIONS` — typically the second half of a zero-downtime migration, e.g. dropping a column one release after its replacement ships. Pass the target version to the generator:

--- a/packages/twenty-server/docs/UPGRADE_COMMANDS.md
+++ b/packages/twenty-server/docs/UPGRADE_COMMANDS.md
@@ -166,7 +166,7 @@ until ! /app/packages/twenty-server/scripts/upgrade-background.sh status > /dev/
 
 It exits `0` while a run is alive and `1` once none is. Note that `1` means "not running", not "failed": a run that completed cleanly still exits `1`, because the code answers liveness and the outcome is in the text.
 
-The three `stop` tiers map onto the signal behavior above, as three explicit invocations with no timed escalation between them: a single workspace segment can take many minutes, and a timer would defeat the graceful path entirely.
+`stop` has three tiers, deliberately three explicit invocations with no timed escalation between them: a single workspace segment can take many minutes, so a timer that escalated to `SIGKILL` on its own would defeat the graceful path entirely.
 
 | Invocation | Signal | Effect |
 | --- | --- | --- |
@@ -197,7 +197,7 @@ Ctrl+C cannot reach a detached run at all: it has its own session and no control
 
 The log and PID files live in `/tmp` inside the container (override with `TWENTY_UPGRADE_LOG_FILE` and `TWENTY_UPGRADE_PID_FILE`). Both are lost if the pod is replaced, along with the run itself.
 
-`terminationGracePeriodSeconds` does not protect a detached run. PID 1 in the command-runner pod is `tail -f /dev/null`, so on pod deletion it exits immediately and the detached node process is torn down without ever receiving `SIGTERM`. The graceful path on eviction only applies when node is the container's main process.
+Kubernetes cannot stop a detached run gracefully either, and `terminationGracePeriodSeconds` is not the lever it looks like. PID 1 in the command-runner pod is `tail -f /dev/null`, so on pod deletion it exits immediately and the detached node process is torn down without ever receiving `SIGTERM`, however long the grace period is. Graceful shutdown on eviction only applies when node is the container's main process, which is the foreground case, not this one.
 
 ## Shipping a command for a future version (deferred drops)
 

--- a/packages/twenty-server/docs/UPGRADE_COMMANDS.md
+++ b/packages/twenty-server/docs/UPGRADE_COMMANDS.md
@@ -154,7 +154,7 @@ yarn upgrade:background:logs     # re-attach from another shell
 yarn upgrade:background:stop     # graceful stop; --now for immediate, --force for SIGKILL
 ```
 
-`upgrade:background` refuses to start when a run is already in flight. Ctrl+C on the log stream detaches the stream only, the run keeps going, and `logs` supports any number of concurrent readers.
+`upgrade:background` refuses to start when it can see a run already in flight. Ctrl+C on the log stream detaches the stream only, the run keeps going, and `logs` supports any number of concurrent readers.
 
 Everything after `upgrade:background` is forwarded verbatim to `upgrade`, so it takes that command's options and no others:
 
@@ -202,6 +202,8 @@ A graceful stop is always safe to rerun: nothing is rolled back, and the rerun r
 Ctrl+C cannot reach a detached run at all: it has its own session and no controlling terminal, so no terminal can send it `SIGINT`. `upgrade:background:stop` is the only graceful entry point here, and the `130` exit code only ever shows up on foreground runs.
 
 The log and PID files live in `/tmp` inside the container (override with `TWENTY_UPGRADE_LOG_FILE` and `TWENTY_UPGRADE_PID_FILE`). Both are lost if the pod is replaced, along with the run itself.
+
+That also bounds what the refusal above is worth. It keeps one pod's bookkeeping straight, one PID file and one log per run, and nothing more: a second pod, or a laptop pointed at the same database, sees none of it. Nothing in `upgrade` itself prevents two sequences running at once either. `upgradeMigration` records only `completed` and `failed`, so it has no in-progress state to lock against, and there is no advisory lock in the sequence runner. Two concurrent runs would each do the work before one of them lost the race to record it and failed on a unique-index violation. Treat "only one upgrade at a time" as an operational rule, not something the tooling enforces.
 
 Detaching needs `setsid`, which is what puts the run in its own session. The runtime image has it (busybox provides the applet) and so does any Linux host, but macOS does not ship it, so `upgrade:background` refuses to start there and points you at the foreground command. That is no real loss, since a local run has no connection to drop in the first place.
 

--- a/packages/twenty-server/docs/UPGRADE_COMMANDS.md
+++ b/packages/twenty-server/docs/UPGRADE_COMMANDS.md
@@ -150,12 +150,22 @@ Use it for any long upgrade started over `kubectl exec` or SSH. A foreground run
 
 ```bash
 yarn upgrade:background [args]   # start detached, then stream the log
-yarn upgrade:background:logs     # re-attach to the log from another shell
-yarn upgrade:background:status   # is it running, and how did it end
+yarn upgrade:background:logs     # re-attach from another shell
+yarn upgrade:background:status   # one-shot check, for scripts
 yarn upgrade:background:stop     # graceful stop; --now for immediate, --force for SIGKILL
 ```
 
 `upgrade:background` refuses to start when a run is already in flight, and forwards any extra arguments (`--include-slow`, workspace filters) to `upgrade`. Ctrl+C on the log stream detaches the stream only, the run keeps going, and `logs` supports any number of concurrent readers.
+
+`logs` is the one to reach for interactively, because it reports what it found before streaming. If a run is alive it announces the pid and follows the log. If none is alive it prints how the last one ended and dumps the tail instead of following, so it always terminates rather than waiting on a log that will never grow again. That distinction cannot be made from the log alone: a workspace segment can run for many minutes without printing anything, so a silent log looks identical whether the run is grinding through a slow segment or was killed twenty minutes ago. Only the recorded pid answers it.
+
+`status` answers the same question in one line and exits, for scripts rather than people. It exits `0` while a run is alive and `1` once none is, so a wait loop reads as:
+
+```bash
+until ! yarn upgrade:background:status > /dev/null; do sleep 30; done
+```
+
+Note that `1` means "not running", not "failed": a run that completed cleanly still exits `1`, because the code answers liveness and the outcome is in the text.
 
 The three `stop` tiers map onto the signal behavior above, as three explicit invocations with no timed escalation between them: a single workspace segment can take many minutes, and a timer would defeat the graceful path entirely.
 
@@ -169,15 +179,15 @@ Only the node process is signalled, never the process group. A group signal woul
 
 #### Reading the outcome
 
-The wrapper outlives node and appends an `EXIT=<code>` line to the log, which is what `status` reports on:
+The wrapper outlives node and appends an `EXIT=<code>` line to the log, which is what `logs` and `status` translate:
 
 | Log | Meaning |
 | --- | --- |
 | `EXIT=0` | completed |
 | `EXIT=130` | graceful stop on `SIGINT` |
 | `EXIT=143` | graceful stop on `SIGTERM`, what `stop` and `stop --now` produce |
-| `EXIT=137` | `SIGKILL`ed, what `stop --force` produces |
-| any other `EXIT=` | the upgrade failed, `status` prints the tail of the log |
+| `EXIT=137` | `SIGKILL`ed, what `stop --force` produces, and what an OOM kill looks like |
+| any other `EXIT=` | the upgrade failed |
 | no `EXIT=` line | the wrapper died too, so the run was killed without any graceful stop (pod replaced, container restarted, host lost) |
 
 A graceful stop is always safe to rerun: nothing is rolled back, and the rerun resumes from the last command recorded in `upgradeMigration`, with each workspace either fully done with its segment or untouched. Rerunning after a forced kill or a lost pod is safe too, but only because upgrade commands are idempotent, since a command interrupted mid-flight may have left partial work.

--- a/packages/twenty-server/docs/UPGRADE_COMMANDS.md
+++ b/packages/twenty-server/docs/UPGRADE_COMMANDS.md
@@ -144,70 +144,45 @@ Expect the first Ctrl+C to look like it did nothing while a long step is running
 
 ### Running detached
 
-A foreground `upgrade` is a child of the shell it was started from, so anything that drops that shell kills the run: a `kubectl exec` session losing its SSM tunnel, a closed laptop, an expired VPN. `scripts/upgrade-background.sh` puts the run in its own session with no controlling terminal and streams its output from a log file instead, so the run survives the disconnect and can be re-attached from a new shell.
-
-Use it for any long upgrade started over `kubectl exec` or SSH. A foreground run is still the right thing locally, or in CI where the parent process is stable.
+A foreground `upgrade` dies with the shell that started it, so a dropped `kubectl exec` tunnel, a closed laptop or an expired VPN kills the run. `scripts/upgrade-background.sh` gives it its own session with no controlling terminal and streams the output from a log file instead. Use it for long upgrades over `kubectl exec` or SSH; foreground is still right locally and in CI.
 
 ```bash
 yarn upgrade:background [args]   # start detached, then stream the log
 yarn upgrade:background:logs     # re-attach from another shell
-yarn upgrade:background:stop     # graceful stop; --now for immediate, --force for SIGKILL
+yarn upgrade:background:stop     # graceful stop; --now immediate, --force SIGKILL
 ```
 
-`upgrade:background` refuses to start when it can see a run already in flight. Ctrl+C on the log stream detaches the stream only, the run keeps going, and `logs` supports any number of concurrent readers.
+`[args]` is forwarded verbatim to `upgrade`: `-d/--dry-run`, `-v/--verbose`, `-w/--workspace-id <id>` (repeatable), `--start-from-workspace-id <id>`, `--workspace-count-limit <n>`. The two workspace selectors are mutually exclusive. `--include-slow` is not among them, it belongs to `run-instance-commands`.
 
-Everything after `upgrade:background` is forwarded verbatim to `upgrade`, so it takes that command's options and no others:
+Ctrl+C detaches the stream only, and `logs` takes any number of concurrent readers. `logs` reports whether a run is alive before streaming, and on a finished one prints the verdict and the log tail rather than following a log that will never grow again: a segment can run for minutes without printing, so a silent log alone cannot tell a slow step from a dead process.
 
-| Option | Effect |
-| --- | --- |
-| `-d`, `--dry-run` | simulate without making changes |
-| `-v`, `--verbose` | verbose output |
-| `-w`, `--workspace-id <id>` | restrict to a workspace, repeatable; all provisioned workspaces if omitted |
-| `--start-from-workspace-id <id>` | resume from a workspace, ascending id order |
-| `--workspace-count-limit <n>` | process at most n workspaces, ascending id order |
-
-`-w` and `--start-from-workspace-id` are mutually exclusive and `upgrade` rejects the combination. Note that `--include-slow` is **not** one of these: it belongs to `run-instance-commands`, which the upgrade pipeline invokes itself.
-
-`logs` is the only one you need to check on a run, because it reports what it found before streaming. If a run is alive it announces the pid and follows the log. If none is alive it prints how the last one ended and dumps the tail instead of following, so it always terminates rather than waiting on a log that will never grow again. That distinction cannot be made from the log alone: a workspace segment can run for many minutes without printing anything, so a silent log looks identical whether the run is grinding through a slow segment or was killed twenty minutes ago. Only the recorded pid answers it.
-
-`stop` has three tiers, deliberately three explicit invocations with no timed escalation between them: a single workspace segment can take many minutes, so a timer that escalated to `SIGKILL` on its own would defeat the graceful path entirely.
+`stop` has three tiers, three explicit invocations with no timed escalation between them, since a segment can take many minutes and a timer would defeat the graceful path. Each prints the log tail after signalling. Only the node process is signalled, never the process group, which would also kill the wrapper that records the exit code.
 
 | Invocation | Signal | Effect |
 | --- | --- | --- |
 | `stop` | one `SIGTERM` | stops at the next boundary, exit `143` |
 | `stop --now` | two spaced `SIGTERM`s | immediate exit, step in progress left unfinished |
-| `stop --force` | `SIGKILL` | no graceful boundary, a multi-transaction command may leave partial work |
+| `stop --force` | `SIGKILL` | no boundary, a multi-transaction command may leave partial work |
 
-Every tier prints the tail of the log after signalling, so you can see which workspace and step the run was on without a second command. The plain `stop` waits a moment first, long enough for the runner's "finishing the step in progress" acknowledgement to reach the log, which is the confirmation that the signal was received and is being honoured rather than ignored.
-
-Only the node process is signalled, never the process group. A group signal would also hit the wrapper shell, killing the process that records the exit code and tearing down node's parent while it is trying to finish its segment.
-
-#### Reading the outcome
-
-The wrapper outlives node and appends an `EXIT=<code>` line to the log, which is what `logs` and `status` translate:
+The wrapper outlives node and appends an `EXIT=<code>` line, which is what `logs` translates:
 
 | Log | Meaning |
 | --- | --- |
 | `EXIT=0` | completed |
-| `EXIT=130` | graceful stop on `SIGINT` |
-| `EXIT=143` | graceful stop on `SIGTERM`, what `stop` and `stop --now` produce |
-| `EXIT=137` | `SIGKILL`ed, what `stop --force` produces, and what an OOM kill looks like |
-| any other `EXIT=` | the upgrade failed |
-| no `EXIT=` line | the wrapper died too, so the run was killed without any graceful stop (pod replaced, container restarted, host lost) |
+| `EXIT=130` / `EXIT=143` | graceful stop on `SIGINT` / `SIGTERM` |
+| `EXIT=137` | `SIGKILL`ed, from `stop --force` or an OOM kill |
+| any other `EXIT=` | failed |
+| no `EXIT=` line | killed without a graceful stop, wrapper included (pod replaced, host lost) |
 
-A graceful stop is always safe to rerun: nothing is rolled back, and the rerun resumes from the last command recorded in `upgradeMigration`, with each workspace either fully done with its segment or untouched. Rerunning after a forced kill or a lost pod is safe too, but only because upgrade commands are idempotent, since a command interrupted mid-flight may have left partial work.
+A graceful stop is always safe to rerun: nothing is rolled back and the run resumes from the last command recorded in `upgradeMigration`, each workspace either fully done with its segment or untouched. Rerunning after a forced kill relies on commands being idempotent.
 
-#### Limits of this mode
+Limits of this mode:
 
-Ctrl+C cannot reach a detached run at all: it has its own session and no controlling terminal, so no terminal can send it `SIGINT`. `upgrade:background:stop` is the only graceful entry point here, and the `130` exit code only ever shows up on foreground runs.
-
-The log and PID files live in `/tmp` inside the container (override with `TWENTY_UPGRADE_LOG_FILE` and `TWENTY_UPGRADE_PID_FILE`). Both are lost if the pod is replaced, along with the run itself.
-
-That also bounds what the refusal above is worth. It keeps one pod's bookkeeping straight, one PID file and one log per run, and nothing more: a second pod, or a laptop pointed at the same database, sees none of it. Nothing in `upgrade` itself prevents two sequences running at once either. `upgradeMigration` records only `completed` and `failed`, so it has no in-progress state to lock against, and there is no advisory lock in the sequence runner. Two concurrent runs would each do the work before one of them lost the race to record it and failed on a unique-index violation. Treat "only one upgrade at a time" as an operational rule, not something the tooling enforces.
-
-Detaching needs `setsid`, which is what puts the run in its own session. The runtime image has it (busybox provides the applet) and so does any Linux host, but macOS does not ship it, so `upgrade:background` refuses to start there and points you at the foreground command. That is no real loss, since a local run has no connection to drop in the first place.
-
-Kubernetes cannot stop a detached run gracefully either, and `terminationGracePeriodSeconds` is not the lever it looks like. PID 1 in the command-runner pod is `tail -f /dev/null`, so on pod deletion it exits immediately and the detached node process is torn down without ever receiving `SIGTERM`, however long the grace period is. Graceful shutdown on eviction only applies when node is the container's main process, which is the foreground case, not this one.
+- Ctrl+C cannot reach a detached run, so `stop` is the only graceful entry point and `130` only ever appears on foreground runs.
+- Log and PID files live in `/tmp` in the container (`TWENTY_UPGRADE_LOG_FILE`, `TWENTY_UPGRADE_PID_FILE`) and are lost with the pod.
+- The start refusal only sees this container. Nothing in `upgrade` prevents two concurrent sequences either: `upgradeMigration` has no in-progress state and the sequence runner takes no advisory lock. One upgrade at a time is an operational rule, not an enforced one.
+- Needs `setsid`, present in the runtime image and on Linux, absent on macOS where `start` refuses and points at the foreground command.
+- `terminationGracePeriodSeconds` does not apply. PID 1 in the command-runner pod is `tail -f /dev/null`, so on pod deletion the detached process is torn down without ever receiving `SIGTERM`.
 
 ## Shipping a command for a future version (deferred drops)
 

--- a/packages/twenty-server/package.json
+++ b/packages/twenty-server/package.json
@@ -12,6 +12,10 @@
     "database:init:prod": "node dist/database/scripts/setup-db.js && yarn database:migrate:prod --force --include-slow",
     "database:migrate:prod": "node dist/command/command run-instance-commands",
     "clickhouse:migrate:prod": "node dist/database/clickHouse/migrations/run-migrations.js",
+    "upgrade:background": "./scripts/upgrade-background.sh start",
+    "upgrade:background:logs": "./scripts/upgrade-background.sh logs",
+    "upgrade:background:status": "./scripts/upgrade-background.sh status",
+    "upgrade:background:stop": "./scripts/upgrade-background.sh stop",
     "typeorm": "../../node_modules/typeorm/.bin/typeorm"
   },
   "dependencies": {

--- a/packages/twenty-server/package.json
+++ b/packages/twenty-server/package.json
@@ -14,7 +14,6 @@
     "clickhouse:migrate:prod": "node dist/database/clickHouse/migrations/run-migrations.js",
     "upgrade:background": "./scripts/upgrade-background.sh start",
     "upgrade:background:logs": "./scripts/upgrade-background.sh logs",
-    "upgrade:background:status": "./scripts/upgrade-background.sh status",
     "upgrade:background:stop": "./scripts/upgrade-background.sh stop",
     "typeorm": "../../node_modules/typeorm/.bin/typeorm"
   },

--- a/packages/twenty-server/scripts/upgrade-background.sh
+++ b/packages/twenty-server/scripts/upgrade-background.sh
@@ -8,6 +8,19 @@ export LOG_FILE PID_FILE
 
 upgrade_pid() { [ -s "$PID_FILE" ] && cat "$PID_FILE" || return 1; }
 is_running()  { pid=$(upgrade_pid) && kill -0 "$pid" 2>/dev/null; }
+stream()      { exec tail -f "$LOG_FILE"; }
+
+last_run() {
+  code=$(grep '^EXIT=' "$LOG_FILE" 2>/dev/null | tail -n 1 | cut -d= -f2)
+  case "$code" in
+    0)   echo "completed" ;;
+    130) echo "stopped gracefully on SIGINT — rerun to resume" ;;
+    143) echo "stopped gracefully on SIGTERM — rerun to resume" ;;
+    137) echo "killed (SIGKILL) — partial work possible, rerun to resume" ;;
+    "")  echo "left no exit code — killed, or never started" ;;
+    *)   echo "failed (exit $code)" ;;
+  esac
+}
 
 start() {
   if is_running; then
@@ -30,21 +43,25 @@ start() {
 
   echo "Upgrade started (pid $(upgrade_pid)), logging to $LOG_FILE"
   echo "Ctrl-C detaches the log stream only. Use upgrade:background:stop to stop the run."
-  exec tail -f "$LOG_FILE"
+  stream
 }
 
-logs() { [ -f "$LOG_FILE" ] || { echo "No log at $LOG_FILE" >&2; exit 1; }; exec tail -f "$LOG_FILE"; }
+# Reports what it found before streaming: a silent log is otherwise ambiguous
+# between a slow workspace segment and a run that died without writing EXIT=.
+logs() {
+  if is_running; then
+    echo "Running (pid $(upgrade_pid)), following $LOG_FILE. Ctrl-C detaches the stream only." >&2
+    stream
+  fi
+  [ -f "$LOG_FILE" ] || { echo "No run found, no log at $LOG_FILE" >&2; exit 1; }
+  echo "Not running, last run $(last_run). Tail of $LOG_FILE:" >&2
+  exec tail -n 20 "$LOG_FILE"
+}
 
 status() {
   is_running && { echo "running (pid $(upgrade_pid))"; exit 0; }
-  code=$(grep '^EXIT=' "$LOG_FILE" 2>/dev/null | tail -n 1 | cut -d= -f2)
-  case "$code" in
-    0)   echo "completed" ;;
-    130) echo "stopped gracefully on SIGINT — rerun to resume" ;;
-    143) echo "stopped gracefully on SIGTERM — rerun to resume" ;;
-    "")  echo "not running, no exit recorded — killed, or never started" ;;
-    *)   echo "failed (exit $code)"; tail -n 20 "$LOG_FILE" ;;
-  esac
+  echo "not running, last run $(last_run)"
+  exit 1
 }
 
 stop() {

--- a/packages/twenty-server/scripts/upgrade-background.sh
+++ b/packages/twenty-server/scripts/upgrade-background.sh
@@ -29,6 +29,11 @@ is_running() {
 # would read as a leftover and delete.
 claim() { (set -C; echo $$ > "$PID_FILE") 2>/dev/null; }
 
+# Shared so start and logs cannot drift apart.
+detach_hint() {
+  echo "Ctrl+C detaches the stream only. Use 'yarn upgrade:background:stop' to stop the run."
+}
+
 last_run() {
   code=$(grep '^EXIT=' "$LOG_FILE" 2>/dev/null | tail -n 1 | cut -d= -f2)
   case "$code" in
@@ -43,18 +48,18 @@ last_run() {
 
 start() {
   command -v setsid > /dev/null || {
-    echo "setsid not found: cannot detach the run from this terminal." >&2
-    echo "Run 'yarn command:prod upgrade' in the foreground instead." >&2
+    echo "Failed to start: setsid not found, cannot detach the run from this terminal" >&2
+    echo "Use 'yarn command:prod upgrade' to run it in the foreground instead." >&2
     exit 1
   }
 
   if ! claim; then
     if is_running; then
-      echo "Already running (pid $(upgrade_pid))." >&2; exit 1
+      echo "Failed to start: already running (pid $(upgrade_pid))" >&2; exit 1
     fi
     # Pid file left by a run that is no longer alive.
     rm -f "$PID_FILE"
-    claim || { echo "Another start is claiming the run, retry." >&2; exit 1; }
+    claim || { echo "Failed to start: another start claimed the run, retry" >&2; exit 1; }
   fi
   : > "$LOG_FILE"
 
@@ -72,10 +77,10 @@ start() {
   while [ "$(cat "$PID_FILE" 2>/dev/null)" = "$$" ] && [ "$i" -lt 10 ]; do
     i=$((i + 1)); sleep 1
   done
-  is_running || { echo "Failed to start, see $LOG_FILE" >&2; tail -n 20 "$LOG_FILE" >&2; exit 1; }
+  is_running || { echo "Failed to start: see $LOG_FILE" >&2; tail -n 20 "$LOG_FILE" >&2; exit 1; }
 
-  echo "Upgrade started (pid $(upgrade_pid)), logging to $LOG_FILE"
-  echo "Ctrl-C detaches the log stream only. Use upgrade:background:stop to stop the run."
+  echo "Running (pid $(upgrade_pid)), logging to $LOG_FILE"
+  detach_hint
   stream
 }
 
@@ -83,37 +88,38 @@ start() {
 # between a slow workspace segment and a run that died without writing EXIT=.
 logs() {
   if is_running; then
-    echo "Running (pid $(upgrade_pid)), following $LOG_FILE. Ctrl-C detaches the stream only." >&2
+    echo "Running (pid $(upgrade_pid)), following $LOG_FILE" >&2
+    detach_hint >&2
     stream
   fi
-  [ -f "$LOG_FILE" ] || { echo "No run found, no log at $LOG_FILE" >&2; exit 1; }
+  [ -f "$LOG_FILE" ] || { echo "Not running, no log at $LOG_FILE" >&2; exit 1; }
   echo "Not running, last run $(last_run). Tail of $LOG_FILE:" >&2
   exec tail -n 20 "$LOG_FILE"
 }
 
 status() {
-  is_running && { echo "running (pid $(upgrade_pid))"; exit 0; }
-  echo "not running, last run $(last_run)"
+  is_running && { echo "Running (pid $(upgrade_pid))"; exit 0; }
+  echo "Not running, last run $(last_run)"
   exit 1
 }
 
 stop() {
-  is_running || { echo "Not running." >&2; rm -f "$PID_FILE"; exit 1; }
+  is_running || { echo "Not running, nothing to stop" >&2; rm -f "$PID_FILE"; exit 1; }
   pid=$(upgrade_pid)
 
   case "${1:-}" in
     "")
       kill -TERM "$pid"
-      echo "SIGTERM sent to $pid. It finishes the step in progress, then stops (exit 143)."
-      echo "Follow with upgrade:background:logs. Still stuck: 'stop --now'. Last resort: 'stop --force'."
+      echo "SIGTERM sent to $pid, it finishes the step in progress then stops (exit 143)"
+      echo "Follow with 'yarn upgrade:background:logs'. Still stuck: 'stop --now'. Last resort: 'stop --force'."
       ;;
     --now)
       kill -TERM "$pid"; sleep 2; kill -TERM "$pid" 2>/dev/null || true
-      echo "Second SIGTERM sent — immediate exit, step in progress left unfinished."
+      echo "Second SIGTERM sent to $pid, immediate exit with the step in progress left unfinished"
       ;;
     --force)
-      echo "SIGKILL: no graceful boundary, a multi-transaction command may leave partial work." >&2
       kill -KILL "$pid"
+      echo "SIGKILL sent to $pid, no graceful boundary so a multi-transaction command may leave partial work" >&2
       ;;
     *) echo "usage: stop [--now|--force]" >&2; exit 1 ;;
   esac

--- a/packages/twenty-server/scripts/upgrade-background.sh
+++ b/packages/twenty-server/scripts/upgrade-background.sh
@@ -109,12 +109,6 @@ logs() {
   show_tail
 }
 
-status() {
-  is_running && { echo "Running (pid $(upgrade_pid))"; exit 0; }
-  echo "Not running, last run $(last_run)"
-  exit 1
-}
-
 stop() {
   is_running || { echo "Not running, nothing to stop" >&2; rm -f "$PID_FILE"; exit 1; }
   pid=$(upgrade_pid)
@@ -144,9 +138,8 @@ stop() {
 }
 
 case "${1:-}" in
-  start)  shift; start "$@" ;;
-  logs)   logs ;;
-  status) status ;;
-  stop)   shift; stop "$@" ;;
-  *) echo "usage: $0 {start [args]|logs|status|stop [--now|--force]}" >&2; exit 1 ;;
+  start) shift; start "$@" ;;
+  logs)  logs ;;
+  stop)  shift; stop "$@" ;;
+  *) echo "usage: $0 {start [args]|logs|stop [--now|--force]}" >&2; exit 1 ;;
 esac

--- a/packages/twenty-server/scripts/upgrade-background.sh
+++ b/packages/twenty-server/scripts/upgrade-background.sh
@@ -1,5 +1,4 @@
 #!/bin/sh
-# Detached `upgrade`, cooperating with CommandShutdownService.
 set -eu
 
 LOG_FILE="${TWENTY_UPGRADE_LOG_FILE:-/tmp/twenty-upgrade.log}"
@@ -10,9 +9,6 @@ export LOG_FILE PID_FILE
 upgrade_pid() { [ -s "$PID_FILE" ] && cat "$PID_FILE" || return 1; }
 stream()      { exec tail -f "$LOG_FILE"; }
 
-# A recorded pid outlives the run that wrote it, so a recycled pid would other-
-# wise be reported as running and, worse, signalled by stop. Where /proc is
-# unavailable (macOS) the check cannot run and the pid is taken at face value.
 is_our_upgrade() {
   [ -r "/proc/$1/cmdline" ] || return 0
   tr '\0' ' ' < "/proc/$1/cmdline" 2>/dev/null | grep -q 'dist/command/command'
@@ -22,12 +18,10 @@ is_running() {
   pid=$(upgrade_pid) && kill -0 "$pid" 2>/dev/null && is_our_upgrade "$pid"
 }
 
-# Shared so start and logs cannot drift apart.
 detach_hint() {
   echo "Ctrl+C detaches the stream only. Use 'yarn upgrade:background:stop' to stop the run."
 }
 
-# Header on stderr, log content on stdout, so redirecting keeps the log clean.
 show_tail() {
   [ -f "$LOG_FILE" ] || return 0
   echo "Tail of $LOG_FILE:" >&2
@@ -53,16 +47,13 @@ start() {
     exit 1
   }
 
-  # Keeps this wrapper's own bookkeeping straight, one pid file and one log per
-  # run. It is not a guard against concurrent upgrades: the pid file is local to
-  # this container, so nothing here constrains another pod or another machine.
   if is_running; then
     echo "Failed to start: already running (pid $(upgrade_pid))" >&2; exit 1
   fi
   : > "$LOG_FILE"; rm -f "$PID_FILE"
 
-  # setsid: own session, no controlling terminal -> survives disconnect.
-  # The wrapper outlives node on purpose, so it can record the exit code.
+  # Not exec: the wrapper has to outlive node to record EXIT=, and stop has to
+  # signal node alone, never the process group this would otherwise share.
   setsid sh -c '
     node dist/command/command upgrade "$@" &
     echo $! > "$PID_FILE"
@@ -83,8 +74,6 @@ start() {
   stream
 }
 
-# Reports what it found before streaming: a silent log is otherwise ambiguous
-# between a slow workspace segment and a run that died without writing EXIT=.
 logs() {
   if is_running; then
     echo "Running (pid $(upgrade_pid)), following $LOG_FILE" >&2
@@ -104,7 +93,6 @@ stop() {
     "")
       kill -TERM "$pid"
       echo "SIGTERM sent to $pid, it finishes the step in progress then stops (exit 143)" >&2
-      # Give the handler a moment so its acknowledgement makes the tail below.
       sleep 1
       show_tail
       echo "Follow with 'yarn upgrade:background:logs'. Still stuck: 'stop --now'. Last resort: 'stop --force'." >&2

--- a/packages/twenty-server/scripts/upgrade-background.sh
+++ b/packages/twenty-server/scripts/upgrade-background.sh
@@ -7,8 +7,27 @@ PID_FILE="${TWENTY_UPGRADE_PID_FILE:-/tmp/twenty-upgrade.pid}"
 export LOG_FILE PID_FILE
 
 upgrade_pid() { [ -s "$PID_FILE" ] && cat "$PID_FILE" || return 1; }
-is_running()  { pid=$(upgrade_pid) && kill -0 "$pid" 2>/dev/null; }
 stream()      { exec tail -f "$LOG_FILE"; }
+
+# A recorded pid outlives the run that wrote it, so a recycled pid would other-
+# wise be reported as running and, worse, signalled by stop. Matches node once
+# started and the claiming wrapper before that. Where /proc is unavailable
+# (macOS) the check cannot run and the pid is taken at face value.
+is_our_upgrade() {
+  [ -r "/proc/$1/cmdline" ] || return 0
+  tr '\0' ' ' < "/proc/$1/cmdline" 2>/dev/null |
+    grep -qE 'dist/command/command|upgrade-background\.sh'
+}
+
+is_running() {
+  pid=$(upgrade_pid) && kill -0 "$pid" 2>/dev/null && is_our_upgrade "$pid"
+}
+
+# O_EXCL create, the atomic half of the singleton check: two concurrent starts
+# both see no run in flight, but only one can create the pid file. It holds the
+# claiming shell's pid until node's replaces it, never a blank the other starts
+# would read as a leftover and delete.
+claim() { (set -C; echo $$ > "$PID_FILE") 2>/dev/null; }
 
 last_run() {
   code=$(grep '^EXIT=' "$LOG_FILE" 2>/dev/null | tail -n 1 | cut -d= -f2)
@@ -23,10 +42,21 @@ last_run() {
 }
 
 start() {
-  if is_running; then
-    echo "Already running (pid $(upgrade_pid))." >&2; exit 1
+  command -v setsid > /dev/null || {
+    echo "setsid not found: cannot detach the run from this terminal." >&2
+    echo "Run 'yarn command:prod upgrade' in the foreground instead." >&2
+    exit 1
+  }
+
+  if ! claim; then
+    if is_running; then
+      echo "Already running (pid $(upgrade_pid))." >&2; exit 1
+    fi
+    # Pid file left by a run that is no longer alive.
+    rm -f "$PID_FILE"
+    claim || { echo "Another start is claiming the run, retry." >&2; exit 1; }
   fi
-  : > "$LOG_FILE"; rm -f "$PID_FILE"
+  : > "$LOG_FILE"
 
   # setsid: own session, no controlling terminal -> survives disconnect.
   # The wrapper outlives node on purpose, so it can record the exit code.
@@ -37,8 +67,11 @@ start() {
     echo "EXIT=$?"
   ' upgrade-background "$@" < /dev/null >> "$LOG_FILE" 2>&1 &
 
+  # Wait for node's pid to replace the claim, not merely for a non-empty file.
   i=0
-  while [ ! -s "$PID_FILE" ] && [ "$i" -lt 10 ]; do i=$((i + 1)); sleep 1; done
+  while [ "$(cat "$PID_FILE" 2>/dev/null)" = "$$" ] && [ "$i" -lt 10 ]; do
+    i=$((i + 1)); sleep 1
+  done
   is_running || { echo "Failed to start, see $LOG_FILE" >&2; tail -n 20 "$LOG_FILE" >&2; exit 1; }
 
   echo "Upgrade started (pid $(upgrade_pid)), logging to $LOG_FILE"

--- a/packages/twenty-server/scripts/upgrade-background.sh
+++ b/packages/twenty-server/scripts/upgrade-background.sh
@@ -4,6 +4,7 @@ set -eu
 
 LOG_FILE="${TWENTY_UPGRADE_LOG_FILE:-/tmp/twenty-upgrade.log}"
 PID_FILE="${TWENTY_UPGRADE_PID_FILE:-/tmp/twenty-upgrade.pid}"
+TAIL_LINES=20
 export LOG_FILE PID_FILE
 
 upgrade_pid() { [ -s "$PID_FILE" ] && cat "$PID_FILE" || return 1; }
@@ -32,6 +33,13 @@ claim() { (set -C; echo $$ > "$PID_FILE") 2>/dev/null; }
 # Shared so start and logs cannot drift apart.
 detach_hint() {
   echo "Ctrl+C detaches the stream only. Use 'yarn upgrade:background:stop' to stop the run."
+}
+
+# Header on stderr, log content on stdout, so redirecting keeps the log clean.
+show_tail() {
+  [ -f "$LOG_FILE" ] || return 0
+  echo "Tail of $LOG_FILE:" >&2
+  tail -n "$TAIL_LINES" "$LOG_FILE"
 }
 
 last_run() {
@@ -77,7 +85,11 @@ start() {
   while [ "$(cat "$PID_FILE" 2>/dev/null)" = "$$" ] && [ "$i" -lt 10 ]; do
     i=$((i + 1)); sleep 1
   done
-  is_running || { echo "Failed to start: see $LOG_FILE" >&2; tail -n 20 "$LOG_FILE" >&2; exit 1; }
+  is_running || {
+    echo "Failed to start: see $LOG_FILE" >&2
+    tail -n "$TAIL_LINES" "$LOG_FILE" >&2
+    exit 1
+  }
 
   echo "Running (pid $(upgrade_pid)), logging to $LOG_FILE"
   detach_hint
@@ -93,8 +105,8 @@ logs() {
     stream
   fi
   [ -f "$LOG_FILE" ] || { echo "Not running, no log at $LOG_FILE" >&2; exit 1; }
-  echo "Not running, last run $(last_run). Tail of $LOG_FILE:" >&2
-  exec tail -n 20 "$LOG_FILE"
+  echo "Not running, last run $(last_run)" >&2
+  show_tail
 }
 
 status() {
@@ -110,16 +122,22 @@ stop() {
   case "${1:-}" in
     "")
       kill -TERM "$pid"
-      echo "SIGTERM sent to $pid, it finishes the step in progress then stops (exit 143)"
-      echo "Follow with 'yarn upgrade:background:logs'. Still stuck: 'stop --now'. Last resort: 'stop --force'."
+      echo "SIGTERM sent to $pid, it finishes the step in progress then stops (exit 143)" >&2
+      # Give the handler a moment so its acknowledgement makes the tail below.
+      sleep 1
+      show_tail
+      echo "Follow with 'yarn upgrade:background:logs'. Still stuck: 'stop --now'. Last resort: 'stop --force'." >&2
       ;;
     --now)
       kill -TERM "$pid"; sleep 2; kill -TERM "$pid" 2>/dev/null || true
-      echo "Second SIGTERM sent to $pid, immediate exit with the step in progress left unfinished"
+      echo "Second SIGTERM sent to $pid, immediate exit with the step in progress left unfinished" >&2
+      sleep 1
+      show_tail
       ;;
     --force)
       kill -KILL "$pid"
       echo "SIGKILL sent to $pid, no graceful boundary so a multi-transaction command may leave partial work" >&2
+      show_tail
       ;;
     *) echo "usage: stop [--now|--force]" >&2; exit 1 ;;
   esac

--- a/packages/twenty-server/scripts/upgrade-background.sh
+++ b/packages/twenty-server/scripts/upgrade-background.sh
@@ -11,24 +11,16 @@ upgrade_pid() { [ -s "$PID_FILE" ] && cat "$PID_FILE" || return 1; }
 stream()      { exec tail -f "$LOG_FILE"; }
 
 # A recorded pid outlives the run that wrote it, so a recycled pid would other-
-# wise be reported as running and, worse, signalled by stop. Matches node once
-# started and the claiming wrapper before that. Where /proc is unavailable
-# (macOS) the check cannot run and the pid is taken at face value.
+# wise be reported as running and, worse, signalled by stop. Where /proc is
+# unavailable (macOS) the check cannot run and the pid is taken at face value.
 is_our_upgrade() {
   [ -r "/proc/$1/cmdline" ] || return 0
-  tr '\0' ' ' < "/proc/$1/cmdline" 2>/dev/null |
-    grep -qE 'dist/command/command|upgrade-background\.sh'
+  tr '\0' ' ' < "/proc/$1/cmdline" 2>/dev/null | grep -q 'dist/command/command'
 }
 
 is_running() {
   pid=$(upgrade_pid) && kill -0 "$pid" 2>/dev/null && is_our_upgrade "$pid"
 }
-
-# O_EXCL create, the atomic half of the singleton check: two concurrent starts
-# both see no run in flight, but only one can create the pid file. It holds the
-# claiming shell's pid until node's replaces it, never a blank the other starts
-# would read as a leftover and delete.
-claim() { (set -C; echo $$ > "$PID_FILE") 2>/dev/null; }
 
 # Shared so start and logs cannot drift apart.
 detach_hint() {
@@ -61,15 +53,13 @@ start() {
     exit 1
   }
 
-  if ! claim; then
-    if is_running; then
-      echo "Failed to start: already running (pid $(upgrade_pid))" >&2; exit 1
-    fi
-    # Pid file left by a run that is no longer alive.
-    rm -f "$PID_FILE"
-    claim || { echo "Failed to start: another start claimed the run, retry" >&2; exit 1; }
+  # Keeps this wrapper's own bookkeeping straight, one pid file and one log per
+  # run. It is not a guard against concurrent upgrades: the pid file is local to
+  # this container, so nothing here constrains another pod or another machine.
+  if is_running; then
+    echo "Failed to start: already running (pid $(upgrade_pid))" >&2; exit 1
   fi
-  : > "$LOG_FILE"
+  : > "$LOG_FILE"; rm -f "$PID_FILE"
 
   # setsid: own session, no controlling terminal -> survives disconnect.
   # The wrapper outlives node on purpose, so it can record the exit code.
@@ -80,11 +70,8 @@ start() {
     echo "EXIT=$?"
   ' upgrade-background "$@" < /dev/null >> "$LOG_FILE" 2>&1 &
 
-  # Wait for node's pid to replace the claim, not merely for a non-empty file.
   i=0
-  while [ "$(cat "$PID_FILE" 2>/dev/null)" = "$$" ] && [ "$i" -lt 10 ]; do
-    i=$((i + 1)); sleep 1
-  done
+  while [ ! -s "$PID_FILE" ] && [ "$i" -lt 10 ]; do i=$((i + 1)); sleep 1; done
   is_running || {
     echo "Failed to start: see $LOG_FILE" >&2
     tail -n "$TAIL_LINES" "$LOG_FILE" >&2

--- a/packages/twenty-server/scripts/upgrade-background.sh
+++ b/packages/twenty-server/scripts/upgrade-background.sh
@@ -1,0 +1,78 @@
+#!/bin/sh
+# Detached `upgrade`, cooperating with CommandShutdownService.
+set -eu
+
+LOG_FILE="${TWENTY_UPGRADE_LOG_FILE:-/tmp/twenty-upgrade.log}"
+PID_FILE="${TWENTY_UPGRADE_PID_FILE:-/tmp/twenty-upgrade.pid}"
+export LOG_FILE PID_FILE
+
+upgrade_pid() { [ -s "$PID_FILE" ] && cat "$PID_FILE" || return 1; }
+is_running()  { pid=$(upgrade_pid) && kill -0 "$pid" 2>/dev/null; }
+
+start() {
+  if is_running; then
+    echo "Already running (pid $(upgrade_pid))." >&2; exit 1
+  fi
+  : > "$LOG_FILE"; rm -f "$PID_FILE"
+
+  # setsid: own session, no controlling terminal -> survives disconnect.
+  # The wrapper outlives node on purpose, so it can record the exit code.
+  setsid sh -c '
+    node dist/command/command upgrade "$@" &
+    echo $! > "$PID_FILE"
+    wait $!
+    echo "EXIT=$?"
+  ' upgrade-background "$@" < /dev/null >> "$LOG_FILE" 2>&1 &
+
+  i=0
+  while [ ! -s "$PID_FILE" ] && [ "$i" -lt 10 ]; do i=$((i + 1)); sleep 1; done
+  is_running || { echo "Failed to start, see $LOG_FILE" >&2; tail -n 20 "$LOG_FILE" >&2; exit 1; }
+
+  echo "Upgrade started (pid $(upgrade_pid)), logging to $LOG_FILE"
+  echo "Ctrl-C detaches the log stream only. Use upgrade:background:stop to stop the run."
+  exec tail -f "$LOG_FILE"
+}
+
+logs() { [ -f "$LOG_FILE" ] || { echo "No log at $LOG_FILE" >&2; exit 1; }; exec tail -f "$LOG_FILE"; }
+
+status() {
+  is_running && { echo "running (pid $(upgrade_pid))"; exit 0; }
+  code=$(grep '^EXIT=' "$LOG_FILE" 2>/dev/null | tail -n 1 | cut -d= -f2)
+  case "$code" in
+    0)   echo "completed" ;;
+    130) echo "stopped gracefully on SIGINT — rerun to resume" ;;
+    143) echo "stopped gracefully on SIGTERM — rerun to resume" ;;
+    "")  echo "not running, no exit recorded — killed, or never started" ;;
+    *)   echo "failed (exit $code)"; tail -n 20 "$LOG_FILE" ;;
+  esac
+}
+
+stop() {
+  is_running || { echo "Not running." >&2; rm -f "$PID_FILE"; exit 1; }
+  pid=$(upgrade_pid)
+
+  case "${1:-}" in
+    "")
+      kill -TERM "$pid"
+      echo "SIGTERM sent to $pid. It finishes the step in progress, then stops (exit 143)."
+      echo "Follow with upgrade:background:logs. Still stuck: 'stop --now'. Last resort: 'stop --force'."
+      ;;
+    --now)
+      kill -TERM "$pid"; sleep 2; kill -TERM "$pid" 2>/dev/null || true
+      echo "Second SIGTERM sent — immediate exit, step in progress left unfinished."
+      ;;
+    --force)
+      echo "SIGKILL: no graceful boundary, a multi-transaction command may leave partial work." >&2
+      kill -KILL "$pid"
+      ;;
+    *) echo "usage: stop [--now|--force]" >&2; exit 1 ;;
+  esac
+}
+
+case "${1:-}" in
+  start)  shift; start "$@" ;;
+  logs)   logs ;;
+  status) status ;;
+  stop)   shift; stop "$@" ;;
+  *) echo "usage: $0 {start [args]|logs|status|stop [--now|--force]}" >&2; exit 1 ;;
+esac


### PR DESCRIPTION
Long upgrades are started over `kubectl exec` into the command-runner pod, where the process is a child of the exec'd shell: a dropped SSM tunnel, a closed laptop or a dead VPN kills the run mid-way. There is no tmux in the image (Alpine, `sh: tmux: not found`).

`scripts/upgrade-background.sh` puts the run in its own session with no controlling terminal and streams its output from a log file, so losing the connection detaches the stream instead of killing the upgrade.

Builds on #23481. The cooperative shutdown path is untouched, this is tooling around it. No TypeScript changed.

## Commands

```bash
yarn upgrade:background [args]   # start detached, then stream the log
yarn upgrade:background:logs     # re-attach from another shell
yarn upgrade:background:stop     # graceful stop; --now immediate, --force SIGKILL
```

`[args]` is forwarded verbatim to `upgrade`, so it takes that command's options and no others:

| Option | Effect |
| --- | --- |
| `-d`, `--dry-run` | simulate without making changes |
| `-v`, `--verbose` | verbose output |
| `-w`, `--workspace-id <id>` | restrict to a workspace, repeatable; all provisioned workspaces if omitted |
| `--start-from-workspace-id <id>` | resume from a workspace, ascending id order |
| `--workspace-count-limit <n>` | process at most n workspaces, ascending id order |

`-w` and `--start-from-workspace-id` are mutually exclusive, `upgrade` rejects the combination.

## Example

```ts
➜  twenty-server git:(claude/upgrade-detached-run-wrapper-5nkb0v) ✗ yarn upgrade:background
Running (pid 15779), logging to /tmp/twenty-upgrade.log
Ctrl+C detaches the stream only. Use 'yarn upgrade:background:stop' to stop the run.
^C%
➜  twenty-server git:(claude/upgrade-detached-run-wrapper-5nkb0v) ✗ yarn upgrade:background:stop
SIGTERM sent to 15779, it finishes the step in progress then stops (exit 143)
Tail of /tmp/twenty-upgrade.log:
[Nest] 15779  - 07/30/2026, 10:47:50 AM     LOG [UpgradeAwareEntityMetadataAdapter] [upgrade-metadata] hidden columns on FieldMetadataEntity: standardOverrides,isCustom
[Nest] 15779  - 07/30/2026, 10:47:50 AM     LOG [UpgradeAwareEntityMetadataAdapter] [upgrade-metadata] applied cursor=217 renamed=0 unavailable=0 hiddenColumns=5
[Nest] 15779  - 07/30/2026, 10:47:50 AM     LOG [UpgradeAwareEntityMetadataAdapter] [upgrade-metadata] hidden columns on RolePermissionFlagEntity: flag
[Nest] 15779  - 07/30/2026, 10:47:50 AM     LOG [UpgradeAwareEntityMetadataAdapter] [upgrade-metadata] hidden columns on ObjectMetadataEntity: standardOverrides,isCustom
[Nest] 15779  - 07/30/2026, 10:47:50 AM     LOG [UpgradeAwareEntityMetadataAdapter] [upgrade-metadata] hidden columns on FieldMetadataEntity: standardOverrides,isCustom
[Nest] 15779  - 07/30/2026, 10:47:50 AM     LOG [UpgradeAwareEntityMetadataAdapter] [upgrade-metadata] applied cursor=207 renamed=0 unavailable=0 hiddenColumns=5
[Nest] 15779  - 07/30/2026, 10:47:50 AM     LOG [DatabaseConfigDriver] [INIT] Loading initial config variables from database
[Nest] 15779  - 07/30/2026, 10:47:50 AM     LOG [DatabaseConfigDriver] [INIT] Config variables loaded: 1 values found in DB, 104 falling to env vars/defaults
[Nest] 15779  - 07/30/2026, 10:47:50 AM     LOG [UpgradeCommand] Initialized upgrade sequence: 217 step(s)
[upgrade] event=sequence.initialized stepCount=217 dryRun=false
[Nest] 15779  - 07/30/2026, 10:47:50 AM     LOG [WorkspaceIteratorService] Running on workspace 20202020-1c25-4d02-bf25-6aeccf7ea419 1/2
[Nest] 15779  - 07/30/2026, 10:47:50 AM     LOG [WorkspaceCommandRunnerService] Upgrading workspace 20202020-1c25-4d02-bf25-6aeccf7ea419 1/2
[upgrade] event=workspace.start workspaceId=20202020-1c25-4d02-bf25-6aeccf7ea419 index=1 total=2 dryRun=false
[Nest] 15779  - 07/30/2026, 10:47:50 AM     LOG [WorkspaceCommandRunnerService] Upgrade for workspace 20202020-1c25-4d02-bf25-6aeccf7ea419 completed.
[upgrade] event=workspace.success workspaceId=20202020-1c25-4d02-bf25-6aeccf7ea419 executedByVersion=unknown dryRun=false
[Nest] 15779  - 07/30/2026, 10:47:50 AM     LOG [WorkspaceIteratorService] Running on workspace 3b8e6458-5fc1-4e63-8563-008ccddaa6db 2/2
[Nest] 15779  - 07/30/2026, 10:47:50 AM     LOG [WorkspaceCommandRunnerService] Upgrading workspace 3b8e6458-5fc1-4e63-8563-008ccddaa6db 2/2
[upgrade] event=workspace.start workspaceId=3b8e6458-5fc1-4e63-8563-008ccddaa6db index=2 total=2 dryRun=false
[Nest] 15779  - 07/30/2026, 10:47:50 AM     LOG [DummySleepCommand] Sleeping for 30000ms on workspace 3b8e6458-5fc1-4e63-8563-008ccddaa6db
[Nest] 15779  - 07/30/2026, 10:47:53 AM    WARN [CommandShutdownService] Received SIGTERM, finishing the step in progress then stopping. Send SIGTERM again to exit immediately.
Follow with 'yarn upgrade:background:logs'. Still stuck: 'stop --now'. Last resort: 'stop --force'.
➜  twenty-server git:(claude/upgrade-detached-run-wrapper-5nkb0v) ✗ yarn upgrade:background:stop --now
Second SIGTERM sent to 15779, immediate exit with the step in progress left unfinished
Tail of /tmp/twenty-upgrade.log:
[Nest] 15779  - 07/30/2026, 10:47:50 AM     LOG [UpgradeAwareEntityMetadataAdapter] [upgrade-metadata] hidden columns on RolePermissionFlagEntity: flag
[Nest] 15779  - 07/30/2026, 10:47:50 AM     LOG [UpgradeAwareEntityMetadataAdapter] [upgrade-metadata] hidden columns on ObjectMetadataEntity: standardOverrides,isCustom
[Nest] 15779  - 07/30/2026, 10:47:50 AM     LOG [UpgradeAwareEntityMetadataAdapter] [upgrade-metadata] hidden columns on FieldMetadataEntity: standardOverrides,isCustom
[Nest] 15779  - 07/30/2026, 10:47:50 AM     LOG [UpgradeAwareEntityMetadataAdapter] [upgrade-metadata] applied cursor=207 renamed=0 unavailable=0 hiddenColumns=5
[Nest] 15779  - 07/30/2026, 10:47:50 AM     LOG [DatabaseConfigDriver] [INIT] Loading initial config variables from database
[Nest] 15779  - 07/30/2026, 10:47:50 AM     LOG [DatabaseConfigDriver] [INIT] Config variables loaded: 1 values found in DB, 104 falling to env vars/defaults
[Nest] 15779  - 07/30/2026, 10:47:50 AM     LOG [UpgradeCommand] Initialized upgrade sequence: 217 step(s)
[upgrade] event=sequence.initialized stepCount=217 dryRun=false
[Nest] 15779  - 07/30/2026, 10:47:50 AM     LOG [WorkspaceIteratorService] Running on workspace 20202020-1c25-4d02-bf25-6aeccf7ea419 1/2
[Nest] 15779  - 07/30/2026, 10:47:50 AM     LOG [WorkspaceCommandRunnerService] Upgrading workspace 20202020-1c25-4d02-bf25-6aeccf7ea419 1/2
[upgrade] event=workspace.start workspaceId=20202020-1c25-4d02-bf25-6aeccf7ea419 index=1 total=2 dryRun=false
[Nest] 15779  - 07/30/2026, 10:47:50 AM     LOG [WorkspaceCommandRunnerService] Upgrade for workspace 20202020-1c25-4d02-bf25-6aeccf7ea419 completed.
[upgrade] event=workspace.success workspaceId=20202020-1c25-4d02-bf25-6aeccf7ea419 executedByVersion=unknown dryRun=false
[Nest] 15779  - 07/30/2026, 10:47:50 AM     LOG [WorkspaceIteratorService] Running on workspace 3b8e6458-5fc1-4e63-8563-008ccddaa6db 2/2
[Nest] 15779  - 07/30/2026, 10:47:50 AM     LOG [WorkspaceCommandRunnerService] Upgrading workspace 3b8e6458-5fc1-4e63-8563-008ccddaa6db 2/2
[upgrade] event=workspace.start workspaceId=3b8e6458-5fc1-4e63-8563-008ccddaa6db index=2 total=2 dryRun=false
[Nest] 15779  - 07/30/2026, 10:47:50 AM     LOG [DummySleepCommand] Sleeping for 30000ms on workspace 3b8e6458-5fc1-4e63-8563-008ccddaa6db
[Nest] 15779  - 07/30/2026, 10:47:53 AM    WARN [CommandShutdownService] Received SIGTERM, finishing the step in progress then stopping. Send SIGTERM again to exit immediately.
[Nest] 15779  - 07/30/2026, 10:48:00 AM    WARN [CommandShutdownService] Received SIGTERM again, exiting immediately. The step in progress is left unfinished, rerun the command to resume from the last recorded step.
EXIT=143
```

## Not a concurrency guard

`start` refuses when it can see a live run, but that only keeps this wrapper's own bookkeeping straight, one PID file and one log per run. The PID file is in the container's `/tmp`, so a second pod or a laptop pointed at the same database sees none of it.

Nothing in `upgrade` prevents two sequences either: `upgradeMigration` records only `completed` and `failed`, so it has no in-progress state to lock against, and the sequence runner takes no advisory lock. Out of scope here, and worth a follow-up if we want it enforced rather than operational.

## Dockerfile

`scripts/` was not copied into the server image, so all three commands would have failed with ENOENT in the pod. Added the COPY, plus a `chmod +x` matching the one already on `entrypoint.sh`.

Rest is documented in `docs/UPGRADE_COMMANDS.md`, including the exit-code table and why a graceful stop is always safe to rerun.