### PR TITLE
fix(upgrade): skip 2.20 campaign view columns whose field does not exist yet

### DIFF
--- a/packages/twenty-server/src/database/commands/upgrade-version-command/2-20/2-20-workspace-command-1783525261000-add-message-campaign-stat-fields.command.ts
+++ b/packages/twenty-server/src/database/commands/upgrade-version-command/2-20/2-20-workspace-command-1783525261000-add-message-campaign-stat-fields.command.ts
@@ -30,6 +30,9 @@ const STAT_FIELD_UNIVERSAL_IDENTIFIERS = [
 // The allMessageCampaigns view is introduced by this feature, so existing
 // workspaces have no messageCampaign view at all. Create the view and every one
 // of its columns (not just the stat columns) so it materializes end to end.
+// The column list is read from the standard application of the running build,
+// which keeps growing after 2.20, so columns whose field is only introduced by a
+// later command are left out here and backfilled by that later command.
 const CAMPAIGN_VIEW_UNIVERSAL_IDENTIFIER =
   CAMPAIGN.views.allMessageCampaigns.universalIdentifier;
 
@@ -123,25 +126,40 @@ export class AddMessageCampaignStatFieldsCommand extends ProvisionedWorkspaceCom
       standardAllFlatEntityMaps,
     });
 
+    const availableFieldUniversalIdentifiers = new Set([
+      ...Object.keys(flatFieldMetadataMaps.byUniversalIdentifier),
+      ...fieldsToCreate.map(({ universalIdentifier }) => universalIdentifier),
+    ]);
+
     const viewFieldsToCreate = CAMPAIGN_VIEW_FIELD_UNIVERSAL_IDENTIFIERS.filter(
       (universalIdentifier) =>
         !isDefined(flatViewFieldMaps.byUniversalIdentifier[universalIdentifier]),
-    ).map((universalIdentifier) => {
-      const standardViewField = findFlatEntityByUniversalIdentifier<FlatViewField>(
-        {
-          flatEntityMaps: standardAllFlatEntityMaps.flatViewFieldMaps,
-          universalIdentifier,
-        },
-      );
+    )
+      .map((universalIdentifier) => {
+        const standardViewField =
+          findFlatEntityByUniversalIdentifier<FlatViewField>({
+            flatEntityMaps: standardAllFlatEntityMaps.flatViewFieldMaps,
+            universalIdentifier,
+          });
 
-      if (!isDefined(standardViewField)) {
-        throw new Error(
-          `Standard application is missing messageCampaign view column ${universalIdentifier}`,
+        if (!isDefined(standardViewField)) {
+          throw new Error(
+            `Standard application is missing messageCampaign view column ${universalIdentifier}`,
+          );
+        }
+
+        return standardViewField;
+      })
+      .filter((standardViewField) => {
+        const fieldUniversalIdentifier =
+          standardAllFlatEntityMaps.flatFieldMetadataMaps
+            .universalIdentifierById[standardViewField.fieldMetadataId];
+
+        return (
+          isDefined(fieldUniversalIdentifier) &&
+          availableFieldUniversalIdentifiers.has(fieldUniversalIdentifier)
         );
-      }
-
-      return standardViewField;
-    });
+      });
 
     const hasMetadataChanges =
       fieldsToCreate.length > 0 ||

--- a/packages/twenty-server/src/database/commands/upgrade-version-command/2-20/2-20-workspace-command-1783525261000-add-message-campaign-stat-fields.command.ts
+++ b/packages/twenty-server/src/database/commands/upgrade-version-command/2-20/2-20-workspace-command-1783525261000-add-message-campaign-stat-fields.command.ts
@@ -28,11 +28,8 @@ const STAT_FIELD_UNIVERSAL_IDENTIFIERS = [
 ];
 
 // The allMessageCampaigns view is introduced by this feature, so existing
