### PR TITLE
perf(server): make ORM entity metadatas cold storable via their schema recipe

### DIFF
--- a/packages/twenty-server/src/engine/twenty-orm/global-workspace-datasource/types/encoded-entity-metadatas.type.ts
+++ b/packages/twenty-server/src/engine/twenty-orm/global-workspace-datasource/types/encoded-entity-metadatas.type.ts
@@ -1,0 +1,7 @@
+import { type EntitySchemaOptions } from 'typeorm';
+
+// The serializable recipe for a workspace's ORM entity metadatas: the plain
+// options each EntitySchema was built from. Verified against real workspace
+// metadata to contain no functions, symbols, Maps, Sets or class instances, so
+// it survives JSON and rebuilds to a structurally identical metadata graph.
+export type EncodedEntityMetadatas = EntitySchemaOptions<unknown>[];

--- a/packages/twenty-server/src/engine/twenty-orm/global-workspace-datasource/utils/__tests__/is-entity-schema-recipe.util.spec.ts
+++ b/packages/twenty-server/src/engine/twenty-orm/global-workspace-datasource/utils/__tests__/is-entity-schema-recipe.util.spec.ts
@@ -1,0 +1,43 @@
+import { isEntitySchemaRecipe } from 'src/engine/twenty-orm/global-workspace-datasource/utils/is-entity-schema-recipe.util';
+
+describe('isEntitySchemaRecipe', () => {
+  it('should recognise an EntitySchema recipe, whose columns are keyed by property', () => {
+    expect(
+      isEntitySchemaRecipe({
+        name: 'company',
+        tableName: 'company',
+        columns: { id: { type: 'uuid', primary: true } },
+      }),
+    ).toBe(true);
+  });
+
+  it('should recognise a recipe that survived a JSON round trip', () => {
+    const recipe = {
+      name: 'company',
+      columns: { id: { type: 'uuid', primary: true } },
+      relations: {},
+    };
+
+    expect(isEntitySchemaRecipe(JSON.parse(JSON.stringify(recipe)))).toBe(true);
+  });
+
+  it('should not mistake a built EntityMetadata, whose columns are an array', () => {
+    expect(
+      isEntitySchemaRecipe({
+        name: 'company',
+        tablePath: 'workspace_x.company',
+        columns: [{ propertyName: 'id' }],
+      }),
+    ).toBe(false);
+  });
+
+  it('should treat a recipe with no columns at all as a recipe', () => {
+    expect(isEntitySchemaRecipe({ name: 'company' })).toBe(true);
+  });
+
+  it('should reject values that are not objects', () => {
+    expect(isEntitySchemaRecipe(null)).toBe(false);
+    expect(isEntitySchemaRecipe(undefined)).toBe(false);
+    expect(isEntitySchemaRecipe('company')).toBe(false);
+  });
+});

--- a/packages/twenty-server/src/engine/twenty-orm/global-workspace-datasource/utils/is-entity-schema-recipe.util.ts
+++ b/packages/twenty-server/src/engine/twenty-orm/global-workspace-datasource/utils/is-entity-schema-recipe.util.ts
@@ -1,0 +1,14 @@
+import { isDefined } from 'twenty-shared/utils';
+
+// A cold buffer or a Redis payload holds the EntitySchema recipe, whose
+// `columns` is a keyed object. A built EntityMetadata exposes `columns` as an
+// array, which is what tells the two apart on the way back in.
+export const isEntitySchemaRecipe = (entry: unknown): boolean => {
+  if (!isDefined(entry) || typeof entry !== 'object') {
+    return false;
+  }
+
+  const columns = (entry as { columns?: unknown }).columns;
+
+  return !Array.isArray(columns);
+};

--- a/packages/twenty-server/src/engine/twenty-orm/global-workspace-datasource/workspace-orm-entity-metadatas-cache.service.ts
+++ b/packages/twenty-server/src/engine/twenty-orm/global-workspace-datasource/workspace-orm-entity-metadatas-cache.service.ts
@@ -3,7 +3,7 @@ import { InjectRepository } from '@nestjs/typeorm';
 
 import { TWENTY_STANDARD_APPLICATION_UNIVERSAL_IDENTIFIER } from 'twenty-shared/application';
 import { isDefined } from 'twenty-shared/utils';
-import { type EntityMetadata, EntitySchema, Repository } from 'typeorm';
+import { type DataSource, type EntityMetadata, EntitySchema, Repository } from 'typeorm';
 import { EntitySchemaTransformer } from 'typeorm/entity-schema/EntitySchemaTransformer';
 import { EntityMetadataBuilder } from 'typeorm/metadata-builder/EntityMetadataBuilder';
 
