### PR TITLE
fix(billing): skip deleted workspaces in the credit balance backfill

### DIFF
--- a/packages/twenty-server/src/database/commands/upgrade-version-command/2-31/2-31-instance-command-slow-1786532184001-backfill-credit-balance-into-grants.ts
+++ b/packages/twenty-server/src/database/commands/upgrade-version-command/2-31/2-31-instance-command-slow-1786532184001-backfill-credit-balance-into-grants.ts
@@ -32,6 +32,10 @@ export class BackfillCreditBalanceIntoGrantsSlowInstanceCommand
     // Expiry follows the workspace's current period, but never lands in the
     // past: a backfilled grant that expires on creation would silently delete
     // the balance it was meant to preserve.
+    //
+    // billingCustomer has no foreign key to workspace, so it outlives deleted
+    // workspaces, while billingCreditGrant does have one. Without the join
+    // those orphans fail the insert and take the whole upgrade down with them.
     await dataSource.query(
       `INSERT INTO "core"."billingCreditGrant" (
         "workspaceId", "amountMicro", "type", "effectiveAt", "expiresAt", "reason", "idempotencyKey"
@@ -58,6 +62,8 @@ export class BackfillCreditBalanceIntoGrantsSlowInstanceCommand
         'Backfilled from billingCustomer.creditBalanceMicro',
         $1 || "billingCustomer"."workspaceId"
       FROM "core"."billingCustomer"
+      INNER JOIN "core"."workspace"
+        ON "workspace"."id" = "billingCustomer"."workspaceId"
       WHERE "billingCustomer"."creditBalanceMicro" > 0
       ON CONFLICT ("idempotencyKey") DO NOTHING`,
       [BACKFILL_IDEMPOTENCY_KEY_PREFIX],


### PR DESCRIPTION
Fixes the failure blocking the 2.31.0 upgrade. My bug, from #23973.

```
ERROR [InstanceCommandRunnerService] 2.31.0_BackfillCreditBalanceIntoGrantsSlowInstanceCommand_1786532184001 data migration failed
QueryFailedError: insert or update on table "billingCreditGrant" violates foreign key constraint "FK_e516eeab5b1dda05b823f235041"
```

## Cause

The backfill inserts one grant per `billingCustomer` with a non-zero `creditBalanceMicro`. In production some of those customer rows point at a workspace that no longer exists, and `billingCreditGrant.workspaceId` carries a foreign key to `core.workspace` (`WorkspaceRelatedEntity`, `onDelete: CASCADE`). Every orphan fails the insert, and because it is a single statement one orphan sinks the whole backfill, which fails the instance command run and stops the upgrade.

## Fix

One join, so only customers whose workspace still exists are backfilled:

```sql
FROM "core"."billingCustomer"
INNER JOIN "core"."workspace"
  ON "workspace"."id" = "billingCustomer"."workspaceId"
WHERE "billingCustomer"."creditBalanceMicro" > 0
```

Nothing of value is dropped: a grant for a deleted workspace is unreachable, and had the FK not rejected it the cascade would have deleted it anyway.

## Verification

Reproduced against Postgres 16 with one live customer and one orphan:

- old statement: `ERROR: insert or update on table "billingCreditGrant" violates foreign key constraint "FK_e516eeab5b1dda05b823f235041"`, `DETAIL: Key (workspaceId)=(99999999-...) is not present in table "workspace"`, the exact production error
- new statement: `INSERT 0 1`, the live workspace only
- re-run of the new statement: `INSERT 0 0`, still idempotent through `ON CONFLICT ("idempotencyKey") DO NOTHING`

The command is edited in place rather than superseded by a 2-32 one because it never completed anywhere: the runner recorded it failed, so it is retried on the next run and the repaired statement is what executes. A new command would leave the broken one failing ahead of it and the upgrade still stuck.

## Related risk, not fixed here

The rollover writes grants for `subscription.workspaceId` on `invoice.finalized`. If `billingSubscription` can outlive its workspace the same way `billingCustomer` does, that webhook would hit the same constraint at runtime. I have not confirmed whether such rows exist, and did not want to widen an urgent fix on a guess. Happy to follow up.


---
_Generated by [Claude Code](https://claude.ai/code/session_018nbFWtp91LYa7sGaAY3piR)_

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/24067?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

