### PR TITLE
fix(logic-function): ship the live SDK metadata client in lambda layers

### DIFF
--- a/packages/twenty-server/src/engine/core-modules/logic-function/logic-function-drivers/drivers/lambda/services/lambda-executor-manager.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/logic-function/logic-function-drivers/drivers/lambda/services/lambda-executor-manager.service.ts
@@ -286,11 +286,11 @@ export class LambdaExecutorManagerService {
       isDefined(lambdaExecutor) &&
       isActive &&
       !flatApplication.isSdkLayerStale &&
-      this.layerManager.hasExpectedLayers({
+      (await this.layerManager.hasExpectedLayers({
         lambdaExecutor,
         flatApplication,
         applicationUniversalIdentifier,
-      });
+      }));
 
     return { canSkip, lambdaExecutor };
   }

--- a/packages/twenty-server/src/engine/core-modules/logic-function/logic-function-drivers/drivers/lambda/services/lambda-layer-manager.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/logic-function/logic-function-drivers/drivers/lambda/services/lambda-layer-manager.service.ts
@@ -21,7 +21,15 @@ import { reprefixLambdaZipEntries } from 'src/engine/core-modules/logic-function
 import { TemporaryDirManager } from 'src/engine/core-modules/logic-function/logic-function-drivers/utils/temporary-dir-manager';
 import { type LogicFunctionResourceService } from 'src/engine/core-modules/logic-function/logic-function-resource/logic-function-resource.service';
 import { type SdkClientArchiveService } from 'src/engine/core-modules/sdk-client/sdk-client-archive.service';
+import { getInstalledSdkMetadataModule } from 'src/engine/core-modules/sdk-client/utils/get-installed-sdk-metadata-module.util';
 import { LogicFunctionRuntime } from 'src/engine/metadata-modules/logic-function/logic-function.entity';
