### PR TITLE
Fix AI chat chips rendering as raw markers

### DIFF
--- a/packages/twenty-front/src/modules/ai/components/__stories__/ChatReferenceChip.stories.tsx
+++ b/packages/twenty-front/src/modules/ai/components/__stories__/ChatReferenceChip.stories.tsx
@@ -129,6 +129,22 @@ export const SurplusClosingBrackets: Story = {
   },
 };
 
+export const LegacyClosingTerminator: Story = {
+  args: {
+    text: `## [[object:partner:Partners]] object created\n\n| Relation | Links to |\n| --- | --- |\n| Company | [[object:company:Companies]] |`,
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    expect(await canvas.findByText('Partners')).toBeVisible();
+    expect((await canvas.findByText('Companies')).closest('a')).toHaveAttribute(
+      'href',
+      `/objects/${companyObjectMetadataItem.namePlural}`,
+    );
+    expect(canvasElement).not.toHaveTextContent('[[object:');
+  },
+};
+
 export const ProposedObject: Story = {
   args: {
     text: `As a Head of Partnerships, you seem to work across partner companies, key contacts, and commercial follow-ups, so I suggest creating a ${formatChatReference(

--- a/packages/twenty-front/src/modules/ai/components/__tests__/TextWithChatReferences.test.tsx
+++ b/packages/twenty-front/src/modules/ai/components/__tests__/TextWithChatReferences.test.tsx
@@ -142,6 +142,15 @@ describe('TextWithChatReferences', () => {
     );
   });
 
+  it('should chip a metadata reference closed by a bare legacy terminator', () => {
+    render(
+      <TextWithChatReferences text="Open [[object:partner:Partners]] to start" />,
+    );
+
+    expect(screen.getByTestId('object-link')).toHaveTextContent('Partners');
+    expect(screen.queryByText(/\[\[object:/)).not.toBeInTheDocument();
+  });
+
   it('should route each reference kind to its own chip', () => {
     render(
       <TextWithChatReferences text="The [[view:44444444-4444-4444-4444-444444444444:Pipeline[[/view]] view of [[object:partner:Partners[[/object]] groups [[record:person:11111111-1111-1111-1111-111111111111:Alice[[/record]] by [[field:33333333-3333-3333-3333-333333333333:Stage[[/field]]" />,

--- a/packages/twenty-front/src/modules/ai/utils/__tests__/findChatReferences.test.ts
+++ b/packages/twenty-front/src/modules/ai/utils/__tests__/findChatReferences.test.ts
@@ -178,10 +178,45 @@ describe('findChatReferences', () => {
     ).toEqual([]);
   });
 
-  it('should drop a metadata reference closed by a bare legacy terminator', () => {
+  it('should support a bare legacy terminator on a metadata reference', () => {
     expect(
       findChatReferences('Open [[object:partner:Partners]] to start'),
-    ).toEqual([]);
+    ).toEqual([
+      {
+        kind: 'object',
+        fullMatch: '[[object:partner:Partners]]',
+        index: 5,
+        objectNameSingular: 'partner',
+        displayName: 'Partners',
+      },
+    ]);
+  });
+
+  it('should find legacy object references in a markdown table row', () => {
+    const references = findChatReferences(
+      '| Owner | Many-to-one | [[object:workspaceMember:Workspace Member]] |\n| Company | Many-to-one | [[object:company:Company]] |',
+    );
+
+    expect(references.map((reference) => reference.displayName)).toEqual([
+      'Workspace Member',
+      'Company',
+    ]);
+  });
+
+  it('should find a legacy object reference in a heading', () => {
+    const references = findChatReferences(
+      '## [[object:project:Project]] object created',
+    );
+
+    expect(references).toEqual([
+      {
+        kind: 'object',
+        fullMatch: '[[object:project:Project]]',
+        index: 3,
+        objectNameSingular: 'project',
+        displayName: 'Project',
+      },
+    ]);
   });
 
   it('should not let a legacy record swallow a foreign close tag', () => {

--- a/packages/twenty-front/src/modules/ai/utils/findChatReferenceClosing.ts
+++ b/packages/twenty-front/src/modules/ai/utils/findChatReferenceClosing.ts
@@ -4,7 +4,7 @@ import { type ChatReferenceKind } from '@/ai/types/ChatReferenceKind';
 import { getChatReferenceCloseTag } from '@/ai/utils/getChatReferenceCloseTag';
 import { isDefined } from 'twenty-shared/utils';
 
-const LEGACY_RECORD_REFERENCE_CLOSE_TAG = ']]';
+const LEGACY_REFERENCE_CLOSE_TAG = ']]';
 
 export const findChatReferenceClosing = ({
   displayNameWindow,
@@ -20,17 +20,13 @@ export const findChatReferenceClosing = ({
     return { index: closeTagIndex, length: closeTag.length };
   }
 
-  if (kind !== 'record') {
-    return undefined;
-  }
-
   const foreignCloseTagMatch =
     ANY_CHAT_REFERENCE_CLOSE_TAG_REGEX.exec(displayNameWindow);
   const legacySearchSpace = isDefined(foreignCloseTagMatch)
     ? displayNameWindow.slice(0, foreignCloseTagMatch.index)
     : displayNameWindow;
   const legacyCloseIndex = legacySearchSpace.lastIndexOf(
-    LEGACY_RECORD_REFERENCE_CLOSE_TAG,
+    LEGACY_REFERENCE_CLOSE_TAG,
   );
 
   if (legacyCloseIndex === -1) {
@@ -39,6 +35,6 @@ export const findChatReferenceClosing = ({
 
   return {
     index: legacyCloseIndex,
-    length: LEGACY_RECORD_REFERENCE_CLOSE_TAG.length,
+    length: LEGACY_REFERENCE_CLOSE_TAG.length,
   };
 };

--- a/packages/twenty-server/src/engine/metadata-modules/ai/ai-chat/constants/chat-system-prompts.const.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/ai/ai-chat/constants/chat-system-prompts.const.ts
@@ -103,7 +103,7 @@ Whenever you name an object, a field, or a view in your prose, write it as a met
 
 - The displayName is what the user reads, so use the human-readable label ("Annual Recurring Revenue"), not the technical name
 - Field and view ids MUST be real UUIDs copied from a tool response - never invent one, and never reference a field or view before the tool that returns it has run
-- Always close a reference with its own tag: \`[[/object]]\`, \`[[/field]]\`, \`[[/view]]\`. A mismatched closing tag drops the chip
+- Always close a reference with its own tag: \`[[/object]]\`, \`[[/field]]\`, \`[[/view]]\`. A closing tag belonging to another kind drops the chip
 - A reference is complete as written: never wrap it in extra square brackets, and never add \`]\` or \`]]\` after its closing tag
 - Use metadata references only in paragraphs, lists, or markdown tables (\`| ... |\`); never in headings, code, links, or raw HTML`,
 };


### PR DESCRIPTION
Object, field and view chips rendered as raw `[[object:project:Project]]` text whenever the model closed a reference with a bare `]]` instead of `[[/object]]`. `findChatReferenceClosing` accepted that terminator only for `record` references, which is why record chips never showed the problem. Removed the special case so every kind resolves its closing tag the same way.

## Follow-up, not in this PR

Kept out to hold this PR to the reported bug. All three are done and verified on `r--ai-chat-chips-markdown-hardening` (`d14da23c25`).

- A display name containing a URL or email still never becomes a chip: GFM autolinks split the marker across sibling nodes, and backslash escaping cannot suppress them. Fix is to replace references with inert placeholders before markdown parsing and restore chips afterwards, which also removes the escaping path.
- A reference inside a markdown link renders a linked chip inside the outer anchor, so an anchor ends up nested in an anchor.
- A reference inside inline code renders a live chip instead of its display name, because the paragraph-level walk clones the `code` element and re-processes its children.
