### PR TITLE
fix(workflow): prioritize ACTIVE status in workflow statuses

### DIFF
--- a/packages/twenty-front/src/modules/workflow/hooks/useActivateWorkflowVersion.ts
+++ b/packages/twenty-front/src/modules/workflow/hooks/useActivateWorkflowVersion.ts
@@ -137,7 +137,7 @@ export const useActivateWorkflowVersion = () => {
         });
 
         const newStatuses = new Set(
-          [...(cachedWorkflow?.statuses ?? []), 'ACTIVE'].filter(
+          ['ACTIVE', ...(cachedWorkflow?.statuses ?? [])].filter(
             (status) => status !== 'DEACTIVATED',
           ),
         );

--- a/packages/twenty-server/src/modules/workflow/workflow-status/jobs/workflow-statuses-update.job.ts
+++ b/packages/twenty-server/src/modules/workflow/workflow-status/jobs/workflow-statuses-update.job.ts
@@ -209,20 +209,20 @@ export class WorkflowStatusesUpdateJob {
       },
     });
 
-    const hasDraftVersion = workflowVersions.some(
-      (version) => version.status === WorkflowVersionStatus.DRAFT,
-    );
-
-    if (hasDraftVersion) {
-      statuses.push(WorkflowStatus.DRAFT);
-    }
-
     const hasActiveVersion = workflowVersions.some(
       (version) => version.status === WorkflowVersionStatus.ACTIVE,
     );
 
     if (hasActiveVersion) {
       statuses.push(WorkflowStatus.ACTIVE);
+    }
+
+    const hasDraftVersion = workflowVersions.some(
+      (version) => version.status === WorkflowVersionStatus.DRAFT,
+    );
+
+    if (hasDraftVersion) {
+      statuses.push(WorkflowStatus.DRAFT);
     }
 
     const hasDeactivatedVersion = workflowVersions.some(


### PR DESCRIPTION
## Summary
When an active workflow has a new draft version created (e.g. while editing), `getWorkflowStatuses()` previously pushed `DRAFT` into the workflow's `statuses` array before `ACTIVE`. As a result, the list view displayed "Draft" (or Draft before Active) as the primary status tag for live active workflows, creating inconsistency with the workflow's live status.

## Changes
- Updated `WorkflowStatusesUpdateJob.getWorkflowStatuses` to evaluate and push `WorkflowStatus.ACTIVE` before `WorkflowStatus.DRAFT`.
- Updated `useActivateWorkflowVersion` in `twenty-front` to place `ACTIVE` first when adding to cached workflow statuses.

Fixes #14408

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/23769?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

