### PR TITLE
fix(logic-function): apply field-watch filter to upserted database events

### DIFF
--- a/packages/twenty-server/src/engine/core-modules/logic-function/logic-function-trigger/triggers/database-event/utils/__tests__/transform-event-batch-to-event-payloads.spec.ts
+++ b/packages/twenty-server/src/engine/core-modules/logic-function/logic-function-trigger/triggers/database-event/utils/__tests__/transform-event-batch-to-event-payloads.spec.ts
@@ -424,6 +424,68 @@ describe('transformEventBatchToEventPayloads', () => {
     });
   });
 
+  describe('upserted event filtering', () => {
+    it('should filter upserted events by updatedFields the same way as updated events', () => {
+      const workspaceEventBatch = createMockWorkspaceEventBatch({
+        name: 'company.upserted',
+        events: [
+          createMockEvent({
+            recordId: 'record-1',
+            properties: { after: {}, updatedFields: ['gstin'] },
+          }),
+          createMockEvent({
+            recordId: 'record-2',
+            properties: { after: {}, updatedFields: ['name'] },
+          }),
+        ],
+      });
+      const logicFunctions = [
+        createMockLogicFunction({
+          databaseEventTriggerSettings: {
+            eventName: 'company.upserted',
+            updatedFields: ['gstin'],
+          },
+        }),
+      ];
+
+      const result = transformEventBatchToEventPayloads({
+        workspaceEventBatch,
+        logicFunctions,
+      });
+
+      expect(result).toHaveLength(1);
+      expect((result[0].payload as ObjectRecordEvent).recordId).toBe('record-1');
+    });
+
+    it('should include all upserted events when no updatedFields filter is set', () => {
+      const workspaceEventBatch = createMockWorkspaceEventBatch({
+        name: 'company.upserted',
+        events: [
+          createMockEvent({
+            recordId: 'record-1',
+            properties: { after: {}, updatedFields: ['gstin'] },
+          }),
+          createMockEvent({
+            recordId: 'record-2',
+            properties: { after: {}, updatedFields: ['name'] },
+          }),
+        ],
+      });
+      const logicFunctions = [
+        createMockLogicFunction({
+          databaseEventTriggerSettings: { eventName: 'company.upserted' },
+        }),
+      ];
+
+      const result = transformEventBatchToEventPayloads({
+        workspaceEventBatch,
+        logicFunctions,
+      });
+
+      expect(result).toHaveLength(2);
+    });
+  });
+
   describe('edge cases', () => {
     it('should return empty array when no logic functions provided', () => {
       const workspaceEventBatch = createMockWorkspaceEventBatch();

--- a/packages/twenty-server/src/engine/core-modules/logic-function/logic-function-trigger/triggers/database-event/utils/transform-event-batch-to-event-payloads.ts
+++ b/packages/twenty-server/src/engine/core-modules/logic-function/logic-function-trigger/triggers/database-event/utils/transform-event-batch-to-event-payloads.ts
@@ -53,7 +53,7 @@ const filterEventsByUpdatedFields = ({
   operation: string;
   triggerUpdatedFields?: string[];
 }): ObjectRecordEvent[] => {
-  if (operation !== 'updated') {
+  if (operation !== 'updated' && operation !== 'upserted') {
     return events;
   }
 


### PR DESCRIPTION
## What

`filterEventsByUpdatedFields` only applied the `triggerUpdatedFields` filter when `operation === 'updated'`. For `upserted` events the condition short-circuited and returned all events unfiltered, so workflow triggers with a "Fields to watch" configuration fired on every upsert regardless of which fields actually changed.

## Why

The `upserted` operation is semantically equivalent to `updated` for filtering purposes — both operations include an `updatedFields` array in the event properties, and the UI exposes the same "Fields to watch" multiselect for both trigger types. The omission was a simple one-line oversight.

## Fix

```diff
- if (operation !== 'updated') {
+ if (operation !== 'updated' && operation !== 'upserted') {
```

Two tests added:
- `upserted` events with a field filter: only events whose `updatedFields` match pass through
- `upserted` events without a field filter: all events pass through

Fixes #22876

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/23735?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

