### PR TITLE
fix: validate chart filter operands and values on app manifest sync

### DIFF
--- a/packages/twenty-server/src/engine/metadata-modules/flat-entity/constant/all-metadata-required-metadata-for-validation.constant.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/flat-entity/constant/all-metadata-required-metadata-for-validation.constant.ts
@@ -103,6 +103,7 @@ export const ALL_METADATA_REQUIRED_METADATA_FOR_VALIDATION = {
     objectMetadata: true,
     pageLayoutTab: true,
     frontComponent: true,
+    fieldMetadata: true,
   },
   rowLevelPermissionPredicate: {
     fieldMetadata: true,

--- a/packages/twenty-server/src/engine/metadata-modules/flat-field-metadata/utils/get-effective-filter-field-type.util.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/flat-field-metadata/utils/get-effective-filter-field-type.util.ts
@@ -1,0 +1,20 @@
+import { FieldMetadataType } from 'twenty-shared/types';
+import { isDefined } from 'twenty-shared/utils';
+
+// A filter on a relation field is evaluated against the relation target field
+// when one is set, so validation has to check the target's type
+export const getEffectiveFilterFieldType = ({
+  fieldType,
+  relationTargetFieldType,
+}: {
+  fieldType: FieldMetadataType;
+  relationTargetFieldType: FieldMetadataType | undefined;
+}): FieldMetadataType => {
+  const isRelationFieldType =
+    fieldType === FieldMetadataType.RELATION ||
+    fieldType === FieldMetadataType.MORPH_RELATION;
+
+  return isRelationFieldType && isDefined(relationTargetFieldType)
+    ? relationTargetFieldType
+    : fieldType;
+};

--- a/packages/twenty-server/src/engine/metadata-modules/flat-page-layout-widget/validators/utils/__tests__/validate-chart-filter.util.spec.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/flat-page-layout-widget/validators/utils/__tests__/validate-chart-filter.util.spec.ts
@@ -1,13 +1,12 @@
-import { FieldMetadataType, ViewFilterOperand } from 'twenty-shared/types';
+import {
+  FieldMetadataType,
+  type UniversalChartFilter,
+  ViewFilterOperand,
+} from 'twenty-shared/types';
 
 import { type MetadataFlatEntityMaps } from 'src/engine/metadata-modules/flat-entity/types/metadata-flat-entity-maps.type';
 import { type FlatFieldMetadata } from 'src/engine/metadata-modules/flat-field-metadata/types/flat-field-metadata.type';
 import { validateChartFilter } from 'src/engine/metadata-modules/flat-page-layout-widget/validators/utils/validate-chart-filter.util';
-import {
-  type AllGraphWidgetConfigurationType,
-  WidgetConfigurationType,
-} from 'src/engine/metadata-modules/page-layout-widget/enums/widget-configuration-type.type';
-import { type UniversalFlatPageLayoutWidget } from 'src/engine/workspace-manager/workspace-migration/universal-flat-entity/types/universal-flat-page-layout-widget.type';
 
 const DATE_FIELD_UNIVERSAL_IDENTIFIER = '20202020-1111-4111-8111-000000000001';
 const SELECT_FIELD_UNIVERSAL_IDENTIFIER =
@@ -48,12 +47,9 @@ const flatFieldMetadataMaps = {
   universalIdentifiersByApplicationId: {},
 } as unknown as MetadataFlatEntityMaps<'fieldMetadata'>;
 
-const validateFilter = (recordFilters: unknown[]) =>
+const validateFilter = (recordFilters: UniversalChartFilter['recordFilters']) =>
   validateChartFilter({
-    graphUniversalConfiguration: {
-      configurationType: WidgetConfigurationType.BAR_CHART,
-      filter: { recordFilters },
-    } as unknown as UniversalFlatPageLayoutWidget<AllGraphWidgetConfigurationType>['universalConfiguration'],
+    filter: { recordFilters },
     widgetTitle: 'Deals per month',
     flatFieldMetadataMaps,
   });
@@ -172,9 +168,7 @@ describe('validateChartFilter', () => {
 
   it('should accept a configuration without any filter', () => {
     const errors = validateChartFilter({
-      graphUniversalConfiguration: {
-        configurationType: WidgetConfigurationType.BAR_CHART,
-      } as unknown as UniversalFlatPageLayoutWidget<AllGraphWidgetConfigurationType>['universalConfiguration'],
+      filter: undefined,
       widgetTitle: 'Deals per month',
       flatFieldMetadataMaps,
     });

--- a/packages/twenty-server/src/engine/metadata-modules/flat-page-layout-widget/validators/utils/__tests__/validate-chart-filter.util.spec.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/flat-page-layout-widget/validators/utils/__tests__/validate-chart-filter.util.spec.ts
@@ -4,9 +4,8 @@ import {
   ViewFilterOperand,
 } from 'twenty-shared/types';
 
-import { type MetadataFlatEntityMaps } from 'src/engine/metadata-modules/flat-entity/types/metadata-flat-entity-maps.type';
-import { type FlatFieldMetadata } from 'src/engine/metadata-modules/flat-field-metadata/types/flat-field-metadata.type';
 import { validateChartFilter } from 'src/engine/metadata-modules/flat-page-layout-widget/validators/utils/validate-chart-filter.util';
+import { type MetadataUniversalFlatEntityMaps } from 'src/engine/workspace-manager/workspace-migration/universal-flat-entity/types/metadata-universal-flat-entity-maps.type';
 
 const DATE_FIELD_UNIVERSAL_IDENTIFIER = '20202020-1111-4111-8111-000000000001';
 const SELECT_FIELD_UNIVERSAL_IDENTIFIER =
@@ -19,14 +18,12 @@ const UNKNOWN_FIELD_UNIVERSAL_IDENTIFIER =
 const flatFieldMetadata = (
   universalIdentifier: string,
   type: FieldMetadataType,
-) =>
-  ({
-    id: universalIdentifier,
-    universalIdentifier,
-    type,
-    label: 'Some field',
-    isActive: true,
-  }) as FlatFieldMetadata;
+) => ({
+  universalIdentifier,
+  type,
+  label: 'Some field',
+  isActive: true,
+});
 
 const flatFieldMetadataMaps = {
   byUniversalIdentifier: {
@@ -43,9 +40,7 @@ const flatFieldMetadataMaps = {
       FieldMetadataType.RELATION,
     ),
   },
-  universalIdentifierById: {},
-  universalIdentifiersByApplicationId: {},
-} as unknown as MetadataFlatEntityMaps<'fieldMetadata'>;
+} as unknown as MetadataUniversalFlatEntityMaps<'fieldMetadata'>;
 
 const validateFilter = (recordFilters: UniversalChartFilter['recordFilters']) =>
   validateChartFilter({
@@ -159,7 +154,11 @@ describe('validateChartFilter', () => {
 
   it('should report a filter without any field reference', () => {
     const errors = validateFilter([
-      { operand: ViewFilterOperand.IS, value: 'anything' },
+      {
+        fieldMetadataUniversalIdentifier: null,
+        operand: ViewFilterOperand.IS,
+        value: 'anything',
+      },
     ]);
 
     expect(errors).toHaveLength(1);

--- a/packages/twenty-server/src/engine/metadata-modules/flat-page-layout-widget/validators/utils/__tests__/validate-chart-filter.util.spec.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/flat-page-layout-widget/validators/utils/__tests__/validate-chart-filter.util.spec.ts
@@ -12,6 +12,10 @@ const SELECT_FIELD_UNIVERSAL_IDENTIFIER =
   '20202020-2222-4222-8222-000000000002';
 const RELATION_FIELD_UNIVERSAL_IDENTIFIER =
   '20202020-3333-4333-8333-000000000003';
+const MORPH_RELATION_FIELD_UNIVERSAL_IDENTIFIER =
+  '20202020-4444-4444-8444-000000000004';
+const RICH_TEXT_FIELD_UNIVERSAL_IDENTIFIER =
+  '20202020-5555-4555-8555-000000000005';
 const UNKNOWN_FIELD_UNIVERSAL_IDENTIFIER =
   '20202020-9999-4999-8999-000000000009';
 
@@ -38,6 +42,14 @@ const flatFieldMetadataMaps = {
     [RELATION_FIELD_UNIVERSAL_IDENTIFIER]: flatFieldMetadata(
       RELATION_FIELD_UNIVERSAL_IDENTIFIER,
       FieldMetadataType.RELATION,
+    ),
+    [MORPH_RELATION_FIELD_UNIVERSAL_IDENTIFIER]: flatFieldMetadata(
+      MORPH_RELATION_FIELD_UNIVERSAL_IDENTIFIER,
+      FieldMetadataType.MORPH_RELATION,
+    ),
+    [RICH_TEXT_FIELD_UNIVERSAL_IDENTIFIER]: flatFieldMetadata(
+      RICH_TEXT_FIELD_UNIVERSAL_IDENTIFIER,
+      FieldMetadataType.RICH_TEXT,
     ),
   },
 } as unknown as MetadataUniversalFlatEntityMaps<'fieldMetadata'>;
@@ -108,19 +120,52 @@ describe('validateChartFilter', () => {
     expect(errors[0].message).toContain('is not supported on field type');
   });
 
-  it('should resolve the relation target field type to validate the value', () => {
+  it.each([
+    ['RELATION', RELATION_FIELD_UNIVERSAL_IDENTIFIER],
+    ['MORPH_RELATION', MORPH_RELATION_FIELD_UNIVERSAL_IDENTIFIER],
+  ])(
+    'should resolve the relation target field type of a %s field to validate the value',
+    (_label, fieldUniversalIdentifier) => {
+      const errors = validateFilter([
+        {
+          fieldMetadataUniversalIdentifier: fieldUniversalIdentifier,
+          relationTargetFieldMetadataUniversalIdentifier:
+            DATE_FIELD_UNIVERSAL_IDENTIFIER,
+          operand: ViewFilterOperand.IS_RELATIVE,
+          value: 'not-a-relative-date',
+        },
+      ]);
+
+      expect(errors).toHaveLength(1);
+      expect(errors[0].message).toContain('DATE');
+    },
+  );
+
+  it('should validate a MORPH_RELATION filter without a target against relation operands', () => {
     const errors = validateFilter([
       {
-        fieldMetadataUniversalIdentifier: RELATION_FIELD_UNIVERSAL_IDENTIFIER,
-        relationTargetFieldMetadataUniversalIdentifier:
-          DATE_FIELD_UNIVERSAL_IDENTIFIER,
+        fieldMetadataUniversalIdentifier:
+          MORPH_RELATION_FIELD_UNIVERSAL_IDENTIFIER,
         operand: ViewFilterOperand.IS_RELATIVE,
-        value: 'not-a-relative-date',
+        value: 'NEXT_30_DAY',
       },
     ]);
 
     expect(errors).toHaveLength(1);
-    expect(errors[0].message).toContain('DATE');
+    expect(errors[0].message).toContain('is not supported on field type');
+  });
+
+  it('should validate a RICH_TEXT filter instead of skipping it', () => {
+    const errors = validateFilter([
+      {
+        fieldMetadataUniversalIdentifier: RICH_TEXT_FIELD_UNIVERSAL_IDENTIFIER,
+        operand: ViewFilterOperand.IS_RELATIVE,
+        value: 'NEXT_30_DAY',
+      },
+    ]);
+
+    expect(errors).toHaveLength(1);
+    expect(errors[0].message).toContain('is not supported on field type');
   });
 
   it('should report an error per invalid filter', () => {

--- a/packages/twenty-server/src/engine/metadata-modules/flat-page-layout-widget/validators/utils/__tests__/validate-chart-filter.util.spec.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/flat-page-layout-widget/validators/utils/__tests__/validate-chart-filter.util.spec.ts
@@ -1,0 +1,184 @@
+import { FieldMetadataType, ViewFilterOperand } from 'twenty-shared/types';
+
+import { type MetadataFlatEntityMaps } from 'src/engine/metadata-modules/flat-entity/types/metadata-flat-entity-maps.type';
+import { type FlatFieldMetadata } from 'src/engine/metadata-modules/flat-field-metadata/types/flat-field-metadata.type';
+import { validateChartFilter } from 'src/engine/metadata-modules/flat-page-layout-widget/validators/utils/validate-chart-filter.util';
+import {
+  type AllGraphWidgetConfigurationType,
+  WidgetConfigurationType,
+} from 'src/engine/metadata-modules/page-layout-widget/enums/widget-configuration-type.type';
+import { type UniversalFlatPageLayoutWidget } from 'src/engine/workspace-manager/workspace-migration/universal-flat-entity/types/universal-flat-page-layout-widget.type';
+
+const DATE_FIELD_UNIVERSAL_IDENTIFIER = '20202020-1111-4111-8111-000000000001';
+const SELECT_FIELD_UNIVERSAL_IDENTIFIER =
+  '20202020-2222-4222-8222-000000000002';
+const RELATION_FIELD_UNIVERSAL_IDENTIFIER =
+  '20202020-3333-4333-8333-000000000003';
+const UNKNOWN_FIELD_UNIVERSAL_IDENTIFIER =
+  '20202020-9999-4999-8999-000000000009';
+
+const flatFieldMetadata = (
+  universalIdentifier: string,
+  type: FieldMetadataType,
+) =>
+  ({
+    id: universalIdentifier,
+    universalIdentifier,
+    type,
+    label: 'Some field',
+    isActive: true,
+  }) as FlatFieldMetadata;
+
+const flatFieldMetadataMaps = {
+  byUniversalIdentifier: {
+    [DATE_FIELD_UNIVERSAL_IDENTIFIER]: flatFieldMetadata(
+      DATE_FIELD_UNIVERSAL_IDENTIFIER,
+      FieldMetadataType.DATE,
+    ),
+    [SELECT_FIELD_UNIVERSAL_IDENTIFIER]: flatFieldMetadata(
+      SELECT_FIELD_UNIVERSAL_IDENTIFIER,
+      FieldMetadataType.SELECT,
+    ),
+    [RELATION_FIELD_UNIVERSAL_IDENTIFIER]: flatFieldMetadata(
+      RELATION_FIELD_UNIVERSAL_IDENTIFIER,
+      FieldMetadataType.RELATION,
+    ),
+  },
+  universalIdentifierById: {},
+  universalIdentifiersByApplicationId: {},
+} as unknown as MetadataFlatEntityMaps<'fieldMetadata'>;
+
+const validateFilter = (recordFilters: unknown[]) =>
+  validateChartFilter({
+    graphUniversalConfiguration: {
+      configurationType: WidgetConfigurationType.BAR_CHART,
+      filter: { recordFilters },
+    } as unknown as UniversalFlatPageLayoutWidget<AllGraphWidgetConfigurationType>['universalConfiguration'],
+    widgetTitle: 'Deals per month',
+    flatFieldMetadataMaps,
+  });
+
+describe('validateChartFilter', () => {
+  it('should accept a valid stringified relative date on a DATE field', () => {
+    const errors = validateFilter([
+      {
+        fieldMetadataUniversalIdentifier: DATE_FIELD_UNIVERSAL_IDENTIFIER,
+        operand: ViewFilterOperand.IS_RELATIVE,
+        value: 'NEXT_30_DAY',
+      },
+    ]);
+
+    expect(errors).toHaveLength(0);
+  });
+
+  // The reported case of #23397, reachable through widget filters
+  it('should reject the object form of a relative date on a DATE field', () => {
+    const errors = validateFilter([
+      {
+        fieldMetadataUniversalIdentifier: DATE_FIELD_UNIVERSAL_IDENTIFIER,
+        operand: ViewFilterOperand.IS_RELATIVE,
+        value: JSON.stringify({
+          direction: 'NEXT',
+          amount: 30,
+          unit: 'DAY',
+        }),
+      },
+    ]);
+
+    expect(errors).toHaveLength(1);
+    expect(errors[0].message).toContain('is not valid for operand');
+    expect(errors[0].message).toContain('Deals per month');
+    expect(errors[0].message).toContain('NEXT_30_DAY');
+  });
+
+  it('should reject an operand that is not supported by the field type', () => {
+    const errors = validateFilter([
+      {
+        fieldMetadataUniversalIdentifier: DATE_FIELD_UNIVERSAL_IDENTIFIER,
+        operand: ViewFilterOperand.VECTOR_SEARCH,
+        value: 'anything',
+      },
+    ]);
+
+    expect(errors).toHaveLength(1);
+    expect(errors[0].message).toContain('is not supported on field type');
+  });
+
+  it('should reject an operand that is not a known operand at all', () => {
+    const errors = validateFilter([
+      {
+        fieldMetadataUniversalIdentifier: DATE_FIELD_UNIVERSAL_IDENTIFIER,
+        operand: 'NOT_AN_OPERAND',
+        value: 'anything',
+      },
+    ]);
+
+    expect(errors).toHaveLength(1);
+    expect(errors[0].message).toContain('is not supported on field type');
+  });
+
+  it('should resolve the relation target field type to validate the value', () => {
+    const errors = validateFilter([
+      {
+        fieldMetadataUniversalIdentifier: RELATION_FIELD_UNIVERSAL_IDENTIFIER,
+        relationTargetFieldMetadataUniversalIdentifier:
+          DATE_FIELD_UNIVERSAL_IDENTIFIER,
+        operand: ViewFilterOperand.IS_RELATIVE,
+        value: 'not-a-relative-date',
+      },
+    ]);
+
+    expect(errors).toHaveLength(1);
+    expect(errors[0].message).toContain('DATE');
+  });
+
+  it('should report an error per invalid filter', () => {
+    const errors = validateFilter([
+      {
+        fieldMetadataUniversalIdentifier: DATE_FIELD_UNIVERSAL_IDENTIFIER,
+        operand: ViewFilterOperand.IS_RELATIVE,
+        value: 'nope',
+      },
+      {
+        fieldMetadataUniversalIdentifier: SELECT_FIELD_UNIVERSAL_IDENTIFIER,
+        operand: ViewFilterOperand.VECTOR_SEARCH,
+        value: 'nope',
+      },
+    ]);
+
+    expect(errors).toHaveLength(2);
+  });
+
+  it('should skip a filter whose field is unknown, the transpilation reports it', () => {
+    const errors = validateFilter([
+      {
+        fieldMetadataUniversalIdentifier: UNKNOWN_FIELD_UNIVERSAL_IDENTIFIER,
+        operand: ViewFilterOperand.IS,
+        value: 'anything',
+      },
+    ]);
+
+    expect(errors).toHaveLength(0);
+  });
+
+  it('should report a filter without any field reference', () => {
+    const errors = validateFilter([
+      { operand: ViewFilterOperand.IS, value: 'anything' },
+    ]);
+
+    expect(errors).toHaveLength(1);
+    expect(errors[0].message).toContain('has no field metadata');
+  });
+
+  it('should accept a configuration without any filter', () => {
+    const errors = validateChartFilter({
+      graphUniversalConfiguration: {
+        configurationType: WidgetConfigurationType.BAR_CHART,
+      } as unknown as UniversalFlatPageLayoutWidget<AllGraphWidgetConfigurationType>['universalConfiguration'],
+      widgetTitle: 'Deals per month',
+      flatFieldMetadataMaps,
+    });
+
+    expect(errors).toHaveLength(0);
+  });
+});

--- a/packages/twenty-server/src/engine/metadata-modules/flat-page-layout-widget/validators/utils/validate-chart-filter.util.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/flat-page-layout-widget/validators/utils/validate-chart-filter.util.ts
@@ -1,0 +1,160 @@
+import { msg, t } from '@lingui/core/macro';
+import { isNonEmptyString } from '@sniptt/guards';
+import {
+  FieldMetadataType,
+  type FilterableAndTSVectorFieldType,
+  type UniversalChartFilter,
+  type ViewFilterOperand,
+} from 'twenty-shared/types';
+import {
+  FILTER_OPERANDS_MAP,
+  getFilterOperandsForFilterableFieldType,
+  getFilterValueValidationIssue,
+  isDefined,
+} from 'twenty-shared/utils';
+
+import { type MetadataFlatEntityMaps } from 'src/engine/metadata-modules/flat-entity/types/metadata-flat-entity-maps.type';
+import { findFlatEntityByUniversalIdentifier } from 'src/engine/metadata-modules/flat-entity/utils/find-flat-entity-by-universal-identifier.util';
+import { type FlatPageLayoutWidgetValidationError } from 'src/engine/metadata-modules/flat-page-layout-widget/types/flat-page-layout-widget-validation-error.type';
+import { type AllGraphWidgetConfigurationType } from 'src/engine/metadata-modules/page-layout-widget/enums/widget-configuration-type.type';
+import { PageLayoutWidgetExceptionCode } from 'src/engine/metadata-modules/page-layout-widget/exceptions/page-layout-widget.exception';
+import { type UniversalFlatPageLayoutWidget } from 'src/engine/workspace-manager/workspace-migration/universal-flat-entity/types/universal-flat-page-layout-widget.type';
+
+type UniversalChartRecordFilter = NonNullable<
+  UniversalChartFilter['recordFilters']
+>[number];
+
+const getEffectiveFieldType = ({
+  fieldType,
+  relationTargetFieldType,
+}: {
+  fieldType: FieldMetadataType;
+  relationTargetFieldType: FieldMetadataType | undefined;
+}): FieldMetadataType =>
+  fieldType === FieldMetadataType.RELATION && isDefined(relationTargetFieldType)
+    ? relationTargetFieldType
+    : fieldType;
+
+const validateChartRecordFilter = ({
+  recordFilter,
+  widgetTitle,
+  flatFieldMetadataMaps,
+}: {
+  recordFilter: UniversalChartRecordFilter;
+  widgetTitle: string;
+  flatFieldMetadataMaps: MetadataFlatEntityMaps<'fieldMetadata'>;
+}): FlatPageLayoutWidgetValidationError[] => {
+  const {
+    fieldMetadataUniversalIdentifier,
+    relationTargetFieldMetadataUniversalIdentifier,
+    operand: rawOperand,
+    subFieldName,
+    value,
+  } = recordFilter;
+
+  if (!isDefined(fieldMetadataUniversalIdentifier)) {
+    return [
+      {
+        code: PageLayoutWidgetExceptionCode.INVALID_PAGE_LAYOUT_WIDGET_DATA,
+        message: t`A chart filter of widget "${widgetTitle}" has no field metadata universal identifier`,
+        userFriendlyMessage: msg`A chart filter has no field`,
+      },
+    ];
+  }
+
+  const filterField = findFlatEntityByUniversalIdentifier({
+    flatEntityMaps: flatFieldMetadataMaps,
+    universalIdentifier: fieldMetadataUniversalIdentifier,
+  });
+
+  // A missing field is already reported when the action is transpiled
+  if (!isDefined(filterField)) {
+    return [];
+  }
+
+  const relationTargetField = isDefined(
+    relationTargetFieldMetadataUniversalIdentifier,
+  )
+    ? findFlatEntityByUniversalIdentifier({
+        flatEntityMaps: flatFieldMetadataMaps,
+        universalIdentifier: relationTargetFieldMetadataUniversalIdentifier,
+      })
+    : undefined;
+
+  const effectiveFieldType = getEffectiveFieldType({
+    fieldType: filterField.type,
+    relationTargetFieldType: relationTargetField?.type,
+  });
+
+  if (!(effectiveFieldType in FILTER_OPERANDS_MAP)) {
+    return [];
+  }
+
+  const allowedOperands = getFilterOperandsForFilterableFieldType({
+    filterType: effectiveFieldType as FilterableAndTSVectorFieldType,
+    subFieldName,
+  });
+
+  const operand = rawOperand as ViewFilterOperand;
+
+  if (!allowedOperands.includes(operand)) {
+    const allowedOperandsText = allowedOperands.join(', ');
+
+    return [
+      {
+        code: PageLayoutWidgetExceptionCode.INVALID_PAGE_LAYOUT_WIDGET_DATA,
+        message: t`Operand "${rawOperand}" of a chart filter of widget "${widgetTitle}" is not supported on field type "${effectiveFieldType}". Supported operands: ${allowedOperandsText}.`,
+        userFriendlyMessage: msg`Chart filter operand is not supported for this field type`,
+        value: rawOperand,
+      },
+    ];
+  }
+
+  const issue = getFilterValueValidationIssue({
+    fieldType: effectiveFieldType,
+    operand,
+    subFieldName,
+    value,
+  });
+
+  if (!isDefined(issue)) {
+    return [];
+  }
+
+  const { stringifiedValue, filterType, hint } = issue;
+
+  return [
+    {
+      code: PageLayoutWidgetExceptionCode.INVALID_PAGE_LAYOUT_WIDGET_DATA,
+      message: isNonEmptyString(hint)
+        ? t`Value "${stringifiedValue}" of a chart filter of widget "${widgetTitle}" is not valid for operand "${operand}" on field type "${filterType}". ${hint}`
+        : t`Value "${stringifiedValue}" of a chart filter of widget "${widgetTitle}" is not valid for operand "${operand}" on field type "${filterType}".`,
+      userFriendlyMessage: msg`Chart filter value is not valid for this operand`,
+      value,
+    },
+  ];
+};
+
+export const validateChartFilter = ({
+  graphUniversalConfiguration,
+  widgetTitle,
+  flatFieldMetadataMaps,
+}: {
+  graphUniversalConfiguration: UniversalFlatPageLayoutWidget<AllGraphWidgetConfigurationType>['universalConfiguration'];
+  widgetTitle: string;
+  flatFieldMetadataMaps: MetadataFlatEntityMaps<'fieldMetadata'>;
+}): FlatPageLayoutWidgetValidationError[] => {
+  const recordFilters = graphUniversalConfiguration.filter?.recordFilters;
+
+  if (!isDefined(recordFilters)) {
+    return [];
+  }
+
+  return recordFilters.flatMap((recordFilter) =>
+    validateChartRecordFilter({
+      recordFilter,
+      widgetTitle,
+      flatFieldMetadataMaps,
+    }),
+  );
+};

--- a/packages/twenty-server/src/engine/metadata-modules/flat-page-layout-widget/validators/utils/validate-chart-filter.util.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/flat-page-layout-widget/validators/utils/validate-chart-filter.util.ts
@@ -4,7 +4,6 @@ import {
   FieldMetadataType,
   type FilterableAndTSVectorFieldType,
   type UniversalChartFilter,
-  type ViewFilterOperand,
 } from 'twenty-shared/types';
 import {
   FILTER_OPERANDS_MAP,
@@ -16,13 +15,16 @@ import {
 import { type MetadataFlatEntityMaps } from 'src/engine/metadata-modules/flat-entity/types/metadata-flat-entity-maps.type';
 import { findFlatEntityByUniversalIdentifier } from 'src/engine/metadata-modules/flat-entity/utils/find-flat-entity-by-universal-identifier.util';
 import { type FlatPageLayoutWidgetValidationError } from 'src/engine/metadata-modules/flat-page-layout-widget/types/flat-page-layout-widget-validation-error.type';
-import { type AllGraphWidgetConfigurationType } from 'src/engine/metadata-modules/page-layout-widget/enums/widget-configuration-type.type';
 import { PageLayoutWidgetExceptionCode } from 'src/engine/metadata-modules/page-layout-widget/exceptions/page-layout-widget.exception';
-import { type UniversalFlatPageLayoutWidget } from 'src/engine/workspace-manager/workspace-migration/universal-flat-entity/types/universal-flat-page-layout-widget.type';
 
 type UniversalChartRecordFilter = NonNullable<
   UniversalChartFilter['recordFilters']
 >[number];
+
+const isFilterableFieldType = (
+  fieldType: FieldMetadataType,
+): fieldType is FilterableAndTSVectorFieldType =>
+  fieldType in FILTER_OPERANDS_MAP;
 
 const getEffectiveFieldType = ({
   fieldType,
@@ -86,18 +88,20 @@ const validateChartRecordFilter = ({
     relationTargetFieldType: relationTargetField?.type,
   });
 
-  if (!(effectiveFieldType in FILTER_OPERANDS_MAP)) {
+  if (!isFilterableFieldType(effectiveFieldType)) {
     return [];
   }
 
   const allowedOperands = getFilterOperandsForFilterableFieldType({
-    filterType: effectiveFieldType as FilterableAndTSVectorFieldType,
+    filterType: effectiveFieldType,
     subFieldName,
   });
 
-  const operand = rawOperand as ViewFilterOperand;
+  const operand = allowedOperands.find(
+    (allowedOperand) => allowedOperand === rawOperand,
+  );
 
-  if (!allowedOperands.includes(operand)) {
+  if (!isDefined(operand)) {
     const allowedOperandsText = allowedOperands.join(', ');
 
     return [
@@ -136,15 +140,15 @@ const validateChartRecordFilter = ({
 };
 
 export const validateChartFilter = ({
-  graphUniversalConfiguration,
+  filter,
   widgetTitle,
   flatFieldMetadataMaps,
 }: {
-  graphUniversalConfiguration: UniversalFlatPageLayoutWidget<AllGraphWidgetConfigurationType>['universalConfiguration'];
+  filter: UniversalChartFilter | undefined;
   widgetTitle: string;
   flatFieldMetadataMaps: MetadataFlatEntityMaps<'fieldMetadata'>;
 }): FlatPageLayoutWidgetValidationError[] => {
-  const recordFilters = graphUniversalConfiguration.filter?.recordFilters;
+  const recordFilters = filter?.recordFilters;
 
   if (!isDefined(recordFilters)) {
     return [];

--- a/packages/twenty-server/src/engine/metadata-modules/flat-page-layout-widget/validators/utils/validate-chart-filter.util.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/flat-page-layout-widget/validators/utils/validate-chart-filter.util.ts
@@ -2,29 +2,24 @@ import { msg, t } from '@lingui/core/macro';
 import { isNonEmptyString } from '@sniptt/guards';
 import {
   FieldMetadataType,
-  type FilterableAndTSVectorFieldType,
   type UniversalChartFilter,
 } from 'twenty-shared/types';
 import {
   FILTER_OPERANDS_MAP,
   getFilterOperandsForFilterableFieldType,
+  getFilterTypeFromFieldType,
   getFilterValueValidationIssue,
   isDefined,
 } from 'twenty-shared/utils';
 
-import { type MetadataFlatEntityMaps } from 'src/engine/metadata-modules/flat-entity/types/metadata-flat-entity-maps.type';
 import { findFlatEntityByUniversalIdentifier } from 'src/engine/metadata-modules/flat-entity/utils/find-flat-entity-by-universal-identifier.util';
 import { type FlatPageLayoutWidgetValidationError } from 'src/engine/metadata-modules/flat-page-layout-widget/types/flat-page-layout-widget-validation-error.type';
+import { type MetadataUniversalFlatEntityMaps } from 'src/engine/workspace-manager/workspace-migration/universal-flat-entity/types/metadata-universal-flat-entity-maps.type';
 import { PageLayoutWidgetExceptionCode } from 'src/engine/metadata-modules/page-layout-widget/exceptions/page-layout-widget.exception';
 
 type UniversalChartRecordFilter = NonNullable<
   UniversalChartFilter['recordFilters']
 >[number];
-
-const isFilterableFieldType = (
-  fieldType: FieldMetadataType,
-): fieldType is FilterableAndTSVectorFieldType =>
-  fieldType in FILTER_OPERANDS_MAP;
 
 const getEffectiveFieldType = ({
   fieldType,
@@ -44,7 +39,7 @@ const validateChartRecordFilter = ({
 }: {
   recordFilter: UniversalChartRecordFilter;
   widgetTitle: string;
-  flatFieldMetadataMaps: MetadataFlatEntityMaps<'fieldMetadata'>;
+  flatFieldMetadataMaps: MetadataUniversalFlatEntityMaps<'fieldMetadata'>;
 }): FlatPageLayoutWidgetValidationError[] => {
   const {
     fieldMetadataUniversalIdentifier,
@@ -88,12 +83,12 @@ const validateChartRecordFilter = ({
     relationTargetFieldType: relationTargetField?.type,
   });
 
-  if (!isFilterableFieldType(effectiveFieldType)) {
+  if (!(effectiveFieldType in FILTER_OPERANDS_MAP)) {
     return [];
   }
 
   const allowedOperands = getFilterOperandsForFilterableFieldType({
-    filterType: effectiveFieldType,
+    filterType: getFilterTypeFromFieldType(effectiveFieldType),
     subFieldName,
   });
 
@@ -146,7 +141,7 @@ export const validateChartFilter = ({
 }: {
   filter: UniversalChartFilter | undefined;
   widgetTitle: string;
-  flatFieldMetadataMaps: MetadataFlatEntityMaps<'fieldMetadata'>;
+  flatFieldMetadataMaps: MetadataUniversalFlatEntityMaps<'fieldMetadata'>;
 }): FlatPageLayoutWidgetValidationError[] => {
   const recordFilters = filter?.recordFilters;
 

--- a/packages/twenty-server/src/engine/metadata-modules/flat-page-layout-widget/validators/utils/validate-chart-filter.util.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/flat-page-layout-widget/validators/utils/validate-chart-filter.util.ts
@@ -1,11 +1,7 @@
 import { msg, t } from '@lingui/core/macro';
 import { isNonEmptyString } from '@sniptt/guards';
+import { type UniversalChartFilter } from 'twenty-shared/types';
 import {
-  FieldMetadataType,
-  type UniversalChartFilter,
-} from 'twenty-shared/types';
-import {
-  FILTER_OPERANDS_MAP,
   getFilterOperandsForFilterableFieldType,
   getFilterTypeFromFieldType,
   getFilterValueValidationIssue,
@@ -13,6 +9,7 @@ import {
 } from 'twenty-shared/utils';
 
 import { findFlatEntityByUniversalIdentifier } from 'src/engine/metadata-modules/flat-entity/utils/find-flat-entity-by-universal-identifier.util';
+import { getEffectiveFilterFieldType } from 'src/engine/metadata-modules/flat-field-metadata/utils/get-effective-filter-field-type.util';
 import { type FlatPageLayoutWidgetValidationError } from 'src/engine/metadata-modules/flat-page-layout-widget/types/flat-page-layout-widget-validation-error.type';
 import { type MetadataUniversalFlatEntityMaps } from 'src/engine/workspace-manager/workspace-migration/universal-flat-entity/types/metadata-universal-flat-entity-maps.type';
 import { PageLayoutWidgetExceptionCode } from 'src/engine/metadata-modules/page-layout-widget/exceptions/page-layout-widget.exception';
@@ -20,17 +17,6 @@ import { PageLayoutWidgetExceptionCode } from 'src/engine/metadata-modules/page-
 type UniversalChartRecordFilter = NonNullable<
   UniversalChartFilter['recordFilters']
 >[number];
-
-const getEffectiveFieldType = ({
-  fieldType,
-  relationTargetFieldType,
-}: {
-  fieldType: FieldMetadataType;
-  relationTargetFieldType: FieldMetadataType | undefined;
-}): FieldMetadataType =>
-  fieldType === FieldMetadataType.RELATION && isDefined(relationTargetFieldType)
-    ? relationTargetFieldType
-    : fieldType;
 
 const validateChartRecordFilter = ({
   recordFilter,
@@ -78,14 +64,10 @@ const validateChartRecordFilter = ({
       })
     : undefined;
 
-  const effectiveFieldType = getEffectiveFieldType({
+  const effectiveFieldType = getEffectiveFilterFieldType({
     fieldType: filterField.type,
     relationTargetFieldType: relationTargetField?.type,
   });
-
-  if (!(effectiveFieldType in FILTER_OPERANDS_MAP)) {
-    return [];
-  }
 
   const allowedOperands = getFilterOperandsForFilterableFieldType({
     filterType: getFilterTypeFromFieldType(effectiveFieldType),

--- a/packages/twenty-server/src/engine/metadata-modules/flat-page-layout-widget/validators/utils/validate-graph-flat-page-layout-widget-for-creation.util.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/flat-page-layout-widget/validators/utils/validate-graph-flat-page-layout-widget-for-creation.util.ts
@@ -4,6 +4,7 @@ import { isDefined } from 'twenty-shared/utils';
 import { type ValidateFlatPageLayoutWidgetTypeSpecificitiesForCreationArgs } from 'src/engine/metadata-modules/flat-page-layout-widget/services/flat-page-layout-widget-type-validator.service';
 import { type FlatPageLayoutWidgetValidationError } from 'src/engine/metadata-modules/flat-page-layout-widget/types/flat-page-layout-widget-validation-error.type';
 import { validateBaseGraphFields } from 'src/engine/metadata-modules/flat-page-layout-widget/validators/utils/validate-base-graph-fields.util';
+import { validateChartFilter } from 'src/engine/metadata-modules/flat-page-layout-widget/validators/utils/validate-chart-filter.util';
 import { validateGraphConfigurationByType } from 'src/engine/metadata-modules/flat-page-layout-widget/validators/utils/validate-graph-configuration-by-type.util';
 import { validateGraphConfigurationType } from 'src/engine/metadata-modules/flat-page-layout-widget/validators/utils/validate-graph-configuration-type.util';
 import { PageLayoutWidgetExceptionCode } from 'src/engine/metadata-modules/page-layout-widget/exceptions/page-layout-widget.exception';
@@ -11,7 +12,10 @@ import { PageLayoutWidgetExceptionCode } from 'src/engine/metadata-modules/page-
 export const validateGraphFlatPageLayoutWidgetForCreation = (
   args: ValidateFlatPageLayoutWidgetTypeSpecificitiesForCreationArgs,
 ): FlatPageLayoutWidgetValidationError[] => {
-  const { flatEntityToValidate } = args;
+  const {
+    flatEntityToValidate,
+    optimisticFlatEntityMapsAndRelatedFlatEntityMaps,
+  } = args;
   const { universalConfiguration, title: widgetTitle } = flatEntityToValidate;
   const errors: FlatPageLayoutWidgetValidationError[] = [];
 
@@ -49,6 +53,15 @@ export const validateGraphFlatPageLayoutWidgetForCreation = (
   });
 
   errors.push(...typeSpecificErrors);
+
+  const chartFilterErrors = validateChartFilter({
+    graphUniversalConfiguration,
+    widgetTitle,
+    flatFieldMetadataMaps:
+      optimisticFlatEntityMapsAndRelatedFlatEntityMaps.flatFieldMetadataMaps,
+  });
+
+  errors.push(...chartFilterErrors);
 
   return errors;
 };

--- a/packages/twenty-server/src/engine/metadata-modules/flat-page-layout-widget/validators/utils/validate-graph-flat-page-layout-widget-for-creation.util.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/flat-page-layout-widget/validators/utils/validate-graph-flat-page-layout-widget-for-creation.util.ts
@@ -55,7 +55,7 @@ export const validateGraphFlatPageLayoutWidgetForCreation = (
   errors.push(...typeSpecificErrors);
 
   const chartFilterErrors = validateChartFilter({
-    graphUniversalConfiguration,
+    filter: graphUniversalConfiguration.filter,
     widgetTitle,
     flatFieldMetadataMaps:
       optimisticFlatEntityMapsAndRelatedFlatEntityMaps.flatFieldMetadataMaps,

--- a/packages/twenty-server/src/engine/metadata-modules/flat-page-layout-widget/validators/utils/validate-graph-flat-page-layout-widget-for-update.util.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/flat-page-layout-widget/validators/utils/validate-graph-flat-page-layout-widget-for-update.util.ts
@@ -3,13 +3,17 @@ import { isDefined } from 'twenty-shared/utils';
 import { type ValidateFlatPageLayoutWidgetTypeSpecificitiesForUpdateArgs } from 'src/engine/metadata-modules/flat-page-layout-widget/services/flat-page-layout-widget-type-validator.service';
 import { type FlatPageLayoutWidgetValidationError } from 'src/engine/metadata-modules/flat-page-layout-widget/types/flat-page-layout-widget-validation-error.type';
 import { validateBaseGraphFields } from 'src/engine/metadata-modules/flat-page-layout-widget/validators/utils/validate-base-graph-fields.util';
+import { validateChartFilter } from 'src/engine/metadata-modules/flat-page-layout-widget/validators/utils/validate-chart-filter.util';
 import { validateGraphConfigurationByType } from 'src/engine/metadata-modules/flat-page-layout-widget/validators/utils/validate-graph-configuration-by-type.util';
 import { validateGraphConfigurationType } from 'src/engine/metadata-modules/flat-page-layout-widget/validators/utils/validate-graph-configuration-type.util';
 
 export const validateGraphFlatPageLayoutWidgetForUpdate = (
   args: ValidateFlatPageLayoutWidgetTypeSpecificitiesForUpdateArgs,
 ): FlatPageLayoutWidgetValidationError[] => {
-  const { flatEntityToValidate } = args;
+  const {
+    flatEntityToValidate,
+    optimisticFlatEntityMapsAndRelatedFlatEntityMaps,
+  } = args;
   const { universalConfiguration, title: widgetTitle } = flatEntityToValidate;
   const errors: FlatPageLayoutWidgetValidationError[] = [];
 
@@ -40,6 +44,15 @@ export const validateGraphFlatPageLayoutWidgetForUpdate = (
   });
 
   errors.push(...typeSpecificErrors);
+
+  const chartFilterErrors = validateChartFilter({
+    graphUniversalConfiguration,
+    widgetTitle,
+    flatFieldMetadataMaps:
+      optimisticFlatEntityMapsAndRelatedFlatEntityMaps.flatFieldMetadataMaps,
+  });
+
+  errors.push(...chartFilterErrors);
 
   return errors;
 };

--- a/packages/twenty-server/src/engine/metadata-modules/flat-page-layout-widget/validators/utils/validate-graph-flat-page-layout-widget-for-update.util.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/flat-page-layout-widget/validators/utils/validate-graph-flat-page-layout-widget-for-update.util.ts
@@ -46,7 +46,7 @@ export const validateGraphFlatPageLayoutWidgetForUpdate = (
   errors.push(...typeSpecificErrors);
 
   const chartFilterErrors = validateChartFilter({
-    graphUniversalConfiguration,
+    filter: graphUniversalConfiguration.filter,
     widgetTitle,
     flatFieldMetadataMaps:
       optimisticFlatEntityMapsAndRelatedFlatEntityMaps.flatFieldMetadataMaps,

--- a/packages/twenty-server/src/engine/workspace-manager/workspace-migration/workspace-migration-builder/validators/services/__tests__/flat-view-filter-validator.service.spec.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/workspace-migration/workspace-migration-builder/validators/services/__tests__/flat-view-filter-validator.service.spec.ts
@@ -124,6 +124,36 @@ describe('FlatViewFilterValidatorService', () => {
 
       expect(result.errors).toEqual([]);
     });
+
+    it('should reject an unsupported operand on a MORPH_RELATION field', () => {
+      const result = service.validateFlatViewFilterCreation(
+        buildCreationArgs({
+          fieldType: FieldMetadataType.MORPH_RELATION,
+          operand: ViewFilterOperand.IS_RELATIVE,
+          value: 'NEXT_30_DAY',
+        }),
+      );
+
+      expect(result.errors).toHaveLength(1);
+      expect(result.errors[0].message).toContain(
+        'is not supported on field type',
+      );
+    });
+
+    it('should reject an unsupported operand on a RICH_TEXT field', () => {
+      const result = service.validateFlatViewFilterCreation(
+        buildCreationArgs({
+          fieldType: FieldMetadataType.RICH_TEXT,
+          operand: ViewFilterOperand.IS_RELATIVE,
+          value: 'NEXT_30_DAY',
+        }),
+      );
+
+      expect(result.errors).toHaveLength(1);
+      expect(result.errors[0].message).toContain(
+        'is not supported on field type',
+      );
+    });
   });
 
   describe('value validation on update', () => {

--- a/packages/twenty-server/src/engine/workspace-manager/workspace-migration/workspace-migration-builder/validators/services/flat-view-filter-validator.service.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/workspace-migration/workspace-migration-builder/validators/services/flat-view-filter-validator.service.ts
@@ -3,19 +3,16 @@ import { Injectable } from '@nestjs/common';
 import { msg, t } from '@lingui/core/macro';
 import { isNonEmptyString } from '@sniptt/guards';
 import { ALL_METADATA_NAME } from 'twenty-shared/metadata';
+import { FieldMetadataType, type ViewFilterOperand } from 'twenty-shared/types';
 import {
-  FieldMetadataType,
-  type FilterableAndTSVectorFieldType,
-  type ViewFilterOperand,
-} from 'twenty-shared/types';
-import {
-  FILTER_OPERANDS_MAP,
   getFilterOperandsForFilterableFieldType,
+  getFilterTypeFromFieldType,
   getFilterValueValidationIssue,
   isDefined,
 } from 'twenty-shared/utils';
 
 import { findFlatEntityByUniversalIdentifier } from 'src/engine/metadata-modules/flat-entity/utils/find-flat-entity-by-universal-identifier.util';
+import { getEffectiveFilterFieldType } from 'src/engine/metadata-modules/flat-field-metadata/utils/get-effective-filter-field-type.util';
 import { type FlatFieldMetadata } from 'src/engine/metadata-modules/flat-field-metadata/types/flat-field-metadata.type';
 import { getInvalidSelectFilterOptionValues } from 'src/engine/metadata-modules/flat-field-metadata/utils/get-invalid-select-filter-option-values.util';
 import { ViewFilterExceptionCode } from 'src/engine/metadata-modules/view-filter/exceptions/view-filter.exception';
@@ -401,7 +398,7 @@ export class FlatViewFilterValidatorService {
     value: ViewFilterValue;
   }) {
     const issue = getFilterValueValidationIssue({
-      fieldType: this.getEffectiveFieldType({
+      fieldType: getEffectiveFilterFieldType({
         fieldType,
         relationTargetFieldType,
       }),
@@ -425,19 +422,6 @@ export class FlatViewFilterValidatorService {
     };
   }
 
-  private getEffectiveFieldType({
-    fieldType,
-    relationTargetFieldType,
-  }: {
-    fieldType: FieldMetadataType;
-    relationTargetFieldType: FieldMetadataType | undefined;
-  }) {
-    return fieldType === FieldMetadataType.RELATION &&
-      isDefined(relationTargetFieldType)
-      ? relationTargetFieldType
-      : fieldType;
-  }
-
   private getIncompatibleOperandError({
     operand,
     fieldType,
@@ -449,17 +433,15 @@ export class FlatViewFilterValidatorService {
     subFieldName: string | null | undefined;
     relationTargetFieldType: FieldMetadataType | undefined;
   }) {
-    const effectiveFieldType = this.getEffectiveFieldType({
+    const effectiveFieldType = getEffectiveFilterFieldType({
       fieldType,
       relationTargetFieldType,
     });
 
-    if (!(effectiveFieldType in FILTER_OPERANDS_MAP)) {
-      return undefined;
-    }
+    const filterType = getFilterTypeFromFieldType(effectiveFieldType);
 
     const allowedOperands = getFilterOperandsForFilterableFieldType({
-      filterType: effectiveFieldType as FilterableAndTSVectorFieldType,
+      filterType,
       subFieldName,
     });
 
@@ -469,7 +451,7 @@ export class FlatViewFilterValidatorService {
 
     return {
       code: ViewFilterExceptionCode.INVALID_VIEW_FILTER_DATA,
-      message: t`Operand "${operand}" is not supported on field type "${effectiveFieldType}". Supported operands: ${allowedOperands.join(', ')}.`,
+      message: t`Operand "${operand}" is not supported on field type "${filterType}". Supported operands: ${allowedOperands.join(', ')}.`,
       userFriendlyMessage: msg`Filter operand is not supported for this field type`,
     };
   }

--- a/packages/twenty-server/test/integration/metadata/suites/page-layout/failing-page-layout-with-tabs-update.integration-spec.ts
+++ b/packages/twenty-server/test/integration/metadata/suites/page-layout/failing-page-layout-with-tabs-update.integration-spec.ts
@@ -11,7 +11,11 @@ import {
 import { createOnePageLayout } from 'test/integration/metadata/suites/page-layout/utils/create-one-page-layout.util';
 import { destroyOnePageLayout } from 'test/integration/metadata/suites/page-layout/utils/destroy-one-page-layout.util';
 import { updateOnePageLayoutWithTabsAndWidgets } from 'test/integration/metadata/suites/page-layout/utils/update-one-page-layout-with-tabs-and-widgets.util';
-import { AggregateOperations, FieldMetadataType } from 'twenty-shared/types';
+import {
+  AggregateOperations,
+  FieldMetadataType,
+  ViewFilterOperand,
+} from 'twenty-shared/types';
 import { isDefined } from 'twenty-shared/utils';
 import { v4 } from 'uuid';
 
@@ -166,7 +170,7 @@ describe('Page layout with tabs update should fail', () => {
           recordFilters: [
             {
               fieldMetadataId: testFilterFieldMetadataId,
-              operand: 'contains',
+              operand: ViewFilterOperand.CONTAINS,
               value: 'acme',
             },
           ],


### PR DESCRIPTION
## Context

Fixes #23872.

#23848 made `ViewFilterManifest.value` fail the sync when the runtime cannot parse it. Chart filters carried by `PageLayoutWidgetManifest.configuration` were left out, so the bug from #23397 is still reachable one layer down: a dashboard chart whose filter value is malformed deploys cleanly and renders empty, with nothing reported at build, sync or runtime.

The widget filter type is also looser than the view filter one, `ChartRecordFilter.operand` is a plain `string` rather than `ViewFilterOperand`, so an operand that the field type does not support passes through as well.

## Changes

- `validateChartFilter` resolves each `recordFilters` entry's field through `flatFieldMetadataMaps`, follows `relationTargetFieldMetadataUniversalIdentifier` to get the effective field type, then rejects an operand the field type does not allow and delegates the value check to `getFilterValueValidationIssue` from #23848. No new contract, the schemas and hints are the ones the view filter path already uses.
- The relation hop is extracted into `getEffectiveFilterFieldType`, shared with `FlatViewFilterValidatorService`, and hops on `MORPH_RELATION` as well as `RELATION`.
- Review caught that gating on `effectiveFieldType in FILTER_OPERANDS_MAP` silently skipped `MORPH_RELATION` and `RICH_TEXT` filters, since the map is keyed by filter type, not by `FieldMetadataType`. Both this util and the view filter validator (which had the same gate since #23848) now convert through `getFilterTypeFromFieldType` and validate every field type.
- Called from `validateGraphFlatPageLayoutWidgetForCreation` and `ForUpdate`, next to `validateBaseGraphFields`, so both paths are covered. Only chart configurations carry filters, hence the graph validators rather than the generic dispatch.
- `pageLayoutWidget` now declares `fieldMetadata: true` in `ALL_METADATA_REQUIRED_METADATA_FOR_VALIDATION`, which is what puts `flatFieldMetadataMaps` in the validation args. `viewFilter` already declares it for the same reason.
- A filter whose field cannot be resolved is left alone rather than double reported, the action transpilation already fails on it.

## Test

Unit spec covers a valid relative date, the reported object form, an operand unsupported by the field type, an unknown operand, the relation target hop on both relation types, `MORPH_RELATION` and `RICH_TEXT` filters being validated rather than skipped, several invalid filters at once, an unresolved field, a filter with no field and a configuration with no filter. The view filter validator spec gains the same two field type cases.

Verified end to end on a local server with an app declaring a `BAR_CHART` widget whose filter is the reported case:

```
Sync failed with 1 error
pageLayoutWidget: 1 error
  1. INVALID_PAGE_LAYOUT_WIDGET_DATA: Value "{"direction":"NEXT","amount":30,"unit":"DAY"}" of a chart
     filter of widget "Amount per close date" is not valid for operand "IS_RELATIVE" on field type
     "DATE". Expected a stringified relative date such as "NEXT_30_DAY".
```

Nothing is persisted, and the same widget with `NEXT_30_DAY` installs with the filter value stored.

## Note

`ChartRecordFilter.operand` being `string` is the underlying looseness here. Typing it as `ViewFilterOperand` would make the operand check unnecessary, but it is a shared type with frontend fallout, so it is worth its own change.
