### PR TITLE
`[APP_PROD_PARITY]` Do not merge Enable cookie-based sessions by default

### DIFF
--- a/packages/twenty-server/src/engine/core-modules/twenty-config/config-variables.ts
+++ b/packages/twenty-server/src/engine/core-modules/twenty-config/config-variables.ts
@@ -369,7 +369,7 @@ export class ConfigVariables {
     type: ConfigVariableType.BOOLEAN,
   })
   @IsOptional()
-  AUTH_COOKIE_SESSIONS_ENABLED = false;
+  AUTH_COOKIE_SESSIONS_ENABLED = true;
 
   @ConfigVariablesMetadata({
     group: ConfigVariablesGroup.TOKENS_DURATION,


### PR DESCRIPTION
Flips the default of `AUTH_COOKIE_SESSIONS_ENABLED` from `false` to `true` in `config-variables.ts`, so cookie-based user sessions are active unless explicitly disabled.

Labeled with `run-e2e-apps-prod-parity-tests` to run the app prod-parity e2e suite with the flag on.

---
_Generated by [Claude Code](https://claude.ai/code/session_01J4srXoSyVfuvSUXwvfbj2f)_

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/23732?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

