### PR TITLE
feat(server): route delete, destroy and restore through the ORM v2 write path

### DIFF
--- a/.github/workflows/ci-server.yaml
+++ b/.github/workflows/ci-server.yaml
@@ -319,7 +319,7 @@ jobs:
       ORM_V2_SHARD_COUNTER: 3
       AUTH_COOKIE_SESSIONS_ENABLED: ${{ contains(github.event.pull_request.labels.*.name, 'ci:auth-cookie-sessions') }}
       TEST_FORCED_FEATURE_FLAGS: ${{ matrix.orm-v2 && 'IS_ORM_V2_READ_PATH_ENABLED' || '' }}
-      ORM_V2_TEST_PATH_PATTERN: '(find-many|find-one|find-duplicates|group-by|composite-field-pagination|filter-by-relation-field|order-by-relation-field|nested-relation|soft-deleted-relation|relation-join-rls|object-records-permissions|merge-many)'
+      ORM_V2_TEST_PATH_PATTERN: '(find-many|find-one|find-duplicates|group-by|composite-field-pagination|filter-by-relation-field|order-by-relation-field|nested-relation|soft-deleted-relation|relation-join-rls|object-records-permissions|merge-many|mutate-by-relation-field|mutation-relation-filter-rls)'
     steps:
       - name: Fetch custom Github Actions and base branch history
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1

--- a/packages/twenty-server/src/engine/api/common/common-query-runners/common-base-query-runner.service.ts
+++ b/packages/twenty-server/src/engine/api/common/common-query-runners/common-base-query-runner.service.ts
@@ -1,8 +1,10 @@
 import { Inject, Injectable } from '@nestjs/common';
 
 import { type PermissionFlagType } from 'twenty-shared/constants';
-import { FeatureFlagKey } from 'twenty-shared/types';
+import { FeatureFlagKey, type ObjectRecord } from 'twenty-shared/types';
 import { type ObjectLiteral } from 'typeorm';
+
+import { type ObjectRecordFilter } from 'src/engine/api/graphql/workspace-query-builder/interfaces/object-record.interface';
 
 import { QueryResultFieldValue } from 'src/engine/api/graphql/workspace-query-runner/factories/query-result-getters/interfaces/query-result-field-value';
 
@@ -18,6 +20,8 @@ import {
   CommonQueryRunnerExceptionCode,
 } from 'src/engine/api/common/common-query-runners/errors/common-query-runner.exception';
 import { STANDARD_ERROR_MESSAGE } from 'src/engine/api/common/common-query-runners/errors/standard-error-message.constant';
+import { buildMutationQueryBuilder } from 'src/engine/api/common/common-query-runners/utils/build-mutation-query-builder.util';
+import { buildMutationQueryBuilderV2 } from 'src/engine/api/common/common-query-runners/utils/build-mutation-query-builder-v2.util';
 import { CommonResultGettersService } from 'src/engine/api/common/common-result-getters/common-result-getters.service';
 import { CommonBaseQueryRunnerContext } from 'src/engine/api/common/types/common-base-query-runner-context.type';
 import { CommonExtendedQueryRunnerContext } from 'src/engine/api/common/types/common-extended-query-runner-context.type';
@@ -62,6 +66,7 @@ import { getWorkspaceContext } from 'src/engine/twenty-orm/storage/orm-workspace
 import { resolveRolePermissionConfig } from 'src/engine/twenty-orm/utils/resolve-role-permission-config.util';
 import { WorkspaceDataSourceV2Service } from 'src/engine/twenty-orm-v2/datasource/workspace-data-source-v2.service';
 import { type WorkspaceRepositoryV2 } from 'src/engine/twenty-orm-v2/repository/workspace-repository-v2';
+import { type MutationKind } from 'src/engine/twenty-orm-v2/sql/utils/build-mutation-statement.util';
 import { WorkspaceCacheService } from 'src/engine/workspace-cache/services/workspace-cache.service';
 
 @Injectable()
@@ -389,6 +394,86 @@ export abstract class CommonBaseQueryRunnerService<
     return this.workspaceDataSourceV2Service
       .getDataSource({ useReplica: this.isReadOnly })
       .getRepository(flatObjectMetadata.nameSingular, rolePermissionConfig);
