### PR TITLE
fix(twenty-server): redact the before snapshot when it fails subscriber RLS

### DIFF
--- a/packages/twenty-server/src/engine/subscriptions/object-record-event/__tests__/object-record-event-publisher.spec.ts
+++ b/packages/twenty-server/src/engine/subscriptions/object-record-event/__tests__/object-record-event-publisher.spec.ts
@@ -578,6 +578,61 @@ describe('ObjectRecordEventPublisher', () => {
       ).not.toHaveBeenCalled();
     });
 
+    it('should redact the before snapshot when it fails the subscriber RLS filter (record entering scope)', async () => {
+      const rlsFilter: RecordGqlOperationFilter = { status: { eq: 'active' } };
+
+      (buildRowLevelPermissionRecordFilter as jest.Mock).mockReturnValue(
+        rlsFilter,
+      );
+
+      (
+        isRecordMatchingRLSRowLevelPermissionPredicate as jest.Mock
+      ).mockImplementation(
+        ({
+          record,
+          filter,
+        }: {
+          record: { status?: string };
+          filter: RecordGqlOperationFilter;
+        }) =>
+          'status' in filter ? record.status === 'active' : true,
+      );
+
+      const eventBatch: WorkspaceEventBatch<MockObjectRecordEvent> = {
+        name: 'company.updated',
+        workspaceId,
+        objectMetadata: companyObjectMetadata,
+        events: [
+          createMockEvent({
+            properties: {
+              before: {
+                id: 'record-1',
+                name: 'Test Company',
+                status: 'archived',
+              },
+              after: { id: 'record-1', name: 'Test Company', status: 'active' },
+            } as MockObjectRecordEvent['properties'],
+          }),
+        ],
+      };
+
+      await service.publish(eventBatch as WorkspaceEventBatch<never>);
+
+      expect(
+        mockSubscriptionService.publishToEventStream,
+      ).toHaveBeenCalledTimes(1);
+      const publishCall = (
+        mockSubscriptionService.publishToEventStream as jest.Mock
+      ).mock.calls[0][0];
+      const deliveredProperties =
+        publishCall.payload.objectRecordEventsWithQueryIds[0].objectRecordEvent
+          .properties;
+
+      expect(deliveredProperties.after).toBeDefined();
+      expect(deliveredProperties.before).toBeUndefined();
+      expect(deliveredProperties.diff).toBeUndefined();
+    });
+
     it('should not publish update events when neither state matches the filter', async () => {
       (
         isRecordMatchingRLSRowLevelPermissionPredicate as jest.Mock

--- a/packages/twenty-server/src/engine/subscriptions/object-record-event/object-record-event-publisher.ts
+++ b/packages/twenty-server/src/engine/subscriptions/object-record-event/object-record-event-publisher.ts
@@ -228,7 +228,12 @@ export class ObjectRecordEventPublisher {
 
       matchedEvents.push({
         queryIds: matchedQueryIds,
-        objectRecordEvent: filteredEvent,
+        objectRecordEvent: this.redactRLSUnauthorizedBeforeSnapshot(
+          filteredEvent,
+          subscriberRLSFilter,
+          workspaceEventBatch.objectMetadata,
+          permissionsContext.flatFieldMetadataMaps,
+        ),
       });
     }
 
@@ -497,6 +502,48 @@ export class ObjectRecordEventPublisher {
     return {
       ...event,
       properties: filteredProperties,
+    } as ObjectRecordSubscriptionEvent;
+  }
+
+  // Strips before/diff when the before snapshot fails subscriber RLS — a record entering scope must not expose prior values.
+  private redactRLSUnauthorizedBeforeSnapshot(
+    event: ObjectRecordSubscriptionEvent,
+    subscriberRLSFilter: RecordGqlOperationFilter | null,
+    objectMetadata: FlatObjectMetadata,
+    flatFieldMetadataMaps: FlatEntityMaps<FlatFieldMetadata>,
+  ): ObjectRecordSubscriptionEvent {
+    if (
+      event.action !== DatabaseEventAction.UPDATED ||
+      !isDefined(subscriberRLSFilter) ||
+      Object.keys(subscriberRLSFilter).length === 0
+    ) {
+      return event;
+    }
+
+    const properties = event.properties as {
+      before?: object;
+      diff?: object;
+    };
+
+    if (
+      !isDefined(properties?.before) ||
+      isRecordMatchingRLSRowLevelPermissionPredicate({
+        record: properties.before,
+        filter: subscriberRLSFilter,
+        flatObjectMetadata: objectMetadata,
+        flatFieldMetadataMaps,
+        shouldIgnoreSoftDeleteDefaultFilter: false,
+      })
+    ) {
+      return event;
+    }
+
+    const { before: _before, diff: _diff, ...redactedProperties } =
+      event.properties as Record<string, unknown>;
+
+    return {
+      ...event,
+      properties: redactedProperties,
     } as ObjectRecordSubscriptionEvent;
   }
 

--- a/packages/twenty-server/src/engine/subscriptions/object-record-event/object-record-event-publisher.ts
+++ b/packages/twenty-server/src/engine/subscriptions/object-record-event/object-record-event-publisher.ts
@@ -505,7 +505,6 @@ export class ObjectRecordEventPublisher {
     } as ObjectRecordSubscriptionEvent;
   }
 
-  // Strips before/diff when the before snapshot fails subscriber RLS — a record entering scope must not expose prior values.
   private redactRLSUnauthorizedBeforeSnapshot(
     event: ObjectRecordSubscriptionEvent,
     subscriberRLSFilter: RecordGqlOperationFilter | null,


### PR DESCRIPTION
## Bug (pre-existing)

Surfaced by cubic's review of #23858, but **predates it**: an UPDATED event's delivered payload carries both snapshots while row-level authorization covers the after state only. A record *entering* the subscriber's RLS scope therefore exposes before values they never had access to — this was equally true on the old after-only matcher.

## Fix

Strip `before`/`diff` from the delivered event when the before snapshot fails the subscriber's RLS filter; the authorized after snapshot is delivered alone. Redaction test asserts after present, before/diff absent.

## Stacking

Based on #23858 (kept minimal there on purpose); GitHub retargets this to `main` automatically when #23858 merges.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/23870?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

