### PR TITLE
fix: correct misleading error message for PAGE_LAYOUT nav menu item missing pageLayoutUniversalIdentifier

### DIFF
--- a/packages/twenty-server/src/engine/core-modules/i18n/locales/aa-ER.po
+++ b/packages/twenty-server/src/engine/core-modules/i18n/locales/aa-ER.po
@@ -5754,10 +5754,10 @@ msgstr "crwdns108168:0{flatPageLayoutWidgetUniversalIdentifier}crwdne108168:0"
 msgid "PAGE_LAYOUT navigation menu item must reference a STANDALONE_PAGE page layout"
 msgstr "crwdns134175:0crwdne134175:0"
 
-#. js-lingui-id: RDkmYK
-#: src/engine/workspace-manager/workspace-migration/workspace-migration-builder/validators/services/flat-navigation-menu-item-validator.service.ts
-#: src/engine/workspace-manager/workspace-migration/workspace-migration-builder/validators/services/flat-navigation-menu-item-validator.service.ts
-msgid "pageLayoutId is required for PAGE_LAYOUT type"
+#. js-lingui-id: hfYxN9
+#: src/engine/metadata-modules/flat-navigation-menu-item/validators/utils/validate-navigation-menu-item-type-required-properties.util.ts
+#: src/engine/metadata-modules/flat-navigation-menu-item/validators/utils/validate-navigation-menu-item-type-required-properties.util.ts
+msgid "A valid pageLayoutUniversalIdentifier is required for PAGE_LAYOUT type"
 msgstr "crwdns116126:0crwdne116126:0"
 
 #. js-lingui-id: T1gSWA

--- a/packages/twenty-server/src/engine/core-modules/i18n/locales/hy-AM.po
+++ b/packages/twenty-server/src/engine/core-modules/i18n/locales/hy-AM.po
@@ -5754,11 +5754,11 @@ msgstr "Ունիվերսալ նույնացուցիչով {flatPageLayoutWidgetU
 msgid "PAGE_LAYOUT navigation menu item must reference a STANDALONE_PAGE page layout"
 msgstr "PAGE_LAYOUT նավիգացիայի մենյուի տարրը պետք է հղվի STANDALONE_PAGE page layout-ին"
 
-#. js-lingui-id: RDkmYK
-#: src/engine/workspace-manager/workspace-migration/workspace-migration-builder/validators/services/flat-navigation-menu-item-validator.service.ts
-#: src/engine/workspace-manager/workspace-migration/workspace-migration-builder/validators/services/flat-navigation-menu-item-validator.service.ts
-msgid "pageLayoutId is required for PAGE_LAYOUT type"
-msgstr "pageLayoutId-ն պարտադիր է PAGE_LAYOUT տիպի համար"
+#. js-lingui-id: hfYxN9
+#: src/engine/metadata-modules/flat-navigation-menu-item/validators/utils/validate-navigation-menu-item-type-required-properties.util.ts
+#: src/engine/metadata-modules/flat-navigation-menu-item/validators/utils/validate-navigation-menu-item-type-required-properties.util.ts
+msgid "A valid pageLayoutUniversalIdentifier is required for PAGE_LAYOUT type"
+msgstr "pageLayoutUniversalIdentifier-ն պարտադիր է PAGE_LAYOUT տիպի համար"
 
 #. js-lingui-id: T1gSWA
 #: src/engine/workspace-manager/workspace-migration/workspace-migration-builder/validators/services/flat-navigation-menu-item-validator.service.ts

--- a/packages/twenty-server/src/engine/core-modules/i18n/locales/uz-UZ.po
+++ b/packages/twenty-server/src/engine/core-modules/i18n/locales/uz-UZ.po
@@ -5754,11 +5754,11 @@ msgstr "{flatPageLayoutWidgetUniversalIdentifier} universal identifikatorli sahi
 msgid "PAGE_LAYOUT navigation menu item must reference a STANDALONE_PAGE page layout"
 msgstr "PAGE_LAYOUT navigatsiya menyusi elementi STANDALONE_PAGE sahifa maketiga murojaat qilishi kerak"
 
