### PR TITLE
fix(twenty-front): await mutation before committing optimistic field value

### DIFF
--- a/packages/twenty-front/src/modules/object-record/record-field/ui/hooks/usePersistField.ts
+++ b/packages/twenty-front/src/modules/object-record/record-field/ui/hooks/usePersistField.ts
@@ -269,7 +269,7 @@ export const usePersistField = ({
           return;
         }
 
-        updateOneRecord({
+        await updateOneRecord({
           objectNameSingular: objectMetadataItem.nameSingular,
           idToUpdate: recordId,
           updateOneRecordInput: {


### PR DESCRIPTION
## Summary
- In `usePersistField`, the non-relation branch (text, number, date, emails, select, currency, phones, links, address, array, files, rich text, boolean, rating, multiselect...) called `updateOneRecord(...)` **without** awaiting it, then immediately wrote the new value into the record store.
- This is inconsistent with the two branches directly above it in the same function (`fieldIsRelationManyToOne`, `fieldIsMorphRelationManyToOne`), which both `await updateOneRecord(...)` before touching the store.
- Net effect: if the server rejects a mutation for any reason (a value that passes client-side validation but violates a server-side constraint, a permission error, etc.), the UI still shows the new value as saved, because the local record-store write isn't gated on the mutation actually succeeding.

This is the general form of #22406 ("Email field: over-length value appears saved but is not persisted"). #22426 already fixed the *specific* repro by adding a `.max(255)` client-side check to `emailSchema` — but the underlying flaw (optimistic local write not gated on mutation success) is still present for every other field type and every other kind of server-side rejection, which is presumably why #22406 is still open after #22426 merged.

## Change
- Add `await` before `updateOneRecord(...)` in the non-relation branch, matching the pattern already used by the relation/morph-relation branches above it. On failure, the function throws before reaching the `store.set(...)` call, so the optimistic write never happens.

## Test plan
- [x] `npx nx typecheck twenty-front`
- [x] `npx oxlint --type-aware` on the changed file (0 warnings/errors)
- [x] `npx oxfmt --check` on the changed file
- No existing unit tests reference `usePersistField` directly, so nothing needed updating.

Fixes #22406

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/23689?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

