### PR TITLE
Deprecate legacy API key and webhook routes

### DIFF
--- a/packages/twenty-server/src/engine/api/rest/metadata/interceptors/__tests__/legacy-metadata-route-deprecation.interceptor.spec.ts
+++ b/packages/twenty-server/src/engine/api/rest/metadata/interceptors/__tests__/legacy-metadata-route-deprecation.interceptor.spec.ts
@@ -1,0 +1,64 @@
+import { type CallHandler, type ExecutionContext } from '@nestjs/common';
+
+import { type Request, type Response } from 'express';
+import { of } from 'rxjs';
+
+import { LegacyMetadataRouteDeprecationInterceptor } from 'src/engine/api/rest/metadata/interceptors/legacy-metadata-route-deprecation.interceptor';
+
+const next = {
+  handle: jest.fn(() => of(undefined)),
+} as unknown as CallHandler;
+
+const makeContext = ({
+  originalUrl,
+  setHeader,
+}: {
+  originalUrl: string;
+  setHeader: jest.Mock;
+}): ExecutionContext =>
+  ({
+    switchToHttp: () => ({
+      getRequest: () => ({ originalUrl }) as Request,
+      getResponse: () => ({ setHeader }) as unknown as Response,
+    }),
+  }) as unknown as ExecutionContext;
+
+describe('LegacyMetadataRouteDeprecationInterceptor', () => {
+  const interceptor = new LegacyMetadataRouteDeprecationInterceptor();
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it.each([
+    ['/rest/apiKeys', '/rest/metadata/apiKeys'],
+    ['/rest/webhooks/id-1?depth=1', '/rest/metadata/webhooks/id-1'],
+  ])(
+    'advertises the successor for legacy route %s',
+    (originalUrl, successorPath) => {
+      const setHeader = jest.fn();
+
+      interceptor.intercept(makeContext({ originalUrl, setHeader }), next);
+
+      expect(setHeader).toHaveBeenCalledWith('Deprecation', '@1786320000');
+      expect(setHeader).toHaveBeenCalledWith(
+        'Link',
+        `<${successorPath}>; rel="successor-version"`,
+      );
+      expect(next.handle).toHaveBeenCalledTimes(1);
+    },
+  );
+
+  it.each([
+    '/rest/metadata/apiKeys',
+    '/rest/metadata/webhooks/id-1',
+    '/rest/apiKeysUnexpected',
+  ])('does not mark canonical or lookalike route %s as deprecated', (url) => {
+    const setHeader = jest.fn();
+
+    interceptor.intercept(makeContext({ originalUrl: url, setHeader }), next);
+
+    expect(setHeader).not.toHaveBeenCalled();
+    expect(next.handle).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/twenty-server/src/engine/api/rest/metadata/interceptors/legacy-metadata-route-deprecation.interceptor.ts
+++ b/packages/twenty-server/src/engine/api/rest/metadata/interceptors/legacy-metadata-route-deprecation.interceptor.ts
@@ -1,0 +1,48 @@
+import {
+  type CallHandler,
+  type ExecutionContext,
+  Injectable,
+  type NestInterceptor,
+} from '@nestjs/common';
+
+import { type Request, type Response } from 'express';
+import { type Observable } from 'rxjs';
+
+// 2026-08-10T00:00:00Z as an RFC 9745 Structured Field Date.
+const DEPRECATION_DATE = '@1786320000';
+
+const LEGACY_ROUTE_SUCCESSORS = [
+  {
+    legacyPath: '/rest/apiKeys',
+    successorPath: '/rest/metadata/apiKeys',
+  },
+  {
+    legacyPath: '/rest/webhooks',
+    successorPath: '/rest/metadata/webhooks',
+  },
+] as const;
+
+@Injectable()
+export class LegacyMetadataRouteDeprecationInterceptor implements NestInterceptor {
+  intercept(context: ExecutionContext, next: CallHandler): Observable<unknown> {
+    const request = context.switchToHttp().getRequest<Request>();
+    const response = context.switchToHttp().getResponse<Response>();
+    const requestPath = request.originalUrl.split('?')[0];
+    const successor = LEGACY_ROUTE_SUCCESSORS.find(
+      ({ legacyPath }) =>
+        requestPath === legacyPath || requestPath.startsWith(`${legacyPath}/`),
+    );
+
+    if (successor) {
+      const successorPath = requestPath.replace(
+        successor.legacyPath,
+        successor.successorPath,
+      );
+
+      response.setHeader('Deprecation', DEPRECATION_DATE);
+      response.setHeader('Link', `<${successorPath}>; rel="successor-version"`);
+    }
+
+    return next.handle();
+  }
+}

--- a/packages/twenty-server/src/engine/core-modules/api-key/controllers/api-key.controller.ts
+++ b/packages/twenty-server/src/engine/core-modules/api-key/controllers/api-key.controller.ts
@@ -8,12 +8,14 @@ import {
   Post,
   UseFilters,
   UseGuards,
+  UseInterceptors,
 } from '@nestjs/common';
 
 import { type QueryDeepPartialEntity } from 'typeorm/query-builder/QueryPartialEntity';
 import { PermissionFlagType } from 'twenty-shared/constants';
 import { ApiPath } from 'twenty-shared/types';
 
+import { LegacyMetadataRouteDeprecationInterceptor } from 'src/engine/api/rest/metadata/interceptors/legacy-metadata-route-deprecation.interceptor';
 import { RestApiExceptionFilter } from 'src/engine/api/rest/rest-api-exception.filter';
 import { type ApiKeyEntity } from 'src/engine/core-modules/api-key/api-key.entity';
 import { CreateApiKeyInput } from 'src/engine/core-modules/api-key/dtos/create-api-key.input';
@@ -38,6 +40,7 @@ import { PermissionsRestApiExceptionFilter } from 'src/engine/metadata-modules/p
   SettingsPermissionGuard(PermissionFlagType.API_KEYS_AND_WEBHOOKS),
 )
 @UseFilters(PermissionsRestApiExceptionFilter, RestApiExceptionFilter)
+@UseInterceptors(LegacyMetadataRouteDeprecationInterceptor)
 export class ApiKeyController {
   constructor(private readonly apiKeyService: ApiKeyService) {}
 

--- a/packages/twenty-server/src/engine/metadata-modules/webhook/controllers/webhook.controller.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/webhook/controllers/webhook.controller.ts
@@ -8,11 +8,13 @@ import {
   Post,
   UseFilters,
   UseGuards,
+  UseInterceptors,
 } from '@nestjs/common';
 
 import { PermissionFlagType } from 'twenty-shared/constants';
 import { ApiPath } from 'twenty-shared/types';
 
+import { LegacyMetadataRouteDeprecationInterceptor } from 'src/engine/api/rest/metadata/interceptors/legacy-metadata-route-deprecation.interceptor';
 import { RestApiExceptionFilter } from 'src/engine/api/rest/rest-api-exception.filter';
 import { WorkspaceEntity } from 'src/engine/core-modules/workspace/workspace.entity';
 import { AuthWorkspace } from 'src/engine/decorators/auth/auth-workspace.decorator';
@@ -27,6 +29,10 @@ import { type WebhookDTO } from 'src/engine/metadata-modules/webhook/dtos/webhoo
 import { WebhookService } from 'src/engine/metadata-modules/webhook/webhook.service';
 import { WorkspaceMigrationRunnerRestApiExceptionFilter } from 'src/engine/workspace-manager/workspace-migration/filters/workspace-migration-runner-rest-api-exception.filter';
 
+/**
+ * rest/webhooks is deprecated, use rest/metadata/webhooks instead
+ * rest/webhooks will be removed in the future
+ */
 @Controller([`${ApiPath.Rest}/webhooks`, `${ApiPath.Rest}/metadata/webhooks`])
 @UseGuards(
   JwtAuthGuard,
@@ -39,6 +45,7 @@ import { WorkspaceMigrationRunnerRestApiExceptionFilter } from 'src/engine/works
   FlatEntityMapsRestApiExceptionFilter,
   WorkspaceMigrationRunnerRestApiExceptionFilter,
 )
+@UseInterceptors(LegacyMetadataRouteDeprecationInterceptor)
 export class WebhookController {
   constructor(private readonly webhookService: WebhookService) {}
 


### PR DESCRIPTION
## What changed

- Adds the RFC 9745 `Deprecation` header to `/rest/apiKeys` and `/rest/webhooks`, including item routes.
- Adds an exact `rel="successor-version"` link to the equivalent `/rest/metadata/*` route.
- Restores the webhook controller's code-level deprecation notice.
- Does not change response bodies or route behavior, and does not announce a `Sunset` date.

## Why

These aliases have been marked deprecated in code since August 2025, but API consumers had no machine-readable runtime signal or migration target.

## Impact

Existing aliases continue to work. Consumers can discover and migrate to the canonical metadata routes. Canonical `/rest/metadata/*` routes are unchanged.

## Validation

- Focused Jest suite: 5 tests passed
- oxfmt check
- Type-aware oxlint

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/23953?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

