### PR TITLE
docs(server): first-pass evidence on replacing TypeORM on the workspace read path

### DIFF
--- a/packages/twenty-server/docs/investigations/orm-read-path/README.md
+++ b/packages/twenty-server/docs/investigations/orm-read-path/README.md
@@ -209,7 +209,7 @@ Relations are declared on **both** sides, as production does: each RELATION fiel
 target field name. Declaring only the owning side builds a smaller, differently shaped graph
 and understates the cost.
 
-| shape | columns | relations | build (median of 3 runs) | traced objects |
+| shape | columns | relations | build (median of 7 builds) | traced objects |
 |---|---|---|---|---|
 | 33 objects, no relations | 726 | 0 | 3.2 ms | 2,948 |
 | 33 objects, 4 relations each | 726 | 264 | 12.6 ms | 4,800 |

--- a/packages/twenty-server/docs/investigations/orm-read-path/README.md
+++ b/packages/twenty-server/docs/investigations/orm-read-path/README.md
@@ -53,7 +53,7 @@ whole of it.
 | 7 | pagination | `common-find-many-query-runner.service.ts:171` | `take(n)` → two-phase `distinctAlias` query keyed on the primary column |
 | 8 | permission check | `workspace-select-query-builder.ts:375-385` → `permissions.utils.ts:270` | reads `expressionMap.aliases[0].metadata.name`, `expressionMap.selects`, `expressionMap.joinAttributes`, `expressionMap.orderBys`, and **regex-parses `"alias"."column"` back out of the select strings** (`permissions.utils.ts:385`, `:436`) |
 | 9 | row-level permission predicates | `apply-row-level-permission-predicates.util.ts:24` | `Brackets` + `.andWhere`. Predicates come from `FlatObjectMetadata` + `flatFieldMetadataMaps` through the *same* filter parser as user filters. No `EntityMetadata` |
-| 10 | soft delete | `applyDeletedAtToBuilder` / `withDeleted()` | the implicit `deletedAt IS NULL` comes from the `deleteDate: true` column flag |
+| 10 | soft delete | `applyDeletedAtToBuilder` / `withDeleted()` | the implicit `deletedAt IS NULL` comes from the `deleteDate: true` column flag. **Not uniform — see below** |
 | 11 | execute + hydrate | `workspace-select-query-builder.ts:138-166` | `super.getMany()` — pg rows → entity instances with **flat** properties |
 | 12 | flat → nested | `format-result.util.ts:51` | nothing. Rebuilds composites from `flatFieldMetadataMaps` |
 | 13 | relations | `process-nested-relations-v2.helper.ts:63` | **separate queries, never joins.** One query per relation field, `IN (:...ids)`, plus a `CROSS JOIN LATERAL (VALUES ...)` for the per-parent limit built as a raw string (`:504-537`) |
@@ -62,6 +62,16 @@ whole of it.
 
 Steps 12, 14 and 15 are three full walks of every record after the driver has already
 built one object per row.
+
+**Soft delete is not one rule.** Step 10's implicit `deletedAt IS NULL` does not apply
+uniformly, and a reimplementation that assumes it does will diverge. To-one relation
+loading deliberately opts out: `process-nested-relations-v2.helper.ts:213-217` forces
+`deletedAt` into the select and calls `withDeleted()` for `MANY_TO_ONE`, then
+`assignRelationResults` (`:573-575`) sets both the relation **and** its foreign key to
+`null` when the target turns out to be soft-deleted, and strips `deletedAt` back out of
+the payload unless the caller selected it (`:577-583`). So a soft-deleted parent is
+fetched and then nulled in JS, rather than filtered in SQL. Any generated query must
+reproduce that, including the FK nulling, which is observable in the GraphQL response.
 
 ## 3. The six questions
 
@@ -95,7 +105,8 @@ Almost nothing, and this is the load-bearing finding.
 - **Computed / derived fields**: none on the entity. `searchVector` is a real generated
   column, handled in DDL.
 - The genuine semantics TypeORM contributes on reads are three flags: `deleteDate` (implicit
-  soft-delete filter), `primary` (the `distinctAlias` key), and relation metadata for the
+  soft-delete filter, plus the `withDeleted()` opt-out that to-one relation loading relies
+  on), `primary` (the `distinctAlias` key), and relation metadata for the
   order-by join in step 5. Two are one-liners; the third is discussed in 3.4.
 
 ### 3.3 How are row-level permission predicates applied?
@@ -193,17 +204,23 @@ Synthetic workspaces shaped like the measured one, built through the same
 `EntitySchemaTransformer` + `EntityMetadataBuilder` pair as
 `workspace-orm-entity-metadatas-cache.service.ts:81`.
 
-| shape | columns | relations | build (median) | traced objects |
+Relations are declared on **both** sides, as production does: each RELATION field is its own
+`fieldMetadata` row, and `determineSchemaRelationDetails:79` sets `inverseSide` to the real
+target field name. Declaring only the owning side builds a smaller, differently shaped graph
+and understates the cost.
+
+| shape | columns | relations | build (median of 3 runs) | traced objects |
 |---|---|---|---|---|
-| 33 objects, no relations | 726 | 0 | 3.3 ms | 2,948 |
-| 33 objects, 4 relations each | 726 | 132 | 12.7 ms | 4,015 |
-| 100 objects, 4 relations each | 2,200 | 400 | 24.5 ms | 12,122 |
+| 33 objects, no relations | 726 | 0 | 3.2 ms | 2,948 |
+| 33 objects, 4 relations each | 726 | 264 | 12.6 ms | 4,800 |
+| 100 objects, 4 relations each | 2,200 | 800 | 25.5 ms | 14,515 |
 
 Two things to take from this, and one not to.
 
-- Build time is 3-4ms for a dev-sized workspace, matching what the
-  `charles/orm-metadata-serializable` branch found, and it is dominated by relations:
-  adding 132 relations to the same 726 columns costs 4x the build time and 36% more objects.
+- Build time is ~3ms for a dev-sized workspace with no relations, in the same range as what
+  the `charles/orm-metadata-serializable` branch found, and it is dominated by relations:
+  adding 264 relation entries to the same 726 columns costs 4x the build time and 63% more
+  objects.
 - Cost is linear in columns, so it scales with custom fields, not with traffic.
 - **Do not compare the object counts to the 40,726 from the heap snapshot.** This traversal
   dedupes strings globally and does not count property backing stores, so it is a lower

