### PR TITLE
fix workflow canvas multi-selection

### DIFF
--- a/packages/twenty-front/src/modules/workflow/workflow-diagram/components/WorkflowDiagramCanvasBase.tsx
+++ b/packages/twenty-front/src/modules/workflow/workflow-diagram/components/WorkflowDiagramCanvasBase.tsx
@@ -99,6 +99,8 @@ const defaultFitViewOptions = {
   maxZoom: 1,
 } satisfies FitViewOptions;
 
+const WORKFLOW_DIAGRAM_PAN_ON_DRAG_BUTTONS = [1];
+
 export const WorkflowDiagramCanvasBase = ({
   nodeTypes,
   edgeTypes,
@@ -610,13 +612,20 @@ export const WorkflowDiagramCanvasBase = ({
         onNodeDragStop={onNodeDragStop}
         onBeforeDelete={onBeforeDelete}
         onDelete={onDelete}
-        selectNodesOnDrag={false}
+        selectNodesOnDrag
+        selectionKeyCode="Shift"
+        selectionOnDrag
         proOptions={{ hideAttribution: true }}
-        multiSelectionKeyCode={null}
+        multiSelectionKeyCode="Shift"
         nodesFocusable={false}
         nodesDraggable={nodesDraggable}
         edgesFocusable={isDefined(onDeleteEdge)}
-        panOnDrag={workflowDiagramPanOnDrag}
+        // Keep primary-button drags available for rubber-band selection.
+        panOnDrag={
+          workflowDiagramPanOnDrag
+            ? WORKFLOW_DIAGRAM_PAN_ON_DRAG_BUTTONS
+            : false
+        }
         panOnScroll={true}
         onPaneContextMenu={onPaneContextMenu}
         nodesConnectable={nodesConnectable}

--- a/packages/twenty-front/src/modules/workflow/workflow-diagram/components/WorkflowDiagramCanvasEditable.tsx
+++ b/packages/twenty-front/src/modules/workflow/workflow-diagram/components/WorkflowDiagramCanvasEditable.tsx
@@ -24,6 +24,7 @@ import { WorkflowDiagramStepNodeEditable } from '@/workflow/workflow-diagram/wor
 import { useCreateEdge } from '@/workflow/workflow-steps/hooks/useCreateEdge';
 import { useDeleteEdge } from '@/workflow/workflow-steps/hooks/useDeleteEdge';
 import { useUpdateStep } from '@/workflow/workflow-steps/hooks/useUpdateStep';
+import { useTidyUpWorkflowVersion } from '@/workflow/workflow-version/hooks/useTidyUpWorkflowVersion';
 import { prepareIfElseStepWithNewBranch } from '@/workflow/workflow-steps/workflow-actions/if-else-action/utils/prepareIfElseStepWithNewBranch';
 import { useUpdateWorkflowVersionTrigger } from '@/workflow/workflow-trigger/hooks/useUpdateWorkflowVersionTrigger';
 import {
@@ -58,6 +59,8 @@ export const WorkflowDiagramCanvasEditable = () => {
   const { deleteEdge } = useDeleteEdge();
 
   const { updateStep } = useUpdateStep();
+
+  const { updateWorkflowVersionPosition } = useTidyUpWorkflowVersion();
 
   const { updateTrigger } = useUpdateWorkflowVersionTrigger();
 
@@ -137,7 +140,20 @@ export const WorkflowDiagramCanvasEditable = () => {
     });
   };
 
-  const onNodeDragStop: OnNodeDrag<WorkflowDiagramNode> = async (_, node) => {
+  const onNodeDragStop: OnNodeDrag<WorkflowDiagramNode> = async (
+    _,
+    node,
+    draggedNodes,
+  ) => {
+    if (draggedNodes.length > 1 && isDefined(flow?.workflowVersionId)) {
+      await updateWorkflowVersionPosition(
+        flow.workflowVersionId,
+        draggedNodes.map(({ id, position }) => ({ id, position })),
+      );
+
+      return;
+    }
+
     const stepToUpdate = flow?.steps?.find((step) => step.id === node.id);
 
     if (isDefined(stepToUpdate)) {


### PR DESCRIPTION
## Summary
- enable rubber-band selection and Shift multi-selection in the workflow canvas
- persist positions for every selected node when dragging a group

## Why
The workflow builder disabled React Flow selection-on-drag and multi-selection, so users could only move one node at a time. Group drags also persisted only the primary dragged node.

Primary-button drags are now available for rubber-band selection; middle-button panning and the existing right-click canvas menu remain available.

## Validation
- TypeScript syntax transpilation passed for both changed files
- whitespace validation passed for both changed files
- the full Yarn/Nx validation suite could not run because dependency installation remained blocked by slow registry downloads and did not produce `node_modules`

Closes #24050

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/24087?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

