### PR TITLE
fix(record-field): await updateOneRecord before writing to store

### DIFF
--- a/packages/twenty-front/src/modules/object-record/record-field/ui/hooks/usePersistField.ts
+++ b/packages/twenty-front/src/modules/object-record/record-field/ui/hooks/usePersistField.ts
@@ -269,18 +269,22 @@ export const usePersistField = ({
           return;
         }
 
-        updateOneRecord({
-          objectNameSingular: objectMetadataItem.nameSingular,
-          idToUpdate: recordId,
-          updateOneRecordInput: {
-            [fieldName]: valueToPersist,
-          },
-        });
+        try {
+          await updateOneRecord({
+            objectNameSingular: objectMetadataItem.nameSingular,
+            idToUpdate: recordId,
+            updateOneRecordInput: {
+              [fieldName]: valueToPersist,
+            },
+          });
 
-        store.set(
-          recordStoreFamilySelector.selectorFamily({ recordId, fieldName }),
-          valueToPersist,
-        );
+          store.set(
+            recordStoreFamilySelector.selectorFamily({ recordId, fieldName }),
+            valueToPersist,
+          );
+        } catch {
+          // mutation rejected by server — leave store at current value
+        }
       } else {
         throw new Error(
           `Invalid value to persist: ${JSON.stringify(


### PR DESCRIPTION
`updateOneRecord()` is called without `await`, then `store.set()` writes the
new value unconditionally regardless of whether the server accepted it. When
the server rejects the value (e.g., an email address that exceeds the 255-char
limit validated by `emailSchema.max(255)`), the UI shows the bad value until
the page is reloaded.

Wrap the call in `try { await updateOneRecord(...); store.set(...) } catch {}`:
- On success: store is updated exactly as before.
- On server rejection: the exception is caught and `store.set()` is skipped, so
  the local store retains the previous valid value.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/23617?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

