### PR TITLE
chore(billing): strip the commentary from the credit grant ledger

### DIFF
--- a/packages/twenty-front/src/modules/settings/admin-panel/components/SettingsAdminWorkspaceCreditGrantModal.tsx
+++ b/packages/twenty-front/src/modules/settings/admin-panel/components/SettingsAdminWorkspaceCreditGrantModal.tsx
@@ -64,11 +64,6 @@ export const SettingsAdminWorkspaceCreditGrantModal = ({
     BillingCreditGrantType.COMPENSATION,
   );
   const [reason, setReason] = useState('');
-  // Identifies one intended grant, so a RetryLink retry or a resubmit after a
-  // lost response is answered with the grant the first attempt wrote rather
-  // than crediting the workspace twice. Keyed on the submitted values, since
-  // editing the amount and resubmitting is a different intent that must not be
-  // answered with the earlier grant.
   const [submittedGrant, setSubmittedGrant] = useState<{
     payload: string;
     clientOperationId: string;
@@ -85,8 +80,6 @@ export const SettingsAdminWorkspaceCreditGrantModal = ({
   const parsedAmount = Number(amount);
   const isAmountValid = Number.isFinite(parsedAmount) && parsedAmount > 0;
 
-  // The modal is mounted for the whole page, so without this the next admin to
-  // open it starts from the last grant's amount and reason.
   const handleClose = () => {
     setAmount('');
     setType(BillingCreditGrantType.COMPENSATION);

--- a/packages/twenty-front/src/modules/settings/admin-panel/components/SettingsAdminWorkspaceCreditGrantsTable.tsx
+++ b/packages/twenty-front/src/modules/settings/admin-panel/components/SettingsAdminWorkspaceCreditGrantsTable.tsx
@@ -33,10 +33,6 @@ type SettingsAdminWorkspaceCreditGrantsTableProps = {
   onGrantCreditsClick: () => void;
 };
 
-// Every row is its own grid, so a fr track is sized by that row's own content
-// and a wide tag pushes the columns after it out of line with the rows above.
-// Fixed widths for all but the reason, which takes what is left because its
-// cell hides the overflow.
 const CREDIT_GRANTS_GRID_AUTO_COLUMNS = '88px 152px 96px 112px 1fr 36px';
 const REVOKE_CREDIT_GRANT_MODAL_ID = 'revoke-credit-grant-modal';
 const EM_DASH = '—';
@@ -87,9 +83,6 @@ export const SettingsAdminWorkspaceCreditGrantsTable = ({
   };
 
   const handleRevoke = async (creditGrantId: string) => {
-    // The refetch that clears the row lands well after the mutation resolves,
-    // so without this the button stays live and a second click revokes an
-    // already revoked grant.
     setIsRevoking(true);
 
     try {

--- a/packages/twenty-front/src/modules/settings/admin-panel/constants/GrantableCreditGrantTypes.ts
+++ b/packages/twenty-front/src/modules/settings/admin-panel/constants/GrantableCreditGrantTypes.ts
@@ -1,8 +1,5 @@
 import { BillingCreditGrantType } from '~/generated-admin/graphql';
 
-// Rollover grants are written by the period transition and onboarding rewards
-// by the onboarding jobs, so neither can be written by hand. The server
-// enforces this too, in ADMIN_GRANTABLE_CREDIT_GRANT_TYPES.
 export const GRANTABLE_CREDIT_GRANT_TYPES: BillingCreditGrantType[] = [
   BillingCreditGrantType.COMPENSATION,
   BillingCreditGrantType.SALES,

--- a/packages/twenty-server/src/engine/core-modules/admin-panel/dtos/grant-workspace-credits.input.ts
+++ b/packages/twenty-server/src/engine/core-modules/admin-panel/dtos/grant-workspace-credits.input.ts
@@ -20,7 +20,6 @@ export class GrantWorkspaceCreditsInput {
   @IsUUID()
   workspaceId: string;
 
-  // In display credits ($1 = 1 credit), converted to micro-credits server side.
   @Field(() => Float)
   @IsPositive()
   amount: number;
@@ -35,8 +34,6 @@ export class GrantWorkspaceCreditsInput {
   @MaxLength(500)
   reason?: string;
 
-  // Identifies one intended grant, so a retried mutation returns the grant the
-  // first attempt wrote instead of handing out the credits a second time.
   @Field(() => UUIDScalarType)
   @IsNotEmpty()
   @IsUUID()

--- a/packages/twenty-server/src/engine/core-modules/admin-panel/services/admin-panel-billing.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/admin-panel/services/admin-panel-billing.service.ts
@@ -68,9 +68,6 @@ export class AdminPanelBillingService {
     clientOperationId: string;
     grantedByUserId: string;
   }): Promise<AdminPanelWorkspaceCreditGrantDTO> {
-    // Enforced server side because the mutation is reachable directly, not only
-    // through the admin panel's picker. See ADMIN_GRANTABLE_CREDIT_GRANT_TYPES
-    // for why these two are excluded.
     if (!ADMIN_GRANTABLE_CREDIT_GRANT_TYPES.includes(type)) {
       throw new BillingException(
         `Cannot grant credits of type ${type} by hand`,
@@ -86,8 +83,6 @@ export class AdminPanelBillingService {
       'BILLING_MAX_ADMIN_CREDIT_GRANT_MICRO',
     );
 
-    // The field is micro-denominated, so a slipped decimal is four orders of
-    // magnitude. Bound what a single grant can hand out.
     if (amountMicro > maxAmountMicro) {
       throw new BillingException(
         `Cannot grant ${toDisplayCredits(amountMicro)} credits at once, the maximum is ${toDisplayCredits(maxAmountMicro)}`,
@@ -110,10 +105,6 @@ export class AdminPanelBillingService {
       return this.toCreditGrantDTO(grant);
     }
 
-    // A null grant is either a replay of this same operation, which must answer
-    // with the grant the first attempt wrote rather than hand out the credits
-    // again, or an instance without billing. The ledger table only exists in
-    // the first case, so it is only queried there.
     const replayedGrant = this.twentyConfigService.get('IS_BILLING_ENABLED')
       ? await this.billingCreditGrantService.findGrantByIdempotencyKey(
           workspaceId,
@@ -193,8 +184,6 @@ export class AdminPanelBillingService {
       this.getWorkspaceCreditGrants(workspaceId),
     ]);
 
-    // A workspace can hold granted credits before it has a customer or a
-    // subscription, and the admin panel still has to show and manage them.
     if (!customer && !subscription && creditGrants.length === 0) {
       return null;
     }
@@ -319,7 +308,5 @@ export class AdminPanelBillingService {
   }
 }
 
-// Namespaced so an operation id can never collide with the carry-forward or
-// backfill keys, which live in the same unique index.
 const buildAdminGrantIdempotencyKey = (clientOperationId: string): string =>
   `admin-grant:${clientOperationId}`;

--- a/packages/twenty-server/src/engine/core-modules/auth/services/sign-in-up.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/auth/services/sign-in-up.service.ts
@@ -692,13 +692,6 @@ export class SignInUpService {
             queryRunner,
           );
 
-          // Click-through DPA: the DPA is incorporated by reference into the
-          // ToS/signup, so acceptance = execution. Only relevant on Twenty's
-          // managed cloud (multi-workspace), where Twenty is the Processor
-          // hosting the data; on self-hosted deployments Twenty is not the
-          // Processor, so there is nothing to record. Done atomically with
-          // workspace creation so we can later prove what was agreed. (Billing
-          // is an independent feature flag and must not be used to detect cloud.)
           if (
             this.twentyConfigService.get('IS_MULTIWORKSPACE_ENABLED') === true
           ) {

--- a/packages/twenty-server/src/engine/core-modules/billing-webhook/services/billing-webhook-customer.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/billing-webhook/services/billing-webhook-customer.service.ts
@@ -72,9 +72,6 @@ export class BillingWebhookCustomerService {
       },
     );
 
-    // Credits granted before this row existed, an onboarding reward at signup
-    // above all, mirrored onto nothing. This is the earliest point the row is
-    // known to exist, so put the ledger balance on it here.
     await this.billingCreditService.reconcileMirroredBalance(workspaceId);
   }
 

--- a/packages/twenty-server/src/engine/core-modules/billing-webhook/services/billing-webhook-invoice.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/billing-webhook/services/billing-webhook-invoice.service.ts
@@ -36,7 +36,6 @@ export class BillingWebhookInvoiceService {
   constructor(
     @InjectRepository(BillingSubscriptionItemEntity)
     private readonly billingSubscriptionItemRepository: Repository<BillingSubscriptionItemEntity>,
-    // Stripe webhook: workspace discovered from BillingCustomer by stripeCustomerId.
     // eslint-disable-next-line twenty/prefer-workspace-scoped-repository
     @InjectRepository(BillingCustomerEntity)
     private readonly billingCustomerRepository: Repository<BillingCustomerEntity>,
@@ -144,8 +143,6 @@ export class BillingWebhookInvoiceService {
       return;
     }
 
-    // Only needed while subscriptions that predate previousPeriodStart are
-    // still transitioning for the first time.
     const ledgerPeriodStart =
       await this.billingCreditGrantService.findPeriodStartBefore({
         workspaceId: subscription.workspaceId,
@@ -169,9 +166,6 @@ export class BillingWebhookInvoiceService {
       ledgerPeriodStart,
     });
 
-    // Credits earned during the trial follow the workspace into its first paid
-    // period, so the trial closes like any other period. Its allowance comes
-    // from config rather than the price, which only applies once paid.
     const closingAllowanceMicro = isFirstPeriodAfterTrial
       ? this.billingUsageService.getTrialResourceUsageCap(subscription)
       : params.tierQuantity;
@@ -203,9 +197,6 @@ export class BillingWebhookInvoiceService {
       );
     }
 
-    // Paying a past-due invoice won't reactivate the subscription if Stripe
-    // already generated a draft for the next period. Finalize it so Stripe
-    // can collect payment and resume the subscription.
     await this.finalizePastDueDraftInvoicesAfterPaidInvoice(
       stripeSubscriptionId,
       paidInvoicePeriodEnd,

--- a/packages/twenty-server/src/engine/core-modules/billing-webhook/services/billing-webhook-subscription.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/billing-webhook/services/billing-webhook-subscription.service.ts
@@ -53,7 +53,6 @@ export class BillingWebhookSubscriptionService {
     private readonly stripeCustomerService: StripeCustomerService,
     @InjectMessageQueue(MessageQueue.workspaceQueue)
     private readonly messageQueueService: MessageQueueService,
-    // Stripe webhook upserts conflict-resolve globally on stripeSubscriptionId.
     // eslint-disable-next-line twenty/prefer-workspace-scoped-repository
     @InjectRepository(BillingSubscriptionEntity)
     private readonly billingSubscriptionRepository: Repository<BillingSubscriptionEntity>,
@@ -116,8 +115,6 @@ export class BillingWebhookSubscriptionService {
       },
     );
 
-    // Credits can be granted before this row exists, and those writes mirrored
-    // onto nothing. The row is here now, so put the ledger balance on it.
     await this.billingCreditService.reconcileMirroredBalance(workspaceId);
 
     const liveCustomerSubscriptions =

--- a/packages/twenty-server/src/engine/core-modules/billing/entities/billing-credit-grant.entity.ts
+++ b/packages/twenty-server/src/engine/core-modules/billing/entities/billing-credit-grant.entity.ts
@@ -39,10 +39,6 @@ export class BillingCreditGrantEntity extends WorkspaceRelatedEntity {
   @Column({ nullable: false, type: 'timestamptz' })
   effectiveAt: Date;
 
-  // Always the end of the billing period the grant belongs to. The available
-  // credit count is cached in Redis until period end and never recomputed
-  // mid-period, so an expiry inside a period would go unnoticed by the only
-  // code path that gates usage.
   @Column({ nullable: false, type: 'timestamptz' })
   expiresAt: Date;
 
@@ -62,7 +58,6 @@ export class BillingCreditGrantEntity extends WorkspaceRelatedEntity {
   @Column({ nullable: true, type: 'varchar' })
   idempotencyKey: string | null;
 
-  // Set when this grant carries forward the unspent part of another one.
   @Column({ nullable: true, type: 'uuid' })
   sourceGrantId: string | null;
 

--- a/packages/twenty-server/src/engine/core-modules/billing/entities/billing-customer.entity.ts
+++ b/packages/twenty-server/src/engine/core-modules/billing/entities/billing-customer.entity.ts
@@ -40,7 +40,6 @@ export class BillingCustomerEntity extends WorkspaceRelatedEntity {
   @Column({ nullable: false, unique: true })
   stripeCustomerId: string;
 
-  // Null means unknown (customer created before the flag existed and not synced yet).
   @Field(() => Boolean, { nullable: true })
   @Column({ nullable: true, type: 'boolean' })
   hasPaymentMethod: boolean | null;

--- a/packages/twenty-server/src/engine/core-modules/billing/entities/billing-subscription.entity.ts
+++ b/packages/twenty-server/src/engine/core-modules/billing/entities/billing-subscription.entity.ts
@@ -17,8 +17,6 @@ import {
 
 import type Stripe from 'stripe';
 
-// Serialized types for JSONB storage - uses Stripe's enum types but normalizes expandable fields
-// These avoid TypeORM's DeepPartialEntity issues with Stripe's expandable object types (e.g. Stripe.Account)
 export type AutomaticTaxJson = {
   disabled_reason: Stripe.Subscription.AutomaticTax['disabled_reason'];
   enabled: boolean;
@@ -132,12 +130,6 @@ export class BillingSubscriptionEntity extends WorkspaceRelatedEntity {
   })
   currentPeriodStart: Date;
 
-  // Where the period before the current one began. Stripe only ever reports the
-  // current window, so once currentPeriodStart advances the previous boundary
-  // is unrecoverable: calendar arithmetic clamps month-end anchors, and the
-  // ledger only shows it when the last transition happened to close a grant.
-  // Written whenever the period moves, and read by the rollover to bound the
-  // usage it settles.
   @Column({ nullable: true, type: 'timestamptz' })
   previousPeriodStart: Date | null;
 

--- a/packages/twenty-server/src/engine/core-modules/billing/enums/billing-credit-grant-type.enum.ts
+++ b/packages/twenty-server/src/engine/core-modules/billing/enums/billing-credit-grant-type.enum.ts
@@ -2,8 +2,6 @@
 
 import { registerEnumType } from '@nestjs/graphql';
 
-// Why a workspace was given credits, not how. Whether a human wrote the grant
-// is already on the row as grantedByUserId, so there is no "manual" type.
 export enum BillingCreditGrantType {
   ROLLOVER = 'ROLLOVER',
   ONBOARDING_REWARD = 'ONBOARDING_REWARD',
@@ -16,17 +14,10 @@ registerEnumType(BillingCreditGrantType, {
   description: 'The origin of a batch of credits granted to a workspace',
 });
 
-// Only ROLLOVER credits are capped when they carry over to the next period.
-// Credits we granted deliberately (compensation, sales, onboarding rewards)
-// keep their full value until spent or expired.
 export const CAPPED_BILLING_CREDIT_GRANT_TYPES: BillingCreditGrantType[] = [
   BillingCreditGrantType.ROLLOVER,
 ];
 
-// What an operator may write by hand. ROLLOVER belongs to the period
-// transition and ONBOARDING_REWARD to the onboarding jobs, so granting either
-// by hand would change carry-forward behaviour and misclassify the audit
-// trail.
 export const ADMIN_GRANTABLE_CREDIT_GRANT_TYPES: BillingCreditGrantType[] = [
   BillingCreditGrantType.COMPENSATION,
   BillingCreditGrantType.SALES,

--- a/packages/twenty-server/src/engine/core-modules/billing/services/billing-credit-grant.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/billing/services/billing-credit-grant.service.ts
@@ -16,8 +16,6 @@ import { BillingCreditGrantType } from 'src/engine/core-modules/billing/enums/bi
 import { InjectWorkspaceScopedRepository } from 'src/engine/twenty-orm/workspace-scoped-repository/inject-workspace-scoped-repository.decorator';
 import { WorkspaceScopedRepository } from 'src/engine/twenty-orm/workspace-scoped-repository/workspace-scoped-repository';
 
-// Shared with the backfill instance command so the two are safe in either
-// order: whichever runs first claims the key, the other is a no-op.
 const LEGACY_BALANCE_IDEMPOTENCY_KEY_PREFIX = 'backfill-credit-balance:';
 
 export type CreateBillingCreditGrantParams = {
@@ -40,8 +38,6 @@ const getPostgresErrorCode = (error: unknown): string | undefined => {
   return typeof error.code === 'string' ? error.code : undefined;
 };
 
-// TypeORM wraps the driver error, and which of the two carries the code
-// depends on how the query was issued.
 const isUniqueViolation = (error: unknown): boolean => {
   if (getPostgresErrorCode(error) === POSTGRESQL_ERROR_CODES.UNIQUE_VIOLATION) {
     return true;
@@ -61,9 +57,6 @@ const isUniqueViolation = (error: unknown): boolean => {
   );
 };
 
-// Owns the billingCreditGrant table. Deliberately free of side effects so that
-// read paths (available credits) can depend on it without pulling in the cache
-// and subscription services that BillingCreditService needs.
 @Injectable()
 export class BillingCreditGrantService {
   constructor(
@@ -73,8 +66,6 @@ export class BillingCreditGrantService {
     private readonly billingCustomerRepository: WorkspaceScopedRepository<BillingCustomerEntity>,
   ) {}
 
-  // Returns null when idempotencyKey has already been used, so callers can tell
-  // a fresh grant from a replayed one.
   async createGrant(
     params: CreateBillingCreditGrantParams,
   ): Promise<BillingCreditGrantEntity | null> {
@@ -150,8 +141,6 @@ export class BillingCreditGrantService {
 
     const total = Number(result?.total ?? 0);
 
-    // Rounding a balance would hand out or withhold credits that were never
-    // granted, so refuse rather than serve a number we cannot represent.
     if (!Number.isSafeInteger(total)) {
       throw new BillingException(
         `Credit balance for workspace ${workspaceId} is not a safe integer (${total})`,
@@ -162,10 +151,6 @@ export class BillingCreditGrantService {
     return total;
   }
 
-  // Moves a not-yet-backfilled balance into the ledger before anything writes
-  // to it. Without this the first grant recomputes the mirror column from a
-  // ledger that does not hold the legacy balance yet, erasing it.
-  // Remove along with creditBalanceMicro.
   async materializeLegacyBalance({
     workspaceId,
     effectiveAt,
@@ -196,10 +181,6 @@ export class BillingCreditGrantService {
     });
   }
 
-  // What a workspace can actually spend, which is the ledger except in the
-  // window between this release deploying and its backfill running: until a
-  // workspace has any grant at all, its balance still only exists in the
-  // mirror column. Remove along with creditBalanceMicro.
   async getSpendableCreditsMicro(workspaceId: string): Promise<number> {
     if (await this.hasAnyGrant(workspaceId)) {
       return this.getActiveCreditsMicro(workspaceId);
@@ -208,7 +189,6 @@ export class BillingCreditGrantService {
     return this.getMirroredBalanceMicro(workspaceId);
   }
 
-  // Grants that were spendable at any point during the given period.
   async findGrantsLiveDuringPeriod({
     workspaceId,
     periodStart,
@@ -228,11 +208,6 @@ export class BillingCreditGrantService {
     });
   }
 
-  // The previous transition pulled every grant it closed back to the instant
-  // the period ended, so the ledger records where the closing period started.
-  // Calendar arithmetic cannot recover it once the subscription has moved on:
-  // a month-end anchor clamps, and subtracting a month from February 28 gives
-  // January 28 rather than the January 31 the period actually started on.
   async findPeriodStartBefore({
     workspaceId,
     boundary,
@@ -249,11 +224,6 @@ export class BillingCreditGrantService {
     return row?.expiresAt ?? null;
   }
 
-  // Enforces the one-grant-per-period invariant at the point where periods
-  // actually roll: whatever a writer guessed for expiresAt, a grant never
-  // outlives the period it was carried forward from. Matched by predicate
-  // rather than by id so a grant created while the transition runs is covered
-  // too.
   async closeGrantsAtPeriodEnd({
     workspaceId,
     periodEnd,
@@ -278,8 +248,6 @@ export class BillingCreditGrantService {
     });
   }
 
-  // wasRevokedNow tells a retried revocation apart from the one that actually
-  // took the credits away, so callers only adjust balances once.
   async revokeGrant({
     workspaceId,
     grantId,
@@ -315,8 +283,6 @@ export class BillingCreditGrantService {
       { where: { id: grantId } },
     );
 
-    // Two concurrent revocations both read an unrevoked grant; only the one
-    // whose UPDATE matched may move the balance.
     return {
       grant: revokedGrant,
       wasRevokedNow: isDefined(affected) && affected > 0,
@@ -334,9 +300,6 @@ export class BillingCreditGrantService {
     return grant ?? null;
   }
 
-  // Whether the ledger has taken over from billingCustomer.creditBalanceMicro
-  // for this workspace. Public so the mirror write can refuse to overwrite a
-  // balance the backfill has not reached yet.
   async hasAnyGrant(workspaceId: string): Promise<boolean> {
     return this.billingCreditGrantRepository.exists(workspaceId, { where: {} });
   }

--- a/packages/twenty-server/src/engine/core-modules/billing/services/billing-credit-rollover.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/billing/services/billing-credit-rollover.service.ts
@@ -26,8 +26,6 @@ export type ProcessRolloverParams = {
   nextAllowanceMicro: number;
 };
 
-// The transition writes more rows than a single grant does, so it is given more
-// room than the lock's default before it gives up.
 const ROLLOVER_LOCK_OPTIONS = { ms: 200, maxRetries: 50, ttl: 30_000 };
 
 @Injectable()
@@ -45,9 +43,6 @@ export class BillingCreditRolloverService {
   ): Promise<void> {
     const { workspaceId, closingPeriodStart, closingPeriodEnd } = params;
 
-    // Read outside the lock: usage comes from ClickHouse and no credit write
-    // can change it, so paying that latency while holding the lock would only
-    // stall concurrent grants.
     const usageMicro =
       await this.billingUsageService.getCreditsUsedBetweenOrNull({
         workspaceId,
@@ -55,12 +50,6 @@ export class BillingCreditRolloverService {
         to: closingPeriodEnd,
       });
 
-    // Reading usage as zero when the query failed would roll a full unused
-    // allowance over to every workspace invoiced during the outage. Throwing
-    // fails the webhook so Stripe redelivers it; returning normally would
-    // answer 200 and the transition would never run, closing no grants and
-    // carrying nothing forward, so the workspace silently loses its balance
-    // at expiry.
     if (!isDefined(usageMicro)) {
       throw new BillingException(
         `Cannot roll credits over for workspace ${workspaceId}: usage for the period starting ${closingPeriodStart.toISOString()} could not be read`,
@@ -68,9 +57,6 @@ export class BillingCreditRolloverService {
       );
     }
 
-    // Everything from here reads the ledger, decides from that snapshot, then
-    // writes it back. A grant landing in between would either be carried twice
-    // or dropped, so the whole read-decide-write runs alone.
     await this.cacheLockService.withLock(
       () => this.carryGrantsForward({ ...params, usageMicro }),
       buildBillingCreditStateLockKey(workspaceId),
@@ -125,9 +111,6 @@ export class BillingCreditRolloverService {
     let carriedForwardMicro = 0;
     let hasReplayedGrant = false;
 
-    // Writes the grants directly rather than through grantCredits: the cache,
-    // cap flag and workspace cache only need refreshing once for the whole
-    // transition, and this runs inside a Stripe webhook.
     for (const carryForwardGrant of carryForwardGrants) {
       const grant = await this.billingCreditGrantService.createGrant({
         workspaceId,
@@ -152,16 +135,6 @@ export class BillingCreditRolloverService {
       }
     }
 
-    // A replay only tells us the rows already exist, not whether the delivery
-    // that wrote them got as far as the counter. Stripe also redelivers events
-    // it already handled successfully, and rebuilding then would throw away a
-    // correct warm counter and recompute it from ClickHouse, crediting back
-    // whatever usage has not been ingested yet. So the transition records under
-    // adjustmentKey that it moved the counter, and the refresh rebuilds only
-    // when that record is absent.
-    //
-    // Runs unconditionally: closing the old grants moves the balance on its
-    // own, so a period where everything was spent still needs the refresh.
     await this.billingCreditService.refreshWorkspaceCreditState({
       workspaceId,
       availableDeltaMicro: carriedForwardMicro,
@@ -172,12 +145,9 @@ export class BillingCreditRolloverService {
   }
 }
 
-// Scopes the completion marker to one period transition, so only a redelivery
-// of that transition can see it.
 const buildRolloverAdjustmentKey = (nextPeriodStart: Date): string =>
   `rollover:${nextPeriodStart.toISOString()}`;
 
-// Stripe redelivers webhooks, so the whole transition has to be replayable.
 const buildCarryForwardIdempotencyKey = ({
   workspaceId,
   nextPeriodStart,

--- a/packages/twenty-server/src/engine/core-modules/billing/services/billing-credit.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/billing/services/billing-credit.service.ts
@@ -21,9 +21,6 @@ import { InjectWorkspaceScopedRepository } from 'src/engine/twenty-orm/workspace
 import { WorkspaceScopedRepository } from 'src/engine/twenty-orm/workspace-scoped-repository/workspace-scoped-repository';
 import { WorkspaceCacheService } from 'src/engine/workspace-cache/services/workspace-cache.service';
 
-// Used when a workspace has no subscription yet, which happens for rewards
-// granted during signup. The next period transition re-emits the unspent part
-// aligned on the real billing period.
 const PROVISIONAL_GRANT_VALIDITY_IN_DAYS = 31;
 
 export type GrantCreditsParams = {
@@ -63,10 +60,6 @@ export class BillingCreditService {
 
     const { workspaceId } = params;
 
-    // Writing the row and moving the counter are two steps, and a reader that
-    // computes availability between them counts the grant from the ledger and
-    // then has it added a second time. Locking keeps the pair indivisible for
-    // anything else touching this workspace's credit state.
     return this.cacheLockService.withLock(
       () => this.writeGrantAndRefreshState(params),
       buildBillingCreditStateLockKey(workspaceId),
@@ -78,12 +71,6 @@ export class BillingCreditService {
   ): Promise<BillingCreditGrantEntity | null> {
     const { workspaceId, amountMicro } = params;
 
-    // Read once for the whole write: the validity window and the state refresh
-    // both need it, and both run inside the lock. Reading it here rather than
-    // before the lock is what keeps a grant that waited behind a period
-    // transition from carrying the period the wait started in, which would
-    // land it already expired while its amount still went onto the counter for
-    // the period that had meanwhile opened.
     const subscription =
       await this.billingSubscriptionService.getCurrentBillingSubscription({
         workspaceId,
@@ -106,22 +93,11 @@ export class BillingCreditService {
       expiresAt,
     });
 
-    // A replay only means the ledger row exists, not that the projections
-    // built from it do: the first attempt can have inserted the row and then
-    // failed on the refresh, and onboarding callers swallow that error. Repair
-    // rather than return, with no counter delta since the original attempt may
-    // already have applied it.
     if (!isDefined(grant)) {
       this.logger.log(
         `Replayed credit grant for workspace ${workspaceId} (idempotency key ${params.idempotencyKey}), repairing derived state`,
       );
 
-      // Rebuilding from the ledger can overstate the balance by whatever
-      // usage ClickHouse has not ingested yet, and that value then stands for
-      // the period. Accepted here because the alternative is a grant that
-      // stays invisible for the whole period, and erring high is the direction
-      // the grant intended. The cap is left to be derived from the rebuilt
-      // balance, since the replayed grant may since have been revoked.
       await this.refreshWorkspaceCreditState({
         workspaceId,
         availableDeltaMicro: 0,
@@ -181,15 +157,6 @@ export class BillingCreditService {
 
     const adjustmentKey = buildRevocationAdjustmentKey(grantId);
 
-    // A retried revocation must not take the same credits off the usage
-    // counter twice, which would block a workspace that still has credits.
-    // Whether the attempt that did revoke got as far as the counter is
-    // recorded under adjustmentKey, so the refresh can tell the two apart:
-    // already applied means repair the rest and leave the counter alone, never
-    // applied means rebuild from the ledger. Guessing either way is wrong,
-    // since always rebuilding freezes ClickHouse lag in as extra credit on
-    // every double click and never rebuilding leaves revoked credits spendable
-    // until the period ends.
     if (!wasRevokedNow) {
       await this.refreshWorkspaceCreditState({
         workspaceId,
@@ -202,11 +169,6 @@ export class BillingCreditService {
       return grant;
     }
 
-    // Only credits the counter actually holds may come off it. The mutation
-    // accepts any grant id, and a grant can expire between the admin panel
-    // rendering and the revoke landing, so subtracting unconditionally would
-    // take away credits that were never counted and block usage until the
-    // period ends.
     const revokedAtMs = (grant.revokedAt ?? new Date()).getTime();
     const wasActiveWhenRevoked =
       grant.effectiveAt.getTime() <= revokedAtMs &&
@@ -222,10 +184,6 @@ export class BillingCreditService {
     return grant;
   }
 
-  // The mirror column only exists once a workspace has a billingCustomer row,
-  // so a grant written before that (an onboarding reward at signup) mirrors
-  // onto nothing. Called when the row appears, so rolling this release back
-  // does not lose those credits. Remove along with creditBalanceMicro.
   async reconcileMirroredBalance(workspaceId: string): Promise<void> {
     if (!this.billingService.isBillingEnabled()) {
       return;
@@ -241,10 +199,6 @@ export class BillingCreditService {
     const activeCreditsMicro =
       await this.billingCreditGrantService.getActiveCreditsMicro(workspaceId);
 
-    // Until the backfill reaches a workspace the column is still the only copy
-    // of its balance, and an empty ledger sums to zero. Callers materialize the
-    // legacy balance before writing, but the guard belongs here too rather than
-    // resting on an ordering contract between services.
     if (
       activeCreditsMicro === 0 &&
       !(await this.billingCreditGrantService.hasAnyGrant(workspaceId))
@@ -261,12 +215,6 @@ export class BillingCreditService {
     return activeCreditsMicro;
   }
 
-  // Keeps everything that reads a credit balance consistent with the ledger:
-  // the mirror column, the Redis counter that gates usage, the flag that drives
-  // the "no more credits" banner, and the cached subscription the front reads.
-  // Public so a caller writing several grants at once pays for this once; such
-  // a caller must hold buildBillingCreditStateLockKey for its own ledger writes
-  // and this refresh together, which is why this does not take the lock itself.
   async refreshWorkspaceCreditState({
     workspaceId,
     availableDeltaMicro,
@@ -277,16 +225,9 @@ export class BillingCreditService {
   }: {
     workspaceId: string;
     availableDeltaMicro: number;
-    // Whether the write that led here could have made credits spendable. Only
-    // the caller knows: a replay of either a grant or a revocation carries a
-    // delta of zero, and the sign cannot tell them apart.
     addsCredits: boolean;
-    // A replay cannot know how far the original attempt got, so the counter is
-    // recomputed from the ledger unless adjustmentKey says it already moved.
     isReplay?: boolean;
-    // Names a one-off adjustment so a retry can see it already landed.
     adjustmentKey?: string;
-    // Saves a re-read for a caller that already has it in hand.
     subscription?: BillingSubscriptionEntity;
   }): Promise<void> {
     const activeCreditsMicro = await this.syncMirrorBalance(workspaceId);
@@ -301,10 +242,6 @@ export class BillingCreditService {
       return;
     }
 
-    // Deliberately not getBillingSubscriptionPeriod, which reports the trial
-    // window while trialing: every usage path keys this counter off
-    // currentPeriodStart, so taking the period from anywhere else would move a
-    // key the gate never reads.
     const periodStart = subscription.currentPeriodStart;
 
     const rebuildCounter =
@@ -330,18 +267,6 @@ export class BillingCreditService {
       );
     }
 
-    // The banner may only come down when this write actually put something
-    // spendable in front of the workspace: the caller says whether it could,
-    // the counter says whether it did, and what is left decides. A replay that
-    // finds the counter already moved did nothing, and its grants may well
-    // have been spent since, so it leaves the banner alone, while a replay
-    // that rebuilt the counter is the repair that lifts it.
-    //
-    // With no counter to speak for the workspace the ledger stands in, which
-    // ignores usage. Erring towards lifting the banner is deliberate there:
-    // the counter is cold exactly after a period transition or a cache flush,
-    // which is when grants land, and leaving it up would hide credits someone
-    // deliberately gave for the rest of the period.
     const spendableAfterWriteMicro =
       counterAfterWriteMicro ?? activeCreditsMicro;
 
@@ -353,8 +278,6 @@ export class BillingCreditService {
     });
   }
 
-  // Returns what the counter holds afterwards, or null when there is no warm
-  // counter to speak for the workspace.
   private async applyCounterWrite({
     workspaceId,
     periodStart,
@@ -379,18 +302,12 @@ export class BillingCreditService {
       return null;
     }
 
-    // Adjusting the warm counter instead of flushing it avoids recomputing
-    // from ClickHouse while its async inserts for recent usage are still
-    // landing, which would credit the workspace for usage it already spent.
     const cachedAvailableCredits =
       await this.billingUsageCacheService.getAvailableCredits(
         workspaceId,
         periodStart,
       );
 
-    // Nothing to do when the counter is cold. A reader can only warm it while
-    // holding this same lock, so it cannot be mid-computation now, and the
-    // next one to take the lock reads a ledger that already has this write.
     if (!isDefined(cachedAvailableCredits)) {
       return null;
     }
@@ -420,8 +337,6 @@ export class BillingCreditService {
   }
 }
 
-// Scopes the completion marker to one revocation, so retrying it is the only
-// thing that can see it.
 const buildRevocationAdjustmentKey = (grantId: string): string =>
   `revoke:${grantId}`;
 
@@ -435,9 +350,6 @@ const resolveGrantValidity = (
     return { effectiveAt, expiresAt: params.expiresAt };
   }
 
-  // A lapsed subscription still carries the period that just ended, and that is
-  // exactly the workspace someone is most likely to be granting credits to.
-  // Falling back keeps the grant from expiring on creation.
   const currentPeriodEnd = isDefined(subscription)
     ? getBillingSubscriptionPeriod(subscription).periodEnd
     : null;

--- a/packages/twenty-server/src/engine/core-modules/billing/services/billing-subscription.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/billing/services/billing-subscription.service.ts
@@ -59,8 +59,6 @@ export class BillingSubscriptionService {
     private readonly billingEntitlementRepository: WorkspaceScopedRepository<BillingEntitlementEntity>,
     @InjectWorkspaceScopedRepository(BillingSubscriptionEntity)
     private readonly billingSubscriptionRepository: WorkspaceScopedRepository<BillingSubscriptionEntity>,
-    // Stripe webhooks resolve by stripeCustomerId before any workspaceId
-    // is known. Used only when the criteria has no workspaceId.
     // eslint-disable-next-line twenty/prefer-workspace-scoped-repository
     @InjectRepository(BillingSubscriptionEntity)
     private readonly billingSubscriptionRepositoryUnscoped: Repository<BillingSubscriptionEntity>,
@@ -389,7 +387,6 @@ export class BillingSubscriptionService {
         workspaceId,
       );
 
-    // V2 subscriptions have no quantityless metered item; skip the stale-item cleanup in that case
     const meterBillingSubscriptionItem = billingSubscriptionItems.find(
       (item) => !isDefined(item.quantity),
     );

--- a/packages/twenty-server/src/engine/core-modules/billing/services/billing-usage-cache.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/billing/services/billing-usage-cache.service.ts
@@ -26,8 +26,6 @@ export class BillingUsageCacheService {
     );
   }
 
-  // Callers must hold buildBillingCreditStateLockKey: that is what stops a
-  // value computed before a grant landed from being installed after it.
   async warmAvailableCredits(
     workspaceId: string,
     periodStart: Date | string,
@@ -64,7 +62,6 @@ export class BillingUsageCacheService {
     );
   }
 
-  // Signed: usage moves it down, a grant moves it up.
   async adjustAvailableCredits(
     workspaceId: string,
     periodStart: Date | string,

--- a/packages/twenty-server/src/engine/core-modules/billing/services/billing-usage-cap.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/billing/services/billing-usage-cap.service.ts
@@ -40,9 +40,6 @@ export class BillingUsageCapService {
     );
   }
 
-  // Lifting the cap must never fail the operation that granted the credits, so
-  // unlike setSubscriptionItemHasReachedCap this tolerates a workspace with no
-  // resource credit item.
   async clearHasReachedCapForWorkspace(workspaceId: string): Promise<void> {
     const billingSubscriptionItems =
       await this.findResourceCreditSubscriptionItems(workspaceId);

--- a/packages/twenty-server/src/engine/core-modules/billing/services/billing-usage.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/billing/services/billing-usage.service.ts
@@ -50,9 +50,6 @@ type ResolvedAvailableCredits = {
   isCounterWarm: boolean;
 };
 
-// This gate runs before every credit-consuming execution, so it waits far less
-// than a writer does and falls back to computing unlocked rather than failing
-// the execution outright.
 const AVAILABLE_CREDITS_WARM_UP_LOCK_OPTIONS = {
   ms: 50,
   maxRetries: 20,
@@ -260,10 +257,6 @@ export class BillingUsageService {
         currentPeriodEnd,
       });
 
-    // A counter held stale by a recent grant must not be created from a value
-    // that may predate it: incrementing an absent key would install
-    // -usedCredits as the whole balance. Compute this turn locally instead and
-    // let the next read rebuild once the marker lapses.
     const decrementedAvailableCredits = isCounterWarm
       ? await this.billingUsageCacheService.adjustAvailableCredits(
           workspaceId,
@@ -285,12 +278,6 @@ export class BillingUsageService {
     return decrementedAvailableCredits;
   }
 
-  // Warming is a read of the ledger followed by a write of what it implies, so
-  // a grant landing in between would be counted from the ledger here and then
-  // added to the counter again by the grant itself. Taking the writers' lock on
-  // the cold path closes that; a hit returns before the lock, keeping the warm
-  // path, which is the overwhelming majority of calls, free of Redis round
-  // trips.
   private async readWarmAvailableCredits(
     params: AvailableCreditsParams,
   ): Promise<ResolvedAvailableCredits | undefined> {
@@ -317,8 +304,6 @@ export class BillingUsageService {
     try {
       return await this.cacheLockService.withLock(
         async () =>
-          // Another reader may have warmed it while this one waited, so a burst
-          // of cold reads pays for ClickHouse once rather than once each.
           (await this.readWarmAvailableCredits(params)) ??
           (await this.computeAndWarmAvailableCredits(params)),
         buildBillingCreditStateLockKey(params.workspaceId),
@@ -332,10 +317,6 @@ export class BillingUsageService {
         throw error;
       }
 
-      // Failing the execution because a grant is being written would be worse
-      // than answering from a value this call computed itself. Deliberately
-      // does not warm: holding the lock is what makes installing a computed
-      // value safe, so the counter stays cold until an uncontended read.
       this.logger.warn(
         `Computing available credits for workspace ${params.workspaceId} without the credit state lock: ${error.message}`,
       );
@@ -411,11 +392,6 @@ export class BillingUsageService {
     }
   }
 
-  // Returns null when usage could not be read. ClickHouseService.select
-  // swallows query errors and returns [], but a bare sum() aggregate always
-  // yields exactly one row, so an empty result means the read failed rather
-  // than "nothing was used". Callers that hand out credits must not confuse
-  // the two.
   private async sumCreditsUsedMicroOrNull(
     condition: string,
     params: Record<string, unknown>,
@@ -438,10 +414,6 @@ export class BillingUsageService {
     return Number.isFinite(total) ? total : 0;
   }
 
-  // Sums by event timestamp rather than by the stamped periodStart dimension.
-  // At a period transition the subscription's currentPeriodStart has already
-  // moved on, so an equality match on periodStart would read the new period
-  // and report a period that has barely started as unused.
   async getCreditsUsedBetweenOrNull({
     workspaceId,
     from,
@@ -461,7 +433,6 @@ export class BillingUsageService {
     );
   }
 
-  // Fails open: an unreadable usage total must never block a paying workspace.
   async getCurrentPeriodCreditsUsed(
     workspaceId: string,
     periodStart: Date,

--- a/packages/twenty-server/src/engine/core-modules/billing/utils/bigint-column-transformer.util.ts
+++ b/packages/twenty-server/src/engine/core-modules/billing/utils/bigint-column-transformer.util.ts
@@ -1,14 +1,5 @@
 /* @license Enterprise */
 
-// Postgres returns bigint as a string, so it needs coercing back. Shared by the
-// micro-denominated credit columns so the ledger and the mirror it sums into
-// cannot coerce differently.
-//
-// Number() is only lossless below 2^53, which is 9e9 credits at
-// INTERNAL_CREDITS_PER_DISPLAY_CREDIT. Balances are bounded well under that by
-// BILLING_MAX_ADMIN_CREDIT_GRANT_MICRO and the rollover cap, and
-// getActiveCreditsMicro throws rather than serve a total that is not a safe
-// integer, so the range is asserted rather than assumed.
 export const bigintColumnTransformer = {
   to: (value: number) => value,
   from: (value: string | number | null) =>

--- a/packages/twenty-server/src/engine/core-modules/billing/utils/build-billing-credit-state-lock-key.util.ts
+++ b/packages/twenty-server/src/engine/core-modules/billing/utils/build-billing-credit-state-lock-key.util.ts
@@ -1,11 +1,4 @@
 /* @license Enterprise */
 
-// Serializes everything that moves a workspace's credit state: writing to the
-// ledger and adjusting the counter derived from it. Readers take it too, but
-// only when the counter is cold, so the warm path stays lock-free.
-//
-// Without it the ledger write and the counter update are two independent
-// steps, and a reader computing availability in between either counts a grant
-// that the writer then adds again, or installs a balance that predates it.
 export const buildBillingCreditStateLockKey = (workspaceId: string): string =>
   `billing-credit-state:${workspaceId}`;

--- a/packages/twenty-server/src/engine/core-modules/billing/utils/build-billing-usage-counter-adjustment-key.util.ts
+++ b/packages/twenty-server/src/engine/core-modules/billing/utils/build-billing-usage-counter-adjustment-key.util.ts
@@ -1,6 +1,3 @@
-// Records that a one-off adjustment (a revocation, a period transition) already
-// moved the counter, so a retry can tell "already applied" from "never got that
-// far".
 export const buildBillingUsageCounterAdjustmentKey = (
   workspaceId: string,
   adjustmentKey: string,

--- a/packages/twenty-server/src/engine/core-modules/billing/utils/compute-carry-forward-grants.util.ts
+++ b/packages/twenty-server/src/engine/core-modules/billing/utils/compute-carry-forward-grants.util.ts
@@ -28,9 +28,6 @@ type CreditBucket = {
 const isCappedType = (type: BillingCreditGrantType): boolean =>
   CAPPED_BILLING_CREDIT_GRANT_TYPES.includes(type);
 
-// Capped credits are spent first so that deliberately granted credits
-// (compensation, partnership, onboarding rewards) survive the period and carry
-// over at their full value instead of being clipped by the rollover cap.
 const compareSpendingOrder = (a: CreditBucket, b: CreditBucket): number => {
   const [isACapped, isBCapped] = [isCappedType(a.type), isCappedType(b.type)];
 
@@ -44,10 +41,6 @@ const compareSpendingOrder = (a: CreditBucket, b: CreditBucket): number => {
     return byCreatedAt;
   }
 
-  // Grants written in the same transaction share a timestamp, and the order
-  // decides which grant id ends up on which carry-forward row. That id is part
-  // of the replay key, so without a stable tie-break a redelivery could write
-  // a second set of rows for the same credits.
   return (a.grantId ?? '').localeCompare(b.grantId ?? '');
 };
 

--- a/packages/twenty-server/src/engine/core-modules/billing/utils/derive-billing-period-transition.util.ts
+++ b/packages/twenty-server/src/engine/core-modules/billing/utils/derive-billing-period-transition.util.ts
@@ -12,10 +12,6 @@ export type BillingPeriodTransition = {
   nextPeriodEnd: Date;
 };
 
-// A subscription_cycle invoice is raised at the instant one period hands over
-// to the next, and Stripe stamps it with the period it bills in advance. So its
-// period_start is the transition instant: the closing period ends there and the
-// new one starts there.
 export const deriveBillingPeriodTransition = ({
   invoicePeriodStart,
   invoicePeriodEnd,
@@ -34,12 +30,7 @@ export const deriveBillingPeriodTransition = ({
   subscriptionInterval: SubscriptionInterval;
   trialStart: Date | null | undefined;
   isFirstPeriodAfterTrial: boolean;
-  // Where the subscription recorded the previous period starting, captured when
-  // it advanced. Null for a subscription that has not transitioned since the
-  // column was added.
   subscriptionPreviousPeriodStart: Date | null;
-  // Where the ledger says the closing period started, used only when the
-  // subscription has no record of it.
   ledgerPeriodStart: Date | null;
 }): BillingPeriodTransition => {
   const boundary = invoicePeriodStart;
@@ -58,11 +49,6 @@ export const deriveBillingPeriodTransition = ({
       return subscriptionCurrentPeriodStart;
     }
 
-    // Recorded when the subscription advanced, so it is exact whatever the
-    // anchor. Calendar arithmetic cannot reproduce it for month-end anchors: a
-    // period running January 31 to February 28 comes back as starting January
-    // 28, which widens the usage window into the period before and drags
-    // already expired grants back into the carry-forward.
     if (
       isDefined(subscriptionPreviousPeriodStart) &&
       subscriptionPreviousPeriodStart.getTime() < boundary.getTime()
@@ -70,9 +56,6 @@ export const deriveBillingPeriodTransition = ({
       return subscriptionPreviousPeriodStart;
     }
 
-    // Only until each subscription has transitioned once with the column in
-    // place. The ledger records the boundary whenever the previous transition
-    // closed a grant there, which is most workspaces but not all.
     if (
       isDefined(ledgerPeriodStart) &&
       ledgerPeriodStart.getTime() < boundary.getTime()
@@ -80,10 +63,6 @@ export const deriveBillingPeriodTransition = ({
       return ledgerPeriodStart;
     }
 
-    // Calendar arithmetic, not the invoiced duration: consecutive periods
-    // differ in length, so a February renewal bills 28 days and subtracting
-    // those from February 1 would place the closing period at January 4 and
-    // drop three days of usage, which then reads as unspent allowance.
     return subscriptionInterval === SubscriptionInterval.Year
       ? subYears(boundary, 1)
       : subMonths(boundary, 1);

--- a/packages/twenty-server/src/engine/core-modules/billing/utils/resolve-billing-period-boundary-update.util.ts
+++ b/packages/twenty-server/src/engine/core-modules/billing/utils/resolve-billing-period-boundary-update.util.ts
@@ -13,10 +13,6 @@ type BillingPeriodBoundaryUpdate = {
   currentPeriodEnd?: Date;
 };
 
-// Stripe only ever reports the current window, so the boundary a period moves
-// off is captured at the moment it moves or lost for good. The rollover needs
-// it to bound the usage it settles, which is why every path that writes a
-// subscription resolves its period fields through this.
 export const resolveBillingPeriodBoundaryUpdate = ({
   incomingPeriodStart,
   storedSubscription,
@@ -34,9 +30,6 @@ export const resolveBillingPeriodBoundaryUpdate = ({
     return { previousPeriodStart: currentPeriodStart };
   }
 
-  // Stripe never moves a period backwards, so an older window is an event
-  // delivered late. Letting it land would rewind the boundary the rollover
-  // settles against and leave it behind the one already recorded.
   if (incomingPeriodStart.getTime() < currentPeriodStart.getTime()) {
     return { currentPeriodStart, currentPeriodEnd };
   }

--- a/packages/twenty-server/src/engine/core-modules/cache-storage/services/cache-storage.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/cache-storage/services/cache-storage.service.ts
@@ -221,9 +221,6 @@ export class CacheStorageService {
 
     do {
       const result = await redisClient.scan(cursor, {
-        // Through getKey, not the namespace alone: under NODE_ENV=test every
-        // key carries a further prefix, so a raw namespace match scans for
-        // keys that do not exist and the flush silently does nothing.
         MATCH: this.getKey(scanPattern),
         COUNT: 100,
       });

--- a/packages/twenty-server/src/engine/core-modules/onboarding/onboarding.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/onboarding/onboarding.service.ts
@@ -81,10 +81,6 @@ export class OnboardingService {
     user: UserEntity;
     workspaceId: string;
   }): Promise<OnboardingStatus | null> {
-    // We always read the workspace directly from the database here (bypassing
-    // the per-instance core entity cache) so that onboardingStatus reflects the
-    // freshest activationStatus right after activateWorkspace, even when a
-    // sibling server instance still has a stale cached workspace.
     const workspace = await this.workspaceRepository.findOne({
       where: { id: workspaceId },
     });
@@ -546,8 +542,6 @@ export class OnboardingService {
           throw new Error('Transaction entity manager has no query runner');
         }
 
-        // Claiming the offer is the single-winner gate: a concurrent enrichment
-        // loses the insert and must not resurrect a step the user already skipped.
         const hasClaimedBookCallOffer =
           await this.userVarsService.setIfNotExists(
             {

--- a/packages/twenty-server/src/engine/core-modules/twenty-config/config-variables.ts
+++ b/packages/twenty-server/src/engine/core-modules/twenty-config/config-variables.ts
@@ -568,10 +568,6 @@ export class ConfigVariables {
       'Deployment region that determines the DPA hosting location shown to customers. The Processor entity (Twenty.com PBC) and governing law (Delaware, USA) are the same for all regions. EU (default) = Frankfurt, Germany; US = United States. Must match where Customer Personal Data actually lives.',
     type: ConfigVariableType.ENUM,
     options: Object.values(DpaRegion),
-    // Deployment-fixed: must mirror where data actually lives. Allowing a
-    // runtime DB/admin override could advertise a hosting location that does
-    // not match where data resides, so this is only configurable via
-    // environment variable.
     isEnvOnly: true,
   })
   @IsOptional()
@@ -709,7 +705,6 @@ export class ConfigVariables {
   @CastToPositiveNumber()
   LOGIC_FUNCTION_EXEC_THROTTLE_LIMIT = 1000;
 
-  // milliseconds
   @ConfigVariablesMetadata({
     group: ConfigVariablesGroup.LOGIC_FUNCTION_CONFIG,
     description: 'Time-to-live for logic function execution throttle',
@@ -1391,7 +1386,6 @@ export class ConfigVariables {
     options: Object.values(NodeEnvironment),
     isEnvOnly: true,
   })
-  // @CastToUpperSnakeCase()
   NODE_ENV: NodeEnvironment = NodeEnvironment.PRODUCTION;
 
   @ConfigVariablesMetadata({

--- a/packages/twenty-server/test/integration/billing/suites/billing-credit-grant-admin.integration-spec.ts
+++ b/packages/twenty-server/test/integration/billing/suites/billing-credit-grant-admin.integration-spec.ts
@@ -173,9 +173,6 @@ describe('Admin credit grant and revoke (integration)', () => {
     );
   });
 
-  // The panel only offers the three operator types, but the mutation is
-  // reachable directly and these two are written by the period transition and
-  // the onboarding jobs.
   it.each([
     BillingCreditGrantType.ROLLOVER,
     BillingCreditGrantType.ONBOARDING_REWARD,
@@ -207,9 +204,6 @@ describe('Admin credit grant and revoke (integration)', () => {
     expect(await listCreditGrants(workspaceId)).toHaveLength(0);
   });
 
-  // The admin panel keeps one operation id per open modal, so an Apollo retry
-  // or a resubmit after a lost response must answer with the grant the first
-  // attempt wrote rather than crediting the workspace a second time.
   it('answers a retried grant with the original instead of granting twice', async () => {
     const clientOperationId = randomUUID();
     const variables = {

--- a/packages/twenty-server/test/integration/billing/suites/billing-credit-rollover.integration-spec.ts
+++ b/packages/twenty-server/test/integration/billing/suites/billing-credit-rollover.integration-spec.ts
@@ -18,9 +18,6 @@ import { type BillingUsageService } from 'src/engine/core-modules/billing/servic
 
 const client = request(`http://localhost:${APP_PORT}`);
 
-// Whole calendar months, anchored so the period the transition opens is the
-// one running right now. The mirror column and the ledger both filter on now(),
-// so periods fixed in the past would read as expired and assert nothing.
 const PERIOD_BOUNDARY = startOfMonth(new Date());
 const CLOSING_PERIOD_START = subMonths(PERIOD_BOUNDARY, 1);
 const CLOSING_PERIOD_END = PERIOD_BOUNDARY;
@@ -69,9 +66,6 @@ describe('Billing credit rollover (integration)', () => {
       creditAmountMicro: ALLOWANCE_MICRO,
     });
 
-    // Usage is read from ClickHouse, whose inserts are asynchronous. Stubbing
-    // the read keeps every expectation exact instead of racing ingestion; the
-    // query itself has its own unit coverage.
     usageSpy = jest.spyOn(billingUsageService, 'getCreditsUsedBetweenOrNull');
   });
 
@@ -138,8 +132,6 @@ describe('Billing credit rollover (integration)', () => {
 
     expect(compensation).toBeDefined();
 
-    // Its expiry was pulled back to the boundary, so the balance counts it
-    // once through its carried-forward copy rather than twice.
     expect(new Date(compensation!.expiresAt)).toEqual(CLOSING_PERIOD_END);
     expect(
       grants.some(
@@ -169,7 +161,6 @@ describe('Billing credit rollover (integration)', () => {
       (grant) => grant.type === BillingCreditGrantType.ROLLOVER,
     );
 
-    // allowance + expiring rollover = 2M unspent, clamped to (2 - 1) x 1M.
     expect(
       carriedRollover.reduce((total, grant) => total + grant.amountMicro, 0),
     ).toBe(ALLOWANCE_MICRO);
@@ -183,7 +174,6 @@ describe('Billing credit rollover (integration)', () => {
     expect(await getMirroredCreditBalance(workspaceId)).toBe(700_000);
   });
 
-  // A redelivery must not hand out the credits a second time.
   it('is idempotent when Stripe redelivers the same invoice', async () => {
     usageSpy.mockResolvedValue(300_000);
 
@@ -200,8 +190,6 @@ describe('Billing credit rollover (integration)', () => {
     expect(await getMirroredCreditBalance(workspaceId)).toBe(700_000);
   });
 
-  // Returning normally would answer 200 and Stripe would never redeliver, so
-  // the transition would be lost and the balance would expire unrolled.
   it('fails the webhook when usage cannot be read so Stripe redelivers', async () => {
     usageSpy.mockResolvedValue(null);
 
@@ -215,9 +203,6 @@ describe('Billing credit rollover (integration)', () => {
     usageSpy.mockResolvedValue(300_000);
     const cache = getBillingUsageCacheService();
 
-    // The counter is keyed by the period the subscription is currently in,
-    // which is the one the invoice is closing: Stripe moves the subscription
-    // forward in a separate event.
     await cache.warmAvailableCredits(
       workspaceId,
       CLOSING_PERIOD_START,
@@ -232,9 +217,6 @@ describe('Billing credit rollover (integration)', () => {
     ).toBe(120_000 + 700_000);
   });
 
-  // Stripe redelivers events it already handled. Rebuilding on that redelivery
-  // would drop a counter that is already correct and recompute it from
-  // ClickHouse, handing back every credit whose usage has not been ingested yet.
   it('leaves a warm counter alone when a successful delivery is repeated', async () => {
     usageSpy.mockResolvedValue(300_000);
     const cache = getBillingUsageCacheService();
@@ -260,10 +242,6 @@ describe('Billing credit rollover (integration)', () => {
     ).toBe(afterFirst);
   });
 
-  // A subscription anchored on the 31st runs January 31 to February 28. Once
-  // the subscription.updated webhook has moved the subscription on, calendar
-  // arithmetic clamps February 28 back to January 28 and the closing period
-  // swallows three days of the period before it.
   describe('a month-end anchor whose subscription already advanced', () => {
     const MONTH_END_BOUNDARY = new Date('2026-02-28T00:00:00.000Z');
     const TRUE_CLOSING_PERIOD_START = new Date('2026-01-31T00:00:00.000Z');
@@ -277,8 +255,6 @@ describe('Billing credit rollover (integration)', () => {
         periodEnd: MONTH_END_NEXT_PERIOD_END,
         creditAmountMicro: ALLOWANCE_MICRO,
       });
-      // What the previous transition left behind: a grant closed at the instant
-      // the period it belonged to ended.
       await insertCreditGrant({
         workspaceId,
         amountMicro: 100_000,

--- a/packages/twenty-server/test/integration/billing/utils/billing-credit-fixtures.util.ts
+++ b/packages/twenty-server/test/integration/billing/utils/billing-credit-fixtures.util.ts
@@ -3,11 +3,6 @@ import { type BillingUsageCacheService } from 'src/engine/core-modules/billing/s
 
 import { getAppProviderByClassName } from 'test/integration/utils/get-app-provider-by-class-name.util';
 
-// The dev seeder gives every workspace a billingCustomer and an active
-// billingSubscription, but no subscription item, and no period. Rollover needs
-// the whole chain — subscription -> item -> product -> price with a
-// credit_amount — so these helpers finish the fixture and put the period where
-// the test wants it.
 export const TEST_STRIPE_CUSTOMER_ID = 'cus_default0';
 export const TEST_STRIPE_SUBSCRIPTION_ID = 'sub_default0';
 
@@ -30,8 +25,6 @@ export type CreditGrantRow = {
 const query = async <T>(sql: string, params: unknown[] = []): Promise<T[]> =>
   global.testDataSource.query(sql, params);
 
-// The billing seeds insert with orIgnore, so the customer and subscription
-// land on exactly one workspace and which one is not worth hardcoding.
 export const getSeededBillingWorkspaceId = async (): Promise<string> => {
   const [row] = await query<{ workspaceId: string }>(
     `SELECT "workspaceId" FROM core."billingSubscription" WHERE "stripeSubscriptionId" = $1`,
@@ -191,9 +184,6 @@ export const resetBillingCreditState = async (
   const cache = getBillingUsageCacheService();
 
   await cache.flushAvailableCredits(workspaceId);
-  // Adjustment markers outlive a counter flush by design, so a transition in
-  // one test would otherwise make the next one read its first delivery as a
-  // replay that had already moved the counter.
   await cache.flushCounterAdjustmentMarkers(workspaceId);
 };
 

--- a/packages/twenty-server/test/integration/billing/utils/create-mock-stripe-invoice-finalized-data.util.ts
+++ b/packages/twenty-server/test/integration/billing/utils/create-mock-stripe-invoice-finalized-data.util.ts
@@ -1,6 +1,3 @@
-// Typed to what the handler actually reads rather than to Stripe.Invoice: the
-// payload crosses the wire as JSON, so the runtime shape is what matters, and
-// a full Stripe.Invoice fixture would be a few hundred lines of noise.
 export type MockStripeInvoiceFinalizedData = {
   object: {
     id: string;
@@ -39,8 +36,6 @@ export const createMockStripeInvoiceFinalizedData = ({
     object: 'invoice',
     billing_reason: billingReason,
     customer: stripeCustomerId,
-    // The invoice for a subscription_cycle bills the period it opens, so its
-    // period_start is the instant the previous period closed.
     period_start: toUnixSeconds(periodStart),
     period_end: toUnixSeconds(periodEnd),
     parent: {


### PR DESCRIPTION
Follow-up to #23973, addressing the comment density Charles flagged.

385 comment lines removed across 33 files. Deletions only: no statement, signature or test changed. Typecheck clean on both packages, 372 unit tests green across billing, billing-webhook, admin-panel, onboarding and cache-storage, lint and format clean.

The `2-31` instance commands are deliberately untouched. They have already run on instances, and 2.32.0 is being cut, so editing them would be a mutation of a shipped command.


---
_Generated by [Claude Code](https://claude.ai/code/session_018nbFWtp91LYa7sGaAY3piR)_

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/24066?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

