### PR TITLE
Rename credits "Increase" button to "Manage"

### DIFF
--- a/packages/twenty-front/src/modules/settings/billing/components/internal/ResourceCreditPriceSelector.tsx
+++ b/packages/twenty-front/src/modules/settings/billing/components/internal/ResourceCreditPriceSelector.tsx
@@ -14,7 +14,12 @@ import { styled } from '@linaria/react';
 import { t } from '@lingui/core/macro';
 import { type ChangeEvent, useMemo, useState } from 'react';
 import { isDefined } from 'twenty-shared/utils';
-import { IconArrowUp, IconCircleX, IconCreditCard } from 'twenty-ui/icon';
+import {
+  IconAdjustments,
+  IconArrowUp,
+  IconCircleX,
+  IconCreditCard,
+} from 'twenty-ui/icon';
 import { Button } from 'twenty-ui/input';
 import { themeCssVariables } from 'twenty-ui/theme-constants';
 import {
@@ -316,7 +321,7 @@ export const ResourceCreditPriceSelector = ({
   const PrimaryActionIcon =
     shouldRedirectToUpdatePayment || shouldRedirectToManageBilling
       ? IconCreditCard
-      : IconArrowUp;
+      : IconAdjustments;
   const handlePrimaryActionClick = () => {
     if (redirectToRequiredBillingAction()) {
       return;
@@ -373,7 +378,7 @@ export const ResourceCreditPriceSelector = ({
                 ? t`Update payment`
                 : shouldRedirectToManageBilling
                   ? t`Manage billing`
-                  : t`Increase`
+                  : t`Manage`
             }
             variant="primary"
             accent="green"


### PR DESCRIPTION
The green primary button in the Credits section was labelled "Increase" with an up-arrow icon, but it opens the credit package picker, whose slider spans every available package including smaller ones. So the label promised upgrade-only while the modal supports both directions.

Renamed it to "Manage" and swapped the up arrow for `IconAdjustments` (sliders), matching the slider-based picker it opens.

The secondary shortcut buttons ("Increase to $100", "Increase to $200") are unchanged since those really do apply an upgrade directly.

---
_Generated by [Claude Code](https://claude.ai/code/session_01CmtdBmWL9eSD3ZX7tgzisZ)_

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/23840?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

