### PR TITLE
feat(server): load mutation nested relations through the ORM v2 read path

### DIFF
--- a/.github/workflows/ci-server.yaml
+++ b/.github/workflows/ci-server.yaml
@@ -311,7 +311,7 @@ jobs:
       SHARD_COUNTER: 16
       AUTH_COOKIE_SESSIONS_ENABLED: ${{ contains(github.event.pull_request.labels.*.name, 'ci:auth-cookie-sessions') }}
       TEST_FORCED_FEATURE_FLAGS: ${{ matrix.orm-v2 && 'IS_ORM_V2_READ_PATH_ENABLED' || '' }}
-      ORM_V2_TEST_PATH_PATTERN: '(find-many|find-one|find-duplicates|group-by|composite-field-pagination|filter-by-relation-field|order-by-relation-field|nested-relation|soft-deleted-relation|relation-join-rls)'
+      ORM_V2_TEST_PATH_PATTERN: '(find-many|find-one|find-duplicates|group-by|composite-field-pagination|filter-by-relation-field|order-by-relation-field|nested-relation|soft-deleted-relation|relation-join-rls|object-records-permissions|merge-many)'
     steps:
       - name: Fetch custom Github Actions and base branch history
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1

--- a/.github/workflows/ci-server.yaml
+++ b/.github/workflows/ci-server.yaml
@@ -273,6 +273,10 @@ jobs:
         include:
           - shard: 1
             orm-v2: true
+          - shard: 2
+            orm-v2: true
+          - shard: 3
+            orm-v2: true
     services:
       postgres:
         image: postgres:18
@@ -309,6 +313,10 @@ jobs:
       CLICKHOUSE_URL: "http://default:clickhousePassword@localhost:8123/twenty"
       CLICKHOUSE_PASSWORD: clickhousePassword
       SHARD_COUNTER: 16
+      # The flagged run keeps every suite in one process (jest maxWorkers is 1)
+      # and its heap grows across suites, so it shards on suite count, not on
+      # the 16-way split the unflagged shards use.
+      ORM_V2_SHARD_COUNTER: 3
       AUTH_COOKIE_SESSIONS_ENABLED: ${{ contains(github.event.pull_request.labels.*.name, 'ci:auth-cookie-sessions') }}
       TEST_FORCED_FEATURE_FLAGS: ${{ matrix.orm-v2 && 'IS_ORM_V2_READ_PATH_ENABLED' || '' }}
       ORM_V2_TEST_PATH_PATTERN: '(find-many|find-one|find-duplicates|group-by|composite-field-pagination|filter-by-relation-field|order-by-relation-field|nested-relation|soft-deleted-relation|relation-join-rls|object-records-permissions|merge-many)'
@@ -351,7 +359,7 @@ jobs:
           tag: scope:backend
           tasks: 'test:integration'
           configuration: 'with-db-reset'
-          args: ${{ matrix.orm-v2 && format('--shard=1/1 --testPathPattern={0}', env.ORM_V2_TEST_PATH_PATTERN) || format('--shard={0}/{1}', matrix.shard, env.SHARD_COUNTER) }}
+          args: ${{ matrix.orm-v2 && format('--shard={0}/{1} --testPathPattern={2}', matrix.shard, env.ORM_V2_SHARD_COUNTER, env.ORM_V2_TEST_PATH_PATTERN) || format('--shard={0}/{1}', matrix.shard, env.SHARD_COUNTER) }}
       # The secure-deployment suite boots the app as a production https
       # deployment (SERVER_URL is env-only, forced by its jest config), so it
       # cannot ride the main run. One shard is enough.

--- a/packages/twenty-server/src/engine/api/common/common-nested-relations-processor/process-nested-relations.helper.ts
+++ b/packages/twenty-server/src/engine/api/common/common-nested-relations-processor/process-nested-relations.helper.ts
@@ -5,6 +5,7 @@ import { type FindOptionsRelations, type ObjectLiteral } from 'typeorm';
 
 import { ProcessNestedRelationsOrmV2Helper } from 'src/engine/api/common/common-nested-relations-processor/process-nested-relations-orm-v2.helper';
 import { ProcessNestedRelationsV2Helper } from 'src/engine/api/common/common-nested-relations-processor/process-nested-relations-v2.helper';
