### PR TITLE
Stop showing raw chunk load errors

### DIFF
--- a/packages/twenty-front/src/modules/error-handler/components/PromiseRejectionEffect.tsx
+++ b/packages/twenty-front/src/modules/error-handler/components/PromiseRejectionEffect.tsx
@@ -11,10 +11,7 @@ import {
   ServerParseError,
   UnconventionalError,
 } from '@apollo/client/errors';
-import { isNonEmptyString, isObject } from '@sniptt/guards';
 import { isDefined, type CustomError } from 'twenty-shared/utils';
-
-const STALE_CHUNK_LAZY_LOADING_FINGERPRINT = 'vite-stale-chunk-lazy-loading';
 
 const isApolloError = (error: unknown): boolean =>
   CombinedGraphQLErrors.is(error) ||
@@ -28,24 +25,7 @@ const isApolloError = (error: unknown): boolean =>
 const hasErrorCode = (
   error: CustomError | any,
 ): error is CustomError & { code: string } => {
-  return isObject(error) && 'code' in error && isDefined(error.code);
-};
-
-// stale chunk messages embed the content-hashed asset URL, so fingerprinting on
-// them would create a new Sentry issue for every deploy and every chunk
-const getPromiseRejectionFingerprint = (
-  error: unknown,
-  isStaleChunkLazyLoadingError: boolean,
-) => {
-  if (isStaleChunkLazyLoadingError) {
-    return STALE_CHUNK_LAZY_LOADING_FINGERPRINT;
-  }
-
-  if (hasErrorCode(error)) {
-    return error.code;
-  }
-
-  return error instanceof Error ? error.message : undefined;
+  return 'code' in error && isDefined(error.code);
 };
 
 export const PromiseRejectionEffect = () => {
@@ -79,26 +59,10 @@ export const PromiseRejectionEffect = () => {
         const { captureException } = await import('@sentry/react');
         captureException(error, (scope) => {
           scope.setExtras({ mechanism: 'onUnhandle' });
-          scope.setTag(
-            'errorSink',
-            isStaleChunkLazyLoadingError
-              ? 'promiseRejectionStaleChunk'
-              : 'promiseRejection',
-          );
 
-          const fingerprint = getPromiseRejectionFingerprint(
-            error,
-            isStaleChunkLazyLoadingError,
-          );
-
-          if (isNonEmptyString(fingerprint)) {
-            scope.setFingerprint([fingerprint]);
-          }
-
-          if (error instanceof Error) {
-            error.name = error.message;
-          }
-
+          const fingerprint = hasErrorCode(error) ? error.code : error.message;
+          scope.setFingerprint([fingerprint]);
+          error.name = error.message;
           return scope;
         });
       } catch (sentryError) {

--- a/packages/twenty-front/src/modules/error-handler/components/PromiseRejectionEffect.tsx
+++ b/packages/twenty-front/src/modules/error-handler/components/PromiseRejectionEffect.tsx
@@ -45,11 +45,11 @@ export const PromiseRejectionEffect = () => {
         error?.networkError?.name === 'AbortError' ||
         error?.name === 'AbortError';
 
-      const isStaleChunkLazyLoadingError =
+      const isViteStaleChunkLazyLoadingError =
         error instanceof Error &&
         checkIfItsAViteStaleChunkLazyLoadingError(error);
 
-      if (!isAbortError && !isStaleChunkLazyLoadingError) {
+      if (!isAbortError && !isViteStaleChunkLazyLoadingError) {
         enqueueErrorSnackBar(
           error instanceof Error ? { message: error.message } : {},
         );

--- a/packages/twenty-front/src/modules/error-handler/components/PromiseRejectionEffect.tsx
+++ b/packages/twenty-front/src/modules/error-handler/components/PromiseRejectionEffect.tsx
@@ -11,7 +11,10 @@ import {
   ServerParseError,
   UnconventionalError,
 } from '@apollo/client/errors';
+import { isNonEmptyString, isObject } from '@sniptt/guards';
 import { isDefined, type CustomError } from 'twenty-shared/utils';
+
+const STALE_CHUNK_LAZY_LOADING_FINGERPRINT = 'vite-stale-chunk-lazy-loading';
 
 const isApolloError = (error: unknown): boolean =>
   CombinedGraphQLErrors.is(error) ||
@@ -25,7 +28,24 @@ const isApolloError = (error: unknown): boolean =>
 const hasErrorCode = (
   error: CustomError | any,
 ): error is CustomError & { code: string } => {
-  return 'code' in error && isDefined(error.code);
+  return isObject(error) && 'code' in error && isDefined(error.code);
+};
+
+// stale chunk messages embed the content-hashed asset URL, so fingerprinting on
+// them would create a new Sentry issue for every deploy and every chunk
+const getPromiseRejectionFingerprint = (
+  error: unknown,
+  isStaleChunkLazyLoadingError: boolean,
+) => {
+  if (isStaleChunkLazyLoadingError) {
+    return STALE_CHUNK_LAZY_LOADING_FINGERPRINT;
+  }
+
+  if (hasErrorCode(error)) {
+    return error.code;
+  }
+
+  return error instanceof Error ? error.message : undefined;
 };
 
 export const PromiseRejectionEffect = () => {
@@ -60,13 +80,25 @@ export const PromiseRejectionEffect = () => {
         captureException(error, (scope) => {
           scope.setExtras({ mechanism: 'onUnhandle' });
           scope.setTag(
-            'isStaleChunkLazyLoadingError',
+            'errorSink',
+            isStaleChunkLazyLoadingError
+              ? 'promiseRejectionStaleChunk'
+              : 'promiseRejection',
+          );
+
+          const fingerprint = getPromiseRejectionFingerprint(
+            error,
             isStaleChunkLazyLoadingError,
           );
 
-          const fingerprint = hasErrorCode(error) ? error.code : error.message;
-          scope.setFingerprint([fingerprint]);
-          error.name = error.message;
+          if (isNonEmptyString(fingerprint)) {
+            scope.setFingerprint([fingerprint]);
+          }
+
+          if (error instanceof Error) {
+            error.name = error.message;
+          }
+
           return scope;
         });
       } catch (sentryError) {

--- a/packages/twenty-front/src/modules/error-handler/components/PromiseRejectionEffect.tsx
+++ b/packages/twenty-front/src/modules/error-handler/components/PromiseRejectionEffect.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useEffect } from 'react';
 
+import { checkIfItsAViteStaleChunkLazyLoadingError } from '@/error-handler/utils/checkIfItsAViteStaleChunkLazyLoadingError';
 import { useSnackBar } from '@/ui/feedback/snack-bar-manager/hooks/useSnackBar';
 import {
   CombinedGraphQLErrors,
@@ -44,7 +45,11 @@ export const PromiseRejectionEffect = () => {
         error?.networkError?.name === 'AbortError' ||
         error?.name === 'AbortError';
 
-      if (!isAbortError) {
+      const isStaleChunkLazyLoadingError =
+        error instanceof Error &&
+        checkIfItsAViteStaleChunkLazyLoadingError(error);
+
+      if (!isAbortError && !isStaleChunkLazyLoadingError) {
         enqueueErrorSnackBar(
           error instanceof Error ? { message: error.message } : {},
         );
@@ -54,6 +59,10 @@ export const PromiseRejectionEffect = () => {
         const { captureException } = await import('@sentry/react');
         captureException(error, (scope) => {
           scope.setExtras({ mechanism: 'onUnhandle' });
+          scope.setTag(
+            'isStaleChunkLazyLoadingError',
+            isStaleChunkLazyLoadingError,
+          );
 
           const fingerprint = hasErrorCode(error) ? error.code : error.message;
           scope.setFingerprint([fingerprint]);

--- a/packages/twenty-front/src/modules/error-handler/components/__tests__/PromiseRejectionEffect.test.tsx
+++ b/packages/twenty-front/src/modules/error-handler/components/__tests__/PromiseRejectionEffect.test.tsx
@@ -14,20 +14,6 @@ jest.mock('@/ui/feedback/snack-bar-manager/hooks/useSnackBar', () => ({
 
 const { captureException } = jest.requireMock('@sentry/react');
 
-const captureScopeOnce = () => {
-  const scope = {
-    setExtras: jest.fn(),
-    setFingerprint: jest.fn(),
-    setTag: jest.fn(),
-  };
-
-  captureException.mockImplementationOnce(
-    (_error: unknown, callback: (scope: unknown) => unknown) => callback(scope),
-  );
-
-  return scope;
-};
-
 const dispatchUnhandledRejection = (reason: unknown) => {
   const event = new Event('unhandledrejection') as Event & { reason: unknown };
   Object.defineProperty(event, 'reason', { value: reason });
@@ -36,17 +22,9 @@ const dispatchUnhandledRejection = (reason: unknown) => {
 };
 
 describe('PromiseRejectionEffect', () => {
-  let consoleErrorSpy: jest.SpyInstance;
-
   beforeEach(() => {
-    consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+    jest.clearAllMocks();
     render(<PromiseRejectionEffect />);
-  });
-
-  afterEach(() => {
-    consoleErrorSpy.mockRestore();
-    jest.restoreAllMocks();
-    jest.resetAllMocks();
   });
 
   it.each([
@@ -55,54 +33,16 @@ describe('PromiseRejectionEffect', () => {
     'error loading dynamically imported module: /assets/Page-abc123.js',
     'Unable to preload CSS for /assets/Page-abc123.css',
   ])('should not snackbar the stale chunk error "%s"', async (message) => {
-    const scope = captureScopeOnce();
-
     dispatchUnhandledRejection(new Error(message));
 
     await waitFor(() => {
-      expect(scope.setTag).toHaveBeenCalledWith(
-        'errorSink',
-        'promiseRejectionStaleChunk',
-      );
+      expect(captureException).toHaveBeenCalledTimes(1);
     });
 
     expect(enqueueErrorSnackBar).not.toHaveBeenCalled();
-    expect(scope.setExtras).toHaveBeenCalledWith({ mechanism: 'onUnhandle' });
   });
 
-  it('should fingerprint every stale chunk error identically so deploys do not split the Sentry issue', async () => {
-    const firstDeployScope = captureScopeOnce();
-
-    dispatchUnhandledRejection(
-      new Error(
-        'Failed to fetch dynamically imported module: /assets/Page-abc123.js',
-      ),
-    );
-
-    await waitFor(() => {
-      expect(firstDeployScope.setFingerprint).toHaveBeenCalledTimes(1);
-    });
-
-    const secondDeployScope = captureScopeOnce();
-
-    dispatchUnhandledRejection(
-      new Error(
-        'Failed to fetch dynamically imported module: /assets/Other-def456.js',
-      ),
-    );
-
-    await waitFor(() => {
-      expect(secondDeployScope.setFingerprint).toHaveBeenCalledTimes(1);
-    });
-
-    expect(secondDeployScope.setFingerprint).toHaveBeenCalledWith(
-      firstDeployScope.setFingerprint.mock.calls[0][0],
-    );
-  });
-
-  it('should still snackbar an unrelated error and tag it as the plain rejection sink', async () => {
-    const scope = captureScopeOnce();
-
+  it('should still snackbar an unrelated error', async () => {
     dispatchUnhandledRejection(new Error('Some unrelated error'));
 
     expect(enqueueErrorSnackBar).toHaveBeenCalledWith({
@@ -110,54 +50,27 @@ describe('PromiseRejectionEffect', () => {
     });
 
     await waitFor(() => {
-      expect(scope.setTag).toHaveBeenCalledWith(
-        'errorSink',
-        'promiseRejection',
-      );
+      expect(captureException).toHaveBeenCalledTimes(1);
     });
-
-    expect(scope.setFingerprint).toHaveBeenCalledWith(['Some unrelated error']);
   });
 
   it('should not snackbar an abort error', async () => {
-    const scope = captureScopeOnce();
-
     dispatchUnhandledRejection({ name: 'AbortError' });
 
     await waitFor(() => {
-      expect(scope.setTag).toHaveBeenCalledWith(
-        'errorSink',
-        'promiseRejection',
-      );
+      expect(captureException).toHaveBeenCalledTimes(1);
     });
 
     expect(enqueueErrorSnackBar).not.toHaveBeenCalled();
   });
 
-  it('should leave Sentry its default grouping when the reason carries no fingerprintable value', async () => {
-    const scope = captureScopeOnce();
-
-    dispatchUnhandledRejection({ name: 'AbortError' });
-
-    await waitFor(() => {
-      expect(scope.setExtras).toHaveBeenCalledTimes(1);
-    });
-
-    expect(scope.setFingerprint).not.toHaveBeenCalled();
-  });
-
   it('should snackbar a generic message when the reason is not an Error', async () => {
-    const scope = captureScopeOnce();
-
     dispatchUnhandledRejection('something went wrong');
 
     expect(enqueueErrorSnackBar).toHaveBeenCalledWith({});
 
     await waitFor(() => {
-      expect(scope.setExtras).toHaveBeenCalledTimes(1);
+      expect(captureException).toHaveBeenCalledTimes(1);
     });
-
-    expect(scope.setTag).toHaveBeenCalledWith('errorSink', 'promiseRejection');
-    expect(consoleErrorSpy).not.toHaveBeenCalled();
   });
 });

--- a/packages/twenty-front/src/modules/error-handler/components/__tests__/PromiseRejectionEffect.test.tsx
+++ b/packages/twenty-front/src/modules/error-handler/components/__tests__/PromiseRejectionEffect.test.tsx
@@ -14,11 +14,19 @@ jest.mock('@/ui/feedback/snack-bar-manager/hooks/useSnackBar', () => ({
 
 const { captureException } = jest.requireMock('@sentry/react');
 
-const buildScope = () => ({
-  setExtras: jest.fn(),
-  setFingerprint: jest.fn(),
-  setTag: jest.fn(),
-});
+const captureScopeOnce = () => {
+  const scope = {
+    setExtras: jest.fn(),
+    setFingerprint: jest.fn(),
+    setTag: jest.fn(),
+  };
+
+  captureException.mockImplementationOnce(
+    (_error: unknown, callback: (scope: unknown) => unknown) => callback(scope),
+  );
+
+  return scope;
+};
 
 const dispatchUnhandledRejection = (reason: unknown) => {
   const event = new Event('unhandledrejection') as Event & { reason: unknown };
@@ -28,9 +36,17 @@ const dispatchUnhandledRejection = (reason: unknown) => {
 };
 
 describe('PromiseRejectionEffect', () => {
+  let consoleErrorSpy: jest.SpyInstance;
+
   beforeEach(() => {
-    jest.clearAllMocks();
+    consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
     render(<PromiseRejectionEffect />);
+  });
+
+  afterEach(() => {
+    consoleErrorSpy.mockRestore();
+    jest.restoreAllMocks();
+    jest.resetAllMocks();
   });
 
   it.each([
@@ -39,40 +55,53 @@ describe('PromiseRejectionEffect', () => {
     'error loading dynamically imported module: /assets/Page-abc123.js',
     'Unable to preload CSS for /assets/Page-abc123.css',
   ])('should not snackbar the stale chunk error "%s"', async (message) => {
+    const scope = captureScopeOnce();
+
     dispatchUnhandledRejection(new Error(message));
 
     await waitFor(() => {
-      expect(captureException).toHaveBeenCalledTimes(1);
-    });
-
-    expect(enqueueErrorSnackBar).not.toHaveBeenCalled();
-  });
-
-  it('should tag stale chunk errors so the two error sinks stay distinguishable', async () => {
-    const scope = buildScope();
-    captureException.mockImplementation(
-      (_error: unknown, callback: (scope: unknown) => unknown) =>
-        callback(scope),
-    );
-
-    dispatchUnhandledRejection(new Error('Importing a module script failed.'));
-
-    await waitFor(() => {
       expect(scope.setTag).toHaveBeenCalledWith(
-        'isStaleChunkLazyLoadingError',
-        true,
+        'errorSink',
+        'promiseRejectionStaleChunk',
       );
     });
 
+    expect(enqueueErrorSnackBar).not.toHaveBeenCalled();
     expect(scope.setExtras).toHaveBeenCalledWith({ mechanism: 'onUnhandle' });
   });
 
-  it('should still snackbar an unrelated error and tag it as not a stale chunk error', async () => {
-    const scope = buildScope();
-    captureException.mockImplementation(
-      (_error: unknown, callback: (scope: unknown) => unknown) =>
-        callback(scope),
+  it('should fingerprint every stale chunk error identically so deploys do not split the Sentry issue', async () => {
+    const firstDeployScope = captureScopeOnce();
+
+    dispatchUnhandledRejection(
+      new Error(
+        'Failed to fetch dynamically imported module: /assets/Page-abc123.js',
+      ),
     );
+
+    await waitFor(() => {
+      expect(firstDeployScope.setFingerprint).toHaveBeenCalledTimes(1);
+    });
+
+    const secondDeployScope = captureScopeOnce();
+
+    dispatchUnhandledRejection(
+      new Error(
+        'Failed to fetch dynamically imported module: /assets/Other-def456.js',
+      ),
+    );
+
+    await waitFor(() => {
+      expect(secondDeployScope.setFingerprint).toHaveBeenCalledTimes(1);
+    });
+
+    expect(secondDeployScope.setFingerprint).toHaveBeenCalledWith(
+      firstDeployScope.setFingerprint.mock.calls[0][0],
+    );
+  });
+
+  it('should still snackbar an unrelated error and tag it as the plain rejection sink', async () => {
+    const scope = captureScopeOnce();
 
     dispatchUnhandledRejection(new Error('Some unrelated error'));
 
@@ -82,29 +111,53 @@ describe('PromiseRejectionEffect', () => {
 
     await waitFor(() => {
       expect(scope.setTag).toHaveBeenCalledWith(
-        'isStaleChunkLazyLoadingError',
-        false,
+        'errorSink',
+        'promiseRejection',
       );
     });
+
+    expect(scope.setFingerprint).toHaveBeenCalledWith(['Some unrelated error']);
   });
 
   it('should not snackbar an abort error', async () => {
+    const scope = captureScopeOnce();
+
     dispatchUnhandledRejection({ name: 'AbortError' });
 
     await waitFor(() => {
-      expect(captureException).toHaveBeenCalledTimes(1);
+      expect(scope.setTag).toHaveBeenCalledWith(
+        'errorSink',
+        'promiseRejection',
+      );
     });
 
     expect(enqueueErrorSnackBar).not.toHaveBeenCalled();
   });
 
+  it('should leave Sentry its default grouping when the reason carries no fingerprintable value', async () => {
+    const scope = captureScopeOnce();
+
+    dispatchUnhandledRejection({ name: 'AbortError' });
+
+    await waitFor(() => {
+      expect(scope.setExtras).toHaveBeenCalledTimes(1);
+    });
+
+    expect(scope.setFingerprint).not.toHaveBeenCalled();
+  });
+
   it('should snackbar a generic message when the reason is not an Error', async () => {
+    const scope = captureScopeOnce();
+
     dispatchUnhandledRejection('something went wrong');
 
     expect(enqueueErrorSnackBar).toHaveBeenCalledWith({});
 
     await waitFor(() => {
-      expect(captureException).toHaveBeenCalledTimes(1);
+      expect(scope.setExtras).toHaveBeenCalledTimes(1);
     });
+
+    expect(scope.setTag).toHaveBeenCalledWith('errorSink', 'promiseRejection');
+    expect(consoleErrorSpy).not.toHaveBeenCalled();
   });
 });

--- a/packages/twenty-front/src/modules/error-handler/components/__tests__/PromiseRejectionEffect.test.tsx
+++ b/packages/twenty-front/src/modules/error-handler/components/__tests__/PromiseRejectionEffect.test.tsx
@@ -15,7 +15,7 @@ jest.mock('@/ui/feedback/snack-bar-manager/hooks/useSnackBar', () => ({
 const { captureException } = jest.requireMock('@sentry/react');
 
 const dispatchUnhandledRejection = (reason: unknown) => {
-  const event = new Event('unhandledrejection') as Event & { reason: unknown };
+  const event = new Event('unhandledrejection');
   Object.defineProperty(event, 'reason', { value: reason });
 
   window.dispatchEvent(event);
@@ -27,13 +27,8 @@ describe('PromiseRejectionEffect', () => {
     render(<PromiseRejectionEffect />);
   });
 
-  it.each([
-    'Importing a module script failed.',
-    'Failed to fetch dynamically imported module: /assets/Page-abc123.js',
-    'error loading dynamically imported module: /assets/Page-abc123.js',
-    'Unable to preload CSS for /assets/Page-abc123.css',
-  ])('should not snackbar the stale chunk error "%s"', async (message) => {
-    dispatchUnhandledRejection(new Error(message));
+  it('should not snackbar a stale chunk error', async () => {
+    dispatchUnhandledRejection(new Error('Importing a module script failed.'));
 
     await waitFor(() => {
       expect(captureException).toHaveBeenCalledTimes(1);

--- a/packages/twenty-front/src/modules/error-handler/components/__tests__/PromiseRejectionEffect.test.tsx
+++ b/packages/twenty-front/src/modules/error-handler/components/__tests__/PromiseRejectionEffect.test.tsx
@@ -1,0 +1,110 @@
+import { render, waitFor } from '@testing-library/react';
+
+import { PromiseRejectionEffect } from '@/error-handler/components/PromiseRejectionEffect';
+
+jest.mock('@sentry/react', () => ({
+  captureException: jest.fn(),
+}));
+
+const enqueueErrorSnackBar = jest.fn();
+
+jest.mock('@/ui/feedback/snack-bar-manager/hooks/useSnackBar', () => ({
+  useSnackBar: () => ({ enqueueErrorSnackBar }),
+}));
+
+const { captureException } = jest.requireMock('@sentry/react');
+
+const buildScope = () => ({
+  setExtras: jest.fn(),
+  setFingerprint: jest.fn(),
+  setTag: jest.fn(),
+});
+
+const dispatchUnhandledRejection = (reason: unknown) => {
+  const event = new Event('unhandledrejection') as Event & { reason: unknown };
+  Object.defineProperty(event, 'reason', { value: reason });
+
+  window.dispatchEvent(event);
+};
+
+describe('PromiseRejectionEffect', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    render(<PromiseRejectionEffect />);
+  });
+
+  it.each([
+    'Importing a module script failed.',
+    'Failed to fetch dynamically imported module: /assets/Page-abc123.js',
+    'error loading dynamically imported module: /assets/Page-abc123.js',
+    'Unable to preload CSS for /assets/Page-abc123.css',
+  ])('should not snackbar the stale chunk error "%s"', async (message) => {
+    dispatchUnhandledRejection(new Error(message));
+
+    await waitFor(() => {
+      expect(captureException).toHaveBeenCalledTimes(1);
+    });
+
+    expect(enqueueErrorSnackBar).not.toHaveBeenCalled();
+  });
+
+  it('should tag stale chunk errors so the two error sinks stay distinguishable', async () => {
+    const scope = buildScope();
+    captureException.mockImplementation(
+      (_error: unknown, callback: (scope: unknown) => unknown) =>
+        callback(scope),
+    );
+
+    dispatchUnhandledRejection(new Error('Importing a module script failed.'));
+
+    await waitFor(() => {
+      expect(scope.setTag).toHaveBeenCalledWith(
+        'isStaleChunkLazyLoadingError',
+        true,
+      );
+    });
+
+    expect(scope.setExtras).toHaveBeenCalledWith({ mechanism: 'onUnhandle' });
+  });
+
+  it('should still snackbar an unrelated error and tag it as not a stale chunk error', async () => {
+    const scope = buildScope();
+    captureException.mockImplementation(
+      (_error: unknown, callback: (scope: unknown) => unknown) =>
+        callback(scope),
+    );
+
+    dispatchUnhandledRejection(new Error('Some unrelated error'));
+
+    expect(enqueueErrorSnackBar).toHaveBeenCalledWith({
+      message: 'Some unrelated error',
+    });
+
+    await waitFor(() => {
+      expect(scope.setTag).toHaveBeenCalledWith(
+        'isStaleChunkLazyLoadingError',
+        false,
+      );
+    });
+  });
+
+  it('should not snackbar an abort error', async () => {
+    dispatchUnhandledRejection({ name: 'AbortError' });
+
+    await waitFor(() => {
+      expect(captureException).toHaveBeenCalledTimes(1);
+    });
+
+    expect(enqueueErrorSnackBar).not.toHaveBeenCalled();
+  });
+
+  it('should snackbar a generic message when the reason is not an Error', async () => {
+    dispatchUnhandledRejection('something went wrong');
+
+    expect(enqueueErrorSnackBar).toHaveBeenCalledWith({});
+
+    await waitFor(() => {
+      expect(captureException).toHaveBeenCalledTimes(1);
+    });
+  });
+});


### PR DESCRIPTION
On iOS Safari, a failed chunk load showed a snackbar containing the raw browser string `Importing a module script failed.`

`PromiseRejectionEffect` snackbars the raw `error.message` of any unhandled rejection, so a floating dynamic import leaked browser internals to the user. It now skips the snackbar for stale chunk errors, which are still captured by Sentry.

This only changes what the user sees, not the underlying fetch failure.
