### PR TITLE
fix: preserve currency precision when opening field editor

### DIFF
--- a/packages/twenty-front/src/modules/ui/field/input/components/CurrencyInput.tsx
+++ b/packages/twenty-front/src/modules/ui/field/input/components/CurrencyInput.tsx
@@ -11,6 +11,7 @@ import { IMaskInput } from 'react-imask';
 import { type IconComponent } from 'twenty-ui/icon';
 import { ThemeContext, themeCssVariables } from 'twenty-ui/theme-constants';
 import { getSeparatorsForNumberFormat } from '~/utils/format/getSeparatorsForNumberFormat';
+import { getSafeScaleForCurrencyInput } from '~/utils/format/getSafeScaleForCurrencyInput';
 
 export const StyledIMaskInput = styled.div`
   display: contents;
@@ -124,6 +125,11 @@ export const CurrencyInput = ({
 
   const Icon: IconComponent = currency?.Icon;
 
+  const safeScale = getSafeScaleForCurrencyInput({
+    value,
+    decimals,
+  });
+
   return (
     <StyledContainer ref={wrapperRef}>
       <CurrencyPickerDropdownButton
@@ -140,7 +146,7 @@ export const CurrencyInput = ({
           mask={Number}
           thousandsSeparator={thousandsSeparator}
           radix={radix}
-          scale={decimals}
+          scale={safeScale}
           onAccept={(value: string) => handleChange(value)}
           inputRef={wrapperRef}
           autoComplete="off"

--- a/packages/twenty-front/src/utils/format/__tests__/getSafeScaleForCurrencyInput.test.ts
+++ b/packages/twenty-front/src/utils/format/__tests__/getSafeScaleForCurrencyInput.test.ts
@@ -1,0 +1,48 @@
+import { getSafeScaleForCurrencyInput } from '~/utils/format/getSafeScaleForCurrencyInput';
+
+describe('getSafeScaleForCurrencyInput', () => {
+  it('returns the existing decimal precision when it is greater than the configured decimals', () => {
+    expect(
+      getSafeScaleForCurrencyInput({
+        value: '458.64',
+        decimals: 0,
+      }),
+    ).toBe(2);
+  });
+
+  it('returns 0 for whole numbers', () => {
+    expect(
+      getSafeScaleForCurrencyInput({
+        value: '458',
+        decimals: 0,
+      }),
+    ).toBe(0);
+  });
+
+  it('returns the configured decimals when greater than the existing precision', () => {
+    expect(
+      getSafeScaleForCurrencyInput({
+        value: '458.64',
+        decimals: 4,
+      }),
+    ).toBe(4);
+  });
+
+  it('returns the existing precision for one decimal place', () => {
+    expect(
+      getSafeScaleForCurrencyInput({
+        value: '458.6',
+        decimals: 0,
+      }),
+    ).toBe(1);
+  });
+
+  it('returns configured decimals for an empty value', () => {
+    expect(
+      getSafeScaleForCurrencyInput({
+        value: '',
+        decimals: 2,
+      }),
+    ).toBe(2);
+  });
+});

--- a/packages/twenty-front/src/utils/format/getSafeScaleForCurrencyInput.ts
+++ b/packages/twenty-front/src/utils/format/getSafeScaleForCurrencyInput.ts
@@ -1,0 +1,10 @@
+type SafeScaleProps = {
+  value: string;
+  decimals?: number;
+};
+export const getSafeScaleForCurrencyInput = ({value,decimals}:SafeScaleProps):number => {
+    const decimalPart = value.split(".")[1];
+    const decimalCount = decimalPart?.length ?? 0
+
+    return Math.max(decimalCount , decimals ?? 0)
+}

--- a/packages/twenty-front/src/utils/format/getSafeScaleForCurrencyInput.ts
+++ b/packages/twenty-front/src/utils/format/getSafeScaleForCurrencyInput.ts
@@ -2,9 +2,12 @@ type SafeScaleProps = {
   value: string;
   decimals?: number;
 };
-export const getSafeScaleForCurrencyInput = ({value,decimals}:SafeScaleProps):number => {
-    const decimalPart = value.split(".")[1];
-    const decimalCount = decimalPart?.length ?? 0
+export const getSafeScaleForCurrencyInput = ({
+  value,
+  decimals,
+}: SafeScaleProps): number => {
+  const decimalPart = value.split('.')[1];
+  const decimalCount = decimalPart?.length ?? 0;
 
-    return Math.max(decimalCount , decimals ?? 0)
-}
+  return Math.max(decimalCount, decimals ?? 0);
+};


### PR DESCRIPTION
## Summary

Fixes #23828

Prevent currency values from losing precision when opening the currency field editor when the stored value contains more decimal places than the field's configured decimal setting.

Instead of always using the configured field decimals as the IMask `scale`, the editor now computes a safe scale using the maximum of:

- the configured field decimals
- the decimal precision already present in the draft value

This preserves the existing precision while editing and prevents values from being truncated or misinterpreted during IMask initialization.

## Verification

Reproduced the issue locally using:

- `amountMicros = 458640000`
- Field "Number of decimals" set to `0`

Verified both affected number formats:

- ✅ `1,234.56` — opening and blurring the field no longer truncates `458.64` to `458`.
- ✅ `1.234,56` — opening and blurring the field no longer corrupts `458.64` into `45864`.

The stored `amountMicros` value remains unchanged after opening and closing the editor without making any edits.

## Remaining work

- [ ✅ ] Add unit tests for `getSafeScaleForCurrencyInput`
- [ ] Add regression tests covering the IMask initialization path

## Question

Would you like me to also add an integration/regression test covering the IMask initialization path, or is the current unit test coverage sufficient?