### PR TITLE
fix(twenty-server): derive PageLayoutWidget.position on app install/sync

### DIFF
--- a/packages/twenty-server/src/engine/core-modules/application/application-manifest/converters/__tests__/from-page-layout-widget-manifest-to-universal-flat-page-layout-widget.util.spec.ts
+++ b/packages/twenty-server/src/engine/core-modules/application/application-manifest/converters/__tests__/from-page-layout-widget-manifest-to-universal-flat-page-layout-widget.util.spec.ts
@@ -136,6 +136,26 @@ describe('fromPageLayoutWidgetManifestToUniversalFlatPageLayoutWidget', () => {
     });
   });
 
+  it('should set CANVAS position when the tab layoutMode is CANVAS', () => {
+    const result = fromPageLayoutWidgetManifestToUniversalFlatPageLayoutWidget({
+      pageLayoutWidgetManifest: {
+        universalIdentifier: 'widget-uuid-5',
+        title: 'Canvas Widget',
+        type: WidgetType.VIEW,
+        configuration: { configurationType: 'VIEW' },
+      },
+      pageLayoutTabUniversalIdentifier,
+      pageLayoutTabLayoutMode: PageLayoutTabLayoutMode.CANVAS,
+      widgetIndex: 0,
+      applicationUniversalIdentifier,
+      now,
+    });
+
+    expect(result.position).toEqual({
+      layoutMode: PageLayoutTabLayoutMode.CANVAS,
+    });
+  });
+
   it('should leave position null when the tab layoutMode is not set', () => {
     const result = fromPageLayoutWidgetManifestToUniversalFlatPageLayoutWidget({
       pageLayoutWidgetManifest: {

--- a/packages/twenty-server/src/engine/core-modules/application/application-manifest/converters/__tests__/from-page-layout-widget-manifest-to-universal-flat-page-layout-widget.util.spec.ts
+++ b/packages/twenty-server/src/engine/core-modules/application/application-manifest/converters/__tests__/from-page-layout-widget-manifest-to-universal-flat-page-layout-widget.util.spec.ts
@@ -1,4 +1,5 @@
 import { DEFAULT_WIDGET_SIZE } from 'twenty-shared/constants';
+import { PageLayoutTabLayoutMode } from 'twenty-shared/types';
 
 import { fromPageLayoutWidgetManifestToUniversalFlatPageLayoutWidget } from 'src/engine/core-modules/application/application-manifest/converters/from-page-layout-widget-manifest-to-universal-flat-page-layout-widget.util';
 import { WidgetType } from 'src/engine/metadata-modules/page-layout-widget/enums/widget-type.enum';
@@ -17,6 +18,8 @@ describe('fromPageLayoutWidgetManifestToUniversalFlatPageLayoutWidget', () => {
         configuration: { configurationType: 'VIEW' },
       },
       pageLayoutTabUniversalIdentifier,
+      pageLayoutTabLayoutMode: PageLayoutTabLayoutMode.VERTICAL_LIST,
+      widgetIndex: 0,
       applicationUniversalIdentifier,
       now,
     });
@@ -38,7 +41,10 @@ describe('fromPageLayoutWidgetManifestToUniversalFlatPageLayoutWidget', () => {
       rowSpan: DEFAULT_WIDGET_SIZE.default.h,
       columnSpan: DEFAULT_WIDGET_SIZE.default.w,
     });
-    expect(result.position).toBeNull();
+    expect(result.position).toEqual({
+      layoutMode: PageLayoutTabLayoutMode.VERTICAL_LIST,
+      index: 0,
+    });
     expect(result.universalConfiguration).toEqual({
       configurationType: 'VIEW',
     });
@@ -57,6 +63,8 @@ describe('fromPageLayoutWidgetManifestToUniversalFlatPageLayoutWidget', () => {
         },
       },
       pageLayoutTabUniversalIdentifier,
+      pageLayoutTabLayoutMode: PageLayoutTabLayoutMode.GRID,
+      widgetIndex: 0,
       applicationUniversalIdentifier,
       now,
     });
@@ -86,6 +94,8 @@ describe('fromPageLayoutWidgetManifestToUniversalFlatPageLayoutWidget', () => {
         configuration: { configurationType: 'VIEW' },
       },
       pageLayoutTabUniversalIdentifier,
+      pageLayoutTabLayoutMode: PageLayoutTabLayoutMode.GRID,
+      widgetIndex: 0,
       applicationUniversalIdentifier,
       now,
     });
@@ -96,5 +106,51 @@ describe('fromPageLayoutWidgetManifestToUniversalFlatPageLayoutWidget', () => {
       rowSpan: 4,
       columnSpan: 6,
     });
+    expect(result.position).toEqual({
+      layoutMode: PageLayoutTabLayoutMode.GRID,
+      row: 2,
+      column: 6,
+      rowSpan: 4,
+      columnSpan: 6,
+    });
+  });
+
+  it('should derive the VERTICAL_LIST position index from the widget order', () => {
+    const result = fromPageLayoutWidgetManifestToUniversalFlatPageLayoutWidget({
+      pageLayoutWidgetManifest: {
+        universalIdentifier: 'widget-uuid-4',
+        title: 'Second Widget',
+        type: WidgetType.VIEW,
+        configuration: { configurationType: 'VIEW' },
+      },
+      pageLayoutTabUniversalIdentifier,
+      pageLayoutTabLayoutMode: PageLayoutTabLayoutMode.VERTICAL_LIST,
+      widgetIndex: 1,
+      applicationUniversalIdentifier,
+      now,
+    });
+
+    expect(result.position).toEqual({
+      layoutMode: PageLayoutTabLayoutMode.VERTICAL_LIST,
+      index: 1,
+    });
+  });
+
+  it('should leave position null when the tab layoutMode is not set', () => {
+    const result = fromPageLayoutWidgetManifestToUniversalFlatPageLayoutWidget({
+      pageLayoutWidgetManifest: {
+        universalIdentifier: 'widget-uuid-5',
+        title: 'Unspecified Layout Widget',
+        type: WidgetType.VIEW,
+        configuration: { configurationType: 'VIEW' },
+      },
+      pageLayoutTabUniversalIdentifier,
+      pageLayoutTabLayoutMode: undefined,
+      widgetIndex: 0,
+      applicationUniversalIdentifier,
+      now,
+    });
+
+    expect(result.position).toBeNull();
   });
 });

