### PR TITLE
perf(server): memoize class-validator target metadata lookup

### DIFF
--- a/packages/twenty-server/src/main.ts
+++ b/packages/twenty-server/src/main.ts
@@ -25,10 +25,12 @@ import { AppModule } from './app.module';
 import './instrument';
 
 import { settings } from './engine/constants/settings';
+import { enableValidationMetadataCache } from './utils/enable-validation-metadata-cache.util';
 import { generateFrontConfig } from './utils/generate-front-config';
 
 // Trigger
 const bootstrap = async () => {
+  enableValidationMetadataCache();
   setPgDateTypeParser();
 
   const app = await NestFactory.create<NestExpressApplication>(AppModule, {

--- a/packages/twenty-server/src/queue-worker/queue-worker.ts
+++ b/packages/twenty-server/src/queue-worker/queue-worker.ts
@@ -5,10 +5,13 @@ import { LoggerService } from 'src/engine/core-modules/logger/logger.service';
 import { shouldCaptureException } from 'src/engine/utils/global-exception-handler.util';
 import 'src/instrument';
 import { QueueWorkerModule } from 'src/queue-worker/queue-worker.module';
+import { enableValidationMetadataCache } from 'src/utils/enable-validation-metadata-cache.util';
 
 async function bootstrap() {
   let exceptionHandlerService: ExceptionHandlerService | undefined;
   let loggerService: LoggerService | undefined;
+
+  enableValidationMetadataCache();
 
   try {
     const app = await NestFactory.createApplicationContext(QueueWorkerModule, {

--- a/packages/twenty-server/src/utils/__tests__/enable-validation-metadata-cache.util.spec.ts
+++ b/packages/twenty-server/src/utils/__tests__/enable-validation-metadata-cache.util.spec.ts
@@ -1,0 +1,67 @@
+import { getMetadataStorage, IsString } from 'class-validator';
+
+import { enableValidationMetadataCache } from 'src/utils/enable-validation-metadata-cache.util';
+
+class ValidatedInput {
+  @IsString()
+  name!: string;
+}
+
+describe('enableValidationMetadataCache', () => {
+  it('should serve repeated identical lookups from cache (same array reference)', () => {
+    enableValidationMetadataCache();
+    const storage = getMetadataStorage();
+
+    const first = storage.getTargetValidationMetadatas(
+      ValidatedInput,
+      '',
+      true,
+      false,
+    );
+    const second = storage.getTargetValidationMetadatas(
+      ValidatedInput,
+      '',
+      true,
+      false,
+    );
+
+    expect(first.length).toBeGreaterThan(0);
+    expect(second).toBe(first);
+  });
+
+  it('should cache independently per lookup arguments', () => {
+    enableValidationMetadataCache();
+    const storage = getMetadataStorage();
+
+    const noGroup = storage.getTargetValidationMetadatas(
+      ValidatedInput,
+      '',
+      true,
+      false,
+    );
+    const withGroup = storage.getTargetValidationMetadatas(
+      ValidatedInput,
+      '',
+      true,
+      false,
+      ['a'],
+    );
+
+    expect(withGroup).not.toBe(noGroup);
+  });
+
+  it('should be idempotent when installed more than once', () => {
+    enableValidationMetadataCache();
+    enableValidationMetadataCache();
+    const storage = getMetadataStorage();
+
+    const result = storage.getTargetValidationMetadatas(
+      ValidatedInput,
+      '',
+      true,
+      false,
+    );
+
+    expect(Array.isArray(result)).toBe(true);
+  });
+});

--- a/packages/twenty-server/src/utils/enable-validation-metadata-cache.util.ts
+++ b/packages/twenty-server/src/utils/enable-validation-metadata-cache.util.ts
@@ -1,0 +1,62 @@
+import { getMetadataStorage } from 'class-validator';
+
+let installed = false;
+
+export const enableValidationMetadataCache = (): void => {
+  if (installed) {
+    return;
+  }
+  installed = true;
+
+  const storage = getMetadataStorage();
+  const computeTargetValidationMetadatas =
+    storage.getTargetValidationMetadatas.bind(storage);
+
+  type ValidationMetadatas = ReturnType<
+    typeof computeTargetValidationMetadatas
+  >;
+
+  const cacheByTarget = new WeakMap<object, Map<string, ValidationMetadatas>>();
+
+  storage.getTargetValidationMetadatas = (
+    targetConstructor,
+    targetSchema,
+    always,
+    strictGroups,
+    groups,
+  ) => {
+    let cacheByArgs = cacheByTarget.get(targetConstructor);
+
+    if (cacheByArgs === undefined) {
+      cacheByArgs = new Map();
+      cacheByTarget.set(targetConstructor, cacheByArgs);
+    }
+
+    const cacheKey = `${targetSchema}|${always}|${strictGroups}|${[
+      ...(groups ?? []),
+    ]
+      .sort()
+      .join(',')}`;
+
+    const cached = cacheByArgs.get(cacheKey);
+
+    if (cached !== undefined) {
+      return cached;
+    }
+
+    // Safe to memoize: a target's own and inherited validation metadata is fully
+    // registered at class load, before the target can ever be validated. Classes loaded
+    // later only register their own metadata and never change this target's result.
+    const metadatas = computeTargetValidationMetadatas(
+      targetConstructor,
+      targetSchema,
+      always,
+      strictGroups,
+      groups,
+    );
+
+    cacheByArgs.set(cacheKey, metadatas);
+
+    return metadatas;
+  };
+};


### PR DESCRIPTION
## Problem
class-validator's `getTargetValidationMetadatas` **rescans the entire global metadata store on every `validate()` call** — filtering, group-matching, and walking the inheritance chain each time. It showed up as a top self-time frame in prod-eu CPU profiles. For a DTO validated on every request, that full O(all-registered-metadata) scan repeats every request even though the class's metadata never changes after startup.

This is the follow-up to #24084. That PR skips the roundtrip for types with *no* validators; this one addresses the types that **do** validate — the part #24084 deliberately doesn't touch.

## Change
Wrap the singleton `getMetadataStorage().getTargetValidationMetadatas` once at bootstrap with a cache keyed by `(target, schema, always, strictGroups, groups)`. After warmup each lookup is an O(1) hit instead of a rescan, for validated types with or without a fast-path skip.

- **Safe** because a target's own and inherited validation metadata is fully registered at class-load, before the target can ever be validated. Classes loaded later only register their own metadata and never change an existing target's result. Each distinct argument tuple (groups/always) gets its own entry, so grouped validation stays correct.
- Keyed in a `WeakMap` by the target constructor, so a collectible (e.g. dynamically generated) class drops its cache with it — no leak.
- Installed in the two long-running entrypoints (`main.ts` http server and `queue-worker.ts` — separate processes). Idempotent.

## Relationship to #24084
Complementary and composable: this makes the scan itself O(1) for **all** validated types; #24084 additionally avoids `plainToInstance` + `validate` for decorator-less types. They can land in either order.

## Tests
`enable-validation-metadata-cache.util.spec.ts`: repeated identical lookups return the **same array reference** (proves the cache is active — the unpatched impl builds a fresh array each call), distinct argument tuples cache independently, and installing twice is idempotent. Lint/format clean.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/24085?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

