### PR TITLE
docs: add Zenith Hosting deploy option

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,10 @@ See the [app development guide](https://docs.twenty.com/developers/extend/apps/g
 
 Run Twenty on your own infrastructure with [Docker Compose](https://docs.twenty.com/developers/self-host/capabilities/docker-compose), or contribute locally via the [local setup guide](https://docs.twenty.com/developers/contribute/capabilities/local-setup).
 
+[![Deploy with Zenith](https://cdn.zenith.hosting/buttons/deploy-with-zenith.svg)](https://zenith.hosting/host/twenty)
+
+One-click managed Twenty, with no infrastructure to run: storage, backups, email and a free subdomain included. A share of every subscription goes back to Twenty.
+
 <br />
 <br />
 

--- a/README.md
+++ b/README.md
@@ -72,9 +72,11 @@ See the [app development guide](https://docs.twenty.com/developers/extend/apps/g
 
 Run Twenty on your own infrastructure with [Docker Compose](https://docs.twenty.com/developers/self-host/capabilities/docker-compose), or contribute locally via the [local setup guide](https://docs.twenty.com/developers/contribute/capabilities/local-setup).
 
-[![Deploy with Zenith](https://cdn.zenith.hosting/buttons/deploy-with-zenith.svg)](https://zenith.hosting/host/twenty)
+### Managed hosting (third-party)
 
-One-click managed Twenty, with no infrastructure to run: storage, backups, email and a free subdomain included. A share of every subscription goes back to Twenty.
+Prefer not to run it yourself? [Zenith](https://zenith.hosting/host/twenty) offers one-click managed Twenty with storage, backups, email and a free subdomain included. It is an independent service and is not run by the Twenty team. A share of every subscription goes back to Twenty.
+
+[![Deploy with Zenith](https://cdn.zenith.hosting/buttons/deploy-with-zenith.svg)](https://zenith.hosting/host/twenty)
 
 <br />
 <br />


### PR DESCRIPTION
hey, i work on Zenith Hosting, a startup doing one-click hosting for open source apps. we added Twenty to our marketplace, so this PR adds a small "Deploy with Zenith" badge under Installation > Self-hosting (links to https://zenith.hosting/host/twenty).

we share a cut of revenue with the projects we host. happy to explain if you're curious: hello@zenith.hosting

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/23681?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

