### PR TITLE
fix(server): scope post-commit cache invalidation to mutated metadata

### DIFF
--- a/packages/twenty-server/src/engine/workspace-manager/workspace-migration/workspace-migration-runner/services/workspace-migration-runner.service.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/workspace-migration/workspace-migration-runner/services/workspace-migration-runner.service.ts
@@ -27,6 +27,7 @@ import {
 } from 'src/engine/workspace-manager/workspace-migration/workspace-migration-runner/exceptions/workspace-migration-runner.exception';
 import { WorkspaceMigrationRunnerActionHandlerRegistryService } from 'src/engine/workspace-manager/workspace-migration/workspace-migration-runner/registry/workspace-migration-runner-action-handler-registry.service';
 import { buildPreallocatedIdByUniversalIdentifierFromActions } from 'src/engine/workspace-manager/workspace-migration/workspace-migration-runner/utils/build-preallocated-id-by-universal-identifier-from-actions.util';
+import { getInvalidatedMetadataNamesFromActions } from 'src/engine/workspace-manager/workspace-migration/workspace-migration-runner/utils/get-invalidated-metadata-names-from-actions.util';
 import { type AfterCommitSideEffect } from 'src/engine/workspace-manager/workspace-migration/workspace-migration-runner/types/after-commit-side-effect.type';
 import { type MetadataEvent } from 'src/engine/workspace-manager/workspace-migration/workspace-migration-runner/types/metadata-event';
 
@@ -294,6 +295,17 @@ export class WorkspaceMigrationRunnerService {
       getMetadataFlatEntityMapsKey,
     );
 
+    // The wide set above is required to read every related map for validation,
+    // but post-commit invalidation only needs the maps a mutation can actually
+    // change. Recomputing validation-only maps (e.g. object/field metadata for a
+    // viewField position update) is the dominant cost on metadata-heavy workspaces.
+    const invalidatedFlatEntityMapsKeys = [
+      ...new Set([
+        ...getInvalidatedMetadataNamesFromActions(actions),
+        ...searchVectorRebuildMetadataNames,
+      ]),
+    ].map(getMetadataFlatEntityMapsKey);
+
     let allFlatEntityMaps =
       await this.flatEntityMapsCacheService.getOrRecomputeManyOrAllFlatEntityMaps<
         typeof allFlatEntityMapsKeys
