### PR TITLE
Throttle local cache expiration sweeps

### DIFF
--- a/packages/twenty-server/src/engine/core-entity-cache/services/__tests__/core-entity-cache.service.spec.ts
+++ b/packages/twenty-server/src/engine/core-entity-cache/services/__tests__/core-entity-cache.service.spec.ts
@@ -1,0 +1,48 @@
+import { type DiscoveryService, type Reflector } from '@nestjs/core';
+
+import { CoreEntityCacheService } from 'src/engine/core-entity-cache/services/core-entity-cache.service';
+import { type CacheStorageService } from 'src/engine/core-modules/cache-storage/services/cache-storage.service';
+
+describe('CoreEntityCacheService', () => {
+  let service: CoreEntityCacheService;
+
+  beforeEach(() => {
+    jest.useFakeTimers();
+
+    service = new CoreEntityCacheService(
+      {} as CacheStorageService,
+      {} as DiscoveryService,
+      {} as Reflector,
+    );
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it('should run the local cache expiration sweep at most once per minute', async () => {
+    const expirationSweepSpy = jest.spyOn(
+      service as unknown as {
+        evictExpiredLocalEntries: (now: number) => void;
+      },
+      'evictExpiredLocalEntries',
+    );
+
+    await expect(
+      service.get('workspaceEntity', 'invalid-entity-id'),
+    ).resolves.toBeNull();
+    await expect(
+      service.get('workspaceEntity', 'invalid-entity-id'),
+    ).resolves.toBeNull();
+
+    expect(expirationSweepSpy).toHaveBeenCalledTimes(1);
+
+    jest.advanceTimersByTime(60_000);
+
+    await expect(
+      service.get('workspaceEntity', 'invalid-entity-id'),
+    ).resolves.toBeNull();
+
+    expect(expirationSweepSpy).toHaveBeenCalledTimes(2);
+  });
+});

--- a/packages/twenty-server/src/engine/core-entity-cache/services/core-entity-cache.service.ts
+++ b/packages/twenty-server/src/engine/core-entity-cache/services/core-entity-cache.service.ts
@@ -21,6 +21,7 @@ import { PromiseMemoizer } from 'src/engine/twenty-orm/storage/promise-memoizer.
 
 const LOCAL_TTL_MS = 100; // 100ms
 const LOCAL_ENTRY_TTL_MS = 30 * 60 * 1000; // 30 minutes
+const LOCAL_CACHE_EXPIRATION_SWEEP_INTERVAL_MS = 60 * 1000;
 const MEMOIZER_TTL_MS = 10_000; // 10 seconds
 const STALE_VERSION_TTL_MS = 5_000; // 5 seconds
 const MAX_LOCAL_STALE_VERSIONS = 5;
@@ -44,6 +45,7 @@ export class CoreEntityCacheService implements OnModuleInit {
   private readonly memoizer = new PromiseMemoizer<CacheableValue>(
     MEMOIZER_TTL_MS,
   );
+  private lastLocalCacheExpirationSweepAt: number | undefined;
 
   private readonly logger = new Logger(CoreEntityCacheService.name);
 
@@ -82,7 +84,7 @@ export class CoreEntityCacheService implements OnModuleInit {
     cacheKeyName: K,
     entityId: string,
   ): Promise<CoreEntityCacheDataMap[K] | null> {
-    this.evictExpiredLocalEntries();
+    this.evictExpiredLocalEntriesIfNeeded();
 
     if (!isDefined(entityId) || !isValidUuid(entityId)) {
       return null;
@@ -288,9 +290,22 @@ export class CoreEntityCacheService implements OnModuleInit {
     }
   }
 
-  private evictExpiredLocalEntries(): void {
+  private evictExpiredLocalEntriesIfNeeded(): void {
     const now = Date.now();
 
+    if (
+      isDefined(this.lastLocalCacheExpirationSweepAt) &&
+      now - this.lastLocalCacheExpirationSweepAt <
+        LOCAL_CACHE_EXPIRATION_SWEEP_INTERVAL_MS
+    ) {
+      return;
+    }
+
+    this.evictExpiredLocalEntries(now);
+    this.lastLocalCacheExpirationSweepAt = now;
+  }
+
+  private evictExpiredLocalEntries(now: number): void {
     for (const [localKey, entry] of this.localCache) {
       for (const [hash, version] of entry.versions) {
         if (now - version.lastReadAt > LOCAL_ENTRY_TTL_MS) {

--- a/packages/twenty-server/src/engine/workspace-cache/services/__tests__/workspace-cache.service.spec.ts
+++ b/packages/twenty-server/src/engine/workspace-cache/services/__tests__/workspace-cache.service.spec.ts
@@ -282,6 +282,34 @@ describe('WorkspaceCacheService', () => {
     });
   });
 
+  describe('local cache expiration sweep', () => {
+    it('should run at most once per minute', async () => {
+      const expirationSweepSpy = jest.spyOn(
+        service as unknown as {
+          evictExpiredLocalEntries: (now: number) => void;
+        },
+        'evictExpiredLocalEntries',
+      );
+
+      await expect(
+        service.getOrRecompute('invalid-workspace-id', ['featureFlagsMap']),
+      ).rejects.toThrow();
+      await expect(
+        service.getOrRecompute('invalid-workspace-id', ['featureFlagsMap']),
+      ).rejects.toThrow();
+
+      expect(expirationSweepSpy).toHaveBeenCalledTimes(1);
+
+      jest.advanceTimersByTime(60_000);
+
+      await expect(
+        service.getOrRecompute('invalid-workspace-id', ['featureFlagsMap']),
+      ).rejects.toThrow();
+
+      expect(expirationSweepSpy).toHaveBeenCalledTimes(2);
+    });
+  });
+
   describe('invalidateAndRecompute', () => {
     beforeEach(async () => {
       discoveryService.getProviders.mockReturnValue([

--- a/packages/twenty-server/src/engine/workspace-cache/services/workspace-cache.service.ts
+++ b/packages/twenty-server/src/engine/workspace-cache/services/workspace-cache.service.ts
@@ -36,6 +36,7 @@ import { combineCacheHashes } from 'src/engine/workspace-cache/utils/combine-cac
 
 const LOCAL_TTL_MS = 100; // 100ms
 const LOCAL_ENTRY_TTL_MS = 30 * 60 * 1000; // 30 minutes
+const LOCAL_CACHE_EXPIRATION_SWEEP_INTERVAL_MS = 60 * 1000;
 const MEMOIZER_TTL_MS = 10_000; // 10 seconds
 const STALE_VERSION_TTL_MS = 5_000; // 5 seconds
 const MAX_LOCAL_STALE_VERSIONS = 5; // 5 stale versions
@@ -71,6 +72,7 @@ export class WorkspaceCacheService implements OnModuleInit {
   private readonly memoizer = new PromiseMemoizer<CacheEntriesResult>(
     MEMOIZER_TTL_MS,
   );
+  private lastLocalCacheExpirationSweepAt: number | undefined;
 
   private readonly logger = new Logger(WorkspaceCacheService.name);
 
@@ -135,7 +137,7 @@ export class WorkspaceCacheService implements OnModuleInit {
     workspaceId: string,
     cacheKeyNames: K,
   ): Promise<WorkspaceCacheResultWithHashes<K>> {
-    this.evictExpiredLocalEntries();
+    this.evictExpiredLocalEntriesIfNeeded();
     this.assertValidCacheParameters(workspaceId, cacheKeyNames);
 
     const memoKey =
@@ -640,9 +642,22 @@ export class WorkspaceCacheService implements OnModuleInit {
     }
   }
 
-  private evictExpiredLocalEntries(): void {
+  private evictExpiredLocalEntriesIfNeeded(): void {
     const now = Date.now();
 
+    if (
+      isDefined(this.lastLocalCacheExpirationSweepAt) &&
+      now - this.lastLocalCacheExpirationSweepAt <
+        LOCAL_CACHE_EXPIRATION_SWEEP_INTERVAL_MS
+    ) {
+      return;
+    }
+
+    this.evictExpiredLocalEntries(now);
+    this.lastLocalCacheExpirationSweepAt = now;
+  }
+
+  private evictExpiredLocalEntries(now: number): void {
     for (const [localKey, entry] of this.localCache) {
       for (const [hash, version] of entry.versions) {
         if (now - version.lastReadAt > LOCAL_ENTRY_TTL_MS) {


### PR DESCRIPTION
## Context

The workspace cache and core entity cache keep bounded in-process maps. Entries that have not been read for 30 minutes are removed by an expiration sweep.

Before this PR, every cache read synchronously walked the entire local cache, including every stored version, before performing the actual lookup. The cost therefore grew with the number of cached entries even when there was nothing to expire. Both caches are used on common server request paths, so these repeated full-map scans add unnecessary CPU work and short-lived allocations, which can contribute to event-loop and garbage-collection pressure under load.

## What changed

- Run each cache's expiration sweep at most once per minute.
- Keep the existing expiration logic unchanged and use one captured timestamp for the complete sweep.
- Cover both cache services with tests proving that repeated reads within the interval trigger one sweep and that sweeping resumes after the interval.

Normal cache reads now pay only for a timestamp check and branch. The full `O(cache size)` scan runs at most once per minute per process.

## Safety

This does not change cache freshness:

- The 100 ms local freshness window and Redis hash validation still run as before.
- Explicit cache invalidation is unchanged.
- The 30-minute inactivity threshold is unchanged.
- LRU eviction still runs when entries are inserted.
- Existing local-cache size limits remain unchanged.

An unused entry can remain in memory for at most one additional minute before the next sweep. This may marginally increase average retained memory, but it cannot cause unbounded growth or allow stale data to bypass the existing hash validation.

## Expected impact

This removes a cache-size-dependent operation from a high-frequency path. The expected benefit is lower CPU and allocation overhead, less garbage-collection pressure, and improved tail latency when local caches are populated.

This is intentionally a narrow optimization. It does not claim to address every source of API tail latency.

## Validation

- `yarn nx typecheck twenty-server`
- Type-aware Oxlint on the changed files
- Oxfmt on the changed files
- Targeted workspace-cache and core-entity-cache Jest suites, 23 tests passing
