### PR TITLE
Update soft delete query to include deleted records

### DIFF
--- a/packages/twenty-server/src/engine/twenty-orm/repository/workspace-soft-delete-query-builder.ts
+++ b/packages/twenty-server/src/engine/twenty-orm/repository/workspace-soft-delete-query-builder.ts
@@ -112,9 +112,11 @@ export class WorkspaceSoftDeleteQueryBuilder<
 
       const typeORMSoftRemoveResultWithOnlyIdColumn = await super.execute();
 
-      const afterWithAllFields = await beforeEventSelectQueryBuilder.getMany({
-        noFormatting: true,
-      });
+      const afterWithAllFields = await beforeEventSelectQueryBuilder
+        .withDeleted()
+        .getMany({
+          noFormatting: true,
+        });
 
       const formattedAfter = formatResult<T[]>(
         afterWithAllFields,


### PR DESCRIPTION
Updated the post-soft-delete event lookup to call .withDeleted() before fetching recordsAfter. Since TypeORM excludes soft-deleted records from normal SELECT queries, the deleted record was unavailable during event formatting, causing DELETED events to be dropped and preventing deletion webhooks from being queued.

This change ensures the soft-deleted record remains available after the delete operation so DELETED events are correctly emitted and webhook jobs are created.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/23725?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

