### PR TITLE
fix(workflow): prevent redundant position updates on unchanged node drag stop (#15682)

### DIFF
--- a/packages/twenty-front/src/modules/workflow/workflow-diagram/components/WorkflowDiagramCanvasEditable.tsx
+++ b/packages/twenty-front/src/modules/workflow/workflow-diagram/components/WorkflowDiagramCanvasEditable.tsx
@@ -141,6 +141,13 @@ export const WorkflowDiagramCanvasEditable = () => {
     const stepToUpdate = flow?.steps?.find((step) => step.id === node.id);
 
     if (isDefined(stepToUpdate)) {
+      if (
+        stepToUpdate.position?.x === node.position.x &&
+        stepToUpdate.position?.y === node.position.y
+      ) {
+        return;
+      }
+
       await updateStep({
         ...stepToUpdate,
         position: node.position,
@@ -152,6 +159,13 @@ export const WorkflowDiagramCanvasEditable = () => {
     const triggerToUpdate = flow?.trigger;
 
     if (isDefined(triggerToUpdate)) {
+      if (
+        triggerToUpdate.position?.x === node.position.x &&
+        triggerToUpdate.position?.y === node.position.y
+      ) {
+        return;
+      }
+
       await updateTrigger({
         ...triggerToUpdate,
         position: node.position,


### PR DESCRIPTION
Fixes #15682

### Summary
Prevent state race conditions and unnecessary API mutations when interacting rapidly with workflow builder nodes on the diagram canvas.

1. ****:
   - Added position equality checks in  for step and trigger nodes ().
   - Prevents sending redundant  or  API calls when nodes are clicked or micro-dragged without actual coordinate changes.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/23847?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

