### PR TITLE
v1.6.2 — fix(partners): drop the removed backfill command from the rls:configure banner

### DIFF
--- a/packages/twenty-apps/internal/twenty-partners/package.json
+++ b/packages/twenty-apps/internal/twenty-partners/package.json
@@ -1,6 +1,6 @@
 {
   "name": "twenty-partners",
-  "version": "1.6.1",
+  "version": "1.6.2",
   "license": "MIT",
   "engines": {
     "node": "^24.5.0",

--- a/packages/twenty-apps/internal/twenty-partners/src/scripts/configure-partner-rls.ts
+++ b/packages/twenty-apps/internal/twenty-partners/src/scripts/configure-partner-rls.ts
@@ -87,8 +87,9 @@ const APPLICATION_FIELD_LOCK_SKIP = new Set([
 
 const APPLY_WORKFLOW_WARNING =
   `[rls:configure] \u26a0 The "Apply to Brief" workflow in this workspace MUST map\n` +
-  `  Partner User -> {{trigger.workspaceMember}} and map no other field, and every\n` +
-  `  Application created before this run needs \`yarn backfill:partner-user\`.\n` +
+  `  Partner User -> {{trigger.workspaceMember}} and map no other field. Run this\n` +
+  `  after \`yarn twenty app:install\`, whose post-install hook stamps the rows\n` +
+  `  created before the narrowing.\n` +
   `  Otherwise partners cannot apply, and admin invites stay invisible to them.\n` +
   `  See src/workflows/README.md.\n`;
 


### PR DESCRIPTION
Version: **1.6.2** (patch — operator copy only, no behaviour change).

## Why

v1.6.1 replaced the manual `yarn backfill:partner-user` step with the app's post-install logic function and deleted both yarn scripts. The banner that `rls:configure` prints before and after its writes still tells the operator to run that command. It no longer exists, so an operator following the on-screen instruction hits `Command not found`.

Caught while deploying 1.6.1 to production.

## What changes

The banner now states the real order: `app:install` runs the post-install hook, which stamps the rows created before the narrowing; `rls:configure` comes after.

```
- Partner User -> {{trigger.workspaceMember}} and map no other field, and every
- Application created before this run needs `yarn backfill:partner-user`.
+ Partner User -> {{trigger.workspaceMember}} and map no other field. Run this
+ after `yarn twenty app:install`, whose post-install hook stamps the rows
+ created before the narrowing.
```

`src/workflows/README.md` already documents this order — only the printed banner was stale.

## Verification

Lint 0, typecheck 0, 221 unit tests pass. No other reference to `backfill:partner-user` remains in `src/` or `package.json`.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/23658?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

