### PR TITLE
Stop webhook subscription renewal retry loop on non-actionable failures

### DIFF
--- a/packages/twenty-server/src/modules/connected-account/services/accounts-to-reconnect.service.ts
+++ b/packages/twenty-server/src/modules/connected-account/services/accounts-to-reconnect.service.ts
@@ -1,6 +1,12 @@
 import { Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
 
+import { isDefined } from 'twenty-shared/utils';
+import { Repository } from 'typeorm';
+
+import { UserWorkspaceEntity } from 'src/engine/core-modules/user-workspace/user-workspace.entity';
 import { UserVarsService } from 'src/engine/core-modules/user/user-vars/services/user-vars.service';
+import { ConnectedAccountEntity } from 'src/engine/metadata-modules/connected-account/entities/connected-account.entity';
 import {
   type AccountsToReconnectKeyValueType,
   AccountsToReconnectKeys,
@@ -10,7 +16,45 @@ import {
 export class AccountsToReconnectService {
   constructor(
     private readonly userVarsService: UserVarsService<AccountsToReconnectKeyValueType>,
+    @InjectRepository(ConnectedAccountEntity)
+    private readonly connectedAccountRepository: Repository<ConnectedAccountEntity>,
+    @InjectRepository(UserWorkspaceEntity)
+    private readonly userWorkspaceRepository: Repository<UserWorkspaceEntity>,
   ) {}
+
+  public async markAccountForReconnect(
+    connectedAccountId: string,
+    workspaceId: string,
+  ) {
+    const connectedAccount = await this.connectedAccountRepository.findOne({
+      where: { id: connectedAccountId, workspaceId },
+    });
+
+    if (!isDefined(connectedAccount)) {
+      return;
+    }
+
+    await this.connectedAccountRepository.update(
+      { id: connectedAccountId, workspaceId },
+      { authFailedAt: new Date() },
+    );
+
+    const userWorkspace = await this.userWorkspaceRepository.findOne({
+      where: { id: connectedAccount.userWorkspaceId },
+      select: ['userId'],
+    });
+
+    if (!isDefined(userWorkspace)) {
+      return;
+    }
+
+    await this.addAccountToReconnectByKey(
+      AccountsToReconnectKeys.ACCOUNTS_TO_RECONNECT_INSUFFICIENT_PERMISSIONS,
+      userWorkspace.userId,
+      workspaceId,
+      connectedAccountId,
+    );
+  }
 
   public async removeAccountToReconnect(
     userId: string,

--- a/packages/twenty-server/src/modules/connected-account/webhook-subscription-manager/crons/jobs/webhook-subscription-renewal.cron.job.ts
+++ b/packages/twenty-server/src/modules/connected-account/webhook-subscription-manager/crons/jobs/webhook-subscription-renewal.cron.job.ts
@@ -6,7 +6,13 @@ import {
   WebhookSubscriptionStatus,
 } from 'twenty-shared/types';
 import { WorkspaceActivationStatus } from 'twenty-shared/workspace';
-import { type FindManyOptions, In, LessThanOrEqual, Repository } from 'typeorm';
+import {
+  type FindManyOptions,
+  In,
+  IsNull,
+  LessThanOrEqual,
+  Repository,
+} from 'typeorm';
 
 import { SentryCronMonitor } from 'src/engine/core-modules/cron/sentry-cron-monitor.decorator';
 import { InjectMessageQueue } from 'src/engine/core-modules/message-queue/decorators/message-queue.decorator';
@@ -94,7 +100,10 @@ export class WebhookSubscriptionRenewalCronJob {
     repository: Repository<TChannel>,
     activeWorkspaceIds: string[],
   ): Promise<StaleChannel[]> {
-    const workspaceScope = { workspaceId: In(activeWorkspaceIds) };
+    const workspaceScope = {
+      workspaceId: In(activeWorkspaceIds),
+      connectedAccount: { authFailedAt: IsNull() },
+    };
     const renewalThreshold = new Date(
       Date.now() + WEBHOOK_SUBSCRIPTION_RENEWAL_BUFFER_MS,
     );

--- a/packages/twenty-server/src/modules/connected-account/webhook-subscription-manager/drivers/exceptions/webhook-subscription-driver.exception.ts
+++ b/packages/twenty-server/src/modules/connected-account/webhook-subscription-manager/drivers/exceptions/webhook-subscription-driver.exception.ts
@@ -8,6 +8,7 @@ export enum WebhookSubscriptionDriverExceptionCode {
   PROVIDER_NOT_CONFIGURED = 'PROVIDER_NOT_CONFIGURED',
   PROVIDER_RESPONSE_INVALID = 'PROVIDER_RESPONSE_INVALID',
   UNSUPPORTED_PROVIDER = 'UNSUPPORTED_PROVIDER',
+  SUBSCRIPTION_FORBIDDEN = 'SUBSCRIPTION_FORBIDDEN',
 }
 
 const getWebhookSubscriptionDriverExceptionUserFriendlyMessage = (
@@ -17,6 +18,7 @@ const getWebhookSubscriptionDriverExceptionUserFriendlyMessage = (
     case WebhookSubscriptionDriverExceptionCode.PROVIDER_NOT_CONFIGURED:
     case WebhookSubscriptionDriverExceptionCode.PROVIDER_RESPONSE_INVALID:
     case WebhookSubscriptionDriverExceptionCode.UNSUPPORTED_PROVIDER:
+    case WebhookSubscriptionDriverExceptionCode.SUBSCRIPTION_FORBIDDEN:
       return msg`The webhook subscription could not be managed for this account.`;
     default:
       assertUnreachable(code);

--- a/packages/twenty-server/src/modules/connected-account/webhook-subscription-manager/drivers/google/google-webhook-subscription.driver.ts
+++ b/packages/twenty-server/src/modules/connected-account/webhook-subscription-manager/drivers/google/google-webhook-subscription.driver.ts
@@ -1,6 +1,7 @@
 import { Injectable } from '@nestjs/common';
 
 import { isNonEmptyString } from '@sniptt/guards';
+import { type GaxiosError } from 'gaxios';
 import { type calendar_v3, type gmail_v1, google } from 'googleapis';
 import { isDefined } from 'twenty-shared/utils';
 import { v4 } from 'uuid';
@@ -19,6 +20,7 @@ import {
   type WebhookSubscriptionResult,
 } from 'src/modules/connected-account/webhook-subscription-manager/types/webhook-subscription-driver.type';
 import { GoogleOAuth2ClientProvider } from 'src/modules/connected-account/oauth2-client-manager/drivers/google/google-oauth2-client.provider';
+import { parseGoogleWatchError } from 'src/modules/connected-account/webhook-subscription-manager/drivers/google/utils/parse-google-watch-error.util';
 
 @Injectable()
 export class GoogleWebhookSubscriptionDriver implements WebhookSubscriptionDriver {
@@ -121,16 +123,20 @@ export class GoogleWebhookSubscriptionDriver implements WebhookSubscriptionDrive
     const notificationAddress = `${this.twentyConfigService.get('SERVER_URL')}/webhooks/google/calendar`;
     const watchChannelId = v4();
 
-    const { data } = await calendarClient.events.watch({
-      calendarId: 'primary',
-      requestBody: {
-        id: watchChannelId,
-        type: 'web_hook',
-        address: notificationAddress,
-        token: clientState,
-        params: { ttl: String(GOOGLE_CALENDAR_WATCH_TTL_MS / 1000) },
-      },
-    });
+    const { data } = await calendarClient.events
+      .watch({
+        calendarId: 'primary',
+        requestBody: {
+          id: watchChannelId,
+          type: 'web_hook',
+          address: notificationAddress,
+          token: clientState,
+          params: { ttl: String(GOOGLE_CALENDAR_WATCH_TTL_MS / 1000) },
+        },
+      })
+      .catch((error: GaxiosError) => {
+        throw parseGoogleWatchError(error);
+      });
 
     if (!isDefined(data.resourceId) || !isDefined(data.expiration)) {
       throw new WebhookSubscriptionDriverException(

--- a/packages/twenty-server/src/modules/connected-account/webhook-subscription-manager/drivers/google/utils/parse-google-watch-error.util.spec.ts
+++ b/packages/twenty-server/src/modules/connected-account/webhook-subscription-manager/drivers/google/utils/parse-google-watch-error.util.spec.ts
@@ -1,0 +1,45 @@
+import {
+  WebhookSubscriptionDriverException,
+  WebhookSubscriptionDriverExceptionCode,
+} from 'src/modules/connected-account/webhook-subscription-manager/drivers/exceptions/webhook-subscription-driver.exception';
+import { parseGoogleWatchError } from 'src/modules/connected-account/webhook-subscription-manager/drivers/google/utils/parse-google-watch-error.util';
+import { createMockGaxiosError } from 'src/modules/messaging/message-import-manager/drivers/gmail/mocks/create-mock-gaxios-error.util';
+
+const createWatchError = (status: number, reason: string, message: string) =>
+  createMockGaxiosError({
+    message,
+    status,
+    data: { error: { errors: [{ reason, message }] } },
+  });
+
+describe('parseGoogleWatchError', () => {
+  it('should map a permanent 403 to a forbidden subscription exception', () => {
+    const error = createWatchError(
+      403,
+      'required',
+      'The user must be signed up for Google Calendar.',
+    );
+
+    const parsedError = parseGoogleWatchError(error);
+
+    expect(parsedError).toBeInstanceOf(WebhookSubscriptionDriverException);
+    expect((parsedError as WebhookSubscriptionDriverException).code).toBe(
+      WebhookSubscriptionDriverExceptionCode.SUBSCRIPTION_FORBIDDEN,
+    );
+  });
+
+  it.each(['rateLimitExceeded', 'userRateLimitExceeded'])(
+    'should keep the original error for 403 %s',
+    (reason) => {
+      const error = createWatchError(403, reason, 'Rate limit exceeded');
+
+      expect(parseGoogleWatchError(error)).toBe(error);
+    },
+  );
+
+  it('should keep the original error for non-403 statuses', () => {
+    const error = createWatchError(500, 'backendError', 'Backend error');
+
+    expect(parseGoogleWatchError(error)).toBe(error);
+  });
+});

--- a/packages/twenty-server/src/modules/connected-account/webhook-subscription-manager/drivers/google/utils/parse-google-watch-error.util.spec.ts
+++ b/packages/twenty-server/src/modules/connected-account/webhook-subscription-manager/drivers/google/utils/parse-google-watch-error.util.spec.ts
@@ -13,10 +13,10 @@ const createWatchError = (status: number, reason: string, message: string) =>
   });
 
 describe('parseGoogleWatchError', () => {
-  it('should map a permanent 403 to a forbidden subscription exception', () => {
+  it('should map a notACalendarUser 403 to a forbidden subscription exception', () => {
     const error = createWatchError(
       403,
-      'required',
+      'notACalendarUser',
       'The user must be signed up for Google Calendar.',
     );
 
@@ -28,10 +28,10 @@ describe('parseGoogleWatchError', () => {
     );
   });
 
-  it.each(['rateLimitExceeded', 'userRateLimitExceeded'])(
+  it.each(['rateLimitExceeded', 'userRateLimitExceeded', 'forbidden'])(
     'should keep the original error for 403 %s',
     (reason) => {
-      const error = createWatchError(403, reason, 'Rate limit exceeded');
+      const error = createWatchError(403, reason, 'Forbidden');
 
       expect(parseGoogleWatchError(error)).toBe(error);
     },

--- a/packages/twenty-server/src/modules/connected-account/webhook-subscription-manager/drivers/google/utils/parse-google-watch-error.util.ts
+++ b/packages/twenty-server/src/modules/connected-account/webhook-subscription-manager/drivers/google/utils/parse-google-watch-error.util.ts
@@ -1,0 +1,25 @@
+import { type GaxiosError } from 'gaxios';
+
+import {
+  WebhookSubscriptionDriverException,
+  WebhookSubscriptionDriverExceptionCode,
+} from 'src/modules/connected-account/webhook-subscription-manager/drivers/exceptions/webhook-subscription-driver.exception';
+
+const RETRIABLE_FORBIDDEN_REASONS = [
+  'rateLimitExceeded',
+  'userRateLimitExceeded',
+];
+
+export const parseGoogleWatchError = (error: GaxiosError): unknown => {
+  const status = error.response?.status;
+  const reason = error.response?.data?.error?.errors?.[0]?.reason ?? '';
+
+  if (status === 403 && !RETRIABLE_FORBIDDEN_REASONS.includes(reason)) {
+    return new WebhookSubscriptionDriverException(
+      error.message,
+      WebhookSubscriptionDriverExceptionCode.SUBSCRIPTION_FORBIDDEN,
+    );
+  }
+
+  return error;
+};

--- a/packages/twenty-server/src/modules/connected-account/webhook-subscription-manager/drivers/google/utils/parse-google-watch-error.util.ts
+++ b/packages/twenty-server/src/modules/connected-account/webhook-subscription-manager/drivers/google/utils/parse-google-watch-error.util.ts
@@ -5,16 +5,14 @@ import {
   WebhookSubscriptionDriverExceptionCode,
 } from 'src/modules/connected-account/webhook-subscription-manager/drivers/exceptions/webhook-subscription-driver.exception';
 
-const RETRIABLE_FORBIDDEN_REASONS = [
-  'rateLimitExceeded',
-  'userRateLimitExceeded',
-];
+// Thrown when the Google account has no Calendar product or is suspended.
+const NOT_A_CALENDAR_USER_REASON = 'notACalendarUser';
 
 export const parseGoogleWatchError = (error: GaxiosError): unknown => {
   const status = error.response?.status;
-  const reason = error.response?.data?.error?.errors?.[0]?.reason ?? '';
+  const reason = error.response?.data?.error?.errors?.[0]?.reason;
 
-  if (status === 403 && !RETRIABLE_FORBIDDEN_REASONS.includes(reason)) {
+  if (status === 403 && reason === NOT_A_CALENDAR_USER_REASON) {
     return new WebhookSubscriptionDriverException(
       error.message,
       WebhookSubscriptionDriverExceptionCode.SUBSCRIPTION_FORBIDDEN,

--- a/packages/twenty-server/src/modules/connected-account/webhook-subscription-manager/services/calendar-webhook-subscription.service.spec.ts
+++ b/packages/twenty-server/src/modules/connected-account/webhook-subscription-manager/services/calendar-webhook-subscription.service.spec.ts
@@ -14,6 +14,7 @@ import {
   ConnectedAccountRefreshAccessTokenException,
   ConnectedAccountRefreshAccessTokenExceptionCode,
 } from 'src/engine/metadata-modules/connected-account/exceptions/connected-account-refresh-tokens.exception';
+import { AccountsToReconnectService } from 'src/modules/connected-account/services/accounts-to-reconnect.service';
 import {
   WebhookSubscriptionDriverException,
   WebhookSubscriptionDriverExceptionCode,
@@ -25,6 +26,7 @@ describe('CalendarWebhookSubscriptionService', () => {
   let service: CalendarWebhookSubscriptionService;
   let calendarChannelRepository: { findOne: jest.Mock; update: jest.Mock };
   let exceptionHandlerService: { captureExceptions: jest.Mock };
+  let accountsToReconnectService: { markAccountForReconnect: jest.Mock };
   let driver: {
     createSubscription: jest.Mock;
     renewSubscription: jest.Mock;
@@ -56,6 +58,9 @@ describe('CalendarWebhookSubscriptionService', () => {
     exceptionHandlerService = {
       captureExceptions: jest.fn(),
     };
+    accountsToReconnectService = {
+      markAccountForReconnect: jest.fn(),
+    };
     driver = {
       createSubscription: jest.fn(),
       renewSubscription: jest.fn(),
@@ -83,6 +88,10 @@ describe('CalendarWebhookSubscriptionService', () => {
         {
           provide: ExceptionHandlerService,
           useValue: exceptionHandlerService,
+        },
+        {
+          provide: AccountsToReconnectService,
+          useValue: accountsToReconnectService,
         },
       ],
     }).compile();
@@ -114,6 +123,9 @@ describe('CalendarWebhookSubscriptionService', () => {
           webhookSubscriptionStatus: WebhookSubscriptionStatus.FAILED,
         }),
       );
+      expect(
+        accountsToReconnectService.markAccountForReconnect,
+      ).toHaveBeenCalledWith('connected-account-id', mockWorkspaceId);
       expect(exceptionHandlerService.captureExceptions).not.toHaveBeenCalled();
     });
 
@@ -153,6 +165,9 @@ describe('CalendarWebhookSubscriptionService', () => {
         [unknownError],
         { workspace: { id: mockWorkspaceId } },
       );
+      expect(
+        accountsToReconnectService.markAccountForReconnect,
+      ).not.toHaveBeenCalled();
     });
   });
 
@@ -186,6 +201,9 @@ describe('CalendarWebhookSubscriptionService', () => {
         mockCalendarChannelId,
         { webhookSubscriptionStatus: WebhookSubscriptionStatus.FAILED },
       );
+      expect(
+        accountsToReconnectService.markAccountForReconnect,
+      ).toHaveBeenCalledWith('connected-account-id', mockWorkspaceId);
       expect(exceptionHandlerService.captureExceptions).not.toHaveBeenCalled();
     });
 

--- a/packages/twenty-server/src/modules/connected-account/webhook-subscription-manager/services/calendar-webhook-subscription.service.spec.ts
+++ b/packages/twenty-server/src/modules/connected-account/webhook-subscription-manager/services/calendar-webhook-subscription.service.spec.ts
@@ -1,0 +1,249 @@
+import { Test, type TestingModule } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+
+import {
+  ConnectedAccountProvider,
+  WebhookSubscriptionChannelType,
+  WebhookSubscriptionStatus,
+} from 'twenty-shared/types';
+
+import { ExceptionHandlerService } from 'src/engine/core-modules/exception-handler/exception-handler.service';
+import { CalendarChannelEntity } from 'src/engine/metadata-modules/calendar-channel/entities/calendar-channel.entity';
+import { ConnectedAccountEntity } from 'src/engine/metadata-modules/connected-account/entities/connected-account.entity';
+import {
+  ConnectedAccountRefreshAccessTokenException,
+  ConnectedAccountRefreshAccessTokenExceptionCode,
+} from 'src/engine/metadata-modules/connected-account/exceptions/connected-account-refresh-tokens.exception';
+import {
+  WebhookSubscriptionDriverException,
+  WebhookSubscriptionDriverExceptionCode,
+} from 'src/modules/connected-account/webhook-subscription-manager/drivers/exceptions/webhook-subscription-driver.exception';
+import { CalendarWebhookSubscriptionService } from 'src/modules/connected-account/webhook-subscription-manager/services/calendar-webhook-subscription.service';
+import { WebhookSubscriptionDriverFactory } from 'src/modules/connected-account/webhook-subscription-manager/services/webhook-subscription-driver-factory.service';
+
+describe('CalendarWebhookSubscriptionService', () => {
+  let service: CalendarWebhookSubscriptionService;
+  let calendarChannelRepository: { findOne: jest.Mock; update: jest.Mock };
+  let exceptionHandlerService: { captureExceptions: jest.Mock };
+  let driver: {
+    createSubscription: jest.Mock;
+    renewSubscription: jest.Mock;
+    deleteSubscription: jest.Mock;
+  };
+
+  const mockWorkspaceId = 'workspace-id';
+  const mockCalendarChannelId = 'calendar-channel-id';
+
+  const mockCalendarChannel = {
+    id: mockCalendarChannelId,
+    workspaceId: mockWorkspaceId,
+    connectedAccountId: 'connected-account-id',
+    connectedAccount: {
+      id: 'connected-account-id',
+      provider: ConnectedAccountProvider.GOOGLE,
+    },
+    webhookSubscriptionStatus: WebhookSubscriptionStatus.FAILED,
+    webhookSubscriptionExternalId: null,
+    webhookSubscriptionExternalResourceId: null,
+    webhookSubscriptionClientState: 'client-state',
+  };
+
+  beforeEach(async () => {
+    calendarChannelRepository = {
+      findOne: jest.fn(),
+      update: jest.fn(),
+    };
+    exceptionHandlerService = {
+      captureExceptions: jest.fn(),
+    };
+    driver = {
+      createSubscription: jest.fn(),
+      renewSubscription: jest.fn(),
+      deleteSubscription: jest.fn(),
+    };
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        CalendarWebhookSubscriptionService,
+        {
+          provide: getRepositoryToken(ConnectedAccountEntity),
+          useValue: { findOne: jest.fn() },
+        },
+        {
+          provide: getRepositoryToken(CalendarChannelEntity),
+          useValue: calendarChannelRepository,
+        },
+        {
+          provide: WebhookSubscriptionDriverFactory,
+          useValue: {
+            isProviderSupported: jest.fn().mockReturnValue(true),
+            getDriver: jest.fn().mockReturnValue(driver),
+          },
+        },
+        {
+          provide: ExceptionHandlerService,
+          useValue: exceptionHandlerService,
+        },
+      ],
+    }).compile();
+
+    service = module.get(CalendarWebhookSubscriptionService);
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('createSubscription', () => {
+    it('should mark the channel as failed without capturing when the refresh token is invalid', async () => {
+      calendarChannelRepository.findOne.mockResolvedValue(mockCalendarChannel);
+      driver.createSubscription.mockRejectedValue(
+        new ConnectedAccountRefreshAccessTokenException(
+          'Invalid Refresh Token: Bad Request',
+          ConnectedAccountRefreshAccessTokenExceptionCode.INVALID_REFRESH_TOKEN,
+        ),
+      );
+
+      await expect(
+        service.createSubscription(mockCalendarChannelId, mockWorkspaceId),
+      ).resolves.toBeUndefined();
+
+      expect(calendarChannelRepository.update).toHaveBeenCalledWith(
+        mockCalendarChannelId,
+        expect.objectContaining({
+          webhookSubscriptionStatus: WebhookSubscriptionStatus.FAILED,
+        }),
+      );
+      expect(exceptionHandlerService.captureExceptions).not.toHaveBeenCalled();
+    });
+
+    it('should mark the channel as failed without capturing when the subscription is forbidden', async () => {
+      calendarChannelRepository.findOne.mockResolvedValue(mockCalendarChannel);
+      driver.createSubscription.mockRejectedValue(
+        new WebhookSubscriptionDriverException(
+          'The user must be signed up for Google Calendar.',
+          WebhookSubscriptionDriverExceptionCode.SUBSCRIPTION_FORBIDDEN,
+        ),
+      );
+
+      await expect(
+        service.createSubscription(mockCalendarChannelId, mockWorkspaceId),
+      ).resolves.toBeUndefined();
+
+      expect(calendarChannelRepository.update).toHaveBeenCalledWith(
+        mockCalendarChannelId,
+        expect.objectContaining({
+          webhookSubscriptionStatus: WebhookSubscriptionStatus.FAILED,
+        }),
+      );
+      expect(exceptionHandlerService.captureExceptions).not.toHaveBeenCalled();
+    });
+
+    it('should capture and rethrow unknown errors', async () => {
+      const unknownError = new Error('boom');
+
+      calendarChannelRepository.findOne.mockResolvedValue(mockCalendarChannel);
+      driver.createSubscription.mockRejectedValue(unknownError);
+
+      await expect(
+        service.createSubscription(mockCalendarChannelId, mockWorkspaceId),
+      ).rejects.toThrow(unknownError);
+
+      expect(exceptionHandlerService.captureExceptions).toHaveBeenCalledWith(
+        [unknownError],
+        { workspace: { id: mockWorkspaceId } },
+      );
+    });
+  });
+
+  describe('renewSubscription', () => {
+    const mockActiveCalendarChannel = {
+      ...mockCalendarChannel,
+      webhookSubscriptionStatus: WebhookSubscriptionStatus.ACTIVE,
+      webhookSubscriptionExternalId: 'external-id',
+      webhookSubscriptionExternalResourceId: 'resource-id',
+    };
+
+    it('should mark the channel as failed without capturing when the refresh token is missing', async () => {
+      calendarChannelRepository.findOne.mockResolvedValue(
+        mockActiveCalendarChannel,
+      );
+      driver.renewSubscription.mockRejectedValue(
+        new ConnectedAccountRefreshAccessTokenException(
+          'No refresh token found',
+          ConnectedAccountRefreshAccessTokenExceptionCode.REFRESH_TOKEN_NOT_FOUND,
+        ),
+      );
+
+      await expect(
+        service.renewSubscription({
+          calendarChannelId: mockCalendarChannelId,
+          workspaceId: mockWorkspaceId,
+        }),
+      ).resolves.toBeUndefined();
+
+      expect(calendarChannelRepository.update).toHaveBeenCalledWith(
+        mockCalendarChannelId,
+        { webhookSubscriptionStatus: WebhookSubscriptionStatus.FAILED },
+      );
+      expect(exceptionHandlerService.captureExceptions).not.toHaveBeenCalled();
+    });
+
+    it('should capture and rethrow unknown errors', async () => {
+      const unknownError = new Error('boom');
+
+      calendarChannelRepository.findOne.mockResolvedValue(
+        mockActiveCalendarChannel,
+      );
+      driver.renewSubscription.mockRejectedValue(unknownError);
+
+      await expect(
+        service.renewSubscription({
+          calendarChannelId: mockCalendarChannelId,
+          workspaceId: mockWorkspaceId,
+        }),
+      ).rejects.toThrow(unknownError);
+
+      expect(exceptionHandlerService.captureExceptions).toHaveBeenCalledWith(
+        [unknownError],
+        { workspace: { id: mockWorkspaceId } },
+      );
+    });
+
+    it('should renew and store the new subscription on success', async () => {
+      const expiresAt = new Date('2026-08-01T00:00:00.000Z');
+
+      calendarChannelRepository.findOne.mockResolvedValue(
+        mockActiveCalendarChannel,
+      );
+      driver.renewSubscription.mockResolvedValue({
+        externalSubscriptionId: 'new-external-id',
+        externalResourceId: 'new-resource-id',
+        expiresAt,
+      });
+
+      await service.renewSubscription({
+        calendarChannelId: mockCalendarChannelId,
+        workspaceId: mockWorkspaceId,
+      });
+
+      expect(driver.renewSubscription).toHaveBeenCalledWith({
+        connectedAccountId: 'connected-account-id',
+        channelType: WebhookSubscriptionChannelType.CALENDAR,
+        externalSubscriptionId: 'external-id',
+        externalResourceId: 'resource-id',
+        clientState: 'client-state',
+      });
+      expect(calendarChannelRepository.update).toHaveBeenCalledWith(
+        mockCalendarChannelId,
+        {
+          webhookSubscriptionExternalId: 'new-external-id',
+          webhookSubscriptionExternalResourceId: 'new-resource-id',
+          webhookSubscriptionStatus: WebhookSubscriptionStatus.ACTIVE,
+          webhookSubscriptionExpiresAt: expiresAt,
+        },
+      );
+      expect(exceptionHandlerService.captureExceptions).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/packages/twenty-server/src/modules/connected-account/webhook-subscription-manager/services/calendar-webhook-subscription.service.ts
+++ b/packages/twenty-server/src/modules/connected-account/webhook-subscription-manager/services/calendar-webhook-subscription.service.ts
@@ -14,6 +14,7 @@ import { CalendarChannelEntity } from 'src/engine/metadata-modules/calendar-chan
 import { ConnectedAccountEntity } from 'src/engine/metadata-modules/connected-account/entities/connected-account.entity';
 import { WebhookSubscriptionDriverFactory } from 'src/modules/connected-account/webhook-subscription-manager/services/webhook-subscription-driver-factory.service';
 import { type WebhookSubscriptionContext } from 'src/modules/connected-account/webhook-subscription-manager/types/webhook-subscription-driver.type';
+import { isNonRetryableWebhookSubscriptionError } from 'src/modules/connected-account/webhook-subscription-manager/utils/is-non-retryable-webhook-subscription-error.util';
 
 @Injectable()
 export class CalendarWebhookSubscriptionService {
@@ -89,6 +90,10 @@ export class CalendarWebhookSubscriptionService {
         webhookSubscriptionExpiresAt: null,
       });
 
+      if (isNonRetryableWebhookSubscriptionError(error)) {
+        return;
+      }
+
       this.exceptionHandlerService.captureExceptions([error], {
         workspace: { id: workspaceId },
       });
@@ -153,6 +158,10 @@ export class CalendarWebhookSubscriptionService {
       await this.calendarChannelRepository.update(calendarChannel.id, {
         webhookSubscriptionStatus: WebhookSubscriptionStatus.FAILED,
       });
+
+      if (isNonRetryableWebhookSubscriptionError(error)) {
+        return;
+      }
 
       this.exceptionHandlerService.captureExceptions([error], {
         workspace: { id: calendarChannel.workspaceId },

--- a/packages/twenty-server/src/modules/connected-account/webhook-subscription-manager/services/calendar-webhook-subscription.service.ts
+++ b/packages/twenty-server/src/modules/connected-account/webhook-subscription-manager/services/calendar-webhook-subscription.service.ts
@@ -12,6 +12,7 @@ import { v4 } from 'uuid';
 import { ExceptionHandlerService } from 'src/engine/core-modules/exception-handler/exception-handler.service';
 import { CalendarChannelEntity } from 'src/engine/metadata-modules/calendar-channel/entities/calendar-channel.entity';
 import { ConnectedAccountEntity } from 'src/engine/metadata-modules/connected-account/entities/connected-account.entity';
+import { AccountsToReconnectService } from 'src/modules/connected-account/services/accounts-to-reconnect.service';
 import { WebhookSubscriptionDriverFactory } from 'src/modules/connected-account/webhook-subscription-manager/services/webhook-subscription-driver-factory.service';
 import { type WebhookSubscriptionContext } from 'src/modules/connected-account/webhook-subscription-manager/types/webhook-subscription-driver.type';
 import { isNonRetryableWebhookSubscriptionError } from 'src/modules/connected-account/webhook-subscription-manager/utils/is-non-retryable-webhook-subscription-error.util';
@@ -25,6 +26,7 @@ export class CalendarWebhookSubscriptionService {
     private readonly calendarChannelRepository: Repository<CalendarChannelEntity>,
     private readonly webhookSubscriptionDriverFactory: WebhookSubscriptionDriverFactory,
     private readonly exceptionHandlerService: ExceptionHandlerService,
+    private readonly accountsToReconnectService: AccountsToReconnectService,
   ) {}
 
   async createSubscription(
@@ -91,6 +93,11 @@ export class CalendarWebhookSubscriptionService {
       });
 
       if (isNonRetryableWebhookSubscriptionError(error)) {
+        await this.accountsToReconnectService.markAccountForReconnect(
+          connectedAccount.id,
+          workspaceId,
+        );
+
         return;
       }
 
@@ -160,6 +167,11 @@ export class CalendarWebhookSubscriptionService {
       });
 
       if (isNonRetryableWebhookSubscriptionError(error)) {
+        await this.accountsToReconnectService.markAccountForReconnect(
+          connectedAccount.id,
+          workspaceId,
+        );
+
         return;
       }
 

--- a/packages/twenty-server/src/modules/connected-account/webhook-subscription-manager/services/messaging-webhook-subscription.service.ts
+++ b/packages/twenty-server/src/modules/connected-account/webhook-subscription-manager/services/messaging-webhook-subscription.service.ts
@@ -12,6 +12,7 @@ import { v4 } from 'uuid';
 import { ExceptionHandlerService } from 'src/engine/core-modules/exception-handler/exception-handler.service';
 import { ConnectedAccountEntity } from 'src/engine/metadata-modules/connected-account/entities/connected-account.entity';
 import { MessageChannelEntity } from 'src/engine/metadata-modules/message-channel/entities/message-channel.entity';
+import { AccountsToReconnectService } from 'src/modules/connected-account/services/accounts-to-reconnect.service';
 import { WebhookSubscriptionDriverFactory } from 'src/modules/connected-account/webhook-subscription-manager/services/webhook-subscription-driver-factory.service';
 import { type WebhookSubscriptionContext } from 'src/modules/connected-account/webhook-subscription-manager/types/webhook-subscription-driver.type';
 import { isNonRetryableWebhookSubscriptionError } from 'src/modules/connected-account/webhook-subscription-manager/utils/is-non-retryable-webhook-subscription-error.util';
@@ -25,6 +26,7 @@ export class MessagingWebhookSubscriptionService {
     private readonly messageChannelRepository: Repository<MessageChannelEntity>,
     private readonly webhookSubscriptionDriverFactory: WebhookSubscriptionDriverFactory,
     private readonly exceptionHandlerService: ExceptionHandlerService,
+    private readonly accountsToReconnectService: AccountsToReconnectService,
   ) {}
 
   async createSubscription(
@@ -90,6 +92,11 @@ export class MessagingWebhookSubscriptionService {
       });
 
       if (isNonRetryableWebhookSubscriptionError(error)) {
+        await this.accountsToReconnectService.markAccountForReconnect(
+          connectedAccount.id,
+          workspaceId,
+        );
+
         return;
       }
 
@@ -158,6 +165,11 @@ export class MessagingWebhookSubscriptionService {
       });
 
       if (isNonRetryableWebhookSubscriptionError(error)) {
+        await this.accountsToReconnectService.markAccountForReconnect(
+          connectedAccount.id,
+          workspaceId,
+        );
+
         return;
       }
 

--- a/packages/twenty-server/src/modules/connected-account/webhook-subscription-manager/services/messaging-webhook-subscription.service.ts
+++ b/packages/twenty-server/src/modules/connected-account/webhook-subscription-manager/services/messaging-webhook-subscription.service.ts
@@ -14,6 +14,7 @@ import { ConnectedAccountEntity } from 'src/engine/metadata-modules/connected-ac
 import { MessageChannelEntity } from 'src/engine/metadata-modules/message-channel/entities/message-channel.entity';
 import { WebhookSubscriptionDriverFactory } from 'src/modules/connected-account/webhook-subscription-manager/services/webhook-subscription-driver-factory.service';
 import { type WebhookSubscriptionContext } from 'src/modules/connected-account/webhook-subscription-manager/types/webhook-subscription-driver.type';
+import { isNonRetryableWebhookSubscriptionError } from 'src/modules/connected-account/webhook-subscription-manager/utils/is-non-retryable-webhook-subscription-error.util';
 
 @Injectable()
 export class MessagingWebhookSubscriptionService {
@@ -88,6 +89,10 @@ export class MessagingWebhookSubscriptionService {
         webhookSubscriptionExpiresAt: null,
       });
 
+      if (isNonRetryableWebhookSubscriptionError(error)) {
+        return;
+      }
+
       this.exceptionHandlerService.captureExceptions([error], {
         workspace: { id: workspaceId },
       });
@@ -151,6 +156,10 @@ export class MessagingWebhookSubscriptionService {
       await this.messageChannelRepository.update(messageChannel.id, {
         webhookSubscriptionStatus: WebhookSubscriptionStatus.FAILED,
       });
+
+      if (isNonRetryableWebhookSubscriptionError(error)) {
+        return;
+      }
 
       this.exceptionHandlerService.captureExceptions([error], {
         workspace: { id: messageChannel.workspaceId },

--- a/packages/twenty-server/src/modules/connected-account/webhook-subscription-manager/utils/is-non-retryable-webhook-subscription-error.util.spec.ts
+++ b/packages/twenty-server/src/modules/connected-account/webhook-subscription-manager/utils/is-non-retryable-webhook-subscription-error.util.spec.ts
@@ -1,0 +1,60 @@
+import {
+  ConnectedAccountRefreshAccessTokenException,
+  ConnectedAccountRefreshAccessTokenExceptionCode,
+} from 'src/engine/metadata-modules/connected-account/exceptions/connected-account-refresh-tokens.exception';
+import {
+  WebhookSubscriptionDriverException,
+  WebhookSubscriptionDriverExceptionCode,
+} from 'src/modules/connected-account/webhook-subscription-manager/drivers/exceptions/webhook-subscription-driver.exception';
+import { isNonRetryableWebhookSubscriptionError } from 'src/modules/connected-account/webhook-subscription-manager/utils/is-non-retryable-webhook-subscription-error.util';
+
+describe('isNonRetryableWebhookSubscriptionError', () => {
+  it.each([
+    ConnectedAccountRefreshAccessTokenExceptionCode.REFRESH_TOKEN_NOT_FOUND,
+    ConnectedAccountRefreshAccessTokenExceptionCode.INVALID_REFRESH_TOKEN,
+  ])('should return true for %s refresh token errors', (code) => {
+    const error = new ConnectedAccountRefreshAccessTokenException(
+      'refresh failed',
+      code,
+    );
+
+    expect(isNonRetryableWebhookSubscriptionError(error)).toBe(true);
+  });
+
+  it.each([
+    ConnectedAccountRefreshAccessTokenExceptionCode.TEMPORARY_NETWORK_ERROR,
+    ConnectedAccountRefreshAccessTokenExceptionCode.ACCESS_TOKEN_NOT_FOUND,
+    ConnectedAccountRefreshAccessTokenExceptionCode.PROVIDER_NOT_SUPPORTED,
+  ])('should return false for %s refresh token errors', (code) => {
+    const error = new ConnectedAccountRefreshAccessTokenException(
+      'refresh failed',
+      code,
+    );
+
+    expect(isNonRetryableWebhookSubscriptionError(error)).toBe(false);
+  });
+
+  it('should return true for forbidden subscription driver errors', () => {
+    const error = new WebhookSubscriptionDriverException(
+      'The user must be signed up for Google Calendar.',
+      WebhookSubscriptionDriverExceptionCode.SUBSCRIPTION_FORBIDDEN,
+    );
+
+    expect(isNonRetryableWebhookSubscriptionError(error)).toBe(true);
+  });
+
+  it('should return false for other driver errors', () => {
+    const error = new WebhookSubscriptionDriverException(
+      'missing configuration',
+      WebhookSubscriptionDriverExceptionCode.PROVIDER_NOT_CONFIGURED,
+    );
+
+    expect(isNonRetryableWebhookSubscriptionError(error)).toBe(false);
+  });
+
+  it('should return false for unknown errors', () => {
+    expect(isNonRetryableWebhookSubscriptionError(new Error('boom'))).toBe(
+      false,
+    );
+  });
+});

--- a/packages/twenty-server/src/modules/connected-account/webhook-subscription-manager/utils/is-non-retryable-webhook-subscription-error.util.ts
+++ b/packages/twenty-server/src/modules/connected-account/webhook-subscription-manager/utils/is-non-retryable-webhook-subscription-error.util.ts
@@ -1,0 +1,24 @@
+import {
+  ConnectedAccountRefreshAccessTokenException,
+  ConnectedAccountRefreshAccessTokenExceptionCode,
+} from 'src/engine/metadata-modules/connected-account/exceptions/connected-account-refresh-tokens.exception';
+import {
+  WebhookSubscriptionDriverException,
+  WebhookSubscriptionDriverExceptionCode,
+} from 'src/modules/connected-account/webhook-subscription-manager/drivers/exceptions/webhook-subscription-driver.exception';
+
+export const isNonRetryableWebhookSubscriptionError = (
+  error: unknown,
+): boolean => {
+  if (error instanceof ConnectedAccountRefreshAccessTokenException) {
+    return [
+      ConnectedAccountRefreshAccessTokenExceptionCode.REFRESH_TOKEN_NOT_FOUND,
+      ConnectedAccountRefreshAccessTokenExceptionCode.INVALID_REFRESH_TOKEN,
+    ].includes(error.code);
+  }
+
+  return (
+    error instanceof WebhookSubscriptionDriverException &&
+    error.code === WebhookSubscriptionDriverExceptionCode.SUBSCRIPTION_FORBIDDEN
+  );
+};

--- a/packages/twenty-server/src/modules/connected-account/webhook-subscription-manager/webhook-subscription.module.ts
+++ b/packages/twenty-server/src/modules/connected-account/webhook-subscription-manager/webhook-subscription.module.ts
@@ -7,6 +7,7 @@ import { WorkspaceEntity } from 'src/engine/core-modules/workspace/workspace.ent
 import { ConnectedAccountEntity } from 'src/engine/metadata-modules/connected-account/entities/connected-account.entity';
 import { CalendarChannelEntity } from 'src/engine/metadata-modules/calendar-channel/entities/calendar-channel.entity';
 import { MessageChannelEntity } from 'src/engine/metadata-modules/message-channel/entities/message-channel.entity';
+import { ConnectedAccountModule } from 'src/modules/connected-account/connected-account.module';
 import { CreateWebhookSubscriptionForConnectedAccountCommand } from 'src/modules/connected-account/webhook-subscription-manager/commands/create-webhook-subscription-for-connected-account.command';
 import { WebhookSubscriptionRenewalCronCommand } from 'src/modules/connected-account/webhook-subscription-manager/crons/commands/webhook-subscription-renewal.cron.command';
 import { CreateWebhookSubscriptionJob } from 'src/modules/connected-account/webhook-subscription-manager/jobs/create-webhook-subscription.job';
@@ -20,6 +21,7 @@ import { WebhookSubscriptionManagerModule } from 'src/modules/connected-account/
 @Module({
   imports: [
     WebhookSubscriptionManagerModule,
+    ConnectedAccountModule,
     FeatureFlagModule,
     WorkspaceIteratorModule,
     TypeOrmModule.forFeature([


### PR DESCRIPTION
## Context

Three Sentry issues, all starting 2026-07-10 (when webhook subscriptions shipped in v2.25.0), share the same stack: the hourly `WebhookSubscriptionRenewalCronJob` re-enqueues every channel with `webhookSubscriptionStatus: FAILED`, the renewal fails again for the same reason, and each attempt is both captured to Sentry and rethrown (so BullMQ retries it 3 more times). This loops forever:

- [TWENTY-SERVER-J1F](https://twenty-v7.sentry.io/issues/7603992092) Invalid Refresh Token: Bad Request (213k events)
- [TWENTY-SERVER-JBZ](https://twenty-v7.sentry.io/issues/7617075015) Refresh Token Not Found (8.7k events)
- [TWENTY-SERVER-J1M](https://twenty-v7.sentry.io/issues/7604014224) The user must be signed up for Google Calendar (3.4k events)

All three are user-side conditions the server cannot fix: the first two mean the account must be reconnected, the third means the Google account has no Calendar product (or is suspended). The message/calendar import managers already classify these as insufficient-permissions and stop syncing (setting `authFailedAt` on the connected account), but the webhook subscription manager kept hammering.

## Fix

- `WebhookSubscriptionRenewalCronJob` now skips channels whose connected account has `authFailedAt` set. Reconnecting the account resets `authFailedAt` to null, so the cron naturally picks the channel up again afterwards.
- `CalendarWebhookSubscriptionService` and `MessagingWebhookSubscriptionService` still mark the channel `FAILED` on these errors, but no longer capture them to Sentry nor rethrow (which was triggering BullMQ retries). Covered errors: `ConnectedAccountRefreshAccessTokenException` with `INVALID_REFRESH_TOKEN` or `REFRESH_TOKEN_NOT_FOUND`, and the new `SUBSCRIPTION_FORBIDDEN` driver code. Temporary network errors and unknown errors keep the current capture-and-rethrow behavior.
- On the first non-retryable failure, the services call the new `AccountsToReconnectService.markAccountForReconnect`, which sets `authFailedAt` and adds the account to the reconnect user var (same marking the sync status services do). This guarantees the cron stops scheduling the channel even if sync has not hit the error yet, and the user gets the reconnect banner.
- `GoogleWebhookSubscriptionDriver` maps a 403 with reason `notACalendarUser` from `events.watch` ("The user must be signed up for Google Calendar.") to `WebhookSubscriptionDriverException` with the new `SUBSCRIPTION_FORBIDDEN` code. Any other error is rethrown unchanged so it stays captured and retried. Microsoft needs no driver change: its token failures already surface as `INVALID_REFRESH_TOKEN` via `parseMsalError`, and no Graph-level permanent subscription errors have been observed.

Fixes TWENTY-SERVER-J1F
Fixes TWENTY-SERVER-JBZ
Fixes TWENTY-SERVER-J1M