### PR TITLE
Add IS_FEATURE_FLAG_MANAGEMENT_ENABLED to unlock feature flag toggling outside cloud

### DIFF
--- a/packages/twenty-server/src/engine/core-modules/client-config/services/client-config.service.spec.ts
+++ b/packages/twenty-server/src/engine/core-modules/client-config/services/client-config.service.spec.ts
@@ -239,6 +239,7 @@ describe('ClientConfigService', () => {
         .mockImplementation((key: string) => {
           if (key === 'NODE_ENV') return NodeEnvironment.PRODUCTION;
           if (key === 'IS_BILLING_ENABLED') return false;
+          if (key === 'IS_FEATURE_FLAG_MANAGEMENT_ENABLED') return false;
 
           return undefined;
         });
@@ -287,6 +288,22 @@ describe('ClientConfigService', () => {
         .mockImplementation((key: string) => {
           if (key === 'NODE_ENV') return NodeEnvironment.PRODUCTION;
           if (key === 'IS_BILLING_ENABLED') return true;
+
+          return undefined;
+        });
+
+      const result = await service.getClientConfig();
+
+      expect(result.canManageFeatureFlags).toBe(true);
+    });
+
+    it('should allow managing feature flags when IS_FEATURE_FLAG_MANAGEMENT_ENABLED is on', async () => {
+      jest
+        .spyOn(twentyConfigService, 'get')
+        .mockImplementation((key: string) => {
+          if (key === 'NODE_ENV') return NodeEnvironment.PRODUCTION;
+          if (key === 'IS_BILLING_ENABLED') return false;
+          if (key === 'IS_FEATURE_FLAG_MANAGEMENT_ENABLED') return true;
 
           return undefined;
         });

--- a/packages/twenty-server/src/engine/core-modules/client-config/services/client-config.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/client-config/services/client-config.service.ts
@@ -252,7 +252,9 @@ export class ClientConfigService {
       analyticsEnabled: this.twentyConfigService.get('ANALYTICS_ENABLED'),
       canManageFeatureFlags:
         this.twentyConfigService.get('NODE_ENV') ===
-          NodeEnvironment.DEVELOPMENT || isBillingEnabled,
+          NodeEnvironment.DEVELOPMENT ||
+        isBillingEnabled ||
+        this.twentyConfigService.get('IS_FEATURE_FLAG_MANAGEMENT_ENABLED'),
       publicFeatureFlags: PUBLIC_FEATURE_FLAGS,
       isCookieSessionEnabled: this.twentyConfigService.get(
         'AUTH_COOKIE_SESSIONS_ENABLED',

--- a/packages/twenty-server/src/engine/core-modules/twenty-config/config-variables.ts
+++ b/packages/twenty-server/src/engine/core-modules/twenty-config/config-variables.ts
@@ -554,6 +554,15 @@ export class ConfigVariables {
   IS_WORKSPACE_CREATION_LIMITED_TO_SERVER_ADMINS = true;
 
   @ConfigVariablesMetadata({
+    group: ConfigVariablesGroup.ADVANCED_SETTINGS,
+    description:
+      'When enabled, server admins can toggle any feature flag for any workspace from the admin panel. Always enabled in development mode and when billing is enabled.',
+    type: ConfigVariableType.BOOLEAN,
+  })
+  @IsOptional()
+  IS_FEATURE_FLAG_MANAGEMENT_ENABLED = false;
+
+  @ConfigVariablesMetadata({
     group: ConfigVariablesGroup.SERVER_CONFIG,
     description:
       'Deployment region that determines the contracting DPA Processor entity, hosting region and governing law. EU (default) = Twenty.com SAS / Frankfurt / France; US = Twenty, Inc. / United States. Must match where Customer Personal Data actually lives.',


### PR DESCRIPTION
The admin panel has a per-workspace Feature Flags tab that can toggle any key in `FeatureFlagKey`, but it was hidden unless `NODE_ENV` was `development` or billing was enabled:

```ts
canManageFeatureFlags:
  this.twentyConfigService.get('NODE_ENV') === NodeEnvironment.DEVELOPMENT || isBillingEnabled,
```

Preview apps run `NODE_ENV=production` with billing off, so the tab disappears and there is no way to flip a flag on a `trycloudflare.com` app short of editing `core.featureFlag` by hand.

This is purely a client-side gate. `updateWorkspaceFeatureFlag` is guarded server-side by `AdminPanelGuard` (`canAccessFullAdminPanel`) and has no billing or cloud check, so unhiding the tab does not widen what the server accepts. The gate has to be coarse because `/client-config` is a public unauthenticated endpoint and cannot carry per-user state, which is presumably why it ended up keyed on `NODE_ENV`/billing.

## Changes

- New `IS_FEATURE_FLAG_MANAGEMENT_ENABLED` config variable (`ADVANCED_SETTINGS`), defaulting to `false`.
- `canManageFeatureFlags` now also honours it. Development mode and billing-enabled instances behave exactly as before.

## Notes

- Deliberately not added to `docker-compose.yml` or `.env.example`, and not documented in `feature-flags.mdx`. Anyone who needs it can set the env var directly.
- `twentyhq/ci-public#3` sets it for preview apps by patching the variable into the server service and the generated `.env`, so it does not depend on the compose file carrying the entry.
- The seeded dev users already have `canAccessFullAdminPanel: true`, and on a non-seeded instance the first user to sign up is granted it, so the tab is reachable once the variable is on.

## Test

`client-config.service.spec.ts` covers the new variable unlocking management in production with billing off, alongside the existing cases for development mode, billing enabled, and both off.

---
_Generated by [Claude Code](https://claude.ai/code/session_015ovxLQNTHxvBbhfrKq2aZt)_

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/23750?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

