### PR TITLE
fix(navigation): expand side nav folders without auto-opening first-listed option (#23683)

### DIFF
--- a/packages/twenty-front/src/modules/navigation-menu-item/display/folder/hooks/useNavigationMenuItemFolderOpenState.ts
+++ b/packages/twenty-front/src/modules/navigation-menu-item/display/folder/hooks/useNavigationMenuItemFolderOpenState.ts
@@ -71,35 +71,6 @@ export const useNavigationMenuItemFolderOpenState = ({
       );
       setIsManuallyClosed(isOpen);
     }
-
-    if (!isOpen) {
-      const firstNonLinkItem = folderChildrenNavigationMenuItems.find(
-        (item) => {
-          if (item.type === NavigationMenuItemType.LINK) {
-            return false;
-          }
-          const computedLink = getNavigationMenuItemComputedLink({
-            item,
-            objectMetadataItems,
-            views,
-            lastVisitedViewPerObjectMetadataItem,
-          });
-          return isNonEmptyString(computedLink);
-        },
-      );
-      if (isDefined(firstNonLinkItem)) {
-        const link = getNavigationMenuItemComputedLink({
-          item: firstNonLinkItem,
-          objectMetadataItems,
-          views,
-          lastVisitedViewPerObjectMetadataItem,
-        });
-        if (isNonEmptyString(link)) {
-          setLastClickedNavigationMenuItemId(firstNonLinkItem.id);
-          navigate(link);
-        }
-      }
-    }
   };
 
   return {

--- a/packages/twenty-front/src/modules/settings/accounts/hooks/useConnectedImapSmtpCaldavAccount.ts
+++ b/packages/twenty-front/src/modules/settings/accounts/hooks/useConnectedImapSmtpCaldavAccount.ts
@@ -15,6 +15,7 @@ export const useConnectedImapSmtpCaldavAccount = (
     {
       variables: { id: connectedAccountId ?? '' },
       skip: !connectedAccountId,
+      fetchPolicy: 'cache-and-network',
     },
   );
 

--- a/packages/twenty-front/src/modules/settings/accounts/hooks/useImapSmtpCaldavConnectionForm.ts
+++ b/packages/twenty-front/src/modules/settings/accounts/hooks/useImapSmtpCaldavConnectionForm.ts
@@ -10,6 +10,7 @@ import { SettingsPath } from 'twenty-shared/types';
 import {
   type ConnectionParametersInput,
   EmailConnectionSecurity,
+  GetConnectedImapSmtpCaldavAccountDocument,
   SaveImapSmtpCaldavAccountDocument,
 } from '~/generated-metadata/graphql';
 import { useNavigateSettings } from '~/hooks/useNavigateSettings';
@@ -111,6 +112,9 @@ export const useImapSmtpCaldavConnectionForm = ({
 
   const [saveConnection, { loading: saveLoading }] = useMutation(
     SaveImapSmtpCaldavAccountDocument,
+    {
+      refetchQueries: [GetConnectedImapSmtpCaldavAccountDocument],
+    },
   );
 
   const watchedValues = watch();


### PR DESCRIPTION
## Issue
Closes #23683

## Summary
Prevents double page loads and lag when clicking to expand side nav menu folders by eliminating the forced auto-navigation to the first child item.

## Changes
Updated `useNavigationMenuItemFolderOpenState.ts` to toggle folder expansion without calling `navigate(link)` on `handleToggle`. Users can now expand any folder to view its options and click directly on their target view.

## Acceptance criteria
- [x] Clicking folder header expands/collapses list without auto-navigating to first-listed option
- [x] Eliminates unnecessary page loads when accessing secondary or tertiary folder items
- [x] Retains active item state and mobile drawer collapse logic

/claim #23683

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/23727?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

