### PR TITLE
feat(server): export V8 GC pause and heap metrics

### DIFF
--- a/packages/twenty-server/src/engine/core-modules/metrics/gc-metrics.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/metrics/gc-metrics.service.ts
@@ -9,7 +9,6 @@ import { isDefined } from 'twenty-shared/utils';
 import { MetricsService } from 'src/engine/core-modules/metrics/metrics.service';
 
 const MILLISECONDS_PER_SECOND = 1_000;
-// Scavenges land under a millisecond; mark-compact over a multi-GB heap runs into seconds.
 const GC_DURATION_BUCKETS_SECONDS = [
   0.0005, 0.001, 0.0025, 0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5,
 ];
@@ -36,9 +35,6 @@ const gcKindOf = (detail: unknown): string => {
   return GC_KIND_BY_CONSTANT.get(detail.kind) ?? 'unknown';
 };
 
-// Attributes event loop stalls to garbage collection: a `major` pause is stop-the-world, so its
-// duration lands directly on request latency. Paired with the heap gauges, this is what tells us
-// whether a cache-size reduction actually bought p99.
 @Injectable()
 export class GcMetricsService implements OnModuleInit, OnModuleDestroy {
   private readonly pauseHistogram: Histogram;
@@ -110,7 +106,6 @@ export class GcMetricsService implements OnModuleInit, OnModuleDestroy {
     }
   }
 
