### PR TITLE
fix(ai-chat): show streaming activity during and between steps

### DIFF
--- a/packages/twenty-front/src/modules/ai/components/AiChatAssistantMessageRenderer.tsx
+++ b/packages/twenty-front/src/modules/ai/components/AiChatAssistantMessageRenderer.tsx
@@ -1,5 +1,6 @@
 import { AiChatCompactionIndicator } from '@/ai/components/AiChatCompactionIndicator';
 import { AiChatInitialLoadingIndicator } from '@/ai/components/AiChatInitialLoadingIndicator';
+import { AiChatStreamingIndicator } from '@/ai/components/AiChatStreamingIndicator';
 import { CodeExecutionDisplay } from '@/ai/components/CodeExecutionDisplay';
 import { RoutingStatusDisplay } from '@/ai/components/RoutingStatusDisplay';
 import { ThinkingStepsDisplay } from '@/ai/components/ThinkingStepsDisplay';
@@ -86,6 +87,8 @@ export const AiChatAssistantMessageRenderer = ({
   );
   const renderItems = groupContiguousThinkingStepParts(filteredParts);
 
+  const shouldShowStreamingIndicator = isLastMessageStreaming && !hasError;
+
   if (!renderItems.length && !hasError) {
     return <AiChatInitialLoadingIndicator />;
   }
@@ -116,6 +119,7 @@ export const AiChatAssistantMessageRenderer = ({
             />
           ),
         )}
+        {shouldShowStreamingIndicator && <AiChatStreamingIndicator />}
       </StyledMessagePartsContainer>
     </div>
   );