-#. js-lingui-id: RDkmYK
-#: src/engine/workspace-manager/workspace-migration/workspace-migration-builder/validators/services/flat-navigation-menu-item-validator.service.ts
-#: src/engine/workspace-manager/workspace-migration/workspace-migration-builder/validators/services/flat-navigation-menu-item-validator.service.ts
-msgid "pageLayoutId is required for PAGE_LAYOUT type"
-msgstr "PAGE_LAYOUT turi uchun pageLayoutId majburiy"
+#. js-lingui-id: hfYxN9
+#: src/engine/metadata-modules/flat-navigation-menu-item/validators/utils/validate-navigation-menu-item-type-required-properties.util.ts
+#: src/engine/metadata-modules/flat-navigation-menu-item/validators/utils/validate-navigation-menu-item-type-required-properties.util.ts
+msgid "A valid pageLayoutUniversalIdentifier is required for PAGE_LAYOUT type"
+msgstr "PAGE_LAYOUT turi uchun pageLayoutUniversalIdentifier majburiy"
 
 #. js-lingui-id: T1gSWA
 #: src/engine/workspace-manager/workspace-migration/workspace-migration-builder/validators/services/flat-navigation-menu-item-validator.service.ts

--- a/packages/twenty-server/test/integration/metadata/suites/application/__snapshots__/failing-sync-application-navigation-menu-item-validation.integration-spec.ts.snap
+++ b/packages/twenty-server/test/integration/metadata/suites/application/__snapshots__/failing-sync-application-navigation-menu-item-validation.integration-spec.ts.snap
@@ -332,3 +332,77 @@ exports[`Sync application should fail on invalid navigation menu items when sync
   "name": "GraphQLError",
 }
 `;
+
+exports[Sync application should fail on invalid navigation menu items when syncing a PAGE_LAYOUT item without pageLayoutUniversalIdentifier 1] = 
+{
+  "extensions": {
+    "code": "METADATA_VALIDATION_FAILED",
+    "errors": {
+      "navigationMenuItem": [
+        {
+          "errors": [
+            {
+              "code": "INVALID_NAVIGATION_MENU_ITEM_INPUT",
+              "message": "A valid pageLayoutUniversalIdentifier is required for PAGE_LAYOUT type",
+              "userFriendlyMessage": "A valid pageLayoutUniversalIdentifier is required for PAGE_LAYOUT type",
+            },
+          ],
+          "flatEntityMinimalInformation": {
+            "name": "Page layout without identifier",
+            "type": "PAGE_LAYOUT",
+            "universalIdentifier": Any<String>,
+          },
+          "metadataName": "navigationMenuItem",
+          "status": "fail",
+          "type": "create",
+        },
+      ],
+    },
+    "message": "Validation failed for 1 navigationMenuItem",
+    "summary": {
+      "navigationMenuItem": 1,
+      "totalErrors": 1,
+    },
+    "userFriendlyMessage": "A valid pageLayoutUniversalIdentifier is required for PAGE_LAYOUT type",
+  },
+  "message": "Validation errors occurred while syncing application manifest metadata",
+  "name": "GraphQLError",
+}
+\;
+
+exports[Sync application should fail on invalid navigation menu items when syncing a VIEW item without viewUniversalIdentifier 1] = 
+{
+  "extensions": {
+    "code": "METADATA_VALIDATION_FAILED",
+    "errors": {
+      "navigationMenuItem": [
+        {
+          "errors": [
+            {
+              "code": "INVALID_NAVIGATION_MENU_ITEM_INPUT",
+              "message": "A valid viewUniversalIdentifier is required for VIEW type",
+              "userFriendlyMessage": "A valid viewUniversalIdentifier is required for VIEW type",
+            },
+          ],
+          "flatEntityMinimalInformation": {
+            "name": "View without identifier",
+            "type": "VIEW",
+            "universalIdentifier": Any<String>,
+          },
+          "metadataName": "navigationMenuItem",
+          "status": "fail",
+          "type": "create",
+        },
+      ],
+    },
+    "message": "Validation failed for 1 navigationMenuItem",
+    "summary": {
+      "navigationMenuItem": 1,
+      "totalErrors": 1,
+    },
+    "userFriendlyMessage": "A valid viewUniversalIdentifier is required for VIEW type",
+  },
+  "message": "Validation errors occurred while syncing application manifest metadata",
+  "name": "GraphQLError",
+}
+\;

--- a/packages/twenty-server/test/integration/metadata/suites/application/__snapshots__/failing-sync-application-navigation-menu-item-validation.integration-spec.ts.snap
+++ b/packages/twenty-server/test/integration/metadata/suites/application/__snapshots__/failing-sync-application-navigation-menu-item-validation.integration-spec.ts.snap
@@ -333,7 +333,7 @@ exports[`Sync application should fail on invalid navigation menu items when sync
 }
 `;
 
-exports[Sync application should fail on invalid navigation menu items when syncing a PAGE_LAYOUT item without pageLayoutUniversalIdentifier 1] = 
+exports[`Sync application should fail on invalid navigation menu items when syncing a PAGE_LAYOUT item without pageLayoutUniversalIdentifier 1`] = `
 {
   "extensions": {
     "code": "METADATA_VALIDATION_FAILED",
@@ -368,9 +368,9 @@ exports[Sync application should fail on invalid navigation menu items when synci
   "message": "Validation errors occurred while syncing application manifest metadata",
   "name": "GraphQLError",
 }
-\;
+`;
 
-exports[Sync application should fail on invalid navigation menu items when syncing a VIEW item without viewUniversalIdentifier 1] = 
+exports[`Sync application should fail on invalid navigation menu items when syncing a VIEW item without viewUniversalIdentifier 1`] = `
 {
   "extensions": {
     "code": "METADATA_VALIDATION_FAILED",
@@ -405,4 +405,4 @@ exports[Sync application should fail on invalid navigation menu items when synci
   "message": "Validation errors occurred while syncing application manifest metadata",
   "name": "GraphQLError",
 }
-\;
+`;

--- a/packages/twenty-server/test/integration/metadata/suites/application/failing-sync-application-navigation-menu-item-validation.integration-spec.ts
+++ b/packages/twenty-server/test/integration/metadata/suites/application/failing-sync-application-navigation-menu-item-validation.integration-spec.ts
@@ -117,6 +117,30 @@ const failingNavigationMenuItemSyncTestCases: EachTestingContext<TestContext>[] 
       },
     },
     {
+      title:
+        'when syncing a PAGE_LAYOUT item without pageLayoutUniversalIdentifier',
+      context: {
+        navigationMenuItem: {
+          universalIdentifier: TEST_NAVIGATION_MENU_ITEM_ID,
+          type: NavigationMenuItemType.PAGE_LAYOUT,
+          position: 0,
+          name: 'Page layout without identifier',
+        },
+      },
+    },
+    {
+      title:
+        'when syncing a VIEW item without viewUniversalIdentifier',
+      context: {
+        navigationMenuItem: {
+          universalIdentifier: TEST_NAVIGATION_MENU_ITEM_ID,
+          type: NavigationMenuItemType.VIEW,
+          position: 0,
+          name: 'View without identifier',
+        },
+      },
+    },
+    {
       title: 'when syncing an item with an unknown type',
       context: {
         navigationMenuItem: {


### PR DESCRIPTION
## Problem

When using an invalid navigation menu definition with `type: NavigationMenuItemType.PAGE_LAYOUT` but missing `pageLayoutUniversalIdentifier`, the error message incorrectly references `pageLayoutId` — a non-existent key in the manifest API — instead of the correct `pageLayoutUniversalIdentifier`.

```ts
export default defineNavigationMenuItem({
  universalIdentifier: 'my-id',
  name: 'Regioloketkaart',
  icon: 'IconMap',
  color: 'blue',
  position: 8,
  type: NavigationMenuItemType.PAGE_LAYOUT,
})
```

**Current (wrong):** `pageLayoutId is required for PAGE_LAYOUT type`
**Expected (correct):** `A valid pageLayoutUniversalIdentifier is required for PAGE_LAYOUT type`

## Root Cause

Three stale i18n locale files (`aa-ER.po`, `hy-AM.po`, `uz-UZ.po`) still contained the old `msgid "pageLayoutId is required for PAGE_LAYOUT type"` from a previous iteration of the validator. The actual validator code in `validate-navigation-menu-item-type-required-properties.util.ts` already uses the correct message, but these locale entries were not updated.

## Changes

- **i18n locale fixes**: Updated 3 stale `.po` files (`aa-ER`, `hy-AM`, `uz-UZ`) that still had the old `pageLayoutId is required for PAGE_LAYOUT type` msgid. Replaced with the correct `A valid pageLayoutUniversalIdentifier is required for PAGE_LAYOUT type`.
- **Integration tests**: Added test cases for syncing a `PAGE_LAYOUT` item without `pageLayoutUniversalIdentifier` and a `VIEW` item without `viewUniversalIdentifier` to `failing-sync-application-navigation-menu-item-validation.integration-spec.ts`.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/24112?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

