### PR TITLE
Stamp applicationUniversalIdentifier on actor context

### DIFF
--- a/packages/twenty-server/src/engine/core-modules/actor/utils/build-created-by-from-application.util.ts
+++ b/packages/twenty-server/src/engine/core-modules/actor/utils/build-created-by-from-application.util.ts
@@ -11,5 +11,7 @@ export const buildCreatedByFromApplication = ({
   source: FieldActorSource.APPLICATION,
   name: application.name,
   workspaceMemberId: null,
-  context: {},
+  context: {
+    applicationUniversalIdentifier: application.universalIdentifier,
+  },
 });

--- a/packages/twenty-shared/src/types/composite-types/actor.composite-type.ts
+++ b/packages/twenty-shared/src/types/composite-types/actor.composite-type.ts
@@ -64,5 +64,6 @@ export type ActorMetadata = {
   name: string;
   context: {
     provider?: ConnectedAccountProvider;
+    applicationUniversalIdentifier?: string;
   };
 };


### PR DESCRIPTION
App-created records carried provenance only through the `createdBy` actor display name, which is not a stable or unique identifier. `buildCreatedByFromApplication` now stamps the application's `universalIdentifier` into the actor `context`. `updatedBy` goes through the same builder, so it is covered too.

`universalIdentifier` rather than `applicationId` because the latter is a workspace-local row id: the same app gets a different one per workspace and per reinstall, so an app cannot compare it against a constant it ships with.

No migration. `context` is an existing nullable `RAW_JSON` composite property, so this adds a key to a jsonb column that already exists. No DDL, no metadata sync, no upgrade command.

No backfill either. The only signal on older rows is the app display name, which is mutable and non-unique, so any backfill would write a guess into a field whose value is being trustworthy. Absence should read as unknown, not as "not an app's".

Deferred: whether this belongs as a real composite property (`createdByApplicationUniversalIdentifier`) rather than a context key. A column is what RLS predicates and indexes can target, and `workspaceMemberId` is already precedent for a source-specific, `hidden: 'input'` actor column. That is a cross-workspace migration and a platform call, tracked in twentyhq/core-team-issues#2746. Stamping now means that migration can backfill exactly from this key instead of guessing.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/23771?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

