### PR TITLE
fix(twenty-orm): add withDeleted() to before-fetch in soft-delete restore path

### DIFF
--- a/packages/twenty-server/src/engine/twenty-orm/repository/workspace-soft-delete-query-builder.ts
+++ b/packages/twenty-server/src/engine/twenty-orm/repository/workspace-soft-delete-query-builder.ts
@@ -100,9 +100,11 @@ export class WorkspaceSoftDeleteQueryBuilder<
 
       const tableName = computeObjectTargetTable(objectMetadata);
 
-      const before = await beforeEventSelectQueryBuilder.getMany({
-        noFormatting: true,
-      });
+      const before = await beforeEventSelectQueryBuilder
+        .withDeleted()
+        .getMany({
+          noFormatting: true,
+        });
 
       this.expressionMap.wheres = applyTableAliasOnWhereCondition({
         condition: this.expressionMap.wheres,


### PR DESCRIPTION
## What

Restoring a soft-deleted record returned a 500 error and fired no webhook.

## Why

`WorkspaceSoftDeleteQueryBuilder.execute()` fetches `before` on line 103 with a plain `getMany()`. TypeORM automatically appends `WHERE deletedAt IS NULL` to `getMany()` — but the record being restored has `deletedAt` set, so `before` returns `[]`.

`formatTwentyOrmEventToDatabaseBatchEvent` then receives `recordsBefore = []` and `recordsAfter = [record]` for the `RESTORED` action and throws `TwentyORMException: Record mismatch detected`.

## Fix

Add `.withDeleted()` to the `beforeEventSelectQueryBuilder` call for the restore path so soft-deleted rows are included in the fetch.

PR #23725 fixed the same pattern for the `after`-fetch (DELETE path) but left the `before`-fetch (RESTORE path) unpatched. This PR closes the remaining gap.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/23737?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

