### PR TITLE
Keep emails and events when removing a connected account

### DIFF
--- a/packages/twenty-front/src/modules/settings/accounts/components/SettingsAccountsRowDropdownMenu.tsx
+++ b/packages/twenty-front/src/modules/settings/accounts/components/SettingsAccountsRowDropdownMenu.tsx
@@ -27,7 +27,7 @@ import {
 import { LightIconButton } from 'twenty-ui/input';
 import { MenuItem } from 'twenty-ui/navigation';
 import { useNavigateSettings } from '~/hooks/useNavigateSettings';
-import { DELETE_CONNECTED_ACCOUNT } from '../graphql/mutations/deleteConnectedAccount';
+import { DISCONNECT_CONNECTED_ACCOUNT } from '../graphql/mutations/disconnectConnectedAccount';
 
 type SettingsAccountsRowDropdownMenuProps = {
   account: ConnectedAccount;
@@ -37,7 +37,7 @@ export const SettingsAccountsRowDropdownMenu = ({
   account,
 }: SettingsAccountsRowDropdownMenuProps) => {
   const dropdownId = `settings-account-row-${account.id}`;
-  const deleteAccountModalId = `delete-account-modal-${account.id}`;
+  const removeAccountModalId = `remove-account-modal-${account.id}`;
   const accountHandle = account.handle;
 
   const { t } = useLingui();
@@ -47,8 +47,8 @@ export const SettingsAccountsRowDropdownMenu = ({
   const { closeDropdown } = useCloseDropdown();
 
   const apolloClient = useApolloClient();
-  const [deleteConnectedAccountMutation] = useMutation(
-    DELETE_CONNECTED_ACCOUNT,
+  const [disconnectConnectedAccountMutation] = useMutation(
+    DISCONNECT_CONNECTED_ACCOUNT,
   );
   const { triggerProviderReconnect } = useTriggerProviderReconnect();
 
@@ -62,8 +62,8 @@ export const SettingsAccountsRowDropdownMenu = ({
         channel.syncStage === CalendarChannelSyncStage.PENDING_CONFIGURATION,
     );
 
-  const deleteAccount = async () => {
-    await deleteConnectedAccountMutation({
+  const removeAccount = async () => {
+    await disconnectConnectedAccountMutation({
       variables: { id: account.id },
     });
     await apolloClient.refetchQueries({ include: 'active' });
@@ -141,7 +141,7 @@ export const SettingsAccountsRowDropdownMenu = ({
                 text={t`Remove account`}
                 onClick={() => {
                   closeDropdown(dropdownId);
-                  openModal(deleteAccountModalId);
+                  openModal(removeAccountModalId);
                 }}
               />
             </DropdownMenuItemsContainer>
@@ -149,16 +149,16 @@ export const SettingsAccountsRowDropdownMenu = ({
         }
       />
       <ConfirmationModal
-        modalInstanceId={deleteAccountModalId}
-        title={t`Data deletion`}
+        modalInstanceId={removeAccountModalId}
+        title={t`Remove account`}
         subtitle={
           <Trans>
-            All emails and events linked to this account ({accountHandle}) will
-            be deleted
+            {accountHandle} will stop syncing. Emails and events already synced
+            stay on your records.
           </Trans>
         }
-        onConfirmClick={deleteAccount}
-        confirmButtonText={t`Delete account`}
+        onConfirmClick={removeAccount}
+        confirmButtonText={t`Remove account`}
       />
     </>
   );

--- a/packages/twenty-front/src/modules/settings/accounts/graphql/mutations/disconnectConnectedAccount.ts
+++ b/packages/twenty-front/src/modules/settings/accounts/graphql/mutations/disconnectConnectedAccount.ts
@@ -1,0 +1,9 @@
+import { gql } from '@apollo/client';
+
+export const DISCONNECT_CONNECTED_ACCOUNT = gql`
+  mutation DisconnectConnectedAccount($id: UUID!) {
+    disconnectConnectedAccount(id: $id) {
+      id
+    }
+  }
+`;

--- a/packages/twenty-server/src/engine/metadata-modules/connected-account/connected-account-metadata.service.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/connected-account/connected-account-metadata.service.ts
@@ -1,7 +1,7 @@
 import { Injectable, Logger } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 
-import { In, IsNull, Repository } from 'typeorm';
+import { type EntityManager, In, IsNull, Repository } from 'typeorm';
 
 import { isDefined } from 'twenty-shared/utils';
 
@@ -47,7 +47,7 @@ export class ConnectedAccountMetadataService {
     workspaceId: string;
   }): Promise<ConnectedAccountEntity[]> {
     return this.repository.find({
-      where: { userWorkspaceId, workspaceId },
+      where: { userWorkspaceId, workspaceId, archivedAt: IsNull() },
     });
   }
 
@@ -188,36 +188,89 @@ export class ConnectedAccountMetadataService {
       await entityManager.update(
         ConnectedAccountEntity,
         { id: In(connectedAccountIds), workspaceId },
-        {
-          userWorkspaceId: toUserWorkspaceId,
-          accessToken: null,
-          refreshToken: null,
-          connectionParameters: null,
-        },
+        { userWorkspaceId: toUserWorkspaceId },
       );
 
-      await entityManager.update(
-        ConnectedAccountEntity,
-        { id: In(connectedAccountIds), workspaceId, archivedAt: IsNull() },
-        { archivedAt: new Date() },
-      );
-
-      await entityManager.update(
-        MessageChannelEntity,
-        { connectedAccountId: In(connectedAccountIds), workspaceId },
-        { isSyncEnabled: false },
-      );
-
-      await entityManager.update(
-        CalendarChannelEntity,
-        { connectedAccountId: In(connectedAccountIds), workspaceId },
-        { isSyncEnabled: false },
-      );
+      await this.disconnectAccounts({
+        entityManager,
+        connectedAccountIds,
+        workspaceId,
+      });
     });
 
     for (const connectedAccount of connectedAccounts) {
       await this.appOAuthRevokeService.revokeIfApp(connectedAccount);
     }
+  }
+
+  private async disconnectAccounts({
+    entityManager,
+    connectedAccountIds,
+    workspaceId,
+  }: {
+    entityManager: EntityManager;
+    connectedAccountIds: string[];
+    workspaceId: string;
+  }): Promise<void> {
+    await entityManager.update(
+      ConnectedAccountEntity,
+      { id: In(connectedAccountIds), workspaceId },
+      {
+        accessToken: null,
+        refreshToken: null,
+        connectionParameters: null,
+      },
+    );
+
+    await entityManager.update(
+      ConnectedAccountEntity,
+      { id: In(connectedAccountIds), workspaceId, archivedAt: IsNull() },
+      { archivedAt: new Date() },
+    );
+
+    await entityManager.update(
+      MessageChannelEntity,
+      { connectedAccountId: In(connectedAccountIds), workspaceId },
+      { isSyncEnabled: false },
+    );
+
+    await entityManager.update(
+      CalendarChannelEntity,
+      { connectedAccountId: In(connectedAccountIds), workspaceId },
+      { isSyncEnabled: false },
+    );
+  }
+
+  async disconnect({
+    id,
+    workspaceId,
+  }: {
+    id: string;
+    workspaceId: string;
+  }): Promise<ConnectedAccountEntity> {
+    const connectedAccount = await this.repository.findOneOrFail({
+      where: { id, workspaceId },
+    });
+
+    await this.repository.manager.transaction(async (entityManager) => {
+      await this.disconnectAccounts({
+        entityManager,
+        connectedAccountIds: [id],
+        workspaceId,
+      });
+    });
+
+    await this.appOAuthRevokeService.revokeIfApp(connectedAccount);
+
+    if (isDefined(connectedAccount.connectionProviderId)) {
+      await this.connectionProviderLifecycleHookService.dispatchOnDisconnect({
+        connectionProviderId: connectedAccount.connectionProviderId,
+        workspaceId,
+        connectedAccountId: id,
+      });
+    }
+
+    return connectedAccount;
   }
 
   async delete({

--- a/packages/twenty-server/src/engine/metadata-modules/connected-account/resolvers/connected-account.resolver.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/connected-account/resolvers/connected-account.resolver.ts
@@ -57,4 +57,25 @@ export class ConnectedAccountResolver {
 
     return buildPublicConnectedAccount(deleted);
   }
+
+  @Mutation(() => ConnectedAccountPublicDTO)
+  @UseGuards(NoPermissionGuard)
+  async disconnectConnectedAccount(
+    @Args('id', { type: () => UUIDScalarType }) id: string,
+    @AuthWorkspace() workspace: WorkspaceEntity,
+    @AuthUserWorkspaceId() userWorkspaceId: string,
+  ): Promise<ConnectedAccountPublicDTO> {
+    await this.connectedAccountMetadataService.verifyOwnership({
+      id,
+      userWorkspaceId,
+      workspaceId: workspace.id,
+    });
+
+    const disconnected = await this.connectedAccountMetadataService.disconnect({
+      id,
+      workspaceId: workspace.id,
+    });
+
+    return buildPublicConnectedAccount(disconnected);
+  }
 }

--- a/packages/twenty-server/test/integration/google/calendar/connected-account-disconnect.integration-spec.ts
+++ b/packages/twenty-server/test/integration/google/calendar/connected-account-disconnect.integration-spec.ts
@@ -1,0 +1,97 @@
+import { randomUUID } from 'node:crypto';
+
+import { ConnectedAccountProvider } from 'twenty-shared/types';
+
+import { googleCalendarEvent } from 'test/integration/google/mocks/google-calendar-event.util';
+import { setupGoogleMock } from 'test/integration/google/mocks/setup-google-mock.util';
+import { connectMessagingAccount } from 'test/integration/utils/connect-messaging-account.util';
+import {
+  findRecordIdsByFilter,
+  findRecordNodesByFilter,
+} from 'test/integration/utils/find-records-by-filter.util';
+import { disconnectConnectedAccount } from 'test/integration/utils/query-messaging.util';
+import { runCalendarChannelEventsImport } from 'test/integration/utils/run-calendar-channel-events-import.util';
+import { runCalendarChannelListFetch } from 'test/integration/utils/run-calendar-channel-list-fetch.util';
+
+const HANDLE = 'calendar-disconnect@apple.dev';
+
+describe('Calendar connected account disconnect (integration)', () => {
+  const eventId = `google-calendar-event-${randomUUID()}`;
+
+  const gmail = setupGoogleMock({ handle: HANDLE });
+
+  let channel: Awaited<ReturnType<typeof connectMessagingAccount>>;
+
+  beforeAll(async () => {
+    channel = await connectMessagingAccount({
+      provider: ConnectedAccountProvider.GOOGLE,
+      handle: HANDLE,
+    });
+
+    gmail.serveCalendarEvents([
+      googleCalendarEvent({
+        id: eventId,
+        attendees: [
+          { email: `organizer-${eventId}@example.com`, organizer: true },
+          { email: `attendee-${eventId}@example.com` },
+        ],
+      }),
+    ]);
+
+    await runCalendarChannelListFetch(channel.calendarChannelId);
+    await runCalendarChannelEventsImport(channel.calendarChannelId);
+  }, 60000);
+
+  afterAll(async () => {
+    await channel?.cleanup().catch(() => undefined);
+  });
+
+  it('keeps all associated calendar data when the connected account is disconnected', async () => {
+    const associations = await findRecordNodesByFilter<{
+      id: string;
+      calendarEventId: string;
+    }>(
+      'calendarChannelEventAssociation',
+      'calendarChannelEventAssociations',
+      `id
+        calendarEventId`,
+      { calendarChannelId: { eq: channel.calendarChannelId } },
+    );
+
+    expect(associations).toHaveLength(1);
+
+    const eventIds = associations.map(
+      (association) => association.calendarEventId,
+    );
+
+    const participantIdsBefore = await findRecordIdsByFilter(
+      'calendarEventParticipant',
+      'calendarEventParticipants',
+      { calendarEventId: { in: eventIds } },
+    );
+
+    expect(participantIdsBefore).not.toHaveLength(0);
+
+    await disconnectConnectedAccount(channel.connectedAccountId);
+
+    expect(
+      await findRecordIdsByFilter(
+        'calendarChannelEventAssociation',
+        'calendarChannelEventAssociations',
+        { calendarChannelId: { eq: channel.calendarChannelId } },
+      ),
+    ).toHaveLength(associations.length);
+    expect(
+      await findRecordIdsByFilter('calendarEvent', 'calendarEvents', {
+        id: { in: eventIds },
+      }),
+    ).toHaveLength(eventIds.length);
+    expect(
+      await findRecordIdsByFilter(
+        'calendarEventParticipant',
+        'calendarEventParticipants',
+        { calendarEventId: { in: eventIds } },
+      ),
+    ).toHaveLength(participantIdsBefore.length);
+  }, 60000);
+});

--- a/packages/twenty-server/test/integration/google/messaging/connected-account-disconnect.integration-spec.ts
+++ b/packages/twenty-server/test/integration/google/messaging/connected-account-disconnect.integration-spec.ts
@@ -1,0 +1,127 @@
+import { ConnectedAccountProvider } from 'twenty-shared/types';
+import { isDefined } from 'twenty-shared/utils';
+
+import { gmailMessage } from 'test/integration/google/mocks/gmail-message.util';
+import { setupGoogleMock } from 'test/integration/google/mocks/setup-google-mock.util';
+import { connectMessagingAccount } from 'test/integration/utils/connect-messaging-account.util';
+import {
+  findRecordIdsByFilter,
+  findRecordNodesByFilter,
+} from 'test/integration/utils/find-records-by-filter.util';
+import {
+  disconnectConnectedAccount,
+  queryConnectedAccounts,
+} from 'test/integration/utils/query-messaging.util';
+import { runMessageChannelSync } from 'test/integration/utils/run-message-channel-sync.util';
+
+const HANDLE = 'messaging-disconnect@apple.dev';
+
+describe('Messaging connected account disconnect (integration)', () => {
+  const inbox = [gmailMessage(), gmailMessage()];
+
+  setupGoogleMock({ handle: HANDLE, inbox });
+
+  let channel: Awaited<ReturnType<typeof connectMessagingAccount>>;
+
+  beforeAll(async () => {
+    channel = await connectMessagingAccount({
+      provider: ConnectedAccountProvider.GOOGLE,
+      handle: HANDLE,
+    });
+
+    await runMessageChannelSync(channel.channelId);
+  }, 60000);
+
+  afterAll(async () => {
+    await channel?.cleanup().catch(() => undefined);
+  });
+
+  it('keeps all associated messaging data when the connected account is disconnected', async () => {
+    const associations = await findRecordNodesByFilter<{
+      id: string;
+      messageId: string;
+    }>(
+      'messageChannelMessageAssociation',
+      'messageChannelMessageAssociations',
+      `id
+        messageId`,
+      { messageChannelId: { eq: channel.channelId } },
+    );
+
+    expect(associations).toHaveLength(inbox.length);
+
+    const associationIds = associations.map((association) => association.id);
+    const messageIds = associations.map((association) => association.messageId);
+
+    const messages = await findRecordNodesByFilter<{
+      id: string;
+      messageThreadId: string | null;
+    }>(
+      'message',
+      'messages',
+      `id
+        messageThreadId`,
+      { id: { in: messageIds } },
+    );
+
+    expect(messages).toHaveLength(inbox.length);
+
+    const threadIds = [
+      ...new Set(messages.map((message) => message.messageThreadId)),
+    ].filter(isDefined);
+
+    const folderIdsBefore = await findRecordIdsByFilter(
+      'messageChannelMessageAssociationMessageFolder',
+      'messageChannelMessageAssociationMessageFolders',
+      { messageChannelMessageAssociationId: { in: associationIds } },
+    );
+    const participantIdsBefore = await findRecordIdsByFilter(
+      'messageParticipant',
+      'messageParticipants',
+      { messageId: { in: messageIds } },
+    );
+
+    expect(folderIdsBefore).not.toHaveLength(0);
+    expect(participantIdsBefore).not.toHaveLength(0);
+
+    await disconnectConnectedAccount(channel.connectedAccountId);
+
+    expect(
+      await findRecordIdsByFilter('message', 'messages', {
+        id: { in: messageIds },
+      }),
+    ).toHaveLength(messageIds.length);
+    expect(
+      await findRecordIdsByFilter(
+        'messageChannelMessageAssociation',
+        'messageChannelMessageAssociations',
+        { messageChannelId: { eq: channel.channelId } },
+      ),
+    ).toHaveLength(associationIds.length);
+    expect(
+      await findRecordIdsByFilter(
+        'messageChannelMessageAssociationMessageFolder',
+        'messageChannelMessageAssociationMessageFolders',
+        { messageChannelMessageAssociationId: { in: associationIds } },
+      ),
+    ).toHaveLength(folderIdsBefore.length);
+    expect(
+      await findRecordIdsByFilter('messageParticipant', 'messageParticipants', {
+        messageId: { in: messageIds },
+      }),
+    ).toHaveLength(participantIdsBefore.length);
+    expect(
+      await findRecordIdsByFilter('messageThread', 'messageThreads', {
+        id: { in: threadIds },
+      }),
+    ).toHaveLength(threadIds.length);
+  }, 60000);
+
+  it('removes the disconnected account from the accounts list', async () => {
+    const accountIds = (await queryConnectedAccounts()).map(
+      (account) => account.id,
+    );
+
+    expect(accountIds).not.toContain(channel.connectedAccountId);
+  }, 60000);
+});

--- a/packages/twenty-server/test/integration/utils/query-messaging.util.ts
+++ b/packages/twenty-server/test/integration/utils/query-messaging.util.ts
@@ -188,9 +188,9 @@ export const queryCalendarChannel = async ({
   return channel;
 };
 
-export const queryConnectedAccount = async (
-  connectedAccountId: string,
-): Promise<ConnectedAccountDto> => {
+export const queryConnectedAccounts = async (): Promise<
+  ConnectedAccountDto[]
+> => {
   const response = await makeMetadataAPIRequest({
     query: gql`
       query ConnectedAccountsForTest {
@@ -205,9 +205,15 @@ export const queryConnectedAccount = async (
     `,
   });
 
-  const account = (
-    getDataOrThrow(response).myConnectedAccounts as ConnectedAccountDto[]
-  ).find((candidate) => candidate.id === connectedAccountId);
+  return getDataOrThrow(response).myConnectedAccounts as ConnectedAccountDto[];
+};
+
+export const queryConnectedAccount = async (
+  connectedAccountId: string,
+): Promise<ConnectedAccountDto> => {
+  const account = (await queryConnectedAccounts()).find(
+    (candidate) => candidate.id === connectedAccountId,
+  );
 
   if (!account) {
     throw new Error(`Connected account ${connectedAccountId} not found`);
@@ -279,6 +285,25 @@ export const startChannelSync = async (
   });
 
   getDataOrThrow(response);
+};
+
+export const disconnectConnectedAccount = async (
+  connectedAccountId: string,
+): Promise<void> => {
+  const response = await makeMetadataAPIRequest({
+    query: gql`
+      mutation DisconnectConnectedAccountForTest($id: UUID!) {
+        disconnectConnectedAccount(id: $id) {
+          id
+        }
+      }
+    `,
+    variables: { id: connectedAccountId },
+  });
+
+  getDataOrThrow(response);
+
+  await waitForAllJobsToFinish();
 };
 
 export const deleteConnectedAccount = async (


### PR DESCRIPTION
Removing a connected account deleted every email and calendar event it had imported. It now disconnects instead: credentials cleared, sync disabled, account archived and hidden from the accounts list. Nothing is deleted.

Member removal is unchanged. `transferOwnership` already preserved this data and hands the account to an admin who keeps full access to it.

Integration tests cover the messaging and calendar disconnect paths.