### PR TITLE
Skip orphaned Recall bot cleanup when no local rows carry bot markers

### DIFF
--- a/packages/twenty-apps/public/call-recorder/src/logic-functions/data/has-call-recording-with-recall-bot-marker.util.ts
+++ b/packages/twenty-apps/public/call-recorder/src/logic-functions/data/has-call-recording-with-recall-bot-marker.util.ts
@@ -1,0 +1,48 @@
+import { type CoreApiClient } from 'twenty-client-sdk/core';
+
+type CallRecordingIdNode = {
+  id: string;
+};
+
+type CallRecordingIdConnection = {
+  edges?: Array<{ node: CallRecordingIdNode }> | null;
+};
+
+export const hasCallRecordingWithRecallBotMarker = async (
+  client: CoreApiClient,
+): Promise<boolean> => {
+  const queryResult = await client.query({
+    callRecordings: {
+      __args: {
+        filter: {
+          and: [
+            {
+              or: [
+                { botScheduleAttemptedAt: { is: 'NOT_NULL' } },
+                { externalBotId: { is: 'NOT_NULL' } },
+              ],
+            },
+            {
+              or: [
+                { deletedAt: { is: 'NULL' } },
+                { deletedAt: { is: 'NOT_NULL' } },
+              ],
+            },
+          ],
+        },
+        first: 1,
+      },
+      edges: {
+        node: {
+          id: true,
+        },
+      },
+    },
+  });
+
+  const connection = queryResult.callRecordings as
+    | CallRecordingIdConnection
+    | undefined;
+
+  return (connection?.edges ?? []).length > 0;
+};

--- a/packages/twenty-apps/public/call-recorder/src/logic-functions/flows/__tests__/cleanup-orphaned-recall-bots.test.ts
+++ b/packages/twenty-apps/public/call-recorder/src/logic-functions/flows/__tests__/cleanup-orphaned-recall-bots.test.ts
@@ -21,26 +21,60 @@ type CallRecordingNode = {
   id: string;
   recordingRequestStatus?: string | null;
   externalBotId?: string | null;
+  botScheduleAttemptedAt?: string | null;
+  deletedAt?: string | null;
 };
+
+const isPresent = (value: string | null | undefined): value is string =>
+  value !== null && value !== undefined;
 
 class FakeCoreApiClient {
   constructor(private callRecordings: CallRecordingNode[]) {}
 
   async query(query: any): Promise<any> {
-    const callRecordingIds = query.callRecordings.__args.filter.id.in;
+    const filter = query.callRecordings.__args.filter;
 
+    if (filter.and !== undefined) {
+      return this.queryBotMarkerPage();
+    }
+
+    return this.queryAliveByIdsPage(filter.id.in);
+  }
+
+  private queryBotMarkerPage() {
+    const markedCallRecordings = this.callRecordings.filter(
+      (callRecording) =>
+        isPresent(callRecording.botScheduleAttemptedAt) ||
+        isPresent(callRecording.externalBotId),
+    );
+
+    return {
+      callRecordings: {
+        edges: markedCallRecordings.slice(0, 1).map((node) => ({ node })),
+      },
+    };
+  }
+
+  private queryAliveByIdsPage(callRecordingIds: string[]) {
     return {
       callRecordings: {
         pageInfo: { hasNextPage: false, endCursor: undefined },
         edges: this.callRecordings
-          .filter((callRecording) =>
-            callRecordingIds.includes(callRecording.id),
+          .filter(
+            (callRecording) =>
+              !isPresent(callRecording.deletedAt) &&
+              callRecordingIds.includes(callRecording.id),
           )
           .map((node) => ({ node })),
       },
     };
   }
 }
+
+const BOT_MARKED_CALL_RECORDING: CallRecordingNode = {
+  id: 'bot-marked-call-recording',
+  botScheduleAttemptedAt: '2026-01-01T07:00:00.000Z',
+};
 
 const buildClient = (callRecordings: CallRecordingNode[]): CoreApiClient =>
   new FakeCoreApiClient(callRecordings) as unknown as CoreApiClient;
@@ -167,6 +201,7 @@ describe('cleanupOrphanedRecallBots', () => {
       scannedBotCount: 1,
       truncatedBotList: false,
       canceledExternalBotIds: [],
+      skippedNoBotMarkers: false,
     });
     expect(getDeleteCalls()).toHaveLength(0);
   });
