### PR TITLE
feat(twenty-server): add command to reseed missing standard command menu items

### DIFF
--- a/packages/twenty-server/src/database/commands/upgrade-version-command/2-27/2-27-upgrade-version-command.module.ts
+++ b/packages/twenty-server/src/database/commands/upgrade-version-command/2-27/2-27-upgrade-version-command.module.ts
@@ -3,6 +3,7 @@ import { Module } from '@nestjs/common';
 import { WorkspaceIteratorModule } from 'src/database/commands/command-runners/workspace-iterator.module';
 import { AddWorkspaceMemberOpenRecordInCommand } from 'src/database/commands/upgrade-version-command/2-27/2-27-workspace-command-1785505000000-add-workspace-member-open-record-in.command';
 import { SeedObjectOpenRecordInCommand } from 'src/database/commands/upgrade-version-command/2-27/2-27-workspace-command-1785505100000-seed-object-open-record-in.command';
+import { RecreateMissingStandardCommandMenuItemsCommand } from 'src/database/commands/upgrade-version-command/2-27/2-27-workspace-command-1785505200000-recreate-missing-standard-command-menu-items.command';
 import { BackfillMissingStandardSkillsCommand } from 'src/database/commands/upgrade-version-command/2-27/2-27-workspace-command-1785499350000-backfill-standard-skills.command';
 import { ApplicationModule } from 'src/engine/core-modules/application/application.module';
 import { WorkspaceCacheModule } from 'src/engine/workspace-cache/workspace-cache.module';
@@ -20,6 +21,7 @@ import { WorkspaceMigrationModule } from 'src/engine/workspace-manager/workspace
   providers: [
     AddWorkspaceMemberOpenRecordInCommand,
     SeedObjectOpenRecordInCommand,
+    RecreateMissingStandardCommandMenuItemsCommand,
     BackfillMissingStandardSkillsCommand,
   ],
 })

