### PR TITLE
fix(messaging): stop logging deleted-message 404s during Gmail import

### DIFF
--- a/packages/twenty-server/src/modules/messaging/message-import-manager/drivers/gmail/services/gmail-messages-import-error-handler.service.ts
+++ b/packages/twenty-server/src/modules/messaging/message-import-manager/drivers/gmail/services/gmail-messages-import-error-handler.service.ts
@@ -16,6 +16,13 @@ export class GmailMessagesImportErrorHandler {
   constructor() {}
 
   public handleError(error: unknown, messageExternalId: string): void {
+    if (
+      isGmailApiError(error) &&
+      (error.response?.status === 404 || error.response?.status === 410)
+    ) {
+      return;
+    }
+
     this.logger.error(
       `Gmail: Error importing message ${messageExternalId}: ${JSON.stringify(error)}`,
     );
@@ -25,13 +32,6 @@ export class GmailMessagesImportErrorHandler {
     }
 
     if (isGmailApiError(error)) {
-      const status = error.response?.status;
-
-      // 404/410 means message was deleted - skip silently
-      if (status === 404 || status === 410) {
-        return;
-      }
-
       throw parseGmailApiError(error);
     }
 


### PR DESCRIPTION
A deleted message returns 404/410 and is already treated as a normal skip, but the error log ran before that check, dumping the full gaxios object (config, retryConfig, response) for every one. Moves the check above the log.

Accounts for the bulk of ERROR-level noise in the messaging worker. No behaviour change.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/24030?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

