### PR TITLE
Stop classifying Recall bot-detection timeouts as NOT_RECORDED in call-recorder

### DIFF
--- a/packages/twenty-apps/public/call-recorder/package.json
+++ b/packages/twenty-apps/public/call-recorder/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@twentyhq/call-recorder",
-  "version": "1.7.0",
+  "version": "1.7.1",
   "license": "MIT",
   "engines": {
     "node": "^24.5.0",

--- a/packages/twenty-apps/public/call-recorder/src/logic-functions/constants/not-recorded-recall-sub-codes.ts
+++ b/packages/twenty-apps/public/call-recorder/src/logic-functions/constants/not-recorded-recall-sub-codes.ts
@@ -2,8 +2,6 @@
 export const NOT_RECORDED_RECALL_SUB_CODES: readonly string[] = [
   'meeting_not_started',
   'timeout_exceeded_noone_joined',
-  'timeout_exceeded_only_bots_detected_using_participant_names',
-  'timeout_exceeded_only_bots_detected_using_participant_events',
   'timeout_exceeded_waiting_room',
   'call_ended_by_platform_waiting_room_timeout',
   'bot_kicked_from_waiting_room',

--- a/packages/twenty-apps/public/call-recorder/src/logic-functions/flows/__tests__/handle-recall-webhook.test.ts
+++ b/packages/twenty-apps/public/call-recorder/src/logic-functions/flows/__tests__/handle-recall-webhook.test.ts
@@ -359,6 +359,15 @@ describe('handleRecallWebhook', () => {
       callRecordingId: 'call-recording-1',
       callRecordingStatus: 'PROCESSING',
     });
+    expect(client.mutations).toEqual([
+      {
+        id: 'call-recording-1',
+        data: {
+          status: 'PROCESSING',
+          externalBotId: 'recall-bot-1',
+        },
+      },
+    ]);
   });
 
   it('ignores a no-capture sub code on a non-terminal status code', async () => {

--- a/packages/twenty-apps/public/call-recorder/src/logic-functions/flows/__tests__/handle-recall-webhook.test.ts
+++ b/packages/twenty-apps/public/call-recorder/src/logic-functions/flows/__tests__/handle-recall-webhook.test.ts
@@ -323,6 +323,44 @@ describe('handleRecallWebhook', () => {
     ]);
   });
 
+  it('treats a bot-detection timeout as a normal call ending', async () => {
+    const client = new FakeCoreApiClient([
+      {
+        id: 'call-recording-1',
+        status: 'RECORDING',
+        externalBotId: 'recall-bot-1',
+      },
+    ]);
+
+    const result = await handleRecallWebhook({
+      client: client as unknown as CoreApiClient,
+      body: {
+        event: 'bot.status_change',
+        data: {
+          bot: {
+            id: 'recall-bot-1',
+            metadata: {
+              twentyWorkspaceId: WORKSPACE_ID,
+              twentyCallRecordingId: 'call-recording-1',
+            },
+          },
+          status: {
+            code: 'call_ended',
+            sub_code:
+              'timeout_exceeded_only_bots_detected_using_participant_names',
+          },
+        },
+      },
+    });
+
+    expect(result).toEqual({
+      status: 'updated',
+      event: 'bot.status_change',
+      callRecordingId: 'call-recording-1',
+      callRecordingStatus: 'PROCESSING',
+    });
+  });
+
   it('ignores a no-capture sub code on a non-terminal status code', async () => {
     const client = new FakeCoreApiClient([
       {


### PR DESCRIPTION
Removes the two `timeout_exceeded_only_bots_detected_*` sub codes from `NOT_RECORDED_RECALL_SUB_CODES`, so a bot-detection leave is handled like any other call ending (`call_ended` -> PROCESSING -> artifact import -> COMPLETED).

These sub codes are leave reasons, not capture verdicts. Bot detection only fires when participants are present (otherwise `noone_joined` fires first), and any participant starts the recording, so a bot-detection ending virtually always has a real recording behind it. It is also the app's own configured exit path whenever a third-party notetaker (Fireflies, Otter) lingers after the humans leave, since a lingering bot keeps `everyone_left_timeout` from ever firing. Classifying it as NOT_RECORDED stamped successfully recorded calls as failures and skipped artifact import; bots in the production Recall workspace end with this sub code near-daily.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/23812?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

