### PR TITLE
fix(twenty-front): prevent command bar from displaying No results found on empty search (#22834)

### DIFF
--- a/packages/twenty-front/src/modules/command-menu-item/display/components/SidePanelCommandMenuItemDisplayPage.tsx
+++ b/packages/twenty-front/src/modules/command-menu-item/display/components/SidePanelCommandMenuItemDisplayPage.tsx
@@ -90,12 +90,19 @@ export const SidePanelCommandMenuItemDisplayPage = () => {
     unpinnedCommandMenuItems,
   );
 
-  const noResults = !matchingPinnedItems.length && !matchingOtherItems.length;
+  const isSearchActive = sidePanelSearch.trim().length > 0;
+  const hasMatchingItems =
+    matchingPinnedItems.length > 0 || matchingOtherItems.length > 0;
+  const showFallbackItems =
+    isSearchActive && !hasMatchingItems && fallbackCommandMenuItems.length > 0;
+
+  const noResults =
+    isSearchActive && !hasMatchingItems && !showFallbackItems;
 
   const selectableItemIds = [
     ...matchingPinnedItems,
     ...matchingOtherItems,
-    ...(noResults ? fallbackCommandMenuItems : []),
+    ...(showFallbackItems ? fallbackCommandMenuItems : []),
   ].map((item) => item.id);
 
   return (
@@ -114,7 +121,7 @@ export const SidePanelCommandMenuItemDisplayPage = () => {
           ))}
         </SidePanelGroup>
       )}
-      {noResults && fallbackCommandMenuItems.length > 0 && (
+      {showFallbackItems && (
         <SidePanelGroup heading={t`Fallback`}>
           {fallbackCommandMenuItems.map((item) => (
             <CommandMenuItemRenderer item={item} key={item.id} />


### PR DESCRIPTION
## Description
Fixes #22834.

### Problem
Opening the command bar (before entering any search text) or performing a search that rendered fallback command menu items always displayed `No results found`.

### Root Cause
In `SidePanelCommandMenuItemDisplayPage.tsx`, `noResults` was computed as:
```ts
const noResults = !matchingPinnedItems.length && !matchingOtherItems.length;
```
1. When search was empty (`""`), `matchingPinnedItems` contained only overflow pinned items (which is empty if all pinned items fit in the header) and `matchingOtherItems` was empty. This evaluated `noResults` to `true` on open before the user typed anything into the search box.
2. When fallback items were displayed on search, `noResults` was still `true`, causing `SidePanelList` to render `No results found` alongside the fallback items.

### Solution
- Checked if search is active (`isSearchActive = sidePanelSearch.trim().length > 0`).
- Computed `showFallbackItems = isSearchActive && !hasMatchingItems && fallbackCommandMenuItems.length > 0`.
- Evaluated `noResults` as `true` only when an active search query was entered, no regular items matched, and no fallback items existed.
- Updated `SidePanelList` children rendering condition for fallback items to use `showFallbackItems`.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/23768?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

