### PR TITLE
fix(twenty-server): notify SSE subscribers when an update leaves their filtered view

### DIFF
--- a/packages/twenty-server/src/engine/subscriptions/object-record-event/__tests__/object-record-event-publisher.spec.ts
+++ b/packages/twenty-server/src/engine/subscriptions/object-record-event/__tests__/object-record-event-publisher.spec.ts
@@ -475,6 +475,104 @@ describe('ObjectRecordEventPublisher', () => {
       ).not.toHaveBeenCalled();
     });
 
+    it('should publish update events when only the BEFORE state matches the filter (record leaving the view)', async () => {
+      (
+        isRecordMatchingRLSRowLevelPermissionPredicate as jest.Mock
+      ).mockImplementation(
+        ({ record }: { record: { name?: string } }) =>
+          record.name === 'Open Company',
+      );
+
+      const streamDataWithFilter: EventStreamData = {
+        ...mockStreamData,
+        queries: {
+          'query-1': {
+            objectNameSingular: 'company',
+            variables: {
+              filter: { name: { eq: 'Open Company' } },
+            },
+          },
+        },
+      };
+
+      mockEventStreamService.getStreamsData.mockResolvedValue(
+        new Map([[streamChannelId, streamDataWithFilter]]) as Map<
+          string,
+          EventStreamData | undefined
+        >,
+      );
+
+      const eventBatch: WorkspaceEventBatch<MockObjectRecordEvent> = {
+        name: 'company.updated',
+        workspaceId,
+        objectMetadata: companyObjectMetadata,
+        events: [
+          createMockEvent({
+            properties: {
+              before: { id: 'record-1', name: 'Open Company' },
+              after: { id: 'record-1', name: 'Done Company' },
+            } as MockObjectRecordEvent['properties'],
+          }),
+        ],
+      };
+
+      await service.publish(eventBatch as WorkspaceEventBatch<never>);
+
+      expect(mockSubscriptionService.publishToEventStream).toHaveBeenCalled();
+      const publishCall = (
+        mockSubscriptionService.publishToEventStream as jest.Mock
+      ).mock.calls[0][0];
+
+      expect(
+        publishCall.payload.objectRecordEventsWithQueryIds[0].queryIds,
+      ).toContain('query-1');
+    });
+
+    it('should not publish update events when neither state matches the filter', async () => {
+      (
+        isRecordMatchingRLSRowLevelPermissionPredicate as jest.Mock
+      ).mockReturnValue(false);
+
+      const streamDataWithFilter: EventStreamData = {
+        ...mockStreamData,
+        queries: {
+          'query-1': {
+            objectNameSingular: 'company',
+            variables: {
+              filter: { name: { eq: 'Open Company' } },
+            },
+          },
+        },
+      };
+
+      mockEventStreamService.getStreamsData.mockResolvedValue(
+        new Map([[streamChannelId, streamDataWithFilter]]) as Map<
+          string,
+          EventStreamData | undefined
+        >,
+      );
+
+      const eventBatch: WorkspaceEventBatch<MockObjectRecordEvent> = {
+        name: 'company.updated',
+        workspaceId,
+        objectMetadata: companyObjectMetadata,
+        events: [
+          createMockEvent({
+            properties: {
+              before: { id: 'record-1', name: 'Unrelated A' },
+              after: { id: 'record-1', name: 'Unrelated B' },
+            } as MockObjectRecordEvent['properties'],
+          }),
+        ],
+      };
+
+      await service.publish(eventBatch as WorkspaceEventBatch<never>);
+
+      expect(
+        mockSubscriptionService.publishToEventStream,
+      ).not.toHaveBeenCalled();
+    });
+
     it('should filter restricted fields from events', async () => {
       const restrictedField = getFlatFieldMetadataMock({
         objectMetadataId: companyObjectMetadata.id,

--- a/packages/twenty-server/src/engine/subscriptions/object-record-event/__tests__/object-record-event-publisher.spec.ts
+++ b/packages/twenty-server/src/engine/subscriptions/object-record-event/__tests__/object-record-event-publisher.spec.ts
@@ -525,9 +525,9 @@ describe('ObjectRecordEventPublisher', () => {
         mockSubscriptionService.publishToEventStream as jest.Mock
       ).mock.calls[0][0];
 
-      expect(
-        publishCall.payload.objectRecordEventsWithQueryIds,
-      ).toHaveLength(1);
+      expect(publishCall.payload.objectRecordEventsWithQueryIds).toHaveLength(
+        1,
+      );
       expect(
         publishCall.payload.objectRecordEventsWithQueryIds[0].queryIds,
       ).toEqual(['query-1']);
@@ -549,8 +549,7 @@ describe('ObjectRecordEventPublisher', () => {
         }: {
           record: { status?: string };
           filter: RecordGqlOperationFilter;
-        }) =>
-          'status' in filter ? record.status === 'active' : true,
+        }) => ('status' in filter ? record.status === 'active' : true),
       );
 
       const eventBatch: WorkspaceEventBatch<MockObjectRecordEvent> = {
@@ -560,7 +559,11 @@ describe('ObjectRecordEventPublisher', () => {
         events: [
           createMockEvent({
             properties: {
-              before: { id: 'record-1', name: 'Test Company', status: 'active' },
+              before: {
+                id: 'record-1',
+                name: 'Test Company',
+                status: 'active',
+              },
               after: {
                 id: 'record-1',
                 name: 'Test Company',

--- a/packages/twenty-server/src/engine/subscriptions/object-record-event/__tests__/object-record-event-publisher.spec.ts
+++ b/packages/twenty-server/src/engine/subscriptions/object-record-event/__tests__/object-record-event-publisher.spec.ts
@@ -578,6 +578,61 @@ describe('ObjectRecordEventPublisher', () => {
       ).not.toHaveBeenCalled();
     });
 
+    it('should redact the before snapshot when it fails the subscriber RLS filter (record entering scope)', async () => {
+      const rlsFilter: RecordGqlOperationFilter = { status: { eq: 'active' } };
+
+      (buildRowLevelPermissionRecordFilter as jest.Mock).mockReturnValue(
+        rlsFilter,
+      );
+
+      (
+        isRecordMatchingRLSRowLevelPermissionPredicate as jest.Mock
+      ).mockImplementation(
+        ({
+          record,
+          filter,
+        }: {
+          record: { status?: string };
+          filter: RecordGqlOperationFilter;
+        }) =>
+          'status' in filter ? record.status === 'active' : true,
+      );
+
+      const eventBatch: WorkspaceEventBatch<MockObjectRecordEvent> = {
+        name: 'company.updated',
+        workspaceId,
+        objectMetadata: companyObjectMetadata,
+        events: [
+          createMockEvent({
+            properties: {
+              before: {
+                id: 'record-1',
+                name: 'Test Company',
+                status: 'archived',
+              },
+              after: { id: 'record-1', name: 'Test Company', status: 'active' },
+            } as MockObjectRecordEvent['properties'],
+          }),
+        ],
+      };
+
+      await service.publish(eventBatch as WorkspaceEventBatch<never>);
+
+      expect(
+        mockSubscriptionService.publishToEventStream,
+      ).toHaveBeenCalledTimes(1);
+      const publishCall = (
+        mockSubscriptionService.publishToEventStream as jest.Mock
+      ).mock.calls[0][0];
+      const deliveredProperties =
+        publishCall.payload.objectRecordEventsWithQueryIds[0].objectRecordEvent
+          .properties;
+
+      expect(deliveredProperties.after).toBeDefined();
+      expect(deliveredProperties.before).toBeUndefined();
+      expect(deliveredProperties.diff).toBeUndefined();
+    });
+
     it('should not publish update events when neither state matches the filter', async () => {
       (
         isRecordMatchingRLSRowLevelPermissionPredicate as jest.Mock

--- a/packages/twenty-server/src/engine/subscriptions/object-record-event/__tests__/object-record-event-publisher.spec.ts
+++ b/packages/twenty-server/src/engine/subscriptions/object-record-event/__tests__/object-record-event-publisher.spec.ts
@@ -518,14 +518,64 @@ describe('ObjectRecordEventPublisher', () => {
 
       await service.publish(eventBatch as WorkspaceEventBatch<never>);
 
-      expect(mockSubscriptionService.publishToEventStream).toHaveBeenCalled();
+      expect(
+        mockSubscriptionService.publishToEventStream,
+      ).toHaveBeenCalledTimes(1);
       const publishCall = (
         mockSubscriptionService.publishToEventStream as jest.Mock
       ).mock.calls[0][0];
 
       expect(
+        publishCall.payload.objectRecordEventsWithQueryIds,
+      ).toHaveLength(1);
+      expect(
         publishCall.payload.objectRecordEventsWithQueryIds[0].queryIds,
-      ).toContain('query-1');
+      ).toEqual(['query-1']);
+    });
+
+    it('should not publish update events when the delivered state fails the RLS filter, even if the before state matched', async () => {
+      const rlsFilter: RecordGqlOperationFilter = { status: { eq: 'active' } };
+
+      (buildRowLevelPermissionRecordFilter as jest.Mock).mockReturnValue(
+        rlsFilter,
+      );
+
+      (
+        isRecordMatchingRLSRowLevelPermissionPredicate as jest.Mock
+      ).mockImplementation(
+        ({
+          record,
+          filter,
+        }: {
+          record: { status?: string };
+          filter: RecordGqlOperationFilter;
+        }) =>
+          'status' in filter ? record.status === 'active' : true,
+      );
+
+      const eventBatch: WorkspaceEventBatch<MockObjectRecordEvent> = {
+        name: 'company.updated',
+        workspaceId,
+        objectMetadata: companyObjectMetadata,
+        events: [
+          createMockEvent({
+            properties: {
+              before: { id: 'record-1', name: 'Test Company', status: 'active' },
+              after: {
+                id: 'record-1',
+                name: 'Test Company',
+                status: 'archived',
+              },
+            } as MockObjectRecordEvent['properties'],
+          }),
+        ],
+      };
+
+      await service.publish(eventBatch as WorkspaceEventBatch<never>);
+
+      expect(
+        mockSubscriptionService.publishToEventStream,
+      ).not.toHaveBeenCalled();
     });
 
     it('should not publish update events when neither state matches the filter', async () => {
@@ -1013,7 +1063,7 @@ describe('ObjectRecordEventPublisher', () => {
       });
     });
 
-    it('should combine query filter with RLS filter', async () => {
+    it('should check the RLS filter and the query filter separately', async () => {
       const rlsFilter: RecordGqlOperationFilter = { status: { eq: 'active' } };
 
       (buildRowLevelPermissionRecordFilter as jest.Mock).mockReturnValue(
@@ -1066,12 +1116,18 @@ describe('ObjectRecordEventPublisher', () => {
             name: 'Test Company',
             status: 'active',
           }),
-          filter: expect.objectContaining({
-            and: expect.arrayContaining([
-              { name: { eq: 'Test Company' } },
-              { status: { eq: 'active' } },
-            ]),
+          filter: { status: { eq: 'active' } },
+        }),
+      );
+      expect(
+        isRecordMatchingRLSRowLevelPermissionPredicate,
+      ).toHaveBeenCalledWith(
+        expect.objectContaining({
+          record: expect.objectContaining({
+            name: 'Test Company',
+            status: 'active',
           }),
+          filter: { name: { eq: 'Test Company' } },
         }),
       );
     });

--- a/packages/twenty-server/src/engine/subscriptions/object-record-event/__tests__/object-record-event-publisher.spec.ts
+++ b/packages/twenty-server/src/engine/subscriptions/object-record-event/__tests__/object-record-event-publisher.spec.ts
@@ -578,61 +578,6 @@ describe('ObjectRecordEventPublisher', () => {
       ).not.toHaveBeenCalled();
     });
 
-    it('should redact the before snapshot when it fails the subscriber RLS filter (record entering scope)', async () => {
-      const rlsFilter: RecordGqlOperationFilter = { status: { eq: 'active' } };
-
-      (buildRowLevelPermissionRecordFilter as jest.Mock).mockReturnValue(
-        rlsFilter,
-      );
-
-      (
-        isRecordMatchingRLSRowLevelPermissionPredicate as jest.Mock
-      ).mockImplementation(
-        ({
-          record,
-          filter,
-        }: {
-          record: { status?: string };
-          filter: RecordGqlOperationFilter;
-        }) =>
-          'status' in filter ? record.status === 'active' : true,
-      );
-
-      const eventBatch: WorkspaceEventBatch<MockObjectRecordEvent> = {
-        name: 'company.updated',
-        workspaceId,
-        objectMetadata: companyObjectMetadata,
-        events: [
-          createMockEvent({
-            properties: {
-              before: {
-                id: 'record-1',
-                name: 'Test Company',
-                status: 'archived',
-              },
-              after: { id: 'record-1', name: 'Test Company', status: 'active' },
-            } as MockObjectRecordEvent['properties'],
-          }),
-        ],
-      };
-
-      await service.publish(eventBatch as WorkspaceEventBatch<never>);
-
-      expect(
-        mockSubscriptionService.publishToEventStream,
-      ).toHaveBeenCalledTimes(1);
-      const publishCall = (
-        mockSubscriptionService.publishToEventStream as jest.Mock
-      ).mock.calls[0][0];
-      const deliveredProperties =
-        publishCall.payload.objectRecordEventsWithQueryIds[0].objectRecordEvent
-          .properties;
-
-      expect(deliveredProperties.after).toBeDefined();
-      expect(deliveredProperties.before).toBeUndefined();
-      expect(deliveredProperties.diff).toBeUndefined();
-    });
-
     it('should not publish update events when neither state matches the filter', async () => {
       (
         isRecordMatchingRLSRowLevelPermissionPredicate as jest.Mock

--- a/packages/twenty-server/src/engine/subscriptions/object-record-event/object-record-event-publisher.ts
+++ b/packages/twenty-server/src/engine/subscriptions/object-record-event/object-record-event-publisher.ts
@@ -12,7 +12,6 @@ import {
   type RestrictedFieldsPermissions,
 } from 'twenty-shared/types';
 import {
-  combineFilters,
   isDefined,
   isNonEmptyArray,
   isRecordGqlOperationSignature,
@@ -547,41 +546,53 @@ export class ObjectRecordEventPublisher {
       before?: object;
     };
 
-    // For updates, both states matter: an after-state match means the record
-    // is (still or newly) in the subscribed view, a before-state match means
-    // it may have just LEFT it — subscribers must be notified either way, or
-    // a record updated out of a filtered view stays on screen forever.
-    const candidateRecords =
-      event.action === DatabaseEventAction.UPDATED
-        ? [properties?.after, properties?.before].filter(isDefined)
-        : [properties?.after ?? properties?.before].filter(isDefined);
+    const deliveredRecord = properties?.after ?? properties?.before;
 
-    if (candidateRecords.length === 0) {
+    if (!isDefined(deliveredRecord)) {
       return false;
-    }
-
-    const queryFilter = operationSignature.variables?.filter ?? {};
-
-    const filtersToApply: RecordGqlOperationFilter[] = [queryFilter];
-
-    if (subscriberRLSFilter && Object.keys(subscriberRLSFilter).length > 0) {
-      filtersToApply.push(subscriberRLSFilter);
-    }
-
-    const combinedFilter = combineFilters(filtersToApply);
-
-    if (Object.keys(combinedFilter).length === 0) {
-      return true;
     }
 
     const shouldIgnoreSoftDeleteDefaultFilter =
       event.action === DatabaseEventAction.DELETED ||
       event.action === DatabaseEventAction.RESTORED;
 
+    // Row-level permission is evaluated ONLY against the delivered snapshot:
+    // a before-state match must never authorize sending an after snapshot the
+    // subscriber has lost access to.
+    if (
+      isDefined(subscriberRLSFilter) &&
+      Object.keys(subscriberRLSFilter).length > 0 &&
+      !isRecordMatchingRLSRowLevelPermissionPredicate({
+        record: deliveredRecord,
+        filter: subscriberRLSFilter,
+        flatObjectMetadata: objectMetadata,
+        flatFieldMetadataMaps,
+        shouldIgnoreSoftDeleteDefaultFilter,
+      })
+    ) {
+      return false;
+    }
+
+    const queryFilter = operationSignature.variables?.filter ?? {};
+
+    if (Object.keys(queryFilter).length === 0) {
+      return true;
+    }
+
+    // View membership may match on either snapshot of an update: an
+    // after-match means the record is (still or newly) in the subscribed
+    // view, a before-match means it may have just LEFT it — subscribers must
+    // be notified either way, or a record updated out of a filtered view
+    // stays on screen forever.
+    const candidateRecords =
+      event.action === DatabaseEventAction.UPDATED
+        ? [properties?.after, properties?.before].filter(isDefined)
+        : [deliveredRecord];
+
     return candidateRecords.some((record) =>
       isRecordMatchingRLSRowLevelPermissionPredicate({
         record,
-        filter: combinedFilter,
+        filter: queryFilter,
         flatObjectMetadata: objectMetadata,
         flatFieldMetadataMaps,
         shouldIgnoreSoftDeleteDefaultFilter,

--- a/packages/twenty-server/src/engine/subscriptions/object-record-event/object-record-event-publisher.ts
+++ b/packages/twenty-server/src/engine/subscriptions/object-record-event/object-record-event-publisher.ts
@@ -556,7 +556,6 @@ export class ObjectRecordEventPublisher {
       event.action === DatabaseEventAction.DELETED ||
       event.action === DatabaseEventAction.RESTORED;
 
-    // RLS is checked on the delivered snapshot only — a before-state match must never authorize an after snapshot.
     if (
       isDefined(subscriberRLSFilter) &&
       Object.keys(subscriberRLSFilter).length > 0 &&
@@ -577,7 +576,6 @@ export class ObjectRecordEventPublisher {
       return true;
     }
 
-    // Membership matches either snapshot of an update, so records leaving a filtered view still notify.
     const candidateRecords =
       event.action === DatabaseEventAction.UPDATED
         ? [properties?.after, properties?.before].filter(isDefined)

--- a/packages/twenty-server/src/engine/subscriptions/object-record-event/object-record-event-publisher.ts
+++ b/packages/twenty-server/src/engine/subscriptions/object-record-event/object-record-event-publisher.ts
@@ -228,12 +228,7 @@ export class ObjectRecordEventPublisher {
 
       matchedEvents.push({
         queryIds: matchedQueryIds,
-        objectRecordEvent: this.redactRLSUnauthorizedBeforeSnapshot(
-          filteredEvent,
-          subscriberRLSFilter,
-          workspaceEventBatch.objectMetadata,
-          permissionsContext.flatFieldMetadataMaps,
-        ),
+        objectRecordEvent: filteredEvent,
       });
     }
 
@@ -502,48 +497,6 @@ export class ObjectRecordEventPublisher {
     return {
       ...event,
       properties: filteredProperties,
-    } as ObjectRecordSubscriptionEvent;
-  }
-
-  // Strips before/diff when the before snapshot fails subscriber RLS — a record entering scope must not expose prior values.
-  private redactRLSUnauthorizedBeforeSnapshot(
-    event: ObjectRecordSubscriptionEvent,
-    subscriberRLSFilter: RecordGqlOperationFilter | null,
-    objectMetadata: FlatObjectMetadata,
-    flatFieldMetadataMaps: FlatEntityMaps<FlatFieldMetadata>,
-  ): ObjectRecordSubscriptionEvent {
-    if (
-      event.action !== DatabaseEventAction.UPDATED ||
-      !isDefined(subscriberRLSFilter) ||
-      Object.keys(subscriberRLSFilter).length === 0
-    ) {
-      return event;
-    }
-
-    const properties = event.properties as {
-      before?: object;
-      diff?: object;
-    };
-
-    if (
-      !isDefined(properties?.before) ||
-      isRecordMatchingRLSRowLevelPermissionPredicate({
-        record: properties.before,
-        filter: subscriberRLSFilter,
-        flatObjectMetadata: objectMetadata,
-        flatFieldMetadataMaps,
-        shouldIgnoreSoftDeleteDefaultFilter: false,
-      })
-    ) {
-      return event;
-    }
-
-    const { before: _before, diff: _diff, ...redactedProperties } =
-      event.properties as Record<string, unknown>;
-
-    return {
-      ...event,
-      properties: redactedProperties,
     } as ObjectRecordSubscriptionEvent;
   }
 

--- a/packages/twenty-server/src/engine/subscriptions/object-record-event/object-record-event-publisher.ts
+++ b/packages/twenty-server/src/engine/subscriptions/object-record-event/object-record-event-publisher.ts
@@ -505,10 +505,7 @@ export class ObjectRecordEventPublisher {
     } as ObjectRecordSubscriptionEvent;
   }
 
-  // The delivered payload carries both snapshots of an update, while the RLS
-  // gate authorizes the after snapshot. A record entering the subscriber's
-  // row-level scope must not expose the before values they had no access to —
-  // strip before/diff when the before snapshot fails the subscriber's RLS.
+  // Strips before/diff when the before snapshot fails subscriber RLS — a record entering scope must not expose prior values.
   private redactRLSUnauthorizedBeforeSnapshot(
     event: ObjectRecordSubscriptionEvent,
     subscriberRLSFilter: RecordGqlOperationFilter | null,
@@ -606,9 +603,7 @@ export class ObjectRecordEventPublisher {
       event.action === DatabaseEventAction.DELETED ||
       event.action === DatabaseEventAction.RESTORED;
 
-    // Row-level permission is evaluated ONLY against the delivered snapshot:
-    // a before-state match must never authorize sending an after snapshot the
-    // subscriber has lost access to.
+    // RLS is checked on the delivered snapshot only — a before-state match must never authorize an after snapshot.
     if (
       isDefined(subscriberRLSFilter) &&
       Object.keys(subscriberRLSFilter).length > 0 &&
@@ -629,11 +624,7 @@ export class ObjectRecordEventPublisher {
       return true;
     }
 
-    // View membership may match on either snapshot of an update: an
-    // after-match means the record is (still or newly) in the subscribed
-    // view, a before-match means it may have just LEFT it — subscribers must
-    // be notified either way, or a record updated out of a filtered view
-    // stays on screen forever.
+    // Membership matches either snapshot of an update, so records leaving a filtered view still notify.
     const candidateRecords =
       event.action === DatabaseEventAction.UPDATED
         ? [properties?.after, properties?.before].filter(isDefined)

--- a/packages/twenty-server/src/engine/subscriptions/object-record-event/object-record-event-publisher.ts
+++ b/packages/twenty-server/src/engine/subscriptions/object-record-event/object-record-event-publisher.ts
@@ -228,7 +228,12 @@ export class ObjectRecordEventPublisher {
 
       matchedEvents.push({
         queryIds: matchedQueryIds,
-        objectRecordEvent: filteredEvent,
+        objectRecordEvent: this.redactRLSUnauthorizedBeforeSnapshot(
+          filteredEvent,
+          subscriberRLSFilter,
+          workspaceEventBatch.objectMetadata,
+          permissionsContext.flatFieldMetadataMaps,
+        ),
       });
     }
 
@@ -497,6 +502,51 @@ export class ObjectRecordEventPublisher {
     return {
       ...event,
       properties: filteredProperties,
+    } as ObjectRecordSubscriptionEvent;
+  }
+
+  // The delivered payload carries both snapshots of an update, while the RLS
+  // gate authorizes the after snapshot. A record entering the subscriber's
+  // row-level scope must not expose the before values they had no access to —
+  // strip before/diff when the before snapshot fails the subscriber's RLS.
+  private redactRLSUnauthorizedBeforeSnapshot(
+    event: ObjectRecordSubscriptionEvent,
+    subscriberRLSFilter: RecordGqlOperationFilter | null,
+    objectMetadata: FlatObjectMetadata,
+    flatFieldMetadataMaps: FlatEntityMaps<FlatFieldMetadata>,
+  ): ObjectRecordSubscriptionEvent {
+    if (
+      event.action !== DatabaseEventAction.UPDATED ||
+      !isDefined(subscriberRLSFilter) ||
+      Object.keys(subscriberRLSFilter).length === 0
+    ) {
+      return event;
+    }
+
+    const properties = event.properties as {
+      before?: object;
+      diff?: object;
+    };
+
+    if (
+      !isDefined(properties?.before) ||
+      isRecordMatchingRLSRowLevelPermissionPredicate({
+        record: properties.before,
+        filter: subscriberRLSFilter,
+        flatObjectMetadata: objectMetadata,
+        flatFieldMetadataMaps,
+        shouldIgnoreSoftDeleteDefaultFilter: false,
+      })
+    ) {
+      return event;
+    }
+
+    const { before: _before, diff: _diff, ...redactedProperties } =
+      event.properties as Record<string, unknown>;
+
+    return {
+      ...event,
+      properties: redactedProperties,
     } as ObjectRecordSubscriptionEvent;
   }
 

--- a/packages/twenty-server/src/engine/subscriptions/object-record-event/object-record-event-publisher.ts
+++ b/packages/twenty-server/src/engine/subscriptions/object-record-event/object-record-event-publisher.ts
@@ -547,9 +547,16 @@ export class ObjectRecordEventPublisher {
       before?: object;
     };
 
-    const record = properties?.after ?? properties?.before;
+    // For updates, both states matter: an after-state match means the record
+    // is (still or newly) in the subscribed view, a before-state match means
+    // it may have just LEFT it — subscribers must be notified either way, or
+    // a record updated out of a filtered view stays on screen forever.
+    const candidateRecords =
+      event.action === DatabaseEventAction.UPDATED
+        ? [properties?.after, properties?.before].filter(isDefined)
+        : [properties?.after ?? properties?.before].filter(isDefined);
 
-    if (!isDefined(record)) {
+    if (candidateRecords.length === 0) {
       return false;
     }
 
@@ -571,13 +578,15 @@ export class ObjectRecordEventPublisher {
       event.action === DatabaseEventAction.DELETED ||
       event.action === DatabaseEventAction.RESTORED;
 
-    return isRecordMatchingRLSRowLevelPermissionPredicate({
-      record,
-      filter: combinedFilter,
-      flatObjectMetadata: objectMetadata,
-      flatFieldMetadataMaps,
-      shouldIgnoreSoftDeleteDefaultFilter,
-    });
+    return candidateRecords.some((record) =>
+      isRecordMatchingRLSRowLevelPermissionPredicate({
+        record,
+        filter: combinedFilter,
+        flatObjectMetadata: objectMetadata,
+        flatFieldMetadataMaps,
+        shouldIgnoreSoftDeleteDefaultFilter,
+      }),
+    );
   }
 
   private async fetchPermissionsContext(


### PR DESCRIPTION
## Context

Record tables subscribe to SSE with their query signature (object + filter) and the server pushes only matching DB events. `isQueryMatchingObjectRecordEvent` evaluated `after ?? before` — for UPDATED events that is always `after`, so an update moving a record **out** of a filtered view never matched: no event, and the open table keeps the stale row until a manual reload.

Symptom on twenty-internal: a Sales Action Item marked Done by an AI-chat tool (or any API/workflow write) stays visible in the `status = OPEN` view. Records *entering* a view appear live; records *leaving* never disappear. UI edits mask the bug via the local Apollo cache.

## Fix

For UPDATED events, view membership now matches on either snapshot (a before-only match = the record just left the view). Row-level authorization is unchanged: still evaluated against the delivered snapshot, so a before-state match cannot authorize a payload the subscriber lost RLS access to.

A pre-existing, unrelated payload leak spotted during review (before values delivered when a record enters RLS scope) is fixed separately in the stacked #23870.

## Test plan

- Unit: leave-view update publishes (fails on the old matcher — verified), neither-state-matches does not, RLS-failing delivered state does not even when before matched. 36/36 on the spec, full server suite green.
- End-to-end on a local stack: companies table filtered `Name contains 'Open'`, `updateCompany` renamed a row out of the filter via the API → row disappeared from the open table within seconds, no reload.