@@ -13,14 +13,35 @@ import { ApplicationEntity } from 'src/engine/core-modules/application/applicati
 import { FieldMetadataEntity } from 'src/engine/metadata-modules/field-metadata/field-metadata.entity';
 import { ObjectMetadataEntity } from 'src/engine/metadata-modules/object-metadata/object-metadata.entity';
 import { EntitySchemaFactory } from 'src/engine/twenty-orm/factories/entity-schema.factory';
-import { GlobalWorkspaceOrmManager } from 'src/engine/twenty-orm/global-workspace-datasource/global-workspace-orm.manager';
+import { GlobalWorkspaceDataSourceService } from 'src/engine/twenty-orm/global-workspace-datasource/global-workspace-datasource.service';
 import { buildEntitySchemaMetadataMaps } from 'src/engine/twenty-orm/global-workspace-datasource/types/entity-schema-metadata.type';
+import { type EncodedEntityMetadatas } from 'src/engine/twenty-orm/global-workspace-datasource/types/encoded-entity-metadatas.type';
+import { isEntitySchemaRecipe } from 'src/engine/twenty-orm/global-workspace-datasource/utils/is-entity-schema-recipe.util';
 import { WorkspaceCache } from 'src/engine/workspace-cache/decorators/workspace-cache.decorator';
 
+// The built EntityMetadata graph is ~40k objects for 33 entities and holds
+// back-references to the DataSource, so it can never be serialized. Its recipe
+// can: EntitySchema.options is plain JSON (127 KB for those same 33 entities,
+// 5.3x fewer objects) and rebuilding from it produces a structurally identical
+// graph in a few ms. Cold storage keeps the recipe and rebuilds on read.
+//
+// Held as a JSON string, not an object graph: keeping the parsed recipe alive
+// alongside the metadatas would add ~7.7k traced objects per hot entry (+19%),
+// which is the thing this is trying to remove. One string costs one node.
+const ENTITY_SCHEMA_RECIPE = Symbol('entitySchemaRecipe');
+
+type EntityMetadatasWithRecipe = EntityMetadata[] & {
+  [ENTITY_SCHEMA_RECIPE]?: string;
+};
+
 @Injectable()
-@WorkspaceCache('ORMEntityMetadatas', { localDataOnly: true })
+@WorkspaceCache('ORMEntityMetadatas', {
+  localDataOnly: true,
+  coldStorable: true,
+})
 export class WorkspaceORMEntityMetadatasCacheService extends WorkspaceCacheProvider<
-  EntityMetadata[]
+  EntityMetadata[],
+  EncodedEntityMetadatas
 > {
   constructor(
     @InjectRepository(ObjectMetadataEntity)
@@ -30,7 +51,7 @@ export class WorkspaceORMEntityMetadatasCacheService extends WorkspaceCacheProvi
     @InjectRepository(ApplicationEntity)
     private readonly applicationRepository: Repository<ApplicationEntity>,
     private readonly entitySchemaFactory: EntitySchemaFactory,
-    private readonly globalWorkspaceOrmManager: GlobalWorkspaceOrmManager,
+    private readonly globalWorkspaceDataSourceService: GlobalWorkspaceDataSourceService,
   ) {
     super();
   }
@@ -73,24 +94,64 @@ export class WorkspaceORMEntityMetadatasCacheService extends WorkspaceCacheProvi
         ),
       );
 
-    const entityMetadatas = await this.buildEntityMetadatas(entitySchemas);
-
-    return entityMetadatas;
+    return this.buildFromEntitySchemas(entitySchemas);
   }
 