--- a/packages/twenty-server/docs/investigations/orm-read-path/README.md
+++ b/packages/twenty-server/docs/investigations/orm-read-path/README.md
@@ -1,0 +1,338 @@
+# Replacing TypeORM on the workspace read path: first-pass evidence
+
+Status: investigation, no code change proposed yet. Everything below is either a file
+reference you can check or a measurement you can re-run (see `bench/`).
+
+Question asked: can `packages/twenty-server` drop TypeORM for workspace data in favour of
+raw parameterised SQL plus a small composition library, and what would that actually buy?
+
+Short answer from this pass: **most of the read path is already SQL that Twenty writes
+itself, and the parts that are not are cheaper than the profile suggests. What TypeORM is
+really being paid for on reads is not entity mapping, it is `EntityMetadata` existing at
+all — and writes need that same object today. Bypassing it on reads shrinks what the
+cache is used for; it does not delete the cache.** The strongest case for change is not
+CPU, it is that four separate call sites reach into `QueryExpressionMap` to recover or
+patch what the builder did, because they were not the ones who built it:
+
+- `permissions.utils.ts:270` recovers the entity, operation and column list
+- `permissions.utils.ts:422` recovers order-by columns per joined alias, by regex
+- `workspace-select-query-builder.ts:434` rewrites `joinAttribute.condition` in place
+- `process-nested-relations-v2.helper.ts:527` filters `expressionMap.aliases` directly
+
+---
+
+## 1. Scope
+
+TypeORM is used for two unrelated things in this package, and only one is in scope.
+
+| | entities | in scope |
+|---|---|---|
+| `core` / `metadata` schemas | 76 files with `@Entity()`, real decorated classes, real migrations, `UpgradeAwareEntityMetadataAdapter` rewriting column visibility per upgrade cursor | **no** — this is what an ORM is for |
+| workspace schemas (`workspace_<hash>`) | zero classes; `EntitySchema` synthesised per request-workspace from `core.objectMetadata` / `core.fieldMetadata` | yes |
+
+`UpgradeAwareEntityMetadataAdapter` (`src/engine/twenty-orm/upgrade-aware/upgrade-aware-entity-metadata.adapter.ts:33`)
+injects `coreDataSource`, not the workspace one. Nothing in this document touches core.
+
+Surface for the in-scope half: 104 `getRepository(` call sites in `src` of which 54 are
+against a workspace data source, 78 files calling `createQueryBuilder(`, and 285 `find*`
+calls under `src/modules`. The GraphQL/REST query runners are a slice of that, not the
+whole of it.
+
+## 2. The traced read path
+
+`POST /graphql` → `findMany` on a standard object. Files in call order.
+
+| # | step | code | needs from TypeORM |
+|---|---|---|---|
+| 1 | resolve role permissions, get repository | `common-base-query-runner.service.ts:315-352` | `getRepository(nameSingular)` → `findMetadata` linear scan over the workspace's `EntityMetadata[]` (`global-workspace-datasource.ts:82-89`) |
+| 2 | parse GraphQL selection into flat column names | `graphql-selected-fields.parser.ts:92-203` | nothing. Composites are flattened to `nameFirstName` here (`:266`) from `compositeTypeDefinitions` |
+| 3 | build filter | `graphql-query-filter-*.parser.ts` → `compute-where-condition-parts.ts` | **string concatenation only.** Twenty writes the SQL itself: `` `"${objectNameSingular}"."${key}" = :${key}${suffix}` `` (`compute-where-condition-parts.ts:42-74`). TypeORM binds `:name` params and nothing else |
+| 4 | build order by | `graphql-query-order.parser.ts` | same; `getOrderByRawSQL` (`graphql-query.parser.ts:179`) already emits the ORDER BY as a raw string for the group-by path |
+| 5 | join, only if ordering by a relation field | `add-relation-join-alias.util.ts:24` | `leftJoin('person.company', 'company')` — **the one place relation metadata is genuinely used on reads** |
+| 6 | column list | `build-columns-to-select.ts:14` | `setFindOptions({ select })`: property-name → column-name mapping, which for workspace entities is the identity function (columns are declared flat, `entity-schema-column.factory.ts:75-114`) |
+| 7 | pagination | `common-find-many-query-runner.service.ts:171` | `take(n)` → two-phase `distinctAlias` query keyed on the primary column |
+| 8 | permission check | `workspace-select-query-builder.ts:375-385` → `permissions.utils.ts:270` | reads `expressionMap.aliases[0].metadata.name`, `expressionMap.selects`, `expressionMap.joinAttributes`, `expressionMap.orderBys`, and **regex-parses `"alias"."column"` back out of the select strings** (`permissions.utils.ts:385`, `:436`) |
+| 9 | row-level permission predicates | `apply-row-level-permission-predicates.util.ts:24` | `Brackets` + `.andWhere`. Predicates come from `FlatObjectMetadata` + `flatFieldMetadataMaps` through the *same* filter parser as user filters. No `EntityMetadata` |
+| 10 | soft delete | `applyDeletedAtToBuilder` / `withDeleted()` | the implicit `deletedAt IS NULL` comes from the `deleteDate: true` column flag |
+| 11 | execute + hydrate | `workspace-select-query-builder.ts:138-166` | `super.getMany()` — pg rows → entity instances with **flat** properties |
+| 12 | flat → nested | `format-result.util.ts:51` | nothing. Rebuilds composites from `flatFieldMetadataMaps` |
+| 13 | relations | `process-nested-relations-v2.helper.ts:63` | **separate queries, never joins.** One query per relation field, `IN (:...ids)`, plus a `CROSS JOIN LATERAL (VALUES ...)` for the per-parent limit built as a raw string (`:504-537`) |
+| 14 | field handlers | `common-result-getters.service.ts` | nothing (rich text, files, workspace member avatars) |
+| 15 | nested → GraphQL JSON | `object-records-to-graphql-connection.helper.ts:150` | nothing. Walks composites again |
+
+Steps 12, 14 and 15 are three full walks of every record after the driver has already
+built one object per row.
+
+## 3. The six questions
+
+### 3.1 What is plain column mapping that raw SQL replaces trivially?
+
+Steps 3, 4, 6, 7, 10, 11. Concretely:
+
+- WHERE and ORDER BY are already Twenty-authored SQL strings. TypeORM is a parameter
+  binder there. `getOrderByRawSQL` proves the ORDER BY half is already portable.
+- `select` is a `Record<columnName, true>`. Because `entity-schema-column.factory.ts`
+  declares every column with `name === key`, TypeORM's property→column mapping is the
+  identity function for workspace entities.
+- Hydration produces an object with flat keys (`nameFirstName`), which is exactly the pg
+  row. `formatResult` then does the real work.
+- Soft delete is `AND "x"."deletedAt" IS NULL`.
+- `take(n)` is the `distinctAlias` behaviour PR #23980 works around. Written by hand it is
+  `LIMIT n` when no to-many join is present, which is the general case since relations are
+  loaded separately.
+
+### 3.2 What depends on real entity semantics?
+
+Almost nothing, and this is the load-bearing finding.
+
+- **Composite types** (currency, address, links, phones, fullName, actor, emails): TypeORM
+  never sees them. `EntitySchemaColumnFactory.createCompositeColumns` expands one field
+  into N flat columns before TypeORM is involved; `formatResult` reassembles them after.
+  Not TypeORM embeddeds, not TypeORM transformers.
+- **Value transformers**: zero. `grep -rn "transformer" src/engine/twenty-orm` matches only
+  `EntitySchemaTransformer` (the metadata builder) and `PlainObjectToDatabaseEntityTransformer`
+  (used on the `save` path only).
+- **Computed / derived fields**: none on the entity. `searchVector` is a real generated
+  column, handled in DDL.
+- The genuine semantics TypeORM contributes on reads are three flags: `deleteDate` (implicit
+  soft-delete filter), `primary` (the `distinctAlias` key), and relation metadata for the
+  order-by join in step 5. Two are one-liners; the third is discussed in 3.4.
+
+### 3.3 How are row-level permission predicates applied?
+
+Two separate mechanisms, and they answer the question differently.
+
+**Predicates (which rows)** — `apply-row-level-permission-predicates.util.ts`. Built from
+`FlatObjectMetadata` and `flatFieldMetadataMaps` via `GraphqlQueryFilterFieldParser`, the
+same parser used for user filters. For joined aliases, `render-row-level-permission-filter-to-sql.util.ts`
+emits SQL and parameters and Twenty splices them into `joinAttribute.condition` by hand
+(`workspace-select-query-builder.ts:462-480`). **No `EntityMetadata` dependency.**
+
+**Validation (which objects and fields)** — `permissions.utils.ts`. This one *does* depend
+on TypeORM, but not for semantics: it depends on `QueryExpressionMap` as a way to find out
+what the query it was handed contains. It reads `aliases[0].metadata.name` for the entity,
+`queryType` for the operation, `selects` for the columns, and where a join is present it
+regex-matches `/"(\w+)"\."(\w+)"/` over the select and order-by strings to recover
+alias/column pairs (`:385`, `:436`).
+
+That is the clearest argument in the whole investigation, and it is an argument about
+structure rather than speed: a caller that generates its own SQL already knows the object,
+the operation and the exact column list. The reverse-engineering layer is not replaced by
+raw SQL, it is deleted by it. `getSelectedColumnsFromExpressionMap` splitting on `.` and
+taking the last segment, and `ProcessAggregateHelper.extractColumnNamesFromAggregateExpression`
+pulling column names back out of aggregate SQL, both exist only because the permission check
+runs downstream of a builder it did not drive.
+
+### 3.4 How are relations loaded?
+
+Separate queries, always, except for ordering.
+
+`ProcessNestedRelationsV2Helper` issues one query per relation field with concurrency 4,
+then stitches results in JS (`:563-588`). To-many gets a `CROSS JOIN LATERAL` over a
+`VALUES` list to bound rows per parent — assembled as a raw string from
+`perParentRecordIdsQueryBuilder.getQuery()`, with the parent ids filtered through
+`isValidUuid` and interpolated (`:498-519`). It already reaches under the builder and edits
+`expressionMap.aliases` directly (`:527-530`).
+
+So "what would replace the join loading" is: nothing, it is already replaced. The only join
+TypeORM generates from relation metadata on a read is the ORDER BY join in step 5 (and the
+equivalent in group-by, `common-group-by-query-runner.service.ts:392`, which already passes
+an explicit ON condition and so needs the relation only for the alias). Both are
+`LEFT JOIN "<schema>"."<target>" AS "<alias>" ON "<parent>"."<fk>" = "<alias>"."id"`,
+derivable from `flatFieldMetadataMaps` alone.
+
+### 3.5 Do writes need `EntityMetadata` in a way reads do not?
+
+Yes. This is the finding that most changes the shape of the answer.
+
+The common API write path does not use `save`/`EntityPersistExecutor` — it uses
+`repository.insert`, `updateMany`, and the delete/soft-delete builders
+(`common-create-many-query-runner.service.ts:230`, `:431`, `:460`). Composite → flat
+conversion is again Twenty's (`format-data.util.ts:18`, called from
+`workspace-insert-query-builder.ts:109`). But `InsertQueryBuilder` / `UpdateQueryBuilder`
+still derive from `EntityMetadata`:
+
+- the insert column list and ordering, plus per-column defaults
+- `createDate` / `updateDate` / `deleteDate` behaviour. Both `createdAt` and `updatedAt`
+  carry `defaultValue: 'now'` (`partial-system-flat-field-metadatas.constant.ts:60`, `:91`)
+  so both get `DEFAULT now()` on insert, but a column default does not fire on UPDATE:
+  `updatedAt` is maintained by TypeORM's `updateDate: true` flag alone
+  (`entity-schema-column.factory.ts:98`)
+- `RETURNING` column mapping back to entity shape, which every write runner relies on to
+  emit its database event
+
+`EntityPersistExecutor` is still reached through `.save()` from 82 call sites across 50
+files, a mix of core and workspace repositories.
+
+Consequence: keeping TypeORM for writes keeps `EntityMetadata` per cached workspace, which
+is the 16.2M-objects-per-pod item. **A read-only bypass does not delete that cost, it only
+stops paying it on the hot path.** Whether the cache shrinks at all depends on whether the
+same workspaces are read-heavy and write-light, which is likely but unmeasured. If the
+memory number is the goal, PR #23984's approach (keep the serialisable `EntitySchema`
+recipe cold, rebuild in ~3-4ms on demand) attacks it directly and is a much smaller change.
+
+### 3.6 What does the migration / DDL system use?
+
+Nothing worth keeping, and it is already separable.
+
+`src/engine/twenty-orm/workspace-schema-manager/services/*` build DDL as strings and call
+`queryRunner.query(sql)` (`workspace-schema-column-manager.service.ts:24-26`). Identifiers
+go through `escapeIdentifier` (`remove-sql-injection.util.ts:11`), and there is an
+`assertSafeTsVectorExpression` guard for generated-column expressions. Across the whole
+`workspace-migration` tree the only TypeORM imports are `QueryRunner`, `DataSource`,
+`ColumnType` and `QueryFailedError`. TypeORM is a connection pool and a transaction handle
+there. Any of the candidate libraries provides both.
+
+## 4. Measurements
+
+Re-run with `node bench/entity-metadata.js` and `node bench/compile.js` after
+`npm i typeorm@0.3.31 kysely drizzle-orm pg-promise postgres @databases/pg` in that
+directory. Numbers below from this container, Node on Linux.
+
+### 4.1 What `EntityMetadata` costs to build
+
+Synthetic workspaces shaped like the measured one, built through the same
+`EntitySchemaTransformer` + `EntityMetadataBuilder` pair as
+`workspace-orm-entity-metadatas-cache.service.ts:81`.
+
+| shape | columns | relations | build (median) | traced objects |
+|---|---|---|---|---|
+| 33 objects, no relations | 726 | 0 | 3.3 ms | 2,948 |
+| 33 objects, 4 relations each | 726 | 132 | 12.7 ms | 4,015 |
+| 100 objects, 4 relations each | 2,200 | 400 | 24.5 ms | 12,122 |
+
+Two things to take from this, and one not to.
+
+- Build time is 3-4ms for a dev-sized workspace, matching what the
+  `charles/orm-metadata-serializable` branch found, and it is dominated by relations:
+  adding 132 relations to the same 726 columns costs 4x the build time and 36% more objects.
+- Cost is linear in columns, so it scales with custom fields, not with traffic.
+- **Do not compare the object counts to the 40,726 from the heap snapshot.** This traversal
+  dedupes strings globally and does not count property backing stores, so it is a lower
+  bound on structural nodes only. It corroborates the shape (linear, relation-heavy), not
+  the magnitude.
+
+### 4.2 What SQL generation costs
+
+A 60-column `findMany` with one ILIKE filter, one ORDER BY and a limit:
+
+| | median |
+|---|---|
+| TypeORM `createQueryBuilder` + `getQueryAndParameters` | 231 µs |
+| Kysely build + `compile()` | 149 µs |
+| hand-rolled template string | 3.7 µs |
+
+Switching builders recovers about a third of query-construction time. Generating the SQL
+directly recovers 98%. If CPU is the motive, the library is not where the win is; caching a
+compiled shape per (object, selected-field-set) is.
+
+### 4.3 Reconciling with the Sentry profile
+
+PR #23980's own profile table, slow `POST /graphql` (>3s) vs normal (<300ms):
+
+| | slow | normal |
+|---|---|---|
+| GC | 25.8% | 8.4% |
+| cold-storage demote | 18.6% | 0% |
+| pg driver `parseRow` | **14.6%** | 6.6% |
+| **TypeORM entity hydration** | **3.0%** | 2.5% |
+
+The 14.6% is the **pg driver** parsing wire rows into JS objects. That cost survives
+removing TypeORM — it is paid by any client that returns rows, including all five
+candidates (postgres.js has a faster parser, but it is still the same order). The part
+attributable to TypeORM hydration is 3.0% of slow-request event-loop time.
+
+Any framing of this work as "14.6% of the event loop is TypeORM hydrating rows" is wrong,
+and the read-path bypass should not be sold on it. The honest CPU budget for a read bypass
+is roughly: 3.0% hydration + a share of the 231µs/query construction + one of the three
+post-query record walks. Real, worth having, not transformative on its own. GC at 25.8% is
+the larger number, and that is a memory-shape argument, i.e. 3.5.
+
+## 5. Library assessment
+
+Injection safety was tested rather than read about: each library was handed the identifier
+`name" , (SELECT pg_sleep(10)) AS "x` in a column position (`bench/identifiers.js`).
+
+| library | dynamic identifier API | result with the hostile identifier | notes |
+|---|---|---|---|
+| Kysely | `sql.ref()`, `db.dynamic.ref()`, `withSchema()` | escaped: `"name"" , (SELECT pg_sleep(10)) AS ""x"` | `withSchema()` takes a runtime string, so `workspace_<hash>` qualification is native. `sql.raw()` does **not** escape, as documented |
+| Drizzle (query builder standalone) | `sql.identifier()`, `pgSchema()` | escaped identically | requires a table object; building one per (workspace, object) at runtime is possible but is the same per-workspace object graph problem in a new shape |
+| pg-promise | `pgp.as.name()`, `$1~` | escaped identically | **but values are escaped client-side and inlined, not bound.** `$1` produced `'abc'` in the SQL text. Well-audited, still a different threat model to `$1` binding |
+| postgres.js | `sql(identifier)` | escaped, and `.` is rewritten to `"."` | `escapeIdentifier('a.b')` yields `"a"."b"`; harmless given Twenty's name regex but it is not a strict identifier escape |
+| @databases/pg | `sql.ident()` via `@databases/escape-identifier` | escaped, plus validation: throws on non-ASCII and on **>60 characters** | that limit is a real incompatibility — `IDENTIFIER_MAX_CHAR_LENGTH` is 63, so a legal 61-63 char field name would throw |
+
+Two conclusions.
+
+1. **Identifier escaping is not a differentiator.** All five escape. More importantly,
+   Twenty does not currently rely on escaping at all: object and field names are validated
+   at write time against `/^[a-z][a-zA-Z0-9]*$/`
+   (`validate-flat-field-metadata-name.util.ts:13`, same for objects), schema names are
+   `workspace_` plus a hash, and `escapeIdentifier` already exists in-tree
+   (`remove-sql-injection.util.ts:11`). The existing raw-SQL sites
+   (`compute-where-condition-parts.ts:42`) interpolate identifiers with plain `"` wrapping
+   and are safe because of that regex, not because of a library. Any move to raw SQL should
+   route every identifier through the in-tree `escapeIdentifier` as defence in depth, but
+   that is one function, not a reason to adopt a dependency.
+2. **The choice should be made on composition ergonomics and on not re-creating a
+   per-workspace object graph.** Kysely is the best fit of the five: `withSchema` takes a
+   runtime string, `sql` fragments compose with bound parameters (which is what
+   `computeWhereConditionParts` already produces, modulo `:name` → `$n`), lateral joins are
+   supported, and it can compile without a connection which makes both-paths diffing easy.
+   Drizzle standalone is a poor fit specifically because its table objects would reintroduce
+   per-workspace structures. postgres.js is the fastest driver but the weakest composer.
+   pg-promise's inline value escaping is a step away from parameter binding, which is the
+   wrong direction for this codebase.
+
+But per 4.2: even Kysely costs 149µs on a 60-column select. If the read bypass is built,
+the shape most likely to pay for itself is a generator over the flat maps producing a
+parameterised string plus a positional param array, with the in-tree `escapeIdentifier` on
+every identifier and the SQL text memoised per query shape. A library would then be used
+for the driver and transactions, not for composition — which points at `pg` (already a
+dependency) or postgres.js, not at a query builder.
+
+## 6. What the evidence supports doing next
+
+The proposed shape ("keep TypeORM for writes, DDL and transactions; bypass hydration on
+reads") holds up, with two corrections:
+
+- It will not remove the `EntityMetadata` cache, because writes need it (3.5). Sell it as
+  latency and as deleting the expression-map reverse-engineering, not as memory.
+- Its CPU headline is ~3% of hydration plus query construction plus one of three record
+  walks, not 14.6% (4.3).
+
+Sequencing, smallest verifiable step first:
+
+1. **Land and measure PR #23980.** Nothing here changes that; two of its three changes
+   target larger numbers than anything in this document.
+2. **Salvage from `charles/orm-metadata-serializable`** regardless of what happens to the
+   read path: the `localDataOnly` / `coldStorable` split is a correctness fix (they were
+   conflated), and the timer-callback guard fixes a real throw-with-no-caller. The cold
+   `EntitySchema` recipe attacks the 16.2M-object number directly and is far smaller than
+   an ORM bypass.
+3. **Prove the mapper before the SQL.** Steps 12→14→15 are three walks producing GraphQL
+   JSON from a flat row, all driven by the same flat maps, none of them touching TypeORM.
+   Fusing them into one generated-per-shape mapper is independently valuable, testable
+   against the current output record-for-record, and does not require a single query to
+   change. If that does not move p90, the SQL half is unlikely to.
+4. **Then** a read-only SQL generator for `findMany` on a single object with no relation
+   ordering, behind a flag, running both paths and diffing the GraphQL response per
+   resolver. Kill criteria stated in advance: if the diff harness finds semantic gaps in
+   more than a handful of field types, or if the flagged path does not beat the TypeORM
+   path by more than the diff harness costs, stop.
+
+What should *not* be attempted from this evidence: replacing the 285 `find*` call sites
+under `src/modules`, or touching the write path. Both are large, and neither has a measured
+number behind it.
+
+## Appendix: reproducing
+
+```bash
+cd packages/twenty-server/docs/investigations/orm-read-path/bench
+npm init -y
+npm i typeorm@0.3.31 pg reflect-metadata kysely drizzle-orm pg-promise postgres @databases/pg
+node entity-metadata.js   # section 4.1
+node compile.js           # section 4.2
+node identifiers.js       # section 5
+```
+
+No database connection is required by any of the three.

--- a/packages/twenty-server/docs/investigations/orm-read-path/README.md
+++ b/packages/twenty-server/docs/investigations/orm-read-path/README.md
@@ -185,9 +185,7 @@ there. Any of the candidate libraries provides both.
 
 ## 4. Measurements
 
-Re-run with `node bench/entity-metadata.js` and `node bench/compile.js` after
-`npm i typeorm@0.3.31 kysely drizzle-orm pg-promise postgres @databases/pg` in that
-directory. Numbers below from this container, Node on Linux.
+Numbers below from this container, Node on Linux. See the appendix for how to re-run them.
 
 ### 4.1 What `EntityMetadata` costs to build
 

--- a/packages/twenty-server/docs/investigations/orm-read-path/bench/compile.js
+++ b/packages/twenty-server/docs/investigations/orm-read-path/bench/compile.js
@@ -1,0 +1,106 @@
+require('reflect-metadata');
+const { DataSource, EntitySchema } = require('typeorm');
+
+const SCHEMA = 'workspace_1wgvd1injqtife6y4rvfbu3h5';
+const COLUMN_COUNT = 60;
+const columnNames = Array.from({ length: COLUMN_COUNT }, (_, i) => `field${i}`);
+
+const median = (xs) => {
+  const sorted = [...xs].sort((a, b) => a - b);
+
+  return sorted[Math.floor(sorted.length / 2)];
+};
+
+const time = (label, iterations, fn) => {
+  for (let i = 0; i < 200; i++) fn();
+  const samples = [];
+
+  for (let i = 0; i < iterations; i++) {
+    const start = process.hrtime.bigint();
+
+    fn();
+    samples.push(Number(process.hrtime.bigint() - start) / 1e3);
+  }
+
+  console.log(`${label.padEnd(34)} median ${median(samples).toFixed(1)} us/query`);
+};
+
+const buildTypeOrm = async () => {
+  const columns = {
+    id: { name: 'id', type: 'uuid', primary: true },
+    deletedAt: { name: 'deletedAt', type: 'timestamptz', deleteDate: true, nullable: true },
+  };
+
+  for (const name of columnNames) columns[name] = { name, type: 'text', nullable: true };
+
+  const person = new EntitySchema({ name: 'person', tableName: 'person', schema: SCHEMA, columns });
+  const dataSource = new DataSource({
+    type: 'postgres',
+    host: 'localhost',
+    database: 'x',
+    username: 'x',
+    password: 'x',
+    entities: [person],
+  });
+
+  await dataSource.buildMetadatas();
+
+  return dataSource;
+};
+
+const run = async () => {
+  const dataSource = await buildTypeOrm();
+  const select = Object.fromEntries(columnNames.map((name) => [name, true]));
+
+  time('typeorm getQueryAndParameters', 2000, () => {
+    const qb = dataSource
+      .createQueryBuilder('person', 'person')
+      .setFindOptions({ select })
+      .andWhere(`"person"."field0" ILIKE :p0`, { p0: '%acme%' })
+      .orderBy({ 'person.field1': 'ASC' })
+      .take(31);
+
+    qb.getQueryAndParameters();
+  });
+
+  const {
+    Kysely,
+    DummyDriver,
+    PostgresAdapter,
+    PostgresIntrospector,
+    PostgresQueryCompiler,
+    sql,
+  } = require('kysely');
+
+  const db = new Kysely({
+    dialect: {
+      createAdapter: () => new PostgresAdapter(),
+      createDriver: () => new DummyDriver(),
+      createIntrospector: (d) => new PostgresIntrospector(d),
+      createQueryCompiler: () => new PostgresQueryCompiler(),
+    },
+  });
+
+  time('kysely compile', 2000, () => {
+    db
+      .withSchema(SCHEMA)
+      .selectFrom('person')
+      .select(columnNames.map((name) => sql.ref(name).as(name)))
+      .where(sql`"person"."field0" ILIKE ${'%acme%'}`)
+      .orderBy(sql.ref('field1'), 'asc')
+      .limit(31)
+      .compile();
+  });
+
+  // What a hand-rolled generator over the flat maps would cost: string building only.
+  time('hand-rolled string builder', 2000, () => {
+    const projection = columnNames.map((name) => `"person"."${name}"`).join(', ');
+
+    void `SELECT ${projection} FROM "${SCHEMA}"."person" AS "person" WHERE "person"."field0" ILIKE $1 AND "person"."deletedAt" IS NULL ORDER BY "person"."field1" ASC LIMIT 31`;
+  });
+};
+
+run().catch((error) => {
+  console.error(error.message);
+  process.exit(1);
+});

--- a/packages/twenty-server/docs/investigations/orm-read-path/bench/entity-metadata.js
+++ b/packages/twenty-server/docs/investigations/orm-read-path/bench/entity-metadata.js
@@ -1,0 +1,168 @@
+require('reflect-metadata');
+const { DataSource, EntitySchema } = require('typeorm');
+const { EntitySchemaTransformer } = require('typeorm/entity-schema/EntitySchemaTransformer');
+const { EntityMetadataBuilder } = require('typeorm/metadata-builder/EntityMetadataBuilder');
+
+// Mirrors EntitySchemaFactory: one EntitySchema per object metadata row,
+// flat columns (composites already expanded), relations for RELATION fields.
+const buildSchemas = ({ objectCount, columnsPerObject, relationsPerObject }) => {
+  const names = Array.from({ length: objectCount }, (_, i) => `object${i}`);
+
+  return names.map((name, index) => {
+    const columns = {
+      id: { name: 'id', type: 'uuid', primary: true, nullable: false },
+      createdAt: { name: 'createdAt', type: 'timestamptz', precision: 3, createDate: true, nullable: false },
+      updatedAt: { name: 'updatedAt', type: 'timestamptz', precision: 3, updateDate: true, nullable: false },
+      deletedAt: { name: 'deletedAt', type: 'timestamptz', precision: 3, deleteDate: true, nullable: true },
+    };
+
+    for (let c = 0; c < columnsPerObject; c++) {
+      columns[`object${index}Field${c}`] = { name: `object${index}Field${c}`, type: 'text', nullable: true };
+    }
+
+    const relations = {};
+
+    for (let r = 0; r < relationsPerObject; r++) {
+      const targetName = names[(index + r + 1) % objectCount];
+      const relationName = `relation${r}`;
+
+      columns[`${relationName}Id`] = { name: `${relationName}Id`, type: 'uuid', nullable: true };
+      relations[relationName] = {
+        type: 'many-to-one',
+        target: targetName,
+        inverseSide: `inverseOf${name}${r}`,
+        joinColumn: { name: `${relationName}Id` },
+      };
+      relations[`inverseOf${targetName}${r}`] = undefined;
+    }
+
+    for (const key of Object.keys(relations)) {
+      if (relations[key] === undefined) delete relations[key];
+    }
+
+    return new EntitySchema({
+      name,
+      tableName: `_${name}`,
+      schema: 'workspace_1wgvd1injqtife6y4rvfbu3h5',
+      columns,
+      relations,
+    });
+  });
+};
+
+const countObjects = (roots, skipKeys) => {
+  const seen = new Set();
+  const strings = new Set();
+  const stack = [...roots];
+  let objects = 0;
+  let arrays = 0;
+  let maps = 0;
+  let functions = 0;
+
+  while (stack.length > 0) {
+    const value = stack.pop();
+
+    if (typeof value === 'string') {
+      strings.add(value);
+      continue;
+    }
+    if (typeof value === 'function') {
+      if (seen.has(value)) continue;
+      seen.add(value);
+      functions++;
+      continue;
+    }
+    if (value === null || typeof value !== 'object') continue;
+    if (seen.has(value)) continue;
+    seen.add(value);
+
+    if (Array.isArray(value)) {
+      arrays++;
+      for (const item of value) stack.push(item);
+      continue;
+    }
+
+    if (value instanceof Map || value instanceof Set) {
+      maps++;
+      for (const item of value.values()) stack.push(item);
+      continue;
+    }
+
+    objects++;
+
+    for (const key of Object.keys(value)) {
+      if (skipKeys.has(key)) continue;
+      let child;
+      try {
+        child = value[key];
+      } catch {
+        continue;
+      }
+      stack.push(child);
+    }
+  }
+
+  return {
+    objects,
+    arrays,
+    maps,
+    functions,
+    distinctStrings: strings.size,
+    total: objects + arrays + maps + functions + strings.size,
+  };
+};
+
+const run = async ({ label, objectCount, columnsPerObject, relationsPerObject, repeats }) => {
+  const dataSource = new DataSource({
+    type: 'postgres',
+    host: 'localhost',
+    port: 5432,
+    username: 'x',
+    password: 'x',
+    database: 'x',
+    entities: [],
+  });
+
+  const schemas = buildSchemas({ objectCount, columnsPerObject, relationsPerObject });
+
+  let metadatas;
+  const timings = [];
+
+  for (let i = 0; i < repeats; i++) {
+    const start = process.hrtime.bigint();
+    const storage = new EntitySchemaTransformer().transform(schemas);
+    metadatas = new EntityMetadataBuilder(dataSource, storage).build();
+    timings.push(Number(process.hrtime.bigint() - start) / 1e6);
+  }
+
+  timings.sort((a, b) => a - b);
+
+  const counted = countObjects(metadatas, new Set(['connection']));
+  const columnCount = metadatas.reduce((acc, m) => acc + m.columns.length, 0);
+  const relationCount = metadatas.reduce((acc, m) => acc + m.relations.length, 0);
+
+  console.log(
+    JSON.stringify(
+      {
+        label,
+        objects: metadatas.length,
+        columns: columnCount,
+        relations: relationCount,
+        buildMsMedian: Number(timings[Math.floor(timings.length / 2)].toFixed(2)),
+        buildMsMin: Number(timings[0].toFixed(2)),
+        tracedObjects: counted.total,
+        breakdown: counted,
+        tracedPerColumn: Number((counted.total / columnCount).toFixed(1)),
+      },
+      null,
+      0,
+    ),
+  );
+};
+
+(async () => {
+  await run({ label: '33 objects / 591 fields (measured workspace)', objectCount: 33, columnsPerObject: 14, relationsPerObject: 4, repeats: 7 });
+  await run({ label: '33 objects / no relations', objectCount: 33, columnsPerObject: 18, relationsPerObject: 0, repeats: 7 });
+  await run({ label: '100 objects / ~1800 columns (prod-sized)', objectCount: 100, columnsPerObject: 14, relationsPerObject: 4, repeats: 7 });
+  await run({ label: '1 object / 18 columns', objectCount: 1, columnsPerObject: 18, relationsPerObject: 0, repeats: 7 });
+})();

--- a/packages/twenty-server/docs/investigations/orm-read-path/bench/entity-metadata.js
+++ b/packages/twenty-server/docs/investigations/orm-read-path/bench/entity-metadata.js
@@ -3,51 +3,70 @@ const { DataSource, EntitySchema } = require('typeorm');
 const { EntitySchemaTransformer } = require('typeorm/entity-schema/EntitySchemaTransformer');
 const { EntityMetadataBuilder } = require('typeorm/metadata-builder/EntityMetadataBuilder');
 
-// Mirrors EntitySchemaFactory: one EntitySchema per object metadata row,
-// flat columns (composites already expanded), relations for RELATION fields.
+// Mirrors EntitySchemaFactory: one EntitySchema per object metadata row, flat columns
+// (composites already expanded), and a relation entry for every RELATION field.
+//
+// Both sides are declared, as production does: a RELATION field exists as its own
+// fieldMetadata row on each object, and determineSchemaRelationDetails sets inverseSide to
+// the real target field name. Declaring only the owning side builds a smaller and
+// structurally different graph than the one the cache actually holds.
 const buildSchemas = ({ objectCount, columnsPerObject, relationsPerObject }) => {
   const names = Array.from({ length: objectCount }, (_, i) => `object${i}`);
+  const columnsByObject = new Map(
+    names.map((name, index) => {
+      const columns = {
+        id: { name: 'id', type: 'uuid', primary: true, nullable: false },
+        createdAt: { name: 'createdAt', type: 'timestamptz', precision: 3, createDate: true, nullable: false },
+        updatedAt: { name: 'updatedAt', type: 'timestamptz', precision: 3, updateDate: true, nullable: false },
+        deletedAt: { name: 'deletedAt', type: 'timestamptz', precision: 3, deleteDate: true, nullable: true },
+      };
 
-  return names.map((name, index) => {
-    const columns = {
-      id: { name: 'id', type: 'uuid', primary: true, nullable: false },
-      createdAt: { name: 'createdAt', type: 'timestamptz', precision: 3, createDate: true, nullable: false },
-      updatedAt: { name: 'updatedAt', type: 'timestamptz', precision: 3, updateDate: true, nullable: false },
-      deletedAt: { name: 'deletedAt', type: 'timestamptz', precision: 3, deleteDate: true, nullable: true },
-    };
+      for (let c = 0; c < columnsPerObject; c++) {
+        columns[`object${index}Field${c}`] = { name: `object${index}Field${c}`, type: 'text', nullable: true };
+      }
 
-    for (let c = 0; c < columnsPerObject; c++) {
-      columns[`object${index}Field${c}`] = { name: `object${index}Field${c}`, type: 'text', nullable: true };
-    }
+      return [name, columns];
+    }),
+  );
+  const relationsByObject = new Map(names.map((name) => [name, {}]));
 
-    const relations = {};
-
+  names.forEach((name, index) => {
     for (let r = 0; r < relationsPerObject; r++) {
       const targetName = names[(index + r + 1) % objectCount];
-      const relationName = `relation${r}`;
+      const owningField = `object${index}Relation${r}`;
+      const inverseField = `object${index}Inverse${r}`;
 
-      columns[`${relationName}Id`] = { name: `${relationName}Id`, type: 'uuid', nullable: true };
-      relations[relationName] = {
+      columnsByObject.get(name)[`${owningField}Id`] = {
+        name: `${owningField}Id`,
+        type: 'uuid',
+        nullable: true,
+      };
+
+      relationsByObject.get(name)[owningField] = {
         type: 'many-to-one',
         target: targetName,
-        inverseSide: `inverseOf${name}${r}`,
-        joinColumn: { name: `${relationName}Id` },
+        inverseSide: inverseField,
+        joinColumn: { name: `${owningField}Id` },
       };
-      relations[`inverseOf${targetName}${r}`] = undefined;
-    }
 
-    for (const key of Object.keys(relations)) {
-      if (relations[key] === undefined) delete relations[key];
+      relationsByObject.get(targetName)[inverseField] = {
+        type: 'one-to-many',
+        target: name,
+        inverseSide: owningField,
+      };
     }
-
-    return new EntitySchema({
-      name,
-      tableName: `_${name}`,
-      schema: 'workspace_1wgvd1injqtife6y4rvfbu3h5',
-      columns,
-      relations,
-    });
   });
+
+  return names.map(
+    (name) =>
+      new EntitySchema({
+        name,
+        tableName: `_${name}`,
+        schema: 'workspace_1wgvd1injqtife6y4rvfbu3h5',
+        columns: columnsByObject.get(name),
+        relations: relationsByObject.get(name),
+      }),
+  );
 };
 
 const countObjects = (roots, skipKeys) => {

--- a/packages/twenty-server/docs/investigations/orm-read-path/bench/identifiers.js
+++ b/packages/twenty-server/docs/investigations/orm-read-path/bench/identifiers.js
@@ -97,21 +97,38 @@ const probePgPromise = () => {
   );
 };
 
+// postgres.js assembles SQL lazily at execution time and does not export its escaper, so
+// this is a transcription of it. The probe asserts the transcription still matches the
+// shipped source rather than evaluating anything out of node_modules.
+const POSTGRES_JS_ESCAPE_SOURCE = `return '"' + str.replace(/"/g, '""').replace(/\\./g, '"."') + '"'`;
+
+const postgresJsEscapeIdentifier = (str) =>
+  '"' + str.replace(/"/g, '""').replace(/\./g, '"."') + '"';
+
 const probePostgresJs = () => {
-  // postgres.js assembles SQL lazily at execution time and does not export its escaper,
-  // so evaluate the function straight out of its source.
   const path = require('path');
   const fs = require('fs');
   const source = fs.readFileSync(
     path.join(process.cwd(), 'node_modules', 'postgres', 'src', 'types.js'),
     'utf8',
   );
-  const body = source.match(/export const escapeIdentifier = function escape\(str\) \{([\s\S]*?)\n\}/)[1];
-  // oxlint-disable-next-line no-new-func
-  const escapeIdentifier = new Function('str', body);
 
-  report('postgres.js', 'escapeIdentifier(hostile)', JSON.stringify(escapeIdentifier(HOSTILE)));
-  report('postgres.js', 'escapeIdentifier("a.b")', JSON.stringify(escapeIdentifier('a.b')));
+  if (!source.includes(POSTGRES_JS_ESCAPE_SOURCE)) {
+    report('postgres.js', 'transcription', 'STALE — escapeIdentifier changed upstream');
+
+    return;
+  }
+
+  report(
+    'postgres.js',
+    'escapeIdentifier(hostile)',
+    JSON.stringify(postgresJsEscapeIdentifier(HOSTILE)),
+  );
+  report(
+    'postgres.js',
+    'escapeIdentifier("a.b")',
+    JSON.stringify(postgresJsEscapeIdentifier('a.b')),
+  );
 };
 
 const probeDatabases = () => {

--- a/packages/twenty-server/docs/investigations/orm-read-path/bench/identifiers.js
+++ b/packages/twenty-server/docs/investigations/orm-read-path/bench/identifiers.js
@@ -1,0 +1,141 @@
+// Hands each candidate library a hostile identifier in a column position and prints the
+// SQL it produces. Workspace object/field names are validated against /^[a-z][a-zA-Z0-9]*$/
+// before they ever reach SQL, so this is a defence-in-depth check, not a live threat model.
+const HOSTILE = 'name" , (SELECT pg_sleep(10)) AS "x';
+const SCHEMA = 'workspace_1wgvd1injqtife6y4rvfbu3h5';
+
+const report = (lib, what, out) =>
+  console.log(`${lib.padEnd(12)} ${what.padEnd(26)} ${out}`);
+
+const probeKysely = () => {
+  const {
+    Kysely,
+    DummyDriver,
+    PostgresAdapter,
+    PostgresIntrospector,
+    PostgresQueryCompiler,
+    sql,
+  } = require('kysely');
+
+  const db = new Kysely({
+    dialect: {
+      createAdapter: () => new PostgresAdapter(),
+      createDriver: () => new DummyDriver(),
+      createIntrospector: (d) => new PostgresIntrospector(d),
+      createQueryCompiler: () => new PostgresQueryCompiler(),
+    },
+  });
+
+  const compiled = db
+    .withSchema(SCHEMA)
+    .selectFrom('person')
+    .select([sql.ref(HOSTILE).as('hostile'), 'person.id'])
+    .where(sql.ref('person.nameFirstName'), '=', 'x')
+    .limit(1)
+    .compile();
+
+  report('kysely', 'sql.ref(hostile)', JSON.stringify(compiled.sql));
+  report('kysely', 'bound params', JSON.stringify(compiled.parameters));
+
+  const dynamic = db
+    .withSchema(SCHEMA)
+    .selectFrom('person')
+    .select(db.dynamic.ref(HOSTILE))
+    .compile();
+
+  report('kysely', 'dynamic.ref(hostile)', JSON.stringify(dynamic.sql));
+
+  const raw = db
+    .withSchema(SCHEMA)
+    .selectFrom('person')
+    .select(sql`${sql.raw(HOSTILE)}`.as('x'))
+    .compile();
+
+  report('kysely', 'sql.raw (escape hatch)', JSON.stringify(raw.sql));
+};
+
+const probeDrizzle = () => {
+  const { pgSchema, text, uuid } = require('drizzle-orm/pg-core');
+  const { drizzle } = require('drizzle-orm/node-postgres');
+  const { sql } = require('drizzle-orm');
+
+  const schema = pgSchema(SCHEMA);
+  const person = schema.table('person', {
+    id: uuid('id').primaryKey(),
+    hostile: text(HOSTILE),
+  });
+
+  const db = drizzle({ client: { query: async () => ({ rows: [] }) } });
+  const query = db
+    .select({ id: person.id, hostile: person.hostile })
+    .from(person)
+    .limit(1);
+
+  report('drizzle', 'runtime-built column', JSON.stringify(query.toSQL().sql));
+  report('drizzle', 'bound params', JSON.stringify(query.toSQL().params));
+
+  const identifier = db.select({ x: sql`${sql.identifier(HOSTILE)}` }).from(person);
+
+  report('drizzle', 'sql.identifier(hostile)', JSON.stringify(identifier.toSQL().sql));
+};
+
+const probePgPromise = () => {
+  const pgp = require('pg-promise')();
+
+  report('pg-promise', 'as.name(hostile)', JSON.stringify(pgp.as.name(HOSTILE)));
+  report(
+    'pg-promise',
+    'format $~ identifier, $ value',
+    JSON.stringify(
+      pgp.as.format('SELECT $1~ FROM $2~.$3~ WHERE "id" = $4', [
+        HOSTILE,
+        SCHEMA,
+        'person',
+        'abc',
+      ]),
+    ),
+  );
+};
+
+const probePostgresJs = () => {
+  // postgres.js assembles SQL lazily at execution time and does not export its escaper,
+  // so evaluate the function straight out of its source.
+  const path = require('path');
+  const fs = require('fs');
+  const source = fs.readFileSync(
+    path.join(process.cwd(), 'node_modules', 'postgres', 'src', 'types.js'),
+    'utf8',
+  );
+  const body = source.match(/export const escapeIdentifier = function escape\(str\) \{([\s\S]*?)\n\}/)[1];
+  // oxlint-disable-next-line no-new-func
+  const escapeIdentifier = new Function('str', body);
+
+  report('postgres.js', 'escapeIdentifier(hostile)', JSON.stringify(escapeIdentifier(HOSTILE)));
+  report('postgres.js', 'escapeIdentifier("a.b")', JSON.stringify(escapeIdentifier('a.b')));
+};
+
+const probeDatabases = () => {
+  const { escapePostgresIdentifier } = require('@databases/escape-identifier');
+
+  const cases = [
+    ['hostile', HOSTILE],
+    ['61 chars', 'a'.repeat(61)],
+    ['non-ascii', 'nomé'],
+  ];
+
+  for (const [label, value] of cases) {
+    try {
+      report('@databases', label, JSON.stringify(escapePostgresIdentifier(value)));
+    } catch (error) {
+      report('@databases', label, `threw: ${error.message}`);
+    }
+  }
+};
+
+for (const probe of [probeKysely, probeDrizzle, probePgPromise, probePostgresJs, probeDatabases]) {
+  try {
+    probe();
+  } catch (error) {
+    report(probe.name, 'failed', error.message);
+  }
+}

--- a/packages/twenty-server/docs/investigations/orm-read-path/bench/identifiers.js
+++ b/packages/twenty-server/docs/investigations/orm-read-path/bench/identifiers.js
@@ -113,7 +113,11 @@ const probePostgresJs = () => {
     'utf8',
   );
 
-  if (!source.includes(POSTGRES_JS_ESCAPE_SOURCE)) {
+  const shippedBody = source
+    .match(/export const escapeIdentifier = function escape\(str\) \{([\s\S]*?)\n\}/)?.[1]
+    ?.trim();
+
+  if (shippedBody !== POSTGRES_JS_ESCAPE_SOURCE) {
     report('postgres.js', 'transcription', 'STALE — escapeIdentifier changed upstream');
 
     return;


### PR DESCRIPTION
Investigation only, no behaviour change. Adds `packages/twenty-server/docs/investigations/orm-read-path/` with the trace, the numbers, and three benchmarks that re-run without a database.

Question: can workspace data drop TypeORM for raw parameterised SQL plus a small composition library, and what would that buy?

## What the trace found

`POST /graphql` findMany on a standard object, 15 steps, each with what it needs from TypeORM. Most of the path is already SQL that Twenty writes itself:

- WHERE is built as raw strings in `compute-where-condition-parts.ts`; TypeORM binds `:name` params and nothing else. ORDER BY already has a raw-string emitter (`getOrderByRawSQL`) used by group-by.
- Composite types never reach TypeORM. `EntitySchemaColumnFactory` expands one field into N flat columns before it is involved, and `formatResult` reassembles them after. No embeddeds, no transformers (zero value transformers in the codebase).
- Relations are loaded as separate queries with a hand-built `CROSS JOIN LATERAL`, never as joins. The only join TypeORM generates from relation metadata on a read is for ordering by a relation field.
- Row-level permission predicates come from the flat maps through the same parser as user filters. No `EntityMetadata` dependency.
- DDL is already `queryRunner.query(sql)` with an in-tree `escapeIdentifier`. TypeORM is a connection pool there.

The real dependency is `QueryExpressionMap`: four call sites reach into it to recover or patch what the builder did, including regex-parsing `"alias"."column"` back out of select strings to run the field-permission check. Raw SQL does not replace that layer, it deletes it.

## Two corrections to the premise

- **Writes still need `EntityMetadata`.** The write path uses `insert`/`updateMany` rather than `save`, but the insert/update builders still derive the column list, `RETURNING` mapping and `updatedAt` maintenance from it. A read-only bypass shrinks what the cache is used for, it does not delete the cache. If memory is the goal, #23984's cold `EntitySchema` recipe attacks it directly and is far smaller.
- **The 14.6% is not TypeORM.** In #23980's own profile table, 14.6% is the pg driver's `parseRow`, which survives any ORM removal; TypeORM entity hydration is 3.0% of slow-request event-loop time. The read bypass should not be sold on the larger number.

## Measurements

`EntityMetadata` build, through the same transformer/builder pair the cache uses:

| shape | columns | relations | build (median) |
|---|---|---|---|
| 33 objects, no relations | 726 | 0 | 3.3 ms |
| 33 objects, 4 relations each | 726 | 132 | 12.7 ms |
| 100 objects, 4 relations each | 2,200 | 400 | 24.5 ms |

SQL generation for a 60-column findMany: TypeORM 231 µs, Kysely 149 µs, hand-rolled template string 3.7 µs. A different builder recovers about a third; generating the SQL directly recovers 98%.

## Library assessment

Each candidate was handed `name" , (SELECT pg_sleep(10)) AS "x` in a column position rather than assessed from docs. All five escape it. `@databases` also validates, but rejects identifiers over 60 characters while `IDENTIFIER_MAX_CHAR_LENGTH` is 63. pg-promise inlines values client-side instead of binding them.

Identifier escaping is therefore not a differentiator: names are already constrained to `/^[a-z][a-zA-Z0-9]*$/` at write time and `escapeIdentifier` exists in-tree. Kysely is the best composer of the five, but given 4.2 the shape most likely to pay for itself uses a generator over the flat maps with the SQL memoised per query shape, and a library only for driver and transactions.

## Suggested sequencing

Land and measure #23980 first. Salvage the `localDataOnly` / `coldStorable` split and the timer guard from `charles/orm-metadata-serializable` regardless. Then fuse the three post-query record walks into one generated mapper, which is testable against current output without changing a single query; only then a flagged read-only SQL generator with both paths diffed per resolver, with kill criteria stated up front.

---
_Generated by [Claude Code](https://claude.ai/code/session_01V19h1U9ng7nEKV4euXHfr2)_

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/23989?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