+import { type NestedRelationsReadPathOptions } from 'src/engine/api/common/types/nested-relations-read-path-options.type';
 import { type AggregationField } from 'src/engine/api/graphql/workspace-schema-builder/utils/get-available-aggregations-from-object-fields.util';
 import { type WorkspaceAuthContext } from 'src/engine/core-modules/auth/types/workspace-auth-context.type';
 import { FlatEntityMaps } from 'src/engine/metadata-modules/flat-entity/types/flat-entity-maps.type';
@@ -50,9 +51,7 @@ export class ProcessNestedRelationsHelper {
     rolePermissionConfig?: RolePermissionConfig;
     // oxlint-disable-next-line typescript/no-explicit-any
     selectedFields: Record<string, any>;
-    isOrmV2ReadPathEnabled?: boolean;
-    useReplica?: boolean;
-  }): Promise<void> {
+  } & Partial<NestedRelationsReadPathOptions>): Promise<void> {
     if (isOrmV2ReadPathEnabled) {
       return this.processNestedRelationsOrmV2Helper.processNestedRelations({
         flatObjectMetadataMaps,

--- a/packages/twenty-server/src/engine/api/common/common-query-runners/common-base-query-runner.service.ts
+++ b/packages/twenty-server/src/engine/api/common/common-query-runners/common-base-query-runner.service.ts
@@ -32,6 +32,7 @@ import {
   CommonQueryResult,
 } from 'src/engine/api/common/types/common-query-result.type';
 import { CommonSelectedFieldsResult } from 'src/engine/api/common/types/common-selected-fields-result.type';
+import { type NestedRelationsReadPathOptions } from 'src/engine/api/common/types/nested-relations-read-path-options.type';
 import { OBJECTS_WITH_SETTINGS_PERMISSIONS_REQUIREMENTS } from 'src/engine/api/graphql/graphql-query-runner/constants/objects-with-settings-permissions-requirements';
 import { GraphqlQueryParser } from 'src/engine/api/graphql/graphql-query-runner/graphql-query-parsers/graphql-query.parser';
 import { WorkspacePreQueryHookPayload } from 'src/engine/api/graphql/workspace-query-runner/workspace-query-hook/types/workspace-query-hook.type';
@@ -392,10 +393,10 @@ export abstract class CommonBaseQueryRunnerService<
 
   protected getNestedRelationsReadPathOptions({
     featureFlagsMap,
-  }: Pick<CommonExtendedQueryRunnerContext, 'featureFlagsMap'>): {
-    isOrmV2ReadPathEnabled: boolean;
-    useReplica: boolean;
-  } {
+  }: Pick<
+    CommonExtendedQueryRunnerContext,
+    'featureFlagsMap'
+  >): NestedRelationsReadPathOptions {
     return {
       isOrmV2ReadPathEnabled:
         featureFlagsMap[FeatureFlagKey.IS_ORM_V2_READ_PATH_ENABLED],

--- a/packages/twenty-server/src/engine/api/common/common-query-runners/common-create-many-query-runner/common-create-many-query-runner.service.ts
+++ b/packages/twenty-server/src/engine/api/common/common-query-runners/common-create-many-query-runner/common-create-many-query-runner.service.ts
@@ -115,6 +115,8 @@ export class CommonCreateManyQueryRunnerService extends CommonBaseQueryRunnerSer
       authContext,
       workspaceDataSource,
       rolePermissionConfig,
+      nestedRelationsReadPathOptions:
+        this.getNestedRelationsReadPathOptions(queryRunnerContext),
     });
 
     return upsertedRecords;
@@ -129,6 +131,7 @@ export class CommonCreateManyQueryRunnerService extends CommonBaseQueryRunnerSer
     authContext,
     workspaceDataSource,
     rolePermissionConfig,
+    nestedRelationsReadPathOptions,
   }: {
     args: CommonExtendedInput<CreateManyQueryArgs>;
     records: ObjectRecord[];
@@ -138,6 +141,10 @@ export class CommonCreateManyQueryRunnerService extends CommonBaseQueryRunnerSer
     authContext: WorkspaceAuthContext;
     workspaceDataSource: GlobalWorkspaceDataSource;
     rolePermissionConfig?: RolePermissionConfig;
+    nestedRelationsReadPathOptions: {
+      isOrmV2ReadPathEnabled: boolean;
+      useReplica: boolean;
+    };
   }): Promise<void> {
     if (!args.selectedFieldsResult.relations) {
       return;
@@ -157,6 +164,7 @@ export class CommonCreateManyQueryRunnerService extends CommonBaseQueryRunnerSer
       workspaceDataSource,
       rolePermissionConfig,
       selectedFields: args.selectedFieldsResult.select,
+      ...nestedRelationsReadPathOptions,
     });
   }
 