-  // The four gauges share one snapshot per scrape instead of each calling into V8.
   private getHeapStatisticsSnapshot(): ReturnType<typeof getHeapStatistics> {
     const now = Date.now();
 

--- a/packages/twenty-server/src/engine/core-modules/metrics/gc-metrics.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/metrics/gc-metrics.service.ts
@@ -23,6 +23,19 @@ const GC_KIND_BY_CONSTANT = new Map<number, string>([
   [constants.NODE_PERFORMANCE_GC_WEAKCB, 'weakcb'],
 ]);
 
+const gcKindOf = (detail: unknown): string => {
+  if (
+    typeof detail !== 'object' ||
+    detail === null ||
+    !('kind' in detail) ||
+    typeof detail.kind !== 'number'
+  ) {
+    return 'unknown';
+  }
+
+  return GC_KIND_BY_CONSTANT.get(detail.kind) ?? 'unknown';
+};
+
 // Attributes event loop stalls to garbage collection: a `major` pause is stop-the-world, so its
 // duration lands directly on request latency. Paired with the heap gauges, this is what tells us
 // whether a cache-size reduction actually bought p99.
@@ -46,13 +59,8 @@ export class GcMetricsService implements OnModuleInit, OnModuleDestroy {
   onModuleInit(): void {
     this.observer = new PerformanceObserver((list) => {
       for (const entry of list.getEntries()) {
-        const kind =
-          GC_KIND_BY_CONSTANT.get(
-            (entry.detail as { kind?: number } | undefined)?.kind ?? -1,
-          ) ?? 'unknown';
-
         this.pauseHistogram.record(entry.duration / MILLISECONDS_PER_SECOND, {
-          kind,
+          kind: gcKindOf(entry.detail),
         });
       }
     });

--- a/packages/twenty-server/src/engine/core-modules/metrics/gc-metrics.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/metrics/gc-metrics.service.ts
@@ -1,0 +1,98 @@
+import { Injectable, OnModuleDestroy, OnModuleInit } from '@nestjs/common';
+
+import { type Histogram } from '@opentelemetry/api';
+import { constants, PerformanceObserver } from 'perf_hooks';
+import { getHeapStatistics } from 'v8';
+
+import { MetricsService } from 'src/engine/core-modules/metrics/metrics.service';
+
+const MILLISECONDS_PER_SECOND = 1_000;
+// Scavenges land under a millisecond; mark-compact over a multi-GB heap runs into seconds.
+const GC_DURATION_BUCKETS_SECONDS = [
+  0.0005, 0.001, 0.0025, 0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5,
+];
+
+const GC_KIND_BY_CONSTANT = new Map<number, string>([
+  [constants.NODE_PERFORMANCE_GC_MINOR, 'minor'],
+  [constants.NODE_PERFORMANCE_GC_MAJOR, 'major'],
+  [constants.NODE_PERFORMANCE_GC_INCREMENTAL, 'incremental'],
+  [constants.NODE_PERFORMANCE_GC_WEAKCB, 'weakcb'],
+]);
+
+// Attributes event loop stalls to garbage collection: a `major` pause is stop-the-world, so its
+// duration lands directly on request latency. Paired with the heap gauges, this is what tells us
+// whether a cache-size reduction actually bought p99.
+@Injectable()
+export class GcMetricsService implements OnModuleInit, OnModuleDestroy {
+  private readonly pauseHistogram: Histogram;
+  private observer?: PerformanceObserver;
+
+  constructor(private readonly metricsService: MetricsService) {
+    this.pauseHistogram = this.metricsService
+      .getMeter()
+      .createHistogram('twenty_nodejs_gc_duration_seconds', {
+        description: 'V8 garbage collection pause duration, by collection kind',
+        unit: 's',
+        advice: { explicitBucketBoundaries: GC_DURATION_BUCKETS_SECONDS },
+      });
+  }
+
+  onModuleInit(): void {
+    this.observer = new PerformanceObserver((list) => {
+      for (const entry of list.getEntries()) {
+        const kind =
+          GC_KIND_BY_CONSTANT.get(
+            (entry.detail as { kind?: number } | undefined)?.kind ?? -1,
+          ) ?? 'unknown';
+
+        this.pauseHistogram.record(entry.duration / MILLISECONDS_PER_SECOND, {
+          kind,
+        });
+      }
+    });
+    this.observer.observe({ entryTypes: ['gc'] });
+
+    this.registerHeapGauges();
+  }
+
+  onModuleDestroy(): void {
+    this.observer?.disconnect();
+  }
+
+  private registerHeapGauges(): void {
+    const gauges: {
+      metricName: string;
+      description: string;
+      read: (statistics: ReturnType<typeof getHeapStatistics>) => number;
+    }[] = [
+      {
+        metricName: 'twenty_nodejs_heap_used_bytes',
+        description: 'V8 heap occupied by live objects',
+        read: (statistics) => statistics.used_heap_size,
+      },
+      {
+        metricName: 'twenty_nodejs_heap_total_bytes',
+        description: 'V8 heap committed by the process',
+        read: (statistics) => statistics.total_heap_size,
+      },
+      {
+        metricName: 'twenty_nodejs_heap_size_limit_bytes',
+        description: 'V8 heap ceiling (--max-old-space-size)',
+        read: (statistics) => statistics.heap_size_limit,
+      },
+      {
+        metricName: 'twenty_nodejs_heap_external_bytes',
+        description: 'Memory held outside the V8 heap by native objects',
+        read: (statistics) => statistics.external_memory,
+      },
+    ];
+
+    for (const gauge of gauges) {
+      this.metricsService.createObservableGauge({
+        metricName: gauge.metricName,
+        options: { description: gauge.description, unit: 'By' },
+        callback: async () => gauge.read(getHeapStatistics()),
+      });
+    }
+  }
+}

--- a/packages/twenty-server/src/engine/core-modules/metrics/gc-metrics.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/metrics/gc-metrics.service.ts
@@ -4,6 +4,8 @@ import { type Histogram } from '@opentelemetry/api';
 import { constants, PerformanceObserver } from 'perf_hooks';
 import { getHeapStatistics } from 'v8';
 
+import { isDefined } from 'twenty-shared/utils';
+
 import { MetricsService } from 'src/engine/core-modules/metrics/metrics.service';
 
 const MILLISECONDS_PER_SECOND = 1_000;
@@ -11,6 +13,8 @@ const MILLISECONDS_PER_SECOND = 1_000;
 const GC_DURATION_BUCKETS_SECONDS = [
   0.0005, 0.001, 0.0025, 0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5,
 ];
+
+const HEAP_STATISTICS_CACHE_MS = 1_000;
 
 const GC_KIND_BY_CONSTANT = new Map<number, string>([
   [constants.NODE_PERFORMANCE_GC_MINOR, 'minor'],
@@ -26,6 +30,8 @@ const GC_KIND_BY_CONSTANT = new Map<number, string>([
 export class GcMetricsService implements OnModuleInit, OnModuleDestroy {
   private readonly pauseHistogram: Histogram;
   private observer?: PerformanceObserver;
+  private heapStatistics?: ReturnType<typeof getHeapStatistics>;
+  private heapStatisticsAt = 0;
 
   constructor(private readonly metricsService: MetricsService) {
     this.pauseHistogram = this.metricsService
@@ -91,8 +97,23 @@ export class GcMetricsService implements OnModuleInit, OnModuleDestroy {
       this.metricsService.createObservableGauge({
         metricName: gauge.metricName,
         options: { description: gauge.description, unit: 'By' },
-        callback: async () => gauge.read(getHeapStatistics()),
+        callback: async () => gauge.read(this.getHeapStatisticsSnapshot()),
       });
     }
+  }
+
+  // The four gauges share one snapshot per scrape instead of each calling into V8.
+  private getHeapStatisticsSnapshot(): ReturnType<typeof getHeapStatistics> {
+    const now = Date.now();
+
+    if (
+      !isDefined(this.heapStatistics) ||
+      now - this.heapStatisticsAt > HEAP_STATISTICS_CACHE_MS
+    ) {
+      this.heapStatistics = getHeapStatistics();
+      this.heapStatisticsAt = now;
+    }
+
+    return this.heapStatistics;
   }
 }

--- a/packages/twenty-server/src/engine/core-modules/metrics/metrics.module.ts
+++ b/packages/twenty-server/src/engine/core-modules/metrics/metrics.module.ts
@@ -1,11 +1,17 @@
 import { Module } from '@nestjs/common';
 
 import { EventLoopMetricsService } from 'src/engine/core-modules/metrics/event-loop-metrics.service';
+import { GcMetricsService } from 'src/engine/core-modules/metrics/gc-metrics.service';
 import { MetricsCacheService } from 'src/engine/core-modules/metrics/metrics-cache.service';
 import { MetricsService } from 'src/engine/core-modules/metrics/metrics.service';
 
 @Module({
-  providers: [MetricsService, MetricsCacheService, EventLoopMetricsService],
+  providers: [
+    MetricsService,
+    MetricsCacheService,
+    EventLoopMetricsService,
+    GcMetricsService,
+  ],
   exports: [MetricsService, MetricsCacheService],
 })
 export class MetricsModule {}


### PR DESCRIPTION
## Why

`POST /graphql` p99 at the ingress is **2.43s** while p50 is 20ms. The event loop delay p99 is **1.4-1.9s** on the large API pods, so this is a stall, not slow work.

We can't currently attribute that stall. `twenty_nodejs_eventloop_delay_seconds` tells us the loop was blocked; it doesn't say by what. The leading hypothesis is V8 major GC over the ~2.4 GB live heap the workspace metadata cache retains, under a 1536m CPU limit that leaves little room for concurrent marking to stay off the main thread. That hypothesis is currently untestable in prod.

Two pieces of evidence make closing this gap the right next step rather than shipping more cache cuts:

- **Event loop delay scales monotonically with cache occupancy.** 6601 entries → 1.66s, 6470 → 1.64s, 5097 → 0.91s, 3989 → 0.46s.
- **The "Slow DB Query" this work was premised on is not a database problem.** Sentry `TWENTY-SERVER-J1R` attributes 1.02s of a 1.81s transaction to the `core.fieldMetadata` SELECT. `pg_stat_statements` on the prod writer measures that same statement at **2.24ms mean over 24.4M calls** (stddev 2.40ms). The span is timed in JS, so it is capturing the stall, not query time. No statement in the database has a mean above 200ms at more than 1000 calls, and the pool is idle (13ms p99 acquisition, 0 waiting, 631/631 idle).

So the cache reduction work needs a metric that can actually show whether a heap reduction bought p99, which pod memory alone has not: the ORM cap in #23778 cut `orm:entity-metadatas` from 2123 MB to 905 MB per pod, but `flat-maps:field-metadata` (uncapped) grew from 1635 MB to 2311 MB in the freed slots under the same byte-blind global entry cap. Net saving ~420 MB, and p99 has been flat at ~2.2s all week.

## What

- `twenty_nodejs_gc_duration_seconds` — histogram of V8 GC pause duration, labelled `kind` (`minor` / `major` / `incremental` / `weakcb`). `major` is stop-the-world, so its duration lands directly on request latency.
- `twenty_nodejs_heap_used_bytes`, `_heap_total_bytes`, `_heap_size_limit_bytes`, `_heap_external_bytes` — real V8 accounting, replacing the sampled deep-size model that is a known upper bound (it charges repeated string keys fresh while V8 interns them).

Observation only, no behaviour change. `PerformanceObserver` on `gc` entries is passive; the heap gauges read `v8.getHeapStatistics()` on scrape.

## Testing

Verified the observer against a retained cache-shaped object graph: entries are captured and classified correctly across `minor`, `major` and `incremental`, with durations and the `detail.kind` mapping resolving as expected.

Once deployed, `histogram_quantile(0.99, sum by (kind, le) (rate(twenty_nodejs_gc_duration_seconds_bucket[15m])))` against `twenty_nodejs_eventloop_delay_seconds` either confirms GC as the stall source or rules it out and redirects the investigation.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/23879?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

