### PR TITLE
Support many-to-one first hops in nested relation widgets

### DIFF
--- a/packages/twenty-docs/developers/extend/apps/layout/page-layouts.mdx
+++ b/packages/twenty-docs/developers/extend/apps/layout/page-layouts.mdx
@@ -78,7 +78,7 @@ A `FIELD` widget renders one field of the record. For relation fields it can als
 
 - `fieldMetadataId` takes the universal identifier of a field on the layout's object.
 - `fieldDisplayMode` is one of `'FIELD'`, `'CARD'`, `'EDITOR'`, `'VIEW'` or `'TABLE'`. `TABLE` embeds a view listing the records of a one-to-many relation field.
-- `nestedRelationFieldMetadataId` is optional and takes the universal identifier of a one-to-many relation field on the relation target object, to list records two relation hops away (e.g. a Company page listing the opportunities of the company's people). Both hops must be one-to-many relation fields (junction relations are not supported), and it requires `fieldDisplayMode: 'TABLE'` — combining it with any other display mode is a validation error, since a nested widget always renders as an embedded view.
+- `nestedRelationFieldMetadataId` is optional and takes the universal identifier of a one-to-many relation field on the relation target object, to list records two relation hops away (e.g. a Company page listing the opportunities of the company's people, or a Person page listing the opportunities of the person's company). The first hop can be a one-to-many or a many-to-one relation field, the second must be one-to-many (junction relations are not supported), and it requires `fieldDisplayMode: 'TABLE'` — combining it with any other display mode is a validation error, since a nested widget always renders as an embedded view.
 
 ## definePageLayoutTab
 

--- a/packages/twenty-front/src/modules/object-record/utils/isPlainManyToOneRelationField.ts
+++ b/packages/twenty-front/src/modules/object-record/utils/isPlainManyToOneRelationField.ts
@@ -1,0 +1,13 @@
+import { type FieldMetadataItem } from '@/object-metadata/types/FieldMetadataItem';
+import { isManyToOneRelationField } from '@/object-metadata/utils/isManyToOneRelationField';
+import { isJunctionRelationField } from '@/object-record/record-field/ui/utils/junction/isJunctionRelationField';
+
+// Junction relation fields also carry MANY_TO_ONE metadata but render through
+// a dedicated junction path, mirroring isPlainOneToManyRelationField.
+export const isPlainManyToOneRelationField = (
+  fieldMetadataItem: FieldMetadataItem,
+): fieldMetadataItem is FieldMetadataItem & {
+  relation: NonNullable<FieldMetadataItem['relation']>;
+} =>
+  isManyToOneRelationField(fieldMetadataItem) &&
+  !isJunctionRelationField(fieldMetadataItem);

--- a/packages/twenty-front/src/modules/page-layout/widgets/field/components/FieldWidgetRelationTable.tsx
+++ b/packages/twenty-front/src/modules/page-layout/widgets/field/components/FieldWidgetRelationTable.tsx
@@ -87,8 +87,12 @@ export const FieldWidgetRelationTable = ({
     ? resolvedNestedRelation?.nestedRelationTargetObjectMetadataItem.id
     : relationObjectMetadataId;
 
-  const { targetFieldMetadataName, relationObjectMetadataNameSingular } =
-    fieldDefinition.metadata;
+  const {
+    targetFieldMetadataName,
+    relationObjectMetadataNameSingular,
+    relationType,
+    fieldName,
+  } = fieldDefinition.metadata;
 
   const nestedRelationCreateThrough = useMemo(
     () =>
@@ -97,6 +101,7 @@ export const FieldWidgetRelationTable = ({
             fieldRelationMetadata: {
               targetFieldMetadataName,
               relationObjectMetadataNameSingular,
+              relationType,
             },
             nestedRelationFieldMetadataItem:
               resolvedNestedRelation.nestedRelationFieldMetadataItem,
@@ -107,6 +112,7 @@ export const FieldWidgetRelationTable = ({
       resolvedNestedRelation,
       targetFieldMetadataName,
       relationObjectMetadataNameSingular,
+      relationType,
       recordId,
     ],
   );
@@ -116,15 +122,13 @@ export const FieldWidgetRelationTable = ({
   // filter's current record, read from the current record's join column.
   const isManyToOneNestedChain =
     isDefined(nestedRelationFieldMetadataId) &&
-    fieldRelationMetadata.relationType === RelationType.MANY_TO_ONE;
+    relationType === RelationType.MANY_TO_ONE;
 
   const intermediateRecordId = useAtomFamilySelectorValue(
     recordStoreFamilySelector,
     {
       recordId,
-      fieldName: computeRelationGqlFieldJoinColumnName({
-        name: fieldRelationMetadata.fieldName,
-      }),
+      fieldName: computeRelationGqlFieldJoinColumnName({ name: fieldName }),
     },
   );
 
@@ -141,8 +145,7 @@ export const FieldWidgetRelationTable = ({
     return isNonEmptyString(intermediateRecordId)
       ? {
           id: intermediateRecordId,
-          objectMetadataNameSingular:
-            fieldRelationMetadata.relationObjectMetadataNameSingular,
+          objectMetadataNameSingular: relationObjectMetadataNameSingular,
         }
       : undefined;
   }, [
@@ -150,7 +153,7 @@ export const FieldWidgetRelationTable = ({
     recordId,
     recordPageObjectMetadataNameSingular,
     intermediateRecordId,
-    fieldRelationMetadata.relationObjectMetadataNameSingular,
+    relationObjectMetadataNameSingular,
   ]);
 
   if (

--- a/packages/twenty-front/src/modules/page-layout/widgets/field/components/FieldWidgetRelationTable.tsx
+++ b/packages/twenty-front/src/modules/page-layout/widgets/field/components/FieldWidgetRelationTable.tsx
@@ -2,6 +2,7 @@ import { useObjectMetadataItems } from '@/object-metadata/hooks/useObjectMetadat
 import { RecordFilterValueDependenciesContext } from '@/object-record/record-filter/contexts/RecordFilterValueDependenciesContext';
 import { type FieldDefinition } from '@/object-record/record-field/ui/types/FieldDefinition';
 import { type FieldRelationMetadata } from '@/object-record/record-field/ui/types/FieldMetadata';
+import { recordStoreFamilySelector } from '@/object-record/record-store/states/selectors/recordStoreFamilySelector';
 import { RECORD_TABLE_ROW_HEIGHT } from '@/object-record/record-table/constants/RecordTableRowHeight';
 import { useIsPageLayoutInEditMode } from '@/page-layout/hooks/useIsPageLayoutInEditMode';
 import { RecordTableWidgetRendererContent } from '@/page-layout/widgets/record-table/components/RecordTableWidgetRendererContent';
@@ -10,9 +11,15 @@ import { isFieldWidget } from '@/page-layout/widgets/field/utils/isFieldWidget';
 import { resolveFieldWidgetNestedRelation } from '@/page-layout/widgets/field/utils/resolveFieldWidgetNestedRelation';
 import { useCurrentWidget } from '@/page-layout/widgets/hooks/useCurrentWidget';
 import { useLayoutRenderingContext } from '@/ui/layout/contexts/LayoutRenderingContext';
+import { useAtomFamilySelectorValue } from '@/ui/utilities/state/jotai/hooks/useAtomFamilySelectorValue';
 import { styled } from '@linaria/react';
+import { isNonEmptyString } from '@sniptt/guards';
 import { useMemo } from 'react';
-import { isDefined } from 'twenty-shared/utils';
+import {
+  computeRelationGqlFieldJoinColumnName,
+  isDefined,
+} from 'twenty-shared/utils';
+import { RelationType } from '~/generated-metadata/graphql';
 
 const FIELD_WIDGET_RELATION_TABLE_MAX_VISIBLE_RECORDS = 20;
 
@@ -85,10 +92,53 @@ export const FieldWidgetRelationTable = ({
     [resolvedNestedRelation, fieldRelationMetadata, recordId],
   );
 
+  // A many-to-one first hop points at a single intermediate record, so the
+  // terminal view is scoped directly by it: the intermediate becomes the
+  // filter's current record, read from the current record's join column.
+  const isManyToOneNestedChain =
+    isDefined(nestedRelationFieldMetadataId) &&
+    fieldRelationMetadata.relationType === RelationType.MANY_TO_ONE;
+
+  const intermediateRecordId = useAtomFamilySelectorValue(
+    recordStoreFamilySelector,
+    {
+      recordId,
+      fieldName: computeRelationGqlFieldJoinColumnName({
+        name: fieldRelationMetadata.fieldName,
+      }),
+    },
+  );
+
+  const filterCurrentRecord = useMemo(() => {
+    if (!isManyToOneNestedChain) {
+      return isDefined(recordPageObjectMetadataNameSingular)
+        ? {
+            id: recordId,
+            objectMetadataNameSingular: recordPageObjectMetadataNameSingular,
+          }
+        : undefined;
+    }
+
+    return isNonEmptyString(intermediateRecordId)
+      ? {
+          id: intermediateRecordId,
+          objectMetadataNameSingular:
+            fieldRelationMetadata.relationObjectMetadataNameSingular,
+        }
+      : undefined;
+  }, [
+    isManyToOneNestedChain,
+    recordId,
+    recordPageObjectMetadataNameSingular,
+    intermediateRecordId,
+    fieldRelationMetadata.relationObjectMetadataNameSingular,
+  ]);
+
   if (
     !isDefined(viewId) ||
     !isDefined(tableObjectMetadataId) ||
-    !isDefined(recordPageObjectMetadataNameSingular)
+    !isDefined(recordPageObjectMetadataNameSingular) ||
+    !isDefined(filterCurrentRecord)
   ) {
     return null;
   }
@@ -96,10 +146,7 @@ export const FieldWidgetRelationTable = ({
   return (
     <RecordFilterValueDependenciesContext.Provider
       value={{
-        currentRecord: {
-          id: recordId,
-          objectMetadataNameSingular: recordPageObjectMetadataNameSingular,
-        },
+        currentRecord: filterCurrentRecord,
       }}
     >
       <StyledContainer>

--- a/packages/twenty-front/src/modules/page-layout/widgets/field/utils/__tests__/getFieldWidgetNestedRelationCreateThrough.test.ts
+++ b/packages/twenty-front/src/modules/page-layout/widgets/field/utils/__tests__/getFieldWidgetNestedRelationCreateThrough.test.ts
@@ -1,5 +1,6 @@
 import { type FieldRelationMetadata } from '@/object-record/record-field/ui/types/FieldMetadata';
 import { getFieldWidgetNestedRelationCreateThrough } from '@/page-layout/widgets/field/utils/getFieldWidgetNestedRelationCreateThrough';
+import { RelationType } from '~/generated-metadata/graphql';
 import { getMockObjectMetadataItemOrThrow } from '~/testing/utils/getMockObjectMetadataItemOrThrow';
 
 const personObjectMetadataItem = getMockObjectMetadataItemOrThrow('person');
@@ -11,6 +12,7 @@ const personOpportunitiesField = personObjectMetadataItem.fields.find(
 const companyPeopleFieldRelationMetadata = {
   relationObjectMetadataNameSingular: 'person',
   targetFieldMetadataName: 'company',
+  relationType: RelationType.ONE_TO_MANY,
 } as FieldRelationMetadata;
 
 describe('getFieldWidgetNestedRelationCreateThrough', () => {
@@ -26,6 +28,21 @@ describe('getFieldWidgetNestedRelationCreateThrough', () => {
       relationRecordsFilter: { companyId: { eq: 'current-company-id' } },
       nestedRelationJoinColumnName: 'pointOfContactId',
     });
+  });
+
+  it('should return undefined for a many-to-one first hop', () => {
+    // The intermediate is unambiguous there, so the created record's join
+    // column is prefilled from the seeded direct filter instead of a picker.
+    expect(
+      getFieldWidgetNestedRelationCreateThrough({
+        fieldRelationMetadata: {
+          ...companyPeopleFieldRelationMetadata,
+          relationType: RelationType.MANY_TO_ONE,
+        },
+        nestedRelationFieldMetadataItem: personOpportunitiesField!,
+        recordId: 'current-company-id',
+      }),
+    ).toBeUndefined();
   });
 
   it('should return undefined without the relation inverse field name', () => {

--- a/packages/twenty-front/src/modules/page-layout/widgets/field/utils/__tests__/getFieldWidgetRelationTraversal.test.ts
+++ b/packages/twenty-front/src/modules/page-layout/widgets/field/utils/__tests__/getFieldWidgetRelationTraversal.test.ts
@@ -14,6 +14,14 @@ const personOpportunitiesField = personObjectMetadataItem.fields.find(
   (field) => field.name === 'pointOfContactForOpportunities',
 );
 
+const personCompanyField = personObjectMetadataItem.fields.find(
+  (field) => field.name === 'company',
+);
+
+const companyOpportunitiesField = companyObjectMetadataItem.fields.find(
+  (field) => field.name === 'opportunities',
+);
+
 describe('getFieldWidgetRelationTraversal', () => {
   it('should scope a direct widget through the relation own inverse', () => {
     const traversal = getFieldWidgetRelationTraversal({
@@ -60,6 +68,23 @@ describe('getFieldWidgetRelationTraversal', () => {
     expect(traversal.targetObjectMetadataId).not.toBe(
       personObjectMetadataItem.id,
     );
+  });
+
+  it('should scope a many-to-one first hop directly, without traversal', () => {
+    const traversal = getFieldWidgetRelationTraversal({
+      sourceFieldMetadataItem: personCompanyField,
+      nestedRelationFieldMetadataItem: companyOpportunitiesField,
+    });
+
+    expect(traversal.targetObjectMetadataId).toBe(
+      opportunityObjectMetadataItem.id,
+    );
+    expect(traversal.inverseFieldMetadataId).toBe(
+      companyOpportunitiesField?.relation?.targetFieldMetadata.id,
+    );
+    // The intermediate is the single record the current record points at, so
+    // the seeded filter is a direct one on the terminal object.
+    expect(traversal.relationTargetFieldMetadataId).toBeNull();
   });
 
   it('should return an empty traversal without a source field', () => {

--- a/packages/twenty-front/src/modules/page-layout/widgets/field/utils/getFieldWidgetNestedRelationCreateThrough.ts
+++ b/packages/twenty-front/src/modules/page-layout/widgets/field/utils/getFieldWidgetNestedRelationCreateThrough.ts
@@ -12,7 +12,9 @@ export const getFieldWidgetNestedRelationCreateThrough = ({
 }: {
   fieldRelationMetadata: Pick<
     FieldRelationMetadata,
-    'targetFieldMetadataName' | 'relationObjectMetadataNameSingular'
+    | 'targetFieldMetadataName'
+    | 'relationObjectMetadataNameSingular'
+    | 'relationType'
   >;
   nestedRelationFieldMetadataItem: FieldMetadataItem;
   recordId: string;

--- a/packages/twenty-front/src/modules/page-layout/widgets/field/utils/getFieldWidgetNestedRelationCreateThrough.ts
+++ b/packages/twenty-front/src/modules/page-layout/widgets/field/utils/getFieldWidgetNestedRelationCreateThrough.ts
@@ -3,6 +3,7 @@ import { type FieldRelationMetadata } from '@/object-record/record-field/ui/type
 import { type RecordTableWidgetNestedRelationCreateThrough } from '@/object-record/record-table-widget/contexts/RecordTableWidgetContext';
 import { isNonEmptyString } from '@sniptt/guards';
 import { computeRelationGqlFieldJoinColumnName } from 'twenty-shared/utils';
+import { RelationType } from '~/generated-metadata/graphql';
 
 export const getFieldWidgetNestedRelationCreateThrough = ({
   fieldRelationMetadata,
@@ -13,6 +14,14 @@ export const getFieldWidgetNestedRelationCreateThrough = ({
   nestedRelationFieldMetadataItem: FieldMetadataItem;
   recordId: string;
 }): RecordTableWidgetNestedRelationCreateThrough | undefined => {
+  // Only a one-to-many first hop leaves the record to create through
+  // ambiguous. A many-to-one first hop points at a single intermediate
+  // record, so the created record's join column is prefilled from the
+  // seeded direct filter instead of a picker.
+  if (fieldRelationMetadata.relationType !== RelationType.ONE_TO_MANY) {
+    return undefined;
+  }
+
   const relationInverseFieldName =
     fieldRelationMetadata.targetFieldMetadataName;
   const nestedRelationInverseFieldName =

--- a/packages/twenty-front/src/modules/page-layout/widgets/field/utils/getFieldWidgetRelationTraversal.ts
+++ b/packages/twenty-front/src/modules/page-layout/widgets/field/utils/getFieldWidgetRelationTraversal.ts
@@ -1,4 +1,5 @@
 import { type FieldMetadataItem } from '@/object-metadata/types/FieldMetadataItem';
+import { isOneToManyRelationField } from '@/object-metadata/utils/isOneToManyRelationField';
 import { isDefined } from 'twenty-shared/utils';
 
 type GetFieldWidgetRelationTraversalArgs = {
@@ -23,13 +24,23 @@ export const getFieldWidgetRelationTraversal = ({
   const lastHopFieldMetadataItem =
     nestedRelationFieldMetadataItem ?? sourceFieldMetadataItem;
 
+  // Only a one-to-many first hop needs the traversal: its intermediate
+  // records carry the join column pointing back at the current record. A
+  // many-to-one first hop points at a single intermediate record, which the
+  // widget supplies as the filter's current record, so the seeded filter
+  // stays a direct one.
+  const shouldTraverseFirstHop =
+    isDefined(nestedRelationFieldMetadataItem) &&
+    isDefined(sourceFieldMetadataItem) &&
+    isOneToManyRelationField(sourceFieldMetadataItem);
+
   return {
     targetObjectMetadataId:
       lastHopFieldMetadataItem?.relation?.targetObjectMetadata.id,
     inverseFieldMetadataId:
       lastHopFieldMetadataItem?.relation?.targetFieldMetadata.id,
-    relationTargetFieldMetadataId: isDefined(nestedRelationFieldMetadataItem)
-      ? (sourceFieldMetadataItem?.relation?.targetFieldMetadata.id ?? null)
+    relationTargetFieldMetadataId: shouldTraverseFirstHop
+      ? (sourceFieldMetadataItem.relation?.targetFieldMetadata.id ?? null)
       : null,
   };
 };

--- a/packages/twenty-front/src/modules/page-layout/widgets/field/utils/isFieldWidgetEligibleNestedParentField.ts
+++ b/packages/twenty-front/src/modules/page-layout/widgets/field/utils/isFieldWidgetEligibleNestedParentField.ts
@@ -1,0 +1,15 @@
+import { type FieldMetadataItem } from '@/object-metadata/types/FieldMetadataItem';
+import { isPlainManyToOneRelationField } from '@/object-record/utils/isPlainManyToOneRelationField';
+import { isPlainOneToManyRelationField } from '@/object-record/utils/isPlainOneToManyRelationField';
+
+// A nested chain can start from either relation direction: a one-to-many
+// first hop scopes the terminal view through a relation traversal filter,
+// while a many-to-one first hop scopes it directly by the single related
+// record the current record points at.
+export const isFieldWidgetEligibleNestedParentField = (
+  fieldMetadataItem: FieldMetadataItem,
+): fieldMetadataItem is FieldMetadataItem & {
+  relation: NonNullable<FieldMetadataItem['relation']>;
+} =>
+  isPlainOneToManyRelationField(fieldMetadataItem) ||
+  isPlainManyToOneRelationField(fieldMetadataItem);

--- a/packages/twenty-front/src/modules/page-layout/widgets/record-table/hooks/__tests__/useResolveFieldWidgetRelationTableViewIdChange.test.tsx
+++ b/packages/twenty-front/src/modules/page-layout/widgets/record-table/hooks/__tests__/useResolveFieldWidgetRelationTableViewIdChange.test.tsx
@@ -24,6 +24,14 @@ const personOpportunitiesField = personObjectMetadataItem.fields.find(
   (field) => field.name === 'pointOfContactForOpportunities',
 );
 
+const personCompanyField = personObjectMetadataItem.fields.find(
+  (field) => field.name === 'company',
+);
+
+const companyOpportunitiesField = companyObjectMetadataItem.fields.find(
+  (field) => field.name === 'opportunities',
+);
+
 const getWrapper =
   (store: ReturnType<typeof createStore>) =>
   ({ children }: { children: ReactNode }) => (
@@ -74,6 +82,44 @@ describe('useResolveFieldWidgetRelationTableViewIdChange', () => {
     expect(draft[WIDGET_ID].view.objectMetadataId).toBe(
       opportunityObjectMetadataItem.id,
     );
+  });
+
+  it('should regenerate a view for a many-to-one first hop chain', () => {
+    const { result, store } = renderResolveHook();
+
+    let change: { viewId?: string | null } | undefined;
+
+    act(() => {
+      change = result.current.resolveFieldWidgetRelationTableViewIdChange({
+        selectedField: personCompanyField,
+        selectedNestedField: companyOpportunitiesField,
+        nextDisplayMode: FieldDisplayMode.TABLE,
+        isSelectingDifferentChain: true,
+        widgetId: WIDGET_ID,
+        currentViewId: undefined,
+      });
+    });
+
+    expect(change?.viewId).toBeDefined();
+
+    const draft = store.get(
+      recordTableWidgetViewDraftComponentState.atomFamily({
+        instanceId: PAGE_LAYOUT_ID,
+      }),
+    );
+
+    expect(draft[WIDGET_ID].view.objectMetadataId).toBe(
+      opportunityObjectMetadataItem.id,
+    );
+    // The intermediate is the single record the current record points at, so
+    // the seeded filter carries no relation traversal.
+    expect(draft[WIDGET_ID].viewFilters).toEqual([
+      expect.objectContaining({
+        fieldMetadataId:
+          companyOpportunitiesField?.relation?.targetFieldMetadata.id,
+        relationTargetFieldMetadataId: null,
+      }),
+    ]);
   });
 
   it('should regenerate a missing view even when the chain is unchanged', () => {

--- a/packages/twenty-front/src/modules/page-layout/widgets/record-table/hooks/useResolveFieldWidgetRelationTableViewIdChange.ts
+++ b/packages/twenty-front/src/modules/page-layout/widgets/record-table/hooks/useResolveFieldWidgetRelationTableViewIdChange.ts
@@ -1,6 +1,7 @@
 import { type FieldMetadataItem } from '@/object-metadata/types/FieldMetadataItem';
 import { isOneToManyRelationField } from '@/object-metadata/utils/isOneToManyRelationField';
 import { getFieldWidgetRelationTraversal } from '@/page-layout/widgets/field/utils/getFieldWidgetRelationTraversal';
+import { isFieldWidgetEligibleNestedParentField } from '@/page-layout/widgets/field/utils/isFieldWidgetEligibleNestedParentField';
 import { useAddDraftViewForFieldRelationTableWidget } from '@/page-layout/widgets/record-table/hooks/useAddDraftViewForFieldRelationTableWidget';
 import { isDefined } from 'twenty-shared/utils';
 import {
@@ -49,9 +50,10 @@ export const useResolveFieldWidgetRelationTableViewIdChange = (
 
     const isValidRelationChain =
       isDefined(selectedField) &&
-      isOneToManyRelationField(selectedField) &&
-      (!isDefined(selectedNestedField) ||
-        isOneToManyRelationField(selectedNestedField));
+      (isDefined(selectedNestedField)
+        ? isFieldWidgetEligibleNestedParentField(selectedField) &&
+          isOneToManyRelationField(selectedNestedField)
+        : isOneToManyRelationField(selectedField));
 
     const shouldRegenerateRelationTableView =
       nextDisplayMode === FieldDisplayMode.TABLE &&

--- a/packages/twenty-front/src/modules/side-panel/pages/page-layout/components/dropdown-content/FieldWidgetFieldDropdownContent.tsx
+++ b/packages/twenty-front/src/modules/side-panel/pages/page-layout/components/dropdown-content/FieldWidgetFieldDropdownContent.tsx
@@ -2,7 +2,7 @@ import { useFieldMetadataItemById } from '@/object-metadata/hooks/useFieldMetada
 import { useObjectMetadataItems } from '@/object-metadata/hooks/useObjectMetadataItems';
 import { type FieldMetadataItem } from '@/object-metadata/types/FieldMetadataItem';
 import { isAdvancedRelationFieldMetadataItem } from '@/object-record/utils/isAdvancedRelationFieldMetadataItem';
-import { isPlainOneToManyRelationField } from '@/object-record/utils/isPlainOneToManyRelationField';
+import { isFieldWidgetEligibleNestedParentField } from '@/page-layout/widgets/field/utils/isFieldWidgetEligibleNestedParentField';
 import { useUpdatePageLayoutWidget } from '@/page-layout/hooks/useUpdatePageLayoutWidget';
 import { type FieldConfiguration } from '@/page-layout/types/FieldConfiguration';
 import { useResolveFieldWidgetRelationTableViewIdChange } from '@/page-layout/widgets/record-table/hooks/useResolveFieldWidgetRelationTableViewIdChange';
@@ -131,7 +131,7 @@ export const FieldWidgetFieldDropdownContent = () => {
     const candidatesByFieldId = new Map<string, FieldMetadataItem[]>();
 
     for (const fieldMetadataItem of allFieldWidgetFieldMetadataItems) {
-      if (!isPlainOneToManyRelationField(fieldMetadataItem)) {
+      if (!isFieldWidgetEligibleNestedParentField(fieldMetadataItem)) {
         continue;
       }
 

--- a/packages/twenty-server/src/engine/metadata-modules/page-layout-widget/utils/__tests__/validate-field-configuration-nested-relation.util.spec.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/page-layout-widget/utils/__tests__/validate-field-configuration-nested-relation.util.spec.ts
@@ -15,6 +15,7 @@ const OPPORTUNITY_OBJECT_ID = 'opportunity-object-id';
 const PEOPLE_FIELD_ID = 'company-people-field-id';
 const OWNED_OPPORTUNITIES_FIELD_ID = 'person-owned-opportunities-field-id';
 const PERSON_COMPANY_FIELD_ID = 'person-company-field-id';
+const COMPANY_NAME_FIELD_ID = 'company-name-field-id';
 
 const peopleField = getFlatFieldMetadataMock({
   id: PEOPLE_FIELD_ID,
@@ -52,6 +53,16 @@ const personCompanyField = getFlatFieldMetadataMock({
   relationTargetObjectMetadataId: COMPANY_OBJECT_ID,
 });
 
+const companyNameField = getFlatFieldMetadataMock({
+  id: COMPANY_NAME_FIELD_ID,
+  universalIdentifier: 'company-name-field-ui',
+  objectMetadataId: COMPANY_OBJECT_ID,
+  type: FieldMetadataType.TEXT,
+  name: 'name',
+  label: 'Name',
+  settings: null,
+});
+
 const buildFlatFieldMetadataMaps = (
   fields: FlatFieldMetadata[],
 ): FlatEntityMaps<FlatFieldMetadata> => ({
@@ -68,6 +79,7 @@ const flatFieldMetadataMaps = buildFlatFieldMetadataMaps([
   peopleField,
   ownedOpportunitiesField,
   personCompanyField,
+  companyNameField,
 ]);
 
 const buildFieldConfiguration = (
@@ -144,16 +156,29 @@ describe('validateFieldConfigurationNestedRelationOrThrow', () => {
     ).toThrow(/not found/);
   });
 
-  it('should throw when the source field is not a one-to-many relation', () => {
+  it('should pass for a valid many-to-one first hop chain', () => {
     expect(() =>
       validateFieldConfigurationNestedRelationOrThrow({
         widgetConfiguration: buildFieldConfiguration({
           fieldMetadataId: PERSON_COMPANY_FIELD_ID,
+          nestedRelationFieldMetadataId: PEOPLE_FIELD_ID,
         }),
         widgetObjectMetadataId: PERSON_OBJECT_ID,
         flatFieldMetadataMaps,
       }),
-    ).toThrow(/one-to-many/);
+    ).not.toThrow();
+  });
+
+  it('should throw when the source field is not a relation', () => {
+    expect(() =>
+      validateFieldConfigurationNestedRelationOrThrow({
+        widgetConfiguration: buildFieldConfiguration({
+          fieldMetadataId: COMPANY_NAME_FIELD_ID,
+        }),
+        widgetObjectMetadataId: COMPANY_OBJECT_ID,
+        flatFieldMetadataMaps,
+      }),
+    ).toThrow(/one-to-many or many-to-one/);
   });
 
   it('should throw when the source field belongs to another object', () => {
@@ -188,6 +213,35 @@ describe('validateFieldConfigurationNestedRelationOrThrow', () => {
         flatFieldMetadataMaps,
       }),
     ).toThrow(/one-to-many/);
+  });
+
+  it('should throw when the source field is a junction many-to-one relation', () => {
+    const junctionSourceField = getFlatFieldMetadataMock({
+      id: 'company-junction-source-field-id',
+      universalIdentifier: 'company-junction-source-field-ui',
+      objectMetadataId: COMPANY_OBJECT_ID,
+      type: FieldMetadataType.RELATION,
+      name: 'primaryAgreement',
+      label: 'Primary agreement',
+      settings: {
+        relationType: RelationType.MANY_TO_ONE,
+        junctionTargetFieldId: 'junction-target-field-id',
+      },
+      relationTargetObjectMetadataId: PERSON_OBJECT_ID,
+    });
+
+    expect(() =>
+      validateFieldConfigurationNestedRelationOrThrow({
+        widgetConfiguration: buildFieldConfiguration({
+          fieldMetadataId: junctionSourceField.id,
+        }),
+        widgetObjectMetadataId: COMPANY_OBJECT_ID,
+        flatFieldMetadataMaps: buildFlatFieldMetadataMaps([
+          junctionSourceField,
+          ownedOpportunitiesField,
+        ]),
+      }),
+    ).toThrow(/one-to-many or many-to-one/);
   });
 
   it('should throw when the nested field is a junction relation', () => {

--- a/packages/twenty-server/src/engine/metadata-modules/page-layout-widget/utils/validate-field-configuration-nested-relation.util.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/page-layout-widget/utils/validate-field-configuration-nested-relation.util.ts
@@ -43,6 +43,15 @@ const isPlainOneToManyRelationFlatFieldMetadata = (
   field.settings.relationType === RelationType.ONE_TO_MANY &&
   !isNonEmptyString(field.settings.junctionTargetFieldId);
 
+// The first hop can also be many-to-one: the widget then scopes the terminal
+// view directly by the single intermediate record the current record points
+// at, instead of traversing the relation.
+const isPlainRelationFlatFieldMetadata = (field: FlatFieldMetadata): boolean =>
+  isFlatFieldMetadataOfType(field, FieldMetadataType.RELATION) &&
+  (field.settings.relationType === RelationType.ONE_TO_MANY ||
+    field.settings.relationType === RelationType.MANY_TO_ONE) &&
+  !isNonEmptyString(field.settings.junctionTargetFieldId);
+
 export const validateFieldConfigurationNestedRelationOrThrow = ({
   widgetConfiguration,
   widgetObjectMetadataId,
@@ -99,10 +108,10 @@ export const validateFieldConfigurationNestedRelationOrThrow = ({
     );
   }
 
-  if (!isPlainOneToManyRelationFlatFieldMetadata(sourceField)) {
+  if (!isPlainRelationFlatFieldMetadata(sourceField)) {
     throw invalidNestedRelation(
-      `nestedRelationFieldMetadataId requires "${sourceField.label}" to be a one-to-many relation field.`,
-      msg`${sourceField.label} must be a one-to-many relation field.`,
+      `nestedRelationFieldMetadataId requires "${sourceField.label}" to be a one-to-many or many-to-one relation field.`,
+      msg`${sourceField.label} must be a one-to-many or many-to-one relation field.`,
     );
   }
 


### PR DESCRIPTION
## Context

Stacked on #23815. That PR supports nested chains whose first hop is one-to-many (Company → People → Opportunities). This one adds many-to-one first hops (Person → Company → Opportunities), so a record page can list records reached through the single record it points at.

## How it works

The traversal filter mechanism cannot express a many-to-one first hop: it relies on the intermediate records carrying the join column pointing back at the current record, which only exists when the first hop is one-to-many. A many-to-one first hop does not need the traversal at all. The intermediate is the single record the current record points at, so:

- The seeded view filter is a plain direct filter on the terminal object (`relationTargetFieldMetadataId: null`), the same shape a one-hop widget uses.
- `FieldWidgetRelationTable` resolves the intermediate record id from the current record&#39;s join column (e.g. `person.companyId`) and supplies the intermediate as the filter&#39;s current record. The `isCurrentRecordSelected` value then compiles to `{ companyId: { in: [intermediateRecordId] } }` with zero changes to filter compilation or the server.
- A record whose first hop is empty (person without a company) renders no table rather than an unscoped one, and re-renders when the join column changes.

Creating records is simpler than the one-to-many case: the intermediate is unambiguous, so the created record&#39;s join column prefills from the seeded filter and no picker is involved. The picker from #23815 stays scoped to one-to-many first hops. Board and calendar create buttons also work in many-to-one nested widgets for the same reason.

## Changes

- Field picker drill-in accepts plain many-to-one relations as parents (`isFieldWidgetEligibleNestedParentField`, new `isPlainManyToOneRelationField` mirroring the one-to-many predicate). The second hop still must be a plain one-to-many.
- `getFieldWidgetRelationTraversal` only emits `relationTargetFieldMetadataId` for one-to-many first hops.
- `getFieldWidgetNestedRelationCreateThrough` returns nothing for many-to-one first hops, so the table shows the plain Add New row.
- The view id change resolver validates chains with either first hop direction; direct (non-nested) table widgets still require one-to-many.
- Server validation accepts plain many-to-one source fields; junction relations stay excluded on both hops.
- Docs updated.

## Tests

- Unit: traversal (many-to-one emits no traversal), view regeneration for a many-to-one chain asserting the seeded filter has no `relationTargetFieldMetadataId`, createThrough gate, server validation (valid many-to-one chain, non-relation source, junction many-to-one source). Full front `page-layout` suites pass (1156 tests), server validator spec passes (16 cases).
- Manual, on seeded data: on Leslie Calderon&#39;s Person page, created a `Company → Opportunities` widget through the drill-in; it lists exactly the two opportunities of her company (Siemens), persists across save with the direct filter in DB, and Add New creates an opportunity with `companyId` prefilled to Siemens with no picker (DB-verified).

---
_Generated by [Claude Code](https://claude.ai/code/session_01Xp3AgGtc4kSP8PpgpKMWLQ)_

<a href="https://cubic.dev/pr/twentyhq/twenty/pull/23836?utm_source=github" rel="nofollow noreferrer noopener" target="_blank">``&lt;img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"&gt;``</a>
