### PR TITLE
ci(claude): drop arbitrary curl from the @claude agent's tool allowlist

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -85,7 +85,7 @@ jobs:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           additional_permissions: |
             actions: read
-          claude_args: '--max-turns 200 --model opus --allowedTools "Edit,Write,WebFetch,Bash(bash packages/twenty-utils/setup-dev-env.sh),Bash(npx nx *),Bash(npx jest *),Bash(yarn *),Bash(git *),Bash(gh *),Bash(sed *),Bash(python3 *),Bash(rm *),Bash(find *),Bash(grep *),Bash(cat *),Bash(ls *),Bash(head *),Bash(tail *),Bash(wc *),Bash(sort *),Bash(uniq *),Bash(mkdir *),Bash(cp *),Bash(mv *),Bash(touch *),Bash(chmod *),Bash(echo *),Bash(curl *),Bash(cd *),Bash(pwd *),Bash(diff *),Bash(xargs *),Bash(awk *),Bash(cut *),Bash(tee *),Bash(tr *)"'
+          claude_args: '--max-turns 200 --model opus --allowedTools "Edit,Write,WebFetch,Bash(bash packages/twenty-utils/setup-dev-env.sh),Bash(npx nx *),Bash(npx jest *),Bash(yarn *),Bash(git *),Bash(gh *),Bash(sed *),Bash(python3 *),Bash(rm *),Bash(find *),Bash(grep *),Bash(cat *),Bash(ls *),Bash(head *),Bash(tail *),Bash(wc *),Bash(sort *),Bash(uniq *),Bash(mkdir *),Bash(cp *),Bash(mv *),Bash(touch *),Bash(chmod *),Bash(echo *),Bash(cd *),Bash(pwd *),Bash(diff *),Bash(xargs *),Bash(awk *),Bash(cut *),Bash(tee *),Bash(tr *)"'
           settings: |
             {
               "env": {
@@ -176,7 +176,7 @@ jobs:
           prompt: ${{ steps.prompt.outputs.prompt }}
           additional_permissions: |
             actions: read
-          claude_args: '--max-turns 200 --model opus --allowedTools "Edit,Write,WebFetch,Bash(bash packages/twenty-utils/setup-dev-env.sh),Bash(npx nx *),Bash(npx jest *),Bash(yarn *),Bash(git *),Bash(gh *),Bash(sed *),Bash(python3 *),Bash(rm *),Bash(find *),Bash(grep *),Bash(cat *),Bash(ls *),Bash(head *),Bash(tail *),Bash(wc *),Bash(sort *),Bash(uniq *),Bash(mkdir *),Bash(cp *),Bash(mv *),Bash(touch *),Bash(chmod *),Bash(echo *),Bash(curl *),Bash(cd *),Bash(pwd *),Bash(diff *),Bash(xargs *),Bash(awk *),Bash(cut *),Bash(tee *),Bash(tr *)"'
+          claude_args: '--max-turns 200 --model opus --allowedTools "Edit,Write,WebFetch,Bash(bash packages/twenty-utils/setup-dev-env.sh),Bash(npx nx *),Bash(npx jest *),Bash(yarn *),Bash(git *),Bash(gh *),Bash(sed *),Bash(python3 *),Bash(rm *),Bash(find *),Bash(grep *),Bash(cat *),Bash(ls *),Bash(head *),Bash(tail *),Bash(wc *),Bash(sort *),Bash(uniq *),Bash(mkdir *),Bash(cp *),Bash(mv *),Bash(touch *),Bash(chmod *),Bash(echo *),Bash(cd *),Bash(pwd *),Bash(diff *),Bash(xargs *),Bash(awk *),Bash(cut *),Bash(tee *),Bash(tr *)"'
           settings: |
             {
               "env": {


### PR DESCRIPTION
## What

Remove `Bash(curl *)` from the `--allowedTools` list in `claude.yml`, in both the issue/PR-triggered `claude` job and the `claude-cross-repo` dispatch job.

## Why

The `@claude` agent runs with `contents`, `pull-requests`, and `issues` write, `id-token: write`, and repo secrets, and it routinely reads untrusted content — e.g. when a maintainer asks it to review or act on an external fork PR, the diff/body it reads is attacker-authored. `Bash(curl *)` hands that agent an unrestricted outbound-HTTP capability, which is a clean data-exfiltration channel if the untrusted content ever succeeds at an indirect prompt injection. It's least-privilege hygiene: the agent shouldn't hold a general "make any HTTP request" tool it doesn't need.

## Why it's safe to remove

- `WebFetch` stays in the allowlist, so controlled URL reads still work.
- The dev-env setup keeps its network access: it runs via the separate `Bash(bash packages/twenty-utils/setup-dev-env.sh)` allowlist entry, and the allowlist only governs what the agent invokes *directly* — any `curl` *inside* that script runs as a subprocess of an already-allowed command and is unaffected.
- No other allowlisted step (`nx`, `jest`, `yarn`, `git`, `gh`, …) depends on the agent calling `curl` itself.

Net: the agent loses only the ability to make arbitrary direct HTTP requests.

## Context

Came out of a review of the org's GitHub Actions AI workflows against the "PromptPwnd" prompt-injection pattern (untrusted input → AI prompt → privileged tools). This closes the widest outbound-exfiltration path on the most privileged agent; the workflow's author-association trigger gate is unchanged and remains the primary control.