### PR TITLE
fix(workflow): skip unmigrated workspace schemas in the consistency cron

### DIFF
--- a/packages/twenty-server/src/modules/workflow/workflow-core-consistency/services/__tests__/workflow-core-consistency.service.spec.ts
+++ b/packages/twenty-server/src/modules/workflow/workflow-core-consistency/services/__tests__/workflow-core-consistency.service.spec.ts
@@ -1,4 +1,4 @@
-import { type DataSource } from 'typeorm';
+import { type DataSource, QueryFailedError } from 'typeorm';
 
 import { type ExceptionHandlerService } from 'src/engine/core-modules/exception-handler/exception-handler.service';
 import { type MetricsService } from 'src/engine/core-modules/metrics/metrics.service';
@@ -244,6 +244,28 @@ describe('WorkflowCoreConsistencyService', () => {
         `"workflowAutomatedTrigger" WHERE "deletedAt" IS NULL`,
       ),
     );
+  });
+
+  it('skips a workspace whose schema is not migrated without reporting to Sentry', async () => {
+    const undefinedColumnError = new QueryFailedError(
+      'SELECT',
+      [],
+      Object.assign(new Error('column wf.coreWorkflowId does not exist'), {
+        code: '42703',
+      }),
+    );
+
+    coreDataSource.query.mockImplementation((sql: string) => {
+      if (sql.includes('FROM core."workspace"')) {
+        return Promise.resolve([{ workspaceId, databaseSchema: schema }]);
+      }
+
+      return Promise.reject(undefinedColumnError);
+    });
+
+    await expect(service.runConsistencyCheck()).resolves.toBeUndefined();
+
+    expect(exceptionHandlerService.captureExceptions).not.toHaveBeenCalled();
   });
 
   it('isolates a per-workspace failure and reports it to Sentry', async () => {

--- a/packages/twenty-server/src/modules/workflow/workflow-core-consistency/services/workflow-core-consistency.service.ts
+++ b/packages/twenty-server/src/modules/workflow/workflow-core-consistency/services/workflow-core-consistency.service.ts
@@ -2,7 +2,7 @@ import { Injectable, Logger } from '@nestjs/common';
 import { InjectDataSource } from '@nestjs/typeorm';
 
 import { isDefined } from 'twenty-shared/utils';
-import { DataSource } from 'typeorm';
+import { DataSource, QueryFailedError } from 'typeorm';
 
 import { ExceptionHandlerService } from 'src/engine/core-modules/exception-handler/exception-handler.service';
 import { MetricsService } from 'src/engine/core-modules/metrics/metrics.service';
@@ -15,6 +15,15 @@ import {
 } from 'src/modules/workflow/workflow-trigger/automated-trigger/constants/automated-trigger-settings';
 
 type DriftCounts = Record<string, number>;
+
+const POSTGRES_UNDEFINED_TABLE = '42P01';
+const POSTGRES_UNDEFINED_COLUMN = '42703';
+
+const isSchemaNotMigratedError = (error: unknown): boolean =>
+  error instanceof QueryFailedError &&
+  [POSTGRES_UNDEFINED_TABLE, POSTGRES_UNDEFINED_COLUMN].includes(
+    (error.driverError as { code?: string } | undefined)?.code ?? '',
+  );
 
 // Detect drift between the workspace source-of-truth records and their core
 // mirror. The dual-write is best-effort (async, not transactional), so core can
@@ -43,6 +52,13 @@ export class WorkflowCoreConsistencyService {
       try {
         await this.checkWorkspace(workspaceId, databaseSchema);
       } catch (error) {
+        if (isSchemaNotMigratedError(error)) {
+          this.logger.warn(
+            `Workflow core consistency: skipping workspace ${workspaceId} - schema not migrated (${(error as Error).message})`,
+          );
+          continue;
+        }
+
         this.exceptionHandlerService.captureExceptions([error], {
           workspace: { id: workspaceId },
         });


### PR DESCRIPTION
## Context

Staging regression from #23807 ([TWENTY-SERVER-JMH](https://twenty-v7.sentry.io/issues/7654702516/), 165 events since Aug 5): `QueryFailedError: column wf.coreWorkflowId does not exist` in `checkWorkflowSync`, every consistency-cron run.

#23807 changed the cron's enumeration from "workspaces having core.workflow rows" to "all active + suspended workspaces" - deliberately, so never-mirrored workspaces stop escaping the check. Side effect: the cron now also reaches workspaces whose schema is behind on upgrade commands and lacks the `coreWorkflowId`/`coreWorkflowVersionId` columns (added in 2-23) or the workflow tables entirely. Their raw-SQL checks fail and the per-workspace catch reports each to Sentry, every run.

## What this does

Migration lag is not drift. The per-workspace catch now recognizes Postgres undefined-column (42703) and undefined-table (42P01) errors and skips the workspace with a warning log instead of capturing to Sentry. Everything else still goes to Sentry unchanged.

Fixes TWENTY-SERVER-JMH

## Verification

- Spec: a workspace failing with a 42703 `QueryFailedError` is skipped without `captureExceptions`; the existing generic-failure spec still asserts real errors are reported. 12/12 pass.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/23975?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

