### PR TITLE
ci: block a version bump that freezes a drifted upgrade sequence

### DIFF
--- a/.github/actions/frozen-version-guard/action.yaml
+++ b/.github/actions/frozen-version-guard/action.yaml
@@ -72,8 +72,6 @@ runs:
         RELEASE_TAG="twenty/v$BASE_VERSION"
         FROZEN_PATH="$COMMANDS_ROOT/$FROZEN_DIR"
 
-        # A patch bump stays inside the same command directory, so it keeps being the
-        # current one and nothing is frozen.
         if [ "$FROZEN_DIR" = "$HEAD_DIR" ]; then
           echo "Version bump $BASE_VERSION -> $HEAD_VERSION stays in $FROZEN_DIR: nothing is being frozen, no drift to check."
           exit 0
@@ -91,10 +89,6 @@ runs:
           exit 1
         fi
 
-        # Diffed against the merge candidate, not base_sha: the candidate is base_sha
-        # plus the bump itself, so this catches drift already on main and drift the bump
-        # PR introduces, and it lets the fix (moving commands into the new current
-        # directory) land in the bump PR and clear the check.
         DRIFT=$(git diff --name-status --find-renames "$RELEASE_TAG" HEAD -- "$FROZEN_PATH")
 
         if [ -n "$DRIFT" ]; then

--- a/.github/actions/frozen-version-guard/action.yaml
+++ b/.github/actions/frozen-version-guard/action.yaml
@@ -91,12 +91,16 @@ runs:
           exit 1
         fi
 
-        DRIFT=$(git diff --name-status --find-renames "$RELEASE_TAG" "$BASE_SHA" -- "$FROZEN_PATH")
+        # Diffed against the merge candidate, not base_sha: the candidate is base_sha
+        # plus the bump itself, so this catches drift already on main and drift the bump
+        # PR introduces, and it lets the fix (moving commands into the new current
+        # directory) land in the bump PR and clear the check.
+        DRIFT=$(git diff --name-status --find-renames "$RELEASE_TAG" HEAD -- "$FROZEN_PATH")
 
         if [ -n "$DRIFT" ]; then
           echo "This bump would freeze $FROZEN_DIR in a state that $RELEASE_TAG never shipped."
           echo ""
-          echo "The following upgrade command files changed between $RELEASE_TAG and the tip of main:"
+          echo "The following upgrade command files changed between $RELEASE_TAG and this merge candidate:"
           echo "$DRIFT" | sed 's/^/  - /'
           echo ""
           echo "$RELEASE_TAG is the image running in production for $BASE_VERSION, and it does not"
@@ -114,4 +118,4 @@ runs:
           exit 1
         fi
 
-        echo "$FROZEN_PATH is identical between $RELEASE_TAG and the tip of main: safe to freeze."
+        echo "$FROZEN_PATH is identical between $RELEASE_TAG and this merge candidate: safe to freeze."

