### PR TITLE
feat(server): route groupBy through the ORM v2 read path

### DIFF
--- a/.github/workflows/ci-server.yaml
+++ b/.github/workflows/ci-server.yaml
@@ -311,7 +311,7 @@ jobs:
       SHARD_COUNTER: 16
       AUTH_COOKIE_SESSIONS_ENABLED: ${{ contains(github.event.pull_request.labels.*.name, 'ci:auth-cookie-sessions') }}
       TEST_FORCED_FEATURE_FLAGS: ${{ matrix.orm-v2 && 'IS_ORM_V2_READ_PATH_ENABLED' || '' }}
-      ORM_V2_TEST_PATH_PATTERN: '(find-many|find-one|find-duplicates|composite-field-pagination|filter-by-relation-field|order-by-relation-field|nested-relation|soft-deleted-relation|relation-join-rls)'
+      ORM_V2_TEST_PATH_PATTERN: '(find-many|find-one|find-duplicates|group-by|composite-field-pagination|filter-by-relation-field|order-by-relation-field|nested-relation|soft-deleted-relation|relation-join-rls)'
     steps:
       - name: Fetch custom Github Actions and base branch history
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1

--- a/packages/twenty-server/src/engine/api/common/common-query-runners/common-group-by-query-runner.service.ts
+++ b/packages/twenty-server/src/engine/api/common/common-query-runners/common-group-by-query-runner.service.ts
@@ -2,6 +2,7 @@ import { Injectable } from '@nestjs/common';
 
 import {
   CompositeFieldSubFieldName,
+  FeatureFlagKey,
   PartialFieldMetadataItemOption,
   RecordFilterGroupLogicalOperator,
   type RestrictedFieldsPermissions,
@@ -43,6 +44,7 @@ import { CommonSelectedFieldsResult } from 'src/engine/api/common/types/common-s
 import { GraphqlQueryParser } from 'src/engine/api/graphql/graphql-query-runner/graphql-query-parsers/graphql-query.parser';
 import { formatResultWithGroupByDimensionValues } from 'src/engine/api/graphql/graphql-query-runner/group-by/resolvers/utils/format-result-with-group-by-dimension-values.util';
 import { GroupByWithRecordsService } from 'src/engine/api/graphql/graphql-query-runner/group-by/services/group-by-with-records.service';
+import { GroupByWithRecordsV2Service } from 'src/engine/api/graphql/graphql-query-runner/group-by/services/group-by-with-records-v2.service';
 import { getGroupLimit } from 'src/engine/api/graphql/graphql-query-runner/group-by/utils/get-group-limit.util';
 import { ProcessAggregateHelper } from 'src/engine/api/graphql/graphql-query-runner/helpers/process-aggregate.helper';
 import { getFlatFieldsFromFlatObjectMetadata } from 'src/engine/api/graphql/workspace-schema-builder/utils/get-flat-fields-for-flat-object-metadata.util';
@@ -57,6 +59,8 @@ import { ViewFilterService } from 'src/engine/metadata-modules/view-filter/servi
 import { ViewService } from 'src/engine/metadata-modules/view/services/view.service';
 import { WorkspaceSelectQueryBuilder } from 'src/engine/twenty-orm/repository/workspace-select-query-builder';
 import { formatColumnNameForRelationField } from 'src/engine/twenty-orm/utils/format-column-name-for-relation-field.util';
+import { type WorkspaceSelectQueryBuilderV2 } from 'src/engine/twenty-orm-v2/query-builder/workspace-select-query-builder-v2';
+import { type WorkspaceRepositoryV2 } from 'src/engine/twenty-orm-v2/repository/workspace-repository-v2';
 
 @Injectable()
 export class CommonGroupByQueryRunnerService extends CommonBaseQueryRunnerService<
@@ -68,6 +72,7 @@ export class CommonGroupByQueryRunnerService extends CommonBaseQueryRunnerServic
     private readonly viewFilterGroupService: ViewFilterGroupService,
     private readonly viewService: ViewService,
     private readonly groupByWithRecordsService: GroupByWithRecordsService,
+    private readonly groupByWithRecordsV2Service: GroupByWithRecordsV2Service,
   ) {
     super();
   }
