### PR TITLE
feat(slack): summarize referenced records under the answer

### DIFF
--- a/packages/twenty-apps/public/slack/src/logic-functions/constants/slack-assistant-failure-text.ts
+++ b/packages/twenty-apps/public/slack/src/logic-functions/constants/slack-assistant-failure-text.ts
@@ -1,2 +1,2 @@
 export const SLACK_ASSISTANT_FAILURE_TEXT =
-  'Sorry, I could not complete that request. An admin can check the Slack Assistant Request record in Twenty for details.';
+  'Sorry, I could not complete that request. Try again or rephrase it; an admin can check the Slack Assistant Request record in Twenty for details.';

--- a/packages/twenty-apps/public/slack/src/logic-functions/slack-assistant-worker.ts
+++ b/packages/twenty-apps/public/slack/src/logic-functions/slack-assistant-worker.ts
@@ -20,11 +20,14 @@ import { buildSlackAssistantAnswerBlocks } from 'src/logic-functions/utils/build
 import { buildSlackAssistantAnswerText } from 'src/logic-functions/utils/build-slack-assistant-answer-text';
 import { buildSlackAssistantPrompt } from 'src/logic-functions/utils/build-slack-assistant-prompt';
 import { buildSlackAssistantRequestName } from 'src/logic-functions/utils/build-slack-assistant-request-name';
+import { buildSlackRecordAttachments } from 'src/logic-functions/utils/build-slack-record-attachments';
 import { extractAgentResponseText } from 'src/logic-functions/utils/extract-agent-response-text';
+import { fetchSlackRecordDetails } from 'src/logic-functions/utils/fetch-slack-record-details';
 import { fetchSlackAssistantContext } from 'src/logic-functions/utils/fetch-slack-assistant-context';
 import { fetchWorkspaceBaseUrl } from 'src/logic-functions/utils/fetch-workspace-base-url';
 import { finishSlackAssistantRequestWithFailure } from 'src/logic-functions/utils/finish-slack-assistant-request-with-failure';
 import { getSlackAssistantParentMessageTimestamp } from 'src/logic-functions/utils/get-slack-assistant-parent-message-timestamp';
+import { parseSlackRecordReferences } from 'src/logic-functions/utils/parse-slack-record-references';
 import { runSlackAssistantAgentWithProgress } from 'src/logic-functions/utils/run-slack-assistant-agent-with-progress';
 import { setSlackAssistantThreadTitle } from 'src/logic-functions/utils/set-slack-assistant-thread-title';
 import { subscribeSlackThread } from 'src/logic-functions/utils/subscribe-slack-thread';
@@ -117,6 +120,23 @@ export const slackAssistantWorkerHandler = async (
       });
     }
 
+    // over the markdown block limit the answer posts without blocks, so
+    // skip the record-card queries entirely
+    const isWithinBlockLimit =
+      responseText.length <= SLACK_MARKDOWN_BLOCK_MAX_LENGTH;
+
+    const recordReferences = isWithinBlockLimit
+      ? parseSlackRecordReferences({ responseText, workspaceBaseUrl })
+      : [];
+
+    const recordAttachments = buildSlackRecordAttachments({
+      references: recordReferences,
+      detailsByRecordId: await fetchSlackRecordDetails(
+        client,
+        recordReferences,
+      ),
+    });
+
     const durationMilliseconds = Date.now() - startedAt;
 
     const deliveryResult = await slackPostMessageHandler({
@@ -127,13 +147,13 @@ export const slackAssistantWorkerHandler = async (
       }),
       parentMessageTimestamp,
       messageFormat: 'markdown',
-      messageBlocks:
-        responseText.length > SLACK_MARKDOWN_BLOCK_MAX_LENGTH
-          ? undefined
-          : buildSlackAssistantAnswerBlocks({
-              responseText,
-              durationMilliseconds,
-            }),
+      messageBlocks: isWithinBlockLimit
+        ? buildSlackAssistantAnswerBlocks({
+            responseText,
+            durationMilliseconds,
+          })
+        : undefined,
+      messageAttachments: isWithinBlockLimit ? recordAttachments : undefined,
     });
 
     if (!deliveryResult.success) {

--- a/packages/twenty-apps/public/slack/src/logic-functions/types/slack-chat-message-body-fields.type.ts
+++ b/packages/twenty-apps/public/slack/src/logic-functions/types/slack-chat-message-body-fields.type.ts
@@ -1,9 +1,10 @@
-import { type KnownBlock } from '@slack/web-api';
+import { type KnownBlock, type MessageAttachment } from '@slack/web-api';
 
 export type SlackChatMessageBodyFields =
   | {
       blocks: KnownBlock[];
       text: string;
+      attachments?: MessageAttachment[];
       markdown_text?: never;
       mrkdwn?: never;
     }
@@ -11,11 +12,13 @@ export type SlackChatMessageBodyFields =
       markdown_text: string;
       blocks?: never;
       text?: never;
+      attachments?: never;
       mrkdwn?: never;
     }
   | {
       text: string;
       blocks?: never;
       markdown_text?: never;
+      attachments?: never;
       mrkdwn?: boolean;
     };

--- a/packages/twenty-apps/public/slack/src/logic-functions/types/slack-message-body.type.ts
+++ b/packages/twenty-apps/public/slack/src/logic-functions/types/slack-message-body.type.ts
@@ -1,8 +1,9 @@
-import { type KnownBlock } from '@slack/web-api';
+import { type KnownBlock, type MessageAttachment } from '@slack/web-api';
 
 import { type SlackMessageBodyFormat } from 'src/logic-functions/types/slack-message-body-format.type';
 
 export type SlackMessageBody = {
   messageFormat?: SlackMessageBodyFormat;
   messageBlocks?: KnownBlock[];
+  messageAttachments?: MessageAttachment[];
 };

--- a/packages/twenty-apps/public/slack/src/logic-functions/types/slack-record-details.type.ts
+++ b/packages/twenty-apps/public/slack/src/logic-functions/types/slack-record-details.type.ts
@@ -1,0 +1,9 @@
+export type SlackRecordField = {
+  label: string;
+  value: string;
+};
+
+export type SlackRecordDetails = {
+  fields: SlackRecordField[];
+  imageUrl?: string;
+};

--- a/packages/twenty-apps/public/slack/src/logic-functions/types/slack-record-reference.type.ts
+++ b/packages/twenty-apps/public/slack/src/logic-functions/types/slack-record-reference.type.ts
@@ -1,0 +1,6 @@
+export type SlackRecordReference = {
+  objectNameSingular: string;
+  recordId: string;
+  recordName: string;
+  recordUrl: string;
+};

