### PR TITLE
fix(twenty-server): give app-dev file uploads their own throttle bucket

### DIFF
--- a/packages/twenty-server/src/engine/core-modules/application/application-development/application-development.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/application/application-development/application-development.service.ts
@@ -28,6 +28,13 @@ import { streamToBuffer } from 'src/utils/stream-to-buffer';
 const APP_DEV_RATE_LIMIT_MAX = 30;
 const APP_DEV_RATE_LIMIT_WINDOW_MS = 30_000;
 
+// File uploads scale with the number of files in an application (potentially
+// hundreds), unlike createDevelopmentApplication/syncApplication which are
+// called at most a couple of times per sync, so they need their own, much
+// more permissive bucket instead of sharing APP_DEV_RATE_LIMIT_MAX.
+const APP_DEV_FILE_UPLOAD_RATE_LIMIT_MAX = 300;
+const APP_DEV_FILE_UPLOAD_RATE_LIMIT_WINDOW_MS = 30_000;
+
 const APP_SYNC_LOCK_OPTIONS = { ttl: 60_000, ms: 500, maxRetries: 120 };
 
 const ALLOWED_APPLICATION_FILE_FOLDERS: FileFolder[] = [
@@ -161,7 +168,7 @@ export class ApplicationDevelopmentService {
     // Lazy so rejected or rate-limited uploads are not buffered into memory.
     getFileBuffer: () => Promise<Buffer>;
   }): Promise<FileDTO> {
-    await this.throttlePerApplication(
+    await this.throttleFileUploadPerApplication(
       applicationUniversalIdentifier,
       workspaceId,
     );
@@ -261,6 +268,18 @@ export class ApplicationDevelopmentService {
       1,
       APP_DEV_RATE_LIMIT_MAX,
       APP_DEV_RATE_LIMIT_WINDOW_MS,
+    );
+  }
+
+  private async throttleFileUploadPerApplication(
+    applicationIdentifier: string,
+    workspaceId: string,
+  ): Promise<void> {
+    await this.throttlerService.tokenBucketThrottleOrThrow(
+      `app-dev-file-upload:${workspaceId}:${applicationIdentifier}`,
+      1,
+      APP_DEV_FILE_UPLOAD_RATE_LIMIT_MAX,
+      APP_DEV_FILE_UPLOAD_RATE_LIMIT_WINDOW_MS,
     );
   }
 


### PR DESCRIPTION
## Summary
- `createDevelopmentApplication`, `syncApplication`, and `uploadApplicationFile` all shared a single token bucket (`APP_DEV_RATE_LIMIT_MAX = 30` tokens per 30s), keyed per application.
- `uploadApplicationFile` is called once per file during `twenty apply`/`twenty-sdk sync`, so any application with a file count approaching 30 (plus the create/sync calls sharing the same bucket) hits `Limit reached (30 tokens per 30000 ms)` on a completely legitimate sync — reported as reproducible with 29 files, and working after removing one.
- File count scales with application size and isn't the abuse vector this throttle is meant to guard against (repeated create/sync calls are); it shouldn't share a budget with those.

## Changes
- Add a separate, more permissive token bucket (`APP_DEV_FILE_UPLOAD_RATE_LIMIT_MAX = 300` per 30s) scoped to `uploadApplicationFile`, keyed independently from the `createDevelopmentApplication`/`syncApplication` bucket.

## Test plan
- [x] `npx nx typecheck twenty-server`
- [x] `npx oxlint --type-aware` on the changed file (0 warnings/errors)

Fixes #23056

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/23687?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

