### PR TITLE
Pin the sanitization contract behind the raw HTML email block

### DIFF
--- a/packages/twenty-emails/src/utils/email-renderer/nodes/html.tsx
+++ b/packages/twenty-emails/src/utils/email-renderer/nodes/html.tsx
@@ -1,6 +1,12 @@
 import { type JSONContent } from '@tiptap/core';
 import { type ReactNode } from 'react';
 
+// The raw HTML block is passed through unescaped on purpose: authors use it for
+// table markup and client hacks that no node type covers. Nothing sanitizes it
+// here, so the rendered markup is only safe because every send path funnels
+// through compileOutboundEmailContent, which runs the whole document through
+// DOMPurify. A caller rendering this package's output without that step would
+// ship author-controlled markup straight to recipients.
 export const html = (node: JSONContent): ReactNode => {
   const html = node.attrs?.html;
 

--- a/packages/twenty-server/src/engine/core-modules/email/utils/__tests__/compile-outbound-email-content.util.spec.ts
+++ b/packages/twenty-server/src/engine/core-modules/email/utils/__tests__/compile-outbound-email-content.util.spec.ts
@@ -188,6 +188,46 @@ describe('compileOutboundEmailContent', () => {
     expect(html).toContain('<table role="presentation">');
   });
 
+  it('should neutralize raw HTML blocks that hide markup from a tag walker', async () => {
+    const html = await compileDocument({
+      type: 'doc',
+      content: [
+        {
+          type: 'html',
+          attrs: {
+            html: [
+              '<template><img src=x onerror="alert(1)"></template>',
+              '<noscript><p title="</noscript><img src=x onerror="alert(1)">">',
+              '<svg><style><a title="</style><img src=x onerror="alert(1)">">',
+            ].join(''),
+          },
+        },
+      ],
+    });
+
+    expect(html).not.toContain('onerror');
+    expect(html).not.toContain('alert(1)');
+  });
+
+  it('should drop raw HTML blocks that redirect or rebase the message', async () => {
+    const html = await compileDocument({
+      type: 'doc',
+      content: [
+        {
+          type: 'html',
+          attrs: {
+            html: '<meta http-equiv="refresh" content="0;url=https://evil.test"><base href="https://evil.test/">',
+          },
+        },
+      ],
+    });
+
+    // The meta element survives as an inert shell: the hook drops every
+    // http-equiv other than content-type, so nothing acts on the stale content.
+    expect(html).not.toContain('http-equiv="refresh"');
+    expect(html).not.toContain('<base');
+  });
+
   it('should wrap linked images in an anchor', async () => {
     const html = await compileDocument({
       type: 'doc',


### PR DESCRIPTION
Third of three code scanner alerts. This one is a false positive, so there is no behaviour change here: the PR records why it is safe and tests the property that makes it so.

## Why the alert is a false positive

`nodes/html.tsx` renders the author's raw HTML unescaped:

```tsx
return <div dangerouslySetInnerHTML={{ __html: html }} />;
```

That is intentional. The block exists so authors can write table markup and client hacks no node type covers. The rendered markup never reaches a recipient unsanitized:

- `reactMarkupFromJSON` has exactly two non-test callers, both going through `compileOutboundEmailContent`, which pipes the rendered document through DOMPurify before sending. The AI email tool and campaign sends both land there.
- Nothing in `twenty-front` imports `twenty-emails`; the only `dangerouslySetInnerHTML` in the front app is the editor preview, which has its own sanitizer.
- No server route renders campaign HTML back to a browser. The emailing endpoints named "preview" are audience preview and the unsubscribe page, neither of which touches body HTML.

There is already a test asserting a raw block's `<script>` and `onclick` are stripped end to end.

## What this PR adds

The safety lives entirely in a distant call, nothing at the render site says so, and `reactMarkupFromJSON` is exported from the package root, so a future consumer can render author markup without the sanitizer and get no warning. This records the invariant where the pass-through happens, and extends the pipeline tests with payloads that specifically hide markup from a naive tag walker rather than from a browser:

- template content, which `querySelectorAll` cannot reach
- the `noscript` and `svg`/`style` parser differentials
- `meta http-equiv=refresh` and `base`, which retarget a message instead of scripting it

## Note on the meta case

Worth knowing for anyone reading the sanitizer: in whole-document mode DOMPurify keeps the `<meta>` element and its `content` attribute, because `meta` is in `ADD_TAGS` for full documents. The `uponSanitizeAttribute` hook strips every `http-equiv` other than `content-type`, so what survives is an inert shell with a stale `content` value and nothing to act on it. The test asserts the refresh directive is gone rather than the string, and a comment explains why.

I verified every assertion against the real sanitizer with the real whole-document config before committing. Two assertions I had drafted from expectation turned out to be wrong (the template shell survives, and a broad `on[a-z]+=` regex matches the word `content=` in the boilerplate), which is why they are written the way they are.

---
_Generated by [Claude Code](https://claude.ai/code/session_018sRaaxTucSdufjk6txdQE9)_

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/23867?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

