### PR TITLE
Make server-served front same-origin by default and surface CORS misconfig

### DIFF
--- a/packages/twenty-docs/developers/self-host/capabilities/docker-compose.mdx
+++ b/packages/twenty-docs/developers/self-host/capabilities/docker-compose.mdx
@@ -102,7 +102,7 @@ curl http://localhost:3000
 
 ### Expose Twenty to External Access
 
-By default, Twenty runs on `localhost` at port `3000`. To access it via an external domain or IP address, you need to configure the `SERVER_URL` in your `.env` file.
+By default, Twenty runs on `localhost` at port `3000`. The UI resolves the API from the browser's own origin, so it loads from any hostname that reaches the container — but still set `SERVER_URL` to your public URL: the server uses it for generated links (emails, OAuth callbacks) and to detect HTTPS for secure cookies.
 
 #### Understanding `SERVER_URL`
 
@@ -217,7 +217,7 @@ Add to your crontab (`crontab -e`):
 
 1. Stop the application:
 ```bash
-docker compose stop twenty-server twenty-front
+docker compose stop server worker
 ```
 
 2. Restore the database:

--- a/packages/twenty-docs/developers/self-host/capabilities/setup.mdx
+++ b/packages/twenty-docs/developers/self-host/capabilities/setup.mdx
@@ -382,17 +382,23 @@ Only relevant if you do not let the back-end serve the front-end. Same-origin
 deployments need nothing here.
 
 Declare every browser origin that talks to the API, comma separated. `SERVER_URL`
-and `FRONTEND_URL` are already trusted.
+and `FRONTEND_URL` are already trusted. The server logs a warning when a browser
+calls it from an undeclared origin.
 
 ```bash
 AUTH_COOKIE_ALLOWED_ORIGINS=https://app.example.com
 ```
 
 <Warning>
-Upgrading to a version with cookie sessions makes this required. The front-end
-now sends credentials on every request, and browsers reject a credentialed
-response from an undeclared origin, so the app fails to load until you set this.
+The front-end sends credentials on every request, and browsers reject a
+credentialed response from an undeclared origin, so the app fails to load until
+you set this.
 </Warning>
 
 If the two hosts are on different registrable domains (not just different
 subdomains), also set `AUTH_COOKIE_SAME_SITE=none`, which requires HTTPS.
+
+With multi-workspace enabled, do not list every workspace subdomain here.
+Instead, route API paths (`/graphql`, `/metadata`, `/rest`, `/auth/`,
+`/client-config`, `/file`) to the back-end on each workspace hostname, so every
+workspace stays same-origin — this is how Twenty Cloud runs.

--- a/packages/twenty-front/src/modules/client-config/utils/__tests__/clientConfigUtils.test.ts
+++ b/packages/twenty-front/src/modules/client-config/utils/__tests__/clientConfigUtils.test.ts
@@ -61,15 +61,11 @@ describe('getClientConfig', () => {
 
     const result = await getClientConfig();
 
+    // No credentials and no custom headers: the request must stay a simple
+    // uncredentialed GET so split-origin deployments can boot (see
+    // getClientConfig).
     expect(fetch).toHaveBeenCalledWith(
       `${REACT_APP_SERVER_BASE_URL}/client-config`,
-      {
-        method: 'GET',
-        headers: {
-          'Content-Type': 'application/json',
-        },
-        credentials: 'include',
-      },
     );
     expect(result).toEqual(mockClientConfig);
   });