--- a/packages/twenty-apps/public/slack/src/logic-functions/utils/__tests__/build-slack-record-attachments.test.ts
+++ b/packages/twenty-apps/public/slack/src/logic-functions/utils/__tests__/build-slack-record-attachments.test.ts
@@ -1,0 +1,196 @@
+import { describe, expect, it } from 'vitest';
+
+import { type SlackRecordDetails } from 'src/logic-functions/types/slack-record-details.type';
+import { type SlackRecordReference } from 'src/logic-functions/types/slack-record-reference.type';
+import { buildSlackRecordAttachments } from 'src/logic-functions/utils/build-slack-record-attachments';
+
+const buildReference = (index: number): SlackRecordReference => ({
+  objectNameSingular: 'company',
+  recordId: `20202020-0000-4000-8000-00000000000${index}`,
+  recordName: `Company ${index}`,
+  recordUrl: `https://acme.twenty.com/object/company/20202020-0000-4000-8000-00000000000${index}`,
+});
+
+const buildDetails = (
+  overrides: Partial<SlackRecordDetails> = {},
+): SlackRecordDetails => ({
+  fields: [{ label: 'Domain', value: 'acme.com' }],
+  ...overrides,
+});
+
+describe('buildSlackRecordAttachments', () => {
+  it('should return no attachments without references', () => {
+    expect(
+      buildSlackRecordAttachments({
+        references: [],
+        detailsByRecordId: new Map(),
+      }),
+    ).toEqual([]);
+  });
+
+  it('should render a record as an accent-bar attachment with a linked name and field grid', () => {
+    const reference = buildReference(1);
+
+    const attachments = buildSlackRecordAttachments({
+      references: [reference],
+      detailsByRecordId: new Map([
+        [
+          reference.recordId,
+          buildDetails({
+            fields: [
+              { label: 'Domain', value: 'acme.com' },
+              { label: 'Annual revenue', value: '$2,000,000' },
+            ],
+          }),
+        ],
+      ]),
+    });
+
+    expect(attachments).toEqual([
+      {
+        color: '#3E63DD',
+        fallback: 'Company 1',
+        blocks: [
+          {
+            type: 'section',
+            text: {
+              type: 'mrkdwn',
+              text: `*<${reference.recordUrl}|Company 1>*   ·   Company`,
+            },
+            fields: [
+              { type: 'mrkdwn', text: '*Domain*\nacme.com' },
+              { type: 'mrkdwn', text: '*Annual revenue*\n$2,000,000' },
+            ],
+          },
+        ],
+      },
+    ]);
+  });
+
+  it('should attach the company logo as an accessory image when resolved', () => {
+    const reference = buildReference(1);
+
+    const attachments = buildSlackRecordAttachments({
+      references: [reference],
+      detailsByRecordId: new Map([
+        [
+          reference.recordId,
+          buildDetails({ imageUrl: 'https://favicon.example/acme.png' }),
+        ],
+      ]),
+    });
+
+    expect(attachments[0].blocks?.[0]).toMatchObject({
+      accessory: {
+        type: 'image',
+        image_url: 'https://favicon.example/acme.png',
+        alt_text: 'Company 1 logo',
+      },
+    });
+  });
+
+  it('should skip records that resolved no fields instead of rendering an empty bar', () => {
+    const withFields = buildReference(1);
+    const withoutFields = buildReference(2);
+
+    const attachments = buildSlackRecordAttachments({
+      references: [withFields, withoutFields],
+      detailsByRecordId: new Map([
+        [withFields.recordId, buildDetails()],
+        [withoutFields.recordId, buildDetails({ fields: [] })],
+      ]),
+    });
+
+    expect(attachments).toHaveLength(1);
+    expect(attachments[0].fallback).toBe('Company 1');
+  });
+
+  it('should render nothing when no record resolved fields', () => {
+    const attachments = buildSlackRecordAttachments({
+      references: [buildReference(1)],
+      detailsByRecordId: new Map(),
+    });
+
+    expect(attachments).toEqual([]);
+  });
+
+  it('should render one attachment per record', () => {
+    const references = [buildReference(1), buildReference(2), buildReference(3)];
+
+    const attachments = buildSlackRecordAttachments({
+      references,
+      detailsByRecordId: new Map(
+        references.map((reference) => [reference.recordId, buildDetails()]),
+      ),
+    });
+
+    expect(attachments.map((attachment) => attachment.fallback)).toEqual([
+      'Company 1',
+      'Company 2',
+      'Company 3',
+    ]);
+  });
+
+  it('should render no attachments when more records are referenced than the cap', () => {
+    const references = Array.from({ length: 8 }, (_, index) =>
+      buildReference(index),
+    );
+
+    const attachments = buildSlackRecordAttachments({
+      references,
+      detailsByRecordId: new Map(
+        references.map((reference) => [reference.recordId, buildDetails()]),
+      ),
+    });
+
+    expect(attachments).toEqual([]);
+  });
+
+  it('should escape mrkdwn control characters in names and field values', () => {
+    const reference = {
+      ...buildReference(1),
+      recordName: 'Acme <Group> & Co',
+    };
+
+    const attachments = buildSlackRecordAttachments({
+      references: [reference],
+      detailsByRecordId: new Map([
+        [
+          reference.recordId,
+          buildDetails({
+            fields: [{ label: 'Domain', value: 'a<b>.com & more' }],
+          }),
+        ],
+      ]),
+    });
+
+    expect(attachments[0].blocks?.[0]).toMatchObject({
+      text: {
+        text: `*<${reference.recordUrl}|Acme &lt;Group&gt; &amp; Co>*   ·   Company`,
+      },
+      fields: [{ type: 'mrkdwn', text: '*Domain*\na&lt;b&gt;.com &amp; more' }],
+    });
+  });
+
+  it('should truncate long names without splitting an escaped entity', () => {
+    const reference = {
+      ...buildReference(1),
+      recordName: `${'x'.repeat(146)} & Co`,
+    };
+
+    const attachments = buildSlackRecordAttachments({
+      references: [reference],
+      detailsByRecordId: new Map([[reference.recordId, buildDetails()]]),
+    });
+
+    const section = attachments[0].blocks?.[0] as {
+      text: { text: string };
+    };
+    const text = section.text.text;
+    const linkedName = text.slice(text.indexOf('|') + 1, text.indexOf('>*'));
+
+    expect(linkedName.length).toBeLessThanOrEqual(150);
+    expect(linkedName).not.toMatch(/&(?!amp;|lt;|gt;)/);
+    expect(linkedName.endsWith('…')).toBe(true);
+  });
+});

