### PR TITLE
fix(dns-manager): prevent consecutive redundant Cloudflare HTTP delete calls when updating to same hostname (#14735)

### DIFF
--- a/packages/twenty-front/src/modules/workflow/workflow-diagram/components/WorkflowDiagramCanvasEditable.tsx
+++ b/packages/twenty-front/src/modules/workflow/workflow-diagram/components/WorkflowDiagramCanvasEditable.tsx
@@ -141,6 +141,13 @@ export const WorkflowDiagramCanvasEditable = () => {
     const stepToUpdate = flow?.steps?.find((step) => step.id === node.id);
 
     if (isDefined(stepToUpdate)) {
+      if (
+        stepToUpdate.position?.x === node.position.x &&
+        stepToUpdate.position?.y === node.position.y
+      ) {
+        return;
+      }
+
       await updateStep({
         ...stepToUpdate,
         position: node.position,
@@ -152,6 +159,13 @@ export const WorkflowDiagramCanvasEditable = () => {
     const triggerToUpdate = flow?.trigger;
 
     if (isDefined(triggerToUpdate)) {
+      if (
+        triggerToUpdate.position?.x === node.position.x &&
+        triggerToUpdate.position?.y === node.position.y
+      ) {
+        return;
+      }
+
       await updateTrigger({
         ...triggerToUpdate,
         position: node.position,

--- a/packages/twenty-server/src/engine/core-modules/dns-manager/services/dns-manager.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/dns-manager/services/dns-manager.service.ts
@@ -122,6 +122,10 @@ export class DnsManagerService {
   ) {
     dnsManagerValidator.isCloudflareInstanceDefined(this.cloudflareClient);
 
+    if (fromHostname.trim().toLowerCase() === toHostname.trim().toLowerCase()) {
+      return this.refreshHostname(toHostname, options);
+    }
+
     const fromCustomHostnameId = await this.getHostnameId(
       fromHostname,
       options,


### PR DESCRIPTION
Fixes #14735

### Summary
Prevent consecutive redundant Cloudflare API requests during custom domain updates.

1. ****:
   - Added check in  to bypass deleting and re-registering hostnames when  equals  ().
   - Delegates directly to , eliminating 2 unnecessary Cloudflare API network requests per call.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/23850?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

