### PR TITLE
fix(front): show Select dropdowns above modals and fix the rollover credits label

### DIFF
--- a/packages/twenty-front/src/modules/settings/admin-panel/components/SettingsAdminWorkspaceBillingContent.tsx
+++ b/packages/twenty-front/src/modules/settings/admin-panel/components/SettingsAdminWorkspaceBillingContent.tsx
@@ -237,7 +237,7 @@ export const SettingsAdminWorkspaceBillingContent = ({
           ? [
               {
                 Icon: IconCoins,
-                label: t`Rollover credits`,
+                label: t`Granted credits`,
                 value: formatCredits(usage.rolloverCredits),
               },
             ]

--- a/packages/twenty-front/src/modules/settings/admin-panel/components/SettingsAdminWorkspaceCreditGrantModal.tsx
+++ b/packages/twenty-front/src/modules/settings/admin-panel/components/SettingsAdminWorkspaceCreditGrantModal.tsx
@@ -184,6 +184,7 @@ export const SettingsAdminWorkspaceCreditGrantModal = ({
             label: t(CREDIT_GRANT_TYPE_LABELS[grantType]),
           }))}
           onChange={setType}
+          isDropdownInModal
           fullWidth
         />
 

--- a/packages/twenty-front/src/modules/settings/billing/components/SettingsBillingCreditsSection.tsx
+++ b/packages/twenty-front/src/modules/settings/billing/components/SettingsBillingCreditsSection.tsx
@@ -183,7 +183,9 @@ export const SettingsBillingCreditsSection = ({
     ? MIN_VISIBLE_EMPTY_CREDIT_PROGRESS_PERCENTAGE
     : clampedRemainingCreditsPercentage;
 
-  const hasRolloverCredits = rolloverCredits > 0;
+  // rolloverCredits sums every active grant, not just the rolled-over ones
+  const extraCredits = rolloverCredits;
+  const hasExtraCredits = extraCredits > 0;
 
   const usedCreditsDisplay = formatNumber(usedCredits, { decimals: 2 });
   const grantedCreditsDisplay = formatNumber(displayedGrantedCredits, {
@@ -192,7 +194,7 @@ export const SettingsBillingCreditsSection = ({
   const totalGrantedCreditsDisplay = formatNumber(totalGrantedCredits, {
     decimals: 2,
   });
-  const rolloverCreditsDisplay = formatNumber(rolloverCredits, {
+  const extraCreditsDisplay = formatNumber(extraCredits, {
     decimals: 2,
   });
   const rolloverCapDisplay = formatNumber(displayedGrantedCredits * 2, {
@@ -269,12 +271,12 @@ export const SettingsBillingCreditsSection = ({
                 </StyledMetricValue>
                 {t`credits available during the trial period`}
               </StyledRolloverText>
-            ) : hasRolloverCredits ? (
+            ) : hasExtraCredits ? (
               <StyledRolloverText>
                 <StyledMetricValue>
                   {totalGrantedCreditsDisplay}
                 </StyledMetricValue>
-                {t`credits available (Including ${rolloverCreditsDisplay} from rollover)`}
+                {t`credits available (including ${extraCreditsDisplay} on top of your plan)`}
               </StyledRolloverText>
             ) : (
               <StyledRolloverText>

--- a/packages/twenty-front/src/modules/ui/input/components/Select.tsx
+++ b/packages/twenty-front/src/modules/ui/input/components/Select.tsx
@@ -55,6 +55,7 @@ export type SelectProps<Value extends SelectValue> = {
   dropdownOffset?: DropdownOffset;
   hasRightElement?: boolean;
   showContextualTextInControl?: boolean;
+  isDropdownInModal?: boolean;
 };
 
 const StyledContainer = styled.div<{ fullWidth?: boolean }>`
@@ -96,6 +97,7 @@ export const Select = <Value extends SelectValue>({
   dropdownOffset,
   hasRightElement,
   showContextualTextInControl = true,
+  isDropdownInModal = false,
 }: SelectProps<Value>) => {
   const selectContainerRef = useRef<HTMLDivElement>(null);
 
@@ -207,6 +209,7 @@ export const Select = <Value extends SelectValue>({
           dropdownId={dropdownId}
           dropdownPlacement="bottom-start"
           dropdownOffset={dropdownOffset}
+          isDropdownInModal={isDropdownInModal}
           onOpen={handleDropdownOpen}
           clickableComponent={
             <SelectControl


### PR DESCRIPTION
Two fixes found while looking at the credit grant admin panel in production.

## The Type dropdown in the grant credits modal did nothing

`Dropdown` picks its portal z-index from `isDropdownInModal`:

```
DropdownPortalBelowModal = 38
RootModalBackDrop        = 39
RootModal                = 40
DropdownPortalAboveModal = 50
```

`Select` never exposed that prop, so it always got the default `false` and its portal landed at 38, underneath the modal at 40. The dropdown was opening on every click, it was just painted behind the modal, so it looked unresponsive.

`Select` now forwards `isDropdownInModal` to `Dropdown`, and the grant credits modal sets it. This is the same flag `MatchColumnToFieldSelect` already uses for the spreadsheet import modal; the grant credits modal is the only place in the codebase where a `Select` sits inside a modal, which is why nobody had needed the prop plumbed through before.

## Compensation and sales grants were labelled as rollover

`rolloverCredits` in `BillingResourceCreditUsageDTO` is `getSpendableCreditsMicro()`, the sum of every active grant regardless of type. Since the credit grant ledger landed, an admin granting compensation or sales credits made those show up under a rollover label in two places:

- the admin panel usage card said "Rollover credits", now "Granted credits", which matches the grants table right below it and sums to the same number
- the customer-facing credits section said "credits available (Including N from rollover)", now "credits available (including N on top of your plan)"

Labels only. The GraphQL field keeps its name because renaming it is a breaking schema change; the local variables in `SettingsBillingCreditsSection` are renamed so the next reader does not repeat the mistake.

## Test plan

- `nx lint:diff-with-main twenty-front` and `nx typecheck twenty-front` pass
- The dropdown fix is not verified in a browser: reaching that modal locally needs billing enabled plus a workspace with a Stripe customer and subscription. The stacking order above is read from `RootStackingContextZIndices` and `DropdownInternalContainer`, and matches the reported symptom exactly.

<a href="https://cubic.dev/pr/twentyhq/twenty/pull/24137?utm_source=github" rel="nofollow noreferrer noopener" target="_blank">``&lt;img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"&gt;``</a>
