### PR TITLE
Update website release notes through 2.26

### DIFF
--- a/packages/twenty-website/src/platform/releases/ReleaseNotes.tsx
+++ b/packages/twenty-website/src/platform/releases/ReleaseNotes.tsx
@@ -5,6 +5,359 @@ import { type ReleaseNote } from './release-note';
 
 export const RELEASE_NOTES: ReleaseNote[] = [
   {
+    release: '2.26.0',
+    date: '2026-07-31',
+    highlights: [
+      {
+        title: msg`Richer relation layouts`,
+        description: (
+          <Trans>
+            Display related records as a table, kanban board, calendar, or
+            grouped table directly inside a record page.
+          </Trans>
+        ),
+      },
+      {
+        title: msg`Preview records while you search`,
+        description: (
+          <Trans>
+            Move through command bar results to see the fields that matter
+            before opening a record.
+          </Trans>
+        ),
+      },
+    ],
+  },
+  {
+    release: '2.24.0',
+    date: '2026-07-24',
+    highlights: [
+      {
+        title: msg`More visual dashboard views`,
+        description: (
+          <Trans>
+            Show records in dashboard widgets as grouped tables, kanban boards,
+            or calendars instead of flat tables only.
+          </Trans>
+        ),
+      },
+      {
+        title: msg`Drag widgets between tabs`,
+        description: (
+          <Trans>
+            Move widgets between record page tabs with drag and drop, including
+            directly onto an empty tab.
+          </Trans>
+        ),
+      },
+      {
+        title: msg`Share call insights`,
+        description: (
+          <Trans>
+            Copy a call recording's transcript or video link directly from the
+            record page.
+          </Trans>
+        ),
+      },
+    ],
+  },
+  {
+    release: '2.22.0',
+    date: '2026-07-17',
+    highlights: [
+      {
+        title: msg`Reorder kanban columns`,
+        description: (
+          <Trans>
+            Drag kanban column headers into the order that works best for your
+            team.
+          </Trans>
+        ),
+      },
+    ],
+  },
+  {
+    release: '2.20.0',
+    date: '2026-07-10',
+    highlights: [
+      {
+        title: msg`Build dashboards with AI`,
+        description: (
+          <Trans>
+            Ask AI to build or reconfigure dashboards and views from your
+            workspace data.
+          </Trans>
+        ),
+      },
+      {
+        title: msg`Featured apps`,
+        description: (
+          <Trans>
+            Find and install featured apps such as People Data Labs, Last
+            Contact, and Call Recorder directly from the marketplace.
+          </Trans>
+        ),
+      },
+      {
+        title: msg`Smarter email recipients`,
+        description: (
+          <Trans>
+            Add recipients with autocomplete, person matching, duplicate
+            detection, and inline email validation.
+          </Trans>
+        ),
+      },
+    ],
+  },
+  {
+    release: '2.18.0',
+    date: '2026-07-02',
+    highlights: [
+      {
+        title: msg`A new onboarding experience`,
+        description: (
+          <Trans>
+            A rebuilt setup flow guides new teams through workspace creation,
+            contact import, and teammate invitations.
+          </Trans>
+        ),
+      },
+      {
+        title: msg`Reliable AI data imports`,
+        description: (
+          <Trans>
+            Import larger CSV and spreadsheet files through AI chat with more
+            reliable relation matching and bulk updates.
+          </Trans>
+        ),
+      },
+      {
+        title: msg`Create synced calendar events`,
+        description: (
+          <Trans>
+            Create events on connected Google or Microsoft calendars from AI and
+            workflows, with optional Meet or Teams links.
+          </Trans>
+        ),
+      },
+      {
+        title: msg`Group records by relationships`,
+        description: (
+          <Trans>
+            Group table and kanban views by a related record, such as an account
+            owner or company.
+          </Trans>
+        ),
+      },
+    ],
+  },
+  {
+    release: '2.16.0',
+    date: '2026-06-25',
+    highlights: [
+      {
+        title: msg`Live email and calendar tabs`,
+        description: (
+          <Trans>
+            New emails and calendar events now appear on record pages without a
+            manual refresh.
+          </Trans>
+        ),
+      },
+      {
+        title: msg`Resizable kanban columns`,
+        description: (
+          <Trans>
+            Drag a column edge to resize every column in a kanban view, with the
+            width saved for that view.
+          </Trans>
+        ),
+      },
+      {
+        title: msg`Smarter record assignment`,
+        description: (
+          <Trans>
+            Workflows can pick records randomly, in round-robin order, or by
+            choosing the least-loaded assignee.
+          </Trans>
+        ),
+      },
+    ],
+  },
+  {
+    release: '2.14.0',
+    date: '2026-06-15',
+    highlights: [
+      {
+        title: msg`Retry failed workflows`,
+        description: (
+          <Trans>
+            Restart a failed workflow run from the step that failed instead of
+            running everything again.
+          </Trans>
+        ),
+      },
+      {
+        title: msg`Clearer dashboard numbers`,
+        description: (
+          <Trans>
+            Choose between abbreviated and full values for number widgets on
+            dashboards.
+          </Trans>
+        ),
+      },
+    ],
+  },
+  {
+    release: '2.12.0',
+    date: '2026-06-12',
+    highlights: [
+      {
+        title: msg`Inline image previews`,
+        description: (
+          <Trans>
+            Image attachments now show a thumbnail inside file field chips, so
+            they are easier to identify at a glance.
+          </Trans>
+        ),
+      },
+      {
+        title: msg`Better sorted kanban boards`,
+        description: (
+          <Trans>
+            Move cards between kanban columns without removing the view's active
+            sort.
+          </Trans>
+        ),
+      },
+    ],
+  },
+  {
+    release: '2.9.0',
+    date: '2026-06-05',
+    highlights: [
+      {
+        title: msg`Relation tables on record pages`,
+        description: (
+          <Trans>
+            Display related records as a full table directly inside a record
+            page layout.
+          </Trans>
+        ),
+      },
+      {
+        title: msg`Easier favorites`,
+        description: (
+          <Trans>
+            Add objects, views, records, links, and folders to Favorites from a
+            dedicated sidebar panel.
+          </Trans>
+        ),
+      },
+      {
+        title: msg`Step-by-step workflow logs`,
+        description: (
+          <Trans>
+            Inspect AI calls, code output, HTTP requests, and emails for every
+            step of a workflow run.
+          </Trans>
+        ),
+      },
+    ],
+  },
+  {
+    release: '2.8.0',
+    date: '2026-05-26',
+    highlights: [
+      {
+        title: msg`Editable text widgets`,
+        description: (
+          <Trans>
+            Edit long-form text directly inside record page widgets with
+            automatic saving.
+          </Trans>
+        ),
+      },
+    ],
+  },
+  {
+    release: '2.6.0',
+    date: '2026-05-19',
+    highlights: [
+      {
+        title: msg`Filter through relationships`,
+        description: (
+          <Trans>
+            Filter records using fields from a related object, such as People
+            whose Company name contains a specific value.
+          </Trans>
+        ),
+      },
+      {
+        title: msg`Sort composite fields`,
+        description: (
+          <Trans>
+            Choose which part of a name or address field a view should sort by
+            directly from the sort chip.
+          </Trans>
+        ),
+      },
+    ],
+  },
+  {
+    release: '2.4.0',
+    date: '2026-05-14',
+    highlights: [
+      {
+        title: msg`Email forwarding`,
+        description: (
+          <Trans>
+            Forward shared inboxes such as support@yourcompany.com into Twenty
+            without connecting a full mailbox.
+          </Trans>
+        ),
+      },
+    ],
+  },
+  {
+    release: '2.2.0',
+    date: '2026-05-04',
+    highlights: [
+      {
+        title: msg`Recurring Google Calendar events`,
+        description: (
+          <Trans>
+            Recurring events from connected Google calendars now stay in sync
+            with Twenty.
+          </Trans>
+        ),
+      },
+      {
+        title: msg`Organized AI chats`,
+        description: (
+          <Trans>
+            Filter, archive, and manage conversations from the AI chat list.
+          </Trans>
+        ),
+      },
+    ],
+  },
+  {
+    release: '2.1.0',
+    date: '2026-04-24',
+    highlights: [
+      {
+        title: msg`Ready-to-use object pages`,
+        description: (
+          <Trans>
+            New objects now start with a record page layout and fields view
+            ready to customize.
+          </Trans>
+        ),
+      },
+    ],
+  },
+  {
     release: '2.0.0',
     date: '2026-04-21',
     highlights: [

--- a/packages/twenty-website/src/platform/releases/latest-release.ts
+++ b/packages/twenty-website/src/platform/releases/latest-release.ts
@@ -7,7 +7,7 @@ export const LATEST_RELEASE: {
   title: string;
   previewImage: string;
 } = {
-  release: '2.0.0',
-  title: 'Build an app',
-  previewImage: '/images/releases/2.0/2.0.0-build-anything.webp',
+  release: '2.26.0',
+  title: 'Richer relation layouts',
+  previewImage: '/images/releases/2.0/2.0.0-custom-layouts.webp',
 };


### PR DESCRIPTION
## Summary

- Add weekly, user-facing release notes from 2.1 through 2.26.
- Highlight completed, generally available product features and exclude Labs or rollout-gated work.
- Update the Releases menu preview to the latest 2.26 entry.

## Before/After

Before: production ends at 2.0. After: the changelog includes weekly releases through 2.26.

<img width="2268" height="720" alt="before-after" src="https://github.com/user-attachments/assets/7ebf0154-596a-4846-b148-3d9aeff7cf0e" />


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/23736?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

