### PR TITLE
Add Petbee CRM model provisioner (Pet, Assinatura, campos de tutor)

### DIFF
--- a/petbee/README.md
+++ b/petbee/README.md
@@ -1,0 +1,103 @@
+# CRM Petbee sobre o Twenty
+
+Esta pasta contém as customizações da Petbee para o Twenty. Ela fica fora de
+`packages/` de propósito: o código do Twenty segue intocado, então sincronizar
+este fork com o repositório oficial (`twentyhq/twenty`) nunca gera conflito.
+
+## O modelo de dados
+
+```mermaid
+erDiagram
+    TUTOR ||--o{ PET : "tem"
+    PET ||--o{ ASSINATURA : "possui"
+    TUTOR ||--o{ ASSINATURA : "é titular de"
+
+    TUTOR {
+        string nome
+        string emails
+        string telefones
+        string cpf
+        select statusCliente "Lead / Cliente ativo / Inativo / Ex-cliente"
+        select canalPreferido "WhatsApp / E-mail / Telefone"
+    }
+    PET {
+        string nome
+        select especie "Cachorro / Gato / Ave / Roedor / Outro"
+        string raca
+        select sexo
+        select porte
+        date dataNascimento
+        number pesoKg
+        boolean castrado
+        string microchip
+    }
+    ASSINATURA {
+        select plano "Essencial / Completo / Premium"
+        select status "Ativa / Inadimplente / Pausada / Cancelada / Encerrada"
+        currency valorMensal
+        date dataInicio
+        date proximaCobranca
+        select formaPagamento "Cartão / Pix / Boleto"
+    }
+```
+
+- **Tutor** — por padrão é o objeto **Person** do Twenty (recomendado: ele já
+  tem e-mails, telefones, timeline, notas, tarefas e integração com
+  Gmail/Calendar). Se você já criou um objeto customizado chamado `tutor` pela
+  interface, o script detecta e usa ele automaticamente.
+- **Pet** — objeto customizado, com relação *muitos pets → um tutor*.
+- **Assinatura** — objeto customizado ligado ao **pet** (qual pet o plano
+  cobre) e ao **titular** (quem paga). Manter as assinaturas como objeto
+  separado (em vez de um campo "plano ativo" no pet) preserva o histórico:
+  cancelamentos, upgrades e reativações viram registros.
+
+Com isso dá para segmentar comunicação com precisão, por exemplo: *tutores
+com assinatura Ativa e pet da espécie Cachorro*, ou *leads com pet idoso sem
+plano* — tudo com filtros e views salvas, sem código.
+
+## Como rodar o provisionador
+
+1. Na sua instância do Twenty, gere uma API key: **Settings → APIs & Webhooks**.
+2. Rode (Node 18+, sem dependências):
+
+```bash
+# Contra a instância local
+TWENTY_API_KEY=<sua-api-key> node petbee/provision-petbee-crm.mjs
+
+# Contra produção
+TWENTY_API_URL=https://crm.suaempresa.com.br TWENTY_API_KEY=<key> node petbee/provision-petbee-crm.mjs
+
+# Só simular, sem alterar nada
+TWENTY_API_KEY=<key> node petbee/provision-petbee-crm.mjs --dry-run
+```
+
+O script é **idempotente**: objetos e campos que já existem (pelo nome) são
+pulados, nunca duplicados nem sobrescritos. Pode rodar na instância onde você
+já criou `pet`/`tutor` à mão — ele só completa o que falta.
+
+Variáveis:
+
+| Variável | Padrão | Para quê |
+|---|---|---|
+| `TWENTY_API_URL` | `http://localhost:3000` | URL da instância |
+| `TWENTY_API_KEY` | — (obrigatória) | API key do workspace |
+| `PETBEE_TUTOR_OBJECT` | auto (`tutor` se existir, senão `person`) | Forçar qual objeto é o tutor |
+
+## Ajustes depois de rodar
+
+- **Nomes dos planos**: Essencial/Completo/Premium são exemplos — edite as
+  opções do campo *Plano* em **Settings → Data model → Assinatura**.
+- **Renomear "Person" para "Tutor"**: se quiser que a interface mostre
+  "Tutores" no menu, edite os rótulos do objeto People em
+  **Settings → Data model** (só muda o rótulo, sem afetar integrações).
+- **Views sugeridas**: crie views filtradas como "Clientes ativos"
+  (statusCliente = Cliente ativo), "Inadimplentes" (Assinaturas com status
+  Inadimplente) e um kanban de Assinaturas agrupado por status.
+
+## Por que via API e não no código?
+
+Objetos criados pela interface ou pela API de metadados ficam no banco do
+workspace — sobrevivem a upgrades do Twenty e não exigem manter um fork
+divergente. Código só será necessário para funcionalidades que a plataforma
+não oferece (ex.: integração própria de WhatsApp); nesse caso, o plano é
+manter essas adições isoladas para facilitar o sync com o upstream.

--- a/petbee/README.md
+++ b/petbee/README.md
@@ -1,103 +1,108 @@
 # CRM Petbee sobre o Twenty
 
-Esta pasta contém as customizações da Petbee para o Twenty. Ela fica fora de
+Esta pasta contém as ferramentas da Petbee para o Twenty. Ela fica fora de
 `packages/` de propósito: o código do Twenty segue intocado, então sincronizar
 este fork com o repositório oficial (`twentyhq/twenty`) nunca gera conflito.
 
