### PR TITLE
Unlist superseded marketplace registrations on catalog sync

### DIFF
--- a/packages/twenty-server/src/engine/core-modules/application/application-marketplace/marketplace-catalog-sync.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/application/application-marketplace/marketplace-catalog-sync.service.ts
@@ -61,6 +61,13 @@ export class MarketplaceCatalogSyncService {
           manifest: fetchedManifest,
         });
 
+        await this.applicationRegistrationService.unlistSupersededCatalogRegistrations(
+          {
+            sourcePackage: pkg.name,
+            currentUniversalIdentifier: universalIdentifier,
+          },
+        );
+
         const registration =
           await this.applicationRegistrationService.findOneByUniversalIdentifier(
             universalIdentifier,

--- a/packages/twenty-server/src/engine/core-modules/application/application-registration/__tests__/application-registration-unlist-superseded.spec.ts
+++ b/packages/twenty-server/src/engine/core-modules/application/application-registration/__tests__/application-registration-unlist-superseded.spec.ts
@@ -1,0 +1,129 @@
+import { Test, type TestingModule } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { Not } from 'typeorm';
+
+import { ApplicationRegistrationAssetUrlService } from 'src/engine/core-modules/application/application-registration/application-registration-asset-url.service';
+import { ApplicationRegistrationEntity } from 'src/engine/core-modules/application/application-registration/application-registration.entity';
+import { ApplicationRegistrationService } from 'src/engine/core-modules/application/application-registration/application-registration.service';
+import { ApplicationRegistrationVariableService } from 'src/engine/core-modules/application/application-registration-variable/application-registration-variable.service';
+import { ApplicationRegistrationSourceType } from 'src/engine/core-modules/application/application-registration/enums/application-registration-source-type.enum';
+import { ApplicationEntity } from 'src/engine/core-modules/application/application.entity';
+import { CacheLockService } from 'src/engine/core-modules/cache-lock/cache-lock.service';
+import { CoreEntityCacheService } from 'src/engine/core-entity-cache/services/core-entity-cache.service';
+import { ServerFileStorageService } from 'src/engine/core-modules/file-storage/services/server-file-storage.service';
+import { MessageQueue } from 'src/engine/core-modules/message-queue/message-queue.constants';
+import { getQueueToken } from 'src/engine/core-modules/message-queue/utils/get-queue-token.util';
+import { MetricsService } from 'src/engine/core-modules/metrics/metrics.service';
+import { WorkspaceEntity } from 'src/engine/core-modules/workspace/workspace.entity';
+
+describe('ApplicationRegistrationService - unlistSupersededCatalogRegistrations', () => {
+  let service: ApplicationRegistrationService;
+  let applicationRegistrationRepository: {
+    find: jest.Mock;
+    update: jest.Mock;
+  };
+  let coreEntityCacheService: { invalidate: jest.Mock };
+
+  const sourcePackage = 'twenty-app-my-app';
+  const currentUniversalIdentifier = '97141c95-2870-5662-8992-44fb6536be9a';
+
+  beforeEach(async () => {
+    applicationRegistrationRepository = {
+      find: jest.fn(),
+      update: jest.fn(),
+    };
+    coreEntityCacheService = { invalidate: jest.fn() };
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        ApplicationRegistrationService,
+        {
+          provide: getRepositoryToken(ApplicationRegistrationEntity),
+          useValue: applicationRegistrationRepository,
+        },
+        {
+          provide: getRepositoryToken(ApplicationEntity),
+          useValue: { find: jest.fn(), findOne: jest.fn() },
+        },
+        {
+          provide: getRepositoryToken(WorkspaceEntity),
+          useValue: { find: jest.fn(), findOne: jest.fn() },
+        },
+        {
+          provide: ApplicationRegistrationVariableService,
+          useValue: { syncVariableSchemas: jest.fn() },
+        },
+        {
+          provide: ApplicationRegistrationAssetUrlService,
+          useValue: { resolveAssetUrls: jest.fn() },
+        },
+        {
+          provide: ServerFileStorageService,
+          useValue: { write: jest.fn(), delete: jest.fn() },
+        },
+        {
+          provide: CacheLockService,
+          useValue: { withLock: jest.fn((_key, fn) => fn()) },
+        },
+        {
+          provide: CoreEntityCacheService,
+          useValue: coreEntityCacheService,
+        },
+        {
+          provide: MetricsService,
+          useValue: { incrementCounterBy: jest.fn() },
+        },
+        {
+          provide: getQueueToken(MessageQueue.workspaceQueue),
+          useValue: { add: jest.fn() },
+        },
+      ],
+    }).compile();
+
+    service = module.get<ApplicationRegistrationService>(
+      ApplicationRegistrationService,
+    );
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should unlist listed npm registrations of the same package with a different universalIdentifier', async () => {
+    applicationRegistrationRepository.find.mockResolvedValue([
+      { id: 'superseded-registration-id' },
+    ]);
+
+    await service.unlistSupersededCatalogRegistrations({
+      sourcePackage,
+      currentUniversalIdentifier,
+    });
+
+    expect(applicationRegistrationRepository.find).toHaveBeenCalledWith({
+      select: ['id'],
+      where: {
+        sourceType: ApplicationRegistrationSourceType.NPM,
+        sourcePackage,
+        universalIdentifier: Not(currentUniversalIdentifier),
+        isListed: true,
+      },
+    });
+    expect(applicationRegistrationRepository.update).toHaveBeenCalledWith(
+      ['superseded-registration-id'],
+      { isListed: false },
+    );
+    expect(coreEntityCacheService.invalidate).toHaveBeenCalled();
+  });
+
+  it('should do nothing when no superseded registration exists', async () => {
+    applicationRegistrationRepository.find.mockResolvedValue([]);
+
+    await service.unlistSupersededCatalogRegistrations({
+      sourcePackage,
+      currentUniversalIdentifier,
+    });
+
+    expect(applicationRegistrationRepository.update).not.toHaveBeenCalled();
+    expect(coreEntityCacheService.invalidate).not.toHaveBeenCalled();
+  });
+});