--- a/packages/twenty-apps/public/slack/src/logic-functions/utils/__tests__/fetch-slack-record-details.test.ts
+++ b/packages/twenty-apps/public/slack/src/logic-functions/utils/__tests__/fetch-slack-record-details.test.ts
@@ -1,0 +1,179 @@
+import { describe, expect, it, vi } from 'vitest';
+import { type CoreApiClient } from 'twenty-client-sdk/core';
+
+import { type SlackRecordReference } from 'src/logic-functions/types/slack-record-reference.type';
+import { fetchSlackRecordDetails } from 'src/logic-functions/utils/fetch-slack-record-details';
+
+const OPPORTUNITY_ID = '20202020-89ab-4cde-8f01-234567890abc';
+const COMPANY_ID = '20202020-1234-4abc-9def-567890abcdef';
+
+const buildReference = (
+  objectNameSingular: string,
+  recordId: string,
+): SlackRecordReference => ({
+  objectNameSingular,
+  recordId,
+  recordName: 'Some record',
+  recordUrl: `https://acme.twenty.com/object/${objectNameSingular}/${recordId}`,
+});
+
+const buildClient = (
+  queryMock: ReturnType<typeof vi.fn>,
+): CoreApiClient => ({ query: queryMock }) as unknown as CoreApiClient;
+
+describe('fetchSlackRecordDetails', () => {
+  it('should resolve formatted fields for an opportunity', async () => {
+    const queryMock = vi.fn().mockResolvedValue({
+      opportunities: {
+        edges: [
+          {
+            node: {
+              id: OPPORTUNITY_ID,
+              stage: 'NEW_LEAD',
+              amount: { amountMicros: 12500000000, currencyCode: 'USD' },
+              closeDate: '2099-01-05T00:00:00.000Z',
+            },
+          },
+        ],
+      },
+    });
+
+    const details = await fetchSlackRecordDetails(buildClient(queryMock), [
+      buildReference('opportunity', OPPORTUNITY_ID),
+    ]);
+
+    expect(details.get(OPPORTUNITY_ID)).toEqual({
+      fields: [
+        { label: 'Stage', value: 'New lead' },
+        { label: 'Amount', value: '$12,500' },
+        { label: 'Close date', value: 'Jan 5, 2099' },
+      ],
+    });
+    expect(queryMock).toHaveBeenCalledExactlyOnceWith({
+      opportunities: expect.objectContaining({
+        __args: {
+          filter: { id: { in: [OPPORTUNITY_ID] } },
+          first: 1,
+        },
+      }),
+    });
+  });
+
+  it('should resolve a favicon image for a company with a domain', async () => {
+    const queryMock = vi.fn().mockResolvedValue({
+      companies: {
+        edges: [
+          {
+            node: {
+              id: COMPANY_ID,
+              domainName: { primaryLinkUrl: 'https://acme.com' },
+              annualRevenue: null,
+            },
+          },
+        ],
+      },
+    });
+
+    const details = await fetchSlackRecordDetails(buildClient(queryMock), [
+      buildReference('company', COMPANY_ID),
+    ]);
+
+    expect(details.get(COMPANY_ID)).toEqual({
+      fields: [{ label: 'Domain', value: 'https://acme.com' }],
+      imageUrl: 'https://www.google.com/s2/favicons?domain=acme.com&sz=64',
+    });
+  });
+
+  it('should batch references of one object into a single query', async () => {
+    const queryMock = vi.fn().mockResolvedValue({ companies: { edges: [] } });
+
+    await fetchSlackRecordDetails(buildClient(queryMock), [
+      buildReference('company', COMPANY_ID),
+      buildReference('company', OPPORTUNITY_ID),
+    ]);
+
+    expect(queryMock).toHaveBeenCalledExactlyOnceWith({
+      companies: expect.objectContaining({
+        __args: {
+          filter: { id: { in: [COMPANY_ID, OPPORTUNITY_ID] } },
+          first: 2,
+        },
+      }),
+    });
+  });
+
+  it('should skip objects without a detail config', async () => {
+    const queryMock = vi.fn();
+
+    const details = await fetchSlackRecordDetails(buildClient(queryMock), [
+      buildReference('customRocket', COMPANY_ID),
+    ]);
+
+    expect(queryMock).not.toHaveBeenCalled();
+    expect(details.size).toBe(0);
+  });
+
+  it('should not render a zero amount when amountMicros is null', async () => {
+    const queryMock = vi.fn().mockResolvedValue({
+      opportunities: {
+        edges: [
+          {
+            node: {
+              id: OPPORTUNITY_ID,
+              stage: 'PROPOSAL',
+              amount: { amountMicros: null, currencyCode: 'USD' },
+              closeDate: null,
+            },
+          },
+        ],
+      },
+    });
+
+    const details = await fetchSlackRecordDetails(buildClient(queryMock), [
+      buildReference('opportunity', OPPORTUNITY_ID),
+    ]);
+
+    expect(details.get(OPPORTUNITY_ID)).toEqual({
+      fields: [{ label: 'Stage', value: 'Proposal' }],
+    });
+  });
+
+  it('should resolve relation fields for a person', async () => {
+    const queryMock = vi.fn().mockResolvedValue({
+      people: {
+        edges: [
+          {
+            node: {
+              id: COMPANY_ID,
+              jobTitle: 'CTO',
+              emails: { primaryEmail: 'jane@acme.com' },
+              company: { name: 'Acme Corp' },
+            },
+          },
+        ],
+      },
+    });
+
+    const details = await fetchSlackRecordDetails(buildClient(queryMock), [
+      buildReference('person', COMPANY_ID),
+    ]);
+
+    expect(details.get(COMPANY_ID)).toEqual({
+      fields: [
+        { label: 'Role', value: 'CTO' },
+        { label: 'Email', value: 'jane@acme.com' },
+        { label: 'Company', value: 'Acme Corp' },
+      ],
+    });
+  });
+
+  it('should return no details when the query fails', async () => {
+    const queryMock = vi.fn().mockRejectedValue(new Error('boom'));
+
+    const details = await fetchSlackRecordDetails(buildClient(queryMock), [
+      buildReference('company', COMPANY_ID),
+    ]);
+
+    expect(details.size).toBe(0);
+  });
+});

