### PR TITLE
Hide app record-selection commands when all records are selected

### DIFF
--- a/packages/twenty-apps/public/call-recorder/package.json
+++ b/packages/twenty-apps/public/call-recorder/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@twentyhq/call-recorder",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "license": "MIT",
   "engines": {
     "node": "^24.5.0",

--- a/packages/twenty-apps/public/call-recorder/src/command-menu-items/generate-call-recording-summary.ts
+++ b/packages/twenty-apps/public/call-recorder/src/command-menu-items/generate-call-recording-summary.ts
@@ -1,5 +1,6 @@
 import {
   defineCommandMenuItem,
+  isSelectAll,
   STANDARD_OBJECT_UNIVERSAL_IDENTIFIERS,
 } from 'twenty-sdk/define';
 
@@ -15,4 +16,5 @@ export default defineCommandMenuItem({
     GENERATE_CALL_RECORDING_SUMMARY_FRONT_COMPONENT_UNIVERSAL_IDENTIFIER,
   label: 'Generate call summary',
   availabilityType: 'RECORD_SELECTION',
+  conditionalAvailabilityExpression: !isSelectAll,
 });

--- a/packages/twenty-apps/public/people-data-labs/package.json
+++ b/packages/twenty-apps/public/people-data-labs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@twentyhq/people-data-labs",
-  "version": "1.0.9",
+  "version": "1.0.10",
   "description": "People Data Labs enrichment app for Twenty",
   "license": "MIT",
   "engines": {

--- a/packages/twenty-apps/public/people-data-labs/src/command-menu-items/enrich-companies.ts
+++ b/packages/twenty-apps/public/people-data-labs/src/command-menu-items/enrich-companies.ts
@@ -1,4 +1,4 @@
-import { defineCommandMenuItem, STANDARD_OBJECT_UNIVERSAL_IDENTIFIERS } from 'twenty-sdk/define';
+import { defineCommandMenuItem, isSelectAll, STANDARD_OBJECT_UNIVERSAL_IDENTIFIERS } from 'twenty-sdk/define';
 import {
   PDL_COMMAND_MENU_ITEM_UNIVERSAL_IDENTIFIERS,
   PDL_FRONT_COMPONENT_UNIVERSAL_IDENTIFIERS
@@ -11,4 +11,5 @@ export default defineCommandMenuItem({
   PDL_FRONT_COMPONENT_UNIVERSAL_IDENTIFIERS.enrichCompanies,
   label: 'Enrich companies',
   availabilityType: 'RECORD_SELECTION',
+  conditionalAvailabilityExpression: !isSelectAll,
 });

--- a/packages/twenty-apps/public/people-data-labs/src/command-menu-items/enrich-people.ts
+++ b/packages/twenty-apps/public/people-data-labs/src/command-menu-items/enrich-people.ts
@@ -1,4 +1,4 @@
-import { defineCommandMenuItem, STANDARD_OBJECT_UNIVERSAL_IDENTIFIERS } from 'twenty-sdk/define';
+import { defineCommandMenuItem, isSelectAll, STANDARD_OBJECT_UNIVERSAL_IDENTIFIERS } from 'twenty-sdk/define';
 import {
   PDL_COMMAND_MENU_ITEM_UNIVERSAL_IDENTIFIERS,
   PDL_FRONT_COMPONENT_UNIVERSAL_IDENTIFIERS
@@ -11,4 +11,5 @@ export default defineCommandMenuItem({
   PDL_FRONT_COMPONENT_UNIVERSAL_IDENTIFIERS.enrichPeople,
   label: 'Enrich people',
   availabilityType: 'RECORD_SELECTION',
+  conditionalAvailabilityExpression: !isSelectAll,
 });


### PR DESCRIPTION
PDL enrichment and call-recorder's call summary are `RECORD_SELECTION` commands backed by headless front components, which only receive record ids in selection mode. Under select all the context store switches to exclusion mode, so they received an empty `recordIds` array and still reported success while enriching nothing.

They now declare `conditionalAvailabilityExpression: !isSelectAll`, so they disappear from the command menu and quick actions while select all is active. Both app versions are bumped since the server rejects redeploying an equal version.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/23561?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

