### PR TITLE
fix(twenty-server): stop lockless applications from sharing one dependency layer

### DIFF
--- a/packages/twenty-server/src/engine/core-modules/logic-function/logic-function-drivers/drivers/lambda/utils/__tests__/get-lambda-deps-layer-name.util.spec.ts
+++ b/packages/twenty-server/src/engine/core-modules/logic-function/logic-function-drivers/drivers/lambda/utils/__tests__/get-lambda-deps-layer-name.util.spec.ts
@@ -5,7 +5,9 @@ const buildFlatApplication = (
   overrides: Partial<FlatApplication> = {},
 ): FlatApplication =>
   ({
+    id: 'app-id-1',
     yarnLockChecksum: 'abc123',
+    packageJsonChecksum: 'pkg456',
     ...overrides,
   }) as FlatApplication;
 
@@ -16,22 +18,33 @@ describe('getLambdaDepsLayerName', () => {
     ).toBe('deps-abc123');
   });
 
-  it('falls back to deps-default when yarnLockChecksum is undefined', () => {
+  it('falls back to the packageJsonChecksum when yarnLockChecksum is undefined', () => {
     expect(
       getLambdaDepsLayerName({
         flatApplication: buildFlatApplication({ yarnLockChecksum: undefined }),
       }),
-    ).toBe('deps-default');
+    ).toBe('deps-pkg456');
   });
 
-  it('falls back to deps-default when yarnLockChecksum is null', () => {
+  it('falls back to the packageJsonChecksum when yarnLockChecksum is null', () => {
     expect(
       getLambdaDepsLayerName({
         flatApplication: buildFlatApplication({
           yarnLockChecksum: null as unknown as string,
         }),
       }),
-    ).toBe('deps-default');
+    ).toBe('deps-pkg456');
+  });
+
+  it('falls back to the application id when both checksums are missing', () => {
+    expect(
+      getLambdaDepsLayerName({
+        flatApplication: buildFlatApplication({
+          yarnLockChecksum: null as unknown as string,
+          packageJsonChecksum: null as unknown as string,
+        }),
+      }),
+    ).toBe('deps-app-id-1');
   });
 
   it('inserts the namespace segment when provided', () => {

--- a/packages/twenty-server/src/engine/core-modules/logic-function/logic-function-drivers/drivers/lambda/utils/get-lambda-deps-layer-name.util.ts
+++ b/packages/twenty-server/src/engine/core-modules/logic-function/logic-function-drivers/drivers/lambda/utils/get-lambda-deps-layer-name.util.ts
@@ -13,5 +13,11 @@ export const getLambdaDepsLayerName = ({
   buildLambdaResourceName({
     resourceNamePrefix: DEPS_LAYER_NAME_PREFIX,
     namespace,
-    checksum: flatApplication.yarnLockChecksum ?? 'default',
+    // A shared fallback like 'default' would make every application without
+    // a lockfile resolve to the same layer and receive whichever
+    // dependencies were built first.
+    checksum:
+      flatApplication.yarnLockChecksum ??
+      flatApplication.packageJsonChecksum ??
+      flatApplication.id,
   });

--- a/packages/twenty-server/src/engine/core-modules/logic-function/logic-function-drivers/drivers/local/utils/__tests__/get-local-deps-layer-path.util.spec.ts
+++ b/packages/twenty-server/src/engine/core-modules/logic-function/logic-function-drivers/drivers/local/utils/__tests__/get-local-deps-layer-path.util.spec.ts
@@ -9,11 +9,22 @@ describe('getLocalDepsLayerPath', () => {
     ).toBe(`${LOGIC_FUNCTION_EXECUTOR_TMPDIR_FOLDER}/deps/abc123`);
   });
 
-  it('falls back to default when yarnLockChecksum is undefined', () => {
+  it('falls back to the packageJsonChecksum when yarnLockChecksum is undefined', () => {
     expect(
       getLocalDepsLayerPath({
         yarnLockChecksum: undefined,
+        packageJsonChecksum: 'pkg456',
       } as unknown as FlatApplication),
-    ).toBe(`${LOGIC_FUNCTION_EXECUTOR_TMPDIR_FOLDER}/deps/default`);
+    ).toBe(`${LOGIC_FUNCTION_EXECUTOR_TMPDIR_FOLDER}/deps/pkg456`);
+  });
+
+  it('falls back to the application id when both checksums are missing', () => {
+    expect(
+      getLocalDepsLayerPath({
+        id: 'app-id-1',
+        yarnLockChecksum: undefined,
+        packageJsonChecksum: undefined,
+      } as unknown as FlatApplication),
+    ).toBe(`${LOGIC_FUNCTION_EXECUTOR_TMPDIR_FOLDER}/deps/app-id-1`);
   });
 });

--- a/packages/twenty-server/src/engine/core-modules/logic-function/logic-function-drivers/drivers/local/utils/get-local-deps-layer-path.util.ts
+++ b/packages/twenty-server/src/engine/core-modules/logic-function/logic-function-drivers/drivers/local/utils/get-local-deps-layer-path.util.ts
@@ -6,7 +6,13 @@ import { LOGIC_FUNCTION_EXECUTOR_TMPDIR_FOLDER } from 'src/engine/core-modules/l
 export const getLocalDepsLayerPath = (
   flatApplication: FlatApplication,
 ): string => {
-  const checksum = flatApplication.yarnLockChecksum ?? 'default';
+  // A shared fallback like 'default' would make every application without
+  // a lockfile resolve to the same layer and receive whichever dependencies
+  // were built first.
+  const checksum =
+    flatApplication.yarnLockChecksum ??
+    flatApplication.packageJsonChecksum ??
+    flatApplication.id;
 
   return join(LOGIC_FUNCTION_EXECUTOR_TMPDIR_FOLDER, 'deps', checksum);
 };


### PR DESCRIPTION
## Context

Found while investigating the yarn-install OOM (#23805): `getLambdaDepsLayerName` and `getLocalDepsLayerPath` fall back to a shared `'default'` checksum when an application has no `yarnLockChecksum`.

## Problem

Every lockless application in a cluster resolves to the same layer name (`deps-<namespace>-default`). `ensureDepsLayer` returns any existing layer by name, so the first application to build publishes its node_modules for all of them — later applications silently execute against another application's dependencies. This is live: prod-eu has 1,187 active applications with a null `yarnLockChecksum` spanning 24 distinct `packageJsonChecksum`s, and shared `deps-da806c103c-default` / `deps-default` layers already published.

## Fix

Fall back to `packageJsonChecksum`, then the application id, so the layer name always reflects the actual dependency set. Self-healing: executors holding an old shared layer fail the `hasExpectedLayers` name check and rebuild onto the correct per-manifest layer on their next invocation; the orphaned shared layers become unused.

## Test

- Updated both util specs for the new fallback chain (9 tests pass).
- `npx nx lint:diff-with-main twenty-server` passes.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/23817?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