+
+// The metadata client is app-agnostic and ships with the server build, but it
+// is bundled inside each app's SDK layer archive. Swapping it for the live
+// module at publish time keeps the layer's client in sync with the running
+// server (e.g. so a newly added metadata mutation is callable) instead of
+// serving whatever was frozen into the archive when it was last generated.
+const SDK_METADATA_MODULE_ARCHIVE_PATH = 'dist/metadata.mjs';
 
 type LayerAppContext = {
   flatApplication: FlatApplication;
@@ -69,9 +77,12 @@ export class LambdaLayerManagerService {
 
   async ensureSdkLayer(context: LayerAppContext): Promise<string> {
     const { flatApplication, applicationUniversalIdentifier } = context;
+    const { moduleBuffer: metadataModuleBuffer, checksum: metadataChecksum } =
+      await getInstalledSdkMetadataModule();
     const layerName = getLambdaSdkLayerName({
       workspaceId: flatApplication.workspaceId,
       applicationUniversalIdentifier,
+      metadataModuleChecksum: metadataChecksum,
     });
 
     if (!flatApplication.isSdkLayerStale) {
@@ -94,6 +105,9 @@ export class LambdaLayerManagerService {
     const zipBuffer = await reprefixLambdaZipEntries({
       sourceBuffer: sdkArchiveBuffer,
       prefix: SDK_LAYER_PREFIX_IN_ZIP,
+      entryReplacements: {
+        [SDK_METADATA_MODULE_ARCHIVE_PATH]: metadataModuleBuffer,
+      },
     });
 
     const arn = await this.publishLayer({ layerName, zipBuffer });
@@ -113,27 +127,32 @@ export class LambdaLayerManagerService {
     workspaceId: string;
     applicationUniversalIdentifier: string;
   }): Promise<void> {
+    const { checksum: metadataChecksum } =
+      await getInstalledSdkMetadataModule();
     const layerName = getLambdaSdkLayerName({
       workspaceId,
       applicationUniversalIdentifier,
+      metadataModuleChecksum: metadataChecksum,
     });
 
     await this.deleteAllLayerVersions(layerName);
   }
 
-  hasExpectedLayers({
+  async hasExpectedLayers({
     lambdaExecutor,
     flatApplication,
     applicationUniversalIdentifier,
   }: LayerAppContext & {
     lambdaExecutor: GetFunctionCommandOutput;
-  }): boolean {
+  }): Promise<boolean> {
     const layers = lambdaExecutor.Configuration?.Layers;
 
     if (!isDefined(layers) || layers.length !== 2) {
       return false;
     }
 
+    const { checksum: metadataChecksum } =
+      await getInstalledSdkMetadataModule();
     const depsLayerName = getLambdaDepsLayerName({
       flatApplication,
       namespace: this.options.resourceNamespace,
@@ -141,6 +160,7 @@ export class LambdaLayerManagerService {
     const sdkLayerName = getLambdaSdkLayerName({
       workspaceId: flatApplication.workspaceId,
       applicationUniversalIdentifier,
+      metadataModuleChecksum: metadataChecksum,
     });
 
     return (

--- a/packages/twenty-server/src/engine/core-modules/logic-function/logic-function-drivers/drivers/lambda/utils/__tests__/get-lambda-sdk-layer-name.util.spec.ts
+++ b/packages/twenty-server/src/engine/core-modules/logic-function/logic-function-drivers/drivers/lambda/utils/__tests__/get-lambda-sdk-layer-name.util.spec.ts
@@ -1,23 +1,41 @@
 import { getLambdaSdkLayerName } from 'src/engine/core-modules/logic-function/logic-function-drivers/drivers/lambda/utils/get-lambda-sdk-layer-name.util';
 
 describe('getLambdaSdkLayerName', () => {
-  it('joins prefix with workspaceId and applicationUniversalIdentifier', () => {
+  it('joins prefix with workspaceId, applicationUniversalIdentifier and metadata checksum', () => {
     expect(
       getLambdaSdkLayerName({
         workspaceId: 'ws-1',
         applicationUniversalIdentifier: 'app-2',
+        metadataModuleChecksum: 'abcdef1234567890',
       }),
-    ).toBe('sdk-ws-1-app-2');
+    ).toBe('sdk-ws-1-app-2-abcdef123456');
   });
 
   it('produces distinct names for distinct identifiers', () => {
     const a = getLambdaSdkLayerName({
       workspaceId: 'a',
       applicationUniversalIdentifier: 'x',
+      metadataModuleChecksum: 'checksum00000',
     });
     const b = getLambdaSdkLayerName({
       workspaceId: 'b',
       applicationUniversalIdentifier: 'x',
+      metadataModuleChecksum: 'checksum00000',
+    });
+
+    expect(a).not.toBe(b);
+  });
+
+  it('produces distinct names when the metadata module checksum changes', () => {
+    const a = getLambdaSdkLayerName({
+      workspaceId: 'ws',
+      applicationUniversalIdentifier: 'app',
+      metadataModuleChecksum: 'aaaaaaaaaaaa',
+    });
+    const b = getLambdaSdkLayerName({
+      workspaceId: 'ws',
+      applicationUniversalIdentifier: 'app',
+      metadataModuleChecksum: 'bbbbbbbbbbbb',
     });
 
     expect(a).not.toBe(b);

--- a/packages/twenty-server/src/engine/core-modules/logic-function/logic-function-drivers/drivers/lambda/utils/get-lambda-sdk-layer-name.util.ts
+++ b/packages/twenty-server/src/engine/core-modules/logic-function/logic-function-drivers/drivers/lambda/utils/get-lambda-sdk-layer-name.util.ts
@@ -1,7 +1,14 @@
+// The metadata module ships with the server build and is app-agnostic, so its
+// checksum is part of the layer identity: when the server upgrade changes it
+// (e.g. a new metadata mutation), the layer name changes and every executor
+// rebuilds to pick up the fresh client instead of reusing a stale layer.
 export const getLambdaSdkLayerName = ({
   workspaceId,
   applicationUniversalIdentifier,
+  metadataModuleChecksum,
 }: {
   workspaceId: string;
   applicationUniversalIdentifier: string;
-}): string => `sdk-${workspaceId}-${applicationUniversalIdentifier}`;
+  metadataModuleChecksum: string;
+}): string =>
+  `sdk-${workspaceId}-${applicationUniversalIdentifier}-${metadataModuleChecksum.slice(0, 12)}`;

--- a/packages/twenty-server/src/engine/core-modules/logic-function/logic-function-drivers/drivers/lambda/utils/reprefix-lambda-zip-entries.util.ts
+++ b/packages/twenty-server/src/engine/core-modules/logic-function/logic-function-drivers/drivers/lambda/utils/reprefix-lambda-zip-entries.util.ts
@@ -1,10 +1,14 @@
 // Re-wraps zip entries under a new prefix path without extracting to disk.
+// entryReplacements swaps the content of matching entries (keyed by their
+// original path) so an app-agnostic module can be refreshed at publish time.
 export const reprefixLambdaZipEntries = async ({
   sourceBuffer,
   prefix,
+  entryReplacements = {},
 }: {
   sourceBuffer: Buffer;
   prefix: string;
+  entryReplacements?: Record<string, Buffer>;
 }): Promise<Buffer> => {
   const { default: unzipper } = await import('unzipper');
   const archiver = (await import('archiver')).default;
@@ -21,7 +25,10 @@ export const reprefixLambdaZipEntries = async ({
       continue;
     }
 
-    archive.append(entry.stream(), {
+    const normalizedPath = entry.path.replace(/^\.\//, '');
+    const replacement = entryReplacements[normalizedPath];
+
+    archive.append(replacement ?? entry.stream(), {
       name: `${prefix}/${entry.path}`,
     });
   }


### PR DESCRIPTION
## Problem

An app's logic function calling a recently added metadata mutation (e.g. `enqueueJob`) fails at runtime with:

```
type `Mutation` does not have a field `enqueueJob`
  at /opt/nodejs/node_modules/twenty-client-sdk/dist/metadata.mjs
```

This surfaced on `backfill-last-contact` after an app upgrade.

## Root cause

The error is thrown **client-side** by genql inside the `metadata.mjs` bundled in the app's lambda **SDK layer** — its `Mutation` typeMap predates `enqueueJob`. It is not a server resolver/module problem:

- The metadata client is app-agnostic and ships with the server build. It is **never** regenerated from resolvers at runtime, and the worker boots via `NestFactory.createApplicationContext` (no GraphQL schema is built there), so which Nest modules the worker loads has no effect on this bundled typeMap.
- The SDK layer's `metadata.mjs` comes from the stored SDK archive. `generateAndStore` copies the current server build's `metadata.mjs` into the archive, but the archive is only regenerated when `isFirstApply || hasSchemaMetadataChanged` (`application-manifest-apply.service.ts:49`).
- So once the server gains `enqueueJob`, a later app upgrade that does **not** change schema keeps shipping the old `metadata.mjs`, and the mutation is missing from the layer even though the server supports it. The frontend is unaffected because `SdkClientController` serves the **live** installed metadata module.

## Fix

Make the lambda SDK layer always carry the live installed metadata module instead of the copy frozen into the archive:

- `ensureSdkLayer` swaps `dist/metadata.mjs` in the layer archive for `getInstalledSdkMetadataModule().moduleBuffer` at publish time (via a new `entryReplacements` option on `reprefixLambdaZipEntries`).
- The SDK layer name now includes the metadata module checksum. When a server upgrade changes the metadata module, the layer identity changes, so `hasExpectedLayers` reports a mismatch and existing executors rebuild to attach the fresh layer. This heals already-deployed apps on their next invocation without waiting for a schema change.

`hasExpectedLayers` became async (it now reads the installed metadata checksum, which is memoized at boot); its only caller in `LambdaExecutorManagerService.checkBuildStatus` was updated to await it.

## Scope / notes

- Scoped to the lambda driver, matching where the incident occurred (`/opt/nodejs`).
- Trade-off: on a metadata-module change, an app's previous checksum-named SDK layer is no longer referenced and is not pruned here (listing layers by prefix isn't available). The metadata module only changes on server upgrades that alter it, so accumulation is slow; bounded cleanup can be a follow-up.

## Tests

- Updated `get-lambda-sdk-layer-name.util.spec.ts` for the checksum-keyed name (passing).
- `nx typecheck twenty-server` passes; oxlint + oxfmt clean on the changed files.

---
_Generated by [Claude Code](https://claude.ai/code/session_01LEHrzgxZ6qFTeBuNqT3aa7)_

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/23663?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

