### PR TITLE
Fix: Calendar drop issue & drop target resolution at list extremes

### DIFF
--- a/packages/twenty-front/src/modules/object-record/record-board/record-board-column/components/RecordBoardColumnDnd.tsx
+++ b/packages/twenty-front/src/modules/object-record/record-board/record-board-column/components/RecordBoardColumnDnd.tsx
@@ -1,5 +1,6 @@
 import { Fragment } from 'react';
 
+import { closestCenter } from '@dnd-kit/collision';
 import { RecordBoardAddGroupColumn } from '@/object-record/record-board/components/RecordBoardAddGroupColumn';
 import { RecordBoardColumnHeaderWrapper } from '@/object-record/record-board/record-board-column/components/RecordBoardColumnHeaderWrapper';
 import { RECORD_BOARD_COLUMN_DROPPABLE_ID } from '@/object-record/record-board/record-board-column/dnd/constants/RecordBoardColumnDroppableId';
@@ -31,6 +32,7 @@ export const RecordBoardColumnDnd = () => {
             group={RECORD_BOARD_COLUMN_DROPPABLE_ID}
             fill
             restrictMovementTo="x"
+            collisionDetector={closestCenter}
           >
             <RecordGroupContext.Provider value={{ recordGroupId }}>
               <RecordBoardColumnHeaderWrapper

--- a/packages/twenty-front/src/modules/object-record/record-board/record-board-column/dnd/hooks/useRecordBoardColumnDndKit.ts
+++ b/packages/twenty-front/src/modules/object-record/record-board/record-board-column/dnd/hooks/useRecordBoardColumnDndKit.ts
@@ -1,4 +1,4 @@
-import { useRef, useState } from 'react';
+import { useState } from 'react';
 import { isDefined } from 'twenty-shared/utils';
 
 import { RECORD_GROUP_REORDER_CONFIRMATION_MODAL_ID } from '@/object-record/record-group/constants/RecordGroupReorderConfirmationModalId';
@@ -72,37 +72,22 @@ export const useRecordBoardColumnDndKit = (): {
     null,
   );
 
-  // The pointer can leave every sortable (column bodies, trailing empty
-  // space); the last resolved boundary is kept so the drop always lands where
-  // the insertion indicator was last shown. A ref because it is
-  // gesture-scoped bookkeeping read back inside drag callbacks.
-  // oxlint-disable-next-line twenty/no-state-useref
-  const lastDropTargetIndexRef = useRef<number | null>(null);
-
   const lastIndex = visibleRecordGroupIds.length;
 
   const handleDragStart = (_event: DragStartPayload) => {
-    lastDropTargetIndexRef.current = null;
     setActiveDropTargetIndex(null);
   };
 
   const handleDragMove = (event: DragMovePayload) => {
     const { target, position } = event.operation;
 
-    const resolvedDropTargetIndex =
+    const dropTargetIndex =
       resolveDropFromPointer({
         target,
         pointer: position.current,
         defaultOrientation: 'vertical',
         getDroppableItemCount: () => lastIndex,
       })?.dropTargetIndex ?? null;
-
-    if (isDefined(resolvedDropTargetIndex)) {
-      lastDropTargetIndexRef.current = resolvedDropTargetIndex;
-    }
-
-    const dropTargetIndex =
-      resolvedDropTargetIndex ?? lastDropTargetIndexRef.current;
 
     setActiveDropTargetIndex((currentActiveDropTargetIndex) =>
       currentActiveDropTargetIndex === dropTargetIndex
@@ -114,9 +99,6 @@ export const useRecordBoardColumnDndKit = (): {
   const handleDragEnd = (event: DragEndPayload) => {
     const { source, target, position } = event.operation;
 
-    const lastDropTargetIndex = lastDropTargetIndexRef.current;
-    lastDropTargetIndexRef.current = null;
-
     setActiveDropTargetIndex(null);
     setDragSelectionStartEnabled(true);
 
@@ -126,13 +108,12 @@ export const useRecordBoardColumnDndKit = (): {
 
     const sourceIndex = source.data.index;
 
-    const dropTargetIndex =
-      resolveDropFromPointer({
-        target,
-        pointer: position.current,
-        defaultOrientation: 'vertical',
-        getDroppableItemCount: () => lastIndex,
-      })?.dropTargetIndex ?? lastDropTargetIndex;
+    const dropTargetIndex = resolveDropFromPointer({
+      target,
+      pointer: position.current,
+      defaultOrientation: 'vertical',
+      getDroppableItemCount: () => lastIndex,
+    })?.dropTargetIndex;
 
     if (!isDefined(dropTargetIndex)) {
       return;

--- a/packages/twenty-front/src/modules/object-record/record-calendar/record-calendar-card/components/RecordCalendarCardDraggableContainer.tsx
+++ b/packages/twenty-front/src/modules/object-record/record-calendar/record-calendar-card/components/RecordCalendarCardDraggableContainer.tsx
@@ -1,3 +1,4 @@
+import { pointerIntersection } from '@dnd-kit/collision';
 import { styled } from '@linaria/react';
 
 import { RECORD_CALENDAR_CARD_DND_TYPE } from '@/object-record/record-calendar/month/constants/RecordCalendarCardDndType';
@@ -36,6 +37,7 @@ export const RecordCalendarCardDraggableContainer = ({
       group={calendarDay}
       type={RECORD_CALENDAR_CARD_DND_TYPE}
       accept={RECORD_CALENDAR_CARD_DND_TYPE}
+      collisionDetector={pointerIntersection}
       disabled={dragIsDisabled}
       fadeSourceWhileDragging
     >

--- a/packages/twenty-front/src/modules/object-record/record-table/record-table-header/components/RecordTableHeaderDnd.tsx
+++ b/packages/twenty-front/src/modules/object-record/record-table/record-table-header/components/RecordTableHeaderDnd.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 
+import { closestCenter } from '@dnd-kit/collision';
 import { useRecordTableContextOrThrow } from '@/object-record/record-table/contexts/RecordTableContext';
 import { RecordTableHeaderAddColumnButton } from '@/object-record/record-table/record-table-header/components/RecordTableHeaderAddColumnButton';
 import { RecordTableHeaderCell } from '@/object-record/record-table/record-table-header/components/RecordTableHeaderCell';
@@ -40,6 +41,7 @@ export const RecordTableHeaderDnd = () => {
           group={RECORD_TABLE_HEADER_DROPPABLE_ID}
           disabled={isRecordTableColumnHeadersReadOnly}
           restrictMovementTo="x"
+          collisionDetector={closestCenter}
         >
           <RecordTableHeaderFirstScrollableCell
             firstScrollableRecordField={firstScrollableRecordField}
@@ -62,6 +64,7 @@ export const RecordTableHeaderDnd = () => {
             group={RECORD_TABLE_HEADER_DROPPABLE_ID}
             disabled={isRecordTableColumnHeadersReadOnly}
             restrictMovementTo="x"
+            collisionDetector={closestCenter}
           >
             <RecordTableHeaderCell
               key={recordField.fieldMetadataItemId}

--- a/packages/twenty-front/src/modules/object-record/record-table/record-table-header/dnd/hooks/useRecordTableHeaderDndKit.ts
+++ b/packages/twenty-front/src/modules/object-record/record-table/record-table-header/dnd/hooks/useRecordTableHeaderDndKit.ts
@@ -1,4 +1,4 @@
-import { useRef, useState } from 'react';
+import { useState } from 'react';
 import { isDefined } from 'twenty-shared/utils';
 
 import { useReorderVisibleRecordFields } from '@/object-record/record-field/hooks/useReorderVisibleRecordFields';
@@ -38,37 +38,22 @@ export const useRecordTableHeaderDndKit = (): {
     number | null
   >(null);
 
-  // The pointer can leave every sortable (sticky pinned column, table body,
-  // trailing empty space); the last resolved boundary is kept so the drop
-  // always lands where the insertion indicator was last shown. A ref because
-  // it is gesture-scoped bookkeeping read back inside drag callbacks.
-  // oxlint-disable-next-line twenty/no-state-useref
-  const lastDropTargetIndexRef = useRef<number | null>(null);
-
   const lastIndex = visibleRecordFields.length - 1;
 
   const handleDragStart = (_event: DragStartPayload) => {
-    lastDropTargetIndexRef.current = null;
     setActiveDropTargetIndex(null);
   };
 
   const handleDragMove = (event: DragMovePayload) => {
     const { target, position } = event.operation;
 
-    const resolvedDropTargetIndex =
+    const dropTargetIndex =
       resolveDropFromPointer({
         target,
         pointer: position.current,
         defaultOrientation: 'vertical',
         getDroppableItemCount: () => lastIndex,
       })?.dropTargetIndex ?? null;
-
-    if (isDefined(resolvedDropTargetIndex)) {
-      lastDropTargetIndexRef.current = resolvedDropTargetIndex;
-    }
-
-    const dropTargetIndex =
-      resolvedDropTargetIndex ?? lastDropTargetIndexRef.current;
 
     setActiveDropTargetIndex((currentActiveDropTargetIndex) =>
       currentActiveDropTargetIndex === dropTargetIndex
@@ -80,9 +65,6 @@ export const useRecordTableHeaderDndKit = (): {
   const handleDragEnd = (event: DragEndPayload) => {
     const { source, target, position } = event.operation;
 
-    const lastDropTargetIndex = lastDropTargetIndexRef.current;
-    lastDropTargetIndexRef.current = null;
-
     setActiveDropTargetIndex(null);
     setDragSelectionStartEnabled(true);
 
@@ -92,13 +74,12 @@ export const useRecordTableHeaderDndKit = (): {
 
     const sourceIndex = source.data.index;
 
-    const dropTargetIndex =
-      resolveDropFromPointer({
-        target,
-        pointer: position.current,
-        defaultOrientation: 'vertical',
-        getDroppableItemCount: () => lastIndex,
-      })?.dropTargetIndex ?? lastDropTargetIndex;
+    const dropTargetIndex = resolveDropFromPointer({
+      target,
+      pointer: position.current,
+      defaultOrientation: 'vertical',
+      getDroppableItemCount: () => lastIndex,
+    })?.dropTargetIndex;
 
     if (!isDefined(dropTargetIndex)) {
       return;

--- a/packages/twenty-front/src/modules/ui/layout/draggable-list/components/DraggableItem.tsx
+++ b/packages/twenty-front/src/modules/ui/layout/draggable-list/components/DraggableItem.tsx
@@ -2,6 +2,7 @@ import { useDragDropMonitor } from '@dnd-kit/react';
 import { isFunction } from '@sniptt/guards';
 import { Fragment, type JSX, useContext, useEffect, useState } from 'react';
 import { isDefined } from 'twenty-shared/utils';
+import { closestCenter } from '@dnd-kit/collision';
 
 import { DraggableListGroupContext } from '@/ui/layout/draggable-list/contexts/DraggableListGroupContext';
 import { DragDropItemDropTarget } from '@/ui/utilities/drag-and-drop/components/DragDropItemDropTarget';
@@ -80,6 +81,7 @@ export const DraggableItem = ({
         highlightWhileDragging={!disableDraggingBackground}
         orientation="horizontal"
         restrictMovementTo={restrictMovementTo}
+        collisionDetector={closestCenter}
       >
         {isFunction(itemComponent)
           ? itemComponent({ isDragging })

--- a/packages/twenty-front/src/modules/ui/utilities/drag-and-drop/components/DragDropItemSortableCell.tsx
+++ b/packages/twenty-front/src/modules/ui/utilities/drag-and-drop/components/DragDropItemSortableCell.tsx
@@ -1,3 +1,5 @@
+import { type CollisionDetector } from '@dnd-kit/abstract';
+import { defaultCollisionDetection } from '@dnd-kit/collision';
 import {
   RestrictToHorizontalAxis,
   RestrictToVerticalAxis,
@@ -57,6 +59,7 @@ const StyledSortableRoot = styled.div<{
 type DragDropItemSortableCellProps = {
   accept?: string;
   children: ReactNode;
+  collisionDetector?: CollisionDetector;
   data?: Record<string, unknown>;
   disabled?: boolean;
   fadeSourceWhileDragging?: boolean;
@@ -76,6 +79,7 @@ type DragDropItemSortableCellProps = {
 export const DragDropItemSortableCell = ({
   accept,
   children,
+  collisionDetector = defaultCollisionDetection,
   data,
   disabled = false,
   fadeSourceWhileDragging = false,
@@ -96,6 +100,7 @@ export const DragDropItemSortableCell = ({
     type,
     accept,
     collisionPriority: SORTABLE_COLLISION_PRIORITY,
+    collisionDetector,
     // Sortable metadata stays authoritative over consumer data so drag
     // handlers always resolve the cell's real group and position.
     data: {


### PR DESCRIPTION
Fixes: #24081

### Calendar: Now able to drop cards wherever we want.

https://github.com/user-attachments/assets/f664ed9b-0b37-4759-93f9-ca06516e3b5d

Taking this same idea of `collisionDetection`, we can also solve another problem: when the pointer moves past the ends of a list, into the empty space beyond every sortable and droppable, `pointerIntersection` returns nothing and the drop target disappears.

### Record table/board: dragging the header cell beyond every header

In the record table/board header we solved this with a `useRef`:

```ts
const lastDropTargetIndexRef = useRef<number | null>(null);
....
if (isDefined(resolvedDropTargetIndex)) {
      lastDropTargetIndexRef.current = resolvedDropTargetIndex;
}

const dropTargetIndex =
      resolvedDropTargetIndex ?? lastDropTargetIndexRef.current;
```

This can be solved instead with the `closestCenter` collision detector. The useRef is no longer needed, and the code is shorter and cleaner.

https://github.com/user-attachments/assets/69e46ab3-ff84-4483-9dbb-f2a994d269fd

### `DraggableItem`: Dragging the item beyond the list.
Same idea, using the `closestCenter` collision detector. This affects the following files:
- `ViewPickerListContent.tsx`
- `ViewFieldsVisibleDropdownSection.tsx`
- `RecordGroupsVisibilityDropdownSection.tsx`
- `SidePanelCommandMenuItemEditPage.tsx`
- `ChartManualSortSubMenuContent.tsx`
- `RecordTableFieldsDropdownVisibleFieldsContent.tsx`
- `RecordTableSettingsFieldVisibility.tsx`
- `SettingsDataModelFieldSelectForm.tsx`
- `WorkflowEditActionFormBuilder.tsx`
All working as expected: dragging an item beyond the list still drops it correctly at the extreme ends.

https://github.com/user-attachments/assets/2ba5af7a-7803-4fef-9447-cdcf3a3fbf4a



<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/24082?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

