### PR TITLE
perf(server): skip resolver validation for types without validators

### DIFF
--- a/packages/twenty-server/src/engine/core-modules/graphql/pipes/__tests__/resolver-validation.pipe.spec.ts
+++ b/packages/twenty-server/src/engine/core-modules/graphql/pipes/__tests__/resolver-validation.pipe.spec.ts
@@ -1,0 +1,53 @@
+import { type ArgumentMetadata, type Type } from '@nestjs/common';
+
+import { IsString } from 'class-validator';
+
+import { ResolverValidationPipe } from 'src/engine/core-modules/graphql/pipes/resolver-validation.pipe';
+import { UserInputError } from 'src/engine/core-modules/graphql/utils/graphql-errors.util';
+
+class DecoratedInput {
+  @IsString()
+  name!: string;
+}
+
+class PlainInput {
+  name!: string;
+}
+
+const argMetadata = (metatype?: Type<unknown>): ArgumentMetadata => ({
+  type: 'body',
+  metatype,
+  data: '',
+});
+
+describe('ResolverValidationPipe', () => {
+  const pipe = new ResolverValidationPipe();
+
+  it('should return the value when a decorated field is valid', async () => {
+    await expect(
+      pipe.transform({ name: 'ok' }, argMetadata(DecoratedInput)),
+    ).resolves.toEqual({ name: 'ok' });
+  });
+
+  it('should throw UserInputError when a decorated field is invalid', async () => {
+    await expect(
+      pipe.transform({ name: 42 }, argMetadata(DecoratedInput)),
+    ).rejects.toBeInstanceOf(UserInputError);
+  });
+
+  it('should return the value for a class without validation metadata', async () => {
+    await expect(
+      pipe.transform({ name: 42 }, argMetadata(PlainInput)),
+    ).resolves.toEqual({ name: 42 });
+  });
+
+  it('should return the value for primitive metatypes', async () => {
+    await expect(pipe.transform('x', argMetadata(String))).resolves.toBe('x');
+  });
+
+  it('should return the value when there is no metatype', async () => {
+    await expect(pipe.transform('x', argMetadata(undefined))).resolves.toBe(
+      'x',
+    );
+  });
+});

--- a/packages/twenty-server/src/engine/core-modules/graphql/pipes/resolver-validation.pipe.ts
+++ b/packages/twenty-server/src/engine/core-modules/graphql/pipes/resolver-validation.pipe.ts
@@ -6,9 +6,36 @@ import {
 } from '@nestjs/common';
 
 import { plainToInstance } from 'class-transformer';
-import { type ValidationError, validate } from 'class-validator';
+import {
+  getMetadataStorage,
+  type ValidationError,
+  validate,
+} from 'class-validator';
 
 import { UserInputError } from 'src/engine/core-modules/graphql/utils/graphql-errors.util';
+
+// class-validator rescans its global metadata store on every validate() call, so we
+// skip the whole plainToInstance + validate roundtrip for argument types that carry no
+// validation decorators. Metadata is registered at class load time, so the answer is
+// stable per constructor and cached. always=true keeps the lookup conservative: any
+// declared constraint (including group-only ones) counts as "has metadata".
+const hasValidationMetadataByTarget = new WeakMap<object, boolean>();
+
+const targetHasValidationMetadata = (metatype: Type<unknown>): boolean => {
+  const cached = hasValidationMetadataByTarget.get(metatype);
+
+  if (cached !== undefined) {
+    return cached;
+  }
+
+  const hasMetadata =
+    getMetadataStorage().getTargetValidationMetadatas(metatype, '', true, false)
+      .length > 0;
+
+  hasValidationMetadataByTarget.set(metatype, hasMetadata);
+
+  return hasMetadata;
+};
 
 const safeClassValidatorValidateWrapper = async (
   object: object,
@@ -26,6 +53,10 @@ export class ResolverValidationPipe implements PipeTransform {
     const { metatype } = metadata;
 
     if (!metatype || !this.toValidate(metatype)) {
+      return value;
+    }
+
+    if (!targetHasValidationMetadata(metatype)) {
       return value;
     }
 


### PR DESCRIPTION
## Problem
`ResolverValidationPipe` runs `plainToInstance` + class-validator `validate()` on every non-primitive resolver argument. class-validator's `getTargetValidationMetadatas` rescans its global metadata store on each `validate()` call and showed up as a top self-time frame in prod-eu CPU profiles. Argument types that carry **no** validation decorators still paid the full roundtrip for nothing.

(The pipe already discards the `plainToInstance` output — it returns the original `value` — so skipping it for un-validated types loses nothing.)

## Change
Short-circuit types with no validation metadata: look up once per constructor whether the type has any validation metadata, cache the answer in a `WeakMap`, and return the value directly when there is none.

- Validation metadata is registered at class-load time, so the per-constructor answer is stable — safe to cache.
- The lookup uses `getTargetValidationMetadatas(metatype, '', true, false)` (`always=true`, no groups), which returns all direct **and inherited** constraints regardless of group. Any declared constraint — including group-only ones — still validates exactly as before. The optimization only removes work for types that have zero validators.

## Tests
New `resolver-validation.pipe.spec.ts`: valid decorated input passes, invalid decorated input still throws `UserInputError`, a class with no validators returns the value, and primitive / missing metatypes pass through. All 5 pass; lint/format clean.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/24084?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

