### PR TITLE
fix(front): make logout navigate once (unbreaks the invite e2e)

### DIFF
--- a/packages/twenty-e2e-testing/tests/authentication/signup_invite_email.spec.ts
+++ b/packages/twenty-e2e-testing/tests/authentication/signup_invite_email.spec.ts
@@ -26,11 +26,14 @@ test('Sign up with invite link via email', async ({
   await test.step('Go to invite link', async () => {
     await settingsPage.logout();
 
-    await Promise.all([
-      expect(page.getByText(/Join .+ team/)).toBeVisible(),
-
-      page.goto(inviteLink),
-    ]);
+    // Logging out fires several redirects to /welcome over ~1s, and one landing
+    // mid-navigation interrupts the goto, so retry until the invite page sticks.
+    await expect(async () => {
+      await page.goto(inviteLink);
+      await expect(page.getByText(/Join .+ team/)).toBeVisible({
+        timeout: 5000,
+      });
+    }).toPass({ timeout: 60000 });
   });
 
   await test.step('Create new account', async () => {

--- a/packages/twenty-e2e-testing/tests/authentication/signup_invite_email.spec.ts
+++ b/packages/twenty-e2e-testing/tests/authentication/signup_invite_email.spec.ts
@@ -25,15 +25,11 @@ test('Sign up with invite link via email', async ({
 
   await test.step('Go to invite link', async () => {
     await settingsPage.logout();
+    // Logging out replaces the document, which would interrupt the goto below.
+    await page.waitForURL('**/welcome');
 
-    // Logging out fires several redirects to /welcome over ~1s, and one landing
-    // mid-navigation interrupts the goto, so retry until the invite page sticks.
-    await expect(async () => {
-      await page.goto(inviteLink);
-      await expect(page.getByText(/Join .+ team/)).toBeVisible({
-        timeout: 5000,
-      });
-    }).toPass({ timeout: 60000 });
+    await page.goto(inviteLink);
+    await expect(page.getByText(/Join .+ team/)).toBeVisible();
   });
 
   await test.step('Create new account', async () => {

--- a/packages/twenty-front/src/modules/auth/hooks/useAuth.ts
+++ b/packages/twenty-front/src/modules/auth/hooks/useAuth.ts
@@ -118,11 +118,8 @@ export const useAuth = () => {
   const navigate = useNavigate();
 
   const clearSession = useCallback(() => {
-    // Clearing the session below flips the still-mounted app to logged out, and
-    // the redirect effect would route it to the sign-in page client-side while
-    // the assign at the end is already replacing the document. The URL would
-    // then read as arrived while a full page load is still in flight, killing
-    // anything navigating in between. The assign is the only navigation here.
+    // The assign below is the only navigation: keep the redirect effect from
+    // racing it to the sign-in page once the session is cleared.
     store.set(isAppEffectRedirectEnabledState.atom, false);
     sessionStorage.clear();
     store.set(tokenPairState.atom, null);

--- a/packages/twenty-front/src/modules/auth/hooks/useAuth.ts
+++ b/packages/twenty-front/src/modules/auth/hooks/useAuth.ts
@@ -118,6 +118,12 @@ export const useAuth = () => {
   const navigate = useNavigate();
 
   const clearSession = useCallback(() => {
+    // Clearing the session below flips the still-mounted app to logged out, and
+    // the redirect effect would route it to the sign-in page client-side while
+    // the assign at the end is already replacing the document. The URL would
+    // then read as arrived while a full page load is still in flight, killing
+    // anything navigating in between. The assign is the only navigation here.
+    store.set(isAppEffectRedirectEnabledState.atom, false);
     sessionStorage.clear();
     store.set(tokenPairState.atom, null);
     store.set(isCookieAuthActiveState.atom, false);


### PR DESCRIPTION
## What

Logout performed two navigations to `/welcome`. It now performs one.

This also unbreaks `signup_invite_email`, the last spec failing `CI E2E Main` on `main` (run [31687111270](https://github.com/twentyhq/twenty/actions/runs/31687111270), failed all 3 attempts).

## Why

`clearSession` resets the session atoms and then calls `window.location.assign(AppPath.SignInUp)`. Clearing the atoms flips the still-mounted app to logged out, so the redirect effect routes it to `/welcome` client-side while the browser is still fetching the document that `assign` asked for. Traced on a production build:

```
=== clicking logout
RESP 200 SignOut errors=false
NAVCALL pushState /welcome     <- react-router, from the redirect effect
COMMITTED /welcome             <- that pushState
COMMITTED /welcome             <- the document load, ~600ms later
```

So the URL reads as arrived at `/welcome` while a full page load is still in flight, and anything that navigates in that window is interrupted. The invite spec did exactly that and died with `Navigation to .../invite/... is interrupted by another navigation to .../welcome`.

`isAppEffectRedirectEnabledState` already exists for this situation and is used the same way around the verify and SSO flows: a deliberate navigation is in flight, so the effect must not route. Setting it in `clearSession` leaves the `assign` as the only navigation. The session teardown is unchanged — the atoms still get cleared, several of them are persisted (the token pair, the workspace-domain cookie) and dropping that would leave the user signed in after the reload.

After the fix, same trace:

```
=== clicking logout
RESP 200 SignOut errors=false
COMMITTED /welcome             <- one navigation
NAVCALL replaceState undefined <- react-router booting in the new document
```

With logout deterministic, the spec just waits for `/welcome` and navigates; no retry loop.

## Tests

Against a local server serving the front build the way CI does:

- `signup_invite_email` `--repeat-each=5`: 5/5 green. Before the fix it failed roughly 1 run in 4, and 3/3 on CI.
- Full e2e suite: 9/9 green.
- `useAuth.test.tsx`: 8/8, including `should handle sign-out`, which asserts the session atoms are cleared.
