### PR TITLE
feat(email-composer): restyle the composer to the Send Email design

### DIFF
--- a/packages/twenty-front/src/modules/activities/emails/components/EmailAttachmentsField.tsx
+++ b/packages/twenty-front/src/modules/activities/emails/components/EmailAttachmentsField.tsx
@@ -1,45 +1,13 @@
 import { styled } from '@linaria/react';
-import { useLingui } from '@lingui/react/macro';
-import { useContext } from 'react';
 import { type EmailAttachment } from 'twenty-shared/types';
-import { isDefined } from 'twenty-shared/utils';
-import { IconUpload } from 'twenty-ui/icon';
-import { ThemeContext, themeCssVariables } from 'twenty-ui/theme-constants';
+import { themeCssVariables } from 'twenty-ui/theme-constants';
 
-import { useUploadEmailAttachment } from '@/activities/emails/hooks/useUploadEmailAttachment';
 import { AttachmentChip } from '@/file/components/AttachmentChip';
-import { useFileUpload } from '@/file-upload/hooks/useFileUpload';
-import { InputLabel } from '@/ui/input/components/InputLabel';
 
 type EmailAttachmentsFieldProps = {
   files: EmailAttachment[];
   onChange: (files: EmailAttachment[]) => void;
-  label?: string;
 };
-
-const StyledContainer = styled.div`
-  display: flex;
-  flex-direction: column;
-`;
-
-const StyledUploadArea = styled.div<{ hasFiles: boolean }>`
-  background-color: ${themeCssVariables.background.transparent.lighter};
-  border: 1px solid ${themeCssVariables.border.color.medium};
-  border-radius: ${themeCssVariables.border.radius.sm};
-  display: flex;
-  flex-direction: column;
-  justify-content: center;
-  min-height: ${({ hasFiles }) => (hasFiles ? 'auto' : '24px')};
-  padding-bottom: ${themeCssVariables.spacing[1]};
-  padding-left: ${themeCssVariables.spacing[2]};
-  padding-right: ${themeCssVariables.spacing[2]};
-  padding-top: ${themeCssVariables.spacing[1]};
-
-  &:hover {
-    background-color: ${themeCssVariables.background.transparent.light};
-    border-color: ${themeCssVariables.border.color.strong};
-  }
-`;
 
 const StyledChipsContainer = styled.div`
   display: flex;
@@ -48,73 +16,23 @@ const StyledChipsContainer = styled.div`
   gap: ${themeCssVariables.spacing[1]};
 `;
 
-const StyledUploadAreaLabel = styled.div`
-  color: ${themeCssVariables.font.color.tertiary};
-  display: flex;
-  font-size: ${themeCssVariables.font.size.sm};
-  font-weight: ${themeCssVariables.font.weight.medium};
-  gap: ${themeCssVariables.spacing[1]};
-  justify-content: center;
-`;
-
 export const EmailAttachmentsField = ({
   files,
-  label,
   onChange,
 }: EmailAttachmentsFieldProps) => {
-  const { theme } = useContext(ThemeContext);
-  const { uploadEmailAttachment } = useUploadEmailAttachment();
-  const { openFileUpload } = useFileUpload();
-  const { t } = useLingui();
-
-  const handleUploadFiles = async (filesToUpload: File[]) => {
-    const uploadedFiles = await Promise.all(
-      filesToUpload.map((file) => uploadEmailAttachment(file)),
-    );
-
-    const successfulUploads = uploadedFiles.filter(isDefined);
-
-    if (successfulUploads.length > 0) {
-      onChange([...files, ...successfulUploads]);
-    }
-  };
-
-  const handleAddFileClick = () => {
-    openFileUpload({
-      multiple: true,
-      onUpload: handleUploadFiles,
-    });
-  };
-
   const handleRemoveFile = (fileId: string) => {
     onChange(files.filter((file) => file.id !== fileId));
   };
 
   return (
-    <StyledContainer>
-      {label ? <InputLabel>{label}</InputLabel> : null}
-
-      <StyledUploadArea
-        hasFiles={files.length > 0}
-        onClick={handleAddFileClick}
-      >
-        {files.length > 0 ? (
-          <StyledChipsContainer>
-            {files.map((file) => (
-              <AttachmentChip
-                key={file.id}
-                file={file}
-                onRemove={() => handleRemoveFile(file.id)}
-              />
-            ))}
-          </StyledChipsContainer>
-        ) : (
-          <StyledUploadAreaLabel>
-            <IconUpload size={theme.icon.size.sm} />
-            <span>{t`Upload file`}</span>
-          </StyledUploadAreaLabel>
-        )}
-      </StyledUploadArea>
-    </StyledContainer>
+    <StyledChipsContainer>
+      {files.map((file) => (
+        <AttachmentChip
+          key={file.id}
+          file={file}
+          onRemove={() => handleRemoveFile(file.id)}
+        />
+      ))}
+    </StyledChipsContainer>
   );
 };

--- a/packages/twenty-front/src/modules/activities/emails/components/EmailComposerFieldRow.tsx
+++ b/packages/twenty-front/src/modules/activities/emails/components/EmailComposerFieldRow.tsx
@@ -40,13 +40,16 @@ type EmailComposerFieldRowProps = {
   trailing?: ReactNode;
 };
 
+// The visible label is a plain span, so it cannot be associated with whatever
+// control the row wraps. Naming the row as a group gives assistive technology
+// the field name even for controls that take no label of their own.
 export const EmailComposerFieldRow = ({
   label,
   children,
   trailing,
 }: EmailComposerFieldRowProps) => (
-  <StyledRow>
-    <StyledLabel>{label}</StyledLabel>
+  <StyledRow role="group" aria-label={label}>
+    <StyledLabel aria-hidden="true">{label}</StyledLabel>
     <StyledContent>{children}</StyledContent>
     {trailing}
   </StyledRow>

--- a/packages/twenty-front/src/modules/activities/emails/components/EmailComposerFieldRow.tsx
+++ b/packages/twenty-front/src/modules/activities/emails/components/EmailComposerFieldRow.tsx
@@ -1,0 +1,53 @@
+import { styled } from '@linaria/react';
+import { type ReactNode } from 'react';
+import { themeCssVariables } from 'twenty-ui/theme-constants';
+
+const ROW_MIN_HEIGHT = '40px';
+
+const StyledRow = styled.div`
+  align-items: center;
+  border-bottom: 1px solid ${themeCssVariables.border.color.light};
+  box-sizing: border-box;
+  display: flex;
+  gap: ${themeCssVariables.spacing[2]};
+  min-height: ${ROW_MIN_HEIGHT};
+  padding: ${themeCssVariables.spacing[1]} ${themeCssVariables.spacing[2]}
+    ${themeCssVariables.spacing[1]} ${themeCssVariables.spacing[3]};
+  width: 100%;
+
+  &:last-of-type {
+    border-bottom: none;
+  }
+`;
+
+const StyledLabel = styled.span`
+  color: ${themeCssVariables.font.color.tertiary};
+  flex-shrink: 0;
+  font-size: ${themeCssVariables.font.size.md};
+  font-weight: ${themeCssVariables.font.weight.regular};
+`;
+
+const StyledContent = styled.div`
+  align-items: center;
+  display: flex;
+  flex: 1;
+  min-width: 0;
+`;
+
+type EmailComposerFieldRowProps = {
+  label: string;
+  children: ReactNode;
+  trailing?: ReactNode;
+};
+
+export const EmailComposerFieldRow = ({
+  label,
+  children,
+  trailing,
+}: EmailComposerFieldRowProps) => (
+  <StyledRow>
+    <StyledLabel>{label}</StyledLabel>
+    <StyledContent>{children}</StyledContent>
+    {trailing}
+  </StyledRow>
+);

--- a/packages/twenty-front/src/modules/activities/emails/components/EmailComposerFields.tsx
+++ b/packages/twenty-front/src/modules/activities/emails/components/EmailComposerFields.tsx
@@ -1,8 +1,15 @@
 import { useQuery } from '@apollo/client/react';
 import { DragDropProvider } from '@dnd-kit/react';
 import { styled } from '@linaria/react';
+import { t } from '@lingui/core/macro';
+import { isDefined } from 'twenty-shared/utils';
+import { type SelectOption } from 'twenty-ui/input';
+import { themeCssVariables } from 'twenty-ui/theme-constants';
 
 import { EmailAttachmentsField } from '@/activities/emails/components/EmailAttachmentsField';
+import { EmailComposerFieldRow } from '@/activities/emails/components/EmailComposerFieldRow';
+import { INLINE_EMAIL_BODY_EDITOR_PROFILE } from '@/activities/emails/editor/constants/InlineEmailBodyEditorProfile';
+import { useUploadEmailImage } from '@/activities/emails/hooks/useUploadEmailImage';
 import { EmailRecipientsFieldInput } from '@/activities/emails/recipients/components/EmailRecipientsFieldInput';
 import { useEmailRecipientsDragAndDrop } from '@/activities/emails/recipients/hooks/useEmailRecipientsDragAndDrop';
 import { type EmailComposerContextRecord } from '@/activities/emails/recipients/types/EmailComposerContextRecord';
@@ -11,50 +18,75 @@ import { type EmailRecipientsFieldId } from '@/activities/emails/recipients/type
 import { getEmailRecipientKey } from '@/activities/emails/recipients/utils/getEmailRecipientKey';
 import { type EmailRecipientsByFieldId } from '@/activities/emails/recipients/utils/moveEmailRecipientsBetweenFields';
 import { type EmailComposerState } from '@/activities/emails/types/EmailComposerState';
-import { isDefined } from 'twenty-shared/utils';
+import { FormAdvancedTextFieldInput } from '@/advanced-text-editor/components/FormAdvancedTextFieldInput';
+import { FORM_FIELD_PLACEHOLDER_STYLES } from '@/ui/input/constants/FormFieldPlaceholderStyles';
+import { Select } from '@/ui/input/components/Select';
 import { DND_KIT_PROVIDER_PLUGINS_WITHOUT_DROP_ANIMATION } from '@/ui/utilities/drag-and-drop/constants/DndKitProviderPluginsWithoutDropAnimation';
 import { DND_KIT_SENSORS } from '@/ui/utilities/drag-and-drop/constants/DndKitSensors';
 import { DragDropItemDndContext } from '@/ui/utilities/drag-and-drop/context/DragDropItemDndContext';
-import { INLINE_EMAIL_BODY_EDITOR_PROFILE } from '@/activities/emails/editor/constants/InlineEmailBodyEditorProfile';
-import { useUploadEmailImage } from '@/activities/emails/hooks/useUploadEmailImage';
-import { FormAdvancedTextFieldInput } from '@/advanced-text-editor/components/FormAdvancedTextFieldInput';
-import { FormTextFieldInput } from '@/object-record/record-field/ui/form-types/components/FormTextFieldInput';
 import { GET_MY_CONNECTED_ACCOUNTS } from '@/settings/accounts/graphql/queries/getMyConnectedAccounts';
-import { Select } from '@/ui/input/components/Select';
-import { t } from '@lingui/core/macro';
-import { type SelectOption } from 'twenty-ui/input';
-import { themeCssVariables } from 'twenty-ui/theme-constants';
 
 const StyledFieldsContainer = styled.div`
   display: flex;
