### PR TITLE
fix(server): validate row level permission predicate values at write time

### DIFF
--- a/packages/twenty-server/src/engine/workspace-manager/workspace-migration/workspace-migration-builder/validators/services/__tests__/flat-row-level-permission-predicate-validator.service.spec.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/workspace-migration/workspace-migration-builder/validators/services/__tests__/flat-row-level-permission-predicate-validator.service.spec.ts
@@ -154,13 +154,13 @@ describe('FlatRowLevelPermissionPredicateValidatorService', () => {
       expect(result.errors).toEqual([]);
     });
 
-    it.each([[''], ['[]'], [[]]])(
+    it.each([[''], ['[]'], [[]], [null], [undefined]])(
       'should reject %p on an operand that expects a value',
       (value) => {
         const result = service.validateFlatRowLevelPermissionPredicateCreation(
           buildCreationArgs({
-            fieldType: FieldMetadataType.RELATION,
-            operand: RowLevelPermissionPredicateOperand.IS,
+            fieldType: FieldMetadataType.TEXT,
+            operand: RowLevelPermissionPredicateOperand.CONTAINS,
             value,
           }),
         );

--- a/packages/twenty-server/src/engine/workspace-manager/workspace-migration/workspace-migration-builder/validators/services/__tests__/flat-row-level-permission-predicate-validator.service.spec.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/workspace-migration/workspace-migration-builder/validators/services/__tests__/flat-row-level-permission-predicate-validator.service.spec.ts
@@ -154,18 +154,21 @@ describe('FlatRowLevelPermissionPredicateValidatorService', () => {
       expect(result.errors).toEqual([]);
     });
 
-    it('should reject an empty value on an operand that expects one', () => {
-      const result = service.validateFlatRowLevelPermissionPredicateCreation(
-        buildCreationArgs({
-          fieldType: FieldMetadataType.RELATION,
-          operand: RowLevelPermissionPredicateOperand.IS,
-          value: '',
-        }),
-      );
+    it.each([[''], ['[]'], [[]]])(
+      'should reject %p on an operand that expects a value',
+      (value) => {
+        const result = service.validateFlatRowLevelPermissionPredicateCreation(
+          buildCreationArgs({
+            fieldType: FieldMetadataType.RELATION,
+            operand: RowLevelPermissionPredicateOperand.IS,
+            value,
+          }),
+        );
 
-      expect(result.errors).toHaveLength(1);
-      expect(result.errors[0].message).toContain('requires a value');
-    });
+        expect(result.errors).toHaveLength(1);
+        expect(result.errors[0].message).toContain('requires a value');
+      },
+    );
 
     it('should accept a value-less operand with no value', () => {
       const result = service.validateFlatRowLevelPermissionPredicateCreation(

--- a/packages/twenty-server/src/engine/workspace-manager/workspace-migration/workspace-migration-builder/validators/services/__tests__/flat-row-level-permission-predicate-validator.service.spec.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/workspace-migration/workspace-migration-builder/validators/services/__tests__/flat-row-level-permission-predicate-validator.service.spec.ts
@@ -1,0 +1,200 @@
+import {
+  FieldMetadataType,
+  RowLevelPermissionPredicateOperand,
+} from 'twenty-shared/types';
+
+import { FlatRowLevelPermissionPredicateValidatorService } from 'src/engine/workspace-manager/workspace-migration/workspace-migration-builder/validators/services/flat-row-level-permission-predicate-validator.service';
+
+const PREDICATE_UNIVERSAL_IDENTIFIER = '00000000-0000-4000-8000-0000000000a1';
+const FIELD_UNIVERSAL_IDENTIFIER = '00000000-0000-4000-8000-0000000000b1';
+const OBJECT_UNIVERSAL_IDENTIFIER = '00000000-0000-4000-8000-0000000000c1';
+const ROLE_UNIVERSAL_IDENTIFIER = '00000000-0000-4000-8000-0000000000d1';
+const RECORD_ID = '20202020-1c25-4d02-bf25-6aeccf7ea419';
+
+const mapsFrom = (
+  entities: { universalIdentifier: string; [key: string]: unknown }[],
+) => ({
+  byUniversalIdentifier: Object.fromEntries(
+    entities.map((entity) => [entity.universalIdentifier, entity]),
+  ),
+});
+
+const buildPredicate = ({
+  operand,
+  value,
+  workspaceMemberFieldMetadataUniversalIdentifier = null,
+}: {
+  operand: RowLevelPermissionPredicateOperand;
+  value: unknown;
+  workspaceMemberFieldMetadataUniversalIdentifier?: string | null;
+}) => ({
+  universalIdentifier: PREDICATE_UNIVERSAL_IDENTIFIER,
+  fieldMetadataUniversalIdentifier: FIELD_UNIVERSAL_IDENTIFIER,
+  objectMetadataUniversalIdentifier: OBJECT_UNIVERSAL_IDENTIFIER,
+  roleUniversalIdentifier: ROLE_UNIVERSAL_IDENTIFIER,
+  rowLevelPermissionPredicateGroupUniversalIdentifier: null,
+  operand,
+  value,
+  subFieldName: null,
+  workspaceMemberFieldMetadataUniversalIdentifier,
+});
+
+const relatedMaps = (fieldType: FieldMetadataType) => ({
+  flatRowLevelPermissionPredicateGroupMaps: mapsFrom([]),
+  flatFieldMetadataMaps: mapsFrom([
+    {
+      universalIdentifier: FIELD_UNIVERSAL_IDENTIFIER,
+      type: fieldType,
+      label: 'Account Owner',
+    },
+  ]),
+  flatObjectMetadataMaps: mapsFrom([
+    { universalIdentifier: OBJECT_UNIVERSAL_IDENTIFIER },
+  ]),
+  flatRoleMaps: mapsFrom([{ universalIdentifier: ROLE_UNIVERSAL_IDENTIFIER }]),
+});
+
+const buildCreationArgs = ({
+  fieldType,
+  operand,
+  value,
+  workspaceMemberFieldMetadataUniversalIdentifier = null,
+}: {
+  fieldType: FieldMetadataType;
+  operand: RowLevelPermissionPredicateOperand;
+  value: unknown;
+  workspaceMemberFieldMetadataUniversalIdentifier?: string | null;
+}) =>
+  ({
+    flatEntityToValidate: buildPredicate({
+      operand,
+      value,
+      workspaceMemberFieldMetadataUniversalIdentifier,
+    }),
+    optimisticFlatEntityMapsAndRelatedFlatEntityMaps: {
+      flatRowLevelPermissionPredicateMaps: mapsFrom([]),
+      ...relatedMaps(fieldType),
+    },
+  }) as unknown as Parameters<
+    FlatRowLevelPermissionPredicateValidatorService['validateFlatRowLevelPermissionPredicateCreation']
+  >[0];
+
+const buildUpdateArgs = ({
+  fieldType,
+  operand,
+  value,
+  flatEntityUpdate,
+}: {
+  fieldType: FieldMetadataType;
+  operand: RowLevelPermissionPredicateOperand;
+  value: unknown;
+  flatEntityUpdate: Record<string, unknown>;
+}) =>
+  ({
+    universalIdentifier: PREDICATE_UNIVERSAL_IDENTIFIER,
+    flatEntityUpdate,
+    optimisticFlatEntityMapsAndRelatedFlatEntityMaps: {
+      flatRowLevelPermissionPredicateMaps: mapsFrom([
+        buildPredicate({
+          operand,
+          value,
+          workspaceMemberFieldMetadataUniversalIdentifier:
+            FIELD_UNIVERSAL_IDENTIFIER,
+        }),
+      ]),
+      ...relatedMaps(fieldType),
+    },
+  }) as unknown as Parameters<
+    FlatRowLevelPermissionPredicateValidatorService['validateFlatRowLevelPermissionPredicateUpdate']
+  >[0];
+
+describe('FlatRowLevelPermissionPredicateValidatorService', () => {
+  let service: FlatRowLevelPermissionPredicateValidatorService;
+
+  beforeEach(() => {
+    service = new FlatRowLevelPermissionPredicateValidatorService();
+  });
+
+  describe('creation', () => {
+    it('should reject a relation value that resolves to no record id', () => {
+      const result = service.validateFlatRowLevelPermissionPredicateCreation(
+        buildCreationArgs({
+          fieldType: FieldMetadataType.RELATION,
+          operand: RowLevelPermissionPredicateOperand.IS,
+          value: { direction: 'NEXT', amount: 30, unit: 'DAY' },
+        }),
+      );
+
+      expect(result.errors).toHaveLength(1);
+    });
+
+    it('should reject the object form of a relative date predicate', () => {
+      const result = service.validateFlatRowLevelPermissionPredicateCreation(
+        buildCreationArgs({
+          fieldType: FieldMetadataType.DATE,
+          operand: RowLevelPermissionPredicateOperand.IS_RELATIVE,
+          value: { direction: 'NEXT', amount: 30, unit: 'DAY' },
+        }),
+      );
+
+      expect(result.errors).toHaveLength(1);
+      expect(result.errors[0].message).toContain('NEXT_30_DAY');
+    });
+
+    it('should accept a valid predicate value', () => {
+      const result = service.validateFlatRowLevelPermissionPredicateCreation(
+        buildCreationArgs({
+          fieldType: FieldMetadataType.RELATION,
+          operand: RowLevelPermissionPredicateOperand.IS,
+          value: { selectedRecordIds: [RECORD_ID] },
+        }),
+      );
+
+      expect(result.errors).toEqual([]);
+    });
+
+    it('should skip validation when the value is resolved from the workspace member', () => {
+      const result = service.validateFlatRowLevelPermissionPredicateCreation(
+        buildCreationArgs({
+          fieldType: FieldMetadataType.RELATION,
+          operand: RowLevelPermissionPredicateOperand.IS,
+          value: null,
+          workspaceMemberFieldMetadataUniversalIdentifier:
+            FIELD_UNIVERSAL_IDENTIFIER,
+        }),
+      );
+
+      expect(result.errors).toEqual([]);
+    });
+  });
+
+  describe('update', () => {
+    it('should validate the retained value when workspace member resolution is cleared', () => {
+      const result = service.validateFlatRowLevelPermissionPredicateUpdate(
+        buildUpdateArgs({
+          fieldType: FieldMetadataType.RELATION,
+          operand: RowLevelPermissionPredicateOperand.IS,
+          value: { direction: 'NEXT', amount: 30, unit: 'DAY' },
+          flatEntityUpdate: {
+            workspaceMemberFieldMetadataUniversalIdentifier: null,
+          },
+        }),
+      );
+
+      expect(result.errors).toHaveLength(1);
+    });
+
+    it('should not validate the value when it is not part of the update', () => {
+      const result = service.validateFlatRowLevelPermissionPredicateUpdate(
+        buildUpdateArgs({
+          fieldType: FieldMetadataType.RELATION,
+          operand: RowLevelPermissionPredicateOperand.IS,
+          value: { direction: 'NEXT', amount: 30, unit: 'DAY' },
+          flatEntityUpdate: { positionInRowLevelPermissionPredicateGroup: 2 },
+        }),
+      );
+
+      expect(result.errors).toEqual([]);
+    });
+  });
+});

--- a/packages/twenty-server/src/engine/workspace-manager/workspace-migration/workspace-migration-builder/validators/services/__tests__/flat-row-level-permission-predicate-validator.service.spec.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/workspace-migration/workspace-migration-builder/validators/services/__tests__/flat-row-level-permission-predicate-validator.service.spec.ts
@@ -154,8 +154,24 @@ describe('FlatRowLevelPermissionPredicateValidatorService', () => {
       expect(result.errors).toEqual([]);
     });
 
-    it.each([[''], ['[]'], [[]], [null], [undefined]])(
+    it.each([[''], ['[]'], [[]]])(
       'should reject %p on an operand that expects a value',
+      (value) => {
+        const result = service.validateFlatRowLevelPermissionPredicateCreation(
+          buildCreationArgs({
+            fieldType: FieldMetadataType.RELATION,
+            operand: RowLevelPermissionPredicateOperand.IS,
+            value,
+          }),
+        );
+
+        expect(result.errors).toHaveLength(1);
+        expect(result.errors[0].message).toContain('requires a value');
+      },
+    );
+
+    it.each([[null], [undefined]])(
+      'should accept %p, a predicate whose value is not filled in yet',
       (value) => {
         const result = service.validateFlatRowLevelPermissionPredicateCreation(
           buildCreationArgs({
@@ -165,8 +181,7 @@ describe('FlatRowLevelPermissionPredicateValidatorService', () => {
           }),
         );
 
-        expect(result.errors).toHaveLength(1);
-        expect(result.errors[0].message).toContain('requires a value');
+        expect(result.errors).toEqual([]);
       },
     );
 

--- a/packages/twenty-server/src/engine/workspace-manager/workspace-migration/workspace-migration-builder/validators/services/__tests__/flat-row-level-permission-predicate-validator.service.spec.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/workspace-migration/workspace-migration-builder/validators/services/__tests__/flat-row-level-permission-predicate-validator.service.spec.ts
@@ -84,11 +84,13 @@ const buildUpdateArgs = ({
   operand,
   value,
   flatEntityUpdate,
+  workspaceMemberFieldMetadataUniversalIdentifier = null,
 }: {
   fieldType: FieldMetadataType;
   operand: RowLevelPermissionPredicateOperand;
   value: unknown;
   flatEntityUpdate: Record<string, unknown>;
+  workspaceMemberFieldMetadataUniversalIdentifier?: string | null;
 }) =>
   ({
     universalIdentifier: PREDICATE_UNIVERSAL_IDENTIFIER,
@@ -98,8 +100,7 @@ const buildUpdateArgs = ({
         buildPredicate({
           operand,
           value,
-          workspaceMemberFieldMetadataUniversalIdentifier:
-            FIELD_UNIVERSAL_IDENTIFIER,
+          workspaceMemberFieldMetadataUniversalIdentifier,
         }),
       ]),
       ...relatedMaps(fieldType),
@@ -153,6 +154,31 @@ describe('FlatRowLevelPermissionPredicateValidatorService', () => {
       expect(result.errors).toEqual([]);
     });
 
+    it('should reject an empty value on an operand that expects one', () => {
+      const result = service.validateFlatRowLevelPermissionPredicateCreation(
+        buildCreationArgs({
+          fieldType: FieldMetadataType.RELATION,
+          operand: RowLevelPermissionPredicateOperand.IS,
+          value: '',
+        }),
+      );
+
+      expect(result.errors).toHaveLength(1);
+      expect(result.errors[0].message).toContain('requires a value');
+    });
+
+    it('should accept a value-less operand with no value', () => {
+      const result = service.validateFlatRowLevelPermissionPredicateCreation(
+        buildCreationArgs({
+          fieldType: FieldMetadataType.RELATION,
+          operand: RowLevelPermissionPredicateOperand.IS_NOT_EMPTY,
+          value: null,
+        }),
+      );
+
+      expect(result.errors).toEqual([]);
+    });
+
     it('should skip validation when the value is resolved from the workspace member', () => {
       const result = service.validateFlatRowLevelPermissionPredicateCreation(
         buildCreationArgs({
@@ -175,6 +201,8 @@ describe('FlatRowLevelPermissionPredicateValidatorService', () => {
           fieldType: FieldMetadataType.RELATION,
           operand: RowLevelPermissionPredicateOperand.IS,
           value: { direction: 'NEXT', amount: 30, unit: 'DAY' },
+          workspaceMemberFieldMetadataUniversalIdentifier:
+            FIELD_UNIVERSAL_IDENTIFIER,
           flatEntityUpdate: {
             workspaceMemberFieldMetadataUniversalIdentifier: null,
           },

--- a/packages/twenty-server/src/engine/workspace-manager/workspace-migration/workspace-migration-builder/validators/services/flat-row-level-permission-predicate-validator.service.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/workspace-migration/workspace-migration-builder/validators/services/flat-row-level-permission-predicate-validator.service.ts
@@ -15,6 +15,7 @@ import {
   getFilterValueValidationIssue,
   isDefined,
   isRecordFilterOperandExpectingValue,
+  isRecordFilterValueValid,
 } from 'twenty-shared/utils';
 
 import { findFlatEntityByUniversalIdentifier } from 'src/engine/metadata-modules/flat-entity/utils/find-flat-entity-by-universal-identifier.util';
@@ -361,7 +362,10 @@ export class FlatRowLevelPermissionPredicateValidatorService {
 
     if (
       isRecordFilterOperandExpectingValue(recordFilterOperand) &&
-      !isNonEmptyString(convertViewFilterValueToString(value))
+      !isRecordFilterValueValid({
+        operand: recordFilterOperand,
+        value: convertViewFilterValueToString(value),
+      })
     ) {
       return {
         code: RowLevelPermissionPredicateExceptionCode.INVALID_ROW_LEVEL_PERMISSION_PREDICATE_DATA,

--- a/packages/twenty-server/src/engine/workspace-manager/workspace-migration/workspace-migration-builder/validators/services/flat-row-level-permission-predicate-validator.service.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/workspace-migration/workspace-migration-builder/validators/services/flat-row-level-permission-predicate-validator.service.ts
@@ -364,7 +364,7 @@ export class FlatRowLevelPermissionPredicateValidatorService {
       isRecordFilterOperandExpectingValue(recordFilterOperand) &&
       !isRecordFilterValueValid({
         operand: recordFilterOperand,
-        value: isDefined(value) ? convertViewFilterValueToString(value) : '',
+        value: convertViewFilterValueToString(value),
       })
     ) {
       return {

--- a/packages/twenty-server/src/engine/workspace-manager/workspace-migration/workspace-migration-builder/validators/services/flat-row-level-permission-predicate-validator.service.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/workspace-migration/workspace-migration-builder/validators/services/flat-row-level-permission-predicate-validator.service.ts
@@ -12,10 +12,12 @@ import {
 } from 'twenty-shared/types';
 import {
   convertViewFilterValueToString,
+  getFilterTypeFromFieldType,
   getFilterValueValidationIssue,
   isDefined,
   isRecordFilterOperandExpectingValue,
   isRecordFilterValueValid,
+  jsonRelationFilterValueSchema,
 } from 'twenty-shared/utils';
 
 import { findFlatEntityByUniversalIdentifier } from 'src/engine/metadata-modules/flat-entity/utils/find-flat-entity-by-universal-identifier.util';
@@ -341,6 +343,43 @@ export class FlatRowLevelPermissionPredicateValidatorService {
     return validationResult;
   }
 
+  // A row level permission predicate compiles without a current record, so a
+  // relation value resolving only through isCurrentRecordSelected yields no
+  // record id and removes the restriction instead of matching nothing. View
+  // filters do resolve it, so this cannot live in the shared schema.
+  private getUnresolvableRelationError({
+    fieldType,
+    operand,
+    value,
+  }: {
+    fieldType: FieldMetadataType;
+    operand: RowLevelPermissionPredicateOperand;
+    value: unknown;
+  }) {
+    if (getFilterTypeFromFieldType(fieldType) !== 'RELATION') {
+      return undefined;
+    }
+
+    const stringifiedValue = convertViewFilterValueToString(value);
+
+    const relationValue =
+      jsonRelationFilterValueSchema.safeParse(stringifiedValue);
+
+    if (
+      !relationValue.success ||
+      relationValue.data.selectedRecordIds.length > 0 ||
+      relationValue.data.isCurrentWorkspaceMemberSelected === true
+    ) {
+      return undefined;
+    }
+
+    return {
+      code: RowLevelPermissionPredicateExceptionCode.INVALID_ROW_LEVEL_PERMISSION_PREDICATE_DATA,
+      message: t`Value "${stringifiedValue}" resolves to no record for operand "${operand}", the current record is not available to a row level permission predicate`,
+      userFriendlyMessage: msg`Predicate value is not valid for this operand`,
+    };
+  }
+
   private getInvalidValueError({
     fieldType,
     operand,
@@ -372,6 +411,16 @@ export class FlatRowLevelPermissionPredicateValidatorService {
         message: t`Operand "${operand}" requires a value, an empty predicate would remove the row restriction entirely`,
         userFriendlyMessage: msg`Predicate is missing a value`,
       };
+    }
+
+    const unresolvableRelationError = this.getUnresolvableRelationError({
+      fieldType,
+      operand,
+      value,
+    });
+
+    if (isDefined(unresolvableRelationError)) {
+      return unresolvableRelationError;
     }
 
     const issue = getFilterValueValidationIssue({

--- a/packages/twenty-server/src/engine/workspace-manager/workspace-migration/workspace-migration-builder/validators/services/flat-row-level-permission-predicate-validator.service.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/workspace-migration/workspace-migration-builder/validators/services/flat-row-level-permission-predicate-validator.service.ts
@@ -364,7 +364,7 @@ export class FlatRowLevelPermissionPredicateValidatorService {
       isRecordFilterOperandExpectingValue(recordFilterOperand) &&
       !isRecordFilterValueValid({
         operand: recordFilterOperand,
-        value: convertViewFilterValueToString(value),
+        value: isDefined(value) ? convertViewFilterValueToString(value) : '',
       })
     ) {
       return {

--- a/packages/twenty-server/src/engine/workspace-manager/workspace-migration/workspace-migration-builder/validators/services/flat-row-level-permission-predicate-validator.service.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/workspace-migration/workspace-migration-builder/validators/services/flat-row-level-permission-predicate-validator.service.ts
@@ -7,9 +7,15 @@ import { isNonEmptyString } from '@sniptt/guards';
 import { ALL_METADATA_NAME } from 'twenty-shared/metadata';
 import {
   type FieldMetadataType,
+  type RowLevelPermissionPredicateOperand,
   type ViewFilterOperand,
 } from 'twenty-shared/types';
-import { getFilterValueValidationIssue, isDefined } from 'twenty-shared/utils';
+import {
+  convertViewFilterValueToString,
+  getFilterValueValidationIssue,
+  isDefined,
+  isRecordFilterOperandExpectingValue,
+} from 'twenty-shared/utils';
 
 import { findFlatEntityByUniversalIdentifier } from 'src/engine/metadata-modules/flat-entity/utils/find-flat-entity-by-universal-identifier.util';
 import { RowLevelPermissionPredicateExceptionCode } from 'src/engine/metadata-modules/row-level-permission-predicate/exceptions/row-level-permission-predicate.exception';
@@ -342,7 +348,7 @@ export class FlatRowLevelPermissionPredicateValidatorService {
     workspaceMemberFieldMetadataUniversalIdentifier,
   }: {
     fieldType: FieldMetadataType;
-    operand: string;
+    operand: RowLevelPermissionPredicateOperand;
     subFieldName: string | null | undefined;
     value: unknown;
     workspaceMemberFieldMetadataUniversalIdentifier: string | null | undefined;
@@ -351,7 +357,18 @@ export class FlatRowLevelPermissionPredicateValidatorService {
       return undefined;
     }
 
-    const recordFilterOperand = operand as ViewFilterOperand;
+    const recordFilterOperand = operand as unknown as ViewFilterOperand;
+
+    if (
+      isRecordFilterOperandExpectingValue(recordFilterOperand) &&
+      !isNonEmptyString(convertViewFilterValueToString(value))
+    ) {
+      return {
+        code: RowLevelPermissionPredicateExceptionCode.INVALID_ROW_LEVEL_PERMISSION_PREDICATE_DATA,
+        message: t`Operand "${operand}" requires a value, an empty predicate would remove the row restriction entirely`,
+        userFriendlyMessage: msg`Predicate is missing a value`,
+      };
+    }
 
     const issue = getFilterValueValidationIssue({
       fieldType,

--- a/packages/twenty-server/src/engine/workspace-manager/workspace-migration/workspace-migration-builder/validators/services/flat-row-level-permission-predicate-validator.service.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/workspace-migration/workspace-migration-builder/validators/services/flat-row-level-permission-predicate-validator.service.ts
@@ -3,8 +3,13 @@
 import { Injectable } from '@nestjs/common';
 
 import { msg, t } from '@lingui/core/macro';
+import { isNonEmptyString } from '@sniptt/guards';
 import { ALL_METADATA_NAME } from 'twenty-shared/metadata';
-import { isDefined } from 'twenty-shared/utils';
+import {
+  type FieldMetadataType,
+  type ViewFilterOperand,
+} from 'twenty-shared/types';
+import { getFilterValueValidationIssue, isDefined } from 'twenty-shared/utils';
 
 import { findFlatEntityByUniversalIdentifier } from 'src/engine/metadata-modules/flat-entity/utils/find-flat-entity-by-universal-identifier.util';
 import { RowLevelPermissionPredicateExceptionCode } from 'src/engine/metadata-modules/row-level-permission-predicate/exceptions/row-level-permission-predicate.exception';
@@ -64,6 +69,19 @@ export class FlatRowLevelPermissionPredicateValidatorService {
         message: t`Field metadata not found`,
         userFriendlyMessage: msg`Field metadata not found`,
       });
+    } else {
+      const invalidValueError = this.getInvalidValueError({
+        fieldType: fieldMetadata.type,
+        operand: flatPredicateToValidate.operand,
+        subFieldName: flatPredicateToValidate.subFieldName,
+        value: flatPredicateToValidate.value,
+        workspaceMemberFieldMetadataUniversalIdentifier:
+          flatPredicateToValidate.workspaceMemberFieldMetadataUniversalIdentifier,
+      });
+
+      if (isDefined(invalidValueError)) {
+        validationResult.errors.push(invalidValueError);
+      }
     }
 
     const objectMetadata = flatObjectMetadataMaps
@@ -240,6 +258,25 @@ export class FlatRowLevelPermissionPredicateValidatorService {
         message: t`Field metadata not found`,
         userFriendlyMessage: msg`Field metadata not found`,
       });
+    } else if (
+      'value' in flatEntityUpdate ||
+      'operand' in flatEntityUpdate ||
+      'fieldMetadataUniversalIdentifier' in flatEntityUpdate ||
+      'subFieldName' in flatEntityUpdate ||
+      'workspaceMemberFieldMetadataUniversalIdentifier' in flatEntityUpdate
+    ) {
+      const invalidValueError = this.getInvalidValueError({
+        fieldType: fieldMetadata.type,
+        operand: updatedPredicate.operand,
+        subFieldName: updatedPredicate.subFieldName,
+        value: updatedPredicate.value,
+        workspaceMemberFieldMetadataUniversalIdentifier:
+          updatedPredicate.workspaceMemberFieldMetadataUniversalIdentifier,
+      });
+
+      if (isDefined(invalidValueError)) {
+        validationResult.errors.push(invalidValueError);
+      }
     }
 
     const objectMetadata = flatObjectMetadataMaps
@@ -295,5 +332,46 @@ export class FlatRowLevelPermissionPredicateValidatorService {
     }
 
     return validationResult;
+  }
+
+  private getInvalidValueError({
+    fieldType,
+    operand,
+    subFieldName,
+    value,
+    workspaceMemberFieldMetadataUniversalIdentifier,
+  }: {
+    fieldType: FieldMetadataType;
+    operand: string;
+    subFieldName: string | null | undefined;
+    value: unknown;
+    workspaceMemberFieldMetadataUniversalIdentifier: string | null | undefined;
+  }) {
+    if (isDefined(workspaceMemberFieldMetadataUniversalIdentifier)) {
+      return undefined;
+    }
+
+    const recordFilterOperand = operand as ViewFilterOperand;
+
+    const issue = getFilterValueValidationIssue({
+      fieldType,
+      operand: recordFilterOperand,
+      subFieldName,
+      value,
+    });
+
+    if (!isDefined(issue)) {
+      return undefined;
+    }
+
+    const { stringifiedValue, filterType, hint } = issue;
+
+    return {
+      code: RowLevelPermissionPredicateExceptionCode.INVALID_ROW_LEVEL_PERMISSION_PREDICATE_DATA,
+      message: isNonEmptyString(hint)
+        ? t`Value "${stringifiedValue}" is not valid for operand "${operand}" on field type "${filterType}". ${hint}`
+        : t`Value "${stringifiedValue}" is not valid for operand "${operand}" on field type "${filterType}".`,
+      userFriendlyMessage: msg`Predicate value is not valid for this operand`,
+    };
   }
 }

--- a/packages/twenty-server/test/integration/graphql/suites/uncompilable-rls-predicate.integration-spec.ts
+++ b/packages/twenty-server/test/integration/graphql/suites/uncompilable-rls-predicate.integration-spec.ts
@@ -1,0 +1,119 @@
+import { randomUUID } from 'crypto';
+
+import { COMPANY_GQL_FIELDS } from 'test/integration/constants/company-gql-fields.constants';
+import { createOneOperationFactory } from 'test/integration/graphql/utils/create-one-operation-factory.util';
+import { destroyOneOperationFactory } from 'test/integration/graphql/utils/destroy-one-operation-factory.util';
+import { findManyOperationFactory } from 'test/integration/graphql/utils/find-many-operation-factory.util';
+import { makeGraphqlAPIRequest } from 'test/integration/graphql/utils/make-graphql-api-request.util';
+import {
+  type AccountOwnerRlsRoleSetup,
+  cleanupAccountOwnerRlsRole,
+  setupAccountOwnerRlsRole,
+  upsertAccountOwnerRlsPredicate,
+} from 'test/integration/graphql/utils/setup-account-owner-rls-role.util';
+
+import { WORKSPACE_MEMBER_DATA_SEED_IDS } from 'src/engine/workspace-manager/dev-seeder/data/constants/workspace-member-data-seeds.constant';
+
+const OWNED_COMPANY_ID = randomUUID();
+const FOREIGN_COMPANY_ID = randomUUID();
+const OWNED_COMPANY_NAME = 'Uncompilable RLS Owned Co';
+const FOREIGN_COMPANY_NAME = 'Uncompilable RLS Foreign Co';
+const PREDICATE_ID = randomUUID();
+
+const findCompanyIdsAsRestrictedRole = async (): Promise<string[]> => {
+  const response = await makeGraphqlAPIRequest(
+    findManyOperationFactory({
+      objectMetadataSingularName: 'company',
+      objectMetadataPluralName: 'companies',
+      gqlFields: 'id',
+      filter: { id: { in: [OWNED_COMPANY_ID, FOREIGN_COMPANY_ID] } },
+    }),
+    APPLE_JONY_MEMBER_ACCESS_TOKEN,
+  );
+
+  expect(response.body.errors).toBeUndefined();
+
+  return response.body.data.companies.edges.map(
+    (edge: { node: { id: string } }) => edge.node.id,
+  );
+};
+
+describe('row-level permission predicates that compile to nothing', () => {
+  let rlsRole: AccountOwnerRlsRoleSetup;
+
+  beforeAll(async () => {
+    for (const { id, name, accountOwnerId } of [
+      {
+        id: OWNED_COMPANY_ID,
+        name: OWNED_COMPANY_NAME,
+        accountOwnerId: WORKSPACE_MEMBER_DATA_SEED_IDS.JONY,
+      },
+      {
+        id: FOREIGN_COMPANY_ID,
+        name: FOREIGN_COMPANY_NAME,
+        accountOwnerId: WORKSPACE_MEMBER_DATA_SEED_IDS.TIM,
+      },
+    ]) {
+      await makeGraphqlAPIRequest(
+        createOneOperationFactory({
+          objectMetadataSingularName: 'company',
+          gqlFields: COMPANY_GQL_FIELDS,
+          data: { id, name, accountOwnerId },
+        }),
+      );
+    }
+
+    rlsRole = await setupAccountOwnerRlsRole({
+      label: 'Uncompilable RLS Predicate Test Role',
+      description: 'Role for testing RLS predicates that compile to nothing',
+    });
+  });
+
+  afterAll(async () => {
+    await cleanupAccountOwnerRlsRole(rlsRole);
+
+    for (const recordId of [OWNED_COMPANY_ID, FOREIGN_COMPANY_ID]) {
+      await makeGraphqlAPIRequest(
+        destroyOneOperationFactory({
+          objectMetadataSingularName: 'company',
+          gqlFields: 'id',
+          recordId,
+        }),
+      );
+    }
+  });
+
+  it('restricts records to the selected account owner', async () => {
+    await upsertAccountOwnerRlsPredicate({
+      setup: rlsRole,
+      predicateId: PREDICATE_ID,
+      value: { selectedRecordIds: [WORKSPACE_MEMBER_DATA_SEED_IDS.JONY] },
+    });
+
+    expect(await findCompanyIdsAsRestrictedRole()).toEqual([OWNED_COMPANY_ID]);
+  });
+
+  // An empty selection compiles to no filter at all, and a role whose only
+  // predicate compiles to nothing ends up with no WHERE clause, so the
+  // restriction disappears instead of matching no record.
+  it('does not expose every record when the only predicate selects no record', async () => {
+    await upsertAccountOwnerRlsPredicate({
+      setup: rlsRole,
+      predicateId: PREDICATE_ID,
+      value: { selectedRecordIds: [] },
+    });
+
+    expect(await findCompanyIdsAsRestrictedRole()).not.toContain(
+      FOREIGN_COMPANY_ID,
+    );
+  });
+
+  it('rejects a predicate value that is not valid for its field type and operand', async () => {
+    await upsertAccountOwnerRlsPredicate({
+      setup: rlsRole,
+      predicateId: PREDICATE_ID,
+      value: { direction: 'NEXT', amount: 30, unit: 'DAY' },
+      expectToFail: true,
+    });
+  });
+});

--- a/packages/twenty-server/test/integration/graphql/suites/uncompilable-rls-predicate.integration-spec.ts
+++ b/packages/twenty-server/test/integration/graphql/suites/uncompilable-rls-predicate.integration-spec.ts
@@ -96,16 +96,25 @@ describe('row-level permission predicates that compile to nothing', () => {
   // An empty selection compiles to no filter at all, and a role whose only
   // predicate compiles to nothing ends up with no WHERE clause, so the
   // restriction disappears instead of matching no record.
-  it('does not expose every record when the only predicate selects no record', async () => {
+  it('does not expose every record when a predicate selects no record', async () => {
     await upsertAccountOwnerRlsPredicate({
       setup: rlsRole,
       predicateId: PREDICATE_ID,
       value: { selectedRecordIds: [] },
+      expectToFail: true,
     });
 
     expect(await findCompanyIdsAsRestrictedRole()).not.toContain(
       FOREIGN_COMPANY_ID,
     );
+  });
+
+  it('accepts a selection resolving to the current workspace member', async () => {
+    await upsertAccountOwnerRlsPredicate({
+      setup: rlsRole,
+      predicateId: PREDICATE_ID,
+      value: { selectedRecordIds: [], isCurrentWorkspaceMemberSelected: true },
+    });
   });
 
   it('rejects a predicate value that is not valid for its field type and operand', async () => {

--- a/packages/twenty-server/test/integration/graphql/suites/uncompilable-rls-predicate.integration-spec.ts
+++ b/packages/twenty-server/test/integration/graphql/suites/uncompilable-rls-predicate.integration-spec.ts
@@ -93,20 +93,22 @@ describe('row-level permission predicates that compile to nothing', () => {
     expect(await findCompanyIdsAsRestrictedRole()).toEqual([OWNED_COMPANY_ID]);
   });
 
-  // An empty selection compiles to no filter at all, and a role whose only
-  // predicate compiles to nothing ends up with no WHERE clause, so the
-  // restriction disappears instead of matching no record.
-  it('does not expose every record when a predicate selects no record', async () => {
+  it('rejects a predicate selecting no record', async () => {
     await upsertAccountOwnerRlsPredicate({
       setup: rlsRole,
       predicateId: PREDICATE_ID,
       value: { selectedRecordIds: [] },
       expectToFail: true,
     });
+  });
 
-    expect(await findCompanyIdsAsRestrictedRole()).not.toContain(
-      FOREIGN_COMPANY_ID,
-    );
+  it('rejects a predicate resolving only through the current record', async () => {
+    await upsertAccountOwnerRlsPredicate({
+      setup: rlsRole,
+      predicateId: PREDICATE_ID,
+      value: { selectedRecordIds: [], isCurrentRecordSelected: true },
+      expectToFail: true,
+    });
   });
 
   it('accepts a selection resolving to the current workspace member', async () => {

--- a/packages/twenty-server/test/integration/graphql/utils/setup-account-owner-rls-role.util.ts
+++ b/packages/twenty-server/test/integration/graphql/utils/setup-account-owner-rls-role.util.ts
@@ -1,0 +1,144 @@
+import { findManyObjectMetadata } from 'test/integration/metadata/suites/object-metadata/utils/find-many-object-metadata.util';
+import { upsertRowLevelPermissionPredicates } from 'test/integration/metadata/suites/row-level-permission-predicate/utils/upsert-row-level-permission-predicates.util';
+import { createOneRole } from 'test/integration/metadata/suites/role/utils/create-one-role.util';
+import { deleteOneRole } from 'test/integration/metadata/suites/role/utils/delete-one-role.util';
+import { findOneRoleByLabel } from 'test/integration/metadata/suites/role/utils/find-one-role-by-label.util';
+import { updateWorkspaceMemberRole } from 'test/integration/metadata/suites/role/utils/update-workspace-member-role.util';
+import { jestExpectToBeDefined } from 'test/utils/jest-expect-to-be-defined.util.test';
+import {
+  type RowLevelPermissionPredicateValue,
+  RowLevelPermissionPredicateOperand,
+} from 'twenty-shared/types';
+import { isDefined } from 'twenty-shared/utils';
+
+import { WORKSPACE_MEMBER_DATA_SEED_IDS } from 'src/engine/workspace-manager/dev-seeder/data/constants/workspace-member-data-seeds.constant';
+
+export type AccountOwnerRlsRoleSetup = {
+  customRoleId: string;
+  originalMemberRoleId: string;
+  companyObjectMetadataId: string;
+  accountOwnerFieldMetadataId: string;
+};
+
+export const setupAccountOwnerRlsRole = async ({
+  label,
+  description,
+}: {
+  label: string;
+  description: string;
+}): Promise<AccountOwnerRlsRoleSetup> => {
+  const memberRole = await findOneRoleByLabel({ label: 'Member' });
+
+  const { data: roleData } = await createOneRole({
+    expectToFail: false,
+    input: {
+      label,
+      description,
+      icon: 'IconSettings',
+      canUpdateAllSettings: false,
+      canAccessAllTools: true,
+      canReadAllObjectRecords: true,
+      canUpdateAllObjectRecords: true,
+      canSoftDeleteAllObjectRecords: false,
+      canDestroyAllObjectRecords: false,
+      canBeAssignedToUsers: true,
+      canBeAssignedToAgents: false,
+      canBeAssignedToApiKeys: false,
+    },
+  });
+
+  const customRoleId = roleData?.createOneRole?.id;
+
+  jestExpectToBeDefined(customRoleId);
+
+  const { objects } = await findManyObjectMetadata({
+    expectToFail: false,
+    input: { filter: {}, paging: { first: 1000 } },
+    gqlFields: `
+        id
+        nameSingular
+        fieldsList {
+          id
+          name
+        }
+      `,
+  });
+
+  jestExpectToBeDefined(objects);
+
+  const companyObjectMetadata = objects.find(
+    (object) => object.nameSingular === 'company',
+  );
+
+  jestExpectToBeDefined(companyObjectMetadata);
+
+  const accountOwnerFieldMetadata = companyObjectMetadata.fieldsList?.find(
+    (field) => field.name === 'accountOwner',
+  );
+
+  jestExpectToBeDefined(accountOwnerFieldMetadata);
+
+  await updateWorkspaceMemberRole({
+    input: {
+      roleId: customRoleId,
+      workspaceMemberId: WORKSPACE_MEMBER_DATA_SEED_IDS.JONY,
+    },
+    expectToFail: false,
+  });
+
+  return {
+    customRoleId,
+    originalMemberRoleId: memberRole.id,
+    companyObjectMetadataId: companyObjectMetadata.id,
+    accountOwnerFieldMetadataId: accountOwnerFieldMetadata.id,
+  };
+};
+
+export const upsertAccountOwnerRlsPredicate = async ({
+  setup,
+  predicateId,
+  value,
+  expectToFail = false,
+}: {
+  setup: AccountOwnerRlsRoleSetup;
+  predicateId: string;
+  value: RowLevelPermissionPredicateValue;
+  expectToFail?: boolean;
+}) =>
+  upsertRowLevelPermissionPredicates({
+    expectToFail,
+    input: {
+      roleId: setup.customRoleId,
+      objectMetadataId: setup.companyObjectMetadataId,
+      predicates: [
+        {
+          id: predicateId,
+          fieldMetadataId: setup.accountOwnerFieldMetadataId,
+          operand: RowLevelPermissionPredicateOperand.IS,
+          value,
+        },
+      ],
+      predicateGroups: [],
+    },
+  });
+
+export const cleanupAccountOwnerRlsRole = async (
+  setup: Partial<AccountOwnerRlsRoleSetup> = {},
+): Promise<void> => {
+  if (isDefined(setup.originalMemberRoleId)) {
+    await updateWorkspaceMemberRole({
+      input: {
+        workspaceMemberId: WORKSPACE_MEMBER_DATA_SEED_IDS.JONY,
+        roleId: setup.originalMemberRoleId,
+      },
+      expectToFail: false,
+    });
+  }
+
+  if (isDefined(setup.customRoleId)) {
+    await deleteOneRole({
+      expectToFail: false,
+      input: { idToDelete: setup.customRoleId },
+    });
+  }
+};

--- a/packages/twenty-shared/src/utils/filter/utils/__tests__/getFilterValueSchema.test.ts
+++ b/packages/twenty-shared/src/utils/filter/utils/__tests__/getFilterValueSchema.test.ts
@@ -194,6 +194,27 @@ describe('getFilterValueSchema', () => {
         ISSUE_23397_VALUE,
       );
     });
+
+    it.each([
+      '{"selectedRecordIds":[]}',
+      '[]',
+      '{"selectedRecordIds":[],"isCurrentWorkspaceMemberSelected":false}',
+    ])('should reject %s, an empty selection', (value) => {
+      expectRejected(
+        { filterType: 'RELATION', operand: ViewFilterOperand.IS },
+        value,
+      );
+    });
+
+    it.each([
+      '{"selectedRecordIds":[],"isCurrentWorkspaceMemberSelected":true}',
+      '{"selectedRecordIds":[],"isCurrentRecordSelected":true}',
+    ])('should accept %s, resolved at read time', (value) => {
+      expectAccepted(
+        { filterType: 'RELATION', operand: ViewFilterOperand.IS },
+        value,
+      );
+    });
   });
 
   describe('uuid', () => {

--- a/packages/twenty-shared/src/utils/filter/utils/validation-schemas/filterValueSchemasMap.ts
+++ b/packages/twenty-shared/src/utils/filter/utils/validation-schemas/filterValueSchemasMap.ts
@@ -32,13 +32,31 @@ type FilterValueSchemasMap = {
     Partial<Record<ViewFilterOperand, z.ZodType>>;
 };
 
+// The reader drops a relation filter resolving to no record id, which turns a
+// row level permission rule into no restriction at all rather than no match.
 const relationFilterValueSchema = jsonRelationFilterValueSchema
   .refine(
     ({ selectedRecordIds }) =>
       strictArrayOfUuidOrVariableSchema.safeParse(selectedRecordIds).success,
     'Expected selectedRecordIds to contain UUIDs or variables',
   )
-  .or(strictArrayOfUuidOrVariableSchema);
+  .refine(
+    ({
+      selectedRecordIds,
+      isCurrentWorkspaceMemberSelected,
+      isCurrentRecordSelected,
+    }) =>
+      selectedRecordIds.length > 0 ||
+      isCurrentWorkspaceMemberSelected === true ||
+      isCurrentRecordSelected === true,
+    'Expected at least one selected record',
+  )
+  .or(
+    strictArrayOfUuidOrVariableSchema.refine(
+      (recordIds) => recordIds.length > 0,
+      'Expected at least one selected record',
+    ),
+  );
 
 // Mirrors normalizeSelectFilterValues: a value that is not JSON is a legacy scalar option.
 const selectFilterValueSchema = nonEmptyStringFilterValueSchema.refine(


### PR DESCRIPTION
## What this does

Fixes #23998.

A row level permission predicate whose stored value cannot be parsed is currently dropped rather than rejected. If it is the only predicate for that role and object, the row restriction disappears and the query runs unfiltered. This adds the same write-time value check view filters got in #23848.

## Why it fails open today

`build-row-level-permission-record-filter.util.ts` compiles predicates through `computeRecordGqlOperationFilter`. For a `RELATION` predicate the reader tolerates a bad value: `jsonRelationFilterValueSchema` catches into `arrayOfUuidOrVariableSchema`, which ends in `.catch([])`, so the id list comes back empty and the reader returns early. From there:

1. `computeRecordGqlOperationFilter` returns `{}`
2. `resolveRowLevelPermissionRecordFilter` maps the empty filter to `null`
3. `workspace-select-query-builder.ts` sees `null`, calls `markRowLevelPermissionPredicateApplied` and continues, adding no SQL condition

`RowLevelPermissionPredicateManifest.value` is typed loosely, so this is reachable from a hand written role manifest. It is not reachable from the UI, which builds predicate values through pickers.

## Changes

`FlatRowLevelPermissionPredicateValidatorService` now calls `getFilterValueValidationIssue` from twenty-shared, the same helper the view filter validator uses, and maps the result onto its own exception code. No new contract, no duplicated schema logic.

- on creation
- on updates touching `value`, `operand`, `fieldMetadataUniversalIdentifier`, `subFieldName` or `workspaceMemberFieldMetadataUniversalIdentifier`

That last key matters: clearing it activates a previously unused stored value, so the update has to revalidate.

## Deliberately skipped

Predicates with `workspaceMemberFieldMetadataUniversalIdentifier` set resolve their value from the current workspace member at query time and ignore the stored value, so validating it would reject valid configurations.

## Testing

6 unit tests: creation rejects a relation value resolving to no record id and the object form of a relative date, accepts a valid value, skips workspace-member-resolved predicates; update revalidates when workspace member resolution is cleared and stays quiet when the value is not part of the update. 43 validator tests pass.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/23999?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

