### PR TITLE
fix(calendar): stop CalDAV errors falling to UNKNOWN and retrying forever

### DIFF
--- a/packages/twenty-server/src/modules/calendar/calendar-event-import-manager/drivers/caldav/services/caldav-get-events.service.ts
+++ b/packages/twenty-server/src/modules/calendar/calendar-event-import-manager/drivers/caldav/services/caldav-get-events.service.ts
@@ -4,6 +4,7 @@ import { CalDavClientProvider } from 'src/modules/calendar/calendar-event-import
 import { CalDavFetchEventsService } from 'src/modules/calendar/calendar-event-import-manager/drivers/caldav/services/caldav-fetch-events.service';
 import { type CalDavSyncCursor } from 'src/modules/calendar/calendar-event-import-manager/drivers/caldav/types/caldav-sync-cursor';
 import { parseCalDAVError } from 'src/modules/calendar/calendar-event-import-manager/drivers/caldav/utils/parse-caldav-error.util';
+import { CalendarEventImportDriverException } from 'src/modules/calendar/calendar-event-import-manager/drivers/exceptions/calendar-event-import-driver.exception';
 import { type GetCalendarEventsResponse } from 'src/modules/calendar/calendar-event-import-manager/services/calendar-get-events.service';
 
 @Injectable()
@@ -44,6 +45,10 @@ export class CalDavGetEventsService {
         `Error in ${CalDavGetEventsService.name} - getCalendarEvents`,
         error,
       );
+
+      if (error instanceof CalendarEventImportDriverException) {
+        throw error;
+      }
 
       throw parseCalDAVError(error as Error);
     }

--- a/packages/twenty-server/src/modules/calendar/calendar-event-import-manager/drivers/caldav/utils/__tests__/parse-caldav-error.util.spec.ts
+++ b/packages/twenty-server/src/modules/calendar/calendar-event-import-manager/drivers/caldav/utils/__tests__/parse-caldav-error.util.spec.ts
@@ -1,47 +1,58 @@
-import {
-  CalendarEventImportDriverException,
-  CalendarEventImportDriverExceptionCode,
-} from 'src/modules/calendar/calendar-event-import-manager/drivers/exceptions/calendar-event-import-driver.exception';
 import { parseCalDAVError } from 'src/modules/calendar/calendar-event-import-manager/drivers/caldav/utils/parse-caldav-error.util';