--- a/packages/twenty-front/src/modules/client-config/utils/__tests__/clientConfigUtils.test.ts
+++ b/packages/twenty-front/src/modules/client-config/utils/__tests__/clientConfigUtils.test.ts
@@ -61,9 +61,6 @@ describe('getClientConfig', () => {
 
     const result = await getClientConfig();
 
-    // No credentials and no custom headers: the request must stay a simple
-    // uncredentialed GET so split-origin deployments can boot (see
-    // getClientConfig).
     expect(fetch).toHaveBeenCalledWith(
       `${REACT_APP_SERVER_BASE_URL}/client-config`,
     );

--- a/packages/twenty-front/src/modules/client-config/utils/getClientConfig.ts
+++ b/packages/twenty-front/src/modules/client-config/utils/getClientConfig.ts
@@ -2,9 +2,6 @@ import { type ClientConfig } from '@/client-config/types/ClientConfig';
 import { REACT_APP_SERVER_BASE_URL } from '~/config';
 
 export const getClientConfig = async (): Promise<ClientConfig> => {
-  // Plain uncredentialed GET: the endpoint is public, and this request must
-  // stay a simple CORS request so a split-origin deployment can still boot
-  // and show a meaningful error when its origin is not allowlisted.
   const response = await fetch(`${REACT_APP_SERVER_BASE_URL}/client-config`);
 
   if (!response.ok) {

--- a/packages/twenty-front/src/modules/client-config/utils/getClientConfig.ts
+++ b/packages/twenty-front/src/modules/client-config/utils/getClientConfig.ts
@@ -2,13 +2,10 @@ import { type ClientConfig } from '@/client-config/types/ClientConfig';
 import { REACT_APP_SERVER_BASE_URL } from '~/config';
 
 export const getClientConfig = async (): Promise<ClientConfig> => {
-  const response = await fetch(`${REACT_APP_SERVER_BASE_URL}/client-config`, {
-    method: 'GET',
-    headers: {
-      'Content-Type': 'application/json',
-    },
-    credentials: 'include',
-  });
+  // Plain uncredentialed GET: the endpoint is public, and this request must
+  // stay a simple CORS request so a split-origin deployment can still boot
+  // and show a meaningful error when its origin is not allowlisted.
+  const response = await fetch(`${REACT_APP_SERVER_BASE_URL}/client-config`);
 
   if (!response.ok) {
     throw new Error(

--- a/packages/twenty-server/src/engine/core-modules/twenty-config/config-variables.ts
+++ b/packages/twenty-server/src/engine/core-modules/twenty-config/config-variables.ts
@@ -1421,23 +1421,6 @@ export class ConfigVariables {
   @ConfigVariablesMetadata({
     group: ConfigVariablesGroup.SERVER_CONFIG,
     description:
-      'When enabled, the served frontend resolves the API base URL from ' +
-      "the browser's current origin (window.location) instead of the " +
-      'baked-in SERVER_URL. Useful for self-hosted deployments reachable ' +
-      'from multiple hostnames (Tailscale IP, LAN DNS, SSH tunnel, public ' +
-      'DNS), where pinning a single SERVER_URL would break every other ' +
-      'host with CORS or unreachable-host errors. Read at startup by ' +
-      'generate-front-config; SERVER_URL is still used for all server-side ' +
-      'URL generation.',
-    type: ConfigVariableType.BOOLEAN,
-    isEnvOnly: true,
-  })
-  @IsOptional()
-  FRONT_AUTO_BASE_URL = false;
-
-  @ConfigVariablesMetadata({
-    group: ConfigVariablesGroup.SERVER_CONFIG,
-    description:
       'Express "trust proxy" setting. Controls whether X-Forwarded-* ' +
       'headers are honored — required for request.protocol to return ' +
       '"https" when TLS is terminated upstream (reverse proxy, ingress, ' +

--- a/packages/twenty-server/src/engine/core-modules/user-session/utils/apply-credentialed-cors.util.spec.ts
+++ b/packages/twenty-server/src/engine/core-modules/user-session/utils/apply-credentialed-cors.util.spec.ts
@@ -1,0 +1,141 @@
+import { type INestApplication, Logger } from '@nestjs/common';
+
+import { type NextFunction, type Request, type Response } from 'express';
+
+import { type TwentyConfigService } from 'src/engine/core-modules/twenty-config/twenty-config.service';
+import { applyCredentialedCors } from 'src/engine/core-modules/user-session/utils/apply-credentialed-cors.util';
+
+describe('applyCredentialedCors', () => {
+  const defaultConfig: Record<string, unknown> = {
+    NODE_ENV: 'production',
+    SERVER_URL: 'https://crm.example.com',
+    FRONTEND_URL: undefined,
+    AUTH_COOKIE_ALLOWED_ORIGINS: '',
+  };
+
+  let mockConfig: Record<string, unknown> = { ...defaultConfig };
+
+  const buildMiddleware = () => {
+    const app = {
+      use: jest.fn(),
+      enableCors: jest.fn(),
+    } as unknown as INestApplication;
+
+    applyCredentialedCors(app, {
+      get: jest.fn((key: string) => mockConfig[key]),
+    } as unknown as TwentyConfigService);
+
+    return (app.use as jest.Mock).mock.calls[0][0] as (
+      request: Request,
+      response: Response,
+      next: NextFunction,
+    ) => void;
+  };
+
+  const buildPreflightRequest = ({
+    origin,
+    host = 'crm.example.com',
+    method = 'OPTIONS',
+    requestedMethod = 'POST',
+  }: {
+    origin?: string;
+    host?: string;
+    method?: string;
+    requestedMethod?: string;
+  }): Request =>
+    ({
+      method,
+      protocol: 'https',
+      headers: {
+        origin,
+        'access-control-request-method': requestedMethod,
+      },
+      get: jest.fn().mockReturnValue(host),
+    }) as unknown as Request;
+
+  const buildResponse = (): Response =>
+    ({ vary: jest.fn() }) as unknown as Response;
+
+  let warnSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockConfig = { ...defaultConfig };
+    warnSpy = jest.spyOn(Logger.prototype, 'warn').mockImplementation();
+  });
+
+  it('should warn once per disallowed cross-origin preflight and always call next', () => {
+    const middleware = buildMiddleware();
+    const next = jest.fn();
+    const response = buildResponse();
+
+    middleware(
+      buildPreflightRequest({ origin: 'https://tenant.example.net' }),
+      response,
+      next,
+    );
+    middleware(
+      buildPreflightRequest({ origin: 'https://tenant.example.net' }),
+      response,
+      next,
+    );
+
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining('https://tenant.example.net'),
+    );
+    expect(response.vary).toHaveBeenCalledTimes(2);
+    expect(next).toHaveBeenCalledTimes(2);
+  });
+
+  it('should not warn for an allowlisted origin', () => {
+    mockConfig.AUTH_COOKIE_ALLOWED_ORIGINS = 'https://front.example.net';
+    const middleware = buildMiddleware();
+
+    middleware(
+      buildPreflightRequest({ origin: 'https://front.example.net' }),
+      buildResponse(),
+      jest.fn(),
+    );
+
+    expect(warnSpy).not.toHaveBeenCalled();
+  });
+
+  it('should not warn for a same-origin preflight since browsers do not enforce CORS on it', () => {
+    const middleware = buildMiddleware();
+
+    middleware(
+      buildPreflightRequest({
+        origin: 'https://lan.example.internal',
+        host: 'lan.example.internal',
+      }),
+      buildResponse(),
+      jest.fn(),
+    );
+
+    expect(warnSpy).not.toHaveBeenCalled();
+  });
+
+  it('should not warn for requests that are not browser preflights', () => {
+    const middleware = buildMiddleware();
+
+    middleware(
+      buildPreflightRequest({
+        origin: 'https://tenant.example.net',
+        method: 'POST',
+      }),
+      buildResponse(),
+      jest.fn(),
+    );
+    middleware(
+      buildPreflightRequest({
+        origin: 'https://tenant.example.net',
+        requestedMethod: '',
+      }),
+      buildResponse(),
+      jest.fn(),
+    );
+
+    expect(warnSpy).not.toHaveBeenCalled();
+  });
+});

--- a/packages/twenty-server/src/engine/core-modules/user-session/utils/apply-credentialed-cors.util.spec.ts
+++ b/packages/twenty-server/src/engine/core-modules/user-session/utils/apply-credentialed-cors.util.spec.ts
@@ -1,11 +1,11 @@
-import { type INestApplication, Logger } from '@nestjs/common';
+import { Logger } from '@nestjs/common';
 
-import { type NextFunction, type Request, type Response } from 'express';
+import { type Request } from 'express';
 
 import { type TwentyConfigService } from 'src/engine/core-modules/twenty-config/twenty-config.service';
-import { applyCredentialedCors } from 'src/engine/core-modules/user-session/utils/apply-credentialed-cors.util';
+import { warnOnceOnDisallowedBrowserPreflight } from 'src/engine/core-modules/user-session/utils/apply-credentialed-cors.util';
 
-describe('applyCredentialedCors', () => {
+describe('warnOnceOnDisallowedBrowserPreflight', () => {
   const defaultConfig: Record<string, unknown> = {
     NODE_ENV: 'production',
     SERVER_URL: 'https://crm.example.com',
@@ -15,22 +15,9 @@ describe('applyCredentialedCors', () => {
 
   let mockConfig: Record<string, unknown> = { ...defaultConfig };
 
-  const buildMiddleware = () => {
-    const app = {
-      use: jest.fn(),
-      enableCors: jest.fn(),
-    } as unknown as INestApplication;
-
-    applyCredentialedCors(app, {
-      get: jest.fn((key: string) => mockConfig[key]),
-    } as unknown as TwentyConfigService);
-
-    return (app.use as jest.Mock).mock.calls[0][0] as (
-      request: Request,
-      response: Response,
-      next: NextFunction,
-    ) => void;
-  };
+  const twentyConfigService = {
+    get: jest.fn((key: string) => mockConfig[key]),
+  } as unknown as TwentyConfigService;
 
   const buildPreflightRequest = ({
     origin,
@@ -53,88 +40,79 @@ describe('applyCredentialedCors', () => {
       get: jest.fn().mockReturnValue(host),
     }) as unknown as Request;
 
-  const buildResponse = (): Response =>
-    ({ vary: jest.fn() }) as unknown as Response;
-
   let warnSpy: jest.SpyInstance;
+  let warnedOrigins: Set<string>;
 
   beforeEach(() => {
-    jest.clearAllMocks();
     mockConfig = { ...defaultConfig };
+    warnedOrigins = new Set<string>();
     warnSpy = jest.spyOn(Logger.prototype, 'warn').mockImplementation();
   });
 
-  it('should warn once per disallowed cross-origin preflight and always call next', () => {
-    const middleware = buildMiddleware();
-    const next = jest.fn();
-    const response = buildResponse();
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
 
-    middleware(
-      buildPreflightRequest({ origin: 'https://tenant.example.net' }),
-      response,
-      next,
-    );
-    middleware(
-      buildPreflightRequest({ origin: 'https://tenant.example.net' }),
-      response,
-      next,
-    );
+  it('should warn once per disallowed cross-origin preflight', () => {
+    warnOnceOnDisallowedBrowserPreflight({
+      request: buildPreflightRequest({ origin: 'https://tenant.example.net' }),
+      twentyConfigService,
+      warnedOrigins,
+    });
+    warnOnceOnDisallowedBrowserPreflight({
+      request: buildPreflightRequest({ origin: 'https://tenant.example.net' }),
+      twentyConfigService,
+      warnedOrigins,
+    });
 
     expect(warnSpy).toHaveBeenCalledTimes(1);
     expect(warnSpy).toHaveBeenCalledWith(
       expect.stringContaining('https://tenant.example.net'),
     );
-    expect(response.vary).toHaveBeenCalledTimes(2);
-    expect(next).toHaveBeenCalledTimes(2);
   });
 
   it('should not warn for an allowlisted origin', () => {
     mockConfig.AUTH_COOKIE_ALLOWED_ORIGINS = 'https://front.example.net';
-    const middleware = buildMiddleware();
 
-    middleware(
-      buildPreflightRequest({ origin: 'https://front.example.net' }),
-      buildResponse(),
-      jest.fn(),
-    );
+    warnOnceOnDisallowedBrowserPreflight({
+      request: buildPreflightRequest({ origin: 'https://front.example.net' }),
+      twentyConfigService,
+      warnedOrigins,
+    });
 
     expect(warnSpy).not.toHaveBeenCalled();
   });
 
   it('should not warn for a same-origin preflight since browsers do not enforce CORS on it', () => {
-    const middleware = buildMiddleware();
-
-    middleware(
-      buildPreflightRequest({
+    warnOnceOnDisallowedBrowserPreflight({
+      request: buildPreflightRequest({
         origin: 'https://lan.example.internal',
         host: 'lan.example.internal',
       }),
-      buildResponse(),
-      jest.fn(),
-    );
+      twentyConfigService,
+      warnedOrigins,
+    });
 
     expect(warnSpy).not.toHaveBeenCalled();
   });
 
   it('should not warn for requests that are not browser preflights', () => {
-    const middleware = buildMiddleware();
-
-    middleware(
-      buildPreflightRequest({
+    warnOnceOnDisallowedBrowserPreflight({
+      request: buildPreflightRequest({
         origin: 'https://tenant.example.net',
         method: 'POST',
       }),
-      buildResponse(),
-      jest.fn(),
-    );
-    middleware(
-      buildPreflightRequest({
+      twentyConfigService,
+      warnedOrigins,
+    });
+    warnOnceOnDisallowedBrowserPreflight({
+      request: buildPreflightRequest({
         origin: 'https://tenant.example.net',
         requestedMethod: '',
       }),
-      buildResponse(),
-      jest.fn(),
-    );
+      twentyConfigService,
+      warnedOrigins,
+    });
 
     expect(warnSpy).not.toHaveBeenCalled();
   });

--- a/packages/twenty-server/src/engine/core-modules/user-session/utils/apply-credentialed-cors.util.ts
+++ b/packages/twenty-server/src/engine/core-modules/user-session/utils/apply-credentialed-cors.util.ts
@@ -1,9 +1,81 @@
-import { type INestApplication } from '@nestjs/common';
+import { type INestApplication, Logger } from '@nestjs/common';
 
+import { isNonEmptyString } from '@sniptt/guards';
 import { type NextFunction, type Request, type Response } from 'express';
 
 import { type TwentyConfigService } from 'src/engine/core-modules/twenty-config/twenty-config.service';
 import { resolveAllowedCredentialedOrigins } from 'src/engine/core-modules/user-session/utils/resolve-allowed-credentialed-origins.util';
+import { getRequestBaseUrl } from 'src/utils/get-request-base-url.util';
+
+const logger = new Logger('CredentialedCors');
+
+// Prevents junk Origin headers from growing the warned set unbounded.
+const WARNED_ORIGINS_MAX = 1_000;
+
+const toComparableOrigin = (value: string): string | undefined => {
+  try {
+    return new URL(value).origin.toLowerCase();
+  } catch {
+    return undefined;
+  }
+};
+
+// The browser reports a rejected credentialed wildcard response only in its
+// own console, leaving nothing server-side for the operator to act on
+// (#24037). Warn once per origin on cross-origin browser preflights that will
+// be answered with the wildcard.
+const warnOnceOnDisallowedBrowserPreflight = ({
+  request,
+  twentyConfigService,
+  warnedOrigins,
+}: {
+  request: Request;
+  twentyConfigService: TwentyConfigService;
+  warnedOrigins: Set<string>;
+}): void => {
+  if (
+    request.method !== 'OPTIONS' ||
+    !isNonEmptyString(request.headers['access-control-request-method'])
+  ) {
+    return;
+  }
+
+  const origin = request.headers.origin;
+
+  if (!isNonEmptyString(origin)) {
+    return;
+  }
+
+  const comparableOrigin = toComparableOrigin(origin);
+
+  if (!isNonEmptyString(comparableOrigin)) {
+    return;
+  }
+
+  // Browsers do not enforce CORS on same-origin requests.
+  if (comparableOrigin === toComparableOrigin(getRequestBaseUrl(request))) {
+    return;
+  }
+
+  if (
+    resolveAllowedCredentialedOrigins(twentyConfigService).has(comparableOrigin)
+  ) {
+    return;
+  }
+
+  if (
+    warnedOrigins.has(comparableOrigin) ||
+    warnedOrigins.size >= WARNED_ORIGINS_MAX
+  ) {
+    return;
+  }
+
+  warnedOrigins.add(comparableOrigin);
+
+  logger.warn(
+    `Cross-origin browser request from ${comparableOrigin} (API host: ${getRequestBaseUrl(request)}); credentialed requests from it will be blocked by the browser. If this is your Twenty front-end, serve it same-origin with the API, or add the origin to AUTH_COOKIE_ALLOWED_ORIGINS. Logged once per origin.`,
+  );
+};
 
 // Shared between the production bootstrap and the integration test harness so
 // the CORS behavior under test is the deployed one.
@@ -11,11 +83,18 @@ export const applyCredentialedCors = (
   app: INestApplication,
   twentyConfigService: TwentyConfigService,
 ): void => {
+  const warnedOrigins = new Set<string>();
+
   // The cors package only emits Vary: Origin when it reflects one, so wildcard
   // and reflected responses would share a cache entry and a credentialed
   // request could be served the wildcard, which browsers reject.
-  app.use((_request: Request, response: Response, next: NextFunction) => {
+  app.use((request: Request, response: Response, next: NextFunction) => {
     response.vary('Origin');
+    warnOnceOnDisallowedBrowserPreflight({
+      request,
+      twentyConfigService,
+      warnedOrigins,
+    });
     next();
   });
 

--- a/packages/twenty-server/src/engine/core-modules/user-session/utils/apply-credentialed-cors.util.ts
+++ b/packages/twenty-server/src/engine/core-modules/user-session/utils/apply-credentialed-cors.util.ts
@@ -24,7 +24,7 @@ const toComparableOrigin = (value: string): string | undefined => {
 // own console, leaving nothing server-side for the operator to act on
 // (#24037). Warn once per origin on cross-origin browser preflights that will
 // be answered with the wildcard.
-const warnOnceOnDisallowedBrowserPreflight = ({
+export const warnOnceOnDisallowedBrowserPreflight = ({
   request,
   twentyConfigService,
   warnedOrigins,

--- a/packages/twenty-server/src/utils/__test__/generate-front-config.spec.ts
+++ b/packages/twenty-server/src/utils/__test__/generate-front-config.spec.ts
@@ -20,8 +20,8 @@ const INDEX_TEMPLATE = `<html>
 </html>`;
 
 // Pull the injected _env_ object back out of the written index.html and
-// normalize whitespace so the multi-line JSON.stringify(..., 2) output can be
-// compared against a compact expected string.
+// normalize whitespace so the multi-line output can be compared against a
+// compact expected string.
 const getInjectedEnv = (): string => {
   const writtenContent = mockedFs.writeFileSync.mock.calls[0][1] as string;
   const match = writtenContent.match(/window\._env_ = (\{[\s\S]*?\});/);
@@ -42,43 +42,11 @@ describe('generateFrontConfig', () => {
     process.env = ORIGINAL_ENV;
   });
 
-  it('should inject the absolute SERVER_URL when set and the toggle is unset', () => {
+  it('should clear any baked value so the front resolves the API origin from the page origin', () => {
     process.env.SERVER_URL = 'http://x.com';
-    delete process.env.FRONT_AUTO_BASE_URL;
-
-    generateFrontConfig();
-
-    expect(getInjectedEnv()).toBe(
-      '{"REACT_APP_SERVER_BASE_URL":"http://x.com"}',
-    );
-  });
-
-  it('should inject an empty _env_ when SERVER_URL is unset', () => {
-    delete process.env.SERVER_URL;
-    delete process.env.FRONT_AUTO_BASE_URL;
 
     generateFrontConfig();
 
     expect(getInjectedEnv()).toBe('{}');
-  });
-
-  it('should inject an empty _env_ when FRONT_AUTO_BASE_URL=true even if SERVER_URL is set', () => {
-    process.env.SERVER_URL = 'http://x.com';
-    process.env.FRONT_AUTO_BASE_URL = 'true';
-
-    generateFrontConfig();
-
-    expect(getInjectedEnv()).toBe('{}');
-  });
-
-  it('should keep the absolute SERVER_URL when FRONT_AUTO_BASE_URL is not exactly "true"', () => {
-    process.env.SERVER_URL = 'http://x.com';
-    process.env.FRONT_AUTO_BASE_URL = 'false';
-
-    generateFrontConfig();
-
-    expect(getInjectedEnv()).toBe(
-      '{"REACT_APP_SERVER_BASE_URL":"http://x.com"}',
-    );
   });
 });

--- a/packages/twenty-server/src/utils/generate-front-config.ts
+++ b/packages/twenty-server/src/utils/generate-front-config.ts
@@ -10,9 +10,8 @@ config({
 export function generateFrontConfig(): void {
   // A page served by this server can always reach the API on the origin it
   // was loaded from, so the front resolves it from window.location (see
-  // packages/twenty-front/src/config). Baking SERVER_URL instead would break
-  // every other hostname (LAN IP, tunnel, workspace subdomain) with
-  // credentialed CORS errors. Rewriting clears any value baked at build time.
+  // packages/twenty-front/src/config). Rewriting clears any value baked into
+  // index.html at build time.
   const configString = `<!-- BEGIN: Twenty Config -->
     <script id="twenty-env-config">
       window._env_ = {};

--- a/packages/twenty-server/src/utils/generate-front-config.ts
+++ b/packages/twenty-server/src/utils/generate-front-config.ts
@@ -8,21 +8,14 @@ config({
 });
 
 export function generateFrontConfig(): void {
-  // When FRONT_AUTO_BASE_URL=true (or SERVER_URL is unset), inject an empty
-  // _env_ so the frontend's getDefaultUrl() fallback resolves the API origin
-  // from the page's own hostname at request time. This lets the same deploy
-  // be reached at both http://<external-ip> and http://localhost without a
-  // hairpin through the public interface.
-  const useAutoUrl =
-    process.env.FRONT_AUTO_BASE_URL === 'true' || !process.env.SERVER_URL;
-
-  const envForFront = useAutoUrl
-    ? {}
-    : { REACT_APP_SERVER_BASE_URL: process.env.SERVER_URL };
-
+  // A page served by this server can always reach the API on the origin it
+  // was loaded from, so the front resolves it from window.location (see
+  // packages/twenty-front/src/config). Baking SERVER_URL instead would break
+  // every other hostname (LAN IP, tunnel, workspace subdomain) with
+  // credentialed CORS errors. Rewriting clears any value baked at build time.
   const configString = `<!-- BEGIN: Twenty Config -->
     <script id="twenty-env-config">
-      window._env_ = ${JSON.stringify(envForFront, null, 2)};
+      window._env_ = {};
     </script>
     <!-- END: Twenty Config -->`;
 


### PR DESCRIPTION
Closes #24037

Since the cookie-session migration, every front request is credentialed, and browsers reject the wildcard CORS response served to undeclared origins. Split-origin self-hosted deployments therefore die at `GET /client-config` with nothing actionable in the server logs. Baking `SERVER_URL` into `index.html` also made single-container setups silently split-origin whenever browsed from another hostname (LAN IP, tunnel, workspace subdomain).

### Changes

- **Server-served front is now always same-origin.** `generateFrontConfig` injects an empty `window._env_`, so the front resolves the API from the page origin — a page served by this server can always reach the API on the origin it was loaded from. This is already how Cloud runs (the S3-served bundle has no `_env_`, so it falls back to `window.location.origin`); the `FRONT_AUTO_BASE_URL` toggle that opted into this is removed. `SERVER_URL` keeps its server-side roles (generated links, OAuth callbacks, HTTPS detection, CORS trust anchor).
- **`/client-config` is fetched as a plain uncredentialed GET.** The endpoint is public; keeping the request "simple" lets a misconfigured split-origin deployment boot far enough to show a real error instead of "unable to reach back-end".
- **The server warns (once per origin) on browser preflights from non-allowlisted origins**, giving operators a server-side breadcrumb with the fix (`serve same-origin, or add to AUTH_COOKIE_ALLOWED_ORIGINS`) instead of a browser-console-only rejection.
- **Docs:** multi-workspace deployments should route API paths on each workspace hostname instead of allowlisting every subdomain; `SERVER_URL` guidance no longer claims the UI needs it to be reachable; removed a stale `twenty-front` compose service reference.

### Notes

- Deployments that intentionally pointed a server-served front at a different API origin now become same-origin, which avoids the credentialed-CORS requirement entirely.
- `AUTH_COOKIE_ALLOWED_ORIGINS` / `AUTH_COOKIE_SAME_SITE` remain the escape hatch for genuinely split origins, unchanged.

https://claude.ai/code/session_01SzX4ttLQffjXuRmYBfjuKr