### PR TITLE
Fix colliding record-page view field positions on batch field creation

### DIFF
--- a/packages/twenty-server/src/engine/metadata-modules/metadata-side-effect/handlers/field-metadata/services/__tests__/field-record-page-view-field-on-create-side-effect-handler.service.spec.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/metadata-side-effect/handlers/field-metadata/services/__tests__/field-record-page-view-field-on-create-side-effect-handler.service.spec.ts
@@ -3,6 +3,7 @@ import { ViewType } from 'twenty-shared/types';
 import { FieldRecordPageViewFieldOnCreateSideEffectHandlerService } from 'src/engine/metadata-modules/metadata-side-effect/handlers/field-metadata/services/field-record-page-view-field-on-create-side-effect-handler.service';
 import {
   buildArgs,
+  buildPendingFieldMetadata,
   computeViewFieldUniversalIdentifier,
   DERIVED_RECORD_PAGE_VIEW_UNIVERSAL_IDENTIFIER,
   filterByView,
@@ -252,6 +253,70 @@ describe('FieldRecordPageViewFieldOnCreateSideEffectHandlerService', () => {
         viewFieldGroupUniversalIdentifier: 'group-uid-2',
         position: 8,
       });
+    });
+
+    it('should offset the append position by the field rank among the batch emitting caller fields', () => {
+      const speciesField = buildPendingFieldMetadata('species');
+      const traitsField = buildPendingFieldMetadata('traits');
+
+      const buildArgsForTrigger = (
+        triggerFieldMetadata: typeof PRIORITY_FIELD,
+      ) =>
+        buildArgs({
+          triggerFieldMetadata,
+          // name is the label identifier and species is already synced:
+          // neither takes an append slot.
+          pendingFieldMetadatas: [
+            NAME_FIELD,
+            speciesField,
+            PRIORITY_FIELD,
+            traitsField,
+          ],
+          objectMetadataInWorkspace: true,
+          viewsInWorkspace: [SYNCED_INDEX_VIEW, SYNCED_RECORD_PAGE_VIEW],
+          viewFieldsInWorkspace: [
+            {
+              universalIdentifier: 'existing-record-page-vf',
+              viewId: SYNCED_RECORD_PAGE_VIEW.id,
+              position: 3,
+              isActive: true,
+            },
+            {
+              universalIdentifier: 'species-synced-vf',
+              viewId: SYNCED_RECORD_PAGE_VIEW.id,
+              fieldMetadataUniversalIdentifier:
+                speciesField.universalIdentifier,
+              position: 0,
+              isActive: true,
+            },
+          ],
+          fieldsWidgetsInWorkspace: [SYNCED_FIELDS_WIDGET],
+        });
+
+      const positions = [PRIORITY_FIELD, traitsField].map(
+        (triggerFieldMetadata) => {
+          const result = handler.buildSideEffects(
+            buildArgsForTrigger(triggerFieldMetadata),
+          );
+
+          expect(result.status).toBe('success');
+
+          if (result.status !== 'success') {
+            throw new Error('expected success');
+          }
+
+          const [recordPageViewField] = filterByView(
+            Object.values(
+              result.operations.viewField?.flatEntityToCreate ?? {},
+            ),
+            DERIVED_RECORD_PAGE_VIEW_UNIVERSAL_IDENTIFIER,
+          );
+
+          return recordPageViewField.position;
+        },
+      );
+
+      expect(positions).toEqual([4, 5]);
     });
 
     it('should not emit when no active FIELDS widget references the engine record-page view', () => {

--- a/packages/twenty-server/src/engine/metadata-modules/metadata-side-effect/handlers/field-metadata/services/field-record-page-view-field-on-create-side-effect-handler.service.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/metadata-side-effect/handlers/field-metadata/services/field-record-page-view-field-on-create-side-effect-handler.service.ts
@@ -10,6 +10,7 @@ import { isDefined } from 'twenty-shared/utils';
 import { DEFAULT_VIEW_FIELD_SIZE } from 'src/engine/metadata-modules/flat-view-field/constants/default-view-field-size.constant';
 import { buildFieldSideEffectParentNotFoundFailure } from 'src/engine/metadata-modules/metadata-side-effect/handlers/field-metadata/utils/build-field-side-effect-parent-not-found-failure.util';
 import { resolveParentFlatObjectMetadataAfterStateForFieldSideEffect } from 'src/engine/metadata-modules/metadata-side-effect/handlers/field-metadata/utils/resolve-parent-flat-object-metadata-after-state-for-field-side-effect.util';
+import { computeCallerFlatFieldMetadatasForObject } from 'src/engine/metadata-modules/metadata-side-effect/handlers/utils/compute-caller-flat-field-metadatas-for-object.util';
 import { computeRecordPageViewFieldForExistingObject } from 'src/engine/metadata-modules/metadata-side-effect/handlers/utils/compute-record-page-view-field-for-existing-object.util';
 import {
   computeSameBatchViewFieldPositionByFieldUniversalIdentifier,
@@ -30,7 +31,7 @@ export class FieldRecordPageViewFieldOnCreateSideEffectHandlerService extends Me
     metadataName: 'fieldMetadata',
     name: 'fieldRecordPageViewFieldOnCreate',
     description:
-      'When a caller-provided field is created, provision its engine-owned view field on the engine-owned FIELDS_WIDGET record-page view, resolved strictly by its derived universal identifier. On an existing object the emission is widget-driven: visibility follows the FIELDS widget newFieldDefaultVisibility and the view field appends into the last active view field group, degrading to no group (the common case: custom objects are created with zero groups). On same-batch object+field creation no widget map exists yet, so the default widget configuration is derived statelessly from the constant (visible, no group, deterministic caller-then-system position shared with objectRecordPageOnCreate). Noop when the object has no engine record-page view, when no active FIELDS widget references it, when the widget does not declare newFieldDefaultVisibility, when the field is the object label identifier (the record page displays it in the title), or when the (view, field) pair is already synced, whatever its identifier. A caller-pending view field for the same pair is not deferred to: the engine always produces its system side effects, and the pair-uniqueness validator surfaces the conflict to the caller, exactly like INDEX. The INDEX counterpart is fieldIndexViewFieldOnCreate.',
+      'When a caller-provided field is created, provision its engine-owned view field on the engine-owned FIELDS_WIDGET record-page view, resolved strictly by its derived universal identifier. On an existing object the emission is widget-driven: visibility follows the FIELDS widget newFieldDefaultVisibility and the view field appends into the last active view field group, degrading to no group (the common case: custom objects are created with zero groups), after the existing active positions and offset by the field rank among the batch emitting caller fields, so batch creations keep the caller-declared order without position collisions. On same-batch object+field creation no widget map exists yet, so the default widget configuration is derived statelessly from the constant (visible, no group, deterministic caller-then-system position shared with objectRecordPageOnCreate). Noop when the object has no engine record-page view, when no active FIELDS widget references it, when the widget does not declare newFieldDefaultVisibility, when the field is the object label identifier (the record page displays it in the title), or when the (view, field) pair is already synced, whatever its identifier. A caller-pending view field for the same pair is not deferred to: the engine always produces its system side effects, and the pair-uniqueness validator surfaces the conflict to the caller, exactly like INDEX. The INDEX counterpart is fieldIndexViewFieldOnCreate.',
   },
 ) {
   buildSideEffects({
@@ -80,6 +81,7 @@ export class FieldRecordPageViewFieldOnCreateSideEffectHandlerService extends Me
           parentFlatObjectMetadata,
           recordPageViewUniversalIdentifier,
           relatedFlatEntityMaps,
+          allFlatEntityOperationRecordByMetadataName,
         });
 
     if (!isDefined(flatRecordPageViewFieldToCreate)) {
@@ -165,15 +167,20 @@ export class FieldRecordPageViewFieldOnCreateSideEffectHandlerService extends Me
     parentFlatObjectMetadata,
     recordPageViewUniversalIdentifier,
     relatedFlatEntityMaps,
+    allFlatEntityOperationRecordByMetadataName,
   }: {
     sourceFlatFieldMetadata: UniversalFlatFieldMetadata;
     parentFlatObjectMetadata: ParentFlatObjectMetadataForViewFields;
     recordPageViewUniversalIdentifier: string;
     relatedFlatEntityMaps: BuildSideEffectsArgs<'fieldMetadata'>['relatedFlatEntityMaps'];
+    allFlatEntityOperationRecordByMetadataName: BuildSideEffectsArgs<'fieldMetadata'>['allFlatEntityOperationRecordByMetadataName'];
   }): UniversalFlatViewField | undefined {
+    const { labelIdentifierFieldMetadataUniversalIdentifier } =
+      parentFlatObjectMetadata;
+
     if (
       sourceFlatFieldMetadata.universalIdentifier ===
-      parentFlatObjectMetadata.labelIdentifierFieldMetadataUniversalIdentifier
+      labelIdentifierFieldMetadataUniversalIdentifier
     ) {
       return undefined;
     }
@@ -183,7 +190,9 @@ export class FieldRecordPageViewFieldOnCreateSideEffectHandlerService extends Me
         recordPageViewUniversalIdentifier
       ];
 
-    const pairAlreadySynced =
+    const isPairAlreadySynced = (
+      fieldMetadataUniversalIdentifier: string,
+    ): boolean =>
       isDefined(existingRecordPageFlatView) &&
       existingRecordPageFlatView.viewFieldUniversalIdentifiers.some(
         (viewFieldUniversalIdentifier) => {
@@ -195,19 +204,47 @@ export class FieldRecordPageViewFieldOnCreateSideEffectHandlerService extends Me
           return (
             isDefined(existingFlatViewField) &&
             existingFlatViewField.fieldMetadataUniversalIdentifier ===
-              sourceFlatFieldMetadata.universalIdentifier &&
+              fieldMetadataUniversalIdentifier &&
             !isDefined(existingFlatViewField.deletedAt)
           );
         },
       );
 
-    if (pairAlreadySynced) {
+    if (isPairAlreadySynced(sourceFlatFieldMetadata.universalIdentifier)) {
       return undefined;
     }
+
+    // Every field of a batch reads the same pre-batch snapshot, so a bare
+    // max+1 append would collide. Offsetting by the field's rank among the
+    // batch's emitting caller fields keeps positions distinct and preserves
+    // the caller-declared order, statelessly (no dependency on the order the
+    // engine processes the batch).
+    const emittingCallerFlatFieldMetadatas =
+      computeCallerFlatFieldMetadatasForObject({
+        objectMetadataUniversalIdentifier:
+          sourceFlatFieldMetadata.objectMetadataUniversalIdentifier,
+        labelIdentifierFieldMetadataUniversalIdentifier,
+        allFlatEntityOperationRecordByMetadataName,
+      }).filter(
+        (callerFlatFieldMetadata) =>
+          callerFlatFieldMetadata.universalIdentifier !==
+            labelIdentifierFieldMetadataUniversalIdentifier &&
+          !isPairAlreadySynced(callerFlatFieldMetadata.universalIdentifier),
+      );
+
+    const batchAppendOffset = Math.max(
+      emittingCallerFlatFieldMetadatas.findIndex(
+        (callerFlatFieldMetadata) =>
+          callerFlatFieldMetadata.universalIdentifier ===
+          sourceFlatFieldMetadata.universalIdentifier,
+      ),
+      0,
+    );
 
     return computeRecordPageViewFieldForExistingObject({
       sourceFlatFieldMetadata,
       recordPageViewUniversalIdentifier,
+      batchAppendOffset,
       flatViewMaps: relatedFlatEntityMaps.flatViewMaps,
       flatViewFieldMaps: relatedFlatEntityMaps.flatViewFieldMaps,
       flatViewFieldGroupMaps: relatedFlatEntityMaps.flatViewFieldGroupMaps,

--- a/packages/twenty-server/src/engine/metadata-modules/metadata-side-effect/handlers/object-metadata/services/object-record-page-label-identifier-on-update-side-effect-handler.service.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/metadata-side-effect/handlers/object-metadata/services/object-record-page-label-identifier-on-update-side-effect-handler.service.ts
@@ -203,6 +203,8 @@ export class ObjectRecordPageLabelIdentifierOnUpdateSideEffectHandlerService ext
     return computeRecordPageViewFieldForExistingObject({
       sourceFlatFieldMetadata: previousLabelIdentifierFlatFieldMetadata,
       recordPageViewUniversalIdentifier,
+      // Relabel restores a single field: no batch to offset within.
+      batchAppendOffset: 0,
       flatViewMaps: relatedFlatEntityMaps.flatViewMaps,
       flatViewFieldMaps: relatedFlatEntityMaps.flatViewFieldMaps,
       flatViewFieldGroupMaps: relatedFlatEntityMaps.flatViewFieldGroupMaps,

--- a/packages/twenty-server/src/engine/metadata-modules/metadata-side-effect/handlers/utils/compute-record-page-view-field-for-existing-object.util.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/metadata-side-effect/handlers/utils/compute-record-page-view-field-for-existing-object.util.ts
@@ -10,6 +10,7 @@ import { type UniversalFlatViewField } from 'src/engine/workspace-manager/worksp
 export const computeRecordPageViewFieldForExistingObject = ({
   sourceFlatFieldMetadata,
   recordPageViewUniversalIdentifier,
+  batchAppendOffset,
   flatViewMaps,
   flatViewFieldMaps,
   flatViewFieldGroupMaps,
@@ -17,6 +18,7 @@ export const computeRecordPageViewFieldForExistingObject = ({
 }: {
   sourceFlatFieldMetadata: UniversalFlatFieldMetadata;
   recordPageViewUniversalIdentifier: string;
+  batchAppendOffset: number;
 } & Pick<
   AllFlatEntityMaps,
   | 'flatViewMaps'
@@ -100,12 +102,16 @@ export const computeRecordPageViewFieldForExistingObject = ({
       )
       .map((flatViewField) => flatViewField.position);
 
-  const position =
+  // All fields of a batch read the same pre-batch maps, so the append base is
+  // identical for each of them: the caller-order offset keeps positions distinct.
+  const appendBasePosition =
     existingActivePositions.reduce(
       (maxPosition, existingPosition) =>
         Math.max(maxPosition, existingPosition),
       -1,
     ) + 1;
+
+  const position = appendBasePosition + batchAppendOffset;
 
   const createdAt = new Date().toISOString();
   const { applicationUniversalIdentifier } = sourceFlatFieldMetadata;


### PR DESCRIPTION
Recreates #24009, closed by the base branch deletion when #23651 merged; rebased onto main.

Follow-up to #23651. Fixes colliding record-page view field positions when several fields are created in one batch on an existing object.

## Bug

`computeRecordPageViewFieldForExistingObject` appended at `max(existing active positions in the target group) + 1`, but every field of a batch reads the same pre-batch `relatedFlatEntityMaps` snapshot, so they all computed the same number. On a fresh `database:reset`, the pet record page ended up with 16 view fields at position 4 (surveyResult 7, company System group 5, person System group 4), the app-declared field order was lost, and tie ordering fell to whatever the API returns. Only this incremental append path was affected: the same-batch object+field path numbers 0..n-1 statelessly, the INDEX handler already offsets by caller rank, and the 2-31 backfill numbers sequentially.

## Fix

Stateless batch offset, mirroring the INDEX handler but indexed over the filtered caller list so the appended run is contiguous: the handler computes the field's rank among the batch's emitting caller fields (`computeCallerFlatFieldMetadatasForObject`, minus the label identifier and minus fields whose (view, field) pair is already synced, both computable from caller input plus the static snapshot) and passes it as `batchAppendOffset` to the util, which now appends at `appendBase + offset`. Position stays a pure function of (pre-batch state, caller input): no dependency on engine processing order, no reading of the accumulated side-effect matrix. The relabel restore path in `objectRecordPageLabelIdentifierOnUpdate` passes offset 0 (single field by construction).

Verified on a fresh reset: zero same-position rows per (view, group) across all FIELDS_WIDGET views in both seeded workspaces, and the pet record page view fields land in manifest order. Note the per-view/per-workspace grouping when checking: grouping by object name alone double-counts across the two dev workspaces.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/24025?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

