### PR TITLE
fix(workflow): handle dangling filterGroupId in if/else step matching & validation

### DIFF
--- a/packages/twenty-server/src/modules/workflow/workflow-builder/workflow-validation/__tests__/workflow-validation.workspace-service.spec.ts
+++ b/packages/twenty-server/src/modules/workflow/workflow-builder/workflow-validation/__tests__/workflow-validation.workspace-service.spec.ts
@@ -7,6 +7,7 @@ import {
   type WorkflowCodeAction,
   type WorkflowFindRecordsAction,
   type WorkflowHttpRequestAction,
+  type WorkflowIfElseAction,
   type WorkflowIteratorAction,
   type WorkflowLogicFunctionAction,
 } from 'src/modules/workflow/workflow-executor/workflow-actions/types/workflow-action.type';
@@ -183,6 +184,24 @@ const buildIteratorStep = (items: string | unknown[]): WorkflowIteratorAction =>
       errorHandlingOptions: ERROR_HANDLING_OPTIONS,
     },
   }) as unknown as WorkflowIteratorAction;
+
+const buildIfElseStep = ({
+  branches,
+  stepFilterGroups,
+}: {
+  branches: Array<{ id: string; filterGroupId?: string; nextStepIds?: string[] }>;
+  stepFilterGroups: Array<{ id: string; logicalOperator: string }>;
+}): WorkflowIfElseAction =>
+  ({
+    id: 'if-else-step',
+    name: 'If/Else',
+    type: WorkflowActionType.IF_ELSE,
+    valid: true,
+    settings: {
+      input: { branches, stepFilterGroups, stepFilters: [] },
+      errorHandlingOptions: ERROR_HANDLING_OPTIONS,
+    },
+  }) as unknown as WorkflowIfElseAction;
 
 const buildLogicFunctionDefinition = (
   properties: Record<string, { type: string; label: string }>,
@@ -529,6 +548,50 @@ describe('WorkflowValidationWorkspaceService', () => {
 
     expect(result.errors.map((issue) => issue.code)).not.toContain(
       'ITERATOR_ITEMS_NOT_ARRAY',
+    );
+  });
+
+  it('should flag an if-else step with a branch referencing a non-existent filterGroupId', async () => {
+    const service = buildService();
+
+    const result = await service.validateWorkflowDefinition({
+      workspaceId: WORKSPACE_ID,
+      trigger: null,
+      steps: [
+        buildIfElseStep({
+          branches: [
+            { id: 'b1', filterGroupId: 'dangling-id', nextStepIds: [] },
+            { id: 'b2', filterGroupId: undefined, nextStepIds: [] },
+          ],
+          stepFilterGroups: [{ id: 'valid-id', logicalOperator: 'AND' }],
+        }),
+      ],
+    });
+
+    expect(result.errors.map((issue) => issue.code)).toContain(
+      'IF_ELSE_INVALID_FILTER_GROUP_ID',
+    );
+  });
+
+  it('should not flag an if-else step when all branch filterGroupIds exist', async () => {
+    const service = buildService();
+
+    const result = await service.validateWorkflowDefinition({
+      workspaceId: WORKSPACE_ID,
+      trigger: null,
+      steps: [
+        buildIfElseStep({
+          branches: [
+            { id: 'b1', filterGroupId: 'valid-id', nextStepIds: [] },
+            { id: 'b2', filterGroupId: undefined, nextStepIds: [] },
+          ],
+          stepFilterGroups: [{ id: 'valid-id', logicalOperator: 'AND' }],
+        }),
+      ],
+    });
+
+    expect(result.errors.map((issue) => issue.code)).not.toContain(
+      'IF_ELSE_INVALID_FILTER_GROUP_ID',
     );
   });
 });

