### PR TITLE
fix(auth): mark OAuth callback URLs as isEnvOnly and resolve dynamically (#22606)

### DIFF
--- a/packages/twenty-server/src/engine/core-modules/auth/strategies/__tests__/google-auth-strategy.spec.ts
+++ b/packages/twenty-server/src/engine/core-modules/auth/strategies/__tests__/google-auth-strategy.spec.ts
@@ -1,0 +1,69 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { Request } from 'express';
+
+import { GoogleStrategy } from 'src/engine/core-modules/auth/strategies/google.auth.strategy';
+import { TwentyConfigService } from 'src/engine/core-modules/twenty-config/twenty-config.service';
+import { isEnvOnlyConfigVar } from 'src/engine/core-modules/twenty-config/utils/is-env-only-config-var.util';
+
+describe('GoogleStrategy', () => {
+  let googleStrategy: GoogleStrategy;
+  let twentyConfigService: TwentyConfigService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        GoogleStrategy,
+        {
+          provide: TwentyConfigService,
+          useValue: {
+            get: jest.fn((key: string) => {
+              if (key === 'AUTH_GOOGLE_CLIENT_ID') return 'client-id';
+              if (key === 'AUTH_GOOGLE_CLIENT_SECRET') return 'client-secret';
+              if (key === 'AUTH_GOOGLE_CALLBACK_URL')
+                return 'http://localhost:3000/auth/google/redirect';
+              return null;
+            }),
+          },
+        },
+      ],
+    }).compile();
+
+    googleStrategy = module.get<GoogleStrategy>(GoogleStrategy);
+    twentyConfigService = module.get<TwentyConfigService>(TwentyConfigService);
+  });
+
+  it('should be defined', () => {
+    expect(googleStrategy).toBeDefined();
+  });
+
+  it('should mark AUTH_GOOGLE_CALLBACK_URL as isEnvOnly', () => {
+    expect(isEnvOnlyConfigVar('AUTH_GOOGLE_CALLBACK_URL')).toBe(true);
+    expect(isEnvOnlyConfigVar('AUTH_GOOGLE_APIS_CALLBACK_URL')).toBe(true);
+    expect(isEnvOnlyConfigVar('AUTH_MICROSOFT_CALLBACK_URL')).toBe(true);
+    expect(isEnvOnlyConfigVar('AUTH_MICROSOFT_APIS_CALLBACK_URL')).toBe(true);
+  });
+
+  it('should dynamically inject current AUTH_GOOGLE_CALLBACK_URL when authenticate is called', () => {
+    const mockReq = {
+      query: {},
+      params: {},
+    } as unknown as Request;
+
+    const superAuthenticateSpy = jest
+      .spyOn(Object.getPrototypeOf(GoogleStrategy.prototype), 'authenticate')
+      .mockImplementation(() => {});
+
+    jest
+      .spyOn(twentyConfigService, 'get')
+      .mockReturnValue('https://custom-domain.com/auth/google/redirect');
+
+    googleStrategy.authenticate(mockReq, {});
+
+    expect(superAuthenticateSpy).toHaveBeenCalledWith(
+      mockReq,
+      expect.objectContaining({
+        callbackURL: 'https://custom-domain.com/auth/google/redirect',
+      }),
+    );
+  });
+});