-// workspaces have no messageCampaign view at all. Create the view and every one
-// of its columns (not just the stat columns) so it materializes end to end.
-// The column list is read from the standard application of the running build,
-// which keeps growing after 2.20, so columns whose field is only introduced by a
-// later command are left out here and backfilled by that later command.
+// workspaces have no messageCampaign view at all. Create the view and its
+// columns (not just the stat columns) so it materializes end to end.
 const CAMPAIGN_VIEW_UNIVERSAL_IDENTIFIER =
   CAMPAIGN.views.allMessageCampaigns.universalIdentifier;
 
@@ -126,40 +123,44 @@ export class AddMessageCampaignStatFieldsCommand extends ProvisionedWorkspaceCom
       standardAllFlatEntityMaps,
     });
 
-    const availableFieldUniversalIdentifiers = new Set([
-      ...Object.keys(flatFieldMetadataMaps.byUniversalIdentifier),
-      ...fieldsToCreate.map(({ universalIdentifier }) => universalIdentifier),
-    ]);
-
     const viewFieldsToCreate = CAMPAIGN_VIEW_FIELD_UNIVERSAL_IDENTIFIERS.filter(
       (universalIdentifier) =>
         !isDefined(flatViewFieldMaps.byUniversalIdentifier[universalIdentifier]),
-    )
-      .map((universalIdentifier) => {
-        const standardViewField =
-          findFlatEntityByUniversalIdentifier<FlatViewField>({
-            flatEntityMaps: standardAllFlatEntityMaps.flatViewFieldMaps,
-            universalIdentifier,
-          });
+    ).flatMap((universalIdentifier) => {
+      const standardViewField =
+        findFlatEntityByUniversalIdentifier<FlatViewField>({
+          flatEntityMaps: standardAllFlatEntityMaps.flatViewFieldMaps,
+          universalIdentifier,
+        });
 
-        if (!isDefined(standardViewField)) {
-          throw new Error(
-            `Standard application is missing messageCampaign view column ${universalIdentifier}`,
-          );
-        }
-
-        return standardViewField;
-      })
-      .filter((standardViewField) => {
-        const fieldUniversalIdentifier =
-          standardAllFlatEntityMaps.flatFieldMetadataMaps
-            .universalIdentifierById[standardViewField.fieldMetadataId];
-
-        return (
-          isDefined(fieldUniversalIdentifier) &&
-          availableFieldUniversalIdentifiers.has(fieldUniversalIdentifier)
+      if (!isDefined(standardViewField)) {
+        throw new Error(
+          `Standard application is missing messageCampaign view column ${universalIdentifier}`,
         );
-      });
+      }
+
+      const fieldUniversalIdentifier =
+        standardAllFlatEntityMaps.flatFieldMetadataMaps.universalIdentifierById[
+          standardViewField.fieldMetadataId
+        ];
+
+      if (!isDefined(fieldUniversalIdentifier)) {
+        return [];
+      }
+
+      // The standard column list keeps growing after 2.20, so skip columns whose
+      // field a later command introduces and backfills.
+      const isFieldAvailable =
+        isDefined(
+          flatFieldMetadataMaps.byUniversalIdentifier[fieldUniversalIdentifier],
+        ) ||
+        fieldsToCreate.some(
+          (fieldToCreate) =>
+            fieldToCreate.universalIdentifier === fieldUniversalIdentifier,
+        );
+
+      return isFieldAvailable ? [standardViewField] : [];
+    });
 
     const hasMetadataChanges =
       fieldsToCreate.length > 0 ||

--- a/packages/twenty-server/src/database/commands/upgrade-version-command/2-20/__tests__/2-20-workspace-command-1783525261000-add-message-campaign-stat-fields.command.spec.ts
+++ b/packages/twenty-server/src/database/commands/upgrade-version-command/2-20/__tests__/2-20-workspace-command-1783525261000-add-message-campaign-stat-fields.command.spec.ts
@@ -29,9 +29,46 @@ const STAT_FIELD_UNIVERSAL_IDENTIFIERS = [
 ];
 const CAMPAIGN_VIEW_UNIVERSAL_IDENTIFIER =
   CAMPAIGN.views.allMessageCampaigns.universalIdentifier;
