### PR TITLE
fix(workflow): stop use as draft hanging when the workflow query gates it

### DIFF
--- a/packages/twenty-front/src/modules/app/components/WorkspaceAppProviders.tsx
+++ b/packages/twenty-front/src/modules/app/components/WorkspaceAppProviders.tsx
@@ -35,6 +35,7 @@ import { UserThemeProviderEffect } from '@/ui/theme/components/UserThemeProvider
 import { PageFavicon } from '@/ui/utilities/page-favicon/components/PageFavicon';
 import { PageTitle } from '@/ui/utilities/page-title/components/PageTitle';
 import { UserContextProvider } from '@/users/components/UserContextProvider';
+import { OverrideWorkflowDraftConfirmationModal } from '@/workflow/components/OverrideWorkflowDraftConfirmationModal';
 import { WorkspaceProviderEffect } from '@/workspace/components/WorkspaceProviderEffect';
 import { getPageTitleFromPath } from '~/utils/title-utils';
 
@@ -72,6 +73,7 @@ export const WorkspaceAppProviders = () => {
                             <GlobalFilePreviewModal />
                             <CommandMenuConfirmationModalManager />
                             <FrontComponentExternalLinkModalManager />
+                            <OverrideWorkflowDraftConfirmationModal />
                             <CommandRunner />
                           </StrictMode>
                         </DialogManager>

--- a/packages/twenty-front/src/modules/command-menu-item/engine-command/record/single-record/workflow-versions/components/UseAsDraftWorkflowVersionSingleRecordCommand.tsx
+++ b/packages/twenty-front/src/modules/command-menu-item/engine-command/record/single-record/workflow-versions/components/UseAsDraftWorkflowVersionSingleRecordCommand.tsx
@@ -1,12 +1,11 @@
 import { HeadlessEngineCommandWrapperEffect } from '@/command-menu-item/engine-command/components/HeadlessEngineCommandWrapperEffect';
 import { useHeadlessCommandContextApi } from '@/command-menu-item/engine-command/hooks/useHeadlessCommandContextApi';
 import { useModal } from '@/ui/layout/modal/hooks/useModal';
-import { OverrideWorkflowDraftConfirmationModal } from '@/workflow/components/OverrideWorkflowDraftConfirmationModal';
+import { useSetAtomState } from '@/ui/utilities/state/jotai/hooks/useSetAtomState';
 import { OVERRIDE_WORKFLOW_DRAFT_CONFIRMATION_MODAL_ID } from '@/workflow/constants/OverrideWorkflowDraftConfirmationModalId';
 import { useCreateDraftFromWorkflowVersion } from '@/workflow/hooks/useCreateDraftFromWorkflowVersion';
-import { useWorkflowVersion } from '@/workflow/hooks/useWorkflowVersion';
 import { useWorkflowWithCurrentVersion } from '@/workflow/hooks/useWorkflowWithCurrentVersion';
-import { useState } from 'react';
+import { overrideWorkflowDraftConfirmationModalConfigState } from '@/workflow/states/overrideWorkflowDraftConfirmationModalConfigState';
 import { AppPath, CoreObjectNameSingular } from 'twenty-shared/types';
 import { isDefined } from 'twenty-shared/utils';
 import { useNavigateApp } from '~/hooks/useNavigateApp';
@@ -23,55 +22,53 @@ const UseAsDraftWorkflowVersionSingleRecordCommandContent = ({
   const { createDraftFromWorkflowVersion } =
     useCreateDraftFromWorkflowVersion();
   const navigate = useNavigateApp();
-  const [hasNavigated, setHasNavigated] = useState(false);
+
+  const setOverrideWorkflowDraftConfirmationModalConfig = useSetAtomState(
+    overrideWorkflowDraftConfirmationModalConfigState,
+  );
 
   const hasAlreadyDraftVersion =
-    workflow?.versions.some((version) => version.status === 'DRAFT') || false;
+    workflow?.versions.some((version) => version.status === 'DRAFT') ?? false;
 
-  const handleExecute = () => {
-    if (!isDefined(workflow) || hasNavigated) {
+  const handleExecute = async () => {
+    // The confirmation modal is rendered outside of the command because the
+    // command unmounts as soon as it has been executed
+    if (hasAlreadyDraftVersion) {
+      setOverrideWorkflowDraftConfirmationModalConfig({
+        workflowId,
+        workflowVersionIdToCopy: workflowVersionId,
+      });
+
+      openModal(OVERRIDE_WORKFLOW_DRAFT_CONFIRMATION_MODAL_ID);
+
       return;
     }
 
-    if (hasAlreadyDraftVersion) {
-      openModal(OVERRIDE_WORKFLOW_DRAFT_CONFIRMATION_MODAL_ID);
-    } else {
-      const executeCommandWithoutWaiting = async () => {
-        await createDraftFromWorkflowVersion({
-          workflowId,
-          workflowVersionIdToCopy: workflowVersionId,
-        });
+    await createDraftFromWorkflowVersion({
+      workflowId,
+      workflowVersionIdToCopy: workflowVersionId,
+    });
 
-        navigate(AppPath.RecordShowPage, {
-          objectNameSingular: CoreObjectNameSingular.Workflow,
-          objectRecordId: workflowId,
-        });
-
-        setHasNavigated(true);
-      };
-
-      executeCommandWithoutWaiting();
-    }
+    navigate(AppPath.RecordShowPage, {
+      objectNameSingular: CoreObjectNameSingular.Workflow,
+      objectRecordId: workflowId,
+    });
   };
 
   return (
-    <>
-      <HeadlessEngineCommandWrapperEffect execute={handleExecute} />
-      <OverrideWorkflowDraftConfirmationModal
-        workflowId={workflowId}
-        workflowVersionIdToCopy={workflowVersionId}
-      />
-    </>
+    <HeadlessEngineCommandWrapperEffect
+      execute={handleExecute}
+      ready={isDefined(workflow)}
+    />
   );
 };
 
 export const UseAsDraftWorkflowVersionSingleRecordCommand = () => {
   const { selectedRecords } = useHeadlessCommandContextApi();
 
-  const recordId = selectedRecords[0]?.id;
-  const workflowVersion = useWorkflowVersion(recordId ?? '');
+  const selectedRecord = selectedRecords[0];
 
-  if (!recordId || !isDefined(workflowVersion?.workflow?.id)) {
+  if (!isDefined(selectedRecord) || !isDefined(selectedRecord.workflowId)) {
     throw new Error(
       'Record ID and workflow ID are required to use as draft workflow version',
     );
@@ -79,8 +76,8 @@ export const UseAsDraftWorkflowVersionSingleRecordCommand = () => {
 
   return (
     <UseAsDraftWorkflowVersionSingleRecordCommandContent
-      workflowId={workflowVersion.workflow.id}
-      workflowVersionId={workflowVersion.id}
+      workflowId={selectedRecord.workflowId}
+      workflowVersionId={selectedRecord.id}
     />
   );
 };

--- a/packages/twenty-front/src/modules/command-menu-item/engine-command/record/single-record/workflow-versions/components/UseAsDraftWorkflowVersionSingleRecordCommand.tsx
+++ b/packages/twenty-front/src/modules/command-menu-item/engine-command/record/single-record/workflow-versions/components/UseAsDraftWorkflowVersionSingleRecordCommand.tsx
@@ -1,14 +1,19 @@
 import { HeadlessEngineCommandWrapperEffect } from '@/command-menu-item/engine-command/components/HeadlessEngineCommandWrapperEffect';
 import { useHeadlessCommandContextApi } from '@/command-menu-item/engine-command/hooks/useHeadlessCommandContextApi';
+import { useFindOneRecord } from '@/object-record/hooks/useFindOneRecord';
 import { useModal } from '@/ui/layout/modal/hooks/useModal';
 import { useSetAtomState } from '@/ui/utilities/state/jotai/hooks/useSetAtomState';
 import { OVERRIDE_WORKFLOW_DRAFT_CONFIRMATION_MODAL_ID } from '@/workflow/constants/OverrideWorkflowDraftConfirmationModalId';
 import { useCreateDraftFromWorkflowVersion } from '@/workflow/hooks/useCreateDraftFromWorkflowVersion';
-import { useWorkflowWithCurrentVersion } from '@/workflow/hooks/useWorkflowWithCurrentVersion';
 import { overrideWorkflowDraftConfirmationModalConfigState } from '@/workflow/states/overrideWorkflowDraftConfirmationModalConfigState';
+import { type Workflow, type WorkflowVersion } from '@/workflow/types/Workflow';
 import { AppPath, CoreObjectNameSingular } from 'twenty-shared/types';
 import { isDefined } from 'twenty-shared/utils';
 import { useNavigateApp } from '~/hooks/useNavigateApp';
+
+type WorkflowWithVersionStatuses = Pick<Workflow, 'id' | '__typename'> & {
+  versions: Array<Pick<WorkflowVersion, 'id' | 'status'>>;
+};
 
 const UseAsDraftWorkflowVersionSingleRecordCommandContent = ({
   workflowId,
@@ -18,7 +23,23 @@ const UseAsDraftWorkflowVersionSingleRecordCommandContent = ({
   workflowVersionId: string;
 }) => {
   const { openModal } = useModal();
-  const workflow = useWorkflowWithCurrentVersion(workflowId);
+
+  // Only the version statuses are needed, so the workflow is fetched directly
+  // rather than through useWorkflowWithCurrentVersion, which stays undefined
+  // until the current version and all of its steps have loaded too
+  const { record: workflow, loading } =
+    useFindOneRecord<WorkflowWithVersionStatuses>({
+      objectNameSingular: CoreObjectNameSingular.Workflow,
+      objectRecordId: workflowId,
+      recordGqlFields: {
+        id: true,
+        versions: {
+          id: true,
+          status: true,
+        },
+      },
+    });
+
   const { createDraftFromWorkflowVersion } =
     useCreateDraftFromWorkflowVersion();
   const navigate = useNavigateApp();
@@ -27,10 +48,17 @@ const UseAsDraftWorkflowVersionSingleRecordCommandContent = ({
     overrideWorkflowDraftConfirmationModalConfigState,
   );
 
-  const hasAlreadyDraftVersion =
-    workflow?.versions.some((version) => version.status === 'DRAFT') ?? false;
-
   const handleExecute = async () => {
+    if (!isDefined(workflow)) {
+      throw new Error(
+        `Workflow ${workflowId} could not be loaded to use one of its versions as draft`,
+      );
+    }
+
+    const hasAlreadyDraftVersion = workflow.versions.some(
+      (version) => version.status === 'DRAFT',
+    );
+
     // The confirmation modal is rendered outside of the command because the
     // command unmounts as soon as it has been executed
     if (hasAlreadyDraftVersion) {
@@ -55,10 +83,13 @@ const UseAsDraftWorkflowVersionSingleRecordCommandContent = ({
     });
   };
 
+  // Waiting on the query settling rather than on the workflow being defined, so
+  // an unreachable workflow surfaces an error and unmounts the command instead
+  // of leaving the action silently stuck
   return (
     <HeadlessEngineCommandWrapperEffect
       execute={handleExecute}
-      ready={isDefined(workflow)}
+      ready={!loading}
     />
   );
 };

--- a/packages/twenty-front/src/modules/views/hooks/__tests__/useQueryVariablesFromParentView.test.tsx
+++ b/packages/twenty-front/src/modules/views/hooks/__tests__/useQueryVariablesFromParentView.test.tsx
@@ -1,0 +1,84 @@
+import { renderHook } from '@testing-library/react';
+
+import { MAIN_CONTEXT_STORE_INSTANCE_ID } from '@/context-store/constants/MainContextStoreInstanceId';
+import { contextStoreRecordShowParentViewComponentState } from '@/context-store/states/contextStoreRecordShowParentViewComponentState';
+import { type RecordFilter } from '@/object-record/record-filter/types/RecordFilter';
+import { type EnrichedObjectMetadataItem } from '@/object-metadata/types/EnrichedObjectMetadataItem';
+import { useQueryVariablesFromParentView } from '@/views/hooks/useQueryVariablesFromParentView';
+import { ViewFilterOperand } from 'twenty-shared/types';
+import { isDefined } from 'twenty-shared/utils';
+import { getJestMetadataAndApolloMocksWrapper } from '~/testing/jest/getJestMetadataAndApolloMocksWrapper';
+import { getMockObjectMetadataItemOrThrow } from '~/testing/utils/getMockObjectMetadataItemOrThrow';
+
+const WORKFLOW_RECORD_ID = '20202020-1c25-4d02-bf25-6aeccf7ea419';
+
+const workflowVersionObjectMetadataItem =
+  getMockObjectMetadataItemOrThrow('workflowVersion');
+const workflowObjectMetadataItem = getMockObjectMetadataItemOrThrow('workflow');
+
+const workflowRelationFieldMetadataItem =
+  workflowVersionObjectMetadataItem.fields.find(
+    (field) => field.name === 'workflow',
+  );
+
+if (!isDefined(workflowRelationFieldMetadataItem)) {
+  throw new Error('Missing "workflow" field on the workflowVersion object');
+}
+
+const workflowRecordFilter: RecordFilter = {
+  id: 'record-filter-1',
+  fieldMetadataId: workflowRelationFieldMetadataItem.id,
+  operand: ViewFilterOperand.IS,
+  value: JSON.stringify({
+    isCurrentWorkspaceMemberSelected: false,
+    isCurrentRecordSelected: false,
+    selectedRecordIds: [WORKFLOW_RECORD_ID],
+  }),
+  displayValue: 'My workflow',
+  type: 'RELATION',
+  label: 'Workflow',
+};
+
+const renderUseQueryVariablesFromParentView = (
+  objectMetadataItem: EnrichedObjectMetadataItem,
+) =>
+  renderHook(() => useQueryVariablesFromParentView({ objectMetadataItem }), {
+    wrapper: getJestMetadataAndApolloMocksWrapper({
+      apolloMocks: [],
+      onInitializeJotaiStore: (store) => {
+        store.set(
+          contextStoreRecordShowParentViewComponentState.atomFamily({
+            instanceId: MAIN_CONTEXT_STORE_INSTANCE_ID,
+          }),
+          {
+            parentViewComponentId: 'record-index-workflow-versions',
+            parentViewObjectNameSingular:
+              workflowVersionObjectMetadataItem.nameSingular,
+            parentViewFilterGroups: [],
+            parentViewFilters: [workflowRecordFilter],
+            parentViewSorts: [],
+          },
+        );
+      },
+    }),
+  });
+
+describe('useQueryVariablesFromParentView', () => {
+  it('should compute the filter when the parent view targets the same object', () => {
+    const { result } = renderUseQueryVariablesFromParentView(
+      workflowVersionObjectMetadataItem,
+    );
+
+    expect(result.current.filter).toEqual({
+      workflowId: { in: [WORKFLOW_RECORD_ID] },
+    });
+  });
+
+  it('should ignore the parent view when it targets another object', () => {
+    const { result } = renderUseQueryVariablesFromParentView(
+      workflowObjectMetadataItem,
+    );
+
+    expect(result.current.filter).toEqual({});
+  });
+});

--- a/packages/twenty-front/src/modules/views/hooks/useQueryVariablesFromParentView.ts
+++ b/packages/twenty-front/src/modules/views/hooks/useQueryVariablesFromParentView.ts
@@ -27,11 +27,19 @@ export const useQueryVariablesFromParentView = ({
 
   const { filterValueDependencies } = useFilterValueDependencies();
 
+  // Navigating between record pages of different objects (through a relation
+  // chip for instance) keeps the parent view of the object we came from, whose
+  // filters and sorts target fields the current object does not have
+  const parentView =
+    contextStoreRecordShowParentView?.parentViewObjectNameSingular ===
+    objectMetadataItem.nameSingular
+      ? contextStoreRecordShowParentView
+      : undefined;
+
   const { filter, orderBy } = getQueryVariablesFromFiltersAndSorts({
-    recordFilterGroups:
-      contextStoreRecordShowParentView?.parentViewFilterGroups ?? [],
-    recordFilters: contextStoreRecordShowParentView?.parentViewFilters ?? [],
-    recordSorts: contextStoreRecordShowParentView?.parentViewSorts ?? [],
+    recordFilterGroups: parentView?.parentViewFilterGroups ?? [],
+    recordFilters: parentView?.parentViewFilters ?? [],
+    recordSorts: parentView?.parentViewSorts ?? [],
     objectMetadataItem,
     objectMetadataItems,
     fieldMetadataItems: flattenedFieldMetadataItems,
@@ -39,7 +47,7 @@ export const useQueryVariablesFromParentView = ({
   });
 
   const isSoftDeleteFilterActive =
-    contextStoreRecordShowParentView?.parentViewFilters.some((recordFilter) =>
+    parentView?.parentViewFilters.some((recordFilter) =>
       isRecordFilterAboutSoftDelete({ recordFilter, objectMetadataItems }),
     ) ?? false;
 

--- a/packages/twenty-front/src/modules/workflow/components/OverrideWorkflowDraftConfirmationModal.tsx
+++ b/packages/twenty-front/src/modules/workflow/components/OverrideWorkflowDraftConfirmationModal.tsx
@@ -17,16 +17,19 @@ import { AppPath, CoreObjectNameSingular } from 'twenty-shared/types';
 import { getAppPath, isDefined } from 'twenty-shared/utils';
 import { useNavigateApp } from '~/hooks/useNavigateApp';
 
-export const OverrideWorkflowDraftConfirmationModal = () => {
+const OverrideWorkflowDraftConfirmationModalContent = ({
+  workflowId,
+  workflowVersionIdToCopy,
+}: {
+  workflowId: string;
+  workflowVersionIdToCopy: string;
+}) => {
   const { closeModal } = useModal();
   const { enqueueErrorSnackBar } = useSnackBar();
   const { t } = useLingui();
 
   const [isCreatingDraft, setIsCreatingDraft] = useState(false);
 
-  const overrideWorkflowDraftConfirmationModalConfig = useAtomStateValue(
-    overrideWorkflowDraftConfirmationModalConfigState,
-  );
   const setOverrideWorkflowDraftConfirmationModalConfig = useSetAtomState(
     overrideWorkflowDraftConfirmationModalConfigState,
   );
@@ -35,13 +38,6 @@ export const OverrideWorkflowDraftConfirmationModal = () => {
     useCreateDraftFromWorkflowVersion();
 
   const navigate = useNavigateApp();
-
-  if (!isDefined(overrideWorkflowDraftConfirmationModalConfig)) {
-    return null;
-  }
-
-  const { workflowId, workflowVersionIdToCopy } =
-    overrideWorkflowDraftConfirmationModalConfig;
 
   const handleOverrideDraft = async () => {
     setIsCreatingDraft(true);
@@ -90,6 +86,27 @@ export const OverrideWorkflowDraftConfirmationModal = () => {
           fullWidth
           justify="center"
         />
+      }
+    />
+  );
+};
+
+// Mounted app-wide, so the content is only rendered once a caller opens the
+// modal: its hooks read workflow metadata the current user may not have access to
+export const OverrideWorkflowDraftConfirmationModal = () => {
+  const overrideWorkflowDraftConfirmationModalConfig = useAtomStateValue(
+    overrideWorkflowDraftConfirmationModalConfigState,
+  );
+
+  if (!isDefined(overrideWorkflowDraftConfirmationModalConfig)) {
+    return null;
+  }
+
+  return (
+    <OverrideWorkflowDraftConfirmationModalContent
+      workflowId={overrideWorkflowDraftConfirmationModalConfig.workflowId}
+      workflowVersionIdToCopy={
+        overrideWorkflowDraftConfirmationModalConfig.workflowVersionIdToCopy
       }
     />
   );

--- a/packages/twenty-front/src/modules/workflow/components/OverrideWorkflowDraftConfirmationModal.tsx
+++ b/packages/twenty-front/src/modules/workflow/components/OverrideWorkflowDraftConfirmationModal.tsx
@@ -1,67 +1,96 @@
+import { CombinedGraphQLErrors } from '@apollo/client/errors';
+
 import {
   ConfirmationModal,
   StyledCenteredButton,
 } from '@/ui/layout/modal/components/ConfirmationModal';
+import { useSnackBar } from '@/ui/feedback/snack-bar-manager/hooks/useSnackBar';
 import { useModal } from '@/ui/layout/modal/hooks/useModal';
+import { useAtomStateValue } from '@/ui/utilities/state/jotai/hooks/useAtomStateValue';
+import { useSetAtomState } from '@/ui/utilities/state/jotai/hooks/useSetAtomState';
 import { OVERRIDE_WORKFLOW_DRAFT_CONFIRMATION_MODAL_ID } from '@/workflow/constants/OverrideWorkflowDraftConfirmationModalId';
 import { useCreateDraftFromWorkflowVersion } from '@/workflow/hooks/useCreateDraftFromWorkflowVersion';
+import { overrideWorkflowDraftConfirmationModalConfigState } from '@/workflow/states/overrideWorkflowDraftConfirmationModalConfigState';
 import { useLingui } from '@lingui/react/macro';
+import { useState } from 'react';
 import { AppPath, CoreObjectNameSingular } from 'twenty-shared/types';
-import { getAppPath } from 'twenty-shared/utils';
+import { getAppPath, isDefined } from 'twenty-shared/utils';
 import { useNavigateApp } from '~/hooks/useNavigateApp';
 
-export const OverrideWorkflowDraftConfirmationModal = ({
-  workflowId,
-  workflowVersionIdToCopy,
-}: {
-  workflowId: string;
-  workflowVersionIdToCopy: string;
-}) => {
+export const OverrideWorkflowDraftConfirmationModal = () => {
   const { closeModal } = useModal();
+  const { enqueueErrorSnackBar } = useSnackBar();
+  const { t } = useLingui();
+
+  const [isCreatingDraft, setIsCreatingDraft] = useState(false);
+
+  const overrideWorkflowDraftConfirmationModalConfig = useAtomStateValue(
+    overrideWorkflowDraftConfirmationModalConfigState,
+  );
+  const setOverrideWorkflowDraftConfirmationModalConfig = useSetAtomState(
+    overrideWorkflowDraftConfirmationModalConfigState,
+  );
 
   const { createDraftFromWorkflowVersion } =
     useCreateDraftFromWorkflowVersion();
 
   const navigate = useNavigateApp();
 
-  const handleOverrideDraft = async () => {
-    await createDraftFromWorkflowVersion({
-      workflowId,
-      workflowVersionIdToCopy,
-    });
+  if (!isDefined(overrideWorkflowDraftConfirmationModalConfig)) {
+    return null;
+  }
 
-    navigate(AppPath.RecordShowPage, {
-      objectNameSingular: CoreObjectNameSingular.Workflow,
-      objectRecordId: workflowId,
-    });
+  const { workflowId, workflowVersionIdToCopy } =
+    overrideWorkflowDraftConfirmationModalConfig;
+
+  const handleOverrideDraft = async () => {
+    setIsCreatingDraft(true);
+
+    try {
+      await createDraftFromWorkflowVersion({
+        workflowId,
+        workflowVersionIdToCopy,
+      });
+
+      navigate(AppPath.RecordShowPage, {
+        objectNameSingular: CoreObjectNameSingular.Workflow,
+        objectRecordId: workflowId,
+      });
+    } catch (error) {
+      enqueueErrorSnackBar({
+        ...(CombinedGraphQLErrors.is(error) ? { apolloError: error } : {}),
+      });
+    } finally {
+      setIsCreatingDraft(false);
+      setOverrideWorkflowDraftConfirmationModalConfig(null);
+    }
   };
 
-  const { t } = useLingui();
-
   return (
-    <>
-      <ConfirmationModal
-        modalInstanceId={OVERRIDE_WORKFLOW_DRAFT_CONFIRMATION_MODAL_ID}
-        title={t`A draft already exists`}
-        subtitle={t`A draft already exists for this workflow. Are you sure you want to erase it?`}
-        onConfirmClick={handleOverrideDraft}
-        confirmButtonText={t`Override Draft`}
-        AdditionalButtons={
-          <StyledCenteredButton
-            to={getAppPath(AppPath.RecordShowPage, {
-              objectNameSingular: CoreObjectNameSingular.Workflow,
-              objectRecordId: workflowId,
-            })}
-            onClick={() => {
-              closeModal(OVERRIDE_WORKFLOW_DRAFT_CONFIRMATION_MODAL_ID);
-            }}
-            variant="secondary"
-            title={t`Go to Draft`}
-            fullWidth
-            justify="center"
-          />
-        }
-      />
-    </>
+    <ConfirmationModal
+      modalInstanceId={OVERRIDE_WORKFLOW_DRAFT_CONFIRMATION_MODAL_ID}
+      title={t`A draft already exists`}
+      subtitle={t`A draft already exists for this workflow. Are you sure you want to erase it?`}
+      onConfirmClick={handleOverrideDraft}
+      onClose={() => setOverrideWorkflowDraftConfirmationModalConfig(null)}
+      loading={isCreatingDraft}
+      confirmButtonText={t`Override Draft`}
+      AdditionalButtons={
+        <StyledCenteredButton
+          to={getAppPath(AppPath.RecordShowPage, {
+            objectNameSingular: CoreObjectNameSingular.Workflow,
+            objectRecordId: workflowId,
+          })}
+          onClick={() => {
+            closeModal(OVERRIDE_WORKFLOW_DRAFT_CONFIRMATION_MODAL_ID);
+            setOverrideWorkflowDraftConfirmationModalConfig(null);
+          }}
+          variant="secondary"
+          title={t`Go to Draft`}
+          fullWidth
+          justify="center"
+        />
+      }
+    />
   );
 };

--- a/packages/twenty-front/src/modules/workflow/states/overrideWorkflowDraftConfirmationModalConfigState.ts
+++ b/packages/twenty-front/src/modules/workflow/states/overrideWorkflowDraftConfirmationModalConfigState.ts
@@ -1,0 +1,12 @@
+import { createAtomState } from '@/ui/utilities/state/jotai/utils/createAtomState';
+
+export type OverrideWorkflowDraftConfirmationModalConfig = {
+  workflowId: string;
+  workflowVersionIdToCopy: string;
+};
+
+export const overrideWorkflowDraftConfirmationModalConfigState =
+  createAtomState<OverrideWorkflowDraftConfirmationModalConfig | null>({
+    key: 'overrideWorkflowDraftConfirmationModalConfigState',
+    defaultValue: null,
+  });


### PR DESCRIPTION
Follow-up on #23524. Based on that branch so the diff is just this one commit.

### Problem

`UseAsDraftWorkflowVersionSingleRecordCommand` gates `HeadlessEngineCommandWrapperEffect` on `ready={isDefined(workflow)}`, where `workflow` comes from `useWorkflowWithCurrentVersion`. That hook returns `undefined` until **both** the workflow **and** its current version with all its steps have loaded, which is two sequential round-trips.

When the current version cannot be read, `workflow` stays `undefined` forever, so:

- `execute` never runs
- `unmountCommand` is never called, so the command stays mounted
- "Use as Draft" sits permanently disabled with no modal, no navigation, no snackbar and no console error

Reproduced in the browser by returning `null` for the `FindOneWorkflowVersion` query of the workflow's current version. On `main` the same condition also does nothing, but the button stays clickable, so the permanent disable is new.

Even in the healthy case the gate is visible: throttling GraphQL responses to 3s makes the click do nothing for several seconds before the modal appears, because the command waits on a query whose result it does not use.

### Fix

Fetch only what the command needs, the version statuses, with `useFindOneRecord` directly instead of `useWorkflowWithCurrentVersion`. That is one round-trip and does not depend on the current version being readable.

Gate on `!loading` rather than on the workflow being defined, and throw from `handleExecute` when the workflow is missing, so `HeadlessEngineCommandWrapperEffect` catches it, shows the error snackbar and unmounts the command. The action stays retryable instead of wedging.

### Test

Verified against the full stack (server, worker, frontend) with Playwright:

- no draft exists: `CreateDraftFromWorkflowVersion` fires and navigates to the workflow
- draft exists: the "A draft already exists" modal opens, from the record page button, the command menu, and the record index action bar
- Override Draft creates the draft and navigates
- repeat clicks after Cancel and after Escape reopen the modal
- the previously wedging scenario now opens the modal normally
- an unreachable workflow shows "An error occurred." and leaves the button enabled

`nx typecheck twenty-front` and `nx lint:diff-with-main twenty-front` pass, and `useQueryVariablesFromParentView.test.tsx` from #23524 still passes.

---
_Generated by [Claude Code](https://claude.ai/code/session_01KPxPwic1cjC8yRtV8EN8hg)_

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/23565?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

