### PR TITLE
Fix: allow confirmation modal button label to wrap

### DIFF
--- a/packages/twenty-front/src/modules/ui/layout/modal/components/ConfirmationModal.tsx
+++ b/packages/twenty-front/src/modules/ui/layout/modal/components/ConfirmationModal.tsx
@@ -32,6 +32,25 @@ export type ConfirmationModalProps = {
 const StyledCenteredButtonContainer = styled.div`
   box-sizing: border-box;
   margin-top: ${themeCssVariables.spacing[2]};
+
+  // Long localized confirmation labels (e.g. "Permanently Destroy <object>")
+  // are nowrap inside the shared Button and overflow the narrow modal.
+  // Let the full-width button grow and wrap instead of clipping the label.
+  > div > button {
+    height: auto;
+    min-height: ${themeCssVariables.spacing[8]};
+    white-space: normal;
+  }
+
+  > div > button > div {
+    min-width: 0;
+  }
+
+  > div > button > div > div {
+    overflow-wrap: break-word;
+    text-align: center;
+    white-space: normal;
+  }
 `;
 
 export const StyledCenteredButton = (
@@ -50,30 +69,6 @@ const StyledCenteredTitle = styled.div`
 const StyledSectionContainer = styled.div`
   margin-bottom: ${themeCssVariables.spacing[6]};
 `;
-
-const StyledConfirmationButtonContainer = styled.div`
-  box-sizing: border-box;
-  margin-top: ${themeCssVariables.spacing[2]};
-  > button {
-    border-color: ${themeCssVariables.border.color.danger};
-    box-shadow: none;
-    color: ${themeCssVariables.color.red};
-    font-size: ${themeCssVariables.font.size.md};
-    line-height: ${themeCssVariables.text.lineHeight.lg};
-    &:hover {
-      background-color: ${themeCssVariables.color.red3};
-    }
-  }
-`;
-
-export const StyledConfirmationButton = (
-  props: React.ComponentProps<typeof Button>,
-) => (
-  <StyledConfirmationButtonContainer>
-    {/* oxlint-disable-next-line react/jsx-props-no-spreading */}
-    <Button {...props} />
-  </StyledConfirmationButtonContainer>
-);
 
 const defaultConfirmButtonText = msg`Confirm`;
 

--- a/packages/twenty-front/src/modules/ui/layout/modal/components/__stories__/ConfirmationModal.stories.tsx
+++ b/packages/twenty-front/src/modules/ui/layout/modal/components/__stories__/ConfirmationModal.stories.tsx
@@ -62,6 +62,17 @@ export const Default: Story = {
   },
 };
 
+export const LongConfirmButtonLabel: Story = {
+  args: {
+    modalInstanceId: 'confirmation-modal',
+    title: 'Pariatur labore.',
+    subtitle: 'Velit dolore aliquip laborum occaecat fugiat.',
+    confirmButtonText:
+      'Permanently Destroy this unbelievably long custom object name',
+    onConfirmClick: fn(),
+  },
+};
+
 export const InputConfirmation: Story = {
   args: {
     confirmationValue: 'email@test.dev',


### PR DESCRIPTION
## Summary

Closes #23501

Long localized confirmation labels (e.g. Dutch "Permanently Destroy <object>" built in `DestroyRecordsCommand`) overflow the confirm button in the narrow confirmation modal. The shared `Button` and `ButtonText` force `white-space: nowrap`, and the button is `fullWidth` inside a `narrowWidth` modal (~272px), so the flex `min-width: auto` text container spills past the button edges instead of wrapping.

### Change

Instead of modifying the shared `Button` (used app-wide), scope the fix to `StyledCenteredButtonContainer`:

- let the full-width button grow vertically (`height: auto`, `min-height: 32px`)
- let the internal text containers shrink (`min-width: 0`)
- allow wrapping + safe breaking of long labels (`white-space: normal`, `overflow-wrap: break-word`)

Also removes the unused `StyledConfirmationButton` / `StyledConfirmationButtonContainer` dead code; accent styling is already handled by the `accent` prop on the shared Button.

Adds a `LongConfirmButtonLabel` story to visually cover the wrapping case.

### Test plan

- `npx nx run twenty-front:typecheck` ✅
- `npx nx run twenty-front:lint` (incl. oxfmt) ✅


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/23946?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

