### PR TITLE
Add nullable applicationUniversalIdentifier columns to ACTOR fields

### DIFF
--- a/packages/twenty-server/src/database/commands/upgrade-version-command/2-28/2-28-upgrade-version-command.module.ts
+++ b/packages/twenty-server/src/database/commands/upgrade-version-command/2-28/2-28-upgrade-version-command.module.ts
@@ -3,7 +3,7 @@ import { Module } from '@nestjs/common';
 import { WorkspaceIteratorModule } from 'src/database/commands/command-runners/workspace-iterator.module';
 import { AddEmailBlockSettingsCommandMenuItemCommand } from 'src/database/commands/upgrade-version-command/2-28/2-28-workspace-command-1785921674941-add-email-block-settings-command-menu-item.command';
 import { RepairOrphanCoreWorkflowVersionsCommand } from 'src/database/commands/upgrade-version-command/2-28/2-28-workspace-command-1785600000000-repair-orphan-core-workflow-versions.command';
-import { AddApplicationUniversalIdentifierToActorCommand } from 'src/database/commands/upgrade-version-command/2-28/2-28-workspace-command-1785915867000-add-application-universal-identifier-to-actor.command';
+import { AddApplicationUniversalIdentifierToActorCommand } from 'src/database/commands/upgrade-version-command/2-28/2-28-workspace-command-1785943810000-add-application-universal-identifier-to-actor.command';
 import { SyncDiscardDraftWorkflowAvailabilityExpressionCommand } from 'src/database/commands/upgrade-version-command/2-28/2-28-workspace-command-1785858486000-sync-discard-draft-workflow-availability-expression.command';
 import { ApplicationModule } from 'src/engine/core-modules/application/application.module';
 import { WorkspaceCacheModule } from 'src/engine/workspace-cache/workspace-cache.module';

--- a/packages/twenty-server/src/database/commands/upgrade-version-command/2-28/2-28-upgrade-version-command.module.ts
+++ b/packages/twenty-server/src/database/commands/upgrade-version-command/2-28/2-28-upgrade-version-command.module.ts
@@ -3,6 +3,7 @@ import { Module } from '@nestjs/common';
 import { WorkspaceIteratorModule } from 'src/database/commands/command-runners/workspace-iterator.module';
 import { AddEmailBlockSettingsCommandMenuItemCommand } from 'src/database/commands/upgrade-version-command/2-28/2-28-workspace-command-1785921674941-add-email-block-settings-command-menu-item.command';
 import { RepairOrphanCoreWorkflowVersionsCommand } from 'src/database/commands/upgrade-version-command/2-28/2-28-workspace-command-1785600000000-repair-orphan-core-workflow-versions.command';
+import { AddApplicationUniversalIdentifierToActorCommand } from 'src/database/commands/upgrade-version-command/2-28/2-28-workspace-command-1785915867000-add-application-universal-identifier-to-actor.command';
 import { SyncDiscardDraftWorkflowAvailabilityExpressionCommand } from 'src/database/commands/upgrade-version-command/2-28/2-28-workspace-command-1785858486000-sync-discard-draft-workflow-availability-expression.command';
 import { ApplicationModule } from 'src/engine/core-modules/application/application.module';
 import { WorkspaceCacheModule } from 'src/engine/workspace-cache/workspace-cache.module';
@@ -20,6 +21,7 @@ import { WorkspaceMigrationModule } from 'src/engine/workspace-manager/workspace
   providers: [
     AddEmailBlockSettingsCommandMenuItemCommand,
     RepairOrphanCoreWorkflowVersionsCommand,
+    AddApplicationUniversalIdentifierToActorCommand,
     SyncDiscardDraftWorkflowAvailabilityExpressionCommand,
   ],
 })

