### PR TITLE
Filter connected account webhook renewal to exclude accounts with failed authentication errors

### DIFF
--- a/packages/twenty-server/src/modules/connected-account/webhook-subscription-manager/crons/jobs/webhook-subscription-renewal.cron.job.ts
+++ b/packages/twenty-server/src/modules/connected-account/webhook-subscription-manager/crons/jobs/webhook-subscription-renewal.cron.job.ts
@@ -6,7 +6,13 @@ import {
   WebhookSubscriptionStatus,
 } from 'twenty-shared/types';
 import { WorkspaceActivationStatus } from 'twenty-shared/workspace';
-import { type FindManyOptions, In, LessThanOrEqual, Repository } from 'typeorm';
+import {
+  type FindManyOptions,
+  In,
+  IsNull,
+  LessThanOrEqual,
+  Repository,
+} from 'typeorm';
 
 import { SentryCronMonitor } from 'src/engine/core-modules/cron/sentry-cron-monitor.decorator';
 import { InjectMessageQueue } from 'src/engine/core-modules/message-queue/decorators/message-queue.decorator';
@@ -94,7 +100,10 @@ export class WebhookSubscriptionRenewalCronJob {
     repository: Repository<TChannel>,
     activeWorkspaceIds: string[],
   ): Promise<StaleChannel[]> {
-    const workspaceScope = { workspaceId: In(activeWorkspaceIds) };
+    const workspaceScope = {
+      workspaceId: In(activeWorkspaceIds),
+      connectedAccount: { authFailedAt: IsNull() },
+    };
     const renewalThreshold = new Date(
       Date.now() + WEBHOOK_SUBSCRIPTION_RENEWAL_BUFFER_MS,
     );


### PR DESCRIPTION
/closes TWENTY-SERVER-J1F

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/23694?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

