### PR TITLE
fix(front): prevent stale timeline diff from crashing the Timeline tab

### DIFF
--- a/packages/twenty-front/src/modules/activities/timeline-activities/rows/main-object/components/EventFieldDiffContainer.tsx
+++ b/packages/twenty-front/src/modules/activities/timeline-activities/rows/main-object/components/EventFieldDiffContainer.tsx
@@ -1,6 +1,7 @@
 import { EventFieldDiff } from '@/activities/timeline-activities/rows/main-object/components/EventFieldDiff';
 import { findFieldMetadataItemByDiffKey } from '@/activities/timeline-activities/utils/findFieldMetadataItemByDiffKey';
 import { isDefined } from 'twenty-shared/utils';
+import { ErrorBoundary } from 'react-error-boundary';
 import { type EnrichedObjectMetadataItem } from '@/object-metadata/types/EnrichedObjectMetadataItem';
 
 type EventFieldDiffContainerProps = {
@@ -30,12 +31,17 @@ export const EventFieldDiffContainer = ({
   const diffArtificialRecordStoreId = eventId + '--' + fieldMetadataItem.id;
 
   return (
-    <EventFieldDiff
-      key={diffArtificialRecordStoreId}
-      fieldDiff={fieldDiff}
-      fieldMetadataItem={fieldMetadataItem}
-      mainObjectMetadataItem={mainObjectMetadataItem}
-      diffArtificialRecordStoreId={diffArtificialRecordStoreId}
-    />
+    <ErrorBoundary
+      resetKeys={[diffArtificialRecordStoreId]}
+      fallbackRender={() => null}
+    >
+      <EventFieldDiff
+        key={diffArtificialRecordStoreId}
+        fieldDiff={fieldDiff}
+        fieldMetadataItem={fieldMetadataItem}
+        mainObjectMetadataItem={mainObjectMetadataItem}
+        diffArtificialRecordStoreId={diffArtificialRecordStoreId}
+      />
+    </ErrorBoundary>
   );
 };


### PR DESCRIPTION
## Problem

Closes #23957.

A single stale timeline entry could replace the entire Timeline tab with "Invalid Configuration". Repro: create a `RICH_TEXT` field, edit it (recording a diff whose value is the composite `{ markdown, blocknote }`), then delete the field and recreate it as `TEXT` under the same name. The old diff value is still the composite object, but it is now rendered by the plain-text display, which throws React error #31 ("Objects are not valid as a React child"). The only `ErrorBoundary` sat in `WidgetCardShell` around the whole widget, so one bad row took the whole tab down.

## Fix

Wrap each per-field diff (`EventFieldDiff`) in its own `ErrorBoundary` with a no-op fallback. A field whose stored value can no longer be rendered is skipped instead of crashing the whole Timeline widget.

Verified in-app: reproduced the crash on real data, then confirmed the Timeline renders with the fix (the affected activity still shows, just without its broken diff detail, and the rest of the timeline is intact).