--- a/packages/twenty-server/src/database/commands/upgrade-version-command/2-28/2-28-workspace-command-1785915867000-add-application-universal-identifier-to-actor.command.ts
+++ b/packages/twenty-server/src/database/commands/upgrade-version-command/2-28/2-28-workspace-command-1785915867000-add-application-universal-identifier-to-actor.command.ts
@@ -1,0 +1,88 @@
+import { Command } from 'nest-commander';
+import { isDefined } from 'twenty-shared/utils';
+
+import { ProvisionedWorkspaceCommandRunner } from 'src/database/commands/command-runners/provisioned-workspace.command-runner';
+import { WorkspaceIteratorService } from 'src/database/commands/command-runners/workspace-iterator.service';
+import { type RunOnWorkspaceArgs } from 'src/database/commands/command-runners/workspace.command-runner';
+import { buildActorApplicationUniversalIdentifierColumnTargets } from 'src/database/commands/upgrade-version-command/2-28/utils/build-actor-application-universal-identifier-column-targets.util';
+import { buildAddActorApplicationUniversalIdentifierColumnsSql } from 'src/database/commands/upgrade-version-command/2-28/utils/build-add-actor-application-universal-identifier-columns-sql.util';
+import { RegisteredWorkspaceCommand } from 'src/engine/core-modules/upgrade/decorators/registered-workspace-command.decorator';
+import { WorkspaceCacheService } from 'src/engine/workspace-cache/services/workspace-cache.service';
+import { getWorkspaceSchemaName } from 'src/engine/workspace-datasource/utils/get-workspace-schema-name.util';
+
+@RegisteredWorkspaceCommand('2.28.0', 1785915867000)
+@Command({
+  name: 'upgrade:2-28:add-application-universal-identifier-to-actor',
+  description:
+    'Add the nullable applicationUniversalIdentifier column to ACTOR fields in existing workspaces',
+})
+export class AddApplicationUniversalIdentifierToActorCommand extends ProvisionedWorkspaceCommandRunner {
+  constructor(
+    protected readonly workspaceIteratorService: WorkspaceIteratorService,
+    private readonly workspaceCacheService: WorkspaceCacheService,
+  ) {
+    super(workspaceIteratorService);
+  }
+
+  override async runOnWorkspace({
+    workspaceId,
+    dataSource,
+    options,
+  }: RunOnWorkspaceArgs): Promise<void> {
+    if (!isDefined(dataSource)) {
+      this.logger.log(`No data source for workspace ${workspaceId}, skipping`);
+
+      return;
+    }
+
+    const { flatObjectMetadataMaps, flatFieldMetadataMaps } =
+      await this.workspaceCacheService.getOrRecompute(workspaceId, [
+        'flatObjectMetadataMaps',
+        'flatFieldMetadataMaps',
+      ]);
+    const actorApplicationUniversalIdentifierColumnTargets =
+      buildActorApplicationUniversalIdentifierColumnTargets({
+        flatObjectMetadataMaps,
+        flatFieldMetadataMaps,
+      });
+
+    if (actorApplicationUniversalIdentifierColumnTargets.length === 0) {
+      this.logger.log(
+        `No local ACTOR fields found for workspace ${workspaceId}, skipping`,
+      );
+
+      return;
+    }
+
+    const isDryRun = options.dryRun ?? false;
+
+    if (isDryRun) {
+      const actorApplicationUniversalIdentifierColumnCount =
+        actorApplicationUniversalIdentifierColumnTargets.flatMap(
+          ({ columnNames }) => columnNames,
+        ).length;
+
+      this.logger.log(
+        `[DRY RUN] Would add ${actorApplicationUniversalIdentifierColumnCount} nullable ACTOR application identity columns across ${actorApplicationUniversalIdentifierColumnTargets.length} tables for workspace ${workspaceId}`,
+      );
+
+      return;
+    }
+
+    const schemaName = getWorkspaceSchemaName(workspaceId);
+
+    // No transaction: IF NOT EXISTS keeps reruns idempotent, and per-table DDL avoids holding ACCESS EXCLUSIVE locks on the whole schema until commit
+    for (const actorApplicationUniversalIdentifierColumnTarget of actorApplicationUniversalIdentifierColumnTargets) {
+      await dataSource.query(
+        buildAddActorApplicationUniversalIdentifierColumnsSql({
+          schemaName,
+          actorApplicationUniversalIdentifierColumnTarget,
+        }),
+      );
+    }
+
+    this.logger.log(
+      `Added nullable ACTOR application identity columns across ${actorApplicationUniversalIdentifierColumnTargets.length} tables for workspace ${workspaceId}`,
+    );
+  }
+}