@@ -175,7 +210,7 @@ describe('cleanupOrphanedRecallBots', () => {
     stubRecallApi({ bots: [] });
 
     await cleanupOrphanedRecallBots({
-      client: buildClient([]),
+      client: buildClient([BOT_MARKED_CALL_RECORDING]),
       joinAtAfter: JOIN_AT_AFTER,
       joinAtBefore: JOIN_AT_BEFORE,
     });
@@ -215,6 +250,7 @@ describe('cleanupOrphanedRecallBots', () => {
       scannedBotCount: 1,
       truncatedBotList: false,
       canceledExternalBotIds: ['stale-cancel-bot'],
+      skippedNoBotMarkers: false,
     });
     expect(fetchMock).toHaveBeenCalledWith(
       `${BASE_URL}/bot/stale-cancel-bot/`,
@@ -252,6 +288,7 @@ describe('cleanupOrphanedRecallBots', () => {
       scannedBotCount: 2,
       truncatedBotList: false,
       canceledExternalBotIds: ['superseded-bot'],
+      skippedNoBotMarkers: false,
     });
     expect(getDeleteCalls()).toHaveLength(1);
     expect(fetchMock).toHaveBeenCalledWith(
@@ -260,7 +297,7 @@ describe('cleanupOrphanedRecallBots', () => {
     );
   });
 
-  it('cancels bots whose call recording no longer exists', async () => {
+  it('cancels bots whose call recording was deleted', async () => {
     stubRecallApi({
       bots: [
         buildCurrentWorkspaceBot({
@@ -271,7 +308,13 @@ describe('cleanupOrphanedRecallBots', () => {
     });
 
     const result = await cleanupOrphanedRecallBots({
-      client: buildClient([]),
+      client: buildClient([
+        {
+          id: 'call-recording-gone',
+          externalBotId: 'orphan-bot',
+          deletedAt: '2026-01-01T10:00:00.000Z',
+        },
+      ]),
       joinAtAfter: JOIN_AT_AFTER,
       joinAtBefore: JOIN_AT_BEFORE,
     });
@@ -280,6 +323,7 @@ describe('cleanupOrphanedRecallBots', () => {
       scannedBotCount: 1,
       truncatedBotList: false,
       canceledExternalBotIds: ['orphan-bot'],
+      skippedNoBotMarkers: false,
     });
   });
 
@@ -299,6 +343,7 @@ describe('cleanupOrphanedRecallBots', () => {
           id: 'call-recording-1',
           recordingRequestStatus: 'REQUESTED',
           externalBotId: null,
+          botScheduleAttemptedAt: '2026-01-01T09:00:00.000Z',
         },
       ]),
       joinAtAfter: JOIN_AT_AFTER,
@@ -309,6 +354,7 @@ describe('cleanupOrphanedRecallBots', () => {
       scannedBotCount: 1,
       truncatedBotList: false,
       canceledExternalBotIds: [],
+      skippedNoBotMarkers: false,
     });
     expect(getDeleteCalls()).toHaveLength(0);
   });
@@ -317,7 +363,7 @@ describe('cleanupOrphanedRecallBots', () => {
     stubRecallApi({ bots: [buildBot({ id: 'unrelated-bot' })] });
 
     const result = await cleanupOrphanedRecallBots({
-      client: buildClient([]),
+      client: buildClient([BOT_MARKED_CALL_RECORDING]),
       joinAtAfter: JOIN_AT_AFTER,
       joinAtBefore: JOIN_AT_BEFORE,
     });
@@ -326,6 +372,7 @@ describe('cleanupOrphanedRecallBots', () => {
       scannedBotCount: 1,
       truncatedBotList: false,
       canceledExternalBotIds: [],
+      skippedNoBotMarkers: false,
     });
     expect(getDeleteCalls()).toHaveLength(0);
   });
@@ -341,7 +388,7 @@ describe('cleanupOrphanedRecallBots', () => {
     });
 
     const result = await cleanupOrphanedRecallBots({
-      client: buildClient([]),
+      client: buildClient([BOT_MARKED_CALL_RECORDING]),
       joinAtAfter: JOIN_AT_AFTER,
       joinAtBefore: JOIN_AT_BEFORE,
     });
@@ -350,6 +397,7 @@ describe('cleanupOrphanedRecallBots', () => {
       scannedBotCount: 1,
       truncatedBotList: false,
       canceledExternalBotIds: [],
+      skippedNoBotMarkers: false,
     });
     expect(getDeleteCalls()).toHaveLength(0);
   });
@@ -366,7 +414,7 @@ describe('cleanupOrphanedRecallBots', () => {
     });
 
     const result = await cleanupOrphanedRecallBots({
-      client: buildClient([]),
+      client: buildClient([BOT_MARKED_CALL_RECORDING]),
       joinAtAfter: JOIN_AT_AFTER,
       joinAtBefore: JOIN_AT_BEFORE,
     });
@@ -375,6 +423,7 @@ describe('cleanupOrphanedRecallBots', () => {
       scannedBotCount: 1,
       truncatedBotList: false,
       canceledExternalBotIds: [],
+      skippedNoBotMarkers: false,
     });
     expect(getDeleteCalls()).toHaveLength(0);
   });
@@ -390,7 +439,7 @@ describe('cleanupOrphanedRecallBots', () => {
     });
 
     const result = await cleanupOrphanedRecallBots({
-      client: buildClient([]),
+      client: buildClient([BOT_MARKED_CALL_RECORDING]),
       joinAtAfter: JOIN_AT_AFTER,
       joinAtBefore: JOIN_AT_BEFORE,
     });
@@ -399,6 +448,7 @@ describe('cleanupOrphanedRecallBots', () => {
       scannedBotCount: 1,
       truncatedBotList: false,
       canceledExternalBotIds: ['same-workspace-bot'],
+      skippedNoBotMarkers: false,
     });
     expect(fetchMock).toHaveBeenCalledWith(
       `${BASE_URL}/bot/same-workspace-bot/`,
@@ -420,7 +470,7 @@ describe('cleanupOrphanedRecallBots', () => {
     });
 
     const resultPromise = cleanupOrphanedRecallBots({
-      client: buildClient([]),
+      client: buildClient([BOT_MARKED_CALL_RECORDING]),
       joinAtAfter: JOIN_AT_AFTER,
       joinAtBefore: JOIN_AT_BEFORE,
     });
@@ -431,6 +481,7 @@ describe('cleanupOrphanedRecallBots', () => {
       scannedBotCount: 1,
       truncatedBotList: false,
       canceledExternalBotIds: ['in-call-orphan'],
+      skippedNoBotMarkers: false,
     });
     expect(fetchMock).toHaveBeenCalledWith(
       `${BASE_URL}/bot/in-call-orphan/leave_call/`,
@@ -467,7 +518,7 @@ describe('cleanupOrphanedRecallBots', () => {
     });
 
     const result = await cleanupOrphanedRecallBots({
-      client: buildClient([]),
+      client: buildClient([BOT_MARKED_CALL_RECORDING]),
       joinAtAfter: JOIN_AT_AFTER,
       joinAtBefore: JOIN_AT_BEFORE,
     });
@@ -476,6 +527,7 @@ describe('cleanupOrphanedRecallBots', () => {
       scannedBotCount: 1,
       truncatedBotList: true,
       canceledExternalBotIds: ['orphan-bot'],
+      skippedNoBotMarkers: false,
     });
     expect(
       fetchMock.mock.calls.filter(([, init]) => init.method === 'GET'),
@@ -494,7 +546,7 @@ describe('cleanupOrphanedRecallBots', () => {
     });
 
     const result = await cleanupOrphanedRecallBots({
-      client: buildClient([]),
+      client: buildClient([BOT_MARKED_CALL_RECORDING]),
       joinAtAfter: JOIN_AT_AFTER,
       joinAtBefore: JOIN_AT_BEFORE,
     });
@@ -503,6 +555,7 @@ describe('cleanupOrphanedRecallBots', () => {
       scannedBotCount: 0,
       truncatedBotList: false,
       canceledExternalBotIds: [],
+      skippedNoBotMarkers: false,
     });
     expect(getDeleteCalls()).toHaveLength(0);
   });
@@ -528,6 +581,50 @@ describe('cleanupOrphanedRecallBots', () => {
       scannedBotCount: 0,
       truncatedBotList: false,
       canceledExternalBotIds: [],
+      skippedNoBotMarkers: false,
+    });
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('skips the Recall list when the workspace has no call recordings', async () => {
+    stubRecallApi({ bots: [] });
+
+    const result = await cleanupOrphanedRecallBots({
+      client: buildClient([]),
+      joinAtAfter: JOIN_AT_AFTER,
+      joinAtBefore: JOIN_AT_BEFORE,
+    });
+
+    expect(result).toEqual({
+      scannedBotCount: 0,
+      truncatedBotList: false,
+      canceledExternalBotIds: [],
+      skippedNoBotMarkers: true,
+    });
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('skips the Recall list when no call recording ever attempted a Recall bot', async () => {
+    stubRecallApi({ bots: [] });
+
+    const result = await cleanupOrphanedRecallBots({
+      client: buildClient([
+        {
+          id: 'fireflies-recording',
+          recordingRequestStatus: 'REQUESTED',
+          externalBotId: null,
+          botScheduleAttemptedAt: null,
+        },
+      ]),
+      joinAtAfter: JOIN_AT_AFTER,
+      joinAtBefore: JOIN_AT_BEFORE,
+    });
+
+    expect(result).toEqual({
+      scannedBotCount: 0,
+      truncatedBotList: false,
+      canceledExternalBotIds: [],
+      skippedNoBotMarkers: true,
     });
     expect(fetchMock).not.toHaveBeenCalled();
   });

--- a/packages/twenty-apps/public/call-recorder/src/logic-functions/flows/cleanup-orphaned-recall-bots.util.ts
+++ b/packages/twenty-apps/public/call-recorder/src/logic-functions/flows/cleanup-orphaned-recall-bots.util.ts
@@ -7,6 +7,7 @@ import { cancelOrEjectRecallBot } from 'src/logic-functions/recall-api/cancel-or
 import { findCallRecordingsByIds } from 'src/logic-functions/data/find-call-recordings-by-ids.util';
 import { getClaimedWorkspaceId } from 'src/logic-functions/recall-api/get-claimed-workspace-id.util';
 import { getCurrentWorkspaceId } from 'src/logic-functions/data/get-current-workspace-id.util';
+import { hasCallRecordingWithRecallBotMarker } from 'src/logic-functions/data/has-call-recording-with-recall-bot-marker.util';
 import { getUniqueSortedIds } from 'src/logic-functions/utils/get-unique-sorted-ids.util';
 import { isNonEmptyString } from 'src/logic-functions/utils/is-non-empty-string.util';
 import {
@@ -18,6 +19,7 @@ export type CleanupOrphanedRecallBotsResult = {
   scannedBotCount: number;
   canceledExternalBotIds: string[];
   truncatedBotList: boolean;
+  skippedNoBotMarkers: boolean;
 };
 
 // Bots no open CallRecording request claims would still join; cancel them on Recall.
@@ -41,6 +43,16 @@ export const cleanupOrphanedRecallBots = async ({
       scannedBotCount: 0,
       canceledExternalBotIds: [],
       truncatedBotList: false,
+      skippedNoBotMarkers: false,
+    };
+  }
+
+  if (!(await hasCallRecordingWithRecallBotMarker(client))) {
+    return {
+      scannedBotCount: 0,
+      canceledExternalBotIds: [],
+      truncatedBotList: false,
+      skippedNoBotMarkers: true,
     };
   }
 
@@ -60,6 +72,7 @@ export const cleanupOrphanedRecallBots = async ({
       scannedBotCount: 0,
       canceledExternalBotIds: [],
       truncatedBotList: false,
+      skippedNoBotMarkers: false,
     };
   }
 
@@ -72,6 +85,7 @@ export const cleanupOrphanedRecallBots = async ({
       scannedBotCount: listResult.bots.length,
       canceledExternalBotIds: [],
       truncatedBotList: listResult.truncated,
+      skippedNoBotMarkers: false,
     };
   }
 
@@ -109,6 +123,7 @@ export const cleanupOrphanedRecallBots = async ({
     scannedBotCount: listResult.bots.length,
     canceledExternalBotIds,
     truncatedBotList: listResult.truncated,
+    skippedNoBotMarkers: false,
   };
 };
 


### PR DESCRIPTION
Every workspace with the call-recorder app runs the orphaned-bot cleanup cron at 4:30 UTC, and each run lists bots from Recall. On the shared Recall account this lands as one burst of ~415 `GET /api/v1/bot` requests in a single minute, of which only the first 240 succeeded under the old rate limit; the rest got 429s and those workspaces silently skipped cleanup. Most of these workspaces have never scheduled a bot.

Bot creation stamps `botScheduleAttemptedAt` on the CallRecording row before the POST reaches Recall, so a workspace with no rows carrying `botScheduleAttemptedAt` or `externalBotId` (soft-deleted rows included) cannot own any Recall bot. The cleanup now checks this locally first and skips the Recall list call when no marked row exists, which drops the daily burst to roughly the number of workspaces with recent recording activity.

Deferred: per-workspace splay of app cron triggers (platform-level), and making the 429 retry delay cross the rate-limit minute window.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/23994?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

Base of the stack #23994 -> #25093 -> #25091: merges first and removes the dormant-workspace share of the current rate-limit burst.



## Invariants

- Bot creation stamps `botScheduleAttemptedAt` before the Recall POST, so a workspace with no row carrying a bot marker (soft-deleted rows included) cannot own a Recall bot.
