### PR TITLE
fix(file): delete file storage assets when attachments or files field items are removed or soft-deleted

### DIFF
--- a/packages/twenty-server/src/engine/core-modules/file/files-field/listeners/files-field-deletion.listener.ts
+++ b/packages/twenty-server/src/engine/core-modules/file/files-field/listeners/files-field-deletion.listener.ts
@@ -1,6 +1,10 @@
 import { Injectable } from '@nestjs/common';
 
-import { type ObjectRecordDestroyEvent } from 'twenty-shared/database-events';
+import {
+  type ObjectRecordDeleteEvent,
+  type ObjectRecordDestroyEvent,
+  type ObjectRecordUpdateEvent,
+} from 'twenty-shared/database-events';
 import { FieldMetadataType } from 'twenty-shared/types';
 import { isDefined } from 'twenty-shared/utils';
 
@@ -34,8 +38,11 @@ export class FilesFieldDeletionListener {
   ) {}
 
   @OnDatabaseBatchEvent('*', DatabaseEventAction.DESTROYED)
-  async handleDestroyedEvent(
-    payload: WorkspaceEventBatch<ObjectRecordDestroyEvent>,
+  @OnDatabaseBatchEvent('*', DatabaseEventAction.DELETED)
+  async handleDestroyedOrDeletedEvent(
+    payload: WorkspaceEventBatch<
+      ObjectRecordDestroyEvent | ObjectRecordDeleteEvent
+    >,
   ) {
     const workspaceId = payload.workspaceId;
     const objectMetadata = payload.objectMetadata;
@@ -100,6 +107,89 @@ export class FilesFieldDeletionListener {
           }
 
           fileIds.add(fileItem.fileId);
+        }
+      }
+    }
+
+    if (fileIds.size > 0) {
+      await this.messageQueueService.add<FilesFieldDeletionJobData>(
+        FilesFieldDeletionJob.name,
+        {
+          workspaceId,
+          fileIds: Array.from(fileIds),
+        },
+      );
+    }
+  }
+
+  @OnDatabaseBatchEvent('*', DatabaseEventAction.UPDATED)
+  async handleUpdatedEvent(
+    payload: WorkspaceEventBatch<ObjectRecordUpdateEvent>,
+  ) {
+    const workspaceId = payload.workspaceId;
+    const objectMetadata = payload.objectMetadata;
+
+    const { flatObjectMetadataMaps, flatFieldMetadataMaps } =
+      await this.workspaceManyOrAllFlatEntityMapsCacheService.getOrRecomputeManyOrAllFlatEntityMaps(
+        {
+          workspaceId,
+          flatMapsKeys: ['flatObjectMetadataMaps', 'flatFieldMetadataMaps'],
+        },
+      );
+
+    const { idByNameSingular } = buildObjectIdByNameMaps(
+      flatObjectMetadataMaps,
+    );
+
+    const objectId = idByNameSingular[objectMetadata.nameSingular];
+
+    if (!isDefined(objectId)) {
+      return;
+    }
+
+    const flatObjectMetadata = findFlatEntityByIdInFlatEntityMaps({
+      flatEntityId: objectId,
+      flatEntityMaps: flatObjectMetadataMaps,
+    });
+
+    if (!isDefined(flatObjectMetadata)) {
+      return;
+    }
+
+    const objectFields = getFlatFieldsFromFlatObjectMetadata(
+      flatObjectMetadata,
+      flatFieldMetadataMaps,
+    );
+
+    const filesFields = objectFields.filter(
+      (field) => field.type === FieldMetadataType.FILES,
+    );
+
+    if (filesFields.length === 0) {
+      return;
+    }
+
+    const fileIds = new Set<string>();
+
+    for (const event of payload.events) {
+      const recordBefore = event.properties.before as Record<string, unknown>;
+      const recordAfter = event.properties.after as Record<string, unknown>;
+
+      for (const filesField of filesFields) {
+        const beforeFiles = (recordBefore[filesField.name] as FileItem[]) ?? [];
+        const afterFiles = (recordAfter[filesField.name] as FileItem[]) ?? [];
+
+        const afterFileIds = new Set(
+          afterFiles.map((fileItem) => fileItem?.fileId).filter(isDefined),
+        );
+
+        for (const beforeFileItem of beforeFiles) {
+          if (
+            isDefined(beforeFileItem?.fileId) &&
+            !afterFileIds.has(beforeFileItem.fileId)
+          ) {
+            fileIds.add(beforeFileItem.fileId);
+          }
         }
       }
     }


### PR DESCRIPTION
## Summary
In self-hosted instances (including local storage), deleting an attachment or removing a file item from a record field removed it logically from the database, but left the corresponding file sitting on disk indefinitely.

## Root Cause
`FilesFieldDeletionListener` was registered to listen exclusively to `DatabaseEventAction.DESTROYED` events. When an attachment record or record with a `FILES` field was soft-deleted (`DELETED`) or updated by removing a file from the `FILES` array (`UPDATED`), `DESTROYED` was never triggered. Thus, `FilesFieldDeletionJob` was never enqueued to delete the underlying file from file storage.

## Fix
- Added `DatabaseEventAction.DELETED` handling to `FilesFieldDeletionListener` to enqueue `FilesFieldDeletionJob` when records with `FILES` fields (such as attachments) are soft-deleted.
- Added `DatabaseEventAction.UPDATED` handling to `FilesFieldDeletionListener` to compare before/after `FILES` field items and enqueue deletion for any file IDs removed during the update.

Fixes #16205

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/23770?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