+  flex: 1;
   flex-direction: column;
-  gap: ${themeCssVariables.spacing[1]};
-  padding: ${themeCssVariables.spacing[3]} ${themeCssVariables.spacing[2]};
+  min-height: 0;
+  width: 100%;
 `;
 
-const StyledToRow = styled.div`
+const StyledHeaderRows = styled.div`
+  background-color: ${themeCssVariables.background.secondary};
+  border-bottom: 1px solid ${themeCssVariables.border.color.medium};
   display: flex;
   flex-direction: column;
-  position: relative;
+  width: 100%;
 `;
 
 const StyledCcBccToggle = styled.button`
   all: unset;
   color: ${themeCssVariables.font.color.tertiary};
   cursor: pointer;
-  font-size: ${themeCssVariables.font.size.xs};
-  position: absolute;
-  right: 0;
-  top: 0;
+  flex-shrink: 0;
+  font-size: ${themeCssVariables.font.size.md};
+  padding: 0 ${themeCssVariables.spacing[1]};
 
   &:hover {
     color: ${themeCssVariables.font.color.secondary};
   }
 `;
 
+const StyledSubjectInput = styled.input`
+  background: transparent;
+  border: none;
+  color: ${themeCssVariables.font.color.primary};
+  font-family: inherit;
+  font-size: ${themeCssVariables.font.size.md};
+  font-weight: ${themeCssVariables.font.weight.regular};
+  outline: none;
+  padding: 0;
+  width: 100%;
+
+  &::placeholder {
+    ${FORM_FIELD_PLACEHOLDER_STYLES}
+  }
+`;
+
+const StyledBody = styled.div`
+  display: flex;
+  flex: 1;
+  flex-direction: column;
+  min-height: 0;
+  padding: ${themeCssVariables.spacing[2]} ${themeCssVariables.spacing[3]};
+`;
+
+const StyledAttachments = styled.div`
+  padding: 0 ${themeCssVariables.spacing[3]} ${themeCssVariables.spacing[2]};
+`;
+
 const StyledRecipientLimitWarning = styled.div`
   color: ${themeCssVariables.color.red};
   font-size: ${themeCssVariables.font.size.xs};
+  padding: ${themeCssVariables.spacing[1]} ${themeCssVariables.spacing[3]};
 `;
 
 type EmailComposerFieldsProps = {
@@ -116,20 +148,11 @@ export const EmailComposerFields = ({
 
   const getDraggedIndicesForField = (fieldId: EmailRecipientsFieldId) =>
     draggedRecipients?.fieldId === fieldId ? draggedRecipients.indices : null;
+
   const areCcBccFieldsVisible = composerState.showCcBcc || isDraggingRecipients;
 
   return (
     <StyledFieldsContainer>
-      {hasMultipleAccounts && (
-        <Select
-          dropdownId="email-composer-from-account"
-          label={t`From`}
-          fullWidth
-          value={composerState.connectedAccountId}
-          options={accountOptions}
-          onChange={(value) => composerState.setConnectedAccountId(value)}
-        />
-      )}
       <DragDropItemDndContext.Provider value={contextValues}>
         <DragDropProvider<EmailRecipientDragData>
           sensors={DND_KIT_SENSORS}
@@ -138,52 +161,82 @@ export const EmailComposerFields = ({
           onDragMove={handlers.onDragMove}
           onDragEnd={handlers.onDragEnd}
         >
-          <StyledToRow>
-            <EmailRecipientsFieldInput
-              fieldId="to"
-              draggedSourceIndices={getDraggedIndicesForField('to')}
-              label={t`To`}
-              placeholder={t`Recipients`}
-              recipients={composerState.to}
-              onChange={composerState.setTo}
-              onSubmit={composerState.handleSend}
-              excludedSuggestionKeys={allRecipientKeys}
-              contextRecord={contextRecord}
-            />
-            {!areCcBccFieldsVisible && (
-              <StyledCcBccToggle
-                onClick={() => composerState.setShowCcBcc(true)}
-              >
-                {t`Cc/Bcc`}
-              </StyledCcBccToggle>
+          <StyledHeaderRows>
+            {hasMultipleAccounts && (
+              <EmailComposerFieldRow label={t`From`}>
+                <Select
+                  dropdownId="email-composer-from-account"
+                  fullWidth
+                  value={composerState.connectedAccountId}
+                  options={accountOptions}
+                  onChange={(value) =>
+                    composerState.setConnectedAccountId(value)
+                  }
+                />
+              </EmailComposerFieldRow>
             )}
-          </StyledToRow>
-          {areCcBccFieldsVisible && (
-            <>
+            <EmailComposerFieldRow
+              label={t`To`}
+              trailing={
+                !areCcBccFieldsVisible && (
+                  <StyledCcBccToggle
+                    onClick={() => composerState.setShowCcBcc(true)}
+                  >
+                    {t`Cc/Bcc`}
+                  </StyledCcBccToggle>
+                )
+              }
+            >
               <EmailRecipientsFieldInput
-                fieldId="cc"
-                draggedSourceIndices={getDraggedIndicesForField('cc')}
-                label={t`Cc`}
-                placeholder={t`Cc`}
-                recipients={composerState.cc}
-                onChange={composerState.setCc}
+                fieldId="to"
+                draggedSourceIndices={getDraggedIndicesForField('to')}
+                label={t`To`}
+                recipients={composerState.to}
+                onChange={composerState.setTo}
                 onSubmit={composerState.handleSend}
                 excludedSuggestionKeys={allRecipientKeys}
                 contextRecord={contextRecord}
               />
-              <EmailRecipientsFieldInput
-                fieldId="bcc"
-                draggedSourceIndices={getDraggedIndicesForField('bcc')}
-                label={t`Bcc`}
-                placeholder={t`Bcc`}
-                recipients={composerState.bcc}
-                onChange={composerState.setBcc}
-                onSubmit={composerState.handleSend}
-                excludedSuggestionKeys={allRecipientKeys}
-                contextRecord={contextRecord}
+            </EmailComposerFieldRow>
+            {areCcBccFieldsVisible && (
+              <>
+                <EmailComposerFieldRow label={t`Cc`}>
+                  <EmailRecipientsFieldInput
+                    fieldId="cc"
+                    draggedSourceIndices={getDraggedIndicesForField('cc')}
+                    label={t`Cc`}
+                    recipients={composerState.cc}
+                    onChange={composerState.setCc}
+                    onSubmit={composerState.handleSend}
+                    excludedSuggestionKeys={allRecipientKeys}
+                    contextRecord={contextRecord}
+                  />
+                </EmailComposerFieldRow>
+                <EmailComposerFieldRow label={t`Bcc`}>
+                  <EmailRecipientsFieldInput
+                    fieldId="bcc"
+                    draggedSourceIndices={getDraggedIndicesForField('bcc')}
+                    label={t`Bcc`}
+                    recipients={composerState.bcc}
+                    onChange={composerState.setBcc}
+                    onSubmit={composerState.handleSend}
+                    excludedSuggestionKeys={allRecipientKeys}
+                    contextRecord={contextRecord}
+                  />
+                </EmailComposerFieldRow>
+              </>
+            )}
+            <EmailComposerFieldRow label={t`Subject`}>
+              <StyledSubjectInput
+                type="text"
+                aria-label={t`Subject`}
+                defaultValue={composerState.initialSubject}
+                onChange={(event) =>
+                  composerState.setSubject(event.target.value)
+                }
               />
-            </>
-          )}
+            </EmailComposerFieldRow>
+          </StyledHeaderRows>
         </DragDropProvider>
       </DragDropItemDndContext.Provider>
       {composerState.exceedsRecipientLimit && (
@@ -191,24 +244,23 @@ export const EmailComposerFields = ({
           {t`Too many recipients (${composerState.recipientCount}/${composerState.maxRecipients}).`}
         </StyledRecipientLimitWarning>
       )}
-      <FormTextFieldInput
-        label={t`Subject`}
-        defaultValue={composerState.initialSubject}
-        onChange={composerState.setSubject}
-        placeholder={t`Subject`}
-      />
-      <FormAdvancedTextFieldInput
-        defaultValue={composerState.initialBody}
-        onChange={composerState.setBody}
-        placeholder={t`Type something or press "/" to see commands`}
-        profile={INLINE_EMAIL_BODY_EDITOR_PROFILE}
-        onImageUpload={uploadEmailImage}
-      />
-      <EmailAttachmentsField
-        label={t`Attachments`}
-        files={composerState.files}
-        onChange={composerState.setFiles}
-      />
+      <StyledBody>
+        <FormAdvancedTextFieldInput
+          defaultValue={composerState.initialBody}
+          onChange={composerState.setBody}
+          placeholder={t`Type something or press "/" to see commands`}
+          profile={INLINE_EMAIL_BODY_EDITOR_PROFILE}
+          onImageUpload={uploadEmailImage}
+        />
+      </StyledBody>
+      {composerState.files.length > 0 && (
+        <StyledAttachments>
+          <EmailAttachmentsField
+            files={composerState.files}
+            onChange={composerState.setFiles}
+          />
+        </StyledAttachments>
+      )}
     </StyledFieldsContainer>
   );
 };

--- a/packages/twenty-front/src/modules/activities/emails/components/EmailComposerFields.tsx
+++ b/packages/twenty-front/src/modules/activities/emails/components/EmailComposerFields.tsx
@@ -3,6 +3,7 @@ import { DragDropProvider } from '@dnd-kit/react';
 import { styled } from '@linaria/react';
 import { t } from '@lingui/core/macro';
 import { isDefined } from 'twenty-shared/utils';
+import { IconPaperclip } from 'twenty-ui/icon';
 import { type SelectOption } from 'twenty-ui/input';
 import { themeCssVariables } from 'twenty-ui/theme-constants';
 
@@ -80,7 +81,25 @@ const StyledBody = styled.div`
 `;
 
 const StyledAttachments = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: ${themeCssVariables.spacing[2]};
   padding: 0 ${themeCssVariables.spacing[3]} ${themeCssVariables.spacing[2]};
+`;
+
+const StyledAttachAction = styled.button`
+  align-items: center;
+  align-self: flex-start;
+  all: unset;
+  color: ${themeCssVariables.font.color.tertiary};
+  cursor: pointer;
+  display: flex;
+  font-size: ${themeCssVariables.font.size.md};
+  gap: ${themeCssVariables.spacing[1]};
+
+  &:hover {
+    color: ${themeCssVariables.font.color.secondary};
+  }
 `;
 
 const StyledRecipientLimitWarning = styled.div`
@@ -92,11 +111,15 @@ const StyledRecipientLimitWarning = styled.div`
 type EmailComposerFieldsProps = {
   composerState: EmailComposerState;
   contextRecord?: EmailComposerContextRecord | null;
+  // Surfaces without a composer footer of their own pass this so attaching
+  // stays reachable from inside the form.
+  onAttachFiles?: () => void;
 };
 
 export const EmailComposerFields = ({
   composerState,
   contextRecord,
+  onAttachFiles,
 }: EmailComposerFieldsProps) => {
   const { uploadEmailImage } = useUploadEmailImage();
   const { data: accountsData } = useQuery<{
@@ -253,12 +276,20 @@ export const EmailComposerFields = ({
           onImageUpload={uploadEmailImage}
         />
       </StyledBody>
-      {composerState.files.length > 0 && (
+      {(composerState.files.length > 0 || isDefined(onAttachFiles)) && (
         <StyledAttachments>
-          <EmailAttachmentsField
-            files={composerState.files}
-            onChange={composerState.setFiles}
-          />
+          {isDefined(onAttachFiles) && (
+            <StyledAttachAction type="button" onClick={onAttachFiles}>
+              <IconPaperclip size={14} />
+              {t`Attach files`}
+            </StyledAttachAction>
+          )}
+          {composerState.files.length > 0 && (
+            <EmailAttachmentsField
+              files={composerState.files}
+              onChange={composerState.setFiles}
+            />
+          )}
         </StyledAttachments>
       )}
     </StyledFieldsContainer>

--- a/packages/twenty-front/src/modules/activities/emails/components/EmailComposerFields.tsx
+++ b/packages/twenty-front/src/modules/activities/emails/components/EmailComposerFields.tsx
@@ -55,6 +55,11 @@ const StyledCcBccToggle = styled.button`
   &:hover {
     color: ${themeCssVariables.font.color.secondary};
   }
+
+  &:focus-visible {
+    outline: 2px solid ${themeCssVariables.color.blue};
+    outline-offset: 2px;
+  }
 `;
 
 const StyledSubjectInput = styled.input`
@@ -100,6 +105,11 @@ const StyledAttachAction = styled.button`
 
   &:hover {
     color: ${themeCssVariables.font.color.secondary};
+  }
+
+  &:focus-visible {
+    outline: 2px solid ${themeCssVariables.color.blue};
+    outline-offset: 2px;
   }
 `;
 

--- a/packages/twenty-front/src/modules/activities/emails/components/EmailComposerFields.tsx
+++ b/packages/twenty-front/src/modules/activities/emails/components/EmailComposerFields.tsx
@@ -1,11 +1,12 @@
 import { useQuery } from '@apollo/client/react';
+import { useContext } from 'react';
 import { DragDropProvider } from '@dnd-kit/react';
 import { styled } from '@linaria/react';
 import { t } from '@lingui/core/macro';
 import { isDefined } from 'twenty-shared/utils';
 import { IconPaperclip } from 'twenty-ui/icon';
 import { type SelectOption } from 'twenty-ui/input';
-import { themeCssVariables } from 'twenty-ui/theme-constants';
+import { ThemeContext, themeCssVariables } from 'twenty-ui/theme-constants';
 
 import { EmailAttachmentsField } from '@/activities/emails/components/EmailAttachmentsField';
 import { EmailComposerFieldRow } from '@/activities/emails/components/EmailComposerFieldRow';
@@ -121,6 +122,7 @@ export const EmailComposerFields = ({
   contextRecord,
   onAttachFiles,
 }: EmailComposerFieldsProps) => {
+  const { theme } = useContext(ThemeContext);
   const { uploadEmailImage } = useUploadEmailImage();
   const { data: accountsData } = useQuery<{
     myConnectedAccounts: { id: string; handle: string }[];
@@ -280,7 +282,7 @@ export const EmailComposerFields = ({
         <StyledAttachments>
           {isDefined(onAttachFiles) && (
             <StyledAttachAction type="button" onClick={onAttachFiles}>
-              <IconPaperclip size={14} />
+              <IconPaperclip size={theme.icon.size.sm} />
               {t`Attach files`}
             </StyledAttachAction>
           )}

--- a/packages/twenty-front/src/modules/activities/emails/editor/constants/InlineEmailBodyEditorProfile.ts
+++ b/packages/twenty-front/src/modules/activities/emails/editor/constants/InlineEmailBodyEditorProfile.ts
@@ -3,8 +3,6 @@ import { buildFullRichTextWithVariableTagExtensions } from '@/advanced-text-edit
 import { parseLegacyHtmlDocument } from '@/advanced-text-editor/utils/parseLegacyHtmlDocument';
 
 export const INLINE_EMAIL_BODY_EDITOR_PROFILE = {
-  // The composer body runs flush to the panel edges, so the editor paints no
-  // field border or background of its own.
   chrome: 'document',
   minHeight: 120,
   enableFullScreen: true,

--- a/packages/twenty-front/src/modules/activities/emails/editor/constants/InlineEmailBodyEditorProfile.ts
+++ b/packages/twenty-front/src/modules/activities/emails/editor/constants/InlineEmailBodyEditorProfile.ts
@@ -3,7 +3,9 @@ import { buildFullRichTextWithVariableTagExtensions } from '@/advanced-text-edit
 import { parseLegacyHtmlDocument } from '@/advanced-text-editor/utils/parseLegacyHtmlDocument';
 
 export const INLINE_EMAIL_BODY_EDITOR_PROFILE = {
-  chrome: 'field',
+  // The composer body runs flush to the panel edges, so the editor paints no
+  // field border or background of its own.
+  chrome: 'document',
   minHeight: 120,
   enableFullScreen: true,
   parseLegacyDocument: parseLegacyHtmlDocument,

--- a/packages/twenty-front/src/modules/activities/emails/hooks/__tests__/useAttachEmailFiles.test.ts
+++ b/packages/twenty-front/src/modules/activities/emails/hooks/__tests__/useAttachEmailFiles.test.ts
@@ -1,0 +1,119 @@
+import { act, renderHook, waitFor } from '@testing-library/react';
+import { type EmailAttachment } from 'twenty-shared/types';
+
+import { useAttachEmailFiles } from '@/activities/emails/hooks/useAttachEmailFiles';
+import { useUploadEmailAttachment } from '@/activities/emails/hooks/useUploadEmailAttachment';
+import { useFileUpload } from '@/file-upload/hooks/useFileUpload';
+
+jest.mock('@/activities/emails/hooks/useUploadEmailAttachment', () => ({
+  useUploadEmailAttachment: jest.fn(),
+}));
+
+jest.mock('@/file-upload/hooks/useFileUpload', () => ({
+  useFileUpload: jest.fn(),
+}));
+
+const mockUseUploadEmailAttachment = useUploadEmailAttachment as jest.Mock;
+const mockUseFileUpload = useFileUpload as jest.Mock;
+
+const buildAttachment = (id: string): EmailAttachment =>
+  ({ id, name: `${id}.pdf` }) as EmailAttachment;
+
+// Captures the onUpload callback the hook hands to the file picker, so a test
+// can drive an upload the way the picker would.
+const setup = (uploadEmailAttachment: jest.Mock) => {
+  let triggerUpload: ((files: File[]) => Promise<void>) | undefined;
+
+  mockUseUploadEmailAttachment.mockReturnValue({ uploadEmailAttachment });
+  mockUseFileUpload.mockReturnValue({
+    openFileUpload: ({
+      onUpload,
+    }: {
+      onUpload: (files: File[]) => Promise<void>;
+    }) => {
+      triggerUpload = onUpload;
+    },
+  });
+
+  const onFilesAttached = jest.fn();
+  const view = renderHook(() => useAttachEmailFiles({ onFilesAttached }));
+
+  act(() => {
+    view.result.current.openAttachmentPicker();
+  });
+
+  return { view, onFilesAttached, getTriggerUpload: () => triggerUpload };
+};
+
+describe('useAttachEmailFiles', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should flag uploads as pending until they resolve', async () => {
+    let resolveUpload: (attachment: EmailAttachment) => void = () => {};
+    const uploadEmailAttachment = jest.fn(
+      () =>
+        new Promise<EmailAttachment>((resolve) => {
+          resolveUpload = resolve;
+        }),
+    );
+
+    const { view, getTriggerUpload } = setup(uploadEmailAttachment);
+
+    expect(view.result.current.isUploadingAttachments).toBe(false);
+
+    let uploadPromise: Promise<void> | undefined;
+    act(() => {
+      uploadPromise = getTriggerUpload()?.([new File([], 'a.pdf')]);
+    });
+
+    await waitFor(() => {
+      expect(view.result.current.isUploadingAttachments).toBe(true);
+    });
+
+    await act(async () => {
+      resolveUpload(buildAttachment('a'));
+      await uploadPromise;
+    });
+
+    expect(view.result.current.isUploadingAttachments).toBe(false);
+  });
+
+  it('should append uploads against the latest attachments rather than a captured list', async () => {
+    const uploadEmailAttachment = jest.fn(async () => buildAttachment('new'));
+
+    const { onFilesAttached, getTriggerUpload } = setup(uploadEmailAttachment);
+
+    await act(async () => {
+      await getTriggerUpload()?.([new File([], 'new.pdf')]);
+    });
+
+    expect(onFilesAttached).toHaveBeenCalledTimes(1);
+
+    const appendToPreviousFiles = onFilesAttached.mock.calls[0][0];
+
+    // The setter is called with an updater, so whatever the list holds when the
+    // upload settles is what gets appended to.
+    expect(typeof appendToPreviousFiles).toBe('function');
+    expect(appendToPreviousFiles([buildAttachment('kept')])).toEqual([
+      buildAttachment('kept'),
+      buildAttachment('new'),
+    ]);
+  });
+
+  it('should not touch the attachments when every upload fails', async () => {
+    const uploadEmailAttachment = jest.fn(async () => undefined);
+
+    const { view, onFilesAttached, getTriggerUpload } = setup(
+      uploadEmailAttachment,
+    );
+
+    await act(async () => {
+      await getTriggerUpload()?.([new File([], 'broken.pdf')]);
+    });
+
+    expect(onFilesAttached).not.toHaveBeenCalled();
+    expect(view.result.current.isUploadingAttachments).toBe(false);
+  });
+});

--- a/packages/twenty-front/src/modules/activities/emails/hooks/useAttachEmailFiles.ts
+++ b/packages/twenty-front/src/modules/activities/emails/hooks/useAttachEmailFiles.ts
@@ -1,0 +1,36 @@
+import { type EmailAttachment } from 'twenty-shared/types';
+import { isDefined } from 'twenty-shared/utils';
+
+import { useUploadEmailAttachment } from '@/activities/emails/hooks/useUploadEmailAttachment';
+import { useFileUpload } from '@/file-upload/hooks/useFileUpload';
+
+type UseAttachEmailFilesArgs = {
+  files: EmailAttachment[];
+  onChange: (files: EmailAttachment[]) => void;
+};
+
+export const useAttachEmailFiles = ({
+  files,
+  onChange,
+}: UseAttachEmailFilesArgs) => {
+  const { uploadEmailAttachment } = useUploadEmailAttachment();
+  const { openFileUpload } = useFileUpload();
+
+  const handleUploadFiles = async (filesToUpload: File[]) => {
+    const uploadedFiles = await Promise.all(
+      filesToUpload.map((file) => uploadEmailAttachment(file)),
+    );
+
+    const successfulUploads = uploadedFiles.filter(isDefined);
+
+    if (successfulUploads.length > 0) {
+      onChange([...files, ...successfulUploads]);
+    }
+  };
+
+  const openAttachmentPicker = () => {
+    openFileUpload({ multiple: true, onUpload: handleUploadFiles });
+  };
+
+  return { openAttachmentPicker };
+};

--- a/packages/twenty-front/src/modules/activities/emails/hooks/useAttachEmailFiles.ts
+++ b/packages/twenty-front/src/modules/activities/emails/hooks/useAttachEmailFiles.ts
@@ -1,3 +1,4 @@
+import { type Dispatch, type SetStateAction } from 'react';
 import { type EmailAttachment } from 'twenty-shared/types';
 import { isDefined } from 'twenty-shared/utils';
 
@@ -5,13 +6,11 @@ import { useUploadEmailAttachment } from '@/activities/emails/hooks/useUploadEma
 import { useFileUpload } from '@/file-upload/hooks/useFileUpload';
 
 type UseAttachEmailFilesArgs = {
-  files: EmailAttachment[];
-  onChange: (files: EmailAttachment[]) => void;
+  onFilesAttached: Dispatch<SetStateAction<EmailAttachment[]>>;
 };
 
 export const useAttachEmailFiles = ({
-  files,
-  onChange,
+  onFilesAttached,
 }: UseAttachEmailFilesArgs) => {
   const { uploadEmailAttachment } = useUploadEmailAttachment();
   const { openFileUpload } = useFileUpload();
@@ -23,9 +22,17 @@ export const useAttachEmailFiles = ({
 
     const successfulUploads = uploadedFiles.filter(isDefined);
 
-    if (successfulUploads.length > 0) {
-      onChange([...files, ...successfulUploads]);
+    if (successfulUploads.length === 0) {
+      return;
     }
+
+    // Appended against the latest state rather than the list captured when the
+    // picker opened: an upload can finish after the user has removed or added
+    // other attachments.
+    onFilesAttached((previousFiles) => [
+      ...previousFiles,
+      ...successfulUploads,
+    ]);
   };
 
   const openAttachmentPicker = () => {

--- a/packages/twenty-front/src/modules/activities/emails/hooks/useAttachEmailFiles.ts
+++ b/packages/twenty-front/src/modules/activities/emails/hooks/useAttachEmailFiles.ts
@@ -1,4 +1,4 @@
-import { type Dispatch, type SetStateAction } from 'react';
+import { type Dispatch, type SetStateAction, useState } from 'react';
 import { type EmailAttachment } from 'twenty-shared/types';
 import { isDefined } from 'twenty-shared/utils';
 
@@ -14,8 +14,19 @@ export const useAttachEmailFiles = ({
 }: UseAttachEmailFilesArgs) => {
   const { uploadEmailAttachment } = useUploadEmailAttachment();
   const { openFileUpload } = useFileUpload();
+  const [pendingUploadCount, setPendingUploadCount] = useState(0);
 
   const handleUploadFiles = async (filesToUpload: File[]) => {
+    setPendingUploadCount((count) => count + 1);
+
+    try {
+      await appendUploadedFiles(filesToUpload);
+    } finally {
+      setPendingUploadCount((count) => count - 1);
+    }
+  };
+
+  const appendUploadedFiles = async (filesToUpload: File[]) => {
     const uploadedFiles = await Promise.all(
       filesToUpload.map((file) => uploadEmailAttachment(file)),
     );
@@ -39,5 +50,10 @@ export const useAttachEmailFiles = ({
     openFileUpload({ multiple: true, onUpload: handleUploadFiles });
   };
 
-  return { openAttachmentPicker };
+  // Attachments only join the draft once their upload resolves, so sending has
+  // to wait or the mail goes out without the file the user just picked.
+  return {
+    openAttachmentPicker,
+    isUploadingAttachments: pendingUploadCount > 0,
+  };
 };

--- a/packages/twenty-front/src/modules/activities/emails/recipients/components/EmailRecipientsFieldInput.tsx
+++ b/packages/twenty-front/src/modules/activities/emails/recipients/components/EmailRecipientsFieldInput.tsx
@@ -37,6 +37,7 @@ import { type EmailRecipientsFieldId } from '@/activities/emails/recipients/type
 import { getEmailRecipientKey } from '@/activities/emails/recipients/utils/getEmailRecipientKey';
 import { isValidEmailRecipientAddress } from '@/activities/emails/recipients/utils/isValidEmailRecipientAddress';
 import { parseEmailRecipients } from '@/activities/emails/recipients/utils/parseEmailRecipients';
+import { FormFieldInputContainer } from '@/ui/input/components/FormFieldInputContainer';
 import { FORM_FIELD_PLACEHOLDER_STYLES } from '@/ui/input/constants/FormFieldPlaceholderStyles';
 import { Dropdown } from '@/ui/layout/dropdown/components/Dropdown';
 import { useCloseDropdown } from '@/ui/layout/dropdown/hooks/useCloseDropdown';
@@ -99,12 +100,6 @@ const StyledInput = styled.input`
   &::placeholder {
     ${FORM_FIELD_PLACEHOLDER_STYLES}
   }
-`;
-
-const StyledFieldContainer = styled.div`
-  display: flex;
-  flex-direction: column;
-  width: 100%;
 `;
 
 type EmailRecipientsFieldInputProps = {
@@ -632,7 +627,7 @@ export const EmailRecipientsFieldInput = ({
   }
 
   return (
-    <StyledFieldContainer>
+    <FormFieldInputContainer>
       <Dropdown
         dropdownId={suggestionsDropdownId}
         dropdownPlacement="bottom-start"
@@ -659,6 +654,6 @@ export const EmailRecipientsFieldInput = ({
           />
         }
       />
-    </StyledFieldContainer>
+    </FormFieldInputContainer>
   );
 };

--- a/packages/twenty-front/src/modules/activities/emails/recipients/components/EmailRecipientsFieldInput.tsx
+++ b/packages/twenty-front/src/modules/activities/emails/recipients/components/EmailRecipientsFieldInput.tsx
@@ -37,9 +37,7 @@ import { type EmailRecipientsFieldId } from '@/activities/emails/recipients/type
 import { getEmailRecipientKey } from '@/activities/emails/recipients/utils/getEmailRecipientKey';
 import { isValidEmailRecipientAddress } from '@/activities/emails/recipients/utils/isValidEmailRecipientAddress';
 import { parseEmailRecipients } from '@/activities/emails/recipients/utils/parseEmailRecipients';
-import { FormFieldInputContainer } from '@/ui/input/components/FormFieldInputContainer';
 import { FORM_FIELD_PLACEHOLDER_STYLES } from '@/ui/input/constants/FormFieldPlaceholderStyles';
-import { InputLabel } from '@/ui/input/components/InputLabel';
 import { Dropdown } from '@/ui/layout/dropdown/components/Dropdown';
 import { useCloseDropdown } from '@/ui/layout/dropdown/hooks/useCloseDropdown';
 import { useOpenDropdown } from '@/ui/layout/dropdown/hooks/useOpenDropdown';
@@ -57,31 +55,31 @@ import { useAtomComponentStateValue } from '@/ui/utilities/state/jotai/hooks/use
 
 const SUGGESTIONS_SEARCH_DEBOUNCE_MS = 300;
 
+// The field sits inside a bordered composer row, so it carries no chrome of its
+// own; the drop-target tint is the only surface it paints.
 const StyledRowContainer = styled.div<{ $isDropTarget: boolean }>`
   align-content: flex-start;
   align-items: center;
   background-color: ${({ $isDropTarget }) =>
     $isDropTarget
       ? themeCssVariables.background.transparent.blue
-      : themeCssVariables.background.transparent.lighter};
-  border: 1px solid
-    ${({ $isDropTarget }) =>
-      $isDropTarget
-        ? themeCssVariables.color.blue
-        : themeCssVariables.border.color.medium};
-  border-radius: ${themeCssVariables.border.radius.md};
+      : 'transparent'};
+  border-radius: ${themeCssVariables.border.radius.sm};
   box-sizing: border-box;
   cursor: text;
   display: flex;
   flex-wrap: wrap;
   gap: ${themeCssVariables.spacing[1]};
   max-height: 96px;
-  min-height: 32px;
+  min-height: 24px;
+  outline: ${({ $isDropTarget }) =>
+    $isDropTarget ? `1px solid ${themeCssVariables.color.blue}` : 'none'};
+  outline-offset: -1px;
   overflow-y: auto;
-  padding: ${themeCssVariables.spacing[1]} ${themeCssVariables.spacing[2]};
+  padding: ${themeCssVariables.spacing[1]} 0;
   transition:
     background-color 120ms ease-out,
-    border-color 120ms ease-out;
+    outline-color 120ms ease-out;
   width: 100%;
 `;
 
@@ -103,13 +101,18 @@ const StyledInput = styled.input`
   }
 `;
 
+const StyledFieldContainer = styled.div`
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+`;
+
 type EmailRecipientsFieldInputProps = {
   fieldId: EmailRecipientsFieldId;
   // Indices being dragged out of this field, or null when the drag started
   // elsewhere.
   draggedSourceIndices: number[] | null;
   label: string;
-  placeholder: string;
   recipients: EmailRecipient[];
   onChange: (recipients: EmailRecipient[]) => void;
   onSubmit?: () => void;
@@ -121,7 +124,6 @@ export const EmailRecipientsFieldInput = ({
   fieldId,
   draggedSourceIndices,
   label,
-  placeholder,
   recipients,
   onChange,
   onSubmit,
@@ -581,9 +583,6 @@ export const EmailRecipientsFieldInput = ({
       role="combobox"
       aria-expanded={isDropdownOpen}
       aria-label={label}
-      placeholder={
-        recipients.length === 0 && !isEditing ? placeholder : undefined
-      }
       value={inputValue}
       onChange={(event) => handleInputChange(event.target.value)}
       onKeyDown={handleInputKeyDown}
@@ -633,8 +632,7 @@ export const EmailRecipientsFieldInput = ({
   }
 
   return (
-    <FormFieldInputContainer>
-      <InputLabel>{label}</InputLabel>
+    <StyledFieldContainer>
       <Dropdown
         dropdownId={suggestionsDropdownId}
         dropdownPlacement="bottom-start"
@@ -661,6 +659,6 @@ export const EmailRecipientsFieldInput = ({
           />
         }
       />
-    </FormFieldInputContainer>
+    </StyledFieldContainer>
   );
 };

--- a/packages/twenty-front/src/modules/page-layout/widgets/email-thread/components/EmailThreadComposer.tsx
+++ b/packages/twenty-front/src/modules/page-layout/widgets/email-thread/components/EmailThreadComposer.tsx
@@ -81,9 +81,11 @@ export const EmailThreadComposer = ({
 
   const { handleSend, canSend } = composerState;
 
-  const { openAttachmentPicker } = useAttachEmailFiles({
+  const { openAttachmentPicker, isUploadingAttachments } = useAttachEmailFiles({
     onFilesAttached: composerState.setFiles,
   });
+
+  const canSendReply = canSend && !isUploadingAttachments;
 
   const footerCommandMenuItems =
     useMemo((): SidePanelFooterCommandMenuItem[] => {
@@ -121,22 +123,22 @@ export const EmailThreadComposer = ({
           isPrimaryCTA: true,
           hotkeys: [getOsControlSymbol(), '⏎'],
           onClick: handleSend,
-          disabled: !canSend,
+          disabled: !canSendReply,
         },
       ];
     }, [
       isComposerOpen,
       handleSend,
-      canSend,
+      canSendReply,
       setIsComposerOpen,
       openAttachmentPicker,
     ]);
 
   const handleSendHotkey = useCallback(() => {
-    if (isComposerOpen && canSend) {
+    if (isComposerOpen && canSendReply) {
       handleSend();
     }
-  }, [isComposerOpen, canSend, handleSend]);
+  }, [isComposerOpen, canSendReply, handleSend]);
 
   useHotkeysOnFocusedElement({
     keys: ['ctrl+Enter,meta+Enter'],
@@ -153,7 +155,10 @@ export const EmailThreadComposer = ({
         />
       )}
       {isComposerOpen ? (
-        <EmailComposerFields composerState={composerState} />
+        <EmailComposerFields
+          composerState={composerState}
+          onAttachFiles={isInSidePanel ? undefined : openAttachmentPicker}
+        />
       ) : (
         !isInSidePanel && (
           <StyledReplyBar onClick={() => setIsComposerOpen(true)}>

--- a/packages/twenty-front/src/modules/page-layout/widgets/email-thread/components/EmailThreadComposer.tsx
+++ b/packages/twenty-front/src/modules/page-layout/widgets/email-thread/components/EmailThreadComposer.tsx
@@ -3,6 +3,7 @@ import { useCallback, useMemo } from 'react';
 
 import { EmailComposerFields } from '@/activities/emails/components/EmailComposerFields';
 import { useEmailComposerState } from '@/activities/emails/hooks/useEmailComposerState';
+import { useAttachEmailFiles } from '@/activities/emails/hooks/useAttachEmailFiles';
 import { type ReplyContextReady } from '@/activities/emails/hooks/useReplyContext';
 import { type EmailDraftPrefill } from '@/activities/emails/types/EmailDraftPrefill';
 import { EmailThreadComposerFooterEffect } from '@/page-layout/widgets/email-thread/components/EmailThreadComposerFooterEffect';
@@ -13,7 +14,12 @@ import { useHotkeysOnFocusedElement } from '@/ui/utilities/hotkey/hooks/useHotke
 import { t } from '@lingui/core/macro';
 import { CoreObjectNameSingular } from 'twenty-shared/types';
 import { isDefined } from 'twenty-shared/utils';
-import { IconArrowBackUp, IconSend, IconX } from 'twenty-ui/icon';
+import {
+  IconArrowBackUp,
+  IconPaperclip,
+  IconSend,
+  IconX,
+} from 'twenty-ui/icon';
 import { themeCssVariables } from 'twenty-ui/theme-constants';
 import { getOsControlSymbol } from 'twenty-ui/utilities';
 
@@ -75,6 +81,11 @@ export const EmailThreadComposer = ({
 
   const { handleSend, canSend } = composerState;
 
+  const { openAttachmentPicker } = useAttachEmailFiles({
+    files: composerState.files,
+    onChange: composerState.setFiles,
+  });
+
   const footerCommandMenuItems =
     useMemo((): SidePanelFooterCommandMenuItem[] => {
       if (!isComposerOpen) {
@@ -98,6 +109,13 @@ export const EmailThreadComposer = ({
           onClick: () => setIsComposerOpen(false),
         },
         {
+          id: 'attach-files',
+          label: t`Attach files`,
+          Icon: IconPaperclip,
+          isPinned: false,
+          onClick: openAttachmentPicker,
+        },
+        {
           id: 'send',
           label: t`Send`,
           Icon: IconSend,
@@ -107,7 +125,13 @@ export const EmailThreadComposer = ({
           disabled: !canSend,
         },
       ];
-    }, [isComposerOpen, handleSend, canSend, setIsComposerOpen]);
+    }, [
+      isComposerOpen,
+      handleSend,
+      canSend,
+      setIsComposerOpen,
+      openAttachmentPicker,
+    ]);
 
   const handleSendHotkey = useCallback(() => {
     if (isComposerOpen && canSend) {

--- a/packages/twenty-front/src/modules/page-layout/widgets/email-thread/components/EmailThreadComposer.tsx
+++ b/packages/twenty-front/src/modules/page-layout/widgets/email-thread/components/EmailThreadComposer.tsx
@@ -82,8 +82,7 @@ export const EmailThreadComposer = ({
   const { handleSend, canSend } = composerState;
 
   const { openAttachmentPicker } = useAttachEmailFiles({
-    files: composerState.files,
-    onChange: composerState.setFiles,
+    onFilesAttached: composerState.setFiles,
   });
 
   const footerCommandMenuItems =

--- a/packages/twenty-front/src/modules/side-panel/pages/compose-email/components/SidePanelComposeEmailPage.tsx
+++ b/packages/twenty-front/src/modules/side-panel/pages/compose-email/components/SidePanelComposeEmailPage.tsx
@@ -60,15 +60,17 @@ export const SidePanelComposeEmailPage = () => {
     onSent: goBackFromSidePanel,
   });
 
-  const { openAttachmentPicker } = useAttachEmailFiles({
+  const { openAttachmentPicker, isUploadingAttachments } = useAttachEmailFiles({
     onFilesAttached: composerState.setFiles,
   });
 
+  const canSend = composerState.canSend && !isUploadingAttachments;
+
   const handleSendHotkey = useCallback(() => {
-    if (composerState.canSend) {
+    if (canSend) {
       composerState.handleSend();
     }
-  }, [composerState]);
+  }, [canSend, composerState]);
 
   useHotkeysOnFocusedElement({
     keys: ['ctrl+Enter,meta+Enter'],
@@ -116,7 +118,7 @@ export const SidePanelComposeEmailPage = () => {
             Icon={IconSend}
             hotkeys={[getOsControlSymbol(), '⏎']}
             onClick={composerState.handleSend}
-            disabled={!composerState.canSend}
+            disabled={!canSend}
           />,
         ]}
       />

--- a/packages/twenty-front/src/modules/side-panel/pages/compose-email/components/SidePanelComposeEmailPage.tsx
+++ b/packages/twenty-front/src/modules/side-panel/pages/compose-email/components/SidePanelComposeEmailPage.tsx
@@ -14,9 +14,11 @@ import { useHotkeysOnFocusedElement } from '@/ui/utilities/hotkey/hooks/useHotke
 import { useAtomComponentStateValue } from '@/ui/utilities/state/jotai/hooks/useAtomComponentStateValue';
 import { styled } from '@linaria/react';
 import { t } from '@lingui/core/macro';
-import { IconSend } from 'twenty-ui/icon';
-import { Button } from 'twenty-ui/input';
+import { IconPaperclip, IconSend, IconTrash } from 'twenty-ui/icon';
+import { Button, IconButton } from 'twenty-ui/input';
 import { getOsControlSymbol } from 'twenty-ui/utilities';
+
+import { useAttachEmailFiles } from '@/activities/emails/hooks/useAttachEmailFiles';
 
 const StyledContainer = styled.div`
   display: flex;
@@ -58,6 +60,11 @@ export const SidePanelComposeEmailPage = () => {
     onSent: goBackFromSidePanel,
   });
 
+  const { openAttachmentPicker } = useAttachEmailFiles({
+    files: composerState.files,
+    onChange: composerState.setFiles,
+  });
+
   const handleSendHotkey = useCallback(() => {
     if (composerState.canSend) {
       composerState.handleSend();
@@ -85,12 +92,21 @@ export const SidePanelComposeEmailPage = () => {
       </StyledContent>
       <SidePanelFooter
         actions={[
-          <Button
-            key="cancel"
+          <IconButton
+            key="discard"
             size="small"
             variant="secondary"
-            title={t`Cancel`}
+            Icon={IconTrash}
+            ariaLabel={t`Discard`}
             onClick={goBackFromSidePanel}
+          />,
+          <IconButton
+            key="attach"
+            size="small"
+            variant="secondary"
+            Icon={IconPaperclip}
+            ariaLabel={t`Attach files`}
+            onClick={openAttachmentPicker}
           />,
           <Button
             key="send"

--- a/packages/twenty-front/src/modules/side-panel/pages/compose-email/components/SidePanelComposeEmailPage.tsx
+++ b/packages/twenty-front/src/modules/side-panel/pages/compose-email/components/SidePanelComposeEmailPage.tsx
@@ -61,8 +61,7 @@ export const SidePanelComposeEmailPage = () => {
   });
 
   const { openAttachmentPicker } = useAttachEmailFiles({
-    files: composerState.files,
-    onChange: composerState.setFiles,
+    onFilesAttached: composerState.setFiles,
   });
 
   const handleSendHotkey = useCallback(() => {


### PR DESCRIPTION
Follow-up to #23947 (now merged); rebased onto `main`, so this diff is design-only.

Implements the [Send Email frame](https://www.figma.com/design/xt8O9mFeLl46C5InWwoMrN/Twenty?node-id=110059-367827).

## Why

The composer stacked bordered form fields with labels above them. That reads as a settings form rather than a mail client, and it spent a lot of vertical space before the body — on a side panel that is mostly body.

## What

- **To / Cc / Bcc / Subject are flush 40px rows** on one `background/secondary` block, each with an inline label on the left and a `borders/light` hairline divider, closed by a `borders/medium` border under the block.
- **The body editor loses its field chrome** and runs to the panel edges, filling the remaining height.
- **Attachments move to the footer**: a paperclip action replaces the permanent "Upload file" box, alongside a discard action. Attachment chips still render under the body once files are attached.

## How

- New `EmailComposerFieldRow` owns the row shell (label, divider, 40px min-height). Rows grow when chips wrap rather than being pinned to 40px. Each row is a `role="group"` named by its label, so controls that take no label of their own — the From select — still reach assistive technology named.
- `EmailRecipientsFieldInput` stops painting its own border, background and label, since the row now provides them. Its drag drop-target highlight becomes a tint plus an inset outline so it still reads without a field border.
- The redundant `placeholder` prop is gone — the row label already names the field, so an empty To row reads exactly as `To` like the frame.
- The body uses the editor's existing `chrome: 'document'` profile variant instead of `'field'`; that flag already existed, so no new styling seam. `INLINE_EMAIL_BODY_EDITOR_PROFILE` is composer-only.
- Attaching is extracted into `useAttachEmailFiles`, shared by both composer surfaces. It appends with a functional update so an upload finishing after the user removed a file can't resurrect it, and it exposes an in-flight flag so Send is held until uploads settle — otherwise sending straight after picking a file sent the mail without it. The email-thread reply renders an inline attach action when it has no footer to register one on.

Figma tokens map 1:1 onto existing theme tokens (`background/secondary`, `borders/light`, `borders/medium`, `text/tertiary`, `text/light`, 13px = `font.size.md`), so nothing new was introduced. Icons come from the project's Tabler set rather than exported assets.

## Deliberately not included

- **The sparkles (AI) action and the Send split-button chevron** in the frame have no behaviour behind them today; a dead control would be worse than leaving them out.
- **The From row keeps a real select control** rather than flattening to text — it is a dropdown, and it only appears when the account has more than one connected mailbox (the frame has no From row).
- **The panel header** is the shared `SidePanelTopBar`, used by every side panel page, so it is out of scope for a composer change.

## Testing

- The 15 Playwright checks from #23947 (multi-select, drag-to-reorder, cross-field drag, selection following a reorder, mid-drag Cc reveal, drop-target highlight) all still pass against the redesigned markup, so the interaction work survives the restyle.
- 98 unit tests pass across the emails module, including a new `renderHook` suite for `useAttachEmailFiles` covering the pending-upload flag, the race-safe append, and the failed-upload path.
- `nx typecheck twenty-front`, `oxlint --type-aware`, and `oxfmt --check` are clean, re-run after the rebase onto `main`.