### PR TITLE
docs: state v1.23 as prerequisite for cross-version upgrades

### DIFF
--- a/packages/twenty-docs/developers/self-host/capabilities/upgrade-guide.mdx
+++ b/packages/twenty-docs/developers/self-host/capabilities/upgrade-guide.mdx
@@ -25,11 +25,11 @@ If you use Docker Compose, follow these steps:
 
 The server runs all required upgrade migrations automatically on startup. No manual command is needed.
 
-## Cross-version upgrades (v1.22+)
+## Cross-version upgrades (v1.23+)
 
-Starting from **v1.22**, Twenty supports cross-version upgrades. You can jump directly from any supported version to the latest release without stepping through each intermediate version.
+Starting from **v1.23**, Twenty supports cross-version upgrades. You can jump directly from any supported version to the latest release without stepping through each intermediate version.
 
-For example, upgrading from v1.22 straight to v2.0 is fully supported.
+For example, upgrading from v1.23 straight to v2.0 is fully supported.
 
 ## Upgrading to v2.5+ — at-rest encryption envelope
 
@@ -97,6 +97,6 @@ docker exec -it {server_container_name_or_id} yarn command:prod upgrade:status -
 
 This shows only workspaces that are behind or have failed, along with the error message for each failure.
 
-## Before v1.22
+## Before v1.23
 
-If your instance is older than v1.22, you must upgrade incrementally through each major tagged version (v1.6 to v1.7, then v1.7 to v1.8, and so on) until you reach v1.22. From there, you can jump directly to the latest version.
+If your instance is older than v1.23, you must upgrade incrementally through each major tagged version (v1.6 to v1.7, then v1.7 to v1.8, and so on) until you reach v1.23. From there, you can jump directly to the latest version.


### PR DESCRIPTION
Fixes #23568

The upgrade guide stated v1.22 was enough before jumping to a 2.x release. In practice that path fails during the workspace migration with `column ViewSortEntity.subFieldName does not exist`. Going through v1.23 first works.

Changes in `packages/twenty-docs/developers/self-host/capabilities/upgrade-guide.mdx`:
- Cross-version upgrade section now says v1.23+ instead of v1.22+, example updated to v1.23 -> v2.0
- "Before v1.22" section renamed to "Before v1.23" and its instructions updated

Only the English source is edited, the `l/<locale>/` copies are Crowdin-managed and will resync.