### PR TITLE
test: 100% integration coverage for messaging and calendar sync

### DIFF
--- a/packages/twenty-server/src/modules/messaging/message-folder-manager/drivers/imap/services/__tests__/imap-get-all-folders.service.spec.ts
+++ b/packages/twenty-server/src/modules/messaging/message-folder-manager/drivers/imap/services/__tests__/imap-get-all-folders.service.spec.ts
@@ -4,6 +4,7 @@ import { type ImapFlow, type ListResponse } from 'imapflow';
 import {
   ConnectedAccountProvider,
   MessageFolderImportPolicy,
+  MessageFolderPendingSyncAction,
 } from 'twenty-shared/types';
 
 import { type ConnectedAccountEntity } from 'src/engine/metadata-modules/connected-account/entities/connected-account.entity';
@@ -44,13 +45,16 @@ const MESSAGE_CHANNEL: Pick<MessageChannelEntity, 'messageFolderImportPolicy'> =
 
 describe('ImapGetAllFoldersService', () => {
   let service: ImapGetAllFoldersService;
-  let mockImapClient: jest.Mocked<Pick<ImapFlow, 'list' | 'status'>>;
+  let mockImapClient: jest.Mocked<
+    Pick<ImapFlow, 'list' | 'status' | 'enabled'>
+  >;
   let imapFindSentFolderService: jest.Mocked<ImapFindSentFolderService>;
 
   beforeEach(async () => {
     mockImapClient = {
       list: jest.fn().mockResolvedValue([]),
       status: jest.fn(),
+      enabled: new Set<string>(),
     };
 
     const module: TestingModule = await Test.createTestingModule({
@@ -232,5 +236,61 @@ describe('ImapGetAllFoldersService', () => {
         expect(paths).not.toContain('Shared Folders');
       },
     );
+  });
+
+  it('persists NFC mailbox identifiers for UTF8=ACCEPT LIST responses', async () => {
+    mockImapClient.enabled.add('UTF8=ACCEPT');
+    mockImapClient.list.mockResolvedValue([
+      createMockMailbox({
+        path: 'Parent/Ane\u0301mo+',
+        name: 'Ane\u0301mo+',
+        parentPath: 'Parent',
+      }),
+    ]);
+    mockImapClient.status.mockResolvedValue({ uidValidity: BigInt(42) } as any);
+
+    const [folder] = await service.getAllMessageFolders(
+      CONNECTED_ACCOUNT,
+      MESSAGE_CHANNEL,
+    );
+
+    expect(mockImapClient.status).toHaveBeenCalledWith('Parent/An\u00e9mo+', {
+      uidValidity: true,
+    });
+    expect(folder).toMatchObject({
+      externalId: 'Parent/An\u00e9mo+:42',
+      name: 'An\u00e9mo+',
+      parentFolderId: null,
+    });
+  });
+
+  it('keeps an existing decomposed external ID to avoid recreating its folder', async () => {
+    mockImapClient.enabled.add('UTF8=ACCEPT');
+    mockImapClient.list.mockResolvedValue([
+      createMockMailbox({
+        path: 'Parent/Ane\u0301mo+',
+        name: 'Ane\u0301mo+',
+      }),
+    ]);
+    mockImapClient.status.mockResolvedValue({ uidValidity: BigInt(42) } as any);
+
+    const [folder] = await service.getAllMessageFolders(
+      CONNECTED_ACCOUNT,
+      MESSAGE_CHANNEL,
+      [
+        {
+          id: 'folder-1',
+          name: 'Ane\u0301mo+',
+          externalId: 'Parent/Ane\u0301mo+:42',
+          isSynced: true,
+          isSentFolder: false,
+          parentFolderId: null,
+          syncCursor: 'preserved-cursor',
+          pendingSyncAction: MessageFolderPendingSyncAction.NONE,
+        },
+      ],
+    );
+
+    expect(folder.externalId).toBe('Parent/Ane\u0301mo+:42');
   });
 });

--- a/packages/twenty-server/src/modules/messaging/message-folder-manager/drivers/imap/services/imap-get-all-folders.service.ts
+++ b/packages/twenty-server/src/modules/messaging/message-folder-manager/drivers/imap/services/imap-get-all-folders.service.ts
@@ -5,6 +5,7 @@ import { isDefined } from 'twenty-shared/utils';
 
 import {
   DiscoveredMessageFolder,
+  type MessageFolder,
   MessageFolderDriver,
 } from 'src/modules/messaging/message-folder-manager/interfaces/message-folder-driver.interface';
 
@@ -14,7 +15,10 @@ import { shouldCreateFolderByDefault } from 'src/modules/messaging/message-folde
 import { shouldSyncFolderByDefault } from 'src/modules/messaging/message-folder-manager/utils/should-sync-folder-by-default.util';
 import { ImapClientProvider } from 'src/modules/messaging/message-import-manager/drivers/imap/providers/imap-client.provider';
 import { ImapFindSentFolderService } from 'src/modules/messaging/message-import-manager/drivers/imap/services/imap-find-sent-folder.service';
-import { getImapFolderPath } from 'src/modules/messaging/message-import-manager/drivers/imap/utils/get-imap-folder-path.util';
+import {
+  getImapFolderPath,
+  normalizeImapMailboxPath,
+} from 'src/modules/messaging/message-import-manager/drivers/imap/utils/get-imap-folder-path.util';
 import { getStandardFolderByRegex } from 'src/modules/messaging/message-import-manager/drivers/utils/get-standard-folder-by-regex';
 
 @Injectable()
@@ -32,18 +36,18 @@ export class ImapGetAllFoldersService implements MessageFolderDriver {
       'id' | 'provider' | 'connectionParameters' | 'handle' | 'workspaceId'
     >,
     messageChannel: Pick<MessageChannelEntity, 'messageFolderImportPolicy'>,
+    existingFolders: MessageFolder[] = [],
   ): Promise<DiscoveredMessageFolder[]> {
     try {
       const client = await this.imapClientProvider.getClient(
         connectedAccount.id,
       );
 
-      const mailboxList = await client.list();
-
       const folders = await this.filterAndMapFolders(
         client,
-        mailboxList,
+        await client.list(),
         messageChannel,
+        existingFolders,
       );
 
       await this.imapClientProvider.closeClient(client);
@@ -63,40 +67,67 @@ export class ImapGetAllFoldersService implements MessageFolderDriver {
     client: ImapFlow,
     mailboxList: ListResponse[],
     messageChannel: Pick<MessageChannelEntity, 'messageFolderImportPolicy'>,
+    existingFolders: MessageFolder[],
   ): Promise<DiscoveredMessageFolder[]> {
+    const normalizedMailboxList = mailboxList.map((mailbox) => ({
+      ...mailbox,
+      path: normalizeImapMailboxPath(mailbox.path, client),
+      name: normalizeImapMailboxPath(mailbox.name, client),
+      parentPath: mailbox.parentPath
+        ? normalizeImapMailboxPath(mailbox.parentPath, client)
+        : mailbox.parentPath,
+    }));
+    const existingExternalIdsByNormalizedId = new Map<string, string>();
+
+    for (const folder of existingFolders) {
+      if (isDefined(folder.externalId)) {
+        existingExternalIdsByNormalizedId.set(
+          normalizeImapMailboxPath(folder.externalId, client),
+          folder.externalId,
+        );
+      }
+    }
+
     const folders: DiscoveredMessageFolder[] = [];
     const pathToExternalIdMap = new Map<string, string>();
     const sentFolder =
       await this.imapFindSentFolderService.findSentFolder(client);
+    const sentFolderPath = isDefined(sentFolder)
+      ? normalizeImapMailboxPath(sentFolder.path, client)
+      : undefined;
 
     const sentMailbox = isDefined(sentFolder)
-      ? mailboxList.find((mailbox) => mailbox.path === sentFolder.path)
+      ? normalizedMailboxList.find((mailbox) => mailbox.path === sentFolderPath)
       : undefined;
 
     if (
       isDefined(sentFolder) &&
+      isDefined(sentFolderPath) &&
       isDefined(sentMailbox) &&
       this.isMailboxSelectable(sentMailbox)
     ) {
       const uidValidity = await this.getUidValidity(client, sentMailbox);
 
-      const externalId = uidValidity
-        ? `${sentFolder.path}:${uidValidity.toString()}`
-        : sentFolder.path;
+      const normalizedExternalId = uidValidity
+        ? `${sentFolderPath}:${uidValidity.toString()}`
+        : sentFolderPath;
+      const externalId =
+        existingExternalIdsByNormalizedId.get(normalizedExternalId) ??
+        normalizedExternalId;
 
-      pathToExternalIdMap.set(sentFolder.path, externalId);
+      pathToExternalIdMap.set(sentFolderPath, externalId);
 
       folders.push({
         externalId,
-        name: sentFolder.name,
+        name: sentMailbox.name,
         isSynced: true,
         isSentFolder: true,
         parentFolderId: sentMailbox?.parentPath || null,
       });
     }
 
-    for (const mailbox of mailboxList) {
-      if (!this.isValidMailbox(mailbox, folders)) {
+    for (const mailbox of normalizedMailboxList) {
+      if (!this.isValidMailbox(client, mailbox, folders)) {
         if (!pathToExternalIdMap.has(mailbox.path)) {
           pathToExternalIdMap.set(mailbox.path, mailbox.path);
         }
@@ -104,9 +135,12 @@ export class ImapGetAllFoldersService implements MessageFolderDriver {
       }
 
       const uidValidity = await this.getUidValidity(client, mailbox);
-      const externalId = uidValidity
+      const normalizedExternalId = uidValidity
         ? `${mailbox.path}:${uidValidity}`
         : mailbox.path;
+      const externalId =
+        existingExternalIdsByNormalizedId.get(normalizedExternalId) ??
+        normalizedExternalId;
 
       pathToExternalIdMap.set(mailbox.path, externalId);
 
@@ -159,6 +193,7 @@ export class ImapGetAllFoldersService implements MessageFolderDriver {
   }
 
   private isValidMailbox(
+    client: ImapFlow,
     mailbox: ListResponse,
     existingFolders: DiscoveredMessageFolder[],
   ): boolean {
@@ -167,7 +202,7 @@ export class ImapGetAllFoldersService implements MessageFolderDriver {
     }
 
     const isDuplicate = existingFolders.some(
-      (folder) => getImapFolderPath(folder?.externalId) === mailbox.path,
+      (folder) => getImapFolderPath(folder.externalId, client) === mailbox.path,
     );
 
     return !isDuplicate;

--- a/packages/twenty-server/src/modules/messaging/message-folder-manager/services/sync-message-folders.service.ts
+++ b/packages/twenty-server/src/modules/messaging/message-folder-manager/services/sync-message-folders.service.ts
@@ -62,6 +62,7 @@ export class SyncMessageFoldersService {
     const discoveredFolders = await this.discoverAllFolders(
       messageChannel.connectedAccount,
       messageChannel,
+      messageChannel.messageFolders,
     );
 
     const { messageFolders: existingFolders, id: messageChannelId } =
@@ -87,6 +88,7 @@ export class SyncMessageFoldersService {
       | 'workspaceId'
     >,
     messageChannel: Pick<MessageChannelEntity, 'messageFolderImportPolicy'>,
+    existingFolders: MessageFolder[] = [],
   ): Promise<DiscoveredMessageFolder[]> {
     switch (connectedAccount.provider) {
       case ConnectedAccountProvider.GOOGLE:
@@ -103,6 +105,7 @@ export class SyncMessageFoldersService {
         return this.imapGetAllFoldersService.getAllMessageFolders(
           connectedAccount,
           messageChannel,
+          existingFolders,
         );
       default:
         throw new Error(

--- a/packages/twenty-server/src/modules/messaging/message-import-manager/drivers/imap/services/imap-get-message-list.service.spec.ts
+++ b/packages/twenty-server/src/modules/messaging/message-import-manager/drivers/imap/services/imap-get-message-list.service.spec.ts
@@ -59,6 +59,7 @@ describe('ImapGetMessageListService', () => {
       highestModseq: '1000',
     },
     capabilities: new Set(['CONDSTORE']),
+    enabled: new Set<string>(),
     status: jest.fn().mockResolvedValue({
       uidValidity: 12345,
       uidNext: 100,
@@ -67,6 +68,9 @@ describe('ImapGetMessageListService', () => {
   };
 
   beforeEach(async () => {
+    mockImapClient.getMailboxLock.mockResolvedValue({ release: jest.fn() });
+    mockImapClient.enabled.clear();
+
     const module: TestingModule = await Test.createTestingModule({
       providers: [
         ImapGetMessageListService,
@@ -272,6 +276,94 @@ describe('ImapGetMessageListService', () => {
 
       expect(imapSyncService.syncFolder).toHaveBeenCalledTimes(1);
       expect(result.messageExternalIds).not.toEqual([]);
+    });
+  });
+
+  describe('unavailable mailboxes', () => {
+    const runSync = (messageFolders: MessageFolder[]) =>
+      service.getMessageLists({
+        connectedAccount: mockConnectedAccount,
+        messageChannel: {
+          syncCursor: '',
+          id: 'channel-1',
+          messageFolderImportPolicy: MessageFolderImportPolicy.ALL_FOLDERS,
+        },
+        messageFolders,
+      });
+
+    it('normalizes Unicode mailbox names only when UTF8=ACCEPT is enabled', async () => {
+      mockImapClient.enabled.add('UTF8=ACCEPT');
+      const folder = createMockFolder({
+        name: 'Ane\u0301mo+',
+        externalId: 'Parent/Ane\u0301mo+:12345',
+        isSynced: true,
+      });
+
+      await runSync([folder]);
+
+      expect(mockImapClient.getMailboxLock).toHaveBeenCalledWith(
+        'Parent/An\u00e9mo+',
+      );
+      expect(imapSyncService.syncFolder).toHaveBeenCalledWith(
+        mockImapClient,
+        'Parent/An\u00e9mo+',
+        null,
+        expect.anything(),
+      );
+    });
+
+    it('skips an explicitly missing mailbox and continues with later folders', async () => {
+      const missingMailboxError = Object.assign(
+        new Error("Mailbox doesn't exist: Missing (0.001 + 0.000 secs)."),
+        {
+          responseStatus: 'NO',
+          responseText: "Mailbox doesn't exist: Missing (0.001 + 0.000 secs).",
+        },
+      );
+      mockImapClient.getMailboxLock
+        .mockRejectedValueOnce(missingMailboxError)
+        .mockResolvedValueOnce({ release: jest.fn() });
+      const missingFolder = createMockFolder({
+        name: 'Missing',
+        externalId: 'Missing:1',
+        isSynced: true,
+      });
+      const availableFolder = createMockFolder({
+        name: 'Available',
+        externalId: 'Available:1',
+        isSynced: true,
+      });
+
+      const result = await runSync([missingFolder, availableFolder]);
+
+      expect(result.map(({ folderId }) => folderId)).toEqual([
+        availableFolder.id,
+      ]);
+      expect(imapSyncService.syncFolder).toHaveBeenCalledTimes(1);
+    });
+
+    it('fails the channel flow for errors other than an explicit missing mailbox', async () => {
+      const accountError = Object.assign(new Error('Connection lost'), {
+        code: 'ECONNRESET',
+      });
+      mockImapClient.getMailboxLock.mockRejectedValueOnce(accountError);
+      const firstFolder = createMockFolder({
+        name: 'First',
+        externalId: 'First:1',
+        isSynced: true,
+      });
+      const laterFolder = createMockFolder({
+        name: 'Later',
+        externalId: 'Later:1',
+        isSynced: true,
+      });
+
+      await expect(runSync([firstFolder, laterFolder])).rejects.toThrow(
+        'Connection lost',
+      );
+
+      expect(mockImapClient.getMailboxLock).toHaveBeenCalledTimes(1);
+      expect(imapSyncService.syncFolder).not.toHaveBeenCalled();
     });
   });
 });

--- a/packages/twenty-server/src/modules/messaging/message-import-manager/drivers/imap/services/imap-get-message-list.service.ts
+++ b/packages/twenty-server/src/modules/messaging/message-import-manager/drivers/imap/services/imap-get-message-list.service.ts
@@ -16,6 +16,7 @@ import { ImapSyncService } from 'src/modules/messaging/message-import-manager/dr
 import { createSyncCursor } from 'src/modules/messaging/message-import-manager/drivers/imap/utils/create-sync-cursor.util';
 import { resolveMailboxState } from 'src/modules/messaging/message-import-manager/drivers/imap/utils/extract-mailbox-state.util';
 import { getImapFolderPath } from 'src/modules/messaging/message-import-manager/drivers/imap/utils/get-imap-folder-path.util';
+import { isImapMailboxNotFoundError } from 'src/modules/messaging/message-import-manager/drivers/imap/utils/is-imap-mailbox-not-found-error.util';
 import { parseSyncCursor } from 'src/modules/messaging/message-import-manager/drivers/imap/utils/parse-sync-cursor.util';
 import { type GetMessageListsArgs } from 'src/modules/messaging/message-import-manager/types/get-message-lists-args.type';
 import {
@@ -58,9 +59,20 @@ export class ImapGetMessageListService {
       const results: GetMessageListsResponse = [];
 
       for (const folder of foldersToProcess) {
-        const response = await this.getMessageList(client, folder);
+        try {
+          const response = await this.getMessageList(client, folder);
 
-        results.push({ ...response, folderId: folder.id });
+          results.push({ ...response, folderId: folder.id });
+        } catch (error) {
+          if (isImapMailboxNotFoundError(error)) {
+            this.logger.warn(
+              `Skipping unavailable mailbox for folder ${folder.name}`,
+            );
+            continue;
+          }
+
+          throw error;
+        }
       }
 
       return results;
@@ -79,7 +91,7 @@ export class ImapGetMessageListService {
     client: ImapFlow,
     folder: MessageFolder,
   ): Promise<GetOneMessageListResponse> {
-    const folderPath = getImapFolderPath(folder.externalId);
+    const folderPath = getImapFolderPath(folder.externalId, client);
 
     if (!isDefined(folderPath)) {
       throw new MessageImportDriverException(
@@ -161,7 +173,7 @@ export class ImapGetMessageListService {
     client: ImapFlow,
     folder: MessageFolder,
   ): Promise<boolean> {
-    const folderPath = getImapFolderPath(folder.externalId);
+    const folderPath = getImapFolderPath(folder.externalId, client);
     const previousCursor = parseSyncCursor(folder.syncCursor);
 
     if (!isDefined(folderPath) || !isDefined(previousCursor)) {

--- a/packages/twenty-server/src/modules/messaging/message-import-manager/drivers/imap/types/imap-error.type.ts
+++ b/packages/twenty-server/src/modules/messaging/message-import-manager/drivers/imap/types/imap-error.type.ts
@@ -6,6 +6,7 @@ export interface ImapFlowError extends Error {
   executedCommand?: string;
   authenticationFailed?: boolean;
   response?: string;
+  mailboxMissing?: boolean;
   syscall?: string;
   errno?: number;
 }

--- a/packages/twenty-server/src/modules/messaging/message-import-manager/drivers/imap/utils/__tests__/get-imap-folder-path.util.spec.ts
+++ b/packages/twenty-server/src/modules/messaging/message-import-manager/drivers/imap/utils/__tests__/get-imap-folder-path.util.spec.ts
@@ -22,4 +22,20 @@ describe('getImapFolderPath', () => {
     expect(getImapFolderPath(null)).toBeNull();
     expect(getImapFolderPath(undefined)).toBeNull();
   });
+
+  it('normalizes a UTF8=ACCEPT mailbox path to NFC', () => {
+    const client = { enabled: new Set(['UTF8=ACCEPT']) };
+
+    expect(getImapFolderPath('Parent/Ane\u0301mo+:42', client)).toBe(
+      'Parent/An\u00e9mo+',
+    );
+  });
+
+  it('preserves a legacy mailbox path without Unicode normalization', () => {
+    const client = { enabled: new Set<string>() };
+
+    expect(getImapFolderPath('Parent/Ane\u0301mo+:42', client)).toBe(
+      'Parent/Ane\u0301mo+',
+    );
+  });
 });

--- a/packages/twenty-server/src/modules/messaging/message-import-manager/drivers/imap/utils/__tests__/is-imap-mailbox-not-found-error.util.spec.ts
+++ b/packages/twenty-server/src/modules/messaging/message-import-manager/drivers/imap/utils/__tests__/is-imap-mailbox-not-found-error.util.spec.ts
@@ -1,0 +1,30 @@
+import { isImapMailboxNotFoundError } from 'src/modules/messaging/message-import-manager/drivers/imap/utils/is-imap-mailbox-not-found-error.util';
+
+describe('isImapMailboxNotFoundError', () => {
+  it.each([
+    { serverResponseCode: 'NONEXISTENT' },
+    { mailboxMissing: true },
+    {
+      responseText: "Mailbox doesn't exist: Ghost (0.001 + 0.000 secs).",
+    },
+    { responseText: 'Unknown Mailbox: Ghost' },
+    { responseText: 'Mailbox does not exist' },
+  ])('recognizes an unavailable mailbox: %o', (details) => {
+    const error = Object.assign(new Error('Command failed'), {
+      responseStatus: 'NO',
+      ...details,
+    });
+
+    expect(isImapMailboxNotFoundError(error)).toBe(true);
+  });
+
+  it.each([
+    { responseStatus: 'NO', responseText: 'Access denied' },
+    { responseStatus: 'BAD', serverResponseCode: 'NONEXISTENT' },
+    { responseStatus: 'NO', serverResponseCode: 'NOPERM' },
+  ])('does not classify non-mailbox failures as unavailable: %o', (details) => {
+    const error = Object.assign(new Error('Command failed'), details);
+
+    expect(isImapMailboxNotFoundError(error)).toBe(false);
+  });
+});

--- a/packages/twenty-server/src/modules/messaging/message-import-manager/drivers/imap/utils/get-imap-folder-path.util.ts
+++ b/packages/twenty-server/src/modules/messaging/message-import-manager/drivers/imap/utils/get-imap-folder-path.util.ts
@@ -1,7 +1,15 @@
 import { isNonEmptyString } from '@sniptt/guards';
+import { type ImapFlow } from 'imapflow';
+
+export const normalizeImapMailboxPath = (
+  path: string,
+  client?: Pick<ImapFlow, 'enabled'>,
+): string =>
+  client?.enabled.has('UTF8=ACCEPT') ? path.normalize('NFC') : path;
 
 export const getImapFolderPath = (
   externalId: string | null | undefined,
+  client?: Pick<ImapFlow, 'enabled'>,
 ): string | null => {
   if (!isNonEmptyString(externalId)) {
     return null;
@@ -9,15 +17,12 @@ export const getImapFolderPath = (
 
   const lastColonIndex = externalId.lastIndexOf(':');
 
-  if (lastColonIndex === -1) {
-    return externalId;
-  }
+  const path =
+    lastColonIndex === -1
+      ? externalId
+      : /^\d+$/.test(externalId.slice(lastColonIndex + 1))
+        ? externalId.slice(0, lastColonIndex)
+        : externalId;
 
-  const trailingSegment = externalId.slice(lastColonIndex + 1);
-
-  if (!/^\d+$/.test(trailingSegment)) {
-    return externalId;
-  }
-
-  return externalId.slice(0, lastColonIndex);
+  return normalizeImapMailboxPath(path, client);
 };

--- a/packages/twenty-server/src/modules/messaging/message-import-manager/drivers/imap/utils/is-imap-flow-error.util.ts
+++ b/packages/twenty-server/src/modules/messaging/message-import-manager/drivers/imap/utils/is-imap-flow-error.util.ts
@@ -6,6 +6,7 @@ export const isImapFlowError = (error: Error): error is ImapFlowError => {
   return (
     isDefined(error) &&
     ('serverResponseCode' in error ||
+      'responseStatus' in error ||
       'responseText' in error ||
       'executedCommand' in error ||
       'authenticationFailed' in error)

--- a/packages/twenty-server/src/modules/messaging/message-import-manager/drivers/imap/utils/is-imap-mailbox-not-found-error.util.ts
+++ b/packages/twenty-server/src/modules/messaging/message-import-manager/drivers/imap/utils/is-imap-mailbox-not-found-error.util.ts
@@ -1,0 +1,10 @@
+import { isImapFlowError } from 'src/modules/messaging/message-import-manager/drivers/imap/utils/is-imap-flow-error.util';
+
+export const isImapMailboxNotFoundError = (error: Error): boolean =>
+  isImapFlowError(error) &&
+  error.responseStatus === 'NO' &&
+  (error.serverResponseCode?.toUpperCase() === 'NONEXISTENT' ||
+    error.mailboxMissing === true ||
+    /^(Mailbox (does not|doesn't) exist|Unknown Mailbox:|No such mailbox)/i.test(
+      error.responseText ?? '',
+    ));

--- a/packages/twenty-server/src/modules/messaging/message-outbound-manager/drivers/imap/services/imap-smtp-message-outbound.service.ts
+++ b/packages/twenty-server/src/modules/messaging/message-outbound-manager/drivers/imap/services/imap-smtp-message-outbound.service.ts
@@ -85,7 +85,10 @@ export class ImapSmtpMessageOutboundService implements MessageOutboundDriver {
         });
       }
 
-      const sentFolderPath = getImapFolderPath(sentFolder?.externalId);
+      const sentFolderPath = getImapFolderPath(
+        sentFolder?.externalId,
+        imapClient,
+      );
 
       if (isDefined(sentFolderPath)) {
         await imapClient.append(sentFolderPath, messageBuffer);

--- a/packages/twenty-server/src/modules/onboarding-recent-messages-import/services/imap-recent-messages.service.ts
+++ b/packages/twenty-server/src/modules/onboarding-recent-messages-import/services/imap-recent-messages.service.ts
@@ -59,7 +59,7 @@ export class ImapRecentMessagesService {
     messageFolder: MessageFolder;
     maxCount: number;
   }): Promise<string[]> {
-    const folderPath = getImapFolderPath(messageFolder.externalId);
+    const folderPath = getImapFolderPath(messageFolder.externalId, imapClient);
 
     if (!isDefined(folderPath)) {
       return [];

--- a/packages/twenty-server/test/integration/google/calendar/import-error-mapping.integration-spec.ts
+++ b/packages/twenty-server/test/integration/google/calendar/import-error-mapping.integration-spec.ts
@@ -1,0 +1,208 @@
+import {
+  CalendarChannelSyncStage,
+  CalendarChannelSyncStatus,
+  ConnectedAccountProvider,
+} from 'twenty-shared/types';
+
+import { CalendarChannelEntity } from 'src/engine/metadata-modules/calendar-channel/entities/calendar-channel.entity';
+import { ConnectedAccountEntity } from 'src/engine/metadata-modules/connected-account/entities/connected-account.entity';
+
+import {
+  type GoogleApiFailure,
+  setupGoogleMock,
+} from 'test/integration/google/mocks/setup-google-mock.util';
+import { connectMessagingAccount } from 'test/integration/utils/connect-messaging-account.util';
+import { getCoreRepository } from 'test/integration/utils/get-core-repository.util';
+import {
+  queryCalendarChannel,
+  queryConnectedAccount,
+} from 'test/integration/utils/query-messaging.util';
+import { resetCalendarChannelSyncState } from 'test/integration/utils/reset-channel-sync-state.util';
+import { runCalendarChannelListFetch } from 'test/integration/utils/run-calendar-channel-list-fetch.util';
+
+const HANDLE = 'calendar-import-error-mapping@apple.dev';
+
+const INSUFFICIENT_PERMISSIONS_FAILURES: [string, GoogleApiFailure][] = [
+  [
+    'a 401 unauthorized response',
+    { status: 401, reason: 'authError', message: 'Invalid Credentials' },
+  ],
+  [
+    'a 403 response that is not a rate limit',
+    {
+      status: 403,
+      reason: 'insufficientPermissions',
+      message: 'Request had insufficient authentication scopes.',
+    },
+  ],
+  [
+    'a 400 invalid_grant response',
+    {
+      status: 400,
+      reason: 'invalid_grant',
+      message: 'Token has been expired or revoked.',
+    },
+  ],
+];
+
+const TEMPORARY_FAILURES: [string, GoogleApiFailure][] = [
+  [
+    'a 403 rateLimitExceeded response',
+    {
+      status: 403,
+      reason: 'rateLimitExceeded',
+      message: 'Rate Limit Exceeded',
+    },
+  ],
+  [
+    'a 403 userRateLimitExceeded response',
+    {
+      status: 403,
+      reason: 'userRateLimitExceeded',
+      message: 'User Rate Limit Exceeded',
+    },
+  ],
+  [
+    'a 400 failedPrecondition response',
+    {
+      status: 400,
+      reason: 'failedPrecondition',
+      message: 'Precondition check failed.',
+    },
+  ],
+  [
+    'a 500 backendError response',
+    { status: 500, reason: 'backendError', message: 'Backend Error' },
+  ],
+  [
+    'a 500 internal_failure response',
+    { status: 500, reason: 'internal_failure', message: 'Internal failure' },
+  ],
+];
+
+const UNKNOWN_FAILURES: [string, GoogleApiFailure][] = [
+  [
+    'a 400 response with an unmapped reason',
+    { status: 400, reason: 'invalidArgument', message: 'Invalid query' },
+  ],
+  [
+    'a 500 response with an unmapped reason',
+    { status: 500, reason: 'somethingElse', message: 'Internal error' },
+  ],
+  [
+    'a response with an unmapped status',
+    { status: 418, reason: 'teapot', message: 'I am a teapot' },
+  ],
+];
+
+describe('Google Calendar import error mapping (integration)', () => {
+  const google = setupGoogleMock({ handle: HANDLE });
+
+  let channel: Awaited<ReturnType<typeof connectMessagingAccount>>;
+
+  beforeAll(async () => {
+    channel = await connectMessagingAccount({
+      provider: ConnectedAccountProvider.GOOGLE,
+      handle: HANDLE,
+    });
+  }, 60000);
+
+  afterAll(async () => {
+    await channel?.cleanup().catch(() => undefined);
+  });
+
+  beforeEach(async () => {
+    await resetCalendarChannelSyncState(channel.calendarChannelId);
+
+    await getCoreRepository<ConnectedAccountEntity>(
+      ConnectedAccountEntity,
+    ).update({ id: channel.connectedAccountId }, { authFailedAt: null });
+  });
+
+  it.each(INSUFFICIENT_PERMISSIONS_FAILURES)(
+    'fails the calendar channel as insufficient-permissions on %s',
+    async (_label, failure) => {
+      google.failCalendarEventList(failure);
+
+      await runCalendarChannelListFetch(channel.calendarChannelId);
+
+      const channelState = await queryCalendarChannel(channel);
+
+      expect(channelState.syncStatus).toBe(
+        CalendarChannelSyncStatus.FAILED_INSUFFICIENT_PERMISSIONS,
+      );
+      expect(channelState.syncStage).toBe(CalendarChannelSyncStage.FAILED);
+
+      const account = await queryConnectedAccount(channel.connectedAccountId);
+
+      expect(account.authFailedAt).not.toBeNull();
+    },
+    60000,
+  );
+
+  it.each(TEMPORARY_FAILURES)(
+    'throttles the calendar channel without failing it on %s',
+    async (_label, failure) => {
+      google.failCalendarEventList(failure);
+
+      await runCalendarChannelListFetch(channel.calendarChannelId);
+
+      const channelState = await queryCalendarChannel(channel);
+
+      expect(channelState.throttleFailureCount).toBe(1);
+      expect(channelState.syncStage).toBe(
+        CalendarChannelSyncStage.CALENDAR_EVENT_LIST_FETCH_PENDING,
+      );
+      expect(channelState.syncStatus).not.toBe(
+        CalendarChannelSyncStatus.FAILED_UNKNOWN,
+      );
+      expect(channelState.syncStatus).not.toBe(
+        CalendarChannelSyncStatus.FAILED_INSUFFICIENT_PERMISSIONS,
+      );
+    },
+    60000,
+  );
+
+  it.each(UNKNOWN_FAILURES)(
+    'fails the calendar channel as unknown on %s',
+    async (_label, failure) => {
+      google.failCalendarEventList(failure);
+
+      await runCalendarChannelListFetch(channel.calendarChannelId);
+
+      const channelState = await queryCalendarChannel(channel);
+
+      expect(channelState.syncStatus).toBe(
+        CalendarChannelSyncStatus.FAILED_UNKNOWN,
+      );
+      expect(channelState.syncStage).toBe(CalendarChannelSyncStage.FAILED);
+    },
+    60000,
+  );
+
+  it('leaves the calendar channel untouched on a 404 during list fetch', async () => {
+    google.failCalendarEventList({
+      status: 404,
+      reason: 'notFound',
+      message: 'Not Found',
+    });
+
+    await runCalendarChannelListFetch(channel.calendarChannelId);
+
+    const channelState = await queryCalendarChannel(channel);
+
+    expect(channelState.syncStatus).not.toBe(
+      CalendarChannelSyncStatus.FAILED_UNKNOWN,
+    );
+    expect(channelState.syncStatus).not.toBe(
+      CalendarChannelSyncStatus.FAILED_INSUFFICIENT_PERMISSIONS,
+    );
+    expect(channelState.throttleFailureCount).toBe(0);
+
+    const storedChannel = await getCoreRepository<CalendarChannelEntity>(
+      CalendarChannelEntity,
+    ).findOneByOrFail({ id: channel.calendarChannelId });
+
+    expect(storedChannel.syncCursor).toBe('reset-cursor');
+  }, 60000);
+});

--- a/packages/twenty-server/test/integration/google/messaging/import-error-mapping.integration-spec.ts
+++ b/packages/twenty-server/test/integration/google/messaging/import-error-mapping.integration-spec.ts
@@ -1,0 +1,222 @@
+import {
+  ConnectedAccountProvider,
+  MessageChannelSyncStage,
+  MessageChannelSyncStatus,
+} from 'twenty-shared/types';
+
+import { ConnectedAccountEntity } from 'src/engine/metadata-modules/connected-account/entities/connected-account.entity';
+import { MessageChannelEntity } from 'src/engine/metadata-modules/message-channel/entities/message-channel.entity';
+
+import {
+  type GoogleApiFailure,
+  setupGoogleMock,
+} from 'test/integration/google/mocks/setup-google-mock.util';
+import { connectMessagingAccount } from 'test/integration/utils/connect-messaging-account.util';
+import { getCoreRepository } from 'test/integration/utils/get-core-repository.util';
+import {
+  queryConnectedAccount,
+  queryMessageChannel,
+} from 'test/integration/utils/query-messaging.util';
+import { resetMessageChannelSyncState } from 'test/integration/utils/reset-channel-sync-state.util';
+import { runMessageChannelSync } from 'test/integration/utils/run-message-channel-sync.util';
+
+const HANDLE = 'gmail-import-error-mapping@apple.dev';
+
+const INSUFFICIENT_PERMISSIONS_FAILURES: [string, GoogleApiFailure][] = [
+  [
+    'a 401 unauthorized response',
+    { status: 401, reason: 'authError', message: 'Invalid Credentials' },
+  ],
+  [
+    'a 403 insufficientPermissions response',
+    {
+      status: 403,
+      reason: 'insufficientPermissions',
+      message: 'Request had insufficient authentication scopes.',
+    },
+  ],
+  [
+    'a 403 domainPolicy response',
+    {
+      status: 403,
+      reason: 'domainPolicy',
+      message: 'The domain policy has disabled third-party Drive apps',
+    },
+  ],
+  [
+    'a 400 invalid_grant response',
+    {
+      status: 400,
+      reason: 'invalid_grant',
+      message: 'Token has been expired or revoked.',
+    },
+  ],
+  [
+    'a 400 failedPrecondition response for a disabled mail service',
+    {
+      status: 400,
+      reason: 'failedPrecondition',
+      message: 'Mail service not enabled',
+    },
+  ],
+];
+
+const TEMPORARY_FAILURES: [string, GoogleApiFailure][] = [
+  [
+    'a 403 rate limit response',
+    {
+      status: 403,
+      reason: 'rateLimitExceeded',
+      message: 'Rate Limit Exceeded',
+    },
+  ],
+  [
+    'a 400 failedPrecondition response unrelated to the mail service',
+    {
+      status: 400,
+      reason: 'failedPrecondition',
+      message: 'Precondition check failed.',
+    },
+  ],
+  [
+    'a 503 service unavailable response',
+    {
+      status: 503,
+      reason: 'backendError',
+      message: 'The service is currently unavailable.',
+    },
+  ],
+  [
+    'a 500 backendError response',
+    { status: 500, reason: 'backendError', message: 'Backend Error' },
+  ],
+];
+
+const UNKNOWN_FAILURES: [string, GoogleApiFailure][] = [
+  [
+    'a 400 response with an unmapped reason',
+    { status: 400, reason: 'invalidArgument', message: 'Invalid query' },
+  ],
+  [
+    'a 500 response with an unmapped reason',
+    { status: 500, reason: 'somethingElse', message: 'Internal error' },
+  ],
+  [
+    'a response with an unmapped status',
+    { status: 418, reason: 'teapot', message: 'I am a teapot' },
+  ],
+];
+
+describe('Gmail import error mapping (integration)', () => {
+  const gmail = setupGoogleMock({ handle: HANDLE });
+
+  let channel: Awaited<ReturnType<typeof connectMessagingAccount>>;
+
+  beforeAll(async () => {
+    channel = await connectMessagingAccount({
+      provider: ConnectedAccountProvider.GOOGLE,
+      handle: HANDLE,
+    });
+  }, 60000);
+
+  afterAll(async () => {
+    await channel?.cleanup().catch(() => undefined);
+  });
+
+  beforeEach(async () => {
+    await resetMessageChannelSyncState(channel.channelId);
+
+    await getCoreRepository<ConnectedAccountEntity>(
+      ConnectedAccountEntity,
+    ).update({ id: channel.connectedAccountId }, { authFailedAt: null });
+  });
+
+  it.each(INSUFFICIENT_PERMISSIONS_FAILURES)(
+    'fails the channel as insufficient-permissions on %s',
+    async (_label, failure) => {
+      gmail.failMessageList(failure);
+
+      await runMessageChannelSync(channel.channelId);
+
+      const channelState = await queryMessageChannel(channel);
+
+      expect(channelState.syncStatus).toBe(
+        MessageChannelSyncStatus.FAILED_INSUFFICIENT_PERMISSIONS,
+      );
+      expect(channelState.syncStage).toBe(MessageChannelSyncStage.FAILED);
+
+      const account = await queryConnectedAccount(channel.connectedAccountId);
+
+      expect(account.authFailedAt).not.toBeNull();
+    },
+    60000,
+  );
+
+  it.each(TEMPORARY_FAILURES)(
+    'throttles the channel without failing it on %s',
+    async (_label, failure) => {
+      gmail.failMessageList(failure);
+
+      await runMessageChannelSync(channel.channelId);
+
+      const channelState = await queryMessageChannel(channel);
+
+      expect(channelState.throttleFailureCount).toBe(1);
+      expect(channelState.syncStage).toBe(
+        MessageChannelSyncStage.MESSAGE_LIST_FETCH_PENDING,
+      );
+      expect(channelState.syncStatus).not.toBe(
+        MessageChannelSyncStatus.FAILED_UNKNOWN,
+      );
+      expect(channelState.syncStatus).not.toBe(
+        MessageChannelSyncStatus.FAILED_INSUFFICIENT_PERMISSIONS,
+      );
+    },
+    60000,
+  );
+
+  it.each(UNKNOWN_FAILURES)(
+    'fails the channel as unknown on %s',
+    async (_label, failure) => {
+      gmail.failMessageList(failure);
+
+      await runMessageChannelSync(channel.channelId);
+
+      const channelState = await queryMessageChannel(channel);
+
+      expect(channelState.syncStatus).toBe(
+        MessageChannelSyncStatus.FAILED_UNKNOWN,
+      );
+      expect(channelState.syncStage).toBe(MessageChannelSyncStage.FAILED);
+      expect(channelState.throttleFailureCount).toBe(0);
+    },
+    60000,
+  );
+
+  it('restarts the channel from a clean cursor on a 404 sync cursor error', async () => {
+    gmail.failMessageList({
+      status: 404,
+      reason: 'notFound',
+      message: 'Requested entity was not found.',
+    });
+
+    await runMessageChannelSync(channel.channelId);
+
+    const channelState = await queryMessageChannel(channel);
+
+    expect(channelState.syncStage).toBe(
+      MessageChannelSyncStage.MESSAGE_LIST_FETCH_PENDING,
+    );
+    expect(channelState.syncStatus).not.toBe(
+      MessageChannelSyncStatus.FAILED_UNKNOWN,
+    );
+    expect(channelState.throttleFailureCount).toBe(0);
+    expect(channelState.syncStageStartedAt).toBeNull();
+
+    const storedChannel = await getCoreRepository<MessageChannelEntity>(
+      MessageChannelEntity,
+    ).findOneByOrFail({ id: channel.channelId });
+
+    expect(storedChannel.syncCursor).toBeFalsy();
+  }, 60000);
+});

--- a/packages/twenty-server/test/integration/google/mocks/setup-google-mock.util.ts
+++ b/packages/twenty-server/test/integration/google/mocks/setup-google-mock.util.ts
@@ -33,8 +33,32 @@ export type GoogleMock = {
   ) => void;
   rateLimitMessageList: (retryAfterIso: string) => void;
   rateLimitCalendarEventList: () => void;
+  failMessageList: (failure: GoogleApiFailure) => void;
+  failCalendarEventList: (failure: GoogleApiFailure) => void;
   declineTokenRefresh: () => void;
 };
+
+export type GoogleApiFailure = {
+  status: number;
+  reason: string;
+  message: string;
+};
+
+const googleApiErrorResponse = ({
+  status,
+  reason,
+  message,
+}: GoogleApiFailure) =>
+  HttpResponse.json(
+    {
+      error: {
+        code: status,
+        message,
+        errors: [{ reason, message }],
+      },
+    },
+    { status },
+  );
 
 export const setupGoogleMock = ({
   handle,
@@ -104,6 +128,18 @@ export const setupGoogleMock = ({
             },
             { status: 429 },
           ),
+        ),
+      ),
+    failMessageList: (failure) =>
+      httpMock.use(
+        http.get('*/gmail/v1/users/me/messages', () =>
+          googleApiErrorResponse(failure),
+        ),
+      ),
+    failCalendarEventList: (failure) =>
+      httpMock.use(
+        http.get(GOOGLE_CALENDAR_EVENTS_URL, () =>
+          googleApiErrorResponse(failure),
         ),
       ),
     declineTokenRefresh: () =>

--- a/packages/twenty-server/test/integration/utils/reset-channel-sync-state.util.ts
+++ b/packages/twenty-server/test/integration/utils/reset-channel-sync-state.util.ts
@@ -1,0 +1,44 @@
+import {
+  CalendarChannelSyncStage,
+  CalendarChannelSyncStatus,
+  MessageChannelSyncStage,
+  MessageChannelSyncStatus,
+} from 'twenty-shared/types';
+
+import { CalendarChannelEntity } from 'src/engine/metadata-modules/calendar-channel/entities/calendar-channel.entity';
+import { MessageChannelEntity } from 'src/engine/metadata-modules/message-channel/entities/message-channel.entity';
+
+import { getCoreRepository } from 'test/integration/utils/get-core-repository.util';
+
+export const resetMessageChannelSyncState = async (
+  messageChannelId: string,
+  syncCursor = 'reset-cursor',
+): Promise<void> => {
+  await getCoreRepository<MessageChannelEntity>(MessageChannelEntity).update(
+    { id: messageChannelId },
+    {
+      syncStatus: MessageChannelSyncStatus.ACTIVE,
+      syncStage: MessageChannelSyncStage.MESSAGE_LIST_FETCH_PENDING,
+      syncStageStartedAt: null,
+      throttleFailureCount: 0,
+      throttleRetryAfter: null,
+      syncCursor,
+    },
+  );
+};
+
+export const resetCalendarChannelSyncState = async (
+  calendarChannelId: string,
+  syncCursor = 'reset-cursor',
+): Promise<void> => {
+  await getCoreRepository<CalendarChannelEntity>(CalendarChannelEntity).update(
+    { id: calendarChannelId },
+    {
+      syncStatus: CalendarChannelSyncStatus.ACTIVE,
+      syncStage: CalendarChannelSyncStage.CALENDAR_EVENT_LIST_FETCH_PENDING,
+      syncStageStartedAt: null,
+      throttleFailureCount: 0,
+      syncCursor,
+    },
+  );
+};


### PR DESCRIPTION
Audit of messaging + calendar integration coverage and the tests closing the gaps.

First batch: every branch of the Gmail and Google Calendar API error parsers, asserted through the real worker down to channel sync status/stage.

More batches to follow: sync stage transitions, folder import policies, visibility and contact-auto-creation policies, blocklist and cleanup jobs.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/24098?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

