### PR TITLE
test: scratch PR for validating the pr-review bot (do not merge)

### DIFF
--- a/packages/twenty-server/src/engine/utils/format-metadata-label.util.ts
+++ b/packages/twenty-server/src/engine/utils/format-metadata-label.util.ts
@@ -1,0 +1,14 @@
+const MAX_LABEL_LENGTH = 64;
+
+export const formatMetadataLabel = (nameSingular: string): string => {
+  const kebab = nameSingular.replace(
+    /([A-Z])/g,
+    (match) => `-${match.toLowerCase()}`,
+  );
+
+  return kebab
+    .split('-')
+    .map((word) => word[0].toUpperCase() + word.slice(1))
+    .join(' ')
+    .slice(0, MAX_LABEL_LENGTH);
+};

--- a/packages/twenty-server/src/engine/utils/format-metadata-label.util.ts
+++ b/packages/twenty-server/src/engine/utils/format-metadata-label.util.ts
@@ -8,6 +8,7 @@ export const formatMetadataLabel = (nameSingular: string): string => {
 
   return kebab
     .split('-')
+    .filter((word) => word.length > 0)
     .map((word) => word[0].toUpperCase() + word.slice(1))
     .join(' ')
     .slice(0, MAX_LABEL_LENGTH);


### PR DESCRIPTION
**Scratch PR — do not merge, do not review.** It exists to verify that the standard review bot no longer re-posts findings it has already made ([ci-privileged#73](https://github.com/twentyhq/ci-privileged/pull/73)), and will be closed as soon as that is confirmed.

The added file contains deliberate problems for the bot to find. It is not imported anywhere.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/23776?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

