### PR TITLE
fix(twenty-front): preserve targetRecord entity when merging persisted junction record

### DIFF
--- a/packages/twenty-front/src/modules/object-record/record-field/ui/hooks/useUpdateJunctionRelationFromCell.ts
+++ b/packages/twenty-front/src/modules/object-record/record-field/ui/hooks/useUpdateJunctionRelationFromCell.ts
@@ -282,7 +282,14 @@ export const useUpdateJunctionRelationFromCell = ({
                 ? junctionRecordsWithoutOptimistic
                 : [
                     ...junctionRecordsWithoutOptimistic,
-                    { ...junctionRecordForStore, ...persistedJunctionRecord },
+                    {
+                      ...junctionRecordForStore,
+                      ...persistedJunctionRecord,
+                      [targetFieldName]:
+                        (persistedJunctionRecord as Record<string, unknown>)[
+                          targetFieldName
+                        ] ?? targetRecord,
+                    },
                   ],
             } as ObjectRecord;
           },


### PR DESCRIPTION
## Scope & Context

Closes #23306.

When creating a link through a junction relation field in the UI, the link is saved successfully on the server, but the newly linked record frequently disappears from the field component until a page refresh. This happens because `createManyRecords` returns only scalar junction columns (`id`, `personId`, `companyId`, etc.) and does not query nested relation targets. When `{ ...junctionRecordForStore, ...persistedJunctionRecord }` was merged into the record store, the nested `[targetFieldName]` object (e.g. `company` or `person`) was overwritten with `undefined`, leaving the UI without target record metadata (display name, avatar).

## Proposed Changes

1. **`useUpdateJunctionRelationFromCell.ts`**:
   - Explicitly preserve `[targetFieldName]: (persistedJunctionRecord as Record<string, unknown>)[targetFieldName] ?? targetRecord` when setting `recordStoreFamilyState` upon mutation settlement.
   - Retains target record details immediately after creation without requiring a browser refresh.

## Verification Plan

### Manual Verification
- Verified state updating logic in `useUpdateJunctionRelationFromCell.ts`.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/23765?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

