### PR TITLE
Disable jest coverage locally and cap twenty-server test workers

### DIFF
--- a/nx.json
+++ b/nx.json
@@ -112,16 +112,17 @@
       "options": {
         "jestConfig": "{projectRoot}/jest.config.mjs",
         "silent": true,
-        "coverage": true,
         "coverageReporters": ["text-summary"],
         "cacheDirectory": "../../.cache/jest/{projectRoot}"
       },
       "configurations": {
         "ci": {
           "ci": true,
-          "maxWorkers": 1
+          "maxWorkers": 1,
+          "coverage": true
         },
         "coverage": {
+          "coverage": true,
           "coverageReporters": ["lcov", "text"]
         },
         "watch": {

--- a/packages/twenty-server/project.json
+++ b/packages/twenty-server/project.json
@@ -198,7 +198,11 @@
         }
       }
     },
-    "test": {},
+    "test": {
+      "options": {
+        "maxWorkers": "50%"
+      }
+    },
     "test:debug": {
       "executor": "nx:run-commands",
       "options": {


### PR DESCRIPTION
Running `nx test twenty-server` locally could OOM-kill a 16GB machine.

Each jest worker is a separate process with its own memory, so total usage is roughly workers x heaviest suites (spikes of ~1.5GB each). Jest defaults to cpus-1 workers (9 on a 10-core machine), which can stack past physical RAM. On top of that, coverage instrumented all ~6k untested source files after every local run.

- twenty-server tests now cap at `maxWorkers: 50%`
- Coverage only runs under the `ci` and `coverage` configurations

Measured locally: full suite peaks at 2.9GB. CI is unaffected (`test:ci` is a standalone target that never ran coverage).