### PR TITLE
feat(workflow): dispatch-source observability for the core rollout

### DIFF
--- a/packages/twenty-server/src/engine/core-modules/metrics/types/metrics-keys.type.ts
+++ b/packages/twenty-server/src/engine/core-modules/metrics/types/metrics-keys.type.ts
@@ -28,6 +28,8 @@ export enum MetricsKeys {
   WorkflowCoreConsistencyWorkflowDrift = 'workflow-core-consistency/workflow/drift',
   WorkflowCoreConsistencyVersionDrift = 'workflow-core-consistency/version/drift',
   WorkflowCoreConsistencyAutomatedTriggerDrift = 'workflow-core-consistency/automated-trigger/drift',
+  WorkflowDispatchDatabaseEventTrigger = 'workflow-dispatch/database-event-trigger',
+  WorkflowCronTriggerCacheRebuild = 'workflow-cron-trigger/cache-rebuild',
   AiChatToolExecutionSucceeded = 'ai-chat/tool-execution-succeeded',
   AiChatToolExecutionFailed = 'ai-chat/tool-execution-failed',
   AiChatToolExecutionDurationMs = 'ai-chat/tool-execution-duration-ms',

--- a/packages/twenty-server/src/modules/workflow/workflow-trigger/automated-trigger/automated-trigger.module.ts
+++ b/packages/twenty-server/src/modules/workflow/workflow-trigger/automated-trigger/automated-trigger.module.ts
@@ -4,6 +4,7 @@ import { TypeOrmModule } from '@nestjs/typeorm';
 import { CacheStorageModule } from 'src/engine/core-modules/cache-storage/cache-storage.module';
 import { CronModule } from 'src/engine/core-modules/cron/cron.module';
 import { FeatureFlagModule } from 'src/engine/core-modules/feature-flag/feature-flag.module';
+import { MetricsModule } from 'src/engine/core-modules/metrics/metrics.module';
 import { WorkspaceEntity } from 'src/engine/core-modules/workspace/workspace.entity';
 import { WorkspaceCacheModule } from 'src/engine/workspace-cache/workspace-cache.module';
 import { WorkspaceDataSourceModule } from 'src/engine/workspace-datasource/workspace-datasource.module';
@@ -19,6 +20,7 @@ import { WorkflowDatabaseEventTriggerListener } from 'src/modules/workflow/workf
     CacheStorageModule,
     CronModule,
     FeatureFlagModule,
+    MetricsModule,
     WorkflowCommonModule,
     WorkspaceCacheModule,
     WorkspaceDataSourceModule,

--- a/packages/twenty-server/src/modules/workflow/workflow-trigger/automated-trigger/crons/jobs/__tests__/workflow-cron-trigger-cron.job.spec.ts
+++ b/packages/twenty-server/src/modules/workflow/workflow-trigger/automated-trigger/crons/jobs/__tests__/workflow-cron-trigger-cron.job.spec.ts
@@ -5,6 +5,7 @@ import { CacheStorageNamespace } from 'src/engine/core-modules/cache-storage/typ
 import { CronTriggerDeduplicationService } from 'src/engine/core-modules/cron/services/cron-trigger-deduplication.service';
 import { ExceptionHandlerService } from 'src/engine/core-modules/exception-handler/exception-handler.service';
 import { FeatureFlagService } from 'src/engine/core-modules/feature-flag/services/feature-flag.service';
+import { MetricsService } from 'src/engine/core-modules/metrics/metrics.service';
 import { WorkspaceEntity } from 'src/engine/core-modules/workspace/workspace.entity';
 import { WorkspaceCacheService } from 'src/engine/workspace-cache/services/workspace-cache.service';
 import { WORKFLOW_CRON_TRIGGER_CACHE_KEY } from 'src/modules/workflow/workflow-trigger/automated-trigger/crons/constants/workflow-cron-trigger-cache-key.constant';
@@ -48,6 +49,10 @@ const mockFeatureFlagService = {
 
 const mockWorkspaceCacheService = {
   getOrRecompute: jest.fn(),
+};
+
+const mockMetricsService = {
+  incrementCounterBy: jest.fn(),
 };
 
 describe('WorkflowCronTriggerCronJob', () => {
@@ -95,6 +100,10 @@ describe('WorkflowCronTriggerCronJob', () => {
         {
           provide: WorkspaceCacheService,
           useValue: mockWorkspaceCacheService,
+        },
+        {
+          provide: MetricsService,
+          useValue: mockMetricsService,
         },
       ],
     }).compile();
@@ -309,6 +318,29 @@ describe('WorkflowCronTriggerCronJob', () => {
         { workspaceId: WORKSPACE_1, workflowId: 'workflow-1', payload: {} },
         { retryLimit: 3 },
       );
+      expect(mockMetricsService.incrementCounterBy).toHaveBeenCalledWith(
+        expect.objectContaining({ attributes: { source: 'core-map' } }),
+      );
+    });
+
+    it('warns when dispatch-from-core is enabled but the core map has no cron triggers while the table does', async () => {
+      mockFeatureFlagService.isFeatureEnabled.mockResolvedValue(true);
+      mockCacheStorageService.hashGetValues.mockResolvedValue([]);
+      mockWorkspaceRepository.find.mockResolvedValue([{ id: WORKSPACE_1 }]);
+      mockWorkspaceCacheService.getOrRecompute.mockResolvedValue({
+        workflowAutomatedTriggerMaps: { byWorkflowId: {} },
+      } as any);
+      mockCoreDataSource.query.mockResolvedValue([{ count: 2 }]);
+      const warnSpy = jest
+        .spyOn(job['logger'], 'warn')
+        .mockImplementation(() => undefined);
+
+      await job.handle();
+
+      expect(warnSpy).toHaveBeenCalledWith(
+        expect.stringContaining('core rows are likely missing'),
+      );
+      expect(mockMessageQueueService.add).not.toHaveBeenCalled();
     });
   });
 

