### PR TITLE
feat(server): export local cache entry count per provider

### DIFF
--- a/packages/twenty-server/src/engine/workspace-cache/services/workspace-cache-metrics.service.ts
+++ b/packages/twenty-server/src/engine/workspace-cache/services/workspace-cache-metrics.service.ts
@@ -16,6 +16,7 @@ import {
   computeLocalCacheStats,
 } from 'src/engine/workspace-cache/utils/compute-local-cache-stats.util';
 import { deepSizeBytes } from 'src/engine/workspace-cache/utils/deep-size-bytes.util';
+import { getProviderFromCacheKey } from 'src/engine/workspace-cache/utils/get-provider-from-cache-key.util';
 
 type LocalCache = ReadonlyMap<
   string,
@@ -153,7 +154,7 @@ export class WorkspaceCacheMetricsService {
     > = {};
 
     for (const [key, entry] of localCache) {
-      const provider = key.slice(0, key.lastIndexOf(':'));
+      const provider = getProviderFromCacheKey(key);
       const stats = (perProvider[provider] ??= {
         count: 0,
         sampledBytes: 0,

--- a/packages/twenty-server/src/engine/workspace-cache/services/workspace-cache-metrics.service.ts
+++ b/packages/twenty-server/src/engine/workspace-cache/services/workspace-cache-metrics.service.ts
@@ -250,5 +250,19 @@ export class WorkspaceCacheMetricsService {
           attributes: { provider },
         })),
     });
+    this.metricsService.createMultiObservableGauge({
+      metricName: 'twenty_workspace_cache_local_entries_by_provider',
+      options: {
+        description:
+          'Entries in the local workspace metadata cache per provider',
+      },
+      callback: async () =>
+        Object.entries(this.getStats().entriesByProvider).map(
+          ([provider, value]) => ({
+            value,
+            attributes: { provider },
+          }),
+        ),
+    });
   }
 }

--- a/packages/twenty-server/src/engine/workspace-cache/utils/__tests__/compute-local-cache-stats.util.spec.ts
+++ b/packages/twenty-server/src/engine/workspace-cache/utils/__tests__/compute-local-cache-stats.util.spec.ts
@@ -11,6 +11,7 @@ describe('computeLocalCacheStats', () => {
       workspaces: 0,
       versionsTotal: 0,
       versionsByCount: { '1': 0, '2': 0, '3': 0, '4': 0, '5+': 0 },
+      entriesByProvider: {},
     });
   });
 
@@ -27,6 +28,10 @@ describe('computeLocalCacheStats', () => {
     // ws-a and ws-b — the same workspace under two providers counts once.
     expect(stats.workspaces).toBe(2);
     expect(stats.versionsTotal).toBe(4);
+    expect(stats.entriesByProvider).toEqual({
+      'orm:entity-metadatas': 2,
+      'flat-maps:field-metadata': 1,
+    });
   });
 
   it('buckets entries by version count and folds 5+ together', () => {

--- a/packages/twenty-server/src/engine/workspace-cache/utils/compute-local-cache-stats.util.ts
+++ b/packages/twenty-server/src/engine/workspace-cache/utils/compute-local-cache-stats.util.ts
@@ -3,6 +3,7 @@ export type LocalCacheStats = {
   workspaces: number;
   versionsTotal: number;
   versionsByCount: Record<string, number>;
+  entriesByProvider: Record<string, number>;
 };
 
 export const computeLocalCacheStats = (
@@ -16,10 +17,14 @@ export const computeLocalCacheStats = (
     '4': 0,
     '5+': 0,
   };
+  const entriesByProvider: Record<string, number> = {};
   let versionsTotal = 0;
 
   for (const [key, entry] of localCache) {
     workspaceIds.add(key.slice(key.lastIndexOf(':') + 1));
+    const provider = key.slice(0, key.lastIndexOf(':'));
+
+    entriesByProvider[provider] = (entriesByProvider[provider] ?? 0) + 1;
     const versionCount = entry.versions.size;
 
     versionsTotal += versionCount;
@@ -33,5 +38,6 @@ export const computeLocalCacheStats = (
     workspaces: workspaceIds.size,
     versionsTotal,
     versionsByCount,
+    entriesByProvider,
   };
 };

--- a/packages/twenty-server/src/engine/workspace-cache/utils/compute-local-cache-stats.util.ts
+++ b/packages/twenty-server/src/engine/workspace-cache/utils/compute-local-cache-stats.util.ts
@@ -1,3 +1,5 @@
+import { getProviderFromCacheKey } from 'src/engine/workspace-cache/utils/get-provider-from-cache-key.util';
+
 export type LocalCacheStats = {
   entries: number;
   workspaces: number;
@@ -22,7 +24,7 @@ export const computeLocalCacheStats = (
 
   for (const [key, entry] of localCache) {
     workspaceIds.add(key.slice(key.lastIndexOf(':') + 1));
-    const provider = key.slice(0, key.lastIndexOf(':'));
+    const provider = getProviderFromCacheKey(key);
 
     entriesByProvider[provider] = (entriesByProvider[provider] ?? 0) + 1;
     const versionCount = entry.versions.size;

--- a/packages/twenty-server/src/engine/workspace-cache/utils/get-provider-from-cache-key.util.ts
+++ b/packages/twenty-server/src/engine/workspace-cache/utils/get-provider-from-cache-key.util.ts
@@ -1,0 +1,2 @@
+export const getProviderFromCacheKey = (cacheKey: string): string =>
+  cacheKey.slice(0, cacheKey.lastIndexOf(':'));


### PR DESCRIPTION
The workspace cache exports `twenty_workspace_cache_local_bytes_by_provider` but not the entry count behind it, so provider growth cannot be attributed from metrics alone.

Concretely: when #23778 capped `orm:entity-metadatas` at 128 entries, pod memory did not move — the freed slots refilled with field-metadata entries under the byte-blind global cap. The only way to see that was slot arithmetic against the byte gauge.

Adds `twenty_workspace_cache_local_entries_by_provider`, counted in `computeLocalCacheStats` (already cached behind a 5s TTL, so a scrape stays one pass over the map).

Two uses:
- **Attribution**: entries alongside per-provider bytes separates "kept more entries" from "entries got bigger".
- **Rollout gauge for #23880**: with cold storage on, the hot tier should pin at its per-provider budget while total entries keep growing. This gauge is how to see that.

Standalone — independent of #23879 and #23880. One gauge, one util change, tests updated.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/23883?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

