### PR TITLE
Add timeline layout support to calendar views

### DIFF
--- a/packages/twenty-client-sdk/src/metadata/generated/schema.graphql
+++ b/packages/twenty-client-sdk/src/metadata/generated/schema.graphql
@@ -854,6 +854,7 @@ enum ViewCalendarLayout {
   DAY
   WEEK
   MONTH
+  TIMELINE
 }
 
 enum ViewVisibility {

--- a/packages/twenty-client-sdk/src/metadata/generated/schema.ts
+++ b/packages/twenty-client-sdk/src/metadata/generated/schema.ts
@@ -590,7 +590,7 @@ export type ViewKey = 'INDEX'
 
 export type ViewOpenRecordIn = 'SIDE_PANEL' | 'RECORD_PAGE'
 
-export type ViewCalendarLayout = 'DAY' | 'WEEK' | 'MONTH'
+export type ViewCalendarLayout = 'DAY' | 'WEEK' | 'MONTH' | 'TIMELINE'
 
 export type ViewVisibility = 'WORKSPACE' | 'UNLISTED'
 
@@ -9288,7 +9288,8 @@ export const enumViewOpenRecordIn = {
 export const enumViewCalendarLayout = {
    DAY: 'DAY' as const,
    WEEK: 'WEEK' as const,
-   MONTH: 'MONTH' as const
+   MONTH: 'MONTH' as const,
+   TIMELINE: 'TIMELINE' as const
 }
 
 export const enumViewVisibility = {

--- a/packages/twenty-front/src/generated-metadata/graphql.ts
+++ b/packages/twenty-front/src/generated-metadata/graphql.ts
@@ -6251,6 +6251,7 @@ export type View = {
 export enum ViewCalendarLayout {
   DAY = 'DAY',
   MONTH = 'MONTH',
+  TIMELINE = 'TIMELINE',
   WEEK = 'WEEK'
 }
 

--- a/packages/twenty-front/src/modules/object-record/object-options-dropdown/components/ObjectOptionsDropdownCalendarViewContent.tsx
+++ b/packages/twenty-front/src/modules/object-record/object-options-dropdown/components/ObjectOptionsDropdownCalendarViewContent.tsx
@@ -28,8 +28,6 @@ import {
   ViewCalendarLayout,
 } from '~/generated-metadata/graphql';
 
-const RECORD_CALENDAR_TIMELINE_VIEW_ID = 'record-calendar-timeline-view';
-
 export const ObjectOptionsDropdownCalendarViewContent = () => {
   const { resetContent } = useObjectOptionsDropdown();
   const recordIndexCalendarLayout = useAtomComponentStateValue(
@@ -58,15 +56,16 @@ export const ObjectOptionsDropdownCalendarViewContent = () => {
     ViewCalendarLayout.DAY,
     ViewCalendarLayout.WEEK,
     ViewCalendarLayout.MONTH,
-    RECORD_CALENDAR_TIMELINE_VIEW_ID,
+    ViewCalendarLayout.TIMELINE,
   ];
 
   const handleCalendarViewChange = async (calendarView: ViewCalendarLayout) => {
-    const isTimeGridLayout =
+    const isExperimentalLayout =
       calendarView === ViewCalendarLayout.DAY ||
-      calendarView === ViewCalendarLayout.WEEK;
+      calendarView === ViewCalendarLayout.WEEK ||
+      calendarView === ViewCalendarLayout.TIMELINE;
 
-    if (isTimeGridLayout && !isCalendarWeekViewEnabled) {
+    if (isExperimentalLayout && !isCalendarWeekViewEnabled) {
       return;
     }
 
@@ -162,15 +161,29 @@ export const ObjectOptionsDropdownCalendarViewContent = () => {
               focused={selectedItemId === ViewCalendarLayout.MONTH}
             />
           </SelectableListItem>
-          <SelectableListItem itemId={RECORD_CALENDAR_TIMELINE_VIEW_ID}>
+          <SelectableListItem
+            itemId={ViewCalendarLayout.TIMELINE}
+            onEnter={() => {
+              if (isCalendarWeekViewEnabled) {
+                handleCalendarViewChange(ViewCalendarLayout.TIMELINE);
+              }
+            }}
+          >
             <MenuItemSelect
               LeftIcon={IconTimelineEvent}
               text={t`Timeline`}
-              selected={false}
-              focused={selectedItemId === RECORD_CALENDAR_TIMELINE_VIEW_ID}
-              contextualText={<Pill label={t`Soon`} />}
+              selected={supportedCalendarLayout === ViewCalendarLayout.TIMELINE}
+              focused={selectedItemId === ViewCalendarLayout.TIMELINE}
+              onClick={
+                isCalendarWeekViewEnabled
+                  ? () => handleCalendarViewChange(ViewCalendarLayout.TIMELINE)
+                  : undefined
+              }
+              contextualText={
+                isCalendarWeekViewEnabled ? undefined : <Pill label={t`Soon`} />
+              }
               contextualTextPosition="right"
-              disabled
+              disabled={!isCalendarWeekViewEnabled}
             />
           </SelectableListItem>
         </SelectableList>

--- a/packages/twenty-front/src/modules/object-record/object-options-dropdown/components/ObjectOptionsDropdownCustomView.tsx
+++ b/packages/twenty-front/src/modules/object-record/object-options-dropdown/components/ObjectOptionsDropdownCustomView.tsx
@@ -254,7 +254,10 @@ export const ObjectOptionsDropdownCustomView = ({
                       ? t`Month`
                       : supportedCalendarLayout === ViewCalendarLayout.WEEK
                         ? t`Week`
-                        : t`Day`
+                        : supportedCalendarLayout ===
+                            ViewCalendarLayout.TIMELINE
+                          ? t`Timeline`
+                          : t`Day`
                   }
                   contextualTextPosition="right"
                 />

--- a/packages/twenty-front/src/modules/object-record/object-options-dropdown/components/ObjectOptionsDropdownLayoutContent.tsx
+++ b/packages/twenty-front/src/modules/object-record/object-options-dropdown/components/ObjectOptionsDropdownLayoutContent.tsx
@@ -273,7 +273,10 @@ export const ObjectOptionsDropdownLayoutContent = () => {
                         ? t`Month`
                         : supportedCalendarLayout === ViewCalendarLayout.WEEK
                           ? t`Week`
-                          : t`Day`
+                          : supportedCalendarLayout ===
+                              ViewCalendarLayout.TIMELINE
+                            ? t`Timeline`
+                            : t`Day`
                     }
                     contextualTextPosition="right"
                     hasSubMenu

--- a/packages/twenty-front/src/modules/object-record/object-options-dropdown/components/__tests__/ObjectOptionsDropdownCalendarViewContent.test.tsx
+++ b/packages/twenty-front/src/modules/object-record/object-options-dropdown/components/__tests__/ObjectOptionsDropdownCalendarViewContent.test.tsx
@@ -100,7 +100,7 @@ describe('ObjectOptionsDropdownCalendarViewContent', () => {
     mockUpdateCurrentView.mockResolvedValue(undefined);
   });
 
-  it('offers Day, Week, and Month while keeping Timeline disabled', () => {
+  it('offers all calendar layouts when the feature is enabled', () => {
     render(<ObjectOptionsDropdownCalendarViewContent />);
 
     expect(
@@ -109,7 +109,7 @@ describe('ObjectOptionsDropdownCalendarViewContent', () => {
         .map((button) => button.textContent?.replace('Soon', '')),
     ).toEqual(['Day', 'Week', 'Month', 'Timeline']);
     expect(screen.getByText('Day').closest('button')).toBeEnabled();
-    expect(screen.getByText('Timeline').closest('button')).toBeDisabled();
+    expect(screen.getByText('Timeline').closest('button')).toBeEnabled();
   });
 
   it('persists Day without treating it as Timeline', async () => {
@@ -126,16 +126,32 @@ describe('ObjectOptionsDropdownCalendarViewContent', () => {
     await waitFor(() => expect(mockCloseDropdown).toHaveBeenCalled());
   });
 
-  it('keeps Day and Week unavailable when the feature flag is disabled', () => {
+  it('persists Timeline when selected', async () => {
+    render(<ObjectOptionsDropdownCalendarViewContent />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Timeline' }));
+
+    expect(mockSetRecordIndexCalendarLayout).toHaveBeenCalledWith(
+      ViewCalendarLayout.TIMELINE,
+    );
+    expect(mockUpdateCurrentView).toHaveBeenCalledWith({
+      calendarLayout: ViewCalendarLayout.TIMELINE,
+    });
+    await waitFor(() => expect(mockCloseDropdown).toHaveBeenCalled());
+  });
+
+  it('keeps experimental layouts unavailable when the feature flag is disabled', () => {
     mockUseIsFeatureEnabled.mockReturnValue(false);
 
     render(<ObjectOptionsDropdownCalendarViewContent />);
 
     const dayButton = screen.getByText('Day').closest('button');
     const weekButton = screen.getByText('Week').closest('button');
+    const timelineButton = screen.getByText('Timeline').closest('button');
 
     expect(dayButton).toBeDisabled();
     expect(weekButton).toBeDisabled();
+    expect(timelineButton).toBeDisabled();
 
     if (dayButton !== null) {
       fireEvent.click(dayButton);

--- a/packages/twenty-front/src/modules/object-record/record-calendar/components/RecordCalendar.tsx
+++ b/packages/twenty-front/src/modules/object-record/record-calendar/components/RecordCalendar.tsx
@@ -7,6 +7,7 @@ import { RecordCalendarTopBar } from '@/object-record/record-calendar/components
 import { RECORD_CALENDAR_CLICK_OUTSIDE_LISTENER_ID } from '@/object-record/record-calendar/constants/RecordCalendarClickOutsideListenerId';
 import { RecordCalendarDay } from '@/object-record/record-calendar/day/components/RecordCalendarDay';
 import { RecordCalendarMonth } from '@/object-record/record-calendar/month/components/RecordCalendarMonth';
+import { RecordCalendarTimeline } from '@/object-record/record-calendar/timeline/components/RecordCalendarTimeline';
 import { RecordCalendarWeek } from '@/object-record/record-calendar/week/components/RecordCalendarWeek';
 import { RECORD_CALENDAR_CARD_CLICK_OUTSIDE_ID } from '@/object-record/record-calendar/record-calendar-card/constants/RecordCalendarCardClickOutsideId';
 import { recordIndexCalendarLayoutComponentState } from '@/object-record/record-index/states/recordIndexCalendarLayoutComponentState';
@@ -85,6 +86,8 @@ export const RecordCalendar = () => {
           <RecordCalendarDay />
         ) : supportedCalendarLayout === ViewCalendarLayout.WEEK ? (
           <RecordCalendarWeek />
+        ) : supportedCalendarLayout === ViewCalendarLayout.TIMELINE ? (
+          <RecordCalendarTimeline />
         ) : (
           <RecordCalendarMonth />
         )}

--- a/packages/twenty-front/src/modules/object-record/record-calendar/components/RecordCalendarTopBar.tsx
+++ b/packages/twenty-front/src/modules/object-record/record-calendar/components/RecordCalendarTopBar.tsx
@@ -136,11 +136,12 @@ export const RecordCalendarTopBar = () => {
   };
 
   const handleCalendarLayoutChange = (calendarLayout: ViewCalendarLayout) => {
-    const isTimeGridLayout =
+    const isExperimentalLayout =
       calendarLayout === ViewCalendarLayout.DAY ||
-      calendarLayout === ViewCalendarLayout.WEEK;
+      calendarLayout === ViewCalendarLayout.WEEK ||
+      calendarLayout === ViewCalendarLayout.TIMELINE;
 
-    if (isTimeGridLayout && !isCalendarWeekViewEnabled) {
+    if (isExperimentalLayout && !isCalendarWeekViewEnabled) {
       return;
     }
 
@@ -186,6 +187,7 @@ export const RecordCalendarTopBar = () => {
                 { label: t`Day`, value: ViewCalendarLayout.DAY },
                 { label: t`Week`, value: ViewCalendarLayout.WEEK },
                 { label: t`Month`, value: ViewCalendarLayout.MONTH },
+                { label: t`Timeline`, value: ViewCalendarLayout.TIMELINE },
               ]}
               selectSizeVariant="small"
               dropdownWidth={120}

--- a/packages/twenty-front/src/modules/object-record/record-calendar/components/__tests__/RecordCalendar.test.tsx
+++ b/packages/twenty-front/src/modules/object-record/record-calendar/components/__tests__/RecordCalendar.test.tsx
@@ -30,6 +30,12 @@ jest.mock(
     RecordCalendarWeek: () => <div data-testid="calendar-week" />,
   }),
 );
+jest.mock(
+  '@/object-record/record-calendar/timeline/components/RecordCalendarTimeline',
+  () => ({
+    RecordCalendarTimeline: () => <div data-testid="calendar-timeline" />,
+  }),
+);
 jest.mock('@/ui/utilities/scroll/components/ScrollWrapper', () => ({
   ScrollWrapper: ({ children }: { children: React.ReactNode }) => children,
 }));
@@ -108,6 +114,18 @@ describe('RecordCalendar', () => {
 
     expect(screen.getByTestId('calendar-week')).toBeInTheDocument();
     expect(screen.queryByTestId('calendar-day')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('calendar-month')).not.toBeInTheDocument();
+  });
+
+  it('renders timeline when the timeline layout is enabled', () => {
+    useAtomComponentStateValueMock.mockReturnValue(ViewCalendarLayout.TIMELINE);
+    useIsFeatureEnabledMock.mockReturnValue(true);
+
+    render(<RecordCalendar />);
+
+    expect(screen.getByTestId('calendar-timeline')).toBeInTheDocument();
+    expect(screen.queryByTestId('calendar-day')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('calendar-week')).not.toBeInTheDocument();
     expect(screen.queryByTestId('calendar-month')).not.toBeInTheDocument();
   });
 });

--- a/packages/twenty-front/src/modules/object-record/record-calendar/components/__tests__/RecordCalendarTopBar.test.tsx
+++ b/packages/twenty-front/src/modules/object-record/record-calendar/components/__tests__/RecordCalendarTopBar.test.tsx
@@ -123,7 +123,7 @@ describe('RecordCalendarTopBar', () => {
     });
   });
 
-  it('shows Day, Week, and Month with the selected full date', () => {
+  it('shows all calendar layouts with the selected full date', () => {
     render(<RecordCalendarTopBar />);
 
     expect(screen.getByTestId('selected-date')).toHaveTextContent(
@@ -133,7 +133,7 @@ describe('RecordCalendarTopBar', () => {
       Array.from(
         screen.getByTestId('layout-select').querySelectorAll('option'),
       ).map((option) => option.textContent),
-    ).toEqual(['Day', 'Week', 'Month']);
+    ).toEqual(['Day', 'Week', 'Month', 'Timeline']);
     expect(screen.queryByTestId('time-zone')).not.toBeInTheDocument();
   });
 

--- a/packages/twenty-front/src/modules/object-record/record-calendar/month/hooks/useRecordCalendarQueryDateRangeFilter.tsx
+++ b/packages/twenty-front/src/modules/object-record/record-calendar/month/hooks/useRecordCalendarQueryDateRangeFilter.tsx
@@ -2,8 +2,10 @@ import { flattenedFieldMetadataItemsSelector } from '@/object-metadata/states/fl
 import { useRecordCalendarContextOrThrow } from '@/object-record/record-calendar/contexts/RecordCalendarContext';
 import { useRecordCalendarMonthDaysRange } from '@/object-record/record-calendar/month/hooks/useRecordCalendarMonthDaysRange';
 import { getRecordCalendarDateRangeOverlapFilter } from '@/object-record/record-calendar/month/utils/getRecordCalendarDateRangeOverlapFilter';
+import { getSupportedRecordCalendarLayout } from '@/object-record/record-calendar/utils/getSupportedRecordCalendarLayout';
 import { recordIndexCalendarEndFieldMetadataIdComponentState } from '@/object-record/record-index/states/recordIndexCalendarEndFieldMetadataIdComponentState';
 import { recordIndexCalendarFieldMetadataIdComponentState } from '@/object-record/record-index/states/recordIndexCalendarFieldMetadataIdComponentState';
+import { recordIndexCalendarLayoutComponentState } from '@/object-record/record-index/states/recordIndexCalendarLayoutComponentState';
 import { currentRecordFilterGroupsComponentState } from '@/object-record/record-filter-group/states/currentRecordFilterGroupsComponentState';
 import { useFilterValueDependencies } from '@/object-record/record-filter/hooks/useFilterValueDependencies';
 import { anyFieldFilterValueComponentState } from '@/object-record/record-filter/states/anyFieldFilterValueComponentState';
@@ -13,6 +15,7 @@ import { RecordFilterOperand } from '@/object-record/record-filter/types/RecordF
 import { useUserTimezone } from '@/ui/input/components/internal/date/hooks/useUserTimezone';
 import { useAtomComponentStateValue } from '@/ui/utilities/state/jotai/hooks/useAtomComponentStateValue';
 import { useAtomStateValue } from '@/ui/utilities/state/jotai/hooks/useAtomStateValue';
+import { useIsFeatureEnabled } from '@/workspace/hooks/useIsFeatureEnabled';
 import { t } from '@lingui/core/macro';
 import { type Temporal } from 'temporal-polyfill';
 import {
@@ -22,7 +25,11 @@ import {
   turnAnyFieldFilterIntoRecordGqlFilter,
   turnPlainDateIntoUserTimeZoneInstantString,
 } from 'twenty-shared/utils';
-import { FieldMetadataType } from '~/generated-metadata/graphql';
+import {
+  FeatureFlagKey,
+  FieldMetadataType,
+  ViewCalendarLayout,
+} from '~/generated-metadata/graphql';
 
 const DATE_RANGE_FILTER_AFTER_ID = 'DATE_RANGE_FILTER_AFTER_ID';
 const DATE_RANGE_FILTER_BEFORE_ID = 'DATE_RANGE_FILTER_BEFORE_ID';
@@ -34,6 +41,28 @@ export const useRecordCalendarQueryDateRangeFilter = (
     useRecordCalendarContextOrThrow();
   const { firstDayOfFirstWeek, lastDayOfLastWeek } =
     useRecordCalendarMonthDaysRange(selectedDate);
+
+  const recordIndexCalendarLayout = useAtomComponentStateValue(
+    recordIndexCalendarLayoutComponentState,
+  );
+  const isCalendarWeekViewEnabled = useIsFeatureEnabled(
+    FeatureFlagKey.IS_CALENDAR_WEEK_VIEW_ENABLED,
+  );
+  const supportedCalendarLayout = getSupportedRecordCalendarLayout({
+    calendarLayout: recordIndexCalendarLayout,
+    isCalendarWeekViewEnabled,
+  });
+
+  const firstDayOfSelectedMonth = selectedDate.with({ day: 1 });
+  const firstDayOfRange =
+    supportedCalendarLayout === ViewCalendarLayout.TIMELINE
+      ? firstDayOfSelectedMonth
+      : firstDayOfFirstWeek;
+  const nextDayAfterLastDayOfRange =
+    supportedCalendarLayout === ViewCalendarLayout.TIMELINE
+      ? firstDayOfSelectedMonth.add({ months: 4 })
+      : lastDayOfLastWeek.add({ days: 1 });
+  const lastDayOfRange = nextDayAfterLastDayOfRange.subtract({ days: 1 });
 
   const { userTimezone } = useUserTimezone();
 
@@ -73,15 +102,14 @@ export const useRecordCalendarQueryDateRangeFilter = (
     };
   }
 
-  const firstDayOfFirstWeekISOString =
-    turnPlainDateIntoUserTimeZoneInstantString(
-      firstDayOfFirstWeek,
-      userTimezone,
-    );
+  const firstDayOfRangeISOString = turnPlainDateIntoUserTimeZoneInstantString(
+    firstDayOfRange,
+    userTimezone,
+  );
 
-  const nextDayAfterLastDayOfLastWeekISOString =
+  const nextDayAfterLastDayOfRangeISOString =
     turnPlainDateIntoUserTimeZoneInstantString(
-      lastDayOfLastWeek.add({ days: 1 }),
+      nextDayAfterLastDayOfRange,
       userTimezone,
     );
 
@@ -103,33 +131,33 @@ export const useRecordCalendarQueryDateRangeFilter = (
         calendarEndField: calendarEndFieldMetadataItem,
         firstDayOfRange:
           calendarFieldMetadataItem.type === FieldMetadataType.DATE_TIME
-            ? firstDayOfFirstWeekISOString
-            : firstDayOfFirstWeek.toString(),
+            ? firstDayOfRangeISOString
+            : firstDayOfRange.toString(),
         nextDayAfterLastDayOfRange:
           calendarFieldMetadataItem.type === FieldMetadataType.DATE_TIME
-            ? nextDayAfterLastDayOfLastWeekISOString
-            : lastDayOfLastWeek.add({ days: 1 }).toString(),
+            ? nextDayAfterLastDayOfRangeISOString
+            : nextDayAfterLastDayOfRange.toString(),
       })
     : undefined;
 
   const dateRangeFilterAfter: RecordFilter = {
     id: DATE_RANGE_FILTER_AFTER_ID,
     fieldMetadataId: dateRangeFilterFieldMetadataId,
-    value: `${firstDayOfFirstWeekISOString}`,
+    value: `${firstDayOfRangeISOString}`,
     operand: RecordFilterOperand.IS_AFTER,
     type: 'DATE_TIME',
     label: t`After or equal`,
-    displayValue: `${firstDayOfFirstWeek.toString()}`,
+    displayValue: `${firstDayOfRange.toString()}`,
   };
 
   const dateRangeFilterBefore: RecordFilter = {
     id: DATE_RANGE_FILTER_BEFORE_ID,
     fieldMetadataId: dateRangeFilterFieldMetadataId,
-    value: `${nextDayAfterLastDayOfLastWeekISOString}`,
+    value: `${nextDayAfterLastDayOfRangeISOString}`,
     operand: RecordFilterOperand.IS_BEFORE,
     type: 'DATE_TIME',
     label: t`Before`,
-    displayValue: `${lastDayOfLastWeek.toString()}`,
+    displayValue: `${lastDayOfRange.toString()}`,
   };
 
   const calendarRecordFilters = isDefined(dateRangeOverlapFilter)

--- a/packages/twenty-front/src/modules/object-record/record-calendar/timeline/components/RecordCalendarTimeline.tsx
+++ b/packages/twenty-front/src/modules/object-record/record-calendar/timeline/components/RecordCalendarTimeline.tsx
@@ -1,0 +1,186 @@
+import { useDateTimeFormat } from '@/localization/hooks/useDateTimeFormat';
+import { useRecordCalendarContextOrThrow } from '@/object-record/record-calendar/contexts/RecordCalendarContext';
+import { RecordCalendarTimelineRecord } from '@/object-record/record-calendar/timeline/components/RecordCalendarTimelineRecord';
+import { RECORD_CALENDAR_TIMELINE_INPUT_ID_PREFIX } from '@/object-record/record-calendar/timeline/constants/RecordCalendarTimelineInputIdPrefix';
+import { recordCalendarTimelineGroupsComponentSelector } from '@/object-record/record-calendar/timeline/states/recordCalendarTimelineGroupsComponentSelector';
+import { recordIndexCalendarFieldMetadataIdComponentState } from '@/object-record/record-index/states/recordIndexCalendarFieldMetadataIdComponentState';
+import { RecordFieldsScopeContextProvider } from '@/object-record/record-field-list/contexts/RecordFieldsScopeContext';
+import { useAtomComponentFamilySelectorValue } from '@/ui/utilities/state/jotai/hooks/useAtomComponentFamilySelectorValue';
+import { useAtomComponentStateValue } from '@/ui/utilities/state/jotai/hooks/useAtomComponentStateValue';
+import { useAtomStateValue } from '@/ui/utilities/state/jotai/hooks/useAtomStateValue';
+import { styled } from '@linaria/react';
+import { Temporal } from 'temporal-polyfill';
+import { isDefined } from 'twenty-shared/utils';
+import { themeCssVariables } from 'twenty-ui/theme-constants';
+import { dateLocaleState } from '~/localization/states/dateLocaleState';
+
+const StyledTimeline = styled.div`
+  display: flex;
+  flex-direction: column;
+  padding-right: ${themeCssVariables.spacing[1]};
+  padding-top: ${themeCssVariables.spacing[2]};
+`;
+
+const StyledMonth = styled.section`
+  & + & {
+    margin-top: ${themeCssVariables.spacing[4]};
+  }
+`;
+
+const StyledMonthHeader = styled.div`
+  align-items: center;
+  box-sizing: border-box;
+  display: flex;
+  font-size: ${themeCssVariables.font.size.sm};
+  font-weight: ${themeCssVariables.font.weight.medium};
+  gap: ${themeCssVariables.spacing[2]};
+  height: 17px;
+  padding-left: ${themeCssVariables.spacing[2]};
+  padding-top: ${themeCssVariables.spacing[2]};
+`;
+
+const StyledMonthName = styled.span`
+  color: ${themeCssVariables.font.color.primary};
+`;
+
+const StyledYear = styled.span`
+  color: ${themeCssVariables.font.color.light};
+`;
+
+const StyledMonthDays = styled.div`
+  background: ${themeCssVariables.background.secondary};
+  border: 1px solid ${themeCssVariables.border.color.medium};
+  border-radius: ${themeCssVariables.border.radius.md};
+  margin-top: ${themeCssVariables.spacing[4]};
+  overflow: hidden;
+`;
+
+const StyledDay = styled.div`
+  align-items: flex-start;
+  border-bottom: 1px solid ${themeCssVariables.border.color.light};
+  box-sizing: border-box;
+  display: flex;
+  gap: ${themeCssVariables.spacing[3]};
+  min-height: 40px;
+  padding: ${themeCssVariables.spacing[2]} ${themeCssVariables.spacing[3]};
+
+  &:last-child {
+    border-bottom: 0;
+  }
+`;
+
+const StyledDayLabel = styled.div`
+  align-items: center;
+  display: flex;
+  flex: 0 0 24px;
+  flex-direction: column;
+  gap: ${themeCssVariables.spacing[1]};
+  height: 24px;
+  justify-content: center;
+`;
+
+const StyledWeekday = styled.span`
+  color: ${themeCssVariables.font.color.tertiary};
+  font-size: 9px;
+  font-weight: ${themeCssVariables.font.weight.semiBold};
+  line-height: normal;
+`;
+
+const StyledDayNumber = styled.span`
+  color: ${themeCssVariables.font.color.secondary};
+  font-size: ${themeCssVariables.font.size.sm};
+  font-weight: ${themeCssVariables.font.weight.medium};
+  line-height: 1.4;
+`;
+
+const StyledDivider = styled.div`
+  align-self: stretch;
+  background: ${themeCssVariables.border.color.medium};
+  border-radius: ${themeCssVariables.border.radius.sm};
+  flex: 0 0 1px;
+`;
+
+const StyledRecords = styled.div`
+  display: flex;
+  flex: 1;
+  flex-direction: column;
+  gap: ${themeCssVariables.spacing[3]};
+  min-width: 0;
+`;
+
+export const RecordCalendarTimeline = () => {
+  const { objectMetadataItem } = useRecordCalendarContextOrThrow();
+  const recordIndexCalendarFieldMetadataId = useAtomComponentStateValue(
+    recordIndexCalendarFieldMetadataIdComponentState,
+  );
+  const calendarFieldMetadataItem = objectMetadataItem.fields.find(
+    ({ id }) => id === recordIndexCalendarFieldMetadataId,
+  );
+  const { timeZone } = useDateTimeFormat();
+  const dateLocale = useAtomStateValue(dateLocaleState);
+  const monthGroups = useAtomComponentFamilySelectorValue(
+    recordCalendarTimelineGroupsComponentSelector,
+    { timeZone },
+  );
+
+  if (!isDefined(calendarFieldMetadataItem)) {
+    return null;
+  }
+
+  return (
+    <RecordFieldsScopeContextProvider
+      value={{ scopeInstanceId: RECORD_CALENDAR_TIMELINE_INPUT_ID_PREFIX }}
+    >
+      <StyledTimeline>
+        {monthGroups.map(({ month, days }) => {
+          const plainYearMonth = Temporal.PlainYearMonth.from(month);
+          const monthDate = plainYearMonth.toPlainDate({ day: 1 });
+
+          return (
+            <StyledMonth key={month}>
+              <StyledMonthHeader>
+                <StyledMonthName>
+                  {monthDate.toLocaleString(dateLocale.locale, {
+                    month: 'long',
+                  })}
+                </StyledMonthName>
+                <StyledYear>{plainYearMonth.year}</StyledYear>
+              </StyledMonthHeader>
+              <StyledMonthDays>
+                {days.map(({ day, recordIds }) => {
+                  const plainDate = Temporal.PlainDate.from(day);
+
+                  return (
+                    <StyledDay key={day}>
+                      <StyledDayLabel>
+                        <StyledWeekday>
+                          {plainDate.toLocaleString(dateLocale.locale, {
+                            weekday: 'short',
+                          })}
+                        </StyledWeekday>
+                        <StyledDayNumber>
+                          {plainDate.day.toString().padStart(2, '0')}
+                        </StyledDayNumber>
+                      </StyledDayLabel>
+                      <StyledDivider />
+                      <StyledRecords>
+                        {recordIds.map((recordId) => (
+                          <RecordCalendarTimelineRecord
+                            key={recordId}
+                            calendarFieldName={calendarFieldMetadataItem.name}
+                            calendarFieldType={calendarFieldMetadataItem.type}
+                            recordId={recordId}
+                          />
+                        ))}
+                      </StyledRecords>
+                    </StyledDay>
+                  );
+                })}
+              </StyledMonthDays>
+            </StyledMonth>
+          );
+        })}
+      </StyledTimeline>
+    </RecordFieldsScopeContextProvider>
+  );
+};

--- a/packages/twenty-front/src/modules/object-record/record-calendar/timeline/components/RecordCalendarTimelineFields.tsx
+++ b/packages/twenty-front/src/modules/object-record/record-calendar/timeline/components/RecordCalendarTimelineFields.tsx
@@ -1,0 +1,88 @@
+import { RECORD_CALENDAR_TIMELINE_INPUT_ID_PREFIX } from '@/object-record/record-calendar/timeline/constants/RecordCalendarTimelineInputIdPrefix';
+import { visibleRecordFieldsComponentSelector } from '@/object-record/record-field/states/visibleRecordFieldsComponentSelector';
+import { FieldContext } from '@/object-record/record-field/ui/contexts/FieldContext';
+import { RecordFieldComponentInstanceContext } from '@/object-record/record-field/ui/states/contexts/RecordFieldComponentInstanceContext';
+import { useRecordIndexContextOrThrow } from '@/object-record/record-index/contexts/RecordIndexContext';
+import { RecordInlineCell } from '@/object-record/record-inline-cell/components/RecordInlineCell';
+import { getRecordFieldInputInstanceId } from '@/object-record/utils/getRecordFieldInputId';
+import { useAtomComponentSelectorValue } from '@/ui/utilities/state/jotai/hooks/useAtomComponentSelectorValue';
+import { styled } from '@linaria/react';
+import { isDefined } from 'twenty-shared/utils';
+
+const StyledFields = styled.div`
+  align-items: center;
+  display: flex;
+  flex: 0 1 auto;
+  justify-content: flex-end;
+  margin-left: auto;
+  min-width: 0;
+  overflow: hidden;
+`;
+
+const StyledField = styled.div`
+  flex: 0 1 auto;
+  max-width: 160px;
+  min-width: 0;
+`;
+
+type RecordCalendarTimelineFieldsProps = {
+  recordId: string;
+};
+
+export const RecordCalendarTimelineFields = ({
+  recordId,
+}: RecordCalendarTimelineFieldsProps) => {
+  const {
+    fieldDefinitionByFieldMetadataItemId,
+    labelIdentifierFieldMetadataItem,
+  } = useRecordIndexContextOrThrow();
+  const visibleRecordFields = useAtomComponentSelectorValue(
+    visibleRecordFieldsComponentSelector,
+  );
+
+  const fieldDefinitions = visibleRecordFields
+    .filter(
+      ({ fieldMetadataItemId }) =>
+        fieldMetadataItemId !== labelIdentifierFieldMetadataItem?.id,
+    )
+    .map(
+      ({ fieldMetadataItemId }) =>
+        fieldDefinitionByFieldMetadataItemId[fieldMetadataItemId],
+    )
+    .filter(isDefined);
+
+  return (
+    <StyledFields>
+      {fieldDefinitions.map((fieldDefinition) => (
+        <StyledField key={fieldDefinition.fieldMetadataId}>
+          <FieldContext.Provider
+            value={{
+              recordId,
+              maxWidth: 156,
+              isLabelIdentifier: false,
+              isRecordFieldReadOnly: true,
+              fieldDefinition,
+              isDisplayModeFixHeight: true,
+              disableChipClick: true,
+              triggerEvent: 'CLICK',
+            }}
+          >
+            <RecordFieldComponentInstanceContext.Provider
+              value={{
+                instanceId: getRecordFieldInputInstanceId({
+                  recordId,
+                  fieldName: fieldDefinition.metadata.fieldName,
+                  prefix: RECORD_CALENDAR_TIMELINE_INPUT_ID_PREFIX,
+                }),
+              }}
+            >
+              <RecordInlineCell
+                instanceIdPrefix={RECORD_CALENDAR_TIMELINE_INPUT_ID_PREFIX}
+              />
+            </RecordFieldComponentInstanceContext.Provider>
+          </FieldContext.Provider>
+        </StyledField>
+      ))}
+    </StyledFields>
+  );
+};

--- a/packages/twenty-front/src/modules/object-record/record-calendar/timeline/components/RecordCalendarTimelineRecord.tsx
+++ b/packages/twenty-front/src/modules/object-record/record-calendar/timeline/components/RecordCalendarTimelineRecord.tsx
@@ -1,0 +1,103 @@
+import { useDateTimeFormat } from '@/localization/hooks/useDateTimeFormat';
+import { RecordChip } from '@/object-record/components/RecordChip';
+import { useRecordCalendarContextOrThrow } from '@/object-record/record-calendar/contexts/RecordCalendarContext';
+import { RecordCalendarTimelineFields } from '@/object-record/record-calendar/timeline/components/RecordCalendarTimelineFields';
+import { formatRecordCalendarWeekEventTimes } from '@/object-record/record-calendar/week/utils/formatRecordCalendarWeekEventTimes';
+import { useOpenRecordFromIndexView } from '@/object-record/record-index/hooks/useOpenRecordFromIndexView';
+import { viewableRecordIdState } from '@/object-record/record-side-panel/states/viewableRecordIdState';
+import { recordStoreFamilyState } from '@/object-record/record-store/states/recordStoreFamilyState';
+import { useAtomStateValue } from '@/ui/utilities/state/jotai/hooks/useAtomStateValue';
+import { useAtomFamilyStateValue } from '@/ui/utilities/state/jotai/hooks/useAtomFamilyStateValue';
+import { styled } from '@linaria/react';
+import { t } from '@lingui/core/macro';
+import { isDefined } from 'twenty-shared/utils';
+import { ChipVariant } from 'twenty-ui/data-display';
+import { themeCssVariables } from 'twenty-ui/theme-constants';
+import { FieldMetadataType } from '~/generated-metadata/graphql';
+
+const StyledRecord = styled.div`
+  align-items: center;
+  cursor: pointer;
+  display: flex;
+  gap: ${themeCssVariables.spacing[2]};
+  height: 24px;
+  min-width: 0;
+`;
+
+const StyledRecordContent = styled.div`
+  align-items: center;
+  border-radius: ${themeCssVariables.border.radius.sm};
+  display: flex;
+  flex: 1;
+  min-width: 0;
+  overflow: hidden;
+  padding: 0 ${themeCssVariables.spacing[1]};
+
+  &[data-focused='true'] {
+    background: ${themeCssVariables.background.secondary};
+  }
+`;
+
+const StyledTime = styled.div`
+  color: ${themeCssVariables.font.color.tertiary};
+  flex: 0 0 64px;
+  font-size: ${themeCssVariables.font.size.sm};
+  line-height: 1.4;
+`;
+
+const StyledRecordChip = styled.div`
+  flex: 0 1 auto;
+  min-width: 0;
+  overflow: hidden;
+`;
+
+type RecordCalendarTimelineRecordProps = {
+  calendarFieldName: string;
+  calendarFieldType: FieldMetadataType;
+  recordId: string;
+};
+
+export const RecordCalendarTimelineRecord = ({
+  calendarFieldName,
+  calendarFieldType,
+  recordId,
+}: RecordCalendarTimelineRecordProps) => {
+  const { objectNameSingular } = useRecordCalendarContextOrThrow();
+  const recordStore = useAtomFamilyStateValue(recordStoreFamilyState, recordId);
+  const viewableRecordId = useAtomStateValue(viewableRecordIdState);
+  const { openRecordFromIndexView } = useOpenRecordFromIndexView();
+  const { timeFormat, timeZone } = useDateTimeFormat();
+
+  if (!isDefined(recordStore)) {
+    return null;
+  }
+
+  const calendarFieldValue = recordStore[calendarFieldName];
+  const eventTimes = formatRecordCalendarWeekEventTimes({
+    startDateTime: calendarFieldValue,
+    timeFormat,
+    timeZone,
+  });
+  const time =
+    calendarFieldType === FieldMetadataType.DATE
+      ? t`All Day`
+      : (eventTimes?.startTime ?? '');
+
+  return (
+    <StyledRecord onClick={() => openRecordFromIndexView({ recordId })}>
+      <StyledTime>{time}</StyledTime>
+      <StyledRecordContent data-focused={viewableRecordId === recordId}>
+        <StyledRecordChip>
+          <RecordChip
+            objectNameSingular={objectNameSingular}
+            record={recordStore}
+            variant={ChipVariant.Transparent}
+            forceDisableClick
+            triggerEvent="CLICK"
+          />
+        </StyledRecordChip>
+        <RecordCalendarTimelineFields recordId={recordId} />
+      </StyledRecordContent>
+    </StyledRecord>
+  );
+};

--- a/packages/twenty-front/src/modules/object-record/record-calendar/timeline/constants/RecordCalendarTimelineInputIdPrefix.ts
+++ b/packages/twenty-front/src/modules/object-record/record-calendar/timeline/constants/RecordCalendarTimelineInputIdPrefix.ts
@@ -1,0 +1,2 @@
+export const RECORD_CALENDAR_TIMELINE_INPUT_ID_PREFIX =
+  'record-calendar-timeline-field';

--- a/packages/twenty-front/src/modules/object-record/record-calendar/timeline/states/recordCalendarTimelineGroupsComponentSelector.ts
+++ b/packages/twenty-front/src/modules/object-record/record-calendar/timeline/states/recordCalendarTimelineGroupsComponentSelector.ts
@@ -1,0 +1,53 @@
+import { objectMetadataItemsSelector } from '@/object-metadata/states/objectMetadataItemsSelector';
+import { RecordCalendarComponentInstanceContext } from '@/object-record/record-calendar/states/contexts/RecordCalendarComponentInstanceContext';
+import { recordCalendarRecordIdsComponentState } from '@/object-record/record-calendar/states/recordCalendarRecordIdsComponentState';
+import { recordCalendarSelectedDateComponentState } from '@/object-record/record-calendar/states/recordCalendarSelectedDateComponentState';
+import { type RecordCalendarTimelineMonthGroup } from '@/object-record/record-calendar/timeline/types/RecordCalendarTimelineGroup';
+import { getRecordCalendarTimelineGroups } from '@/object-record/record-calendar/timeline/utils/getRecordCalendarTimelineGroups';
+import { recordIndexCalendarFieldMetadataIdComponentState } from '@/object-record/record-index/states/recordIndexCalendarFieldMetadataIdComponentState';
+import { recordStoreFamilyState } from '@/object-record/record-store/states/recordStoreFamilyState';
+import { createAtomComponentFamilySelector } from '@/ui/utilities/state/jotai/utils/createAtomComponentFamilySelector';
+import { isDefined } from 'twenty-shared/utils';
+
+export const recordCalendarTimelineGroupsComponentSelector =
+  createAtomComponentFamilySelector<
+    RecordCalendarTimelineMonthGroup[],
+    { timeZone: string }
+  >({
+    key: 'recordCalendarTimelineGroupsComponentSelector',
+    componentInstanceContext: RecordCalendarComponentInstanceContext,
+    get:
+      ({ instanceId, familyKey: { timeZone } }) =>
+      ({ get }) => {
+        const calendarFieldMetadataId = get(
+          recordIndexCalendarFieldMetadataIdComponentState,
+          { instanceId },
+        );
+        const objectMetadataItems = get(objectMetadataItemsSelector);
+        const calendarFieldMetadataItem = objectMetadataItems
+          .flatMap(({ fields }) => fields)
+          .find(({ id }) => id === calendarFieldMetadataId);
+
+        if (!isDefined(calendarFieldMetadataItem)) {
+          return [];
+        }
+
+        const recordIds = get(recordCalendarRecordIdsComponentState, {
+          instanceId,
+        });
+        const records = recordIds
+          .map((recordId) => get(recordStoreFamilyState, recordId))
+          .filter(isDefined);
+        const selectedDate = get(recordCalendarSelectedDateComponentState, {
+          instanceId,
+        });
+
+        return getRecordCalendarTimelineGroups({
+          calendarFieldName: calendarFieldMetadataItem.name,
+          calendarFieldType: calendarFieldMetadataItem.type,
+          records,
+          selectedDate,
+          timeZone,
+        });
+      },
+  });

--- a/packages/twenty-front/src/modules/object-record/record-calendar/timeline/types/RecordCalendarTimelineGroup.ts
+++ b/packages/twenty-front/src/modules/object-record/record-calendar/timeline/types/RecordCalendarTimelineGroup.ts
@@ -1,0 +1,9 @@
+export type RecordCalendarTimelineDayGroup = {
+  day: string;
+  recordIds: string[];
+};
+
+export type RecordCalendarTimelineMonthGroup = {
+  month: string;
+  days: RecordCalendarTimelineDayGroup[];
+};

--- a/packages/twenty-front/src/modules/object-record/record-calendar/timeline/utils/__tests__/getRecordCalendarTimelineGroups.test.ts
+++ b/packages/twenty-front/src/modules/object-record/record-calendar/timeline/utils/__tests__/getRecordCalendarTimelineGroups.test.ts
@@ -1,0 +1,59 @@
+import { getRecordCalendarTimelineGroups } from '@/object-record/record-calendar/timeline/utils/getRecordCalendarTimelineGroups';
+import { type ObjectRecord } from '@/object-record/types/ObjectRecord';
+import { Temporal } from 'temporal-polyfill';
+import { FieldMetadataType } from '~/generated-metadata/graphql';
+
+const record = (id: string, startsAt: string): ObjectRecord =>
+  ({ __typename: 'Opportunity', id, startsAt }) as ObjectRecord;
+
+describe('getRecordCalendarTimelineGroups', () => {
+  it('sorts and groups date records across the four-month timeline range', () => {
+    const groups = getRecordCalendarTimelineGroups({
+      calendarFieldName: 'startsAt',
+      calendarFieldType: FieldMetadataType.DATE,
+      records: [
+        record('april', '2025-04-02'),
+        record('before-range', '2025-02-28'),
+        record('march', '2025-03-20'),
+        record('after-range', '2025-07-01'),
+      ],
+      selectedDate: Temporal.PlainDate.from('2025-03-15'),
+      timeZone: 'Europe/Paris',
+    });
+
+    expect(groups).toEqual([
+      {
+        month: '2025-03',
+        days: [{ day: '2025-03-20', recordIds: ['march'] }],
+      },
+      {
+        month: '2025-04',
+        days: [{ day: '2025-04-02', recordIds: ['april'] }],
+      },
+    ]);
+  });
+
+  it('groups date-time records by their day in the user time zone', () => {
+    const groups = getRecordCalendarTimelineGroups({
+      calendarFieldName: 'startsAt',
+      calendarFieldType: FieldMetadataType.DATE_TIME,
+      records: [
+        record('april-in-paris', '2025-03-31T22:30:00Z'),
+        record('march-in-paris', '2025-03-31T21:30:00Z'),
+      ],
+      selectedDate: Temporal.PlainDate.from('2025-03-15'),
+      timeZone: 'Europe/Paris',
+    });
+
+    expect(groups).toEqual([
+      {
+        month: '2025-03',
+        days: [{ day: '2025-03-31', recordIds: ['march-in-paris'] }],
+      },
+      {
+        month: '2025-04',
+        days: [{ day: '2025-04-01', recordIds: ['april-in-paris'] }],
+      },
+    ]);
+  });
+});

--- a/packages/twenty-front/src/modules/object-record/record-calendar/timeline/utils/getRecordCalendarTimelineGroups.ts
+++ b/packages/twenty-front/src/modules/object-record/record-calendar/timeline/utils/getRecordCalendarTimelineGroups.ts
@@ -1,0 +1,110 @@
+import { type ObjectRecord } from '@/object-record/types/ObjectRecord';
+import {
+  type RecordCalendarTimelineDayGroup,
+  type RecordCalendarTimelineMonthGroup,
+} from '@/object-record/record-calendar/timeline/types/RecordCalendarTimelineGroup';
+import { Temporal } from 'temporal-polyfill';
+import { FieldMetadataType } from '~/generated-metadata/graphql';
+
+type GetRecordCalendarTimelineGroupsArgs = {
+  calendarFieldName: string;
+  calendarFieldType: FieldMetadataType;
+  records: ObjectRecord[];
+  selectedDate: Temporal.PlainDate;
+  timeZone: string;
+};
+
+type TimelineRecord = {
+  day: Temporal.PlainDate;
+  recordId: string;
+  sortValue: number;
+};
+
+const getTimelineRecord = ({
+  calendarFieldName,
+  calendarFieldType,
+  record,
+  timeZone,
+}: Pick<
+  GetRecordCalendarTimelineGroupsArgs,
+  'calendarFieldName' | 'calendarFieldType' | 'timeZone'
+> & {
+  record: ObjectRecord;
+}): TimelineRecord | null => {
+  const fieldValue = record[calendarFieldName];
+
+  if (typeof fieldValue !== 'string') {
+    return null;
+  }
+
+  try {
+    if (calendarFieldType === FieldMetadataType.DATE) {
+      const day = Temporal.PlainDate.from(fieldValue);
+
+      return {
+        day,
+        recordId: record.id,
+        sortValue: day.toZonedDateTime('UTC').epochMilliseconds,
+      };
+    }
+
+    const instant = Temporal.Instant.from(fieldValue);
+
+    return {
+      day: instant.toZonedDateTimeISO(timeZone).toPlainDate(),
+      recordId: record.id,
+      sortValue: instant.epochMilliseconds,
+    };
+  } catch {
+    return null;
+  }
+};
+
+export const getRecordCalendarTimelineGroups = ({
+  calendarFieldName,
+  calendarFieldType,
+  records,
+  selectedDate,
+  timeZone,
+}: GetRecordCalendarTimelineGroupsArgs): RecordCalendarTimelineMonthGroup[] => {
+  const firstDayOfRange = selectedDate.with({ day: 1 });
+  const firstDayAfterRange = firstDayOfRange.add({ months: 4 });
+
+  const timelineRecords = records
+    .map((record) =>
+      getTimelineRecord({
+        calendarFieldName,
+        calendarFieldType,
+        record,
+        timeZone,
+      }),
+    )
+    .filter((record): record is TimelineRecord => record !== null)
+    .filter(
+      ({ day }) =>
+        Temporal.PlainDate.compare(day, firstDayOfRange) >= 0 &&
+        Temporal.PlainDate.compare(day, firstDayAfterRange) < 0,
+    )
+    .sort((recordA, recordB) => recordA.sortValue - recordB.sortValue);
+
+  const monthGroups = new Map<
+    string,
+    Map<string, RecordCalendarTimelineDayGroup>
+  >();
+
+  for (const timelineRecord of timelineRecords) {
+    const month = timelineRecord.day.toPlainYearMonth().toString();
+    const day = timelineRecord.day.toString();
+    const dayGroups = monthGroups.get(month) ?? new Map();
+    const dayGroup = dayGroups.get(day) ?? { day, recordIds: [] };
+
+    dayGroup.recordIds.push(timelineRecord.recordId);
+    dayGroups.set(day, dayGroup);
+    monthGroups.set(month, dayGroups);
+  }
+
+  return Array.from(monthGroups, ([month, dayGroups]) => ({
+    month,
+    days: Array.from(dayGroups.values()),
+  }));
+};

--- a/packages/twenty-front/src/modules/object-record/record-calendar/utils/__tests__/getSupportedRecordCalendarLayout.test.ts
+++ b/packages/twenty-front/src/modules/object-record/record-calendar/utils/__tests__/getSupportedRecordCalendarLayout.test.ts
@@ -6,6 +6,7 @@ describe('getSupportedRecordCalendarLayout', () => {
     [ViewCalendarLayout.WEEK, ViewCalendarLayout.WEEK],
     [ViewCalendarLayout.MONTH, ViewCalendarLayout.MONTH],
     [ViewCalendarLayout.DAY, ViewCalendarLayout.DAY],
+    [ViewCalendarLayout.TIMELINE, ViewCalendarLayout.TIMELINE],
     [null, ViewCalendarLayout.MONTH],
     [undefined, ViewCalendarLayout.MONTH],
   ])(
@@ -24,6 +25,7 @@ describe('getSupportedRecordCalendarLayout', () => {
     ViewCalendarLayout.WEEK,
     ViewCalendarLayout.MONTH,
     ViewCalendarLayout.DAY,
+    ViewCalendarLayout.TIMELINE,
     null,
     undefined,
   ])(

--- a/packages/twenty-front/src/modules/object-record/record-calendar/utils/getSupportedRecordCalendarLayout.ts
+++ b/packages/twenty-front/src/modules/object-record/record-calendar/utils/getSupportedRecordCalendarLayout.ts
@@ -9,11 +9,12 @@ export const getSupportedRecordCalendarLayout = ({
   calendarLayout,
   isCalendarWeekViewEnabled,
 }: GetSupportedRecordCalendarLayoutArgs) => {
-  const isTimeGridLayout =
+  const isExperimentalLayout =
     calendarLayout === ViewCalendarLayout.DAY ||
-    calendarLayout === ViewCalendarLayout.WEEK;
+    calendarLayout === ViewCalendarLayout.WEEK ||
+    calendarLayout === ViewCalendarLayout.TIMELINE;
 
-  return isCalendarWeekViewEnabled && isTimeGridLayout
+  return isCalendarWeekViewEnabled && isExperimentalLayout
     ? calendarLayout
     : ViewCalendarLayout.MONTH;
 };

--- a/packages/twenty-server/src/database/commands/upgrade-version-command/2-26/2-26-instance-command-fast-1785516963000-add-calendar-timeline-layout.ts
+++ b/packages/twenty-server/src/database/commands/upgrade-version-command/2-26/2-26-instance-command-fast-1785516963000-add-calendar-timeline-layout.ts
@@ -1,0 +1,33 @@
+import { type QueryRunner } from 'typeorm';
+
+import { RegisteredInstanceCommand } from 'src/engine/core-modules/upgrade/decorators/registered-instance-command.decorator';
+import { type FastInstanceCommand } from 'src/engine/core-modules/upgrade/interfaces/fast-instance-command.interface';
+
+@RegisteredInstanceCommand('2.26.0', 1785516963000)
+export class AddCalendarTimelineLayoutFastInstanceCommand
+  implements FastInstanceCommand
+{
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TYPE "core"."view_calendarlayout_enum" ADD VALUE IF NOT EXISTS 'TIMELINE' AFTER 'MONTH'`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `UPDATE "core"."view" SET "calendarLayout" = 'MONTH' WHERE "calendarLayout" = 'TIMELINE'`,
+    );
+    await queryRunner.query(
+      `ALTER TYPE "core"."view_calendarlayout_enum" RENAME TO "view_calendarlayout_enum_old"`,
+    );
+    await queryRunner.query(
+      `CREATE TYPE "core"."view_calendarlayout_enum" AS ENUM('DAY', 'WEEK', 'MONTH')`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "core"."view" ALTER COLUMN "calendarLayout" TYPE "core"."view_calendarlayout_enum" USING "calendarLayout"::"text"::"core"."view_calendarlayout_enum"`,
+    );
+    await queryRunner.query(
+      `DROP TYPE "core"."view_calendarlayout_enum_old"`,
+    );
+  }
+}

--- a/packages/twenty-server/src/database/commands/upgrade-version-command/instance-commands.constant.ts
+++ b/packages/twenty-server/src/database/commands/upgrade-version-command/instance-commands.constant.ts
@@ -131,6 +131,7 @@ import { AddPageLayoutCascadeDeleteIndexesFastInstanceCommand } from './2-25/2-2
 import { AddChannelWebhookSubscriptionExternalIdIndexesFastInstanceCommand } from 'src/database/commands/upgrade-version-command/2-25/2-25-instance-command-fast-1785173910915-add-channel-webhook-subscription-external-id-indexes';
 import { AddIsHiddenToAgentMessageFastInstanceCommand } from './2-25/2-25-instance-command-fast-1785230296000-add-is-hidden-to-agent-message';
 import { AddConnectedAccountHandleProviderIndexFastInstanceCommand } from 'src/database/commands/upgrade-version-command/2-26/2-26-instance-command-fast-1785420705255-add-connected-account-handle-provider-index';
+import { AddCalendarTimelineLayoutFastInstanceCommand } from 'src/database/commands/upgrade-version-command/2-26/2-26-instance-command-fast-1785516963000-add-calendar-timeline-layout';
 import { AddOpenRecordInToObjectMetadataFastInstanceCommand } from 'src/database/commands/upgrade-version-command/2-27/2-27-instance-command-fast-1785504900000-add-open-record-in-to-object-metadata';
 
 export const INSTANCE_COMMANDS = [
@@ -265,5 +266,6 @@ export const INSTANCE_COMMANDS = [
   AddChannelWebhookSubscriptionExternalIdIndexesFastInstanceCommand,
   AddIsHiddenToAgentMessageFastInstanceCommand,
   AddConnectedAccountHandleProviderIndexFastInstanceCommand,
+  AddCalendarTimelineLayoutFastInstanceCommand,
   AddOpenRecordInToObjectMetadataFastInstanceCommand,
 ];

--- a/packages/twenty-server/src/engine/metadata-modules/view/tools/view-tools.factory.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/view/tools/view-tools.factory.ts
@@ -107,10 +107,11 @@ const CreateViewInputSchema = z.object({
       ViewCalendarLayout.DAY,
       ViewCalendarLayout.WEEK,
       ViewCalendarLayout.MONTH,
+      ViewCalendarLayout.TIMELINE,
     ])
     .optional()
     .describe(
-      'Calendar layout (required for CALENDAR views, e.g., "DAY", "WEEK", "MONTH")',
+      'Calendar layout (required for CALENDAR views, e.g., "DAY", "WEEK", "MONTH", "TIMELINE")',
     ),
   calendarFieldName: z
     .string()
@@ -254,6 +255,7 @@ const UpsertCompleteViewInputSchema = z.object({
       ViewCalendarLayout.DAY,
       ViewCalendarLayout.WEEK,
       ViewCalendarLayout.MONTH,
+      ViewCalendarLayout.TIMELINE,
     ])
     .optional()
     .describe('Calendar layout (required for CALENDAR).'),
@@ -542,7 +544,7 @@ export class ViewToolsFactory {
 
       if (!isDefined(parameters.calendarLayout)) {
         throw new Error(
-          'CALENDAR views require calendarLayout. Provide one of: "DAY", "WEEK", "MONTH".',
+          'CALENDAR views require calendarLayout. Provide one of: "DAY", "WEEK", "MONTH", "TIMELINE".',
         );
       }
     }
@@ -836,7 +838,7 @@ VIEW TYPES: TABLE (default), KANBAN (requires mainGroupByFieldName, a SELECT fie
 
               if (!parameters.calendarLayout) {
                 throw new Error(
-                  'CALENDAR views require calendarLayout. Provide one of: "DAY", "WEEK", "MONTH".',
+                  'CALENDAR views require calendarLayout. Provide one of: "DAY", "WEEK", "MONTH", "TIMELINE".',
                 );
               }
             }

--- a/packages/twenty-server/src/engine/workspace-manager/twenty-standard-application/utils/skill-metadata/create-standard-flat-skill-metadata.util.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/twenty-standard-application/utils/skill-metadata/create-standard-flat-skill-metadata.util.ts
@@ -382,7 +382,7 @@ STEP 8: For each new custom object, repeat ALL of the following sub-steps before
     - If the object has a SELECT field (e.g. status, stage, priority, type), create a **KANBAN** view grouped by that SELECT field with a relevant name like "By Status", "Pipeline", "By Priority".
       - Set kanbanAggregateOperation to COUNT so each column shows the number of records.
       - If there is a CURRENCY or NUMERIC field, also set kanbanAggregateOperationFieldName to that field for a SUM aggregate view.
-    - If the object has a DATE or DATE_TIME field (e.g. dueDate, closedAt, scheduledAt), create a **CALENDAR** view and pass both \`calendarFieldName\` (that field name) and \`calendarLayout\` ("DAY", "WEEK", or "MONTH") with a relevant name like "Calendar", "Schedule", "Timeline".
+    - If the object has a DATE or DATE_TIME field (e.g. dueDate, closedAt, scheduledAt), create a **CALENDAR** view and pass both \`calendarFieldName\` (that field name) and \`calendarLayout\` ("DAY", "WEEK", "MONTH", or "TIMELINE") with a relevant name like "Calendar", "Schedule", "Timeline".
     - Create a **TABLE** view with a meaningful group (mainGroupByFieldName set to a SELECT field) with a name like "By Type", "By Stage", "Grouped", or similar.
   - Use create_many_view_fields to add all relevant field columns to this view (using decimal positions between 0 and 1)
   - Add filters and sorts to this view:
@@ -1338,7 +1338,7 @@ Example: { "objectNameSingular": "opportunity", "type": "KANBAN", "name": "Pipel
 
 3. **Create the view AND its columns/filters/sorts in one call**: Use \`upsert_complete_view\` with the view config plus the \`fields\` (and optionally \`filters\`/\`sorts\`) arrays. Reference fields by name.
    - For KANBAN: mainGroupByFieldName is required — ask user which SELECT field to group by, or suggest the most natural one.
-   - For CALENDAR: provide both \`calendarFieldName\` (a DATE/DATE_TIME field name) and \`calendarLayout\` ("DAY", "WEEK", or "MONTH").
+   - For CALENDAR: provide both \`calendarFieldName\` (a DATE/DATE_TIME field name) and \`calendarLayout\` ("DAY", "WEEK", "MONTH", or "TIMELINE").
    - For TABLE: No special configuration needed beyond the fields list.
 
 4. **Navigate**: Use navigate_app to show the user their new view.

--- a/packages/twenty-shared/src/types/ViewCalendarLayout.ts
+++ b/packages/twenty-shared/src/types/ViewCalendarLayout.ts
@@ -2,4 +2,5 @@ export enum ViewCalendarLayout {
   DAY = 'DAY',
   WEEK = 'WEEK',
   MONTH = 'MONTH',
+  TIMELINE = 'TIMELINE',
 }


### PR DESCRIPTION
## Summary

- Add timeline as a supported calendar layout across metadata, view configuration, and upgrade commands
- Implement timeline rendering with grouped records, fields, and input state
- Update calendar layout selection and shared calendar behavior for timeline views
- Extend coverage for layout support, timeline grouping, calendar navigation, and event positioning

Note: Missing a design when there is no event at all, currently the page is white. To solve before merging.
Also probably need to add a feature flag for that layout.

<img width="1283" height="849" alt="Screenshot 2026-07-31 at 19 48 35" src="https://github.com/user-attachments/assets/ecea6d61-ed83-4810-b9ec-5a22e37c0ebc" />