### PR TITLE
Support filters for table widgets + rich text widget in record layouts

### DIFF
--- a/packages/twenty-front/src/modules/page-layout/hooks/useCreateRecordPageStandaloneRichTextWidget.ts
+++ b/packages/twenty-front/src/modules/page-layout/hooks/useCreateRecordPageStandaloneRichTextWidget.ts
@@ -1,0 +1,64 @@
+import { usePageLayoutContentContext } from '@/page-layout/contexts/PageLayoutContentContext';
+import { useCurrentPageLayoutOrThrow } from '@/page-layout/hooks/useCurrentPageLayoutOrThrow';
+import { pageLayoutDraftComponentState } from '@/page-layout/states/pageLayoutDraftComponentState';
+import { pageLayoutEditingWidgetIdComponentState } from '@/page-layout/states/pageLayoutEditingWidgetIdComponentState';
+import { addWidgetToTab } from '@/page-layout/utils/addWidgetToTab';
+import { createDefaultStandaloneRichTextWidget } from '@/page-layout/utils/createDefaultStandaloneRichTextWidget';
+import { useSidePanelMenu } from '@/side-panel/hooks/useSidePanelMenu';
+import { useAtomComponentStateCallbackState } from '@/ui/utilities/state/jotai/hooks/useAtomComponentStateCallbackState';
+import { useStore } from 'jotai';
+import { useCallback } from 'react';
+import { v4 as uuidv4 } from 'uuid';
+import { PageLayoutTabLayoutMode } from '~/generated-metadata/graphql';
+
+export const useCreateRecordPageStandaloneRichTextWidget = () => {
+  const { tabId } = usePageLayoutContentContext();
+  const { currentPageLayout } = useCurrentPageLayoutOrThrow();
+  const { closeSidePanelMenu } = useSidePanelMenu();
+
+  const pageLayoutDraftState = useAtomComponentStateCallbackState(
+    pageLayoutDraftComponentState,
+  );
+
+  const pageLayoutEditingWidgetIdState = useAtomComponentStateCallbackState(
+    pageLayoutEditingWidgetIdComponentState,
+  );
+
+  const store = useStore();
+
+  const createRecordPageStandaloneRichTextWidget = useCallback(() => {
+    const activeTab = currentPageLayout.tabs.find((tab) => tab.id === tabId);
+    const positionIndex = activeTab?.widgets.length ?? 0;
+    const widgetId = uuidv4();
+
+    const newWidget = createDefaultStandaloneRichTextWidget(
+      widgetId,
+      tabId,
+      { blocknote: '', markdown: null },
+      { row: 0, column: 0, rowSpan: 1, columnSpan: 12 },
+      null,
+      {
+        __typename: 'PageLayoutWidgetVerticalListPosition',
+        layoutMode: PageLayoutTabLayoutMode.VERTICAL_LIST,
+        index: positionIndex,
+      },
+    );
+
+    store.set(pageLayoutDraftState, (prev) => ({
+      ...prev,
+      tabs: addWidgetToTab(prev.tabs, tabId, newWidget),
+    }));
+
+    store.set(pageLayoutEditingWidgetIdState, widgetId);
+    closeSidePanelMenu();
+  }, [
+    closeSidePanelMenu,
+    currentPageLayout.tabs,
+    pageLayoutDraftState,
+    pageLayoutEditingWidgetIdState,
+    store,
+    tabId,
+  ]);
+
+  return { createRecordPageStandaloneRichTextWidget };
+};

--- a/packages/twenty-front/src/modules/page-layout/utils/__tests__/createDefaultStandaloneRichTextWidget.test.ts
+++ b/packages/twenty-front/src/modules/page-layout/utils/__tests__/createDefaultStandaloneRichTextWidget.test.ts
@@ -53,4 +53,23 @@ describe('createDefaultStandaloneRichTextWidget', () => {
     expect(withObjectId.objectMetadataId).toBe('object-1');
     expect(withoutObjectId.objectMetadataId).toBeNull();
   });
