### PR TITLE
Fix clipped confirm button label in permanent-delete modal

### DIFF
--- a/packages/twenty-front/src/modules/ui/layout/modal/components/ConfirmationModal.tsx
+++ b/packages/twenty-front/src/modules/ui/layout/modal/components/ConfirmationModal.tsx
@@ -187,6 +187,7 @@ export const ConfirmationModal = ({
         title={translatedConfirmButtonText}
         disabled={!isValidValue || loading}
         fullWidth
+        wrapText
         justify="center"
         dataTestId="confirmation-modal-confirm-button"
       />

--- a/packages/twenty-ui/src/input/Button/Button.module.scss
+++ b/packages/twenty-ui/src/input/Button/Button.module.scss
@@ -70,10 +70,14 @@ $gray-scale-light-gray1: color(display-p3 1 1 1);
 }
 
 .small {
+  --btn-min-height: 24px;
+
   height: 24px;
 }
 
 .medium {
+  --btn-min-height: 32px;
+
   height: 32px;
 }
 
@@ -81,6 +85,16 @@ $gray-scale-light-gray1: color(display-p3 1 1 1);
 // width wins the cascade at equal specificity.
 .fullWidth {
   width: 100%;
+}
+
+// Declared after the size classes so the auto height wins the cascade at equal
+// specificity: the button grows to fit a wrapped label instead of clipping it.
+.wrapText {
+  height: auto;
+  min-height: var(--btn-min-height);
+  padding-bottom: var(--t-spacing-1);
+  padding-top: var(--t-spacing-1);
+  white-space: normal;
 }
 
 // position only reshapes radius and collapses inner borders. The legacy

--- a/packages/twenty-ui/src/input/Button/Button.module.scss.d.ts
+++ b/packages/twenty-ui/src/input/Button/Button.module.scss.d.ts
@@ -5,5 +5,6 @@ declare const classNames: {
   readonly small: 'small';
   readonly medium: 'medium';
   readonly fullWidth: 'fullWidth';
+  readonly wrapText: 'wrapText';
 };
 export default classNames;

--- a/packages/twenty-ui/src/input/Button/Button.tsx
+++ b/packages/twenty-ui/src/input/Button/Button.tsx
@@ -40,6 +40,7 @@ export type ButtonProps = {
   hotkeys?: string[];
   ariaLabel?: string;
   isLoading?: boolean;
+  wrapText?: boolean;
 } & Pick<React.ComponentProps<'button'>, 'type'> &
   ClickOutsideAttributes;
 
@@ -68,6 +69,7 @@ export const Button = ({
   ariaLabel,
   type,
   isLoading = false,
+  wrapText = false,
 }: ButtonProps) => {
   const isMobile = useIsMobile();
 
@@ -94,6 +96,7 @@ export const Button = ({
           styles.button,
           styles[size],
           fullWidth && styles.fullWidth,
+          wrapText && styles.wrapText,
           className,
         )}
         data-variant={variant}
@@ -119,7 +122,12 @@ export const Button = ({
           <ButtonIcon Icon={Icon} isLoading={!!isLoading} />
         )}
         {isDefined(title) && (
-          <ButtonText hasIcon={!!Icon} title={title} isLoading={isLoading} />
+          <ButtonText
+            hasIcon={!!Icon}
+            title={title}
+            isLoading={isLoading}
+            wrapText={wrapText}
+          />
         )}
         {hotkeys && !isMobile && (
           <ButtonHotkeys

--- a/packages/twenty-ui/src/input/Button/internal/ButtonText.module.scss
+++ b/packages/twenty-ui/src/input/Button/internal/ButtonText.module.scss
@@ -19,6 +19,12 @@ $base-transition-timing: 300ms;
   transition-delay: $base-transition-timing * 0.25;
   white-space: nowrap;
 
+  &[data-wrap] {
+    overflow-wrap: anywhere;
+    text-align: center;
+    white-space: normal;
+  }
+
   &[data-loading] {
     clip-path: inset(0 var(--t-spacing-12) 0 0);
     transform: translateX(var(--t-spacing-7));

--- a/packages/twenty-ui/src/input/Button/internal/ButtonText.tsx
+++ b/packages/twenty-ui/src/input/Button/internal/ButtonText.tsx
@@ -4,10 +4,12 @@ export const ButtonText = ({
   hasIcon = false,
   isLoading,
   title,
+  wrapText = false,
 }: {
   isLoading?: boolean;
   hasIcon: boolean;
   title?: string;
+  wrapText?: boolean;
 }) => {
   return (
     <div className={styles.textWrapper}>
@@ -15,6 +17,7 @@ export const ButtonText = ({
         className={styles.text}
         data-loading={isLoading || undefined}
         data-has-icon={hasIcon || undefined}
+        data-wrap={wrapText || undefined}
       >
         {title}
       </div>


### PR DESCRIPTION
Closes #23501

### Problem

`DestroyRecordsCommand` builds the confirm label as `Permanently Destroy <object name>`. Inside `ConfirmationModal` that button is `fullWidth` with `white-space: nowrap` (set on both `.button` and the inner `.text`), in a `narrowWidth` modal that hides horizontal overflow. Longer localized labels (reported in Dutch) or long object names get clipped.

### Fix

Opt-in `wrapText` prop on the shared `Button`:

- `.wrapText` unsets `white-space: nowrap`, switches `height` to `auto` with `min-height` taken from the size class (24px small / 32px medium), and adds vertical padding. It is declared after `.small`/`.medium`/`.fullWidth` so it wins the cascade at equal specificity, matching the convention already used for `.fullWidth` in that file.
- `ButtonText` gets a `data-wrap` attribute that unsets the inner `nowrap`, centers wrapped lines, and uses `overflow-wrap: anywhere` so a single long word cannot overflow either.
- `ConfirmationModal` passes `wrapText` to the confirm button only. `fullWidth` and `justify="center"` are untouched, and short labels still render on one line at the same 32px height.

The modal title already wraps (`H1Title` has no `nowrap`), so no change was needed there.

### Notes for reviewers

- The prop is opt-in and defaults to `false`, so every other `Button` call site is unaffected.
- Verified with `oxlint` on the changed files and `nx typecheck` for `twenty-ui` and `twenty-front`. The wrapped two-line layout has not been checked in a browser.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/23518?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

