### PR TITLE
ci: unbreak CI E2E Main (same-origin front + fix the specs behind the login gate)

### DIFF
--- a/.github/workflows/ci-e2e-main.yaml
+++ b/.github/workflows/ci-e2e-main.yaml
@@ -98,17 +98,19 @@ jobs:
           PGPASSWORD=postgres psql -h localhost -p 5432 -U postgres -d postgres -c 'CREATE DATABASE "test";'
           npx nx run twenty-server:database:reset
 
+      # The server serves the front so the browser origin always matches the API
+      # origin, workspace subdomains included. Cookie sessions are credentialed
+      # and only the exact SERVER_URL / FRONTEND_URL origins are allowlisted, so
+      # a front served on its own port cannot authenticate. This is also how the
+      # twenty docker image ships the front.
+      - name: Serve the frontend from the server
+        run: cp -r packages/twenty-front/build packages/twenty-server/dist/front
+
       - name: Start server
         run: |
-          npx nx start twenty-server &
+          npx nx run twenty-server:start:ci &
           echo "Waiting for server to be ready..."
-          timeout 60 bash -c 'until curl -s http://localhost:3000/health; do sleep 2; done'
-
-      - name: Start frontend
-        run: |
-          npm_config_yes=true npx serve -s packages/twenty-front/build -l 3001 &
-          echo "Waiting for frontend to be ready..."
-          timeout 60 bash -c 'until curl -s http://localhost:3001; do sleep 2; done'
+          timeout 120 bash -c 'until curl -sf http://localhost:3000/healthz > /dev/null; do sleep 2; done'
 
       - name: Start worker
         run: |
@@ -116,6 +118,8 @@ jobs:
           echo "Worker started"
 
       - name: Run Playwright tests
+        env:
+          FRONTEND_BASE_URL: http://localhost:3000
         run: npx nx test twenty-e2e-testing
 
       - name: Upload Playwright results

--- a/.github/workflows/ci-e2e-main.yaml
+++ b/.github/workflows/ci-e2e-main.yaml
@@ -98,11 +98,8 @@ jobs:
           PGPASSWORD=postgres psql -h localhost -p 5432 -U postgres -d postgres -c 'CREATE DATABASE "test";'
           npx nx run twenty-server:database:reset
 
-      # The server serves the front so the browser origin always matches the API
-      # origin, workspace subdomains included. Cookie sessions are credentialed
-      # and only the exact SERVER_URL / FRONTEND_URL origins are allowlisted, so
-      # a front served on its own port cannot authenticate. This is also how the
-      # twenty docker image ships the front.
+      # Cookie sessions are credentialed, so the front only authenticates from
+      # the API's own origin, workspace subdomains included.
       - name: Serve the frontend from the server
         run: cp -r packages/twenty-front/build packages/twenty-server/dist/front
 

--- a/packages/twenty-e2e-testing/tests/authentication/onboarding.spec.ts
+++ b/packages/twenty-e2e-testing/tests/authentication/onboarding.spec.ts
@@ -1,10 +1,8 @@
 import { randomUUID } from 'crypto';
 import { expect, test } from './fixture';
 
