### PR TITLE
[Twenty-front][Calendar]: Prevent calendar card cell hover/edit state for multi-day records

### DIFF
--- a/packages/twenty-front/src/modules/object-record/record-calendar/record-calendar-card/anchored-portal/components/RecordCalendarCardCellEditModePortal.tsx
+++ b/packages/twenty-front/src/modules/object-record/record-calendar/record-calendar-card/anchored-portal/components/RecordCalendarCardCellEditModePortal.tsx
@@ -2,9 +2,9 @@ import { useAtomComponentStateValue } from '@/ui/utilities/state/jotai/hooks/use
 
 import { useRecordCalendarContextOrThrow } from '@/object-record/record-calendar/contexts/RecordCalendarContext';
 import { RecordCalendarCardInputContextProvider } from '@/object-record/record-calendar/record-calendar-card/anchored-portal/components/RecordCalendarCardInputContextProvider';
-import { RECORD_CALENDAR_CARD_INPUT_ID_PREFIX } from '@/object-record/record-calendar/record-calendar-card/constants/RecordCalendarCardInputIdPrefix';
 import { useRecordCalendarCardMetadataFromPosition } from '@/object-record/record-calendar/record-calendar-card/hooks/useRecordCalendarCardMetadataFromPosition';
 import { recordCalendarCardEditModePositionComponentState } from '@/object-record/record-calendar/record-calendar-card/states/recordCalendarCardEditModePositionComponentState';
+import { getRecordCalendarCardInstanceIdPrefix } from '@/object-record/record-calendar/record-calendar-card/utils/getRecordCalendarCardInstanceIdPrefix';
 import { FieldInput } from '@/object-record/record-field/ui/components/FieldInput';
 import { RecordInlineCellAnchoredPortal } from '@/object-record/record-inline-cell/components/RecordInlineCellAnchoredPortal';
 import { RecordInlineCellEditMode } from '@/object-record/record-inline-cell/components/RecordInlineCellEditMode';
