### PR TITLE
Fix record title crash on non-string value (trim is not a function)

### DIFF
--- a/packages/twenty-front/src/modules/object-record/record-title-cell/components/RecordTitleCellTextFieldDisplay.tsx
+++ b/packages/twenty-front/src/modules/object-record/record-title-cell/components/RecordTitleCellTextFieldDisplay.tsx
@@ -64,11 +64,7 @@ export const RecordTitleCellSingleTextDisplayMode = ({
       {isEmpty ? (
         <StyledEmptyText>{t`Untitled`}</StyledEmptyText>
       ) : (
-        <OverflowingTextWithTooltip
-          text={
-            isNonEmptyString(fieldValue) ? fieldValue : fieldDefinition.label
-          }
-        />
+        <OverflowingTextWithTooltip text={fieldValue} />
       )}
     </StyledDiv>
   );

--- a/packages/twenty-front/src/modules/object-record/record-title-cell/components/RecordTitleCellTextFieldDisplay.tsx
+++ b/packages/twenty-front/src/modules/object-record/record-title-cell/components/RecordTitleCellTextFieldDisplay.tsx
@@ -6,8 +6,8 @@ import { getRecordFieldInputInstanceId } from '@/object-record/utils/getRecordFi
 import { useAtomFamilyStateValue } from '@/ui/utilities/state/jotai/hooks/useAtomFamilyStateValue';
 import { styled } from '@linaria/react';
 import { t } from '@lingui/core/macro';
+import { isNonEmptyString } from '@sniptt/guards';
 import { useContext } from 'react';
-import { isDefined } from 'twenty-shared/utils';
 import { OverflowingTextWithTooltip } from 'twenty-ui/surfaces';
 import { themeCssVariables } from 'twenty-ui/theme-constants';
 
@@ -43,7 +43,7 @@ export const RecordTitleCellSingleTextDisplayMode = ({
   const recordStore = useAtomFamilyStateValue(recordStoreFamilyState, recordId);
 
   const fieldValue = recordStore?.[fieldDefinition.metadata.fieldName];
-  const isEmpty = !isDefined(fieldValue) || fieldValue.trim() === '';
+  const isEmpty = !isNonEmptyString(fieldValue) || fieldValue.trim() === '';
 
   const { openRecordTitleCell } = useRecordTitleCell();
 
@@ -66,8 +66,7 @@ export const RecordTitleCellSingleTextDisplayMode = ({
       ) : (
         <OverflowingTextWithTooltip
           text={
-            recordStore?.[fieldDefinition.metadata.fieldName] ||
-            fieldDefinition.label
+            isNonEmptyString(fieldValue) ? fieldValue : fieldDefinition.label
           }
         />
       )}


### PR DESCRIPTION
## Problem

Opening a Company details page can crash the whole app with `TypeError: r.trim is not a function`, showing "Sorry, something went wrong". Once the React error boundary trips, other pages break too.

Fixes #23928.

## Root cause

`RecordTitleCellSingleTextDisplayMode` only renders when `isFieldText(fieldDefinition)` is true, which checks *only* the field metadata `type === TEXT`. It never validates the actual store value. The empty check was:

```ts
const isEmpty = !isDefined(fieldValue) || fieldValue.trim() === '';
```

`isDefined` excludes `null`/`undefined` but not non-strings, so any defined non-string value under the title field (number, boolean, object) reaches `.trim()` and throws. The same raw value was also passed straight into `OverflowingTextWithTooltip`.

## Fix

Guard with `isNonEmptyString` (matching the sibling `RecordTitleFullNameFieldDisplay`) so non-string values safely fall back to "Untitled" / the field label instead of crashing.

## Notes

The exact per-record data that produced a non-string under a TEXT-typed identifier isn't in the issue (likely stale/mismatched metadata after a self-host upgrade, or malformed cache data). This PR removes the crash regardless of which produced it.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/23950?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