+import { CalendarEventImportDriverExceptionCode } from 'src/modules/calendar/calendar-event-import-manager/drivers/exceptions/calendar-event-import-driver.exception';
+
+const expectCode = (
+  message: string,
+  code: CalendarEventImportDriverExceptionCode,
+) => {
+  expect(parseCalDAVError(new Error(message)).code).toBe(code);
+};
 
 describe('parseCalDAVError', () => {
-  it('maps tsdav auth-failure messages to INSUFFICIENT_PERMISSIONS', () => {
-    for (const message of [
-      'no account for fetchCalendars',
-      'Must have account before syncCalendars',
-      'Invalid credentials',
-      'Invalid auth method',
-    ]) {
-      const result = parseCalDAVError(new Error(message));
-
-      expect(result).toBeInstanceOf(CalendarEventImportDriverException);
-      expect(result.code).toBe(
-        CalendarEventImportDriverExceptionCode.INSUFFICIENT_PERMISSIONS,
-      );
-    }
+  it.each([
+    'no account for smartCollectionSync',
+    'no account for fetchAddressBooks',
+    'no account for fetchCalendars',
+    'Must have account before syncCalendars',
+    'Invalid auth method',
+    'Invalid credentials',
+    'cannot find principalUrl',
+  ])('maps "%s" to INSUFFICIENT_PERMISSIONS', (message) => {
+    expectCode(
+      message,
+      CalendarEventImportDriverExceptionCode.INSUFFICIENT_PERMISSIONS,
+    );
   });
 
-  it('maps tsdav not-found messages to NOT_FOUND', () => {
-    for (const message of [
-      'Collection does not exist on server',
-      'cannot find homeUrl',
-      'cannot fetchCalendarObjects for undefined calendar',
-    ]) {
-      expect(parseCalDAVError(new Error(message)).code).toBe(
-        CalendarEventImportDriverExceptionCode.NOT_FOUND,
+  it.each([
+    'Collection does not exist on server',
+    'cannot fetchVCards for undefined addressBook',
+    'cannot find calendarUserAddresses',
+    'cannot fetchCalendarObjects for undefined calendar',
+    'cannot find homeUrl',
+  ])('maps "%s" to NOT_FOUND', (message) => {
+    expectCode(message, CalendarEventImportDriverExceptionCode.NOT_FOUND);
+  });
+
+  describe('messages tsdav interpolates', () => {
+    it('maps the credentials failure raised during login to INSUFFICIENT_PERMISSIONS', () => {
+      expectCode(
+        'Invalid credentials: PROPFIND https://dav.example.com/ returned 401 Unauthorized',
+        CalendarEventImportDriverExceptionCode.INSUFFICIENT_PERMISSIONS,
       );
-    }
+    });
   });
 
   it('falls back to UNKNOWN for unrecognised errors', () => {
-    expect(parseCalDAVError(new Error('TLS handshake failed')).code).toBe(
+    expectCode(
+      'TLS handshake failed',
       CalendarEventImportDriverExceptionCode.UNKNOWN,
     );
   });
 
   it('forwards the original error message untouched', () => {
-    const result = parseCalDAVError(new Error('Invalid credentials'));
-
-    expect(result.message).toBe('Invalid credentials');
+    expect(parseCalDAVError(new Error('Invalid auth method')).message).toBe(
+      'Invalid auth method',
+    );
   });
 });

--- a/packages/twenty-server/src/modules/calendar/calendar-event-import-manager/drivers/caldav/utils/parse-caldav-error.util.ts
+++ b/packages/twenty-server/src/modules/calendar/calendar-event-import-manager/drivers/caldav/utils/parse-caldav-error.util.ts
@@ -8,6 +8,13 @@ export const parseCalDAVError = (
 ): CalendarEventImportDriverException => {
   const { message } = error;
 
+  if (message.includes('Invalid credentials')) {
+    return new CalendarEventImportDriverException(
+      message,
+      CalendarEventImportDriverExceptionCode.INSUFFICIENT_PERMISSIONS,
+    );
+  }
+
   switch (message) {
     case 'Collection does not exist on server':
       return new CalendarEventImportDriverException(
@@ -15,6 +22,7 @@ export const parseCalDAVError = (
         CalendarEventImportDriverExceptionCode.NOT_FOUND,
       );
 
+    case 'cannot find principalUrl':
     case 'no account for smartCollectionSync':
     case 'no account for fetchAddressBooks':
     case 'no account for fetchCalendars':
@@ -31,12 +39,6 @@ export const parseCalDAVError = (
       return new CalendarEventImportDriverException(
         message,
         CalendarEventImportDriverExceptionCode.NOT_FOUND,
-      );
-
-    case 'Invalid credentials':
-      return new CalendarEventImportDriverException(
-        message,
-        CalendarEventImportDriverExceptionCode.INSUFFICIENT_PERMISSIONS,
       );
 
     case 'Invalid auth method':


### PR DESCRIPTION
Anything `parseCalDAVError` did not recognise became `UNKNOWN`, and `FAILED_UNKNOWN` is revived by `CalendarRelaunchFailedCalendarChannelsCronJob` every 30 minutes with `throttleFailureCount` reset, so a permanently broken channel retries forever. One account has been looping since 2026-05-04.

tsdav interpolates the account and collection into several of its messages, so the exact-match switch never hit them. Adds `includes` checks for those, adds `cannot find principalUrl` (28 occurrences in prod over 14 days), and treats incomplete account discovery as retryable rather than a silent disconnect.

`caldav-get-events.service.ts` also gains the driver exception re-throw guard that `caldav-import-events.service.ts` already had, so the `INSUFFICIENT_PERMISSIONS` raised by `getClient` for missing credentials is no longer re-parsed into `UNKNOWN`.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/24079?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

