### PR TITLE
Remove outdated index view pitfall from app agent docs

### DIFF
--- a/packages/create-twenty-app/src/constants/template/AGENTS.md
+++ b/packages/create-twenty-app/src/constants/template/AGENTS.md
@@ -43,7 +43,6 @@
 
 ## Common Pitfalls
 
-- Creating an object without an index view associated. Unless this is a technical object, user will need to visualize it.
 - Creating a view without a navigationMenuItem associated. This will make the view available on the left sidebar.
 - Creating a front-end component that has a scroll instead of being responsive to its fixed widget height and width, unless it is specifically meant to be used in a canvas tab.
 

--- a/packages/twenty-apps/examples/hello-world/LLMS.md
+++ b/packages/twenty-apps/examples/hello-world/LLMS.md
@@ -9,6 +9,5 @@
 
 ## Common Pitfalls
 
-- Creating an object without an index view associated. Unless this is a technical object, user will need to visualize it.
 - Creating a view without a navigationMenuItem associated. This will make the view available on the left sidebar.
 - Creating a front-end component that has a scroll instead of being responsive to its fixed widget height and width, unless it is specifically meant to be used in a canvas tab.

--- a/packages/twenty-apps/examples/postcard/AGENT.md
+++ b/packages/twenty-apps/examples/postcard/AGENT.md
@@ -9,6 +9,5 @@
 
 ## Common Pitfalls
 
-- Creating an object without an index view associated. Unless this is a technical object, user will need to visualize it.
 - Creating a view without a navigationMenuItem associated. This will make the view available on the left sidebar.
 - Creating a front-end component that has a scroll instead of being responsive to its fixed widget height and width, unless it is specifically meant to be used in a canvas tab.

--- a/packages/twenty-apps/examples/postcard/CLAUDE.md
+++ b/packages/twenty-apps/examples/postcard/CLAUDE.md
@@ -9,6 +9,5 @@
 
 ## Common Pitfalls
 
-- Creating an object without an index view associated. Unless this is a technical object, user will need to visualize it.
 - Creating a view without a navigationMenuItem associated. This will make the view available on the left sidebar.
 - Creating a front-end component that has a scroll instead of being responsive to its fixed widget height and width, unless it is specifically meant to be used in a canvas tab.

--- a/packages/twenty-apps/examples/postcard/LLMS.md
+++ b/packages/twenty-apps/examples/postcard/LLMS.md
@@ -9,6 +9,5 @@
 
 ## Common Pitfalls
 
-- Creating an object without an index view associated. Unless this is a technical object, user will need to visualize it.
 - Creating a view without a navigationMenuItem associated. This will make the view available on the left sidebar.
 - Creating a front-end component that has a scroll instead of being responsive to its fixed widget height and width, unless it is specifically meant to be used in a canvas tab.

--- a/packages/twenty-apps/internal/self-hosting/AGENT.md
+++ b/packages/twenty-apps/internal/self-hosting/AGENT.md
@@ -9,6 +9,5 @@
 
 ## Common Pitfalls
 
-- Creating an object without an index view associated. Unless this is a technical object, user will need to visualize it.
 - Creating a view without a navigationMenuItem associated. This will make the view available on the left sidebar.
 - Creating a front-end component that has a scroll instead of being responsive to its fixed widget height and width, unless it is specifically meant to be used in a canvas tab.

--- a/packages/twenty-apps/internal/self-hosting/CLAUDE.md
+++ b/packages/twenty-apps/internal/self-hosting/CLAUDE.md
@@ -9,6 +9,5 @@
 
 ## Common Pitfalls
 
-- Creating an object without an index view associated. Unless this is a technical object, user will need to visualize it.
 - Creating a view without a navigationMenuItem associated. This will make the view available on the left sidebar.
 - Creating a front-end component that has a scroll instead of being responsive to its fixed widget height and width, unless it is specifically meant to be used in a canvas tab.