-## O modelo de dados
+A instância atual roda em **https://crm.petbeetools.com.br** (Railway). O
+modelo abaixo é o retrato do que existe lá (snapshot de 2026-08-11) — e o
+script desta pasta reproduz esse modelo em qualquer instância nova (ex.: a
+futura produção).
+
+## O modelo de dados (como construído)
 
 ```mermaid
 erDiagram
-    TUTOR ||--o{ PET : "tem"
-    PET ||--o{ ASSINATURA : "possui"
-    TUTOR ||--o{ ASSINATURA : "é titular de"
+    TUTOR ||--o{ PETS : "tem"
+    PETS ||--o{ ASSINATURA : "possui"
+    PLANO ||--o{ ASSINATURA : "precifica"
+    TUTOR ||--o{ ASSINATURA : "paga"
 
-    TUTOR {
-        string nome
-        string emails
-        string telefones
-        string cpf
-        select statusCliente "Lead / Cliente ativo / Inativo / Ex-cliente"
+    TUTOR["Tutor (Person)"] {
+        fullName name
+        emails emails
+        phones phones
+        text cpf
+        select statusCliente "Lead / Ativo / Inativo"
         select canalPreferido "WhatsApp / E-mail / Telefone"
+        text humanid
+        text hIdPetbee "ID Petbee"
+        text idBitrix "ID Bitrix (migração)"
+        text utmSource
+        text utmMedium
+        text utmCampaign
     }
-    PET {
-        string nome
-        select especie "Cachorro / Gato / Ave / Roedor / Outro"
-        string raca
-        select sexo
-        select porte
-        date dataNascimento
-        number pesoKg
-        boolean castrado
-        string microchip
+    PETS {
+        text name
+        text especie
+        text raca
+        select sexo "Macho / Fêmea"
+        select porte "Pequeno / Médio / Grande / Gigante"
+        date dataDeNascimento
+        text carteirinha
+        text petIdPetbee "ID Petbee"
+    }
+    PLANO {
+        text name
+        currency valorMensal
+        boolean ativo
+        multiselect addonsInclusos "Vacinas / Checkup / Limpeza Dentária"
+        text planIdPetbee "ID Petbee"
     }
     ASSINATURA {
-        select plano "Essencial / Completo / Premium"
-        select status "Ativa / Inadimplente / Pausada / Cancelada / Encerrada"
-        currency valorMensal
+        select status "Ativa / Bloqueada / Cancelada"
+        select periodicidade "Mensal / Anual"
+        currency valorMensal "MRR"
+        number diaVencimento
         date dataInicio
-        date proximaCobranca
-        select formaPagamento "Cartão / Pix / Boleto"
+        date dataCancelamento
+        multiselect addons "extras"
+        text cupom
+        text subsIdPetbee "ID Petbee"
     }
 ```
 
-- **Tutor** — por padrão é o objeto **Person** do Twenty (recomendado: ele já
-  tem e-mails, telefones, timeline, notas, tarefas e integração com
-  Gmail/Calendar). Se você já criou um objeto customizado chamado `tutor` pela
-  interface, o script detecta e usa ele automaticamente.
-- **Pet** — objeto customizado, com relação *muitos pets → um tutor*.
-- **Assinatura** — objeto customizado ligado ao **pet** (qual pet o plano
-  cobre) e ao **titular** (quem paga). Manter as assinaturas como objeto
-  separado (em vez de um campo "plano ativo" no pet) preserva o histórico:
-  cancelamentos, upgrades e reativações viram registros.
+- **Tutor** é o objeto padrão **Person** do Twenty (com e-mails, telefones,
+  timeline, notas, tarefas e integração Gmail/Calendar), estendido com os
+  campos da Petbee.
+- **Pets** guarda os animais, ligados ao tutor.
+- **Plano** é o catálogo de planos (nome, valor, addons inclusos).
+- **Assinatura** é o coração comercial: liga tutor + pet + plano, com status,
+  periodicidade, MRR, vencimento e cupom. Histórico preservado — upgrades e
+  cancelamentos viram registros, não sobrescrevem nada.
+- Os campos **ID Petbee** (tutor/pet/plano/assinatura) ancoram sincronização
+  com o sistema da Petbee; **ID Bitrix** ancora a migração do Bitrix24 (cada
+  contato importado guarda o ID de origem — dá para reimportar sem duplicar).
 
-Com isso dá para segmentar comunicação com precisão, por exemplo: *tutores
-com assinatura Ativa e pet da espécie Cachorro*, ou *leads com pet idoso sem
-plano* — tudo com filtros e views salvas, sem código.
+> Detalhe técnico importante para scripts de migração: o objeto Pets tem
+> `nameSingular: pets` e `namePlural: petss` (sic). Na API de registros as
+> queries usam o plural — ou seja, `petss`. O provisionador reproduz isso
+> igual para manter compatibilidade entre ambientes.
 
-## Como rodar o provisionador
+## Como reprovisionar em outra instância
 
-1. Na sua instância do Twenty, gere uma API key: **Settings → APIs & Webhooks**.
+1. Na instância de destino, gere uma API key: **Settings → APIs & Webhooks**.
 2. Rode (Node 18+, sem dependências):
 
 ```bash
-# Contra a instância local
-TWENTY_API_KEY=<sua-api-key> node petbee/provision-petbee-crm.mjs
+# Simular primeiro (recomendado)
+TWENTY_API_URL=https://<instancia> TWENTY_API_KEY=<key> node petbee/provision-petbee-crm.mjs --dry-run
 
-# Contra produção
-TWENTY_API_URL=https://crm.suaempresa.com.br TWENTY_API_KEY=<key> node petbee/provision-petbee-crm.mjs
-
-# Só simular, sem alterar nada
-TWENTY_API_KEY=<key> node petbee/provision-petbee-crm.mjs --dry-run
+# Aplicar
+TWENTY_API_URL=https://<instancia> TWENTY_API_KEY=<key> node petbee/provision-petbee-crm.mjs
 ```
 
 O script é **idempotente**: objetos e campos que já existem (pelo nome) são
-pulados, nunca duplicados nem sobrescritos. Pode rodar na instância onde você
-já criou `pet`/`tutor` à mão — ele só completa o que falta.
+pulados, nunca duplicados nem sobrescritos. Rodar duas vezes não faz mal.
 
-Variáveis:
+## Melhorias sugeridas (backlog)
 
-| Variável | Padrão | Para quê |
-|---|---|---|
-| `TWENTY_API_URL` | `http://localhost:3000` | URL da instância |
-| `TWENTY_API_KEY` | — (obrigatória) | API key do workspace |
-| `PETBEE_TUTOR_OBJECT` | auto (`tutor` se existir, senão `person`) | Forçar qual objeto é o tutor |
-
-## Ajustes depois de rodar
-
-- **Nomes dos planos**: Essencial/Completo/Premium são exemplos — edite as
-  opções do campo *Plano* em **Settings → Data model → Assinatura**.
-- **Renomear "Person" para "Tutor"**: se quiser que a interface mostre
-  "Tutores" no menu, edite os rótulos do objeto People em
-  **Settings → Data model** (só muda o rótulo, sem afetar integrações).
-- **Views sugeridas**: crie views filtradas como "Clientes ativos"
-  (statusCliente = Cliente ativo), "Inadimplentes" (Assinaturas com status
-  Inadimplente) e um kanban de Assinaturas agrupado por status.
-
-## Por que via API e não no código?
-
-Objetos criados pela interface ou pela API de metadados ficam no banco do
-workspace — sobrevivem a upgrades do Twenty e não exigem manter um fork
-divergente. Código só será necessário para funcionalidades que a plataforma
-não oferece (ex.: integração própria de WhatsApp); nesse caso, o plano é
-manter essas adições isoladas para facilitar o sync com o upstream.
+- **Espécie como seleção**: hoje `especie` é texto livre em Pets — como
+  seleção (Cachorro/Gato/…) os filtros e a segmentação ficam mais confiáveis.
+  Requer migrar os valores já digitados; fazer quando a base ainda é pequena.
+- **Views salvas**: "Clientes ativos" (statusCliente = Ativo), "Assinaturas
+  bloqueadas", kanban de Assinaturas por status, "Leads sem pet cadastrado".
+- **Workflows**: ex. quando Assinatura muda para Bloqueada → criar tarefa de
+  cobrança para o time.
+- **Migração Bitrix**: exportar contatos/negócios do Bitrix24 e importar
+  preenchendo `idBitrix` — em lotes pequenos, validando a cada lote.

