### PR TITLE
fix(front): allow deleting empty workflow nodes

### DIFF
--- a/packages/twenty-front/src/modules/workflow/workflow-steps/components/WorkflowRunStepNodeDetail.tsx
+++ b/packages/twenty-front/src/modules/workflow/workflow-steps/components/WorkflowRunStepNodeDetail.tsx
@@ -297,6 +297,7 @@ export const WorkflowRunStepNodeDetail = ({
           return (
             <WorkflowEditActionEmpty
               key={stepId}
+              action={stepDefinition.definition}
               actionOptions={{
                 readonly: true,
               }}

--- a/packages/twenty-front/src/modules/workflow/workflow-steps/components/WorkflowStepDetail.tsx
+++ b/packages/twenty-front/src/modules/workflow/workflow-steps/components/WorkflowStepDetail.tsx
@@ -263,7 +263,14 @@ export const WorkflowStepDetail = ({
           );
         }
         case 'EMPTY': {
-          return <WorkflowEditActionEmpty key={stepId} actionOptions={props} />;
+          return (
+            <WorkflowEditActionEmpty
+              key={stepId}
+              action={stepDefinition.definition}
+              steps={steps}
+              actionOptions={props}
+            />
+          );
         }
         case 'DELAY': {
           return (

--- a/packages/twenty-front/src/modules/workflow/workflow-steps/components/WorkflowStepFooter.tsx
+++ b/packages/twenty-front/src/modules/workflow/workflow-steps/components/WorkflowStepFooter.tsx
@@ -29,9 +29,11 @@ import { useNavigateSettings } from '~/hooks/useNavigateSettings';
 export const WorkflowStepFooter = ({
   stepId,
   additionalActions,
+  shouldHideOptionsDropdown = false,
 }: {
   stepId: string;
   additionalActions?: React.ReactNode[];
+  shouldHideOptionsDropdown?: boolean;
 }) => {
   const dropdownId = useId();
   const { t } = useLingui();
@@ -179,7 +181,7 @@ export const WorkflowStepFooter = ({
   return (
     <SidePanelFooter
       actions={[
-        OptionsDropdown,
+        ...(shouldHideOptionsDropdown ? [] : [OptionsDropdown]),
         ...(additionalActions ?? []),
         ...(shouldPinDeleteButton ? [deleteButton] : []),
       ]}

--- a/packages/twenty-front/src/modules/workflow/workflow-steps/utils/__tests__/isEmptyStepDeletable.test.ts
+++ b/packages/twenty-front/src/modules/workflow/workflow-steps/utils/__tests__/isEmptyStepDeletable.test.ts
@@ -1,0 +1,115 @@
+import { type WorkflowAction } from '@/workflow/types/Workflow';
+import { isEmptyStepDeletable } from '@/workflow/workflow-steps/utils/isEmptyStepDeletable';
+
+const EMPTY_STEP_ID = 'empty-step-id';
+
+const createEmptyStep = (id: string): WorkflowAction =>
+  ({
+    id,
+    name: 'Add an Action',
+    type: 'EMPTY',
+    valid: true,
+    settings: {
+      outputSchema: {},
+      errorHandlingOptions: {
+        continueOnFailure: { value: false },
+        retryOnFailure: { value: false },
+      },
+      input: {},
+    },
+  }) as WorkflowAction;
+
+const createIfElseStep = (
+  branches: Array<{ filterGroupId?: string; nextStepIds: string[] }>,
+): WorkflowAction =>
+  ({
+    id: 'if-else-step-id',
+    name: 'If/Else',
+    type: 'IF_ELSE',
+    valid: true,
+    settings: {
+      outputSchema: {},
+      errorHandlingOptions: {
+        continueOnFailure: { value: false },
+        retryOnFailure: { value: false },
+      },
+      input: {
+        stepFilterGroups: [],
+        stepFilters: [],
+        branches: branches.map((branch, branchIndex) => ({
+          id: `branch-${branchIndex}`,
+          filterGroupId: branch.filterGroupId,
+          nextStepIds: branch.nextStepIds,
+        })),
+      },
+    },
+  }) as WorkflowAction;
+
+describe('isEmptyStepDeletable', () => {
+  it('should return true when the step is not attached to an If/Else branch', () => {
+    expect(
+      isEmptyStepDeletable({
+        stepId: EMPTY_STEP_ID,
+        steps: [createEmptyStep(EMPTY_STEP_ID)],
+      }),
+    ).toBe(true);
+  });
+
+  it('should return true when there are no steps', () => {
+    expect(isEmptyStepDeletable({ stepId: EMPTY_STEP_ID, steps: null })).toBe(
+      true,
+    );
+  });
+
+  it('should return false when the step is the only child of the if branch', () => {
+    const steps = [
+      createIfElseStep([
+        { filterGroupId: 'filter-group-1', nextStepIds: [EMPTY_STEP_ID] },
+        { nextStepIds: ['other-step-id'] },
+      ]),
+      createEmptyStep(EMPTY_STEP_ID),
+    ];
+
+    expect(isEmptyStepDeletable({ stepId: EMPTY_STEP_ID, steps })).toBe(false);
+  });
+
+  it('should return false when the step is the only child of the else branch', () => {
+    const steps = [
+      createIfElseStep([
+        { filterGroupId: 'filter-group-1', nextStepIds: ['other-step-id'] },
+        { nextStepIds: [EMPTY_STEP_ID] },
+      ]),
+      createEmptyStep(EMPTY_STEP_ID),
+    ];
+
+    expect(isEmptyStepDeletable({ stepId: EMPTY_STEP_ID, steps })).toBe(false);
+  });
+
+  it('should return true when the step is the child of an else-if branch', () => {
+    const steps = [
+      createIfElseStep([
+        { filterGroupId: 'filter-group-1', nextStepIds: ['other-step-id'] },
+        { filterGroupId: 'filter-group-2', nextStepIds: [EMPTY_STEP_ID] },
+        { nextStepIds: ['another-step-id'] },
+      ]),
+      createEmptyStep(EMPTY_STEP_ID),
+    ];
+
+    expect(isEmptyStepDeletable({ stepId: EMPTY_STEP_ID, steps })).toBe(true);
+  });
+
+  it('should return true when the if branch has another child left', () => {
+    const steps = [
+      createIfElseStep([
+        {
+          filterGroupId: 'filter-group-1',
+          nextStepIds: [EMPTY_STEP_ID, 'other-step-id'],
+        },
+        { nextStepIds: ['another-step-id'] },
+      ]),
+      createEmptyStep(EMPTY_STEP_ID),
+    ];
+
+    expect(isEmptyStepDeletable({ stepId: EMPTY_STEP_ID, steps })).toBe(true);
+  });
+});

--- a/packages/twenty-front/src/modules/workflow/workflow-steps/utils/isEmptyStepDeletable.ts
+++ b/packages/twenty-front/src/modules/workflow/workflow-steps/utils/isEmptyStepDeletable.ts
@@ -1,0 +1,32 @@
+import { type WorkflowAction } from '@/workflow/types/Workflow';
+import { isDefined } from 'twenty-shared/utils';
+
+// The "if" and "else" branches of an If/Else step always keep at least one child:
+// deleting their last child would only make the server recreate an empty step.
+export const isEmptyStepDeletable = ({
+  stepId,
+  steps,
+}: {
+  stepId: string;
+  steps: WorkflowAction[] | null;
+}): boolean => {
+  return (steps ?? []).every((step) => {
+    if (step.type !== 'IF_ELSE') {
+      return true;
+    }
+
+    const branches = step.settings.input.branches;
+
+    return branches.every((branch, branchIndex) => {
+      if (!branch.nextStepIds.includes(stepId)) {
+        return true;
+      }
+
+      const isIfBranch = branchIndex === 0;
+      const isElseBranch =
+        branchIndex === branches.length - 1 && !isDefined(branch.filterGroupId);
+
+      return !(isIfBranch || isElseBranch) || branch.nextStepIds.length > 1;
+    });
+  });
+};

--- a/packages/twenty-front/src/modules/workflow/workflow-steps/workflow-actions/components/WorkflowEditActionEmpty.tsx
+++ b/packages/twenty-front/src/modules/workflow/workflow-steps/workflow-actions/components/WorkflowEditActionEmpty.tsx
@@ -1,8 +1,15 @@
 import { SidePanelWorkflowSelectAction } from '@/side-panel/pages/workflow/action/components/SidePanelWorkflowSelectAction';
 import { SidePanelWorkflowEditStepType } from '@/side-panel/pages/workflow/step/edit/components/SidePanelWorkflowEditStepType';
-import { type WorkflowEmptyAction } from '@/workflow/types/Workflow';
+import {
+  type WorkflowAction,
+  type WorkflowEmptyAction,
+} from '@/workflow/types/Workflow';
+import { WorkflowStepFooter } from '@/workflow/workflow-steps/components/WorkflowStepFooter';
+import { isEmptyStepDeletable } from '@/workflow/workflow-steps/utils/isEmptyStepDeletable';
 
 type WorkflowEditActionEmptyProps = {
+  action: WorkflowEmptyAction;
+  steps?: WorkflowAction[] | null;
   actionOptions:
     | {
         readonly: true;
@@ -14,11 +21,20 @@ type WorkflowEditActionEmptyProps = {
 };
 
 export const WorkflowEditActionEmpty = ({
+  action,
+  steps,
   actionOptions,
 }: WorkflowEditActionEmptyProps) => {
   if (actionOptions.readonly === true) {
     return <SidePanelWorkflowSelectAction onActionSelected={() => {}} />;
   }
 
-  return <SidePanelWorkflowEditStepType />;
+  return (
+    <>
+      <SidePanelWorkflowEditStepType />
+      {isEmptyStepDeletable({ stepId: action.id, steps: steps ?? null }) && (
+        <WorkflowStepFooter stepId={action.id} shouldHideOptionsDropdown />
+      )}
+    </>
+  );
 };

--- a/packages/twenty-front/src/modules/workflow/workflow-steps/workflow-actions/components/__stories__/WorkflowEditActionEmpty.stories.tsx
+++ b/packages/twenty-front/src/modules/workflow/workflow-steps/workflow-actions/components/__stories__/WorkflowEditActionEmpty.stories.tsx
@@ -1,0 +1,199 @@
+import {
+  type WorkflowAction,
+  type WorkflowEmptyAction,
+  type WorkflowIfElseAction,
+} from '@/workflow/types/Workflow';
+import { WorkflowEditActionEmpty } from '@/workflow/workflow-steps/workflow-actions/components/WorkflowEditActionEmpty';
+import { flowComponentState } from '@/workflow/states/flowComponentState';
+import { getWorkflowVisualizerComponentInstanceId } from '@/workflow/utils/getWorkflowVisualizerComponentInstanceId';
+import {
+  type Decorator,
+  type Meta,
+  type StoryObj,
+} from '@storybook/react-vite';
+import { useStore } from 'jotai';
+import { useEffect, useState } from 'react';
+import { expect, fn, within } from 'storybook/test';
+import { ComponentDecorator, RouterDecorator } from 'twenty-ui/testing';
+import { ObjectMetadataItemsDecorator } from '~/testing/decorators/ObjectMetadataItemsDecorator';
+import { SnackBarDecorator } from '~/testing/decorators/SnackBarDecorator';
+import { WorkflowStepActionDrawerDecorator } from '~/testing/decorators/WorkflowStepActionDrawerDecorator';
+import { WorkflowStepDecorator } from '~/testing/decorators/WorkflowStepDecorator';
+import { WorkspaceDecorator } from '~/testing/decorators/WorkspaceDecorator';
+import { graphqlMocks } from '~/testing/graphqlMocks';
+import {
+  mockedWorkflow,
+  mockedWorkflowVersion,
+} from '~/testing/mock-data/workflow';
+
+const EMPTY_STEP_ID = '2f4f1cbc-6f1e-4b9f-9f0e-0c1c3a1a2b3c';
+const OTHER_STEP_ID = '9d0e5f2a-1b3c-4d5e-8f90-1a2b3c4d5e6f';
+
+const DEFAULT_ACTION = {
+  id: EMPTY_STEP_ID,
+  name: 'Add an Action',
+  type: 'EMPTY',
+  valid: true,
+  settings: {
+    input: {},
+    outputSchema: {},
+    errorHandlingOptions: {
+      retryOnFailure: {
+        value: false,
+      },
+      continueOnFailure: {
+        value: false,
+      },
+    },
+  },
+} satisfies WorkflowEmptyAction;
+
+const createIfElseStep = (
+  branches: WorkflowIfElseAction['settings']['input']['branches'],
+) =>
+  ({
+    id: 'f0b1a2c3-d4e5-4f60-9a1b-2c3d4e5f6071',
+    name: 'If/Else',
+    type: 'IF_ELSE',
+    valid: true,
+    settings: {
+      input: {
+        stepFilterGroups: [],
+        stepFilters: [],
+        branches,
+      },
+      outputSchema: {},
+      errorHandlingOptions: {
+        retryOnFailure: {
+          value: false,
+        },
+        continueOnFailure: {
+          value: false,
+        },
+      },
+    },
+  }) as WorkflowIfElseAction;
+
+const ELSE_IF_BRANCH_STEPS: WorkflowAction[] = [
+  createIfElseStep([
+    {
+      id: 'branch-if',
+      filterGroupId: 'group-if',
+      nextStepIds: [OTHER_STEP_ID],
+    },
+    {
+      id: 'branch-else-if',
+      filterGroupId: 'group-else-if',
+      nextStepIds: [EMPTY_STEP_ID],
+    },
+    { id: 'branch-else', nextStepIds: [OTHER_STEP_ID] },
+  ]),
+  DEFAULT_ACTION,
+];
+
+const IF_BRANCH_STEPS: WorkflowAction[] = [
+  createIfElseStep([
+    {
+      id: 'branch-if',
+      filterGroupId: 'group-if',
+      nextStepIds: [EMPTY_STEP_ID],
+    },
+    { id: 'branch-else', nextStepIds: [OTHER_STEP_ID] },
+  ]),
+  DEFAULT_ACTION,
+];
+
+// SidePanelWorkflowEditStepType re-scopes the visualizer instance to the side
+// panel workflow id, so the flow has to be seeded under that instance too.
+const SidePanelFlowDecorator: Decorator = (Story, { args }) => {
+  const store = useStore();
+  const [isFlowSeeded, setIsFlowSeeded] = useState(false);
+  const steps = (args.steps as WorkflowAction[] | null | undefined) ?? null;
+
+  useEffect(() => {
+    store.set(
+      flowComponentState.atomFamily({
+        instanceId: getWorkflowVisualizerComponentInstanceId({
+          recordId: mockedWorkflow.id,
+        }),
+      }),
+      {
+        workflowVersionId: mockedWorkflowVersion.id,
+        trigger: null,
+        steps,
+      },
+    );
+    setIsFlowSeeded(true);
+  }, [store, steps]);
+
+  return isFlowSeeded ? <Story /> : null;
+};
+
+const meta: Meta<typeof WorkflowEditActionEmpty> = {
+  title: 'Modules/Workflow/Actions/Empty/EditAction',
+  component: WorkflowEditActionEmpty,
+  parameters: {
+    msw: graphqlMocks,
+  },
+  args: {
+    action: DEFAULT_ACTION,
+  },
+  decorators: [
+    SidePanelFlowDecorator,
+    WorkflowStepActionDrawerDecorator,
+    WorkflowStepDecorator,
+    ComponentDecorator,
+    ObjectMetadataItemsDecorator,
+    SnackBarDecorator,
+    RouterDecorator,
+    WorkspaceDecorator,
+  ],
+};
+
+export default meta;
+
+type Story = StoryObj<typeof WorkflowEditActionEmpty>;
+
+export const Default: Story = {
+  args: {
+    steps: ELSE_IF_BRANCH_STEPS,
+    actionOptions: {
+      onActionUpdate: fn(),
+    },
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    expect(await canvas.findByText('Create Record')).toBeVisible();
+    expect(await canvas.findByText('Delete')).toBeVisible();
+  },
+};
+
+export const NotDeletableInRequiredBranch: Story = {
+  args: {
+    steps: IF_BRANCH_STEPS,
+    actionOptions: {
+      onActionUpdate: fn(),
+    },
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    expect(await canvas.findByText('Create Record')).toBeVisible();
+    expect(canvas.queryByText('Delete')).not.toBeInTheDocument();
+  },
+};
+
+export const Readonly: Story = {
+  args: {
+    actionOptions: {
+      readonly: true,
+    },
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    expect(await canvas.findByText('Create Record')).toBeVisible();
+    expect(canvas.queryByText('Delete')).not.toBeInTheDocument();
+  },
+};


### PR DESCRIPTION
Fixes #24049

An empty "Add an Action" node could not be deleted. `WorkflowEditActionEmpty` rendered only the action picker, with no `WorkflowStepFooter`, so the only delete affordance in the whole editor was unreachable for EMPTY steps. Removing a placeholder created by mistake (typically an If/Else route you no longer want) meant assigning a random action first, then deleting the resulting node.

## What changed

- `WorkflowEditActionEmpty` now renders `WorkflowStepFooter` for editable EMPTY steps.
- `WorkflowStepFooter` takes a `shouldHideOptionsDropdown` prop, used here so the empty node exposes only Delete. "Change node type" is what the panel already is, and "Duplicate node" makes no sense for a placeholder.
- New `isEmptyStepDeletable` util hides Delete when the step is the last child of an If/Else `if` or `else` branch. Those branches always keep a child: `removeStep` on the server creates a replacement empty node, so the button would look like a no-op.

Deleting the placeholder of an `else if` branch removes the branch itself, which is the case in the issue.

The transient placeholder shown while the create-step panel is open is not persisted and already disappears when the panel closes, so it needs no delete path.

## Testing

- Storybook stories for `WorkflowEditActionEmpty`: delete button shown for an `else if` placeholder, absent for an `if` placeholder and in readonly.
- Unit tests for the `isEmptyStepDeletable` util.
- Manually in the app: create an If/Else, add a route, delete the new branch's empty node. The branch disappears from the diagram and from the If/Else settings. The `if` and `else` placeholders show no Delete button.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/twentyhq/twenty/pull/24134?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->


