### PR TITLE
fix(twenty-shared): support cursor gt/lt operators in isMatchingSelectFilter

### DIFF
--- a/packages/twenty-shared/src/types/RecordGqlOperationFilter.ts
+++ b/packages/twenty-shared/src/types/RecordGqlOperationFilter.ts
@@ -129,6 +129,10 @@ export type SelectFilter = {
   is?: IsFilter;
   in?: string[];
   eq?: string;
+  gt?: string;
+  gte?: string;
+  lt?: string;
+  lte?: string;
   neq?: string;
 };
 

--- a/packages/twenty-shared/src/utils/filter/utils/__tests__/isMatchingSelectFilter.test.ts
+++ b/packages/twenty-shared/src/utils/filter/utils/__tests__/isMatchingSelectFilter.test.ts
@@ -72,6 +72,68 @@ describe('isMatchingSelectFilter', () => {
     });
   });
 
+  describe('gt', () => {
+    it('should return true when value is greater', () => {
+      expect(
+        isMatchingSelectFilter({
+          selectFilter: { gt: 'ACTIVE' },
+          value: 'CLOSED',
+        }),
+      ).toBe(true);
+    });
+
+    it('should return false when value is not greater', () => {
+      expect(
+        isMatchingSelectFilter({
+          selectFilter: { gt: 'CLOSED' },
+          value: 'ACTIVE',
+        }),
+      ).toBe(false);
+    });
+  });
+
+  describe('gte', () => {
+    it('should return true when value is equal', () => {
+      expect(
+        isMatchingSelectFilter({
+          selectFilter: { gte: 'ACTIVE' },
+          value: 'ACTIVE',
+        }),
+      ).toBe(true);
+    });
+  });
+
+  describe('lt', () => {
+    it('should return true when value is lower', () => {
+      expect(
+        isMatchingSelectFilter({
+          selectFilter: { lt: 'CLOSED' },
+          value: 'ACTIVE',
+        }),
+      ).toBe(true);
+    });
+
+    it('should return false when value is not lower', () => {
+      expect(
+        isMatchingSelectFilter({
+          selectFilter: { lt: 'ACTIVE' },
+          value: 'CLOSED',
+        }),
+      ).toBe(false);
+    });
+  });
+
+  describe('lte', () => {
+    it('should return true when value is equal', () => {
+      expect(
+        isMatchingSelectFilter({
+          selectFilter: { lte: 'ACTIVE' },
+          value: 'ACTIVE',
+        }),
+      ).toBe(true);
+    });
+  });
+
   describe('default', () => {
     it('should throw for unexpected filter', () => {
       expect(() =>

--- a/packages/twenty-shared/src/utils/filter/utils/__tests__/isMatchingSelectFilter.test.ts
+++ b/packages/twenty-shared/src/utils/filter/utils/__tests__/isMatchingSelectFilter.test.ts
@@ -134,6 +134,40 @@ describe('isMatchingSelectFilter', () => {
     });
   });
 
+  describe('case insensitivity', () => {
+    it('should compare case-insensitively, matching the server ordering', () => {
+      expect(
+        isMatchingSelectFilter({
+          selectFilter: { gt: 'ACTIVE' },
+          value: 'closed',
+        }),
+      ).toBe(true);
+    });
+
+    it('should not order lowercase values after uppercase ones', () => {
+      expect(
+        isMatchingSelectFilter({
+          selectFilter: { gt: 'closed' },
+          value: 'ACTIVE',
+        }),
+      ).toBe(false);
+    });
+  });
+
+  describe('null values', () => {
+    it.each(['gt', 'gte', 'lt', 'lte'] as const)(
+      'should not match %s when value is null',
+      (operand) => {
+        expect(
+          isMatchingSelectFilter({
+            selectFilter: { [operand]: 'ACTIVE' },
+            value: null as any,
+          }),
+        ).toBe(false);
+      },
+    );
+  });
+
   describe('default', () => {
     it('should throw for unexpected filter', () => {
       expect(() =>

--- a/packages/twenty-shared/src/utils/filter/utils/isMatchingSelectFilter.ts
+++ b/packages/twenty-shared/src/utils/filter/utils/isMatchingSelectFilter.ts
@@ -24,6 +24,24 @@ export const isMatchingSelectFilter = ({
     case selectFilter.neq !== undefined: {
       return value !== selectFilter.neq;
     }
+    // Cursor-based pagination builds gt/lt conditions from the view's sort,
+    // so a view sorted by a Select field produces them on this filter.
+    // Compared lexicographically, like isMatchingUUIDFilter and
+    // isMatchingStringFilter — the server orders by option position, so an
+    // optimistic result can be misplaced until the next fetch corrects it.
+    // Throwing here instead would abort the mutation and lose the write.
+    case selectFilter.gt !== undefined: {
+      return value > selectFilter.gt;
+    }
+    case selectFilter.gte !== undefined: {
+      return value >= selectFilter.gte;
+    }
+    case selectFilter.lt !== undefined: {
+      return value < selectFilter.lt;
+    }
+    case selectFilter.lte !== undefined: {
+      return value <= selectFilter.lte;
+    }
     default: {
       throw new Error(
         `Unexpected value for select filter : ${JSON.stringify(selectFilter)}`,

--- a/packages/twenty-shared/src/utils/filter/utils/isMatchingSelectFilter.ts
+++ b/packages/twenty-shared/src/utils/filter/utils/isMatchingSelectFilter.ts
@@ -1,4 +1,5 @@
 import { type SelectFilter } from '@/types';
+import { isDefined } from '@/utils';
 
 export const isMatchingSelectFilter = ({
   selectFilter,
@@ -24,23 +25,32 @@ export const isMatchingSelectFilter = ({
     case selectFilter.neq !== undefined: {
       return value !== selectFilter.neq;
     }
-    // Cursor-based pagination builds gt/lt conditions from the view's sort,
-    // so a view sorted by a Select field produces them on this filter.
-    // Compared lexicographically, like isMatchingUUIDFilter and
-    // isMatchingStringFilter — the server orders by option position, so an
-    // optimistic result can be misplaced until the next fetch corrects it.
-    // Throwing here instead would abort the mutation and lose the write.
+    // Cursor-based pagination builds gt/lt conditions from the view's sort, so
+    // a view sorted by a Select field produces them on this filter. The server
+    // orders Select as LOWER(value::text), so compare case-insensitively to
+    // keep the optimistic cache consistent with its ordering. A null value
+    // satisfies no comparison, matching NULL semantics in Postgres.
     case selectFilter.gt !== undefined: {
-      return value > selectFilter.gt;
+      return (
+        isDefined(value) && value.toLowerCase() > selectFilter.gt.toLowerCase()
+      );
     }
     case selectFilter.gte !== undefined: {
-      return value >= selectFilter.gte;
+      return (
+        isDefined(value) &&
+        value.toLowerCase() >= selectFilter.gte.toLowerCase()
+      );
     }
     case selectFilter.lt !== undefined: {
-      return value < selectFilter.lt;
+      return (
+        isDefined(value) && value.toLowerCase() < selectFilter.lt.toLowerCase()
+      );
     }
     case selectFilter.lte !== undefined: {
-      return value <= selectFilter.lte;
+      return (
+        isDefined(value) &&
+        value.toLowerCase() <= selectFilter.lte.toLowerCase()
+      );
     }
     default: {
       throw new Error(


### PR DESCRIPTION
Fixes #23468

## Problem

On a table view sorted by a Select field, editing that field on a record shows `Unexpected value for select filter : {"lt":"NEW"}` and the change is not saved. It only happens once the view has paginated, and a hard reload clears it until you scroll again. The record silently keeps its old value.

## Cause

`computeCursorArgFilter` derives the cursor operator from the sort and pagination direction only, with no regard for field type:

```ts
const computeOperator = (isAscending: boolean, isForwardPagination: boolean): string =>
  (isAscending ? isForwardPagination : !isForwardPagination) ? 'gt' : 'lt';
```

So a Select-sorted view produces `{ stage: { lt: 'NEW' } }`. That filter is stored in the Apollo cache as part of the `findMany` root query args and replayed by `triggerUpdateRecordOptimisticEffect` on every record update.

`isMatchingSelectFilter` only handled `in` / `is` / `eq` / `neq` and threw in its `default` branch. Because that throw is synchronous in `useUpdateOneRecord` before `apolloCoreClient.mutate` is called, the write is lost rather than just noisy.

Views with no sort only get an `id` cursor, which `isMatchingUUIDFilter` already handles — which is why this reproduces only on Select-sorted views.

## Fix

`SelectFilter` was the only filter type without comparison operators, and `isMatchingSelectFilter` the only matcher not handling them — `isMatchingUUIDFilter`, `isMatchingStringFilter` and `isMatchingFloatFilter` all do. This adds `gt`/`gte`/`lt`/`lte` to both, following those matchers.

Comparison is case-insensitive to match how the server orders Select fields. `shouldCastToText` and `shouldUseCaseInsensitiveOrder` both return true for `SELECT`, so the ordering column is built as `LOWER(value::text)` in `graphql-query.parser`. Comparing raw strings would disagree with that for mixed-case option values and could place an optimistically updated record on the wrong side of the cursor.

A null value satisfies no comparison, matching `NULL` semantics in Postgres and avoiding a throw on `toLowerCase`.

Thanks @greptile-apps for catching the case-sensitivity mismatch on the first pass.

## Tests

Added `gt`/`gte`/`lt`/`lte` cases, mixed-case coverage, and null-value coverage to `isMatchingSelectFilter.test.ts`, keeping the existing `default` throw test.

- `isMatchingSelectFilter` — 20/20 pass
- `twenty-shared` full suite — 227 suites / 1785 tests pass
- `nx typecheck twenty-shared` and `nx typecheck twenty-front` pass
- `nx lint twenty-shared` — 0 warnings, 0 errors