-const CAMPAIGN_VIEW_FIELD_UNIVERSAL_IDENTIFIERS = Object.values(
+
+const CAMPAIGN_FIELD_UNIVERSAL_IDENTIFIER_BY_NAME: Record<string, string> =
+  Object.fromEntries(
+    Object.entries(CAMPAIGN.fields).map(
+      ([fieldName, { universalIdentifier }]) => [fieldName, universalIdentifier],
+    ),
+  );
+
+// The command reads the view columns from the standard application of the
+// running build, and resolves each column's field through fieldMetadataId, so
+// the mocks mirror that indirection. Field ids double as their universal
+// identifier here.
+const CAMPAIGN_VIEW_FIELDS = Object.entries(
   CAMPAIGN.views.allMessageCampaigns.viewFields,
-).map((viewField) => viewField.universalIdentifier);
+).map(([fieldName, { universalIdentifier }]) => ({
+  universalIdentifier,
+  fieldUniversalIdentifier: CAMPAIGN_FIELD_UNIVERSAL_IDENTIFIER_BY_NAME[
+    fieldName
+  ],
+}));
+
+const CAMPAIGN_VIEW_FIELD_UNIVERSAL_IDENTIFIERS = CAMPAIGN_VIEW_FIELDS.map(
+  ({ universalIdentifier }) => universalIdentifier,
+);
+
+const NAME_FIELD_UNIVERSAL_IDENTIFIER = CAMPAIGN.fields.name.universalIdentifier;
+const NAME_VIEW_FIELD_UNIVERSAL_IDENTIFIER =
+  CAMPAIGN.views.allMessageCampaigns.viewFields.name.universalIdentifier;
+
+// Everything the allMessageCampaigns view references that a 2.19 workspace
+// already has: neither the stat fields (added by this command) nor name (added
+// by the 2.25 command).
+const PRE_EXISTING_CAMPAIGN_FIELD_UNIVERSAL_IDENTIFIERS =
+  CAMPAIGN_VIEW_FIELDS.map(
+    ({ fieldUniversalIdentifier }) => fieldUniversalIdentifier,
+  ).filter(
+    (universalIdentifier) =>
+      universalIdentifier !== NAME_FIELD_UNIVERSAL_IDENTIFIER &&
+      !STAT_FIELD_UNIVERSAL_IDENTIFIERS.includes(universalIdentifier),
+  );
 
 const buildByUniversalIdentifierMap = (universalIdentifiers: string[]) => ({
   byUniversalIdentifier: Object.fromEntries(
@@ -39,6 +76,27 @@ const buildByUniversalIdentifierMap = (universalIdentifiers: string[]) => ({
       universalIdentifier,
       { universalIdentifier },
     ]),
+  ),
+});
+
+const buildStandardFieldMetadataMaps = (universalIdentifiers: string[]) => ({
+  ...buildByUniversalIdentifierMap(universalIdentifiers),
+  universalIdentifierById: Object.fromEntries(
+    universalIdentifiers.map((universalIdentifier) => [
+      universalIdentifier,
+      universalIdentifier,
+    ]),
+  ),
+});
+
+const buildStandardViewFieldMaps = () => ({
+  byUniversalIdentifier: Object.fromEntries(
+    CAMPAIGN_VIEW_FIELDS.map(
+      ({ universalIdentifier, fieldUniversalIdentifier }) => [
+        universalIdentifier,
+        { universalIdentifier, fieldMetadataId: fieldUniversalIdentifier },
+      ],
+    ),
   ),
 });
 