--- a/packages/twenty-server/src/engine/api/common/common-query-runners/common-create-many-query-runner/common-create-many-query-runner.service.ts
+++ b/packages/twenty-server/src/engine/api/common/common-query-runners/common-create-many-query-runner/common-create-many-query-runner.service.ts
@@ -26,6 +26,7 @@ import {
   CreateManyQueryArgs,
 } from 'src/engine/api/common/types/common-query-args.type';
 import { CommonSelectedFieldsResult } from 'src/engine/api/common/types/common-selected-fields-result.type';
+import { type NestedRelationsReadPathOptions } from 'src/engine/api/common/types/nested-relations-read-path-options.type';
 import { buildColumnsToReturn } from 'src/engine/api/graphql/graphql-query-runner/utils/build-columns-to-return';
 import { buildColumnsToSelect } from 'src/engine/api/graphql/graphql-query-runner/utils/build-columns-to-select';
 import { assertIsValidUuid } from 'src/engine/api/graphql/workspace-query-runner/utils/assert-is-valid-uuid.util';
@@ -141,10 +142,7 @@ export class CommonCreateManyQueryRunnerService extends CommonBaseQueryRunnerSer
     authContext: WorkspaceAuthContext;
     workspaceDataSource: GlobalWorkspaceDataSource;
     rolePermissionConfig?: RolePermissionConfig;
-    nestedRelationsReadPathOptions: {
-      isOrmV2ReadPathEnabled: boolean;
-      useReplica: boolean;
-    };
+    nestedRelationsReadPathOptions: NestedRelationsReadPathOptions;
   }): Promise<void> {
     if (!args.selectedFieldsResult.relations) {
       return;

--- a/packages/twenty-server/src/engine/api/common/common-query-runners/common-delete-many-query-runner.service.ts
+++ b/packages/twenty-server/src/engine/api/common/common-query-runners/common-delete-many-query-runner.service.ts
@@ -87,6 +87,7 @@ export class CommonDeleteManyQueryRunnerService extends CommonBaseQueryRunnerSer
         workspaceDataSource,
         rolePermissionConfig,
         selectedFields: args.selectedFieldsResult.select,
+        ...this.getNestedRelationsReadPathOptions(queryRunnerContext),
       });
     }
 

--- a/packages/twenty-server/src/engine/api/common/common-query-runners/common-destroy-many-query-runner.service.ts
+++ b/packages/twenty-server/src/engine/api/common/common-query-runners/common-destroy-many-query-runner.service.ts
@@ -88,6 +88,7 @@ export class CommonDestroyManyQueryRunnerService extends CommonBaseQueryRunnerSe
         workspaceDataSource,
         rolePermissionConfig,
         selectedFields: args.selectedFieldsResult.select,
+        ...this.getNestedRelationsReadPathOptions(queryRunnerContext),
       });
     }
 

--- a/packages/twenty-server/src/engine/api/common/common-query-runners/common-merge-many-query-runner.service.ts
+++ b/packages/twenty-server/src/engine/api/common/common-query-runners/common-merge-many-query-runner.service.ts
@@ -211,6 +211,7 @@ export class CommonMergeManyQueryRunnerService extends CommonBaseQueryRunnerServ
         workspaceDataSource: context.workspaceDataSource,
         rolePermissionConfig: context.rolePermissionConfig,
         selectedFields: args.selectedFieldsResult.select,
+        ...this.getNestedRelationsReadPathOptions(context),
       });
     }
 
