### PR TITLE
fix(workflow): honor defaultSettings input for CODE/LOGIC_FUNCTION step creation

### DIFF
--- a/packages/twenty-server/src/modules/workflow/workflow-builder/workflow-version-step/workflow-version-step-operations.workspace-service.ts
+++ b/packages/twenty-server/src/modules/workflow/workflow-builder/workflow-version-step/workflow-version-step-operations.workspace-service.ts
@@ -234,14 +234,14 @@ export class WorkflowVersionStepOperationsWorkspaceService {
               expectedOutputSchema: {},
               input: {
                 logicFunctionId: newLogicFunction.id,
-                logicFunctionInput: isDefined(
+                logicFunctionInput: defaultSettings?.input?.logicFunctionInput ?? (isDefined(
                   newLogicFunction.workflowActionTriggerSettings?.inputSchema,
                 )
                   ? (getFunctionInputFromInputSchema(
                       newLogicFunction.workflowActionTriggerSettings
                         .inputSchema,
                     )[0] ?? {})
-                  : {},
+                  : {})
               },
             },
           },
@@ -302,14 +302,14 @@ export class WorkflowVersionStepOperationsWorkspaceService {
               expectedOutputSchema: {},
               input: {
                 logicFunctionId,
-                logicFunctionInput: isDefined(
+                logicFunctionInput: defaultSettings?.input?.logicFunctionInput ?? (isDefined(
                   flatLogicFunction.workflowActionTriggerSettings?.inputSchema,
                 )
                   ? (getFunctionInputFromInputSchema(
                       flatLogicFunction.workflowActionTriggerSettings
                         .inputSchema,
                     )[0] ?? {})
-                  : {},
+                  : {})
               },
             },
           },

--- a/packages/twenty-server/src/modules/workflow/workflow-builder/workflow-version-step/workflow-version-step-operations.workspace-service.ts
+++ b/packages/twenty-server/src/modules/workflow/workflow-builder/workflow-version-step/workflow-version-step-operations.workspace-service.ts
@@ -215,6 +215,12 @@ export class WorkflowVersionStepOperationsWorkspaceService {
           );
         }
 
+        const defaultLogicFunctionInput = (
+          defaultSettings?.input as
+            | { logicFunctionInput?: Record<string, unknown> }
+            | undefined
+        )?.logicFunctionInput;
+
         return {
           builtStep: {
             ...baseStep,
@@ -234,23 +240,29 @@ export class WorkflowVersionStepOperationsWorkspaceService {
               expectedOutputSchema: {},
               input: {
                 logicFunctionId: newLogicFunction.id,
-                logicFunctionInput: defaultSettings?.input?.logicFunctionInput ?? (isDefined(
-                  newLogicFunction.workflowActionTriggerSettings?.inputSchema,
-                )
-                  ? (getFunctionInputFromInputSchema(
-                      newLogicFunction.workflowActionTriggerSettings
-                        .inputSchema,
-                    )[0] ?? {})
-                  : {})
+                logicFunctionInput:
+                  defaultLogicFunctionInput ??
+                  (isDefined(
+                    newLogicFunction.workflowActionTriggerSettings?.inputSchema,
+                  )
+                    ? (getFunctionInputFromInputSchema(
+                        newLogicFunction.workflowActionTriggerSettings
+                          .inputSchema,
+                      )[0] ?? {})
+                    : {}),
               },
             },
           },
         };
       }
       case WorkflowActionType.LOGIC_FUNCTION: {
-        const logicFunctionId = (
-          defaultSettings?.input as { logicFunctionId: string } | undefined
-        )?.logicFunctionId;
+        const defaultInput = defaultSettings?.input as
+          | {
+              logicFunctionId?: string;
+              logicFunctionInput?: Record<string, unknown>;
+            }
+          | undefined;
+        const logicFunctionId = defaultInput?.logicFunctionId;
 
         if (!isDefined(logicFunctionId)) {
           throw new WorkflowVersionStepException(
@@ -302,14 +314,17 @@ export class WorkflowVersionStepOperationsWorkspaceService {
               expectedOutputSchema: {},
               input: {
                 logicFunctionId,
-                logicFunctionInput: defaultSettings?.input?.logicFunctionInput ?? (isDefined(
-                  flatLogicFunction.workflowActionTriggerSettings?.inputSchema,
-                )
-                  ? (getFunctionInputFromInputSchema(
-                      flatLogicFunction.workflowActionTriggerSettings
-                        .inputSchema,
-                    )[0] ?? {})
-                  : {})
+                logicFunctionInput:
+                  defaultInput?.logicFunctionInput ??
+                  (isDefined(
+                    flatLogicFunction.workflowActionTriggerSettings
+                      ?.inputSchema,
+                  )
+                    ? (getFunctionInputFromInputSchema(
+                        flatLogicFunction.workflowActionTriggerSettings
+                          .inputSchema,
+                      )[0] ?? {})
+                    : {}),
               },
             },
           },


### PR DESCRIPTION
## Problem

When creating a CODE or LOGIC_FUNCTION step via `create_workflow_version_step`, the `defaultSettings.input.logicFunctionInput` parameter is silently ignored. The step always receives `{a: null, b: null}` as its input, regardless of what the caller passes.

This broke the MCP/AI workflow creation flow after PR #17856 removed CODE step support from `create_complete_workflow`. Previously, callers could create a complete workflow with proper trigger variable mappings in a single call. Now they must create the step, then separately update the input mapping — which requires the workflow to be in draft state and the `update_workflow_version_step` tool to work (which is unreliable for CODE steps).

## Fix

In `runStepCreationSideEffectsAndBuildStep`, check `defaultSettings?.input?.logicFunctionInput` before falling back to the seed schema (`{a: null, b: null}`). This is a one-line change that restores the original capability.

### Before
```ts
logicFunctionInput: isDefined(
  newLogicFunction.workflowActionTriggerSettings?.inputSchema,
)
  ? getFunctionInputFromInputSchema(...)[0] ?? {}
  : {}
```

### After
```ts
logicFunctionInput: defaultSettings?.input?.logicFunctionInput ?? (isDefined(
  newLogicFunction.workflowActionTriggerSettings?.inputSchema,
)
  ? getFunctionInputFromInputSchema(...)[0] ?? {}
  : {})
```

## Testing

Tested on production with a patched v2.28.0 image. Creating a CODE step with:
```json
{
  "defaultSettings": {
    "input": {
      "logicFunctionInput": {
        "stage": "{{trigger.properties.after.stage}}",
        "pointOfContactId": "{{trigger.properties.after.pointOfContactId}}"
      }
    }
  }
}
```
correctly produces a step with those trigger variable mappings instead of `{a: null, b: null}`.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/23976?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