--- a/packages/twenty-apps/public/slack/src/logic-functions/utils/__tests__/format-slack-record-values.test.ts
+++ b/packages/twenty-apps/public/slack/src/logic-functions/utils/__tests__/format-slack-record-values.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it } from 'vitest';
+
+import { formatSlackRecordAmount } from 'src/logic-functions/utils/format-slack-record-amount';
+import { formatSlackRecordDate } from 'src/logic-functions/utils/format-slack-record-date';
+import { formatSlackRecordSelectValue } from 'src/logic-functions/utils/format-slack-record-select-value';
+
+describe('formatSlackRecordSelectValue', () => {
+  it('should turn SCREAMING_SNAKE_CASE option values into readable labels', () => {
+    expect(formatSlackRecordSelectValue('NEW_CUSTOMER')).toBe('New customer');
+    expect(formatSlackRecordSelectValue('PROPOSAL')).toBe('Proposal');
+  });
+
+  it('should leave values that are not option api names untouched', () => {
+    expect(formatSlackRecordSelectValue('Won deal')).toBe('Won deal');
+  });
+
+  it('should keep acronym-like segments with digits uppercase', () => {
+    expect(formatSlackRecordSelectValue('B2B')).toBe('B2B');
+    expect(formatSlackRecordSelectValue('B2B_SALES')).toBe('B2B sales');
+    expect(formatSlackRecordSelectValue('NEW_B2B_LEAD')).toBe('New B2B lead');
+  });
+});
+
+describe('formatSlackRecordAmount', () => {
+  it('should format micros with the currency symbol and thousands separators', () => {
+    expect(
+      formatSlackRecordAmount({
+        amountMicros: 12500000000,
+        currencyCode: 'USD',
+      }),
+    ).toBe('$12,500');
+  });
+
+  it('should keep cents when the amount is not a whole number', () => {
+    expect(
+      formatSlackRecordAmount({ amountMicros: 458640000, currencyCode: 'EUR' }),
+    ).toBe('€458.64');
+  });
+
+  it('should respect currencies without minor units', () => {
+    expect(
+      formatSlackRecordAmount({
+        amountMicros: 12500000000,
+        currencyCode: 'JPY',
+      }),
+    ).toBe('¥12,500');
+  });
+
+  it('should fall back to a plain number for an unknown currency code', () => {
+    expect(
+      formatSlackRecordAmount({
+        amountMicros: 1000000000,
+        currencyCode: 'NOT_A_CODE',
+      }),
+    ).toBe('1,000');
+  });
+});
+
+describe('formatSlackRecordDate', () => {
+  it('should hide the year for dates in the current year', () => {
+    const now = new Date('2099-06-01T00:00:00.000Z');
+
+    expect(formatSlackRecordDate('2099-01-05T00:00:00.000Z', now)).toBe(
+      'Jan 5',
+    );
+  });
+
+  it('should show the year for other years', () => {
+    const now = new Date('2099-06-01T00:00:00.000Z');
+
+    expect(formatSlackRecordDate('2098-01-05T00:00:00.000Z', now)).toBe(
+      'Jan 5, 2098',
+    );
+  });
+
+  it('should return undefined for an unparseable date', () => {
+    expect(formatSlackRecordDate('not-a-date')).toBeUndefined();
+  });
+});

--- a/packages/twenty-apps/public/slack/src/logic-functions/utils/__tests__/get-slack-chat-message-body-fields.test.ts
+++ b/packages/twenty-apps/public/slack/src/logic-functions/utils/__tests__/get-slack-chat-message-body-fields.test.ts
@@ -40,6 +40,32 @@ describe('getSlackChatMessageBodyFields', () => {
     ).toEqual({ blocks: messageBlocks, text: 'hello' });
   });
 