--- a/packages/twenty-server/src/modules/workflow/workflow-trigger/automated-trigger/crons/jobs/workflow-cron-trigger-cron.job.ts
+++ b/packages/twenty-server/src/modules/workflow/workflow-trigger/automated-trigger/crons/jobs/workflow-cron-trigger-cron.job.ts
@@ -17,6 +17,8 @@ import { InjectMessageQueue } from 'src/engine/core-modules/message-queue/decora
 import { Process } from 'src/engine/core-modules/message-queue/decorators/process.decorator';
 import { Processor } from 'src/engine/core-modules/message-queue/decorators/processor.decorator';
 import { MessageQueue } from 'src/engine/core-modules/message-queue/message-queue.constants';
+import { MetricsService } from 'src/engine/core-modules/metrics/metrics.service';
+import { MetricsKeys } from 'src/engine/core-modules/metrics/types/metrics-keys.type';
 import { MessageQueueService } from 'src/engine/core-modules/message-queue/services/message-queue.service';
 import { WorkspaceEntity } from 'src/engine/core-modules/workspace/workspace.entity';
 import { isCachedCronTrigger } from 'src/engine/core-modules/workflow/utils/cached-workflow-automated-trigger.util';
@@ -51,6 +53,7 @@ export class WorkflowCronTriggerCronJob {
     private readonly cronTriggerDeduplicationService: CronTriggerDeduplicationService,
     private readonly featureFlagService: FeatureFlagService,
     private readonly workspaceCacheService: WorkspaceCacheService,
+    private readonly metricsService: MetricsService,
   ) {}
 
   @Process(WorkflowCronTriggerCronJob.name)
@@ -230,25 +233,40 @@ export class WorkflowCronTriggerCronJob {
         workspaceId,
       );
 
+    const schemaName = getWorkspaceSchemaName(workspaceId);
+
     if (isDispatchFromCoreEnabled) {
       const { workflowAutomatedTriggerMaps } =
         await this.workspaceCacheService.getOrRecompute(workspaceId, [
           'workflowAutomatedTriggerMaps',
         ]);
 
-      return Object.values(workflowAutomatedTriggerMaps.byWorkflowId)
+      const cronTriggers = Object.values(
+        workflowAutomatedTriggerMaps.byWorkflowId,
+      )
         .filter(isCachedCronTrigger)
         .map((trigger) => ({
           workflowId: trigger.workflowId,
           pattern: trigger.settings.pattern,
         }));
-    }
 
-    const schemaName = getWorkspaceSchemaName(workspaceId);
+      if (cronTriggers.length === 0) {
+        await this.warnOnCronTriggersMissingFromCoreMap(
+          workspaceId,
+          schemaName,
+        );
+      }
+
+      this.emitCacheRebuildMetric('core-map', cronTriggers.length);
+
+      return cronTriggers;
+    }
 
     const rows = await this.coreDataSource.query(
       `SELECT "workflowId", settings FROM ${schemaName}."workflowAutomatedTrigger" WHERE type = '${AutomatedTriggerType.CRON}'`,
     );
