### PR TITLE
feat(ai): add Atlas Cloud provider

### DIFF
--- a/packages/twenty-server/.env.example
+++ b/packages/twenty-server/.env.example
@@ -96,6 +96,7 @@ FRONTEND_URL=http://localhost:3001
 # ———————— AI ————————
 # API keys for built-in providers (also editable from Admin Panel > Config Variables):
 # OPENAI_API_KEY=
+# ATLASCLOUD_API_KEY=
 # ANTHROPIC_API_KEY=
 # GOOGLE_API_KEY=
 # XAI_API_KEY=

--- a/packages/twenty-server/src/engine/core-modules/twenty-config/config-variables.ts
+++ b/packages/twenty-server/src/engine/core-modules/twenty-config/config-variables.ts
@@ -1682,6 +1682,15 @@ export class ConfigVariables {
   @ConfigVariablesMetadata({
     group: ConfigVariablesGroup.LLM,
     isSensitive: true,
+    description: 'API key for Atlas Cloud models',
+    type: ConfigVariableType.STRING,
+  })
+  @IsOptional()
+  ATLASCLOUD_API_KEY?: string;
+
+  @ConfigVariablesMetadata({
+    group: ConfigVariablesGroup.LLM,
+    isSensitive: true,
     description: 'API key for Anthropic models (Claude)',
     type: ConfigVariableType.STRING,
   })

--- a/packages/twenty-server/src/engine/metadata-modules/ai/ai-models/__tests__/ai-providers-json.spec.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/ai/ai-models/__tests__/ai-providers-json.spec.ts
@@ -7,6 +7,7 @@ import { normalizeAiProviders } from 'src/engine/metadata-modules/ai/ai-models/u
 const PROVIDERS = normalizeAiProviders(defaultAiProviders as AiProvidersConfig);
 
 const EXPECTED_PROVIDER_NAMES = [
+  'atlascloud',
   'openai',
   'anthropic',
   'google',
@@ -79,5 +80,16 @@ describe('ai-providers.json integrity', () => {
       expect(config.npm).toBeDefined();
       expect(config.npm).toMatch(/^@ai-sdk\//);
     });
+  });
+
+  it('should configure Atlas Cloud as an OpenAI-compatible provider', () => {
+    const atlasCloud = PROVIDERS.atlascloud;
+
+    expect(atlasCloud?.npm).toBe('@ai-sdk/openai-compatible');
+    expect(atlasCloud?.baseUrl).toBe('https://api.atlascloud.ai/v1');
+    expect(atlasCloud?.apiKey).toBe('{{ATLASCLOUD_API_KEY}}');
+    expect(atlasCloud?.models?.map(({ name }) => name)).toContain(
+      'deepseek-ai/deepseek-v4-pro',
+    );
   });
 });

--- a/packages/twenty-server/src/engine/metadata-modules/ai/ai-models/ai-providers.json
+++ b/packages/twenty-server/src/engine/metadata-modules/ai/ai-models/ai-providers.json
@@ -1,4 +1,21 @@
 {
+  "atlascloud": {
+    "npm": "@ai-sdk/openai-compatible",
+    "label": "Atlas Cloud",
+    "baseUrl": "https://api.atlascloud.ai/v1",
+    "apiKey": "{{ATLASCLOUD_API_KEY}}",
+    "models": [
+      {
+        "name": "deepseek-ai/deepseek-v4-pro",
+        "label": "DeepSeek V4 Pro",
+        "inputCostPerMillionTokens": 1.68,
+        "outputCostPerMillionTokens": 3.38,
+        "cachedInputCostPerMillionTokens": 0.13,
+        "contextWindowTokens": 1048576,
+        "maxOutputTokens": 393216
+      }
+    ]
+  },
   "openai": {
     "npm": "@ai-sdk/openai",
     "label": "OpenAI",


### PR DESCRIPTION
## Summary

- add Atlas Cloud to the built-in AI provider catalog through the existing OpenAI-compatible SDK path
- expose `ATLASCLOUD_API_KEY` as a sensitive LLM configuration variable and document it in the server environment example
- register `deepseek-ai/deepseek-v4-pro` with context, output, cache, and pricing metadata from the Atlas Cloud model catalog
- extend catalog integrity coverage for the provider endpoint, credential template, and default model

## Validation

- `ai-providers-json.spec.ts`: 8 passed
- Prettier check for changed JSON and TypeScript files
- TypeScript syntax transpilation for changed TypeScript files
- live Atlas Cloud catalog metadata comparison
- live Chat Completions forced tool call via `@ai-sdk/openai-compatible`: HTTP 200, `get_weather` tool call returned

Full Nx typecheck was not run because the local focused install did not include all prebuilt workspace declaration packages.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/23679?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

