### PR TITLE
fix(twenty-front): resolve the command menu item i18n rendering issue

### DIFF
--- a/packages/twenty-front/src/modules/command-menu-item/utils/getCommandMenuItemLabel.ts
+++ b/packages/twenty-front/src/modules/command-menu-item/utils/getCommandMenuItemLabel.ts
@@ -1,5 +1,4 @@
 import { i18n, type MessageDescriptor } from '@lingui/core';
-import { isString } from '@sniptt/guards';
 import { type Nullable } from 'twenty-shared/types';
 import { isDefined } from 'twenty-shared/utils';
 
@@ -10,5 +9,5 @@ export const getCommandMenuItemLabel = (
     return '';
   }
 
-  return isString(label) ? label : i18n._(label);
+  return i18n._(label);
 };


### PR DESCRIPTION
The most command menus item labels are `string`. The original logic prevent it form being translated.

Additionally, the `i18n._()` can handle both `string` and `MessageDescriptor` type, so it's safe to remove this logic.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/23913?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