--- a/packages/twenty-server/src/database/commands/upgrade-version-command/2-27/2-27-workspace-command-1785505200000-recreate-missing-standard-command-menu-items.command.ts
+++ b/packages/twenty-server/src/database/commands/upgrade-version-command/2-27/2-27-workspace-command-1785505200000-recreate-missing-standard-command-menu-items.command.ts
@@ -1,0 +1,112 @@
+import { Command } from 'nest-commander';
+import { isDefined } from 'twenty-shared/utils';
+
+import { ProvisionedWorkspaceCommandRunner } from 'src/database/commands/command-runners/provisioned-workspace.command-runner';
+import { WorkspaceIteratorService } from 'src/database/commands/command-runners/workspace-iterator.service';
+import { type RunOnWorkspaceArgs } from 'src/database/commands/command-runners/workspace.command-runner';
+import { ApplicationService } from 'src/engine/core-modules/application/application.service';
+import { RegisteredWorkspaceCommand } from 'src/engine/core-modules/upgrade/decorators/registered-workspace-command.decorator';
+import { WorkspaceCacheService } from 'src/engine/workspace-cache/services/workspace-cache.service';
+import { computeTwentyStandardApplicationAllFlatEntityMaps } from 'src/engine/workspace-manager/twenty-standard-application/utils/twenty-standard-application-all-flat-entity-maps.constant';
+import { WorkspaceMigrationValidateBuildAndRunService } from 'src/engine/workspace-manager/workspace-migration/services/workspace-migration-validate-build-and-run-service';
+
+@RegisteredWorkspaceCommand('2.27.0', 1785505200000)
+@Command({
+  name: 'upgrade:2-27:recreate-missing-standard-command-menu-items',
+  description:
+    'Recreate any standard command menu item missing from an existing workspace (e.g. the Twenty Standard application was never re-synced after being pre-installed). Additive only: never updates or deletes an existing item.',
+})
+export class RecreateMissingStandardCommandMenuItemsCommand extends ProvisionedWorkspaceCommandRunner {
+  constructor(
+    protected readonly workspaceIteratorService: WorkspaceIteratorService,
+    private readonly applicationService: ApplicationService,
+    private readonly workspaceMigrationValidateBuildAndRunService: WorkspaceMigrationValidateBuildAndRunService,
+    private readonly workspaceCacheService: WorkspaceCacheService,
+  ) {
+    super(workspaceIteratorService);
+  }
+
+  override async runOnWorkspace({
+    workspaceId,
+    options,
+  }: RunOnWorkspaceArgs): Promise<void> {
+    const isDryRun = options.dryRun ?? false;
+
+    const { twentyStandardFlatApplication } =
+      await this.applicationService.findWorkspaceTwentyStandardAndCustomApplicationOrThrow(
+        { workspaceId },
+      );
+
+    const { flatCommandMenuItemMaps: existingFlatCommandMenuItemMaps } =
+      await this.workspaceCacheService.getOrRecompute(workspaceId, [
+        'flatCommandMenuItemMaps',
+      ]);
+
+    const { allFlatEntityMaps: standardAllFlatEntityMaps } =
+      computeTwentyStandardApplicationAllFlatEntityMaps({
+        now: new Date().toISOString(),
+        workspaceId,
+        twentyStandardApplicationId: twentyStandardFlatApplication.id,
+      });
+
+    const itemsToCreate = Object.values(
+      standardAllFlatEntityMaps.flatCommandMenuItemMaps.byUniversalIdentifier,
+    )
+      .filter(isDefined)
+      .filter(
+        (standardItem) =>
+          !isDefined(
+            existingFlatCommandMenuItemMaps.byUniversalIdentifier[
+              standardItem.universalIdentifier
+            ],
+          ),
+      );
+
+    if (itemsToCreate.length === 0) {
+      this.logger.log(
+        `All standard command menu items already exist for workspace ${workspaceId}, skipping`,
+      );
+
+      return;
+    }
+
+    this.logger.log(
+      `${isDryRun ? '[DRY RUN] ' : ''}Workspace ${workspaceId}: recreating ${itemsToCreate.length} missing standard command menu item(s)`,
+    );
+
+    if (isDryRun) {
+      return;
+    }
+
+    const validateAndBuildResult =
+      await this.workspaceMigrationValidateBuildAndRunService.validateBuildAndRunLegacyWorkspaceMigration(
+        {
+          isSystemBuild: true,
+          allFlatEntityOperationByMetadataName: {
+            commandMenuItem: {
+              flatEntityToCreate: itemsToCreate,
+              flatEntityToDelete: [],
+              flatEntityToUpdate: [],
+            },
+          },
+          workspaceId,
+          applicationUniversalIdentifier:
+            twentyStandardFlatApplication.universalIdentifier,
+        },
+      );
+
+    if (validateAndBuildResult.status === 'fail') {
+      this.logger.error(
+        `Failed to recreate missing standard command menu items:\n${JSON.stringify(validateAndBuildResult, null, 2)}`,
+      );
+
+      throw new Error(
+        `Failed to recreate missing standard command menu items for workspace ${workspaceId}`,
+      );
+    }
+
+    this.logger.log(
+      `Recreated ${itemsToCreate.length} missing standard command menu item(s) for workspace ${workspaceId}`,
+    );
+  }
+}

