### PR TITLE
fix: validate every item in a comma-separated cron field

### DIFF
--- a/packages/twenty-front/src/modules/workflow/workflow-trigger/utils/cron-to-human/__tests__/validateCronField.test.ts
+++ b/packages/twenty-front/src/modules/workflow/workflow-trigger/utils/cron-to-human/__tests__/validateCronField.test.ts
@@ -1,0 +1,31 @@
+import { validateCronField } from '@/workflow/workflow-trigger/utils/cron-to-human/utils/validateCronField';
+
+describe('validateCronField', () => {
+  it('should accept wildcards, values, ranges and steps', () => {
+    expect(validateCronField('*', 'hours')).toBe(true);
+    expect(validateCronField('9', 'hours')).toBe(true);
+    expect(validateCronField('1-5', 'hours')).toBe(true);
+    expect(validateCronField('*/5', 'hours')).toBe(true);
+    expect(validateCronField('1,2,3', 'minutes')).toBe(true);
+  });
+
+  it('should reject values outside the field range', () => {
+    expect(validateCronField('99', 'hours')).toBe(false);
+    expect(validateCronField('60', 'minutes')).toBe(false);
+    expect(validateCronField('1-99', 'hours')).toBe(false);
+  });
+
+  it('should validate every item of a comma-separated list, not just the first', () => {
+    // Regression: '-'/'/' used to be handled before ',', so only the first list
+    // item was checked and out-of-range items after it were silently accepted.
+    expect(validateCronField('1-5,10', 'hours')).toBe(true);
+    expect(validateCronField('1-5,99', 'hours')).toBe(false);
+    expect(validateCronField('0-23,88,77', 'hours')).toBe(false);
+    expect(validateCronField('*/5,999', 'hours')).toBe(false);
+  });
+
+  it('should treat 0 and 7 as valid days of week', () => {
+    expect(validateCronField('0-7,7', 'dayOfWeek')).toBe(true);
+    expect(validateCronField('8', 'dayOfWeek')).toBe(false);
+  });
+});

--- a/packages/twenty-front/src/modules/workflow/workflow-trigger/utils/cron-to-human/utils/validateCronField.ts
+++ b/packages/twenty-front/src/modules/workflow/workflow-trigger/utils/cron-to-human/utils/validateCronField.ts
@@ -34,6 +34,15 @@ export const validateCronField = (
     return false;
   }
 
+  // A cron field is a comma-separated list, so split it first and validate each
+  // item on its own. Handling '-'/'/' before ',' meant only the first list item
+  // was checked (e.g. '1-5,99' passed because '99' was never validated).
+  if (value.includes(',')) {
+    return value
+      .split(',')
+      .every((item) => validateCronField(item.trim(), fieldType));
+  }
+
   if (value.includes('/')) {
     const [rangePart, stepPart] = value.split('/');
     const step = parseInt(stepPart, 10);
@@ -65,11 +74,6 @@ export const validateCronField = (
       end <= range.max &&
       start <= end
     );
-  }
-
-  if (value.includes(',')) {
-    const values = value.split(',');
-    return values.every((val) => validateCronField(val.trim(), fieldType));
   }
 
   const numValue = parseInt(value, 10);


### PR DESCRIPTION
## What

`validateCronField` checks `/` (step) and `-` (range) before `,` (list), but a cron field is fundamentally a comma-separated list. When the first list item is a range or step, only that first item gets validated and the rest is silently dropped, because `value.split('-')` / `value.split('/')` run before the comma is considered and `parseInt` truncates at the comma.

So invalid fields pass validation:

```ts
validateCronField('1-5,99', 'hours');      // -> true (99 > 23)
validateCronField('0-23,88,77', 'hours');  // -> true (88, 77 ignored)
validateCronField('*/5,999', 'hours');     // -> true (999 ignored)
```

This feeds the scheduled-trigger cron validation (`parseCronExpression`), so an invalid cron expression can slip through.

## Fix

Split on `,` first and validate each list item on its own; each item then flows through the existing value/range/step logic.

```ts
validateCronField('1-5,99', 'hours');  // -> false
validateCronField('1-5,10', 'hours');  // -> true  (still valid)
```

Added a regression test in `cron-to-human/__tests__/validateCronField.test.ts`.

## Testing

I verified the before/after behavior directly against the function's logic. I could not run the full `twenty-front` jest suite locally (fresh clone, no install), so the added unit test covers the fix and CI runs the suite.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/23745?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