@@ -80,17 +85,21 @@ export class CommonGroupByQueryRunnerService extends CommonBaseQueryRunnerServic
     queryRunnerContext: CommonExtendedQueryRunnerContext,
   ): Promise<CommonGroupByOutputItem[]> {
     const {
-      repository,
       commonQueryParser,
       flatObjectMetadata,
       flatObjectMetadataMaps,
       flatFieldMetadataMaps,
       authContext,
+      featureFlagsMap,
     } = queryRunnerContext;
 
     const objectAlias = getObjectAlias(flatObjectMetadata);
 
-    let queryBuilder = repository.createQueryBuilder(objectAlias);
+    const readRepository = this.getReadRepository(queryRunnerContext);
+
+    let queryBuilder = readRepository.createQueryBuilder(
+      objectAlias,
+    ) as WorkspaceSelectQueryBuilder<ObjectLiteral>;
 
     const groupByFields =
       this.groupByArgProcessor.validateAndTransformGroupByFieldsOrThrow({
@@ -150,6 +159,22 @@ export class CommonGroupByQueryRunnerService extends CommonBaseQueryRunnerServic
     const shouldIncludeRecords = args.includeRecords ?? false;
 
     if (shouldIncludeRecords) {
+      if (featureFlagsMap[FeatureFlagKey.IS_ORM_V2_READ_PATH_ENABLED]) {
+        return this.groupByWithRecordsV2Service.resolveWithRecords({
+          queryBuilderWithFiltersAndWithoutGroupBy:
+            queryBuilderWithFiltersAndWithoutGroupBy as unknown as WorkspaceSelectQueryBuilderV2,
+          queryBuilderWithGroupBy:
+            queryBuilder as unknown as WorkspaceSelectQueryBuilderV2,
+          readRepository: readRepository as WorkspaceRepositoryV2,
+          groupByDefinitions,
+          selectedFieldsResult: args.selectedFieldsResult,
+          queryRunnerContext,
+          orderByForRecords: args.orderByForRecords ?? [],
+          groupLimit: args.limit,
+          offsetForRecords: args.offsetForRecords,
+        });
+      }
+
       return this.groupByWithRecordsService.resolveWithRecords({
         queryBuilderWithFiltersAndWithoutGroupBy,
         queryBuilderWithGroupBy: queryBuilder,

--- a/packages/twenty-server/src/engine/api/common/core-common-api.module.ts
+++ b/packages/twenty-server/src/engine/api/common/core-common-api.module.ts
@@ -8,6 +8,7 @@ import { ProcessNestedRelationsHelper } from 'src/engine/api/common/common-neste
 import { CommonQueryRunners } from 'src/engine/api/common/common-query-runners/common-query-runners';
 import { CommonResultGettersService } from 'src/engine/api/common/common-result-getters/common-result-getters.service';
 import { GroupByWithRecordsService } from 'src/engine/api/graphql/graphql-query-runner/group-by/services/group-by-with-records.service';
+import { GroupByWithRecordsV2Service } from 'src/engine/api/graphql/graphql-query-runner/group-by/services/group-by-with-records-v2.service';
 import { ProcessAggregateHelper } from 'src/engine/api/graphql/graphql-query-runner/helpers/process-aggregate.helper';
 import { WorkspaceQueryHookModule } from 'src/engine/api/graphql/workspace-query-runner/workspace-query-hook/workspace-query-hook.module';
 import { WorkspaceQueryRunnerModule } from 'src/engine/api/graphql/workspace-query-runner/workspace-query-runner.module';
@@ -57,6 +58,7 @@ import { WorkspaceCacheModule } from 'src/engine/workspace-cache/workspace-cache
     ...CommonQueryRunners,
     CommonResultGettersService,
     GroupByWithRecordsService,
+    GroupByWithRecordsV2Service,
   ],
   exports: [...CommonQueryRunners, GroupByArgProcessorService],
 })

--- a/packages/twenty-server/src/engine/api/graphql/graphql-query-runner/group-by/services/group-by-with-records-v2.service.ts
+++ b/packages/twenty-server/src/engine/api/graphql/graphql-query-runner/group-by/services/group-by-with-records-v2.service.ts
@@ -1,0 +1,319 @@
+import { Inject, Injectable } from '@nestjs/common';
+
+import { isNonEmptyString } from '@sniptt/guards';
+import isEmpty from 'lodash.isempty';
+import { ObjectRecord } from 'twenty-shared/types';
+import { isDefined } from 'twenty-shared/utils';
+import { type FindOptionsRelations, type ObjectLiteral } from 'typeorm';
+
+import { ObjectRecordOrderBy } from 'src/engine/api/graphql/workspace-query-builder/interfaces/object-record.interface';
+
+import { ProcessNestedRelationsHelper } from 'src/engine/api/common/common-nested-relations-processor/process-nested-relations.helper';
+import { type GroupByDefinition } from 'src/engine/api/common/common-query-runners/types/group-by-definition.type';
+import { getObjectAlias } from 'src/engine/api/common/common-query-runners/utils/get-object-alias-for-group-by.util';
+import { CommonResultGettersService } from 'src/engine/api/common/common-result-getters/common-result-getters.service';
+import { CommonExtendedQueryRunnerContext } from 'src/engine/api/common/types/common-extended-query-runner-context.type';
+import { type CommonGroupByOutputItem } from 'src/engine/api/common/types/common-group-by-output-item.type';
+import { CommonSelectedFieldsResult } from 'src/engine/api/common/types/common-selected-fields-result.type';
+import { GraphqlQueryParser } from 'src/engine/api/graphql/graphql-query-runner/graphql-query-parsers/graphql-query.parser';
+import { addRelationJoinAliasToQueryBuilder } from 'src/engine/api/graphql/graphql-query-runner/graphql-query-parsers/utils/add-relation-join-alias.util';
+import { type RecordQueryBuilder } from 'src/engine/api/graphql/graphql-query-runner/types/record-query-builder.type';
+import { formatResultWithGroupByDimensionValues } from 'src/engine/api/graphql/graphql-query-runner/group-by/resolvers/utils/format-result-with-group-by-dimension-values.util';
+import { getGroupLimit } from 'src/engine/api/graphql/graphql-query-runner/group-by/utils/get-group-limit.util';
+import { buildColumnsToSelect } from 'src/engine/api/graphql/graphql-query-runner/utils/build-columns-to-select';
+import { type FlatEntityMaps } from 'src/engine/metadata-modules/flat-entity/types/flat-entity-maps.type';
+import { type FlatFieldMetadata } from 'src/engine/metadata-modules/flat-field-metadata/types/flat-field-metadata.type';
+import { type FlatObjectMetadata } from 'src/engine/metadata-modules/flat-object-metadata/types/flat-object-metadata.type';
+import { type WorkspaceSelectQueryBuilderV2 } from 'src/engine/twenty-orm-v2/query-builder/workspace-select-query-builder-v2';
+import { type WorkspaceRepositoryV2 } from 'src/engine/twenty-orm-v2/repository/workspace-repository-v2';
+
+const RECORDS_PER_GROUP_LIMIT = 10;
+const RELATIONS_PER_RECORD_LIMIT = 5;
+const SUB_QUERY_PREFIX = 'sub_query_';
+
+@Injectable()
+export class GroupByWithRecordsV2Service {
+  @Inject()
+  protected readonly processNestedRelationsHelper: ProcessNestedRelationsHelper;
+  @Inject()
+  protected readonly commonResultGettersService: CommonResultGettersService;
+
+  public async resolveWithRecords({
+    queryBuilderWithGroupBy,
+    queryBuilderWithFiltersAndWithoutGroupBy,
+    groupByDefinitions,
+    selectedFieldsResult,
+    queryRunnerContext,
+    readRepository,
+    orderByForRecords,
+    groupLimit,
+    offsetForRecords,
+  }: {
+    queryBuilderWithGroupBy: WorkspaceSelectQueryBuilderV2;
+    queryBuilderWithFiltersAndWithoutGroupBy: WorkspaceSelectQueryBuilderV2;
+    groupByDefinitions: GroupByDefinition[];
+    selectedFieldsResult: CommonSelectedFieldsResult;
+    queryRunnerContext: CommonExtendedQueryRunnerContext;
+    readRepository: WorkspaceRepositoryV2;
+    orderByForRecords: ObjectRecordOrderBy;
+    groupLimit?: number;
+    offsetForRecords?: number;
+  }): Promise<CommonGroupByOutputItem[]> {
+    const effectiveGroupLimit = getGroupLimit(groupLimit);
+
+    const groupsResult = await queryBuilderWithGroupBy
+      .limit(effectiveGroupLimit)
+      .getRawMany();
+
+    if (groupsResult.length === 0) {
+      return [];
+    }
+
+    const {
+      authContext,
+      workspaceDataSource,
+      rolePermissionConfig,
+      flatObjectMetadata,
+      flatObjectMetadataMaps,
+      flatFieldMetadataMaps,
+    } = queryRunnerContext;
+
+    const columnsToSelect = buildColumnsToSelect({
+      select: selectedFieldsResult.select,
+      relations: selectedFieldsResult.relations,
+      flatObjectMetadata,
+      flatObjectMetadataMaps,
+      flatFieldMetadataMaps,
+    });
+
+    const { sql, parameters } = this.buildRankedRecordsStatement({
+      subQueryBuilder: queryBuilderWithFiltersAndWithoutGroupBy,
+      columnsToSelect,
+      groupsResult,
+      groupByDefinitions,
+      orderByForRecords,
+      flatObjectMetadata,
+      flatObjectMetadataMaps,
+      flatFieldMetadataMaps,
+      offsetForRecords: offsetForRecords ?? 0,
+    });
+
+    const recordsResult = await readRepository.executeRaw<
+      Record<string, unknown>
+    >(sql, parameters);
+
+    const allRecords = recordsResult
+      .flatMap((group) => group.records as ObjectRecord[])
+      .filter(isDefined);
+
+    if (!isEmpty(selectedFieldsResult.relations)) {
+      await this.processNestedRelationsHelper.processNestedRelations({
+        flatObjectMetadataMaps,
+        flatFieldMetadataMaps,
+        parentObjectMetadataItem: flatObjectMetadata,
+        parentObjectRecords: allRecords,
+        parentObjectRecordsAggregatedValues: {},
+        relations: selectedFieldsResult.relations as Record<
+          string,
+          FindOptionsRelations<ObjectLiteral>
+        >,
+        aggregate: selectedFieldsResult.aggregate,
+        limit: RELATIONS_PER_RECORD_LIMIT,
+        authContext,
+        workspaceDataSource,
+        rolePermissionConfig,
+        selectedFields: selectedFieldsResult.select,
+      });
+    }
+
+    return await formatResultWithGroupByDimensionValues({
+      groupsResult,
+      recordsResult,
+      groupByDefinitions,
+      aggregateFieldNames: Object.keys(selectedFieldsResult.aggregate),
+      flatObjectMetadata,
+      flatObjectMetadataMaps,
+      flatFieldMetadataMaps,
+      processRecord: (record: ObjectRecord) =>
+        this.commonResultGettersService.processRecord(
+          record,
+          flatObjectMetadata,
+          flatObjectMetadataMaps,
+          flatFieldMetadataMaps,
+          authContext.workspace.id,
+        ),
+    });
+  }
+
+  private buildRankedRecordsStatement({
+    subQueryBuilder,
+    columnsToSelect,
+    groupsResult,
+    groupByDefinitions,
+    orderByForRecords,
+    flatObjectMetadata,
+    flatObjectMetadataMaps,
+    flatFieldMetadataMaps,
+    offsetForRecords,
+  }: {
+    subQueryBuilder: WorkspaceSelectQueryBuilderV2;
+    columnsToSelect: Record<string, boolean>;
+    groupsResult: Array<Record<string, unknown>>;
+    groupByDefinitions: GroupByDefinition[];
+    orderByForRecords: ObjectRecordOrderBy;
+    flatObjectMetadata: FlatObjectMetadata;
+    flatObjectMetadataMaps: FlatEntityMaps<FlatObjectMetadata>;
+    flatFieldMetadataMaps: FlatEntityMaps<FlatFieldMetadata>;
+    offsetForRecords: number;
+  }): { sql: string; parameters: Record<string, unknown> } {
+    const objectAlias = getObjectAlias(flatObjectMetadata);
+
+    subQueryBuilder.select([]);
+
+    for (const columnName of Object.keys(columnsToSelect)) {
+      subQueryBuilder.addSelect(
+        `"${objectAlias}"."${columnName}"`,
+        `${SUB_QUERY_PREFIX}${columnName}`,
+      );
+    }
+
+    for (const groupByDefinition of groupByDefinitions) {
+      subQueryBuilder.addSelect(
+        groupByDefinition.expression,
+        groupByDefinition.alias,
+      );
+    }
+
+    const groupConditions = this.buildGroupConditions({
+      groupsResult,
+      groupByDefinitions,
+      subQueryBuilder,
+    });
+
+    subQueryBuilder.andWhere(groupConditions);
+
+    subQueryBuilder.addSelect(
+      this.buildRowNumberExpression({
+        groupByDefinitions,
+        orderByForRecords,
+        subQueryBuilder,
+        flatObjectMetadata,
+        flatObjectMetadataMaps,
+        flatFieldMetadataMaps,
+      }),
+      'record_row_number',
+    );
+
+    subQueryBuilder.applyRowLevelPermissions();
+
+    const groupByAliases = groupByDefinitions
+      .map((groupByDefinition) => `"${groupByDefinition.alias}"`)
+      .join(', ');
+
+    const pageStart = offsetForRecords;
+    const pageEnd = offsetForRecords + RECORDS_PER_GROUP_LIMIT;
+
+    const jsonObjectEntries = [
+      ...Object.keys(columnsToSelect).map(
+        (columnName) => `'${columnName}', "${SUB_QUERY_PREFIX}${columnName}"`,
+      ),
+      ...groupByDefinitions.map(
+        (groupByDefinition) =>
+          `'${groupByDefinition.alias}', "${groupByDefinition.alias}"`,
+      ),
+    ].join(', ');
+
+    const pageFilter = `record_row_number > ${pageStart} AND record_row_number <= ${pageEnd}`;
+
+    const sql =
+      `SELECT ${groupByAliases}, ` +
+      `JSON_AGG(CASE WHEN ${pageFilter} THEN JSON_BUILD_OBJECT(${jsonObjectEntries}) END) ` +
+      `FILTER (WHERE ${pageFilter}) AS "records" ` +
+      `FROM (${subQueryBuilder.getQuery()}) AS "ranked_records" ` +
+      `GROUP BY ${groupByAliases}`;
+
+    return { sql, parameters: subQueryBuilder.getParameters() };
+  }
+
+  private buildRowNumberExpression({
+    groupByDefinitions,
+    orderByForRecords,
+    subQueryBuilder,
+    flatObjectMetadata,
+    flatObjectMetadataMaps,
+    flatFieldMetadataMaps,
+  }: {
+    groupByDefinitions: GroupByDefinition[];
+    orderByForRecords: ObjectRecordOrderBy;
+    subQueryBuilder: WorkspaceSelectQueryBuilderV2;
+    flatObjectMetadata: FlatObjectMetadata;
+    flatObjectMetadataMaps: FlatEntityMaps<FlatObjectMetadata>;
+    flatFieldMetadataMaps: FlatEntityMaps<FlatFieldMetadata>;
+  }): string {
+    const partitionBy = groupByDefinitions
+      .map((groupByDefinition) => groupByDefinition.expression)
+      .join(', ');
+
+    if (isEmpty(orderByForRecords)) {
+      return `ROW_NUMBER() OVER (PARTITION BY ${partitionBy})`;
+    }
+
+    const graphqlQueryParser = new GraphqlQueryParser(
+      flatObjectMetadata,
+      flatObjectMetadataMaps,
+      flatFieldMetadataMaps,
+    );
+
+    const { orderByRawSQL, relationJoins } =
+      graphqlQueryParser.getOrderByRawSQL(
+        orderByForRecords,
+        flatObjectMetadata.nameSingular,
+      );
+
+    if (!isNonEmptyString(orderByRawSQL)) {
+      return `ROW_NUMBER() OVER (PARTITION BY ${partitionBy})`;
+    }
+
+    for (const joinInfo of relationJoins) {
+      addRelationJoinAliasToQueryBuilder({
+        queryBuilder: subQueryBuilder as unknown as RecordQueryBuilder,
+        parentAlias: flatObjectMetadata.nameSingular,
+        relationName: joinInfo.joinAlias,
+      });
+    }
+
+    return `ROW_NUMBER() OVER (PARTITION BY ${partitionBy} ${orderByRawSQL})`;
+  }
+
+  private buildGroupConditions({
+    groupsResult,
+    groupByDefinitions,
+    subQueryBuilder,
+  }: {
+    groupsResult: Array<Record<string, unknown>>;
+    groupByDefinitions: GroupByDefinition[];
+    subQueryBuilder: WorkspaceSelectQueryBuilderV2;
+  }): string {
+    const groupConditions = groupsResult.map((group, groupIndex) => {
+      const conditions = groupByDefinitions
+        .map((groupByDefinition, definitionIndex) => {
+          const parameterValue = group[groupByDefinition.alias];
+
+          if (!isDefined(parameterValue)) {
+            return `${groupByDefinition.expression} IS NULL`;
+          }
+
+          const parameterName = `groupValue_${groupIndex}_${definitionIndex}`;
+
+          subQueryBuilder.setParameter(parameterName, parameterValue);
+
+          return `${groupByDefinition.expression} = :${parameterName}`;
+        })
+        .join(' AND ');
+
+      return `(${conditions})`;
+    });
+
+    return `(${groupConditions.join(' OR ')})`;
+  }
+}

--- a/packages/twenty-server/src/engine/api/graphql/graphql-query-runner/group-by/services/group-by-with-records-v2.service.ts
+++ b/packages/twenty-server/src/engine/api/graphql/graphql-query-runner/group-by/services/group-by-with-records-v2.service.ts
@@ -19,6 +19,11 @@ import { GraphqlQueryParser } from 'src/engine/api/graphql/graphql-query-runner/
 import { addRelationJoinAliasToQueryBuilder } from 'src/engine/api/graphql/graphql-query-runner/graphql-query-parsers/utils/add-relation-join-alias.util';
 import { type RecordQueryBuilder } from 'src/engine/api/graphql/graphql-query-runner/types/record-query-builder.type';
 import { formatResultWithGroupByDimensionValues } from 'src/engine/api/graphql/graphql-query-runner/group-by/resolvers/utils/format-result-with-group-by-dimension-values.util';
+import {
+  RECORDS_PER_GROUP_LIMIT,
+  RELATIONS_PER_RECORD_LIMIT,
+  SUB_QUERY_PREFIX,
+} from 'src/engine/api/graphql/graphql-query-runner/group-by/services/group-by-with-records.constants';
 import { getGroupLimit } from 'src/engine/api/graphql/graphql-query-runner/group-by/utils/get-group-limit.util';
 import { buildColumnsToSelect } from 'src/engine/api/graphql/graphql-query-runner/utils/build-columns-to-select';
 import { type FlatEntityMaps } from 'src/engine/metadata-modules/flat-entity/types/flat-entity-maps.type';
@@ -26,10 +31,6 @@ import { type FlatFieldMetadata } from 'src/engine/metadata-modules/flat-field-m
 import { type FlatObjectMetadata } from 'src/engine/metadata-modules/flat-object-metadata/types/flat-object-metadata.type';
 import { type WorkspaceSelectQueryBuilderV2 } from 'src/engine/twenty-orm-v2/query-builder/workspace-select-query-builder-v2';
 import { type WorkspaceRepositoryV2 } from 'src/engine/twenty-orm-v2/repository/workspace-repository-v2';
-
-const RECORDS_PER_GROUP_LIMIT = 10;
-const RELATIONS_PER_RECORD_LIMIT = 5;
-const SUB_QUERY_PREFIX = 'sub_query_';
 
 @Injectable()
 export class GroupByWithRecordsV2Service {

--- a/packages/twenty-server/src/engine/api/graphql/graphql-query-runner/group-by/services/group-by-with-records-v2.service.ts
+++ b/packages/twenty-server/src/engine/api/graphql/graphql-query-runner/group-by/services/group-by-with-records-v2.service.ts
@@ -17,13 +17,13 @@ import { type CommonGroupByOutputItem } from 'src/engine/api/common/types/common
 import { CommonSelectedFieldsResult } from 'src/engine/api/common/types/common-selected-fields-result.type';
 import { GraphqlQueryParser } from 'src/engine/api/graphql/graphql-query-runner/graphql-query-parsers/graphql-query.parser';
 import { addRelationJoinAliasToQueryBuilder } from 'src/engine/api/graphql/graphql-query-runner/graphql-query-parsers/utils/add-relation-join-alias.util';
-import { type RecordQueryBuilder } from 'src/engine/api/graphql/graphql-query-runner/types/record-query-builder.type';
 import { formatResultWithGroupByDimensionValues } from 'src/engine/api/graphql/graphql-query-runner/group-by/resolvers/utils/format-result-with-group-by-dimension-values.util';
 import {
   RECORDS_PER_GROUP_LIMIT,
   RELATIONS_PER_RECORD_LIMIT,
   SUB_QUERY_PREFIX,
 } from 'src/engine/api/graphql/graphql-query-runner/group-by/services/group-by-with-records.constants';
+import { buildGroupByRecordConditions } from 'src/engine/api/graphql/graphql-query-runner/group-by/utils/build-group-by-record-conditions.util';
 import { getGroupLimit } from 'src/engine/api/graphql/graphql-query-runner/group-by/utils/get-group-limit.util';
 import { buildColumnsToSelect } from 'src/engine/api/graphql/graphql-query-runner/utils/build-columns-to-select';
 import { type FlatEntityMaps } from 'src/engine/metadata-modules/flat-entity/types/flat-entity-maps.type';
@@ -185,13 +185,11 @@ export class GroupByWithRecordsV2Service {
       );
     }
 
-    const groupConditions = this.buildGroupConditions({
-      groupsResult,
-      groupByDefinitions,
-      subQueryBuilder,
-    });
+    const { sql: groupConditionsSql, parameters: groupConditionParameters } =
+      buildGroupByRecordConditions({ groupsResult, groupByDefinitions });
 
-    subQueryBuilder.andWhere(groupConditions);
+    subQueryBuilder.setParameters(groupConditionParameters);
+    subQueryBuilder.andWhere(groupConditionsSql);
 
     subQueryBuilder.addSelect(
       this.buildRowNumberExpression({
@@ -277,44 +275,12 @@ export class GroupByWithRecordsV2Service {
 
     for (const joinInfo of relationJoins) {
       addRelationJoinAliasToQueryBuilder({
-        queryBuilder: subQueryBuilder as unknown as RecordQueryBuilder,
+        queryBuilder: subQueryBuilder,
         parentAlias: flatObjectMetadata.nameSingular,
         relationName: joinInfo.joinAlias,
       });
     }
 
     return `ROW_NUMBER() OVER (PARTITION BY ${partitionBy} ${orderByRawSQL})`;
-  }
-
-  private buildGroupConditions({
-    groupsResult,
-    groupByDefinitions,
-    subQueryBuilder,
-  }: {
-    groupsResult: Array<Record<string, unknown>>;
-    groupByDefinitions: GroupByDefinition[];
-    subQueryBuilder: WorkspaceSelectQueryBuilderV2;
-  }): string {
-    const groupConditions = groupsResult.map((group, groupIndex) => {
-      const conditions = groupByDefinitions
-        .map((groupByDefinition, definitionIndex) => {
-          const parameterValue = group[groupByDefinition.alias];
-
-          if (!isDefined(parameterValue)) {
-            return `${groupByDefinition.expression} IS NULL`;
-          }
-
-          const parameterName = `groupValue_${groupIndex}_${definitionIndex}`;
-
-          subQueryBuilder.setParameter(parameterName, parameterValue);
-
-          return `${groupByDefinition.expression} = :${parameterName}`;
-        })
-        .join(' AND ');
-
-      return `(${conditions})`;
-    });
-
-    return `(${groupConditions.join(' OR ')})`;
   }
 }

--- a/packages/twenty-server/src/engine/api/graphql/graphql-query-runner/group-by/services/group-by-with-records.constants.ts
+++ b/packages/twenty-server/src/engine/api/graphql/graphql-query-runner/group-by/services/group-by-with-records.constants.ts
@@ -1,0 +1,3 @@
+export const RECORDS_PER_GROUP_LIMIT = 10;
+export const RELATIONS_PER_RECORD_LIMIT = 5;
+export const SUB_QUERY_PREFIX = 'sub_query_';

--- a/packages/twenty-server/src/engine/api/graphql/graphql-query-runner/group-by/services/group-by-with-records.service.ts
+++ b/packages/twenty-server/src/engine/api/graphql/graphql-query-runner/group-by/services/group-by-with-records.service.ts
@@ -23,6 +23,7 @@ import {
   RELATIONS_PER_RECORD_LIMIT,
   SUB_QUERY_PREFIX,
 } from 'src/engine/api/graphql/graphql-query-runner/group-by/services/group-by-with-records.constants';
+import { buildGroupByRecordConditions } from 'src/engine/api/graphql/graphql-query-runner/group-by/utils/build-group-by-record-conditions.util';
 import { getGroupLimit } from 'src/engine/api/graphql/graphql-query-runner/group-by/utils/get-group-limit.util';
 import { buildColumnsToSelect } from 'src/engine/api/graphql/graphql-query-runner/utils/build-columns-to-select';
 import { type FlatEntityMaps } from 'src/engine/metadata-modules/flat-entity/types/flat-entity-maps.type';
@@ -171,11 +172,8 @@ export class GroupByWithRecordsService {
       .map((def) => `"${def.alias}"`)
       .join(', ');
 
-    const groupConditions = this.buildGroupConditions(
-      groupsResult,
-      groupByDefinitions,
-      queryBuilderForSubQuery,
-    );
+    const { sql: groupConditions, parameters: groupConditionParameters } =
+      buildGroupByRecordConditions({ groupsResult, groupByDefinitions });
 
     const objectAlias = getObjectAlias(flatObjectMetadata);
 
@@ -190,6 +188,7 @@ export class GroupByWithRecordsService {
     const subQuery = queryBuilderForSubQuery
       .select(recordSelectWithAlias)
       .addSelect(groupBySelectWithAlias)
+      .setParameters(groupConditionParameters)
       .andWhere(groupConditions);
 
     this.applyPartitionByToBuilder({
@@ -294,31 +293,5 @@ export class GroupByWithRecordsService {
       `ROW_NUMBER() OVER (PARTITION BY ${groupByExpressions})`,
       'record_row_number',
     );
-  }
-
-  private buildGroupConditions(
-    groupsResult: Array<Record<string, unknown>>,
-    groupByDefinitions: GroupByDefinition[],
-    queryBuilder: WorkspaceSelectQueryBuilder<ObjectLiteral>,
-  ): string {
-    const groupConditions = groupsResult.map((group, groupIndex) => {
-      const conditions = groupByDefinitions
-        .map((def, defIndex) => {
-          const paramName = `groupValue_${groupIndex}_${defIndex}`;
-          const paramValue = group[def.alias];
-
-          if (!isDefined(paramValue)) {
-            return `${def.expression} IS NULL`;
-          }
-          queryBuilder.setParameter(paramName, paramValue);
-
-          return `${def.expression} = :${paramName}`;
-        })
-        .join(' AND ');
-
-      return `(${conditions})`;
-    });
-
-    return `(${groupConditions.join(' OR ')})`;
   }
 }

--- a/packages/twenty-server/src/engine/api/graphql/graphql-query-runner/group-by/services/group-by-with-records.service.ts
+++ b/packages/twenty-server/src/engine/api/graphql/graphql-query-runner/group-by/services/group-by-with-records.service.ts
@@ -18,6 +18,11 @@ import { CommonSelectedFieldsResult } from 'src/engine/api/common/types/common-s
 import { GraphqlQueryParser } from 'src/engine/api/graphql/graphql-query-runner/graphql-query-parsers/graphql-query.parser';
 import { addRelationJoinAliasToQueryBuilder } from 'src/engine/api/graphql/graphql-query-runner/graphql-query-parsers/utils/add-relation-join-alias.util';
 import { formatResultWithGroupByDimensionValues } from 'src/engine/api/graphql/graphql-query-runner/group-by/resolvers/utils/format-result-with-group-by-dimension-values.util';
+import {
+  RECORDS_PER_GROUP_LIMIT,
+  RELATIONS_PER_RECORD_LIMIT,
+  SUB_QUERY_PREFIX,
+} from 'src/engine/api/graphql/graphql-query-runner/group-by/services/group-by-with-records.constants';
 import { getGroupLimit } from 'src/engine/api/graphql/graphql-query-runner/group-by/utils/get-group-limit.util';
 import { buildColumnsToSelect } from 'src/engine/api/graphql/graphql-query-runner/utils/build-columns-to-select';
 import { type FlatEntityMaps } from 'src/engine/metadata-modules/flat-entity/types/flat-entity-maps.type';
@@ -25,10 +30,6 @@ import { type FlatFieldMetadata } from 'src/engine/metadata-modules/flat-field-m
 import { type FlatObjectMetadata } from 'src/engine/metadata-modules/flat-object-metadata/types/flat-object-metadata.type';
 import { type WorkspaceSelectQueryBuilder } from 'src/engine/twenty-orm/repository/workspace-select-query-builder';
 import { type WorkspaceRepository } from 'src/engine/twenty-orm/repository/workspace.repository';
-
-const RECORDS_PER_GROUP_LIMIT = 10;
-const RELATIONS_PER_RECORD_LIMIT = 5;
-const SUB_QUERY_PREFIX = 'sub_query_';
 
 @Injectable()
 export class GroupByWithRecordsService {

--- a/packages/twenty-server/src/engine/api/graphql/graphql-query-runner/group-by/utils/build-group-by-record-conditions.util.ts
+++ b/packages/twenty-server/src/engine/api/graphql/graphql-query-runner/group-by/utils/build-group-by-record-conditions.util.ts
@@ -1,0 +1,37 @@
+import { isDefined } from 'twenty-shared/utils';
+
+import { type GroupByDefinition } from 'src/engine/api/common/common-query-runners/types/group-by-definition.type';
+
+// Builds the WHERE that scopes the per-group record subquery to the resolved groups,
+// shared by the v1 and v2 with-records services so the two ORM paths cannot diverge.
+export const buildGroupByRecordConditions = ({
+  groupsResult,
+  groupByDefinitions,
+}: {
+  groupsResult: Array<Record<string, unknown>>;
+  groupByDefinitions: GroupByDefinition[];
+}): { sql: string; parameters: Record<string, unknown> } => {
+  const parameters: Record<string, unknown> = {};
+
+  const groupConditions = groupsResult.map((group, groupIndex) => {
+    const conditions = groupByDefinitions
+      .map((groupByDefinition, definitionIndex) => {
+        const parameterValue = group[groupByDefinition.alias];
+
+        if (!isDefined(parameterValue)) {
+          return `${groupByDefinition.expression} IS NULL`;
+        }
+
+        const parameterName = `groupValue_${groupIndex}_${definitionIndex}`;
+
+        parameters[parameterName] = parameterValue;
+
+        return `${groupByDefinition.expression} = :${parameterName}`;
+      })
+      .join(' AND ');
+
+    return `(${conditions})`;
+  });
+
+  return { sql: `(${groupConditions.join(' OR ')})`, parameters };
+};

--- a/packages/twenty-server/src/engine/twenty-orm-v2/README.md
+++ b/packages/twenty-server/src/engine/twenty-orm-v2/README.md
@@ -123,11 +123,13 @@ subquery with the v2 builder and runs the composed outer query through
   through v1.
 - `find` / `findOne` / `findBy` and the rest of the repository surface used by
   `src/modules`.
-- Transactions, DDL, aggregate group-by.
-- One cast remains where `CommonFindManyQueryRunnerService` hands the v2 builder to the
-  shared parsers, because they are typed against the TypeORM class rather than an
-  interface. Giving the parsers a structural `SelectQueryBuilderLike` type removes it and
-  is the next cleanup.
+- Transactions and DDL.
+- Ordering group-by "with records" by a to-many relation: v2 refuses to-many joins, so
+  it surfaces the standard "unsupported" user error rather than the row-multiplying join
+  v1 would emit.
+- The read runners hand the v2 builder to the shared parsers with a cast, because they
+  are typed against the TypeORM class rather than an interface. Giving the parsers a
+  structural `SelectQueryBuilderLike` type removes it and is the next cleanup.
 
 ## Verifying a change
 

--- a/packages/twenty-server/src/engine/twenty-orm-v2/README.md
+++ b/packages/twenty-server/src/engine/twenty-orm-v2/README.md
@@ -94,17 +94,23 @@ findMany round trip.
 ## Covered so far
 
 `createQueryBuilder`, `clone`, `where` / `andWhere` / `orWhere` (strings, bracket
-factories, and object literals like `{ id: In([...]) }` — `in` and equality only),
-`setParameters`, `setFindOptions({ select })`, `addSelect`, `orderBy` / `addOrderBy`,
-`leftJoin` on to-one relations, `withDeleted`, `limit` / `offset`, `take` / `skip`
-(aliases of `limit` / `offset` — safe because v2 never joins to-many),
-`getMany`, `getOne`, `getRawOne`, `getCount`, `getQuery`, `getQueryAndParameters`.
+factories, and object literals like `{ id: In([...]) }` — `in` only), `setParameters` /
+`setParameter`, `setFindOptions({ select })`, `select` / `addSelect`, `orderBy` /
+`addOrderBy`, `groupBy` / `addGroupBy`, `leftJoin` on to-one relations, `withDeleted`,
+`limit` / `offset`, `take` / `skip` (aliases of `limit` / `offset` — safe because v2
+never joins to-many), `getMany`, `getOne`, `getRawOne`, `getRawMany`, `getCount`,
+`applyRowLevelPermissions`, `getQuery`, `getQueryAndParameters`. The repository also
+exposes `executeRaw` for statements the table-shape builder cannot model (see below).
 
-The surface stops there on purpose: anything the wired runners cannot reach
-(`getRawMany`, `groupBy`) is left to v1 until a runner needs it.
+Wired into `CommonFindManyQueryRunnerService`, `CommonFindOneQueryRunnerService`,
+`CommonFindDuplicatesQueryRunnerService` and `CommonGroupByQueryRunnerService`. Other
+runners keep `repository`.
 
-Wired into `CommonFindManyQueryRunnerService`, `CommonFindOneQueryRunnerService` and
-`CommonFindDuplicatesQueryRunnerService`. Other runners keep `repository`.
+group-by "with records" is the one path that is not a transparent swap: it wraps a
+builder subquery in a table-less `FROM (subquery)` JSON_AGG query, which the
+table-shape builder cannot represent. `GroupByWithRecordsV2Service` builds the inner
+subquery with the v2 builder and runs the composed outer query through
+`repository.executeRaw`; the runner flag-branches between it and the v1 service.
 
 ## Not covered yet
 

--- a/packages/twenty-server/src/engine/twenty-orm-v2/query-builder/__tests__/workspace-select-query-builder-v2.spec.ts
+++ b/packages/twenty-server/src/engine/twenty-orm-v2/query-builder/__tests__/workspace-select-query-builder-v2.spec.ts
@@ -629,4 +629,60 @@ describe('WorkspaceSelectQueryBuilderV2', () => {
       TwentyOrmV2Exception,
     );
   });
+
+  it('should emit a GROUP BY with aggregate and grouped columns', () => {
+    const { queryBuilder } = buildQueryBuilder();
+
+    queryBuilder
+      .select([])
+      .addSelect('COUNT(*)', 'totalCount')
+      .addSelect('"person"."companyId"', 'companyId')
+      .groupBy('"person"."companyId"');
+
+    expect(queryBuilder.getQuery()).toBe(
+      'SELECT COUNT(*) AS "totalCount", "person"."companyId" AS "companyId" ' +
+        `FROM "${SCHEMA_NAME}"."person" AS "person" ` +
+        'WHERE "person"."deletedAt" IS NULL ' +
+        'GROUP BY "person"."companyId"',
+    );
+  });
+
+  it('should append additional GROUP BY expressions with addGroupBy', () => {
+    const { queryBuilder } = buildQueryBuilder();
+
+    queryBuilder
+      .select([])
+      .addSelect('COUNT(*)', 'totalCount')
+      .groupBy('"person"."companyId"')
+      .addGroupBy('"person"."nameFirstName"');
+
+    expect(queryBuilder.getQuery()).toContain(
+      'GROUP BY "person"."companyId", "person"."nameFirstName"',
+    );
+  });
+
+  it('should return every raw row from getRawMany', async () => {
+    const { queryBuilder, executedStatements } = buildQueryBuilder({
+      rows: [
+        { companyId: 'c1', totalCount: '3' },
+        { companyId: 'c2', totalCount: '1' },
+      ],
+    });
+
+    queryBuilder
+      .select([])
+      .addSelect('COUNT(*)', 'totalCount')
+      .addSelect('"person"."companyId"', 'companyId')
+      .groupBy('"person"."companyId"');
+
+    const rows = await queryBuilder.getRawMany();
+
+    expect(rows).toEqual([
+      { companyId: 'c1', totalCount: '3' },
+      { companyId: 'c2', totalCount: '1' },
+    ]);
+    expect(executedStatements[0].text).toContain(
+      'GROUP BY "person"."companyId"',
+    );
+  });
 });

--- a/packages/twenty-server/src/engine/twenty-orm-v2/query-builder/workspace-select-query-builder-v2.ts
+++ b/packages/twenty-server/src/engine/twenty-orm-v2/query-builder/workspace-select-query-builder-v2.ts
@@ -65,6 +65,7 @@ export class WorkspaceSelectQueryBuilderV2 implements WhereExpressionLike {
   private readonly joinClauses: JoinClause[] = [];
   private readonly extraSelectClauses: SelectClause[] = [];
   private orderByClauses: OrderByClause[] = [];
+  private groupByExpressions: string[] = [];
   private parameters: Record<string, unknown> = {};
   private findOptions: FindOptionsLike = {};
   private limitValue?: number;
@@ -105,6 +106,7 @@ export class WorkspaceSelectQueryBuilderV2 implements WhereExpressionLike {
     );
     cloned.extraSelectClauses.push(...this.extraSelectClauses);
     cloned.orderByClauses = [...this.orderByClauses];
+    cloned.groupByExpressions = [...this.groupByExpressions];
     cloned.parameters = { ...this.parameters };
     cloned.findOptions = { ...this.findOptions };
     cloned.limitValue = this.limitValue;
@@ -159,6 +161,10 @@ export class WorkspaceSelectQueryBuilderV2 implements WhereExpressionLike {
     this.parameters = { ...this.parameters, ...parameters };
 
     return this;
+  }
+
+  setParameter(key: string, value: unknown): this {
+    return this.setParameters({ [key]: value });
   }
 
   getParameters(): Record<string, unknown> {
@@ -221,6 +227,18 @@ export class WorkspaceSelectQueryBuilderV2 implements WhereExpressionLike {
     nulls?: 'NULLS FIRST' | 'NULLS LAST',
   ): this {
     return this.appendOrderBy(orderByOrExpression, direction, nulls);
+  }
+
+  groupBy(expression: string): this {
+    this.groupByExpressions = [this.normaliseColumnExpression(expression)];
+
+    return this;
+  }
+
+  addGroupBy(expression: string): this {
+    this.groupByExpressions.push(this.normaliseColumnExpression(expression));
+
+    return this;
   }
 
   leftJoin(relationPath: string, alias: string, condition?: string): this {
@@ -366,6 +384,18 @@ export class WorkspaceSelectQueryBuilderV2 implements WhereExpressionLike {
     } finally {
       this.limitValue = previousLimit;
     }
+  }
+
+  async getRawMany<T extends Record<string, unknown>>(): Promise<T[]> {
+    const rows = await this.executeSelect();
+
+    return rows as T[];
+  }
+
+  applyRowLevelPermissions(): this {
+    this.context.onBeforeExecute(this);
+
+    return this;
   }
 
   async getCount(): Promise<number> {
@@ -582,6 +612,7 @@ export class WorkspaceSelectQueryBuilderV2 implements WhereExpressionLike {
       extraSelectClauses: this.extraSelectClauses,
       joinClauses: this.joinClauses,
       whereClauses: this.whereClauses,
+      groupByExpressions: this.groupByExpressions,
       orderByClauses: this.orderByClauses,
       includeDeleted: this.includeDeleted,
       limitValue: this.limitValue,

--- a/packages/twenty-server/src/engine/twenty-orm-v2/repository/workspace-repository-v2.ts
+++ b/packages/twenty-server/src/engine/twenty-orm-v2/repository/workspace-repository-v2.ts
@@ -10,6 +10,7 @@ import { resolveRowLevelPermissionRecordFilter } from 'src/engine/twenty-orm/uti
 import { formatResult } from 'src/engine/twenty-orm/utils/format-result.util';
 import { type QueryExecutorV2 } from 'src/engine/twenty-orm-v2/executor/types/query-executor-v2.type';
 import { WorkspaceSelectQueryBuilderV2 } from 'src/engine/twenty-orm-v2/query-builder/workspace-select-query-builder-v2';
+import { compileNamedParameters } from 'src/engine/twenty-orm-v2/sql/utils/compile-named-parameters.util';
 import { type WorkspaceTableShape } from 'src/engine/twenty-orm-v2/table-shape/types/workspace-table-shape.type';
 
 type WorkspaceRepositoryV2Options = {
@@ -36,6 +37,15 @@ export class WorkspaceRepositoryV2 {
   constructor(options: WorkspaceRepositoryV2Options) {
     this.options = options;
     this.objectRecordsPermissions = options.objectRecordsPermissions;
+  }
+
+  async executeRaw<T extends Record<string, unknown>>(
+    sql: string,
+    parameters: Record<string, unknown>,
+  ): Promise<T[]> {
+    const compiled = compileNamedParameters(sql, parameters);
+
+    return this.options.executor.execute(compiled) as Promise<T[]>;
   }
 
   createQueryBuilder(alias?: string): WorkspaceSelectQueryBuilderV2 {

--- a/packages/twenty-server/src/engine/twenty-orm-v2/sql/utils/build-select-statement.util.ts
+++ b/packages/twenty-server/src/engine/twenty-orm-v2/sql/utils/build-select-statement.util.ts
@@ -43,6 +43,7 @@ export type SelectStatementState = {
   extraSelectClauses: SelectClause[];
   joinClauses: JoinClause[];
   whereClauses: WhereClause[];
+  groupByExpressions: string[];
   orderByClauses: OrderByClause[];
   includeDeleted: boolean;
   limitValue?: number;
@@ -178,6 +179,14 @@ export const buildJoinClause = (state: SelectStatementState): string =>
     })
     .join(' ');
 
+export const buildGroupByClause = (state: SelectStatementState): string => {
+  if (state.groupByExpressions.length === 0) {
+    return '';
+  }
+
+  return `GROUP BY ${state.groupByExpressions.join(', ')}`;
+};
+
 export const buildOrderByClause = (state: SelectStatementState): string => {
   if (state.orderByClauses.length === 0) {
     return '';
@@ -222,6 +231,7 @@ export const buildSelectStatement = (state: SelectStatementState): string => {
     buildFromClause(state),
     buildJoinClause(state),
     whereExpression.length > 0 ? `WHERE ${whereExpression}` : '',
+    buildGroupByClause(state),
     buildOrderByClause(state),
     isDefined(state.limitValue) ? `LIMIT :${LIMIT_PARAMETER_NAME}` : '',
     isDefined(state.offsetValue) ? `OFFSET :${OFFSET_PARAMETER_NAME}` : '',


### PR DESCRIPTION
Follow-up to the findMany / findOne / findDuplicates migrations. Routes
`CommonGroupByQueryRunnerService` through the ORM v2 read path, behind
`IS_ORM_V2_READ_PATH_ENABLED`. Flag off, nothing changes.

groupBy has two paths, handled differently:

**Aggregate group-by** — a transparent `getReadRepository` swap. Adds to the v2
builder: `groupBy` / `addGroupBy`, `getRawMany`, and `GROUP BY` emission.

**group-by "with records"** — not a transparent swap. It wraps a builder subquery
in a table-less `FROM (subquery)` `JSON_AGG` + `ROW_NUMBER() OVER (PARTITION BY …)`
query, which v2's table-shape-based builder cannot represent. So:
- `GroupByWithRecordsV2Service` builds the inner subquery with the v2 builder
  (`select([])` + `addSelect` for record columns / group dimensions / window rank,
  `andWhere` for the group predicates, `applyRowLevelPermissions`) and composes the
  outer `JSON_AGG` query as raw SQL, run through a new `repository.executeRaw`
  (compiles the builder's named params once and executes on the v2 pool).
- The runner flag-branches: v2 service when the flag is on, the existing v1 service
  otherwise. Supporting v2 additions: `setParameter`, `applyRowLevelPermissions`.

## Verification

- 72 v2 builder unit tests (new: GROUP BY / addGroupBy, getRawMany).
- `group-by` added to `ORM_V2_TEST_PATH_PATTERN`, so the flagged shard runs all
  group-by suites (aggregate, with-records, both RLS variants, order-by-with-group-by,
  REST) against v2.
- Ran locally both ways: all 7 group-by integration suites green with the flag on
  (52/52) and off (52/52). oxlint / oxfmt / typecheck clean.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/24092?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

