### PR TITLE
chore(slack): bump app version to 0.3.0

### DIFF
--- a/packages/twenty-apps/public/slack/package.json
+++ b/packages/twenty-apps/public/slack/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@twentyhq/slack",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "Slack assistant and workflow steps for Twenty",
   "license": "MIT",
   "engines": {


### PR DESCRIPTION
## Summary
- Bumps `@twentyhq/slack` from `0.2.0` to `0.3.0` so a new app release can be published (server rejects same/lower semver).

## Test plan
- [ ] Confirm `packages/twenty-apps/public/slack/package.json` version is `0.3.0`
- [ ] After merge, publish with `yarn twenty app:publish` (or `--private`) from the Slack app directory