### PR TITLE
fix(ci): set parallel=1 for server-integration-test nx-affected step

### DIFF
--- a/.github/workflows/ci-server.yaml
+++ b/.github/workflows/ci-server.yaml
@@ -343,6 +343,7 @@ jobs:
           tag: scope:backend
           tasks: 'test:integration'
           configuration: 'with-db-reset'
+          parallel: 1
           args: --shard=${{ matrix.shard }}/${{ env.SHARD_COUNTER }}
 
   cross-version-upgrade:


### PR DESCRIPTION
The nx-affected action defaults to parallel=3. With the 16-shard matrix running concurrently, the default caused multiple sub-processes within each shard, which in turn led to the database:reset / database:init chain in test:integration:with-db-reset racing with neighbouring shards on the shared 'test' database.

Forcing parallel=1 makes Nx run the database:reset → database:init → database:migrate → jest sequence serially within a single Node process per shard, eliminating the sub-process race.

The 16-shard matrix parallelism is unchanged — only the intra-shard parallelism is reduced to 1.

Fixes the flakiness on #23609 (and any other PR that hits server-integration-test).
@prastoin 

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/23648?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