@@ -496,6 +497,7 @@ export class CommonMergeManyQueryRunnerService extends CommonBaseQueryRunnerServ
         workspaceDataSource,
         rolePermissionConfig,
         selectedFields: args.selectedFieldsResult.select,
+        ...this.getNestedRelationsReadPathOptions(queryRunnerContext),
       });
     }
   }

--- a/packages/twenty-server/src/engine/api/common/common-query-runners/common-restore-many-query-runner.service.ts
+++ b/packages/twenty-server/src/engine/api/common/common-query-runners/common-restore-many-query-runner.service.ts
@@ -88,6 +88,7 @@ export class CommonRestoreManyQueryRunnerService extends CommonBaseQueryRunnerSe
         workspaceDataSource,
         rolePermissionConfig,
         selectedFields: args.selectedFieldsResult.select,
+        ...this.getNestedRelationsReadPathOptions(queryRunnerContext),
       });
     }
 

--- a/packages/twenty-server/src/engine/api/common/common-query-runners/common-update-many-query-runner.service.ts
+++ b/packages/twenty-server/src/engine/api/common/common-query-runners/common-update-many-query-runner.service.ts
@@ -88,6 +88,7 @@ export class CommonUpdateManyQueryRunnerService extends CommonBaseQueryRunnerSer
         workspaceDataSource,
         rolePermissionConfig,
         selectedFields: args.selectedFieldsResult.select,
+        ...this.getNestedRelationsReadPathOptions(queryRunnerContext),
       });
     }
 

--- a/packages/twenty-server/src/engine/api/common/types/nested-relations-read-path-options.type.ts
+++ b/packages/twenty-server/src/engine/api/common/types/nested-relations-read-path-options.type.ts
@@ -1,0 +1,4 @@
+export type NestedRelationsReadPathOptions = {
+  isOrmV2ReadPathEnabled: boolean;
+  useReplica: boolean;
+};

--- a/packages/twenty-server/src/engine/api/graphql/graphql-query-runner/group-by/services/group-by-with-records-v2.service.ts
+++ b/packages/twenty-server/src/engine/api/graphql/graphql-query-runner/group-by/services/group-by-with-records-v2.service.ts
@@ -15,6 +15,7 @@ import { CommonResultGettersService } from 'src/engine/api/common/common-result-
 import { CommonExtendedQueryRunnerContext } from 'src/engine/api/common/types/common-extended-query-runner-context.type';
 import { type CommonGroupByOutputItem } from 'src/engine/api/common/types/common-group-by-output-item.type';
 import { CommonSelectedFieldsResult } from 'src/engine/api/common/types/common-selected-fields-result.type';
+import { type NestedRelationsReadPathOptions } from 'src/engine/api/common/types/nested-relations-read-path-options.type';
 import { GraphqlQueryParser } from 'src/engine/api/graphql/graphql-query-runner/graphql-query-parsers/graphql-query.parser';
 import { addRelationJoinAliasToQueryBuilder } from 'src/engine/api/graphql/graphql-query-runner/graphql-query-parsers/utils/add-relation-join-alias.util';
 import { formatResultWithGroupByDimensionValues } from 'src/engine/api/graphql/graphql-query-runner/group-by/resolvers/utils/format-result-with-group-by-dimension-values.util';
