### PR TITLE
feat(server): attach app attributes to application rate-limited metric

### DIFF
--- a/packages/twenty-server/src/engine/api/common/common-query-runners/common-base-query-runner.service.ts
+++ b/packages/twenty-server/src/engine/api/common/common-query-runners/common-base-query-runner.service.ts
@@ -373,6 +373,11 @@ export abstract class CommonBaseQueryRunnerService<
         await this.metricsService.incrementCounterForEvent({
           key: MetricsKeys.CommonApiApplicationQueryRateLimited,
           shouldStoreInCache: false,
+          attributes: {
+            universal_identifier: authContext.application.universalIdentifier,
+            app_name: authContext.application.name,
+            source_type: authContext.application.sourceType,
+          },
         });
       }
 


### PR DESCRIPTION
## What

`MetricsKeys.CommonApiApplicationQueryRateLimited` (`common-api-query/application-rate-limited`) is emitted from the per-application throttler in `common-base-query-runner.service.ts` **without any attributes**. Downstream that means a single undifferentiated counter — there is no way to tell *which* application is hitting `APPLICATION_API_RATE_LIMITING_LIMIT`.

This attaches the app dimension:

```ts
await this.metricsService.incrementCounterForEvent({
  key: MetricsKeys.CommonApiApplicationQueryRateLimited,
  shouldStoreInCache: false,
  attributes: {
    universal_identifier: authContext.application.universalIdentifier,
    app_name: authContext.application.name,
    source_type: authContext.application.sourceType,
  },
});
```

## Why these three attributes

Same trio already emitted by `application-registration.service.ts`, `application-install.service.ts` and `application-gauge.service.ts`, so per-app API rate limiting joins cleanly against the existing app lifecycle metrics rather than introducing a second naming scheme.

## Notes

- **No new data fetching.** `authContext` is already narrowed to `ApplicationWorkspaceAuthContext` by the `isApplicationAuthContext` guard at the top of the method, and the throttler key a few lines above already reads `authContext.application.universalIdentifier`. `name` and `sourceType` are plain columns on `FlatApplication`, present on the same in-memory object.
- **Bounded cardinality.** `universalIdentifier` is stable for an application across workspaces (see the unique index on `(universalIdentifier, workspaceId)`), so the label set is bounded by the number of distinct applications, not by installs.
- **`source_type` typing.** `ApplicationRegistrationSourceType` is a string enum, assignable to OTel's `AttributeValue`.

## Context

The consuming dashboard panels are already merged-pending in `twentyhq/twenty-infra` ([PR #835](https://github.com/twentyhq/twenty-infra/pull/835)) and written with a `coalesce(nullIf(Attributes['app_name'], ''), nullIf(Attributes['universal_identifier'], ''), 'unknown')` fallback, so they render today as a single `unknown` series and start splitting per app automatically once this ships — no dashboard change needed on either side of the deploy.

## Test plan

- Behaviour is unchanged: the counter still fires once per `ThrottlerException`, and the error is still rethrown. Only the attribute bag is new.
- I did not run the twenty-server test suite or typecheck locally — this was authored against a shallow clone without a monorepo install, so I'm relying on CI for both.

---
_Generated by [Claude Code](https://claude.ai/code/session_01VbFtaCS5RkxDhLJApNSteV)_

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/23500?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

