### PR TITLE
fix: stop select filter matching from throwing on cursor comparison operators

### DIFF
--- a/packages/twenty-shared/src/utils/filter/utils/__tests__/isMatchingSelectFilter.test.ts
+++ b/packages/twenty-shared/src/utils/filter/utils/__tests__/isMatchingSelectFilter.test.ts
@@ -72,6 +72,29 @@ describe('isMatchingSelectFilter', () => {
     });
   });
 
+  describe('comparison operators emitted by cursor pagination', () => {
+    it.each(['gt', 'gte', 'lt', 'lte'])(
+      'should not throw for %s',
+      (operator) => {
+        expect(() =>
+          isMatchingSelectFilter({
+            selectFilter: { [operator]: 'NEW' } as any,
+            value: 'ACTIVE',
+          }),
+        ).not.toThrow();
+      },
+    );
+
+    it('should keep the record rather than exclude it', () => {
+      expect(
+        isMatchingSelectFilter({
+          selectFilter: { lt: 'NEW' } as any,
+          value: 'ACTIVE',
+        }),
+      ).toBe(true);
+    });
+  });
+
   describe('default', () => {
     it('should throw for unexpected filter', () => {
       expect(() =>

--- a/packages/twenty-shared/src/utils/filter/utils/isMatchingSelectFilter.ts
+++ b/packages/twenty-shared/src/utils/filter/utils/isMatchingSelectFilter.ts
@@ -1,5 +1,11 @@
 import { type SelectFilter } from '@/types';
 
+// Cursor-based pagination derives its operator from the sort direction alone,
+// without looking at the field type, so a view sorted on a SELECT field emits
+// filters such as { stage: { lt: 'NEW' } }. These operators are absent from
+// SelectFilter, yet they reach this predicate at runtime.
+const COMPARISON_OPERATORS = ['gt', 'gte', 'lt', 'lte'] as const;
+
 export const isMatchingSelectFilter = ({
   selectFilter,
   value,
@@ -25,6 +31,15 @@ export const isMatchingSelectFilter = ({
       return value !== selectFilter.neq;
     }
     default: {
+      // SELECT columns are PostgreSQL enums, so the server compares them on
+      // option position — an order this predicate cannot know, since it only
+      // receives the value. Throwing here would abort the caller's mutation
+      // (the optimistic cache update runs inside it), so keep the record and
+      // let the server, which is authoritative, settle it.
+      if (COMPARISON_OPERATORS.some((operator) => operator in selectFilter)) {
+        return true;
+      }
+
       throw new Error(
         `Unexpected value for select filter : ${JSON.stringify(selectFilter)}`,
       );


### PR DESCRIPTION
Fixes #23468

## What happens today

On a Table view sorted by a Select field, once you scroll past the first page the cursor query kicks in. Editing that Select field on any row then shows `Unexpected value for select filter : {"lt":"NEW"}` and **the change is silently discarded** — the record keeps its old value. A hard reload fixes it until you scroll again.

## Why

`computeCursorArgFilter` picks its operator from the sort direction and the pagination direction alone:

```ts
const computeOperator = (isAscending: boolean, isForwardPagination: boolean): string =>
  (isAscending ? isForwardPagination : !isForwardPagination) ? 'gt' : 'lt';
```

It never looks at the field type, so a view sorted on a SELECT field produces `{ stage: { lt: 'NEW' } }`. Note these operators are not even part of `SelectFilter` (`is | in | eq | neq`) — they reach the predicate at runtime because the filter is built dynamically as `{ [operator]: value }`.

`isMatchingSelectFilter` handled only those four operators and fell through to `throw`. It runs inside `isRecordMatchingFilter`, i.e. inside the optimistic cache update, so the synchronous throw aborts the caller's mutation. Hence the lost edit.

## The fix

`isMatchingSelectFilter` returns `true` for `gt`/`gte`/`lt`/`lte` instead of throwing.

Returning `true` rather than `false` is deliberate: `false` would drop the row out of the cached view, which the user would see. `true` keeps it until the server response settles it — the server is authoritative either way.

I did **not** implement a real comparison, and that is the point worth reviewing. SELECT columns are PostgreSQL enums (`field-metadata-type-to-column-type.util.ts` maps `SELECT` → `enum`), so the server orders them by **option position**, not alphabetically. This predicate only ever receives `{ selectFilter, value }` — never the option order — so a string comparison here would be quietly wrong (`'IN_PROGRESS' < 'NEW'` is true alphabetically but meaningless against a `NEW, SCREENING, MEETING…` enum). It cannot answer the question, so it should not pretend to.

The `throw` is preserved for genuinely unknown filter shapes, and the existing test covering it still passes.

## Tests

Added a `describe` block in `isMatchingSelectFilter.test.ts`: the four comparison operators must not throw, and the record is kept. Verified they fail on `main` with the exact error from the issue and pass with this change — 13/13 green.

## What this does not fix

The root cause is upstream: `computeCursorArgFilter` should arguably never emit `gt`/`lt` on a SELECT field in the first place. Fixing it there would mean threading field metadata into the cursor builder, which is shared by the front (`object-record/graphql/utils/computeCursorArgFilter.ts`) and the server (`engine/api/utils/compute-cursor-arg-filter.utils.ts`) — a much wider change, and one I'd rather not make unilaterally.

This PR makes the predicate stop breaking mutations. Happy to follow up on the cursor builder if that's the direction you'd prefer.

Unrelated, noticed while reading: the `is` branch compares `value === null` while the parameter is typed `value: string` (the existing test works around it with `null as any`). Left alone — separate concern.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/23629?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