@@ -61,15 +119,15 @@ describe('AddMessageCampaignStatFieldsCommand', () => {
 
     computeTwentyStandardApplicationAllFlatEntityMapsMock.mockReturnValue({
       allFlatEntityMaps: {
-        flatFieldMetadataMaps: buildByUniversalIdentifierMap(
-          STAT_FIELD_UNIVERSAL_IDENTIFIERS,
+        flatFieldMetadataMaps: buildStandardFieldMetadataMaps(
+          CAMPAIGN_VIEW_FIELDS.map(
+            ({ fieldUniversalIdentifier }) => fieldUniversalIdentifier,
+          ),
         ),
         flatViewMaps: buildByUniversalIdentifierMap([
           CAMPAIGN_VIEW_UNIVERSAL_IDENTIFIER,
         ]),
-        flatViewFieldMaps: buildByUniversalIdentifierMap(
-          CAMPAIGN_VIEW_FIELD_UNIVERSAL_IDENTIFIERS,
-        ),
+        flatViewFieldMaps: buildStandardViewFieldMaps(),
       },
     });
 
@@ -116,8 +174,13 @@ describe('AddMessageCampaignStatFieldsCommand', () => {
     });
   };
 
-  it('creates missing stat fields, the campaign view, and all campaign view fields', async () => {
-    mockWorkspaceCache({});
+  it('creates missing stat fields, the campaign view, and every campaign view field whose field is available', async () => {
+    mockWorkspaceCache({
+      existingFields: [
+        ...PRE_EXISTING_CAMPAIGN_FIELD_UNIVERSAL_IDENTIFIERS,
+        NAME_FIELD_UNIVERSAL_IDENTIFIER,
+      ],
+    });
 
     await runOnWorkspace();
 
@@ -166,9 +229,34 @@ describe('AddMessageCampaignStatFieldsCommand', () => {
     ).toHaveLength(CAMPAIGN_VIEW_FIELD_UNIVERSAL_IDENTIFIERS.length);
   });
 
+  it('leaves out view columns whose field does not exist in the workspace yet', async () => {
+    mockWorkspaceCache({
+      existingFields: PRE_EXISTING_CAMPAIGN_FIELD_UNIVERSAL_IDENTIFIERS,
+    });
+
+    await runOnWorkspace();
+
+    const payload =
+      validateBuildAndRunWorkspaceMigrationMock.mock.calls[0][0]
+        .allFlatEntityOperationByMetadataName;
+
+    expect(payload.viewField.flatEntityToCreate).not.toContainEqual(
+      expect.objectContaining({
+        universalIdentifier: NAME_VIEW_FIELD_UNIVERSAL_IDENTIFIER,
+      }),
+    );
+    expect(payload.viewField.flatEntityToCreate).toHaveLength(
+      CAMPAIGN_VIEW_FIELD_UNIVERSAL_IDENTIFIERS.length - 1,
+    );
+  });
+
   it('creates only missing pieces when rerun against a partially migrated workspace', async () => {
     mockWorkspaceCache({
-      existingFields: [CAMPAIGN.fields.sentCount.universalIdentifier],
+      existingFields: [
+        ...PRE_EXISTING_CAMPAIGN_FIELD_UNIVERSAL_IDENTIFIERS,
+        NAME_FIELD_UNIVERSAL_IDENTIFIER,
+        CAMPAIGN.fields.sentCount.universalIdentifier,
+      ],
       existingViews: [CAMPAIGN_VIEW_UNIVERSAL_IDENTIFIER],
       existingViewFields: [
         CAMPAIGN.views.allMessageCampaigns.viewFields.subject


### PR DESCRIPTION
Fixes #23982.

The 2.20 command builds the `allMessageCampaigns` view with every column listed in the standard application of the *running* build. That list now includes `name`, a field only introduced by the 2.25 command, so a 2.19 workspace upgrading on 2.26 dies at 2.20 with `Field metadata not found` and the cursor never moves.

It now only creates columns whose field already exists or is created in the same run. The 2.25 command backfills `name` and its column as before.

Fixing 2.20 in place is the only option, since the sequence aborts there and never reaches a later repair step, hence the `ci:allow-previous-version-upgrade-mutation` label.