### PR TITLE
feat(slack): let the assistant use the Markdown Slack actually renders

### DIFF
--- a/packages/twenty-apps/public/slack/src/constants/default-slack-assistant-prompt.ts
+++ b/packages/twenty-apps/public/slack/src/constants/default-slack-assistant-prompt.ts
@@ -8,12 +8,20 @@ Slack reply style:
 - Always finish with a short text reply the member can read in the thread; never end on a tool call alone
 - When a tool fails, explain the error briefly and ask for any missing fields, then retry when possible
 
+Formatting you can use, when it earns its place:
+- Slack renders full Markdown: tables, ordered and unordered lists, task lists with - [ ] and - [x], > blockquotes, \`inline code\`, fenced code blocks, ~~strikethrough~~ and --- rules
+- Reach for structure only when it beats a sentence. Most answers are one or two lines and need none of it
+- Use a table when the member is comparing several records across the same two or three attributes, so the values line up in columns
+- Use a bullet list when the records share no common attributes, or when there is only one thing to say about each
+- Use a numbered list for steps the member should follow in order
+- Skip headings in short replies; they add weight without adding meaning. Use them only when a long answer genuinely has sections
+- Never wrap a whole reply in a code block, and never show raw JSON or API payloads
+
 Presenting records:
-- Bold a record's name the first time it appears in a reply
-- Never dump a record's fields into prose; write only the values that answer the question and leave the rest for the member to open in Twenty
-- When the whole answer is a list of records, open with one lead line carrying the count and any meaningful total, then one bullet per record: the linked name plus the asked-about value, nothing more
-- Never write Markdown tables; they render poorly in Slack, especially on mobile
-- List at most 5 records, most relevant first, closing with "and N more" telling the member where to see the rest in Twenty
+- Link every record the first time you name it, as [Record Name](<workspace url>/object/<objectNameSingular>/<recordId>), using an id a tool returned; never invent one
+- Write only the values that answer the question; leave the rest for the member to open in Twenty
+- When the whole answer is a list of records, open with one lead line carrying the count and any meaningful total, then the table or list
+- Show at most 5 records, most relevant first, closing with "and N more" telling the member where to see the rest in Twenty
 - Write amounts with the currency symbol and thousands separators, like $12,500
 - Write dates as "Jan 5" with the year only when it is not the current year
 - Write field values as plain words, never API names: "Todo", not "TODO"; "New lead", not "NEW_LEAD"


### PR DESCRIPTION
## The bug

#23887 shipped this rule to the agent:

> Never write Markdown tables; they render poorly in Slack, especially on mobile

That is wrong. Slack's `markdown` block renders pipe tables, ordered lists, task lists with `- [ ]`, blockquotes, `inline code`, fenced code blocks, strikethrough and `---` rules. Slack's own Block Kit template gallery has a template demonstrating precisely that set.

So the agent has been steered away from the single best format for the case it hits most often: comparing several records across the same attributes. It was told to emit bullet lines instead, which is why list answers read as flat.

## The change

Prompt only, one file. A new section names the formatting that exists and, more usefully, when each one earns its place:

- **Table** when the member is comparing records across the same two or three attributes, so values line up in columns.
- **Bullet list** when records share no common attributes, or there is one thing to say about each.
- **Numbered list** for ordered steps.
- **Nothing** for the one- or two-line answers that make up most replies. The section leads with "reach for structure only when it beats a sentence" so this doesn't turn every reply into a document.
- Headings discouraged in short replies; whole-reply code blocks and raw JSON ruled out.

Record linking moves up into the presentation rules, so "name a record" and "format a record" sit together instead of being split between the prompt builder and the style list.

## Why this instead of building blocks

Three block-based designs (cards + carousel, unfurl-style sections, accent-bar attachments) were all rejected in testing as chrome competing with the answer, and a fourth built the records into `table` blocks off a structured response format (#23986). If the agent can express a table in the text it already produces, none of that machinery is needed: no response schema, no parser, no renderer dispatch, no record cap to keep in sync.

Blocks still have two jobs, and both compose with a markdown body in the same message: interactive elements (buttons, which markdown cannot carry) and the small context footer. Those come back when there is a decision for a button to make.

## Trade-offs

- **No timezone-aware dates.** `<!date^…>` is mrkdwn syntax and probably renders literally inside a `markdown` block, so the agent formats dates itself and everyone sees the same string. Verifiable in a live workspace; if it does work, it is a one-line prompt addition.
- **No server-built record URLs.** #23986 had the worker construct links from the workspace URL it resolved, making an invented link structurally impossible. Here the agent writes links directly, as it did before that prototype. The prompt requires tool-returned ids. If we want a hard guarantee, a small validator rejecting links outside the workspace base URL is contained and does not bring back the parse-and-render layer.

## Testing

App unit suite (103 tests), typecheck and lint clean against current main. The formatting judgement itself needs a live workspace: the risk worth watching is over-structuring, an agent that reaches for a table when a sentence would do.

---
_Generated by [Claude Code](https://claude.ai/code/session_018LvBc8LRgRbWrGYyj6TQaA)_

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/23987?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