+
+    this.emitCacheRebuildMetric('entity', rows.length);
 
     return rows.map(
       (row: { workflowId: string; settings: CronTriggerSettings }) => ({
@@ -256,5 +274,33 @@ export class WorkflowCronTriggerCronJob {
         pattern: row.settings?.pattern,
       }),
     );
+  }
+
+  private async warnOnCronTriggersMissingFromCoreMap(
+    workspaceId: string,
+    schemaName: string,
+  ): Promise<void> {
+    const [{ count }] = await this.coreDataSource.query(
+      `SELECT count(*)::int AS count FROM ${schemaName}."workflowAutomatedTrigger" WHERE type = '${AutomatedTriggerType.CRON}' AND "deletedAt" IS NULL`,
+    );
+
+    if (count > 0) {
+      this.logger.warn(
+        `Workspace ${workspaceId}: dispatch-from-core is enabled but the core trigger map has no CRON triggers while the workspace table has ${count} - core rows are likely missing, cron workflows will not dispatch`,
+      );
+    }
+  }
+
+  private emitCacheRebuildMetric(
+    source: 'core-map' | 'entity',
+    amount: number,
+  ): void {
+    if (amount > 0) {
+      this.metricsService.incrementCounterBy({
+        key: MetricsKeys.WorkflowCronTriggerCacheRebuild,
+        amount,
+        attributes: { source },
+      });
+    }
   }
 }

--- a/packages/twenty-server/src/modules/workflow/workflow-trigger/automated-trigger/listeners/__tests__/workflow-database-event-trigger.listener.spec.ts
+++ b/packages/twenty-server/src/modules/workflow/workflow-trigger/automated-trigger/listeners/__tests__/workflow-database-event-trigger.listener.spec.ts
@@ -1,6 +1,7 @@
 import { Test, type TestingModule } from '@nestjs/testing';
 
 import { FeatureFlagService } from 'src/engine/core-modules/feature-flag/services/feature-flag.service';
+import { MetricsService } from 'src/engine/core-modules/metrics/metrics.service';
 import { MessageQueueService } from 'src/engine/core-modules/message-queue/services/message-queue.service';
 import { type FlatObjectMetadata } from 'src/engine/metadata-modules/flat-object-metadata/types/flat-object-metadata.type';
 import { GlobalWorkspaceOrmManager } from 'src/engine/twenty-orm/global-workspace-datasource/global-workspace-orm.manager';