--- a/petbee/provision-petbee-crm.mjs
+++ b/petbee/provision-petbee-crm.mjs
@@ -262,7 +262,7 @@ const run = async () => {
     label: 'Valor mensal',
     type: 'CURRENCY',
     icon: 'IconCurrencyDollar',
-    defaultValue: { amountMicros: null, currencyCode: "'BRL'" },
+    defaultValue: { amountMicros: null, currencyCode: 'BRL' },
   });
   await ensureField(subscriptionObject, {
     name: 'dataInicio',

--- a/petbee/provision-petbee-crm.mjs
+++ b/petbee/provision-petbee-crm.mjs
@@ -1,0 +1,364 @@
+#!/usr/bin/env node
+// Provisionador do modelo de CRM da Petbee para o Twenty.
+//
+// Cria (ou completa) os objetos Pet e Assinatura, os campos da Petbee no
+// objeto de tutor (Person padrão ou um objeto "tutor" customizado que você
+// já tenha criado pela interface) e as relações entre eles, via API de
+// metadados do Twenty.
+//
+// Idempotente: pode rodar quantas vezes quiser — objetos e campos que já
+// existem são detectados pelo nome e pulados, nunca duplicados. Por isso é
+// seguro rodar contra a sua instância local (onde você já criou pet/tutor)
+// e depois contra a produção.
+//
+// Uso:
+//   TWENTY_API_KEY=<sua-api-key> node petbee/provision-petbee-crm.mjs
+//   TWENTY_API_URL=https://crm.petbee.com.br TWENTY_API_KEY=... node petbee/provision-petbee-crm.mjs
+//   ... --dry-run   (só mostra o que seria feito, sem alterar nada)
+//
+// Requisitos: Node 18+ e uma API key do Twenty (Settings → APIs & Webhooks).
+
+const API_URL = (process.env.TWENTY_API_URL ?? 'http://localhost:3000').replace(/\/+$/, '');
+const API_KEY = process.env.TWENTY_API_KEY;
+const DRY_RUN = process.argv.includes('--dry-run');
+// Force um objeto de tutor específico (nameSingular), ex.: PETBEE_TUTOR_OBJECT=tutor
+const TUTOR_OBJECT_OVERRIDE = process.env.PETBEE_TUTOR_OBJECT;
+
+if (!API_KEY) {
+  console.error('Erro: defina a variável de ambiente TWENTY_API_KEY.');
+  console.error('Gere uma API key no Twenty em Settings → APIs & Webhooks.');
+  process.exit(1);
+}
+
+const gql = async (query, variables = {}) => {
+  let response;
+  try {
+    response = await fetch(`${API_URL}/metadata`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${API_KEY}`,
+      },
+      body: JSON.stringify({ query, variables }),
+    });
+  } catch (error) {
+    throw new Error(`Não consegui conectar em ${API_URL} — a instância está no ar? (${error.message})`);
+  }
+
+  if (response.status === 401 || response.status === 403) {
+    throw new Error('API key inválida ou sem permissão (HTTP ' + response.status + ').');
+  }
+
+  const json = await response.json();
+
+  if (json.errors?.length) {
+    throw new Error(json.errors.map((graphqlError) => graphqlError.message).join(' | '));
+  }
+
+  return json.data;
+};
+
+const fetchObjects = async () => {
+  const data = await gql(`
+    query ObjectsMetadata($filter: ObjectFilter!, $paging: CursorPaging!) {
+      objects(filter: $filter, paging: $paging) {
+        edges {
+          node {
+            id
+            nameSingular
+            namePlural
+            labelSingular
+            isCustom
+            isActive
+            fieldsList { id name label type isActive }
+          }
+        }
+      }
+    }
+  `, { filter: {}, paging: { first: 1000 } });
+
+  return data.objects.edges.map((edge) => edge.node);
+};
+
+const findObject = (objects, nameSingular) =>
+  objects.find((object) => object.nameSingular.toLowerCase() === nameSingular.toLowerCase());
+
+const ensureObject = async (objects, definition) => {
+  const existing = findObject(objects, definition.nameSingular);
+
+  if (existing) {
+    console.log(`• Objeto "${definition.labelSingular}" já existe (${existing.nameSingular}) — mantido como está.`);
+    if (!existing.isActive) {
+      console.warn(`  ⚠ Ele está desativado. Reative em Settings → Data model.`);
+    }
+    return existing;
+  }
+
+  if (DRY_RUN) {
+    console.log(`→ [dry-run] Criaria o objeto "${definition.labelSingular}".`);
+    return { id: `dry-run-${definition.nameSingular}`, ...definition, fieldsList: [], isActive: true };
+  }
+
+  const data = await gql(`
+    mutation CreateOneObjectMetadataItem($input: CreateOneObjectInput!) {
+      createOneObject(input: $input) { id nameSingular }
+    }
+  `, { input: { object: definition } });
+
+  console.log(`✓ Objeto "${definition.labelSingular}" criado.`);
+
+  return { ...data.createOneObject, ...definition, fieldsList: [], isActive: true };
+};
+
+const ensureField = async (object, field) => {
+  const existing = (object.fieldsList ?? []).find(
+    (existingField) => existingField.name.toLowerCase() === field.name.toLowerCase(),
+  );
+
+  if (existing) {
+    console.log(`  • Campo "${field.label}" (${field.name}) já existe em ${object.nameSingular} — pulado.`);
+    return existing;
+  }
+
+  if (DRY_RUN) {
+    console.log(`  → [dry-run] Criaria o campo "${field.label}" (${field.type}) em ${object.nameSingular}.`);
+    return null;
+  }
+
+  const data = await gql(`
+    mutation CreateOneFieldMetadataItem($input: CreateOneFieldMetadataInput!) {
+      createOneField(input: $input) { id name }
+    }
+  `, { input: { field: { ...field, objectMetadataId: object.id } } });
+
+  console.log(`  ✓ Campo "${field.label}" criado em ${object.nameSingular}.`);
+  object.fieldsList = [...(object.fieldsList ?? []), data.createOneField];
+
+  return data.createOneField;
+};
+
+const run = async () => {
+  console.log(`Provisionando o modelo Petbee em ${API_URL}${DRY_RUN ? ' (dry-run)' : ''}…\n`);
+
+  const objects = await fetchObjects();
+
+  // Tutor: usa um objeto customizado "tutor" se você já o criou pela
+  // interface; senão usa o objeto padrão Person (recomendado, pois ele já
+  // tem e-mails, telefones, timeline e integrações de e-mail/calendário).
+  const tutorObject = TUTOR_OBJECT_OVERRIDE
+    ? findObject(objects, TUTOR_OBJECT_OVERRIDE)
+    : (findObject(objects, 'tutor') ?? findObject(objects, 'person'));
+
+  if (!tutorObject) {
+    throw new Error(
+      TUTOR_OBJECT_OVERRIDE
+        ? `Objeto "${TUTOR_OBJECT_OVERRIDE}" (PETBEE_TUTOR_OBJECT) não encontrado nesta instância.`
+        : 'Nem "tutor" nem "person" foram encontrados nesta instância.',
+    );
+  }
+
+  console.log(`Usando "${tutorObject.labelSingular}" (${tutorObject.nameSingular}) como objeto de tutor.\n`);
+
+  const petObject = await ensureObject(objects, {
+    nameSingular: 'pet',
+    namePlural: 'pets',
+    labelSingular: 'Pet',
+    labelPlural: 'Pets',
+    icon: 'IconPaw',
+    description: 'Pet vinculado a um tutor (cliente ou lead da Petbee).',
+  });
+
+  const subscriptionObject = await ensureObject(objects, {
+    nameSingular: 'assinatura',
+    namePlural: 'assinaturas',
+    labelSingular: 'Assinatura',
+    labelPlural: 'Assinaturas',
+    icon: 'IconCreditCard',
+    description: 'Assinatura de plano Petbee de um pet, com status e cobrança.',
+  });
+
+  console.log('\nCampos do Pet:');
+  await ensureField(petObject, {
+    name: 'especie',
+    label: 'Espécie',
+    type: 'SELECT',
+    icon: 'IconCategory',
+    options: [
+      { label: 'Cachorro', value: 'CACHORRO', color: 'blue', position: 0 },
+      { label: 'Gato', value: 'GATO', color: 'purple', position: 1 },
+      { label: 'Ave', value: 'AVE', color: 'yellow', position: 2 },
+      { label: 'Roedor', value: 'ROEDOR', color: 'orange', position: 3 },
+      { label: 'Outro', value: 'OUTRO', color: 'gray', position: 4 },
+    ],
+  });
+  await ensureField(petObject, { name: 'raca', label: 'Raça', type: 'TEXT', icon: 'IconDna' });
+  await ensureField(petObject, {
+    name: 'sexo',
+    label: 'Sexo',
+    type: 'SELECT',
+    icon: 'IconTag',
+    options: [
+      { label: 'Macho', value: 'MACHO', color: 'blue', position: 0 },
+      { label: 'Fêmea', value: 'FEMEA', color: 'pink', position: 1 },
+    ],
+  });
+  await ensureField(petObject, {
+    name: 'porte',
+    label: 'Porte',
+    type: 'SELECT',
+    icon: 'IconRuler',
+    options: [
+      { label: 'Pequeno', value: 'PEQUENO', color: 'green', position: 0 },
+      { label: 'Médio', value: 'MEDIO', color: 'yellow', position: 1 },
+      { label: 'Grande', value: 'GRANDE', color: 'orange', position: 2 },
+      { label: 'Gigante', value: 'GIGANTE', color: 'red', position: 3 },
+    ],
+  });
+  await ensureField(petObject, {
+    name: 'dataNascimento',
+    label: 'Data de nascimento',
+    type: 'DATE',
+    icon: 'IconCalendar',
+  });
+  await ensureField(petObject, {
+    name: 'pesoKg',
+    label: 'Peso (kg)',
+    type: 'NUMBER',
+    icon: 'IconScale',
+    settings: { decimals: 2 },
+  });
+  await ensureField(petObject, { name: 'castrado', label: 'Castrado(a)', type: 'BOOLEAN', icon: 'IconScissors' });
+  await ensureField(petObject, { name: 'microchip', label: 'Microchip', type: 'TEXT', icon: 'IconCpu' });
+  await ensureField(petObject, { name: 'observacoes', label: 'Observações', type: 'TEXT', icon: 'IconNotes' });
+
+  console.log('\nCampos da Assinatura:');
+  await ensureField(subscriptionObject, {
+    name: 'plano',
+    label: 'Plano',
+    type: 'SELECT',
+    icon: 'IconPackage',
+    // Ajuste os nomes dos planos abaixo (ou depois, em Settings → Data model).
+    options: [
+      { label: 'Essencial', value: 'ESSENCIAL', color: 'blue', position: 0 },
+      { label: 'Completo', value: 'COMPLETO', color: 'violet', position: 1 },
+      { label: 'Premium', value: 'PREMIUM', color: 'amber', position: 2 },
+    ],
+  });
+  await ensureField(subscriptionObject, {
+    name: 'status',
+    label: 'Status',
+    type: 'SELECT',
+    icon: 'IconCircleCheck',
+    options: [
+      { label: 'Ativa', value: 'ATIVA', color: 'green', position: 0 },
+      { label: 'Inadimplente', value: 'INADIMPLENTE', color: 'orange', position: 1 },
+      { label: 'Pausada', value: 'PAUSADA', color: 'yellow', position: 2 },
+      { label: 'Cancelada', value: 'CANCELADA', color: 'red', position: 3 },
+      { label: 'Encerrada', value: 'ENCERRADA', color: 'gray', position: 4 },
+    ],
+  });
+  await ensureField(subscriptionObject, {
+    name: 'valorMensal',
+    label: 'Valor mensal',
+    type: 'CURRENCY',
+    icon: 'IconCurrencyDollar',
+    defaultValue: { amountMicros: null, currencyCode: "'BRL'" },
+  });
+  await ensureField(subscriptionObject, {
+    name: 'dataInicio',
+    label: 'Início da vigência',
+    type: 'DATE',
+    icon: 'IconCalendar',
+  });
+  await ensureField(subscriptionObject, {
+    name: 'proximaCobranca',
+    label: 'Próxima cobrança',
+    type: 'DATE',
+    icon: 'IconCalendarDue',
+  });
+  await ensureField(subscriptionObject, {
+    name: 'formaPagamento',
+    label: 'Forma de pagamento',
+    type: 'SELECT',
+    icon: 'IconCreditCard',
+    options: [
+      { label: 'Cartão de crédito', value: 'CARTAO_CREDITO', color: 'blue', position: 0 },
+      { label: 'Pix', value: 'PIX', color: 'green', position: 1 },
+      { label: 'Boleto', value: 'BOLETO', color: 'gray', position: 2 },
+    ],
+  });
+
+  console.log(`\nCampos do tutor (${tutorObject.nameSingular}):`);
+  await ensureField(tutorObject, { name: 'cpf', label: 'CPF', type: 'TEXT', icon: 'IconId' });
+  await ensureField(tutorObject, {
+    name: 'statusCliente',
+    label: 'Status do cliente',
+    type: 'SELECT',
+    icon: 'IconCircleCheck',
+    options: [
+      { label: 'Lead', value: 'LEAD', color: 'blue', position: 0 },
+      { label: 'Cliente ativo', value: 'CLIENTE_ATIVO', color: 'green', position: 1 },
+      { label: 'Inativo', value: 'INATIVO', color: 'gray', position: 2 },
+      { label: 'Ex-cliente', value: 'EX_CLIENTE', color: 'red', position: 3 },
+    ],
+  });
+  await ensureField(tutorObject, {
+    name: 'canalPreferido',
+    label: 'Canal preferido',
+    type: 'SELECT',
+    icon: 'IconMessageCircle',
+    options: [
+      { label: 'WhatsApp', value: 'WHATSAPP', color: 'green', position: 0 },
+      { label: 'E-mail', value: 'EMAIL', color: 'blue', position: 1 },
+      { label: 'Telefone', value: 'TELEFONE', color: 'yellow', position: 2 },
+    ],
+  });
+
+  console.log('\nRelações:');
+  // Muitos pets → um tutor; o tutor ganha o campo espelhado "Pets".
+  await ensureField(petObject, {
+    name: 'tutor',
+    label: 'Tutor',
+    type: 'RELATION',
+    icon: 'IconUser',
+    relationCreationPayload: {
+      targetObjectMetadataId: tutorObject.id,
+      targetFieldLabel: 'Pets',
+      targetFieldIcon: 'IconPaw',
+      type: 'MANY_TO_ONE',
+    },
+  });
+  // Muitas assinaturas → um pet (histórico de planos do pet).
+  await ensureField(subscriptionObject, {
+    name: 'pet',
+    label: 'Pet',
+    type: 'RELATION',
+    icon: 'IconPaw',
+    relationCreationPayload: {
+      targetObjectMetadataId: petObject.id,
+      targetFieldLabel: 'Assinaturas',
+      targetFieldIcon: 'IconCreditCard',
+      type: 'MANY_TO_ONE',
+    },
+  });
+  // Muitas assinaturas → um titular (quem paga), direto no tutor.
+  await ensureField(subscriptionObject, {
+    name: 'titular',
+    label: 'Titular',
+    type: 'RELATION',
+    icon: 'IconUser',
+    relationCreationPayload: {
+      targetObjectMetadataId: tutorObject.id,
+      targetFieldLabel: 'Assinaturas',
+      targetFieldIcon: 'IconCreditCard',
+      type: 'MANY_TO_ONE',
+    },
+  });
+
+  console.log(`\nPronto${DRY_RUN ? ' (nada foi alterado — dry-run)' : ''}. Abra Settings → Data model no Twenty para revisar.`);
+};
+
+run().catch((error) => {
+  console.error(`\nFalhou: ${error.message}`);
+  process.exit(1);
+});

--- a/petbee/provision-petbee-crm.mjs
+++ b/petbee/provision-petbee-crm.mjs
@@ -1,19 +1,20 @@
 #!/usr/bin/env node
 // Provisionador do modelo de CRM da Petbee para o Twenty.
 //
-// Cria (ou completa) os objetos Pet e Assinatura, os campos da Petbee no
-// objeto de tutor (Person padrão ou um objeto "tutor" customizado que você
-// já tenha criado pela interface) e as relações entre eles, via API de
-// metadados do Twenty.
+// Este script é o "retrato como construído" do CRM da Petbee: ele reproduz,
+// em qualquer instância do Twenty, o modelo que existe hoje em
+// https://crm.petbeetools.com.br (snapshot capturado em 2026-08-11 via API
+// de metadados). Use-o para montar a futura instância de produção ou para
+// reconstruir o ambiente do zero.
 //
-// Idempotente: pode rodar quantas vezes quiser — objetos e campos que já
-// existem são detectados pelo nome e pulados, nunca duplicados. Por isso é
-// seguro rodar contra a sua instância local (onde você já criou pet/tutor)
-// e depois contra a produção.
+// Modelo: Tutor (Person) 1—N Pets 1—N Assinatura N—1 Plano
+//
+// Idempotente: objetos e campos já existentes (pelo nome) são detectados e
+// pulados, nunca duplicados nem sobrescritos. Rodar de novo é sempre seguro.
 //
 // Uso:
 //   TWENTY_API_KEY=<sua-api-key> node petbee/provision-petbee-crm.mjs
-//   TWENTY_API_URL=https://crm.petbee.com.br TWENTY_API_KEY=... node petbee/provision-petbee-crm.mjs
+//   TWENTY_API_URL=https://crm.petbeetools.com.br TWENTY_API_KEY=... node petbee/provision-petbee-crm.mjs
 //   ... --dry-run   (só mostra o que seria feito, sem alterar nada)
 //
 // Requisitos: Node 18+ e uma API key do Twenty (Settings → APIs & Webhooks).
@@ -21,8 +22,6 @@
 const API_URL = (process.env.TWENTY_API_URL ?? 'http://localhost:3000').replace(/\/+$/, '');
 const API_KEY = process.env.TWENTY_API_KEY;
 const DRY_RUN = process.argv.includes('--dry-run');
-// Force um objeto de tutor específico (nameSingular), ex.: PETBEE_TUTOR_OBJECT=tutor
-const TUTOR_OBJECT_OVERRIDE = process.env.PETBEE_TUTOR_OBJECT;
 
 if (!API_KEY) {
   console.error('Erro: defina a variável de ambiente TWENTY_API_KEY.');
@@ -49,7 +48,14 @@ const gql = async (query, variables = {}) => {
     throw new Error('API key inválida ou sem permissão (HTTP ' + response.status + ').');
   }
 
-  const json = await response.json();
+  const body = await response.text();
+  let json;
+
+  try {
+    json = JSON.parse(body);
+  } catch {
+    throw new Error(`Resposta inesperada (HTTP ${response.status}) de ${API_URL}/metadata: ${body.slice(0, 200)}`);
+  }
 
   if (json.errors?.length) {
     throw new Error(json.errors.map((graphqlError) => graphqlError.message).join(' | '));
@@ -57,6 +63,23 @@ const gql = async (query, variables = {}) => {
 
   return json.data;
 };
+
+// "Assinaturas" → "assinaturas", "Data de nascimento" → "dataDeNascimento":
+// mesmo algoritmo que o Twenty usa para derivar o nome do campo espelhado de
+// uma relação a partir do rótulo.
+const labelToFieldName = (label) =>
+  label
+    .normalize('NFD')
+    .replace(/\p{Diacritic}/gu, '')
+    .replace(/[^a-zA-Z0-9 ]/g, ' ')
+    .trim()
+    .split(/\s+/)
+    .map((word, index) =>
+      index === 0
+        ? word.charAt(0).toLowerCase() + word.slice(1)
+        : word.charAt(0).toUpperCase() + word.slice(1),
+    )
+    .join('');
 
 const fetchObjects = async () => {
   const data = await gql(`
@@ -68,7 +91,6 @@ const fetchObjects = async () => {
             nameSingular
             namePlural
             labelSingular
-            isCustom
             isActive
             fieldsList { id name label type isActive }
           }
@@ -110,7 +132,7 @@ const ensureObject = async (objects, definition) => {
   return { ...data.createOneObject, ...definition, fieldsList: [], isActive: true };
 };
 
-const ensureField = async (object, field) => {
+const ensureField = async (object, field, relationTargetObject) => {
   const existing = (object.fieldsList ?? []).find(
     (existingField) => existingField.name.toLowerCase() === field.name.toLowerCase(),
   );
@@ -118,6 +140,25 @@ const ensureField = async (object, field) => {
   if (existing) {
     console.log(`  • Campo "${field.label}" (${field.name}) já existe em ${object.nameSingular} — pulado.`);
     return existing;
+  }
+
+  // Relações criam um campo espelhado no objeto de destino. Se uma execução
+  // anterior parou no meio e só o espelho existe, recriar falharia — então
+  // detectamos e avisamos em vez de quebrar o restante do provisionamento.
+  if (field.relationCreationPayload && relationTargetObject) {
+    const mirroredFieldName = labelToFieldName(field.relationCreationPayload.targetFieldLabel);
+    const mirrorTaken = (relationTargetObject.fieldsList ?? []).some(
+      (targetField) => targetField.name.toLowerCase() === mirroredFieldName.toLowerCase(),
+    );
+
+    if (mirrorTaken) {
+      console.warn(
+        `  ⚠ Relação "${field.label}" não criada: ${object.nameSingular}.${field.name} não existe, mas ` +
+          `${relationTargetObject.nameSingular}.${mirroredFieldName} já existe (estado parcial de uma execução ` +
+          `anterior?). Resolva manualmente em Settings → Data model e rode de novo.`,
+      );
+      return null;
+    }
   }
 
   if (DRY_RUN) {
@@ -137,35 +178,42 @@ const ensureField = async (object, field) => {
   return data.createOneField;
 };
 
+// Opções compartilhadas entre Plano (inclusos) e Assinatura (extras).
+const ADDON_OPTIONS = [
+  { label: 'Vacinas', value: 'VACINAS', color: 'green', position: 0 },
+  { label: 'Checkup', value: 'CHECKUP', color: 'blue', position: 1 },
+  { label: 'Limpeza Dentária', value: 'LIMPEZA_DENTARIA', color: 'purple', position: 2 },
+];
+
 const run = async () => {
   console.log(`Provisionando o modelo Petbee em ${API_URL}${DRY_RUN ? ' (dry-run)' : ''}…\n`);
 
   const objects = await fetchObjects();
 
-  // Tutor: usa um objeto customizado "tutor" se você já o criou pela
-  // interface; senão usa o objeto padrão Person (recomendado, pois ele já
-  // tem e-mails, telefones, timeline e integrações de e-mail/calendário).
-  const tutorObject = TUTOR_OBJECT_OVERRIDE
-    ? findObject(objects, TUTOR_OBJECT_OVERRIDE)
-    : (findObject(objects, 'tutor') ?? findObject(objects, 'person'));
+  const personObject = findObject(objects, 'person');
 
-  if (!tutorObject) {
-    throw new Error(
-      TUTOR_OBJECT_OVERRIDE
-        ? `Objeto "${TUTOR_OBJECT_OVERRIDE}" (PETBEE_TUTOR_OBJECT) não encontrado nesta instância.`
-        : 'Nem "tutor" nem "person" foram encontrados nesta instância.',
-    );
+  if (!personObject) {
+    throw new Error('Objeto padrão "person" não encontrado nesta instância.');
   }
 
-  console.log(`Usando "${tutorObject.labelSingular}" (${tutorObject.nameSingular}) como objeto de tutor.\n`);
-
-  const petObject = await ensureObject(objects, {
-    nameSingular: 'pet',
-    namePlural: 'pets',
-    labelSingular: 'Pet',
+  // namePlural "petss" reproduz a instância original: o objeto foi criado lá
+  // com singular "pets", e a API de registros usa o plural "petss" nas
+  // queries. Mantido igual para os scripts de migração funcionarem nas duas.
+  const petsObject = await ensureObject(objects, {
+    nameSingular: 'pets',
+    namePlural: 'petss',
+    labelSingular: 'Pets',
     labelPlural: 'Pets',
-    icon: 'IconPaw',
-    description: 'Pet vinculado a um tutor (cliente ou lead da Petbee).',
+    icon: 'IconListNumbers',
+    description: 'Pets individual',
+  });
+
+  const planObject = await ensureObject(objects, {
+    nameSingular: 'plano',
+    namePlural: 'planos',
+    labelSingular: 'Plano',
+    labelPlural: 'Planos',
+    icon: 'IconLicense',
   });
 
   const subscriptionObject = await ensureObject(objects, {
@@ -173,36 +221,29 @@ const run = async () => {
     namePlural: 'assinaturas',
     labelSingular: 'Assinatura',
     labelPlural: 'Assinaturas',
-    icon: 'IconCreditCard',
-    description: 'Assinatura de plano Petbee de um pet, com status e cobrança.',
+    icon: 'IconFileInvoice',
   });
 
-  console.log('\nCampos do Pet:');
-  await ensureField(petObject, {
-    name: 'especie',
-    label: 'Espécie',
-    type: 'SELECT',
-    icon: 'IconCategory',
-    options: [
-      { label: 'Cachorro', value: 'CACHORRO', color: 'blue', position: 0 },
-      { label: 'Gato', value: 'GATO', color: 'purple', position: 1 },
-      { label: 'Ave', value: 'AVE', color: 'yellow', position: 2 },
-      { label: 'Roedor', value: 'ROEDOR', color: 'orange', position: 3 },
-      { label: 'Outro', value: 'OUTRO', color: 'gray', position: 4 },
-    ],
+  console.log('\nCampos de Pets:');
+  await ensureField(petsObject, { name: 'especie', label: 'Espécie', type: 'TEXT', icon: 'IconTypography' });
+  await ensureField(petsObject, { name: 'raca', label: 'Raça', type: 'TEXT', icon: 'IconDna' });
+  await ensureField(petsObject, {
+    name: 'dataDeNascimento',
+    label: 'Data de nascimento',
+    type: 'DATE',
+    icon: 'IconCalendarEvent',
   });
-  await ensureField(petObject, { name: 'raca', label: 'Raça', type: 'TEXT', icon: 'IconDna' });
-  await ensureField(petObject, {
+  await ensureField(petsObject, {
     name: 'sexo',
     label: 'Sexo',
     type: 'SELECT',
     icon: 'IconTag',
     options: [
-      { label: 'Macho', value: 'MACHO', color: 'blue', position: 0 },
-      { label: 'Fêmea', value: 'FEMEA', color: 'pink', position: 1 },
+      { label: 'Macho', value: 'MACHO', color: 'green', position: 0 },
+      { label: 'Fêmea', value: 'FEMEA', color: 'jade', position: 1 },
     ],
   });
-  await ensureField(petObject, {
+  await ensureField(petsObject, {
     name: 'porte',
     label: 'Porte',
     type: 'SELECT',
@@ -214,95 +255,111 @@ const run = async () => {
       { label: 'Gigante', value: 'GIGANTE', color: 'red', position: 3 },
     ],
   });
-  await ensureField(petObject, {
-    name: 'dataNascimento',
-    label: 'Data de nascimento',
-    type: 'DATE',
-    icon: 'IconCalendar',
-  });
-  await ensureField(petObject, {
-    name: 'pesoKg',
-    label: 'Peso (kg)',
-    type: 'NUMBER',
-    icon: 'IconScale',
+  await ensureField(petsObject, { name: 'carteirinha', label: 'Carteirinha', type: 'TEXT', icon: 'IconTypography' });
+  await ensureField(petsObject, { name: 'petIdPetbee', label: 'ID Petbee (pet)', type: 'TEXT', icon: 'IconKey' });
+
+  console.log('\nCampos de Plano:');
+  await ensureField(planObject, {
+    name: 'valorMensal',
+    label: 'Valor mensal',
+    type: 'CURRENCY',
+    icon: 'IconCoin',
     settings: { decimals: 2 },
   });
-  await ensureField(petObject, { name: 'castrado', label: 'Castrado(a)', type: 'BOOLEAN', icon: 'IconScissors' });
-  await ensureField(petObject, { name: 'microchip', label: 'Microchip', type: 'TEXT', icon: 'IconCpu' });
-  await ensureField(petObject, { name: 'observacoes', label: 'Observações', type: 'TEXT', icon: 'IconNotes' });
-
-  console.log('\nCampos da Assinatura:');
-  await ensureField(subscriptionObject, {
-    name: 'plano',
-    label: 'Plano',
-    type: 'SELECT',
-    icon: 'IconPackage',
-    // Ajuste os nomes dos planos abaixo (ou depois, em Settings → Data model).
-    options: [
-      { label: 'Essencial', value: 'ESSENCIAL', color: 'blue', position: 0 },
-      { label: 'Completo', value: 'COMPLETO', color: 'violet', position: 1 },
-      { label: 'Premium', value: 'PREMIUM', color: 'amber', position: 2 },
-    ],
+  await ensureField(planObject, {
+    name: 'ativo',
+    label: 'Ativo',
+    type: 'BOOLEAN',
+    icon: 'IconToggleRight',
+    defaultValue: true,
   });
+  await ensureField(planObject, {
+    name: 'addonsInclusos',
+    label: 'Addons inclusos',
+    type: 'MULTI_SELECT',
+    icon: 'IconGift',
+    options: ADDON_OPTIONS,
+  });
+  await ensureField(planObject, { name: 'planIdPetbee', label: 'ID Petbee (plano)', type: 'TEXT', icon: 'IconKey' });
+
+  console.log('\nCampos de Assinatura:');
   await ensureField(subscriptionObject, {
     name: 'status',
     label: 'Status',
     type: 'SELECT',
-    icon: 'IconCircleCheck',
+    icon: 'IconProgressCheck',
+    defaultValue: "'ATIVA'",
     options: [
       { label: 'Ativa', value: 'ATIVA', color: 'green', position: 0 },
-      { label: 'Inadimplente', value: 'INADIMPLENTE', color: 'orange', position: 1 },
-      { label: 'Pausada', value: 'PAUSADA', color: 'yellow', position: 2 },
-      { label: 'Cancelada', value: 'CANCELADA', color: 'red', position: 3 },
-      { label: 'Encerrada', value: 'ENCERRADA', color: 'gray', position: 4 },
+      { label: 'Bloqueada', value: 'BLOQUEADA', color: 'gray', position: 1 },
+      { label: 'Cancelada', value: 'CANCELADA', color: 'red', position: 2 },
+    ],
+  });
+  await ensureField(subscriptionObject, {
+    name: 'periodicidade',
+    label: 'Periodicidade',
+    type: 'SELECT',
+    icon: 'IconCalendarRepeat',
+    defaultValue: "'MENSAL'",
+    options: [
+      { label: 'Mensal', value: 'MENSAL', color: 'blue', position: 0 },
+      { label: 'Anual', value: 'ANUAL', color: 'green', position: 1 },
     ],
   });
   await ensureField(subscriptionObject, {
     name: 'valorMensal',
-    label: 'Valor mensal',
+    label: 'Valor mensal (MRR)',
     type: 'CURRENCY',
-    icon: 'IconCurrencyDollar',
-    defaultValue: { amountMicros: null, currencyCode: 'BRL' },
+    icon: 'IconCoin',
+    settings: { decimals: 2 },
   });
   await ensureField(subscriptionObject, {
-    name: 'dataInicio',
-    label: 'Início da vigência',
-    type: 'DATE',
-    icon: 'IconCalendar',
-  });
-  await ensureField(subscriptionObject, {
-    name: 'proximaCobranca',
-    label: 'Próxima cobrança',
-    type: 'DATE',
+    name: 'diaVencimento',
+    label: 'Dia de vencimento',
+    type: 'NUMBER',
     icon: 'IconCalendarDue',
   });
   await ensureField(subscriptionObject, {
-    name: 'formaPagamento',
-    label: 'Forma de pagamento',
-    type: 'SELECT',
-    icon: 'IconCreditCard',
-    options: [
-      { label: 'Cartão de crédito', value: 'CARTAO_CREDITO', color: 'blue', position: 0 },
-      { label: 'Pix', value: 'PIX', color: 'green', position: 1 },
-      { label: 'Boleto', value: 'BOLETO', color: 'gray', position: 2 },
-    ],
+    name: 'dataInicio',
+    label: 'Data de início',
+    type: 'DATE',
+    icon: 'IconCalendarPlus',
+  });
+  await ensureField(subscriptionObject, {
+    name: 'dataCancelamento',
+    label: 'Data de cancelamento',
+    type: 'DATE',
+    icon: 'IconCalendarX',
+  });
+  await ensureField(subscriptionObject, {
+    name: 'addons',
+    label: 'Addons (extras)',
+    type: 'MULTI_SELECT',
+    icon: 'IconPlus',
+    options: ADDON_OPTIONS,
+  });
+  await ensureField(subscriptionObject, { name: 'cupom', label: 'Cupom', type: 'TEXT', icon: 'IconTicket' });
+  await ensureField(subscriptionObject, {
+    name: 'subsIdPetbee',
+    label: 'ID Petbee (assinatura)',
+    type: 'TEXT',
+    icon: 'IconKey',
   });
 
-  console.log(`\nCampos do tutor (${tutorObject.nameSingular}):`);
-  await ensureField(tutorObject, { name: 'cpf', label: 'CPF', type: 'TEXT', icon: 'IconId' });
-  await ensureField(tutorObject, {
+  console.log('\nCampos do tutor (Person):');
+  await ensureField(personObject, { name: 'cpf', label: 'CPF', type: 'TEXT', icon: 'IconId' });
+  await ensureField(personObject, {
     name: 'statusCliente',
     label: 'Status do cliente',
     type: 'SELECT',
-    icon: 'IconCircleCheck',
+    icon: 'IconUserCheck',
     options: [
       { label: 'Lead', value: 'LEAD', color: 'blue', position: 0 },
-      { label: 'Cliente ativo', value: 'CLIENTE_ATIVO', color: 'green', position: 1 },
-      { label: 'Inativo', value: 'INATIVO', color: 'gray', position: 2 },
-      { label: 'Ex-cliente', value: 'EX_CLIENTE', color: 'red', position: 3 },
+      { label: 'Ativo', value: 'ATIVO', color: 'green', position: 1 },
+      { label: 'Inativo', value: 'INATIVO', color: 'red', position: 2 },
     ],
   });
-  await ensureField(tutorObject, {
+  await ensureField(personObject, {
     name: 'canalPreferido',
     label: 'Canal preferido',
     type: 'SELECT',
@@ -313,47 +370,76 @@ const run = async () => {
       { label: 'Telefone', value: 'TELEFONE', color: 'yellow', position: 2 },
     ],
   });
+  await ensureField(personObject, { name: 'humanid', label: 'HumanID', type: 'TEXT', icon: 'IconTypography' });
+  await ensureField(personObject, { name: 'hIdPetbee', label: 'ID Petbee (tutor)', type: 'TEXT', icon: 'IconKey' });
+  await ensureField(personObject, {
+    name: 'idBitrix',
+    label: 'ID Bitrix (contato)',
+    type: 'TEXT',
+    icon: 'IconBrandBitbucket',
+  });
+  await ensureField(personObject, { name: 'utmSource', label: 'UTM Source', type: 'TEXT', icon: 'IconBrandGoogle' });
+  await ensureField(personObject, { name: 'utmMedium', label: 'UTM Medium', type: 'TEXT', icon: 'IconAd' });
+  await ensureField(personObject, {
+    name: 'utmCampaign',
+    label: 'UTM Campaign',
+    type: 'TEXT',
+    icon: 'IconSpeakerphone',
+  });
 
   console.log('\nRelações:');
-  // Muitos pets → um tutor; o tutor ganha o campo espelhado "Pets".
-  await ensureField(petObject, {
+  // Muitos pets → um tutor; Person ganha o campo espelhado "Pets".
+  await ensureField(petsObject, {
     name: 'tutor',
     label: 'Tutor',
     type: 'RELATION',
-    icon: 'IconUser',
+    icon: 'IconUsers',
     relationCreationPayload: {
-      targetObjectMetadataId: tutorObject.id,
+      targetObjectMetadataId: personObject.id,
       targetFieldLabel: 'Pets',
-      targetFieldIcon: 'IconPaw',
+      targetFieldIcon: 'IconRelationOneToMany',
       type: 'MANY_TO_ONE',
     },
-  });
+  }, personObject);
+  // Muitas assinaturas → um tutor (quem paga).
+  await ensureField(subscriptionObject, {
+    name: 'tutor',
+    label: 'Tutor',
+    type: 'RELATION',
+    icon: 'IconLink',
+    relationCreationPayload: {
+      targetObjectMetadataId: personObject.id,
+      targetFieldLabel: 'Assinaturas',
+      targetFieldIcon: 'IconFileInvoice',
+      type: 'MANY_TO_ONE',
+    },
+  }, personObject);
   // Muitas assinaturas → um pet (histórico de planos do pet).
   await ensureField(subscriptionObject, {
     name: 'pet',
     label: 'Pet',
     type: 'RELATION',
-    icon: 'IconPaw',
+    icon: 'IconLink',
     relationCreationPayload: {
-      targetObjectMetadataId: petObject.id,
+      targetObjectMetadataId: petsObject.id,
       targetFieldLabel: 'Assinaturas',
-      targetFieldIcon: 'IconCreditCard',
+      targetFieldIcon: 'IconFileInvoice',
       type: 'MANY_TO_ONE',
     },
-  });
-  // Muitas assinaturas → um titular (quem paga), direto no tutor.
+  }, petsObject);
+  // Muitas assinaturas → um plano (catálogo de planos).
   await ensureField(subscriptionObject, {
-    name: 'titular',
-    label: 'Titular',
+    name: 'plano',
+    label: 'Plano',
     type: 'RELATION',
-    icon: 'IconUser',
+    icon: 'IconLink',
     relationCreationPayload: {
-      targetObjectMetadataId: tutorObject.id,
+      targetObjectMetadataId: planObject.id,
       targetFieldLabel: 'Assinaturas',
-      targetFieldIcon: 'IconCreditCard',
+      targetFieldIcon: 'IconFileInvoice',
       type: 'MANY_TO_ONE',
     },
-  });
+  }, planObject);
 
   console.log(`\nPronto${DRY_RUN ? ' (nada foi alterado — dry-run)' : ''}. Abra Settings → Data model no Twenty para revisar.`);
 };


### PR DESCRIPTION
Cria via API de metadados do Twenty os objetos Pet e Assinatura, os campos da Petbee no objeto de tutor (Person ou objeto customizado 'tutor') e as relacoes Tutor 1-N Pet 1-N Assinatura. Idempotente: detecta o que ja existe pelo nome e so completa o que falta, entao roda com seguranca tanto na instancia local quanto em producao.

Claude-Session: https://claude.ai/code/session_01CHphuGsxW42yKvgmAmsjB4

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/24029?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

