### PR TITLE
fix(billing): skip the rollover for workspaces that no longer exist

### DIFF
--- a/packages/twenty-server/src/engine/core-modules/billing-webhook/services/billing-webhook-invoice.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/billing-webhook/services/billing-webhook-invoice.service.ts
@@ -134,10 +134,6 @@ export class BillingWebhookInvoiceService {
     invoicePeriodEnd: Date;
     isFirstPeriodAfterTrial: boolean;
   }): Promise<void> {
-    // billingSubscription outlives hard-deleted workspaces, and a credit grant
-    // has a foreign key to workspace, so carrying one forward for a workspace
-    // that is gone fails the insert and the webhook with it. Soft-deleted ones
-    // still have their row and can still be restored, so they carry forward.
     const workspaceExists = await this.workspaceRepository.exists({
       where: { id: subscription.workspaceId },
       withDeleted: true,

--- a/packages/twenty-server/src/engine/core-modules/billing-webhook/services/billing-webhook-invoice.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/billing-webhook/services/billing-webhook-invoice.service.ts
@@ -134,6 +134,19 @@ export class BillingWebhookInvoiceService {
     invoicePeriodEnd: Date;
     isFirstPeriodAfterTrial: boolean;
   }): Promise<void> {
+    // billingSubscription outlives hard-deleted workspaces, and a credit grant
+    // has a foreign key to workspace, so carrying one forward for a workspace
+    // that is gone fails the insert and the webhook with it. Soft-deleted ones
+    // still have their row and can still be restored, so they carry forward.
+    const workspaceExists = await this.workspaceRepository.exists({
+      where: { id: subscription.workspaceId },
+      withDeleted: true,
+    });
+
+    if (!workspaceExists) {
+      return;
+    }
+
     const params =
       await this.resourceCreditService.getResourceCreditRolloverParameters(
         subscription.workspaceId,


### PR DESCRIPTION
Same class of bug as #24067, on the runtime path rather than the migration.

## Why

`billingSubscription` outlives hard-deleted workspaces. On twenty-main:

```sql
SELECT count(*) FROM core."billingSubscription" bs
LEFT JOIN core."workspace" w ON w.id = bs."workspaceId"
WHERE w.id IS NULL;
-- 17559
```

The rollover writes a credit grant for `subscription.workspaceId` on `invoice.finalized`, and `billingCreditGrant` carries a foreign key to `core.workspace` (`WorkspaceRelatedEntity`, `onDelete: CASCADE`). So any of those 17,559 subscriptions that still receives a `subscription_cycle` invoice fails the insert with `FK_e516eeab5b1dda05b823f235041`, the webhook 500s, and Stripe retries it on a schedule until it gives up.

Nothing between the webhook and the insert checked that the workspace was still there. `getResourceCreditRolloverParameters` returns as soon as it finds the subscription and its pricing and never looks at `core.workspace`.

I originally guessed this was unlikely, on the grounds that deleting a workspace cancels its Stripe subscription (`workspace.service.ts:574`). The row count says that reasoning was wrong: whatever produced those orphans bypassed that path, the same way it produced the orphaned `billingCustomer` rows behind #24067.

## What

One existence check before any rollover work, so an orphan is skipped rather than crashing the webhook.

Soft-deleted workspaces are deliberately included (`withDeleted: true`): their row still exists, so the foreign key is satisfied, and a restored workspace should come back with its credits. This matches the decision in #24067.

## Verification

Typecheck clean, 231 unit tests green across billing and billing-webhook, lint and format clean.

Not covered by a new test: the failure needs an orphaned subscription, and a freshly built database enforces `billingSubscription -> workspace`, so the state cannot be constructed in dev or CI. That is the same reason #24067's bug reached production, and it is worth deciding separately whether these backfills and webhooks should be exercised against a restored production snapshot.


---
_Generated by [Claude Code](https://claude.ai/code/session_018nbFWtp91LYa7sGaAY3piR)_

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/24068?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

