### PR TITLE
Keep leading + when filtering phones by calling code

### DIFF
--- a/packages/twenty-front/src/modules/object-record/record-filter/utils/__tests__/computeViewRecordGqlOperationFilter.test.ts
+++ b/packages/twenty-front/src/modules/object-record/record-filter/utils/__tests__/computeViewRecordGqlOperationFilter.test.ts
@@ -799,6 +799,60 @@ describe('should work as expected for the different field types', () => {
     });
   });
 
+  it('phones field type with an international calling code prefix', () => {
+    const personMockPhonesFieldMetadataItem =
+      personMockObjectMetadataItem.fields.find(
+        (field) => field.name === 'phones',
+      );
+
+    if (!isDefined(personMockPhonesFieldMetadataItem)) {
+      throw new Error('Person mock phones field metadata ID is undefined');
+    }
+
+    const phonesFilterContains: RecordFilter = {
+      id: 'person-phones-filter-contains-calling-code',
+      value: '+33 6 12',
+      fieldMetadataId: personMockPhonesFieldMetadataItem.id,
+      displayValue: '+33 6 12',
+      operand: ViewFilterOperand.CONTAINS,
+      label: 'Phones',
+      type: FieldMetadataType.PHONES,
+    };
+
+    const result = computeRecordGqlOperationFilter({
+      filterValueDependencies: mockFilterValueDependencies,
+      recordFilters: [phonesFilterContains],
+      recordFilterGroups: [],
+      fieldMetadataItems: personFields,
+    });
+
+    expect(result).toEqual({
+      or: [
+        {
+          phones: {
+            primaryPhoneNumber: {
+              ilike: '%+33612%',
+            },
+          },
+        },
+        {
+          phones: {
+            primaryPhoneCallingCode: {
+              ilike: '%+33612%',
+            },
+          },
+        },
+        {
+          phones: {
+            additionalPhones: {
+              like: '%+33612%',
+            },
+          },
+        },
+      ],
+    });
+  });
+
   it('emails field type', () => {
     const personMockEmailFieldMetadataId = getMockFieldMetadataItemOrThrow({
       objectMetadataItem: personMockObjectMetadataItem,

--- a/packages/twenty-shared/src/utils/filter/turnRecordFilterIntoGqlOperationFilter.ts
+++ b/packages/twenty-shared/src/utils/filter/turnRecordFilterIntoGqlOperationFilter.ts
@@ -60,7 +60,6 @@ import {
   computeRelationGqlFieldJoinColumnName,
 } from '@/utils/fieldMetadata/compute-relation-gql-field-join-column-name';
 
-// Strips every non-digit except a single leading + (preserving the calling code)
 const PHONE_FILTER_NON_SIGNIFICANT_CHARS = /(?!^)\+|[^0-9+]/g;
 
 const CONTAINS_DIGIT = /[0-9]/;

--- a/packages/twenty-shared/src/utils/filter/turnRecordFilterIntoGqlOperationFilter.ts
+++ b/packages/twenty-shared/src/utils/filter/turnRecordFilterIntoGqlOperationFilter.ts
@@ -1403,8 +1403,6 @@ const buildDirectFieldGqlOperationFilter = ({
     }
     case 'PHONES': {
       if (!isSubFieldFilter) {
-        // Keep a leading '+' so an international calling code like '+33' is not
-        // matched against phone numbers merely containing '33'
         const filterValue = recordFilter.value
           .trim()
           .replace(/(?!^)\+|[^0-9+]/g, '');

--- a/packages/twenty-shared/src/utils/filter/turnRecordFilterIntoGqlOperationFilter.ts
+++ b/packages/twenty-shared/src/utils/filter/turnRecordFilterIntoGqlOperationFilter.ts
@@ -1403,11 +1403,18 @@ const buildDirectFieldGqlOperationFilter = ({
     }
     case 'PHONES': {
       if (!isSubFieldFilter) {
-        const filterValue = recordFilter.value.replace(/[^0-9]/g, '');
+        const trimmedValue = recordFilter.value.trim();
+        const digits = trimmedValue.replace(/[^0-9]/g, '');
 
-        if (!isNonEmptyString(filterValue)) {
+        if (!isNonEmptyString(digits)) {
           return;
         }
+
+        // Keep the leading '+' so an international calling code like '+33' is not
+        // matched against phone numbers merely containing '33'
+        const filterValue = trimmedValue.startsWith('+')
+          ? `+${digits}`
+          : digits;
 
         switch (recordFilter.operand) {
           case RecordFilterOperand.CONTAINS:

--- a/packages/twenty-shared/src/utils/filter/turnRecordFilterIntoGqlOperationFilter.ts
+++ b/packages/twenty-shared/src/utils/filter/turnRecordFilterIntoGqlOperationFilter.ts
@@ -60,6 +60,11 @@ import {
   computeRelationGqlFieldJoinColumnName,
 } from '@/utils/fieldMetadata/compute-relation-gql-field-join-column-name';
 
+// Strips every non-digit except a single leading + (preserving the calling code)
+const PHONE_FILTER_NON_SIGNIFICANT_CHARS = /(?!^)\+|[^0-9+]/g;
+
+const CONTAINS_DIGIT = /[0-9]/;
+
 type FieldSharedMorphRelation = {
   type: RelationType;
   targetObjectMetadata: {
@@ -1405,9 +1410,9 @@ const buildDirectFieldGqlOperationFilter = ({
       if (!isSubFieldFilter) {
         const filterValue = recordFilter.value
           .trim()
-          .replace(/(?!^)\+|[^0-9+]/g, '');
+          .replace(PHONE_FILTER_NON_SIGNIFICANT_CHARS, '');
 
-        if (!/[0-9]/.test(filterValue)) {
+        if (!CONTAINS_DIGIT.test(filterValue)) {
           return;
         }
 

--- a/packages/twenty-shared/src/utils/filter/turnRecordFilterIntoGqlOperationFilter.ts
+++ b/packages/twenty-shared/src/utils/filter/turnRecordFilterIntoGqlOperationFilter.ts
@@ -1403,18 +1403,15 @@ const buildDirectFieldGqlOperationFilter = ({
     }
     case 'PHONES': {
       if (!isSubFieldFilter) {
-        const trimmedValue = recordFilter.value.trim();
-        const digits = trimmedValue.replace(/[^0-9]/g, '');
+        // Keep a leading '+' so an international calling code like '+33' is not
+        // matched against phone numbers merely containing '33'
+        const filterValue = recordFilter.value
+          .trim()
+          .replace(/(?!^)\+|[^0-9+]/g, '');
 
-        if (!isNonEmptyString(digits)) {
+        if (!/[0-9]/.test(filterValue)) {
           return;
         }
-
-        // Keep the leading '+' so an international calling code like '+33' is not
-        // matched against phone numbers merely containing '33'
-        const filterValue = trimmedValue.startsWith('+')
-          ? `+${digits}`
-          : digits;
 
         switch (recordFilter.operand) {
           case RecordFilterOperand.CONTAINS:


### PR DESCRIPTION
Fixes #23528

Filtering a PHONES field with `CONTAINS` / `DOES_NOT_CONTAIN` stripped every non-digit character from the filter value, so `+33` became `33` and the generated `ilike`/`like` predicates could not distinguish an international calling code from any number containing those digits.

`turnRecordFilterIntoGqlOperationFilter` now preserves a leading `+` while still removing other formatting characters (spaces, dashes, parentheses). `+33 6 12` becomes `+33612`; values without a `+` are unchanged.

Added a regression test in `computeViewRecordGqlOperationFilter.test.ts` for a `+`-prefixed value.

Lint and typecheck pass on `twenty-shared` and `twenty-front`; the filter test suites pass in both packages.