--- a/packages/twenty-apps/internal/self-hosting/LLMS.md
+++ b/packages/twenty-apps/internal/self-hosting/LLMS.md
@@ -9,6 +9,5 @@
 
 ## Common Pitfalls
 
-- Creating an object without an index view associated. Unless this is a technical object, user will need to visualize it.
 - Creating a view without a navigationMenuItem associated. This will make the view available on the left sidebar.
 - Creating a front-end component that has a scroll instead of being responsive to its fixed widget height and width, unless it is specifically meant to be used in a canvas tab.

--- a/packages/twenty-apps/public/call-recorder/AGENTS.md
+++ b/packages/twenty-apps/public/call-recorder/AGENTS.md
@@ -43,7 +43,6 @@
 
 ## Common Pitfalls
 
-- Creating an object without an index view associated. Unless this is a technical object, user will need to visualize it.
 - Creating a view without a navigationMenuItem associated. This will make the view unavailable on the left sidebar.
 - Creating a front-end component that has a scroll instead of being responsive to its fixed widget height and width, unless it is specifically meant to be used in a canvas tab.
 

--- a/packages/twenty-apps/public/call-recorder/CLAUDE.md
+++ b/packages/twenty-apps/public/call-recorder/CLAUDE.md
@@ -43,7 +43,6 @@
 
 ## Common Pitfalls
 
-- Creating an object without an index view associated. Unless this is a technical object, user will need to visualize it.
 - Creating a view without a navigationMenuItem associated. This will make the view unavailable on the left sidebar.
 - Creating a front-end component that has a scroll instead of being responsive to its fixed widget height and width, unless it is specifically meant to be used in a canvas tab.
 

--- a/packages/twenty-apps/public/last-contact/AGENTS.md
+++ b/packages/twenty-apps/public/last-contact/AGENTS.md
@@ -43,7 +43,6 @@
 
 ## Common Pitfalls
 
-- Creating an object without an index view associated. Unless this is a technical object, user will need to visualize it.
 - Creating a view without a navigationMenuItem associated. This will make the view available on the left sidebar.
 - Creating a front-end component that has a scroll instead of being responsive to its fixed widget height and width, unless it is specifically meant to be used in a canvas tab.
 

--- a/packages/twenty-apps/public/last-contact/CLAUDE.md
+++ b/packages/twenty-apps/public/last-contact/CLAUDE.md
@@ -43,7 +43,6 @@
 
 ## Common Pitfalls
 
-- Creating an object without an index view associated. Unless this is a technical object, user will need to visualize it.
 - Creating a view without a navigationMenuItem associated. This will make the view available on the left sidebar.
 - Creating a front-end component that has a scroll instead of being responsive to its fixed widget height and width, unless it is specifically meant to be used in a canvas tab.
 

--- a/packages/twenty-apps/public/linear/AGENT.md
+++ b/packages/twenty-apps/public/linear/AGENT.md
@@ -9,6 +9,5 @@
 
 ## Common Pitfalls
 
-- Creating an object without an index view associated. Unless this is a technical object, user will need to visualize it.
 - Creating a view without a navigationMenuItem associated. This will make the view available on the left sidebar.
 - Creating a front-end component that has a scroll instead of being responsive to its fixed widget height and width, unless it is specifically meant to be used in a canvas tab.

--- a/packages/twenty-apps/public/linear/CLAUDE.md
+++ b/packages/twenty-apps/public/linear/CLAUDE.md
@@ -9,6 +9,5 @@
 
 ## Common Pitfalls
 
-- Creating an object without an index view associated. Unless this is a technical object, user will need to visualize it.
 - Creating a view without a navigationMenuItem associated. This will make the view available on the left sidebar.
 - Creating a front-end component that has a scroll instead of being responsive to its fixed widget height and width, unless it is specifically meant to be used in a canvas tab.

--- a/packages/twenty-apps/public/linear/LLMS.md
+++ b/packages/twenty-apps/public/linear/LLMS.md
@@ -9,6 +9,5 @@
 
 ## Common Pitfalls
 
