### PR TITLE
Fix untouched record title persisting an empty name (re-land #22293)

### DIFF
--- a/packages/twenty-front/src/modules/object-record/record-title-cell/components/RecordTitleCellTextFieldInput.tsx
+++ b/packages/twenty-front/src/modules/object-record/record-title-cell/components/RecordTitleCellTextFieldInput.tsx
@@ -28,24 +28,34 @@ export const RecordTitleCellTextFieldInput = ({
     FieldInputEventContext,
   );
 
+  // When the title cell is in edit mode but the user never typed anything, the
+  // draft is undefined. Persisting then writes an empty string over the existing
+  // label identifier — e.g. opening another field counts as a click-outside and
+  // blanks the record's name. Skip persisting an untouched title.
+  const isTitleUntouched = !isDefined(draftValue);
+
   useRegisterInputEvents<string>({
     focusId: instanceId,
     inputRef: wrapperRef,
     inputValue: draftValue ?? '',
     onEnter: (inputValue) => {
-      onEnter?.({ newValue: inputValue });
+      onEnter?.({ newValue: inputValue, skipPersist: isTitleUntouched });
     },
     onEscape: (inputValue) => {
       onEscape?.({ newValue: inputValue });
     },
     onClickOutside: (event, inputValue) => {
-      onClickOutside?.({ newValue: inputValue, event });
+      onClickOutside?.({
+        newValue: inputValue,
+        event,
+        skipPersist: isTitleUntouched,
+      });
     },
     onTab: (inputValue) => {
-      onTab?.({ newValue: inputValue });
+      onTab?.({ newValue: inputValue, skipPersist: isTitleUntouched });
     },
     onShiftTab: (inputValue) => {
-      onShiftTab?.({ newValue: inputValue });
+      onShiftTab?.({ newValue: inputValue, skipPersist: isTitleUntouched });
     },
   });
 


### PR DESCRIPTION
## What

When a record title cell is in edit mode but the user never typed anything, the draft value is `undefined`. Persisting then writes an **empty string over the record's label identifier** — e.g. clicking into another field right after creating a record counts as a click-outside and silently blanks the record's name.

This passes `skipPersist` from `RecordTitleCellTextFieldInput` when the title is untouched. `RecordTitleCell` already honors the flag on every handler.

## Context

This is a **re-land of #22293** (merged 2026-07-04): a later refactor of `RecordTitleCellTextFieldInput` dropped the `skipPersist` wiring, silently reintroducing the bug. Happy to add a regression test for the untouched-title path if you can point me at the preferred harness for this component — the lack of one is what let the fix disappear unnoticed.

## Repro (on current main)

1. Create a record; the title cell opens focused.
2. Without typing, click into any other field.
3. The record's name is persisted as `""` — the record shows as "Untitled".

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/23550?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

