### PR TITLE
Keep fullWidth buttons at full width while loading

### DIFF
--- a/packages/twenty-ui/src/input/Button/Button.module.scss
+++ b/packages/twenty-ui/src/input/Button/Button.module.scss
@@ -78,8 +78,10 @@ $gray-scale-light-gray1: color(display-p3 1 1 1);
 }
 
 // Applied to both the wrapper and the button; declared after them so the
-// width wins the cascade at equal specificity.
+// sizing wins the cascade at equal specificity, including over
+// .wrapperLoading's max-width shrink which only applies to auto-width buttons.
 .fullWidth {
+  max-width: 100%;
   width: 100%;
 }
 


### PR DESCRIPTION
When a `Button` enters its loading state, the wrapper gets `.wrapperLoading { max-width: calc(100% - 32px) }` to make room for the spinner on auto-width buttons. `.fullWidth` only set `width: 100%` without a max-width, so any full-width button shrank by 32px for as long as its loader was visible, leaving a visible gap on the right. Most noticeable on the "Add credit card" button in the billing modal while the card is being validated.

Fix: `.fullWidth` now also pins `max-width: 100%`. It is declared after `.wrapperLoading`, so it wins the cascade at equal specificity and the loading shrink keeps applying only to auto-width buttons.

---
_Generated by [Claude Code](https://claude.ai/code/session_01W1J7cW2MhaqXGfdjvHeFoX)_

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/23536?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