--- a/packages/twenty-server/src/engine/core-modules/application/application-registration/application-registration.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/application/application-registration/application-registration.service.ts
@@ -7,7 +7,13 @@ import { isNonEmptyString } from '@sniptt/guards';
 import * as bcrypt from 'bcrypt';
 import { type Manifest } from 'twenty-shared/application';
 import { isDefined } from 'twenty-shared/utils';
-import { ILike, IsNull, type FindOptionsWhere, type Repository } from 'typeorm';
+import {
+  ILike,
+  IsNull,
+  Not,
+  type FindOptionsWhere,
+  type Repository,
+} from 'typeorm';
 import { type QueryDeepPartialEntity } from 'typeorm/query-builder/QueryPartialEntity';
 import { v4 } from 'uuid';
 
@@ -733,6 +739,42 @@ export class ApplicationRegistrationService {
       registration.id,
       params.manifest.application.serverVariables,
     );
+  }
+
+  // Only called right after a successful catalog sync of the package, so
+  // unlisting never acts on stale or partially fetched registry data.
+  async unlistSupersededCatalogRegistrations({
+    sourcePackage,
+    currentUniversalIdentifier,
+  }: {
+    sourcePackage: string;
+    currentUniversalIdentifier: string;
+  }): Promise<void> {
+    const supersededRegistrations =
+      await this.applicationRegistrationRepository.find({
+        select: ['id'],
+        where: {
+          sourceType: ApplicationRegistrationSourceType.NPM,
+          sourcePackage,
+          universalIdentifier: Not(currentUniversalIdentifier),
+          isListed: true,
+        },
+      });
+
+    if (supersededRegistrations.length === 0) {
+      return;
+    }
+
+    await this.applicationRegistrationRepository.update(
+      supersededRegistrations.map((registration) => registration.id),
+      { isListed: false },
+    );
+
+    this.logger.log(
+      `Unlisted ${supersededRegistrations.length} superseded registration(s) for package "${sourcePackage}"`,
+    );
+
+    await this.invalidateMarketplaceAppsCache();
   }
 
   async createCliRegistrationIfNotExists(): Promise<ApplicationRegistrationEntity | null> {


### PR DESCRIPTION
Addresses the ghost-duplicate half of #20424.

## Problem

`MarketplaceCatalogSyncService` is upsert-only. When a package's manifest rotates its `universalIdentifier` between versions, the row for the previous identifier is never touched again: it stays `isListed: true` forever, pointing at a version that no longer resolves. The marketplace search then shows two entries for the same `sourcePackage`, and installing the older one fails.

## Fix

After each successful package sync, unlist any other listed NPM registration with the same `sourcePackage` but a different `universalIdentifier`. This only runs right after fresh data for that exact package was fetched and upserted, so a registry hiccup or partial catalog fetch can never mass-unlist anything.

Rows are unlisted, not deleted: installed workspaces keep referencing the registration, and the re-listing logic from #22877 brings a row back automatically if its identifier reappears in the catalog.

## Out of scope

Garbage-collecting registrations whose package was unpublished from npm entirely. That needs a way to distinguish "gone from the registry" from a transient fetch failure, and is left for a follow-up.

## Test

Unit spec covering the unlist query/update path and the no-op case.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/23808?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

