### PR TITLE
Strip template elements from the HTML block preview

### DIFF
--- a/packages/twenty-front/src/modules/advanced-text-editor/extensions/blocks/HtmlNodeView.tsx
+++ b/packages/twenty-front/src/modules/advanced-text-editor/extensions/blocks/HtmlNodeView.tsx
@@ -11,6 +11,11 @@ const StyledPreview = styled.div`
   outline: 1px dashed transparent;
   outline-offset: 2px;
 
+  // Inline styles survive sanitization so the preview matches the sent email,
+  // which leaves the block free to position content over the editor chrome.
+  // Paint containment keeps that rendering inside the block's own box.
+  contain: paint;
+
   &:hover {
     outline-color: ${themeCssVariables.border.color.medium};
   }

--- a/packages/twenty-front/src/modules/advanced-text-editor/extensions/blocks/HtmlNodeView.tsx
+++ b/packages/twenty-front/src/modules/advanced-text-editor/extensions/blocks/HtmlNodeView.tsx
@@ -11,8 +11,6 @@ const StyledPreview = styled.div`
   outline: 1px dashed transparent;
   outline-offset: 2px;
 
-  contain: paint;
-
   &:hover {
     outline-color: ${themeCssVariables.border.color.medium};
   }

--- a/packages/twenty-front/src/modules/advanced-text-editor/extensions/blocks/HtmlNodeView.tsx
+++ b/packages/twenty-front/src/modules/advanced-text-editor/extensions/blocks/HtmlNodeView.tsx
@@ -11,9 +11,6 @@ const StyledPreview = styled.div`
   outline: 1px dashed transparent;
   outline-offset: 2px;
 
-  // Inline styles survive sanitization so the preview matches the sent email,
-  // which leaves the block free to position content over the editor chrome.
-  // Paint containment keeps that rendering inside the block's own box.
   contain: paint;
 
   &:hover {

--- a/packages/twenty-front/src/modules/advanced-text-editor/utils/__tests__/sanitizeHtmlPreview.test.ts
+++ b/packages/twenty-front/src/modules/advanced-text-editor/utils/__tests__/sanitizeHtmlPreview.test.ts
@@ -55,7 +55,9 @@ describe('sanitizeHtmlPreview', () => {
 
   it('should remove templates instead of leaving their handlers unreachable', () => {
     expect(
-      sanitizeHtmlPreview('<template><img src=x onerror="alert(1)"></template>'),
+      sanitizeHtmlPreview(
+        '<template><img src=x onerror="alert(1)"></template>',
+      ),
     ).toBe('');
     expect(
       sanitizeHtmlPreview(

--- a/packages/twenty-front/src/modules/advanced-text-editor/utils/__tests__/sanitizeHtmlPreview.test.ts
+++ b/packages/twenty-front/src/modules/advanced-text-editor/utils/__tests__/sanitizeHtmlPreview.test.ts
@@ -53,6 +53,17 @@ describe('sanitizeHtmlPreview', () => {
     ).toContain('data:image/png');
   });
 
+  it('should remove templates instead of leaving their handlers unreachable', () => {
+    expect(
+      sanitizeHtmlPreview('<template><img src=x onerror="alert(1)"></template>'),
+    ).toBe('');
+    expect(
+      sanitizeHtmlPreview(
+        '<div><template><img src=x onerror="alert(1)"></template></div>',
+      ),
+    ).toBe('<div></div>');
+  });
+
   it('should strip srcdoc and formaction attributes', () => {
     expect(
       sanitizeHtmlPreview('<div srcdoc="<script>x</script>">a</div>'),

--- a/packages/twenty-front/src/modules/advanced-text-editor/utils/sanitizeHtmlPreview.ts
+++ b/packages/twenty-front/src/modules/advanced-text-editor/utils/sanitizeHtmlPreview.ts
@@ -1,5 +1,9 @@
+// template is blocked rather than traversed: its children live in a separate
+// content fragment that querySelectorAll never reaches, so handlers inside it
+// would survive stripping. The outbound email sanitizer drops it too, so the
+// preview keeps matching what is actually sent.
 const BLOCKED_ELEMENT_SELECTOR =
-  'script, iframe, frame, object, embed, link, meta, base, style, svg, math';
+  'script, iframe, frame, object, embed, link, meta, base, style, svg, math, template';
 
 const URL_ATTRIBUTE_NAMES = ['href', 'src', 'xlink:href', 'action'];
 

--- a/packages/twenty-front/src/modules/advanced-text-editor/utils/sanitizeHtmlPreview.ts
+++ b/packages/twenty-front/src/modules/advanced-text-editor/utils/sanitizeHtmlPreview.ts
@@ -1,7 +1,3 @@
-// template is blocked rather than traversed: its children live in a separate
-// content fragment that querySelectorAll never reaches, so handlers inside it
-// would survive stripping. The outbound email sanitizer drops it too, so the
-// preview keeps matching what is actually sent.
 const BLOCKED_ELEMENT_SELECTOR =
   'script, iframe, frame, object, embed, link, meta, base, style, svg, math, template';
 


### PR DESCRIPTION
Follow-up to a code scanner alert on `HtmlNodeView`. The alert itself is not a live vulnerability, but auditing the hand-rolled sanitizer behind it turned up one gap worth closing.

## What I checked

`sanitizeHtmlPreview` is a blocklist sanitizer feeding `dangerouslySetInnerHTML` in the editor, so I ran ~30 payloads through the real implementation in headless Chromium, inserting the sanitized output into a live document. A deliberately unsanitized control payload fired, so the harness was actually detecting execution.

Nothing executed. The parser-differential classes it already survives: `noscript`, `noembed`, `noframes`, `xmp`, `listing`, `title` and `textarea` raw-text handling; `svg`/`math`/`mglyph`/`foreignObject` namespace confusion; comment breakouts; table foster parenting; `<body onload>`; `<iframe srcdoc>`; `data:text/html`; and `javascript:` with entity and control-character obfuscation.

## The gap

`document.body.querySelectorAll('*')` does not descend into a `<template>`'s content, which lives in a separate document fragment. So this:

```html
<template>``&lt;img src=x onerror="alert(1)"&gt;``</template>
```

came back out of the sanitizer with its handler intact.

It does not execute as currently used — template content is inert when assigned through `innerHTML`, and I confirmed that. But a live event handler sitting inside a string the sanitizer just declared clean is a footgun for anything that later clones, re-parses or forwards it.

The outbound email sanitizer already drops template content, so blocking the element here also stops the preview from showing something the sent email would not contain.

## Scope

One word in the blocklist plus tests. Inline styles are deliberately untouched, since dropping them would make the preview diverge from the rendered email.

An earlier revision also added `contain: paint` to the preview, to stop a block from painting over the editor chrome. That was dropped after testing showed it clips box-shadows bleeding past the block edge and negative-margin full-bleed layouts, both normal in email design. Details in the review thread. The overlay it guarded against needs an authenticated member who can already edit the template, which does not justify constraining newsletter design.

## Testing

Re-ran the full payload corpus with the new blocklist. The template payload's handler is gone, every other result is byte-identical, and the control still fires. The two new unit tests were verified to pass under jsdom, the environment jest actually uses.