--- a/.github/actions/frozen-version-guard/action.yaml
+++ b/.github/actions/frozen-version-guard/action.yaml
@@ -1,0 +1,117 @@
+name: Frozen Version Guard
+description: >
+  Validates that a version bump only freezes an upgrade command directory that
+  still matches the release tag it shipped as. Bumping TWENTY_CURRENT_VERSION
+  makes upgrade-mutation-guard stop allowing writes to the outgoing version's
+  directory, so anything that landed there after its release tag was cut gets
+  frozen into a version that never shipped it. Keyed on the constant changing,
+  not on a branch name, so a renamed bump branch cannot skip the check.
+
+inputs:
+  base_sha:
+    description: Commit to diff the working tree against.
+    required: true
+  allow_frozen_version_drift:
+    description: Skip the drift check (PR label bypass).
+    required: false
+    default: 'false'
+
+runs:
+  using: composite
+  steps:
+    - name: Fetch base commit
+      shell: bash
+      env:
+        BASE_SHA: ${{ inputs.base_sha }}
+      run: |
+        set -euo pipefail
+        if [ -z "$BASE_SHA" ]; then
+          echo "::error::base_sha input is empty"
+          exit 1
+        fi
+        git fetch --no-tags --depth=1 origin "$BASE_SHA"
+
+    - name: Check the frozen upgrade command directory still matches its release tag
+      if: ${{ inputs.allow_frozen_version_drift != 'true' }}
+      shell: bash
+      env:
+        BASE_SHA: ${{ inputs.base_sha }}
+        COMMANDS_ROOT: packages/twenty-server/src/database/commands/upgrade-version-command
+      run: |
+        set -euo pipefail
+        VERSION_CONSTANT_FILE="packages/twenty-server/src/engine/core-modules/upgrade/constants/twenty-current-version.constant.ts"
+
+        extract_version() {
+          sed -n "s/.*TWENTY_CURRENT_VERSION = '\([0-9.]*\)'.*/\1/p"
+        }
+
+        HEAD_VERSION=$(extract_version < "$VERSION_CONSTANT_FILE")
+        BASE_VERSION=$(git show "$BASE_SHA:$VERSION_CONSTANT_FILE" | extract_version)
+
+        if [ -z "$HEAD_VERSION" ]; then
+          echo "::error::Could not extract TWENTY_CURRENT_VERSION from $VERSION_CONSTANT_FILE"
+          exit 1
+        fi
+
+        if [ -z "$BASE_VERSION" ]; then
+          echo "::error::Could not extract TWENTY_CURRENT_VERSION from $VERSION_CONSTANT_FILE at $BASE_SHA"
+          exit 1
+        fi
+
+        if [ "$BASE_VERSION" = "$HEAD_VERSION" ]; then
+          echo "TWENTY_CURRENT_VERSION is unchanged ($HEAD_VERSION): nothing is being frozen, no drift to check."
+          exit 0
+        fi
+
+        version_dir() {
+          echo "$1" | sed -E 's/^([0-9]+)\.([0-9]+)\..*/\1-\2/'
+        }
+
+        FROZEN_DIR=$(version_dir "$BASE_VERSION")
+        HEAD_DIR=$(version_dir "$HEAD_VERSION")
+        RELEASE_TAG="twenty/v$BASE_VERSION"
+        FROZEN_PATH="$COMMANDS_ROOT/$FROZEN_DIR"
+
+        # A patch bump stays inside the same command directory, so it keeps being the
+        # current one and nothing is frozen.
+        if [ "$FROZEN_DIR" = "$HEAD_DIR" ]; then
+          echo "Version bump $BASE_VERSION -> $HEAD_VERSION stays in $FROZEN_DIR: nothing is being frozen, no drift to check."
+          exit 0
+        fi
+
+        echo "Version bump: $BASE_VERSION -> $HEAD_VERSION"
+        echo "This freezes $FROZEN_PATH, which must still match what $RELEASE_TAG shipped."
+
+        if ! git fetch --no-tags --depth=1 origin "+refs/tags/$RELEASE_TAG:refs/tags/$RELEASE_TAG"; then
+          echo "There is no $RELEASE_TAG tag, so nothing pins what $BASE_VERSION actually shipped"
+          echo "and the upgrade sequence frozen into $FROZEN_DIR cannot be verified against a release."
+          echo ""
+          echo "Cut the $RELEASE_TAG release tag first, then re-queue this bump."
+          echo "::error::Release tag $RELEASE_TAG does not exist; cut it before bumping past $BASE_VERSION."
+          exit 1
+        fi
+
+        DRIFT=$(git diff --name-status --find-renames "$RELEASE_TAG" "$BASE_SHA" -- "$FROZEN_PATH")
+
+        if [ -n "$DRIFT" ]; then
+          echo "This bump would freeze $FROZEN_DIR in a state that $RELEASE_TAG never shipped."
+          echo ""
+          echo "The following upgrade command files changed between $RELEASE_TAG and the tip of main:"
+          echo "$DRIFT" | sed 's/^/  - /'
+          echo ""
+          echo "$RELEASE_TAG is the image running in production for $BASE_VERSION, and it does not"
+          echo "contain these commands. Instances upgrading to $BASE_VERSION from that image will"
+          echo "never run them, while main would claim they belong to $BASE_VERSION forever: once"
+          echo "TWENTY_CURRENT_VERSION is $HEAD_VERSION, upgrade-mutation-guard freezes $FROZEN_DIR"
+          echo "and the sequence can no longer be corrected in place."
+          echo ""
+          echo "Either move these commands into the new current directory ($HEAD_DIR) so they ship"
+          echo "with the next release, or cut a patch release off main that includes them (patch-bump"
+          echo "the constant, tag it, deploy it) so the tag pinning $FROZEN_DIR agrees with it again."
+          echo ""
+          echo "If this is intentional, add the label 'ci:allow-frozen-version-drift' to the PR and re-run CI."
+          echo "::error::Version bump would freeze $FROZEN_DIR with commands that $RELEASE_TAG did not ship."
+          exit 1
+        fi
+
+        echo "$FROZEN_PATH is identical between $RELEASE_TAG and the tip of main: safe to freeze."