--- a/packages/twenty-server/src/engine/core-modules/auth/strategies/google.auth.strategy.ts
+++ b/packages/twenty-server/src/engine/core-modules/auth/strategies/google.auth.strategy.ts
@@ -38,7 +38,7 @@ export type GoogleRequest = Omit<
 
 @Injectable()
 export class GoogleStrategy extends PassportStrategy(Strategy, 'google') {
-  constructor(twentyConfigService: TwentyConfigService) {
+  constructor(private readonly twentyConfigService: TwentyConfigService) {
     super({
       clientID: twentyConfigService.get('AUTH_GOOGLE_CLIENT_ID'),
       clientSecret: twentyConfigService.get('AUTH_GOOGLE_CLIENT_SECRET'),
@@ -52,6 +52,7 @@ export class GoogleStrategy extends PassportStrategy(Strategy, 'google') {
   authenticate(req: Request, options: any) {
     options = {
       ...options,
+      callbackURL: this.twentyConfigService.get('AUTH_GOOGLE_CALLBACK_URL'),
       state: JSON.stringify({
         workspaceInviteHash: req.query.workspaceInviteHash,
         workspaceId: req.params.workspaceId,

--- a/packages/twenty-server/src/engine/core-modules/auth/strategies/microsoft.auth.strategy.ts
+++ b/packages/twenty-server/src/engine/core-modules/auth/strategies/microsoft.auth.strategy.ts
@@ -36,7 +36,7 @@ export type MicrosoftRequest = Omit<
 
 @Injectable()
 export class MicrosoftStrategy extends PassportStrategy(Strategy, 'microsoft') {
-  constructor(twentyConfigService: TwentyConfigService) {
+  constructor(private readonly twentyConfigService: TwentyConfigService) {
     super({
       clientID: twentyConfigService.get('AUTH_MICROSOFT_CLIENT_ID'),
       clientSecret: twentyConfigService.get('AUTH_MICROSOFT_CLIENT_SECRET'),
@@ -51,6 +51,7 @@ export class MicrosoftStrategy extends PassportStrategy(Strategy, 'microsoft') {
   authenticate(req: Request, options: any) {
     options = {
       ...options,
+      callbackURL: this.twentyConfigService.get('AUTH_MICROSOFT_CALLBACK_URL'),
       state: JSON.stringify({
         workspaceInviteHash: req.query.workspaceInviteHash,
         workspaceId: req.params.workspaceId,

--- a/packages/twenty-server/src/engine/core-modules/twenty-config/config-variables.ts
+++ b/packages/twenty-server/src/engine/core-modules/twenty-config/config-variables.ts
@@ -142,6 +142,7 @@ export class ConfigVariables {
     description: 'Callback URL for Google Auth APIs',
     type: ConfigVariableType.STRING,
     isSensitive: false,
+    isEnvOnly: true,
   })
   AUTH_GOOGLE_APIS_CALLBACK_URL: string;
 
@@ -176,6 +177,7 @@ export class ConfigVariables {
     isSensitive: false,
     description: 'Callback URL for Google authentication',
     type: ConfigVariableType.STRING,
+    isEnvOnly: true,
   })
   @IsUrl({ require_tld: false, require_protocol: true })
   @ValidateIf((env) => env.AUTH_GOOGLE_ENABLED)
@@ -276,6 +278,7 @@ export class ConfigVariables {
     isSensitive: false,
     description: 'Callback URL for Microsoft authentication',
     type: ConfigVariableType.STRING,
+    isEnvOnly: true,
   })
   @IsUrl({ require_tld: false, require_protocol: true })
   @ValidateIf((env) => env.AUTH_MICROSOFT_ENABLED)
@@ -286,6 +289,7 @@ export class ConfigVariables {
     isSensitive: false,
     description: 'Callback URL for Microsoft APIs',
     type: ConfigVariableType.STRING,
+    isEnvOnly: true,
   })
   @IsUrl({ require_tld: false, require_protocol: true })
   @ValidateIf((env) => env.AUTH_MICROSOFT_ENABLED)


### PR DESCRIPTION
## Description
Fixes #22606.

When running in self-hosted Docker environments, updating `AUTH_GOOGLE_CALLBACK_URL` in environment variables did not update Google OAuth callback behavior because stale DB-backed configurations overrode the environment variable. Furthermore, Passport strategy instances cached `callbackURL` only once during NestJS instantiation in constructor time.

### Changes
1. **Config Variables**: Marked `AUTH_GOOGLE_CALLBACK_URL`, `AUTH_GOOGLE_APIS_CALLBACK_URL`, `AUTH_MICROSOFT_CALLBACK_URL`, and `AUTH_MICROSOFT_APIS_CALLBACK_URL` as `isEnvOnly: true` in `config-variables.ts`. This prevents stale values in the database from overriding environment variables (matching the pattern used by `SERVER_URL`).
2. **Dynamic Strategy Callbacks**: Updated `GoogleStrategy` and `MicrosoftStrategy` to store `twentyConfigService` and inject `callbackURL: this.twentyConfigService.get(...)` dynamically in `authenticate()`.
3. **Unit Tests**: Added unit tests in `google-auth-strategy.spec.ts` verifying `isEnvOnly` metadata and dynamic callback injection.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/23767?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