--- a/packages/twenty-server/src/modules/workflow/workflow-builder/workflow-validation/workflow-validation.workspace-service.ts
+++ b/packages/twenty-server/src/modules/workflow/workflow-builder/workflow-validation/workflow-validation.workspace-service.ts
@@ -31,6 +31,7 @@ import { getPickRecordLoadBalanceConfigError } from 'src/modules/workflow/workfl
 import {
   type WorkflowAction,
   type WorkflowAiAgentAction,
+  type WorkflowIfElseAction,
   type WorkflowIteratorAction,
   type WorkflowLogicFunctionAction,
 } from 'src/modules/workflow/workflow-executor/workflow-actions/types/workflow-action.type';
@@ -240,6 +241,35 @@ export class WorkflowValidationWorkspaceService {
         case WorkflowActionType.ITERATOR:
           issues.push(...this.validateIteratorStep({ step, steps, trigger }));
           break;
+        case WorkflowActionType.IF_ELSE:
+          issues.push(...this.validateIfElseStep(step));
+          break;
+      }
+    }
+
+    return issues;
+  }
+
+  private validateIfElseStep(
+    step: WorkflowIfElseAction,
+  ): WorkflowValidationIssue[] {
+    const issues: WorkflowValidationIssue[] = [];
+
+    const branches = step.settings?.input?.branches ?? [];
+    const stepFilterGroups = step.settings?.input?.stepFilterGroups ?? [];
+    const validGroupIds = new Set(stepFilterGroups.map((group) => group.id));
+
+    for (const branch of branches) {
+      if (
+        isDefined(branch.filterGroupId) &&
+        !validGroupIds.has(branch.filterGroupId)
+      ) {
+        issues.push({
+          severity: 'error',
+          code: 'IF_ELSE_INVALID_FILTER_GROUP_ID',
+          message: `If/Else step "${step.name ?? step.id}" branch "${branch.id}" references non-existent filter group "${branch.filterGroupId}".`,
+          stepId: step.id,
+        });
       }
     }
 

--- a/packages/twenty-server/src/modules/workflow/workflow-executor/workflow-actions/if-else/utils/__tests__/find-matching-branch.util.spec.ts
+++ b/packages/twenty-server/src/modules/workflow/workflow-executor/workflow-actions/if-else/utils/__tests__/find-matching-branch.util.spec.ts
@@ -1,0 +1,108 @@
+import {
+  findMatchingBranch,
+  type ResolvedFilter,
+} from 'src/modules/workflow/workflow-executor/workflow-actions/if-else/utils/find-matching-branch.util';
+import { type StepFilterGroup } from 'twenty-shared/types';
+import { type StepIfElseBranch } from 'twenty-shared/workflow';
+
+describe('findMatchingBranch', () => {
+  const stepFilterGroups: StepFilterGroup[] = [
+    {
+      id: 'real-group',
+      logicalOperator: 'AND',
+    },
+  ];
+
+  it('should match branch when filter conditions evaluate to true', () => {
+    const branches: StepIfElseBranch[] = [
+      {
+        id: 'branch-A',
+        filterGroupId: 'real-group',
+        nextStepIds: ['step-a'],
+      },
+      {
+        id: 'branch-else',
+        filterGroupId: undefined,
+        nextStepIds: ['step-else'],
+      },
+    ];
+
+    const resolvedFilters: ResolvedFilter[] = [
+      {
+        id: 'f1',
+        stepFilterGroupId: 'real-group',
+        type: 'TEXT',
+        operand: 'IS',
+        rightOperand: 'value',
+        leftOperand: 'value',
+      },
+    ];
+
+    const result = findMatchingBranch({
+      branches,
+      stepFilterGroups,
+      resolvedFilters,
+    });
+
+    expect(result.id).toBe('branch-A');
+  });
+
+  it('should skip branch with dangling filterGroupId and fall through to else branch', () => {
+    const branches: StepIfElseBranch[] = [
+      {
+        id: 'branch-dangling',
+        filterGroupId: 'dangling-group-id',
+        nextStepIds: ['wrong-step'],
+      },
+      {
+        id: 'branch-else',
+        filterGroupId: undefined,
+        nextStepIds: ['correct-step'],
+      },
+    ];
+
+    const resolvedFilters: ResolvedFilter[] = [];
+
+    const result = findMatchingBranch({
+      branches,
+      stepFilterGroups,
+      resolvedFilters,
+    });
+
+    expect(result.id).toBe('branch-else');
+  });
+
+  it('should skip branch with dangling filterGroupId and select subsequent matching valid branch', () => {
+    const branches: StepIfElseBranch[] = [
+      {
+        id: 'branch-dangling',
+        filterGroupId: 'non-existent-group',
+        nextStepIds: ['wrong-step'],
+      },
+      {
+        id: 'branch-valid',
+        filterGroupId: 'real-group',
+        nextStepIds: ['correct-step'],
+      },
+    ];
+
+    const resolvedFilters: ResolvedFilter[] = [
+      {
+        id: 'f1',
+        stepFilterGroupId: 'real-group',
+        type: 'TEXT',
+        operand: 'IS',
+        rightOperand: 'hello',
+        leftOperand: 'hello',
+      },
+    ];
+
+    const result = findMatchingBranch({
+      branches,
+      stepFilterGroups,
+      resolvedFilters,
+    });
+
+    expect(result.id).toBe('branch-valid');
+  });
+});

--- a/packages/twenty-server/src/modules/workflow/workflow-executor/workflow-actions/if-else/utils/find-matching-branch.util.ts
+++ b/packages/twenty-server/src/modules/workflow/workflow-executor/workflow-actions/if-else/utils/find-matching-branch.util.ts
@@ -51,6 +51,14 @@ export const findMatchingBranch = ({
       return true;
     }
 
+    const rootGroupExists = stepFilterGroups.some(
+      (group) => group.id === branch.filterGroupId,
+    );
+
+    if (!rootGroupExists) {
+      return false;
+    }
+
     const branchFilterGroups = Array.from(
       collectAllDescendantGroups(branch.filterGroupId, stepFilterGroups),
     );


### PR DESCRIPTION
## Scope & Context

Closes #23754.

An `IF_ELSE` workflow step branch whose `filterGroupId` does not correspond to any entry in `stepFilterGroups` currently matches unconditionally before any other branch condition is evaluated. This occurs because `collectAllDescendantGroups` returns an empty set when `filterGroupId` is not found, causing `evaluateFilterConditions` to receive empty filter groups/filters and evaluate to `true`. Furthermore, `validate_workflow` does not check for dangling `filterGroupId` references in `IF_ELSE` step branches.

## Proposed Changes

1. **`find-matching-branch.util.ts`**:
   - Added an explicit check (`rootGroupExists`) to ensure `branch.filterGroupId` exists in `stepFilterGroups` before evaluating the branch condition.
   - If `branch.filterGroupId` is defined but does not exist in `stepFilterGroups`, the branch condition evaluates to `false` (skipped), allowing remaining branches or the fallback `else` branch to be evaluated.

2. **`workflow-validation.workspace-service.ts`**:
   - Added `WorkflowActionType.IF_ELSE` case in `validateStepTypeRequirements`.
   - Added `validateIfElseStep` to validate that every branch with a defined `filterGroupId` references an existing group ID in `stepFilterGroups`, emitting an `IF_ELSE_INVALID_FILTER_GROUP_ID` error when invalid.

3. **Tests**:
   - Added unit test suite in `find-matching-branch.util.spec.ts`.
   - Added `IF_ELSE` validation unit tests in `workflow-validation.workspace-service.spec.ts`.

## Verification Plan

### Automated Tests
- Added unit tests in `packages/twenty-server/src/modules/workflow/workflow-executor/workflow-actions/if-else/utils/__tests__/find-matching-branch.util.spec.ts`.
- Added unit tests in `packages/twenty-server/src/modules/workflow/workflow-builder/workflow-validation/__tests__/workflow-validation.workspace-service.spec.ts`.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/23762?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

