### PR TITLE
ci(pr-review): dispatch the review on PR open

### DIFF
--- a/.github/workflows/pr-review-dispatch.yaml
+++ b/.github/workflows/pr-review-dispatch.yaml
@@ -3,7 +3,7 @@ run-name: "PR Review Dispatch #${{ github.event.pull_request.number }}"
 
 on:
   pull_request_target:
-    types: [ready_for_review, synchronize, labeled]
+    types: [opened, ready_for_review, synchronize, labeled]
 
 permissions: {}
 


### PR DESCRIPTION
## Problem

`pr-review-dispatch.yaml` listens to `pull_request_target` types `[ready_for_review, synchronize, labeled]` — **not `opened`**. A PR opened directly as non-draft (what `gh pr create` / the API produce) fires none of those, so it gets no review until a later push (`synchronize`), a draft→ready toggle (`ready_for_review`), or a `pr-review-*` label. Members hit this constantly — #23697 was opened non-draft by a member and got no review.

## Change

Add `opened` to the trigger list. That is the whole change — one word:

```yaml
types: [opened, ready_for_review, synchronize, labeled]
```

*Which* checks run is decided entirely by the orchestrator in `ci-privileged` (security+triage for everyone, `standard` only for core-team authors on non-draft PRs — see twentyhq/ci-privileged#65). So the dispatcher stays purely event-driven with **no author-role logic**.

| Event | Before | After |
|-------|--------|-------|
| opened, non-draft | no dispatch | **dispatch** |
| opened, draft | no dispatch | no dispatch |
| synchronize / ready_for_review | dispatch | dispatch (unchanged) |
| labeled `pr-review-*` | dispatch | dispatch (unchanged) |
| labeled other | no dispatch | no dispatch (unchanged) |

External contributors' PRs are auto-drafted on open by `external-contributor-pr-auto-draft`, so for them this fires the auto gate on open and again on `ready_for_review`; `concurrency: cancel-in-progress` collapses any overlap.
