### PR TITLE
fix: preserve morph-related records when merging people

### DIFF
--- a/packages/twenty-server/src/engine/api/common/common-query-runners/common-merge-many-query-runner.service.ts
+++ b/packages/twenty-server/src/engine/api/common/common-query-runners/common-merge-many-query-runner.service.ts
@@ -39,7 +39,7 @@ import { FlatEntityMaps } from 'src/engine/metadata-modules/flat-entity/types/fl
 import { findFlatEntityByIdInFlatEntityMaps } from 'src/engine/metadata-modules/flat-entity/utils/find-flat-entity-by-id-in-flat-entity-maps.util';
 import { FlatFieldMetadata } from 'src/engine/metadata-modules/flat-field-metadata/types/flat-field-metadata.type';
 import { buildFieldMapsFromFlatObjectMetadata } from 'src/engine/metadata-modules/flat-field-metadata/utils/build-field-maps-from-flat-object-metadata.util';
-import { isFlatFieldMetadataOfType } from 'src/engine/metadata-modules/flat-field-metadata/utils/is-flat-field-metadata-of-type.util';
+import { isMorphOrRelationFlatFieldMetadata } from 'src/engine/metadata-modules/flat-field-metadata/utils/is-morph-or-relation-flat-field-metadata.util';
 import { FlatObjectMetadata } from 'src/engine/metadata-modules/flat-object-metadata/types/flat-object-metadata.type';
 import { assertMutationNotOnRemoteObject } from 'src/engine/metadata-modules/object-metadata/utils/assert-mutation-not-on-remote-object.util';
 import { WorkspaceEntityManager } from 'src/engine/twenty-orm/entity-manager/workspace-entity-manager';
@@ -408,7 +408,7 @@ export class CommonMergeManyQueryRunnerService extends CommonBaseQueryRunnerServ
       flatFieldMetadataMaps.byUniversalIdentifier,
     ).filter(isDefined)) {
       if (
-        !isFlatFieldMetadataOfType(field, FieldMetadataType.RELATION) ||
+        !isMorphOrRelationFlatFieldMetadata(field) ||
         field.relationTargetObjectMetadataId !== flatObjectMetadata.id ||
         !field.isActive
       ) {
@@ -417,6 +417,7 @@ export class CommonMergeManyQueryRunnerService extends CommonBaseQueryRunnerServ
 
       const relationSettings = field.settings as
         | FieldMetadataSettingsMapping['RELATION']
+        | FieldMetadataSettingsMapping['MORPH_RELATION']
         | undefined;
 
       if (relationSettings?.relationType !== RelationType.MANY_TO_ONE) {

--- a/packages/twenty-server/test/integration/graphql/suites/object-generated/people-merge-many.integration-spec.ts
+++ b/packages/twenty-server/test/integration/graphql/suites/object-generated/people-merge-many.integration-spec.ts
@@ -1,5 +1,6 @@
 import { PERSON_GQL_FIELDS } from 'test/integration/constants/person-gql-fields.constants';
 import { createManyOperationFactory } from 'test/integration/graphql/utils/create-many-operation-factory.util';
+import { createOneOperationFactory } from 'test/integration/graphql/utils/create-one-operation-factory.util';
 import { findOneOperationFactory } from 'test/integration/graphql/utils/find-one-operation-factory.util';
 import { makeGraphqlAPIRequest } from 'test/integration/graphql/utils/make-graphql-api-request.util';
 import { mergeManyOperationFactory } from 'test/integration/graphql/utils/merge-many-operation-factory.util';
@@ -15,6 +16,82 @@ describe('people merge resolvers (integration)', () => {
       await deleteRecordsByIds('person', createdPersonIdsForCleaning);
       createdPersonIdsForCleaning = [];
     }
+  });
+
+  describe('migrating related records', () => {
+    it('should migrate timeline activities targeting the merged person', async () => {
+      const createPersonsOperation = createManyOperationFactory({
+        objectMetadataSingularName: 'person',
+        objectMetadataPluralName: 'people',
+        gqlFields: PERSON_GQL_FIELDS,
+        data: [
+          {
+            name: {
+              firstName: 'Priority',
+              lastName: 'Person',
+            },
+          },
+          {
+            name: {
+              firstName: 'Duplicate',
+              lastName: 'Person',
+            },
+          },
+        ],
+      });
+
+      const createPersonsResponse = await makeGraphqlAPIRequest(
+        createPersonsOperation,
+      );
+      const [priorityPerson, duplicatePerson] =
+        createPersonsResponse.body.data.createPeople;
+
+      createdPersonIdsForCleaning.push(priorityPerson.id, duplicatePerson.id);
+
+      const createTimelineActivityResponse = await makeGraphqlAPIRequest(
+        createOneOperationFactory({
+          objectMetadataSingularName: 'timelineActivity',
+          gqlFields: 'id targetPersonId',
+          data: {
+            happensAt: new Date().toISOString(),
+            targetPersonId: duplicatePerson.id,
+          },
+        }),
+      );
+
+      expect(createTimelineActivityResponse.body.errors).toBeUndefined();
+
+      const timelineActivity =
+        createTimelineActivityResponse.body.data.createTimelineActivity;
+
+      const mergeResponse = await makeGraphqlAPIRequest(
+        mergeManyOperationFactory({
+          objectMetadataPluralName: 'people',
+          gqlFields: PERSON_GQL_FIELDS,
+          ids: [priorityPerson.id, duplicatePerson.id],
+          conflictPriorityIndex: 0,
+        }),
+      );
+
+      expect(mergeResponse.body.errors).toBeUndefined();
+
+      const findTimelineActivityResponse = await makeGraphqlAPIRequest(
+        findOneOperationFactory({
+          objectMetadataSingularName: 'timelineActivity',
+          gqlFields: 'id targetPersonId',
+          filter: {
+            id: {
+              eq: timelineActivity.id,
+            },
+          },
+        }),
+      );
+
+      expect(findTimelineActivityResponse.body.errors).toBeUndefined();
+      expect(
+        findTimelineActivityResponse.body.data.timelineActivity.targetPersonId,
+      ).toBe(priorityPerson.id);
+    });
   });
 
   describe('merging composite fields', () => {


### PR DESCRIPTION
## Summary
- migrate active many-to-one morph relations before deleting merged people
- retain timeline activities that target a merged person

Fixes #23903.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/23945?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

