### PR TITLE
Fix record-page reconcile self-collision on user-added FIELDS widgets

### DIFF
--- a/packages/twenty-server/src/database/commands/upgrade-version-command/2-31/utils/__tests__/compute-record-page-stack-reown-updates.util.spec.ts
+++ b/packages/twenty-server/src/database/commands/upgrade-version-command/2-31/utils/__tests__/compute-record-page-stack-reown-updates.util.spec.ts
@@ -392,8 +392,10 @@ describe('computeRecordPageStackReownUpdates', () => {
   });
 
   // Pre-2-15 custom rows are stuck at isSystemSideEffect false, so the engine
-  // view and a user-added view are indistinguishable: refuse selection.
-  it('warns and re-owns no view when a custom object has several unflagged FIELDS widget views', () => {
+  // view and a user-added view are indistinguishable: refuse selection and
+  // skip the whole stack, otherwise a re-owned layout would keep a FIELDS
+  // widget pointing at an un-reowned view the backfill never repairs.
+  it('warns and re-owns nothing when a custom object has several unflagged FIELDS widget views', () => {
     const customObjectMetadata = {
       universalIdentifier: '20202020-0000-4000-8000-0000000000cd',
       applicationUniversalIdentifier: CUSTOM_APPLICATION_UNIVERSAL_IDENTIFIER,
@@ -426,8 +428,7 @@ describe('computeRecordPageStackReownUpdates', () => {
     expect(warnMock).toHaveBeenCalledWith(
       expect.stringContaining('Ambiguous FIELDS widget views'),
     );
-    expect(reownUpdates.viewUpdates).toHaveLength(0);
-    expect(reownUpdates.viewFieldUpdates).toHaveLength(0);
+    expect(countRecordPageReownUpdates(reownUpdates)).toBe(0);
   });
 
   it('skips the second standard group claiming the same name with a warning', () => {

--- a/packages/twenty-server/src/database/commands/upgrade-version-command/2-31/utils/__tests__/compute-record-page-stack-reown-updates.util.spec.ts
+++ b/packages/twenty-server/src/database/commands/upgrade-version-command/2-31/utils/__tests__/compute-record-page-stack-reown-updates.util.spec.ts
@@ -57,6 +57,7 @@ describe('computeRecordPageStackReownUpdates', () => {
     engineOwnedApplicationUniversalIdentifiers = new Set([
       STANDARD_APPLICATION_UNIVERSAL_IDENTIFIER,
     ]),
+    objectMetadata = OBJECT_METADATA,
   }: {
     stack: ReturnType<typeof buildStack>;
     extraTabs?: Record<string, unknown>[];
@@ -65,6 +66,7 @@ describe('computeRecordPageStackReownUpdates', () => {
     fieldMetadatas?: Record<string, unknown>[];
     pageLayoutOverride?: Record<string, unknown>;
     engineOwnedApplicationUniversalIdentifiers?: Set<string>;
+    objectMetadata?: typeof OBJECT_METADATA;
   }) => {
     const flatPageLayout = {
       ...stack.pageLayout,
@@ -74,10 +76,14 @@ describe('computeRecordPageStackReownUpdates', () => {
     return computeRecordPageStackReownUpdates({
       workspaceId: WORKSPACE_ID,
       logger: { warn: warnMock },
-      flatObjectMetadata: OBJECT_METADATA,
+      flatObjectMetadata: objectMetadata,
       flatPageLayout,
       derivedPageLayoutUniversalIdentifier:
-        DERIVED_PAGE_LAYOUT_UNIVERSAL_IDENTIFIER,
+        getSystemRecordPageLayoutUniversalIdentifier({
+          objectMetadataApplicationUniversalIdentifier:
+            objectMetadata.applicationUniversalIdentifier,
+          objectUniversalIdentifier: objectMetadata.universalIdentifier,
+        }),
       engineOwnedApplicationUniversalIdentifiers,
       twentyStandardApplicationUniversalIdentifier:
         STANDARD_APPLICATION_UNIVERSAL_IDENTIFIER,
@@ -348,6 +354,80 @@ describe('computeRecordPageStackReownUpdates', () => {
 
     expect(reownUpdates.viewUpdates).toHaveLength(1);
     expect(reownUpdates.viewUpdates[0].id).toBe(stack.view.id);
+  });
+
+  // Custom objects have no pre-2.31 literal and their engine widget is not
+  // twenty-standard-owned: selection must not fall back to walk order.
+  it('selects the flagged engine view of a custom object even when a user-added FIELDS widget comes first', () => {
+    const customObjectMetadata = {
+      universalIdentifier: '20202020-0000-4000-8000-0000000000cd',
+      applicationUniversalIdentifier: CUSTOM_APPLICATION_UNIVERSAL_IDENTIFIER,
+    };
+    const stack = buildUnderivedRecordPageStack({
+      idPrefix: 'custom-stack',
+      objectUniversalIdentifier: customObjectMetadata.universalIdentifier,
+      applicationUniversalIdentifier: CUSTOM_APPLICATION_UNIVERSAL_IDENTIFIER,
+    });
+    const { userFieldsView, userFieldsWidget } =
+      buildUserAddedFieldsWidgetAndView();
+
+    stack.homeTab.widgetUniversalIdentifiers = [
+      userFieldsWidget.universalIdentifier,
+      ...stack.homeTab.widgetUniversalIdentifiers,
+    ];
+
+    const reownUpdates = runCompute({
+      stack,
+      objectMetadata: customObjectMetadata,
+      extraWidgets: [userFieldsWidget],
+      extraViews: [userFieldsView],
+      engineOwnedApplicationUniversalIdentifiers: new Set([
+        STANDARD_APPLICATION_UNIVERSAL_IDENTIFIER,
+        CUSTOM_APPLICATION_UNIVERSAL_IDENTIFIER,
+      ]),
+    });
+
+    expect(reownUpdates.viewUpdates).toHaveLength(1);
+    expect(reownUpdates.viewUpdates[0].id).toBe(stack.view.id);
+  });
+
+  // Pre-2-15 custom rows are stuck at isSystemSideEffect false, so the engine
+  // view and a user-added view are indistinguishable: refuse selection.
+  it('warns and re-owns no view when a custom object has several unflagged FIELDS widget views', () => {
+    const customObjectMetadata = {
+      universalIdentifier: '20202020-0000-4000-8000-0000000000cd',
+      applicationUniversalIdentifier: CUSTOM_APPLICATION_UNIVERSAL_IDENTIFIER,
+    };
+    const stack = buildUnderivedRecordPageStack({
+      idPrefix: 'custom-stack',
+      objectUniversalIdentifier: customObjectMetadata.universalIdentifier,
+      applicationUniversalIdentifier: CUSTOM_APPLICATION_UNIVERSAL_IDENTIFIER,
+      isSystemSideEffect: false,
+    });
+    const { userFieldsView, userFieldsWidget } =
+      buildUserAddedFieldsWidgetAndView();
+
+    stack.homeTab.widgetUniversalIdentifiers = [
+      userFieldsWidget.universalIdentifier,
+      ...stack.homeTab.widgetUniversalIdentifiers,
+    ];
+
+    const reownUpdates = runCompute({
+      stack,
+      objectMetadata: customObjectMetadata,
+      extraWidgets: [userFieldsWidget],
+      extraViews: [userFieldsView],
+      engineOwnedApplicationUniversalIdentifiers: new Set([
+        STANDARD_APPLICATION_UNIVERSAL_IDENTIFIER,
+        CUSTOM_APPLICATION_UNIVERSAL_IDENTIFIER,
+      ]),
+    });
+
+    expect(warnMock).toHaveBeenCalledWith(
+      expect.stringContaining('Ambiguous FIELDS widget views'),
+    );
+    expect(reownUpdates.viewUpdates).toHaveLength(0);
+    expect(reownUpdates.viewFieldUpdates).toHaveLength(0);
   });
 
   it('skips the second standard group claiming the same name with a warning', () => {

--- a/packages/twenty-server/src/database/commands/upgrade-version-command/2-31/utils/__tests__/compute-record-page-stack-reown-updates.util.spec.ts
+++ b/packages/twenty-server/src/database/commands/upgrade-version-command/2-31/utils/__tests__/compute-record-page-stack-reown-updates.util.spec.ts
@@ -173,7 +173,10 @@ describe('computeRecordPageStackReownUpdates', () => {
     );
   });
 
-  it('warns on a dangling FIELDS widget view and skips the view branch', () => {
+  // A stack without a resolvable system view must not be re-owned at all:
+  // a derived layout whose FIELDS widget dangles would never be repaired by
+  // the backfill, which does not touch widgets of an existing layout.
+  it('warns and re-owns nothing when the only FIELDS widget view is dangling', () => {
     const stack = buildStack();
 
     stack.fieldsWidget.configuration.viewId = 'unknown-view-db-id';
@@ -181,12 +184,9 @@ describe('computeRecordPageStackReownUpdates', () => {
     const reownUpdates = runCompute({ stack });
 
     expect(warnMock).toHaveBeenCalledWith(
-      expect.stringContaining('Dangling FIELDS widget view unknown-view-db-id'),
+      expect.stringContaining('No resolvable system FIELDS widget view'),
     );
-    expect(reownUpdates.viewUpdates).toHaveLength(0);
-    expect(reownUpdates.viewFieldUpdates).toHaveLength(0);
-    // The widget itself is still re-owned.
-    expect(reownUpdates.pageLayoutWidgetUpdates).toHaveLength(1);
+    expect(countRecordPageReownUpdates(reownUpdates)).toBe(0);
   });
 
   it('warns and skips a view field whose displayed field is missing', () => {

--- a/packages/twenty-server/src/database/commands/upgrade-version-command/2-31/utils/__tests__/compute-record-page-stack-reown-updates.util.spec.ts
+++ b/packages/twenty-server/src/database/commands/upgrade-version-command/2-31/utils/__tests__/compute-record-page-stack-reown-updates.util.spec.ts
@@ -10,6 +10,7 @@ import {
 } from 'src/database/commands/upgrade-version-command/2-31/__tests__/record-page-reconcile-test-setup';
 import { computeRecordPageStackReownUpdates } from 'src/database/commands/upgrade-version-command/2-31/utils/compute-record-page-stack-reown-updates.util';
 import { countRecordPageReownUpdates } from 'src/database/commands/upgrade-version-command/2-31/utils/count-record-page-reown-updates.util';
+import { WidgetConfigurationType } from 'src/engine/metadata-modules/page-layout-widget/enums/widget-configuration-type.type';
 
 const OBJECT_UNIVERSAL_IDENTIFIER = '20202020-0000-4000-8000-0000000000bb';
 
@@ -53,6 +54,9 @@ describe('computeRecordPageStackReownUpdates', () => {
     extraViews = [] as Record<string, unknown>[],
     fieldMetadatas = [FIELD_METADATA],
     pageLayoutOverride = {} as Record<string, unknown>,
+    engineOwnedApplicationUniversalIdentifiers = new Set([
+      STANDARD_APPLICATION_UNIVERSAL_IDENTIFIER,
+    ]),
   }: {
     stack: ReturnType<typeof buildStack>;
     extraTabs?: Record<string, unknown>[];
@@ -60,6 +64,7 @@ describe('computeRecordPageStackReownUpdates', () => {
     extraViews?: Record<string, unknown>[];
     fieldMetadatas?: Record<string, unknown>[];
     pageLayoutOverride?: Record<string, unknown>;
+    engineOwnedApplicationUniversalIdentifiers?: Set<string>;
   }) => {
     const flatPageLayout = {
       ...stack.pageLayout,
@@ -73,9 +78,7 @@ describe('computeRecordPageStackReownUpdates', () => {
       flatPageLayout,
       derivedPageLayoutUniversalIdentifier:
         DERIVED_PAGE_LAYOUT_UNIVERSAL_IDENTIFIER,
-      engineOwnedApplicationUniversalIdentifiers: new Set([
-        STANDARD_APPLICATION_UNIVERSAL_IDENTIFIER,
-      ]),
+      engineOwnedApplicationUniversalIdentifiers,
       twentyStandardApplicationUniversalIdentifier:
         STANDARD_APPLICATION_UNIVERSAL_IDENTIFIER,
       flatViewMaps: buildByUniversalIdentifierMap([
@@ -265,6 +268,86 @@ describe('computeRecordPageStackReownUpdates', () => {
       ),
     );
     expect(collidingReownUpdates.pageLayoutUpdates).toHaveLength(0);
+  });
+
+  const buildUserAddedFieldsWidgetAndView = () => {
+    const userFieldsView = {
+      id: 'user-view-db-id',
+      universalIdentifier: 'user-view-universal-identifier',
+      key: null,
+      isSystemSideEffect: false,
+      deletedAt: null,
+      objectMetadataUniversalIdentifier: OBJECT_UNIVERSAL_IDENTIFIER,
+      applicationUniversalIdentifier: CUSTOM_APPLICATION_UNIVERSAL_IDENTIFIER,
+      viewFieldUniversalIdentifiers: [],
+      viewFieldGroupUniversalIdentifiers: [],
+    };
+
+    const userFieldsWidget = {
+      id: 'user-widget-db-id',
+      universalIdentifier: 'user-widget-universal-identifier',
+      title: 'My fields',
+      isSystemSideEffect: false,
+      deletedAt: null,
+      applicationUniversalIdentifier: CUSTOM_APPLICATION_UNIVERSAL_IDENTIFIER,
+      configuration: {
+        configurationType: WidgetConfigurationType.FIELDS,
+        viewId: userFieldsView.id,
+        newFieldDefaultVisibility: true,
+      },
+    };
+
+    return { userFieldsView, userFieldsWidget };
+  };
+
+  // A user-added FIELDS widget carries its own view: both views derive the
+  // same object-based identifier, so re-owning both would self-collide on the
+  // unique index at apply time.
+  it('re-owns only the system view when a user-added FIELDS widget carries its own view', () => {
+    const stack = buildStack();
+    const { userFieldsView, userFieldsWidget } =
+      buildUserAddedFieldsWidgetAndView();
+
+    stack.homeTab.widgetUniversalIdentifiers.push(
+      userFieldsWidget.universalIdentifier,
+    );
+
+    const reownUpdates = runCompute({
+      stack,
+      extraWidgets: [userFieldsWidget],
+      extraViews: [userFieldsView],
+      engineOwnedApplicationUniversalIdentifiers: new Set([
+        STANDARD_APPLICATION_UNIVERSAL_IDENTIFIER,
+        CUSTOM_APPLICATION_UNIVERSAL_IDENTIFIER,
+      ]),
+    });
+
+    expect(reownUpdates.viewUpdates).toHaveLength(1);
+    expect(reownUpdates.viewUpdates[0].id).toBe(stack.view.id);
+  });
+
+  it('re-owns only the system view when the user-added FIELDS widget comes first in walk order', () => {
+    const stack = buildStack();
+    const { userFieldsView, userFieldsWidget } =
+      buildUserAddedFieldsWidgetAndView();
+
+    stack.homeTab.widgetUniversalIdentifiers = [
+      userFieldsWidget.universalIdentifier,
+      ...stack.homeTab.widgetUniversalIdentifiers,
+    ];
+
+    const reownUpdates = runCompute({
+      stack,
+      extraWidgets: [userFieldsWidget],
+      extraViews: [userFieldsView],
+      engineOwnedApplicationUniversalIdentifiers: new Set([
+        STANDARD_APPLICATION_UNIVERSAL_IDENTIFIER,
+        CUSTOM_APPLICATION_UNIVERSAL_IDENTIFIER,
+      ]),
+    });
+
+    expect(reownUpdates.viewUpdates).toHaveLength(1);
+    expect(reownUpdates.viewUpdates[0].id).toBe(stack.view.id);
   });
 
   it('skips the second standard group claiming the same name with a warning', () => {

--- a/packages/twenty-server/src/database/commands/upgrade-version-command/2-31/utils/compute-record-page-stack-reown-updates.util.ts
+++ b/packages/twenty-server/src/database/commands/upgrade-version-command/2-31/utils/compute-record-page-stack-reown-updates.util.ts
@@ -8,6 +8,7 @@ import {
 } from 'twenty-shared/application';
 import { isDefined } from 'twenty-shared/utils';
 
+import { PRE_2_31_RECORD_PAGE_UNIVERSAL_IDENTIFIER_BY_DERIVED } from 'src/database/commands/upgrade-version-command/2-10/utils/remap-record-page-universal-identifiers-to-pre-2-31.util';
 import {
   type RecordPageReownUpdate,
   type RecordPageReownUpdates,
@@ -87,6 +88,13 @@ export const computeRecordPageStackReownUpdates = ({
     flatEntity: flatPageLayout,
     derivedUniversalIdentifier: derivedPageLayoutUniversalIdentifier,
     flatEntitiesByUniversalIdentifier: flatPageLayoutMaps.byUniversalIdentifier,
+  });
+
+  const systemFieldsViewId = selectSystemFieldsViewId({
+    stackTree,
+    flatObjectMetadata,
+    engineOwnedApplicationUniversalIdentifiers,
+    twentyStandardApplicationUniversalIdentifier,
   });
 
   const seenDerivedTabUniversalIdentifiers = new Set<string>();
@@ -184,6 +192,11 @@ export const computeRecordPageStackReownUpdates = ({
 
       if (
         !isDefined(fieldsView) ||
+        // Only the selected system view is re-owned: any other FIELDS widget
+        // view (e.g. user-added through layout customization) would derive
+        // the same object-based identifier and self-collide at apply time,
+        // and is user-space anyway.
+        fieldsView.flatView.id !== systemFieldsViewId ||
         processedViewIds.has(fieldsView.flatView.id)
       ) {
         continue;
@@ -206,6 +219,91 @@ export const computeRecordPageStackReownUpdates = ({
   }
 
   return reownUpdates;
+};
+
+// One system FIELDS_WIDGET view per object: resolve it by identifier first
+// (the pre-2.31 pinned literal for standard objects, then the derived
+// identifier on reruns), then by the twenty-standard-owned widget reference,
+// then by walk order (custom objects, whose single engine widget comes
+// first). Every other FIELDS widget view reached through the layout is
+// user-space and must not be re-owned.
+const selectSystemFieldsViewId = ({
+  stackTree,
+  flatObjectMetadata,
+  engineOwnedApplicationUniversalIdentifiers,
+  twentyStandardApplicationUniversalIdentifier,
+}: {
+  stackTree: ReturnType<typeof collectRecordPageStackTree>;
+  flatObjectMetadata: ComputeRecordPageStackReownUpdatesArgs['flatObjectMetadata'];
+  engineOwnedApplicationUniversalIdentifiers: Set<string>;
+  twentyStandardApplicationUniversalIdentifier: string;
+}): string | undefined => {
+  const derivedViewUniversalIdentifier = getSystemViewUniversalIdentifier({
+    objectMetadataApplicationUniversalIdentifier:
+      flatObjectMetadata.applicationUniversalIdentifier,
+    objectUniversalIdentifier: flatObjectMetadata.universalIdentifier,
+    viewKey: SYSTEM_VIEW_KEYS.FIELDS_WIDGET,
+  });
+  const pre231ViewUniversalIdentifier =
+    PRE_2_31_RECORD_PAGE_UNIVERSAL_IDENTIFIER_BY_DERIVED[
+      derivedViewUniversalIdentifier
+    ];
+
+  const candidates: {
+    fieldsView: RecordPageStackFieldsViewNode;
+    widgetApplicationUniversalIdentifier: string;
+  }[] = [];
+  const seenCandidateViewIds = new Set<string>();
+
+  for (const { flatPageLayoutTab, widgets } of stackTree.tabs) {
+    if (
+      !engineOwnedApplicationUniversalIdentifiers.has(
+        flatPageLayoutTab.applicationUniversalIdentifier,
+      )
+    ) {
+      continue;
+    }
+
+    for (const { flatPageLayoutWidget, fieldsView } of widgets) {
+      if (
+        !engineOwnedApplicationUniversalIdentifiers.has(
+          flatPageLayoutWidget.applicationUniversalIdentifier,
+        ) ||
+        !isDefined(fieldsView) ||
+        seenCandidateViewIds.has(fieldsView.flatView.id)
+      ) {
+        continue;
+      }
+      seenCandidateViewIds.add(fieldsView.flatView.id);
+
+      candidates.push({
+        fieldsView,
+        widgetApplicationUniversalIdentifier:
+          flatPageLayoutWidget.applicationUniversalIdentifier,
+      });
+    }
+  }
+
+  const selectedCandidate =
+    candidates.find(
+      ({ fieldsView }) =>
+        isDefined(pre231ViewUniversalIdentifier) &&
+        fieldsView.flatView.universalIdentifier ===
+          pre231ViewUniversalIdentifier,
+    ) ??
+    candidates.find(
+      ({ fieldsView }) =>
+        fieldsView.flatView.universalIdentifier ===
+        derivedViewUniversalIdentifier,
+    ) ??
+    candidates.find(
+      ({ widgetApplicationUniversalIdentifier }) =>
+        widgetApplicationUniversalIdentifier ===
+        twentyStandardApplicationUniversalIdentifier,
+    ) ??
+    candidates[0];
+
+  return selectedCandidate?.fieldsView.flatView.id;
 };
 
 const computeRecordPageViewReownUpdates = ({
@@ -242,8 +340,9 @@ const computeRecordPageViewReownUpdates = ({
     viewKey: SYSTEM_VIEW_KEYS.FIELDS_WIDGET,
   });
 
-  // The view identifier derives from the object alone, so a second view
-  // reached through another FIELDS widget of the same stack cannot take it.
+  // Only the selected system view reaches this point, so a holder here is a
+  // row outside the walk (e.g. a soft-deleted view still occupying the
+  // identifier in the non-partial unique index).
   const derivedViewIdentifierHolder =
     flatViewMaps.byUniversalIdentifier[derivedViewUniversalIdentifier];
 

--- a/packages/twenty-server/src/database/commands/upgrade-version-command/2-31/utils/compute-record-page-stack-reown-updates.util.ts
+++ b/packages/twenty-server/src/database/commands/upgrade-version-command/2-31/utils/compute-record-page-stack-reown-updates.util.ts
@@ -2,9 +2,9 @@ import {
   SYSTEM_VIEW_KEYS,
   getSystemPageLayoutTabUniversalIdentifier,
   getSystemPageLayoutWidgetUniversalIdentifier,
+  getSystemViewFieldGroupUniversalIdentifier,
   getSystemViewFieldUniversalIdentifier,
   getSystemViewUniversalIdentifier,
-  getSystemViewFieldGroupUniversalIdentifier,
 } from 'twenty-shared/application';
 import { isDefined } from 'twenty-shared/utils';
 
@@ -223,18 +223,6 @@ export const computeRecordPageStackReownUpdates = ({
   return reownUpdates;
 };
 
-// One system FIELDS_WIDGET view per object: resolve it by identifier first
-// (the pre-2.31 pinned literal for standard objects, then the derived
-// identifier on reruns), then by the twenty-standard-owned widget reference,
-// then by the isSystemSideEffect flag (post-2-15 custom objects, whose
-// engine view is flagged while user-added views never are). A lone leftover
-// candidate wins by elimination; several leftovers (pre-2-15 custom rows are
-// stuck unflagged, so an added user view is indistinguishable) are ambiguous
-// and selection is refused with a warning rather than scored, matching the
-// layout decision table: the backfill provisions the derived stack next and
-// the untouched views keep working as user-space customs. Every
-// non-selected FIELDS widget view reached through the layout is user-space
-// and must not be re-owned.
 const selectSystemFieldsViewId = ({
   workspaceId,
   logger,

--- a/packages/twenty-server/src/database/commands/upgrade-version-command/2-31/utils/compute-record-page-stack-reown-updates.util.ts
+++ b/packages/twenty-server/src/database/commands/upgrade-version-command/2-31/utils/compute-record-page-stack-reown-updates.util.ts
@@ -91,6 +91,8 @@ export const computeRecordPageStackReownUpdates = ({
   });
 
   const systemFieldsViewId = selectSystemFieldsViewId({
+    workspaceId,
+    logger,
     stackTree,
     flatObjectMetadata,
     engineOwnedApplicationUniversalIdentifiers,
@@ -224,15 +226,25 @@ export const computeRecordPageStackReownUpdates = ({
 // One system FIELDS_WIDGET view per object: resolve it by identifier first
 // (the pre-2.31 pinned literal for standard objects, then the derived
 // identifier on reruns), then by the twenty-standard-owned widget reference,
-// then by walk order (custom objects, whose single engine widget comes
-// first). Every other FIELDS widget view reached through the layout is
-// user-space and must not be re-owned.
+// then by the isSystemSideEffect flag (post-2-15 custom objects, whose
+// engine view is flagged while user-added views never are). A lone leftover
+// candidate wins by elimination; several leftovers (pre-2-15 custom rows are
+// stuck unflagged, so an added user view is indistinguishable) are ambiguous
+// and selection is refused with a warning rather than scored, matching the
+// layout decision table: the backfill provisions the derived stack next and
+// the untouched views keep working as user-space customs. Every
+// non-selected FIELDS widget view reached through the layout is user-space
+// and must not be re-owned.
 const selectSystemFieldsViewId = ({
+  workspaceId,
+  logger,
   stackTree,
   flatObjectMetadata,
   engineOwnedApplicationUniversalIdentifiers,
   twentyStandardApplicationUniversalIdentifier,
 }: {
+  workspaceId: string;
+  logger: ReownLogger;
   stackTree: ReturnType<typeof collectRecordPageStackTree>;
   flatObjectMetadata: ComputeRecordPageStackReownUpdatesArgs['flatObjectMetadata'];
   engineOwnedApplicationUniversalIdentifiers: Set<string>;
@@ -301,9 +313,23 @@ const selectSystemFieldsViewId = ({
         widgetApplicationUniversalIdentifier ===
         twentyStandardApplicationUniversalIdentifier,
     ) ??
-    candidates[0];
+    candidates.find(({ fieldsView }) => fieldsView.flatView.isSystemSideEffect);
 
-  return selectedCandidate?.fieldsView.flatView.id;
+  if (isDefined(selectedCandidate)) {
+    return selectedCandidate.fieldsView.flatView.id;
+  }
+
+  if (candidates.length > 1) {
+    logger.warn(
+      `Ambiguous FIELDS widget views for object ${flatObjectMetadata.universalIdentifier} in workspace ${workspaceId}, skipping view re-own (candidates: ${candidates
+        .map(({ fieldsView }) => fieldsView.flatView.id)
+        .join(', ')})`,
+    );
+
+    return undefined;
+  }
+
+  return candidates[0]?.fieldsView.flatView.id;
 };
 
 const computeRecordPageViewReownUpdates = ({

--- a/packages/twenty-server/src/database/commands/upgrade-version-command/2-31/utils/compute-record-page-stack-reown-updates.util.ts
+++ b/packages/twenty-server/src/database/commands/upgrade-version-command/2-31/utils/compute-record-page-stack-reown-updates.util.ts
@@ -22,6 +22,11 @@ import { type AllFlatEntityMaps } from 'src/engine/metadata-modules/flat-entity/
 
 type ReownLogger = { warn: (message: string) => void };
 
+type SystemFieldsViewSelection =
+  | { status: 'selected'; viewId: string }
+  | { status: 'none' }
+  | { status: 'ambiguous' };
+
 type RecordPageStackMaps = Pick<
   AllFlatEntityMaps,
   | 'flatViewMaps'
@@ -81,6 +86,31 @@ export const computeRecordPageStackReownUpdates = ({
     flatPageLayoutWidgetMaps,
   });
 
+  const systemFieldsViewSelection = selectSystemFieldsView({
+    workspaceId,
+    logger,
+    stackTree,
+    flatObjectMetadata,
+    engineOwnedApplicationUniversalIdentifiers,
+    twentyStandardApplicationUniversalIdentifier,
+  });
+
+  // An ambiguous view selection skips the WHOLE stack, not just the view:
+  // re-owning the layout and widgets while their FIELDS configuration still
+  // points at an un-reowned view would leave a half-derived system stack the
+  // backfill never repairs (it does not touch widgets of an existing layout).
+  // Untouched, the stack degrades to a user custom layout, which the
+  // frontend prefers anyway, and the backfill provisions a coherent derived
+  // stack beside it.
+  if (systemFieldsViewSelection.status === 'ambiguous') {
+    return reownUpdates;
+  }
+
+  const systemFieldsViewId =
+    systemFieldsViewSelection.status === 'selected'
+      ? systemFieldsViewSelection.viewId
+      : undefined;
+
   pushReownUpdate({
     workspaceId,
     logger,
@@ -88,15 +118,6 @@ export const computeRecordPageStackReownUpdates = ({
     flatEntity: flatPageLayout,
     derivedUniversalIdentifier: derivedPageLayoutUniversalIdentifier,
     flatEntitiesByUniversalIdentifier: flatPageLayoutMaps.byUniversalIdentifier,
-  });
-
-  const systemFieldsViewId = selectSystemFieldsViewId({
-    workspaceId,
-    logger,
-    stackTree,
-    flatObjectMetadata,
-    engineOwnedApplicationUniversalIdentifiers,
-    twentyStandardApplicationUniversalIdentifier,
   });
 
   const seenDerivedTabUniversalIdentifiers = new Set<string>();
@@ -223,7 +244,11 @@ export const computeRecordPageStackReownUpdates = ({
   return reownUpdates;
 };
 
-const selectSystemFieldsViewId = ({
+// One system FIELDS_WIDGET view per object, resolved by identifier or
+// unforgeable ownership, never by walk order; indistinguishable candidates
+// (pre-2-15 custom rows are stuck unflagged) refuse selection rather than
+// score.
+const selectSystemFieldsView = ({
   workspaceId,
   logger,
   stackTree,
@@ -237,7 +262,7 @@ const selectSystemFieldsViewId = ({
   flatObjectMetadata: ComputeRecordPageStackReownUpdatesArgs['flatObjectMetadata'];
   engineOwnedApplicationUniversalIdentifiers: Set<string>;
   twentyStandardApplicationUniversalIdentifier: string;
-}): string | undefined => {
+}): SystemFieldsViewSelection => {
   const derivedViewUniversalIdentifier = getSystemViewUniversalIdentifier({
     objectMetadataApplicationUniversalIdentifier:
       flatObjectMetadata.applicationUniversalIdentifier,
@@ -304,20 +329,24 @@ const selectSystemFieldsViewId = ({
     candidates.find(({ fieldsView }) => fieldsView.flatView.isSystemSideEffect);
 
   if (isDefined(selectedCandidate)) {
-    return selectedCandidate.fieldsView.flatView.id;
+    return { status: 'selected', viewId: selectedCandidate.fieldsView.flatView.id };
   }
 
   if (candidates.length > 1) {
     logger.warn(
-      `Ambiguous FIELDS widget views for object ${flatObjectMetadata.universalIdentifier} in workspace ${workspaceId}, skipping view re-own (candidates: ${candidates
+      `Ambiguous FIELDS widget views for object ${flatObjectMetadata.universalIdentifier} in workspace ${workspaceId}, skipping the whole stack re-own (candidates: ${candidates
         .map(({ fieldsView }) => fieldsView.flatView.id)
         .join(', ')})`,
     );
 
-    return undefined;
+    return { status: 'ambiguous' };
   }
 
-  return candidates[0]?.fieldsView.flatView.id;
+  if (candidates.length === 1) {
+    return { status: 'selected', viewId: candidates[0].fieldsView.flatView.id };
+  }
+
+  return { status: 'none' };
 };
 
 const computeRecordPageViewReownUpdates = ({

--- a/packages/twenty-server/src/database/commands/upgrade-version-command/2-31/utils/compute-record-page-stack-reown-updates.util.ts
+++ b/packages/twenty-server/src/database/commands/upgrade-version-command/2-31/utils/compute-record-page-stack-reown-updates.util.ts
@@ -95,13 +95,6 @@ export const computeRecordPageStackReownUpdates = ({
     twentyStandardApplicationUniversalIdentifier,
   });
 
-  // No selected view (ambiguous or none) skips the WHOLE stack, not just the
-  // view: re-owning the layout and widgets without a connected system view
-  // would leave a half-derived stack the backfill never repairs (it does not
-  // touch widgets of an existing layout) and the field handlers would noop on
-  // forever. Untouched, the stack degrades to a user custom layout, which
-  // the frontend prefers anyway, and the backfill provisions a coherent
-  // derived stack beside it.
   if (systemFieldsViewSelection.status !== 'selected') {
     return reownUpdates;
   }
@@ -241,10 +234,6 @@ export const computeRecordPageStackReownUpdates = ({
   return reownUpdates;
 };
 
-// One system FIELDS_WIDGET view per object, resolved by identifier or
-// unforgeable ownership, never by walk order; indistinguishable candidates
-// (pre-2-15 custom rows are stuck unflagged) refuse selection rather than
-// score.
 const selectSystemFieldsView = ({
   workspaceId,
   logger,
@@ -326,7 +315,10 @@ const selectSystemFieldsView = ({
     candidates.find(({ fieldsView }) => fieldsView.flatView.isSystemSideEffect);
 
   if (isDefined(selectedCandidate)) {
-    return { status: 'selected', viewId: selectedCandidate.fieldsView.flatView.id };
+    return {
+      status: 'selected',
+      viewId: selectedCandidate.fieldsView.flatView.id,
+    };
   }
 
   if (candidates.length > 1) {

--- a/packages/twenty-server/src/database/commands/upgrade-version-command/2-31/utils/compute-record-page-stack-reown-updates.util.ts
+++ b/packages/twenty-server/src/database/commands/upgrade-version-command/2-31/utils/compute-record-page-stack-reown-updates.util.ts
@@ -95,21 +95,18 @@ export const computeRecordPageStackReownUpdates = ({
     twentyStandardApplicationUniversalIdentifier,
   });
 
-  // An ambiguous view selection skips the WHOLE stack, not just the view:
-  // re-owning the layout and widgets while their FIELDS configuration still
-  // points at an un-reowned view would leave a half-derived system stack the
-  // backfill never repairs (it does not touch widgets of an existing layout).
-  // Untouched, the stack degrades to a user custom layout, which the
-  // frontend prefers anyway, and the backfill provisions a coherent derived
-  // stack beside it.
-  if (systemFieldsViewSelection.status === 'ambiguous') {
+  // No selected view (ambiguous or none) skips the WHOLE stack, not just the
+  // view: re-owning the layout and widgets without a connected system view
+  // would leave a half-derived stack the backfill never repairs (it does not
+  // touch widgets of an existing layout) and the field handlers would noop on
+  // forever. Untouched, the stack degrades to a user custom layout, which
+  // the frontend prefers anyway, and the backfill provisions a coherent
+  // derived stack beside it.
+  if (systemFieldsViewSelection.status !== 'selected') {
     return reownUpdates;
   }
 
-  const systemFieldsViewId =
-    systemFieldsViewSelection.status === 'selected'
-      ? systemFieldsViewSelection.viewId
-      : undefined;
+  const systemFieldsViewId = systemFieldsViewSelection.viewId;
 
   pushReownUpdate({
     workspaceId,
@@ -345,6 +342,10 @@ const selectSystemFieldsView = ({
   if (candidates.length === 1) {
     return { status: 'selected', viewId: candidates[0].fieldsView.flatView.id };
   }
+
+  logger.warn(
+    `No resolvable system FIELDS widget view for object ${flatObjectMetadata.universalIdentifier} in workspace ${workspaceId}, skipping the whole stack re-own`,
+  );
 
   return { status: 'none' };
 };


### PR DESCRIPTION
Fixes the ReconcileStandardRecordPage upgrade failures observed on dev (3/70 workspaces, `duplicate key value violates unique constraint "IDX_552aa6908966e980099b3e5ebf"` on `view.universalIdentifier`).

## Root cause

The derived record-page view identifier is a function of the object alone. The reconcile walked every FIELDS widget of a stack and re-owned each referenced view, deduplicating only by view id. A layout carrying two FIELDS widgets with two distinct views, which is exactly what layout customization produces (each user-added FIELDS widget gets its own view, owned by the workspace-custom application, which is inside the engine-owned set), yielded two updates claiming the same derived identifier in one plan. The existing holder guard only checks rows that already exist in the maps, so it cannot see a claim planned thirty lines earlier: the first UPDATE takes the identifier, the second violates the unique index, the transaction rolls back and the workspace upgrade fails deterministically (a cache flush changes nothing). Confirmed by reproducing unit tests; the failing workspaces are the ones with customized opportunity/person record pages.

## Fix

One system FIELDS_WIDGET view per object, selected before the walk, and only that view is re-owned:

1. the view holding the object's pre-2.31 pinned literal (`PRE_2_31_RECORD_PAGE_UNIVERSAL_IDENTIFIER_BY_DERIVED` lookup, automatic for standard objects, a miss for custom ones);
2. the view already holding the derived identifier (reruns, engine-created rows);
3. the view referenced by the twenty-standard-owned widget (pre-literal legacy workspaces);
4. the view flagged isSystemSideEffect (custom objects post-2-15: the engine view is flagged, user-added views never are);
5. a lone leftover candidate wins by elimination; several leftovers are ambiguous (pre-2-15 custom rows are stuck unflagged, indistinguishable from a user-added view) and no selection is made. Walk order never decides.

No selected view, no re-own at all: when selection is ambiguous or no system view is resolvable (dangling FIELDS widget reference, no FIELDS widget), the whole stack is skipped with a warning instead of scored, matching the workspace-custom command's layout decision table. Re-owning only the shell would leave a half-derived stack whose FIELDS widget points at an un-reowned or missing view, which the backfill never repairs (it does not touch widgets of an existing layout) and which the field handlers would treat as a missing system view forever.

Every other FIELDS widget view reached through the layout is user-space and left untouched, which also stops a user-created view from being conscripted into the flagged system view. The double claim becomes structurally impossible. The in-walk holder guard stays, now covering only rows outside the walk (e.g. a soft-deleted view still occupying the identifier in the non-partial unique index).

## Coverage guarantee

The invariant this converges on: every standard universal identifier is always identified and mutated, across all workspace generations, by identifier or unforgeable ownership, never by walk order.

- #23081-era workspaces (the fleet's vast majority): the curated view is identified by its pinned pre-2.31 literal (branch 1). This is the case of the three failed dev workspaces: on rerun they re-own the curated opportunity/person views and ignore the user-added ones.
- Reruns and partially converged workspaces: the derived-identifier holder (branch 2) keeps the selection stable, so no wrong winner can ever get locked in.
- Pre-literal legacy workspaces: the twenty-standard-owned widget reference (branch 3) is unforgeable, since layout customization always writes workspace-custom-owned rows; and the curated definitions declare a single fields view per object, so even a duplicated standard widget yields a single candidate.

Custom objects are identified whenever the data allows (derived holder or the isSystemSideEffect flag) and never guessed when it does not: the ambiguous pre-2-15 shape refuses the whole stack re-own with a warning, the untouched stack degrades to a user custom layout (which the frontend prefers for display anyway), and the backfill command provisions a coherent derived system stack beside it right after. Mutation is deferred to creation instead of gambled on ordering.

## Specs

Four new cases on the shared compute util: the standard stack plus a workspace-custom-owned user-added FIELDS widget with its own view (engine-owned set containing both applications, as the command passes it) with the user widget second and first in walk order, both failing with two colliding view updates before the fix; and the custom-object shape, where a flagged engine view is selected even when the user-added widget precedes it, several unflagged views warn and re-own nothing at all (zero updates across every bucket), and a stack whose only FIELDS widget view is dangling is skipped whole for the same reason.

Left unchanged on purpose: user-added tabs and widgets on standard layouts are still re-owned and flagged (title-derived identifiers, deduplicated by the existing seen-sets); soft-deleted holders are skipped, not remediated.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/24022?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-light.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->