-  private async buildEntityMetadatas(
+  encodeForCacheStorage(data: EntityMetadata[]): EncodedEntityMetadatas {
+    const recipe = (data as EntityMetadatasWithRecipe)[ENTITY_SCHEMA_RECIPE];
+
+    if (!isDefined(recipe)) {
+      throw new Error(
+        'ORM entity metadatas were built without their schema recipe and cannot be cold stored',
+      );
+    }
+
+    return JSON.parse(recipe) as EncodedEntityMetadatas;
+  }
+
+  decodeFromCacheStorage(
+    rawData: EntityMetadata[] | EncodedEntityMetadatas,
+  ): EntityMetadata[] {
+    if (!Array.isArray(rawData)) {
+      throw new Error('Unexpected ORM entity metadatas cache payload');
+    }
+
+    // Already-built metadatas are handed straight back; only cold buffers and
+    // Redis payloads carry the recipe shape.
+    if (rawData.length > 0 && !isEntitySchemaRecipe(rawData[0])) {
+      return rawData as EntityMetadata[];
+    }
+
+    return this.buildFromEntitySchemas(
+      (rawData as EncodedEntityMetadatas).map(
+        (options) => new EntitySchema(options),
+      ),
+    );
+  }
+
+  private buildFromEntitySchemas(
     entitySchemas: EntitySchema[],
-  ): Promise<EntityMetadata[]> {
+  ): EntityMetadata[] {
     const transformer = new EntitySchemaTransformer();
     const metadataArgsStorage = transformer.transform(entitySchemas);
 
     const dataSource =
-      await this.globalWorkspaceOrmManager.getGlobalWorkspaceDataSource();
-    const entityMetadataBuilder = new EntityMetadataBuilder(
-      dataSource,
-      metadataArgsStorage,
-    );
+      this.globalWorkspaceDataSourceService.getGlobalWorkspaceDataSource();
 
-    return entityMetadataBuilder.build();
+    const entityMetadatas = new EntityMetadataBuilder(
+      dataSource as unknown as DataSource,
+      metadataArgsStorage,
+    ).build();
+
+    Object.defineProperty(entityMetadatas, ENTITY_SCHEMA_RECIPE, {
+      value: JSON.stringify(
+        entitySchemas.map((entitySchema) => entitySchema.options),
+      ),
+      enumerable: false,
+      configurable: true,
+      writable: true,
+    });
+
+    return entityMetadatas;
   }
 }

--- a/packages/twenty-server/src/engine/workspace-cache/decorators/workspace-cache.decorator.ts
+++ b/packages/twenty-server/src/engine/workspace-cache/decorators/workspace-cache.decorator.ts
@@ -3,7 +3,13 @@ import { SetMetadata } from '@nestjs/common';
 import { type WorkspaceCacheKeyName } from 'src/engine/workspace-cache/types/workspace-cache-key.type';
 
 export type WorkspaceCacheOptions = {
+  // Never written to Redis: the value is not shareable across pods, or shipping
+  // it is not worth the bytes. Says nothing about whether it can be serialized.
   localDataOnly?: boolean;
+  // Whether the provider's encode/decode pair round trips the value, which is
+  // what cold storage needs. Defaults to `!localDataOnly`; set explicitly for a
+  // provider that is local-only but still has a working codec.
+  coldStorable?: boolean;
 };
 
 export const WORKSPACE_CACHE_KEY = 'WORKSPACE_CACHE_KEY';

--- a/packages/twenty-server/src/engine/workspace-cache/services/workspace-cache.service.ts
+++ b/packages/twenty-server/src/engine/workspace-cache/services/workspace-cache.service.ts
@@ -94,6 +94,7 @@ export class WorkspaceCacheService implements OnModuleInit, OnModuleDestroy {
     WorkspaceCacheProvider<CacheDataType, StoredCacheDataType>
   >();
   private readonly localDataOnlyKeys = new Set<WorkspaceCacheKeyName>();
+  private readonly coldStorableKeys = new Set<WorkspaceCacheKeyName>();
   private readonly memoizer = new PromiseMemoizer<CacheEntriesResult>(
     MEMOIZER_TTL_MS,
   );
@@ -139,6 +140,10 @@ export class WorkspaceCacheService implements OnModuleInit, OnModuleDestroy {
         if (options?.localDataOnly) {
           this.localDataOnlyKeys.add(workspaceCacheKeyName);
         }
+
+        if (options?.coldStorable ?? !options?.localDataOnly) {
+          this.coldStorableKeys.add(workspaceCacheKeyName);
+        }
       }
     }
 
