### PR TITLE
Remove noisy actor context injection logs

### DIFF
--- a/packages/twenty-server/src/engine/core-modules/actor/services/actor-from-auth-context.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/actor/services/actor-from-auth-context.service.ts
@@ -1,4 +1,4 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
 
 import { type ActorMetadata } from 'twenty-shared/types';
 import { isDefined } from 'twenty-shared/utils';
@@ -25,8 +25,6 @@ export type InjectActorParams = {
 
 @Injectable()
 export class ActorFromAuthContextService {
-  private readonly logger = new Logger(ActorFromAuthContextService.name);
-
   constructor(
     private readonly flatEntityMapsCacheService: WorkspaceManyOrAllFlatEntityMapsCacheService,
   ) {}
@@ -113,15 +111,7 @@ export class ActorFromAuthContextService {
         ).fieldIdByName
       : {};
 
-    this.logger.log(
-      `Object metadata found with fields: ${Object.keys(fieldIdByName)}`,
-    );
-
     if (!isDefined(fieldIdByName[fieldName])) {
-      this.logger.log(
-        `${fieldName} field not found in object metadata, skipping injection`,
-      );
-
       return records;
     }
 


### PR DESCRIPTION
## Context

`ActorFromAuthContextService` runs while preparing records for create and update operations. Every actor-field injection logged the complete list of field names found in the object's metadata. It also logged when an object did not contain the actor field, even though skipping injection is an expected control-flow path.

These messages are not actionable in normal operation. On a frequently used path, building and emitting them adds avoidable string allocation, serialization, output, and log-ingestion work.

## What changed

- Remove the metadata field-list info log.
- Remove the info log for the expected missing-field path.
- Remove the now-unused NestJS logger instance.

## Safety

This only removes routine informational logging. Actor metadata lookup, missing-field handling, record cloning, and `createdBy` / `updatedBy` injection are unchanged. Errors are not suppressed, including the existing error for an unsupported authentication context.

## Expected impact

This reduces application log volume and avoids repeated formatting of metadata field-name arrays on record mutations. It is a small hot-path cleanup intended to reduce allocation and logging overhead, not a standalone fix for API tail latency.

## Validation

- Oxfmt check on the changed service
- Oxlint on the changed service
- `ActorFromAuthContextService` Jest suite, 4 tests passing
- `git diff --check`