--- a/packages/twenty-server/src/database/commands/upgrade-version-command/2-27/__tests__/2-27-workspace-command-1785505200000-recreate-missing-standard-command-menu-items.command.spec.ts
+++ b/packages/twenty-server/src/database/commands/upgrade-version-command/2-27/__tests__/2-27-workspace-command-1785505200000-recreate-missing-standard-command-menu-items.command.spec.ts
@@ -1,0 +1,167 @@
+import { type WorkspaceIteratorService } from 'src/database/commands/command-runners/workspace-iterator.service';
+import { RecreateMissingStandardCommandMenuItemsCommand } from 'src/database/commands/upgrade-version-command/2-27/2-27-workspace-command-1785505200000-recreate-missing-standard-command-menu-items.command';
+import { type ApplicationService } from 'src/engine/core-modules/application/application.service';
+import { type WorkspaceCacheService } from 'src/engine/workspace-cache/services/workspace-cache.service';
+import { computeTwentyStandardApplicationAllFlatEntityMaps } from 'src/engine/workspace-manager/twenty-standard-application/utils/twenty-standard-application-all-flat-entity-maps.constant';
+import { type WorkspaceMigrationValidateBuildAndRunService } from 'src/engine/workspace-manager/workspace-migration/services/workspace-migration-validate-build-and-run-service';
+
+jest.mock(
+  'src/engine/workspace-manager/twenty-standard-application/utils/twenty-standard-application-all-flat-entity-maps.constant',
+);
+
+const computeTwentyStandardApplicationAllFlatEntityMapsMock =
+  computeTwentyStandardApplicationAllFlatEntityMaps as jest.Mock;
+
+const WORKSPACE_ID = '20202020-0000-0000-0000-000000000001';
+const STANDARD_APPLICATION = {
+  id: '20202020-0000-0000-0000-0000000000aa',
+  universalIdentifier: '20202020-0000-0000-0000-0000000000bb',
+};
+
+const STANDARD_COMMAND_MENU_ITEM_UNIVERSAL_IDENTIFIERS = [
+  '20202020-0000-0000-0000-000000000010',
+  '20202020-0000-0000-0000-000000000011',
+  '20202020-0000-0000-0000-000000000012',
+];
+
+const buildByUniversalIdentifierMap = (universalIdentifiers: string[]) => ({
+  byUniversalIdentifier: Object.fromEntries(
+    universalIdentifiers.map((universalIdentifier) => [
+      universalIdentifier,
+      { universalIdentifier },
+    ]),
+  ),
+});
+
+describe('RecreateMissingStandardCommandMenuItemsCommand', () => {
+  let command: RecreateMissingStandardCommandMenuItemsCommand;
+  let findApplicationMock: jest.Mock;
+  let getOrRecomputeMock: jest.Mock;
+  let validateBuildAndRunLegacyWorkspaceMigrationMock: jest.Mock;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    findApplicationMock = jest.fn().mockResolvedValue({
+      twentyStandardFlatApplication: STANDARD_APPLICATION,
+    });
+    getOrRecomputeMock = jest.fn();
+    validateBuildAndRunLegacyWorkspaceMigrationMock = jest
+      .fn()
+      .mockResolvedValue({ status: 'success' });
+
+    computeTwentyStandardApplicationAllFlatEntityMapsMock.mockReturnValue({
+      allFlatEntityMaps: {
+        flatCommandMenuItemMaps: buildByUniversalIdentifierMap(
+          STANDARD_COMMAND_MENU_ITEM_UNIVERSAL_IDENTIFIERS,
+        ),
+      },
+    });
+
+    command = new RecreateMissingStandardCommandMenuItemsCommand(
+      {} as WorkspaceIteratorService,
+      {
+        findWorkspaceTwentyStandardAndCustomApplicationOrThrow:
+          findApplicationMock,
+      } as unknown as ApplicationService,
+      {
+        validateBuildAndRunLegacyWorkspaceMigration:
+          validateBuildAndRunLegacyWorkspaceMigrationMock,
+      } as unknown as WorkspaceMigrationValidateBuildAndRunService,
+      {
+        getOrRecompute: getOrRecomputeMock,
+      } as unknown as WorkspaceCacheService,
+    );
+  });
+
+  const runOnWorkspace = (dryRun = false) =>
+    command.runOnWorkspace({
+      workspaceId: WORKSPACE_ID,
+      options: { dryRun },
+      index: 0,
+      total: 1,
+    });
+
+  const mockWorkspaceCache = (existingCommandMenuItems: string[]) => {
+    getOrRecomputeMock.mockResolvedValue({
+      flatCommandMenuItemMaps: buildByUniversalIdentifierMap(
+        existingCommandMenuItems,
+      ),
+    });
+  };
+
+  it('recreates every missing standard command menu item when none exist', async () => {
+    mockWorkspaceCache([]);
+
+    await runOnWorkspace();
+
+    expect(
+      validateBuildAndRunLegacyWorkspaceMigrationMock,
+    ).toHaveBeenCalledWith({
+      isSystemBuild: true,
+      workspaceId: WORKSPACE_ID,
+      applicationUniversalIdentifier: STANDARD_APPLICATION.universalIdentifier,
+      allFlatEntityOperationByMetadataName: {
+        commandMenuItem: {
+          flatEntityToCreate: expect.arrayContaining(
+            STANDARD_COMMAND_MENU_ITEM_UNIVERSAL_IDENTIFIERS.map(
+              (universalIdentifier) =>
+                expect.objectContaining({ universalIdentifier }),
+            ),
+          ),
+          flatEntityToDelete: [],
+          flatEntityToUpdate: [],
+        },
+      },
+    });
+    expect(
+      validateBuildAndRunLegacyWorkspaceMigrationMock.mock.calls[0][0]
+        .allFlatEntityOperationByMetadataName.commandMenuItem
+        .flatEntityToCreate,
+    ).toHaveLength(STANDARD_COMMAND_MENU_ITEM_UNIVERSAL_IDENTIFIERS.length);
+  });
+
+  it('only recreates the items missing from a partially seeded workspace', async () => {
+    mockWorkspaceCache([STANDARD_COMMAND_MENU_ITEM_UNIVERSAL_IDENTIFIERS[0]]);
+
+    await runOnWorkspace();
+
+    const payload =
+      validateBuildAndRunLegacyWorkspaceMigrationMock.mock.calls[0][0]
+        .allFlatEntityOperationByMetadataName.commandMenuItem;
+
+    expect(payload.flatEntityToCreate).toEqual(
+      expect.arrayContaining(
+        STANDARD_COMMAND_MENU_ITEM_UNIVERSAL_IDENTIFIERS.slice(1).map(
+          (universalIdentifier) =>
+            expect.objectContaining({ universalIdentifier }),
+        ),
+      ),
+    );
+    expect(payload.flatEntityToCreate).toHaveLength(
+      STANDARD_COMMAND_MENU_ITEM_UNIVERSAL_IDENTIFIERS.length - 1,
+    );
+    expect(payload.flatEntityToUpdate).toEqual([]);
+    expect(payload.flatEntityToDelete).toEqual([]);
+  });
+
+  it('never touches existing command menu items (additive only)', async () => {
+    mockWorkspaceCache(STANDARD_COMMAND_MENU_ITEM_UNIVERSAL_IDENTIFIERS);
+
+    await runOnWorkspace();
+
+    expect(
+      validateBuildAndRunLegacyWorkspaceMigrationMock,
+    ).not.toHaveBeenCalled();
+  });
+
+  it('does not write metadata in dry-run mode', async () => {
+    mockWorkspaceCache([]);
+
+    await runOnWorkspace(true);
+
+    expect(
+      validateBuildAndRunLegacyWorkspaceMigrationMock,
+    ).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
- After a rocky multi-version upgrade, a workspace can end up with all of its standard `commandMenuItem` rows gone (record actions menu and bulk action bar empty), with no supported way to get them back.
- `install-pre-installed-apps` doesn't help: `ApplicationInstallService.installApplication` returns immediately for any `LOCAL`-sourced app registration — which is how the Twenty Standard application is registered — so it never reaches the manifest-sync path that would (re)create `commandMenuItem` rows.
- The Twenty Standard application is also deliberately never re-synced onto existing workspaces (see `upgrade:1-21:fix-message-thread-view-and-label-identifier`'s own description), so there's no other existing lever to pull.

## Change
Add `upgrade:2-27:recreate-missing-standard-command-menu-items`: for a given workspace, diff the code-defined standard command menu item set against what's actually present and create only the ones missing, by universal identifier.

Deliberately **create-only**, not a full resync:
- A full `synchronizeTwentyStandardApplicationOrThrow` (the path used for brand-new workspace provisioning) spans 18 standard metadata types, several of which (`view`, `role`, `permissionFlag`, `pageLayout*`) are legitimately user-customizable — reusing it here with `inferDeletionFromMissingEntities: true` risks silently reverting or deleting a user's intentional changes.
- This mirrors the existing, narrower precedent commands (`add-compose-email-command-menu-item`, `configure-message-campaign-command-menu`): only fill genuine gaps, never touch an item that already exists.
- Idempotent — running it again on an already-healthy workspace is a no-op (`validateBuildAndRunLegacyWorkspaceMigration` isn't even called).

## Test plan
- [x] New unit tests: recreates all missing items, recreates only the gap on a partially-seeded workspace, no-ops when everything already exists, no-ops in dry-run mode (4/4 passing)
- [x] `npx nx typecheck twenty-server`
- [x] `npx oxlint --type-aware` on the changed/new files (0 warnings/errors)

Fixes #22605

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/23692?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

