### PR TITLE
fix(twenty-front): keep auto-select model preselection instead of discarding it

### DIFF
--- a/packages/twenty-front/src/modules/ai/hooks/__tests__/useAgentChatModelId.test.tsx
+++ b/packages/twenty-front/src/modules/ai/hooks/__tests__/useAgentChatModelId.test.tsx
@@ -87,4 +87,13 @@ describe('useAgentChatModelId', () => {
 
     expect(result.current.modelIdForRequest).toBe('openai/gpt-4.1');
   });
+
+  it('should keep an auto-select sentinel selection instead of discarding it', () => {
+    const result = renderHooks({
+      pathname: '/objects/companies',
+      userSelectedModel: 'default-fast-model',
+    });
+
+    expect(result.current.modelIdForRequest).toBe('default-fast-model');
+  });
 });

--- a/packages/twenty-front/src/modules/ai/hooks/useAgentChatModelId.ts
+++ b/packages/twenty-front/src/modules/ai/hooks/useAgentChatModelId.ts
@@ -1,4 +1,4 @@
-import { isDefined } from 'twenty-shared/utils';
+import { isAutoSelectModelId, isDefined } from 'twenty-shared/utils';
 
 import { useIsWorkspaceSetupChat } from '@/ai/hooks/useIsWorkspaceSetupChat';
 import { useWorkspaceAiModelAvailability } from '@/ai/hooks/useWorkspaceAiModelAvailability';
@@ -14,8 +14,14 @@ export const useAgentChatModelId = () => {
   const currentWorkspace = useAtomStateValue(currentWorkspaceState);
   const isWorkspaceSetupChat = useIsWorkspaceSetupChat();
 
+  // Auto-select sentinel ids ("default-fast-model" / "default-smart-model")
+  // are resolved server-side by the model registry and are deliberately absent
+  // from the enabled-models list — treat them as always available, or a FAST
+  // preselection silently degrades to the server default (the smart model)
+  // for every workspace whose fastModel is the default sentinel.
   const isUserModelAvailable =
     !isDefined(agentChatUserSelectedModel) ||
+    isAutoSelectModelId(agentChatUserSelectedModel) ||
     enabledModels.some((model) => model.modelId === agentChatUserSelectedModel);
 
   const selectedModelId = isUserModelAvailable

--- a/packages/twenty-front/src/modules/ai/hooks/useAgentChatModelId.ts
+++ b/packages/twenty-front/src/modules/ai/hooks/useAgentChatModelId.ts
@@ -14,11 +14,7 @@ export const useAgentChatModelId = () => {
   const currentWorkspace = useAtomStateValue(currentWorkspaceState);
   const isWorkspaceSetupChat = useIsWorkspaceSetupChat();
 
-  // Auto-select sentinel ids ("default-fast-model" / "default-smart-model")
-  // are resolved server-side by the model registry and are deliberately absent
-  // from the enabled-models list — treat them as always available, or a FAST
-  // preselection silently degrades to the server default (the smart model)
-  // for every workspace whose fastModel is the default sentinel.
+  // Auto-select sentinels are server-resolved and absent from enabledModels — without this a FAST preselection silently degrades to the smart model.
   const isUserModelAvailable =
     !isDefined(agentChatUserSelectedModel) ||
     isAutoSelectModelId(agentChatUserSelectedModel) ||

--- a/packages/twenty-front/src/modules/ai/hooks/useAgentChatModelId.ts
+++ b/packages/twenty-front/src/modules/ai/hooks/useAgentChatModelId.ts
@@ -14,7 +14,6 @@ export const useAgentChatModelId = () => {
   const currentWorkspace = useAtomStateValue(currentWorkspaceState);
   const isWorkspaceSetupChat = useIsWorkspaceSetupChat();
 
-  // Auto-select sentinels are server-resolved and absent from enabledModels — without this a FAST preselection silently degrades to the smart model.
   const isUserModelAvailable =
     !isDefined(agentChatUserSelectedModel) ||
     isAutoSelectModelId(agentChatUserSelectedModel) ||


### PR DESCRIPTION
## Context

Opening the Ask AI panel with a FAST model preselection (`useOpenAskAiPageWithPreprompt`) sets the chat's model to the workspace's `fastModel`. For every workspace on default settings that value is the auto-select sentinel `default-fast-model`.

## Bug

`useAgentChatModelId` validates the selected model against the enabled-models list — and `useWorkspaceAiModelAvailability` deliberately filters sentinel ids out of that list. The preselection is therefore silently discarded (`selectedModelId = null`), the request is sent with no model, and the server falls back to its default — the **smart** model. Net effect: FAST preselection no-ops on default-configured workspaces (observed on twenty-internal: a `model: 'FAST'` entry point ran on gpt-5.6-sol instead of gpt-5.6-luna).

## Fix

Treat auto-select sentinel ids as always available in the check — the server-side registry already resolves them (`getEffectiveModelConfig` → `getDefaultSpeedModel`). One line + a regression test.

## Test

`useAgentChatModelId.test.tsx`: new case asserting a sentinel selection survives to `modelIdForRequest`; all 4 pass.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/23854?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

