### PR TITLE
fix(messaging): apply selected folder filter during Gmail incremental history sync

### DIFF
--- a/packages/twenty-server/src/modules/messaging/message-import-manager/drivers/gmail/services/__tests__/gmail-get-message-list.service.spec.ts
+++ b/packages/twenty-server/src/modules/messaging/message-import-manager/drivers/gmail/services/__tests__/gmail-get-message-list.service.spec.ts
@@ -1,0 +1,126 @@
+import { Test, type TestingModule } from '@nestjs/testing';
+import { ConnectedAccountProvider, MessageFolderImportPolicy } from 'twenty-shared/types';
+
+import { GoogleOAuth2ClientProvider } from 'src/modules/connected-account/oauth2-client-manager/drivers/google/google-oauth2-client.provider';
+import { GmailGetHistoryService } from 'src/modules/messaging/message-import-manager/drivers/gmail/services/gmail-get-history.service';
+import { GmailGetMessageListService } from 'src/modules/messaging/message-import-manager/drivers/gmail/services/gmail-get-message-list.service';
+import { GmailMessageListFetchErrorHandler } from 'src/modules/messaging/message-import-manager/drivers/gmail/services/gmail-message-list-fetch-error-handler.service';
+
+describe('GmailGetMessageListService', () => {
+  let service: GmailGetMessageListService;
+  let gmailGetHistoryService: GmailGetHistoryService;
+
+  const mockConnectedAccount = {
+    id: 'connected-account-id',
+    provider: ConnectedAccountProvider.GOOGLE,
+    handle: 'test@gmail.com',
+  };
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        GmailGetMessageListService,
+        {
+          provide: GmailGetHistoryService,
+          useValue: {
+            getHistory: jest.fn().mockResolvedValue({
+              history: [],
+              historyId: '100',
+            }),
+            getMessageIdsFromHistory: jest.fn().mockResolvedValue({
+              messagesAdded: ['msg-1'],
+              messagesDeleted: [],
+            }),
+          },
+        },
+        {
+          provide: GoogleOAuth2ClientProvider,
+          useValue: {
+            getClient: jest.fn().mockResolvedValue({}),
+          },
+        },
+        {
+          provide: GmailMessageListFetchErrorHandler,
+          useValue: {
+            handleError: jest.fn(),
+          },
+        },
+      ],
+    }).compile();
+
+    service = module.get<GmailGetMessageListService>(GmailGetMessageListService);
+    gmailGetHistoryService = module.get<GmailGetHistoryService>(GmailGetHistoryService);
+  });
+
+  describe('getMessageLists with syncCursor (incremental sync)', () => {
+    it('should query history with labelId when SELECTED_FOLDERS policy is active', async () => {
+      const mockFolders = [
+        {
+          name: 'CRM',
+          externalId: 'Label_CRM',
+          isSynced: true,
+          parentFolderId: null,
+        },
+        {
+          name: 'Archive',
+          externalId: 'Label_Archive',
+          isSynced: false,
+          parentFolderId: null,
+        },
+      ];
+
+      const response = await service.getMessageLists({
+        connectedAccount: mockConnectedAccount,
+        messageChannel: {
+          id: 'channel-id',
+          messageFolderImportPolicy: MessageFolderImportPolicy.SELECTED_FOLDERS,
+          syncCursor: '50',
+        },
+        messageFolders: mockFolders,
+      });
+
+      expect(gmailGetHistoryService.getHistory).toHaveBeenCalledTimes(1);
+      expect(gmailGetHistoryService.getHistory).toHaveBeenCalledWith(
+        expect.anything(),
+        '50',
+        'Label_CRM',
+      );
+      expect(response).toEqual([
+        {
+          messageExternalIds: ['msg-1'],
+          messageExternalIdsToDelete: [],
+          previousSyncCursor: '50',
+          nextSyncCursor: '100',
+          folderId: undefined,
+        },
+      ]);
+    });
+
+    it('should query history without labelId when ALL_FOLDERS policy is active', async () => {
+      const mockFolders = [
+        {
+          name: 'CRM',
+          externalId: 'Label_CRM',
+          isSynced: true,
+          parentFolderId: null,
+        },
+      ];
+
+      await service.getMessageLists({
+        connectedAccount: mockConnectedAccount,
+        messageChannel: {
+          id: 'channel-id',
+          messageFolderImportPolicy: MessageFolderImportPolicy.ALL_FOLDERS,
+          syncCursor: '50',
+        },
+        messageFolders: mockFolders,
+      });
+
+      expect(gmailGetHistoryService.getHistory).toHaveBeenCalledTimes(1);
+      expect(gmailGetHistoryService.getHistory).toHaveBeenCalledWith(
+        expect.anything(),
+        '50',
+      );
+    });
+  });
+});

