### PR TITLE
Pin last-contact to twenty &gt;=2.26.0

### DIFF
--- a/packages/twenty-apps/public/last-contact/CHANGELOG.md
+++ b/packages/twenty-apps/public/last-contact/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 1.1.3
 
 - Stop declaring INDEX view fields explicitly: the server now provisions the INDEX view column for each app field automatically, so the manifest no longer targets the engine-owned standard INDEX views.
+- Require Twenty `>=2.26.0`: the engine-owned INDEX view fields this version relies on only exist from 2.26.
 
 ## 1.1.1
 

--- a/packages/twenty-apps/public/last-contact/package.json
+++ b/packages/twenty-apps/public/last-contact/package.json
@@ -6,7 +6,7 @@
     "node": "^24.5.0",
     "npm": "please-use-yarn",
     "yarn": ">=4.0.2",
-    "twenty": ">=2.23.0"
+    "twenty": ">=2.26.0"
   },
   "keywords": [
     "twenty-app"


### PR DESCRIPTION
Follow-up to #23081.

`twenty-last-contact@1.1.3` stopped declaring its INDEX view fields explicitly and now relies on the engine's `fieldIndexViewFieldOnCreate` to provision the INDEX view column of each app field. That handler only exists from `2.26`, but the app still advertised `engines.twenty: ">=2.23.0"`.

This bumps the range to `>=2.26.0` and documents it in the changelog.

## Why the range matters

`engines.twenty` is checked in two different places against two different versions:

- `ApplicationTarballService.extractAndValidateTarball` → `validateServerCompatibility`, against the **store server's** inferred version. So `1.1.3` can only be deployed once the store instance is on `2.26`.
- `ApplicationInstallService.runInstall` → `validateWorkspaceCompatibility`, against the **workspace's completed upgrade version**.

The second one is the reason for this PR. Publishing a new version calls `enqueueAutoUpgradeApplications`, and the auto-upgrade path (`ApplicationUpgradeService.upgradeApplicationToVersion`) does not pass `skipWorkspaceCompatibilityCheck`. Without the bump, a workspace that has not yet completed the `2.26` workspace commands would be auto-upgraded to `1.1.3` and end up with no last-contact columns at all: the manifest no longer declares them, and pre-`2.26` there is no handler to provision them. With `>=2.26.0` those workspaces are skipped and stay on `1.1.2`, which still works on a `2.25` server.

## No SDK bump needed

The only SDK surface the deleted `src/view-fields/*` files used was `STANDARD_OBJECT_UNIVERSAL_IDENTIFIERS.<object>.views.*.universalIdentifier`, which is exactly what #23081 mutated. Everything left in the app reads only `.<object>.universalIdentifier`, unchanged, so `twenty-sdk@2.23.0-alpha.2` still transpiles `1.1.3` to the manifest `2.26` expects.

## Note on the version number

This pins the existing `1.1.3`, which assumes it has not been deployed to the store yet. If it has, `validateVersionProgression` rejects a same-version deploy and this needs to go out as `1.1.4` instead — a one-line change on this branch.

## Not covered here

Stale `1.1.2` installs on a `2.26` server keep working at runtime (view fields resolve by database id) but fail any manifest re-sync with `View not found`, since the standard INDEX view identifiers they target were renamed by `upgrade:2-26:reconcile-index-view-universal-identifier`. They will be picked up by auto-upgrade once `1.1.3` is published. Force-upgrading them from within the `2.26` workspace upgrade, as done for people-data-labs in `2.23`, would need `skipWorkspaceCompatibilityCheck: true` (the command runs before the workspace is marked as having completed `2.26`) and is left out of this PR.


---
_Generated by [Claude Code](https://claude.ai/code/session_01YEDaMaXaAgj2oTpQHzSqDz)_

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/23520?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

