### PR TITLE
fix(calendar): classify the full CalDAV error surface instead of defaulting to UNKNOWN

### DIFF
--- a/packages/twenty-server/src/modules/calendar/calendar-event-import-manager/drivers/caldav/services/caldav-get-events.service.ts
+++ b/packages/twenty-server/src/modules/calendar/calendar-event-import-manager/drivers/caldav/services/caldav-get-events.service.ts
@@ -21,10 +21,10 @@ export class CalDavGetEventsService {
   ): Promise<GetCalendarEventsResponse> {
     this.logger.debug(`Getting calendar events for ${connectedAccountId}`);
 
-    try {
-      const client =
-        await this.calDavClientProvider.getClient(connectedAccountId);
+    const client =
+      await this.calDavClientProvider.getClient(connectedAccountId);
 
+    try {
       const result = await this.fetchEventsService.fetchChangedEventHrefs(
         client,
         syncCursor ? (JSON.parse(syncCursor) as CalDavSyncCursor) : undefined,
@@ -45,7 +45,7 @@ export class CalDavGetEventsService {
         error,
       );
 
-      throw parseCalDAVError(error as Error);
+      throw parseCalDAVError(error);
     }
   }
 }

--- a/packages/twenty-server/src/modules/calendar/calendar-event-import-manager/drivers/caldav/services/caldav-import-events.service.ts
+++ b/packages/twenty-server/src/modules/calendar/calendar-event-import-manager/drivers/caldav/services/caldav-import-events.service.ts
@@ -3,7 +3,6 @@ import { Injectable, Logger } from '@nestjs/common';
 import { CalDavClientProvider } from 'src/modules/calendar/calendar-event-import-manager/drivers/caldav/providers/caldav-client.provider';
 import { CalDavFetchEventsService } from 'src/modules/calendar/calendar-event-import-manager/drivers/caldav/services/caldav-fetch-events.service';
 import { parseCalDAVError } from 'src/modules/calendar/calendar-event-import-manager/drivers/caldav/utils/parse-caldav-error.util';
-import { CalendarEventImportDriverException } from 'src/modules/calendar/calendar-event-import-manager/drivers/exceptions/calendar-event-import-driver.exception';
 import { type FetchedCalendarEvent } from 'src/modules/calendar/common/types/fetched-calendar-event';
 
 @Injectable()
@@ -37,11 +36,7 @@ export class CalDavImportEventsService {
         error,
       );
 
-      if (error instanceof CalendarEventImportDriverException) {
-        throw error;
-      }
-
-      throw parseCalDAVError(error as Error);
+      throw parseCalDAVError(error);
     }
   }
 }

--- a/packages/twenty-server/src/modules/calendar/calendar-event-import-manager/drivers/caldav/utils/__tests__/parse-caldav-error.util.spec.ts
+++ b/packages/twenty-server/src/modules/calendar/calendar-event-import-manager/drivers/caldav/utils/__tests__/parse-caldav-error.util.spec.ts
@@ -2,46 +2,171 @@ import {
   CalendarEventImportDriverException,
   CalendarEventImportDriverExceptionCode,
 } from 'src/modules/calendar/calendar-event-import-manager/drivers/exceptions/calendar-event-import-driver.exception';
+import {
+  ConnectedAccountRefreshAccessTokenException,
+  ConnectedAccountRefreshAccessTokenExceptionCode,
+} from 'src/engine/metadata-modules/connected-account/exceptions/connected-account-refresh-tokens.exception';
 import { parseCalDAVError } from 'src/modules/calendar/calendar-event-import-manager/drivers/caldav/utils/parse-caldav-error.util';
 
