### PR TITLE
Enforce role permissions on system objects

### DIFF
--- a/packages/twenty-server/src/engine/metadata-modules/role/services/__tests__/workspace-roles-permissions-cache.service.spec.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/role/services/__tests__/workspace-roles-permissions-cache.service.spec.ts
@@ -325,9 +325,30 @@ describe('WorkspaceRolesPermissionsCacheService', () => {
   });
 
   describe('system object (message)', () => {
-    it('should default to full access when no object permission override exists', async () => {
+    it('should deny access when a deny-all role has no object permission override', async () => {
       roleRepository.find.mockResolvedValue([
         createBaseRole({
+          rolePermissionFlags: [],
+          objectPermissions: [],
+        }),
+      ]);
+
+      const result = await service.computeForCache(WORKSPACE_ID);
+      const messagePermissions = result[ROLE_ID][MESSAGE_OBJECT_METADATA_ID];
+
+      expect(messagePermissions.canReadObjectRecords).toBe(false);
+      expect(messagePermissions.canUpdateObjectRecords).toBe(false);
+      expect(messagePermissions.canSoftDeleteObjectRecords).toBe(false);
+      expect(messagePermissions.canDestroyObjectRecords).toBe(false);
+    });
+
+    it('should follow role-wide defaults when no object permission override exists', async () => {
+      roleRepository.find.mockResolvedValue([
+        createBaseRole({
+          canReadAllObjectRecords: true,
+          canUpdateAllObjectRecords: true,
+          canSoftDeleteAllObjectRecords: true,
+          canDestroyAllObjectRecords: true,
           rolePermissionFlags: [],
           objectPermissions: [],
         }),
@@ -342,7 +363,7 @@ describe('WorkspaceRolesPermissionsCacheService', () => {
       expect(messagePermissions.canDestroyObjectRecords).toBe(true);
     });
 
-    it('should honor an explicit deny override instead of forcing system default', async () => {
+    it('should honor an explicit deny override on a read-all role', async () => {
       objectPermissionRepository.find.mockResolvedValue([
         {
           roleId: ROLE_ID,
@@ -356,6 +377,10 @@ describe('WorkspaceRolesPermissionsCacheService', () => {
 
       roleRepository.find.mockResolvedValue([
         createBaseRole({
+          canReadAllObjectRecords: true,
+          canUpdateAllObjectRecords: true,
+          canSoftDeleteAllObjectRecords: true,
+          canDestroyAllObjectRecords: true,
           rolePermissionFlags: [],
           objectPermissions: [],
         }),

--- a/packages/twenty-server/src/engine/metadata-modules/role/services/workspace-roles-permissions-cache.service.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/role/services/workspace-roles-permissions-cache.service.ts
@@ -128,11 +128,7 @@ export class WorkspaceRolesPermissionsCacheService extends WorkspaceCacheProvide
       const objectRecordsPermissions: ObjectsPermissions = {};
 
       for (const objectMetadata of workspaceObjectMetadataCollection) {
-        const {
-          id: objectMetadataId,
-          isSystem,
-          universalIdentifier,
-        } = objectMetadata;
+        const { id: objectMetadataId, universalIdentifier } = objectMetadata;
 
         let canRead = role.canReadAllObjectRecords;
         let canUpdate = role.canUpdateAllObjectRecords;
@@ -178,27 +174,17 @@ export class WorkspaceRolesPermissionsCacheService extends WorkspaceCacheProvide
                 objectPermission.objectMetadataId === objectMetadataId,
             );
 
-            const getPermissionValue = (
-              overrideValue: boolean | undefined,
-              defaultValue: boolean,
-            ) => overrideValue ?? (isSystem ? true : defaultValue);
-
-            canRead = getPermissionValue(
-              objectRecordPermissionsOverride?.canReadObjectRecords,
-              canRead,
-            );
-            canUpdate = getPermissionValue(
-              objectRecordPermissionsOverride?.canUpdateObjectRecords,
-              canUpdate,
-            );
-            canSoftDelete = getPermissionValue(
-              objectRecordPermissionsOverride?.canSoftDeleteObjectRecords,
-              canSoftDelete,
-            );
-            canDestroy = getPermissionValue(
-              objectRecordPermissionsOverride?.canDestroyObjectRecords,
-              canDestroy,
-            );
+            canRead =
+              objectRecordPermissionsOverride?.canReadObjectRecords ?? canRead;
+            canUpdate =
+              objectRecordPermissionsOverride?.canUpdateObjectRecords ??
+              canUpdate;
+            canSoftDelete =
+              objectRecordPermissionsOverride?.canSoftDeleteObjectRecords ??
+              canSoftDelete;
+            canDestroy =
+              objectRecordPermissionsOverride?.canDestroyObjectRecords ??
+              canDestroy;
           }
 
           const fieldPermissionsForObject = roleFieldPermissions.filter(

--- a/packages/twenty-server/src/engine/twenty-orm/repository/permissions.utils.ts
+++ b/packages/twenty-server/src/engine/twenty-orm/repository/permissions.utils.ts
@@ -1,6 +1,5 @@
 import { isNonEmptyString } from '@sniptt/guards';
 import isEmpty from 'lodash.isempty';
-import { STANDARD_OBJECTS } from 'twenty-shared/metadata';
 import {
   type ObjectsPermissions,
   type RestrictedFieldsPermissions,
@@ -20,9 +19,6 @@ import {
   PermissionsExceptionMessage,
 } from 'src/engine/metadata-modules/permissions/permissions.exception';
 import { getColumnNameToFieldMetadataIdMap } from 'src/engine/twenty-orm/utils/get-column-name-to-field-metadata-id.util';
-
-const WORKSPACE_MEMBER_OBJECT_UNIVERSAL_IDENTIFIER =
-  STANDARD_OBJECTS.workspaceMember.universalIdentifier;
 
 const getTargetEntityAndOperationType = (
   expressionMap: QueryExpressionMap,
@@ -111,16 +107,6 @@ export const validateOperationIsPermittedOrThrow = ({
       PermissionsExceptionMessage.PERMISSION_DENIED,
       PermissionsExceptionCode.PERMISSION_DENIED,
     );
-  }
-
-  const objectMetadataIsSystem = objectMetadata.isSystem === true;
-  const isWorkspaceMemberObject =
-    objectMetadata.universalIdentifier ===
-    WORKSPACE_MEMBER_OBJECT_UNIVERSAL_IDENTIFIER;
-
-  // TODO: this should be improved, we may have more complex permission configuration for is system objects
-  if (objectMetadataIsSystem && !isWorkspaceMemberObject) {
-    return;
   }
 
   const columnNameToFieldMetadataIdMap = getColumnNameToFieldMetadataIdMap(

--- a/packages/twenty-server/test/integration/graphql/suites/object-records-permissions/granular-object-records-permissions.integration-spec.ts
+++ b/packages/twenty-server/test/integration/graphql/suites/object-records-permissions/granular-object-records-permissions.integration-spec.ts
@@ -1,6 +1,7 @@
 import { default as request } from 'supertest';
 import { createCustomRoleWithObjectPermissions } from 'test/integration/graphql/utils/create-custom-role-with-object-permissions.util';
 import { deleteRole } from 'test/integration/graphql/utils/delete-one-role.util';
+import { findManyOperationFactory } from 'test/integration/graphql/utils/find-many-operation-factory.util';
 import { findOneOperationFactory } from 'test/integration/graphql/utils/find-one-operation-factory.util';
 import { makeGraphqlAPIRequestWithMemberRole as makeGraphqlAPIRequestWithJony } from 'test/integration/graphql/utils/make-graphql-api-request-with-member-role.util';
 import { updateWorkspaceMemberRole } from 'test/integration/graphql/utils/update-workspace-member-role.util';
@@ -168,6 +169,60 @@ describe('granularObjectRecordsPermissions', () => {
       expect(companyResponse.body.errors[0].extensions.code).toBe(
         ErrorCode.FORBIDDEN,
       );
+    });
+
+    it('should throw permission error when querying a system object (calendarEvent) with a deny-all role', async () => {
+      const { roleId } = await createCustomRoleWithObjectPermissions({
+        label: 'DenyAllSystemObjectRole',
+        hasAllObjectRecordsReadPermission: false,
+      });
+
+      customRoleId = roleId;
+
+      await updateWorkspaceMemberRole({
+        client,
+        roleId: customRoleId,
+        workspaceMemberId: WORKSPACE_MEMBER_DATA_SEED_IDS.JONY,
+      });
+
+      const graphqlOperation = findManyOperationFactory({
+        objectMetadataSingularName: 'calendarEvent',
+        objectMetadataPluralName: 'calendarEvents',
+        gqlFields: `id`,
+      });
+
+      const response = await makeGraphqlAPIRequestWithJony(graphqlOperation);
+
+      expect(response.body.errors).toBeDefined();
+      expect(response.body.errors[0].message).toBe(
+        PermissionsExceptionMessage.PERMISSION_DENIED,
+      );
+      expect(response.body.errors[0].extensions.code).toBe(ErrorCode.FORBIDDEN);
+    });
+
+    it('should successfully query a system object (calendarEvent) with a read-all role', async () => {
+      const { roleId } = await createCustomRoleWithObjectPermissions({
+        label: 'ReadAllSystemObjectRole',
+      });
+
+      customRoleId = roleId;
+
+      await updateWorkspaceMemberRole({
+        client,
+        roleId: customRoleId,
+        workspaceMemberId: WORKSPACE_MEMBER_DATA_SEED_IDS.JONY,
+      });
+
+      const graphqlOperation = findManyOperationFactory({
+        objectMetadataSingularName: 'calendarEvent',
+        objectMetadataPluralName: 'calendarEvents',
+        gqlFields: `id`,
+      });
+
+      const response = await makeGraphqlAPIRequestWithJony(graphqlOperation);
+
+      expect(response.body.errors).toBeUndefined();
+      expect(response.body.data.calendarEvents).toBeDefined();
     });
   });
 });


### PR DESCRIPTION
## Bug

Fixes #23533 (security follow-up to #23062). A workspace member whose role denies all object access could still read and mutate non-workflow, non-workspace-member system objects (message, calendarEvent, connectedAccount, attachment, timelineActivity, etc.). #23280 only fixed override precedence in the role cache; two `isSystem` bypasses remained.

## Root causes

1. **Role cache** (`workspace-roles-permissions-cache.service.ts`): for non-workflow, non-workspace-member objects the helper resolved `overrideValue ?? (isSystem ? true : defaultValue)`. When a system object had no explicit override row, `isSystem` forced every CRUD permission to `true`, ignoring the role-wide `canReadAllObjectRecords` / `canUpdate...` / etc. defaults.

2. **ORM validator** (`permissions.utils.ts`): `validateOperationIsPermittedOrThrow` returned early for `isSystem && !workspaceMember` before running any object, CRUD, or field permission check, so even an explicit deny override was never enforced on normal ORM paths.

## Fix

1. Cache: system objects now resolve `overrideValue ?? defaultValue`, identical to regular objects. An explicit override still wins; otherwise the role-wide default applies. Workflow objects (settings-gated via `WORKFLOWS`) and workspace-member objects (settings-gated, always readable) keep their dedicated branches and are unchanged.

2. ORM: removed the `isSystem` early return so system objects go through the same object/CRUD/field checks as every other object. Trusted internal flows are unaffected: they run under `SystemAuthContext`, which short-circuits earlier via `shouldBypassPermissionChecks` in `resolveRolePermissionConfig`. Default Member/Guest roles keep `canReadAllObjectRecords: true`, so normal users retain access; only restrictive roles are now denied.

## Testing

Unit (`workspace-roles-permissions-cache.service.spec.ts`):
- Deny-all role, no override, system object → all CRUD `false` (the bug).
- Role-wide read-all defaults, no override → follows defaults.
- Explicit deny override on a read-all role → denied.

Integration (`granular-object-records-permissions.integration-spec.ts`):
- Deny-all role querying a system object (`calendarEvent`) → `PERMISSION_DENIED`.
- Read-all role querying the same system object → succeeds.

Cache unit suite passes (10/10). Lint and typecheck pass on the changed files.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/23548?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

