### PR TITLE
perf(server): cap the flat field metadata entries a pod retains

### DIFF
--- a/packages/twenty-server/src/engine/workspace-cache/services/workspace-cache.service.ts
+++ b/packages/twenty-server/src/engine/workspace-cache/services/workspace-cache.service.ts
@@ -48,9 +48,9 @@ const MAX_LOCAL_CACHE_ENTRIES = 6_000;
 const MIN_EVICT_KEYS = 100;
 const LOCAL_ENTRY_TTL_MS = 30 * 60 * 1000; // 30 minutes idle
 const LOCAL_CACHE_SWEEP_INTERVAL_MS = 60 * 1000;
-// Per-provider entry caps, keyed by local cache key prefix (ORM graphs are ~5 MB each).
 const MAX_LOCAL_ENTRIES_BY_PREFIX = new Map<string, number>([
   [WORKSPACE_CACHE_KEYS_V2.ORMEntityMetadatas, 128],
+  [WORKSPACE_CACHE_KEYS_V2.flatFieldMetadataMaps, 256],
 ]);
 type CacheDataType = WorkspaceCacheDataMap[WorkspaceCacheKeyName];
 


### PR DESCRIPTION
`flat-maps:field-metadata` is the only heavy provider without an entry cap. That is why the ORM cap in #23778 did not reduce pod memory — the freed slots refilled with field metadata under the same global count cap, and the pod working set stayed at 84% of its limit.

Measured on a prod-sized workspace against the real provider (booted through `AppModule`, not the sampled walker):

| entries held | retained |
|---|---|
| ~500 (today, uncapped) | ~440 MB |
| **256 (this PR)** | **~225 MB** |

An entry retains ~0.88 MB.

## Why this is its own PR

It is deliberately split out of #23880. That PR gates everything behind `IS_WORKSPACE_CACHE_COMPACT_STORAGE_ENABLED` so a workspace without the flag behaves exactly as it does today. This cap cannot work that way — `MAX_LOCAL_ENTRIES_BY_PREFIX` is a pod-global constant while the flag is per-workspace — so it changes behaviour for **every** workspace on deploy: field-metadata entries beyond 256 are evicted and recomputed.

That is a different risk profile and deserves its own deploy and its own watch.

## On the value

256 is a judgement call worth revisiting with data. A recompute is not free — `computeForCache` fires nine parallel queries — and on a pod serving ~500 workspaces this means roughly half the working set misses and rebuilds. 128 would mirror the ORM cap and halve memory again at a higher miss rate; 384 would be gentler.

#23883 (merged) now exports `twenty_workspace_cache_local_entries_by_provider`, and #23879 (merged) exports the GC pause histogram, so after this deploys the value can be tuned against `twenty_workspace_cache_recompute_duration_seconds_count{cache_key="flatFieldMetadataMaps"}` rather than estimated.

## Also

Removes the comment above the map claiming ORM graphs are ~5 MB each. That figure came from the sampled deep-size walker, which the design doc flags as an upper bound; measured against the real provider they are 0.48 MB. Leaving a disproven number beside the caps would misdirect whoever tunes them next.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/23961?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

