### PR TITLE
fix(settings): invalidate Apollo cache on connected account updates (#19273)

### DIFF
--- a/packages/twenty-front/src/modules/settings/accounts/hooks/useConnectedImapSmtpCaldavAccount.ts
+++ b/packages/twenty-front/src/modules/settings/accounts/hooks/useConnectedImapSmtpCaldavAccount.ts
@@ -15,6 +15,7 @@ export const useConnectedImapSmtpCaldavAccount = (
     {
       variables: { id: connectedAccountId ?? '' },
       skip: !connectedAccountId,
+      fetchPolicy: 'cache-and-network',
     },
   );
 

--- a/packages/twenty-front/src/modules/settings/accounts/hooks/useImapSmtpCaldavConnectionForm.ts
+++ b/packages/twenty-front/src/modules/settings/accounts/hooks/useImapSmtpCaldavConnectionForm.ts
@@ -10,6 +10,7 @@ import { SettingsPath } from 'twenty-shared/types';
 import {
   type ConnectionParametersInput,
   EmailConnectionSecurity,
+  GetConnectedImapSmtpCaldavAccountDocument,
   SaveImapSmtpCaldavAccountDocument,
 } from '~/generated-metadata/graphql';
 import { useNavigateSettings } from '~/hooks/useNavigateSettings';
@@ -111,6 +112,9 @@ export const useImapSmtpCaldavConnectionForm = ({
 
   const [saveConnection, { loading: saveLoading }] = useMutation(
     SaveImapSmtpCaldavAccountDocument,
+    {
+      refetchQueries: [GetConnectedImapSmtpCaldavAccountDocument],
+    },
   );
 
   const watchedValues = watch();


### PR DESCRIPTION
## Description
Resolves an issue where editing an existing connected account's connection settings (CalDAV/IMAP/SMTP) appears to succeed in the UI, but Apollo Client's cache serves stale account data on subsequent form views.

## Root Cause
1. `useConnectedImapSmtpCaldavAccount` executed `useQuery` with default cache policy (`cache-first`).
2. `useImapSmtpCaldavConnectionForm` executed `saveConnection` mutation without instructing Apollo to refetch `GetConnectedImapSmtpCaldavAccountDocument`.

## Fix Applied
1. Added `fetchPolicy: 'cache-and-network'` to `useConnectedImapSmtpCaldavAccount`.
2. Added `refetchQueries: [GetConnectedImapSmtpCaldavAccountDocument]` to the `saveConnection` mutation options in `useImapSmtpCaldavConnectionForm.ts`.

Fixes #19273

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/23706?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