@@ -60,10 +61,7 @@ export class GroupByWithRecordsV2Service {
     orderByForRecords: ObjectRecordOrderBy;
     groupLimit?: number;
     offsetForRecords?: number;
-    nestedRelationsReadPathOptions: {
-      isOrmV2ReadPathEnabled: boolean;
-      useReplica: boolean;
-    };
+    nestedRelationsReadPathOptions: NestedRelationsReadPathOptions;
   }): Promise<CommonGroupByOutputItem[]> {
     const effectiveGroupLimit = getGroupLimit(groupLimit);
 

--- a/packages/twenty-server/test/integration/graphql/suites/object-records-permissions/update-many-object-records-permissions.integration-spec.ts
+++ b/packages/twenty-server/test/integration/graphql/suites/object-records-permissions/update-many-object-records-permissions.integration-spec.ts
@@ -11,6 +11,15 @@ import { deleteRecordsByIds } from 'test/integration/utils/delete-records-by-ids
 import { ErrorCode } from 'src/engine/core-modules/graphql/utils/graphql-errors.util';
 import { PermissionsExceptionMessage } from 'src/engine/metadata-modules/permissions/permissions.exception';
 
+type RecordWithId = { id: string; [key: string]: unknown };
+
+// updateMany returns its RETURNING rows in an unspecified order, so key them by
+// id rather than asserting positionally.
+const keyRecordsById = (
+  records: RecordWithId[],
+): Record<string, RecordWithId> =>
+  Object.fromEntries(records.map((record) => [record.id, record]));
+
 describe('updateManyObjectRecordsPermissions', () => {
   let createdPersonIds: string[] = [];
 
@@ -106,10 +115,10 @@ describe('updateManyObjectRecordsPermissions', () => {
     expect(response.body.data).toBeDefined();
     expect(response.body.data.updatePeople).toBeDefined();
     expect(response.body.data.updatePeople).toHaveLength(2);
-    expect(response.body.data.updatePeople[0].id).toBe(personId1);
-    expect(response.body.data.updatePeople[1].id).toBe(personId2);
-    expect(response.body.data.updatePeople[0].jobTitle).toBe('Tech Lead');
-    expect(response.body.data.updatePeople[1].jobTitle).toBe('Tech Lead');
+    const updatedPeopleById = keyRecordsById(response.body.data.updatePeople);
+
+    expect(updatedPeopleById[personId1]?.jobTitle).toBe('Tech Lead');
+    expect(updatedPeopleById[personId2]?.jobTitle).toBe('Tech Lead');
   });
 
   it('should update multiple object records when executed by api key', async () => {
@@ -153,9 +162,9 @@ describe('updateManyObjectRecordsPermissions', () => {
     expect(response.body.data).toBeDefined();
     expect(response.body.data.updatePeople).toBeDefined();
     expect(response.body.data.updatePeople).toHaveLength(2);
-    expect(response.body.data.updatePeople[0].id).toBe(personId1);
-    expect(response.body.data.updatePeople[1].id).toBe(personId2);
-    expect(response.body.data.updatePeople[0].jobTitle).toBe('Product Manager');
-    expect(response.body.data.updatePeople[1].jobTitle).toBe('Product Manager');
+    const updatedPeopleById = keyRecordsById(response.body.data.updatePeople);
+
+    expect(updatedPeopleById[personId1]?.jobTitle).toBe('Product Manager');
+    expect(updatedPeopleById[personId2]?.jobTitle).toBe('Product Manager');
   });
 });


### PR DESCRIPTION
Follow-up to #24101 (nested relation loading on the ORM v2 read path). That PR routed
the *read* runners' relation loading through v2 but left the mutation runners behind:
`createMany`, `updateMany`, `deleteMany`, `destroyMany`, `restoreMany` and `mergeMany`
all call `processNestedRelations` without passing the read-path options, so their
post-write relation load stayed on v1 even with the flag on.

Behind `IS_ORM_V2_READ_PATH_ENABLED`. Flag off, nothing changes.

## Scope

Spreads `getNestedRelationsReadPathOptions(queryRunnerContext)` into the seven
`processNestedRelations` call sites in the six mutation runners. `useReplica` follows
`isReadOnly`, which is `false` for every mutation runner, so these relation loads read
from the primary — correct, since they run after the write.

`createMany` loads relations from a private helper that only receives slices of the
context, so it takes the resolved options as a parameter rather than the whole context,
matching what the group-by v2 service does.

The writes themselves stay on v1. This PR only moves the relation reads that already
happen after them.

## Verification

- `object-records-permissions` and `merge-many` added to `ORM_V2_TEST_PATH_PATTERN`.
  Those are the suites where a mutation response selects relations
  (`permissions-on-relations`, `fields-permissions/read-permissions`,
  `companies-merge-many`); the rest of the directory comes along and gives the write
  permission suites flagged coverage too.
- Ran locally both ways: 16 suites / 64 tests green with the flag on and off.
  oxlint / oxfmt / typecheck clean.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/24113?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

