### PR TITLE
ci(preview-env): a preview app on every PR, at a stable URL

### DIFF
--- a/.github/workflows/preview-env-dispatch.yaml
+++ b/.github/workflows/preview-env-dispatch.yaml
@@ -12,21 +12,7 @@ concurrency:
 
 jobs:
   trigger-preview:
-    if: |
-      (github.event.action == 'labeled' && github.event.label.name == 'preview-app') ||
-      (
-        (
-          github.event.pull_request.author_association == 'MEMBER' ||
-          github.event.pull_request.author_association == 'OWNER' ||
-          github.event.pull_request.author_association == 'COLLABORATOR' ||
-          github.event.pull_request.author_association == 'CONTRIBUTOR'
-        ) && (
-          github.event.action == 'opened' ||
-          github.event.action == 'synchronize' ||
-          github.event.action == 'reopened' ||
-          github.event.action == 'ready_for_review'
-        )
-      )
+    if: github.event.action != 'labeled' || github.event.label.name == 'preview-app'
     timeout-minutes: 5
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/preview-env-dispatch.yaml
+++ b/.github/workflows/preview-env-dispatch.yaml
@@ -18,7 +18,8 @@ jobs:
         (
           github.event.pull_request.author_association == 'MEMBER' ||
           github.event.pull_request.author_association == 'OWNER' ||
-          github.event.pull_request.author_association == 'COLLABORATOR'
+          github.event.pull_request.author_association == 'COLLABORATOR' ||
+          github.event.pull_request.author_association == 'CONTRIBUTOR'
         ) && (
           github.event.action == 'opened' ||
           github.event.action == 'synchronize' ||

--- a/.github/workflows/preview-env-dispatch.yaml
+++ b/.github/workflows/preview-env-dispatch.yaml
@@ -12,10 +12,7 @@ concurrency:
 
 jobs:
   trigger-preview:
-    if: |
-      github.event.action != 'closed' && (
-        github.event.action != 'labeled' || github.event.label.name == 'preview-app'
-      )
+    if: github.event.action != 'labeled' || github.event.label.name == 'preview-app'
     timeout-minutes: 5
     runs-on: ubuntu-latest
     steps:
@@ -34,6 +31,7 @@ jobs:
           permission-actions: write
 
       - name: Dispatch preview-env-prepare to ci-privileged
+        if: github.event.action != 'closed'
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
@@ -45,22 +43,8 @@ jobs:
             -f pr_head_sha="$PR_HEAD_SHA" \
             -f repo="$REPOSITORY"
 
-  trigger-cleanup:
-    if: github.event.action == 'closed'
-    timeout-minutes: 5
-    runs-on: ubuntu-latest
-    steps:
-      - name: Mint ci-privileged dispatch token
-        id: app-token
-        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
-        with:
-          client-id: ${{ vars.TWENTY_WORKFLOW_DISPATCHER_CLIENT_ID }}
-          private-key: ${{ secrets.TWENTY_WORKFLOW_DISPATCHER_PRIVATE_KEY }}
-          owner: twentyhq
-          repositories: ci-privileged
-          permission-actions: write
-
       - name: Dispatch preview-env-cleanup to ci-privileged
+        if: github.event.action == 'closed'
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
           PR_NUMBER: ${{ github.event.pull_request.number }}

--- a/.github/workflows/preview-env-dispatch.yaml
+++ b/.github/workflows/preview-env-dispatch.yaml
@@ -5,6 +5,11 @@ permissions: {}
 on:
   pull_request_target:
     types: [opened, synchronize, reopened, ready_for_review, labeled, closed]
+    paths:
+      - packages/twenty-docker/**
+      - packages/twenty-server/**
+      - packages/twenty-front/**
+      - .github/workflows/preview-env-dispatch.yaml
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number }}

--- a/.github/workflows/preview-env-dispatch.yaml
+++ b/.github/workflows/preview-env-dispatch.yaml
@@ -4,20 +4,9 @@ permissions: {}
 
 on:
   pull_request_target:
-    # Draft PRs are included on purpose: a preview env is most useful while the
-    # work is still in progress. `ready_for_review` is here because a draft can
-    # sit for days, and the env it got on `opened` expires after 5h — flipping
-    # it out of draft mints a fresh one without needing a dummy push.
     types: [opened, synchronize, reopened, ready_for_review, labeled]
-    paths:
-      - packages/twenty-docker/**
-      - packages/twenty-server/**
-      - packages/twenty-front/**
-      - .github/workflows/preview-env-dispatch.yaml
 
 concurrency:
-  # Keyed on PR number so independent PRs don't cancel each other. `github.ref`
-  # resolves to the base branch under pull_request_target and would collide.
   group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
   cancel-in-progress: true
 

--- a/.github/workflows/preview-env-dispatch.yaml
+++ b/.github/workflows/preview-env-dispatch.yaml
@@ -4,7 +4,11 @@ permissions: {}
 
 on:
   pull_request_target:
-    types: [opened, synchronize, reopened, labeled]
+    # Draft PRs are included on purpose: a preview env is most useful while the
+    # work is still in progress. `ready_for_review` is here because a draft can
+    # sit for days, and the env it got on `opened` expires after 5h — flipping
+    # it out of draft mints a fresh one without needing a dummy push.
+    types: [opened, synchronize, reopened, ready_for_review, labeled]
     paths:
       - packages/twenty-docker/**
       - packages/twenty-server/**
@@ -12,7 +16,9 @@ on:
       - .github/workflows/preview-env-dispatch.yaml
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  # Keyed on PR number so independent PRs don't cancel each other. `github.ref`
+  # resolves to the base branch under pull_request_target and would collide.
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
   cancel-in-progress: true
 
 jobs:
@@ -27,7 +33,8 @@ jobs:
         ) && (
           github.event.action == 'opened' ||
           github.event.action == 'synchronize' ||
-          github.event.action == 'reopened'
+          github.event.action == 'reopened' ||
+          github.event.action == 'ready_for_review'
         )
       )
     timeout-minutes: 5

--- a/.github/workflows/preview-env-dispatch.yaml
+++ b/.github/workflows/preview-env-dispatch.yaml
@@ -4,7 +4,7 @@ permissions: {}
 
 on:
   pull_request_target:
-    types: [opened, synchronize, reopened, ready_for_review, labeled]
+    types: [opened, synchronize, reopened, ready_for_review, labeled, closed]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
@@ -12,32 +12,58 @@ concurrency:
 
 jobs:
   trigger-preview:
-    if: github.event.action != 'labeled' || github.event.label.name == 'preview-app'
+    if: |
+      github.event.action != 'closed' && (
+        github.event.action != 'labeled' || github.event.label.name == 'preview-app'
+      )
     timeout-minutes: 5
     runs-on: ubuntu-latest
     steps:
-      # Preview envs run on the PUBLIC ci-public repo so the 5h keepalive job
-      # consumes free Actions minutes (private repos bill them). ci-public holds
-      # no privileged secret: it starts the tunnel and dispatches the URL back to
-      # ci-privileged for the PR comment *before* running any PR-controlled code.
-      - name: Mint ci-public dispatch token
+      # The preview env itself runs on the PUBLIC ci-public repo so the 5h
+      # keepalive consumes free Actions minutes (private repos bill them).
+      # ci-privileged provisions the tunnel and posts the URL first, so ci-public
+      # holds no GitHub credential while running PR-controlled code.
+      - name: Mint ci-privileged dispatch token
         id: app-token
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
           client-id: ${{ vars.TWENTY_WORKFLOW_DISPATCHER_CLIENT_ID }}
           private-key: ${{ secrets.TWENTY_WORKFLOW_DISPATCHER_PRIVATE_KEY }}
           owner: twentyhq
-          repositories: ci-public
+          repositories: ci-privileged
           permission-actions: write
 
-      - name: Dispatch preview-env to ci-public
+      - name: Dispatch preview-env-prepare to ci-privileged
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
           PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
           REPOSITORY: ${{ github.repository }}
         run: |
-          gh workflow run preview-env.yaml --repo twentyhq/ci-public --ref main \
+          gh workflow run preview-env-prepare.yaml --repo twentyhq/ci-privileged --ref main \
             -f pr_number="$PR_NUMBER" \
             -f pr_head_sha="$PR_HEAD_SHA" \
             -f repo="$REPOSITORY"
+
+  trigger-cleanup:
+    if: github.event.action == 'closed'
+    timeout-minutes: 5
+    runs-on: ubuntu-latest
+    steps:
+      - name: Mint ci-privileged dispatch token
+        id: app-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          client-id: ${{ vars.TWENTY_WORKFLOW_DISPATCHER_CLIENT_ID }}
+          private-key: ${{ secrets.TWENTY_WORKFLOW_DISPATCHER_PRIVATE_KEY }}
+          owner: twentyhq
+          repositories: ci-privileged
+          permission-actions: write
+
+      - name: Dispatch preview-env-cleanup to ci-privileged
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          gh workflow run preview-env-cleanup.yaml --repo twentyhq/ci-privileged --ref main \
+            -f pr_number="$PR_NUMBER"


### PR DESCRIPTION
A preview env now runs on every PR touching the app, whatever the author, and lives at a stable `pr-<n>.twenty-preview.com` address.

Requires twentyhq/ci-privileged#72 and twentyhq/ci-public#4 to be merged first, since the dispatch targets `--ref main`.

**Coverage**

- Drop the author-association gate. External contributions previously needed a maintainer to add the `preview-app` label.
- Add `ready_for_review`, so a draft sitting past the 5h expiry gets a fresh env when marked ready rather than needing a dummy push.
- Key the concurrency group on the PR number instead of `github.ref`, which under `pull_request_target` resolves to the base branch and is therefore shared by every open PR.

The `paths` filter is unchanged. Drafts were already covered before this: `opened` and `synchronize` fire on draft PRs and there is no `draft` gate anywhere in the chain.

**Stable URL, and why it is also the security fix**

Dispatch now goes to ci-privileged rather than straight to ci-public. ci-privileged provisions a named Cloudflare tunnel, assigns `pr-<n>.twenty-preview.com`, and posts the comment before the build starts.

That matters beyond bookmarkable links. ci-public executes PR-controlled code with passwordless sudo, and any secret a job references stays resident on the runner for the job's whole duration, so `PREVIEW_DISPATCH_APP_PRIVATE_KEY` was recoverable from runner process memory. That key existed only so ci-public could report its random `*.trycloudflare.com` URL back. A deterministic hostname removes the reverse channel, and ci-public now holds no GitHub credential at all.

The tunnel is reused across pushes rather than recreated, so a superseded environment keeps serving until the new build connects and the URL is never dead. Concurrent 5h runs per PR remain, as before.

**Cleanup**

`closed` is added to the trigger types and dispatches teardown of the tunnel, DNS record and per-PR secret. Nothing was cleaned up before because nothing persisted.

The `preview-app` label is kept as the manual re-trigger. Note that a preview obtained by label on a PR outside the `paths` filter will not receive its `closed` cleanup event.