### PR TITLE
fix(front): stop showing No results found while command menu items are displayed

### DIFF
--- a/packages/twenty-front/src/modules/command-menu-item/display/components/SidePanelCommandMenuItemDisplayPage.tsx
+++ b/packages/twenty-front/src/modules/command-menu-item/display/components/SidePanelCommandMenuItemDisplayPage.tsx
@@ -82,10 +82,11 @@ export const SidePanelCommandMenuItemDisplayPage = () => {
     ? pinnedCommandMenuItems.slice(visiblePinnedCommandMenuItemCount)
     : pinnedCommandMenuItems;
 
-  const pinnedItemsToFilter =
-    sidePanelSearch.length > 0
-      ? pinnedCommandMenuItems
-      : pinnedOverflowCommandMenuItems;
+  const isSearchActive = sidePanelSearch.trim().length > 0;
+
+  const pinnedItemsToFilter = isSearchActive
+    ? pinnedCommandMenuItems
+    : pinnedOverflowCommandMenuItems;
 
   const matchingPinnedItems =
     filterCommandMenuItemsWithSidePanelSearch(pinnedItemsToFilter);
@@ -93,16 +94,26 @@ export const SidePanelCommandMenuItemDisplayPage = () => {
     unpinnedCommandMenuItems,
   );
 
-  const noResults = !matchingPinnedItems.length && !matchingOtherItems.length;
+  const hasNoMatchingItems =
+    !matchingPinnedItems.length && !matchingOtherItems.length;
+
+  const shouldDisplayFallbackItems =
+    hasNoMatchingItems && fallbackCommandMenuItems.length > 0;
+
+  const shouldDisplayNoResults =
+    isSearchActive && hasNoMatchingItems && !shouldDisplayFallbackItems;
 
   const selectableItemIds = [
     ...matchingPinnedItems,
     ...matchingOtherItems,
-    ...(noResults ? fallbackCommandMenuItems : []),
+    ...(shouldDisplayFallbackItems ? fallbackCommandMenuItems : []),
   ].map((item) => item.id);
 
   return (
-    <SidePanelList selectableItemIds={selectableItemIds} noResults={noResults}>
+    <SidePanelList
+      selectableItemIds={selectableItemIds}
+      noResults={shouldDisplayNoResults}
+    >
       {matchingPinnedItems.length > 0 && (
         <SidePanelGroup heading={t`Pinned`}>
           {matchingPinnedItems.map((item) => (
@@ -117,7 +128,7 @@ export const SidePanelCommandMenuItemDisplayPage = () => {
           ))}
         </SidePanelGroup>
       )}
-      {noResults && fallbackCommandMenuItems.length > 0 && (
+      {shouldDisplayFallbackItems && (
         <SidePanelGroup heading={t`Fallback`}>
           {fallbackCommandMenuItems.map((item) => (
             <CommandMenuItemRenderer item={item} key={item.id} />

--- a/packages/twenty-front/src/modules/command-menu-item/display/components/SidePanelCommandMenuItemDisplayPage.tsx
+++ b/packages/twenty-front/src/modules/command-menu-item/display/components/SidePanelCommandMenuItemDisplayPage.tsx
@@ -11,7 +11,7 @@ import { sidePanelSearchState } from '@/side-panel/states/sidePanelSearchState';
 import { useAtomFamilyStateValue } from '@/ui/utilities/state/jotai/hooks/useAtomFamilyStateValue';
 import { useAtomStateValue } from '@/ui/utilities/state/jotai/hooks/useAtomStateValue';
 import { useLingui } from '@lingui/react/macro';
-import { isNumber } from '@sniptt/guards';
+import { isNonEmptyString, isNumber } from '@sniptt/guards';
 import { useContext, useMemo } from 'react';
 import { CommandMenuItemAvailabilityType } from '~/generated-metadata/graphql';
 
@@ -82,7 +82,7 @@ export const SidePanelCommandMenuItemDisplayPage = () => {
     ? pinnedCommandMenuItems.slice(visiblePinnedCommandMenuItemCount)
     : pinnedCommandMenuItems;
 
-  const isSearchActive = sidePanelSearch.trim().length > 0;
+  const isSearchActive = isNonEmptyString(sidePanelSearch.trim());
 
   const pinnedItemsToFilter = isSearchActive
     ? pinnedCommandMenuItems

--- a/packages/twenty-front/src/modules/command-menu-item/display/components/__stories__/SidePanelCommandMenuItemDisplayPage.stories.tsx
+++ b/packages/twenty-front/src/modules/command-menu-item/display/components/__stories__/SidePanelCommandMenuItemDisplayPage.stories.tsx
@@ -156,6 +156,25 @@ export const EmptySearchWithAllPinnedItemsInHeader: Story = {
   },
 };
 
+export const WhitespaceOnlySearchWithAllPinnedItemsInHeader: Story = {
+  decorators: [
+    createDecorator({
+      commandMenuItems: [...PINNED_ITEMS, FALLBACK_ITEM],
+      sidePanelSearch: '   ',
+      pinnedItemsContainerWidth: 1000,
+    }),
+  ],
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    expect(await canvas.findByText('Search records')).toBeVisible();
+    await waitFor(() => {
+      expect(canvas.queryByText('No results found')).not.toBeInTheDocument();
+    });
+    expect(canvas.queryByText('Delete')).not.toBeInTheDocument();
+  },
+};
+
 export const EmptySearchWithOverflowingPinnedItems: Story = {
   decorators: [
     createDecorator({

--- a/packages/twenty-front/src/modules/command-menu-item/display/components/__stories__/SidePanelCommandMenuItemDisplayPage.stories.tsx
+++ b/packages/twenty-front/src/modules/command-menu-item/display/components/__stories__/SidePanelCommandMenuItemDisplayPage.stories.tsx
@@ -1,0 +1,228 @@
+import {
+  type Decorator,
+  type Meta,
+  type StoryObj,
+} from '@storybook/react-vite';
+import { Provider as JotaiProvider } from 'jotai';
+import { expect, waitFor, within } from 'storybook/test';
+
+import { CommandMenuContext } from '@/command-menu-item/contexts/CommandMenuContext';
+import { EMPTY_COMMAND_MENU_CONTEXT_API } from '@/command-menu-item/constants/EmptyCommandMenuContextApi';
+import { SidePanelCommandMenuItemDisplayPage } from '@/command-menu-item/display/components/SidePanelCommandMenuItemDisplayPage';
+import { commandMenuPinnedInlineLayoutFamilyState } from '@/command-menu-item/display/states/commandMenuPinnedInlineLayoutFamilyState';
+import { CommandMenuComponentInstanceContext } from '@/command-menu/states/contexts/CommandMenuComponentInstanceContext';
+import { sidePanelSearchState } from '@/side-panel/states/sidePanelSearchState';
+import { jotaiStore } from '@/ui/utilities/state/jotai/jotaiStore';
+import { RouterDecorator } from 'twenty-ui/testing';
+import { ContextStoreDecorator } from '~/testing/decorators/ContextStoreDecorator';
+import { ObjectMetadataItemsDecorator } from '~/testing/decorators/ObjectMetadataItemsDecorator';
+import { SnackBarDecorator } from '~/testing/decorators/SnackBarDecorator';
+import {
+  CommandMenuItemAvailabilityType,
+  EngineComponentKey,
+  type CommandMenuItemFieldsFragment,
+} from '~/generated-metadata/graphql';
+
+const PINNED_ITEM_WIDTH = 100;
+
+const createCommandMenuItem = (
+  overrides: Partial<CommandMenuItemFieldsFragment> &
+    Pick<CommandMenuItemFieldsFragment, 'id' | 'label'>,
+): CommandMenuItemFieldsFragment => ({
+  __typename: 'CommandMenuItem',
+  isActive: true,
+  workflowVersionId: null,
+  frontComponentId: null,
+  frontComponent: null,
+  engineComponentKey: EngineComponentKey.GO_TO_PEOPLE,
+  icon: 'IconUser',
+  shortLabel: overrides.label,
+  position: 1,
+  isPinned: false,
+  hotKeys: null,
+  conditionalAvailabilityExpression: null,
+  availabilityType: CommandMenuItemAvailabilityType.GLOBAL,
+  availabilityObjectMetadataId: null,
+  payload: null,
+  ...overrides,
+});
+
+const PINNED_ITEMS = [
+  createCommandMenuItem({
+    id: 'story-pinned-add-to-favorites',
+    label: 'Add to favorites',
+    icon: 'IconHeart',
+    engineComponentKey: EngineComponentKey.ADD_TO_FAVORITES,
+    isPinned: true,
+  }),
+  createCommandMenuItem({
+    id: 'story-pinned-delete',
+    label: 'Delete',
+    icon: 'IconTrash',
+    engineComponentKey: EngineComponentKey.DELETE_SINGLE_RECORD,
+    isPinned: true,
+  }),
+];
+
+const OTHER_ITEM = createCommandMenuItem({
+  id: 'story-go-to-people',
+  label: 'Go to People',
+});
+
+const FALLBACK_ITEM = createCommandMenuItem({
+  id: 'story-search-records-fallback',
+  label: 'Search records',
+  icon: 'IconSearch',
+  engineComponentKey: EngineComponentKey.SEARCH_RECORDS_FALLBACK,
+  availabilityType: CommandMenuItemAvailabilityType.FALLBACK,
+});
+
+type CreateDecoratorParams = {
+  commandMenuItems: CommandMenuItemFieldsFragment[];
+  sidePanelSearch: string;
+  pinnedItemsContainerWidth: number;
+};
+
+const createDecorator =
+  ({
+    commandMenuItems,
+    sidePanelSearch,
+    pinnedItemsContainerWidth,
+  }: CreateDecoratorParams): Decorator =>
+  (Story) => {
+    jotaiStore.set(sidePanelSearchState.atom, sidePanelSearch);
+    jotaiStore.set(
+      commandMenuPinnedInlineLayoutFamilyState.atomFamily('page-header'),
+      {
+        containerWidth: pinnedItemsContainerWidth,
+        commandMenuItemWidthsByKey: Object.fromEntries(
+          PINNED_ITEMS.map((item) => [item.id, PINNED_ITEM_WIDTH]),
+        ),
+      },
+    );
+
+    return (
+      <JotaiProvider store={jotaiStore}>
+        <CommandMenuComponentInstanceContext.Provider
+          value={{ instanceId: 'story-command-menu' }}
+        >
+          <CommandMenuContext.Provider
+            value={{
+              displayType: 'listItem',
+              containerType: 'command-menu-list',
+              commandMenuItems,
+              commandMenuContextApi: EMPTY_COMMAND_MENU_CONTEXT_API,
+              isInPreviewMode: false,
+            }}
+          >
+            <Story />
+          </CommandMenuContext.Provider>
+        </CommandMenuComponentInstanceContext.Provider>
+      </JotaiProvider>
+    );
+  };
+
+const meta: Meta<typeof SidePanelCommandMenuItemDisplayPage> = {
+  title: 'Modules/CommandMenu/SidePanelCommandMenuItemDisplayPage',
+  component: SidePanelCommandMenuItemDisplayPage,
+  decorators: [
+    ContextStoreDecorator,
+    ObjectMetadataItemsDecorator,
+    SnackBarDecorator,
+    RouterDecorator,
+  ],
+};
+
+export default meta;
+
+type Story = StoryObj<typeof SidePanelCommandMenuItemDisplayPage>;
+
+export const EmptySearchWithAllPinnedItemsInHeader: Story = {
+  decorators: [
+    createDecorator({
+      commandMenuItems: [...PINNED_ITEMS, FALLBACK_ITEM],
+      sidePanelSearch: '',
+      pinnedItemsContainerWidth: 1000,
+    }),
+  ],
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    expect(await canvas.findByText('Search records')).toBeVisible();
+    await waitFor(() => {
+      expect(canvas.queryByText('No results found')).not.toBeInTheDocument();
+    });
+    expect(canvas.queryByText('Delete')).not.toBeInTheDocument();
+  },
+};
+
+export const EmptySearchWithOverflowingPinnedItems: Story = {
+  decorators: [
+    createDecorator({
+      commandMenuItems: [...PINNED_ITEMS, OTHER_ITEM],
+      sidePanelSearch: '',
+      pinnedItemsContainerWidth: PINNED_ITEM_WIDTH,
+    }),
+  ],
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    expect(await canvas.findByText('Delete')).toBeVisible();
+    expect(await canvas.findByText('Go to People')).toBeVisible();
+    await waitFor(() => {
+      expect(canvas.queryByText('No results found')).not.toBeInTheDocument();
+    });
+  },
+};
+
+export const SearchWithMatchingItems: Story = {
+  decorators: [
+    createDecorator({
+      commandMenuItems: [...PINNED_ITEMS, OTHER_ITEM, FALLBACK_ITEM],
+      sidePanelSearch: 'delete',
+      pinnedItemsContainerWidth: 1000,
+    }),
+  ],
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    expect(await canvas.findByText('Delete')).toBeVisible();
+    await waitFor(() => {
+      expect(canvas.queryByText('No results found')).not.toBeInTheDocument();
+      expect(canvas.queryByText('Search records')).not.toBeInTheDocument();
+    });
+  },
+};
+
+export const SearchWithoutMatchingItemsAndWithoutFallback: Story = {
+  decorators: [
+    createDecorator({
+      commandMenuItems: [...PINNED_ITEMS, OTHER_ITEM],
+      sidePanelSearch: 'nothing matches this',
+      pinnedItemsContainerWidth: 1000,
+    }),
+  ],
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    expect(await canvas.findByText('No results found')).toBeVisible();
+  },
+};
+
+export const SearchWithoutMatchingItemsAndWithFallback: Story = {
+  decorators: [
+    createDecorator({
+      commandMenuItems: [...PINNED_ITEMS, OTHER_ITEM, FALLBACK_ITEM],
+      sidePanelSearch: 'nothing matches this',
+      pinnedItemsContainerWidth: 1000,
+    }),
+  ],
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    expect(await canvas.findByText('Search records')).toBeVisible();
+    await waitFor(() => {
+      expect(canvas.queryByText('No results found')).not.toBeInTheDocument();
+    });
+  },
+};

--- a/packages/twenty-front/src/modules/command-menu/components/__stories__/CommandMenu.stories.tsx
+++ b/packages/twenty-front/src/modules/command-menu/components/__stories__/CommandMenu.stories.tsx
@@ -231,7 +231,10 @@ export const NoResultsSearchFallback: Story = {
     const searchInput = await canvas.findByTestId(SIDE_PANEL_FOCUS_ID);
     await sleep(openTimeout);
     await userEvent.type(searchInput, 'input without results');
-    expect(await canvas.findByText('No results found')).toBeVisible();
+    expect(await canvas.findByText('Fallback')).toBeVisible();
+    await waitFor(() => {
+      expect(canvas.queryByText('No results found')).not.toBeInTheDocument();
+    });
   },
   parameters: {
     msw: {


### PR DESCRIPTION
Fixes #22834

### Problem

`SidePanelCommandMenuItemDisplayPage` derived a single `noResults` flag and used it for two unrelated things: as the empty-state trigger passed to `SidePanelList`, and as the condition for rendering the fallback items.

With an empty search string, `matchingPinnedItems` only holds the pinned items that overflowed out of the page header, so it is empty whenever every pinned item fits inline. `matchingOtherItems` is empty when the workspace has no unpinned non-fallback item. `noResults` was then true, which both rendered the fallback group and printed "No results found" above it, so the message showed while results were on screen.

### Fix

Split the two concerns:

- `isSearchActive` is true only when the trimmed search string is non-empty (it also replaces the raw `length > 0` check that decided which pinned items to filter, so a whitespace-only search no longer counts as a search).
- `shouldDisplayFallbackItems` keeps the previous trigger: no matching items and at least one fallback item.
- `shouldDisplayNoResults`, passed to `SidePanelList`, is true only for an active search that matched nothing and rendered no fallback items.

### Tests

New stories in `SidePanelCommandMenuItemDisplayPage.stories.tsx` cover the empty search with all pinned items in the header (the regression), the empty search with overflowing pinned items, a matching search, and a non-matching search with and without fallback items.

`CommandMenu.stories.tsx` > `NoResultsSearchFallback` used to assert that the message and the fallback item render together; it now asserts the fallback group renders without the message.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/24040?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

