### PR TITLE
fix(slack): cap prose record lists at the number the worker summarizes

### DIFF
--- a/packages/twenty-apps/public/slack/src/constants/__tests__/default-slack-assistant-prompt.test.ts
+++ b/packages/twenty-apps/public/slack/src/constants/__tests__/default-slack-assistant-prompt.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from 'vitest';
+
+import { DEFAULT_SLACK_ASSISTANT_PROMPT } from 'src/constants/default-slack-assistant-prompt';
+import { SLACK_RECORD_SUMMARY_MAX_COUNT } from 'src/constants/slack-record-summary-max-count';
+
+describe('DEFAULT_SLACK_ASSISTANT_PROMPT', () => {
+  it('should cap its record list at the count the worker renders summaries for', () => {
+    expect(DEFAULT_SLACK_ASSISTANT_PROMPT).toContain(
+      `List at most ${SLACK_RECORD_SUMMARY_MAX_COUNT} records`,
+    );
+  });
+
+  it('should not name any other record list cap', () => {
+    const listCaps = [
+      ...DEFAULT_SLACK_ASSISTANT_PROMPT.matchAll(/List at most (\d+) records/g),
+    ].map(([, count]) => Number(count));
+
+    expect(listCaps).toEqual([SLACK_RECORD_SUMMARY_MAX_COUNT]);
+  });
+});

--- a/packages/twenty-apps/public/slack/src/constants/default-slack-assistant-prompt.ts
+++ b/packages/twenty-apps/public/slack/src/constants/default-slack-assistant-prompt.ts
@@ -1,3 +1,5 @@
+import { SLACK_RECORD_SUMMARY_MAX_COUNT } from 'src/constants/slack-record-summary-max-count';
+
 export const DEFAULT_SLACK_ASSISTANT_PROMPT = `You are Twenty's CRM assistant in Slack. Members @mention you in a channel or message you in a DM.
 
 Slack reply style:
@@ -13,7 +15,7 @@ Presenting records:
 - Each record you link is summarized under your reply with its headline fields, so never dump a record's fields into prose; write only the values that answer the question
 - When the whole answer is a list of records, open with one lead line carrying the count and any meaningful total, then one bullet per record: the linked name plus the asked-about value, nothing more
 - Never write Markdown tables; they render poorly in Slack, especially on mobile
-- List at most 7 records, most relevant first, closing with "and N more" telling the member where to see the rest in Twenty
+- List at most ${SLACK_RECORD_SUMMARY_MAX_COUNT} records, most relevant first, closing with "and N more" telling the member where to see the rest in Twenty
 - Write amounts with the currency symbol and thousands separators, like $12,500
 - Write dates as "Jan 5" with the year only when it is not the current year
 - Write field values as plain words, never API names: "Todo", not "TODO"; "New lead", not "NEW_LEAD"

--- a/packages/twenty-apps/public/slack/src/constants/slack-record-summary-max-count.ts
+++ b/packages/twenty-apps/public/slack/src/constants/slack-record-summary-max-count.ts
@@ -1,0 +1,5 @@
+// how many records a reply may present: the prompt caps its record list at
+// this many, and the worker renders one summary attachment per listed record.
+// both sides read this constant so a reply can never list records the
+// summaries silently drop.
+export const SLACK_RECORD_SUMMARY_MAX_COUNT = 5;

--- a/packages/twenty-apps/public/slack/src/logic-functions/utils/build-slack-record-attachments.ts
+++ b/packages/twenty-apps/public/slack/src/logic-functions/utils/build-slack-record-attachments.ts
@@ -1,6 +1,7 @@
 import { type MessageAttachment, type SectionBlock } from '@slack/web-api';
 import { isNonEmptyArray } from '@sniptt/guards';
 
+import { SLACK_RECORD_SUMMARY_MAX_COUNT } from 'src/constants/slack-record-summary-max-count';
 import {
   type SlackRecordDetails,
   type SlackRecordField,
@@ -10,7 +11,6 @@ import { type SlackRecordReference } from 'src/logic-functions/types/slack-recor
 // Twenty's accent (Radix indigo9), rendered as the attachment's left bar
 const RECORD_ACCENT_COLOR = '#3E63DD';
 
-const RECORD_ATTACHMENT_MAX_COUNT = 5;
 const RECORD_NAME_MAX_LENGTH = 150;
 
 const ELLIPSIS = '…';
@@ -90,7 +90,7 @@ export const buildSlackRecordAttachments = ({
   // subject; a truncated sample would only add noise
   if (
     !isNonEmptyArray(references) ||
-    references.length > RECORD_ATTACHMENT_MAX_COUNT
+    references.length > SLACK_RECORD_SUMMARY_MAX_COUNT
   ) {
     return [];
   }


### PR DESCRIPTION
## Problem

The reply prompt and the summary renderer disagreed on how many records a reply may present:

- the prompt told the model to *"List at most **7** records"*
- `build-slack-record-attachments` renders nothing at all when a reply references more than **5**

So a 6- or 7-record list answer — exactly the shape the prompt is written to produce, and exactly the case where the summaries are meant to *be* the answer rather than decoration — silently rendered no summaries and degraded to bare prose bullets. Nothing surfaced the mismatch: no error, no log, just a plainer reply.

The 5 was itself inherited rather than chosen: it started as a cap on the carousel in the original card design (max 10 cards) and survived two redesigns unchanged.

## Change

One `SLACK_RECORD_SUMMARY_MAX_COUNT` constant, read by both sides — the prompt interpolates it into its list rule, the attachment builder uses it as its threshold. The value stays 5: each summary is a full section with a field grid, so seven of them plus seven prose bullets makes a very tall message, and a lower cap puts *"and N more in Twenty"* to work sooner.

A guard test asserts the prompt names that count and no other, so the two cannot drift apart again — same pattern as the existing status-step spacing invariant.

## Stacking

Based on `feat/slack-answer-blocks` (#23888), which is itself stacked on #23886 → #23838. Retargets down the chain as its parents land.

## Testing

111 unit tests in the app (2 new), typecheck and lint clean.

---
_Generated by [Claude Code](https://claude.ai/code/session_018LvBc8LRgRbWrGYyj6TQaA)_

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/23949?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