--- a/packages/twenty-front/src/modules/ai/components/AiChatMessage.tsx
+++ b/packages/twenty-front/src/modules/ai/components/AiChatMessage.tsx
@@ -176,7 +176,7 @@ export const AiChatMessage = ({
       <StyledMessageContainer isUser={isUser}>
         <StyledMessageText isUser={isUser}>
           <AiChatAssistantMessageRenderer
-            isLastMessageStreaming={isLastMessageStreaming}
+            isLastMessageStreaming={isLastMessageStreaming && !isUser}
             messageParts={agentChatMessage.parts}
             hasError={shouldShowError}
           />

--- a/packages/twenty-front/src/modules/ai/components/AiChatStreamingIndicator.tsx
+++ b/packages/twenty-front/src/modules/ai/components/AiChatStreamingIndicator.tsx
@@ -1,0 +1,19 @@
+import { styled } from '@linaria/react';
+import { ThinkingOrbitLoaderIcon } from 'twenty-ui/icon';
+import { themeCssVariables } from 'twenty-ui/theme-constants';
+
+const StyledLoaderContainer = styled.div`
+  align-items: center;
+  color: ${themeCssVariables.font.color.tertiary};
+  display: flex;
+  min-height: ${themeCssVariables.spacing[6]};
+  width: fit-content;
+`;
+
+export const AiChatStreamingIndicator = () => {
+  return (
+    <StyledLoaderContainer>
+      <ThinkingOrbitLoaderIcon />
+    </StyledLoaderContainer>
+  );
+};

--- a/packages/twenty-front/src/modules/ai/components/ThinkingStepsDisplay.tsx
+++ b/packages/twenty-front/src/modules/ai/components/ThinkingStepsDisplay.tsx
@@ -14,6 +14,7 @@ import { AnimatedExpandableContainer } from 'twenty-ui/layout';
 import { themeCssVariables } from 'twenty-ui/theme-constants';
 import { type JsonValue } from 'type-fest';
 
+import { ShimmeringText } from '@/ai/components/ShimmeringText';
 import { useToolDisplayContext } from '@/ai/hooks/useToolDisplayContext';
 import { getToolIcon } from '@/ai/utils/getToolIcon';
 import { getToolDisplayMessage } from '@/ai/utils/tool-display/get-tool-display-message';
@@ -298,6 +299,13 @@ const ThinkingToolStepRow = ({
     { id: 'input', title: t`Input` },
   ];
 
+  const toolRowLabel = (
+    <OverflowingTextWithTooltip
+      text={displayMessage}
+      tooltipDelay={TooltipDelay.shortDelay}
+    />
+  );
+
   return (
     <StyledToolRowContainer>
       <StyledToolRowButton
@@ -317,10 +325,11 @@ const ThinkingToolStepRow = ({
         </StyledIconContainer>
         <StyledRowLabelContainer>
           <StyledToolRowLabel>
-            <OverflowingTextWithTooltip
-              text={displayMessage}
-              tooltipDelay={TooltipDelay.shortDelay}
-            />
+            {isActive ? (
+              <ShimmeringText>{toolRowLabel}</ShimmeringText>
+            ) : (
+              toolRowLabel
+            )}
           </StyledToolRowLabel>
           {isExpandable && (
             <StyledChevronContainer isExpanded={isExpanded}>

--- a/packages/twenty-front/src/modules/ai/components/__tests__/AiChatAssistantMessageRenderer.test.tsx
+++ b/packages/twenty-front/src/modules/ai/components/__tests__/AiChatAssistantMessageRenderer.test.tsx
@@ -40,12 +40,19 @@ jest.mock('@/ai/components/CodeExecutionDisplay', () => ({
   CodeExecutionDisplay: () => <div data-testid="code-execution-display" />,
 }));
 
-const renderAssistantRenderer = (messageParts: ExtendedUIMessagePart[]) => {
+jest.mock('@/ai/components/AiChatStreamingIndicator', () => ({
+  AiChatStreamingIndicator: () => <div data-testid="streaming-indicator" />,
+}));
+
+const renderAssistantRenderer = (
+  messageParts: ExtendedUIMessagePart[],
+  { isLastMessageStreaming = false }: { isLastMessageStreaming?: boolean } = {},
+) => {
   return render(
     <ThemeProvider colorScheme="light">
       <AiChatAssistantMessageRenderer
         messageParts={messageParts}
-        isLastMessageStreaming={false}
+        isLastMessageStreaming={isLastMessageStreaming}
       />
     </ThemeProvider>,
   );
@@ -232,6 +239,63 @@ describe('AiChatAssistantMessageRenderer', () => {
       'Routing complete',
     );
     expect(screen.getByTestId('code-execution-display')).toBeInTheDocument();
+  });
+
+  it('should show the streaming indicator between two tool steps while streaming', () => {
+    const messageParts = [
+      {
+        type: 'reasoning',
+        text: 'Reasoning content',
+        state: 'done',
+      },
+      {
+        type: 'tool-web_search',
+        toolCallId: 'tool-1',
+        input: { query: 'crm software' },
+        output: { result: { ok: true } },
+        state: 'output-available',
+      },
+    ] as ExtendedUIMessagePart[];
+
+    renderAssistantRenderer(messageParts, { isLastMessageStreaming: true });
+
+    expect(screen.getByTestId('streaming-indicator')).toBeInTheDocument();
+  });
+
+  it('should show the streaming indicator while a tool call awaits its output', () => {
+    const messageParts = [
+      {
+        type: 'tool-web_search',
+        toolCallId: 'tool-1',
+        input: { query: 'crm software' },
+        state: 'input-available',
+      },
+    ] as ExtendedUIMessagePart[];
+
+    renderAssistantRenderer(messageParts, { isLastMessageStreaming: true });
+
+    expect(screen.getByTestId('streaming-indicator')).toBeInTheDocument();
+  });
+
+  it('should not show the streaming indicator when the message is not streaming', () => {
+    const messageParts = [
+      {
+        type: 'tool-web_search',
+        toolCallId: 'tool-1',
+        input: { query: 'crm software' },
+        output: { result: { ok: true } },
+        state: 'output-available',
+      },
+      {
+        type: 'text',
+        text: 'Final answer',
+        state: 'done',
+      },
+    ] as ExtendedUIMessagePart[];
+
+    renderAssistantRenderer(messageParts);
+
+    expect(screen.queryByTestId('streaming-indicator')).toBeNull();
   });
 
   it('should group a dynamic-tool part (native web search) into ThinkingStepsDisplay', () => {

--- a/packages/twenty-front/src/modules/ai/components/__tests__/ThinkingStepsDisplay.test.tsx
+++ b/packages/twenty-front/src/modules/ai/components/__tests__/ThinkingStepsDisplay.test.tsx
@@ -120,6 +120,17 @@ describe('ThinkingStepsDisplay', () => {
     expect(document.querySelector('svg[viewBox="0 0 14 14"]')).not.toBeNull();
   });
 
+  it('should render the loading label for a tool step awaiting its output while streaming', () => {
+    renderThinkingStepsDisplay({
+      isLastMessageStreaming: true,
+      parts: [createToolPart({ output: null })],
+    });
+
+    expect(
+      screen.getByText('Searching the web for crm software'),
+    ).toBeInTheDocument();
+  });
+
   it('should render done state collapsed by default', () => {
     renderThinkingStepsDisplay({
       isLastMessageStreaming: false,


### PR DESCRIPTION
## Problem

During a streaming turn with tool calls, the chat goes completely static in two places:

- **Between two steps**: once a tool's output arrives, its row flips to past tense and nothing animates until the model's next chunk arrives (a full LLM round trip, often several seconds). This window is defined by the absence of parts, so no part-driven component can fill it — and the pre-turn "…" indicator can't either, since it's cleared on the turn's first chunk and never comes back.
- **During tool execution**: the active tool row in `ThinkingStepsDisplay` is a static icon + label; the only animated element there is the orbit loader on an actively-streaming reasoning part.

Users can't tell whether the chat is still working or blocked.

## Fix

- **Beating AI icon between steps.** `AiChatAssistantMessageRenderer` renders a pulsing `IconSparkles` (`AiChatPendingNextStepIndicator`, claude.ai-style heartbeat) at the tail of the streaming message whenever the stream is open, there is no error, and no part is in progress. It disappears the instant the next chunk creates a real part. Part-level activity is decided by a new `isMessagePartInProgress` util: text/reasoning still streaming, tool call awaiting output, routing `loading`, code execution `pending`/`running`.
- **Shimmer on executing tools.** Active tool rows in `ThinkingStepsDisplay` wrap their label ("Searching the web for…") in the existing `ShimmeringText` while awaiting output.
- `AiChatMessage` passes `isLastMessageStreaming && !isUser` down, so the indicator can't render under the user's own bubble during the one-frame window where streaming has started but the assistant message hasn't been appended yet.

Net effect: something on screen is always moving while a turn is alive.

## Notes

- The indicator renders purely from `agentChatIsStreaming`, which the existing keepalive watchdog force-clears (with a visible connection-lost error) after ~5s of subscription silence — so it cannot beat forever on a dead stream.
- A brief pulse is possible between the final `text-end` and the stream's finish event, bounded by the persist round trip. Accepted: suppressing it would also suppress the indicator after mid-turn text parts, which is a real gap.

## Tests

- `isMessagePartInProgress` unit tests per part type
- Renderer tests: indicator shown between steps; hidden while a tool awaits output, while answer text streams, and when not streaming
- `ThinkingStepsDisplay` test for the loading label on a tool step awaiting output

Lint, format, and `typecheck twenty-front` are clean.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/23578?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