--- a/.github/workflows/ci-merge-queue.yaml
+++ b/.github/workflows/ci-merge-queue.yaml
@@ -59,20 +59,6 @@ jobs:
           base_sha: ${{ github.event.merge_group.base_sha }}
           allow_previous_version_mutation: ${{ steps.labels.outputs.skip }}
 
-  # A version bump freezes the outgoing version's upgrade command directory: once
-  # TWENTY_CURRENT_VERSION moves, upgrade-mutation-guard stops allowing writes to
-  # the old one. Anything that landed there after its release tag was cut is not in
-  # the image running in production, so instances upgrading to that version never
-  # run those commands while main claims they belong to it.
-  #
-  # This only works in the merge queue. base_sha is main's real tip at the merge
-  # attempt, which is exactly the question being asked: has anything landed in the
-  # frozen directory since the tag, as of now? A PR-level run would diff the bump
-  # PR's own base and be stale by construction, reporting green while main moved on.
-  #
-  # Like the job above, this one always runs and reports a real success/failure so
-  # the required check never resolves to a skipped state, and the bypass label is
-  # resolved from the queued PR because merge_group carries no labels.
   frozen-version-guard:
     timeout-minutes: 5
     runs-on: ubuntu-latest

--- a/.github/workflows/ci-merge-queue.yaml
+++ b/.github/workflows/ci-merge-queue.yaml
@@ -58,3 +58,54 @@ jobs:
         with:
           base_sha: ${{ github.event.merge_group.base_sha }}
           allow_previous_version_mutation: ${{ steps.labels.outputs.skip }}
+
+  # A version bump freezes the outgoing version's upgrade command directory: once
+  # TWENTY_CURRENT_VERSION moves, upgrade-mutation-guard stops allowing writes to
+  # the old one. Anything that landed there after its release tag was cut is not in
+  # the image running in production, so instances upgrading to that version never
+  # run those commands while main claims they belong to it.
+  #
+  # This only works in the merge queue. base_sha is main's real tip at the merge
+  # attempt, which is exactly the question being asked: has anything landed in the
+  # frozen directory since the tag, as of now? A PR-level run would diff the bump
+  # PR's own base and be stale by construction, reporting green while main moved on.
+  #
+  # Like the job above, this one always runs and reports a real success/failure so
+  # the required check never resolves to a skipped state, and the bypass label is
+  # resolved from the queued PR because merge_group carries no labels.
+  frozen-version-guard:
+    timeout-minutes: 5
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout merge candidate
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          fetch-depth: 2
+      - name: Resolve frozen-version-drift bypass label from the queued PR
+        id: labels
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          HEAD_REF: ${{ github.event.merge_group.head_ref }}
+        run: |
+          set -euo pipefail
+          PR_NUMBER=$(echo "$HEAD_REF" | sed -n -E 's|.*/pr-([0-9]+)-[0-9a-f]+$|\1|p')
+
+          skip=false
+          if [ -n "$PR_NUMBER" ]; then
+            LABELS=$(gh pr view "$PR_NUMBER" --repo "$GITHUB_REPOSITORY" --json labels --jq '.labels[].name')
+            echo "Queued PR #$PR_NUMBER labels:"
+            echo "$LABELS"
+
+            if echo "$LABELS" | grep -qxF 'ci:allow-frozen-version-drift'; then
+              skip=true
+            fi
+          else
+            echo "Could not parse a PR number from '$HEAD_REF'; enforcing strictly."
+          fi
+
+          echo "skip=$skip" >> "$GITHUB_OUTPUT"
+      - name: Validate the frozen upgrade directory against its release tag
+        uses: ./.github/actions/frozen-version-guard
+        with:
+          base_sha: ${{ github.event.merge_group.base_sha }}
+          allow_frozen_version_drift: ${{ steps.labels.outputs.skip }}