@@ -17,6 +18,10 @@ describe('WorkflowDatabaseEventTriggerListener', () => {
   let messageQueueService: jest.Mocked<MessageQueueService>;
   let featureFlagService: jest.Mocked<FeatureFlagService>;
   let workspaceCacheService: jest.Mocked<WorkspaceCacheService>;
+
+  const metricsService = {
+    incrementCounterBy: jest.fn(),
+  };
 
   const mockRepository = {
     find: jest.fn(),
@@ -91,6 +96,10 @@ describe('WorkflowDatabaseEventTriggerListener', () => {
           useValue: workspaceCacheService,
         },
         {
+          provide: MetricsService,
+          useValue: metricsService,
+        },
+        {
           provide: 'MESSAGE_QUEUE_workflow-queue',
           useValue: messageQueueService,
         },
@@ -159,6 +168,9 @@ describe('WorkflowDatabaseEventTriggerListener', () => {
         },
         { retryLimit: 3 },
       );
+      expect(metricsService.incrementCounterBy).toHaveBeenCalledWith(
+        expect.objectContaining({ attributes: { source: 'entity' } }),
+      );
     });
 
     it('reads listeners from the core trigger map when dispatch-from-core is enabled', async () => {
@@ -173,6 +185,9 @@ describe('WorkflowDatabaseEventTriggerListener', () => {
 
       // Dispatch is driven by the core map, not the workspace entity.
       expect(mockRepository.find).not.toHaveBeenCalled();
+      expect(metricsService.incrementCounterBy).toHaveBeenCalledWith(
+        expect.objectContaining({ attributes: { source: 'core-map' } }),
+      );
       expect(messageQueueService.add).toHaveBeenCalledWith(
         WorkflowTriggerJob.name,
         {

--- a/packages/twenty-server/src/modules/workflow/workflow-trigger/automated-trigger/listeners/workflow-database-event-trigger.listener.ts
+++ b/packages/twenty-server/src/modules/workflow/workflow-trigger/automated-trigger/listeners/workflow-database-event-trigger.listener.ts
@@ -16,6 +16,8 @@ import { In, Raw } from 'typeorm';
 import { OnDatabaseBatchEvent } from 'src/engine/api/graphql/graphql-query-runner/decorators/on-database-batch-event.decorator';
 import { DatabaseEventAction } from 'src/engine/api/graphql/graphql-query-runner/enums/database-event-action';
 import { FeatureFlagService } from 'src/engine/core-modules/feature-flag/services/feature-flag.service';
+import { MetricsService } from 'src/engine/core-modules/metrics/metrics.service';
+import { MetricsKeys } from 'src/engine/core-modules/metrics/types/metrics-keys.type';
 import { InjectMessageQueue } from 'src/engine/core-modules/message-queue/decorators/message-queue.decorator';
 import { MessageQueue } from 'src/engine/core-modules/message-queue/message-queue.constants';
 import { MessageQueueService } from 'src/engine/core-modules/message-queue/services/message-queue.service';
@@ -72,6 +74,7 @@ export class WorkflowDatabaseEventTriggerListener {
     private readonly workflowCommonWorkspaceService: WorkflowCommonWorkspaceService,
     private readonly featureFlagService: FeatureFlagService,
     private readonly workspaceCacheService: WorkspaceCacheService,
+    private readonly metricsService: MetricsService,
   ) {}
 
   @OnDatabaseBatchEvent('*', DatabaseEventAction.CREATED)
@@ -357,10 +360,19 @@ export class WorkflowDatabaseEventTriggerListener {
     const workspaceId = payload.workspaceId;
     const databaseEventName = payload.name;
 
+    const isDispatchFromCoreEnabled =
+      await this.featureFlagService.isFeatureEnabled(
+        FeatureFlagKey.IS_WORKFLOW_DISPATCH_FROM_CORE_ENABLED,
+        workspaceId,
+      );
+
     const eventListeners = await this.getDatabaseEventListeners(
       workspaceId,
       databaseEventName,
+      isDispatchFromCoreEnabled,
     );
+
+    let enqueuedCount = 0;
 
     for (const eventListener of eventListeners) {
       for (const eventPayload of payload.events) {
@@ -380,21 +392,27 @@ export class WorkflowDatabaseEventTriggerListener {
             },
             { retryLimit: 3 },
           );
+          enqueuedCount++;
         }
       }
+    }
+
+    if (enqueuedCount > 0) {
+      this.metricsService.incrementCounterBy({
+        key: MetricsKeys.WorkflowDispatchDatabaseEventTrigger,
+        amount: enqueuedCount,
+        attributes: {
+          source: isDispatchFromCoreEnabled ? 'core-map' : 'entity',
+        },
+      });
     }
   }
 
   private async getDatabaseEventListeners(
     workspaceId: string,
     databaseEventName: string,
+    isDispatchFromCoreEnabled: boolean,
   ): Promise<DatabaseEventTriggerListener[]> {
-    const isDispatchFromCoreEnabled =
-      await this.featureFlagService.isFeatureEnabled(
-        FeatureFlagKey.IS_WORKFLOW_DISPATCH_FROM_CORE_ENABLED,
-        workspaceId,
-      );
-
     if (isDispatchFromCoreEnabled) {
       const { workflowAutomatedTriggerMaps } =
         await this.workspaceCacheService.getOrRecompute(workspaceId, [


### PR DESCRIPTION
## Context

Follow-up to #23775 (dispatch read-switch, merged) and companion to #23807 (rollout readiness). During the flag rollout we need to see, per workspace, which source dispatch actually used - and get warned about the one silent failure mode: flag on with missing core rows means the trigger map computes to empty and workflows just stop, with no error anywhere.

## What this does

- New counter `workflow-dispatch/database-event-trigger` with `source: core-map | entity`, incremented per enqueued trigger job in the DB-event listener. Rollout shows up as volume moving from `entity` to `core-map`; a silent stop shows as a rate drop.
- New counter `workflow-cron-trigger/cache-rebuild` with the same `source` attribute, counting entries cached per rebuild. Cache-hit dispatches inherit the rebuild's provenance, so this tells you which source feeds cron dispatch.
- Warn on rebuild when dispatch-from-core is enabled but the core map yields zero CRON triggers while the workspace table still has non-deleted CRON rows - the "core rows are likely missing" signature. One extra COUNT, only on that path.

No dispatch behavior change: metrics and one warning only.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/23809?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

