### PR TITLE
fix(auth): trust workspace subdomains for credentialed CORS

### DIFF
--- a/packages/twenty-docs/developers/self-host/capabilities/setup.mdx
+++ b/packages/twenty-docs/developers/self-host/capabilities/setup.mdx
@@ -382,7 +382,8 @@ Only relevant if you do not let the back-end serve the front-end. Same-origin
 deployments need nothing here.
 
 Declare every browser origin that talks to the API, comma separated. `SERVER_URL`
-and `FRONTEND_URL` are already trusted.
+and `FRONTEND_URL` are already trusted, as are subdomains of `FRONTEND_URL` when
+`IS_MULTIWORKSPACE_ENABLED=true`, so workspace subdomains need no entry here.
 
 ```bash
 AUTH_COOKIE_ALLOWED_ORIGINS=https://app.example.com

--- a/packages/twenty-server/src/engine/core-modules/user-session/utils/apply-credentialed-cors.util.ts
+++ b/packages/twenty-server/src/engine/core-modules/user-session/utils/apply-credentialed-cors.util.ts
@@ -3,7 +3,7 @@ import { type INestApplication } from '@nestjs/common';
 import { type NextFunction, type Request, type Response } from 'express';
 
 import { type TwentyConfigService } from 'src/engine/core-modules/twenty-config/twenty-config.service';
-import { resolveAllowedCredentialedOrigins } from 'src/engine/core-modules/user-session/utils/resolve-allowed-credentialed-origins.util';
+import { isOriginAllowedForCredentials } from 'src/engine/core-modules/user-session/utils/is-origin-allowed-for-credentials.util';
 
 // Shared between the production bootstrap and the integration test harness so
 // the CORS behavior under test is the deployed one.
@@ -30,9 +30,7 @@ export const applyCredentialedCors = (
     ) => {
       if (
         origin &&
-        resolveAllowedCredentialedOrigins(twentyConfigService).has(
-          origin.toLowerCase(),
-        )
+        isOriginAllowedForCredentials({ origin, twentyConfigService })
       ) {
         return callback(null, true);
       }

--- a/packages/twenty-server/src/engine/core-modules/user-session/utils/is-origin-allowed-for-credentials.util.spec.ts
+++ b/packages/twenty-server/src/engine/core-modules/user-session/utils/is-origin-allowed-for-credentials.util.spec.ts
@@ -1,0 +1,100 @@
+import { NodeEnvironment } from 'src/engine/core-modules/twenty-config/interfaces/node-environment.interface';
+import { type TwentyConfigService } from 'src/engine/core-modules/twenty-config/twenty-config.service';
+import { isOriginAllowedForCredentials } from 'src/engine/core-modules/user-session/utils/is-origin-allowed-for-credentials.util';
+
+const buildConfigService = (
+  overrides: Record<string, unknown> = {},
+): TwentyConfigService => {
+  const config: Record<string, unknown> = {
+    SERVER_URL: 'https://api.twenty.example',
+    FRONTEND_URL: 'https://twenty.example',
+    AUTH_COOKIE_ALLOWED_ORIGINS: '',
+    IS_MULTIWORKSPACE_ENABLED: false,
+    NODE_ENV: NodeEnvironment.DEVELOPMENT,
+    ...overrides,
+  };
+
+  return {
+    get: (key: string) => config[key],
+  } as unknown as TwentyConfigService;
+};
+
+const expectAllowed = (
+  origin: string,
+  overrides: Record<string, unknown> = {},
+) =>
+  isOriginAllowedForCredentials({
+    origin,
+    twentyConfigService: buildConfigService(overrides),
+  });
+
+describe('isOriginAllowedForCredentials', () => {
+  it('should allow the configured front-end and server origins', () => {
+    expect(expectAllowed('https://twenty.example')).toBe(true);
+    expect(expectAllowed('https://api.twenty.example')).toBe(true);
+  });
+
+  it('should allow an explicitly declared origin', () => {
+    expect(
+      expectAllowed('https://app.other.example', {
+        AUTH_COOKIE_ALLOWED_ORIGINS: 'https://app.other.example',
+      }),
+    ).toBe(true);
+  });
+
+  it('should reject an unrelated origin', () => {
+    expect(expectAllowed('https://attacker.example')).toBe(false);
+  });
+
+  describe('workspace subdomains', () => {
+    const multiWorkspace = { IS_MULTIWORKSPACE_ENABLED: true };
+
+    it('should allow any subdomain of the front-end domain', () => {
+      expect(expectAllowed('https://acme.twenty.example', multiWorkspace)).toBe(
+        true,
+      );
+      expect(expectAllowed('https://app.twenty.example', multiWorkspace)).toBe(
+        true,
+      );
+    });
+
+    it('should reject subdomains when multi-workspace is disabled', () => {
+      expect(expectAllowed('https://acme.twenty.example')).toBe(false);
+    });
+
+    it('should reject a host that merely ends with the front-end domain string', () => {
+      expect(expectAllowed('https://eviltwenty.example', multiWorkspace)).toBe(
+        false,
+      );
+    });
+
+    it('should reject a subdomain on another scheme or port', () => {
+      expect(expectAllowed('http://acme.twenty.example', multiWorkspace)).toBe(
+        false,
+      );
+      expect(
+        expectAllowed('https://acme.twenty.example:8443', multiWorkspace),
+      ).toBe(false);
+    });
+
+    it('should allow a deeper label under the front-end domain', () => {
+      expect(
+        expectAllowed('https://acme.eu.twenty.example', multiWorkspace),
+      ).toBe(true);
+    });
+
+    it('should reject a subdomain of the server domain, which no browser is served from', () => {
+      expect(
+        expectAllowed('https://acme.api.example', {
+          ...multiWorkspace,
+          SERVER_URL: 'https://api.example',
+        }),
+      ).toBe(false);
+    });
+  });
+
+  it('should reject opaque origins', () => {
+    expect(expectAllowed('null')).toBe(false);
+    expect(expectAllowed('file:///etc/passwd')).toBe(false);
+  });
+});

--- a/packages/twenty-server/src/engine/core-modules/user-session/utils/is-origin-allowed-for-credentials.util.ts
+++ b/packages/twenty-server/src/engine/core-modules/user-session/utils/is-origin-allowed-for-credentials.util.ts
@@ -1,0 +1,64 @@
+import { isNonEmptyString } from '@sniptt/guards';
+
+import { type TwentyConfigService } from 'src/engine/core-modules/twenty-config/twenty-config.service';
+import { resolveAllowedCredentialedOrigins } from 'src/engine/core-modules/user-session/utils/resolve-allowed-credentialed-origins.util';
+import { toComparableOrigin } from 'src/engine/core-modules/user-session/utils/to-comparable-origin.util';
+
+// With multi-workspace on, every workspace is served from a subdomain of
+// FRONTEND_URL (WorkspaceDomainsService.getTwentyWorkspaceUrl), so the browser
+// origin is never the bare FRONTEND_URL. Subdomains are minted at runtime and
+// cannot be enumerated in AUTH_COOKIE_ALLOWED_ORIGINS, so they are derived the
+// same way DomainServerConfigService.getSubdomainAndDomainFromUrl derives them.
+// Scheme and port must match too: https://twenty.com must not vouch for
+// http://acme.twenty.com.
+const isWorkspaceSubdomainOrigin = (
+  origin: string,
+  twentyConfigService: TwentyConfigService,
+): boolean => {
+  if (!twentyConfigService.get('IS_MULTIWORKSPACE_ENABLED')) {
+    return false;
+  }
+
+  const frontendUrl = twentyConfigService.get('FRONTEND_URL');
+
+  if (!isNonEmptyString(frontendUrl)) {
+    return false;
+  }
+
+  try {
+    const parsedOrigin = new URL(origin);
+    const parsedFrontendUrl = new URL(frontendUrl);
+
+    return (
+      parsedOrigin.protocol === parsedFrontendUrl.protocol &&
+      parsedOrigin.port === parsedFrontendUrl.port &&
+      parsedOrigin.hostname.endsWith(
+        `.${parsedFrontendUrl.hostname.toLowerCase()}`,
+      )
+    );
+  } catch {
+    return false;
+  }
+};
+
+export const isOriginAllowedForCredentials = ({
+  origin,
+  twentyConfigService,
+}: {
+  origin: string;
+  twentyConfigService: TwentyConfigService;
+}): boolean => {
+  const comparableOrigin = toComparableOrigin(origin);
+
+  if (!isNonEmptyString(comparableOrigin)) {
+    return false;
+  }
+
+  if (
+    resolveAllowedCredentialedOrigins(twentyConfigService).has(comparableOrigin)
+  ) {
+    return true;
+  }
+
+  return isWorkspaceSubdomainOrigin(comparableOrigin, twentyConfigService);
+};

--- a/packages/twenty-server/src/engine/core-modules/user-session/utils/is-request-origin-allowed.util.ts
+++ b/packages/twenty-server/src/engine/core-modules/user-session/utils/is-request-origin-allowed.util.ts
@@ -2,16 +2,9 @@ import { type Request } from 'express';
 import { isDefined } from 'twenty-shared/utils';
 
 import { type TwentyConfigService } from 'src/engine/core-modules/twenty-config/twenty-config.service';
-import { resolveAllowedCredentialedOrigins } from 'src/engine/core-modules/user-session/utils/resolve-allowed-credentialed-origins.util';
+import { isOriginAllowedForCredentials } from 'src/engine/core-modules/user-session/utils/is-origin-allowed-for-credentials.util';
+import { toComparableOrigin } from 'src/engine/core-modules/user-session/utils/to-comparable-origin.util';
 import { getRequestBaseUrl } from 'src/utils/get-request-base-url.util';
-
-const toComparableOrigin = (value: string): string | undefined => {
-  try {
-    return new URL(value).origin.toLowerCase();
-  } catch {
-    return undefined;
-  }
-};
 
 export const isRequestOriginAllowed = ({
   origin,
@@ -39,7 +32,8 @@ export const isRequestOriginAllowed = ({
     return true;
   }
 
-  return resolveAllowedCredentialedOrigins(twentyConfigService).has(
-    normalizedOrigin,
-  );
+  return isOriginAllowedForCredentials({
+    origin: normalizedOrigin,
+    twentyConfigService,
+  });
 };

--- a/packages/twenty-server/src/engine/core-modules/user-session/utils/resolve-allowed-credentialed-origins.util.ts
+++ b/packages/twenty-server/src/engine/core-modules/user-session/utils/resolve-allowed-credentialed-origins.util.ts
@@ -2,22 +2,7 @@ import { isNonEmptyString } from '@sniptt/guards';
 
 import { NodeEnvironment } from 'src/engine/core-modules/twenty-config/interfaces/node-environment.interface';
 import { type TwentyConfigService } from 'src/engine/core-modules/twenty-config/twenty-config.service';
-
-// Opaque schemes (file:, data:) serialise to the literal "null" origin, which
-// would otherwise allowlist every sandboxed document that sends Origin: null.
-const toOrigin = (url: string): string | undefined => {
-  try {
-    const parsedUrl = new URL(url);
-
-    if (parsedUrl.protocol !== 'http:' && parsedUrl.protocol !== 'https:') {
-      return undefined;
-    }
-
-    return parsedUrl.origin.toLowerCase();
-  } catch {
-    return undefined;
-  }
-};
+import { toComparableOrigin } from 'src/engine/core-modules/user-session/utils/to-comparable-origin.util';
 
 // URL canonicalises [::ffff:127.0.0.1] to [::ffff:7f00:1], so only the hex
 // spelling reaches here. All of 127.0.0.0/8 is loopback.
@@ -79,7 +64,7 @@ export const resolveAllowedCredentialedOrigins = (
       continue;
     }
 
-    const origin = toOrigin(candidateUrl);
+    const origin = toComparableOrigin(candidateUrl);
 
     if (!isNonEmptyString(origin)) {
       continue;

--- a/packages/twenty-server/src/engine/core-modules/user-session/utils/to-comparable-origin.util.ts
+++ b/packages/twenty-server/src/engine/core-modules/user-session/utils/to-comparable-origin.util.ts
@@ -1,0 +1,15 @@
+// Opaque schemes (file:, data:) serialise to the literal "null" origin, which
+// would otherwise allowlist every sandboxed document that sends Origin: null.
+export const toComparableOrigin = (url: string): string | undefined => {
+  try {
+    const parsedUrl = new URL(url);
+
+    if (parsedUrl.protocol !== 'http:' && parsedUrl.protocol !== 'https:') {
+      return undefined;
+    }
+
+    return parsedUrl.origin.toLowerCase();
+  } catch {
+    return undefined;
+  }
+};

--- a/packages/twenty-server/test/integration/graphql/suites/auth/user-sessions/workspace-subdomain-cors.integration-spec.ts
+++ b/packages/twenty-server/test/integration/graphql/suites/auth/user-sessions/workspace-subdomain-cors.integration-spec.ts
@@ -1,0 +1,73 @@
+import request from 'supertest';
+
+const SERVER_URL = `http://localhost:${APP_PORT}`;
+
+// Every workspace lives on a subdomain of FRONTEND_URL when multi-workspace is
+// enabled (WorkspaceDomainsService.getTwentyWorkspaceUrl), so those, not the
+// bare FRONTEND_URL, are the origins a browser actually sends. Subdomains are
+// minted at runtime, so AUTH_COOKIE_ALLOWED_ORIGINS cannot enumerate them.
+// .env.test enables multi-workspace.
+const buildFrontendOrigin = (hostnamePrefix = ''): string => {
+  const frontendUrl = new URL(
+    process.env.FRONTEND_URL ?? 'http://localhost:3001',
+  );
+
+  frontendUrl.hostname = `${hostnamePrefix}${frontendUrl.hostname}`;
+
+  return frontendUrl.origin;
+};
+
+const getCorsHeadersForOrigin = async (origin: string) => {
+  const response = await request(SERVER_URL)
+    .get('/client-config')
+    .set('Origin', origin)
+    .expect(200);
+
+  return {
+    allowOrigin: response.headers['access-control-allow-origin'],
+    allowCredentials: response.headers['access-control-allow-credentials'],
+  };
+};
+
+describe('workspace subdomain CORS (integration)', () => {
+  it.each([['app.'], ['acme.']])(
+    'should give the %s workspace subdomain a credentialed CORS response',
+    async (hostnamePrefix) => {
+      const origin = buildFrontendOrigin(hostnamePrefix);
+
+      const { allowOrigin, allowCredentials } =
+        await getCorsHeadersForOrigin(origin);
+
+      expect(allowOrigin).toBe(origin);
+      expect(allowCredentials).toBe('true');
+    },
+  );
+
+  it('should not credential a host that merely ends with the front domain string', async () => {
+    const origin = buildFrontendOrigin('evil');
+
+    const { allowOrigin } = await getCorsHeadersForOrigin(origin);
+
+    expect(allowOrigin).toBe('*');
+  });
+
+  it('should not credential a workspace subdomain on another port', async () => {
+    const frontendUrl = new URL(buildFrontendOrigin('acme.'));
+
+    frontendUrl.port = '9999';
+
+    const { allowOrigin } = await getCorsHeadersForOrigin(frontendUrl.origin);
+
+    expect(allowOrigin).toBe('*');
+  });
+
+  it('should not credential a workspace subdomain on another scheme', async () => {
+    const frontendUrl = new URL(buildFrontendOrigin('acme.'));
+
+    frontendUrl.protocol = 'https:';
+
+    const { allowOrigin } = await getCorsHeadersForOrigin(frontendUrl.origin);
+
+    expect(allowOrigin).toBe('*');
+  });
+});


### PR DESCRIPTION
With multi-workspace enabled every workspace is served from a subdomain of FRONTEND_URL, so the browser origin is never the bare FRONTEND_URL the allowlist was built from. Those requests fell through to the wildcard, and since the front-end now sends credentials on every request the browser rejected the response, leaving the app unable to load. Subdomains are minted at runtime, so AUTH_COOKIE_ALLOWED_ORIGINS could never enumerate them.

Origins under FRONTEND_URL are now derived the same way DomainServerConfigService.getSubdomainAndDomainFromUrl derives them, gated on IS_MULTIWORKSPACE_ENABLED and requiring a matching scheme and port.

This hits local development with IS_MULTIWORKSPACE_ENABLED=true, which the contributor setup guide recommends for subdomain work, and any deployment serving the API from a different origin than the app. Deployments where the back-end serves the front-end are same-origin and were unaffected.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/23777?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

