### PR TITLE
fix(front): hide the remove icon on the last invite-team input

### DIFF
--- a/packages/twenty-front/src/pages/onboarding/InviteTeam.tsx
+++ b/packages/twenty-front/src/pages/onboarding/InviteTeam.tsx
@@ -58,6 +58,8 @@ export const InviteTeam = () => {
   const creditsRewardPerUser = onboardingConfig?.inviteTeamCreditsRewardPerUser;
   const transition = useOnboardingMotionTransition();
 
+  const canRemoveEmailField = fields.length > 1;
+
   return (
     <StyledOnboardingStepPage>
       <StyledOnboardingStepHeading>
@@ -108,8 +110,10 @@ export const InviteTeam = () => {
                       onBlur={onBlur}
                       error={error?.message}
                       onChange={onChange}
-                      RightIcon={IconX}
-                      onRightIconClick={() => remove(index)}
+                      RightIcon={canRemoveEmailField ? IconX : undefined}
+                      onRightIconClick={
+                        canRemoveEmailField ? () => remove(index) : undefined
+                      }
                       noErrorHelper
                       fullWidth
                     />

--- a/packages/twenty-front/src/pages/onboarding/__stories__/InviteTeam.stories.tsx
+++ b/packages/twenty-front/src/pages/onboarding/__stories__/InviteTeam.stories.tsx
@@ -1,7 +1,7 @@
 import { getOperationName } from '~/utils/getOperationName';
 import { type Meta, type StoryObj } from '@storybook/react-vite';
 import { HttpResponse, graphql } from 'msw';
-import { within } from 'storybook/test';
+import { expect, userEvent, waitFor, within } from 'storybook/test';
 import { AppPath } from 'twenty-shared/types';
 
 import { OnboardingStatus } from '~/generated-metadata/graphql';
@@ -31,6 +31,11 @@ const meta: Meta<PageDecoratorArgs> = {
             },
           });
         }),
+        graphql.query('GetInviteSuggestions', () => {
+          return HttpResponse.json({
+            data: { getInviteSuggestions: [] },
+          });
+        }),
         graphqlMocks.handlers,
       ],
     },
@@ -41,9 +46,42 @@ export default meta;
 
 export type Story = StoryObj<typeof InviteTeam>;
 
+const findEmailInputs = (canvas: ReturnType<typeof within>) =>
+  canvas.findAllByPlaceholderText(/@apple\.com$/);
+
+const getRemoveButtons = (canvasElement: HTMLElement) =>
+  canvasElement.ownerDocument.body.querySelectorAll('.tabler-icon-x');
+
 export const Default: Story = {
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement.ownerDocument.body);
     await canvas.findByText('Invite your team');
+  },
+};
+
+export const RemovesAllInputsButTheLast: Story = {
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement.ownerDocument.body);
+
+    await canvas.findByText('Invite your team');
+    await waitFor(async () =>
+      expect(await findEmailInputs(canvas)).toHaveLength(3),
+    );
+
+    expect(getRemoveButtons(canvasElement)).toHaveLength(3);
+
+    await userEvent.click(getRemoveButtons(canvasElement)[2]);
+    await waitFor(async () =>
+      expect(await findEmailInputs(canvas)).toHaveLength(2),
+    );
+    expect(getRemoveButtons(canvasElement)).toHaveLength(2);
+
+    await userEvent.click(getRemoveButtons(canvasElement)[1]);
+    await waitFor(async () =>
+      expect(await findEmailInputs(canvas)).toHaveLength(1),
+    );
+    await waitFor(() =>
+      expect(getRemoveButtons(canvasElement)).toHaveLength(0),
+    );
   },
 };


### PR DESCRIPTION
## Problem

The invite-team onboarding step renders an `x` on every email input. Once the user has removed inputs down to a single one, that `x` is still shown — and clicking it removes the only place left to type an address. The step is left with no input at all, and there is no "add" button to get one back.

## Fix

`InviteTeam.tsx` now only passes `RightIcon`/`onRightIconClick` to `TextInput` when more than one input is displayed, so the remove affordance disappears on the last remaining field.

A single field is always empty in practice — the form appends a new blank input as soon as the last one is filled — so nothing is lost by hiding the remove action there.

## Tests

Added a `RemovesAllInputsButTheLast` play story to `InviteTeam.stories.tsx`, covering both directions: every input keeps its remove icon while several are displayed, and the icon is gone once removals leave a single input.

Verified against the unfixed component it fails with `expected <svg> to have a length of +0 but got 1`, and passes with the fix. `npx nx typecheck twenty-front` plus oxlint/oxfmt on the changed files are clean.