@@ -12,10 +12,12 @@ import { isDefined } from 'twenty-shared/utils';
 
 type RecordCalendarCardCellEditModePortalProps = {
   recordId: string;
+  calendarDay: string;
 };
 
 export const RecordCalendarCardCellEditModePortal = ({
   recordId,
+  calendarDay,
 }: RecordCalendarCardCellEditModePortalProps) => {
   const { objectMetadataItem } = useRecordCalendarContextOrThrow();
 
@@ -38,7 +40,7 @@ export const RecordCalendarCardCellEditModePortal = ({
       fieldMetadataItem={editedFieldMetadataItem}
       objectMetadataItem={objectMetadataItem}
       recordId={recordId}
-      instanceIdPrefix={RECORD_CALENDAR_CARD_INPUT_ID_PREFIX}
+      instanceIdPrefix={getRecordCalendarCardInstanceIdPrefix(calendarDay)}
     >
       <RecordCalendarCardInputContextProvider>
         <RecordInlineCellEditMode>

--- a/packages/twenty-front/src/modules/object-record/record-calendar/record-calendar-card/anchored-portal/components/RecordCalendarCardCellHoveredPortal.tsx
+++ b/packages/twenty-front/src/modules/object-record/record-calendar/record-calendar-card/anchored-portal/components/RecordCalendarCardCellHoveredPortal.tsx
@@ -3,18 +3,20 @@ import { useAtomComponentStateValue } from '@/ui/utilities/state/jotai/hooks/use
 import { useRecordCalendarContextOrThrow } from '@/object-record/record-calendar/contexts/RecordCalendarContext';
 import { RecordCalendarCardCellHoveredPortalContent } from '@/object-record/record-calendar/record-calendar-card/anchored-portal/components/RecordCalendarCardCellHoveredPortalContent';
 import { RecordCalendarCardInputContextProvider } from '@/object-record/record-calendar/record-calendar-card/anchored-portal/components/RecordCalendarCardInputContextProvider';
-import { RECORD_CALENDAR_CARD_INPUT_ID_PREFIX } from '@/object-record/record-calendar/record-calendar-card/constants/RecordCalendarCardInputIdPrefix';
 import { useRecordCalendarCardMetadataFromPosition } from '@/object-record/record-calendar/record-calendar-card/hooks/useRecordCalendarCardMetadataFromPosition';
 import { recordCalendarCardHoverPositionComponentState } from '@/object-record/record-calendar/record-calendar-card/states/recordCalendarCardHoverPositionComponentState';
+import { getRecordCalendarCardInstanceIdPrefix } from '@/object-record/record-calendar/record-calendar-card/utils/getRecordCalendarCardInstanceIdPrefix';
 import { RecordInlineCellAnchoredPortal } from '@/object-record/record-inline-cell/components/RecordInlineCellAnchoredPortal';
 import { isDefined } from 'twenty-shared/utils';
 
 type RecordCalendarCardCellHoveredPortalProps = {
   recordId: string;
+  calendarDay: string;
 };
 
 export const RecordCalendarCardCellHoveredPortal = ({
   recordId,
+  calendarDay,
 }: RecordCalendarCardCellHoveredPortalProps) => {
   const { objectMetadataItem } = useRecordCalendarContextOrThrow();
 
@@ -37,10 +39,10 @@ export const RecordCalendarCardCellHoveredPortal = ({
       fieldMetadataItem={hoveredFieldMetadataItem}
       objectMetadataItem={objectMetadataItem}
       recordId={recordId}
-      instanceIdPrefix={RECORD_CALENDAR_CARD_INPUT_ID_PREFIX}
+      instanceIdPrefix={getRecordCalendarCardInstanceIdPrefix(calendarDay)}
     >
       <RecordCalendarCardInputContextProvider>
-        <RecordCalendarCardCellHoveredPortalContent />
+        <RecordCalendarCardCellHoveredPortalContent calendarDay={calendarDay} />
       </RecordCalendarCardInputContextProvider>
     </RecordInlineCellAnchoredPortal>
   );

--- a/packages/twenty-front/src/modules/object-record/record-calendar/record-calendar-card/anchored-portal/components/RecordCalendarCardCellHoveredPortalContent.tsx
+++ b/packages/twenty-front/src/modules/object-record/record-calendar/record-calendar-card/anchored-portal/components/RecordCalendarCardCellHoveredPortalContent.tsx
@@ -13,7 +13,6 @@ import { getRecordFieldInputInstanceId } from '@/object-record/utils/getRecordFi
 import { useAtomComponentState } from '@/ui/utilities/state/jotai/hooks/useAtomComponentState';
 import { useSetAtomComponentState } from '@/ui/utilities/state/jotai/hooks/useSetAtomComponentState';
 import { useContext } from 'react';
-import { RECORD_CALENDAR_CARD_INPUT_ID_PREFIX } from '@/object-record/record-calendar/record-calendar-card/constants/RecordCalendarCardInputIdPrefix';
 
 type RecordCalendarCardCellHoveredPortalContentProps = {
   calendarDay: string;
@@ -34,7 +33,7 @@ export const RecordCalendarCardCellHoveredPortalContent = ({
     getRecordFieldInputInstanceId({
       recordId,
       fieldName: fieldDefinition.metadata.fieldName,
-      prefix: RECORD_CALENDAR_CARD_INPUT_ID_PREFIX,
+      prefix: cardInstanceIdPrefix,
     }),
   );
 

--- a/packages/twenty-front/src/modules/object-record/record-calendar/record-calendar-card/anchored-portal/components/RecordCalendarCardCellHoveredPortalContent.tsx
+++ b/packages/twenty-front/src/modules/object-record/record-calendar/record-calendar-card/anchored-portal/components/RecordCalendarCardCellHoveredPortalContent.tsx
@@ -27,7 +27,8 @@ export const RecordCalendarCardCellHoveredPortalContent = ({
   const { isRecordFieldReadOnly, recordId, fieldDefinition } =
     useContext(FieldContext);
 
-  const cardInstanceIdPrefix = getRecordCalendarCardInstanceIdPrefix(calendarDay);
+  const cardInstanceIdPrefix =
+    getRecordCalendarCardInstanceIdPrefix(calendarDay);
 
   const { openInlineCell } = useInlineCell(
     getRecordFieldInputInstanceId({

--- a/packages/twenty-front/src/modules/object-record/record-calendar/record-calendar-card/anchored-portal/components/RecordCalendarCardCellHoveredPortalContent.tsx
+++ b/packages/twenty-front/src/modules/object-record/record-calendar/record-calendar-card/anchored-portal/components/RecordCalendarCardCellHoveredPortalContent.tsx
@@ -1,6 +1,6 @@
-import { RECORD_CALENDAR_CARD_INPUT_ID_PREFIX } from '@/object-record/record-calendar/record-calendar-card/constants/RecordCalendarCardInputIdPrefix';
 import { recordCalendarCardEditModePositionComponentState } from '@/object-record/record-calendar/record-calendar-card/states/recordCalendarCardEditModePositionComponentState';
 import { recordCalendarCardHoverPositionComponentState } from '@/object-record/record-calendar/record-calendar-card/states/recordCalendarCardHoverPositionComponentState';
+import { getRecordCalendarCardInstanceIdPrefix } from '@/object-record/record-calendar/record-calendar-card/utils/getRecordCalendarCardInstanceIdPrefix';
 import { FieldDisplay } from '@/object-record/record-field/ui/components/FieldDisplay';
 import { FieldInput } from '@/object-record/record-field/ui/components/FieldInput';
 import { FieldContext } from '@/object-record/record-field/ui/contexts/FieldContext';
@@ -13,12 +13,21 @@ import { getRecordFieldInputInstanceId } from '@/object-record/utils/getRecordFi
 import { useAtomComponentState } from '@/ui/utilities/state/jotai/hooks/useAtomComponentState';
 import { useSetAtomComponentState } from '@/ui/utilities/state/jotai/hooks/useSetAtomComponentState';
 import { useContext } from 'react';
+import { RECORD_CALENDAR_CARD_INPUT_ID_PREFIX } from '@/object-record/record-calendar/record-calendar-card/constants/RecordCalendarCardInputIdPrefix';
 
-export const RecordCalendarCardCellHoveredPortalContent = () => {
+type RecordCalendarCardCellHoveredPortalContentProps = {
+  calendarDay: string;
+};
+
+export const RecordCalendarCardCellHoveredPortalContent = ({
+  calendarDay,
+}: RecordCalendarCardCellHoveredPortalContentProps) => {
   const { editModeContentOnly, isCentered } = useRecordInlineCellContext();
 
   const { isRecordFieldReadOnly, recordId, fieldDefinition } =
     useContext(FieldContext);
+
+  const cardInstanceIdPrefix = getRecordCalendarCardInstanceIdPrefix(calendarDay);
 
   const { openInlineCell } = useInlineCell(
     getRecordFieldInputInstanceId({
@@ -47,7 +56,7 @@ export const RecordCalendarCardCellHoveredPortalContent = () => {
       openFieldInput({
         fieldDefinition,
         recordId,
-        prefix: RECORD_CALENDAR_CARD_INPUT_ID_PREFIX,
+        prefix: cardInstanceIdPrefix,
         onFileUploadClose: () => setRecordCalendarCardEditModePosition(null),
       });
     }

--- a/packages/twenty-front/src/modules/object-record/record-calendar/record-calendar-card/components/RecordCalendarCard.tsx
+++ b/packages/twenty-front/src/modules/object-record/record-calendar/record-calendar-card/components/RecordCalendarCard.tsx
@@ -7,8 +7,8 @@ import { RecordCalendarCardBody } from '@/object-record/record-calendar/record-c
 import { RecordCalendarCardHeader } from '@/object-record/record-calendar/record-calendar-card/components/RecordCalendarCardHeader';
 import { RecordDragMultiDragStack } from '@/object-record/record-drag/components/RecordDragMultiDragStack';
 import { RECORD_CALENDAR_CARD_CLICK_OUTSIDE_ID } from '@/object-record/record-calendar/record-calendar-card/constants/RecordCalendarCardClickOutsideId';
-import { RECORD_CALENDAR_CARD_INPUT_ID_PREFIX } from '@/object-record/record-calendar/record-calendar-card/constants/RecordCalendarCardInputIdPrefix';
 import { RecordCalendarCardComponentInstanceContext } from '@/object-record/record-calendar/record-calendar-card/states/contexts/RecordCalendarCardComponentInstanceContext';
+import { getRecordCalendarCardInstanceIdPrefix } from '@/object-record/record-calendar/record-calendar-card/utils/getRecordCalendarCardInstanceIdPrefix';
 import { isRecordCalendarCardSelectedComponentFamilyState } from '@/object-record/record-calendar/record-calendar-card/states/isRecordCalendarCardSelectedComponentFamilyState';
 import { RecordCalendarComponentInstanceContext } from '@/object-record/record-calendar/states/contexts/RecordCalendarComponentInstanceContext';
 import { RecordCard } from '@/object-record/record-card/components/RecordCard';
@@ -47,11 +47,13 @@ const StyledCardContainer = styled.div<{ isPrimaryMultiDrag?: boolean }>`
 
 type RecordCalendarCardProps = {
   recordId: string;
+  calendarDay: string;
   isDragOverlay?: boolean;
 };
 
 export const RecordCalendarCard = ({
   recordId,
+  calendarDay,
   isDragOverlay = false,
 }: RecordCalendarCardProps) => {
   const { currentView } = useGetCurrentViewOnly();
@@ -132,11 +134,13 @@ export const RecordCalendarCard = ({
   return (
     <RecordCalendarCardComponentInstanceContext.Provider
       value={{
-        instanceId: recordId,
+        instanceId: `${recordId}-${calendarDay}`,
       }}
     >
       <RecordFieldsScopeContextProvider
-        value={{ scopeInstanceId: RECORD_CALENDAR_CARD_INPUT_ID_PREFIX }}
+        value={{
+          scopeInstanceId: getRecordCalendarCardInstanceIdPrefix(calendarDay),
+        }}
       >
         <StyledContainer onContextMenu={handleContextMenuOpen}>
           <StyledRecordCardContainer>
@@ -161,6 +165,7 @@ export const RecordCalendarCard = ({
                 >
                   <RecordCalendarCardBody
                     recordId={recordId}
+                    calendarDay={calendarDay}
                     isRecordReadOnly={false}
                   />
                 </AnimatedEaseInOut>
@@ -169,8 +174,14 @@ export const RecordCalendarCard = ({
           </StyledRecordCardContainer>
           {!isDragOverlay && (
             <>
-              <RecordCalendarCardCellHoveredPortal recordId={recordId} />
-              <RecordCalendarCardCellEditModePortal recordId={recordId} />
+              <RecordCalendarCardCellHoveredPortal
+                recordId={recordId}
+                calendarDay={calendarDay}
+              />
+              <RecordCalendarCardCellEditModePortal
+                recordId={recordId}
+                calendarDay={calendarDay}
+              />
             </>
           )}
         </StyledContainer>

--- a/packages/twenty-front/src/modules/object-record/record-calendar/record-calendar-card/components/RecordCalendarCardBody.tsx
+++ b/packages/twenty-front/src/modules/object-record/record-calendar/record-calendar-card/components/RecordCalendarCardBody.tsx
@@ -3,7 +3,6 @@ import { useUpdateOneRecord } from '@/object-record/hooks/useUpdateOneRecord';
 import { isRecordFieldReadOnly } from '@/object-record/read-only/utils/isRecordFieldReadOnly';
 import { StopPropagationContainer } from '@/object-record/record-board/record-board-card/components/StopPropagationContainer';
 import { useRecordCalendarContextOrThrow } from '@/object-record/record-calendar/contexts/RecordCalendarContext';
-import { RECORD_CALENDAR_CARD_INPUT_ID_PREFIX } from '@/object-record/record-calendar/record-calendar-card/constants/RecordCalendarCardInputIdPrefix';
 import { recordCalendarCardHoverPositionComponentState } from '@/object-record/record-calendar/record-calendar-card/states/recordCalendarCardHoverPositionComponentState';
 import { getRecordCalendarCardInstanceIdPrefix } from '@/object-record/record-calendar/record-calendar-card/utils/getRecordCalendarCardInstanceIdPrefix';
 import { RecordCardBodyContainer } from '@/object-record/record-card/components/RecordCardBodyContainer';
@@ -35,7 +34,8 @@ export const RecordCalendarCardBody = ({
   const { objectPermissions, objectMetadataItem } =
     useRecordCalendarContextOrThrow();
 
-  const cardInstanceIdPrefix = getRecordCalendarCardInstanceIdPrefix(calendarDay);
+  const cardInstanceIdPrefix =
+    getRecordCalendarCardInstanceIdPrefix(calendarDay);
 
   const { updateOneRecord } = useUpdateOneRecord();
 

--- a/packages/twenty-front/src/modules/object-record/record-calendar/record-calendar-card/components/RecordCalendarCardBody.tsx
+++ b/packages/twenty-front/src/modules/object-record/record-calendar/record-calendar-card/components/RecordCalendarCardBody.tsx
@@ -5,6 +5,7 @@ import { StopPropagationContainer } from '@/object-record/record-board/record-bo
 import { useRecordCalendarContextOrThrow } from '@/object-record/record-calendar/contexts/RecordCalendarContext';
 import { RECORD_CALENDAR_CARD_INPUT_ID_PREFIX } from '@/object-record/record-calendar/record-calendar-card/constants/RecordCalendarCardInputIdPrefix';
 import { recordCalendarCardHoverPositionComponentState } from '@/object-record/record-calendar/record-calendar-card/states/recordCalendarCardHoverPositionComponentState';
+import { getRecordCalendarCardInstanceIdPrefix } from '@/object-record/record-calendar/record-calendar-card/utils/getRecordCalendarCardInstanceIdPrefix';
 import { RecordCardBodyContainer } from '@/object-record/record-card/components/RecordCardBodyContainer';
 import { visibleRecordFieldsComponentSelector } from '@/object-record/record-field/states/visibleRecordFieldsComponentSelector';
 import {
@@ -22,15 +23,19 @@ import { themeCssVariables } from 'twenty-ui/theme-constants';
 
 type RecordCalendarCardBodyProps = {
   recordId: string;
+  calendarDay: string;
   isRecordReadOnly: boolean;
 };
 
 export const RecordCalendarCardBody = ({
   recordId,
+  calendarDay,
   isRecordReadOnly,
 }: RecordCalendarCardBodyProps) => {
   const { objectPermissions, objectMetadataItem } =
     useRecordCalendarContextOrThrow();
+
+  const cardInstanceIdPrefix = getRecordCalendarCardInstanceIdPrefix(calendarDay);
 
   const { updateOneRecord } = useUpdateOneRecord();
 
@@ -108,7 +113,7 @@ export const RecordCalendarCardBody = ({
                 useUpdateRecord: useUpdateOneRecordHook,
                 isDisplayModeFixHeight: true,
                 triggerEvent: 'CLICK',
-                anchorId: `${RECORD_CALENDAR_CARD_INPUT_ID_PREFIX}-${recordId}-${correspondingFieldDefinition.metadata.fieldName}`,
+                anchorId: `${cardInstanceIdPrefix}-${recordId}-${correspondingFieldDefinition.metadata.fieldName}`,
                 onMouseEnter: () => handleMouseEnter(index),
               }}
             >
@@ -117,13 +122,11 @@ export const RecordCalendarCardBody = ({
                   instanceId: getRecordFieldInputInstanceId({
                     recordId,
                     fieldName: correspondingFieldDefinition.metadata.fieldName,
-                    prefix: RECORD_CALENDAR_CARD_INPUT_ID_PREFIX,
+                    prefix: cardInstanceIdPrefix,
                   }),
                 }}
               >
-                <RecordInlineCell
-                  instanceIdPrefix={RECORD_CALENDAR_CARD_INPUT_ID_PREFIX}
-                />
+                <RecordInlineCell instanceIdPrefix={cardInstanceIdPrefix} />
               </RecordFieldComponentInstanceContext.Provider>
             </FieldContext.Provider>
           </StopPropagationContainer>

--- a/packages/twenty-front/src/modules/object-record/record-calendar/record-calendar-card/components/RecordCalendarCardDragOverlayContent.tsx
+++ b/packages/twenty-front/src/modules/object-record/record-calendar/record-calendar-card/components/RecordCalendarCardDragOverlayContent.tsx
@@ -2,7 +2,7 @@ import { type Draggable } from '@dnd-kit/dom';
 import { isDefined } from 'twenty-shared/utils';
 
 import { RecordCalendarMonthContextProvider } from '@/object-record/record-calendar/month/contexts/RecordCalendarMonthContext';
-import { RecordCalendarCardComponentInstanceContext } from '@/object-record/record-calendar/record-calendar-card/states/contexts/RecordCalendarCardComponentInstanceContext';
+import { RECORD_CALENDAR_CARD_DRAG_OVERLAY_CALENDAR_DAY } from '@/object-record/record-calendar/record-calendar-card/constants/RecordCalendarCardDragOverlayCalendarDay';
 import { RecordCalendarCard } from '@/object-record/record-calendar/record-calendar-card/components/RecordCalendarCard';
 import { useRecordCalendarMonthDaysRange } from '@/object-record/record-calendar/month/hooks/useRecordCalendarMonthDaysRange';
 import { getRecordIdFromRecordCalendarCardDraggableId } from '@/object-record/record-calendar/record-calendar-card/utils/getRecordCalendarCardDraggableId';
@@ -50,12 +50,12 @@ export const RecordCalendarCardDragOverlayContent = ({
         weekStartsOnDayIndex,
       }}
     >
-      <RecordCalendarCardComponentInstanceContext.Provider
-        value={{ instanceId: recordId }}
-      >
-        <RecordCalendarCard recordId={recordId} isDragOverlay />
-        <RecordCalendarCardMultiDragPreview recordId={recordId} />
-      </RecordCalendarCardComponentInstanceContext.Provider>
+      <RecordCalendarCard
+        recordId={recordId}
+        calendarDay={RECORD_CALENDAR_CARD_DRAG_OVERLAY_CALENDAR_DAY}
+        isDragOverlay
+      />
+      <RecordCalendarCardMultiDragPreview recordId={recordId} />
     </RecordCalendarMonthContextProvider>
   );
 };

--- a/packages/twenty-front/src/modules/object-record/record-calendar/record-calendar-card/components/RecordCalendarCardDraggableContainer.tsx
+++ b/packages/twenty-front/src/modules/object-record/record-calendar/record-calendar-card/components/RecordCalendarCardDraggableContainer.tsx
@@ -3,7 +3,6 @@ import { styled } from '@linaria/react';
 import { RECORD_CALENDAR_CARD_DND_TYPE } from '@/object-record/record-calendar/month/constants/RecordCalendarCardDndType';
 import { RecordCalendarCard } from '@/object-record/record-calendar/record-calendar-card/components/RecordCalendarCard';
 import { useIsRecordCalendarCardDragDisabled } from '@/object-record/record-calendar/record-calendar-card/hooks/useIsRecordCalendarCardDragDisabled';
-import { RecordCalendarCardComponentInstanceContext } from '@/object-record/record-calendar/record-calendar-card/states/contexts/RecordCalendarCardComponentInstanceContext';
 import { getRecordCalendarCardDraggableId } from '@/object-record/record-calendar/record-calendar-card/utils/getRecordCalendarCardDraggableId';
 import { DragDropItemSortableCell } from '@/ui/utilities/drag-and-drop/components/DragDropItemSortableCell';
 
@@ -31,25 +30,21 @@ export const RecordCalendarCardDraggableContainer = ({
   });
 
   return (
-    <RecordCalendarCardComponentInstanceContext.Provider
-      value={{ instanceId: recordId }}
+    <DragDropItemSortableCell
+      id={draggableId}
+      index={index}
+      group={calendarDay}
+      type={RECORD_CALENDAR_CARD_DND_TYPE}
+      accept={RECORD_CALENDAR_CARD_DND_TYPE}
+      disabled={dragIsDisabled}
+      fadeSourceWhileDragging
     >
-      <DragDropItemSortableCell
-        id={draggableId}
-        index={index}
-        group={calendarDay}
-        type={RECORD_CALENDAR_CARD_DND_TYPE}
-        accept={RECORD_CALENDAR_CARD_DND_TYPE}
-        disabled={dragIsDisabled}
-        fadeSourceWhileDragging
+      <StyledDraggableContainer
+        id={`record-calendar-card-${recordId}-${calendarDay}`}
+        data-selectable-id={recordId}
       >
-        <StyledDraggableContainer
-          id={`record-calendar-card-${recordId}-${calendarDay}`}
-          data-selectable-id={recordId}
-        >
-          <RecordCalendarCard recordId={recordId} />
-        </StyledDraggableContainer>
-      </DragDropItemSortableCell>
-    </RecordCalendarCardComponentInstanceContext.Provider>
+        <RecordCalendarCard recordId={recordId} calendarDay={calendarDay} />
+      </StyledDraggableContainer>
+    </DragDropItemSortableCell>
   );
 };

--- a/packages/twenty-front/src/modules/object-record/record-calendar/record-calendar-card/components/__tests__/RecordCalendarCard.test.tsx
+++ b/packages/twenty-front/src/modules/object-record/record-calendar/record-calendar-card/components/__tests__/RecordCalendarCard.test.tsx
@@ -97,7 +97,7 @@ describe('RecordCalendarCard', () => {
       currentView: { isCompact: false },
     });
 
-    render(<RecordCalendarCard recordId="record-id" />);
+    render(<RecordCalendarCard recordId="record-id" calendarDay="2024-01-01" />);
 
     expect(screen.getByTestId('card-header')).toBeInTheDocument();
     expect(screen.getByTestId('card-body')).toBeInTheDocument();
@@ -112,7 +112,7 @@ describe('RecordCalendarCard', () => {
       currentView: { isCompact: true },
     });
 
-    render(<RecordCalendarCard recordId="record-id" />);
+    render(<RecordCalendarCard recordId="record-id" calendarDay="2024-01-01" />);
 
     expect(screen.getByTestId('card-header')).toBeInTheDocument();
     expect(screen.queryByTestId('card-body')).not.toBeInTheDocument();

--- a/packages/twenty-front/src/modules/object-record/record-calendar/record-calendar-card/components/__tests__/RecordCalendarCard.test.tsx
+++ b/packages/twenty-front/src/modules/object-record/record-calendar/record-calendar-card/components/__tests__/RecordCalendarCard.test.tsx
@@ -97,7 +97,9 @@ describe('RecordCalendarCard', () => {
       currentView: { isCompact: false },
     });
 
-    render(<RecordCalendarCard recordId="record-id" calendarDay="2024-01-01" />);
+    render(
+      <RecordCalendarCard recordId="record-id" calendarDay="2024-01-01" />,
+    );
 
     expect(screen.getByTestId('card-header')).toBeInTheDocument();
     expect(screen.getByTestId('card-body')).toBeInTheDocument();
@@ -112,7 +114,9 @@ describe('RecordCalendarCard', () => {
       currentView: { isCompact: true },
     });
 
-    render(<RecordCalendarCard recordId="record-id" calendarDay="2024-01-01" />);
+    render(
+      <RecordCalendarCard recordId="record-id" calendarDay="2024-01-01" />,
+    );
 
     expect(screen.getByTestId('card-header')).toBeInTheDocument();
     expect(screen.queryByTestId('card-body')).not.toBeInTheDocument();

--- a/packages/twenty-front/src/modules/object-record/record-calendar/record-calendar-card/constants/RecordCalendarCardDragOverlayCalendarDay.ts
+++ b/packages/twenty-front/src/modules/object-record/record-calendar/record-calendar-card/constants/RecordCalendarCardDragOverlayCalendarDay.ts
@@ -1,0 +1,1 @@
+export const RECORD_CALENDAR_CARD_DRAG_OVERLAY_CALENDAR_DAY = 'drag-overlay';

--- a/packages/twenty-front/src/modules/object-record/record-calendar/record-calendar-card/utils/getRecordCalendarCardInstanceIdPrefix.ts
+++ b/packages/twenty-front/src/modules/object-record/record-calendar/record-calendar-card/utils/getRecordCalendarCardInstanceIdPrefix.ts
@@ -1,0 +1,4 @@
+import { RECORD_CALENDAR_CARD_INPUT_ID_PREFIX } from '@/object-record/record-calendar/record-calendar-card/constants/RecordCalendarCardInputIdPrefix';
+
+export const getRecordCalendarCardInstanceIdPrefix = (calendarDay: string) =>
+  `${RECORD_CALENDAR_CARD_INPUT_ID_PREFIX}-${calendarDay}`;

--- a/packages/twenty-front/src/modules/object-record/record-calendar/time-grid/components/RecordCalendarTimeGridAllDayCell.tsx
+++ b/packages/twenty-front/src/modules/object-record/record-calendar/time-grid/components/RecordCalendarTimeGridAllDayCell.tsx
@@ -44,7 +44,7 @@ export const RecordCalendarTimeGridAllDayCell = ({
     <StyledAllDayCell>
       {allDayRecordIds.map((recordId) => (
         <StyledCardContainer key={recordId} data-selectable-id={recordId}>
-          <RecordCalendarCard recordId={recordId} />
+          <RecordCalendarCard recordId={recordId} calendarDay={day.toString()} />
         </StyledCardContainer>
       ))}
     </StyledAllDayCell>

--- a/packages/twenty-front/src/modules/object-record/record-calendar/time-grid/components/RecordCalendarTimeGridAllDayCell.tsx
+++ b/packages/twenty-front/src/modules/object-record/record-calendar/time-grid/components/RecordCalendarTimeGridAllDayCell.tsx
@@ -44,7 +44,10 @@ export const RecordCalendarTimeGridAllDayCell = ({
     <StyledAllDayCell>
       {allDayRecordIds.map((recordId) => (
         <StyledCardContainer key={recordId} data-selectable-id={recordId}>
-          <RecordCalendarCard recordId={recordId} calendarDay={day.toString()} />
+          <RecordCalendarCard
+            recordId={recordId}
+            calendarDay={day.toString()}
+          />
         </StyledCardContainer>
       ))}
     </StyledAllDayCell>


### PR DESCRIPTION
Fixes: #23960

https://github.com/user-attachments/assets/4885aa27-f2d4-484c-bd5d-dff9c10529f9


### Problem
- When a record spans several days, the calendar draws it as one card per day. Every one of those cards was identified only by the record's id, so the app couldn't tell them apart.
- Because they looked identical, the cards shared the same hover and edit state. Hovering a cell on a later card lit up the same cell on the first card too.
- For the same reason, every card pointed at the first card's DOM element. So clicking a cell on a later card opened the editor on the first card, and the card you actually clicked did nothing.

### Fix
- Gave each card its own identity by combining the record id with its day, so the cards are now distinct and no longer share state.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/23962?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

