### PR TITLE
chore(codeowners): guard .claude, .mcp.json and CLAUDE.md

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -4,3 +4,6 @@
 /.github/actions/      @charlesBochet @FelixMalfait @Weiko @prastoin @bosiraphael @etiennejouan @ijreilly @martmull @thomtrp
 /.github/dependabot.yml @charlesBochet @FelixMalfait @Weiko @prastoin @bosiraphael @etiennejouan @ijreilly @martmull @thomtrp
 /.yarnrc.yml           @charlesBochet @FelixMalfait @Weiko @prastoin @bosiraphael @etiennejouan @ijreilly @martmull @thomtrp
+/.claude/              @charlesBochet @FelixMalfait @Weiko @prastoin @bosiraphael @etiennejouan @ijreilly @martmull @thomtrp
+/.mcp.json             @charlesBochet @FelixMalfait @Weiko @prastoin @bosiraphael @etiennejouan @ijreilly @martmull @thomtrp
+/CLAUDE.md             @charlesBochet @FelixMalfait @Weiko @prastoin @bosiraphael @etiennejouan @ijreilly @martmull @thomtrp


### PR DESCRIPTION
## What

Adds `.claude/`, `.mcp.json` and `CLAUDE.md` to CODEOWNERS.

## Why

These files configure the coding agent that maintainers attach to PRs: `SessionStart` hooks, MCP servers, and agent instructions. They were previously outside CODEOWNERS coverage (which only spanned `.github/` and `.yarnrc.yml`), so a change to any of them could land on `main` without core-team review.

CODEOWNERS gates merge approval only. It does not affect an unmerged branch that a session merely checks out, so this closes the "malicious agent config quietly lands on main" path, not fork-branch execution. It is one layer, not the whole answer.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/23734?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