-- Creating an object without an index view associated. Unless this is a technical object, user will need to visualize it.
 - Creating a view without a navigationMenuItem associated. This will make the view available on the left sidebar.
 - Creating a front-end component that has a scroll instead of being responsive to its fixed widget height and width, unless it is specifically meant to be used in a canvas tab.

--- a/packages/twenty-docs/developers/extend/apps/data/objects.mdx
+++ b/packages/twenty-docs/developers/extend/apps/data/objects.mdx
@@ -139,4 +139,4 @@ Changes to `isNullable` are applied on every sync, including syncs that update a
 
 - **Connect this object to others** — see [Relations](/developers/extend/apps/data/relations) for the bidirectional relation pattern.
 - **Add fields to objects from other apps** — see [Extending Objects](/developers/extend/apps/data/extending-objects) for `defineField()`.
-- **Display this object in the UI** — see [Views](/developers/extend/apps/layout/views) and [Navigation Menu Items](/developers/extend/apps/layout/navigation-menu-items) to put it in the sidebar.
+- **Display this object in the UI** — see [Navigation Menu Items](/developers/extend/apps/layout/navigation-menu-items) to add a sidebar entry; see [Views](/developers/extend/apps/layout/views) to add custom list configurations.

--- a/packages/twenty-docs/developers/extend/apps/layout/navigation-menu-items.mdx
+++ b/packages/twenty-docs/developers/extend/apps/layout/navigation-menu-items.mdx
@@ -39,5 +39,5 @@ export default defineNavigationMenuItem({
 - `folderUniversalIdentifier` is also available on any item to nest it inside a `FOLDER`-type parent.
 
 <Note>
-**Common pitfall:** creating an object without an associated view + navigation menu item makes that object invisible to users. Unless it's a technical/internal object, every custom object should have a default view *and* a sidebar entry pointing at it.
+**Common pitfall:** creating an object without an associated navigation menu item makes that object unreachable from the sidebar. Unless it's a technical/internal object, every custom object should have a sidebar entry pointing at it.
 </Note>

--- a/packages/twenty-docs/developers/extend/apps/layout/views.mdx
+++ b/packages/twenty-docs/developers/extend/apps/layout/views.mdx
@@ -110,4 +110,4 @@ The `value` field is always a JSON-serializable value, but its expected shape de
 
 ## How views show up in the UI
 
-A view by itself isn't reachable from the sidebar. To make it appear there, pair it with a [navigation menu item](/developers/extend/apps/layout/navigation-menu-items) of type `VIEW` that points at the view's `universalIdentifier`. That's the canonical pattern: every custom object typically ships a default view + a sidebar entry that opens it.
+A view by itself isn't reachable from the sidebar. To make it appear there, pair it with a [navigation menu item](/developers/extend/apps/layout/navigation-menu-items) of type `VIEW` that points at the view's `universalIdentifier`. That's the canonical pattern: every custom object gets a default index view auto-generated at creation, so you only need to ship the sidebar entry that opens it.


### PR DESCRIPTION
## Context

Index views are now auto-generated by a metadata side effect when an object is created, so the "Common Pitfalls" entry warning against creating an object without an associated index view is obsolete.

## What changed

Removed the line "Creating an object without an index view associated. Unless this is a technical object, user will need to visualize it." from:

- the `create-twenty-app` template (`packages/create-twenty-app/src/constants/template/AGENTS.md`), used for newly scaffolded apps
- the 14 existing copies across `packages/twenty-apps` (`AGENT.md` / `AGENTS.md` / `CLAUDE.md` / `LLMS.md` in `examples`, `public`, and `internal` apps)

The other pitfalls (navigationMenuItem, front-component scroll) are unchanged since they still apply.

---
_Generated by [Claude Code](https://claude.ai/code/session_01YYzo4dY3V7QXdDZtvk5FwY)_

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/23667?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