--- a/packages/twenty-server/src/modules/messaging/message-import-manager/drivers/gmail/services/gmail-get-history.service.ts
+++ b/packages/twenty-server/src/modules/messaging/message-import-manager/drivers/gmail/services/gmail-get-history.service.ts
@@ -15,6 +15,7 @@ export class GmailGetHistoryService {
   public async getHistory(
     gmailClient: gmail_v1.Gmail,
     lastSyncHistoryId: string,
+    labelId?: string,
   ): Promise<{
     history: gmail_v1.Schema$History[];
     historyId?: string | null;
@@ -31,6 +32,7 @@ export class GmailGetHistoryService {
           maxResults: MESSAGING_GMAIL_USERS_HISTORY_MAX_RESULT,
           pageToken,
           startHistoryId: lastSyncHistoryId,
+          ...(isNonEmptyString(labelId) ? { labelId } : {}),
           historyTypes: [
             'messageAdded',
             'messageDeleted',

--- a/packages/twenty-server/src/modules/messaging/message-import-manager/drivers/gmail/services/gmail-get-message-list.service.ts
+++ b/packages/twenty-server/src/modules/messaging/message-import-manager/drivers/gmail/services/gmail-get-message-list.service.ts
@@ -175,6 +175,58 @@ export class GmailGetMessageListService {
       );
     }
 
+    if (
+      messageChannel.messageFolderImportPolicy ===
+      MessageFolderImportPolicy.SELECTED_FOLDERS
+    ) {
+      const foldersToSync = messageFolders.filter((folder) => folder.isSynced);
+      let allMessagesAdded: string[] = [];
+      let allMessagesDeleted: string[] = [];
+      let latestNextSyncCursor: string | undefined = undefined;
+
+      for (const folder of foldersToSync) {
+        const labelId = folder.externalId || folder.name;
+        const { history, historyId: nextSyncCursor } =
+          await this.gmailGetHistoryService.getHistory(
+            gmailClient,
+            messageChannel.syncCursor,
+            labelId,
+          );
+
+        const { messagesAdded, messagesDeleted } =
+          await this.gmailGetHistoryService.getMessageIdsFromHistory(history);
+
+        allMessagesAdded.push(...messagesAdded);
+        allMessagesDeleted.push(...messagesDeleted);
+
+        if (
+          nextSyncCursor &&
+          (!latestNextSyncCursor || nextSyncCursor > latestNextSyncCursor)
+        ) {
+          latestNextSyncCursor = nextSyncCursor;
+        }
+      }
+
+      const nextSyncCursor = latestNextSyncCursor ?? messageChannel.syncCursor;
+
+      const uniqueMessagesAdded = [...new Set(allMessagesAdded)].filter(
+        (id) => !allMessagesDeleted.includes(id),
+      );
+      const uniqueMessagesDeleted = [...new Set(allMessagesDeleted)].filter(
+        (id) => !allMessagesAdded.includes(id),
+      );
+
+      return [
+        {
+          messageExternalIds: uniqueMessagesAdded,
+          messageExternalIdsToDelete: uniqueMessagesDeleted,
+          previousSyncCursor: messageChannel.syncCursor,
+          nextSyncCursor,
+          folderId: undefined,
+        },
+      ];
+    }
+
     const { history, historyId: nextSyncCursor } =
       await this.gmailGetHistoryService.getHistory(
         gmailClient,


### PR DESCRIPTION
## Scope & Context

Closes #22889.

When a Gmail message channel is configured with `messageFolderImportPolicy = SELECTED_FOLDERS`, the folder selection filter was applied only on the initial full fetch (`getMessageListWithoutCursor`). Incremental syncs (when `messageChannel.syncCursor` is set) called `gmailGetHistoryService.getHistory()` without specifying a `labelId`. As a result, `users.history.list` returned history events and messages from all Gmail labels/folders, causing emails outside the selected folders to be imported and creating unwanted People/Companies.

## Proposed Changes

1. **`gmail-get-history.service.ts`**:
   - Added optional `labelId?: string` parameter to `getHistory()` and passed it to `gmailClient.users.history.list({ ..., labelId })`.

2. **`gmail-get-message-list.service.ts`**:
   - In `getMessageLists()`: When `messageFolderImportPolicy === MessageFolderImportPolicy.SELECTED_FOLDERS`, loop over `foldersToSync` and pass `labelId` (`folder.externalId || folder.name`) to `getHistory()`.
   - Combined and deduplicated message IDs across all synced folders, returning the unified list and highest `nextSyncCursor`.

3. **Tests**:
   - Created `gmail-get-message-list.service.spec.ts` unit test verifying `labelId` filtering on incremental syncs.

## Verification Plan

### Automated Tests
- Verified unit test suite `gmail-get-message-list.service.spec.ts`.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/23766?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