+  it('should include attachments only alongside blocks', () => {
+    const messageBlocks: KnownBlock[] = [{ type: 'markdown', text: 'hello' }];
+    const messageAttachments = [{ color: '#3E63DD', fallback: 'Acme' }];
+
+    expect(
+      getSlackChatMessageBodyFields({
+        messageText: 'hello',
+        messageFormat: 'markdown',
+        messageBlocks,
+        messageAttachments,
+      }),
+    ).toEqual({
+      blocks: messageBlocks,
+      text: 'hello',
+      attachments: messageAttachments,
+    });
+
+    expect(
+      getSlackChatMessageBodyFields({
+        messageText: 'hello',
+        messageFormat: 'markdown',
+        messageAttachments,
+      }),
+    ).toEqual({ markdown_text: 'hello' });
+  });
+
   it('should ignore an empty blocks array and honour the format instead', () => {
     expect(
       getSlackChatMessageBodyFields({

--- a/packages/twenty-apps/public/slack/src/logic-functions/utils/__tests__/parse-slack-record-references.test.ts
+++ b/packages/twenty-apps/public/slack/src/logic-functions/utils/__tests__/parse-slack-record-references.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, it } from 'vitest';
+
+import { parseSlackRecordReferences } from 'src/logic-functions/utils/parse-slack-record-references';
+
+const BASE_URL = 'https://acme.twenty.com';
+const OPPORTUNITY_ID = '20202020-89ab-4cde-8f01-234567890abc';
+const COMPANY_ID = '20202020-1234-4abc-9def-567890abcdef';
+
+describe('parseSlackRecordReferences', () => {
+  it('should extract a record reference from a markdown record link', () => {
+    const references = parseSlackRecordReferences({
+      responseText: `Closed [Acme deal](${BASE_URL}/object/opportunity/${OPPORTUNITY_ID}) today.`,
+      workspaceBaseUrl: BASE_URL,
+    });
+
+    expect(references).toEqual([
+      {
+        objectNameSingular: 'opportunity',
+        recordId: OPPORTUNITY_ID,
+        recordName: 'Acme deal',
+        recordUrl: `${BASE_URL}/object/opportunity/${OPPORTUNITY_ID}`,
+      },
+    ]);
+  });
+
+  it('should keep references in order of first appearance and dedupe repeats', () => {
+    const responseText = [
+      `[Acme deal](${BASE_URL}/object/opportunity/${OPPORTUNITY_ID})`,
+      `[Acme Corp](${BASE_URL}/object/company/${COMPANY_ID})`,
+      `[Acme deal again](${BASE_URL}/object/opportunity/${OPPORTUNITY_ID})`,
+    ].join(' and ');
+
+    const references = parseSlackRecordReferences({
+      responseText,
+      workspaceBaseUrl: BASE_URL,
+    });
+
+    expect(references.map((reference) => reference.recordId)).toEqual([
+      OPPORTUNITY_ID,
+      COMPANY_ID,
+    ]);
+    expect(references[0].recordName).toBe('Acme deal');
+  });
+
+  it('should ignore links pointing outside the workspace', () => {
+    const references = parseSlackRecordReferences({
+      responseText: `See [Acme](https://other.example.com/object/company/${COMPANY_ID}).`,
+      workspaceBaseUrl: BASE_URL,
+    });
+
+    expect(references).toEqual([]);
+  });
+
+  it('should ignore workspace links that are not record pages', () => {
+    const references = parseSlackRecordReferences({
+      responseText: `See [settings](${BASE_URL}/settings/accounts) and [list](${BASE_URL}/object/company/not-a-uuid).`,
+      workspaceBaseUrl: BASE_URL,
+    });
+
+    expect(references).toEqual([]);
+  });
+
+  it('should match custom object names containing digits', () => {
+    const references = parseSlackRecordReferences({
+      responseText: `See [Rocket v2](${BASE_URL}/object/rocket2/${COMPANY_ID}).`,
+      workspaceBaseUrl: BASE_URL,
+    });
+
+    expect(references).toEqual([
+      {
+        objectNameSingular: 'rocket2',
+        recordId: COMPANY_ID,
+        recordName: 'Rocket v2',
+        recordUrl: `${BASE_URL}/object/rocket2/${COMPANY_ID}`,
+      },
+    ]);
+  });
+
+  it('should return nothing when the workspace URL is unknown', () => {
+    const references = parseSlackRecordReferences({
+      responseText: `[Acme](${BASE_URL}/object/company/${COMPANY_ID})`,
+      workspaceBaseUrl: undefined,
+    });
+
+    expect(references).toEqual([]);
+  });
+});

--- a/packages/twenty-apps/public/slack/src/logic-functions/utils/build-slack-record-attachments.ts
+++ b/packages/twenty-apps/public/slack/src/logic-functions/utils/build-slack-record-attachments.ts
@@ -1,0 +1,115 @@
+import { type MessageAttachment, type SectionBlock } from '@slack/web-api';
+import { isNonEmptyArray } from '@sniptt/guards';
+
+import {
+  type SlackRecordDetails,
+  type SlackRecordField,
+} from 'src/logic-functions/types/slack-record-details.type';
+import { type SlackRecordReference } from 'src/logic-functions/types/slack-record-reference.type';
+
+// Twenty's accent (Radix indigo9), rendered as the attachment's left bar
+const RECORD_ACCENT_COLOR = '#3E63DD';
+
+const RECORD_ATTACHMENT_MAX_COUNT = 5;
+const RECORD_NAME_MAX_LENGTH = 150;
+
+const ELLIPSIS = '…';
+
+const escapeSlackMrkdwn = (text: string): string =>
+  text.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
+
+// truncates the raw text so the escaped result fits the limit without
+// splitting an &amp;-style entity or a surrogate pair
+const escapeAndTruncate = (rawText: string, maxLength: number): string => {
+  const escaped = escapeSlackMrkdwn(rawText);
+
+  if (escaped.length <= maxLength) {
+    return escaped;
+  }
+
+  const codePoints = [...rawText];
+
+  for (let end = codePoints.length - 1; end > 0; end--) {
+    const candidate =
+      escapeSlackMrkdwn(codePoints.slice(0, end).join('')) + ELLIPSIS;
+
+    if (candidate.length <= maxLength) {
+      return candidate;
+    }
+  }
+
+  return ELLIPSIS;
+};
+
+const buildFieldText = (field: SlackRecordField): string =>
+  `*${escapeSlackMrkdwn(field.label)}*\n${escapeSlackMrkdwn(field.value)}`;
+
+// the classic Slack record look: an accent-bar attachment holding a bold
+// linked name, the object type, a label-over-value field grid, and the
+// company logo when there is one
+const buildRecordSection = (
+  reference: SlackRecordReference,
+  details: SlackRecordDetails,
+): SectionBlock => {
+  const objectLabel =
+    reference.objectNameSingular.charAt(0).toUpperCase() +
+    reference.objectNameSingular.slice(1);
+
+  const linkedName = `*<${reference.recordUrl}|${escapeAndTruncate(
+    reference.recordName,
+    RECORD_NAME_MAX_LENGTH,
+  )}>*   ·   ${escapeSlackMrkdwn(objectLabel)}`;
+
+  return {
+    type: 'section',
+    text: { type: 'mrkdwn', text: linkedName },
+    fields: details.fields.map((field) => ({
+      type: 'mrkdwn',
+      text: buildFieldText(field),
+    })),
+    ...(details.imageUrl !== undefined
+      ? {
+          accessory: {
+            type: 'image',
+            image_url: details.imageUrl,
+            alt_text: `${reference.recordName} logo`,
+          },
+        }
+      : {}),
+  };
+};
+
+export const buildSlackRecordAttachments = ({
+  references,
+  detailsByRecordId,
+}: {
+  references: SlackRecordReference[];
+  detailsByRecordId: Map<string, SlackRecordDetails>;
+}): MessageAttachment[] => {
+  // above the cap the records are passing mentions, not the answer's
+  // subject; a truncated sample would only add noise
+  if (
+    !isNonEmptyArray(references) ||
+    references.length > RECORD_ATTACHMENT_MAX_COUNT
+  ) {
+    return [];
+  }
+
+  // a record with no readable fields would only repeat the prose link,
+  // so it renders nothing
+  return references.flatMap((reference) => {
+    const details = detailsByRecordId.get(reference.recordId);
+
+    if (details === undefined || !isNonEmptyArray(details.fields)) {
+      return [];
+    }
+
+    return [
+      {
+        color: RECORD_ACCENT_COLOR,
+        fallback: reference.recordName,
+        blocks: [buildRecordSection(reference, details)],
+      },
+    ];
+  });
+};

--- a/packages/twenty-apps/public/slack/src/logic-functions/utils/fetch-slack-record-details.ts
+++ b/packages/twenty-apps/public/slack/src/logic-functions/utils/fetch-slack-record-details.ts
@@ -1,0 +1,220 @@
+import { isNonEmptyString } from '@sniptt/guards';
+import { type CoreApiClient } from 'twenty-client-sdk/core';
+
+import {
+  type SlackRecordDetails,
+  type SlackRecordField,
+} from 'src/logic-functions/types/slack-record-details.type';
+import { type SlackRecordReference } from 'src/logic-functions/types/slack-record-reference.type';
+import { formatSlackRecordAmount } from 'src/logic-functions/utils/format-slack-record-amount';
+import { formatSlackRecordDate } from 'src/logic-functions/utils/format-slack-record-date';
+import { formatSlackRecordSelectValue } from 'src/logic-functions/utils/format-slack-record-select-value';
+import { getCompanyFaviconUrl } from 'src/logic-functions/utils/get-company-favicon-url';
+
+type CurrencyValue = {
+  amountMicros?: string | number | null;
+  currencyCode?: string | null;
+};
+
+type RecordNode = {
+  id?: string;
+  stage?: string | null;
+  amount?: CurrencyValue | null;
+  closeDate?: string | null;
+  domainName?: { primaryLinkUrl?: string | null } | null;
+  annualRevenue?: CurrencyValue | null;
+  jobTitle?: string | null;
+  emails?: { primaryEmail?: string | null } | null;
+  company?: { name?: string | null } | null;
+  status?: string | null;
+  dueAt?: string | null;
+};
+
+const buildCurrencyField = (
+  label: string,
+  currencyValue: CurrencyValue | null | undefined,
+): SlackRecordField | undefined => {
+  const rawAmountMicros = currencyValue?.amountMicros;
+
+  if (rawAmountMicros === null || rawAmountMicros === undefined) {
+    return undefined;
+  }
+
+  const amountMicros = Number(rawAmountMicros);
+
+  if (!Number.isFinite(amountMicros)) {
+    return undefined;
+  }
+
+  return {
+    label,
+    value: formatSlackRecordAmount({
+      amountMicros,
+      currencyCode: currencyValue?.currencyCode ?? undefined,
+    }),
+  };
+};
+
+const buildDateField = (
+  label: string,
+  isoDate: string | null | undefined,
+): SlackRecordField | undefined => {
+  if (!isNonEmptyString(isoDate)) {
+    return undefined;
+  }
+
+  const formattedDate = formatSlackRecordDate(isoDate);
+
+  return formattedDate === undefined
+    ? undefined
+    : { label, value: formattedDate };
+};
+
+const buildSelectField = (
+  label: string,
+  value: string | null | undefined,
+): SlackRecordField | undefined =>
+  isNonEmptyString(value)
+    ? { label, value: formatSlackRecordSelectValue(value) }
+    : undefined;
+
+const buildTextField = (
+  label: string,
+  value: string | null | undefined,
+): SlackRecordField | undefined =>
+  isNonEmptyString(value) ? { label, value } : undefined;
+
+const isRecordField = (
+  field: SlackRecordField | undefined,
+): field is SlackRecordField => field !== undefined;
+
+// headline fields per standard object; custom objects render without details
+const RECORD_DETAIL_QUERY_CONFIGS: Record<
+  string,
+  {
+    queryFieldName: string;
+    selection: object;
+    buildDetails: (node: RecordNode) => SlackRecordDetails;
+  }
+> = {
+  opportunity: {
+    queryFieldName: 'opportunities',
+    selection: {
+      stage: true,
+      amount: { amountMicros: true, currencyCode: true },
+      closeDate: true,
+    },
+    buildDetails: (node) => ({
+      fields: [
+        buildSelectField('Stage', node.stage),
+        buildCurrencyField('Amount', node.amount),
+        buildDateField('Close date', node.closeDate),
+      ].filter(isRecordField),
+    }),
+  },
+  company: {
+    queryFieldName: 'companies',
+    selection: {
+      domainName: { primaryLinkUrl: true },
+      annualRevenue: { amountMicros: true, currencyCode: true },
+    },
+    buildDetails: (node) => ({
+      fields: [
+        buildTextField('Domain', node.domainName?.primaryLinkUrl),
+        buildCurrencyField('Annual revenue', node.annualRevenue),
+      ].filter(isRecordField),
+      imageUrl: getCompanyFaviconUrl(node.domainName?.primaryLinkUrl),
+    }),
+  },
+  person: {
+    queryFieldName: 'people',
+    selection: {
+      jobTitle: true,
+      emails: { primaryEmail: true },
+      company: { name: true },
+    },
+    buildDetails: (node) => ({
+      fields: [
+        buildTextField('Role', node.jobTitle),
+        buildTextField('Email', node.emails?.primaryEmail),
+        buildTextField('Company', node.company?.name),
+      ].filter(isRecordField),
+    }),
+  },
+  task: {
+    queryFieldName: 'tasks',
+    selection: {
+      status: true,
+      dueAt: true,
+    },
+    buildDetails: (node) => ({
+      fields: [
+        buildSelectField('Status', node.status),
+        buildDateField('Due', node.dueAt),
+      ].filter(isRecordField),
+    }),
+  },
+};
+
+export const fetchSlackRecordDetails = async (
+  client: CoreApiClient,
+  references: SlackRecordReference[],
+): Promise<Map<string, SlackRecordDetails>> => {
+  const detailsByRecordId = new Map<string, SlackRecordDetails>();
+
+  const referencesByObjectName = new Map<string, SlackRecordReference[]>();
+
+  for (const reference of references) {
+    const objectNameSingular = reference.objectNameSingular.toLowerCase();
+
+    referencesByObjectName.set(objectNameSingular, [
+      ...(referencesByObjectName.get(objectNameSingular) ?? []),
+      reference,
+    ]);
+  }
+
+  await Promise.all(
+    [...referencesByObjectName.entries()].map(
+      async ([objectNameSingular, objectReferences]) => {
+        const config = RECORD_DETAIL_QUERY_CONFIGS[objectNameSingular];
+
+        if (config === undefined) {
+          return;
+        }
+
+        const recordIds = objectReferences.map(
+          (reference) => reference.recordId,
+        );
+
+        try {
+          const queryResult = await client.query({
+            [config.queryFieldName]: {
+              __args: {
+                filter: { id: { in: recordIds } },
+                first: recordIds.length,
+              },
+              edges: { node: { id: true, ...config.selection } },
+            },
+          });
+
+          const edges: { node?: RecordNode }[] =
+            queryResult[config.queryFieldName]?.edges ?? [];
+
+          for (const edge of edges) {
+            const node = edge.node;
+
+            if (node === undefined || !isNonEmptyString(node.id)) {
+              continue;
+            }
+
+            detailsByRecordId.set(node.id, config.buildDetails(node));
+          }
+        } catch {
+          // records without readable details render as plain prose links only
+        }
+      },
+    ),
+  );
+
+  return detailsByRecordId;
+};

--- a/packages/twenty-apps/public/slack/src/logic-functions/utils/finish-slack-assistant-request-with-failure.ts
+++ b/packages/twenty-apps/public/slack/src/logic-functions/utils/finish-slack-assistant-request-with-failure.ts
@@ -27,6 +27,13 @@ export const finishSlackAssistantRequestWithFailure = async ({
     slackChannelId,
     messageText: SLACK_ASSISTANT_FAILURE_TEXT,
     parentMessageTimestamp,
+    messageBlocks: [
+      {
+        type: 'alert',
+        level: 'warning',
+        text: { type: 'plain_text', text: SLACK_ASSISTANT_FAILURE_TEXT },
+      },
+    ],
   });
 
   await updateSlackAssistantRequest(client, {

--- a/packages/twenty-apps/public/slack/src/logic-functions/utils/format-slack-record-amount.ts
+++ b/packages/twenty-apps/public/slack/src/logic-functions/utils/format-slack-record-amount.ts
@@ -1,0 +1,23 @@
+const MICROS_PER_UNIT = 1_000_000;
+
+export const formatSlackRecordAmount = ({
+  amountMicros,
+  currencyCode,
+}: {
+  amountMicros: number;
+  currencyCode: string | undefined;
+}): string => {
+  const amount = amountMicros / MICROS_PER_UNIT;
+
+  try {
+    // minimumFractionDigits 0 drops trailing zeros on whole amounts while
+    // keeping each currency's own maximum minor-unit precision
+    return new Intl.NumberFormat('en-US', {
+      style: 'currency',
+      currency: currencyCode ?? 'USD',
+      minimumFractionDigits: 0,
+    }).format(amount);
+  } catch {
+    return amount.toLocaleString('en-US');
+  }
+};

--- a/packages/twenty-apps/public/slack/src/logic-functions/utils/format-slack-record-date.ts
+++ b/packages/twenty-apps/public/slack/src/logic-functions/utils/format-slack-record-date.ts
@@ -1,0 +1,19 @@
+export const formatSlackRecordDate = (
+  isoDate: string,
+  now: Date = new Date(),
+): string | undefined => {
+  const date = new Date(isoDate);
+
+  if (Number.isNaN(date.getTime())) {
+    return undefined;
+  }
+
+  const showYear = date.getUTCFullYear() !== now.getUTCFullYear();
+
+  return date.toLocaleDateString('en-US', {
+    month: 'short',
+    day: 'numeric',
+    ...(showYear ? { year: 'numeric' } : {}),
+    timeZone: 'UTC',
+  });
+};

--- a/packages/twenty-apps/public/slack/src/logic-functions/utils/format-slack-record-select-value.ts
+++ b/packages/twenty-apps/public/slack/src/logic-functions/utils/format-slack-record-select-value.ts
@@ -1,0 +1,24 @@
+// select option values are stored as SCREAMING_SNAKE_CASE api names
+const SCREAMING_SNAKE_CASE_PATTERN = /^[A-Z0-9]+(_[A-Z0-9]+)*$/;
+
+// acronym-like segments such as B2B keep their casing
+const hasDigit = (word: string): boolean => /\d/.test(word);
+
+export const formatSlackRecordSelectValue = (value: string): string => {
+  if (!SCREAMING_SNAKE_CASE_PATTERN.test(value)) {
+    return value;
+  }
+
+  const words = value
+    .split('_')
+    .map((word) => (hasDigit(word) ? word : word.toLowerCase()));
+
+  const [firstWord, ...restWords] = words;
+
+  return [
+    hasDigit(firstWord)
+      ? firstWord
+      : firstWord.charAt(0).toUpperCase() + firstWord.slice(1),
+    ...restWords,
+  ].join(' ');
+};

--- a/packages/twenty-apps/public/slack/src/logic-functions/utils/get-company-favicon-url.ts
+++ b/packages/twenty-apps/public/slack/src/logic-functions/utils/get-company-favicon-url.ts
@@ -1,0 +1,25 @@
+import { isNonEmptyString } from '@sniptt/guards';
+
+const FAVICON_SIZE = 64;
+
+export const getCompanyFaviconUrl = (
+  domainUrl: string | null | undefined,
+): string | undefined => {
+  if (!isNonEmptyString(domainUrl)) {
+    return undefined;
+  }
+
+  try {
+    const hostname = new URL(
+      domainUrl.includes('://') ? domainUrl : `https://${domainUrl}`,
+    ).hostname;
+
+    if (!isNonEmptyString(hostname)) {
+      return undefined;
+    }
+
+    return `https://www.google.com/s2/favicons?domain=${encodeURIComponent(hostname)}&sz=${FAVICON_SIZE}`;
+  } catch {
+    return undefined;
+  }
+};

--- a/packages/twenty-apps/public/slack/src/logic-functions/utils/get-slack-chat-message-body-fields.ts
+++ b/packages/twenty-apps/public/slack/src/logic-functions/utils/get-slack-chat-message-body-fields.ts
@@ -7,9 +7,16 @@ export const getSlackChatMessageBodyFields = ({
   messageText,
   messageFormat,
   messageBlocks,
+  messageAttachments,
 }: { messageText: string } & SlackMessageBody): SlackChatMessageBodyFields => {
   if (isNonEmptyArray(messageBlocks)) {
-    return { blocks: messageBlocks, text: messageText };
+    return {
+      blocks: messageBlocks,
+      text: messageText,
+      ...(isNonEmptyArray(messageAttachments)
+        ? { attachments: messageAttachments }
+        : {}),
+    };
   }
 
   switch (messageFormat) {

--- a/packages/twenty-apps/public/slack/src/logic-functions/utils/is-slack-markdown-format-error.ts
+++ b/packages/twenty-apps/public/slack/src/logic-functions/utils/is-slack-markdown-format-error.ts
@@ -5,6 +5,7 @@ import { getSlackApiErrorCode } from 'src/logic-functions/utils/get-slack-api-er
 const SLACK_MARKDOWN_FORMAT_ERROR_CODES = new Set([
   'invalid_arguments',
   'invalid_blocks',
+  'invalid_attachments',
 ]);
 
 export const isSlackMarkdownFormatError = (error: unknown): boolean => {

--- a/packages/twenty-apps/public/slack/src/logic-functions/utils/parse-slack-record-references.ts
+++ b/packages/twenty-apps/public/slack/src/logic-functions/utils/parse-slack-record-references.ts
@@ -1,0 +1,42 @@
+import { isNonEmptyString } from '@sniptt/guards';
+
+import { type SlackRecordReference } from 'src/logic-functions/types/slack-record-reference.type';
+
+const UUID_PATTERN = '[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}';
+
+const escapeForRegExp = (value: string): string =>
+  value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+
+export const parseSlackRecordReferences = ({
+  responseText,
+  workspaceBaseUrl,
+}: {
+  responseText: string;
+  workspaceBaseUrl: string | undefined;
+}): SlackRecordReference[] => {
+  if (!isNonEmptyString(workspaceBaseUrl)) {
+    return [];
+  }
+
+  const recordLinkPattern = new RegExp(
+    `\\[([^\\]\\n]+)\\]\\((${escapeForRegExp(workspaceBaseUrl)}/object/([a-zA-Z][a-zA-Z0-9]*)/(${UUID_PATTERN}))\\)`,
+    'gi',
+  );
+
+  const referencesByRecordId = new Map<string, SlackRecordReference>();
+
+  for (const match of responseText.matchAll(recordLinkPattern)) {
+    const [, recordName, recordUrl, objectNameSingular, recordId] = match;
+
+    if (!referencesByRecordId.has(recordId)) {
+      referencesByRecordId.set(recordId, {
+        objectNameSingular,
+        recordId,
+        recordName: recordName.trim(),
+        recordUrl,
+      });
+    }
+  }
+
+  return [...referencesByRecordId.values()];
+};

--- a/packages/twenty-apps/public/slack/src/logic-functions/utils/post-slack-message.ts
+++ b/packages/twenty-apps/public/slack/src/logic-functions/utils/post-slack-message.ts
@@ -18,6 +18,7 @@ export const postSlackMessage = async (
     messageBody: {
       messageFormat: parameters.messageFormat,
       messageBlocks: parameters.messageBlocks,
+      messageAttachments: parameters.messageAttachments,
     },
     failureMessage: 'Failed to post Slack message',
     sendMessage: async (bodyFields) => {

--- a/packages/twenty-apps/public/slack/src/roles/default-function.role.ts
+++ b/packages/twenty-apps/public/slack/src/roles/default-function.role.ts
@@ -1,15 +1,29 @@
-import { defineApplicationRole, SystemPermissionFlag } from 'twenty-sdk/define';
+import {
+  defineApplicationRole,
+  STANDARD_OBJECT_UNIVERSAL_IDENTIFIERS,
+  SystemPermissionFlag,
+} from 'twenty-sdk/define';
 
 import {
   DEFAULT_ROLE_UNIVERSAL_IDENTIFIER,
   SLACK_ASSISTANT_REQUEST_OBJECT_UNIVERSAL_IDENTIFIER,
 } from 'src/constants/universal-identifiers';
 
+// read-only access for rendering record cards under assistant answers;
+// the records shown are ones the agent (with its own CRM role) already
+// surfaced to the same Slack conversation
+const RECORD_CARD_OBJECT_UNIVERSAL_IDENTIFIERS = [
+  STANDARD_OBJECT_UNIVERSAL_IDENTIFIERS.person.universalIdentifier,
+  STANDARD_OBJECT_UNIVERSAL_IDENTIFIERS.company.universalIdentifier,
+  STANDARD_OBJECT_UNIVERSAL_IDENTIFIERS.opportunity.universalIdentifier,
+  STANDARD_OBJECT_UNIVERSAL_IDENTIFIERS.task.universalIdentifier,
+] as const;
+
 export default defineApplicationRole({
   universalIdentifier: DEFAULT_ROLE_UNIVERSAL_IDENTIFIER,
   label: 'Twenty Slack tools role',
   description:
-    'No CRM data access — tools only forward requests to Slack using the configured connected account. Also tracks assistant requests and runs the assistant agent; CRM access is granted separately through the role assigned to the agent.',
+    'Tools only forward requests to Slack using the configured connected account. Also tracks assistant requests, runs the assistant agent, and reads people, companies, opportunities and tasks to render record cards under answers; all other CRM access is granted separately through the role assigned to the agent.',
   canReadAllObjectRecords: false,
   canUpdateAllObjectRecords: false,
   canSoftDeleteAllObjectRecords: false,
@@ -27,6 +41,15 @@ export default defineApplicationRole({
       canSoftDeleteObjectRecords: false,
       canDestroyObjectRecords: false,
     },
+    ...RECORD_CARD_OBJECT_UNIVERSAL_IDENTIFIERS.map(
+      (objectUniversalIdentifier) => ({
+        objectUniversalIdentifier,
+        canReadObjectRecords: true,
+        canUpdateObjectRecords: false,
+        canSoftDeleteObjectRecords: false,
+        canDestroyObjectRecords: false,
+      }),
+    ),
   ],
   fieldPermissions: [],
   permissionFlagUniversalIdentifiers: [SystemPermissionFlag.AI],


### PR DESCRIPTION
Replaces #23888, which repo automation auto-closed as stale and GitHub refuses to reopen (its branch was force-pushed while closed). Same branch, same work, now rebased so it carries **no prompt changes** — those live in #23887, which this stacks on.

## Context

CRM records exist only as inline links inside the reply prose. This adds a compact summary of each referenced record under the answer, so a member can see a record's headline fields without leaving the thread.

**Stacked on #23887** (reply anatomy prompt) → #23886 → #23838. Retargets down the chain as its parents land.

## What this does

The worker extracts the record links the agent already writes (`{workspaceBaseUrl}/object/{objectNameSingular}/{uuid}`), so there is no new agent contract and nothing breaks when the model writes no links.

Records render as **accent-bar attachments** — the mechanism behind the familiar GitHub/Linear/Jira record look, and consistent with Slack's own agent sample, which keeps the message body plain and puts structure alongside it. One attachment per record: Twenty's indigo (`#3E63DD`) bar, bold linked name with the object type, a label-over-value field grid, and the company's domain favicon as an accessory image. Navigation lives in the linked name — no buttons.

- `parse-slack-record-references` — pulls references out of the response text, deduped in order of first appearance; inert when the workspace URL is unresolved. Object names may contain digits (custom objects).
- `fetch-slack-record-details` — batch-loads headline fields per standard object, one query per type (opportunity: stage/amount/close date; company: domain/annual revenue; person: role/email/company; task: status/due). Formats select api names as readable labels ("New lead", acronyms like B2B preserved), currency micros as `$12,500` honoring each currency's minor units, and short dates. Null amounts are omitted rather than rendered as `$0`.
- `build-slack-record-attachments` — one attachment per record. **A record that resolved no fields renders nothing** (custom objects, permission gaps, failed queries): a bare name would only repeat the prose link. More than five references renders nothing at all — that many links means an analytical answer mentioning records in passing, not a lookup whose subject they are. Five matches the list cap in #23887's prompt.

The app's default function role gains **read-only** access to the four summarized objects (person, company, opportunity, task); the records it reads are ones the agent, under its own CRM role, already surfaced to the same conversation.

**Failures as alert blocks.** `finishSlackAssistantRequestWithFailure` posts a `warning`-level alert block instead of a bare apology line, with actionable text.

## Safety

- Attachments ride only with block bodies; every rung of the existing fallback ladder drops them, and `invalid_attachments` joins the retry codes — a rejected payload still posts the markdown answer, so no answer is ever lost.
- The >12k-char path skips the record-detail queries entirely, since blocks will not post anyway.
- Name and field values are mrkdwn-escaped; name truncation trims raw code points so no `&amp;`-entity or surrogate pair is split.

## Known limitation

Recovering structured records by regexing the agent's own prose is a workaround, not the end state. The clean version is a structured `responseFormat` where the agent returns the records it touched along with their field values — removing the regex, the second fetch and the role widening, and making the prose/summary split enforced rather than instructed. Planned as a follow-up; the presentation layer here survives that change unmodified.

## Testing

109 unit tests in the app (parsing, detail fetching/formatting, attachment building, body-field plumbing), typecheck and lint clean. Needs one manual pass in a dev workspace after the app re-syncs (the role change requires it) to confirm populated field grids, favicons, and bar rendering.

---
_Generated by [Claude Code](https://claude.ai/code/session_018LvBc8LRgRbWrGYyj6TQaA)_

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/23951?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

