### PR TITLE
Ignore expired invitations in invitation lookups

### DIFF
--- a/packages/twenty-server/src/engine/core-modules/auth/services/auth.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/auth/services/auth.service.ts
@@ -807,7 +807,10 @@ export class AuthService {
       .andWhere('"appToken".type IN (:...types)', {
         types: INVITATION_APP_TOKEN_TYPES,
       })
-      .andWhere('"appToken"."deletedAt" IS NULL');
+      .andWhere('"appToken"."deletedAt" IS NULL')
+      .andWhere('"appToken"."expiresAt" > :now', {
+        now: new Date(),
+      });
 
     if ('workspacePersonalInviteToken' in params) {
       qr.andWhere('"appToken".value = :personalInviteToken', {

--- a/packages/twenty-server/src/engine/core-modules/workspace-invitation/services/workspace-invitation.service.spec.ts
+++ b/packages/twenty-server/src/engine/core-modules/workspace-invitation/services/workspace-invitation.service.spec.ts
@@ -155,11 +155,7 @@ describe('WorkspaceInvitationService', () => {
       const email = 'test@example.com';
       const workspace = { id: 'workspace-id' } as WorkspaceEntity;
 
-      jest.spyOn(appTokenRepository, 'createQueryBuilder').mockReturnValue({
-        where: jest.fn().mockReturnThis(),
-        andWhere: jest.fn().mockReturnThis(),
-        getOne: jest.fn().mockResolvedValue(null),
-      } as any);
+      jest.spyOn(appTokenRepository, 'findOne').mockResolvedValue(null);
 
       jest.spyOn(userWorkspaceRepository, 'exists').mockResolvedValue(false);
       jest
@@ -175,11 +171,9 @@ describe('WorkspaceInvitationService', () => {
       const email = 'test@example.com';
       const workspace = { id: 'workspace-id' } as WorkspaceEntity;
 
-      jest.spyOn(appTokenRepository, 'createQueryBuilder').mockReturnValue({
-        where: jest.fn().mockReturnThis(),
-        andWhere: jest.fn().mockReturnThis(),
-        getOne: jest.fn().mockResolvedValue({}),
-      } as any);
+      jest
+        .spyOn(appTokenRepository, 'findOne')
+        .mockResolvedValue({} as AppTokenEntity);
 
       await expect(
         service.createWorkspaceInvitation(email, workspace),

--- a/packages/twenty-server/src/engine/core-modules/workspace-invitation/services/workspace-invitation.service.spec.ts
+++ b/packages/twenty-server/src/engine/core-modules/workspace-invitation/services/workspace-invitation.service.spec.ts
@@ -1,7 +1,7 @@
 import { Test, type TestingModule } from '@nestjs/testing';
 import { getRepositoryToken } from '@nestjs/typeorm';
 
-import { Repository } from 'typeorm';
+import { type DeleteResult, Repository } from 'typeorm';
 
 import {
   AppTokenEntity,
@@ -156,6 +156,9 @@ describe('WorkspaceInvitationService', () => {
       const workspace = { id: 'workspace-id' } as WorkspaceEntity;
 
       jest.spyOn(appTokenRepository, 'findOne').mockResolvedValue(null);
+      jest
+        .spyOn(appTokenRepository, 'delete')
+        .mockResolvedValue({} as DeleteResult);
 
       jest.spyOn(userWorkspaceRepository, 'exists').mockResolvedValue(false);
       jest

--- a/packages/twenty-server/src/engine/core-modules/workspace-invitation/services/workspace-invitation.service.spec.ts
+++ b/packages/twenty-server/src/engine/core-modules/workspace-invitation/services/workspace-invitation.service.spec.ts
@@ -155,7 +155,11 @@ describe('WorkspaceInvitationService', () => {
       const email = 'test@example.com';
       const workspace = { id: 'workspace-id' } as WorkspaceEntity;
 
-      jest.spyOn(appTokenRepository, 'findOne').mockResolvedValue(null);
+      jest.spyOn(appTokenRepository, 'createQueryBuilder').mockReturnValue({
+        where: jest.fn().mockReturnThis(),
+        andWhere: jest.fn().mockReturnThis(),
+        getOne: jest.fn().mockResolvedValue(null),
+      } as any);
 
       jest.spyOn(userWorkspaceRepository, 'exists').mockResolvedValue(false);
       jest
@@ -171,9 +175,11 @@ describe('WorkspaceInvitationService', () => {
       const email = 'test@example.com';
       const workspace = { id: 'workspace-id' } as WorkspaceEntity;
 
-      jest
-        .spyOn(appTokenRepository, 'findOne')
-        .mockResolvedValue({} as AppTokenEntity);
+      jest.spyOn(appTokenRepository, 'createQueryBuilder').mockReturnValue({
+        where: jest.fn().mockReturnThis(),
+        andWhere: jest.fn().mockReturnThis(),
+        getOne: jest.fn().mockResolvedValue({}),
+      } as any);
 
       await expect(
         service.createWorkspaceInvitation(email, workspace),

--- a/packages/twenty-server/src/engine/core-modules/workspace-invitation/services/workspace-invitation.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/workspace-invitation/services/workspace-invitation.service.ts
@@ -9,7 +9,7 @@ import ms from 'ms';
 import { SendInviteLinkEmail, renderEmail } from 'twenty-emails';
 import { AppPath, FileFolder } from 'twenty-shared/types';
 import { getAppPath, isDefined } from 'twenty-shared/utils';
-import { In, IsNull, MoreThan, Raw, Repository } from 'typeorm';
+import { In, IsNull, Repository } from 'typeorm';
 
 import {
   AppTokenEntity,
@@ -109,15 +109,20 @@ export class WorkspaceInvitationService {
   }
 
   async getOneWorkspaceInvitation(workspaceId: string, email: string) {
-    return await this.appTokenRepository.findOne({
-      where: {
+    return await this.appTokenRepository
+      .createQueryBuilder('appToken')
+      .where('"appToken"."workspaceId" = :workspaceId', {
         workspaceId,
-        type: In(INVITATION_APP_TOKEN_TYPES),
-        deletedAt: IsNull(),
-        expiresAt: MoreThan(new Date()),
-        context: Raw((alias) => `${alias} ->> 'email' = :email`, { email }),
-      },
-    });
+      })
+      .andWhere('"appToken".type IN (:...types)', {
+        types: INVITATION_APP_TOKEN_TYPES,
+      })
+      .andWhere('"appToken".context->>\'email\' = :email', { email })
+      .andWhere('appToken.deletedAt IS NULL')
+      .andWhere('appToken.expiresAt > :now', {
+        now: new Date(),
+      })
+      .getOne();
   }
 
   async getAppTokenByInvitationToken(invitationToken: string) {

--- a/packages/twenty-server/src/engine/core-modules/workspace-invitation/services/workspace-invitation.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/workspace-invitation/services/workspace-invitation.service.ts
@@ -9,7 +9,14 @@ import ms from 'ms';
 import { SendInviteLinkEmail, renderEmail } from 'twenty-emails';
 import { AppPath, FileFolder } from 'twenty-shared/types';
 import { getAppPath, isDefined } from 'twenty-shared/utils';
-import { In, IsNull, MoreThan, Raw, Repository } from 'typeorm';
+import {
+  In,
+  IsNull,
+  LessThanOrEqual,
+  MoreThan,
+  Raw,
+  Repository,
+} from 'typeorm';
 
 import {
   AppTokenEntity,
@@ -190,6 +197,17 @@ export class WorkspaceInvitationService {
         WorkspaceInvitationExceptionCode.USER_ALREADY_EXIST,
       );
     }
+
+    // Expired invitations are ignored by getOneWorkspaceInvitation, so without
+    // this they would pile up in the database on every re-invite.
+    await this.appTokenRepository.delete({
+      workspaceId: workspace.id,
+      type: In(INVITATION_APP_TOKEN_TYPES),
+      expiresAt: LessThanOrEqual(new Date()),
+      context: Raw((alias) => `${alias} ->> 'email' = :email`, {
+        email: email.toLowerCase(),
+      }),
+    });
 
     return this.generateInvitationToken(
       workspace.id,

--- a/packages/twenty-server/src/engine/core-modules/workspace-invitation/services/workspace-invitation.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/workspace-invitation/services/workspace-invitation.service.ts
@@ -118,6 +118,10 @@ export class WorkspaceInvitationService {
         types: INVITATION_APP_TOKEN_TYPES,
       })
       .andWhere('"appToken".context->>\'email\' = :email', { email })
+      .andWhere('appToken.deletedAt IS NULL')
+      .andWhere('appToken.expiresAt > :now', {
+        now: new Date(),
+      })
       .getOne();
   }
 

--- a/packages/twenty-server/src/engine/core-modules/workspace-invitation/services/workspace-invitation.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/workspace-invitation/services/workspace-invitation.service.ts
@@ -9,7 +9,7 @@ import ms from 'ms';
 import { SendInviteLinkEmail, renderEmail } from 'twenty-emails';
 import { AppPath, FileFolder } from 'twenty-shared/types';
 import { getAppPath, isDefined } from 'twenty-shared/utils';
-import { In, IsNull, MoreThan, Repository } from 'typeorm';
+import { In, IsNull, MoreThan, Raw, Repository } from 'typeorm';
 
 import {
   AppTokenEntity,
@@ -109,20 +109,15 @@ export class WorkspaceInvitationService {
   }
 
   async getOneWorkspaceInvitation(workspaceId: string, email: string) {
-    return await this.appTokenRepository
-      .createQueryBuilder('appToken')
-      .where('"appToken"."workspaceId" = :workspaceId', {
+    return await this.appTokenRepository.findOne({
+      where: {
         workspaceId,
-      })
-      .andWhere('"appToken".type IN (:...types)', {
-        types: INVITATION_APP_TOKEN_TYPES,
-      })
-      .andWhere('"appToken".context->>\'email\' = :email', { email })
-      .andWhere('"appToken"."deletedAt" IS NULL')
-      .andWhere('"appToken"."expiresAt" > :now', {
-        now: new Date(),
-      })
-      .getOne();
+        type: In(INVITATION_APP_TOKEN_TYPES),
+        deletedAt: IsNull(),
+        expiresAt: MoreThan(new Date()),
+        context: Raw((alias) => `${alias} ->> 'email' = :email`, { email }),
+      },
+    });
   }
 
   async getAppTokenByInvitationToken(invitationToken: string) {

--- a/packages/twenty-server/src/engine/core-modules/workspace-invitation/services/workspace-invitation.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/workspace-invitation/services/workspace-invitation.service.ts
@@ -9,7 +9,7 @@ import ms from 'ms';
 import { SendInviteLinkEmail, renderEmail } from 'twenty-emails';
 import { AppPath, FileFolder } from 'twenty-shared/types';
 import { getAppPath, isDefined } from 'twenty-shared/utils';
-import { In, IsNull, Repository } from 'typeorm';
+import { In, IsNull, MoreThan, Repository } from 'typeorm';
 
 import {
   AppTokenEntity,
@@ -469,6 +469,7 @@ export class WorkspaceInvitationService {
         workspaceId,
         type: AppTokenType.OnboardingInvitationToken,
         deletedAt: IsNull(),
+        expiresAt: MoreThan(new Date()),
       },
     });
 

--- a/packages/twenty-server/src/engine/core-modules/workspace-invitation/services/workspace-invitation.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/workspace-invitation/services/workspace-invitation.service.ts
@@ -118,8 +118,8 @@ export class WorkspaceInvitationService {
         types: INVITATION_APP_TOKEN_TYPES,
       })
       .andWhere('"appToken".context->>\'email\' = :email', { email })
-      .andWhere('appToken.deletedAt IS NULL')
-      .andWhere('appToken.expiresAt > :now', {
+      .andWhere('"appToken"."deletedAt" IS NULL')
+      .andWhere('"appToken"."expiresAt" > :now', {
         now: new Date(),
       })
       .getOne();

--- a/packages/twenty-server/src/engine/core-modules/workspace-invitation/services/workspace-invitation.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/workspace-invitation/services/workspace-invitation.service.ts
@@ -9,7 +9,7 @@ import ms from 'ms';
 import { SendInviteLinkEmail, renderEmail } from 'twenty-emails';
 import { AppPath, FileFolder } from 'twenty-shared/types';
 import { getAppPath, isDefined } from 'twenty-shared/utils';
-import { In, IsNull, Repository } from 'typeorm';
+import { In, IsNull, MoreThan, Raw, Repository } from 'typeorm';
 
 import {
   AppTokenEntity,
@@ -109,20 +109,15 @@ export class WorkspaceInvitationService {
   }
 
   async getOneWorkspaceInvitation(workspaceId: string, email: string) {
-    return await this.appTokenRepository
-      .createQueryBuilder('appToken')
-      .where('"appToken"."workspaceId" = :workspaceId', {
+    return await this.appTokenRepository.findOne({
+      where: {
         workspaceId,
-      })
-      .andWhere('"appToken".type IN (:...types)', {
-        types: INVITATION_APP_TOKEN_TYPES,
-      })
-      .andWhere('"appToken".context->>\'email\' = :email', { email })
-      .andWhere('appToken.deletedAt IS NULL')
-      .andWhere('appToken.expiresAt > :now', {
-        now: new Date(),
-      })
-      .getOne();
+        type: In(INVITATION_APP_TOKEN_TYPES),
+        deletedAt: IsNull(),
+        expiresAt: MoreThan(new Date()),
+        context: Raw((alias) => `${alias} ->> 'email' = :email`, { email }),
+      },
+    });
   }
 
   async getAppTokenByInvitationToken(invitationToken: string) {

--- a/packages/twenty-server/src/engine/core-modules/workspace-invitation/services/workspace-invitation.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/workspace-invitation/services/workspace-invitation.service.ts
@@ -198,8 +198,6 @@ export class WorkspaceInvitationService {
       );
     }
 
-    // Expired invitations are ignored by getOneWorkspaceInvitation, so without
-    // this they would pile up in the database on every re-invite.
     await this.appTokenRepository.delete({
       workspaceId: workspace.id,
       type: In(INVITATION_APP_TOKEN_TYPES),

--- a/packages/twenty-server/test/integration/graphql/suites/__snapshots__/expired-workspace-invitation.integration-spec.ts.snap
+++ b/packages/twenty-server/test/integration/graphql/suites/__snapshots__/expired-workspace-invitation.integration-spec.ts.snap
@@ -1,0 +1,13 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`expired workspace invitation filtering signUpInWorkspace with a personal invite token denies access when the personal invitation is expired 1`] = `
+{
+  "extensions": {
+    "code": "FORBIDDEN",
+    "subCode": "FORBIDDEN_EXCEPTION",
+    "userFriendlyMessage": "User does not have access to this workspace",
+  },
+  "message": "User does not have access to this workspace",
+  "name": "ForbiddenError",
+}
+`;

--- a/packages/twenty-server/test/integration/graphql/suites/auth/sign-up/__snapshots__/failing-sign-up-with-expired-invitation.integration-spec.ts.snap
+++ b/packages/twenty-server/test/integration/graphql/suites/auth/sign-up/__snapshots__/failing-sign-up-with-expired-invitation.integration-spec.ts.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`expired workspace invitation filtering signUpInWorkspace with a personal invite token denies access when the personal invitation is expired 1`] = `
+exports[`signUpInWorkspace with an expired personal invitation (integration) denies access when the personal invitation is expired 1`] = `
 {
   "extensions": {
     "code": "FORBIDDEN",

--- a/packages/twenty-server/test/integration/graphql/suites/auth/sign-up/failing-sign-up-with-expired-invitation.integration-spec.ts
+++ b/packages/twenty-server/test/integration/graphql/suites/auth/sign-up/failing-sign-up-with-expired-invitation.integration-spec.ts
@@ -1,0 +1,40 @@
+import { expectOneNotInternalServerErrorSnapshot } from 'test/integration/graphql/utils/expect-one-not-internal-server-error-snapshot.util';
+import {
+  deleteWorkspaceInvitationsByEmail,
+  seedWorkspaceInvitation,
+} from 'test/integration/graphql/utils/seed-workspace-invitation.util';
+import { signUpInWorkspaceOperationFactory } from 'test/integration/graphql/utils/sign-up-in-workspace-operation-factory.util';
+import { makeMetadataAPIRequest } from 'test/integration/metadata/suites/utils/make-metadata-api-request.util';
+
+import { SEED_APPLE_WORKSPACE_ID } from 'src/engine/workspace-manager/dev-seeder/core/constants/seeder-workspaces.constant';
+
+const ONE_HOUR_IN_MS = 60 * 60 * 1000;
+
+describe('signUpInWorkspace with an expired personal invitation (integration)', () => {
+  const email = `expired-invite-signup-${Date.now()}@example.com`;
+  const token = `expired-invite-signup-token-${Date.now()}`;
+
+  beforeAll(() =>
+    seedWorkspaceInvitation({
+      email,
+      value: token,
+      expiresAt: new Date(Date.now() - ONE_HOUR_IN_MS),
+    }),
+  );
+
+  afterAll(() => deleteWorkspaceInvitationsByEmail({ email }));
+
+  it('denies access when the personal invitation is expired', async () => {
+    const response = await makeMetadataAPIRequest(
+      signUpInWorkspaceOperationFactory({
+        email,
+        workspaceId: SEED_APPLE_WORKSPACE_ID,
+        workspacePersonalInviteToken: token,
+      }),
+      undefined,
+    );
+
+    expect(response.body.data?.signUpInWorkspace).toBeFalsy();
+    expectOneNotInternalServerErrorSnapshot({ errors: response.body.errors });
+  });
+});

--- a/packages/twenty-server/test/integration/graphql/suites/auth/sign-up/successful-sign-up-with-valid-invitation.integration-spec.ts
+++ b/packages/twenty-server/test/integration/graphql/suites/auth/sign-up/successful-sign-up-with-valid-invitation.integration-spec.ts
@@ -1,0 +1,74 @@
+import { deleteUser } from 'test/integration/graphql/utils/delete-user.util';
+import { getAuthTokensFromLoginToken } from 'test/integration/graphql/utils/get-auth-tokens-from-login-token.util';
+import {
+  deleteWorkspaceInvitationsByEmail,
+  seedWorkspaceInvitation,
+} from 'test/integration/graphql/utils/seed-workspace-invitation.util';
+import { signUpInWorkspaceOperationFactory } from 'test/integration/graphql/utils/sign-up-in-workspace-operation-factory.util';
+import { makeMetadataAPIRequest } from 'test/integration/metadata/suites/utils/make-metadata-api-request.util';
+
+import { SEED_APPLE_WORKSPACE_ID } from 'src/engine/workspace-manager/dev-seeder/core/constants/seeder-workspaces.constant';
+
+const ONE_HOUR_IN_MS = 60 * 60 * 1000;
+
+// Counterpart to failing-sign-up-with-expired-invitation: proves the expiry
+// filter only rejects expired invitations and still admits valid ones.
+describe('signUpInWorkspace with a valid personal invitation (integration)', () => {
+  const email = `valid-invite-signup-${Date.now()}@example.com`;
+  const token = `valid-invite-signup-token-${Date.now()}`;
+
+  let accessToken: string | undefined;
+
+  beforeAll(() =>
+    seedWorkspaceInvitation({
+      email,
+      value: token,
+      expiresAt: new Date(Date.now() + ONE_HOUR_IN_MS),
+    }),
+  );
+
+  afterAll(async () => {
+    if (accessToken) {
+      await deleteUser({ accessToken, expectToFail: false });
+    }
+
+    await deleteWorkspaceInvitationsByEmail({ email });
+  });
+
+  it('grants access when the personal invitation is still valid', async () => {
+    const response = await makeMetadataAPIRequest(
+      signUpInWorkspaceOperationFactory({
+        email,
+        workspaceId: SEED_APPLE_WORKSPACE_ID,
+        workspacePersonalInviteToken: token,
+      }),
+      undefined,
+    );
+
+    expect(response.body.errors).toBeUndefined();
+
+    const signUpPayload = response.body.data.signUpInWorkspace;
+
+    expect(signUpPayload.workspace.id).toBe(SEED_APPLE_WORKSPACE_ID);
+    expect(signUpPayload.loginToken.token).toBeDefined();
+
+    await testDataSource.query(
+      'UPDATE core."user" SET "isEmailVerified" = true WHERE email = $1',
+      [email],
+    );
+
+    const {
+      data: { getAuthTokensFromLoginToken: authTokensData },
+    } = await getAuthTokensFromLoginToken({
+      loginToken: signUpPayload.loginToken.token,
+      origin:
+        signUpPayload.workspace.workspaceUrls?.subdomainUrl ??
+        'http://localhost:3001',
+      expectToFail: false,
+    });
+
+    accessToken = authTokensData.tokens.accessOrWorkspaceAgnosticToken.token;
+
+    expect(accessToken).toBeDefined();
+  });
+});

--- a/packages/twenty-server/test/integration/graphql/suites/auth/sign-up/successful-sign-up-with-valid-invitation.integration-spec.ts
+++ b/packages/twenty-server/test/integration/graphql/suites/auth/sign-up/successful-sign-up-with-valid-invitation.integration-spec.ts
@@ -11,8 +11,6 @@ import { SEED_APPLE_WORKSPACE_ID } from 'src/engine/workspace-manager/dev-seeder
 
 const ONE_HOUR_IN_MS = 60 * 60 * 1000;
 
-// Counterpart to failing-sign-up-with-expired-invitation: proves the expiry
-// filter only rejects expired invitations and still admits valid ones.
 describe('signUpInWorkspace with a valid personal invitation (integration)', () => {
   const email = `valid-invite-signup-${Date.now()}@example.com`;
   const token = `valid-invite-signup-token-${Date.now()}`;

--- a/packages/twenty-server/test/integration/graphql/suites/expired-workspace-invitation.integration-spec.ts
+++ b/packages/twenty-server/test/integration/graphql/suites/expired-workspace-invitation.integration-spec.ts
@@ -1,5 +1,5 @@
-import gql from 'graphql-tag';
 import { makeMetadataAPIRequest } from 'test/integration/metadata/suites/utils/make-metadata-api-request.util';
+import { sendInvitationsOperationFactory } from 'test/integration/graphql/utils/send-invitations-operation-factory.util';
 import { signUpInWorkspaceOperationFactory } from 'test/integration/graphql/utils/sign-up-in-workspace-operation-factory.util';
 
 import { AppTokenType } from 'src/engine/core-modules/app-token/app-token.entity';
@@ -64,16 +64,9 @@ describe('expired workspace invitation filtering', () => {
 
   describe('sendInvitations re-invite behaviour', () => {
     const sendInvitations = (email: string) =>
-      makeMetadataAPIRequest({
-        query: gql`
-          mutation SendInvitations($emails: [String!]!) {
-            sendInvitations(emails: $emails) {
-              success
-            }
-          }
-        `,
-        variables: { emails: [email] },
-      });
+      makeMetadataAPIRequest(
+        sendInvitationsOperationFactory({ emails: [email] }),
+      );
 
     it('re-invites an email whose only existing invitation is expired', async () => {
       const email = `expired-invite-resend-${Date.now()}@example.com`;

--- a/packages/twenty-server/test/integration/graphql/suites/expired-workspace-invitation.integration-spec.ts
+++ b/packages/twenty-server/test/integration/graphql/suites/expired-workspace-invitation.integration-spec.ts
@@ -1,5 +1,6 @@
 import {
   deleteWorkspaceInvitationsByEmail,
+  findWorkspaceInvitationsByEmail,
   seedWorkspaceInvitation,
 } from 'test/integration/graphql/utils/seed-workspace-invitation.util';
 import { sendInvitationsOperationFactory } from 'test/integration/graphql/utils/send-invitations-operation-factory.util';
@@ -15,10 +16,11 @@ describe('sendInvitations expired invitation handling (integration)', () => {
 
   it('re-invites an email whose only existing invitation is expired', async () => {
     const email = `expired-invite-resend-${Date.now()}@example.com`;
+    const staleToken = `expired-invite-resend-token-${Date.now()}`;
 
     await seedWorkspaceInvitation({
       email,
-      value: `expired-invite-resend-token-${Date.now()}`,
+      value: staleToken,
       expiresAt: new Date(Date.now() - ONE_HOUR_IN_MS),
     });
 
@@ -27,6 +29,15 @@ describe('sendInvitations expired invitation handling (integration)', () => {
 
       expect(response.body.errors).toBeUndefined();
       expect(response.body.data.sendInvitations.success).toBe(true);
+
+      // The expired token must be replaced, not accumulated alongside the new one.
+      const remainingTokens = await findWorkspaceInvitationsByEmail({ email });
+
+      expect(remainingTokens).toHaveLength(1);
+      expect(remainingTokens[0].value).not.toBe(staleToken);
+      expect(new Date(remainingTokens[0].expiresAt).getTime()).toBeGreaterThan(
+        Date.now(),
+      );
     } finally {
       await deleteWorkspaceInvitationsByEmail({ email });
     }

--- a/packages/twenty-server/test/integration/graphql/suites/expired-workspace-invitation.integration-spec.ts
+++ b/packages/twenty-server/test/integration/graphql/suites/expired-workspace-invitation.integration-spec.ts
@@ -30,7 +30,6 @@ describe('sendInvitations expired invitation handling (integration)', () => {
       expect(response.body.errors).toBeUndefined();
       expect(response.body.data.sendInvitations.success).toBe(true);
 
-      // The expired token must be replaced, not accumulated alongside the new one.
       const remainingTokens = await findWorkspaceInvitationsByEmail({ email });
 
       expect(remainingTokens).toHaveLength(1);

--- a/packages/twenty-server/test/integration/graphql/suites/expired-workspace-invitation.integration-spec.ts
+++ b/packages/twenty-server/test/integration/graphql/suites/expired-workspace-invitation.integration-spec.ts
@@ -1,173 +1,52 @@
-import { makeMetadataAPIRequest } from 'test/integration/metadata/suites/utils/make-metadata-api-request.util';
-import { deleteUser } from 'test/integration/graphql/utils/delete-user.util';
-import { expectOneNotInternalServerErrorSnapshot } from 'test/integration/graphql/utils/expect-one-not-internal-server-error-snapshot.util';
-import { getAuthTokensFromLoginToken } from 'test/integration/graphql/utils/get-auth-tokens-from-login-token.util';
+import {
+  deleteWorkspaceInvitationsByEmail,
+  seedWorkspaceInvitation,
+} from 'test/integration/graphql/utils/seed-workspace-invitation.util';
 import { sendInvitationsOperationFactory } from 'test/integration/graphql/utils/send-invitations-operation-factory.util';
-import { signUpInWorkspaceOperationFactory } from 'test/integration/graphql/utils/sign-up-in-workspace-operation-factory.util';
-
-import { AppTokenType } from 'src/engine/core-modules/app-token/app-token.entity';
-import { SEED_APPLE_WORKSPACE_ID } from 'src/engine/workspace-manager/dev-seeder/core/constants/seeder-workspaces.constant';
+import { makeMetadataAPIRequest } from 'test/integration/metadata/suites/utils/make-metadata-api-request.util';
 
 const ONE_HOUR_IN_MS = 60 * 60 * 1000;
 
-const seedInvitation = ({
-  email,
-  value,
-  expiresAt,
-}: {
-  email: string;
-  value: string;
-  expiresAt: Date;
-}) =>
-  testDataSource.query(
-    `INSERT INTO core."appToken" ("workspaceId", "type", "value", "expiresAt", "context")
-     VALUES ($1, $2, $3, $4, $5::jsonb)`,
-    [
-      SEED_APPLE_WORKSPACE_ID,
-      AppTokenType.InvitationToken,
-      value,
-      expiresAt.toISOString(),
-      JSON.stringify({ email }),
-    ],
-  );
+describe('sendInvitations expired invitation handling (integration)', () => {
+  const sendInvitations = (email: string) =>
+    makeMetadataAPIRequest(
+      sendInvitationsOperationFactory({ emails: [email] }),
+    );
 
-const removeSeededInvitations = (email: string) =>
-  testDataSource.query(
-    `DELETE FROM core."appToken" WHERE "workspaceId" = $1 AND context->>'email' = $2`,
-    [SEED_APPLE_WORKSPACE_ID, email],
-  );
+  it('re-invites an email whose only existing invitation is expired', async () => {
+    const email = `expired-invite-resend-${Date.now()}@example.com`;
 
-describe('expired workspace invitation filtering', () => {
-  describe('signUpInWorkspace with a personal invite token', () => {
-    const signUpWithInviteToken = ({
+    await seedWorkspaceInvitation({
       email,
-      token,
-    }: {
-      email: string;
-      token: string;
-    }) =>
-      makeMetadataAPIRequest(
-        signUpInWorkspaceOperationFactory({
-          email,
-          workspaceId: SEED_APPLE_WORKSPACE_ID,
-          workspacePersonalInviteToken: token,
-        }),
-        undefined,
-      );
-
-    it('denies access when the personal invitation is expired', async () => {
-      const email = `expired-invite-signup-${Date.now()}@example.com`;
-      const token = `expired-invite-signup-token-${Date.now()}`;
-
-      await seedInvitation({
-        email,
-        value: token,
-        expiresAt: new Date(Date.now() - ONE_HOUR_IN_MS),
-      });
-
-      try {
-        const response = await signUpWithInviteToken({ email, token });
-
-        expect(response.body.data?.signUpInWorkspace).toBeFalsy();
-        expectOneNotInternalServerErrorSnapshot({
-          errors: response.body.errors,
-        });
-      } finally {
-        await removeSeededInvitations(email);
-      }
+      value: `expired-invite-resend-token-${Date.now()}`,
+      expiresAt: new Date(Date.now() - ONE_HOUR_IN_MS),
     });
 
-    // Positive control: the denial above must come from the expiry filter, not
-    // from an unrelated rejection of the sign-up request itself.
-    it('grants access when the personal invitation is still valid', async () => {
-      const email = `valid-invite-signup-${Date.now()}@example.com`;
-      const token = `valid-invite-signup-token-${Date.now()}`;
+    try {
+      const response = await sendInvitations(email);
 
-      await seedInvitation({
-        email,
-        value: token,
-        expiresAt: new Date(Date.now() + ONE_HOUR_IN_MS),
-      });
-
-      let accessToken: string | undefined;
-
-      try {
-        const response = await signUpWithInviteToken({ email, token });
-
-        expect(response.body.errors).toBeUndefined();
-
-        const signUpPayload = response.body.data.signUpInWorkspace;
-
-        expect(signUpPayload.workspace.id).toBe(SEED_APPLE_WORKSPACE_ID);
-        expect(signUpPayload.loginToken.token).toBeDefined();
-
-        await testDataSource.query(
-          'UPDATE core."user" SET "isEmailVerified" = true WHERE email = $1',
-          [email],
-        );
-
-        const {
-          data: { getAuthTokensFromLoginToken: authTokensData },
-        } = await getAuthTokensFromLoginToken({
-          loginToken: signUpPayload.loginToken.token,
-          origin:
-            signUpPayload.workspace.workspaceUrls?.subdomainUrl ??
-            'http://localhost:3001',
-          expectToFail: false,
-        });
-
-        accessToken =
-          authTokensData.tokens.accessOrWorkspaceAgnosticToken.token;
-      } finally {
-        if (accessToken) {
-          await deleteUser({ accessToken, expectToFail: false });
-        }
-        await removeSeededInvitations(email);
-      }
-    });
+      expect(response.body.errors).toBeUndefined();
+      expect(response.body.data.sendInvitations.success).toBe(true);
+    } finally {
+      await deleteWorkspaceInvitationsByEmail({ email });
+    }
   });
 
-  describe('sendInvitations re-invite behaviour', () => {
-    const sendInvitations = (email: string) =>
-      makeMetadataAPIRequest(
-        sendInvitationsOperationFactory({ emails: [email] }),
-      );
+  it('still reports a valid invitation as already existing', async () => {
+    const email = `valid-invite-resend-${Date.now()}@example.com`;
 
-    it('re-invites an email whose only existing invitation is expired', async () => {
-      const email = `expired-invite-resend-${Date.now()}@example.com`;
-
-      await seedInvitation({
-        email,
-        value: `expired-invite-resend-token-${Date.now()}`,
-        expiresAt: new Date(Date.now() - ONE_HOUR_IN_MS),
-      });
-
-      try {
-        const response = await sendInvitations(email);
-
-        expect(response.body.errors).toBeUndefined();
-        expect(response.body.data.sendInvitations.success).toBe(true);
-      } finally {
-        await removeSeededInvitations(email);
-      }
+    await seedWorkspaceInvitation({
+      email,
+      value: `valid-invite-resend-token-${Date.now()}`,
+      expiresAt: new Date(Date.now() + ONE_HOUR_IN_MS),
     });
 
-    it('still reports a valid invitation as already existing', async () => {
-      const email = `valid-invite-resend-${Date.now()}@example.com`;
+    try {
+      const response = await sendInvitations(email);
 
-      await seedInvitation({
-        email,
-        value: `valid-invite-resend-token-${Date.now()}`,
-        expiresAt: new Date(Date.now() + ONE_HOUR_IN_MS),
-      });
-
-      try {
-        const response = await sendInvitations(email);
-
-        expect(response.body.data.sendInvitations.success).toBe(false);
-      } finally {
-        await removeSeededInvitations(email);
-      }
-    });
+      expect(response.body.data.sendInvitations.success).toBe(false);
+    } finally {
+      await deleteWorkspaceInvitationsByEmail({ email });
+    }
   });
 });

--- a/packages/twenty-server/test/integration/graphql/suites/expired-workspace-invitation.integration-spec.ts
+++ b/packages/twenty-server/test/integration/graphql/suites/expired-workspace-invitation.integration-spec.ts
@@ -1,11 +1,10 @@
-import request from 'supertest';
+import gql from 'graphql-tag';
+import { makeMetadataAPIRequest } from 'test/integration/metadata/suites/utils/make-metadata-api-request.util';
 
 import { AppTokenType } from 'src/engine/core-modules/app-token/app-token.entity';
 import { SEED_APPLE_WORKSPACE_ID } from 'src/engine/workspace-manager/dev-seeder/core/constants/seeder-workspaces.constant';
 
 const ONE_HOUR_IN_MS = 60 * 60 * 1000;
-
-const client = request(`http://localhost:${APP_PORT}`);
 
 const seedInvitation = ({
   email,
@@ -48,16 +47,20 @@ describe('expired workspace invitation filtering', () => {
         expiresAt: new Date(Date.now() - ONE_HOUR_IN_MS),
       });
 
-      await client
-        .post('/metadata')
-        .send({
-          query: `
-            mutation SignUpInWorkspace {
+      const response = await makeMetadataAPIRequest(
+        {
+          query: gql`
+            mutation SignUpInWorkspace(
+              $email: String!
+              $password: String!
+              $workspaceId: UUID!
+              $workspacePersonalInviteToken: String!
+            ) {
               signUpInWorkspace(
-                email: "${email}"
-                password: "Test123!@#"
-                workspaceId: "${SEED_APPLE_WORKSPACE_ID}"
-                workspacePersonalInviteToken: "${token}"
+                email: $email
+                password: $password
+                workspaceId: $workspaceId
+                workspacePersonalInviteToken: $workspacePersonalInviteToken
               ) {
                 workspace {
                   id
@@ -65,29 +68,33 @@ describe('expired workspace invitation filtering', () => {
               }
             }
           `,
-        })
-        .expect(200)
-        .expect((res) => {
-          expect(res.body.data?.signUpInWorkspace).toBeFalsy();
-          expect(res.body.errors).toBeDefined();
-        });
+          variables: {
+            email,
+            password: 'Test123!@#',
+            workspaceId: SEED_APPLE_WORKSPACE_ID,
+            workspacePersonalInviteToken: token,
+          },
+        },
+        undefined,
+      );
+
+      expect(response.body.data?.signUpInWorkspace).toBeFalsy();
+      expect(response.body.errors).toBeDefined();
     });
   });
 
   describe('sendInvitations re-invite behaviour', () => {
     const sendInvitations = (email: string) =>
-      client
-        .post('/metadata')
-        .set('Authorization', `Bearer ${APPLE_JANE_ADMIN_ACCESS_TOKEN}`)
-        .send({
-          query: `
-            mutation SendInvitations {
-              sendInvitations(emails: ["${email}"]) {
-                success
-              }
+      makeMetadataAPIRequest({
+        query: gql`
+          mutation SendInvitations($emails: [String!]!) {
+            sendInvitations(emails: $emails) {
+              success
             }
-          `,
-        });
+          }
+        `,
+        variables: { emails: [email] },
+      });
 
     it('re-invites an email whose only existing invitation is expired', async () => {
       const email = `expired-invite-resend-${Date.now()}@example.com`;
@@ -99,12 +106,10 @@ describe('expired workspace invitation filtering', () => {
       });
 
       try {
-        await sendInvitations(email)
-          .expect(200)
-          .expect((res) => {
-            expect(res.body.errors).toBeUndefined();
-            expect(res.body.data.sendInvitations.success).toBe(true);
-          });
+        const response = await sendInvitations(email);
+
+        expect(response.body.errors).toBeUndefined();
+        expect(response.body.data.sendInvitations.success).toBe(true);
       } finally {
         await removeSeededInvitations(email);
       }
@@ -120,11 +125,9 @@ describe('expired workspace invitation filtering', () => {
       });
 
       try {
-        await sendInvitations(email)
-          .expect(200)
-          .expect((res) => {
-            expect(res.body.data.sendInvitations.success).toBe(false);
-          });
+        const response = await sendInvitations(email);
+
+        expect(response.body.data.sendInvitations.success).toBe(false);
       } finally {
         await removeSeededInvitations(email);
       }

--- a/packages/twenty-server/test/integration/graphql/suites/expired-workspace-invitation.integration-spec.ts
+++ b/packages/twenty-server/test/integration/graphql/suites/expired-workspace-invitation.integration-spec.ts
@@ -1,5 +1,6 @@
 import gql from 'graphql-tag';
 import { makeMetadataAPIRequest } from 'test/integration/metadata/suites/utils/make-metadata-api-request.util';
+import { signUpInWorkspaceOperationFactory } from 'test/integration/graphql/utils/sign-up-in-workspace-operation-factory.util';
 
 import { AppTokenType } from 'src/engine/core-modules/app-token/app-token.entity';
 import { SEED_APPLE_WORKSPACE_ID } from 'src/engine/workspace-manager/dev-seeder/core/constants/seeder-workspaces.constant';
@@ -48,33 +49,11 @@ describe('expired workspace invitation filtering', () => {
       });
 
       const response = await makeMetadataAPIRequest(
-        {
-          query: gql`
-            mutation SignUpInWorkspace(
-              $email: String!
-              $password: String!
-              $workspaceId: UUID!
-              $workspacePersonalInviteToken: String!
-            ) {
-              signUpInWorkspace(
-                email: $email
-                password: $password
-                workspaceId: $workspaceId
-                workspacePersonalInviteToken: $workspacePersonalInviteToken
-              ) {
-                workspace {
-                  id
-                }
-              }
-            }
-          `,
-          variables: {
-            email,
-            password: 'Test123!@#',
-            workspaceId: SEED_APPLE_WORKSPACE_ID,
-            workspacePersonalInviteToken: token,
-          },
-        },
+        signUpInWorkspaceOperationFactory({
+          email,
+          workspaceId: SEED_APPLE_WORKSPACE_ID,
+          workspacePersonalInviteToken: token,
+        }),
         undefined,
       );
 

--- a/packages/twenty-server/test/integration/graphql/suites/expired-workspace-invitation.integration-spec.ts
+++ b/packages/twenty-server/test/integration/graphql/suites/expired-workspace-invitation.integration-spec.ts
@@ -1,0 +1,93 @@
+import { type Repository } from 'typeorm';
+
+import {
+  AppTokenEntity,
+  AppTokenType,
+} from 'src/engine/core-modules/app-token/app-token.entity';
+import { AuthService } from 'src/engine/core-modules/auth/services/auth.service';
+import { WorkspaceInvitationService } from 'src/engine/core-modules/workspace-invitation/services/workspace-invitation.service';
+import { WorkspaceEntity } from 'src/engine/core-modules/workspace/workspace.entity';
+import { SEED_APPLE_WORKSPACE_ID } from 'src/engine/workspace-manager/dev-seeder/core/constants/seeder-workspaces.constant';
+import { getCoreRepository } from 'test/integration/utils/get-core-repository.util';
+
+const ONE_HOUR_IN_MS = 60 * 60 * 1000;
+
+describe('expired workspace invitation filtering', () => {
+  const email = 'expired-invitation-filtering@example.com';
+  const workspaceId = SEED_APPLE_WORKSPACE_ID;
+  const workspace = { id: workspaceId } as WorkspaceEntity;
+
+  let appTokenRepository: Repository<AppTokenEntity>;
+  let workspaceInvitationService: WorkspaceInvitationService;
+  let authService: AuthService;
+
+  const removeSeededInvitations = () =>
+    global.testDataSource.query(
+      `DELETE FROM core."appToken" WHERE "workspaceId" = $1 AND context->>'email' = $2`,
+      [workspaceId, email],
+    );
+
+  const seedInvitation = (expiresAt: Date) =>
+    appTokenRepository.save(
+      appTokenRepository.create({
+        workspaceId,
+        type: AppTokenType.InvitationToken,
+        value: `expired-invitation-filtering-${expiresAt.getTime()}`,
+        expiresAt,
+        context: { email },
+      }),
+    );
+
+  beforeAll(() => {
+    appTokenRepository = getCoreRepository(AppTokenEntity);
+    workspaceInvitationService = global.app.get(WorkspaceInvitationService, {
+      strict: false,
+    });
+    authService = global.app.get(AuthService, { strict: false });
+  });
+
+  afterEach(() => removeSeededInvitations());
+
+  it('getOneWorkspaceInvitation ignores an expired invitation', async () => {
+    await seedInvitation(new Date(Date.now() - ONE_HOUR_IN_MS));
+
+    const invitation =
+      await workspaceInvitationService.getOneWorkspaceInvitation(
+        workspaceId,
+        email,
+      );
+
+    expect(invitation).toBeNull();
+  });
+
+  it('getOneWorkspaceInvitation still returns a valid invitation', async () => {
+    await seedInvitation(new Date(Date.now() + ONE_HOUR_IN_MS));
+
+    const invitation =
+      await workspaceInvitationService.getOneWorkspaceInvitation(
+        workspaceId,
+        email,
+      );
+
+    expect(invitation?.context?.email).toBe(email);
+  });
+
+  it('findInvitationForSignInUp ignores an expired invitation', async () => {
+    await seedInvitation(new Date(Date.now() - ONE_HOUR_IN_MS));
+
+    const invitation = await authService.findInvitationForSignInUp({
+      currentWorkspace: workspace,
+      email,
+    });
+
+    expect(invitation).toBeUndefined();
+  });
+
+  it('createWorkspaceInvitation re-invites an email whose only invitation is expired', async () => {
+    await seedInvitation(new Date(Date.now() - ONE_HOUR_IN_MS));
+
+    await expect(
+      workspaceInvitationService.createWorkspaceInvitation(email, workspace),
+    ).resolves.toBeDefined();
+  });
+});

--- a/packages/twenty-server/test/integration/graphql/suites/expired-workspace-invitation.integration-spec.ts
+++ b/packages/twenty-server/test/integration/graphql/suites/expired-workspace-invitation.integration-spec.ts
@@ -1,4 +1,7 @@
 import { makeMetadataAPIRequest } from 'test/integration/metadata/suites/utils/make-metadata-api-request.util';
+import { deleteUser } from 'test/integration/graphql/utils/delete-user.util';
+import { expectOneNotInternalServerErrorSnapshot } from 'test/integration/graphql/utils/expect-one-not-internal-server-error-snapshot.util';
+import { getAuthTokensFromLoginToken } from 'test/integration/graphql/utils/get-auth-tokens-from-login-token.util';
 import { sendInvitationsOperationFactory } from 'test/integration/graphql/utils/send-invitations-operation-factory.util';
 import { signUpInWorkspaceOperationFactory } from 'test/integration/graphql/utils/sign-up-in-workspace-operation-factory.util';
 
@@ -36,19 +39,14 @@ const removeSeededInvitations = (email: string) =>
 
 describe('expired workspace invitation filtering', () => {
   describe('signUpInWorkspace with a personal invite token', () => {
-    const email = `expired-invite-signup-${Date.now()}@example.com`;
-    const token = `expired-invite-signup-token-${Date.now()}`;
-
-    afterAll(() => removeSeededInvitations(email));
-
-    it('denies access when the personal invitation is expired', async () => {
-      await seedInvitation({
-        email,
-        value: token,
-        expiresAt: new Date(Date.now() - ONE_HOUR_IN_MS),
-      });
-
-      const response = await makeMetadataAPIRequest(
+    const signUpWithInviteToken = ({
+      email,
+      token,
+    }: {
+      email: string;
+      token: string;
+    }) =>
+      makeMetadataAPIRequest(
         signUpInWorkspaceOperationFactory({
           email,
           workspaceId: SEED_APPLE_WORKSPACE_ID,
@@ -57,8 +55,75 @@ describe('expired workspace invitation filtering', () => {
         undefined,
       );
 
-      expect(response.body.data?.signUpInWorkspace).toBeFalsy();
-      expect(response.body.errors).toBeDefined();
+    it('denies access when the personal invitation is expired', async () => {
+      const email = `expired-invite-signup-${Date.now()}@example.com`;
+      const token = `expired-invite-signup-token-${Date.now()}`;
+
+      await seedInvitation({
+        email,
+        value: token,
+        expiresAt: new Date(Date.now() - ONE_HOUR_IN_MS),
+      });
+
+      try {
+        const response = await signUpWithInviteToken({ email, token });
+
+        expect(response.body.data?.signUpInWorkspace).toBeFalsy();
+        expectOneNotInternalServerErrorSnapshot({
+          errors: response.body.errors,
+        });
+      } finally {
+        await removeSeededInvitations(email);
+      }
+    });
+
+    // Positive control: the denial above must come from the expiry filter, not
+    // from an unrelated rejection of the sign-up request itself.
+    it('grants access when the personal invitation is still valid', async () => {
+      const email = `valid-invite-signup-${Date.now()}@example.com`;
+      const token = `valid-invite-signup-token-${Date.now()}`;
+
+      await seedInvitation({
+        email,
+        value: token,
+        expiresAt: new Date(Date.now() + ONE_HOUR_IN_MS),
+      });
+
+      let accessToken: string | undefined;
+
+      try {
+        const response = await signUpWithInviteToken({ email, token });
+
+        expect(response.body.errors).toBeUndefined();
+
+        const signUpPayload = response.body.data.signUpInWorkspace;
+
+        expect(signUpPayload.workspace.id).toBe(SEED_APPLE_WORKSPACE_ID);
+        expect(signUpPayload.loginToken.token).toBeDefined();
+
+        await testDataSource.query(
+          'UPDATE core."user" SET "isEmailVerified" = true WHERE email = $1',
+          [email],
+        );
+
+        const {
+          data: { getAuthTokensFromLoginToken: authTokensData },
+        } = await getAuthTokensFromLoginToken({
+          loginToken: signUpPayload.loginToken.token,
+          origin:
+            signUpPayload.workspace.workspaceUrls?.subdomainUrl ??
+            'http://localhost:3001',
+          expectToFail: false,
+        });
+
+        accessToken =
+          authTokensData.tokens.accessOrWorkspaceAgnosticToken.token;
+      } finally {
+        if (accessToken) {
+          await deleteUser({ accessToken, expectToFail: false });
+        }
+        await removeSeededInvitations(email);
+      }
     });
   });
 

--- a/packages/twenty-server/test/integration/graphql/suites/expired-workspace-invitation.integration-spec.ts
+++ b/packages/twenty-server/test/integration/graphql/suites/expired-workspace-invitation.integration-spec.ts
@@ -1,93 +1,133 @@
-import { type Repository } from 'typeorm';
+import request from 'supertest';
 
-import {
-  AppTokenEntity,
-  AppTokenType,
-} from 'src/engine/core-modules/app-token/app-token.entity';
-import { AuthService } from 'src/engine/core-modules/auth/services/auth.service';
-import { WorkspaceInvitationService } from 'src/engine/core-modules/workspace-invitation/services/workspace-invitation.service';
-import { WorkspaceEntity } from 'src/engine/core-modules/workspace/workspace.entity';
+import { AppTokenType } from 'src/engine/core-modules/app-token/app-token.entity';
 import { SEED_APPLE_WORKSPACE_ID } from 'src/engine/workspace-manager/dev-seeder/core/constants/seeder-workspaces.constant';
-import { getCoreRepository } from 'test/integration/utils/get-core-repository.util';
 
 const ONE_HOUR_IN_MS = 60 * 60 * 1000;
 
+const client = request(`http://localhost:${APP_PORT}`);
+
+const seedInvitation = ({
+  email,
+  value,
+  expiresAt,
+}: {
+  email: string;
+  value: string;
+  expiresAt: Date;
+}) =>
+  testDataSource.query(
+    `INSERT INTO core."appToken" ("workspaceId", "type", "value", "expiresAt", "context")
+     VALUES ($1, $2, $3, $4, $5::jsonb)`,
+    [
+      SEED_APPLE_WORKSPACE_ID,
+      AppTokenType.InvitationToken,
+      value,
+      expiresAt.toISOString(),
+      JSON.stringify({ email }),
+    ],
+  );
+
+const removeSeededInvitations = (email: string) =>
+  testDataSource.query(
+    `DELETE FROM core."appToken" WHERE "workspaceId" = $1 AND context->>'email' = $2`,
+    [SEED_APPLE_WORKSPACE_ID, email],
+  );
+
 describe('expired workspace invitation filtering', () => {
-  const email = 'expired-invitation-filtering@example.com';
-  const workspaceId = SEED_APPLE_WORKSPACE_ID;
-  const workspace = { id: workspaceId } as WorkspaceEntity;
+  describe('signUpInWorkspace with a personal invite token', () => {
+    const email = `expired-invite-signup-${Date.now()}@example.com`;
+    const token = `expired-invite-signup-token-${Date.now()}`;
 
-  let appTokenRepository: Repository<AppTokenEntity>;
-  let workspaceInvitationService: WorkspaceInvitationService;
-  let authService: AuthService;
+    afterAll(() => removeSeededInvitations(email));
 
-  const removeSeededInvitations = () =>
-    global.testDataSource.query(
-      `DELETE FROM core."appToken" WHERE "workspaceId" = $1 AND context->>'email' = $2`,
-      [workspaceId, email],
-    );
-
-  const seedInvitation = (expiresAt: Date) =>
-    appTokenRepository.save(
-      appTokenRepository.create({
-        workspaceId,
-        type: AppTokenType.InvitationToken,
-        value: `expired-invitation-filtering-${expiresAt.getTime()}`,
-        expiresAt,
-        context: { email },
-      }),
-    );
-
-  beforeAll(() => {
-    appTokenRepository = getCoreRepository(AppTokenEntity);
-    workspaceInvitationService = global.app.get(WorkspaceInvitationService, {
-      strict: false,
-    });
-    authService = global.app.get(AuthService, { strict: false });
-  });
-
-  afterEach(() => removeSeededInvitations());
-
-  it('getOneWorkspaceInvitation ignores an expired invitation', async () => {
-    await seedInvitation(new Date(Date.now() - ONE_HOUR_IN_MS));
-
-    const invitation =
-      await workspaceInvitationService.getOneWorkspaceInvitation(
-        workspaceId,
+    it('denies access when the personal invitation is expired', async () => {
+      await seedInvitation({
         email,
-      );
+        value: token,
+        expiresAt: new Date(Date.now() - ONE_HOUR_IN_MS),
+      });
 
-    expect(invitation).toBeNull();
+      await client
+        .post('/metadata')
+        .send({
+          query: `
+            mutation SignUpInWorkspace {
+              signUpInWorkspace(
+                email: "${email}"
+                password: "Test123!@#"
+                workspaceId: "${SEED_APPLE_WORKSPACE_ID}"
+                workspacePersonalInviteToken: "${token}"
+              ) {
+                workspace {
+                  id
+                }
+              }
+            }
+          `,
+        })
+        .expect(200)
+        .expect((res) => {
+          expect(res.body.data?.signUpInWorkspace).toBeFalsy();
+          expect(res.body.errors).toBeDefined();
+        });
+    });
   });
 
-  it('getOneWorkspaceInvitation still returns a valid invitation', async () => {
-    await seedInvitation(new Date(Date.now() + ONE_HOUR_IN_MS));
+  describe('sendInvitations re-invite behaviour', () => {
+    const sendInvitations = (email: string) =>
+      client
+        .post('/metadata')
+        .set('Authorization', `Bearer ${APPLE_JANE_ADMIN_ACCESS_TOKEN}`)
+        .send({
+          query: `
+            mutation SendInvitations {
+              sendInvitations(emails: ["${email}"]) {
+                success
+              }
+            }
+          `,
+        });
 
-    const invitation =
-      await workspaceInvitationService.getOneWorkspaceInvitation(
-        workspaceId,
+    it('re-invites an email whose only existing invitation is expired', async () => {
+      const email = `expired-invite-resend-${Date.now()}@example.com`;
+
+      await seedInvitation({
         email,
-      );
+        value: `expired-invite-resend-token-${Date.now()}`,
+        expiresAt: new Date(Date.now() - ONE_HOUR_IN_MS),
+      });
 
-    expect(invitation?.context?.email).toBe(email);
-  });
-
-  it('findInvitationForSignInUp ignores an expired invitation', async () => {
-    await seedInvitation(new Date(Date.now() - ONE_HOUR_IN_MS));
-
-    const invitation = await authService.findInvitationForSignInUp({
-      currentWorkspace: workspace,
-      email,
+      try {
+        await sendInvitations(email)
+          .expect(200)
+          .expect((res) => {
+            expect(res.body.errors).toBeUndefined();
+            expect(res.body.data.sendInvitations.success).toBe(true);
+          });
+      } finally {
+        await removeSeededInvitations(email);
+      }
     });
 
-    expect(invitation).toBeUndefined();
-  });
+    it('still reports a valid invitation as already existing', async () => {
+      const email = `valid-invite-resend-${Date.now()}@example.com`;
 
-  it('createWorkspaceInvitation re-invites an email whose only invitation is expired', async () => {
-    await seedInvitation(new Date(Date.now() - ONE_HOUR_IN_MS));
+      await seedInvitation({
+        email,
+        value: `valid-invite-resend-token-${Date.now()}`,
+        expiresAt: new Date(Date.now() + ONE_HOUR_IN_MS),
+      });
 
-    await expect(
-      workspaceInvitationService.createWorkspaceInvitation(email, workspace),
-    ).resolves.toBeDefined();
+      try {
+        await sendInvitations(email)
+          .expect(200)
+          .expect((res) => {
+            expect(res.body.data.sendInvitations.success).toBe(false);
+          });
+      } finally {
+        await removeSeededInvitations(email);
+      }
+    });
   });
 });

--- a/packages/twenty-server/test/integration/graphql/utils/seed-workspace-invitation.util.ts
+++ b/packages/twenty-server/test/integration/graphql/utils/seed-workspace-invitation.util.ts
@@ -1,0 +1,37 @@
+import { AppTokenType } from 'src/engine/core-modules/app-token/app-token.entity';
+import { SEED_APPLE_WORKSPACE_ID } from 'src/engine/workspace-manager/dev-seeder/core/constants/seeder-workspaces.constant';
+
+export const seedWorkspaceInvitation = ({
+  email,
+  value,
+  expiresAt,
+  workspaceId = SEED_APPLE_WORKSPACE_ID,
+}: {
+  email: string;
+  value: string;
+  expiresAt: Date;
+  workspaceId?: string;
+}) =>
+  testDataSource.query(
+    `INSERT INTO core."appToken" ("workspaceId", "type", "value", "expiresAt", "context")
+     VALUES ($1, $2, $3, $4, $5::jsonb)`,
+    [
+      workspaceId,
+      AppTokenType.InvitationToken,
+      value,
+      expiresAt.toISOString(),
+      JSON.stringify({ email }),
+    ],
+  );
+
+export const deleteWorkspaceInvitationsByEmail = ({
+  email,
+  workspaceId = SEED_APPLE_WORKSPACE_ID,
+}: {
+  email: string;
+  workspaceId?: string;
+}) =>
+  testDataSource.query(
+    `DELETE FROM core."appToken" WHERE "workspaceId" = $1 AND context->>'email' = $2`,
+    [workspaceId, email],
+  );

--- a/packages/twenty-server/test/integration/graphql/utils/seed-workspace-invitation.util.ts
+++ b/packages/twenty-server/test/integration/graphql/utils/seed-workspace-invitation.util.ts
@@ -24,6 +24,18 @@ export const seedWorkspaceInvitation = ({
     ],
   );
 
+export const findWorkspaceInvitationsByEmail = ({
+  email,
+  workspaceId = SEED_APPLE_WORKSPACE_ID,
+}: {
+  email: string;
+  workspaceId?: string;
+}): Promise<{ value: string; expiresAt: string }[]> =>
+  testDataSource.query(
+    `SELECT "value", "expiresAt" FROM core."appToken" WHERE "workspaceId" = $1 AND context->>'email' = $2`,
+    [workspaceId, email],
+  );
+
 export const deleteWorkspaceInvitationsByEmail = ({
   email,
   workspaceId = SEED_APPLE_WORKSPACE_ID,

--- a/packages/twenty-server/test/integration/graphql/utils/send-invitations-operation-factory.util.ts
+++ b/packages/twenty-server/test/integration/graphql/utils/send-invitations-operation-factory.util.ts
@@ -1,0 +1,18 @@
+import gql from 'graphql-tag';
+
+export const sendInvitationsOperationFactory = ({
+  emails,
+  roleId,
+}: {
+  emails: string[];
+  roleId?: string;
+}) => ({
+  query: gql`
+    mutation SendInvitations($emails: [String!]!, $roleId: UUID) {
+      sendInvitations(emails: $emails, roleId: $roleId) {
+        success
+      }
+    }
+  `,
+  variables: { emails, roleId },
+});

--- a/packages/twenty-server/test/integration/graphql/utils/sign-up-in-workspace-operation-factory.util.ts
+++ b/packages/twenty-server/test/integration/graphql/utils/sign-up-in-workspace-operation-factory.util.ts
@@ -1,0 +1,44 @@
+import gql from 'graphql-tag';
+
+export const signUpInWorkspaceOperationFactory = ({
+  email,
+  password = 'Test123!@#',
+  workspaceId,
+  workspaceInviteHash,
+  workspacePersonalInviteToken,
+}: {
+  email: string;
+  password?: string;
+  workspaceId?: string;
+  workspaceInviteHash?: string;
+  workspacePersonalInviteToken?: string;
+}) => ({
+  query: gql`
+    mutation SignUpInWorkspace(
+      $email: String!
+      $password: String!
+      $workspaceId: UUID
+      $workspaceInviteHash: String
+      $workspacePersonalInviteToken: String
+    ) {
+      signUpInWorkspace(
+        email: $email
+        password: $password
+        workspaceId: $workspaceId
+        workspaceInviteHash: $workspaceInviteHash
+        workspacePersonalInviteToken: $workspacePersonalInviteToken
+      ) {
+        workspace {
+          id
+        }
+      }
+    }
+  `,
+  variables: {
+    email,
+    password,
+    workspaceId,
+    workspaceInviteHash,
+    workspacePersonalInviteToken,
+  },
+});

--- a/packages/twenty-server/test/integration/graphql/utils/sign-up-in-workspace-operation-factory.util.ts
+++ b/packages/twenty-server/test/integration/graphql/utils/sign-up-in-workspace-operation-factory.util.ts
@@ -28,8 +28,14 @@ export const signUpInWorkspaceOperationFactory = ({
         workspaceInviteHash: $workspaceInviteHash
         workspacePersonalInviteToken: $workspacePersonalInviteToken
       ) {
+        loginToken {
+          token
+        }
         workspace {
           id
+          workspaceUrls {
+            subdomainUrl
+          }
         }
       }
     }


### PR DESCRIPTION
## What

Invitation lookups did not filter on `expiresAt`, so expired invitations were still treated as active. This aligns them with the sibling `findInvitationsByEmail`, which already applied that filter.

- `WorkspaceInvitationService.getOneWorkspaceInvitation` - added `deletedAt IS NULL` and `expiresAt > now` (also converted to a typed `findOne` so the column references are checked).
- `AuthService.findInvitationForSignInUp` - added `expiresAt > now` (it already filtered `deletedAt`).
- `throwIfOnboardingInvitationLimitReached` - expired tokens no longer count toward the onboarding invitation limit.
- `createWorkspaceInvitation` - deletes the expired token for that email before issuing a replacement, so re-invites don't accumulate stale rows.

## Why

Without the filter, an expired pending invitation behaved as if it were still active:

- On sign-up with a personal invite token, an expired invitation still granted access to the workspace.
- Re-inviting an email whose invitation had lapsed reported `INVITATION_ALREADY_EXIST` instead of sending a fresh invite.
- Expired onboarding invitations still consumed quota, so the limit could be hit by invitations nobody could use.

Once expired tokens are ignored on read, a re-invite would leave the old row behind, so `createWorkspaceInvitation` now removes it. The delete is scoped to the same workspace, invitation token types, that exact email, and `expiresAt <= now`, so it can only remove tokens that are already unusable.

Closes twentyhq/private-issues#503

## Tests

Integration suites added, run against a real database:

- `auth/sign-up/failing-sign-up-with-expired-invitation` - expired personal invitation is rejected (snapshot asserts the specific `FORBIDDEN` error).
- `auth/sign-up/successful-sign-up-with-valid-invitation` - positive control: a valid invitation still grants access, so the rejection above cannot pass for an unrelated reason.
- `expired-workspace-invitation` - re-invite over an expired invitation succeeds and leaves exactly one (fresh) token; a valid invitation is still reported as already existing.

Each assertion was verified to fail when its corresponding filter is removed. Unit tests (`workspace-invitation.service.spec.ts`, `auth.service.spec.ts`), typecheck, and lint all pass.

Not included: invitations that expire and are never re-invited still linger, since no cron reaps invitation tokens today.