### PR TITLE
fix(server): signal truncation to AI agent in find_many record tool

### DIFF
--- a/packages/twenty-server/src/engine/core-modules/record-crud/services/find-records.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/record-crud/services/find-records.service.ts
@@ -79,7 +79,7 @@ export class FindRecordsService {
       ];
 
       const {
-        results: { records, totalCount },
+        results: { records, totalCount, pageInfo },
       } = await this.commonFindManyRunner.execute(
         {
           filter,
@@ -109,6 +109,7 @@ export class FindRecordsService {
         result: {
           records,
           count: totalCount,
+          hasNextPage: pageInfo.hasNextPage,
         },
         ...(isNonEmptyArray(warnings) ? { warnings: warnings } : {}),
         recordReferences,

--- a/packages/twenty-server/src/engine/core-modules/record-crud/types/find-records-result.type.ts
+++ b/packages/twenty-server/src/engine/core-modules/record-crud/types/find-records-result.type.ts
@@ -1,4 +1,5 @@
 export type FindRecordsResult = {
   records: unknown[];
   count: number;
+  hasNextPage: boolean;
 };

--- a/packages/twenty-server/src/engine/core-modules/tool-provider/providers/database-tool.provider.ts
+++ b/packages/twenty-server/src/engine/core-modules/tool-provider/providers/database-tool.provider.ts
@@ -181,7 +181,7 @@ export class DatabaseToolProvider implements ToolProvider {
             this.i18nService,
             context.locale,
           ),
-          description: `Search for ${objectMetadata.labelPlural} records using flexible filtering criteria. Supports exact matches, pattern matching, ranges, and null checks. Use limit/offset for pagination and orderBy for sorting. Filter fields are top-level arguments — pass each field as its own key (e.g. { id: { eq: "record-id" } }, or { name: { firstName: { ilike: "%ada%" } } }); do NOT wrap them in a "filter" object and do NOT place a bare operator like "ilike"/"eq" at the top level. Combine conditions with and/or/not. Returns an array of matching records with their full data.`,
+          description: `Search for ${objectMetadata.labelPlural} records using flexible filtering criteria. Supports exact matches, pattern matching, ranges, and null checks. Use limit/offset for pagination and orderBy for sorting. Filter fields are top-level arguments — pass each field as its own key (e.g. { id: { eq: "record-id" } }, or { name: { firstName: { ilike: "%ada%" } } }); do NOT wrap them in a "filter" object and do NOT place a bare operator like "ilike"/"eq" at the top level. Combine conditions with and/or/not. Returns an array of matching records with their full data, plus a "count" of total matches and a "hasNextPage" flag. When "hasNextPage" is true, more records match than were returned: continue with a higher offset (or increase the limit) before concluding a record is absent or answering count/enumeration questions.`,
           category: ToolCategory.DATABASE_CRUD,
           ...(shouldIncludeSchema(`find_many_${snakePlural}`) && {
             inputSchema: toToolJsonSchema(


### PR DESCRIPTION
## Problem

Closes #23941.

The AI agent's `find_many_<object>` tool defaults `limit` to 10 (intentional, for token usage) but its result only exposed `records` and `count`. There was no signal to the model that the returned page was truncated, so the agent:

- reported existing records as "not found" when the target was outside the first 10, and
- computed count/enumeration answers over a partial set.

The underlying query runner already computes `pageInfo.hasNextPage`, but `FindRecordsService` discarded it.

## Fix

- Propagate `pageInfo.hasNextPage` from `CommonFindManyQueryRunnerService` through `FindRecordsService` into the tool result (`hasNextPage`).
- Update the `find_many_*` tool description to instruct the model to inspect `hasNextPage` and continue with a higher offset (or larger limit) before concluding a record is absent or answering enumeration questions.

The small default limit is preserved; the model now has an explicit continuation signal instead of treating a truncated page as complete.

## Notes

- `FindRecordsResult` gains a required `hasNextPage: boolean`. The only consumers (`find-records` and `pick-record` workflow actions) read `records`/`count` only, so they are unaffected.
- `database-tool.provider` spec passes.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/23955?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

