### PR TITLE
feat(server): observe ORM v2 read-path usage with a metric

### DIFF
--- a/packages/twenty-server/src/engine/api/common/common-query-runners/common-base-query-runner.service.ts
+++ b/packages/twenty-server/src/engine/api/common/common-query-runners/common-base-query-runner.service.ts
@@ -379,6 +379,12 @@ export abstract class CommonBaseQueryRunnerService<
       return repository;
     }
 
+    this.metricsService.incrementCounterBy({
+      key: MetricsKeys.OrmV2ReadPathUsed,
+      amount: 1,
+      attributes: { operation: this.operationName },
+    });
+
     return this.workspaceDataSourceV2Service
       .getDataSource({ useReplica: this.isReadOnly })
       .getRepository(flatObjectMetadata.nameSingular, rolePermissionConfig);

--- a/packages/twenty-server/src/engine/core-modules/metrics/types/metrics-keys.type.ts
+++ b/packages/twenty-server/src/engine/core-modules/metrics/types/metrics-keys.type.ts
@@ -91,4 +91,5 @@ export enum MetricsKeys {
   WorkspaceMigrationRunPhaseDurationMs = 'workspace-migration/run-phase-duration-ms',
   WorkspaceMigrationActionDurationMs = 'workspace-migration/action-duration-ms',
   WorkspaceMigrationActionCount = 'workspace-migration/action-count',
+  OrmV2ReadPathUsed = 'orm-v2/read-path-used',
 }


### PR DESCRIPTION
Follow-up to #24077 (merged), which routed findMany and findOne through the
ORM v2 read path behind `IS_ORM_V2_READ_PATH_ENABLED` via a shared
`getReadRepository` helper.

v2 reads are parity-identical to v1 output, so "did this workspace actually
switch to v2" is otherwise invisible without inspecting raw SQL on the DB.
This makes the rollout observable: `getReadRepository` now emits an
`orm-v2/read-path-used` counter (tagged by `operation`) whenever it returns
the v2 repository. A non-zero rate in Grafana confirms which operations run
on v2 per deploy/workspace.

Flag off, nothing changes (the counter only increments on the v2 branch).

oxlint / oxfmt / typecheck clean.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/24086?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

