### PR TITLE
fix(front): send bulk emails to Bcc instead of To

### DIFF
--- a/packages/twenty-front/src/modules/activities/emails/hooks/useEmailComposerState.ts
+++ b/packages/twenty-front/src/modules/activities/emails/hooks/useEmailComposerState.ts
@@ -13,6 +13,7 @@ type UseEmailComposerStateArgs = {
   connectedAccountId: string;
   draftPrefill?: EmailDraftPrefill | null;
   defaultTo?: string;
+  defaultBcc?: string;
   defaultSubject?: string;
   defaultInReplyTo?: string;
   onSent?: (messageThreadId: string | null) => void;
@@ -27,13 +28,14 @@ export const useEmailComposerState = ({
   connectedAccountId: initialConnectedAccountId,
   draftPrefill,
   defaultTo = '',
+  defaultBcc = '',
   defaultSubject = '',
   defaultInReplyTo,
   onSent,
 }: UseEmailComposerStateArgs) => {
   const initialTo = draftPrefill?.to ?? defaultTo;
   const initialCc = draftPrefill?.cc ?? '';
-  const initialBcc = draftPrefill?.bcc ?? '';
+  const initialBcc = draftPrefill?.bcc ?? defaultBcc;
   const initialSubject = draftPrefill?.subject ?? defaultSubject;
   const initialBody = draftPrefill?.body ?? '';
 

--- a/packages/twenty-front/src/modules/command-menu-item/engine-command/global/components/ComposeEmailCommand.tsx
+++ b/packages/twenty-front/src/modules/command-menu-item/engine-command/global/components/ComposeEmailCommand.tsx
@@ -11,8 +11,11 @@ import { isDefined } from 'twenty-shared/utils';
 import { useNavigateSettings } from '~/hooks/useNavigateSettings';
 
 export const ComposeEmailCommand = () => {
-  const { connectedAccountId, loading: accountLoading } =
-    useFirstConnectedAccount();
+  const {
+    connectedAccountId,
+    connectedAccountHandle,
+    loading: accountLoading,
+  } = useFirstConnectedAccount();
   const { openComposeEmailInSidePanel } = useOpenComposeEmailInSidePanel();
   const navigateSettings = useNavigateSettings();
 
@@ -35,7 +38,8 @@ export const ComposeEmailCommand = () => {
       objectNameSingular: CoreObjectNameSingular.Person,
       filter: graphqlFilter ?? undefined,
       recordGqlFields: { id: true, emails: { primaryEmail: true } },
-      limit: MAX_EMAIL_RECIPIENTS,
+      // Reserve one recipient slot for the sender's own address in To.
+      limit: MAX_EMAIL_RECIPIENTS - 1,
       skip: !isBulkPerson,
     });
 
@@ -49,12 +53,21 @@ export const ComposeEmailCommand = () => {
       recordId: singleSelectedRecordId,
     });
 
+  const bulkRecipientEmails = bulkPersonRecords
+    .map(getPrimaryEmailFromRecord)
+    .filter(isDefined);
+
+  // Bulk sends go out as Bcc so recipients don't see each other's addresses;
+  // To falls back to the sender so the message still has a visible recipient.
+  // Leave To empty when no bulk recipient resolved so Send stays disabled,
+  // instead of silently emailing only the sender.
   const defaultTo = isBulkPerson
-    ? bulkPersonRecords
-        .map(getPrimaryEmailFromRecord)
-        .filter(isDefined)
-        .join(', ')
+    ? bulkRecipientEmails.length > 0
+      ? (connectedAccountHandle ?? '')
+      : ''
     : singleDefaultTo;
+
+  const defaultBcc = isBulkPerson ? bulkRecipientEmails.join(', ') : undefined;
 
   const handleExecute = () => {
     if (!isDefined(connectedAccountId)) {
@@ -66,6 +79,7 @@ export const ComposeEmailCommand = () => {
     openComposeEmailInSidePanel({
       connectedAccountId,
       defaultTo,
+      defaultBcc,
       contextRecord:
         isDefined(objectNameSingular) && isDefined(singleSelectedRecordId)
           ? {

--- a/packages/twenty-front/src/modules/side-panel/hooks/useOpenComposeEmailInSidePanel.ts
+++ b/packages/twenty-front/src/modules/side-panel/hooks/useOpenComposeEmailInSidePanel.ts
@@ -9,6 +9,7 @@ import { type EmailComposerContextRecord } from '@/activities/emails/recipients/
 import { useSidePanelMenu } from '@/side-panel/hooks/useSidePanelMenu';
 import { composeEmailConnectedAccountIdComponentState } from '@/side-panel/pages/compose-email/states/composeEmailConnectedAccountIdComponentState';
 import { composeEmailContextRecordComponentState } from '@/side-panel/pages/compose-email/states/composeEmailContextRecordComponentState';
+import { composeEmailDefaultBccComponentState } from '@/side-panel/pages/compose-email/states/composeEmailDefaultBccComponentState';
 import { composeEmailDefaultInReplyToComponentState } from '@/side-panel/pages/compose-email/states/composeEmailDefaultInReplyToComponentState';
 import { composeEmailDefaultSubjectComponentState } from '@/side-panel/pages/compose-email/states/composeEmailDefaultSubjectComponentState';
 import { composeEmailDefaultToComponentState } from '@/side-panel/pages/compose-email/states/composeEmailDefaultToComponentState';
@@ -18,6 +19,7 @@ type OpenComposeEmailParams = {
   threadId?: string;
   connectedAccountId: string;
   defaultTo?: string;
+  defaultBcc?: string;
   defaultSubject?: string;
   defaultInReplyTo?: string;
   contextRecord?: EmailComposerContextRecord;
@@ -47,6 +49,13 @@ export const useOpenComposeEmailInSidePanel = () => {
           instanceId: pageId,
         }),
         params.defaultTo ?? '',
+      );
+
+      store.set(
+        composeEmailDefaultBccComponentState.atomFamily({
+          instanceId: pageId,
+        }),
+        params.defaultBcc ?? '',
       );
 
       store.set(

--- a/packages/twenty-front/src/modules/side-panel/pages/compose-email/components/SidePanelComposeEmailPage.tsx
+++ b/packages/twenty-front/src/modules/side-panel/pages/compose-email/components/SidePanelComposeEmailPage.tsx
@@ -6,6 +6,7 @@ import { SIDE_PANEL_FOCUS_ID } from '@/side-panel/constants/SidePanelFocusId';
 import { useSidePanelHistory } from '@/side-panel/hooks/useSidePanelHistory';
 import { composeEmailConnectedAccountIdComponentState } from '@/side-panel/pages/compose-email/states/composeEmailConnectedAccountIdComponentState';
 import { composeEmailContextRecordComponentState } from '@/side-panel/pages/compose-email/states/composeEmailContextRecordComponentState';
+import { composeEmailDefaultBccComponentState } from '@/side-panel/pages/compose-email/states/composeEmailDefaultBccComponentState';
 import { composeEmailDefaultInReplyToComponentState } from '@/side-panel/pages/compose-email/states/composeEmailDefaultInReplyToComponentState';
 import { composeEmailDefaultSubjectComponentState } from '@/side-panel/pages/compose-email/states/composeEmailDefaultSubjectComponentState';
 import { composeEmailDefaultToComponentState } from '@/side-panel/pages/compose-email/states/composeEmailDefaultToComponentState';
@@ -38,6 +39,9 @@ export const SidePanelComposeEmailPage = () => {
   const composeEmailDefaultTo = useAtomComponentStateValue(
     composeEmailDefaultToComponentState,
   );
+  const composeEmailDefaultBcc = useAtomComponentStateValue(
+    composeEmailDefaultBccComponentState,
+  );
   const composeEmailDefaultSubject = useAtomComponentStateValue(
     composeEmailDefaultSubjectComponentState,
   );
@@ -53,6 +57,7 @@ export const SidePanelComposeEmailPage = () => {
   const composerState = useEmailComposerState({
     connectedAccountId: composeEmailConnectedAccountId ?? '',
     defaultTo: composeEmailDefaultTo ?? '',
+    defaultBcc: composeEmailDefaultBcc ?? '',
     defaultSubject: composeEmailDefaultSubject ?? '',
     defaultInReplyTo: composeEmailDefaultInReplyTo ?? undefined,
     onSent: goBackFromSidePanel,

--- a/packages/twenty-front/src/modules/side-panel/pages/compose-email/states/composeEmailDefaultBccComponentState.ts
+++ b/packages/twenty-front/src/modules/side-panel/pages/compose-email/states/composeEmailDefaultBccComponentState.ts
@@ -1,0 +1,9 @@
+import { SidePanelPageComponentInstanceContext } from '@/side-panel/states/contexts/SidePanelPageComponentInstanceContext';
+import { createAtomComponentState } from '@/ui/utilities/state/jotai/utils/createAtomComponentState';
+
+export const composeEmailDefaultBccComponentState =
+  createAtomComponentState<string>({
+    key: 'side-panel/compose-email-default-bcc',
+    defaultValue: '',
+    componentInstanceContext: SidePanelPageComponentInstanceContext,
+  });


### PR DESCRIPTION
## Problem

Selecting multiple People in a view and using **Send Email** puts every selected person's primary email address in the **To** field. Every recipient can then see the email addresses of everyone else the message was sent to.

This is a privacy/data-protection issue rather than a UI preference: sending to N contacts currently exposes the full contact list to all N of them.

Root cause: `ComposeEmailCommand.tsx` builds the bulk default recipient string and passes it straight into `defaultTo`, with no `bcc` involved anywhere in that path.

## Fix

The backend already fully supports `bcc` end-to-end (`SendEmailInput.bcc`, mapped through in `SendEmailService`), and the composer UI already has a Cc/Bcc section that opens automatically once a non-empty `bcc` value is supplied (`useEmailComposerState`'s `showCcBcc` initial state). The gap was only in the default-value plumbing for `bcc`, so this PR is front-end only, 5 files:

1. `useEmailComposerState.ts` — accepts a new `defaultBcc?: string`, threaded into `initialBcc` the same way `defaultTo` already feeds `initialTo`.
2. `composeEmailDefaultBccComponentState.ts` (new) — mirrors the existing `composeEmailDefaultToComponentState.ts` atom.
3. `useOpenComposeEmailInSidePanel.ts` — accepts and stores `defaultBcc`, same pattern as `defaultTo`.
4. `SidePanelComposeEmailPage.tsx` — reads the new atom and passes it into `useEmailComposerState`.
5. `ComposeEmailCommand.tsx` — for bulk Person selections, the resolved recipient emails now go into `defaultBcc` instead of `defaultTo`.

The single-recipient compose path is untouched.

### To field for bulk sends

The composer disables Send while `To` is empty (`canSend = to.length > 0 && ...`), so bulk sends can't just leave To blank. To now falls back to the sending account's own address, so the message keeps a visible recipient. Two follow-on details handled:

- If none of the selected records resolve a primary email, `To` is left empty (instead of defaulting to the sender) so Send stays correctly disabled rather than silently emailing only yourself.
- The bulk record query limit is reduced from `MAX_EMAIL_RECIPIENTS` to `MAX_EMAIL_RECIPIENTS - 1` to leave room for the sender's own address in `To`, so a maximum-size selection doesn't get pushed 1 over the combined recipient limit.

### Known limitation

The sender placeholder in `To` is captured once when the composer opens (same "initial value" pattern the hook already uses for `defaultSubject`/`defaultInReplyTo`). If a user has multiple connected accounts and switches the **From** account after opening a bulk compose, `To` keeps showing the original account instead of following the switch. Reactively syncing it would mean overwriting whatever the user may have already typed into `To`, which felt like the wrong tradeoff to make silently — flagging it here in case maintainers want it handled differently.

## Testing

- `npx nx lint:diff-with-main twenty-front` — clean.
- `npx nx typecheck twenty-front` — clean.
- Manually traced the recipient-count guard (`recipientCount = to.length + cc.length + bcc.length`) and the zero-recipient / max-recipient edge cases above.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/23875?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

