### PR TITLE
Install pre-installed apps in a dedicated job after the workspace upgrade cursor is written

### DIFF
--- a/packages/twenty-server/src/engine/core-modules/application/pre-installed-apps/__tests__/pre-installed-apps.service.spec.ts
+++ b/packages/twenty-server/src/engine/core-modules/application/pre-installed-apps/__tests__/pre-installed-apps.service.spec.ts
@@ -9,6 +9,8 @@ import {
   ApplicationException,
   ApplicationExceptionCode,
 } from 'src/engine/core-modules/application/application.exception';
+import { MessageQueue } from 'src/engine/core-modules/message-queue/message-queue.constants';
+import { getQueueToken } from 'src/engine/core-modules/message-queue/utils/get-queue-token.util';
 
 describe('PreInstalledAppsService', () => {
   let service: PreInstalledAppsService;
@@ -18,11 +20,13 @@ describe('PreInstalledAppsService', () => {
     findOne: jest.Mock;
   };
   let workspaceIteratorService: { iterate: jest.Mock };
+  let messageQueueService: { add: jest.Mock };
 
   beforeEach(async () => {
     applicationInstallService = { installApplication: jest.fn() };
     applicationRegistrationRepository = { find: jest.fn(), findOne: jest.fn() };
     workspaceIteratorService = { iterate: jest.fn() };
+    messageQueueService = { add: jest.fn() };
 
     const module: TestingModule = await Test.createTestingModule({
       providers: [
@@ -38,6 +42,10 @@ describe('PreInstalledAppsService', () => {
         {
           provide: WorkspaceIteratorService,
           useValue: workspaceIteratorService,
+        },
+        {
+          provide: getQueueToken(MessageQueue.workspaceQueue),
+          useValue: messageQueueService,
         },
       ],
     }).compile();

--- a/packages/twenty-server/src/engine/core-modules/application/pre-installed-apps/jobs/install-pre-installed-apps.job-constants.ts
+++ b/packages/twenty-server/src/engine/core-modules/application/pre-installed-apps/jobs/install-pre-installed-apps.job-constants.ts
@@ -1,0 +1,5 @@
+export const INSTALL_PRE_INSTALLED_APPS_JOB_NAME = 'InstallPreInstalledAppsJob';
+
+export type InstallPreInstalledAppsJobData = {
+  workspaceId: string;
+};

--- a/packages/twenty-server/src/engine/core-modules/application/pre-installed-apps/jobs/install-pre-installed-apps.job.ts
+++ b/packages/twenty-server/src/engine/core-modules/application/pre-installed-apps/jobs/install-pre-installed-apps.job.ts
@@ -1,0 +1,28 @@
+import { Logger } from '@nestjs/common';
+
+import {
+  INSTALL_PRE_INSTALLED_APPS_JOB_NAME,
+  type InstallPreInstalledAppsJobData,
+} from 'src/engine/core-modules/application/pre-installed-apps/jobs/install-pre-installed-apps.job-constants';
+import { PreInstalledAppsService } from 'src/engine/core-modules/application/pre-installed-apps/pre-installed-apps.service';
+import { Process } from 'src/engine/core-modules/message-queue/decorators/process.decorator';
+import { Processor } from 'src/engine/core-modules/message-queue/decorators/processor.decorator';
+import { MessageQueue } from 'src/engine/core-modules/message-queue/message-queue.constants';
+
+@Processor(MessageQueue.workspaceQueue)
+export class InstallPreInstalledAppsJob {
+  private readonly logger = new Logger(InstallPreInstalledAppsJob.name);
+
+  constructor(
+    private readonly preInstalledAppsService: PreInstalledAppsService,
+  ) {}
+
+  @Process(INSTALL_PRE_INSTALLED_APPS_JOB_NAME)
+  async handle({ workspaceId }: InstallPreInstalledAppsJobData): Promise<void> {
+    this.logger.log(
+      `Installing pre-installed apps on workspace ${workspaceId}`,
+    );
+
+    await this.preInstalledAppsService.installOnWorkspace(workspaceId);
+  }
+}

--- a/packages/twenty-server/src/engine/core-modules/application/pre-installed-apps/pre-installed-apps.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/application/pre-installed-apps/pre-installed-apps.service.ts
@@ -10,6 +10,13 @@ import {
   ApplicationException,
   ApplicationExceptionCode,
 } from 'src/engine/core-modules/application/application.exception';
+import {
+  INSTALL_PRE_INSTALLED_APPS_JOB_NAME,
+  type InstallPreInstalledAppsJobData,
+} from 'src/engine/core-modules/application/pre-installed-apps/jobs/install-pre-installed-apps.job-constants';
+import { InjectMessageQueue } from 'src/engine/core-modules/message-queue/decorators/message-queue.decorator';
+import { MessageQueue } from 'src/engine/core-modules/message-queue/message-queue.constants';
+import { MessageQueueService } from 'src/engine/core-modules/message-queue/services/message-queue.service';
 
 @Injectable()
 export class PreInstalledAppsService {
@@ -20,7 +27,17 @@ export class PreInstalledAppsService {
     @InjectRepository(ApplicationRegistrationEntity)
     private readonly applicationRegistrationRepository: Repository<ApplicationRegistrationEntity>,
     private readonly workspaceIteratorService: WorkspaceIteratorService,
+    @InjectMessageQueue(MessageQueue.workspaceQueue)
+    private readonly messageQueueService: MessageQueueService,
   ) {}
+
+  async enqueueInstallOnWorkspace(workspaceId: string): Promise<void> {
+    await this.messageQueueService.add<InstallPreInstalledAppsJobData>(
+      INSTALL_PRE_INSTALLED_APPS_JOB_NAME,
+      { workspaceId },
+      { id: `${INSTALL_PRE_INSTALLED_APPS_JOB_NAME}-${workspaceId}` },
+    );
+  }
 
   // Per-app failures are logged but never block the other installs —
   // `ApplicationInstallService` holds a per-app cache lock so parallel

--- a/packages/twenty-server/src/engine/core-modules/message-queue/jobs.module.ts
+++ b/packages/twenty-server/src/engine/core-modules/message-queue/jobs.module.ts
@@ -16,6 +16,8 @@ import { ApplicationInstallModule } from 'src/engine/core-modules/application/ap
 import { ApplicationRegistrationModule } from 'src/engine/core-modules/application/application-registration/application-registration.module';
 import { ApplicationUpgradeModule } from 'src/engine/core-modules/application/application-upgrade/application-upgrade.module';
 import { UpgradeApplicationsJob } from 'src/engine/core-modules/application/jobs/upgrade-applications.job';
+import { InstallPreInstalledAppsJob } from 'src/engine/core-modules/application/pre-installed-apps/jobs/install-pre-installed-apps.job';
+import { PreInstalledAppsModule } from 'src/engine/core-modules/application/pre-installed-apps/pre-installed-apps.module';
 import { InstallOnboardingAppsJob } from 'src/engine/core-modules/onboarding/jobs/install-onboarding-apps.job';
 import { OnboardingModule } from 'src/engine/core-modules/onboarding/onboarding.module';
 import { EmailSenderJob } from 'src/engine/core-modules/email/email-sender.job';
@@ -95,6 +97,7 @@ import { WorkflowModule } from 'src/modules/workflow/workflow.module';
     ApplicationInstallModule,
     ApplicationRegistrationModule,
     ApplicationUpgradeModule,
+    PreInstalledAppsModule,
     OnboardingModule,
     BillingReminderModule,
   ],
@@ -113,6 +116,7 @@ import { WorkflowModule } from 'src/modules/workflow/workflow.module';
     GenerateSdkClientJob,
     UpgradeApplicationsJob,
     InstallOnboardingAppsJob,
+    InstallPreInstalledAppsJob,
   ],
 })
 export class JobsModule {

--- a/packages/twenty-server/src/engine/core-modules/workspace/services/__tests__/workspace.service.spec.ts
+++ b/packages/twenty-server/src/engine/core-modules/workspace/services/__tests__/workspace.service.spec.ts
@@ -37,6 +37,38 @@ import { SdkClientGenerationService } from 'src/engine/core-modules/sdk-client/s
 import { WorkspaceMigrationValidateBuildAndRunService } from 'src/engine/workspace-manager/workspace-migration/services/workspace-migration-validate-build-and-run-service';
 import { WorkspaceManagerService } from 'src/engine/workspace-manager/workspace-manager.service';
 
+jest.mock(
+  'src/engine/workspace-manager/standard-objects-prefill-data/utils/prefill-companies.util',
+  () => ({ prefillCompanies: jest.fn() }),
+);
+jest.mock(
+  'src/engine/workspace-manager/standard-objects-prefill-data/utils/prefill-people.util',
+  () => ({ prefillPeople: jest.fn() }),
+);
+jest.mock(
+  'src/engine/workspace-manager/standard-objects-prefill-data/utils/prefill-workflows.util',
+  () => ({ prefillWorkflows: jest.fn() }),
+);
+jest.mock(
+  'src/engine/workspace-manager/standard-objects-prefill-data/utils/prefill-opportunities.util',
+  () => ({ prefillOpportunities: jest.fn() }),
+);
+jest.mock(
+  'src/engine/workspace-manager/standard-objects-prefill-data/utils/prefill-dashboards.util',
+  () => ({ prefillDashboards: jest.fn() }),
+);
+jest.mock(
+  'src/engine/workspace-manager/standard-objects-prefill-data/utils/prefill-workflow-command-menu-items.util',
+  () => ({ prefillWorkflowCommandMenuItems: jest.fn() }),
+);
+jest.mock(
+  'src/engine/workspace-manager/standard-objects-prefill-data/utils/prefill-workflow-code-step-logic-functions.util',
+  () => ({
+    getCreateCompanyWhenAddingNewPersonCodeStepLogicFunctionDefinitions:
+      jest.fn().mockReturnValue([]),
+  }),
+);
+
 describe('WorkspaceService', () => {
   let service: WorkspaceService;
   let userWorkspaceRepository: Repository<UserWorkspaceEntity>;
@@ -47,9 +79,10 @@ describe('WorkspaceService', () => {
   let dnsManagerService: DnsManagerService;
   let billingSubscriptionService: BillingSubscriptionService;
   let userWorkspaceService: UserWorkspaceService;
+  let module: TestingModule;
 
   beforeEach(async () => {
-    const module: TestingModule = await Test.createTestingModule({
+    module = await Test.createTestingModule({
       providers: [
         WorkspaceService,
         {
@@ -164,6 +197,7 @@ describe('WorkspaceService', () => {
               release: jest.fn(),
               manager: {
                 delete: jest.fn().mockResolvedValue({ affected: 0 }),
+                update: jest.fn().mockResolvedValue({ affected: 1 }),
               },
             }),
             getRepository: jest.fn().mockReturnValue({
@@ -405,6 +439,128 @@ describe('WorkspaceService', () => {
       const hasBeenSuspended = await service.suspendWorkspace('workspace-id');
 
       expect(hasBeenSuspended).toBe(false);
+    });
+  });
+
+  describe('activateWorkspace', () => {
+    const setupActivationMocks = () => {
+      const callOrder: string[] = [];
+
+      jest
+        .spyOn(workspaceRepository, 'update')
+        .mockResolvedValue({ affected: 1 } as never);
+      workspaceRepository.findOneBy = jest.fn().mockResolvedValue({
+        id: 'workspace-id',
+      });
+
+      const workspaceManagerService =
+        module.get<WorkspaceManagerService>(WorkspaceManagerService);
+
+      workspaceManagerService.init = jest.fn();
+
+      const featureFlagService =
+        module.get<FeatureFlagService>(FeatureFlagService);
+
+      featureFlagService.enableFeatureFlags = jest.fn();
+
+      userWorkspaceService.createWorkspaceMember = jest.fn();
+
+      const prefillLogicFunctionService = module.get<PrefillLogicFunctionService>(
+        PrefillLogicFunctionService,
+      );
+
+      prefillLogicFunctionService.ensureSeeded = jest.fn();
+
+      const twentyConfigService =
+        module.get<TwentyConfigService>(TwentyConfigService);
+
+      twentyConfigService.get = jest.fn().mockReturnValue('2.0.0');
+
+      const billingService = module.get<BillingService>(BillingService);
+
+      billingService.hasWorkspaceAnySubscription = jest
+        .fn()
+        .mockResolvedValue(false);
+
+      const upgradeMigrationService = module.get<UpgradeMigrationService>(
+        UpgradeMigrationService,
+      );
+
+      upgradeMigrationService.getLastAttemptedInstanceCommandOrThrow = jest
+        .fn()
+        .mockResolvedValue({ name: 'command', status: 'completed' });
+      upgradeMigrationService.markAsWorkspaceInitial = jest
+        .fn()
+        .mockImplementation(async () => {
+          callOrder.push('markAsWorkspaceInitial');
+        });
+
+      const upgradeSequenceReaderService =
+        module.get<UpgradeSequenceReaderService>(UpgradeSequenceReaderService);
+
+      upgradeSequenceReaderService.getInitialCursorForNewWorkspace = jest
+        .fn()
+        .mockReturnValue({ name: 'command', status: 'completed' });
+
+      const preInstalledAppsService = module.get<PreInstalledAppsService>(
+        PreInstalledAppsService,
+      );
+
+      preInstalledAppsService.installOnWorkspace = jest
+        .fn()
+        .mockImplementation(async () => {
+          callOrder.push('installOnWorkspace');
+        });
+
+      const sdkClientGenerationService = module.get<SdkClientGenerationService>(
+        SdkClientGenerationService,
+      );
+
+      sdkClientGenerationService.enqueueSdkClientGenerationForWorkspace =
+        jest.fn();
+
+      return { callOrder, preInstalledAppsService };
+    };
+
+    // The compatibility check of an app pinning `engines.twenty` resolves the
+    // workspace version from its upgrade cursor, so installing before the
+    // cursor exists rejects every pinned pre-installed app.
+    it('should install pre-installed apps after the upgrade cursor is written', async () => {
+      const { callOrder, preInstalledAppsService } = setupActivationMocks();
+
+      await service.activateWorkspace(
+        { id: 'user-id' } as never,
+        { id: 'workspace-id' } as WorkspaceEntity,
+      );
+
+      expect(preInstalledAppsService.installOnWorkspace).toHaveBeenCalledWith(
+        'workspace-id',
+      );
+      expect(callOrder).toEqual([
+        'markAsWorkspaceInitial',
+        'installOnWorkspace',
+      ]);
+    });
+
+    it('should not fail activation when installing pre-installed apps throws', async () => {
+      const { preInstalledAppsService } = setupActivationMocks();
+
+      preInstalledAppsService.installOnWorkspace = jest
+        .fn()
+        .mockRejectedValue(new Error('install failed'));
+
+      const exceptionHandlerService = module.get<ExceptionHandlerService>(
+        ExceptionHandlerService,
+      );
+
+      exceptionHandlerService.captureExceptions = jest.fn();
+
+      await expect(
+        service.activateWorkspace(
+          { id: 'user-id' } as never,
+          { id: 'workspace-id' } as WorkspaceEntity,
+        ),
+      ).resolves.toEqual({ id: 'workspace-id' });
     });
   });
 });

--- a/packages/twenty-server/src/engine/core-modules/workspace/services/__tests__/workspace.service.spec.ts
+++ b/packages/twenty-server/src/engine/core-modules/workspace/services/__tests__/workspace.service.spec.ts
@@ -37,39 +37,6 @@ import { SdkClientGenerationService } from 'src/engine/core-modules/sdk-client/s
 import { WorkspaceMigrationValidateBuildAndRunService } from 'src/engine/workspace-manager/workspace-migration/services/workspace-migration-validate-build-and-run-service';
 import { WorkspaceManagerService } from 'src/engine/workspace-manager/workspace-manager.service';
 
-jest.mock(
-  'src/engine/workspace-manager/standard-objects-prefill-data/utils/prefill-companies.util',
-  () => ({ prefillCompanies: jest.fn() }),
-);
-jest.mock(
-  'src/engine/workspace-manager/standard-objects-prefill-data/utils/prefill-people.util',
-  () => ({ prefillPeople: jest.fn() }),
-);
-jest.mock(
-  'src/engine/workspace-manager/standard-objects-prefill-data/utils/prefill-workflows.util',
-  () => ({ prefillWorkflows: jest.fn() }),
-);
-jest.mock(
-  'src/engine/workspace-manager/standard-objects-prefill-data/utils/prefill-opportunities.util',
-  () => ({ prefillOpportunities: jest.fn() }),
-);
-jest.mock(
-  'src/engine/workspace-manager/standard-objects-prefill-data/utils/prefill-dashboards.util',
-  () => ({ prefillDashboards: jest.fn() }),
-);
-jest.mock(
-  'src/engine/workspace-manager/standard-objects-prefill-data/utils/prefill-workflow-command-menu-items.util',
-  () => ({ prefillWorkflowCommandMenuItems: jest.fn() }),
-);
-jest.mock(
-  'src/engine/workspace-manager/standard-objects-prefill-data/utils/prefill-workflow-code-step-logic-functions.util',
-  () => ({
-    getCreateCompanyWhenAddingNewPersonCodeStepLogicFunctionDefinitions: jest
-      .fn()
-      .mockReturnValue([]),
-  }),
-);
-
 describe('WorkspaceService', () => {
   let service: WorkspaceService;
   let userWorkspaceRepository: Repository<UserWorkspaceEntity>;
@@ -80,10 +47,9 @@ describe('WorkspaceService', () => {
   let dnsManagerService: DnsManagerService;
   let billingSubscriptionService: BillingSubscriptionService;
   let userWorkspaceService: UserWorkspaceService;
-  let module: TestingModule;
 
   beforeEach(async () => {
-    module = await Test.createTestingModule({
+    const module: TestingModule = await Test.createTestingModule({
       providers: [
         WorkspaceService,
         {
@@ -198,7 +164,6 @@ describe('WorkspaceService', () => {
               release: jest.fn(),
               manager: {
                 delete: jest.fn().mockResolvedValue({ affected: 0 }),
-                update: jest.fn().mockResolvedValue({ affected: 1 }),
               },
             }),
             getRepository: jest.fn().mockReturnValue({
@@ -440,128 +405,6 @@ describe('WorkspaceService', () => {
       const hasBeenSuspended = await service.suspendWorkspace('workspace-id');
 
       expect(hasBeenSuspended).toBe(false);
-    });
-  });
-
-  describe('activateWorkspace', () => {
-    // getWorkspaceSchemaName hashes the id, so it has to be a real uuid.
-    const WORKSPACE_ID = '20202020-1c25-4d02-bf25-6aeccf7ea419';
-
-    const setupActivationMocks = () => {
-      const callOrder: string[] = [];
-
-      jest
-        .spyOn(workspaceRepository, 'update')
-        .mockResolvedValue({ affected: 1 } as never);
-      workspaceRepository.findOneBy = jest.fn().mockResolvedValue({
-        id: WORKSPACE_ID,
-      });
-
-      const workspaceManagerService = module.get<WorkspaceManagerService>(
-        WorkspaceManagerService,
-      );
-
-      workspaceManagerService.init = jest.fn();
-
-      const featureFlagService =
-        module.get<FeatureFlagService>(FeatureFlagService);
-
-      featureFlagService.enableFeatureFlags = jest.fn();
-
-      userWorkspaceService.createWorkspaceMember = jest.fn();
-
-      const prefillLogicFunctionService =
-        module.get<PrefillLogicFunctionService>(PrefillLogicFunctionService);
-
-      prefillLogicFunctionService.ensureSeeded = jest.fn();
-
-      const twentyConfigService =
-        module.get<TwentyConfigService>(TwentyConfigService);
-
-      twentyConfigService.get = jest.fn().mockReturnValue('2.0.0');
-
-      const billingService = module.get<BillingService>(BillingService);
-
-      billingService.hasWorkspaceAnySubscription = jest
-        .fn()
-        .mockResolvedValue(false);
-
-      const upgradeMigrationService = module.get<UpgradeMigrationService>(
-        UpgradeMigrationService,
-      );
-
-      upgradeMigrationService.getLastAttemptedInstanceCommandOrThrow = jest
-        .fn()
-        .mockResolvedValue({ name: 'command', status: 'completed' });
-      upgradeMigrationService.markAsWorkspaceInitial = jest
-        .fn()
-        .mockImplementation(async () => {
-          callOrder.push('markAsWorkspaceInitial');
-        });
-
-      const upgradeSequenceReaderService =
-        module.get<UpgradeSequenceReaderService>(UpgradeSequenceReaderService);
-
-      upgradeSequenceReaderService.getInitialCursorForNewWorkspace = jest
-        .fn()
-        .mockReturnValue({ name: 'command', status: 'completed' });
-
-      const preInstalledAppsService = module.get<PreInstalledAppsService>(
-        PreInstalledAppsService,
-      );
-
-      preInstalledAppsService.installOnWorkspace = jest
-        .fn()
-        .mockImplementation(async () => {
-          callOrder.push('installOnWorkspace');
-        });
-
-      const sdkClientGenerationService = module.get<SdkClientGenerationService>(
-        SdkClientGenerationService,
-      );
-
-      sdkClientGenerationService.enqueueSdkClientGenerationForWorkspace =
-        jest.fn();
-
-      return { callOrder, preInstalledAppsService };
-    };
-
-    it('should install pre-installed apps after the upgrade cursor is written', async () => {
-      const { callOrder, preInstalledAppsService } = setupActivationMocks();
-
-      await service.activateWorkspace(
-        { id: 'user-id' } as never,
-        { id: WORKSPACE_ID } as WorkspaceEntity,
-      );
-
-      expect(preInstalledAppsService.installOnWorkspace).toHaveBeenCalledWith(
-        WORKSPACE_ID,
-      );
-      expect(callOrder).toEqual([
-        'markAsWorkspaceInitial',
-        'installOnWorkspace',
-      ]);
-    });
-
-    it('should not fail activation when installing pre-installed apps throws', async () => {
-      const { preInstalledAppsService } = setupActivationMocks();
-
-      preInstalledAppsService.installOnWorkspace = jest
-        .fn()
-        .mockRejectedValue(new Error('install failed'));
-
-      const exceptionHandlerService = module.get<ExceptionHandlerService>(
-        ExceptionHandlerService,
-      );
-
-      exceptionHandlerService.captureExceptions = jest.fn();
-
-      await expect(
-        service.activateWorkspace(
-          { id: 'user-id' } as never,
-          { id: WORKSPACE_ID } as WorkspaceEntity,
-        ),
-      ).resolves.toEqual({ id: WORKSPACE_ID });
     });
   });
 });

--- a/packages/twenty-server/src/engine/core-modules/workspace/services/__tests__/workspace.service.spec.ts
+++ b/packages/twenty-server/src/engine/core-modules/workspace/services/__tests__/workspace.service.spec.ts
@@ -64,8 +64,9 @@ jest.mock(
 jest.mock(
   'src/engine/workspace-manager/standard-objects-prefill-data/utils/prefill-workflow-code-step-logic-functions.util',
   () => ({
-    getCreateCompanyWhenAddingNewPersonCodeStepLogicFunctionDefinitions:
-      jest.fn().mockReturnValue([]),
+    getCreateCompanyWhenAddingNewPersonCodeStepLogicFunctionDefinitions: jest
+      .fn()
+      .mockReturnValue([]),
   }),
 );
 
@@ -443,6 +444,9 @@ describe('WorkspaceService', () => {
   });
 
   describe('activateWorkspace', () => {
+    // getWorkspaceSchemaName hashes the id, so it has to be a real uuid.
+    const WORKSPACE_ID = '20202020-1c25-4d02-bf25-6aeccf7ea419';
+
     const setupActivationMocks = () => {
       const callOrder: string[] = [];
 
@@ -450,11 +454,12 @@ describe('WorkspaceService', () => {
         .spyOn(workspaceRepository, 'update')
         .mockResolvedValue({ affected: 1 } as never);
       workspaceRepository.findOneBy = jest.fn().mockResolvedValue({
-        id: 'workspace-id',
+        id: WORKSPACE_ID,
       });
 
-      const workspaceManagerService =
-        module.get<WorkspaceManagerService>(WorkspaceManagerService);
+      const workspaceManagerService = module.get<WorkspaceManagerService>(
+        WorkspaceManagerService,
+      );
 
       workspaceManagerService.init = jest.fn();
 
@@ -465,9 +470,8 @@ describe('WorkspaceService', () => {
 
       userWorkspaceService.createWorkspaceMember = jest.fn();
 
-      const prefillLogicFunctionService = module.get<PrefillLogicFunctionService>(
-        PrefillLogicFunctionService,
-      );
+      const prefillLogicFunctionService =
+        module.get<PrefillLogicFunctionService>(PrefillLogicFunctionService);
 
       prefillLogicFunctionService.ensureSeeded = jest.fn();
 
@@ -530,11 +534,11 @@ describe('WorkspaceService', () => {
 
       await service.activateWorkspace(
         { id: 'user-id' } as never,
-        { id: 'workspace-id' } as WorkspaceEntity,
+        { id: WORKSPACE_ID } as WorkspaceEntity,
       );
 
       expect(preInstalledAppsService.installOnWorkspace).toHaveBeenCalledWith(
-        'workspace-id',
+        WORKSPACE_ID,
       );
       expect(callOrder).toEqual([
         'markAsWorkspaceInitial',
@@ -558,9 +562,9 @@ describe('WorkspaceService', () => {
       await expect(
         service.activateWorkspace(
           { id: 'user-id' } as never,
-          { id: 'workspace-id' } as WorkspaceEntity,
+          { id: WORKSPACE_ID } as WorkspaceEntity,
         ),
-      ).resolves.toEqual({ id: 'workspace-id' });
+      ).resolves.toEqual({ id: WORKSPACE_ID });
     });
   });
 });

--- a/packages/twenty-server/src/engine/core-modules/workspace/services/__tests__/workspace.service.spec.ts
+++ b/packages/twenty-server/src/engine/core-modules/workspace/services/__tests__/workspace.service.spec.ts
@@ -526,9 +526,6 @@ describe('WorkspaceService', () => {
       return { callOrder, preInstalledAppsService };
     };
 
-    // The compatibility check of an app pinning `engines.twenty` resolves the
-    // workspace version from its upgrade cursor, so installing before the
-    // cursor exists rejects every pinned pre-installed app.
     it('should install pre-installed apps after the upgrade cursor is written', async () => {
       const { callOrder, preInstalledAppsService } = setupActivationMocks();
 

--- a/packages/twenty-server/src/engine/core-modules/workspace/services/workspace.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/workspace/services/workspace.service.ts
@@ -412,9 +412,6 @@ export class WorkspaceService {
         workspaceId: workspace.id,
       });
 
-      // Must run after the upgrade cursor is written: an app pinning
-      // `engines.twenty` is checked against the workspace completed version,
-      // which is undeterminable while the workspace has no upgrade migration row.
       await this.installPreInstalledApps(workspace.id);
     } catch (error) {
       await this.workspaceRepository.update(workspace.id, {

--- a/packages/twenty-server/src/engine/core-modules/workspace/services/workspace.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/workspace/services/workspace.service.ts
@@ -411,6 +411,11 @@ export class WorkspaceService {
       await this.activateAndInitializeUpgradeState({
         workspaceId: workspace.id,
       });
+
+      // Must run after the upgrade cursor is written: an app pinning
+      // `engines.twenty` is checked against the workspace completed version,
+      // which is undeterminable while the workspace has no upgrade migration row.
+      await this.installPreInstalledApps(workspace.id);
     } catch (error) {
       await this.workspaceRepository.update(workspace.id, {
         activationStatus: WorkspaceActivationStatus.PENDING_CREATION,
@@ -952,7 +957,9 @@ export class WorkspaceService {
       );
       this.exceptionHandlerService.captureExceptions([error as Error]);
     }
+  }
 
+  private async installPreInstalledApps(workspaceId: string): Promise<void> {
     try {
       await this.preInstalledAppsService.installOnWorkspace(workspaceId);
     } catch (error) {

--- a/packages/twenty-server/src/engine/core-modules/workspace/services/workspace.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/workspace/services/workspace.service.ts
@@ -412,7 +412,7 @@ export class WorkspaceService {
         workspaceId: workspace.id,
       });
 
-      await this.installPreInstalledApps(workspace.id);
+      await this.enqueuePreInstalledAppsInstallation(workspace.id);
     } catch (error) {
       await this.workspaceRepository.update(workspace.id, {
         activationStatus: WorkspaceActivationStatus.PENDING_CREATION,
@@ -956,12 +956,14 @@ export class WorkspaceService {
     }
   }
 
-  private async installPreInstalledApps(workspaceId: string): Promise<void> {
+  private async enqueuePreInstalledAppsInstallation(
+    workspaceId: string,
+  ): Promise<void> {
     try {
-      await this.preInstalledAppsService.installOnWorkspace(workspaceId);
+      await this.preInstalledAppsService.enqueueInstallOnWorkspace(workspaceId);
     } catch (error) {
       this.logger.error(
-        `Non-critical: failed to install pre-installed apps for workspace ${workspaceId}`,
+        `Non-critical: failed to enqueue pre-installed apps installation for workspace ${workspaceId}`,
         error,
       );
       this.exceptionHandlerService.captureExceptions([error as Error]);


### PR DESCRIPTION
## Problem

Application registrations flagged `isPreInstalled: true` were not installed on newly created workspaces.

The call was wired in, but it ran too early. `activateWorkspace` invoked `preInstalledAppsService.installOnWorkspace` from inside `prefillCreatedWorkspaceRecords`, which runs **before** `activateAndInitializeUpgradeState`.

The install path validates app/workspace version compatibility:

- `ApplicationInstallService.runInstall` reads `engines.twenty` from the app's `package.json` and calls `validateWorkspaceCompatibility`
- `ApplicationVersionValidationService.validateWorkspaceCompatibility` resolves the workspace version through `UpgradeStatusService.getWorkspaceCompletedVersion`
- that reads the workspace's upgrade-migration cursor, which is only written by `markAsWorkspaceInitial` inside `activateAndInitializeUpgradeState`

During creation the workspace has no cursor row yet, so `getWorkspaceCompletedVersion` returns `null`, the install throws `INVALID_WORKSPACE_VERSION`, and the failure is swallowed twice over: `PreInstalledAppsService` logs per-app failures without rethrowing, and `activateWorkspace` wraps the whole call in non-critical error handling. The workspace comes up silently missing its apps.

This affects most real apps, since they pin `engines.twenty`: `fireflies`, `last-contact`, `people-data-labs`, `call-recorder`, `postcard`, `self-hosting`, `twenty-partners` (`>=2.23.0`) and `exa`, `real-estate` (`>=2.19.0`). Only apps with no `engines.twenty` installed successfully. The same interaction is already documented in `2-23-workspace-command-1784565137000-upgrade-people-data-labs-application.command.ts`, which works around it with `skipWorkspaceCompatibilityCheck: true`.

## Changes

- Added `InstallPreInstalledAppsJob` on the workspace queue, mirroring the existing `InstallOnboardingAppsJob`.
- `activateWorkspace` now enqueues that job instead of installing synchronously, so workspace creation no longer blocks on package fetching and manifest application.
- The enqueue happens after `activateAndInitializeUpgradeState` writes the upgrade cursor, so the compatibility check has a workspace version to resolve by the time the worker picks the job up.

## Notes

Workspaces created before this fix can be repaired with the existing `install-pre-installed-apps` backfill command, which is idempotent.
