### PR TITLE
perf(record-index): paint cached views instantly on navigation

### DIFF
--- a/packages/twenty-front/src/modules/object-record/record-board/record-board-column/components/RecordBoardColumnCardsContainer.tsx
+++ b/packages/twenty-front/src/modules/object-record/record-board/record-board-column/components/RecordBoardColumnCardsContainer.tsx
@@ -54,7 +54,8 @@ export const RecordBoardColumnCardsContainer = ({
           />
         </Fragment>
       ))}
-      {recordBoardShouldFetchMoreInColumn ? (
+      {recordBoardShouldFetchMoreInColumn &&
+      recordIndexRecordIdsByGroup.length === 0 ? (
         <RecordBoardColumnLoadingSkeletonCards />
       ) : null}
       <DragDropItemDropTarget

--- a/packages/twenty-front/src/modules/object-record/record-field/hooks/useRelevantRecordsGqlFields.ts
+++ b/packages/twenty-front/src/modules/object-record/record-field/hooks/useRelevantRecordsGqlFields.ts
@@ -13,6 +13,7 @@ import { useRecordIndexContextOrThrow } from '@/object-record/record-index/conte
 
 import { useAtomComponentSelectorValue } from '@/ui/utilities/state/jotai/hooks/useAtomComponentSelectorValue';
 import { useAtomComponentStateValue } from '@/ui/utilities/state/jotai/hooks/useAtomComponentStateValue';
+import { useMemo } from 'react';
 import { filterDuplicatesById, isDefined } from 'twenty-shared/utils';
 
 type UseRecordsUsefulGqlFields = {
@@ -37,74 +38,88 @@ export const useRelevantRecordsGqlFields = ({
 
   const { objectMetadataItems } = useObjectMetadataItems();
 
-  const visibleRecordFieldMetadataItems = visibleRecordFields
-    .map(
-      (field) =>
-        fieldMetadataItemByFieldMetadataItemId[field.fieldMetadataItemId],
-    )
-    .filter(isDefined);
+  // A new object identity here rebuilds the whole GraphQL document downstream,
+  // and this hook is instantiated several times per record index render tree
+  const additionalFieldMetadataIdsKey = additionalFieldMetadataIds.join(',');
 
-  const recordFilterFields = currentRecordFilters
-    .map((recordFilter) =>
-      objectMetadataItem.fields.find(
-        (field) => field.id === recordFilter.fieldMetadataId,
-      ),
-    )
-    .filter(isDefined);
+  return useMemo(() => {
+    const visibleRecordFieldMetadataItems = visibleRecordFields
+      .map(
+        (field) =>
+          fieldMetadataItemByFieldMetadataItemId[field.fieldMetadataItemId],
+      )
+      .filter(isDefined);
 
-  const additionalFieldMetadataItems = additionalFieldMetadataIds
-    .filter(isDefined)
-    .map(
-      (fieldMetadataId) =>
-        fieldMetadataItemByFieldMetadataItemId[fieldMetadataId],
-    )
-    .filter(isDefined);
+    const recordFilterFields = currentRecordFilters
+      .map((recordFilter) =>
+        objectMetadataItem.fields.find(
+          (field) => field.id === recordFilter.fieldMetadataId,
+        ),
+      )
+      .filter(isDefined);
 
-  const fieldMetadataItemsToUse = [
-    ...visibleRecordFieldMetadataItems,
-    ...(recordFilterFields ?? []),
-    ...additionalFieldMetadataItems,
-  ].filter(filterDuplicatesById);
+    const additionalFieldMetadataItems = additionalFieldMetadataIdsKey
+      .split(',')
+      .filter((fieldMetadataId) => fieldMetadataId !== '')
+      .map(
+        (fieldMetadataId) =>
+          fieldMetadataItemByFieldMetadataItemId[fieldMetadataId],
+      )
+      .filter(isDefined);
 
-  const allDepthOneGqlFields = generateDepthRecordGqlFieldsFromFields({
+    const fieldMetadataItemsToUse = [
+      ...visibleRecordFieldMetadataItems,
+      ...recordFilterFields,
+      ...additionalFieldMetadataItems,
+    ].filter(filterDuplicatesById);
+
+    const allDepthOneGqlFields = generateDepthRecordGqlFieldsFromFields({
+      objectMetadataItems,
+      fields: fieldMetadataItemsToUse,
+      depth: 1,
+    });
+
+    const labelIdentifierFieldMetadataItem =
+      getLabelIdentifierFieldMetadataItem(objectMetadataItem);
+    const imageIdentifierFieldMetadataItem =
+      getImageIdentifierFieldMetadataItem(objectMetadataItem);
+
+    const hasPosition = hasObjectMetadataItemPositionField(objectMetadataItem);
+
+    const isObjectAnActivity =
+      objectMetadataItem.nameSingular === CoreObjectNameSingular.Note ||
+      objectMetadataItem.nameSingular === CoreObjectNameSingular.Task;
+
+    return {
+      id: true,
+      ...(isDefined(labelIdentifierFieldMetadataItem)
+        ? { [labelIdentifierFieldMetadataItem.name]: true }
+        : {}),
+      ...(isDefined(imageIdentifierFieldMetadataItem)
+        ? { [imageIdentifierFieldMetadataItem.name]: true }
+        : {}),
+      ...(hasPosition ? { position: true } : {}),
+      ...allDepthOneGqlFields,
+      createdAt: true,
+      updatedAt: true,
+      deletedAt: true,
+      noteTargets: generateActivityTargetGqlFields({
+        activityObjectNameSingular: CoreObjectNameSingular.Note,
+        objectMetadataItems,
+        loadRelations: isObjectAnActivity ? 'relations' : 'activity',
+      }),
+      taskTargets: generateActivityTargetGqlFields({
+        activityObjectNameSingular: CoreObjectNameSingular.Task,
+        objectMetadataItems,
+        loadRelations: isObjectAnActivity ? 'relations' : 'activity',
+      }),
+    };
+  }, [
+    visibleRecordFields,
+    currentRecordFilters,
+    fieldMetadataItemByFieldMetadataItemId,
+    objectMetadataItem,
     objectMetadataItems,
-    fields: fieldMetadataItemsToUse,
-    depth: 1,
-  });
-
-  const labelIdentifierFieldMetadataItem =
-    getLabelIdentifierFieldMetadataItem(objectMetadataItem);
-  const imageIdentifierFieldMetadataItem =
-    getImageIdentifierFieldMetadataItem(objectMetadataItem);
-
-  const hasPosition = hasObjectMetadataItemPositionField(objectMetadataItem);
-
-  const isObjectAnActivity =
-    objectMetadataItem.nameSingular === CoreObjectNameSingular.Note ||
-    objectMetadataItem.nameSingular === CoreObjectNameSingular.Task;
-
-  return {
-    id: true,
-    ...(isDefined(labelIdentifierFieldMetadataItem)
-      ? { [labelIdentifierFieldMetadataItem.name]: true }
-      : {}),
-    ...(isDefined(imageIdentifierFieldMetadataItem)
-      ? { [imageIdentifierFieldMetadataItem.name]: true }
-      : {}),
-    ...(hasPosition ? { position: true } : {}),
-    ...allDepthOneGqlFields,
-    createdAt: true,
-    updatedAt: true,
-    deletedAt: true,
-    noteTargets: generateActivityTargetGqlFields({
-      activityObjectNameSingular: CoreObjectNameSingular.Note,
-      objectMetadataItems,
-      loadRelations: isObjectAnActivity ? 'relations' : 'activity',
-    }),
-    taskTargets: generateActivityTargetGqlFields({
-      activityObjectNameSingular: CoreObjectNameSingular.Task,
-      objectMetadataItems,
-      loadRelations: isObjectAnActivity ? 'relations' : 'activity',
-    }),
-  };
+    additionalFieldMetadataIdsKey,
+  ]);
 };

--- a/packages/twenty-front/src/modules/object-record/record-index/states/recordIndexRecordGroupsAreInInitialLoadingComponentState.ts
+++ b/packages/twenty-front/src/modules/object-record/record-index/states/recordIndexRecordGroupsAreInInitialLoadingComponentState.ts
@@ -1,9 +1,11 @@
-import { ContextStoreComponentInstanceContext } from '@/context-store/states/contexts/ContextStoreComponentInstanceContext';
+import { RecordBoardComponentInstanceContext } from '@/object-record/record-board/states/contexts/RecordBoardComponentInstanceContext';
 import { createAtomComponentState } from '@/ui/utilities/state/jotai/utils/createAtomComponentState';
 
+// Bound per record board: the context store instance is global, so this
+// in-flight flag leaked between boards
 export const recordIndexRecordGroupsAreInInitialLoadingComponentState =
   createAtomComponentState<boolean>({
     key: 'recordIndexRecordGroupsAreInInitialLoadingComponentState',
     defaultValue: false,
-    componentInstanceContext: ContextStoreComponentInstanceContext,
+    componentInstanceContext: RecordBoardComponentInstanceContext,
   });

--- a/packages/twenty-front/src/modules/object-record/record-table/record-table-body/components/RecordTableBodyLoading.tsx
+++ b/packages/twenty-front/src/modules/object-record/record-table/record-table-body/components/RecordTableBodyLoading.tsx
@@ -11,9 +11,21 @@ import { RecordTableCellLoading } from '@/object-record/record-table/record-tabl
 import { RecordTableLastEmptyCell } from '@/object-record/record-table/record-table-cell/components/RecordTableLastEmptyCell';
 import { RecordTablePlusButtonCellPlaceholder } from '@/object-record/record-table/record-table-cell/components/RecordTablePlusButtonCellPlaceholder';
 import { RecordTableTr } from '@/object-record/record-table/record-table-row/components/RecordTableTr';
+import { RECORD_TABLE_ROW_HEIGHT } from '@/object-record/record-table/constants/RecordTableRowHeight';
+import { useMemo } from 'react';
+
+const LOADING_ROWS_BUFFER = 2;
 
 export const RecordTableBodyLoading = () => {
   const { visibleRecordFields } = useRecordTableContextOrThrow();
+
+  // Only the rows that can actually be seen, mounting more costs a full cell tree each
+  const numberOfLoadingRows = useMemo(
+    () =>
+      Math.ceil(window.innerHeight / RECORD_TABLE_ROW_HEIGHT) +
+      LOADING_ROWS_BUFFER,
+    [],
+  );
 
   const isRecordTableDragColumnHidden = useAtomComponentStateValue(
     isRecordTableDragColumnHiddenComponentState,
@@ -25,7 +37,7 @@ export const RecordTableBodyLoading = () => {
 
   return (
     <RecordTableBody>
-      {Array.from({ length: 80 }).map((_, rowIndex) => (
+      {Array.from({ length: numberOfLoadingRows }).map((_, rowIndex) => (
         <RecordTableRowContextProvider
           key={rowIndex}
           value={{

--- a/packages/twenty-front/src/modules/object-record/record-table/virtualization/components/RecordTableVirtualizedInitialDataLoadEffect.tsx
+++ b/packages/twenty-front/src/modules/object-record/record-table/virtualization/components/RecordTableVirtualizedInitialDataLoadEffect.tsx
@@ -2,6 +2,7 @@ import { useRecordIndexTableLazyQuery } from '@/object-record/record-index/hooks
 import { useRecordTableContextOrThrow } from '@/object-record/record-table/contexts/RecordTableContext';
 
 import { visibleRecordFieldsComponentSelector } from '@/object-record/record-field/states/visibleRecordFieldsComponentSelector';
+import { recordIndexAllRecordIdsComponentSelector } from '@/object-record/record-index/states/selectors/recordIndexAllRecordIdsComponentSelector';
 import { recordTableWentFromEmptyToNotEmptyComponentState } from '@/object-record/record-table/states/recordTableWentFromEmptyToNotEmptyComponentState';
 import { useTriggerInitialRecordTableDataLoad } from '@/object-record/record-table/virtualization/hooks/useTriggerInitialRecordTableDataLoad';
 import { isInitializingVirtualTableDataLoadingComponentState } from '@/object-record/record-table/virtualization/states/isInitializingVirtualTableDataLoadingComponentState';
@@ -9,10 +10,12 @@ import { lastContextStoreVirtualizedViewIdComponentState } from '@/object-record
 import { lastContextStoreVirtualizedVisibleRecordFieldsComponentState } from '@/object-record/record-table/virtualization/states/lastContextStoreVirtualizedVisibleRecordFieldsComponentState';
 import { lastRecordTableQueryIdentifierComponentState } from '@/object-record/record-table/virtualization/states/lastRecordTableQueryIdentifierComponentState';
 import { isFetchingMoreRecordsFamilyState } from '@/object-record/states/isFetchingMoreRecordsFamilyState';
+import { useAtomComponentSelectorCallbackState } from '@/ui/utilities/state/jotai/hooks/useAtomComponentSelectorCallbackState';
 import { useAtomComponentSelectorValue } from '@/ui/utilities/state/jotai/hooks/useAtomComponentSelectorValue';
 import { useAtomComponentState } from '@/ui/utilities/state/jotai/hooks/useAtomComponentState';
 import { useAtomFamilyStateValue } from '@/ui/utilities/state/jotai/hooks/useAtomFamilyStateValue';
 import { useGetCurrentViewOnly } from '@/views/hooks/useGetCurrentViewOnly';
+import { useStore } from 'jotai';
 import isEmpty from 'lodash.isempty';
 import { useEffect, useState } from 'react';
 
@@ -60,6 +63,14 @@ export const RecordTableVirtualizedInitialDataLoadEffect = () => {
   );
 
   const { currentView } = useGetCurrentViewOnly();
+
+  const recordIndexAllRecordIdsCallbackState =
+    useAtomComponentSelectorCallbackState(
+      recordIndexAllRecordIdsComponentSelector,
+      recordTableId,
+    );
+
+  const store = useStore();
 
   useEffect(() => {
     if (isInitializingVirtualTableDataLoading) {
@@ -111,7 +122,14 @@ export const RecordTableVirtualizedInitialDataLoadEffect = () => {
         }
       } else if (!isInitializedOnMount) {
         setIsInitializedOnMount(true);
-        await triggerInitialRecordTableDataLoad();
+
+        // A remount of an instance that still holds its rows does not need a reload
+        const hasRecordsAlreadyLoaded =
+          store.get(recordIndexAllRecordIdsCallbackState).length > 0;
+
+        if (!hasRecordsAlreadyLoaded) {
+          await triggerInitialRecordTableDataLoad();
+        }
       }
     })();
   }, [
@@ -131,6 +149,8 @@ export const RecordTableVirtualizedInitialDataLoadEffect = () => {
     visibleRecordFields,
     isInitializedOnMount,
     setIsInitializedOnMount,
+    store,
+    recordIndexAllRecordIdsCallbackState,
   ]);
 
   return <></>;

--- a/packages/twenty-front/src/modules/object-record/record-table/virtualization/hooks/useTriggerInitialRecordTableDataLoad.ts
+++ b/packages/twenty-front/src/modules/object-record/record-table/virtualization/hooks/useTriggerInitialRecordTableDataLoad.ts
@@ -131,7 +131,15 @@ export const useTriggerInitialRecordTableDataLoad = () => {
       store.set(isInitializingVirtualTableDataLoadingCallbackState, true);
 
       try {
-        store.set(isRecordTableInitialLoading, true);
+        const currentRecordIds = store.get(recordIndexAllRecordIds);
+
+        // Keep the already rendered rows visible while the (often cached)
+        // fetch resolves, so navigating back to a view does not flash a skeleton
+        const tableIsEmpty = currentRecordIds.length === 0;
+
+        if (tableIsEmpty) {
+          store.set(isRecordTableInitialLoading, true);
+        }
 
         resetTableFocuses();
 
@@ -149,10 +157,16 @@ export const useTriggerInitialRecordTableDataLoad = () => {
           'hidden',
         );
 
-        const currentRecordIds = store.get(recordIndexAllRecordIds);
-
         let records: ObjectRecord[] | null = null;
         let totalCount = 0;
+
+        const { records: findManyRecords, totalCount: findManyTotalCount } =
+          await findManyRecordsLazy();
+
+        records = findManyRecords;
+        totalCount = findManyTotalCount;
+
+        const recordIdsToClear = store.get(recordIndexAllRecordIds);
 
         const newRecordIdByRealIndex = new Map(
           store.get(recordIdByRealIndexCallbackState),
@@ -161,7 +175,7 @@ export const useTriggerInitialRecordTableDataLoad = () => {
           store.get(dataLoadingStatusByRealIndexCallbackState),
         );
 
-        for (const [realIndex] of currentRecordIds.entries()) {
+        for (const [realIndex] of recordIdsToClear.entries()) {
           newDataLoadingStatusByRealIndex.set(realIndex, 'not-loaded');
           newRecordIdByRealIndex.delete(realIndex);
         }
@@ -176,12 +190,6 @@ export const useTriggerInitialRecordTableDataLoad = () => {
           recordIndexRecordIdsByGroupFamilyState(NO_RECORD_GROUP_FAMILY_KEY),
           [],
         );
-
-        const { records: findManyRecords, totalCount: findManyTotalCount } =
-          await findManyRecordsLazy();
-
-        records = findManyRecords;
-        totalCount = findManyTotalCount;
 
         store.set(
           totalNumberOfRecordsToVirtualizeCallbackState,

--- a/packages/twenty-front/src/modules/object-record/record-table/virtualization/states/lastContextStoreVirtualizedViewIdComponentState.ts
+++ b/packages/twenty-front/src/modules/object-record/record-table/virtualization/states/lastContextStoreVirtualizedViewIdComponentState.ts
@@ -1,9 +1,11 @@
-import { ContextStoreComponentInstanceContext } from '@/context-store/states/contexts/ContextStoreComponentInstanceContext';
+import { RecordTableComponentInstanceContext } from '@/object-record/record-table/states/context/RecordTableComponentInstanceContext';
 import { createAtomComponentState } from '@/ui/utilities/state/jotai/utils/createAtomComponentState';
 
+// Bound per record table: the context store instance is global, so storing the
+// last view there made every navigation look like a view change
 export const lastContextStoreVirtualizedViewIdComponentState =
   createAtomComponentState<string | null>({
     key: 'lastContextStoreVirtualizedViewIdComponentState',
-    componentInstanceContext: ContextStoreComponentInstanceContext,
+    componentInstanceContext: RecordTableComponentInstanceContext,
     defaultValue: null,
   });

--- a/packages/twenty-front/src/modules/object-record/record-table/virtualization/states/lastContextStoreVirtualizedVisibleRecordFieldsComponentState.ts
+++ b/packages/twenty-front/src/modules/object-record/record-table/virtualization/states/lastContextStoreVirtualizedVisibleRecordFieldsComponentState.ts
@@ -1,10 +1,11 @@
-import { ContextStoreComponentInstanceContext } from '@/context-store/states/contexts/ContextStoreComponentInstanceContext';
 import { type RecordField } from '@/object-record/record-field/types/RecordField';
+import { RecordTableComponentInstanceContext } from '@/object-record/record-table/states/context/RecordTableComponentInstanceContext';
 import { createAtomComponentState } from '@/ui/utilities/state/jotai/utils/createAtomComponentState';
 
+// Bound per record table for the same reason as the last virtualized view id
 export const lastContextStoreVirtualizedVisibleRecordFieldsComponentState =
   createAtomComponentState<RecordField[] | null>({
     key: 'lastContextStoreVirtualizedVisibleRecordFieldsComponentState',
-    componentInstanceContext: ContextStoreComponentInstanceContext,
+    componentInstanceContext: RecordTableComponentInstanceContext,
     defaultValue: null,
   });


### PR DESCRIPTION
Makes navigating between record views paint instantly when the data is already known, instead of wiping the table and showing a skeleton on every navigation.

## Why

All view, field and filter metadata is already client-cached, and the records query answers fast, yet every navigation between record index views costs a visible 1-2s. The time is spent in the frontend, not the network:

- `useTriggerInitialRecordTableDataLoad` sets `isRecordTableInitialLoading` and wipes the row ids **before** awaiting the fetch, so even a cache hit renders a skeleton for at least one commit.
- `lastContextStoreVirtualizedViewIdComponentState` and `lastContextStoreVirtualizedVisibleRecordFieldsComponentState` are bound to `ContextStoreComponentInstanceContext`, whose only provider uses the single global `MAIN_CONTEXT_STORE_INSTANCE_ID`. The stored value is therefore "the last view the whole app was on", so the guard in `RecordTableVirtualizedInitialDataLoadEffect` is always true and a revisit can never short-circuit. Same for `recordIndexRecordGroupsAreInInitialLoadingComponentState` on the board.
- `RecordTableBodyLoading` mounts 80 rows times every visible column, twice per navigation, while the virtualizer shows about 15.
- `useRelevantRecordsGqlFields` returns a fresh object literal each render, defeating the `useMemo` in `useFindManyRecordsQuery`, so the GraphQL document is rebuilt on every render of the record index.

## Changes

- Keep already rendered rows on screen while the initial load resolves; only enter the skeleton state when the instance genuinely has no rows.
- Scope the three load guards to their own component instance so a revisit no-ops.
- Show the board column skeleton only when the column is actually empty, not whenever `recordBoardShouldFetchMoreInColumn` is true, which it is by default.
- Size the table skeleton to the viewport.
- Memoize the relevant records gql fields so the query document stops being rebuilt per render.

Data still refreshes when the view, filters, sorts or visible fields genuinely change, and the SSE resync path is untouched.

Tested: typecheck clean, 176 tests across the record-table, record-index and record-board suites pass.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/23911?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