--- a/packages/twenty-server/src/database/commands/upgrade-version-command/2-28/2-28-workspace-command-1785943810000-add-application-universal-identifier-to-actor.command.ts
+++ b/packages/twenty-server/src/database/commands/upgrade-version-command/2-28/2-28-workspace-command-1785943810000-add-application-universal-identifier-to-actor.command.ts
@@ -10,7 +10,7 @@ import { RegisteredWorkspaceCommand } from 'src/engine/core-modules/upgrade/deco
 import { WorkspaceCacheService } from 'src/engine/workspace-cache/services/workspace-cache.service';
 import { getWorkspaceSchemaName } from 'src/engine/workspace-datasource/utils/get-workspace-schema-name.util';
 
-@RegisteredWorkspaceCommand('2.28.0', 1785915867000)
+@RegisteredWorkspaceCommand('2.28.0', 1785943810000)
 @Command({
   name: 'upgrade:2-28:add-application-universal-identifier-to-actor',
   description:

--- a/packages/twenty-server/src/database/commands/upgrade-version-command/2-28/2-28-workspace-command-1785943810000-add-application-universal-identifier-to-actor.command.ts
+++ b/packages/twenty-server/src/database/commands/upgrade-version-command/2-28/2-28-workspace-command-1785943810000-add-application-universal-identifier-to-actor.command.ts
@@ -70,15 +70,22 @@ export class AddApplicationUniversalIdentifierToActorCommand extends Provisioned
     }
 
     const schemaName = getWorkspaceSchemaName(workspaceId);
+    const queryRunner = dataSource.createQueryRunner();
 
-    // No transaction: IF NOT EXISTS keeps reruns idempotent, and per-table DDL avoids holding ACCESS EXCLUSIVE locks on the whole schema until commit
-    for (const actorApplicationUniversalIdentifierColumnTarget of actorApplicationUniversalIdentifierColumnTargets) {
-      await dataSource.query(
-        buildAddActorApplicationUniversalIdentifierColumnsSql({
-          schemaName,
-          actorApplicationUniversalIdentifierColumnTarget,
-        }),
-      );
+    try {
+      await queryRunner.connect();
+
+      // No transaction: IF NOT EXISTS keeps reruns idempotent, and per-table DDL avoids holding ACCESS EXCLUSIVE locks on the whole schema until commit
+      for (const actorApplicationUniversalIdentifierColumnTarget of actorApplicationUniversalIdentifierColumnTargets) {
+        await queryRunner.query(
+          buildAddActorApplicationUniversalIdentifierColumnsSql({
+            schemaName,
+            actorApplicationUniversalIdentifierColumnTarget,
+          }),
+        );
+      }
+    } finally {
+      await queryRunner.release();
     }
 
     this.logger.log(

--- a/packages/twenty-server/src/database/commands/upgrade-version-command/2-28/2-28-workspace-command-1785943810000-add-application-universal-identifier-to-actor.command.ts
+++ b/packages/twenty-server/src/database/commands/upgrade-version-command/2-28/2-28-workspace-command-1785943810000-add-application-universal-identifier-to-actor.command.ts
@@ -75,7 +75,6 @@ export class AddApplicationUniversalIdentifierToActorCommand extends Provisioned
     try {
       await queryRunner.connect();
 
-      // No transaction: IF NOT EXISTS keeps reruns idempotent, and per-table DDL avoids holding ACCESS EXCLUSIVE locks on the whole schema until commit
       for (const actorApplicationUniversalIdentifierColumnTarget of actorApplicationUniversalIdentifierColumnTargets) {
         await queryRunner.query(
           buildAddActorApplicationUniversalIdentifierColumnsSql({

--- a/packages/twenty-server/src/database/commands/upgrade-version-command/2-28/utils/__tests__/build-actor-application-universal-identifier-column-targets.util.spec.ts
+++ b/packages/twenty-server/src/database/commands/upgrade-version-command/2-28/utils/__tests__/build-actor-application-universal-identifier-column-targets.util.spec.ts
@@ -1,0 +1,94 @@
+import { TWENTY_STANDARD_APPLICATION_UNIVERSAL_IDENTIFIER } from 'twenty-shared/application';
+import { FieldMetadataType } from 'twenty-shared/types';
+
+import { buildActorApplicationUniversalIdentifierColumnTargets } from 'src/database/commands/upgrade-version-command/2-28/utils/build-actor-application-universal-identifier-column-targets.util';
+import { type FlatEntityMaps } from 'src/engine/metadata-modules/flat-entity/types/flat-entity-maps.type';
+import { type SyncableFlatEntity } from 'src/engine/metadata-modules/flat-entity/types/flat-entity-from.type';
+import { type FlatFieldMetadata } from 'src/engine/metadata-modules/flat-field-metadata/types/flat-field-metadata.type';
+import { type FlatObjectMetadata } from 'src/engine/metadata-modules/flat-object-metadata/types/flat-object-metadata.type';
+
+const buildFlatEntityMaps = <TFlatEntity extends SyncableFlatEntity>(
+  flatEntities: TFlatEntity[],
+): FlatEntityMaps<TFlatEntity> => ({
+  byUniversalIdentifier: Object.fromEntries(
+    flatEntities.map((flatEntity) => [
+      flatEntity.universalIdentifier,
+      flatEntity,
+    ]),
+  ),
+  universalIdentifierById: Object.fromEntries(
+    flatEntities.map((flatEntity) => [
+      flatEntity.id,
+      flatEntity.universalIdentifier,
+    ]),
+  ),
+  universalIdentifiersByApplicationId: {},
+});
+
+describe('buildActorApplicationUniversalIdentifierColumnTargets', () => {
+  it('builds one nullable UUID column target for every local ACTOR field', () => {
+    const personObject = {
+      id: 'person-id',
+      universalIdentifier: 'person-universal-identifier',
+      nameSingular: 'person',
+      applicationUniversalIdentifier:
+        TWENTY_STANDARD_APPLICATION_UNIVERSAL_IDENTIFIER,
+      isRemote: false,
+    } as FlatObjectMetadata;
+    const remoteObject = {
+      id: 'remote-id',
+      universalIdentifier: 'remote-universal-identifier',
+      nameSingular: 'remotePerson',
+      applicationUniversalIdentifier: '22222222-2222-4222-8222-222222222222',
+      isRemote: true,
+    } as FlatObjectMetadata;
+    const flatFieldMetadataItems = [
+      {
+        id: 'created-by-id',
+        universalIdentifier: 'created-by-universal-identifier',
+        name: 'createdBy',
+        type: FieldMetadataType.ACTOR,
+        objectMetadataUniversalIdentifier: personObject.universalIdentifier,
+      },
+      {
+        id: 'updated-by-id',
+        universalIdentifier: 'updated-by-universal-identifier',
+        name: 'updatedBy',
+        type: FieldMetadataType.ACTOR,
+        objectMetadataUniversalIdentifier: personObject.universalIdentifier,
+      },
+      {
+        id: 'name-id',
+        universalIdentifier: 'name-universal-identifier',
+        name: 'name',
+        type: FieldMetadataType.TEXT,
+        objectMetadataUniversalIdentifier: personObject.universalIdentifier,
+      },
+      {
+        id: 'remote-created-by-id',
+        universalIdentifier: 'remote-created-by-universal-identifier',
+        name: 'createdBy',
+        type: FieldMetadataType.ACTOR,
+        objectMetadataUniversalIdentifier: remoteObject.universalIdentifier,
+      },
+    ] as FlatFieldMetadata[];
+
+    expect(
+      buildActorApplicationUniversalIdentifierColumnTargets({
+        flatObjectMetadataMaps: buildFlatEntityMaps([
+          personObject,
+          remoteObject,
+        ]),
+        flatFieldMetadataMaps: buildFlatEntityMaps(flatFieldMetadataItems),
+      }),
+    ).toEqual([
+      {
+        tableName: 'person',
+        columnNames: [
+          'createdByApplicationUniversalIdentifier',
+          'updatedByApplicationUniversalIdentifier',
+        ],
+      },
+    ]);
+  });
+});

--- a/packages/twenty-server/src/database/commands/upgrade-version-command/2-28/utils/__tests__/build-add-actor-application-universal-identifier-columns-sql.util.spec.ts
+++ b/packages/twenty-server/src/database/commands/upgrade-version-command/2-28/utils/__tests__/build-add-actor-application-universal-identifier-columns-sql.util.spec.ts
@@ -1,0 +1,20 @@
+import { buildAddActorApplicationUniversalIdentifierColumnsSql } from 'src/database/commands/upgrade-version-command/2-28/utils/build-add-actor-application-universal-identifier-columns-sql.util';
+
+describe('buildAddActorApplicationUniversalIdentifierColumnsSql', () => {
+  it('builds idempotent DDL without a default or row backfill', () => {
+    const sql = buildAddActorApplicationUniversalIdentifierColumnsSql({
+      schemaName: 'workspace_test',
+      actorApplicationUniversalIdentifierColumnTarget: {
+        tableName: 'person',
+        columnNames: ['createdByApplicationUniversalIdentifier'],
+      },
+    });
+
+    expect(sql).toBe(
+      'ALTER TABLE "workspace_test"."person" ADD COLUMN IF NOT EXISTS "createdByApplicationUniversalIdentifier" uuid',
+    );
+    expect(sql).not.toContain('DEFAULT');
+    expect(sql).not.toContain('NOT NULL');
+    expect(sql).not.toContain('UPDATE');
+  });
+});

--- a/packages/twenty-server/src/database/commands/upgrade-version-command/2-28/utils/build-actor-application-universal-identifier-column-targets.util.ts
+++ b/packages/twenty-server/src/database/commands/upgrade-version-command/2-28/utils/build-actor-application-universal-identifier-column-targets.util.ts
@@ -1,0 +1,53 @@
+import { FieldMetadataType } from 'twenty-shared/types';
+import { isDefined } from 'twenty-shared/utils';
+
+import { type FlatEntityMaps } from 'src/engine/metadata-modules/flat-entity/types/flat-entity-maps.type';
+import { type FlatFieldMetadata } from 'src/engine/metadata-modules/flat-field-metadata/types/flat-field-metadata.type';
+import { type FlatObjectMetadata } from 'src/engine/metadata-modules/flat-object-metadata/types/flat-object-metadata.type';
+import { computeObjectTargetTable } from 'src/engine/utils/compute-object-target-table.util';
+
+export type ActorApplicationUniversalIdentifierColumnTarget = {
+  tableName: string;
+  columnNames: string[];
+};
+
+// Hardcoded pascalCase suffix so the columns can ship one release before the applicationUniversalIdentifier ACTOR composite property exists
+const ACTOR_APPLICATION_UNIVERSAL_IDENTIFIER_COLUMN_SUFFIX =
+  'ApplicationUniversalIdentifier';
+
+export const buildActorApplicationUniversalIdentifierColumnTargets = ({
+  flatObjectMetadataMaps,
+  flatFieldMetadataMaps,
+}: {
+  flatObjectMetadataMaps: FlatEntityMaps<FlatObjectMetadata>;
+  flatFieldMetadataMaps: FlatEntityMaps<FlatFieldMetadata>;
+}): ActorApplicationUniversalIdentifierColumnTarget[] => {
+  const columnNamesByTableName = new Map<string, string[]>();
+
+  for (const flatFieldMetadata of Object.values(
+    flatFieldMetadataMaps.byUniversalIdentifier,
+  ).filter(isDefined)) {
+    if (flatFieldMetadata.type !== FieldMetadataType.ACTOR) {
+      continue;
+    }
+
+    const flatObjectMetadata =
+      flatObjectMetadataMaps.byUniversalIdentifier[
+        flatFieldMetadata.objectMetadataUniversalIdentifier
+      ];
+
+    if (!isDefined(flatObjectMetadata) || flatObjectMetadata.isRemote) {
+      continue;
+    }
+
+    const tableName = computeObjectTargetTable(flatObjectMetadata);
+    const columnName = `${flatFieldMetadata.name}${ACTOR_APPLICATION_UNIVERSAL_IDENTIFIER_COLUMN_SUFFIX}`;
+    const existingColumnNames = columnNamesByTableName.get(tableName) ?? [];
+
+    columnNamesByTableName.set(tableName, [...existingColumnNames, columnName]);
+  }
+
+  return [...columnNamesByTableName.entries()].map(
+    ([tableName, columnNames]) => ({ tableName, columnNames }),
+  );
+};

--- a/packages/twenty-server/src/database/commands/upgrade-version-command/2-28/utils/build-actor-application-universal-identifier-column-targets.util.ts
+++ b/packages/twenty-server/src/database/commands/upgrade-version-command/2-28/utils/build-actor-application-universal-identifier-column-targets.util.ts
@@ -11,7 +11,6 @@ export type ActorApplicationUniversalIdentifierColumnTarget = {
   columnNames: string[];
 };
 
-// Hardcoded pascalCase suffix so the columns can ship one release before the applicationUniversalIdentifier ACTOR composite property exists
 const ACTOR_APPLICATION_UNIVERSAL_IDENTIFIER_COLUMN_SUFFIX =
   'ApplicationUniversalIdentifier';
 

--- a/packages/twenty-server/src/database/commands/upgrade-version-command/2-28/utils/build-add-actor-application-universal-identifier-columns-sql.util.ts
+++ b/packages/twenty-server/src/database/commands/upgrade-version-command/2-28/utils/build-add-actor-application-universal-identifier-columns-sql.util.ts
@@ -1,0 +1,16 @@
+import { type ActorApplicationUniversalIdentifierColumnTarget } from 'src/database/commands/upgrade-version-command/2-28/utils/build-actor-application-universal-identifier-column-targets.util';
+import { escapeIdentifier } from 'src/engine/workspace-manager/workspace-migration/utils/remove-sql-injection.util';
+
+export const buildAddActorApplicationUniversalIdentifierColumnsSql = ({
+  schemaName,
+  actorApplicationUniversalIdentifierColumnTarget,
+}: {
+  schemaName: string;
+  actorApplicationUniversalIdentifierColumnTarget: ActorApplicationUniversalIdentifierColumnTarget;
+}): string =>
+  `ALTER TABLE ${escapeIdentifier(schemaName)}.${escapeIdentifier(actorApplicationUniversalIdentifierColumnTarget.tableName)} ${actorApplicationUniversalIdentifierColumnTarget.columnNames
+    .map(
+      (columnName) =>
+        `ADD COLUMN IF NOT EXISTS ${escapeIdentifier(columnName)} uuid`,
+    )
+    .join(', ')}`;


### PR DESCRIPTION
Part 1 of 2 — the follow-up #23825 (composite property + stamping + filtering) is stacked on this PR and must deploy in a later release, after this command has run on every workspace.

Adds a nullable uuid column `<actorField>ApplicationUniversalIdentifier` to every table carrying an ACTOR field, via a 2.28 workspace upgrade command. The columns are unused for now.

Carved out so the columns exist on every workspace before any code references them: composite sub-columns are mapped from code globally, so the moment #23825 deploys, its code references these columns on reads and writes. The column suffix is hardcoded here because the composite property does not exist yet.