### PR DESCRIPTION
## The gap

`upgrade-mutation-guard` derives the current upgrade command directory from `TWENTY_CURRENT_VERSION` and blocks writes outside it. That means merging a version bump *freezes* the outgoing version's directory: once the constant moves from `2.25.0` to `2.26.0`, `2-25/` stops being writable.

The problem is the window before that. Server releases are tagged `twenty/vX.Y.Z`, and the bump PR opens after the tag is cut (for `twenty/v2.25.0` = `f5da810`, tagged 2026-07-28 15:02Z, the bump PR #23451 merged at 17:03Z — two hours). Until it merges, `2-25/` is still current, so commands can legitimately land in it. Anything that does is *not* in `twenty/v2.25.0`, the image actually running in production. The bump then freezes a directory that no longer matches what shipped: instances upgrading to 2.25.0 from the released image never run those commands, while main claims they belong to 2.25.0 forever. Nothing catches this today.

## What this adds

`.github/actions/frozen-version-guard/action.yaml`, mirroring `upgrade-mutation-guard`'s shape (`base_sha` input, `allow_frozen_version_drift` label bypass):

```
BASE_VERSION = TWENTY_CURRENT_VERSION at base_sha
HEAD_VERSION = TWENTY_CURRENT_VERSION in the working tree
BASE == HEAD                     -> exit 0, nothing is being frozen
same major-minor (patch bump)    -> exit 0, the directory stays current
twenty/v<BASE_VERSION> missing   -> fail, cut the tag first
diff twenty/v<BASE_VERSION>..HEAD over the frozen dir non-empty -> fail, listing the paths
```

Three properties worth calling out:

- **Keyed on the diff, not the branch.** Any change to `TWENTY_CURRENT_VERSION` freezes a directory, whatever the branch is called, so a renamed bump branch cannot silently skip the check. There is no `version-bump/*` pattern anywhere in the action or the job.
- **Never skips.** When the constant is unchanged it exits 0 with an explicit "nothing is being frozen" line rather than skipping, so this can be a required check without ever resolving to a skipped state. Same reasoning as the comment block at the top of `ci-merge-queue.yaml`.
- **A missing release tag fails.** Bumping past a version that was never tagged means nothing pins what shipped, so the sequence is unverifiable rather than verified-clean.

The drift diff's right-hand side is `HEAD` (the merge candidate = `base_sha` plus the bump), not `base_sha`. That catches drift already on main *and* drift the bump PR itself introduces, and it is what makes the first remedy reachable: relocating the drifted commands into the new current directory inside the bump PR clears the check. See the thread on `action.yaml` for the repro of both.

Both fetches are `--depth=1`: `git diff A B` needs only both commits' trees, so no unshallow.

## Merge queue only

Wired into `ci-merge-queue.yaml` with `base_sha: ${{ github.event.merge_group.base_sha }}`, alongside the existing guard. That is the only correct home. The question being asked is "has anything landed in `2-25/` since the tag, **as of now**?", and in the merge queue `base_sha` is main's real tip at the merge attempt. A PR-level invocation would diff the bump PR's own base and be stale by construction, reporting green while main moved on, so there deliberately isn't one.

The bypass label is resolved the way the existing job does it (parse the PR number out of the merge-queue ref, `gh pr view`, fail closed if the lookup fails), since `merge_group` carries no labels.

It is a separate label from `ci:allow-previous-version-upgrade-mutation` on purpose. The two bypass different invariants, and the bump PR is exactly where both labels can be present at once: the fix for drift is to move commands out of `2-25/`, which trips the mutation guard and so needs that label. If one label gated both checks, applying the fix would switch off the verification of the fix.

## Verification

**The historical case is clean.** Diffing `twenty/v2.25.0` against `e5ac9f5` (tip of main immediately before #23451 merged) scoped to `.../upgrade-version-command/2-25` is empty: only one commit landed in that two-hour window and it was a docs change. Extending the same check backwards over the last five releases, all of them are clean:

| freezes | tag | bump merged | drift |
| --- | --- | --- | --- |
| `2-21` | 07-13 13:12Z | `ca437d3` 07-13 14:49Z | clean |
| `2-22` | 07-17 06:45Z | `d99f57b` 07-17 07:54Z | clean |
| `2-23` | 07-22 08:22Z | `10a313d` 07-22 08:48Z | clean |
| `2-24` | 07-23 17:12Z | `6623901` 07-23 17:50Z | clean |
| `2-25` | 07-28 15:02Z | `4730542` 07-28 17:03Z | clean |

So this is a guard against a race that has not yet fired, not a fix for a known incident. It has stayed clean because the bump has so far merged within an hour or two of the tag; the check is what keeps that from being load-bearing.

Also exercised by hand, running the action's script verbatim (extracted from the YAML) against real history:

- **Real bump**: candidate `4730542`, `base_sha` = `e5ac9f5`. Exits 0, reporting `2-25` identical between tag and candidate.
- **Drift already on main**: a command lands in `2-25/` on top of `e5ac9f5`, then the constant bumps. Fails, listing the path.
- **Drift introduced by the bump PR**: candidate bumps the constant *and* modifies a file in `2-25/`, on a base where `2-25/` matches the tag. Fails. This was a silent pass before the `HEAD` fix.
- **Remedy applied inside the bump PR**: drift on main, candidate relocates it into `2-26/`. Exits 0.
- **No-op**: candidate at main's tip, `base_sha` = its parent, constant untouched. Exits 0 with `TWENTY_CURRENT_VERSION is unchanged (2.26.0): nothing is being frozen`.
- **Missing tag**: a synthetic `2.98.0 -> 2.99.0` bump. Fails with "cut the `twenty/v2.98.0` release tag first".
- **Patch bump**: `2.25.0 -> 2.25.1`. Exits 0, since `2-25` remains the current directory and nothing is frozen. This case is not in the original sketch but a naive major-minor comparison would have false-positived on it, and it is also the path that makes the second remedy work: patch-bump, tag, deploy, and the next minor bump then diffs against `twenty/v2.25.1`.

## Open question: do `.spec.ts` files count as drift?

**As implemented, yes** — the check diffs the whole frozen directory. `upgrade-mutation-guard` skips specs for its timestamp check but not for its version-directory check, so this matches the closer precedent.

The argument for keeping them in: a spec change is cheap to relocate, and the useful invariant is "the frozen directory is byte-identical to what shipped", which is trivial to reason about and has no carve-out to get subtly wrong. The argument for excluding them: a spec does not run during an upgrade, so a spec-only edit cannot change what an instance actually executes, and blocking a bump PR on it is friction with no correctness payoff. Happy to exclude them if reviewers prefer that; it is a one-line `:(exclude)` pathspec.

## Related

`twentyhq/twenty-eng` #370 adds a release-buddy step that pushes the release owner to merge the bump PR. It deliberately does not verify the upgrade sequence itself (a polling widget can only report a verdict not anchored to the merge event), and its hint text tells the release owner that CI on the bump PR checks the folder still matches what the tag shipped. That promise is this PR.