### PR TITLE
feat(server): route nested relation loading through the ORM v2 read path

### DIFF
--- a/packages/twenty-server/src/engine/api/common/common-nested-relations-processor/process-nested-relations-orm-v2.helper.ts
+++ b/packages/twenty-server/src/engine/api/common/common-nested-relations-processor/process-nested-relations-orm-v2.helper.ts
@@ -58,10 +58,6 @@ type ProcessNestedRelationsOrmV2Args<T extends ObjectRecord = ObjectRecord> = {
   selectedFields: Record<string, any>;
 };
 
-// ORM v2 counterpart of ProcessNestedRelationsV2Helper. Batched loading and relation
-// aggregates use the shared builder surface; the per-parent-limit path is composed as
-// raw SQL (CROSS JOIN LATERAL) and run through the v2 pool, since v2's table-shape
-// builder cannot model the table-less `FROM (subquery)` the v1 helper relies on.
 @Injectable()
 export class ProcessNestedRelationsOrmV2Helper {
   constructor(
@@ -519,8 +515,6 @@ export class ProcessNestedRelationsOrmV2Helper {
 
     perParentRecordIdsQueryBuilder.applyRowLevelPermissions();
 
-    // perParentLimit is inlined (a numeric constant) rather than bound, because the
-    // per-parent LIMIT lives inside the composed lateral subquery, not the builder.
     const perParentRecordIdsSql = `${perParentRecordIdsQueryBuilder.getQuery()} LIMIT ${Number(perParentLimit)}`;
 
     const parentValues = sanitizedIds.map((id) => `('${id}'::uuid)`).join(', ');

--- a/packages/twenty-server/src/engine/api/common/common-nested-relations-processor/process-nested-relations-orm-v2.helper.ts
+++ b/packages/twenty-server/src/engine/api/common/common-nested-relations-processor/process-nested-relations-orm-v2.helper.ts
@@ -17,7 +17,6 @@ import {
   GraphqlQueryRunnerExceptionCode,
 } from 'src/engine/api/graphql/graphql-query-runner/errors/graphql-query-runner.exception';
 import { ProcessAggregateHelper } from 'src/engine/api/graphql/graphql-query-runner/helpers/process-aggregate.helper';
-import { type RecordQueryBuilder } from 'src/engine/api/graphql/graphql-query-runner/types/record-query-builder.type';
 import { buildColumnsToSelect } from 'src/engine/api/graphql/graphql-query-runner/utils/build-columns-to-select';
 import { getTargetObjectMetadataOrThrow } from 'src/engine/api/graphql/graphql-query-runner/utils/get-target-object-metadata.util';
 import { type AggregationField } from 'src/engine/api/graphql/workspace-schema-builder/utils/get-available-aggregations-from-object-fields.util';
@@ -194,7 +193,7 @@ export class ProcessNestedRelationsOrmV2Helper {
       );
     }
 
-    const relationType = sourceFieldMetadata.settings?.relationType;
+    const relationType = sourceFieldMetadata.settings.relationType;
     const { targetRelationName, targetObjectMetadata, targetRelation } =
       this.getTargetObjectMetadata({
         flatObjectMetadataMaps,
@@ -426,7 +425,7 @@ export class ProcessNestedRelationsOrmV2Helper {
 
       ProcessAggregateHelper.addSelectedAggregatedFieldsQueriesToQueryBuilder({
         selectedAggregatedFields: aggregateForRelation,
-        queryBuilder: aggregateQueryBuilder as unknown as RecordQueryBuilder,
+        queryBuilder: aggregateQueryBuilder,
         objectMetadataNameSingular: targetObjectNameSingular,
       });
 

--- a/packages/twenty-server/src/engine/api/common/common-nested-relations-processor/process-nested-relations-orm-v2.helper.ts
+++ b/packages/twenty-server/src/engine/api/common/common-nested-relations-processor/process-nested-relations-orm-v2.helper.ts
@@ -1,0 +1,596 @@
+import { Injectable } from '@nestjs/common';
+
+import { FieldMetadataType, type ObjectRecord } from 'twenty-shared/types';
+import { isDefined, isValidUuid } from 'twenty-shared/utils';
+import { type FindOptionsRelations, type ObjectLiteral } from 'typeorm';
+
+import { computeMorphOrRelationFieldJoinColumnName } from 'src/engine/metadata-modules/field-metadata/utils/compute-morph-or-relation-field-join-column-name.util';
+import { RelationType } from 'src/engine/metadata-modules/field-metadata/interfaces/relation-type.interface';
+
+import {
+  type ConcurrencyLimiter,
+  createConcurrencyLimiter,
+} from 'src/engine/api/common/common-nested-relations-processor/utils/create-concurrency-limiter.util';
+import { STANDARD_ERROR_MESSAGE } from 'src/engine/api/common/common-query-runners/errors/standard-error-message.constant';
+import {
+  GraphqlQueryRunnerException,
+  GraphqlQueryRunnerExceptionCode,
+} from 'src/engine/api/graphql/graphql-query-runner/errors/graphql-query-runner.exception';
+import { ProcessAggregateHelper } from 'src/engine/api/graphql/graphql-query-runner/helpers/process-aggregate.helper';
+import { type RecordQueryBuilder } from 'src/engine/api/graphql/graphql-query-runner/types/record-query-builder.type';
+import { buildColumnsToSelect } from 'src/engine/api/graphql/graphql-query-runner/utils/build-columns-to-select';
+import { getTargetObjectMetadataOrThrow } from 'src/engine/api/graphql/graphql-query-runner/utils/get-target-object-metadata.util';
+import { type AggregationField } from 'src/engine/api/graphql/workspace-schema-builder/utils/get-available-aggregations-from-object-fields.util';
+import { type WorkspaceAuthContext } from 'src/engine/core-modules/auth/types/workspace-auth-context.type';
+import { FlatEntityMaps } from 'src/engine/metadata-modules/flat-entity/types/flat-entity-maps.type';
+import { findFlatEntityByIdInFlatEntityMaps } from 'src/engine/metadata-modules/flat-entity/utils/find-flat-entity-by-id-in-flat-entity-maps.util';
+import { FlatFieldMetadata } from 'src/engine/metadata-modules/flat-field-metadata/types/flat-field-metadata.type';
+import {
+  buildFieldMapsFromFlatObjectMetadata,
+  type FieldMapsForObject,
+} from 'src/engine/metadata-modules/flat-field-metadata/utils/build-field-maps-from-flat-object-metadata.util';
+import { FlatObjectMetadata } from 'src/engine/metadata-modules/flat-object-metadata/types/flat-object-metadata.type';
+import { type RolePermissionConfig } from 'src/engine/twenty-orm/types/role-permission-config';
+import { type WorkspaceDataSourceV2 } from 'src/engine/twenty-orm-v2/datasource/workspace-data-source-v2';
+import { WorkspaceDataSourceV2Service } from 'src/engine/twenty-orm-v2/datasource/workspace-data-source-v2.service';
+import { type WorkspaceSelectQueryBuilderV2 } from 'src/engine/twenty-orm-v2/query-builder/workspace-select-query-builder-v2';
+import { type WorkspaceRepositoryV2 } from 'src/engine/twenty-orm-v2/repository/workspace-repository-v2';
+import { isFieldMetadataEntityOfType } from 'src/engine/utils/is-field-metadata-of-type.util';
+
+const EMPTY_RELATION_SENTINEL_RECORD_ID =
+  '00000000-0000-0000-0000-000000000000';
+const NESTED_RELATION_QUERY_MAX_CONCURRENCY = 4;
+
+type ProcessNestedRelationsOrmV2Args<T extends ObjectRecord = ObjectRecord> = {
+  flatObjectMetadataMaps: FlatEntityMaps<FlatObjectMetadata>;
+  flatFieldMetadataMaps: FlatEntityMaps<FlatFieldMetadata>;
+  parentObjectMetadataItem: FlatObjectMetadata;
+  parentObjectRecords: T[];
+  // oxlint-disable-next-line typescript/no-explicit-any
+  parentObjectRecordsAggregatedValues?: Record<string, any>;
+  relations: Record<string, FindOptionsRelations<ObjectLiteral>>;
+  aggregate?: Record<string, AggregationField>;
+  limit: number;
+  authContext: WorkspaceAuthContext;
+  useReplica: boolean;
+  rolePermissionConfig?: RolePermissionConfig;
+  // oxlint-disable-next-line typescript/no-explicit-any
+  selectedFields: Record<string, any>;
+};
+
+// ORM v2 counterpart of ProcessNestedRelationsV2Helper. Batched loading and relation
+// aggregates use the shared builder surface; the per-parent-limit path is composed as
+// raw SQL (CROSS JOIN LATERAL) and run through the v2 pool, since v2's table-shape
+// builder cannot model the table-less `FROM (subquery)` the v1 helper relies on.
+@Injectable()
+export class ProcessNestedRelationsOrmV2Helper {
+  constructor(
+    private readonly workspaceDataSourceV2Service: WorkspaceDataSourceV2Service,
+  ) {}
+
+  public async processNestedRelations<T extends ObjectRecord = ObjectRecord>(
+    args: ProcessNestedRelationsOrmV2Args<T>,
+  ): Promise<void> {
+    const dataSource = this.workspaceDataSourceV2Service.getDataSource({
+      useReplica: args.useReplica,
+    });
+
+    await this.processNestedRelationsWithLimiter(
+      args,
+      dataSource,
+      createConcurrencyLimiter(NESTED_RELATION_QUERY_MAX_CONCURRENCY),
+    );
+  }
+
+  private async processNestedRelationsWithLimiter<
+    T extends ObjectRecord = ObjectRecord,
+  >(
+    {
+      flatObjectMetadataMaps,
+      flatFieldMetadataMaps,
+      parentObjectMetadataItem,
+      parentObjectRecords,
+      parentObjectRecordsAggregatedValues = {},
+      relations,
+      aggregate = {},
+      limit,
+      authContext,
+      useReplica,
+      rolePermissionConfig,
+      selectedFields,
+    }: ProcessNestedRelationsOrmV2Args<T>,
+    dataSource: WorkspaceDataSourceV2,
+    relationQueryLimiter: ConcurrencyLimiter,
+  ): Promise<void> {
+    const processRelationTasks = Object.entries(relations).map(
+      ([sourceFieldName, nestedRelations]) =>
+        this.processRelation({
+          flatObjectMetadataMaps,
+          flatFieldMetadataMaps,
+          parentObjectMetadataItem,
+          parentObjectRecords,
+          parentObjectRecordsAggregatedValues,
+          sourceFieldName,
+          nestedRelations,
+          aggregate,
+          limit,
+          authContext,
+          useReplica,
+          dataSource,
+          rolePermissionConfig,
+          relationQueryLimiter,
+          selectedFields:
+            selectedFields[sourceFieldName] instanceof Object
+              ? selectedFields[sourceFieldName]
+              : undefined,
+        }),
+    );
+
+    await Promise.all(processRelationTasks);
+  }
+
+  private async processRelation<T extends ObjectRecord = ObjectRecord>({
+    flatObjectMetadataMaps,
+    flatFieldMetadataMaps,
+    parentObjectMetadataItem,
+    parentObjectRecords,
+    parentObjectRecordsAggregatedValues,
+    sourceFieldName,
+    nestedRelations,
+    aggregate,
+    limit,
+    authContext,
+    useReplica,
+    dataSource,
+    rolePermissionConfig,
+    relationQueryLimiter,
+    selectedFields,
+  }: {
+    flatObjectMetadataMaps: FlatEntityMaps<FlatObjectMetadata>;
+    flatFieldMetadataMaps: FlatEntityMaps<FlatFieldMetadata>;
+    parentObjectMetadataItem: FlatObjectMetadata;
+    parentObjectRecords: T[];
+    // oxlint-disable-next-line typescript/no-explicit-any
+    parentObjectRecordsAggregatedValues: Record<string, any>;
+    sourceFieldName: string;
+    nestedRelations: FindOptionsRelations<ObjectLiteral>;
+    aggregate: Record<string, AggregationField>;
+    limit: number;
+    authContext: WorkspaceAuthContext;
+    useReplica: boolean;
+    dataSource: WorkspaceDataSourceV2;
+    rolePermissionConfig?: RolePermissionConfig;
+    relationQueryLimiter: ConcurrencyLimiter;
+    selectedFields: Record<string, unknown>;
+  }): Promise<void> {
+    const fieldMaps = buildFieldMapsFromFlatObjectMetadata(
+      flatFieldMetadataMaps,
+      parentObjectMetadataItem,
+    );
+
+    const sourceFieldMetadata = findFlatEntityByIdInFlatEntityMaps({
+      flatEntityId: fieldMaps.fieldIdByName[sourceFieldName],
+      flatEntityMaps: flatFieldMetadataMaps,
+    });
+
+    if (!sourceFieldMetadata) {
+      return;
+    }
+
+    if (
+      !isFieldMetadataEntityOfType(
+        sourceFieldMetadata,
+        FieldMetadataType.RELATION,
+      ) &&
+      !isFieldMetadataEntityOfType(
+        sourceFieldMetadata,
+        FieldMetadataType.MORPH_RELATION,
+      )
+    ) {
+      return;
+    }
+
+    if (!sourceFieldMetadata.settings) {
+      throw new GraphqlQueryRunnerException(
+        `Relation settings not found for field ${sourceFieldName}`,
+        GraphqlQueryRunnerExceptionCode.RELATION_SETTINGS_NOT_FOUND,
+        { userFriendlyMessage: STANDARD_ERROR_MESSAGE },
+      );
+    }
+
+    const relationType = sourceFieldMetadata.settings?.relationType;
+    const { targetRelationName, targetObjectMetadata, targetRelation } =
+      this.getTargetObjectMetadata({
+        flatObjectMetadataMaps,
+        flatFieldMetadataMaps,
+        parentObjectMetadataItem,
+        sourceFieldName,
+        fieldMaps,
+      });
+
+    const targetObjectRepository = dataSource.getRepository(
+      targetObjectMetadata.nameSingular,
+      rolePermissionConfig,
+    );
+
+    const targetObjectNameSingular = targetObjectMetadata.nameSingular;
+
+    let targetObjectQueryBuilder = targetObjectRepository.createQueryBuilder(
+      targetObjectNameSingular,
+    );
+
+    const columnsToSelect: Record<string, boolean> = buildColumnsToSelect({
+      select: selectedFields,
+      relations: nestedRelations,
+      flatObjectMetadata: targetObjectMetadata,
+      flatObjectMetadataMaps,
+      flatFieldMetadataMaps,
+    });
+
+    if (relationType === RelationType.MANY_TO_ONE) {
+      columnsToSelect.deletedAt = true;
+      targetObjectQueryBuilder = targetObjectQueryBuilder.withDeleted();
+    }
+
+    targetObjectQueryBuilder = targetObjectQueryBuilder.setFindOptions({
+      select: columnsToSelect,
+    });
+
+    const joinColumnName = computeMorphOrRelationFieldJoinColumnName({
+      name: sourceFieldName,
+    });
+
+    const relationIds = this.getUniqueIds({
+      records: parentObjectRecords,
+      idField:
+        relationType === RelationType.ONE_TO_MANY ? 'id' : joinColumnName,
+    });
+
+    if (
+      relationType === RelationType.ONE_TO_MANY &&
+      !isDefined(targetRelationName)
+    ) {
+      throw new GraphqlQueryRunnerException(
+        `Could not resolve target relation for one-to-many field ${sourceFieldName}`,
+        GraphqlQueryRunnerExceptionCode.RELATION_TARGET_OBJECT_METADATA_NOT_FOUND,
+        { userFriendlyMessage: STANDARD_ERROR_MESSAGE },
+      );
+    }
+
+    const fieldMetadataTargetRelationColumnName =
+      computeMorphOrRelationFieldJoinColumnName({
+        name:
+          targetRelation &&
+          isFieldMetadataEntityOfType(
+            targetRelation,
+            FieldMetadataType.MORPH_RELATION,
+          )
+            ? targetRelation.name
+            : (targetRelationName as string),
+      });
+
+    const { relationResults, relationAggregatedFieldsResult } =
+      await relationQueryLimiter(() =>
+        this.findRelations({
+          referenceQueryBuilder: targetObjectQueryBuilder,
+          targetObjectRepository,
+          column:
+            relationType === RelationType.ONE_TO_MANY
+              ? `"${fieldMetadataTargetRelationColumnName}"`
+              : 'id',
+          ids: relationIds,
+          relationType,
+          perParentLimit: limit,
+          parentRecordsCount: parentObjectRecords.length,
+          aggregate,
+          sourceFieldName,
+          targetObjectNameSingular,
+        }),
+      );
+
+    this.assignRelationResults({
+      parentRecords: parentObjectRecords,
+      parentObjectRecordsAggregatedValues,
+      relationResults,
+      relationAggregatedFieldsResult,
+      sourceFieldName,
+      joinField:
+        relationType === RelationType.ONE_TO_MANY
+          ? `${fieldMetadataTargetRelationColumnName}`
+          : 'id',
+      joinColumnName,
+      relationType,
+      selectedFields,
+    });
+
+    if (Object.keys(nestedRelations).length > 0) {
+      await this.processNestedRelationsWithLimiter(
+        {
+          flatObjectMetadataMaps,
+          flatFieldMetadataMaps,
+          parentObjectMetadataItem: targetObjectMetadata,
+          parentObjectRecords: relationResults as ObjectRecord[],
+          parentObjectRecordsAggregatedValues: relationAggregatedFieldsResult,
+          relations: nestedRelations as Record<
+            string,
+            FindOptionsRelations<ObjectLiteral>
+          >,
+          aggregate,
+          limit,
+          authContext,
+          useReplica,
+          rolePermissionConfig,
+          selectedFields,
+        },
+        dataSource,
+        relationQueryLimiter,
+      );
+    }
+  }
+
+  private getTargetObjectMetadata({
+    flatObjectMetadataMaps,
+    flatFieldMetadataMaps,
+    parentObjectMetadataItem,
+    sourceFieldName,
+    fieldMaps,
+  }: {
+    flatObjectMetadataMaps: FlatEntityMaps<FlatObjectMetadata>;
+    flatFieldMetadataMaps: FlatEntityMaps<FlatFieldMetadata>;
+    parentObjectMetadataItem: FlatObjectMetadata;
+    sourceFieldName: string;
+    fieldMaps: FieldMapsForObject;
+  }) {
+    const targetFieldMetadata = findFlatEntityByIdInFlatEntityMaps({
+      flatEntityId: fieldMaps.fieldIdByName[sourceFieldName],
+      flatEntityMaps: flatFieldMetadataMaps,
+    });
+
+    if (!targetFieldMetadata) {
+      throw new GraphqlQueryRunnerException(
+        `Field ${sourceFieldName} not found on object ${parentObjectMetadataItem.nameSingular}`,
+        GraphqlQueryRunnerExceptionCode.FIELD_NOT_FOUND,
+        { userFriendlyMessage: STANDARD_ERROR_MESSAGE },
+      );
+    }
+
+    const targetObjectMetadata = getTargetObjectMetadataOrThrow(
+      targetFieldMetadata,
+      flatObjectMetadataMaps,
+    );
+
+    if (
+      !targetFieldMetadata.relationTargetObjectMetadataId ||
+      !targetFieldMetadata.relationTargetFieldMetadataId
+    ) {
+      throw new GraphqlQueryRunnerException(
+        `Relation target object metadata id or field metadata id not found for field ${sourceFieldName}`,
+        GraphqlQueryRunnerExceptionCode.RELATION_TARGET_OBJECT_METADATA_NOT_FOUND,
+        { userFriendlyMessage: STANDARD_ERROR_MESSAGE },
+      );
+    }
+
+    const targetRelation = findFlatEntityByIdInFlatEntityMaps({
+      flatEntityId: targetFieldMetadata.relationTargetFieldMetadataId,
+      flatEntityMaps: flatFieldMetadataMaps,
+    });
+
+    const targetRelationName = targetRelation?.name;
+
+    return { targetRelationName, targetObjectMetadata, targetRelation };
+  }
+
+  private getUniqueIds({
+    records,
+    idField,
+  }: {
+    records: ObjectRecord[];
+    idField: string;
+    // oxlint-disable-next-line typescript/no-explicit-any
+  }): any[] {
+    return [...new Set(records.map((item) => item[idField]))];
+  }
+
+  private async findRelations({
+    referenceQueryBuilder,
+    targetObjectRepository,
+    column,
+    ids,
+    relationType,
+    perParentLimit,
+    parentRecordsCount,
+    aggregate,
+    sourceFieldName,
+    targetObjectNameSingular,
+  }: {
+    referenceQueryBuilder: WorkspaceSelectQueryBuilderV2;
+    targetObjectRepository: WorkspaceRepositoryV2;
+    column: string;
+    // oxlint-disable-next-line typescript/no-explicit-any
+    ids: any[];
+    relationType: RelationType;
+    perParentLimit: number;
+    parentRecordsCount: number;
+    // oxlint-disable-next-line typescript/no-explicit-any
+    aggregate: Record<string, any>;
+    sourceFieldName: string;
+    targetObjectNameSingular: string;
+    // oxlint-disable-next-line typescript/no-explicit-any
+  }): Promise<{ relationResults: any[]; relationAggregatedFieldsResult: any }> {
+    if (ids.length === 0) {
+      return { relationResults: [], relationAggregatedFieldsResult: {} };
+    }
+
+    const aggregateForRelation = aggregate[sourceFieldName];
+    // oxlint-disable-next-line typescript/no-explicit-any
+    let relationAggregatedFieldsResult: Record<string, any> = {};
+
+    if (aggregateForRelation) {
+      const aggregateQueryBuilder = referenceQueryBuilder.clone();
+
+      ProcessAggregateHelper.addSelectedAggregatedFieldsQueriesToQueryBuilder({
+        selectedAggregatedFields: aggregateForRelation,
+        queryBuilder: aggregateQueryBuilder as unknown as RecordQueryBuilder,
+        objectMetadataNameSingular: targetObjectNameSingular,
+      });
+
+      const aggregatedFieldsValues = await aggregateQueryBuilder
+        .addSelect(column, column.replace(/["']/g, ''))
+        .where(`${column} IN (:...ids)`, { ids })
+        .groupBy(column)
+        .getRawMany();
+
+      relationAggregatedFieldsResult = aggregatedFieldsValues.reduce<
+        Record<string, unknown>
+      >((acc, item) => {
+        const columnWithoutQuotes = column.replace(/["']/g, '');
+        const key = String(item[columnWithoutQuotes]);
+        const { [column]: _, ...itemWithoutColumn } = item;
+
+        acc[key] = itemWithoutColumn;
+
+        return acc;
+      }, {});
+    }
+
+    const queryBuilderOptions = referenceQueryBuilder.getFindOptions();
+    const columnWithoutQuotes = column.replace(/["']/g, '');
+
+    const findOptionsWithJoinColumn = {
+      ...queryBuilderOptions,
+      select: { ...queryBuilderOptions.select, [columnWithoutQuotes]: true },
+    };
+
+    if (relationType !== RelationType.ONE_TO_MANY) {
+      const result = await referenceQueryBuilder
+        .setFindOptions(findOptionsWithJoinColumn)
+        .where(`${column} IN (:...ids)`, { ids })
+        .take(perParentLimit * parentRecordsCount)
+        .getMany();
+
+      return { relationResults: result, relationAggregatedFieldsResult };
+    }
+
+    const allowedRelationRecordIds =
+      await this.findRelationRecordIdsLimitedPerParent({
+        targetObjectRepository,
+        targetObjectNameSingular,
+        column,
+        ids,
+        perParentLimit,
+      });
+
+    const recordIdsToHydrate =
+      allowedRelationRecordIds.length > 0
+        ? allowedRelationRecordIds
+        : [EMPTY_RELATION_SENTINEL_RECORD_ID];
+
+    const result = await referenceQueryBuilder
+      .setFindOptions(findOptionsWithJoinColumn)
+      .where(`id IN (:...recordIdsToHydrate)`, { recordIdsToHydrate })
+      .getMany();
+
+    return { relationResults: result, relationAggregatedFieldsResult };
+  }
+
+  private async findRelationRecordIdsLimitedPerParent({
+    targetObjectRepository,
+    targetObjectNameSingular,
+    column,
+    ids,
+    perParentLimit,
+  }: {
+    targetObjectRepository: WorkspaceRepositoryV2;
+    targetObjectNameSingular: string;
+    column: string;
+    ids: string[];
+    perParentLimit: number;
+  }): Promise<string[]> {
+    const sanitizedIds = ids.filter(isValidUuid);
+
+    if (sanitizedIds.length === 0) {
+      return [];
+    }
+
+    const perParentRecordIdsQueryBuilder = targetObjectRepository
+      .createQueryBuilder(targetObjectNameSingular)
+      .select(`"${targetObjectNameSingular}"."id"`, 'id')
+      .where(`${column} = "lateralParents"."parentId"`);
+
+    perParentRecordIdsQueryBuilder.applyRowLevelPermissions();
+
+    // perParentLimit is inlined (a numeric constant) rather than bound, because the
+    // per-parent LIMIT lives inside the composed lateral subquery, not the builder.
+    const perParentRecordIdsSql = `${perParentRecordIdsQueryBuilder.getQuery()} LIMIT ${Number(perParentLimit)}`;
+
+    const parentValues = sanitizedIds.map((id) => `('${id}'::uuid)`).join(', ');
+
+    const lateralSql =
+      `SELECT "limited_relation_records"."id" AS "id" FROM (` +
+      `SELECT "lateralRecords"."id" AS "id" ` +
+      `FROM (VALUES ${parentValues}) AS "lateralParents"("parentId") ` +
+      `CROSS JOIN LATERAL (${perParentRecordIdsSql}) AS "lateralRecords"` +
+      `) AS "limited_relation_records"`;
+
+    const limitedRecords = await targetObjectRepository.executeRaw<{
+      id: string;
+    }>(lateralSql, perParentRecordIdsQueryBuilder.getParameters());
+
+    return limitedRecords.map((limitedRecord) => limitedRecord.id);
+  }
+
+  private assignRelationResults({
+    parentRecords,
+    parentObjectRecordsAggregatedValues,
+    relationResults,
+    relationAggregatedFieldsResult,
+    sourceFieldName,
+    joinField,
+    joinColumnName,
+    relationType,
+    selectedFields,
+  }: {
+    parentRecords: ObjectRecord[];
+    // oxlint-disable-next-line typescript/no-explicit-any
+    parentObjectRecordsAggregatedValues: Record<string, any>;
+    // oxlint-disable-next-line typescript/no-explicit-any
+    relationResults: any[];
+    // oxlint-disable-next-line typescript/no-explicit-any
+    relationAggregatedFieldsResult: Record<string, any>;
+    sourceFieldName: string;
+    joinField: string;
+    joinColumnName: string;
+    relationType: RelationType;
+    selectedFields: Record<string, unknown>;
+  }): void {
+    parentRecords.forEach((item) => {
+      if (relationType === RelationType.ONE_TO_MANY) {
+        item[sourceFieldName] = relationResults.filter(
+          (rel) => rel[joinField] === item.id,
+        );
+      } else {
+        const matchedRelation = relationResults.find(
+          (rel) => rel.id === item[joinColumnName],
+        );
+
+        if (isDefined(matchedRelation?.deletedAt)) {
+          item[sourceFieldName] = null;
+          item[joinColumnName] = null;
+        } else if (isDefined(matchedRelation)) {
+          if (selectedFields?.deletedAt !== true) {
+            const { deletedAt: _, ...rest } = matchedRelation;
+
+            item[sourceFieldName] = rest;
+          } else {
+            item[sourceFieldName] = matchedRelation;
+          }
+        } else {
+          item[sourceFieldName] = null;
+        }
+      }
+    });
+
+    parentObjectRecordsAggregatedValues[sourceFieldName] =
+      relationAggregatedFieldsResult;
+  }
+}

--- a/packages/twenty-server/src/engine/api/common/common-nested-relations-processor/process-nested-relations.helper.ts
+++ b/packages/twenty-server/src/engine/api/common/common-nested-relations-processor/process-nested-relations.helper.ts
@@ -3,6 +3,7 @@ import { Injectable } from '@nestjs/common';
 import { type ObjectRecord } from 'twenty-shared/types';
 import { type FindOptionsRelations, type ObjectLiteral } from 'typeorm';
 
+import { ProcessNestedRelationsOrmV2Helper } from 'src/engine/api/common/common-nested-relations-processor/process-nested-relations-orm-v2.helper';
 import { ProcessNestedRelationsV2Helper } from 'src/engine/api/common/common-nested-relations-processor/process-nested-relations-v2.helper';
 import { type AggregationField } from 'src/engine/api/graphql/workspace-schema-builder/utils/get-available-aggregations-from-object-fields.util';
 import { type WorkspaceAuthContext } from 'src/engine/core-modules/auth/types/workspace-auth-context.type';
@@ -16,6 +17,7 @@ import { RolePermissionConfig } from 'src/engine/twenty-orm/types/role-permissio
 export class ProcessNestedRelationsHelper {
   constructor(
     private readonly processNestedRelationsV2Helper: ProcessNestedRelationsV2Helper,
+    private readonly processNestedRelationsOrmV2Helper: ProcessNestedRelationsOrmV2Helper,
   ) {}
 
   public async processNestedRelations<T extends ObjectRecord = ObjectRecord>({
@@ -31,6 +33,8 @@ export class ProcessNestedRelationsHelper {
     workspaceDataSource,
     rolePermissionConfig,
     selectedFields,
+    isOrmV2ReadPathEnabled = false,
+    useReplica = false,
   }: {
     flatObjectMetadataMaps: FlatEntityMaps<FlatObjectMetadata>;
     flatFieldMetadataMaps: FlatEntityMaps<FlatFieldMetadata>;
@@ -46,7 +50,26 @@ export class ProcessNestedRelationsHelper {
     rolePermissionConfig?: RolePermissionConfig;
     // oxlint-disable-next-line typescript/no-explicit-any
     selectedFields: Record<string, any>;
+    isOrmV2ReadPathEnabled?: boolean;
+    useReplica?: boolean;
   }): Promise<void> {
+    if (isOrmV2ReadPathEnabled) {
+      return this.processNestedRelationsOrmV2Helper.processNestedRelations({
+        flatObjectMetadataMaps,
+        flatFieldMetadataMaps,
+        parentObjectMetadataItem,
+        parentObjectRecords,
+        parentObjectRecordsAggregatedValues,
+        relations,
+        aggregate,
+        limit,
+        authContext,
+        useReplica,
+        rolePermissionConfig,
+        selectedFields,
+      });
+    }
+
     return this.processNestedRelationsV2Helper.processNestedRelations({
       flatObjectMetadataMaps,
       flatFieldMetadataMaps,

--- a/packages/twenty-server/src/engine/api/common/common-query-runners/common-base-query-runner.service.ts
+++ b/packages/twenty-server/src/engine/api/common/common-query-runners/common-base-query-runner.service.ts
@@ -390,6 +390,19 @@ export abstract class CommonBaseQueryRunnerService<
       .getRepository(flatObjectMetadata.nameSingular, rolePermissionConfig);
   }
 
+  protected getNestedRelationsReadPathOptions({
+    featureFlagsMap,
+  }: Pick<CommonExtendedQueryRunnerContext, 'featureFlagsMap'>): {
+    isOrmV2ReadPathEnabled: boolean;
+    useReplica: boolean;
+  } {
+    return {
+      isOrmV2ReadPathEnabled:
+        featureFlagsMap[FeatureFlagKey.IS_ORM_V2_READ_PATH_ENABLED],
+      useReplica: this.isReadOnly,
+    };
+  }
+
   private async throttleQueryExecution(authContext: WorkspaceAuthContext) {
     await this.throttleApiKeyQueryExecution(authContext);
     await this.throttleApplicationQueryExecution(authContext);

--- a/packages/twenty-server/src/engine/api/common/common-query-runners/common-find-duplicates-query-runner.service.ts
+++ b/packages/twenty-server/src/engine/api/common/common-query-runners/common-find-duplicates-query-runner.service.ts
@@ -170,6 +170,7 @@ export class CommonFindDuplicatesQueryRunnerService extends CommonBaseQueryRunne
         workspaceDataSource,
         rolePermissionConfig,
         selectedFields: args.selectedFieldsResult.select,
+        ...this.getNestedRelationsReadPathOptions(queryRunnerContext),
       });
     }
 

--- a/packages/twenty-server/src/engine/api/common/common-query-runners/common-find-many-query-runner.service.ts
+++ b/packages/twenty-server/src/engine/api/common/common-query-runners/common-find-many-query-runner.service.ts
@@ -241,6 +241,7 @@ export class CommonFindManyQueryRunnerService extends CommonBaseQueryRunnerServi
         workspaceDataSource,
         rolePermissionConfig,
         selectedFields: args.selectedFieldsResult.select,
+        ...this.getNestedRelationsReadPathOptions(queryRunnerContext),
       });
     }
 

--- a/packages/twenty-server/src/engine/api/common/common-query-runners/common-find-one-query-runner.service.ts
+++ b/packages/twenty-server/src/engine/api/common/common-query-runners/common-find-one-query-runner.service.ts
@@ -107,6 +107,7 @@ export class CommonFindOneQueryRunnerService extends CommonBaseQueryRunnerServic
         workspaceDataSource,
         rolePermissionConfig,
         selectedFields: args.selectedFieldsResult.select,
+        ...this.getNestedRelationsReadPathOptions(queryRunnerContext),
       });
     }
 

--- a/packages/twenty-server/src/engine/api/common/common-query-runners/common-group-by-query-runner.service.ts
+++ b/packages/twenty-server/src/engine/api/common/common-query-runners/common-group-by-query-runner.service.ts
@@ -172,6 +172,8 @@ export class CommonGroupByQueryRunnerService extends CommonBaseQueryRunnerServic
           orderByForRecords: args.orderByForRecords ?? [],
           groupLimit: args.limit,
           offsetForRecords: args.offsetForRecords,
+          nestedRelationsReadPathOptions:
+            this.getNestedRelationsReadPathOptions(queryRunnerContext),
         });
       }
 

--- a/packages/twenty-server/src/engine/api/common/core-common-api.module.ts
+++ b/packages/twenty-server/src/engine/api/common/core-common-api.module.ts
@@ -4,6 +4,7 @@ import { TypeOrmModule } from '@nestjs/typeorm';
 import { CommonArgsProcessors } from 'src/engine/api/common/common-args-processors/common-args-processors';
 import { GroupByArgProcessorService } from 'src/engine/api/common/common-args-processors/group-by-arg-processor/group-by-arg-processor.service';
 import { ProcessNestedRelationsV2Helper } from 'src/engine/api/common/common-nested-relations-processor/process-nested-relations-v2.helper';
+import { ProcessNestedRelationsOrmV2Helper } from 'src/engine/api/common/common-nested-relations-processor/process-nested-relations-orm-v2.helper';
 import { ProcessNestedRelationsHelper } from 'src/engine/api/common/common-nested-relations-processor/process-nested-relations.helper';
 import { CommonQueryRunners } from 'src/engine/api/common/common-query-runners/common-query-runners';
 import { CommonResultGettersService } from 'src/engine/api/common/common-result-getters/common-result-getters.service';
@@ -53,6 +54,7 @@ import { WorkspaceCacheModule } from 'src/engine/workspace-cache/workspace-cache
   providers: [
     ProcessNestedRelationsHelper,
     ProcessNestedRelationsV2Helper,
+    ProcessNestedRelationsOrmV2Helper,
     ...CommonArgsProcessors,
     ProcessAggregateHelper,
     ...CommonQueryRunners,

--- a/packages/twenty-server/src/engine/api/graphql/graphql-query-runner/graphql-query-runner.module.ts
+++ b/packages/twenty-server/src/engine/api/graphql/graphql-query-runner/graphql-query-runner.module.ts
@@ -2,6 +2,8 @@ import { Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
 
 import { ProcessNestedRelationsV2Helper } from 'src/engine/api/common/common-nested-relations-processor/process-nested-relations-v2.helper';
+import { ProcessNestedRelationsOrmV2Helper } from 'src/engine/api/common/common-nested-relations-processor/process-nested-relations-orm-v2.helper';
+import { TwentyORMV2Module } from 'src/engine/twenty-orm-v2/twenty-orm-v2.module';
 import { ProcessNestedRelationsHelper } from 'src/engine/api/common/common-nested-relations-processor/process-nested-relations.helper';
 import { ProcessAggregateHelper } from 'src/engine/api/graphql/graphql-query-runner/helpers/process-aggregate.helper';
 import { WorkspaceQueryHookModule } from 'src/engine/api/graphql/workspace-query-runner/workspace-query-hook/workspace-query-hook.module';
@@ -16,6 +18,7 @@ import { ViewModule } from 'src/engine/metadata-modules/view/view.module';
 
 @Module({
   imports: [
+    TwentyORMV2Module,
     WorkspaceQueryHookModule,
     WorkspaceQueryRunnerModule,
     PermissionsModule,
@@ -29,6 +32,7 @@ import { ViewModule } from 'src/engine/metadata-modules/view/view.module';
   providers: [
     ProcessNestedRelationsHelper,
     ProcessNestedRelationsV2Helper,
+    ProcessNestedRelationsOrmV2Helper,
     ProcessAggregateHelper,
   ],
 })

--- a/packages/twenty-server/src/engine/api/graphql/graphql-query-runner/group-by/services/group-by-with-records-v2.service.ts
+++ b/packages/twenty-server/src/engine/api/graphql/graphql-query-runner/group-by/services/group-by-with-records-v2.service.ts
@@ -124,6 +124,8 @@ export class GroupByWithRecordsV2Service {
         workspaceDataSource,
         rolePermissionConfig,
         selectedFields: selectedFieldsResult.select,
+        isOrmV2ReadPathEnabled: true,
+        useReplica: true,
       });
     }
 

--- a/packages/twenty-server/src/engine/api/graphql/graphql-query-runner/group-by/services/group-by-with-records-v2.service.ts
+++ b/packages/twenty-server/src/engine/api/graphql/graphql-query-runner/group-by/services/group-by-with-records-v2.service.ts
@@ -49,6 +49,7 @@ export class GroupByWithRecordsV2Service {
     orderByForRecords,
     groupLimit,
     offsetForRecords,
+    nestedRelationsReadPathOptions,
   }: {
     queryBuilderWithGroupBy: WorkspaceSelectQueryBuilderV2;
     queryBuilderWithFiltersAndWithoutGroupBy: WorkspaceSelectQueryBuilderV2;
@@ -59,6 +60,10 @@ export class GroupByWithRecordsV2Service {
     orderByForRecords: ObjectRecordOrderBy;
     groupLimit?: number;
     offsetForRecords?: number;
+    nestedRelationsReadPathOptions: {
+      isOrmV2ReadPathEnabled: boolean;
+      useReplica: boolean;
+    };
   }): Promise<CommonGroupByOutputItem[]> {
     const effectiveGroupLimit = getGroupLimit(groupLimit);
 
@@ -124,8 +129,7 @@ export class GroupByWithRecordsV2Service {
         workspaceDataSource,
         rolePermissionConfig,
         selectedFields: selectedFieldsResult.select,
-        isOrmV2ReadPathEnabled: true,
-        useReplica: true,
+        ...nestedRelationsReadPathOptions,
       });
     }
 

--- a/packages/twenty-server/src/engine/subscriptions/subscriptions.module.ts
+++ b/packages/twenty-server/src/engine/subscriptions/subscriptions.module.ts
@@ -2,6 +2,8 @@ import { Global, Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
 
 import { ProcessNestedRelationsV2Helper } from 'src/engine/api/common/common-nested-relations-processor/process-nested-relations-v2.helper';
+import { ProcessNestedRelationsOrmV2Helper } from 'src/engine/api/common/common-nested-relations-processor/process-nested-relations-orm-v2.helper';
+import { TwentyORMV2Module } from 'src/engine/twenty-orm-v2/twenty-orm-v2.module';
 import { ProcessNestedRelationsHelper } from 'src/engine/api/common/common-nested-relations-processor/process-nested-relations.helper';
 import { CommonSelectFieldsHelper } from 'src/engine/api/common/common-select-fields/common-select-fields-helper';
 import { CacheLockModule } from 'src/engine/core-modules/cache-lock/cache-lock.module';
@@ -25,6 +27,7 @@ import { WorkspaceCacheModule } from 'src/engine/workspace-cache/workspace-cache
 @Global()
 @Module({
   imports: [
+    TwentyORMV2Module,
     RedisClientModule,
     CacheStorageModule,
     CacheLockModule,
@@ -46,6 +49,7 @@ import { WorkspaceCacheModule } from 'src/engine/workspace-cache/workspace-cache
     WorkspaceEventBroadcaster,
     ProcessNestedRelationsHelper,
     ProcessNestedRelationsV2Helper,
+    ProcessNestedRelationsOrmV2Helper,
     CommonSelectFieldsHelper,
   ],
   exports: [

--- a/packages/twenty-server/src/engine/twenty-orm-v2/README.md
+++ b/packages/twenty-server/src/engine/twenty-orm-v2/README.md
@@ -106,6 +106,12 @@ Wired into `CommonFindManyQueryRunnerService`, `CommonFindOneQueryRunnerService`
 `CommonFindDuplicatesQueryRunnerService` and `CommonGroupByQueryRunnerService`. Other
 runners keep `repository`.
 
+Nested relation loading also routes through v2 under the flag:
+`ProcessNestedRelationsOrmV2Helper` loads relations and relation aggregates on v2
+repositories, and composes the per-parent-limit `CROSS JOIN LATERAL` as raw SQL run
+through `repository.executeRaw`. The shared `ProcessNestedRelationsHelper` flag-branches
+to it, so a flagged read now reads root rows and their relations through v2.
+
 group-by "with records" is the one path that is not a transparent swap: it wraps a
 builder subquery in a table-less `FROM (subquery)` JSON_AGG query, which the
 table-shape builder cannot represent. `GroupByWithRecordsV2Service` builds the inner
@@ -118,9 +124,6 @@ subquery with the v2 builder and runs the composed outer query through
   where `EntityMetadata` is genuinely used (column list, `RETURNING` mapping, `updatedAt`
   maintenance). Removing it from reads shrinks what the metadata cache is used for; it
   does not delete the cache.
-- Relation loading. `ProcessNestedRelationsV2Helper` still runs on v1 repositories, so a
-  flagged findMany selecting relations reads its root rows through v2 and its relations
-  through v1.
 - `find` / `findOne` / `findBy` and the rest of the repository surface used by
   `src/modules`.
 - Transactions and DDL.


### PR DESCRIPTION
Follow-up to the read-runner migrations. Routes **nested relation loading** through the
ORM v2 read path, so a flagged read now reads both its root rows and their relations
through v2 (previously root=v2 but relations=v1, a mixed path).

Adds `ProcessNestedRelationsOrmV2Helper`, a parallel to the existing v1 helper:
- To-one / to-many loading and relation aggregates use the shared v2 builder surface
  (`setFindOptions`, `where(:...ids)`, `take`, `getMany`, `clone`, `addSelect`,
  `groupBy`, `getRawMany`) on v2 repositories.
- The per-parent-limit path (`CROSS JOIN LATERAL` wrapped in a table-less
  `FROM (subquery)`) is composed as raw SQL and run through `repository.executeRaw`
  with the builder's RLS-applied subquery, since the table-shape builder cannot model a
  table-less FROM.

The shared `ProcessNestedRelationsHelper` flag-branches to it (v1 helper untouched for
flag-off). Callers (findMany / findOne / findDuplicates runners, groupBy with-records)
pass `isOrmV2ReadPathEnabled` + `useReplica` via a small base-runner helper.

Behind `IS_ORM_V2_READ_PATH_ENABLED`. Flag off, nothing changes.

## Verification

- Ran the relation-loading integration suites (nested-relation, per-parent-limit +RLS,
  soft-deleted-relation, relation-join-rls, all-people-resolvers) locally **both flag
  states: 45/45 each** — including the lateral per-parent-limit path, RLS, soft-delete,
  and to-one/to-many. typecheck / oxlint / oxfmt clean.
- These suites are already in `ORM_V2_TEST_PATH_PATTERN`, so the flagged CI shard now
  exercises v2 relation loading (no pattern change needed).

Note: `order-by-relation-field`'s case-insensitive assertions were flaky in my local
test DB (they fail identically on `origin/main` with the flag off, i.e. pre-existing /
DB-state sensitive, not from this change); CI's per-shard fresh DB is the source of
truth there.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/24101?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

