### PR TITLE
chore: set npm packages to 2.31.0-alpha.1

### DIFF
--- a/packages/create-twenty-app/package.json
+++ b/packages/create-twenty-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-twenty-app",
-  "version": "2.31.0",
+  "version": "2.31.0-alpha.1",
   "description": "Command-line interface to create Twenty application",
   "main": "dist/cli.cjs",
   "bin": "dist/cli.cjs",

--- a/packages/twenty-client-sdk/package.json
+++ b/packages/twenty-client-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "twenty-client-sdk",
-  "version": "2.31.0",
+  "version": "2.31.0-alpha.1",
   "sideEffects": false,
   "license": "MIT",
   "scripts": {

--- a/packages/twenty-sdk/package.json
+++ b/packages/twenty-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "twenty-sdk",
-  "version": "2.31.0",
+  "version": "2.31.0-alpha.1",
   "sideEffects": false,
   "bin": {
     "twenty": "dist/cli.cjs"


### PR DESCRIPTION
Sets the published npm packages to an alpha prerelease of the current version.

- `create-twenty-app`: 2.31.0 -> 2.31.0-alpha.1
- `twenty-sdk`: 2.31.0 -> 2.31.0-alpha.1
- `twenty-client-sdk`: 2.31.0 -> 2.31.0-alpha.1

Internal cross-references use `workspace:*` so nothing else needed updating. Generated apps pin `twenty-sdk` / `twenty-client-sdk` to `create-twenty-app`'s own version (`app-template.ts`), so scaffolded apps will pick up the alpha automatically.

The server's `TWENTY_CURRENT_VERSION` (2.31.0) is a separate versioning track and is untouched.