### PR TITLE
fix: expand navigation folders without redirecting

### DIFF
--- a/packages/twenty-front/src/modules/navigation-menu-item/display/folder/hooks/useNavigationMenuItemFolderOpenState.ts
+++ b/packages/twenty-front/src/modules/navigation-menu-item/display/folder/hooks/useNavigationMenuItemFolderOpenState.ts
@@ -1,22 +1,12 @@
-import { isNonEmptyString } from '@sniptt/guards';
 import { useState } from 'react';
-import { useNavigate } from 'react-router-dom';
-import { NavigationMenuItemType } from 'twenty-shared/types';
-import { isDefined } from 'twenty-shared/utils';
 import { useIsMobile } from 'twenty-ui/utilities';
 import { type NavigationMenuItem } from '~/generated-metadata/graphql';
 
 import { currentNavigationMenuItemFolderIdState } from '@/navigation-menu-item/common/states/currentNavigationMenuItemFolderIdState';
-import { lastClickedNavigationMenuItemIdState } from '@/navigation-menu-item/common/states/lastClickedNavigationMenuItemIdState';
 import { openNavigationMenuItemFolderIdsState } from '@/navigation-menu-item/common/states/openNavigationMenuItemFolderIdsState';
 import { useIdentifyActiveNavigationMenuItems } from '@/navigation-menu-item/display/hooks/useIdentifyActiveNavigationMenuItems';
-import { getNavigationMenuItemComputedLink } from '@/navigation-menu-item/display/utils/getNavigationMenuItemComputedLink';
-import { objectMetadataItemsSelector } from '@/object-metadata/states/objectMetadataItemsSelector';
 import { useAtomState } from '@/ui/utilities/state/jotai/hooks/useAtomState';
-import { useAtomStateValue } from '@/ui/utilities/state/jotai/hooks/useAtomStateValue';
 import { useSetAtomState } from '@/ui/utilities/state/jotai/hooks/useSetAtomState';
-import { viewsSelector } from '@/views/states/selectors/viewsSelector';
-import { lastVisitedViewPerObjectMetadataItemState } from '@/navigation/states/lastVisitedViewPerObjectMetadataItemState';
 
 type UseNavigationMenuItemFolderOpenStateParams = {
   folderId: string;
@@ -27,13 +17,7 @@ export const useNavigationMenuItemFolderOpenState = ({
   folderId,
   folderChildrenNavigationMenuItems,
 }: UseNavigationMenuItemFolderOpenStateParams) => {
-  const navigate = useNavigate();
   const isMobile = useIsMobile();
-  const objectMetadataItems = useAtomStateValue(objectMetadataItemsSelector);
-  const views = useAtomStateValue(viewsSelector);
-  const lastVisitedViewPerObjectMetadataItem = useAtomStateValue(
-    lastVisitedViewPerObjectMetadataItemState,
-  );
 
   const [openNavigationMenuItemFolderIds, setOpenNavigationMenuItemFolderIds] =
     useAtomState(openNavigationMenuItemFolderIdsState);
@@ -43,9 +27,6 @@ export const useNavigationMenuItemFolderOpenState = ({
 
   const { activeNavigationMenuItemIds } =
     useIdentifyActiveNavigationMenuItems();
-  const setLastClickedNavigationMenuItemId = useSetAtomState(
-    lastClickedNavigationMenuItemIdState,
-  );
 
   const [isManuallyClosed, setIsManuallyClosed] = useState(false);
 
@@ -70,35 +51,6 @@ export const useNavigationMenuItemFolderOpenState = ({
             : [...current, folderId],
       );
       setIsManuallyClosed(isOpen);
-    }
-
-    if (!isOpen) {
-      const firstNonLinkItem = folderChildrenNavigationMenuItems.find(
-        (item) => {
-          if (item.type === NavigationMenuItemType.LINK) {
-            return false;
-          }
-          const computedLink = getNavigationMenuItemComputedLink({
-            item,
-            objectMetadataItems,
-            views,
-            lastVisitedViewPerObjectMetadataItem,
-          });
-          return isNonEmptyString(computedLink);
-        },
-      );
-      if (isDefined(firstNonLinkItem)) {
-        const link = getNavigationMenuItemComputedLink({
-          item: firstNonLinkItem,
-          objectMetadataItems,
-          views,
-          lastVisitedViewPerObjectMetadataItem,
-        });
-        if (isNonEmptyString(link)) {
-          setLastClickedNavigationMenuItemId(firstNonLinkItem.id);
-          navigate(link);
-        }
-      }
     }
   };
 


### PR DESCRIPTION
## Summary

- Remove automatic navigation to the first item when expanding a navigation folder.
- Keep the existing expand and collapse behavior unchanged.

Closes #23683

## Testing

- `oxlint` without type-aware analysis: passed with 0 warnings and 0 errors
- `oxfmt --check`: passed
- `git diff --check`: passed
- Full typecheck and type-aware lint could not complete locally due to Codespaces resource limits (`SIGTERM`); these checks are left to CI.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/23703?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