+  }
+
+  // Behind IS_ORM_V2_READ_PATH_ENABLED, writes go through the ORM v2 repository. Unlike
+  // reads, writes always hit the primary, so useReplica is pinned false regardless of
+  // isReadOnly. The caller gates the flag; this is only reached on the v2 branch.
+  protected getWriteRepository({
+    rolePermissionConfig,
+    flatObjectMetadata,
+  }: Pick<
+    CommonExtendedQueryRunnerContext,
+    'rolePermissionConfig' | 'flatObjectMetadata'
+  >): WorkspaceRepositoryV2 {
+    this.metricsService.incrementCounterBy({
+      key: MetricsKeys.OrmV2WritePathUsed,
+      amount: 1,
+      attributes: { operation: this.operationName },
+    });
+
+    return this.workspaceDataSourceV2Service
+      .getDataSource({ useReplica: false })
+      .getRepository(flatObjectMetadata.nameSingular, rolePermissionConfig);
+  }
+
+  protected async runFilteredMutation({
+    queryRunnerContext,
+    filter,
+    columnsToReturn,
+    kind,
+  }: {
+    queryRunnerContext: CommonExtendedQueryRunnerContext;
+    filter: Partial<ObjectRecordFilter>;
+    columnsToReturn: string[];
+    kind: MutationKind;
+  }): Promise<ObjectRecord[]> {
+    const {
+      repository,
+      flatObjectMetadata,
+      commonQueryParser,
+      featureFlagsMap,
+    } = queryRunnerContext;
+    const alias = flatObjectMetadata.nameSingular;
+
+    if (featureFlagsMap[FeatureFlagKey.IS_ORM_V2_READ_PATH_ENABLED]) {
+      const writeRepository = this.getWriteRepository(queryRunnerContext);
+
+      const { selectQueryBuilder, rowLevelPermissionsApplied } =
+        buildMutationQueryBuilderV2({
+          repository: writeRepository,
+          alias,
+          filter,
+          commonQueryParser,
+        });
+
+      return writeRepository.runMutation({
+        selectQueryBuilder,
+        rowLevelPermissionsApplied,
+        kind,
+        columnsToReturn,
+      });
+    }
+
+    const queryBuilder = buildMutationQueryBuilder({
+      repository,
+      alias,
+      filter,
+      commonQueryParser,
+    });
+
+    const mutationQueryBuilder =
+      kind === 'soft-delete'
+        ? queryBuilder.softDelete()
+        : kind === 'restore'
+          ? queryBuilder.restore()
+          : queryBuilder.delete();
+
+    const result = await mutationQueryBuilder
+      .returning(columnsToReturn)
+      .execute();
+
+    return result.generatedMaps as ObjectRecord[];
   }
 
   protected getNestedRelationsReadPathOptions({

--- a/packages/twenty-server/src/engine/api/common/common-query-runners/common-base-query-runner.service.ts
+++ b/packages/twenty-server/src/engine/api/common/common-query-runners/common-base-query-runner.service.ts
@@ -396,9 +396,7 @@ export abstract class CommonBaseQueryRunnerService<
       .getRepository(flatObjectMetadata.nameSingular, rolePermissionConfig);
   }
 
-  // Behind IS_ORM_V2_READ_PATH_ENABLED, writes go through the ORM v2 repository. Unlike
-  // reads, writes always hit the primary, so useReplica is pinned false regardless of
-  // isReadOnly. The caller gates the flag; this is only reached on the v2 branch.
+  // Writes always hit the primary, so useReplica is pinned false regardless of isReadOnly.
   protected getWriteRepository({
     rolePermissionConfig,
     flatObjectMetadata,

--- a/packages/twenty-server/src/engine/api/common/common-query-runners/common-delete-many-query-runner.service.ts
+++ b/packages/twenty-server/src/engine/api/common/common-query-runners/common-delete-many-query-runner.service.ts
@@ -12,7 +12,6 @@ import {
   CommonQueryRunnerExceptionCode,
 } from 'src/engine/api/common/common-query-runners/errors/common-query-runner.exception';
 import { STANDARD_ERROR_MESSAGE } from 'src/engine/api/common/common-query-runners/errors/standard-error-message.constant';
-import { buildMutationQueryBuilder } from 'src/engine/api/common/common-query-runners/utils/build-mutation-query-builder.util';
 import { CommonBaseQueryRunnerContext } from 'src/engine/api/common/types/common-base-query-runner-context.type';
 import { CommonExtendedQueryRunnerContext } from 'src/engine/api/common/types/common-extended-query-runner-context.type';
 import {
@@ -40,22 +39,13 @@ export class CommonDeleteManyQueryRunnerService extends CommonBaseQueryRunnerSer
     queryRunnerContext: CommonExtendedQueryRunnerContext,
   ): Promise<ObjectRecord[]> {
     const {
-      repository,
       authContext,
       rolePermissionConfig,
       workspaceDataSource,
       flatObjectMetadataMaps,
       flatFieldMetadataMaps,
       flatObjectMetadata,
-      commonQueryParser,
     } = queryRunnerContext;
-
-    const queryBuilder = buildMutationQueryBuilder({
-      repository,
-      alias: flatObjectMetadata.nameSingular,
-      filter: args.filter,
-      commonQueryParser,
-    });
 
     const columnsToReturn = buildColumnsToReturn({
       select: args.selectedFieldsResult.select,
@@ -65,12 +55,12 @@ export class CommonDeleteManyQueryRunnerService extends CommonBaseQueryRunnerSer
       flatFieldMetadataMaps,
     });
 
-    const deletedObjectRecords = await queryBuilder
-      .softDelete()
-      .returning(columnsToReturn)
-      .execute();
-
-    const deletedRecords = deletedObjectRecords.generatedMaps as ObjectRecord[];
+    const deletedRecords = await this.runFilteredMutation({
+      queryRunnerContext,
+      filter: args.filter,
+      columnsToReturn,
+      kind: 'soft-delete',
+    });
 
     if (isDefined(args.selectedFieldsResult.relations)) {
       await this.processNestedRelationsHelper.processNestedRelations({

--- a/packages/twenty-server/src/engine/api/common/common-query-runners/common-destroy-many-query-runner.service.ts
+++ b/packages/twenty-server/src/engine/api/common/common-query-runners/common-destroy-many-query-runner.service.ts
@@ -12,7 +12,6 @@ import {
   CommonQueryRunnerExceptionCode,
 } from 'src/engine/api/common/common-query-runners/errors/common-query-runner.exception';
 import { STANDARD_ERROR_MESSAGE } from 'src/engine/api/common/common-query-runners/errors/standard-error-message.constant';
-import { buildMutationQueryBuilder } from 'src/engine/api/common/common-query-runners/utils/build-mutation-query-builder.util';
 import { CommonBaseQueryRunnerContext } from 'src/engine/api/common/types/common-base-query-runner-context.type';
 import { CommonExtendedQueryRunnerContext } from 'src/engine/api/common/types/common-extended-query-runner-context.type';
 import {
@@ -40,22 +39,13 @@ export class CommonDestroyManyQueryRunnerService extends CommonBaseQueryRunnerSe
     queryRunnerContext: CommonExtendedQueryRunnerContext,
   ): Promise<ObjectRecord[]> {
     const {
-      repository,
       authContext,
       rolePermissionConfig,
       workspaceDataSource,
       flatObjectMetadataMaps,
       flatFieldMetadataMaps,
       flatObjectMetadata,
-      commonQueryParser,
     } = queryRunnerContext;
-
-    const queryBuilder = buildMutationQueryBuilder({
-      repository,
-      alias: flatObjectMetadata.nameSingular,
-      filter: args.filter,
-      commonQueryParser,
-    });
 
     const columnsToReturn = buildColumnsToReturn({
       select: args.selectedFieldsResult.select,
@@ -65,13 +55,12 @@ export class CommonDestroyManyQueryRunnerService extends CommonBaseQueryRunnerSe
       flatFieldMetadataMaps,
     });
 
-    const destroyedObjectRecords = await queryBuilder
-      .delete()
-      .returning(columnsToReturn)
-      .execute();
-
-    const destroyedRecords =
-      destroyedObjectRecords.generatedMaps as ObjectRecord[];
+    const destroyedRecords = await this.runFilteredMutation({
+      queryRunnerContext,
+      filter: args.filter,
+      columnsToReturn,
+      kind: 'delete',
+    });
 
     if (isDefined(args.selectedFieldsResult.relations)) {
       await this.processNestedRelationsHelper.processNestedRelations({

--- a/packages/twenty-server/src/engine/api/common/common-query-runners/common-restore-many-query-runner.service.ts
+++ b/packages/twenty-server/src/engine/api/common/common-query-runners/common-restore-many-query-runner.service.ts
@@ -12,7 +12,6 @@ import {
   CommonQueryRunnerExceptionCode,
 } from 'src/engine/api/common/common-query-runners/errors/common-query-runner.exception';
 import { STANDARD_ERROR_MESSAGE } from 'src/engine/api/common/common-query-runners/errors/standard-error-message.constant';
-import { buildMutationQueryBuilder } from 'src/engine/api/common/common-query-runners/utils/build-mutation-query-builder.util';
 import { CommonBaseQueryRunnerContext } from 'src/engine/api/common/types/common-base-query-runner-context.type';
 import { CommonExtendedQueryRunnerContext } from 'src/engine/api/common/types/common-extended-query-runner-context.type';
 import {
@@ -40,22 +39,13 @@ export class CommonRestoreManyQueryRunnerService extends CommonBaseQueryRunnerSe
     queryRunnerContext: CommonExtendedQueryRunnerContext,
   ): Promise<ObjectRecord[]> {
     const {
-      repository,
       authContext,
       rolePermissionConfig,
       workspaceDataSource,
       flatObjectMetadataMaps,
       flatFieldMetadataMaps,
       flatObjectMetadata,
-      commonQueryParser,
     } = queryRunnerContext;
-
-    const queryBuilder = buildMutationQueryBuilder({
-      repository,
-      alias: flatObjectMetadata.nameSingular,
-      filter: args.filter,
-      commonQueryParser,
-    });
 
     const columnsToReturn = buildColumnsToReturn({
       select: args.selectedFieldsResult.select,
@@ -65,13 +55,12 @@ export class CommonRestoreManyQueryRunnerService extends CommonBaseQueryRunnerSe
       flatFieldMetadataMaps,
     });
 
-    const restoredObjectRecords = await queryBuilder
-      .restore()
-      .returning(columnsToReturn)
-      .execute();
-
-    const restoredRecords =
-      restoredObjectRecords.generatedMaps as ObjectRecord[];
+    const restoredRecords = await this.runFilteredMutation({
+      queryRunnerContext,
+      filter: args.filter,
+      columnsToReturn,
+      kind: 'restore',
+    });
 
     if (isDefined(args.selectedFieldsResult.relations)) {
       await this.processNestedRelationsHelper.processNestedRelations({

--- a/packages/twenty-server/src/engine/api/common/common-query-runners/utils/build-mutation-query-builder-v2.util.ts
+++ b/packages/twenty-server/src/engine/api/common/common-query-runners/utils/build-mutation-query-builder-v2.util.ts
@@ -1,7 +1,6 @@
 import { type ObjectRecordFilter } from 'src/engine/api/graphql/workspace-query-builder/interfaces/object-record.interface';
 
 import { type GraphqlQueryParser } from 'src/engine/api/graphql/graphql-query-runner/graphql-query-parsers/graphql-query.parser';
-import { type RecordQueryBuilder } from 'src/engine/api/graphql/graphql-query-runner/types/record-query-builder.type';
 import { type WorkspaceSelectQueryBuilderV2 } from 'src/engine/twenty-orm-v2/query-builder/workspace-select-query-builder-v2';
 import { type WorkspaceRepositoryV2 } from 'src/engine/twenty-orm-v2/repository/workspace-repository-v2';
 
@@ -23,11 +22,7 @@ export const buildMutationQueryBuilderV2 = ({
 } => {
   const filteredQueryBuilder = repository.createQueryBuilder(alias);
 
-  commonQueryParser.applyFilterToBuilder(
-    filteredQueryBuilder as unknown as RecordQueryBuilder,
-    alias,
-    filter,
-  );
+  commonQueryParser.applyFilterToBuilder(filteredQueryBuilder, alias, filter);
 
   const hasRelationTraversal =
     filteredQueryBuilder.expressionMap.joinAttributes.length > 0;

--- a/packages/twenty-server/src/engine/api/common/common-query-runners/utils/build-mutation-query-builder-v2.util.ts
+++ b/packages/twenty-server/src/engine/api/common/common-query-runners/utils/build-mutation-query-builder-v2.util.ts
@@ -1,0 +1,54 @@
+import { type ObjectRecordFilter } from 'src/engine/api/graphql/workspace-query-builder/interfaces/object-record.interface';
+
+import { type GraphqlQueryParser } from 'src/engine/api/graphql/graphql-query-runner/graphql-query-parsers/graphql-query.parser';
+import { type RecordQueryBuilder } from 'src/engine/api/graphql/graphql-query-runner/types/record-query-builder.type';
+import { type WorkspaceSelectQueryBuilderV2 } from 'src/engine/twenty-orm-v2/query-builder/workspace-select-query-builder-v2';
+import { type WorkspaceRepositoryV2 } from 'src/engine/twenty-orm-v2/repository/workspace-repository-v2';
+
+type BuildMutationQueryBuilderV2Args = {
+  repository: WorkspaceRepositoryV2;
+  alias: string;
+  filter: Partial<ObjectRecordFilter>;
+  commonQueryParser: GraphqlQueryParser;
+};
+
+export const buildMutationQueryBuilderV2 = ({
+  repository,
+  alias,
+  filter,
+  commonQueryParser,
+}: BuildMutationQueryBuilderV2Args): {
+  selectQueryBuilder: WorkspaceSelectQueryBuilderV2;
+  rowLevelPermissionsApplied: boolean;
+} => {
+  const filteredQueryBuilder = repository.createQueryBuilder(alias);
+
+  commonQueryParser.applyFilterToBuilder(
+    filteredQueryBuilder as unknown as RecordQueryBuilder,
+    alias,
+    filter,
+  );
+
+  const hasRelationTraversal =
+    filteredQueryBuilder.expressionMap.joinAttributes.length > 0;
+
+  if (!hasRelationTraversal) {
+    return {
+      selectQueryBuilder: filteredQueryBuilder,
+      rowLevelPermissionsApplied: false,
+    };
+  }
+
+  const idSubQueryBuilder = filteredQueryBuilder
+    .select(`${alias}.id`)
+    .withDeleted();
+
+  repository.applyWriteRowLevelPermissions(idSubQueryBuilder);
+
+  const selectQueryBuilder = repository
+    .createQueryBuilder(alias)
+    .where(`"${alias}"."id" IN (${idSubQueryBuilder.getQuery()})`)
+    .setParameters(idSubQueryBuilder.getParameters());
+
+  return { selectQueryBuilder, rowLevelPermissionsApplied: true };
+};

--- a/packages/twenty-server/src/engine/core-modules/metrics/types/metrics-keys.type.ts
+++ b/packages/twenty-server/src/engine/core-modules/metrics/types/metrics-keys.type.ts
@@ -92,4 +92,5 @@ export enum MetricsKeys {
   WorkspaceMigrationActionDurationMs = 'workspace-migration/action-duration-ms',
   WorkspaceMigrationActionCount = 'workspace-migration/action-count',
   OrmV2ReadPathUsed = 'orm-v2/read-path-used',
+  OrmV2WritePathUsed = 'orm-v2/write-path-used',
 }

--- a/packages/twenty-server/src/engine/twenty-orm-v2/README.md
+++ b/packages/twenty-server/src/engine/twenty-orm-v2/README.md
@@ -120,7 +120,7 @@ table-shape builder cannot represent. `GroupByWithRecordsV2Service` builds the i
 subquery with the v2 builder and runs the composed outer query through
 `repository.executeRaw`; the runner flag-branches between it and the v1 service.
 
-## Writes: the statement layer exists, nothing is wired
+## Writes: delete, destroy and restore route through v2
 
 `WorkspaceMutationQueryBuilderV2` generates `UPDATE` / `DELETE` / soft-delete / restore
 statements with `RETURNING`, reusing the same primitives as the select builder
@@ -129,29 +129,42 @@ generator. The select builder morphs into it: `.update()` / `.delete()` / `.soft
 / `.restore()` carry the current where clauses and parameters into the mutation, matching
 the TypeORM surface the mutation runners already call.
 
-Deliberate choices, all asserted by exact-SQL unit tests:
+`deleteMany`, `destroyMany` and `restoreMany` (and their `...One` delegates) flag-branch to
+this path. Each runner builds the filtered v2 select builder with
+`buildMutationQueryBuilderV2` (which rewrites a relation-traversal filter into an
+`id IN (subquery)` predicate, RLS inside the subquery) and hands it to
+`WorkspaceRepositoryV2.runMutation`, which owns the choreography the v1 mutation builders
+own: apply the row-level predicate, validate the write with the matching operation type,
+snapshot the affected rows before and after through a permission-bypassing all-columns
+select, run the statement, and emit the `DELETED` / `RESTORED` / `DESTROYED` batch event
+through the shared `formatTwentyOrmEventToDatabaseBatchEvent`. `getWriteRepository` on the
+base runner pins the primary and counts `orm-v2/write-path-used`.
+
+Deliberate choices, the SQL ones asserted by exact-SQL unit tests:
 
 - Statements are alias-form (`UPDATE "schema"."table" AS "person" ... RETURNING
   "person"."id" AS "person_id"`), so the where renderer and the `RETURNING` projection are
-  the select builder's, unchanged. `execute()` returns `{ generatedMaps, affected }` with
-  `generatedMaps` run through the shared `formatResult`, matching what the v1 mutation
-  builders hand back.
+  the select builder's, unchanged. The returned records come from `RETURNING` rather than a
+  full re-select; the GraphQL layer reads only the selected fields either way, so this is
+  observably identical to v1.
 - A mutation never adds the `deletedAt IS NULL` predicate the read path uses: it operates
   on exactly the rows its filter matches, so restore reaches soft-deleted rows and delete
   reaches any row. This mirrors TypeORM, which injects the soft-delete predicate for
-  SELECT only.
+  SELECT only. The event snapshot select is `withDeleted` for the same reason.
 - `updatedAt` is stamped `CURRENT_TIMESTAMP` on every update unless the caller set it;
   soft-delete stamps `deletedAt` and `updatedAt`; restore clears `deletedAt` and stamps
   `updatedAt`.
+- Hard delete snapshots its before-image with `getOne`, so a `DESTROYED` event carries at
+  most one record. This matches the v1 delete builder rather than fixing it here; changing
+  it would change flag-off behaviour too and belongs in a separate change to both paths.
 
-Not wired to any runner yet: the mutation runners keep `repository` (v1) until the
-per-endpoint migrations route them through this builder. Permission enforcement, row-level
-predicates on writes and database event emission ride with that wiring, not this layer.
+Update, insert and upsert still keep `repository` (v1).
 
 ## Not covered yet
 
-- Insert and upsert. `INSERT` / `ON CONFLICT` still go through v1, which is where the
-  column defaults and conflict-target derivation live.
+- Update, insert and upsert. `UPDATE ... SET` from caller data, `INSERT` and
+  `ON CONFLICT` still go through v1, which is where composite flattening of the input and
+  the column defaults / conflict-target derivation live.
 - `find` / `findOne` / `findBy` and the rest of the repository surface used by
   `src/modules`.
 - Transactions and DDL.

--- a/packages/twenty-server/src/engine/twenty-orm-v2/README.md
+++ b/packages/twenty-server/src/engine/twenty-orm-v2/README.md
@@ -157,6 +157,9 @@ Deliberate choices, the SQL ones asserted by exact-SQL unit tests:
 - Hard delete snapshots its before-image with `getOne`, so a `DESTROYED` event carries at
   most one record. This matches the v1 delete builder rather than fixing it here; changing
   it would change flag-off behaviour too and belongs in a separate change to both paths.
+- A filter that traverses a to-many relation surfaces the same `UNSUPPORTED_OPERATION`
+  user-input error the read path already produces (v2 refuses to render a to-many join),
+  rather than the row-multiplying join v1 would emit.
 
 Update, insert and upsert still keep `repository` (v1).
 

--- a/packages/twenty-server/src/engine/twenty-orm-v2/query-builder/workspace-select-query-builder-v2.ts
+++ b/packages/twenty-server/src/engine/twenty-orm-v2/query-builder/workspace-select-query-builder-v2.ts
@@ -136,6 +136,13 @@ export class WorkspaceSelectQueryBuilderV2 implements WhereExpressionLike {
     return this.appendWhere('and', condition, parameters);
   }
 
+  copyWhereFrom(source: WorkspaceSelectQueryBuilderV2): this {
+    this.whereClauses.push(...source.whereClauses);
+    this.parameters = { ...this.parameters, ...source.parameters };
+
+    return this;
+  }
+
   andWhere(
     condition: WhereConditionLike,
     parameters?: Record<string, unknown>,

--- a/packages/twenty-server/src/engine/twenty-orm-v2/repository/workspace-repository-v2.ts
+++ b/packages/twenty-server/src/engine/twenty-orm-v2/repository/workspace-repository-v2.ts
@@ -1,14 +1,20 @@
-import { type ObjectsPermissions } from 'twenty-shared/types';
+import {
+  type ObjectRecord,
+  type ObjectsPermissions,
+} from 'twenty-shared/types';
 import { isDefined } from 'twenty-shared/utils';
 
+import { DatabaseEventAction } from 'src/engine/api/graphql/graphql-query-runner/enums/database-event-action';
 import { type WorkspaceAuthContext } from 'src/engine/core-modules/auth/types/workspace-auth-context.type';
 import { type FlatObjectMetadata } from 'src/engine/metadata-modules/flat-object-metadata/types/flat-object-metadata.type';
 import { validateOperationIsPermittedOrThrow } from 'src/engine/twenty-orm/repository/permissions.utils';
 import { type WorkspaceInternalContext } from 'src/engine/twenty-orm/interfaces/workspace-internal-context.interface';
+import { formatResult } from 'src/engine/twenty-orm/utils/format-result.util';
+import { formatTwentyOrmEventToDatabaseBatchEvent } from 'src/engine/twenty-orm/utils/format-twenty-orm-event-to-database-batch-event.util';
 import { renderRowLevelPermissionFilterToSql } from 'src/engine/twenty-orm/utils/render-row-level-permission-filter-to-sql.util';
 import { resolveRowLevelPermissionRecordFilter } from 'src/engine/twenty-orm/utils/resolve-row-level-permission-record-filter.util';
-import { formatResult } from 'src/engine/twenty-orm/utils/format-result.util';
 import { type QueryExecutorV2 } from 'src/engine/twenty-orm-v2/executor/types/query-executor-v2.type';
+import { type MutationKind } from 'src/engine/twenty-orm-v2/sql/utils/build-mutation-statement.util';
 import { WorkspaceSelectQueryBuilderV2 } from 'src/engine/twenty-orm-v2/query-builder/workspace-select-query-builder-v2';
 import { compileNamedParameters } from 'src/engine/twenty-orm-v2/sql/utils/compile-named-parameters.util';
 import { type WorkspaceTableShape } from 'src/engine/twenty-orm-v2/table-shape/types/workspace-table-shape.type';
@@ -69,6 +75,152 @@ export class WorkspaceRepositoryV2 {
       this.options.internalContext.flatObjectMetadataMaps,
       this.options.internalContext.flatFieldMetadataMaps,
     );
+  }
+
+  applyWriteRowLevelPermissions(
+    queryBuilder: WorkspaceSelectQueryBuilderV2,
+  ): void {
+    this.applyRowLevelPermissionPredicates(queryBuilder);
+  }
+
+  async runMutation({
+    selectQueryBuilder,
+    rowLevelPermissionsApplied,
+    kind,
+    columnsToReturn,
+  }: {
+    selectQueryBuilder: WorkspaceSelectQueryBuilderV2;
+    rowLevelPermissionsApplied: boolean;
+    kind: MutationKind;
+    columnsToReturn: string[];
+  }): Promise<ObjectRecord[]> {
+    if (!rowLevelPermissionsApplied) {
+      this.applyRowLevelPermissionPredicates(selectQueryBuilder);
+    }
+
+    this.validateWriteIsPermitted(kind, columnsToReturn);
+
+    const eventSelectQueryBuilder =
+      this.buildEventSnapshotQueryBuilder(selectQueryBuilder);
+
+    const recordsBefore =
+      kind === 'delete'
+        ? [
+            await eventSelectQueryBuilder.getOne<ObjectRecord>({
+              noFormatting: true,
+            }),
+          ].filter(isDefined)
+        : await eventSelectQueryBuilder.getMany<ObjectRecord>({
+            noFormatting: true,
+          });
+
+    const mutationResult = await this.morphAndExecute(
+      selectQueryBuilder,
+      kind,
+      columnsToReturn,
+    );
+
+    const recordsAfter =
+      kind === 'delete'
+        ? undefined
+        : await eventSelectQueryBuilder.getMany<ObjectRecord>({
+            noFormatting: true,
+          });
+
+    this.emitMutationEvent({ kind, recordsBefore, recordsAfter });
+
+    return mutationResult.generatedMaps;
+  }
+
+  private async morphAndExecute(
+    selectQueryBuilder: WorkspaceSelectQueryBuilderV2,
+    kind: MutationKind,
+    columnsToReturn: string[],
+  ): Promise<{ generatedMaps: ObjectRecord[] }> {
+    const mutationQueryBuilder =
+      kind === 'soft-delete'
+        ? selectQueryBuilder.softDelete()
+        : kind === 'restore'
+          ? selectQueryBuilder.restore()
+          : selectQueryBuilder.delete();
+
+    return mutationQueryBuilder.returning(columnsToReturn).execute();
+  }
+
+  private buildEventSnapshotQueryBuilder(
+    source: WorkspaceSelectQueryBuilderV2,
+  ): WorkspaceSelectQueryBuilderV2 {
+    const eventSelectQueryBuilder = new WorkspaceSelectQueryBuilderV2(
+      source.alias,
+      {
+        tableShape: this.options.tableShape,
+        executor: this.options.executor,
+        objectRecordsPermissions: this.options.objectRecordsPermissions,
+        tableShapeByObjectMetadataId: this.options.tableShapeByObjectMetadataId,
+        onBeforeExecute: () => undefined,
+        formatResult: (records) => this.formatResult(records),
+      },
+    );
+
+    return eventSelectQueryBuilder.copyWhereFrom(source).withDeleted();
+  }
+
+  private validateWriteIsPermitted(
+    operationType: MutationKind,
+    columnsToReturn: string[],
+  ): void {
+    if (this.options.shouldBypassPermissionChecks) {
+      return;
+    }
+
+    validateOperationIsPermittedOrThrow({
+      entityName: this.options.tableShape.nameSingular,
+      operationType,
+      objectsPermissions: this.options.objectRecordsPermissions,
+      flatObjectMetadataMaps:
+        this.options.internalContext.flatObjectMetadataMaps,
+      flatFieldMetadataMaps: this.options.internalContext.flatFieldMetadataMaps,
+      objectIdByNameSingular:
+        this.options.internalContext.objectIdByNameSingular,
+      selectedColumns: columnsToReturn,
+      allFieldsSelected: false,
+      updatedColumns: [],
+    });
+  }
+
+  private emitMutationEvent({
+    kind,
+    recordsBefore,
+    recordsAfter,
+  }: {
+    kind: MutationKind;
+    recordsBefore: ObjectRecord[];
+    recordsAfter?: ObjectRecord[];
+  }): void {
+    const action =
+      kind === 'delete'
+        ? DatabaseEventAction.DESTROYED
+        : kind === 'restore'
+          ? DatabaseEventAction.RESTORED
+          : DatabaseEventAction.DELETED;
+
+    const event = formatTwentyOrmEventToDatabaseBatchEvent({
+      action,
+      objectMetadataItem: this.options.flatObjectMetadata,
+      flatFieldMetadataMaps: this.options.internalContext.flatFieldMetadataMaps,
+      workspaceId: this.options.internalContext.workspaceId,
+      recordsBefore: this.formatResult<ObjectRecord[]>(recordsBefore),
+      recordsAfter: isDefined(recordsAfter)
+        ? this.formatResult<ObjectRecord[]>(recordsAfter)
+        : undefined,
+      authContext: this.options.authContext,
+    });
+
+    if (isDefined(event)) {
+      this.options.internalContext.eventEmitterService.emitDatabaseBatchEvent(
+        event,
+      );
+    }
   }
 
   private onBeforeExecute(queryBuilder: WorkspaceSelectQueryBuilderV2): void {

--- a/packages/twenty-server/src/engine/twenty-orm-v2/repository/workspace-repository-v2.ts
+++ b/packages/twenty-server/src/engine/twenty-orm-v2/repository/workspace-repository-v2.ts
@@ -98,7 +98,7 @@ export class WorkspaceRepositoryV2 {
       this.applyRowLevelPermissionPredicates(selectQueryBuilder);
     }
 
-    this.validateWriteIsPermitted(kind, columnsToReturn);
+    this.validateWriteIsPermitted({ operationType: kind, columnsToReturn });
 
     const eventSelectQueryBuilder =
       this.buildEventSnapshotQueryBuilder(selectQueryBuilder);
@@ -114,11 +114,11 @@ export class WorkspaceRepositoryV2 {
             noFormatting: true,
           });
 
-    const mutationResult = await this.morphAndExecute(
+    const mutationResult = await this.morphAndExecute({
       selectQueryBuilder,
       kind,
       columnsToReturn,
-    );
+    });
 
     const recordsAfter =
       kind === 'delete'
@@ -132,11 +132,15 @@ export class WorkspaceRepositoryV2 {
     return mutationResult.generatedMaps;
   }
 
-  private async morphAndExecute(
-    selectQueryBuilder: WorkspaceSelectQueryBuilderV2,
-    kind: MutationKind,
-    columnsToReturn: string[],
-  ): Promise<{ generatedMaps: ObjectRecord[] }> {
+  private async morphAndExecute({
+    selectQueryBuilder,
+    kind,
+    columnsToReturn,
+  }: {
+    selectQueryBuilder: WorkspaceSelectQueryBuilderV2;
+    kind: MutationKind;
+    columnsToReturn: string[];
+  }): Promise<{ generatedMaps: ObjectRecord[] }> {
     const mutationQueryBuilder =
       kind === 'soft-delete'
         ? selectQueryBuilder.softDelete()
@@ -165,10 +169,13 @@ export class WorkspaceRepositoryV2 {
     return eventSelectQueryBuilder.copyWhereFrom(source).withDeleted();
   }
 
-  private validateWriteIsPermitted(
-    operationType: MutationKind,
-    columnsToReturn: string[],
-  ): void {
+  private validateWriteIsPermitted({
+    operationType,
+    columnsToReturn,
+  }: {
+    operationType: MutationKind;
+    columnsToReturn: string[];
+  }): void {
     if (this.options.shouldBypassPermissionChecks) {
       return;
     }


### PR DESCRIPTION
Follow-up to the ORM v2 write statement layer (#24118). Routes `deleteMany`,
`destroyMany` and `restoreMany` (and their `...One` delegates) through the v2 write path.

Behind `IS_ORM_V2_READ_PATH_ENABLED` (the same flag; there is no separate write flag).
Flag off, nothing changes.

## Scope

Each runner flag-branches through a shared `runFilteredMutation` on the base runner:

- **Off**: the existing v1 path (`buildMutationQueryBuilder` + the TypeORM mutation builder).
- **On**: `buildMutationQueryBuilderV2` builds the filtered v2 select builder — rewriting a
  relation-traversal filter into an `id IN (subquery)` predicate with RLS inside the
  subquery, mirroring the v1 util — then `WorkspaceRepositoryV2.runMutation` owns the
  choreography the v1 mutation builders own: apply the row-level predicate, validate the
  write with the matching operation type (`soft-delete` / `restore` / `delete`), snapshot
  the affected rows before and after through a permission-bypassing all-columns select,
  run the statement, and emit the `DELETED` / `RESTORED` / `DESTROYED` batch event through
  the shared `formatTwentyOrmEventToDatabaseBatchEvent`.

`getWriteRepository` on the base runner pins the primary (writes never hit the replica) and
counts a new `orm-v2/write-path-used` metric.

Deliberately matching v1: returned records come from `RETURNING` rather than a full
re-select (the GraphQL layer reads only the selected fields either way); a mutation never
adds the `deletedAt IS NULL` predicate, and the snapshot select is `withDeleted`, so
restore reaches soft-deleted rows; hard delete snapshots its before-image with `getOne`, so
a `DESTROYED` event carries at most one record — same as the v1 delete builder, not fixed
here (that would change flag-off too).

Update, insert and upsert stay on v1.

## Verification

- Ran locally both ways: the delete/destroy/restore permission suites (many + one), plus
  `mutate-by-relation-field` and `mutation-relation-filter-rls` (the join-rewrite path), all
  green with the flag on and off. Broader flag-on sweep of `object-records-permissions`,
  `soft-deleted-relation` and `merge-many`: 17 suites / 67 tests green.
- `mutate-by-relation-field` and `mutation-relation-filter-rls` added to
  `ORM_V2_TEST_PATH_PATTERN` (the delete/destroy/restore suites already ride
  `object-records-permissions`). 89 v2 builder unit tests still green. oxlint / oxfmt /
  typecheck clean.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/24131?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

