### PR TITLE
feat: let send_email/draft_email select the sender by email address (fromHandle)

### DIFF
--- a/packages/twenty-server/src/engine/core-modules/tool/tools/email-tool/draft-email-tool.ts
+++ b/packages/twenty-server/src/engine/core-modules/tool/tools/email-tool/draft-email-tool.ts
@@ -17,7 +17,7 @@ export class DraftEmailTool implements Tool {
   private readonly logger = new Logger(DraftEmailTool.name);
 
   description =
-    'Create a draft email using a connected account. The email will be saved as a draft, not sent.';
+    'Create a draft email using a connected account. The email will be saved as a draft, not sent. To choose the sender, pass fromHandle with the email address to draft from (or connectedAccountId if you already have its UUID); otherwise the default connected account is used.';
   inputSchema = EmailToolInputZodSchema;
 
   constructor(

--- a/packages/twenty-server/src/engine/core-modules/tool/tools/email-tool/email-composer.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/tool/tools/email-tool/email-composer.service.ts
@@ -22,7 +22,9 @@ import {
 } from 'src/engine/core-modules/tool/tools/email-tool/exceptions/email-tool.exception';
 import { type ComposeEmailParams } from 'src/engine/core-modules/tool/tools/email-tool/types/compose-email-params.type';
 import { EmailComposerResult } from 'src/engine/core-modules/tool/tools/email-tool/types/email-composer-result.type';
+import { getUsableConnectedAccountHandles } from 'src/engine/core-modules/tool/tools/email-tool/utils/get-usable-connected-account-handles.util';
 import { parseCommaSeparatedEmails } from 'src/engine/core-modules/tool/tools/email-tool/utils/parse-comma-separated-emails.util';
+import { selectConnectedAccountIdByHandle } from 'src/engine/core-modules/tool/tools/email-tool/utils/select-connected-account-id-by-handle.util';
 import { selectConnectedAccountIdForCaller } from 'src/engine/core-modules/tool/tools/email-tool/utils/select-connected-account-id-for-caller.util';
 import { type ToolExecutionContext } from 'src/engine/core-modules/tool/types/tool-execution-context.type';
 import { ConnectedAccountEntity } from 'src/engine/metadata-modules/connected-account/entities/connected-account.entity';
@@ -128,6 +130,57 @@ export class EmailComposerService {
         if (!isDefined(connectedAccountId)) {
           throw new EmailToolException(
             `No connected account available for user workspace '${userWorkspaceId}'`,
+            EmailToolExceptionCode.CONNECTED_ACCOUNT_NOT_FOUND,
+          );
+        }
+
+        return connectedAccountId;
+      },
+      authContext,
+    );
+  }
+
+  private async getConnectedAccountIdByHandleOrThrow({
+    fromHandle,
+    workspaceId,
+    userWorkspaceId,
+  }: {
+    fromHandle: string;
+    workspaceId: string;
+    userWorkspaceId?: string;
+  }): Promise<string> {
+    const authContext = buildSystemAuthContext(workspaceId);
+
+    return this.globalWorkspaceOrmManager.executeInWorkspaceContext(
+      async () => {
+        const allAccounts = await this.connectedAccountRepository.find({
+          where: { workspaceId, archivedAt: IsNull() },
+          order: { createdAt: 'ASC', id: 'ASC' },
+        });
+
+        if (!isNonEmptyArray(allAccounts)) {
+          throw new EmailToolException(
+            'No connected accounts found for this workspace',
+            EmailToolExceptionCode.CONNECTED_ACCOUNT_NOT_FOUND,
+          );
+        }
+
+        const connectedAccountId = selectConnectedAccountIdByHandle({
+          connectedAccounts: allAccounts,
+          handle: fromHandle,
+          userWorkspaceId,
+        });
+
+        if (!isDefined(connectedAccountId)) {
+          const usableHandles = getUsableConnectedAccountHandles({
+            connectedAccounts: allAccounts,
+            userWorkspaceId,
+          });
+
+          throw new EmailToolException(
+            isNonEmptyArray(usableHandles)
+              ? `No connected account found for handle '${fromHandle}'. Available handles: ${usableHandles.join(', ')}`
+              : `No connected account found for handle '${fromHandle}', and no connected account is available to you in this workspace`,
             EmailToolExceptionCode.CONNECTED_ACCOUNT_NOT_FOUND,
           );
         }
@@ -338,7 +391,7 @@ export class EmailComposerService {
     context: ToolExecutionContext,
   ): Promise<EmailComposerResult> {
     const { workspaceId, userWorkspaceId } = context;
-    const { subject, body, files, inReplyTo } = parameters;
+    const { subject, body, files, inReplyTo, fromHandle } = parameters;
     let { connectedAccountId } = parameters;
 
     let recipients: { to: string[]; cc: string[]; bcc: string[] };
@@ -374,6 +427,14 @@ export class EmailComposerService {
     }
 
     const toRecipientsDisplay = recipients.to.join(', ');
+
+    if (!connectedAccountId && isNonEmptyString(fromHandle)) {
+      connectedAccountId = await this.getConnectedAccountIdByHandleOrThrow({
+        fromHandle,
+        workspaceId,
+        userWorkspaceId,
+      });
+    }
 
     if (!connectedAccountId) {
       connectedAccountId = await this.getDefaultConnectedAccountIdOrThrow({

--- a/packages/twenty-server/src/engine/core-modules/tool/tools/email-tool/email-tool.schema.ts
+++ b/packages/twenty-server/src/engine/core-modules/tool/tools/email-tool/email-tool.schema.ts
@@ -33,7 +33,13 @@ export const EmailToolInputZodSchema = z.object({
     .string()
     .refine((val) => isValidUuid(val))
     .describe(
-      'The UUID of the connected account to send the email from. Provide this only if you have it; otherwise, leave blank.',
+      'The UUID of the connected account to send the email from. Provide this only if you have it; otherwise use fromHandle, or leave both blank to use the default account.',
+    )
+    .optional(),
+  fromHandle: z
+    .string()
+    .describe(
+      'The email address to send from, e.g. "work@example.com". Resolved server-side to a connected account you are allowed to send from; the send fails listing the available addresses if it is not connected. Use this instead of connectedAccountId when you know the sender address but not its UUID. Ignored when connectedAccountId is provided.',
     )
     .optional(),
   files: z

--- a/packages/twenty-server/src/engine/core-modules/tool/tools/email-tool/send-email-tool.ts
+++ b/packages/twenty-server/src/engine/core-modules/tool/tools/email-tool/send-email-tool.ts
@@ -15,7 +15,7 @@ export class SendEmailTool implements Tool {
   private readonly logger = new Logger(SendEmailTool.name);
 
   description =
-    'Send an email using a connected account. Requires SEND_EMAIL_TOOL permission.';
+    'Send an email using a connected account. To choose the sender, pass fromHandle with the email address to send from (or connectedAccountId if you already have its UUID); otherwise the default connected account is used. Requires SEND_EMAIL_TOOL permission.';
   inputSchema = EmailToolInputZodSchema;
 
   constructor(

--- a/packages/twenty-server/src/engine/core-modules/tool/tools/email-tool/types/compose-email-params.type.ts
+++ b/packages/twenty-server/src/engine/core-modules/tool/tools/email-tool/types/compose-email-params.type.ts
@@ -10,6 +10,7 @@ export type ComposeEmailParams = {
   subject: string;
   body: string | EmailDocument;
   connectedAccountId?: string;
+  fromHandle?: string;
   files?: Array<EmailAttachment>;
   inReplyTo?: string;
 };

--- a/packages/twenty-server/src/engine/core-modules/tool/tools/email-tool/utils/__tests__/get-usable-connected-account-handles.util.spec.ts
+++ b/packages/twenty-server/src/engine/core-modules/tool/tools/email-tool/utils/__tests__/get-usable-connected-account-handles.util.spec.ts
@@ -1,0 +1,68 @@
+import { getUsableConnectedAccountHandles } from 'src/engine/core-modules/tool/tools/email-tool/utils/get-usable-connected-account-handles.util';
+
+const USER_WORKSPACE_ID = '20202020-2222-4222-8222-222222222222';
+const OTHER_USER_WORKSPACE_ID = '20202020-3333-4333-8333-333333333333';
+
+const ownAccount = {
+  handle: 'work@example.com',
+  userWorkspaceId: USER_WORKSPACE_ID,
+  visibility: 'user' as const,
+};
+
+const colleagueAccount = {
+  handle: 'colleague@example.com',
+  userWorkspaceId: OTHER_USER_WORKSPACE_ID,
+  visibility: 'user' as const,
+};
+
+const sharedAccount = {
+  handle: 'contact@example.com',
+  userWorkspaceId: OTHER_USER_WORKSPACE_ID,
+  visibility: 'workspace' as const,
+};
+
+describe('getUsableConnectedAccountHandles', () => {
+  it("lists the caller's own and workspace-shared handles", () => {
+    expect(
+      getUsableConnectedAccountHandles({
+        connectedAccounts: [ownAccount, sharedAccount],
+        userWorkspaceId: USER_WORKSPACE_ID,
+      }),
+    ).toEqual(['work@example.com', 'contact@example.com']);
+  });
+
+  it("omits a colleague's private handle", () => {
+    expect(
+      getUsableConnectedAccountHandles({
+        connectedAccounts: [ownAccount, colleagueAccount],
+        userWorkspaceId: USER_WORKSPACE_ID,
+      }),
+    ).toEqual(['work@example.com']);
+  });
+
+  it('deduplicates handles', () => {
+    expect(
+      getUsableConnectedAccountHandles({
+        connectedAccounts: [ownAccount, { ...sharedAccount, ...ownAccount }],
+        userWorkspaceId: USER_WORKSPACE_ID,
+      }),
+    ).toEqual(['work@example.com']);
+  });
+
+  it('lists every handle when there is no caller', () => {
+    expect(
+      getUsableConnectedAccountHandles({
+        connectedAccounts: [ownAccount, colleagueAccount],
+      }),
+    ).toEqual(['work@example.com', 'colleague@example.com']);
+  });
+
+  it('returns an empty list when no account is usable', () => {
+    expect(
+      getUsableConnectedAccountHandles({
+        connectedAccounts: [colleagueAccount],
+        userWorkspaceId: USER_WORKSPACE_ID,
+      }),
+    ).toEqual([]);
+  });
+});

--- a/packages/twenty-server/src/engine/core-modules/tool/tools/email-tool/utils/__tests__/select-connected-account-id-by-handle.util.spec.ts
+++ b/packages/twenty-server/src/engine/core-modules/tool/tools/email-tool/utils/__tests__/select-connected-account-id-by-handle.util.spec.ts
@@ -1,0 +1,119 @@
+import { selectConnectedAccountIdByHandle } from 'src/engine/core-modules/tool/tools/email-tool/utils/select-connected-account-id-by-handle.util';
+
+const USER_WORKSPACE_ID = '20202020-2222-4222-8222-222222222222';
+const OTHER_USER_WORKSPACE_ID = '20202020-3333-4333-8333-333333333333';
+
+const ownAccount = {
+  id: 'own-account-id',
+  handle: 'work@example.com',
+  userWorkspaceId: USER_WORKSPACE_ID,
+  visibility: 'user' as const,
+};
+
+const otherOwnAccount = {
+  id: 'other-own-account-id',
+  handle: 'personal@example.com',
+  userWorkspaceId: USER_WORKSPACE_ID,
+  visibility: 'user' as const,
+};
+
+const colleagueAccount = {
+  id: 'colleague-account-id',
+  handle: 'colleague@example.com',
+  userWorkspaceId: OTHER_USER_WORKSPACE_ID,
+  visibility: 'user' as const,
+};
+
+const sharedAccount = {
+  id: 'shared-account-id',
+  handle: 'contact@example.com',
+  userWorkspaceId: OTHER_USER_WORKSPACE_ID,
+  visibility: 'workspace' as const,
+};
+
+describe('selectConnectedAccountIdByHandle', () => {
+  it('resolves the account matching the requested handle', () => {
+    expect(
+      selectConnectedAccountIdByHandle({
+        connectedAccounts: [ownAccount, otherOwnAccount],
+        handle: 'personal@example.com',
+        userWorkspaceId: USER_WORKSPACE_ID,
+      }),
+    ).toBe('other-own-account-id');
+  });
+
+  it('does not fall back to another account when the handle is unknown', () => {
+    expect(
+      selectConnectedAccountIdByHandle({
+        connectedAccounts: [ownAccount, otherOwnAccount],
+        handle: 'unknown@example.com',
+        userWorkspaceId: USER_WORKSPACE_ID,
+      }),
+    ).toBeUndefined();
+  });
+
+  it('matches case-insensitively and ignores surrounding whitespace', () => {
+    expect(
+      selectConnectedAccountIdByHandle({
+        connectedAccounts: [ownAccount],
+        handle: '  Work@Example.COM ',
+        userWorkspaceId: USER_WORKSPACE_ID,
+      }),
+    ).toBe('own-account-id');
+  });
+
+  it('resolves an account shared with the whole workspace', () => {
+    expect(
+      selectConnectedAccountIdByHandle({
+        connectedAccounts: [sharedAccount],
+        handle: 'contact@example.com',
+        userWorkspaceId: USER_WORKSPACE_ID,
+      }),
+    ).toBe('shared-account-id');
+  });
+
+  it("refuses a colleague's private account even on an exact handle match", () => {
+    expect(
+      selectConnectedAccountIdByHandle({
+        connectedAccounts: [colleagueAccount],
+        handle: 'colleague@example.com',
+        userWorkspaceId: USER_WORKSPACE_ID,
+      }),
+    ).toBeUndefined();
+  });
+
+  it("prefers the caller's own account when two accounts share a handle", () => {
+    const sharedHandleColleagueAccount = {
+      ...colleagueAccount,
+      handle: 'work@example.com',
+      visibility: 'workspace' as const,
+    };
+
+    expect(
+      selectConnectedAccountIdByHandle({
+        connectedAccounts: [sharedHandleColleagueAccount, ownAccount],
+        handle: 'work@example.com',
+        userWorkspaceId: USER_WORKSPACE_ID,
+      }),
+    ).toBe('own-account-id');
+  });
+
+  it('matches without visibility filtering when there is no caller', () => {
+    expect(
+      selectConnectedAccountIdByHandle({
+        connectedAccounts: [colleagueAccount],
+        handle: 'colleague@example.com',
+      }),
+    ).toBe('colleague-account-id');
+  });
+
+  it('returns undefined when there is no account at all', () => {
+    expect(
+      selectConnectedAccountIdByHandle({
+        connectedAccounts: [],
+        handle: 'work@example.com',
+        userWorkspaceId: USER_WORKSPACE_ID,
+      }),
+    ).toBeUndefined();
+  });
+});

--- a/packages/twenty-server/src/engine/core-modules/tool/tools/email-tool/utils/get-usable-connected-account-handles.util.ts
+++ b/packages/twenty-server/src/engine/core-modules/tool/tools/email-tool/utils/get-usable-connected-account-handles.util.ts
@@ -1,0 +1,32 @@
+import { isDefined } from 'twenty-shared/utils';
+
+import { isConnectedAccountUsableByCaller } from 'src/engine/metadata-modules/connected-account/utils/is-connected-account-usable-by-caller.util';
+import { type ConnectedAccountEntity } from 'src/engine/metadata-modules/connected-account/entities/connected-account.entity';
+
+// Only the handles the caller may actually send from, so the "unknown handle"
+// error can list the valid choices without disclosing a colleague's private
+// connected account.
+export const getUsableConnectedAccountHandles = ({
+  connectedAccounts,
+  userWorkspaceId,
+}: {
+  connectedAccounts: Pick<
+    ConnectedAccountEntity,
+    'handle' | 'visibility' | 'userWorkspaceId'
+  >[];
+  userWorkspaceId?: string;
+}): string[] => {
+  const usableConnectedAccounts = isDefined(userWorkspaceId)
+    ? connectedAccounts.filter((connectedAccount) =>
+        isConnectedAccountUsableByCaller({ connectedAccount, userWorkspaceId }),
+      )
+    : connectedAccounts;
+
+  return [
+    ...new Set(
+      usableConnectedAccounts
+        .map((connectedAccount) => connectedAccount.handle)
+        .filter((handle) => handle.length > 0),
+    ),
+  ];
+};

--- a/packages/twenty-server/src/engine/core-modules/tool/tools/email-tool/utils/normalize-connected-account-handle.util.ts
+++ b/packages/twenty-server/src/engine/core-modules/tool/tools/email-tool/utils/normalize-connected-account-handle.util.ts
@@ -1,0 +1,2 @@
+export const normalizeConnectedAccountHandle = (handle: string): string =>
+  handle.trim().toLowerCase();

--- a/packages/twenty-server/src/engine/core-modules/tool/tools/email-tool/utils/select-connected-account-id-by-handle.util.ts
+++ b/packages/twenty-server/src/engine/core-modules/tool/tools/email-tool/utils/select-connected-account-id-by-handle.util.ts
@@ -1,0 +1,39 @@
+import { isDefined } from 'twenty-shared/utils';
+
+import { normalizeConnectedAccountHandle } from 'src/engine/core-modules/tool/tools/email-tool/utils/normalize-connected-account-handle.util';
+import { selectConnectedAccountIdForCaller } from 'src/engine/core-modules/tool/tools/email-tool/utils/select-connected-account-id-for-caller.util';
+import { type ConnectedAccountEntity } from 'src/engine/metadata-modules/connected-account/entities/connected-account.entity';
+
+// Matches on the primary handle only: `handleAliases` are addresses the mailbox
+// receives on, but the provider still stamps the primary handle as the sender,
+// so resolving an alias here would silently send from a different address than
+// the one that was asked for.
+export const selectConnectedAccountIdByHandle = ({
+  connectedAccounts,
+  handle,
+  userWorkspaceId,
+}: {
+  connectedAccounts: Pick<
+    ConnectedAccountEntity,
+    'id' | 'handle' | 'visibility' | 'userWorkspaceId'
+  >[];
+  handle: string;
+  userWorkspaceId?: string;
+}): string | undefined => {
+  const normalizedHandle = normalizeConnectedAccountHandle(handle);
+
+  const matchingConnectedAccounts = connectedAccounts.filter(
+    (connectedAccount) =>
+      normalizeConnectedAccountHandle(connectedAccount.handle) ===
+      normalizedHandle,
+  );
+
+  if (!isDefined(userWorkspaceId)) {
+    return matchingConnectedAccounts[0]?.id;
+  }
+
+  return selectConnectedAccountIdForCaller({
+    connectedAccounts: matchingConnectedAccounts,
+    userWorkspaceId,
+  });
+};


### PR DESCRIPTION
## Problem

`send_email` / `draft_email` can target a specific connected account only through `connectedAccountId` — a UUID that **nothing in the AI/MCP tool surface exposes**:

- `find_many_connectedAccounts` does not exist, and `connectedAccounts` is not among the `DATABASE_CRUD` objects.
- `find_many_messageChannels` does not exist; only message/thread/participant/association objects are exposed, none of which resolve a handle → `connectedAccountId`.
- `messages` does not expose `connectedAccountId` as a selectable field, and `message_participants` returns `handle` + `role` but not the account id.

So in a workspace with more than one connected account, an agent cannot honour *"send from work@example.com"*. Every send silently falls back to the workspace default account, and the actual sender can only be recovered **after** the mail has gone out (via `message_participants`, `role = FROM`).

## Change

Adds an optional `fromHandle` to the email tool input, resolved to a connected account server-side:

```jsonc
{ "recipients": { "to": "someone@example.com" },
  "subject": "…", "body": "…",
  "fromHandle": "work@example.com" }
```

- Matching is case-insensitive and whitespace-tolerant on the connected account's **primary handle**.
- Resolution applies the **same visibility rules as default-account selection** (`isConnectedAccountUsableByCaller`), so `fromHandle` cannot be used to send from a colleague's private connected account. Where a caller identity is absent (system/workflow context), it behaves like the existing default-selection path.
- If the handle is not connected, the call **fails instead of falling back**, and the error lists the addresses the caller may send from — which also gives agents a way to discover valid senders without a dedicated read tool.
- `connectedAccountId` keeps priority when both are supplied; behaviour is unchanged when neither is supplied.
- Both tool descriptions now advertise the parameter so agents pick it up from the catalog.

### Why primary handle only, not `handleAliases`

`handleAliases` are addresses a mailbox *receives* on, but the provider still stamps the primary handle as the sender. Resolving an alias would reintroduce exactly the silent wrong-sender problem this fixes, so an alias is treated as "not connected" and surfaces the available handles instead.

## Alternatives considered

The report suggested three options: a `find_many_connectedAccounts` / `list_connected_accounts` read tool, a `fromHandle` parameter, or exposing `messageChannels`. `fromHandle` was chosen as the smallest surface that fully resolves the use case — the agent already knows the address the user named, so it never needs to enumerate first; and the error path covers discovery when it guesses wrong. Happy to add a dedicated list tool instead/as well if maintainers prefer that shape.

## Tests

13 new unit tests across two utils, covering exact match, unknown handle (no silent fallback), case/whitespace normalisation, workspace-shared accounts, refusal of a colleague's private account, own-account preference on duplicate handles, the no-caller path, and handle-list redaction/dedup.

```
npx jest src/engine/core-modules/tool/tools/email-tool/
  Test Suites: 6 passed, 6 total
  Tests:       33 passed, 33 total
```

Also verified: `npx nx typecheck twenty-server` and `npx nx lint twenty-server` (oxlint + oxfmt) both clean.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/23968?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