-describe('parseCalDAVError', () => {
-  it('maps tsdav auth-failure messages to INSUFFICIENT_PERMISSIONS', () => {
-    for (const message of [
-      'no account for fetchCalendars',
-      'Must have account before syncCalendars',
-      'Invalid credentials',
-      'Invalid auth method',
-    ]) {
-      const result = parseCalDAVError(new Error(message));
+const expectCode = (
+  message: string,
+  code: CalendarEventImportDriverExceptionCode,
+) => {
+  expect(parseCalDAVError(new Error(message)).code).toBe(code);
+};
 
-      expect(result).toBeInstanceOf(CalendarEventImportDriverException);
-      expect(result.code).toBe(
+describe('parseCalDAVError', () => {
+  describe('already classified exceptions', () => {
+    it('returns a driver exception untouched', () => {
+      const exception = new CalendarEventImportDriverException(
+        'Missing CalDAV credentials for connected account 01599b71-cde9-444c-843f-12acfce6df09',
         CalendarEventImportDriverExceptionCode.INSUFFICIENT_PERMISSIONS,
       );
-    }
-  });
 
-  it('maps tsdav not-found messages to NOT_FOUND', () => {
-    for (const message of [
-      'Collection does not exist on server',
-      'cannot find homeUrl',
-      'cannot fetchCalendarObjects for undefined calendar',
-    ]) {
-      expect(parseCalDAVError(new Error(message)).code).toBe(
-        CalendarEventImportDriverExceptionCode.NOT_FOUND,
+      expect(parseCalDAVError(exception)).toBe(exception);
+    });
+
+    it('returns a refresh token exception untouched', () => {
+      const exception = new ConnectedAccountRefreshAccessTokenException(
+        'No refresh token found',
+        ConnectedAccountRefreshAccessTokenExceptionCode.REFRESH_TOKEN_NOT_FOUND,
       );
-    }
+
+      expect(parseCalDAVError(exception)).toBe(exception);
+    });
+
+    it('is idempotent', () => {
+      const once = parseCalDAVError(new Error('cannot find principalUrl'));
+
+      expect(parseCalDAVError(once)).toBe(once);
+    });
   });
 
-  it('falls back to UNKNOWN for unrecognised errors', () => {
-    expect(parseCalDAVError(new Error('TLS handshake failed')).code).toBe(
-      CalendarEventImportDriverExceptionCode.UNKNOWN,
-    );
+  describe('authentication failures', () => {
+    it.each([
+      'Invalid auth method',
+      'Basic auth header was not encoded correctly',
+      "authMethod 'Custom' requires an authFunction to produce request headers",
+      'Invalid credentials: PROPFIND https://dav.example.com/ returned 401 Unauthorized',
+      'Oauth credentials missing: redirectUrl,clientId,clientSecret,tokenUrl',
+      'Oauth credentials missing: refreshToken,clientId,clientSecret,tokenUrl',
+    ])('maps "%s" to INSUFFICIENT_PERMISSIONS', (message) => {
+      expectCode(
+        message,
+        CalendarEventImportDriverExceptionCode.INSUFFICIENT_PERMISSIONS,
+      );
+    });
   });
 
-  it('forwards the original error message untouched', () => {
-    const result = parseCalDAVError(new Error('Invalid credentials'));
+  describe('missing resources', () => {
+    it.each([
+      'Collection does not exist on server',
+      'Calendar object to delete was not found',
+      'Calendar object to update was not found',
+      'Created calendar object was not found',
+    ])('maps "%s" to NOT_FOUND', (message) => {
+      expectCode(message, CalendarEventImportDriverExceptionCode.NOT_FOUND);
+    });
+  });
 
-    expect(result.message).toBe('Invalid credentials');
+  describe('discovery failures are retryable', () => {
+    it.each([
+      'cannot find principalUrl',
+      'cannot find homeUrl',
+      'cannot find calendarUserAddresses',
+      'no account for fetchCalendars',
+      'no account for fetchAddressBooks',
+      'no account for smartCollectionSync',
+      'Must have account before syncCalendars',
+      'account must have rootUrl before fetchPrincipalUrl',
+      'account must have principalUrl before fetchHomeUrl',
+      'account must have homeUrl,rootUrl before fetchCalendars',
+      'account must have homeUrl,rootUrl before fetchAddressBooks',
+      'account must have principalUrl,rootUrl before fetchUserAddresses',
+      'account must have accountType,homeUrl before smartCollectionSync',
+    ])('maps "%s" to TEMPORARY_ERROR', (message) => {
+      expectCode(
+        message,
+        CalendarEventImportDriverExceptionCode.TEMPORARY_ERROR,
+      );
+    });
+  });
+
+  describe('caller mistakes are not blamed on the account', () => {
+    it.each([
+      'cannot fetchCalendarObjects for undefined calendar',
+      'cannot fetchVCards for undefined addressBook',
+      'collection.fetchObjects is required for basic sync changes',
+      'collection.objectMultiGet is required for webdav sync changes',
+      'timeRange is required',
+      'invalid timeRange format, not in ISO8601',
+      'invalid timeRange: start must be before end',
+      'invalid timeRange: start or end is not a valid date',
+      'freeBusyQuery returned no response',
+      'calendar must have url before fetchCalendarObjects',
+      'addressBook must have url before fetchVCards',
+    ])('maps "%s" to CHANNEL_MISCONFIGURED', (message) => {
+      expectCode(
+        message,
+        CalendarEventImportDriverExceptionCode.CHANNEL_MISCONFIGURED,
+      );
+    });
+  });
+
+  describe('http status carrying messages', () => {
+    it.each([
+      [
+        'Collection query failed: 401 Unauthorized',
+        CalendarEventImportDriverExceptionCode.INSUFFICIENT_PERMISSIONS,
+      ],
+      [
+        'Collection status check failed: 401 Unauthorized',
+        CalendarEventImportDriverExceptionCode.INSUFFICIENT_PERMISSIONS,
+      ],
+      [
+        'Collection query failed: 403 Forbidden',
+        CalendarEventImportDriverExceptionCode.INSUFFICIENT_PERMISSIONS,
+      ],
+      [
+        'Collection query failed: 404 Not Found',
+        CalendarEventImportDriverExceptionCode.NOT_FOUND,
+      ],
+      [
+        'Collection query failed: 504 Gateway Time-out',
+        CalendarEventImportDriverExceptionCode.TEMPORARY_ERROR,
+      ],
+      [
+        'Collection query failed: 429 Too Many Requests',
+        CalendarEventImportDriverExceptionCode.TEMPORARY_ERROR,
+      ],
+      [
+        'Collection query failed: 400 Bad Request',
+        CalendarEventImportDriverExceptionCode.UNKNOWN,
+      ],
+    ])('maps "%s" by status', (message, code) => {
+      expectCode(message, code);
+    });
+  });
+
+  describe('fallbacks', () => {
+    it('falls back to UNKNOWN for unrecognised errors', () => {
+      expectCode(
+        'TLS handshake failed',
+        CalendarEventImportDriverExceptionCode.UNKNOWN,
+      );
+    });
+
+    it('handles a non Error being thrown', () => {
+      const result = parseCalDAVError('socket hang up');
+
+      expect(result.code).toBe(CalendarEventImportDriverExceptionCode.UNKNOWN);
+      expect(result.message).toBe('Unknown CalDAV error: socket hang up');
+    });
+
+    it('forwards the original error message untouched', () => {
+      expect(parseCalDAVError(new Error('Invalid auth method')).message).toBe(
+        'Invalid auth method',
+      );
+    });
   });
 });

--- a/packages/twenty-server/src/modules/calendar/calendar-event-import-manager/drivers/caldav/utils/parse-caldav-error.util.ts
+++ b/packages/twenty-server/src/modules/calendar/calendar-event-import-manager/drivers/caldav/utils/parse-caldav-error.util.ts
@@ -2,48 +2,147 @@ import {
   CalendarEventImportDriverException,
   CalendarEventImportDriverExceptionCode,
 } from 'src/modules/calendar/calendar-event-import-manager/drivers/exceptions/calendar-event-import-driver.exception';
+import { ConnectedAccountRefreshAccessTokenException } from 'src/engine/metadata-modules/connected-account/exceptions/connected-account-refresh-tokens.exception';
+import { TwentyORMException } from 'src/engine/twenty-orm/exceptions/twenty-orm.exception';
 
-export const parseCalDAVError = (
-  error: Error,
+type ClassifiedException =
+  | CalendarEventImportDriverException
+  | ConnectedAccountRefreshAccessTokenException
+  | TwentyORMException;
+
+const CALDAV_AUTH_ERROR_MESSAGES = [
+  'Invalid auth method',
+  'Basic auth header was not encoded correctly',
+  "authMethod 'Custom' requires an authFunction to produce request headers",
+];
+
+const CALDAV_NOT_FOUND_ERROR_MESSAGES = [
+  'Collection does not exist on server',
+  'Calendar object to delete was not found',
+  'Calendar object to update was not found',
+  'Created calendar object was not found',
+];
+
+const CALDAV_DISCOVERY_ERROR_MESSAGES = [
+  'cannot find principalUrl',
+  'cannot find homeUrl',
+  'cannot find calendarUserAddresses',
+  'no account for fetchCalendars',
+  'no account for fetchAddressBooks',
+  'no account for smartCollectionSync',
+  'Must have account before syncCalendars',
+];
+
+const CALDAV_CALLER_ERROR_MESSAGES = [
+  'cannot fetchCalendarObjects for undefined calendar',
+  'cannot fetchVCards for undefined addressBook',
+  'collection.fetchObjects is required for basic sync changes',
+  'collection.objectMultiGet is required for webdav sync changes',
+  'timeRange is required',
+  'invalid timeRange format, not in ISO8601',
+  'invalid timeRange: start must be before end',
+  'invalid timeRange: start or end is not a valid date',
+  'freeBusyQuery returned no response',
+  'DAVClient not exported from built ESM bundle',
+];
+
+const CALDAV_AUTH_ERROR_PREFIXES = [
+  'Invalid credentials',
+  'Oauth credentials missing:',
+];
+
+const CALDAV_HTTP_ERROR_PREFIXES = [
+  'Collection query failed:',
+  'Collection status check failed:',
+];
+
+const CALDAV_DISCOVERY_ERROR_PATTERN = /^account must have .+ before /;
+const CALDAV_CALLER_ERROR_PATTERN = /^\w+ must have url before /;
+const CALDAV_HTTP_STATUS_PATTERN = /failed: (\d{3})\b/;
+
+const parseCalDAVHttpStatusError = (
+  message: string,
 ): CalendarEventImportDriverException => {
-  const { message } = error;
+  const status = Number(message.match(CALDAV_HTTP_STATUS_PATTERN)?.[1]);
 
-  switch (message) {
-    case 'Collection does not exist on server':
-      return new CalendarEventImportDriverException(
-        message,
-        CalendarEventImportDriverExceptionCode.NOT_FOUND,
-      );
+  if (status === 401 || status === 403) {
+    return new CalendarEventImportDriverException(
+      message,
+      CalendarEventImportDriverExceptionCode.INSUFFICIENT_PERMISSIONS,
+    );
+  }
 
-    case 'no account for smartCollectionSync':
-    case 'no account for fetchAddressBooks':
-    case 'no account for fetchCalendars':
-    case 'Must have account before syncCalendars':
-      return new CalendarEventImportDriverException(
-        message,
-        CalendarEventImportDriverExceptionCode.INSUFFICIENT_PERMISSIONS,
-      );
+  if (status === 404 || status === 410) {
+    return new CalendarEventImportDriverException(
+      message,
+      CalendarEventImportDriverExceptionCode.NOT_FOUND,
+    );
+  }
 
-    case 'cannot fetchVCards for undefined addressBook':
-    case 'cannot find calendarUserAddresses':
-    case 'cannot fetchCalendarObjects for undefined calendar':
-    case 'cannot find homeUrl':
-      return new CalendarEventImportDriverException(
-        message,
-        CalendarEventImportDriverExceptionCode.NOT_FOUND,
-      );
+  if (status === 408 || status === 429 || status >= 500) {
+    return new CalendarEventImportDriverException(
+      message,
+      CalendarEventImportDriverExceptionCode.TEMPORARY_ERROR,
+    );
+  }
 
-    case 'Invalid credentials':
-      return new CalendarEventImportDriverException(
-        message,
-        CalendarEventImportDriverExceptionCode.INSUFFICIENT_PERMISSIONS,
-      );
+  return new CalendarEventImportDriverException(
+    message,
+    CalendarEventImportDriverExceptionCode.UNKNOWN,
+  );
+};
 
-    case 'Invalid auth method':
-      return new CalendarEventImportDriverException(
-        message,
-        CalendarEventImportDriverExceptionCode.INSUFFICIENT_PERMISSIONS,
-      );
+export const parseCalDAVError = (error: unknown): ClassifiedException => {
+  if (
+    error instanceof CalendarEventImportDriverException ||
+    error instanceof ConnectedAccountRefreshAccessTokenException ||
+    error instanceof TwentyORMException
+  ) {
+    return error;
+  }
+
+  const message =
+    error instanceof Error ? error.message : `Unknown CalDAV error: ${error}`;
+
+  if (CALDAV_HTTP_ERROR_PREFIXES.some((prefix) => message.startsWith(prefix))) {
+    return parseCalDAVHttpStatusError(message);
+  }
+
+  if (
+    CALDAV_AUTH_ERROR_MESSAGES.includes(message) ||
+    CALDAV_AUTH_ERROR_PREFIXES.some((prefix) => message.startsWith(prefix))
+  ) {
+    return new CalendarEventImportDriverException(
+      message,
+      CalendarEventImportDriverExceptionCode.INSUFFICIENT_PERMISSIONS,
+    );
+  }
+
+  if (CALDAV_NOT_FOUND_ERROR_MESSAGES.includes(message)) {
+    return new CalendarEventImportDriverException(
+      message,
+      CalendarEventImportDriverExceptionCode.NOT_FOUND,
+    );
+  }
+
+  if (
+    CALDAV_CALLER_ERROR_MESSAGES.includes(message) ||
+    CALDAV_CALLER_ERROR_PATTERN.test(message)
+  ) {
+    return new CalendarEventImportDriverException(
+      message,
+      CalendarEventImportDriverExceptionCode.CHANNEL_MISCONFIGURED,
+    );
+  }
+
+  if (
+    CALDAV_DISCOVERY_ERROR_MESSAGES.includes(message) ||
+    CALDAV_DISCOVERY_ERROR_PATTERN.test(message)
+  ) {
+    return new CalendarEventImportDriverException(
+      message,
+      CalendarEventImportDriverExceptionCode.TEMPORARY_ERROR,
+    );
   }
 
   return new CalendarEventImportDriverException(


### PR DESCRIPTION
`parseCalDAVError` matched 11 of tsdav's error messages. Everything else fell to UNKNOWN, and FAILED_UNKNOWN is revived by the relaunch cron every 30 minutes with the retry counter reset, so a permanently broken channel retries forever. One account has been looping since May.

Ports every throw site in tsdav, adds prefix matching for the dynamic message families (`Collection query failed: <status>`, `Oauth credentials missing: <fields>`, `account must have <fields> before <op>`), and makes the parser total and idempotent so an already-classified exception is never downgraded no matter where it is caught.

Auth failures are permanent, discovery failures are retryable rather than a silent disconnect, and errors caused by calling tsdav wrong map to CHANNEL_MISCONFIGURED so they read as our defect, not the customer's permissions. Tests mirror tsdav's own assertions so they break if upstream rewords.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/24032?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

