### PR TITLE
ci(pr-review): dispatch on PR open (standard review only)

### DIFF
--- a/.github/workflows/pr-review-dispatch.yaml
+++ b/.github/workflows/pr-review-dispatch.yaml
@@ -3,7 +3,7 @@ run-name: "PR Review Dispatch #${{ github.event.pull_request.number }}"
 
 on:
   pull_request_target:
-    types: [ready_for_review, synchronize, labeled]
+    types: [opened, ready_for_review, synchronize, labeled]
 
 permissions: {}
 
@@ -33,6 +33,8 @@ jobs:
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
+          EVENT: ${{ github.event.action }}
         run: |
           gh workflow run pr-review.yaml --repo twentyhq/ci-privileged --ref main \
-            -f pr_number="$PR_NUMBER"
+            -f pr_number="$PR_NUMBER" \
+            -f event="$EVENT"


### PR DESCRIPTION
## Why

A PR opened directly as non-draft (the normal member flow: push branch → `gh pr create`) fires no dispatcher trigger — the initial commits arrived before the PR existed, so they're an `opened` event, not `synchronize`. With no `opened` trigger, such a PR gets **no review at all** unless it's later pushed to or manually labelled. This is live today: #23697 and #23707 are core-team PRs sitting with the bot's `-PR: draft` label but zero "PR Review" status.

## Change

Add `opened` back to the dispatcher, and forward the triggering PR event to the orchestrator:

```yaml
types: [opened, ready_for_review, synchronize, labeled]
# ...
-f pr_number="$PR_NUMBER" -f event="$EVENT"
```

The orchestrator (twentyhq/ci-privileged#65) maps **`opened` → standard review only**; `security` + `triage` stay on pushes / ready-for-review. So opening a PR gives core-team authors the standard (architectural) review early, without firing the full gate on open, and the "opened and never pushed again" hole is closed.

No author-role logic lives here — the dispatcher just forwards `pr_number` + `event`; all who-gets-what policy is resolved in the orchestrator.

## Merge order

Depends on **twentyhq/ci-privileged#65** (adds the `event` input). Merge that first — it's backward-compatible (empty `event` = today's auto-gate behaviour), so nothing breaks in between.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/23708?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

