### PR TITLE
Remove alpha sufix to npm packages

### DIFF
--- a/packages/create-twenty-app/package.json
+++ b/packages/create-twenty-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-twenty-app",
-  "version": "2.31.0-alpha.1",
+  "version": "2.31.0",
   "description": "Command-line interface to create Twenty application",
   "main": "dist/cli.cjs",
   "bin": "dist/cli.cjs",

--- a/packages/twenty-client-sdk/package.json
+++ b/packages/twenty-client-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "twenty-client-sdk",
-  "version": "2.31.0-alpha.1",
+  "version": "2.31.0",
   "sideEffects": false,
   "license": "MIT",
   "scripts": {

--- a/packages/twenty-sdk/package.json
+++ b/packages/twenty-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "twenty-sdk",
-  "version": "2.31.0-alpha.1",
+  "version": "2.31.0",
   "sideEffects": false,
   "bin": {
     "twenty": "dist/cli.cjs"


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/24059?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