--- a/packages/twenty-server/src/engine/core-modules/application/application-manifest/converters/from-page-layout-widget-manifest-to-universal-flat-page-layout-widget.util.ts
+++ b/packages/twenty-server/src/engine/core-modules/application/application-manifest/converters/from-page-layout-widget-manifest-to-universal-flat-page-layout-widget.util.ts
@@ -1,17 +1,57 @@
 import { type PageLayoutWidgetManifest } from 'twenty-shared/application';
 import { DEFAULT_WIDGET_SIZE } from 'twenty-shared/constants';
+import {
+  PageLayoutTabLayoutMode,
+  type PageLayoutWidgetPosition,
+} from 'twenty-shared/types';
 
 import { type WidgetType } from 'src/engine/metadata-modules/page-layout-widget/enums/widget-type.enum';
 import { type UniversalFlatPageLayoutWidget } from 'src/engine/workspace-manager/workspace-migration/universal-flat-entity/types/universal-flat-page-layout-widget.type';
 
+const computePageLayoutWidgetPosition = ({
+  pageLayoutWidgetManifest,
+  pageLayoutTabLayoutMode,
+  widgetIndex,
+}: {
+  pageLayoutWidgetManifest: PageLayoutWidgetManifest;
+  pageLayoutTabLayoutMode: PageLayoutTabLayoutMode | undefined;
+  widgetIndex: number;
+}): PageLayoutWidgetPosition | null => {
+  switch (pageLayoutTabLayoutMode) {
+    case PageLayoutTabLayoutMode.VERTICAL_LIST:
+      return {
+        layoutMode: PageLayoutTabLayoutMode.VERTICAL_LIST,
+        index: widgetIndex,
+      };
+    case PageLayoutTabLayoutMode.GRID: {
+      const gridPosition = pageLayoutWidgetManifest.gridPosition ?? {
+        row: 0,
+        column: 0,
+        rowSpan: DEFAULT_WIDGET_SIZE.default.h,
+        columnSpan: DEFAULT_WIDGET_SIZE.default.w,
+      };
+
+      return { layoutMode: PageLayoutTabLayoutMode.GRID, ...gridPosition };
+    }
+    case PageLayoutTabLayoutMode.CANVAS:
+      return { layoutMode: PageLayoutTabLayoutMode.CANVAS };
+    default:
+      return null;
+  }
+};
+
 export const fromPageLayoutWidgetManifestToUniversalFlatPageLayoutWidget = ({
   pageLayoutWidgetManifest,
   pageLayoutTabUniversalIdentifier,
+  pageLayoutTabLayoutMode,
+  widgetIndex,
   applicationUniversalIdentifier,
   now,
 }: {
   pageLayoutWidgetManifest: PageLayoutWidgetManifest;
   pageLayoutTabUniversalIdentifier: string;
+  pageLayoutTabLayoutMode: PageLayoutTabLayoutMode | undefined;
+  widgetIndex: number;
   applicationUniversalIdentifier: string;
   now: string;
 }): UniversalFlatPageLayoutWidget => {
@@ -32,7 +72,11 @@ export const fromPageLayoutWidgetManifestToUniversalFlatPageLayoutWidget = ({
       rowSpan: DEFAULT_WIDGET_SIZE.default.h,
       columnSpan: DEFAULT_WIDGET_SIZE.default.w,
     },
-    position: null,
+    position: computePageLayoutWidgetPosition({
+      pageLayoutWidgetManifest,
+      pageLayoutTabLayoutMode,
+      widgetIndex,
+    }),
     universalConfiguration:
       pageLayoutWidgetManifest.configuration as UniversalFlatPageLayoutWidget['universalConfiguration'],
     createdAt: now,

--- a/packages/twenty-server/src/engine/core-modules/application/application-manifest/services/compute-application-manifest-all-universal-flat-entity-maps.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/application/application-manifest/services/compute-application-manifest-all-universal-flat-entity-maps.service.ts
@@ -534,8 +534,9 @@ export class ComputeApplicationManifestAllUniversalFlatEntityMapsService {
             allUniversalFlatEntityMaps.flatPageLayoutTabMaps,
         });
 
-        for (const pageLayoutWidgetManifest of pageLayoutTabManifest.widgets ??
-          []) {
+        for (const [widgetIndex, pageLayoutWidgetManifest] of (
+          pageLayoutTabManifest.widgets ?? []
+        ).entries()) {
           addUniversalFlatEntityToUniversalFlatEntityMapsThroughMutationOrThrow(
             {
               universalFlatEntity:
@@ -543,6 +544,8 @@ export class ComputeApplicationManifestAllUniversalFlatEntityMapsService {
                   pageLayoutWidgetManifest,
                   pageLayoutTabUniversalIdentifier:
                     pageLayoutTabManifest.universalIdentifier,
+                  pageLayoutTabLayoutMode: pageLayoutTabManifest.layoutMode,
+                  widgetIndex,
                   applicationUniversalIdentifier,
                   now,
                 }),
@@ -581,14 +584,17 @@ export class ComputeApplicationManifestAllUniversalFlatEntityMapsService {
           allUniversalFlatEntityMaps.flatPageLayoutTabMaps,
       });
 
-      for (const pageLayoutWidgetManifest of pageLayoutTabManifest.widgets ??
-        []) {
+      for (const [widgetIndex, pageLayoutWidgetManifest] of (
+        pageLayoutTabManifest.widgets ?? []
+      ).entries()) {
         addUniversalFlatEntityToUniversalFlatEntityMapsThroughMutationOrThrow({
           universalFlatEntity:
             fromPageLayoutWidgetManifestToUniversalFlatPageLayoutWidget({
               pageLayoutWidgetManifest,
               pageLayoutTabUniversalIdentifier:
                 pageLayoutTabManifest.universalIdentifier,
+              pageLayoutTabLayoutMode: pageLayoutTabManifest.layoutMode,
+              widgetIndex,
               applicationUniversalIdentifier,
               now,
             }),


### PR DESCRIPTION
## Summary
- The application-sync converter (`fromPageLayoutWidgetManifestToUniversalFlatPageLayoutWidget`) persisted every manifest-created `PageLayoutWidget` with a hardcoded `position: null`, only ever filling the legacy `gridPosition` field.
- Since the frontend orders record-page tab widgets by the `position` union (`PageLayoutWidgetVerticalListPosition`/`PageLayoutWidgetGridPosition`), any app-defined tab with multiple widgets rendered incompletely after `app:install`/`app:publish`, with no error anywhere (build, install, console all clean).
- The converter already has everything needed to derive `position` at creation time: the owning tab's `layoutMode` (available at both call sites in `ComputeApplicationManifestAllUniversalFlatEntityMapsService`) and the widget's index in the manifest's `widgets` array.

## Changes
- Thread `pageLayoutTabLayoutMode` and `widgetIndex` into `fromPageLayoutWidgetManifestToUniversalFlatPageLayoutWidget`.
- Derive `position` instead of hardcoding `null`:
  - `VERTICAL_LIST` → `{ layoutMode, index }` from the widget's array index
  - `GRID` → `{ layoutMode, ...gridPosition }`
  - `CANVAS` → `{ layoutMode }`
- Update/extend the existing converter unit tests to cover all three layout modes plus the "no layoutMode" fallback.

## Test plan
- [x] `npx jest .../from-page-layout-widget-manifest-to-universal-flat-page-layout-widget.util.spec.ts` — 5/5 passing
- [x] `npx nx typecheck twenty-server`
- [x] `npx oxlint --type-aware` on changed files (0 warnings/errors)

Fixes #23401

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/23686?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

