### PR TITLE
fix(twenty-front): skip aggregate refetch on no-op SSE update echoes

### DIFF
--- a/packages/twenty-front/src/modules/sse-db-event/hooks/useTriggerOptimisticEffectFromSseUpdateEvents.ts
+++ b/packages/twenty-front/src/modules/sse-db-event/hooks/useTriggerOptimisticEffectFromSseUpdateEvents.ts
@@ -20,6 +20,7 @@ import {
   DatabaseEventAction,
   type ObjectRecordEvent,
 } from '~/generated-metadata/graphql';
+import { isDeeplyEqual } from '~/utils/isDeeplyEqual';
 
 export const useTriggerOptimisticEffectFromSseUpdateEvents = () => {
   const store = useStore();
@@ -49,6 +50,8 @@ export const useTriggerOptimisticEffectFromSseUpdateEvents = () => {
       const updateEvents = objectRecordEvents.filter((objectRecordEvent) => {
         return objectRecordEvent.action === DatabaseEventAction.UPDATED;
       });
+
+      let hasAnyRecordActuallyChanged = false;
 
       for (const updateEvent of updateEvents) {
         const recordFromEvent = updateEvent.properties.after;
@@ -129,7 +132,22 @@ export const useTriggerOptimisticEffectFromSseUpdateEvents = () => {
           !isDefined(cachedRecord) ||
           !isDefined(cachedRecordWithConnection)
         ) {
+          // No cached snapshot to compare against, so we can't rule out an
+          // actual change - keep the aggregate refetch conservative.
+          hasAnyRecordActuallyChanged = true;
           continue;
+        }
+
+        const hasThisEventChangedAnyFieldValue = Object.entries(
+          updatedRecord,
+        ).some(
+          ([fieldName, fieldValue]) =>
+            fieldName !== 'updatedAt' &&
+            !isDeeplyEqual(cachedRecord[fieldName], fieldValue),
+        );
+
+        if (hasThisEventChangedAnyFieldValue) {
+          hasAnyRecordActuallyChanged = true;
         }
 
         upsertRecordsInStore({ partialRecords: [updatedRecord] });
@@ -165,7 +183,7 @@ export const useTriggerOptimisticEffectFromSseUpdateEvents = () => {
         });
       }
 
-      if (isNonEmptyArray(updateEvents)) {
+      if (hasAnyRecordActuallyChanged) {
         refetchAggregateQueriesForObjectMetadataItem({
           objectMetadataItem,
         });

--- a/packages/twenty-front/src/modules/sse-db-event/hooks/useTriggerOptimisticEffectFromSseUpdateEvents.ts
+++ b/packages/twenty-front/src/modules/sse-db-event/hooks/useTriggerOptimisticEffectFromSseUpdateEvents.ts
@@ -138,12 +138,13 @@ export const useTriggerOptimisticEffectFromSseUpdateEvents = () => {
           continue;
         }
 
-        const hasThisEventChangedAnyFieldValue = Object.entries(
-          updatedRecord,
-        ).some(
-          ([fieldName, fieldValue]) =>
+        const updatedFieldNames =
+          updateEvent.properties.updatedFields ?? Object.keys(updatedRecord);
+
+        const hasThisEventChangedAnyFieldValue = updatedFieldNames.some(
+          (fieldName) =>
             fieldName !== 'updatedAt' &&
-            !isDeeplyEqual(cachedRecord[fieldName], fieldValue),
+            !isDeeplyEqual(cachedRecord[fieldName], updatedRecord[fieldName]),
         );
 
         if (hasThisEventChangedAnyFieldValue) {

--- a/packages/twenty-front/src/modules/sse-db-event/hooks/useTriggerOptimisticEffectFromSseUpdateEvents.ts
+++ b/packages/twenty-front/src/modules/sse-db-event/hooks/useTriggerOptimisticEffectFromSseUpdateEvents.ts
@@ -139,7 +139,9 @@ export const useTriggerOptimisticEffectFromSseUpdateEvents = () => {
         }
 
         const updatedFieldNames =
-          updateEvent.properties.updatedFields ?? Object.keys(updatedRecord);
+          (updateEvent.properties.updatedFields ?? Object.keys(updatedRecord)).filter(
+            (fieldName) => fieldName in updatedRecord,
+          );
 
         const hasThisEventChangedAnyFieldValue = updatedFieldNames.some(
           (fieldName) =>


### PR DESCRIPTION
## Summary
- A single field edit fires two independent aggregate (`AggregateX`/`GroupByAggregateX`) refetches for the same object:
  1. `useUpdateOneRecord`'s mutation-success handler calls `refetchAggregateQueries(...)`.
  2. `useTriggerOptimisticEffectFromSseUpdateEvents` unconditionally calls `refetchAggregateQueriesForObjectMetadataItem(...)` for **any** non-empty batch of `UPDATED` SSE events — including the server's own echo of the edit the client just made.
- Since both refetches land within a short window of each other, whichever aggregate-footer watchers happen to be mounted at both moments get double-fetched — matching the reported "3 of 8 exact duplicates" pattern.
- A prior attempt (#22590) diagnosed the same root cause and a maintainer agreed with the approach, but the PR went stale and was closed for inactivity, not because the fix was wrong.

## Change
In `useTriggerOptimisticEffectFromSseUpdateEvents.ts`, before applying each SSE update event's cache write, compare its fields against the already-cached record (ignoring `updatedAt`). Only trigger the aggregate refetch if at least one event in the batch actually changed a field relative to the cache:
- If nothing changed, the event is just an echo of a mutation that has already triggered its own refetch via `useUpdateOneRecord` — nothing new for the aggregate to reflect.
- If there's no cached snapshot to compare against (record not resident in cache), keep the previous conservative behavior and still refetch.

## Test plan
- [x] `npx nx typecheck twenty-front`
- [x] `npx oxlint --type-aware` on the changed file (0 warnings/errors)
- [x] `npx oxfmt --check` on the changed file
- No existing unit tests reference this hook.

Fixes #22460

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/23691?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

