### PR TITLE
docs(slack): add short and long OAuth app descriptions

### DIFF
--- a/packages/twenty-apps/public/slack/SETUP.md
+++ b/packages/twenty-apps/public/slack/SETUP.md
@@ -6,6 +6,26 @@ Two parts: a **Slack app** you create, and the **Twenty side** where you paste i
 
 1. Create a Slack app at [api.slack.com/apps](https://api.slack.com/apps). Use a dedicated app — do not reuse one across Twenty apps.
 
+   Under **Basic Information → Display Information** you can paste these descriptions (Slack caps the short description at 140 characters):
+
+   **Short description**
+
+   ```text
+   Your Twenty CRM inside Slack. Mention the bot to read, create and update records, and post to any channel from your workflows.
+   ```
+
+   **Long description**
+
+   ```text
+   Twenty brings your CRM into Slack so your team can work records without switching tabs.
+
+   Mention the bot in any channel or send it a direct message to ask about your data ("how many open opportunities do we have?") or change it ("create a company called ACME"). It replies in the thread using your CRM as context and remembers the conversation, so follow-ups need no new mention. It can read, create, update and soft-delete people, companies, opportunities, notes and tasks, with access controlled by a dedicated role you can tighten at any time.
+
+   Beyond the assistant, Twenty adds Slack steps to your workflows: post, update, delete and ephemeral messages, reactions and channel listing, so your automations reach the right channel at the right moment. A "Send Slack message" command lets anyone post to a channel from inside Twenty.
+
+   Twenty is the open-source CRM. Learn more at https://twenty.com.
+   ```
+
 2. **OAuth & Permissions → Bot Token Scopes.** Twenty uses Slack's bot OAuth (`oauth/v2/authorize` with `scope=…`), so scopes must be added here and not only under **User Token Scopes**, otherwise Slack refuses the install with *"doesn't have a bot user to install"*.
 
    The scopes requested at connect time must all appear under **Bot Token Scopes** (Slack validates the set):


### PR DESCRIPTION
## What

Adds ready-to-paste **short** and **long** descriptions for the Slack OAuth application to `packages/twenty-apps/public/slack/SETUP.md`, under step 1 where users create the Slack app at api.slack.com/apps.

- **Short description** (126 chars, within Slack's 140-char cap): one line covering the assistant and workflow posting.
- **Long description**: three paragraphs describing the conversational CRM assistant (mention/DM, in-thread answers, thread memory, read/create/update/soft-delete on a scoped role), the Slack workflow steps, and the "Send Slack message" command.

## Why

`SETUP.md` told users to create a Slack app but gave no display copy for the **Basic Information → Display Information** fields. These descriptions can now be pasted directly.

## Notes

Docs-only change. No code or scope changes.

---
_Generated by [Claude Code](https://claude.ai/code/session_012mPPBGW8NqD1LA2gKSa86a)_

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/23626?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