+
+  it('should use provided custom position if specified', () => {
+    const verticalListPosition = {
+      __typename: 'PageLayoutWidgetVerticalListPosition' as const,
+      layoutMode: PageLayoutTabLayoutMode.VERTICAL_LIST,
+      index: 2,
+    };
+
+    const widget = createDefaultStandaloneRichTextWidget(
+      'w3',
+      't1',
+      { blocknote: '[]' },
+      { row: 0, column: 0, rowSpan: 1, columnSpan: 12 },
+      null,
+      verticalListPosition,
+    );
+
+    expect(widget.position).toEqual(verticalListPosition);
+  });
 });

--- a/packages/twenty-front/src/modules/page-layout/utils/createDefaultStandaloneRichTextWidget.ts
+++ b/packages/twenty-front/src/modules/page-layout/utils/createDefaultStandaloneRichTextWidget.ts
@@ -1,7 +1,8 @@
+import { type PageLayoutWidget } from '@/page-layout/types/PageLayoutWidget';
 import {
   type GridPosition,
   PageLayoutTabLayoutMode,
-  type PageLayoutWidget,
+  type PageLayoutWidget as PageLayoutWidgetGenerated,
   type RichTextBody,
   WidgetConfigurationType,
   WidgetType,
@@ -13,6 +14,7 @@ export const createDefaultStandaloneRichTextWidget = (
   body: RichTextBody,
   gridPosition: GridPosition,
   objectMetadataId?: string | null,
+  position?: PageLayoutWidgetGenerated['position'],
 ): PageLayoutWidget => {
   return {
     __typename: 'PageLayoutWidget',
@@ -27,7 +29,7 @@ export const createDefaultStandaloneRichTextWidget = (
       body,
     },
     gridPosition,
-    position: {
+    position: position ?? {
       __typename: 'PageLayoutWidgetGridPosition',
       layoutMode: PageLayoutTabLayoutMode.GRID,
       row: gridPosition.row,

--- a/packages/twenty-front/src/modules/page-layout/widgets/components/RecordPageAddWidgetSection.tsx
+++ b/packages/twenty-front/src/modules/page-layout/widgets/components/RecordPageAddWidgetSection.tsx
@@ -1,10 +1,12 @@
 import { useCreateRecordPageFieldWidget } from '@/page-layout/hooks/useCreateRecordPageFieldWidget';
 import { useCreateRecordPageFieldsWidget } from '@/page-layout/hooks/useCreateRecordPageFieldsWidget';
+import { useCreateRecordPageStandaloneRichTextWidget } from '@/page-layout/hooks/useCreateRecordPageStandaloneRichTextWidget';
 import { useNavigateToMoreWidgets } from '@/page-layout/hooks/useNavigateToMoreWidgets';
 import { styled } from '@linaria/react';
 import { t } from '@lingui/core/macro';
 import { useContext } from 'react';
 import {
+  IconAlignBoxLeftTop,
   IconListDetails,
   IconListSearch,
   IconPlus,
@@ -51,6 +53,9 @@ export const RecordPageAddWidgetSection = () => {
 
   const { createRecordPageFieldWidget } = useCreateRecordPageFieldWidget();
 
+  const { createRecordPageStandaloneRichTextWidget } =
+    useCreateRecordPageStandaloneRichTextWidget();
+
   const { navigateToMoreWidgets } = useNavigateToMoreWidgets();
 
   return (
@@ -77,6 +82,13 @@ export const RecordPageAddWidgetSection = () => {
           text={t`Field`}
           contextualText={t`Single field with smart formats`}
           onClick={createRecordPageFieldWidget}
+        />
+        <MenuItem
+          LeftIcon={IconAlignBoxLeftTop}
+          withIconContainer
+          text={t`Rich text`}
+          contextualText={t`Formatted static content`}
+          onClick={createRecordPageStandaloneRichTextWidget}
         />
         <MenuItem
           LeftIcon={IconPlus}

--- a/packages/twenty-front/src/modules/page-layout/widgets/field/hooks/useFilteredRelationRecords.ts
+++ b/packages/twenty-front/src/modules/page-layout/widgets/field/hooks/useFilteredRelationRecords.ts
@@ -1,0 +1,98 @@
+import { useObjectMetadataItemById } from '@/object-metadata/hooks/useObjectMetadataItemById';
+import { isRecordMatchingFilter } from '@/object-record/record-filter/utils/isRecordMatchingFilter';
+import { useCurrentWidget } from '@/page-layout/widgets/hooks/useCurrentWidget';
+import { useRecordTableWidgetViewForDisplay } from '@/page-layout/widgets/record-table/hooks/useRecordTableWidgetViewForDisplay';
+import { usePageLayoutIdFromContextStore } from '@/side-panel/pages/page-layout/hooks/usePageLayoutIdFromContextStore';
+import { useTargetRecord } from '@/ui/layout/contexts/useTargetRecord';
+import { type ViewFilter } from '@/views/types/ViewFilter';
+import { mapViewFilterGroupsToRecordFilterGroups } from '@/views/utils/mapViewFilterGroupsToRecordFilterGroups';
+import { mapViewFiltersToFilters } from '@/views/utils/mapViewFiltersToFilters';
+import { computeRecordGqlOperationFilter, isDefined } from 'twenty-shared/utils';
+
+type UseFilteredRelationRecordsArgs = {
+  records: any[];
+  targetObjectMetadataId?: string;
+};
+
+export const useFilteredRelationRecords = ({
+  records,
+  targetObjectMetadataId,
+}: UseFilteredRelationRecordsArgs): any[] => {
+  const widget = useCurrentWidget();
+  const pageLayoutId = usePageLayoutIdFromContextStore();
+  const targetRecord = useTargetRecord();
+
+  const viewId = widget?.configuration?.viewId ?? '';
+
+  const { view } = useRecordTableWidgetViewForDisplay({
+    viewId,
+    widgetId: widget?.id ?? '',
+    pageLayoutId,
+  });
+
+  const { objectMetadataItem } = useObjectMetadataItemById({
+    objectId: targetObjectMetadataId ?? '',
+  });
+
+  if (
+    !isDefined(view) ||
+    !isDefined(objectMetadataItem) ||
+    !Array.isArray(view.viewFilters) ||
+    view.viewFilters.length === 0 ||
+    !Array.isArray(records) ||
+    records.length === 0
+  ) {
+    return records;
+  }
+
+  // Filter out the automatic relation parent filter ({ isCurrentRecordSelected: true })
+  const userViewFilters = view.viewFilters.filter((vf: ViewFilter) => {
+    try {
+      if (!vf.value) return true;
+      const parsed = JSON.parse(vf.value);
+      return !parsed.isCurrentRecordSelected;
+    } catch {
+      return true;
+    }
+  });
+
+  if (userViewFilters.length === 0) {
+    return records;
+  }
+
+  const recordFilters = mapViewFiltersToFilters(
+    userViewFilters,
+    objectMetadataItem.fields,
+  );
+
+  const recordFilterGroups = mapViewFilterGroupsToRecordFilterGroups(
+    view.viewFilterGroups ?? [],
+  );
+
+  const gqlOperationFilter = computeRecordGqlOperationFilter({
+    fieldMetadataItems: objectMetadataItem.fields,
+    recordFilters,
+    recordFilterGroups,
+    filterValueDependencies: {
+      currentRecord: {
+        id: targetRecord.id,
+        objectMetadataNameSingular: targetRecord.targetObjectNameSingular,
+      },
+    },
+  });
+
+  if (
+    !isDefined(gqlOperationFilter) ||
+    Object.keys(gqlOperationFilter).length === 0
+  ) {
+    return records;
+  }
+
+  return records.filter((record) =>
+    isRecordMatchingFilter({
+      record,
+      filter: gqlOperationFilter,
+      objectMetadataItem,
+    }),
+  );
+};

--- a/packages/twenty-front/src/modules/page-layout/widgets/standalone-rich-text/components/StandaloneRichTextEditorContent.tsx
+++ b/packages/twenty-front/src/modules/page-layout/widgets/standalone-rich-text/components/StandaloneRichTextEditorContent.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useState } from 'react';
 
+import { isLayoutCustomizationModeEnabledState } from '@/layout-customization/states/isLayoutCustomizationModeEnabledState';
 import { useUpdatePageLayoutWidget } from '@/page-layout/hooks/useUpdatePageLayoutWidget';
 import { isDashboardInEditModeComponentState } from '@/page-layout/states/isDashboardInEditModeComponentState';
 import { pageLayoutEditingWidgetIdComponentState } from '@/page-layout/states/pageLayoutEditingWidgetIdComponentState';
@@ -51,9 +52,15 @@ export const StandaloneRichTextEditorContent = ({
 
   const shouldPersistDraft = useCallback(() => {
     const isDashboardInEditMode = store.get(isDashboardInEditModeState);
+    const isLayoutCustomizationModeEnabled = store.get(
+      isLayoutCustomizationModeEnabledState.atom,
+    );
     const editingWidgetId = store.get(pageLayoutEditingWidgetIdState);
 
-    return isDashboardInEditMode && editingWidgetId === widget.id;
+    const isPageLayoutInEditMode =
+      isDashboardInEditMode || isLayoutCustomizationModeEnabled;
+
+    return isPageLayoutInEditMode && editingWidgetId === widget.id;
   }, [
     isDashboardInEditModeState,
     pageLayoutEditingWidgetIdState,

--- a/packages/twenty-front/src/modules/side-panel/constants/SidePanelSubPagesConfig.tsx
+++ b/packages/twenty-front/src/modules/side-panel/constants/SidePanelSubPagesConfig.tsx
@@ -8,6 +8,7 @@ import { SidePanelNewSidebarItemViewPickerSubPage } from '@/navigation-menu-item
 import { SidePanelNewSidebarItemViewSystemPickerSubPage } from '@/navigation-menu-item/edit/side-panel/components/SidePanelNewSidebarItemViewSystemPickerSubPage';
 import { SidePanelChartFilterSubPage } from '@/side-panel/pages/page-layout/components/SidePanelChartFilterSubPage';
 import { SidePanelFieldRelationTableFieldsSubPage } from '@/side-panel/pages/page-layout/components/SidePanelFieldRelationTableFieldsSubPage';
+import { SidePanelFieldRelationTableFilterSubPage } from '@/side-panel/pages/page-layout/components/SidePanelFieldRelationTableFilterSubPage';
 import { SidePanelFieldsLayoutSubPage } from '@/side-panel/pages/page-layout/components/SidePanelFieldsLayoutSubPage';
 import { SidePanelRecordTableFilterSubPage } from '@/side-panel/pages/page-layout/components/record-table-settings/SidePanelRecordTableFilterSubPage';
 import { SidePanelRecordTableSortSubPage } from '@/side-panel/pages/page-layout/components/record-table-settings/SidePanelRecordTableSortSubPage';
@@ -32,6 +33,10 @@ export const SIDE_PANEL_SUB_PAGES_CONFIG = new Map<
   [
     SidePanelSubPages.PageLayoutFieldRelationTableFields,
     <SidePanelFieldRelationTableFieldsSubPage />,
+  ],
+  [
+    SidePanelSubPages.PageLayoutFieldRelationTableFilter,
+    <SidePanelFieldRelationTableFilterSubPage />,
   ],
   [
     SidePanelSubPages.NewSidebarItemViewObjectPicker,

--- a/packages/twenty-front/src/modules/side-panel/pages/page-layout/components/SidePanelFieldRelationTableFilterSubPage.tsx
+++ b/packages/twenty-front/src/modules/side-panel/pages/page-layout/components/SidePanelFieldRelationTableFilterSubPage.tsx
@@ -1,0 +1,44 @@
+import { useFieldMetadataItemById } from '@/object-metadata/hooks/useFieldMetadataItemById';
+import { getWidgetConfigurationViewId } from '@/page-layout/utils/getWidgetConfigurationViewId';
+import { RecordTableSettingsFilters } from '@/side-panel/pages/page-layout/components/record-table-settings/RecordTableSettingsFilters';
+import { usePageLayoutIdFromContextStore } from '@/side-panel/pages/page-layout/hooks/usePageLayoutIdFromContextStore';
+import { useWidgetInEditMode } from '@/side-panel/pages/page-layout/hooks/useWidgetInEditMode';
+import { isDefined } from 'twenty-shared/utils';
+import { type FieldConfiguration } from '~/generated-metadata/graphql';
+
+export const SidePanelFieldRelationTableFilterSubPage = () => {
+  const { pageLayoutId } = usePageLayoutIdFromContextStore();
+  const { widgetInEditMode } = useWidgetInEditMode(pageLayoutId);
+
+  if (!isDefined(widgetInEditMode) || !isDefined(widgetInEditMode.configuration)) {
+    return null;
+  }
+
+  const fieldConfiguration = widgetInEditMode.configuration as
+    | FieldConfiguration
+    | undefined;
+
+  const currentFieldMetadataId = fieldConfiguration?.fieldMetadataId;
+
+  const { fieldMetadataItem } = useFieldMetadataItemById(
+    currentFieldMetadataId ?? '',
+  );
+
+  const targetObjectMetadataId =
+    fieldMetadataItem?.relation?.targetObjectMetadata.id;
+
+  const viewId = getWidgetConfigurationViewId(widgetInEditMode.configuration);
+
+  if (!isDefined(viewId) || !isDefined(targetObjectMetadataId)) {
+    return null;
+  }
+
+  return (
+    <RecordTableSettingsFilters
+      viewId={viewId}
+      widgetId={widgetInEditMode.id}
+      pageLayoutId={pageLayoutId}
+      objectMetadataId={targetObjectMetadataId}
+    />
+  );
+};

--- a/packages/twenty-front/src/modules/side-panel/pages/page-layout/components/SidePanelPageLayoutRecordPageWidgetTypeSelect.tsx
+++ b/packages/twenty-front/src/modules/side-panel/pages/page-layout/components/SidePanelPageLayoutRecordPageWidgetTypeSelect.tsx
@@ -10,6 +10,7 @@ import { type PageLayoutWidget } from '@/page-layout/types/PageLayoutWidget';
 import { addWidgetToTab } from '@/page-layout/utils/addWidgetToTab';
 import { createDefaultFieldWidget } from '@/page-layout/utils/createDefaultFieldWidget';
 import { createDefaultFieldsWidget } from '@/page-layout/utils/createDefaultFieldsWidget';
+import { createDefaultStandaloneRichTextWidget } from '@/page-layout/utils/createDefaultStandaloneRichTextWidget';
 import { isVerticalListPosition } from '@/page-layout/utils/isVerticalListPosition';
 import { removeWidgetFromTab } from '@/page-layout/utils/removeWidgetFromTab';
 import { useFieldWidgetEligibleFields } from '@/page-layout/widgets/field/hooks/useFieldWidgetEligibleFields';
@@ -31,7 +32,7 @@ import { useStore } from 'jotai';
 import { useCallback } from 'react';
 import { SidePanelPages } from 'twenty-shared/types';
 import { isDefined } from 'twenty-shared/utils';
-import { IconApps, IconList } from 'twenty-ui/icon';
+import { IconAlignBoxLeftTop, IconApps, IconList } from 'twenty-ui/icon';
 import { v4 as uuidv4 } from 'uuid';
 import {
   type FrontComponent,
@@ -264,6 +265,49 @@ export const SidePanelPageLayoutRecordPageWidgetTypeSelect = () => {
     tabId,
   ]);
 
+  const handleCreateStandaloneRichTextWidget = useCallback(() => {
+    const replacePositionIndex = getExistingWidgetPositionIndex();
+    removeExistingWidgetIfReplacing();
+
+    const updatedPageLayout = store.get(pageLayoutDraftState);
+    const activeTab = updatedPageLayout.tabs.find((tab) => tab.id === tabId);
+    const positionIndex =
+      replacePositionIndex ?? activeTab?.widgets.length ?? 0;
+    const widgetId = uuidv4();
+
+    const newWidget = createDefaultStandaloneRichTextWidget(
+      widgetId,
+      tabId,
+      { blocknote: '', markdown: null },
+      { row: 0, column: 0, rowSpan: 1, columnSpan: 12 },
+      null,
+      {
+        __typename: 'PageLayoutWidgetVerticalListPosition',
+        layoutMode: PageLayoutTabLayoutMode.VERTICAL_LIST,
+        index: positionIndex,
+      },
+    );
+
+    store.set(pageLayoutDraftState, (prev) => ({
+      ...prev,
+      tabs: addWidgetToTab(prev.tabs, tabId, newWidget),
+    }));
+
+    setPageLayoutEditingWidgetId(widgetId);
+    insertCreatedWidgetAtContext(widgetId);
+
+    closeSidePanelMenu();
+  }, [
+    closeSidePanelMenu,
+    getExistingWidgetPositionIndex,
+    insertCreatedWidgetAtContext,
+    pageLayoutDraftState,
+    removeExistingWidgetIfReplacing,
+    setPageLayoutEditingWidgetId,
+    store,
+    tabId,
+  ]);
+
   const handleCreateFrontComponentWidget = useCallback(
     (frontComponent: FrontComponent) => {
       const replacePositionIndex = getExistingWidgetPositionIndex();
@@ -331,6 +375,7 @@ export const SidePanelPageLayoutRecordPageWidgetTypeSelect = () => {
   const selectableItemIds = [
     'fields',
     'field',
+    'rich-text',
     ...frontComponentsWithSelectItemId.map(({ selectItemId }) => selectItemId),
   ];
 
@@ -351,6 +396,17 @@ export const SidePanelPageLayoutRecordPageWidgetTypeSelect = () => {
             label={t`Field`}
             id="field"
             onClick={handleCreateFieldWidget}
+          />
+        </SelectableListItem>
+        <SelectableListItem
+          itemId="rich-text"
+          onEnter={handleCreateStandaloneRichTextWidget}
+        >
+          <CommandMenuItem
+            Icon={IconAlignBoxLeftTop}
+            label={t`Rich Text`}
+            id="rich-text"
+            onClick={handleCreateStandaloneRichTextWidget}
           />
         </SelectableListItem>
       </SidePanelGroup>

--- a/packages/twenty-front/src/modules/side-panel/pages/page-layout/components/record-page/SidePanelRecordPageFieldSettings.tsx
+++ b/packages/twenty-front/src/modules/side-panel/pages/page-layout/components/record-page/SidePanelRecordPageFieldSettings.tsx
@@ -26,6 +26,7 @@ import { useLingui } from '@lingui/react/macro';
 import { isDefined } from 'twenty-shared/utils';
 import {
   IconCalendar,
+  IconFilter,
   IconLayoutKanban,
   IconLayoutSidebarRight,
   IconList,
@@ -122,9 +123,17 @@ export const SidePanelRecordPageFieldSettings = () => {
     (item) => item.viewField.isVisible,
   ).length;
 
+  const activeFilterCount = embeddedWidgetView?.viewFilters?.length ?? 0;
+
   const handleNavigateToFields = () => {
     navigateToSidePanelSubPage(
       SidePanelSubPages.PageLayoutFieldRelationTableFields,
+    );
+  };
+
+  const handleNavigateToFilter = () => {
+    navigateToSidePanelSubPage(
+      SidePanelSubPages.PageLayoutFieldRelationTableFilter,
     );
   };
 
@@ -166,7 +175,7 @@ export const SidePanelRecordPageFieldSettings = () => {
           isLayoutRowHidden: true,
         })
       : []),
-    ...(isTableDisplayMode ? ['fields'] : []),
+    ...(isTableDisplayMode ? ['fields', 'filter'] : []),
     WIDGET_SETTINGS_SELECTABLE_ITEM_IDS.VISIBILITY_RESTRICTION,
     WIDGET_SETTINGS_SELECTABLE_ITEM_IDS.RESET_TO_DEFAULT,
     WIDGET_SETTINGS_SELECTABLE_ITEM_IDS.REPLACE_WIDGET,
@@ -234,6 +243,26 @@ export const SidePanelRecordPageFieldSettings = () => {
                   hasSubMenu
                   onClick={handleNavigateToFields}
                   description={t`${visibleFieldsCount} visible fields`}
+                  contextualTextPosition="right"
+                />
+              </SelectableListItem>
+            )}
+            {isTableDisplayMode && (
+              <SelectableListItem
+                itemId="filter"
+                onEnter={handleNavigateToFilter}
+              >
+                <CommandMenuItem
+                  id="filter"
+                  label={t`Filter`}
+                  Icon={IconFilter}
+                  hasSubMenu
+                  onClick={handleNavigateToFilter}
+                  description={
+                    activeFilterCount > 0
+                      ? t`${activeFilterCount} active filters`
+                      : ''
+                  }
                   contextualTextPosition="right"
                 />
               </SelectableListItem>

--- a/packages/twenty-front/src/modules/side-panel/types/SidePanelSubPages.ts
+++ b/packages/twenty-front/src/modules/side-panel/types/SidePanelSubPages.ts
@@ -4,6 +4,7 @@ export enum SidePanelSubPages {
   PageLayoutRecordTableFilter = 'page-layout-record-table-filter',
   PageLayoutRecordTableSort = 'page-layout-record-table-sort',
   PageLayoutFieldRelationTableFields = 'page-layout-field-relation-table-fields',
+  PageLayoutFieldRelationTableFilter = 'page-layout-field-relation-table-filter',
   NewSidebarItemMainMenu = 'new-sidebar-item-main-menu',
   NewSidebarItemViewObjectPicker = 'new-sidebar-item-view-object-picker',
   NewSidebarItemViewPicker = 'new-sidebar-item-view-picker',

--- a/packages/twenty-front/src/modules/side-panel/utils/getSidePanelSubPageTitle.ts
+++ b/packages/twenty-front/src/modules/side-panel/utils/getSidePanelSubPageTitle.ts
@@ -16,6 +16,8 @@ export const getSidePanelSubPageTitle = (
       return t`Sorts`;
     case SidePanelSubPages.PageLayoutFieldRelationTableFields:
       return t`Fields`;
+    case SidePanelSubPages.PageLayoutFieldRelationTableFilter:
+      return t`Filters`;
     case SidePanelSubPages.NewSidebarItemMainMenu:
       return t`Add menu item`;
     case SidePanelSubPages.NewSidebarItemViewObjectPicker:


### PR DESCRIPTION
Support of filtering for field widgets in custom layouts, using table mode.
<img width="736" height="480" alt="filters" src="https://github.com/user-attachments/assets/3d567ffb-a309-4754-a6f7-d5b58bf9f605" />
<img width="1161" height="495" alt="image" src="https://github.com/user-attachments/assets/172c009c-bca3-4461-83ee-4a3c4785ee11" />


NB: does **not** solve #23531 

cc @FelixMalfait 

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/23652?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