@@ -515,7 +527,7 @@ export class WorkspaceMigrationRunnerService {
 
     try {
       await this.invalidateCache({
-        allFlatEntityMapsKeys,
+        allFlatEntityMapsKeys: invalidatedFlatEntityMapsKeys,
         workspaceId,
       });
 
@@ -541,7 +553,7 @@ export class WorkspaceMigrationRunnerService {
       performance.now() - postCommitInvalidateStart;
 
     this.logger.perf(
-      `[install-perf] Runner post-commit invalidateCache took ${postCommitInvalidateMs.toFixed(1)}ms for ${allFlatEntityMapsKeys.length} flat-maps keys`,
+      `[install-perf] Runner post-commit invalidateCache took ${postCommitInvalidateMs.toFixed(1)}ms for ${invalidatedFlatEntityMapsKeys.length} flat-maps keys`,
       'Runner',
     );
 

--- a/packages/twenty-server/src/engine/workspace-manager/workspace-migration/workspace-migration-runner/utils/__tests__/get-invalidated-metadata-names-from-actions.util.spec.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/workspace-migration/workspace-migration-runner/utils/__tests__/get-invalidated-metadata-names-from-actions.util.spec.ts
@@ -1,0 +1,109 @@
+import { type AllUniversalWorkspaceMigrationAction } from 'src/engine/workspace-manager/workspace-migration/workspace-migration-builder/types/workspace-migration-action-common';
+import { getInvalidatedMetadataNamesFromActions } from 'src/engine/workspace-manager/workspace-migration/workspace-migration-runner/utils/get-invalidated-metadata-names-from-actions.util';
+
+const asActions = (
+  actions: unknown[],
+): AllUniversalWorkspaceMigrationAction[] =>
+  actions as AllUniversalWorkspaceMigrationAction[];
+
+describe('getInvalidatedMetadataNamesFromActions', () => {
+  it('invalidates only the mutated map for an attribute-only update', () => {
+    const result = getInvalidatedMetadataNamesFromActions(
+      asActions([
+        {
+          type: 'update',
+          metadataName: 'viewField',
+          universalIdentifier: 'view-field-1',
+          update: { position: 3 },
+        },
+      ]),
+    );
+
+    expect(result).toEqual(['viewField']);
+  });
+
+  it('invalidates related maps when an update moves a relation foreign key', () => {
+    const result = getInvalidatedMetadataNamesFromActions(
+      asActions([
+        {
+          type: 'update',
+          metadataName: 'viewField',
+          universalIdentifier: 'view-field-1',
+          update: { viewFieldGroupId: 'group-2' },
+        },
+      ]),
+    );
+
+    expect(result.sort()).toEqual(
+      ['fieldMetadata', 'view', 'viewField', 'viewFieldGroup'].sort(),
+    );
+    expect(result).not.toContain('objectMetadata');
+  });
+
+  it('detects relation changes expressed with a universal foreign key', () => {
+    const result = getInvalidatedMetadataNamesFromActions(
+      asActions([
+        {
+          type: 'update',
+          metadataName: 'viewField',
+          universalIdentifier: 'view-field-1',
+          update: { viewFieldGroupUniversalIdentifier: 'group-2' },
+        },
+      ]),
+    );
+
+    expect(result).toContain('viewFieldGroup');
+  });
+
+  it('invalidates related maps on create', () => {
+    const result = getInvalidatedMetadataNamesFromActions(
+      asActions([
+        {
+          type: 'create',
+          metadataName: 'viewField',
+          flatEntity: {},
+        },
+      ]),
+    );
+
+    expect(result.sort()).toEqual(
+      ['fieldMetadata', 'view', 'viewField', 'viewFieldGroup'].sort(),
+    );
+  });
+
+  it('invalidates related maps on delete', () => {
+    const result = getInvalidatedMetadataNamesFromActions(
+      asActions([
+        {
+          type: 'delete',
+          metadataName: 'viewField',
+          universalIdentifier: 'view-field-1',
+        },
+      ]),
+    );
+
+    expect(result).toContain('view');
+    expect(result).toContain('viewField');
+  });
+
+  it('deduplicates across multiple actions', () => {
+    const result = getInvalidatedMetadataNamesFromActions(
+      asActions([
+        {
+          type: 'update',
+          metadataName: 'viewField',
+          universalIdentifier: 'view-field-1',
+          update: { position: 1 },
+        },
+        {
+          type: 'update',
+          metadataName: 'viewField',
+          universalIdentifier: 'view-field-2',
+          update: { position: 2 },
+        },
+      ]),
+    );
+
+    expect(result).toEqual(['viewField']);
+  });
+});

--- a/packages/twenty-server/src/engine/workspace-manager/workspace-migration/workspace-migration-runner/utils/get-invalidated-metadata-names-from-actions.util.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/workspace-migration/workspace-migration-runner/utils/get-invalidated-metadata-names-from-actions.util.ts
@@ -1,0 +1,54 @@
+import { type AllMetadataName } from 'twenty-shared/metadata';
+import { isDefined } from 'twenty-shared/utils';
+
+import { ALL_MANY_TO_ONE_METADATA_RELATIONS } from 'src/engine/metadata-modules/flat-entity/constant/all-many-to-one-metadata-relations.constant';
+import { getMetadataRelatedMetadataNames } from 'src/engine/metadata-modules/flat-entity/utils/get-metadata-related-metadata-names.util';
+import { getMetadataSerializedRelationNames } from 'src/engine/metadata-modules/flat-entity/utils/get-metadata-serialized-relation-names.util';
+import { type AllUniversalWorkspaceMigrationAction } from 'src/engine/workspace-manager/workspace-migration/workspace-migration-builder/types/workspace-migration-action-common';
+
+const getMetadataManyToOneForeignKeys = (
+  metadataName: AllMetadataName,
+): string[] =>
+  Object.values(ALL_MANY_TO_ONE_METADATA_RELATIONS[metadataName])
+    .filter(isDefined)
+    .flatMap((relation) => [relation.foreignKey, relation.universalForeignKey]);
+
+// A mutation only affects a related entity's cached flat map when it changes
+// which entities reference each other: create, delete, or an update that moves
+// a relation foreign key. A plain attribute update (e.g. a viewField position
+// change) leaves every related map untouched, so only the mutated entity's own
+// map needs invalidation.
+const actionChangesRelationMembership = (
+  action: AllUniversalWorkspaceMigrationAction,
+): boolean => {
+  if (action.type !== 'update') {
+    return true;
+  }
+
+  const foreignKeys = getMetadataManyToOneForeignKeys(action.metadataName);
+
+  return Object.keys(action.update).some((updatedKey) =>
+    foreignKeys.includes(updatedKey),
+  );
+};
+
+export const getInvalidatedMetadataNamesFromActions = (
+  actions: AllUniversalWorkspaceMigrationAction[],
+): AllMetadataName[] => {
+  const metadataNames = new Set<AllMetadataName>();
+
+  for (const action of actions) {
+    metadataNames.add(action.metadataName);
+
+    if (actionChangesRelationMembership(action)) {
+      getMetadataRelatedMetadataNames(action.metadataName).forEach(
+        (metadataName) => metadataNames.add(metadataName),
+      );
+      getMetadataSerializedRelationNames(action.metadataName).forEach(
+        (metadataName) => metadataNames.add(metadataName),
+      );
+    }
+  }
+
+  return [...metadataNames];
+};


### PR DESCRIPTION
## Problem

Closes #23918.

Reordering a single column in a record-table view runs a 1 ms single-row `UPDATE` on `core."viewField"`, then spends 230-450 ms in post-commit cache invalidation, recomputing five flat entity maps including the two heaviest (`flatObjectMetadataMaps`, `flatFieldMetadataMaps`). A view-field position change cannot affect object or field metadata, so that work is wasted, and it scales with total workspace metadata size.

## Root cause

`WorkspaceMigrationRunnerService` builds one wide key set (`allFlatEntityMapsKeys`) from action + related + validation metadata. That set is correct for the **initial cache retrieval** (validation needs to read the parent maps), but it is then reused for **post-commit invalidation**. For a `viewField` update this expands to `flatViewFieldMaps, flatFieldMetadataMaps, flatViewMaps, flatViewFieldGroupMaps, flatObjectMetadataMaps`. Because the set contains `flatFieldMetadataMaps`/`flatObjectMetadataMaps`, it also trips `shouldIncrementMetadataGraphqlSchemaVersion`, firing the legacy ORM/roles/metadata-version cascade on top.

## Fix

Derive the post-commit invalidation set from what each action actually mutates, not from validation dependencies:

- **create / delete**: mutated map + many-to-one parent maps + serialized-relation maps. Parent flat maps store back-reference id arrays (`flatFieldMetadataMaps.viewFieldIds`, `flatViewMaps.viewFieldIds`, the viewFieldGroup aggregator), so their caches genuinely change when a child is added or removed.
- **update**: mutated map only, unless the update moves a relation foreign key (reparent), in which case related maps are included too. Foreign-key detection checks both the flat `foreignKey` and the `universalForeignKey`, since the runner operates on universal actions.
- validation-only dependencies are never invalidated.

The wide set is still used for initial retrieval/validation. Only the post-commit invalidation is narrowed. The search-vector rebuild path keeps invalidating `flatIndexMaps`.

### Effect for a viewField position drag

| | before | after |
|---|---|---|
| maps flushed + recomputed | 5 | 1 (`flatViewFieldMaps`) |
| `shouldIncrementMetadataGraphqlSchemaVersion` | true | false |
| legacy ORM/roles/version cascade | fires | skipped |

## Scope / deliberately unchanged

- The rollback-path invalidation still uses the wide set (rare error path, DB is unchanged, broad is safe).
- `hasSchemaMetadataChanged` is still derived from the wide set to avoid changing the application-manifest apply flow. The perf win does not depend on it.

## Tests

Unit test covering attribute-only update (narrow), foreign-key reparent (flat and universal key), create, delete, and dedup across actions.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/23964?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