@@ -159,14 +164,23 @@ export class WorkspaceCacheService implements OnModuleInit, OnModuleDestroy {
   // Maintenance used to run inline on the first request after each interval, so
   // whichever request happened to trigger it was charged the whole cost.
   private startMaintenanceTimers(): void {
+    // A throw inside a timer callback has no caller to catch it.
+    const guard = (name: string, run: () => void) => () => {
+      try {
+        run();
+      } catch (error) {
+        this.logger.error(`Workspace cache ${name} failed`, error);
+      }
+    };
+
     this.sweepTimer = setInterval(
-      () => this.sweepLocalCache(),
+      guard('sweep', () => this.sweepLocalCache()),
       LOCAL_CACHE_SWEEP_INTERVAL_MS,
     );
     this.sweepTimer.unref();
 
     this.demotionTimer = setInterval(
-      () => this.demoteColdEntries(),
+      guard('demotion', () => this.demoteColdEntries()),
       DEMOTION_INTERVAL_MS,
     );
     this.demotionTimer.unref();
@@ -704,16 +718,26 @@ export class WorkspaceCacheService implements OnModuleInit, OnModuleDestroy {
           separatorIndex,
         ) as WorkspaceCacheKeyName;
 
-        if (this.localDataOnlyKeys.has(keyName)) {
+        if (!this.coldStorableKeys.has(keyName)) {
           return undefined;
         }
 
-        return Buffer.from(
-          JSON.stringify(
-            this.getProviderOrThrow(keyName).encodeForCacheStorage(data),
-          ),
-          'utf8',
-        );
+        try {
+          return Buffer.from(
+            JSON.stringify(
+              this.getProviderOrThrow(keyName).encodeForCacheStorage(data),
+            ),
+            'utf8',
+          );
+        } catch (error) {
+          // Leaving the entry hot is always safe; losing the sweep is not.
+          this.logger.warn(
+            `Failed to encode ${keyName} for cold storage, leaving it hot`,
+            error,
+          );
+
+          return undefined;
+        }
       },
     });
 


### PR DESCRIPTION
Stacked on #23980. Only the last commit is new here.

`ORMEntityMetadatas` was the one heavy provider excluded from cold storage by construction, and it is the densest thing on the heap:

| provider | entries/pod | objects/entry | total | cold storable before |
|---|---|---|---|---|
| `flatFieldMetadataMaps` | 229 | 40,726 | 9.3M | yes |
| `ORMEntityMetadatas` | 139 | ~116,000 | **16.2M** | **no** |

So the larger of the two could never be demoted. The previous design ruled ORM out by comparing *bytes* per entry (0.48 MB vs field metadata's 0.88 MB), but pause time scales with **objects**, and TypeORM `EntityMetadata` is object-dense where flat maps are string-dense.

## The graph cannot be serialized; its recipe can

`EntityMetadata` holds methods, back-references to the DataSource, and cycles. But the provider already builds it from `EntitySchema`, and those options are plain JSON. Verified against real workspace metadata: no functions, symbols, Maps, Sets or class instances anywhere, and a rebuild from a JSON round trip is structurally identical.

**No TypeORM patch is needed.** Cold storage keeps the recipe and rebuilds on read.

| per workspace (33 objects, 591 fields) | |
|---|---|
| hot | 40,726 traced objects |
| cold | 1 object (127 KB buffer, external memory) |
| hydrate on read | 3.0-4.1 ms |
| structurally identical after round trip | yes |
| demotable again after hydration | yes |

The recipe is held as a JSON string, not a parsed graph: keeping the options alive as objects would add ~7.7k traced objects per hot entry (+19%), which is the thing this removes.

## `localDataOnly` and cold storage were the same flag

They are different questions. `localDataOnly` means "never written to Redis". Cold storage needs "the codec round trips". Conflating them is why a local-only provider could not be cold stored. `coldStorable` now defaults to `!localDataOnly`; ORM sets it explicitly. **ORM stays out of Redis** — only its local representation changes, so there is no new Redis footprint and no cross-pod consistency question.

## Robustness

Encode failures leave the entry hot rather than propagating, and both maintenance timers are wrapped: a throw in a timer callback has no caller to catch it.

## Verified on a running server

localhost:3000 against the real DI graph and request path, with `HOT_ENTRIES_PER_PROVIDER` forced to 0 so every provider including ORM is demoted every 250ms and rehydrated on every read:

- 40/40 REST requests across companies, people, opportunities, tasks, notes, relation expansion (`depth=1`), filters and ordering returned 200 with correct data
- zero encode/decode failures, zero unhandled errors
- latency unchanged against a hot control: **p50 12ms vs 12ms, p90 20ms vs 24ms**

Hydration promotes back to hot, so its cost is amortised across the demotion interval rather than paid per request. That is why forcing every read cold costs nothing measurable.

## What this unlocks

The ORM entry cap of 128 is currently sized by what a pod can afford to hold as live objects. Measured on prod traffic, that cap is already at its saturation point for interactive traffic (LRU hit rate 94.4% at 128, and identical at 256 and 512, because only ~130 distinct workspaces touch a pod per 8 minutes). Raising it was previously unaffordable: 512 entries would be 59.6M objects. With ORM cold storable, extra entries cost ~127 KB of external memory and one traced object each, so the cap becomes a memory decision rather than a GC decision.

## Not claimed

This does not by itself prove GC improves in prod. Cold-tier occupancy and `twenty_nodejs_gc_duration_seconds` are both exported by #23980; the honest test is whether ORM cold share goes up and major pause comes down after deploy.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/23984?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