-// Creating a workspace has to start from the workspace-agnostic base domain.
-// The shared fixture points baseURL at the workspace subdomain the login setup
-// landed on, where the server resolves an existing workspace and refuses to
-// sign a new user up to it.
+// Signing up on the workspace subdomain the shared fixture points at is
+// refused, so create the workspace from the base domain instead.
 test.use({
   storageState: { cookies: [], origins: [] },
   baseURL: process.env.FRONTEND_BASE_URL ?? 'http://localhost:3001',
@@ -45,9 +43,8 @@ test('New workspace signup goes through every onboarding stage', async ({
   const installAppsHeading = page.getByText('Install your first apps');
   const createProfileHeading = page.getByText('Create profile');
 
-  // Both stages auto-skip themselves when the instance offers nothing to do
-  // there: no connected-account provider, no vetted marketplace app. That is
-  // how the e2e server is configured, so onboarding lands on the profile stage.
+  // Both stages auto-skip when the instance has no connected-account provider
+  // and no vetted marketplace app, which is how the e2e server is configured.
   await test.step('Sync-email stage (when shown)', async () => {
     await expect(
       syncEmailsHeading.or(installAppsHeading).or(createProfileHeading),

--- a/packages/twenty-e2e-testing/tests/authentication/onboarding.spec.ts
+++ b/packages/twenty-e2e-testing/tests/authentication/onboarding.spec.ts
@@ -1,7 +1,14 @@
 import { randomUUID } from 'crypto';
 import { expect, test } from './fixture';
 
-test.use({ storageState: { cookies: [], origins: [] } });
+// Creating a workspace has to start from the workspace-agnostic base domain.
+// The shared fixture points baseURL at the workspace subdomain the login setup
+// landed on, where the server resolves an existing workspace and refuses to
+// sign a new user up to it.
+test.use({
+  storageState: { cookies: [], origins: [] },
+  baseURL: process.env.FRONTEND_BASE_URL ?? 'http://localhost:3001',
+});
 
 test('New workspace signup goes through every onboarding stage', async ({
   page,
@@ -34,41 +41,45 @@ test('New workspace signup goes through every onboarding stage', async ({
     await page.waitForURL('**/workspace-activation', { timeout: 90000 });
   });
 
-  let hasSkippedSyncEmailStage = false;
+  const syncEmailsHeading = page.getByText('Import your contacts');
+  const installAppsHeading = page.getByText('Install your first apps');
+  const createProfileHeading = page.getByText('Create profile');
 
-  await test.step('Sync-email stage (skip when shown)', async () => {
-    const syncEmailsHeading = page.getByText('Import your contacts');
-    const installAppsHeading = page.getByText('Install your first apps');
-
-    await expect(syncEmailsHeading.or(installAppsHeading)).toBeVisible({
+  // Both stages auto-skip themselves when the instance offers nothing to do
+  // there: no connected-account provider, no vetted marketplace app. That is
+  // how the e2e server is configured, so onboarding lands on the profile stage.
+  await test.step('Sync-email stage (when shown)', async () => {
+    await expect(
+      syncEmailsHeading.or(installAppsHeading).or(createProfileHeading),
+    ).toBeVisible({
       timeout: 90000,
     });
 
-    if (await syncEmailsHeading.isVisible()) {
-      await loginPage.clickSkipOnboardingStep();
-      hasSkippedSyncEmailStage = true;
-    }
-  });
-
-  await test.step('Install-apps stage', async () => {
-    await expect(page.getByText('Install your first apps')).toBeVisible();
-
-    if (hasSkippedSyncEmailStage) {
-      await test.step('Goes back to the skipped sync-email stage', async () => {
-        await page.getByRole('button', { name: 'Go back' }).click();
-        await expect(page.getByText('Import your contacts')).toBeVisible();
-
-        await page.reload();
-        await expect(page.getByText('Import your contacts')).toBeVisible({
-          timeout: 30000,
-        });
-
-        await loginPage.clickSkipOnboardingStep();
-        await expect(page.getByText('Install your first apps')).toBeVisible();
-      });
+    if (!(await syncEmailsHeading.isVisible())) {
+      return;
     }
 
     await loginPage.clickSkipOnboardingStep();
+    await expect(installAppsHeading).toBeVisible();
+
+    await test.step('Goes back to the skipped sync-email stage', async () => {
+      await page.getByRole('button', { name: 'Go back' }).click();
+      await expect(syncEmailsHeading).toBeVisible();
+
+      await page.reload();
+      await expect(syncEmailsHeading).toBeVisible({
+        timeout: 30000,
+      });
+
+      await loginPage.clickSkipOnboardingStep();
+      await expect(installAppsHeading).toBeVisible();
+    });
+  });
+
+  await test.step('Install-apps stage (when shown)', async () => {
+    if (await installAppsHeading.isVisible()) {
+      await loginPage.clickSkipOnboardingStep();
+    }
   });
 
   await test.step('Create-profile stage', async () => {

--- a/packages/twenty-e2e-testing/tests/create-record.spec.ts
+++ b/packages/twenty-e2e-testing/tests/create-record.spec.ts
@@ -114,7 +114,7 @@ test('Create and update record', async ({ page }) => {
     recordFieldList.getByText('Work Preference').first().click({force: true});
 
     // Open full record page to get person ID
-    await page.getByRole('button', { name: /^Open/ }).click();
+    await page.getByRole('button', { name: 'Expand record' }).click();
     await page.waitForURL(/\/object\/person\//);
     const newPersonId = page.url().match(/\/object\/person\/([a-f0-9-]+)/)?.[1];
 

--- a/packages/twenty-front/src/modules/settings/data-model/fields/forms/select/components/SettingsDataModelFieldSelectForm.tsx
+++ b/packages/twenty-front/src/modules/settings/data-model/fields/forms/select/components/SettingsDataModelFieldSelectForm.tsx
@@ -443,7 +443,6 @@ export const SettingsDataModelFieldSelectForm = ({
                               key={option.id}
                               draggableId={option.id}
                               index={index}
-                              isDragDisabled={options.length === 1}
                               itemComponent={
                                 <SettingsDataModelFieldSelectFormOptionRow
                                   key={option.id}

--- a/packages/twenty-server/.env.e2e-testing-server
+++ b/packages/twenty-server/.env.e2e-testing-server
@@ -5,4 +5,5 @@ APP_SECRET=replace_me_with_a_random_string
 SIGN_IN_PREFILLED=true
 IS_MULTIWORKSPACE_ENABLED=true
 
-FRONTEND_URL=http://localhost:3001
+# The CI job serves the front build from this server, so both share one origin.
+FRONTEND_URL=http://localhost:3000

--- a/packages/twenty-server/.env.e2e-testing-server
+++ b/packages/twenty-server/.env.e2e-testing-server
@@ -4,9 +4,8 @@ REDIS_URL=redis://localhost:6379
 APP_SECRET=replace_me_with_a_random_string
 SIGN_IN_PREFILLED=true
 IS_MULTIWORKSPACE_ENABLED=true
-# The onboarding e2e signs a fresh user up and creates a workspace, which the
-# default admin-only restriction rejects.
+# The onboarding e2e creates a workspace, which the default rejects.
 IS_WORKSPACE_CREATION_LIMITED_TO_SERVER_ADMINS=false
 
-# The CI job serves the front build from this server, so both share one origin.
+# This server serves the front build, so both share one origin.
 FRONTEND_URL=http://localhost:3000

--- a/packages/twenty-server/.env.e2e-testing-server
+++ b/packages/twenty-server/.env.e2e-testing-server
@@ -4,6 +4,9 @@ REDIS_URL=redis://localhost:6379
 APP_SECRET=replace_me_with_a_random_string
 SIGN_IN_PREFILLED=true
 IS_MULTIWORKSPACE_ENABLED=true
+# The onboarding e2e signs a fresh user up and creates a workspace, which the
+# default admin-only restriction rejects.
+IS_WORKSPACE_CREATION_LIMITED_TO_SERVER_ADMINS=false
 
 # The CI job serves the front build from this server, so both share one origin.
 FRONTEND_URL=http://localhost:3000


### PR DESCRIPTION
## What

Unbreaks `CI E2E Main`, which has failed on every push to `main` for weeks.

The job now serves the front build from the server instead of a separate static server on port 3001, and the four specs that were failing behind that gate are fixed.

## Why the suite was red

**The login setup died on "Unable to Reach Back-end"**, so 8 of 9 tests never ran. Two changes stacked up:

- Since the cookie-session migration (#23642) the front sends credentialed requests, and only the exact `SERVER_URL` / `FRONTEND_URL` origins are reflected in `Access-Control-Allow-Origin`. A front on `:3001` talking to an API on `:3000` was already broken for workspace subdomains (`apple.localhost:3001` is not in the allowlist).
- #23779 then collapsed the front config to `window._env_?.REACT_APP_SERVER_BASE_URL || window.location.origin`. The job serves the production bundle with `npx serve` and never injects `window._env_`, so the front called `localhost:3001/client-config`, got the SPA fallback HTML back, and rendered the backend-unreachable screen.

Serving the front from the server makes every request same-origin, subdomains included, so neither CORS nor the cookie allowlist is involved. It is also how the `twenty` docker image ships the front (`COPY ... /app/packages/twenty-server/dist/front`).

## Changes

CI harness:

- Copy `packages/twenty-front/build` into `packages/twenty-server/dist/front` before starting the server, and drop the `npx serve` step.
- Start the server with `start:ci` (`nest start`) rather than `start` (`rimraf dist && nest start --watch`), which would delete the front we just copied.
- Point Playwright's `FRONTEND_BASE_URL` and the server's `FRONTEND_URL` at `http://localhost:3000`.
- Health-gate on `/healthz` (the real endpoint; `/health` 404s, and a bare `curl -s` accepted that 404 as ready).

Specs behind the gate:

- `onboarding`: run it against the workspace-agnostic base domain. The shared fixture sets `baseURL` to the workspace subdomain the login setup landed on, where the server correctly refuses to sign a new user up to an existing workspace. Also allow workspace creation on the e2e server (`IS_WORKSPACE_CREATION_LIMITED_TO_SERVER_ADMINS=false`, it defaults to admin-only), and make the sync-email and install-apps stages optional: both auto-skip when the instance has no connected-account provider and no vetted marketplace app, which is how the e2e server is configured.
- `create-record`: the side panel button is `Expand record` since #23965, not `Open …`.
- `create-kanban-view`: drop `isDragDisabled={options.length === 1}` on select-field options. dnd-kit sets `aria-disabled` on the drag activator, which is the whole row here since the row registers no drag handle, so a single option's inputs were announced as disabled to assistive tech and refused by Playwright. A one-item list cannot be reordered anyway, so disabling the drag bought nothing.

## Tests

Full suite locally against a server serving the front build the same way, all 9 green:

```
✅ setup › login.setup.ts › Login test
✅ authentication/onboarding.spec.ts › New workspace signup goes through every onboarding stage
✅ authentication/return-to-path.spec.ts › should redirect to deep link after login
✅ authentication/return-to-path.spec.ts › should preserve path with query params across login
✅ authentication/signup_invite_email.spec.ts › Sign up with invite link via email
✅ create-kanban-view.spec.ts › Create Industry Select Field
✅ create-kanban-view.spec.ts › Create Kanban View from Industry Select Field
✅ create-record.spec.ts › Create and update record
✅ workflow-creation.spec.ts › Create workflow
```

The first CI run of this branch (harness fix only) went from 0 passed / 1 failed / 8 not run to 5 passed, with exactly the three specs above failing; this push fixes those.
